### PR TITLE
[GEN] Backport more of WW3D2 from Zero Hour

### DIFF
--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/assetmgr.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/assetmgr.cpp
@@ -200,6 +200,7 @@ protected:
 WW3DAssetManager::WW3DAssetManager(void) :
 	PrototypeLoaders		(PROTOLOADERS_VECTOR_SIZE),
 	Prototypes				(PROTOTYPES_VECTOR_SIZE),
+
 	WW3D_Load_On_Demand		(false),
 	Activate_Fog_On_Load		(false),
 	MetalManager(0)
@@ -212,7 +213,10 @@ WW3DAssetManager::WW3DAssetManager(void) :
 	Prototypes.Set_Growth_Step(PROTOTYPES_GROWTH_RATE);
 
 	// install the default loaders
+#ifndef USE_WWSHADE
 	Register_Prototype_Loader(&_MeshLoader);
+#endif
+
 	Register_Prototype_Loader(&_HModelLoader);
 	Register_Prototype_Loader(&_CollectionLoader);
 	Register_Prototype_Loader(&_BoxLoader);
@@ -798,7 +802,8 @@ RenderObjClass * WW3DAssetManager::Create_Render_Obj(const char * name)
 
 		// If we can't find it, try the parent directory
 		if ( Load_3D_Assets( filename ) == false ) {
-			StringClass	new_filename = StringClass("..\\") + filename;
+			StringClass	new_filename(StringClass("..\\"),true);
+			new_filename+=filename;
 			Load_3D_Assets( new_filename );
 		}
 
@@ -1024,7 +1029,8 @@ HTreeClass *	WW3DAssetManager::Get_HTree(const char * name)
 
 		// If we can't find it, try the parent directory
 		if ( Load_3D_Assets( filename ) == false ) {
-			StringClass	new_filename = StringClass("..\\") + filename;
+			StringClass	new_filename("..\\",true);
+			new_filename+=filename;
 			Load_3D_Assets( new_filename );
 		}
 

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8caps.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8caps.cpp
@@ -22,16 +22,17 @@
  *                                                                                             *
  *                 Project Name : dx8 caps                                                     *
  *                                                                                             *
- *                     $Archive:: /VSS_Sync/ww3d2/dx8caps.cpp                                 $*
+ *                     $Archive:: /Commando/Code/ww3d2/dx8caps.cpp                            $*
  *                                                                                             *
  *              Original Author:: Hector Yee                                                   *
  *                                                                                             *
- *                      $Author:: Vss_sync                                                    $*
+ *                       Author : Kenny Mitchell                                               * 
+ *                                                                                             * 
+ *                     $Modtime:: 06/27/02 1:27p                                              $*
  *                                                                                             *
- *                     $Modtime:: 8/29/01 8:16p                                               $*
+ *                    $Revision:: 31                                                          $*
  *                                                                                             *
- *                    $Revision:: 11                                                          $*
- *                                                                                             *
+ * 06/27/02 KM Z Format support																						*
  *---------------------------------------------------------------------------------------------*
  * Functions:                                                                                  *
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
@@ -40,6 +41,11 @@
 #include "dx8caps.h"
 #include "dx8wrapper.h"
 #include "formconv.h"
+#pragma warning (disable : 4201)		// nonstandard extension - nameless struct
+#include <windows.h>
+#include <mmsystem.h>
+
+static StringClass CapsWorkString;
 
 
 enum {
@@ -47,11 +53,429 @@ enum {
 	VENROD_ID_ATI=0x1002
 };
 
+
+static const char* VendorNames[]={
+	"Unknown",
+	"NVidia",
+	"ATI",
+	"Intel",
+	"S3",
+	"PowerVR",
+	"Matrox",
+	"3Dfx",
+	"3DLabs",
+	"CirrusLogic",
+	"Rendition"
+};
+
+DX8Caps::VendorIdType DX8Caps::Define_Vendor(unsigned vendor_id)
+{
+	switch (vendor_id) {
+	case 0x3d3d:
+	case 0x104c: return VENDOR_3DLABS;
+	case 0x12D2: // STB - NVIDIA's Riva128
+	case 0x14AF: // Guillemot's NVIDIA based cards
+	case 0x10de: return VENDOR_NVIDIA;
+	case 0x1002: return VENDOR_ATI;
+	case 0x8086: return VENDOR_INTEL;
+	case 0x5333: return VENDOR_S3;
+	case 0x104A: return VENDOR_POWERVR;
+	case 0x102B: return VENDOR_MATROX;
+	case 0x1142: // Alliance based reference cards
+	case 0x109D: // Macronix based reference cards
+	case 0x121A: return VENDOR_3DFX;
+	default:
+		return VENDOR_UNKNOWN;
+	}
+}
+
+static const char* DeviceNamesNVidia[]={
+	"Unknown NVidia device",
+	"GeForce3",
+	"Quadro2 PRO",
+	"GeForce2 Go",
+	"GeForce2 ULTRA",
+	"GeForce2 GTS",
+	"Quadro",
+	"GeForce DDR",
+	"GeForce 256",
+	"TNT2 Aladdin",
+	"TNT2",
+	"TNT2 ULTRA",
+	"TNT2 Vanta",
+	"TNT2 M64",
+	"TNT",
+	"RIVA 128",
+	"TNT Vanta",
+	"NV1",
+	"GeForce2 MX"
+	"GeForce4 Ti 4600",
+	"GeForce4 Ti 4400",
+	"GeForce4 Ti",
+	"GeForce4 Ti 4200",
+	"GeForce4 MX 460",
+	"GeForce4 MX 440",
+	"GeForce4 MX 420",
+	"GeForce4",
+	"GeForce4 Go 440",
+	"GeForce4 Go 420",
+	"GeForce4 Go 420 32M",
+	"GeForce4 Go 440 64M",
+	"GeForce4 Go",
+	"GeForce3 Ti 500",
+	"GeForce3 Ti 200",
+	"GeForce2 Integrated",
+	"GeForce2 Ti",
+	"Quadro2 MXR//EX//GO",
+	"GeFORCE2_MX 100//200",
+	"GeFORCE2_MX 400",
+	"Quadro DCC"
+};
+
+static const char* DeviceNamesATI[]={
+	"Unknown ATI Device",
+	"Rage II",
+	"Rage II+",
+	"Rage IIc PCI",
+	"Rage IIc AGP",
+	"Rage 128 Mobility",
+	"Rage 128 Mobility M3",
+	"Rage 128 Mobility M4",
+	"Rage 128 PRO ULTRA",
+	"Rage 128 4X",
+	"Rage 128 PRO GL",
+	"Rage 128 PRO VR",
+	"Rage 128 GL",
+	"Rage 128 VR",
+	"Rage PRO",
+	"Rage PRO Mobility",
+	"Mobility Radeon",
+	"Mobility Radeon VE(M6)",
+	"Radeon VE",
+	"Radeon DDR",
+	"Radeon",
+	"Mobility R7500",
+	"R7500",
+	"R8500"
+};
+
+static const char* DeviceNames3DLabs[]={
+	"Unknown 3DLabs Device",
+	"Permedia",
+	"300SX",
+	"500TX",
+	"Delta",
+	"MX",
+	"Gamma",
+	"Permedia2S (ST)",
+	"Permedia3",
+	"R3",
+	"Permedia4",
+	"R4",
+	"G2",
+	"Oxygen VX1",
+	"TI P1",
+	"Permedia2"
+};
+
+static const char* DeviceNames3Dfx[]={
+	"Unknown 3Dfx Device",
+	"Voodoo 5500 AGP",
+	"Voodoo 3",
+	"Banshee",
+	"Voodoo 2",
+	"Voodoo Graphics",
+	"Voodoo Rush"
+};
+
+static const char* DeviceNamesMatrox[]={
+	"Unknown Matrox Device",
+	"G550",
+	"G400",
+	"G200 AGP",
+	"G200 PCI",
+	"G100 PCI",
+	"G100 AGP",
+	"Millennium II AGP",
+	"Millennium II PCI",
+	"Mystique",
+	"Millennium",
+	"Parhelia",
+	"Parhelia AGP 8X"
+};
+
+static const char* DeviceNamesPowerVR[]={
+	"Unknown PowerVR Device",
+	"Kyro"
+};
+
+static const char* DeviceNamesS3[]={
+	"Unknown S3 Device",
+	"Savage MX",
+	"Savage 4",
+	"Savage 200"
+};
+
+static const char* DeviceNamesIntel[]={
+	"Unknown Intel Device",
+	"i810",
+	"i810e",
+	"i815"
+};
+
+DX8Caps::DeviceTypeATI DX8Caps::Get_ATI_Device(unsigned device_id)
+{
+	switch (device_id) {
+	case 0x4754: return DEVICE_ATI_RAGE_II;
+	case 0x4755: return DEVICE_ATI_RAGE_II_PLUS;
+	case 0x5656: return DEVICE_ATI_RAGE_IIC_PCI;
+	case 0x4756: return DEVICE_ATI_RAGE_IIC_PCI;
+	case 0x475A: return DEVICE_ATI_RAGE_IIC_AGP;
+	case 0x4759: return DEVICE_ATI_RAGE_IIC_AGP;
+	case 0x4757: return DEVICE_ATI_RAGE_IIC_AGP;
+	case 0x4742:
+	case 0x4744:
+	case 0x4749:
+	case 0x4750:
+	case 0x474C:
+	case 0x474E:
+	case 0x474D:
+	case 0x474F:
+	case 0x4752: return DEVICE_ATI_RAGE_PRO;
+
+	case 0x4C4D:
+	case 0x4C52:
+	case 0x4C42:
+	case 0x4C49:
+	case 0x4C50: return DEVICE_ATI_RAGE_PRO_MOBILITY;
+
+	case 0x4C57: return DEVICE_ATI_MOBILITY_R7500;
+
+	case 0x4C59:
+	case 0x4C5A: return DEVICE_ATI_MOBILITY_RADEON_VE_M6;
+
+	case 0x4D46:
+	case 0x4D4C: return DEVICE_ATI_RAGE_128_MOBILITY_M4;
+	case 0x4C45:
+	case 0x4C46: return DEVICE_ATI_RAGE_128_MOBILITY_M3;
+
+	case 0x5041: 
+	case 0x5042: 
+	case 0x5043: 
+	case 0x5044: 
+	case 0x5045: 
+	case 0x5046: return DEVICE_ATI_RAGE_128_PRO_GL;
+
+	case 0x5047:
+	case 0x5048:
+	case 0x5049:
+	case 0x504A:
+	case 0x504B:
+	case 0x504C:
+	case 0x504D:
+	case 0x504E:
+	case 0x504F:
+	case 0x5050:
+	case 0x5051:
+	case 0x5052:
+	case 0x5053:
+	case 0x5054:
+	case 0x5055:
+	case 0x5056:
+	case 0x5057:
+	case 0x5058: return DEVICE_ATI_RAGE_128_PRO_VR;
+
+	case 0x5159:
+	case 0x515A: return DEVICE_ATI_RADEON_VE;
+
+	case 0x5144:
+	case 0x5145:
+	case 0x5146:
+	case 0x5147: return DEVICE_ATI_RADEON_DDR;
+
+	case 0x514c:
+	case 0x514e:
+	case 0x514f: return DEVICE_ATI_R8500;
+
+	case 0x5157: return DEVICE_ATI_R7500;
+
+	case 0x5245: 
+	case 0x5246: 
+	case 0x534B: 
+	case 0x534C: 
+	case 0x534D: return DEVICE_ATI_RAGE_128_GL;
+
+	case 0x524B:
+	case 0x524C:
+	case 0x5345:
+	case 0x5346:
+	case 0x5347: return DEVICE_ATI_RAGE_128_VR;
+
+	case 0x5446:
+	case 0x544C:
+	case 0x5452:
+	case 0x5453:
+	case 0x5454:
+	case 0x5455: return DEVICE_ATI_RAGE_128_PRO_ULTRA;
+
+	case 0x534E: return DEVICE_ATI_RAGE_128_4X;
+
+	default: return DEVICE_ATI_UNKNOWN;
+	}
+}
+
+DX8Caps::DeviceType3DLabs DX8Caps::Get_3DLabs_Device(unsigned device_id)
+{
+	switch (device_id) {
+	case 0x0001: return DEVICE_3DLABS_300SX;
+	case 0x0002: return DEVICE_3DLABS_500TX;
+	case 0x0003: return DEVICE_3DLABS_DELTA;
+	case 0x0004: return DEVICE_3DLABS_PERMEDIA;
+	case 0x0006: return DEVICE_3DLABS_MX;
+	case 0x0007: return DEVICE_3DLABS_PERMEDIA2;
+	case 0x0008: return DEVICE_3DLABS_GAMMA;
+	case 0x0009: return DEVICE_3DLABS_PERMEDIA2S_ST;
+	case 0x000a: return DEVICE_3DLABS_PERMEDIA3;
+	case 0x000b: return DEVICE_3DLABS_R3;
+	case 0x000c: return DEVICE_3DLABS_PERMEDIA4;
+	case 0x000d: return DEVICE_3DLABS_R4;
+	case 0x000e: return DEVICE_3DLABS_G2;
+	case 0x4C59: return DEVICE_3DLABS_OXYGEN_VX1;
+	case 0x3D04: return DEVICE_3DLABS_TI_P1;
+	case 0x3D07: return DEVICE_3DLABS_PERMEDIA2;
+	default: return DEVICE_3DLABS_UNKNOWN;
+	}
+}
+
+DX8Caps::DeviceTypeNVidia DX8Caps::Get_NVidia_Device(unsigned device_id)
+{
+	switch (device_id) {
+	case 0x0250: return DEVICE_NVIDIA_GEFORCE4_TI_4600;
+	case 0x0251: return DEVICE_NVIDIA_GEFORCE4_TI_4400;
+	case 0x0252: return DEVICE_NVIDIA_GEFORCE4_TI;
+	case 0x0253: return DEVICE_NVIDIA_GEFORCE4_TI_4200;
+	case 0x0170: return DEVICE_NVIDIA_GEFORCE4_MX_460;
+	case 0x0171: return DEVICE_NVIDIA_GEFORCE4_MX_440;
+	case 0x0172: return DEVICE_NVIDIA_GEFORCE4_MX_420;
+	case 0x0173: return DEVICE_NVIDIA_GEFORCE4;
+	case 0x0174: return DEVICE_NVIDIA_GEFORCE4_GO_440;
+	case 0x0175: return DEVICE_NVIDIA_GEFORCE4_GO_420;
+	case 0x0176: return DEVICE_NVIDIA_GEFORCE4_GO_420_32M;
+	case 0x0178: return DEVICE_NVIDIA_GEFORCE4_GO;
+	case 0x0179: return DEVICE_NVIDIA_GEFORCE4_GO_440_64M;
+	case 0x0203: return DEVICE_NVIDIA_QUADRO_DCC;
+	case 0x0202: return DEVICE_NVIDIA_GEFORCE3_TI_500;
+	case 0x0201: return DEVICE_NVIDIA_GEFORCE3_TI_200;
+	case 0x0200: return DEVICE_NVIDIA_GEFORCE3;
+	case 0x01A0: return DEVICE_NVIDIA_GEFORCE2_INTEGRATED;
+	case 0x0153: return DEVICE_NVIDIA_QUADRO2_PRO;
+	case 0x0152: return DEVICE_NVIDIA_GEFORCE2_ULTRA;
+	case 0x0151: return DEVICE_NVIDIA_GEFORCE2_TI;
+	case 0x0150: return DEVICE_NVIDIA_GEFORCE2_GTS;
+	case 0x0113: return DEVICE_NVIDIA_QUADRO2_MXR_EX_GO;
+	case 0x0112: return DEVICE_NVIDIA_GEFORCE2_GO;
+	case 0x0111: return DEVICE_NVIDIA_GEFORCE2_MX_100_200;
+	case 0x0110: return DEVICE_NVIDIA_GEFORCE2_MX_400;
+	case 0x0103: return DEVICE_NVIDIA_QUADRO;
+	case 0x0101: return DEVICE_NVIDIA_GEFORCE_DDR;
+	case 0x0100: return DEVICE_NVIDIA_GEFORCE_256;
+	case 0x00A0: return DEVICE_NVIDIA_TNT2_ALADDIN;
+	case 0x0028: return DEVICE_NVIDIA_TNT2;
+	case 0x0029: return DEVICE_NVIDIA_TNT2_ULTRA;
+	case 0x002C: return DEVICE_NVIDIA_TNT2_VANTA;
+	case 0x002D: return DEVICE_NVIDIA_TNT2_M64;
+	case 0x0020: return DEVICE_NVIDIA_TNT;
+	case 0x0008: return DEVICE_NVIDIA_NV1;
+
+	// STB cards
+	case 0x0019:
+	case 0x0018: return DEVICE_NVIDIA_RIVA_128;
+
+	// Guillemot Cards
+	case 0x5008: return DEVICE_NVIDIA_TNT_VANTA;		// Maxi Gamer Phoenix 2
+	case 0x5810: return DEVICE_NVIDIA_TNT2;			// Maxi Gamer Xentor
+	case 0x5820: return DEVICE_NVIDIA_TNT2_ULTRA;	// Maxi Gamer Xentor 32
+	case 0x4d20: return DEVICE_NVIDIA_TNT2_M64;		// Maxi Gamer Cougar
+	case 0x5620: return DEVICE_NVIDIA_TNT2_M64;		// Maxi Gamer Cougar Video Edition
+	case 0x5020: return DEVICE_NVIDIA_GEFORCE_256;	// Maxi Gamer 3D Prophet
+
+	default: return DEVICE_NVIDIA_UNKNOWN;
+	}
+}
+
+
+DX8Caps::DeviceType3Dfx DX8Caps::Get_3Dfx_Device(unsigned device_id)
+{
+	switch (device_id) {
+	case 0x0009: return DEVICE_3DFX_VOODOO_5500_AGP;
+	case 0x0005: return DEVICE_3DFX_VOODOO_3;
+	case 0x0003: return DEVICE_3DFX_BANSHEE;
+	case 0x0002: return DEVICE_3DFX_VOODOO_2;
+	case 0x0001: return DEVICE_3DFX_VOODOO_GRAPHICS;
+	case 0x643d: // Alliance AT25/AT3D based reference board
+	case 0x8626: // Macronix based reference board
+		return DEVICE_3DFX_VOODOO_RUSH;
+	default: return DEVICE_3DFX_UNKNOWN;
+	}
+}
+
+DX8Caps::DeviceTypeMatrox DX8Caps::Get_Matrox_Device(unsigned device_id)
+{
+	switch (device_id) {
+	case 0x2527: return DEVICE_MATROX_G550;
+	case 0x0525: return DEVICE_MATROX_G400;
+	case 0x0521: return DEVICE_MATROX_G200_AGP;
+	case 0x0520: return DEVICE_MATROX_G200_PCI;
+	case 0x1000: return DEVICE_MATROX_G100_PCI;
+	case 0x1001: return DEVICE_MATROX_G100_AGP;
+	case 0x051F: return DEVICE_MATROX_MILLENNIUM_II_AGP;
+	case 0x051B: return DEVICE_MATROX_MILLENNIUM_II_PCI;
+	case 0x051A: return DEVICE_MATROX_MYSTIQUE;
+	case 0x0519: return DEVICE_MATROX_MILLENNIUM;
+	case 0x0527: return DEVICE_MATROX_PARHELIA;
+	case 0x0528: return DEVICE_MATROX_PARHELIA_AGP8X;
+
+	default: return DEVICE_MATROX_UNKNOWN;
+	}
+}
+ 
+DX8Caps::DeviceTypePowerVR DX8Caps::Get_PowerVR_Device(unsigned device_id)
+{
+	switch (device_id) {
+	case 0x0010: return DEVICE_POWERVR_KYRO;
+	default: return DEVICE_POWERVR_UNKNOWN;
+	}
+}
+
+DX8Caps::DeviceTypeS3 DX8Caps::Get_S3_Device(unsigned device_id)
+{
+	switch (device_id) {
+	case 0x8C10: return DEVICE_S3_SAVAGE_MX;
+	case 0x8A22: return DEVICE_S3_SAVAGE_4;
+	case 0x9102: return DEVICE_S3_SAVAGE_200;
+	default: return DEVICE_S3_UNKNOWN;
+	}
+}
+
+DX8Caps::DeviceTypeIntel DX8Caps::Get_Intel_Device(unsigned device_id)
+{
+	switch (device_id) {
+	case 0x7123: return DEVICE_INTEL_810;
+	case 0x7121: return DEVICE_INTEL_810E;
+	case 0x1132: return DEVICE_INTEL_815;
+	default: return DEVICE_INTEL_UNKNOWN;
+	}
+}
+
 DX8Caps::DX8Caps(
 	IDirect3D8* direct3d,
 	IDirect3DDevice8* D3DDevice, 
 	WW3DFormat display_format, 
 	const D3DADAPTER_IDENTIFIER8& adapter_id)
+	:
+	Direct3D(direct3d),
+	MaxDisplayWidth(0),
+	MaxDisplayHeight(0)
 {
 	Init_Caps(D3DDevice);
 	Compute_Caps(display_format, adapter_id);
@@ -61,6 +485,7 @@ DX8Caps::DX8Caps(
 //they don't show up in our memory manager as a leak. -MW 7-22-03
 void DX8Caps::Shutdown(void)
 {
+	CapsWorkString.Release_Resources();
 }
 
 // ----------------------------------------------------------------------------
@@ -110,12 +535,15 @@ void DX8Caps::Compute_Caps(WW3DFormat display_format, const D3DADAPTER_IDENTIFIE
 
 	supportGamma=((swVPCaps.Caps2&D3DCAPS2_FULLSCREENGAMMA)==D3DCAPS2_FULLSCREENGAMMA);
 
+	MaxTexturesPerPass=MAX_TEXTURE_STAGES;
+
 	Check_Texture_Format_Support(display_format,caps);
 	Check_Texture_Compression_Support(caps);
 	Check_Bumpmap_Support(caps);
 	Check_Shader_Support(caps);
 	Check_Maximum_Texture_Support(caps);
 	Vendor_Specific_Hacks(adapter_id);
+	CapsWorkString="";
 }
 
 // ----------------------------------------------------------------------------
@@ -147,20 +575,96 @@ void DX8Caps::Check_Texture_Compression_Support(const D3DCAPS8& caps)
 
 void DX8Caps::Check_Texture_Format_Support(WW3DFormat display_format,const D3DCAPS8& caps)
 {
+	if (display_format==WW3D_FORMAT_UNKNOWN) {
+		for (unsigned i=0;i<WW3D_FORMAT_COUNT;++i) {
+			SupportTextureFormat[i]=false;
+		}
+		return;
+	}
 	D3DFORMAT d3d_display_format=WW3DFormat_To_D3DFormat(display_format);
 	for (unsigned i=0;i<WW3D_FORMAT_COUNT;++i) {
 		if (i==WW3D_FORMAT_UNKNOWN) {
 			SupportTextureFormat[i]=false;
 		}
 		else {
+			WW3DFormat format=(WW3DFormat)i;
 			SupportTextureFormat[i]=SUCCEEDED(
-				DX8Wrapper::_Get_D3D8()->CheckDeviceFormat(
+				Direct3D->CheckDeviceFormat(
 					caps.AdapterOrdinal,
 					caps.DeviceType,
 					d3d_display_format,
 					0,
 					D3DRTYPE_TEXTURE,
-					WW3DFormat_To_D3DFormat((WW3DFormat)i)));
+					WW3DFormat_To_D3DFormat(format)));
+		}
+	}
+}
+
+void DX8Caps::Check_Render_To_Texture_Support(WW3DFormat display_format,const D3DCAPS8& caps)
+{
+	if (display_format==WW3D_FORMAT_UNKNOWN) {
+		for (unsigned i=0;i<WW3D_FORMAT_COUNT;++i) {
+			SupportRenderToTextureFormat[i]=false;
+		}
+		return;
+	}
+	D3DFORMAT d3d_display_format=WW3DFormat_To_D3DFormat(display_format);
+	for (unsigned i=0;i<WW3D_FORMAT_COUNT;++i) {
+		if (i==WW3D_FORMAT_UNKNOWN) {
+			SupportRenderToTextureFormat[i]=false;
+		}
+		else {
+			WW3DFormat format=(WW3DFormat)i;
+			SupportRenderToTextureFormat[i]=SUCCEEDED(
+				Direct3D->CheckDeviceFormat(
+					caps.AdapterOrdinal,
+					caps.DeviceType,
+					d3d_display_format,
+					D3DUSAGE_RENDERTARGET,
+					D3DRTYPE_TEXTURE,
+					WW3DFormat_To_D3DFormat(format)));
+		}
+	}
+}
+
+//**********************************************************************************************
+//! Check Depth Stencil Format Support
+/*! KJM
+*/
+void DX8Caps::Check_Depth_Stencil_Support(WW3DFormat display_format, const D3DCAPS8& caps)
+{
+	if (display_format==WW3D_FORMAT_UNKNOWN) 
+	{
+		for (unsigned i=0;i<WW3D_ZFORMAT_COUNT;++i) 
+		{
+			SupportDepthStencilFormat[i]=false;
+		}
+		return;
+	}
+
+	D3DFORMAT d3d_display_format=WW3DFormat_To_D3DFormat(display_format);
+	
+	for (unsigned i=0;i<WW3D_ZFORMAT_COUNT;++i) 
+	{
+		if (i==WW3D_ZFORMAT_UNKNOWN) 
+		{
+			SupportDepthStencilFormat[i]=false;
+		}
+		else 
+		{
+			WW3DZFormat format=(WW3DZFormat)i;
+			SupportDepthStencilFormat[i]=SUCCEEDED
+			(
+				Direct3D->CheckDeviceFormat
+				(
+					caps.AdapterOrdinal,
+					caps.DeviceType,
+					d3d_display_format,
+					D3DUSAGE_DEPTHSTENCIL,
+					D3DRTYPE_TEXTURE,
+					WW3DZFormat_To_D3DFormat(format)
+				)
+			);
 		}
 	}
 }
@@ -199,3 +703,4 @@ void DX8Caps::Vendor_Specific_Hacks(const D3DADAPTER_IDENTIFIER8& adapter_id)
 //	SupportDXTC=false;
 
 }
+

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8caps.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8caps.h
@@ -22,16 +22,17 @@
  *                                                                                             *
  *                 Project Name : DX8 Caps                                                     *
  *                                                                                             *
- *                     $Archive:: /VSS_Sync/ww3d2/dx8caps.h                                   $*
+ *                     $Archive:: /Commando/Code/ww3d2/dx8caps.h                              $*
  *                                                                                             *
  *              Original Author:: Hector Yee                                                   *
  *                                                                                             *
- *                      $Author:: Vss_sync                                                    $*
+ *                       Author : Kenny Mitchell                                               * 
+ *                                                                                             * 
+ *                     $Modtime:: 06/27/02 1:27p                                              $*
  *                                                                                             *
- *                     $Modtime:: 8/29/01 8:16p                                               $*
+ *                    $Revision:: 24                                                          $*
  *                                                                                             *
- *                    $Revision:: 8                                                           $*
- *                                                                                             *
+ * 06/27/02 KM Z Format support																						*
  *---------------------------------------------------------------------------------------------*
  * Functions:                                                                                  *
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
@@ -217,6 +218,7 @@ public:
 	bool Support_Bump_Envmap() const { return SupportBumpEnvmap; }
 	bool Support_Bump_Envmap_Luminance() const { return SupportBumpEnvmapLuminance; }
 	bool Support_Dot3() const { return SupportDot3; }
+	int Get_Max_Textures_Per_Pass() const { return MaxTexturesPerPass; }
 
 	// -------------------------------------------------------------------------
 	//
@@ -232,6 +234,8 @@ public:
 	int Get_Max_Simultaneous_Textures()	const { return MaxSimultaneousTextures;}
 
 	bool Support_Texture_Format(WW3DFormat format) const { return SupportTextureFormat[format]; }
+	bool Support_Render_To_Texture_Format(WW3DFormat format) const { return SupportRenderToTextureFormat[format]; }
+	bool Support_Depth_Stencil_Format(WW3DZFormat format) const { return SupportDepthStencilFormat[format]; }
 
 	D3DCAPS8 const & Get_DX8_Caps() const { return (SupportTnL?hwVPCaps:swVPCaps); }
 
@@ -239,13 +243,28 @@ public:
 	D3DCAPS8 const & Get_SW_VP_Caps() const { return swVPCaps; };
 
 private:
+	static VendorIdType Define_Vendor(unsigned vendor_id);
+	static DeviceTypeATI Get_ATI_Device(unsigned device_id);
+	static DeviceType3DLabs Get_3DLabs_Device(unsigned device_id);
+	static DeviceTypeNVidia Get_NVidia_Device(unsigned device_id);
+	static DeviceType3Dfx Get_3Dfx_Device(unsigned device_id);
+	static DeviceTypeMatrox Get_Matrox_Device(unsigned device_id);
+	static DeviceTypePowerVR Get_PowerVR_Device(unsigned device_id);
+	static DeviceTypeS3 Get_S3_Device(unsigned device_id);
+	static DeviceTypeIntel Get_Intel_Device(unsigned device_id);
+
 	void Init_Caps(IDirect3DDevice8* D3DDevice);
 	void Check_Texture_Format_Support(WW3DFormat display_format,const D3DCAPS8& caps);
+	void Check_Render_To_Texture_Support(WW3DFormat display_format,const D3DCAPS8& caps);
+	void Check_Depth_Stencil_Support(WW3DFormat display_format, const D3DCAPS8& caps);
 	void Check_Texture_Compression_Support(const D3DCAPS8& caps);
 	void Check_Bumpmap_Support(const D3DCAPS8& caps);
 	void Check_Shader_Support(const D3DCAPS8& caps);
 	void Check_Maximum_Texture_Support(const D3DCAPS8& caps);
 	void Vendor_Specific_Hacks(const D3DADAPTER_IDENTIFIER8& adapter_id);
+
+	int MaxDisplayWidth;
+	int MaxDisplayHeight;
 
 	D3DCAPS8 hwVPCaps;
 	D3DCAPS8 swVPCaps;
@@ -256,10 +275,14 @@ private:
 	bool SupportBumpEnvmap;
 	bool SupportBumpEnvmapLuminance;
 	bool SupportTextureFormat[WW3D_FORMAT_COUNT];
+	bool SupportRenderToTextureFormat[WW3D_FORMAT_COUNT];
+	bool SupportDepthStencilFormat[WW3D_ZFORMAT_COUNT];
 	bool SupportDot3;
+	int MaxTexturesPerPass;
 	int VertexShaderVersion;
 	int PixelShaderVersion;
 	int MaxSimultaneousTextures;
+	IDirect3D8* Direct3D; // warning XDK name conflict KJM
 };
 
 

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8list.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8list.h
@@ -26,12 +26,13 @@
  *                                                                                             *
  *              Original Author:: Greg Hjelstrom                                               *
  *                                                                                             *
- *                      $Author:: Hector_y                                                    $*
+ *                       Author : Kenny Mitchell                                               * 
+ *                                                                                             * 
+ *                     $Modtime:: 06/27/02 1:27p                                              $*
  *                                                                                             *
- *                     $Modtime:: 4/25/01 1:37p                                               $*
+ *                    $Revision:: 5                                                           $*
  *                                                                                             *
- *                    $Revision:: 4                                                           $*
- *                                                                                             *
+ * 06/27/02 KM Texture class abstraction																			*
  *---------------------------------------------------------------------------------------------*
  * Functions:                                                                                  *
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
@@ -64,9 +65,9 @@ class DX8PolygonRendererClass;
 typedef MultiListClass<DX8PolygonRendererClass>			DX8PolygonRendererList;
 typedef MultiListIterator<DX8PolygonRendererClass>		DX8PolygonRendererListIterator; 
 
-class DX8TextureTrackerClass;
-typedef MultiListClass<DX8TextureTrackerClass>			DX8TextureTrackerList;
-typedef MultiListIterator<DX8TextureTrackerClass>		DX8TextureTrackerListIterator;
+class TextureTrackerClass;
+typedef MultiListClass<TextureTrackerClass>				TextureTrackerList;
+typedef MultiListIterator<TextureTrackerClass>			TextureTrackerListIterator;
 
 
 #endif //DX8LIST_H

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8texman.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8texman.cpp
@@ -26,12 +26,13 @@
  *                                                                                             *
  *              Original Author:: Hector Yee                                                   *
  *                                                                                             *
- *                      $Author:: Hector_y                                                    $*
+ *                       Author : Kenny Mitchell                                               * 
+ *                                                                                             * 
+ *                     $Modtime:: 06/27/02 1:27p                                              $*
  *                                                                                             *
- *                     $Modtime:: 4/26/01 1:41p                                               $*
+ *                    $Revision:: 4                                                           $*
  *                                                                                             *
- *                    $Revision:: 3                                                           $*
- *                                                                                             *
+ * 06/27/02 KM Texture class abstraction																			*
  *---------------------------------------------------------------------------------------------*
  * Functions:                                                                                  *
  *   DX8TextureManagerClass::Shutdown -- Shuts down the texture manager                        *
@@ -51,7 +52,7 @@
 
 #include "dx8texman.h"
 
-DX8TextureTrackerList DX8TextureManagerClass::Managed_Textures;
+TextureTrackerList DX8TextureManagerClass::Managed_Textures;
 
 
 /***********************************************************************************************
@@ -68,12 +69,13 @@ DX8TextureTrackerList DX8TextureManagerClass::Managed_Textures;
  *                                                                                             *
  * HISTORY:                                                                                    *
  *   4/25/2001  hy : Created.                                                                  *
+ *   5/16/2002  km : Added depth stencil texture tracking and abstraction                      *
  *=============================================================================================*/
 void DX8TextureManagerClass::Shutdown()
 {
 	while (!Managed_Textures.Is_Empty())
 	{
-		DX8TextureTrackerClass *track=Managed_Textures.Remove_Head();
+		TextureTrackerClass *track=Managed_Textures.Remove_Head();
 		delete track;
 		track=NULL;
 	}
@@ -93,8 +95,9 @@ void DX8TextureManagerClass::Shutdown()
  *                                                                                             *
  * HISTORY:                                                                                    *
  *   4/25/2001  hy : Created.                                                                  *
+ *   5/16/2002  km : Added depth stencil texture tracking and abstraction                      *
  *=============================================================================================*/
-void DX8TextureManagerClass::Add(DX8TextureTrackerClass *track)
+void DX8TextureManagerClass::Add(TextureTrackerClass *track)
 {
 	// this function should only be called by the texture constructor
 	Managed_Textures.Add(track);
@@ -115,16 +118,17 @@ void DX8TextureManagerClass::Add(DX8TextureTrackerClass *track)
  *                                                                                             *
  * HISTORY:                                                                                    *
  *   4/25/2001  hy : Created.                                                                  *
+ *   5/16/2002  km : Added depth stencil texture tracking and abstraction                      *
  *=============================================================================================*/
-void DX8TextureManagerClass::Remove(TextureClass *tex)
+void DX8TextureManagerClass::Remove(TextureBaseClass *tex)
 {
 	// this function should only be called by the texture destructor
-	DX8TextureTrackerListIterator it(&Managed_Textures);
+	TextureTrackerListIterator it(&Managed_Textures);
 
 	while (!it.Is_Done())
 	{
-		DX8TextureTrackerClass *track=it.Peek_Obj();		
-		if (track->Texture==tex)
+		TextureTrackerClass *track=it.Peek_Obj();		
+		if (track->Get_Texture()==tex)
 		{			
 			it.Remove_Current_Object();
 			delete track;
@@ -149,17 +153,16 @@ void DX8TextureManagerClass::Remove(TextureClass *tex)
  *                                                                                             *
  * HISTORY:                                                                                    *
  *   4/25/2001  hy : Created.                                                                  *
+ *   5/16/2002  km : Added depth stencil texture tracking and abstraction                      *
  *=============================================================================================*/
 void DX8TextureManagerClass::Release_Textures()
 {
-	DX8TextureTrackerListIterator it(&Managed_Textures);
+	TextureTrackerListIterator it(&Managed_Textures);
 
 	while (!it.Is_Done())
 	{
-		DX8TextureTrackerClass *track=it.Peek_Obj();		
-		WWASSERT(track->Texture->D3DTexture);
-		track->Texture->D3DTexture->Release();
-		track->Texture->D3DTexture=NULL;
+		TextureTrackerClass *track=it.Peek_Obj();		
+		track->Release();
 		it.Next();
 	}
 }
@@ -179,18 +182,18 @@ void DX8TextureManagerClass::Release_Textures()
  *                                                                                             *
  * HISTORY:                                                                                    *
  *   4/25/2001  hy : Created.                                                                  *
+ *   5/16/2002  km : Added depth stencil texture tracking and abstraction                      *
  *=============================================================================================*/
 void DX8TextureManagerClass::Recreate_Textures()
 {
-	DX8TextureTrackerListIterator it(&Managed_Textures);
+	TextureTrackerListIterator it(&Managed_Textures);
 
 	while (!it.Is_Done())
 	{
-		DX8TextureTrackerClass *track=it.Peek_Obj();
-		WWASSERT(track->Texture->D3DTexture==NULL);
-		track->Texture->D3DTexture=DX8Wrapper::_Create_DX8_Texture(track->Width,track->Height,
-			track->Format,track->Mip_level_count,D3DPOOL_DEFAULT,track->RenderTarget);
-		track->Texture->Dirty=true;
+		TextureTrackerClass *track=it.Peek_Obj();
+		track->Recreate();
+		track->Get_Texture()->Set_Dirty();
 		it.Next();
 	}
 }
+

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
@@ -42,6 +42,7 @@
 #define WW3D_DEVTYPE D3DDEVTYPE_HAL
 
 #include "dx8wrapper.h"
+#include "dx8webbrowser.h"
 #include "dx8fvf.h"
 #include "dx8vertexbuffer.h"
 #include "dx8indexbuffer.h"
@@ -109,6 +110,19 @@ D3DMATRIX						DX8Wrapper::old_world;
 D3DMATRIX						DX8Wrapper::old_view;
 D3DMATRIX						DX8Wrapper::old_prj;
 
+// shader system additions KJM v
+DWORD								DX8Wrapper::Vertex_Shader								= 0;
+DWORD								DX8Wrapper::Pixel_Shader								= 0;
+
+Vector4							DX8Wrapper::Vertex_Shader_Constants[MAX_VERTEX_SHADER_CONSTANTS];
+Vector4							DX8Wrapper::Pixel_Shader_Constants[MAX_PIXEL_SHADER_CONSTANTS];
+
+LightEnvironmentClass*		DX8Wrapper::Light_Environment							= NULL;
+RenderInfoClass*				DX8Wrapper::Render_Info									= NULL;
+
+DWORD								DX8Wrapper::Vertex_Processing_Behavior				= 0;
+Vector3							DX8Wrapper::Ambient_Color;
+// shader system additions KJM ^
 bool								DX8Wrapper::world_identity;
 unsigned							DX8Wrapper::RenderStates[256];
 unsigned							DX8Wrapper::TextureStageStates[MAX_TEXTURE_STAGES][32];
@@ -123,6 +137,7 @@ IDirect3D8 *					DX8Wrapper::D3DInterface								= NULL;
 IDirect3DDevice8 *			DX8Wrapper::D3DDevice									= NULL;
 IDirect3DSurface8 *			DX8Wrapper::CurrentRenderTarget						= NULL;
 IDirect3DSurface8 *			DX8Wrapper::DefaultRenderTarget						= NULL;
+bool								DX8Wrapper::IsRenderToTexture							= false;
 
 unsigned							DX8Wrapper::matrix_changes								= 0;
 unsigned							DX8Wrapper::material_changes							= 0;
@@ -132,10 +147,20 @@ unsigned							DX8Wrapper::light_changes								= 0;
 unsigned							DX8Wrapper::texture_changes							= 0;
 unsigned							DX8Wrapper::render_state_changes						= 0;
 unsigned							DX8Wrapper::texture_stage_state_changes			= 0;
+unsigned							DX8Wrapper::draw_calls									= 0;
 unsigned							DX8Wrapper::_MainThreadID								= 0;
 bool								DX8Wrapper::CurrentDX8LightEnables[4];
+bool								DX8Wrapper::IsDeviceLost;
+int								DX8Wrapper::ZBias;
+float								DX8Wrapper::ZNear;
+float								DX8Wrapper::ZFar;
+Matrix4x4						DX8Wrapper::ProjectionMatrix;
+Matrix4x4						DX8Wrapper::DX8Transforms[D3DTS_WORLD+1];
 
 DX8Caps*							DX8Wrapper::CurrentCaps = 0;
+
+// Hack test... this disables rendering of batches of too few polygons.
+unsigned							DX8Wrapper::DrawPolygonLowBoundLimit=0;
 
 D3DADAPTER_IDENTIFIER8		DX8Wrapper::CurrentAdapterIdentifier;
 
@@ -153,21 +178,17 @@ static unsigned				last_frame_texture_changes								= 0;
 static unsigned				last_frame_render_state_changes						= 0;
 static unsigned				last_frame_texture_stage_state_changes				= 0;
 static unsigned				last_frame_number_of_DX8_calls						= 0;
+static unsigned				last_frame_draw_calls									= 0;
 
 static D3DPRESENT_PARAMETERS								_PresentParameters;
 static DynamicVectorClass<StringClass>					_RenderDeviceNameTable;
 static DynamicVectorClass<StringClass>					_RenderDeviceShortNameTable;
 static DynamicVectorClass<RenderDeviceDescClass>	_RenderDeviceDescriptionTable;
 
-/*
-** Registry value names
-*/
-#define	VALUE_NAME_RENDER_DEVICE_NAME					"RenderDeviceName"
-#define	VALUE_NAME_RENDER_DEVICE_WIDTH				"RenderDeviceWidth"
-#define	VALUE_NAME_RENDER_DEVICE_HEIGHT				"RenderDeviceHeight"
-#define	VALUE_NAME_RENDER_DEVICE_DEPTH				"RenderDeviceDepth"
-#define	VALUE_NAME_RENDER_DEVICE_WINDOWED			"RenderDeviceWindowed"
-#define	VALUE_NAME_RENDER_DEVICE_TEXTURE_DEPTH		"RenderDeviceTextureDepth"
+
+typedef IDirect3D8* (WINAPI *Direct3DCreate8Type) (UINT SDKVersion);
+Direct3DCreate8Type	Direct3DCreate8Ptr = NULL;
+HINSTANCE D3D8Lib = NULL;
 
 DX8_CleanupHook	 *DX8Wrapper::m_pCleanupHook=NULL;
 #ifdef EXTENDED_STATS
@@ -210,10 +231,13 @@ void Non_Fatal_Log_DX8_ErrorCode(unsigned res,const char * file,int line)
 }
 
 
-bool DX8Wrapper::Init(void * hwnd)
+
+bool DX8Wrapper::Init(void * hwnd, bool lite)
 {
 	WWASSERT(!IsInitted);
 
+	memset(Vertex_Shader_Constants,0,sizeof(Vector4)*MAX_VERTEX_SHADER_CONSTANTS);
+	memset(Pixel_Shader_Constants,0,sizeof(Vector4)*MAX_PIXEL_SHADER_CONSTANTS);
 	/*
 	** Initialize all variables!
 	*/
@@ -250,19 +274,32 @@ bool DX8Wrapper::Init(void * hwnd)
 
 	Invalidate_Cached_Render_States();
 
-	/*
-	** Create the D3D interface object
-	*/
-	D3DInterface = Direct3DCreate8(D3D_SDK_VERSION);		// TODO: handle failure cases...
-	if (D3DInterface == NULL) {
-		return(false);
-	}
-	IsInitted = true;	
+	if (!lite) {
+		D3D8Lib = LoadLibrary("D3D8.DLL");
 
-	/*
-	** Enumerate the available devices
-	*/
-	Enumerate_Devices();
+		if (D3D8Lib == NULL) return false;	// Return false at this point if init failed
+
+		Direct3DCreate8Ptr = (Direct3DCreate8Type) GetProcAddress(D3D8Lib, "Direct3DCreate8");
+		if (Direct3DCreate8Ptr == NULL) return false;
+
+		/*
+		** Create the D3D interface object
+		*/
+		WWDEBUG_SAY(("Create Direct3D8\n"));
+		D3DInterface = Direct3DCreate8Ptr(D3D_SDK_VERSION);		// TODO: handle failure cases...
+		if (D3DInterface == NULL) {
+			return(false);
+		}
+		IsInitted = true;
+
+		/*
+		** Enumerate the available devices
+		*/
+		WWDEBUG_SAY(("Enumerate devices\n"));
+		Enumerate_Devices();
+		WWDEBUG_SAY(("DX8Wrapper Init completed\n"));
+	}
+
 	return(true);
 }
 
@@ -274,16 +311,33 @@ void DX8Wrapper::Shutdown(void)
 		Release_Device();
 	}
 
-	for (int i = 0; i < MAX_TEXTURE_STAGES; i++) {
-		if (Textures[i]) {
-			Textures[i]->Release();
-			Textures[i] = NULL;
+	if (D3DInterface) {
+		D3DInterface->Release();
+		D3DInterface=NULL;
+
+	}
+
+	if (CurrentCaps)
+	{
+		int max=CurrentCaps->Get_Max_Textures_Per_Pass();
+		for (int i = 0; i < max; i++) 
+		{
+			if (Textures[i]) 
+			{
+				Textures[i]->Release();
+				Textures[i] = NULL;
+			}
 		}
 	}
 
 	if (D3DInterface) {
 		UINT newRefCount=D3DInterface->Release();
 		D3DInterface=NULL;
+	}
+
+	if (D3D8Lib) {
+		FreeLibrary(D3D8Lib);
+		D3D8Lib = NULL;
 	}
 
 	_RenderDeviceNameTable.Clear();		 // note - Delete_All() resizes the vector, causing a reallocation.  Clear is better. jba.
@@ -313,21 +367,6 @@ void DX8Wrapper::Do_Onetime_Device_Dependent_Inits(void)
 	ShatterSystem::Init();
 	TextureLoader::Init();
 
-#ifdef WW3D_DX8
-
-//	WW3DAssetManager::Get_Instance()->Open_Texture_File_Cache("cache_");	
-
-	/*
-	** Initialize the dazzle system
-	*/
-	FileClass * dazzle_ini_file = _TheFileFactory->Get_File(DAZZLE_INI_FILENAME);
-	if (dazzle_ini_file) { 
-		INIClass dazzle_ini(*dazzle_ini_file);
-		DazzleRenderObjClass::Init_From_INI(&dazzle_ini);
-		_TheFileFactory->Return_File(dazzle_ini_file);
-	}
-#endif //WW3D_DX8
-	
 	Set_Default_Global_Render_States();
 }
 
@@ -387,9 +426,20 @@ void DX8Wrapper::Invalidate_Cached_Render_States(void)
 		}
 		Textures[a]=NULL;
 	}
+
 	ShaderClass::Invalidate();
+
 	//Need to explicitly set render_state texture pointers to NULL. MW
 	Release_Render_State();
+
+	// (gth) clear the matrix shadows too
+	for (int i=0; i<D3DTS_WORLD+1; i++) {
+		DX8Transforms[i][0].Set(0,0,0,0);
+		DX8Transforms[i][1].Set(0,0,0,0);
+		DX8Transforms[i][2].Set(0,0,0,0);
+		DX8Transforms[i][3].Set(0,0,0,0);
+	}
+
 }
 
 void DX8Wrapper::Do_Onetime_Device_Dependent_Shutdowns(void)
@@ -397,16 +447,14 @@ void DX8Wrapper::Do_Onetime_Device_Dependent_Shutdowns(void)
 	/*
 	** Shutdown ww3d systems
 	*/
+	int i;
 	if (render_state.vertex_buffer) render_state.vertex_buffer->Release_Engine_Ref();
 	REF_PTR_RELEASE(render_state.vertex_buffer);
 	if (render_state.index_buffer) render_state.index_buffer->Release_Engine_Ref();
 	REF_PTR_RELEASE(render_state.index_buffer);
 	REF_PTR_RELEASE(render_state.material);
-	for (unsigned i=0;i<MAX_TEXTURE_STAGES;++i) REF_PTR_RELEASE(render_state.Textures[i]);
+	for (i=0;i<CurrentCaps->Get_Max_Textures_Per_Pass();++i) REF_PTR_RELEASE(render_state.Textures[i]);
 
-#ifdef WW3D_DX8
-	DazzleRenderObjClass::Deinit();
-#endif //WW3D_DX8
 
 	TextureLoader::Deinit();
 	SortingRendererClass::Deinit();
@@ -418,6 +466,11 @@ void DX8Wrapper::Do_Onetime_Device_Dependent_Shutdowns(void)
 	BoxRenderObjClass::Shutdown();
 	TheDX8MeshRenderer.Shutdown();
 	MissingTexture::_Deinit();
+
+	if (CurrentCaps) {
+		delete CurrentCaps;
+		CurrentCaps=NULL;
+	}
 
 }
 
@@ -461,28 +514,32 @@ bool DX8Wrapper::Create_Device(void)
 		return false;
 	}
 
-	unsigned vertex_processing_type=D3DCREATE_SOFTWARE_VERTEXPROCESSING;
+	Vertex_Processing_Behavior=D3DCREATE_SOFTWARE_VERTEXPROCESSING;
 	if (caps.DevCaps&D3DDEVCAPS_HWTRANSFORMANDLIGHT) 
 	{
-		vertex_processing_type=D3DCREATE_MIXED_VERTEXPROCESSING;
+		Vertex_Processing_Behavior=D3DCREATE_MIXED_VERTEXPROCESSING;
 	}
 
 #ifdef CREATE_DX8_MULTI_THREADED
-	vertex_processing_type|=D3DCREATE_MULTITHREADED;
+	Vertex_Processing_Behavior|=D3DCREATE_MULTITHREADED;
 	_DX8SingleThreaded=false;
 #else
 	_DX8SingleThreaded=true;
 #endif
 
 	if (DX8Wrapper_PreserveFPU)
-		vertex_processing_type |= D3DCREATE_FPU_PRESERVE;
+		Vertex_Processing_Behavior |= D3DCREATE_FPU_PRESERVE;
+
+#ifdef CREATE_DX8_FPU_PRESERVE
+	Vertex_Processing_Behavior|=D3DCREATE_FPU_PRESERVE;
+#endif
 
 	HRESULT hr=D3DInterface->CreateDevice
 	(
 		CurRenderDevice,
 		WW3D_DEVTYPE,
 		_Hwnd,
-		vertex_processing_type,
+		Vertex_Processing_Behavior,
 		&_PresentParameters,
 		&D3DDevice 
 	);
@@ -501,6 +558,7 @@ bool DX8Wrapper::Create_Device(void)
 
 bool DX8Wrapper::Reset_Device(bool reload_assets)
 {
+	WWDEBUG_SAY(("Resetting device.\n"));
 	DX8_THREAD_ASSERT();
 	if ((IsInitted) && (D3DDevice != NULL)) {
 		// Release all non-MANAGED stuff
@@ -512,6 +570,9 @@ bool DX8Wrapper::Reset_Device(bool reload_assets)
 		DynamicVBAccessClass::_Deinit();
 		DynamicIBAccessClass::_Deinit();
 		DX8TextureManagerClass::Release_Textures();
+
+		memset(Vertex_Shader_Constants,0,sizeof(Vector4)*MAX_VERTEX_SHADER_CONSTANTS);
+		memset(Pixel_Shader_Constants,0,sizeof(Vector4)*MAX_PIXEL_SHADER_CONSTANTS);
 
 		HRESULT hr=_Get_D3D_Device8()->TestCooperativeLevel();
 		if (hr != D3DERR_DEVICELOST )
@@ -531,8 +592,10 @@ bool DX8Wrapper::Reset_Device(bool reload_assets)
 		}
 		Invalidate_Cached_Render_States();
 		Set_Default_Global_Render_States();
+		WWDEBUG_SAY(("Device reset completed\n"));
 		return true;
 	}
+	WWDEBUG_SAY(("Device reset failed\n"));
 	return false;
 }
 
@@ -1375,8 +1438,9 @@ bool DX8Wrapper::Find_Z_Mode(D3DFORMAT colorbuffer,D3DFORMAT backbuffer, D3DFORM
 		WWDEBUG_SAY(("Found zbuffer mode D3DFMT_D15S1\n"));
 		return true;
 	}
-	
+
 	// can't find a match
+	WWDEBUG_SAY(("Failed to find a valid zbuffer mode\r\n"));
 	return false;
 }
 
@@ -1411,6 +1475,7 @@ void DX8Wrapper::Reset_Statistics()
 	texture_changes = 0;
 	render_state_changes =0;
 	texture_stage_state_changes =0;
+	draw_calls =0;
 
 	number_of_DX8_calls = 0;
 	last_frame_matrix_changes = 0;
@@ -1422,6 +1487,7 @@ void DX8Wrapper::Reset_Statistics()
 	last_frame_render_state_changes = 0;
 	last_frame_texture_stage_state_changes = 0;
 	last_frame_number_of_DX8_calls = 0;
+	last_frame_draw_calls =0;
 }
 
 void DX8Wrapper::Begin_Statistics()
@@ -1435,6 +1501,7 @@ void DX8Wrapper::Begin_Statistics()
 	render_state_changes =0;
 	texture_stage_state_changes =0;
 	number_of_DX8_calls=0;
+	draw_calls=0;
 }
 
 void DX8Wrapper::End_Statistics()
@@ -1448,6 +1515,7 @@ void DX8Wrapper::End_Statistics()
 	last_frame_render_state_changes = render_state_changes;
 	last_frame_texture_stage_state_changes = texture_stage_state_changes;
 	last_frame_number_of_DX8_calls=number_of_DX8_calls;
+	last_frame_draw_calls=draw_calls;
 }
 
 unsigned DX8Wrapper::Get_Last_Frame_Matrix_Changes()			{ return last_frame_matrix_changes; }
@@ -1459,6 +1527,7 @@ unsigned DX8Wrapper::Get_Last_Frame_Texture_Changes()			{ return last_frame_text
 unsigned DX8Wrapper::Get_Last_Frame_Render_State_Changes()	{ return last_frame_render_state_changes; }
 unsigned DX8Wrapper::Get_Last_Frame_Texture_Stage_State_Changes()	{ return last_frame_texture_stage_state_changes; }
 unsigned DX8Wrapper::Get_Last_Frame_DX8_Calls()					{ return last_frame_number_of_DX8_calls; }
+unsigned DX8Wrapper::Get_Last_Frame_Draw_Calls()				{ return last_frame_draw_calls; }
 unsigned long DX8Wrapper::Get_FrameCount(void) {return FrameCount;}
 
 void DX8_Assert()
@@ -1470,6 +1539,11 @@ void DX8_Assert()
 void DX8Wrapper::Begin_Scene(void)
 {
 	DX8_THREAD_ASSERT();
+
+#if ENABLE_EMBEDDED_BROWSER
+	DX8WebBrowser::Update();
+#endif
+	
 	DX8CALL(BeginScene());
 
 	DX8WebBrowser::Update();
@@ -1484,7 +1558,12 @@ void DX8Wrapper::End_Scene(bool flip_frames)
 
 	if (flip_frames) {
 		DX8_Assert();
-		HRESULT hr=_Get_D3D_Device8()->Present(NULL, NULL, NULL, NULL);
+		HRESULT hr;
+		{
+			WWPROFILE("DX8Device::Present()");
+			hr=_Get_D3D_Device8()->Present(NULL, NULL, NULL, NULL);
+		}
+
 		number_of_DX8_calls++;
 
 		if (SUCCEEDED(hr)) {
@@ -1493,7 +1572,11 @@ void DX8Wrapper::End_Scene(bool flip_frames)
 				::Sleep(stats.m_sleepTime);
 			}
 #endif
+			IsDeviceLost=false;
 			FrameCount++;
+		}
+		else {
+			IsDeviceLost=true;
 		}
 
 		// If the device was lost we need to check for cooperative level and possibly reset the device
@@ -1501,6 +1584,10 @@ void DX8Wrapper::End_Scene(bool flip_frames)
 			hr=_Get_D3D_Device8()->TestCooperativeLevel();
 			if (hr==D3DERR_DEVICENOTRESET) {
 				Reset_Device();
+			}
+			else {
+				// Sleep it not active
+				ThreadClass::Sleep_Ms(200);
 			}
 		}
 		else {
@@ -1511,7 +1598,7 @@ void DX8Wrapper::End_Scene(bool flip_frames)
 	// Each frame, release all of the buffers and textures.
 	Set_Vertex_Buffer(NULL);
 	Set_Index_Buffer(NULL,0);
-	for (unsigned i=0;i<MAX_TEXTURE_STAGES;++i) Set_Texture(i,NULL);
+	for (int i=0;i<CurrentCaps->Get_Max_Textures_Per_Pass();++i) Set_Texture(i,NULL);
 	Set_Material(NULL);
 }
 
@@ -1536,12 +1623,14 @@ void DX8Wrapper::Flip_To_Primary(void)
 				WWDEBUG_SAY(("TestCooperativeLevel Failed!\n"));
 
 				if (D3DERR_DEVICELOST == hr) {
+					IsDeviceLost=true;
 					WWDEBUG_SAY(("DEVICELOST: Cannot flip to primary.\n"));
 					return;
 				}
+				IsDeviceLost=false;
 
 				if (D3DERR_DEVICENOTRESET == hr) {
-					WWDEBUG_SAY(("DEVICENOTRESET: Resetting device.\n"));
+					WWDEBUG_SAY(("DEVICENOTRESET\n"));
 					Reset_Device();
 					resetAttempts++;
 				}
@@ -1550,8 +1639,12 @@ void DX8Wrapper::Flip_To_Primary(void)
 				hr = _Get_D3D_Device8()->Present(NULL, NULL, NULL, NULL);
 
 				if (SUCCEEDED(hr)) {
+					IsDeviceLost=false;
 					FrameCount++;
 					WWDEBUG_SAY(("Flip to primary succeeded %ld\n", FrameCount));
+				}
+				else {
+					IsDeviceLost=true;
 				}
 			}
 
@@ -1588,7 +1681,7 @@ void DX8Wrapper::Set_Viewport(CONST D3DVIEWPORT8* pViewport)
 // ----------------------------------------------------------------------------
 //
 // Set vertex buffer. A reference to previous vertex buffer is released and
-// this one is assigned the current vertex buffer. The DX8 vertex buffer will 
+// this one is assigned the current vertex buffer. The DX8 vertex buffer will
 // actually be set in Apply() which is called by Draw_Indexed_Triangles().
 //
 // ----------------------------------------------------------------------------
@@ -1614,7 +1707,7 @@ void DX8Wrapper::Set_Vertex_Buffer(const VertexBufferClass* vb)
 // ----------------------------------------------------------------------------
 //
 // Set index buffer. A reference to previous index buffer is released and
-// this one is assigned the current index buffer. The DX8 index buffer will 
+// this one is assigned the current index buffer. The DX8 index buffer will
 // actually be set in Apply() which is called by Draw_Indexed_Triangles().
 //
 // ----------------------------------------------------------------------------
@@ -1685,7 +1778,7 @@ void DX8Wrapper::Set_Index_Buffer(const DynamicIBAccessClass& iba_,unsigned shor
 
 void DX8Wrapper::Draw_Sorting_IB_VB(
 	unsigned primitive_type,
-	unsigned short start_index, 
+	unsigned short start_index,
 	unsigned short polygon_count,
 	unsigned short min_vertex_index,
 	unsigned short vertex_count)
@@ -1703,7 +1796,7 @@ void DX8Wrapper::Draw_Sorting_IB_VB(
 		unsigned  size = dyn_vb_access.FVF_Info().Get_FVF_Size()*vertex_count/sizeof(unsigned);
 		unsigned *dest_u =(unsigned*) dest;
 		unsigned *src_u = (unsigned*) src;
-		
+
 		for (unsigned i=0;i<size;++i) {
 			*dest_u++=*src_u++;
 		}
@@ -1746,6 +1839,7 @@ void DX8Wrapper::Draw_Sorting_IB_VB(
 		dyn_vb_access.VertexBufferOffset));
 	DX8_RECORD_INDEX_BUFFER_CHANGE();
 
+	DX8_RECORD_DRAW_CALLS();
 	DX8CALL(DrawIndexedPrimitive(
 		D3DPT_TRIANGLELIST,
 		0,		// start vertex
@@ -1764,11 +1858,13 @@ void DX8Wrapper::Draw_Sorting_IB_VB(
 
 void DX8Wrapper::Draw(
 	unsigned primitive_type,
-	unsigned short start_index, 
+	unsigned short start_index,
 	unsigned short polygon_count,
 	unsigned short min_vertex_index,
 	unsigned short vertex_count)
 {
+	if (DrawPolygonLowBoundLimit && DrawPolygonLowBoundLimit>=polygon_count) return;
+
 	DX8_THREAD_ASSERT();
 	SNAPSHOT_SAY(("DX8 - draw\n"));
 
@@ -1777,7 +1873,58 @@ void DX8Wrapper::Draw(
 	// Debug feature to disable triangle drawing...
 	if (!_Is_Triangle_Draw_Enabled()) return;
 
-	SNAPSHOT_SAY(("DX8 - draw %s polygons (%d vertices)\n",polygon_count,vertex_count));
+#ifdef MESH_RENDER_SNAPSHOT_ENABLED
+	if (WW3D::Is_Snapshot_Activated()) {
+		unsigned long passes=0;
+		SNAPSHOT_SAY(("ValidateDevice: "));
+		HRESULT res=D3DDevice->ValidateDevice(&passes);
+		switch (res) {
+		case D3D_OK:
+			SNAPSHOT_SAY(("OK\n"));
+			break;
+
+		case D3DERR_CONFLICTINGTEXTUREFILTER:
+			SNAPSHOT_SAY(("D3DERR_CONFLICTINGTEXTUREFILTER\n"));
+			break;
+		case D3DERR_CONFLICTINGTEXTUREPALETTE:
+			SNAPSHOT_SAY(("D3DERR_CONFLICTINGTEXTUREPALETTE\n"));
+			break;
+		case D3DERR_DEVICELOST:
+			SNAPSHOT_SAY(("D3DERR_DEVICELOST\n"));
+			break;
+		case D3DERR_TOOMANYOPERATIONS:
+			SNAPSHOT_SAY(("D3DERR_TOOMANYOPERATIONS\n"));
+			break;
+		case D3DERR_UNSUPPORTEDALPHAARG:
+			SNAPSHOT_SAY(("D3DERR_UNSUPPORTEDALPHAARG\n"));
+			break;
+		case D3DERR_UNSUPPORTEDALPHAOPERATION:
+			SNAPSHOT_SAY(("D3DERR_UNSUPPORTEDALPHAOPERATION\n"));
+			break;
+		case D3DERR_UNSUPPORTEDCOLORARG:
+			SNAPSHOT_SAY(("D3DERR_UNSUPPORTEDCOLORARG\n"));
+			break;
+		case D3DERR_UNSUPPORTEDCOLOROPERATION:
+			SNAPSHOT_SAY(("D3DERR_UNSUPPORTEDCOLOROPERATION\n"));
+			break;
+		case D3DERR_UNSUPPORTEDFACTORVALUE:
+			SNAPSHOT_SAY(("D3DERR_UNSUPPORTEDFACTORVALUE\n"));
+			break;
+		case D3DERR_UNSUPPORTEDTEXTUREFILTER:
+			SNAPSHOT_SAY(("D3DERR_UNSUPPORTEDTEXTUREFILTER\n"));
+			break;
+		case D3DERR_WRONGTEXTUREFORMAT:
+			SNAPSHOT_SAY(("D3DERR_WRONGTEXTUREFORMAT\n"));
+			break;
+		default:
+			SNAPSHOT_SAY(("UNKNOWN Error\n"));
+			break;
+		}
+	}
+#endif	// MESH_RENDER_SHAPSHOT_ENABLED
+
+
+	SNAPSHOT_SAY(("DX8 - draw %d polygons (%d vertices)\n",polygon_count,vertex_count));
 
 	if (vertex_count<3) {
 		min_vertex_index=0;
@@ -1806,6 +1953,7 @@ void DX8Wrapper::Draw(
 					break;
 				}*/
 				DX8_RECORD_RENDER(polygon_count,vertex_count,render_state.shader);
+				DX8_RECORD_DRAW_CALLS();
 				DX8CALL(DrawIndexedPrimitive(
 					(D3DPRIMITIVETYPE)primitive_type,
 					min_vertex_index,
@@ -1853,7 +2001,7 @@ void DX8Wrapper::Draw(
 
 void DX8Wrapper::Draw_Triangles(
 	unsigned buffer_type,
-	unsigned short start_index, 
+	unsigned short start_index,
 	unsigned short polygon_count,
 	unsigned short min_vertex_index,
 	unsigned short vertex_count)
@@ -1873,7 +2021,7 @@ void DX8Wrapper::Draw_Triangles(
 // ----------------------------------------------------------------------------
 
 void DX8Wrapper::Draw_Triangles(
-	unsigned short start_index, 
+	unsigned short start_index,
 	unsigned short polygon_count,
 	unsigned short min_vertex_index,
 	unsigned short vertex_count)
@@ -1888,7 +2036,7 @@ void DX8Wrapper::Draw_Triangles(
 // ----------------------------------------------------------------------------
 
 void DX8Wrapper::Draw_Strip(
-	unsigned short start_index, 
+	unsigned short start_index,
 	unsigned short polygon_count,
 	unsigned short min_vertex_index,
 	unsigned short vertex_count)
@@ -1904,6 +2052,8 @@ void DX8Wrapper::Draw_Strip(
 
 void DX8Wrapper::Apply_Render_State_Changes()
 {
+	SNAPSHOT_SAY(("DX8Wrapper::Apply_Render_State_Changes()\n"));
+	
 	if (!render_state_changed) return;
 	if (render_state_changed&SHADER_CHANGED) {
 		SNAPSHOT_SAY(("DX8 - apply shader\n"));
@@ -1911,11 +2061,21 @@ void DX8Wrapper::Apply_Render_State_Changes()
 	}
 
 	unsigned mask=TEXTURE0_CHANGED;
-	for (unsigned i=0;i<MAX_TEXTURE_STAGES;++i,mask<<=1) {
-		if (render_state_changed&mask) {
+	int i=0;
+	for (;i<CurrentCaps->Get_Max_Textures_Per_Pass();++i,mask<<=1) 
+	{
+		if (render_state_changed&mask) 
+		{
 			SNAPSHOT_SAY(("DX8 - apply texture %d\n",i));
-			if (render_state.Textures[i]) render_state.Textures[i]->Apply(i);
-			else TextureBaseClass::Apply_Null(i);
+
+			if (render_state.Textures[i]) 
+			{
+				render_state.Textures[i]->Apply(i);
+			}
+			else 
+			{
+				TextureBaseClass::Apply_Null(i);
+			}
 		}
 	}
 
@@ -1937,11 +2097,28 @@ void DX8Wrapper::Apply_Render_State_Changes()
 			if (render_state_changed&mask) {
 				SNAPSHOT_SAY(("DX8 - apply light %d\n",index));
 				if (render_state.LightEnable[index]) {
+#ifdef MESH_RENDER_SNAPSHOT_ENABLED		
+					if ( WW3D::Is_Snapshot_Activated() ) {
+						D3DLIGHT8 * light = &(render_state.Lights[index]);
+						static const char * _light_types[] = { "Unknown", "Point","Spot", "Directional" };
+						WWASSERT((light->Type >= 0) && (light->Type <= 3));					
+
+						SNAPSHOT_SAY((" type = %s amb = %4.2f,%4.2f,%4.2f  diff = %4.2f,%4.2f,%4.2f spec = %4.2f, %4.2f, %4.2f\n",
+							_light_types[light->Type],
+							light->Ambient.r,light->Ambient.g,light->Ambient.b,
+							light->Diffuse.r,light->Diffuse.g,light->Diffuse.b,
+							light->Specular.r,light->Specular.g,light->Specular.b ));
+						SNAPSHOT_SAY((" pos = %f, %f, %f  dir = %f, %f, %f\n",
+							light->Position.x, light->Position.y, light->Position.z,
+							light->Direction.x, light->Direction.y, light->Direction.z ));
+					}
+#endif
+
 					Set_DX8_Light(index,&render_state.Lights[index]);
 				}
 				else {
 					Set_DX8_Light(index,NULL);
-
+					SNAPSHOT_SAY((" clearing light to NULL\n"));
 				}
 			}
 		}
@@ -2006,6 +2183,8 @@ void DX8Wrapper::Apply_Render_State_Changes()
 	}
 
 	render_state_changed&=((unsigned)WORLD_IDENTITY|(unsigned)VIEW_IDENTITY);
+
+	SNAPSHOT_SAY(("DX8Wrapper::Apply_Render_State_Changes() - finished\n"));
 }
 
 IDirect3DTexture8 * DX8Wrapper::_Create_DX8_Texture
@@ -2097,7 +2276,7 @@ IDirect3DTexture8 * DX8Wrapper::_Create_DX8_Texture
 		filename,
 		D3DX_DEFAULT,
 		D3DX_DEFAULT,
-		mip_level_count,//create_mipmaps ? 0 : 1, 
+		mip_level_count,//create_mipmaps ? 0 : 1,
 		0,
 		D3DFMT_UNKNOWN,
 		D3DPOOL_MANAGED,
@@ -2119,13 +2298,6 @@ IDirect3DTexture8 * DX8Wrapper::_Create_DX8_Texture
 		texture->Release();
 		return MissingTexture::_Get_Missing_Texture();
 	}
-	else {
-//		unsigned reduction=WW3D::Get_Texture_Reduction();
-//		unsigned level_count=texture->GetLevelCount();
-//		if (reduction>=level_count) reduction=level_count-1;
-//		texture->SetLOD(reduction);
-	}
-
 	return texture;
 }
 
@@ -2259,6 +2431,19 @@ void DX8Wrapper::Compute_Caps(WW3DFormat display_format)
 	DX8_Assert();
 	delete CurrentCaps;
 	CurrentCaps=new DX8Caps(_Get_D3D8(),D3DDevice,display_format,Get_Current_Adapter_Identifier());
+}
+
+
+void DX8Wrapper::Set_Light(unsigned index, const D3DLIGHT8* light)
+{
+	if (light) {
+		render_state.Lights[index]=*light;
+		render_state.LightEnable[index]=true;
+	}
+	else {
+		render_state.LightEnable[index]=false;
+	}
+	render_state_changed|=(LIGHT0_CHANGED<<index);
 }
 
 void DX8Wrapper::Set_Light(unsigned index,const LightClass &light)
@@ -2550,6 +2735,8 @@ DX8Wrapper::Set_Render_Target(IDirect3DSwapChain8 *swap_chain)
 		render_target = NULL;
 	}
 
+	IsRenderToTexture = false;
+
 	return ;
 }
 
@@ -2635,6 +2822,7 @@ DX8Wrapper::Set_Render_Target(IDirect3DSurface8 *render_target)
 		depth_buffer = NULL;
 	}
 
+	IsRenderToTexture = false;
 	return ;
 }
 
@@ -2721,7 +2909,7 @@ void DX8Wrapper::Set_Gamma(float gamma,float bright,float contrast,bool calibrat
 		ramp.blue[i]=(WORD) (out*65535);
 	}
 
-	if (DX8Wrapper::Get_Current_Caps()->Support_Gamma())	{
+	if (Get_Current_Caps()->Support_Gamma())	{
 		DX8Wrapper::_Get_D3D_Device8()->SetGammaRamp(flag,&ramp);
 	} else {
 		HWND hwnd = GetDesktopWindow();
@@ -2733,6 +2921,739 @@ void DX8Wrapper::Set_Gamma(float gamma,float bright,float contrast,bool calibrat
 		}
 	}
 }
+
+//**********************************************************************************************
+//! Resets render device to default state
+/*!
+*/
+void DX8Wrapper::Apply_Default_State()
+{
+	SNAPSHOT_SAY(("DX8Wrapper::Apply_Default_State()\n"));
+	
+	// only set states used in game
+	Set_DX8_Render_State(D3DRS_ZENABLE, TRUE);
+//	Set_DX8_Render_State(D3DRS_FILLMODE, D3DFILL_SOLID);
+	Set_DX8_Render_State(D3DRS_SHADEMODE, D3DSHADE_GOURAUD);
+	//Set_DX8_Render_State(D3DRS_LINEPATTERN, 0);
+	Set_DX8_Render_State(D3DRS_ZWRITEENABLE, TRUE);
+	Set_DX8_Render_State(D3DRS_ALPHATESTENABLE, FALSE);
+	//Set_DX8_Render_State(D3DRS_LASTPIXEL, FALSE);
+	Set_DX8_Render_State(D3DRS_SRCBLEND, D3DBLEND_ONE);
+	Set_DX8_Render_State(D3DRS_DESTBLEND, D3DBLEND_ZERO);
+	Set_DX8_Render_State(D3DRS_CULLMODE, D3DCULL_CW);
+	Set_DX8_Render_State(D3DRS_ZFUNC, D3DCMP_LESSEQUAL);
+	Set_DX8_Render_State(D3DRS_ALPHAREF, 0);
+	Set_DX8_Render_State(D3DRS_ALPHAFUNC, D3DCMP_LESSEQUAL);
+	Set_DX8_Render_State(D3DRS_DITHERENABLE, FALSE);
+	Set_DX8_Render_State(D3DRS_ALPHABLENDENABLE, FALSE);
+	Set_DX8_Render_State(D3DRS_FOGENABLE, FALSE);
+	Set_DX8_Render_State(D3DRS_SPECULARENABLE, FALSE);
+//	Set_DX8_Render_State(D3DRS_ZVISIBLE, FALSE);
+//	Set_DX8_Render_State(D3DRS_FOGCOLOR, 0);
+//	Set_DX8_Render_State(D3DRS_FOGTABLEMODE, D3DFOG_NONE);
+//	Set_DX8_Render_State(D3DRS_FOGSTART, 0);
+
+//	Set_DX8_Render_State(D3DRS_FOGEND, WWMath::Float_As_Int(1.0f));
+//	Set_DX8_Render_State(D3DRS_FOGDENSITY, WWMath::Float_As_Int(1.0f));
+
+	//Set_DX8_Render_State(D3DRS_EDGEANTIALIAS, FALSE);
+	Set_DX8_Render_State(D3DRS_ZBIAS, 0);
+//	Set_DX8_Render_State(D3DRS_RANGEFOGENABLE, FALSE);
+	Set_DX8_Render_State(D3DRS_STENCILENABLE, FALSE);
+	Set_DX8_Render_State(D3DRS_STENCILFAIL, D3DSTENCILOP_KEEP);
+	Set_DX8_Render_State(D3DRS_STENCILZFAIL, D3DSTENCILOP_KEEP);
+	Set_DX8_Render_State(D3DRS_STENCILPASS, D3DSTENCILOP_KEEP);
+	Set_DX8_Render_State(D3DRS_STENCILFUNC, D3DCMP_ALWAYS);
+	Set_DX8_Render_State(D3DRS_STENCILREF, 0);
+	Set_DX8_Render_State(D3DRS_STENCILMASK, 0xffffffff);
+	Set_DX8_Render_State(D3DRS_STENCILWRITEMASK, 0xffffffff);
+	Set_DX8_Render_State(D3DRS_TEXTUREFACTOR, 0);
+/*	Set_DX8_Render_State(D3DRS_WRAP0, D3DWRAP_U| D3DWRAP_V);
+	Set_DX8_Render_State(D3DRS_WRAP1, D3DWRAP_U| D3DWRAP_V);
+	Set_DX8_Render_State(D3DRS_WRAP2, D3DWRAP_U| D3DWRAP_V);
+	Set_DX8_Render_State(D3DRS_WRAP3, D3DWRAP_U| D3DWRAP_V);
+	Set_DX8_Render_State(D3DRS_WRAP4, D3DWRAP_U| D3DWRAP_V);
+	Set_DX8_Render_State(D3DRS_WRAP5, D3DWRAP_U| D3DWRAP_V);
+	Set_DX8_Render_State(D3DRS_WRAP6, D3DWRAP_U| D3DWRAP_V);
+	Set_DX8_Render_State(D3DRS_WRAP7, D3DWRAP_U| D3DWRAP_V);*/
+	Set_DX8_Render_State(D3DRS_CLIPPING, TRUE);
+	Set_DX8_Render_State(D3DRS_LIGHTING, FALSE);
+	//Set_DX8_Render_State(D3DRS_AMBIENT, 0);
+//	Set_DX8_Render_State(D3DRS_FOGVERTEXMODE, D3DFOG_NONE);
+	Set_DX8_Render_State(D3DRS_COLORVERTEX, TRUE);
+/*	Set_DX8_Render_State(D3DRS_LOCALVIEWER, TRUE);
+	Set_DX8_Render_State(D3DRS_NORMALIZENORMALS, FALSE);
+	Set_DX8_Render_State(D3DRS_DIFFUSEMATERIALSOURCE, D3DMCS_COLOR1);
+	Set_DX8_Render_State(D3DRS_SPECULARMATERIALSOURCE, D3DMCS_COLOR2);
+	Set_DX8_Render_State(D3DRS_AMBIENTMATERIALSOURCE, D3DMCS_MATERIAL);
+	Set_DX8_Render_State(D3DRS_EMISSIVEMATERIALSOURCE, D3DMCS_MATERIAL);
+	Set_DX8_Render_State(D3DRS_VERTEXBLEND, D3DVBF_DISABLE);*/
+	//Set_DX8_Render_State(D3DRS_CLIPPLANEENABLE, 0);
+	Set_DX8_Render_State(D3DRS_SOFTWAREVERTEXPROCESSING, FALSE);
+	//Set_DX8_Render_State(D3DRS_POINTSIZE, 0x3f800000);
+	//Set_DX8_Render_State(D3DRS_POINTSIZE_MIN, 0);
+	//Set_DX8_Render_State(D3DRS_POINTSPRITEENABLE, FALSE);
+	//Set_DX8_Render_State(D3DRS_POINTSCALEENABLE, FALSE);
+	//Set_DX8_Render_State(D3DRS_POINTSCALE_A, 0);
+	//Set_DX8_Render_State(D3DRS_POINTSCALE_B, 0);
+	//Set_DX8_Render_State(D3DRS_POINTSCALE_C, 0);
+	//Set_DX8_Render_State(D3DRS_MULTISAMPLEANTIALIAS, TRUE);
+	//Set_DX8_Render_State(D3DRS_MULTISAMPLEMASK, 0xffffffff);
+	//Set_DX8_Render_State(D3DRS_PATCHEDGESTYLE, D3DPATCHEDGE_DISCRETE);
+	//Set_DX8_Render_State(D3DRS_PATCHSEGMENTS, 0x3f800000);
+	//Set_DX8_Render_State(D3DRS_DEBUGMONITORTOKEN, D3DDMT_ENABLE);
+	//Set_DX8_Render_State(D3DRS_POINTSIZE_MAX, Float_At_Int(64.0f));
+	//Set_DX8_Render_State(D3DRS_INDEXEDVERTEXBLENDENABLE, FALSE);
+	Set_DX8_Render_State(D3DRS_COLORWRITEENABLE, 0x0000000f);
+	//Set_DX8_Render_State(D3DRS_TWEENFACTOR, 0);
+	Set_DX8_Render_State(D3DRS_BLENDOP, D3DBLENDOP_ADD);
+	//Set_DX8_Render_State(D3DRS_POSITIONORDER, D3DORDER_CUBIC);
+	//Set_DX8_Render_State(D3DRS_NORMALORDER, D3DORDER_LINEAR);
+
+	// disable TSS stages
+	int i;
+	for (i=0; i<CurrentCaps->Get_Max_Textures_Per_Pass(); i++)
+	{
+		Set_DX8_Texture_Stage_State(i, D3DTSS_COLOROP, D3DTOP_DISABLE);
+		Set_DX8_Texture_Stage_State(i, D3DTSS_COLORARG1, D3DTA_TEXTURE);
+		Set_DX8_Texture_Stage_State(i, D3DTSS_COLORARG2, D3DTA_DIFFUSE);
+
+		Set_DX8_Texture_Stage_State(i, D3DTSS_ALPHAOP, D3DTOP_DISABLE);
+		Set_DX8_Texture_Stage_State(i, D3DTSS_ALPHAARG1, D3DTA_TEXTURE);
+		Set_DX8_Texture_Stage_State(i, D3DTSS_ALPHAARG2, D3DTA_DIFFUSE);
+	
+		/*Set_DX8_Texture_Stage_State(i, D3DTSS_BUMPENVMAT00, 0);
+		Set_DX8_Texture_Stage_State(i, D3DTSS_BUMPENVMAT01, 0);
+		Set_DX8_Texture_Stage_State(i, D3DTSS_BUMPENVMAT10, 0);
+		Set_DX8_Texture_Stage_State(i, D3DTSS_BUMPENVMAT11, 0);
+		Set_DX8_Texture_Stage_State(i, D3DTSS_BUMPENVLSCALE, 0);
+		Set_DX8_Texture_Stage_State(i, D3DTSS_BUMPENVLOFFSET, 0);*/
+
+		Set_DX8_Texture_Stage_State(i, D3DTSS_TEXCOORDINDEX, i);
+		
+
+		Set_DX8_Texture_Stage_State(i, D3DTSS_ADDRESSU, D3DTADDRESS_WRAP);
+		Set_DX8_Texture_Stage_State(i, D3DTSS_ADDRESSV, D3DTADDRESS_WRAP);
+		Set_DX8_Texture_Stage_State(i, D3DTSS_BORDERCOLOR, 0);
+//		Set_DX8_Texture_Stage_State(i, D3DTSS_MAGFILTER, D3DTEXF_LINEAR);
+//		Set_DX8_Texture_Stage_State(i, D3DTSS_MINFILTER, D3DTEXF_LINEAR);
+//		Set_DX8_Texture_Stage_State(i, D3DTSS_MIPFILTER, D3DTEXF_LINEAR);
+//		Set_DX8_Texture_Stage_State(i, D3DTSS_MIPMAPLODBIAS, 0);
+//		Set_DX8_Texture_Stage_State(i, D3DTSS_MAXMIPLEVEL, 0);
+//		Set_DX8_Texture_Stage_State(i, D3DTSS_MAXANISOTROPY, 1);
+		//Set_DX8_Texture_Stage_State(i, D3DTSS_ADDRESSW, D3DTADDRESS_WRAP);
+		//Set_DX8_Texture_Stage_State(i, D3DTSS_COLORARG0, D3DTA_CURRENT);
+		//Set_DX8_Texture_Stage_State(i, D3DTSS_ALPHAARG0, D3DTA_CURRENT);
+		//Set_DX8_Texture_Stage_State(i, D3DTSS_RESULTARG, D3DTA_CURRENT);
+
+		Set_DX8_Texture_Stage_State(i, D3DTSS_TEXTURETRANSFORMFLAGS, D3DTTFF_DISABLE);
+		Set_Texture(i,NULL);
+	}
+
+//	DX8Wrapper::Set_Material(NULL);
+	VertexMaterialClass::Apply_Null();
+
+	for (unsigned index=0;index<4;++index) {
+		SNAPSHOT_SAY(("Clearing light %d to NULL\n",index));
+		Set_DX8_Light(index,NULL);
+	}
+
+	// set up simple default TSS 
+	Vector4 vconst[MAX_VERTEX_SHADER_CONSTANTS];
+	memset(vconst,0,sizeof(Vector4)*MAX_VERTEX_SHADER_CONSTANTS);
+	Set_Vertex_Shader_Constant(0, vconst, MAX_VERTEX_SHADER_CONSTANTS);
+
+	Vector4 pconst[MAX_PIXEL_SHADER_CONSTANTS];
+	memset(pconst,0,sizeof(Vector4)*MAX_PIXEL_SHADER_CONSTANTS);
+	Set_Pixel_Shader_Constant(0, pconst, MAX_PIXEL_SHADER_CONSTANTS);
+
+	Set_Vertex_Shader(DX8_FVF_XYZNDUV2);
+	Set_Pixel_Shader(0);
+
+	ShaderClass::Invalidate();
+}
+
+const char* DX8Wrapper::Get_DX8_Render_State_Name(D3DRENDERSTATETYPE state)
+{
+	switch (state) {
+	case D3DRS_ZENABLE                       : return "D3DRS_ZENABLE";
+	case D3DRS_FILLMODE                      : return "D3DRS_FILLMODE";
+	case D3DRS_SHADEMODE                     : return "D3DRS_SHADEMODE";
+	case D3DRS_LINEPATTERN                   : return "D3DRS_LINEPATTERN";
+	case D3DRS_ZWRITEENABLE                  : return "D3DRS_ZWRITEENABLE";
+	case D3DRS_ALPHATESTENABLE               : return "D3DRS_ALPHATESTENABLE";
+	case D3DRS_LASTPIXEL                     : return "D3DRS_LASTPIXEL";
+	case D3DRS_SRCBLEND                      : return "D3DRS_SRCBLEND";
+	case D3DRS_DESTBLEND                     : return "D3DRS_DESTBLEND";
+	case D3DRS_CULLMODE                      : return "D3DRS_CULLMODE";
+	case D3DRS_ZFUNC                         : return "D3DRS_ZFUNC";
+	case D3DRS_ALPHAREF                      : return "D3DRS_ALPHAREF";
+	case D3DRS_ALPHAFUNC                     : return "D3DRS_ALPHAFUNC";
+	case D3DRS_DITHERENABLE                  : return "D3DRS_DITHERENABLE";
+	case D3DRS_ALPHABLENDENABLE              : return "D3DRS_ALPHABLENDENABLE";
+	case D3DRS_FOGENABLE                     : return "D3DRS_FOGENABLE";
+	case D3DRS_SPECULARENABLE                : return "D3DRS_SPECULARENABLE";
+	case D3DRS_ZVISIBLE                      : return "D3DRS_ZVISIBLE";
+	case D3DRS_FOGCOLOR                      : return "D3DRS_FOGCOLOR";
+	case D3DRS_FOGTABLEMODE                  : return "D3DRS_FOGTABLEMODE";
+	case D3DRS_FOGSTART                      : return "D3DRS_FOGSTART";
+	case D3DRS_FOGEND                        : return "D3DRS_FOGEND";
+	case D3DRS_FOGDENSITY                    : return "D3DRS_FOGDENSITY";
+	case D3DRS_EDGEANTIALIAS                 : return "D3DRS_EDGEANTIALIAS";
+	case D3DRS_ZBIAS                         : return "D3DRS_ZBIAS";
+	case D3DRS_RANGEFOGENABLE                : return "D3DRS_RANGEFOGENABLE";
+	case D3DRS_STENCILENABLE                 : return "D3DRS_STENCILENABLE";
+	case D3DRS_STENCILFAIL                   : return "D3DRS_STENCILFAIL";
+	case D3DRS_STENCILZFAIL                  : return "D3DRS_STENCILZFAIL";
+	case D3DRS_STENCILPASS                   : return "D3DRS_STENCILPASS";
+	case D3DRS_STENCILFUNC                   : return "D3DRS_STENCILFUNC";
+	case D3DRS_STENCILREF                    : return "D3DRS_STENCILREF";
+	case D3DRS_STENCILMASK                   : return "D3DRS_STENCILMASK";
+	case D3DRS_STENCILWRITEMASK              : return "D3DRS_STENCILWRITEMASK";
+	case D3DRS_TEXTUREFACTOR                 : return "D3DRS_TEXTUREFACTOR";
+	case D3DRS_WRAP0                         : return "D3DRS_WRAP0";
+	case D3DRS_WRAP1                         : return "D3DRS_WRAP1";
+	case D3DRS_WRAP2                         : return "D3DRS_WRAP2";
+	case D3DRS_WRAP3                         : return "D3DRS_WRAP3";
+	case D3DRS_WRAP4                         : return "D3DRS_WRAP4";
+	case D3DRS_WRAP5                         : return "D3DRS_WRAP5";
+	case D3DRS_WRAP6                         : return "D3DRS_WRAP6";
+	case D3DRS_WRAP7                         : return "D3DRS_WRAP7";
+	case D3DRS_CLIPPING                      : return "D3DRS_CLIPPING";
+	case D3DRS_LIGHTING                      : return "D3DRS_LIGHTING";
+	case D3DRS_AMBIENT                       : return "D3DRS_AMBIENT";
+	case D3DRS_FOGVERTEXMODE                 : return "D3DRS_FOGVERTEXMODE";
+	case D3DRS_COLORVERTEX                   : return "D3DRS_COLORVERTEX";
+	case D3DRS_LOCALVIEWER                   : return "D3DRS_LOCALVIEWER";
+	case D3DRS_NORMALIZENORMALS              : return "D3DRS_NORMALIZENORMALS";
+	case D3DRS_DIFFUSEMATERIALSOURCE         : return "D3DRS_DIFFUSEMATERIALSOURCE";
+	case D3DRS_SPECULARMATERIALSOURCE        : return "D3DRS_SPECULARMATERIALSOURCE";
+	case D3DRS_AMBIENTMATERIALSOURCE         : return "D3DRS_AMBIENTMATERIALSOURCE";
+	case D3DRS_EMISSIVEMATERIALSOURCE        : return "D3DRS_EMISSIVEMATERIALSOURCE";
+	case D3DRS_VERTEXBLEND                   : return "D3DRS_VERTEXBLEND";
+	case D3DRS_CLIPPLANEENABLE               : return "D3DRS_CLIPPLANEENABLE";
+	case D3DRS_SOFTWAREVERTEXPROCESSING      : return "D3DRS_SOFTWAREVERTEXPROCESSING";
+	case D3DRS_POINTSIZE                     : return "D3DRS_POINTSIZE";
+	case D3DRS_POINTSIZE_MIN                 : return "D3DRS_POINTSIZE_MIN";
+	case D3DRS_POINTSPRITEENABLE             : return "D3DRS_POINTSPRITEENABLE";
+	case D3DRS_POINTSCALEENABLE              : return "D3DRS_POINTSCALEENABLE";
+	case D3DRS_POINTSCALE_A                  : return "D3DRS_POINTSCALE_A";
+	case D3DRS_POINTSCALE_B                  : return "D3DRS_POINTSCALE_B";
+	case D3DRS_POINTSCALE_C                  : return "D3DRS_POINTSCALE_C";
+	case D3DRS_MULTISAMPLEANTIALIAS          : return "D3DRS_MULTISAMPLEANTIALIAS";
+	case D3DRS_MULTISAMPLEMASK               : return "D3DRS_MULTISAMPLEMASK";
+	case D3DRS_PATCHEDGESTYLE                : return "D3DRS_PATCHEDGESTYLE";
+	case D3DRS_PATCHSEGMENTS                 : return "D3DRS_PATCHSEGMENTS";
+	case D3DRS_DEBUGMONITORTOKEN             : return "D3DRS_DEBUGMONITORTOKEN";
+	case D3DRS_POINTSIZE_MAX                 : return "D3DRS_POINTSIZE_MAX";
+	case D3DRS_INDEXEDVERTEXBLENDENABLE      : return "D3DRS_INDEXEDVERTEXBLENDENABLE";
+	case D3DRS_COLORWRITEENABLE              : return "D3DRS_COLORWRITEENABLE";
+	case D3DRS_TWEENFACTOR                   : return "D3DRS_TWEENFACTOR";
+	case D3DRS_BLENDOP                       : return "D3DRS_BLENDOP";
+//	case D3DRS_POSITIONORDER                 : return "D3DRS_POSITIONORDER";
+//	case D3DRS_NORMALORDER                   : return "D3DRS_NORMALORDER";
+	default											  : return "UNKNOWN";
+	}
+}
+
+const char* DX8Wrapper::Get_DX8_Texture_Stage_State_Name(D3DTEXTURESTAGESTATETYPE state)
+{
+	switch (state) {
+	case D3DTSS_COLOROP                   : return "D3DTSS_COLOROP";
+	case D3DTSS_COLORARG1                 : return "D3DTSS_COLORARG1";
+	case D3DTSS_COLORARG2                 : return "D3DTSS_COLORARG2";
+	case D3DTSS_ALPHAOP                   : return "D3DTSS_ALPHAOP";
+	case D3DTSS_ALPHAARG1                 : return "D3DTSS_ALPHAARG1";
+	case D3DTSS_ALPHAARG2                 : return "D3DTSS_ALPHAARG2";
+	case D3DTSS_BUMPENVMAT00              : return "D3DTSS_BUMPENVMAT00";
+	case D3DTSS_BUMPENVMAT01              : return "D3DTSS_BUMPENVMAT01";
+	case D3DTSS_BUMPENVMAT10              : return "D3DTSS_BUMPENVMAT10";
+	case D3DTSS_BUMPENVMAT11              : return "D3DTSS_BUMPENVMAT11";
+	case D3DTSS_TEXCOORDINDEX             : return "D3DTSS_TEXCOORDINDEX";
+	case D3DTSS_ADDRESSU                  : return "D3DTSS_ADDRESSU";
+	case D3DTSS_ADDRESSV                  : return "D3DTSS_ADDRESSV";
+	case D3DTSS_BORDERCOLOR               : return "D3DTSS_BORDERCOLOR";
+	case D3DTSS_MAGFILTER                 : return "D3DTSS_MAGFILTER";
+	case D3DTSS_MINFILTER                 : return "D3DTSS_MINFILTER";
+	case D3DTSS_MIPFILTER                 : return "D3DTSS_MIPFILTER";
+	case D3DTSS_MIPMAPLODBIAS             : return "D3DTSS_MIPMAPLODBIAS";
+	case D3DTSS_MAXMIPLEVEL               : return "D3DTSS_MAXMIPLEVEL";
+	case D3DTSS_MAXANISOTROPY             : return "D3DTSS_MAXANISOTROPY";
+	case D3DTSS_BUMPENVLSCALE             : return "D3DTSS_BUMPENVLSCALE";
+	case D3DTSS_BUMPENVLOFFSET            : return "D3DTSS_BUMPENVLOFFSET";
+	case D3DTSS_TEXTURETRANSFORMFLAGS     : return "D3DTSS_TEXTURETRANSFORMFLAGS";
+	case D3DTSS_ADDRESSW                  : return "D3DTSS_ADDRESSW";
+	case D3DTSS_COLORARG0                 : return "D3DTSS_COLORARG0";
+	case D3DTSS_ALPHAARG0                 : return "D3DTSS_ALPHAARG0";
+	case D3DTSS_RESULTARG                 : return "D3DTSS_RESULTARG";
+	default										  : return "UNKNOWN";
+	}
+}
+
+void DX8Wrapper::Get_DX8_Render_State_Value_Name(StringClass& name, D3DRENDERSTATETYPE state, unsigned value)
+{
+	switch (state) {
+	case D3DRS_ZENABLE:
+		name=Get_DX8_ZBuffer_Type_Name(value);
+		break;
+
+	case D3DRS_FILLMODE:
+		name=Get_DX8_Fill_Mode_Name(value);
+		break;
+
+	case D3DRS_SHADEMODE:
+		name=Get_DX8_Shade_Mode_Name(value);
+		break;
+
+	case D3DRS_LINEPATTERN:
+	case D3DRS_FOGCOLOR:
+	case D3DRS_ALPHAREF:
+	case D3DRS_STENCILMASK:
+	case D3DRS_STENCILWRITEMASK:
+	case D3DRS_TEXTUREFACTOR:
+	case D3DRS_AMBIENT:
+	case D3DRS_CLIPPLANEENABLE:
+	case D3DRS_MULTISAMPLEMASK:
+		name.Format("0x%x",value);
+		break;
+
+	case D3DRS_ZWRITEENABLE:
+	case D3DRS_ALPHATESTENABLE:
+	case D3DRS_LASTPIXEL:
+	case D3DRS_DITHERENABLE:
+	case D3DRS_ALPHABLENDENABLE:
+	case D3DRS_FOGENABLE:
+	case D3DRS_SPECULARENABLE:
+	case D3DRS_STENCILENABLE:
+	case D3DRS_RANGEFOGENABLE:
+	case D3DRS_EDGEANTIALIAS:
+	case D3DRS_CLIPPING:
+	case D3DRS_LIGHTING:
+	case D3DRS_COLORVERTEX:
+	case D3DRS_LOCALVIEWER:
+	case D3DRS_NORMALIZENORMALS:
+	case D3DRS_SOFTWAREVERTEXPROCESSING:
+	case D3DRS_POINTSPRITEENABLE:
+	case D3DRS_POINTSCALEENABLE:
+	case D3DRS_MULTISAMPLEANTIALIAS:
+	case D3DRS_INDEXEDVERTEXBLENDENABLE:
+		name=value ? "TRUE" : "FALSE";
+		break;
+
+	case D3DRS_SRCBLEND:
+	case D3DRS_DESTBLEND:
+		name=Get_DX8_Blend_Name(value);
+		break;
+
+	case D3DRS_CULLMODE:
+		name=Get_DX8_Cull_Mode_Name(value);
+		break;
+
+	case D3DRS_ZFUNC:
+	case D3DRS_ALPHAFUNC:
+	case D3DRS_STENCILFUNC:
+		name=Get_DX8_Cmp_Func_Name(value);
+		break;
+
+	case D3DRS_ZVISIBLE:
+		name="NOTSUPPORTED";
+		break;
+
+	case D3DRS_FOGTABLEMODE:
+	case D3DRS_FOGVERTEXMODE:
+		name=Get_DX8_Fog_Mode_Name(value);
+		break;
+
+	case D3DRS_FOGSTART:
+	case D3DRS_FOGEND:
+	case D3DRS_FOGDENSITY:
+	case D3DRS_POINTSIZE:
+	case D3DRS_POINTSIZE_MIN:
+	case D3DRS_POINTSCALE_A:
+	case D3DRS_POINTSCALE_B:
+	case D3DRS_POINTSCALE_C:
+	case D3DRS_PATCHSEGMENTS:
+	case D3DRS_POINTSIZE_MAX:
+	case D3DRS_TWEENFACTOR:
+		name.Format("%f",*(float*)&value);
+		break;
+
+	case D3DRS_ZBIAS:
+	case D3DRS_STENCILREF:
+		name.Format("%d",value);
+		break;
+
+	case D3DRS_STENCILFAIL:
+	case D3DRS_STENCILZFAIL:
+	case D3DRS_STENCILPASS:
+		name=Get_DX8_Stencil_Op_Name(value);
+		break;
+
+	case D3DRS_WRAP0:
+	case D3DRS_WRAP1:
+	case D3DRS_WRAP2:
+	case D3DRS_WRAP3:
+	case D3DRS_WRAP4:
+	case D3DRS_WRAP5:
+	case D3DRS_WRAP6:
+	case D3DRS_WRAP7:
+		name="0";
+		if (value&D3DWRAP_U) name+="|D3DWRAP_U";
+		if (value&D3DWRAP_V) name+="|D3DWRAP_V";
+		if (value&D3DWRAP_W) name+="|D3DWRAP_W";
+		break;
+
+	case D3DRS_DIFFUSEMATERIALSOURCE:
+	case D3DRS_SPECULARMATERIALSOURCE:
+	case D3DRS_AMBIENTMATERIALSOURCE:
+	case D3DRS_EMISSIVEMATERIALSOURCE:
+		name=Get_DX8_Material_Source_Name(value);
+		break;
+
+	case D3DRS_VERTEXBLEND:
+		name=Get_DX8_Vertex_Blend_Flag_Name(value);
+		break;
+
+	case D3DRS_PATCHEDGESTYLE:
+		name=Get_DX8_Patch_Edge_Style_Name(value);
+		break;
+
+	case D3DRS_DEBUGMONITORTOKEN:
+		name=Get_DX8_Debug_Monitor_Token_Name(value);
+		break;
+
+	case D3DRS_COLORWRITEENABLE:
+		name="0";
+		if (value&D3DCOLORWRITEENABLE_RED) name+="|D3DCOLORWRITEENABLE_RED";
+		if (value&D3DCOLORWRITEENABLE_GREEN) name+="|D3DCOLORWRITEENABLE_GREEN";
+		if (value&D3DCOLORWRITEENABLE_BLUE) name+="|D3DCOLORWRITEENABLE_BLUE";
+		if (value&D3DCOLORWRITEENABLE_ALPHA) name+="|D3DCOLORWRITEENABLE_ALPHA";
+		break;
+	case D3DRS_BLENDOP:
+		name=Get_DX8_Blend_Op_Name(value);
+		break;
+	default:
+		name.Format("UNKNOWN (%d)",value);
+		break;
+	}
+}
+
+void DX8Wrapper::Get_DX8_Texture_Stage_State_Value_Name(StringClass& name, D3DTEXTURESTAGESTATETYPE state, unsigned value)
+{
+	switch (state) {
+	case D3DTSS_COLOROP:
+	case D3DTSS_ALPHAOP:
+		name=Get_DX8_Texture_Op_Name(value);
+		break;
+
+	case D3DTSS_COLORARG0:
+	case D3DTSS_COLORARG1:
+	case D3DTSS_COLORARG2:
+	case D3DTSS_ALPHAARG0:
+	case D3DTSS_ALPHAARG1:
+	case D3DTSS_ALPHAARG2:
+	case D3DTSS_RESULTARG:
+		name=Get_DX8_Texture_Arg_Name(value);
+		break;
+
+	case D3DTSS_ADDRESSU:
+	case D3DTSS_ADDRESSV:
+	case D3DTSS_ADDRESSW:
+		name=Get_DX8_Texture_Address_Name(value);
+		break;
+
+	case D3DTSS_MAGFILTER:
+	case D3DTSS_MINFILTER:
+	case D3DTSS_MIPFILTER:
+		name=Get_DX8_Texture_Filter_Name(value);
+		break;
+
+	case D3DTSS_TEXTURETRANSFORMFLAGS:
+		name=Get_DX8_Texture_Transform_Flag_Name(value);
+
+	// Floating point values
+	case D3DTSS_MIPMAPLODBIAS:
+	case D3DTSS_BUMPENVMAT00:
+	case D3DTSS_BUMPENVMAT01:
+	case D3DTSS_BUMPENVMAT10:
+	case D3DTSS_BUMPENVMAT11:
+	case D3DTSS_BUMPENVLSCALE:
+	case D3DTSS_BUMPENVLOFFSET:
+		name.Format("%f",*(float*)&value);
+		break;
+
+	case D3DTSS_TEXCOORDINDEX:
+		if ((value&0xffff0000)==D3DTSS_TCI_CAMERASPACENORMAL) {
+			name.Format("D3DTSS_TCI_CAMERASPACENORMAL|%d",value&0xffff);
+		}
+		else if ((value&0xffff0000)==D3DTSS_TCI_CAMERASPACEPOSITION) {
+			name.Format("D3DTSS_TCI_CAMERASPACEPOSITION|%d",value&0xffff);
+		}
+		else if ((value&0xffff0000)==D3DTSS_TCI_CAMERASPACEREFLECTIONVECTOR) {
+			name.Format("D3DTSS_TCI_CAMERASPACEREFLECTIONVECTOR|%d",value&0xffff);
+		}
+		else {
+			name.Format("%d",value);
+		}
+		break;
+
+	// Integer value
+	case D3DTSS_MAXMIPLEVEL:
+	case D3DTSS_MAXANISOTROPY:
+		name.Format("%d",value);
+		break;
+	// Hex values
+	case D3DTSS_BORDERCOLOR:
+		name.Format("0x%x",value);
+		break;
+
+	default:
+		name.Format("UNKNOWN (%d)",value);
+		break;
+	}
+}
+
+const char* DX8Wrapper::Get_DX8_Texture_Op_Name(unsigned value)
+{
+	switch (value) {
+	case D3DTOP_DISABLE                      : return "D3DTOP_DISABLE";
+	case D3DTOP_SELECTARG1                   : return "D3DTOP_SELECTARG1";
+	case D3DTOP_SELECTARG2                   : return "D3DTOP_SELECTARG2";
+	case D3DTOP_MODULATE                     : return "D3DTOP_MODULATE";
+	case D3DTOP_MODULATE2X                   : return "D3DTOP_MODULATE2X";
+	case D3DTOP_MODULATE4X                   : return "D3DTOP_MODULATE4X";
+	case D3DTOP_ADD                          : return "D3DTOP_ADD";
+	case D3DTOP_ADDSIGNED                    : return "D3DTOP_ADDSIGNED";
+	case D3DTOP_ADDSIGNED2X                  : return "D3DTOP_ADDSIGNED2X";
+	case D3DTOP_SUBTRACT                     : return "D3DTOP_SUBTRACT";
+	case D3DTOP_ADDSMOOTH                    : return "D3DTOP_ADDSMOOTH";
+	case D3DTOP_BLENDDIFFUSEALPHA            : return "D3DTOP_BLENDDIFFUSEALPHA";
+	case D3DTOP_BLENDTEXTUREALPHA            : return "D3DTOP_BLENDTEXTUREALPHA";
+	case D3DTOP_BLENDFACTORALPHA             : return "D3DTOP_BLENDFACTORALPHA";
+	case D3DTOP_BLENDTEXTUREALPHAPM          : return "D3DTOP_BLENDTEXTUREALPHAPM";
+	case D3DTOP_BLENDCURRENTALPHA            : return "D3DTOP_BLENDCURRENTALPHA";
+	case D3DTOP_PREMODULATE                  : return "D3DTOP_PREMODULATE";
+	case D3DTOP_MODULATEALPHA_ADDCOLOR       : return "D3DTOP_MODULATEALPHA_ADDCOLOR";
+	case D3DTOP_MODULATECOLOR_ADDALPHA       : return "D3DTOP_MODULATECOLOR_ADDALPHA";
+	case D3DTOP_MODULATEINVALPHA_ADDCOLOR    : return "D3DTOP_MODULATEINVALPHA_ADDCOLOR";
+	case D3DTOP_MODULATEINVCOLOR_ADDALPHA    : return "D3DTOP_MODULATEINVCOLOR_ADDALPHA";
+	case D3DTOP_BUMPENVMAP                   : return "D3DTOP_BUMPENVMAP";
+	case D3DTOP_BUMPENVMAPLUMINANCE          : return "D3DTOP_BUMPENVMAPLUMINANCE";
+	case D3DTOP_DOTPRODUCT3                  : return "D3DTOP_DOTPRODUCT3";
+	case D3DTOP_MULTIPLYADD                  : return "D3DTOP_MULTIPLYADD";
+	case D3DTOP_LERP                         : return "D3DTOP_LERP";
+	default										     : return "UNKNOWN";
+	}
+}
+
+const char* DX8Wrapper::Get_DX8_Texture_Arg_Name(unsigned value)
+{
+	switch (value) {
+	case D3DTA_CURRENT			: return "D3DTA_CURRENT";
+	case D3DTA_DIFFUSE			: return "D3DTA_DIFFUSE";
+	case D3DTA_SELECTMASK		: return "D3DTA_SELECTMASK";
+	case D3DTA_SPECULAR			: return "D3DTA_SPECULAR";
+	case D3DTA_TEMP				: return "D3DTA_TEMP";
+	case D3DTA_TEXTURE			: return "D3DTA_TEXTURE";
+	case D3DTA_TFACTOR			: return "D3DTA_TFACTOR";
+	case D3DTA_ALPHAREPLICATE	: return "D3DTA_ALPHAREPLICATE";
+	case D3DTA_COMPLEMENT		: return "D3DTA_COMPLEMENT";
+	default					      : return "UNKNOWN";
+	}
+}
+
+const char* DX8Wrapper::Get_DX8_Texture_Filter_Name(unsigned value)
+{
+	switch (value) {
+	case D3DTEXF_NONE				: return "D3DTEXF_NONE";
+	case D3DTEXF_POINT			: return "D3DTEXF_POINT";
+	case D3DTEXF_LINEAR			: return "D3DTEXF_LINEAR";
+	case D3DTEXF_ANISOTROPIC	: return "D3DTEXF_ANISOTROPIC";
+	case D3DTEXF_FLATCUBIC		: return "D3DTEXF_FLATCUBIC";
+	case D3DTEXF_GAUSSIANCUBIC	: return "D3DTEXF_GAUSSIANCUBIC";
+	default					      : return "UNKNOWN";
+	}
+}
+
+const char* DX8Wrapper::Get_DX8_Texture_Address_Name(unsigned value)
+{
+	switch (value) {
+	case D3DTADDRESS_WRAP		: return "D3DTADDRESS_WRAP";
+	case D3DTADDRESS_MIRROR		: return "D3DTADDRESS_MIRROR";
+	case D3DTADDRESS_CLAMP		: return "D3DTADDRESS_CLAMP";
+	case D3DTADDRESS_BORDER		: return "D3DTADDRESS_BORDER";
+	case D3DTADDRESS_MIRRORONCE: return "D3DTADDRESS_MIRRORONCE";
+	default					      : return "UNKNOWN";
+	}
+}
+
+const char* DX8Wrapper::Get_DX8_Texture_Transform_Flag_Name(unsigned value)
+{
+	switch (value) {
+	case D3DTTFF_DISABLE			: return "D3DTTFF_DISABLE";
+	case D3DTTFF_COUNT1			: return "D3DTTFF_COUNT1";
+	case D3DTTFF_COUNT2			: return "D3DTTFF_COUNT2";
+	case D3DTTFF_COUNT3			: return "D3DTTFF_COUNT3";
+	case D3DTTFF_COUNT4			: return "D3DTTFF_COUNT4";
+	case D3DTTFF_PROJECTED		: return "D3DTTFF_PROJECTED";
+	default					      : return "UNKNOWN";
+	}
+}
+
+const char* DX8Wrapper::Get_DX8_ZBuffer_Type_Name(unsigned value)
+{
+	switch (value) {
+	case D3DZB_FALSE				: return "D3DZB_FALSE";
+	case D3DZB_TRUE				: return "D3DZB_TRUE";
+	case D3DZB_USEW				: return "D3DZB_USEW";
+	default					      : return "UNKNOWN";
+	}
+}
+
+const char* DX8Wrapper::Get_DX8_Fill_Mode_Name(unsigned value)
+{
+	switch (value) {
+	case D3DFILL_POINT			: return "D3DFILL_POINT";
+	case D3DFILL_WIREFRAME		: return "D3DFILL_WIREFRAME";
+	case D3DFILL_SOLID			: return "D3DFILL_SOLID";
+	default					      : return "UNKNOWN";
+	}
+}
+
+const char* DX8Wrapper::Get_DX8_Shade_Mode_Name(unsigned value)
+{
+	switch (value) {
+	case D3DSHADE_FLAT			: return "D3DSHADE_FLAT";
+	case D3DSHADE_GOURAUD		: return "D3DSHADE_GOURAUD";
+	case D3DSHADE_PHONG			: return "D3DSHADE_PHONG";
+	default							: return "UNKNOWN";
+	}
+}
+
+const char* DX8Wrapper::Get_DX8_Blend_Name(unsigned value)
+{
+	switch (value) {
+	case D3DBLEND_ZERO                : return "D3DBLEND_ZERO";
+	case D3DBLEND_ONE                 : return "D3DBLEND_ONE";
+	case D3DBLEND_SRCCOLOR            : return "D3DBLEND_SRCCOLOR";
+	case D3DBLEND_INVSRCCOLOR         : return "D3DBLEND_INVSRCCOLOR";
+	case D3DBLEND_SRCALPHA            : return "D3DBLEND_SRCALPHA";
+	case D3DBLEND_INVSRCALPHA         : return "D3DBLEND_INVSRCALPHA";
+	case D3DBLEND_DESTALPHA           : return "D3DBLEND_DESTALPHA";
+	case D3DBLEND_INVDESTALPHA        : return "D3DBLEND_INVDESTALPHA";
+	case D3DBLEND_DESTCOLOR           : return "D3DBLEND_DESTCOLOR";
+	case D3DBLEND_INVDESTCOLOR        : return "D3DBLEND_INVDESTCOLOR";
+	case D3DBLEND_SRCALPHASAT         : return "D3DBLEND_SRCALPHASAT";
+	case D3DBLEND_BOTHSRCALPHA        : return "D3DBLEND_BOTHSRCALPHA";
+	case D3DBLEND_BOTHINVSRCALPHA     : return "D3DBLEND_BOTHINVSRCALPHA";
+	default									 : return "UNKNOWN";
+	}
+}
+
+const char* DX8Wrapper::Get_DX8_Cull_Mode_Name(unsigned value)
+{
+	switch (value) {
+	case D3DCULL_NONE				: return "D3DCULL_NONE";
+	case D3DCULL_CW				: return "D3DCULL_CW";
+	case D3DCULL_CCW				: return "D3DCULL_CCW";
+	default							: return "UNKNOWN";
+	}
+}
+
+const char* DX8Wrapper::Get_DX8_Cmp_Func_Name(unsigned value)
+{
+	switch (value) {
+	case D3DCMP_NEVER          : return "D3DCMP_NEVER";
+	case D3DCMP_LESS           : return "D3DCMP_LESS";
+	case D3DCMP_EQUAL          : return "D3DCMP_EQUAL";
+	case D3DCMP_LESSEQUAL      : return "D3DCMP_LESSEQUAL";
+	case D3DCMP_GREATER        : return "D3DCMP_GREATER";
+	case D3DCMP_NOTEQUAL       : return "D3DCMP_NOTEQUAL";
+	case D3DCMP_GREATEREQUAL   : return "D3DCMP_GREATEREQUAL";
+	case D3DCMP_ALWAYS         : return "D3DCMP_ALWAYS";
+	default							: return "UNKNOWN";
+	}
+}
+
+const char* DX8Wrapper::Get_DX8_Fog_Mode_Name(unsigned value)
+{
+	switch (value) {
+	case D3DFOG_NONE				: return "D3DFOG_NONE";
+	case D3DFOG_EXP				: return "D3DFOG_EXP";
+	case D3DFOG_EXP2				: return "D3DFOG_EXP2";
+	case D3DFOG_LINEAR			: return "D3DFOG_LINEAR";
+	default							: return "UNKNOWN";
+	}
+}
+
+const char* DX8Wrapper::Get_DX8_Stencil_Op_Name(unsigned value)
+{
+	switch (value) {
+	case D3DSTENCILOP_KEEP		: return "D3DSTENCILOP_KEEP";
+	case D3DSTENCILOP_ZERO		: return "D3DSTENCILOP_ZERO";
+	case D3DSTENCILOP_REPLACE	: return "D3DSTENCILOP_REPLACE";
+	case D3DSTENCILOP_INCRSAT	: return "D3DSTENCILOP_INCRSAT";
+	case D3DSTENCILOP_DECRSAT	: return "D3DSTENCILOP_DECRSAT";
+	case D3DSTENCILOP_INVERT	: return "D3DSTENCILOP_INVERT";
+	case D3DSTENCILOP_INCR		: return "D3DSTENCILOP_INCR";
+	case D3DSTENCILOP_DECR		: return "D3DSTENCILOP_DECR";
+	default							: return "UNKNOWN";
+	}
+}
+
+const char* DX8Wrapper::Get_DX8_Material_Source_Name(unsigned value)
+{
+	switch (value) {
+	case D3DMCS_MATERIAL			: return "D3DMCS_MATERIAL";
+	case D3DMCS_COLOR1			: return "D3DMCS_COLOR1";
+	case D3DMCS_COLOR2			: return "D3DMCS_COLOR2";
+	default							: return "UNKNOWN";
+	}
+}
+
+const char* DX8Wrapper::Get_DX8_Vertex_Blend_Flag_Name(unsigned value)
+{
+	switch (value) {
+	case D3DVBF_DISABLE			: return "D3DVBF_DISABLE";
+	case D3DVBF_1WEIGHTS			: return "D3DVBF_1WEIGHTS";
+	case D3DVBF_2WEIGHTS			: return "D3DVBF_2WEIGHTS";
+	case D3DVBF_3WEIGHTS			: return "D3DVBF_3WEIGHTS";
+	case D3DVBF_TWEENING			: return "D3DVBF_TWEENING";
+	case D3DVBF_0WEIGHTS			: return "D3DVBF_0WEIGHTS";
+	default							: return "UNKNOWN";
+	}
+}
+
+const char* DX8Wrapper::Get_DX8_Patch_Edge_Style_Name(unsigned value)
+{
+	switch (value) {
+	case D3DPATCHEDGE_DISCRETE	: return "D3DPATCHEDGE_DISCRETE";
+   case D3DPATCHEDGE_CONTINUOUS:return "D3DPATCHEDGE_CONTINUOUS";
+	default							: return "UNKNOWN";
+	}
+}
+
+const char* DX8Wrapper::Get_DX8_Debug_Monitor_Token_Name(unsigned value)
+{
+	switch (value) {
+	case D3DDMT_ENABLE			: return "D3DDMT_ENABLE";
+	case D3DDMT_DISABLE			: return "D3DDMT_DISABLE";
+	default							: return "UNKNOWN";
+	}
+}
+
+const char* DX8Wrapper::Get_DX8_Blend_Op_Name(unsigned value)
+{
+	switch (value) {
+	case D3DBLENDOP_ADD			: return "D3DBLENDOP_ADD";
+	case D3DBLENDOP_SUBTRACT	: return "D3DBLENDOP_SUBTRACT";
+	case D3DBLENDOP_REVSUBTRACT: return "D3DBLENDOP_REVSUBTRACT";
+	case D3DBLENDOP_MIN			: return "D3DBLENDOP_MIN";
+	case D3DBLENDOP_MAX			: return "D3DBLENDOP_MAX";
+	default							: return "UNKNOWN";
+	}
+}
+
 
 //============================================================================
 // DX8Wrapper::getBackBufferFormat

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/matpass.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/matpass.cpp
@@ -26,12 +26,13 @@
  *                                                                                             *
  *              Original Author:: Greg Hjelstrom                                               *
  *                                                                                             *
- *                      $Author:: Greg_h                                                      $*
+ *                       Author : Kenny Mitchell                                               * 
+ *                                                                                             * 
+ *                     $Modtime:: 06/27/02 1:27p                                              $*
  *                                                                                             *
- *                     $Modtime:: 5/13/01 11:19a                                              $*
+ *                    $Revision:: 8                                                           $*
  *                                                                                             *
- *                    $Revision:: 7                                                           $*
- *                                                                                             *
+ * 06/27/02 KM Changes to max texture stage caps															*
  *---------------------------------------------------------------------------------------------*
  * Functions:                                                                                  *
  *   MaterialPassClass::MaterialPassClass -- Constructor                                       *
@@ -90,6 +91,7 @@ MaterialPassClass::MaterialPassClass(void) :
  *                                                                                             *
  * HISTORY:                                                                                    *
  *   12/9/99    gth : Created.                                                                 *
+ *	  06/27/02   kjm : Changes to max texture stage caps															*
  *=============================================================================================*/
 MaterialPassClass::~MaterialPassClass(void)
 {
@@ -117,7 +119,8 @@ void MaterialPassClass::Install_Materials(void) const
 {
 	DX8Wrapper::Set_Material(Peek_Material());
 	DX8Wrapper::Set_Shader(Peek_Shader());
-	for (unsigned i=0;i<MAX_TEXTURE_STAGES;++i) {
+	for (int i=0;i<DX8Wrapper::Get_Current_Caps()->Get_Max_Textures_Per_Pass();++i) 
+	{
 		DX8Wrapper::Set_Texture(i,Peek_Texture(i));
 	}
 }

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/seglinerenderer.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/seglinerenderer.h
@@ -48,6 +48,7 @@
 class RenderInfoClass;
 class SphereClass;
 struct W3dEmitterLinePropertiesStruct;
+struct VertexFormatXYZDUV1;
 
 
 // The maximum allowable level of subdivision. This should be no more than 7 to avoid increasing
@@ -106,9 +107,7 @@ public:
 	void					Set_Merge_Abort_Factor(float factor)				{ MergeAbortFactor = factor; }
 	void					Set_Current_Subdivision_Level(unsigned int lv)	{ SubdivisionLevel = lv; }
 	void					Set_Texture_Mapping_Mode(TextureMapMode mode);
-	// WARNING! Do NOT set the tile factor to be too high (should be less than 8) or negative
-	//performance impact will result!
-	void					Set_Texture_Tile_Factor(float factor);
+	void					Set_Texture_Tile_Factor(float factor);	// Might be clamped if too high
 	void					Set_Current_UV_Offset(const Vector2 & offset);
 	void					Set_UV_Offset_Rate(const Vector2 &rate);
 	void					Set_Merge_Intersections(int onoff)					{ if (onoff) { Bits |= MERGE_INTERSECTIONS; } else { Bits &= ~MERGE_INTERSECTIONS; }; }
@@ -121,16 +120,19 @@ public:
 										const Matrix3D & transform,
 										unsigned int point_count,
 										Vector3 * points,
-										const SphereClass & obj_sphere);
+										const SphereClass & obj_sphere,
+										Vector4 * rgbas = 0);
 
 	void					Reset_Line(void);
+	void					Scale(float scale);
 
 private:
 
 	// Utility functions
 	void								subdivision_util(unsigned int point_cnt, const Vector3 *xformed_pts,
 											const float *base_tex_v, unsigned int *p_sub_point_cnt,
-											Vector3 *xformed_subdiv_pts, float *subdiv_tex_v);
+											Vector3 *xformed_subdiv_pts, float *subdiv_tex_v,
+											Vector4 *base_diffuse, Vector4 *subdiv_diffuse);
 
 	// Global properties
 	TextureClass *					Texture;
@@ -176,6 +178,10 @@ private:
 	unsigned int					Bits;
 
 	friend class SegmentedLineClass;
+
+	VertexFormatXYZDUV1 *getVertexBuffer(unsigned int number);
+	unsigned int m_vertexBufferSize;
+	VertexFormatXYZDUV1 *m_vertexBuffer;
 };
 
 

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/sortingrenderer.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/sortingrenderer.cpp
@@ -420,10 +420,12 @@ void SortingRendererClass::Insert_Triangles(
 
 void Release_Refs(SortingNodeStruct* state)
 {
+	int i;
 	REF_PTR_RELEASE(state->sorting_state.vertex_buffer);
 	REF_PTR_RELEASE(state->sorting_state.index_buffer);
 	REF_PTR_RELEASE(state->sorting_state.material);
-	for (unsigned i=0;i<MAX_TEXTURE_STAGES;++i) {
+	for (i=0;i<DX8Wrapper::Get_Current_Caps()->Get_Max_Textures_Per_Pass();++i) 
+	{
 		REF_PTR_RELEASE(state->sorting_state.Textures[i]);
 	}
 }
@@ -431,7 +433,7 @@ void Release_Refs(SortingNodeStruct* state)
 static unsigned overlapping_node_count;
 static unsigned overlapping_polygon_count;
 static unsigned overlapping_vertex_count;
-const unsigned MAX_OVERLAPPING_NODES=4096;
+static const unsigned MAX_OVERLAPPING_NODES=4096;
 static SortingNodeStruct* overlapping_nodes[MAX_OVERLAPPING_NODES];
 
 // ----------------------------------------------------------------------------
@@ -451,6 +453,7 @@ void SortingRendererClass::Insert_To_Sorting_Pool(SortingNodeStruct* state)
 }
 
 // ----------------------------------------------------------------------------
+//static unsigned prevLight = 0xffffffff;
 
 static void Apply_Render_State(RenderStateStruct& render_state)
 {
@@ -467,7 +470,7 @@ static void Apply_Render_State(RenderStateStruct& render_state)
 	if (render_state.Textures[6]) render_state.Textures[6]->Apply();
 	if (render_state.Textures[7]) render_state.Textures[7]->Apply();
 */
-	for (unsigned i=0;i<MAX_TEXTURE_STAGES;++i)
+	for (int i=0;i<DX8Wrapper::Get_Current_Caps()->Get_Max_Textures_Per_Pass();++i) 
 	{
 		DX8Wrapper::Set_Texture(i,render_state.Textures[i]);
 	}
@@ -478,6 +481,7 @@ static void Apply_Render_State(RenderStateStruct& render_state)
 
 	if (!render_state.material->Get_Lighting())
 		return;	//no point changing lights if they are ignored.
+  //prevLight = render_state.lightsHash;
 
 	if (render_state.LightEnable[0]) {
 		DX8Wrapper::Set_DX8_Light(0,&render_state.Lights[0]);

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/static_sort_list.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/static_sort_list.cpp
@@ -80,8 +80,16 @@ void DefaultStaticSortListClass::Render_And_Clear(RenderInfoClass & rinfo)
 		for (	RenderObjClass *robj = SortLists[sort_level].Remove_Head(); robj;
 				robj->Release_Ref(), robj = SortLists[sort_level].Remove_Head())
 		{
-			robj->Render(rinfo);
-			render = true;
+			if (robj->Get_Render_Hook()) {
+				if (robj->Get_Render_Hook()->Pre_Render(robj, rinfo)) {
+					robj->Render(rinfo);
+					render = true;
+				}
+				robj->Get_Render_Hook()->Post_Render(robj, rinfo);
+			} else {
+				robj->Render(rinfo);
+				render = true;
+			}
 		}
 		if (render) TheDX8MeshRenderer.Flush();
 	}

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/streakRender.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/streakRender.h
@@ -48,7 +48,7 @@
 class RenderInfoClass;
 class SphereClass;
 struct W3dEmitterLinePropertiesStruct;
-
+struct VertexFormatXYZUV1;
 
 // The maximum allowable level of subdivision. This should be no more than 7 to avoid increasing
 // the chunk buffer size too much
@@ -89,8 +89,8 @@ public:
 	float					Get_Merge_Abort_Factor(void) const					{ return MergeAbortFactor; }
 	unsigned int		Get_Current_Subdivision_Level(void)	const			{ return SubdivisionLevel; }
 	TextureMapMode		Get_Texture_Mapping_Mode(void) const;
-	float					Get_Texture_Tile_Factor(void) const					{ return TextureTileFactor; }
-	Vector2				Get_UV_Offset_Rate(void) const;
+	// float					Get_Texture_Tile_Factor(void) const					{ return TextureTileFactor; }
+	// Vector2				Get_UV_Offset_Rate(void) const;
 	int					Is_Merge_Intersections(void) const					{ return Bits & MERGE_INTERSECTIONS; }
 	int					Is_Freeze_Random(void) const							{ return Bits & FREEZE_RANDOM; }
 	int					Is_Sorting_Disabled(void) const						{ return Bits & DISABLE_SORTING; }
@@ -104,13 +104,16 @@ public:
 	void					Set_Opacity(float opacity)								{ Opacity = opacity; }
 	void					Set_Noise_Amplitude(float amplitude)				{ NoiseAmplitude = amplitude; }
 	void					Set_Merge_Abort_Factor(float factor)				{ MergeAbortFactor = factor; }
-	void					Set_Current_Subdivision_Level(unsigned int lv)	{ SubdivisionLevel = lv; }
+	void					Set_Current_Subdivision_Level(unsigned int lv)	{
+		DEBUG_ASSERTCRASH(lv == 0, ("Streak renderer does not work for non-zero subdivisions"));
+		SubdivisionLevel = lv; SubdivisionLevel = 0;
+	}
 	void					Set_Texture_Mapping_Mode(TextureMapMode mode);
 	// WARNING! Do NOT set the tile factor to be too high (should be less than 8) or negative
 	//performance impact will result!
-	void					Set_Texture_Tile_Factor(float factor);
-	void					Set_Current_UV_Offset(const Vector2 & offset);
-	void					Set_UV_Offset_Rate(const Vector2 &rate);
+	// void					Set_Texture_Tile_Factor(float factor);
+	// void					Set_Current_UV_Offset(const Vector2 & offset);
+	// void					Set_UV_Offset_Rate(const Vector2 &rate);
 	void					Set_Merge_Intersections(int onoff)					{ if (onoff) { Bits |= MERGE_INTERSECTIONS; } else { Bits &= ~MERGE_INTERSECTIONS; }; }
 	void					Set_Freeze_Random(int onoff)							{ if (onoff) { Bits |= FREEZE_RANDOM; } else { Bits &= ~FREEZE_RANDOM; }; }
 	void					Set_Disable_Sorting(int onoff)						{ if (onoff) { Bits |= DISABLE_SORTING; } else { Bits &= ~DISABLE_SORTING; }; }
@@ -160,12 +163,12 @@ private:
 	// Affects tiled texture mapping mode only. If this is set too high, performance (and
 	// possibly visual) problems will result from excessive tiling over a single polygon, over
 	// the entire line, or both.
-	float								TextureTileFactor;
+	// float								TextureTileFactor;
 
 	// Used for texture coordinate animation
-	unsigned int					LastUsedSyncTime;		// Last sync time used	
-	Vector2							CurrentUVOffset;		// Current UV offset
-	Vector2							UVOffsetDeltaPerMS;	// Amount to increase offset each millisec
+	// unsigned int					LastUsedSyncTime;		// Last sync time used	
+	// Vector2							CurrentUVOffset;		// Current UV offset
+	// Vector2							UVOffsetDeltaPerMS;	// Amount to increase offset each millisec
 	
 	// Various flags
 	enum BitShiftOffsets {
@@ -185,6 +188,11 @@ private:
 	unsigned int					Bits;
 
 	friend class SegmentedLineClass;
+
+	// Vertex buffer manager
+	VertexFormatXYZUV1 *getVertexBuffer(unsigned int number);
+	unsigned int m_vertexBufferSize;
+	VertexFormatXYZUV1 *m_vertexBuffer;
 };
 
 
@@ -200,16 +208,20 @@ inline void StreakRendererClass::Set_Texture_Mapping_Mode(StreakRendererClass::T
 	Bits |= ((mode << TEXTURE_MAP_MODE_OFFSET) & TEXTURE_MAP_MODE_MASK);
 }
 
-inline Vector2 StreakRendererClass::Get_UV_Offset_Rate(void) const
-{	
-	return UVOffsetDeltaPerMS * 1000.0f;
-}
+// inline Vector2 StreakRendererClass::Get_UV_Offset_Rate(void) const
+// {	
+// 	return UVOffsetDeltaPerMS * 1000.0f;
+// }
 
-inline void StreakRendererClass::Set_UV_Offset_Rate(const Vector2 &rate)
+// inline void StreakRendererClass::Set_UV_Offset_Rate(const Vector2 &rate)
+// {
+// 	UVOffsetDeltaPerMS = rate * 0.001f;
+// }
+
+inline void StreakRendererClass::Reset_Line(void)
 {
-	UVOffsetDeltaPerMS = rate * 0.001f;
+	// Empty
 }
-
 
 #endif //STREAKRENDER_H
 

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/texture.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/texture.cpp
@@ -128,8 +128,8 @@ TextureClass::TextureClass(unsigned width, unsigned height, WW3DFormat format, M
 			height, 
 			format, 
 			mip_level_count,
-			rendertarget,
-			this
+			this,
+			rendertarget
 		);
 		DX8TextureManagerClass::Add(track);
 	}

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/texture.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/texture.h
@@ -71,6 +71,8 @@ class TextureClass : public W3DMPO, public RefCountClass
 {
 	W3DMPO_GLUE(TextureClass)
 
+	friend class DX8TextureTrackerClass;  //(gth) so it can call Poke_Texture, 
+
 	friend DX8Wrapper;
 	friend TextureLoader;
 	friend LoaderThreadClass;
@@ -186,6 +188,7 @@ class TextureClass : public W3DMPO, public RefCountClass
 
 		// Support for self managed textures
 		bool Is_Dirty() { WWASSERT(Pool==POOL_DEFAULT); return Dirty; };
+		void Set_Dirty() { WWASSERT(Pool==POOL_DEFAULT); Dirty=true; }
 		void Clean() { Dirty=false; };
 
 		unsigned Get_Reduction() const;
@@ -193,6 +196,8 @@ class TextureClass : public W3DMPO, public RefCountClass
 		bool Is_Compression_Allowed() const { return IsCompressionAllowed; }
 
 	protected:
+		void Poke_Texture(IDirect3DBaseTexture8* tex) { D3DTexture = tex; }
+
 		// Apply this texture's settings into D3D
 		virtual void Apply(unsigned int stage);
 		void Load_Locked_Surface();


### PR DESCRIPTION
This change ports some WW3D2 code from Zero Hour to Generals.

It includes a few performance optimizations among a lot of refactors and render feature additions.

* dx8caps : Adds device format support checks
* dx8texman : Does texture class abstraction
* dx8texman : Adds depth stencil texture tracking and abstraction
* dx8wrapper : Adds shader system updates
* dx8wrapper : Fixes missing deletion of CurrentCaps in DX8Wrapper::Do_Onetime_Device_Dependent_Shutdowns
* dx8wrapper : Fixes busy cpu when game window is minimized
* dx8wrapper : Adds additional draw calls counters to debug statistics
* dx8wrapper : Adds MESH_RENDER_SNAPSHOT_ENABLED logging
* dynamesh : Adds second texture stage support
* seglinerenderer : Adds diffuse color support
* seglinerenderer : Optimizes segline render function by removing per frame buffer allocations
* shattersystem : Adds second texture stage support
* streakRender : Optimizes streak render function by removing per frame buffer allocations
* streakRender : Removes unused code
* ww3d : Adds scalable shader library integration
* ww3d : Adds texture class redesign
* ww3d : Adds BMP screenshot support with gamma adjustment
* ww3d : Implements ww3d lite to skip DazzleRenderObjClass, AnimatedSoundMgrClass, rendering(?)
* ww3d : Implements texture filter support; bilinear, trilinear, anisotropic

