### PR TITLE
[GEN][ZH] Add Windows application manifest to executables

### DIFF
--- a/Generals/Code/Main/CMakeLists.txt
+++ b/Generals/Code/Main/CMakeLists.txt
@@ -60,6 +60,13 @@ target_sources(g_generals PRIVATE
 )
 
 if(WIN32 OR "${CMAKE_SYSTEM}" MATCHES "Windows")
+    # VS2005 and later adds default manifest, we need to turn it off to prevent conflict with custom manifest
+    if(NOT IS_VS6_BUILD)
+        target_link_options(g_generals PRIVATE
+            "/MANIFEST:NO"
+        )
+    endif()
+
     target_sources(g_generals PRIVATE
         RTS.RC
     )

--- a/Generals/Code/Main/RTS.RC
+++ b/Generals/Code/Main/RTS.RC
@@ -65,6 +65,8 @@ IDB_LOAD_SCREEN         BITMAP  DISCARDABLE     "Install_Final.bmp"
 #endif    // English (U.S.) resources
 /////////////////////////////////////////////////////////////////////////////
 
+// Add manifest to specify that the app is DPI aware and prevent forced scaling by the system
+1 24 "app.manifest"
 
 
 #ifndef APSTUDIO_INVOKED

--- a/Generals/Code/Main/app.manifest
+++ b/Generals/Code/Main/app.manifest
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level='asInvoker' uiAccess='false' />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+      />
+    </dependentAssembly>
+  </dependency>
+  <asmv3:application>
+    <asmv3:windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </asmv3:windowsSettings>
+  </asmv3:application>
+</assembly>

--- a/GeneralsMD/Code/Main/CMakeLists.txt
+++ b/GeneralsMD/Code/Main/CMakeLists.txt
@@ -61,6 +61,13 @@ target_sources(z_generals PRIVATE
 )
 
 if(WIN32 OR "${CMAKE_SYSTEM}" MATCHES "Windows")
+    # VS2005 and later adds default manifest, we need to turn it off to prevent conflict with custom manifest
+    if(NOT IS_VS6_BUILD)
+        target_link_options(z_generals PRIVATE
+            "/MANIFEST:NO"
+        )
+    endif()
+
     target_sources(z_generals PRIVATE
         RTS.RC
     )

--- a/GeneralsMD/Code/Main/RTS.RC
+++ b/GeneralsMD/Code/Main/RTS.RC
@@ -58,6 +58,8 @@ IDI_ApplicationIcon     ICON    DISCARDABLE     "GENERALS.ICO"
 #endif    // English (U.S.) resources
 /////////////////////////////////////////////////////////////////////////////
 
+// Add manifest to specify that the app is DPI aware and prevent forced scaling by the system
+1 24 "app.manifest"
 
 
 #ifndef APSTUDIO_INVOKED

--- a/GeneralsMD/Code/Main/app.manifest
+++ b/GeneralsMD/Code/Main/app.manifest
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level='asInvoker' uiAccess='false' />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+      />
+    </dependentAssembly>
+  </dependency>
+  <asmv3:application>
+    <asmv3:windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </asmv3:windowsSettings>
+  </asmv3:application>
+</assembly>


### PR DESCRIPTION
Currently, Windows treats the Gen and ZH executables as [DPI unaware](https://learn.microsoft.com/en-us/windows/win32/hidpi/high-dpi-desktop-application-development-on-windows#dpi-awareness-mode) and forcefully scales the content of all application windows when the display scaling factor is set to something other than 100%. This means that when running the game in windowed mode with a resolution of 800x600, the real window size on screens with scaling set to 200% will be 1600x1200, and every pixel will simply be stretched to four pixels. To prevent this system scaling, the application should indicate to the system that it is DPI aware. The best way to achieve this is to add an application [manifest](https://learn.microsoft.com/en-us/windows/win32/hidpi/setting-the-default-dpi-awareness-for-a-process#setting-default-awareness-with-the-application-manifest) with the `dpiAware` setting.

Another feature that can be configured via the application manifest is the application of [modern visual styles](https://learn.microsoft.com/en-us/windows/win32/controls/cookbook-overview#using-manifests-or-directives-to-ensure-that-visual-styles-can-be-applied-to-applications). By default, applications are linked to ComCtl32.dll version 5, which contains UI elements styled like Windows 98/ME/2000. To use modern-looking elements, the application should request loading ComCtl32.dll version 6, which supports themed UI elements from Windows XP and later.

#### Changes

This PR adds an application manifest that addresses both issues:

- Specifies that the application is DPI aware, preventing Windows from scaling the app’s windows.
- Requests the modern version of the common controls library, ensuring that system dialogs in the app have a modern look.

#### Screenshots on screen with 200% display scaling

<details>
<summary>Without Manifest</summary>

##### Splash screen window scaled to 1600x1200 from 800x600, and the message dialog has stretched pixelated text, a Windows 98-style button, and an icon.

<img src="https://github.com/user-attachments/assets/f467986f-2624-4231-b930-f7e2d8b0849a">
</details>

<details>
<summary>With Manifest</summary>

##### Splash screen remains unscaled at 800x600, and the message dialog has crisp text, a modern-looking button, and an icon.

<img src="https://github.com/user-attachments/assets/24d10dcb-197d-466b-9630-9bf7e536f318">
</details>