### PR TITLE
[GEN][ZH] Fix dangling pointer at Player::m_defaultTeam when Team is destroyed

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -1301,6 +1301,10 @@ void Player::preTeamDestroy( const Team *team )
 	// ai notification callback
 	if( m_ai )
 		m_ai->aiPreTeamDestroy( team );
+
+	// TheSuperHackers @bugfix Mauller/Xezon 03/05/2025 Clear the default team to prevent dangling pointer usage
+	if( m_defaultTeam == team )
+		m_defaultTeam = NULL;
 }  // preTeamDestroy
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -1652,6 +1652,10 @@ void Player::preTeamDestroy( const Team *team )
 	// ai notification callback
 	if( m_ai )
 		m_ai->aiPreTeamDestroy( team );
+
+	// TheSuperHackers @bugfix Mauller/Xezon 03/05/2025 Clear the default team to prevent dangling pointer usage
+	if( m_defaultTeam == team )
+		m_defaultTeam = NULL;
 }  // preTeamDestroy
 
 //-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR performs some extra sanitation on the player during reset to prevent invalid codepaths being entered when the teamlist is cleared and teams are destroyed.

The way to trigger the issue that this fixes is to play as the USA, build a strategy center and enable the "search and destroy" battleplan. Make sure you have a few units then exit the game.

The full explanation for what is occuring can be found in the attached issue.

This issues does not cause crashing in the retail executable.

- Closes: #773 