### PR TITLE
[GEN][ZH] Fix CRC debug logger deleting logs when shellmap is loaded

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/CRCDebug.cpp
+++ b/Generals/Code/GameEngine/Source/Common/CRCDebug.cpp
@@ -120,6 +120,8 @@ extern Bool inCRCGen;
 
 void CRCDebugStartNewGame()
 {
+	if (TheGameLogic->isInShellGame())
+		return;
 	if (g_saveDebugCRCPerFrame)
 	{
 		// Create folder for frame data, if it doesn't exist yet.

--- a/GeneralsMD/Code/GameEngine/Source/Common/CRCDebug.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/CRCDebug.cpp
@@ -120,6 +120,8 @@ extern Bool inCRCGen;
 
 void CRCDebugStartNewGame()
 {
+	if (TheGameLogic->isInShellGame())
+		return;
 	if (g_saveDebugCRCPerFrame)
 	{
 		// Create folder for frame data, if it doesn't exist yet.


### PR DESCRIPTION
When the feature is enabled to output crc log files per frame, CRCDebugStartNewGame() is supposed to clear the folder with those files when a new game is started.
But it's not supposed to do that when the shell map is loaded. (shellmap frames are not logged)

(I didn't notice this while implementing this because I usually use -quickstart)