### PR TITLE
[GEN][ZH] Fix various memory leaks

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
@@ -217,6 +217,8 @@ ProductionUpdate::~ProductionUpdate( void )
 
 		production = m_productionQueue;
 		removeFromProductionQueue( production );
+		// TheSuperHackers @fix Mauller 13/04/2025 Delete instance of production item
+		production->deleteInstance();
 
 	}  // end while
 

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DLaserDraw.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DLaserDraw.cpp
@@ -234,6 +234,8 @@ W3DLaserDraw::~W3DLaserDraw( void )
 	}  // end for i
 
 	delete [] m_line3D;
+	// TheSuperHackers @fix Mauller 11/03/2025 Free reference counted material
+	REF_PTR_RELEASE(m_texture);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankDraw.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankDraw.cpp
@@ -163,6 +163,9 @@ void W3DTankDraw::createEmitters( void )
 //-------------------------------------------------------------------------------------------------
 W3DTankDraw::~W3DTankDraw()
 {
+	// TheSuperHackers @fix Mauller 16/04/2025 Delete particle systems
+	tossEmitters();
+
 	for (Int i=0; i<MAX_TREADS_PER_TANK; i++)
 		if (m_treads[i].m_robj)
 			REF_PTR_RELEASE(m_treads[i].m_robj);

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -376,10 +376,17 @@ W3DDisplay::~W3DDisplay()
 
 	// get rid of the debug display
 	delete m_debugDisplay;
+	m_debugDisplay = NULL;
+	m_nativeDebugDisplay = NULL;
 
 	// delete the display strings
 	for (int i = 0; i < DisplayStringCount; i++)
 		TheDisplayStringManager->freeDisplayString(m_displayStrings[i]);
+
+	// TheSuperHackers @fix Mauller/Tomsons26 28/04/2025 Free benchmark display string
+	if( m_benchmarkDisplayString ) {
+		TheDisplayStringManager->freeDisplayString(m_benchmarkDisplayString);
+	}
 
 	// delete 2D renderer
 	if( m_2DRender )

--- a/Generals/Code/GameEngineDevice/Source/Win32Device/Common/Win32BIGFileSystem.cpp
+++ b/Generals/Code/GameEngineDevice/Source/Win32Device/Common/Win32BIGFileSystem.cpp
@@ -77,8 +77,6 @@ ArchiveFile * Win32BIGFileSystem::openArchiveFile(const Char *filename) {
 	Int archiveFileSize = 0;
 	Int numLittleFiles = 0;
 
-	ArchiveFile *archiveFile = NEW Win32BIGFile;
-
 	DEBUG_LOG(("Win32BIGFileSystem::openArchiveFile - opening BIG file %s\n", filename));
 
 	if (fp == NULL) {
@@ -120,6 +118,8 @@ ArchiveFile * Win32BIGFileSystem::openArchiveFile(const Char *filename) {
 	fp->seek(0x10, File::START);
 	// read in each directory listing.
 	ArchivedFileInfo *fileInfo = NEW ArchivedFileInfo;
+	// TheSuperHackers @fix Mauller 23/04/2025 Create new file handle when necessary to prevent memory leak
+	ArchiveFile *archiveFile = NEW Win32BIGFile;
 
 	for (Int i = 0; i < numLittleFiles; ++i) {
 		Int filesize = 0;

--- a/Generals/Code/GameEngineDevice/Source/Win32Device/Common/Win32LocalFileSystem.cpp
+++ b/Generals/Code/GameEngineDevice/Source/Win32Device/Common/Win32LocalFileSystem.cpp
@@ -45,7 +45,6 @@ Win32LocalFileSystem::~Win32LocalFileSystem() {
 File * Win32LocalFileSystem::openFile(const Char *filename, Int access /* = 0 */) 
 {
 	//USE_PERF_TIMER(Win32LocalFileSystem_openFile)
-	Win32LocalFile *file = newInstance( Win32LocalFile );	
 
 	// sanity check
 	if (strlen(filename) <= 0) {
@@ -68,6 +67,9 @@ File * Win32LocalFileSystem::openFile(const Char *filename, Int access /* = 0 */
 			dirName.concat(token);
 		}
 	}
+
+	// TheSuperHackers @fix Mauller 21/04/2025 Create new file handle when necessary to prevent memory leak
+	Win32LocalFile *file = newInstance( Win32LocalFile );	
 
 	if (file->open(filename, access) == FALSE) {
 		file->close();

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/meshmdl.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/meshmdl.cpp
@@ -102,8 +102,6 @@ MeshModelClass::MeshModelClass(const MeshModelClass & that) :
 
 MeshModelClass::~MeshModelClass(void)
 {
-//	WWDEBUG_SAY(("Note: Mesh %s was never used\n",Get_Name()));
-	TheDX8MeshRenderer.Unregister_Mesh_Type(this);
 
 	Reset(0,0,0);
 	REF_PTR_RELEASE(MatInfo);
@@ -151,6 +149,11 @@ MeshModelClass & MeshModelClass::operator = (const MeshModelClass & that)
 
 void MeshModelClass::Reset(int polycount,int vertcount,int passcount)
 {
+	//DMS - We must delete the gapfiller object BEFORE the geometry is reset.  Otherwise,
+	// the number of stages and passes gets reset and the gapfiller cannot deallocate properly.
+	delete GapFiller;
+	GapFiller=NULL;
+
 	Reset_Geometry(polycount,vertcount);
 
 	// Release everything we have and reset to initial state
@@ -164,9 +167,6 @@ void MeshModelClass::Reset(int polycount,int vertcount,int passcount)
 		AlternateMatDesc = NULL;
 	}
 	CurMatDesc = DefMatDesc;
-
-	delete GapFiller;
-	GapFiller=NULL;
 
 	return ;
 }

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/meshmdl.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/meshmdl.cpp
@@ -141,7 +141,7 @@ MeshModelClass & MeshModelClass::operator = (const MeshModelClass & that)
 		clone_materials(that);
 
 		if (GapFiller) {
-			delete[] GapFiller;
+			delete GapFiller;
 				GapFiller=NULL;
 		}
 		if (that.GapFiller) GapFiller=W3DNEW GapFillerClass(*that.GapFiller);

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Snow.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Snow.cpp
@@ -99,6 +99,13 @@ SnowManager::~SnowManager()
 {
 	delete [] m_startingHeights;
 	m_startingHeights=NULL;
+
+	// TheSuperHackers @fix Mauller 13/04/2025 Delete the instance of the weather settings
+	if (TheWeatherSetting)
+	{
+		((WeatherSetting*)TheWeatherSetting.getNonOverloadedPointer())->deleteInstance();
+		TheWeatherSetting=NULL;
+	}
 }
 
 OVERRIDE<WeatherSetting> TheWeatherSetting = NULL;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
@@ -218,6 +218,8 @@ ProductionUpdate::~ProductionUpdate( void )
 
 		production = m_productionQueue;
 		removeFromProductionQueue( production );
+		// TheSuperHackers @fix Mauller 13/04/2025 Delete instance of production item
+		production->deleteInstance();
 
 	}  // end while
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DLaserDraw.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DLaserDraw.cpp
@@ -237,6 +237,8 @@ W3DLaserDraw::~W3DLaserDraw( void )
 	}  // end for i
 
 	delete [] m_line3D;
+	// TheSuperHackers @fix Mauller 11/03/2025 Free reference counted material
+	REF_PTR_RELEASE(m_texture);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankDraw.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankDraw.cpp
@@ -163,6 +163,9 @@ void W3DTankDraw::createEmitters( void )
 //-------------------------------------------------------------------------------------------------
 W3DTankDraw::~W3DTankDraw()
 {
+	// TheSuperHackers @fix Mauller 16/04/2025 Delete particle systems
+	tossEmitters();
+
 	for (Int i=0; i<MAX_TREADS_PER_TANK; i++)
 		if (m_treads[i].m_robj)
 			REF_PTR_RELEASE(m_treads[i].m_robj);

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -426,10 +426,17 @@ W3DDisplay::~W3DDisplay()
 
 	// get rid of the debug display
 	delete m_debugDisplay;
+	m_debugDisplay = NULL;
+	m_nativeDebugDisplay = NULL;
 
 	// delete the display strings
 	for (int i = 0; i < DisplayStringCount; i++)
 		TheDisplayStringManager->freeDisplayString(m_displayStrings[i]);
+
+	// TheSuperHackers @fix Mauller/Tomsons26 28/04/2025 Free benchmark display string
+	if( m_benchmarkDisplayString ) {
+		TheDisplayStringManager->freeDisplayString(m_benchmarkDisplayString);
+	}
 
 	// delete 2D renderer
 	if( m_2DRender )

--- a/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/Common/Win32BIGFileSystem.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/Common/Win32BIGFileSystem.cpp
@@ -90,8 +90,6 @@ ArchiveFile * Win32BIGFileSystem::openArchiveFile(const Char *filename) {
 	Int archiveFileSize = 0;
 	Int numLittleFiles = 0;
 
-	ArchiveFile *archiveFile = NEW Win32BIGFile;
-
 	DEBUG_LOG(("Win32BIGFileSystem::openArchiveFile - opening BIG file %s\n", filename));
 
 	if (fp == NULL) {
@@ -133,6 +131,8 @@ ArchiveFile * Win32BIGFileSystem::openArchiveFile(const Char *filename) {
 	fp->seek(0x10, File::START);
 	// read in each directory listing.
 	ArchivedFileInfo *fileInfo = NEW ArchivedFileInfo;
+	// TheSuperHackers @fix Mauller 23/04/2025 Create new file handle when necessary to prevent memory leak
+	ArchiveFile *archiveFile = NEW Win32BIGFile;
 
 	for (Int i = 0; i < numLittleFiles; ++i) {
 		Int filesize = 0;

--- a/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/Common/Win32LocalFileSystem.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/Common/Win32LocalFileSystem.cpp
@@ -45,7 +45,6 @@ Win32LocalFileSystem::~Win32LocalFileSystem() {
 File * Win32LocalFileSystem::openFile(const Char *filename, Int access /* = 0 */) 
 {
 	//USE_PERF_TIMER(Win32LocalFileSystem_openFile)
-	Win32LocalFile *file = newInstance( Win32LocalFile );	
 
 	// sanity check
 	if (strlen(filename) <= 0) {
@@ -68,6 +67,9 @@ File * Win32LocalFileSystem::openFile(const Char *filename, Int access /* = 0 */
 			dirName.concat(token);
 		}
 	}
+
+	// TheSuperHackers @fix Mauller 21/04/2025 Create new file handle when necessary to prevent memory leak
+	Win32LocalFile *file = newInstance( Win32LocalFile );	
 
 	if (file->open(filename, access) == FALSE) {
 		file->close();

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmdl.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmdl.cpp
@@ -106,8 +106,6 @@ MeshModelClass::MeshModelClass(const MeshModelClass & that) :
 
 MeshModelClass::~MeshModelClass(void)
 {
-//	WWDEBUG_SAY(("Note: Mesh %s was never used\n",Get_Name()));
-	TheDX8MeshRenderer.Unregister_Mesh_Type(this);
 
 	Reset(0,0,0);
 	REF_PTR_RELEASE(MatInfo);


### PR DESCRIPTION
**Merge with Rebase**

Fix freeing some reference counted pointers so that underlying memory is properly freed.
Also fix the cleanup in some classes that were not clearing dependent objects.

~~Will be checking for more so left this as draft for the moment.~~
EDIT: This should be good to merge now, the memory leaks it fixes are some of the most prominent that i came across.

Fixes:

- Gen + ZH - ~W3DLaserDraw() was leaking materials.
- Gen + ZH - ~ProductionUpdate() was leaking production queue items if game exited before buildings sold or destroyed.
- ZH - Snow system was leaking on shutdown, wouldn't affect runtime but means a clean shutdown.
- Gen + ZH - ~W3DTankDraw() was leaking particle systems, therefore leaking particles as well.
- Gen + ZH - ~MeshModelClass() had an extra call to free directx8 references in the wrong place, this could cause other dependent assets to not be deallocated properly within reset(). And Generals behaviour was freeing data in the wrong order.
- Gen + ZH - Win32LocalFileSystem was leaking Win32File handlers due to creating a handler and returning early on a null filename before deleting it. Moved the creation of the file handler after the early return and where it is needed / used.
- Gen - ~MeshModelClass() was calling the wrong delete method when deallocating GapFiller data. Fixed already in ZH.
- Gen + ZH - Win32BigFileSystem was leaking Big32File handlers due to creating a handler and returning early on a null filename before deleting it. Moved the creation of the file handler after the early return and where it is needed / used.
- Gen + ZH - ~W3DDisplay() was not releasing its debug display string so it could prevent DisplayStringManager from being cleanly destroyed.