### PR TITLE
[GEN][ZH] Fix drawable assignment in StealthUpdate::changeVisualDisguise()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/StealthUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/StealthUpdate.cpp
@@ -755,7 +755,9 @@ void StealthUpdate::changeVisualDisguise()
 
 		const ThingTemplate *tTemplate = self->getTemplate();
 
-		TheThingFactory->newDrawable( tTemplate );
+		// TheSuperHackers @fix helmutbuhler 13/04/2025 Fixes missing pointer assignment for the new drawable.
+		// This originally caused no runtime crash because the new drawable is allocated at the same address as the previously deleted drawable via the MemoryPoolBlob.
+		draw = TheThingFactory->newDrawable( tTemplate );
 		if( draw )
 		{
 			TheGameLogic->bindObjectAndDrawable(self, draw);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/StealthUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/StealthUpdate.cpp
@@ -1055,7 +1055,9 @@ void StealthUpdate::changeVisualDisguise()
 
 		const ThingTemplate *tTemplate = self->getTemplate();
 
-		TheThingFactory->newDrawable( tTemplate );
+		// TheSuperHackers @fix helmutbuhler 13/04/2025 Fixes missing pointer assignment for the new drawable.
+		// This originally caused no runtime crash because the new drawable is allocated at the same address as the previously deleted drawable via the MemoryPoolBlob.
+		draw = TheThingFactory->newDrawable( tTemplate );
 		if( draw )
 		{
 			TheGameLogic->bindObjectAndDrawable(self, draw);


### PR DESCRIPTION
This fix was originally discovered by @helmutbuhler and split out of the original PR it was contained in.

This fix corrects the behaviour where when the drawable was not being set for a new visual disguise on a stealth unit.
The call to get the new drawable was not being handled correctly and was not updating the draw variable.
This would have resulted in a memory leak, possible use after free and unexpected behaviour with stealthing units.

- Relates https://github.com/TheSuperHackers/GeneralsGameCode/pull/716