### PR TITLE
[GEN][ZH] Fix stlport iterator use to conform with STL

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -1346,9 +1346,12 @@ void ControlBar::update( void )
 
 		}  
 		else // get the first and only drawble in the selection list
-			drawToEvaluateFor = TheInGameUI->getAllSelectedDrawables()->front();
-		Object *obj = drawToEvaluateFor ? drawToEvaluateFor->getObject() : NULL;
-		setPortraitByObject( obj );
+			// TheSuperHackers @fix Mauller 07/04/2025 The first access to this can return an empty list
+			if (!TheInGameUI->getAllSelectedDrawables()->empty()) {
+				drawToEvaluateFor = TheInGameUI->getAllSelectedDrawables()->front();
+				Object *obj = drawToEvaluateFor ? drawToEvaluateFor->getObject() : NULL;
+				setPortraitByObject( obj );
+			}
 		
 		return;
 	}

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/MobNexusContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/MobNexusContain.cpp
@@ -348,7 +348,7 @@ UpdateSleepTime MobNexusContain::update()
 				ContainedItemsList::const_iterator it;
 				it = items->begin();
 
-				while( *it )
+				while( it != items->end() )
 				{
 					Object *object = *it;
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -1283,7 +1283,7 @@ void OpenContain::processDamageToContained()
 		ContainedItemsList::const_iterator it;
 		it = items->begin();
 
-		while( *it )
+		while( it != items->end() )
 		{
 			Object *object = *it;
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp
@@ -435,7 +435,7 @@ void OverlordContain::clientVisibleContainedFlashAsSelected()
 		ContainedItemsList::const_iterator it;
 		it = items->begin();
 
-		while( *it )
+		while( it != items->end() )
 		{
 			Object *object = *it;
 			if ( object && object->isKindOf( KINDOF_PORTABLE_STRUCTURE ) )

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
@@ -382,7 +382,7 @@ UpdateSleepTime TransportContain::update()
 				ContainedItemsList::const_iterator it;
 				it = items->begin();
 
-				while( *it )
+				while( it != items->end() )
 				{
 					Object *object = *it;
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
@@ -5480,7 +5480,7 @@ Bool PartitionFilterStealthedAndUndetected::allow( Object *objOther )
 		//This handles neutral containers that hold stealth units. This specifically fixes a bug where hunt scripts would ignore
 		//this case -- units would acquire the building Jarmen Kell occupied even though it was not stealth detected.
 		const ContainModuleInterface* contain = objOther->getContain();
-		if( contain )
+		if( contain && !contain->getContainedItemsList()->empty() )
 		{
 			const Player* victimApparentController = contain->getApparentControllingPlayer( m_obj->getControllingPlayer() );
 			//Check if it's stealthed!

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/RailroadGuideAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/RailroadGuideAIUpdate.cpp
@@ -1384,12 +1384,17 @@ void RailroadBehavior::FindPosByPathDistance( Coord3D *pos, const Real dist, con
 	{
 		const TrackPoint *thisPoint = &(*pointIter);
 		++pointIter;// next pointIter in this list, so then...
-		const TrackPoint *nextPoint = &(*pointIter);
 
 
 		if (thisPoint && thisPoint->m_distanceFromFirst < actualDistance)// I am after this point, and
 		{
 			Coord3D thisPointPos = thisPoint->m_position;
+			const TrackPoint *nextPoint = NULL;
+
+			// TheSuperHackers Mauller 02/04/2025 Prevent dereferencing of endpoint pointer which throws asserts during Debug
+			if (pointIter != pointList->end()) {
+				 nextPoint = &(*pointIter);
+			}
 			
 			if (nextPoint && nextPoint->m_distanceFromFirst > actualDistance)
 			{

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -1450,9 +1450,12 @@ void ControlBar::update( void )
 
 		}  
 		else // get the first and only drawble in the selection list
-			drawToEvaluateFor = TheInGameUI->getAllSelectedDrawables()->front();
-		Object *obj = drawToEvaluateFor ? drawToEvaluateFor->getObject() : NULL;
-		setPortraitByObject( obj );
+			// TheSuperHackers @fix Mauller 07/04/2025 The first access to this can return an empty list
+			if (!TheInGameUI->getAllSelectedDrawables()->empty()) {
+				drawToEvaluateFor = TheInGameUI->getAllSelectedDrawables()->front();
+				Object *obj = drawToEvaluateFor ? drawToEvaluateFor->getObject() : NULL;
+				setPortraitByObject( obj );
+			}
 		
 		return;
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/MobNexusContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/MobNexusContain.cpp
@@ -348,7 +348,7 @@ UpdateSleepTime MobNexusContain::update()
 				ContainedItemsList::const_iterator it;
 				it = items->begin();
 
-				while( *it )
+				while( it != items->end() )
 				{
 					Object *object = *it;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -1448,7 +1448,7 @@ void OpenContain::processDamageToContained(Real percentDamage)
 		ContainedItemsList::const_iterator it;
 		it = items->begin();
 
-		while( *it )
+		while( it != items->end() )
 		{
 			Object *object = *it;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp
@@ -555,7 +555,7 @@ void OverlordContain::clientVisibleContainedFlashAsSelected()
 		ContainedItemsList::const_iterator it;
 		it = items->begin();
 
-		while( *it )
+		while( it != items->end() )
 		{
 			Object *object = *it;
 			if ( object && object->isKindOf( KINDOF_PORTABLE_STRUCTURE ) )

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
@@ -240,7 +240,7 @@ void TransportContain::letRidersUpgradeWeaponSet( void )
 		ContainedItemsList::const_iterator it;
 		it = riderList->begin();
 
-		while( *it )
+		while( it != riderList->end() )
 		{
 			Object *rider = *it;
 
@@ -494,7 +494,7 @@ UpdateSleepTime TransportContain::update()
 				ContainedItemsList::const_iterator it;
 				it = items->begin();
 
-				while( *it )
+				while( it != items->end() )
 				{
 					Object *object = *it;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
@@ -5552,7 +5552,7 @@ Bool PartitionFilterStealthedAndUndetected::allow( Object *objOther )
 		//This handles neutral containers that hold stealth units. This specifically fixes a bug where hunt scripts would ignore
 		//this case -- units would acquire the building Jarmen Kell occupied even though it was not stealth detected.
 		const ContainModuleInterface* contain = objOther->getContain();
-		if( contain )
+		if( contain && !contain->getContainedItemsList()->empty() )
 		{
 			const Player* victimApparentController = contain->getApparentControllingPlayer( m_obj->getControllingPlayer() );
 			//Check if it's stealthed!

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/RailroadGuideAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/RailroadGuideAIUpdate.cpp
@@ -1425,12 +1425,17 @@ void RailroadBehavior::FindPosByPathDistance( Coord3D *pos, const Real dist, con
 	{
 		const TrackPoint *thisPoint = &(*pointIter);
 		++pointIter;// next pointIter in this list, so then...
-		const TrackPoint *nextPoint = &(*pointIter);
 
 
 		if (thisPoint && thisPoint->m_distanceFromFirst < actualDistance)// I am after this point, and
 		{
 			Coord3D thisPointPos = thisPoint->m_position;
+			const TrackPoint *nextPoint = NULL;
+
+			// TheSuperHackers Mauller 02/04/2025 Prevent dereferencing of endpoint pointer which throws asserts during Debug
+			if (pointIter != pointList->end()) {
+				 nextPoint = &(*pointIter);
+			}
 			
 			if (nextPoint && nextPoint->m_distanceFromFirst > actualDistance)
 			{


### PR DESCRIPTION
Throughout the code there are various iterators in loops that are expecting to break the loop when the end iterator returns null.

Std lib iterators do not work like this and require an explicit check against the end iterator.

There are also other code blocks that attempt to use iterators even if the container is empty, this is undefined behaviour within std lib as the start iterator of an empty container is invalid.

Some checks are also trying to get an iterator and expecting an empty iterator to signal that a conditional should not be entered. This needs to be corrected by validating that the iterator can be obtained first.

- Related to: #563 