### PR TITLE
[GEN] Backport WaterTransparencySetting additions from Zero Hour

### DIFF
--- a/Generals/Code/GameEngine/Include/GameClient/Water.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Water.h
@@ -81,6 +81,10 @@ class WaterTransparencySetting : public Overridable
 	public:
 		Real m_transparentWaterDepth;
 		Real m_minWaterOpacity;
+		RGBColor m_standingWaterColor;
+		RGBColor m_radarColor;
+		Bool m_additiveBlend;
+		AsciiString m_standingWaterTexture;
 		
 		AsciiString m_skyboxTextureN;
 		AsciiString m_skyboxTextureE;
@@ -93,6 +97,15 @@ class WaterTransparencySetting : public Overridable
 		{
 			m_transparentWaterDepth = 3.0f;
 			m_minWaterOpacity = 1.0f;
+			m_standingWaterColor.red = 1.0f;
+			m_standingWaterColor.green = 1.0f;
+			m_standingWaterColor.blue = 1.0f;
+			m_radarColor.red = 140;
+			m_radarColor.green = 140;
+			m_radarColor.blue = 255;
+			m_standingWaterTexture = "TWWater01.tga";
+			m_additiveBlend = FALSE;
+
 			m_skyboxTextureN = "TSMorningN.tga";
 			m_skyboxTextureE = "TSMorningE.tga";
 			m_skyboxTextureS = "TSMorningS.tga";

--- a/Generals/Code/GameEngine/Source/GameClient/Water.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Water.cpp
@@ -64,7 +64,10 @@ const FieldParse WaterTransparencySetting::m_waterTransparencySettingFieldParseT
 
 	{ "TransparentWaterDepth",			INI::parseReal,				NULL,			offsetof( WaterTransparencySetting, m_transparentWaterDepth ) },
 	{ "TransparentWaterMinOpacity",	INI::parseReal,				NULL,			offsetof( WaterTransparencySetting, m_minWaterOpacity ) },
-
+	{ "StandingWaterColor",	INI::parseRGBColor,			NULL,			offsetof( WaterTransparencySetting, m_standingWaterColor ) },
+	{ "StandingWaterTexture",INI::parseAsciiString,		NULL,			offsetof( WaterTransparencySetting, m_standingWaterTexture ) },
+	{ "AdditiveBlending", INI::parseBool,				NULL,			offsetof( WaterTransparencySetting, m_additiveBlend) },
+	{ "RadarWaterColor", INI::parseRGBColor,			NULL,			offsetof( WaterTransparencySetting, m_radarColor) },
 	{ "SkyboxTextureN",							INI::parseAsciiString,NULL,			offsetof( WaterTransparencySetting, m_skyboxTextureN ) },
 	{ "SkyboxTextureE",							INI::parseAsciiString,NULL,			offsetof( WaterTransparencySetting, m_skyboxTextureE ) },
 	{ "SkyboxTextureS",							INI::parseAsciiString,NULL,			offsetof( WaterTransparencySetting, m_skyboxTextureS ) },

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/Common/W3DRadar.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/Common/W3DRadar.h
@@ -76,12 +76,12 @@ protected:
 	void initializeTextureFormats( void );				///< find format to use for the radar texture
 	void deleteResources( void );									///< delete resources used
 	void drawEvents( Int pixelX, Int pixelY, Int width, Int height);		///< draw all of the radar events
- 	void drawHeroIcon( Int pixelX, Int pixelY, Int width, Int height, const Coord3D *pos );	//< draw a hero icon
+	void drawHeroIcon( Int pixelX, Int pixelY, Int width, Int height, const Coord3D *pos );	//< draw a hero icon
 	void drawViewBox( Int pixelX, Int pixelY, Int width, Int height );  ///< draw view box
 	void buildTerrainTexture( TerrainLogic *terrain );	 ///< create the terrain texture of the radar
 	void drawIcons( Int pixelX, Int pixelY, Int width, Int height );	///< draw all of the radar icons
 	void renderObjectList( const RadarObject *listHead, TextureClass *texture, Bool calcHero = FALSE );			 ///< render an object list to the texture
- 	void interpolateColorForHeight( RGBColor *color, 
+	void interpolateColorForHeight( RGBColor *color, 
 																	Real height, 
 																	Real hiZ, 
 																	Real midZ, 
@@ -118,7 +118,7 @@ protected:
 	Real m_viewZoom;															///< camera zoom used for the view box we have	
 	ICoord2D m_viewBox[ 4 ];											///< radar cell points for the 4 corners of view box
 
- 	std::list<const Coord3D *> m_cachedHeroPosList;					//< cache of hero positions for drawing icons in radar overlay
+	std::list<const Coord3D *> m_cachedHeroPosList;					//< cache of hero positions for drawing icons in radar overlay
 };
 
 

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DWater.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DWater.h
@@ -105,6 +105,7 @@ public:
 	void load(void);	///< load/setup any map dependent features
 	void update( void ); ///< update phase of the water
 	void enableWaterGrid(Bool state);	///< used to active custom water for special maps. (i.e DAM).
+	void updateMapOverrides(void);	///< used to update any map specific map overrides for water appearance.
 	void setTimeOfDay(TimeOfDay tod); ///<change sky/water for time of day
 	void toggleCloudLayer(Bool state)	{	m_useCloudLayer=state;}	///<enables/disables the cloud layer
 	void updateRenderTargetTextures(CameraClass *cam);	///< renders into any required textures.	

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/Common/System/W3DRadar.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/Common/System/W3DRadar.cpp
@@ -48,6 +48,7 @@
 #include "GameClient/Image.h"
 #include "GameClient/Line2D.h"
 #include "GameClient/TerrainVisual.h"
+#include "GameClient/Water.h"
 #include "W3DDevice/Common/W3DRadar.h"
 #include "W3DDevice/GameClient/HeightMap.h"
 #include "W3DDevice/GameClient/W3DShroud.h"
@@ -59,6 +60,7 @@
 //#pragma optimize("", off)
 //#pragma MESSAGE("************************************** WARNING, optimization disabled for debugging purposes")
 #endif
+
 
 // PRIVATE DATA ///////////////////////////////////////////////////////////////////////////////////
 enum { OVERLAY_REFRESH_RATE = 6 };  ///< over updates once this many frames
@@ -276,8 +278,6 @@ void W3DRadar::drawHeroIcon( Int pixelX, Int pixelY, Int width, Int height, cons
 		TheDisplay->drawImage( image, offsetScreen.x , offsetScreen.y, offsetScreen.x + iconWidth, offsetScreen.y + iconHeight );
 	}
 }
-
-
 
 //-------------------------------------------------------------------------------------------------
 /** Draw a "box" into the texture passed in that represents the viewable area for
@@ -615,7 +615,6 @@ void W3DRadar::drawIcons( Int pixelX, Int pixelY, Int width, Int height )
 		++iter;
 	}
 }
-
 
 //-------------------------------------------------------------------------------------------------
 /** Render an object list into the texture passed in */
@@ -1034,9 +1033,9 @@ void W3DRadar::buildTerrainTexture( TerrainLogic *terrain )
 	m_reconstructViewBox = TRUE;
 
 	// setup our water color
-	waterColor.red = 0.55f;
-	waterColor.green = 0.55f;
-	waterColor.blue = 1.0f;
+	waterColor.red = TheWaterTransparency->m_radarColor.red;
+	waterColor.green = TheWaterTransparency->m_radarColor.green;
+	waterColor.blue = TheWaterTransparency->m_radarColor.blue;
 
 	// get the terrain surface to draw in
 	surface = m_terrainTexture->Get_Surface_Level();


### PR DESCRIPTION
This change backports the code for the following WaterTransparency ini settings from Zero Hour to Generals:
```
StandingWaterColor = R:255 G:255 B:255
StandingWaterTexture = Texture.tga
AdditiveBlending = yes/no
RadarWaterColor = R:140 G:140 B:255
```

The behaviour of Generals is unchanged.

Additionally it fixes a memory leak in the destructor of WaterRenderObjClass. That is only called on shutdown and therefore inconsequential.