### PR TITLE
[GEN] Backport command line arguments from Zero Hour

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/CommandLine.h
+++ b/Generals/Code/GameEngine/Include/Common/CommandLine.h
@@ -1,5 +1,5 @@
 /*
-**	Command & Conquer Generals(tm)
+**	Command & Conquer Generals Zero Hour(tm)
 **	Copyright 2025 Electronic Arts Inc.
 **
 **	This program is free software: you can redistribute it and/or modify

--- a/Generals/Code/GameEngine/Include/Common/GlobalData.h
+++ b/Generals/Code/GameEngine/Include/Common/GlobalData.h
@@ -326,6 +326,7 @@ public:
 	AsciiString m_shellMapName;				///< Holds the shell map name
 	Bool m_shellMapOn;								///< User can set the shell map not to load
 	Bool m_playIntro;									///< Flag to say if we're to play the intro or not
+	Bool m_playSizzle;								///< Flag to say whether we play the sizzle movie after the logo movie.
 	Bool m_afterIntro;								///< we need to tell the game our intro is done
 	Bool m_allowExitOutOfMovies;			///< flag to allow exit out of movies only after the Intro has played
 
@@ -480,6 +481,7 @@ public:
 	Int m_latencyPeriod;					///< Period of sinusoidal modulation of latency
 	Int m_latencyNoise;						///< Max amplitude of jitter to throw in
 	Int m_packetLoss;							///< Percent of packets to drop
+	Bool m_extraLogging;					///< More expensive debug logging to catch crashes.
 #endif
 
 #ifdef DEBUG_CRASHING

--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -518,6 +518,7 @@ GlobalData* GlobalData::m_theOriginal = NULL;
 	{ "UseLocalMOTD",								INI::parseBool,				NULL,			offsetof( GlobalData, m_useLocalMOTD ) },
 	{ "BaseStatsDir",								INI::parseAsciiString,NULL,			offsetof( GlobalData, m_baseStatsDir ) },
 	{ "LocalMOTDPath",							INI::parseAsciiString,NULL,			offsetof( GlobalData, m_MOTDPath ) },
+	{ "ExtraLogging",								INI::parseBool,				NULL,			offsetof(GlobalData, m_extraLogging) },
 #endif
 
 	{ NULL,					NULL,						NULL,						0 }  // keep this last
@@ -581,6 +582,7 @@ GlobalData::GlobalData()
 	m_useLocalMOTD = FALSE;
 	m_baseStatsDir = ".\\";
 	m_MOTDPath = "MOTD.txt";
+	m_extraLogging = FALSE;
 #endif
 
 #ifdef DEBUG_CRASHING
@@ -957,6 +959,7 @@ GlobalData::GlobalData()
 	m_shellMapName.set("Maps\\ShellMap1\\ShellMap1.map");
 	m_shellMapOn =TRUE;
 	m_playIntro = TRUE;
+	m_playSizzle = TRUE;
 	m_afterIntro = FALSE;
 	m_allowExitOutOfMovies = FALSE;
 	m_loadScreenRender = FALSE;

--- a/Generals/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -511,7 +511,7 @@ void GameClient::update( void )
 	//Initial Game Codition.  We must show the movie first and then we can display the shell	
 	if(TheGlobalData->m_afterIntro && !TheDisplay->isMoviePlaying())
 	{
-		if( playSizzle)
+		if( playSizzle && TheGlobalData->m_playSizzle)
 		{
 			TheWritableGlobalData->m_allowExitOutOfMovies = TRUE;
 			if(TheGameLODManager && TheGameLODManager->didMemPass())

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -852,6 +852,14 @@ AsciiString AIStateMachine::getCurrentStateName(void) const
  */
 StateReturnType AIStateMachine::updateStateMachine()
 {
+	//-extraLogging
+	#if (defined(_DEBUG) || defined(_INTERNAL))
+	Bool idle = getOwner()->getAI()->isIdle();
+	if (!idle && TheGlobalData->m_extraLogging)
+		DEBUG_LOG(("%d - %s::update() start - %s", TheGameLogic->getFrame(), getCurrentStateName().str(), getOwner()->getTemplate()->getName().str()));
+	#endif
+	//end -extraLogging 
+
 	if (m_temporaryState)
 	{
 		// execute this state
@@ -862,13 +870,48 @@ StateReturnType AIStateMachine::updateStateMachine()
 				status = STATE_SUCCESS;
 			}
 		}
-		if (status==STATE_CONTINUE)	{
+		if (status==STATE_CONTINUE)	
+		{
+			//-extraLogging
+			#if (defined(_DEBUG) || defined(_INTERNAL))
+				if (!idle && TheGlobalData->m_extraLogging)
+					DEBUG_LOG((" - RETURN EARLY STATE_CONTINUE\n"));
+			#endif
+			//end -extraLogging 
 			return status;
 		}
 		m_temporaryState->onExit(EXIT_NORMAL);
 		m_temporaryState = NULL;
 	}
-	return StateMachine::updateStateMachine();
+	StateReturnType retType = StateMachine::updateStateMachine();
+
+	//-extraLogging 
+	#if (defined(_DEBUG) || defined(_INTERNAL))
+		AsciiString result;
+		if (TheGlobalData->m_extraLogging)
+		{
+			switch (retType)
+			{
+			case STATE_CONTINUE:
+				result.format("CONTINUE");
+				break;
+			case STATE_SUCCESS:
+				result.format("SUCCESS");
+				break;
+			case STATE_FAILURE:
+				result.format("FAILURE");
+				break;
+			default:
+				result.format("UNKNOWN %d", retType);
+				break;
+			}
+			if (!idle)
+				DEBUG_LOG((" - RETURNING %s\n", result.str()));
+		}
+	#endif
+	//end -extraLogging 
+
+	return retType;
 }
 
 //----------------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -743,11 +743,37 @@ UnsignedInt WeaponTemplate::fireWeaponTemplate
 	ObjectID* projectileID
 ) const
 {
+
+	//-extraLogging 
+	#if (defined(_DEBUG) || defined(_INTERNAL))
+		AsciiString targetStr;
+		if (TheGlobalData->m_extraLogging)
+		{
+			if (victimObj)
+				targetStr.format("%s", victimObj->getTemplate()->getName().str());
+			else if (victimPos)
+				targetStr.format("%d,%d,%d", victimPos->x, victimPos->y, victimPos->z);
+			else
+				targetStr.format("SELF.");
+
+			DEBUG_LOG(("%d - WeaponTemplate::fireWeaponTemplate() begin - %s attacking %s - ",
+				TheGameLogic->getFrame(), sourceObj->getTemplate()->getName().str(), targetStr.str()));
+		}
+	#endif
+	//end -extraLogging 
+
 	//CRCDEBUG_LOG(("WeaponTemplate::fireWeaponTemplate() from %s\n", DescribeObject(sourceObj).str()));
 	DEBUG_ASSERTCRASH(specificBarrelToUse >= 0, ("specificBarrelToUse should no longer be -1\n"));
 
 	if (sourceObj == NULL || (victimObj == NULL && victimPos == NULL))
 	{
+		//-extraLogging 
+		#if (defined(_DEBUG) || defined(_INTERNAL))
+			if (TheGlobalData->m_extraLogging)
+				DEBUG_LOG(("FAIL 1 (sourceObj %d == NULL || (victimObj %d == NULL && victimPos %d == NULL)\n", sourceObj != 0, victimObj != 0, victimPos != 0));
+		#endif
+		//end -extraLogging 
+
 		return 0;
 	}
 
@@ -819,6 +845,14 @@ UnsignedInt WeaponTemplate::fireWeaponTemplate
 		if (distSqr > attackRangeSqr)
 		{
 			//DEBUG_ASSERTCRASH(distSqr < 5*5 || distSqr < attackRangeSqr*1.2f, ("*** victim is out of range (%f vs %f) of this weapon -- why did we attempt to fire?\n",sqrtf(distSqr),sqrtf(attackRangeSqr)));
+			
+			//-extraLogging 
+			#if (defined(_DEBUG) || defined(_INTERNAL))
+				if( TheGlobalData->m_extraLogging )
+					DEBUG_LOG( ("FAIL 2 (distSqr %.2f > attackRangeSqr %.2f)\n", distSqr, attackRangeSqr ) );
+			#endif
+			//end -extraLogging 
+
 			return 0;
 		}
 	}
@@ -833,6 +867,14 @@ UnsignedInt WeaponTemplate::fireWeaponTemplate
 #endif
 		{
 			DEBUG_ASSERTCRASH(distSqr > minAttackRangeSqr*0.8f, ("*** victim is closer than min attack range (%f vs %f) of this weapon -- why did we attempt to fire?\n",sqrtf(distSqr),sqrtf(minAttackRangeSqr)));
+
+			//-extraLogging 
+			#if (defined(_DEBUG) || defined(_INTERNAL))
+				if( TheGlobalData->m_extraLogging )
+					DEBUG_LOG( ("FAIL 3 (distSqr %.2f< minAttackRangeSqr %.2f - 0.5f && !isProjectileDetonation %d)\n", distSqr, minAttackRangeSqr, isProjectileDetonation ) );
+			#endif
+			//end -extraLogging 
+
 			return 0;
 		}
 	}
@@ -921,6 +963,15 @@ UnsignedInt WeaponTemplate::fireWeaponTemplate
 			// go ahead and do it now
 			//DEBUG_LOG(("WeaponTemplate::fireWeaponTemplate: firing weapon immediately!\n"));
 			dealDamageInternal(sourceID, damageID, damagePos, bonus, isProjectileDetonation);
+
+			//-extraLogging 
+			#if (defined(_DEBUG) || defined(_INTERNAL))
+				if( TheGlobalData->m_extraLogging )
+					DEBUG_LOG( ("EARLY 4 (delayed damage applied now)\n") );
+			#endif
+			//end -extraLogging 
+
+
 			return TheGameLogic->getFrame();
 		}
 		else
@@ -933,6 +984,15 @@ UnsignedInt WeaponTemplate::fireWeaponTemplate
 				//DEBUG_LOG(("WeaponTemplate::fireWeaponTemplate: firing weapon in %d frames (= %d)!\n", delayInWholeFrames,when));
 				TheWeaponStore->setDelayedDamage(this, damagePos, when, sourceID, damageID, bonus);
 			}
+
+			//-extraLogging 
+			#if (defined(_DEBUG) || defined(_INTERNAL))
+				if( TheGlobalData->m_extraLogging )
+					DEBUG_LOG( ("EARLY 5 (delaying damage applied until frame %d)\n", when ) );
+			#endif
+			//end -extraLogging 
+
+
 			return when;
 		}
 	}
@@ -1040,6 +1100,13 @@ UnsignedInt WeaponTemplate::fireWeaponTemplate
 			// actually, this is ok, for things like Firestorm.... (srj)
 			projectile->setPosition(&projectileDestination);
 		}
+		//-extraLogging 
+		#if (defined(_DEBUG) || defined(_INTERNAL))
+			if( TheGlobalData->m_extraLogging )
+				DEBUG_LOG( ("DONE\n") );
+		#endif
+		//end -extraLogging 
+
 		return 0;
 	}
 }


### PR DESCRIPTION
This change unifies the code in CommandLine from Zero Hour to Generals.

ZH uses slightly different command line parameters.
This PR makes GEN uses the ZH version.

This also fixes an issue where -quickstart command was encapsulated in `Debug` and `Internal` flags since removal of `Playtest` flag, and thus didn't work in release versions.

Generals gets the followin new command line arguments:
* -extraLogging
* -stats
* -noshaders