### PR TITLE
[GEN][ZH] Decouple Compress from CRCDiff

### DIFF
--- a/Generals/Code/Tools/Compress/CMakeLists.txt
+++ b/Generals/Code/Tools/Compress/CMakeLists.txt
@@ -1,7 +1,5 @@
 set(COMRPESS_SRC
     "Compress.cpp"
-    "../CRCDiff/debug.cpp"
-    "../CRCDiff/debug.h"
 )
 
 add_executable(g_compress WIN32)

--- a/Generals/Code/Tools/Compress/Compress.cpp
+++ b/Generals/Code/Tools/Compress/Compress.cpp
@@ -20,28 +20,11 @@
 #include <cstdio>
 #include "Lib/BaseType.h"
 #include "Compression.h"
-#include "../CRCDiff/debug.h"
 
-#ifndef DEBUG
 
-#include <cstdarg>
+// TheSuperHackers @todo Streamline and simplify the logging approach for tools
+#define DEBUG_LOG(x) printf x
 
-void ReleaseLog(const char *fmt, ...)
-{
-	static char buffer[1024];
-	va_list va;
-	va_start( va, fmt );
-	vsnprintf(buffer, 1024, fmt, va );
-	buffer[1023] = 0;
-	va_end( va );
-
-	printf( "%s", buffer );
-}
-
-#undef DEBUG_LOG
-#define DEBUG_LOG(x) ReleaseLog x
-
-#endif
 
 void dumpHelp(const char *exe)
 {

--- a/GeneralsMD/Code/Tools/Compress/CMakeLists.txt
+++ b/GeneralsMD/Code/Tools/Compress/CMakeLists.txt
@@ -1,7 +1,5 @@
 set(COMRPESS_SRC
     "Compress.cpp"
-    "../CRCDiff/debug.cpp"
-    "../CRCDiff/debug.h"
 )
 
 add_executable(z_compress WIN32)

--- a/GeneralsMD/Code/Tools/Compress/Compress.cpp
+++ b/GeneralsMD/Code/Tools/Compress/Compress.cpp
@@ -20,28 +20,11 @@
 #include <cstdio>
 #include "Lib/BaseType.h"
 #include "Compression.h"
-#include "../CRCDiff/debug.h"
 
-#ifndef DEBUG
 
-#include <cstdarg>
+// TheSuperHackers @todo Streamline and simplify the logging approach for tools
+#define DEBUG_LOG(x) printf x
 
-void ReleaseLog(const char *fmt, ...)
-{
-	static char buffer[1024];
-	va_list va;
-	va_start( va, fmt );
-	vsnprintf(buffer, 1024, fmt, va );
-	buffer[1023] = 0;
-	va_end( va );
-
-	printf( "%s", buffer );
-}
-
-#undef DEBUG_LOG
-#define DEBUG_LOG(x) ReleaseLog x
-
-#endif
 
 void dumpHelp(const char *exe)
 {


### PR DESCRIPTION
This change decouples the Compress tool from CRCDiff. It does so by getting rid of the CRCDiff/Debug.h include. This means it loses the `OutputDebugString` call in Debug, but that should be of no major concern. The logging inside tools may need another pass entirely.