### PR TITLE
[GEN][ZH] Fix uninitialized memory access in Get_OS_Info

### DIFF
--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/cpudetect.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/cpudetect.cpp
@@ -1265,8 +1265,8 @@ void Get_OS_Info(
 	unsigned build_minor=(OSVersionBuildNumber&0xff0000)>>16;
 	unsigned build_sub=(OSVersionBuildNumber&0xffff);
 
-	// Fill os_info with default values, before anything else
-	memset(&os_info,0,sizeof(os_info));
+	// TheSuperHackers @bugfix JAJames 17/03/2025 Fix uninitialized memory access and add more Windows versions.
+	os_info = {0};
 	os_info.Code="UNKNOWN";
 	os_info.SubCode="UNKNOWN";
 	os_info.VersionString="UNKNOWN";

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/cpudetect.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/cpudetect.cpp
@@ -1265,12 +1265,14 @@ void Get_OS_Info(
 	unsigned build_minor=(OSVersionBuildNumber&0xff0000)>>16;
 	unsigned build_sub=(OSVersionBuildNumber&0xffff);
 
+	// Fill os_info with default values, before anything else
+	memset(&os_info,0,sizeof(os_info));
+	os_info.Code="UNKNOWN";
+	os_info.SubCode="UNKNOWN";
+	os_info.VersionString="UNKNOWN";
+
 	switch (OSVersionPlatformId) {
 	default:
-		memset(&os_info,0,sizeof(os_info));
-		os_info.Code="UNKNOWN";
-		os_info.SubCode="UNKNOWN";
-		os_info.VersionString="UNKNOWN";
 		break;
 	case VER_PLATFORM_WIN32_WINDOWS:
 		{
@@ -1325,8 +1327,33 @@ void Get_OS_Info(
 				os_info.Code="WINXP";
 				return;
 			}
-			os_info.Code="WINXX";
+		}
+		if (OSVersionNumberMajor==6) {
+			if (OSVersionNumberMinor==0) {
+				os_info.Code="WINVS"; // Vista
+				return;
+			}
+			if (OSVersionNumberMinor==1) {
+				os_info.Code="WIN70"; // Win 7
+				return;
+			}
+			if (OSVersionNumberMinor==2) {
+				os_info.Code="WIN80"; // Win 8.0
+				return;
+			}
+			if (OSVersionNumberMinor==3) {
+				os_info.Code="WIN81"; // Win 8.1
+				return;
+			}
+		}
+		if (OSVersionNumberMinor==10) {
+			os_info.Code="WIN1X"; // Win 10, Win 11, Server 2016, Server 2019, Server 2022
 			return;
 		}
+		// Reference 1: https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoa#remarks
+		// Reference 2: https://learn.microsoft.com/en-us/windows/win32/sysinfo/operating-system-version
+
+		// No more-specific version detected; fallback to XX
+		os_info.Code="WINXX";
 	}
 }

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/cpudetect.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/cpudetect.cpp
@@ -1266,7 +1266,7 @@ void Get_OS_Info(
 	unsigned build_sub=(OSVersionBuildNumber&0xffff);
 
 	// TheSuperHackers @bugfix JAJames 17/03/2025 Fix uninitialized memory access and add more Windows versions.
-	os_info = {0};
+	memset(&os_info,0,sizeof(os_info));
 	os_info.Code="UNKNOWN";
 	os_info.SubCode="UNKNOWN";
 	os_info.VersionString="UNKNOWN";

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/cpudetect.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/cpudetect.cpp
@@ -1265,8 +1265,8 @@ void Get_OS_Info(
 	unsigned build_minor=(OSVersionBuildNumber&0xff0000)>>16;
 	unsigned build_sub=(OSVersionBuildNumber&0xffff);
 
-	// Fill os_info with default values, before anything else
-	memset(&os_info,0,sizeof(os_info));
+	// TheSuperHackers @bugfix JAJames 17/03/2025 Fix uninitialized memory access and add more Windows versions.
+	os_info = {0};
 	os_info.Code="UNKNOWN";
 	os_info.SubCode="UNKNOWN";
 	os_info.VersionString="UNKNOWN";

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/cpudetect.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/cpudetect.cpp
@@ -1265,12 +1265,14 @@ void Get_OS_Info(
 	unsigned build_minor=(OSVersionBuildNumber&0xff0000)>>16;
 	unsigned build_sub=(OSVersionBuildNumber&0xffff);
 
+	// Fill os_info with default values, before anything else
+	memset(&os_info,0,sizeof(os_info));
+	os_info.Code="UNKNOWN";
+	os_info.SubCode="UNKNOWN";
+	os_info.VersionString="UNKNOWN";
+
 	switch (OSVersionPlatformId) {
 	default:
-		memset(&os_info,0,sizeof(os_info));
-		os_info.Code="UNKNOWN";
-		os_info.SubCode="UNKNOWN";
-		os_info.VersionString="UNKNOWN";
 		break;
 	case VER_PLATFORM_WIN32_WINDOWS:
 		{
@@ -1325,8 +1327,33 @@ void Get_OS_Info(
 				os_info.Code="WINXP";
 				return;
 			}
-			os_info.Code="WINXX";
+		}
+		if (OSVersionNumberMajor==6) {
+			if (OSVersionNumberMinor==0) {
+				os_info.Code="WINVS"; // Vista
+				return;
+			}
+			if (OSVersionNumberMinor==1) {
+				os_info.Code="WIN70"; // Win 7
+				return;
+			}
+			if (OSVersionNumberMinor==2) {
+				os_info.Code="WIN80"; // Win 8.0
+				return;
+			}
+			if (OSVersionNumberMinor==3) {
+				os_info.Code="WIN81"; // Win 8.1
+				return;
+			}
+		}
+		if (OSVersionNumberMinor==10) {
+			os_info.Code="WIN1X"; // Win 10, Win 11, Server 2016, Server 2019, Server 2022
 			return;
 		}
+		// Reference 1: https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoa#remarks
+		// Reference 2: https://learn.microsoft.com/en-us/windows/win32/sysinfo/operating-system-version
+
+		// No more-specific version detected; fallback to XX
+		os_info.Code="WINXX";
 	}
 }

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/cpudetect.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/cpudetect.cpp
@@ -1266,7 +1266,7 @@ void Get_OS_Info(
 	unsigned build_sub=(OSVersionBuildNumber&0xffff);
 
 	// TheSuperHackers @bugfix JAJames 17/03/2025 Fix uninitialized memory access and add more Windows versions.
-	os_info = {0};
+	memset(&os_info,0,sizeof(os_info));
 	os_info.Code="UNKNOWN";
 	os_info.SubCode="UNKNOWN";
 	os_info.VersionString="UNKNOWN";


### PR DESCRIPTION
* Fixes #437

Changes below are minimal

Analysis:
* `generals.exe` was crashing in `CPUDetectClass::Init_Compact_Log` when attempting to log the `Code` and `SubCode` strings on `os_info`, due to them being initialized with garbage data.
* This was caused because there were not entries for any Windows newer than XP
* This was also caused because the `os_info` object was not default-initialized with any sane values

Changes:
1) Moved the zero-initialization from the `default` block, to just always execute first instead, so that it's guaranteed to be zero-initialized and set
2) Added entries for Windows Vista/7/8/8.1/10/11
3) Added a fallback entry for versions otherwise not detected
4) My IDE ate the micro symbol, I suppose because the source file isn't actually stored as UTF-8, but some other encoding instead. Instead of dwelling on it, I just replaced it with the letter `u`.

Impact:
* Startup no longer crashes here (instead, I now crash due to an INI parsing issue)
* I don't think this actually affects anything else however, except for logs.