### PR TITLE
Add "-noborder" launch argument for borderless windowed mode

### DIFF
--- a/Generals/Code/Main/WinMain.cpp
+++ b/Generals/Code/Main/WinMain.cpp
@@ -75,6 +75,12 @@
 HINSTANCE ApplicationHInstance = NULL;  ///< our application instance
 HWND ApplicationHWnd = NULL;  ///< our application window handle
 Bool ApplicationIsWindowed = false;
+
+	//  =================== Community Fix Start =================
+	//	Borderless Support - PR #327 //
+Bool ApplicationIsBorderless = false;
+	//  =================== Community Fix End =================
+
 Win32Mouse *TheWin32Mouse= NULL;  ///< for the WndProc() only
 DWORD TheMessageTime = 0;	///< For getting the time that a message was posted from Windows.
 
@@ -674,7 +680,12 @@ static Bool initializeAppWindows( HINSTANCE hInstance, Int nCmdShow, Bool runWin
    // Create our main window
 	windowStyle =  WS_POPUP|WS_VISIBLE;
 	if (runWindowed) 
-		windowStyle |= WS_DLGFRAME | WS_CAPTION | WS_SYSMENU;
+		//  =================== Community Fix Start =================
+		//	Borderless Support - PR #327 //
+		if(!ApplicationIsBorderless)
+			windowStyle |= WS_DLGFRAME | WS_CAPTION | WS_SYSMENU;
+		//  =================== Community Fix End =================
+
 	else
 		windowStyle |= WS_EX_TOPMOST | WS_SYSMENU;
 
@@ -901,6 +912,12 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 			//added a preparse step for this flag because it affects window creation style
 			if (stricmp(token,"-win")==0)
 				ApplicationIsWindowed=true;
+			//  =================== Community Fix Start =================
+			//	Borderless Support - PR #327 //
+			if(stricmp(token,"-noborder")==0)
+				ApplicationIsBorderless=true;
+			//  =================== Community Fix End =================
+
 			token = nextParam(NULL, "\" ");	   
 		}
 

--- a/Generals/Code/Main/WinMain.cpp
+++ b/Generals/Code/Main/WinMain.cpp
@@ -75,12 +75,7 @@
 HINSTANCE ApplicationHInstance = NULL;  ///< our application instance
 HWND ApplicationHWnd = NULL;  ///< our application window handle
 Bool ApplicationIsWindowed = false;
-
-	//  =================== Community Fix Start =================
-	//	Borderless Support - PR #327 //
-Bool ApplicationIsBorderless = false;
-	//  =================== Community Fix End =================
-
+Bool ApplicationIsBorderless = false; // TheSuperHackers @feature @ShizCalev 04/04/2025 - Borderless Windowed support
 Win32Mouse *TheWin32Mouse= NULL;  ///< for the WndProc() only
 DWORD TheMessageTime = 0;	///< For getting the time that a message was posted from Windows.
 
@@ -680,12 +675,9 @@ static Bool initializeAppWindows( HINSTANCE hInstance, Int nCmdShow, Bool runWin
    // Create our main window
 	windowStyle =  WS_POPUP|WS_VISIBLE;
 	if (runWindowed) 
-		//  =================== Community Fix Start =================
-		//	Borderless Support - PR #327 //
+		// TheSuperHackers @feature @ShizCalev 04/04/2025 - Borderless Windowed support
 		if(!ApplicationIsBorderless)
 			windowStyle |= WS_DLGFRAME | WS_CAPTION | WS_SYSMENU;
-		//  =================== Community Fix End =================
-
 	else
 		windowStyle |= WS_EX_TOPMOST | WS_SYSMENU;
 
@@ -912,12 +904,9 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 			//added a preparse step for this flag because it affects window creation style
 			if (stricmp(token,"-win")==0)
 				ApplicationIsWindowed=true;
-			//  =================== Community Fix Start =================
-			//	Borderless Support - PR #327 //
+			// TheSuperHackers @feature @ShizCalev 04/04/2025 - Borderless Windowed support
 			if(stricmp(token,"-noborder")==0)
 				ApplicationIsBorderless=true;
-			//  =================== Community Fix End =================
-
 			token = nextParam(NULL, "\" ");	   
 		}
 

--- a/Generals/Code/Main/WinMain.cpp
+++ b/Generals/Code/Main/WinMain.cpp
@@ -903,7 +903,7 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 			//added a preparse step for this flag because it affects window creation style
 			if (stricmp(token,"-win")==0)
 				ApplicationIsWindowed=true;
-			if(stricmp(token,"-noborder")==0)
+			if (stricmp(token,"-noborder")==0)
 				ApplicationIsBorderless=true;
 			token = nextParam(NULL, "\" ");	   
 		}

--- a/Generals/Code/Main/WinMain.cpp
+++ b/Generals/Code/Main/WinMain.cpp
@@ -675,7 +675,6 @@ static Bool initializeAppWindows( HINSTANCE hInstance, Int nCmdShow, Bool runWin
    // Create our main window
 	windowStyle =  WS_POPUP|WS_VISIBLE;
 	if (runWindowed) 
-		// TheSuperHackers @feature @ShizCalev 04/04/2025 - Borderless Windowed support
 		if(!ApplicationIsBorderless)
 			windowStyle |= WS_DLGFRAME | WS_CAPTION | WS_SYSMENU;
 	else
@@ -904,7 +903,6 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 			//added a preparse step for this flag because it affects window creation style
 			if (stricmp(token,"-win")==0)
 				ApplicationIsWindowed=true;
-			// TheSuperHackers @feature @ShizCalev 04/04/2025 - Borderless Windowed support
 			if(stricmp(token,"-noborder")==0)
 				ApplicationIsBorderless=true;
 			token = nextParam(NULL, "\" ");	   

--- a/GeneralsMD/Code/Main/WinMain.cpp
+++ b/GeneralsMD/Code/Main/WinMain.cpp
@@ -78,12 +78,7 @@
 HINSTANCE ApplicationHInstance = NULL;  ///< our application instance
 HWND ApplicationHWnd = NULL;  ///< our application window handle
 Bool ApplicationIsWindowed = false;
-
-	//  =================== Community Fix Start =================
-	//	Borderless Support - PR #327 //
-Bool ApplicationIsBorderless = false;
-	//  =================== Community Fix End =================
-
+Bool ApplicationIsBorderless = false; // TheSuperHackers @feature @ShizCalev 04/04/2025 - Borderless Windowed support
 Win32Mouse *TheWin32Mouse= NULL;  ///< for the WndProc() only
 DWORD TheMessageTime = 0;	///< For getting the time that a message was posted from Windows.
 
@@ -702,12 +697,9 @@ static Bool initializeAppWindows( HINSTANCE hInstance, Int nCmdShow, Bool runWin
    // Create our main window
 	windowStyle =  WS_POPUP|WS_VISIBLE;
 	if (runWindowed) 
-		//  =================== Community Fix Start =================
-		//	Borderless Support - PR #327 //
+		// TheSuperHackers @feature @ShizCalev 04/04/2025 - Borderless Windowed support
 		if(!ApplicationIsBorderless)
 			windowStyle |= WS_DLGFRAME | WS_CAPTION | WS_SYSMENU;
-		//  =================== Community Fix End =================
-
 	else
 		windowStyle |= WS_EX_TOPMOST | WS_SYSMENU;
 
@@ -937,13 +929,9 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 			//added a preparse step for this flag because it affects window creation style
 			if (stricmp(token,"-win")==0)
 				ApplicationIsWindowed=true;
-				
-			//  =================== Community Fix Start =================
-			//	Borderless Support - PR #327 //
+			// TheSuperHackers @feature @ShizCalev 04/04/2025 - Borderless Windowed support
 			if(stricmp(token,"-noborder")==0)
 				ApplicationIsBorderless=true;)
-			//  =================== Community Fix End =================
-
 			token = nextParam(NULL, "\" ");	   
 		}
 

--- a/GeneralsMD/Code/Main/WinMain.cpp
+++ b/GeneralsMD/Code/Main/WinMain.cpp
@@ -697,7 +697,6 @@ static Bool initializeAppWindows( HINSTANCE hInstance, Int nCmdShow, Bool runWin
    // Create our main window
 	windowStyle =  WS_POPUP|WS_VISIBLE;
 	if (runWindowed) 
-		// TheSuperHackers @feature @ShizCalev 04/04/2025 - Borderless Windowed support
 		if(!ApplicationIsBorderless)
 			windowStyle |= WS_DLGFRAME | WS_CAPTION | WS_SYSMENU;
 	else
@@ -929,7 +928,6 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 			//added a preparse step for this flag because it affects window creation style
 			if (stricmp(token,"-win")==0)
 				ApplicationIsWindowed=true;
-			// TheSuperHackers @feature @ShizCalev 04/04/2025 - Borderless Windowed support
 			if(stricmp(token,"-noborder")==0)
 				ApplicationIsBorderless=true;
 			token = nextParam(NULL, "\" ");	   

--- a/GeneralsMD/Code/Main/WinMain.cpp
+++ b/GeneralsMD/Code/Main/WinMain.cpp
@@ -78,6 +78,12 @@
 HINSTANCE ApplicationHInstance = NULL;  ///< our application instance
 HWND ApplicationHWnd = NULL;  ///< our application window handle
 Bool ApplicationIsWindowed = false;
+
+	//  =================== Community Fix Start =================
+	//	Borderless Support - PR #327 //
+Bool ApplicationIsBorderless = false;
+	//  =================== Community Fix End =================
+
 Win32Mouse *TheWin32Mouse= NULL;  ///< for the WndProc() only
 DWORD TheMessageTime = 0;	///< For getting the time that a message was posted from Windows.
 
@@ -696,7 +702,12 @@ static Bool initializeAppWindows( HINSTANCE hInstance, Int nCmdShow, Bool runWin
    // Create our main window
 	windowStyle =  WS_POPUP|WS_VISIBLE;
 	if (runWindowed) 
-		windowStyle |= WS_DLGFRAME | WS_CAPTION | WS_SYSMENU;
+		//  =================== Community Fix Start =================
+		//	Borderless Support - PR #327 //
+		if(!ApplicationIsBorderless)
+			windowStyle |= WS_DLGFRAME | WS_CAPTION | WS_SYSMENU;
+		//  =================== Community Fix End =================
+
 	else
 		windowStyle |= WS_EX_TOPMOST | WS_SYSMENU;
 
@@ -926,6 +937,13 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 			//added a preparse step for this flag because it affects window creation style
 			if (stricmp(token,"-win")==0)
 				ApplicationIsWindowed=true;
+				
+			//  =================== Community Fix Start =================
+			//	Borderless Support - PR #327 //
+			if(stricmp(token,"-noborder")==0)
+				ApplicationIsBorderless=true;)
+			//  =================== Community Fix End =================
+
 			token = nextParam(NULL, "\" ");	   
 		}
 

--- a/GeneralsMD/Code/Main/WinMain.cpp
+++ b/GeneralsMD/Code/Main/WinMain.cpp
@@ -931,7 +931,7 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 				ApplicationIsWindowed=true;
 			// TheSuperHackers @feature @ShizCalev 04/04/2025 - Borderless Windowed support
 			if(stricmp(token,"-noborder")==0)
-				ApplicationIsBorderless=true;)
+				ApplicationIsBorderless=true;
 			token = nextParam(NULL, "\" ");	   
 		}
 


### PR DESCRIPTION
WS_POPUP|WS_VISIBLE being the only flags = noborder.

Currently set to only trigger if both `-win` & `-noborder` are set as launch params, can simplify it down to just one of that's preferred.