### PR TITLE
[GEN][ZH] Fix game halting when left Alt key is pressed

### DIFF
--- a/Generals/Code/Main/WinMain.cpp
+++ b/Generals/Code/Main/WinMain.cpp
@@ -366,10 +366,12 @@ LRESULT CALLBACK WndProc( HWND hWnd, UINT message,
             // Prevent moving/sizing and power loss in fullscreen mode
             switch( wParam )
             {
+                case SC_KEYMENU:
+                    // TheSuperHackers @bugfix Mauller 10/05/2025 Always handle this command to prevent halting the game when left Alt is pressed.
+                    return 1;
                 case SC_MOVE:
                 case SC_SIZE:
                 case SC_MAXIMIZE:
-                case SC_KEYMENU:
                 case SC_MONITORPOWER:
                     if( FALSE == ApplicationIsWindowed )
                         return 1;

--- a/GeneralsMD/Code/Main/WinMain.cpp
+++ b/GeneralsMD/Code/Main/WinMain.cpp
@@ -369,10 +369,12 @@ LRESULT CALLBACK WndProc( HWND hWnd, UINT message,
             // Prevent moving/sizing and power loss in fullscreen mode
             switch( wParam )
             {
+                case SC_KEYMENU:
+                    // TheSuperHackers @bugfix Mauller 10/05/2025 Always handle this command to prevent halting the game when left Alt is pressed.
+                    return 1;
                 case SC_MOVE:
                 case SC_SIZE:
                 case SC_MAXIMIZE:
-                case SC_KEYMENU:
                 case SC_MONITORPOWER:
                     if( FALSE == ApplicationIsWindowed )
                         return 1;


### PR DESCRIPTION
This PR prevents the game from freezing when the left ALT key is pressed.

The underlying issue is due to the games window process not acknowledging the ```WM_SYSCOMMAND SC_KEYMENU``` message.

Due to this, the message is then processed by the default window process which then will try to open the windows context menu which does not exist in this instance but causes the message loop to freeze.

- Resolves: #105

This may also help prevent some mismatches that could be caused by a game freezing for too long when someone is playing in window mode.