### PR TITLE
[GEN] Replace inline assembler for non VS6 builds

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/PerfTimer.h
+++ b/Generals/Code/GameEngine/Include/Common/PerfTimer.h
@@ -31,6 +31,8 @@
 #ifndef __PERFTIMER_H__
 #define __PERFTIMER_H__
 
+#include "Utility/intrin_compat.h"
+
 #if defined(_DEBUG) || defined(_INTERNAL)
 	/*
 		NOTE NOTE NOTE: never check this in with this enabled, since there is a nonzero time penalty
@@ -71,16 +73,7 @@ __forceinline void GetPrecisionTimer(Int64* t)
 #ifdef USE_QPF
 	QueryPerformanceCounter((LARGE_INTEGER*)t);
 #else
-	// CPUID is needed to force serialization of any previous instructions. 
-	__asm 
-	{
-		// for now, I am commenting this out. It throws the timings off a bit more (up to .001%) jkmcd
-		//		CPUID
-		RDTSC
-		MOV ECX,[t]
-		MOV [ECX], EAX
-		MOV [ECX+4], EDX
-	}
+	*t = _rdtsc();
 #endif
 }
 #endif

--- a/Generals/Code/Libraries/Include/Lib/BaseType.h
+++ b/Generals/Code/Libraries/Include/Lib/BaseType.h
@@ -179,10 +179,14 @@ __forceinline long fast_float2long_round(float f)
 {
 	long i;
 
+#if defined(_MSC_VER) && _MSC_VER < 1300
 	__asm {
 		fld [f]
 		fistp [i]
 	}
+#else
+	i = lroundf(f);
+#endif
 
 	return i;
 }

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
@@ -750,6 +750,7 @@ WWINLINE unsigned int DX8Wrapper::Convert_Color(const Vector4& color)
 
 WWINLINE unsigned int DX8Wrapper::Convert_Color(const Vector3& color,float alpha)
 {
+#if defined(_MSC_VER) && _MSC_VER < 1300
 	const float scale = 255.0;
 	unsigned int col;
 
@@ -816,24 +817,21 @@ not_changed:
 		mov	col,eax
 	}
 	return col;
+#else
+	return color.Convert_To_ARGB(alpha);
+#endif // defined(_MSC_VER) && _MSC_VER < 1300
 }
 
 // ----------------------------------------------------------------------------
 //
-// Clamp color vertor to [0...1] range
+// Clamp color vector to [0...1] range
 //
 // ----------------------------------------------------------------------------
 
 WWINLINE void DX8Wrapper::Clamp_Color(Vector4& color)
 {
-	if (!CPUDetectClass::Has_CMOV_Instruction()) {
-		for (int i=0;i<4;++i) {
-			float f=(color[i]<0.0f) ? 0.0f : color[i];
-			color[i]=(f>1.0f) ? 1.0f : f;
-		}
-		return;
-	}
-
+#if defined(_MSC_VER) && _MSC_VER < 1300
+	if (CPUDetectClass::Has_CMOV_Instruction()) {
 	__asm
 	{
 		mov	esi,dword ptr color
@@ -875,6 +873,14 @@ WWINLINE void DX8Wrapper::Clamp_Color(Vector4& color)
 		cmp edi,edx		// if no less than 1.0 set to 1.0
 		cmovnb edi,edx
 		mov dword ptr[esi+12],edi
+	}
+	return;
+	}
+#endif // defined(_MSC_VER) && _MSC_VER < 1300
+
+	for (int i=0;i<4;++i) {
+		float f=(color[i]<0.0f) ? 0.0f : color[i];
+		color[i]=(f>1.0f) ? 1.0f : f;
 	}
 }
 

--- a/Generals/Code/Libraries/Source/WWVegas/WWDebug/CMakeLists.txt
+++ b/Generals/Code/Libraries/Source/WWVegas/WWDebug/CMakeLists.txt
@@ -17,4 +17,5 @@ target_sources(g_wwdebug PRIVATE ${WWDEBUG_SRC})
 
 target_link_libraries(g_wwdebug PRIVATE
     g_wwcommon
+    gi_libraries_include
 )

--- a/Generals/Code/Libraries/Source/WWVegas/WWDebug/wwdebug.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WWDebug/wwdebug.h
@@ -41,6 +41,11 @@
 #ifndef WWDEBUG_H
 #define WWDEBUG_H
 				
+// TheSuperHackers @todo Recover WWDEBUG?
+#ifdef WWDEBUG
+#include <Utility/intrin_compat.h>
+#endif
+
 // The macro MESSAGE allows user to put:
 // #pragma MESSAGE("Hello world")
 // anywhere in a source file.  The message:
@@ -139,9 +144,9 @@ void					WWDebug_DBWin32_Message_Handler( const char * message);
 ** the debugger...
 */
 #ifdef WWDEBUG
-#define WWDEBUG_BREAK							_asm int 0x03
+# define WWDEBUG_BREAK __debugbreak();
 #else
-#define WWDEBUG_BREAK							_asm int 0x03
+#define WWDEBUG_BREAK
 #endif
 
 /*

--- a/Generals/Code/Libraries/Source/WWVegas/WWDebug/wwprofile.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WWDebug/wwprofile.cpp
@@ -54,6 +54,7 @@
 #include "wwprofile.h"
 #include "wwdebug.h"
 #include <windows.h>
+#include <Utility/intrin_compat.h>
 
 
 
@@ -74,18 +75,7 @@ inline void WWProfile_Get_Ticks(_int64 * ticks)
 #ifdef _UNIX
 	*ticks = 0;
 #else 
-	__asm
-	{
-		push edx;
-		push ecx;
-		mov ecx,ticks;
-		_emit 0Fh
-		_emit 31h
-		mov [ecx],eax;
-		mov [ecx+4],edx;
-		pop ecx;
-		pop edx;
-	}
+	*ticks = _rdtsc();
 #endif
 }
 

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/CMakeLists.txt
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/CMakeLists.txt
@@ -196,4 +196,5 @@ target_sources(g_wwlib PRIVATE ${WWLIB_SRC})
 
 target_link_libraries(g_wwlib PRIVATE
     g_wwcommon
+    gi_libraries_include
 )

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/cpudetect.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/cpudetect.cpp
@@ -24,6 +24,7 @@
 #pragma warning (disable : 4201)	// Nonstandard extension - nameless struct
 #include <windows.h>
 #include "systimer.h"
+#include <Utility/intrin_compat.h>
 
 #ifdef _UNIX
 # include <time.h>  // for time(), localtime() and timezone variable.
@@ -127,42 +128,18 @@ const char* CPUDetectClass::Get_Processor_Manufacturer_Name()
 
 static unsigned Calculate_Processor_Speed(__int64& ticks_per_second)
 {
-	struct {
-		unsigned timer0_h;
-		unsigned timer0_l;
-		unsigned timer1_h;
-		unsigned timer1_l;
-	} Time;
+	unsigned __int64 timer0=0;
+	unsigned __int64 timer1=0;
 
-#ifdef WIN32
-   __asm {
-      ASM_RDTSC;
-      mov Time.timer0_h, eax
-      mov Time.timer0_l, edx
-   }
-#elif defined(_UNIX)
-      __asm__("rdtsc");
-      __asm__("mov %eax, __Time.timer1_h");
-      __asm__("mov %edx, __Time.timer1_l");
-#endif
+	timer0=_rdtsc();
 
 	unsigned start=TIMEGETTIME();
 	unsigned elapsed;
 	while ((elapsed=TIMEGETTIME()-start)<200) {
-#ifdef WIN32
-      __asm {
-         ASM_RDTSC;
-         mov Time.timer1_h, eax
-         mov Time.timer1_l, edx
-      }
-#elif defined(_UNIX)
-      __asm__ ("rdtsc");
-      __asm__("mov %eax, __Time.timer1_h");
-      __asm__("mov %edx, __Time.timer1_l");
-#endif
+		timer1=_rdtsc();
 	}
 
-	__int64 t=*(__int64*)&Time.timer1_h-*(__int64*)&Time.timer0_h;
+	__int64 t=timer1-timer0;
 	ticks_per_second=(__int64)((1000.0/(double)elapsed)*(double)t);	// Ticks per second
 	return unsigned((double)t/(double)(elapsed*1000));
 }
@@ -826,6 +803,7 @@ void CPUDetectClass::Init_CPUID_Instruction()
    // because CodeWarrior seems to have problems with
    // the command (huh?)
 
+#if defined(_MSC_VER) && _MSC_VER < 1300
 #ifdef WIN32
    __asm
    {
@@ -868,6 +846,10 @@ void CPUDetectClass::Init_CPUID_Instruction()
      __asm__(" pop %ebx");
 #endif
 	HasCPUIDInstruction=!!cpuid_available;
+#else
+	// TheSuperHackers @info Mauller 30/3/2020 All modern CPUs have the CPUID instruction, VS22 code will not run on a cpu that doesn't.
+	HasCPUIDInstruction = true;
+#endif	// defined(_MSC_VER) && _MSC_VER < 1300
 }
 
 void CPUDetectClass::Init_Processor_Features()
@@ -941,44 +923,12 @@ bool CPUDetectClass::CPUID(
 {
 	if (!Has_CPUID_Instruction()) return false;	// Most processors since 486 have CPUID...
 
-	unsigned u_eax;
-	unsigned u_ebx;
-	unsigned u_ecx;
-	unsigned u_edx;
-
-#ifdef WIN32
-   __asm
-   {
-      pushad
-      mov	eax, [cpuid_type]
-      xor	ebx, ebx
-      xor	ecx, ecx
-      xor	edx, edx
-      cpuid
-      mov	[u_eax], eax
-      mov	[u_ebx], ebx
-      mov	[u_ecx], ecx
-      mov	[u_edx], edx
-      popad
-   }
-#elif defined(_UNIX)
-   __asm__("pusha");
-   __asm__("mov	__cpuid_type, %eax");
-   __asm__("xor	%ebx, %ebx");
-   __asm__("xor	%ecx, %ecx");
-   __asm__("xor	%edx, %edx");
-   __asm__("cpuid");
-   __asm__("mov	%eax, __u_eax");
-   __asm__("mov	%ebx, __u_ebx");
-   __asm__("mov	%ecx, __u_ecx");
-   __asm__("mov	%edx, __u_edx");
-   __asm__("popa");
-#endif
-
-	u_eax_=u_eax;
-	u_ebx_=u_ebx;
-	u_ecx_=u_ecx;
-	u_edx_=u_edx;
+	unsigned int regs[4];
+	cpuid(regs, cpuid_type);
+	u_eax_ = regs[0];
+	u_ebx_ = regs[1];
+	u_ecx_ = regs[2];
+	u_edx_ = regs[3];
 
 	return true;
 }

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/lcw.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/lcw.cpp
@@ -168,7 +168,7 @@ int LCW_Uncomp(void const * source, void * dest, unsigned long )
 }
 
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && defined(_M_IX86)
 
 
 /*********************************************************************************************** 
@@ -439,6 +439,6 @@ outofhere:
 #endif
 	return(retval);
 }
-#endif
+#endif // defined(_MSC_VER) && defined(_M_IX86)
 
 

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/mpu.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/mpu.cpp
@@ -40,6 +40,7 @@
 #include	"MPU.H"
 #include "math.h"
 #include <assert.h>
+#include <Utility/intrin_compat.h>
 
 typedef union {
 	LARGE_INTEGER LargeInt;
@@ -88,12 +89,11 @@ unsigned long Get_CPU_Clock(unsigned long & high)
 {
 	int h;
 	int l;
-	__asm {
-		_emit 0Fh
-		_emit 31h
-		mov	[h],edx
-		mov	[l],eax
-	}
+
+	auto tsc = _rdtsc();
+	h = tsc >> 32;
+	l = tsc & 0xFFFFFFFF;
+
 	high = h;
 	return(l);
 }
@@ -126,12 +126,9 @@ static unsigned long TSC_High;
 
 void RDTSC(void)
 {
-    _asm
-    {
-        ASM_RDTSC;
-        mov     TSC_Low, eax
-        mov     TSC_High, edx
-    }
+    auto TSC = _rdtsc();
+    TSC_Low = TSC & 0xFFFFFFFF;
+    TSC_High = TSC >> 32;
 }
 
 
@@ -197,8 +194,7 @@ int Get_RDTSC_CPU_Speed(void)
 			QueryPerformanceCounter(&t1);
 		}
 
-		ASM_RDTSC;
-		_asm	mov	stamp0, EAX
+		stamp0 = _rdtsc();
 
 		t0.LowPart = t1.LowPart;		// Reset Initial Time
 		t0.HighPart = t1.HighPart;
@@ -211,9 +207,7 @@ int Get_RDTSC_CPU_Speed(void)
 			QueryPerformanceCounter(&t1);
 		}
 
-		ASM_RDTSC;
-		_asm	mov	stamp1, EAX
-
+		stamp1 = _rdtsc();
 
 		cycles = stamp1 - stamp0;					// # of cycles passed between reads
 

--- a/Generals/Code/Libraries/Source/WWVegas/WWMath/vector3.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WWMath/vector3.h
@@ -188,6 +188,7 @@ public:
 	// Color Conversion
 	WWINLINE unsigned	long	Convert_To_ABGR( void ) const;
 	WWINLINE unsigned	long	Convert_To_ARGB( void ) const;
+	WWINLINE unsigned	long	Convert_To_ARGB( float alpha ) const;
 };
 
 
@@ -910,6 +911,14 @@ WWINLINE unsigned long	Vector3::Convert_To_ARGB( void ) const
 			 (unsigned(X*255.0f)<<16) | 
 			 (unsigned(Y*255.0f)<<8) | 
 			 (unsigned(Z*255.0f));
+}
+
+WWINLINE unsigned long Vector3::Convert_To_ARGB( float alpha ) const
+{
+    return (unsigned(alpha * 255)<<24) |
+        (unsigned(X*255.0f)<<16) |
+        (unsigned(Y*255.0f)<<8) |
+        (unsigned(Z*255.0f));
 }
 
 #endif /* Vector3_H */

--- a/Generals/Code/Tools/timingTest/timingTest.cpp
+++ b/Generals/Code/Tools/timingTest/timingTest.cpp
@@ -24,6 +24,7 @@
 #include <windows.h>
 #include <mmsystem.h>
 #include <Utility/iostream_adapter.h>
+#include <Utility/intrin_compat.h>
 #include <string.h>
 
 double s_ticksPerSec = 0.0f;
@@ -33,6 +34,7 @@ char buffer[1024];
 //-------------------------------------------------------------------------------------------------
 void GetPrecisionTimer(INT64* t)
 {
+#if defined(_MSC_VER) && _MSC_VER < 1300
 	// CPUID is needed to force serialization of any previous instructions. 
 	__asm 
 	{
@@ -41,6 +43,9 @@ void GetPrecisionTimer(INT64* t)
 		MOV [ECX], EAX
 		MOV [ECX+4], EDX
 	}
+#else
+	*t = _rdtsc();
+#endif
 }
 
 //-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This replaces the inline ASM in non VS6 builds that causes crashing during running of the application.

This is a combination of code suggestions by myself and fixes by xezon.

This fix doesn't include other ASM changes seen in the Zero hour ASM change, this only resolves ASM that is causing crashes.