### PR TITLE
[GEN] Backport structure multi selection fix from Zero Hour

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
@@ -1105,6 +1105,18 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 				else
 				{
 
+					//  =================== Community Fix Start =================
+					//	Backported Zero Hour 1.03 scud storm exploit fix //
+					Drawable *draw = TheInGameUI->getFirstSelectedDrawable();
+					if( draw && draw->isKindOf( KINDOF_STRUCTURE ) )
+					{
+						//Kris: Jan 12, 2005
+						//Can't select other units if you have a structure selected. So deselect the structure to prevent
+						//group force attack exploit.
+						TheInGameUI->deselectAllDrawables();
+					}
+					//  =================== Community Fix End =================
+					
 					// no need to send two messages for selecting the same group.
 					TheMessageStream->appendMessage((GameMessage::Type)(GameMessage::MSG_ADD_TEAM0 + group));
 					Player *player = ThePlayerList->getLocalPlayer();

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
@@ -1105,8 +1105,7 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 				else
 				{
 
-					//  =================== Community Fix Start =================
-					//	Backported Zero Hour 1.03 scud storm exploit fix //
+					// TheSuperHackers @bugfix @ShizCalev 04/04/2025 - Backported Zero Hour 1.03 scud storm exploit fix
 					Drawable *draw = TheInGameUI->getFirstSelectedDrawable();
 					if( draw && draw->isKindOf( KINDOF_STRUCTURE ) )
 					{
@@ -1115,7 +1114,6 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 						//group force attack exploit.
 						TheInGameUI->deselectAllDrawables();
 					}
-					//  =================== Community Fix End =================
 					
 					// no need to send two messages for selecting the same group.
 					TheMessageStream->appendMessage((GameMessage::Type)(GameMessage::MSG_ADD_TEAM0 + group));

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
@@ -1105,7 +1105,6 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 				else
 				{
 
-					// TheSuperHackers @bugfix @ShizCalev 04/04/2025 - Backported Zero Hour 1.03 scud storm exploit fix
 					Drawable *draw = TheInGameUI->getFirstSelectedDrawable();
 					if( draw && draw->isKindOf( KINDOF_STRUCTURE ) )
 					{

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -5264,7 +5264,7 @@ StateReturnType AIAttackState::onEnter()
 		return STATE_SUCCESS;
 
 		
-	// TheSuperHackers @bugfix @ShizCalev 04/04/2025 - Backported Zero Hour 1.03 scud storm exploit fix
+	// TheSuperHackers @bugfix @ShizCalev 04/04/2025 - Backported Zero Hour 1.03 scud storm exploit fix - pr #334
 	//Kris: Jan 12, 2005
 	//Don't allow units under construction to attack! The selection/action manager system was responsible for preventing this
 	//from ever happening, but failed in two cases which I fixed. This is an extra check to mitigate cheats.

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -5271,8 +5271,6 @@ StateReturnType AIAttackState::onEnter()
 	{
 		return STATE_FAILURE;
 	}
-
-	
 	// if all of our weapons are out of ammo, can't attack.
 	// (this can happen for units which never auto-reload, like the Raptor)
 	if (source->isOutOfAmmo() && !source->isKindOf(KINDOF_PROJECTILE))

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -5264,8 +5264,7 @@ StateReturnType AIAttackState::onEnter()
 		return STATE_SUCCESS;
 
 		
-					//  =================== Community Fix Start =================
-					//	Backported Zero Hour 1.03 scud storm exploit fix //
+	// TheSuperHackers @bugfix @ShizCalev 04/04/2025 - Backported Zero Hour 1.03 scud storm exploit fix
 	//Kris: Jan 12, 2005
 	//Don't allow units under construction to attack! The selection/action manager system was responsible for preventing this
 	//from ever happening, but failed in two cases which I fixed. This is an extra check to mitigate cheats.
@@ -5273,7 +5272,6 @@ StateReturnType AIAttackState::onEnter()
 	{
 		return STATE_FAILURE;
 	}
-					//  =================== Community Fix End =================
 
 	
 	// if all of our weapons are out of ammo, can't attack.

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -5263,6 +5263,19 @@ StateReturnType AIAttackState::onEnter()
 	if (m_attackParameters && m_attackParameters->shouldExit(getMachine())) 
 		return STATE_SUCCESS;
 
+		
+					//  =================== Community Fix Start =================
+					//	Backported Zero Hour 1.03 scud storm exploit fix //
+	//Kris: Jan 12, 2005
+	//Don't allow units under construction to attack! The selection/action manager system was responsible for preventing this
+	//from ever happening, but failed in two cases which I fixed. This is an extra check to mitigate cheats.
+	if( source->testStatus( OBJECT_STATUS_UNDER_CONSTRUCTION ) )
+	{
+		return STATE_FAILURE;
+	}
+					//  =================== Community Fix End =================
+
+	
 	// if all of our weapons are out of ammo, can't attack.
 	// (this can happen for units which never auto-reload, like the Raptor)
 	if (source->isOutOfAmmo() && !source->isKindOf(KINDOF_PROJECTILE))

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -5264,7 +5264,6 @@ StateReturnType AIAttackState::onEnter()
 		return STATE_SUCCESS;
 
 		
-	// TheSuperHackers @bugfix @ShizCalev 04/04/2025 - Backported Zero Hour 1.03 scud storm exploit fix - pr #334
 	//Kris: Jan 12, 2005
 	//Don't allow units under construction to attack! The selection/action manager system was responsible for preventing this
 	//from ever happening, but failed in two cases which I fixed. This is an extra check to mitigate cheats.


### PR DESCRIPTION
*Squash and merge*

syncs the two codebases up by backporting the (partial) fix. the exploit can still be performed, but it's harder according to @Mauller . 