### PR TITLE
[CMAKE] Make W3DView only depend on WWVegas

### DIFF
--- a/Core/Libraries/Source/WWVegas/WWStub/wwallocstub.cpp
+++ b/Core/Libraries/Source/WWVegas/WWStub/wwallocstub.cpp
@@ -63,3 +63,23 @@ void operator delete[](void * p, const char *, int)
 }
 
 #endif
+
+void* createW3DMemPool(const char *poolName, int allocationSize)
+{
+	return NULL;
+}
+
+void* allocateFromW3DMemPool(void* pool, int allocationSize)
+{
+	return malloc(allocationSize);
+}
+
+void* allocateFromW3DMemPool(void* pool, int allocationSize, const char* msg, int unused)
+{
+	return malloc(allocationSize);
+}
+
+void freeFromW3DMemPool(void* pool, void* p)
+{
+	free(p);
+}

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/CMakeLists.txt
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(z_wwvegas INTERFACE)
 target_include_directories(z_wwvegas INTERFACE
     .
     WW3D2
+    WWAudio
     WWDownload
     WWMath
     WWSaveLoad

--- a/GeneralsMD/Code/Tools/W3DView/CMakeLists.txt
+++ b/GeneralsMD/Code/Tools/W3DView/CMakeLists.txt
@@ -171,14 +171,20 @@ add_executable(z_w3dview WIN32)
 target_sources(z_w3dview PRIVATE ${W3DVIEW_SRC})
 
 target_link_libraries(z_w3dview PRIVATE
+    core_config
+    core_utility
+    core_wwstub # avoid linking GameEngine
+    d3d8
+    d3d8lib
+    d3dx8
     dbghelplib
     imm32
+    milesstub
     Version
     vfw32
     winmm
     z_wwaudio
-    z_wwcommon
-    z_gameenginedevice
+    z_wwvegas
 )
 
 if(WIN32 OR "${CMAKE_SYSTEM}" MATCHES "Windows")

--- a/GeneralsMD/Code/Tools/wdump/CMakeLists.txt
+++ b/GeneralsMD/Code/Tools/wdump/CMakeLists.txt
@@ -18,11 +18,12 @@ set_target_properties(z_wdump PROPERTIES OUTPUT_NAME wdump)
 target_sources(z_wdump PRIVATE ${WDUMP_SRC})
 
 target_link_libraries(z_wdump PRIVATE
+    core_config
+    core_wwstub # avoid linking GameEngine
     dbghelplib
     imm32
     vfw32
     winmm
-    core_wwstub # avoid linking GameEngine
     z_wwvegas
 )
 


### PR DESCRIPTION
This change reduces the library dependencies of w3dview.

Before:
![image](https://github.com/user-attachments/assets/2328f785-5585-407b-817c-b198d5f61d92)

After:
![image](https://github.com/user-attachments/assets/09183f17-b54d-4f24-a09a-3299aa2b016e)
