### PR TITLE
[GEN][ZH] Implement multi instance support for the game client

### DIFF
--- a/Generals/Code/GameEngine/CMakeLists.txt
+++ b/Generals/Code/GameEngine/CMakeLists.txt
@@ -132,6 +132,7 @@ set(GAMEENGINE_SRC
     Include/GameClient/AnimateWindowManager.h
     Include/GameClient/CampaignManager.h
     Include/GameClient/CDCheck.h
+    Include/GameClient/ClientInstance.h
     Include/GameClient/ClientRandomValue.h
     Include/GameClient/Color.h
     Include/GameClient/CommandXlat.h
@@ -632,6 +633,7 @@ set(GAMEENGINE_SRC
     Source/Common/Thing/ThingTemplate.cpp
     Source/Common/UserPreferences.cpp
     Source/Common/version.cpp
+    Source/GameClient/ClientInstance.cpp
     Source/GameClient/Color.cpp
     Source/GameClient/Credits.cpp
     Source/GameClient/Display.cpp

--- a/Generals/Code/GameEngine/Include/GameClient/ClientInstance.h
+++ b/Generals/Code/GameEngine/Include/GameClient/ClientInstance.h
@@ -1,0 +1,47 @@
+/*
+**	Command & Conquer Generals Zero Hour(tm)
+**	Copyright 2025 TheSuperHackers
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "Lib/BaseType.h"
+
+namespace rts
+{
+
+// TheSuperHackers @feature Adds support for launching multiple game clients and keeping track of their instance id.
+
+class ClientInstance
+{
+public:
+	// Can be called N times, but is initialized just once.
+	static bool initialize();
+
+	static bool isInitialized();
+
+	// Returns the instance index of this game client. Starts at 0.
+	static UnsignedInt getInstanceIndex();
+
+	// Returns the instance id of this game client. Starts at 1.
+	static UnsignedInt getInstanceId();
+
+	// Returns the instance name of the first game client.
+	static const char* getFirstInstanceName();
+
+private:
+	static HANDLE s_mutexHandle;
+	static UnsignedInt s_instanceIndex;
+};
+
+} // namespace rts

--- a/Generals/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Recorder.cpp
@@ -30,6 +30,7 @@
 #include "Common/Player.h"
 #include "Common/GlobalData.h"
 #include "Common/GameEngine.h"
+#include "GameClient/ClientInstance.h"
 #include "GameClient/GameWindow.h"
 #include "GameClient/GameWindowManager.h"
 #include "GameClient/InGameUI.h"
@@ -1595,7 +1596,17 @@ AsciiString RecorderClass::getLastReplayFileName()
 		}
 	}
 #endif
-	return AsciiString(lastReplayFileName);
+
+	AsciiString filename;
+	if (rts::ClientInstance::getInstanceId() > 1u)
+	{
+		filename.format("%s_Instance%.2u", lastReplayFileName, rts::ClientInstance::getInstanceId());
+	}
+	else
+	{
+		filename = lastReplayFileName;
+	}
+	return filename;
 }
 
 /**

--- a/Generals/Code/GameEngine/Source/Common/System/Debug.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/Debug.cpp
@@ -364,7 +364,8 @@ void DebugInit(int flags)
 
 	#ifdef DEBUG_LOGGING
 
-		// Debug initialization can happen very early. Initialize the client instance now.
+		// TheSuperHackers @info Debug initialization can happen very early.
+		// Therefore, initialize the client instance now.
 		if (!rts::ClientInstance::initialize())
 			return;
 

--- a/Generals/Code/GameEngine/Source/Common/System/Debug.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/Debug.cpp
@@ -63,6 +63,7 @@
 #include "Common/Registry.h"
 #include "Common/SystemInfo.h"
 #include "Common/UnicodeString.h"
+#include "GameClient/ClientInstance.h"
 #include "GameClient/GameText.h"
 #include "GameClient/Keyboard.h"
 #include "GameClient/Mouse.h"
@@ -86,14 +87,14 @@ extern const char *gAppPrefix; /// So WB can have a different log file name.
 #ifdef DEBUG_LOGGING
 
 #if defined(RTS_INTERNAL)
-	#define DEBUG_FILE_NAME				"DebugLogFileI.txt"
-	#define DEBUG_FILE_NAME_PREV	"DebugLogFilePrevI.txt"
+	#define DEBUG_FILE_NAME				"DebugLogFileI"
+	#define DEBUG_FILE_NAME_PREV	"DebugLogFilePrevI"
 #elif defined(RTS_DEBUG)
-	#define DEBUG_FILE_NAME				"DebugLogFileD.txt"
-	#define DEBUG_FILE_NAME_PREV	"DebugLogFilePrevD.txt"
+	#define DEBUG_FILE_NAME				"DebugLogFileD"
+	#define DEBUG_FILE_NAME_PREV	"DebugLogFilePrevD"
 #else
-	#define DEBUG_FILE_NAME				"DebugLogFile.txt"
-	#define DEBUG_FILE_NAME_PREV	"DebugLogFilePrev.txt"
+	#define DEBUG_FILE_NAME				"DebugLogFile"
+	#define DEBUG_FILE_NAME_PREV	"DebugLogFilePrev"
 #endif
 
 #endif
@@ -363,6 +364,10 @@ void DebugInit(int flags)
 
 	#ifdef DEBUG_LOGGING
 
+		// Debug initialization can happen very early. Initialize the client instance now.
+		if (!rts::ClientInstance::initialize())
+			return;
+
 		char dirbuf[ _MAX_PATH ];
 		::GetModuleFileName( NULL, dirbuf, sizeof( dirbuf ) );
 		char *pEnd = dirbuf + strlen( dirbuf );
@@ -379,10 +384,16 @@ void DebugInit(int flags)
 		strcpy(theLogFileNamePrev, dirbuf);
 		strcat(theLogFileNamePrev, gAppPrefix);
 		strcat(theLogFileNamePrev, DEBUG_FILE_NAME_PREV);
+		if (rts::ClientInstance::getInstanceId() > 1u)
+			sprintf(theLogFileNamePrev + strlen(theLogFileNamePrev), "_Instance%.2u", rts::ClientInstance::getInstanceId());
+		strcat(theLogFileNamePrev, ".txt");
 
 		strcpy(theLogFileName, dirbuf);
 		strcat(theLogFileName, gAppPrefix);
 		strcat(theLogFileName, DEBUG_FILE_NAME);
+		if (rts::ClientInstance::getInstanceId() > 1u)
+			sprintf(theLogFileName + strlen(theLogFileName), "_Instance%.2u", rts::ClientInstance::getInstanceId());
+		strcat(theLogFileName, ".txt");
 
 		remove(theLogFileNamePrev);
 		rename(theLogFileName, theLogFileNamePrev);

--- a/Generals/Code/GameEngine/Source/GameClient/ClientInstance.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/ClientInstance.cpp
@@ -1,0 +1,99 @@
+/*
+**	Command & Conquer Generals Zero Hour(tm)
+**	Copyright 2025 TheSuperHackers
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "PreRTS.h"
+#include "GameClient/ClientInstance.h"
+
+#define GENERALS_GUID "685EAFF2-3216-4265-B047-251C5F4B82F3"
+
+namespace rts
+{
+HANDLE ClientInstance::s_mutexHandle = NULL;
+UnsignedInt ClientInstance::s_instanceIndex = 0;
+
+bool ClientInstance::initialize()
+{
+	if (isInitialized())
+	{
+		return true;
+	}
+
+	// Create a mutex with a unique name to Generals in order to determine if our app is already running.
+	// WARNING: DO NOT use this number for any other application except Generals.
+	while (true)
+	{
+#if RTS_MULTI_INSTANCE
+		std::string guidStr = getFirstInstanceName();
+		if (s_instanceIndex > 0u)
+		{
+			char idStr[33];
+			itoa(s_instanceIndex, idStr, 10);
+			guidStr.push_back('-');
+			guidStr.append(idStr);
+		}
+		s_mutexHandle = CreateMutex(NULL, FALSE, guidStr.c_str());
+		if (GetLastError() == ERROR_ALREADY_EXISTS)
+		{
+			if (s_mutexHandle != NULL)
+			{
+				CloseHandle(s_mutexHandle);
+				s_mutexHandle = NULL;
+			}
+			// Try again with a new instance.
+			++s_instanceIndex;
+			continue;
+		}
+#else
+		s_mutexHandle = CreateMutex(NULL, FALSE, getFirstInstanceName());
+		if (GetLastError() == ERROR_ALREADY_EXISTS)
+		{
+			if (s_mutexHandle != NULL)
+			{
+				CloseHandle(s_mutexHandle);
+				s_mutexHandle = NULL;
+			}
+			return false;
+		}
+#endif
+		break;
+	}
+
+	return true;
+}
+
+bool ClientInstance::isInitialized()
+{
+	return s_mutexHandle != NULL;
+}
+
+UnsignedInt ClientInstance::getInstanceIndex()
+{
+	DEBUG_ASSERTLOG(!isInitialized(), ("ClientInstance::isInitialized() failed"));
+	return s_instanceIndex;
+}
+
+UnsignedInt ClientInstance::getInstanceId()
+{
+	return getInstanceIndex() + 1;
+}
+
+const char* ClientInstance::getFirstInstanceName()
+{
+	return GENERALS_GUID;
+}
+
+} // namespace rts

--- a/Generals/Code/GameEngine/Source/GameClient/ClientInstance.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/ClientInstance.cpp
@@ -36,7 +36,7 @@ bool ClientInstance::initialize()
 	// WARNING: DO NOT use this number for any other application except Generals.
 	while (true)
 	{
-#if RTS_MULTI_INSTANCE
+#ifdef RTS_MULTI_INSTANCE
 		std::string guidStr = getFirstInstanceName();
 		if (s_instanceIndex > 0u)
 		{

--- a/Generals/Code/GameEngine/Source/GameClient/GameText.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GameText.cpp
@@ -48,6 +48,7 @@
 #include "GameClient/GameText.h"
 #include "Common/Language.h"
 #include "Common/Registry.h"
+#include "GameClient/ClientInstance.h"
 #include "GameClient/LanguageFilter.h"
 #include "Common/Debug.h"
 #include "Common/UnicodeString.h"
@@ -370,6 +371,14 @@ void GameTextManager::init( void )
 	qsort( m_stringLUT, m_textCount, sizeof(StringLookUp), compareLUT  );
 
 	UnicodeString ourName = fetch("GUI:Command&ConquerGenerals");
+
+	if (rts::ClientInstance::getInstanceId() > 1u)
+	{
+		UnicodeString s;
+		s.format(L"Instance:%.2u - %s", rts::ClientInstance::getInstanceId(), ourName.str());
+		ourName = s;
+	}
+
 	extern HWND ApplicationHWnd;  ///< our application window handle
 	if (ApplicationHWnd) {
 		::SetWindowTextW(ApplicationHWnd, ourName.str());

--- a/GeneralsMD/Code/GameEngine/CMakeLists.txt
+++ b/GeneralsMD/Code/GameEngine/CMakeLists.txt
@@ -139,6 +139,7 @@ set(GAMEENGINE_SRC
     Include/GameClient/CampaignManager.h
     Include/GameClient/CDCheck.h
     Include/GameClient/ChallengeGenerals.h
+    Include/GameClient/ClientInstance.h
     Include/GameClient/ClientRandomValue.h
     Include/GameClient/Color.h
     Include/GameClient/CommandXlat.h
@@ -676,6 +677,7 @@ set(GAMEENGINE_SRC
     Source/Common/Thing/ThingTemplate.cpp
     Source/Common/UserPreferences.cpp
     Source/Common/version.cpp
+    Source/GameClient/ClientInstance.cpp
     Source/GameClient/Color.cpp
     Source/GameClient/Credits.cpp
     Source/GameClient/Display.cpp

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/ClientInstance.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/ClientInstance.h
@@ -30,10 +30,11 @@ public:
 
 	static bool isInitialized();
 
-	// Returns the instance if of this game client.
+	// Returns the instance id of this game client.
 	static UnsignedInt getInstanceId();
 
-	static const char* getInstanceName();
+	// Returns the instance name of the first game client.
+	static const char* getFirstInstanceName();
 
 private:
 	static HANDLE s_mutexHandle;

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/ClientInstance.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/ClientInstance.h
@@ -30,7 +30,10 @@ public:
 
 	static bool isInitialized();
 
-	// Returns the instance id of this game client.
+	// Returns the instance index of this game client. Starts at 0.
+	static UnsignedInt getInstanceIndex();
+
+	// Returns the instance id of this game client. Starts at 1.
 	static UnsignedInt getInstanceId();
 
 	// Returns the instance name of the first game client.
@@ -38,7 +41,7 @@ public:
 
 private:
 	static HANDLE s_mutexHandle;
-	static UnsignedInt s_instanceId;
+	static UnsignedInt s_instanceIndex;
 };
 
 } // namespace rts

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/ClientInstance.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/ClientInstance.h
@@ -1,0 +1,43 @@
+/*
+**	Command & Conquer Generals Zero Hour(tm)
+**	Copyright 2025 TheSuperHackers
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "Lib/BaseType.h"
+
+namespace rts
+{
+
+// TheSuperHackers @feature Adds support for launching multiple game clients and keeping track of their instance id.
+
+class ClientInstance
+{
+public:
+	// Can be called N times, but is initialized just once.
+	static bool initialize();
+
+	static bool isInitialized();
+
+	// Returns the instance if of this game client.
+	static UnsignedInt getInstanceId();
+
+	static const char* getInstanceName();
+
+private:
+	static HANDLE s_mutexHandle;
+	static UnsignedInt s_instanceId;
+};
+
+} // namespace rts

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -1601,9 +1601,9 @@ AsciiString RecorderClass::getLastReplayFileName()
 #endif
 
 	AsciiString filename;
-	if (rts::ClientInstance::getInstanceId() > 0u)
+	if (rts::ClientInstance::getInstanceId() > 1u)
 	{
-		filename.format("%s_id%u", lastReplayFileName, rts::ClientInstance::getInstanceId());
+		filename.format("%s_Instance%u", lastReplayFileName, rts::ClientInstance::getInstanceId());
 	}
 	else
 	{

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -30,6 +30,7 @@
 #include "Common/Player.h"
 #include "Common/GlobalData.h"
 #include "Common/GameEngine.h"
+#include "GameClient/ClientInstance.h"
 #include "GameClient/GameWindow.h"
 #include "GameClient/GameWindowManager.h"
 #include "GameClient/InGameUI.h"
@@ -1598,7 +1599,13 @@ AsciiString RecorderClass::getLastReplayFileName()
 		}
 	}
 #endif
-	return AsciiString(lastReplayFileName);
+	AsciiString filename = lastReplayFileName;
+
+	if (rts::ClientInstance::getInstanceId() > 0u)
+	{
+		filename.format("%s_Instance%u", lastReplayFileName, rts::ClientInstance::getInstanceId());
+	}
+	return filename;
 }
 
 /**

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -1599,11 +1599,15 @@ AsciiString RecorderClass::getLastReplayFileName()
 		}
 	}
 #endif
-	AsciiString filename = lastReplayFileName;
 
+	AsciiString filename;
 	if (rts::ClientInstance::getInstanceId() > 0u)
 	{
-		filename.format("%s_Instance%u", lastReplayFileName, rts::ClientInstance::getInstanceId());
+		filename.format("%s_id%u", lastReplayFileName, rts::ClientInstance::getInstanceId());
+	}
+	else
+	{
+		filename = lastReplayFileName;
 	}
 	return filename;
 }

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -1603,7 +1603,7 @@ AsciiString RecorderClass::getLastReplayFileName()
 	AsciiString filename;
 	if (rts::ClientInstance::getInstanceId() > 1u)
 	{
-		filename.format("%s_Instance%u", lastReplayFileName, rts::ClientInstance::getInstanceId());
+		filename.format("%s_Instance%.2u", lastReplayFileName, rts::ClientInstance::getInstanceId());
 	}
 	else
 	{

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/Debug.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/Debug.cpp
@@ -386,14 +386,14 @@ void DebugInit(int flags)
 		strcat(theLogFileNamePrev, gAppPrefix);
 		strcat(theLogFileNamePrev, DEBUG_FILE_NAME_PREV);
 		if (rts::ClientInstance::getInstanceId() > 1u)
-			sprintf(theLogFileNamePrev + strlen(theLogFileNamePrev), "_Instance%u", rts::ClientInstance::getInstanceId());
+			sprintf(theLogFileNamePrev + strlen(theLogFileNamePrev), "_Instance%.2u", rts::ClientInstance::getInstanceId());
 		strcat(theLogFileNamePrev, ".txt");
 
 		strcpy(theLogFileName, dirbuf);
 		strcat(theLogFileName, gAppPrefix);
 		strcat(theLogFileName, DEBUG_FILE_NAME);
 		if (rts::ClientInstance::getInstanceId() > 1u)
-			sprintf(theLogFileName + strlen(theLogFileName), "_Instance%u", rts::ClientInstance::getInstanceId());
+			sprintf(theLogFileName + strlen(theLogFileName), "_Instance%.2u", rts::ClientInstance::getInstanceId());
 		strcat(theLogFileName, ".txt");
 
 		remove(theLogFileNamePrev);

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/Debug.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/Debug.cpp
@@ -62,6 +62,7 @@
 #include "Common/CRCDebug.h"
 #include "Common/SystemInfo.h"
 #include "Common/UnicodeString.h"
+#include "GameClient/ClientInstance.h"
 #include "GameClient/GameText.h"
 #include "GameClient/Keyboard.h"
 #include "GameClient/Mouse.h"
@@ -87,14 +88,14 @@ extern const char *gAppPrefix; /// So WB can have a different log file name.
 #ifdef DEBUG_LOGGING
 
 #if defined(RTS_INTERNAL)
-	#define DEBUG_FILE_NAME				"DebugLogFileI.txt"
-	#define DEBUG_FILE_NAME_PREV	"DebugLogFilePrevI.txt"
+	#define DEBUG_FILE_NAME				"DebugLogFileI"
+	#define DEBUG_FILE_NAME_PREV	"DebugLogFilePrevI"
 #elif defined(RTS_DEBUG)
-	#define DEBUG_FILE_NAME				"DebugLogFileD.txt"
-	#define DEBUG_FILE_NAME_PREV	"DebugLogFilePrevD.txt"
+	#define DEBUG_FILE_NAME				"DebugLogFileD"
+	#define DEBUG_FILE_NAME_PREV	"DebugLogFilePrevD"
 #else
-	#define DEBUG_FILE_NAME				"DebugLogFile.txt"
-	#define DEBUG_FILE_NAME_PREV	"DebugLogFilePrev.txt"
+	#define DEBUG_FILE_NAME				"DebugLogFile"
+	#define DEBUG_FILE_NAME_PREV	"DebugLogFilePrev"
 #endif
 
 #endif
@@ -363,6 +364,10 @@ void DebugInit(int flags)
 		theMainThreadID = GetCurrentThreadId();
 
 	#ifdef DEBUG_LOGGING
+
+		// Debug initialization can happen very early. Initialize the client instance now.
+		if (!rts::ClientInstance::initialize())
+			return;
 
 		char dirbuf[ _MAX_PATH ];
 		::GetModuleFileName( NULL, dirbuf, sizeof( dirbuf ) );

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/Debug.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/Debug.cpp
@@ -365,7 +365,8 @@ void DebugInit(int flags)
 
 	#ifdef DEBUG_LOGGING
 
-		// Debug initialization can happen very early. Initialize the client instance now.
+		// TheSuperHackers @info Debug initialization can happen very early.
+		// Therefore, initialize the client instance now.
 		if (!rts::ClientInstance::initialize())
 			return;
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/Debug.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/Debug.cpp
@@ -385,10 +385,16 @@ void DebugInit(int flags)
 		strcpy(theLogFileNamePrev, dirbuf);
 		strcat(theLogFileNamePrev, gAppPrefix);
 		strcat(theLogFileNamePrev, DEBUG_FILE_NAME_PREV);
+		if (rts::ClientInstance::getInstanceId() > 1u)
+			sprintf(theLogFileNamePrev + strlen(theLogFileNamePrev), "_Instance%u", rts::ClientInstance::getInstanceId());
+		strcat(theLogFileNamePrev, ".txt");
 
 		strcpy(theLogFileName, dirbuf);
 		strcat(theLogFileName, gAppPrefix);
 		strcat(theLogFileName, DEBUG_FILE_NAME);
+		if (rts::ClientInstance::getInstanceId() > 1u)
+			sprintf(theLogFileName + strlen(theLogFileName), "_Instance%u", rts::ClientInstance::getInstanceId());
+		strcat(theLogFileName, ".txt");
 
 		remove(theLogFileNamePrev);
 		rename(theLogFileName, theLogFileNamePrev);

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/ClientInstance.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/ClientInstance.cpp
@@ -37,7 +37,7 @@ bool ClientInstance::initialize()
 	while (true)
 	{
 #if RTS_MULTI_INSTANCE
-		std::string guidStr = getInstanceName();
+		std::string guidStr = getFirstInstanceName();
 		if (s_instanceId > 0u)
 		{
 			char idStr[33];
@@ -58,7 +58,7 @@ bool ClientInstance::initialize()
 			continue;
 		}
 #else
-		s_mutexHandle = CreateMutex(NULL, FALSE, getInstanceName());
+		s_mutexHandle = CreateMutex(NULL, FALSE, getFirstInstanceName());
 		if (GetLastError() == ERROR_ALREADY_EXISTS)
 		{
 			if (s_mutexHandle != NULL)
@@ -86,7 +86,7 @@ UnsignedInt ClientInstance::getInstanceId()
 	return s_instanceId;
 }
 
-const char* ClientInstance::getInstanceName()
+const char* ClientInstance::getFirstInstanceName()
 {
 	return GENERALS_GUID;
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/ClientInstance.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/ClientInstance.cpp
@@ -36,7 +36,7 @@ bool ClientInstance::initialize()
 	// WARNING: DO NOT use this number for any other application except Generals.
 	while (true)
 	{
-#if RTS_MULTI_INSTANCE
+#ifdef RTS_MULTI_INSTANCE
 		std::string guidStr = getFirstInstanceName();
 		if (s_instanceIndex > 0u)
 		{

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/ClientInstance.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/ClientInstance.cpp
@@ -1,0 +1,94 @@
+/*
+**	Command & Conquer Generals Zero Hour(tm)
+**	Copyright 2025 TheSuperHackers
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "PreRTS.h"
+#include "GameClient/ClientInstance.h"
+
+#define GENERALS_GUID "685EAFF2-3216-4265-B047-251C5F4B82F3"
+
+namespace rts
+{
+HANDLE ClientInstance::s_mutexHandle = NULL;
+UnsignedInt ClientInstance::s_instanceId = 0;
+
+bool ClientInstance::initialize()
+{
+	if (isInitialized())
+	{
+		return true;
+	}
+
+	// Create a mutex with a unique name to Generals in order to determine if our app is already running.
+	// WARNING: DO NOT use this number for any other application except Generals.
+	while (true)
+	{
+#if RTS_MULTI_INSTANCE
+		std::string guidStr = getInstanceName();
+		if (s_instanceId > 0u)
+		{
+			char idStr[33];
+			itoa(s_instanceId, idStr, 10);
+			guidStr.push_back('-');
+			guidStr.append(idStr);
+		}
+		s_mutexHandle = CreateMutex(NULL, FALSE, guidStr.c_str());
+		if (GetLastError() == ERROR_ALREADY_EXISTS)
+		{
+			if (s_mutexHandle != NULL)
+			{
+				CloseHandle(s_mutexHandle);
+				s_mutexHandle = NULL;
+			}
+			// Try again with a new instance.
+			++s_instanceId;
+			continue;
+		}
+#else
+		s_mutexHandle = CreateMutex(NULL, FALSE, getInstanceName());
+		if (GetLastError() == ERROR_ALREADY_EXISTS)
+		{
+			if (s_mutexHandle != NULL)
+			{
+				CloseHandle(s_mutexHandle);
+				s_mutexHandle = NULL;
+			}
+			return false;
+		}
+#endif
+		break;
+	}
+
+	return true;
+}
+
+bool ClientInstance::isInitialized()
+{
+	return s_mutexHandle != NULL;
+}
+
+UnsignedInt ClientInstance::getInstanceId()
+{
+	DEBUG_ASSERTLOG(!isInitialized(), ("ClientInstance::isInitialized() failed"));
+	return s_instanceId;
+}
+
+const char* ClientInstance::getInstanceName()
+{
+	return GENERALS_GUID;
+}
+
+} // namespace rts

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/ClientInstance.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/ClientInstance.cpp
@@ -23,7 +23,7 @@
 namespace rts
 {
 HANDLE ClientInstance::s_mutexHandle = NULL;
-UnsignedInt ClientInstance::s_instanceId = 0;
+UnsignedInt ClientInstance::s_instanceIndex = 0;
 
 bool ClientInstance::initialize()
 {
@@ -38,10 +38,10 @@ bool ClientInstance::initialize()
 	{
 #if RTS_MULTI_INSTANCE
 		std::string guidStr = getFirstInstanceName();
-		if (s_instanceId > 0u)
+		if (s_instanceIndex > 0u)
 		{
 			char idStr[33];
-			itoa(s_instanceId, idStr, 10);
+			itoa(s_instanceIndex, idStr, 10);
 			guidStr.push_back('-');
 			guidStr.append(idStr);
 		}
@@ -54,7 +54,7 @@ bool ClientInstance::initialize()
 				s_mutexHandle = NULL;
 			}
 			// Try again with a new instance.
-			++s_instanceId;
+			++s_instanceIndex;
 			continue;
 		}
 #else
@@ -80,10 +80,15 @@ bool ClientInstance::isInitialized()
 	return s_mutexHandle != NULL;
 }
 
-UnsignedInt ClientInstance::getInstanceId()
+UnsignedInt ClientInstance::getInstanceIndex()
 {
 	DEBUG_ASSERTLOG(!isInitialized(), ("ClientInstance::isInitialized() failed"));
-	return s_instanceId;
+	return s_instanceIndex;
+}
+
+UnsignedInt ClientInstance::getInstanceId()
+{
+	return getInstanceIndex() + 1;
 }
 
 const char* ClientInstance::getFirstInstanceName()

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GameText.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GameText.cpp
@@ -375,7 +375,7 @@ void GameTextManager::init( void )
 	if (rts::ClientInstance::getInstanceId() > 1u)
 	{
 		UnicodeString s;
-		s.format(L"Instance%u - %s", rts::ClientInstance::getInstanceId(), ourName.str());
+		s.format(L"Instance:%.2u - %s", rts::ClientInstance::getInstanceId(), ourName.str());
 		ourName = s;
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GameText.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GameText.cpp
@@ -48,6 +48,7 @@
 #include "GameClient/GameText.h"
 #include "Common/Language.h"
 #include "Common/Registry.h"
+#include "GameClient/ClientInstance.h"
 #include "GameClient/LanguageFilter.h"
 #include "Common/Debug.h"
 #include "Common/UnicodeString.h"
@@ -370,6 +371,14 @@ void GameTextManager::init( void )
 	qsort( m_stringLUT, m_textCount, sizeof(StringLookUp), compareLUT  );
 
 	UnicodeString ourName = fetch("GUI:Command&ConquerGenerals");
+
+	if (rts::ClientInstance::getInstanceId() > 0u)
+	{
+		UnicodeString instanceStr;
+		instanceStr.format(L" - Instance:%u", rts::ClientInstance::getInstanceId());
+		ourName.concat(instanceStr.str());
+	}
+
 	AsciiString ourNameA;
 	ourNameA.translate(ourName);	//get ASCII version for Win 9x
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GameText.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GameText.cpp
@@ -372,10 +372,10 @@ void GameTextManager::init( void )
 
 	UnicodeString ourName = fetch("GUI:Command&ConquerGenerals");
 
-	if (rts::ClientInstance::getInstanceId() > 0u)
+	if (rts::ClientInstance::getInstanceId() > 1u)
 	{
 		UnicodeString s;
-		s.format(L"id:%u - %s", rts::ClientInstance::getInstanceId(), ourName.str());
+		s.format(L"Instance%u - %s", rts::ClientInstance::getInstanceId(), ourName.str());
 		ourName = s;
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GameText.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GameText.cpp
@@ -374,9 +374,9 @@ void GameTextManager::init( void )
 
 	if (rts::ClientInstance::getInstanceId() > 0u)
 	{
-		UnicodeString instanceStr;
-		instanceStr.format(L" - Instance:%u", rts::ClientInstance::getInstanceId());
-		ourName.concat(instanceStr.str());
+		UnicodeString s;
+		s.format(L"id:%u - %s", rts::ClientInstance::getInstanceId(), ourName.str());
+		ourName = s;
 	}
 
 	AsciiString ourNameA;

--- a/GeneralsMD/Code/Main/WinMain.cpp
+++ b/GeneralsMD/Code/Main/WinMain.cpp
@@ -991,7 +991,7 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 
 		if (!rts::ClientInstance::initialize())
 		{
-			HWND ccwindow = FindWindow(rts::ClientInstance::getInstanceName(), NULL);
+			HWND ccwindow = FindWindow(rts::ClientInstance::getFirstInstanceName(), NULL);
 			if (ccwindow)
 			{
 				SetForegroundWindow(ccwindow);

--- a/GeneralsMD/Code/Main/WinMain.cpp
+++ b/GeneralsMD/Code/Main/WinMain.cpp
@@ -54,6 +54,7 @@
 #include "Common/MessageStream.h"
 #include "Common/Registry.h"
 #include "Common/Team.h"
+#include "GameClient/ClientInstance.h"
 #include "GameClient/InGameUI.h"
 #include "GameClient/GameClient.h"
 #include "GameLogic/GameLogic.h"  ///< @todo for demo, remove
@@ -86,8 +87,6 @@ const Char *g_strFile = "data\\Generals.str";
 const Char *g_csfFile = "data\\%s\\Generals.csf";
 const char *gAppPrefix = ""; /// So WB can have a different debug log file name.
 
-static HANDLE GeneralsMutex = NULL;
-#define GENERALS_GUID "685EAFF2-3216-4265-B047-251C5F4B82F3"
 #define DEFAULT_XRESOLUTION 800
 #define DEFAULT_YRESOLUTION 600
 
@@ -988,22 +987,15 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 #endif
 
 
-		//Create a mutex with a unique name to Generals in order to determine if
-		//our app is already running.
-		//WARNING: DO NOT use this number for any other application except Generals.
-		GeneralsMutex = CreateMutex(NULL, FALSE, GENERALS_GUID);
-		if (GetLastError() == ERROR_ALREADY_EXISTS)
+		// TheSuperHackers @refactor The instance mutex now lives in its own class.
+
+		if (!rts::ClientInstance::initialize())
 		{
-			HWND ccwindow = FindWindow(GENERALS_GUID, NULL);
+			HWND ccwindow = FindWindow(rts::ClientInstance::getInstanceName(), NULL);
 			if (ccwindow)
 			{
 				SetForegroundWindow(ccwindow);
 				ShowWindow(ccwindow, SW_RESTORE);
-			}
-			if (GeneralsMutex != NULL)
-			{
-				CloseHandle(GeneralsMutex);
-				GeneralsMutex = NULL;
 			}
 
 			DEBUG_LOG(("Generals is already running...Bail!\n"));
@@ -1013,7 +1005,7 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 			DEBUG_SHUTDOWN();
 			return 0;
 		}
-		DEBUG_LOG(("Create GeneralsMutex okay.\n"));
+		DEBUG_LOG(("Create Generals Mutex okay.\n"));
 
 #ifdef DO_COPY_PROTECTION
 		if (!CopyProtect::notifyLauncher())

--- a/cmake/config-debug.cmake
+++ b/cmake/config-debug.cmake
@@ -10,7 +10,8 @@ set_property(CACHE RTS_DEBUG_STACKTRACE PROPERTY STRINGS DEFAULT ON OFF)
 set(RTS_DEBUG_PROFILE "DEFAULT" CACHE STRING "Enables debug profiling. When DEFAULT, this option is enabled with DEBUG or INTERNAL")
 set_property(CACHE RTS_DEBUG_PROFILE PROPERTY STRINGS DEFAULT ON OFF)
 
-option(RTS_DEBUG_INCLUDE_DEBUG_LOG_IN_CRC_LOG "Include normal debug log in crc log" OFF)
+option(RTS_DEBUG_INCLUDE_DEBUG_LOG_IN_CRC_LOG "Includes normal debug log in crc log" OFF)
+option(RTS_DEBUG_MULTI_INSTANCE "Enables multi client instance support" OFF)
 
 
 # Helper macro that handles DEFAULT ON OFF options
@@ -35,8 +36,13 @@ define_debug_option(RTS_DEBUG_STACKTRACE DEBUG_STACKTRACE DISABLE_DEBUG_STACKTRA
 define_debug_option(RTS_DEBUG_PROFILE    DEBUG_PROFILE    DISABLE_DEBUG_PROFILE    DebugProfile    "Build with Debug Profiling")
 
 add_feature_info(DebugIncludeDebugLogInCrcLog RTS_DEBUG_INCLUDE_DEBUG_LOG_IN_CRC_LOG "Build with Debug Logging in CRC log")
+add_feature_info(DebugMultiInstance RTS_DEBUG_MULTI_INSTANCE "Build with Multi Client Instance support")
 
 
 if(RTS_DEBUG_INCLUDE_DEBUG_LOG_IN_CRC_LOG)
     target_compile_definitions(core_config INTERFACE INCLUDE_DEBUG_LOG_IN_CRC_LOG)
+endif()
+
+if(RTS_DEBUG_MULTI_INSTANCE)
+    target_compile_definitions(core_config INTERFACE RTS_MULTI_INSTANCE)
 endif()


### PR DESCRIPTION
* Relates to #407

This change adds multi instance support for debugging and testing. Accessible in cmake with the RTS_DEBUG_MULTI_INSTANCE option. It is turned off by default. When turned off, the game behaves as usual. When turned on, the game clients can do the following:

1. More than one game client can be launched
2. The instance id will be appended to the game window title for clients 2..N
3. The instance id will be appended to the log file names for clients 2..N
4. The instance id will be appended to the replay file names for clients 2..N

## TODO

- [x] Replicate in Generals

Replicated with
```
git diff ce5d683582389c63d05fd370390059a301672d2e..06e5179db50763d8a2466c2f16dcc746024bf29e > changes.patch
git apply -p2 --directory=Generals --reject --whitespace=fix changes.patch
```