### PR TITLE
[GEN][ZH] Add optional game memory null replacement

### DIFF
--- a/Generals/Code/GameEngine/CMakeLists.txt
+++ b/Generals/Code/GameEngine/CMakeLists.txt
@@ -24,14 +24,14 @@ set(GAMEENGINE_SRC
     Source/Common/System/FileSystem.cpp
     Source/Common/System/FunctionLexicon.cpp
     Source/Common/System/GameCommon.cpp
-    Source/Common/System/GameMemory.cpp
+    #Source/Common/System/GameMemory.cpp
     Source/Common/System/GameType.cpp
     Source/Common/System/Geometry.cpp
     Source/Common/System/KindOf.cpp
     Source/Common/System/List.cpp
     Source/Common/System/LocalFile.cpp
     Source/Common/System/LocalFileSystem.cpp
-    Source/Common/System/MemoryInit.cpp
+    #Source/Common/System/MemoryInit.cpp
     Source/Common/System/QuickTrig.cpp
     Source/Common/System/QuotedPrintable.cpp
     Source/Common/System/Radar.cpp
@@ -1055,6 +1055,21 @@ set(GAMEENGINE_SRC
     Include/GameNetwork/User.h
     Include/Precompiled/PreRTS.h
 )
+
+if(GENZH_GAMEMEMORY_ENABLE)
+    # Uses the original Game Memory implementation.
+    list(APPEND GAMEENGINE_SRC
+        Source/Common/System/GameMemory.cpp
+        Source/Common/System/MemoryInit.cpp
+    )
+else()
+    # Uses the null implementation when disabled.
+    list(APPEND GAMEENGINE_SRC
+        Source/Common/System/GameMemoryNull.cpp
+        Include/Common/GameMemoryNull.h
+    )
+endif()
+
 
 add_library(g_gameengine STATIC)
 

--- a/Generals/Code/GameEngine/Include/Common/GameMemory.h
+++ b/Generals/Code/GameEngine/Include/Common/GameMemory.h
@@ -90,20 +90,6 @@
 		#define MEMORYPOOL_BOUNDINGWALL
 	#endif
 
-	#define DECLARE_LITERALSTRING_ARG1										const char * debugLiteralTagString
-	#define PASS_LITERALSTRING_ARG1												debugLiteralTagString
-	#define DECLARE_LITERALSTRING_ARG2										, const char * debugLiteralTagString
-	#define PASS_LITERALSTRING_ARG2												, debugLiteralTagString
-
-	#define MP_LOC_SUFFIX																/*" [" DEBUG_FILENLINE "]"*/
-
-	#define allocateBlock(ARGLITERAL)										allocateBlockImplementation(ARGLITERAL MP_LOC_SUFFIX)
-	#define allocateBlockDoNotZero(ARGLITERAL)					allocateBlockDoNotZeroImplementation(ARGLITERAL MP_LOC_SUFFIX)
-	#define allocateBytes(ARGCOUNT,ARGLITERAL)					allocateBytesImplementation(ARGCOUNT, ARGLITERAL MP_LOC_SUFFIX)
-	#define allocateBytesDoNotZero(ARGCOUNT,ARGLITERAL)	allocateBytesDoNotZeroImplementation(ARGCOUNT, ARGLITERAL MP_LOC_SUFFIX)
-	#define newInstanceDesc(ARGCLASS,ARGLITERAL)				new(ARGCLASS::ARGCLASS##_GLUE_NOT_IMPLEMENTED, ARGLITERAL MP_LOC_SUFFIX) ARGCLASS
-	#define newInstance(ARGCLASS)												new(ARGCLASS::ARGCLASS##_GLUE_NOT_IMPLEMENTED, __FILE__) ARGCLASS
-
 	#if !defined(MEMORYPOOL_STACKTRACE) && !defined(DISABLE_MEMORYPOOL_STACKTRACE)
 		#define MEMORYPOOL_STACKTRACE
 	#endif
@@ -190,6 +176,31 @@
 #endif // MEMORYPOOL_CHECKPOINTING
 		
 	};
+
+#endif // MEMORYPOOL_DEBUG
+
+// TheSuperHackers @compile xezon 30/03/2025 Define DISABLE_GAMEMEMORY to use a null implementations for Game Memory.
+// Useful for address sanitizer checks and other investigations.
+// Is included below the macros so that memory pool debug code can still be used.
+#ifdef DISABLE_GAMEMEMORY
+#include "GameMemoryNull.h"
+#else
+
+#ifdef MEMORYPOOL_DEBUG
+
+	#define DECLARE_LITERALSTRING_ARG1										const char * debugLiteralTagString
+	#define PASS_LITERALSTRING_ARG1												debugLiteralTagString
+	#define DECLARE_LITERALSTRING_ARG2										, const char * debugLiteralTagString
+	#define PASS_LITERALSTRING_ARG2												, debugLiteralTagString
+
+	#define MP_LOC_SUFFIX																/*" [" DEBUG_FILENLINE "]"*/
+
+	#define allocateBlock(ARGLITERAL)										allocateBlockImplementation(ARGLITERAL MP_LOC_SUFFIX)
+	#define allocateBlockDoNotZero(ARGLITERAL)					allocateBlockDoNotZeroImplementation(ARGLITERAL MP_LOC_SUFFIX)
+	#define allocateBytes(ARGCOUNT,ARGLITERAL)					allocateBytesImplementation(ARGCOUNT, ARGLITERAL MP_LOC_SUFFIX)
+	#define allocateBytesDoNotZero(ARGCOUNT,ARGLITERAL)	allocateBytesDoNotZeroImplementation(ARGCOUNT, ARGLITERAL MP_LOC_SUFFIX)
+	#define newInstanceDesc(ARGCLASS,ARGLITERAL)				new(ARGCLASS::ARGCLASS##_GLUE_NOT_IMPLEMENTED, ARGLITERAL MP_LOC_SUFFIX) ARGCLASS
+	#define newInstance(ARGCLASS)												new(ARGCLASS::ARGCLASS##_GLUE_NOT_IMPLEMENTED, __FILE__) ARGCLASS
 
 #else
 
@@ -718,16 +729,6 @@ private: \
 	} \
 public: /* include this line at the end to reset visibility to 'public' */ 
 
-// ----------------------------------------------------------------------------
-/**
-	Sometimes you want to make a class's destructor protected so that it can only
-	be destroyed under special circumstances. MemoryPoolObject short-circuits this
-	by making the destructor always be protected, and the true delete technique
-	(namely, deleteInstance) always public by default. You can simulate the behavior
-	you really want by including this macro 
-*/
-#define MEMORY_POOL_DELETEINSTANCE_VISIBILITY(ARGVIS)\
-ARGVIS:	void deleteInstance() { MemoryPoolObject::deleteInstance(); } public: 
 
 
 // ----------------------------------------------------------------------------
@@ -766,21 +767,6 @@ public:
 	} 
 };
 
-// ----------------------------------------------------------------------------
-/**
-	A simple utility class to ensure exception safety; this holds a MemoryPoolObject
-	and deletes it in its destructor. Especially useful for iterators!
-*/
-class MemoryPoolObjectHolder
-{
-private:
-	MemoryPoolObject *m_mpo;
-public:
-	MemoryPoolObjectHolder(MemoryPoolObject *mpo = NULL) : m_mpo(mpo) { }
-	void hold(MemoryPoolObject *mpo) { DEBUG_ASSERTCRASH(!m_mpo, ("already holding")); m_mpo = mpo; }
-	void release() { m_mpo = NULL; }
-	~MemoryPoolObjectHolder() { m_mpo->deleteInstance(); }
-};
 
 
 // INLINING ///////////////////////////////////////////////////////////////////
@@ -903,6 +889,38 @@ public:
 	static void* allocate(size_t __n);
 	static void deallocate(void* __p, size_t);
 };
+
+#endif //DISABLE_GAMEMEMORY
+
+
+// ----------------------------------------------------------------------------
+/**
+	A simple utility class to ensure exception safety; this holds a MemoryPoolObject
+	and deletes it in its destructor. Especially useful for iterators!
+*/
+class MemoryPoolObjectHolder
+{
+private:
+	MemoryPoolObject *m_mpo;
+public:
+	MemoryPoolObjectHolder(MemoryPoolObject *mpo = NULL) : m_mpo(mpo) { }
+	void hold(MemoryPoolObject *mpo) { DEBUG_ASSERTCRASH(!m_mpo, ("already holding")); m_mpo = mpo; }
+	void release() { m_mpo = NULL; }
+	~MemoryPoolObjectHolder() { m_mpo->deleteInstance(); }
+};
+
+
+// ----------------------------------------------------------------------------
+/**
+	Sometimes you want to make a class's destructor protected so that it can only
+	be destroyed under special circumstances. MemoryPoolObject short-circuits this
+	by making the destructor always be protected, and the true delete technique
+	(namely, deleteInstance) always public by default. You can simulate the behavior
+	you really want by including this macro 
+*/
+#define MEMORY_POOL_DELETEINSTANCE_VISIBILITY(ARGVIS)\
+ARGVIS:	void deleteInstance() { MemoryPoolObject::deleteInstance(); } public: 
+
 
 #define EMPTY_DTOR(CLASS) inline CLASS::~CLASS() { }
 

--- a/Generals/Code/GameEngine/Include/Common/GameMemoryNull.h
+++ b/Generals/Code/GameEngine/Include/Common/GameMemoryNull.h
@@ -1,0 +1,160 @@
+/*
+**	Command & Conquer Generals Zero Hour(tm)
+**	Copyright 2025 TheSuperHackers
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#define allocateBytes(ARGCOUNT,ARGLITERAL)          allocateBytesImplementation(ARGCOUNT)
+#define allocateBytesDoNotZero(ARGCOUNT,ARGLITERAL) allocateBytesDoNotZeroImplementation(ARGCOUNT)
+#define newInstanceDesc(ARGCLASS,ARGLITERAL)        new ARGCLASS
+#define newInstance(ARGCLASS)                       new ARGCLASS
+#define MSGNEW(MSG)                                 new
+#define NEW                                         new
+
+
+/**
+	The DynamicMemoryAllocator class is used to handle unpredictably-sized
+	allocation requests.
+*/
+class DynamicMemoryAllocator
+{
+public:
+
+	/// allocate bytes from this pool. (don't call directly; use allocateBytes() macro)
+	void *allocateBytesImplementation(Int numBytes);
+
+	/// like allocateBytesImplementation, but zeroes the memory before returning
+	void *allocateBytesDoNotZeroImplementation(Int numBytes);
+
+#ifdef MEMORYPOOL_DEBUG
+	void debugIgnoreLeaksForThisBlock(void* pBlockPtr);
+#endif
+
+	/// free the bytes. (assumes allocated by this dma.)
+	void freeBytes(void* pMem);
+
+	/**
+		return the actual number of bytes that would be allocated 
+		if you tried to allocate the given size.
+	*/
+	Int getActualAllocationSize(Int numBytes);
+};
+
+
+/**
+	The class that manages all the MemoryPools and DynamicMemoryAllocators.
+	Usually you will create exactly one of these (TheMemoryPoolFactory)
+	and use it for everything.
+*/
+class MemoryPoolFactory
+{
+public:
+
+	void memoryPoolUsageReport( const char* filename, FILE *appendToFileInstead = NULL );
+
+#ifdef MEMORYPOOL_DEBUG
+
+	void debugMemoryReport(Int flags, Int startCheckpoint, Int endCheckpoint, FILE *fp = NULL );
+	void debugSetInitFillerIndex(Int index);
+
+#endif
+};
+
+
+#define MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+protected: \
+	virtual ~ARGCLASS(); \
+public: /* include this line at the end to reset visibility to 'public' */ 
+
+
+#define MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(ARGCLASS, ARGPOOLNAME) \
+	MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS)
+
+
+// this is the version for an Abstract Base Class, which will never be instantiated...
+#define MEMORY_POOL_GLUE_ABC(ARGCLASS) \
+protected: \
+	virtual ~ARGCLASS(); \
+public: /* include this line at the end to reset visibility to 'public' */ 
+
+
+/**
+	This class is provided as a simple and safe way to integrate C++ object allocation
+	into MemoryPool usage. To use it, you must have your class inherit from
+	MemoryPoolObject, then put the macro MEMORY_POOL_GLUE(MyClassName, "MyPoolName")
+	at the start of your class definition. (This does not create the pool itself -- you
+	must create that manually using MemoryPoolFactory::createMemoryPool)
+*/
+class MemoryPoolObject
+{
+protected:
+
+	/** ensure that all destructors are virtual */
+	virtual ~MemoryPoolObject() { }
+
+public:
+
+	void deleteInstance() 
+	{
+		delete this;
+	}
+};
+
+
+/**
+	Initialize the memory manager. Construct a new MemoryPoolFactory and 
+	DynamicMemoryAllocator and store 'em in the singletons of the relevant
+	names. 
+*/
+extern void initMemoryManager();
+
+/**
+	return true if initMemoryManager() has been called.
+	return false if only preMainInitMemoryManager() has been called.
+*/
+extern Bool isMemoryManagerOfficiallyInited();
+
+/**
+	Shut down the memory manager. Throw away TheMemoryPoolFactory and 
+	TheDynamicMemoryAllocator.
+*/
+extern void shutdownMemoryManager();
+
+extern MemoryPoolFactory *TheMemoryPoolFactory;
+extern DynamicMemoryAllocator *TheDynamicMemoryAllocator;
+
+
+// TheSuperHackers @info
+// The new operator overloads will zero all memory after allocation.
+// This replicates the behavior of the original Game Memory implementation and is necessary to avoid crashing the game,
+// where data is not properly zero initialized. Disable these operators when fixing those issues.
+#ifndef DISABLE_GAMEMEMORY_NEW_OPERATORS
+
+extern void * __cdecl operator new(size_t size);
+extern void __cdecl operator delete(void *p);
+
+extern void * __cdecl operator new[](size_t size);
+extern void __cdecl operator delete[](void *p);
+
+// additional overloads to account for VC/MFC funky versions
+extern void* __cdecl operator new(size_t size, const char *, int);
+extern void __cdecl operator delete(void *p, const char *, int);
+
+extern void* __cdecl operator new[](size_t size, const char *, int);
+extern void __cdecl operator delete[](void *p, const char *, int);
+
+#endif

--- a/Generals/Code/GameEngine/Source/Common/System/GameMemoryNull.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/GameMemoryNull.cpp
@@ -1,0 +1,213 @@
+/*
+**	Command & Conquer Generals Zero Hour(tm)
+**	Copyright 2025 TheSuperHackers
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "PreRTS.h"
+
+#include <malloc.h>
+
+#include "Common/GameMemoryNull.h"
+
+static Bool theMainInitFlag = false;
+
+// ----------------------------------------------------------------------------
+// PUBLIC DATA 
+// ----------------------------------------------------------------------------
+
+MemoryPoolFactory *TheMemoryPoolFactory = NULL;
+DynamicMemoryAllocator *TheDynamicMemoryAllocator = NULL;
+
+//-----------------------------------------------------------------------------
+// METHODS for DynamicMemoryAllocator
+//-----------------------------------------------------------------------------
+
+/**
+	allocate a chunk-o-bytes from this DMA and return it, but don't bother zeroing
+	out the block. if unable to allocate, throw ERROR_OUT_OF_MEMORY. this
+	function will never return null.
+
+  added code to make sure we're on a DWord boundary, throw exception if not
+*/
+void *DynamicMemoryAllocator::allocateBytesDoNotZeroImplementation(Int numBytes)
+{
+	void *p = malloc(numBytes);
+	if (p == NULL)
+		throw ERROR_OUT_OF_MEMORY;
+	return p;
+}
+
+/**
+	allocate a chunk-o-bytes from this DMA and return it, and zero out the contents first.
+	if unable to allocate, throw ERROR_OUT_OF_MEMORY. 
+	this function will never return null.
+*/
+void *DynamicMemoryAllocator::allocateBytesImplementation(Int numBytes)
+{
+	void* p = allocateBytesDoNotZeroImplementation(numBytes);	// throws on failure
+	memset(p, 0, numBytes);
+	return p;
+}
+
+/**
+	free a chunk-o-bytes allocated by this dma. it's ok to pass null.
+*/
+void DynamicMemoryAllocator::freeBytes(void* pBlockPtr)
+{
+	free(pBlockPtr);
+}
+
+Int DynamicMemoryAllocator::getActualAllocationSize(Int numBytes)
+{
+	return numBytes;
+}
+
+#ifdef MEMORYPOOL_DEBUG
+void DynamicMemoryAllocator::debugIgnoreLeaksForThisBlock(void* pBlockPtr)
+{
+}
+#endif
+
+//-----------------------------------------------------------------------------
+// METHODS for MemoryPoolFactory
+//-----------------------------------------------------------------------------
+
+void MemoryPoolFactory::memoryPoolUsageReport( const char* filename, FILE *appendToFileInstead )
+{
+}
+
+#ifdef MEMORYPOOL_DEBUG
+void MemoryPoolFactory::debugMemoryReport(Int flags, Int startCheckpoint, Int endCheckpoint, FILE *fp )
+{
+}
+void MemoryPoolFactory::debugSetInitFillerIndex(Int index)
+{
+}
+#endif
+
+//-----------------------------------------------------------------------------
+// GLOBAL FUNCTIONS
+//-----------------------------------------------------------------------------
+
+/**
+	Initialize the memory manager, and create TheMemoryPoolFactory and TheDynamicMemoryAllocator.
+*/
+void initMemoryManager()
+{
+	if (TheMemoryPoolFactory == NULL && TheDynamicMemoryAllocator == NULL)
+	{
+		TheMemoryPoolFactory = new (malloc(sizeof MemoryPoolFactory)) MemoryPoolFactory;
+		TheDynamicMemoryAllocator = new (malloc(sizeof DynamicMemoryAllocator)) DynamicMemoryAllocator;
+	}
+	else
+	{
+			DEBUG_CRASH(("memory manager is already inited"));
+	}
+
+	theMainInitFlag = true;
+}
+
+//-----------------------------------------------------------------------------
+Bool isMemoryManagerOfficiallyInited()
+{
+	return theMainInitFlag;
+}
+
+//-----------------------------------------------------------------------------
+/**
+	shutdown the memory manager and discard all memory. Note: if preMainInitMemoryManager()
+	was called prior to initMemoryManager(), this call will do nothing.
+*/
+void shutdownMemoryManager()
+{
+	if (TheDynamicMemoryAllocator != NULL)
+	{
+		TheDynamicMemoryAllocator->~DynamicMemoryAllocator();
+		free((void *)TheDynamicMemoryAllocator);
+		TheDynamicMemoryAllocator = NULL;
+	}
+
+	if (TheMemoryPoolFactory != NULL)
+	{
+		TheMemoryPoolFactory->~MemoryPoolFactory();
+		free((void *)TheMemoryPoolFactory);
+		TheMemoryPoolFactory = NULL;
+	}
+
+	theMainInitFlag = false;
+}
+
+
+#ifndef DISABLE_GAMEMEMORY_NEW_OPERATORS
+
+extern void * __cdecl operator new(size_t size)
+{
+	void *p = malloc(size);
+	if (p == NULL)
+		throw ERROR_OUT_OF_MEMORY;
+	memset(p, 0, size);
+	return p;
+}
+
+extern void __cdecl operator delete(void *p)
+{
+	free(p);
+}
+
+extern void * __cdecl operator new[](size_t size)
+{
+	void *p = malloc(size);
+	if (p == NULL)
+		throw ERROR_OUT_OF_MEMORY;
+	memset(p, 0, size);
+	return p;
+}
+
+extern void __cdecl operator delete[](void *p)
+{
+	free(p);
+}
+
+// additional overloads to account for VC/MFC funky versions
+extern void* __cdecl operator new(size_t size, const char *, int)
+{
+	void *p = malloc(size);
+	if (p == NULL)
+		throw ERROR_OUT_OF_MEMORY;
+	memset(p, 0, size);
+	return p;
+}
+
+extern void __cdecl operator delete(void *p, const char *, int)
+{
+	free(p);
+}
+
+extern void* __cdecl operator new[](size_t size, const char *, int)
+{
+	void *p = malloc(size);
+	if (p == NULL)
+		throw ERROR_OUT_OF_MEMORY;
+	memset(p, 0, size);
+	return p;
+}
+
+extern void __cdecl operator delete[](void *p, const char *, int)
+{
+	free(p);
+}
+
+#endif

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/always.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/always.h
@@ -72,6 +72,8 @@
 #endif	//_MSC_VER
 #endif	//_DEBUG
 
+#if !defined(DISABLE_GAMEMEMORY) // (gth) killing the Generals Memory Manager!
+
 #ifndef _OPERATOR_NEW_DEFINED_
 
 	#define _OPERATOR_NEW_DEFINED_
@@ -155,6 +157,19 @@ public:
 	virtual ~W3DMPO() { /* nothing */ }
 };
 // ----------------------------------------------------------------------------
+
+#else
+
+	#define MSGW3DNEW(MSG)					new
+	#define MSGW3DNEWARRAY(MSG)			new
+	#define W3DNEW									new
+	#define W3DNEWARRAY							new
+
+	#define W3DMPO_GLUE(ARGCLASS)
+
+	class W3DMPO { };
+
+#endif // (gth) removing the generals memory stuff from W3D
 
 
 // Jani: Intel's C++ compiler issues too many warnings in WW libraries when using warning level 4

--- a/GeneralsMD/Code/GameEngine/CMakeLists.txt
+++ b/GeneralsMD/Code/GameEngine/CMakeLists.txt
@@ -645,14 +645,14 @@ set(GAMEENGINE_SRC
     Source/Common/System/FileSystem.cpp
     Source/Common/System/FunctionLexicon.cpp
     Source/Common/System/GameCommon.cpp
-    Source/Common/System/GameMemory.cpp
+    #Source/Common/System/GameMemory.cpp
     Source/Common/System/GameType.cpp
     Source/Common/System/Geometry.cpp
     Source/Common/System/KindOf.cpp
     Source/Common/System/List.cpp
     Source/Common/System/LocalFile.cpp
     Source/Common/System/LocalFileSystem.cpp
-    Source/Common/System/MemoryInit.cpp
+    #Source/Common/System/MemoryInit.cpp
     Source/Common/System/ObjectStatusTypes.cpp
     Source/Common/System/QuickTrig.cpp
     Source/Common/System/QuotedPrintable.cpp
@@ -1137,6 +1137,21 @@ set(GAMEENGINE_SRC
     Source/GameNetwork/WOLBrowser/WebBrowser.cpp
     Source/Precompiled/PreRTS.cpp
 )
+
+if(GENZH_GAMEMEMORY_ENABLE)
+    list(APPEND GAMEENGINE_SRC
+        Source/Common/System/GameMemory.cpp
+        Source/Common/System/MemoryInit.cpp
+        #Include/Common/GameMemory.h
+    )
+else()
+    # Uses the null implementation when disabled.
+    list(APPEND GAMEENGINE_SRC
+        Source/Common/System/GameMemoryNull.cpp
+        Include/Common/GameMemoryNull.h
+    )
+endif()
+
 
 add_library(z_gameengine STATIC)
 

--- a/GeneralsMD/Code/GameEngine/CMakeLists.txt
+++ b/GeneralsMD/Code/GameEngine/CMakeLists.txt
@@ -1139,10 +1139,10 @@ set(GAMEENGINE_SRC
 )
 
 if(GENZH_GAMEMEMORY_ENABLE)
+    # Uses the original Game Memory implementation.
     list(APPEND GAMEENGINE_SRC
         Source/Common/System/GameMemory.cpp
         Source/Common/System/MemoryInit.cpp
-        #Include/Common/GameMemory.h
     )
 else()
     # Uses the null implementation when disabled.

--- a/GeneralsMD/Code/GameEngine/Include/Common/GameMemory.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GameMemory.h
@@ -786,6 +786,39 @@ inline DynamicMemoryAllocator *DynamicMemoryAllocator::getNextDmaInList() { retu
 // EXTERNALS //////////////////////////////////////////////////////////////////
 
 /**
+	Initialize the memory manager. Construct a new MemoryPoolFactory and 
+	DynamicMemoryAllocator and store 'em in the singletons of the relevant
+	names. 
+*/
+extern void initMemoryManager();
+
+/**
+	return true if initMemoryManager() has been called.
+	return false if only preMainInitMemoryManager() has been called.
+*/
+extern Bool isMemoryManagerOfficiallyInited();
+
+/**
+	similar to initMemoryManager, but this should be used if the memory manager must be initialized
+	prior to main() (e.g., from a static constructor). If preMainInitMemoryManager() is called prior
+	to initMemoryManager(), then subsequent calls to either are quietly ignored, AS IS any subsequent
+	call to shutdownMemoryManager() [since there's no safe way to ensure that shutdownMemoryManager
+	will execute after all static destructors].
+
+	(Note: this function is actually not externally visible, but is documented here for clarity.)
+*/
+/* extern void preMainInitMemoryManager(); */
+
+/**
+	Shut down the memory manager. Throw away TheMemoryPoolFactory and 
+	TheDynamicMemoryAllocator.
+*/
+extern void shutdownMemoryManager();
+
+extern MemoryPoolFactory *TheMemoryPoolFactory;
+extern DynamicMemoryAllocator *TheDynamicMemoryAllocator;
+
+/**
 	This function is declared in this header, but is not defined anywhere -- you must provide
 	it in your code. It is called by initMemoryManager() or preMainInitMemoryManager() in order
 	to get the specifics of the subpool for the dynamic memory allocator. (If you just want
@@ -856,40 +889,6 @@ public:
 };
 
 #endif // DISABLE_GAMEMEMORY
-
-
-/**
-	Initialize the memory manager. Construct a new MemoryPoolFactory and 
-	DynamicMemoryAllocator and store 'em in the singletons of the relevant
-	names. 
-*/
-extern void initMemoryManager();
-
-/**
-	return true if initMemoryManager() has been called.
-	return false if only preMainInitMemoryManager() has been called.
-*/
-extern Bool isMemoryManagerOfficiallyInited();
-
-/**
-	similar to initMemoryManager, but this should be used if the memory manager must be initialized
-	prior to main() (e.g., from a static constructor). If preMainInitMemoryManager() is called prior
-	to initMemoryManager(), then subsequent calls to either are quietly ignored, AS IS any subsequent
-	call to shutdownMemoryManager() [since there's no safe way to ensure that shutdownMemoryManager
-	will execute after all static destructors].
-
-	(Note: this function is actually not externally visible, but is documented here for clarity.)
-*/
-/* extern void preMainInitMemoryManager(); */
-
-/**
-	Shut down the memory manager. Throw away TheMemoryPoolFactory and 
-	TheDynamicMemoryAllocator.
-*/
-extern void shutdownMemoryManager();
-
-extern MemoryPoolFactory *TheMemoryPoolFactory;
-extern DynamicMemoryAllocator *TheDynamicMemoryAllocator;
 
 
 /**

--- a/GeneralsMD/Code/GameEngine/Include/Common/GameMemoryNull.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GameMemoryNull.h
@@ -115,6 +115,29 @@ public:
 };
 
 
+/**
+	Initialize the memory manager. Construct a new MemoryPoolFactory and 
+	DynamicMemoryAllocator and store 'em in the singletons of the relevant
+	names. 
+*/
+extern void initMemoryManager();
+
+/**
+	return true if initMemoryManager() has been called.
+	return false if only preMainInitMemoryManager() has been called.
+*/
+extern Bool isMemoryManagerOfficiallyInited();
+
+/**
+	Shut down the memory manager. Throw away TheMemoryPoolFactory and 
+	TheDynamicMemoryAllocator.
+*/
+extern void shutdownMemoryManager();
+
+extern MemoryPoolFactory *TheMemoryPoolFactory;
+extern DynamicMemoryAllocator *TheDynamicMemoryAllocator;
+
+
 // TheSuperHackers @info
 // The new operator overloads will zero all memory after allocation.
 // This replicates the behavior of the original Game Memory implementation and is necessary to avoid crashing the game,

--- a/GeneralsMD/Code/GameEngine/Include/Common/GameMemoryNull.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GameMemoryNull.h
@@ -1,0 +1,137 @@
+/*
+**	Command & Conquer Generals Zero Hour(tm)
+**	Copyright 2025 TheSuperHackers
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#define allocateBytes(ARGCOUNT,ARGLITERAL)          allocateBytesImplementation(ARGCOUNT)
+#define allocateBytesDoNotZero(ARGCOUNT,ARGLITERAL) allocateBytesDoNotZeroImplementation(ARGCOUNT)
+#define newInstanceDesc(ARGCLASS,ARGLITERAL)        new ARGCLASS
+#define newInstance(ARGCLASS)                       new ARGCLASS
+#define MSGNEW(MSG)                                 new
+#define NEW                                         new
+
+
+/**
+	The DynamicMemoryAllocator class is used to handle unpredictably-sized
+	allocation requests.
+*/
+class DynamicMemoryAllocator
+{
+public:
+
+	/// allocate bytes from this pool. (don't call directly; use allocateBytes() macro)
+	void *allocateBytesImplementation(Int numBytes);
+
+	/// like allocateBytesImplementation, but zeroes the memory before returning
+	void *allocateBytesDoNotZeroImplementation(Int numBytes);
+
+#ifdef MEMORYPOOL_DEBUG
+	void debugIgnoreLeaksForThisBlock(void* pBlockPtr);
+#endif
+
+	/// free the bytes. (assumes allocated by this dma.)
+	void freeBytes(void* pMem);
+
+	/**
+		return the actual number of bytes that would be allocated 
+		if you tried to allocate the given size.
+	*/
+	Int getActualAllocationSize(Int numBytes);
+};
+
+
+/**
+	The class that manages all the MemoryPools and DynamicMemoryAllocators.
+	Usually you will create exactly one of these (TheMemoryPoolFactory)
+	and use it for everything.
+*/
+class MemoryPoolFactory
+{
+public:
+
+	void memoryPoolUsageReport( const char* filename, FILE *appendToFileInstead = NULL );
+
+#ifdef MEMORYPOOL_DEBUG
+
+	void debugMemoryReport(Int flags, Int startCheckpoint, Int endCheckpoint, FILE *fp = NULL );
+	void debugSetInitFillerIndex(Int index);
+
+#endif
+};
+
+
+#define MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS) \
+protected: \
+	virtual ~ARGCLASS(); \
+public: /* include this line at the end to reset visibility to 'public' */ 
+
+
+#define MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(ARGCLASS, ARGPOOLNAME) \
+	MEMORY_POOL_GLUE_WITHOUT_GCMP(ARGCLASS)
+
+
+// this is the version for an Abstract Base Class, which will never be instantiated...
+#define MEMORY_POOL_GLUE_ABC(ARGCLASS) \
+protected: \
+	virtual ~ARGCLASS(); \
+public: /* include this line at the end to reset visibility to 'public' */ 
+
+
+/**
+	This class is provided as a simple and safe way to integrate C++ object allocation
+	into MemoryPool usage. To use it, you must have your class inherit from
+	MemoryPoolObject, then put the macro MEMORY_POOL_GLUE(MyClassName, "MyPoolName")
+	at the start of your class definition. (This does not create the pool itself -- you
+	must create that manually using MemoryPoolFactory::createMemoryPool)
+*/
+class MemoryPoolObject
+{
+protected:
+
+	/** ensure that all destructors are virtual */
+	virtual ~MemoryPoolObject() { }
+
+public:
+
+	void deleteInstance() 
+	{
+		delete this;
+	}
+};
+
+
+// TheSuperHackers @info
+// The new operator overloads will zero all memory after allocation.
+// This replicates the behavior of the original Game Memory implementation and is necessary to avoid crashing the game,
+// where data is not properly zero initialized. Disable these operators when fixing those issues.
+#ifndef DISABLE_GAMEMEMORY_NEW_OPERATORS
+
+extern void * __cdecl operator new(size_t size);
+extern void __cdecl operator delete(void *p);
+
+extern void * __cdecl operator new[](size_t size);
+extern void __cdecl operator delete[](void *p);
+
+// additional overloads to account for VC/MFC funky versions
+extern void* __cdecl operator new(size_t size, const char *, int);
+extern void __cdecl operator delete(void *p, const char *, int);
+
+extern void* __cdecl operator new[](size_t size, const char *, int);
+extern void __cdecl operator delete[](void *p, const char *, int);
+
+#endif

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/GameMemoryNull.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/GameMemoryNull.cpp
@@ -1,0 +1,213 @@
+/*
+**	Command & Conquer Generals Zero Hour(tm)
+**	Copyright 2025 TheSuperHackers
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "PreRTS.h"
+
+#include <malloc.h>
+
+#include "Common/GameMemoryNull.h"
+
+static Bool theMainInitFlag = false;
+
+// ----------------------------------------------------------------------------
+// PUBLIC DATA 
+// ----------------------------------------------------------------------------
+
+MemoryPoolFactory *TheMemoryPoolFactory = NULL;
+DynamicMemoryAllocator *TheDynamicMemoryAllocator = NULL;
+
+//-----------------------------------------------------------------------------
+// METHODS for DynamicMemoryAllocator
+//-----------------------------------------------------------------------------
+
+/**
+	allocate a chunk-o-bytes from this DMA and return it, but don't bother zeroing
+	out the block. if unable to allocate, throw ERROR_OUT_OF_MEMORY. this
+	function will never return null.
+
+  added code to make sure we're on a DWord boundary, throw exception if not
+*/
+void *DynamicMemoryAllocator::allocateBytesDoNotZeroImplementation(Int numBytes)
+{
+	void *p = malloc(numBytes);
+	if (p == NULL)
+		throw ERROR_OUT_OF_MEMORY;
+	return p;
+}
+
+/**
+	allocate a chunk-o-bytes from this DMA and return it, and zero out the contents first.
+	if unable to allocate, throw ERROR_OUT_OF_MEMORY. 
+	this function will never return null.
+*/
+void *DynamicMemoryAllocator::allocateBytesImplementation(Int numBytes)
+{
+	void* p = allocateBytesDoNotZeroImplementation(numBytes);	// throws on failure
+	memset(p, 0, numBytes);
+	return p;
+}
+
+/**
+	free a chunk-o-bytes allocated by this dma. it's ok to pass null.
+*/
+void DynamicMemoryAllocator::freeBytes(void* pBlockPtr)
+{
+	free(pBlockPtr);
+}
+
+Int DynamicMemoryAllocator::getActualAllocationSize(Int numBytes)
+{
+	return numBytes;
+}
+
+#ifdef MEMORYPOOL_DEBUG
+void DynamicMemoryAllocator::debugIgnoreLeaksForThisBlock(void* pBlockPtr)
+{
+}
+#endif
+
+//-----------------------------------------------------------------------------
+// METHODS for MemoryPoolFactory
+//-----------------------------------------------------------------------------
+
+void MemoryPoolFactory::memoryPoolUsageReport( const char* filename, FILE *appendToFileInstead )
+{
+}
+
+#ifdef MEMORYPOOL_DEBUG
+void MemoryPoolFactory::debugMemoryReport(Int flags, Int startCheckpoint, Int endCheckpoint, FILE *fp )
+{
+}
+void MemoryPoolFactory::debugSetInitFillerIndex(Int index)
+{
+}
+#endif
+
+//-----------------------------------------------------------------------------
+// GLOBAL FUNCTIONS
+//-----------------------------------------------------------------------------
+
+/**
+	Initialize the memory manager, and create TheMemoryPoolFactory and TheDynamicMemoryAllocator.
+*/
+void initMemoryManager()
+{
+	if (TheMemoryPoolFactory == NULL && TheDynamicMemoryAllocator == NULL)
+	{
+		TheMemoryPoolFactory = new (malloc(sizeof MemoryPoolFactory)) MemoryPoolFactory;
+		TheDynamicMemoryAllocator = new (malloc(sizeof DynamicMemoryAllocator)) DynamicMemoryAllocator;
+	}
+	else
+	{
+			DEBUG_CRASH(("memory manager is already inited"));
+	}
+
+	theMainInitFlag = true;
+}
+
+//-----------------------------------------------------------------------------
+Bool isMemoryManagerOfficiallyInited()
+{
+	return theMainInitFlag;
+}
+
+//-----------------------------------------------------------------------------
+/**
+	shutdown the memory manager and discard all memory. Note: if preMainInitMemoryManager()
+	was called prior to initMemoryManager(), this call will do nothing.
+*/
+void shutdownMemoryManager()
+{
+	if (TheDynamicMemoryAllocator != NULL)
+	{
+		TheDynamicMemoryAllocator->~DynamicMemoryAllocator();
+		free((void *)TheDynamicMemoryAllocator);
+		TheDynamicMemoryAllocator = NULL;
+	}
+
+	if (TheMemoryPoolFactory != NULL)
+	{
+		TheMemoryPoolFactory->~MemoryPoolFactory();
+		free((void *)TheMemoryPoolFactory);
+		TheMemoryPoolFactory = NULL;
+	}
+
+	theMainInitFlag = false;
+}
+
+
+#ifndef DISABLE_GAMEMEMORY_NEW_OPERATORS
+
+extern void * __cdecl operator new(size_t size)
+{
+	void *p = malloc(size);
+	if (p == NULL)
+		throw ERROR_OUT_OF_MEMORY;
+	memset(p, 0, size);
+	return p;
+}
+
+extern void __cdecl operator delete(void *p)
+{
+	free(p);
+}
+
+extern void * __cdecl operator new[](size_t size)
+{
+	void *p = malloc(size);
+	if (p == NULL)
+		throw ERROR_OUT_OF_MEMORY;
+	memset(p, 0, size);
+	return p;
+}
+
+extern void __cdecl operator delete[](void *p)
+{
+	free(p);
+}
+
+// additional overloads to account for VC/MFC funky versions
+extern void* __cdecl operator new(size_t size, const char *, int)
+{
+	void *p = malloc(size);
+	if (p == NULL)
+		throw ERROR_OUT_OF_MEMORY;
+	memset(p, 0, size);
+	return p;
+}
+
+extern void __cdecl operator delete(void *p, const char *, int)
+{
+	free(p);
+}
+
+extern void* __cdecl operator new[](size_t size, const char *, int)
+{
+	void *p = malloc(size);
+	if (p == NULL)
+		throw ERROR_OUT_OF_MEMORY;
+	memset(p, 0, size);
+	return p;
+}
+
+extern void __cdecl operator delete[](void *p, const char *, int)
+{
+	free(p);
+}
+
+#endif

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/always.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/always.h
@@ -72,7 +72,7 @@
 #endif	//_MSC_VER
 #endif	//_DEBUG
 
-#if 1 // (gth) killing the Generals Memory Manager!
+#if !defined(DISABLE_GAMEMEMORY) // (gth) killing the Generals Memory Manager!
 
 #ifndef _OPERATOR_NEW_DEFINED_
 

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -19,9 +19,10 @@ add_feature_info(ProfileBuild GENZH_BUILD_PROFILE "Building as a \"Profile\" bui
 add_feature_info(DebugBuild GENZH_BUILD_DEBUG "Building as a \"Debug\" build")
 
 
-### MEMORY POOL OPTIONS ###
+### GAME MEMORY OPTIONS ###
 
 # Memory pool features
+option(GENZH_GAMEMEMORY_ENABLE "Enables the memory pool and dynamic memory allocator." ON)
 option(GENZH_MEMORYPOOL_OVERRIDE_MALLOC "Enables the Dynamic Memory Allocator for malloc calls." OFF)
 option(GENZH_MEMORYPOOL_MPSB_DLINK "Adds a backlink to MemoryPoolSingleBlock. Makes it faster to free raw DMA blocks, but increases memory consumption." ON)
 
@@ -80,6 +81,10 @@ else()
 endif()
 
 # Memory pool features
+if(NOT GENZH_GAMEMEMORY_ENABLE)
+    target_compile_definitions(gz_config INTERFACE DISABLE_GAMEMEMORY=1)
+endif()
+
 if(GENZH_MEMORYPOOL_OVERRIDE_MALLOC)
     target_compile_definitions(gz_config INTERFACE MEMORYPOOL_OVERRIDE_MALLOC=1)
 endif()

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -21,8 +21,10 @@ add_feature_info(DebugBuild GENZH_BUILD_DEBUG "Building as a \"Debug\" build")
 
 ### GAME MEMORY OPTIONS ###
 
-# Memory pool features
+# Game Memory features
 option(GENZH_GAMEMEMORY_ENABLE "Enables the memory pool and dynamic memory allocator." ON)
+
+# Memory pool features
 option(GENZH_MEMORYPOOL_OVERRIDE_MALLOC "Enables the Dynamic Memory Allocator for malloc calls." OFF)
 option(GENZH_MEMORYPOOL_MPSB_DLINK "Adds a backlink to MemoryPoolSingleBlock. Makes it faster to free raw DMA blocks, but increases memory consumption." ON)
 
@@ -35,6 +37,9 @@ option(GENZH_MEMORYPOOL_DEBUG_STACKTRACE "Enables stack trace collection for all
 option(GENZH_MEMORYPOOL_DEBUG_INTENSE_VERIFY "Enables intensive verifications after nearly every memory operation. OFF by default, since it slows down things a lot, but is worth turning on for really obscure memory corruption issues." OFF)
 option(GENZH_MEMORYPOOL_DEBUG_CHECK_BLOCK_OWNERSHIP "Enables debug to verify that a block actually belongs to the pool it is called with. This is great for debugging, but can be realllly slow, so is OFF by default." OFF)
 option(GENZH_MEMORYPOOL_DEBUG_INTENSE_DMA_BOOKKEEPING "Prints statistics for memory usage of Memory Pools." OFF)
+
+# Game Memory features
+add_feature_info(GameMemoryEnable GENZH_GAMEMEMORY_ENABLE "Build with the original game memory implementation")
 
 # Memory pool features
 add_feature_info(MemoryPoolOverrideMalloc GENZH_MEMORYPOOL_OVERRIDE_MALLOC "Build with Memory Pool malloc")
@@ -80,11 +85,13 @@ else()
     endif()
 endif()
 
-# Memory pool features
+
+# Game Memory features
 if(NOT GENZH_GAMEMEMORY_ENABLE)
     target_compile_definitions(gz_config INTERFACE DISABLE_GAMEMEMORY=1)
 endif()
 
+# Memory pool features
 if(GENZH_MEMORYPOOL_OVERRIDE_MALLOC)
     target_compile_definitions(gz_config INTERFACE MEMORYPOOL_OVERRIDE_MALLOC=1)
 endif()


### PR DESCRIPTION
This change adds a game memory replacement without memory pools.

Everything that is not called by user code is stripped away in the null implementation.

`new`/`delete` overloads still exist, because right now we do require zero memset for allocations. Disabling the zero memset will cause the game to crash in various places that forgot to zero initialize critical variables, such as pointers, that we would need to fix before being able to get rid of zero memset.

This change unlocks established memory debugs, such as Asan, and performance comparisons of game memory pools vs system heap allocator.