### PR TITLE
[GEN][ZH] Fix list element erasure with iterator on unrelated container in ResourceGatheringManager::findBestSupplyCenter, MilesAudioManager::killLowestPrioritySoundImmediately

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/RTS/ResourceGatheringManager.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/ResourceGatheringManager.cpp
@@ -213,7 +213,7 @@ Object *ResourceGatheringManager::findBestSupplyCenter( Object *queryObject )
 		if( dock )
 		{
 			static const NameKeyType key_centerUpdate = NAMEKEY("SupplyCenterDockUpdate");
-			SupplyWarehouseDockUpdate *centerModule = (SupplyWarehouseDockUpdate*)dock->findUpdateModule( key_centerUpdate );
+			SupplyCenterDockUpdate *centerModule = (SupplyCenterDockUpdate*)dock->findUpdateModule( key_centerUpdate );
 			//If remotely okay, let User win.
 			if( centerModule && computeRelativeCost( queryObject, dock, NULL ) != FLT_MAX )
 				return dock;
@@ -234,7 +234,7 @@ Object *ResourceGatheringManager::findBestSupplyCenter( Object *queryObject )
 
 		if( currentCenter == NULL )
 		{
-			iterator = m_supplyWarehouses.erase( iterator );
+			iterator = m_supplyCenters.erase( iterator );
 		}
 		else
 		{

--- a/Generals/Code/GameEngine/Source/Common/System/SubsystemInterface.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/SubsystemInterface.cpp
@@ -137,7 +137,7 @@ void SubsystemInterfaceList::addSubsystem(SubsystemInterface* sys)
 void SubsystemInterfaceList::removeSubsystem(SubsystemInterface* sys)
 {
 #ifdef DUMP_PERF_STATS
-	for (SubsystemList::iterator it = m_allSubsystems.begin(); it != m_subsystems.end(); ++it)
+	for (SubsystemList::iterator it = m_allSubsystems.begin(); it != m_allSubsystems.end(); ++it)
 	{	 
 		if ( (*it) == sys) {
 			m_allSubsystems.erase(it);

--- a/Generals/Code/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
+++ b/Generals/Code/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
@@ -2085,9 +2085,9 @@ Bool MilesAudioManager::killLowestPrioritySoundImmediately( AudioEventRTS *event
 
 				if( playing->m_audioEventRTS && playing->m_audioEventRTS == lowestPriorityEvent ) 
 				{
-					//Release this 3D sound channel immediately because we are going to play another sound in it's place.
+					//Release this sound channel immediately because we are going to play another sound in it's place.
 					releasePlayingAudio( playing );
-					m_playing3DSounds.erase( it );
+					m_playingSounds.erase( it );
 					return TRUE;
 				}
 			}

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/ResourceGatheringManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/ResourceGatheringManager.cpp
@@ -213,7 +213,7 @@ Object *ResourceGatheringManager::findBestSupplyCenter( Object *queryObject )
 		if( dock )
 		{
 			static const NameKeyType key_centerUpdate = NAMEKEY("SupplyCenterDockUpdate");
-			SupplyWarehouseDockUpdate *centerModule = (SupplyWarehouseDockUpdate*)dock->findUpdateModule( key_centerUpdate );
+			SupplyCenterDockUpdate *centerModule = (SupplyCenterDockUpdate*)dock->findUpdateModule( key_centerUpdate );
 			//If remotely okay, let User win.
 			if( centerModule && computeRelativeCost( queryObject, dock, NULL ) != FLT_MAX )
 				return dock;
@@ -234,7 +234,7 @@ Object *ResourceGatheringManager::findBestSupplyCenter( Object *queryObject )
 
 		if( currentCenter == NULL )
 		{
-			iterator = m_supplyWarehouses.erase( iterator );
+			iterator = m_supplyCenters.erase( iterator );
 		}
 		else
 		{

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/SubsystemInterface.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/SubsystemInterface.cpp
@@ -146,7 +146,7 @@ void SubsystemInterfaceList::addSubsystem(SubsystemInterface* sys)
 void SubsystemInterfaceList::removeSubsystem(SubsystemInterface* sys)
 {
 #ifdef DUMP_PERF_STATS
-	for (SubsystemList::iterator it = m_allSubsystems.begin(); it != m_subsystems.end(); ++it)
+	for (SubsystemList::iterator it = m_allSubsystems.begin(); it != m_allSubsystems.end(); ++it)
 	{	 
 		if ( (*it) == sys) {
 			m_allSubsystems.erase(it);

--- a/GeneralsMD/Code/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
@@ -2087,9 +2087,9 @@ Bool MilesAudioManager::killLowestPrioritySoundImmediately( AudioEventRTS *event
 
 				if( playing->m_audioEventRTS && playing->m_audioEventRTS == lowestPriorityEvent ) 
 				{
-					//Release this 3D sound channel immediately because we are going to play another sound in it's place.
+					//Release this sound channel immediately because we are going to play another sound in it's place.
 					releasePlayingAudio( playing );
-					m_playing3DSounds.erase( it );
+					m_playingSounds.erase( it );
 					return TRUE;
 				}
 			}


### PR DESCRIPTION
* Resolves #342
* Resolves #537 
* Closes #349
* Relates to #563 

Within some iterator use, likely due to copy and paste errors, there are iterators being used on the wrong container.

In the short term this can cause memory leaks as the required data is never freed from the container.

This can also cause unexpected behaviour as the container is growing with data that should have been removed.


There is also a bug fix for a cast that was setting the wrong type on a pointer, this does not seem to affect runtime but could be an issue in the future.


