### PR TITLE
[GEN][ZH] Reset DrawableID on map load to avoid massive id growth over the lifetime of the game

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -457,6 +457,9 @@ void GameClient::reset( void )
 	// clear any drawable TOC we might have
 	m_drawableTOC.clear();
 
+	// TheSuperHackers @fix Mauller 13/04/2025 Reset the drawable id so it does not keep growing over the lifetime of the game.
+	m_nextDrawableID = (DrawableID)1;
+
 }  // end reset
 
 /** -----------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -478,6 +478,9 @@ void GameClient::reset( void )
 	// clear any drawable TOC we might have
 	m_drawableTOC.clear();
 
+	// TheSuperHackers @fix Mauller 13/04/2025 Reset the drawable id so it does not keep growing over the lifetime of the game.
+	m_nextDrawableID = (DrawableID)1;
+
 }  // end reset
 
 /** -----------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR resets the drawable ID within `GameClient::reset()` so it does not keep growing over the lifetime of the game. The implication of uncapped growth is that the `GameClient::m_drawableVector` will keep growing as well.

EDIT: This PR has been heavily modified over time and now only resets the DrawableID

~~Within GameClient::reset the lookup tables were being cleared before their relevant drawables were removed from them.
This was causing out of range container errors similar to what was seen in GameLogic::reset.~~

~~destroyDrawable was also reordered so that the drawable was removed from the lookup table before being destroyed in the drawable list.~~

~~This PR reverts some earlier changes made when zero hour was using a vector as a lookup table and resets the drawable ID in gameclient.~~

~~It also adds some debug messages to GameClient and GameLogics ```removeObject/DrawableFromLookupTable``` functions.~~
