### PR TITLE
[CMAKE][ZH] Fix compile errors and add cmake options for DEBUG_LOGGING, DEBUG_CRASHING, DEBUG_STACKTRACE, DEBUG_PROFILE

### DIFF
--- a/Core/Libraries/Source/Compression/CompressionManager.cpp
+++ b/Core/Libraries/Source/Compression/CompressionManager.cpp
@@ -37,6 +37,7 @@ extern "C" {
 //#pragma message("************************************** WARNING, optimization disabled for debugging purposes")
 #endif
 
+// TheSuperHackers @todo Recover debug logging in this file?
 #define DEBUG_LOG(x) {}
 
 const char *CompressionManager::getCompressionNameByType( CompressionType compType )
@@ -328,10 +329,6 @@ Int CompressionManager::decompressData( void *srcVoid, Int srcLen, void *destVoi
 
 	if (compType >= COMPRESSION_ZLIB1 && compType <= COMPRESSION_ZLIB9)
 	{
-#ifdef DEBUG_LOGGING
-		Int level = compType - COMPRESSION_ZLIB1 + 1; // 1-9
-#endif
-
 		unsigned long outLen = destLen;
 		Int err = z_uncompress(dest, &outLen, src+8, srcLen-8);
 		if (err == Z_OK || err == Z_STREAM_END)
@@ -340,7 +337,8 @@ Int CompressionManager::decompressData( void *srcVoid, Int srcLen, void *destVoi
 		}
 		else
 		{
-			DEBUG_LOG(("ZLib decompression error (src is level %d, %d bytes long) %d\n", level, srcLen, err));
+			DEBUG_LOG(("ZLib decompression error (src is level %d, %d bytes long) %d\n",
+				compType - COMPRESSION_ZLIB1 + 1 /* 1-9 */, srcLen, err));
 			return 0;
 		}
 	}

--- a/Generals/Code/GameEngine/Include/Common/Debug.h
+++ b/Generals/Code/GameEngine/Include/Common/Debug.h
@@ -66,6 +66,9 @@ class AsciiString;
 // by default, turn on ALLOW_DEBUG_UTILS if _DEBUG is turned on.
 #if (defined(_DEBUG) || defined(_INTERNAL)) && !defined(ALLOW_DEBUG_UTILS) && !defined(DISABLE_ALLOW_DEBUG_UTILS)
 	#define ALLOW_DEBUG_UTILS 1
+#elif defined(DEBUG_LOGGING) || defined(DEBUG_CRASHING) || defined(DEBUG_STACKTRACE) || defined(DEBUG_PROFILE)
+	// TheSuperHackers @tweak also turn on when any of the above options is already set.
+	#define ALLOW_DEBUG_UTILS 1
 #endif
 
 // these are predicated on ALLOW_DEBUG_UTILS, not _DEBUG, and allow you to selectively disable
@@ -76,10 +79,11 @@ class AsciiString;
 #if defined(ALLOW_DEBUG_UTILS) && !defined(DEBUG_CRASHING) && !defined(DISABLE_DEBUG_CRASHING)
 	#define DEBUG_CRASHING 1
 #endif
-
-// BGC - added the DEBUG_LOGGING term...doesn't make sense to do stack debugging without a debug log to print to.
-#if defined(ALLOW_DEBUG_UTILS) && !defined(DEBUG_STACKTRACE) && !defined(DISABLE_DEBUG_STACKTRACE) && defined(DEBUG_LOGGING)
+#if defined(ALLOW_DEBUG_UTILS) && !defined(DEBUG_STACKTRACE) && !defined(DISABLE_DEBUG_STACKTRACE)
 	#define DEBUG_STACKTRACE 1
+	#ifndef DEBUG_LOGGING
+		#define DEBUG_LOGGING 1 // TheSuperHackers @compile Stack trace requires logging.
+	#endif
 #endif
 #if defined(ALLOW_DEBUG_UTILS) && !defined(DEBUG_PROFILE) && !defined(DISABLE_DEBUG_PROFILE)
 	#define DEBUG_PROFILE 1

--- a/Generals/Code/GameEngine/Include/Common/GlobalData.h
+++ b/Generals/Code/GameEngine/Include/Common/GlobalData.h
@@ -469,8 +469,6 @@ public:
 	Real m_debugProjectileTileWidth;			///< How wide should these tiles be?
 	Int m_debugProjectileTileDuration;		///< How long should these tiles stay around, in frames?
 	RGBColor m_debugProjectileTileColor;	///< What color should these tiles be?
-	Bool m_debugIgnoreAsserts;						///< Ignore all asserts.
-	Bool m_debugIgnoreStackTrace;					///< No stacktraces for asserts.
 	Bool m_showCollisionExtents;	///< Used to display collision extents
 	Bool m_saveStats;
 	Bool m_saveAllStats;
@@ -482,6 +480,14 @@ public:
 	Int m_latencyPeriod;					///< Period of sinusoidal modulation of latency
 	Int m_latencyNoise;						///< Max amplitude of jitter to throw in
 	Int m_packetLoss;							///< Percent of packets to drop
+#endif
+
+#ifdef DEBUG_CRASHING
+	Bool m_debugIgnoreAsserts;						///< Ignore all asserts.
+#endif
+
+#ifdef DEBUG_STACKTRACE
+	Bool m_debugIgnoreStackTrace;					///< No stacktraces for asserts.
 #endif
 
 	Bool				m_isBreakableMovie;							///< if we enter a breakable movie, set this flag

--- a/Generals/Code/GameEngine/Include/Common/INI.h
+++ b/Generals/Code/GameEngine/Include/Common/INI.h
@@ -399,7 +399,7 @@ protected:
 	const char *m_sepsQuote;									///< token to represent a quoted ascii string
 	const char *m_blockEndToken;							///< token to represent end of data block
 	Bool m_endOfFile;													///< TRUE when we've hit EOF
-#if defined(_DEBUG) || defined(_INTERNAL)
+#ifdef DEBUG_CRASHING
 	char m_curBlockStart[ INI_MAX_CHARS_PER_LINE ];	///< first line of cur block
 #endif
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/AIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/AIUpdate.h
@@ -629,7 +629,7 @@ public:
 
 	// this is intended for use ONLY by AIFollowPathState.
 	inline void friend_setCurrentGoalPathIndex( Int index ) { m_nextGoalPathIndex = index; }
-#if defined(_DEBUG) || defined(_INTERNAL)	
+#ifdef DEBUG_LOGGING
 	inline const Coord3D *friend_getRequestedDestination() const { return &m_requestedDestination; }
 	inline const Coord3D *friend_getRequestedDestination2() const { return &m_requestedDestination2; }
 #endif

--- a/Generals/Code/GameEngine/Include/GameNetwork/udp.h
+++ b/Generals/Code/GameEngine/Include/GameNetwork/udp.h
@@ -124,6 +124,8 @@ class UDP
 	Int						AllowBroadcasts(Bool status);
 };
 
+#ifdef DEBUG_LOGGING
 AsciiString GetWSAErrorString( Int error );
+#endif
 
 #endif

--- a/Generals/Code/GameEngine/Source/Common/CommandLine.cpp
+++ b/Generals/Code/GameEngine/Source/Common/CommandLine.cpp
@@ -32,6 +32,7 @@
 #include "Common/version.h"
 #include "GameClient/TerrainVisual.h" // for TERRAIN_LOD_MIN definition
 #include "GameClient/GameText.h"
+#include "GameNetwork/NetworkDefs.h"
 
 Bool TheDebugIgnoreSyncErrors = FALSE;
 extern Int DX8Wrapper_PreserveFPU;
@@ -103,9 +104,7 @@ static void ConvertShortMapPathToLongMapPath(AsciiString &mapName)
 //=============================================================================
 Int parseNoLogOrCrash(char *args[], int)
 {
-#ifdef ALLOW_DEBUG_UTILS
 	DEBUG_CRASH(("-NoLogOrCrash not supported in this build\n"));
-#endif
 	return 1;
 }
 
@@ -325,7 +324,9 @@ Int parseNoDraw(char *args[], int argc)
 //=============================================================================
 Int parseLogToConsole(char *args[], int)
 {
+#ifdef ALLOW_DEBUG_UTILS
 	DebugSetFlags(DebugGetFlags() | DEBUG_FLAG_LOG_TO_CONSOLE);
+#endif
 	return 1;
 }
 
@@ -950,7 +951,7 @@ Int parseBenchmark(char *args[], int num)
 }
 #endif
 
-#if defined(_DEBUG) || defined(_INTERNAL)
+#ifdef DEBUG_CRASHING
 Int parseIgnoreAsserts(char *args[], int num)
 {
 	if (TheWritableGlobalData && num > 0)
@@ -961,7 +962,7 @@ Int parseIgnoreAsserts(char *args[], int num)
 }
 #endif
 
-#if defined(_DEBUG) || defined(_INTERNAL)
+#ifdef DEBUG_STACKTRACE
 Int parseIgnoreStackTrace(char *args[], int num)
 {
 	if (TheWritableGlobalData && num > 0)
@@ -1058,7 +1059,7 @@ Int parseMod(char *args[], Int num)
 	return 1;
 }
 
-#if defined(_DEBUG) || defined(_INTERNAL)
+#ifdef DEBUG_LOGGING
 Int parseSetDebugLevel(char *args[], int num)
 {
 	if (num > 1)
@@ -1113,7 +1114,6 @@ static CommandLineParam params[] =
 	{ "-novideo", parseNoVideo },
 	{ "-noLogOrCrash", parseNoLogOrCrash },
 	{ "-FPUPreserve", parseFPUPreserve },
-#if defined(_DEBUG) || defined(_INTERNAL)
 	{ "-benchmark", parseBenchmark },
 	{ "-saveStats", parseSaveStats },
 	{ "-localMOTD", parseLocalMOTD },
@@ -1161,16 +1161,11 @@ static CommandLineParam params[] =
 	{ "-netMinPlayers", parseNetMinPlayers },
 	{ "-DemoLoadScreen", parseDemoLoadScreen },
 	{ "-cameraDebug", parseCameraDebug },
-	{ "-ignoreAsserts", parseIgnoreAsserts },
-	{ "-ignoreStackTrace", parseIgnoreStackTrace },
 	{ "-logToCon", parseLogToConsole },
 	{ "-vTune", parseVTune },
 	{ "-selectTheUnselectable", parseSelectAll },
 	{ "-RunAhead", parseRunAhead },
 	{ "-noshroud", parseNoShroud },
-	{ "-setDebugLevel", parseSetDebugLevel },
-	{ "-clearDebugLevel", parseClearDebugLevel },
-#endif
 	{ "-forceBenchmark", parseForceBenchmark },
 	{ "-buildmapcache", parseBuildMapCache },
 	{ "-noshadowvolumes", parseNoShadows },
@@ -1189,6 +1184,19 @@ static CommandLineParam params[] =
 	{ "-jumpToFrame", parseJumpToFrame },
 	{ "-updateImages", parseUpdateImages },
 	{ "-showTeamDot", parseShowTeamDot },
+#endif
+
+#ifdef DEBUG_LOGGING
+	{ "-setDebugLevel", parseSetDebugLevel },
+	{ "-clearDebugLevel", parseClearDebugLevel },
+#endif
+
+#ifdef DEBUG_CRASHING
+	{ "-ignoreAsserts", parseIgnoreAsserts },
+#endif
+
+#ifdef DEBUG_STACKTRACE
+	{ "-ignoreStackTrace", parseIgnoreStackTrace },
 #endif
 };
 

--- a/Generals/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -262,7 +262,7 @@ void GameEngine::init( int argc, char *argv[] )
 	#elif defined _INTERNAL
 			const char *buildType = "Internal";
 	#else
-	//	const char *buildType = "Release";
+			const char *buildType = "Release";
 	#endif
 #endif // DEBUG_LOGGING
 			DEBUG_LOG(("Generals version %s (%s)\n", TheVersion->getAsciiVersion().str(), buildType));

--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -564,8 +564,6 @@ GlobalData::GlobalData()
 	m_debugCashValueMap = FALSE;
 	m_maxDebugValue = 10000;
 	m_debugCashValueMapTileDuration = LOGICFRAMES_PER_SECOND; // Changed By Sadullah Nader
-	m_debugIgnoreAsserts = FALSE;
-	m_debugIgnoreStackTrace = FALSE;
 	m_vTune = false;
 	m_checkForLeaks = TRUE;
 	m_benchmarkTimer = -1;
@@ -583,6 +581,14 @@ GlobalData::GlobalData()
 	m_useLocalMOTD = FALSE;
 	m_baseStatsDir = ".\\";
 	m_MOTDPath = "MOTD.txt";
+#endif
+
+#ifdef DEBUG_CRASHING
+	m_debugIgnoreAsserts = FALSE;
+#endif
+
+#ifdef DEBUG_STACKTRACE
+	m_debugIgnoreStackTrace = FALSE;
 #endif
 
 	m_playStats = -1;

--- a/Generals/Code/GameEngine/Source/Common/INI/INI.cpp
+++ b/Generals/Code/GameEngine/Source/Common/INI/INI.cpp
@@ -190,7 +190,7 @@ INI::INI( void )
 	m_blockEndToken			= "END";
 	m_endOfFile					= FALSE;
 	m_buffer[0]					= 0;
-#if defined(_DEBUG) || defined(_INTERNAL)
+#ifdef DEBUG_CRASHING
 	m_curBlockStart[0]	= 0;
 #endif
 
@@ -368,7 +368,7 @@ void INI::load( AsciiString filename, INILoadType loadType, Xfer *pXfer )
 				INIBlockParse parse = findBlockParse(token);
 				if (parse)
 				{
-					#if defined(_DEBUG) || defined(_INTERNAL)
+					#ifdef DEBUG_CRASHING
 					strcpy(m_curBlockStart, m_buffer);
 					#endif
 					try {
@@ -381,7 +381,7 @@ void INI::load( AsciiString filename, INILoadType loadType, Xfer *pXfer )
 
 						throw INIException(buff);
 					}
-					#if defined(_DEBUG) || defined(_INTERNAL)
+					#ifdef DEBUG_CRASHING
 						strcpy(m_curBlockStart, "NO_BLOCK");
 					#endif
 				}

--- a/Generals/Code/GameEngine/Source/Common/System/Debug.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/Debug.cpp
@@ -550,7 +550,7 @@ void DebugSetFlags(int flags)
 
 #endif	// ALLOW_DEBUG_UTILS
 
-#ifdef ALLOW_DEBUG_UTILS
+#ifdef DEBUG_PROFILE
 // ----------------------------------------------------------------------------
 SimpleProfiler::SimpleProfiler()
 {
@@ -630,7 +630,7 @@ double SimpleProfiler::getAverageTime()
 	return (double)m_totalAllSessions * 1000.0 / ((double)m_freq * (double)m_numSessions);
 }
 
-#endif	// ALLOW_DEBUG_UTILS
+#endif	// DEBUG_PROFILE
 
 // ----------------------------------------------------------------------------
 // ReleaseCrash

--- a/Generals/Code/GameEngine/Source/Common/System/Debug.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/Debug.cpp
@@ -125,7 +125,9 @@ static const char *prepBuffer(const char* format, char *buffer);
 #ifdef DEBUG_LOGGING
 static void doLogOutput(const char *buffer);
 #endif
+#ifdef DEBUG_CRASHING
 static int doCrashBox(const char *buffer, Bool logResult);
+#endif
 static void whackFunnyCharacters(char *buf);
 #ifdef DEBUG_STACKTRACE
 static void doStackDump();
@@ -138,7 +140,7 @@ static void doStackDump();
 // ----------------------------------------------------------------------------
 inline Bool ignoringAsserts()
 {
-#if defined(_DEBUG) || defined(_INTERNAL)
+#ifdef DEBUG_CRASHING
 	return !DX8Wrapper_IsWindowed || TheGlobalData->m_debugIgnoreAsserts;
 #else
 	return !DX8Wrapper_IsWindowed;
@@ -244,6 +246,7 @@ static void doLogOutput(const char *buffer)
 	we exit the app, break into debugger, or continue execution. 
 */
 // ----------------------------------------------------------------------------
+#ifdef DEBUG_CRASHING
 static int doCrashBox(const char *buffer, Bool logResult)
 {
 	int result;
@@ -281,6 +284,7 @@ static int doCrashBox(const char *buffer, Bool logResult)
 	}
 	return result;
 }
+#endif
 
 #ifdef DEBUG_STACKTRACE
 // ----------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/Common/System/GameMemory.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/GameMemory.cpp
@@ -3079,8 +3079,10 @@ void MemoryPoolFactory::debugMemoryReport(Int flags, Int startCheckpoint, Int en
 {
 	//USE_PERF_TIMER(MemoryPoolDebugging) skip end-of-run reporting stuff
 
+#ifdef ALLOW_DEBUG_UTILS
 	Int oldFlags = DebugGetFlags();
 	DebugSetFlags(oldFlags & ~DEBUG_FLAG_PREPEND_TIME);
+#endif
 
 #ifdef MEMORYPOOL_CHECKPOINTING
 	Bool doBlockReport = (flags & _REPORT_CP_ALLOCATED_DONTCARE) != 0 && (flags & _REPORT_CP_FREED_DONTCARE) != 0;
@@ -3236,7 +3238,9 @@ void MemoryPoolFactory::debugMemoryReport(Int flags, Int startCheckpoint, Int en
 	}
 #endif
 
+#ifdef ALLOW_DEBUG_UTILS
 	DebugSetFlags(oldFlags);
+#endif
 }
 #endif
 

--- a/Generals/Code/GameEngine/Source/Common/Thing/ModuleFactory.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Thing/ModuleFactory.cpp
@@ -589,7 +589,7 @@ Module *ModuleFactory::newModule( Thing *thing, const AsciiString& name, const M
 	{
 		Module* mod = (*mt->m_createProc)( thing, moduleData );
 
-#ifdef _DEBUG
+#ifdef DEBUG_CRASHING
 		if (type == MODULETYPE_BEHAVIOR)
 		{
 			BehaviorModule* bm = (BehaviorModule*)mod;

--- a/Generals/Code/GameEngine/Source/Common/Thing/ThingFactory.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Thing/ThingFactory.cpp
@@ -363,7 +363,7 @@ Drawable *ThingFactory::newDrawable(const ThingTemplate *tmplate, DrawableStatus
 
 }  // end newDrawableByType
 
-#if defined(_DEBUG) || defined(_INTERNAL)
+#if defined(_DEBUG) || defined(_INTERNAL) || defined(DEBUG_CRASHING)
 AsciiString TheThingTemplateBeingParsedName;
 #endif
 
@@ -372,7 +372,7 @@ AsciiString TheThingTemplateBeingParsedName;
 //-------------------------------------------------------------------------------------------------
 /*static*/ void ThingFactory::parseObjectDefinition( INI* ini, const AsciiString& name, const AsciiString& reskinFrom )
 {
-#if defined(_DEBUG) || defined(_INTERNAL)
+#if defined(_DEBUG) || defined(_INTERNAL) || defined(DEBUG_CRASHING)
 	TheThingTemplateBeingParsedName = name;
 #endif
 
@@ -426,7 +426,7 @@ AsciiString TheThingTemplateBeingParsedName;
 
 	thingTemplate->validate();
 
-#if defined(_DEBUG) || defined(_INTERNAL)
+#if defined(_DEBUG) || defined(_INTERNAL) || defined(DEBUG_CRASHING)
 	TheThingTemplateBeingParsedName.clear();
 #endif
 }

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -5155,7 +5155,7 @@ Bool Pathfinder::adjustToPossibleDestination(Object *obj, const LocomotorSet& lo
  */
 Bool Pathfinder::queueForPath(ObjectID id)
 {
-#if defined(_DEBUG) || defined(_INTERNAL)
+#ifdef DEBUG_LOGGING
 	{
 		Object *tmpObj = TheGameLogic->findObjectByID(id);
 		if (tmpObj) {
@@ -5386,7 +5386,7 @@ void Pathfinder::processPathfindQueue(void)
 		return;
 	}
 #ifdef DEBUG_QPF
-#if defined _DEBUG || defined _INTERNAL
+#ifdef DEBUG_LOGGING
 	Int startTimeMS = ::GetTickCount();
 	__int64 startTime64;
 	double timeToUpdate=0.0f;
@@ -5433,7 +5433,7 @@ void Pathfinder::processPathfindQueue(void)
 	}
 	if (pathsFound>0) {
 #ifdef DEBUG_QPF
-#if defined _DEBUG || defined _INTERNAL
+#ifdef DEBUG_LOGGING
 		QueryPerformanceCounter((LARGE_INTEGER *)&endTime64);
 		timeToUpdate = ((double)(endTime64-startTime64) / (double)(freq64));
 		if (timeToUpdate>0.01f) 
@@ -5952,7 +5952,7 @@ Path *Pathfinder::internalFindPath( Object *obj, const LocomotorSet& locomotorSe
 	DEBUG_LOG(("internal find path...\n"));
 #endif
 
-#if defined _DEBUG || defined _INTERNAL
+#ifdef DEBUG_LOGGING
 	Int startTimeMS = ::GetTickCount();
 #endif
 	Bool centerInCell = true;
@@ -6179,12 +6179,6 @@ Path *Pathfinder::internalFindPath( Object *obj, const LocomotorSet& locomotorSe
 	}	
 
 	if (obj) {
-		Bool valid;
-		valid = validMovementPosition( isCrusher, obj->getLayer(), locomotorSet, to ) ;
-
-		DEBUG_LOG(("%d ", TheGameLogic->getFrame()));
-		DEBUG_LOG(("Pathfind failed from (%f,%f) to (%f,%f), OV %d\n", from->x, from->y, to->x, to->y, valid));
-		DEBUG_LOG(("Unit '%s', time %f, cells %d\n", obj->getTemplate()->getName().str(), (::GetTickCount()-startTimeMS)/1000.0f,cellCount));
 #ifdef DUMP_PERF_STATS
 		TheGameLogic->incrementOverallFailedPathfinds();
 #endif
@@ -6196,6 +6190,19 @@ Path *Pathfinder::internalFindPath( Object *obj, const LocomotorSet& locomotorSe
 #endif
 	}
 #endif
+
+#ifdef DEBUG_LOGGING
+	if (obj)
+	{
+		Bool valid;
+		valid = validMovementPosition( isCrusher, obj->getLayer(), locomotorSet, to ) ;
+
+		DEBUG_LOG(("%d ", TheGameLogic->getFrame()));
+		DEBUG_LOG(("Pathfind failed from (%f,%f) to (%f,%f), OV %d\n", from->x, from->y, to->x, to->y, valid));
+		DEBUG_LOG(("Unit '%s', time %f, cells %d\n", obj->getTemplate()->getName().str(), (::GetTickCount()-startTimeMS)/1000.0f,cellCount));
+	}
+#endif
+
 	m_isTunneling = false;
 	goalCell->releaseInfo();
 	cleanOpenAndClosedLists();
@@ -6465,7 +6472,7 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 													 const Coord3D *rawTo, Int pathDiameter, Bool crusher)
 {
 	//CRCDEBUG_LOG(("Pathfinder::findGroundPath()\n"));
-#if defined _DEBUG || defined _INTERNAL
+#ifdef DEBUG_LOGGING
 	Int startTimeMS = ::GetTickCount();
 #endif
 #ifdef INTENSE_DEBUG
@@ -6785,11 +6792,12 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 
 		}
 	}	
+#endif
 
 	DEBUG_LOG(("%d ", TheGameLogic->getFrame()));
 	DEBUG_LOG(("FindGroundPath failed from (%f,%f) to (%f,%f)\n", from->x, from->y, to->x, to->y));
 	DEBUG_LOG(("time %f\n", (::GetTickCount()-startTimeMS)/1000.0f));
-#endif
+
 #ifdef DUMP_PERF_STATS
 	TheGameLogic->incrementOverallFailedPathfinds();
 #endif
@@ -6905,7 +6913,7 @@ Path *Pathfinder::internal_findHierarchicalPath( Bool isHuman, const LocomotorSu
 													 const Coord3D *rawTo, Bool crusher, Bool closestOK)
 {
 	//CRCDEBUG_LOG(("Pathfinder::findGroundPath()\n"));
-#if defined _DEBUG || defined _INTERNAL
+#ifdef DEBUG_LOGGING
 	Int startTimeMS = ::GetTickCount();
 #endif
 	
@@ -7400,11 +7408,12 @@ Path *Pathfinder::internal_findHierarchicalPath( Bool isHuman, const LocomotorSu
 
 		}
 	}	
+#endif
 
 	DEBUG_LOG(("%d ", TheGameLogic->getFrame()));
 	DEBUG_LOG(("FindHierarchicalPath failed from (%f,%f) to (%f,%f)\n", from->x, from->y, to->x, to->y));
 	DEBUG_LOG(("time %f\n", (::GetTickCount()-startTimeMS)/1000.0f));
-#endif
+
 #ifdef DUMP_PERF_STATS
 	TheGameLogic->incrementOverallFailedPathfinds();
 #endif
@@ -8046,7 +8055,7 @@ Path *Pathfinder::findClosestPath( Object *obj, const LocomotorSet& locomotorSet
 																	Coord3D *rawTo, Bool blocked, Real pathCostMultiplier, Bool moveAllies)
 {
 	//CRCDEBUG_LOG(("Pathfinder::findClosestPath()\n"));
-#if defined _DEBUG || defined _INTERNAL
+#ifdef DEBUG_LOGGING
 	Int startTimeMS = ::GetTickCount();
 #endif
 	Bool isHuman = true;
@@ -8318,13 +8327,15 @@ Path *Pathfinder::findClosestPath( Object *obj, const LocomotorSet& locomotorSet
 	}
 
 	// failure - goal cannot be reached
-#if defined _DEBUG || defined _INTERNAL
+#ifdef DEBUG_LOGGING
 	Bool valid;
 	valid = validMovementPosition( isCrusher, obj->getLayer(), locomotorSet, to ) ;
 
 	DEBUG_LOG(("%d ", TheGameLogic->getFrame()));
 	DEBUG_LOG(("Pathfind(findClosestPath) failed from (%f,%f) to (%f,%f), original valid %d --", from->x, from->y, to->x, to->y, valid));
 	DEBUG_LOG(("Unit '%s', time %f\n", obj->getTemplate()->getName().str(), (::GetTickCount()-startTimeMS)/1000.0f));
+#endif
+#if defined _DEBUG || defined _INTERNAL
 	if (TheGlobalData->m_debugAI) 
 		debugShowSearch(false);
 #endif
@@ -9556,7 +9567,7 @@ Path *Pathfinder::getMoveAwayFromPath(Object* obj, Object *otherObj,
 											Path *pathToAvoid, Object *otherObj2, Path *pathToAvoid2)
 {
 	if (m_isMapReady == false) return NULL; // Should always be ok.
-#if defined _DEBUG || defined _INTERNAL
+#ifdef DEBUG_LOGGING
 	Int startTimeMS = ::GetTickCount();
 #endif
 	Bool isHuman = true;
@@ -9712,10 +9723,12 @@ Path *Pathfinder::getMoveAwayFromPath(Object* obj, Object *otherObj,
 
 #if defined _DEBUG || defined _INTERNAL
 	debugShowSearch(true);
+#endif
+
 	DEBUG_LOG(("%d ", TheGameLogic->getFrame()));
 	DEBUG_LOG(("getMoveAwayFromPath pathfind failed  -- "));
 	DEBUG_LOG(("Unit '%s', time %f\n", obj->getTemplate()->getName().str(), (::GetTickCount()-startTimeMS)/1000.0f));
-#endif
+
 	m_isTunneling = false;
 	cleanOpenAndClosedLists();
 	return NULL;
@@ -9729,7 +9742,7 @@ Path *Pathfinder::patchPath( const Object *obj, const LocomotorSet& locomotorSet
 		Path *originalPath, Bool blocked )
 {
 	//CRCDEBUG_LOG(("Pathfinder::patchPath()\n"));
-#if defined _DEBUG || defined _INTERNAL
+#ifdef DEBUG_LOGGING
 	Int startTimeMS = ::GetTickCount();
 #endif
 	if (originalPath==NULL) return NULL;
@@ -9891,10 +9904,11 @@ Path *Pathfinder::patchPath( const Object *obj, const LocomotorSet& locomotorSet
 		}
 	}
 
-#if defined _DEBUG || defined _INTERNAL
 	DEBUG_LOG(("%d ", TheGameLogic->getFrame()));
 	DEBUG_LOG(("patchPath Pathfind failed  -- "));
 	DEBUG_LOG(("Unit '%s', time %f\n", obj->getTemplate()->getName().str(), (::GetTickCount()-startTimeMS)/1000.0f));
+
+#if defined _DEBUG || defined _INTERNAL
 	if (TheGlobalData->m_debugAI) {
 		debugShowSearch(true);
 	}

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
@@ -2146,6 +2146,7 @@ Int PartitionData::calcMaxCoiForShape(GeometryType geom, Real majorRadius, Real 
 	{
 		#if defined(_DEBUG) || defined(_INTERNAL)
 		Int chk = calcMaxCoiForShape(geom, majorRadius, minorRadius, false);
+		(void)chk;
 		DEBUG_ASSERTCRASH(chk <= 4, ("Small objects should be <= 4 cells, but I calced %s as %d\n",theObjName.str(),chk));
 		#endif
 		result = 4;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
@@ -1408,7 +1408,7 @@ UnsignedInt PartitionCell::getThreatValue( Int playerIndex )
 void PartitionCell::addThreatValue( Int playerIndex, UnsignedInt threatValue )
 {
 	if (playerIndex >= 0 && playerIndex < MAX_PLAYER_COUNT) {
-#ifdef _DEBUG
+#ifdef DEBUG_CRASHING
 		UnsignedInt oldThreatVal = m_threatValue[playerIndex];
 		DEBUG_ASSERTCRASH(oldThreatVal <= oldThreatVal + threatValue, ("adding new threat value overflowed allotted storage."));
 #endif
@@ -1420,7 +1420,7 @@ void PartitionCell::addThreatValue( Int playerIndex, UnsignedInt threatValue )
 void PartitionCell::removeThreatValue( Int playerIndex, UnsignedInt threatValue )
 {
 	if (playerIndex >= 0 && playerIndex < MAX_PLAYER_COUNT) {
-#ifdef _DEBUG
+#ifdef DEBUG_CRASHING
 		UnsignedInt oldThreatVal = m_threatValue[playerIndex];
 		DEBUG_ASSERTCRASH(oldThreatVal >= oldThreatVal - threatValue, ("removing new threat value underflowed allotted storage."));
 #endif
@@ -1441,7 +1441,7 @@ UnsignedInt PartitionCell::getCashValue( Int playerIndex )
 void PartitionCell::addCashValue( Int playerIndex, UnsignedInt cashValue )
 {
 	if (playerIndex >= 0 && playerIndex < MAX_PLAYER_COUNT) {
-#ifdef _DEBUG
+#ifdef DEBUG_CRASHING
 		UnsignedInt oldCashVal = m_cashValue[playerIndex];
 		DEBUG_ASSERTCRASH(oldCashVal <= oldCashVal + cashValue, ("adding new cash value overflowed allotted storage."));
 #endif
@@ -1453,7 +1453,7 @@ void PartitionCell::addCashValue( Int playerIndex, UnsignedInt cashValue )
 void PartitionCell::removeCashValue( Int playerIndex, UnsignedInt cashValue )
 {
 	if (playerIndex >= 0 && playerIndex < MAX_PLAYER_COUNT) {
-#ifdef _DEBUG
+#ifdef DEBUG_CRASHING
 		UnsignedInt oldCashVal = m_cashValue[playerIndex];
 		DEBUG_ASSERTCRASH(oldCashVal >= oldCashVal - cashValue, ("removing new cash value underflowed allotted storage."));
 #endif

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/MissileLauncherBuildingUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/MissileLauncherBuildingUpdate.cpp
@@ -205,7 +205,10 @@ void MissileLauncherBuildingUpdate::switchToState(DoorStateType dst)
 //-------------------------------------------------------------------------------------------------
 void MissileLauncherBuildingUpdate::initiateIntentToDoSpecialPower( const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, UnsignedInt commandOptions, Int locationCount )
 {
+#if defined(_DEBUG) || defined(_INTERNAL)
 	DEBUG_ASSERTCRASH(!TheGlobalData->m_specialPowerUsesDelay || m_doorState == DOOR_OPEN, ("door is not fully open when specialpower is fired!"));
+#endif
+
 	switchToState(DOOR_WAITING_TO_CLOSE);
 }
 
@@ -247,7 +250,9 @@ UpdateSleepTime MissileLauncherBuildingUpdate::update( void )
 			switchToState(m_timeoutState);
 		}
 
+#if defined(_DEBUG) || defined(_INTERNAL)
 		DEBUG_ASSERTCRASH(!TheGlobalData->m_specialPowerUsesDelay || !(m_specialPowerModule->isReady() && m_doorState != DOOR_OPEN), ("door is not fully open when specialpower is ready!"));
+#endif
 
 		if (m_doorState != DOOR_OPEN && m_specialPowerModule->isReady())
 		{

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
@@ -6228,7 +6228,7 @@ void ScriptActions::executeAction( ScriptAction *pAction )
 				                     pAction->getParameter(2)->getInt());
 			return;
 		case ScriptAction::DEBUG_CRASH_BOX:
-#if defined(_DEBUG) || defined(_INTERNAL)
+#ifdef DEBUG_CRASHING
 			{
 				const char* MSG = "Your Script requested the following message be displayed:\n\n";
 				const char* MSG2 = "\n\nTHIS IS NOT A BUG. DO NOT REPORT IT.";

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
@@ -203,6 +203,7 @@ void AttackPriorityInfo::dumpPriorityInfo(void)
 	for (AttackPriorityMap::const_iterator it = m_priorityMap->begin(); it != m_priorityMap->end(); ++it) {
 		const ThingTemplate *tThing = (*it).first;
 		Int priority = (*it).second;
+		(void)tThing; (void)priority;
 		DEBUG_LOG(("  Thing '%s' priority %d\n",tThing->getName().str(), priority));
 	}
 }

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -1972,7 +1972,9 @@ void GameLogic::startNewGame( Bool saveGame )
 
 	// Turn off shadows
 	TheWritableGlobalData->m_useShadowVolumes = false;
+#ifdef DEBUG_CRASHING
 	TheWritableGlobalData->m_debugIgnoreAsserts = TRUE;
+#endif
 
 	// Just look somewhere.  lookAt does some terrain specific setup, so it is good
 	// to call it.  jba
@@ -2387,8 +2389,8 @@ void GameLogic::deselectObject(Object *obj, PlayerMaskType playerMask, Bool affe
 // ------------------------------------------------------------------------------------------------
 inline void GameLogic::validateSleepyUpdate() const
 {
-// pretty slow, so do only for DEBUG for now. turn on if you suspect wonkiness.
-#ifdef _DEBUG
+// pretty slow, so do only for DEBUG_CRASHING for now. turn on if you suspect wonkiness.
+#ifdef DEBUG_CRASHING
 	#define SLEEPY_DEBUG
 #endif
 #ifdef SLEEPY_DEBUG
@@ -3118,7 +3120,6 @@ void GameLogic::update( void )
 	Bool isMPGameOrReplay = (TheRecorder && TheRecorder->isMultiplayer() && getGameMode() != GAME_SHELL && getGameMode() != GAME_NONE);
 	Bool isSoloGameOrReplay = (TheRecorder && !TheRecorder->isMultiplayer() && getGameMode() != GAME_SHELL && getGameMode() != GAME_NONE);
 	Bool generateForMP = (isMPGameOrReplay && (m_frame % TheGameInfo->getCRCInterval()) == 0);
-//#if defined(_DEBUG) || defined(_INTERNAL)
 #ifdef DEBUG_CRC
 	Bool generateForSolo = isSoloGameOrReplay && ((m_frame && (m_frame%100 == 0)) ||
 		(getFrame() > TheCRCFirstFrameToLog && getFrame() < TheCRCLastFrameToLog && ((m_frame % REPLAY_CRC_INTERVAL) == 0)));

--- a/Generals/Code/GameEngine/Source/GameNetwork/udp.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/udp.cpp
@@ -43,7 +43,7 @@
 
 //-------------------------------------------------------------------------
 
-#if defined(_DEBUG) || defined(_INTERNAL)
+#ifdef DEBUG_LOGGING
 
 #define CASE(x) case (x): return #x;
 

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DModelDraw.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DModelDraw.h
@@ -175,7 +175,7 @@ struct ModelConditionInfo
 		Int							m_fxBone;											///< the FX bone for this barrel (zero == no bone)
 		Int							m_muzzleFlashBone;						///< the muzzle-flash subobj bone for this barrel (zero == none)
 		Matrix3D				m_projectileOffsetMtx;				///< where the projectile fires from
-#if defined(_DEBUG) || defined(_INTERNAL)
+#if defined(_DEBUG) || defined(_INTERNAL) || defined(DEBUG_CRASHING)
 		AsciiString			m_muzzleFlashBoneName;
 #endif
 
@@ -190,7 +190,7 @@ struct ModelConditionInfo
 			m_fxBone = 0;
 			m_muzzleFlashBone = 0;
 			m_projectileOffsetMtx.Make_Identity();
-#if defined(_DEBUG) || defined(_INTERNAL)
+#if defined(_DEBUG) || defined(_INTERNAL) || defined(DEBUG_CRASHING)
 			m_muzzleFlashBoneName.clear();
 #endif
 		}
@@ -199,7 +199,7 @@ struct ModelConditionInfo
 	}; 
 	typedef std::vector<WeaponBarrelInfo>	WeaponBarrelInfoVec;
 
-#if defined(_DEBUG) || defined(_INTERNAL)
+#if defined(_DEBUG) || defined(_INTERNAL) || defined(DEBUG_CRASHING)
 	AsciiString												m_description;
 #endif
 	std::vector<ModelConditionFlags>	m_conditionsYesVec;

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
@@ -205,8 +205,11 @@ LogClass BonePosLog("bonePositions.txt");
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
 
-#if defined(_DEBUG) || defined(_INTERNAL)
+#if defined(_DEBUG) || defined(_INTERNAL) || defined(DEBUG_CRASHING)
 extern AsciiString TheThingTemplateBeingParsedName;
+#endif
+
+#if defined(_DEBUG) || defined(_INTERNAL)
 extern Real TheSkateDistOverride;
 #endif
 
@@ -749,7 +752,7 @@ void ModelConditionInfo::validateWeaponBarrelInfo() const
 				{
 					sprintf(buffer, "%s%02d", mfName.str(), i);
 					findPristineBone(NAMEKEY(buffer), &info.m_muzzleFlashBone);
-#if defined(_DEBUG) || defined(_INTERNAL)
+#if defined(_DEBUG) || defined(_INTERNAL) || defined(DEBUG_CRASHING)
 					if (info.m_muzzleFlashBone)
 						info.m_muzzleFlashBoneName = buffer;
 #endif
@@ -797,7 +800,7 @@ void ModelConditionInfo::validateWeaponBarrelInfo() const
 				if (!mfName.isEmpty())
 					findPristineBone(NAMEKEY(mfName), &info.m_muzzleFlashBone);
 
-#if defined(_DEBUG) || defined(_INTERNAL)
+#if defined(_DEBUG) || defined(_INTERNAL) || defined(DEBUG_CRASHING)
 				if (info.m_muzzleFlashBone)
 					info.m_muzzleFlashBoneName = mfName;
 #endif
@@ -1558,7 +1561,7 @@ void W3DModelDrawModuleData::parseConditionState(INI* ini, void *instance, void 
 	//	}
 			
 			ModelConditionFlags conditionsYes;
-	#if defined(_DEBUG) || defined(_INTERNAL)
+	#if defined(_DEBUG) || defined(_INTERNAL) || defined(DEBUG_CRASHING)
 			AsciiString description;
 			conditionsYes.parse(ini, &description);
 

--- a/Generals/Code/Libraries/Source/WWVegas/WWDownload/CMakeLists.txt
+++ b/Generals/Code/Libraries/Source/WWVegas/WWDownload/CMakeLists.txt
@@ -21,4 +21,5 @@ target_sources(g_wwdownload PRIVATE ${WWDOWNLOAD_SRC})
 
 target_link_libraries(g_wwdownload PRIVATE
     g_wwcommon
+    gi_gameengine_include
 )

--- a/Generals/Code/Libraries/Source/WWVegas/WWDownload/DownloadDebug.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WWDownload/DownloadDebug.h
@@ -21,48 +21,6 @@
 #ifndef __DOWNLOADDEBUG_H_
 #define __DOWNLOADDEBUG_H_
 
-// BGC 3/27/03 - added this for disabling debug logging for "release" worldbuilder.
-// uncomment this line to remove logging from game spy code.
-//#define DISABLE_DEBUG_LOGGING
-
-#if defined(NDEBUG) || defined(DISABLE_DEBUG_LOGGING)
-#define DEBUG_LOG(exp) ((void)0)
-#else
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-	#include <stdarg.h>
-	extern void DebugCrash( const char *fmt, ... );
-	extern void DebugLog( const char *fmt, ... );
-
-	/*
-		Yeah, it's a sleazy global, since we can't reasonably add
-		any args to DebugCrash due to the varargs nature of it. 
-		We'll just let it slide in this case...
-	*/
-	extern char* TheCurrentIgnoreCrashPtr;
-
-	#define DEBUG_CRASH(m)	\
-		do { \
-			{ \
-				static char ignoreCrash = 0; \
-				if (!ignoreCrash) { \
-					TheCurrentIgnoreCrashPtr = &ignoreCrash; \
-					DebugCrash m ; \
-					TheCurrentIgnoreCrashPtr = NULL; \
-				} \
-			} \
-		} while (0)
-
-	#define DEBUG_LOG(x)		do { DebugLog x; } while (0)
-	#define DEBUG_ASSERTCRASH(c, m)		do { { if (!(c)) DEBUG_CRASH(m); } } while (0)
-
-#ifdef __cplusplus
-}
-#endif
-
-#endif // NDEBUG
+#include "Common/Debug.h"
 
 #endif //__DOWNLOADDEBUG_H_

--- a/Generals/Code/Tools/PATCHGET/debug.cpp
+++ b/Generals/Code/Tools/PATCHGET/debug.cpp
@@ -66,7 +66,7 @@ static int doCrashBox(const char *buffer, bool logResult)
 	return result;
 }
 
-#ifdef DEBUG
+#if defined(DEBUG) || defined(DEBUG_LOGGING)
 
 void DebugLog(const char *fmt, ...)
 {
@@ -80,7 +80,7 @@ void DebugLog(const char *fmt, ...)
 	printf( "%s", theBuffer );
 }
 
-#endif // DEBUG
+#endif // defined(DEBUG) || defined(DEBUG_LOGGING)
 
 #ifdef DEBUG_CRASHING
 

--- a/Generals/Code/Tools/PATCHGET/debug.h
+++ b/Generals/Code/Tools/PATCHGET/debug.h
@@ -26,7 +26,7 @@
 namespace patchget
 {
 
-#ifdef DEBUG
+#if defined(DEBUG) || defined(DEBUG_LOGGING)
 
 void DebugLog( const char *fmt, ... );
 #define DEBUG_LOG(x) DebugLog x

--- a/Generals/Code/Tools/WorldBuilder/include/WHeightMapEdit.h
+++ b/Generals/Code/Tools/WorldBuilder/include/WHeightMapEdit.h
@@ -46,7 +46,7 @@ public:
 /// Struct in memory.
 typedef struct 
 {
-#ifdef _DEBUG
+#ifdef DEBUG_CRASHING
 	Int forDebugOnly_fileTextureClass;
 #endif
 	Int numTiles;

--- a/Generals/Code/Tools/WorldBuilder/src/CUndoable.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/CUndoable.cpp
@@ -723,6 +723,7 @@ m_pDoc(pDoc)
 	m_new = newSL;
 	// ensure the new setup is valid. (don't mess with the old one.)
 	Bool modified = m_new.validateSides();
+	(void)modified;
 	DEBUG_ASSERTLOG(!modified,("*** had to clean up sides in SidesListUndoable! (caller should do this)\n"));
 }
 

--- a/Generals/Code/Tools/WorldBuilder/src/WBPopupSlider.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/WBPopupSlider.cpp
@@ -288,7 +288,7 @@ PopupSlider::~PopupSlider()
 {
 	if (mIcon) {
 		BOOL bRet = DestroyIcon(mIcon);
-
+		(void)bRet;
 		DEBUG_ASSERTCRASH(bRet != 0, ("Oops."));
 
 		mIcon = NULL;

--- a/Generals/Code/Tools/WorldBuilder/src/WHeightMapEdit.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/WHeightMapEdit.cpp
@@ -298,7 +298,7 @@ WorldHeightMapEdit::WorldHeightMapEdit(ChunkInputStream *pStrm):
 		optimizeTiles();
 	}
 	selectDuplicates();
-#ifdef _DEBUG
+#ifdef DEBUG_CRASHING
 	if (didCancel) {
 		return; // won't check out right.
 	}
@@ -810,7 +810,7 @@ void WorldHeightMapEdit::saveToFile(DataChunkOutput &chunkWriter)
 
 	chunkWriter.closeDataChunk();
 
-#ifdef _DEBUG
+#ifdef DEBUG_CRASHING
 	for (i=0; i<m_dataSize; i++) {
 		Int texNdx = this->m_tileNdxes[i];
 		DEBUG_ASSERTCRASH((texNdx>>2) < m_numBitmapTiles,("oops"));
@@ -1949,7 +1949,7 @@ Int WorldHeightMapEdit::getFirstTile(Int textureClass)
 */	 
 void WorldHeightMapEdit::dbgVerifyAfterUndo(void)
 {
-#ifdef _DEBUG
+#ifdef DEBUG_CRASHING
 	Int i, j;
 	for (i=0; i<m_numGlobalTextureClasses; i++) {
 		m_globalTextureClasses[i].forDebugOnly_fileTextureClass = -1;

--- a/Generals/Code/Tools/WorldBuilder/src/WorldBuilder.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/WorldBuilder.cpp
@@ -343,7 +343,7 @@ BOOL CWorldBuilderApp::InitInstance()
 	ini.load( AsciiString( "Data\\INI\\GameDataDebug.ini" ), INI_LOAD_MULTIFILE, NULL );
 #endif
 
-#if defined(_DEBUG) || defined(_INTERNAL)
+#ifdef DEBUG_CRASHING
 	TheWritableGlobalData->m_debugIgnoreAsserts = true;
 #endif
 

--- a/Generals/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp
@@ -1606,7 +1606,7 @@ void CWorldBuilderDoc::compressWaypointIds(void)
 	}
 	m_waypointTableNeedsUpdate = true;
 	updateWaypointTable();
-#ifdef _DEBUG
+#ifdef DEBUG_CRASHING
 	for (i=0; i<m_numWaypointLinks; i++) {
 		MapObject *pWay1 = getWaypointByID(m_waypointLinks[i].waypoint1);
 		MapObject *pWay2 = getWaypointByID(m_waypointLinks[i].waypoint2);

--- a/Generals/Code/Tools/WorldBuilder/src/addplayerdialog.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/addplayerdialog.cpp
@@ -85,6 +85,7 @@ void AddPlayerDialog::OnOK()
 			SidesList newSides = *TheSidesList;
 			newSides.addPlayerByTemplate(m_addedSide);
 			Bool modified = newSides.validateSides();
+			(void)modified;
 			DEBUG_ASSERTLOG(!modified,("had to clean up sides in AddPlayerDialog::OnOK"));
 
 			CWorldBuilderDoc* pDoc = CWorldBuilderDoc::GetActiveDoc();

--- a/Generals/Code/Tools/WorldBuilder/src/playerlistdlg.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/playerlistdlg.cpp
@@ -372,6 +372,7 @@ void PlayerListDlg::OnEditplayer()
 		fixDefaultTeamName(m_sides, pnameold, pnamenew);
 
 		Bool modified = m_sides.validateSides();
+		(void)modified;
 		DEBUG_ASSERTLOG(!modified,("had to clean up sides in PlayerListDlg::OnEditplayer"));
 
 		updateTheUI();

--- a/Generals/Code/Tools/WorldBuilder/src/playerlistdlg.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/playerlistdlg.cpp
@@ -324,6 +324,7 @@ void PlayerListDlg::OnNewplayer()
 			m_sides.addSide(&newPlayerDict);
 
 			Bool modified = m_sides.validateSides();
+			(void)modified;
 			DEBUG_ASSERTLOG(!modified,("had to clean up sides in PlayerListDlg::OnNewplayer"));
 			m_curPlayerIdx = m_sides.getNumSides()-1;
 			updateTheUI();
@@ -420,6 +421,7 @@ try_again:
 	} 
 
 	Bool modified = m_sides.validateSides();
+	(void)modified;
 	DEBUG_ASSERTLOG(!modified,("had to clean up sides in PlayerListDlg::OnRemoveplayer"));
 	updateTheUI();
 }
@@ -442,6 +444,7 @@ void PlayerListDlg::updateTheUI(void)
 
 	// make sure everything is canonical.
 	Bool modified = m_sides.validateSides();
+	(void)modified;
 	DEBUG_ASSERTLOG(!modified,("had to clean up sides in PlayerListDlg::updateTheUI! (caller should do this)"));
 
 	if (m_curPlayerIdx < 0) m_curPlayerIdx = 0;
@@ -741,6 +744,7 @@ void PlayerListDlg::OnSelchangeEnemieslist()
 void PlayerListDlg::OnOK() 
 {
 	Bool modified = m_sides.validateSides();
+	(void)modified;
 	DEBUG_ASSERTLOG(!modified,("had to clean up sides in CTeamsDialog::OnOK"));
 
 	CWorldBuilderDoc* pDoc = CWorldBuilderDoc::GetActiveDoc();
@@ -861,6 +865,7 @@ void PlayerListDlg::OnAddskirmishplayers()
 		m_sides.addSide(&newPlayerDict);
 
 		Bool modified = m_sides.validateSides();
+		(void)modified;
 		DEBUG_ASSERTLOG(!modified,("had to clean up sides in PlayerListDlg::OnNewplayer"));
 	}
 
@@ -882,6 +887,7 @@ void PlayerListDlg::OnAddskirmishplayers()
 		m_sides.addSide(&newPlayerDict);
 
 		Bool modified = m_sides.validateSides();
+		(void)modified;
 		DEBUG_ASSERTLOG(!modified,("had to clean up sides in PlayerListDlg::OnNewplayer"));
 	}
 
@@ -903,6 +909,7 @@ void PlayerListDlg::OnAddskirmishplayers()
 		m_sides.addSide(&newPlayerDict);
 
 		Bool modified = m_sides.validateSides();
+		(void)modified;
 		DEBUG_ASSERTLOG(!modified,("had to clean up sides in PlayerListDlg::OnNewplayer"));
 	}
 
@@ -924,6 +931,7 @@ void PlayerListDlg::OnAddskirmishplayers()
 		m_sides.addSide(&newPlayerDict);
 
 		Bool modified = m_sides.validateSides();
+		(void)modified;
 		DEBUG_ASSERTLOG(!modified,("had to clean up sides in PlayerListDlg::OnNewplayer"));
 	}
 	updateTheUI();

--- a/Generals/Code/Tools/WorldBuilder/src/teamsdialog.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/teamsdialog.cpp
@@ -223,6 +223,7 @@ BOOL CTeamsDialog::OnInitDialog()
 void CTeamsDialog::OnOK() 
 {
 	Bool modified = m_sides.validateSides();
+	(void)modified;
 	DEBUG_ASSERTLOG(!modified,("had to clean up sides in CTeamsDialog::OnOK"));
 
 	CWorldBuilderDoc* pDoc = CWorldBuilderDoc::GetActiveDoc();

--- a/GeneralsMD/Code/GameEngine/Include/Common/Debug.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Debug.h
@@ -72,6 +72,9 @@ class AsciiString;
 // by default, turn on ALLOW_DEBUG_UTILS if _DEBUG is turned on.
 #if (defined(_DEBUG) || defined(_INTERNAL)) && !defined(ALLOW_DEBUG_UTILS) && !defined(DISABLE_ALLOW_DEBUG_UTILS)
 	#define ALLOW_DEBUG_UTILS 1
+#elif defined(DEBUG_LOGGING) || defined(DEBUG_CRASHING) || defined(DEBUG_STACKTRACE) || defined(DEBUG_PROFILE)
+	// TheSuperHackers @tweak also turn on when any of the above options is already set.
+	#define ALLOW_DEBUG_UTILS 1
 #endif
 
 // these are predicated on ALLOW_DEBUG_UTILS, not _DEBUG, and allow you to selectively disable
@@ -84,6 +87,9 @@ class AsciiString;
 #endif
 #if defined(ALLOW_DEBUG_UTILS) && !defined(DEBUG_STACKTRACE) && !defined(DISABLE_DEBUG_STACKTRACE)
 	#define DEBUG_STACKTRACE 1
+	#ifndef DEBUG_LOGGING
+		#define DEBUG_LOGGING 1 // TheSuperHackers @compile Stack trace requires logging.
+	#endif
 #endif
 #if defined(ALLOW_DEBUG_UTILS) && !defined(DEBUG_PROFILE) && !defined(DISABLE_DEBUG_PROFILE)
 	#define DEBUG_PROFILE 1

--- a/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
@@ -505,7 +505,7 @@ public:
 #endif
 
 #ifdef DEBUG_CRASHING
-		Bool m_debugIgnoreAsserts;						///< Ignore all asserts.
+	Bool m_debugIgnoreAsserts;						///< Ignore all asserts.
 #endif
 
 #ifdef DEBUG_STACKTRACE

--- a/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
@@ -489,8 +489,6 @@ public:
 	Real m_debugProjectileTileWidth;			///< How wide should these tiles be?
 	Int m_debugProjectileTileDuration;		///< How long should these tiles stay around, in frames?
 	RGBColor m_debugProjectileTileColor;	///< What color should these tiles be?
-	Bool m_debugIgnoreAsserts;						///< Ignore all asserts.
-	Bool m_debugIgnoreStackTrace;					///< No stacktraces for asserts.
 	Bool m_showCollisionExtents;	///< Used to display collision extents
   Bool m_showAudioLocations;    ///< Used to display audio markers and ambient sound radii
 	Bool m_saveStats;
@@ -504,6 +502,14 @@ public:
 	Int m_latencyNoise;						///< Max amplitude of jitter to throw in
 	Int m_packetLoss;							///< Percent of packets to drop
 	Bool m_extraLogging;					///< More expensive debug logging to catch crashes.
+#endif
+
+#ifdef DEBUG_CRASHING
+		Bool m_debugIgnoreAsserts;						///< Ignore all asserts.
+#endif
+
+#ifdef DEBUG_STACKTRACE
+	Bool m_debugIgnoreStackTrace;					///< No stacktraces for asserts.
 #endif
 
 	Bool				m_isBreakableMovie;							///< if we enter a breakable movie, set this flag

--- a/GeneralsMD/Code/GameEngine/Include/Common/INI.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/INI.h
@@ -411,7 +411,7 @@ protected:
 	const char *m_sepsQuote;									///< token to represent a quoted ascii string
 	const char *m_blockEndToken;							///< token to represent end of data block
 	Bool m_endOfFile;													///< TRUE when we've hit EOF
-#if defined(_DEBUG) || defined(_INTERNAL)
+#ifdef DEBUG_CRASHING
 	char m_curBlockStart[ INI_MAX_CHARS_PER_LINE ];	///< first line of cur block
 #endif
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/AIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/AIUpdate.h
@@ -647,7 +647,7 @@ public:
 
 	// this is intended for use ONLY by AIFollowPathState.
 	inline void friend_setCurrentGoalPathIndex( Int index ) { m_nextGoalPathIndex = index; }
-#if defined(_DEBUG) || defined(_INTERNAL)	
+#ifdef DEBUG_LOGGING
 	inline const Coord3D *friend_getRequestedDestination() const { return &m_requestedDestination; }
 	inline const Coord3D *friend_getRequestedDestination2() const { return &m_requestedDestination2; }
 #endif

--- a/GeneralsMD/Code/GameEngine/Source/Common/CommandLine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/CommandLine.cpp
@@ -1247,10 +1247,6 @@ static CommandLineParam params[] =
 	{ "-selectTheUnselectable", parseSelectAll },
 	{ "-RunAhead", parseRunAhead },
 	{ "-noshroud", parseNoShroud },
-#ifdef DEBUG_LOGGING
-	{ "-setDebugLevel", parseSetDebugLevel },
-	{ "-clearDebugLevel", parseClearDebugLevel },
-#endif
 	{ "-forceBenchmark", parseForceBenchmark },
 	{ "-buildmapcache", parseBuildMapCache },
 	{ "-noshadowvolumes", parseNoShadows },
@@ -1272,12 +1268,17 @@ static CommandLineParam params[] =
 
 #endif
 
+#ifdef DEBUG_LOGGING
+	{ "-setDebugLevel", parseSetDebugLevel },
+	{ "-clearDebugLevel", parseClearDebugLevel },
+#endif
+
 #ifdef DEBUG_CRASHING
-		{ "-ignoreAsserts", parseIgnoreAsserts },
+	{ "-ignoreAsserts", parseIgnoreAsserts },
 #endif
 
 #ifdef DEBUG_STACKTRACE
-		{ "-ignoreStackTrace", parseIgnoreStackTrace },
+	{ "-ignoreStackTrace", parseIgnoreStackTrace },
 #endif
 
 	//-allAdvice feature

--- a/GeneralsMD/Code/GameEngine/Source/Common/CommandLine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/CommandLine.cpp
@@ -32,6 +32,7 @@
 #include "Common/version.h"
 #include "GameClient/TerrainVisual.h" // for TERRAIN_LOD_MIN definition
 #include "GameClient/GameText.h"
+#include "GameNetwork/NetworkDefs.h"
 
 #ifdef _INTERNAL
 // for occasional debugging...
@@ -111,9 +112,7 @@ static void ConvertShortMapPathToLongMapPath(AsciiString &mapName)
 //=============================================================================
 Int parseNoLogOrCrash(char *args[], int)
 {
-#ifdef ALLOW_DEBUG_UTILS
 	DEBUG_CRASH(("-NoLogOrCrash not supported in this build\n"));
-#endif
 	return 1;
 }
 
@@ -333,7 +332,9 @@ Int parseNoDraw(char *args[], int argc)
 //=============================================================================
 Int parseLogToConsole(char *args[], int)
 {
+#ifdef ALLOW_DEBUG_UTILS
 	DebugSetFlags(DebugGetFlags() | DEBUG_FLAG_LOG_TO_CONSOLE);
+#endif
 	return 1;
 }
 
@@ -1023,7 +1024,7 @@ Int parseStats(char *args[], int num)
 #endif
 #endif
 
-#if defined(_DEBUG) || defined(_INTERNAL)
+#ifdef DEBUG_CRASHING
 Int parseIgnoreAsserts(char *args[], int num)
 {
 	if (TheWritableGlobalData && num > 0)
@@ -1034,7 +1035,7 @@ Int parseIgnoreAsserts(char *args[], int num)
 }
 #endif
 
-#if defined(_DEBUG) || defined(_INTERNAL)
+#ifdef DEBUG_STACKTRACE
 Int parseIgnoreStackTrace(char *args[], int num)
 {
 	if (TheWritableGlobalData && num > 0)
@@ -1131,7 +1132,7 @@ Int parseMod(char *args[], Int num)
 	return 1;
 }
 
-#if defined(_DEBUG) || defined(_INTERNAL)
+#ifdef DEBUG_LOGGING
 Int parseSetDebugLevel(char *args[], int num)
 {
 	if (num > 1)
@@ -1241,15 +1242,15 @@ static CommandLineParam params[] =
 	{ "-netMinPlayers", parseNetMinPlayers },
 	{ "-DemoLoadScreen", parseDemoLoadScreen },
 	{ "-cameraDebug", parseCameraDebug },
-	{ "-ignoreAsserts", parseIgnoreAsserts },
-	{ "-ignoreStackTrace", parseIgnoreStackTrace },
 	{ "-logToCon", parseLogToConsole },
 	{ "-vTune", parseVTune },
 	{ "-selectTheUnselectable", parseSelectAll },
 	{ "-RunAhead", parseRunAhead },
 	{ "-noshroud", parseNoShroud },
+#ifdef DEBUG_LOGGING
 	{ "-setDebugLevel", parseSetDebugLevel },
 	{ "-clearDebugLevel", parseClearDebugLevel },
+#endif
 	{ "-forceBenchmark", parseForceBenchmark },
 	{ "-buildmapcache", parseBuildMapCache },
 	{ "-noshadowvolumes", parseNoShadows },
@@ -1269,6 +1270,14 @@ static CommandLineParam params[] =
 	{ "-showTeamDot", parseShowTeamDot },
 	{ "-extraLogging", parseExtraLogging },
 
+#endif
+
+#ifdef DEBUG_CRASHING
+		{ "-ignoreAsserts", parseIgnoreAsserts },
+#endif
+
+#ifdef DEBUG_STACKTRACE
+		{ "-ignoreStackTrace", parseIgnoreStackTrace },
 #endif
 
 	//-allAdvice feature

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -571,8 +571,6 @@ GlobalData::GlobalData()
 	m_debugCashValueMap = FALSE;
 	m_maxDebugValue = 10000;
 	m_debugCashValueMapTileDuration = LOGICFRAMES_PER_SECOND; // Changed By Sadullah Nader
-	m_debugIgnoreAsserts = FALSE;
-	m_debugIgnoreStackTrace = FALSE;
 	m_vTune = false;
 	m_checkForLeaks = TRUE;
 	m_benchmarkTimer = -1;
@@ -593,6 +591,14 @@ GlobalData::GlobalData()
 	m_baseStatsDir = ".\\";
 	m_MOTDPath = "MOTD.txt";
 	m_extraLogging = FALSE;
+#endif
+
+#ifdef DEBUG_CRASHING
+	m_debugIgnoreAsserts = FALSE;
+#endif
+
+#ifdef DEBUG_STACKTRACE
+	m_debugIgnoreStackTrace = FALSE;
 #endif
 
 	m_playStats = -1;

--- a/GeneralsMD/Code/GameEngine/Source/Common/INI/INI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/INI/INI.cpp
@@ -196,7 +196,7 @@ INI::INI( void )
 	m_blockEndToken			= "END";
 	m_endOfFile					= FALSE;
 	m_buffer[0]					= 0;
-#if defined(_DEBUG) || defined(_INTERNAL)
+#ifdef DEBUG_CRASHING
 	m_curBlockStart[0]	= 0;
 #endif
 
@@ -375,7 +375,7 @@ void INI::load( AsciiString filename, INILoadType loadType, Xfer *pXfer )
 				INIBlockParse parse = findBlockParse(token);
 				if (parse)
 				{
-					#if defined(_DEBUG) || defined(_INTERNAL)
+					#ifdef DEBUG_CRASHING
 					strcpy(m_curBlockStart, m_buffer);
 					#endif
 					try {
@@ -388,7 +388,7 @@ void INI::load( AsciiString filename, INILoadType loadType, Xfer *pXfer )
 
 						throw INIException(buff);
 					}
-					#if defined(_DEBUG) || defined(_INTERNAL)
+					#ifdef DEBUG_CRASHING
 						strcpy(m_curBlockStart, "NO_BLOCK");
 					#endif
 				}

--- a/GeneralsMD/Code/GameEngine/Source/Common/StateMachine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/StateMachine.cpp
@@ -664,7 +664,7 @@ StateReturnType StateMachine::internalSetState( StateID newStateID )
  */
 StateReturnType StateMachine::initDefaultState()
 {
-#if defined(_DEBUG) || defined(_INTERNAL)
+#ifdef DEBUG_LOGGING
 #ifdef STATE_MACHINE_DEBUG
 #define REALLY_VERBOSE_LOG(x) /* */
 	// Run through all the transitions and make sure there aren't any transitions to undefined states. jba. [8/18/2003]

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/DataChunk.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/DataChunk.cpp
@@ -893,7 +893,7 @@ void DataChunkInput::readArrayOfBytes(char *ptr, Int len)
 NameKeyType DataChunkInput::readNameKey(void)
 {
 		Int keyAndType = readInt();
-#if (defined(_DEBUG) || defined(_INTERNAL))
+#ifdef DEBUG_CRASHING
 		Dict::DataType t = (Dict::DataType)(keyAndType & 0xff);
 		DEBUG_ASSERTCRASH(t==Dict::DICT_ASCIISTRING,("Invalid key data."));
 #endif

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/Debug.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/Debug.cpp
@@ -631,7 +631,7 @@ double SimpleProfiler::getAverageTime()
 	return (double)m_totalAllSessions * 1000.0 / ((double)m_freq * (double)m_numSessions);
 }
 
-#endif	// ALLOW_DEBUG_UTILS
+#endif	// DEBUG_PROFILE
 
 // ----------------------------------------------------------------------------
 // ReleaseCrash

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/Debug.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/Debug.cpp
@@ -126,7 +126,9 @@ static const char *prepBuffer(const char* format, char *buffer);
 #ifdef DEBUG_LOGGING
 static void doLogOutput(const char *buffer);
 #endif
+#ifdef DEBUG_CRASHING
 static int doCrashBox(const char *buffer, Bool logResult);
+#endif
 static void whackFunnyCharacters(char *buf);
 #ifdef DEBUG_STACKTRACE
 static void doStackDump();
@@ -139,7 +141,7 @@ static void doStackDump();
 // ----------------------------------------------------------------------------
 inline Bool ignoringAsserts()
 {
-#if defined(_DEBUG) || defined(_INTERNAL)
+#ifdef DEBUG_CRASHING
 	return !DX8Wrapper_IsWindowed || (TheGlobalData&&TheGlobalData->m_debugIgnoreAsserts);
 #else
 	return !DX8Wrapper_IsWindowed;
@@ -245,6 +247,7 @@ static void doLogOutput(const char *buffer)
 	we exit the app, break into debugger, or continue execution. 
 */
 // ----------------------------------------------------------------------------
+#ifdef DEBUG_CRASHING
 static int doCrashBox(const char *buffer, Bool logResult)
 {
 	int result;
@@ -282,6 +285,7 @@ static int doCrashBox(const char *buffer, Bool logResult)
 	}
 	return result;
 }
+#endif
 
 #ifdef DEBUG_STACKTRACE
 // ----------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/GameMemory.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/GameMemory.cpp
@@ -3069,8 +3069,10 @@ void MemoryPoolFactory::debugMemoryReport(Int flags, Int startCheckpoint, Int en
 {
 	//USE_PERF_TIMER(MemoryPoolDebugging) skip end-of-run reporting stuff
 
+#ifdef ALLOW_DEBUG_UTILS
 	Int oldFlags = DebugGetFlags();
 	DebugSetFlags(oldFlags & ~DEBUG_FLAG_PREPEND_TIME);
+#endif
 
 #ifdef MEMORYPOOL_CHECKPOINTING
 	Bool doBlockReport = (flags & _REPORT_CP_ALLOCATED_DONTCARE) != 0 && (flags & _REPORT_CP_FREED_DONTCARE) != 0;
@@ -3226,7 +3228,9 @@ void MemoryPoolFactory::debugMemoryReport(Int flags, Int startCheckpoint, Int en
 	}
 #endif
 
+#ifdef ALLOW_DEBUG_UTILS
 	DebugSetFlags(oldFlags);
+#endif
 }
 #endif
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/Thing/ModuleFactory.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Thing/ModuleFactory.cpp
@@ -644,7 +644,7 @@ Module *ModuleFactory::newModule( Thing *thing, const AsciiString& name, const M
 	{
 		Module* mod = (*mt->m_createProc)( thing, moduleData );
 
-#ifdef _DEBUG
+#ifdef DEBUG_CRASHING
 		if (type == MODULETYPE_BEHAVIOR)
 		{
 			BehaviorModule* bm = (BehaviorModule*)mod;

--- a/GeneralsMD/Code/GameEngine/Source/Common/Thing/ThingFactory.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Thing/ThingFactory.cpp
@@ -366,7 +366,7 @@ Drawable *ThingFactory::newDrawable(const ThingTemplate *tmplate, DrawableStatus
 
 }  // end newDrawableByType
 
-#if defined(_DEBUG) || defined(_INTERNAL)
+#if defined(_DEBUG) || defined(_INTERNAL) || defined(DEBUG_CRASHING)
 AsciiString TheThingTemplateBeingParsedName;
 #endif
 
@@ -375,7 +375,7 @@ AsciiString TheThingTemplateBeingParsedName;
 //-------------------------------------------------------------------------------------------------
 /*static*/ void ThingFactory::parseObjectDefinition( INI* ini, const AsciiString& name, const AsciiString& reskinFrom )
 {
-#if defined(_DEBUG) || defined(_INTERNAL)
+#if defined(_DEBUG) || defined(_INTERNAL) || defined(DEBUG_CRASHING)
 	TheThingTemplateBeingParsedName = name;
 #endif
 
@@ -434,7 +434,7 @@ AsciiString TheThingTemplateBeingParsedName;
 		thingTemplate->resolveNames();
 	}
 
-#if defined(_DEBUG) || defined(_INTERNAL)
+#if defined(_DEBUG) || defined(_INTERNAL) || defined(DEBUG_CRASHING)
 	TheThingTemplateBeingParsedName.clear();
 #endif
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -5647,7 +5647,7 @@ Bool Pathfinder::adjustToPossibleDestination(Object *obj, const LocomotorSet& lo
  */
 Bool Pathfinder::queueForPath(ObjectID id)
 {
-#if defined(_DEBUG) || defined(_INTERNAL)
+#ifdef DEBUG_LOGGING
 	{
 		Object *tmpObj = TheGameLogic->findObjectByID(id);
 		if (tmpObj) {
@@ -5885,7 +5885,7 @@ void Pathfinder::processPathfindQueue(void)
 		return;
 	}
 #ifdef DEBUG_QPF
-#if defined _DEBUG || defined _INTERNAL
+#ifdef DEBUG_LOGGING
 	Int startTimeMS = ::GetTickCount();
 	__int64 startTime64;
 	double timeToUpdate=0.0f;
@@ -5944,7 +5944,7 @@ void Pathfinder::processPathfindQueue(void)
 	}
 	if (pathsFound>0) {
 #ifdef DEBUG_QPF
-#if defined _DEBUG || defined _INTERNAL
+#ifdef DEBUG_LOGGING
 		QueryPerformanceCounter((LARGE_INTEGER *)&endTime64);
 		timeToUpdate = ((double)(endTime64-startTime64) / (double)(freq64));
 		if (timeToUpdate>0.01f) 
@@ -6467,7 +6467,7 @@ Path *Pathfinder::internalFindPath( Object *obj, const LocomotorSet& locomotorSe
 	DEBUG_LOG(("internal find path...\n"));
 #endif
 
-#if defined _DEBUG || defined _INTERNAL
+#ifdef DEBUG_LOGGING
 	Int startTimeMS = ::GetTickCount();
 #endif
 	Bool centerInCell = true;
@@ -6694,12 +6694,6 @@ Path *Pathfinder::internalFindPath( Object *obj, const LocomotorSet& locomotorSe
 	}	
 
 	if (obj) {
-		Bool valid;
-		valid = validMovementPosition( isCrusher, obj->getLayer(), locomotorSet, to ) ;
-
-		DEBUG_LOG(("%d ", TheGameLogic->getFrame()));
-		DEBUG_LOG(("Pathfind failed from (%f,%f) to (%f,%f), OV %d\n", from->x, from->y, to->x, to->y, valid));
-		DEBUG_LOG(("Unit '%s', time %f, cells %d\n", obj->getTemplate()->getName().str(), (::GetTickCount()-startTimeMS)/1000.0f,cellCount));
 #ifdef DUMP_PERF_STATS
 		TheGameLogic->incrementOverallFailedPathfinds();
 #endif
@@ -6711,6 +6705,19 @@ Path *Pathfinder::internalFindPath( Object *obj, const LocomotorSet& locomotorSe
 #endif
 	}
 #endif
+
+#ifdef DEBUG_LOGGING
+	if (obj)
+	{
+		Bool valid;
+		valid = validMovementPosition( isCrusher, obj->getLayer(), locomotorSet, to ) ;
+
+		DEBUG_LOG(("%d ", TheGameLogic->getFrame()));
+		DEBUG_LOG(("Pathfind failed from (%f,%f) to (%f,%f), OV %d\n", from->x, from->y, to->x, to->y, valid));
+		DEBUG_LOG(("Unit '%s', time %f, cells %d\n", obj->getTemplate()->getName().str(), (::GetTickCount()-startTimeMS)/1000.0f,cellCount));
+	}
+#endif
+
 	m_isTunneling = false;
 	goalCell->releaseInfo();
 	cleanOpenAndClosedLists();
@@ -7006,7 +7013,7 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 													 const Coord3D *rawTo, Int pathDiameter, Bool crusher)
 {
 	//CRCDEBUG_LOG(("Pathfinder::findGroundPath()\n"));
-#if defined _DEBUG || defined _INTERNAL
+#ifdef DEBUG_LOGGING
 	Int startTimeMS = ::GetTickCount();
 #endif
 #ifdef INTENSE_DEBUG
@@ -7326,11 +7333,12 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 
 		}
 	}	
+#endif
 
 	DEBUG_LOG(("%d ", TheGameLogic->getFrame()));
 	DEBUG_LOG(("FindGroundPath failed from (%f,%f) to (%f,%f)\n", from->x, from->y, to->x, to->y));
 	DEBUG_LOG(("time %f\n", (::GetTickCount()-startTimeMS)/1000.0f));
-#endif
+
 #ifdef DUMP_PERF_STATS
 	TheGameLogic->incrementOverallFailedPathfinds();
 #endif
@@ -7460,7 +7468,7 @@ Path *Pathfinder::internal_findHierarchicalPath( Bool isHuman, const LocomotorSu
 													 const Coord3D *rawTo, Bool crusher, Bool closestOK)
 {
 	//CRCDEBUG_LOG(("Pathfinder::findGroundPath()\n"));
-#if defined _DEBUG || defined _INTERNAL
+#ifdef DEBUG_LOGGING
 	Int startTimeMS = ::GetTickCount();
 #endif
 	
@@ -7955,11 +7963,12 @@ Path *Pathfinder::internal_findHierarchicalPath( Bool isHuman, const LocomotorSu
 
 		}
 	}	
+#endif
 
 	DEBUG_LOG(("%d ", TheGameLogic->getFrame()));
 	DEBUG_LOG(("FindHierarchicalPath failed from (%f,%f) to (%f,%f)\n", from->x, from->y, to->x, to->y));
 	DEBUG_LOG(("time %f\n", (::GetTickCount()-startTimeMS)/1000.0f));
-#endif
+
 #ifdef DUMP_PERF_STATS
 	TheGameLogic->incrementOverallFailedPathfinds();
 #endif
@@ -8663,7 +8672,7 @@ Path *Pathfinder::findClosestPath( Object *obj, const LocomotorSet& locomotorSet
 																	Coord3D *rawTo, Bool blocked, Real pathCostMultiplier, Bool moveAllies)
 {
 	//CRCDEBUG_LOG(("Pathfinder::findClosestPath()\n"));
-#if defined _DEBUG || defined _INTERNAL
+#ifdef DEBUG_LOGGING
 	Int startTimeMS = ::GetTickCount();
 #endif
 	Bool isHuman = true;
@@ -8938,13 +8947,15 @@ Path *Pathfinder::findClosestPath( Object *obj, const LocomotorSet& locomotorSet
 	}
 
 	// failure - goal cannot be reached
-#if defined _DEBUG || defined _INTERNAL
+#ifdef DEBUG_LOGGING
 	Bool valid;
 	valid = validMovementPosition( isCrusher, obj->getLayer(), locomotorSet, to ) ;
 
 	DEBUG_LOG(("%d ", TheGameLogic->getFrame()));
 	DEBUG_LOG(("Pathfind(findClosestPath) failed from (%f,%f) to (%f,%f), original valid %d --", from->x, from->y, to->x, to->y, valid));
 	DEBUG_LOG(("Unit '%s', time %f\n", obj->getTemplate()->getName().str(), (::GetTickCount()-startTimeMS)/1000.0f));
+#endif
+#if defined _DEBUG || defined _INTERNAL
 	if (TheGlobalData->m_debugAI) 
 		debugShowSearch(false);
 #endif
@@ -10198,7 +10209,7 @@ Path *Pathfinder::getMoveAwayFromPath(Object* obj, Object *otherObj,
 											Path *pathToAvoid, Object *otherObj2, Path *pathToAvoid2)
 {
 	if (m_isMapReady == false) return NULL; // Should always be ok.
-#if defined _DEBUG || defined _INTERNAL
+#ifdef DEBUG_LOGGING
 	Int startTimeMS = ::GetTickCount();
 #endif
 	Bool isHuman = true;
@@ -10354,10 +10365,12 @@ Path *Pathfinder::getMoveAwayFromPath(Object* obj, Object *otherObj,
 
 #if defined _DEBUG || defined _INTERNAL
 	debugShowSearch(true);
+#endif
+
 	DEBUG_LOG(("%d ", TheGameLogic->getFrame()));
 	DEBUG_LOG(("getMoveAwayFromPath pathfind failed  -- "));
 	DEBUG_LOG(("Unit '%s', time %f\n", obj->getTemplate()->getName().str(), (::GetTickCount()-startTimeMS)/1000.0f));
-#endif
+
 	m_isTunneling = false;
 	cleanOpenAndClosedLists();
 	return NULL;
@@ -10371,7 +10384,7 @@ Path *Pathfinder::patchPath( const Object *obj, const LocomotorSet& locomotorSet
 		Path *originalPath, Bool blocked )
 {
 	//CRCDEBUG_LOG(("Pathfinder::patchPath()\n"));
-#if defined _DEBUG || defined _INTERNAL
+#ifdef DEBUG_LOGGING
 	Int startTimeMS = ::GetTickCount();
 #endif
 	if (originalPath==NULL) return NULL;
@@ -10533,10 +10546,11 @@ Path *Pathfinder::patchPath( const Object *obj, const LocomotorSet& locomotorSet
 		}
 	}
 
-#if defined _DEBUG || defined _INTERNAL
 	DEBUG_LOG(("%d ", TheGameLogic->getFrame()));
 	DEBUG_LOG(("patchPath Pathfind failed  -- "));
 	DEBUG_LOG(("Unit '%s', time %f\n", obj->getTemplate()->getName().str(), (::GetTickCount()-startTimeMS)/1000.0f));
+
+#if defined _DEBUG || defined _INTERNAL
 	if (TheGlobalData->m_debugAI) {
 		debugShowSearch(true);
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
@@ -376,12 +376,7 @@ void TransportContain::onRemoving( Object *rider )
 	Int transportSlotCount = rider->getTransportSlotCount();
 	DEBUG_ASSERTCRASH(transportSlotCount > 0, ("Hmm, this object isnt transportable"));
 	m_extraSlotsInUse -= transportSlotCount - 1;
-
-#ifdef DEBUG_CRASHING
-	UnsignedInt containCount = getContainCount();
-	UnsignedInt containMax = getContainMax();
-	DEBUG_ASSERTCRASH(m_extraSlotsInUse >= 0 && m_extraSlotsInUse + containCount <= containMax, ("Hmm, bad slot count"));
-#endif
+	DEBUG_ASSERTCRASH(m_extraSlotsInUse >= 0 && m_extraSlotsInUse + getContainCount() <= getContainMax(), ("Hmm, bad slot count"));
 
 	// when we are empty again, clear the model condition for loaded
 	if( getContainCount() == 0 )

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
@@ -377,7 +377,7 @@ void TransportContain::onRemoving( Object *rider )
 	DEBUG_ASSERTCRASH(transportSlotCount > 0, ("Hmm, this object isnt transportable"));
 	m_extraSlotsInUse -= transportSlotCount - 1;
 
-#if (defined(_DEBUG) || defined(_INTERNAL))
+#ifdef DEBUG_CRASHING
 	UnsignedInt containCount = getContainCount();
 	UnsignedInt containMax = getContainMax();
 	DEBUG_ASSERTCRASH(m_extraSlotsInUse >= 0 && m_extraSlotsInUse + containCount <= containMax, ("Hmm, bad slot count"));

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
@@ -1412,7 +1412,7 @@ UnsignedInt PartitionCell::getThreatValue( Int playerIndex )
 void PartitionCell::addThreatValue( Int playerIndex, UnsignedInt threatValue )
 {
 	if (playerIndex >= 0 && playerIndex < MAX_PLAYER_COUNT) {
-#ifdef _DEBUG
+#ifdef DEBUG_CRASHING
 		UnsignedInt oldThreatVal = m_threatValue[playerIndex];
 		DEBUG_ASSERTCRASH(oldThreatVal <= oldThreatVal + threatValue, ("adding new threat value overflowed allotted storage."));
 #endif
@@ -1424,7 +1424,7 @@ void PartitionCell::addThreatValue( Int playerIndex, UnsignedInt threatValue )
 void PartitionCell::removeThreatValue( Int playerIndex, UnsignedInt threatValue )
 {
 	if (playerIndex >= 0 && playerIndex < MAX_PLAYER_COUNT) {
-#ifdef _DEBUG
+#ifdef DEBUG_CRASHING
 		UnsignedInt oldThreatVal = m_threatValue[playerIndex];
 		DEBUG_ASSERTCRASH(oldThreatVal >= oldThreatVal - threatValue, ("removing new threat value underflowed allotted storage."));
 #endif
@@ -1445,7 +1445,7 @@ UnsignedInt PartitionCell::getCashValue( Int playerIndex )
 void PartitionCell::addCashValue( Int playerIndex, UnsignedInt cashValue )
 {
 	if (playerIndex >= 0 && playerIndex < MAX_PLAYER_COUNT) {
-#ifdef _DEBUG
+#ifdef DEBUG_CRASHING
 		UnsignedInt oldCashVal = m_cashValue[playerIndex];
 		DEBUG_ASSERTCRASH(oldCashVal <= oldCashVal + cashValue, ("adding new cash value overflowed allotted storage."));
 #endif
@@ -1457,7 +1457,7 @@ void PartitionCell::addCashValue( Int playerIndex, UnsignedInt cashValue )
 void PartitionCell::removeCashValue( Int playerIndex, UnsignedInt cashValue )
 {
 	if (playerIndex >= 0 && playerIndex < MAX_PLAYER_COUNT) {
-#ifdef _DEBUG
+#ifdef DEBUG_CRASHING
 		UnsignedInt oldCashVal = m_cashValue[playerIndex];
 		DEBUG_ASSERTCRASH(oldCashVal >= oldCashVal - cashValue, ("removing new cash value underflowed allotted storage."));
 #endif

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/MissileLauncherBuildingUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/MissileLauncherBuildingUpdate.cpp
@@ -210,7 +210,11 @@ Bool MissileLauncherBuildingUpdate::initiateIntentToDoSpecialPower( const Specia
 	{
 		return FALSE;
 	}
+
+#if defined(_DEBUG) || defined(_INTERNAL) || defined(_ALLOW_DEBUG_CHEATS_IN_RELEASE)
 	DEBUG_ASSERTCRASH(!TheGlobalData->m_specialPowerUsesDelay || m_doorState == DOOR_OPEN, ("door is not fully open when specialpower is fired!"));
+#endif
+
 	switchToState(DOOR_WAITING_TO_CLOSE);
 //	getObject()->getControllingPlayer()->getAcademyStats()->recordSpecialPowerUsed( specialPowerTemplate );
 	return TRUE;
@@ -254,7 +258,9 @@ UpdateSleepTime MissileLauncherBuildingUpdate::update( void )
 			switchToState(m_timeoutState);
 		}
 
+#if defined(_DEBUG) || defined(_INTERNAL) || defined(_ALLOW_DEBUG_CHEATS_IN_RELEASE)
 		DEBUG_ASSERTCRASH(!TheGlobalData->m_specialPowerUsesDelay || !(m_specialPowerModule->isReady() && m_doorState != DOOR_OPEN), ("door is not fully open when specialpower is ready!"));
+#endif
 
 		if (m_doorState != DOOR_OPEN && m_specialPowerModule->isReady())
 		{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
@@ -6753,7 +6753,7 @@ void ScriptActions::executeAction( ScriptAction *pAction )
 				                     pAction->getParameter(2)->getInt());
 			return;
 		case ScriptAction::DEBUG_CRASH_BOX:
-#if defined(_DEBUG) || defined(_INTERNAL)
+#ifdef DEBUG_CRASHING
 			{
 				const char* MSG = "Your Script requested the following message be displayed:\n\n";
 				const char* MSG2 = "\n\nTHIS IS NOT A BUG. DO NOT REPORT IT.";

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/Scripts.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/Scripts.cpp
@@ -2479,7 +2479,7 @@ ScriptAction *ScriptAction::ParseAction(DataChunkInput &file, DataChunkInfo *inf
 			}
 		}
 	}
-#if defined(_DEBUG) || defined(_INTERNAL)
+#ifdef DEBUG_CRASHING
 	Script *pScript = (Script *)userData;
 	if (at && (at->getName().isEmpty() || (at->getName().compareNoCase("(placeholder)") == 0))) {
 		DEBUG_CRASH(("Invalid Script Action found in script '%s'\n", pScript->getName().str()));

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -2272,7 +2272,9 @@ void GameLogic::startNewGame( Bool loadingSaveGame )
 
 	// Turn off shadows
 	TheWritableGlobalData->m_useShadowVolumes = false;
+#ifdef DEBUG_CRASHING
 	TheWritableGlobalData->m_debugIgnoreAsserts = TRUE;
+#endif
 
 	// Just look somewhere.  lookAt does some terrain specific setup, so it is good
 	// to call it.  jba
@@ -2717,8 +2719,8 @@ void GameLogic::deselectObject(Object *obj, PlayerMaskType playerMask, Bool affe
 // ------------------------------------------------------------------------------------------------
 inline void GameLogic::validateSleepyUpdate() const
 {
-// pretty slow, so do only for DEBUG for now. turn on if you suspect wonkiness.
-#ifdef _DEBUG
+// pretty slow, so do only for DEBUG_CRASHING for now. turn on if you suspect wonkiness.
+#ifdef DEBUG_CRASHING
 	#define SLEEPY_DEBUG
 #endif
 #ifdef SLEEPY_DEBUG
@@ -3652,12 +3654,12 @@ void GameLogic::update( void )
 	Bool isMPGameOrReplay = (TheRecorder && TheRecorder->isMultiplayer() && getGameMode() != GAME_SHELL && getGameMode() != GAME_NONE);
 	Bool isSoloGameOrReplay = (TheRecorder && !TheRecorder->isMultiplayer() && getGameMode() != GAME_SHELL && getGameMode() != GAME_NONE);
 	Bool generateForMP = (isMPGameOrReplay && (m_frame % TheGameInfo->getCRCInterval()) == 0);
-#if defined(_DEBUG) || defined(_INTERNAL)
+#ifdef DEBUG_CRC
 	Bool generateForSolo = isSoloGameOrReplay && ((m_frame && (m_frame%100 == 0)) ||
 		(getFrame() > TheCRCFirstFrameToLog && getFrame() < TheCRCLastFrameToLog && ((m_frame % REPLAY_CRC_INTERVAL) == 0)));
 #else
 	Bool generateForSolo = isSoloGameOrReplay && ((m_frame % REPLAY_CRC_INTERVAL) == 0);
-#endif // defined(_DEBUG) || defined(_INTERNAL)
+#endif // DEBUG_CRC
 
 	if (generateForSolo || generateForMP)
 	{

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DModelDraw.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DModelDraw.h
@@ -176,7 +176,7 @@ struct ModelConditionInfo
 		Int							m_fxBone;											///< the FX bone for this barrel (zero == no bone)
 		Int							m_muzzleFlashBone;						///< the muzzle-flash subobj bone for this barrel (zero == none)
 		Matrix3D				m_projectileOffsetMtx;				///< where the projectile fires from
-#if defined(_DEBUG) || defined(_INTERNAL)
+#if defined(_DEBUG) || defined(_INTERNAL) || defined(DEBUG_CRASHING)
 		AsciiString			m_muzzleFlashBoneName;
 #endif
 
@@ -191,7 +191,7 @@ struct ModelConditionInfo
 			m_fxBone = 0;
 			m_muzzleFlashBone = 0;
 			m_projectileOffsetMtx.Make_Identity();
-#if defined(_DEBUG) || defined(_INTERNAL)
+#if defined(_DEBUG) || defined(_INTERNAL) || defined(DEBUG_CRASHING)
 			m_muzzleFlashBoneName.clear();
 #endif
 		}
@@ -200,7 +200,7 @@ struct ModelConditionInfo
 	}; 
 	typedef std::vector<WeaponBarrelInfo>	WeaponBarrelInfoVec;
 
-#if defined(_DEBUG) || defined(_INTERNAL)
+#if defined(_DEBUG) || defined(_INTERNAL) || defined(DEBUG_CRASHING)
 	AsciiString												m_description;
 #endif
 	std::vector<ModelConditionFlags>	m_conditionsYesVec;

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
@@ -205,8 +205,11 @@ LogClass BonePosLog("bonePositions.txt");
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
 
-#if defined(_DEBUG) || defined(_INTERNAL)
+#if defined(_DEBUG) || defined(_INTERNAL) || defined(DEBUG_CRASHING)
 extern AsciiString TheThingTemplateBeingParsedName;
+#endif
+
+#if defined(_DEBUG) || defined(_INTERNAL)
 extern Real TheSkateDistOverride;
 #endif
 
@@ -770,7 +773,7 @@ void ModelConditionInfo::validateWeaponBarrelInfo() const
 				{
 					sprintf(buffer, "%s%02d", mfName.str(), i);
 					findPristineBone(NAMEKEY(buffer), &info.m_muzzleFlashBone);
-#if defined(_DEBUG) || defined(_INTERNAL)
+#if defined(_DEBUG) || defined(_INTERNAL) || defined(DEBUG_CRASHING)
 					if (info.m_muzzleFlashBone)
 						info.m_muzzleFlashBoneName = buffer;
 #endif
@@ -818,7 +821,7 @@ void ModelConditionInfo::validateWeaponBarrelInfo() const
 				if (!mfName.isEmpty())
 					findPristineBone(NAMEKEY(mfName), &info.m_muzzleFlashBone);
 
-#if defined(_DEBUG) || defined(_INTERNAL)
+#if defined(_DEBUG) || defined(_INTERNAL) || defined(DEBUG_CRASHING)
 				if (info.m_muzzleFlashBone)
 					info.m_muzzleFlashBoneName = mfName;
 #endif
@@ -1586,7 +1589,7 @@ void W3DModelDrawModuleData::parseConditionState(INI* ini, void *instance, void 
 	//	}
 			
 			ModelConditionFlags conditionsYes;
-	#if defined(_DEBUG) || defined(_INTERNAL)
+	#if defined(_DEBUG) || defined(_INTERNAL) || defined(DEBUG_CRASHING)
 			AsciiString description;
 			conditionsYes.parse(ini, &description);
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWDownload/CMakeLists.txt
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWDownload/CMakeLists.txt
@@ -21,4 +21,5 @@ target_sources(z_wwdownload PRIVATE ${WWDOWNLOAD_SRC})
 
 target_link_libraries(z_wwdownload PRIVATE
     z_wwcommon
+    zi_gameengine_include
 )

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWDownload/DownloadDebug.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWDownload/DownloadDebug.h
@@ -21,44 +21,6 @@
 #ifndef __DOWNLOADDEBUG_H_
 #define __DOWNLOADDEBUG_H_
 
-#ifdef  NDEBUG
-#define DEBUG_LOG(exp) ((void)0)
-#else
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-	#include <stdarg.h>
-	extern void DebugCrash( const char *fmt, ... );
-	extern void DebugLog( const char *fmt, ... );
-
-	/*
-		Yeah, it's a sleazy global, since we can't reasonably add
-		any args to DebugCrash due to the varargs nature of it. 
-		We'll just let it slide in this case...
-	*/
-	extern char* TheCurrentIgnoreCrashPtr;
-
-	#define DEBUG_CRASH(m)	\
-		do { \
-			{ \
-				static char ignoreCrash = 0; \
-				if (!ignoreCrash) { \
-					TheCurrentIgnoreCrashPtr = &ignoreCrash; \
-					DebugCrash m ; \
-					TheCurrentIgnoreCrashPtr = NULL; \
-				} \
-			} \
-		} while (0)
-
-	#define DEBUG_LOG(x)		do { DebugLog x; } while (0)
-	#define DEBUG_ASSERTCRASH(c, m)		do { { if (!(c)) DEBUG_CRASH(m); } } while (0)
-
-#ifdef __cplusplus
-}
-#endif
-
-#endif // NDEBUG
+#include "Common/Debug.h"
 
 #endif //__DOWNLOADDEBUG_H_

--- a/GeneralsMD/Code/Tools/PATCHGET/debug.cpp
+++ b/GeneralsMD/Code/Tools/PATCHGET/debug.cpp
@@ -66,7 +66,7 @@ static int doCrashBox(const char *buffer, bool logResult)
 	return result;
 }
 
-#ifdef DEBUG
+#if defined(DEBUG) || defined(DEBUG_LOGGING)
 
 void DebugLog(const char *fmt, ...)
 {
@@ -80,7 +80,7 @@ void DebugLog(const char *fmt, ...)
 	printf( "%s", theBuffer );
 }
 
-#endif // DEBUG
+#endif // defined(DEBUG) || defined(DEBUG_LOGGING)
 
 #ifdef DEBUG_CRASHING
 

--- a/GeneralsMD/Code/Tools/PATCHGET/debug.h
+++ b/GeneralsMD/Code/Tools/PATCHGET/debug.h
@@ -26,7 +26,7 @@
 namespace patchget
 {
 
-#ifdef DEBUG
+#if defined(DEBUG) || defined(DEBUG_LOGGING)
 
 void DebugLog( const char *fmt, ... );
 #define DEBUG_LOG(x) DebugLog x

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/WHeightMapEdit.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/WHeightMapEdit.h
@@ -46,7 +46,7 @@ public:
 /// Struct in memory.
 typedef struct 
 {
-#ifdef _DEBUG
+#ifdef DEBUG_CRASHING
 	Int forDebugOnly_fileTextureClass;
 #endif
 	Int numTiles;

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/CUndoable.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/CUndoable.cpp
@@ -723,6 +723,7 @@ m_pDoc(pDoc)
 	m_new = newSL;
 	// ensure the new setup is valid. (don't mess with the old one.)
 	Bool modified = m_new.validateSides();
+	(void)modified;
 	DEBUG_ASSERTLOG(!modified,("*** had to clean up sides in SidesListUndoable! (caller should do this)\n"));
 }
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/WBPopupSlider.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/WBPopupSlider.cpp
@@ -288,7 +288,7 @@ PopupSlider::~PopupSlider()
 {
 	if (mIcon) {
 		BOOL bRet = DestroyIcon(mIcon);
-
+		(void)bRet;
 		DEBUG_ASSERTCRASH(bRet != 0, ("Oops."));
 
 		mIcon = NULL;

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/WHeightMapEdit.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/WHeightMapEdit.cpp
@@ -304,7 +304,7 @@ WorldHeightMapEdit::WorldHeightMapEdit(ChunkInputStream *pStrm):
 		optimizeTiles();
 	}
 	selectDuplicates();
-#ifdef _DEBUG
+#ifdef DEBUG_CRASHING
 	if (didCancel) {
 		return; // won't check out right.
 	}
@@ -782,7 +782,7 @@ void WorldHeightMapEdit::saveToFile(DataChunkOutput &chunkWriter)
 
 	chunkWriter.closeDataChunk();
 
-#ifdef _DEBUG
+#ifdef DEBUG_CRASHING
 	for (i=0; i<m_dataSize; i++) {
 		Int texNdx = this->m_tileNdxes[i];
 		DEBUG_ASSERTCRASH((texNdx>>2) < m_numBitmapTiles,("oops"));
@@ -1926,7 +1926,7 @@ Int WorldHeightMapEdit::getFirstTile(Int textureClass)
 */	 
 void WorldHeightMapEdit::dbgVerifyAfterUndo(void)
 {
-#ifdef _DEBUG
+#ifdef DEBUG_CRASHING
 	Int i, j;
 	for (i=0; i<m_numGlobalTextureClasses; i++) {
 		m_globalTextureClasses[i].forDebugOnly_fileTextureClass = -1;

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/WorldBuilder.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/WorldBuilder.cpp
@@ -354,6 +354,9 @@ BOOL CWorldBuilderApp::InitInstance()
 	
 #if defined(_DEBUG) || defined(_INTERNAL)
 	ini.load( AsciiString( "Data\\INI\\GameDataDebug.ini" ), INI_LOAD_MULTIFILE, NULL );
+#endif
+
+#ifdef DEBUG_CRASHING
 	TheWritableGlobalData->m_debugIgnoreAsserts = false;
 #endif
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp
@@ -1675,7 +1675,7 @@ void CWorldBuilderDoc::compressWaypointIds(void)
 	}
 	m_waypointTableNeedsUpdate = true;
 	updateWaypointTable();
-#ifdef _DEBUG
+#ifdef DEBUG_CRASHING
 	for (i=0; i<m_numWaypointLinks; i++) {
 		MapObject *pWay1 = getWaypointByID(m_waypointLinks[i].waypoint1);
 		MapObject *pWay2 = getWaypointByID(m_waypointLinks[i].waypoint2);

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/addplayerdialog.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/addplayerdialog.cpp
@@ -85,6 +85,7 @@ void AddPlayerDialog::OnOK()
 			SidesList newSides = *TheSidesList;
 			newSides.addPlayerByTemplate(m_addedSide);
 			Bool modified = newSides.validateSides();
+			(void)modified;
 			DEBUG_ASSERTLOG(!modified,("had to clean up sides in AddPlayerDialog::OnOK"));
 
 			CWorldBuilderDoc* pDoc = CWorldBuilderDoc::GetActiveDoc();

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/mapobjectprops.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/mapobjectprops.cpp
@@ -1704,6 +1704,7 @@ void MapObjectProps::InitSound(void)
     for ( i = 0; i <= AP_CRITICAL; i++ )
     {
       Int index = priorityComboBox->InsertString( i,theAudioPriorityNames[i] );
+      (void)index;
       DEBUG_ASSERTCRASH( index == i, ("insert string returned %d, expected %d", index, i ) );
     }
   }

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/playerlistdlg.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/playerlistdlg.cpp
@@ -324,6 +324,7 @@ void PlayerListDlg::OnNewplayer()
 			m_sides.addSide(&newPlayerDict);
 
 			Bool modified = m_sides.validateSides();
+			(void)modified;
 			DEBUG_ASSERTLOG(!modified,("had to clean up sides in PlayerListDlg::OnNewplayer"));
 			m_curPlayerIdx = m_sides.getNumSides()-1;
 			updateTheUI();
@@ -422,6 +423,7 @@ try_again:
 	} 
 
 	Bool modified = m_sides.validateSides();
+	(void)modified;
 	DEBUG_ASSERTLOG(!modified,("had to clean up sides in PlayerListDlg::OnRemoveplayer"));
 	updateTheUI();
 }
@@ -444,6 +446,7 @@ void PlayerListDlg::updateTheUI(void)
 
 	// make sure everything is canonical.
 	Bool modified = m_sides.validateSides();
+	(void)modified;
 	DEBUG_ASSERTLOG(!modified,("had to clean up sides in PlayerListDlg::updateTheUI! (caller should do this)"));
 
 	if (m_curPlayerIdx < 0) m_curPlayerIdx = 0;
@@ -743,6 +746,7 @@ void PlayerListDlg::OnSelchangeEnemieslist()
 void PlayerListDlg::OnOK() 
 {
 	Bool modified = m_sides.validateSides();
+	(void)modified;
 	DEBUG_ASSERTLOG(!modified,("had to clean up sides in CTeamsDialog::OnOK"));
 
 	CWorldBuilderDoc* pDoc = CWorldBuilderDoc::GetActiveDoc();
@@ -859,6 +863,7 @@ static void addSide(SidesList *sides, AsciiString faction,
 		sides->addSide(&newPlayerDict);
 
 		Bool modified = sides->validateSides();
+		(void)modified;
 		DEBUG_ASSERTLOG(!modified,("had to clean up sides in PlayerListDlg::OnNewplayer"));
 	}
 }

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/teamsdialog.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/teamsdialog.cpp
@@ -224,6 +224,7 @@ BOOL CTeamsDialog::OnInitDialog()
 void CTeamsDialog::OnOK() 
 {
 	Bool modified = m_sides.validateSides();
+	(void)modified;
 	DEBUG_ASSERTLOG(!modified,("had to clean up sides in CTeamsDialog::OnOK"));
 
 	CWorldBuilderDoc* pDoc = CWorldBuilderDoc::GetActiveDoc();

--- a/cmake/config-debug.cmake
+++ b/cmake/config-debug.cmake
@@ -1,0 +1,36 @@
+set(RTS_DEBUG_LOGGING "DEFAULT" CACHE STRING "Enables debug logging.")
+set_property(CACHE RTS_DEBUG_LOGGING PROPERTY STRINGS DEFAULT ON OFF)
+
+set(RTS_DEBUG_CRASHING "DEFAULT" CACHE STRING "Enables debug assert dialogs.")
+set_property(CACHE RTS_DEBUG_CRASHING PROPERTY STRINGS DEFAULT ON OFF)
+
+set(RTS_DEBUG_STACKTRACE "DEFAULT" CACHE STRING "Enables debug stacktracing. This inherintly also enables debug logging.")
+set_property(CACHE RTS_DEBUG_STACKTRACE PROPERTY STRINGS DEFAULT ON OFF)
+
+set(RTS_DEBUG_PROFILE "DEFAULT" CACHE STRING "Enables debug profiling.")
+set_property(CACHE RTS_DEBUG_PROFILE PROPERTY STRINGS DEFAULT ON OFF)
+
+
+add_feature_info(DebugLogging RTS_DEBUG_LOGGING "Build with Debug Logging")
+add_feature_info(DebugLogging RTS_DEBUG_CRASHING "Build with Debug Crashing")
+add_feature_info(DebugLogging RTS_DEBUG_STACKTRACE "Build with Debug Stacktracing")
+add_feature_info(DebugLogging RTS_DEBUG_PROFILE "Build with Debug Profiling")
+
+
+macro(define_debug_option OptionName OptionEnabledCompileDef OptionDisabledCompileDef)
+    if(${OptionName} STREQUAL "DEFAULT")
+        # Does nothing
+    elseif(${OptionName} STREQUAL "ON")
+        target_compile_definitions(core_config INTERFACE ${OptionEnabledCompileDef}=1)
+    elseif(${OptionName} STREQUAL "OFF")
+        target_compile_definitions(core_config INTERFACE ${OptionDisabledCompileDef}=1)
+    else()
+        message(FATAL_ERROR "Unhandled option")
+    endif()
+endmacro()
+
+
+define_debug_option(RTS_DEBUG_LOGGING    DEBUG_LOGGING    DISABLE_DEBUG_LOGGING   )
+define_debug_option(RTS_DEBUG_CRASHING   DEBUG_CRASHING   DISABLE_DEBUG_CRASHING  )
+define_debug_option(RTS_DEBUG_STACKTRACE DEBUG_STACKTRACE DISABLE_DEBUG_STACKTRACE)
+define_debug_option(RTS_DEBUG_PROFILE    DEBUG_PROFILE    DISABLE_DEBUG_PROFILE   )

--- a/cmake/config-debug.cmake
+++ b/cmake/config-debug.cmake
@@ -1,13 +1,13 @@
-set(RTS_DEBUG_LOGGING "DEFAULT" CACHE STRING "Enables debug logging.")
+set(RTS_DEBUG_LOGGING "DEFAULT" CACHE STRING "Enables debug logging. When DEFAULT, this option is enabled with DEBUG or INTERNAL")
 set_property(CACHE RTS_DEBUG_LOGGING PROPERTY STRINGS DEFAULT ON OFF)
 
-set(RTS_DEBUG_CRASHING "DEFAULT" CACHE STRING "Enables debug assert dialogs.")
+set(RTS_DEBUG_CRASHING "DEFAULT" CACHE STRING "Enables debug assert dialogs. When DEFAULT, this option is enabled with DEBUG or INTERNAL")
 set_property(CACHE RTS_DEBUG_CRASHING PROPERTY STRINGS DEFAULT ON OFF)
 
-set(RTS_DEBUG_STACKTRACE "DEFAULT" CACHE STRING "Enables debug stacktracing. This inherintly also enables debug logging.")
+set(RTS_DEBUG_STACKTRACE "DEFAULT" CACHE STRING "Enables debug stacktracing. This inherintly also enables debug logging. When DEFAULT, this option is enabled with DEBUG or INTERNAL")
 set_property(CACHE RTS_DEBUG_STACKTRACE PROPERTY STRINGS DEFAULT ON OFF)
 
-set(RTS_DEBUG_PROFILE "DEFAULT" CACHE STRING "Enables debug profiling.")
+set(RTS_DEBUG_PROFILE "DEFAULT" CACHE STRING "Enables debug profiling. When DEFAULT, this option is enabled with DEBUG or INTERNAL")
 set_property(CACHE RTS_DEBUG_PROFILE PROPERTY STRINGS DEFAULT ON OFF)
 
 

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -1,4 +1,5 @@
 add_library(core_config INTERFACE)
 
 include(${CMAKE_CURRENT_LIST_DIR}/config-build.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/config-debug.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/config-memory.cmake)


### PR DESCRIPTION
* Merge after #666

This change fixes a multitude of compile errors with Debug macros DEBUG_LOGGING, DEBUG_CRASHING, DEBUG_STACKTRACE, DEBUG_PROFILE.

Compile fixes include:

* Compile errors when disabling any or all of the 4 options in Debug
* Compile errors when enabling any or all of the 4 options in Release

The cmake setup now has new options with

RTS_DEBUG_LOGGING
RTS_DEBUG_CRASHING
RTS_DEBUG_STRACKTRACE
RTS_DEBUG_PROFILE

They have 3 states: DEFAULT, ON, OFF

DEFAULT reacts to default behaviour linked to _DEBUG and _INTERNAL
ON forces it on
OFF forces it off

## TODO

- [x] Replicate in Generals