### PR TITLE
[CORE][CMAKE] Fix Linux compilation of WWDebug

### DIFF
--- a/Core/Libraries/Source/WWVegas/WWDebug/wwdebug.cpp
+++ b/Core/Libraries/Source/WWVegas/WWDebug/wwdebug.cpp
@@ -43,7 +43,6 @@
 
 
 #include "wwdebug.h"
-#include <windows.h>
 //#include "win.h" can use this if allowed to see wwlib
 #include <stdlib.h>
 #include <stdarg.h>
@@ -53,6 +52,11 @@
 #include <signal.h>
 #include "Except.h"
 
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <errno.h>
+#endif
 
 static PrintFunc			_CurMessageHandler = NULL;
 static AssertPrintFunc	_CurAssertHandler = NULL;
@@ -79,7 +83,11 @@ void Convert_System_Error_To_String(int id, char* buffer, int buf_len)
 
 int Get_Last_System_Error()
 {
+#ifdef _WIN32
 	return GetLastError();
+#else
+	return errno;
+#endif
 }
 
 /***********************************************************************************************

--- a/Core/Libraries/Source/WWVegas/WWDebug/wwmemlog.cpp
+++ b/Core/Libraries/Source/WWVegas/WWDebug/wwmemlog.cpp
@@ -43,7 +43,6 @@
 #include "wwdebug.h"
 #include "Vector.H"
 #include "FastAllocator.h"
-#include <windows.h>
 
 #define USE_FAST_ALLOCATOR
 
@@ -70,7 +69,8 @@
 ** Enable one of the following #defines to specify which thread-sychronization
 ** method to use.
 */
-#ifndef _UNIX
+#ifdef _WIN32
+#include <windows.h>
 #define MEMLOG_USE_MUTEX					0
 #define MEMLOG_USE_CRITICALSECTION		1
 #define MEMLOG_USE_FASTCRITICALSECTION	0
@@ -288,6 +288,10 @@ WWINLINE void * Get_Mem_Log_Mutex(void)
 	}
 	return _MemLogCriticalSectionHandle;
 
+#endif
+
+#if DISABLE_MEMLOG
+	return NULL;
 #endif
 }
 

--- a/Core/Libraries/Source/WWVegas/WWDebug/wwprofile.cpp
+++ b/Core/Libraries/Source/WWVegas/WWDebug/wwprofile.cpp
@@ -53,7 +53,6 @@
 #include "wwprofile.h"
 #include "FastAllocator.h"
 #include "wwdebug.h"
-#include <windows.h>
 //#include "systimer.h"
 #include "systimer.h"
 #include "RAWFILE.H"


### PR DESCRIPTION
Requires #698 

This PR makes sure windows specific headers are guarded.
The MEMLOG was disabled on UNIX already