### PR TITLE
[GEN][ZH] Fix missing rename for RTS_DEBUG, RTS_INTERNAL, RTS_PROFILE

### DIFF
--- a/Core/Libraries/Source/WWVegas/WWLib/Except.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/Except.cpp
@@ -793,7 +793,7 @@ int Exception_Handler(int exception_code, EXCEPTION_POINTERS *e_info)
 	}
 #else
 	exception_code = exception_code;
-#endif	//_DEBUG
+#endif	//RTS_DEBUG
 
 #ifdef WWDEBUG
 	//CONTEXT *context;
@@ -833,7 +833,7 @@ int Exception_Handler(int exception_code, EXCEPTION_POINTERS *e_info)
 				}
 			}
 			DebugString ("Debug file copied\n");
-#endif	//_DEBUG
+#endif	//RTS_DEBUG
 #endif	//_DEBUG_PRINT
 #endif	//(0)
 
@@ -854,7 +854,7 @@ int Exception_Handler(int exception_code, EXCEPTION_POINTERS *e_info)
 	if (ExitOnException) {
 #ifdef RTS_DEBUG
 		_CrtSetDbgFlag(0);
-#endif //_DEBUG
+#endif //RTS_DEBUG
 		TryingToExit = true;
 
 		unsigned long id = Get_Main_Thread_ID();

--- a/Core/Libraries/Source/WWVegas/WWLib/always.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/always.h
@@ -74,7 +74,7 @@
 
 #endif	//STEVES_NEW_CATCHER
 #endif	//_MSC_VER
-#endif	//_DEBUG
+#endif	//RTS_DEBUG
 
 #if !defined(DISABLE_GAMEMEMORY) // (gth) killing the Generals Memory Manager!
 

--- a/Core/Tools/W3DView/DataTreeView.cpp
+++ b/Core/Tools/W3DView/DataTreeView.cpp
@@ -149,7 +149,7 @@ void CDataTreeView::Dump(CDumpContext& dc) const
 {
 	CTreeView::Dump(dc);
 }
-#endif //_DEBUG
+#endif //RTS_DEBUG
 
 /////////////////////////////////////////////////////////////////////////////
 // CDataTreeView message handlers

--- a/Core/Tools/W3DView/DialogToolbar.cpp
+++ b/Core/Tools/W3DView/DialogToolbar.cpp
@@ -68,7 +68,7 @@ void DialogToolbarClass::Dump(CDumpContext& dc) const
 {
 	CToolBar::Dump(dc);
 }
-#endif //_DEBUG
+#endif //RTS_DEBUG
 
 
 ///////////////////////////////////////////////////////////////////

--- a/Core/Tools/W3DView/GraphicView.cpp
+++ b/Core/Tools/W3DView/GraphicView.cpp
@@ -154,7 +154,7 @@ void CGraphicView::Dump(CDumpContext& dc) const
 {
 	CView::Dump(dc);
 }
-#endif //_DEBUG
+#endif //RTS_DEBUG
 
 
 

--- a/Core/Tools/W3DView/MainFrm.cpp
+++ b/Core/Tools/W3DView/MainFrm.cpp
@@ -634,7 +634,7 @@ void CMainFrame::Dump(CDumpContext& dc) const
 	CFrameWnd::Dump(dc);
 }
 
-#endif //_DEBUG
+#endif //RTS_DEBUG
 
 
 ////////////////////////////////////////////////////////////////////////////

--- a/Core/Tools/W3DView/SoundEditDialog.cpp
+++ b/Core/Tools/W3DView/SoundEditDialog.cpp
@@ -122,7 +122,7 @@ void SoundEditDialogClass::Dump(CDumpContext& dc) const
 {
 	CDialog::Dump(dc);
 }
-#endif //_DEBUG
+#endif //RTS_DEBUG
 
 
 

--- a/Core/Tools/W3DView/W3DView.cpp
+++ b/Core/Tools/W3DView/W3DView.cpp
@@ -113,7 +113,7 @@ WinMain
 #ifndef RTS_DEBUG
 	try
 	{
-#endif //_DEBUG
+#endif //RTS_DEBUG
 
 		//::AfxWinInit (hInstance, hPrevInstance, lpCmdLine, nCmdShow);
 		//::AfxInitialize (FALSE, _MFC_VER);
@@ -134,7 +134,7 @@ WinMain
 
 		::MessageBox (NULL, "Internal Application Error", "Unrecoverable Error", MB_ICONERROR | MB_OK);
 	}
-#endif //_DEBUG
+#endif //RTS_DEBUG
 
 	return retcode;
 }

--- a/Core/Tools/W3DView/W3DViewDoc.cpp
+++ b/Core/Tools/W3DView/W3DViewDoc.cpp
@@ -343,7 +343,7 @@ void CW3DViewDoc::Dump(CDumpContext& dc) const
 {
 	CDocument::Dump(dc);
 }
-#endif //_DEBUG
+#endif //RTS_DEBUG
 
 
 ///////////////////////////////////////////////////////////////

--- a/Core/Tools/W3DView/W3DViewView.cpp
+++ b/Core/Tools/W3DView/W3DViewView.cpp
@@ -92,7 +92,7 @@ CW3DViewDoc* CW3DViewView::GetDocument() // non-debug version is inline
 	ASSERT(m_pDocument->IsKindOf(RUNTIME_CLASS(CW3DViewDoc)));
 	return (CW3DViewDoc*)m_pDocument;
 }
-#endif //_DEBUG
+#endif //RTS_DEBUG
 
 /////////////////////////////////////////////////////////////////////////////
 // CW3DViewView message handlers

--- a/Core/Tools/WW3D/pluglib/always.h
+++ b/Core/Tools/WW3D/pluglib/always.h
@@ -67,7 +67,7 @@ void* __cdecl operator new(unsigned int s);
 
 #endif	//STEVES_NEW_CATCHER
 #endif	//_MSC_VER
-#endif	//_DEBUG
+#endif	//RTS_DEBUG
 
 
 // Jani: Intel's C++ compiler issues too many warnings in WW libraries when using warning level 4

--- a/Generals/Code/GameEngine/Include/Common/Debug.h
+++ b/Generals/Code/GameEngine/Include/Common/Debug.h
@@ -71,7 +71,7 @@ class AsciiString;
 	#define ALLOW_DEBUG_UTILS 1
 #endif
 
-// these are predicated on ALLOW_DEBUG_UTILS, not _DEBUG, and allow you to selectively disable
+// these are predicated on ALLOW_DEBUG_UTILS, not RTS_DEBUG, and allow you to selectively disable
 // bits of the debug stuff for special builds.
 #if defined(ALLOW_DEBUG_UTILS) && !defined(DEBUG_LOGGING) && !defined(DISABLE_DEBUG_LOGGING)
 	#define DEBUG_LOGGING 1

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
@@ -1857,7 +1857,7 @@ void W3DModelDraw::getRenderCost(RenderCost & rc) const
 	if (m_shadow)
 		m_shadow->getRenderCost(rc);
 }
-#endif //_DEBUG || RTS_INTERNAL
+#endif //RTS_DEBUG || RTS_INTERNAL
 
 
 /**recurse through sub-objs to collect stats about the rendering cost of this draw module */
@@ -1898,7 +1898,7 @@ void W3DModelDraw::getRenderCostRecursive(RenderCost & rc,RenderObjClass * robj)
 		}
 	}
 }
-#endif //_DEBUG || RTS_INTERNAL
+#endif //RTS_DEBUG || RTS_INTERNAL
 
 //-------------------------------------------------------------------------------------------------
 void W3DModelDraw::setFullyObscuredByShroud(Bool fullyObscured)

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDebugIcons.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDebugIcons.cpp
@@ -312,4 +312,4 @@ void W3DDebugIcons::Render(RenderInfoClass & rinfo)
 	}
 }
 
-#endif // RTS_DEBUG or _INTERNAL
+#endif // RTS_DEBUG or RTS_INTERNAL

--- a/Generals/Code/Tools/WorldBuilder/src/MainFrm.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/MainFrm.cpp
@@ -425,7 +425,7 @@ void CMainFrame::Dump(CDumpContext& dc) const
 	CFrameWnd::Dump(dc);
 }
 
-#endif //_DEBUG
+#endif //RTS_DEBUG
 
 /////////////////////////////////////////////////////////////////////////////
 // CMainFrame message handlers

--- a/Generals/Code/Tools/WorldBuilder/src/WorldBuilder.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/WorldBuilder.cpp
@@ -283,10 +283,10 @@ BOOL CWorldBuilderApp::InitInstance()
 	DEBUG_INIT(DEBUG_FLAGS_DEFAULT);
 	DEBUG_LOG(("starting Worldbuilder.\n"));
 #ifdef RTS_INTERNAL
-	DEBUG_LOG(("_INTERNAL defined.\n"));
+	DEBUG_LOG(("RTS_INTERNAL defined.\n"));
 #endif
 #ifdef RTS_DEBUG
-	DEBUG_LOG(("_DEBUG defined.\n"));
+	DEBUG_LOG(("RTS_DEBUG defined.\n"));
 #endif
 	initMemoryManager();
 #ifdef MEMORYPOOL_CHECKPOINTING

--- a/Generals/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp
@@ -859,7 +859,7 @@ void CWorldBuilderDoc::Dump(CDumpContext& dc) const
 {
 	CDocument::Dump(dc);
 }
-#endif //_DEBUG
+#endif //RTS_DEBUG
 
 /////////////////////////////////////////////////////////////////////////////
 // CWorldBuilderDoc commands

--- a/Generals/Code/Tools/WorldBuilder/src/WorldBuilderView.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/WorldBuilderView.cpp
@@ -148,7 +148,7 @@ void CWorldBuilderView::Dump(CDumpContext& dc) const
 	WbView::Dump(dc);
 }
 
-#endif //_DEBUG
+#endif //RTS_DEBUG
 
 /** Set the cell size, and invalidate. */
 void CWorldBuilderView::setCellSize(Int cellSize)

--- a/Generals/Code/Tools/WorldBuilder/src/wbview.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/wbview.cpp
@@ -159,7 +159,7 @@ void WbView::Dump(CDumpContext& dc) const
 {
 	CView::Dump(dc);
 }
-#endif //_DEBUG
+#endif //RTS_DEBUG
 
 /////////////////////////////////////////////////////////////////////////////
 // WbView message handlers

--- a/Generals/Code/Tools/WorldBuilder/src/wbview3d.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/wbview3d.cpp
@@ -2140,7 +2140,7 @@ void WbView3d::Dump(CDumpContext& dc) const
 {
 	WbView::Dump(dc);
 }
-#endif //_DEBUG
+#endif //RTS_DEBUG
 
 // ----------------------------------------------------------------------------
 void WbView3d::initWW3D()

--- a/GeneralsMD/Code/GameEngine/Include/Common/Debug.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Debug.h
@@ -77,7 +77,7 @@ class AsciiString;
 	#define ALLOW_DEBUG_UTILS 1
 #endif
 
-// these are predicated on ALLOW_DEBUG_UTILS, not _DEBUG, and allow you to selectively disable
+// these are predicated on ALLOW_DEBUG_UTILS, not RTS_DEBUG, and allow you to selectively disable
 // bits of the debug stuff for special builds.
 #if defined(ALLOW_DEBUG_UTILS) && !defined(DEBUG_LOGGING) && !defined(DISABLE_DEBUG_LOGGING)
 	#define DEBUG_LOGGING 1

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
@@ -1896,7 +1896,7 @@ void W3DModelDraw::getRenderCost(RenderCost & rc) const
 	if (m_shadow)
 		m_shadow->getRenderCost(rc);
 }
-#endif //_DEBUG || RTS_INTERNAL
+#endif //RTS_DEBUG || RTS_INTERNAL
 
 
 /**recurse through sub-objs to collect stats about the rendering cost of this draw module */
@@ -1937,7 +1937,7 @@ void W3DModelDraw::getRenderCostRecursive(RenderCost & rc,RenderObjClass * robj)
 		}
 	}
 }
-#endif //_DEBUG || RTS_INTERNAL
+#endif //RTS_DEBUG || RTS_INTERNAL
 
 //-------------------------------------------------------------------------------------------------
 void W3DModelDraw::setFullyObscuredByShroud(Bool fullyObscured)

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDebugIcons.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDebugIcons.cpp
@@ -312,4 +312,4 @@ void W3DDebugIcons::Render(RenderInfoClass & rinfo)
 	}
 }
 
-#endif // RTS_DEBUG or _INTERNAL
+#endif // RTS_DEBUG or RTS_INTERNAL

--- a/GeneralsMD/Code/Libraries/Source/profile/profile_funclevel.h
+++ b/GeneralsMD/Code/Libraries/Source/profile/profile_funclevel.h
@@ -36,7 +36,7 @@
   \brief The function level profiler.
 
   Note that this class exists even if the current build configuration
-  is not _PROFILE. In these cases all calls will simply return
+  is not RTS_PROFILE. In these cases all calls will simply return
   empty data.
 */
 class ProfileFuncLevel

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/MainFrm.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/MainFrm.cpp
@@ -458,7 +458,7 @@ void CMainFrame::Dump(CDumpContext& dc) const
 	CFrameWnd::Dump(dc);
 }
 
-#endif //_DEBUG
+#endif //RTS_DEBUG
 
 /////////////////////////////////////////////////////////////////////////////
 // CMainFrame message handlers

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/WorldBuilder.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/WorldBuilder.cpp
@@ -296,10 +296,10 @@ BOOL CWorldBuilderApp::InitInstance()
 	DEBUG_LOG(("starting Worldbuilder.\n"));
 
 #ifdef RTS_INTERNAL
-	DEBUG_LOG(("_INTERNAL defined.\n"));
+	DEBUG_LOG(("RTS_INTERNAL defined.\n"));
 #endif
 #ifdef RTS_DEBUG
-	DEBUG_LOG(("_DEBUG defined.\n"));
+	DEBUG_LOG(("RTS_DEBUG defined.\n"));
 #endif
 	initMemoryManager();
 #ifdef MEMORYPOOL_CHECKPOINTING

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp
@@ -920,7 +920,7 @@ void CWorldBuilderDoc::Dump(CDumpContext& dc) const
 {
 	CDocument::Dump(dc);
 }
-#endif //_DEBUG
+#endif //RTS_DEBUG
 
 /////////////////////////////////////////////////////////////////////////////
 // CWorldBuilderDoc commands

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/WorldBuilderView.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/WorldBuilderView.cpp
@@ -148,7 +148,7 @@ void CWorldBuilderView::Dump(CDumpContext& dc) const
 	WbView::Dump(dc);
 }
 
-#endif //_DEBUG
+#endif //RTS_DEBUG
 
 /** Set the cell size, and invalidate. */
 void CWorldBuilderView::setCellSize(Int cellSize)

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/wbview.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/wbview.cpp
@@ -169,7 +169,7 @@ void WbView::Dump(CDumpContext& dc) const
 {
 	CView::Dump(dc);
 }
-#endif //_DEBUG
+#endif //RTS_DEBUG
 
 /////////////////////////////////////////////////////////////////////////////
 // WbView message handlers

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/wbview3d.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/wbview3d.cpp
@@ -2222,7 +2222,7 @@ void WbView3d::Dump(CDumpContext& dc) const
 {
 	WbView::Dump(dc);
 }
-#endif //_DEBUG
+#endif //RTS_DEBUG
 
 // ----------------------------------------------------------------------------
 void WbView3d::initWW3D()

--- a/GeneralsMD/Code/Tools/wdump/mainfrm.cpp
+++ b/GeneralsMD/Code/Tools/wdump/mainfrm.cpp
@@ -143,7 +143,7 @@ void CMainFrame::Dump(CDumpContext& dc) const
 	CFrameWnd::Dump(dc);
 }
 
-#endif //_DEBUG
+#endif //RTS_DEBUG
 
 /////////////////////////////////////////////////////////////////////////////
 // CMainFrame message handlers

--- a/GeneralsMD/Code/Tools/wdump/wdeview.cpp
+++ b/GeneralsMD/Code/Tools/wdump/wdeview.cpp
@@ -73,7 +73,7 @@ void CWDumpEditView::Dump(CDumpContext& dc) const
 {
 	CEditView::Dump(dc);
 }
-#endif //_DEBUG
+#endif //RTS_DEBUG
 
 /////////////////////////////////////////////////////////////////////////////
 // CWDumpEditView message handlers

--- a/GeneralsMD/Code/Tools/wdump/wdlview.cpp
+++ b/GeneralsMD/Code/Tools/wdump/wdlview.cpp
@@ -71,7 +71,7 @@ void CWDumpListView::Dump(CDumpContext& dc) const
 {
 	CListView::Dump(dc);
 }
-#endif //_DEBUG
+#endif //RTS_DEBUG
 
 /////////////////////////////////////////////////////////////////////////////
 // CWDumpListView message handlers

--- a/GeneralsMD/Code/Tools/wdump/wdtview.cpp
+++ b/GeneralsMD/Code/Tools/wdump/wdtview.cpp
@@ -77,7 +77,7 @@ void CWDumpTreeView::Dump(CDumpContext& dc) const
 {
 	CTreeView::Dump(dc);
 }
-#endif //_DEBUG
+#endif //RTS_DEBUG
 
 /////////////////////////////////////////////////////////////////////////////
 // CWDumpTreeView message handlers

--- a/GeneralsMD/Code/Tools/wdump/wdumpdoc.cpp
+++ b/GeneralsMD/Code/Tools/wdump/wdumpdoc.cpp
@@ -97,7 +97,7 @@ void CWdumpDoc::Dump(CDumpContext& dc) const
 {
 	CDocument::Dump(dc);
 }
-#endif //_DEBUG
+#endif //RTS_DEBUG
 
 /////////////////////////////////////////////////////////////////////////////
 // CWdumpDoc commands

--- a/GeneralsMD/Code/Tools/wdump/wdview.cpp
+++ b/GeneralsMD/Code/Tools/wdump/wdview.cpp
@@ -94,7 +94,7 @@ CWdumpDoc* CWdumpView::GetDocument() // non-debug version is inline
 	ASSERT(m_pDocument->IsKindOf(RUNTIME_CLASS(CWdumpDoc)));
 	return (CWdumpDoc*)m_pDocument;
 }
-#endif //_DEBUG
+#endif //RTS_DEBUG
 
 /////////////////////////////////////////////////////////////////////////////
 // CWdumpView message handlers


### PR DESCRIPTION
* Follow up for #780

This change renames a few more macros that were missed in #780.