### PR TITLE
Fix filename casings in CMakeLists for case-sensitive systems.

### DIFF
--- a/Generals/Code/GameEngine/CMakeLists.txt
+++ b/Generals/Code/GameEngine/CMakeLists.txt
@@ -1049,7 +1049,7 @@ set(GAMEENGINE_SRC
     Include/GameNetwork/NetPacket.h
     Include/GameNetwork/NetworkDefs.h
     Include/GameNetwork/NetworkInterface.h
-    Include/GameNetwork/NetworkUtil.h
+    Include/GameNetwork/networkutil.h
     Include/GameNetwork/RankPointValue.h
     Include/GameNetwork/Transport.h
     Include/GameNetwork/udp.h

--- a/Generals/Code/Libraries/Source/WWVegas/WWDownload/CMakeLists.txt
+++ b/Generals/Code/Libraries/Source/WWVegas/WWDownload/CMakeLists.txt
@@ -1,14 +1,14 @@
 # Set source files
 set(WWDOWNLOAD_SRC
     Download.cpp
-    Ftp.cpp
+    FTP.CPP
     registry.cpp
     urlBuilder.cpp
     Download.h
     DownloadDebug.h
-    DownloadDefs.h
-    Ftp.h
-    FtpDefs.h
+    downloaddefs.h
+    ftp.h
+    ftpdefs.h
     Registry.h
     urlBuilder.h
 )


### PR DESCRIPTION
Match the file names in CMakeLists with the casing of the actual files, for case sensitive systems. This also matches the corresponding CMakeLists in GeneralsMD.