### PR TITLE
[GEN][ZH] Fix rebalanceChildSleepyUpdate debug runtime exceptions

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -2504,14 +2504,17 @@ Int GameLogic::rebalanceChildSleepyUpdate(Int i)
 	UpdateModulePtr* pI = &m_sleepyUpdates[i];
 
 	// our children are i*2 and i*2+1
-  Int child = ((i+1)<<1)-1;
+	Int child = ((i+1)<<1)-1;
+	UnsignedInt containerSize = m_sleepyUpdates.size();
+	// TheSuperHackers @fix Mauller 02/04/2025 Prevent invalid index into container throwing errors during debug
+	if(child >= containerSize) return i;
 	UpdateModulePtr* pChild = &m_sleepyUpdates[child];
-	UpdateModulePtr* pSZ = &m_sleepyUpdates[m_sleepyUpdates.size()];	// yes, this is off the end.
+	UpdateModulePtr* pSZ = &m_sleepyUpdates[containerSize - 1];
 
-  while (pChild < pSZ) 
+  while (pChild <= pSZ) 
 	{
 		// choose the higher-priority of the two children; we must be higher-pri than that.
-		if (pChild < pSZ-1 && isLowerPriority(*pChild, *(pChild+1)))
+		if (pChild < pSZ && isLowerPriority(*pChild, *(pChild+1)))
 		{
       ++pChild;
 			++child;
@@ -2537,6 +2540,8 @@ Int GameLogic::rebalanceChildSleepyUpdate(Int i)
 		pI = pChild;
 
 		child = ((i+1)<<1)-1;
+		// TheSuperHackers @fix Mauller 02/04/2025 Prevent invalid index into container throwing errors during debug
+		if(child >= containerSize) break;
 		pChild = &m_sleepyUpdates[child];
   }
 #else

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -2834,14 +2834,17 @@ Int GameLogic::rebalanceChildSleepyUpdate(Int i)
 	UpdateModulePtr* pI = &m_sleepyUpdates[i];
 
 	// our children are i*2 and i*2+1
-  Int child = ((i+1)<<1)-1;
+	Int child = ((i+1)<<1)-1;
+	UnsignedInt containerSize = m_sleepyUpdates.size();
+	// TheSuperHackers @fix Mauller 02/04/2025 Prevent invalid index into container throwing errors during debug
+	if(child >= containerSize) return i;
 	UpdateModulePtr* pChild = &m_sleepyUpdates[child];
-	UpdateModulePtr* pSZ = &m_sleepyUpdates[m_sleepyUpdates.size()];	// yes, this is off the end.
+	UpdateModulePtr* pSZ = &m_sleepyUpdates[containerSize - 1];
 
-  while (pChild < pSZ) 
+  while (pChild <= pSZ) 
 	{
 		// choose the higher-priority of the two children; we must be higher-pri than that.
-		if (pChild < pSZ-1 && isLowerPriority(*pChild, *(pChild+1)))
+		if (pChild < pSZ && isLowerPriority(*pChild, *(pChild+1)))
 		{
       ++pChild;
 			++child;
@@ -2867,6 +2870,8 @@ Int GameLogic::rebalanceChildSleepyUpdate(Int i)
 		pI = pChild;
 
 		child = ((i+1)<<1)-1;
+		// TheSuperHackers @fix Mauller 02/04/2025 Prevent invalid index into container throwing errors during debug
+		if(child >= containerSize) break;
 		pChild = &m_sleepyUpdates[child];
   }
 #else


### PR DESCRIPTION
Previously known as: [GEN][ZH] Fix debug critical runtime errors

~~Fix critical runtime errors in generals and zero hour that are preventing debug from working.~~

Edit: I have split out a lot of the fixes that were within this PR into smaller PR's to make them easier to review individualy.
This PR now only contains fixes to the sleepy updates loop within GameLogic.

The issue with the sleep updates loop is that the passed in value i can create a child index that is beyond the end of the container it is used with. This will cause unexpected behaviour but is caught by the check on the while loop, the child pointer must be smaller than the end of container pointer.

This behaviour also occurs within the loop when the next i value and child index are calculated, so must be guarded within the loop as well.

The out of bounds access exception is only thrown during debug and prevents the use of debug. under normal gameplay the pointer returned should never be acted upon if it is beyond the bounds of the container.

This fix only concerns Debug and doesn't affect normal runtime, but it does prevent us from running debug at all.

~~Current known issues:~~
~~- Depends on: #464~~
~~* #489~~ 
~~* #536 ~~
~~* #537~~
~~* #538~~