### PR TITLE
[Git] Expand gitignore to include CLion / JetBrains IDEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,14 @@ thumbs.db
 .clang-format
 /.vscode
 /Dependencies/MaxSDK/maxsdk
+
+## IntelliJ, CLion, etc.
+/.idea
+
+# IntelliJ-style CMake bits
+cmake-build-*/
+
+## Ninja
+.ninja_deps
+.ninja_log
+build.ninja


### PR DESCRIPTION
CLion throws out a `cmake-build-$target/` directory in various places that could pollute the repository. Using Ninja with CLion creates numerous `build.ninja` files across the tree.

This commit fixes those two problems for developers using these tools to avoid accidentally committing those files.