### PR TITLE
[GEN][ZH] Refactor GameLogic::rebalanceChildSleepyUpdate to avoid "vector subscript out of range" debug error

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -2504,9 +2504,9 @@ Int GameLogic::rebalanceChildSleepyUpdate(Int i)
 	UpdateModulePtr* pI = &m_sleepyUpdates[i];
 
 	// our children are i*2 and i*2+1
-  Int child = ((i+1)<<1)-1;
-	UpdateModulePtr* pChild = &m_sleepyUpdates[child];
-	UpdateModulePtr* pSZ = &m_sleepyUpdates[m_sleepyUpdates.size()];	// yes, this is off the end.
+  Int child = ((i)<<1)+1;
+	UpdateModulePtr* pChild = &m_sleepyUpdates[0] + child;
+	UpdateModulePtr* pSZ = &m_sleepyUpdates[0] + m_sleepyUpdates.size();	// yes, this is off the end.
 
   while (pChild < pSZ) 
 	{
@@ -2536,13 +2536,13 @@ Int GameLogic::rebalanceChildSleepyUpdate(Int i)
 		i = child;
 		pI = pChild;
 
-		child = ((i+1)<<1)-1;
-		pChild = &m_sleepyUpdates[child];
+		child = ((i)<<1)+1;
+		pChild = &m_sleepyUpdates[0] + child;
   }
 #else
 	// our children are i*2 and i*2+1
 	Int sz = m_sleepyUpdates.size();
-  Int child = ((i+1)<<1)-1;
+  Int child = ((i)<<1)+1;
   while (child < sz) 
 	{
 		// choose the higher-priority of the two children; we must be higher-pri than that.
@@ -2565,7 +2565,7 @@ Int GameLogic::rebalanceChildSleepyUpdate(Int i)
 		a->friend_setIndexInLogic(i);
 		b->friend_setIndexInLogic(child);
 		i = child;
-		child = ((i+1)<<1)-1;
+		child = ((i)<<1)+1;
   }
 #endif
 	return i;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -2834,9 +2834,9 @@ Int GameLogic::rebalanceChildSleepyUpdate(Int i)
 	UpdateModulePtr* pI = &m_sleepyUpdates[i];
 
 	// our children are i*2 and i*2+1
-  Int child = ((i+1)<<1)-1;
-	UpdateModulePtr* pChild = &m_sleepyUpdates[child];
-	UpdateModulePtr* pSZ = &m_sleepyUpdates[m_sleepyUpdates.size()];	// yes, this is off the end.
+  Int child = ((i)<<1)+1;
+	UpdateModulePtr* pChild = &m_sleepyUpdates[0] + child;
+	UpdateModulePtr* pSZ = &m_sleepyUpdates[0] + m_sleepyUpdates.size();	// yes, this is off the end.
 
   while (pChild < pSZ) 
 	{
@@ -2866,13 +2866,13 @@ Int GameLogic::rebalanceChildSleepyUpdate(Int i)
 		i = child;
 		pI = pChild;
 
-		child = ((i+1)<<1)-1;
-		pChild = &m_sleepyUpdates[child];
+		child = ((i)<<1)+1;
+		pChild = &m_sleepyUpdates[0] + child;
   }
 #else
 	// our children are i*2 and i*2+1
 	Int sz = m_sleepyUpdates.size();
-  Int child = ((i+1)<<1)-1;
+  Int child = ((i)<<1)+1;
   while (child < sz) 
 	{
 		// choose the higher-priority of the two children; we must be higher-pri than that.
@@ -2895,7 +2895,7 @@ Int GameLogic::rebalanceChildSleepyUpdate(Int i)
 		a->friend_setIndexInLogic(i);
 		b->friend_setIndexInLogic(child);
 		i = child;
-		child = ((i+1)<<1)-1;
+		child = ((i)<<1)+1;
   }
 #endif
 	return i;


### PR DESCRIPTION
* Closes #563

This change refactors GameLogic::rebalanceChildSleepyUpdate to avoid the "vector subscript out of range" debug error. Functionality wise nothing changes. In release this is no bug.

## TODO

- [x] Replicate in Generals