### PR TITLE
[GEN][ZH] Fix possible division by zero in W3DCommandBarGenExpDraw()

### DIFF
--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/GUICallbacks/W3DControlBar.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/GUICallbacks/W3DControlBar.cpp
@@ -497,8 +497,14 @@ void W3DCommandBarGenExpDraw( GameWindow *window, WinInstanceData *instData )
 	static const Image *endBar = TheMappedImageCollection->findImageByName("GenExpBarTop1");
 	static const Image *beginBar = TheMappedImageCollection->findImageByName("GenExpBarBottom1");
 	static const Image *centerBar = TheMappedImageCollection->findImageByName("GenExpBar1");
-	Int progress;
-	progress = ((player->getSkillPoints() - player->getSkillPointsLevelDown()) * 100) /(player->getSkillPointsLevelUp() - player->getSkillPointsLevelDown());
+	Int progress = 0;
+	Int skillPointsRequired = player->getSkillPointsLevelUp() - player->getSkillPointsLevelDown();
+
+	// TheSuperHackers @bugfix Mauller 04/05/2025 Prevent possible division by zero
+	if ( skillPointsRequired > 0)
+	{
+		progress = ( ((player->getSkillPoints() - player->getSkillPointsLevelDown()) * 100) / skillPointsRequired );
+	}
 	
 	if(progress <= 0)
 		return;

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/GUICallbacks/W3DControlBar.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/GUICallbacks/W3DControlBar.cpp
@@ -497,8 +497,14 @@ void W3DCommandBarGenExpDraw( GameWindow *window, WinInstanceData *instData )
 	static const Image *endBar = TheMappedImageCollection->findImageByName("GenExpBarTop1");
 	static const Image *beginBar = TheMappedImageCollection->findImageByName("GenExpBarBottom1");
 	static const Image *centerBar = TheMappedImageCollection->findImageByName("GenExpBar1");
-	Int progress;
-	progress = ((player->getSkillPoints() - player->getSkillPointsLevelDown()) * 100) /(player->getSkillPointsLevelUp() - player->getSkillPointsLevelDown());
+	Int progress = 0;
+	Int skillPointsRequired = player->getSkillPointsLevelUp() - player->getSkillPointsLevelDown();
+
+	// TheSuperHackers @bugfix Mauller 04/05/2025 Prevent possible division by zero
+	if ( skillPointsRequired > 0)
+	{
+		progress = ( ((player->getSkillPoints() - player->getSkillPointsLevelDown()) * 100) / skillPointsRequired );
+	}
 	
 	if(progress <= 0)
 		return;


### PR DESCRIPTION
* Fixes #797

This PR prevents a possible division by zero from occuring when player progress is calculated.
