### PR TITLE
[GEN] Backport WW3D2's StaticSortListClass from Zero Hour

### DIFF
--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/CMakeLists.txt
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/CMakeLists.txt
@@ -86,6 +86,7 @@ set(WW3D2_SRC
     sortingrenderer.cpp
     soundrobj.cpp
     sphereobj.cpp
+    static_sort_list.cpp
     statistics.cpp
     streak.cpp
     streakRender.cpp
@@ -197,6 +198,7 @@ set(WW3D2_SRC
     sortingrenderer.h
     soundrobj.h
     sphereobj.h
+    static_sort_list.h
     statistics.h
     streak.h
     streakRender.h

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/static_sort_list.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/static_sort_list.cpp
@@ -1,0 +1,89 @@
+/*
+**	Command & Conquer Generals(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*************************************************************************************************** 
+ ***                  C O N F I D E N T I A L  ---  W E S T W O O D  S T U D I O S               *** 
+ *************************************************************************************************** 
+ *                                                                                                 * 
+ *                     Project Name : G                                                            * 
+ *                                                                                                 * 
+ *                         $Archive::                                                             $* 
+ *                                                                                                 * 
+ *                          Creator::Scott K. Bowen - 7/15/2002                                        *
+ *                                                                                                 * 
+ *                          $Author::                                                             $* 
+ *                                                                                                 * 
+ *                         $Modtime::                                                             $* 
+ *                                                                                                 * 
+ *                        $Revision::                                                             $* 
+ *                                                                                                 * 
+ *-------------------------------------------------------------------------------------------------* 
+ * Functions:                                                                                      * 
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -  - - -  - - */
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Include files ///////////////////////////////////////////////////////////////////////////////////
+
+#include "static_sort_list.h"
+
+#include "rendobj.h"
+#include "dx8renderer.h"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Initialization Functions ////////////////////////////////////////////////////////////////////////
+
+DefaultStaticSortListClass::DefaultStaticSortListClass(void) :
+	StaticSortListClass(),
+	SortLists(),
+	MinSort(1),
+	MaxSort(MAX_SORT_LEVEL)
+{
+}
+
+DefaultStaticSortListClass::~DefaultStaticSortListClass(void)
+{
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Virtual functions ///////////////////////////////////////////////////////////////////////////////
+
+void DefaultStaticSortListClass::Add_To_List(RenderObjClass * robj, unsigned int sort_level)
+{
+	if(sort_level < 1 || sort_level > MAX_SORT_LEVEL) {
+		WWASSERT(0);
+		return;
+	}
+	SortLists[sort_level].Add_Tail(robj, false);
+}
+
+void DefaultStaticSortListClass::Render_And_Clear(RenderInfoClass & rinfo)
+{
+	// We go from higher sort level to lower, since lower sort level means higher priority (in
+	// front), so lower sort level meshes need to be rendered later.
+	for(unsigned int sort_level = MaxSort; sort_level >= MinSort; sort_level--) {
+		bool render=false;
+		for (	RenderObjClass *robj = SortLists[sort_level].Remove_Head(); robj;
+				robj->Release_Ref(), robj = SortLists[sort_level].Remove_Head())
+		{
+			robj->Render(rinfo);
+			render = true;
+		}
+		if (render) TheDX8MeshRenderer.Flush();
+	}
+}
+

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/static_sort_list.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/static_sort_list.h
@@ -1,0 +1,99 @@
+/*
+**	Command & Conquer Generals(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/***************************************************************************************************************** 
+ ***                      C O N F I D E N T I A L  ---  W E S T W O O D  S T U D I O S                         *** 
+ ***************************************************************************************************************** 
+ *                                                                                                               * 
+ *                         Project Name : G                                                                      * 
+ *                                                                                                               * 
+ *                             $Archive::                                                                       $* 
+ *                                                                                                               * 
+ *                              Creator::Scott K. Bowen - 7/15/2002                                                  *
+ *                                                                                                               * 
+ *                              $Author::                                                                       $* 
+ *                                                                                                               * 
+ *                             $Modtime::                                                                       $* 
+ *                                                                                                               * 
+ *                            $Revision::                                                                       $* 
+ *                                                                                                               * 
+ *---------------------------------------------------------------------------------------------------------------* 
+ * Functions:                                                                                                    * 
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#ifndef STATIC_SORT_LIST_H
+#define STATIC_SORT_LIST_H
+
+#include "robjlist.h"
+#include "w3d_file.h"
+
+class RenderInfoClass;
+
+// Just defines the interface for the class as used by WW3D..
+class StaticSortListClass
+{
+	public:
+		///////////////////////////////////////////////////////////////////////////////////
+		// Construction.
+		StaticSortListClass(void) {}
+		virtual ~StaticSortListClass(void) {}
+
+		virtual void 	Add_To_List(RenderObjClass * robj, unsigned int sort_level) = 0;
+		virtual void 	Render_And_Clear(RenderInfoClass & rinfo) = 0;
+
+}; // end StaticSortListClass
+
+// The actual implementation for the standard ww3d StaticSortList.
+class DefaultStaticSortListClass : public StaticSortListClass
+{
+	public:
+		///////////////////////////////////////////////////////////////////////////////////
+		// Construction.
+		DefaultStaticSortListClass(void);
+		virtual ~DefaultStaticSortListClass(void);
+
+		virtual void 	Add_To_List(RenderObjClass * robj, unsigned int sort_level);
+		virtual void 	Render_And_Clear(RenderInfoClass & rinfo);
+
+
+		unsigned int 	Get_Min_Sort(void) const 			{return MinSort;};
+		unsigned int 	Get_Max_Sort(void) const 			{return MaxSort;};
+
+		void				Set_Min_Sort(unsigned int value)	{MinSort = (value > MAX_SORT_LEVEL) ? MAX_SORT_LEVEL : value;}
+		void				Set_Max_Sort(unsigned int value)	{MaxSort = (value > MAX_SORT_LEVEL) ? MAX_SORT_LEVEL : value;}
+
+	private:
+		// These are for use by controlling classes to allow control of what levels
+		// to render when Render_And_Clear() is called.  As for this class, the values
+		// are set to 1..MAX_SORT_LEVEL and then never changed.
+		unsigned int				MinSort;
+		unsigned int				MaxSort;
+ 
+		// An array of lists - each object in a given list has same SortLevel.
+		RefRenderObjListClass 	SortLists[MAX_SORT_LEVEL + 1];
+
+}; // end StaticSortListClass
+
+
+
+
+#endif //STATIC_SORT_LIST_H
+

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/ww3d.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/ww3d.h
@@ -62,6 +62,7 @@ class		RenderDeviceDescClass;
 class		StringClass;
 class		LightEnvironmentClass;
 class		MaterialPassClass;
+class 	StaticSortListClass;
 
 #define SNAPSHOT_SAY(x) if (WW3D::Is_Snapshot_Activated()) { WWDEBUG_SAY(x); }
 //#define SNAPSHOT_SAY(x)
@@ -278,7 +279,7 @@ public:
 	static bool					Is_Munge_Sort_On_Load_Enabled(void)		{ return MungeSortOnLoad; }
 	static void					Add_To_Static_Sort_List(RenderObjClass *robj, unsigned int sort_level);
 	static void					Render_And_Clear_Static_Sort_Lists(RenderInfoClass & rinfo);
-	static void					Override_Current_Static_Sort_Lists(RefRenderObjListClass *sort_list, unsigned int min_sort, unsigned int max_sort);
+	static void					Override_Current_Static_Sort_Lists(StaticSortListClass * sort_list);
 	static void					Reset_Current_Static_Sort_Lists_To_Default(void);
 
 	static bool					Is_Snapshot_Activated()						{ return SnapshotActivated; }
@@ -367,12 +368,9 @@ private:
 	// For meshes which have a static sorting order. These will get drawn
 	// after opaque meshes and before normally sorted meshes. The 'current'
 	// pointer is so the application can temporarily set a different set of
-	// static sort lists to be used temporarily. This and the min/max sort
-	// levels are for specialised uses.
-	static RefRenderObjListClass * DefaultStaticSortLists;
-	static RefRenderObjListClass * CurrentStaticSortLists;
-	static unsigned int MinStaticSortLevel;
-	static unsigned int MaxStaticSortLevel;
+	// static sort lists to be used temporarily. This is for specialised uses.
+	static StaticSortListClass * DefaultStaticSortLists;
+	static StaticSortListClass * CurrentStaticSortLists;
 
 	// Memory allocation statistics
 	static int							LastFrameMemoryAllocations;


### PR DESCRIPTION
Functionally wise this is exactly the same as original General's code before this change. The Zero Hour specific additions to StaticSortListClass are not ported.