### PR TITLE
[ZH] Unify code of AsciiString

### DIFF
--- a/GeneralsMD/Code/GameEngine/Include/Common/CriticalSection.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/CriticalSection.h
@@ -99,7 +99,7 @@ class ScopedCriticalSection
 
 // These should be NULL on creation then non-NULL in WinMain or equivalent.
 // This allows us to be silently non-threadsafe for WB and other single-threaded apps.
-extern FastCriticalSectionClass TheAsciiStringCriticalSection;
+extern CriticalSection *TheAsciiStringCriticalSection;
 extern CriticalSection *TheUnicodeStringCriticalSection;
 extern CriticalSection *TheDmaCriticalSection;
 extern CriticalSection *TheMemoryPoolCriticalSection;

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/CriticalSection.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/CriticalSection.cpp
@@ -27,7 +27,7 @@
 #include "Common/CriticalSection.h"
 
 // Definitions.
-FastCriticalSectionClass TheAsciiStringCriticalSection;
+CriticalSection *TheAsciiStringCriticalSection = NULL;
 CriticalSection *TheUnicodeStringCriticalSection = NULL;
 CriticalSection *TheDmaCriticalSection = NULL;
 CriticalSection *TheMemoryPoolCriticalSection = NULL;


### PR DESCRIPTION
- Merge after: #798 

This PR unifies the implementation of AsciiString between Generals and Zero Hour by using the Generals version of AsciiString in Zero Hour.

Zero Hour had to use a different scoped mutex implementation as they inlined a few of the string access functions. They likely thought this would help performance but it lead to a messier implementation.

The Generals version of AsciiString is also more cross compatible than the Zero Hour version as it is not dependend on windows functions. And the scoped section can have its implementation altered independent of code that makes use of it.
