### PR TITLE
[GEN][ZH] Fix and simplify the use of the log file in RecorderClass

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/Debug.h
+++ b/Generals/Code/GameEngine/Include/Common/Debug.h
@@ -148,6 +148,8 @@ class AsciiString;
 #ifdef DEBUG_LOGGING
 
 	DEBUG_EXTERN_C void DebugLog(const char *format, ...);
+	DEBUG_EXTERN_C const char* DebugGetLogFileName();
+	DEBUG_EXTERN_C const char* DebugGetLogFileNamePrev();
 
 	// This defines a bitmask of log types that we care about, to allow some flexability
 	// in what gets logged.  This should be extended to asserts, too, but the assert box

--- a/Generals/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Recorder.cpp
@@ -282,19 +282,6 @@ void RecorderClass::logGameEnd( void )
 #endif
 }
 
-#ifdef DEBUG_LOGGING
-	#if defined(RTS_INTERNAL)
-		#define DEBUG_FILE_NAME				"DebugLogFileI.txt"
-		#define DEBUG_FILE_NAME_PREV	"DebugLogFilePrevI.txt"
-	#elif defined(RTS_DEBUG)
-		#define DEBUG_FILE_NAME				"DebugLogFileD.txt"
-		#define DEBUG_FILE_NAME_PREV	"DebugLogFilePrevD.txt"
-	#else
-		#define DEBUG_FILE_NAME				"DebugLogFile.txt"
-		#define DEBUG_FILE_NAME_PREV	"DebugLogFilePrev.txt"
-	#endif
-#endif
-
 void RecorderClass::cleanUpReplayFile( void )
 {
 #if defined(RTS_DEBUG) || defined(RTS_INTERNAL)
@@ -307,14 +294,18 @@ void RecorderClass::cleanUpReplayFile( void )
 		AsciiString oldFname;
 		oldFname.format("%s%s", getReplayDir().str(), m_fileName.str());
 		CopyFile(oldFname.str(), fname, TRUE);
-#ifdef DEBUG_FILE_NAME
+
+		const char* logFileName = DebugGetLogFileName();
+		if (logFileName[0] == '\0')
+			return;
+
 		AsciiString debugFname = fname;
 		debugFname.removeLastChar();
 		debugFname.removeLastChar();
 		debugFname.removeLastChar();
 		debugFname.concat("txt");
 		UnsignedInt fileSize = 0;
-		FILE *fp = fopen(DEBUG_FILE_NAME, "rb");
+		FILE *fp = fopen(logFileName, "rb");
 		if (fp)
 		{
 			fseek(fp, 0, SEEK_END);
@@ -327,13 +318,13 @@ void RecorderClass::cleanUpReplayFile( void )
 		const int MAX_DEBUG_SIZE = 65536;
 		if (fileSize <= MAX_DEBUG_SIZE || TheGlobalData->m_saveAllStats)
 		{
-			DEBUG_LOG(("Using CopyFile to copy %s\n", DEBUG_FILE_NAME));
-			CopyFile(DEBUG_FILE_NAME, debugFname.str(), TRUE);
+			DEBUG_LOG(("Using CopyFile to copy %s\n", logFileName));
+			CopyFile(logFileName, debugFname.str(), TRUE);
 		}
 		else
 		{
-			DEBUG_LOG(("manual copy of %s\n", DEBUG_FILE_NAME));
-			FILE *ifp = fopen(DEBUG_FILE_NAME, "rb");
+			DEBUG_LOG(("manual copy of %s\n", logFileName));
+			FILE *ifp = fopen(logFileName, "rb");
 			FILE *ofp = fopen(debugFname.str(), "wb");
 			if (ifp && ofp)
 			{
@@ -357,7 +348,6 @@ void RecorderClass::cleanUpReplayFile( void )
 				ofp = NULL;
 			}
 		}
-#endif // DEBUG_FILE_NAME
 	}
 #endif
 }

--- a/Generals/Code/GameEngine/Source/Common/System/Debug.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/Debug.cpp
@@ -105,8 +105,12 @@ extern const char *gAppPrefix; /// So WB can have a different log file name.
 // ----------------------------------------------------------------------------
 // PRIVATE DATA 
 // ----------------------------------------------------------------------------
+// TheSuperHackers @info Must not use static RAII types when set in DebugInit,
+// because DebugInit can be called during static module initialization before the main function is called.
 #ifdef DEBUG_LOGGING
 static FILE *theLogFile = NULL;
+static char theLogFileName[ _MAX_PATH ];
+static char theLogFileNamePrev[ _MAX_PATH ];
 #endif
 #define LARGE_BUFFER	8192
 static char theBuffer[ LARGE_BUFFER ];	// make it big to avoid weird overflow bugs in debug mode
@@ -372,22 +376,20 @@ void DebugInit(int flags)
 			pEnd--;
 		}
 
-		char prevbuf[ _MAX_PATH ];
-		char curbuf[ _MAX_PATH ];
+		strcpy(theLogFileNamePrev, dirbuf);
+		strcat(theLogFileNamePrev, gAppPrefix);
+		strcat(theLogFileNamePrev, DEBUG_FILE_NAME_PREV);
 
-		strcpy(prevbuf, dirbuf);
-		strcat(prevbuf, gAppPrefix);
-		strcat(prevbuf, DEBUG_FILE_NAME_PREV);
-		strcpy(curbuf, dirbuf);
-		strcat(curbuf, gAppPrefix);
-		strcat(curbuf, DEBUG_FILE_NAME);
+		strcpy(theLogFileName, dirbuf);
+		strcat(theLogFileName, gAppPrefix);
+		strcat(theLogFileName, DEBUG_FILE_NAME);
 
- 		remove(prevbuf);
-		rename(curbuf, prevbuf);
-		theLogFile = fopen(curbuf, "w");
+		remove(theLogFileNamePrev);
+		rename(theLogFileName, theLogFileNamePrev);
+		theLogFile = fopen(theLogFileName, "w");
 		if (theLogFile != NULL)
 		{
-			DebugLog("Log %s opened: %s\n", curbuf, getCurrentTimeString());
+			DebugLog("Log %s opened: %s\n", theLogFileName, getCurrentTimeString());
 		} 
 	#endif
 	}
@@ -424,6 +426,17 @@ void DebugLog(const char *format, ...)
 	whackFunnyCharacters(theBuffer);
 	doLogOutput(theBuffer);
 } 
+
+const char* DebugGetLogFileName()
+{
+	return theLogFileName;
+}
+
+const char* DebugGetLogFileNamePrev()
+{
+	return theLogFileNamePrev;
+}
+
 #endif
 
 // ----------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Include/Common/Debug.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Debug.h
@@ -154,6 +154,8 @@ class AsciiString;
 #ifdef DEBUG_LOGGING
 
 	DEBUG_EXTERN_C void DebugLog(const char *format, ...);
+	DEBUG_EXTERN_C const char* DebugGetLogFileName();
+	DEBUG_EXTERN_C const char* DebugGetLogFileNamePrev();
 
 	// This defines a bitmask of log types that we care about, to allow some flexability
 	// in what gets logged.  This should be extended to asserts, too, but the assert box

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -282,19 +282,6 @@ void RecorderClass::logGameEnd( void )
 #endif
 }
 
-#ifdef DEBUG_LOGGING
-	#if defined(RTS_INTERNAL)
-		#define DEBUG_FILE_NAME				"DebugLogFileI.txt"
-		#define DEBUG_FILE_NAME_PREV	"DebugLogFilePrevI.txt"
-	#elif defined(RTS_DEBUG)
-		#define DEBUG_FILE_NAME				"DebugLogFileD.txt"
-		#define DEBUG_FILE_NAME_PREV	"DebugLogFilePrevD.txt"
-	#else
-		#define DEBUG_FILE_NAME				"DebugLogFile.txt"
-		#define DEBUG_FILE_NAME_PREV	"DebugLogFilePrev.txt"
-	#endif
-#endif
-
 void RecorderClass::cleanUpReplayFile( void )
 {
 #if defined(RTS_DEBUG) || defined(RTS_INTERNAL)
@@ -307,14 +294,18 @@ void RecorderClass::cleanUpReplayFile( void )
 		AsciiString oldFname;
 		oldFname.format("%s%s", getReplayDir().str(), m_fileName.str());
 		CopyFile(oldFname.str(), fname, TRUE);
-#ifdef DEBUG_FILE_NAME
+
+		const char* logFileName = DebugGetLogFileName();
+		if (logFileName[0] == '\0')
+			return;
+
 		AsciiString debugFname = fname;
 		debugFname.removeLastChar();
 		debugFname.removeLastChar();
 		debugFname.removeLastChar();
 		debugFname.concat("txt");
 		UnsignedInt fileSize = 0;
-		FILE *fp = fopen(DEBUG_FILE_NAME, "rb");
+		FILE *fp = fopen(logFileName, "rb");
 		if (fp)
 		{
 			fseek(fp, 0, SEEK_END);
@@ -327,13 +318,13 @@ void RecorderClass::cleanUpReplayFile( void )
 		const int MAX_DEBUG_SIZE = 65536;
 		if (fileSize <= MAX_DEBUG_SIZE || TheGlobalData->m_saveAllStats)
 		{
-			DEBUG_LOG(("Using CopyFile to copy %s\n", DEBUG_FILE_NAME));
-			CopyFile(DEBUG_FILE_NAME, debugFname.str(), TRUE);
+			DEBUG_LOG(("Using CopyFile to copy %s\n", logFileName));
+			CopyFile(logFileName, debugFname.str(), TRUE);
 		}
 		else
 		{
-			DEBUG_LOG(("manual copy of %s\n", DEBUG_FILE_NAME));
-			FILE *ifp = fopen(DEBUG_FILE_NAME, "rb");
+			DEBUG_LOG(("manual copy of %s\n", logFileName));
+			FILE *ifp = fopen(logFileName, "rb");
 			FILE *ofp = fopen(debugFname.str(), "wb");
 			if (ifp && ofp)
 			{
@@ -357,7 +348,6 @@ void RecorderClass::cleanUpReplayFile( void )
 				ofp = NULL;
 			}
 		}
-#endif // DEBUG_FILE_NAME
 	}
 #endif
 }


### PR DESCRIPTION
This change couples the use of the debug log file in the Recorder class with the actual debug log file. This removes code duplication but also fixes minor discrepancies with how the log file is used in RecorderClass.

1. RecorderClass originally relied on the log file being located in the work directory
2. RecorderClass originally did not consider the app prefix for the log file name

Both of these were no practical issues, but are not clean either. With this change, both these things are no longer a concern.

## TODO

- [x] Replicate in Generals

Replicated without conflicts with
```
git diff d2e5d6007e0baa92d3d79ea2cf40200bdf581a0f..c27da312a54c3b479d527dee298e5400ae41384d > changes.patch
git apply -p2 --directory=Generals --reject --whitespace=fix changes.patch