### PR TITLE
[GEN][ZH] Fix uninitialized memory read in DockUpdate::loadDockPositions

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/DockUpdate/DockUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/DockUpdate/DockUpdate.cpp
@@ -501,7 +501,9 @@ void DockUpdate::loadDockPositions()
 		if( m_numberApproachPositions != DYNAMIC_APPROACH_VECTOR_FLAG )
 		{
 			// Dynamic means no bones
-			Coord3D approachBones[DEFAULT_APPROACH_VECTOR_SIZE];
+			// TheSuperHackers @fix helmutbuhler 19/04/2025 Zero initialize array to prevent uninitialized memory reads.
+			// Important: the entire target vector is used for serialization and crc and must not contain random data.
+			Coord3D approachBones[DEFAULT_APPROACH_VECTOR_SIZE] = {0};
 			m_numberApproachPositionBones = myDrawable->getPristineBonePositions( "DockWaiting", 1, approachBones, NULL, m_numberApproachPositions);
 			if( m_numberApproachPositions == m_approachPositions.size() )//safeguard: will always be true
 			{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/DockUpdate/DockUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/DockUpdate/DockUpdate.cpp
@@ -510,7 +510,9 @@ void DockUpdate::loadDockPositions()
 			if( m_numberApproachPositions != DYNAMIC_APPROACH_VECTOR_FLAG )
 			{
 				// Dynamic means no bones
-				Coord3D approachBones[DEFAULT_APPROACH_VECTOR_SIZE];
+				// TheSuperHackers @fix helmutbuhler 19/04/2025 Zero initialize array to prevent uninitialized memory reads.
+				// Important: the entire target vector is used for serialization and crc and must not contain random data.
+				Coord3D approachBones[DEFAULT_APPROACH_VECTOR_SIZE] = {0};
 				m_numberApproachPositionBones = myDrawable->getPristineBonePositions( "DockWaiting", 1, approachBones, NULL, m_numberApproachPositions);
 				if( m_numberApproachPositions == m_approachPositions.size() )//safeguard: will always be true
 				{


### PR DESCRIPTION
This fix was originally discovered by @helmutbuhler and split out of the original PR it was contained in.

This fix initiallises an array that is used immediately but not all of the bins are updated with data.
This can result in random contents being included instead of being zeroed.

- Relates https://github.com/TheSuperHackers/GeneralsGameCode/pull/716