### PR TITLE
[GEN] Backport SpecialPowerUpdate changes from Zero Hour

### DIFF
--- a/Generals/Code/GameEngine/CMakeLists.txt
+++ b/Generals/Code/GameEngine/CMakeLists.txt
@@ -391,6 +391,7 @@ set(GAMEENGINE_SRC
     Include/GameLogic/Module/SpecialPowerCompletionDie.h
     Include/GameLogic/Module/SpecialPowerCreate.h
     Include/GameLogic/Module/SpecialPowerModule.h
+    Include/GameLogic/Module/SpecialPowerUpdateModule.h
     Include/GameLogic/Module/SpyVisionSpecialPower.h
     Include/GameLogic/Module/SpyVisionUpdate.h
     Include/GameLogic/Module/SquishCollide.h

--- a/Generals/Code/GameEngine/Include/Common/GameType.h
+++ b/Generals/Code/GameEngine/Include/Common/GameType.h
@@ -58,6 +58,8 @@ enum FormationID CPP_11(: Int)
 	FORCE_FORMATIONID_TO_LONG_SIZE = 0x7ffffff
 };
 
+#define INVALID_ANGLE -100.0f
+
 class INI;
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Include/Common/SpecialPower.h
+++ b/Generals/Code/GameEngine/Include/Common/SpecialPower.h
@@ -123,6 +123,7 @@ public:
 	UnsignedInt getViewObjectDuration( void ) const { return getFO()->m_viewObjectDuration; }
 	Real getViewObjectRange( void ) const { return getFO()->m_viewObjectRange; }
 	Real getRadiusCursorRadius() const { return getFO()->m_radiusCursorRadius; }
+	Bool isShortcutPower() const { return getFO()->m_shortcutPower; }
 
 private: 
 
@@ -142,6 +143,7 @@ private:
 	Real							m_radiusCursorRadius;	///< size of radius cursor, if any
 	Bool							m_publicTimer;				///< display a countdown timer for this special power for all to see
 	Bool							m_sharedNSync;				///< If true, this is a special that is shared between all of a player's command centers
+	Bool							m_shortcutPower;		///< Is this shortcut power capable of being fired by the side panel?
 
 	static const FieldParse m_specialPowerFieldParse[];		///< the parse table
 

--- a/Generals/Code/GameEngine/Include/GameLogic/AI.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AI.h
@@ -892,7 +892,7 @@ public:
 	void groupHackInternet( CommandSourceType cmdSource );				///< Begin hacking the internet for free cash from the heavens.
 	void groupDoSpecialPower( UnsignedInt specialPowerID, UnsignedInt commandOptions );
 	void groupDoSpecialPowerAtObject( UnsignedInt specialPowerID, Object *object, UnsignedInt commandOptions ); 
-	void groupDoSpecialPowerAtLocation( UnsignedInt specialPowerID, const Coord3D *location, const Object *object, UnsignedInt commandOptions );
+	void groupDoSpecialPowerAtLocation( UnsignedInt specialPowerID, const Coord3D *location, Real angle, const Object *object, UnsignedInt commandOptions );
 #ifdef ALLOW_SURRENDER
 	void groupSurrender( const Object *objWeSurrenderedTo, Bool surrender, CommandSourceType cmdSource );
 #endif

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/BaikonurLaunchPower.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/BaikonurLaunchPower.h
@@ -80,7 +80,7 @@ public:
 	BaikonurLaunchPower( Thing *thing, const ModuleData *moduleData );
 
 	virtual void doSpecialPower( UnsignedInt commandOptions );
-	virtual void doSpecialPowerAtLocation( const Coord3D *loc, UnsignedInt commandOptions );
+	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions );
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/BattlePlanUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/BattlePlanUpdate.h
@@ -34,7 +34,7 @@
 
 // INCLUDES ///////////////////////////////////////////////////////////////////////////////////////
 #include "Common/KindOf.h"
-#include "GameLogic/Module/UpdateModule.h"
+#include "GameLogic/Module/SpecialPowerUpdateModule.h"
 
 // FORWARD REFERENCES /////////////////////////////////////////////////////////////////////////////
 class SpecialPowerModule;
@@ -137,12 +137,13 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	// SpecialPowerUpdateInterface
-	virtual void initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, UnsignedInt commandOptions, Int locationCount );
+	virtual Bool initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions );
 	virtual Bool isSpecialAbility() const { return false; }
 	virtual Bool isSpecialPower() const { return true; }
 	virtual Bool isActive() const {return m_status != TRANSITIONSTATUS_IDLE;}
 	virtual SpecialPowerUpdateInterface* getSpecialPowerUpdateInterface() { return this; }
-	virtual Bool doesSpecialPowerHaveOverridableDestinationActive() const { return false; }
+	virtual Bool doesSpecialPowerHaveOverridableDestinationActive() const { return false; } //Is it active now?
+	virtual Bool doesSpecialPowerHaveOverridableDestination() const { return false; }	//Does it have it, even if it's not active?
 	virtual void setSpecialPowerOverridableDestination( const Coord3D *loc ) {}
 	virtual Bool isPowerCurrentlyInUse( const CommandButton *command = NULL ) const;
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/CashHackSpecialPower.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/CashHackSpecialPower.h
@@ -78,7 +78,7 @@ public:
 	// virtual destructor provided by memory pool object
 
 	virtual void doSpecialPowerAtObject( Object *obj, UnsignedInt commandOptions );
-	virtual void doSpecialPowerAtLocation( const Coord3D *loc, UnsignedInt commandOptions );
+	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions );
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/CleanupAreaPower.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/CleanupAreaPower.h
@@ -73,7 +73,7 @@ public:
 	CleanupAreaPower( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype defined by MemoryPoolObject
 
-	virtual void doSpecialPowerAtLocation( const Coord3D *loc, UnsignedInt commandOptions );
+	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions );
 };
 
 #endif 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/DefectorSpecialPower.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/DefectorSpecialPower.h
@@ -76,7 +76,7 @@ public:
 	// virtual destructor prototype provided by memory pool object
 
 	virtual void doSpecialPowerAtObject( Object *obj, UnsignedInt commandOptions );
-	virtual void doSpecialPowerAtLocation( const Coord3D *loc, UnsignedInt commandOptions );
+	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions );
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/DemoralizeSpecialPower.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/DemoralizeSpecialPower.h
@@ -75,7 +75,7 @@ public:
 	// virtual destructor prototype provided by memory pool object
 
 	virtual void doSpecialPowerAtObject( const Object *obj, UnsignedInt commandOptions );
-	virtual void doSpecialPowerAtLocation( const Coord3D *loc, UnsignedInt commandOptions );
+	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions );
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/MissileLauncherBuildingUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/MissileLauncherBuildingUpdate.h
@@ -35,7 +35,7 @@
 // INCLUDES ///////////////////////////////////////////////////////////////////////////////////////
 #include "Common/AudioEventRTS.h"
 #include "Common/INI.h"
-#include "GameLogic/Module/UpdateModule.h"
+#include "GameLogic/Module/SpecialPowerUpdateModule.h"
 class DamageInfo;
 class SpecialPowerTemplate;
 class SpecialPowerModule;
@@ -102,12 +102,13 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	//SpecialPowerUpdateInterface pure virtual implementations
-	virtual void initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, UnsignedInt commandOptions, Int locationCount );
+	virtual Bool initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions );
 	virtual Bool isSpecialAbility() const { return false; }
 	virtual Bool isSpecialPower() const { return true; }
 	virtual Bool isActive() const { return m_doorState != m_timeoutState; }
 	SpecialPowerTemplate* getTemplate() const;
-	virtual Bool doesSpecialPowerHaveOverridableDestinationActive() const { return false; }
+	virtual Bool doesSpecialPowerHaveOverridableDestinationActive() const { return false; } //Is it active now?
+	virtual Bool doesSpecialPowerHaveOverridableDestination() const { return false; }	//Does it have it, even if it's not active?
 	virtual void setSpecialPowerOverridableDestination( const Coord3D *loc ) {}
 
 	virtual SpecialPowerUpdateInterface* getSpecialPowerUpdateInterface() { return this; }

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/OCLSpecialPower.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/OCLSpecialPower.h
@@ -90,7 +90,7 @@ public:
 
 	virtual void doSpecialPower( UnsignedInt commandOptions );
 	virtual void doSpecialPowerAtObject( Object *obj, UnsignedInt commandOptions );
-	virtual void doSpecialPowerAtLocation( const Coord3D *loc, UnsignedInt commandOptions );
+	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions );
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/ParticleUplinkCannonUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/ParticleUplinkCannonUpdate.h
@@ -34,7 +34,7 @@
 
 // INCLUDES ///////////////////////////////////////////////////////////////////////////////////////
 #include "Common/KindOf.h"
-#include "GameLogic/Module/UpdateModule.h"
+#include "GameLogic/Module/SpecialPowerUpdateModule.h"
 
 // FORWARD REFERENCES /////////////////////////////////////////////////////////////////////////////
 class SpecialPowerModule;
@@ -156,7 +156,7 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	// SpecialPowerUpdateInterface
-	virtual void initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, UnsignedInt commandOptions, Int locationCount );
+	virtual Bool initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions );
 	virtual Bool isSpecialAbility() const { return false; }
 	virtual Bool isSpecialPower() const { return true; }
 	virtual Bool isActive() const {return m_status != STATUS_IDLE;}
@@ -180,7 +180,8 @@ public:
 	Bool calculateDefaultInformation();
 	Bool calculateUpBonePositions();
 
-	virtual Bool doesSpecialPowerHaveOverridableDestinationActive() const;
+	virtual Bool doesSpecialPowerHaveOverridableDestinationActive() const; //Is it active now?
+	virtual Bool doesSpecialPowerHaveOverridableDestination() const { return true; }	//Does it have it, even if it's not active?
 	virtual void setSpecialPowerOverridableDestination( const Coord3D *loc );
 
 	// Disabled conditions to process (termination conditions!)

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/SpecialAbility.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/SpecialAbility.h
@@ -59,7 +59,7 @@ public:
 	SpecialAbility( Thing *thing, const ModuleData *moduleData );
 
 	virtual void doSpecialPowerAtObject( Object *obj, UnsignedInt commandOptions );
-	virtual void doSpecialPowerAtLocation( const Coord3D *loc, UnsignedInt commandOptions );
+	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions );
 	virtual void doSpecialPower( UnsignedInt commandOptions );
 
 protected:

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/SpecialAbilityUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/SpecialAbilityUpdate.h
@@ -35,7 +35,7 @@
 // INCLUDES ///////////////////////////////////////////////////////////////////////////////////////
 #include "Common/AudioEventRTS.h"
 #include "Common/INI.h"
-#include "GameLogic/Module/UpdateModule.h"
+#include "GameLogic/Module/SpecialPowerUpdateModule.h"
 #include "GameClient/ParticleSys.h"	
 
 class DamageInfo;
@@ -173,11 +173,12 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	// SpecialPowerUpdateInterface
-	virtual void initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, UnsignedInt commandOptions, Int locationCount );
+	virtual Bool initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions );
 	virtual Bool isSpecialAbility() const { return true; }
 	virtual Bool isSpecialPower() const { return false; }
 	virtual Bool isActive() const { return m_active; }
-	virtual Bool doesSpecialPowerHaveOverridableDestinationActive() const { return false; }
+	virtual Bool doesSpecialPowerHaveOverridableDestinationActive() const { return false; } //Is it active now?
+	virtual Bool doesSpecialPowerHaveOverridableDestination() const { return false; }	//Does it have it, even if it's not active?
 	virtual void setSpecialPowerOverridableDestination( const Coord3D *loc ) {}
 	virtual Bool isPowerCurrentlyInUse( const CommandButton *command = NULL ) const;
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/SpecialPowerModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/SpecialPowerModule.h
@@ -64,8 +64,8 @@ public:
 	virtual void pauseCountdown( Bool pause ) = 0;
 	virtual void doSpecialPower( UnsignedInt commandOptions ) = 0;
 	virtual void doSpecialPowerAtObject( Object *obj, UnsignedInt commandOptions ) = 0;
-	virtual void doSpecialPowerAtLocation( const Coord3D *loc, UnsignedInt commandOptions ) = 0;
-	virtual void doSpecialPowerAtMultipleLocations( const Coord3D *locations, Int locCount, UnsignedInt commandOptions ) = 0;
+	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions ) = 0;
+	virtual void doSpecialPowerUsingWaypoints( const Waypoint *way, UnsignedInt commandOptions ) = 0;
 	virtual void markSpecialPowerTriggered( const Coord3D *location ) = 0;
 	virtual void startPowerRecharge() = 0;	
 	virtual const AudioEventRTS& getInitiateSound() const = 0;
@@ -134,8 +134,8 @@ public:
 	//
 	virtual void doSpecialPower( UnsignedInt commandOptions );
 	virtual void doSpecialPowerAtObject( Object *obj, UnsignedInt commandOptions );
-	virtual void doSpecialPowerAtLocation( const Coord3D *loc, UnsignedInt commandOptions );
-	virtual void doSpecialPowerAtMultipleLocations( const Coord3D *locations, Int locCount, UnsignedInt commandOptions );
+	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions );
+	virtual void doSpecialPowerUsingWaypoints( const Waypoint *way, UnsignedInt commandOptions );
 
 	/**
 	 Now, there are special powers that require some preliminary processing before the actual
@@ -157,10 +157,7 @@ public:
 
 protected:
 
-	void initiateIntentToDoSpecialPower( const Object *targetObj, 
-																			 const Coord3D *targetPos, 
-																			 UnsignedInt commandOptions, 
-																			 Int locationCount = 0 );
+	Bool initiateIntentToDoSpecialPower( const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions );
 	void triggerSpecialPower( const Coord3D *location );
 	void createViewObject( const Coord3D *location );
 	void resolveSpecialPower( void );

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/SpecialPowerUpdateModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/SpecialPowerUpdateModule.h
@@ -1,0 +1,53 @@
+/*
+**	Command & Conquer Generals(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+////////////////////////////////////////////////////////////////////////////////
+//																																						//
+//  (c) 2001-2003 Electronic Arts Inc.																				//
+//																																						//
+////////////////////////////////////////////////////////////////////////////////
+
+// FILE: SpecialPowerUpdateModule.h /////////////////////////////////////////////////////////////////////////////////
+// Author: Kris Morness, July 2003
+// Desc: Originally lived in UpdateModule.h
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#ifndef __SPECIAL_POWER_UPDATE_MODULE_H
+#define __SPECIAL_POWER_UPDATE_MODULE_H
+
+#include "Common/Module.h"
+#include "Common/GameType.h"
+
+//-------------------------------------------------------------------------------------------------
+class SpecialPowerUpdateInterface
+{
+public:
+	virtual Bool initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions ) = 0;
+	virtual Bool isSpecialAbility() const = 0;
+	virtual Bool isSpecialPower() const = 0;
+	virtual Bool isActive() const = 0;
+	virtual CommandOption getCommandOption() const = 0;
+	virtual Bool doesSpecialPowerHaveOverridableDestinationActive() const = 0; //Is it active now?
+	virtual Bool doesSpecialPowerHaveOverridableDestination() const = 0;	//Does it have it, even if it's not active?
+	virtual void setSpecialPowerOverridableDestination( const Coord3D *loc ) = 0;
+	virtual Bool isPowerCurrentlyInUse( const CommandButton *command = NULL ) const = 0;
+};
+
+#endif

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/UpdateModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/UpdateModule.h
@@ -63,6 +63,7 @@ class WeaponTemplate;
 class DamageInfo;
 class ParticleSystemTemplate;
 class CommandButton;
+class Waypoint;
 enum CommandOption CPP_11(: Int);
 
 //-------------------------------------------------------------------------------------------------
@@ -257,20 +258,6 @@ public:
 	virtual void onSlaverDamage( const DamageInfo *info ) = 0;
 	virtual	Bool isSelfTasking() const = 0;
 
-};
-
-//-------------------------------------------------------------------------------------------------
-class SpecialPowerUpdateInterface
-{
-public:
-	virtual void initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, UnsignedInt commandOptions, Int locationCount = 0 ) = 0;
-	virtual Bool isSpecialAbility() const = 0;
-	virtual Bool isSpecialPower() const = 0;
-	virtual Bool isActive() const = 0;
-	virtual CommandOption getCommandOption() const = 0;
-	virtual Bool doesSpecialPowerHaveOverridableDestinationActive() const = 0;
-	virtual void setSpecialPowerOverridableDestination( const Coord3D *loc ) = 0;
-	virtual Bool isPowerCurrentlyInUse( const CommandButton *command = NULL ) const = 0;
 };
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Include/GameLogic/Object.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Object.h
@@ -306,9 +306,11 @@ public:
 
 	// Ditto for special powers -- Kris
 	SpecialPowerModuleInterface* findSpecialPowerModuleInterface( SpecialPowerType type ) const;
+	SpecialPowerModuleInterface* findAnyShortcutSpecialPowerModuleInterface() const;
 	SpecialAbilityUpdate* findSpecialAbilityUpdate( SpecialPowerType type ) const;
 	SpecialPowerCompletionDie* findSpecialPowerCompletionDie() const;
 	SpecialPowerUpdateInterface* findSpecialPowerWithOverridableDestinationActive( SpecialPowerType type = SPECIAL_INVALID ) const;
+	SpecialPowerUpdateInterface* findSpecialPowerWithOverridableDestination( SpecialPowerType type = SPECIAL_INVALID ) const;
 
 	inline ObjectStatusMaskType getStatusBits() const { return m_status; }
 	inline Bool testStatus( ObjectStatusTypes bit ) const { return m_status.test( bit ); }
@@ -425,9 +427,9 @@ public:
 	SpecialPowerModuleInterface *getSpecialPowerModule( const SpecialPowerTemplate *specialPowerTemplate ) const;
 	void doSpecialPower( const SpecialPowerTemplate *specialPowerTemplate, UnsignedInt commandOptions, Bool forced = false );	///< execute power
 	void doSpecialPowerAtObject( const SpecialPowerTemplate *specialPowerTemplate, Object *obj, UnsignedInt commandOptions, Bool forced = false );	///< execute power
-	void doSpecialPowerAtLocation( const SpecialPowerTemplate *specialPowerTemplate, const Coord3D *loc, UnsignedInt commandOptions, Bool forced = false );	///< execute power
-	void doSpecialPowerAtMultipleLocations( const SpecialPowerTemplate *specialPowerTemplate,
-																					const Coord3D *locations, Int locCount, UnsignedInt commandOptions, Bool forced = false );	///< execute power
+	void doSpecialPowerAtLocation( const SpecialPowerTemplate *specialPowerTemplate, const Coord3D *loc, Real angle, UnsignedInt commandOptions, Bool forced = false );	///< execute power
+	void doSpecialPowerUsingWaypoints( const SpecialPowerTemplate *specialPowerTemplate, const Waypoint *way, UnsignedInt commandOptions, Bool forced = false );	///< execute power
+
 	void doCommandButton( const CommandButton *commandButton, CommandSourceType cmdSource );
 	void doCommandButtonAtObject( const CommandButton *commandButton, Object *obj, CommandSourceType cmdSource );
 	void doCommandButtonAtPosition( const CommandButton *commandButton, const Coord3D *pos, CommandSourceType cmdSource );

--- a/Generals/Code/GameEngine/Source/Common/RTS/SpecialPower.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/SpecialPower.cpp
@@ -176,6 +176,7 @@ void SpecialPowerStore::parseSpecialPowerDefinition( INI *ini )
 	{ "ViewObjectDuration",				INI::parseDurationUnsignedInt,		NULL,	offsetof( SpecialPowerTemplate, m_viewObjectDuration ) },
 	{ "ViewObjectRange",					INI::parseReal,										NULL,	offsetof( SpecialPowerTemplate, m_viewObjectRange ) },
 	{ "RadiusCursorRadius",				INI::parseReal,										NULL,	offsetof( SpecialPowerTemplate, m_radiusCursorRadius ) },
+	{ "ShortcutPower",						INI::parseBool,										NULL, offsetof( SpecialPowerTemplate, m_shortcutPower ) },
 	{ NULL,	NULL, NULL,	0 }  // keep this last
 
 };
@@ -194,6 +195,7 @@ SpecialPowerTemplate::SpecialPowerTemplate()
 	m_viewObjectDuration = 0;
 	m_viewObjectRange = 0;
 	m_radiusCursorRadius = 0;
+	m_shortcutPower = FALSE;
 
 }  // end SpecialPowerTemplate
 

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
@@ -53,6 +53,7 @@
 #include "GameLogic/Module/SpawnBehavior.h"
 #include "GameLogic/Module/SpecialPowerModule.h"
 #include "GameLogic/Module/StealthUpdate.h"
+#include "GameLogic/Module/SpecialPowerUpdateModule.h"
 #include "GameLogic/ObjectIter.h"
 
 #ifdef RTS_INTERNAL
@@ -2513,7 +2514,7 @@ void AIGroup::groupDoSpecialPower( UnsignedInt specialPowerID, UnsignedInt comma
  * don't use AIUpdateInterfaces!!! No special power uses an AIUpdateInterface immediately, but special
  * abilities, which are derived from special powers do... and are unit triggered. Those do have AI.
  */
-void AIGroup::groupDoSpecialPowerAtLocation( UnsignedInt specialPowerID, const Coord3D *location, const Object *objectInWay, UnsignedInt commandOptions )
+void AIGroup::groupDoSpecialPowerAtLocation( UnsignedInt specialPowerID, const Coord3D *location, Real angle, const Object *objectInWay, UnsignedInt commandOptions )
 {
 	//This one requires a position
 	std::list<Object *>::iterator i;
@@ -2538,7 +2539,7 @@ void AIGroup::groupDoSpecialPowerAtLocation( UnsignedInt specialPowerID, const C
 			{
 				if( TheActionManager->canDoSpecialPowerAtLocation( object, location, CMD_FROM_PLAYER, spTemplate, objectInWay, commandOptions ) )
 				{
-					mod->doSpecialPowerAtLocation( location, commandOptions );
+					mod->doSpecialPowerAtLocation( location, angle, commandOptions );
 
 					object->friend_setUndetectedDefector( FALSE );// My secret is out
 				}

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/SpecialPower/BaikonurLaunchPower.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/SpecialPower/BaikonurLaunchPower.cpp
@@ -98,7 +98,7 @@ void BaikonurLaunchPower::doSpecialPower( UnsignedInt commandOptions )
 }  
 
 // ------------------------------------------------------------------------------------------------
-void BaikonurLaunchPower::doSpecialPowerAtLocation( const Coord3D *loc, UnsignedInt commandOptions )
+void BaikonurLaunchPower::doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions )
 {
 	if (getObject()->isDisabled())
 		return;
@@ -106,7 +106,7 @@ void BaikonurLaunchPower::doSpecialPowerAtLocation( const Coord3D *loc, Unsigned
 	const BaikonurLaunchPowerModuleData *data = getBaikonurLaunchPowerModuleData();
 
 	// call the base class action cause we are *EXTENDING* functionality
-	SpecialPowerModule::doSpecialPowerAtLocation( loc, commandOptions );
+	SpecialPowerModule::doSpecialPowerAtLocation( loc, angle, commandOptions );
 
 	//Create the detonation
 	const ThingTemplate *thing = TheThingFactory->findTemplate( data->m_detonationObject );

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/SpecialPower/CashHackSpecialPower.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/SpecialPower/CashHackSpecialPower.cpp
@@ -97,7 +97,7 @@ CashHackSpecialPower::~CashHackSpecialPower( void )
 
 // ------------------------------------------------------------------------------------------------
 // ------------------------------------------------------------------------------------------------
-void CashHackSpecialPower::doSpecialPowerAtLocation( const Coord3D *loc, UnsignedInt commandOptions )
+void CashHackSpecialPower::doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions )
 {
 	if (getObject()->isDisabled())
 		return;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/SpecialPower/CleanupAreaPower.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/SpecialPower/CleanupAreaPower.cpp
@@ -84,7 +84,7 @@ CleanupAreaPower::~CleanupAreaPower()
 }
 
 //-------------------------------------------------------------------------------------------------
-void CleanupAreaPower::doSpecialPowerAtLocation( const Coord3D *loc, UnsignedInt commandOptions )
+void CleanupAreaPower::doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions )
 {
 	if (getObject()->isDisabled())
 		return;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/SpecialPower/DefectorSpecialPower.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/SpecialPower/DefectorSpecialPower.cpp
@@ -90,7 +90,7 @@ DefectorSpecialPower::~DefectorSpecialPower( void )
  
 // ------------------------------------------------------------------------------------------------
 
-void DefectorSpecialPower::doSpecialPowerAtLocation( const Coord3D *loc, UnsignedInt commandOptions )
+void DefectorSpecialPower::doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions )
 {
 	if (getObject()->isDisabled())
 		return;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/SpecialPower/DemoralizeSpecialPower.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/SpecialPower/DemoralizeSpecialPower.cpp
@@ -98,7 +98,7 @@ DemoralizeSpecialPower::~DemoralizeSpecialPower( void )
 
 // ------------------------------------------------------------------------------------------------
 // ------------------------------------------------------------------------------------------------
-void DemoralizeSpecialPower::doSpecialPowerAtLocation( const Coord3D *loc, UnsignedInt commandOptions )
+void DemoralizeSpecialPower::doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions )
 {
 	if (getObject()->isDisabled())
 		return;
@@ -108,7 +108,7 @@ void DemoralizeSpecialPower::doSpecialPowerAtLocation( const Coord3D *loc, Unsig
 		return;
 
 	// call the base class action cause we are *EXTENDING* functionality
-	SpecialPowerModule::doSpecialPowerAtLocation( loc, commandOptions );
+	SpecialPowerModule::doSpecialPowerAtLocation( loc, angle, commandOptions );
 
 	// the source of my fiendish power
 	Object *source = getObject();
@@ -179,13 +179,13 @@ void DemoralizeSpecialPower::doSpecialPowerAtLocation( const Coord3D *loc, Unsig
 
 // ------------------------------------------------------------------------------------------------
 // ------------------------------------------------------------------------------------------------
-void DemoralizeSpecialPower::doSpecialPowerAtObject( const Object *obj, UnsignedInt commandOptions )
+void DemoralizeSpecialPower::doSpecialPowerAtObject( const Object *obj, Real angle, UnsignedInt commandOptions )
 {
 	if (getObject()->isDisabled())
 		return;
 
 	if( obj )
-		doSpecialPowerAtLocation( obj->getPosition(), commandOptions );
+		doSpecialPowerAtLocation( obj->getPosition(), angle, commandOptions );
 
 }  // end doSpecialPowerAtObject
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/SpecialPower/OCLSpecialPower.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/SpecialPower/OCLSpecialPower.cpp
@@ -145,7 +145,7 @@ OCLSpecialPower::~OCLSpecialPower( void )
 //-------------------------------------------------------------------------------------------------
 /** Execute the power */
 //-------------------------------------------------------------------------------------------------
-void OCLSpecialPower::doSpecialPowerAtLocation( const Coord3D *loc, UnsignedInt commandOptions )
+void OCLSpecialPower::doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions )
 {
 	if (getObject()->isDisabled())
 		return;
@@ -155,7 +155,7 @@ void OCLSpecialPower::doSpecialPowerAtLocation( const Coord3D *loc, UnsignedInt 
 		return;
 
 	// call the base class action cause we are *EXTENDING* functionality
-	SpecialPowerModule::doSpecialPowerAtLocation( loc, commandOptions );
+	SpecialPowerModule::doSpecialPowerAtLocation( loc, angle, commandOptions );
 
 	const ObjectCreationList* ocl = findOCL();
 
@@ -207,7 +207,7 @@ void OCLSpecialPower::doSpecialPowerAtObject( Object *obj, UnsignedInt commandOp
 	// convert to a location
 	if( !obj )
 		return;
-	doSpecialPowerAtLocation( obj->getPosition(), commandOptions );
+	doSpecialPowerAtLocation( obj->getPosition(), INVALID_ANGLE, commandOptions );
 }  
 
 // ------------------------------------------------------------------------------------------------
@@ -220,7 +220,7 @@ void OCLSpecialPower::doSpecialPower( UnsignedInt commandOptions )
 	creationCoord.set( getObject()->getPosition() );
 	
 	// call the base class action cause we are *EXTENDING* functionality
-	SpecialPowerModule::doSpecialPowerAtLocation( &creationCoord, commandOptions );
+	SpecialPowerModule::doSpecialPowerAtLocation( &creationCoord, INVALID_ANGLE, commandOptions );
 
 	const ObjectCreationList* ocl = findOCL();
 	ObjectCreationList::create( ocl, getObject(), &creationCoord, &creationCoord, false );

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/SpecialPower/SpecialAbility.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/SpecialPower/SpecialAbility.cpp
@@ -39,6 +39,11 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////////////
+#ifdef RTS_INTERNAL
+// for occasional debugging...
+//#pragma optimize("", off)
+//#pragma MESSAGE("************************************** WARNING, optimization disabled for debugging purposes")
+#endif
 
 // ------------------------------------------------------------------------------------------------
 // ------------------------------------------------------------------------------------------------
@@ -57,7 +62,7 @@ SpecialAbility::~SpecialAbility( void )
 
 // ------------------------------------------------------------------------------------------------
 // ------------------------------------------------------------------------------------------------
-void SpecialAbility::doSpecialPowerAtLocation( const Coord3D *loc, UnsignedInt commandOptions )
+void SpecialAbility::doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions )
 {
 	if (getObject()->isDisabled())
 		return;
@@ -67,7 +72,7 @@ void SpecialAbility::doSpecialPowerAtLocation( const Coord3D *loc, UnsignedInt c
 		return;
 
 	// call the base class action cause we are *EXTENDING* functionality
-	SpecialPowerModule::doSpecialPowerAtLocation( loc, commandOptions );
+	SpecialPowerModule::doSpecialPowerAtLocation( loc, angle, commandOptions );
 }  
 
 // ------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/SpecialPower/SpecialPowerModule.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/SpecialPower/SpecialPowerModule.cpp
@@ -46,6 +46,7 @@
 #include "GameLogic/Module/DeletionUpdate.h"
 #include "GameLogic/Module/UpdateModule.h"
 #include "GameLogic/Module/SpecialPowerModule.h"
+#include "GameLogic/Module/SpecialPowerUpdateModule.h"
 #include "GameLogic/ScriptEngine.h"
 
 #include "GameClient/Eva.h"
@@ -388,7 +389,7 @@ void SpecialPowerModule::startPowerRecharge()
 
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
-void SpecialPowerModule::initiateIntentToDoSpecialPower( const Object *targetObj, const Coord3D *targetPos, UnsignedInt commandOptions, Int locationCount )
+Bool SpecialPowerModule::initiateIntentToDoSpecialPower( const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions )
 {
 	Bool valid = false;
 	// tell our update modules that we intend to do this special power.
@@ -400,7 +401,7 @@ void SpecialPowerModule::initiateIntentToDoSpecialPower( const Object *targetObj
 			//Validate that we are calling the correct module!
 			if( isModuleForPower( getSpecialPowerModuleData()->m_specialPowerTemplate ) )
 			{
-				spu->initiateIntentToDoSpecialPower( getSpecialPowerModuleData()->m_specialPowerTemplate, targetObj, targetPos, commandOptions, locationCount );
+				spu->initiateIntentToDoSpecialPower( getSpecialPowerModuleData()->m_specialPowerTemplate, targetObj, targetPos, way, commandOptions );
 				valid = true;
 			}
 		}
@@ -414,6 +415,8 @@ void SpecialPowerModule::initiateIntentToDoSpecialPower( const Object *targetObj
 		//DEBUG_CRASH(( "Object does not contain special power module (%s) to execute.  Did you forget to add it to the object INI?\n",
 		//							command->m_specialPower->getName().str() ));
 	}
+
+	return valid;
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -537,7 +540,7 @@ void SpecialPowerModule::doSpecialPower( UnsignedInt commandOptions )
 
 	//This tells the update module that we want to do our special power. The update modules
 	//will then start processing each frame.
-	initiateIntentToDoSpecialPower( NULL, NULL, commandOptions );
+	initiateIntentToDoSpecialPower( NULL, NULL, NULL, commandOptions );
 
 	//Only trigger the special power immediately if the updatemodule doesn't start the attack.
 	//An example of a case that wouldn't trigger immediately is for a unit that needs to 
@@ -559,7 +562,7 @@ void SpecialPowerModule::doSpecialPowerAtObject( Object *obj, UnsignedInt comman
 
 	//This tells the update module that we want to do our special power. The update modules
 	//will then start processing each frame.
-	initiateIntentToDoSpecialPower( obj, NULL, commandOptions );
+	initiateIntentToDoSpecialPower( obj, NULL, NULL, commandOptions );
 
 	//Only trigger the special power immediately if the updatemodule doesn't start the attack.
 	//An example of a case that wouldn't trigger immediately is for a unit that needs to 
@@ -573,7 +576,7 @@ void SpecialPowerModule::doSpecialPowerAtObject( Object *obj, UnsignedInt comman
 
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
-void SpecialPowerModule::doSpecialPowerAtLocation( const Coord3D *loc, UnsignedInt commandOptions )
+void SpecialPowerModule::doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions )
 {
 	if (m_pausedCount > 0 || getObject()->isDisabled()) {
 		return;
@@ -581,7 +584,7 @@ void SpecialPowerModule::doSpecialPowerAtLocation( const Coord3D *loc, UnsignedI
 
 	//This tells the update module that we want to do our special power. The update modules
 	//will then start processing each frame.
-	initiateIntentToDoSpecialPower( NULL, loc, commandOptions );
+	initiateIntentToDoSpecialPower( NULL, loc, NULL, commandOptions );
 
 	//Only trigger the special power immediately if the updatemodule doesn't start the attack.
 	//An example of a case that wouldn't trigger immediately is for a unit that needs to 
@@ -595,7 +598,7 @@ void SpecialPowerModule::doSpecialPowerAtLocation( const Coord3D *loc, UnsignedI
 
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
-void SpecialPowerModule::doSpecialPowerAtMultipleLocations( const Coord3D *locations, Int locCount, UnsignedInt commandOptions )
+void SpecialPowerModule::doSpecialPowerUsingWaypoints( const Waypoint *way, UnsignedInt commandOptions )
 {
 	if (m_pausedCount > 0 || getObject()->isDisabled()) {
 		return;
@@ -603,7 +606,7 @@ void SpecialPowerModule::doSpecialPowerAtMultipleLocations( const Coord3D *locat
 
 	//This tells the update module that we want to do our special power. The update modules
 	//will then start processing each frame.
-	initiateIntentToDoSpecialPower( NULL, locations, commandOptions, locCount );
+	initiateIntentToDoSpecialPower( NULL, NULL, way, commandOptions );
 
 	//Only trigger the special power immediately if the updatemodule doesn't start the attack.
 	//An example of a case that wouldn't trigger immediately is for a unit that needs to 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/BattlePlanUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/BattlePlanUpdate.cpp
@@ -264,12 +264,12 @@ void BattlePlanUpdate::onObjectCreated()
 }
 
 //-------------------------------------------------------------------------------------------------
-void BattlePlanUpdate::initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, UnsignedInt commandOptions, Int locationCount )
+Bool BattlePlanUpdate::initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions )
 {
 	if( m_specialPowerModule->getSpecialPowerTemplate() != specialPowerTemplate )
 	{
 		//Check to make sure our modules are connected.
-		return;
+		return FALSE;
 	}
 
 	//Set the desired status based on the command button option!
@@ -285,6 +285,13 @@ void BattlePlanUpdate::initiateIntentToDoSpecialPower(const SpecialPowerTemplate
 	{
 		m_desiredPlan = PLANSTATUS_SEARCHANDDESTROY;
 	}
+	else
+	{
+		DEBUG_CRASH( ("Selected an unsupported strategy for strategy center.") );
+		return FALSE;
+	}
+
+	return TRUE;
 }
 
 Bool BattlePlanUpdate::isPowerCurrentlyInUse( const CommandButton *command ) const

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/MissileLauncherBuildingUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/MissileLauncherBuildingUpdate.cpp
@@ -203,13 +203,14 @@ void MissileLauncherBuildingUpdate::switchToState(DoorStateType dst)
 }
 
 //-------------------------------------------------------------------------------------------------
-void MissileLauncherBuildingUpdate::initiateIntentToDoSpecialPower( const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, UnsignedInt commandOptions, Int locationCount )
+Bool MissileLauncherBuildingUpdate::initiateIntentToDoSpecialPower( const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions )
 {
 #if defined(RTS_DEBUG) || defined(RTS_INTERNAL)
 	DEBUG_ASSERTCRASH(!TheGlobalData->m_specialPowerUsesDelay || m_doorState == DOOR_OPEN, ("door is not fully open when specialpower is fired!"));
 #endif
 
 	switchToState(DOOR_WAITING_TO_CLOSE);
+	return TRUE;
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
@@ -268,14 +268,14 @@ void ParticleUplinkCannonUpdate::onObjectCreated()
 }
 
 //-------------------------------------------------------------------------------------------------
-void ParticleUplinkCannonUpdate::initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, UnsignedInt commandOptions, Int locationCount )
+Bool ParticleUplinkCannonUpdate::initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions )
 {
 	const ParticleUplinkCannonUpdateModuleData *data = getParticleUplinkCannonUpdateModuleData();
 
 	if( m_specialPowerModule->getSpecialPowerTemplate() != specialPowerTemplate )
 	{
 		//Check to make sure our modules are connected.
-		return;
+		return FALSE;
 	}
 
 	if( !BitIsSet( commandOptions, COMMAND_FIRED_BY_SCRIPT ) )
@@ -306,6 +306,7 @@ void ParticleUplinkCannonUpdate::initiateIntentToDoSpecialPower(const SpecialPow
 		SpecialPowerModule *spModule = (SpecialPowerModule*)spmInterface;
 		spModule->markSpecialPowerTriggered( &m_initialTargetPosition );
 	}
+	return TRUE;
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
@@ -380,11 +380,11 @@ UpdateSleepTime SpecialAbilityUpdate::update( void )
 }
 
 //-------------------------------------------------------------------------------------------------
-void SpecialAbilityUpdate::initiateIntentToDoSpecialPower( const SpecialPowerTemplate *specialPowerTemplate, 
+Bool SpecialAbilityUpdate::initiateIntentToDoSpecialPower( const SpecialPowerTemplate *specialPowerTemplate, 
 																													 const Object *targetObj, 
 																													 const Coord3D *targetPos, 
-																													 UnsignedInt commandOptions, 
-																													 Int locationCount )
+																													 const Waypoint *way, 
+																													 UnsignedInt commandOptions )
 {
 	const SpecialAbilityUpdateModuleData* data = getSpecialAbilityUpdateModuleData();
 	const SpecialPowerTemplate *spTemplate = data->m_specialPowerTemplate;
@@ -392,7 +392,7 @@ void SpecialAbilityUpdate::initiateIntentToDoSpecialPower( const SpecialPowerTem
 	if( spTemplate != specialPowerTemplate )
 	{
 		//Check to make sure our modules are connected.
-		return;
+		return FALSE;
 	}
 
 	//Clear target values
@@ -418,13 +418,12 @@ void SpecialAbilityUpdate::initiateIntentToDoSpecialPower( const SpecialPowerTem
 	{
 		//Get the position!
 		m_targetPos = *targetPos;
-		m_locationCount = locationCount;
 	}
 	
 	//Clear any old AI before starting this special ability.
 	if( !getObject()->getAIUpdateInterface() )
 	{
-		return;
+		return FALSE;
 	}
 	getObject()->getAIUpdateInterface()->aiIdle( CMD_FROM_AI );
 
@@ -459,6 +458,8 @@ void SpecialAbilityUpdate::initiateIntentToDoSpecialPower( const SpecialPowerTem
 
 
 	setWakeFrame(getObject(), UPDATE_SLEEP_NONE);
+
+	return TRUE;
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
@@ -3893,7 +3893,7 @@ void ScriptActions::doNamedFireSpecialPowerAtWaypoint( const AsciiString& unit, 
 			if (!way) {
 				return;
 			}
-			mod->doSpecialPowerAtLocation(way->getLocation(), COMMAND_FIRED_BY_SCRIPT );
+			mod->doSpecialPowerAtLocation(way->getLocation(), INVALID_ANGLE, COMMAND_FIRED_BY_SCRIPT );
 		}
 	}
 }
@@ -3936,10 +3936,9 @@ void ScriptActions::doSkirmishFireSpecialPowerAtMostCost( const AsciiString &pla
 				SpecialPowerModuleInterface *mod = pObj->getSpecialPowerModule(power);
 				if (mod)
 				{
-					mod->doSpecialPowerAtLocation( &location, COMMAND_FIRED_BY_SCRIPT );
+					mod->doSpecialPowerAtLocation( &location, INVALID_ANGLE, COMMAND_FIRED_BY_SCRIPT );
 					break;
 				}
-
 			}
 		}
 	}

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -691,7 +691,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			{
 				AIGroup* theGroup = TheAI->createGroup();
 				theGroup->add(source);
-				theGroup->groupDoSpecialPowerAtLocation( specialPowerID, &targetCoord, objectInWay, options );
+				theGroup->groupDoSpecialPowerAtLocation( specialPowerID, &targetCoord, INVALID_ANGLE, objectInWay, options );
 				TheAI->destroyGroup(theGroup);
 			}
 			else
@@ -699,7 +699,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 				//Use the selected group!
 				if( currentlySelectedGroup )
 				{
-					currentlySelectedGroup->groupDoSpecialPowerAtLocation( specialPowerID, &targetCoord, objectInWay, options );
+					currentlySelectedGroup->groupDoSpecialPowerAtLocation( specialPowerID, &targetCoord, INVALID_ANGLE, objectInWay, options );
 				}
 			}
 			break;


### PR DESCRIPTION
This change ports SpecialPowerUpdate changes from Zero Hour to Generals. It also adds the 'ShortcutPower' field to the 'SpecialPower' INI section.

`LocationCount` doesn't ever seem to have been set to anything but 0 so this seems safe to backport.