### PR TITLE
[GEN][ZH] Fix stack-buffer-overflow in HotKeyTranslator::translateGameMessage

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/HotKey.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/HotKey.cpp
@@ -100,7 +100,7 @@ GameMessageDisposition HotKeyTranslator::translateGameMessage(const GameMessage 
 			return disp;
 		WideChar key = TheKeyboard->getPrintableKey(msg->getArgument(0)->integer, 0);
 		UnicodeString uKey;
-		uKey.set(&key);
+		uKey.concat(key);
 		AsciiString aKey;
 		aKey.translate(uKey);
 		if(TheHotKeyManager && TheHotKeyManager->executeHotKey(aKey))

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/HotKey.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/HotKey.cpp
@@ -100,7 +100,7 @@ GameMessageDisposition HotKeyTranslator::translateGameMessage(const GameMessage 
 			return disp;
 		WideChar key = TheKeyboard->getPrintableKey(msg->getArgument(0)->integer, 0);
 		UnicodeString uKey;
-		uKey.set(&key);
+		uKey.concat(key);
 		AsciiString aKey;
 		aKey.translate(uKey);
 		if(TheHotKeyManager && TheHotKeyManager->executeHotKey(aKey))


### PR DESCRIPTION
We cannot pass a pointer to a wchar_t and treat it as a string. It may not be 0 terminated!

```
==23980==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x017ef62a at pc 0x565b75e2 bp 0x017ef5d0 sp 0x017ef1b0
READ of size 8 at 0x017ef62a thread T0
==23980==WARNING: Failed to use and restart external symbolizer!
    #0 0x565b75e1 in wcslen D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\sanitizer_common\sanitizer_common_interceptors.inc:7199
    #1 0x0052bcc0 in UnicodeString::set D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\System\UnicodeString.cpp:176
    #2 0x00bd3e7d in HotKeyTranslator::translateGameMessage D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameClient\MessageStream\HotKey.cpp:103
    #3 0x005268fe in MessageStream::propagateMessages D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\MessageStream.cpp:1095
    #4 0x005043da in GameEngine::update D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\GameEngine.cpp:771
    #5 0x00ce3c7d in Win32GameEngine::update D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngineDevice\Source\Win32Device\Common\Win32GameEngine.cpp:90
    #6 0x00501aea in GameEngine::execute D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\GameEngine.cpp:845
    #7 0x004efc45 in GameMain D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\GameMain.cpp:44
    #8 0x004e8e77 in WinMain D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\Main\WinMain.cpp:1067
    #9 0x011e03f2 in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #10 0x777efcc8 in BaseThreadInitThunk+0x18 (C:\WINDOWS\System32\KERNEL32.DLL+0x6b81fcc8)
    #11 0x77a382ad in RtlGetAppContainerNamedObjectPath+0x11d (C:\WINDOWS\SYSTEM32\ntdll.dll+0x4b2e82ad)
    #12 0x77a3827d in RtlGetAppContainerNamedObjectPath+0xed (C:\WINDOWS\SYSTEM32\ntdll.dll+0x4b2e827d)

Address 0x017ef62a is located in stack of thread T0 at offset 18 in frame
    #0 0x00bd3c6f in HotKeyTranslator::translateGameMessage D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameClient\MessageStream\HotKey.cpp:71

  This frame has 3 object(s):
    [16, 18) 'key' <== Memory access at offset 18 overflows this variable
    [32, 36) 'uKey'
    [48, 52) 'aKey'
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp, SEH and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\System\UnicodeString.cpp:176 in UnicodeString::set
Shadow bytes around the buggy address:
  0x017ef380: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x017ef400: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x017ef480: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x017ef500: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x017ef580: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x017ef600: 00 00 00 f1 f1[02]f2 04 f2 04 f3 f3 f3 f3 00 00
  0x017ef680: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x017ef700: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x017ef780: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x017ef800: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x017ef880: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
=================================================================
==23980==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x017ef62a at pc 0x565b75e2 bp 0x017ef5d0 sp 0x017ef1b0
READ of size 8 at 0x017ef62a thread T0
==23980==WARNING: Failed to use and restart external symbolizer!
    #0 0x565b75e1 in wcslen D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\sanitizer_common\sanitizer_common_interceptors.inc:7199
    #1 0x0052bcc0 in UnicodeString::set D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\System\UnicodeString.cpp:176
    #2 0x00bd3e7d in HotKeyTranslator::translateGameMessage D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameClient\MessageStream\HotKey.cpp:103
    #3 0x005268fe in MessageStream::propagateMessages D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\MessageStream.cpp:1095
    #4 0x005043da in GameEngine::update D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\GameEngine.cpp:771
    #5 0x00ce3c7d in Win32GameEngine::update D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngineDevice\Source\Win32Device\Common\Win32GameEngine.cpp:90
    #6 0x00501aea in GameEngine::execute D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\GameEngine.cpp:845
    #7 0x004efc45 in GameMain D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\GameMain.cpp:44
    #8 0x004e8e77 in WinMain D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\Main\WinMain.cpp:1067
    #9 0x011e03f2 in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #10 0x777efcc8 in BaseThreadInitThunk+0x18 (C:\WINDOWS\System32\KERNEL32.DLL+0x6b81fcc8)
    #11 0x77a382ad in RtlGetAppContainerNamedObjectPath+0x11d (C:\WINDOWS\SYSTEM32\ntdll.dll+0x4b2e82ad)
    #12 0x77a3827d in RtlGetAppContainerNamedObjectPath+0xed (C:\WINDOWS\SYSTEM32\ntdll.dll+0x4b2e827d)

Address 0x017ef62a is located in stack of thread T0 at offset 18 in frame
    #0 0x00bd3c6f in HotKeyTranslator::translateGameMessage D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameClient\MessageStream\HotKey.cpp:71

  This frame has 3 object(s):
    [16, 18) 'key' <== Memory access at offset 18 overflows this variable
    [32, 36) 'uKey'
    [48, 52) 'aKey'
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp, SEH and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\System\UnicodeString.cpp:176 in UnicodeString::set
Shadow bytes around the buggy address:
  0x017ef380: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x017ef400: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x017ef480: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x017ef500: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x017ef580: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x017ef600: 00 00 00 f1 f1[02]f2 04 f2 04 f3 f3 f3 f3 00 00
  0x017ef680: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x017ef700: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x017ef780: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x017ef800: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x017ef880: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
Address Sanitizer Error: Stack buffer overflow

Full error details can be found in the Debug Output window
```