### PR TITLE
[GEN] Backport BlurTime functionality in WW3D2's ParticleBufferClass

### DIFF
--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/part_buf.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/part_buf.h
@@ -89,7 +89,8 @@ class ParticleBufferClass : public RenderObjClass
 		ParticleBufferClass(ParticleEmitterClass *emitter, unsigned int buffer_size,
 			ParticlePropertyStruct<Vector3> &color, ParticlePropertyStruct<float> &opacity,
 			ParticlePropertyStruct<float> &size, ParticlePropertyStruct<float> &rotation,
-			float orient_rnd, ParticlePropertyStruct<float> &frame, Vector3 accel,
+			float orient_rnd, ParticlePropertyStruct<float> &frame,
+			ParticlePropertyStruct<float> &blurtime, Vector3 accel,
 			float max_age, TextureClass *tex, ShaderClass shader, bool pingpong,
 			int render_mode, int frame_mode, const W3dEmitterLinePropertiesStruct * line_props);
 
@@ -151,6 +152,7 @@ class ParticleBufferClass : public RenderObjClass
 		void Reset_Size(ParticlePropertyStruct<float> &new_props);
 		void Reset_Rotations(ParticlePropertyStruct<float> &new_rotations, float orient_rnd);
 		void Reset_Frames(ParticlePropertyStruct<float> &new_frames);
+		void Reset_Blur_Times(ParticlePropertyStruct<float> &new_blur_times);
 
 		// This informs the buffer that the emitter is dead, so it can release
 		// its pointer to it and be removed itself after all its particles dies
@@ -217,6 +219,7 @@ class ParticleBufferClass : public RenderObjClass
 		void						Get_Size_Key_Frames (ParticlePropertyStruct<float>	&sizes) const;
 		void						Get_Rotation_Key_Frames (ParticlePropertyStruct<float> &rotations) const;
 		void						Get_Frame_Key_Frames (ParticlePropertyStruct<float> &frames) const;
+		void						Get_Blur_Time_Key_Frames (ParticlePropertyStruct<float> &blurtimes) const;
 		float						Get_Initial_Orientation_Random (void) const { return InitialOrientationRandom; }
 
 		// Total Active Particle Buffer Count
@@ -329,6 +332,10 @@ class ParticleBufferClass : public RenderObjClass
 		unsigned int * FrameKeyFrameTimes;		// 0th entry is always 0
 		float *			FrameKeyFrameValues;
 		float *			FrameKeyFrameDeltas;
+		unsigned int	NumBlurTimeKeyFrames;
+		unsigned int * BlurTimeKeyFrameTimes;		// 0th entry is always 0
+		float *			BlurTimeKeyFrameValues;
+		float *			BlurTimeKeyFrameDeltas;
 
 		// These tables are indexed by the array position in the particle buffer.
 		// The table size is either the smallest power of two equal or larger
@@ -350,12 +357,15 @@ class ParticleBufferClass : public RenderObjClass
 		float *			RandomOrientationEntries;
 		unsigned int	NumRandomFrameEntriesMinus1;			// 2^n - 1 so can be used as a mask also
 		float *			RandomFrameEntries;
+		unsigned int	NumRandomBlurTimeEntriesMinus1;		// 2^n - 1 so can be used as a mask also
+		float *			RandomBlurTimeEntries;
 		
 		Vector3			ColorRandom;
 		float				OpacityRandom;
 		float				SizeRandom;
 		float				RotationRandom;
 		float				FrameRandom;
+		float				BlurTimeRandom;
 		float				InitialOrientationRandom;
 
 		// This object implements particle rendering
@@ -375,6 +385,7 @@ class ParticleBufferClass : public RenderObjClass
 		ShareBufferClass<float> *		Alpha;
 		ShareBufferClass<float> *		Size;
 		ShareBufferClass<uint8> *		Frame;
+		ShareBufferClass<Vector3> *	TailPosition;	// Only used for line groups
 		ShareBufferClass<uint8> *		Orientation;
 		ShareBufferClass<unsigned int> *	APT;
 

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/part_emt.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/part_emt.h
@@ -115,6 +115,7 @@ class ParticleEmitterClass : public RenderObjClass
 			ParticlePropertyStruct<float> &size, 
 			ParticlePropertyStruct<float> &rotation, float orient_rnd,
 			ParticlePropertyStruct<float> &frames,
+			ParticlePropertyStruct<float> &blur_times,
 			Vector3 accel, float max_age, TextureClass *tex,
 			ShaderClass shader = ShaderClass::_PresetAdditiveSpriteShader, 
 			int max_particles = 0, int max_buffer_size = -1, bool pingpong = false,
@@ -159,7 +160,7 @@ class ParticleEmitterClass : public RenderObjClass
 		virtual void			Set_Animation_Hidden(int onoff)	{ RenderObjClass::Set_Animation_Hidden (onoff); Update_On_Visibilty (); }
 		virtual void			Set_Force_Visible(int onoff)		{ RenderObjClass::Set_Force_Visible (onoff); Update_On_Visibilty (); }
 
-		virtual void				Set_LOD_Bias(float bias)			{ if (Buffer) Buffer->Set_LOD_Bias(bias); }
+		virtual void			Set_LOD_Bias(float bias)			{ if (Buffer) Buffer->Set_LOD_Bias(bias); }
 
 
 		// These are not part of the renderobject interface:
@@ -184,6 +185,7 @@ class ParticleEmitterClass : public RenderObjClass
 		void Reset_Size(ParticlePropertyStruct<float> &new_props)								{ if (Buffer) Buffer->Reset_Size(new_props); }
 		void Reset_Rotations(ParticlePropertyStruct<float> &new_props, float orient_rnd)	{ if (Buffer) Buffer->Reset_Rotations(new_props, orient_rnd); }
 		void Reset_Frames(ParticlePropertyStruct<float> &new_props)								{ if (Buffer) Buffer->Reset_Frames(new_props); }
+		void Reset_Blur_Times(ParticlePropertyStruct<float> &new_props)								{ if (Buffer) Buffer->Reset_Blur_Times(new_props); }
 
 		// Change emission/burst rate, or tell the emitter to emit a one-time burst.
 		// NOTE: default buffer size fits the emission/burst rate that the emitter was created with.
@@ -252,6 +254,7 @@ class ParticleEmitterClass : public RenderObjClass
 		void						Get_Size_Key_Frames (ParticlePropertyStruct<float>	&sizes) const				{ Buffer->Get_Size_Key_Frames (sizes); }
 		void						Get_Rotation_Key_Frames (ParticlePropertyStruct<float> &rotations) const	{ Buffer->Get_Rotation_Key_Frames (rotations); }
 		void						Get_Frame_Key_Frames (ParticlePropertyStruct<float> &frames) const			{ Buffer->Get_Frame_Key_Frames (frames); }
+		void						Get_Blur_Time_Key_Frames (ParticlePropertyStruct<float> &blurtimes) const	{ Buffer->Get_Blur_Time_Key_Frames (blurtimes); }
 		float						Get_Initial_Orientation_Random (void) const											{ return Buffer->Get_Initial_Orientation_Random(); }
 
 		// Line rendering accessors


### PR DESCRIPTION
Needed for W3DView, afaict this shouldn't affect any behaviors so hopefully this doesn't backport the reason particles are broken in ZH version
Line Group code isn't ported over yet so this code won't be functional as TailPosition remains NULL