### PR TITLE
[CMAKE] Fix feature infos of debug options

### DIFF
--- a/cmake/config-debug.cmake
+++ b/cmake/config-debug.cmake
@@ -34,6 +34,9 @@ define_debug_option(RTS_DEBUG_CRASHING   DEBUG_CRASHING   DISABLE_DEBUG_CRASHING
 define_debug_option(RTS_DEBUG_STACKTRACE DEBUG_STACKTRACE DISABLE_DEBUG_STACKTRACE DebugStacktrace "Build with Debug Stacktracing")
 define_debug_option(RTS_DEBUG_PROFILE    DEBUG_PROFILE    DISABLE_DEBUG_PROFILE    DebugProfile    "Build with Debug Profiling")
 
+add_feature_info(DebugIncludeDebugLogInCrcLog RTS_DEBUG_INCLUDE_DEBUG_LOG_IN_CRC_LOG "Build with Debug Logging in CRC log")
+
+
 if(RTS_DEBUG_INCLUDE_DEBUG_LOG_IN_CRC_LOG)
     target_compile_definitions(core_config INTERFACE INCLUDE_DEBUG_LOG_IN_CRC_LOG)
 endif()

--- a/cmake/config-debug.cmake
+++ b/cmake/config-debug.cmake
@@ -13,31 +13,26 @@ set_property(CACHE RTS_DEBUG_PROFILE PROPERTY STRINGS DEFAULT ON OFF)
 option(RTS_DEBUG_INCLUDE_DEBUG_LOG_IN_CRC_LOG "Include normal debug log in crc log" OFF)
 
 
-add_feature_info(DebugLogging                 RTS_DEBUG_LOGGING                      "Build with Debug Logging")
-add_feature_info(DebugCrashing                RTS_DEBUG_CRASHING                     "Build with Debug Crashing")
-add_feature_info(DebugStacktrace              RTS_DEBUG_STACKTRACE                   "Build with Debug Stacktracing")
-add_feature_info(DebugProfile                 RTS_DEBUG_PROFILE                      "Build with Debug Profiling")
-add_feature_info(DebugIncludeDebugLogInCrcLog RTS_DEBUG_INCLUDE_DEBUG_LOG_IN_CRC_LOG "Build with Debug Logging in CRC log")
-
-
 # Helper macro that handles DEFAULT ON OFF options
-macro(define_debug_option OptionName OptionEnabledCompileDef OptionDisabledCompileDef)
+macro(define_debug_option OptionName OptionEnabledCompileDef OptionDisabledCompileDef FeatureInfoName FeatureInfoDescription)
     if(${OptionName} STREQUAL "DEFAULT")
         # Does nothing
     elseif(${OptionName} STREQUAL "ON")
         target_compile_definitions(core_config INTERFACE ${OptionEnabledCompileDef}=1)
+        add_feature_info(${FeatureInfoName} TRUE ${FeatureInfoDescription})
     elseif(${OptionName} STREQUAL "OFF")
         target_compile_definitions(core_config INTERFACE ${OptionDisabledCompileDef}=1)
+        add_feature_info(${FeatureInfoName} FALSE ${FeatureInfoDescription})
     else()
         message(FATAL_ERROR "Unhandled option")
     endif()
 endmacro()
 
 
-define_debug_option(RTS_DEBUG_LOGGING    DEBUG_LOGGING    DISABLE_DEBUG_LOGGING   )
-define_debug_option(RTS_DEBUG_CRASHING   DEBUG_CRASHING   DISABLE_DEBUG_CRASHING  )
-define_debug_option(RTS_DEBUG_STACKTRACE DEBUG_STACKTRACE DISABLE_DEBUG_STACKTRACE)
-define_debug_option(RTS_DEBUG_PROFILE    DEBUG_PROFILE    DISABLE_DEBUG_PROFILE   )
+define_debug_option(RTS_DEBUG_LOGGING    DEBUG_LOGGING    DISABLE_DEBUG_LOGGING    DebugLogging    "Build with Debug Logging")
+define_debug_option(RTS_DEBUG_CRASHING   DEBUG_CRASHING   DISABLE_DEBUG_CRASHING   DebugCrashing   "Build with Debug Crashing")
+define_debug_option(RTS_DEBUG_STACKTRACE DEBUG_STACKTRACE DISABLE_DEBUG_STACKTRACE DebugStacktrace "Build with Debug Stacktracing")
+define_debug_option(RTS_DEBUG_PROFILE    DEBUG_PROFILE    DISABLE_DEBUG_PROFILE    DebugProfile    "Build with Debug Profiling")
 
 if(RTS_DEBUG_INCLUDE_DEBUG_LOG_IN_CRC_LOG)
     target_compile_definitions(core_config INTERFACE INCLUDE_DEBUG_LOG_IN_CRC_LOG)


### PR DESCRIPTION
This change fixes incorrect feature info setup for debug options in cmake.

Affects

* DebugLogging
* DebugCrashing
* DebugStacktrace
* DebugProfile

Previously it would claim that the debug options were always turned on.