### PR TITLE
[GEN] Backport left click deselect functionality with Alternate Mouse Setup from Zero Hour

### DIFF
--- a/Generals/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/Generals/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -416,11 +416,9 @@ public:  // ********************************************************************
 	virtual void placeBuildAvailable( const ThingTemplate *build, Drawable *buildDrawable );				///< built thing being placed
 	virtual const ThingTemplate *getPendingPlaceType( void );					///< get item we're trying to place
 	virtual const ObjectID getPendingPlaceSourceObjectID( void );			///< get producing object
-			//  =================== Community Fix Start =================
-			//	Backport Zero Hour Left Click Deselect in Alt Mouse Control Mode //
+			// TheSuperHackers @feature @ShizCalev 04/04/2025 - Backports Zero Hour's alt-mouse mode's left click deselect functionality
 	virtual Bool getPreventLeftClickDeselectionInAlternateMouseModeForOneClick() const { return m_preventLeftClickDeselectionInAlternateMouseModeForOneClick; }
 	virtual void setPreventLeftClickDeselectionInAlternateMouseModeForOneClick( Bool set ) { m_preventLeftClickDeselectionInAlternateMouseModeForOneClick = set; }
-			// =================== Community Fix End =================
 	virtual void setPlacementStart( const ICoord2D *start );					///< placement anchor point (for choosing angles)
 	virtual void setPlacementEnd( const ICoord2D *end );							///< set target placement point (for choosing angles)
 	virtual Bool isPlacementAnchored( void );													///< is placement arrow anchor set
@@ -697,10 +695,7 @@ protected:
 	BuildProgress								m_buildProgress[ MAX_BUILD_PROGRESS ];	///< progress for building units
 	const ThingTemplate *				m_pendingPlaceType;											///< type of built thing we're trying to place
 	ObjectID										m_pendingPlaceSourceObjectID;						///< source object of the thing constructing the item
-				//  =================== Community Fix Start =================
-				//	Backport Zero Hour Left Click Deselect in Alt Mouse Control Mode //
-	Bool										m_preventLeftClickDeselectionInAlternateMouseModeForOneClick;
-				// =================== Community Fix End =================
+	Bool										m_preventLeftClickDeselectionInAlternateMouseModeForOneClick; // TheSuperHackers @feature @ShizCalev 04/04/2025 - Backports Zero Hour's alt-mouse mode's left click deselect functionality
 	Drawable **									m_placeIcon;														///< array for drawables to appear at the cursor when building in the world
 	Bool												m_placeAnchorInProgress;								///< is place angle interface for placement active
 	ICoord2D										m_placeAnchorStart;											///< place angle anchor start

--- a/Generals/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/Generals/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -416,6 +416,11 @@ public:  // ********************************************************************
 	virtual void placeBuildAvailable( const ThingTemplate *build, Drawable *buildDrawable );				///< built thing being placed
 	virtual const ThingTemplate *getPendingPlaceType( void );					///< get item we're trying to place
 	virtual const ObjectID getPendingPlaceSourceObjectID( void );			///< get producing object
+			//  =================== Community Fix Start =================
+			//	Backport Zero Hour Left Click Deselect in Alt Mouse Control Mode //
+	virtual Bool getPreventLeftClickDeselectionInAlternateMouseModeForOneClick() const { return m_preventLeftClickDeselectionInAlternateMouseModeForOneClick; }
+	virtual void setPreventLeftClickDeselectionInAlternateMouseModeForOneClick( Bool set ) { m_preventLeftClickDeselectionInAlternateMouseModeForOneClick = set; }
+			// =================== Community Fix End =================
 	virtual void setPlacementStart( const ICoord2D *start );					///< placement anchor point (for choosing angles)
 	virtual void setPlacementEnd( const ICoord2D *end );							///< set target placement point (for choosing angles)
 	virtual Bool isPlacementAnchored( void );													///< is placement arrow anchor set
@@ -692,6 +697,10 @@ protected:
 	BuildProgress								m_buildProgress[ MAX_BUILD_PROGRESS ];	///< progress for building units
 	const ThingTemplate *				m_pendingPlaceType;											///< type of built thing we're trying to place
 	ObjectID										m_pendingPlaceSourceObjectID;						///< source object of the thing constructing the item
+				//  =================== Community Fix Start =================
+				//	Backport Zero Hour Left Click Deselect in Alt Mouse Control Mode //
+	Bool										m_preventLeftClickDeselectionInAlternateMouseModeForOneClick;
+				// =================== Community Fix End =================
 	Drawable **									m_placeIcon;														///< array for drawables to appear at the cursor when building in the world
 	Bool												m_placeAnchorInProgress;								///< is place angle interface for placement active
 	ICoord2D										m_placeAnchorStart;											///< place angle anchor start

--- a/Generals/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/Generals/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -416,7 +416,6 @@ public:  // ********************************************************************
 	virtual void placeBuildAvailable( const ThingTemplate *build, Drawable *buildDrawable );				///< built thing being placed
 	virtual const ThingTemplate *getPendingPlaceType( void );					///< get item we're trying to place
 	virtual const ObjectID getPendingPlaceSourceObjectID( void );			///< get producing object
-			// TheSuperHackers @feature @ShizCalev 04/04/2025 - Backports Zero Hour's alt-mouse mode's left click deselect functionality
 	virtual Bool getPreventLeftClickDeselectionInAlternateMouseModeForOneClick() const { return m_preventLeftClickDeselectionInAlternateMouseModeForOneClick; }
 	virtual void setPreventLeftClickDeselectionInAlternateMouseModeForOneClick( Bool set ) { m_preventLeftClickDeselectionInAlternateMouseModeForOneClick = set; }
 	virtual void setPlacementStart( const ICoord2D *start );					///< placement anchor point (for choosing angles)

--- a/Generals/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/Generals/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -694,7 +694,7 @@ protected:
 	BuildProgress								m_buildProgress[ MAX_BUILD_PROGRESS ];	///< progress for building units
 	const ThingTemplate *				m_pendingPlaceType;											///< type of built thing we're trying to place
 	ObjectID										m_pendingPlaceSourceObjectID;						///< source object of the thing constructing the item
-	Bool										m_preventLeftClickDeselectionInAlternateMouseModeForOneClick; // TheSuperHackers @feature @ShizCalev 04/04/2025 - Backports Zero Hour's alt-mouse mode's left click deselect functionality
+	Bool										m_preventLeftClickDeselectionInAlternateMouseModeForOneClick;
 	Drawable **									m_placeIcon;														///< array for drawables to appear at the cursor when building in the world
 	Bool												m_placeAnchorInProgress;								///< is place angle interface for placement active
 	ICoord2D										m_placeAnchorStart;											///< place angle anchor start

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -2879,7 +2879,6 @@ void InGameUI::placeBuildAvailable( const ThingTemplate *build, Drawable *buildD
 	// place something, it is overwritten
 	//
 	m_pendingPlaceType = build;
-	// TheSuperHackers @feature @ShizCalev 04/04/2025 - Backports Zero Hour's alt-mouse mode's left click deselect functionality
 	
 	//Keep the prev pending place for left click deselection prevention in alternate mouse mode.
 	//We want to keep our dozer selected after initiating construction.

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -905,7 +905,7 @@ InGameUI::InGameUI()
 		m_placeIcon[ i ] = NULL;
 	m_pendingPlaceType = NULL;
 	m_pendingPlaceSourceObjectID = INVALID_ID;
-	m_preventLeftClickDeselectionInAlternateMouseModeForOneClick = FALSE; // TheSuperHackers @feature @ShizCalev 04/04/2025 - Backports Zero Hour's alt-mouse mode's left click deselect functionality
+	m_preventLeftClickDeselectionInAlternateMouseModeForOneClick = FALSE;
 	m_placeAnchorStart.x = m_placeAnchorStart.y = 0;
 	m_placeAnchorEnd.x = m_placeAnchorEnd.y = 0;
 	m_placeAnchorInProgress = FALSE;

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -905,6 +905,10 @@ InGameUI::InGameUI()
 		m_placeIcon[ i ] = NULL;
 	m_pendingPlaceType = NULL;
 	m_pendingPlaceSourceObjectID = INVALID_ID;
+				//  =================== Community Fix Start =================
+				//	Backport Zero Hour Left Click Deselect in Alt Mouse Control Mode //
+	m_preventLeftClickDeselectionInAlternateMouseModeForOneClick = FALSE;
+				// =================== Community Fix End =================
 	m_placeAnchorStart.x = m_placeAnchorStart.y = 0;
 	m_placeAnchorEnd.x = m_placeAnchorEnd.y = 0;
 	m_placeAnchorInProgress = FALSE;
@@ -2878,6 +2882,12 @@ void InGameUI::placeBuildAvailable( const ThingTemplate *build, Drawable *buildD
 	// place something, it is overwritten
 	//
 	m_pendingPlaceType = build;
+			//  =================== Community Fix Start =================
+			//	Backport Zero Hour Left Click Deselect in Alt Mouse Control Mode //
+	//Keep the prev pending place for left click deselection prevention in alternate mouse mode.
+	//We want to keep our dozer selected after initiating construction.
+	setPreventLeftClickDeselectionInAlternateMouseModeForOneClick( m_pendingPlaceSourceObjectID != INVALID_ID );
+			// =================== Community Fix End =================
 	m_pendingPlaceSourceObjectID = INVALID_ID;
 
 	Object *sourceObject = NULL;

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -905,10 +905,7 @@ InGameUI::InGameUI()
 		m_placeIcon[ i ] = NULL;
 	m_pendingPlaceType = NULL;
 	m_pendingPlaceSourceObjectID = INVALID_ID;
-				//  =================== Community Fix Start =================
-				//	Backport Zero Hour Left Click Deselect in Alt Mouse Control Mode //
-	m_preventLeftClickDeselectionInAlternateMouseModeForOneClick = FALSE;
-				// =================== Community Fix End =================
+	m_preventLeftClickDeselectionInAlternateMouseModeForOneClick = FALSE; // TheSuperHackers @feature @ShizCalev 04/04/2025 - Backports Zero Hour's alt-mouse mode's left click deselect functionality
 	m_placeAnchorStart.x = m_placeAnchorStart.y = 0;
 	m_placeAnchorEnd.x = m_placeAnchorEnd.y = 0;
 	m_placeAnchorInProgress = FALSE;
@@ -2882,12 +2879,11 @@ void InGameUI::placeBuildAvailable( const ThingTemplate *build, Drawable *buildD
 	// place something, it is overwritten
 	//
 	m_pendingPlaceType = build;
-			//  =================== Community Fix Start =================
-			//	Backport Zero Hour Left Click Deselect in Alt Mouse Control Mode //
+	// TheSuperHackers @feature @ShizCalev 04/04/2025 - Backports Zero Hour's alt-mouse mode's left click deselect functionality
+	
 	//Keep the prev pending place for left click deselection prevention in alternate mouse mode.
 	//We want to keep our dozer selected after initiating construction.
 	setPreventLeftClickDeselectionInAlternateMouseModeForOneClick( m_pendingPlaceSourceObjectID != INVALID_ID );
-			// =================== Community Fix End =================
 	m_pendingPlaceSourceObjectID = INVALID_ID;
 
 	Object *sourceObject = NULL;

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/GUICommandTranslator.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/GUICommandTranslator.cpp
@@ -493,7 +493,7 @@ GameMessageDisposition GUICommandTranslator::translateGameMessage(const GameMess
 				// get out of GUI command mode if we completed the command one way or another
 				if( commandStatus == COMMAND_COMPLETE )
 				{
-					TheInGameUI->setPreventLeftClickDeselectionInAlternateMouseModeForOneClick( TRUE ); // TheSuperHackers @feature @ShizCalev 04/04/2025 - Backports Zero Hour's alt-mouse mode's left click deselect functionality
+					TheInGameUI->setPreventLeftClickDeselectionInAlternateMouseModeForOneClick( TRUE );
 					TheInGameUI->setGUICommand( NULL );
 				}
 			}  // end if

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/GUICommandTranslator.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/GUICommandTranslator.cpp
@@ -492,7 +492,15 @@ GameMessageDisposition GUICommandTranslator::translateGameMessage(const GameMess
 
 				// get out of GUI command mode if we completed the command one way or another
 				if( commandStatus == COMMAND_COMPLETE )
+				{
+					//  =================== Community Fix Start =================
+					//	Backport Zero Hour Left Click Deselect in Alt Mouse Control Mode //
+					TheInGameUI->setPreventLeftClickDeselectionInAlternateMouseModeForOneClick( TRUE );
+					//  =================== Community Fix End =================
+
 					TheInGameUI->setGUICommand( NULL );
+					
+				}
 			}  // end if
 
 			break;

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/GUICommandTranslator.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/GUICommandTranslator.cpp
@@ -493,13 +493,8 @@ GameMessageDisposition GUICommandTranslator::translateGameMessage(const GameMess
 				// get out of GUI command mode if we completed the command one way or another
 				if( commandStatus == COMMAND_COMPLETE )
 				{
-					//  =================== Community Fix Start =================
-					//	Backport Zero Hour Left Click Deselect in Alt Mouse Control Mode //
-					TheInGameUI->setPreventLeftClickDeselectionInAlternateMouseModeForOneClick( TRUE );
-					//  =================== Community Fix End =================
-
+					TheInGameUI->setPreventLeftClickDeselectionInAlternateMouseModeForOneClick( TRUE ); // TheSuperHackers @feature @ShizCalev 04/04/2025 - Backports Zero Hour's alt-mouse mode's left click deselect functionality
 					TheInGameUI->setGUICommand( NULL );
-					
 				}
 			}  // end if
 

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
@@ -511,9 +511,9 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 
 				// Yay. Either select across the screen or the world depending on selectAcrossMap
 				if (selectAcrossMap)
-					TheInGameUI->selectAcrossMap();
+					TheInGameUI->selectAcrossMap(); //Changed to selectMatchingAcrossMap() in Zero Hour.
 				else 
-					TheInGameUI->selectAcrossScreen();
+					TheInGameUI->selectAcrossScreen(); //Changed to selectMatchingAcrossScreen() in Zero Hour
 
 				// emit "picked" message
 				GameMessage *pickMsg = TheMessageStream->appendMessage( GameMessage::MSG_AREA_SELECTION );
@@ -870,6 +870,33 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 				buildRegion( &m_selectFeedbackAnchor, &msg->getArgument(0)->pixel, &selectionRegion );
 				dragMsg->appendPixelRegionArgument( selectionRegion );
 			}
+			//  =================== Community Fix Start =================
+			//	Backport Zero Hour Left Click Deselect in Alt Mouse Control Mode //
+			else
+			{
+				// left click behavior (not right drag)
+
+				//Added support to cancel the GUI command without deselecting the unit(s) involved
+				//when you right click.
+				if( !TheInGameUI->getGUICommand() && !TheKeyboard->isShift() && !TheKeyboard->isCtrl() && !TheKeyboard->isAlt() )
+				{
+					//No GUI command mode, so deselect everyone if we're in alternate mouse mode.
+					if( TheGlobalData->m_useAlternateMouse && TheInGameUI->getPendingPlaceSourceObjectID() == INVALID_ID )
+					{
+						if( !TheInGameUI->getPreventLeftClickDeselectionInAlternateMouseModeForOneClick() )
+						{
+							deselectAll();
+						}
+						else
+						{
+							//Prevent deselection of unit if it just issued some type of UI order such as attack move, guard, 
+							//initiating construction of a new structure.
+							TheInGameUI->setPreventLeftClickDeselectionInAlternateMouseModeForOneClick( FALSE );
+						}
+					}
+				}
+			}
+			//  =================== Community Fix End =================
 
 			break;
 		}

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
@@ -511,9 +511,9 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 
 				// Yay. Either select across the screen or the world depending on selectAcrossMap
 				if (selectAcrossMap)
-					TheInGameUI->selectAcrossMap(); //Changed to selectMatchingAcrossMap() in Zero Hour.
+					TheInGameUI->selectAcrossMap();
 				else 
-					TheInGameUI->selectAcrossScreen(); //Changed to selectMatchingAcrossScreen() in Zero Hour
+					TheInGameUI->selectAcrossScreen();
 
 				// emit "picked" message
 				GameMessage *pickMsg = TheMessageStream->appendMessage( GameMessage::MSG_AREA_SELECTION );
@@ -870,8 +870,7 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 				buildRegion( &m_selectFeedbackAnchor, &msg->getArgument(0)->pixel, &selectionRegion );
 				dragMsg->appendPixelRegionArgument( selectionRegion );
 			}
-			//  =================== Community Fix Start =================
-			//	Backport Zero Hour Left Click Deselect in Alt Mouse Control Mode //
+			// TheSuperHackers @feature @ShizCalev 04/04/2025 - Backports Zero Hour's alt-mouse mode's left click deselect functionality
 			else
 			{
 				// left click behavior (not right drag)
@@ -896,7 +895,6 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 					}
 				}
 			}
-			//  =================== Community Fix End =================
 
 			break;
 		}

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
@@ -870,7 +870,7 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 				buildRegion( &m_selectFeedbackAnchor, &msg->getArgument(0)->pixel, &selectionRegion );
 				dragMsg->appendPixelRegionArgument( selectionRegion );
 			}
-			else
+			else 
 			{
 				// left click behavior (not right drag)
 

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
@@ -870,7 +870,6 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 				buildRegion( &m_selectFeedbackAnchor, &msg->getArgument(0)->pixel, &selectionRegion );
 				dragMsg->appendPixelRegionArgument( selectionRegion );
 			}
-			// TheSuperHackers @feature @ShizCalev 04/04/2025 - Backports Zero Hour's alt-mouse mode's left click deselect functionality
 			else
 			{
 				// left click behavior (not right drag)


### PR DESCRIPTION
- Resolves #305
- Relates to #555 
- Requires issue #525 to be resolved first

This change backports the left mouse click deselect functionality with the Alternate Mouse Setup from Zero Hour to Generals. Previously in Generals it was not possible to deselect units or buildings with a mouse click when the Alternate Mouse Setup was enabled.