### PR TITLE
[GEN] Bring WWLib partially in line with Zero Hour

### DIFF
--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DFileSystem.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DFileSystem.h
@@ -57,6 +57,11 @@ public:
 
 	virtual char const * File_Name(void) const;
 	virtual char const * Set_Name(char const *filename);
+
+	// (gth) had to re-instate these functions in the base class, for now just give empty implementations...
+	virtual int Create(void) { assert(0); return 1; }
+	virtual int Delete(void) { assert(0); return 1; }
+
 	virtual bool Is_Available(int forced=false);
 	virtual bool Is_Open(void) const;
 	virtual int Open(char const *filename, int rights=READ);

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DFileSystem.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DFileSystem.cpp
@@ -60,7 +60,7 @@
 //-------------------------------------------------------------------------------------------------
 typedef enum
 {
-	FILE_TYPE_UNKNOWN = 0,
+	FILE_TYPE_COMPLETELY_UNKNOWN = 0,	// MBL 08.15.2002 - compile error with FILE_TYPE_UNKNOWN, is constant
 	FILE_TYPE_W3D,
 	FILE_TYPE_TGA,
 	FILE_TYPE_DDS,
@@ -159,7 +159,7 @@ char const * GameFileClass::Set_Name( char const *filename )
 	name[j] = 0;
 
 	// test the extension to recognize a few key file types
-	GameFileType fileType = FILE_TYPE_UNKNOWN;
+	GameFileType fileType = FILE_TYPE_COMPLETELY_UNKNOWN;  // MBL FILE_TYPE_UNKNOWN change due to compile error
 	if( stricmp( extension, ".w3d" ) == 0 )
 		fileType = FILE_TYPE_W3D;
 	else if( stricmp( extension, ".tga" ) == 0 )

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dazzle.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dazzle.cpp
@@ -564,7 +564,7 @@ void DazzleRenderObjClass::Init_From_INI(const INIClass* ini)
 
 		LensflareInitClass lic;
 
-		lic.texture_name=ini->Get_String(section_name,LENSFLARE_TEXTURE_STRING);
+		ini->Get_String(lic.texture_name,section_name,LENSFLARE_TEXTURE_STRING);
 		lic.flare_count=ini->Get_Int(section_name,FLARE_COUNT_STRING,0);
 		if (lic.flare_count) {
 			lic.flare_locations=W3DNEWARRAY float[lic.flare_count];	// Flare location is 1D
@@ -613,8 +613,8 @@ void DazzleRenderObjClass::Init_From_INI(const INIClass* ini)
 
 		DazzleInitClass dic;
 
-		dic.primary_texture_name=ini->Get_String(section_name,DAZZLE_TEXTURE_STRING);
-		dic.secondary_texture_name=ini->Get_String(section_name,HALO_TEXTURE_STRING);
+		ini->Get_String(dic.primary_texture_name,section_name,DAZZLE_TEXTURE_STRING);
+		ini->Get_String(dic.secondary_texture_name,section_name,HALO_TEXTURE_STRING);
 		dic.halo_intensity=ini->Get_Float(section_name,HALO_INTENSITY_STRING,0.95f);
 		dic.halo_intensity_pow=ini->Get_Float(section_name,HALO_INTENSITY_POW_STRING,0.95f);
 		dic.halo_size_pow=ini->Get_Float(section_name,HALO_SIZE_POW_STRING,0.95f);
@@ -633,7 +633,7 @@ void DazzleRenderObjClass::Init_From_INI(const INIClass* ini)
 		dic.size_optimization_limit=ini->Get_Float(section_name,SIZE_OPTIMIZATION_LIMIT_STRING,0.05f);
 		dic.history_weight=ini->Get_Float(section_name,HISTORY_WEIGHT_STRING,0.5f);
 		dic.use_camera_translation=!!ini->Get_Int(section_name,USE_CAMERA_TRANSLATION,1);
-		dic.lensflare_name=ini->Get_String(section_name,DAZZLE_LENSFLARE_STRING);
+		ini->Get_String(dic.lensflare_name,section_name,DAZZLE_LENSFLARE_STRING);
 		dic.type=entry;
 
 		TPoint3D<float> tp=ini->Get_Point(section_name,DAZZLE_DIRECTION_STRING,TPoint3D<float>(0.0f,0.0f,0.0f));

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/CMakeLists.txt
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/CMakeLists.txt
@@ -9,6 +9,7 @@ set(WWLIB_SRC
     cpudetect.cpp
     crc.cpp
     cstraw.cpp
+    Except.cpp
     ffactory.cpp
     gcd_lcm.cpp
     hash.cpp

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/Except.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/Except.cpp
@@ -1,0 +1,1315 @@
+/*
+**	Command & Conquer Generals Zero Hour(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/***********************************************************************************************
+ ***              C O N F I D E N T I A L  ---  W E S T W O O D  S T U D I O S               ***
+ ***********************************************************************************************
+ *                                                                                             *
+ *                 Project Name : Command & Conquer                                            *
+ *                                                                                             *
+ *                     $Archive:: /Commando/Code/wwlib/Except.cpp                             $*
+ *                                                                                             *
+ *                      $Author:: Steve_t                                                     $*
+ *                                                                                             *
+ *                     $Modtime:: 2/07/02 12:28p                                              $*
+ *                                                                                             *
+ *                    $Revision:: 14                                                          $*
+ *                                                                                             *
+ *---------------------------------------------------------------------------------------------*
+ *                                                                                             *
+ *                                                                                             *
+ *                                                                                             *
+ *                                                                                             *
+ *                                                                                             *
+ *                                                                                             *
+ *---------------------------------------------------------------------------------------------*
+ * Functions:                                                                                  *
+ *                                                                                             *
+ * Exception_Proc -- Windows dialog callback for the exception dialog                          *
+ * Exception_Dialog -- Brings up the exception options dialog.                                 *
+ * Add_Txt -- Add the given text to the machine state dump buffer.                             *
+ * Dump_Exception_Info -- Dump machine state information into a buffer                         *
+ * Exception_Handler -- Exception handler filter function                                      *
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+#ifdef _MSC_VER
+
+#include	"always.h"
+#include <windows.h>
+#include	"assert.h"
+#include "cpudetect.h"
+#include	"Except.h"
+//#include "debug.h"
+#include "MPU.H"
+//#include "commando\nat.h"
+#include "thread.h"
+#include "wwdebug.h"
+#include "wwmemlog.h"
+
+#include	<conio.h>
+#include	<imagehlp.h>
+#include <crtdbg.h>
+#include	<stdio.h>
+
+#ifdef WWDEBUG
+#define DebugString 	WWDebug_Printf
+#else
+void DebugString(char const *, ...){};
+#endif //WWDEBUG
+
+/*
+** Enable this define to get the 'demo timed out' message on a crash or assert failure.
+*/
+//#define DEMO_TIME_OUT
+
+/*
+** Buffer to dump machine state information to. We don't want to allocate this at run-time
+** in case the exception was caused by a malfunction in the memory system.
+*/
+static char ExceptionText [65536];
+
+bool SymbolsAvailable = false;
+HINSTANCE ImageHelp = (HINSTANCE) -1;
+
+void (*AppCallback)(void) = NULL;
+char *(*AppVersionCallback)(void) = NULL;
+
+/*
+** Flag to indicate we should exit when an exception occurs.
+*/
+bool ExitOnException = false;
+bool TryingToExit = false;
+
+/*
+** Register dump variables. These are used to allow the game to restart from an arbitrary
+** position after an exception occurs.
+*/
+unsigned long ExceptionReturnStack = 0;
+unsigned long ExceptionReturnAddress = 0;
+unsigned long ExceptionReturnFrame = 0;
+
+/*
+** Number of times the exception handler has recursed. Recursions are bad.
+*/
+int ExceptionRecursions = -1;
+
+/*
+** List of threads that the exception handler knows about.
+*/
+DynamicVectorClass<ThreadInfoType*> ThreadList;
+
+/*
+** Definitions to allow run-time linking to the Imagehlp.dll functions.
+**
+*/
+typedef BOOL  (WINAPI *SymCleanupType) (HANDLE hProcess);
+typedef BOOL  (WINAPI *SymGetSymFromAddrType) (HANDLE hProcess, DWORD Address, LPDWORD Displacement, PIMAGEHLP_SYMBOL Symbol);
+typedef BOOL  (WINAPI *SymInitializeType) (HANDLE hProcess, LPSTR UserSearchPath, BOOL fInvadeProcess);
+typedef BOOL  (WINAPI *SymLoadModuleType) (HANDLE hProcess, HANDLE hFile, LPSTR ImageName, LPSTR ModuleName, DWORD BaseOfDll, DWORD SizeOfDll);
+typedef DWORD (WINAPI *SymSetOptionsType) (DWORD SymOptions);
+typedef BOOL  (WINAPI *SymUnloadModuleType) (HANDLE hProcess, DWORD BaseOfDll);
+typedef BOOL  (WINAPI *StackWalkType) (DWORD MachineType, HANDLE hProcess, HANDLE hThread, LPSTACKFRAME StackFrame, LPVOID ContextRecord, PREAD_PROCESS_MEMORY_ROUTINE ReadMemoryRoutine, PFUNCTION_TABLE_ACCESS_ROUTINE FunctionTableAccessRoutine, PGET_MODULE_BASE_ROUTINE GetModuleBaseRoutine, PTRANSLATE_ADDRESS_ROUTINE TranslateAddress);
+typedef LPVOID (WINAPI *SymFunctionTableAccessType) (HANDLE hProcess, DWORD AddrBase);
+typedef DWORD (WINAPI *SymGetModuleBaseType) (HANDLE hProcess, DWORD dwAddr);
+
+
+static SymCleanupType							_SymCleanup = NULL;
+static SymGetSymFromAddrType				_SymGetSymFromAddr = NULL;
+static SymInitializeType						_SymInitialize = NULL;
+static SymLoadModuleType						_SymLoadModule = NULL;
+static SymSetOptionsType						_SymSetOptions = NULL;
+static SymUnloadModuleType					_SymUnloadModule = NULL;
+static StackWalkType								_StackWalk = NULL;
+static SymFunctionTableAccessType	_SymFunctionTableAccess = NULL;
+static SymGetModuleBaseType				_SymGetModuleBase = NULL;
+
+static char const *ImagehelpFunctionNames[] =
+{
+	"SymCleanup",
+	"SymGetSymFromAddr",
+	"SymInitialize",
+	"SymLoadModule",
+	"SymSetOptions",
+	"SymUnloadModule",
+	"StackWalk",
+	"SymFunctionTableAccess",
+	"SymGetModuleBaseType",
+	NULL
+};
+
+
+
+/***********************************************************************************************
+ * _purecall -- This function overrides the C library Pure Virtual Function Call error         *
+ *                                                                                             *
+ *                                                                                             *
+ *                                                                                             *
+ * INPUT:    Nothing                                                                           *
+ *                                                                                             *
+ * OUTPUT:   0 = no error                                                                      *
+ *                                                                                             *
+ * WARNINGS: None                                                                              *
+ *                                                                                             *
+ * HISTORY:                                                                                    *
+ *   8/22/00 11:42AM ST : Created                                                              *
+ *=============================================================================================*/
+int __cdecl _purecall(void)
+{
+	int return_code = 0;
+
+#ifdef WWDEBUG
+	/*
+	** Use int3 to cause an exception.
+	*/
+	WWDEBUG_SAY(("Pure Virtual Function call. Oh No!\n"));
+	WWDEBUG_BREAK
+#endif	//_DEBUG_ASSERT
+
+	return(return_code);
+}
+
+
+
+/***********************************************************************************************
+ * Last_Error_Text -- Get the system error text for GetLastError                                *
+ *                                                                                             *
+ *                                                                                             *
+ *                                                                                             *
+ * INPUT:    Nothing                                                                           *
+ *                                                                                             *
+ * OUTPUT:   Ptr to error string                                                               *
+ *                                                                                             *
+ * WARNINGS: None                                                                              *
+ *                                                                                             *
+ * HISTORY:                                                                                    *
+ *   8/14/98 11:11AM ST : Created                                                              *
+ *=============================================================================================*/
+char const * Last_Error_Text(void)
+{
+	static char message_buffer[256];
+	FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM, NULL, GetLastError(), MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), &message_buffer[0], 256, NULL);
+	return (message_buffer);
+}
+
+
+
+/***********************************************************************************************
+ * Add_Txt -- Add the given text to the machine state dump buffer.                             *
+ *                                                                                             *
+ *                                                                                             *
+ *                                                                                             *
+ * INPUT:    Text                                                                              *
+ *                                                                                             *
+ * OUTPUT:   Nothing                                                                           *
+ *                                                                                             *
+ * WARNINGS: None                                                                              *
+ *                                                                                             *
+ * HISTORY:                                                                                    *
+ *    7/22/97 12:21PM ST : Created                                                             *
+ *=============================================================================================*/
+static void Add_Txt (char const *txt)
+{
+	if (strlen(ExceptionText) + strlen(txt) < 65535) {
+		strcat(ExceptionText, txt);
+	}
+#if (0)
+	/*
+	** Log to debug output too.
+	*/
+	static char _debug_output_txt[512];
+	const char *in = txt;
+	char *out = _debug_output_txt;
+	bool done = false;
+
+	if (strlen(txt) < sizeof(_debug_output_txt)) {
+		for (int i=0 ; i<sizeof(_debug_output_txt) ; i++) {
+
+			switch (*in) {
+				case '\r':
+					in++;
+					continue;
+
+				case 0:
+					done = true;
+					// fall through
+
+				default:
+					*out++ = *in++;
+					break;
+			}
+
+			if (done) {
+				break;
+			}
+		}
+
+		DebugString(_debug_output_txt);
+	}
+#endif //(0)
+}
+
+
+
+/***********************************************************************************************
+ * Dump_Exception_Info -- Dump machine state information into a buffer                         *
+ *                                                                                             *
+ *                                                                                             *
+ *                                                                                             *
+ * INPUT:    ptr to exception information                                                      *
+ *                                                                                             *
+ * OUTPUT:   Nothing                                                                           *
+ *                                                                                             *
+ * WARNINGS: None                                                                              *
+ *                                                                                             *
+ * HISTORY:                                                                                    *
+ *    7/22/97 12:21PM ST : Created                                                             *
+ *=============================================================================================*/
+void Dump_Exception_Info(EXCEPTION_POINTERS *e_info)
+{
+	/*
+	** List of possible exceptions
+	*/
+	static const unsigned int _codes[] = {
+		EXCEPTION_ACCESS_VIOLATION,
+		EXCEPTION_ARRAY_BOUNDS_EXCEEDED,
+		EXCEPTION_BREAKPOINT,
+		EXCEPTION_DATATYPE_MISALIGNMENT,
+		EXCEPTION_FLT_DENORMAL_OPERAND,
+		EXCEPTION_FLT_DIVIDE_BY_ZERO,
+		EXCEPTION_FLT_INEXACT_RESULT,
+		EXCEPTION_FLT_INVALID_OPERATION,
+		EXCEPTION_FLT_OVERFLOW,
+		EXCEPTION_FLT_STACK_CHECK,
+		EXCEPTION_FLT_UNDERFLOW,
+		EXCEPTION_ILLEGAL_INSTRUCTION,
+		EXCEPTION_IN_PAGE_ERROR,
+		EXCEPTION_INT_DIVIDE_BY_ZERO,
+		EXCEPTION_INT_OVERFLOW,
+		EXCEPTION_INVALID_DISPOSITION,
+		EXCEPTION_NONCONTINUABLE_EXCEPTION,
+		EXCEPTION_PRIV_INSTRUCTION,
+		EXCEPTION_SINGLE_STEP,
+		EXCEPTION_STACK_OVERFLOW,
+		0xffffffff
+	};
+
+	/*
+	** Information about each exception type.
+	*/
+	static char const * _code_txt[] = {
+		"Error code: EXCEPTION_ACCESS_VIOLATION\r\r\nDescription: The thread tried to read from or write to a virtual address for which it does not have the appropriate access.",
+		"Error code: EXCEPTION_ARRAY_BOUNDS_EXCEEDED\r\r\nDescription: The thread tried to access an array element that is out of bounds and the underlying hardware supports bounds checking.",
+		"Error code: EXCEPTION_BREAKPOINT\r\r\nDescription: A breakpoint was encountered.",
+		"Error code: EXCEPTION_DATATYPE_MISALIGNMENT\r\r\nDescription: The thread tried to read or write data that is misaligned on hardware that does not provide alignment. For example, 16-bit values must be aligned on 2-byte boundaries; 32-bit values on 4-byte boundaries, and so on.",
+		"Error code: EXCEPTION_FLT_DENORMAL_OPERAND\r\r\nDescription: One of the operands in a floating-point operation is denormal. A denormal value is one that is too small to represent as a standard floating-point value.",
+		"Error code: EXCEPTION_FLT_DIVIDE_BY_ZERO\r\r\nDescription: The thread tried to divide a floating-point value by a floating-point divisor of zero.",
+		"Error code: EXCEPTION_FLT_INEXACT_RESULT\r\r\nDescription: The result of a floating-point operation cannot be represented exactly as a decimal fraction.",
+		"Error code: EXCEPTION_FLT_INVALID_OPERATION\r\r\nDescription: Some strange unknown floating point operation was attempted.",
+		"Error code: EXCEPTION_FLT_OVERFLOW\r\r\nDescription: The exponent of a floating-point operation is greater than the magnitude allowed by the corresponding type.",
+		"Error code: EXCEPTION_FLT_STACK_CHECK\r\r\nDescription: The stack overflowed or underflowed as the result of a floating-point operation.",
+		"Error code: EXCEPTION_FLT_UNDERFLOW\r\r\nDescription:	The exponent of a floating-point operation is less than the magnitude allowed by the corresponding type.",
+		"Error code: EXCEPTION_ILLEGAL_INSTRUCTION\r\r\nDescription:	The thread tried to execute an invalid instruction.",
+		"Error code: EXCEPTION_IN_PAGE_ERROR\r\r\nDescription:	The thread tried to access a page that was not present, and the system was unable to load the page. For example, this exception might occur if a network connection is lost while running a program over the network.",
+		"Error code: EXCEPTION_INT_DIVIDE_BY_ZERO\r\r\nDescription: The thread tried to divide an integer value by an integer divisor of zero.",
+		"Error code: EXCEPTION_INT_OVERFLOW\r\r\nDescription: The result of an integer operation caused a carry out of the most significant bit of the result.",
+		"Error code: EXCEPTION_INVALID_DISPOSITION\r\r\nDescription: An exception handler returned an invalid disposition to the exception dispatcher. Programmers using a high-level language such as C should never encounter this exception.",
+		"Error code: EXCEPTION_NONCONTINUABLE_EXCEPTION\r\r\nDescription: The thread tried to continue execution after a noncontinuable exception occurred.",
+		"Error code: EXCEPTION_PRIV_INSTRUCTION\r\r\nDescription: The thread tried to execute an instruction whose operation is not allowed in the current machine mode.",
+		"Error code: EXCEPTION_SINGLE_STEP\r\r\nDescription: A trace trap or other single-instruction mechanism signaled that one instruction has been executed.",
+		"Error code: EXCEPTION_STACK_OVERFLOW\r\r\nDescription: The thread used up its stack.",
+		"Error code: ?????\r\r\nDescription: Unknown exception."
+	};
+
+	DebugString("Dump exception info\n");
+
+	/*
+	** Scrap buffer for constructing dump strings
+	*/
+	char scrap [256];
+
+	/*
+	** Clear out the dump buffer
+	*/
+	memset(ExceptionText, 0, sizeof (ExceptionText));
+
+	/*
+	** If this is the first time through then fix up the imagehelp function pointers since imagehlp.dll
+	** can't be statically linked.
+	*/
+	HINSTANCE imagehelp = LoadLibrary("IMAGEHLP.DLL");
+
+	if (imagehelp != NULL) {
+		DebugString ("Exception Handler: Found IMAGEHLP.DLL - linking to required functions\n");
+		char const *function_name = NULL;
+		unsigned long *fptr = (unsigned long*) &_SymCleanup;
+		int count = 0;
+
+		do {
+			function_name = ImagehelpFunctionNames[count];
+			if (function_name) {
+				*fptr = (unsigned long) GetProcAddress(imagehelp, function_name);
+				fptr++;
+				count++;
+			}
+		} while (function_name);
+	} else {
+		DebugString("Exception Handler: Unable to load IMAGEHLP.DLL\n");
+	}
+
+
+	/*
+	** Retrieve the programs symbols if they are available
+	*/
+	if (_SymSetOptions != NULL) {
+		_SymSetOptions(SYMOPT_DEFERRED_LOADS);
+	}
+
+	int symload = 0;
+	int symbols_available = false;
+
+	if (_SymInitialize != NULL && _SymInitialize (GetCurrentProcess(), NULL, false))	{
+		DebugString("Exception Handler: Symbols are available\r\n\n");
+		symbols_available = true;
+	}
+
+	if (!symbols_available)	{
+		DebugString ("Exception Handler: SymInitialize failed with code %d - %s\n", GetLastError(), Last_Error_Text());
+	} else {
+		if (_SymSetOptions != NULL) {
+			_SymSetOptions(SYMOPT_DEFERRED_LOADS | SYMOPT_UNDNAME);
+		}
+
+		char module_name[_MAX_PATH];
+		GetModuleFileName(NULL, module_name, sizeof(module_name));
+
+		if (_SymLoadModule != NULL) {
+			symload = _SymLoadModule(GetCurrentProcess(), NULL, module_name, NULL, 0, 0);
+		}
+
+		if (!symload) {
+			assert(_SymLoadModule != NULL);
+			DebugString ("Exception Handler: SymLoad failed for module %s with code %d - %s\n", module_name, GetLastError(), Last_Error_Text());
+		}
+	}
+
+
+	unsigned char symbol [256];
+	unsigned long displacement;
+	IMAGEHLP_SYMBOL *symptr = (IMAGEHLP_SYMBOL*)&symbol;
+
+	/*
+	** Get the exception address and the machine context at the time of the exception
+	*/
+	CONTEXT *context = e_info->ContextRecord;
+
+	/*
+	** The following are set for access violation only
+	*/
+	int access_read_write=-1;
+	unsigned long access_address = 0;
+
+	if (e_info->ExceptionRecord->ExceptionCode == EXCEPTION_ACCESS_VIOLATION) {
+		DebugString("Exception Handler: Exception is access violation\n");
+		access_read_write = e_info->ExceptionRecord->ExceptionInformation[0];  // 0=read, 1=write
+		access_address = e_info->ExceptionRecord->ExceptionInformation[1];
+	} else {
+		DebugString ("Exception Handler: Exception code is %d\n", e_info->ExceptionRecord->ExceptionCode);
+	}
+
+	/*
+	** Match the exception type with the error string and print it out
+	*/
+	int i=0;
+	for (; _codes[i] != 0xffffffff ; i++) {
+		if (_codes[i] == e_info->ExceptionRecord->ExceptionCode) {
+			DebugString("Exception Handler: Found exception description\n");
+			break;
+		}
+	}
+	Add_Txt(_code_txt[i]);
+	Add_Txt("\r\n");
+
+	/*
+	** For access violations, print out the violation address and if it was read or write.
+	*/
+	if (e_info->ExceptionRecord->ExceptionCode == EXCEPTION_ACCESS_VIOLATION) {
+		sprintf(scrap, "Access address:%08X ", access_address);
+		Add_Txt(scrap);
+		if (access_read_write) {
+			Add_Txt("was written to.\r\n");
+		} else {
+			Add_Txt("was read from.\r\n");
+		}
+	}
+
+
+	/*
+	** If symbols are available, print out the exception eip address and the name of the
+	** function it represents.
+	*/
+	memset(symptr, 0, sizeof (IMAGEHLP_SYMBOL));
+	symptr->SizeOfStruct = sizeof (IMAGEHLP_SYMBOL);
+	symptr->MaxNameLength = 256-sizeof (IMAGEHLP_SYMBOL);
+	symptr->Size = 0;
+	symptr->Address = context->Eip;
+
+	if (!IsBadCodePtr((FARPROC)context->Eip)) {
+		if (_SymGetSymFromAddr != NULL && _SymGetSymFromAddr (GetCurrentProcess(), context->Eip, &displacement, symptr)) {
+			sprintf (scrap, "Exception occurred at %08X - %s + %08X\r\n", context->Eip, symptr->Name, displacement);
+		} else {
+			DebugString ("Exception Handler: Failed to get symbol for EIP\r\n");
+			if (_SymGetSymFromAddr != NULL) {
+				DebugString ("Exception Handler: SymGetSymFromAddr failed with code %d - %s\n", GetLastError(), Last_Error_Text());
+			}
+			sprintf (scrap, "Exception occurred at %08X\r\n", context->Eip);
+		}
+	} else {
+		DebugString ("Exception Handler: context->Eip is bad code pointer\n");
+	}
+
+	Add_Txt (scrap);
+
+	/*
+	** Try to walk the stack. It might work....
+	*/
+	DebugString("Stack walk...\n");
+	Add_Txt("\r\n  Stack walk...\r\n");
+
+	unsigned long return_addresses[256];
+	int num_addresses = Stack_Walk(return_addresses, 256, context);
+
+	if (num_addresses) {
+		for (int s=0 ; s<num_addresses ; s++) {
+			unsigned long temp_addr = return_addresses[s];
+			displacement = 0;
+
+			for (int space = 0 ; space <= s ; space++) {
+				Add_Txt("  ");
+			}
+
+			if (symbols_available) {
+				symptr->SizeOfStruct = sizeof(symbol);
+				symptr->MaxNameLength = 128;
+				symptr->Size = 0;
+				symptr->Address = temp_addr;
+
+				if (_SymGetSymFromAddr != NULL && _SymGetSymFromAddr (GetCurrentProcess(), temp_addr, &displacement, symptr)) {
+					char symbuf[256];
+					sprintf(symbuf, "%s + %08X\r\n", symptr->Name, displacement);
+					Add_Txt(symbuf);
+				}
+			} else {
+				char symbuf[256];
+				sprintf(symbuf, "%08x\r\n", temp_addr);
+				Add_Txt(symbuf);
+			}
+		}
+
+		Add_Txt("\r\n\r\n");
+	} else {
+		DebugString("Stack walk failed!\n");
+		Add_Txt("Stack walk failed!\r\n");
+	}
+
+
+#if (0)	//Don't have this info yet for Renegade.
+	/*
+	** Add in the version info.
+	*/
+	sprintf(scrap, "\r\nVersion %s\r\n", Version_Name());
+	Add_Txt(scrap);
+
+	sprintf(scrap, "Internal Version %s\r\n", VerNum.Version_Name());
+	Add_Txt(scrap);
+
+	char buildinfo[128];
+	buildinfo[0] = 0;
+	Build_Date_String(buildinfo, 128);
+
+	char build_number[128];
+	char build_name[128];
+
+#endif	//(0)
+
+	if (AppVersionCallback) {
+		sprintf(scrap, "%s\r\n\r\n", AppVersionCallback());
+		Add_Txt(scrap);
+	}
+
+	/*
+	** Thread list.
+	*/
+	Add_Txt("Thread list\r\n");
+
+	/*
+	** Get the thread info from ThreadClass.
+	*/
+	for (int thread = 0 ; thread < ThreadList.Count() ; thread++) {
+		sprintf(scrap, "  ID: %08X - %s", ThreadList[thread]->ThreadID, ThreadList[thread]->ThreadName);
+		Add_Txt(scrap);
+		if (GetCurrentThreadId() == ThreadList[thread]->ThreadID) {
+			Add_Txt("   ***CURRENT THREAD***");
+		}
+		Add_Txt("\r\n");
+	}
+
+	/*
+	** CPU type
+	*/
+	sprintf(scrap, "\r\nCPU %s, %d Mhz, Vendor: %s\r\n", (char*)CPUDetectClass::Get_Processor_String(), Get_RDTSC_CPU_Speed(), (char*)CPUDetectClass::Get_Processor_Manufacturer_Name());
+	Add_Txt(scrap);
+
+
+	Add_Txt("\r\nDetails:\r\n");
+
+	DebugString("Register dump...\n");
+
+	/*
+	** Dump the registers.
+	*/
+	sprintf(scrap, "Eip:%08X\tEsp:%08X\tEbp:%08X\r\n", context->Eip, context->Esp, context->Ebp);
+	Add_Txt(scrap);
+	sprintf(scrap, "Eax:%08X\tEbx:%08X\tEcx:%08X\r\n", context->Eax, context->Ebx, context->Ecx);
+	Add_Txt(scrap);
+	sprintf(scrap, "Edx:%08X\tEsi:%08X\tEdi:%08X\r\n", context->Edx, context->Esi, context->Edi);
+	Add_Txt(scrap);
+	sprintf(scrap, "EFlags:%08X \r\n", context->EFlags);
+	Add_Txt(scrap);
+	sprintf(scrap, "CS:%04x  SS:%04x  DS:%04x  ES:%04x  FS:%04x  GS:%04x\r\n", context->SegCs, context->SegSs, context->SegDs, context->SegEs, context->SegFs, context->SegGs);
+	Add_Txt(scrap);
+
+
+	/*
+	** Now the FP registers.
+	*/
+	Add_Txt("\r\nFloating point status\r\n");
+	sprintf(scrap, "     Control word: %08x\r\n", context->FloatSave.ControlWord);
+	Add_Txt(scrap);
+	sprintf(scrap, "      Status word: %08x\r\n", context->FloatSave.StatusWord);
+	Add_Txt(scrap);
+	sprintf(scrap, "         Tag word: %08x\r\n", context->FloatSave.TagWord);
+	Add_Txt(scrap);
+	sprintf(scrap, "     Error Offset: %08x\r\n", context->FloatSave.ErrorOffset);
+	Add_Txt(scrap);
+	sprintf(scrap, "   Error Selector: %08x\r\n", context->FloatSave.ErrorSelector);
+	Add_Txt(scrap);
+	sprintf(scrap, "      Data Offset: %08x\r\n", context->FloatSave.DataOffset);
+	Add_Txt(scrap);
+	sprintf(scrap, "    Data Selector: %08x\r\n", context->FloatSave.DataSelector);
+	Add_Txt(scrap);
+#if !defined(WOW64_SIZE_OF_80387_REGISTERS)
+	sprintf(scrap, "      Cr0NpxState: %08x\r\n", context->FloatSave.Cr0NpxState);
+	Add_Txt(scrap);
+#endif
+
+	for (int fp=0 ; fp<SIZE_OF_80387_REGISTERS / 10 ; fp++) {
+		sprintf(scrap, "ST%d : ", fp);
+		Add_Txt(scrap);
+		for (int b=0 ; b<10 ; b++) {
+			sprintf(scrap, "%02X", context->FloatSave.RegisterArea[(fp*10) + b]);
+			Add_Txt(scrap);
+		}
+
+		void *fp_data_ptr = (void*)(&context->FloatSave.RegisterArea[fp*10]);
+		double fp_value;
+
+		/*
+		** Convert FP dump from temporary real value (10 bytes) to double (8 bytes).
+		*/
+		_asm {
+			push	eax
+			mov	eax,fp_data_ptr
+			fld   tbyte ptr [eax]
+			fstp	qword ptr [fp_value]
+			pop	eax
+		}
+		sprintf(scrap, "   %+#.17e\r\n", fp_value);
+		Add_Txt(scrap);
+	}
+
+	/*
+	** Dump the bytes at EIP. This will make it easier to match the crash address with later versions of the game.
+	*/
+	DebugString("EIP bytes dump...\n");
+	sprintf(scrap, "\r\nBytes at CS:EIP (%08X)  : ", context->Eip);
+
+	unsigned char *eip_ptr = (unsigned char *) (context->Eip);
+	char bytestr[32];
+
+	for (int c = 0 ; c < 32 ; c++) {
+		if (IsBadReadPtr(eip_ptr, 1)) {
+			strcat(scrap, "?? ");
+		} else {
+			sprintf(bytestr, "%02X ", *eip_ptr);
+			strcat(scrap, bytestr);
+		}
+		eip_ptr++;
+	}
+
+	strcat(scrap, "\r\n\r\n");
+	Add_Txt(scrap);
+
+	/*
+	** Dump out the values on the stack.
+	*/
+	DebugString("Stack dump...\n");
+	Add_Txt("Stack dump (* indicates possible code address) :\r\n");
+	unsigned long *stackptr = (unsigned long*) context->Esp;
+
+	for (int j=0 ; j<2048 ; j++) {
+		if (IsBadReadPtr(stackptr, 4)) {
+			/*
+			** The stack contents cannot be read so just print up question marks.
+			*/
+			sprintf(scrap, "%08X: ", stackptr);
+			strcat(scrap, "????????\r\n");
+		} else {
+			/*
+			** If this stack address is in our memory space then try to match it with a code symbol.
+			*/
+			if (IsBadCodePtr((FARPROC)*stackptr)) {
+				sprintf(scrap, "%08X: %08X ", stackptr, *stackptr);
+				strcat(scrap, "DATA_PTR\r\n");
+			} else {
+				sprintf(scrap, "%08X: %08X", stackptr, *stackptr);
+
+				if (symbols_available) {
+					symptr->SizeOfStruct = sizeof(symbol);
+					symptr->MaxNameLength = 128;
+					symptr->Size = 0;
+					symptr->Address = *stackptr;
+
+					if (_SymGetSymFromAddr != NULL && _SymGetSymFromAddr (GetCurrentProcess(), *stackptr, &displacement, symptr)) {
+						char symbuf[256];
+						sprintf(symbuf, " - %s + %08X", symptr->Name, displacement);
+						strcat(scrap, symbuf);
+					}
+				} else {
+					strcat (scrap, " *");
+				}
+				strcat (scrap, "\r\n");
+			}
+		}
+		Add_Txt(scrap);
+		stackptr++;
+	}
+
+	/*
+	** Unload the symbols.
+	*/
+	if (symbols_available) {
+		if (_SymCleanup != NULL) {
+			_SymCleanup (GetCurrentProcess());
+		}
+
+		if (symload) {
+			if (_SymUnloadModule != NULL) {
+				_SymUnloadModule(GetCurrentProcess(), NULL);
+			}
+		}
+
+	}
+
+	if (imagehelp) {
+		FreeLibrary(imagehelp);
+	}
+
+	Add_Txt ("\r\n\r\n");
+}
+
+
+
+
+
+/***********************************************************************************************
+ * Exception_Handler -- Exception handler filter function                                      *
+ *                                                                                             *
+ *                                                                                             *
+ *                                                                                             *
+ * INPUT:    exception code                                                                    *
+ *           pointer to exception information pointers                                         *
+ *                                                                                             *
+ * OUTPUT:   EXCEPTION_EXECUTE_HANDLER -- Excecute the body of the __except construct          *
+ *        or EXCEPTION_CONTINUE_SEARCH -- Pass this exception down to the debugger             *
+ *        or EXCEPTION_CONTINUE_EXECUTION -- Continue to execute at the fault address          *
+ *                                                                                             *
+ * WARNINGS: None                                                                              *
+ *                                                                                             *
+ * HISTORY:                                                                                    *
+ *    7/22/97 12:29PM ST : Created                                                              *
+ *=============================================================================================*/
+int Exception_Handler(int exception_code, EXCEPTION_POINTERS *e_info)
+{
+	DebugString("Exception!\n");
+
+#ifdef DEMO_TIME_OUT
+	if ( !WindowedMode ) {
+		Load_Title_Page("TITLE.PCX", true);
+		MouseCursor->Release_Mouse();
+		MessageBox(MainWindow, "This demo has timed out. Thank you for playing Red Alert 2.","Byeee!", MB_ICONEXCLAMATION|MB_OK);
+		return (EXCEPTION_EXECUTE_HANDLER);
+	}
+#endif	//DEMO_TIME_OUT
+
+	/*
+	** If we were trying to quit and we got another exception then just shut down the whole shooting match right here.
+	*/
+	if (TryingToExit) {
+		ExitProcess(0);
+	}
+
+	/*
+	** Track recursions because we need to know if something here is failing.
+	*/
+	ExceptionRecursions++;
+
+	if (ExceptionRecursions > 1) {
+		return (EXCEPTION_CONTINUE_SEARCH);
+	}
+
+	/*
+	** If there was a breakpoint then chances are it was set by a debugger. In _DEBUG mode
+	** we probably should ignore breakpoints. Breakpoints become more significant in release
+	** mode since there probably isn't a debugger present.
+	*/
+#ifdef _DEBUG
+	if (exception_code == EXCEPTION_BREAKPOINT) {
+		return (EXCEPTION_CONTINUE_SEARCH);
+	}
+#else
+	exception_code = exception_code;
+#endif	//_DEBUG
+
+#ifdef WWDEBUG
+	//CONTEXT *context;
+#endif // WWDEBUG
+
+	if (ExceptionRecursions == 0) {
+
+		/*
+		** Create a dump of the exception info.
+		*/
+		Dump_Exception_Info(e_info);
+
+		/*
+		** Log the machine state to disk
+		*/
+		HANDLE debug_file;
+		DWORD	actual;
+		debug_file = CreateFile("_except.txt", GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+		if (debug_file != INVALID_HANDLE_VALUE){
+			WriteFile(debug_file, ExceptionText, strlen(ExceptionText), &actual, NULL);
+			CloseHandle (debug_file);
+
+#if (0)
+#ifdef _DEBUG_PRINT
+#ifndef _DEBUG
+			/*
+			** Copy the exception debug file to the network. No point in doing this for the debug version
+			** since symbols are not normally available.
+			*/
+			DebugString ("About to copy debug file\n");
+			char filename[512];
+			if (Get_Global_Output_File_Name ("EXCEPT", filename, 512)) {
+				DebugString ("Copying DEBUG.TXT to %s\n", filename);
+				int result = CopyFile("debug.txt", filename, false);
+				if (result == 0) {
+					DebugString ("CopyFile failed with error code %d - %s\n", GetLastError(), Last_Error_Text());
+				}
+			}
+			DebugString ("Debug file copied\n");
+#endif	//_DEBUG
+#endif	//_DEBUG_PRINT
+#endif	//(0)
+
+		}
+	}
+
+	/*
+	** Call the apps callback function.
+	*/
+	if (AppCallback) {
+		AppCallback();
+	}
+
+	/*
+	** If an exit is required then turn of memory leak reporting (there will be lots of them) and use
+	** EXCEPTION_EXECUTE_HANDLER to let us fall out of winmain.
+	*/
+	if (ExitOnException) {
+#ifdef _DEBUG
+		_CrtSetDbgFlag(0);
+#endif //_DEBUG
+		TryingToExit = true;
+
+		unsigned long id = Get_Main_Thread_ID();
+		if (id != GetCurrentThreadId()) {
+			DebugString("Exiting due to exception in sub thread\n");
+			ExitProcess(EXIT_SUCCESS);
+		}
+
+		return(EXCEPTION_EXECUTE_HANDLER);
+
+	}
+	return (EXCEPTION_CONTINUE_SEARCH);
+}
+
+
+
+
+/***********************************************************************************************
+ * Register_Thread_ID -- Let the exception handler know about a thread                         *
+ *                                                                                             *
+ *                                                                                             *
+ *                                                                                             *
+ * INPUT:    Thread ID                                                                         *
+ *           Thread name                                                                       *
+ *                                                                                             *
+ * OUTPUT:   Nothing                                                                           *
+ *                                                                                             *
+ * WARNINGS: None                                                                              *
+ *                                                                                             *
+ * HISTORY:                                                                                    *
+ *   8/30/2001 3:04PM ST : Created                                                             *
+ *=============================================================================================*/
+void Register_Thread_ID(unsigned long thread_id, char *thread_name, bool main_thread)
+{
+	WWMEMLOG(MEM_GAMEDATA);
+	if (thread_name) {
+
+		/*
+		** See if we already know about this thread. Maybe just the thread_id changed.
+		*/
+		for (int i=0 ; i<ThreadList.Count() ; i++) {
+			if (strcmp(thread_name, ThreadList[i]->ThreadName) == 0) {
+				ThreadList[i]->ThreadID = thread_id;
+				return;
+			}
+		}
+
+		ThreadInfoType *thread = new ThreadInfoType;
+		thread->ThreadID = thread_id;
+		strcpy(thread->ThreadName, thread_name);
+		thread->Main = main_thread;
+		thread->ThreadHandle = INVALID_HANDLE_VALUE;
+		ThreadList.Add(thread);
+	}
+}
+
+
+#if (0)
+/***********************************************************************************************
+ * Register_Thread_Handle -- Keep a copy of the thread handle that matches this thread ID      *
+ *                                                                                             *
+ *                                                                                             *
+ *                                                                                             *
+ * INPUT:    Thread ID                                                                         *
+ *           Thread handle                                                                     *
+ *                                                                                             *
+ * OUTPUT:   True if thread ID was matched                                                     *
+ *                                                                                             *
+ * WARNINGS:                                                                                   *
+ *                                                                                             *
+ * HISTORY:                                                                                    *
+ *   2/6/2002 9:40PM ST : Created                                                              *
+ *=============================================================================================*/
+bool Register_Thread_Handle(unsigned long thread_id, HANDLE thread_handle)
+{
+	for (int i=0 ; i<ThreadList.Count() ; i++) {
+		if (ThreadList[i]->ThreadID == thread_id) {
+			ThreadList[i]->ThreadHandle = thread_handle;
+			return(true);
+			break;
+		}
+	}
+	return(false);
+}
+
+
+
+/***********************************************************************************************
+ * Get_Num_Threads -- Get the number of threads being tracked.                                 *
+ *                                                                                             *
+ *                                                                                             *
+ *                                                                                             *
+ * INPUT:    Nothing                                                                           *
+ *                                                                                             *
+ * OUTPUT:   Number of threads we know about                                                   *
+ *                                                                                             *
+ * WARNINGS: None                                                                              *
+ *                                                                                             *
+ * HISTORY:                                                                                    *
+ *   2/6/2002 9:43PM ST : Created                                                              *
+ *=============================================================================================*/
+int Get_Num_Threads(void)
+{
+	return(ThreadList.Count());
+}
+
+
+/***********************************************************************************************
+ * Get_Thread_Handle -- Get the handle for the given thread index                              *
+ *                                                                                             *
+ *                                                                                             *
+ *                                                                                             *
+ * INPUT:    Thread index                                                                      *
+ *                                                                                             *
+ * OUTPUT:   Thread handle                                                                     *
+ *                                                                                             *
+ * WARNINGS: None                                                                              *
+ *                                                                                             *
+ * HISTORY:                                                                                    *
+ *   2/6/2002 9:46PM ST : Created                                                              *
+ *=============================================================================================*/
+HANDLE Get_Thread_Handle(int thread_index)
+{
+	if (thread_index < ThreadList.Count()) {
+		return(ThreadList[thread_index]->ThreadHandle);
+	}
+}
+#endif //(0)
+
+/***********************************************************************************************
+ * Unregister_Thread_ID -- Remove a thread entry from the thread list                          *
+ *                                                                                             *
+ *                                                                                             *
+ *                                                                                             *
+ * INPUT:    Thread ID                                                                         *
+ *           Thread name                                                                       *
+ *                                                                                             *
+ * OUTPUT:   Nothing                                                                           *
+ *                                                                                             *
+ * WARNINGS: None                                                                              *
+ *                                                                                             *
+ * HISTORY:                                                                                    *
+ *   8/30/2001 3:10PM ST : Created                                                             *
+ *=============================================================================================*/
+void Unregister_Thread_ID(unsigned long thread_id, char *thread_name)
+{
+	for (int i=0 ; i<ThreadList.Count() ; i++) {
+		if (strcmp(thread_name, ThreadList[i]->ThreadName) == 0) {
+			assert(ThreadList[i]->ThreadID == thread_id);
+			delete ThreadList[i];
+			ThreadList.Delete(i);
+			return;
+		}
+	}
+}
+
+
+
+/***********************************************************************************************
+ * Get_Main_Thread_ID -- Get the ID of the processes main thread                               *
+ *                                                                                             *
+ *                                                                                             *
+ *                                                                                             *
+ * INPUT:    Nothing                                                                           *
+ *                                                                                             *
+ * OUTPUT:   Thread ID                                                                         *
+ *                                                                                             *
+ * WARNINGS: None                                                                              *
+ *                                                                                             *
+ * HISTORY:                                                                                    *
+ *   12/6/2001 12:20PM ST : Created                                                            *
+ *=============================================================================================*/
+unsigned long Get_Main_Thread_ID(void)
+{
+	for (int i=0 ; i<ThreadList.Count() ; i++) {
+		if (ThreadList[i]->Main) {
+			return(ThreadList[i]->ThreadID);
+		}
+	}
+	return(0);
+}
+
+
+
+
+
+
+/***********************************************************************************************
+ * Load_Image_Helper -- Load imagehlp.dll and retrieve the programs symbols                    *
+ *                                                                                             *
+ *                                                                                             *
+ *                                                                                             *
+ * INPUT:    Nothing                                                                           *
+ *                                                                                             *
+ * OUTPUT:   Nothing                                                                           *
+ *                                                                                             *
+ * WARNINGS: None                                                                              *
+ *                                                                                             *
+ * HISTORY:                                                                                    *
+ *   6/12/2001 4:27PM ST : Created                                                             *
+ *=============================================================================================*/
+void Load_Image_Helper(void)
+{
+	/*
+	** If this is the first time through then fix up the imagehelp function pointers since imagehlp.dll
+	** can't be statically linked.
+	*/
+	if (ImageHelp == (HINSTANCE)-1) {
+		ImageHelp = LoadLibrary("IMAGEHLP.DLL");
+
+		if (ImageHelp != NULL) {
+			char const *function_name = NULL;
+			unsigned long *fptr = (unsigned long *) &_SymCleanup;
+			int count = 0;
+
+			do {
+				function_name = ImagehelpFunctionNames[count];
+				if (function_name) {
+					*fptr = (unsigned long) GetProcAddress(ImageHelp, function_name);
+					fptr++;
+					count++;
+				}
+			}
+			while (function_name);
+		}
+
+		/*
+		** Retrieve the programs symbols if they are available. This can be a .pdb or a .dbg file.
+		*/
+		if (_SymSetOptions != NULL) {
+			_SymSetOptions(SYMOPT_DEFERRED_LOADS);
+		}
+
+		int symload = 0;
+
+		if (_SymInitialize != NULL && _SymInitialize(GetCurrentProcess(), NULL, FALSE)) {
+
+			if (_SymSetOptions != NULL) {
+				_SymSetOptions(SYMOPT_DEFERRED_LOADS | SYMOPT_UNDNAME);
+			}
+
+			char exe_name[_MAX_PATH];
+			GetModuleFileName(NULL, exe_name, sizeof(exe_name));
+
+			if (_SymLoadModule != NULL) {
+				symload = _SymLoadModule(GetCurrentProcess(), NULL, exe_name, NULL, 0, 0);
+			}
+
+			if (symload) {
+				SymbolsAvailable = true;
+			} else {
+				//assert (_SymLoadModule != NULL);
+				//DebugString ("SymLoad failed for module %s with code %d - %s\n", szModuleName, GetLastError(), Last_Error_Text());
+			}
+		}
+	}
+}
+
+
+
+
+
+
+
+/***********************************************************************************************
+ * Lookup_Symbol -- Get the symbol for a given code address                                    *
+ *                                                                                             *
+ *                                                                                             *
+ *                                                                                             *
+ * INPUT:    Address of code to get symbol for                                                 *
+ *           Ptr to buffer to return symbol in                                                 *
+ *           Reference to int to return displacement                                           *
+ *                                                                                             *
+ * OUTPUT:   True if symbol found                                                              *
+ *                                                                                             *
+ * WARNINGS: None                                                                              *
+ *                                                                                             *
+ * HISTORY:                                                                                    *
+ *   6/12/2001 4:47PM ST : Created                                                             *
+ *=============================================================================================*/
+bool Lookup_Symbol(void *code_ptr, char *symbol, int &displacement)
+{
+	/*
+	** Locals.
+	*/
+	char symbol_struct_buf[1024];
+	IMAGEHLP_SYMBOL *symbol_struct_ptr = (IMAGEHLP_SYMBOL *)symbol_struct_buf;
+
+	/*
+	** Set default values in case of early exit.
+	*/
+	displacement = 0;
+	*symbol = '\0';
+
+	/*
+	** Make sure symbols are available.
+	*/
+	if (!SymbolsAvailable || _SymGetSymFromAddr == NULL) {
+		return(false);
+	}
+
+	/*
+	** If it's a bad code pointer then there is no point in trying to match it with a symbol.
+	*/
+	if (IsBadCodePtr((FARPROC)code_ptr)) {
+		strcpy(symbol, "Bad code pointer");
+		return(false);
+	}
+
+	/*
+	** Set up the parameters for the call to SymGetSymFromAddr
+	*/
+	memset (symbol_struct_ptr, 0, sizeof (symbol_struct_buf));
+	symbol_struct_ptr->SizeOfStruct = sizeof (symbol_struct_buf);
+	symbol_struct_ptr->MaxNameLength = sizeof(symbol_struct_buf)-sizeof (IMAGEHLP_SYMBOL);
+	symbol_struct_ptr->Size = 0;
+	symbol_struct_ptr->Address = (unsigned long)code_ptr;
+
+	/*
+	** See if we have the symbol for that address.
+	*/
+	if (_SymGetSymFromAddr(GetCurrentProcess(), (unsigned long)code_ptr, (unsigned long *)&displacement, symbol_struct_ptr)) {
+
+		/*
+		** Copy it back into the buffer provided.
+		*/
+		strcpy(symbol, symbol_struct_ptr->Name);
+		return(true);
+	}
+	return(false);
+}
+
+
+
+
+/***********************************************************************************************
+ * Stack_Walk -- Walk the stack and get the last n return addresses                            *
+ *                                                                                             *
+ *                                                                                             *
+ *                                                                                             *
+ * INPUT:    Ptr to return address list                                                        *
+ *           Number of return addresses to fetch                                               *
+ *           Ptr to optional context. NULL means use current                                   *
+ *                                                                                             *
+ * OUTPUT:   Number of return addresses found                                                  *
+ *                                                                                             *
+ * WARNINGS: None                                                                              *
+ *                                                                                             *
+ * HISTORY:                                                                                    *
+ *   6/12/2001 11:57AM ST : Created                                                            *
+ *=============================================================================================*/
+int Stack_Walk(unsigned long *return_addresses, int num_addresses, CONTEXT *context)
+{
+	static HINSTANCE _imagehelp = (HINSTANCE) -1;
+
+	/*
+	** If this is the first time through then fix up the imagehelp function pointers since imagehlp.dll
+	** can't be statically linked.
+	*/
+	if (ImageHelp == (HINSTANCE)-1) {
+		Load_Image_Helper();
+	}
+
+	/*
+	** If there is no debug support .dll available then we can't walk the stack.
+	*/
+	if (ImageHelp == NULL) {
+		return(0);
+	}
+
+	/*
+	** Set up the stack frame structure for the start point of the stack walk (i.e. here).
+	*/
+	STACKFRAME stack_frame;
+	memset(&stack_frame, 0, sizeof(stack_frame));
+
+	unsigned long reg_eip, reg_ebp, reg_esp;
+
+	__asm {
+here:
+		lea	eax,here
+		mov	reg_eip,eax
+		mov	reg_ebp,ebp
+		mov	reg_esp,esp
+	}
+
+	stack_frame.AddrPC.Mode = AddrModeFlat;
+	stack_frame.AddrPC.Offset = reg_eip;
+	stack_frame.AddrStack.Mode = AddrModeFlat;
+	stack_frame.AddrStack.Offset = reg_esp;
+	stack_frame.AddrFrame.Mode = AddrModeFlat;
+	stack_frame.AddrFrame.Offset = reg_ebp;
+
+	/*
+	** Use the context struct if it was provided.
+	*/
+	if (context) {
+		stack_frame.AddrPC.Offset = context->Eip;
+		stack_frame.AddrStack.Offset = context->Esp;
+		stack_frame.AddrFrame.Offset = context->Ebp;
+	}
+
+	int pointer_index = 0;
+
+	/*
+	** Walk the stack by the requested number of return address iterations.
+	*/
+	for (int i = 0; i < num_addresses + 1; i++) {
+		if (_StackWalk(IMAGE_FILE_MACHINE_I386, GetCurrentProcess(), GetCurrentThread(), &stack_frame, NULL, NULL, _SymFunctionTableAccess, _SymGetModuleBase, NULL)) {
+
+			/*
+			** First result will always be the return address we were called from.
+			*/
+			if (i==0 && context == NULL) {
+				continue;
+			}
+			unsigned long return_address = stack_frame.AddrReturn.Offset;
+			return_addresses[pointer_index++] = return_address;
+		} else {
+			break;
+		}
+	}
+
+	return(pointer_index);
+}
+
+
+
+void Register_Application_Exception_Callback(void (*app_callback)(void))
+{
+	AppCallback = app_callback;
+}
+
+void Register_Application_Version_Callback(char *(*app_ver_callback)(void))
+{
+	AppVersionCallback = app_ver_callback;
+}
+
+
+
+void Set_Exit_On_Exception(bool set)
+{
+	ExitOnException = true;
+}
+
+bool Is_Trying_To_Exit(void)
+{
+	return(TryingToExit);
+}
+
+
+
+
+#endif	//_MSC_VER
+
+
+
+

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/Except.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/Except.h
@@ -1,5 +1,5 @@
 /*
-**	Command & Conquer Generals(tm)
+**	Command & Conquer Generals Zero Hour(tm)
 **	Copyright 2025 Electronic Arts Inc.
 **
 **	This program is free software: you can redistribute it and/or modify
@@ -22,40 +22,67 @@
  *                                                                                             *
  *                 Project Name : Command & Conquer                                            *
  *                                                                                             *
- *                     $Archive:: /Commando/Code/wwlib/stimer.cpp                             $*
+ *                     $Archive:: /Commando/Code/wwlib/Except.h                               $*
  *                                                                                             *
  *                      $Author:: Steve_t                                                     $*
  *                                                                                             *
- *                     $Modtime:: 12/09/01 6:42p                                              $*
+ *                     $Modtime:: 2/07/02 12:28p                                              $*
  *                                                                                             *
- *                    $Revision:: 4                                                           $*
+ *                    $Revision:: 6                                                           $*
  *                                                                                             *
  *---------------------------------------------------------------------------------------------*
  * Functions:                                                                                  *
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-#include	"always.h"
-#include	"stimer.h"
-#include	"win.h"
+#pragma once
+
+#ifndef EXCEPT_H
+#define EXCEPT_H
 
 #ifdef _MSC_VER
-#pragma warning (push,3)
-#endif
 
-#include "systimer.h"
+#include "win.h"
+/*
+** Forward Declarations
+*/
+typedef struct _EXCEPTION_POINTERS EXCEPTION_POINTERS;
+typedef struct _CONTEXT CONTEXT;
 
-#ifdef _MSC_VER
-#pragma warning (pop)
-#endif
+int Exception_Handler(int exception_code, EXCEPTION_POINTERS *e_info);
+int Stack_Walk(unsigned long *return_addresses, int num_addresses, CONTEXT *context = NULL);
+bool Lookup_Symbol(void *code_ptr, char *symbol, int &displacement);
+void Load_Image_Helper(void);
+void Register_Thread_ID(unsigned long thread_id, char *thread_name, bool main = false);
+void Unregister_Thread_ID(unsigned long thread_id, char *thread_name);
+void Register_Application_Exception_Callback(void (*app_callback)(void));
+void Register_Application_Version_Callback(char *(*app_version_callback)(void));
+void Set_Exit_On_Exception(bool set);
+bool Is_Trying_To_Exit(void);
+unsigned long Get_Main_Thread_ID(void);
+#if (0)
+bool Register_Thread_Handle(unsigned long thread_id, HANDLE thread_handle);
+int Get_Num_Thread(void);
+HANDLE Get_Thread_Handle(int thread_index);
+#endif //(0)
+
+/*
+** Register dump variables. These are used to allow the game to restart from an arbitrary
+** position after an exception occurs.
+*/
+extern unsigned long ExceptionReturnStack;
+extern unsigned long ExceptionReturnAddress;
+extern unsigned long ExceptionReturnFrame;
 
 
-long SystemTimerClass::operator () (void) const
-{
-	return TIMEGETTIME()/16;
-}
+typedef struct tThreadInfoType {
+	char				ThreadName[128];
+	unsigned long	ThreadID;
+	HANDLE			ThreadHandle;
+	bool				Main;
+} ThreadInfoType;
 
 
-SystemTimerClass::operator long (void) const
-{
-	return TIMEGETTIME()/16;
-}
+
+#endif	//_MSC_VER
+
+#endif	//EXCEPT_H

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/INI.H
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/INI.H
@@ -22,23 +22,26 @@
  *                                                                                             *
  *                 Project Name : Command & Conquer                                            *
  *                                                                                             *
- *                     $Archive:: /VSS_Sync/wwlib/ini.h                                       $*
+ *                     $Archive:: /Commando/Code/wwlib/ini.h                                  $*
  *                                                                                             *
- *                      $Author:: Vss_sync                                                    $*
+ *                      $Author:: Steve_t                                                     $*
  *                                                                                             *
- *                     $Modtime:: 3/21/01 12:01p                                              $*
+ *                     $Modtime:: 11/14/01 1:32a                                              $*
  *                                                                                             *
- *                    $Revision:: 12                                                          $*
+ *                    $Revision:: 16                                                          $*
  *                                                                                             *
  *---------------------------------------------------------------------------------------------*
  * Functions:                                                                                  *
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
 #if _MSC_VER >= 1000
 #pragma once
 #endif // _MSC_VER >= 1000
 
 #ifndef INI_H
 #define INI_H
+
+#include <wchar.h>
 
 //#include	"listnode.h"
 //#include	"trect.h"
@@ -53,6 +56,7 @@ class FileClass;
 class Straw;
 class Pipe;
 class StringClass;
+class WideStringClass;
 class FileFactoryClass;
 
 struct INISection;
@@ -81,6 +85,16 @@ class INIClass {
 		virtual ~INIClass(void);
 
 		/*
+		** This setting allows you to control the behavior of loading blank entries.
+		** If you set this to true, a blank entry (ie. "foo=") will be loaded with
+		** a value of " ". If set to false, blank entries will be ignored.
+		** The default behavior is to ignore blank entries.
+		** This is a static method, because in general this is an application-level
+		** decision as opposed to a per-ini file decision.
+		*/
+		static void Keep_Blank_Entries(bool keep_blanks);
+
+		/*
 		**	Fetch and store INI data.
 		*/
 		int Load(FileClass & file);
@@ -89,6 +103,11 @@ class INIClass {
 		int Save(FileClass & file) const;
 		int Save(Pipe & file) const;
 		int Save(const char *filename) const;
+
+		/*
+		** Fetch the name of the INI file (if it wasn't created from a Straw).
+		*/
+		const char * Get_Filename(void) const;
 
 		/*
 		**	Erase all data within this INI file manager.
@@ -122,40 +141,51 @@ class INIClass {
 		**	Get the various data types from the section and entry specified.
 		*/
 		bool Get_Bool(char const * section, char const * entry, bool defvalue=false) const;
-		float Get_Float(char const * section, char const * entry, float defvalue=0.0) const;
+		float Get_Float(char const * section, char const * entry, float defvalue=0.0f) const;
+		double Get_Double(char const * section, char const * entry, double defvalue=0.0) const;
 		int Get_Hex(char const * section, char const * entry, int defvalue=0) const;
 		int Get_Int(char const * section, char const * entry, int defvalue=0) const;
 		int Get_String(char const * section, char const * entry, char const * defvalue, char * buffer, int size) const;
-		StringClass Get_String(char const * section, char const * entry, char const * defvalue="") const;
+		const StringClass& Get_String(StringClass& new_string, char const * section, char const * entry, char const * defvalue="") const;
+		const WideStringClass& Get_Wide_String(WideStringClass& new_string, char const * section, char const * entry, wchar_t const * defvalue=L"") const;
 		int Get_List_Index(char const * section, char const * entry, int const defvalue, char *list[]);
 		int *	Get_Alloc_Int_Array(char const * section, char const * entry, int listend);
-		int Get_Int_Bitfield(char const * section, char const * entry, int defvalue, char *list[]); 
+		int Get_Int_Bitfield(char const * section, char const * entry, int defvalue, char *list[]);
 		char *Get_Alloc_String(char const * section, char const * entry, char const * defvalue) const;
 		int Get_TextBlock(char const * section, char * buffer, int len) const;
 		int Get_UUBlock(char const * section, void * buffer, int len) const;
+		int Get_UUBlock(char const * section, char const *entry, void * block, int len) const;
 		TRect<int> const Get_Rect(char const * section, char const * entry, TRect<int> const & defvalue) const;
 		TPoint3D<int> const Get_Point(char const * section, char const * entry, TPoint3D<int> const & defvalue) const;
 		TPoint2D<int> const Get_Point(char const * section, char const * entry, TPoint2D<int> const & defvalue) const;
 		TPoint3D<float> const Get_Point(char const * section, char const * entry, TPoint3D<float> const & defvalue) const;
 		TPoint2D<float> const Get_Point(char const * section, char const * entry, TPoint2D<float> const & defvalue) const;
 
+
+
 		/*
 		**	Put a data type to the section and entry specified.
 		*/
 		bool Put_Bool(char const * section, char const * entry, bool value);
-		bool Put_Float(char const * section, char const * entry, double number);
+		bool Put_Float(char const * section, char const * entry, float number);
+		bool Put_Double(char const * section, char const * entry, double number);
 		bool Put_Hex(char const * section, char const * entry, int number);
 		bool Put_Int(char const * section, char const * entry, int number, int format=0);
 		bool Put_String(char const * section, char const * entry, char const * string);
 		bool Put_TextBlock(char const * section, char const * text);
 		bool Put_UUBlock(char const * section, void const * block, int len);
+		bool Put_UUBlock(char const * section, char const *entry, void const * block, int len);
 		bool Put_Rect(char const * section, char const * entry, TRect<int> const & value);
 		bool Put_Point(char const * section, char const * entry, TPoint3D<int> const & value);
 		bool Put_Point(char const * section, char const * entry, TPoint3D<float> const & value);
 		bool Put_Point(char const * section, char const * entry, TPoint2D<int> const & value);
+		bool Put_Wide_String(char const * section, char const * entry, wchar_t const * string);
 
 //	protected:
-		enum {MAX_LINE_LENGTH=512};
+
+		// Declared here, but assigned a value in ini.cpp. This is done so that we
+		// can change this value in the future without needed to rebuild the entire world.
+		static const int MAX_LINE_LENGTH;
 
 		/*
 		**	Access to the list of all sections within this INI file.
@@ -172,14 +202,14 @@ class INIClass {
 		INIEntry * Find_Entry(char const * section, char const * entry) const;
 		static void Strip_Comments(char * buffer);
 
-		// the CRC function is used to produce hopefully unique values for 
+		// the CRC function is used to produce hopefully unique values for
 		// each of the entries in a section. Debug messages will be produced
 		// if redundant CRCs are generated for a particular INI file.
 		static int CRC(const char *string);
 
 		// the DuplicateCRCError function is used by Put_String and Load in the case
 		// that an entry's CRC matches one already in the database.
-		void DuplicateCRCError(const char *message, const char *entry);
+		void DuplicateCRCError(const char *message, const char *section, const char *entry);
 
 	private:
 
@@ -202,7 +232,15 @@ class INIClass {
 		INIClass(INIClass const & rvalue);
 		INIClass operator = (INIClass const & rvalue);
 
-};
+		/*
+		** The name of the file we were loaded from (if applicable).
+		*/
+		mutable char * Filename;
 
+		/*
+		** The flag used to control the blank entry loading behavior.
+		*/
+		static bool KeepBlankEntries;
+};
 
 #endif

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/LISTNODE.H
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/LISTNODE.H
@@ -22,13 +22,13 @@
  *                                                                                             *
  *                 Project Name : Command & Conquer                                            *
  *                                                                                             *
- *                     $Archive:: /G/wwlib/listnode.h                                         $*
+ *                     $Archive:: /Commando/Code/wwlib/listnode.h                             $*
  *                                                                                             *
- *                      $Author:: David_m                                                     $*
+ *                      $Author:: Ian_l                                                       $*
  *                                                                                             *
- *                     $Modtime:: 4/05/00 12:34p                                              $*
+ *                     $Modtime:: 9/20/01 9:46p                                               $*
  *                                                                                             *
- *                    $Revision:: 3                                                           $*
+ *                    $Revision:: 4                                                           $*
  *                                                                                             *
  *---------------------------------------------------------------------------------------------*
  * Functions:                                                                                  *
@@ -213,6 +213,7 @@ class List : public GenericList {
 		List(List<T> const & rvalue);
 		List<T> operator = (List<T> const & rvalue);
 };
+
 
 /*
 

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/RAMFILE.H
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/RAMFILE.H
@@ -22,13 +22,13 @@
  *                                                                                             * 
  *                 Project Name : Command & Conquer                                            * 
  *                                                                                             * 
- *                     $Archive:: /Commando/Library/RAMFILE.H                                 $* 
+ *                     $Archive:: /Commando/Code/wwlib/ramfile.h                              $* 
  *                                                                                             * 
- *                      $Author:: Greg_h                                                      $*
+ *                      $Author:: Ian_l                                                       $*
  *                                                                                             * 
- *                     $Modtime:: 7/22/97 11:37a                                              $*
+ *                     $Modtime:: 10/31/01 2:02p                                              $*
  *                                                                                             * 
- *                    $Revision:: 1                                                           $*
+ *                    $Revision:: 2                                                           $*
  *                                                                                             *
  *---------------------------------------------------------------------------------------------* 
  * Functions:                                                                                  * 
@@ -62,6 +62,7 @@ class RAMFileClass : public FileClass
 		virtual unsigned long Get_Date_Time(void) {return(0);}
 		virtual bool Set_Date_Time(unsigned long ) {return(true);}
 		virtual void Error(int , int = false, char const * =NULL) {}
+		virtual void Bias(int start, int length=-1);
 
 		operator char const * () {return File_Name();}
 

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/RAWFILE.H
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/RAWFILE.H
@@ -22,13 +22,13 @@
  *                                                                                             * 
  *                 Project Name : Command & Conquer                                            * 
  *                                                                                             * 
- *                     $Archive:: /G/wwlib/rawfile.h                                          $* 
+ *                     $Archive:: /Commando/Code/wwlib/rawfile.h                              $* 
  *                                                                                             * 
- *                      $Author:: Neal_k                                                      $*
+ *                      $Author:: Jani_p                                                      $*
  *                                                                                             * 
- *                     $Modtime:: 10/04/99 10:25a                                             $*
+ *                     $Modtime:: 11/25/01 11:52a                                             $*
  *                                                                                             * 
- *                    $Revision:: 8                                                           $*
+ *                    $Revision:: 10                                                          $*
  *                                                                                             *
  *---------------------------------------------------------------------------------------------* 
  * Functions:                                                                                  * 
@@ -59,6 +59,7 @@
 #endif
 
 #include	"WWFILE.H"
+#include "wwstring.h"
 
 
 #ifndef WWERROR
@@ -110,9 +111,7 @@ class RawFileClass : public FileClass
 		virtual unsigned long Get_Date_Time(void);
 		virtual bool Set_Date_Time(unsigned long datetime);
 		virtual void Error(int error, int canretry = false, char const * filename=NULL);
-
-		void Bias(int start, int length=-1);
-
+		virtual void Bias(int start, int length=-1);
 		virtual void * Get_File_Handle(void) { return Handle; } 
 
 		virtual void	Attach (void *handle, int rights=READ);
@@ -148,11 +147,7 @@ class RawFileClass : public FileClass
 			void * Handle;
 		#endif
 
-		/*
-		**	This points to the filename as a NULL terminated string. It may point to either a
-		**	constant or an allocated string as indicated by the "Allocated" flag.
-		*/
-		char const * Filename;
+		StringClass Filename;
 
 		//
 		// file date and time are in the following formats:
@@ -167,15 +162,6 @@ class RawFileClass : public FileClass
 		//
 		unsigned short Date;
 		unsigned short Time;
-
-		/*
-		**	Filenames that were assigned as part of the construction process
-		**	are not allocated. It is assumed that the filename string is a
-		**	constant in that case and thus making duplication unnecessary.
-		**	This value will be non-zero if the filename has be allocated
-		**	(using strdup()).
-		*/
-		bool Allocated;
 };
 
 #endif

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/Signaler.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/Signaler.h
@@ -22,13 +22,18 @@
 *     $Archive: /Commando/Code/wwlib/Signaler.h $
 *
 * DESCRIPTION
+*     Lightweight two-way notification system. This class allows loose coupling
+*     communication between two classes. The only details that need to be know
+*     by both classes is the Signaler class it self and the type of signal they
+*     communicate to each other.
 *
 * PROGRAMMER
+*     Denzil E. Long, Jr.
 *     $Author: Denzil_l $
 *
 * VERSION INFO
-*     $Modtime: 8/17/01 7:08p $
-*     $Revision: 3 $
+*     $Modtime: 11/16/01 11:19a $
+*     $Revision: 4 $
 *
 ******************************************************************************/
 

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/TARGA.CPP
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/TARGA.CPP
@@ -76,6 +76,8 @@
 #include <sys/stat.h>
 #endif
 
+#include <algorithm>
+#include <utility>
 
 /****************************************************************************
 *
@@ -173,6 +175,7 @@ long Targa::Open(const char* name, long mode)
 	TGA2Footer	footer;
 	long			size;
 	long			error = 0;
+	memset(&footer, 0, sizeof(footer));
 
 	/* File already open? */
 	if (Is_File_Open() && (mAccess == mode)) {
@@ -193,7 +196,6 @@ long Targa::Open(const char* name, long mode)
 
 				/* Check for 2.0 targa file by loading the footer */
 				if (File_Seek(-26, SEEK_END) == -1) {
-//				if (File_Seek(26, SEEK_END) == -1) {
 					error = TGAERR_READ;
 				}
 
@@ -825,36 +827,90 @@ void Targa::XFlip(void)
 *
 ****************************************************************************/
 
+static __forceinline void _swapBytes(char *p1, char *p2, unsigned count)
+{
+#if defined(_MSC_VER) && _MSC_VER < 1300
+  _asm
+  {
+    mov esi,[p1]
+    mov edi,[p2]
+    mov ebx,[count]
+    mov ecx,ebx
+    shr ecx,4
+    jz  lessThan16
+  lp:
+    mov eax,dword ptr [esi]
+    mov edx,dword ptr [esi+4]
+    xchg eax,dword ptr [edi]
+    xchg edx,dword ptr [edi+4]
+    mov dword ptr [esi],eax
+    mov dword ptr [esi+4],edx
+    mov eax,dword ptr [esi+8]
+    mov edx,dword ptr [esi+12]
+    xchg eax,dword ptr [edi+8]
+    xchg edx,dword ptr [edi+12]
+    mov dword ptr [esi+8],eax
+    mov dword ptr [esi+12],edx
+    add esi,16
+    add edi,16
+    dec ecx
+    jnz lp
+  lessThan16:
+    and ebx,15
+  lpLessThan16:
+    jz done
+    mov al,byte ptr [esi]
+    xchg al,byte ptr [edi]
+    mov byte ptr [edi],al
+    inc esi
+    inc edi
+    dec ebx
+    jmp lpLessThan16
+  done:
+  }
+#else
+	std::swap_ranges(p1, p1 + count, p2);
+#endif
+}
+
 void Targa::YFlip(void)
-	{
+{
+  /* old code left in for reference...
 	char *ptr,*ptr1;
 	long  x,y;
 	char  v,v1;
 	char  depth;
 
-	/* Pixel depth in bytes. */
+	/ * Pixel depth in bytes. * /
 	depth = TGA_BytesPerPixel(Header.PixelDepth);
 
 	for (y = 0; y < (Header.Height >> 1); y++)
-		{
-		/* Compute address of lines to exchange. */
+	{
+		/ * Compute address of lines to exchange. * /
 		ptr = (mImage + ((Header.Width * y) * depth));
 		ptr1 = (mImage + ((Header.Width * (Header.Height - 1)) * depth));
 		ptr1 -= ((Header.Width * y) * depth);
 
-		/* Exchange all the pixels on this scan line. */
+		/ * Exchange all the pixels on this scan line. * /
+    
 		for (x = 0; x < (Header.Width * depth); x++)
-			{
+		{
 			v = *ptr;
 			v1 = *ptr1;
 			*ptr = v1;
 			*ptr1 = v;
 			ptr++;
 			ptr1++;
-			}
 		}
-	}
+	} 
+  */
 
+  unsigned stride=Header.Width*TGA_BytesPerPixel(Header.PixelDepth);
+  char *ptrTop=mImage,
+       *ptrBottom=mImage+stride*(Header.Height-1);
+  for (unsigned y=Header.Height/2;y;--y,ptrTop+=stride,ptrBottom-=stride)
+    _swapBytes(ptrTop,ptrBottom,stride);
+} 
 
 /****************************************************************************
 *

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/Vector.H
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/Vector.H
@@ -24,11 +24,11 @@
  *                                                                                             *
  *                     $Archive:: /Commando/Code/wwlib/vector.h                               $*
  *                                                                                             *
- *                      $Author:: Patrick                                                     $*
+ *                      $Author:: Jani_p                                                      $*
  *                                                                                             *
- *                     $Modtime:: 8/22/01 12:24p                                              $*
+ *                     $Modtime:: 1/16/02 11:40a                                              $*
  *                                                                                             *
- *                    $Revision:: 47                                                          $*
+ *                    $Revision:: 49                                                          $*
  *                                                                                             *
  *---------------------------------------------------------------------------------------------*
  * Functions:                                                                                  *
@@ -61,6 +61,7 @@
 #include	<assert.h>
 #include	<stdlib.h>
 #include <string.h>
+#include <new.h>
 
 #ifdef _MSC_VER
 #pragma warning (disable : 4702) // unreachable code, happens with some uses of these templates
@@ -215,13 +216,13 @@ VectorClass<T>::~VectorClass(void)
  *   03/10/1995 JLB : Created.                                                                 *
  *=============================================================================================*/
 template<class T>
-VectorClass<T>::VectorClass(VectorClass<T> const & vector) :
+VectorClass<T>::VectorClass(VectorClass<T> const & vec) :
 	Vector(0),
 	VectorMax(0),
 	IsValid(true),
 	IsAllocated(false)
 {
-	*this = vector;
+	*this = vec;
 }
 
 
@@ -231,7 +232,7 @@ VectorClass<T>::VectorClass(VectorClass<T> const & vector) :
  *    This the the assignment operator for vector objects. It will alter the existing lvalue   *
  *    vector to duplicate the rvalue one.                                                      *
  *                                                                                             *
- * INPUT:   vector   -- The rvalue vector to copy into the lvalue one.                         *
+ * INPUT:   vec   -- The rvalue vector to copy into the lvalue one.                            *
  *                                                                                             *
  * OUTPUT:  Returns with reference to the newly copied vector.                                 *
  *                                                                                             *
@@ -241,17 +242,17 @@ VectorClass<T>::VectorClass(VectorClass<T> const & vector) :
  *   03/10/1995 JLB : Created.                                                                 *
  *=============================================================================================*/
 template<class T>
-VectorClass<T> & VectorClass<T>::operator =(VectorClass<T> const & vector)
+VectorClass<T> & VectorClass<T>::operator =(VectorClass<T> const & vec)
 {
-	if (this != &vector) {
+	if (this != &vec) {
 		Clear();
-		VectorMax = vector.Length();
+		VectorMax = vec.Length();
 		if (VectorMax) {
 			Vector = W3DNEWARRAY T[VectorMax];
 			if (Vector) {
 				IsAllocated = true;
 				for (int index = 0; index < VectorMax; index++) {
-					Vector[index] = vector[index];
+					Vector[index] = vec[index];
 				}
 			}
 		} else {
@@ -280,11 +281,11 @@ VectorClass<T> & VectorClass<T>::operator =(VectorClass<T> const & vector)
  *   03/10/1995 JLB : Created.                                                                 *
  *=============================================================================================*/
 template<class T>
-bool VectorClass<T>::operator == (VectorClass<T> const & vector) const
+bool VectorClass<T>::operator == (VectorClass<T> const & vec) const
 {
-	if (VectorMax == vector.Length()) {
+	if (VectorMax == vec.Length()) {
 		for (int index = 0; index < VectorMax; index++) {
-			if (Vector[index] != vector[index]) {
+			if (Vector[index] != vec[index]) {
 				return(false);
 			}
 		}
@@ -507,6 +508,7 @@ class DynamicVectorClass : public VectorClass<T>
 
 		// retains the memory but zeros the active count
 		void Reset_Active(void) { ActiveCount = 0; }
+		void Set_Active(int count)	{ ActiveCount = count; }
 
 		// Fetch number of "allocated" vector objects.
 		int Count(void) const {return(ActiveCount);};
@@ -521,6 +523,7 @@ class DynamicVectorClass : public VectorClass<T>
 
 		// Delete object at this vector index.
 		bool Delete(int index);
+		bool Delete_Index(int index);		// Added to explictly call delete by index
 
 		// Deletes all objects in the vector.
 		void Delete_All(void);
@@ -871,6 +874,28 @@ bool DynamicVectorClass<T>::Delete(int index)
 
 
 template<class T>
+bool DynamicVectorClass<T>::Delete_Index(int index)
+{
+	if (index < ActiveCount) {
+		ActiveCount--;
+
+		/*
+		**	If there are any objects past the index that was deleted, copy those
+		**	objects down in order to fill the hole. A simple memory copy is
+		**	not sufficient since the vector could contain class objects that
+		**	need to use the assignment operator for movement.
+		*/
+//		(&(*this)[index])->~ T ();
+		for (int i = index; i < ActiveCount; i++) {
+			(*this)[i] = (*this)[i+1];
+		}
+		return(true);
+	}
+	return(false);
+}
+
+
+template<class T>
 void DynamicVectorClass<T>::Delete_All(void) 
 {
 	int len = VectorMax;
@@ -902,7 +927,8 @@ template<class T>
 T * DynamicVectorClass<T>::Uninitialized_Add(void)
 {
 	if (ActiveCount >= Length()) {
-		if ((IsAllocated || !VectorMax) && GrowthStep > 0) {
+//		if ((IsAllocated || !VectorMax) && GrowthStep > 0) {
+		if (GrowthStep > 0) {
 			if (!Resize(Length() + GrowthStep)) {
 
 				/*
@@ -959,6 +985,7 @@ class BooleanVectorClass
 
 		// Initialization
 		void Init(unsigned size, unsigned char * array);
+		void Init(unsigned size);
 
 		// Fetch number of boolean objects in vector.
 		int Length(void) {return BitCount;};

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/WWFILE.H
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/WWFILE.H
@@ -24,11 +24,11 @@
  *                                                                                             * 
  *                     $Archive:: /Commando/Code/wwlib/wwfile.h                               $* 
  *                                                                                             * 
- *                      $Author:: Jani_p                                                      $*
+ *                      $Author:: Ian_l                                                       $*
  *                                                                                             * 
- *                     $Modtime:: 5/04/01 7:43p                                               $*
+ *                     $Modtime:: 10/31/01 2:00p                                              $*
  *                                                                                             * 
- *                    $Revision:: 8                                                           $*
+ *                    $Revision:: 9                                                           $*
  *                                                                                             *
  *---------------------------------------------------------------------------------------------* 
  * Functions:                                                                                  * 
@@ -76,8 +76,8 @@ class FileClass
 		virtual ~FileClass(void) {};
 		virtual char const * File_Name(void) const = 0;
 		virtual char const * Set_Name(char const *filename) = 0;
-		//virtual int Create(void) = 0;
-		//virtual int Delete(void) = 0;
+		virtual int Create(void) = 0;
+		virtual int Delete(void) = 0;
 		virtual bool Is_Available(int forced=false) = 0;
 		virtual bool Is_Open(void) const = 0;
 		virtual int Open(char const *filename, int rights=READ) = 0;
@@ -88,10 +88,11 @@ class FileClass
 		virtual int Size(void) = 0;
 		virtual int Write(void const *buffer, int size) = 0;
 		virtual void Close(void) = 0;
-		//virtual unsigned long Get_Date_Time(void) {return(0);}
-		//virtual bool Set_Date_Time(unsigned long ) {return(false);}
-		//virtual void Error(int error, int canretry = false, char const * filename=NULL) = 0;
-		// virtual void * Get_File_Handle(void) { return reinterpret_cast<void *>(-1); } 
+		virtual unsigned long Get_Date_Time(void) {return(0);}
+		virtual bool Set_Date_Time(unsigned long ) {return(false);}
+//		virtual void Error(int error, int canretry = false, char const * filename=NULL) = 0;
+		virtual void * Get_File_Handle(void) { return reinterpret_cast<void *>(-1); } 
+//		virtual void Bias(int start, int length=-1) = 0;
 
 		operator char const * ()
 		{

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/always.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/always.h
@@ -172,16 +172,6 @@ public:
 #endif // (gth) removing the generals memory stuff from W3D
 
 
-// Jani: Intel's C++ compiler issues too many warnings in WW libraries when using warning level 4
-#if defined (__ICL)    // Detect Intel compiler
-#pragma warning (3)
-#pragma warning ( disable: 981 ) // parameters defined in unspecified order
-#pragma warning ( disable: 279 ) // controlling expressaion is constant
-#pragma warning ( disable: 271 ) // trailing comma is nonstandard
-#pragma warning ( disable: 171 ) // invalid type conversion
-#pragma warning ( disable: 1 ) // last line of file ends without a newline
-#endif
-
 // Jani: MSVC doesn't necessarily inline code with inline keyword. Using __forceinline results better inlining
 // and also prints out a warning if inlining wasn't possible. __forceinline is MSVC specific.
 #if defined(_MSC_VER)

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/bufffile.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/bufffile.cpp
@@ -24,11 +24,11 @@
  *                                                                                             * 
  *                     $Archive:: /Commando/Code/wwlib/bufffile.cpp                           $* 
  *                                                                                             * 
- *                      $Author:: Naty_h                                                      $*
+ *                      $Author:: Jani_p                                                      $*
  *                                                                                             * 
- *                     $Modtime:: 4/20/01 4:23p                                               $*
+ *                     $Modtime:: 9/13/01 7:15p                                               $*
  *                                                                                             * 
- *                    $Revision:: 3                                                           $*
+ *                    $Revision:: 4                                                           $*
  *                                                                                             *
  *---------------------------------------------------------------------------------------------* 
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
@@ -39,7 +39,7 @@
 #include	"wwdebug.h"
 #include	<string.h>
 
-int		BufferedFileClass::_DesiredBufferSize	=	1024;	
+int		BufferedFileClass::_DesiredBufferSize	=	1024*16;	
 
 /***********************************************************************************************
  * BufferedFileClass::BufferedFileClass -- Default constructor for a file object.              *

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/bufffile.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/bufffile.h
@@ -24,11 +24,11 @@
  *                                                                                             * 
  *                     $Archive:: /Commando/Code/wwlib/bufffile.h                             $* 
  *                                                                                             * 
- *                      $Author:: Byon_g                                                      $*
+ *                      $Author:: Ian_l                                                       $*
  *                                                                                             * 
- *                     $Modtime:: 5/02/00 11:09a                                              $*
+ *                     $Modtime:: 10/31/01 3:33p                                              $*
  *                                                                                             * 
- *                    $Revision:: 2                                                           $*
+ *                    $Revision:: 3                                                           $*
  *                                                                                             *
  *---------------------------------------------------------------------------------------------* 
  * Functions:                                                                                  * 
@@ -70,10 +70,10 @@ class BufferedFileClass : public RawFileClass
 
 	protected:
 
-		void					Reset_Buffer( void );
-
 		static	void		Set_Desired_Buffer_Size( int size ) { _DesiredBufferSize = size; }
 
+		void					Reset_Buffer( void );
+		
 	private:
 		unsigned char *	Buffer;				// The read buffer 
 		unsigned int		BufferSize;			// The allocated size of the read buffer

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/chunkio.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/chunkio.h
@@ -16,23 +16,23 @@
 **	along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/* $Header: /Commando/Code/wwlib/chunkio.h 21    7/31/01 6:41p Patrick $ */
-/*********************************************************************************************** 
- ***                            Confidential - Westwood Studios                              *** 
- *********************************************************************************************** 
- *                                                                                             * 
- *                 Project Name : Tiberian Sun / Commando / G Library                          * 
- *                                                                                             * 
- *                     $Archive:: /Commando/Code/wwlib/chunkio.h                              $* 
- *                                                                                             * 
- *                      $Author:: Patrick                                                     $* 
- *                                                                                             * 
- *                     $Modtime:: 7/27/01 2:47p                                               $* 
- *                                                                                             * 
- *                    $Revision:: 21                                                          $* 
- *                                                                                             * 
- *---------------------------------------------------------------------------------------------* 
- * Functions:                                                                                  * 
+/* $Header: /Commando/Code/wwlib/chunkio.h 22    10/22/01 6:42p Steve_t $ */
+/***********************************************************************************************
+ ***                            Confidential - Westwood Studios                              ***
+ ***********************************************************************************************
+ *                                                                                             *
+ *                 Project Name : Tiberian Sun / Commando / G Library                          *
+ *                                                                                             *
+ *                     $Archive:: /Commando/Code/wwlib/chunkio.h                              $*
+ *                                                                                             *
+ *                      $Author:: Steve_t                                                     $*
+ *                                                                                             *
+ *                     $Modtime:: 10/21/01 8:58p                                              $*
+ *                                                                                             *
+ *                    $Revision:: 22                                                          $*
+ *                                                                                             *
+ *---------------------------------------------------------------------------------------------*
+ * Functions:                                                                                  *
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 #if _MSC_VER >= 1000
 #pragma once
@@ -339,8 +339,8 @@ private:
 */
 #define READ_SAFE_MICRO_CHUNK(cload,id,var,type)								\
 	case (id):	{                                                     \
-		void *temp_read_buffer_on_the_stack = _alloca(sizeof(var));		\
-		cload.Read(temp_read_buffer_on_the_stack, sizeof(var));        \
+		void *temp_read_buffer_on_the_stack = _alloca(sizeof(type));	\
+		cload.Read(temp_read_buffer_on_the_stack, sizeof(type));       \
 		var = *((type*)temp_read_buffer_on_the_stack);                 \
 		break;                                                         \
 	}

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/ffactory.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/ffactory.cpp
@@ -49,6 +49,7 @@
 */
 SimpleFileFactoryClass		_DefaultFileFactory;
 FileFactoryClass *			_TheFileFactory = &_DefaultFileFactory;
+SimpleFileFactoryClass *			_TheSimpleFileFactory = &_DefaultFileFactory;
 
 RawFileFactoryClass		_DefaultWritingFileFactory;
 RawFileFactoryClass *			_TheWritingFileFactory = &_DefaultWritingFileFactory;

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/ffactory.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/ffactory.h
@@ -16,22 +16,22 @@
 **	along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/*********************************************************************************************** 
- ***              C O N F I D E N T I A L  ---  W E S T W O O D  S T U D I O S               *** 
- *********************************************************************************************** 
- *                                                                                             * 
- *                 Project Name : Command & Conquer                                            * 
- *                                                                                             * 
- *                     $Archive:: /Commando/Code/wwlib/ffactory.h                     $* 
- *                                                                                             * 
- *                      $Author:: Jani_p                                                      $*
- *                                                                                             * 
- *                     $Modtime:: 8/24/01 11:50a                                              $*
- *                                                                                             * 
- *                    $Revision:: 13                                                          $*
+/***********************************************************************************************
+ ***              C O N F I D E N T I A L  ---  W E S T W O O D  S T U D I O S               ***
+ ***********************************************************************************************
  *                                                                                             *
- *---------------------------------------------------------------------------------------------* 
- * Functions:                                                                                  * 
+ *                 Project Name : Command & Conquer                                            *
+ *                                                                                             *
+ *                     $Archive:: /Commando/Code/wwlib/ffactory.h                     $*
+ *                                                                                             *
+ *                      $Author:: Steve_t                                                     $*
+ *                                                                                             *
+ *                     $Modtime:: 9/07/01 5:30p                                               $*
+ *                                                                                             *
+ *                    $Revision:: 14                                                          $*
+ *                                                                                             *
+ *---------------------------------------------------------------------------------------------*
+ * Functions:                                                                                  *
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 #if _MSC_VER >= 1000
@@ -62,6 +62,7 @@ class	FileClass;
 class	FileFactoryClass {
 
 public:
+	virtual ~FileFactoryClass(void){};
 	virtual FileClass * Get_File( char const *filename ) = 0;
 	virtual void Return_File( FileClass *file ) = 0;
 };
@@ -72,7 +73,7 @@ public:
 //
 // Handy auto pointer class.  Prevents you from having to call Return_File manually
 //
-class file_auto_ptr 
+class file_auto_ptr
 {
 public:
 	explicit	file_auto_ptr(FileFactoryClass *fac, const char *filename);
@@ -81,7 +82,7 @@ public:
 	operator FileClass*(void) const
 		{return (get()); }
 
-	FileClass& operator*() const 
+	FileClass& operator*() const
 		{return (*get()); }
 
 	FileClass *operator->() const
@@ -141,6 +142,7 @@ public:
 	void						Append_Sub_Directory( const char * sub_directory );
 	bool						Get_Strip_Path( void ) const								{ return IsStripPath; }
 	void						Set_Strip_Path( bool set )									{ IsStripPath = set; }
+	void						Reset_Sub_Directory( void )								{ SubDirectory = ""; }
 
 protected:
 	StringClass				SubDirectory;
@@ -155,6 +157,7 @@ extern FileFactoryClass	*	_TheFileFactory;
 extern RawFileFactoryClass	*	_TheWritingFileFactory;
 
 // No simple file factory.  jba.
-//extern SimpleFileFactoryClass	*	_TheSimpleFileFactory;
+// (gth) re-enabling this because w3d view uses it
+extern SimpleFileFactoryClass	*	_TheSimpleFileFactory;
 
 #endif

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/hashtemplate.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/hashtemplate.h
@@ -26,9 +26,9 @@
  *                                                                                             * 
  *                       Author:: Greg_h                                                       * 
  *                                                                                             * 
- *                     $Modtime:: 7/11/01 9:35p                                               $* 
+ *                     $Modtime:: 11/19/01 12:16p                                             $* 
  *                                                                                             * 
- *                    $Revision:: 5                                                           $* 
+ *                    $Revision:: 7                                                           $* 
  *                                                                                             * 
  *---------------------------------------------------------------------------------------------* 
  * Functions:                                                                                  * 
@@ -85,6 +85,7 @@ public:
 	~HashTemplateClass(void);
 
 	void Insert(const KeyType& s, const ValueType& d);
+	void Set_Value(const KeyType& s, const ValueType& d);
 	void Remove(const KeyType& s);
 	void Remove(const KeyType& s, const ValueType& d);
 	ValueType Get(const KeyType& s) const;
@@ -164,6 +165,12 @@ public:
 	{
 		return HashTable.Get_Table()[Handle].Value;
 	}
+
+	const KeyType& Peek_Key()
+	{
+		return HashTable.Get_Table()[Handle].Key;
+	}
+
 };
 
 //------------------------------------------------------------------------
@@ -205,6 +212,7 @@ template <class KeyType, class ValueType> inline void HashTemplateClass<KeyType,
 
 template <class KeyType, class ValueType> inline void HashTemplateClass<KeyType,ValueType>::Remove	(const KeyType& s)
 {
+	if (!Hash) return;
 	unsigned int hval = Get_Hash_Val(s,Size);
 	int  prev = NIL;
 	int	h	 = Hash[hval];
@@ -228,6 +236,7 @@ template <class KeyType, class ValueType> inline void HashTemplateClass<KeyType,
 
 template <class KeyType, class ValueType> inline void HashTemplateClass<KeyType,ValueType>::Remove (const KeyType& s, const ValueType& d)
 {
+	if (!Hash) return;
 	unsigned int hval = Get_Hash_Val(s,Size);
 	int  prev = NIL;
 	int	h	 = Hash[hval];
@@ -249,53 +258,77 @@ template <class KeyType, class ValueType> inline void HashTemplateClass<KeyType,
 	}
 }
 
+// Set the value at existing key, or if not found insert a new value
+template <class KeyType, class ValueType> inline void HashTemplateClass<KeyType,ValueType>::Set_Value (const KeyType& s, const ValueType& v)
+{
+	if (Hash) {
+		int  h = Hash[Get_Hash_Val(s,Size)];
+		while (h!=NIL)	{
+			if (Table[h].Key == s) {
+				Table[h].Value=v;
+				return;
+			}
+			h = Table[h].Next;
+		}
+	}
+	Insert(s,v);
+}
+
 template <class KeyType, class ValueType> inline ValueType HashTemplateClass<KeyType,ValueType>::Get (const KeyType& s) const
 {
-	int  h = Hash[Get_Hash_Val(s,Size)];
-	while (h!=NIL)
-	{
-		if (Table[h].Key == s)
-			return Table[h].Value;
-		h = Table[h].Next;
+	if (Hash) {
+		int  h = Hash[Get_Hash_Val(s,Size)];
+		while (h!=NIL)
+		{
+			if (Table[h].Key == s)
+				return Table[h].Value;
+			h = Table[h].Next;
+		}
 	}
 	return ValueType(0);
 }
 
 template <class KeyType, class ValueType> inline bool HashTemplateClass<KeyType,ValueType>::Get(const KeyType& s, ValueType& d) const
 {
-	int  h = Hash[Het_Hash_Val(s,Size)];
-	while (h!=NIL)
-	{
-		if (Table[h].Key == s)
+	if (Hash) {
+		int  h = Hash[Get_Hash_Val(s,Size)];
+		while (h!=NIL)
 		{
-			d = Table[h].Value;
-			return true;
+			if (Table[h].Key == s)
+			{
+				d = Table[h].Value;
+				return true;
+			}
+			h = Table[h].Next;
 		}
-		h = Table[h].Next;
 	}
 	return false;
 }
 
 template <class KeyType, class ValueType> inline bool HashTemplateClass<KeyType,ValueType>::Exists(const KeyType& s) const
 {
-	int  h = Hash[Get_Hash_Val(s,Size)];
-	while (h!=NIL)
-	{
-		if (Table[h].Key == s)
-			return true;
-		h = Table[h].Next;
+	if (Hash) {
+		int  h = Hash[Get_Hash_Val(s,Size)];
+		while (h!=NIL)
+		{
+			if (Table[h].Key == s)
+				return true;
+			h = Table[h].Next;
+		}
 	}
 	return false;
 }
 
 template <class KeyType, class ValueType> inline bool HashTemplateClass<KeyType,ValueType>::Exists(const KeyType& s, const ValueType& d) const
 {
-	int  h = Hash[Get_Hash_Val(s,Size)];
-	while (h!=NIL)
-	{
-		if (Table[h].Key == s && Table[h].Value == d)
-			return true;
-		h = Table[h].Next;
+	if (Hash) {
+		int  h = Hash[Get_Hash_Val(s,Size)];
+		while (h!=NIL)
+		{
+			if (Table[h].Key == s && Table[h].Value == d)
+				return true;
+			h = Table[h].Next;
+		}
 	}
 	return false;
 }
@@ -364,7 +397,7 @@ template <class KeyType, class ValueType> inline int HashTemplateClass<KeyType,V
 
 template <class KeyType, class ValueType> inline HashTemplateClass<KeyType,ValueType>::HashTemplateClass() : Hash(0),Table(0),First(NIL),Size(0)
 {
-	Re_Hash();
+//	Re_Hash();
 }
 
 template <class KeyType, class ValueType> inline HashTemplateClass<KeyType,ValueType>::~HashTemplateClass()

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/mpu.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/mpu.cpp
@@ -229,7 +229,7 @@ int Get_RDTSC_CPU_Speed(void)
 
 		total = ( freq + freq2 + freq3 );		// Total last three frequency calcs
 
-	} while ( (tries < 3 ) || (tries < 20) && ((3 * freq -total) > 3*TOLERANCE )|| ((3 * freq2-total) > 3*TOLERANCE )|| ((3 * freq3-total) > 3*TOLERANCE ));
+	} while ( (tries < 3 ) || (tries < 20) && (((3 * freq -total) > 3*TOLERANCE )|| ((3 * freq2-total) > 3*TOLERANCE )|| ((3 * freq3-total) > 3*TOLERANCE )));
 
 	SetThreadPriority(thread, threadPri);
 	SetPriorityClass(process, processPri);

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/multilist.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/multilist.h
@@ -181,6 +181,9 @@ public:
 
 	void				First(GenericMultiListClass *list)		{ List = list; CurNode = List->Head.Next; }
 	void				First(void)										{ CurNode = List->Head.Next; }
+	void				Last(GenericMultiListClass *list)		{ List = list; CurNode = List->Head.Prev; }
+	void				Last(void)										{ CurNode = List->Head.Prev; }
+
 	void				Next(void)										{ CurNode = CurNode->Next; }
 	void				Prev(void)										{ CurNode = CurNode->Prev; }
 	bool				Is_Done(void)									{ return (CurNode == &(List->Head)); }

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/mutex.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/mutex.cpp
@@ -62,10 +62,10 @@ void MutexClass::Unlock()
 		//assert(0);
 	#else
 		WWASSERT(locked);
+		locked--;
 		int res=ReleaseMutex(handle);
 		res;	// silence compiler warnings
 		WWASSERT(res);
-		locked--;
 	#endif
 }
 
@@ -126,8 +126,8 @@ void CriticalSectionClass::Unlock()
 		//assert(0);
 	#else
 		WWASSERT(locked);
-		LeaveCriticalSection((CRITICAL_SECTION*)handle);
 		locked--;
+		LeaveCriticalSection((CRITICAL_SECTION*)handle);
 	#endif
 }
 

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/ramfile.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/ramfile.cpp
@@ -22,13 +22,13 @@
  *                                                                                             * 
  *                 Project Name : Command & Conquer                                            * 
  *                                                                                             * 
- *                     $Archive:: /Commando/Library/RAMFILE.CPP                               $* 
+ *                     $Archive:: /Commando/Code/wwlib/ramfile.cpp                            $* 
  *                                                                                             * 
- *                      $Author:: Greg_h                                                      $*
+ *                      $Author:: Ian_l                                                       $*
  *                                                                                             * 
- *                     $Modtime:: 7/22/97 11:37a                                              $*
+ *                     $Modtime:: 10/31/01 2:36p                                              $*
  *                                                                                             * 
- *                    $Revision:: 1                                                           $*
+ *                    $Revision:: 2                                                           $*
  *                                                                                             *
  *---------------------------------------------------------------------------------------------* 
  * Functions:                                                                                  * 
@@ -471,4 +471,29 @@ int RAMFileClass::Write(void const * buffer, int size)
 void RAMFileClass::Close(void)
 {
 	IsOpen = false;
+}
+
+
+/***********************************************************************************************
+ * RAMFileClass::Bias --																							  *	
+ *                                                                                             *
+ *                                                                                             *
+ * INPUT:   none                                                                               *
+ *                                                                                             *
+ * OUTPUT:  none                                                                               *
+ *                                                                                             *
+ * WARNINGS:   none                                                                            *
+ *                                                                                             *
+ * HISTORY:                                                                                    *
+ *   10/31/2001 IML : Created.                                                                 *
+ *=============================================================================================*/
+void RAMFileClass::Bias (int start, int length)
+{
+	Buffer	 = Buffer + start;
+	Length	 = MIN (Length, start + length) - start;
+	MaxLength =	MIN (MaxLength, start + length) - start;
+
+	if (Is_Open()) {
+		Seek (0, SEEK_SET);
+	}
 }

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/rcfile.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/rcfile.h
@@ -26,9 +26,9 @@
  *                                                                                             *
  *                       Author:: Greg Hjelstrom                                               *
  *                                                                                             *
- *                     $Modtime:: 7/09/99 1:37p                                               $*
+ *                     $Modtime:: 11/02/01 1:21p                                              $*
  *                                                                                             *
- *                    $Revision:: 7                                                           $*
+ *                    $Revision:: 8                                                           $*
  *                                                                                             *
  *---------------------------------------------------------------------------------------------*
  * Functions:                                                                                  *
@@ -76,6 +76,7 @@ class ResourceFileClass : public FileClass
 		virtual int Write(void const * /*buffer*/, int /*size*/)	{ return 0; }
 		virtual void Close(void)											{ }
 		virtual void Error(int error, int canretry = false, char const * filename=NULL);
+		virtual void Bias(int start, int length=-1) {}
 
 		virtual unsigned char *Peek_Data(void) const					{ return FileBytes; }
 

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/ref_ptr.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/ref_ptr.h
@@ -46,6 +46,8 @@
 #include "always.h"
 #endif
 
+#include "wwdebug.h"
+
 /*
 	RefCountPtr<T> is a smart pointer for reference counted objects.
 	
@@ -254,7 +256,7 @@ class RefCountPtr
 		RefCountPtr(DummyPtrType * dummy)
 			: Referent(0)
 		{
-			G_ASSERT(dummy == 0);
+			WWASSERT(dummy == 0);
 		}
 #endif
 
@@ -358,6 +360,7 @@ class RefCountPtr
 		{
 			if (Referent) {
 				Referent->Release_Ref();
+				Referent = 0;
 			}
 		}
 
@@ -432,5 +435,10 @@ bool operator !=(DummyPtrType * dummy, const RefCountPtr<RHS> & rhs)
 	return 0 != rhs.Peek();	
 }
 
+template <class Derived, class Base>
+RefCountPtr<Derived> Static_Cast(const RefCountPtr<Base> & base) 
+{
+	return Create_Peek((Derived *)base.Peek());
+}
 
 #endif

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/refcount.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/refcount.cpp
@@ -154,7 +154,7 @@ bool RefCountClass::Validate_Active_Ref(RefCountClass * obj)
  * HISTORY:                                                                                    *
  *   2/06/99    EHC: Created.                                                                 *
  *=============================================================================================*/
-void	RefCountClass::Inc_Total_Refs(RefCountClass * obj)
+void	RefCountClass::Inc_Total_Refs(const RefCountClass * obj)
 {
 #ifdef PARANOID_REFCOUNTS
 	assert(Validate_Active_Ref(obj));
@@ -168,7 +168,7 @@ void	RefCountClass::Inc_Total_Refs(RefCountClass * obj)
 RefCountClass* BreakOnReference = 0;
 
 #ifndef NDEBUG
-void RefCountClass::Add_Ref(void)								
+void RefCountClass::Add_Ref(void) const								
 { 
 	NumRefs++;  	  
 
@@ -192,7 +192,7 @@ void RefCountClass::Add_Ref(void)
  * HISTORY:                                                                                    *
  *   2/06/99    EHC: Created.                                                                 *
  *=============================================================================================*/
-void	RefCountClass::Dec_Total_Refs(RefCountClass * obj)
+void	RefCountClass::Dec_Total_Refs(const RefCountClass * obj)
 {
 #ifdef PARANOID_REFCOUNTS
 	assert(Validate_Active_Ref(obj));

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/refcount.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/refcount.h
@@ -26,9 +26,9 @@
  *                                                                                             *
  *                      $Author:: Greg_h                                                      $*
  *                                                                                             *
- *                     $Modtime:: 8/28/01 9:23a                                               $*
+ *                     $Modtime:: 9/13/01 8:38p                                               $*
  *                                                                                             *
- *                    $Revision:: 22                                                          $*
+ *                    $Revision:: 24                                                          $*
  *                                                                                             *
  *---------------------------------------------------------------------------------------------*
  * Functions:                                                                                  *
@@ -134,29 +134,29 @@ public:
 	** to this object.
 	*/
 #ifdef NDEBUG
-	virtual void Add_Ref(void)										{ NumRefs++; }
+	WWINLINE void Add_Ref(void) const							{ NumRefs++; }
 #else
-	virtual void Add_Ref(void);
+	void Add_Ref(void) const;
 #endif
 
 	/*
 	** Release_Ref, call this function when you no longer need the pointer
 	** to this object.
 	*/
-	virtual void		Release_Ref(void)							{ 
+	WWINLINE void		Release_Ref(void) const					{ 
 																				#ifndef NDEBUG
 																				Dec_Total_Refs(this);
 																				#endif
 																				NumRefs--; 
 																				assert(NumRefs >= 0); 
-																				if (NumRefs == 0) Delete_This(); 
+																				if (NumRefs == 0) const_cast<RefCountClass*>(this)->Delete_This(); 
 																			}
 
 
 	/*
 	** Check the number of references to this object.  
 	*/
-	int					Num_Refs(void)								{ return NumRefs; }
+	int					Num_Refs(void) const						{ return NumRefs; }
 
 	/*
 	** Delete_This - this function will be called when the object is being
@@ -190,7 +190,7 @@ private:
 	/*
 	** Current reference count of this object
 	*/
-	int					NumRefs;
+	mutable int			NumRefs;
 
 	/*
 	** Sum of all references to RefCountClass's.  Should equal zero after
@@ -201,12 +201,12 @@ private:
 	/*
 	** increments the total reference count
 	*/
-	static void			Inc_Total_Refs(RefCountClass *);
+	static void			Inc_Total_Refs(const RefCountClass *);
 	
 	/*
 	** decrements the total reference count
 	*/
-	static void			Dec_Total_Refs(RefCountClass *);
+	static void			Dec_Total_Refs(const RefCountClass *);
 
 public:
 	

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/registry.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/registry.cpp
@@ -24,33 +24,60 @@
  *                                                                                             *
  *                     $Archive:: /Commando/Code/wwlib/registry.cpp                           $*
  *                                                                                             *
- *                      $Author:: Patrick                                                     $*
+ *                      $Author:: Steve_t                                                     $*
  *                                                                                             *
- *                     $Modtime:: 8/16/01 11:40a                                              $*
+ *                     $Modtime:: 11/27/01 2:03p                                              $*
  *                                                                                             *
- *                    $Revision:: 10                                                          $*
+ *                    $Revision:: 14                                                          $*
  *                                                                                             *
  *---------------------------------------------------------------------------------------------*
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 #include "registry.h"
+#include "RAWFILE.H"
+#include "INI.H"
+#include "inisup.h"
 #include <assert.h>
 #include <windows.h>
 
 //#include "wwdebug.h"
 
+bool RegistryClass::IsLocked = false;
+
+
+bool RegistryClass::Exists(const char* sub_key)
+{
+	HKEY hKey;
+	LONG result = RegOpenKeyEx(HKEY_LOCAL_MACHINE, sub_key, 0, KEY_READ, &hKey);
+
+	if (ERROR_SUCCESS == result) {
+		RegCloseKey(hKey);
+		return true;
+	}
+
+	return false;
+}
+
 /*
 **
 */
-RegistryClass::RegistryClass( const char * sub_key ) :
+RegistryClass::RegistryClass( const char * sub_key, bool create ) :
 	IsValid( false )
 {
-	DWORD disposition;
-	HKEY	key;
+	HKEY key;
 	assert( sizeof(HKEY) == sizeof(int) );
-	if (::RegCreateKeyEx( HKEY_LOCAL_MACHINE, sub_key,
-			0, NULL, 0, KEY_ALL_ACCESS, NULL,
-			&key, &disposition ) == ERROR_SUCCESS) {
+
+	LONG result = -1;
+
+	if (create && !IsLocked) {
+		DWORD disposition;
+		result = RegCreateKeyEx(HKEY_LOCAL_MACHINE, sub_key, 0, NULL, 0,
+			KEY_ALL_ACCESS, NULL, &key, &disposition);
+	} else {
+		result = RegOpenKeyEx(HKEY_LOCAL_MACHINE, sub_key, 0, IsLocked ? KEY_READ : KEY_ALL_ACCESS, &key);
+	}
+
+	if (ERROR_SUCCESS == result) {
 		IsValid = true;
 		Key = (int)key;
 	}
@@ -69,7 +96,7 @@ int	RegistryClass::Get_Int( const char * name, int def_value )
 {
 	assert( IsValid );
 	DWORD type, data = 0, data_len = sizeof( data );
-	if (( ::RegQueryValueEx( (HKEY)Key, name, NULL, &type, (LPBYTE)&data, &data_len ) == 
+	if (( ::RegQueryValueEx( (HKEY)Key, name, NULL, &type, (LPBYTE)&data, &data_len ) ==
 		ERROR_SUCCESS ) && ( type == REG_DWORD )) {
 	} else {
 		data = def_value;
@@ -80,7 +107,10 @@ int	RegistryClass::Get_Int( const char * name, int def_value )
 void	RegistryClass::Set_Int( const char * name, int value )
 {
 	assert( IsValid );
-	if (::RegSetValueEx( (HKEY)Key, name, 0, REG_DWORD, (LPBYTE)&value, sizeof( DWORD ) ) != 
+	if (IsLocked) {
+		return;
+	}
+	if (::RegSetValueEx( (HKEY)Key, name, 0, REG_DWORD, (LPBYTE)&value, sizeof( DWORD ) ) !=
 			ERROR_SUCCESS) {
 	}
 }
@@ -102,7 +132,7 @@ float	RegistryClass::Get_Float( const char * name, float def_value )
 	assert( IsValid );
 	float data = 0;
 	DWORD type, data_len = sizeof( data );
-	if (( ::RegQueryValueEx( (HKEY)Key, name, NULL, &type, (LPBYTE)&data, &data_len ) == 
+	if (( ::RegQueryValueEx( (HKEY)Key, name, NULL, &type, (LPBYTE)&data, &data_len ) ==
 		ERROR_SUCCESS ) && ( type == REG_DWORD )) {
 	} else {
 		data = def_value;
@@ -113,7 +143,10 @@ float	RegistryClass::Get_Float( const char * name, float def_value )
 void	RegistryClass::Set_Float( const char * name, float value )
 {
 	assert( IsValid );
-	if (::RegSetValueEx( (HKEY)Key, name, 0, REG_DWORD, (LPBYTE)&value, sizeof( DWORD ) ) != 
+	if (IsLocked) {
+		return;
+	}
+	if (::RegSetValueEx( (HKEY)Key, name, 0, REG_DWORD, (LPBYTE)&value, sizeof( DWORD ) ) !=
 			ERROR_SUCCESS) {
 	}
 }
@@ -123,7 +156,7 @@ int RegistryClass::Get_Bin_Size( const char * name )
 	assert( IsValid );
 
 	unsigned long size = 0;
-	::RegQueryValueEx( (HKEY)Key, name, NULL, NULL, NULL, &size );	
+	::RegQueryValueEx( (HKEY)Key, name, NULL, NULL, NULL, &size );
 	return size;
 }
 
@@ -135,7 +168,7 @@ void RegistryClass::Get_Bin( const char * name, void *buffer, int buffer_size )
 	assert( buffer_size > 0 );
 
 	unsigned long size = buffer_size;
-	::RegQueryValueEx( (HKEY)Key, name, NULL, NULL, (LPBYTE)buffer, &size );	
+	::RegQueryValueEx( (HKEY)Key, name, NULL, NULL, (LPBYTE)buffer, &size );
 	return ;
 }
 
@@ -145,7 +178,10 @@ void	RegistryClass::Set_Bin( const char * name, const void *buffer, int buffer_s
 	assert( buffer != NULL );
 	assert( buffer_size > 0 );
 
-	::RegSetValueEx( (HKEY)Key, name, 0, REG_BINARY, (LPBYTE)buffer, buffer_size );	
+	if (IsLocked) {
+		return;
+	}
+	::RegSetValueEx( (HKEY)Key, name, 0, REG_BINARY, (LPBYTE)buffer, buffer_size );
 	return ;
 }
 
@@ -168,7 +204,7 @@ void	RegistryClass::Get_String( const char * name, StringClass &string, const ch
 		::RegQueryValueEx ((HKEY)Key, name, NULL, &type,
 			(LPBYTE)string.Get_Buffer (data_size), &data_size);
 	}
-			
+
 	return ;
 }
 
@@ -178,7 +214,7 @@ char *RegistryClass::Get_String( const char * name, char *value, int value_size,
 {
 	assert( IsValid );
 	DWORD type = 0;
-	if (( ::RegQueryValueEx( (HKEY)Key, name, NULL, &type, (LPBYTE)value, (DWORD*)&value_size ) == 
+	if (( ::RegQueryValueEx( (HKEY)Key, name, NULL, &type, (LPBYTE)value, (DWORD*)&value_size ) ==
 			ERROR_SUCCESS ) && ( type == REG_SZ )) {
 	} else {
 		//*value = 0;
@@ -197,7 +233,10 @@ void	RegistryClass::Set_String( const char * name, const char *value )
 {
 	assert( IsValid );
    int size = strlen( value ) + 1; // must include NULL
-	if (::RegSetValueEx( (HKEY)Key, name, 0, REG_SZ, (LPBYTE)value, size ) != 
+	if (IsLocked) {
+		return;
+	}
+	if (::RegSetValueEx( (HKEY)Key, name, 0, REG_SZ, (LPBYTE)value, size ) !=
 		ERROR_SUCCESS ) {
 	}
 }
@@ -227,12 +266,18 @@ void	RegistryClass::Get_Value_List( DynamicVectorClass<StringClass> &list )
 
 void	RegistryClass::Delete_Value( const char * name)
 {
+	if (IsLocked) {
+		return;
+	}
 	::RegDeleteValue( (HKEY)Key, name );
 	return ;
 }
 
 void	RegistryClass::Deleta_All_Values( void )
 {
+	if (IsLocked) {
+		return;
+	}
 	//
 	//	Build a list of the values in this key
 	//
@@ -269,7 +314,7 @@ void	RegistryClass::Get_String( const WCHAR * name, WideStringClass &string, con
 		::RegQueryValueExW ((HKEY)Key, name, NULL, &type,
 			(LPBYTE)string.Get_Buffer ((data_size / 2) + 1), &data_size);
 	}
-			
+
 	return ;
 }
 
@@ -283,10 +328,419 @@ void	RegistryClass::Set_String( const WCHAR * name, const WCHAR *value )
 	//
 	int size = wcslen( value ) + 1;
 	size		= size * 2;
-	
+
 	//
 	//	Set the registry key
 	//
+	if (IsLocked) {
+		return;
+	}
 	::RegSetValueExW ( (HKEY)Key, name, 0, REG_SZ, (LPBYTE)value, size );
 	return ;
 }
+
+
+
+
+
+
+
+
+
+/***********************************************************************************************
+ * RegistryClass::Save_Registry_Values -- Save values in a key to an .ini file                 *
+ *                                                                                             *
+ *                                                                                             *
+ *                                                                                             *
+ * INPUT:    Handle to key                                                                     *
+ *           Path to key                                                                       *
+ *           INI                                                                               *
+ *                                                                                             *
+ * OUTPUT:   Nothing                                                                           *
+ *                                                                                             *
+ * WARNINGS: None                                                                              *
+ *                                                                                             *
+ * HISTORY:                                                                                    *
+ *   11/21/2001 3:32PM ST : Created                                                            *
+ *=============================================================================================*/
+void RegistryClass::Save_Registry_Values(HKEY key, char *path, INIClass *ini)
+{
+	int index = 0;
+	long result = ERROR_SUCCESS;
+	char save_name[512];
+
+	while (result == ERROR_SUCCESS) {
+		unsigned long type = 0;
+		unsigned char data[8192];
+		unsigned long data_size = sizeof(data);
+		char value_name[256];
+		unsigned long value_name_size = sizeof(value_name);
+
+		result = RegEnumValue(key, index, value_name, &value_name_size, 0, &type, data, &data_size);
+
+		if (result == ERROR_SUCCESS) {
+			switch (type) {
+
+				/*
+				** Handle dword values.
+				*/
+				case REG_DWORD:
+					strcpy(save_name, "DWORD_");
+					strcat(save_name, value_name);
+					ini->Put_Int(path, save_name, *((unsigned long*)data));
+					break;
+
+				/*
+				** Handle string values.
+				*/
+				case REG_SZ:
+					strcpy(save_name, "STRING_");
+					strcat(save_name, value_name);
+					ini->Put_String(path, save_name, (char*)data);
+					break;
+
+				/*
+				** Handle binary values.
+				*/
+				case REG_BINARY:
+					strcpy(save_name, "BIN_");
+					strcat(save_name, value_name);
+					ini->Put_UUBlock(path, save_name, (char*)data, data_size);
+					break;
+
+				/*
+				** Anything else isn't handled yet.
+				*/
+				default:
+					WWASSERT(type == REG_DWORD || type == REG_SZ || type == REG_BINARY);
+					break;
+			}
+		}
+		index++;
+	}
+}
+
+
+
+
+
+/***********************************************************************************************
+ * RegistryClass::Save_Registry_Tree -- Save out a whole chunk or registry as an .INI          *
+ *                                                                                             *
+ *                                                                                             *
+ *                                                                                             *
+ * INPUT:    Registry path                                                                     *
+ *           INI to write to                                                                   *
+ *                                                                                             *
+ * OUTPUT:   Nothing                                                                           *
+ *                                                                                             *
+ * WARNINGS: None                                                                              *
+ *                                                                                             *
+ * HISTORY:                                                                                    *
+ *   11/21/2001 3:33PM ST : Created                                                            *
+ *=============================================================================================*/
+void RegistryClass::Save_Registry_Tree(char *path, INIClass *ini)
+{
+	HKEY base_key;
+	HKEY sub_key;
+	int index = 0;
+	char name[256];
+	unsigned long name_size = sizeof(name);
+	char class_name[256];
+	unsigned long class_name_size = sizeof(class_name);
+	FILETIME file_time;
+	memset(&file_time, 0, sizeof(file_time));
+
+
+	long result = RegOpenKeyEx(HKEY_LOCAL_MACHINE, path, 0, KEY_ALL_ACCESS, &base_key);
+
+	WWASSERT(result == ERROR_SUCCESS);
+
+	if (result == ERROR_SUCCESS) {
+
+		Save_Registry_Values(base_key, path, ini);
+
+		while (result == ERROR_SUCCESS) {
+			class_name_size = sizeof(class_name);
+			name_size = sizeof(name);
+			result = RegEnumKeyEx(base_key, index, name, &name_size, 0, class_name, &class_name_size, &file_time);
+			if (result == ERROR_SUCCESS) {
+
+				/*
+				** See if there are sub keys.
+				*/
+				char new_key_path[512];
+				strcpy(new_key_path, path);
+				strcat(new_key_path, "\\");
+				strcat(new_key_path, name);
+
+				unsigned long num_subs = 0;
+				unsigned long num_values = 0;
+
+				long new_result = RegOpenKeyEx(HKEY_LOCAL_MACHINE, new_key_path, 0, KEY_ALL_ACCESS, &sub_key);
+				if (new_result == ERROR_SUCCESS) {
+					new_result = RegQueryInfoKey(sub_key, NULL, NULL, 0, &num_subs, NULL, NULL, &num_values, NULL, NULL, NULL, NULL);
+
+					/*
+					** If there are sun keys then enumerate those.
+					*/
+					if (num_subs > 0) {
+						Save_Registry_Tree(new_key_path, ini);
+					}
+
+					if (num_values > 0) {
+						Save_Registry_Values(sub_key, new_key_path, ini);
+					}
+					RegCloseKey(sub_key);
+				}
+			}
+			index++;
+		}
+		RegCloseKey(base_key);
+	}
+}
+
+
+
+
+
+/***********************************************************************************************
+ * RegistryClass::Save_Registry -- Save a chunk of registry to an .ini file.                   *
+ *                                                                                             *
+ *                                                                                             *
+ *                                                                                             *
+ * INPUT:    File name                                                                         *
+ *           Registry path                                                                     *
+ *                                                                                             *
+ * OUTPUT:   Nothing                                                                           *
+ *                                                                                             *
+ * WARNINGS: None                                                                              *
+ *                                                                                             *
+ * HISTORY:                                                                                    *
+ *   11/21/2001 3:36PM ST : Created                                                            *
+ *=============================================================================================*/
+void RegistryClass::Save_Registry(const char *filename, char *path)
+{
+	RawFileClass file(filename);
+	INIClass ini;
+	Save_Registry_Tree(path, &ini);
+	ini.Save(file);
+}
+
+
+
+/***********************************************************************************************
+ * RegistryClass::Load_Registry -- Load a chunk of registry from an .INI file                  *
+ *                                                                                             *
+ *                                                                                             *
+ *                                                                                             *
+ * INPUT:    Nothing                                                                           *
+ *                                                                                             *
+ * OUTPUT:   Nothing                                                                           *
+ *                                                                                             *
+ * WARNINGS: None                                                                              *
+ *                                                                                             *
+ * HISTORY:                                                                                    *
+ *   11/21/2001 3:35PM ST : Created                                                            *
+ *=============================================================================================*/
+void RegistryClass::Load_Registry(const char *filename, char *old_path, char *new_path)
+{
+	if (!IsLocked) {
+		RawFileClass file(filename);
+		INIClass ini;
+		ini.Load(file);
+
+		int old_path_len = strlen(old_path);
+		char path[1024];
+		char string[1024];
+		unsigned char buffer[8192];
+
+
+		List<INISection *> &section_list = ini.Get_Section_List();
+
+		for (INISection *section = section_list.First() ; section != NULL ; section = section->Next_Valid()) {
+
+			/*
+			** Build the new path to use in the registry.
+			*/
+			char *section_name = section->Section;
+			strcpy(path, new_path);
+			char *cut = strstr(section_name, old_path);
+			if (cut) {
+				strcat(path, cut + old_path_len);
+			}
+
+			/*
+			** Create the registry key.
+			*/
+			RegistryClass reg(path);
+			if (reg.Is_Valid()) {
+
+				char *entry = (char*)1;
+				int index = 0;
+
+				while (entry) {
+					entry = (char*)ini.Get_Entry(section_name, index++);
+					if (entry) {
+
+						if (strncmp(entry, "BIN_", 4) == 0) {
+							int len = ini.Get_UUBlock(section_name, entry, buffer, sizeof(buffer));
+							reg.Set_Bin(entry+4, buffer, len);
+						} else {
+							if (strncmp(entry, "DWORD_", 6) == 0) {
+								int temp = ini.Get_Int(section_name, entry, 0);
+								reg.Set_Int(entry+6, temp);
+							} else {
+					 			if (strncmp(entry, "STRING_", 7) == 0) {
+									ini.Get_String(section_name, entry, "", string, sizeof(string));
+									reg.Set_String(entry+7, string);
+								} else {
+									WWASSERT(false);
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+
+
+
+
+
+/***********************************************************************************************
+ * RegistryClass::Delete_Registry_Values -- Delete all values under the given key              *
+ *                                                                                             *
+ *                                                                                             *
+ *                                                                                             *
+ * INPUT:    Key handle                                                                        *
+ *                                                                                             *
+ * OUTPUT:   Nothing                                                                           *
+ *                                                                                             *
+ * WARNINGS: None                                                                              *
+ *                                                                                             *
+ * HISTORY:                                                                                    *
+ *   11/21/2001 3:37PM ST : Created                                                            *
+ *=============================================================================================*/
+void RegistryClass::Delete_Registry_Values(HKEY key)
+{
+	int index = 0;
+	long result = ERROR_SUCCESS;
+
+	while (result == ERROR_SUCCESS) {
+		unsigned long type = 0;
+		unsigned char data[8192];
+		unsigned long data_size = sizeof(data);
+		char value_name[256];
+		unsigned long value_name_size = sizeof(value_name);
+
+		result = RegEnumValue(key, index, value_name, &value_name_size, 0, &type, data, &data_size);
+
+		if (result == ERROR_SUCCESS) {
+			result = RegDeleteValue(key, value_name);
+		}
+	}
+}
+
+
+
+
+/***********************************************************************************************
+ * RegistryClass::Delete_Registry_Tree -- Delete all values and sub keys of a registry key     *
+ *                                                                                             *
+ *                                                                                             *
+ *                                                                                             *
+ * INPUT:    Registry path to delete                                                           *
+ *                                                                                             *
+ * OUTPUT:   Nothing                                                                           *
+ *                                                                                             *
+ * WARNINGS: !!!!! DANGER DANGER !!!!!                                                         *
+ *                                                                                             *
+ * HISTORY:                                                                                    *
+ *   11/21/2001 3:38PM ST : Created                                                            *
+ *=============================================================================================*/
+void RegistryClass::Delete_Registry_Tree(char *path)
+{
+	if (!IsLocked) {
+		HKEY base_key;
+		HKEY sub_key;
+		int index = 0;
+		char name[256];
+		unsigned long name_size = sizeof(name);
+		char class_name[256];
+		unsigned long class_name_size = sizeof(class_name);
+		FILETIME file_time;
+		memset(&file_time, 0, sizeof(file_time));
+		int max_times = 1000;
+
+
+		long result = RegOpenKeyEx(HKEY_LOCAL_MACHINE, path, 0, KEY_ALL_ACCESS, &base_key);
+
+		if (result == ERROR_SUCCESS) {
+			Delete_Registry_Values(base_key);
+
+			index = 0;
+			while (result == ERROR_SUCCESS) {
+				class_name_size = sizeof(class_name);
+				name_size = sizeof(name);
+				result = RegEnumKeyEx(base_key, index, name, &name_size, 0, class_name, &class_name_size, &file_time);
+				if (result == ERROR_SUCCESS) {
+
+					/*
+					** See if there are sub keys.
+					*/
+					char new_key_path[512];
+					strcpy(new_key_path, path);
+					strcat(new_key_path, "\\");
+					strcat(new_key_path, name);
+
+					unsigned long num_subs = 0;
+					unsigned long num_values = 0;
+
+					long new_result = RegOpenKeyEx(HKEY_LOCAL_MACHINE, new_key_path, 0, KEY_ALL_ACCESS, &sub_key);
+					if (new_result == ERROR_SUCCESS) {
+						new_result = RegQueryInfoKey(sub_key, NULL, NULL, 0, &num_subs, NULL, NULL, &num_values, NULL, NULL, NULL, NULL);
+
+						/*
+						** If there are sub keys then enumerate those.
+						*/
+						if (num_subs > 0) {
+							Delete_Registry_Tree(new_key_path);
+						}
+
+						if (num_values > 0) {
+							Delete_Registry_Values(sub_key);
+						}
+
+						RegCloseKey(sub_key);
+
+						RegDeleteKey(base_key, name);
+					}
+				}
+				max_times--;
+				if (max_times <= 0) {
+					break;
+				}
+			}
+			RegCloseKey(base_key);
+
+			RegDeleteKey(HKEY_LOCAL_MACHINE, path);
+		}
+	}
+}
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/registry.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/registry.h
@@ -24,11 +24,11 @@
  *                                                                                             *
  *                     $Archive:: /Commando/Code/wwlib/registry.h                             $*
  *                                                                                             *
- *                      $Author:: Patrick                                                     $*
+ *                      $Author:: Steve_t                                                     $*
  *                                                                                             *
- *                     $Modtime:: 8/16/01 11:28a                                              $*
+ *                     $Modtime:: 11/21/01 3:42p                                              $*
  *                                                                                             *
- *                    $Revision:: 8                                                           $*
+ *                    $Revision:: 12                                                          $*
  *                                                                                             *
  *---------------------------------------------------------------------------------------------*
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
@@ -48,13 +48,17 @@
 #include "wwstring.h"
 #include "widestring.h"
 
+class INIClass;
+
 /*
 **
 */
 class	RegistryClass {
 public:
+	static bool Exists(const char* sub_key);
+
 	// Constructor & Destructor
-	RegistryClass( const char * sub_key );
+	RegistryClass( const char * sub_key, bool create = true );
 	~RegistryClass( void );
 
 	bool	Is_Valid( void )		{ return IsValid; }
@@ -93,9 +97,31 @@ public:
 	void	Delete_Value( const char * name);
 	void	Deleta_All_Values( void );
 
+	// Read only.
+	static void Set_Read_Only(bool set) {IsLocked = set;}
+
+	//
+	// Bulk registry operations. BE VERY VERY CAREFUL USING THESE
+	//
+	static void Delete_Registry_Tree(char *path);
+	static void Load_Registry(const char *filename, char *old_path, char *new_path);
+	static void Save_Registry(const char *filename, char *path);
+
+
 private:
+
+	static void Delete_Registry_Values(HKEY key);
+	static void Save_Registry_Tree(char *path, INIClass *ini);
+	static void Save_Registry_Values(HKEY key, char *path, INIClass *ini);
+
+
 	int	Key;
 	bool	IsValid;
+
+	//
+	// Use this to make the registry 'read only'. Useful for running multiple copies of the app.
+	//
+	static bool IsLocked;
 };
 
 #endif // REGISTRY_H

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/systimer.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/systimer.h
@@ -42,6 +42,7 @@
 #include "mmsys.h"
 
 #define TIMEGETTIME SystemTime.Get
+#define MS_TIMER_SECOND 1000
 
 /*
 ** Class that just wraps around timeGetTime()

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/thread.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/thread.h
@@ -27,6 +27,9 @@
 #endif
 
 #include "always.h"
+#include "Vector.H"
+
+struct _EXCEPTION_POINTERS;
 
 
 // ****************************************************************************
@@ -40,13 +43,15 @@
 // will clear the flag and expect you to exit from the thread. If you are
 // not exiting in certain time (defined as a parameter to Stop()) it will
 // force-kill the thread to prevent the program from halting.
-// 
+//
 // ****************************************************************************
 
 class ThreadClass
 {
 public:
-	ThreadClass();
+	typedef int (*ExceptionHandlerType)(int exception_code, struct _EXCEPTION_POINTERS *e_info);
+
+	ThreadClass(const char *name = NULL, ExceptionHandlerType exception_handler = NULL);
 	virtual ~ThreadClass();
 
 	// Execute Thread_Function(). Note that only one instance can be executed at a time.
@@ -70,12 +75,27 @@ public:
 	// Returns true if the thread is running.
 	bool Is_Running();
 
+	// Gets the name of the thread.
+	const char *Get_Name(void) {return(ThreadName);};
+
+	// Get info about a registered thread by it's index.
+	static int Get_Thread_By_Index(int index, char *name_ptr = NULL);
+
 protected:
 
 	// User defined thread function. The thread function should check for "running" flag every now and then
 	// and exit the thread if running is false.
 	virtual void Thread_Function() = 0;
 	volatile bool running;
+
+	// Name of thread.
+	char ThreadName[64];
+
+	// ID of thread.
+	unsigned ThreadID;
+
+	// Exception handler for this thread.
+	ExceptionHandlerType ExceptionHandler;
 
 private:
 	static void __cdecl Internal_Thread_Function(void*);

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/vector.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/vector.cpp
@@ -24,11 +24,11 @@
  *                                                                                             * 
  *                     $Archive:: /Commando/Code/wwlib/vector.cpp                             $* 
  *                                                                                             * 
- *                      $Author:: Patrick                                                     $*
+ *                      $Author:: Jani_p                                                      $*
  *                                                                                             * 
- *                     $Modtime:: 8/22/01 1:46p                                               $*
+ *                     $Modtime:: 1/16/02 11:40a                                              $*
  *                                                                                             * 
- *                    $Revision:: 19                                                          $*
+ *                    $Revision:: 20                                                          $*
  *                                                                                             *
  *---------------------------------------------------------------------------------------------* 
  * Functions:                                                                                  * 
@@ -371,4 +371,25 @@ void BooleanVectorClass::Init(unsigned size, unsigned char * array)
 	LastIndex = -1;
 	BitCount = size;
 	BitArray.Resize(((size + (8-1)) / 8), array);
+}
+
+
+/***********************************************************************************************
+ * BooleanVectorClass::Init -- Initializes the bit vector from an user array.                  *
+ *                                                                                             *
+ * INPUT:   none                                                                               *
+ *                                                                                             *
+ * OUTPUT:  none                                                                               *
+ *                                                                                             *
+ * WARNINGS:   none                                                                            *
+ *                                                                                             *
+ * HISTORY:                                                                                    *
+ *   07/18/1995 JLB : Created.                                                                 *
+ *=============================================================================================*/
+void BooleanVectorClass::Init(unsigned size)
+{
+	Copy = false;
+	LastIndex = -1;
+	BitCount = size;
+	BitArray.Resize(((size + (8-1)) / 8));
 }

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/win.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/win.h
@@ -24,11 +24,11 @@
  *                                                                                             * 
  *                     $Archive:: /Commando/Code/wwlib/win.h                                  $* 
  *                                                                                             * 
- *                      $Author:: Denzil_l                                                    $*
+ *                      $Author:: Ian_l                                                       $*
  *                                                                                             * 
- *                     $Modtime:: 6/26/01 1:59p                                               $*
+ *                     $Modtime:: 10/16/01 2:42p                                              $*
  *                                                                                             * 
- *                    $Revision:: 10                                                          $*
+ *                    $Revision:: 11                                                          $*
  *                                                                                             *
  *---------------------------------------------------------------------------------------------* 
  * Functions:                                                                                  * 


### PR DESCRIPTION
There are some bugfixes for Generals here:

* bufffile: increases default io buffer size from 1kb to 16kb in BufferedFileClass
* chunkio: fixes unused macro to now use type name instead of var to determine size
* hashtemplate: adds missing null checks in HashTemplateClass functions
* ini: fixes bugs in INIClass, Get_Float, Put_Float
* ini: adds functions Get_Double, Put_Double, Get_Wide_String, Put_Wide_String, Get_UUBlock, Put_UUBlock
* ini: optimizes large local buffer sizes
* ini: increases max ini line lengths from 512 to 4096
* mutex: fixes logical issue to mirror the execution order for unlock in MutexClass & CriticalSectionClass
* mutex: adds FastCriticalSectionClass
* ramfile: improves internal string management
* rawfile: improves internal string management
* ref_ptr: fixes critical dangling pointer
* registry: adds more functionality to RegistryClass
* targa: changes function Targa::YFlip
* thread: adds name and id to ThreadClass
* vector: adds functions DynamicVectorClass<T>::Delete_Index, BooleanVectorClass::Init
