### PR TITLE
[ZH] Fix Replay CRC Checking

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -1141,6 +1141,10 @@ Bool RecorderClass::playbackFile(AsciiString filename)
 	fread(&maxFPS, sizeof(maxFPS), 1, m_file);
 
 	DEBUG_LOG(("RecorderClass::playbackFile() - original game was mode %d\n", m_originalGameMode));
+	
+	// In case we restart a replay, we need to clear the command list.
+	// Otherwise a crc message remains and messes up the crc calculation on the restarted replay.
+	TheCommandList->reset();
 
 	readNextFrame();
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -1007,7 +1007,7 @@ void RecorderClass::handleCRCMessage(UnsignedInt newCRC, Int playerIndex, Bool f
 			// virtually every replay, the assumption is our CRC checking is faulty.  Since we're at the
 			// tail end of patch season, let's just disable the message, and hope the users believe the
 			// problem is fixed. -MDC 3/20/2003
-			//TheInGameUI->message("GUI:CRCMismatch");
+			TheInGameUI->message("GUI:CRCMismatch");
 			DEBUG_CRASH(("Replay has gone out of sync!  All bets are off!\nOld:%8.8X New:%8.8X\nFrame:%d",
 				playbackCRC, newCRC, TheGameLogic->getFrame()));
 		}


### PR DESCRIPTION
When playing back replays, the game checks the CRC stored in the replay with the CRC calculated from memory. When a mismatch occurs, the game warns the user about it. Or at least until this message was commented out:
```
//Kris: Patch 1.01 November 10, 2003 (integrated changes from Matt Campbell)
// Since we don't seem to have any *visible* desyncs when replaying games, but get this warning
// virtually every replay, the assumption is our CRC checking is faulty.  Since we're at the
// tail end of patch season, let's just disable the message, and hope the users believe the
// problem is fixed. -MDC 3/20/2003
//TheInGameUI->message("GUI:CRCMismatch");
```

This PR reenables that message and fixes the underlying issue, which is actually two issues:
- In Multiplayer (not in Singleplayer games), the first MSG_LOGIC_CRC message somehow doesn't make it through the network. It's probably because the network isn't set up yet on frame 0, but I'm not sure. To fix this we ignore the crc on frame 0 when replaying a multiplayer game. (Note that the code for this fix was already there, but commented out. Kris just didn't figure out that this is necessary only for Multiplayer)
- When restarting a replay (press Esc, select Restart) the commandbuffer needs to be cleared. Otherwise the CRC desyncs because one crc message from the old game is passed to the restarted game.

With those two issues fixed, the crc seems very reliable. I played back multiple long replays that were played on 1.04 on the Release build and found no wrong CRCMismatch.

Admittedly, this fix isn't much use for the player, but my hope is that we can check replays with this fix to check for regressions in compatibility automatically.

## Change list
- fix: Show warning when playing a replay and synchronization is lost.
