### PR TITLE
Add natvis for AsciiString, UnicodeString, _STL::_List_base, _STL::_Vector_base

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ add_subdirectory(Dependencies/Benchmark)
 add_subdirectory(Dependencies/MaxSDK)
 add_subdirectory(Dependencies/SafeDisc)
 add_subdirectory(Dependencies/Utility)
+add_subdirectory(resources)
 
 # Do we want to build extra SDK stuff or just the game binary?
 option(GENZH_BUILD_ZEROHOUR "Build Zero Hour code." ON)

--- a/resources/CMakeLists.txt
+++ b/resources/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Add resources (optional)
+if (MSVC_IDE)
+    add_library(resources INTERFACE
+        visualstudio/asciistring.natvis
+        visualstudio/stllist.natvis
+        visualstudio/stlvector.natvis
+        visualstudio/unicodestring.natvis
+    )
+endif()

--- a/resources/visualstudio/asciistring.natvis
+++ b/resources/visualstudio/asciistring.natvis
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?> 
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+    <Type Name="AsciiString">
+        <DisplayString Condition="m_data != nullptr">{(const char *)(&amp; m_data[1]),s8}</DisplayString>
+        <DisplayString Condition="m_data == nullptr">""</DisplayString>
+        <Expand>
+            <Item Name="[data]" Optional="true" Condition="m_data != nullptr">m_data</Item>
+            <Item Name="[str]" Optional="true" Condition="m_data != nullptr">(const char *)(&amp; m_data[1])</Item>
+        </Expand>
+    </Type>
+</AutoVisualizer>

--- a/resources/visualstudio/stllist.natvis
+++ b/resources/visualstudio/stllist.natvis
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?> 
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+    <Type Name="_STL::_List_iterator&lt;*&gt;">
+        <AlternativeType Name="_STL::_List_const_iterator&lt;*&gt;" />
+        <DisplayString>{((_Node*)_M_node)-&gt;_M_data}</DisplayString>
+        <Expand>
+            <Item Name="[data]">((_Node*)_M_node)-&gt;_M_data</Item>
+        </Expand>
+    </Type>
+    <Type Name="_STL::_List_base&lt;*&gt;">
+        <DisplayString Condition="_M_node._M_data-&gt;_M_next == _M_node._M_data">{{ Empty List }}</DisplayString>
+        <DisplayString Condition="_M_node._M_data-&gt;_M_next != _M_node._M_data">{{ List }}</DisplayString>
+        <Expand>
+            <CustomListItems>
+                <Variable Name="begin" InitialValue="_M_node._M_data-&gt;_M_next"/>
+                <Variable Name="end" InitialValue="_M_node._M_data"/>
+                <Loop>
+                    <Break Condition="begin == end"/>
+                    <Item>((_Node*)begin)-&gt;_M_data</Item>
+                    <Exec>begin = begin-&gt;_M_next</Exec>
+                </Loop>
+            </CustomListItems>
+        </Expand>
+    </Type>
+</AutoVisualizer>

--- a/resources/visualstudio/stlvector.natvis
+++ b/resources/visualstudio/stlvector.natvis
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?> 
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+    <Type Name="_STL::_Vector_base&lt;*&gt;">
+        <DisplayString>{{ size={_M_finish - _M_start} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]" ExcludeView="simple" >_M_finish - _M_start</Item>
+            <Item Name="[capacity]" ExcludeView="simple">_M_end_of_storage._M_data - _M_start</Item>
+            <ArrayItems>
+                <Size>_M_finish - _M_start</Size>
+                <ValuePointer>_M_start</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+</AutoVisualizer>

--- a/resources/visualstudio/unicodestring.natvis
+++ b/resources/visualstudio/unicodestring.natvis
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?> 
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+    <Type Name="UnicodeString">
+        <DisplayString Condition="m_data != nullptr">{(const wchar_t *)(&amp; m_data[1]),su}</DisplayString>
+        <DisplayString Condition="m_data == nullptr">""</DisplayString>
+        <Expand>
+            <Item Name="[data]" Optional="true" Condition="m_data != nullptr">m_data</Item>
+            <Item Name="[str]" Optional="true" Condition="m_data != nullptr">(const wchar_t *)(&amp; m_data[1])</Item>
+        </Expand>
+    </Type>
+</AutoVisualizer>


### PR DESCRIPTION
This change adds natvis files for AsciiString, UnicodeString, _STL::_List_base, _STL::_Vector_base. Taken from Thyme. It allows to properly inspect these types in the Visual Studio debugger. Most useful for the game string classes. The STL ones are for stlport and are not really essential for us, but it does not hurt to have them.