### PR TITLE
[BFME][ZH] Validate map chunk versions in debug

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
@@ -134,6 +134,7 @@ PolygonTrigger *PolygonTrigger::getPolygonTriggerByID(Int triggerID)
 */
 Bool PolygonTrigger::ParsePolygonTriggersDataChunk(DataChunkInput &file, DataChunkInfo *info, void *userData)
 {
+	DEBUG_ASSERTCRASH(info->version <= K_TRIGGERS_VERSION_4, ("PolygonTriggers chunk version newer than supported."));
 	Int count;
 	Int numPoints;
 	Int triggerID;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/SidesList.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/SidesList.cpp
@@ -242,6 +242,7 @@ void SidesList::clear(void)
 */
 Bool SidesList::ParseSidesDataChunk(DataChunkInput &file, DataChunkInfo *info, void *userData)
 {
+	DEBUG_ASSERTCRASH(info->version <= K_SIDES_DATA_VERSION_3, ("Sides chunk version newer than supported."));
 	DEBUG_ASSERTCRASH(TheSidesList, ("TheSidesList is null"));
 
 	if (TheSidesList==NULL) 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/WorldHeightMap.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/WorldHeightMap.cpp
@@ -762,6 +762,7 @@ void WorldHeightMap::setCliffState(Int xIndex, Int yIndex, Bool state)
 
 Bool WorldHeightMap::ParseWorldDictDataChunk(DataChunkInput &file, DataChunkInfo *info, void *userData)
 {
+	DEBUG_ASSERTCRASH(info->version <= K_WORLDDICT_VERSION_1, ("WorldDict chunk version newer than supported."));
 	Dict d = file.readDict();
 	*MapObject::getWorldDict() = d;
 	Bool exists;
@@ -781,6 +782,7 @@ Bool WorldHeightMap::ParseWorldDictDataChunk(DataChunkInput &file, DataChunkInfo
 */
 Bool WorldHeightMap::ParseLightingDataChunk(DataChunkInput &file, DataChunkInfo *info, void *userData)
 {
+		DEBUG_ASSERTCRASH(info->version <= K_LIGHTING_VERSION_3, ("Lighting chunk version newer than supported."));
 		TheWritableGlobalData->m_timeOfDay = (TimeOfDay)file.readInt();
 		Int i;
 		GlobalData::TerrainLighting	initLightValues	= { { 0,0,0},{0,0,0},{0,0,-1.0f}};
@@ -889,6 +891,7 @@ Bool WorldHeightMap::ParseHeightMapDataChunk(DataChunkInput &file, DataChunkInfo
 */
 Bool WorldHeightMap::ParseHeightMapData(DataChunkInput &file, DataChunkInfo *info, void *userData)
 {
+	DEBUG_ASSERTCRASH(info->version <= K_HEIGHT_MAP_VERSION_4, ("HeightMap chunk version newer than supported."));
 	m_width = file.readInt();
 	m_height = file.readInt();
 	if (info->version >= K_HEIGHT_MAP_VERSION_3) {
@@ -963,6 +966,7 @@ Bool WorldHeightMap::ParseSizeOnlyInChunk(DataChunkInput &file, DataChunkInfo *i
 */
 Bool WorldHeightMap::ParseSizeOnly(DataChunkInput &file, DataChunkInfo *info, void *userData)
 {
+	DEBUG_ASSERTCRASH(info->version <= K_HEIGHT_MAP_VERSION_4, ("HeightMap chunk version newer than supported."));
 	m_width = file.readInt();
 	m_height = file.readInt();
 	if (info->version >= K_HEIGHT_MAP_VERSION_3) {
@@ -1070,6 +1074,7 @@ void WorldHeightMap::readTexClass(TXTextureClass *texClass, TileData **tileData)
 */
 Bool WorldHeightMap::ParseBlendTileData(DataChunkInput &file, DataChunkInfo *info, void *userData)
 {
+	DEBUG_ASSERTCRASH(info->version <= K_BLEND_TILE_VERSION_8, ("BlendTile chunk version newer than supported."));
 	int i, j;
 	Int len = file.readInt();
 	if (m_dataSize != len) {
@@ -1250,6 +1255,7 @@ Bool WorldHeightMap::ParseObjectDataChunk(DataChunkInput &file, DataChunkInfo *i
 */
 Bool WorldHeightMap::ParseObjectData(DataChunkInput &file, DataChunkInfo *info, void *userData, Bool readDict)
 {
+	DEBUG_ASSERTCRASH(info->version <= K_OBJECTS_VERSION_3, ("Objects chunk version newer than supported."));
 	MapObject *pPrevious = (MapObject *)file.m_currentObject;
 
 	Coord3D loc;


### PR DESCRIPTION
Findings so far for BFME maps:
- HeightMap version increment from 4 to 5:
  - Version 5: Elevations are 16-bit (instead of 8-bit)
  - Version 6: There is a HeightMap border (This is post BFME, see OpenSage for reference)
- 