### PR TITLE
[GEN][ZH] Compile out duplicate serial check in LAN lobby

### DIFF
--- a/Generals/Code/GameEngine/Source/GameNetwork/LANAPIhandlers.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/LANAPIhandlers.cpp
@@ -251,6 +251,8 @@ void LANAPI::handleRequestJoin( LANMessage *msg, UnsignedInt senderIP )
 			}
 #endif
 			
+// TheSuperHackers @tweak Disables the duplicate serial check
+#if 0
 			// check for a duplicate serial
 			AsciiString s;
 			for (player = 0; canJoin && player<MAX_SLOTS; ++player)
@@ -286,6 +288,7 @@ void LANAPI::handleRequestJoin( LANMessage *msg, UnsignedInt senderIP )
 					}
 				}
 			}
+#endif
 
 			// We're the host, so see if he has a duplicate name
 			for (player = 0; canJoin && player<MAX_SLOTS; ++player)

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/LANAPIhandlers.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/LANAPIhandlers.cpp
@@ -252,6 +252,8 @@ void LANAPI::handleRequestJoin( LANMessage *msg, UnsignedInt senderIP )
 			}
 #endif
 			
+// TheSuperHackers @tweak Disables the duplicate serial check
+#if 0
 			// check for a duplicate serial
 			AsciiString s;
 			for (player = 0; canJoin && player<MAX_SLOTS; ++player)
@@ -287,6 +289,7 @@ void LANAPI::handleRequestJoin( LANMessage *msg, UnsignedInt senderIP )
 					}
 				}
 			}
+#endif
 
 			// We're the host, so see if he has a duplicate name
 			for (player = 0; canJoin && player<MAX_SLOTS; ++player)


### PR DESCRIPTION
**Merge with Rebase**

* Split off of #408

This change compiles out the duplicate serial check in LAN lobby. This is a requirement for running multiple clients locally.