### PR TITLE
[GEN][ZH] Fix crash when DEBUG_CRASHING is enabled and loading a replay with unicode characters

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Recorder.cpp
@@ -1115,7 +1115,11 @@ Bool RecorderClass::playbackFile(AsciiString filename)
 		debugString = "EXE is different:\n";
 		if (versionStringDiff)
 		{
-			tempStr.format("   Version [%ls] vs [%ls]\n", TheVersion->getUnicodeVersion().str(), header.versionString.str());
+			// TheSuperHackers @fix helmutbuhler 05/05/2025
+			// AsciiString::format with %ls can make internal _vsnprintf call fail on some strings. We convert using translate here.
+			UnicodeString tempStrWide;
+			tempStrWide.format(L"   Version [%s] vs [%s]\n", TheVersion->getUnicodeVersion().str(), header.versionString.str());
+			tempStr.translate(tempStrWide);
 			debugString.concat(tempStr);
 		}
 		if (versionTimeStringDiff)

--- a/Generals/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Recorder.cpp
@@ -1099,8 +1099,8 @@ Bool RecorderClass::playbackFile(AsciiString filename)
 	{
 		return FALSE;
 	}
-#ifdef DEBUG_LOGGING
 
+#ifdef DEBUG_CRASHING
 	Bool versionStringDiff = header.versionString != TheVersion->getUnicodeVersion();
 	Bool versionTimeStringDiff = header.versionTimeString != TheVersion->getUnicodeBuildTime();
 	Bool versionNumberDiff = header.versionNumber != TheVersion->getVersionNumber();
@@ -1112,19 +1112,20 @@ Bool RecorderClass::playbackFile(AsciiString filename)
 	AsciiString tempStr;
 	if (exeDifferent)
 	{
+		// TheSuperHackers @fix helmutbuhler 05/05/2025 No longer attempts to print unicode as ascii
+		// via a call to AsciiString::format with %ls format. It does not work with non-ascii characters.
+		UnicodeString tempStrWide;
 		debugString = "EXE is different:\n";
 		if (versionStringDiff)
 		{
-			// TheSuperHackers @fix helmutbuhler 05/05/2025
-			// AsciiString::format with %ls can make internal _vsnprintf call fail on some strings. We convert using translate here.
-			UnicodeString tempStrWide;
 			tempStrWide.format(L"   Version [%s] vs [%s]\n", TheVersion->getUnicodeVersion().str(), header.versionString.str());
 			tempStr.translate(tempStrWide);
 			debugString.concat(tempStr);
 		}
 		if (versionTimeStringDiff)
 		{
-			tempStr.format("   Build Time [%ls] vs [%ls]\n", TheVersion->getUnicodeBuildTime().str(), header.versionTimeString.str());
+			tempStrWide.format(L"   Build Time [%s] vs [%s]\n", TheVersion->getUnicodeBuildTime().str(), header.versionTimeString.str());
+			tempStr.translate(tempStrWide);
 			debugString.concat(tempStr);
 		}
 		if (versionNumberDiff)

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -1118,7 +1118,11 @@ Bool RecorderClass::playbackFile(AsciiString filename)
 		debugString = "EXE is different:\n";
 		if (versionStringDiff)
 		{
-			tempStr.format("   Version [%ls] vs [%ls]\n", TheVersion->getUnicodeVersion().str(), header.versionString.str());
+			// TheSuperHackers @fix helmutbuhler 05/05/2025
+			// AsciiString::format with %ls can make internal _vsnprintf call fail on some strings. We convert using translate here.
+			UnicodeString tempStrWide;
+			tempStrWide.format(L"   Version [%s] vs [%s]\n", TheVersion->getUnicodeVersion().str(), header.versionString.str());
+			tempStr.translate(tempStrWide);
 			debugString.concat(tempStr);
 		}
 		if (versionTimeStringDiff)

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -1102,8 +1102,8 @@ Bool RecorderClass::playbackFile(AsciiString filename)
 	{
 		return FALSE;
 	}
-#ifdef DEBUG_LOGGING
 
+#ifdef DEBUG_CRASHING
 	Bool versionStringDiff = header.versionString != TheVersion->getUnicodeVersion();
 	Bool versionTimeStringDiff = header.versionTimeString != TheVersion->getUnicodeBuildTime();
 	Bool versionNumberDiff = header.versionNumber != TheVersion->getVersionNumber();
@@ -1115,19 +1115,20 @@ Bool RecorderClass::playbackFile(AsciiString filename)
 	AsciiString tempStr;
 	if (exeDifferent)
 	{
+		// TheSuperHackers @fix helmutbuhler 05/05/2025 No longer attempts to print unicode as ascii
+		// via a call to AsciiString::format with %ls format. It does not work with non-ascii characters.
+		UnicodeString tempStrWide;
 		debugString = "EXE is different:\n";
 		if (versionStringDiff)
 		{
-			// TheSuperHackers @fix helmutbuhler 05/05/2025
-			// AsciiString::format with %ls can make internal _vsnprintf call fail on some strings. We convert using translate here.
-			UnicodeString tempStrWide;
 			tempStrWide.format(L"   Version [%s] vs [%s]\n", TheVersion->getUnicodeVersion().str(), header.versionString.str());
 			tempStr.translate(tempStrWide);
 			debugString.concat(tempStr);
 		}
 		if (versionTimeStringDiff)
 		{
-			tempStr.format("   Build Time [%ls] vs [%ls]\n", TheVersion->getUnicodeBuildTime().str(), header.versionTimeString.str());
+			tempStrWide.format(L"   Build Time [%s] vs [%s]\n", TheVersion->getUnicodeBuildTime().str(), header.versionTimeString.str());
+			tempStr.translate(tempStrWide);
 			debugString.concat(tempStr);
 		}
 		if (versionNumberDiff)


### PR DESCRIPTION
When AsciiString::format is called with format %ls it is supposed to convert Unicode to Ascii. When that conversion fails AsciiString::format throws an exception which results in a serious error.

Long term we should fix this by using UTF-8 everywhere, but for now using AsciiString::translate fixes the problem.

Note that this crash only occurs in debug build and is therefore no problem for retail version. Also the display of the version in the replay menu works fine, just this debug code for an assertion is crashing.

Here is a replay to test: 
[00-00-01_3v3_DESKTOPT_DESKTOPS_DESKTOPG_MediAI_MediAI_MediAI.zip](https://github.com/user-attachments/files/20078145/00-00-01_3v3_DESKTOPT_DESKTOPS_DESKTOPG_MediAI_MediAI_MediAI.zip)

### Callstack

```
 	KernelBase.dll!75bcb5e2()	Unknown
 	[Frames below may be incorrect and/or missing, no symbols loaded for KernelBase.dll]	
 	vcruntime140.dll!749248f7()	Unknown
>	[Inline Frame] generalsv.exe!AsciiString::format_va(const char * format, char *) Line 388	C++
 	generalsv.exe!AsciiString::format(const char * format, ...) Line 366	C++
 	generalsv.exe!RecorderClass::playbackFile(AsciiString filename) Line 1118	C++
 	generalsv.exe!ReplayMenuSystem(GameWindow * window, unsigned int msg, unsigned int mData1, unsigned int mData2) Line 503	C++
 	generalsv.exe!GameWindowManager::winSendSystemMsg(GameWindow * window, unsigned int msg, unsigned int mData1, unsigned int mData2) Line 709	C++
 	generalsv.exe!PassMessagesToParentSystem(GameWindow * window, unsigned int msg, unsigned int mData1, unsigned int mData2) Line 178	C++
 	generalsv.exe!GameWindowManager::winSendSystemMsg(GameWindow * window, unsigned int msg, unsigned int mData1, unsigned int mData2) Line 709	C++
 	generalsv.exe!PassMessagesToParentSystem(GameWindow * window, unsigned int msg, unsigned int mData1, unsigned int mData2) Line 178	C++
 	generalsv.exe!GameWindowManager::winSendSystemMsg(GameWindow * window, unsigned int msg, unsigned int mData1, unsigned int mData2) Line 709	C++
 	generalsv.exe!GadgetListBoxInput(GameWindow * window, unsigned int msg, unsigned int mData1, unsigned int mData2) Line 838	C++
 	generalsv.exe!GameWindowManager::winSendInputMsg(GameWindow * window, unsigned int msg, unsigned int mData1, unsigned int mData2) Line 728	C++
 	generalsv.exe!GameWindowManager::winProcessMouseEvent(GameWindowMessage msg, ICoord2D * mousePos, void * data) Line 931	C++
 	generalsv.exe!WindowTranslator::translateGameMessage(const GameMessage * msg) Line 229	C++
 	generalsv.exe!MessageStream::propagateMessages() Line 1063	C++
 	generalsv.exe!GameEngine::update() Line 562	C++
 	generalsv.exe!Win32GameEngine::update() Line 93	C++
 	generalsv.exe!GameEngine::execute() Line 635	C++
 	generalsv.exe!GameMain(int argc, char * * argv) Line 47	C++
 	generalsv.exe!WinMain(HINSTANCE__ * hInstance, HINSTANCE__ * hPrevInstance, char * lpCmdLine, int nCmdShow) Line 986	C++
 	[Inline Frame] generalsv.exe!invoke_main() Line 102	C++
 	generalsv.exe!__scrt_common_main_seh() Line 288	C++
 	kernel32.dll!75cefcc9()	Unknown
 	ntdll.dll!779682ae()	Unknown
 	ntdll.dll!7796827e()	Unknown
```