### PR TITLE
Simulate VS6 Optimizer in Code for Compatibility

### DIFF
--- a/GeneralsMD/Code/GameEngine/Include/Common/Debug.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Debug.h
@@ -54,6 +54,14 @@ class AsciiString;
 	#error "Only one at a time of these should ever be defined"
 #endif
 
+// This define enables some code that imitates the gamelogic optimizations applied
+// by the VC6 optimizer to the floating point math.
+// Ideally, this allows you to replay release games in debug mode and may even allow
+// you to compile the game on newer compilers without breaking compatibility.
+// Sadly, there are quite a few places to fix, and I only managed to make a very short replay
+// work in debug mode. So this isn't quite finished (and probably never will).
+#define SIMULATE_VC6_OPTIMIZATION 0
+
 #define NO_RELEASE_DEBUG_LOGGING
 
 #ifdef RELEASE_DEBUG_LOGGING  ///< Creates a DebugLogFile.txt (No I or D) with all the debug log goodness.  Good for startup problems.

--- a/GeneralsMD/Code/GameEngine/Include/Common/Thing.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Thing.h
@@ -156,6 +156,8 @@ protected:
 	virtual void reactToTransformChange(const Matrix3D* oldMtx, const Coord3D* oldPos, Real oldAngle) = 0;
 
 private:
+	
+	void myReactToTransformChange(const Matrix3D* oldMtx, const Coord3D* oldPos, Real oldAngle);
 
 	// note that it is declared 'const' -- the assumption being that
 	// since ThingTemplates are shared between many, many Things, the Thing

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp
@@ -821,9 +821,10 @@ void ActiveBody::attemptHealing( DamageInfo *damageInfo )
 	// initialize these, just in case we bail out early
 	damageInfo->out.m_actualDamageDealt = 0.0f;
 	damageInfo->out.m_actualDamageClipped = 0.0f;
-
+	
+	DUMPREAL(damageInfo->in.m_amount);
 	Real amount = m_curArmor.adjustDamage(damageInfo->in.m_damageType, damageInfo->in.m_amount);
-
+	DUMPREAL(amount);
 	// sanity check the damage value -- can't apply negative healing
 	if( amount > 0.0f )
 	{
@@ -897,7 +898,9 @@ void ActiveBody::setInitialHealth(Int initialPercent)
 void ActiveBody::setMaxHealth( Real maxHealth, MaxHealthChangeType healthChangeType )
 {
 	Real prevMaxHealth = m_maxHealth;
+	DUMPREAL(m_maxHealth);
 	m_maxHealth = maxHealth;
+	DUMPREAL(m_maxHealth);
 	m_initialHealth = maxHealth;
 
 	switch( healthChangeType )
@@ -1213,9 +1216,10 @@ void ActiveBody::internalChangeHealth( Real delta )
 {
 	// save the current health as the previous health
 	m_prevHealth = m_currentHealth;
-
+	DUMPREAL(m_currentHealth);
 	// change the health by the delta, it can be positive or negative
 	m_currentHealth += delta;
+	DUMPREAL(m_currentHealth);
 
 	// high end cap
 	Real maxHealth = m_maxHealth;
@@ -1226,6 +1230,7 @@ void ActiveBody::internalChangeHealth( Real delta )
 	const Real lowEndCap = 0.0f;  // low end cap for health, don't go below this
 	if( m_currentHealth < lowEndCap )
 		m_currentHealth = lowEndCap;
+	DUMPREAL(m_currentHealth);
 
 	// recalc the damage state
 	BodyDamageType oldState = m_curDamageState;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -1743,6 +1743,9 @@ inline Bool isAngleDifferent(Real a, Real b)
 //-------------------------------------------------------------------------------------------------
 void Object::reactToTurretChange( WhichTurretType turret, Real oldRotation, Real oldPitch )
 {
+	DUMPREAL(oldRotation);
+	DUMPREAL(oldPitch);
+
 	Real currentRotation = 0.0f;
 	Real currentPitch = 0.0f;
 	if( getAI() )
@@ -1927,6 +1930,7 @@ Bool Object::attemptHealingFromSoleBenefactor ( Real amount, const Object* sourc
 			damageInfo.in.m_deathType = DEATH_NONE;
 			damageInfo.in.m_sourceID = source ? source->getID() : INVALID_ID;
 			damageInfo.in.m_amount = amount;
+			DUMPREAL(amount);
 			body->attemptHealing( &damageInfo );
 		}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -43,6 +43,7 @@
 #include "Common/GameState.h"
 #include "Common/GlobalData.h"
 #include "Common/Xfer.h"
+#include "Common/CRCDebug.h"
 #include "GameClient/Drawable.h"
 #include "GameClient/GameText.h"
 #include "GameLogic/AIPathfind.h"
@@ -716,8 +717,13 @@ StateReturnType DozerActionDoActionState::update( void )
 				{
 
 					// figure out how much health we will restore this frame
+#if SIMULATE_VC6_OPTIMIZATION
+					Real health = body->getMaxHealth() * dozerAI->getRepairHealthPerSecond() * (1.0f / LOGICFRAMES_PER_SECOND);
+#else
 					Real health = body->getMaxHealth() * dozerAI->getRepairHealthPerSecond() /
 												LOGICFRAMES_PER_SECOND;
+#endif
+					DUMPREAL(health);
 
 					// try to give it a little bit-o-health
 					if ( ! goalObject->attemptHealingFromSoleBenefactor(health, dozer, 2) )//this frame and the next

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -33,6 +33,7 @@
 #include "Common/MiscAudio.h"
 #include "Common/ThingFactory.h"
 #include "Common/ThingTemplate.h"
+#include "Common/CRCDebug.h"
 #include "GameClient/Drawable.h"
 #include "GameClient/GameClient.h"
 #include "GameLogic/ExperienceTracker.h"
@@ -522,7 +523,13 @@ public:
 		Coord3D intermedPt;
 		Bool intermed = false;
 		Real orient = atan2(ppinfo.runwayPrep.y - ppinfo.parkingSpace.y, ppinfo.runwayPrep.x - ppinfo.parkingSpace.x);
+#if SIMULATE_VC6_OPTIMIZATION
+		Real diff = stdAngleDiff(orient, ppinfo.parkingOrientation);
+		DUMPREAL(diff);
+		if (fabs(diff) > PI/128)
+#else
 		if (fabs(stdAngleDiff(orient, ppinfo.parkingOrientation)) > PI/128)
+#endif
 		{
 			intermedPt.z = (ppinfo.parkingSpace.z + ppinfo.runwayPrep.z) * 0.5f;
 			intermed = intersectInfiniteLine2D(

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/RailroadGuideAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/RailroadGuideAIUpdate.cpp
@@ -32,6 +32,7 @@
 #include "Common/Player.h"
 #include "Common/ThingFactory.h"
 #include "Common/ThingTemplate.h"
+#include "Common/CRCDebug.h"
 
 #include "GameLogic/Locomotor.h"
 #include "GameLogic/Module/RailroadGuideAIUpdate.h"
@@ -1310,6 +1311,7 @@ void RailroadBehavior::updatePositionTrackDistance( PullInfo *pullerInfo, PullIn
 
 
 	Real relAngle = stdAngleDiff(desiredAngle, obj->getTransformMatrix()->Get_Z_Rotation());
+	DUMPREAL(relAngle);
 
 
 	Matrix3D mtx;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWMath/matrix3d.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWMath/matrix3d.h
@@ -200,8 +200,10 @@ public:
 	);
 
 	WWINLINE void Set(const Vector3 & axis,float angle);
+	WWINLINE void Set2(const Vector3 & axis,float angle);
 
 	WWINLINE void Set(const Vector3 & axis,float sine,float cosine);
+	WWINLINE void Set2(const Vector3 & axis,double sine,double cosine);
 
 	void Set(const Matrix3x3 & rotation,const Vector3 & position);
 
@@ -278,8 +280,11 @@ public:
 	WWINLINE void	Pre_Rotate_Y(float s,float c);
 	WWINLINE void	Pre_Rotate_Z(float s,float c);
 	WWINLINE void	In_Place_Pre_Rotate_X(float theta);
+	WWINLINE void	In_Place_Pre_Rotate_X2(float theta);//unused
 	WWINLINE void	In_Place_Pre_Rotate_Y(float theta);
+	WWINLINE void	In_Place_Pre_Rotate_Y2(float theta);
 	WWINLINE void 	In_Place_Pre_Rotate_Z(float theta);
+	WWINLINE void 	In_Place_Pre_Rotate_Z2(float theta);
 	WWINLINE void	In_Place_Pre_Rotate_X(float s,float c);
 	WWINLINE void	In_Place_Pre_Rotate_Y(float s,float c);
 	WWINLINE void	In_Place_Pre_Rotate_Z(float s,float c);
@@ -380,7 +385,7 @@ public:
 	static const Matrix3D		RotateZ180;
 	static const Matrix3D		RotateZ270;
 
-protected:
+//protected: // todo hack!
 
 	Vector4			Row[3];
 
@@ -576,6 +581,14 @@ WWINLINE void Matrix3D::Set(const Vector3 & axis,float angle)
 	Set(axis,s,c);
 }
 
+WWINLINE void Matrix3D::Set2(const Vector3 & axis,float angle)
+{
+	double c = cos(angle);
+	double s = sin(angle);
+
+	Set2(axis,s,c);
+}
+
 /***********************************************************************************************
  * Matrix3D::Set -- init a matrix to be a rotation about the given axis                        *
  *                                                                                             *
@@ -609,6 +622,32 @@ WWINLINE void Matrix3D::Set(const Vector3 & axis,float s,float c)
 	Row[2].Set(
 		(float)(axis[2]*axis[0]*(1.0f - c) - axis[1]*s),
 		(float)(axis[1]*axis[2]*(1.0f - c) + axis[0]*s),
+		(float)(axis[2]*axis[2] + c*(1 - axis[2]*axis[2])),
+		0.0f
+	);
+}
+
+WWINLINE void Matrix3D::Set2(const Vector3 & axis,double s,double c)
+{
+	assert(WWMath::Fabs(axis.Length2() - 1.0f) < 0.001f);
+
+	Row[0].Set(
+		(float)(axis[0]*axis[0] + c*(1.0 - axis[0]*axis[0])),
+		(float)(axis[0]*axis[1]*(1.0 - c) - axis[2]*s),
+		(float)(axis[2]*axis[0]*(1.0 - c) + axis[1]*s),
+		0.0f
+	);
+
+	Row[1].Set(
+		(float)(axis[0]*axis[1]*(1.0 - c) + axis[2]*s),
+		(float)(axis[1]*axis[1] + c*(1.0 - axis[1]*axis[1])),
+		(float)(axis[1]*axis[2]*(1.0 - c) - axis[0]*s),
+		0.0f
+	);
+
+	Row[2].Set(
+		(float)(axis[2]*axis[0]*(1.0 - c) - axis[1]*s),
+		(float)(axis[1]*axis[2]*(1.0 - c) + axis[0]*s),
 		(float)(axis[2]*axis[2] + c*(1 - axis[2]*axis[2])),
 		0.0f
 	);
@@ -1294,6 +1333,27 @@ WWINLINE void Matrix3D::In_Place_Pre_Rotate_X(float theta)
 	Row[2][2] = (float)(s*tmp1 + c*tmp2);
 }
 
+WWINLINE void Matrix3D::In_Place_Pre_Rotate_X2(float theta)
+{
+	double tmp1,tmp2;
+	double c,s;
+
+	c = cos(theta);
+	s = sin(theta);
+
+	tmp1 = Row[1][0]; tmp2 = Row[2][0];
+	Row[1][0] = (float)(c*tmp1 - s*tmp2);
+	Row[2][0] = (float)(s*tmp1 + c*tmp2);
+
+	tmp1 = Row[1][1]; tmp2 = Row[2][1];
+	Row[1][1] = (float)(c*tmp1 - s*tmp2);
+	Row[2][1] = (float)(s*tmp1 + c*tmp2);
+
+	tmp1 = Row[1][2]; tmp2 = Row[2][2];
+	Row[1][2] = (float)(c*tmp1 - s*tmp2);
+	Row[2][2] = (float)(s*tmp1 + c*tmp2);
+}
+
 /*********************************************************************************************** 
  * M3DC::In_Place_Pre_Rotate_Y -- Pre-multiplies rotation part of matrix by a rotation about Y * 
  *                                                                                             * 
@@ -1314,6 +1374,26 @@ WWINLINE void Matrix3D::In_Place_Pre_Rotate_Y(float theta)
 
 	c = cosf(theta);
 	s = sinf(theta);
+
+	tmp1 = Row[0][0]; tmp2 = Row[2][0];
+	Row[0][0] = (float)( c*tmp1 + s*tmp2);
+	Row[2][0] = (float)(-s*tmp1 + c*tmp2);
+
+	tmp1 = Row[0][1]; tmp2 = Row[2][1];
+	Row[0][1] = (float)( c*tmp1 + s*tmp2);
+	Row[2][1] = (float)(-s*tmp1 + c*tmp2);
+
+	tmp1 = Row[0][2]; tmp2 = Row[2][2];
+	Row[0][2] = (float)( c*tmp1 + s*tmp2);
+	Row[2][2] = (float)(-s*tmp1 + c*tmp2);
+}
+WWINLINE void Matrix3D::In_Place_Pre_Rotate_Y2(float theta)
+{
+	double tmp1,tmp2;
+	double c,s;
+
+	c = cos(theta);
+	s = sin(theta);
 
 	tmp1 = Row[0][0]; tmp2 = Row[2][0];
 	Row[0][0] = (float)( c*tmp1 + s*tmp2);
@@ -1348,6 +1428,27 @@ WWINLINE void Matrix3D::In_Place_Pre_Rotate_Z(float theta)
 
 	c = cosf(theta);
 	s = sinf(theta);
+
+	tmp1 = Row[0][0]; tmp2 = Row[1][0];
+	Row[0][0] = (float)(c*tmp1 - s*tmp2);
+	Row[1][0] = (float)(s*tmp1 + c*tmp2);
+
+	tmp1 = Row[0][1]; tmp2 = Row[1][1];
+	Row[0][1] = (float)(c*tmp1 - s*tmp2);
+	Row[1][1] = (float)(s*tmp1 + c*tmp2);
+
+	tmp1 = Row[0][2]; tmp2 = Row[1][2];
+	Row[0][2] = (float)(c*tmp1 - s*tmp2);
+	Row[1][2] = (float)(s*tmp1 + c*tmp2);
+}
+
+WWINLINE void Matrix3D::In_Place_Pre_Rotate_Z2(float theta)
+{
+	double tmp1,tmp2;
+	double c,s;
+
+	c = cos(theta);
+	s = sin(theta);
 
 	tmp1 = Row[0][0]; tmp2 = Row[1][0];
 	Row[0][0] = (float)(c*tmp1 - s*tmp2);


### PR DESCRIPTION
For context: VC6 is basically compiling with fast-math enabled, which means that it changes floating-point instructions around, even if they are not 100% exact. That means that compiling with a different compiler would break compatibility because slightly different gamelogic will result in mismatches.

This PR adds some code that imitates the gamelogic optimizations applied by the VC6 optimizer to the floating point math.
Ideally, this allows you to replay release games in debug mode and may even allow you to compile the game on newer compilers without breaking compatibility. Sadly, there are quite a few places to fix, and I only managed to make a very short replay work in debug mode. So this isn't quite finished (and probably never will).
I figured I make a PR just in case someone wants/has to continue to work on it. You can also see in the changes here what kind of optimizations VC6 is doing:
 - It does some calculations in double, even though the code says float.
 - It inlines some functions and simplifies formulas.
 - It changes the order of basic math operations arbitrarily around.
Sadly it's quite timeconsuming to figure those optimizations out, because you either have to look at the disassembly or change the code around with trial and error while comparing logs of debug and release builds.

So, no merge yet! You can also delete this PR if it doesn't fit here.