### PR TITLE
[GEN] Backport WW3D2's ringobj, sphereobj, assetstatus from Zero Hour

### DIFF
--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/CMakeLists.txt
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/CMakeLists.txt
@@ -5,6 +5,7 @@ set(WW3D2_SRC
     agg_def.cpp
     animobj.cpp
     assetmgr.cpp
+    assetstatus.cpp
     bitmaphandler.cpp
     bmp2d.cpp
     boxrobj.cpp
@@ -107,6 +108,7 @@ set(WW3D2_SRC
     agg_def.h
     animobj.h
     assetmgr.h
+    assetstatus.h
     bitmaphandler.h
     bmp2d.h
     boxrobj.h

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/assetstatus.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/assetstatus.cpp
@@ -1,0 +1,115 @@
+/*
+**	Command & Conquer Generals Zero Hour(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "assetstatus.h"
+#include "hashtemplate.h"
+#include "wwstring.h"
+#include "RAWFILE.H"
+
+AssetStatusClass AssetStatusClass::Instance;
+
+const char* ReportCategoryNames[AssetStatusClass::REPORT_COUNT]={
+	"LOAD_ON_DEMAND_ROBJ",
+	"LOAD_ON_DEMAND_HANIM",
+	"LOAD_ON_DEMAND_HTREE",
+	"MISSING_ROBJ",
+	"MISSING_HANIM",
+	"MISSING_HTREE"
+};
+
+AssetStatusClass::AssetStatusClass()
+	:
+	Reporting (true),
+	LoadOnDemandReporting(false)
+{
+}
+
+AssetStatusClass::~AssetStatusClass()
+{
+#ifdef WWDEBUG
+	if (Reporting) {
+		StringClass report("Load-on-demand and missing assets report\r\n\r\n");
+		for (int i=0;i<REPORT_COUNT;++i) {
+			report+="Category: ";
+			report+=ReportCategoryNames[i];
+			report+="\r\n\r\n";
+
+			HashTemplateIterator<StringClass,int> ite(ReportHashTables[i]);
+			for (ite.First();!ite.Is_Done();ite.Next()) {
+				report+=ite.Peek_Key();
+				int count=ite.Peek_Value();
+				if (count>1) {
+					StringClass tmp(0,true);
+					tmp.Format("\t(reported %d times)",count);
+					report+=tmp;
+				}
+				report+="\r\n";
+			}
+			report+="\r\n";
+		}
+		if (report.Get_Length()) {
+			RawFileClass raw_log_file("asset_report.txt");
+			raw_log_file.Create();
+			raw_log_file.Open(RawFileClass::WRITE);
+			raw_log_file.Write(report,report.Get_Length());
+			raw_log_file.Close();
+		}
+	}
+#endif
+}
+
+void AssetStatusClass::Add_To_Report(int index, const char* name)
+{
+	StringClass lower_case_name(name,true);
+	_strlwr(lower_case_name.Peek_Buffer());
+	// This is a bit slow - two accesses to the same member, but currently there's no better way to do it.
+	int count=ReportHashTables[index].Get(lower_case_name);
+	count++;
+	ReportHashTables[index].Set_Value(lower_case_name,count);
+}
+
+void AssetStatusClass::Report_Load_On_Demand_RObj(const char* name)
+{
+	if (LoadOnDemandReporting) Add_To_Report(REPORT_LOAD_ON_DEMAND_ROBJ,name);
+}
+
+void AssetStatusClass::Report_Load_On_Demand_HAnim(const char* name)
+{
+	if (LoadOnDemandReporting) Add_To_Report(REPORT_LOAD_ON_DEMAND_HANIM,name);
+}
+
+void AssetStatusClass::Report_Load_On_Demand_HTree(const char* name)
+{
+	if (LoadOnDemandReporting) Add_To_Report(REPORT_LOAD_ON_DEMAND_HTREE,name);
+}
+
+void AssetStatusClass::Report_Missing_RObj(const char* name)
+{
+	Add_To_Report(REPORT_MISSING_ROBJ,name);
+}
+
+void AssetStatusClass::Report_Missing_HAnim(const char* name)
+{
+	Add_To_Report(REPORT_MISSING_HANIM,name);
+}
+
+void AssetStatusClass::Report_Missing_HTree(const char* name)
+{
+	Add_To_Report(REPORT_MISSING_HTREE,name);
+}
+

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/assetstatus.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/assetstatus.h
@@ -1,0 +1,68 @@
+/*
+**	Command & Conquer Generals Zero Hour(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#ifndef WW3D_ASSET_STATUS_H
+#define WW3D_ASSET_STATUS_H
+
+#include "always.h"
+#include "hashtemplate.h"
+
+class AssetStatusClass
+{
+public:
+	enum {
+		REPORT_LOAD_ON_DEMAND_ROBJ,
+		REPORT_LOAD_ON_DEMAND_HANIM,
+		REPORT_LOAD_ON_DEMAND_HTREE,
+		REPORT_MISSING_ROBJ,
+		REPORT_MISSING_HANIM,
+		REPORT_MISSING_HTREE,
+		REPORT_COUNT
+	};
+
+	AssetStatusClass();
+	~AssetStatusClass();
+
+	void Enable_Reporting(bool enable)					  { Reporting=enable; }	
+	void Enable_Load_On_Demand_Reporting(bool enable) { LoadOnDemandReporting=enable; }
+
+	void Report_Load_On_Demand_RObj(const char* name);
+	void Report_Load_On_Demand_HAnim(const char* name);
+	void Report_Load_On_Demand_HTree(const char* name);
+
+	void Report_Missing_RObj(const char* name);
+	void Report_Missing_HAnim(const char* name);
+	void Report_Missing_HTree(const char* name);
+
+	static AssetStatusClass* Peek_Instance() { return &Instance; }
+
+private:
+	bool Reporting;
+	bool LoadOnDemandReporting;
+	static AssetStatusClass Instance;
+	HashTemplateClass<StringClass, int> ReportHashTables[REPORT_COUNT];
+
+	void Add_To_Report(int index, const char* name);
+
+};
+
+#endif

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/ringobj.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/ringobj.h
@@ -129,6 +129,22 @@ public:
 	virtual void 					Set_Position(const Vector3 &v);
    virtual void					Get_Obj_Space_Bounding_Sphere(SphereClass	& sphere) const;
    virtual void					Get_Obj_Space_Bounding_Box(AABoxClass & box) const;
+
+	virtual void					Prepare_LOD(CameraClass &camera);
+	virtual void					Increment_LOD(void);
+	virtual void					Decrement_LOD(void);
+	virtual float					Get_Cost(void) const;
+	virtual float					Get_Value(void) const;
+	virtual float					Get_Post_Increment_Value(void) const;
+	virtual void					Set_LOD_Level(int lod);
+	virtual int						Get_LOD_Level(void) const;
+	virtual int						Get_LOD_Count(void) const;
+	virtual void					Set_LOD_Bias(float bias)	{ LODBias = MAX(bias, 0.0f); }
+	virtual int						Calculate_Cost_Value_Arrays(float screen_area, float *values, float *costs) const;
+
+	virtual void					Scale(float scale);
+	virtual void					Scale(float scalex, float scaley, float scalez);
+
 	virtual void					Set_Hidden(int onoff)				{ RenderObjClass::Set_Hidden (onoff); Update_On_Visibilty (); }
 	virtual void					Set_Visible(int onoff)				{ RenderObjClass::Set_Visible (onoff); Update_On_Visibilty (); }
 	virtual void					Set_Animation_Hidden(int onoff)	{ RenderObjClass::Set_Animation_Hidden (onoff); Update_On_Visibilty (); }
@@ -222,6 +238,12 @@ protected:
 	float								AnimDuration;
 	bool								IsAnimating;
 
+	// LOD Stuff
+	void								calculate_value_array(float screen_area, float *values) const;
+	float								LODBias;
+	int						 		CurrentLOD;
+	float								Value[RING_NUM_LOD + 2];// Value array needs # of LODs + 1 (RING_NUM_LOD doesn't include null LOD)
+
 	RingColorChannelClass		ColorChannel;
 	RingAlphaChannelClass		AlphaChannel;
 	RingScaleChannelClass		InnerScaleChannel;
@@ -238,7 +260,6 @@ protected:
 	Vector2							InnerExtent;
 	Vector2							OuterExtent;
 
-	int						 		CurrentLOD;
 	int								TextureTileCount;
 
 	// Current State

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/sphereobj.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/sphereobj.cpp
@@ -63,6 +63,8 @@
  *   SphereRenderObjClass::Intersect_OBSphere -- Intersect this Sphere with an OBSphere        *
  *   SphereRenderObjClass::Get_Obj_Space_Bounding_Sphere -- return the object-space bounding sp*
  *   SphereRenderObjClass::Get_Obj_Space_Bounding_Sphere -- returns the obj-space bounding Sphe*
+ *   SphereRenderObjClass::Scale -- scales sphere uniformly.                                   *
+ *   SphereRenderObjClass::Scale -- scales sphere non-uniformly.                               *
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 
@@ -74,7 +76,9 @@
 #include "chunkio.h"
 #include "rinfo.h"
 #include "coltest.h"
+#include "bound.h"
 #include "inttest.h"
+#include "predlod.h"
 #include "matrix3.h"
 #include "wwmath.h"
 #include "assetmgr.h"
@@ -87,17 +91,10 @@
 #include "sortingrenderer.h"
 #include "visrasterizer.h"
 
-
-#define SPHERE_NUM_LOD		(6)
-#define SPHERE_LOWEST_LOD	(4)
-#define SPHERE_HIGHEST_LOD (16)
-
-#define STATIC_SORT_SPHERES	1
-#define SPHERE_SORT_LEVEL		1
-
 static bool Sphere_Array_Valid = false;
 
 SphereMeshClass SphereMeshArray[SPHERE_NUM_LOD];
+float SphereLODCosts[SPHERE_NUM_LOD + 1];	// SPHERE_NUM_LOD doesn't include the null LOD
 
 
 /*
@@ -119,28 +116,30 @@ SphereMeshClass SphereMeshArray[SPHERE_NUM_LOD];
 SphereRenderObjClass::SphereRenderObjClass(void)
 	:	anim_time (0.0F),
 		IsAnimating (true),
+		LODBias(1.0f),
+		CurrentLOD(SPHERE_NUM_LOD),	// SPHERE_NUM_LOD does not include the null LOD
 		AnimDuration (0.0F),
 		SphereMaterial (NULL),
 		SphereTexture (NULL),
-		Color (0.75F,0.75F,0.75F),
-		Scale (1, 1, 1),
-		Alpha (1.0F),
+		CurrentColor(0.75f, 0.75f, 0.75F),
+		CurrentAlpha(1.0f),
+		CurrentScale(1.0f, 1.0f, 1.0f),
+		CurrentVector(),
 		Flags(USE_ALPHA_VECTOR),
 		ObjSpaceCenter (0, 0, 0),
-		ObjSpaceExtent (1, 1, 1),
-		CurrentLOD (SPHERE_NUM_LOD - 1)
+		ObjSpaceExtent (1, 1, 1)
 {
-	Generate_Shared_Mesh_Arrays ( Vector );
+	Generate_Shared_Mesh_Arrays ( CurrentVector );
 
 	Orientation.Make_Identity();
 	memset(Name,0,sizeof(Name));
 
 	Init_Material ();
 
-#if (STATIC_SORT_SPHERES)
-	//	(gth) testing whether we can get away without poly-sorting rings and spheres
-	Set_Sort_Level(SPHERE_SORT_LEVEL);
-#endif
+	// So that the object is ready for use after construction, we will
+	// complete its initialization by initializing its value array
+	// according to a screen area of 1.
+	calculate_value_array(1.0f, Value);
 }
 
 
@@ -159,18 +158,20 @@ SphereRenderObjClass::SphereRenderObjClass(void)
 SphereRenderObjClass::SphereRenderObjClass(const W3dSphereStruct & def)
 	:	anim_time (0.0F),
 		IsAnimating (true),
+		LODBias(1.0f),
+		CurrentLOD(SPHERE_NUM_LOD),	// SPHERE_NUM_LOD does not include the null LOD
 		AnimDuration (0.0F),
 		SphereMaterial (NULL),
 		SphereTexture (NULL),
-		Color (0.75F,0.75F,0.75F),
-		Scale (1, 1, 1),
-		Alpha (1.0F),
+		CurrentColor(0.75f, 0.75f, 0.75F),
+		CurrentAlpha(1.0f),
+		CurrentScale(1.0f, 1.0f, 1.0f),
+		CurrentVector(),
 		Flags(USE_ALPHA_VECTOR),
 		ObjSpaceCenter (0, 0, 0),
-		ObjSpaceExtent (1, 1, 1),
-		CurrentLOD (SPHERE_NUM_LOD - 1)
+		ObjSpaceExtent (1, 1, 1)
 {
-	Generate_Shared_Mesh_Arrays ( Vector );
+	Generate_Shared_Mesh_Arrays ( CurrentVector );
 	Init_Material ();
 	Orientation.Make_Identity();
 	
@@ -185,10 +186,10 @@ SphereRenderObjClass::SphereRenderObjClass(const W3dSphereStruct & def)
 		SphereTexture = WW3DAssetManager::Get_Instance ()->Get_Texture (def.TextureName);
 	}
 
-#if (STATIC_SORT_SPHERES)
-	//	(gth) testing whether we can get away without poly-sorting rings and spheres
-	Set_Sort_Level(SPHERE_SORT_LEVEL);
-#endif
+	// So that the object is ready for use after construction, we will
+	// complete its initialization by initializing its value array
+	// according to a screen area of 1.
+	calculate_value_array(1.0f, Value);
 }
 
 
@@ -207,27 +208,29 @@ SphereRenderObjClass::SphereRenderObjClass(const W3dSphereStruct & def)
 SphereRenderObjClass::SphereRenderObjClass(const SphereRenderObjClass & src)
 	:	anim_time (0.0F),
 		IsAnimating (true),
+		LODBias(1.0f),
+		CurrentLOD(SPHERE_NUM_LOD),	// SPHERE_NUM_LOD does not include the null LOD
 		AnimDuration (0.0F),
 		SphereMaterial (NULL),
 		SphereTexture (NULL),
-		Color (0.75F,0.75F,0.75F),
-		Scale (1, 1, 1),
-		Alpha (1.0F),
+		CurrentColor(0.75f, 0.75f, 0.75F),
+		CurrentAlpha(1.0f),
+		CurrentScale(1.0f, 1.0f, 1.0f),
+		CurrentVector(),
 		Flags(USE_ALPHA_VECTOR),
 		ObjSpaceCenter (0, 0, 0),
-		ObjSpaceExtent (1, 1, 1),
-		CurrentLOD (SPHERE_NUM_LOD - 1)
+		ObjSpaceExtent (1, 1, 1)
 {
-	Generate_Shared_Mesh_Arrays ( Vector );	
+	Generate_Shared_Mesh_Arrays ( CurrentVector );	
 	Init_Material ();
 	Orientation.Make_Identity();
 
 	*this = src;
 
-#if (STATIC_SORT_SPHERES)
-	//	(gth) testing whether we can get away without poly-sorting rings and spheres
-	Set_Sort_Level(SPHERE_SORT_LEVEL);
-#endif
+	// So that the object is ready for use after construction, we will
+	// complete its initialization by initializing its value array
+	// according to a screen area of 1.
+	calculate_value_array(1.0f, Value);
 }
 
 SphereRenderObjClass::~SphereRenderObjClass()
@@ -252,10 +255,10 @@ SphereRenderObjClass & SphereRenderObjClass::operator = (const SphereRenderObjCl
 	if (this != &that) {
 		RenderObjClass::operator = (that);
 		Set_Name(that.Get_Name());
-		Color					= that.Color;
-		Alpha					= that.Alpha;
-		Scale					= that.Scale;
-		Vector				= that.Vector;
+		CurrentColor		= that.CurrentColor;
+		CurrentAlpha		= that.CurrentAlpha;
+		CurrentScale		= that.CurrentScale;
+		CurrentVector		= that.CurrentVector;
 		Flags					= that.Flags;
 		Orientation			= that.Orientation;
 		SphereShader		= that.SphereShader;
@@ -297,9 +300,12 @@ void SphereRenderObjClass::Generate_Shared_Mesh_Arrays (const AlphaVectorStruct 
 		float step = (SPHERE_HIGHEST_LOD - SPHERE_LOWEST_LOD);
 		step /= SPHERE_NUM_LOD;
 
+		// For NULL LOD set Cost to a small nonzero amount to avoid divisions by zero.
+		SphereLODCosts[0] = 0.000001f;
 		for(int i=0; i < SPHERE_NUM_LOD; i++) {
 
 			SphereMeshArray[i].Generate(1.0f, size, size);
+			SphereLODCosts[i + 1] = SphereMeshArray[i].Get_Num_Polys();
 
 			size+=step;
 
@@ -312,6 +318,20 @@ void SphereRenderObjClass::Generate_Shared_Mesh_Arrays (const AlphaVectorStruct 
 
 	return ;
 }
+
+
+// This is used both by Prepare_LOD and Calculate_Cost_Value_Arrays.
+void SphereRenderObjClass::calculate_value_array(float screen_area, float *values) const
+{
+	values[0] = AT_MIN_LOD;
+	for (int lod = 1; lod <= SPHERE_NUM_LOD; lod++) {
+		float polycount = SphereLODCosts[lod];
+		float benefit_factor = 1 - (0.5f / (polycount * polycount));
+		values[lod] = (benefit_factor * screen_area * LODBias) / polycount;
+	}
+	values[SPHERE_NUM_LOD + 1] = AT_MAX_LOD; 	// Post-inc value will flag max LOD.
+}
+
 
 /***********************************************************************************************
  * SphereRenderObjClass::Init_Material -- Sets up the material and default shader for the sphere.*
@@ -340,6 +360,10 @@ void SphereRenderObjClass::Init_Material (void)
 
 	// Texturing, zbuffer, primary gradient, alpha blending
 	SphereShader = ShaderClass::_PresetAlphaShader;
+	
+	// (gth) Looks like sphere's were coded with backwards normals! Quick fix (though expensive)
+	// is to turn off backface culling...  ug...
+	SphereShader.Set_Cull_Mode(ShaderClass::CULL_MODE_DISABLE);
 
 }	// Init_Material
 
@@ -358,7 +382,7 @@ void SphereRenderObjClass::Init_Material (void)
  *=============================================================================================*/
 int SphereRenderObjClass::Get_Num_Polys(void) const
 {
-	return SphereMeshArray[ CurrentLOD ].Get_Num_Polys();
+	return SphereLODCosts[CurrentLOD];
 }
 
 
@@ -433,7 +457,13 @@ void SphereRenderObjClass::Set_Name(const char * name)
  *=============================================================================================*/
 void SphereRenderObjClass::render_sphere()
 {
-	SphereMeshClass & mesh = SphereMeshArray[ CurrentLOD ];
+	// Should never get here with NULL LOD
+	if (CurrentLOD == 0) {
+		WWASSERT(0);
+		return;
+	}
+
+	SphereMeshClass & mesh = SphereMeshArray[CurrentLOD - 1];
 
 	if (SphereTexture) {
 		SphereShader.Set_Texturing (ShaderClass::TEXTURING_ENABLE);
@@ -444,7 +474,11 @@ void SphereRenderObjClass::render_sphere()
 	DX8Wrapper::Set_Texture(0,SphereTexture);
 	DX8Wrapper::Set_Material(SphereMaterial);	
 
-	DynamicVBAccessClass vb(BUFFER_TYPE_DYNAMIC_SORTING,dynamic_fvf_type,mesh.Vertex_ct);
+	// Enable sorting if the primitive is translucent, alpha testing is not enabled, and sorting is enabled globally.
+	const bool sort = (SphereShader.Get_Dst_Blend_Func() != ShaderClass::DSTBLEND_ZERO) && (SphereShader.Get_Alpha_Test() == ShaderClass::ALPHATEST_DISABLE) && (WW3D::Is_Sorting_Enabled());
+ 	const unsigned int buffer_type = sort ? BUFFER_TYPE_DYNAMIC_SORTING : BUFFER_TYPE_DYNAMIC_DX8;
+
+	DynamicVBAccessClass vb(buffer_type, dynamic_fvf_type, mesh.Vertex_ct);
 	{
 		DynamicVBAccessClass::WriteLockClass Lock(&vb);
 		VertexFormatXYZNDUV2 *vb = Lock.Get_Formatted_Vertex_Array();
@@ -473,7 +507,7 @@ void SphereRenderObjClass::render_sphere()
 		}		
 	}
 
-	DynamicIBAccessClass ib(BUFFER_TYPE_DYNAMIC_SORTING,mesh.face_ct*3);
+	DynamicIBAccessClass ib(buffer_type, mesh.face_ct*3);
 	{
 		DynamicIBAccessClass::WriteLockClass Lock(&ib);
 		unsigned short *mem=Lock.Get_Index_Array();
@@ -488,16 +522,11 @@ void SphereRenderObjClass::render_sphere()
 	DX8Wrapper::Set_Vertex_Buffer(vb);
 	DX8Wrapper::Set_Index_Buffer(ib,0);
 
-#if (STATIC_SORT_SPHERES)
-	DX8Wrapper::Draw_Triangles(0,mesh.face_ct,0,mesh.Vertex_ct);
-#else
-	SortingRendererClass::Insert_Triangles(
-		Get_Bounding_Sphere(),
-		0,
-		mesh.face_ct,
-		0,
-		mesh.Vertex_ct);
-#endif
+	if (sort) {
+		SortingRendererClass::Insert_Triangles(Get_Bounding_Sphere(), 0, mesh.face_ct, 0, mesh.Vertex_ct);
+	} else {
+		DX8Wrapper::Draw_Triangles(0,mesh.face_ct,0,mesh.Vertex_ct);
+	}
 
 } // render_sphere
 
@@ -571,13 +600,18 @@ int SphereRenderObjClass::Class_ID(void) const
  *=============================================================================================*/
 void SphereRenderObjClass::Render(RenderInfoClass & rinfo)
 {
+	// NULL LOD
+	if (CurrentLOD == 0) return;
+
 	if (Is_Not_Hidden_At_All() == false) {
 		return;
 	}
 	
-	// If static sort lists are enabled and this mesh has a sort level, put it on the list instead
-	// of rendering it.
-	unsigned int sort_level = (unsigned int)Get_Sort_Level();
+	unsigned int sort_level = SORT_LEVEL_NONE;
+
+	if (!WW3D::Is_Sorting_Enabled()) {
+		sort_level = SphereShader.Guess_Sort_Level();
+	}
 
 	if (WW3D::Are_Static_Sort_Lists_Enabled() && sort_level != SORT_LEVEL_NONE) {
 
@@ -588,31 +622,6 @@ void SphereRenderObjClass::Render(RenderInfoClass & rinfo)
 		// Process texture reductions:
 //		if (SphereTexture) SphereTexture->Process_Reduction();
 
-		// Determine LOD
-
-		float screen_size = Get_Screen_Size(rinfo.Camera);
-		
-		// This code assumes that screen_size returns back the percentage of the screen, 0.0 = 0%, 1.0f = 100%
-
-		// Currently it will use Linear interpolation over 0.0 to 1.0, with the SPHERE_NUM_LOD
-		// to set the CurrentLOD
-
-		screen_size = sqrtf(screen_size);
-
-		float lod     = screen_size * ((float) SPHERE_NUM_LOD);
-		int	lod_int = lod;
-		lod-=lod_int;
-
-		if (lod >= 0.5f) lod_int++;
-
-		if (lod_int < 0) lod_int = 0;
-		if (lod_int >= SPHERE_NUM_LOD) lod_int = SPHERE_NUM_LOD-1;
-
-		CurrentLOD = lod_int;
-
-
-		// End LOD Determination
-
 		Matrix3D temp = Transform;
 
 		// Do Time Based Animation
@@ -621,9 +630,9 @@ void SphereRenderObjClass::Render(RenderInfoClass & rinfo)
 		// Scale
 
 		Vector3 real_scale;
-		real_scale.X = ObjSpaceExtent.X * Scale.X;
-		real_scale.Y = ObjSpaceExtent.Y * Scale.Y;
-		real_scale.Z = ObjSpaceExtent.Z * Scale.Z;
+		real_scale.X = ObjSpaceExtent.X * CurrentScale.X;
+		real_scale.Y = ObjSpaceExtent.Y * CurrentScale.Y;
+		real_scale.Z = ObjSpaceExtent.Z * CurrentScale.Z;
 		temp.Scale(real_scale);
 
 		//
@@ -631,10 +640,10 @@ void SphereRenderObjClass::Render(RenderInfoClass & rinfo)
 		//
 		bool is_additive = (SphereShader.Get_Dst_Blend_Func () == ShaderClass::DSTBLEND_ONE);
 		if (is_additive) {
-			SphereMaterial->Set_Emissive (Alpha * Color);
+			SphereMaterial->Set_Emissive (CurrentAlpha * CurrentColor);
 		} else {
-			SphereMaterial->Set_Opacity (Alpha);
-			SphereMaterial->Set_Emissive (Color);
+			SphereMaterial->Set_Opacity (CurrentAlpha);
+			SphereMaterial->Set_Emissive (CurrentColor);
 		}
 
 		// If using Alpha Vector, check to see if it needs updated
@@ -646,7 +655,7 @@ void SphereRenderObjClass::Render(RenderInfoClass & rinfo)
 				use_inverse = true;
 			}
 
-			SphereMeshArray[CurrentLOD].Set_Alpha_Vector( Vector, use_inverse, is_additive );
+			SphereMeshArray[CurrentLOD - 1].Set_Alpha_Vector( CurrentVector, use_inverse, is_additive );
 		}
 
 		// Camera Align
@@ -757,8 +766,6 @@ void SphereRenderObjClass::update_cached_box(void)
 }
 
 
-
-
 /***********************************************************************************************
  * SphereRenderObjClass::Get_Obj_Space_Bounding_Sphere -- return the object-space bounding sphe *
  *                                                                                             *
@@ -794,6 +801,133 @@ void SphereRenderObjClass::Get_Obj_Space_Bounding_Box(AABoxClass & box) const
 	box.Init(ObjSpaceCenter,ObjSpaceExtent);
 }
 
+
+void SphereRenderObjClass::Prepare_LOD(CameraClass &camera)
+{
+	if (Is_Not_Hidden_At_All() == false) {
+		return;
+	}
+
+	calculate_value_array(Get_Screen_Size(camera), Value);
+
+	PredictiveLODOptimizerClass::Add_Object(this);
+}
+
+void SphereRenderObjClass::Increment_LOD(void)
+{
+	if (CurrentLOD < SPHERE_NUM_LOD) CurrentLOD++;
+}
+
+void SphereRenderObjClass::Decrement_LOD(void)
+{
+	if (CurrentLOD > 0) CurrentLOD--;
+}
+
+float SphereRenderObjClass::Get_Cost(void) const
+{
+	return Get_Num_Polys();	// Currently cost == polys
+}
+
+float SphereRenderObjClass::Get_Value(void) const
+{
+	return Value[CurrentLOD];
+}
+
+float SphereRenderObjClass::Get_Post_Increment_Value(void) const
+{
+	return Value[CurrentLOD + 1];
+}
+
+void SphereRenderObjClass::Set_LOD_Level(int lod)
+{
+	CurrentLOD = Bound(lod, 0, SPHERE_NUM_LOD);	// SPHERE_NUM_LOD doesn't include the null LOD
+}
+
+int SphereRenderObjClass::Get_LOD_Level(void) const
+{
+	return CurrentLOD;
+}
+
+int SphereRenderObjClass::Get_LOD_Count(void) const
+{
+	return SPHERE_NUM_LOD + 1;	// SPHERE_NUM_LOD doesn't include the null LOD
+}
+
+int SphereRenderObjClass::Calculate_Cost_Value_Arrays(float screen_area, float *values, float *costs) const
+{
+	calculate_value_array(screen_area, values);
+	for (int lod = 0; lod <= SPHERE_NUM_LOD; lod++) {
+		costs[lod] = SphereLODCosts[lod];
+	}
+
+	// We currently don't support max screen size or minimum LOD clamping for sphere objects
+	return 0;
+}
+
+
+/***********************************************************************************************
+ * SphereRenderObjClass::Scale -- scales sphere uniformly.                                     *
+ *                                                                                             *
+ * INPUT:                                                                                      *
+ *                                                                                             *
+ * OUTPUT:                                                                                     *
+ *                                                                                             *
+ * WARNINGS:                                                                                   *
+ *                                                                                             *
+ * HISTORY:                                                                                    *
+ *   7/01/02    NH : Created.                                                                  *
+ *=============================================================================================*/
+void SphereRenderObjClass::Scale(float scale)
+{
+	if (scale == 1.0f) return;
+
+	// Scale default value
+	CurrentScale *= scale;
+
+	// Loop over all keys in scale channel and scale values.
+	int i;
+	int count = ScaleChannel.Get_Key_Count();
+	for (i = 0; i < count; i++) {
+		const PrimitiveAnimationChannelClass<Vector3>::KeyClass &key = ScaleChannel.Get_Key(i);
+		ScaleChannel.Set_Key_Value(i, key.Get_Value() * scale);
+	}
+}
+
+
+/***********************************************************************************************
+ * SphereRenderObjClass::Scale -- scales sphere non-uniformly.                                 *
+ *                                                                                             *
+ * INPUT:                                                                                      *
+ *                                                                                             *
+ * OUTPUT:                                                                                     *
+ *                                                                                             *
+ * WARNINGS:                                                                                   *
+ *                                                                                             *
+ * HISTORY:                                                                                    *
+ *   7/01/02    NH : Created.                                                                  *
+ *=============================================================================================*/
+void SphereRenderObjClass::Scale(float scalex, float scaley, float scalez)
+{
+	// Scale default value
+	CurrentScale.X *= scalex;
+	CurrentScale.Y *= scaley;
+	CurrentScale.Z *= scalez;
+
+	// Loop over all keys in scale channel and scale values.
+	int i;
+	int count = ScaleChannel.Get_Key_Count();
+	for (i = 0; i < count; i++) {
+		const PrimitiveAnimationChannelClass<Vector3>::KeyClass &key = ScaleChannel.Get_Key(i);
+		Vector3 key_val = key.Get_Value();
+		key_val.X *= scalex;
+		key_val.Y *= scaley;
+		key_val.Z *= scalez;
+		ScaleChannel.Set_Key_Value(i, key_val);
+	}
+}
+
+
+
 /***********************************************************************************************
  * SphereRenderObjClass::Update_Cached_Bounding_Volumes -- Updates world-space bounding volumes *
  *                                                                                             *
@@ -808,9 +942,9 @@ void SphereRenderObjClass::Get_Obj_Space_Bounding_Box(AABoxClass & box) const
  *=============================================================================================*/
 void SphereRenderObjClass::Update_Cached_Bounding_Volumes(void) const
 {
-	CachedBoundingBox.Extent.X = ObjSpaceExtent.X * Scale.X;
-	CachedBoundingBox.Extent.Y = ObjSpaceExtent.Y * Scale.Y;
-	CachedBoundingBox.Extent.Z = ObjSpaceExtent.Z * Scale.Z;
+	CachedBoundingBox.Extent.X = ObjSpaceExtent.X * CurrentScale.X;
+	CachedBoundingBox.Extent.Y = ObjSpaceExtent.Y * CurrentScale.Y;
+	CachedBoundingBox.Extent.Z = ObjSpaceExtent.Z * CurrentScale.Z;
 
 	CachedBoundingSphere.Center = CachedBoundingBox.Center = Get_Position() + ObjSpaceCenter;
 	CachedBoundingSphere.Radius = CachedBoundingBox.Extent.Length();
@@ -838,7 +972,7 @@ Vector3 SphereRenderObjClass::Get_Default_Color(void) const
 	if (ColorChannel.Get_Key_Count () > 0) {
 		value = ColorChannel.Get_Key (0).Get_Value ();
 	} else {
-		value = Color;
+		value = CurrentColor;
 	}
 
 	return value;
@@ -864,7 +998,7 @@ float SphereRenderObjClass::Get_Default_Alpha(void) const
 	if (AlphaChannel.Get_Key_Count () > 0) {
 		value = AlphaChannel.Get_Key (0).Get_Value ();
 	} else {
-		value = Alpha;
+		value = CurrentAlpha;
 	}
 
 	return value;
@@ -890,7 +1024,7 @@ Vector3 SphereRenderObjClass::Get_Default_Scale(void) const
 	if (ScaleChannel.Get_Key_Count () > 0) {
 		value = ScaleChannel.Get_Key (0).Get_Value ();
 	} else {
-		value = Scale;
+		value = CurrentScale;
 	}
 
 	return value;
@@ -916,7 +1050,7 @@ AlphaVectorStruct SphereRenderObjClass::Get_Default_Vector(void) const
 	if (VectorChannel.Get_Key_Count () > 0) {
 		value = VectorChannel.Get_Key (0).Get_Value ();
 	} else {
-		value = Vector;
+		value = CurrentVector;
 	}
 
 	return value;
@@ -987,20 +1121,20 @@ void SphereRenderObjClass::animate (void)
 			}
 
 			if (ColorChannel.Get_Key_Count () > 0) {
-				Color	= ColorChannel.Evaluate (anim_time);
+				CurrentColor	= ColorChannel.Evaluate (anim_time);
 			}
 			
 			if (AlphaChannel.Get_Key_Count () > 0) {
-				Alpha	= AlphaChannel.Evaluate (anim_time);
+				CurrentAlpha	= AlphaChannel.Evaluate (anim_time);
 			}
 			
 			if (ScaleChannel.Get_Key_Count () > 0) {
-				Scale	= ScaleChannel.Evaluate (anim_time);
+				CurrentScale	= ScaleChannel.Evaluate (anim_time);
 				Update_Cached_Bounding_Volumes ();
 			}
 			
 			if (VectorChannel.Get_Key_Count () > 0) {
-				Vector = VectorChannel.Evaluate (anim_time);
+				CurrentVector = VectorChannel.Evaluate (anim_time);
 			}
 		}
 	}
@@ -1186,11 +1320,11 @@ RenderObjClass * SpherePrototypeClass::Create(void)
 	if (WW3DAssetManager::Get_Instance()->Get_Activate_Fog_On_Load()) {
 		sphere->SphereShader.Enable_Fog ("SpherePrototypeClass");
 	}
-	W3dUtilityClass::Convert_Vector (Definition.DefaultColor, &sphere->Color);
-	W3dUtilityClass::Convert_Vector (Definition.DefaultScale, &sphere->Scale);
-	sphere->Vector = Definition.DefaultVector;
+	W3dUtilityClass::Convert_Vector (Definition.DefaultColor, &sphere->CurrentColor);
+	W3dUtilityClass::Convert_Vector (Definition.DefaultScale, &sphere->CurrentScale);
+	sphere->CurrentVector = Definition.DefaultVector;
 	sphere->Set_Animation_Duration (Definition.AnimDuration);	
-	sphere->Alpha = Definition.DefaultAlpha;
+	sphere->CurrentAlpha = Definition.DefaultAlpha;
 	sphere->Set_Flags (Definition.Attributes);
 	
 	//

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/sphereobj.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/sphereobj.h
@@ -26,9 +26,9 @@
  *                                                                                             *
  *                       Author:: Jason Andersen                                               *
  *                                                                                             *
- *                     $Modtime:: 5/05/01 6:28p                                               $*
+ *                     $Modtime:: 11/24/01 6:21p                                              $*
  *                                                                                             *
- *                    $Revision:: 6                                                           $*
+ *                    $Revision:: 7                                                           $*
  *                                                                                             *
  *---------------------------------------------------------------------------------------------*
  * Functions:                                                                                  *
@@ -256,6 +256,21 @@ public:
 	virtual void 					Set_Position(const Vector3 &v);
    virtual void					Get_Obj_Space_Bounding_Sphere(SphereClass & sphere) const;
    virtual void					Get_Obj_Space_Bounding_Box(AABoxClass & aabox) const;
+
+	virtual void					Prepare_LOD(CameraClass &camera);
+	virtual void					Increment_LOD(void);
+	virtual void					Decrement_LOD(void);
+	virtual float					Get_Cost(void) const;
+	virtual float					Get_Value(void) const;
+	virtual float					Get_Post_Increment_Value(void) const;
+	virtual void					Set_LOD_Level(int lod);
+	virtual int						Get_LOD_Level(void) const;
+	virtual int						Get_LOD_Count(void) const;
+	virtual void					Set_LOD_Bias(float bias)	{ LODBias = MAX(bias, 0.0f); }
+	virtual int						Calculate_Cost_Value_Arrays(float screen_area, float *values, float *costs) const;
+
+	virtual void					Scale(float scale);
+	virtual void					Scale(float scalex, float scaley, float scalez);
 	virtual void					Set_Hidden(int onoff)				{ RenderObjClass::Set_Hidden (onoff); Update_On_Visibilty (); }
 	virtual void					Set_Visible(int onoff)				{ RenderObjClass::Set_Visible (onoff); Update_On_Visibilty (); }
 	virtual void					Set_Animation_Hidden(int onoff)	{ RenderObjClass::Set_Animation_Hidden (onoff); Update_On_Visibilty (); }
@@ -278,15 +293,15 @@ public:
 	void								Stop_Animating (void)	{ IsAnimating = false; anim_time = 0; }
 
 	// Current state access
-	void							 	Set_Color(const Vector3 & color)			{ Color = color; }
-	void							 	Set_Alpha(float alpha)						{ Alpha = alpha; }
-	void							 	Set_Scale(const Vector3 & scale)			{ Scale = scale; }
-	void								Set_Vector(const AlphaVectorStruct &v)	{ Vector = v; }
+	void							 	Set_Color(const Vector3 & color)			{ CurrentColor = color; }
+	void							 	Set_Alpha(float alpha)						{ CurrentAlpha = alpha; }
+	void							 	Set_Scale(const Vector3 & scale)			{ CurrentScale = scale; }
+	void								Set_Vector(const AlphaVectorStruct &v)	{ CurrentVector = v; }
 
-	const Vector3 &				Get_Color(void) const	{ return Color; }
-	float								Get_Alpha(void) const	{ return Alpha; }
-	const Vector3 &				Get_Scale(void) const	{ return Scale; }
-	const AlphaVectorStruct &	Get_Vector(void) const	{ return Vector; }
+	const Vector3 &				Get_Color(void) const	{ return CurrentColor; }
+	float								Get_Alpha(void) const	{ return CurrentAlpha; }
+	const Vector3 &				Get_Scale(void) const	{ return CurrentScale; }
+	const AlphaVectorStruct &	Get_Vector(void) const	{ return CurrentVector; }
 
 	Vector3							Get_Default_Color(void) const;
 	float								Get_Default_Alpha(void) const;
@@ -343,6 +358,12 @@ protected:
 	float								AnimDuration;
 	bool								IsAnimating;
 	
+	// LOD Stuff
+	void								calculate_value_array(float screen_area, float *values) const;
+	float								LODBias;
+	int						 		CurrentLOD;
+	float								Value[SPHERE_NUM_LOD + 2];// Value array needs # of LODs + 1 (RING_NUM_LOD doesn't include null LOD)
+
 	SphereColorChannelClass		ColorChannel;
 	SphereAlphaChannelClass		AlphaChannel;
 	SphereScaleChannelClass		ScaleChannel;
@@ -356,13 +377,11 @@ protected:
 	Vector3					 		ObjSpaceCenter;
 	Vector3					 		ObjSpaceExtent;
 
-	int						 		CurrentLOD;
-
 	// Current State
-	Vector3					 		Color;
-	float								Alpha;
-	Vector3							Scale;
-	AlphaVectorStruct				Vector;
+	Vector3					 		CurrentColor;
+	float								CurrentAlpha;
+	Vector3							CurrentScale;
+	AlphaVectorStruct				CurrentVector;
 
 	Quaternion						Orientation;
 


### PR DESCRIPTION
We don't care for code diffs in the RenderObj classes because they are safe to copy over as asset manager didn't call Register_Prototype_Loader on _RingLoader or _SphereLoader so these chunks wouldn't had worked in Generals at all.