### PR TITLE
[GEN][ZH] Fix uninitialized variable read in ConnectionManager::allCommandsReady()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameNetwork/ConnectionManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/ConnectionManager.cpp
@@ -1554,7 +1554,7 @@ Int commandsReadyDebugSpewage = 0;
  */
 Bool ConnectionManager::allCommandsReady(UnsignedInt frame, Bool justTesting /* = FALSE */) {
 	Bool retval = TRUE;
-	FrameDataReturnType frameRetVal;
+	FrameDataReturnType frameRetVal = FRAMEDATA_NOTREADY;
 //	retval = FALSE;  // ****for testing purposes only!!!!!!****
 	Int i = 0;
 	for (; (i < MAX_SLOTS) && retval; ++i) {

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/ConnectionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/ConnectionManager.cpp
@@ -1554,7 +1554,7 @@ Int commandsReadyDebugSpewage = 0;
  */
 Bool ConnectionManager::allCommandsReady(UnsignedInt frame, Bool justTesting /* = FALSE */) {
 	Bool retval = TRUE;
-	FrameDataReturnType frameRetVal;
+	FrameDataReturnType frameRetVal = FRAMEDATA_NOTREADY;
 //	retval = FALSE;  // ****for testing purposes only!!!!!!****
 	Int i = 0;
 	for (; (i < MAX_SLOTS) && retval; ++i) {


### PR DESCRIPTION
This change fixes an uninitialized variable read in ConnectionManager::allCommandsReady()

It happened on Network match exit in Debug configuration.

```
>	generalszh.exe!ConnectionManager::allCommandsReady(unsigned int frame, bool justTesting) Line 1584	C++
 	generalszh.exe!Network::AllCommandsReady(unsigned int frame) Line 580	C++
 	generalszh.exe!Network::update() Line 717	C++
 	generalszh.exe!SubsystemInterface::UPDATE() Line 134	C++
 	generalszh.exe!GameEngine::update() Line 766	C++
 	generalszh.exe!Win32GameEngine::update() Line 90	C++
 	generalszh.exe!GameEngine::execute() Line 836	C++
 	generalszh.exe!GameMain(int argc, char * * argv) Line 44	C++
 	generalszh.exe!WinMain(HINSTANCE__ * hInstance, HINSTANCE__ * hPrevInstance, char * lpCmdLine, int nCmdShow) Line 1063	C++
 	generalszh.exe!invoke_main() Line 107	C++
 	generalszh.exe!__scrt_common_main_seh() Line 288	C++
 	generalszh.exe!__scrt_common_main() Line 331	C++
 	generalszh.exe!WinMainCRTStartup(void * __formal) Line 17	C++
 	kernel32.dll!74fafcc9()	Unknown
 	[Frames below may be incorrect and/or missing, no symbols loaded for kernel32.dll]	
 	ntdll.dll!76f582ae()	Unknown
 	ntdll.dll!76f5827e()	Unknown
```
```
Run-Time Check Failure #3 - The variable 'frameRetVal' is being used without being initialized.
```