### PR TITLE
[GEN] Bring texture related code in WW3D2 closer to Zero Hour

### DIFF
--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/TerrainTex.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/TerrainTex.cpp
@@ -88,7 +88,7 @@ int TerrainTextureClass::update(WorldHeightMap *htMap)
 	IDirect3DSurface8 *surface_level;
 	D3DSURFACE_DESC surface_desc;
 	D3DLOCKED_RECT locked_rect;
-	DX8_ErrorCode(D3DTexture->GetSurfaceLevel(0, &surface_level));
+	DX8_ErrorCode(Peek_D3D_Texture()->GetSurfaceLevel(0, &surface_level));
 	DX8_ErrorCode(surface_level->GetDesc(&surface_desc));
 	if (surface_desc.Width < TEXTURE_WIDTH) {
 		surface_level->Release();
@@ -186,9 +186,9 @@ int TerrainTextureClass::update(WorldHeightMap *htMap)
 	}
 	surface_level->UnlockRect();
 	surface_level->Release();
-	DX8_ErrorCode(D3DXFilterTexture(D3DTexture, NULL, 0, D3DX_FILTER_BOX));	
+	DX8_ErrorCode(D3DXFilterTexture(Peek_D3D_Texture(), NULL, 0, D3DX_FILTER_BOX));	
 	if (TheWritableGlobalData->m_textureReductionFactor) {
-		D3DTexture->SetLOD(TheWritableGlobalData->m_textureReductionFactor);
+		Peek_D3D_Texture()->SetLOD(TheWritableGlobalData->m_textureReductionFactor);
 	}
 	return(surface_desc.Height);
 }
@@ -362,7 +362,7 @@ int TerrainTextureClass::update256(WorldHeightMap *htMap)
 	IDirect3DSurface8 *surface_level;
 	D3DSURFACE_DESC surface_desc;
 	D3DLOCKED_RECT locked_rect;
-	DX8_ErrorCode(D3DTexture->GetSurfaceLevel(0, &surface_level));
+	DX8_ErrorCode(Peek_D3D_Texture()->GetSurfaceLevel(0, &surface_level));
 	DX8_ErrorCode(surface_level->GetDesc(&surface_desc));
 	if (surface_desc.Width != 256) {
 		surface_level->Release();
@@ -499,7 +499,7 @@ int TerrainTextureClass::update256(WorldHeightMap *htMap)
 	}
 	surface_level->UnlockRect();
 	surface_level->Release();
-	DX8_ErrorCode(D3DXFilterTexture(D3DTexture, NULL, 0, D3DX_FILTER_BOX));
+	DX8_ErrorCode(D3DXFilterTexture(Peek_D3D_Texture(), NULL, 0, D3DX_FILTER_BOX));
 	// Note - normal width for the terrain texture is 1024.  We are at 256
 	// probably running on a voodoo.  The height we return is scaled up 
 	// to match the expected width of 1024.  jba.
@@ -565,14 +565,9 @@ AlphaTerrainTextureClass::AlphaTerrainTextureClass( TextureClass *pBaseTex ):
 	TextureClass(8, 8, 
 		WW3D_FORMAT_A1R5G5B5, MIP_LEVELS_1 )
 { 
-	if (D3DTexture) {
-		// Release the 8x8 texture.
-		D3DTexture->Release();
-		D3DTexture = NULL;
-	}
 	// Attach the base texture's d3d texture.
-	D3DTexture = pBaseTex->Peek_D3D_Texture();
-	D3DTexture->AddRef();
+	IDirect3DTexture8 * d3d_tex = pBaseTex->Peek_D3D_Texture();
+	Set_D3D_Base_Texture(d3d_tex);
 }
 
 
@@ -849,7 +844,7 @@ int AlphaEdgeTextureClass::update(WorldHeightMap *htMap)
 	IDirect3DSurface8 *surface_level;
 	D3DSURFACE_DESC surface_desc;
 	D3DLOCKED_RECT locked_rect;
-	DX8_ErrorCode(D3DTexture->GetSurfaceLevel(0, &surface_level));
+	DX8_ErrorCode(Peek_D3D_Texture()->GetSurfaceLevel(0, &surface_level));
 	DX8_ErrorCode(surface_level->LockRect(&locked_rect, NULL, 0));
 	DX8_ErrorCode(surface_level->GetDesc(&surface_desc));
 
@@ -912,7 +907,7 @@ int AlphaEdgeTextureClass::update(WorldHeightMap *htMap)
 	}
 	surface_level->UnlockRect();
 	surface_level->Release();
-	DX8_ErrorCode(D3DXFilterTexture(D3DTexture, NULL, 0, D3DX_FILTER_BOX));
+	DX8_ErrorCode(D3DXFilterTexture(Peek_D3D_Texture(), NULL, 0, D3DX_FILTER_BOX));
 	return(surface_desc.Height);
 }
 

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -670,7 +670,6 @@ void W3DDisplay::init( void )
 	WW3D::Set_Prelit_Mode( WW3D::PRELIT_MODE_LIGHTMAP_MULTI_PASS );
 	WW3D::Set_Collision_Box_Display_Mask(0x00);	///<set to 0xff to make collision boxes visible
 	WW3D::Enable_Static_Sort_Lists(true);
-	WW3D::Set_Texture_Compression_Mode(WW3D::TEXTURE_COMPRESSION_ENABLE);
 	WW3D::Set_Thumbnail_Enabled(false);
 	WW3D::Set_Screen_UV_Bias( TRUE );  ///< this makes text look good :)
 			

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/assetmgr.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/assetmgr.cpp
@@ -1095,10 +1095,20 @@ TextureClass * WW3DAssetManager::Get_Texture
 	const char * filename, 
 	MipCountType mip_level_count,
 	WW3DFormat texture_format,
-	bool allow_compression
+	bool allow_compression,
+	TextureBaseClass::TexAssetType type,
+	bool allow_reduction
 )
 {
 	WWPROFILE( "WW3DAssetManager::Get_Texture 1" );
+
+	/*
+	** We cannot currently mip-map bumpmaps
+	*/
+	if (texture_format==WW3D_FORMAT_U8V8) 
+	{
+		mip_level_count=MIP_LEVELS_1;
+	}
 
 	/*
 	** Bail if the user isn't really asking for anything
@@ -1114,11 +1124,10 @@ TextureClass * WW3DAssetManager::Get_Texture
 	/*
 	** See if the texture has already been loaded.
 	*/
-
 	TextureClass* tex = TextureHash.Get(lower_case_name);
 	if (tex && texture_format!=WW3D_FORMAT_UNKNOWN) 
 	{
-		WWASSERT_PRINT(tex->Get_Texture_Format()==texture_format,("Texture %s has already been loaded witt different format",filename));
+		WWASSERT_PRINT(tex->Get_Texture_Format()==texture_format,("Texture %s has already been loaded with different format",filename));
 	}
 
 	/*
@@ -1126,7 +1135,10 @@ TextureClass * WW3DAssetManager::Get_Texture
 	*/
 	if (!tex) 
 	{
-		tex = NEW_REF (TextureClass, (lower_case_name, NULL, mip_level_count, texture_format, allow_compression));
+		if (type==TextureBaseClass::TEX_REGULAR)
+		{
+			tex = NEW_REF (TextureClass, (lower_case_name, NULL, mip_level_count, texture_format, allow_compression));
+		}
 		TextureHash.Insert(tex->Get_Texture_Name(),tex);
 	}
 

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/assetmgr.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/assetmgr.h
@@ -16,7 +16,7 @@
 **	along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/* $Header: /Commando/Code/ww3d2/assetmgr.h 15    7/24/01 6:28p Jani_p $ */
+/* $Header: /Commando/Code/ww3d2/assetmgr.h 19    12/17/01 7:55p Jani_p $ */
 /*********************************************************************************************** 
  ***                            Confidential - Westwood Studios                              *** 
  *********************************************************************************************** 
@@ -27,9 +27,9 @@
  *                                                                                             * 
  *                       Author:: Greg_h                                                       * 
  *                                                                                             * 
- *                     $Modtime:: 7/17/01 5:52p                                               $* 
+ *                     $Modtime:: 12/15/01 4:14p                                              $* 
  *                                                                                             * 
- *                    $Revision:: 15                                                          $* 
+ *                    $Revision:: 19                                                          $* 
  *                                                                                             * 
  *---------------------------------------------------------------------------------------------* 
  * Functions:                                                                                  * 
@@ -267,7 +267,9 @@ public:
 		const char * filename, 
 		MipCountType mip_level_count=MIP_LEVELS_ALL,
 		WW3DFormat texture_format=WW3D_FORMAT_UNKNOWN,
-		bool allow_compression=true
+		bool allow_compression=true,
+		TextureBaseClass::TexAssetType type=TextureBaseClass::TEX_REGULAR,
+		bool allow_reduction=true
 	);
 	TextureClass*						Get_Bumpmap_Based_On_Texture(TextureClass* texture);
 

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/ddsfile.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/ddsfile.cpp
@@ -99,10 +99,10 @@ DDSFileClass::DDSFileClass(const char* name,unsigned reduction_factor)
 	if (MipLevels==0) MipLevels=1;
 
 	//Adjust the reduction factor to keep textures above some minimum dimensions
-	if (MipLevels <= WW3D::Get_Texture_Min_Mip_Levels())
+	if (MipLevels <= WW3D::Get_Texture_Min_Dimension())
 		ReductionFactor=0;
 	else
-	{	int mipToDrop=MipLevels-WW3D::Get_Texture_Min_Mip_Levels();
+	{	int mipToDrop=MipLevels-WW3D::Get_Texture_Min_Dimension();
 		if (ReductionFactor >= mipToDrop)
 			ReductionFactor=mipToDrop;
 	}

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
@@ -2248,9 +2248,9 @@ void DX8Wrapper::_Update_Texture(TextureClass *system, TextureClass *video)
 {
 	WWASSERT(system);
 	WWASSERT(video);
-	WWASSERT(system->Pool==TextureClass::POOL_SYSTEMMEM);
-	WWASSERT(video->Pool==TextureClass::POOL_DEFAULT);
-	DX8CALL(UpdateTexture(system->D3DTexture,video->D3DTexture));
+	WWASSERT(system->Get_Pool()==TextureClass::POOL_SYSTEMMEM);
+	WWASSERT(video->Get_Pool()==TextureClass::POOL_DEFAULT);
+	DX8CALL(UpdateTexture(system->Peek_D3D_Base_Texture(),video->Peek_D3D_Base_Texture()));
 }
 
 void DX8Wrapper::Compute_Caps(WW3DFormat display_format)
@@ -2504,7 +2504,7 @@ DX8Wrapper::Create_Render_Target (int width, int height, bool alpha)
 
 	// 3dfx drivers are lying in the CheckDeviceFormat call and claiming
 	// that they support render targets!
-	if (tex->Peek_D3D_Texture() == NULL) 
+	if (tex->Peek_D3D_Base_Texture() == NULL) 
 	{
 		WWDEBUG_SAY(("DX8Wrapper - Render target creation failed!\r\n"));
 		REF_PTR_RELEASE(tex);

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
@@ -239,6 +239,9 @@ public:
 	*/
 	static void	Do_Onetime_Device_Dependent_Inits(void);
 	static void Do_Onetime_Device_Dependent_Shutdowns(void);
+
+	static bool Is_Initted(void) { return IsInitted; }
+
 	static bool Has_Stencil (void);
 	static void Get_Format_Name(unsigned int format, StringClass *tex_format);
 
@@ -329,6 +332,7 @@ public:
 	/*
 	** Resources
 	*/
+
 	static IDirect3DTexture8 * _Create_DX8_Texture
 	(
 		unsigned int width,

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/part_emt.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/part_emt.cpp
@@ -212,8 +212,9 @@ ParticleEmitterClass::Create_From_Definition (const ParticleEmitterDefClass &def
 		(
 			ptexture_filename,
 			MIP_LEVELS_ALL,
-			WW3D_FORMAT_UNKNOWN,
-			false);	// no compression for particle textures!
+			WW3D_FORMAT_UNKNOWN
+		);
+//			false);	// no compression for particle textures!
 	}
 	
 	ShaderClass shader;

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/texture.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/texture.cpp
@@ -290,7 +290,7 @@ TextureClass::TextureClass(IDirect3DTexture8* d3d_texture)
 {
 	D3DTexture->AddRef();
 	IDirect3DSurface8* surface;
-	DX8_ErrorCode(D3DTexture->GetSurfaceLevel(0,&surface));
+	DX8_ErrorCode(Peek_D3D_Texture()->GetSurfaceLevel(0,&surface));
 	D3DSURFACE_DESC d3d_desc;
 	::ZeroMemory(&d3d_desc, sizeof(D3DSURFACE_DESC));
 	DX8_ErrorCode(surface->GetDesc(&d3d_desc));
@@ -370,6 +370,35 @@ void TextureClass::Invalidate()
 	}
 }
 
+//**********************************************************************************************
+//! Returns a pointer to the d3d texture
+/*! 
+*/
+IDirect3DBaseTexture8 * TextureClass::Peek_D3D_Base_Texture() const 
+{ 	
+	LastAccessed=WW3D::Get_Sync_Time(); 
+	return D3DTexture; 
+}
+
+//**********************************************************************************************
+//! Set the d3d texture pointer.  Handles ref counts properly.
+/*! 
+*/
+void TextureClass::Set_D3D_Base_Texture(IDirect3DBaseTexture8* tex) 
+{ 
+	// (gth) Generals does stuff directly with the D3DTexture pointer so lets
+	// reset the access timer whenever someon messes with this pointer.
+	LastAccessed=WW3D::Get_Sync_Time();
+	
+	if (D3DTexture != NULL) {
+		D3DTexture->Release();
+	}
+	D3DTexture = tex;
+	if (D3DTexture != NULL) {
+		D3DTexture->AddRef();
+	}
+}
+
 // ----------------------------------------------------------------------------
 
 void TextureClass::Load_Locked_Surface()
@@ -424,7 +453,7 @@ void TextureClass::Get_Level_Description(SurfaceClass::SurfaceDescription &surfa
 	}
 
 	D3DSURFACE_DESC d3d_surf_desc;
-	DX8_ErrorCode(D3DTexture->GetLevelDesc(level, &d3d_surf_desc));
+	DX8_ErrorCode(Peek_D3D_Texture()->GetLevelDesc(level, &d3d_surf_desc));
 	surface_desc.Format = D3DFormat_To_WW3DFormat(d3d_surf_desc.Format);
 	surface_desc.Height = d3d_surf_desc.Height; 
 	surface_desc.Width = d3d_surf_desc.Width;
@@ -435,7 +464,7 @@ void TextureClass::Get_Level_Description(SurfaceClass::SurfaceDescription &surfa
 SurfaceClass *TextureClass::Get_Surface_Level(unsigned int level)
 {
 	IDirect3DSurface8 *d3d_surface = NULL;
-	DX8_ErrorCode(D3DTexture->GetSurfaceLevel(level, &d3d_surface));
+	DX8_ErrorCode(Peek_D3D_Texture()->GetSurfaceLevel(level, &d3d_surface));
 	SurfaceClass *surface = W3DNEW SurfaceClass(d3d_surface);
 	d3d_surface->Release();
 	return surface;
@@ -520,7 +549,7 @@ void TextureClass::Apply_New_Surface(bool initialized)
 
 	WWASSERT(D3DTexture);
 	IDirect3DSurface8* surface;
-	DX8_ErrorCode(D3DTexture->GetSurfaceLevel(0,&surface));
+	DX8_ErrorCode(Peek_D3D_Texture()->GetSurfaceLevel(0,&surface));
 	D3DSURFACE_DESC d3d_desc;
 	::ZeroMemory(&d3d_desc, sizeof(D3DSURFACE_DESC));
 	DX8_ErrorCode(surface->GetDesc(&d3d_desc));

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/texture.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/texture.h
@@ -50,8 +50,10 @@
 #include "wwstring.h"
 #include "texturefilter.h"
 
-class DX8Wrapper;
+struct IDirect3DBaseTexture8;
 struct IDirect3DTexture8;
+
+class DX8Wrapper;
 class TextureLoader;
 class LoaderThreadClass;
 class DX8TextureManagerClass;
@@ -82,6 +84,11 @@ class TextureClass : public W3DMPO, public RefCountClass
 			POOL_SYSTEMMEM
 		};
 
+		enum TexAssetType
+		{
+			TEX_REGULAR,
+		};
+
 		// Create texture with desired height, width and format.
 		TextureClass(
 			unsigned width, 
@@ -107,6 +114,8 @@ class TextureClass : public W3DMPO, public RefCountClass
 			MipCountType mip_level_count=MIP_LEVELS_ALL);		
 
 		TextureClass(IDirect3DTexture8* d3d_texture);
+
+		virtual TexAssetType Get_Asset_Type() const { return TEX_REGULAR; }
 
 		virtual ~TextureClass(void);
 
@@ -165,10 +174,13 @@ class TextureClass : public W3DMPO, public RefCountClass
 		// This utility function processes the texture reduction (used during rendering)
 		void Invalidate();
 
-		IDirect3DTexture8 *Peek_D3D_Texture()
-		{
-			return D3DTexture;
-		}
+		IDirect3DTexture8 *Peek_D3D_Texture() const { return (IDirect3DTexture8 *)Peek_D3D_Base_Texture(); }
+
+		// texture accessors (dx8)
+		IDirect3DBaseTexture8 *Peek_D3D_Base_Texture() const;
+		void Set_D3D_Base_Texture(IDirect3DBaseTexture8* tex);
+
+		PoolType Get_Pool() const { return Pool; }
 
 		bool Is_Missing_Texture();
 
@@ -194,7 +206,7 @@ class TextureClass : public W3DMPO, public RefCountClass
 		TextureFilterClass Filter;
 
 		// Direct3D texture object
-		IDirect3DTexture8 *D3DTexture;
+		IDirect3DBaseTexture8 *D3DTexture;
 		bool Initialized;
 
 		// Name
@@ -215,7 +227,7 @@ class TextureClass : public W3DMPO, public RefCountClass
 		bool IsProcedural;
 		bool IsCompressionAllowed;
 
-		unsigned LastAccessed;
+		mutable unsigned LastAccessed;
 		WW3DFormat TextureFormat;
 
 		int Width;

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/textureloader.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/textureloader.cpp
@@ -72,9 +72,8 @@ static bool Is_Format_Compressed(WW3DFormat texture_format,bool allow_compressio
 	// If hardware supports DXTC compression, load a compressed texture. Proceed only if the texture format hasn't been
 	// defined as non-compressed.
 	compressed|=(
-		texture_format==WW3D_FORMAT_UNKNOWN && 
-		DX8Wrapper::Get_Current_Caps()->Support_DXTC() && 
-		WW3D::Get_Texture_Compression_Mode()==WW3D::TEXTURE_COMPRESSION_ENABLE &&
+		texture_format==WW3D_FORMAT_UNKNOWN &&
+		DX8Wrapper::Get_Current_Caps()->Support_DXTC() &&
 		allow_compression);
 
 	return compressed;
@@ -1115,10 +1114,10 @@ void TextureLoadTaskClass::Begin_Texture_Load()
 					MipLevels++;
 
 			//Adjust the reduction factor to keep textures above some minimum dimensions
-			if (MipLevels <= WW3D::Get_Texture_Min_Mip_Levels())
+			if (MipLevels <= WW3D::Get_Texture_Min_Dimension())
 				ReductionFactor=0;
 			else
-			{	int mipToDrop=MipLevels-WW3D::Get_Texture_Min_Mip_Levels();
+			{	int mipToDrop=MipLevels-WW3D::Get_Texture_Min_Dimension();
 				if (ReductionFactor >= mipToDrop)
 					ReductionFactor=mipToDrop;
 			}

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
@@ -207,7 +207,6 @@ bool														WW3D::SnapshotActivated=false;
 bool														WW3D::ThumbnailEnabled=true;
 
 WW3D::MeshDrawModeEnum								WW3D::MeshDrawMode = MESH_DRAW_MODE_OLD;
-WW3D::TextureCompressionModeEnum					WW3D::TextureCompressionMode = TEXTURE_COMPRESSION_ENABLE;
 WW3D::NPatchesGapFillingModeEnum					WW3D::NPatchesGapFillingMode = NPATCHES_GAP_FILLING_ENABLED;
 unsigned													WW3D::NPatchesLevel=1;
 bool														WW3D::IsTexturingEnabled=true;
@@ -215,7 +214,8 @@ bool										WW3D::IsColoringEnabled=false;
 
 static HWND												_Hwnd = NULL;		// Not a member to hide windows from WW3D users
 static int												_TextureReduction = 0;
-static int												_TextureMinMipLevels = 1;
+static int												_TextureMinDim = 1;
+static bool												_LargeTextureExtraReductionEnabled = false;
 int														WW3D::LastFrameMemoryAllocations;
 int														WW3D::LastFrameMemoryFrees;
 
@@ -224,14 +224,6 @@ int														WW3D::LastFrameMemoryFrees;
 **  WW3D Static Functions
 **
 ***********************************************************************************/
-
-void WW3D::Set_Texture_Compression_Mode(TextureCompressionModeEnum mode)
-{
-	if (TextureCompressionMode!=mode) {
-		TextureCompressionMode = mode; 
-		_Invalidate_Textures();
-	}
-}
 
 void WW3D::Set_NPatches_Gap_Filling_Mode(NPatchesGapFillingModeEnum mode)
 {
@@ -1615,11 +1607,13 @@ float	WW3D::Get_Movie_Capture_Frame_Rate( void )
  * HISTORY:                                                                                    *
  *   5/19/99    GTH : Created.                                                                 *
  *=============================================================================================*/
-void	WW3D::Set_Texture_Reduction( int value, int min_mip_levels )
+void	WW3D::Set_Texture_Reduction( int value, int minDim )
 {
-	_TextureReduction=value;
-	_TextureMinMipLevels=min_mip_levels;
-	_Invalidate_Textures();
+	if (_TextureReduction != value || _TextureMinDim != minDim) {
+		_TextureReduction=value;
+		_TextureMinDim=minDim;
+		_Invalidate_Textures();
+	}
 }
 
 
@@ -1664,9 +1658,22 @@ int	WW3D::Get_Texture_Reduction( void )
  * HISTORY:                                                                                    *
  *   11/25/99    TSS : Created.                                                                 *
  *=============================================================================================*/
-int	WW3D::Get_Texture_Min_Mip_Levels( void )
+int	WW3D::Get_Texture_Min_Dimension( void )
 {
-	return _TextureMinMipLevels;
+	return _TextureMinDim;
+}
+
+void WW3D::Enable_Large_Texture_Extra_Reduction(bool onoff)
+{
+	if (_LargeTextureExtraReductionEnabled != onoff) {
+		_LargeTextureExtraReductionEnabled = onoff;
+		_Invalidate_Textures();
+	}
+}
+
+bool WW3D::Is_Large_Texture_Extra_Reduction_Enabled(void)
+{
+	return _LargeTextureExtraReductionEnabled;
 }
 
 /***********************************************************************************************

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/ww3d.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/ww3d.h
@@ -93,11 +93,6 @@ public:
 		MESH_DRAW_MODE_DX8_ONLY
 	};
 
-	enum TextureCompressionModeEnum {
-		TEXTURE_COMPRESSION_DISABLE,
-		TEXTURE_COMPRESSION_ENABLE
-	};
-
 	enum NPatchesGapFillingModeEnum {
 		NPATCHES_GAP_FILLING_DISABLED,
 		NPATCHES_GAP_FILLING_ENABLED,
@@ -199,9 +194,11 @@ public:
 	** all textures to be half their normal resolution.  Passing in 3 causes them to
 	** be cut in half twice, etc
 	*/
-	static void					Set_Texture_Reduction( int value, int min_mip_levels=1 );
+	static void					Set_Texture_Reduction( int value, int min_dim=1 );
 	static int					Get_Texture_Reduction( void );
-	static int					Get_Texture_Min_Mip_Levels( void );
+	static int					Get_Texture_Min_Dimension(void);
+	static void					Enable_Large_Texture_Extra_Reduction(bool onoff);
+	static bool					Is_Large_Texture_Extra_Reduction_Enabled(void);
 	static void					_Invalidate_Mesh_Cache();
 	static void					_Invalidate_Textures();
 
@@ -238,9 +235,6 @@ public:
 
 	static void					Set_Mesh_Draw_Mode (MeshDrawModeEnum mode)	{ MeshDrawMode = mode; }
 	static MeshDrawModeEnum Get_Mesh_Draw_Mode ()								{ return (MeshDrawMode); }
-
-	static void					Set_Texture_Compression_Mode (TextureCompressionModeEnum mode);
-	static TextureCompressionModeEnum 	Get_Texture_Compression_Mode () { return (TextureCompressionMode); }
 
 	static void					Set_NPatches_Gap_Filling_Mode (NPatchesGapFillingModeEnum mode);
 	static NPatchesGapFillingModeEnum 	Get_NPatches_Gap_Filling_Mode () { return (NPatchesGapFillingMode); }
@@ -351,7 +345,6 @@ private:
 	static bool							ThumbnailEnabled;
 
 	static MeshDrawModeEnum			MeshDrawMode;
-	static TextureCompressionModeEnum TextureCompressionMode;
 	static NPatchesGapFillingModeEnum NPatchesGapFillingMode;
 	static unsigned NPatchesLevel;
 	static bool							IsTexturingEnabled;

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/ww3dformat.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/ww3dformat.h
@@ -26,12 +26,13 @@
  *                                                                                             *
  *              Original Author:: Nathaniel Hoffman                                            *
  *                                                                                             *
- *                      $Author:: Jani_p                                                      $*
+ *                       Author : Kenny Mitchell                                               * 
+ *                                                                                             * 
+ *                     $Modtime:: 06/27/02 1:27p                                              $*
  *                                                                                             *
- *                     $Modtime:: 8/20/01 9:41a                                               $*
+ *                    $Revision:: 12                                                          $*
  *                                                                                             *
- *                    $Revision:: 9                                                           $*
- *                                                                                             *
+ * 06/27/02 KM Z Format support																						*
  *---------------------------------------------------------------------------------------------*
  * Functions:                                                                                  *
  * Vector4_to_Color - converts a vector4 to the format in format                               *
@@ -187,6 +188,9 @@ void Color_to_Vector4(Vector4* outc,const unsigned int inc,const WW3DFormat form
 // src_bpp - bytes per pixel in the source surface
 // targa - reference to the targa object...
 void Get_WW3D_Format(WW3DFormat& dest_format,WW3DFormat& src_format,unsigned& src_bpp,const Targa& targa);
+
+// The same as above, but doesn't validate the device - only checks the source format.
+void Get_WW3D_Format(WW3DFormat& src_format,unsigned& src_bpp,const Targa& targa);
 
 // Get valid texture format (on current hardware) that is closest to the given format (for instance, 32 bit ARGB8888 would
 // return 16 bit ARGB4444 if the device doesn't support 32 bit textures).

--- a/Generals/Code/Tools/WorldBuilder/src/wbview3d.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/wbview3d.cpp
@@ -2207,7 +2207,6 @@ void WbView3d::initWW3D()
 		}
 
 		WW3D::Enable_Static_Sort_Lists(true);
-		WW3D::Set_Texture_Compression_Mode(WW3D::TEXTURE_COMPRESSION_ENABLE);
 		WW3D::Set_Thumbnail_Enabled(false);
 		WW3D::Set_Screen_UV_Bias( TRUE );  ///< this makes text look good :)
 


### PR DESCRIPTION
This change refactors texture related code in WW3D2 to come closer to the implementation of Zero Hour. It does not change behaviour.