### PR TITLE
[ZH] Replace inline assembler for non VS6 builds

### DIFF
--- a/Dependencies/Utility/Utility/intrin_compat.h
+++ b/Dependencies/Utility/Utility/intrin_compat.h
@@ -2,8 +2,50 @@
 
 // VC6 macros
 #if defined(_MSC_VER) && _MSC_VER < 1300
+
+#ifndef __debugbreak
 #define __debugbreak() __asm { int 3 }
 #endif
+
+#ifndef _rdtsc
+static inline __int64 _rdtsc()
+{
+	int h;
+	int l;
+
+	__asm {
+		_emit 0Fh
+		_emit 31h
+		mov	[h],edx
+		mov	[l],eax
+	}
+
+    __int64 result ((__int64)h << 32 | l);
+    return result;
+}
+#endif //_rdtsc
+
+#if defined _WIN32 && (defined _M_IX86 || defined _M_AMD64)
+#ifndef cpuid
+#define cpuid(regs, cpuid_type) __asm\
+{\
+    __asm { pushad }\
+    __asm { mov eax,[cpuid_type] }\
+    __asm { xor ebx,ebx }\
+    __asm { xor ecx,ecx }\
+    __asm { xor edx,edx }\
+    __asm { cpuid}\
+    __asm { mov [regs + 0],eax }\
+    __asm { mov [regs + 4],ebx }\
+    __asm { mov [regs + 8],ecx }\
+    __asm { mov [regs + 12],edx }\
+    __asm { popad }\
+}
+#endif
+#endif //defined _WIN32 && (defined _M_IX86 || defined _M_AMD64)
+
+#endif // defined(_MSC_VER) && _MSC_VER < 1300
+
 
 // Non-VC6 macros
 #if !(defined(_MSC_VER) && _MSC_VER < 1300)
@@ -69,5 +111,19 @@ static inline uint64_t _rdtsc()
 #elif !defined(_MSC_VER)
 #error "No implementation for __debugbreak"
 #endif
+
+#ifndef cpuid
+#if defined(_MSC_VER)
+#include <intrin.h>
+#define cpuid(regs, cpuid_type) __cpuid(reinterpret_cast<int *>(regs), cpuid_type)
+#elif (defined __clang__ || defined __GNUC__) && (defined __i386__ || defined __amd64__)
+#include <cpuid.h>
+#define cpuid(regs, cpuid_type) __cpuid(cpuid_type, regs[0], regs[1], regs[2], regs[3])
+#else
+/* Just return 0 for everything if its not x86 */
+#include <string.h>
+#define cpuid(regs, cpuid_type) memset(regs, 0, 16)
+#endif
+#endif //cpuid
 
 #endif // defined(_MSC_VER) && _MSC_VER < 1300

--- a/Dependencies/Utility/Utility/intrin_compat.h
+++ b/Dependencies/Utility/Utility/intrin_compat.h
@@ -16,6 +16,7 @@ static inline uint32_t _lrotl(uint32_t value, int shift)
 #if defined(__has_builtin) && __has_builtin(__builtin_rotateleft32)
     return __builtin_rotateleft32(value, shift);
 #else
+    shift &= 31;
     return ((value << shift) | (value >> (32 - shift)));
 #endif
 }

--- a/Dependencies/Utility/Utility/intrin_compat.h
+++ b/Dependencies/Utility/Utility/intrin_compat.h
@@ -1,5 +1,11 @@
 #pragma once
 
+// VC6 macros
+#if defined(_MSC_VER) && _MSC_VER < 1300
+#define __debugbreak() __asm { int 3 }
+#endif
+
+// Non-VC6 macros
 #if !(defined(_MSC_VER) && _MSC_VER < 1300)
 
 #include <cstdint>

--- a/GeneralsMD/Code/GameEngine/Include/Common/PerfTimer.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/PerfTimer.h
@@ -31,6 +31,8 @@
 #ifndef __PERFTIMER_H__
 #define __PERFTIMER_H__
 
+#include "Lib/intrin_compat.h"
+
 #if defined(_DEBUG) || defined(_INTERNAL)
 	/*
 		NOTE NOTE NOTE: never check this in with this enabled, since there is a nonzero time penalty
@@ -71,6 +73,7 @@ __forceinline void GetPrecisionTimer(Int64* t)
 #ifdef USE_QPF
 	QueryPerformanceCounter((LARGE_INTEGER*)t);
 #else
+# if defined(_MSC_VER) && _MSC_VER < 1300
 	// CPUID is needed to force serialization of any previous instructions. 
 	__asm 
 	{
@@ -81,6 +84,9 @@ __forceinline void GetPrecisionTimer(Int64* t)
 		MOV [ECX], EAX
 		MOV [ECX+4], EDX
 	}
+# else
+	*t = _rdtsc();
+# endif
 #endif
 }
 #endif

--- a/GeneralsMD/Code/GameEngine/Include/Common/PerfTimer.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/PerfTimer.h
@@ -31,7 +31,7 @@
 #ifndef __PERFTIMER_H__
 #define __PERFTIMER_H__
 
-#include "Lib/intrin_compat.h"
+#include "Utility/intrin_compat.h"
 
 #if defined(_DEBUG) || defined(_INTERNAL)
 	/*

--- a/GeneralsMD/Code/GameEngine/Include/Common/PerfTimer.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/PerfTimer.h
@@ -73,20 +73,7 @@ __forceinline void GetPrecisionTimer(Int64* t)
 #ifdef USE_QPF
 	QueryPerformanceCounter((LARGE_INTEGER*)t);
 #else
-# if defined(_MSC_VER) && _MSC_VER < 1300
-	// CPUID is needed to force serialization of any previous instructions. 
-	__asm 
-	{
-		// for now, I am commenting this out. It throws the timings off a bit more (up to .001%) jkmcd
-		//		CPUID
-		RDTSC
-		MOV ECX,[t]
-		MOV [ECX], EAX
-		MOV [ECX+4], EDX
-	}
-# else
 	*t = _rdtsc();
-# endif
 #endif
 }
 #endif

--- a/GeneralsMD/Code/GameEngine/Include/Common/crc.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/crc.h
@@ -67,7 +67,8 @@ public:
     if (!buf||len<1)
       return;
     
-    /* C++ version left in for reference purposes
+#if !(defined(_MSC_VER) && _MSC_VER < 1300)
+    // C++ version left in for reference purposes
 	  for (UnsignedByte *uintPtr=(UnsignedByte *)buf;len>0;len--,uintPtr++)
     {
     	int hibit;
@@ -84,8 +85,7 @@ public:
 	    crc += *uintPtr;
 	    crc += hibit;
     }
-    */
-
+#else
     // ASM version, verified by comparing resulting data with C++ version data
     unsigned *crcPtr=&crc;
     _asm
@@ -105,6 +105,7 @@ public:
       jns lp
       mov dword ptr [edi],ebx
     };
+#endif
   }
 
   /// Clears the CRC to 0

--- a/GeneralsMD/Code/GameEngine/Source/Common/PerfTimer.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/PerfTimer.cpp
@@ -37,6 +37,7 @@
 
 __forceinline void ProfileGetTime(__int64 &t)
 {
+#if defined(_MSC_VER) && _MSC_VER < 1300
   _asm
   {
     mov ecx,[t]
@@ -48,6 +49,9 @@ __forceinline void ProfileGetTime(__int64 &t)
     pop edx
     pop eax
   };
+#else
+	t = _rdtsc();
+#endif
 }
 
 #ifdef _INTERNAL

--- a/GeneralsMD/Code/GameEngine/Source/Common/PerfTimer.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/PerfTimer.cpp
@@ -37,21 +37,7 @@
 
 __forceinline void ProfileGetTime(__int64 &t)
 {
-#if defined(_MSC_VER) && _MSC_VER < 1300
-  _asm
-  {
-    mov ecx,[t]
-    push eax
-    push edx
-    rdtsc
-    mov [ecx],eax
-    mov [ecx+4],edx
-    pop edx
-    pop eax
-  };
-#else
 	t = _rdtsc();
-#endif
 }
 
 #ifdef _INTERNAL

--- a/GeneralsMD/Code/Libraries/Include/Lib/BaseType.h
+++ b/GeneralsMD/Code/Libraries/Include/Lib/BaseType.h
@@ -190,7 +190,6 @@ __forceinline long fast_float2long_round(float f)
 		fistp [i]
 	}
 #else
-	// TheSuperHackers @fix Use simple C code instead of inline assembly
 	i = lroundf(f);
 #endif
 

--- a/GeneralsMD/Code/Libraries/Include/Lib/BaseType.h
+++ b/GeneralsMD/Code/Libraries/Include/Lib/BaseType.h
@@ -197,25 +197,6 @@ __forceinline long fast_float2long_round(float f)
 	return i;
 }
 
-#if !(defined(_MSC_VER) && _MSC_VER < 1300)
-__forceinline unsigned int x86_shift_right_emu(unsigned int value, unsigned int shift, bool shift_ones)
-{
-	// This is what the CPU does
-	shift %= 32;
-	if (shift_ones)
-	{
-		// shift in ones
-		unsigned int ones = ((0xFFFFFFFFULL << (32 - shift)) & 0xFFFFFFFF);
-		return (value >> shift) | ones;
-	}
-	else
-	{
-		return value >> shift;
-	}
-	return value;
-}
-#endif
-
 // super fast float trunc routine, works always (independent of any FPU modes)
 // code courtesy of Martin Hoffesommer (grin)
 __forceinline float fast_float_trunc(float f)
@@ -234,23 +215,13 @@ __forceinline float fast_float_trunc(float f)
   }
   return f;
 #else
-	unsigned int value_as_int = *(unsigned int *)&f;
-	// Mask to only keep exponent and sign
-	unsigned int mantissa_mask = 0xff800000;
-
-	unsigned int sign_and_exponent = value_as_int >> 23;
-	unsigned char exponent = sign_and_exponent & 0xff;
-	bool shift_ones = true;
-	if (exponent < 127)
-	{
-		mantissa_mask = 0;
-		shift_ones = false;
-	}
-	exponent -= 127;
-	// Arithmetic shift right
-	mantissa_mask = x86_shift_right_emu(mantissa_mask, exponent, shift_ones);
-	value_as_int &= mantissa_mask;
-	return *(float *)&value_as_int;
+  unsigned x = *(unsigned *)&f;
+  unsigned char exp = x >> 23;
+  int mask = exp < 127 ? 0 : 0xff800000;
+  exp -= 127;
+  mask >>= exp & 31;
+  x &= mask;
+  return *(float *)&x;
 #endif
 }
 

--- a/GeneralsMD/Code/Libraries/Include/Lib/intrin_compat.h
+++ b/GeneralsMD/Code/Libraries/Include/Lib/intrin_compat.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#if !(defined(_MSC_VER) && _MSC_VER < 1300)
+
+#include <cstdint>
+
+#if !defined(_lrotl) && !defined(_WIN32)
+static inline uint32_t _lrotl(uint32_t value, int shift)
+{
+#if defined(__has_builtin) && __has_builtin(__builtin_rotateleft32)
+    return __builtin_rotateleft32(value, shift);
+#else
+    return ((value << shift) | (value >> (32 - shift)));
+#endif
+}
+#endif
+
+#ifndef _rdtsc
+#ifdef _WIN32
+#include <intrin.h>
+#pragma intrinsic(__rdtsc)
+#endif
+
+static inline uint64_t _rdtsc()
+{
+#if _WIN32
+    return __rdtsc();
+#elif defined(__has_builtin) && __has_builtin(__builtin_readcyclecounter)
+    return __builtin_readcyclecounter();
+#elif defined(__has_builtin) && __has_builtin(__builtin_ia32_rdtsc)
+    return __builtin_ia32_rdtsc();
+#else
+#error "No implementation for _rdtsc"
+#endif
+}
+#endif
+ 
+#ifdef _MSC_VER
+#include <intrin.h>
+#pragma intrinsic(_ReturnAddress)
+#elif defined(__has_builtin)
+    #if __has_builtin(__builtin_return_address)
+    static inline uintptr_t _ReturnAddress()
+    {
+        return reinterpret_cast<uintptr_t>(__builtin_return_address(0));
+    }
+    #else
+    #error "No implementation for _ReturnAddress"
+    #endif
+#else
+#error "No implementation for _ReturnAddress"
+#endif
+
+#if defined(__has_builtin) 
+    #if  __has_builtin(__builtin_debugtrap)
+    #define __debugbreak() __builtin_debugtrap()
+    #elif __has_builtin(__builtin_trap)
+    #define __debugbreak() __builtin_trap()
+    #else
+    #error "No implementation for __debugbreak"
+    #endif
+#elif !defined(_MSC_VER)
+#error "No implementation for __debugbreak"
+#endif
+
+#endif // defined(_MSC_VER) && _MSC_VER < 1300

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
@@ -1003,6 +1003,7 @@ WWINLINE unsigned int DX8Wrapper::Convert_Color(const Vector4& color)
 
 WWINLINE unsigned int DX8Wrapper::Convert_Color(const Vector3& color,float alpha)
 {
+#if defined(_MSC_VER) && _MSC_VER < 1300
 	const float scale = 255.0;
 	unsigned int col;
 
@@ -1069,16 +1070,20 @@ not_changed:
 		mov	col,eax
 	}
 	return col;
+#else
+	return color.Convert_To_ARGB(alpha);
+#endif // defined(_MSC_VER) && _MSC_VER < 1300
 }
 
 // ----------------------------------------------------------------------------
 //
-// Clamp color vertor to [0...1] range
+// Clamp color vector to [0...1] range
 //
 // ----------------------------------------------------------------------------
 
 WWINLINE void DX8Wrapper::Clamp_Color(Vector4& color)
 {
+#if defined(_MSC_VER) && _MSC_VER < 1300
 	if (!CPUDetectClass::Has_CMOV_Instruction()) {
 		for (int i=0;i<4;++i) {
 			float f=(color[i]<0.0f) ? 0.0f : color[i];
@@ -1129,6 +1134,12 @@ WWINLINE void DX8Wrapper::Clamp_Color(Vector4& color)
 		cmovnb edi,edx
 		mov dword ptr[esi+12],edi
 	}
+#else
+	for (int i=0;i<4;++i) {
+		float f=(color[i]<0.0f) ? 0.0f : color[i];
+		color[i]=(f>1.0f) ? 1.0f : f;
+	}
+#endif // defined(_MSC_VER) && _MSC_VER < 1300
 }
 
 // ----------------------------------------------------------------------------

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
@@ -1084,14 +1084,7 @@ not_changed:
 WWINLINE void DX8Wrapper::Clamp_Color(Vector4& color)
 {
 #if defined(_MSC_VER) && _MSC_VER < 1300
-	if (!CPUDetectClass::Has_CMOV_Instruction()) {
-		for (int i=0;i<4;++i) {
-			float f=(color[i]<0.0f) ? 0.0f : color[i];
-			color[i]=(f>1.0f) ? 1.0f : f;
-		}
-		return;
-	}
-
+	if (CPUDetectClass::Has_CMOV_Instruction()) {
 	__asm
 	{
 		mov	esi,dword ptr color
@@ -1134,12 +1127,14 @@ WWINLINE void DX8Wrapper::Clamp_Color(Vector4& color)
 		cmovnb edi,edx
 		mov dword ptr[esi+12],edi
 	}
-#else
+	return;
+	}
+#endif // defined(_MSC_VER) && _MSC_VER < 1300
+
 	for (int i=0;i<4;++i) {
 		float f=(color[i]<0.0f) ? 0.0f : color[i];
 		color[i]=(f>1.0f) ? 1.0f : f;
 	}
-#endif // defined(_MSC_VER) && _MSC_VER < 1300
 }
 
 // ----------------------------------------------------------------------------

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWDebug/CMakeLists.txt
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWDebug/CMakeLists.txt
@@ -17,4 +17,5 @@ target_sources(z_wwdebug PRIVATE ${WWDEBUG_SRC})
 
 target_link_libraries(z_wwdebug PRIVATE
     z_wwcommon
+    zi_libraries_include
 )

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWDebug/wwdebug.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWDebug/wwdebug.cpp
@@ -313,7 +313,7 @@ void WWDebug_Assert_Fail(const char * expr,const char * file, int line)
       }
 
 		if (code == IDRETRY) {
-			_asm int 3;
+			WWDEBUG_BREAK
       	return;
 		}
    }

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWDebug/wwdebug.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWDebug/wwdebug.h
@@ -40,7 +40,11 @@
 
 #ifndef WWDEBUG_H
 #define WWDEBUG_H
-				
+
+#ifdef WWDEBUG
+#include <Lib/intrin_compat.h>
+#endif
+
 // The macro MESSAGE allows user to put:
 // #pragma MESSAGE("Hello world")
 // anywhere in a source file.  The message:
@@ -142,9 +146,9 @@ void					WWDebug_DBWin32_Message_Handler( const char * message);
 ** the debugger...
 */
 #ifdef WWDEBUG
-#define WWDEBUG_BREAK							_asm int 0x03
+#define WWDEBUG_BREAK __debugbreak();
 #else
-#define WWDEBUG_BREAK							_asm int 0x03
+#define WWDEBUG_BREAK
 #endif
 
 /*

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWDebug/wwdebug.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWDebug/wwdebug.h
@@ -42,7 +42,7 @@
 #define WWDEBUG_H
 
 #ifdef WWDEBUG
-#include <Lib/intrin_compat.h>
+#include <Utility/intrin_compat.h>
 #endif
 
 // The macro MESSAGE allows user to put:

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWDebug/wwprofile.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWDebug/wwprofile.cpp
@@ -62,6 +62,7 @@
 #include "cpudetect.h"
 #include "hashtemplate.h"
 #include <stdio.h>
+#include <Utility/intrin_compat.h>
 
 static SimpleDynVecClass<WWProfileHierachyNodeClass*> ProfileCollectVector;
 static double TotalFrameTimes;
@@ -101,20 +102,7 @@ inline void WWProfile_Get_Ticks(_int64 * ticks)
 #ifdef _UNIX
        *ticks = TIMEGETTIME();
 #else
-	__asm
-	{
-		push edx;
-		push ecx;
-		push eax;
-		mov ecx,ticks;
-		_emit 0Fh
-		_emit 31h
-		mov [ecx],eax;
-		mov [ecx+4],edx;
-		pop eax;
-		pop ecx;
-		pop edx;
-	}
+	*ticks = _rdtsc();
 #endif
 }
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/CMakeLists.txt
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/CMakeLists.txt
@@ -204,4 +204,5 @@ target_sources(z_wwlib PRIVATE ${WWLIB_SRC})
 
 target_link_libraries(z_wwlib PRIVATE
     z_wwcommon
+    zi_libraries_include
 )

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/Except.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/Except.cpp
@@ -177,7 +177,7 @@ int __cdecl _purecall(void)
 	** Use int3 to cause an exception.
 	*/
 	WWDEBUG_SAY(("Pure Virtual Function call. Oh No!\n"));
-	_asm int 0x03;
+	WWDEBUG_BREAK
 #endif	//_DEBUG_ASSERT
 
 	return(return_code);

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/TARGA.CPP
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/TARGA.CPP
@@ -827,6 +827,7 @@ void Targa::XFlip(void)
 
 static __forceinline void _swapBytes(char *p1, char *p2, unsigned count)
 {
+#if defined(_MSC_VER) && _MSC_VER < 1300
   _asm
   {
     mov esi,[p1]
@@ -865,6 +866,17 @@ static __forceinline void _swapBytes(char *p1, char *p2, unsigned count)
     jmp lpLessThan16
   done:
   }
+#else
+	char *p1end=p1+count;
+	while (p1<p1end)
+	{
+		char tmp=*p1;
+		*p1=*p2;
+		*p2=tmp;
+		++p1;
+		++p2;
+	}
+#endif
 }
 
 void Targa::YFlip(void)

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/TARGA.CPP
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/TARGA.CPP
@@ -76,6 +76,8 @@
 #include <sys/stat.h>
 #endif
 
+#include <algorithm>
+#include <utility>
 
 /****************************************************************************
 *
@@ -867,15 +869,7 @@ static __forceinline void _swapBytes(char *p1, char *p2, unsigned count)
   done:
   }
 #else
-	char *p1end=p1+count;
-	while (p1<p1end)
-	{
-		char tmp=*p1;
-		*p1=*p2;
-		*p2=tmp;
-		++p1;
-		++p2;
-	}
+	std::swap_ranges(p1, p1 + count, p2);
 #endif
 }
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/cpudetect.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/cpudetect.cpp
@@ -24,6 +24,7 @@
 #pragma warning (disable : 4201)	// Nonstandard extension - nameless struct
 #include <windows.h>
 #include "systimer.h"
+#include <Utility/intrin_compat.h>
 
 #ifdef _UNIX
 # include <time.h>  // for time(), localtime() and timezone variable.
@@ -127,42 +128,18 @@ const char* CPUDetectClass::Get_Processor_Manufacturer_Name()
 
 static unsigned Calculate_Processor_Speed(__int64& ticks_per_second)
 {
-	struct {
-		unsigned timer0_h;
-		unsigned timer0_l;
-		unsigned timer1_h;
-		unsigned timer1_l;
-	} Time;
+	unsigned __int64 timer0=0;
+	unsigned __int64 timer1=0;
 
-#ifdef WIN32
-   __asm {
-      ASM_RDTSC;
-      mov Time.timer0_h, eax
-      mov Time.timer0_l, edx
-   }
-#elif defined(_UNIX)
-      __asm__("rdtsc");
-      __asm__("mov %eax, __Time.timer1_h");
-      __asm__("mov %edx, __Time.timer1_l");
-#endif
+	timer0=_rdtsc();
 
 	unsigned start=TIMEGETTIME();
 	unsigned elapsed;
 	while ((elapsed=TIMEGETTIME()-start)<200) {
-#ifdef WIN32
-      __asm {
-         ASM_RDTSC;
-         mov Time.timer1_h, eax
-         mov Time.timer1_l, edx
-      }
-#elif defined(_UNIX)
-      __asm__ ("rdtsc");
-      __asm__("mov %eax, __Time.timer1_h");
-      __asm__("mov %edx, __Time.timer1_l");
-#endif
+		timer1=_rdtsc();
 	}
 
-	__int64 t=*(__int64*)&Time.timer1_h-*(__int64*)&Time.timer0_h;
+	__int64 t=timer1-timer0;
 	ticks_per_second=(__int64)((1000.0/(double)elapsed)*(double)t);	// Ticks per second
 	return unsigned((double)t/(double)(elapsed*1000));
 }
@@ -826,6 +803,7 @@ void CPUDetectClass::Init_CPUID_Instruction()
    // because CodeWarrior seems to have problems with
    // the command (huh?)
 
+#if defined(_MSC_VER) && _MSC_VER < 1300
 #ifdef WIN32
    __asm
    {
@@ -868,6 +846,10 @@ void CPUDetectClass::Init_CPUID_Instruction()
      __asm__(" pop %ebx");
 #endif
 	HasCPUIDInstruction=!!cpuid_available;
+#else
+	// TheSuperHackers @info Mauller 30/3/2020 All modern CPUs have the CPUID instruction, VS22 code will not run on a cpu that doesn't.
+	HasCPUIDInstruction = true;
+#endif	// defined(_MSC_VER) && _MSC_VER < 1300
 }
 
 void CPUDetectClass::Init_Processor_Features()
@@ -941,44 +923,12 @@ bool CPUDetectClass::CPUID(
 {
 	if (!Has_CPUID_Instruction()) return false;	// Most processors since 486 have CPUID...
 
-	unsigned u_eax;
-	unsigned u_ebx;
-	unsigned u_ecx;
-	unsigned u_edx;
-
-#ifdef WIN32
-   __asm
-   {
-      pushad
-      mov	eax, [cpuid_type]
-      xor	ebx, ebx
-      xor	ecx, ecx
-      xor	edx, edx
-      cpuid
-      mov	[u_eax], eax
-      mov	[u_ebx], ebx
-      mov	[u_ecx], ecx
-      mov	[u_edx], edx
-      popad
-   }
-#elif defined(_UNIX)
-   __asm__("pusha");
-   __asm__("mov	__cpuid_type, %eax");
-   __asm__("xor	%ebx, %ebx");
-   __asm__("xor	%ecx, %ecx");
-   __asm__("xor	%edx, %edx");
-   __asm__("cpuid");
-   __asm__("mov	%eax, __u_eax");
-   __asm__("mov	%ebx, __u_ebx");
-   __asm__("mov	%ecx, __u_ecx");
-   __asm__("mov	%edx, __u_edx");
-   __asm__("popa");
-#endif
-
-	u_eax_=u_eax;
-	u_ebx_=u_ebx;
-	u_ecx_=u_ecx;
-	u_edx_=u_edx;
+	unsigned int regs[4];
+	cpuid(regs, cpuid_type);
+	u_eax_ = regs[0];
+	u_ebx_ = regs[1];
+	u_ecx_ = regs[2];
+	u_edx_ = regs[3];
 
 	return true;
 }

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/lcw.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/lcw.cpp
@@ -168,7 +168,7 @@ int LCW_Uncomp(void const * source, void * dest, unsigned long )
 }
 
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && defined(_M_IX86)
 
 
 /*********************************************************************************************** 
@@ -439,6 +439,6 @@ outofhere:
 #endif
 	return(retval);
 }
-#endif
+#endif // defined(_MSC_VER) && defined(_M_IX86)
 
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/mpu.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/mpu.cpp
@@ -96,12 +96,12 @@ unsigned long Get_CPU_Clock(unsigned long & high)
 		mov	[h],edx
 		mov	[l],eax
 	}
-	high = h;
 #else
 	auto tsc = _rdtsc();
 	h = tsc >> 32;
 	l = tsc & 0xFFFFFFFF;
 #endif
+	high = h;
 	return(l);
 }
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/mpu.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/mpu.cpp
@@ -85,20 +85,23 @@ unsigned long Get_CPU_Rate(unsigned long & high)
 }
 
 
-// unused
 unsigned long Get_CPU_Clock(unsigned long & high)
 {
 	int h;
 	int l;
-#if defined(_MSC_VER) && defined(_M_IX86)
+#if defined(_MSC_VER) && _MSC_VER < 1300
 	__asm {
 		_emit 0Fh
 		_emit 31h
 		mov	[h],edx
 		mov	[l],eax
 	}
-#endif
 	high = h;
+#else
+	auto tsc = _rdtsc();
+	h = tsc >> 32;
+	l = tsc & 0xFFFFFFFF;
+#endif
 	return(l);
 }
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/mpu.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/mpu.cpp
@@ -40,7 +40,7 @@
 #include	"MPU.H"
 #include "math.h"
 #include <assert.h>
-#include <Lib/intrin_compat.h>
+#include <Utility/intrin_compat.h>
 
 typedef union {
 	LARGE_INTEGER LargeInt;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/mpu.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/mpu.cpp
@@ -89,18 +89,11 @@ unsigned long Get_CPU_Clock(unsigned long & high)
 {
 	int h;
 	int l;
-#if defined(_MSC_VER) && _MSC_VER < 1300
-	__asm {
-		_emit 0Fh
-		_emit 31h
-		mov	[h],edx
-		mov	[l],eax
-	}
-#else
+
 	auto tsc = _rdtsc();
 	h = tsc >> 32;
 	l = tsc & 0xFFFFFFFF;
-#endif
+
 	high = h;
 	return(l);
 }
@@ -133,18 +126,9 @@ static unsigned long TSC_High;
 
 void RDTSC(void)
 {
-#if defined(_MSC_VER) && _MSC_VER < 1300
-    _asm
-    {
-        ASM_RDTSC;
-        mov     TSC_Low, eax
-        mov     TSC_High, edx
-    }
-#else
     auto TSC = _rdtsc();
     TSC_Low = TSC & 0xFFFFFFFF;
     TSC_High = TSC >> 32;
-#endif
 }
 
 
@@ -210,12 +194,7 @@ int Get_RDTSC_CPU_Speed(void)
 			QueryPerformanceCounter(&t1);
 		}
 
-#if defined(_MSC_VER) && _MSC_VER < 1300
-		ASM_RDTSC;
-		_asm	mov	stamp0, EAX
-#else
 		stamp0 = _rdtsc();
-#endif
 
 		t0.LowPart = t1.LowPart;		// Reset Initial Time
 		t0.HighPart = t1.HighPart;
@@ -228,12 +207,7 @@ int Get_RDTSC_CPU_Speed(void)
 			QueryPerformanceCounter(&t1);
 		}
 
-#if defined(_MSC_VER) && _MSC_VER < 1300
-		ASM_RDTSC;
-		_asm	mov	stamp1, EAX
-#else
 		stamp1 = _rdtsc();
-#endif
 
 		cycles = stamp1 - stamp0;					// # of cycles passed between reads
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWMath/vector3.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWMath/vector3.h
@@ -188,6 +188,7 @@ public:
 	// Color Conversion
 	WWINLINE unsigned	long	Convert_To_ABGR( void ) const;
 	WWINLINE unsigned	long	Convert_To_ARGB( void ) const;
+	WWINLINE unsigned	long	Convert_To_ARGB( float alpha ) const;
 };
 
 
@@ -910,6 +911,14 @@ WWINLINE unsigned long	Vector3::Convert_To_ARGB( void ) const
 			 (unsigned(X*255.0f)<<16) | 
 			 (unsigned(Y*255.0f)<<8) | 
 			 (unsigned(Z*255.0f));
+}
+
+WWINLINE unsigned long Vector3::Convert_To_ARGB( float alpha ) const
+{
+    return (unsigned(alpha * 255)<<24) |
+        (unsigned(X*255.0f)<<16) |
+        (unsigned(Y*255.0f)<<8) |
+        (unsigned(Z*255.0f));
 }
 
 #endif /* Vector3_H */

--- a/GeneralsMD/Code/Libraries/Source/profile/CMakeLists.txt
+++ b/GeneralsMD/Code/Libraries/Source/profile/CMakeLists.txt
@@ -28,5 +28,6 @@ target_include_directories(z_profile INTERFACE
 
 target_link_libraries(z_profile PRIVATE
     gz_config
+    gz_utility
     zi_libraries_include
 )

--- a/GeneralsMD/Code/Tools/timingTest/timingTest.cpp
+++ b/GeneralsMD/Code/Tools/timingTest/timingTest.cpp
@@ -24,6 +24,7 @@
 #include <windows.h>
 #include <mmsystem.h>
 #include <Utility/iostream_adapter.h>
+#include <Utility/intrin_compat.h>
 #include <string.h>
 
 double s_ticksPerSec = 0.0f;
@@ -33,6 +34,7 @@ char buffer[1024];
 //-------------------------------------------------------------------------------------------------
 void GetPrecisionTimer(INT64* t)
 {
+#if defined(_MSC_VER) && _MSC_VER < 1300
 	// CPUID is needed to force serialization of any previous instructions. 
 	__asm 
 	{
@@ -41,6 +43,9 @@ void GetPrecisionTimer(INT64* t)
 		MOV [ECX], EAX
 		MOV [ECX+4], EDX
 	}
+#else
+	*t = _rdtsc();
+#endif
 }
 
 //-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This change replaces most inline assembler for Zero Hour, but VS6 builds will still use the legacy inline assembler everywhere.

This change is required to run the VS2022 c++20 build without crashes.

This change was put together by reference changes from https://github.com/Fighter19/CnC_Generals_Zero_Hour and user Mauller.

TODO:

- [x] Replace inline assembler in Zero Hour Tools
- ~~Provide better macros (*1)~~
- ~~Add code comments where necessary~~

(*1) 
`#if defined(_MSC_VER) && _MSC_VER < 1300` -> `#define VS6_BUILD 1`
`#if defined(_MSC_VER) && defined(_M_IX86)` -> `#define MSC_X86_BUILD 1`
`#if defined (_WIN32) && !defined (_WIN64)` -> `#define WIN32_BUILD 1`
