### PR TITLE
[GEN][ZH] Fix incorrect string copy with overlapping memory regions in AsciiString, UnicodeString, strtrim

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/System/AsciiString.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/AsciiString.cpp
@@ -131,7 +131,8 @@ void AsciiString::ensureUniqueBufferOfSize(int numCharsNeeded, Bool preserveData
 	{
 		// no buffer manhandling is needed (it's already large enough, and unique to us)
 		if (strToCopy)
-			strcpy(m_data->peek(), strToCopy);
+			// TheSuperHackers @fix Mauller 04/04/2025 Replace strcpy with safer memmove as memory regions can overlap when part of string is copied to itself
+			memmove(m_data->peek(), strToCopy, strlen(strToCopy) + 1);
 		if (strToCat)
 			strcat(m_data->peek(), strToCat);
 		return;

--- a/Generals/Code/GameEngine/Source/Common/System/UnicodeString.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/UnicodeString.cpp
@@ -87,7 +87,8 @@ void UnicodeString::ensureUniqueBufferOfSize(int numCharsNeeded, Bool preserveDa
 	{
 		// no buffer manhandling is needed (it's already large enough, and unique to us)
 		if (strToCopy)
-			wcscpy(m_data->peek(), strToCopy);
+			// TheSuperHackers @fix Mauller 04/04/2025 Replace wcscpy with safer memmove as memory regions can overlap when part of string is copied to itself
+			memmove(m_data->peek(), strToCopy, (wcslen(strToCopy) + 1) * sizeof(WideChar));
 		if (strToCat)
 			wcscat(m_data->peek(), strToCat);
 		return;

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/trim.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/trim.cpp
@@ -71,7 +71,8 @@ char * strtrim(char * buffer)
 			source++;
 		}
 		if (source != buffer) {
-			strcpy(buffer, source);
+			// TheSuperHackers @fix Mauller 04/04/2025 Replace strcpy with safer memmove as memory regions can overlap when part of string is copied to itself
+			memmove(buffer, source, strlen(source) +1);
 		}
 
 		/*
@@ -100,7 +101,8 @@ wchar_t * wcstrim(wchar_t * buffer)
 			source++;
 		}
 		if (source != buffer) {
-			wcscpy(buffer, source);
+			// TheSuperHackers @fix Mauller 04/04/2025 Replace wcscpy with safer memmove as memory regions can overlap when part of string is copied to itself
+			memmove(buffer, source, (wcslen(source) + 1) * sizeof(wchar_t));
 		}
 
 		/*

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/AsciiString.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/AsciiString.cpp
@@ -127,7 +127,8 @@ void AsciiString::ensureUniqueBufferOfSize(int numCharsNeeded, Bool preserveData
 	{
 		// no buffer manhandling is needed (it's already large enough, and unique to us)
 		if (strToCopy)
-			strcpy(m_data->peek(), strToCopy);
+			// TheSuperHackers @fix Mauller 04/04/2025 Replace strcpy with safer memmove as memory regions can overlap when part of string is copied to itself
+			memmove(m_data->peek(), strToCopy, strlen(strToCopy) + 1);
 		if (strToCat)
 			strcat(m_data->peek(), strToCat);
 		return;

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/UnicodeString.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/UnicodeString.cpp
@@ -87,7 +87,8 @@ void UnicodeString::ensureUniqueBufferOfSize(int numCharsNeeded, Bool preserveDa
 	{
 		// no buffer manhandling is needed (it's already large enough, and unique to us)
 		if (strToCopy)
-			wcscpy(m_data->peek(), strToCopy);
+			// TheSuperHackers @fix Mauller 04/04/2025 Replace wcscpy with safer memmove as memory regions can overlap when part of string is copied to itself
+			memmove(m_data->peek(), strToCopy, (wcslen(strToCopy) + 1) * sizeof(WideChar));
 		if (strToCat)
 			wcscat(m_data->peek(), strToCat);
 		return;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/trim.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/trim.cpp
@@ -68,7 +68,8 @@ char* strtrim(char* buffer)
 		}
 
 		if (source != buffer) {
-			strcpy(buffer, source);
+			// TheSuperHackers @fix Mauller 04/04/2025 Replace strcpy with safer memmove as memory regions can overlap when part of string is copied to itself
+			memmove(buffer, source, strlen(source) +1);
 		}
 
 		/* Clip trailing white space from the string. */
@@ -96,7 +97,8 @@ wchar_t* wcstrim(wchar_t* buffer)
 		}
 		
 		if (source != buffer) {
-			wcscpy(buffer, source);
+			// TheSuperHackers @fix Mauller 04/04/2025 Replace wcscpy with safer memmove as memory regions can overlap when part of string is copied to itself
+			memmove(buffer, source, (wcslen(source) + 1) * sizeof(wchar_t));
 		}
 
 		/* Clip trailing white space from the string. */


### PR DESCRIPTION
The two commits here correct some functionality that was causing ASAN to trigger on startup.

The source and destination buffers, according to ASAN, have overlapping memory regions meaning the copy would be unsafe to perform.

The solution and safe way to do this, if it was intended, such as shuffling characters along in a buffer, you should use memmove.
memmove is used in other parts of the code base as well so has compat with VC6.

To see this you must have the null memory implementation in use and ASAN running.

EDIT: Updated to include Unicode and wide character string trim.