### PR TITLE
Fix Replay GUI

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
@@ -181,7 +181,8 @@ void PopulateReplayFileListbox(GameWindow *listbox)
 				const MapMetaData *md = TheMapCache->findMap(info.getMap());
 				if (!md)
 				{
-					mapStr.translate(info.getMap());
+					const char* filename = info.getMap().reverseFind('\\');
+					mapStr.translate(filename ? filename + 1 : info.getMap());
 				}
 				else
 				{

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
@@ -254,8 +254,17 @@ void PopulateReplayFileListbox(GameWindow *listbox)
 						color = colors[COLOR_SP_CRC_MISMATCH];
 					}
 				}
-				
+
 				Int insertionIndex = GadgetListBoxAddEntryText(listbox, replayNameToShow, color, -1, 0);
+				if (insertionIndex == -1)
+				{
+					// The list originally has a maximum length of 100. If we fail here we probably
+					// exceeded that and just double the max here and try again.
+					Int length = GadgetListBoxGetNumEntries(listbox);
+					GadgetListBoxSetListLength(listbox, length * 2);
+
+					insertionIndex = GadgetListBoxAddEntryText(listbox, replayNameToShow, color, -1, 0);
+				}
 				GadgetListBoxAddEntryText(listbox, displayTimeBuffer, color, insertionIndex, 1);
 				GadgetListBoxAddEntryText(listbox, header.versionString, color, insertionIndex, 2);
 				GadgetListBoxAddEntryText(listbox, mapStr, color, insertionIndex, 3);


### PR DESCRIPTION
This fixes two issues in the Load Replay GUI:
 - If a replay whose map is not in the mapcache is present, it will now continue to display correctly. (Before it tried to display the absolute path of the map, which the gui cannot handle)
 - There is no longer a limit of 100 replays max.