### PR TITLE
Fix invalid memory access when connecting to Online Lobby

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameSpy/StagingRoomGameInfo.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameSpy/StagingRoomGameInfo.cpp
@@ -81,7 +81,7 @@ GameSpyGameSlot::GameSpyGameSlot()
 BOOL (__stdcall *SnmpExtensionInitPtr)(IN DWORD dwUpTimeReference, OUT HANDLE *phSubagentTrapEvent, OUT AsnObjectIdentifier *pFirstSupportedRegion);
 BOOL (__stdcall *SnmpExtensionQueryPtr)(IN BYTE bPduType, IN OUT RFC1157VarBindList *pVarBindList, OUT AsnInteger32 *pErrorStatus, OUT AsnInteger32 *pErrorIndex);
 LPVOID (__stdcall *SnmpUtilMemAllocPtr)(IN DWORD bytes);
-VOID (__stdcall *SnmpUtilMemFreePtr)(IN LPVOID pMem);
+VOID (__stdcall *SnmpUtilVarBindListFreePtr)(IN SnmpVarBindList *pVbl);
 
 typedef struct tConnInfoStruct {
 	unsigned int State;
@@ -222,17 +222,13 @@ Bool GetLocalChatConnectionAddress(AsciiString serverName, UnsignedShort serverP
 	SnmpExtensionInitPtr = (int (__stdcall *)(unsigned long,void ** ,AsnObjectIdentifier *)) GetProcAddress(mib_ii_dll, "SnmpExtensionInit");
 	SnmpExtensionQueryPtr = (int (__stdcall *)(unsigned char,SnmpVarBindList *,long *,long *)) GetProcAddress(mib_ii_dll, "SnmpExtensionQuery");
 	SnmpUtilMemAllocPtr = (void *(__stdcall *)(unsigned long)) GetProcAddress(snmpapi_dll, "SnmpUtilMemAlloc");
-	SnmpUtilMemFreePtr = (void (__stdcall *)(void *)) GetProcAddress(snmpapi_dll, "SnmpUtilMemFree");
-	if (SnmpExtensionInitPtr == NULL || SnmpExtensionQueryPtr == NULL || SnmpUtilMemAllocPtr == NULL || SnmpUtilMemFreePtr == NULL) {
+	SnmpUtilVarBindListFreePtr = (void (__stdcall *)(SnmpVarBindList *)) GetProcAddress(snmpapi_dll, "SnmpUtilVarBindListFree");
+	if (SnmpExtensionInitPtr == NULL || SnmpExtensionQueryPtr == NULL || SnmpUtilMemAllocPtr == NULL || SnmpUtilVarBindListFreePtr == NULL) {
 		DEBUG_LOG(("Failed to get proc addresses for linked functions\n"));
 		FreeLibrary(snmpapi_dll);
 		FreeLibrary(mib_ii_dll);
 		return(false);
 	}
-
-
-	RFC1157VarBindList *bind_list_ptr = (RFC1157VarBindList *) SnmpUtilMemAllocPtr(sizeof(RFC1157VarBindList));
-	RFC1157VarBind *bind_ptr = (RFC1157VarBind *) SnmpUtilMemAllocPtr(sizeof(RFC1157VarBind));
 
 	/*
 	** OK, here we go. Try to initialise the .dll
@@ -245,8 +241,6 @@ Bool GetLocalChatConnectionAddress(AsciiString serverName, UnsignedShort serverP
 		** Aw crap.
 		*/
 		DEBUG_LOG(("Failed to init the .dll\n"));
-		SnmpUtilMemFreePtr(bind_list_ptr);
-		SnmpUtilMemFreePtr(bind_ptr);
 		FreeLibrary(snmpapi_dll);
 		FreeLibrary(mib_ii_dll);
 		return(false);
@@ -270,10 +264,12 @@ Bool GetLocalChatConnectionAddress(AsciiString serverName, UnsignedShort serverP
 	/*
 	** Set up the bind list.
 	*/
+	RFC1157VarBindList bind_list;
+	RFC1157VarBind *bind_ptr = (RFC1157VarBind *) SnmpUtilMemAllocPtr(sizeof(RFC1157VarBind));
 	bind_ptr->name.idLength = ARRAY_SIZE(mib_ii_name);
-	bind_ptr->name.ids = mib_ii_name;
-	bind_list_ptr->list = bind_ptr;
-	bind_list_ptr->len = 1;
+	bind_ptr->name.ids = mib_ii_name_ptr; // mib_ii_name_ptr should be treated as a weak pointer after this point
+	bind_list.list = bind_ptr; // bind_ptr should be treated as a weak pointer after this point
+	bind_list.len = 1;
 
 
 	/*
@@ -291,14 +287,20 @@ Bool GetLocalChatConnectionAddress(AsciiString serverName, UnsignedShort serverP
 	*/
 	while (true) {
 
-		if (!SnmpExtensionQueryPtr(SNMP_PDU_GETNEXT, bind_list_ptr, &error_status, &error_index)) {
+		if (!SnmpExtensionQueryPtr(SNMP_PDU_GETNEXT, &bind_list, &error_status, &error_index)) {
 		//if (!SnmpExtensionQueryPtr(ASN_RFC1157_GETNEXTREQUEST, bind_list_ptr, &error_status, &error_index)) {
 			DEBUG_LOG(("SnmpExtensionQuery returned false\n"));
-			SnmpUtilMemFreePtr(bind_list_ptr);
-			SnmpUtilMemFreePtr(bind_ptr);
+			SnmpUtilVarBindListFreePtr(&bind_list);
 			FreeLibrary(snmpapi_dll);
 			FreeLibrary(mib_ii_dll);
 			return(false);
+		}
+
+		bind_ptr = bind_list.list;
+		if (bind_ptr == NULL) {
+			DEBUG_LOG(("bind_list_ptr->list unexpectedly NULL\n"));
+			SnmpUtilVarBindListFreePtr(&bind_list);
+			return false;
 		}
 
 		/*
@@ -393,9 +395,7 @@ Bool GetLocalChatConnectionAddress(AsciiString serverName, UnsignedShort serverP
 		}
 	}
 
-	SnmpUtilMemFreePtr(bind_list_ptr);
-	SnmpUtilMemFreePtr(bind_ptr);
-	SnmpUtilMemFreePtr(mib_ii_name_ptr);
+	SnmpUtilVarBindListFreePtr(&bind_list);
 
 	DEBUG_LOG(("Got %d connections in list, parsing...\n", connectionVector.size()));
 


### PR DESCRIPTION
Fixes #91: Memory corruption on connecting to Online Lobby 
This should remain a draft PR until this has been tested.

Analysis:
* `bind_ptr->name.ids` is currently being assigned to some stack memory, instead of the copy that's allocated via `SnmpUtilMemAlloc`. That's probably the main cause of the originally reported issue
* `SnmpExtensionQuery` is documented as potentially allocating/reallocating/freeing memory on the VarBindList. This is validated by the fact that the reported crash happens in that function, when it attempts to free the aforementioned stack memory. So for safety, we should probably assume it invalidates any pointers.
* `SnmpUtilVarBindListFree` handles cleaning up *members* of the `SnmpVarBindList`. Based on example usage and peeking at the [ReactOS implementation](https://doxygen.reactos.org/d4/dca/dll_2win32_2snmpapi_2main_8c.html#a9fb003c6e067158dd0c58749945c478a), it seems like the actual `SnmpVarBindList` is not free'd by the function, because it's not necessarily expected to be allocated via `SnmpUtilMemAlloc`. So there's an opportunity to clean this up to not require calling `SnmpUtilMemFree` directly at all.
* The existing code doesn't free some of the members of the binds, so there's possibly a small memory leak here
* If we assign `mib_ii_name_ptr` directly to `name.ids` without cleaning up some of these other issues, we risk a double-free and small memory leak

Changes:
* Changed `bind_ptr->name.ids` assignment to actually use the `SnmpUtilMemAlloc` allocated memory, rather than the static array sitting in stack, to satisfy requirements indicated by [MSDN documentation](https://learn.microsoft.com/en-us/windows/win32/api/snmp/nf-snmp-snmpextensionquery#remarks)
* Cleaned up the memory handling around this in general, so that we can just call `SnmpUtilVarBindListFree` and be done.

Testing:
* None at all; I don't have a great reproduction case, and I haven't actually tried compiling locally yet, as I'm waiting on the CMake branch to be merged.

This can probably be merged after some basic testing.