### PR TITLE
[ZH] Use hash maps for Object and Drawable lookups in GameClient, GameLogic like Generals does

### DIFF
--- a/GeneralsMD/Code/GameEngine/Include/GameClient/GameClient.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/GameClient.h
@@ -59,10 +59,8 @@ class SnowManager;
 
 /// Function pointers for use by GameClient callback functions.
 typedef void (*GameClientFuncPtr)( Drawable *draw, void *userData ); 
-//typedef std::hash_map<DrawableID, Drawable *, rts::hash<DrawableID>, rts::equal_to<DrawableID> > DrawablePtrHash;
-//typedef DrawablePtrHash::iterator DrawablePtrHashIt;
-
-typedef std::vector<Drawable*> DrawablePtrVector;
+typedef std::hash_map<DrawableID, Drawable *, rts::hash<DrawableID>, rts::equal_to<DrawableID> > DrawablePtrHash;
+typedef DrawablePtrHash::iterator DrawablePtrHashIt;
 
 //-----------------------------------------------------------------------------
 /** The Client message dispatcher, this is the last "translator" on the message
@@ -165,8 +163,7 @@ protected:
 	UnsignedInt m_frame;																				///< Simulation frame number from server
 
 	Drawable *m_drawableList;																		///< All of the drawables in the world
-//	DrawablePtrHash m_drawableHash;															///< Used for DrawableID lookups
-	DrawablePtrVector m_drawableVector;
+	DrawablePtrHash m_drawableHash;															///< Used for DrawableID lookups
 
 	DrawableID m_nextDrawableID;																///< For allocating drawable id's
 	DrawableID allocDrawableID( void );													///< Returns a new unique drawable id
@@ -241,18 +238,13 @@ inline Drawable* GameClient::findDrawableByID( const DrawableID id )
 	if( id == INVALID_DRAWABLE_ID )
 		return NULL;
 
-//	DrawablePtrHashIt it = m_drawableHash.find(id);
-//	if (it == m_drawableHash.end()) {
-//		// no such drawable	
-//		return NULL;
-//	}
-//
-//	return (*it).second;
+	DrawablePtrHashIt it = m_drawableHash.find(id);
+	if (it == m_drawableHash.end()) {
+		// no such drawable	
+		return NULL;
+	}
 
-	if( (size_t)id < m_drawableVector.size() )
-		return m_drawableVector[(size_t)id];
-
-	return NULL;
+	return (*it).second;
 }
 
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/GameLogic.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/GameLogic.h
@@ -92,10 +92,9 @@ enum
 
 /// Function pointers for use by GameLogic callback functions.
 typedef void (*GameLogicFuncPtr)( Object *obj, void *userData ); 
-//typedef std::hash_map<ObjectID, Object *, rts::hash<ObjectID>, rts::equal_to<ObjectID> > ObjectPtrHash;
-//typedef ObjectPtrHash::const_iterator ObjectPtrIter;
+typedef std::hash_map<ObjectID, Object *, rts::hash<ObjectID>, rts::equal_to<ObjectID> > ObjectPtrHash;
+typedef ObjectPtrHash::const_iterator ObjectPtrIter;
 
-typedef std::vector<Object*> ObjectPtrVector;
 
 // ------------------------------------------------------------------------------------------------
 /**
@@ -320,8 +319,7 @@ private:
 	WindowLayout *m_background;
 
 	Object* m_objList;																			///< All of the objects in the world.
-//	ObjectPtrHash m_objHash;																///< Used for ObjectID lookups
-	ObjectPtrVector m_objVector;
+	ObjectPtrHash m_objHash;																///< Used for ObjectID lookups
 
 	// this is a vector, but is maintained as a priority queue.
 	// never modify it directly; please use the proper access methods.
@@ -412,15 +410,11 @@ inline Object* GameLogic::findObjectByID( ObjectID id )
 	if( id == INVALID_ID )
 		return NULL;
 
-//	ObjectPtrHash::iterator it = m_objHash.find(id);
-//	if (it == m_objHash.end())
-//		return NULL;
-//	
-//	return (*it).second;
-	if( (size_t)id < m_objVector.size() )
-		return m_objVector[(size_t)id];
+	ObjectPtrHash::iterator it = m_objHash.find(id);
+	if (it == m_objHash.end())
+		return NULL;
 
-	return NULL;
+	return (*it).second;
 }
 
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -450,11 +450,12 @@ void GameClient::init( void )
 void GameClient::reset( void )
 {
 	Drawable *draw, *nextDraw;
-//	m_drawableHash.clear();
-//	m_drawableHash.resize(DRAWABLE_HASH_SIZE);
-
-	m_drawableVector.clear();
-	m_drawableVector.resize(DRAWABLE_HASH_SIZE, NULL);
+	m_drawableHash.clear();
+#if USING_STLPORT
+	m_drawableHash.resize(DRAWABLE_HASH_SIZE);
+#else
+	m_drawableHash.reserve(DRAWABLE_HASH_SIZE);
+#endif
 
 	// need to reset the in game UI to clear drawables before they are destroyed
 	TheInGameUI->reset();
@@ -862,12 +863,7 @@ void GameClient::addDrawableToLookupTable(Drawable *draw )
 		return;
 
 	// add to lookup
-//	m_drawableHash[ draw->getID() ] = draw;
-	DrawableID newID = draw->getID();
-	while( newID >= m_drawableVector.size() ) // Fail case is hella rare, so faster to double up on size() call
-		m_drawableVector.resize(m_drawableVector.size() * 2, NULL);
-
-	m_drawableVector[ newID ] = draw;
+	m_drawableHash[ draw->getID() ] = draw;
 
 }  // end addDrawableToLookupTable
 
@@ -882,8 +878,7 @@ void GameClient::removeDrawableFromLookupTable( Drawable *draw )
 		return;
 
 	// remove from table
-//	m_drawableHash.erase( draw->getID() );
-	m_drawableVector[ draw->getID() ] = NULL;
+	m_drawableHash.erase( draw->getID() );
 
 }  // end removeDrawableFromLookupTable
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -441,11 +441,12 @@ void GameLogic::reset( void )
 	destroyAllObjectsImmediate();
 
 	// set the hash to be rather large. We need to optimize this value later.
-//	m_objHash.clear();
-//	m_objHash.resize(OBJ_HASH_SIZE);
-	m_objVector.clear();
-	m_objVector.resize(OBJ_HASH_SIZE, NULL);
-
+	m_objHash.clear();
+#if USING_STLPORT
+	m_objHash.resize(OBJ_HASH_SIZE);
+#else
+	m_objHash.reserve(OBJ_HASH_SIZE);
+#endif
 	m_gamePaused = FALSE;
 	m_inputEnabledMemory = TRUE;
 	m_mouseVisibleMemory = TRUE;
@@ -3857,12 +3858,7 @@ void GameLogic::addObjectToLookupTable( Object *obj )
 		return;
 
 	// add to lookup
-//	m_objHash[ obj->getID() ] = obj;
-	ObjectID newID = obj->getID();
-	while( newID >= m_objVector.size() ) // Fail case is hella rare, so faster to double up on size() call
-		m_objVector.resize(m_objVector.size() * 2, NULL);
-
-	m_objVector[ newID ] = obj;
+	m_objHash[ obj->getID() ] = obj;
 
 }  // end addObjectToLookupTable
 
@@ -3877,8 +3873,7 @@ void GameLogic::removeObjectFromLookupTable( Object *obj )
 		return;
 
 	// remove from lookup table
-//	m_objHash.erase( obj->getID() );
-	m_objVector[ obj->getID() ] = NULL;
+	m_objHash.erase( obj->getID() );
 
 }  // end removeObjectFromLookupTable
 


### PR DESCRIPTION
This PR changes zero hour so it uses hashmaps for the Object and Drawable lookup tables, the same as it was in Generals and how it also is in other SAGE games.

I have also added debug asserts to both games into the ```GameLogic::removeObjectFromLookupTable``` function, the drawables equivalent in GameClient will be added with other required fixes in PR #657.