### PR TITLE
[ZH] Make game start on the monitor that it is launched from

### DIFF
--- a/GeneralsMD/Code/Main/WinMain.cpp
+++ b/GeneralsMD/Code/Main/WinMain.cpp
@@ -32,6 +32,12 @@
 
 // SYSTEM INCLUDES ////////////////////////////////////////////////////////////
 #define WIN32_LEAN_AND_MEAN  // only bare bones windows stuff wanted
+
+// This is required to access GetMonitorInfo in VC6.
+// As soon as we break compatibility with VC6 we can remove this.
+#undef WINVER
+#define WINVER 0x0500
+
 #include <windows.h>
 #include <stdlib.h>
 #include <crtdbg.h>
@@ -693,7 +699,22 @@ static Bool initializeAppWindows( HINSTANCE hInstance, Int nCmdShow, Bool runWin
 	                     TEXT("Game Window") };
   RegisterClass( &wndClass );
 
-   // Create our main window
+	// Find out which monitor to create the window on.
+	// This way, when the executable or a shortcut to it is opened on a certain monitor, the window
+	// opens on the same monitor. This also works when the game is started from the taskbar.
+	// See docs for STARTUPINFO for how this works.
+	STARTUPINFO si;
+	GetStartupInfo(&si);
+	HMONITOR hMonitor = (HMONITOR)si.hStdOutput;
+	MONITORINFO mi = { sizeof(mi) };
+	if (!GetMonitorInfo(hMonitor, &mi))
+	{
+		// Default to primary monitor.
+		hMonitor = MonitorFromWindow(NULL, MONITOR_DEFAULTTOPRIMARY);
+		GetMonitorInfo(hMonitor, &mi);
+	}
+
+    // Create our main window
 	windowStyle =  WS_POPUP|WS_VISIBLE;
 	if (runWindowed) 
 		windowStyle |= WS_DLGFRAME | WS_CAPTION | WS_SYSMENU;
@@ -705,27 +726,27 @@ static Bool initializeAppWindows( HINSTANCE hInstance, Int nCmdShow, Bool runWin
 	rect.top = 0;
 	rect.right = startWidth;
 	rect.bottom = startHeight;
+	// todo: use AdjustWindowRectExForDpi when we make this Per Monitor DPI compatible
 	AdjustWindowRect (&rect, windowStyle, FALSE);
-	if (runWindowed) {
-		// Makes the normal debug 800x600 window center in the screen.
-		startWidth = DEFAULT_XRESOLUTION;
-		startHeight= DEFAULT_YRESOLUTION;
-	}
+	startWidth = rect.right - rect.left;
+	startHeight = rect.bottom - rect.top;
 
 	gInitializing = true;
 
   HWND hWnd = CreateWindow( TEXT("Game Window"),
                             TEXT("Command and Conquer Generals"),
                             windowStyle, 
-														(GetSystemMetrics( SM_CXSCREEN ) / 2) - (startWidth / 2), // original position X
-														(GetSystemMetrics( SM_CYSCREEN ) / 2) - (startHeight / 2),// original position Y
+														//(GetSystemMetrics( SM_CXSCREEN ) / 2) - (startWidth / 2), // original position X
+														//(GetSystemMetrics( SM_CYSCREEN ) / 2) - (startHeight / 2),// original position Y
 														// Lorenzen nudged the window higher
 														// so the constantdebug report would 
 														// not get obliterated by assert windows, thank you.
 														//(GetSystemMetrics( SM_CXSCREEN ) / 2) - (startWidth / 2),   //this works with any screen res
 														//(GetSystemMetrics( SM_CYSCREEN ) / 25) - (startHeight / 25),//this works with any screen res
-														rect.right-rect.left,
-														rect.bottom-rect.top,
+														(mi.rcMonitor.right+mi.rcMonitor.left-startWidth) / 2,
+														(mi.rcMonitor.bottom+mi.rcMonitor.top-startHeight) / 2,
+														startWidth,
+														startHeight,
 														0L, 
 														0L, 
 														hInstance, 


### PR DESCRIPTION
This PR fixes the window creation to open on the monitor the game is launched on.
This way, when the executable or a shortcut to it is opened on a certain monitor, the window opens on the same monitor. This also works when the game is started from the taskbar.
The code to do this may seem hacky, but it's exactly what the documentation for GetStartupInfo recommends.

Also note that I needed to #define WINVER 0x0500, because the Monitor API didn't exist in Win 95 yet. This causes the compiler to emit a message when compiling WinMain.cpp, but generates no error or warning. The game will also no longer run on Win95, but I think we can live with that.

## Change list
- fix: The game starts now on the monitor it's launched from

