### PR TITLE
[GEN][ZH] Fix compile error in RecorderClass::cleanUpReplayFile when building RTS_DEBUG without DEBUG_LOGGING

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Recorder.cpp
@@ -296,6 +296,7 @@ void RecorderClass::cleanUpReplayFile( void )
 		oldFname.format("%s%s", getReplayDir().str(), m_fileName.str());
 		CopyFile(oldFname.str(), fname, TRUE);
 
+#ifdef DEBUG_LOGGING
 		const char* logFileName = DebugGetLogFileName();
 		if (logFileName[0] == '\0')
 			return;
@@ -349,6 +350,7 @@ void RecorderClass::cleanUpReplayFile( void )
 				ofp = NULL;
 			}
 		}
+#endif // DEBUG_LOGGING
 	}
 #endif
 }

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -296,6 +296,7 @@ void RecorderClass::cleanUpReplayFile( void )
 		oldFname.format("%s%s", getReplayDir().str(), m_fileName.str());
 		CopyFile(oldFname.str(), fname, TRUE);
 
+#ifdef DEBUG_LOGGING
 		const char* logFileName = DebugGetLogFileName();
 		if (logFileName[0] == '\0')
 			return;
@@ -349,6 +350,7 @@ void RecorderClass::cleanUpReplayFile( void )
 				ofp = NULL;
 			}
 		}
+#endif // DEBUG_LOGGING
 	}
 #endif
 }


### PR DESCRIPTION
* Follow up for #795

This change fixes a compile error in RecorderClass::cleanUpReplayFile when building RTS_DEBUG without DEBUG_LOGGING. Introduced by #795.