### PR TITLE
Allow multiple instances to run and connect to each other for debugging

### DIFF
--- a/GeneralsMD/Code/GameEngine/Include/Common/Debug.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Debug.h
@@ -95,6 +95,26 @@ class AsciiString;
 	#define DEBUG_EXTERN_C extern
 #endif
 
+// The following define controls whether fake ips are enabled
+// If it's enabled, it changes the behavior of the game in some ways:
+// - The game can be started multiple times on the same machine.
+// - It can be called with the commandline -fakeip 1 (or some other number),
+//   assigning it a fake ip.
+// - Multiple instances with fake ips can communicate with each other on the
+//   same machine, as if they are communicating in a LAN.
+// - The replay is saved to a separate file for each instance (00000000_42.rep for ip 42)
+// - The logfile (if one is created) is also saved with the ip name in the filename.
+// So, if you want to use this to debug network functionality on a single computer
+// you can enable this define and start the game multiple times, each time passing a different
+// fake ip.
+// WARNING: If this define is set (even if no fake ip is supplied):
+// - all network communication works internally via broadcasts (not just in the lobby room).
+//   so you might wanna disconnect from your network while using this.
+// - the network protocol becomes incompatible with the original.
+//
+// Note that this define is currently in Debug.h. That's because the logfile is created
+// before the commandline is parsed, and we need to create the log file with the correct name.
+#define ENABLE_FAKE_IP 0
 
 // SYSTEM INCLUDES ////////////////////////////////////////////////////////////
 
@@ -112,6 +132,10 @@ class AsciiString;
 #define DEBUG_STRING_IT(b)	#b
 #define DEBUG_TOKEN_IT(a)		DEBUG_STRING_IT(a)
 #define DEBUG_FILENLINE			__FILE__ ":" DEBUG_TOKEN_IT(__LINE__)
+
+#if ENABLE_FAKE_IP
+	DEBUG_EXTERN_C int getFakeIPNo();
+#endif
 
 #ifdef ALLOW_DEBUG_UTILS
 

--- a/GeneralsMD/Code/GameEngine/Include/GameNetwork/NetworkDefs.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameNetwork/NetworkDefs.h
@@ -79,6 +79,10 @@ struct TransportMessageHeader
 {
 	UnsignedInt crc;											///< packet-level CRC (must be first in packet)
 	UnsignedShort magic;									///< Magic number identifying Generals packets
+#if ENABLE_FAKE_IP
+	// In Fake IP mode, we send the involved ips directly with the network packets
+	UnsignedInt from, to;
+#endif
 //	Int id;
 //	NetMessageFlags flags;
 };
@@ -175,7 +179,12 @@ enum PlayerLeaveCode {
 };
 
 // Magic number for identifying a Generals packet.
+#if ENABLE_FAKE_IP
+// If fake ips are enabled, the message format changes. Change magic to avoid conflicts
+static const UnsignedShort GENERALS_MAGIC_NUMBER = 0xF00D+1;
+#else
 static const UnsignedShort GENERALS_MAGIC_NUMBER = 0xF00D;
+#endif
 
 // The number of fps history entries.
 //static const Int NETWORK_FPS_HISTORY_LENGTH = 30;

--- a/GeneralsMD/Code/GameEngine/Include/GameNetwork/Transport.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameNetwork/Transport.h
@@ -79,7 +79,10 @@ public:
 #if defined(_DEBUG) || defined(_INTERNAL)
 	DelayedTransportMessage m_delayedInBuffer[MAX_MESSAGES];
 #endif
-
+#if ENABLE_FAKE_IP
+	// Need to know our own IP when using fake ips
+	UnsignedInt	m_localIP;
+#endif
 	UnsignedShort m_port;
 private:
 	Bool m_winsockInit;

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -1562,7 +1562,14 @@ AsciiString RecorderClass::getLastReplayFileName()
 		}
 	}
 #endif
-	return AsciiString(lastReplayFileName);
+	AsciiString filename = lastReplayFileName;
+#if ENABLE_FAKE_IP
+	// Adjust replay name when multiple instances run on the same machine
+	// so there are no conflicts
+	if (getFakeIPNo())
+		filename.format("%s_%d", lastReplayFileName, getFakeIPNo());
+#endif
+	return filename;
 }
 
 /**

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanLobbyMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanLobbyMenu.cpp
@@ -84,6 +84,15 @@ LANPreferences::~LANPreferences()
 UnicodeString LANPreferences::getUserName(void)
 {
 	UnicodeString ret;
+#if ENABLE_FAKE_IP
+	if (getFakeIPNo())
+	{
+		// Set user to fake ip number as a convenience
+		ret.format(L"fake_ip_%d", getFakeIPNo());
+		return ret;
+	}
+#endif
+
 	LANPreferences::const_iterator it = find("UserName");
 	if (it == end())
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanLobbyMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanLobbyMenu.cpp
@@ -400,7 +400,14 @@ void LanLobbyMenuInit( WindowLayout *layout, void *userData )
 	// Choose an IP address, then initialize the LAN singleton
 	UnsignedInt IP = TheGlobalData->m_defaultIP;
 	IPEnumeration IPs;
-
+#if ENABLE_FAKE_IP
+	if (getFakeIPNo())
+	{
+		IP = getFakeIPNo();
+		//IPSource = L"Using Fake IP";
+	}
+	else
+#endif
 	if (!IP)
 	{
 		EnumeratedIP *IPlist = IPs.getAddresses();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GameText.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GameText.cpp
@@ -370,6 +370,14 @@ void GameTextManager::init( void )
 	qsort( m_stringLUT, m_textCount, sizeof(StringLookUp), compareLUT  );
 
 	UnicodeString ourName = fetch("GUI:Command&ConquerGenerals");
+#if ENABLE_FAKE_IP
+	if (getFakeIPNo())
+	{
+		// Set window title to make it easier to differentiate
+		ourName.format(L"Fake IP %d", getFakeIPNo());
+	}
+#endif
+
 	AsciiString ourNameA;
 	ourNameA.translate(ourName);	//get ASCII version for Win 9x
 

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/Transport.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/Transport.cpp
@@ -329,8 +329,8 @@ Bool Transport::doRecv()
 #if ENABLE_FAKE_IP
 		if (incomingMessage.header.to != m_localIP && incomingMessage.header.to != -1)
 		{
-			DEBUG_LOG(("Transport::doRecv got message for %d.%d.%d.%d, I'm %d.%d.%d.%d. Ignoring!\n",
-				PRINT_IP_HELPER(incomingMessage.header.to), PRINT_IP_HELPER(m_localIP)));
+			//DEBUG_LOG(("Transport::doRecv got message for %d.%d.%d.%d, I'm %d.%d.%d.%d. Ignoring!\n",
+			//	PRINT_IP_HELPER(incomingMessage.header.to), PRINT_IP_HELPER(m_localIP)));
 			continue;
 		}
 #endif

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/udp.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/udp.cpp
@@ -169,6 +169,14 @@ Int UDP::Bind(UnsignedInt IP,UnsignedShort Port)
   if (fd==-1)
     return(UNKNOWN);
 
+#if ENABLE_FAKE_IP
+  addr.sin_addr.s_addr=0; // Allow packets from any ip;
+
+  // Allow the sockets to listen on multiple instances on the same port
+  int enable = 1;
+  retval = setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (const char*)&enable, sizeof(int));
+#endif
+
   retval=bind(fd,(struct sockaddr *)&addr,sizeof(addr));
 
   #ifdef _WINDOWS
@@ -194,7 +202,11 @@ Int UDP::Bind(UnsignedInt IP,UnsignedShort Port)
   retval=SetBlocking(FALSE);
   if (retval==-1)
     fprintf(stderr,"Couldn't set nonblocking mode!\n");
-
+  
+#if ENABLE_FAKE_IP
+  AllowBroadcasts(true);
+#endif
+  
   return(OK);
 }
 

--- a/GeneralsMD/Code/Main/WinMain.cpp
+++ b/GeneralsMD/Code/Main/WinMain.cpp
@@ -1025,6 +1025,8 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 		//Create a mutex with a unique name to Generals in order to determine if
 		//our app is already running.
 		//WARNING: DO NOT use this number for any other application except Generals.
+#if ENABLE_FAKE_IP == 0
+		// With Fake IPs, we allow multiple instances though
 		GeneralsMutex = CreateMutex(NULL, FALSE, GENERALS_GUID);
 		if (GetLastError() == ERROR_ALREADY_EXISTS)
 		{
@@ -1048,6 +1050,7 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 			return 0;
 		}
 		DEBUG_LOG(("Create GeneralsMutex okay.\n"));
+#endif
 
 #ifdef DO_COPY_PROTECTION
 		if (!CopyProtect::notifyLauncher())


### PR DESCRIPTION
This adds a define ENABLE_FAKE_IP which can be used to build in a way that allows multiple instances to run on the same computer and connect to each other, as if the instances connect in a LAN.

![Preview video](https://github.com/user-attachments/assets/5140aba9-449c-4549-9d16-e0c7ad499557)

Note that this PR only changes the code when the #define is set. So it doesn't actually change anything for the final build. But if the goal for the first patch is to fix network bugs, I believe this could help other developers to tackle those.

See also the following description:
```
// The following define controls whether fake ips are enabled
// If it's enabled, it changes the behavior of the game in some ways:
// - The game can be started multiple times on the same machine.
// - It can be called with the commandline -fakeip 1 (or some other number),
//   assigning it a fake ip.
// - Multiple instances with fake ips can communicate with each other on the
//   same machine, as if they are communicating in a LAN.
// - The replay is saved to a separate file for each instance (00000000_42.rep for ip 42)
// - The logfile (if one is created) is also saved with the ip name in the filename.
// So, if you want to use this to debug network functionality on a single computer
// you can enable this define and start the game multiple times, each time passing a different
// fake ip.
// WARNING: If this define is set (even if no fake ip is supplied):
// - all network communication works internally via broadcasts (not just in the lobby room).
//   so you might wanna disconnect from your network while using this.
// - the network protocol becomes incompatible with the original.
//
// Note that this define is currently in Debug.h. That's because the logfile is created
// before the commandline is parsed, and we need to create the log file with the correct name.
#define ENABLE_FAKE_IP 0
```