### PR TITLE
[CMAKE] Move all RTS cmake options into early config-build.cmake to prevent cmake error on first generation

### DIFF
--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -14,12 +14,6 @@ target_link_libraries(corei_always INTERFACE
     corei_libraries_include
 )
 
-# Do we want to build extra SDK stuff or just the game binary?
-option(RTS_BUILD_CORE_TOOLS "Build core tools" ON)
-add_feature_info(CoreTools RTS_BUILD_CORE_TOOLS "Build Core Mod Tools")
-option(RTS_BUILD_CORE_EXTRAS "Build core extra tools/tests" OFF)
-add_feature_info(CoreExtras RTS_BUILD_CORE_EXTRAS "Build Core Extra Tools/Tests")
-
 # Set where the build results will end up
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 

--- a/Generals/CMakeLists.txt
+++ b/Generals/CMakeLists.txt
@@ -2,15 +2,6 @@ cmake_minimum_required(VERSION 3.25)
 
 project(g_generals LANGUAGES C CXX)
 
-# Do we want to build extra SDK stuff or just the game binary?
-option(RTS_BUILD_GENERALS_TOOLS "Build tools for Generals" ON)
-add_feature_info(GeneralsTools RTS_BUILD_GENERALS_TOOLS "Build Generals Mod Tools")
-option(RTS_BUILD_GENERALS_EXTRAS "Build extra tools/tests for Generals" OFF)
-add_feature_info(GeneralsExtras RTS_BUILD_GENERALS_EXTRAS "Build Generals Extra Tools/Tests")
-
-# Do we want to build documentation?
-option(RTS_BUILD_GENERALS_DOCS "Build documentation for Generals" OFF)
-add_feature_info(GeneralsDocs RTS_BUILD_GENERALS_DOCS "Build Generals Documentation")
 if (RTS_BUILD_GENERALS_DOCS)
     find_package(Doxygen REQUIRED)
     doxygen_add_docs(g_docs Code)

--- a/GeneralsMD/CMakeLists.txt
+++ b/GeneralsMD/CMakeLists.txt
@@ -2,15 +2,6 @@ cmake_minimum_required(VERSION 3.25)
 
 project(z_generals LANGUAGES C CXX)
 
-# Do we want to build extra SDK stuff or just the game binary?
-option(RTS_BUILD_ZEROHOUR_TOOLS "Build tools for Zero Hour" ON)
-add_feature_info(ZeroHourTools RTS_BUILD_ZEROHOUR_TOOLS "Build Zero Hour Mod Tools")
-option(RTS_BUILD_ZEROHOUR_EXTRAS "Build extra tools/tests for Zero Hour" OFF)
-add_feature_info(ZeroHourExtras RTS_BUILD_ZEROHOUR_EXTRAS "Build Zero Hour Extra Tools/Tests")
-
-# Do we want to build documentation?
-option(RTS_BUILD_ZEROHOUR_DOCS "Build documentation for Zero Hour" OFF)
-add_feature_info(ZeroHourDocs RTS_BUILD_ZEROHOUR_DOCS "Build Zero Hour Documentation")
 if (RTS_BUILD_ZEROHOUR_DOCS)
     find_package(Doxygen REQUIRED)
     doxygen_add_docs(z_docs Code)

--- a/cmake/config-build.cmake
+++ b/cmake/config-build.cmake
@@ -1,4 +1,6 @@
 # Do we want to build extra SDK stuff or just the game binary?
+option(RTS_BUILD_CORE_TOOLS "Build core tools" ON)
+option(RTS_BUILD_CORE_EXTRAS "Build core extra tools/tests" OFF)
 option(RTS_BUILD_ZEROHOUR "Build Zero Hour code." ON)
 option(RTS_BUILD_GENERALS "Build Generals code." ON)
 option(RTS_BUILD_OPTION_INTERNAL "Build code with the \"Internal\" configuration." OFF)
@@ -11,6 +13,8 @@ if(NOT RTS_BUILD_ZEROHOUR AND NOT RTS_BUILD_GENERALS)
     message("You must select one project to build, building Zero Hour by default.")
 endif()
 
+add_feature_info(CoreTools RTS_BUILD_CORE_TOOLS "Build Core Mod Tools")
+add_feature_info(CoreExtras RTS_BUILD_CORE_EXTRAS "Build Core Extra Tools/Tests")
 add_feature_info(ZeroHourStuff RTS_BUILD_ZEROHOUR "Build Zero Hour code")
 add_feature_info(GeneralsStuff RTS_BUILD_GENERALS "Build Generals code")
 add_feature_info(InternalBuild RTS_BUILD_OPTION_INTERNAL "Building as an \"Internal\" build")
@@ -18,6 +22,25 @@ add_feature_info(ProfileBuild RTS_BUILD_OPTION_PROFILE "Building as a \"Profile\
 add_feature_info(DebugBuild RTS_BUILD_OPTION_DEBUG "Building as a \"Debug\" build")
 add_feature_info(AddressSanitizer RTS_BUILD_OPTION_ASAN "Building with address sanitizer")
 
+if(RTS_BUILD_ZEROHOUR)
+    option(RTS_BUILD_ZEROHOUR_TOOLS "Build tools for Zero Hour" ON)
+    option(RTS_BUILD_ZEROHOUR_EXTRAS "Build extra tools/tests for Zero Hour" OFF)
+    option(RTS_BUILD_ZEROHOUR_DOCS "Build documentation for Zero Hour" OFF)
+
+    add_feature_info(ZeroHourTools RTS_BUILD_ZEROHOUR_TOOLS "Build Zero Hour Mod Tools")
+    add_feature_info(ZeroHourExtras RTS_BUILD_ZEROHOUR_EXTRAS "Build Zero Hour Extra Tools/Tests")
+    add_feature_info(ZeroHourDocs RTS_BUILD_ZEROHOUR_DOCS "Build Zero Hour Documentation")
+endif()
+
+if(RTS_BUILD_ZEROHOUR)
+    option(RTS_BUILD_GENERALS_TOOLS "Build tools for Generals" ON)
+    option(RTS_BUILD_GENERALS_EXTRAS "Build extra tools/tests for Generals" OFF)
+    option(RTS_BUILD_GENERALS_DOCS "Build documentation for Generals" OFF)
+
+    add_feature_info(GeneralsTools RTS_BUILD_GENERALS_TOOLS "Build Generals Mod Tools")
+    add_feature_info(GeneralsExtras RTS_BUILD_GENERALS_EXTRAS "Build Generals Extra Tools/Tests")
+    add_feature_info(GeneralsDocs RTS_BUILD_GENERALS_DOCS "Build Generals Documentation")
+endif()
 
 if(NOT IS_VS6_BUILD)
     # Because we set CMAKE_CXX_STANDARD_REQUIRED and CMAKE_CXX_EXTENSIONS in the compilers.cmake this should be enforced.

--- a/cmake/config-build.cmake
+++ b/cmake/config-build.cmake
@@ -32,7 +32,7 @@ if(RTS_BUILD_ZEROHOUR)
     add_feature_info(ZeroHourDocs RTS_BUILD_ZEROHOUR_DOCS "Build Zero Hour Documentation")
 endif()
 
-if(RTS_BUILD_ZEROHOUR)
+if(RTS_BUILD_GENERALS)
     option(RTS_BUILD_GENERALS_TOOLS "Build tools for Generals" ON)
     option(RTS_BUILD_GENERALS_EXTRAS "Build extra tools/tests for Generals" OFF)
     option(RTS_BUILD_GENERALS_DOCS "Build documentation for Generals" OFF)


### PR DESCRIPTION
This change fixes the CMake error on the first generation.

```
...

CMake Error at C:/Program Files/Microsoft Visual Studio/2022/Community/VC/vcpkg/scripts/buildsystems/vcpkg.cmake:598 (_add_executable):
  No SOURCES given to target: g_mapcachebuilder
Call Stack (most recent call first):
  Generals/Code/Tools/MapCacheBuilder/CMakeLists.txt:1 (add_executable)

CMake Generate step failed.  Build files cannot be regenerated correctly.
```

It happens because some RTS_GENERALS_* and RTS_ZEROHOUR_* related cmake options are created after they are used in Core.

This change creates all RTS cmake options before using them.

