### PR TITLE
[GEN][ZH] Refactor FileSystem::openFile to reduce file system overhead

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/System/FileSystem.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/FileSystem.cpp
@@ -176,14 +176,14 @@ File*		FileSystem::openFile( const Char *filename, Int access )
 	USE_PERF_TIMER(FileSystem)
 	File *file = NULL;
 
-	if ( TheLocalFileSystem != NULL )
-	{
-		file = TheLocalFileSystem->openFile( filename, access );
-	}
-
-	if ( (TheArchiveFileSystem != NULL) && (file == NULL) )
+	if ( TheArchiveFileSystem != NULL )
 	{
 		file = TheArchiveFileSystem->openFile( filename );
+	}
+
+	if ( (TheLocalFileSystem != NULL) && (file == NULL) )
+	{
+		file = TheLocalFileSystem->openFile( filename, access );
 	}
 
 	return file;

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/FileSystem.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/FileSystem.cpp
@@ -176,14 +176,14 @@ File*		FileSystem::openFile( const Char *filename, Int access )
 	USE_PERF_TIMER(FileSystem)
 	File *file = NULL;
 
-	if ( TheLocalFileSystem != NULL )
-	{
-		file = TheLocalFileSystem->openFile( filename, access );
-	}
-
-	if ( (TheArchiveFileSystem != NULL) && (file == NULL) )
+	if ( TheArchiveFileSystem != NULL )
 	{
 		file = TheArchiveFileSystem->openFile( filename );
+	}
+
+	if ( (TheLocalFileSystem != NULL) && (file == NULL) )
+	{
+		file = TheLocalFileSystem->openFile( filename, access );
 	}
 
 	return file;


### PR DESCRIPTION
This change is a small refactor to change the ordering where files are looked for.

The majority of the time the game will be getting files from loaded big archives, this refactor reduces disk access by checking the archives on disk or in ram first before checking the local file system.

Previously there would always be a superfluous disk access as the code would always check to see if the file existed in the local file system before checking the archive file system.