### PR TITLE
[ZH] Fix Supply drops instantly triggering when built while disabled

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/OCLUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/OCLUpdate.cpp
@@ -123,8 +123,15 @@ OCLUpdate::~OCLUpdate( void )
 //-------------------------------------------------------------------------------------------------
 UpdateSleepTime OCLUpdate::update( void )
 {
-	if( getObject()->isDisabled() )
+	if(m_nextCreationFrame == 0 ) 
 	{
+		setNextCreationFrame();
+		return UPDATE_SLEEP_NONE;
+	}
+
+	if( getObject()->isDisabled() || getObject()->getStatusBits().test( OBJECT_STATUS_UNDER_CONSTRUCTION ) )
+	{
+		// if( getObject()->getStatusBits().test( OBJECT_STATUS_UNDER_CONSTRUCTION ) ) return UPDATE_SLEEP_NONE;// not built yet	
 		m_nextCreationFrame++;
 		return UPDATE_SLEEP_NONE;
 	}


### PR DESCRIPTION
resolves #374

USA supply drops no longer instant trigger if you subdue them while they are being built. 

May not be backward compatible with retail version. Only tested in multiplayer. 

This fix causes a visual bug where the timer displays the correct time, but the progress bar is about half way.