### PR TITLE
[LINUX] Pass va_list by value

### DIFF
--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/widestring.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/widestring.cpp
@@ -243,7 +243,7 @@ WideStringClass::Free_String (void)
 //
 ///////////////////////////////////////////////////////////////////
 int _cdecl
-WideStringClass::Format_Args (const WCHAR *format, const va_list & arg_list )
+WideStringClass::Format_Args (const WCHAR *format, va_list arg_list )
 {
 	//
 	// Make a guess at the maximum length of the resulting string

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/widestring.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/widestring.h
@@ -112,7 +112,7 @@ public:
 
 	void			Erase (int start_index, int char_count);
 	int _cdecl  Format (const WCHAR *format, ...);
-	int _cdecl  Format_Args (const WCHAR *format, const va_list & arg_list );
+	int _cdecl  Format_Args (const WCHAR *format, va_list arg_list );
 	void			Convert_From (const char *text);
 	void			Convert_To (StringClass &string);
 	void			Convert_To (StringClass &string) const;

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/wwstring.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/wwstring.cpp
@@ -224,7 +224,7 @@ StringClass::Free_String (void)
 //
 ///////////////////////////////////////////////////////////////////
 int _cdecl
-StringClass::Format_Args (const TCHAR *format, const va_list & arg_list )
+StringClass::Format_Args (const TCHAR *format, va_list arg_list )
 {
 	//
 	// Make a guess at the maximum length of the resulting string

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/wwstring.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/wwstring.h
@@ -118,7 +118,7 @@ public:
 
 	void			Erase (int start_index, int char_count);
 	int _cdecl  Format (const TCHAR *format, ...);
-	int _cdecl  Format_Args (const TCHAR *format, const va_list & arg_list );
+	int _cdecl  Format_Args (const TCHAR *format, va_list arg_list );
 
 	TCHAR *		Get_Buffer (int new_length);
 	TCHAR *		Peek_Buffer (void);

--- a/Generals/Code/Tools/WW3D/max2w3d/logdlg.cpp
+++ b/Generals/Code/Tools/WW3D/max2w3d/logdlg.cpp
@@ -106,7 +106,7 @@ void LogDataDialogClass::printf(const char *text, ...)
 	va_start(arguments, text);
 }	// printf
 
-void LogDataDialogClass::printf(const char * text, const va_list & args)
+void LogDataDialogClass::printf(const char * text, va_list args)
 {
 	static char string_buffer[256];
 
@@ -151,7 +151,7 @@ void LogDataDialogClass::rprintf(const char *text, ...)
 	rprintf(text,arguments);
 }
 
-void LogDataDialogClass::rprintf(const char *text, const va_list & args)
+void LogDataDialogClass::rprintf(const char *text, va_list args)
 {
 	static char string_buffer[256];
 	vsprintf(string_buffer, text, args);

--- a/Generals/Code/Tools/WW3D/max2w3d/logdlg.h
+++ b/Generals/Code/Tools/WW3D/max2w3d/logdlg.h
@@ -52,9 +52,9 @@ public:
    void	Wait_OK();	// wait for user to hit OK
    
    void	printf(const char *, ...);
-	void	printf(const char * text, const va_list & args);
+	void	printf(const char * text, va_list args);
 	void  rprintf(const char *, ...);
-	void	rprintf(const char *text, const va_list & args);
+	void	rprintf(const char *text, va_list args);
 	
 	void	updatebar(float position, float total);
    

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/widestring.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/widestring.cpp
@@ -244,7 +244,7 @@ WideStringClass::Free_String (void)
 //
 ///////////////////////////////////////////////////////////////////
 int _cdecl
-WideStringClass::Format_Args (const WCHAR *format, const va_list & arg_list )
+WideStringClass::Format_Args (const WCHAR *format, va_list arg_list )
 {
 	if (format == NULL) {
 		return 0;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/widestring.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/widestring.h
@@ -114,7 +114,7 @@ public:
 
 	void			Erase (int start_index, int char_count);
 	int _cdecl  Format (const WCHAR *format, ...);
-	int _cdecl  Format_Args (const WCHAR *format, const va_list & arg_list );
+	int _cdecl  Format_Args (const WCHAR *format, va_list arg_list );
 	bool			Convert_From (const char *text);
 	bool			Convert_To (StringClass &string);
 	bool			Convert_To (StringClass &string) const;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/wwstring.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/wwstring.cpp
@@ -238,7 +238,7 @@ StringClass::Free_String (void)
 //
 ///////////////////////////////////////////////////////////////////
 int _cdecl
-StringClass::Format_Args (const TCHAR *format, const va_list & arg_list )
+StringClass::Format_Args (const TCHAR *format, va_list arg_list )
 {
 	//
 	// Make a guess at the maximum length of the resulting string

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/wwstring.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/wwstring.h
@@ -122,7 +122,7 @@ public:
 
 	void			Erase (int start_index, int char_count);
 	int _cdecl  Format (const TCHAR *format, ...);
-	int _cdecl  Format_Args (const TCHAR *format, const va_list & arg_list );
+	int _cdecl  Format_Args (const TCHAR *format, va_list arg_list );
 
 	// Trim leading and trailing whitespace characters (values <= 32)
 	void Trim(void);

--- a/GeneralsMD/Code/Tools/WW3D/max2w3d/logdlg.cpp
+++ b/GeneralsMD/Code/Tools/WW3D/max2w3d/logdlg.cpp
@@ -106,7 +106,7 @@ void LogDataDialogClass::printf(const char *text, ...)
 	va_start(arguments, text);
 }	// printf
 
-void LogDataDialogClass::printf(const char * text, const va_list & args)
+void LogDataDialogClass::printf(const char * text, va_list args)
 {
 	static char string_buffer[256];
 
@@ -151,7 +151,7 @@ void LogDataDialogClass::rprintf(const char *text, ...)
 	rprintf(text,arguments);
 }
 
-void LogDataDialogClass::rprintf(const char *text, const va_list & args)
+void LogDataDialogClass::rprintf(const char *text, va_list args)
 {
 	static char string_buffer[256];
 	vsprintf(string_buffer, text, args);

--- a/GeneralsMD/Code/Tools/WW3D/max2w3d/logdlg.h
+++ b/GeneralsMD/Code/Tools/WW3D/max2w3d/logdlg.h
@@ -52,9 +52,9 @@ public:
    void	Wait_OK();	// wait for user to hit OK
    
    void	printf(const char *, ...);
-	void	printf(const char * text, const va_list & args);
+	void	printf(const char * text, va_list args);
 	void  rprintf(const char *, ...);
-	void	rprintf(const char *text, const va_list & args);
+	void	rprintf(const char *text, va_list args);
 	
 	void	updatebar(float position, float total);
    


### PR DESCRIPTION
This change passes `va_list` by value instead by reference.