### PR TITLE
Fix monitors going to sleep during cutscenes on systems with low display turn off timeouts

### DIFF
--- a/Generals/Code/GameEngine/Include/GameLogic/GameLogic.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/GameLogic.h
@@ -39,6 +39,10 @@
 #include "GameNetwork/NetworkDefs.h"
 #include "Common/STLTypedefs.h"
 #include "GameLogic/Module/UpdateModule.h"	// needed for DIRECT_UPDATEMODULE_ACCESS
+// TheSuperHackers @bugfix @ShizCalev 04/03/2025 - Prevents monitors from going to sleep during long periods of inactivity while the game is running - pr #281
+#ifdef _WIN32
+ #include <WinBase.h>
+#endif
 
 /*
 	At one time, we distinguished between sleepy and nonsleepy
@@ -376,7 +380,20 @@ inline Real GameLogic::getHeight( void ) { return m_height; }
 inline UnsignedInt GameLogic::getFrame( void ) { return m_frame; }
 
 inline Bool GameLogic::isInGame( void ) { return !(m_gameMode == GAME_NONE); }
-inline void GameLogic::setGameMode( Int mode ) { m_gameMode = mode; }
+
+	// TheSuperHackers @bugfix @ShizCalev 04/03/2025 - Prevents monitors from going to sleep during long periods of inactivity while the game is running - pr #281
+inline void GameLogic::setGameMode( Int mode ) 
+{ 
+	m_gameMode = mode;
+	#ifdef _WIN32	
+		if(!isInGame())
+			SetThreadExecutionState(ES_CONTINUOUS);
+			return;
+		
+		SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED | ES_DISPLAY_REQUIRED);
+	#endif	
+}
+
 inline Int  GameLogic::getGameMode( void ) { return m_gameMode; }
 #if !defined(_PLAYTEST)
 inline Bool GameLogic::isInLanGame( void ) { return (m_gameMode == GAME_LAN); }

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -3657,6 +3657,12 @@ void GameLogic::setGamePaused( Bool paused, Bool pauseMusic )
 	
 	if(paused)
 	{
+		// TheSuperHackers @bugfix @ShizCalev 04/03/2025 - Prevents monitors from going to sleep during long periods of inactivity while the game is running - pr #281
+		#ifdef _WIN32
+			SetThreadExecutionState(ES_CONTINUOUS);
+		#endif
+		
+
 		// remember the state of the mouse/input so we can return to the same state once we "unpause"
 		m_inputEnabledMemory = TheInGameUI->getInputEnabled();
 		m_mouseVisibleMemory = TheMouse->getVisibility();
@@ -3682,6 +3688,13 @@ void GameLogic::setGamePaused( Bool paused, Bool pauseMusic )
 	}
 	else
 	{
+		// TheSuperHackers @bugfix @ShizCalev 04/03/2025 - Prevents monitors from going to sleep during long periods of inactivity while the game is running - pr #281
+		#ifdef _WIN32
+			if(isInGame())
+				SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED | ES_DISPLAY_REQUIRED);
+		#endif
+
+		
 		// set the mouse/input states to what they were before we paused.
 		TheMouse->setVisibility(m_mouseVisibleMemory);
 		if(m_inputEnabledMemory)

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/GameLogic.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/GameLogic.h
@@ -41,6 +41,11 @@
 #include "Common/STLTypedefs.h"
 #include "GameLogic/Module/UpdateModule.h"	// needed for DIRECT_UPDATEMODULE_ACCESS
 
+// TheSuperHackers @bugfix @ShizCalev 04/03/2025 - Prevents monitors from going to sleep during long periods of inactivity while the game is running
+#ifdef _WIN32
+ #include <WinBase.h>
+#endif
+
 /*
 	At one time, we distinguished between sleepy and nonsleepy
 	update modules, and kept a separate list for each. however,
@@ -397,7 +402,21 @@ inline Real GameLogic::getHeight( void ) { return m_height; }
 inline UnsignedInt GameLogic::getFrame( void ) { return m_frame; }
 
 inline Bool GameLogic::isInGame( void ) { return !(m_gameMode == GAME_NONE); }
-inline void GameLogic::setGameMode( Int mode ) { m_gameMode = mode; }
+
+	// TheSuperHackers @bugfix @ShizCalev 04/03/2025 - Prevents monitors from going to sleep during long periods of inactivity while the game is running
+inline void GameLogic::setGameMode( Int mode ) 
+{ 
+	m_gameMode = mode;
+
+	#ifdef _WIN32	
+		if(!isInGame())
+			SetThreadExecutionState(ES_CONTINUOUS);
+			return;
+		
+		SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED | ES_DISPLAY_REQUIRED);
+	#endif	
+}
+
 inline Int  GameLogic::getGameMode( void ) { return m_gameMode; }
 inline Bool GameLogic::isInLanGame( void ) { return (m_gameMode == GAME_LAN); }
 inline Bool GameLogic::isInSkirmishGame( void ) { return (m_gameMode == GAME_SKIRMISH); }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -4208,6 +4208,12 @@ void GameLogic::setGamePaused( Bool paused, Bool pauseMusic )
 	
 	if(paused)
 	{
+		// TheSuperHackers @bugfix @ShizCalev 04/03/2025 - Prevents monitors from going to sleep during long periods of inactivity while the game is running - pr #281
+		#ifdef _WIN32
+			SetThreadExecutionState(ES_CONTINUOUS);
+		#endif
+		
+
 		// remember the state of the mouse/input so we can return to the same state once we "unpause"
 		m_inputEnabledMemory = TheInGameUI->getInputEnabled();
 		m_mouseVisibleMemory = TheMouse->getVisibility();
@@ -4239,6 +4245,13 @@ void GameLogic::setGamePaused( Bool paused, Bool pauseMusic )
 	}
 	else
 	{
+		// TheSuperHackers @bugfix @ShizCalev 04/03/2025 - Prevents monitors from going to sleep during long periods of inactivity while the game is running - pr #281
+		#ifdef _WIN32
+			if(isInGame())
+				SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED | ES_DISPLAY_REQUIRED);
+		#endif
+		
+		
 		// set the mouse/input states to what they were before we paused.
 		TheMouse->setVisibility(m_mouseVisibleMemory);
 		if(m_inputEnabledMemory)


### PR DESCRIPTION
Folks who use OLED screens tend to set their display sleep timers pretty low to prevent burn-in. 
![image](https://github.com/user-attachments/assets/ed7ca78e-6937-4332-8744-01aee5b5e144)

On top of not only being inconvenient during cutscenes, this can also cause the game to crash outright since lots of stuff gets shifted by Windows when a display turns off.

This fix simply sets the main process to flag itself as `ES_DISPLAY_REQUIRED` (and the necessary prerequisite flags), meaning the game now tells powercfg that the screen must remain on at all times while it's running.