### PR TITLE
Fix loop variable typo in matchbot

### DIFF
--- a/Generals/Code/Tools/matchbot/generals.cpp
+++ b/Generals/Code/Tools/matchbot/generals.cpp
@@ -626,7 +626,7 @@ void GeneralsMatcher::checkMatchesInUserMap(UserMap& userMap, int ladderID, int 
 									{
 
 										i5 = i4;
-										for (++i5; i5 != userMap.end(); ++i3)
+										for (++i5; i5 != userMap.end(); ++i5)
 										{
 											u5 = i5->second;
 											if (u5->status != STATUS_WORKING)

--- a/GeneralsMD/Code/Tools/matchbot/generals.cpp
+++ b/GeneralsMD/Code/Tools/matchbot/generals.cpp
@@ -626,7 +626,7 @@ void GeneralsMatcher::checkMatchesInUserMap(UserMap& userMap, int ladderID, int 
 									{
 
 										i5 = i4;
-										for (++i5; i5 != userMap.end(); ++i3)
+										for (++i5; i5 != userMap.end(); ++i5)
 										{
 											u5 = i5->second;
 											if (u5->status != STATUS_WORKING)


### PR DESCRIPTION
Fixed the typo referenced in #328 
Fixes #343 

Changing the loop variable from i3 to i5
Credit to @ThePrimeagen
