### PR TITLE
[GEN] Backport TextureFilterClass

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/MapUtil.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MapUtil.cpp
@@ -1162,7 +1162,7 @@ Image *getMapPreviewImage( AsciiString mapName )
 	mapPreviewImage->setStatus(IMAGE_STATUS_RAW_TEXTURE);
 // allocate our terrain texture
 	TextureClass * texture = new TextureClass( size.x, size.y, 
-																			 WW3D_FORMAT_X8R8G8B8, TextureClass::MIP_LEVELS_1 );
+																			 WW3D_FORMAT_X8R8G8B8, MIP_LEVELS_1 );
 	uv.lo.x = 0.0f;
 	uv.lo.y = 1.0f;
 	uv.hi.x = 1.0f;

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DAssetManager.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DAssetManager.h
@@ -68,7 +68,7 @@ public:
 	virtual bool Load_3D_Assets( const char * filename ); // This CANNOT be Bool, as it will not inherit properly if you make Bool == Int
 	virtual TextureClass *			Get_Texture(
 		const char * filename, 
-		TextureClass::MipCountType mip_level_count=TextureClass::MIP_LEVELS_ALL,
+		MipCountType mip_level_count=MIP_LEVELS_ALL,
 		WW3DFormat texture_format=WW3D_FORMAT_UNKNOWN,
 		bool allow_compression=true);
 
@@ -107,7 +107,7 @@ private:
 
 	//'E&B' customizations
 /*	virtual RenderObjClass * Create_Render_Obj(const char * name, float scale, const Vector3 &hsv_shift);	
-	TextureClass * Get_Texture_With_HSV_Shift(const char * filename, const Vector3 &hsv_shift, TextureClass::MipCountType mip_level_count = TextureClass::MIP_LEVELS_ALL);
+	TextureClass * Get_Texture_With_HSV_Shift(const char * filename, const Vector3 &hsv_shift, MipCountType mip_level_count = MIP_LEVELS_ALL);
 	void Recolor_Vertex_Material(VertexMaterialClass *vmat, const Vector3 &hsv_shift);
 	void Recolor_Vertices(unsigned int *color, int count, const Vector3 &hsv_shift);	
 	void Recolor_Mesh(RenderObjClass *robj, const Vector3 &hsv_shift);

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DShroud.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DShroud.h
@@ -116,7 +116,7 @@ protected:
 	TextureClass *m_pDstTexture;			///<stores vidmem copy of visible shroud.
 	Int m_dstTextureWidth;					///<dimensions of m_pDstTexture
 	Int m_dstTextureHeight;					///<dimensions of m_pDstTexture
-	TextureClass::FilterType m_shroudFilter;
+	TextureFilterClass::FilterType m_shroudFilter;
 	Real m_drawOriginX;
 	Real m_drawOriginY;
 	Bool m_drawFogOfWar;					///<switch to draw alternate fog style instead of solid black

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/Common/System/W3DRadar.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/Common/System/W3DRadar.cpp
@@ -886,24 +886,24 @@ void W3DRadar::init( void )
 	// allocate our terrain texture
 	// poolify
 	m_terrainTexture = MSGNEW("TextureClass") TextureClass( m_textureWidth, m_textureHeight, 
-																			 m_terrainTextureFormat, TextureClass::MIP_LEVELS_1 );
+																			 m_terrainTextureFormat, MIP_LEVELS_1 );
 	DEBUG_ASSERTCRASH( m_terrainTexture, ("W3DRadar: Unable to allocate terrain texture\n") );
 
 	// allocate our overlay texture
 	m_overlayTexture = MSGNEW("TextureClass") TextureClass( m_textureWidth, m_textureHeight,
-																			 m_overlayTextureFormat, TextureClass::MIP_LEVELS_1 );
+																			 m_overlayTextureFormat, MIP_LEVELS_1 );
 	DEBUG_ASSERTCRASH( m_overlayTexture, ("W3DRadar: Unable to allocate overlay texture\n") );
 
 	// set filter type for the overlay texture, try it and see if you like it, I don't ;)
-//	m_overlayTexture->Set_Min_Filter( TextureClass::FILTER_TYPE_NONE );
-//	m_overlayTexture->Set_Mag_Filter( TextureClass::FILTER_TYPE_NONE );
+//	m_overlayTexture->Set_Min_Filter( TextureFilterClass::FILTER_TYPE_NONE );
+//	m_overlayTexture->Set_Mag_Filter( TextureFilterClass::FILTER_TYPE_NONE );
 
 	// allocate our shroud texture
 	m_shroudTexture = MSGNEW("TextureClass") TextureClass( m_textureWidth, m_textureHeight,
-																			 m_shroudTextureFormat, TextureClass::MIP_LEVELS_1 );
+																			 m_shroudTextureFormat, MIP_LEVELS_1 );
 	DEBUG_ASSERTCRASH( m_shroudTexture, ("W3DRadar: Unable to allocate shroud texture\n") );
-	m_shroudTexture->Set_Min_Filter( TextureClass::FILTER_TYPE_DEFAULT );
-	m_shroudTexture->Set_Mag_Filter( TextureClass::FILTER_TYPE_DEFAULT );
+	m_shroudTexture->Set_Min_Filter( TextureFilterClass::FILTER_TYPE_DEFAULT );
+	m_shroudTexture->Set_Mag_Filter( TextureFilterClass::FILTER_TYPE_DEFAULT );
 
 	//
 	// create images used for rendering and set them up with the textures

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/HeightMap.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/HeightMap.cpp
@@ -2565,8 +2565,8 @@ void HeightMapRenderObjClass::initDestAlphaLUT(void)
 			surf->Unlock();
 		}
 
-		m_destAlphaTexture->Set_U_Addr_Mode(TextureClass::TEXTURE_ADDRESS_CLAMP);
-		m_destAlphaTexture->Set_V_Addr_Mode(TextureClass::TEXTURE_ADDRESS_CLAMP);
+		m_destAlphaTexture->Set_U_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
+		m_destAlphaTexture->Set_V_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
 		REF_PTR_RELEASE(surf);
 		m_currentMinWaterOpacity = TheWaterTransparency->m_minWaterOpacity;
 	}
@@ -2678,7 +2678,7 @@ Int HeightMapRenderObjClass::initHeightData(Int x, Int y, WorldHeightMap *pMap, 
 		REF_PTR_SET(m_map,pMap);	//update our heightmap pointer in case it changed since last call.
 		m_stageTwoTexture=NEW CloudMapTerrainTextureClass;
 		m_stageThreeTexture=NEW LightMapTerrainTextureClass(m_macroTextureName);
-		m_destAlphaTexture=MSGNEW("TextureClass") TextureClass(256,1,WW3D_FORMAT_A8R8G8B8,TextureClass::MIP_LEVELS_1);
+		m_destAlphaTexture=MSGNEW("TextureClass") TextureClass(256,1,WW3D_FORMAT_A8R8G8B8,MIP_LEVELS_1);
 		initDestAlphaLUT();
 #ifdef DO_SCORCH
 		allocateScorchBuffers();

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DProjectedShadow.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DProjectedShadow.cpp
@@ -1530,9 +1530,9 @@ Shadow* W3DProjectedShadowManager::addDecal(Shadow::ShadowTypeInfo *shadowInfo)
 	{
 		//Adding a new decal texture
 		TextureClass *w3dTexture=WW3DAssetManager::Get_Instance()->Get_Texture(texture_name);
-		w3dTexture->Set_U_Addr_Mode(TextureClass::TEXTURE_ADDRESS_CLAMP);
-		w3dTexture->Set_V_Addr_Mode(TextureClass::TEXTURE_ADDRESS_CLAMP);
-		w3dTexture->Set_Mip_Mapping(TextureClass::FILTER_TYPE_NONE);
+		w3dTexture->Set_U_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
+		w3dTexture->Set_V_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
+		w3dTexture->Set_Mip_Mapping(TextureFilterClass::FILTER_TYPE_NONE);
 
 		DEBUG_ASSERTCRASH(w3dTexture != NULL, ("Could not load decal texture: %s\n",texture_name));
 
@@ -1648,9 +1648,9 @@ Shadow* W3DProjectedShadowManager::addDecal(RenderObjClass *robj, Shadow::Shadow
 	{
 		//Adding a new decal texture
 		TextureClass *w3dTexture=WW3DAssetManager::Get_Instance()->Get_Texture(texture_name);
-		w3dTexture->Set_U_Addr_Mode(TextureClass::TEXTURE_ADDRESS_CLAMP);
-		w3dTexture->Set_V_Addr_Mode(TextureClass::TEXTURE_ADDRESS_CLAMP);
-		w3dTexture->Set_Mip_Mapping(TextureClass::FILTER_TYPE_NONE);
+		w3dTexture->Set_U_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
+		w3dTexture->Set_V_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
+		w3dTexture->Set_Mip_Mapping(TextureFilterClass::FILTER_TYPE_NONE);
 
 		DEBUG_ASSERTCRASH(w3dTexture != NULL, ("Could not load decal texture: %s\n",texture_name));
 
@@ -1793,9 +1793,9 @@ W3DProjectedShadow* W3DProjectedShadowManager::addShadow(RenderObjClass *robj, S
 				{
 					//need to add this texture without creating it from a real renderobject
 					TextureClass *w3dTexture=WW3DAssetManager::Get_Instance()->Get_Texture(texture_name);
-					w3dTexture->Set_U_Addr_Mode(TextureClass::TEXTURE_ADDRESS_CLAMP);
-					w3dTexture->Set_V_Addr_Mode(TextureClass::TEXTURE_ADDRESS_CLAMP);
-					w3dTexture->Set_Mip_Mapping(TextureClass::FILTER_TYPE_NONE);
+					w3dTexture->Set_U_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
+					w3dTexture->Set_V_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
+					w3dTexture->Set_Mip_Mapping(TextureFilterClass::FILTER_TYPE_NONE);
 
 					DEBUG_ASSERTCRASH(w3dTexture != NULL, ("Could not load decal texture"));
 
@@ -2189,7 +2189,7 @@ Int W3DShadowTexture::init(RenderObjClass *robj)
 
 	TheW3DProjectedShadowManager->getRenderTarget()->Get_Level_Description(surface_desc);
 
-	TextureClass *new_texture = MSGNEW("TextureClass") TextureClass(surface_desc.Width,surface_desc.Height,surface_desc.Format,TextureClass::MIP_LEVELS_1);
+	TextureClass *new_texture = MSGNEW("TextureClass") TextureClass(surface_desc.Width,surface_desc.Height,surface_desc.Format,MIP_LEVELS_1);
 
 	setTexture(new_texture);
 

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/TerrainTex.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/TerrainTex.cpp
@@ -989,7 +989,7 @@ up the "sliding" parameters for the clouds to slide over the terrain. */
 CloudMapTerrainTextureClass::CloudMapTerrainTextureClass(MipCountType mipLevelCount) :
 	TextureClass("TSCloudMed.tga","TSCloudMed.tga", mipLevelCount )
 { 
-	Set_Mip_Mapping( FILTER_TYPE_FAST );
+	Set_Mip_Mapping( TextureFilterClass::FILTER_TYPE_FAST );
 	m_xSlidePerSecond = -0.02f;	 
 	m_ySlidePerSecond =  1.50f * m_xSlidePerSecond;
 	m_curTick = 0;

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DAssetManager.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DAssetManager.cpp
@@ -170,7 +170,7 @@ __int64 Total_Get_Texture_Time=0;
 //---------------------------------------------------------------------
 TextureClass *W3DAssetManager::Get_Texture(
 	const char * filename,
-	TextureClass::MipCountType mip_level_count,
+	MipCountType mip_level_count,
 	WW3DFormat texture_format,
 	bool allow_compression
 )
@@ -640,7 +640,7 @@ TextureClass * W3DAssetManager::Recolor_Texture_One_Time(TextureClass *texture, 
 
 	// make sure texture is loaded
 	if (!texture->Is_Initialized())	
-		TextureLoader::Request_High_Priority_Loading(texture, (TextureClass::MipCountType)texture->Get_Mip_Level_Count());
+		TextureLoader::Request_High_Priority_Loading(texture, (MipCountType)texture->Get_Mip_Level_Count());
 
 	SurfaceClass::SurfaceDescription desc;
 	SurfaceClass *newsurf, *oldsurf;
@@ -661,7 +661,7 @@ TextureClass * W3DAssetManager::Recolor_Texture_One_Time(TextureClass *texture, 
 	if (*(name+3) == 'A' || *(name+3) == 'a')
 		Remap_Palette(newsurf,color, false, true );	//texture only contains a palette stored in top row.
 
-	TextureClass * newtex=NEW_REF(TextureClass,(newsurf,(TextureClass::MipCountType)texture->Get_Mip_Level_Count()));
+	TextureClass * newtex=NEW_REF(TextureClass,(newsurf,(MipCountType)texture->Get_Mip_Level_Count()));
 	newtex->Set_Mag_Filter(texture->Get_Mag_Filter());
 	newtex->Set_Min_Filter(texture->Get_Min_Filter());
 	newtex->Set_Mip_Mapping(texture->Get_Mip_Mapping());
@@ -1521,7 +1521,7 @@ RenderObjClass * W3DAssetManager::Create_Render_Obj(const char * name,float scal
 	return w3dproto->Create();
 }
 
-TextureClass * W3DAssetManager::Get_Texture_With_HSV_Shift(const char * filename, const Vector3 &hsv_shift, TextureClass::MipCountType mip_level_count)
+TextureClass * W3DAssetManager::Get_Texture_With_HSV_Shift(const char * filename, const Vector3 &hsv_shift, MipCountType mip_level_count)
 {
 	WWPROFILE( "W3DAssetManager::Get_Texture with HSV shift" );
 
@@ -1625,7 +1625,7 @@ TextureClass * W3DAssetManager::Recolor_Texture_One_Time(TextureClass *texture, 
 
 	// make sure texture is loaded
 	if (!texture->Is_Initialized())	
-		TextureLoader::Request_High_Priority_Loading(texture, (TextureClass::MipCountType)texture->Get_Mip_Level_Count());
+		TextureLoader::Request_High_Priority_Loading(texture, (MipCountType)texture->Get_Mip_Level_Count());
 
 	SurfaceClass::SurfaceDescription desc;
 	SurfaceClass *newsurf, *oldsurf, *smallsurf;
@@ -1633,7 +1633,7 @@ TextureClass * W3DAssetManager::Recolor_Texture_One_Time(TextureClass *texture, 
 
 	// if texture is monochrome and no value shifting
 	// return NULL	
-	smallsurf=texture->Get_Surface_Level((TextureClass::MipCountType)texture->Get_Mip_Level_Count()-1);
+	smallsurf=texture->Get_Surface_Level((MipCountType)texture->Get_Mip_Level_Count()-1);
 	if (hsv_shift.Z==0.0f && smallsurf->Is_Monochrome())
 	{
 		REF_PTR_RELEASE(smallsurf);
@@ -1646,7 +1646,7 @@ TextureClass * W3DAssetManager::Recolor_Texture_One_Time(TextureClass *texture, 
 	newsurf=NEW_REF(SurfaceClass,(desc.Width,desc.Height,desc.Format));
 	newsurf->Copy(0,0,0,0,desc.Width,desc.Height,oldsurf);
 	newsurf->Hue_Shift(hsv_shift);
-	TextureClass * newtex=NEW_REF(TextureClass,(newsurf,(TextureClass::MipCountType)texture->Get_Mip_Level_Count()));
+	TextureClass * newtex=NEW_REF(TextureClass,(newsurf,(MipCountType)texture->Get_Mip_Level_Count()));
 	newtex->Set_Mag_Filter(texture->Get_Mag_Filter());
 	newtex->Set_Min_Filter(texture->Get_Min_Filter());
 	newtex->Set_Mip_Mapping(texture->Get_Mip_Mapping());

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DBibBuffer.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DBibBuffer.cpp
@@ -228,10 +228,10 @@ W3DBibBuffer::W3DBibBuffer(void)
 
 	m_bibTexture = NEW_REF(TextureClass, ("TBBib.tga"));
 	m_highlightBibTexture = NEW_REF(TextureClass, ("TBRedBib.tga"));
-	m_bibTexture->Set_U_Addr_Mode(TextureClass::TEXTURE_ADDRESS_CLAMP);
-	m_bibTexture->Set_V_Addr_Mode(TextureClass::TEXTURE_ADDRESS_CLAMP);
-	m_highlightBibTexture->Set_U_Addr_Mode(TextureClass::TEXTURE_ADDRESS_CLAMP);
-	m_highlightBibTexture->Set_V_Addr_Mode(TextureClass::TEXTURE_ADDRESS_CLAMP);
+	m_bibTexture->Set_U_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
+	m_bibTexture->Set_V_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
+	m_highlightBibTexture->Set_U_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
+	m_highlightBibTexture->Set_V_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
 	m_initialized = true;
 }
 

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DBridgeBuffer.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DBridgeBuffer.cpp
@@ -242,7 +242,7 @@ Bool W3DBridge::load(enum BodyDamageType curDamageState)
 	strcpy(right, modelName);
 	strcat(right, ".BRIDGE_RIGHT");
 
-	m_bridgeTexture = pMgr->Get_Texture(textureFile,  TextureClass::MIP_LEVELS_3); 
+	m_bridgeTexture = pMgr->Get_Texture(textureFile,  MIP_LEVELS_3); 
 	m_leftMtx.Make_Identity();
 	m_rightMtx.Make_Identity();
 	m_sectionMtx.Make_Identity();

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DCustomEdging.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DCustomEdging.cpp
@@ -317,7 +317,7 @@ void W3DCustomEdging::allocateEdgingBuffers(void)
 	m_indexEdging=NEW_REF(DX8IndexBufferClass,(2*MAX_EDGE_INDEX+4, DX8IndexBufferClass::USAGE_DYNAMIC));
 	m_curNumEdgingVertices=0;
 	m_curNumEdgingIndices=0;
-	//m_edgeTexture = MSGNEW("TextureClass") TextureClass("EdgingTemplate.tga","EdgingTemplate.tga", TextureClass::MIP_LEVELS_3);
+	//m_edgeTexture = MSGNEW("TextureClass") TextureClass("EdgingTemplate.tga","EdgingTemplate.tga", MIP_LEVELS_3);
 }
 
 //=============================================================================

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DRoadBuffer.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DRoadBuffer.cpp
@@ -178,12 +178,12 @@ void RoadType::loadTexture(AsciiString path, Int ID)
 	/// @todo - delay loading textures and only load textures referenced by map.
 	WW3DAssetManager *pMgr = W3DAssetManager::Get_Instance();
 
-	m_roadTexture = pMgr->Get_Texture(path.str(), TextureClass::MIP_LEVELS_3); 
+	m_roadTexture = pMgr->Get_Texture(path.str(), MIP_LEVELS_3); 
 
-	m_roadTexture->Set_Mip_Mapping( TextureClass::FILTER_TYPE_BEST );
+	m_roadTexture->Set_Mip_Mapping( TextureFilterClass::FILTER_TYPE_BEST );
 
-	m_roadTexture->Set_U_Addr_Mode(TextureClass::TEXTURE_ADDRESS_REPEAT);
-	m_roadTexture->Set_V_Addr_Mode(TextureClass::TEXTURE_ADDRESS_REPEAT);
+	m_roadTexture->Set_U_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_REPEAT);
+	m_roadTexture->Set_V_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_REPEAT);
 
 	m_vertexRoad=NEW_REF(DX8VertexBufferClass,(DX8_FVF_XYZDUV1,TheGlobalData->m_maxRoadVertex+4,DX8VertexBufferClass::USAGE_DYNAMIC));
 	m_indexRoad=NEW_REF(DX8IndexBufferClass,(TheGlobalData->m_maxRoadIndex+4, DX8IndexBufferClass::USAGE_DYNAMIC));
@@ -206,11 +206,11 @@ void RoadType::loadTestTexture(void)
 {
 	if (m_isAutoLoaded && m_uniqueID>0 && !m_texturePath.isEmpty()) {
 		/// @todo - delay loading textures and only load textures referenced by map.
-		m_roadTexture = NEW_REF(TextureClass, (m_texturePath.str(), m_texturePath.str(), TextureClass::MIP_LEVELS_3));
-		m_roadTexture->Set_Mip_Mapping( TextureClass::FILTER_TYPE_BEST );
+		m_roadTexture = NEW_REF(TextureClass, (m_texturePath.str(), m_texturePath.str(), MIP_LEVELS_3));
+		m_roadTexture->Set_Mip_Mapping( TextureFilterClass::FILTER_TYPE_BEST );
 
-		m_roadTexture->Set_U_Addr_Mode(TextureClass::TEXTURE_ADDRESS_REPEAT);
-		m_roadTexture->Set_V_Addr_Mode(TextureClass::TEXTURE_ADDRESS_REPEAT);
+		m_roadTexture->Set_U_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_REPEAT);
+		m_roadTexture->Set_V_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_REPEAT);
 	}
 }
 #endif

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DShaderManager.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DShaderManager.cpp
@@ -559,9 +559,9 @@ Int ScreenCrossFadeFilter::init(void)
 	m_fadePatternTexture=WW3DAssetManager::Get_Instance()->Get_Texture("exmask_g.tga");
 	if (!m_fadePatternTexture)
 		return FALSE;
-	m_fadePatternTexture->Set_U_Addr_Mode(TextureClass::TEXTURE_ADDRESS_CLAMP);
-	m_fadePatternTexture->Set_V_Addr_Mode(TextureClass::TEXTURE_ADDRESS_CLAMP);
-	m_fadePatternTexture->Set_Mip_Mapping(TextureClass::FILTER_TYPE_NONE);
+	m_fadePatternTexture->Set_U_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
+	m_fadePatternTexture->Set_V_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
+	m_fadePatternTexture->Set_Mip_Mapping(TextureFilterClass::FILTER_TYPE_NONE);
 
 	W3DFilters[FT_VIEW_CROSSFADE]=&screenCrossFadeFilter;
 

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DShroud.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DShroud.cpp
@@ -90,7 +90,7 @@ W3DShroud::W3DShroud(void)
 	m_cellHeight=DEFAULT_SHROUD_CELL_SIZE;
 	m_numCellsX=0;
 	m_numCellsY=0;
-	m_shroudFilter=TextureClass::FILTER_TYPE_DEFAULT;
+	m_shroudFilter=TextureFilterClass::FILTER_TYPE_DEFAULT;
 }
 
 //-----------------------------------------------------------------------------
@@ -234,10 +234,10 @@ Bool W3DShroud::ReAcquireResources(void)
 		// Since we control the video memory copy, we can do partial updates more efficiently. Or do shift blits.
 #if defined(_DEBUG) || defined(_INTERNAL)
 		if (TheGlobalData && TheGlobalData->m_fogOfWarOn)
-			m_pDstTexture = MSGNEW("TextureClass") TextureClass(m_dstTextureWidth,m_dstTextureHeight,WW3D_FORMAT_A4R4G4B4,TextureClass::MIP_LEVELS_1, TextureClass::POOL_DEFAULT);
+			m_pDstTexture = MSGNEW("TextureClass") TextureClass(m_dstTextureWidth,m_dstTextureHeight,WW3D_FORMAT_A4R4G4B4,MIP_LEVELS_1, TextureClass::POOL_DEFAULT);
 		else
 #endif
-			m_pDstTexture = MSGNEW("TextureClass") TextureClass(m_dstTextureWidth,m_dstTextureHeight,WW3D_FORMAT_R5G6B5,TextureClass::MIP_LEVELS_1, TextureClass::POOL_DEFAULT);
+			m_pDstTexture = MSGNEW("TextureClass") TextureClass(m_dstTextureWidth,m_dstTextureHeight,WW3D_FORMAT_R5G6B5,MIP_LEVELS_1, TextureClass::POOL_DEFAULT);
 
 		DEBUG_ASSERTCRASH( m_pDstTexture != NULL, ("Failed ReAcquire of shroud texture"));
 
@@ -247,9 +247,9 @@ Bool W3DShroud::ReAcquireResources(void)
 			m_dstTextureHeight = 0;
 			return FALSE;
 		}
-		m_pDstTexture->Set_U_Addr_Mode(TextureClass::TEXTURE_ADDRESS_CLAMP);
-		m_pDstTexture->Set_V_Addr_Mode(TextureClass::TEXTURE_ADDRESS_CLAMP);
-		m_pDstTexture->Set_Mip_Mapping(TextureClass::FILTER_TYPE_NONE);
+		m_pDstTexture->Set_U_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
+		m_pDstTexture->Set_V_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
+		m_pDstTexture->Set_Mip_Mapping(TextureFilterClass::FILTER_TYPE_NONE);
 		m_clearDstTexture = TRUE;	//force clearing of destination texture first time it's used.
 
 		return TRUE;
@@ -762,9 +762,9 @@ void W3DShroud::interpolateFogLevels(RECT *rect)
 void W3DShroud::setShroudFilter(Bool enable)
 {
 	if (enable)
-		m_shroudFilter=TextureClass::FILTER_TYPE_DEFAULT;
+		m_shroudFilter=TextureFilterClass::FILTER_TYPE_DEFAULT;
 	else
-		m_shroudFilter=TextureClass::FILTER_TYPE_NONE;
+		m_shroudFilter=TextureFilterClass::FILTER_TYPE_NONE;
 }
 
 //-----------------------------------------------------------------------------

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DTreeBuffer.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DTreeBuffer.cpp
@@ -529,8 +529,8 @@ W3DTreeBuffer::W3DTreeBuffer(void)
 		return;  // WorldBuilderTool doesn't initialize the asset manager.  jba.
 
 	m_treeTexture = NEW_REF(TextureClass, ("trees.tga"));
-	m_treeTexture->Set_U_Addr_Mode(TextureClass::TEXTURE_ADDRESS_CLAMP);
-	m_treeTexture->Set_V_Addr_Mode(TextureClass::TEXTURE_ADDRESS_CLAMP);
+	m_treeTexture->Set_U_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
+	m_treeTexture->Set_V_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
 	for (i=0; i<MAX_TYPES; i++) {
 		switch(i) {
 		case 0:

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DVideoBuffer.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DVideoBuffer.cpp
@@ -131,7 +131,7 @@ Bool W3DVideoBuffer::allocate( UnsignedInt width, UnsignedInt height )
 		return NULL;	
 	}
 
-	m_texture  = MSGNEW("TextureClass") TextureClass ( m_textureWidth, m_textureHeight, w3dFormat, TextureClass::MIP_LEVELS_1 );
+	m_texture  = MSGNEW("TextureClass") TextureClass ( m_textureWidth, m_textureHeight, w3dFormat, MIP_LEVELS_1 );
 
 	if ( m_texture == NULL )
 	{

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
@@ -201,9 +201,9 @@ void WaterRenderObjClass::setupJbaWaterShader(void)
 	VertexMaterialClass *vmat=VertexMaterialClass::Get_Preset(VertexMaterialClass::PRELIT_DIFFUSE);
 	DX8Wrapper::Set_Material(vmat);
 	REF_PTR_RELEASE(vmat);
-	m_riverTexture->Set_Mag_Filter(TextureClass::FILTER_TYPE_BEST);
-	m_riverTexture->Set_Min_Filter(TextureClass::FILTER_TYPE_BEST);
-	m_riverTexture->Set_Mip_Mapping(TextureClass::FILTER_TYPE_BEST);
+	m_riverTexture->Set_Mag_Filter(TextureFilterClass::FILTER_TYPE_BEST);
+	m_riverTexture->Set_Min_Filter(TextureFilterClass::FILTER_TYPE_BEST);
+	m_riverTexture->Set_Mip_Mapping(TextureFilterClass::FILTER_TYPE_BEST);
 
 
 //	Setting *setting=&m_settings[m_tod];	
@@ -440,7 +440,7 @@ HRESULT WaterRenderObjClass::initBumpMap(LPDIRECT3DTEXTURE8 *pTex, TextureClass 
 		return S_OK;
 	} 
 
-	pTex[0]=DX8Wrapper::_Create_DX8_Texture(d3dsd.Width,d3dsd.Height,WW3D_FORMAT_U8V8,TextureClass::MIP_LEVELS_ALL,D3DPOOL_MANAGED,false);
+	pTex[0]=DX8Wrapper::_Create_DX8_Texture(d3dsd.Width,d3dsd.Height,WW3D_FORMAT_U8V8,MIP_LEVELS_ALL,D3DPOOL_MANAGED,false);
 
 	for (Int level=0; level < numLevels; level++)
 	{
@@ -526,7 +526,7 @@ HRESULT WaterRenderObjClass::initBumpMap(LPDIRECT3DTEXTURE8 *pTex, TextureClass 
 	pSrc=(unsigned char *)surf->Lock((int *)&dwSrcPitch);
 
     // Create the bumpmap's surface and texture objects
-	m_pBumpTexture[i]=DX8Wrapper::_Create_DX8_Texture(d3dsd.Width,d3dsd.Height,WW3D_FORMAT_U8V8,TextureClass::MIP_LEVELS_1,D3DPOOL_MANAGED,false);
+	m_pBumpTexture[i]=DX8Wrapper::_Create_DX8_Texture(d3dsd.Width,d3dsd.Height,WW3D_FORMAT_U8V8,MIP_LEVELS_1,D3DPOOL_MANAGED,false);
 
     // Fill the bits of the new texture surface with bits from
     // a private format.
@@ -1073,8 +1073,8 @@ Int WaterRenderObjClass::init(Real waterLevel, Real dx, Real dy, SceneClass *par
 		{
 			if (material->Peek_Texture(i))
 			{		
-				material->Peek_Texture(i)->Set_U_Addr_Mode(TextureClass::TEXTURE_ADDRESS_CLAMP);
-				material->Peek_Texture(i)->Set_V_Addr_Mode(TextureClass::TEXTURE_ADDRESS_CLAMP);
+				material->Peek_Texture(i)->Set_U_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
+				material->Peek_Texture(i)->Set_V_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
 			}
 		}
 	}
@@ -1082,7 +1082,7 @@ Int WaterRenderObjClass::init(Real waterLevel, Real dx, Real dy, SceneClass *par
 	m_riverTexture=WW3DAssetManager::Get_Instance()->Get_Texture("TWWater01.tga"); 
 	
 	//For some reason setting a NULL texture does not result in 0xffffffff for pixel shaders so using explicit "white" texture.
-	m_whiteTexture=MSGNEW("TextureClass") TextureClass(1,1,WW3D_FORMAT_A4R4G4B4,TextureClass::MIP_LEVELS_1);
+	m_whiteTexture=MSGNEW("TextureClass") TextureClass(1,1,WW3D_FORMAT_A4R4G4B4,MIP_LEVELS_1);
 	SurfaceClass *surface=m_whiteTexture->Get_Surface_Level();
 	surface->DrawPixel(0,0,0xffffffff);
 	REF_PTR_RELEASE(surface);
@@ -1296,8 +1296,8 @@ void WaterRenderObjClass::replaceSkyboxTexture(const AsciiString& oldTexName, co
 		{
 			if (material->Peek_Texture(i))
 			{		
-				material->Peek_Texture(i)->Set_U_Addr_Mode(TextureClass::TEXTURE_ADDRESS_CLAMP);
-				material->Peek_Texture(i)->Set_V_Addr_Mode(TextureClass::TEXTURE_ADDRESS_CLAMP);
+				material->Peek_Texture(i)->Set_U_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
+				material->Peek_Texture(i)->Set_V_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
 			}
 		}
 	}
@@ -1617,11 +1617,11 @@ void WaterRenderObjClass::Render(RenderInfoClass & rinfo)
 				DX8Wrapper::Set_DX8_Render_State(D3DRS_ALPHATESTENABLE, true);	//test pixels if transparent(clipped) before rendering.
 
 				// Set clipping texture
-				m_alphaClippingTexture->Set_U_Addr_Mode(TextureClass::TEXTURE_ADDRESS_CLAMP);
-				m_alphaClippingTexture->Set_V_Addr_Mode(TextureClass::TEXTURE_ADDRESS_CLAMP);
-				m_alphaClippingTexture->Set_Min_Filter(TextureClass::FILTER_TYPE_NONE);
-				m_alphaClippingTexture->Set_Mag_Filter(TextureClass::FILTER_TYPE_NONE);
-				m_alphaClippingTexture->Set_Mip_Mapping(TextureClass::FILTER_TYPE_NONE);
+				m_alphaClippingTexture->Set_U_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
+				m_alphaClippingTexture->Set_V_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
+				m_alphaClippingTexture->Set_Min_Filter(TextureFilterClass::FILTER_TYPE_NONE);
+				m_alphaClippingTexture->Set_Mag_Filter(TextureFilterClass::FILTER_TYPE_NONE);
+				m_alphaClippingTexture->Set_Mip_Mapping(TextureFilterClass::FILTER_TYPE_NONE);
 
 				DX8Wrapper::Set_Texture(0,m_alphaClippingTexture);
 
@@ -2899,9 +2899,9 @@ void WaterRenderObjClass::setupFlatWaterShader(void)
 	VertexMaterialClass *vmat=VertexMaterialClass::Get_Preset(VertexMaterialClass::PRELIT_DIFFUSE);
 	DX8Wrapper::Set_Material(vmat);
 	REF_PTR_RELEASE(vmat);
-	m_riverTexture->Set_Mag_Filter(TextureClass::FILTER_TYPE_BEST);
-	m_riverTexture->Set_Min_Filter(TextureClass::FILTER_TYPE_BEST);
-	m_riverTexture->Set_Mip_Mapping(TextureClass::FILTER_TYPE_BEST);
+	m_riverTexture->Set_Mag_Filter(TextureFilterClass::FILTER_TYPE_BEST);
+	m_riverTexture->Set_Min_Filter(TextureFilterClass::FILTER_TYPE_BEST);
+	m_riverTexture->Set_Mip_Mapping(TextureFilterClass::FILTER_TYPE_BEST);
 
 	DX8Wrapper::Apply_Render_State_Changes();	//force update of view and projection matrices
 

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/CMakeLists.txt
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/CMakeLists.txt
@@ -93,6 +93,7 @@ set(WW3D2_SRC
     texfcach.cpp
     texproject.cpp
     texture.cpp
+    texturefilter.cpp
     textureloader.cpp
     texturethumbnail.cpp
     txt.cpp
@@ -204,6 +205,7 @@ set(WW3D2_SRC
     texfcach.h
     texproject.h
     texture.h
+    texturefilter.h
     textureloader.h
     texturethumbnail.h
     txt.h

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/assetmgr.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/assetmgr.cpp
@@ -1085,7 +1085,7 @@ TextureClass* WW3DAssetManager::Get_Bumpmap_Based_On_Texture(TextureClass* textu
  *=============================================================================================*/
 TextureClass * WW3DAssetManager::Get_Texture(
 	const char * filename, 
-	TextureClass::MipCountType mip_level_count,
+	MipCountType mip_level_count,
 	WW3DFormat texture_format,
 	bool allow_compression)
 {

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/assetmgr.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/assetmgr.h
@@ -261,11 +261,13 @@ public:
 
 	static void Log_Texture_Statistics();
 
-	virtual TextureClass *			Get_Texture(
+	virtual TextureClass *			Get_Texture
+	(
 		const char * filename, 
-		TextureClass::MipCountType mip_level_count=TextureClass::MIP_LEVELS_ALL,
+		MipCountType mip_level_count=MIP_LEVELS_ALL,
 		WW3DFormat texture_format=WW3D_FORMAT_UNKNOWN,
-		bool allow_compression=true);
+		bool allow_compression=true
+	);
 	TextureClass*						Get_Bumpmap_Based_On_Texture(TextureClass* texture);
 
 	virtual void						Release_All_Textures(void);

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/bmp2d.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/bmp2d.cpp
@@ -154,9 +154,9 @@ Bitmap2DObjClass::Bitmap2DObjClass
 			// create the texture and turn MIP-mapping off.
 			SurfaceClass *piece_surface=NEW_REF(SurfaceClass,(pot,pot,sd.Format));			
 			piece_surface->Copy(0,0,tlpx,tlpy,pot,pot,surface);
-			TextureClass *piece_texture =NEW_REF(TextureClass,(piece_surface,TextureClass::MIP_LEVELS_1));			
-			piece_texture->Set_U_Addr_Mode(TextureClass::TEXTURE_ADDRESS_CLAMP);
-			piece_texture->Set_V_Addr_Mode(TextureClass::TEXTURE_ADDRESS_CLAMP);
+			TextureClass *piece_texture =NEW_REF(TextureClass,(piece_surface,MIP_LEVELS_1));			
+			piece_texture->Set_U_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
+			piece_texture->Set_V_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
 			REF_PTR_RELEASE(piece_surface);			
 
 			// calculate our actual texture coordinates based on the difference between

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8texman.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8texman.h
@@ -58,7 +58,7 @@ class DX8TextureTrackerClass : public MultiListObjectClass
 friend DX8TextureManagerClass;
 public:
 	DX8TextureTrackerClass(unsigned int w, unsigned int h, WW3DFormat format,
-		TextureClass::MipCountType count,bool rt,
+		MipCountType count,bool rt,
 		TextureClass *tex):
 	Width(w),
 	Height(h),
@@ -72,7 +72,7 @@ private:
 	unsigned int Width;
 	unsigned int Height;
 	WW3DFormat Format;
-	TextureClass::MipCountType Mip_level_count;
+	MipCountType Mip_level_count;
 	bool RenderTarget;
 	TextureClass *Texture;
 };

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
@@ -298,7 +298,7 @@ void DX8Wrapper::Do_Onetime_Device_Dependent_Inits(void)
 	** Initalize any other subsystems inside of WW3D
 	*/
 	MissingTexture::_Init();
-	TextureClass::_Init_Filters();
+	TextureFilterClass::_Init_Filters();
 	TheDX8MeshRenderer.Init();
 	BoxRenderObjClass::Init();
 	VertexMaterialClass::Init();
@@ -1965,7 +1965,7 @@ IDirect3DTexture8 * DX8Wrapper::_Create_DX8_Texture(
 	unsigned int width, 
 	unsigned int height,
 	WW3DFormat format, 
-	TextureClass::MipCountType mip_level_count,
+	MipCountType mip_level_count,
 	D3DPOOL pool,
 	bool rendertarget)
 {
@@ -2030,7 +2030,7 @@ IDirect3DTexture8 * DX8Wrapper::_Create_DX8_Texture(
 
 IDirect3DTexture8 * DX8Wrapper::_Create_DX8_Texture(
 	const char *filename, 
-	TextureClass::MipCountType mip_level_count)
+	MipCountType mip_level_count)
 {
 	DX8_THREAD_ASSERT();
 	DX8_Assert();
@@ -2080,7 +2080,7 @@ IDirect3DTexture8 * DX8Wrapper::_Create_DX8_Texture(
 
 IDirect3DTexture8 * DX8Wrapper::_Create_DX8_Texture(
 	IDirect3DSurface8 *surface,
-	TextureClass::MipCountType mip_level_count)
+	MipCountType mip_level_count)
 {
 	DX8_THREAD_ASSERT();
 	DX8_Assert();
@@ -2102,7 +2102,7 @@ IDirect3DTexture8 * DX8Wrapper::_Create_DX8_Texture(
 	tex_surface->Release();
 
 	// Create mipmaps if needed
-	if (mip_level_count!=TextureClass::MIP_LEVELS_1) {
+	if (mip_level_count!=MIP_LEVELS_1) {
 		DX8_ErrorCode(D3DXFilterTexture(texture, NULL, 0, D3DX_FILTER_BOX));
 	}
 
@@ -2424,7 +2424,7 @@ DX8Wrapper::Create_Render_Target (int width, int height, bool alpha)
 	//	
 	DX8_Assert();
 	WW3DFormat format=D3DFormat_To_WW3DFormat(mode.Format);
-	TextureClass * tex = NEW_REF(TextureClass,(width,height,format,TextureClass::MIP_LEVELS_1,TextureClass::POOL_DEFAULT,true));
+	TextureClass * tex = NEW_REF(TextureClass,(width,height,format,MIP_LEVELS_1,TextureClass::POOL_DEFAULT,true));
 	
 	// 3dfx drivers are lying in the CheckDeviceFormat call and claiming
 	// that they support render targets!

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
@@ -53,6 +53,7 @@
 #include "shader.h"
 #include "vector4.h"
 #include "cpudetect.h"
+#include "dx8caps.h"
 
 #include "texture.h"
 #include "dx8vertexbuffer.h"
@@ -332,11 +333,11 @@ public:
 		unsigned int width, 
 		unsigned int height, 
 		WW3DFormat format, 
-		TextureClass::MipCountType mip_level_count,
+		MipCountType mip_level_count,
 		D3DPOOL pool=D3DPOOL_MANAGED,
 		bool rendertarget=false);
-	static IDirect3DTexture8 * _Create_DX8_Texture(const char *filename, TextureClass::MipCountType mip_level_count);
-	static IDirect3DTexture8 * _Create_DX8_Texture(IDirect3DSurface8 *surface, TextureClass::MipCountType mip_level_count);
+	static IDirect3DTexture8 * _Create_DX8_Texture(const char *filename, MipCountType mip_level_count);
+	static IDirect3DTexture8 * _Create_DX8_Texture(IDirect3DSurface8 *surface, MipCountType mip_level_count);
 
 	static IDirect3DSurface8 * _Create_DX8_Surface(unsigned int width, unsigned int height, WW3DFormat format);
 	static IDirect3DSurface8 * _Create_DX8_Surface(const char *filename);

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/font3d.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/font3d.cpp
@@ -333,7 +333,7 @@ bool	Font3DDataClass::Load_Font_Image( const char *filename )
 
 	// create the texture
 	if ( _surface ) {
-		Texture = NEW_REF(TextureClass,(_surface,TextureClass::MIP_LEVELS_1));
+		Texture = NEW_REF(TextureClass,(_surface,MIP_LEVELS_1));
 		REF_PTR_RELEASE(_surface);
 	}
 

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/metalmap.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/metalmap.cpp
@@ -131,9 +131,9 @@ MetalMapManagerClass::MetalMapManagerClass(INIClass &ini) :
 
 	for (int i = 0; i < lp; i++) {		
 		// Create texture. NOTE: we should add code here to ensure we use a native texture format
-		Textures[i]=NEW_REF(TextureClass,(METALMAP_SIZE,METALMAP_SIZE,WW3D_FORMAT_A8R8G8B8,TextureClass::MIP_LEVELS_1));
-		Textures[i]->Set_U_Addr_Mode(TextureClass::TEXTURE_ADDRESS_CLAMP);
-		Textures[i]->Set_V_Addr_Mode(TextureClass::TEXTURE_ADDRESS_CLAMP);
+		Textures[i]=NEW_REF(TextureClass,(METALMAP_SIZE,METALMAP_SIZE,WW3D_FORMAT_A8R8G8B8,MIP_LEVELS_1));
+		Textures[i]->Set_U_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
+		Textures[i]->Set_V_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
 		StringClass tex_name;
 		tex_name.Format("!m%02d.tga", i);		
 		Textures[i]->Set_Texture_Name(tex_name);		

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/missingtexture.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/missingtexture.cpp
@@ -64,7 +64,7 @@ void MissingTexture::_Init()
 		missing_image_width,
 		missing_image_height,
 		WW3D_FORMAT_A8R8G8B8,
-		TextureClass::MIP_LEVELS_ALL);
+		MIP_LEVELS_ALL);
 
 	D3DLOCKED_RECT locked_rect;
 	RECT rect;

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/part_emt.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/part_emt.cpp
@@ -209,7 +209,7 @@ ParticleEmitterClass::Create_From_Definition (const ParticleEmitterDefClass &def
 	if (ptexture_filename && ptexture_filename[0]) {
 		ptexture = WW3DAssetManager::Get_Instance()->Get_Texture(
 			ptexture_filename,
-			TextureClass::MIP_LEVELS_ALL,
+			MIP_LEVELS_ALL,
 			WW3D_FORMAT_UNKNOWN,
 			false);	// no compression for particle textures!
 	}

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/render2d.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/render2d.cpp
@@ -109,7 +109,7 @@ void Render2DClass::Set_Texture(TextureClass* tex)
 
 void Render2DClass::Set_Texture( const char * filename)
 {
-	TextureClass * tex = WW3DAssetManager::Get_Instance()->Get_Texture( filename, TextureClass::MIP_LEVELS_1 );
+	TextureClass * tex = WW3DAssetManager::Get_Instance()->Get_Texture( filename, MIP_LEVELS_1 );
 	Set_Texture( tex );
 	if ( tex != NULL ) {
 		SET_REF_OWNER( tex );

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/render2dsentence.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/render2dsentence.cpp
@@ -379,14 +379,14 @@ Render2DSentenceClass::Build_Textures (void)
 		//
 		//	Create the new texture
 		//
-		TextureClass *new_texture = W3DNEW TextureClass (desc.Width, desc.Width, WW3D_FORMAT_A4R4G4B4, TextureClass::MIP_LEVELS_1);
+		TextureClass *new_texture = W3DNEW TextureClass (desc.Width, desc.Width, WW3D_FORMAT_A4R4G4B4, MIP_LEVELS_1);
 		SurfaceClass *texture_surface = new_texture->Get_Surface_Level ();
 
-		new_texture->Set_U_Addr_Mode(TextureClass::TEXTURE_ADDRESS_CLAMP);
-		new_texture->Set_V_Addr_Mode(TextureClass::TEXTURE_ADDRESS_CLAMP);
-		new_texture->Set_Min_Filter	(TextureClass::FILTER_TYPE_NONE);
-		new_texture->Set_Mag_Filter	(TextureClass::FILTER_TYPE_NONE);
-		new_texture->Set_Mip_Mapping	(TextureClass::FILTER_TYPE_NONE);
+		new_texture->Set_U_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
+		new_texture->Set_V_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
+		new_texture->Set_Min_Filter	(TextureFilterClass::FILTER_TYPE_NONE);
+		new_texture->Set_Mag_Filter	(TextureFilterClass::FILTER_TYPE_NONE);
+		new_texture->Set_Mip_Mapping	(TextureFilterClass::FILTER_TYPE_NONE);
 
 		//
 		//	Copy the contents of the texture from the surface

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp
@@ -574,8 +574,8 @@ void TexProjectClass::Init_Multiplicative(void)
 		*/
 		TextureClass * grad_tex = WW3DAssetManager::Get_Instance()->Get_Texture("MultProjectorGradient.tga");
 		if (grad_tex) {
-			grad_tex->Set_U_Addr_Mode(TextureClass::TEXTURE_ADDRESS_CLAMP);
-			grad_tex->Set_V_Addr_Mode(TextureClass::TEXTURE_ADDRESS_CLAMP);
+			grad_tex->Set_U_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
+			grad_tex->Set_V_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
 			MaterialPass->Set_Texture(grad_tex,1);
 			grad_tex->Release_Ref();
 		} else {
@@ -676,8 +676,8 @@ void TexProjectClass::Init_Additive(void)
 	*/
 	TextureClass * grad_tex = WW3DAssetManager::Get_Instance()->Get_Texture("AddProjectorGradient.tga");
 	if (grad_tex) {
-		grad_tex->Set_U_Addr_Mode(TextureClass::TEXTURE_ADDRESS_CLAMP);
-		grad_tex->Set_V_Addr_Mode(TextureClass::TEXTURE_ADDRESS_CLAMP);
+		grad_tex->Set_U_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
+		grad_tex->Set_V_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
 		MaterialPass->Set_Texture(grad_tex,1);
 		grad_tex->Release_Ref();
 	} else {
@@ -730,8 +730,8 @@ void TexProjectClass::Init_Additive(void)
 void TexProjectClass::Set_Texture(TextureClass * texture)
 {
 	if (texture != NULL) {
-		texture->Set_U_Addr_Mode(TextureClass::TEXTURE_ADDRESS_CLAMP);
-		texture->Set_V_Addr_Mode(TextureClass::TEXTURE_ADDRESS_CLAMP);	
+		texture->Set_U_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
+		texture->Set_V_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);	
 		MaterialPass->Set_Texture(texture);
 
 		SurfaceClass::SurfaceDescription surface_desc;

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/texture.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/texture.h
@@ -48,6 +48,7 @@
 #include "surfaceclass.h"
 #include "ww3dformat.h"
 #include "wwstring.h"
+#include "texturefilter.h"
 
 class DX8Wrapper;
 struct IDirect3DTexture8;
@@ -79,35 +80,6 @@ class TextureClass : public W3DMPO, public RefCountClass
 			POOL_DEFAULT=0,
 			POOL_MANAGED,
 			POOL_SYSTEMMEM
-		};
-
-		enum FilterType {
-			FILTER_TYPE_NONE,
-			FILTER_TYPE_FAST,
-			FILTER_TYPE_BEST,
-			FILTER_TYPE_DEFAULT,
-			FILTER_TYPE_COUNT
-		};
-
-		enum TxtAddrMode {
-			TEXTURE_ADDRESS_REPEAT=0,
-			TEXTURE_ADDRESS_CLAMP
-		};
-
-		enum MipCountType {
-			MIP_LEVELS_ALL=0,		// generate all mipmap levels down to 1x1 size
-			MIP_LEVELS_1,			// no mipmapping at all (just one mip level)
-			MIP_LEVELS_2,
-			MIP_LEVELS_3,
-			MIP_LEVELS_4,
-			MIP_LEVELS_5,
-			MIP_LEVELS_6,
-			MIP_LEVELS_7,
-			MIP_LEVELS_8,
-			MIP_LEVELS_10,
-			MIP_LEVELS_11,
-			MIP_LEVELS_12,
-			MIP_LEVELS_MAX			// This isn't to be used (use MIP_LEVELS_ALL instead), it is just an enum for creating static tables etc.
 		};
 
 		// Create texture with desired height, width and format.
@@ -160,18 +132,18 @@ class TextureClass : public W3DMPO, public RefCountClass
 		unsigned int Set_Priority(unsigned int priority);	// Returns previous priority
 
 		// Filter and MIPmap settings:
-		FilterType Get_Min_Filter(void) const { return TextureMinFilter; }
-		FilterType Get_Mag_Filter(void) const { return TextureMagFilter; }
-		FilterType Get_Mip_Mapping(void) const { return MipMapFilter; }
-		void Set_Min_Filter(FilterType filter) { TextureMinFilter=filter; }
-		void Set_Mag_Filter(FilterType filter) { TextureMagFilter=filter; }
-		void Set_Mip_Mapping(FilterType mipmap);
+		TextureFilterClass::FilterType Get_Min_Filter(void) const { return Filter.Get_Min_Filter(); }
+		TextureFilterClass::FilterType Get_Mag_Filter(void) const { return Filter.Get_Mag_Filter(); }
+		TextureFilterClass::FilterType Get_Mip_Mapping(void) const { return Filter.Get_Mip_Mapping(); }
+		void Set_Min_Filter(TextureFilterClass::FilterType filter) { Filter.Set_Min_Filter(filter); }
+		void Set_Mag_Filter(TextureFilterClass::FilterType filter) { Filter.Set_Mag_Filter(filter); }
+		void Set_Mip_Mapping(TextureFilterClass::FilterType mipmap);
 
 		// Texture address mode
-		TxtAddrMode Get_U_Addr_Mode(void) const { return UAddressMode; }
-		TxtAddrMode Get_V_Addr_Mode(void) const { return VAddressMode; }
-		void Set_U_Addr_Mode(TxtAddrMode mode) { UAddressMode=mode; }
-		void Set_V_Addr_Mode(TxtAddrMode mode) { VAddressMode=mode; }
+		TextureFilterClass::TxtAddrMode Get_U_Addr_Mode(void) const { return Filter.Get_U_Addr_Mode(); }
+		TextureFilterClass::TxtAddrMode Get_V_Addr_Mode(void) const { return Filter.Get_V_Addr_Mode(); }
+		void Set_U_Addr_Mode(TextureFilterClass::TxtAddrMode mode) { Filter.Set_U_Addr_Mode(mode); }
+		void Set_V_Addr_Mode(TextureFilterClass::TxtAddrMode mode) { Filter.Set_V_Addr_Mode(mode); }
 
 		// Debug utility functions for returning the texture memory usage
 		unsigned Get_Texture_Memory_Usage() const;
@@ -188,12 +160,9 @@ class TextureClass : public W3DMPO, public RefCountClass
 		static int _Get_Total_Lightmap_Texture_Count();
 		static int _Get_Total_Procedural_Texture_Count();
 
-		// This needs to be called after device has been created
-		static void _Init_Filters();
-
-		static void _Set_Default_Min_Filter(FilterType filter);
-		static void _Set_Default_Mag_Filter(FilterType filter);
-		static void _Set_Default_Mip_Filter(FilterType filter);
+		static void _Set_Default_Min_Filter(TextureFilterClass::FilterType filter);
+		static void _Set_Default_Mag_Filter(TextureFilterClass::FilterType filter);
+		static void _Set_Default_Mip_Filter(TextureFilterClass::FilterType filter);
 
 		// This utility function processes the texture reduction (used during rendering)
 		void Invalidate();
@@ -224,11 +193,7 @@ class TextureClass : public W3DMPO, public RefCountClass
 		static void Apply_Null(unsigned int stage);
 
 		// State not contained in the Direct3D texture object:
-		FilterType TextureMinFilter;
-		FilterType TextureMagFilter;
-		FilterType MipMapFilter;
-		TxtAddrMode UAddressMode;
-		TxtAddrMode VAddressMode;
+		TextureFilterClass Filter;
 
 		// Direct3D texture object
 		IDirect3DTexture8 *D3DTexture;

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/texturefilter.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/texturefilter.cpp
@@ -1,0 +1,192 @@
+/*
+**	Command & Conquer Generals Zero Hour(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/***********************************************************************************************
+ ***              C O N F I D E N T I A L  ---  W E S T W O O D  S T U D I O S               ***
+ ***********************************************************************************************
+ *                                                                                             *
+ *                 Project Name : WW3D                                                         *
+ *                                                                                             *
+ *                     $Archive:: ww3d2/texturefilter.cpp												$*
+ *                                                                                             *
+ *                  $Org Author:: Kenny Mitchell                                              $*
+ *                                                                                             *
+ *                       Author : Kenny Mitchell                                               * 
+ *                                                                                             * 
+ *                     $Modtime:: 08/05/02 1:27p                                              $*
+ *                                                                                             *
+ *                    $Revision:: 1                                                          $*
+ *                                                                                             *
+ * 08/05/02 KM Texture filter class abstraction																			*
+ *---------------------------------------------------------------------------------------------*
+ * Functions:                                                                                  *
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+#include "texturefilter.h"
+#include "dx8wrapper.h"
+#include "meshmatdesc.h"
+
+unsigned _MinTextureFilters[TextureFilterClass::FILTER_TYPE_COUNT];
+unsigned _MagTextureFilters[TextureFilterClass::FILTER_TYPE_COUNT];
+unsigned _MipMapFilters[TextureFilterClass::FILTER_TYPE_COUNT];
+
+/*************************************************************************
+**                             TextureFilterClass
+*************************************************************************/
+TextureFilterClass::TextureFilterClass(MipCountType mip_level_count=MIP_LEVELS_1)
+:	TextureMinFilter(FILTER_TYPE_DEFAULT),
+	TextureMagFilter(FILTER_TYPE_DEFAULT),
+	UAddressMode(TEXTURE_ADDRESS_REPEAT),
+	VAddressMode(TEXTURE_ADDRESS_REPEAT)
+{
+	if (mip_level_count!=MIP_LEVELS_1)
+	{
+		MipMapFilter=FILTER_TYPE_DEFAULT;
+	}
+	else
+	{
+		MipMapFilter=FILTER_TYPE_NONE;
+	}
+}
+
+//**********************************************************************************************
+//! Apply filters (legacy)
+/*!
+*/
+void TextureFilterClass::Apply(unsigned int stage)
+{
+	DX8Wrapper::Set_DX8_Texture_Stage_State(stage,D3DTSS_MINFILTER,_MinTextureFilters[TextureMinFilter]);
+	DX8Wrapper::Set_DX8_Texture_Stage_State(stage,D3DTSS_MAGFILTER,_MagTextureFilters[TextureMagFilter]);
+	DX8Wrapper::Set_DX8_Texture_Stage_State(stage,D3DTSS_MIPFILTER,_MipMapFilters[MipMapFilter]);
+
+	switch (Get_U_Addr_Mode()) 
+	{
+	case TEXTURE_ADDRESS_REPEAT:
+		DX8Wrapper::Set_DX8_Texture_Stage_State(stage, D3DTSS_ADDRESSU, D3DTADDRESS_WRAP);
+		break;
+
+	case TEXTURE_ADDRESS_CLAMP:
+		DX8Wrapper::Set_DX8_Texture_Stage_State(stage, D3DTSS_ADDRESSU, D3DTADDRESS_CLAMP);
+		break;
+	}
+
+	switch (Get_V_Addr_Mode()) 
+	{
+	case TEXTURE_ADDRESS_REPEAT:
+		DX8Wrapper::Set_DX8_Texture_Stage_State(stage, D3DTSS_ADDRESSV, D3DTADDRESS_WRAP);
+		break;
+
+	case TEXTURE_ADDRESS_CLAMP:
+		DX8Wrapper::Set_DX8_Texture_Stage_State(stage, D3DTSS_ADDRESSV, D3DTADDRESS_CLAMP);
+		break;
+	}
+}
+
+//**********************************************************************************************
+//! Init filters (legacy)
+/*!
+*/
+void TextureFilterClass::_Init_Filters(void)
+{
+	const D3DCAPS8& dx8caps=DX8Caps::Get_Default_Caps();
+
+	_MinTextureFilters[FILTER_TYPE_NONE]=D3DTEXF_POINT;
+	_MagTextureFilters[FILTER_TYPE_NONE]=D3DTEXF_POINT;
+	_MipMapFilters[FILTER_TYPE_NONE]=D3DTEXF_NONE;
+
+	_MinTextureFilters[FILTER_TYPE_FAST]=D3DTEXF_LINEAR;
+	_MagTextureFilters[FILTER_TYPE_FAST]=D3DTEXF_LINEAR;
+	_MipMapFilters[FILTER_TYPE_FAST]=D3DTEXF_POINT;
+
+	// Jani: Disabling anisotropic filtering as it doesn't seem to work with the latest nVidia drivers.
+	if (dx8caps.TextureFilterCaps&D3DPTFILTERCAPS_MAGFAFLATCUBIC) _MagTextureFilters[FILTER_TYPE_BEST]=D3DTEXF_FLATCUBIC;
+	else if (dx8caps.TextureFilterCaps&D3DPTFILTERCAPS_MAGFANISOTROPIC) _MagTextureFilters[FILTER_TYPE_BEST]=D3DTEXF_ANISOTROPIC;
+	else if (dx8caps.TextureFilterCaps&D3DPTFILTERCAPS_MAGFGAUSSIANCUBIC) _MagTextureFilters[FILTER_TYPE_BEST]=D3DTEXF_GAUSSIANCUBIC;
+	else if (dx8caps.TextureFilterCaps&D3DPTFILTERCAPS_MAGFLINEAR) _MagTextureFilters[FILTER_TYPE_BEST]=D3DTEXF_LINEAR;
+	else if (dx8caps.TextureFilterCaps&D3DPTFILTERCAPS_MAGFPOINT) _MagTextureFilters[FILTER_TYPE_BEST]=D3DTEXF_POINT;
+	else {
+		WWASSERT_PRINT(0,("No magnification filter found!"));
+	}
+
+	if (dx8caps.TextureFilterCaps&D3DPTFILTERCAPS_MINFANISOTROPIC) _MinTextureFilters[FILTER_TYPE_BEST]=D3DTEXF_ANISOTROPIC;
+	else if (dx8caps.TextureFilterCaps&D3DPTFILTERCAPS_MINFLINEAR) _MinTextureFilters[FILTER_TYPE_BEST]=D3DTEXF_LINEAR;
+	else if (dx8caps.TextureFilterCaps&D3DPTFILTERCAPS_MINFPOINT) _MinTextureFilters[FILTER_TYPE_BEST]=D3DTEXF_POINT;
+	else {
+		WWASSERT_PRINT(0,("No minification filter found!"));
+	}
+
+	if (dx8caps.TextureFilterCaps&D3DPTFILTERCAPS_MIPFLINEAR) _MipMapFilters[FILTER_TYPE_BEST]=D3DTEXF_LINEAR;
+	else if (dx8caps.TextureFilterCaps&D3DPTFILTERCAPS_MIPFPOINT) _MipMapFilters[FILTER_TYPE_BEST]=D3DTEXF_POINT;
+	else {
+		WWASSERT_PRINT(0,("No mip filter found!"));
+	}
+
+//_MagTextureFilters[FILTER_TYPE_BEST]=D3DTEXF_FLATCUBIC;
+//	WWASSERT(Validate_Filters(FILTER_TYPE_BEST));
+
+	_MinTextureFilters[FILTER_TYPE_DEFAULT]=_MinTextureFilters[FILTER_TYPE_BEST];
+	_MagTextureFilters[FILTER_TYPE_DEFAULT]=_MagTextureFilters[FILTER_TYPE_BEST];
+	_MipMapFilters[FILTER_TYPE_DEFAULT]=_MipMapFilters[FILTER_TYPE_BEST];
+
+	for (int stage=0;stage<MeshMatDescClass::MAX_TEX_STAGES;++stage) {
+		DX8Wrapper::Set_DX8_Texture_Stage_State(stage,D3DTSS_MAXANISOTROPY,2);
+	}
+}
+
+
+//**********************************************************************************************
+//! Set mip mapping filter (legacy)
+/*!
+*/
+void TextureFilterClass::Set_Mip_Mapping(FilterType mipmap)
+{
+//	if (mipmap != FILTER_TYPE_NONE && Get_Mip_Level_Count() <= 1 && Is_Initialized()) 
+//	{
+//		WWASSERT_PRINT(0, "Trying to enable MipMapping on texture w/o Mip levels!\n");
+//		return;
+//	}
+	MipMapFilter=mipmap;
+}
+
+//**********************************************************************************************
+//! Set default min filter (legacy)
+/*!
+*/
+void TextureFilterClass::_Set_Default_Min_Filter(FilterType filter)
+{
+	_MinTextureFilters[FILTER_TYPE_DEFAULT]=_MinTextureFilters[filter];
+}
+
+
+//**********************************************************************************************
+//! Set default mag filter (legacy)
+/*!
+*/
+void TextureFilterClass::_Set_Default_Mag_Filter(FilterType filter)
+{
+	_MagTextureFilters[FILTER_TYPE_DEFAULT]=_MagTextureFilters[filter];
+}
+
+//**********************************************************************************************
+//! Set default mip filter (legacy)
+/*!
+*/
+void TextureFilterClass::_Set_Default_Mip_Filter(FilterType filter)
+{
+	_MipMapFilters[FILTER_TYPE_DEFAULT]=_MipMapFilters[filter];
+}

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/texturefilter.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/texturefilter.h
@@ -1,0 +1,133 @@
+/*
+**	Command & Conquer Generals Zero Hour(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/***********************************************************************************************
+ ***              C O N F I D E N T I A L  ---  W E S T W O O D  S T U D I O S               ***
+ ***********************************************************************************************
+ *                                                                                             *
+ *                 Project Name : WW3D                                                         *
+ *                                                                                             *
+ *                     $Archive:: ww3d2/texturefilter.h												$*
+ *                                                                                             *
+ *                  $Org Author:: Kenny Mitchell                                              $*
+ *                                                                                             *
+ *                       Author : Kenny Mitchell                                               * 
+ *                                                                                             * 
+ *                     $Modtime:: 08/05/02 1:27p                                              $*
+ *                                                                                             *
+ *                    $Revision:: 1                                                          $*
+ *                                                                                             *
+ * 08/05/02 KM Texture filter class abstraction																			*
+ *---------------------------------------------------------------------------------------------*
+ * Functions:                                                                                  *
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+#ifndef TEXTUREFILTER_H
+#define TEXTUREFILTER_H
+
+#ifndef DX8_WRAPPER_H
+//#include "dx8wrapper.h"
+#endif
+
+enum MipCountType 
+{
+	MIP_LEVELS_ALL=0,		// generate all mipmap levels down to 1x1 size
+	MIP_LEVELS_1,			// no mipmapping at all (just one mip level)
+	MIP_LEVELS_2,
+	MIP_LEVELS_3,
+	MIP_LEVELS_4,
+	MIP_LEVELS_5,
+	MIP_LEVELS_6,
+	MIP_LEVELS_7,
+	MIP_LEVELS_8,
+	MIP_LEVELS_10,
+	MIP_LEVELS_11,
+	MIP_LEVELS_12,
+	MIP_LEVELS_MAX			// This isn't to be used (use MIP_LEVELS_ALL instead), it is just an enum for creating static tables etc.
+};
+
+
+// NOTE: Since "texture wrapping" (NOT TEXTURE WRAP MODE - THIS IS
+// SOMETHING ELSE) is a global state that affects all texture stages,
+// and this class only affects its own stage, we will not worry about
+// it for now. Later (probably when we implement world-oriented
+// environment maps) we will consider where to put it.
+
+// This is legacy and should be phased out into wwshade shader states
+// keeping as an abstracted class for now to support this transition later
+class TextureFilterClass
+{
+public:
+
+	enum FilterType 
+	{
+		FILTER_TYPE_NONE,
+		FILTER_TYPE_FAST,
+		FILTER_TYPE_BEST,
+		FILTER_TYPE_DEFAULT,
+		FILTER_TYPE_COUNT
+	};
+
+	enum TextureFilterMode
+	{
+		TEXTURE_FILTER_BILINEAR,
+		TEXTURE_FILTER_TRILINEAR,
+		TEXTURE_FILTER_ANISOTROPIC
+	};
+
+	enum TxtAddrMode
+	{
+		TEXTURE_ADDRESS_REPEAT=0,
+		TEXTURE_ADDRESS_CLAMP
+	};
+
+	TextureFilterClass(MipCountType mip_level_count);
+
+	void Apply(unsigned int stage);
+
+	// Filter and MIPmap settings:
+	FilterType Get_Min_Filter(void) const { return TextureMinFilter; }
+	FilterType Get_Mag_Filter(void) const { return TextureMagFilter; }
+	FilterType Get_Mip_Mapping(void) const { return MipMapFilter; }
+	void Set_Min_Filter(FilterType filter) { TextureMinFilter=filter; }
+	void Set_Mag_Filter(FilterType filter) { TextureMagFilter=filter; }
+	void Set_Mip_Mapping(FilterType mipmap);
+
+	// Texture address mode
+	TxtAddrMode Get_U_Addr_Mode(void) const { return UAddressMode; }
+	TxtAddrMode Get_V_Addr_Mode(void) const { return VAddressMode; }
+	void Set_U_Addr_Mode(TxtAddrMode mode) { UAddressMode=mode; }
+	void Set_V_Addr_Mode(TxtAddrMode mode) { VAddressMode=mode; }
+
+	// This needs to be called after device has been created
+	static void _Init_Filters(void);
+
+	static void _Set_Default_Min_Filter(FilterType filter);
+	static void _Set_Default_Mag_Filter(FilterType filter);
+	static void _Set_Default_Mip_Filter(FilterType filter);
+
+private:
+	// State not contained in the Direct3D texture object:
+	FilterType TextureMinFilter;
+	FilterType TextureMagFilter;
+	FilterType MipMapFilter;
+	TxtAddrMode UAddressMode;
+	TxtAddrMode VAddressMode;
+};
+
+#endif

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/textureloader.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/textureloader.cpp
@@ -198,7 +198,7 @@ IDirect3DTexture8* TextureLoader::Load_Thumbnail(const StringClass& filename,WW3
 		thumb->Get_Width(),
 		thumb->Get_Height(),
 		dest_format,
-		TextureClass::MIP_LEVELS_ALL);
+		MIP_LEVELS_ALL);
 
 	unsigned level=0;
 	D3DLOCKED_RECT locked_rects[12];
@@ -265,7 +265,7 @@ static bool Is_Power_Of_Two(unsigned i)
 IDirect3DTexture8* Load_Compressed_Texture(
 	const StringClass& filename, 
 	unsigned reduction_factor,
-	TextureClass::MipCountType mip_level_count,
+	MipCountType mip_level_count,
 	WW3DFormat dest_format)
 {
 	// If DDS file isn't available, use TGA file to convert to DDS.
@@ -286,7 +286,7 @@ IDirect3DTexture8* Load_Compressed_Texture(
 		width,
 		height,
 		dest_format,
-		(TextureClass::MipCountType)mips);
+		(MipCountType)mips);
 
 	for (unsigned level=0;level<mips;++level) {
 		IDirect3DSurface8* d3d_surface=NULL;
@@ -313,7 +313,7 @@ IDirect3DSurface8* TextureLoader::Load_Surface_Immediate(
 	bool compressed=Is_Format_Compressed(texture_format,allow_compression);
 
 	if (compressed) {
-		IDirect3DTexture8* comp_tex=Load_Compressed_Texture(filename,0,TextureClass::MIP_LEVELS_1,WW3D_FORMAT_UNKNOWN);
+		IDirect3DTexture8* comp_tex=Load_Compressed_Texture(filename,0,MIP_LEVELS_1,WW3D_FORMAT_UNKNOWN);
 		if (comp_tex) {
 			IDirect3DSurface8* d3d_surface=NULL;
 			DX8_ErrorCode(comp_tex->GetSurfaceLevel(0,&d3d_surface));
@@ -795,7 +795,7 @@ IDirect3DTexture8* TextureLoader::Generate_Bumpmap(TextureClass* texture)
 		width,
 		height,
 		bump_format,
-		TextureClass::MIP_LEVELS_1);
+		MIP_LEVELS_1);
 
 	D3DLOCKED_RECT src_locked_rect;
 	DX8_ErrorCode(
@@ -924,7 +924,7 @@ void TextureLoader::Add_Load_Task(TextureClass* tc)
 
 void TextureLoader::Request_High_Priority_Loading(
 	TextureClass* tc,
-	TextureClass::MipCountType mip_level_count)
+	MipCountType mip_level_count)
 {
 	TextureLoadTaskClass* task=TextureLoadTaskClass::Get_Instance(tc,true);
 	task->Begin_Texture_Load();
@@ -994,7 +994,7 @@ void TextureLoadTaskClass::Init(TextureClass* tc,bool high_priority)
 	Format=Texture->Get_Texture_Format();
 
 	Texture->TextureLoadTask=this;
-	for (int i=0;i<TextureClass::MIP_LEVELS_MAX;++i) {
+	for (int i=0;i<MIP_LEVELS_MAX;++i) {
 		LockedSurfacePtr[i]=NULL;
 		LockedSurfacePitch[i]=0;
 	}
@@ -1005,7 +1005,7 @@ void TextureLoadTaskClass::Deinit()
 	WWASSERT(Succ==NULL);
 	WWASSERT(D3DTexture==NULL);
 	WWASSERT(IsLoading==false);
-	for (int i=0;i<TextureClass::MIP_LEVELS_MAX;++i) {
+	for (int i=0;i<MIP_LEVELS_MAX;++i) {
 		WWASSERT(LockedSurfacePtr[i]==NULL);
 	}
 	if (Texture) {
@@ -1077,7 +1077,7 @@ void TextureLoadTaskClass::Begin_Texture_Load()
 				}
 				if (mip_level_count>max_mip_level_count) mip_level_count=max_mip_level_count;
 
-				D3DTexture=DX8Wrapper::_Create_DX8_Texture(Width,Height,Format,(TextureClass::MipCountType)mip_level_count);
+				D3DTexture=DX8Wrapper::_Create_DX8_Texture(Width,Height,Format,(MipCountType)mip_level_count);
 				MipLevelCount=mip_level_count;
 				//Texture->MipLevelCount);
 				loaded=true;

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/textureloader.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/textureloader.h
@@ -63,7 +63,7 @@ public:
 	// is called from the main thread the texture is loaded immediatelly.
 	static void Request_High_Priority_Loading(
 		TextureClass* texture,
-		TextureClass::MipCountType mip_level_count);
+		MipCountType mip_level_count);
 	static void	Request_Thumbnail(TextureClass* tc);
 
 	static void Update();
@@ -90,8 +90,8 @@ class TextureLoadTaskClass : public W3DMPO
 	unsigned Width;
 	unsigned Height;
 	WW3DFormat Format;
-	unsigned char* LockedSurfacePtr[TextureClass::MIP_LEVELS_MAX];
-	unsigned LockedSurfacePitch[TextureClass::MIP_LEVELS_MAX];
+	unsigned char* LockedSurfacePtr[MIP_LEVELS_MAX];
+	unsigned LockedSurfacePitch[MIP_LEVELS_MAX];
 	unsigned MipLevelCount;
 	unsigned Reduction;
 	TextureLoadTaskClass* Succ;


### PR DESCRIPTION
Currently this leaves wrappers for the filter functions in TextureClass to reduce the diff complexity, in ZH the TFC functions are called like `newtex->Get_Filter().Set_Mag_Filter(texture->Get_Filter().Get_Mag_Filter());`

Additionally, unlike ZH version TFC here doesn't use MAX_TEXTURE_STAGES for filter arrays, unclear to me if it's safe to port that over or not