### PR TITLE
[CMAKE] Add support for DirectX 9 SDK in CMake configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ if((WIN32 OR "${CMAKE_SYSTEM}" MATCHES "Windows") AND ${CMAKE_SIZEOF_VOID_P} EQU
     include(cmake/miles.cmake)
     include(cmake/bink.cmake)
     include(cmake/dx8.cmake)
+    include(cmake/dx9.cmake)
     include(cmake/dbghelp.cmake)
 endif()
 

--- a/cmake/dx9.cmake
+++ b/cmake/dx9.cmake
@@ -1,0 +1,8 @@
+FetchContent_Declare(
+    dx9sdk # Name for FetchContent to manage
+    GIT_REPOSITORY https://github.com/OmarAglan/DX9SDK.git
+    GIT_TAG        423475713f7f8a396474fd6907d4357b8da8e24a # Use the specific commit hash you just pushed
+)
+
+# Make the dx9sdk source available (will be in build/_deps/dx9sdk-src)
+FetchContent_MakeAvailable(dx9sdk)


### PR DESCRIPTION
Add support for DirectX 9 SDK:
Right now it's Cloning from my repository, as we dont have a dx9 sdk repository in the SuperHackers.
this is first step on multiple pull requests for dx9 support for this game

* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR46): Added `include(cmake/dx9.cmake)` to include the new DirectX 9 SDK configuration.

* [`cmake/dx9.cmake`](diffhunk://#diff-bc9c8ed06e1ac4e0f47d25b8c0bc4f9bc1599c2b890052e3b3fccbd6e89f0fa8R1-R8): Added a new file to declare and make available the DirectX 9 SDK using `FetchContent_Declare` and `FetchContent_MakeAvailable`.