### PR TITLE
[GEN][ZH] Fix stack-buffer-underflow in Win32BIGFileSystem::openArchiveFile

### DIFF
--- a/Generals/Code/GameEngineDevice/Source/Win32Device/Common/Win32BIGFileSystem.cpp
+++ b/Generals/Code/GameEngineDevice/Source/Win32Device/Common/Win32BIGFileSystem.cpp
@@ -142,7 +142,7 @@ ArchiveFile * Win32BIGFileSystem::openArchiveFile(const Char *filename) {
 		} while (buffer[pathIndex] != 0);
 
 		Int filenameIndex = pathIndex;
-		while ((buffer[filenameIndex] != '\\') && (buffer[filenameIndex] != '/') && (filenameIndex >= 0)) {
+		while ((filenameIndex >= 0) && (buffer[filenameIndex] != '\\') && (buffer[filenameIndex] != '/')) {
 			--filenameIndex;
 		}
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/Common/Win32BIGFileSystem.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/Common/Win32BIGFileSystem.cpp
@@ -155,7 +155,7 @@ ArchiveFile * Win32BIGFileSystem::openArchiveFile(const Char *filename) {
 		} while (buffer[pathIndex] != 0);
 
 		Int filenameIndex = pathIndex;
-		while ((buffer[filenameIndex] != '\\') && (buffer[filenameIndex] != '/') && (filenameIndex >= 0)) {
+		while ((filenameIndex >= 0) && (buffer[filenameIndex] != '\\') && (buffer[filenameIndex] != '/')) {
 			--filenameIndex;
 		}
 


### PR DESCRIPTION
Checking filename index after using it is no good.

```
==16248==ERROR: AddressSanitizer: stack-buffer-underflow on address 0x020fa947 at pc 0x013440f9 bp 0x020fa918 sp 0x020fa918
READ of size 1 at 0x020fa947 thread T0
==16248==WARNING: Failed to use and restart external symbolizer!
    #0 0x013440f8 in Win32BIGFileSystem::openArchiveFile D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngineDevice\Source\Win32Device\Common\Win32BIGFileSystem.cpp:159
    #1 0x01343a8a in Win32BIGFileSystem::loadBigFilesFromDirectory D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngineDevice\Source\Win32Device\Common\Win32BIGFileSystem.cpp:222
    #2 0x0134366c in Win32BIGFileSystem::init D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngineDevice\Source\Win32Device\Common\Win32BIGFileSystem.cpp:61
    #3 0x00b54d45 in SubsystemInterfaceList::initSubsystem D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\System\SubsystemInterface.cpp:162
    #4 0x00b2ddfa in initSubsystem<ArchiveFileSystem> D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\GameEngine.cpp:167
    #5 0x00b31a4a in GameEngine::tryInit D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\GameEngine.cpp:393
    #6 0x00b313cd in GameEngine::init D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\GameEngine.cpp:278
    #7 0x00b1fb82 in GameMain D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\GameMain.cpp:41
    #8 0x00b18ce7 in WinMain D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\Main\WinMain.cpp:1067
    #9 0x01779092 in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #10 0x7734fcc8 in BaseThreadInitThunk+0x18 (C:\WINDOWS\System32\KERNEL32.DLL+0x6b81fcc8)
    #11 0x774982ad in RtlGetAppContainerNamedObjectPath+0x11d (C:\WINDOWS\SYSTEM32\ntdll.dll+0x4b2e82ad)
    #12 0x7749827d in RtlGetAppContainerNamedObjectPath+0xed (C:\WINDOWS\SYSTEM32\ntdll.dll+0x4b2e827d)

Address 0x020fa947 is located in stack of thread T0 at offset 15 in frame
    #0 0x01343bcf in Win32BIGFileSystem::openArchiveFile D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngineDevice\Source\Win32Device\Common\Win32BIGFileSystem.cpp:85

  This frame has 9 object(s):
    [16, 276) 'buffer' <== Memory access at offset 15 underflows this variable
    [32, 36) 'archiveFileName'
    [48, 52) 'archiveFileSize'
    [64, 68) 'numLittleFiles'
    [80, 84) 'asciibuf'
    [96, 100) 'filesize'
    [112, 116) 'fileOffset'
    [128, 132) 'path'
    [144, 148) 'debugpath'
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp, SEH and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-underflow D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngineDevice\Source\Win32Device\Common\Win32BIGFileSystem.cpp:159 in Win32BIGFileSystem::openArchiveFile
Shadow bytes around the buggy address:
  0x020fa680: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x020fa700: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x020fa780: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x020fa800: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x020fa880: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x020fa900: 00 00 00 00 00 00 00 f1[f1]00 00 00 00 00 00 00
  0x020fa980: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x020faa00: 00 00 00 00 00 00 00 00 00 04 f2 f2 f2 f2 04 f2
  0x020faa80: 04 f2 04 f2 04 f2 04 f2 04 f2 04 f2 04 f3 f3 f3
  0x020fab00: f3 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x020fab80: 00 00 00 f1 f1 00 f2 f8 f2 04 f2 f8 f2 f8 f3 f3
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
=================================================================
==16248==ERROR: AddressSanitizer: stack-buffer-underflow on address 0x020fa947 at pc 0x013440f9 bp 0x020fa918 sp 0x020fa918
READ of size 1 at 0x020fa947 thread T0
==16248==WARNING: Failed to use and restart external symbolizer!
    #0 0x013440f8 in Win32BIGFileSystem::openArchiveFile D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngineDevice\Source\Win32Device\Common\Win32BIGFileSystem.cpp:159
    #1 0x01343a8a in Win32BIGFileSystem::loadBigFilesFromDirectory D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngineDevice\Source\Win32Device\Common\Win32BIGFileSystem.cpp:222
    #2 0x0134366c in Win32BIGFileSystem::init D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngineDevice\Source\Win32Device\Common\Win32BIGFileSystem.cpp:61
    #3 0x00b54d45 in SubsystemInterfaceList::initSubsystem D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\System\SubsystemInterface.cpp:162
    #4 0x00b2ddfa in initSubsystem<ArchiveFileSystem> D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\GameEngine.cpp:167
    #5 0x00b31a4a in GameEngine::tryInit D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\GameEngine.cpp:393
    #6 0x00b313cd in GameEngine::init D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\GameEngine.cpp:278
    #7 0x00b1fb82 in GameMain D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\GameMain.cpp:41
    #8 0x00b18ce7 in WinMain D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\Main\WinMain.cpp:1067
    #9 0x01779092 in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #10 0x7734fcc8 in BaseThreadInitThunk+0x18 (C:\WINDOWS\System32\KERNEL32.DLL+0x6b81fcc8)
    #11 0x774982ad in RtlGetAppContainerNamedObjectPath+0x11d (C:\WINDOWS\SYSTEM32\ntdll.dll+0x4b2e82ad)
    #12 0x7749827d in RtlGetAppContainerNamedObjectPath+0xed (C:\WINDOWS\SYSTEM32\ntdll.dll+0x4b2e827d)

Address 0x020fa947 is located in stack of thread T0 at offset 15 in frame
    #0 0x01343bcf in Win32BIGFileSystem::openArchiveFile D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngineDevice\Source\Win32Device\Common\Win32BIGFileSystem.cpp:85

  This frame has 9 object(s):
    [16, 276) 'buffer' <== Memory access at offset 15 underflows this variable
    [32, 36) 'archiveFileName'
    [48, 52) 'archiveFileSize'
    [64, 68) 'numLittleFiles'
    [80, 84) 'asciibuf'
    [96, 100) 'filesize'
    [112, 116) 'fileOffset'
    [128, 132) 'path'
    [144, 148) 'debugpath'
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp, SEH and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-underflow D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngineDevice\Source\Win32Device\Common\Win32BIGFileSystem.cpp:159 in Win32BIGFileSystem::openArchiveFile
Shadow bytes around the buggy address:
  0x020fa680: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x020fa700: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x020fa780: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x020fa800: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x020fa880: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x020fa900: 00 00 00 00 00 00 00 f1[f1]00 00 00 00 00 00 00
  0x020fa980: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x020faa00: 00 00 00 00 00 00 00 00 00 04 f2 f2 f2 f2 04 f2
  0x020faa80: 04 f2 04 f2 04 f2 04 f2 04 f2 04 f2 04 f3 f3 f3
  0x020fab00: f3 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x020fab80: 00 00 00 f1 f1 00 f2 f8 f2 04 f2 f8 f2 f8 f3 f3
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
Address Sanitizer Error: Stack buffer underflow
```