### PR TITLE
[GitHub] Cancel in-progress jobs only for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   detect-changes:


### PR DESCRIPTION
Change CI to only cancel in-progress jobs for pull requests. 

This should allow all jobs related to pushes to main to complete irrespective of concurrency.