### PR TITLE
[GEN] Backport collision test related changes and fixes in WWMath from Zero Hour

### DIFF
--- a/Generals/Code/Libraries/Source/WWVegas/WWMath/cardinalspline.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WWMath/cardinalspline.cpp
@@ -22,13 +22,13 @@
  *                                                                                             *
  *                 Project Name : WWMath                                                       *
  *                                                                                             *
- *                     $Archive:: /VSS_Sync/wwmath/cardinalspline.cpp                         $*
+ *                     $Archive:: /Commando/Code/wwmath/cardinalspline.cpp                    $*
  *                                                                                             *
  *                       Author:: Greg Hjelstrom                                               *
  *                                                                                             *
- *                     $Modtime:: 6/13/01 2:18p                                               $*
+ *                     $Modtime:: 9/16/01 4:07p                                               $*
  *                                                                                             *
- *                    $Revision:: 5                                                           $*
+ *                    $Revision:: 6                                                           $*
  *                                                                                             *
  *---------------------------------------------------------------------------------------------*
  * Functions:                                                                                  *
@@ -108,6 +108,7 @@ void CardinalSpline3DClass::Update_Tangents(void)
 			Tangents[0].InTangent.Set(0,0,0);
 			Tangents[0].OutTangent.Set(0,0,0);
 		}
+		return;
 	}
 
 	// First and Last Key: 

--- a/Generals/Code/Libraries/Source/WWVegas/WWMath/colmathaabox.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WWMath/colmathaabox.cpp
@@ -26,9 +26,9 @@
  *                                                                                             *
  *                       Author:: Greg Hjelstrom                                               *
  *                                                                                             *
- *                     $Modtime:: 11/14/00 2:46p                                              $*
+ *                     $Modtime:: 8/30/01 7:40p                                               $*
  *                                                                                             *
- *                    $Revision:: 21                                                          $*
+ *                    $Revision:: 22                                                          $*
  *                                                                                             *
  *---------------------------------------------------------------------------------------------*
  * Functions:                                                                                  *
@@ -583,10 +583,11 @@ exit:
 
 		result->Fraction = context.MaxFrac;
 		result->Normal.Set(0,0,0);
-		result->Normal[context.AxisId] = context.Side;
+		result->Normal[context.AxisId] = -context.Side;
 
 		if (result->ComputeContactPoint) {
-			WWASSERT(0); // TODO
+			//WWASSERT(0); // TODO
+			WWDEBUG_SAY(("AABox-AABox collision does not currently support contact point computation\r\n"));
 		}
 
 		return true;

--- a/Generals/Code/Libraries/Source/WWVegas/WWMath/colmathaabtri.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WWMath/colmathaabtri.cpp
@@ -26,9 +26,9 @@
  *                                                                                             *
  *                       Author:: Greg Hjelstrom                                               *
  *                                                                                             *
- *                     $Modtime:: 5/08/01 9:52a                                               $*
+ *                     $Modtime:: 1/15/02 2:46p                                               $*
  *                                                                                             *
- *                    $Revision:: 17                                                          $*
+ *                    $Revision:: 19                                                          $*
  *                                                                                             *
  *---------------------------------------------------------------------------------------------*
  * Functions:                                                                                  *
@@ -503,10 +503,11 @@ static inline void aabtri_compute_contact_normal
 	switch(CollisionContext.AxisId) 
 	{
 		case INTERSECTION:
-			set_norm = *CollisionContext.Tri->N;
+			set_norm = CollisionContext.N;
+			set_norm.Normalize();
 			break;
 		case AXIS_N:
-			set_norm = -CollisionContext.Side * *CollisionContext.Tri->N;
+			set_norm = -CollisionContext.Side * CollisionContext.N;
 			set_norm.Normalize();
 			break;
 		case AXIS_A0:
@@ -559,7 +560,8 @@ static inline void aabtri_compute_contact_normal
 	WWASSERT(set_norm.Length2() > 0.0f);
 
 #else
-	set_norm = *CollisionContext.Tri.N;
+	set_norm = *CollisionContext.N;
+	set_norm.Normalize();
 	if (Vector3::Dot_Product(set_norm,CollisionContext.Move) > 0.0f) {
 		set_norm = -(set_norm);
 	}
@@ -832,8 +834,7 @@ exit:
 				(Vector3::Dot_Product(tmp_norm,move) < Vector3::Dot_Product(result->Normal,move)))
 		{
 			result->Normal = tmp_norm;
-#pragma message("fatal assert disabled for demo")
-			//WWASSERT(WWMath::Fabs(result->Normal.Length() - 1.0f) < WWMATH_EPSILON);
+			WWASSERT(WWMath::Fabs(result->Normal.Length() - 1.0f) < WWMATH_EPSILON);
 		}
 				
 		result->Fraction = CollisionContext.MaxFrac;

--- a/Generals/Code/Libraries/Source/WWVegas/WWMath/colmathobbobb.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WWMath/colmathobbobb.cpp
@@ -26,9 +26,9 @@
  *                                                                                             *
  *                       Author:: Greg Hjelstrom                                               *
  *                                                                                             *
- *                     $Modtime:: 5/04/01 8:37p                                               $*
+ *                     $Modtime:: 1/04/02 6:29p                                               $*
  *                                                                                             *
- *                    $Revision:: 14                                                          $*
+ *                    $Revision:: 15                                                          $*
  *                                                                                             *
  *---------------------------------------------------------------------------------------------*
  * Functions:                                                                                  *
@@ -593,7 +593,7 @@ static inline bool obb_separation_test
 		if ( u1 > rsum ) { 
 			context.MaxFrac = 1.0f; 
 			return true;
-		} else { 
+		} else if (WWMath::Fabs(u1-u0) > 0.0f) {
 			tmp = (rsum-u0)/(u1-u0);
 			if ( tmp > context.MaxFrac ) {
 				context.MaxFrac = tmp; 
@@ -606,7 +606,7 @@ static inline bool obb_separation_test
 		if ( u1 < -rsum ) {
 			context.MaxFrac = 1.0f; 
 			return true;
-		} else {
+		} else if (WWMath::Fabs(u1-u0) > 0.0f) {
 			tmp = (-rsum-u0)/(u1-u0);
 			if ( tmp > context.MaxFrac ) {
 				context.MaxFrac = tmp;

--- a/Generals/Code/Libraries/Source/WWVegas/WWMath/colmathobbtri.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WWMath/colmathobbtri.cpp
@@ -26,9 +26,9 @@
  *                                                                                             *
  *                       Author:: Greg Hjelstrom                                               *
  *                                                                                             *
- *                     $Modtime:: 5/04/01 8:37p                                               $*
+ *                     $Modtime:: 11/28/01 5:56p                                              $*
  *                                                                                             *
- *                    $Revision:: 15                                                          $*
+ *                    $Revision:: 16                                                          $*
  *                                                                                             *
  *---------------------------------------------------------------------------------------------*
  * Functions:                                                                                  *
@@ -527,7 +527,7 @@ static inline float eval_side(float val,int side)
 static inline void obbtri_compute_contact_normal
 (
 	const BTCollisionStruct &	context,
-	CastResultStruct *			result
+	Vector3 *						set_normal
 )
 {
 	switch(context.AxisId) 
@@ -536,55 +536,55 @@ static inline void obbtri_compute_contact_normal
 //			WWASSERT(0);
 			break;
 		case AXIS_N:
-			result->Normal = -context.Side * *context.Tri.N;
+			*set_normal = -context.Side * *context.Tri.N;
 			break;
 		case AXIS_A0:
-			result->Normal = -context.Side * context.A[0];
+			*set_normal = -context.Side * context.A[0];
 			break;
 		case AXIS_A1:
-			result->Normal = -context.Side * context.A[1];
+			*set_normal = -context.Side * context.A[1];
 			break;
 		case AXIS_A2:
-			result->Normal = -context.Side * context.A[2];
+			*set_normal = -context.Side * context.A[2];
 			break;
 		case AXIS_A0E0:
-			result->Normal = -context.Side * context.AxE[0][0];
-			result->Normal.Normalize();
+			*set_normal = -context.Side * context.AxE[0][0];
+			set_normal->Normalize();
 			break;
 		case AXIS_A1E0:
-			result->Normal = -context.Side * context.AxE[1][0];
-			result->Normal.Normalize();
+			*set_normal = -context.Side * context.AxE[1][0];
+			set_normal->Normalize();
 			break;
 		case AXIS_A2E0:
-			result->Normal = -context.Side * context.AxE[2][0];
-			result->Normal.Normalize();
+			*set_normal = -context.Side * context.AxE[2][0];
+			set_normal->Normalize();
 			break;
 		case AXIS_A0E1:
-			result->Normal = -context.Side * context.AxE[0][1];
-			result->Normal.Normalize();
+			*set_normal = -context.Side * context.AxE[0][1];
+			set_normal->Normalize();
 			break;
 		case AXIS_A1E1:
-			result->Normal = -context.Side * context.AxE[1][1];
-			result->Normal.Normalize();
+			*set_normal = -context.Side * context.AxE[1][1];
+			set_normal->Normalize();
 			break;
 		case AXIS_A2E1:
-			result->Normal = -context.Side * context.AxE[2][1];
-			result->Normal.Normalize();
+			*set_normal = -context.Side * context.AxE[2][1];
+			set_normal->Normalize();
 			break;
 		case AXIS_A0E2:
-			result->Normal = -context.Side * context.AxE[0][2];
-			result->Normal.Normalize();
+			*set_normal = -context.Side * context.AxE[0][2];
+			set_normal->Normalize();
 			break;
 		case AXIS_A1E2:
-			result->Normal = -context.Side * context.AxE[1][2];
-			result->Normal.Normalize();
+			*set_normal = -context.Side * context.AxE[1][2];
+			set_normal->Normalize();
 			break;
 		case AXIS_A2E2:
-			result->Normal = -context.Side * context.AxE[2][2];
-			result->Normal.Normalize();
+			*set_normal = -context.Side * context.AxE[2][2];
+			set_normal->Normalize();
 			break;
 	}
-	WWASSERT(result->Normal.Length2() > 0.0f);
+	WWASSERT(set_normal->Length2() > 0.0f);
 }
 
 
@@ -1095,10 +1095,13 @@ exit:
 
 	if ((context.MaxFrac < 1.0f) && (context.MaxFrac <= result->Fraction)) {
 
+		Vector3 normal;
+		obbtri_compute_contact_normal(context,&normal);
+
 		if (	(WWMath::Fabs(context.MaxFrac - result->Fraction) > WWMATH_EPSILON) ||
-				(Vector3::Dot_Product(*(tri.N),move) < Vector3::Dot_Product(result->Normal,move)) )
+				(Vector3::Dot_Product(normal,move) < Vector3::Dot_Product(result->Normal,move)) )
 		{
-			obbtri_compute_contact_normal(context,result);
+			result->Normal = normal; //obbtri_compute_contact_normal(context,result);
 		}
 				
 		result->Fraction = context.MaxFrac;


### PR DESCRIPTION
**Merge with Rebase**

* Follow up for #694

This change unifies the remaining code of WWMath.

Generals inherits the following changes:

* cardinalspline : Optimizes code in CardinalSpline3DClass::Update_Tangents
* colmathaabox : Fixes normal direction in CollisionMath::Collide for AABox-AABox collision
* colmathaabtri : Refactors the origin of the CollisionContext normal in aabtri_compute_contact_normal function
* colmathobbobb : Fixes float division by zero in obb_separation_test function
* colmathobbtri : Refactors storage type in obbtri_compute_contact_normal function
* colmathobbtri : Changes normal value calculation in CollisionMath::Collide for OBBox-Tri collision

As far as I could tell, the collision math changes in colmathaabox, colmathaabtri, colmathobbtri are never called in Zero Hour (should have checked Generals but it is probably the same). So these math changes are probably inconsequential. If there were actual game logic relevant collisions using this code, it could incur behaviour changes.

Regarding CollisionContext, there appears to be a relevant comment nearby:
```
** Note that much of the code needs the un-normalized triangle normal.  For this reason,
** I have to compute N rather than copying it from the triangle.  (commenting this to
** avoid re-generating a difficult to find bug that I had)
```

The math changes are split into separate commits to make testing of older changes easier if we ever wanted to revisit a particular change.