### PR TITLE
[GEN][ZH] Fix COM related compile errors for MinGW

### DIFF
--- a/Core/Libraries/Source/EABrowserDispatch/BrowserDispatch.idl
+++ b/Core/Libraries/Source/EABrowserDispatch/BrowserDispatch.idl
@@ -25,6 +25,6 @@ library BROWSERDISPATCHLib
 	]
 	interface IBrowserDispatch : IUnknown
 	{
-		[id(1), helpstring("method TestMethod")] HRESULT TestMethod(Int num1);
+		[id(1), helpstring("method TestMethod")] HRESULT TestMethod(int num1);
 	};
 };

--- a/Core/Libraries/Source/EABrowserEngine/BrowserEngine.idl
+++ b/Core/Libraries/Source/EABrowserEngine/BrowserEngine.idl
@@ -2,6 +2,9 @@
 // 
 // typelib filename: <could not determine filename>
 
+// NOTE: Import of oaidl.idl has been added to fix compilation error with widl:
+// BrowserEngine.idl:31:44: error: type 'IDispatch' not found in global namespace
+import "oaidl.idl";
 [
   uuid(6EE45698-21BA-420D-AD40-1B547699BEFB),
   version(1.0)

--- a/Dependencies/Utility/Utility/CppMacros.h
+++ b/Dependencies/Utility/Utility/CppMacros.h
@@ -25,6 +25,13 @@
 #define NOEXCEPT_17
 #endif
 
+// noexcept for methods of IUNKNOWN interface
+#if defined(_MSC_VER)
+#define IUNKNOWN_NOEXCEPT NOEXCEPT_17
+#else
+#define IUNKNOWN_NOEXCEPT
+#endif
+
 #if __cplusplus >= 201103L
     #define CPP_11(code) code
 #else

--- a/Generals/Code/GameEngine/Include/GameNetwork/WOLBrowser/WebBrowser.h
+++ b/Generals/Code/GameEngine/Include/GameNetwork/WOLBrowser/WebBrowser.h
@@ -113,9 +113,9 @@ class WebBrowser :
 	// IUnknown methods
 	//---------------------------------------------------------------------------
 	protected:
-		HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObject) NOEXCEPT_17;
-		ULONG STDMETHODCALLTYPE AddRef(void) NOEXCEPT_17;
-		ULONG STDMETHODCALLTYPE Release(void) NOEXCEPT_17;
+		HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObject) IUNKNOWN_NOEXCEPT;
+		ULONG STDMETHODCALLTYPE AddRef(void) IUNKNOWN_NOEXCEPT;
+		ULONG STDMETHODCALLTYPE Release(void) IUNKNOWN_NOEXCEPT;
 
 	//---------------------------------------------------------------------------
 	// IBrowserDispatch methods

--- a/Generals/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -192,7 +192,7 @@ GameEngine::GameEngine( void )
 	m_quitting = FALSE;
 	m_isActive = FALSE;
 
-	_Module.Init(NULL, ApplicationHInstance);
+	_Module.Init(NULL, ApplicationHInstance, NULL);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameNetwork/WOLBrowser/WebBrowser.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/WOLBrowser/WebBrowser.cpp
@@ -237,7 +237,7 @@ WebBrowserURL * WebBrowser::makeNewURL(AsciiString tag)
 *
 ******************************************************************************/
 
-STDMETHODIMP WebBrowser::QueryInterface(REFIID iid, void** ppv) NOEXCEPT_17
+STDMETHODIMP WebBrowser::QueryInterface(REFIID iid, void** ppv) IUNKNOWN_NOEXCEPT
 {
 	*ppv = NULL;
 
@@ -270,7 +270,7 @@ STDMETHODIMP WebBrowser::QueryInterface(REFIID iid, void** ppv) NOEXCEPT_17
 *
 ******************************************************************************/
 
-ULONG STDMETHODCALLTYPE WebBrowser::AddRef(void) NOEXCEPT_17
+ULONG STDMETHODCALLTYPE WebBrowser::AddRef(void) IUNKNOWN_NOEXCEPT
 {
 	return ++mRefCount;
 }
@@ -290,7 +290,7 @@ ULONG STDMETHODCALLTYPE WebBrowser::AddRef(void) NOEXCEPT_17
 *
 ******************************************************************************/
 
-ULONG STDMETHODCALLTYPE WebBrowser::Release(void) NOEXCEPT_17
+ULONG STDMETHODCALLTYPE WebBrowser::Release(void) IUNKNOWN_NOEXCEPT
 {
 	DEBUG_ASSERTCRASH(mRefCount > 0, ("Negative reference count"));
 	--mRefCount;

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DWebBrowser.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DWebBrowser.cpp
@@ -57,7 +57,11 @@ Bool W3DWebBrowser::createBrowserWindow(const char *tag, GameWindow *win)
 		return FALSE;
 	}
 
+#ifdef __GNUC__
+	CComQIIDPtr<I_ID(IDispatch)> idisp(m_dispatch);
+#else
 	CComQIPtr<IDispatch> idisp(m_dispatch);
+#endif
 	if (m_dispatch == NULL)
 	{
 		return FALSE;

--- a/GeneralsMD/Code/GameEngine/Include/GameNetwork/WOLBrowser/WebBrowser.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameNetwork/WOLBrowser/WebBrowser.h
@@ -113,9 +113,9 @@ class WebBrowser :
 	// IUnknown methods
 	//---------------------------------------------------------------------------
 	protected:
-		HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObject) NOEXCEPT_17;
-		ULONG STDMETHODCALLTYPE AddRef(void) NOEXCEPT_17;
-		ULONG STDMETHODCALLTYPE Release(void) NOEXCEPT_17;
+		HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObject) IUNKNOWN_NOEXCEPT;
+		ULONG STDMETHODCALLTYPE AddRef(void) IUNKNOWN_NOEXCEPT;
+		ULONG STDMETHODCALLTYPE Release(void) IUNKNOWN_NOEXCEPT;
 
 	//---------------------------------------------------------------------------
 	// IBrowserDispatch methods

--- a/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -190,7 +190,7 @@ GameEngine::GameEngine( void )
 	m_quitting = FALSE;
 	m_isActive = FALSE;
 
-	_Module.Init(NULL, ApplicationHInstance);
+	_Module.Init(NULL, ApplicationHInstance, NULL);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/WOLBrowser/WebBrowser.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/WOLBrowser/WebBrowser.cpp
@@ -237,7 +237,7 @@ WebBrowserURL * WebBrowser::makeNewURL(AsciiString tag)
 *
 ******************************************************************************/
 
-STDMETHODIMP WebBrowser::QueryInterface(REFIID iid, void** ppv) NOEXCEPT_17
+STDMETHODIMP WebBrowser::QueryInterface(REFIID iid, void** ppv) IUNKNOWN_NOEXCEPT
 {
 	*ppv = NULL;
 
@@ -270,7 +270,7 @@ STDMETHODIMP WebBrowser::QueryInterface(REFIID iid, void** ppv) NOEXCEPT_17
 *
 ******************************************************************************/
 
-ULONG STDMETHODCALLTYPE WebBrowser::AddRef(void) NOEXCEPT_17
+ULONG STDMETHODCALLTYPE WebBrowser::AddRef(void) IUNKNOWN_NOEXCEPT
 {
 	return ++mRefCount;
 }
@@ -290,7 +290,7 @@ ULONG STDMETHODCALLTYPE WebBrowser::AddRef(void) NOEXCEPT_17
 *
 ******************************************************************************/
 
-ULONG STDMETHODCALLTYPE WebBrowser::Release(void) NOEXCEPT_17
+ULONG STDMETHODCALLTYPE WebBrowser::Release(void) IUNKNOWN_NOEXCEPT
 {
 	DEBUG_ASSERTCRASH(mRefCount > 0, ("Negative reference count"));
 	--mRefCount;

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DWebBrowser.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DWebBrowser.cpp
@@ -57,7 +57,11 @@ Bool W3DWebBrowser::createBrowserWindow(const char *tag, GameWindow *win)
 		return FALSE;
 	}
 
+#ifdef __GNUC__
+	CComQIIDPtr<I_ID(IDispatch)> idisp(m_dispatch);
+#else
 	CComQIPtr<IDispatch> idisp(m_dispatch);
+#endif
 	if (m_dispatch == NULL)
 	{
 		return FALSE;


### PR DESCRIPTION
COM related fixes to be able to build using MinGW. 
- fixes to idl files to be able to build using [widl](https://gitlab.winehq.org/wine/wine/-/wikis/Man-Pages/widl)
- fixes to c++ to be able to build using mingw toolchain + [atl](https://github.com/reactos/reactos/tree/master/sdk/lib/atl) library from reactos sdk (MinGW itself does not include atl)

This was extracted from bigger change-set fixing build on MinGW: https://github.com/TheSuperHackers/GeneralsGameCode/pull/547