### PR TITLE
[GEN][ZH] Correct the most egregious signed / unsigned mismatch warnings

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/ThingTemplate.h
+++ b/Generals/Code/GameEngine/Include/Common/ThingTemplate.h
@@ -289,14 +289,14 @@ public:
 #if defined(_DEBUG) || defined(_INTERNAL)
 	Bool containsPartialName(const char* n) const
 	{
-		for (int i = 0; i < m_info.size(); i++)
+		for (size_t i = 0; i < m_info.size(); i++)
 			if (strstr(m_info[i].first.str(), n) != NULL)
 				return true;
 		return false;
 	}
 #endif
 
-	AsciiString getNthName(Int i) const
+	AsciiString getNthName(size_t i) const
 	{
 		if (i >= 0 && i < m_info.size())
 		{
@@ -305,7 +305,7 @@ public:
 		return AsciiString::TheEmptyString;
 	}
 
-	AsciiString getNthTag(Int i) const
+	AsciiString getNthTag(size_t i) const
 	{
 		if (i >= 0 && i < m_info.size())
 		{
@@ -314,7 +314,7 @@ public:
 		return AsciiString::TheEmptyString;
 	}
 
-	const ModuleData* getNthData(Int i) const
+	const ModuleData* getNthData(size_t i) const
 	{
 		if (i >= 0 && i < m_info.size())
 		{
@@ -333,7 +333,7 @@ public:
 
 	void setCopiedFromDefault(Bool v)
 	{
-		for (int i = 0; i < m_info.size(); i++)
+		for (size_t i = 0; i < m_info.size(); i++)
 			m_info[i].copiedFromDefault = v;
 	}
 

--- a/Generals/Code/GameEngine/Include/GameLogic/ObjectTypes.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/ObjectTypes.h
@@ -75,10 +75,10 @@ public:
 	Bool isInSet(const ThingTemplate* objectType) const;
 
 	// Is the set empty?
-	UnsignedInt getListSize(void) const { return m_objectTypes.size(); }
+	size_t getListSize(void) const { return m_objectTypes.size(); }
 	
 	// I'd like to loop through, please.
-	AsciiString getNthInList( Int index ) const { return (index < getListSize()) ? m_objectTypes[index] : AsciiString::TheEmptyString; }
+	AsciiString getNthInList( size_t index ) const { return (index < getListSize()) ? m_objectTypes[index] : AsciiString::TheEmptyString; }
 
 	// Prep two arrays for usage with Player::countObjectsByThingTemplate
 	Int prepForPlayerCounting( std::vector<const ThingTemplate *>& templates, std::vector<Int>& counts);

--- a/GeneralsMD/Code/GameEngine/Include/Common/ThingTemplate.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/ThingTemplate.h
@@ -289,14 +289,14 @@ public:
 #if defined(_DEBUG) || defined(_INTERNAL)
 	Bool containsPartialName(const char* n) const
 	{
-		for (int i = 0; i < m_info.size(); i++)
+		for (size_t i = 0; i < m_info.size(); i++)
 			if (strstr(m_info[i].first.str(), n) != NULL)
 				return true;
 		return false;
 	}
 #endif
 
-	AsciiString getNthName(Int i) const
+	AsciiString getNthName(size_t i) const
 	{
 		if (i >= 0 && i < m_info.size())
 		{
@@ -305,7 +305,7 @@ public:
 		return AsciiString::TheEmptyString;
 	}
 
-	AsciiString getNthTag(Int i) const
+	AsciiString getNthTag(size_t i) const
 	{
 		if (i >= 0 && i < m_info.size())
 		{
@@ -314,7 +314,7 @@ public:
 		return AsciiString::TheEmptyString;
 	}
 
-	const ModuleData* getNthData(Int i) const
+	const ModuleData* getNthData(size_t i) const
 	{
 		if (i >= 0 && i < m_info.size())
 		{
@@ -333,7 +333,7 @@ public:
 
 	void setCopiedFromDefault(Bool v)
 	{
-		for (int i = 0; i < m_info.size(); i++)
+		for (size_t i = 0; i < m_info.size(); i++)
 			m_info[i].copiedFromDefault = v;
 	}
 

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/GameClient.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/GameClient.h
@@ -249,8 +249,8 @@ inline Drawable* GameClient::findDrawableByID( const DrawableID id )
 //
 //	return (*it).second;
 
-	if( (Int)id < m_drawableVector.size() )
-		return m_drawableVector[(Int)id];
+	if( (size_t)id < m_drawableVector.size() )
+		return m_drawableVector[(size_t)id];
 
 	return NULL;
 }

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/GameLogic.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/GameLogic.h
@@ -417,8 +417,8 @@ inline Object* GameLogic::findObjectByID( ObjectID id )
 //		return NULL;
 //	
 //	return (*it).second;
-	if( (Int)id < m_objVector.size() )
-		return m_objVector[(Int)id];
+	if( (size_t)id < m_objVector.size() )
+		return m_objVector[(size_t)id];
 
 	return NULL;
 }

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/ObjectTypes.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/ObjectTypes.h
@@ -75,10 +75,10 @@ public:
 	Bool isInSet(const ThingTemplate* objectType) const;
 
 	// Is the set empty?
-	UnsignedInt getListSize(void) const { return m_objectTypes.size(); }
+	size_t getListSize(void) const { return m_objectTypes.size(); }
 	
 	// I'd like to loop through, please.
-	AsciiString getNthInList( Int index ) const { return (index < getListSize()) ? m_objectTypes[index] : AsciiString::TheEmptyString; }
+	AsciiString getNthInList( size_t index ) const { return (index < getListSize()) ? m_objectTypes[index] : AsciiString::TheEmptyString; }
 
 	// Prep two arrays for usage with Player::countObjectsByThingTemplate
 	Int prepForPlayerCounting( std::vector<const ThingTemplate *>& templates, std::vector<Int>& counts);


### PR DESCRIPTION
I managed to grab the lowest hanging fruit with the least number of changes to knock out 1500 warnings.

Fixing the types on these headers shaved 1/4 of the build time off.

Generals does not have an equivalent to change in GameLogic or GameClient.