### PR TITLE
[GEN][ZH] Remove unused granny related code

### DIFF
--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DAssetManager.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DAssetManager.h
@@ -54,7 +54,6 @@
 
 class Vector3;
 class VertexMaterialClass;
-class GrannyAnimManagerClass;
 
 class W3DAssetManager: public WW3DAssetManager
 {
@@ -102,8 +101,6 @@ private:
 	int replaceAssetTexture(RenderObjClass *robj, TextureClass *oldTex, TextureClass *newTex);
 	int replaceHLODTexture(RenderObjClass *robj, TextureClass *oldTex, TextureClass *newTex);
 	int replaceMeshTexture(RenderObjClass *robj, TextureClass *oldTex, TextureClass *newTex);
-
-	GrannyAnimManagerClass		*m_GrannyAnimManager;
 
 	//'E&B' customizations
 /*	virtual RenderObjClass * Create_Render_Obj(const char * name, float scale, const Vector3 &hsv_shift);	

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp
@@ -748,43 +748,6 @@ Int W3DShadowGeometry::initFromMesh(RenderObjClass *robj)
 Int W3DShadowGeometry::init(RenderObjClass *robj)
 {
 	return TRUE;
-//	m_robj=robj;
-/*	//code to deal with granny - don't think we'll use shadow volumes on these!?
-	granny_file *fileInfo=robj->getPrototype().m_file;
-
-	for (Int modelIndex=0; modelIndex<fileInfo->ModelCount; modelIndex++)
-	{
-		granny_model *sourceModel =  fileInfo->Models[modelIndex];
-		if (stricmp(sourceModel->Name,"AABOX") == 0)
-		{	//found a collision box, copy out data
-			int MeshCount = sourceModel->MeshBindingCount;
-			if (MeshCount==1)
-			{
-				granny_mesh *sourceMesh = sourceModel->MeshBindings[0].Mesh;
-				granny_pn33_vertex *Vertices = (granny_pn33_vertex *)sourceMesh->PrimaryVertexData->Vertices;
-				Vector3 points[24];
-
-				assert (sourceMesh->PrimaryVertexData->VertexCount <= 24);
-
-				for (Int boxVertex=0; boxVertex<sourceMesh->PrimaryVertexData->VertexCount; boxVertex++)
-				{	points[boxVertex].Set(Vertices[boxVertex].Position[0],
-										  Vertices[boxVertex].Position[1],
-										  Vertices[boxVertex].Position[2]);
-				}
-				box.Init(points,sourceMesh->PrimaryVertexData->VertexCount);
-			}
-		}
-		else
-		{	//mesh is part of model
-			int meshCount = sourceModel->MeshBindingCount;
-			for (Int meshIndex=0; meshIndex<meshCount; meshIndex++)
-			{
-				granny_mesh *sourceMesh = sourceModel->MeshBindings[meshIndex].Mesh;
-				if (sourceMesh->PrimaryVertexData)
-					vertexCount+=sourceMesh->PrimaryVertexData->VertexCount;
-			}
-		}
-	}*/
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3944,7 +3907,7 @@ Error:
 }
 
 /*
-** Iterator converter from HashableClass to GrannyAnimClass
+** Iterator converter from HashableClass to W3DShadowGeometry
 */
 W3DShadowGeometry * W3DShadowGeometryManagerIterator::Get_Current_Geom( void )	
 { 

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DScene.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DScene.cpp
@@ -1124,16 +1124,6 @@ void RTS3DScene::Customized_Render( RenderInfoClass &rinfo )
 				renderOneObject(rinfo, robj, localPlayerIndex);
 		}
 	}
-
-#ifdef	INCLUDE_GRANNY_IN_BUILD
-	if (TheGrannyRenderObjSystem)
-	{	//we only want to update granny animations once per frame, so only queue
-		//them up if this is not a mirror pass.
-		if (!ShaderClass::Is_Backface_Culling_Inverted())
-			TheGrannyRenderObjSystem->queueUpdate();
-		TheGrannyRenderObjSystem->Flush();
-	}
-#endif
 	
 	//Tell shadow manager to render shadows at the end of this frame
 	//Don't draw shadows if there is no terrain present.

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DTerrainVisual.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DTerrainVisual.cpp
@@ -84,14 +84,6 @@ W3DTerrainVisual::~W3DTerrainVisual()
 		TheTerrainTracksRenderObjClassSystem=NULL;
 	}
 
-#ifdef	INCLUDE_GRANNY_IN_BUILD
-	if (TheGrannyRenderObjSystem)
-	{
-		delete TheGrannyRenderObjSystem;
-		TheGrannyRenderObjSystem=NULL;
-	}
-#endif
-
 	if (TheW3DShadowManager)
 	{	
 		delete TheW3DShadowManager;
@@ -120,11 +112,6 @@ void W3DTerrainVisual::init( void )
 	// initialize track drawing system
 	TheTerrainTracksRenderObjClassSystem = NEW TerrainTracksRenderObjClassSystem;
 	TheTerrainTracksRenderObjClassSystem->init(W3DDisplay::m_3DScene);
-
-#ifdef	INCLUDE_GRANNY_IN_BUILD
-	// initialize Granny model drawing system
-	TheGrannyRenderObjSystem = NEW GrannyRenderObjSystem;
-#endif
 
 	// initialize object shadow drawing system
 	TheW3DShadowManager = NEW W3DShadowManager;

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DAssetManager.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DAssetManager.h
@@ -54,7 +54,6 @@
 
 class Vector3;
 class VertexMaterialClass;
-class GrannyAnimManagerClass;
 
 class W3DAssetManager: public WW3DAssetManager
 {
@@ -107,8 +106,6 @@ private:
 	int replaceAssetTexture(RenderObjClass *robj, TextureClass *oldTex, TextureClass *newTex);
 	int replaceHLODTexture(RenderObjClass *robj, TextureClass *oldTex, TextureClass *newTex);
 	int replaceMeshTexture(RenderObjClass *robj, TextureClass *oldTex, TextureClass *newTex);
-
-	GrannyAnimManagerClass		*m_GrannyAnimManager;
 
 	//'E&B' customizations
 /*	virtual RenderObjClass * Create_Render_Obj(const char * name, float scale, const Vector3 &hsv_shift);	

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp
@@ -850,43 +850,6 @@ Int W3DShadowGeometry::initFromMesh(RenderObjClass *robj)
 Int W3DShadowGeometry::init(RenderObjClass *robj)
 {
 	return TRUE;
-//	m_robj=robj;
-/*	//code to deal with granny - don't think we'll use shadow volumes on these!?
-	granny_file *fileInfo=robj->getPrototype().m_file;
-
-	for (Int modelIndex=0; modelIndex<fileInfo->ModelCount; modelIndex++)
-	{
-		granny_model *sourceModel =  fileInfo->Models[modelIndex];
-		if (stricmp(sourceModel->Name,"AABOX") == 0)
-		{	//found a collision box, copy out data
-			int MeshCount = sourceModel->MeshBindingCount;
-			if (MeshCount==1)
-			{
-				granny_mesh *sourceMesh = sourceModel->MeshBindings[0].Mesh;
-				granny_pn33_vertex *Vertices = (granny_pn33_vertex *)sourceMesh->PrimaryVertexData->Vertices;
-				Vector3 points[24];
-
-				assert (sourceMesh->PrimaryVertexData->VertexCount <= 24);
-
-				for (Int boxVertex=0; boxVertex<sourceMesh->PrimaryVertexData->VertexCount; boxVertex++)
-				{	points[boxVertex].Set(Vertices[boxVertex].Position[0],
-										  Vertices[boxVertex].Position[1],
-										  Vertices[boxVertex].Position[2]);
-				}
-				box.Init(points,sourceMesh->PrimaryVertexData->VertexCount);
-			}
-		}
-		else
-		{	//mesh is part of model
-			int meshCount = sourceModel->MeshBindingCount;
-			for (Int meshIndex=0; meshIndex<meshCount; meshIndex++)
-			{
-				granny_mesh *sourceMesh = sourceModel->MeshBindings[meshIndex].Mesh;
-				if (sourceMesh->PrimaryVertexData)
-					vertexCount+=sourceMesh->PrimaryVertexData->VertexCount;
-			}
-		}
-	}*/
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4088,7 +4051,7 @@ Error:
 }
 
 /*
-** Iterator converter from HashableClass to GrannyAnimClass
+** Iterator converter from HashableClass to W3DShadowGeometry
 */
 W3DShadowGeometry * W3DShadowGeometryManagerIterator::Get_Current_Geom( void )	
 { 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DAssetManager.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DAssetManager.cpp
@@ -151,17 +151,11 @@ RenderObjClass * W3DPrototypeClass::Create(void)
 //---------------------------------------------------------------------
 W3DAssetManager::W3DAssetManager(void)
 {
-#ifdef	INCLUDE_GRANNY_IN_BUILD
-	m_GrannyAnimManager = NEW GrannyAnimManagerClass;
-#endif
 }
 
 //---------------------------------------------------------------------
 W3DAssetManager::~W3DAssetManager(void)
 {
-#ifdef	INCLUDE_GRANNY_IN_BUILD
-	delete m_GrannyAnimManager;
-#endif
 }
 
 #ifdef DUMP_PERF_STATS
@@ -730,12 +724,6 @@ RenderObjClass * W3DAssetManager::Create_Render_Obj(
 	GetPrecisionTimer(&startTime64);
 	#endif
 
-#ifdef	INCLUDE_GRANNY_IN_BUILD
-	Bool isGranny = false;
-	char *pext=strrchr(name,'.');	//find file extension
-	if (pext)
-		isGranny=(strnicmp(pext,".GR2",4) == 0);
-#endif
 	Bool reallyscale = (WWMath::Fabs(scale - ident_scale) > scale_epsilon);
 	Bool reallycolor = (color & 0xFFFFFF) != 0;	//black is not a valid color and assumes no custom coloring.
 	Bool reallytexture = (oldTexture != NULL && newTexture != NULL);
@@ -757,12 +745,6 @@ RenderObjClass * W3DAssetManager::Create_Render_Obj(
 	// see if we got a cached version
 	RenderObjClass *rendobj = NULL;
 
-#ifdef	INCLUDE_GRANNY_IN_BUILD
-	if (isGranny)
-	{	//Granny objects share the same prototype since they allow instance scaling.
-		strcpy(newname,name);	//use same name for all granny objects at any scale.
-	}
-#endif
 	Set_WW3D_Load_On_Demand(false); // munged name will never be found in a file.
 	rendobj = WW3DAssetManager::Create_Render_Obj(newname);
 	if (rendobj)
@@ -770,11 +752,6 @@ RenderObjClass * W3DAssetManager::Create_Render_Obj(
 		//when we need to save this render object to a file.  Used during saving
 		//of fog of war ghost objects.
 		rendobj->Set_ObjectColor(color);
-#ifdef	INCLUDE_GRANNY_IN_BUILD
-		if (isGranny)
-			///@todo Granny objects are realtime scaled - fix to scale like W3D.
-			rendobj->Set_ObjectScale(scale);
-#endif
 		Set_WW3D_Load_On_Demand(true); // Auto Load.
 
 	#ifdef DUMP_PERF_STATS
@@ -797,16 +774,11 @@ RenderObjClass * W3DAssetManager::Create_Render_Obj(
 	{	
 		// If we didn't find one, try to load on demand
 		char filename [MAX_PATH];
-		const char *mesh_name = ::strchr (name, '.');
+		const char *mesh_name = strchr (name, '.');
 		if (mesh_name != NULL) 
 		{
-			::lstrcpyn(filename, name, ((int)mesh_name) - ((int)name) + 1);
-#ifdef	INCLUDE_GRANNY_IN_BUILD
-			if (isGranny)
-				::lstrcat(filename, ".gr2");
-			else
-#endif
-				::lstrcat(filename, ".w3d");
+			lstrcpyn(filename, name, ((int)mesh_name) - ((int)name) + 1);
+			lstrcat(filename, ".w3d");
 		} else {
 			sprintf( filename, "%s.w3d", name);
 		}
@@ -815,15 +787,7 @@ RenderObjClass * W3DAssetManager::Create_Render_Obj(
 		if ( Load_3D_Assets( filename ) == false ) 
 		{
 			StringClass	new_filename = StringClass("..\\") + filename;
-			if (Load_3D_Assets( new_filename ) == false)
-			{
-#ifdef	INCLUDE_GRANNY_IN_BUILD
-				char *mesh_name = ::strchr (filename, '.');
-				::lstrcpyn (mesh_name, ".gr2",5);
-				Load_3D_Assets( filename );
-				isGranny=true;
-#endif
-			}
+			Load_3D_Assets(new_filename);
 		}
 
 		proto = Find_Prototype(name);		// try again
@@ -853,35 +817,23 @@ RenderObjClass * W3DAssetManager::Create_Render_Obj(
 	#endif
 		return NULL;
 	}
-#ifdef	INCLUDE_GRANNY_IN_BUILD
-	if (!isGranny)
-#endif
+
+	if (reallyscale)
+		rendobj->Scale(scale);	//this also makes it unique
+
+	Make_Unique(rendobj,reallyscale,reallycolor);
+
+	if (reallytexture)
 	{	
-		if (reallyscale)
-			rendobj->Scale(scale);	//this also makes it unique
-
-		Make_Unique(rendobj,reallyscale,reallycolor);
-
-		if (reallytexture)
-		{	
-			TextureClass *oldTex = Get_Texture(oldTexture);
-			TextureClass *newTex = Get_Texture(newTexture);
-			replaceAssetTexture(rendobj,oldTex,newTex);
-			REF_PTR_RELEASE(newTex);
-			REF_PTR_RELEASE(oldTex);
-		}
-
-		if (reallycolor)
-			Recolor_Asset(rendobj,color);
+		TextureClass *oldTex = Get_Texture(oldTexture);
+		TextureClass *newTex = Get_Texture(newTexture);
+		replaceAssetTexture(rendobj,oldTex,newTex);
+		REF_PTR_RELEASE(newTex);
+		REF_PTR_RELEASE(oldTex);
 	}
-#ifdef	INCLUDE_GRANNY_IN_BUILD
-	else
-	{	
-		///@todo Granny objects are realtime scaled - fix to scale like W3D.
-		rendobj->Set_ObjectScale(scale);
-		return rendobj;
-	}
-#endif
+
+	if (reallycolor)
+		Recolor_Asset(rendobj,color);
 
 	W3DPrototypeClass *w3dproto = newInstance(W3DPrototypeClass)(rendobj, newname);	
 	rendobj->Release_Ref();
@@ -1018,14 +970,6 @@ bool W3DAssetManager::Load_3D_Assets( const char * filename )
 		GetPrecisionTimer(&startTime64);
 #endif
 
-#ifdef	INCLUDE_GRANNY_IN_BUILD
-	Bool isGranny = false;
-	char *pext=strrchr(filename,'.');	//find file extension
-	if (pext)
-		isGranny=(strnicmp(pext,".GR2",4) == 0);
-	if (!isGranny)
-#endif
-
 	// Try to find an existing prototype
 	char basename[512];
 	strcpy(basename, filename);
@@ -1070,40 +1014,6 @@ bool W3DAssetManager::Load_3D_Assets( const char * filename )
 #endif
 	return result;
 
-#ifdef	INCLUDE_GRANNY_IN_BUILD
-	//Loading assets for Granny File
-	PrototypeClass * newproto = NULL;
-	newproto = _GrannyLoader.Load_W3D(filename);
-	/*
-	** Now, see if the prototype that we loaded has a duplicate
-	** name with any of our currently loaded prototypes (can't have that!)
-	*/
-	if (newproto != NULL) {
-		if (!Render_Obj_Exists(newproto->Get_Name())) {
-			/*
-			** Add the new, unique prototype to our list
-			*/
-			Add_Prototype(newproto);
-		} else {
-			/*
-			** Warn the user about a name collision with this prototype 
-			** and dump it
-			*/
-			WWDEBUG_SAY(("Render Object Name Collision: %s\r\n",newproto->Get_Name()));
-			delete newproto;
-			newproto = NULL;
-			return false;
-		}
-	} else {
-		/*
-		** Warn user that a prototype was not generated from this 
-		** chunk type
-		*/
-		WWDEBUG_SAY(("Could not generate Granny prototype!  File  = %d\r\n",filename));
-		return false;
-	}
-	return true;
-#endif
 }
 
 #ifdef DUMP_PERF_STATS
@@ -1121,47 +1031,17 @@ HAnimClass *	W3DAssetManager::Get_HAnim(const char * name)
 #endif
 	WWPROFILE( "WW3DAssetManager::Get_HAnim" );
 
-#ifdef	INCLUDE_GRANNY_IN_BUILD
-	Bool isGranny = false;
-	char *pext=strrchr(name,'.');	//find file extension
-	if (pext)
-		isGranny=(strnicmp(pext,".GR2",4) == 0);
-	if (!isGranny)
-#endif
-	{
-		HAnimClass *anim=WW3DAssetManager::Get_HAnim(name);	//we only do custom granny processing.
+	HAnimClass *anim=WW3DAssetManager::Get_HAnim(name);
 #ifdef DUMP_PERF_STATS
-		if (HAnim_Recursions == 1)
-		{
-			GetPrecisionTimer(&endTime64);
-			Total_Get_HAnim_Time += endTime64-startTime64;
-		}
-		HAnim_Recursions--;
+	if (HAnim_Recursions == 1)
+	{
+		GetPrecisionTimer(&endTime64);
+		Total_Get_HAnim_Time += endTime64-startTime64;
+	}
+	HAnim_Recursions--;
 #endif
-		return anim;
-	}
-
-#ifdef	INCLUDE_GRANNY_IN_BUILD
-	// Try to find the hanim
-	HAnimClass * anim = m_GrannyAnimManager->Get_Anim(name);
-	if (WW3D_Load_On_Demand && anim == NULL) {	// If we didn't find it, try to load on demand
-		if ( !m_GrannyAnimManager->Is_Missing( name ) ) {	// if this is NOT a known missing anim
-
-			// If we can't find it, try the parent directory
-			if ( m_GrannyAnimManager->Load_Anim(name) == 1 ) {
-				StringClass	new_filename = StringClass("..\\") + name;
-				m_GrannyAnimManager->Load_Anim( new_filename );
-			}
-
-			anim = m_GrannyAnimManager->Get_Anim(name);		// Try again
-			if (anim == NULL) {
-//				WWDEBUG_SAY(("WARNING: Animation %s not found!\n", name));
-				m_GrannyAnimManager->Register_Missing( name );		// This is now a KNOWN missing anim
-			}
-		}
-	}
 	return anim;
-#endif
+
 }
 
 //---------------------------------------------------------------------
@@ -1447,11 +1327,6 @@ static inline void Munge_Texture_Name(char *newname, const char *oldname, const 
 RenderObjClass * W3DAssetManager::Create_Render_Obj(const char * name,float scale, const Vector3 &hsv_shift)
 {
 	Bool isGranny = false;
-#ifdef	INCLUDE_GRANNY_IN_BUILD
-	char *pext=strrchr(name,'.');	//find file extension
-	if (pext)
-		isGranny=(strnicmp(pext,".GR2",4) == 0);
-#endif
 	Bool reallyscale = (WWMath::Fabs(scale - ident_scale) > scale_epsilon);
 	Bool reallyhsv_shift = (WWMath::Fabs(hsv_shift.X - ident_HSV.X) > H_epsilon ||
 		WWMath::Fabs(hsv_shift.Y - ident_HSV.Y) > S_epsilon || WWMath::Fabs(hsv_shift.Z - ident_HSV.Z) > V_epsilon);

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DScene.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DScene.cpp
@@ -1173,16 +1173,6 @@ void RTS3DScene::Customized_Render( RenderInfoClass &rinfo )
 				renderOneObject(rinfo, robj, localPlayerIndex);
 		}
 	}
-
-#ifdef	INCLUDE_GRANNY_IN_BUILD
-	if (TheGrannyRenderObjSystem)
-	{	//we only want to update granny animations once per frame, so only queue
-		//them up if this is not a mirror pass.
-		if (!ShaderClass::Is_Backface_Culling_Inverted())
-			TheGrannyRenderObjSystem->queueUpdate();
-		TheGrannyRenderObjSystem->Flush();
-	}
-#endif
 	
 	//Tell shadow manager to render shadows at the end of this frame
 	//Don't draw shadows if there is no terrain present.

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DTerrainVisual.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DTerrainVisual.cpp
@@ -197,14 +197,6 @@ W3DTerrainVisual::~W3DTerrainVisual()
 		TheTerrainTracksRenderObjClassSystem=NULL;
 	}
 
-#ifdef	INCLUDE_GRANNY_IN_BUILD
-	if (TheGrannyRenderObjSystem)
-	{
-		delete TheGrannyRenderObjSystem;
-		TheGrannyRenderObjSystem=NULL;
-	}
-#endif
-
 	if (TheW3DShadowManager)
 	{	
 		delete TheW3DShadowManager;
@@ -243,11 +235,6 @@ void W3DTerrainVisual::init( void )
 	// initialize track drawing system
 	TheTerrainTracksRenderObjClassSystem = NEW TerrainTracksRenderObjClassSystem;
 	TheTerrainTracksRenderObjClassSystem->init(W3DDisplay::m_3DScene);
-
-#ifdef	INCLUDE_GRANNY_IN_BUILD
-	// initialize Granny model drawing system
-	TheGrannyRenderObjSystem = NEW GrannyRenderObjSystem;
-#endif
 
 	// initialize object shadow drawing system
 	TheW3DShadowManager = NEW W3DShadowManager;


### PR DESCRIPTION
This PR removes code blocks for granny based file support that were conditionally included.
It also makes small refactors in some places where the granny code was coupled with non granny code in W3DAssetManager.

There is still some granny referencing code within W3DAssetManger, but this is in a commented out block of functions from Earth and Beyond at the end of the file. I left these blocks untouched, apart from removing the conditional block, to be looked at another time.

Changes:

- Remove and refactor blocks for supporting granny code in W3DAssetManager.
- Remove conditional blocks for granny from W3DScene and W3DTerrainVisual.
- Remove commented out granny affiliated code from W3DVolumetricShadow and correct comment on Iterator.