### PR TITLE
[CORE][CMAKE] Fix Linux compilation of WWLib

### DIFF
--- a/Core/Libraries/Source/WWVegas/WWLib/CMakeLists.txt
+++ b/Core/Libraries/Source/WWVegas/WWLib/CMakeLists.txt
@@ -71,8 +71,6 @@ set(WWLIB_SRC
     #md5.h
     mempool.h
     mmsys.h
-    mpu.cpp
-    MPU.H
     multilist.cpp
     multilist.h
     mutex.cpp
@@ -91,8 +89,6 @@ set(WWLIB_SRC
     RANDOM.H
     rawfile.cpp
     RAWFILE.H
-    rcfile.cpp
-    rcfile.h
     readline.cpp
     readline.h
     realcrc.cpp
@@ -102,8 +98,6 @@ set(WWLIB_SRC
     refcount.h
     #regexpr.cpp
     #regexpr.h
-    registry.cpp
-    registry.h
     #search.h
     sharebuf.h
     Signaler.h
@@ -134,14 +128,10 @@ set(WWLIB_SRC
     uarray.h
     vector.cpp
     Vector.H
-    verchk.cpp
-    verchk.h
     visualc.h
     widestring.cpp
     widestring.h
     win.h
-    WWCOMUtil.cpp
-    WWCOMUtil.h
     wwfile.cpp
     WWFILE.H
     wwstring.cpp
@@ -151,6 +141,21 @@ set(WWLIB_SRC
     xstraw.cpp
     XSTRAW.H
 )
+
+if(WIN32)
+    list(APPEND WWLIB_SRC
+        mpu.cpp
+        MPU.H
+        rcfile.cpp
+        rcfile.h
+        registry.cpp
+        registry.h
+        verchk.cpp
+        verchk.h
+        WWCOMUtil.cpp
+        WWCOMUtil.h
+    )
+endif()
 
 # Targets to build.
 add_library(core_wwlib STATIC)

--- a/Core/Libraries/Source/WWVegas/WWLib/CRC.H
+++ b/Core/Libraries/Source/WWVegas/WWLib/CRC.H
@@ -41,9 +41,9 @@
 #define CRC_H
 
 #include	<stdlib.h>
-#ifdef _UNIX
-	#include "osdep.h"
-#endif
+
+// TheSuperHackers @compile feliwir 17/04/2025 include _ltrotl macros
+#include <Utility/intrin_compat.h>
 
 /*
 **	This is a CRC engine class. It will process submitted data and generate a CRC from it.

--- a/Core/Libraries/Source/WWVegas/WWLib/FastAllocator.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/FastAllocator.cpp
@@ -17,7 +17,7 @@
 */
 
 #include "FastAllocator.h"
-#include <new.h>
+#include <new>
 
 static FastAllocatorGeneral* generalAllocator; //This general allocator will do all allocations for us.
 

--- a/Core/Libraries/Source/WWVegas/WWLib/Vector.H
+++ b/Core/Libraries/Source/WWVegas/WWLib/Vector.H
@@ -61,7 +61,7 @@
 #include	<assert.h>
 #include	<stdlib.h>
 #include <string.h>
-#include <new.h>
+#include <new>
 
 #ifdef _MSC_VER
 #pragma warning (disable : 4702) // unreachable code, happens with some uses of these templates

--- a/Core/Libraries/Source/WWVegas/WWLib/WWFILE.H
+++ b/Core/Libraries/Source/WWVegas/WWLib/WWFILE.H
@@ -40,10 +40,6 @@
 #ifndef WWFILE_Hx
 #define WWFILE_Hx
 
-#ifdef _UNIX
-#include "osdep.h"
-#endif
-
 #define YEAR(dt)	(((dt & 0xFE000000) >> (9 + 16)) + 1980)
 #define MONTH(dt)	 ((dt & 0x01E00000) >> (5 + 16))
 #define DAY(dt)	 ((dt & 0x001F0000) >> (0 + 16))

--- a/Core/Libraries/Source/WWVegas/WWLib/always.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/always.h
@@ -43,6 +43,9 @@
 #include <assert.h>
 #include <new>
 
+// TheSuperHackers @compile feliwir 17/04/2025 include utility macros for cross-platform compatibility
+#include <Utility/compat.h>
+
 // Disable warning about exception handling not being enabled. It's used as part of STL - in a part of STL we don't use.
 #pragma warning(disable : 4530)
 

--- a/Core/Libraries/Source/WWVegas/WWLib/argv.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/argv.h
@@ -47,10 +47,6 @@
 #include "always.h"
 #endif
 
-#ifdef _UNIX
-#include "osdep.h"
-#endif
-
 // Used to parse command line that is passed into WinMain.  
 // It also has the ability to load a file with values to append to the command line.
 // Normally in WinMain() there would be a call Argv::Init(lpCmdLine, fileprefix).  

--- a/Core/Libraries/Source/WWVegas/WWLib/cpudetect.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/cpudetect.cpp
@@ -21,9 +21,12 @@
 #include "wwdebug.h"
 #include "thread.h"
 #pragma warning (disable : 4201)	// Nonstandard extension - nameless struct
-#include <windows.h>
 #include "systimer.h"
 #include <Utility/intrin_compat.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
 
 #ifdef _UNIX
 # include <time.h>  // for time(), localtime() and timezone variable.
@@ -57,7 +60,7 @@ int CPUDetectClass::ProcessorFamily;
 int CPUDetectClass::ProcessorModel;
 int CPUDetectClass::ProcessorRevision;
 int CPUDetectClass::ProcessorSpeed;
-__int64 CPUDetectClass::ProcessorTicksPerSecond;	// Ticks per second
+sint64 CPUDetectClass::ProcessorTicksPerSecond;	// Ticks per second
 double CPUDetectClass::InvProcessorTicksPerSecond;	// 1.0 / Ticks per second
 
 unsigned CPUDetectClass::FeatureBits;
@@ -125,10 +128,10 @@ const char* CPUDetectClass::Get_Processor_Manufacturer_Name()
 
 #define ASM_RDTSC _asm _emit 0x0f _asm _emit 0x31
 
-static unsigned Calculate_Processor_Speed(__int64& ticks_per_second)
+static unsigned Calculate_Processor_Speed(sint64& ticks_per_second)
 {
-	unsigned __int64 timer0=0;
-	unsigned __int64 timer1=0;
+	sint64 timer0=0;
+	sint64 timer1=0;
 
 	timer0=_rdtsc();
 
@@ -138,8 +141,8 @@ static unsigned Calculate_Processor_Speed(__int64& ticks_per_second)
 		timer1=_rdtsc();
 	}
 
-	__int64 t=timer1-timer0;
-	ticks_per_second=(__int64)((1000.0/(double)elapsed)*(double)t);	// Ticks per second
+	sint64 t=timer1-timer0;
+	ticks_per_second=(sint64)((1000.0/(double)elapsed)*(double)t);	// Ticks per second
 	return unsigned((double)t/(double)(elapsed*1000));
 }
 
@@ -898,8 +901,8 @@ void CPUDetectClass::Init_Memory()
 
 void CPUDetectClass::Init_OS()
 {
-	OSVERSIONINFO os;
 #ifdef WIN32
+	OSVERSIONINFO os;
    os.dwOSVersionInfoSize = sizeof(os);
 	GetVersionEx(&os);
 
@@ -940,9 +943,11 @@ void CPUDetectClass::Init_Processor_Log()
 
 	SYSLOG(("Operating System: "));
 	switch (OSVersionPlatformId) {
+#ifdef _WIN32
 	case VER_PLATFORM_WIN32s: SYSLOG(("Windows 3.1")); break;
 	case VER_PLATFORM_WIN32_WINDOWS: SYSLOG(("Windows 9x")); break;
 	case VER_PLATFORM_WIN32_NT: SYSLOG(("Windows NT")); break;
+#endif
 	}
 	SYSLOG(("\r\n"));
 
@@ -1223,6 +1228,7 @@ void Get_OS_Info(
 	switch (OSVersionPlatformId) {
 	default:
 		break;
+#ifdef _WIN32
 	case VER_PLATFORM_WIN32_WINDOWS:
 		{
 			for(int i=0;i<sizeof(Windows9xVersionTable)/sizeof(os_info);++i) {
@@ -1304,5 +1310,6 @@ void Get_OS_Info(
 
 		// No more-specific version detected; fallback to XX
 		os_info.Code="WINXX";
+#endif
 	}
 }

--- a/Core/Libraries/Source/WWVegas/WWLib/hash.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/hash.cpp
@@ -38,9 +38,6 @@
 #include "hash.h"
 #include "wwdebug.h"
 #include "realcrc.h"
-#ifdef _UNIX
-#include "osdep.h"
-#endif
 
 #include <string.h>
 

--- a/Core/Libraries/Source/WWVegas/WWLib/mempool.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/mempool.h
@@ -53,7 +53,7 @@
 #include "bittype.h"
 #include "wwdebug.h"
 #include "mutex.h"
-#include <new.h>
+#include <new>
 #include <stdlib.h>
 #include <stddef.h>
 
@@ -157,8 +157,14 @@ private:
 ** Macro to declare the allocator for your class.  Put this in the cpp file for
 ** the class.
 */
+#if defined(_MSC_VER) && _MSC_VER < 1300
 #define DEFINE_AUTO_POOL(T,BLOCKSIZE) \
 ObjectPoolClass<T,BLOCKSIZE> AutoPoolClass<T,BLOCKSIZE>::Allocator;
+#else
+#define DEFINE_AUTO_POOL(T,BLOCKSIZE) \
+template<>\
+ObjectPoolClass<T,BLOCKSIZE> AutoPoolClass<T,BLOCKSIZE>::Allocator = {}
+#endif
 
 
 /***********************************************************************************************

--- a/Core/Libraries/Source/WWVegas/WWLib/mutex.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/mutex.cpp
@@ -18,8 +18,9 @@
 
 #include "mutex.h"
 #include "wwdebug.h"
+#ifdef _WIN32
 #include <windows.h>
-
+#endif
 
 // ----------------------------------------------------------------------------
 

--- a/Core/Libraries/Source/WWVegas/WWLib/refcount.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/refcount.cpp
@@ -40,8 +40,9 @@
 
 
 #include "refcount.h"
-#include <windows.h>
 
+// TheSuperHackers @compile feliwir 17/04/2025 include __debugbreak macros
+#include <Utility/intrin_compat.h>
 
 #ifndef NDEBUG
 
@@ -174,7 +175,7 @@ void RefCountClass::Add_Ref(void) const
 
 	// See if programmer set break on for a specific address.
 	if (this == BreakOnReference) {
-		DebugBreak();  // trigger the debugger
+		__debugbreak();  // trigger the debugger
 	}
 	Inc_Total_Refs(this);
 }
@@ -201,7 +202,7 @@ void	RefCountClass::Dec_Total_Refs(const RefCountClass * obj)
 
 	// See if programmer set break on for a specific address.
 	if (obj == BreakOnReference) {
-		 DebugBreak();  // trigger the debugger
+		__debugbreak();  // trigger the debugger
 	}
 }
 

--- a/Core/Libraries/Source/WWVegas/WWLib/systimer.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/systimer.h
@@ -38,11 +38,25 @@
 #ifndef _SYSTIMER_H
 
 #include "always.h"
+#ifdef _WIN32
 #include <windows.h>
 #include "mmsys.h"
 
 #define TIMEGETTIME SystemTime.Get
 #define MS_TIMER_SECOND 1000
+#else
+#include <sys/time.h>
+
+inline unsigned long systimerGetMS(void)
+{
+	struct timeval tv;
+	gettimeofday(&tv, NULL);
+	return (tv.tv_sec * 1000) + (tv.tv_usec / 1000);
+}
+
+#define TIMEGETTIME systimerGetMS
+#define MS_TIMER_SECOND 1000
+#endif
 
 /*
 ** Class that just wraps around timeGetTime()

--- a/Core/Libraries/Source/WWVegas/WWLib/thread.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/thread.cpp
@@ -21,13 +21,15 @@
 #include "thread.h"
 #include "Except.h"
 #include "wwdebug.h"
-#include <process.h>
-#include <windows.h>
 #pragma warning ( push )
 #pragma warning ( disable : 4201 )
 #include "systimer.h"
 #pragma warning ( pop )
 
+#ifdef _WIN32
+#include <process.h>
+#include <windows.h>
+#endif
 
 ThreadClass::ThreadClass(const char *thread_name, ExceptionHandlerType exception_handler) : handle(0), running(false), thread_priority(0)
 {

--- a/Core/Libraries/Source/WWVegas/WWLib/thread.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/thread.h
@@ -22,9 +22,6 @@
 #if defined(_MSC_VER)
 #pragma once
 #endif
-#ifdef _UNIX
-#include "osdep.h"
-#endif
 
 #include "always.h"
 #include "Vector.H"

--- a/Core/Libraries/Source/WWVegas/WWLib/widestring.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/widestring.h
@@ -49,9 +49,6 @@
 #include "wwstring.h"
 #include "trim.h"
 #include <wchar.h>
-#ifdef _UNIX
-#include "osdep.h"
-#endif
 
 //////////////////////////////////////////////////////////////////////
 //

--- a/Core/Libraries/Source/WWVegas/WWLib/win.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/win.h
@@ -49,6 +49,8 @@
 **	4069, 4200, 4237, 4103, 4001, 4035, 4164. Makes you wonder, eh?
 */
 
+#ifdef _WIN32
+
 // When including windows, lets just bump the warning level back to 3...
 #if (_MSC_VER >= 1200)
 #pragma warning(push, 3)
@@ -69,7 +71,6 @@
 #pragma warning(pop)
 #endif
 
-#ifdef _WINDOWS
 extern HINSTANCE	ProgramInstance;
 extern HWND			MainWindow;
 extern bool GameInFocus;
@@ -84,8 +85,8 @@ void __cdecl Print_Win32Error(unsigned long win32Error);
 
 #endif // _DEBUG
 
-#else // _WINDOWS
+#else // _WIN32
 //#include <unistd.h>	// file does not exist
-#endif // _WINDOWS
+#endif // _WIN32
 
 #endif // WIN_H

--- a/Core/Libraries/Source/WWVegas/WWLib/wwfile.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/wwfile.cpp
@@ -39,6 +39,9 @@
 #include <memory.h>
 #include "WWFILE.H"
 
+// TheSuperHackers @compile feliwir 17/04/2025 include _vsnprintf macros
+#include <Utility/compat.h>
+
 #pragma warning(disable : 4514)
 
 int FileClass::Printf(char *str, ...)

--- a/Core/Libraries/Source/WWVegas/WWLib/wwstring.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/wwstring.cpp
@@ -35,7 +35,6 @@
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 #include "wwstring.h"
-#include "win.h"
 #include "wwmemlog.h"
 #include "mutex.h"
 #include <stdio.h>
@@ -102,7 +101,7 @@ StringClass::Get_String (int length, bool is_temp)
 				//
 				//	Grab this unused buffer for our string
 				//
-				unsigned temp_string=reinterpret_cast<unsigned>(m_TempStrings);
+				unsigned long temp_string=reinterpret_cast<unsigned long>(m_TempStrings);
 				temp_string+=MAX_TEMP_BYTES*MAX_TEMP_STRING;
 				temp_string&=~(MAX_TEMP_BYTES*MAX_TEMP_STRING-1);
 				temp_string+=index*MAX_TEMP_BYTES;
@@ -197,8 +196,8 @@ StringClass::Free_String (void)
 {
 	if (m_Buffer != m_EmptyString) {
 
-		unsigned buffer_base=reinterpret_cast<unsigned>(m_Buffer-sizeof (StringClass::_HEADER));
-		unsigned temp_base=reinterpret_cast<unsigned>(m_TempStrings+MAX_TEMP_BYTES*MAX_TEMP_STRING);
+		unsigned long buffer_base=reinterpret_cast<unsigned long>(m_Buffer-sizeof (StringClass::_HEADER));
+		unsigned long temp_base=reinterpret_cast<unsigned long>(m_TempStrings+MAX_TEMP_BYTES*MAX_TEMP_STRING);
 
 		if ((buffer_base>>11)==(temp_base>>11)) {
 			m_Buffer[0] = 0;
@@ -321,7 +320,7 @@ bool StringClass::Copy_Wide (const WCHAR *source)
 	if (source != NULL) {
 
 		int  length;
-		BOOL unmapped;
+		int unmapped;
 			
 		length = WideCharToMultiByte (CP_ACP, 0 , source, -1, NULL, 0, NULL, &unmapped);
 		if (length > 0) {

--- a/Core/Libraries/Source/WWVegas/WWLib/wwstring.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/wwstring.h
@@ -46,11 +46,10 @@
 #include "win.h"
 #include <string.h>
 #include <stdarg.h>
-#include <tchar.h>
 #include "trim.h"
 #include "wwdebug.h"
-#ifdef _UNIX
-#include "osdep.h"
+#ifdef _WIN32
+#include <tchar.h>
 #endif
 
 

--- a/GeneralsMD/Code/Tools/wdump/CMakeLists.txt
+++ b/GeneralsMD/Code/Tools/wdump/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(z_wdump PRIVATE ${WDUMP_SRC})
 
 target_link_libraries(z_wdump PRIVATE
     core_config
+    core_utility
     core_wwstub # avoid linking GameEngine
     dbghelplib
     imm32

--- a/cmake/config-build.cmake
+++ b/cmake/config-build.cmake
@@ -31,6 +31,10 @@ if(MSVC)
     target_compile_definitions(core_config INTERFACE _CRT_NONSTDC_NO_WARNINGS _CRT_SECURE_NO_WARNINGS $<$<CONFIG:DEBUG>:_DEBUG_CRT>)
 endif()
 
+if(UNIX)
+    target_compile_definitions(core_config INTERFACE _UNIX)
+endif()
+
 if(RTS_BUILD_OPTION_DEBUG)
     target_compile_definitions(core_config INTERFACE _DEBUG WWDEBUG DEBUG)
 else()


### PR DESCRIPTION
Partially implements #522 

This PR does the following things to fix Linux compilation:
- Define the `_UNIX` macro for non windows platforms
- Guard any includes of window specific APIs
- Remove usage of the missing `osdep.h`. We replaced this with out compat library
- Don't compile windows specific files, like rcfile, registry, verchk