### PR TITLE
[CMAKE] Add missing headers to WWLib and comment out all unused source files

### DIFF
--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/CMakeLists.txt
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/CMakeLists.txt
@@ -1,13 +1,15 @@
 # Set source files
 set(WWLIB_SRC
     always.h
-    argv.h
+    #argv.cpp
+    #argv.h
     b64pipe.cpp
     b64pipe.h
     b64straw.cpp
     b64straw.h
     base64.cpp
     base64.h
+    #bfiofile.h
     binheap.h
     bittype.h
     bound.h
@@ -23,9 +25,12 @@ set(WWLIB_SRC
     cpudetect.h
     crc.cpp
     CRC.H
+    #crcpipe.h
+    #crcstraw.h
     cstraw.cpp
     cstraw.h
     Except.cpp
+    Except.h
     ffactory.cpp
     ffactory.h
     gcd_lcm.cpp
@@ -34,7 +39,9 @@ set(WWLIB_SRC
     hash.h
     hashcalc.h
     HASHLIST.H
+    #hashtab.h
     hashtemplate.h
+    #incdec.h
     INDEX.H
     ini.cpp
     INI.H
@@ -43,12 +50,14 @@ set(WWLIB_SRC
     jshell.cpp
     LISTNODE.H
     mempool.h
+    mmsys.h
     mpu.cpp
     MPU.H
     multilist.cpp
     multilist.h
     mutex.cpp
     mutex.h
+    #noinit.h
     Notify.h
     nstrdup.cpp
     nstrdup.h
@@ -69,9 +78,11 @@ set(WWLIB_SRC
     realcrc.cpp
     realcrc.h
     refcount.cpp
+    refcount.h
     ref_ptr.h
     registry.cpp
     registry.h
+    #search.h
     sharebuf.h
     Signaler.h
     simplevec.h
@@ -79,10 +90,12 @@ set(WWLIB_SRC
     slnode.cpp
     SLNODE.H
     stimer.cpp
+    stimer.h
     straw.cpp
     STRAW.H
     strtok_r.cpp
     strtok_r.h
+    #swap.h
     systimer.cpp
     systimer.h
     TARGA.CPP
@@ -97,6 +110,7 @@ set(WWLIB_SRC
     uarray.h
     vector.cpp
     Vector.H
+    verchk.cpp
     verchk.h
     visualc.h
     widestring.cpp

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/CMakeLists.txt
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/CMakeLists.txt
@@ -1,116 +1,116 @@
 # Set source files
 set(WWLIB_SRC
-    b64pipe.cpp
-    b64straw.cpp
-    base64.cpp
-    buff.cpp
-    bufffile.cpp
-    chunkio.cpp
-    cpudetect.cpp
-    crc.cpp
-    cstraw.cpp
-    Except.cpp
-    ffactory.cpp
-    gcd_lcm.cpp
-    hash.cpp
-    ini.cpp
-    jshell.cpp
-    mpu.cpp
-    multilist.cpp
-    mutex.cpp
-    nstrdup.cpp
-    pipe.cpp
-    ramfile.cpp
-    random.cpp
-    rawfile.cpp
-    rcfile.cpp
-    readline.cpp
-    realcrc.cpp
-    refcount.cpp
-    registry.cpp
-    slnode.cpp
-    stimer.cpp
-    straw.cpp
-    strtok_r.cpp
-    systimer.cpp
-    TARGA.CPP
-    textfile.cpp
-    thread.cpp
-    trim.cpp
-    vector.cpp
-    widestring.cpp
-    WWCOMUtil.cpp
-    wwfile.cpp
-    wwstring.cpp
-    xpipe.cpp
-    xstraw.cpp
     always.h
     argv.h
+    b64pipe.cpp
     b64pipe.h
+    b64straw.cpp
     b64straw.h
+    base64.cpp
     base64.h
     binheap.h
     bittype.h
     bound.h
     BSEARCH.H
+    buff.cpp
     BUFF.H
+    bufffile.cpp
     bufffile.h
     CallbackHook.h
+    chunkio.cpp
     chunkio.h
+    cpudetect.cpp
     cpudetect.h
+    crc.cpp
     CRC.H
+    cstraw.cpp
     cstraw.h
+    Except.cpp
+    ffactory.cpp
     ffactory.h
+    gcd_lcm.cpp
     gcd_lcm.h
+    hash.cpp
     hash.h
     hashcalc.h
     HASHLIST.H
     hashtemplate.h
     INDEX.H
+    ini.cpp
     INI.H
     inisup.h
     iostruct.h
+    jshell.cpp
     LISTNODE.H
     mempool.h
+    mpu.cpp
     MPU.H
+    multilist.cpp
     multilist.h
+    mutex.cpp
     mutex.h
     Notify.h
+    nstrdup.cpp
     nstrdup.h
     ntree.h
+    pipe.cpp
     PIPE.H
     Point.h
+    ramfile.cpp
     RAMFILE.H
+    random.cpp
     RANDOM.H
+    rawfile.cpp
     RAWFILE.H
+    rcfile.cpp
     rcfile.h
+    readline.cpp
     readline.h
+    realcrc.cpp
     realcrc.h
+    refcount.cpp
     ref_ptr.h
+    registry.cpp
     registry.h
     sharebuf.h
     Signaler.h
     simplevec.h
     SLIST.H
+    slnode.cpp
     SLNODE.H
+    stimer.cpp
+    straw.cpp
     STRAW.H
+    strtok_r.cpp
     strtok_r.h
+    systimer.cpp
     systimer.h
+    TARGA.CPP
     TARGA.H
+    textfile.cpp
     textfile.h
+    thread.cpp
     thread.h
     trect.h
+    trim.cpp
     trim.h
     uarray.h
+    vector.cpp
     Vector.H
     verchk.h
     visualc.h
+    widestring.cpp
     widestring.h
     win.h
+    WWCOMUtil.cpp
     WWCOMUtil.h
+    wwfile.cpp
     WWFILE.H
+    wwstring.cpp
     wwstring.h
+    xpipe.cpp
     XPIPE.H
+    xstraw.cpp
     XSTRAW.H
 )
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/CMakeLists.txt
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/CMakeLists.txt
@@ -9,6 +9,8 @@ set(WWLIB_SRC
     b64straw.h
     base64.cpp
     base64.h
+    #bfiofile.cpp
+    #bfiofile.h
     binheap.h
     bittype.h
     bound.h
@@ -22,22 +24,31 @@ set(WWLIB_SRC
     chunkio.h
     cpudetect.cpp
     cpudetect.h
+    #crandom.h
     crc.cpp
     CRC.H
+    #crcpipe.cpp
+    #crcpipe.h
+    #crcstraw.cpp
+    #crcstraw.h
     cstraw.cpp
     cstraw.h
     Except.cpp
+    Except.h
     FastAllocator.cpp
     FastAllocator.h
     ffactory.cpp
     ffactory.h
     gcd_lcm.cpp
     gcd_lcm.h
+    #global.h
     hash.cpp
     hash.h
     hashcalc.h
     HASHLIST.H
+    #hashtab.h
     hashtemplate.h
+    #incdec.h
     INDEX.H
     ini.cpp
     INI.H
@@ -45,13 +56,28 @@ set(WWLIB_SRC
     iostruct.h
     jshell.cpp
     LISTNODE.H
+    #lzo.cpp
+    #lzo.h
+    #lzo1x.h
+    #lzo1x_c.cpp
+    #lzo1x_d.cpp
+    #lzoconf.h
+    #lzopipe.cpp
+    #lzopipe.h
+    #lzostraw.cpp
+    #lzostraw.h
+    #lzo_conf.h
+    #md5.cpp
+    #md5.h
     mempool.h
+    mmsys.h
     mpu.cpp
     MPU.H
     multilist.cpp
     multilist.h
     mutex.cpp
     mutex.h
+    #noinit.h
     notifier.h
     nstrdup.cpp
     nstrdup.h
@@ -72,9 +98,13 @@ set(WWLIB_SRC
     realcrc.cpp
     realcrc.h
     refcount.cpp
+    refcount.h
     ref_ptr.h
+    #regexpr.cpp
+    #regexpr.h
     registry.cpp
     registry.h
+    #search.h
     sharebuf.h
     Signaler.h
     simplevec.h
@@ -82,10 +112,12 @@ set(WWLIB_SRC
     slnode.cpp
     SLNODE.H
     stimer.cpp
+    stimer.h
     straw.cpp
     STRAW.H
     strtok_r.cpp
     strtok_r.h
+    #swap.h
     systimer.cpp
     systimer.h
     TARGA.CPP

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/CMakeLists.txt
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/CMakeLists.txt
@@ -1,122 +1,122 @@
 # Set source files
 set(WWLIB_SRC
-    argv.cpp
-    b64pipe.cpp
-    b64straw.cpp
-    base64.cpp
-    buff.cpp
-    bufffile.cpp
-    chunkio.cpp
-    cpudetect.cpp
-    crc.cpp
-    cstraw.cpp
-    Except.cpp
-    FastAllocator.cpp
-    ffactory.cpp
-    gcd_lcm.cpp
-    hash.cpp
-    ini.cpp
-    jshell.cpp
-    mpu.cpp
-    multilist.cpp
-    mutex.cpp
-    nstrdup.cpp
-    pipe.cpp
-    ramfile.cpp
-    random.cpp
-    rawfile.cpp
-    rcfile.cpp
-    readline.cpp
-    realcrc.cpp
-    refcount.cpp
-    registry.cpp
-    slnode.cpp
-    stimer.cpp
-    straw.cpp
-    strtok_r.cpp
-    systimer.cpp
-    TARGA.CPP
-    textfile.cpp
-    tgatodxt.cpp
-    thread.cpp
-    trim.cpp
-    vector.cpp
-    verchk.cpp
-    widestring.cpp
-    WWCOMUtil.cpp
-    wwfile.cpp
-    wwstring.cpp
-    xpipe.cpp
-    xstraw.cpp
     always.h
+    argv.cpp
     argv.h
+    b64pipe.cpp
     b64pipe.h
+    b64straw.cpp
     b64straw.h
+    base64.cpp
     base64.h
     binheap.h
     bittype.h
     bound.h
     BSEARCH.H
+    buff.cpp
     BUFF.H
+    bufffile.cpp
     bufffile.h
     CallbackHook.h
+    chunkio.cpp
     chunkio.h
+    cpudetect.cpp
     cpudetect.h
+    crc.cpp
     CRC.H
+    cstraw.cpp
     cstraw.h
+    Except.cpp
+    FastAllocator.cpp
     FastAllocator.h
+    ffactory.cpp
     ffactory.h
+    gcd_lcm.cpp
     gcd_lcm.h
+    hash.cpp
     hash.h
     hashcalc.h
     HASHLIST.H
     hashtemplate.h
     INDEX.H
+    ini.cpp
     INI.H
     inisup.h
     iostruct.h
+    jshell.cpp
     LISTNODE.H
     mempool.h
+    mpu.cpp
     MPU.H
+    multilist.cpp
     multilist.h
+    mutex.cpp
     mutex.h
     notifier.h
+    nstrdup.cpp
     nstrdup.h
     ntree.h
+    pipe.cpp
     PIPE.H
     Point.h
+    ramfile.cpp
     RAMFILE.H
+    random.cpp
     RANDOM.H
+    rawfile.cpp
     RAWFILE.H
+    rcfile.cpp
     rcfile.h
+    readline.cpp
     readline.h
+    realcrc.cpp
     realcrc.h
+    refcount.cpp
     ref_ptr.h
+    registry.cpp
     registry.h
     sharebuf.h
     Signaler.h
     simplevec.h
     SLIST.H
+    slnode.cpp
     SLNODE.H
+    stimer.cpp
+    straw.cpp
     STRAW.H
+    strtok_r.cpp
     strtok_r.h
+    systimer.cpp
     systimer.h
+    TARGA.CPP
     TARGA.H
+    textfile.cpp
     textfile.h
+    tgatodxt.cpp
     tgatodxt.h
+    thread.cpp
     thread.h
     trect.h
+    trim.cpp
     trim.h
     uarray.h
+    vector.cpp
     Vector.H
+    verchk.cpp
     verchk.h
     visualc.h
+    widestring.cpp
     widestring.h
     win.h
+    WWCOMUtil.cpp
     WWCOMUtil.h
+    wwfile.cpp
     WWFILE.H
+    wwstring.cpp
     wwstring.h
+    xpipe.cpp
     XPIPE.H
+    xstraw.cpp
     XSTRAW.H
 )
 


### PR DESCRIPTION
This change
* Adds missing headers to the source lists of WWLib
* ~~Compiles out the unused verchk.cpp~~ It is used by W3DView