### PR TITLE
[Gen] Fix incorrect AsciiString hash implementation for non-stlport

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/STLTypedefs.h
+++ b/Generals/Code/GameEngine/Include/Common/STLTypedefs.h
@@ -204,10 +204,15 @@ namespace rts
 
 	template<> struct hash<AsciiString>
 	{
-		size_t operator()(AsciiString ast) const
-		{ 
-			std::hash<const char *> tmp;
-			return tmp((const char *) ast.str());
+		size_t operator()(const AsciiString& ast) const
+		{
+#ifdef USING_STLPORT
+			std::hash<const char*> tmp;
+			return tmp((const char*)ast.str());
+#else
+			std::hash<std::string_view> hasher;
+			return hasher(std::string_view(ast.str(), ast.getLength()));
+#endif
 		}
 	};
 


### PR DESCRIPTION
Copy the fixes that were made in the zero hour code by Xezon.

This fixes as fatal error at startup that prevents the game from starting.