### PR TITLE
[CORE] Fix Compress tool build error

### DIFF
--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -1,7 +1,12 @@
 # c stands for core, i stands for Interface
 add_library(corei_libraries_include INTERFACE)
+add_library(corei_always INTERFACE)
 
 target_include_directories(corei_libraries_include INTERFACE "Libraries/Include")
+target_link_libraries(corei_always INTERFACE
+    core_utility
+    corei_libraries_include
+)
 
 # Do we want to build extra SDK stuff or just the game binary?
 option(RTS_BUILD_CORE_TOOLS "Build core tools" ON)

--- a/Core/Tools/Compress/CMakeLists.txt
+++ b/Core/Tools/Compress/CMakeLists.txt
@@ -10,7 +10,7 @@ target_sources(core_compress PRIVATE ${COMRPESS_SRC})
 target_link_libraries(core_compress PRIVATE
     core_config
     core_compression
-    zi_always
+    corei_always
 )
 
 if(WIN32 OR "${CMAKE_SYSTEM}" MATCHES "Windows")


### PR DESCRIPTION
The compress tool currently does not build without Zero Hour:

```
D:\Projects\TheSuperHackers\GeneralsGameCode\Core\Tools\Compress\Compress.cpp(21,10): error C1083: Cannot open include file: 'Lib/BaseTypeCore.h': No such file or directory
```

This change makes it independent of Zero Hour and fixes the problem.