### PR TITLE
Increase camera height for wider aspect ratios

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/GlobalData.h
+++ b/Generals/Code/GameEngine/Include/Common/GlobalData.h
@@ -72,6 +72,7 @@ public:
 	void update() { }
 
 	Bool setTimeOfDay( TimeOfDay tod );		///< Use this function to set the Time of day;
+	void setResolution(Int xres, Int yres);
 
 	static void parseGameDataDefinition( INI* ini );
 
@@ -159,6 +160,7 @@ public:
 	Real m_cameraHeight;
 	Real m_maxCameraHeight;
 	Real m_minCameraHeight;
+	Real m_cameraHeightAspectRatioMultiplier;
 	Real m_terrainHeightAtEdgeOfMap;
 	Real m_unitDamagedThresh;
 	Real m_unitReallyDamagedThresh;

--- a/Generals/Code/GameEngine/Source/Common/CommandLine.cpp
+++ b/Generals/Code/GameEngine/Source/Common/CommandLine.cpp
@@ -389,7 +389,7 @@ Int parseXRes(char *args[], int num)
 {
 	if (TheWritableGlobalData && num > 1)
 	{
-		TheWritableGlobalData->m_xResolution = atoi(args[1]);
+		TheWritableGlobalData->setResolution(atoi(args[1]), TheWritableGlobalData->m_yResolution);
 		return 2;
 	}
 	return 1;
@@ -399,7 +399,7 @@ Int parseYRes(char *args[], int num)
 {
 	if (TheWritableGlobalData && num > 1)
 	{
-		TheWritableGlobalData->m_yResolution = atoi(args[1]);
+		TheWritableGlobalData->setResolution(TheWritableGlobalData->m_xResolution, atoi(args[1]));
 		return 2;
 	}
 	return 1;

--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -1216,5 +1216,24 @@ void GlobalData::parseGameDataDefinition( INI* ini )
 
 	TheWritableGlobalData->m_xResolution = xres;
 	TheWritableGlobalData->m_yResolution = yres;
+
+	// TheSuperHackers @tweak valeronm 21/03/2025 Increase camera height for wide resolutions
+	// Change camera height based on xezon code from https://github.com/TheSuperHackers/GeneralsGameCode/issues/78
+	static const Real aspect_4_3 = 4.f / 3.f;
+	static const Real aspect_16_9 = 16.f / 9.f;
+	Real aspect = static_cast<Real>(xres) / static_cast<Real>(yres);
+
+	// Resolution must be greater than 4:3
+	// Screen width must be greater 640px and height greater 480
+	if (aspect > aspect_4_3 && xres >= 640 && yres >= 480) {
+		if (aspect > aspect_16_9)
+			aspect = aspect_16_9;
+		const Real multi = aspect - aspect_4_3 + 1.0f;
+		const Real nerf = 1.0f - (aspect - aspect_4_3) / 12.0f;
+
+		TheWritableGlobalData->m_maxCameraHeight *= multi * nerf;
+		TheWritableGlobalData->m_minCameraHeight *= multi * nerf;
+		TheWritableGlobalData->m_drawEntireTerrain = TRUE;
+	}
 }
 

--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -52,6 +52,7 @@
 
 #include "GameClient/Color.h"
 #include "GameClient/TerrainVisual.h"
+#include "GameClient/View.h"
 
 #include "GameNetwork/FirewallHelper.h"
 
@@ -1076,6 +1077,35 @@ Bool GlobalData::setTimeOfDay( TimeOfDay tod )
 
 }
 
+// TheSuperHackers @tweak valeronm 21/03/2025 Increase camera height for wide resolutions
+void GlobalData::setResolution(Int xres, Int yres) {
+	static const Real aspect_4_3 = 4.f / 3.f;
+	static const Real aspect_16_9 = 16.f / 9.f;
+
+	m_xResolution = xres;
+	m_yResolution = yres;
+
+	// Change camera height based on xezon code from https://github.com/TheSuperHackers/GeneralsGameCode/issues/78
+	Real aspect = static_cast<Real>(xres) / static_cast<Real>(yres);
+
+	if (aspect > aspect_4_3 && xres >= 640 && yres >= 480) {
+		if (aspect > aspect_16_9)
+			aspect = aspect_16_9;
+		const Real multi = aspect - aspect_4_3 + 1.0f;
+		const Real nerf = 1.0f - (aspect - aspect_4_3) / 12.0f;
+		m_cameraHeightAspectRatioMultiplier = multi * nerf;
+		m_drawEntireTerrain = TRUE;
+	}
+	else
+	{
+		m_cameraHeightAspectRatioMultiplier = 1.0f;
+		m_drawEntireTerrain = FALSE;
+	}
+	if (TheTacticalView) {
+		TheTacticalView->setDefaultView(0.0f, 0.0f, 1.0f);
+	}
+}
+
 //-------------------------------------------------------------------------------------------------
 /** Create a new global data instance to override the existing data set.  The
 	* initial values of the newly created instance will be a copy of the current
@@ -1213,27 +1243,6 @@ void GlobalData::parseGameDataDefinition( INI* ini )
 
 	Int xres,yres;
 	optionPref.getResolution(&xres, &yres);
-
-	TheWritableGlobalData->m_xResolution = xres;
-	TheWritableGlobalData->m_yResolution = yres;
-
-	// TheSuperHackers @tweak valeronm 21/03/2025 Increase camera height for wide resolutions
-	// Change camera height based on xezon code from https://github.com/TheSuperHackers/GeneralsGameCode/issues/78
-	static const Real aspect_4_3 = 4.f / 3.f;
-	static const Real aspect_16_9 = 16.f / 9.f;
-	Real aspect = static_cast<Real>(xres) / static_cast<Real>(yres);
-
-	// Resolution must be greater than 4:3
-	// Screen width must be greater 640px and height greater 480
-	if (aspect > aspect_4_3 && xres >= 640 && yres >= 480) {
-		if (aspect > aspect_16_9)
-			aspect = aspect_16_9;
-		const Real multi = aspect - aspect_4_3 + 1.0f;
-		const Real nerf = 1.0f - (aspect - aspect_4_3) / 12.0f;
-
-		TheWritableGlobalData->m_maxCameraHeight *= multi * nerf;
-		TheWritableGlobalData->m_minCameraHeight *= multi * nerf;
-		TheWritableGlobalData->m_drawEntireTerrain = TRUE;
-	}
+	TheWritableGlobalData->setResolution(xres,yres);
 }
 

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/MainMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/MainMenu.cpp
@@ -737,8 +737,7 @@ void DeclineResolution()
 		dispChanged = FALSE;
 		newDispSettings = oldDispSettings;
 
-		TheWritableGlobalData->m_xResolution = newDispSettings.xRes;
-		TheWritableGlobalData->m_yResolution = newDispSettings.yRes;
+		TheWritableGlobalData->setResolution(newDispSettings.xRes, newDispSettings.yRes);
 		
 		TheHeaderTemplateManager->headerNotifyResolutionChange();
 		TheMouse->mouseNotifyResolutionChange();

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -1031,8 +1031,7 @@ static void saveOptions( void )
 			if (TheDisplay->setDisplayMode(xres,yres,bitDepth,TheDisplay->getWindowed()))
 			{
 				dispChanged = TRUE;
-				TheWritableGlobalData->m_xResolution = xres;
-				TheWritableGlobalData->m_yResolution = yres;
+				TheWritableGlobalData->setResolution(xres, yres);
 
 				TheHeaderTemplateManager->headerNotifyResolutionChange();
 				TheMouse->mouseNotifyResolutionChange();

--- a/Generals/Code/GameEngine/Source/GameClient/View.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/View.cpp
@@ -102,7 +102,7 @@ void View::init( void )
 	m_maxZoom = 1.3f;
 	m_minZoom = 0.2f;
 	m_zoom = m_maxZoom;
-	m_maxHeightAboveGround = TheGlobalData->m_maxCameraHeight;
+	m_maxHeightAboveGround = TheGlobalData->m_maxCameraHeight * TheGlobalData->m_cameraHeightAspectRatioMultiplier;
 	m_minHeightAboveGround = TheGlobalData->m_minCameraHeight;
 	m_okToAdjustHeight = FALSE;
 

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -1617,7 +1617,7 @@ void W3DView::setDefaultView(Real pitch, Real angle, Real maxHeight)
 	// MDC - we no longer want to rotate maps (design made all of them right to begin with)
 	//	m_defaultAngle = angle * M_PI/180.0f;
 	m_defaultPitchAngle = pitch;
-	m_maxHeightAboveGround = TheGlobalData->m_maxCameraHeight*maxHeight;
+	m_maxHeightAboveGround = TheGlobalData->m_maxCameraHeight * TheGlobalData->m_cameraHeightAspectRatioMultiplier * maxHeight;
 	if (m_minHeightAboveGround > m_maxHeightAboveGround)
 		m_maxHeightAboveGround = m_minHeightAboveGround;
 }

--- a/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
@@ -75,6 +75,7 @@ public:
 	void update() { }
 
 	Bool setTimeOfDay( TimeOfDay tod );		///< Use this function to set the Time of day;
+	void setResolution(Int xRes, Int yRes);
 
 	static void parseGameDataDefinition( INI* ini );
 
@@ -166,6 +167,7 @@ public:
 	Real m_cameraHeight;
 	Real m_maxCameraHeight;
 	Real m_minCameraHeight;
+	Real m_cameraHeightAspectRatioMultiplier;
 	Real m_terrainHeightAtEdgeOfMap;
 	Real m_unitDamagedThresh;
 	Real m_unitReallyDamagedThresh;

--- a/GeneralsMD/Code/GameEngine/Source/Common/CommandLine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/CommandLine.cpp
@@ -397,7 +397,7 @@ Int parseXRes(char *args[], int num)
 {
 	if (TheWritableGlobalData && num > 1)
 	{
-		TheWritableGlobalData->m_xResolution = atoi(args[1]);
+		TheWritableGlobalData->setResolution(atoi(args[1]), TheWritableGlobalData->m_yResolution);
 		return 2;
 	}
 	return 1;
@@ -407,7 +407,7 @@ Int parseYRes(char *args[], int num)
 {
 	if (TheWritableGlobalData && num > 1)
 	{
-		TheWritableGlobalData->m_yResolution = atoi(args[1]);
+		TheWritableGlobalData->setResolution(TheWritableGlobalData->m_xResolution, atoi(args[1]));
 		return 2;
 	}
 	return 1;

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -1252,5 +1252,24 @@ void GlobalData::parseGameDataDefinition( INI* ini )
 
 	TheWritableGlobalData->m_xResolution = xres;
 	TheWritableGlobalData->m_yResolution = yres;
+
+	// TheSuperHackers @tweak valeronm 21/03/2025 Increase camera height for wide resolutions
+	// Change camera height based on xezon code from https://github.com/TheSuperHackers/GeneralsGameCode/issues/78
+	static const Real aspect_4_3 = 4.f / 3.f;
+	static const Real aspect_16_9 = 16.f / 9.f;
+	Real aspect = static_cast<Real>(xres) / static_cast<Real>(yres);
+
+	// Resolution must be greater than 4:3
+	// Screen width must be greater 640px and height greater 480
+	if (aspect > aspect_4_3 && xres >= 640 && yres >= 480) {
+		if (aspect > aspect_16_9)
+			aspect = aspect_16_9;
+		const Real multi = aspect - aspect_4_3 + 1.0f;
+		const Real nerf = 1.0f - (aspect - aspect_4_3) / 12.0f;
+
+		TheWritableGlobalData->m_maxCameraHeight *= multi * nerf;
+		TheWritableGlobalData->m_minCameraHeight *= multi * nerf;
+		TheWritableGlobalData->m_drawEntireTerrain = TRUE;
+	}
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/MainMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/MainMenu.cpp
@@ -747,8 +747,7 @@ void DeclineResolution()
 		dispChanged = FALSE;
 		newDispSettings = oldDispSettings;
 
-		TheWritableGlobalData->m_xResolution = newDispSettings.xRes;
-		TheWritableGlobalData->m_yResolution = newDispSettings.yRes;
+		TheWritableGlobalData->setResolution(newDispSettings.xRes, newDispSettings.yRes);
 		
 		TheHeaderTemplateManager->headerNotifyResolutionChange();
 		TheMouse->mouseNotifyResolutionChange();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -1086,8 +1086,7 @@ static void saveOptions( void )
 			if (TheDisplay->setDisplayMode(xres,yres,bitDepth,TheDisplay->getWindowed()))
 			{
 				dispChanged = TRUE;
-				TheWritableGlobalData->m_xResolution = xres;
-				TheWritableGlobalData->m_yResolution = yres;
+				TheWritableGlobalData->setResolution(xres, yres);
 
 				TheHeaderTemplateManager->headerNotifyResolutionChange();
 				TheMouse->mouseNotifyResolutionChange();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/View.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/View.cpp
@@ -102,7 +102,7 @@ void View::init( void )
 	m_maxZoom = 1.3f;
 	m_minZoom = 0.2f;
 	m_zoom = m_maxZoom;
-	m_maxHeightAboveGround = TheGlobalData->m_maxCameraHeight;
+	m_maxHeightAboveGround = TheGlobalData->m_maxCameraHeight * TheGlobalData->m_cameraHeightAspectRatioMultiplier;
 	m_minHeightAboveGround = TheGlobalData->m_minCameraHeight;
 	m_okToAdjustHeight = FALSE;
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -1916,7 +1916,7 @@ void W3DView::setDefaultView(Real pitch, Real angle, Real maxHeight)
 	// MDC - we no longer want to rotate maps (design made all of them right to begin with)
 	//	m_defaultAngle = angle * M_PI/180.0f;
 	m_defaultPitchAngle = pitch;
-	m_maxHeightAboveGround = TheGlobalData->m_maxCameraHeight*maxHeight;
+	m_maxHeightAboveGround = TheGlobalData->m_maxCameraHeight * TheGlobalData->m_cameraHeightAspectRatioMultiplier * maxHeight;
 	if (m_minHeightAboveGround > m_maxHeightAboveGround)
 		m_maxHeightAboveGround = m_minHeightAboveGround;
 }


### PR DESCRIPTION
The game doesn't support wide screens well because it has static horizontal field of view (FOV) and static maximum camera height. This means that for every resolution, the camera shows the same horizontal amount of terrain, but the vertical field of view becomes narrower for wider resolutions. So on wide screens, we get a center crop of what is visible on 4:3 resolutions (screenshots below).
To get vertical FOV similar to what's visible on 4:3 screens, we need to move the camera further from terrain or change the FOV of the camera. Ability to manipulate FOV of the camera only [available](https://github.com/TheSuperHackers/GeneralsGameCode/blob/114f16a921591a046039c0ddabb766e9149bc3f6/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp#L611-L613) in the DEBUG and INTERNAL builds, so changing camera height is more straightforward and this is how GenTool already supports wide resolutions based on #78.

#### Changes
- Added camera height multiplier, which is used to adjust camera height in tactical view;
- Added function to set game resolution, which also recalculates max camera height multiplier using code from #78;
- Updated code to set resolution using `setResolution` function to recalculate camera height multiplier on every resolution change.

#### Screenshots
<details><summary>1600 x 1200 - 4:3 field of view</summary>
  <img src="https://github.com/user-attachments/assets/cea59851-83c7-4a46-8b15-08ff9dc5a4b8">
</details>
<details><summary>1600 x 900 - 16:9 field of view (the same camera height as in 4:3)</summary>
  <img src="https://github.com/user-attachments/assets/f4755fa8-ee53-484c-8847-2a51b678c95d">
</details>
<details><summary>1600 x 900 - 16:9 field of view (adjusted camera height)</summary>
  <img src="https://github.com/user-attachments/assets/7150edea-5298-4c4a-b47e-0c0c48a9fc87">
</details>

Fixes #78 
Depends on #460 to make wide resolutions selectable