### PR TITLE
[GEN][ZH] Fix Invalid memory access in AudioManager::addAudioEvent

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/GameAudio.h
+++ b/Generals/Code/GameEngine/Include/Common/GameAudio.h
@@ -263,7 +263,7 @@ class AudioManager : public SubsystemInterface
 		const MiscAudio *getMiscAudio( void ) const;
 
 		// This function should only be called by AudioManager, MusicManager and SoundManager
-		virtual void releaseAudioEventRTS( AudioEventRTS *eventToRelease );
+		virtual void releaseAudioEventRTS( AudioEventRTS *&eventToRelease );
 
 		// For INI
 		AudioSettings *friend_getAudioSettings( void );

--- a/Generals/Code/GameEngine/Include/Common/GameSounds.h
+++ b/Generals/Code/GameEngine/Include/Common/GameSounds.h
@@ -69,7 +69,7 @@ class SoundManager : public SubsystemInterface
 		virtual void setCameraAudibleDistance( Real audibleDistance );
 		virtual Real getCameraAudibleDistance( void );
 		
-		virtual void addAudioEvent(AudioEventRTS *eventToAdd);	// pre-copied
+		virtual void addAudioEvent(AudioEventRTS *&eventToAdd);	// pre-copied
 
 		virtual void notifyOf2DSampleStart( void );
 		virtual void notifyOf3DSampleStart( void );

--- a/Generals/Code/GameEngine/Source/Common/Audio/GameAudio.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Audio/GameAudio.cpp
@@ -1038,7 +1038,7 @@ AudioHandle AudioManager::allocateNewHandle( void )
 }
 
 //-------------------------------------------------------------------------------------------------
-void AudioManager::releaseAudioEventRTS( AudioEventRTS *eventToRelease )
+void AudioManager::releaseAudioEventRTS( AudioEventRTS *&eventToRelease )
 {
 	if( eventToRelease )
 	{

--- a/Generals/Code/GameEngine/Source/Common/Audio/GameSounds.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Audio/GameSounds.cpp
@@ -136,7 +136,7 @@ Real SoundManager::getCameraAudibleDistance( void )
 }
 
 //-------------------------------------------------------------------------------------------------
-void SoundManager::addAudioEvent(AudioEventRTS *eventToAdd)
+void SoundManager::addAudioEvent(AudioEventRTS *&eventToAdd)
 {
 	if (m_num2DSamples == 0 && m_num3DSamples == 0) {
 		m_num2DSamples = TheAudio->getNum2DSamples();

--- a/GeneralsMD/Code/GameEngine/Include/Common/GameAudio.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GameAudio.h
@@ -262,7 +262,7 @@ class AudioManager : public SubsystemInterface
 		const MiscAudio *getMiscAudio( void ) const;
 
 		// This function should only be called by AudioManager, MusicManager and SoundManager
-		virtual void releaseAudioEventRTS( AudioEventRTS *eventToRelease );
+		virtual void releaseAudioEventRTS( AudioEventRTS *&eventToRelease );
 
 		// For INI
 		AudioSettings *friend_getAudioSettings( void );

--- a/GeneralsMD/Code/GameEngine/Include/Common/GameSounds.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GameSounds.h
@@ -69,7 +69,7 @@ class SoundManager : public SubsystemInterface
 		virtual void setCameraAudibleDistance( Real audibleDistance );
 		virtual Real getCameraAudibleDistance( void );
 		
-		virtual void addAudioEvent(AudioEventRTS *eventToAdd);	// pre-copied
+		virtual void addAudioEvent(AudioEventRTS *&eventToAdd);	// pre-copied
 
 		virtual void notifyOf2DSampleStart( void );
 		virtual void notifyOf3DSampleStart( void );

--- a/GeneralsMD/Code/GameEngine/Source/Common/Audio/GameAudio.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Audio/GameAudio.cpp
@@ -1090,7 +1090,7 @@ AudioHandle AudioManager::allocateNewHandle( void )
 }
 
 //-------------------------------------------------------------------------------------------------
-void AudioManager::releaseAudioEventRTS( AudioEventRTS *eventToRelease )
+void AudioManager::releaseAudioEventRTS( AudioEventRTS *&eventToRelease )
 {
 	if( eventToRelease )
 	{

--- a/GeneralsMD/Code/GameEngine/Source/Common/Audio/GameSounds.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Audio/GameSounds.cpp
@@ -136,7 +136,7 @@ Real SoundManager::getCameraAudibleDistance( void )
 }
 
 //-------------------------------------------------------------------------------------------------
-void SoundManager::addAudioEvent(AudioEventRTS *eventToAdd)
+void SoundManager::addAudioEvent(AudioEventRTS *&eventToAdd)
 {
 	if (m_num2DSamples == 0 && m_num3DSamples == 0) {
 		m_num2DSamples = TheAudio->getNum2DSamples();


### PR DESCRIPTION
What happens here is that `addAudioEvent` can delete the passed pointer (there even is a EA comment), but the caller then does nothing if that happens and keeps using that pointer.

This happens right on game boot.