### PR TITLE
[GEN][ZH] Remove duplicate strtrim implementations

### DIFF
--- a/Generals/Code/Main/WinMain.cpp
+++ b/Generals/Code/Main/WinMain.cpp
@@ -64,6 +64,7 @@
 #include "BuildVersion.h"
 #include "GeneratedVersion.h"
 #include "resource.h"
+#include "trim.h"
 
 #ifdef _INTERNAL
 // for occasional debugging...
@@ -753,41 +754,6 @@ void checkProtection(void)
 		exit(0); // someone is messing with us.
 	}
 #endif
-}
-
-// strtrim ====================================================================
-/** Trim leading and trailing whitespace from a character string (in place). */
-//=============================================================================
-static char* strtrim(char* buffer)
-{
-	if (buffer != NULL) {
-		//	Strip leading white space from the string.
-		char * source = buffer;
-		while ((*source != 0) && ((unsigned char)*source <= 32))
-		{
-			source++;
-		}
-
-		if (source != buffer)
-		{
-			strcpy(buffer, source);
-		}
-
-		//	Clip trailing white space from the string.
-		for (int index = strlen(buffer)-1; index >= 0; index--)
-		{
-			if ((*source != 0) && ((unsigned char)buffer[index] <= 32))
-			{
-				buffer[index] = '\0';
-			}
-			else
-			{
-				break;
-			}
-		}
-	}
-
-	return buffer;
 }
 
 char *nextParam(char *newSource, const char *seps)

--- a/Generals/Code/Tools/MapCacheBuilder/Source/WinMain.cpp
+++ b/Generals/Code/Tools/MapCacheBuilder/Source/WinMain.cpp
@@ -103,6 +103,7 @@
 #include "Win32Device/GameClient/Win32Mouse.h"
 #include "Win32Device/Common/Win32LocalFileSystem.h"
 #include "Win32Device/Common/Win32BIGFileSystem.h"
+#include "trim.h"
 
 
 // DEFINES ////////////////////////////////////////////////////////////////////
@@ -145,41 +146,6 @@ const Char *g_csfFile = "data\\%s\\Generals.csf";
 ///////////////////////////////////////////////////////////////////////////////
 // PRIVATE FUNCTIONS //////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////
-
-// strtrim ====================================================================
-/** Trim leading and trailing whitespace from a character string (in place). */
-//=============================================================================
-static char* strtrim(char* buffer)
-{
-	if (buffer != NULL) {
-		//	Strip leading white space from the string.
-		char * source = buffer;
-		while ((*source != 0) && ((unsigned char)*source <= 32))
-		{
-			source++;
-		}
-
-		if (source != buffer)
-		{
-			strcpy(buffer, source);
-		}
-
-		//	Clip trailing white space from the string.
-		for (int index = strlen(buffer)-1; index >= 0; index--)
-		{
-			if ((*source != 0) && ((unsigned char)buffer[index] <= 32))
-			{
-				buffer[index] = '\0';
-			}
-			else
-			{
-				break;
-			}
-		}
-	}
-
-	return buffer;
-}
 
 static char *nextParam(char *newSource, const char *seps)
 {

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/CMakeLists.txt
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/CMakeLists.txt
@@ -44,7 +44,7 @@ target_include_directories(z_wwvegas INTERFACE
     WW3D2
     WWDebug
     WWDownload
-    WWLib
+    #WWLib
     WWMath
     WWSaveLoad
     Wwutil

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/CMakeLists.txt
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/CMakeLists.txt
@@ -126,6 +126,10 @@ set_target_properties(z_wwlib PROPERTIES OUTPUT_NAME wwlib)
 
 target_sources(z_wwlib PRIVATE ${WWLIB_SRC})
 
+target_include_directories(z_wwlib PUBLIC
+    .
+)
+
 target_link_libraries(z_wwlib PRIVATE
     z_wwcommon
     zi_always

--- a/GeneralsMD/Code/Main/WinMain.cpp
+++ b/GeneralsMD/Code/Main/WinMain.cpp
@@ -65,6 +65,7 @@
 #include "BuildVersion.h"
 #include "GeneratedVersion.h"
 #include "resource.h"
+#include "trim.h"
 
 #include <rts/profile.h>
 
@@ -775,41 +776,6 @@ void checkProtection(void)
 		exit(0); // someone is messing with us.
 	}
 #endif
-}
-
-// strtrim ====================================================================
-/** Trim leading and trailing whitespace from a character string (in place). */
-//=============================================================================
-static char* strtrim(char* buffer)
-{
-	if (buffer != NULL) {
-		//	Strip leading white space from the string.
-		char * source = buffer;
-		while ((*source != 0) && ((unsigned char)*source <= 32))
-		{
-			source++;
-		}
-
-		if (source != buffer)
-		{
-			strcpy(buffer, source);
-		}
-
-		//	Clip trailing white space from the string.
-		for (int index = strlen(buffer)-1; index >= 0; index--)
-		{
-			if ((*source != 0) && ((unsigned char)buffer[index] <= 32))
-			{
-				buffer[index] = '\0';
-			}
-			else
-			{
-				break;
-			}
-		}
-	}
-
-	return buffer;
 }
 
 char *nextParam(char *newSource, const char *seps)

--- a/GeneralsMD/Code/Tools/MapCacheBuilder/Source/WinMain.cpp
+++ b/GeneralsMD/Code/Tools/MapCacheBuilder/Source/WinMain.cpp
@@ -103,6 +103,7 @@
 #include "Win32Device/GameClient/Win32Mouse.h"
 #include "Win32Device/Common/Win32LocalFileSystem.h"
 #include "Win32Device/Common/Win32BIGFileSystem.h"
+#include "trim.h"
 
 
 // DEFINES ////////////////////////////////////////////////////////////////////
@@ -145,41 +146,6 @@ const Char *g_csfFile = "data\\%s\\Generals.csf";
 ///////////////////////////////////////////////////////////////////////////////
 // PRIVATE FUNCTIONS //////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////
-
-// strtrim ====================================================================
-/** Trim leading and trailing whitespace from a character string (in place). */
-//=============================================================================
-static char* strtrim(char* buffer)
-{
-	if (buffer != NULL) {
-		//	Strip leading white space from the string.
-		char * source = buffer;
-		while ((*source != 0) && ((unsigned char)*source <= 32))
-		{
-			source++;
-		}
-
-		if (source != buffer)
-		{
-			strcpy(buffer, source);
-		}
-
-		//	Clip trailing white space from the string.
-		for (int index = strlen(buffer)-1; index >= 0; index--)
-		{
-			if ((*source != 0) && ((unsigned char)buffer[index] <= 32))
-			{
-				buffer[index] = '\0';
-			}
-			else
-			{
-				break;
-			}
-		}
-	}
-
-	return buffer;
-}
 
 static char *nextParam(char *newSource, const char *seps)
 {

--- a/GeneralsMD/Code/Tools/buildVersionUpdate/CMakeLists.txt
+++ b/GeneralsMD/Code/Tools/buildVersionUpdate/CMakeLists.txt
@@ -9,4 +9,5 @@ target_sources(z_buildversionupdate PRIVATE ${BUILDVERSIONUPDATE_SRC})
 
 target_link_libraries(z_buildversionupdate PRIVATE
     core_config
+    z_wwlib
 )

--- a/GeneralsMD/Code/Tools/buildVersionUpdate/buildVersionUpdate.cpp
+++ b/GeneralsMD/Code/Tools/buildVersionUpdate/buildVersionUpdate.cpp
@@ -27,6 +27,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <trim.h>
 
 // Local defines
 #define VERSION_MAJOR "VERSION_MAJOR"
@@ -70,42 +71,6 @@ static void usage(char *progname)
 	{
 		printf ("Usage: %s versionfile.h", progname);
 	}
-}
-
-
-// strtrim ====================================================================
-/** Trim leading and trailing whitespace from a character string (in place). */
-//=============================================================================
-static char* strtrim(char* buffer)
-{
-	if (buffer != NULL) {
-		//	Strip leading white space from the string.
-		char * source = buffer;
-		while ((*source != 0) && ((unsigned char)*source <= 32))
-		{
-			source++;
-		}
-
-		if (source != buffer)
-		{
-			strcpy(buffer, source);
-		}
-
-		//	Clip trailing white space from the string.
-		for (int index = strlen(buffer)-1; index >= 0; index--)
-		{
-			if ((*source != 0) && ((unsigned char)buffer[index] <= 32))
-			{
-				buffer[index] = '\0';
-			}
-			else
-			{
-				break;
-			}
-		}
-	}
-
-	return buffer;
 }
 
 int APIENTRY WinMain(HINSTANCE hInstance,

--- a/GeneralsMD/Code/Tools/textureCompress/CMakeLists.txt
+++ b/GeneralsMD/Code/Tools/textureCompress/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(z_texturecompress PRIVATE ${TEXTURECOMPRESS_SRC})
 
 target_link_libraries(z_texturecompress PRIVATE
     core_config
+    z_wwlib
 )
 
 if(WIN32 OR "${CMAKE_SYSTEM}" MATCHES "Windows")

--- a/GeneralsMD/Code/Tools/textureCompress/textureCompress.cpp
+++ b/GeneralsMD/Code/Tools/textureCompress/textureCompress.cpp
@@ -36,6 +36,7 @@
 #include <io.h>
 #include <sys/stat.h>
 #include <sys/utime.h>
+#include <trim.h>
 
 static const char *nodxtPrefix[] = {
 	"zhca",
@@ -265,43 +266,6 @@ FileInfoSet* Directory::getFiles( void )
 FileInfoSet* Directory::getSubdirs( void )
 {
 	return &m_subdirs;
-}
-
-//-------------------------------------------------------------------------------------------------
-
-// strtrim ====================================================================
-/** Trim leading and trailing whitespace from a character string (in place). */
-//=============================================================================
-static char* strtrim(char* buffer)
-{
-	if (buffer != NULL) {
-		//	Strip leading white space from the string.
-		char * source = buffer;
-		while ((*source != 0) && ((unsigned char)*source <= 32))
-		{
-			source++;
-		}
-
-		if (source != buffer)
-		{
-			strcpy(buffer, source);
-		}
-
-		//	Clip trailing white space from the string.
-		for (int index = strlen(buffer)-1; index >= 0; index--)
-		{
-			if ((*source != 0) && ((unsigned char)buffer[index] <= 32))
-			{
-				buffer[index] = '\0';
-			}
-			else
-			{
-				break;
-			}
-		}
-	}
-
-	return buffer;
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/Tools/versionUpdate/CMakeLists.txt
+++ b/GeneralsMD/Code/Tools/versionUpdate/CMakeLists.txt
@@ -9,4 +9,5 @@ target_sources(z_versionupdate PRIVATE ${VERSIONUPDATE_SRC})
 
 target_link_libraries(z_versionupdate PRIVATE
     core_config
+    z_wwlib
 )

--- a/GeneralsMD/Code/Tools/versionUpdate/versionUpdate.cpp
+++ b/GeneralsMD/Code/Tools/versionUpdate/versionUpdate.cpp
@@ -27,6 +27,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <trim.h>
 
 // Local defines
 #define VERSION_BUILDNUM "VERSION_LOCALBUILDNUM"
@@ -86,42 +87,6 @@ static void usage(char *progname)
 	{
 		printf ("Usage: %s versionfile.h", progname);
 	}
-}
-
-
-// strtrim ====================================================================
-/** Trim leading and trailing whitespace from a character string (in place). */
-//=============================================================================
-static char* strtrim(char* buffer)
-{
-	if (buffer != NULL) {
-		//	Strip leading white space from the string.
-		char * source = buffer;
-		while ((*source != 0) && ((unsigned char)*source <= 32))
-		{
-			source++;
-		}
-
-		if (source != buffer)
-		{
-			strcpy(buffer, source);
-		}
-
-		//	Clip trailing white space from the string.
-		for (int index = strlen(buffer)-1; index >= 0; index--)
-		{
-			if ((*source != 0) && ((unsigned char)buffer[index] <= 32))
-			{
-				buffer[index] = '\0';
-			}
-			else
-			{
-				break;
-			}
-		}
-	}
-
-	return buffer;
 }
 
 int APIENTRY WinMain(HINSTANCE hInstance,


### PR DESCRIPTION
- Depends on: #615 

This PR mostly unifies the strtrim implementation across the various applications that use strtrim.

The trim.h header has been used to include the wwlib variant of trim directly, local variants that were present have been removed.

~~For some tools that don't include the relevant library, the local implementation has been updated to match the implementation of strtrim in trim.cpp.~~