### PR TITLE
[GEN][ZH] Fix compile errors with ALLOW_TEMPORARIES in WWMath

### DIFF
--- a/Generals/Code/Libraries/Source/WWVegas/WWMath/CMakeLists.txt
+++ b/Generals/Code/Libraries/Source/WWVegas/WWMath/CMakeLists.txt
@@ -88,3 +88,6 @@ target_sources(g_wwmath PRIVATE ${WWMATH_SRC})
 target_link_libraries(g_wwmath PRIVATE
     g_wwcommon
 )
+
+# @todo Test its impact and see what to do with the legacy functions.
+#add_compile_definitions(z_wwmath PUBLIC ALLOW_TEMPORARIES) # Enables legacy math with "temporaries"

--- a/Generals/Code/Libraries/Source/WWVegas/WWMath/matrix3d.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WWMath/matrix3d.cpp
@@ -1187,7 +1187,7 @@ void Matrix3D::Lerp(const Matrix3D &A, const Matrix3D &B, float factor, Matrix3D
 
 	// Lerp position
 #ifdef ALLOW_TEMPORARIES
-  Vector3 pos = Lerp(A.Get_Translation(), B.Get_Translation(), factor);
+  Vector3 pos = Vector3::Lerp(A.Get_Translation(), B.Get_Translation(), factor);
 #else
 	Vector3 pos;
 	Vector3::Lerp(A.Get_Translation(), B.Get_Translation(), factor, &pos);

--- a/Generals/Code/Libraries/Source/WWVegas/WWMath/matrix3d.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WWMath/matrix3d.h
@@ -1662,7 +1662,7 @@ WWINLINE void Matrix3D::mulVector3Array(const Vector3* in, Vector3* out, int cou
 {
 	assert(in != out);
 #ifdef ALLOW_TEMPORARIES
-	for (i=0; i<count; i++)
+	for (int i=0; i<count; i++)
 	{
 		out[i] = (*this) * in[i];
 	}
@@ -1682,7 +1682,7 @@ WWINLINE void Matrix3D::mulVector3Array(const Vector3* in, Vector3* out, int cou
 WWINLINE void Matrix3D::mulVector3Array(Vector3* inout, int count) const
 {
 #ifdef ALLOW_TEMPORARIES
-	for (i=0; i<count; i++)
+	for (int i=0; i<count; i++)
 	{
 		inout[i] = (*this) * inout[i];
 	}

--- a/Generals/Code/Libraries/Source/WWVegas/WWMath/vector3.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WWMath/vector3.h
@@ -146,7 +146,7 @@ public:
    WWINLINE friend bool Equal_Within_Epsilon(const Vector3 &a,const Vector3 &b,float epsilon);
 
 	// dot product / inner product
-	//WWINLINE friend float operator * (const Vector3 &a,const Vector3 &b);
+	WWINLINE friend float operator * (const Vector3 &a,const Vector3 &b);
 	static WWINLINE float Dot_Product(const Vector3 &a,const Vector3 &b);
 	
 	// cross product / outer product
@@ -184,6 +184,10 @@ public:
 
 	// Linearly interpolate two Vector3's
 	static void Lerp(const Vector3 & a, const Vector3 & b, float alpha,Vector3 * set_result);
+
+#ifdef ALLOW_TEMPORARIES
+	static Vector3 Lerp(const Vector3 & a, const Vector3 & b, float alpha);
+#endif
 
 	// Color Conversion
 	WWINLINE unsigned	long	Convert_To_ABGR( void ) const;
@@ -284,12 +288,12 @@ WWINLINE Vector3 operator - (const Vector3 &a,const Vector3 &b)
  *                                                                        * 
  * HISTORY:                                                               * 
  *========================================================================*/
-//WWINLINE float operator * (const Vector3 &a,const Vector3 &b)
-//{
-//	return	a.X*b.X + 
-//				a.Y*b.Y + 
-//				a.Z*b.Z;
-//}
+WWINLINE float operator * (const Vector3 &a,const Vector3 &b)
+{
+	return	a.X*b.X + 
+				a.Y*b.Y + 
+				a.Z*b.Z;
+}
 
 WWINLINE float Vector3::Dot_Product(const Vector3 &a,const Vector3 &b)
 {
@@ -540,6 +544,16 @@ WWINLINE void Vector3::Lerp(const Vector3 & a, const Vector3 & b, float alpha,Ve
    set_result->Y = (a.Y + (b.Y - a.Y)*alpha);
    set_result->Z = (a.Z + (b.Z - a.Z)*alpha);
 }
+
+
+#ifdef ALLOW_TEMPORARIES
+WWINLINE Vector3 Vector3::Lerp(const Vector3 & a, const Vector3 & b, float alpha)
+{
+	Vector3 set_result;
+	Vector3::Lerp(a, b, alpha, &set_result);
+	return set_result;
+}
+#endif
 
 /***********************************************************************************************
  * Vector3::Add -- Add two vector3's without return-by-value                                   *

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWMath/CMakeLists.txt
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWMath/CMakeLists.txt
@@ -88,3 +88,6 @@ target_sources(z_wwmath PRIVATE ${WWMATH_SRC})
 target_link_libraries(z_wwmath PRIVATE
     z_wwcommon
 )
+
+# @todo Test its impact and see what to do with the legacy functions.
+#add_compile_definitions(z_wwmath PUBLIC ALLOW_TEMPORARIES) # Enables legacy math with "temporaries"

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWMath/matrix3d.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWMath/matrix3d.cpp
@@ -1187,7 +1187,7 @@ void Matrix3D::Lerp(const Matrix3D &A, const Matrix3D &B, float factor, Matrix3D
 
 	// Lerp position
 #ifdef ALLOW_TEMPORARIES
-  Vector3 pos = Lerp(A.Get_Translation(), B.Get_Translation(), factor);
+  Vector3 pos = Vector3::Lerp(A.Get_Translation(), B.Get_Translation(), factor);
 #else
 	Vector3 pos;
 	Vector3::Lerp(A.Get_Translation(), B.Get_Translation(), factor, &pos);

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWMath/matrix3d.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWMath/matrix3d.h
@@ -1662,7 +1662,7 @@ WWINLINE void Matrix3D::mulVector3Array(const Vector3* in, Vector3* out, int cou
 {
 	assert(in != out);
 #ifdef ALLOW_TEMPORARIES
-	for (i=0; i<count; i++)
+	for (int i=0; i<count; i++)
 	{
 		out[i] = (*this) * in[i];
 	}
@@ -1682,7 +1682,7 @@ WWINLINE void Matrix3D::mulVector3Array(const Vector3* in, Vector3* out, int cou
 WWINLINE void Matrix3D::mulVector3Array(Vector3* inout, int count) const
 {
 #ifdef ALLOW_TEMPORARIES
-	for (i=0; i<count; i++)
+	for (int i=0; i<count; i++)
 	{
 		inout[i] = (*this) * inout[i];
 	}

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWMath/vector3.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWMath/vector3.h
@@ -550,9 +550,7 @@ WWINLINE void Vector3::Lerp(const Vector3 & a, const Vector3 & b, float alpha,Ve
 WWINLINE Vector3 Vector3::Lerp(const Vector3 & a, const Vector3 & b, float alpha)
 {
 	Vector3 set_result;
-	set_result.X = (a.X + (b.X - a.X)*alpha);
-	set_result.Y = (a.Y + (b.Y - a.Y)*alpha);
-	set_result.Z = (a.Z + (b.Z - a.Z)*alpha);
+	Vector3::Lerp(a, b, alpha, &set_result);
 	return set_result;
 }
 #endif

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWMath/vector3.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWMath/vector3.h
@@ -146,7 +146,7 @@ public:
    WWINLINE friend bool Equal_Within_Epsilon(const Vector3 &a,const Vector3 &b,float epsilon);
 
 	// dot product / inner product
-	//WWINLINE friend float operator * (const Vector3 &a,const Vector3 &b);
+	WWINLINE friend float operator * (const Vector3 &a,const Vector3 &b);
 	static WWINLINE float Dot_Product(const Vector3 &a,const Vector3 &b);
 	
 	// cross product / outer product
@@ -184,6 +184,10 @@ public:
 
 	// Linearly interpolate two Vector3's
 	static void Lerp(const Vector3 & a, const Vector3 & b, float alpha,Vector3 * set_result);
+
+#ifdef ALLOW_TEMPORARIES
+	static Vector3 Lerp(const Vector3 & a, const Vector3 & b, float alpha);
+#endif
 
 	// Color Conversion
 	WWINLINE unsigned	long	Convert_To_ABGR( void ) const;
@@ -284,12 +288,12 @@ WWINLINE Vector3 operator - (const Vector3 &a,const Vector3 &b)
  *                                                                        * 
  * HISTORY:                                                               * 
  *========================================================================*/
-//WWINLINE float operator * (const Vector3 &a,const Vector3 &b)
-//{
-//	return	a.X*b.X + 
-//				a.Y*b.Y + 
-//				a.Z*b.Z;
-//}
+WWINLINE float operator * (const Vector3 &a,const Vector3 &b)
+{
+	return	a.X*b.X + 
+				a.Y*b.Y + 
+				a.Z*b.Z;
+}
 
 WWINLINE float Vector3::Dot_Product(const Vector3 &a,const Vector3 &b)
 {
@@ -540,6 +544,18 @@ WWINLINE void Vector3::Lerp(const Vector3 & a, const Vector3 & b, float alpha,Ve
    set_result->Y = (a.Y + (b.Y - a.Y)*alpha);
    set_result->Z = (a.Z + (b.Z - a.Z)*alpha);
 }
+
+
+#ifdef ALLOW_TEMPORARIES
+WWINLINE Vector3 Vector3::Lerp(const Vector3 & a, const Vector3 & b, float alpha)
+{
+	Vector3 set_result;
+	set_result.X = (a.X + (b.X - a.X)*alpha);
+	set_result.Y = (a.Y + (b.Y - a.Y)*alpha);
+	set_result.Z = (a.Z + (b.Z - a.Z)*alpha);
+	return set_result;
+}
+#endif
 
 /***********************************************************************************************
  * Vector3::Add -- Add two vector3's without return-by-value                                   *


### PR DESCRIPTION
* Relates to #602

This change fixes compile errors with ALLOW_TEMPORARIES in WWMath.

ALLOW_TEMPORARIES unlocks math functions which are industry standard for vectors and matrices.

## TODO

- [x] Replicate in Generals