### PR TITLE
[GEN][ZH] Fix hollow BOX particles treated as LINE particles in ParticleSystem::computeParticlePosition()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/System/ParticleSys.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/System/ParticleSys.cpp
@@ -1737,8 +1737,8 @@ const Coord3D *ParticleSystem::computeParticlePosition( void )
 				newPos.x = GameClientRandomValueReal( -m_emissionVolume.box.halfSize.x, m_emissionVolume.box.halfSize.x );
 				newPos.y = GameClientRandomValueReal( -m_emissionVolume.box.halfSize.y, m_emissionVolume.box.halfSize.y );
 				newPos.z = GameClientRandomValueReal( -m_emissionVolume.box.halfSize.z, m_emissionVolume.box.halfSize.z );
-			break;
 			}
+			break;
 		}
 
 		case LINE:

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/System/ParticleSys.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/System/ParticleSys.cpp
@@ -1637,8 +1637,8 @@ const Coord3D *ParticleSystem::computeParticlePosition( void )
 				newPos.x = GameClientRandomValueReal( -m_emissionVolume.box.halfSize.x, m_emissionVolume.box.halfSize.x );
 				newPos.y = GameClientRandomValueReal( -m_emissionVolume.box.halfSize.y, m_emissionVolume.box.halfSize.y );
 				newPos.z = GameClientRandomValueReal( -m_emissionVolume.box.halfSize.z, m_emissionVolume.box.halfSize.z );
-			break;
 			}
+			break;
 		}
 
 		case LINE:


### PR DESCRIPTION
A break statement was in the wrong scope leading to hollow boxes behaving as though they were line systems.

MSVC says
```
GeneralsMD\Code\GameEngine\Source\GameClient\System\ParticleSys.cpp(1644): warning C26819: Unannotated fallthrough between switch labels (es.78).
```