### PR TITLE
[GEN][ZH] Fix incorrectly initialized bool GhostObject::m_parentGeometryIsSmall

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/GhostObject.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/GhostObject.cpp
@@ -42,6 +42,9 @@ GhostObject::GhostObject(void):
 //Added By Sadullah Nader
 //Initializations missing and needed
 m_parentAngle(0.0f),
+// TheSuperHackers @bugfix tomsons26 26/04/2025 Change initialization of m_parentGeometryIsSmall from 0.0f.
+// Assigning a float to a bool results in the compiler using a random 1 byte value to assign to the bool.
+// @todo Change initialization to 'false' when applicable.
 m_parentGeometryIsSmall(true),
 m_parentGeometryMajorRadius(0.0f),
 m_parentGeometryminorRadius(0.0f),

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/GhostObject.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/GhostObject.cpp
@@ -42,7 +42,7 @@ GhostObject::GhostObject(void):
 //Added By Sadullah Nader
 //Initializations missing and needed
 m_parentAngle(0.0f),
-m_parentGeometryIsSmall(0.0f),
+m_parentGeometryIsSmall(true),
 m_parentGeometryMajorRadius(0.0f),
 m_parentGeometryminorRadius(0.0f),
 m_parentObject(NULL),

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/GhostObject.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/GhostObject.cpp
@@ -42,6 +42,9 @@ GhostObject::GhostObject(void):
 //Added By Sadullah Nader
 //Initializations missing and needed
 m_parentAngle(0.0f),
+// TheSuperHackers @bugfix tomsons26 26/04/2025 Change initialization of m_parentGeometryIsSmall from 0.0f.
+// Assigning a float to a bool results in the compiler using a random 1 byte value to assign to the bool.
+// @todo Change initialization to 'false' when applicable.
 m_parentGeometryIsSmall(true),
 m_parentGeometryMajorRadius(0.0f),
 m_parentGeometryminorRadius(0.0f),

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/GhostObject.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/GhostObject.cpp
@@ -42,7 +42,7 @@ GhostObject::GhostObject(void):
 //Added By Sadullah Nader
 //Initializations missing and needed
 m_parentAngle(0.0f),
-m_parentGeometryIsSmall(0.0f),
+m_parentGeometryIsSmall(true),
 m_parentGeometryMajorRadius(0.0f),
 m_parentGeometryminorRadius(0.0f),
 m_parentObject(NULL),


### PR DESCRIPTION
In VS6 assigning a float to a bool results in the compiler using uninitialized memory to assign the bool.
This member got initialized in Generals 1.08 to 192, in Zero Hour 1.04 to 72.
Intended value seems to be false, however, the correct way to not break any compatibility is to set this to true.
In the future it should be investigated if it's safe to set it to false.

Fixing this now like this ensures it's always not 0, where's keeping it doesn't guarantee VS6 may not in fact set it to 0 on some build