### PR TITLE
[GEN] Backport WWDebug changes to wwdebug, wwmemlog, wwprofile from Zero Hour

### DIFF
--- a/Generals/Code/Libraries/Source/WWVegas/WWDebug/wwdebug.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WWDebug/wwdebug.cpp
@@ -22,13 +22,13 @@
  *                                                                                             *
  *                 Project Name : WWDebug                                                      *
  *                                                                                             *
- *                     $Archive:: /VSS_Sync/wwdebug/wwdebug.cpp                               $*
+ *                     $Archive:: /Commando/Code/wwdebug/wwdebug.cpp                          $*
  *                                                                                             *
- *                      $Author:: Vss_sync                                                    $*
+ *                      $Author:: Greg_h                                                      $*
  *                                                                                             *
- *                     $Modtime:: 10/19/00 2:12p                                              $*
+ *                     $Modtime:: 1/13/02 1:46p                                               $*
  *                                                                                             *
- *                    $Revision:: 13                                                          $*
+ *                    $Revision:: 16                                                          $*
  *                                                                                             *
  *---------------------------------------------------------------------------------------------*
  * Functions:                                                                                  *
@@ -50,6 +50,8 @@
 #include <stdio.h>
 #include <assert.h>
 #include <string.h>
+#include <signal.h>
+#include "Except.h"
 
 
 static PrintFunc			_CurMessageHandler = NULL;
@@ -93,7 +95,7 @@ int Get_Last_System_Error()
  *   2/19/98    GTH : Created.                                                                 *
  *=============================================================================================*/
 PrintFunc WWDebug_Install_Message_Handler(PrintFunc func)
-{	
+{
 	PrintFunc tmp = _CurMessageHandler;
 	_CurMessageHandler = func;
 	return tmp;
@@ -192,13 +194,13 @@ ProfileFunc	WWDebug_Install_Profile_Stop_Handler(ProfileFunc func)
  * HISTORY:                                                                                    *
  *   2/19/98    GTH : Created.                                                                 *
  *=============================================================================================*/
-#ifdef WWDEBUG
+
 void WWDebug_Printf(const char * format,...)
 {
 	if (_CurMessageHandler != NULL) {
-		
+
 		va_list	va;
-		char buffer[1024];
+		char buffer[4096];
 
 		va_start(va, format);
 		vsprintf(buffer, format, va);
@@ -209,7 +211,6 @@ void WWDebug_Printf(const char * format,...)
 
 	}
 }
-#endif
 
 /***********************************************************************************************
  * WWDebug_Printf_Warning -- Internal function for passing messages to installed handler       *
@@ -223,13 +224,13 @@ void WWDebug_Printf(const char * format,...)
  * HISTORY:                                                                                    *
  *   2/19/98    GTH : Created.                                                                 *
  *=============================================================================================*/
-#ifdef WWDEBUG
+
 void WWDebug_Printf_Warning(const char * format,...)
 {
 	if (_CurMessageHandler != NULL) {
-		
+
 		va_list	va;
-		char buffer[1024];
+		char buffer[4096];
 
 		va_start(va, format);
 		vsprintf(buffer, format, va);
@@ -240,7 +241,6 @@ void WWDebug_Printf_Warning(const char * format,...)
 
 	}
 }
-#endif
 
 /***********************************************************************************************
  * WWDebug_Printf_Error -- Internal function for passing messages to installed handler         *
@@ -254,13 +254,13 @@ void WWDebug_Printf_Warning(const char * format,...)
  * HISTORY:                                                                                    *
  *   2/19/98    GTH : Created.                                                                 *
  *=============================================================================================*/
-#ifdef WWDEBUG
+
 void WWDebug_Printf_Error(const char * format,...)
 {
 	if (_CurMessageHandler != NULL) {
-		
+
 		va_list	va;
-		char buffer[1024];
+		char buffer[4096];
 
 		va_start(va, format);
 		vsprintf(buffer, format, va);
@@ -271,7 +271,6 @@ void WWDebug_Printf_Error(const char * format,...)
 
 	}
 }
-#endif
 
 /***********************************************************************************************
  * WWDebug_Assert_Fail -- Internal function for passing assert messages to installed handler   *
@@ -289,18 +288,68 @@ void WWDebug_Printf_Error(const char * format,...)
 void WWDebug_Assert_Fail(const char * expr,const char * file, int line)
 {
 	if (_CurAssertHandler != NULL) {
-	
-		char buffer[1024];
+
+		char buffer[4096];
 		sprintf(buffer,"%s (%d) Assert: %s\n",file,line,expr);
 		_CurAssertHandler(buffer);
 
 	} else {
 
-		assert(0);
+		/*
+		// If the exception handler is try to quit the game then don't show an assert.
+		*/
+		if (Is_Trying_To_Exit()) {
+			ExitProcess(0);
+		}
 
-	}
+      char assertbuf[4096];
+		sprintf(assertbuf, "Assert failed\n\n. File %s Line %d", file, line);
+
+      int code = MessageBoxA(NULL, assertbuf, "WWDebug_Assert_Fail", MB_ABORTRETRYIGNORE|MB_ICONHAND|MB_SETFOREGROUND|MB_TASKMODAL);
+
+      if (code == IDABORT) {
+      	raise(SIGABRT);
+      	_exit(3);
+      }
+
+		if (code == IDRETRY) {
+			WWDEBUG_BREAK
+      	return;
+		}
+   }
 }
 #endif
+
+
+
+
+/***********************************************************************************************
+ * _assert -- Catch all asserts by overriding lib function                                     *
+ *                                                                                             *
+ *                                                                                             *
+ *                                                                                             *
+ * INPUT:    Assert stuff                                                                      *
+ *                                                                                             *
+ * OUTPUT:   Nothing                                                                           *
+ *                                                                                             *
+ * WARNINGS: None                                                                              *
+ *                                                                                             *
+ * HISTORY:                                                                                    *
+ *   12/11/2001 3:56PM ST : Created                                                            *
+ *=============================================================================================*/
+#if 0 //(gth) this is giving me link errors for some reason...
+
+#ifndef W3D_MAX4
+#ifdef WWDEBUG
+void __cdecl _assert(void *expr, void *filename, unsigned lineno)
+{
+	WWDebug_Assert_Fail((const char*)expr, (const char*)filename, lineno);
+}
+#endif //WWDEBUG
+#endif
+
+#endif
+
 
 
 /***********************************************************************************************
@@ -320,14 +369,14 @@ void WWDebug_Assert_Fail_Print(const char * expr,const char * file, int line,con
 {
 	if (_CurAssertHandler != NULL) {
 
-		char buffer[1024];
+		char buffer[4096];
 		sprintf(buffer,"%s (%d) Assert: %s %s\n",file,line,expr, string);
 		_CurAssertHandler(buffer);
 
 	} else {
 
 		assert(0);
-	
+
 	}
 }
 #endif
@@ -422,7 +471,7 @@ void WWDebug_DBWin32_Message_Handler( const char * str )
     if ( !heventDBWIN )
     {
         //MessageBox(NULL, "DBWIN_BUFFER_READY nonexistent", NULL, MB_OK);
-        return;            
+        return;
     }
 
     /* get a handle to the data synch object */
@@ -431,11 +480,11 @@ void WWDebug_DBWin32_Message_Handler( const char * str )
     {
         // MessageBox(NULL, "DBWIN_DATA_READY nonexistent", NULL, MB_OK);
         CloseHandle(heventDBWIN);
-        return;            
+        return;
     }
-    
+
     hSharedFile = CreateFileMapping((HANDLE)-1, NULL, PAGE_READWRITE, 0, 4096, "DBWIN_BUFFER");
-    if (!hSharedFile) 
+    if (!hSharedFile)
     {
         //MessageBox(NULL, "DebugTrace: Unable to create file mapping object DBWIN_BUFFER", "Error", MB_OK);
         CloseHandle(heventDBWIN);
@@ -444,7 +493,7 @@ void WWDebug_DBWin32_Message_Handler( const char * str )
     }
 
     lpszSharedMem = (LPSTR)MapViewOfFile(hSharedFile, FILE_MAP_WRITE, 0, 0, 512);
-    if (!lpszSharedMem) 
+    if (!lpszSharedMem)
     {
         //MessageBox(NULL, "DebugTrace: Unable to map shared memory", "Error", MB_OK);
         CloseHandle(heventDBWIN);
@@ -470,4 +519,3 @@ void WWDebug_DBWin32_Message_Handler( const char * str )
     return;
 }
 #endif // WWDEBUG
-

--- a/Generals/Code/Libraries/Source/WWVegas/WWDebug/wwdebug.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WWDebug/wwdebug.h
@@ -40,7 +40,7 @@
 
 #ifndef WWDEBUG_H
 #define WWDEBUG_H
-				
+
 // TheSuperHackers @todo Recover WWDEBUG?
 #ifdef WWDEBUG
 #include <Utility/intrin_compat.h>
@@ -87,10 +87,10 @@ ProfileFunc			WWDebug_Install_Profile_Stop_Handler(ProfileFunc func);
 /*
 ** Users should not call the following three functions directly!  Use the macros below instead...
 */
-#ifdef WWDEBUG
 void					WWDebug_Printf(const char * format,...);
 void					WWDebug_Printf_Warning(const char * format,...);
 void					WWDebug_Printf_Error(const char * format,...);
+#ifdef WWDEBUG
 void					WWDebug_Assert_Fail(const char * expr,const char * file, int line);
 void					WWDebug_Assert_Fail_Print(const char * expr,const char * file, int line,const char * string);
 bool					WWDebug_Check_Trigger(int trigger_num);
@@ -123,6 +123,9 @@ void					WWDebug_DBWin32_Message_Handler( const char * message);
 // WW3d is compiled at warning level 4, causes DEBUG_ASSERTCRASH to generate 
 // the 4127 warning (constant conditional expression)
 #pragma warning(disable:4127)
+#define WWRELEASE_SAY(x)						WWDebug_Printf x
+#define WWRELEASE_WARNING(x)					WWDebug_Printf_Warning x
+#define WWRELEASE_ERROR(x)						WWDebug_Printf_Error x
 /*
 ** The WWASSERT and WWASSERT_PRINT macros will send messages to your
 ** assert handler.
@@ -144,7 +147,7 @@ void					WWDebug_DBWin32_Message_Handler( const char * message);
 ** the debugger...
 */
 #ifdef WWDEBUG
-# define WWDEBUG_BREAK __debugbreak();
+#define WWDEBUG_BREAK __debugbreak();
 #else
 #define WWDEBUG_BREAK
 #endif

--- a/Generals/Code/Libraries/Source/WWVegas/WWDebug/wwprofile.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WWDebug/wwprofile.h
@@ -24,11 +24,11 @@
  *                                                                                             *
  *                     $Archive:: /Commando/Code/wwdebug/wwprofile.h                          $*
  *                                                                                             *
- *                      $Author:: Tom_s                                                       $*
+ *                      $Author:: Jani_p                                                      $*
  *                                                                                             *
- *                     $Modtime:: 6/29/01 3:10p                                               $*
+ *                     $Modtime:: 3/25/02 2:05p                                               $*
  *                                                                                             *
- *                    $Revision:: 8                                                           $*
+ *                    $Revision:: 14                                                          $*
  *                                                                                             *
  *---------------------------------------------------------------------------------------------*
  * Functions:                                                                                  *
@@ -38,14 +38,25 @@
 #pragma once
 #endif // _MSC_VER >= 1000
 
+//#define ENABLE_TIME_AND_MEMORY_LOG
+
 #ifndef WWPROFILE_H
 #define WWPROFILE_H
+
+#include "wwstring.h"
 
 #ifdef _UNIX
 typedef signed long long __int64;
 typedef signed long long _int64;
 #endif
-	
+
+// enable profiling by default in debug mode.
+#ifdef WWDEBUG
+#define ENABLE_WWPROFILE	
+#endif
+
+extern unsigned WWProfile_Get_System_Time();	// timeGetTime() wrapper
+class FileClass;
 			
 /*
 ** A node in the WWProfile Hierarchy Tree
@@ -54,6 +65,7 @@ class	WWProfileHierachyNodeClass {
 
 public:
 	WWProfileHierachyNodeClass( const char * name, WWProfileHierachyNodeClass * parent );
+	WWProfileHierachyNodeClass( unsigned id, WWProfileHierachyNodeClass * parent );
 	~WWProfileHierachyNodeClass( void );
 
 	WWProfileHierachyNodeClass * Get_Sub_Node( const char * name );
@@ -62,6 +74,10 @@ public:
 	WWProfileHierachyNodeClass * Get_Sibling( void )		{ return Sibling; }
 	WWProfileHierachyNodeClass * Get_Child( void )			{ return Child; }
 
+	void Set_Parent( WWProfileHierachyNodeClass *node )			{ Parent=node; }
+	void Set_Sibling( WWProfileHierachyNodeClass *node )			{ Sibling=node; }
+	void Set_Child( WWProfileHierachyNodeClass *node )			{ Child=node; }
+
 	void								Reset( void );
 	void								Call( void );
 	bool								Return( void );
@@ -69,6 +85,13 @@ public:
 	const char *					Get_Name( void )				{ return Name; }
 	int								Get_Total_Calls( void )		{ return TotalCalls; }
 	float								Get_Total_Time( void )		{ return TotalTime; }
+	void								Set_Total_Calls(int calls) { TotalCalls=calls; }
+	void								Set_Total_Time(float time) { TotalTime=time; }
+
+	WWProfileHierachyNodeClass* Clone_Hierarchy(WWProfileHierachyNodeClass* parent);
+	void								Write_To_File(FileClass* file,int recursion);
+	void								Add_To_String_Compact(StringClass& string,int recursion);
+
 
 protected:
 
@@ -77,10 +100,42 @@ protected:
 	float								TotalTime;
 	__int64							StartTime;
 	int								RecursionCounter;
+	unsigned						ProfileStringID;
 
 	WWProfileHierachyNodeClass *	Parent;
 	WWProfileHierachyNodeClass *	Child;
 	WWProfileHierachyNodeClass *	Sibling;
+};
+
+class	WWProfileHierachyInfoClass {
+public:
+	WWProfileHierachyInfoClass( const char * name, WWProfileHierachyInfoClass * parent );
+	~WWProfileHierachyInfoClass( void );
+
+	WWProfileHierachyInfoClass * Get_Parent( void )			{ return Parent; }
+	WWProfileHierachyInfoClass * Get_Sibling( void )		{ return Sibling; }
+	WWProfileHierachyInfoClass * Get_Child( void )			{ return Child; }
+
+	void Set_Parent( WWProfileHierachyInfoClass *node )			{ Parent=node; }
+	void Set_Sibling( WWProfileHierachyInfoClass *node )			{ Sibling=node; }
+	void Set_Child( WWProfileHierachyInfoClass *node )			{ Child=node; }
+
+	const char *						Get_Name( void )				{ return Name; }
+	void								Set_Name( const char* name )	{ Name=name; }
+	int									Get_Total_Calls( void )		{ return TotalCalls; }
+	float								Get_Total_Time( void )		{ return TotalTime; }
+	void								Set_Total_Calls(int calls) { TotalCalls=calls; }
+	void								Set_Total_Time(float time) { TotalTime=time; }
+
+protected:
+
+	StringClass							Name;
+	int								TotalCalls;
+	float								TotalTime;
+
+	WWProfileHierachyInfoClass *	Parent;
+	WWProfileHierachyInfoClass *	Child;
+	WWProfileHierachyInfoClass *	Sibling;
 };
 
 /*
@@ -145,8 +200,14 @@ protected:
 */
 class	WWProfileManager {
 public:
+	WWINLINE static	void					Enable_Profile(bool enable) { IsProfileEnabled=enable; }
+	WWINLINE static	bool					Is_Profile_Enabled() { return IsProfileEnabled; }
+
 	static	void								Start_Profile( const char * name );
 	static	void								Stop_Profile( void );
+
+	static	void								Start_Root_Profile( const char * name );
+	static	void								Stop_Root_Profile( void );
 
 	static	void								Reset( void );
 	static	void								Increment_Frame_Counter( void );
@@ -158,11 +219,20 @@ public:
 	static	WWProfileInOrderIterator *	Get_In_Order_Iterator( void );
 	static	void								Release_In_Order_Iterator( WWProfileInOrderIterator * iterator );
 
+	static	WWProfileHierachyNodeClass *	Get_Root( void ) { return &Root; }
+
+	static	void								Begin_Collecting();
+	static	void								End_Collecting(const char* filename);
+
+	static	void								Load_Profile_Log(const char* filename, WWProfileHierachyInfoClass**& array, unsigned& count);
+
 private:
 	static	WWProfileHierachyNodeClass		Root;
 	static	WWProfileHierachyNodeClass *	CurrentNode;
+	static	WWProfileHierachyNodeClass *	CurrentRootNode;
 	static	int									FrameCounter;
 	static	__int64								ResetTime;
+	static	bool									IsProfileEnabled;
 
 	friend	class		WWProfileInOrderIterator;
 };
@@ -173,22 +243,32 @@ private:
 ** Use the WWPROFILE macro at the start of scope to time
 */
 class	WWProfileSampleClass {
+	bool IsRoot;
+	bool Enabled;
 public:
-	WWProfileSampleClass( const char * name )		
+	WWProfileSampleClass( const char * name, bool is_root )		 : IsRoot(is_root), Enabled(WWProfileManager::Is_Profile_Enabled())
 	{ 
-		WWProfileManager::Start_Profile( name ); 
+		if (Enabled) {
+			if (IsRoot) WWProfileManager::Start_Root_Profile( name ); 
+			else WWProfileManager::Start_Profile( name ); 
+		}
 	}
 	
 	~WWProfileSampleClass( void )					
 	{ 
-		WWProfileManager::Stop_Profile(); 
+		if (Enabled) {
+			if (IsRoot) WWProfileManager::Stop_Root_Profile(); 
+			else WWProfileManager::Stop_Profile(); 
+		}
 	}
 };
 
-#ifdef WWDEBUG
-#define	WWPROFILE( name )						WWProfileSampleClass _wwprofile( name )
+#ifdef ENABLE_WWPROFILE
+#define	WWPROFILE( name )						WWProfileSampleClass _wwprofile( name, false )
+#define	WWROOTPROFILE( name )				WWProfileSampleClass _wwprofile( name, true )
 #else
 #define	WWPROFILE( name )
+#define	WWROOTPROFILE( name )
 #endif
 
 
@@ -204,7 +284,7 @@ private:
 	__int64	Time;
 };
 
-#ifdef WWDEBUG
+#ifdef ENABLE_WWPROFILE
 #define	WWTIMEIT( name )	WWTimeItClass _wwtimeit( name )
 #else
 #define	WWTIMEIT( name )
@@ -213,7 +293,6 @@ private:
 
 
 /*
-** TSS 06/27/01
 ** WWMeasureItClass is like WWTimeItClass, but it pokes the result into the given float, 
 ** and can be used in the release build.
 */
@@ -227,5 +306,37 @@ private:
 	float *  PResult;
 };
 
+// ----------------------------------------------------------------------------
+//
+// Use the first macro to log time and memory usage within the stack segment.
+// Use the second macro to log intermediate values. The intermediate values are
+// calculated from the previous intermediate log, so you can log how much each
+// item takes by placing the macro after each of the 
+//
+// ----------------------------------------------------------------------------
+
+#ifdef ENABLE_TIME_AND_MEMORY_LOG
+#define WWLOG_PREPARE_TIME_AND_MEMORY(t) WWMemoryAndTimeLog memory_and_time_log(t)
+#define WWLOG_INTERMEDIATE(t) memory_and_time_log.Log_Intermediate(t)
+#else
+#define WWLOG_PREPARE_TIME_AND_MEMORY(t)
+#define WWLOG_INTERMEDIATE(t)
+#endif
+
+struct WWMemoryAndTimeLog
+{
+	unsigned TimeStart;
+	unsigned IntermediateTimeStart;
+	int AllocCountStart;
+	int IntermediateAllocCountStart;
+	int AllocSizeStart;
+	int IntermediateAllocSizeStart;
+	StringClass Name;
+	static unsigned TabCount;
+
+	WWMemoryAndTimeLog(const char* name);
+	~WWMemoryAndTimeLog();
+	void Log_Intermediate(const char* text);
+};
 
 #endif	// WWPROFILE_H

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/CMakeLists.txt
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/CMakeLists.txt
@@ -31,6 +31,8 @@ set(WWLIB_SRC
     cstraw.h
     Except.cpp
     Except.h
+    FastAllocator.cpp
+    FastAllocator.h
     ffactory.cpp
     ffactory.h
     gcd_lcm.cpp

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/FastAllocator.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/FastAllocator.cpp
@@ -1,0 +1,42 @@
+/*
+**	Command & Conquer Generals Zero Hour(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "FastAllocator.h"
+#include <new.h>
+
+static FastAllocatorGeneral* generalAllocator; //This general allocator will do all allocations for us.
+
+FastAllocatorGeneral* FastAllocatorGeneral::Get_Allocator()
+{
+	if (!generalAllocator) {
+		generalAllocator=reinterpret_cast<FastAllocatorGeneral*>(::malloc(sizeof(FastAllocatorGeneral)));
+
+		new (generalAllocator) FastAllocatorGeneral();
+	}
+	return generalAllocator;
+}
+
+FastAllocatorGeneral::FastAllocatorGeneral() : MemoryLeakLogEnabled(false), AllocatedWithMalloc(0), AllocatedWithMallocCount(0), ActualMemoryUsage(0)
+{
+	int alloc_size=ALLOC_STEP;
+	for (int i=0;i<MAX_ALLOC_SIZE/ALLOC_STEP;++i) {
+	   allocators[i].Init(alloc_size);
+		alloc_size+=ALLOC_STEP;
+	}
+}
+

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/FastAllocator.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/FastAllocator.h
@@ -1,0 +1,735 @@
+/*
+**	Command & Conquer Generals Zero Hour(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+///////////////////////////////////////////////////////////////////////////////
+// FastAllocator.h
+//
+// Implements simple and fast memory allocators. Includes sample code for 
+// STL and overriding of specific or global new/delete.
+//
+// Allocators are very fast and prevent memory fragmentation. They use up
+// a little more space on average than generic new/malloc free/delete.
+//
+///////////////////////////////////////////////////////////////////////////////
+
+
+#ifndef FASTALLOCATOR_H
+#define FASTALLOCATOR_H
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+//#define MEMORY_OVERWRITE_TEST
+
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Include files
+//
+#include "always.h"
+#include "wwdebug.h"
+#include "mutex.h"
+#include <malloc.h>
+#include <stddef.h> //size_t & ptrdiff_t definition
+#include <string.h>
+
+///////////////////////////////////////////////////////////////////////////////
+// Forward Declarations
+//
+class FastFixedAllocator;    //Allocates and deletes items of a fixed size.
+class FastAllocatorGeneral;  //Allocates and deletes items of any size. Can use as a fast replacement for global new/delete.
+
+
+
+///////////////////////////////////////////////////////////////////////////////
+// StackAllocator
+//
+// Introduction:
+//    This templated class allows you to allocate a dynamically sized temporary
+//    block of memory local to a function in a way that causes it to use some
+//    stack space instead of using the (very slow) malloc function. You don't
+//    want to call malloc/new to allocate temporary blocks of memory when speed
+//    is important. This class is only practical if you are allocating arrays of
+//    objects (especially smaller objects). If you have a class whose size is
+//    40K, you aren't going to be able to put even one of them on the stack.
+//    If you don't need an array but instead just need a single object, then you
+//    can simply create your object on the stack and be done with it. However, 
+//    there are some times when you need a temporary array of objects (or just 
+//    an array of chars or pointers) but don't know the size beforehand. That's
+//    where this class is useful.
+//
+// Parameters:
+//    The class takes three templated parameters: T, nStackCount, bConstruct.
+//      T           -- The type of object being allocated. Examples include char,
+//                     cRZString, int*, cRZRect*.
+//      nStackCount -- How many items to allocate on the stack before switching
+//                     to a heap allocation. Note that if you want to write 
+//                     portable code, you need to use no more than about 2K
+//                     of stack space. So make sure nStackCount*sizeof(T) < 2048.
+//      bConstruct  -- This is normally 1, but setting it to 0 is a hint to the 
+//                     compiler that you are constructing a type that has no
+//                     constructor. Testing showed that the VC++ compiler wasn't
+//                     completely able to optimize on its own. In particular, it
+//                     was smart enough to remove the while loop, but not smart
+//                     enough to remore the pTArrayEnd assignment.
+//
+// Benchmarks:
+//    Testing one one machine showed that allocating and freeing a block of 
+//    2048 bytes via malloc/free took 8700 and 8400 clock ticks respectively.
+//    Using this stack allocator to do the same thing tooko 450 and 375 clock
+//    ticks respectively. 
+//
+// Usage and examples:
+//    Since we are using a local allocator and not overloading global or class 
+//    operator new, you have to directory call StackAllocator::New instead  
+//    of operator new. So instead of saying:
+//       SomeStruct* pStructArray = new SomeStruct[13];
+//    you say:
+//       SomeStruct* pStructArray = stackAllocator.New(13);
+//
+//    void Example(int nSize){
+//       StackAllocator<char, 512> stackAllocator;    //Create an instance
+//       char* pArray = stackAllocator.New(nSize);    //Allocate memory, it will auto-freed.
+//       memset(pArray, 0, nSize*sizeof(char));       //Do something with the memory.
+//    }
+//
+//    void Example(int nSize){
+//       StackAllocator<int*, 512, 0> stackAllocator; //Create an instance. We use the 'construct' hint feature here.
+//       int** pArray = stackAllocator.New(nSize);    //Allocate memory.
+//       memset(pArray, 0, nSize*sizeof(int*));       //Do something with the memory.
+//       stackAllocator.Delete(pArray);               //In this example, we explicity free the memory.
+//    }
+//
+//    void Example(int nSize){
+//       StackAllocator<cRZRect, 200> stackAllocator;       //Create an instance
+//       cRZRect* pRectArray = stackAllocator.New(nSize);   //Allocate memory, it will auto-freed.
+//       pRectArray[0].SetRect(0,0,1,1);                    //Do something with the memory.
+//    }
+//
+//    void Example(int nSize){
+//       StackAllocator<char, 200> stackAllocator;    //Create an instance
+//       char* pArray  = stackAllocator.New(nSize);   //Allocate memory.
+//       char* pArray2 = stackAllocator.New(nSize);   //Allocate some additional memory.
+//       memset(pArray, 0, nSize*sizeof(char));       //Do something with the memory.
+//       stackAllocator.Delete(pArray);               //Delete the memory
+//       pArray = stackAllocator.New(nSize*2);        //Allocate some new memory. We'll let the allocator free it.
+//       memset(pArray, 0, nSize*2*sizeof(char));     //Do something with the new memory.
+//       stackAllocator.Delete(pArray2);              //Delete the additional memory.
+//    }
+//
+template<class T, int nStackCount, int bConstruct=1>
+class StackAllocator{
+public:
+   StackAllocator() : mnAllocCount(-1), mpTHeap(NULL){}
+  ~StackAllocator(){
+      if(mnAllocCount != -1){ //If there is anything to do...
+         if(mpTHeap)
+            delete mpTHeap;
+         else{
+            if(bConstruct){ //Since this constant, the comparison gets optimized away.
+               T* pTArray = (T*)mTArray;
+               const T* const pTArrayEnd = pTArray + mnAllocCount;
+               while(pTArray < pTArrayEnd){
+                  pTArray->~T(); //Call the destructor on the object directly.
+                  ++pTArray;
+               }
+            }
+         }
+      }
+   }
+
+   T* New(unsigned nCount){
+      if(mnAllocCount == -1){
+         mnAllocCount = nCount;
+         if(nCount < nStackCount){ //If the request is small enough to come from the stack...
+            //We call the constructors of all the objects here.
+            if(bConstruct){ //Since this constant, the comparison gets optimized away.
+               T* pTArray = (T*)mTArray;
+               const T* const pTArrayEnd = pTArray + nCount;
+               while(pTArray < pTArrayEnd){
+                  new(pTArray)T; //Use the placement operator new. This simply calls the constructor 
+                  ++pTArray;     //of T with 'this' set to the input address. Note that we don't put
+               }                 //a '()' after the T this is because () causes trivial types like int
+            }                    //and class* to be assigned zero/NULL. We don't want that.
+            return (T*)mTArray;
+         } //Else the request is too big. So let's use (the slower) operator new.
+         return (mpTHeap = new T[nCount]); //The compiler will call the constructors here.
+      } //Else we are being used. Let's be nice and allocate something anyway.
+      return new T[nCount];
+   }
+
+   void Delete(T* pT){
+      if(pT == (T*)mTArray){ //If the allocation came from our stack...
+         if(bConstruct){ //Since this constant, the comparison gets optimized away.
+            T* pTArray = (T*)mTArray;
+            const T* const pTArrayEnd = pTArray + mnAllocCount;
+            while(pTArray < pTArrayEnd){
+               pTArray->~T(); //Call the destructor on the object directly.
+               ++pTArray;
+            }
+         }
+         mnAllocCount = -1;
+      }
+      else if(pT == mpTHeap){ //If the allocation came from our heap...
+         delete[] mpTHeap;    //The compiler will call the destructors here.
+         mpTHeap      = NULL; //We clear these out so that we can possibly
+         mnAllocCount = -1;   //  use the allocator again.
+      }
+      else //Else the allocation came from the external heap.
+         delete[] pT;
+   }
+
+protected:
+   int  mnAllocCount;                     //Count of objects allocated. -1 means that nothing is allocated. We don't use zero because zero is a legal allocation count in C++.
+   T*   mpTHeap;                          //This is normally NULL, but gets used of the allocation request is too high.
+   char mTArray[nStackCount*sizeof(T)];   //This is our stack memory.
+};
+///////////////////////////////////////////////////////////////////////////////
+
+
+
+
+///////////////////////////////////////////////////////////////////////////////
+// class FastFixedAllocator
+//
+class FastFixedAllocator
+{
+public:
+	FastFixedAllocator(unsigned int n=0);
+  ~FastFixedAllocator();
+   void  Init(unsigned int n); //Useful for setting allocation size *after* construction,
+                               //but before first use.
+	void* Alloc();
+	void  Free(void* pAlloc);
+
+	unsigned Get_Heap_Size() const { return TotalHeapSize; }
+	unsigned Get_Allocated_Size() const { return TotalAllocatedSize; }
+	unsigned Get_Allocation_Count() const { return TotalAllocationCount; }
+
+protected:
+	struct Link
+	{
+		Link* next;
+	};
+
+   struct Chunk
+	{
+		enum {
+			size = 8*1024-16
+		};
+
+		Chunk* next;
+		char mem[size];
+	};
+	Chunk* chunks;
+	unsigned int esize;
+	unsigned TotalHeapSize;
+	unsigned TotalAllocatedSize;
+	unsigned TotalAllocationCount;
+	Link*  head;
+	void   grow();
+};
+
+// ----------------------------------------------------------------------------
+//
+//
+//
+// ----------------------------------------------------------------------------
+
+WWINLINE void* FastFixedAllocator::Alloc()
+{
+	TotalAllocationCount++;
+	TotalAllocatedSize+=esize;
+   if (head==0) {
+      grow();
+	}
+   Link* p = head;
+   head    = p->next;
+   return p;
+}
+
+// ----------------------------------------------------------------------------
+//
+//
+//
+// ----------------------------------------------------------------------------
+
+WWINLINE void FastFixedAllocator::Free(void* pAlloc)
+{
+	TotalAllocationCount--;
+	TotalAllocatedSize-=esize;
+   Link* p = static_cast<Link*>(pAlloc);
+   p->next = head;
+   head    = p;
+}
+
+// ----------------------------------------------------------------------------
+//
+//
+//
+// ----------------------------------------------------------------------------
+
+WWINLINE FastFixedAllocator::FastFixedAllocator(unsigned int n) : esize(1), TotalHeapSize(0), TotalAllocatedSize(0), TotalAllocationCount(0)
+{
+   head   = 0;
+   chunks = 0;
+   Init(n);
+}
+
+// ----------------------------------------------------------------------------
+//
+//
+//
+// ----------------------------------------------------------------------------
+
+WWINLINE FastFixedAllocator::~FastFixedAllocator()
+{
+   Chunk* n = chunks;
+   while(n){
+      Chunk* p = n;
+      n = n->next;
+      delete p;
+   }
+}
+
+// ----------------------------------------------------------------------------
+//
+//
+//
+// ----------------------------------------------------------------------------
+
+WWINLINE void FastFixedAllocator::Init(unsigned int n)
+{
+   esize = (n<sizeof(Link*) ? sizeof(Link*) : n);
+}
+
+// ----------------------------------------------------------------------------
+//
+//
+//
+// ----------------------------------------------------------------------------
+
+WWINLINE void FastFixedAllocator::grow()
+{
+   Chunk* n = new Chunk;
+   n->next  = chunks;
+   chunks   = n;
+	TotalHeapSize+=sizeof(Chunk);
+   
+   const int nelem = Chunk::size/esize;
+   char* start = n->mem;
+   char* last = &start[(nelem-1)*esize];
+   for(char* p = start; p<last; p+=esize)
+      reinterpret_cast<Link*>(p)->next = reinterpret_cast<Link*>(p+esize);
+   reinterpret_cast<Link*>(last)->next = 0;
+   head = reinterpret_cast<Link*>(start);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+
+
+
+
+
+
+///////////////////////////////////////////////////////////////////////////////
+// class FastAllocatorGeneral
+//
+// This class works by putting sizes into fixed size buckets. Each fixed size
+// bucket is a FastFixedAllocator.
+//
+class FastAllocatorGeneral
+{
+	enum {
+		MAX_ALLOC_SIZE=2048,
+		ALLOC_STEP=16
+	};
+public:
+	FastAllocatorGeneral();
+	void* Alloc(unsigned int n);
+	void  Free(void* pAlloc);
+  	void* Realloc(void* pAlloc, unsigned int n);
+
+	unsigned Get_Total_Heap_Size();
+	unsigned Get_Total_Allocated_Size();
+	unsigned Get_Total_Allocation_Count();
+	unsigned Get_Total_Actual_Memory_Usage() { return ActualMemoryUsage; }
+
+	static FastAllocatorGeneral* Get_Allocator();
+
+protected:
+   FastFixedAllocator allocators[MAX_ALLOC_SIZE/ALLOC_STEP];
+	FastCriticalSectionClass CriticalSections[MAX_ALLOC_SIZE/ALLOC_STEP];
+	bool MemoryLeakLogEnabled;
+
+	unsigned AllocatedWithMalloc;
+	unsigned AllocatedWithMallocCount;
+	unsigned ActualMemoryUsage;
+};
+///////////////////////////////////////////////////////////////////////////////
+
+WWINLINE unsigned FastAllocatorGeneral::Get_Total_Heap_Size()
+{
+	int size=AllocatedWithMalloc;
+	for (int i=0;i<MAX_ALLOC_SIZE/ALLOC_STEP;++i) {
+		FastCriticalSectionClass::LockClass lock(CriticalSections[i]);
+		size+=allocators[i].Get_Heap_Size();
+	}
+	return size;
+}
+
+WWINLINE unsigned FastAllocatorGeneral::Get_Total_Allocated_Size()
+{
+	int size=AllocatedWithMalloc;
+	for (int i=0;i<MAX_ALLOC_SIZE/ALLOC_STEP;++i) {
+		FastCriticalSectionClass::LockClass lock(CriticalSections[i]);
+		size+=allocators[i].Get_Allocated_Size();
+	}
+	return size;
+}
+
+WWINLINE unsigned FastAllocatorGeneral::Get_Total_Allocation_Count()
+{
+	int count=AllocatedWithMallocCount;
+	for (int i=0;i<MAX_ALLOC_SIZE/ALLOC_STEP;++i) {
+		FastCriticalSectionClass::LockClass lock(CriticalSections[i]);
+		count+=allocators[i].Get_Allocation_Count();
+	}
+	return count;
+}
+
+// ----------------------------------------------------------------------------
+//
+//
+//
+// ----------------------------------------------------------------------------
+
+WWINLINE void* FastAllocatorGeneral::Alloc(unsigned int n)
+{
+   void* pMemory;
+	static int re_entrancy=0;
+	re_entrancy++;
+
+   //We actually allocate n+4 bytes. We store the # allocated 
+   //in the first 4 bytes, and return the ptr to the rest back
+   //to the user.
+   n += sizeof(unsigned int); 
+#ifdef MEMORY_OVERWRITE_TEST
+	n+=sizeof(unsigned int);
+#endif
+
+	if (re_entrancy==1) {
+		ActualMemoryUsage+=n;
+	}
+	if (n<MAX_ALLOC_SIZE) {
+		int index=(n)/ALLOC_STEP;
+		{
+			FastCriticalSectionClass::LockClass lock(CriticalSections[index]);
+			pMemory = allocators[index].Alloc();
+		}
+	}
+   else {
+		if (re_entrancy==1) {
+			AllocatedWithMalloc+=n;
+			AllocatedWithMallocCount++;
+		}
+      pMemory = ::malloc(n);
+	}
+#ifdef MEMORY_OVERWRITE_TEST
+	*((unsigned int*)((char*)pMemory+n)-1)=0xabbac0de;
+#endif
+
+	re_entrancy--;
+   *((unsigned int*)pMemory) = n;     //Write modified (augmented by 4) count into first four bytes.
+   return ((unsigned int*)pMemory)+1; //return ptr to bytes after it back to user.
+}
+
+// ----------------------------------------------------------------------------
+//
+//
+//
+// ----------------------------------------------------------------------------
+
+WWINLINE void FastAllocatorGeneral::Free(void* pAlloc)
+{
+   if (pAlloc) {
+      unsigned int* n = ((unsigned int*)pAlloc)-1; //Subtract four bytes and the count is stored there.
+
+#ifdef MEMORY_OVERWRITE_TEST
+		WWASSERT(*((unsigned int*)((char*)n+*n)-1)==0xabbac0de);
+#endif
+
+		unsigned size=*n;
+		ActualMemoryUsage-=size;
+
+		if (size<MAX_ALLOC_SIZE) {
+			int index=size/ALLOC_STEP;
+			FastCriticalSectionClass::LockClass lock(CriticalSections[index]);
+         allocators[index].Free(n);
+		}
+      else {
+			AllocatedWithMallocCount--;
+			AllocatedWithMalloc-=size;
+         ::free(n);
+		}
+   }
+}
+
+//ANSI C requires:
+//  (1) realloc(NULL, newsize) is equivalent to malloc(newsize).
+//  (2) realloc(pblock, 0) is equivalent to free(pblock) (except that NULL is returned).
+//  (3) if the realloc() fails, the object pointed to by pblock is left unchanged.
+//
+WWINLINE void* FastAllocatorGeneral::Realloc(void* pAlloc, unsigned int n){
+   if(n){
+      void* const pNewAlloc = Alloc(n);      //Allocate the new memory. This never fails.
+      if(pAlloc){
+         n = *(((unsigned int*)pAlloc)-1);   //Subtract four bytes and the count is stored there.
+         ::memcpy(pNewAlloc, pAlloc, n);     //Copy the old memory into the new memory.
+         Free(pAlloc);                       //Delete the old memory.
+      }
+      return pNewAlloc;
+   }
+   Free(pAlloc);
+   return NULL;
+}
+
+
+
+
+
+
+
+///////////////////////////////////////////////////////////////////////////////
+// FastSTLAllocator
+//
+// An STL allocator based on a simple fixed size allocator is not going to
+// buy you the performance you really want. This is because STL containers
+// allocate not just objects of the size of the container, but other objects
+// as well. For example, the STL "list" class generally allocates item nodes
+// and not items themselves. The STL vector class usually allocates in chunks
+// of contiguous items. So your allocator will probably want to have a bucket
+// system whereby it maintains buckets for integral sizes.
+//
+
+#ifdef _MSC_VER 
+   //VC++ continues to be the one compiler that lacks the ability to compile
+   //standard C++. So we define a version of the STL allocator specifically
+   //for VC++, and let other compilers use a standard allocator template.
+   template <class T>
+   struct FastSTLAllocator{
+      typedef size_t    size_type;        //basically, "unsigned int"
+      typedef ptrdiff_t difference_type;  //basically, "int"
+      typedef T*        pointer;
+      typedef const T*  const_pointer;
+      typedef T&        reference;
+      typedef const T&  const_reference;
+      typedef T         value_type;
+
+      T*            address(T& t)       const             { return (&t); } //These two are slightly strange but 
+      const  T*     address(const T& t) const             { return (&t); } //required functions. Just do it.
+      static T*     allocate(size_t n, const void* =NULL) { return (T*)FastAllocatorGeneral::Get_Allocator()->Alloc(n*sizeof(T)); }
+      static void   construct(T* ptr, const T& value)     { new(ptr) T(value); }
+      static void   deallocate(void* ptr, size_t /*n*/)   { FastAllocatorGeneral::Get_Allocator()->Free(ptr); }
+      static void   destroy(T* ptr)                       { ptr->~T(); }
+      static size_t max_size()                            { return (size_t)-1; }
+
+      //This _Charalloc is required by VC++5 since it VC++5 predates
+      //the language standardization. Allocator behaviour is one of the
+      //last things to have been hammered out. Important note: If you 
+      //decide to write your own fast allocator, containers will allocate
+      //random objects through this function but delete them through 
+      //the above delallocate() function. So your version of deallocate
+      //should *not* assume that it will only be given T objects to delete.
+      char* _Charalloc(size_t n){ return (char*)FastAllocatorGeneral::Get_Allocator()->Alloc(n*sizeof(char)); }
+   };
+#else
+   //This is a C++ language standard allocator. Most C++ compilers after 1999 
+   //other than Microsoft C++ compile this fine. Otherwise. you might be able
+   //to use the same allocator as VC++ uses above.
+   template <class T>
+   class FastSTLAllocator{
+   public:
+     typedef size_t     size_type;
+     typedef ptrdiff_t  difference_type;
+     typedef T*         pointer;
+     typedef const T*   const_pointer;
+     typedef T&         reference;
+     typedef const T&   const_reference;
+     typedef T          value_type;
+
+     template <class T1> struct rebind {
+        typedef FastSTLAllocator<T1> other;
+     };
+
+     FastSTLAllocator() {}
+     FastSTLAllocator(const FastSTLAllocator&) {}
+     template <class T1> FastSTLAllocator(const FastSTLAllocator<T1>&) {}
+     ~FastSTLAllocator() {}
+
+     pointer address(reference x) const             { return &x; }
+     const_pointer address(const_reference x) const { return &x; }
+
+     T* allocate(size_type n, const void* = NULL) { return n != 0 ? static_cast<T*>(FastAllocatorGeneral::Get_Allocator()->Alloc(n*sizeof(T))) : NULL; }
+     void deallocate(pointer p, size_type n)      { FastAllocatorGeneral::Get_Allocator()->Free(p); }
+     size_type max_size() const                   { return size_t(-1) / sizeof(T); }
+     void construct(pointer p, const T& val)      { new(p) T(val); }
+     void destroy(pointer p)                      { p->~T(); }
+   };
+#endif
+
+template<class T>
+WWINLINE bool operator==(const FastSTLAllocator<T>&, const FastSTLAllocator<T>&) { return true;  }
+template<class T>
+WWINLINE bool operator!=(const FastSTLAllocator<T>&, const FastSTLAllocator<T>&) { return false; }
+///////////////////////////////////////////////////////////////////////////////
+
+
+
+
+
+/*
+///////////////////////////////////////////////////////////////////////////////
+// Example usage of fast allocators in STL.
+//
+///////////////////////////////////////////////////////////////////////////////
+
+#include <stdio.h>
+#include <vector>
+#include <list>
+#include <deque>
+#include <queue>
+#include <stack>
+#include <set>
+#include <map>
+#include <string>
+#include <memory>
+#include <hash_set> //Uncomment this if you have hash containers available.
+#include <hash_map>
+using namespace std;
+
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Here's how you declare a custom allocator for every regular STL container class:
+//
+typedef vector<int, FastSTLAllocator<int> >                            IntArray;
+typedef list<int, FastSTLAllocator<int> >                              IntList;
+typedef deque<int, FastSTLAllocator<int> >                             IntDequeue;
+typedef queue<int, deque<int, FastSTLAllocator<int> > >                IntQueue;
+typedef priority_queue<int, vector<int, FastSTLAllocator<int> > >      IntPriorityQueue;
+typedef stack<int, deque<int, FastSTLAllocator<int> > >                IntStack;
+typedef map<int, int, less<int>, FastSTLAllocator<int> >               IntMap;
+typedef multimap<int, int, less<int>, FastSTLAllocator<int> >          IntMultiMap;
+typedef set<int, less<int>, FastSTLAllocator<int> >                    IntSet;
+typedef multiset<int, less<int>, FastSTLAllocator<int> >               IntMultiSet;
+
+//If you have the hashing containers available, here's how you do it:
+typedef hash_map<int, int, hash<int>, equal_to<int>, FastSTLAllocator<int> >        IntHashMap;
+typedef hash_multimap<int, int, hash<int>, equal_to<int>, FastSTLAllocator<int> >   IntHashMultiMap;
+typedef hash_set<int, hash<int>, equal_to<int>, FastSTLAllocator<int> >             IntHashSet;
+typedef hash_multiset<int, hash<int>, equal_to<int>, FastSTLAllocator<int> >        IntHashMultiSet;
+
+typedef basic_string<char, char_traits<char>, FastSTLAllocator<char> > CharString;
+
+//bitset and valarray don't allow custom allocators.
+
+///////////////////////////////////////////////////////////////////////////////
+
+
+void main(){   
+   IntArray intArray;
+   intArray.push_back(3);
+   intArray.pop_back();
+
+   IntList intList;
+   intList.push_back(3);
+   intList.pop_back();
+
+   IntDequeue intDequeue;
+   intDequeue.push_back(3);
+   intDequeue.pop_back();
+   
+   IntQueue intQueue;
+   intQueue.push(3);
+   intQueue.pop();
+
+   IntPriorityQueue intPriorityQueue;
+   intPriorityQueue.push(3);
+   intPriorityQueue.pop();
+
+   IntStack intStack;
+   intStack.push(3);
+   intStack.pop();
+
+   IntMap intMap;
+   intMap.insert(pair<int,int>(3,3));
+   intMap.erase(3);
+
+   IntMultiMap intMultiMap;
+   intMultiMap.insert(pair<int,int>(3,3));
+   intMultiMap.erase(3);
+
+   IntSet intSet;
+   intSet.insert(3);
+   intSet.erase(3);
+
+   IntMultiSet intMultiSet;
+   intMultiSet.insert(3);
+   intMultiSet.erase(3);
+
+   IntHashMap intHashMap;
+   intHashMap.insert(3);
+   intHashMap.erase(3);
+
+   IntHashMultiMap intHashMultiMap;
+   intHashMultiMap.insert(3);
+   intHashMultiMap.erase(3);
+
+   IntHashSet intHashSet;
+   intHashSet.insert(3);
+   intHashSet.erase(3);
+
+   IntHashMultiSet intHashMultiSet;
+   intHashMultiSet.insert(3);
+   intHashMultiSet.erase(3);
+
+   CharString charString;
+   charString.append(1, '3');
+   charString.erase(charString.length()-1);
+
+   //Shutdown
+   printf("\nDone. Press the 'any' key\n");
+   getchar();
+}
+*/
+
+
+
+#endif //sentry
+
+
+
+
+
+
+
+
+

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWDebug/wwdebug.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWDebug/wwdebug.h
@@ -41,6 +41,7 @@
 #ifndef WWDEBUG_H
 #define WWDEBUG_H
 
+// TheSuperHackers @todo Recover WWDEBUG?
 #ifdef WWDEBUG
 #include <Utility/intrin_compat.h>
 #endif


### PR DESCRIPTION
This change backports all remaining WWDebug changes to wwdebug, wwmemlog, wwprofile from Zero Hour to Generals. WWLib has FastAllocator added because it is a dependency in WWDebug.

Changes
* wwdebug : increases printing buffers from 1024 to 4096 bytes
* wwdebug : adds functionality to exit process on assertion fail
* wwmemlog : adds functionality to enable/disable memlog
* wwmemlog : adds new memory logging categories
* wwmemlog : improves performance of memlog by replacing mutex with critical section
* wwprofile : adds functionality to enable/disable profiler
* wwprofile : implements new profile log systems
