### PR TITLE
[GEN][ZH] Fix compile warnings related to the use of printf and scanf

### DIFF
--- a/Core/Libraries/Source/WWVegas/WWLib/Except.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/Except.cpp
@@ -676,17 +676,17 @@ void Dump_Exception_Info(EXCEPTION_POINTERS *e_info)
 			/*
 			** The stack contents cannot be read so just print up question marks.
 			*/
-			sprintf(scrap, "%08X: ", stackptr);
+			sprintf(scrap, "%p: ", static_cast<void*>(stackptr));
 			strcat(scrap, "????????\r\n");
 		} else {
 			/*
 			** If this stack address is in our memory space then try to match it with a code symbol.
 			*/
 			if (IsBadCodePtr((FARPROC)*stackptr)) {
-				sprintf(scrap, "%08X: %08X ", stackptr, *stackptr);
+				sprintf(scrap, "%p: %08lX ", static_cast<void*>(stackptr), *stackptr);
 				strcat(scrap, "DATA_PTR\r\n");
 			} else {
-				sprintf(scrap, "%08X: %08X", stackptr, *stackptr);
+				sprintf(scrap, "%p: %08lX", static_cast<void*>(stackptr), *stackptr);
 
 				if (symbols_available) {
 					symptr->SizeOfStruct = sizeof(symbol);

--- a/Core/Libraries/Source/WWVegas/WWLib/ini.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/ini.cpp
@@ -1560,7 +1560,7 @@ double INIClass::Get_Double(char const * section, char const * entry, double def
 
 	INIEntry * entryptr = Find_Entry(section, entry);
 	if (entryptr != NULL && entryptr->Value != NULL) {
-		float val = defvalue;
+		double val = defvalue;
 		sscanf(entryptr->Value, "%lf", &val);
 		defvalue = val;
 		if (strchr(entryptr->Value, '%') != NULL) {

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dazzle.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dazzle.cpp
@@ -303,7 +303,7 @@ const Vector2 DazzleINIClass::Get_Vector2(char const *section, char const *entry
 		INIEntry * entryptr = Find_Entry(section, entry);
 		if (entryptr && entryptr->Value != NULL) {
 			Vector2	ret;
-			if ( sscanf( entryptr->Value, "%f,%f", &ret[0], &ret[1], &ret[2] ) == 2 ) {
+			if ( sscanf( entryptr->Value, "%f,%f", &ret[0], &ret[1] ) == 2 ) {
 				return ret;
 			}
 		}

--- a/Generals/Code/Tools/GUIEdit/Source/Dialog Procedures/ListboxProperties.cpp
+++ b/Generals/Code/Tools/GUIEdit/Source/Dialog Procedures/ListboxProperties.cpp
@@ -636,7 +636,7 @@ static LRESULT CALLBACK listboxPropertiesCallback( HWND hWndDialog,
 								else if((total > 100 ) || (total < 100 && !token ))
 								{
 									Char *whoopsMsg = new char[250];
-									sprintf(whoopsMsg,"Please Double check to make sure your percentages add up to 100.", newColumns, i - 1);
+									sprintf(whoopsMsg,"Please Double check to make sure your percentages add up to 100.");
 									MessageBox(NULL, whoopsMsg,"Whoops",MB_OK | MB_ICONSTOP | MB_APPLMODAL);
 									return 0;
 								}

--- a/Generals/Code/Tools/GUIEdit/Source/LayoutScheme.cpp
+++ b/Generals/Code/Tools/GUIEdit/Source/LayoutScheme.cpp
@@ -2361,19 +2361,19 @@ Bool LayoutScheme::loadScheme( char *filename )
 	}  // end if
 
 	// default text colors
-	fscanf( fp, "Enabled Text: (%d,%d,%d,%d)\n", &colorR, &colorG, &colorB, &colorA );
+	fscanf( fp, "Enabled Text: (%hhu,%hhu,%hhu,%hhu)\n", &colorR, &colorG, &colorB, &colorA );
 	m_enabledText.color = GameMakeColor( colorR, colorG, colorB, colorA );
-	fscanf( fp, "Enabled Text Border: (%d,%d,%d,%d)\n", &colorR, &colorG, &colorB, &colorA );
+	fscanf( fp, "Enabled Text Border: (%hhu,%hhu,%hhu,%hhu)\n", &colorR, &colorG, &colorB, &colorA );
 	m_enabledText.borderColor = GameMakeColor( colorR, colorG, colorB, colorA );
 
-	fscanf( fp, "Disabled Text: (%d,%d,%d,%d)\n", &colorR, &colorG, &colorB, &colorA );
+	fscanf( fp, "Disabled Text: (%hhu,%hhu,%hhu,%hhu)\n", &colorR, &colorG, &colorB, &colorA );
 	m_disabledText.color = GameMakeColor( colorR, colorG, colorB, colorA );
-	fscanf( fp, "Disabled Text Border: (%d,%d,%d,%d)\n", &colorR, &colorG, &colorB, &colorA );
+	fscanf( fp, "Disabled Text Border: (%hhu,%hhu,%hhu,%hhu)\n", &colorR, &colorG, &colorB, &colorA );
 	m_disabledText.borderColor = GameMakeColor( colorR, colorG, colorB, colorA );
 
-	fscanf( fp, "Hilite Text: (%d,%d,%d,%d)\n", &colorR, &colorG, &colorB, &colorA );
+	fscanf( fp, "Hilite Text: (%hhu,%hhu,%hhu,%hhu)\n", &colorR, &colorG, &colorB, &colorA );
 	m_hiliteText.color = GameMakeColor( colorR, colorG, colorB, colorA );
-	fscanf( fp, "Hilite Text Border: (%d,%d,%d,%d)\n", &colorR, &colorG, &colorB, &colorA );
+	fscanf( fp, "Hilite Text Border: (%hhu,%hhu,%hhu,%hhu)\n", &colorR, &colorG, &colorB, &colorA );
 	m_hiliteText.borderColor = GameMakeColor( colorR, colorG, colorB, colorA );
 
 	// default font
@@ -2399,7 +2399,7 @@ Bool LayoutScheme::loadScheme( char *filename )
 	c = fgetc( fp );  // the end quite itself
 
 	// read the size and bold data elements
-	fscanf( fp, " Size: %d Bold: %d\n", &size, &bold );
+	fscanf( fp, " Size: %i Bold: %i\n", &size, &bold );
 
 	// set the font
 	m_font = TheFontLibrary->getFont( AsciiString(fontBuffer), size, bold );
@@ -2407,12 +2407,12 @@ Bool LayoutScheme::loadScheme( char *filename )
 	// all the data for all the states
 	Int numStates, state;
 	char imageBuffer[ 128 ];
-	fscanf( fp, "Number of states: %d\n", &numStates );
+	fscanf( fp, "Number of states: %i\n", &numStates );
 	for( Int i = 0; i < numStates; i++ )
 	{
 
 		// read all the data
-		fscanf( fp, "%d: Image: %s Color: (%d,%d,%d,%d) Border: (%d,%d,%d,%d)\n",
+		fscanf( fp, "%d: Image: %s Color: (%hhu,%hhu,%hhu,%hhu) Border: (%hhu,%hhu,%hhu,%hhu)\n",
 						&state, imageBuffer, &colorR, &colorG, &colorB, &colorA,
 						&bColorR, &bColorG, &bColorB, &bColorA );
 

--- a/Generals/Code/Tools/GUIEdit/Source/LayoutScheme.cpp
+++ b/Generals/Code/Tools/GUIEdit/Source/LayoutScheme.cpp
@@ -2349,32 +2349,43 @@ Bool LayoutScheme::loadScheme( char *filename )
 
 	// write header
 	Int version;
-	fscanf( fp, "Window Layout Scheme: Version '%d'\n", &version );
-	if( version != SCHEME_VERSION )
+	if (fscanf( fp, "Window Layout Scheme: Version '%d'\n", &version ) == 1)
 	{
+		if( version != SCHEME_VERSION )
+		{
 
-		DEBUG_LOG(( "loadScheme: Old layout file version '%d'\n", version ));
-		MessageBox( TheEditor->getWindowHandle(),
-								"Old layout version, cannot open.", "Old File", MB_OK );
-		return FALSE;
+			DEBUG_LOG(( "loadScheme: Old layout file version '%d'\n", version ));
+			MessageBox( TheEditor->getWindowHandle(),
+									"Old layout version, cannot open.", "Old File", MB_OK );
+			return FALSE;
 
-	}  // end if
-
+		}  // end if
+	}
 	// default text colors
-	fscanf( fp, "Enabled Text: (%hhu,%hhu,%hhu,%hhu)\n", &colorR, &colorG, &colorB, &colorA );
-	m_enabledText.color = GameMakeColor( colorR, colorG, colorB, colorA );
-	fscanf( fp, "Enabled Text Border: (%hhu,%hhu,%hhu,%hhu)\n", &colorR, &colorG, &colorB, &colorA );
-	m_enabledText.borderColor = GameMakeColor( colorR, colorG, colorB, colorA );
-
-	fscanf( fp, "Disabled Text: (%hhu,%hhu,%hhu,%hhu)\n", &colorR, &colorG, &colorB, &colorA );
-	m_disabledText.color = GameMakeColor( colorR, colorG, colorB, colorA );
-	fscanf( fp, "Disabled Text Border: (%hhu,%hhu,%hhu,%hhu)\n", &colorR, &colorG, &colorB, &colorA );
-	m_disabledText.borderColor = GameMakeColor( colorR, colorG, colorB, colorA );
-
-	fscanf( fp, "Hilite Text: (%hhu,%hhu,%hhu,%hhu)\n", &colorR, &colorG, &colorB, &colorA );
-	m_hiliteText.color = GameMakeColor( colorR, colorG, colorB, colorA );
-	fscanf( fp, "Hilite Text Border: (%hhu,%hhu,%hhu,%hhu)\n", &colorR, &colorG, &colorB, &colorA );
-	m_hiliteText.borderColor = GameMakeColor( colorR, colorG, colorB, colorA );
+	if (fscanf( fp, "Enabled Text: (%hhu,%hhu,%hhu,%hhu)\n", &colorR, &colorG, &colorB, &colorA ) == 4)
+	{
+		m_enabledText.color = GameMakeColor( colorR, colorG, colorB, colorA );
+	}
+	if (fscanf( fp, "Enabled Text Border: (%hhu,%hhu,%hhu,%hhu)\n", &colorR, &colorG, &colorB, &colorA ) == 4)
+	{
+		m_enabledText.borderColor = GameMakeColor( colorR, colorG, colorB, colorA );
+	}
+	if (fscanf( fp, "Disabled Text: (%hhu,%hhu,%hhu,%hhu)\n", &colorR, &colorG, &colorB, &colorA ) == 4)
+	{
+		m_disabledText.color = GameMakeColor( colorR, colorG, colorB, colorA );
+	}
+	if (fscanf( fp, "Disabled Text Border: (%hhu,%hhu,%hhu,%hhu)\n", &colorR, &colorG, &colorB, &colorA ) == 4)
+	{
+		m_disabledText.borderColor = GameMakeColor( colorR, colorG, colorB, colorA );
+	}
+	if (fscanf( fp, "Hilite Text: (%hhu,%hhu,%hhu,%hhu)\n", &colorR, &colorG, &colorB, &colorA ) == 4)
+	{
+		m_hiliteText.color = GameMakeColor( colorR, colorG, colorB, colorA );
+	}
+	if (fscanf( fp, "Hilite Text Border: (%hhu,%hhu,%hhu,%hhu)\n", &colorR, &colorG, &colorB, &colorA ) == 4)
+	{
+		m_hiliteText.borderColor = GameMakeColor( colorR, colorG, colorB, colorA );
+	}
 
 	// default font
 	char fontBuffer[ 256 ];
@@ -2399,34 +2410,36 @@ Bool LayoutScheme::loadScheme( char *filename )
 	c = fgetc( fp );  // the end quite itself
 
 	// read the size and bold data elements
-	fscanf( fp, " Size: %i Bold: %i\n", &size, &bold );
-
-	// set the font
-	m_font = TheFontLibrary->getFont( AsciiString(fontBuffer), size, bold );
+	if(fscanf( fp, " Size: %i Bold: %i\n", &size, &bold ) == 2)
+	{
+		// set the font
+		m_font = TheFontLibrary->getFont( AsciiString(fontBuffer), size, bold );
+	}
 
 	// all the data for all the states
 	Int numStates, state;
 	char imageBuffer[ 128 ];
-	fscanf( fp, "Number of states: %i\n", &numStates );
-	for( Int i = 0; i < numStates; i++ )
+	if (fscanf( fp, "Number of states: %i\n", &numStates ) == 1)
 	{
+		for( Int i = 0; i < numStates; i++ )
+		{
 
-		// read all the data
-		fscanf( fp, "%d: Image: %s Color: (%hhu,%hhu,%hhu,%hhu) Border: (%hhu,%hhu,%hhu,%hhu)\n",
-						&state, imageBuffer, &colorR, &colorG, &colorB, &colorA,
-						&bColorR, &bColorG, &bColorB, &bColorA );
+			// read all the data
+			if( fscanf( fp, "%d: Image: %s Color: (%hhu,%hhu,%hhu,%hhu) Border: (%hhu,%hhu,%hhu,%hhu)\n",
+							&state, imageBuffer, &colorR, &colorG, &colorB, &colorA,
+							&bColorR, &bColorG, &bColorB, &bColorA ) == 10)
+			{
+				// sanity
+				assert( state == i );
 
-		// sanity
-		assert( state == i );
-
-		// store the info
-		storeImageAndColor( (StateIdentifier)state,
-												TheMappedImageCollection->findImageByName( AsciiString(  imageBuffer ) ),
-												GameMakeColor( colorR, colorG, colorB, colorA ),
-												GameMakeColor( bColorR, bColorG, bColorB, bColorA ) );
-
-	}  // end for i
-
+				// store the info
+				storeImageAndColor( (StateIdentifier)state,
+														TheMappedImageCollection->findImageByName( AsciiString(  imageBuffer ) ),
+														GameMakeColor( colorR, colorG, colorB, colorA ),
+														GameMakeColor( bColorR, bColorG, bColorB, bColorA ) );
+			}
+		}  // end for i
+	}
 	// close the file
 	fclose( fp );
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dazzle.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dazzle.cpp
@@ -305,7 +305,7 @@ const Vector2 DazzleINIClass::Get_Vector2(char const *section, char const *entry
 		INIEntry * entryptr = Find_Entry(section, entry);
 		if (entryptr && entryptr->Value != NULL) {
 			Vector2	ret;
-			if ( sscanf( entryptr->Value, "%f,%f", &ret[0], &ret[1], &ret[2] ) == 2 ) {
+			if ( sscanf( entryptr->Value, "%f,%f", &ret[0], &ret[1] ) == 2 ) {
 				return ret;
 			}
 		}

--- a/GeneralsMD/Code/Tools/GUIEdit/Source/Dialog Procedures/ListboxProperties.cpp
+++ b/GeneralsMD/Code/Tools/GUIEdit/Source/Dialog Procedures/ListboxProperties.cpp
@@ -636,7 +636,7 @@ static LRESULT CALLBACK listboxPropertiesCallback( HWND hWndDialog,
 								else if((total > 100 ) || (total < 100 && !token ))
 								{
 									Char *whoopsMsg = new char[250];
-									sprintf(whoopsMsg,"Please Double check to make sure your percentages add up to 100.", newColumns, i - 1);
+									sprintf(whoopsMsg,"Please Double check to make sure your percentages add up to 100.");
 									MessageBox(NULL, whoopsMsg,"Whoops",MB_OK | MB_ICONSTOP | MB_APPLMODAL);
 									return 0;
 								}

--- a/GeneralsMD/Code/Tools/GUIEdit/Source/LayoutScheme.cpp
+++ b/GeneralsMD/Code/Tools/GUIEdit/Source/LayoutScheme.cpp
@@ -2361,19 +2361,19 @@ Bool LayoutScheme::loadScheme( char *filename )
 	}  // end if
 
 	// default text colors
-	fscanf( fp, "Enabled Text: (%d,%d,%d,%d)\n", &colorR, &colorG, &colorB, &colorA );
+	fscanf( fp, "Enabled Text: (%hhu,%hhu,%hhu,%hhu)\n", &colorR, &colorG, &colorB, &colorA );
 	m_enabledText.color = GameMakeColor( colorR, colorG, colorB, colorA );
-	fscanf( fp, "Enabled Text Border: (%d,%d,%d,%d)\n", &colorR, &colorG, &colorB, &colorA );
+	fscanf( fp, "Enabled Text Border: (%hhu,%hhu,%hhu,%hhu)\n", &colorR, &colorG, &colorB, &colorA );
 	m_enabledText.borderColor = GameMakeColor( colorR, colorG, colorB, colorA );
 
-	fscanf( fp, "Disabled Text: (%d,%d,%d,%d)\n", &colorR, &colorG, &colorB, &colorA );
+	fscanf( fp, "Disabled Text: (%hhu,%hhu,%hhu,%hhu)\n", &colorR, &colorG, &colorB, &colorA );
 	m_disabledText.color = GameMakeColor( colorR, colorG, colorB, colorA );
-	fscanf( fp, "Disabled Text Border: (%d,%d,%d,%d)\n", &colorR, &colorG, &colorB, &colorA );
+	fscanf( fp, "Disabled Text Border: (%hhu,%hhu,%hhu,%hhu)\n", &colorR, &colorG, &colorB, &colorA );
 	m_disabledText.borderColor = GameMakeColor( colorR, colorG, colorB, colorA );
 
-	fscanf( fp, "Hilite Text: (%d,%d,%d,%d)\n", &colorR, &colorG, &colorB, &colorA );
+	fscanf( fp, "Hilite Text: (%hhu,%hhu,%hhu,%hhu)\n", &colorR, &colorG, &colorB, &colorA );
 	m_hiliteText.color = GameMakeColor( colorR, colorG, colorB, colorA );
-	fscanf( fp, "Hilite Text Border: (%d,%d,%d,%d)\n", &colorR, &colorG, &colorB, &colorA );
+	fscanf( fp, "Hilite Text Border: (%hhu,%hhu,%hhu,%hhu)\n", &colorR, &colorG, &colorB, &colorA );
 	m_hiliteText.borderColor = GameMakeColor( colorR, colorG, colorB, colorA );
 
 	// default font
@@ -2399,7 +2399,7 @@ Bool LayoutScheme::loadScheme( char *filename )
 	c = fgetc( fp );  // the end quite itself
 
 	// read the size and bold data elements
-	fscanf( fp, " Size: %d Bold: %d\n", &size, &bold );
+	fscanf( fp, " Size: %i Bold: %i\n", &size, &bold );
 
 	// set the font
 	m_font = TheFontLibrary->getFont( AsciiString(fontBuffer), size, bold );
@@ -2407,12 +2407,12 @@ Bool LayoutScheme::loadScheme( char *filename )
 	// all the data for all the states
 	Int numStates, state;
 	char imageBuffer[ 128 ];
-	fscanf( fp, "Number of states: %d\n", &numStates );
+	fscanf( fp, "Number of states: %i\n", &numStates );
 	for( Int i = 0; i < numStates; i++ )
 	{
 
 		// read all the data
-		fscanf( fp, "%d: Image: %s Color: (%d,%d,%d,%d) Border: (%d,%d,%d,%d)\n",
+		fscanf( fp, "%d: Image: %s Color: (%hhu,%hhu,%hhu,%hhu) Border: (%hhu,%hhu,%hhu,%hhu)\n",
 						&state, imageBuffer, &colorR, &colorG, &colorB, &colorA,
 						&bColorR, &bColorG, &bColorB, &bColorA );
 

--- a/GeneralsMD/Code/Tools/GUIEdit/Source/LayoutScheme.cpp
+++ b/GeneralsMD/Code/Tools/GUIEdit/Source/LayoutScheme.cpp
@@ -2349,33 +2349,44 @@ Bool LayoutScheme::loadScheme( char *filename )
 
 	// write header
 	Int version;
-	fscanf( fp, "Window Layout Scheme: Version '%d'\n", &version );
-	if( version != SCHEME_VERSION )
+	if (fscanf( fp, "Window Layout Scheme: Version '%d'\n", &version ) == 1)
 	{
+		if( version != SCHEME_VERSION )
+		{
 
-		DEBUG_LOG(( "loadScheme: Old layout file version '%d'\n", version ));
-		MessageBox( TheEditor->getWindowHandle(),
-								"Old layout version, cannot open.", "Old File", MB_OK );
-		return FALSE;
+			DEBUG_LOG(( "loadScheme: Old layout file version '%d'\n", version ));
+			MessageBox( TheEditor->getWindowHandle(),
+									"Old layout version, cannot open.", "Old File", MB_OK );
+			return FALSE;
 
-	}  // end if
+		}  // end if
+	}
 
 	// default text colors
-	fscanf( fp, "Enabled Text: (%hhu,%hhu,%hhu,%hhu)\n", &colorR, &colorG, &colorB, &colorA );
-	m_enabledText.color = GameMakeColor( colorR, colorG, colorB, colorA );
-	fscanf( fp, "Enabled Text Border: (%hhu,%hhu,%hhu,%hhu)\n", &colorR, &colorG, &colorB, &colorA );
-	m_enabledText.borderColor = GameMakeColor( colorR, colorG, colorB, colorA );
-
-	fscanf( fp, "Disabled Text: (%hhu,%hhu,%hhu,%hhu)\n", &colorR, &colorG, &colorB, &colorA );
-	m_disabledText.color = GameMakeColor( colorR, colorG, colorB, colorA );
-	fscanf( fp, "Disabled Text Border: (%hhu,%hhu,%hhu,%hhu)\n", &colorR, &colorG, &colorB, &colorA );
-	m_disabledText.borderColor = GameMakeColor( colorR, colorG, colorB, colorA );
-
-	fscanf( fp, "Hilite Text: (%hhu,%hhu,%hhu,%hhu)\n", &colorR, &colorG, &colorB, &colorA );
-	m_hiliteText.color = GameMakeColor( colorR, colorG, colorB, colorA );
-	fscanf( fp, "Hilite Text Border: (%hhu,%hhu,%hhu,%hhu)\n", &colorR, &colorG, &colorB, &colorA );
-	m_hiliteText.borderColor = GameMakeColor( colorR, colorG, colorB, colorA );
-
+	if (fscanf( fp, "Enabled Text: (%hhu,%hhu,%hhu,%hhu)\n", &colorR, &colorG, &colorB, &colorA ) == 4)
+	{
+		m_enabledText.color = GameMakeColor( colorR, colorG, colorB, colorA );
+	}
+	if (fscanf( fp, "Enabled Text Border: (%hhu,%hhu,%hhu,%hhu)\n", &colorR, &colorG, &colorB, &colorA ) == 4)
+	{
+		m_enabledText.borderColor = GameMakeColor( colorR, colorG, colorB, colorA );
+	}
+	if (fscanf( fp, "Disabled Text: (%hhu,%hhu,%hhu,%hhu)\n", &colorR, &colorG, &colorB, &colorA ) == 4)
+	{
+		m_disabledText.color = GameMakeColor( colorR, colorG, colorB, colorA );
+	}
+	if (fscanf( fp, "Disabled Text Border: (%hhu,%hhu,%hhu,%hhu)\n", &colorR, &colorG, &colorB, &colorA ) == 4)
+	{
+		m_disabledText.borderColor = GameMakeColor( colorR, colorG, colorB, colorA );
+	}
+	if (fscanf( fp, "Hilite Text: (%hhu,%hhu,%hhu,%hhu)\n", &colorR, &colorG, &colorB, &colorA ) == 4)
+	{
+		m_hiliteText.color = GameMakeColor( colorR, colorG, colorB, colorA );
+	}
+	if (fscanf( fp, "Hilite Text Border: (%hhu,%hhu,%hhu,%hhu)\n", &colorR, &colorG, &colorB, &colorA ) == 4)
+	{
+		m_hiliteText.borderColor = GameMakeColor( colorR, colorG, colorB, colorA );
+	}
 	// default font
 	char fontBuffer[ 256 ];
 	Int size, bold;
@@ -2399,33 +2410,36 @@ Bool LayoutScheme::loadScheme( char *filename )
 	c = fgetc( fp );  // the end quite itself
 
 	// read the size and bold data elements
-	fscanf( fp, " Size: %i Bold: %i\n", &size, &bold );
-
-	// set the font
-	m_font = TheFontLibrary->getFont( AsciiString(fontBuffer), size, bold );
+	if(fscanf( fp, " Size: %i Bold: %i\n", &size, &bold ) == 2)
+	{
+		// set the font
+		m_font = TheFontLibrary->getFont( AsciiString(fontBuffer), size, bold );
+	}
 
 	// all the data for all the states
 	Int numStates, state;
 	char imageBuffer[ 128 ];
-	fscanf( fp, "Number of states: %i\n", &numStates );
-	for( Int i = 0; i < numStates; i++ )
+	if (fscanf( fp, "Number of states: %i\n", &numStates ) == 1)
 	{
+		for( Int i = 0; i < numStates; i++ )
+		{
 
-		// read all the data
-		fscanf( fp, "%d: Image: %s Color: (%hhu,%hhu,%hhu,%hhu) Border: (%hhu,%hhu,%hhu,%hhu)\n",
-						&state, imageBuffer, &colorR, &colorG, &colorB, &colorA,
-						&bColorR, &bColorG, &bColorB, &bColorA );
+			// read all the data
+			if( fscanf( fp, "%d: Image: %s Color: (%hhu,%hhu,%hhu,%hhu) Border: (%hhu,%hhu,%hhu,%hhu)\n",
+							&state, imageBuffer, &colorR, &colorG, &colorB, &colorA,
+							&bColorR, &bColorG, &bColorB, &bColorA ) == 10)
+			{
+				// sanity
+				assert( state == i );
 
-		// sanity
-		assert( state == i );
-
-		// store the info
-		storeImageAndColor( (StateIdentifier)state,
-												TheMappedImageCollection->findImageByName( AsciiString(  imageBuffer ) ),
-												GameMakeColor( colorR, colorG, colorB, colorA ),
-												GameMakeColor( bColorR, bColorG, bColorB, bColorA ) );
-
-	}  // end for i
+				// store the info
+				storeImageAndColor( (StateIdentifier)state,
+														TheMappedImageCollection->findImageByName( AsciiString(  imageBuffer ) ),
+														GameMakeColor( colorR, colorG, colorB, colorA ),
+														GameMakeColor( bColorR, bColorG, bColorB, bColorA ) );
+			}
+		}  // end for i
+	}
 
 	// close the file
 	fclose( fp );

--- a/GeneralsMD/Code/Tools/wdump/chunk_d.cpp
+++ b/GeneralsMD/Code/Tools/wdump/chunk_d.cpp
@@ -2396,7 +2396,7 @@ void ChunkData::Add_Chunk(ChunkLoadClass & cload, ChunkItem *Parent)
 				existing.SetAt(data, data);
 
 				if(theApp.TextureDumpFile != 0) 
-					fprintf(theApp.TextureDumpFile, "%s,%s\n", theApp.Filename, data);
+					fprintf(theApp.TextureDumpFile, "%s,%s\n", (LPCTSTR)theApp.Filename, data);
 				TRACE("%s,%s\n", theApp.Filename, data);
 			}
 		}


### PR DESCRIPTION
Fixes the following warnings:

- Incorrect string format specifier used
- Number of parameters not matching number of format specifiers
- Not using the return result of fscanf (separate commit)