### PR TITLE
[GEN][ZH] Initialize supplyTruck variable

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -1041,9 +1041,11 @@ Bool AIPlayer::isLocationSafe(const Coord3D *pos, const ThingTemplate *tthing )
 void AIPlayer::onUnitProduced( Object *factory, Object *unit )
 {
 	Bool found = false;
-	// TheSuperHackers @fix helmutbuhler 05/05/2025 Fixes uninitialized variable.
-	Bool supplyTruck = true;
-
+#if defined(_MSC_VER) && _MSC_VER < 1300
+	Bool supplyTruck = true; // TheSuperHackers @fix helmutbuhler 05/05/2025 This was originally uninitialized and very likely true
+#else
+	Bool supplyTruck = false;
+#endif
 	// factory could be NULL at the start of the game.
 	if (factory == NULL) {
 		return;

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -1041,11 +1041,14 @@ Bool AIPlayer::isLocationSafe(const Coord3D *pos, const ThingTemplate *tthing )
 void AIPlayer::onUnitProduced( Object *factory, Object *unit )
 {
 	Bool found = false;
+	// TheSuperHackers @fix Mauller 26/04/2025 Fixes uninitialized variable.
+	// To keep retail compatibility it needs to be set true in VS6 builds.
 #if defined(_MSC_VER) && _MSC_VER < 1300
-	Bool supplyTruck = true; // TheSuperHackers @fix helmutbuhler 05/05/2025 This was originally uninitialized and very likely true
+	Bool supplyTruck = true;
 #else
 	Bool supplyTruck = false;
 #endif
+
 	// factory could be NULL at the start of the game.
 	if (factory == NULL) {
 		return;

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -1041,13 +1041,8 @@ Bool AIPlayer::isLocationSafe(const Coord3D *pos, const ThingTemplate *tthing )
 void AIPlayer::onUnitProduced( Object *factory, Object *unit )
 {
 	Bool found = false;
-	// TheSuperHackers @fix Mauller 26/04/2025 Fixes uninitialized variable.
-	// To keep retail compatibility this needs to remain uninitialized in VS6 builds.
-#if defined(_MSC_VER) && _MSC_VER < 1300
-	Bool supplyTruck;
-#else
-	Bool supplyTruck = false;
-#endif
+	// TheSuperHackers @fix helmutbuhler 05/05/2025 Fixes uninitialized variable.
+	Bool supplyTruck = true;
 
 	// factory could be NULL at the start of the game.
 	if (factory == NULL) {

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -1048,11 +1048,14 @@ Bool AIPlayer::isLocationSafe(const Coord3D *pos, const ThingTemplate *tthing )
 void AIPlayer::onUnitProduced( Object *factory, Object *unit )
 {
 	Bool found = false;
+	// TheSuperHackers @fix Mauller 26/04/2025 Fixes uninitialized variable.
+	// To keep retail compatibility it needs to be set true in VS6 builds.
 #if defined(_MSC_VER) && _MSC_VER < 1300
-	Bool supplyTruck = true; // TheSuperHackers @fix helmutbuhler 05/05/2025 This was originally uninitialized and very likely true
+	Bool supplyTruck = true;
 #else
 	Bool supplyTruck = false;
 #endif
+
 	// factory could be NULL at the start of the game.
 	if (factory == NULL) {
 		return;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -1048,9 +1048,11 @@ Bool AIPlayer::isLocationSafe(const Coord3D *pos, const ThingTemplate *tthing )
 void AIPlayer::onUnitProduced( Object *factory, Object *unit )
 {
 	Bool found = false;
-	// TheSuperHackers @fix helmutbuhler 05/05/2025 Fixes uninitialized variable.
-	Bool supplyTruck = true;
-
+#if defined(_MSC_VER) && _MSC_VER < 1300
+	Bool supplyTruck = true; // TheSuperHackers @fix helmutbuhler 05/05/2025 This was originally uninitialized and very likely true
+#else
+	Bool supplyTruck = false;
+#endif
 	// factory could be NULL at the start of the game.
 	if (factory == NULL) {
 		return;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -1048,13 +1048,8 @@ Bool AIPlayer::isLocationSafe(const Coord3D *pos, const ThingTemplate *tthing )
 void AIPlayer::onUnitProduced( Object *factory, Object *unit )
 {
 	Bool found = false;
-	// TheSuperHackers @fix Mauller 26/04/2025 Fixes uninitialized variable.
-	// To keep retail compatibility this needs to remain uninitialized in VS6 builds.
-#if defined(_MSC_VER) && _MSC_VER < 1300
-	Bool supplyTruck;
-#else
-	Bool supplyTruck = false;
-#endif
+	// TheSuperHackers @fix helmutbuhler 05/05/2025 Fixes uninitialized variable.
+	Bool supplyTruck = true;
 
 	// factory could be NULL at the start of the game.
 	if (factory == NULL) {


### PR DESCRIPTION
* Follow up for #653

So I did a bunch of automated testing with about 1400 replays (that's about 20 days of combined gametime). All these replays 
- did not mismatch when they were originally played (that is stored in the replay)
- have at least 2 human players
- have at least one AI player
- were played on a compatible 1.04 or 1.05 retail version

I checked to leave the supplyTruck variable uninitialized and initialized to true. The end result was that not a single replay mismatched with it initialized to true. (I already confirmed that initializing to false causes mismatches, so I didn't check that again)

So I suggest to initialize it. Why?
 - I already confirmed that enabling some logging in StateMachine::internalGetState will cause mismatches when the variable is left uninitialized. (See #759)
 - Some future changes in very different areas can cause mismatches in the future
 - Even in the current version, leaving it uninitialized can potentially cause mismatches when two peers happen to have different stack memory there (that's quite difficult to check though)

I realize that some tests were already made where it was concluded to leave it uninitialized. But those tests were made on a version that added some logging in the function with the uninitialized variable. That likely skewed the results. I also asked for replays that were used in those tests, but have received none so far.

If there is demand I can upload the replays I tested with. I will also hopefully be able to make a PR with the automated testing code soon.

I can also conditionally initialize the variable to false on newer compilers, if that would be more logical (I haven't studied the code that uses that variable much).