### PR TITLE
[GEN][ZH] Fix uninitialized supplyTruck variable in AiPlayer::onUnitProduced()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -1041,7 +1041,13 @@ Bool AIPlayer::isLocationSafe(const Coord3D *pos, const ThingTemplate *tthing )
 void AIPlayer::onUnitProduced( Object *factory, Object *unit )
 {
 	Bool found = false;
+	// TheSuperHackers @fix Mauller 26/04/2025 Fixes uninitialized variable.
+	// To keep retail compatibility this needs to remain uninitialized in VS6 builds.
+#if defined(_MSC_VER) && _MSC_VER < 1300
 	Bool supplyTruck;
+#else
+	Bool supplyTruck = false;
+#endif
 
 	// factory could be NULL at the start of the game.
 	if (factory == NULL) {

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -1048,7 +1048,13 @@ Bool AIPlayer::isLocationSafe(const Coord3D *pos, const ThingTemplate *tthing )
 void AIPlayer::onUnitProduced( Object *factory, Object *unit )
 {
 	Bool found = false;
+	// TheSuperHackers @fix Mauller 26/04/2025 Fixes uninitialized variable.
+	// To keep retail compatibility this needs to remain uninitialized in VS6 builds.
+#if defined(_MSC_VER) && _MSC_VER < 1300
 	Bool supplyTruck;
+#else
+	Bool supplyTruck = false;
+#endif
 
 	// factory could be NULL at the start of the game.
 	if (factory == NULL) {


### PR DESCRIPTION
When running Debug, there are instances where the varaible ```CPP supplyTruck``` will cause a runtime exception due to being uninitialised.

From current testing, the behaviour appears to be that with the value set to False, we can consistantly desync a game with retail.

As the variables is uninitialised, there is a higher chance of it being a non-zero value, resulting in it being considered true in retail.

This needs some further testing and discussion to determine if we set the value to True for now and correct it later, or just set a value in debug only and leave it uninitialised in retail.

- Relates To: #632 