### PR TITLE
[GEN][ZH] Fix compile warnings from the use of deprecated register keywords

### DIFF
--- a/Dependencies/Utility/Utility/CppMacros.h
+++ b/Dependencies/Utility/Utility/CppMacros.h
@@ -37,3 +37,9 @@
 #else
     #define CPP_11(code)
 #endif
+
+#if __cplusplus >= 201703L
+#define REGISTER
+#else
+#define REGISTER register
+#endif

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/intersec.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/intersec.cpp
@@ -40,6 +40,7 @@
 #include "camera.h"
 #include "scene.h"
 #include "intersec.inl"
+#include "Utility/CppMacros.h"
 
 
 //////////////////////////////////////////////////////////////////////
@@ -190,7 +191,7 @@ bool IntersectionClass::Intersect_Box(Vector3 &Box_Min, Vector3 &Box_Max, Inters
 	float distance[PLANE_COUNT];
 	float candidate_plane[PLANE_COUNT];
 	
-	register Vector3 *intersection = &FinalResult->Intersection;
+	REGISTER Vector3 *intersection = &FinalResult->Intersection;
 	
 	// Find candidate planes and determine if the ray is outside the box
 	for (counter = 0; counter < PLANE_COUNT; counter++) {

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -52,6 +52,7 @@
 
 #include "Common/UnitTimings.h" //Contains the DO_UNIT_TIMINGS define jba.	
 
+#include "Utility/CppMacros.h"
 
 #define no_INTENSE_DEBUG
 
@@ -2641,7 +2642,7 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
 //		//	DEBUG_ASSERTCRASH(map[i][j].getZone() != 0, ("Cleared the zone."));
 //		}
 //	}
-  register UnsignedInt maxZone = m_maxZone;
+  REGISTER UnsignedInt maxZone = m_maxZone;
 	j=globalBounds.lo.y;
   while( j <= globalBounds.hi.y )	
   {
@@ -2754,7 +2755,7 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
   //FLATTEN HIERARCHICAL ZONES
   {
 	  i = 1;
-    register Int zone;  
+    REGISTER Int zone;  
     while ( i < maxZone ) 
     {		// Flatten hierarchical zones.
 		  zone = m_hierarchicalZones[i];

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/intersec.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/intersec.cpp
@@ -40,6 +40,7 @@
 #include "camera.h"
 #include "scene.h"
 #include "intersec.inl"
+#include "Utility/CppMacros.h"
 
 
 //////////////////////////////////////////////////////////////////////
@@ -190,7 +191,7 @@ bool IntersectionClass::Intersect_Box(Vector3 &Box_Min, Vector3 &Box_Max, Inters
 	float distance[PLANE_COUNT];
 	float candidate_plane[PLANE_COUNT];
 	
-	register Vector3 *intersection = &FinalResult->Intersection;
+	REGISTER Vector3 *intersection = &FinalResult->Intersection;
 	
 	// Find candidate planes and determine if the ray is outside the box
 	for (counter = 0; counter < PLANE_COUNT; counter++) {


### PR DESCRIPTION
Fixes warnings of `register` keyword being deprecated, by introducing a macro for the register keyword.