### PR TITLE
Fix DEBUG_CRC compile errors and add RTS_DEBUG_CRC cmake option

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/CRCDebug.h
+++ b/Generals/Code/GameEngine/Include/Common/CRCDebug.h
@@ -33,7 +33,9 @@
 
 #include "Common/Debug.h"
 
-#ifndef NO_DEBUG_CRC
+#ifdef NO_DEBUG_CRC
+	#undef DEBUG_CRC
+#else
 	#ifdef DEBUG_LOGGING
 		#define DEBUG_CRC
 	#endif

--- a/Generals/Code/GameEngine/Include/GameLogic/Object.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Object.h
@@ -763,10 +763,8 @@ private:
 
 };  // end class Object
 
-#ifdef DEBUG_LOGGING
 // describe an object as an AsciiString: e.g. "Object 102 (KillerBuggy) [GLARocketBuggy, owned by player 2 (GLAIntroPlayer)]"
-AsciiString DescribeObject(const Object *obj);
-#endif // DEBUG_LOGGING
+AsciiString DebugDescribeObject(const Object *obj);
 
 #if defined(_DEBUG) || defined(_INTERNAL)
 	#define DEBUG_OBJECT_ID_EXISTS

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -743,7 +743,7 @@ void Path::computePointOnPath(
 	ClosestPointOnPathInfo& out
 )
 {
-	CRCDEBUG_LOG(("Path::computePointOnPath() fzor %s\n", DescribeObject(obj).str()));
+	CRCDEBUG_LOG(("Path::computePointOnPath() for %s\n", DebugDescribeObject(obj).str()));
 
 	out.layer = LAYER_GROUND;
 	out.posOnPath.zero();

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -142,8 +142,7 @@ extern void addIcon(const Coord3D *pos, Real width, Int numFramesDuration, RGBCo
 
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
-#ifdef DEBUG_LOGGING
-AsciiString DescribeObject(const Object *obj)
+AsciiString DebugDescribeObject(const Object *obj)
 {
 	if (!obj)
 		return "<No Object>";
@@ -167,7 +166,6 @@ AsciiString DescribeObject(const Object *obj)
 
 	return ret;
 }
-#endif // DEBUG_LOGGING
 
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -2163,7 +2163,7 @@ UpdateSleepTime AIUpdateInterface::doLocomotor( void )
 							// obstacles, and follow the intermediate path points.
 							ClosestPointOnPathInfo info;
 							CRCDEBUG_LOG(("AIUpdateInterface::doLocomotor() - calling computePointOnPath() for %s\n",
-								DescribeObject(getObject()).str()));
+								DebugDescribeObject(getObject()).str()));
 							getPath()->computePointOnPath(getObject(), m_locomotorSet, *getObject()->getPosition(), info);
 							onPathDistToGoal = info.distAlongPath;
 							goalPos = info.posOnPath;

--- a/GeneralsMD/Code/GameEngine/Include/Common/CRCDebug.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/CRCDebug.h
@@ -33,7 +33,9 @@
 
 #include "Common/Debug.h"
 
-#ifndef NO_DEBUG_CRC
+#ifdef NO_DEBUG_CRC
+	#undef DEBUG_CRC
+#else
 	#ifdef DEBUG_LOGGING
 		#define DEBUG_CRC
 	#endif

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
@@ -811,10 +811,8 @@ private:
 
 };  // end class Object
 
-#ifdef DEBUG_LOGGING
 // describe an object as an AsciiString: e.g. "Object 102 (KillerBuggy) [GLARocketBuggy, owned by player 2 (GLAIntroPlayer)]"
-AsciiString DescribeObject(const Object *obj);
-#endif // DEBUG_LOGGING
+AsciiString DebugDescribeObject(const Object *obj);
 
 #if defined(_DEBUG) || defined(_INTERNAL)
 	#define DEBUG_OBJECT_ID_EXISTS

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -760,7 +760,7 @@ void Path::computePointOnPath(
 	ClosestPointOnPathInfo& out
 )
 {
-	CRCDEBUG_LOG(("Path::computePointOnPath() fzor %s\n", DescribeObject(obj).str()));
+	CRCDEBUG_LOG(("Path::computePointOnPath() for %s\n", DebugDescribeObject(obj).str()));
 
 	out.layer = LAYER_GROUND;
 	out.posOnPath.zero();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -152,8 +152,7 @@ extern void addIcon(const Coord3D *pos, Real width, Int numFramesDuration, RGBCo
 
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
-#ifdef DEBUG_LOGGING
-AsciiString DescribeObject(const Object *obj)
+AsciiString DebugDescribeObject(const Object *obj)
 {
 	if (!obj)
 		return "<No Object>";
@@ -177,7 +176,6 @@ AsciiString DescribeObject(const Object *obj)
 
 	return ret;
 }
-#endif // DEBUG_LOGGING
 
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -2205,7 +2205,7 @@ UpdateSleepTime AIUpdateInterface::doLocomotor( void )
 							// obstacles, and follow the intermediate path points.
 							ClosestPointOnPathInfo info;
 							CRCDEBUG_LOG(("AIUpdateInterface::doLocomotor() - calling computePointOnPath() for %s\n",
-								DescribeObject(getObject()).str()));
+								DebugDescribeObject(getObject()).str()));
 							getPath()->computePointOnPath(getObject(), m_locomotorSet, *getObject()->getPosition(), info);
 							onPathDistToGoal = info.distAlongPath;
 							goalPos = info.posOnPath;

--- a/cmake/config-debug.cmake
+++ b/cmake/config-debug.cmake
@@ -10,7 +10,10 @@ set_property(CACHE RTS_DEBUG_STACKTRACE PROPERTY STRINGS DEFAULT ON OFF)
 set(RTS_DEBUG_PROFILE "DEFAULT" CACHE STRING "Enables debug profiling. When DEFAULT, this option is enabled with DEBUG or INTERNAL")
 set_property(CACHE RTS_DEBUG_PROFILE PROPERTY STRINGS DEFAULT ON OFF)
 
-option(RTS_DEBUG_INCLUDE_DEBUG_LOG_IN_CRC_LOG "Include normal debug log in crc log" OFF)
+set(RTS_DEBUG_CRC "DEFAULT" CACHE STRING "Enables debug CRC testing. When DEFAULT, this option is enabled with DEBUG_LOGGING")
+set_property(CACHE RTS_DEBUG_CRC PROPERTY STRINGS DEFAULT ON OFF)
+
+option(RTS_DEBUG_INCLUDE_DEBUG_LOG_IN_CRC_LOG "Includes normal debug log in CRC log" OFF)
 
 
 # Helper macro that handles DEFAULT ON OFF options
@@ -33,6 +36,7 @@ define_debug_option(RTS_DEBUG_LOGGING    DEBUG_LOGGING    DISABLE_DEBUG_LOGGING 
 define_debug_option(RTS_DEBUG_CRASHING   DEBUG_CRASHING   DISABLE_DEBUG_CRASHING   DebugCrashing   "Build with Debug Crashing")
 define_debug_option(RTS_DEBUG_STACKTRACE DEBUG_STACKTRACE DISABLE_DEBUG_STACKTRACE DebugStacktrace "Build with Debug Stacktracing")
 define_debug_option(RTS_DEBUG_PROFILE    DEBUG_PROFILE    DISABLE_DEBUG_PROFILE    DebugProfile    "Build with Debug Profiling")
+define_debug_option(RTS_DEBUG_CRC        DEBUG_CRC        NO_DEBUG_CRC             DebugCRC        "Build with Debug CRC Testing")
 
 if(RTS_DEBUG_INCLUDE_DEBUG_LOG_IN_CRC_LOG)
     target_compile_definitions(core_config INTERFACE INCLUDE_DEBUG_LOG_IN_CRC_LOG)

--- a/cmake/config-debug.cmake
+++ b/cmake/config-debug.cmake
@@ -13,31 +13,26 @@ set_property(CACHE RTS_DEBUG_PROFILE PROPERTY STRINGS DEFAULT ON OFF)
 option(RTS_DEBUG_INCLUDE_DEBUG_LOG_IN_CRC_LOG "Include normal debug log in crc log" OFF)
 
 
-add_feature_info(DebugLogging                 RTS_DEBUG_LOGGING                      "Build with Debug Logging")
-add_feature_info(DebugCrashing                RTS_DEBUG_CRASHING                     "Build with Debug Crashing")
-add_feature_info(DebugStacktrace              RTS_DEBUG_STACKTRACE                   "Build with Debug Stacktracing")
-add_feature_info(DebugProfile                 RTS_DEBUG_PROFILE                      "Build with Debug Profiling")
-add_feature_info(DebugIncludeDebugLogInCrcLog RTS_DEBUG_INCLUDE_DEBUG_LOG_IN_CRC_LOG "Build with Debug Logging in CRC log")
-
-
 # Helper macro that handles DEFAULT ON OFF options
-macro(define_debug_option OptionName OptionEnabledCompileDef OptionDisabledCompileDef)
+macro(define_debug_option OptionName OptionEnabledCompileDef OptionDisabledCompileDef FeatureInfoName FeatureInfoDescription)
     if(${OptionName} STREQUAL "DEFAULT")
         # Does nothing
     elseif(${OptionName} STREQUAL "ON")
         target_compile_definitions(core_config INTERFACE ${OptionEnabledCompileDef}=1)
+        add_feature_info(${FeatureInfoName} TRUE ${FeatureInfoDescription})
     elseif(${OptionName} STREQUAL "OFF")
         target_compile_definitions(core_config INTERFACE ${OptionDisabledCompileDef}=1)
+        add_feature_info(${FeatureInfoName} FALSE ${FeatureInfoDescription})
     else()
         message(FATAL_ERROR "Unhandled option")
     endif()
 endmacro()
 
 
-define_debug_option(RTS_DEBUG_LOGGING    DEBUG_LOGGING    DISABLE_DEBUG_LOGGING   )
-define_debug_option(RTS_DEBUG_CRASHING   DEBUG_CRASHING   DISABLE_DEBUG_CRASHING  )
-define_debug_option(RTS_DEBUG_STACKTRACE DEBUG_STACKTRACE DISABLE_DEBUG_STACKTRACE)
-define_debug_option(RTS_DEBUG_PROFILE    DEBUG_PROFILE    DISABLE_DEBUG_PROFILE   )
+define_debug_option(RTS_DEBUG_LOGGING    DEBUG_LOGGING    DISABLE_DEBUG_LOGGING    DebugLogging    "Build with Debug Logging")
+define_debug_option(RTS_DEBUG_CRASHING   DEBUG_CRASHING   DISABLE_DEBUG_CRASHING   DebugCrashing   "Build with Debug Crashing")
+define_debug_option(RTS_DEBUG_STACKTRACE DEBUG_STACKTRACE DISABLE_DEBUG_STACKTRACE DebugStacktrace "Build with Debug Stacktracing")
+define_debug_option(RTS_DEBUG_PROFILE    DEBUG_PROFILE    DISABLE_DEBUG_PROFILE    DebugProfile    "Build with Debug Profiling")
 
 if(RTS_DEBUG_INCLUDE_DEBUG_LOG_IN_CRC_LOG)
     target_compile_definitions(core_config INTERFACE INCLUDE_DEBUG_LOG_IN_CRC_LOG)


### PR DESCRIPTION
**Merge with Rebase**

* Depends on #768

This change fixes compile errors from enabling DEBUG_CRC and adds a RTS_DEBUG_CRC cmake option.