### PR TITLE
[GEN][ZH] Demote throw to assert in AsciiString::format_va, UnicodeString::format_va

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/System/AsciiString.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/AsciiString.cpp
@@ -379,7 +379,7 @@ void AsciiString::format_va(const char* format, va_list args)
 {
 	validate();
 	char buf[MAX_FORMAT_BUF_LEN];
-	const int result = _vsnprintf(buf, sizeof(buf)/sizeof(WideChar)-1, format, args);
+	const int result = _vsnprintf(buf, sizeof(buf)/sizeof(char)-1, format, args);
 	if (result >= 0)
 	{
 		set(buf);

--- a/Generals/Code/GameEngine/Source/Common/System/AsciiString.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/AsciiString.cpp
@@ -387,7 +387,7 @@ void AsciiString::format_va(const char* format, va_list args)
 	}
 	else
 	{
-		DEBUG_ASSERTCRASH(false, ("%s failed with code:%d format:\"%s\"", __FUNCTION__, result, format));
+		DEBUG_ASSERTCRASH(false, ("AsciiString::format_va failed with code:%d format:\"%s\"", result, format));
 	}
 }
 

--- a/Generals/Code/GameEngine/Source/Common/System/AsciiString.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/AsciiString.cpp
@@ -371,12 +371,7 @@ void AsciiString::format(const char* format, ...)
 // -----------------------------------------------------
 void AsciiString::format_va(const AsciiString& format, va_list args)
 {
-	validate();
-	char buf[MAX_FORMAT_BUF_LEN];
-  if (_vsnprintf(buf, sizeof(buf)/sizeof(char)-1, format.str(), args) < 0)
-			throw ERROR_OUT_OF_MEMORY;
-	set(buf);
-	validate();
+	format_va(format.str(), args);
 }
 
 // -----------------------------------------------------
@@ -384,10 +379,16 @@ void AsciiString::format_va(const char* format, va_list args)
 {
 	validate();
 	char buf[MAX_FORMAT_BUF_LEN];
-  if (_vsnprintf(buf, sizeof(buf)/sizeof(char)-1, format, args) < 0)
-			throw ERROR_OUT_OF_MEMORY;
-	set(buf);
-	validate();
+	const int result = _vsnprintf(buf, sizeof(buf)/sizeof(WideChar)-1, format, args);
+	if (result >= 0)
+	{
+		set(buf);
+		validate();
+	}
+	else
+	{
+		DEBUG_ASSERTCRASH(false, ("%s failed with code:%d format:\"%s\"", __FUNCTION__, result, format));
+	}
 }
 
 // -----------------------------------------------------

--- a/Generals/Code/GameEngine/Source/Common/System/UnicodeString.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/UnicodeString.cpp
@@ -324,7 +324,7 @@ void UnicodeString::format_va(const WideChar* format, va_list args)
 	}
 	else
 	{
-		DEBUG_ASSERTCRASH(false, ("%s failed with code:%d", __FUNCTION__, result));
+		DEBUG_ASSERTCRASH(false, ("UnicodeString::format_va failed with code:%d", result));
 	}
 }
 

--- a/Generals/Code/GameEngine/Source/Common/System/UnicodeString.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/UnicodeString.cpp
@@ -308,12 +308,7 @@ void UnicodeString::format(const WideChar* format, ...)
 // -----------------------------------------------------
 void UnicodeString::format_va(const UnicodeString& format, va_list args)
 {
-	validate();
-	WideChar buf[MAX_FORMAT_BUF_LEN];
-  if (_vsnwprintf(buf, sizeof(buf)/sizeof(WideChar)-1, format.str(), args) < 0)
-			throw ERROR_OUT_OF_MEMORY;
-	set(buf);
-	validate();
+	format_va(format.str(), args);
 }
 
 // -----------------------------------------------------
@@ -321,10 +316,16 @@ void UnicodeString::format_va(const WideChar* format, va_list args)
 {
 	validate();
 	WideChar buf[MAX_FORMAT_BUF_LEN];
-  if (_vsnwprintf(buf, sizeof(buf)/sizeof(WideChar)-1, format, args) < 0)
-			throw ERROR_OUT_OF_MEMORY;
-	set(buf);
-	validate();
+	const int result = _vsnwprintf(buf, sizeof(buf)/sizeof(WideChar)-1, format, args);
+	if (result >= 0)
+	{
+		set(buf);
+		validate();
+	}
+	else
+	{
+		DEBUG_ASSERTCRASH(false, ("%s failed with code:%d", __FUNCTION__, result));
+	}
 }
 
 //-----------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/AsciiString.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/AsciiString.cpp
@@ -292,7 +292,7 @@ void AsciiString::format_va(const char* format, va_list args)
 {
 	validate();
 	char buf[MAX_FORMAT_BUF_LEN];
-	const int result = _vsnprintf(buf, sizeof(buf)/sizeof(WideChar)-1, format, args);
+	const int result = _vsnprintf(buf, sizeof(buf)/sizeof(char)-1, format, args);
 	if (result >= 0)
 	{
 		set(buf);

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/AsciiString.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/AsciiString.cpp
@@ -284,12 +284,7 @@ void AsciiString::format(const char* format, ...)
 // -----------------------------------------------------
 void AsciiString::format_va(const AsciiString& format, va_list args)
 {
-	validate();
-	char buf[MAX_FORMAT_BUF_LEN];
-  if (_vsnprintf(buf, sizeof(buf)/sizeof(char)-1, format.str(), args) < 0)
-			throw ERROR_OUT_OF_MEMORY;
-	set(buf);
-	validate();
+	format_va(format.str(), args);
 }
 
 // -----------------------------------------------------
@@ -297,10 +292,16 @@ void AsciiString::format_va(const char* format, va_list args)
 {
 	validate();
 	char buf[MAX_FORMAT_BUF_LEN];
-  if (_vsnprintf(buf, sizeof(buf)/sizeof(char)-1, format, args) < 0)
-			throw ERROR_OUT_OF_MEMORY;
-	set(buf);
-	validate();
+	const int result = _vsnprintf(buf, sizeof(buf)/sizeof(WideChar)-1, format, args);
+	if (result >= 0)
+	{
+		set(buf);
+		validate();
+	}
+	else
+	{
+		DEBUG_ASSERTCRASH(false, ("%s failed with code:%d format:\"%s\"", __FUNCTION__, result, format));
+	}
 }
 
 // -----------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/AsciiString.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/AsciiString.cpp
@@ -300,7 +300,7 @@ void AsciiString::format_va(const char* format, va_list args)
 	}
 	else
 	{
-		DEBUG_ASSERTCRASH(false, ("%s failed with code:%d format:\"%s\"", __FUNCTION__, result, format));
+		DEBUG_ASSERTCRASH(false, ("AsciiString::format_va failed with code:%d format:\"%s\"", result, format));
 	}
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/UnicodeString.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/UnicodeString.cpp
@@ -324,7 +324,7 @@ void UnicodeString::format_va(const WideChar* format, va_list args)
 	}
 	else
 	{
-		DEBUG_ASSERTCRASH(false, ("%s failed with code:%d", __FUNCTION__, result));
+		DEBUG_ASSERTCRASH(false, ("UnicodeString::format_va failed with code:%d", result));
 	}
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/UnicodeString.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/UnicodeString.cpp
@@ -308,12 +308,7 @@ void UnicodeString::format(const WideChar* format, ...)
 // -----------------------------------------------------
 void UnicodeString::format_va(const UnicodeString& format, va_list args)
 {
-	validate();
-	WideChar buf[MAX_FORMAT_BUF_LEN];
-  if (_vsnwprintf(buf, sizeof(buf)/sizeof(WideChar)-1, format.str(), args) < 0)
-			throw ERROR_OUT_OF_MEMORY;
-	set(buf);
-	validate();
+	format_va(format.str(), args);
 }
 
 // -----------------------------------------------------
@@ -321,10 +316,16 @@ void UnicodeString::format_va(const WideChar* format, va_list args)
 {
 	validate();
 	WideChar buf[MAX_FORMAT_BUF_LEN];
-  if (_vsnwprintf(buf, sizeof(buf)/sizeof(WideChar)-1, format, args) < 0)
-			throw ERROR_OUT_OF_MEMORY;
-	set(buf);
-	validate();
+	const int result = _vsnwprintf(buf, sizeof(buf)/sizeof(WideChar)-1, format, args);
+	if (result >= 0)
+	{
+		set(buf);
+		validate();
+	}
+	else
+	{
+		DEBUG_ASSERTCRASH(false, ("%s failed with code:%d", __FUNCTION__, result));
+	}
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
* Relates to #824

This change demotes the unnecessary throw to debug assert in AsciiString::format_va and UnicodeString::format_va. Unnecessary throw because this format error is not necessarily a fatal error that needs to terminate the process. The program may just run fine with this error. The debug assert is enough to see the error.

## Original

![image](https://github.com/user-attachments/assets/e912fd18-1058-40a7-a6a9-36213e38d4a5)

## This change

![image](https://github.com/user-attachments/assets/5a24819a-4526-4702-9b70-baaae2d40841)
