### PR TITLE
[GEN][ZH] Fix invalidated iterator access in ScriptEngine::evaluateAndProgressAllSequentialScripts

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
@@ -7159,12 +7159,13 @@ void ScriptEngine::setSequentialTimer(Team *team, Int frameCount)
 
 void ScriptEngine::evaluateAndProgressAllSequentialScripts( void )
 {
-	VecSequentialScriptPtrIt it, lastIt;
-	lastIt = m_sequentialScripts.end();
+	VecSequentialScriptPtrIt it;
+	SequentialScript* lastScript = NULL;
+	Bool itAdvanced = false;
 
 	Int spinCount = 0;
 	for (it = m_sequentialScripts.begin(); it != m_sequentialScripts.end(); /* empty */) {
-		if (it == lastIt) {
+		if ((*it) == lastScript) {
 			++spinCount;
 		} else {
 			spinCount = 0;
@@ -7180,9 +7181,9 @@ void ScriptEngine::evaluateAndProgressAllSequentialScripts( void )
 			continue;
 		}
 
-		lastIt = it;
+		lastScript = (*it);
 		
-		Bool itAdvanced = false;
+		itAdvanced = false;
 
 		SequentialScript *seqScript = (*it);
 		if (seqScript == NULL) {

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
@@ -7883,12 +7883,13 @@ void ScriptEngine::setSequentialTimer(Team *team, Int frameCount)
 
 void ScriptEngine::evaluateAndProgressAllSequentialScripts( void )
 {
-	VecSequentialScriptPtrIt it, lastIt;
-	lastIt = m_sequentialScripts.end();
+	VecSequentialScriptPtrIt it;
+	SequentialScript* lastScript = NULL;
+	Bool itAdvanced = false;
 
 	Int spinCount = 0;
 	for (it = m_sequentialScripts.begin(); it != m_sequentialScripts.end(); /* empty */) {
-		if (it == lastIt) {
+		if ((*it) == lastScript) {
 			++spinCount;
 		} else {
 			spinCount = 0;
@@ -7904,9 +7905,9 @@ void ScriptEngine::evaluateAndProgressAllSequentialScripts( void )
 			continue;
 		}
 
-		lastIt = it;
+		lastScript = (*it);
 		
-		Bool itAdvanced = false;
+		itAdvanced = false;
 
 		SequentialScript *seqScript = (*it);
 		if (seqScript == NULL) {


### PR DESCRIPTION
The script engines stored a copy of the previous iterator to determine if it was stuck within a loop.
The issue is that when the container for the scripts is modified, this previous iterator becomes invalidated with std lib style iterators.

To correct this and replicate the behaviour that Stl port style iterators would have, i instead store the value of the data pointed at by the previous iterator and compare that to the data pointed at by the current iterator.

This correction is required for Debug to work, it also removes any unexpected behaviour that may happen.

- Related to: #563 