### PR TITLE
[GEN][ZH] Enable resolutions with aspect ratios different from 4:3 in Options Menu

### DIFF
--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -432,7 +432,9 @@ W3DDisplay::~W3DDisplay()
 
 }  // end ~W3DDisplay
 
-// TheSuperHackers @tweak valeronm 20/03/2025 Only accept 24-bit modes with min width 800
+// TheSuperHackers @tweak valeronm 20/03/2025 There was slightly different code for checking supported resolutions
+// in Generals and Generals ZH but in both places it was only allowing resolutions with 4:3 aspect ratio. The tweaked
+// code is now the same in both codebases and doesn't check aspect ratio.
 inline Bool isResolutionSupported(const ResolutionDescClass &res)
 {
 	static const Int minBitDepth = 24;

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -432,6 +432,14 @@ W3DDisplay::~W3DDisplay()
 
 }  // end ~W3DDisplay
 
+// TheSuperHackers @tweak valeronm 20/03/2025 Only accept 24-bit modes with min width 800
+inline Bool isResolutionSupported(const ResolutionDescClass &res)
+{
+	static const Int minBitDepth = 24;
+
+	return res.Width >= MIN_DISPLAY_RESOLUTION_X && res.BitDepth >= minBitDepth;
+}
+
 /*Return number of screen modes supported by the current device*/
 Int W3DDisplay::getDisplayModeCount(void)
 {
@@ -455,8 +463,8 @@ Int W3DDisplay::getDisplayModeCount(void)
 	for (int res = 0; res < resolutions.Count ();  res ++)
 	{
 		// Is this the resolution we are looking for?
-		if (resolutions[res].BitDepth >= 24 && resolutions[res].Width >= 800 && (fabs((Real)resolutions[res].Width/(Real)resolutions[res].Height - 1.3333f)) < 0.01f)	//only accept 4:3 aspect ratio modes.
-		{	
+		if (isResolutionSupported(resolutions[res]))
+		{
 			numResolutions++;
 		}
 	}
@@ -473,7 +481,7 @@ void W3DDisplay::getDisplayModeDescription(Int modeIndex, Int *xres, Int *yres, 
 	for (int res = 0; res < resolutions.Count ();  res ++)
 	{
 		// Is this the resolution we are looking for?
-		if (resolutions[res].BitDepth >= 24 && resolutions[res].Width >= 800 && (fabs((Real)resolutions[res].Width/(Real)resolutions[res].Height - 1.3333f)) < 0.01f)	//only accept 4:3 aspect ratio modes.
+		if (isResolutionSupported(resolutions[res]))
 		{	
 			if (numResolutions == modeIndex)
 			{	//found the mode

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -432,9 +432,7 @@ W3DDisplay::~W3DDisplay()
 
 }  // end ~W3DDisplay
 
-// TheSuperHackers @tweak valeronm 20/03/2025 There was slightly different code for checking supported resolutions
-// in Generals and Generals ZH but in both places it was only allowing resolutions with 4:3 aspect ratio. The tweaked
-// code is now the same in both codebases and doesn't check aspect ratio.
+// TheSuperHackers @tweak valeronm 20/03/2025 No longer filters resolutions by a 4:3 aspect ratio.
 inline Bool isResolutionSupported(const ResolutionDescClass &res)
 {
 	static const Int minBitDepth = 24;

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -481,9 +481,7 @@ W3DDisplay::~W3DDisplay()
 
 }  // end ~W3DDisplay
 
-// TheSuperHackers @tweak valeronm 20/03/2025 There was slightly different code for checking supported resolutions
-// in Generals and Generals ZH but in both places it was only allowing resolutions with 4:3 aspect ratio. The tweaked
-// code is now the same in both codebases and doesn't check aspect ratio.
+// TheSuperHackers @tweak valeronm 20/03/2025 No longer filters resolutions by a 4:3 aspect ratio.
 inline Bool isResolutionSupported(const ResolutionDescClass &res)
 {
 	static const Int minBitDepth = 24;

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -481,17 +481,13 @@ W3DDisplay::~W3DDisplay()
 
 }  // end ~W3DDisplay
 
-
-Bool IS_FOUR_BY_THREE_ASPECT( Real x, Real y )
+// TheSuperHackers @tweak valeronm 20/03/2025 Only accept 24-bit modes with min width 800
+inline Bool isResolutionSupported(const ResolutionDescClass &res)
 {
-  if ( y == 0 )
-    return FALSE;
-  
-  Real aspectRatio = fabs( x / y ); 
-  return (( aspectRatio > 1.332f) && ( aspectRatio < 1.334f));
-  
-}
+	static const Int minBitDepth = 24;
 
+	return res.Width >= MIN_DISPLAY_RESOLUTION_X && res.BitDepth >= minBitDepth;
+}
 
 /*Return number of screen modes supported by the current device*/
 Int W3DDisplay::getDisplayModeCount(void)
@@ -516,8 +512,7 @@ Int W3DDisplay::getDisplayModeCount(void)
 	for (int res = 0; res < resolutions.Count ();  res ++)
 	{
 		// Is this the resolution we are looking for?
-		if (resolutions[res].BitDepth >= 24 && resolutions[res].Width >= MIN_DISPLAY_RESOLUTION_X 
-      && IS_FOUR_BY_THREE_ASPECT( (Real)resolutions[res].Width, (Real)resolutions[res].Height ) )	//only accept 4:3 aspect ratio modes.
+		if (isResolutionSupported(resolutions[res]))
 		{	
 			numResolutions++;
 		}
@@ -535,8 +530,7 @@ void W3DDisplay::getDisplayModeDescription(Int modeIndex, Int *xres, Int *yres, 
 	for (int res = 0; res < resolutions.Count ();  res ++)
 	{
 		// Is this the resolution we are looking for?
-		if ( resolutions[res].BitDepth >= 24 && resolutions[res].Width >= MIN_DISPLAY_RESOLUTION_X 
-      && IS_FOUR_BY_THREE_ASPECT( (Real)resolutions[res].Width, (Real)resolutions[res].Height ) )	//only accept 4:3 aspect ratio modes.
+		if (isResolutionSupported(resolutions[res]))
 		{	
 			if (numResolutions == modeIndex)
 			{	//found the mode

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -481,7 +481,9 @@ W3DDisplay::~W3DDisplay()
 
 }  // end ~W3DDisplay
 
-// TheSuperHackers @tweak valeronm 20/03/2025 Only accept 24-bit modes with min width 800
+// TheSuperHackers @tweak valeronm 20/03/2025 There was slightly different code for checking supported resolutions
+// in Generals and Generals ZH but in both places it was only allowing resolutions with 4:3 aspect ratio. The tweaked
+// code is now the same in both codebases and doesn't check aspect ratio.
 inline Bool isResolutionSupported(const ResolutionDescClass &res)
 {
 	static const Int minBitDepth = 24;


### PR DESCRIPTION
The game only allows select resolutions with 4:3 aspect ratio and the logic between Generals and Generals ZH is slightly different. With these changes, it's possible to select all supported by display resolutions.

#### Changes:
- Extracted duplicated logic for filtering resolutions from `W3DDisplay::getDisplayModeCount` and `W3DDisplay::getDisplayModeDescription` into single function `isResolutionSupported`;
- Allowed all aspect ratios between instead of fixed 4:3;
- Applied the same logic for Generals and Generals ZH.

#### Screenshot
![image](https://github.com/user-attachments/assets/620e33b6-c791-46f7-8dca-56fd79741e45)

Fixes #72