### PR TITLE
[Linux] Fix indentation for cmake on UNIX systems

### DIFF
--- a/Generals/Code/GameEngine/CMakeLists.txt
+++ b/Generals/Code/GameEngine/CMakeLists.txt
@@ -1049,7 +1049,7 @@ set(GAMEENGINE_SRC
     Include/GameNetwork/NetPacket.h
     Include/GameNetwork/NetworkDefs.h
     Include/GameNetwork/NetworkInterface.h
-    Include/GameNetwork/NetworkUtil.h
+    Include/GameNetwork/networkutil.h
     Include/GameNetwork/RankPointValue.h
     Include/GameNetwork/Transport.h
     Include/GameNetwork/udp.h

--- a/Generals/Code/Libraries/Source/WWVegas/WWDownload/CMakeLists.txt
+++ b/Generals/Code/Libraries/Source/WWVegas/WWDownload/CMakeLists.txt
@@ -1,14 +1,14 @@
 # Set source files
 set(WWDOWNLOAD_SRC
     Download.cpp
-    Ftp.cpp
+    FTP.CPP
     registry.cpp
     urlBuilder.cpp
     Download.h
     DownloadDebug.h
-    DownloadDefs.h
-    Ftp.h
-    FtpDefs.h
+    downloaddefs.h
+    ftp.h
+    ftpdefs.h
     Registry.h
     urlBuilder.h
 )


### PR DESCRIPTION
Linux uses a case sensitive file system. It is possible to import the cmake project into a Linux IDE and it would load fine with the exception of two CMakeLists.txt in the Generals project. This has already been done in GeneralsMD. This PR is the replication for Generals

**Changes**
Change the indentation to match the file case sensitivity on CMakeLists.txt for Generals

**Vision**
- Longterm vision to support a native Linux build.
- Support of cross compilers like MinGW32.