### PR TITLE
[GEN][ZH] Introduce VC6_BUILD macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ if((WIN32 OR "${CMAKE_SYSTEM}" MATCHES "Windows") AND ${CMAKE_SIZEOF_VOID_P} EQU
 endif()
 
 # Define a dummy stlport target when not on VC6.
-if (IS_VS6_BUILD)
+if (IS_VC6_BUILD)
     include(cmake/stlport.cmake)
 else()
     add_library(stlport INTERFACE)
@@ -58,7 +58,7 @@ include(cmake/gamespy.cmake)
 include(cmake/lzhl.cmake)
 
 add_subdirectory(Dependencies/Benchmark)
-if (IS_VS6_BUILD)
+if (IS_VC6_BUILD)
     # The original max sdk does not compile against a modern compiler.
     # If there is a desire to make this work, then a fixed max sdk needs to be created.
     add_subdirectory(Dependencies/MaxSDK)

--- a/Core/Libraries/Source/WWVegas/WW3D2/CMakeLists.txt
+++ b/Core/Libraries/Source/WWVegas/WW3D2/CMakeLists.txt
@@ -237,7 +237,7 @@ add_library(corei_ww3d2 INTERFACE)
 
 target_sources(corei_ww3d2 INTERFACE ${WW3D2_SRC})
 
-if (NOT IS_VS6_BUILD)
+if (NOT IS_VC6_BUILD)
     target_link_libraries(corei_ww3d2 INTERFACE
         comsuppw
     )

--- a/Core/Libraries/Source/WWVegas/WW3D2/dx8webbrowser.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/dx8webbrowser.cpp
@@ -36,7 +36,7 @@
 
 #if ENABLE_EMBEDDED_BROWSER
 
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if VC6_BUILD
 
 // Import the Browser Type Library
 // BGC, the path for the dll file is pretty odd, no?
@@ -232,7 +232,7 @@ void	DX8WebBrowser::DestroyBrowser(const char* browsername)
 bool	DX8WebBrowser::Is_Browser_Open(const char* browsername)
 {
 	if(pBrowser == 0) return false;
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if VC6_BUILD
 	return (pBrowser->IsOpen(_bstr_t(browsername)) != 0);
 #else
 	long isOpen;

--- a/Core/Libraries/Source/WWVegas/WW3D2/dx8webbrowser.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/dx8webbrowser.cpp
@@ -36,7 +36,7 @@
 
 #if ENABLE_EMBEDDED_BROWSER
 
-#if VC6_BUILD
+#if defined(VC6_BUILD)
 
 // Import the Browser Type Library
 // BGC, the path for the dll file is pretty odd, no?
@@ -232,7 +232,7 @@ void	DX8WebBrowser::DestroyBrowser(const char* browsername)
 bool	DX8WebBrowser::Is_Browser_Open(const char* browsername)
 {
 	if(pBrowser == 0) return false;
-#if VC6_BUILD
+#if defined(VC6_BUILD)
 	return (pBrowser->IsOpen(_bstr_t(browsername)) != 0);
 #else
 	long isOpen;

--- a/Core/Libraries/Source/WWVegas/WWLib/TARGA.CPP
+++ b/Core/Libraries/Source/WWVegas/WWLib/TARGA.CPP
@@ -829,7 +829,7 @@ void Targa::XFlip(void)
 
 static __forceinline void _swapBytes(char *p1, char *p2, unsigned count)
 {
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if VC6_BUILD
   _asm
   {
     mov esi,[p1]

--- a/Core/Libraries/Source/WWVegas/WWLib/TARGA.CPP
+++ b/Core/Libraries/Source/WWVegas/WWLib/TARGA.CPP
@@ -829,7 +829,7 @@ void Targa::XFlip(void)
 
 static __forceinline void _swapBytes(char *p1, char *p2, unsigned count)
 {
-#if VC6_BUILD
+#if defined(VC6_BUILD)
   _asm
   {
     mov esi,[p1]

--- a/Core/Libraries/Source/WWVegas/WWLib/always.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/always.h
@@ -95,7 +95,7 @@
 	extern void* __cdecl operator new[]		(size_t nSize, const char *, int);
 	extern void __cdecl operator delete[]	(void *, const char *, int);
 
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if VC6_BUILD
 	// additional overloads for 'placement new'
 	//inline void* __cdecl operator new							(size_t s, void *p) { return p; }
 	//inline void __cdecl operator delete						(void *, void *p)		{ }

--- a/Core/Libraries/Source/WWVegas/WWLib/always.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/always.h
@@ -95,7 +95,7 @@
 	extern void* __cdecl operator new[]		(size_t nSize, const char *, int);
 	extern void __cdecl operator delete[]	(void *, const char *, int);
 
-#if VC6_BUILD
+#if defined(VC6_BUILD)
 	// additional overloads for 'placement new'
 	//inline void* __cdecl operator new							(size_t s, void *p) { return p; }
 	//inline void __cdecl operator delete						(void *, void *p)		{ }

--- a/Core/Libraries/Source/WWVegas/WWLib/cpudetect.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/cpudetect.cpp
@@ -805,7 +805,7 @@ void CPUDetectClass::Init_CPUID_Instruction()
    // because CodeWarrior seems to have problems with
    // the command (huh?)
 
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if VC6_BUILD
 #ifdef WIN32
    __asm
    {
@@ -851,7 +851,7 @@ void CPUDetectClass::Init_CPUID_Instruction()
 #else
 	// TheSuperHackers @info Mauller 30/3/2020 All modern CPUs have the CPUID instruction, VS22 code will not run on a cpu that doesn't.
 	HasCPUIDInstruction = true;
-#endif	// defined(_MSC_VER) && _MSC_VER < 1300
+#endif	// VC6_BUILD
 }
 
 void CPUDetectClass::Init_Processor_Features()

--- a/Core/Libraries/Source/WWVegas/WWLib/cpudetect.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/cpudetect.cpp
@@ -805,7 +805,7 @@ void CPUDetectClass::Init_CPUID_Instruction()
    // because CodeWarrior seems to have problems with
    // the command (huh?)
 
-#if VC6_BUILD
+#if defined(VC6_BUILD)
 #ifdef WIN32
    __asm
    {
@@ -851,7 +851,7 @@ void CPUDetectClass::Init_CPUID_Instruction()
 #else
 	// TheSuperHackers @info Mauller 30/3/2020 All modern CPUs have the CPUID instruction, VS22 code will not run on a cpu that doesn't.
 	HasCPUIDInstruction = true;
-#endif	// VC6_BUILD
+#endif	// defined(VC6_BUILD)
 }
 
 void CPUDetectClass::Init_Processor_Features()

--- a/Core/Libraries/Source/WWVegas/WWLib/mempool.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/mempool.h
@@ -157,7 +157,7 @@ private:
 ** Macro to declare the allocator for your class.  Put this in the cpp file for
 ** the class.
 */
-#if VC6_BUILD
+#if defined(VC6_BUILD)
 #define DEFINE_AUTO_POOL(T,BLOCKSIZE) \
 ObjectPoolClass<T,BLOCKSIZE> AutoPoolClass<T,BLOCKSIZE>::Allocator;
 #else

--- a/Core/Libraries/Source/WWVegas/WWLib/mempool.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/mempool.h
@@ -157,7 +157,7 @@ private:
 ** Macro to declare the allocator for your class.  Put this in the cpp file for
 ** the class.
 */
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if VC6_BUILD
 #define DEFINE_AUTO_POOL(T,BLOCKSIZE) \
 ObjectPoolClass<T,BLOCKSIZE> AutoPoolClass<T,BLOCKSIZE>::Allocator;
 #else

--- a/Core/Libraries/Source/WWVegas/WWLib/mutex.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/mutex.h
@@ -26,7 +26,7 @@
 #include "always.h"
 #include "thread.h"
 
-#if !VC6_BUILD
+#if !defined(VC6_BUILD)
 #include <atomic>
 #endif
 
@@ -120,7 +120,7 @@ public:
 
 class FastCriticalSectionClass
 {
-#if VC6_BUILD
+#if defined(VC6_BUILD)
 	// TheSuperHackers @info Mauller 30/03/2025 Added volatile to prevent reordering of critical sections if inlined
 	volatile unsigned Flag;
 #else
@@ -130,7 +130,7 @@ class FastCriticalSectionClass
 public:
 	// Name can (and usually should) be NULL. Use name only if you wish to create a globally unique mutex
 	FastCriticalSectionClass()
-#if VC6_BUILD
+#if defined(VC6_BUILD)
 		: Flag(0)
 #endif
 	{}
@@ -152,7 +152,7 @@ public:
 	private:
 
     void lock() {
-#if VC6_BUILD
+#if defined(VC6_BUILD)
 		  volatile unsigned& nFlag=cs.Flag;
 
 		  #define ts_lock _emit 0xF0
@@ -191,7 +191,7 @@ public:
     }
 
     void unlock() {
-#if VC6_BUILD
+#if defined(VC6_BUILD)
       cs.Flag=0;
 #else
       cs.Flag.clear(std::memory_order_release);

--- a/Core/Libraries/Source/WWVegas/WWLib/mutex.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/mutex.h
@@ -26,7 +26,7 @@
 #include "always.h"
 #include "thread.h"
 
-#if !(defined(_MSC_VER) && _MSC_VER < 1300)
+#if !VC6_BUILD
 #include <atomic>
 #endif
 
@@ -120,7 +120,7 @@ public:
 
 class FastCriticalSectionClass
 {
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if VC6_BUILD
 	// TheSuperHackers @info Mauller 30/03/2025 Added volatile to prevent reordering of critical sections if inlined
 	volatile unsigned Flag;
 #else
@@ -130,7 +130,7 @@ class FastCriticalSectionClass
 public:
 	// Name can (and usually should) be NULL. Use name only if you wish to create a globally unique mutex
 	FastCriticalSectionClass()
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if VC6_BUILD
 		: Flag(0)
 #endif
 	{}
@@ -152,7 +152,7 @@ public:
 	private:
 
     void lock() {
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if VC6_BUILD
 		  volatile unsigned& nFlag=cs.Flag;
 
 		  #define ts_lock _emit 0xF0
@@ -191,7 +191,7 @@ public:
     }
 
     void unlock() {
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if VC6_BUILD
       cs.Flag=0;
 #else
       cs.Flag.clear(std::memory_order_release);

--- a/Core/Libraries/Source/profile/internal.h
+++ b/Core/Libraries/Source/profile/internal.h
@@ -38,7 +38,7 @@
 #include "internal_cmd.h"
 #include "internal_result.h"
 
-#if !VC6_BUILD
+#if !defined(VC6_BUILD)
 #include <atomic>
 #include <Utility/intrin_compat.h>
 #endif
@@ -50,7 +50,7 @@ class ProfileFastCS
   
 	static HANDLE testEvent;
 
-#if VC6_BUILD
+#if defined(VC6_BUILD)
 	volatile unsigned m_Flag;
 
 	void ThreadSafeSetFlag()
@@ -137,7 +137,7 @@ void ProfileFreeMemory(void *ptr);
 
 __forceinline void ProfileGetTime(__int64 &t)
 {
-#if VC6_BUILD
+#if defined(VC6_BUILD)
   _asm
   {
     mov ecx,[t]

--- a/Core/Libraries/Source/profile/internal.h
+++ b/Core/Libraries/Source/profile/internal.h
@@ -38,7 +38,7 @@
 #include "internal_cmd.h"
 #include "internal_result.h"
 
-#if !(defined(_MSC_VER) && _MSC_VER < 1300)
+#if !VC6_BUILD
 #include <atomic>
 #include <Utility/intrin_compat.h>
 #endif
@@ -50,7 +50,7 @@ class ProfileFastCS
   
 	static HANDLE testEvent;
 
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if VC6_BUILD
 	volatile unsigned m_Flag;
 
 	void ThreadSafeSetFlag()
@@ -137,7 +137,7 @@ void ProfileFreeMemory(void *ptr);
 
 __forceinline void ProfileGetTime(__int64 &t)
 {
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if VC6_BUILD
   _asm
   {
     mov ecx,[t]

--- a/Core/Tools/Compress/CMakeLists.txt
+++ b/Core/Tools/Compress/CMakeLists.txt
@@ -14,7 +14,7 @@ target_link_libraries(core_compress PRIVATE
 )
 
 if(WIN32 OR "${CMAKE_SYSTEM}" MATCHES "Windows")
-    if(IS_VS6_BUILD)
+    if(IS_VC6_BUILD)
         target_compile_definitions(core_compress PRIVATE vsnprintf=_vsnprintf)
     endif()
     target_link_options(core_compress PRIVATE /subsystem:console)

--- a/Core/Tools/Launcher/Toolkit/Support/UTypes.h
+++ b/Core/Tools/Launcher/Toolkit/Support/UTypes.h
@@ -68,7 +68,7 @@ typedef char Char;
 typedef unsigned char UChar;
 
 //! Wide character (Unicode)
-#if VC6_BUILD
+#if defined(VC6_BUILD)
 typedef unsigned short WChar;
 #else
 typedef wchar_t WChar;

--- a/Core/Tools/Launcher/Toolkit/Support/UTypes.h
+++ b/Core/Tools/Launcher/Toolkit/Support/UTypes.h
@@ -68,7 +68,7 @@ typedef char Char;
 typedef unsigned char UChar;
 
 //! Wide character (Unicode)
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if VC6_BUILD
 typedef unsigned short WChar;
 #else
 typedef wchar_t WChar;

--- a/Core/Tools/Launcher/streamer.cpp
+++ b/Core/Tools/Launcher/streamer.cpp
@@ -22,7 +22,7 @@
   #include <windows.h>
 #endif
 
-#if defined(USING_STLPORT) || (defined(_MSC_VER) && _MSC_VER < 1300)
+#if defined(USING_STLPORT) || VC6_BUILD
 #define STREAMER_UNBUFFERED unbuffered()
 #else
 #define STREAMER_UNBUFFERED 0
@@ -30,7 +30,7 @@
 
 Streamer::Streamer() : streambuf(), Output_Device(NULL), Buf(NULL)
 {
-#if defined(USING_STLPORT) || (defined(_MSC_VER) && _MSC_VER < 1300)
+#if defined(USING_STLPORT) || VC6_BUILD
   int state=unbuffered();
   unbuffered(0);  // 0 = buffered, 1 = unbuffered
 #else
@@ -107,7 +107,7 @@ int Streamer::doallocate()
     memset(Buf,0,2*STREAMER_BUFSIZ);
 
     // Buffer
-#if defined(USING_STLPORT) || (defined(_MSC_VER) && _MSC_VER < 1300)
+#if defined(USING_STLPORT) || VC6_BUILD
     setb(
        Buf,         // base pointer
        Buf+STREAMER_BUFSIZ,  // ebuf pointer (end of buffer);

--- a/Core/Tools/Launcher/streamer.cpp
+++ b/Core/Tools/Launcher/streamer.cpp
@@ -22,7 +22,7 @@
   #include <windows.h>
 #endif
 
-#if defined(USING_STLPORT) || VC6_BUILD
+#if defined(USING_STLPORT) || defined(VC6_BUILD)
 #define STREAMER_UNBUFFERED unbuffered()
 #else
 #define STREAMER_UNBUFFERED 0
@@ -30,7 +30,7 @@
 
 Streamer::Streamer() : streambuf(), Output_Device(NULL), Buf(NULL)
 {
-#if defined(USING_STLPORT) || VC6_BUILD
+#if defined(USING_STLPORT) || defined(VC6_BUILD)
   int state=unbuffered();
   unbuffered(0);  // 0 = buffered, 1 = unbuffered
 #else
@@ -107,7 +107,7 @@ int Streamer::doallocate()
     memset(Buf,0,2*STREAMER_BUFSIZ);
 
     // Buffer
-#if defined(USING_STLPORT) || VC6_BUILD
+#if defined(USING_STLPORT) || defined(VC6_BUILD)
     setb(
        Buf,         // base pointer
        Buf+STREAMER_BUFSIZ,  // ebuf pointer (end of buffer);

--- a/Core/Tools/PATCHGET/CHATAPI.CPP
+++ b/Core/Tools/PATCHGET/CHATAPI.CPP
@@ -31,7 +31,7 @@
 #include <windows.h>
 #include <initguid.h>
 #include <olectl.h>
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if VC6_BUILD
 #include <mapicode.h>
 #endif
 #include "RESOURCE.H"

--- a/Core/Tools/PATCHGET/CHATAPI.CPP
+++ b/Core/Tools/PATCHGET/CHATAPI.CPP
@@ -31,7 +31,7 @@
 #include <windows.h>
 #include <initguid.h>
 #include <olectl.h>
-#if VC6_BUILD
+#if defined(VC6_BUILD)
 #include <mapicode.h>
 #endif
 #include "RESOURCE.H"

--- a/Core/Tools/W3DView/MainFrm.h
+++ b/Core/Tools/W3DView/MainFrm.h
@@ -31,7 +31,7 @@
 #include "Toolbar.H"
 
 
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if VC6_BUILD
 typedef HTASK HTASK_OR_DWORD;
 #else
 typedef DWORD HTASK_OR_DWORD;

--- a/Core/Tools/W3DView/MainFrm.h
+++ b/Core/Tools/W3DView/MainFrm.h
@@ -31,7 +31,7 @@
 #include "Toolbar.H"
 
 
-#if VC6_BUILD
+#if defined(VC6_BUILD)
 typedef HTASK HTASK_OR_DWORD;
 #else
 typedef DWORD HTASK_OR_DWORD;

--- a/Core/Tools/mangler/wlib/streamer.cpp
+++ b/Core/Tools/mangler/wlib/streamer.cpp
@@ -22,7 +22,7 @@
   #include <windows.h>
 #endif
 
-#if defined(USING_STLPORT) || (defined(_MSC_VER) && _MSC_VER < 1300)
+#if defined(USING_STLPORT) || VC6_BUILD
 #define STREAMER_UNBUFFERED unbuffered()
 #else
 #define STREAMER_UNBUFFERED 0
@@ -30,7 +30,7 @@
 
 Streamer::Streamer() : streambuf(), Output_Device(NULL), Buf(NULL)
 {
-#if defined(USING_STLPORT) || (defined(_MSC_VER) && _MSC_VER < 1300)
+#if defined(USING_STLPORT) || VC6_BUILD
   int state=unbuffered();
   unbuffered(0);  // 0 = buffered, 1 = unbuffered
 #else
@@ -107,7 +107,7 @@ int Streamer::doallocate()
     memset(Buf,0,2*STREAMER_BUFSIZ);
 
     // Buffer
-#if defined(USING_STLPORT) || (defined(_MSC_VER) && _MSC_VER < 1300)
+#if defined(USING_STLPORT) || VC6_BUILD
     setb(
        Buf,         // base pointer
        Buf+STREAMER_BUFSIZ,  // ebuf pointer (end of buffer);

--- a/Core/Tools/mangler/wlib/streamer.cpp
+++ b/Core/Tools/mangler/wlib/streamer.cpp
@@ -22,7 +22,7 @@
   #include <windows.h>
 #endif
 
-#if defined(USING_STLPORT) || VC6_BUILD
+#if defined(USING_STLPORT) || defined(VC6_BUILD)
 #define STREAMER_UNBUFFERED unbuffered()
 #else
 #define STREAMER_UNBUFFERED 0
@@ -30,7 +30,7 @@
 
 Streamer::Streamer() : streambuf(), Output_Device(NULL), Buf(NULL)
 {
-#if defined(USING_STLPORT) || VC6_BUILD
+#if defined(USING_STLPORT) || defined(VC6_BUILD)
   int state=unbuffered();
   unbuffered(0);  // 0 = buffered, 1 = unbuffered
 #else
@@ -107,7 +107,7 @@ int Streamer::doallocate()
     memset(Buf,0,2*STREAMER_BUFSIZ);
 
     // Buffer
-#if defined(USING_STLPORT) || VC6_BUILD
+#if defined(USING_STLPORT) || defined(VC6_BUILD)
     setb(
        Buf,         // base pointer
        Buf+STREAMER_BUFSIZ,  // ebuf pointer (end of buffer);

--- a/Core/Tools/matchbot/wlib/streamer.cpp
+++ b/Core/Tools/matchbot/wlib/streamer.cpp
@@ -22,7 +22,7 @@
   #include <windows.h>
 #endif
 
-#if defined(USING_STLPORT) || (defined(_MSC_VER) && _MSC_VER < 1300)
+#if defined(USING_STLPORT) || VC6_BUILD
 #define STREAMER_UNBUFFERED unbuffered()
 #else
 #define STREAMER_UNBUFFERED 0
@@ -30,7 +30,7 @@
 
 Streamer::Streamer() : streambuf(), Output_Device(NULL), Buf(NULL)
 {
-#if defined(USING_STLPORT) || (defined(_MSC_VER) && _MSC_VER < 1300)
+#if defined(USING_STLPORT) || VC6_BUILD
   int state=unbuffered();
   unbuffered(0);  // 0 = buffered, 1 = unbuffered
 #else
@@ -107,7 +107,7 @@ int Streamer::doallocate()
     memset(Buf,0,2*STREAMER_BUFSIZ);
 
     // Buffer
-#if defined(USING_STLPORT) || (defined(_MSC_VER) && _MSC_VER < 1300)
+#if defined(USING_STLPORT) || VC6_BUILD
     setb(
        Buf,         // base pointer
        Buf+STREAMER_BUFSIZ,  // ebuf pointer (end of buffer);

--- a/Core/Tools/matchbot/wlib/streamer.cpp
+++ b/Core/Tools/matchbot/wlib/streamer.cpp
@@ -22,7 +22,7 @@
   #include <windows.h>
 #endif
 
-#if defined(USING_STLPORT) || VC6_BUILD
+#if defined(USING_STLPORT) || defined(VC6_BUILD)
 #define STREAMER_UNBUFFERED unbuffered()
 #else
 #define STREAMER_UNBUFFERED 0
@@ -30,7 +30,7 @@
 
 Streamer::Streamer() : streambuf(), Output_Device(NULL), Buf(NULL)
 {
-#if defined(USING_STLPORT) || VC6_BUILD
+#if defined(USING_STLPORT) || defined(VC6_BUILD)
   int state=unbuffered();
   unbuffered(0);  // 0 = buffered, 1 = unbuffered
 #else
@@ -107,7 +107,7 @@ int Streamer::doallocate()
     memset(Buf,0,2*STREAMER_BUFSIZ);
 
     // Buffer
-#if defined(USING_STLPORT) || VC6_BUILD
+#if defined(USING_STLPORT) || defined(VC6_BUILD)
     setb(
        Buf,         // base pointer
        Buf+STREAMER_BUFSIZ,  // ebuf pointer (end of buffer);

--- a/Core/Tools/timingTest/timingTest.cpp
+++ b/Core/Tools/timingTest/timingTest.cpp
@@ -34,7 +34,7 @@ char buffer[1024];
 //-------------------------------------------------------------------------------------------------
 void GetPrecisionTimer(INT64* t)
 {
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if VC6_BUILD
 	// CPUID is needed to force serialization of any previous instructions. 
 	__asm 
 	{

--- a/Core/Tools/timingTest/timingTest.cpp
+++ b/Core/Tools/timingTest/timingTest.cpp
@@ -34,7 +34,7 @@ char buffer[1024];
 //-------------------------------------------------------------------------------------------------
 void GetPrecisionTimer(INT64* t)
 {
-#if VC6_BUILD
+#if defined(VC6_BUILD)
 	// CPUID is needed to force serialization of any previous instructions. 
 	__asm 
 	{

--- a/Core/Tools/wolSetup/WOLAPI/wolapi.h
+++ b/Core/Tools/wolSetup/WOLAPI/wolapi.h
@@ -433,7 +433,7 @@ void __RPC_STUB IRTPatcherEvent_OnTermination_Stub(
 /* interface IChat */
 /* [object][unique][helpstring][uuid] */ 
 
-#if VC6_BUILD
+#if defined(VC6_BUILD)
 typedef long time_t;
 #endif
 

--- a/Core/Tools/wolSetup/WOLAPI/wolapi.h
+++ b/Core/Tools/wolSetup/WOLAPI/wolapi.h
@@ -433,7 +433,7 @@ void __RPC_STUB IRTPatcherEvent_OnTermination_Stub(
 /* interface IChat */
 /* [object][unique][helpstring][uuid] */ 
 
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if VC6_BUILD
 typedef long time_t;
 #endif
 

--- a/Dependencies/Utility/Utility/endian_compat.h
+++ b/Dependencies/Utility/Utility/endian_compat.h
@@ -64,7 +64,7 @@
 #define le64toh(x) letoh64(x)
 
 #elif defined(_WIN32) || defined(_WIN64)
-#if !(defined(_MSC_VER) && _MSC_VER < 1300)
+#if !VC6_BUILD
 #include <intrin.h>
 #define htobe16(x) _byteswap_ushort(x)
 #define htole16(x) (x)
@@ -154,7 +154,7 @@ static_assert(sizeof(SwapType32) == 4, "expected size does not match");
 static_assert(sizeof(SwapType64) == 8, "expected size does not match");
 
 // VC6 compatible overloaded endian functions
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if VC6_BUILD
 
 // Big endian to host
 inline int16_t  betoh(int16_t value)  { return be16toh(value); }
@@ -241,6 +241,6 @@ template<typename Type> inline void betoh_ref(Type &value) { value = Endian::bet
 // Little endian to host
 template<typename Type> inline void letoh_ref(Type &value) { value = Endian::letohHelper<Type>::swap(value); }
 
-#endif // _MSC_VER < 1300
+#endif // VC6_BUILD
 
 #endif // ENDIAN_COMPAT_H

--- a/Dependencies/Utility/Utility/endian_compat.h
+++ b/Dependencies/Utility/Utility/endian_compat.h
@@ -64,7 +64,7 @@
 #define le64toh(x) letoh64(x)
 
 #elif defined(_WIN32) || defined(_WIN64)
-#if !VC6_BUILD
+#if !defined(VC6_BUILD)
 #include <intrin.h>
 #define htobe16(x) _byteswap_ushort(x)
 #define htole16(x) (x)
@@ -154,7 +154,7 @@ static_assert(sizeof(SwapType32) == 4, "expected size does not match");
 static_assert(sizeof(SwapType64) == 8, "expected size does not match");
 
 // VC6 compatible overloaded endian functions
-#if VC6_BUILD
+#if defined(VC6_BUILD)
 
 // Big endian to host
 inline int16_t  betoh(int16_t value)  { return be16toh(value); }
@@ -241,6 +241,6 @@ template<typename Type> inline void betoh_ref(Type &value) { value = Endian::bet
 // Little endian to host
 template<typename Type> inline void letoh_ref(Type &value) { value = Endian::letohHelper<Type>::swap(value); }
 
-#endif // VC6_BUILD
+#endif // defined(VC6_BUILD)
 
 #endif // ENDIAN_COMPAT_H

--- a/Dependencies/Utility/Utility/hash_map_adapter.h
+++ b/Dependencies/Utility/Utility/hash_map_adapter.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#if defined(USING_STLPORT) || VC6_BUILD
+#if defined(USING_STLPORT) || defined(VC6_BUILD)
 
 #include <hash_map>
 

--- a/Dependencies/Utility/Utility/hash_map_adapter.h
+++ b/Dependencies/Utility/Utility/hash_map_adapter.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#if defined(USING_STLPORT) || (defined(_MSC_VER) && _MSC_VER < 1300)
+#if defined(USING_STLPORT) || VC6_BUILD
 
 #include <hash_map>
 

--- a/Dependencies/Utility/Utility/intrin_compat.h
+++ b/Dependencies/Utility/Utility/intrin_compat.h
@@ -20,7 +20,7 @@
 #pragma once
 
 // VC6 macros
-#if VC6_BUILD
+#if defined(VC6_BUILD)
 
 #ifndef __debugbreak
 #define __debugbreak() __asm { int 3 }
@@ -63,11 +63,11 @@ static inline __int64 _rdtsc()
 #endif
 #endif //defined _WIN32 && (defined _M_IX86 || defined _M_AMD64)
 
-#endif // VC6_BUILD
+#endif // defined(VC6_BUILD)
 
 
 // Non-VC6 macros
-#if !VC6_BUILD
+#if !defined(VC6_BUILD)
 
 #include <cstdint>
 
@@ -149,4 +149,4 @@ static inline uint64_t _rdtsc()
 #define cpuid(regs, cpuid_type) memset(regs, 0, 16)
 #endif // cpuid
 
-#endif // !VC6_BUILD
+#endif // !defined(VC6_BUILD)

--- a/Dependencies/Utility/Utility/intrin_compat.h
+++ b/Dependencies/Utility/Utility/intrin_compat.h
@@ -20,7 +20,7 @@
 #pragma once
 
 // VC6 macros
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if VC6_BUILD
 
 #ifndef __debugbreak
 #define __debugbreak() __asm { int 3 }
@@ -63,11 +63,11 @@ static inline __int64 _rdtsc()
 #endif
 #endif //defined _WIN32 && (defined _M_IX86 || defined _M_AMD64)
 
-#endif // defined(_MSC_VER) && _MSC_VER < 1300
+#endif // VC6_BUILD
 
 
 // Non-VC6 macros
-#if !(defined(_MSC_VER) && _MSC_VER < 1300)
+#if !VC6_BUILD
 
 #include <cstdint>
 
@@ -149,4 +149,4 @@ static inline uint64_t _rdtsc()
 #define cpuid(regs, cpuid_type) memset(regs, 0, 16)
 #endif // cpuid
 
-#endif // !(defined(_MSC_VER) && _MSC_VER < 1300)
+#endif // !VC6_BUILD

--- a/Dependencies/Utility/Utility/iostream_adapter.h
+++ b/Dependencies/Utility/Utility/iostream_adapter.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#if defined(USING_STLPORT) || (defined(_MSC_VER) && _MSC_VER < 1300)
+#if defined(USING_STLPORT) || VC6_BUILD
 
 #include <iostream.h>
 

--- a/Dependencies/Utility/Utility/iostream_adapter.h
+++ b/Dependencies/Utility/Utility/iostream_adapter.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#if defined(USING_STLPORT) || VC6_BUILD
+#if defined(USING_STLPORT) || defined(VC6_BUILD)
 
 #include <iostream.h>
 

--- a/Dependencies/Utility/Utility/sstream_adapter.h
+++ b/Dependencies/Utility/Utility/sstream_adapter.h
@@ -20,7 +20,7 @@
 // where symbols are not contained in the std namespace.
 #pragma once
 
-#if defined(USING_STLPORT) || VC6_BUILD
+#if defined(USING_STLPORT) || defined(VC6_BUILD)
 
 #include <strstrea.h>
 

--- a/Dependencies/Utility/Utility/sstream_adapter.h
+++ b/Dependencies/Utility/Utility/sstream_adapter.h
@@ -20,7 +20,7 @@
 // where symbols are not contained in the std namespace.
 #pragma once
 
-#if defined(USING_STLPORT) || (defined(_MSC_VER) && _MSC_VER < 1300)
+#if defined(USING_STLPORT) || VC6_BUILD
 
 #include <strstrea.h>
 

--- a/Dependencies/Utility/Utility/stdint_adapter.h
+++ b/Dependencies/Utility/Utility/stdint_adapter.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#if defined(USING_STLPORT) || VC6_BUILD
+#if defined(USING_STLPORT) || defined(VC6_BUILD)
 /* 7.18.1.4  Integer types capable of holding object pointers */
 #ifdef _WIN64
   typedef __int64 intptr_t;

--- a/Dependencies/Utility/Utility/stdint_adapter.h
+++ b/Dependencies/Utility/Utility/stdint_adapter.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#if defined(USING_STLPORT) || (defined(_MSC_VER) && _MSC_VER < 1300)
+#if defined(USING_STLPORT) || VC6_BUILD
 /* 7.18.1.4  Integer types capable of holding object pointers */
 #ifdef _WIN64
   typedef __int64 intptr_t;

--- a/Generals/Code/GameEngine/Include/Common/GameMemory.h
+++ b/Generals/Code/GameEngine/Include/Common/GameMemory.h
@@ -863,7 +863,7 @@ extern void userMemoryAdjustPoolSize(const char *poolName, Int& initialAllocatio
 	extern void* __cdecl operator new[](size_t nSize, const char *, int);
 	extern void __cdecl operator delete[](void *, const char *, int);
 
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if VC6_BUILD
 	// additional overloads for 'placement new'
 	//inline void* __cdecl operator new							(size_t s, void *p) { return p; }
 	//inline void __cdecl operator delete						(void *, void *p)		{ }

--- a/Generals/Code/GameEngine/Include/Common/GameMemory.h
+++ b/Generals/Code/GameEngine/Include/Common/GameMemory.h
@@ -863,7 +863,7 @@ extern void userMemoryAdjustPoolSize(const char *poolName, Int& initialAllocatio
 	extern void* __cdecl operator new[](size_t nSize, const char *, int);
 	extern void __cdecl operator delete[](void *, const char *, int);
 
-#if VC6_BUILD
+#if defined(VC6_BUILD)
 	// additional overloads for 'placement new'
 	//inline void* __cdecl operator new							(size_t s, void *p) { return p; }
 	//inline void __cdecl operator delete						(void *, void *p)		{ }

--- a/Generals/Code/GameEngine/Include/Common/GlobalData.h
+++ b/Generals/Code/GameEngine/Include/Common/GlobalData.h
@@ -524,7 +524,7 @@ private:
 	GlobalData *newOverride( void );		/** create a new override, copy data from previous
 																			override, and return it */
 
-#if VC6_BUILD
+#if defined(VC6_BUILD)
 	GlobalData(const GlobalData& that) { DEBUG_CRASH(("unimplemented")); }
 	GlobalData& operator=(const GlobalData& that) { DEBUG_CRASH(("unimplemented")); return *this; }
 #else

--- a/Generals/Code/GameEngine/Include/Common/GlobalData.h
+++ b/Generals/Code/GameEngine/Include/Common/GlobalData.h
@@ -524,7 +524,7 @@ private:
 	GlobalData *newOverride( void );		/** create a new override, copy data from previous
 																			override, and return it */
 
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if VC6_BUILD
 	GlobalData(const GlobalData& that) { DEBUG_CRASH(("unimplemented")); }
 	GlobalData& operator=(const GlobalData& that) { DEBUG_CRASH(("unimplemented")); return *this; }
 #else

--- a/Generals/Code/GameEngine/Include/Common/ThingTemplate.h
+++ b/Generals/Code/GameEngine/Include/Common/ThingTemplate.h
@@ -352,7 +352,7 @@ class ThingTemplate : public Overridable
 
 private:
 
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if VC6_BUILD
 	ThingTemplate(const ThingTemplate& that) : m_geometryInfo(that.m_geometryInfo) 
 	{ 
 		DEBUG_CRASH(("This should never be called\n")); 

--- a/Generals/Code/GameEngine/Include/Common/ThingTemplate.h
+++ b/Generals/Code/GameEngine/Include/Common/ThingTemplate.h
@@ -352,7 +352,7 @@ class ThingTemplate : public Overridable
 
 private:
 
-#if VC6_BUILD
+#if defined(VC6_BUILD)
 	ThingTemplate(const ThingTemplate& that) : m_geometryInfo(that.m_geometryInfo) 
 	{ 
 		DEBUG_CRASH(("This should never be called\n")); 

--- a/Generals/Code/GameEngine/Include/Common/crc.h
+++ b/Generals/Code/GameEngine/Include/Common/crc.h
@@ -67,7 +67,7 @@ public:
     if (!buf||len<1)
       return;
     
-#if !VC6_BUILD
+#if !defined(VC6_BUILD)
     // C++ version left in for reference purposes
 	  for (UnsignedByte *uintPtr=(UnsignedByte *)buf;len>0;len--,uintPtr++)
     {

--- a/Generals/Code/GameEngine/Include/Common/crc.h
+++ b/Generals/Code/GameEngine/Include/Common/crc.h
@@ -67,7 +67,7 @@ public:
     if (!buf||len<1)
       return;
     
-#if !(defined(_MSC_VER) && _MSC_VER < 1300)
+#if !VC6_BUILD
     // C++ version left in for reference purposes
 	  for (UnsignedByte *uintPtr=(UnsignedByte *)buf;len>0;len--,uintPtr++)
     {

--- a/Generals/Code/GameEngine/Include/Precompiled/PreRTS.h
+++ b/Generals/Code/GameEngine/Include/Precompiled/PreRTS.h
@@ -54,7 +54,7 @@ class STLSpecialAlloc;
 #include <io.h>
 #include <limits.h>
 #include <lmcons.h>
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if VC6_BUILD
 #include <mapicode.h>
 #endif
 #include <math.h>

--- a/Generals/Code/GameEngine/Include/Precompiled/PreRTS.h
+++ b/Generals/Code/GameEngine/Include/Precompiled/PreRTS.h
@@ -54,7 +54,7 @@ class STLSpecialAlloc;
 #include <io.h>
 #include <limits.h>
 #include <lmcons.h>
-#if VC6_BUILD
+#if defined(VC6_BUILD)
 #include <mapicode.h>
 #endif
 #include <math.h>

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -1043,7 +1043,7 @@ void AIPlayer::onUnitProduced( Object *factory, Object *unit )
 	Bool found = false;
 	// TheSuperHackers @fix Mauller 26/04/2025 Fixes uninitialized variable.
 	// To keep retail compatibility it needs to be set true in VS6 builds.
-#if VC6_BUILD
+#if defined(VC6_BUILD)
 	Bool supplyTruck = true;
 #else
 	Bool supplyTruck = false;

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -1043,7 +1043,7 @@ void AIPlayer::onUnitProduced( Object *factory, Object *unit )
 	Bool found = false;
 	// TheSuperHackers @fix Mauller 26/04/2025 Fixes uninitialized variable.
 	// To keep retail compatibility it needs to be set true in VS6 builds.
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if VC6_BUILD
 	Bool supplyTruck = true;
 #else
 	Bool supplyTruck = false;

--- a/Generals/Code/Libraries/Include/Lib/BaseType.h
+++ b/Generals/Code/Libraries/Include/Lib/BaseType.h
@@ -83,7 +83,7 @@ __forceinline long fast_float2long_round(float f)
 {
 	long i;
 
-#if VC6_BUILD
+#if defined(VC6_BUILD)
 	__asm {
 		fld [f]
 		fistp [i]

--- a/Generals/Code/Libraries/Include/Lib/BaseType.h
+++ b/Generals/Code/Libraries/Include/Lib/BaseType.h
@@ -83,7 +83,7 @@ __forceinline long fast_float2long_round(float f)
 {
 	long i;
 
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if VC6_BUILD
 	__asm {
 		fld [f]
 		fistp [i]

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
@@ -940,7 +940,7 @@ WWINLINE unsigned int DX8Wrapper::Convert_Color(const Vector4& color)
 
 WWINLINE unsigned int DX8Wrapper::Convert_Color(const Vector3& color,float alpha)
 {
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if VC6_BUILD
 	const float scale = 255.0;
 	unsigned int col;
 
@@ -1009,7 +1009,7 @@ not_changed:
 	return col;
 #else
 	return color.Convert_To_ARGB(alpha);
-#endif // defined(_MSC_VER) && _MSC_VER < 1300
+#endif // VC6_BUILD
 }
 
 // ----------------------------------------------------------------------------
@@ -1020,7 +1020,7 @@ not_changed:
 
 WWINLINE void DX8Wrapper::Clamp_Color(Vector4& color)
 {
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if VC6_BUILD
 	if (CPUDetectClass::Has_CMOV_Instruction()) {
 	__asm
 	{
@@ -1066,7 +1066,7 @@ WWINLINE void DX8Wrapper::Clamp_Color(Vector4& color)
 	}
 	return;
 	}
-#endif // defined(_MSC_VER) && _MSC_VER < 1300
+#endif // VC6_BUILD
 
 	for (int i=0;i<4;++i) {
 		float f=(color[i]<0.0f) ? 0.0f : color[i];

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
@@ -940,7 +940,7 @@ WWINLINE unsigned int DX8Wrapper::Convert_Color(const Vector4& color)
 
 WWINLINE unsigned int DX8Wrapper::Convert_Color(const Vector3& color,float alpha)
 {
-#if VC6_BUILD
+#if defined(VC6_BUILD)
 	const float scale = 255.0;
 	unsigned int col;
 
@@ -1009,7 +1009,7 @@ not_changed:
 	return col;
 #else
 	return color.Convert_To_ARGB(alpha);
-#endif // VC6_BUILD
+#endif // defined(VC6_BUILD)
 }
 
 // ----------------------------------------------------------------------------
@@ -1020,7 +1020,7 @@ not_changed:
 
 WWINLINE void DX8Wrapper::Clamp_Color(Vector4& color)
 {
-#if VC6_BUILD
+#if defined(VC6_BUILD)
 	if (CPUDetectClass::Has_CMOV_Instruction()) {
 	__asm
 	{
@@ -1066,7 +1066,7 @@ WWINLINE void DX8Wrapper::Clamp_Color(Vector4& color)
 	}
 	return;
 	}
-#endif // VC6_BUILD
+#endif // defined(VC6_BUILD)
 
 	for (int i=0;i<4;++i) {
 		float f=(color[i]<0.0f) ? 0.0f : color[i];

--- a/GeneralsMD/Code/GameEngine/Include/Common/GameMemory.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GameMemory.h
@@ -861,7 +861,7 @@ extern void userMemoryAdjustPoolSize(const char *poolName, Int& initialAllocatio
 	extern void* __cdecl operator new[](size_t nSize, const char *, int);
 	extern void __cdecl operator delete[](void *, const char *, int);
 
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if VC6_BUILD
 	// additional overloads for 'placement new'
 	//inline void* __cdecl operator new							(size_t s, void *p) { return p; }
 	//inline void __cdecl operator delete						(void *, void *p)		{ }

--- a/GeneralsMD/Code/GameEngine/Include/Common/GameMemory.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GameMemory.h
@@ -861,7 +861,7 @@ extern void userMemoryAdjustPoolSize(const char *poolName, Int& initialAllocatio
 	extern void* __cdecl operator new[](size_t nSize, const char *, int);
 	extern void __cdecl operator delete[](void *, const char *, int);
 
-#if VC6_BUILD
+#if defined(VC6_BUILD)
 	// additional overloads for 'placement new'
 	//inline void* __cdecl operator new							(size_t s, void *p) { return p; }
 	//inline void __cdecl operator delete						(void *, void *p)		{ }

--- a/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
@@ -537,7 +537,7 @@ private:
 	GlobalData *newOverride( void );		/** create a new override, copy data from previous
 																			override, and return it */
 
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if VC6_BUILD
 	GlobalData(const GlobalData& that) { DEBUG_CRASH(("unimplemented")); }
 	GlobalData& operator=(const GlobalData& that) { DEBUG_CRASH(("unimplemented")); return *this; }
 #else

--- a/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
@@ -537,7 +537,7 @@ private:
 	GlobalData *newOverride( void );		/** create a new override, copy data from previous
 																			override, and return it */
 
-#if VC6_BUILD
+#if defined(VC6_BUILD)
 	GlobalData(const GlobalData& that) { DEBUG_CRASH(("unimplemented")); }
 	GlobalData& operator=(const GlobalData& that) { DEBUG_CRASH(("unimplemented")); return *this; }
 #else

--- a/GeneralsMD/Code/GameEngine/Include/Common/ThingTemplate.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/ThingTemplate.h
@@ -352,7 +352,7 @@ class ThingTemplate : public Overridable
 
 private:
 
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if VC6_BUILD
 	ThingTemplate(const ThingTemplate& that) : m_geometryInfo(that.m_geometryInfo) 
 	{ 
 		DEBUG_CRASH(("This should never be called\n")); 

--- a/GeneralsMD/Code/GameEngine/Include/Common/ThingTemplate.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/ThingTemplate.h
@@ -352,7 +352,7 @@ class ThingTemplate : public Overridable
 
 private:
 
-#if VC6_BUILD
+#if defined(VC6_BUILD)
 	ThingTemplate(const ThingTemplate& that) : m_geometryInfo(that.m_geometryInfo) 
 	{ 
 		DEBUG_CRASH(("This should never be called\n")); 

--- a/GeneralsMD/Code/GameEngine/Include/Common/crc.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/crc.h
@@ -67,7 +67,7 @@ public:
     if (!buf||len<1)
       return;
     
-#if !VC6_BUILD
+#if !defined(VC6_BUILD)
     // C++ version left in for reference purposes
 	  for (UnsignedByte *uintPtr=(UnsignedByte *)buf;len>0;len--,uintPtr++)
     {

--- a/GeneralsMD/Code/GameEngine/Include/Common/crc.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/crc.h
@@ -67,7 +67,7 @@ public:
     if (!buf||len<1)
       return;
     
-#if !(defined(_MSC_VER) && _MSC_VER < 1300)
+#if !VC6_BUILD
     // C++ version left in for reference purposes
 	  for (UnsignedByte *uintPtr=(UnsignedByte *)buf;len>0;len--,uintPtr++)
     {

--- a/GeneralsMD/Code/GameEngine/Include/Precompiled/PreRTS.h
+++ b/GeneralsMD/Code/GameEngine/Include/Precompiled/PreRTS.h
@@ -54,7 +54,7 @@ class STLSpecialAlloc;
 #include <io.h>
 #include <limits.h>
 #include <lmcons.h>
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if VC6_BUILD
 #include <mapicode.h>
 #endif
 #include <math.h>

--- a/GeneralsMD/Code/GameEngine/Include/Precompiled/PreRTS.h
+++ b/GeneralsMD/Code/GameEngine/Include/Precompiled/PreRTS.h
@@ -54,7 +54,7 @@ class STLSpecialAlloc;
 #include <io.h>
 #include <limits.h>
 #include <lmcons.h>
-#if VC6_BUILD
+#if defined(VC6_BUILD)
 #include <mapicode.h>
 #endif
 #include <math.h>

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -1050,7 +1050,7 @@ void AIPlayer::onUnitProduced( Object *factory, Object *unit )
 	Bool found = false;
 	// TheSuperHackers @fix Mauller 26/04/2025 Fixes uninitialized variable.
 	// To keep retail compatibility it needs to be set true in VS6 builds.
-#if VC6_BUILD
+#if defined(VC6_BUILD)
 	Bool supplyTruck = true;
 #else
 	Bool supplyTruck = false;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -1050,7 +1050,7 @@ void AIPlayer::onUnitProduced( Object *factory, Object *unit )
 	Bool found = false;
 	// TheSuperHackers @fix Mauller 26/04/2025 Fixes uninitialized variable.
 	// To keep retail compatibility it needs to be set true in VS6 builds.
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if VC6_BUILD
 	Bool supplyTruck = true;
 #else
 	Bool supplyTruck = false;

--- a/GeneralsMD/Code/GameEngineDevice/CMakeLists.txt
+++ b/GeneralsMD/Code/GameEngineDevice/CMakeLists.txt
@@ -195,7 +195,7 @@ set(GAMEENGINEDEVICE_SRC
 )
 
 # Add C++ 17 FileSystem implementation for non-VS6 builds
-if(NOT IS_VS6_BUILD)
+if(NOT IS_VC6_BUILD)
     list(APPEND GAMEENGINEDEVICE_SRC
         Include/StdDevice/Common/StdBIGFile.h
         Include/StdDevice/Common/StdBIGFileSystem.h

--- a/GeneralsMD/Code/Libraries/Include/Lib/BaseType.h
+++ b/GeneralsMD/Code/Libraries/Include/Lib/BaseType.h
@@ -83,7 +83,7 @@ __forceinline long fast_float2long_round(float f)
 {
 	long i;
 
-#if VC6_BUILD
+#if defined(VC6_BUILD)
 	__asm {
 		fld [f]
 		fistp [i]
@@ -99,7 +99,7 @@ __forceinline long fast_float2long_round(float f)
 // code courtesy of Martin Hoffesommer (grin)
 __forceinline float fast_float_trunc(float f)
 {
-#if VC6_BUILD
+#if defined(VC6_BUILD)
   _asm
   {
     mov ecx,[f]

--- a/GeneralsMD/Code/Libraries/Include/Lib/BaseType.h
+++ b/GeneralsMD/Code/Libraries/Include/Lib/BaseType.h
@@ -83,7 +83,7 @@ __forceinline long fast_float2long_round(float f)
 {
 	long i;
 
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if VC6_BUILD
 	__asm {
 		fld [f]
 		fistp [i]
@@ -99,7 +99,7 @@ __forceinline long fast_float2long_round(float f)
 // code courtesy of Martin Hoffesommer (grin)
 __forceinline float fast_float_trunc(float f)
 {
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if VC6_BUILD
   _asm
   {
     mov ecx,[f]

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
@@ -1003,7 +1003,7 @@ WWINLINE unsigned int DX8Wrapper::Convert_Color(const Vector4& color)
 
 WWINLINE unsigned int DX8Wrapper::Convert_Color(const Vector3& color,float alpha)
 {
-#if VC6_BUILD
+#if defined(VC6_BUILD)
 	const float scale = 255.0;
 	unsigned int col;
 
@@ -1072,7 +1072,7 @@ not_changed:
 	return col;
 #else
 	return color.Convert_To_ARGB(alpha);
-#endif // VC6_BUILD
+#endif // defined(VC6_BUILD)
 }
 
 // ----------------------------------------------------------------------------
@@ -1083,7 +1083,7 @@ not_changed:
 
 WWINLINE void DX8Wrapper::Clamp_Color(Vector4& color)
 {
-#if VC6_BUILD
+#if defined(VC6_BUILD)
 	if (CPUDetectClass::Has_CMOV_Instruction()) {
 	__asm
 	{
@@ -1129,7 +1129,7 @@ WWINLINE void DX8Wrapper::Clamp_Color(Vector4& color)
 	}
 	return;
 	}
-#endif // VC6_BUILD
+#endif // defined(VC6_BUILD)
 
 	for (int i=0;i<4;++i) {
 		float f=(color[i]<0.0f) ? 0.0f : color[i];

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
@@ -1003,7 +1003,7 @@ WWINLINE unsigned int DX8Wrapper::Convert_Color(const Vector4& color)
 
 WWINLINE unsigned int DX8Wrapper::Convert_Color(const Vector3& color,float alpha)
 {
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if VC6_BUILD
 	const float scale = 255.0;
 	unsigned int col;
 
@@ -1072,7 +1072,7 @@ not_changed:
 	return col;
 #else
 	return color.Convert_To_ARGB(alpha);
-#endif // defined(_MSC_VER) && _MSC_VER < 1300
+#endif // VC6_BUILD
 }
 
 // ----------------------------------------------------------------------------
@@ -1083,7 +1083,7 @@ not_changed:
 
 WWINLINE void DX8Wrapper::Clamp_Color(Vector4& color)
 {
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if VC6_BUILD
 	if (CPUDetectClass::Has_CMOV_Instruction()) {
 	__asm
 	{
@@ -1129,7 +1129,7 @@ WWINLINE void DX8Wrapper::Clamp_Color(Vector4& color)
 	}
 	return;
 	}
-#endif // defined(_MSC_VER) && _MSC_VER < 1300
+#endif // VC6_BUILD
 
 	for (int i=0;i<4;++i) {
 		float f=(color[i]<0.0f) ? 0.0f : color[i];

--- a/cmake/compilers.cmake
+++ b/cmake/compilers.cmake
@@ -11,7 +11,6 @@ endif()
 # Set variable for VS6 to handle special cases.
 if (DEFINED MSVC_VERSION AND MSVC_VERSION LESS 1300)
     set(IS_VC6_BUILD TRUE)
-    add_compile_definitions(VC6_BUILD=1)
 else()
     set(IS_VC6_BUILD FALSE)
 endif()

--- a/cmake/compilers.cmake
+++ b/cmake/compilers.cmake
@@ -10,9 +10,10 @@ endif()
 
 # Set variable for VS6 to handle special cases.
 if (DEFINED MSVC_VERSION AND MSVC_VERSION LESS 1300)
-    set(IS_VS6_BUILD TRUE)
+    set(IS_VC6_BUILD TRUE)
+    add_compile_definitions(VC6_BUILD=1)
 else()
-    set(IS_VS6_BUILD FALSE)
+    set(IS_VC6_BUILD FALSE)
 endif()
 
 # Make release builds have debug information too.
@@ -29,7 +30,7 @@ endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)  # Ensures only ISO features are used
 
-if (NOT IS_VS6_BUILD)
+if (NOT IS_VC6_BUILD)
     if (MSVC)
         # Multithreaded build.
         add_compile_options(/MP)

--- a/cmake/config-build.cmake
+++ b/cmake/config-build.cmake
@@ -44,7 +44,9 @@ if(RTS_BUILD_GENERALS)
     add_feature_info(GeneralsDocs RTS_BUILD_GENERALS_DOCS "Build Generals Documentation")
 endif()
 
-if(NOT IS_VC6_BUILD)
+if(IS_VC6_BUILD)
+    target_compile_definitions(core_config INTERFACE defined(VC6_BUILD))
+else()
     # Because we set CMAKE_CXX_STANDARD_REQUIRED and CMAKE_CXX_EXTENSIONS in the compilers.cmake this should be enforced.
     target_compile_features(core_config INTERFACE cxx_std_20)
 endif()

--- a/cmake/config-build.cmake
+++ b/cmake/config-build.cmake
@@ -44,7 +44,7 @@ if(RTS_BUILD_GENERALS)
     add_feature_info(GeneralsDocs RTS_BUILD_GENERALS_DOCS "Build Generals Documentation")
 endif()
 
-if(NOT IS_VS6_BUILD)
+if(NOT IS_VC6_BUILD)
     # Because we set CMAKE_CXX_STANDARD_REQUIRED and CMAKE_CXX_EXTENSIONS in the compilers.cmake this should be enforced.
     target_compile_features(core_config INTERFACE cxx_std_20)
 endif()


### PR DESCRIPTION
This change adds a VC6_BUILD macro to simplify writing it.

It also renames the "IS_VS6_BUILD" variable to "IS_VC6_BUILD" in cmake.