### PR TITLE
[CMAKE] Use CMAKE_CURRENT_SOURCE_DIR instead of dot for current directories

### DIFF
--- a/Core/Libraries/Source/Compression/CMakeLists.txt
+++ b/Core/Libraries/Source/Compression/CMakeLists.txt
@@ -25,7 +25,7 @@ set_target_properties(core_compression PROPERTIES OUTPUT_NAME compression)
 target_sources(core_compression PRIVATE ${COMPRESSION_SRC})
 
 target_include_directories(core_compression INTERFACE
-    .
+    ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 target_link_libraries(core_compression PRIVATE

--- a/Core/Libraries/Source/WWVegas/CMakeLists.txt
+++ b/Core/Libraries/Source/WWVegas/CMakeLists.txt
@@ -15,7 +15,7 @@ target_link_libraries(core_wwcommon INTERFACE
 )
 
 target_include_directories(core_wwcommon INTERFACE
-    .
+    ${CMAKE_CURRENT_SOURCE_DIR}
     # WW3D2
     WWAudio
     WWDebug
@@ -38,7 +38,7 @@ add_subdirectory(WWStub)
 add_library(core_wwvegas INTERFACE)
 
 target_include_directories(core_wwvegas INTERFACE
-    .
+    ${CMAKE_CURRENT_SOURCE_DIR}
     #WW3D2
     WWAudio
     WWDebug

--- a/Core/Libraries/Source/WWVegas/WWLib/CMakeLists.txt
+++ b/Core/Libraries/Source/WWVegas/WWLib/CMakeLists.txt
@@ -164,7 +164,7 @@ set_target_properties(core_wwlib PROPERTIES OUTPUT_NAME wwlib)
 target_sources(core_wwlib PRIVATE ${WWLIB_SRC})
 
 target_include_directories(core_wwlib PUBLIC
-    .
+    ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 target_link_libraries(core_wwlib PRIVATE

--- a/Core/Tools/mangler/CMakeLists.txt
+++ b/Core/Tools/mangler/CMakeLists.txt
@@ -60,7 +60,11 @@ add_library(core_manglerlib STATIC)
 set_target_properties(core_manglerlib PROPERTIES OUTPUT_NAME manglerlib)
 
 target_sources(core_manglerlib PUBLIC ${MANGLERLIB_SRC})
-target_include_directories(core_manglerlib PRIVATE . wlib wnet)
+target_include_directories(core_manglerlib PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    wlib
+    wnet
+)
 target_link_libraries(core_manglerlib PRIVATE wsock32)
 target_link_libraries(core_manglerlib PUBLIC
     core_config
@@ -73,7 +77,11 @@ add_executable(core_mangler WIN32)
 set_target_properties(core_mangler PROPERTIES OUTPUT_NAME mangler)
 
 target_sources(core_mangler PRIVATE ${MANGLER_SRC})
-target_include_directories(core_mangler PRIVATE . wlib wnet)
+target_include_directories(core_mangler PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    wlib
+    wnet
+)
 target_link_libraries(core_mangler PRIVATE core_manglerlib)
 
 if(WIN32 OR "${CMAKE_SYSTEM}" MATCHES "Windows")
@@ -87,7 +95,11 @@ add_executable(core_manglertest WIN32)
 set_target_properties(core_manglertest PROPERTIES OUTPUT_NAME manglertest)
 
 target_sources(core_manglertest PRIVATE ${MANGLERTEST_SRC})
-target_include_directories(core_manglertest PRIVATE . wlib wnet)
+target_include_directories(core_manglertest PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    wlib
+    wnet
+)
 target_link_libraries(core_manglertest PRIVATE core_manglerlib)
 
 if(WIN32 OR "${CMAKE_SYSTEM}" MATCHES "Windows")

--- a/Core/Tools/matchbot/CMakeLists.txt
+++ b/Core/Tools/matchbot/CMakeLists.txt
@@ -64,7 +64,11 @@ set_target_properties(core_matchbot PROPERTIES OUTPUT_NAME matchbot)
 
 target_sources(core_matchbot PRIVATE ${MATCHBOT_SRC})
 
-target_include_directories(core_matchbot PRIVATE . wlib wnet)
+target_include_directories(core_matchbot PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    wlib
+    wnet
+)
 
 target_link_libraries(core_matchbot PRIVATE
     gamespy::gamespy

--- a/Dependencies/SafeDisc/CMakeLists.txt
+++ b/Dependencies/SafeDisc/CMakeLists.txt
@@ -1,2 +1,4 @@
 add_library(safedisc INTERFACE)
-target_include_directories(safedisc INTERFACE .)
+target_include_directories(safedisc INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/Generals/Code/Libraries/Source/WWVegas/CMakeLists.txt
+++ b/Generals/Code/Libraries/Source/WWVegas/CMakeLists.txt
@@ -11,7 +11,7 @@ target_link_libraries(g_wwcommon INTERFACE
 )
 
 target_include_directories(g_wwcommon INTERFACE
-    .
+    ${CMAKE_CURRENT_SOURCE_DIR}
     WW3D2
 )
 
@@ -23,7 +23,7 @@ add_subdirectory(WWDownload)
 add_library(g_wwvegas INTERFACE)
 
 target_include_directories(g_wwvegas INTERFACE
-    .
+    ${CMAKE_CURRENT_SOURCE_DIR}
     WW3D2
 )
 

--- a/Generals/Code/Tools/WorldBuilder/CMakeLists.txt
+++ b/Generals/Code/Tools/WorldBuilder/CMakeLists.txt
@@ -199,7 +199,7 @@ set(WORLDBUILDER_SRC
 add_executable(g_worldbuilder WIN32)
 
 target_include_directories(g_worldbuilder PRIVATE
-    .
+    ${CMAKE_CURRENT_SOURCE_DIR}
     include
     res
 )

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/CMakeLists.txt
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/CMakeLists.txt
@@ -11,7 +11,7 @@ target_link_libraries(z_wwcommon INTERFACE
 )
 
 target_include_directories(z_wwcommon INTERFACE
-    .
+    ${CMAKE_CURRENT_SOURCE_DIR}
     WW3D2
 )
 
@@ -23,7 +23,7 @@ add_subdirectory(WWDownload)
 add_library(z_wwvegas INTERFACE)
 
 target_include_directories(z_wwvegas INTERFACE
-    .
+    ${CMAKE_CURRENT_SOURCE_DIR}
     WW3D2
 )
 

--- a/GeneralsMD/Code/Libraries/Source/debug/CMakeLists.txt
+++ b/GeneralsMD/Code/Libraries/Source/debug/CMakeLists.txt
@@ -29,7 +29,7 @@ add_library(z_debug STATIC)
 target_sources(z_debug PRIVATE ${DEBUG_SRC})
 
 target_include_directories(z_debug INTERFACE
-    .
+    ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 target_link_libraries(z_debug PRIVATE

--- a/GeneralsMD/Code/Libraries/Source/profile/CMakeLists.txt
+++ b/GeneralsMD/Code/Libraries/Source/profile/CMakeLists.txt
@@ -23,7 +23,7 @@ add_library(z_profile STATIC)
 target_sources(z_profile PRIVATE ${PROFILE_SRC})
 
 target_include_directories(z_profile INTERFACE
-    .
+    ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 target_link_libraries(z_profile PRIVATE

--- a/GeneralsMD/Code/Main/CMakeLists.txt
+++ b/GeneralsMD/Code/Main/CMakeLists.txt
@@ -50,7 +50,7 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/BuildVersion.h
 target_link_options(z_generals PRIVATE "/NODEFAULTLIB:libci.lib")
 
 target_include_directories(z_generals PRIVATE
-    .
+    ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}
 )
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/CMakeLists.txt
+++ b/GeneralsMD/Code/Tools/WorldBuilder/CMakeLists.txt
@@ -204,7 +204,7 @@ add_executable(z_worldbuilder WIN32)
 target_sources(z_worldbuilder PRIVATE ${WORLDBUILDER_SRC})
 
 target_include_directories(z_worldbuilder PRIVATE
-    .
+    ${CMAKE_CURRENT_SOURCE_DIR}
     include
     res
 )


### PR DESCRIPTION
This change replaces dots with CMAKE_CURRENT_SOURCE_DIR to point to current directories.

This makes the setup just a bit cleaner, because then folders no longer look like this:
```
path/to/folder/.
```
but like this:
```
path/to/folder
```