### PR TITLE
[GEN] Backport various crash and memory fixes from Zero Hour

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/Science.h
+++ b/Generals/Code/GameEngine/Include/Common/Science.h
@@ -81,6 +81,8 @@ class ScienceStore : public SubsystemInterface
 	friend class ScienceInfo;
 
 public:
+	virtual ~ScienceStore();
+
 	void init();
 	void reset();
 	void update() { }

--- a/Generals/Code/GameEngine/Include/Common/SparseMatchFinder.h
+++ b/Generals/Code/GameEngine/Include/Common/SparseMatchFinder.h
@@ -176,16 +176,22 @@ public:
 	const MATCHABLE* findBestInfo(const std::vector<MATCHABLE>& v, const BITSET& bits) const
 	{
 		typename MatchMap::const_iterator it = m_bestMatches.find(bits);
+
+		const MATCHABLE *first = NULL;
 		if (it != m_bestMatches.end())
 		{
-			return (*it).second;
+			first = (*it).second;
 		}
-
+		if (first != NULL) {
+			return first;
+		}
+		
 		const MATCHABLE* info = findBestInfoSlow(v, bits);
 
 		DEBUG_ASSERTCRASH(info != NULL, ("no suitable match for criteria was found!\n"));
-		if (info != NULL)
+		if (info != NULL) {
 			m_bestMatches[bits] = info;
+		}
 
 		return info;
 	}

--- a/Generals/Code/GameEngine/Include/GameLogic/RankInfo.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/RankInfo.h
@@ -49,11 +49,13 @@ public:
 	Int							m_sciencePurchasePointsGranted;
 	ScienceVec			m_sciencesGranted;
 };
-EMPTY_DTOR(RankInfo)
+//EMPTY_DTOR(RankInfo)
 
 //-------------------------------------------------------------------------------------------------
 class RankInfoStore : public SubsystemInterface
 {
+public:
+	virtual ~RankInfoStore();
 
 public:
 	void init();

--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -1055,8 +1055,10 @@ GlobalData::~GlobalData( void )
 	if (m_weaponBonusSet)
 		m_weaponBonusSet->deleteInstance();
 
-	if( m_theOriginal == this )
+	if( m_theOriginal == this )	{
 		m_theOriginal = NULL;
+		TheWritableGlobalData = NULL;
+	}
 
 }  // end ~GlobalData
 

--- a/Generals/Code/GameEngine/Source/Common/MiniLog.cpp
+++ b/Generals/Code/GameEngine/Source/Common/MiniLog.cpp
@@ -61,6 +61,8 @@ LogClass::~LogClass()
 
 void LogClass::log(const char *fmt, ...)
 {
+	if (!m_fp)
+		return;
 	static char buf[1024];
 	static Int lastFrame = 0;
 	static Int lastIndex = 0;

--- a/Generals/Code/GameEngine/Source/Common/RTS/Science.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/Science.cpp
@@ -49,6 +49,23 @@ void ScienceStore::init()
 }
 
 //-----------------------------------------------------------------------------
+ScienceStore::~ScienceStore()
+{
+	// nope.
+	//m_sciences.clear();
+
+	// go through all sciences and delete any overrides
+	for (ScienceInfoVec::iterator it = m_sciences.begin(); it != m_sciences.end(); /*++it*/)
+	{
+		ScienceInfo* si = *it;
+		++it;
+		if (si) {
+			si->deleteInstance();
+		}
+	}
+}
+
+//-----------------------------------------------------------------------------
 void ScienceStore::reset()
 {
 	// nope.

--- a/Generals/Code/GameEngine/Source/Common/System/Debug.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/Debug.cpp
@@ -141,7 +141,7 @@ static void doStackDump();
 inline Bool ignoringAsserts()
 {
 #ifdef DEBUG_CRASHING
-	return !DX8Wrapper_IsWindowed || TheGlobalData->m_debugIgnoreAsserts;
+	return !DX8Wrapper_IsWindowed || (TheGlobalData&&TheGlobalData->m_debugIgnoreAsserts);
 #else
 	return !DX8Wrapper_IsWindowed;
 #endif
@@ -468,7 +468,7 @@ void DebugCrash(const char *format, ...)
 	doLogOutput(theCrashBuffer);
 #endif
 #ifdef DEBUG_STACKTRACE
-	if (!TheGlobalData->m_debugIgnoreStackTrace)
+	if (!(TheGlobalData && TheGlobalData->m_debugIgnoreStackTrace))
 	{
 		doStackDump();
 	}
@@ -662,6 +662,10 @@ void ReleaseCrash(const char *reason)
 
 	char prevbuf[ _MAX_PATH ];
 	char curbuf[ _MAX_PATH ];
+
+	if (TheGlobalData==NULL) {
+		return; // We are shutting down, and TheGlobalData has been freed.  jba. [4/15/2003]
+	}
 
 	strcpy(prevbuf, TheGlobalData->getPath_UserData().str());
 	strcat(prevbuf, RELEASECRASH_FILE_NAME_PREV);

--- a/Generals/Code/GameEngine/Source/Common/System/Xfer.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/Xfer.cpp
@@ -540,7 +540,7 @@ void Xfer::xferScienceType( ScienceType *science )
 	else
 	{
 
-		DEBUG_CRASH(( "xferScienceVec - Unknown xfer mode '%d'\n", getXferMode() ));
+		DEBUG_CRASH(( "xferScienceType - Unknown xfer mode '%d'\n", getXferMode() ));
 		throw XFER_MODE_UNKNOWN;
 
 	}  // end else
@@ -577,8 +577,12 @@ void Xfer::xferScienceVec( ScienceVec *scienceVec )
 		// vector should be empty at this point
 		if( scienceVec->empty() == FALSE )
 		{
-			DEBUG_CRASH(( "xferScienceVec - vector is not empty, but should be\n" ));
-			throw XFER_LIST_NOT_EMPTY;
+			// Not worth an assert, since things can give you Sciences on creation.  Just handle it and load.
+			scienceVec->clear();
+
+			// Homework for today.  Write 2000 words reconciling "Your code must never crash" with "Intentionally putting crashes in the code".  Fucktard.
+//			DEBUG_CRASH(( "xferScienceVec - vector is not empty, but should be\n" ));
+//			throw XFER_LIST_NOT_EMPTY;
 		}
 
 		for( UnsignedShort i = 0; i < count; ++i )

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -252,7 +252,11 @@ void ControlBar::populatePurchaseScience( Player* player )
 
 			setControlCommand( m_sciencePurchaseWindowsRank3[ i ], commandButton );
 			ScienceType	st = SCIENCE_INVALID; 
-			st = commandButton->getScienceVec()[ 0 ];
+			ScienceVec sv = commandButton->getScienceVec();
+			if (! sv.empty())
+			{
+				st = sv[ 0 ];
+			}
 
 			if( player->isScienceDisabled( st ) )
 			{
@@ -940,6 +944,10 @@ ControlBar::~ControlBar( void )
 	}
 
 	m_radarAttackGlowWindow = NULL;
+
+	if (m_rightHUDCameoWindow && m_rightHUDCameoWindow->winGetUserData())
+		delete m_rightHUDCameoWindow->winGetUserData();
+
 }  // end ~ControlBar
 void ControlBarPopupDescriptionUpdateFunc( WindowLayout *layout, void *param );
 
@@ -1017,9 +1025,12 @@ void ControlBar::init( void )
 			id = TheNameKeyGenerator->nameToKey( windowName.str() );
 			m_commandWindows[ i ] = 
 				TheWindowManager->winGetWindowFromId( m_contextParent[ CP_COMMAND ], id );
-			m_commandWindows[ i ]->winGetPosition(&commandPos.x, &commandPos.y);
-			m_commandWindows[ i ]->winGetSize(&commandSize.x, &commandSize.y);
-			m_commandWindows[ i ]->winSetStatus( WIN_STATUS_USE_OVERLAY_STATES );
+			if (m_commandWindows[ i ])
+			{
+				m_commandWindows[ i ]->winGetPosition(&commandPos.x, &commandPos.y);
+				m_commandWindows[ i ]->winGetSize(&commandSize.x, &commandSize.y);
+				m_commandWindows[ i ]->winSetStatus( WIN_STATUS_USE_OVERLAY_STATES );
+			}
 
 	// removed from multiplayer branch
 //			windowName.format( "ControlBar.wnd:CommandMarker%02d", i + 1 );
@@ -1052,7 +1063,7 @@ void ControlBar::init( void )
 			m_sciencePurchaseWindowsRank3[ i ]->winSetStatus( WIN_STATUS_USE_OVERLAY_STATES );
 		}  // end for i
 		
-		for( i = 0; i < MAX_PURCHASE_SCIENCE_RANK_8; i++ )
+		for( i = 0; i < MAX_PURCHASE_SCIENCE_RANK_8; i++ ) 
 		{
 			windowName.format( "GeneralsExpPoints.wnd:ButtonRank8Number%d", i );
 			id = TheNameKeyGenerator->nameToKey( windowName.str() );
@@ -1933,7 +1944,10 @@ CommandSet* ControlBar::findNonConstCommandSet( const AsciiString& name )
 const CommandButton *ControlBar::findCommandButton( const AsciiString& name ) 
 { 
 	CommandButton *btn =  findNonConstCommandButton(name); 
-	btn = (CommandButton *)btn->friend_getFinalOverride();
+	if( btn )
+	{
+		btn = (CommandButton *)btn->friend_getFinalOverride();
+	}
 	return btn; 
 }
 
@@ -2059,7 +2073,11 @@ void ControlBar::switchToContext( ControlBarContext context, Drawable *draw )
 			//Clear any potentially flashing buttons!
 			for( int i = 0; i < MAX_COMMANDS_PER_SET; i++ )
 			{
-				m_commandWindows[ i ]->winClearStatus( WIN_STATUS_FLASHING );
+				// the implementation won't necessarily use the max number of windows possible
+				if (m_commandWindows[ i ]) 
+				{
+					m_commandWindows[ i ]->winClearStatus( WIN_STATUS_FLASHING );
+				}
 			}
 			// if there is a current selected drawable then we wil display a selection portrait if present
 			if( draw )

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarCommand.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarCommand.cpp
@@ -179,6 +179,8 @@ void ControlBar::doTransportInventoryUI( Object *transport, const CommandSet *co
 	const CommandButton *commandButton;
 	for( Int i = 0; i < MAX_COMMANDS_PER_SET; i++ )
 	{
+		// our implementation doesn't necessarily make use of the max possible command buttons
+		if (! m_commandWindows[ i ]) continue;
 
 		// get command button
 		commandButton = commandSet->getCommandButton(i);
@@ -212,6 +214,9 @@ void ControlBar::doTransportInventoryUI( Object *transport, const CommandSet *co
  			{
  				m_commandWindows[ i ]->winHide( TRUE );
  			}
+
+      
+     //  is this where we set the cameos disabled when container is subdued?
 
 			// if we've counted more UI spots than the transport can hold, hide this command window
 			if( inventoryCommandCount > transportMax )
@@ -279,7 +284,10 @@ void ControlBar::populateCommand( Object *obj )
 
 		// hide all the buttons
 		for( i = 0; i < MAX_COMMANDS_PER_SET; i++ )
-			m_commandWindows[ i ]->winHide( TRUE );
+			if (m_commandWindows[ i ])
+			{
+				m_commandWindows[ i ]->winHide( TRUE );
+			}
 
 		// nothing left to do
 		return;
@@ -294,6 +302,8 @@ void ControlBar::populateCommand( Object *obj )
 	const CommandButton *commandButton;
 	for( i = 0; i < MAX_COMMANDS_PER_SET; i++ )
 	{
+		// our implementation doesn't necessarily make use of the max possible command buttons
+		if (! m_commandWindows[ i ]) continue;
 
 		// get command button
 		commandButton = commandSet->getCommandButton(i);
@@ -377,7 +387,7 @@ void ControlBar::populateCommand( Object *obj )
 								//Now we have to search through the command buttons to find a matching purchase science button.
 								for( const CommandButton *command = m_commandButtons; command; command = command->getNext() )
 								{
-									if( command->getCommandType() == GUI_COMMAND_PURCHASE_SCIENCE )
+									if( command && command->getCommandType() == GUI_COMMAND_PURCHASE_SCIENCE )
 									{
 										//All purchase sciences specify a single science.
 										if( command->getScienceVec().empty() )
@@ -731,6 +741,9 @@ void ControlBar::updateContextCommand( void )
 	{
 		GameWindow *win;
 		const CommandButton *command;
+
+		// our implementation doesn't necessarily make use of the max possible command buttons
+		if (! m_commandWindows[ i ]) continue;
 
 		// get the window
 		win = m_commandWindows[ i ];
@@ -1277,7 +1290,7 @@ CommandAvailability ControlBar::getCommandAvailability( const CommandButton *com
 			}
 			else if( SpecialAbilityUpdate *spUpdate = obj->findSpecialAbilityUpdate( command->getSpecialPowerTemplate()->getSpecialPowerType() ) )
 			{
-				if( spUpdate->isPowerCurrentlyInUse( command ) )
+				if( spUpdate && spUpdate->isPowerCurrentlyInUse( command ) )
 				{
 					return COMMAND_RESTRICTED;
 				}

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarCommandProcessing.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarCommandProcessing.cpp
@@ -95,6 +95,11 @@ CBCommandStatus ControlBar::processCommandUI( GameWindow *control,
 {
 	// get the command pointer from the control user data we put in the button
 	const CommandButton *commandButton = (const CommandButton *)GadgetButtonGetData(control);
+	if( !commandButton )
+	{
+		DEBUG_CRASH( ("ControlBar::processCommandUI() -- Button activated has no data. Ignoring...") );
+		return CBC_COMMAND_NOT_USED;
+	}
 
 	// sanity, we won't process messages if we have no source object, 
 	// unless we're CB_CONTEXT_PURCHASE_SCIENCE or GUI_COMMAND_SPECIAL_POWER_FROM_COMMAND_CENTER

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarMultiSelect.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarMultiSelect.cpp
@@ -96,7 +96,10 @@ void ControlBar::addCommonCommands( Drawable *draw, Bool firstDrawable )
 		{
 
 			m_commonCommands[ i ] = NULL;
-			m_commandWindows[ i ]->winHide( TRUE );
+			if (m_commandWindows[ i ])
+			{
+				m_commandWindows[ i ]->winHide( TRUE );
+			}
 			// After Every change to the m_commandWIndows, we need to show fill in the missing blanks with the images
 	// removed from multiplayer branch
 			//showCommandMarkers();
@@ -118,6 +121,8 @@ void ControlBar::addCommonCommands( Drawable *draw, Bool firstDrawable )
 		// just add each command that is classified as a common command
 		for( i = 0; i < MAX_COMMANDS_PER_SET; i++ )
 		{
+			// our implementation doesn't necessarily make use of the max possible command buttons
+			if (! m_commandWindows[ i ]) continue;
 
 			// get command
 			command = commandSet->getCommandButton(i);
@@ -148,6 +153,9 @@ void ControlBar::addCommonCommands( Drawable *draw, Bool firstDrawable )
 		for( i = 0; i < MAX_COMMANDS_PER_SET; i++ )
 		{
 		
+			// our implementation doesn't necessarily make use of the max possible command buttons
+			if (! m_commandWindows[ i ]) continue;
+
 			// get the command
 			command = commandSet->getCommandButton(i);
 					
@@ -213,7 +221,12 @@ void ControlBar::populateMultiSelect( void )
 
 	// by default, hide all the controls in the command section
 	for( Int i = 0; i < MAX_COMMANDS_PER_SET; i++ )
-		m_commandWindows[ i ]->winHide( TRUE );
+	{
+		if (m_commandWindows[ i ])
+		{
+			m_commandWindows[ i ]->winHide( TRUE );
+		}
+	}
 
 	// sanity
 	DEBUG_ASSERTCRASH( TheInGameUI->getSelectCount() > 1,
@@ -333,6 +346,9 @@ void ControlBar::updateContextMultiSelect( void )
 			// get the control window
 			win = m_commandWindows[ i ];
 
+			// our implementation doesn't necessarily make use of the max possible command buttons
+			if (!win) continue;
+
 			// don't consider hidden windows
 			if( win->winIsHidden() == TRUE )
 				continue;
@@ -389,6 +405,8 @@ void ControlBar::updateContextMultiSelect( void )
 	//
 	for( i = 0; i < MAX_COMMANDS_PER_SET; i++ )
 	{
+		// our implementation doesn't necessarily make use of the max possible command buttons
+		if (! m_commandWindows[ i ]) continue;
 
 		// don't consider hidden commands
 		if( m_commandWindows[ i ]->winIsHidden() == TRUE )

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishGameOptionsMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishGameOptionsMenu.cpp
@@ -778,7 +778,12 @@ void updateMapStartSpots( GameInfo *myGame, GameWindow *buttonMapStartPositions[
 	if (it == TheMapCache->end())
 	{
 		for (Int i = 0; i < MAX_SLOTS; ++i)
-			buttonMapStartPositions[i]->winHide(TRUE);
+    {
+      if ( buttonMapStartPositions[i] != NULL )
+      {
+  			buttonMapStartPositions[i]->winHide(TRUE);
+      }
+    }
 		return;
 	}
 	MapMetaData mmd = it->second;
@@ -786,14 +791,20 @@ void updateMapStartSpots( GameInfo *myGame, GameWindow *buttonMapStartPositions[
 	Int i = 0;
 	for(; i < MAX_SLOTS; ++i)
 	{
-		GadgetButtonSetText(buttonMapStartPositions[i], UnicodeString::TheEmptyString);
-		if (!onLoadScreen)
-		{
-			buttonMapStartPositions[i]->winSetTooltip(TheGameText->fetch("TOOLTIP:StartPosition"));
-		}
+    if ( buttonMapStartPositions[i] != NULL )
+    {
+		  GadgetButtonSetText(buttonMapStartPositions[i], UnicodeString::TheEmptyString);
+		  if (!onLoadScreen)
+		  {
+			  buttonMapStartPositions[i]->winSetTooltip(TheGameText->fetch("TOOLTIP:StartPosition"));
+		  }
+    }
 	}
 	for( i = 0; i < MAX_SLOTS; ++i)
 	{
+    if ( buttonMapStartPositions[i] == NULL )
+      continue;
+
 		GameSlot *gs =myGame->getSlot(i);
 		if(onLoadScreen)
 		{

--- a/Generals/Code/GameEngine/Source/GameClient/Input/Mouse.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Input/Mouse.cpp
@@ -389,6 +389,7 @@ void Mouse::checkForDrag( void )
 
 }  // end checkForDrag
 
+
 //-------------------------------------------------------------------------------------------------
 /** Check for mouse click, using allowed drag forgiveness */
 //-------------------------------------------------------------------------------------------------
@@ -409,6 +410,7 @@ Bool Mouse::isClick(const ICoord2D *anchor, const ICoord2D *dest, UnsignedInt pr
 	}
 	return TRUE;
 }
+
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -636,7 +638,8 @@ void Mouse::reset( void )
 	///@ todo Write Mouse::reset() if there needs to be anything here
 
 	// reset the text of the cursor text
-	m_cursorTextDisplayString->reset();
+  if ( m_cursorTextDisplayString )
+  	m_cursorTextDisplayString->reset();
 
 }  // end reset
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
@@ -136,7 +136,7 @@ Object *Bridge::createTower( Coord3D *worldPos,
 	if( towerTemplate == NULL || bridge == NULL )
 	{
 
-		DEBUG_CRASH(( "createTower: Invalid params\n" ));
+		DEBUG_CRASH(( "Bridge::createTower(): Invalid params\n" ));
 		return NULL;
 
 	}  // end if
@@ -430,9 +430,11 @@ Bridge::Bridge(Object *bridgeObj)
 
 		}  // end switch
 		tower = createTower( &pos, type, towerTemplate, bridgeObj );
-
-		// store the tower object ID
-		m_bridgeInfo.towerObjectID[ i ] = tower->getID();
+		if( tower )
+		{
+			// store the tower object ID
+			m_bridgeInfo.towerObjectID[ i ] = tower->getID();
+		}
 
 	}  // end for, i
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2114,6 +2114,9 @@ void DozerAIUpdate::internalCancelTask( DozerTask task )
 
 	// sanity
 	DEBUG_ASSERTCRASH( task >= 0 && task < DOZER_NUM_TASKS, ("Illegal dozer task '%d'\n", task) );
+	
+	if(task < 0 || task >= DOZER_NUM_TASKS)
+		return;  //DAMNIT!  You CANNOT assert and then not handle the damn error!  The.  Code.  Must.  Not.  Crash.
 
 	// call the single method that gets called for completing and canceling tasks
 	internalTaskCompleteOrCancelled( task );

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -43,6 +43,7 @@
 #include "Common/RandomValue.h"
 #include "Common/GlobalData.h"
 #include "Common/ResourceGatheringManager.h"
+#include "Common/Upgrade.h"
 
 #include "GameClient/Drawable.h"
 #include "GameClient/GameText.h"
@@ -775,6 +776,9 @@ void WorkerAIUpdate::internalCancelTask( DozerTask task )
 
 	// sanity
 	DEBUG_ASSERTCRASH( task >= 0 && task < DOZER_NUM_TASKS, ("Illegal dozer task '%d'\n", task) );
+	
+	if(task < 0 || task >= DOZER_NUM_TASKS)
+		return;  //DAMNIT!  You CANNOT assert and then not handle the damn error!  The.  Code.  Must.  Not.  Crash.
 
 	// call the single method that gets called for completing and canceling tasks
 	internalTaskCompleteOrCancelled( task );

--- a/Generals/Code/GameEngine/Source/GameLogic/System/RankInfo.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/RankInfo.cpp
@@ -42,6 +42,28 @@ RankInfoStore* TheRankInfoStore = NULL;
 #endif
 
 //-----------------------------------------------------------------------------
+RankInfo::~RankInfo()
+{
+}
+
+
+//-----------------------------------------------------------------------------
+RankInfoStore::~RankInfoStore()
+{
+	Int level;
+	for (level =0; level < getRankLevelCount(); level++)
+	{
+		RankInfo* ri = m_rankInfos[level];
+		if (ri)
+		{
+			ri->deleteInstance();
+		}
+	}
+	m_rankInfos.clear();
+}
+
+
+//-----------------------------------------------------------------------------
 void RankInfoStore::init()
 {
 	DEBUG_ASSERTCRASH(m_rankInfos.empty(), ("Hmm"));

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTruckDraw.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTruckDraw.cpp
@@ -265,7 +265,8 @@ void W3DTruckDraw::enableEmitters( Bool enable  )
 	}
 }
 //-------------------------------------------------------------------------------------------------
-void W3DTruckDraw::updateBones( void ) {
+void W3DTruckDraw::updateBones( void ) 
+{
 	if( getW3DTruckDrawModuleData() ) 
 	{
 		//Front tires
@@ -273,28 +274,25 @@ void W3DTruckDraw::updateBones( void ) {
 		{
 			m_frontLeftTireBone = getRenderObject()->Get_Bone_Index(getW3DTruckDrawModuleData()->m_frontLeftTireBoneName.str());
 			DEBUG_ASSERTCRASH(m_frontLeftTireBone, ("Missing front-left tire bone %s in model %s\n", getW3DTruckDrawModuleData()->m_frontLeftTireBoneName.str(), getRenderObject()->Get_Name()));
-			
+		}
+
+		if( !getW3DTruckDrawModuleData()->m_frontRightTireBoneName.isEmpty() )
+		{
 			m_frontRightTireBone = getRenderObject()->Get_Bone_Index(getW3DTruckDrawModuleData()->m_frontRightTireBoneName.str());
 			DEBUG_ASSERTCRASH(m_frontRightTireBone, ("Missing front-right tire bone %s in model %s\n", getW3DTruckDrawModuleData()->m_frontRightTireBoneName.str(), getRenderObject()->Get_Name()));
-			
-			if (!m_frontRightTireBone ) 
-			{
-				m_frontLeftTireBone = 0;
-			}
 		}
+
 		//Rear tires
 		if( !getW3DTruckDrawModuleData()->m_rearLeftTireBoneName.isEmpty() ) 
 		{
 			m_rearLeftTireBone = getRenderObject()->Get_Bone_Index(getW3DTruckDrawModuleData()->m_rearLeftTireBoneName.str());
 			DEBUG_ASSERTCRASH(m_rearLeftTireBone, ("Missing rear-left tire bone %s in model %s\n", getW3DTruckDrawModuleData()->m_rearLeftTireBoneName.str(), getRenderObject()->Get_Name()));
+		}
 
+		if( !getW3DTruckDrawModuleData()->m_rearRightTireBoneName.isEmpty() ) 
+		{
 			m_rearRightTireBone = getRenderObject()->Get_Bone_Index(getW3DTruckDrawModuleData()->m_rearRightTireBoneName.str());
 			DEBUG_ASSERTCRASH(m_rearRightTireBone, ("Missing rear-left tire bone %s in model %s\n", getW3DTruckDrawModuleData()->m_rearRightTireBoneName.str(), getRenderObject()->Get_Name()));
-
-			if (!m_rearRightTireBone) 
-			{
-				m_rearLeftTireBone = 0;
-			}
 		}
 
 		//midFront tires

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DBibBuffer.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DBibBuffer.cpp
@@ -92,10 +92,16 @@ void W3DBibBuffer::loadBibsInVertexAndIndexBuffers(void)
 	if (!m_anythingChanged) {
 		return;
 	}
+
 	m_curNumBibVertices = 0;
 	m_curNumBibIndices = 0;
 	m_curNumNormalBibIndices = 0;
 	m_curNumNormalBibVertex = 0;
+
+	if (m_numBibs==0) {
+		return;	
+	}
+
 	VertexFormatXYZDUV1 *vb;
 	UnsignedShort *ib;
 	// Lock the buffers.

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DBridgeBuffer.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DBridgeBuffer.cpp
@@ -72,6 +72,12 @@
 #include "WW3D2/meshmdl.h"
 #include "WW3D2/scene.h"
 
+#ifdef _INTERNAL
+// for occasional debugging...
+//#pragma optimize("", off)
+//#pragma MESSAGE("************************************** WARNING, optimization disabled for debugging purposes")
+#endif
+
 //-----------------------------------------------------------------------------
 //         Private Data                                                     
 //-----------------------------------------------------------------------------
@@ -130,7 +136,7 @@ are already set.  */
 //=============================================================================
 void W3DBridge::renderBridge(Bool wireframe)
 {
-	if (m_visible) {
+	if (m_visible && m_numPolygons && m_numVertex) {
 		if (!wireframe) DX8Wrapper::Set_Texture(0,m_bridgeTexture);
 		// Draw all the bridges.
 		DX8Wrapper::Draw_Triangles(	m_firstIndex, m_numPolygons, m_firstVertex,	m_numVertex);
@@ -514,7 +520,17 @@ void W3DBridge::getIndicesNVertices(UnsignedShort *destination_ib, VertexFormatX
 	m_numPolygons = 0;
 	if (m_sectionMesh == NULL) {
 		numV = getModelVerticesFixed(destination_vb, *curVertexP, m_leftMtx, m_leftMesh, pLightsIterator);
+		if (!numV)
+		{	//not enough room for vertices
+			DEBUG_ASSERTCRASH( numV, ("W3DBridge::GetIndicesNVertices(). Vertex overflow.\n") );
+			return;
+		}
 		numI = getModelIndices( destination_ib, *curIndexP, *curVertexP, m_leftMesh);
+		if (!numI)
+		{	//not enough room for indices
+			DEBUG_ASSERTCRASH( numI, ("W3DBridge::GetIndicesNVertices(). Index overflow.\n") );
+			return;
+		}
 		*curIndexP += numI;
 		*curVertexP += numV;
 		m_numVertex += numV;
@@ -554,7 +570,17 @@ void W3DBridge::getIndicesNVertices(UnsignedShort *destination_ib, VertexFormatX
 	vec /= bridgeLength;
 	numV = getModelVertices(destination_vb, *curVertexP, xOffset, vec, vecNormal, vecZ, m_start, 
 		m_leftMtx, m_leftMesh, pLightsIterator);
+	if (!numV)
+	{	//not enough room for vertices
+		DEBUG_ASSERTCRASH( numV, ("W3DBridge::GetIndicesNVertices(). Vertex overflow.\n") );
+		return;
+	}
 	numI = getModelIndices( destination_ib, *curIndexP, *curVertexP, m_leftMesh);
+	if (!numI)
+	{	//not enough room for indices
+		DEBUG_ASSERTCRASH( numI, ("W3DBridge::GetIndicesNVertices(). Index overflow.\n") );
+		return;
+	}
 	*curIndexP += numI;
 	*curVertexP += numV;
 	m_numVertex += numV;
@@ -565,7 +591,17 @@ void W3DBridge::getIndicesNVertices(UnsignedShort *destination_ib, VertexFormatX
 	for (i=0; i<numSpans; i++) {
 		numV = getModelVertices(destination_vb, *curVertexP, xOffset+i*spanLength, vec, vecNormal, vecZ, m_start, 
 			m_sectionMtx, m_sectionMesh, pLightsIterator);
+		if (!numV)
+		{	//not enough room for vertices
+			DEBUG_ASSERTCRASH( numV, ("W3DBridge::GetIndicesNVertices(). Vertex overflow.\n") );
+			return;
+		}
 		numI = getModelIndices( destination_ib, *curIndexP, *curVertexP, m_sectionMesh);
+		if (!numI)
+		{	//not enough room for indices
+			DEBUG_ASSERTCRASH( numI, ("W3DBridge::GetIndicesNVertices(). Index overflow.\n") );
+			return;
+		}
 		*curIndexP += numI;
 		*curVertexP += numV;
 		m_numVertex += numV;
@@ -575,7 +611,17 @@ void W3DBridge::getIndicesNVertices(UnsignedShort *destination_ib, VertexFormatX
 	// Draw the right end.
 	numV = getModelVertices(destination_vb, *curVertexP, xOffset+(numSpans-1)*spanLength, vec, vecNormal, vecZ, m_start,
 		m_rightMtx, m_rightMesh, pLightsIterator);
+	if (!numV)
+	{	//not enough room for vertices
+		DEBUG_ASSERTCRASH( numV, ("W3DBridge::GetIndicesNVertices(). Vertex overflow.\n") );
+		return;
+	}
 	numI = getModelIndices( destination_ib, *curIndexP, *curVertexP, m_rightMesh);
+	if (!numI)
+	{	//not enough room for indices
+		DEBUG_ASSERTCRASH( numI, ("W3DBridge::GetIndicesNVertices(). Index overflow.\n") );
+		return;
+	}
 	*curIndexP += numI;
 	*curVertexP += numV;
 	m_numVertex += numV;

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3dWaypointBuffer.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3dWaypointBuffer.cpp
@@ -125,6 +125,8 @@ W3DWaypointBuffer::W3DWaypointBuffer(void)
 W3DWaypointBuffer::~W3DWaypointBuffer(void)
 {
 	REF_PTR_RELEASE( m_waypointNodeRobj );
+	REF_PTR_RELEASE( m_texture );
+	REF_PTR_RELEASE( m_line );
 }
 
 //=============================================================================
@@ -418,7 +420,6 @@ void W3DWaypointBuffer::drawWaypoints(RenderInfoClass &rinfo)
 					m_line->Render( localRinfo );
 
 				}
-
 				
 			}
 		}

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
@@ -430,7 +430,6 @@ HRESULT WaterRenderObjClass::initBumpMap(LPDIRECT3DTEXTURE8 *pTex, TextureClass 
 
 #ifdef MIPMAP_BUMP_TEXTURE
 
-	numLevels=pBumpSource->Get_Mip_Level_Count();
 	pBumpSource->Get_Level_Description(d3dsd);
 
 	if (Get_Bytes_Per_Pixel(d3dsd.Format) != 4)
@@ -439,6 +438,13 @@ HRESULT WaterRenderObjClass::initBumpMap(LPDIRECT3DTEXTURE8 *pTex, TextureClass 
 		//		DEBUG_CRASH(("WaterRenderObjClass::Invalid BumpMap format - Was it compressed?") );
 		return S_OK;
 	} 
+
+	if (pBumpSource->Peek_D3D_Texture())
+	{
+		numLevels=pBumpSource->Peek_D3D_Texture()->GetLevelCount();
+	}
+	else
+		return S_OK;
 
 	pTex[0]=DX8Wrapper::_Create_DX8_Texture(d3dsd.Width,d3dsd.Height,WW3D_FORMAT_U8V8,MIP_LEVELS_ALL,D3DPOOL_MANAGED,false);
 
@@ -929,9 +935,9 @@ void WaterRenderObjClass::ReAcquireResources(void)
 		}
 		shader = 
 			"ps.1.1\n \
-			tex t0 \n\
-			tex t1	\n\
-			tex t2	\n\
+			tex t0 ;get water texture\n\
+			tex t1 ;get white highlights on black background\n\
+			tex t2 ;get white highlights with more tiling\n\
 			tex t3	; get black shroud \n\
 			mul r0,v0,t0 ; blend vertex color and alpha into base texture. \n\
 			mad r0.rgb, t1, t2, r0	; blend sparkles and noise \n\
@@ -1078,6 +1084,8 @@ Int WaterRenderObjClass::init(Real waterLevel, Real dx, Real dy, SceneClass *par
 				material->Peek_Texture(i)->Get_Filter().Set_V_Addr_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
 			}
 		}
+
+		REF_PTR_RELEASE(material);
 	}
 
 	m_riverTexture=WW3DAssetManager::Get_Instance()->Get_Texture("TWWater01.tga"); 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarCommand.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarCommand.cpp
@@ -207,9 +207,6 @@ void ControlBar::doTransportInventoryUI( Object *transport, const CommandSet *co
 			m_commandWindows[ i ]->winHide( FALSE );
 			m_commandWindows[ i ]->winEnable( FALSE );
 
-      
-///////// poopy
-
 			//Clear any potential veterancy rank, or else we'll see it when it's empty!
 			GadgetButtonDrawOverlayImage( m_commandWindows[ i ], NULL );
 			

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameSpy/Thread/BuddyThread.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameSpy/Thread/BuddyThread.cpp
@@ -545,7 +545,7 @@ void BuddyThreadClass::connectCallback( GPConnection *con, GPConnectResponseArg 
 			DEBUG_LOG(("Buddy connect: trying chat connect\n"));
 			PeerRequest req;
 			req.peerRequestType = PeerRequest::PEERREQUEST_LOGIN;
-			req.nick = m_nick.c_str();
+			req.nick = m_nick;
 			req.password = m_pass;
 			req.email = m_email;
 			req.login.profileID = arg->profile;


### PR DESCRIPTION
Partial split from #688
- ZH BuddyThread.cpp fixes string assignment
- ControlBar.cpp fixes invalid science vector access, fixes memory leak on rightHUDCameoWindow, adds various null checks
- ControlBarCommand.cpp adds various null checks
- ControlBarCommandProcessing.cpp adds various null checks
- ControlBarMultiSelect.cpp adds various null checks
- Debug.cpp adds various null checks
- DozerAIUpdate.cpp - fixes out of bounds crash on invalid task id
- GlobalData.cpp - fixes dangling TheWritableGlobalData pointer
- MiniLog.cpp - fixes crash when m_fp is null
- Mouse.cpp - fixes crash when m_cursorTextDisplayString is null
- RankInfo.cpp - fixes memory leak
- RankInfo.h
- Science.cpp - fixes memory leak
- Science.h
- SkirmishGameOptionsMenu.cpp adds various null checks
- SparseMatchFinder.h adds various null checks
- TerrainLogic.cpp - fixes crash when tower is null
- W3DBibBuffer.cpp - fixes crash when there's nothing in buffer
- W3DBridgeBuffer.cpp - fixes crash when there's not enough room in buffer
- W3DTruckDraw.cpp - fixes crash when Tire Bones are null
- W3DWater.cpp - fixes crash when bumpsource is null
- W3dWaypointBuffer.cpp - fixes two memory leaks
- WorkerAIUpdate.cpp - fixes out of bounds crash on invalid task id
- Xfer.cpp - fixes incorrect forced crash when science vector isn't empty