### PR TITLE
[GEN][ZH] Remove all instances of stopAllAmbientsBy()

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/GameAudio.h
+++ b/Generals/Code/GameEngine/Include/Common/GameAudio.h
@@ -152,10 +152,6 @@ class AudioManager : public SubsystemInterface
 		virtual void resumeAudio( AudioAffect which ) = 0;
 		virtual void pauseAmbient( Bool shouldPause ) = 0;
 
-		// device dependent stops.
-		virtual void stopAllAmbientsBy( Object* obj ) = 0;
-		virtual void stopAllAmbientsBy( Drawable* draw ) = 0;
-
 		// for focus issues
 		virtual void loseFocus( void );
 		virtual void regainFocus( void );

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Die/FXListDie.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Die/FXListDie.cpp
@@ -65,8 +65,6 @@ void FXListDie::onDie( const DamageInfo *damageInfo )
 	const FXListDieModuleData* d = getFXListDieModuleData();
 	if (d->m_defaultDeathFX)
 	{
-		// if the object has any ambient sound(s), kill 'em now.
-		TheAudio->stopAllAmbientsBy(getObject());
 		
 		if (d->m_orientToObject)
 		{

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -3706,7 +3706,6 @@ void GameLogic::setGamePaused( Bool paused, Bool pauseMusic )
 		while( drawable )
 		{
 			drawable->startAmbientSound();
-			TheAudio->stopAllAmbientsBy( drawable );
 			drawable = drawable->getNextDrawable();
 		}
 	}

--- a/Generals/Code/GameEngineDevice/Include/MilesAudioDevice/MilesAudioManager.h
+++ b/Generals/Code/GameEngineDevice/Include/MilesAudioDevice/MilesAudioManager.h
@@ -167,9 +167,6 @@ class MilesAudioManager : public AudioManager
 
 		virtual void killAudioEventImmediately( AudioHandle audioEvent );
 
-		virtual void stopAllAmbientsBy( Object *objID );
-		virtual void stopAllAmbientsBy( Drawable *drawID );
-
 		///< Return whether the current audio is playing or not. 
 		///< NOTE NOTE NOTE !!DO NOT USE THIS IN FOR GAMELOGIC PURPOSES!! NOTE NOTE NOTE
 		virtual Bool isCurrentlyPlaying( AudioHandle handle );

--- a/Generals/Code/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
+++ b/Generals/Code/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
@@ -653,19 +653,6 @@ void MilesAudioManager::pauseAmbient( Bool shouldPause )
 }
 
 //-------------------------------------------------------------------------------------------------
-void MilesAudioManager::stopAllAmbientsBy( Object *obj )
-{
-
-}
-
-//-------------------------------------------------------------------------------------------------
-void MilesAudioManager::stopAllAmbientsBy( Drawable *draw )
-{
-
-}
-
-
-//-------------------------------------------------------------------------------------------------
 void MilesAudioManager::playAudioEvent( AudioEventRTS *event )
 {
 #ifdef INTENSIVE_AUDIO_DEBUG

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -4268,7 +4268,6 @@ void GameLogic::setGamePaused( Bool paused, Bool pauseMusic )
 		while( drawable )
 		{
 			drawable->startAmbientSound();
-			TheAudio->stopAllAmbientsBy( drawable );
 			drawable = drawable->getNextDrawable();
 		}
 #endif


### PR DESCRIPTION
**Merge by rebase**

This PR removes all instances of the empty ```stopAllAmbientsBy()``` functions and the functions definitions.

- Required For: #782 