### PR TITLE
[GEN] Store StealthUpdate pointer in the Object class to avoid module lookups

### DIFF
--- a/Generals/Code/GameEngine/Include/GameLogic/Module/BehaviorModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/BehaviorModule.h
@@ -79,6 +79,7 @@ class SpecialPowerTemplate;
 class WeaponTemplate;
 class DamageInfo;
 class ParticleSystemTemplate;
+class StealthUpdate;
 
 
 //-------------------------------------------------------------------------------------------------
@@ -163,6 +164,7 @@ public:
 	virtual SpecialPowerModuleInterface* getSpecialPower() { return NULL; }
 	virtual UpdateModuleInterface* getUpdate() { return NULL; }
 	virtual UpgradeModuleInterface* getUpgrade() { return NULL; }
+	virtual StealthUpdate* getStealth() { return NULL; }
 
 	virtual ParkingPlaceBehaviorInterface* getParkingPlaceBehaviorInterface() { return NULL; }
 	virtual RebuildHoleBehaviorInterface* getRebuildHoleBehaviorInterface() { return NULL; }

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/StealthUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/StealthUpdate.h
@@ -123,6 +123,8 @@ public:
 	StealthUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
+	virtual StealthUpdate* getStealth() { return this; }
+
 	virtual UpdateSleepTime update();
 
 	//Still gets called, even if held -ML

--- a/Generals/Code/GameEngine/Include/GameLogic/Object.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Object.h
@@ -45,6 +45,7 @@
 #include "GameLogic/WeaponBonusConditionFlags.h"
 #include "GameLogic/WeaponSet.h"
 #include "GameLogic/WeaponSetFlags.h"
+#include "GameLogic/Module/StealthUpdate.h"
 
 //-----------------------------------------------------------------------------
 //           Forward References
@@ -271,6 +272,7 @@ public:
 
 	BodyModuleInterface* getBodyModule() const { return m_body; }
 	ContainModuleInterface* getContain() const { return m_contain; }
+	StealthUpdate* getStealth() const { return m_stealth; }
 	SpawnBehaviorInterface* getSpawnBehaviorInterface() const;
 
 
@@ -691,6 +693,7 @@ private:
 	// cache these, for convenience
 	ContainModuleInterface*				m_contain;
 	BodyModuleInterface*					m_body;
+	StealthUpdate*						m_stealth;
 
 	AIUpdateInterface*						m_ai;	///< ai interface (if any), cached for handy access. (duplicate of entry in the module array!)
 	PhysicsBehavior*							m_physics;	///< physics interface (if any), cached for handy access. (duplicate of entry in the module array!)

--- a/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -1093,8 +1093,7 @@ void Player::becomingLocalPlayer(Bool yes)
 					Drawable *draw = object->getDrawable();
 					if( draw )
 					{
-						static NameKeyType key_StealthUpdate = NAMEKEY( "StealthUpdate" );
-						StealthUpdate *update = (StealthUpdate*)object->findUpdateModule( key_StealthUpdate );
+						StealthUpdate *update = object->getStealth();
 						if( update && update->isDisguised() )
 						{
 							Player *disguisedPlayer = ThePlayerList->getNthPlayer( update->getDisguisedPlayerIndex() );

--- a/Generals/Code/GameEngine/Source/Common/System/Radar.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/Radar.cpp
@@ -426,8 +426,7 @@ void Radar::addObject( Object *obj )
 		//Because we have support for disguised units pretending to be units from another
 		//team, we need to intercept it here and make sure it's rendered appropriately
 		//based on which client is rendering it.
-		static NameKeyType key_StealthUpdate = NAMEKEY( "StealthUpdate" );
-		StealthUpdate *update = (StealthUpdate*)obj->findUpdateModule( key_StealthUpdate );
+		StealthUpdate *update = obj->getStealth();
 		if( update )
 		{
 			if( update->isDisguised() )

--- a/Generals/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -2126,8 +2126,7 @@ void Drawable::setStealthLook(StealthLookType look)
 				if( obj )
 				{
 					//Try to get the stealthupdate module and see if the opacity value is overriden.
-					static NameKeyType key_StealthUpdate = NAMEKEY("StealthUpdate");
-					StealthUpdate* stealth = (StealthUpdate *)obj->findUpdateModule(key_StealthUpdate);
+					StealthUpdate* stealth = obj->getStealth();
 					if( stealth )
 					{
 						if( stealth->isDisguised() )

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -2506,8 +2506,7 @@ void ControlBar::setPortraitByObject( Object *obj )
 				setPortraitByObject( NULL );
 				return;
 			}
-			static NameKeyType key_StealthUpdate = NAMEKEY("StealthUpdate");
-			StealthUpdate* stealth = (StealthUpdate *)obj->findUpdateModule(key_StealthUpdate);
+			StealthUpdate* stealth = obj->getStealth();
 			if( stealth && stealth->isDisguised() )
 			{
 				//Fake player upgrades too!

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -2218,8 +2218,7 @@ void InGameUI::createMouseoverHint( const GameMessage *msg )
 				//Because we have support for disguised units pretending to be units from another
 				//team, we need to intercept it here and make sure it's rendered appropriately
 				//based on which client is rendering it.
-				static NameKeyType key_StealthUpdate = NAMEKEY( "StealthUpdate" );
-				StealthUpdate *update = (StealthUpdate*)obj->findUpdateModule( key_StealthUpdate );
+				StealthUpdate *update = obj->getStealth();
 				if( update )
 				{
 					if( update->isDisguised() )

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
@@ -1620,8 +1620,7 @@ void AIGroup::groupMoveToPosition( const Coord3D *pos, Bool addWaypoint, Command
 				//Not stealthed, not detected -- so do auto-acquire while stealthed?
 				if( !ai->canAutoAcquireWhileStealthed() )
 				{
-					static NameKeyType key_StealthUpdate = NAMEKEY( "StealthUpdate" );
-					StealthUpdate* stealth = (StealthUpdate*)theUnit->findUpdateModule( key_StealthUpdate );
+					StealthUpdate* stealth = theUnit->getStealth();
 					if( stealth )
 					{
 						//Delay the mood check time (for autoacquire) until after the unit can stealth again.
@@ -1915,8 +1914,7 @@ void AIGroup::groupIdle(CommandSourceType cmdSource)
 					//Not stealthed, not detected -- so do auto-acquire while stealthed?
 					if( !ai->canAutoAcquireWhileStealthed() )
 					{
-						static NameKeyType key_StealthUpdate = NAMEKEY( "StealthUpdate" );
-						StealthUpdate* stealth = (StealthUpdate*)obj->findUpdateModule( key_StealthUpdate );
+						StealthUpdate* stealth = obj->getStealth();
 						if( stealth )
 						{
 							//Delay the mood check time (for autoacquire) until after the unit can stealth again.

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/MobNexusContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/MobNexusContain.cpp
@@ -442,8 +442,7 @@ Bool MobNexusContain::tryToEvacuate( Bool exposeStealthedUnits )
 
 			if( obj->isKindOf( KINDOF_STEALTH_GARRISON ) && exposeStealthedUnits )
 			{
-				static NameKeyType key_StealthUpdate = NAMEKEY( "StealthUpdate" );
-				StealthUpdate* stealth = (StealthUpdate*)obj->findUpdateModule( key_StealthUpdate );
+				StealthUpdate* stealth = obj->getStealth();
 				if( stealth )
 				{
 					stealth->markAsDetected();

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -533,8 +533,7 @@ void OpenContain::removeFromContainViaIterator( ContainedItemsList::iterator it,
 		m_stealthUnitsContained--;
 		if( exposeStealthUnits )
 		{
-			static NameKeyType key_StealthUpdate = NAMEKEY( "StealthUpdate" );
-			StealthUpdate* stealth = (StealthUpdate*)rider->findUpdateModule( key_StealthUpdate );
+			StealthUpdate* stealth = rider->getStealth();
 			if( stealth )
 			{
 				stealth->markAsDetected();
@@ -700,8 +699,7 @@ void OpenContain::onCollide( Object *other, const Coord3D *loc, const Coord3D *n
 				if( rider->isKindOf( KINDOF_STEALTH_GARRISON ) )
 				{
 					// aiExit is needed to walk away from the building well, but it doesn't take the Unstealth flag
-					static const NameKeyType key_StealthUpdate = NAMEKEY( "StealthUpdate" );
-					StealthUpdate* stealth = (StealthUpdate*)rider->findUpdateModule( key_StealthUpdate );
+					StealthUpdate* stealth = rider->getStealth();
 					if( stealth )
 					{
 						stealth->markAsDetected();
@@ -1239,8 +1237,7 @@ void OpenContain::markAllPassengersDetected( )
 		// call it
 		if( rider->isKindOf( KINDOF_STEALTH_GARRISON ) )
 		{
-			static const NameKeyType key_StealthUpdate = NAMEKEY( "StealthUpdate" );
-			StealthUpdate* stealth = (StealthUpdate*)rider->findUpdateModule( key_StealthUpdate );
+			StealthUpdate* stealth = rider->getStealth();
 			if( stealth )
 			{
 				stealth->markAsDetected();

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -183,6 +183,7 @@ Object::Object( const ThingTemplate *tt, const ObjectStatusMaskType &objectStatu
 	m_behaviors(NULL),
 	m_body(NULL),
 	m_contain(NULL),
+	m_stealth(NULL),
 	m_partitionData(NULL),
 	m_radarData(NULL),
 	m_drawable(NULL),
@@ -364,6 +365,13 @@ Object::Object( const ThingTemplate *tt, const ObjectStatusMaskType &objectStatu
 		{
 			DEBUG_ASSERTCRASH(m_contain == NULL, ("Duplicate containers"));
 			m_contain = contain;
+		}
+
+		StealthUpdate* stealth = newMod->getStealth();
+		if ( stealth )
+		{
+			DEBUG_ASSERTCRASH( m_stealth == NULL, ("DuplicateStealthUpdates!") );
+			m_stealth = stealth;
 		}
 
 		AIUpdateInterface* ai = newMod->getAIUpdateInterface();

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
@@ -5458,8 +5458,7 @@ Bool PartitionFilterStealthedAndUndetected::allow( Object *objOther )
 		else
 		{
 			//Exception case -- bomb trucks can't be considered stealthed units when they are disguised as the enemy.
-			static NameKeyType key_StealthUpdate = NAMEKEY( "StealthUpdate" );
-			StealthUpdate *update = (StealthUpdate*)objOther->findUpdateModule( key_StealthUpdate );
+			StealthUpdate *update = objOther->getStealth();
 			if( update && update->isDisguised() )
 			{
 				Player *ourPlayer = m_obj->getControllingPlayer();

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
@@ -580,8 +580,7 @@ Bool SpecialAbilityUpdate::handlePackingProcessing()
 		if( getSpecialAbilityUpdateModuleData()->m_loseStealthOnTrigger &&
 			m_animFrames < getSpecialAbilityUpdateModuleData()->m_preTriggerUnstealthFrames)
 		{
-			static NameKeyType key_StealthUpdate = NAMEKEY( "StealthUpdate" );
-			StealthUpdate* stealth = (StealthUpdate*)getObject()->findUpdateModule( key_StealthUpdate );
+			StealthUpdate* stealth = getObject()->getStealth();
 			if( stealth )
 			{
 				stealth->markAsDetected();
@@ -1440,10 +1439,9 @@ void SpecialAbilityUpdate::triggerAbilityEffect()
 		case SPECIAL_DISGUISE_AS_VEHICLE:
 		{
 			Object *target = TheGameLogic->findObjectByID( m_targetID );
-			static NameKeyType key_StealthUpdate = NAMEKEY( "StealthUpdate" );
 			if( target )
 			{
-				StealthUpdate *update = (StealthUpdate*)object->findUpdateModule( key_StealthUpdate );
+				StealthUpdate *update = object->getStealth();
 				if( update )
 				{
 					update->disguiseAsObject( target );
@@ -1456,8 +1454,7 @@ void SpecialAbilityUpdate::triggerAbilityEffect()
 
 	if( data->m_loseStealthOnTrigger && okToLoseStealth)
 	{
-		static NameKeyType key_StealthUpdate = NAMEKEY( "StealthUpdate" );
-		StealthUpdate* stealth = (StealthUpdate*)object->findUpdateModule( key_StealthUpdate );
+		StealthUpdate* stealth = object->getStealth();
 		if( stealth )
 		{
 			stealth->markAsDetected();

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/StealthDetectorUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/StealthDetectorUpdate.cpp
@@ -207,8 +207,7 @@ UpdateSleepTime StealthDetectorUpdate::update( void )
 		if ( them->isEffectivelyDead() )
 			continue;
 
-		static NameKeyType key_StealthUpdate = NAMEKEY("StealthUpdate");
-		StealthUpdate* stealth = (StealthUpdate *)them->findUpdateModule(key_StealthUpdate);
+		StealthUpdate* stealth = them->getStealth();
 		if ( stealth ) 
 		{
 
@@ -324,8 +323,7 @@ UpdateSleepTime StealthDetectorUpdate::update( void )
 				{
 					rider = *it;
 
-					static NameKeyType key_StealthUpdate = NAMEKEY("StealthUpdate");
-					StealthUpdate* stealth = (StealthUpdate *)rider->findUpdateModule(key_StealthUpdate);
+					StealthUpdate* stealth = rider->getStealth();
 					if ( stealth ) 
 					{
 						// we have found someone

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/StealthUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/StealthUpdate.cpp
@@ -647,8 +647,7 @@ void StealthUpdate::disguiseAsObject( const Object *target )
 	const StealthUpdateModuleData *data = getStealthUpdateModuleData();
 	if( target && target->getControllingPlayer() )
 	{
-		static NameKeyType key_StealthUpdate = NAMEKEY( "StealthUpdate" );
-		StealthUpdate* stealth = (StealthUpdate*)target->findUpdateModule( key_StealthUpdate );
+		StealthUpdate* stealth = target->getStealth();
 		if( stealth && stealth->getDisguisedTemplate() )
 		{
 			m_disguiseAsTemplate				= stealth->getDisguisedTemplate();

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/WeaponSet.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/WeaponSet.cpp
@@ -425,7 +425,6 @@ Bool WeaponSet::isAnyWithinTargetPitch(const Object* obj, const Object* victim) 
 //-------------------------------------------------------------------------------------------------
 CanAttackResult WeaponSet::getAbleToAttackSpecificObject( AbleToAttackType attackType, const Object* source, const Object* victim, CommandSourceType commandSource ) const
 {
-  static NameKeyType key_StealthUpdate = NAMEKEY( "StealthUpdate" );
 
 	// basic sanity checks.
 	if (!source || 
@@ -467,7 +466,7 @@ CanAttackResult WeaponSet::getAbleToAttackSpecificObject( AbleToAttackType attac
     // force-attack allows you to attack disguised things, which also happen to be stealthed.
     // since we normally disallow attacking stealthed things (even via force-fire), we check
     // for disguised and explicitly ignore stealth in that case
-	  StealthUpdate *update = (StealthUpdate*)victim->findUpdateModule( key_StealthUpdate );
+	  StealthUpdate *update = victim->getStealth();
     if (update && update->isDisguised())
   	  allowStealthToPreventAttacks = FALSE;
   }
@@ -485,7 +484,7 @@ CanAttackResult WeaponSet::getAbleToAttackSpecificObject( AbleToAttackType attac
 		else
 		{
 			//Exception case -- don't return false if we are a bomb truck disguised as an enemy vehicle.
-			StealthUpdate *update = (StealthUpdate*)victim->findUpdateModule( key_StealthUpdate );
+			StealthUpdate *update = victim->getStealth();
 			if( update && update->isDisguised() )
 			{
 				Player *ourPlayer = source->getControllingPlayer();

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/Common/System/W3DRadar.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/Common/System/W3DRadar.cpp
@@ -698,8 +698,7 @@ void W3DRadar::renderObjectList( const RadarObject *listHead, TextureClass *text
 		// Now it twinkles for any stealthed object, whether locally controlled or neutral-observier-viewed
 		if( obj->testStatus( OBJECT_STATUS_STEALTHED ) )
 		{
-			static NameKeyType key_StealthUpdate = NAMEKEY( "StealthUpdate" );
-			StealthUpdate* stealth = (StealthUpdate*)obj->findUpdateModule( key_StealthUpdate );
+			StealthUpdate* stealth = obj->getStealth();
 			if( !stealth )
 				continue;
 


### PR DESCRIPTION
This is backported from change done in ZH, shouldn't break any replays or saves.