### PR TITLE
[GEN] Fix incorrect minor version

### DIFF
--- a/Generals/Code/Main/CMakeLists.txt
+++ b/Generals/Code/Main/CMakeLists.txt
@@ -41,7 +41,7 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/BuildVersion.h
 "#pragma once
 
 #define VERSION_MAJOR 1
-#define VERSION_MINOR 4
+#define VERSION_MINOR 8
 #define VERSION_BUILDNUM 601
 "
 )


### PR DESCRIPTION
The CMakeList file for generals vanilla contains the major and minor version. Probably a copy-paste error from Zero-Hour, the minor version is 4, instead of 9.

As Generals Vanilla uses the version in the CRC executable check, this causes a mismatch when joining a multiplayer. This PR changes the minor version to 9.