### PR TITLE
[GEN][ZH] Fix memory leak in SortingRendererClass::Insert_To_Sorting_Pool()

### DIFF
--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/sortingrenderer.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/sortingrenderer.cpp
@@ -442,6 +442,7 @@ void SortingRendererClass::Insert_To_Sorting_Pool(SortingNodeStruct* state)
 {
 	if (overlapping_node_count>=MAX_OVERLAPPING_NODES) {
 		Release_Refs(state);
+		delete state;
 		WWASSERT(0);
 		return;
 	}

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/sortingrenderer.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/sortingrenderer.cpp
@@ -344,6 +344,7 @@ void SortingRendererClass::Insert_To_Sorting_Pool(SortingNodeStruct* state)
 {
 	if (overlapping_node_count>=MAX_OVERLAPPING_NODES) {
 		Release_Refs(state);
+		delete state;
 		WWASSERT(0);
 		return;
 	}


### PR DESCRIPTION
* Fixes #181

This change fixes a major memory leak in SortingRendererClass::Insert_To_Sorting_Pool(). It can be triggered by spawning the binary shower particle effects with the Hacker.

### Callstack

```
>	generalszh.exe!SortingRendererClass::Flush() Line 617	C++
 	generalszh.exe!RTS3DScene::Flush(RenderInfoClass & rinfo) Line 872	C++
 	generalszh.exe!RTS3DScene::Render(RenderInfoClass & rinfo) Line 1074	C++
 	generalszh.exe!WW3D::Render(SceneClass * scene, CameraClass * cam, bool clear, bool clearz, const Vector3 & color) Line 979	C++
 	generalszh.exe!RTS3DScene::draw() Line 1724	C++
 	generalszh.exe!SubsystemInterface::DRAW() Line 105	C++
 	generalszh.exe!RTS3DScene::doRender(CameraClass * cam) Line 1708	C++
 	generalszh.exe!W3DView::draw() Line 1565	C++
 	generalszh.exe!SubsystemInterface::DRAW() Line 105	C++
 	generalszh.exe!Display::drawViews() Line 118	C++
 	generalszh.exe!W3DDisplay::draw() Line 1910	C++
 	generalszh.exe!SubsystemInterface::DRAW() Line 105	C++
 	generalszh.exe!GameClient::update() Line 767	C++
 	generalszh.exe!SubsystemInterface::UPDATE() Line 79	C++
 	generalszh.exe!GameEngine::update() Line 735	C++
 	generalszh.exe!Win32GameEngine::update() Line 93	C++
 	generalszh.exe!GameEngine::execute() Line 810	C++
 	generalszh.exe!GameMain(int argc, char * * argv) Line 47	C++
 	generalszh.exe!WinMain(HINSTANCE__ * hInstance, HINSTANCE__ * hPrevInstance, char * lpCmdLine, int nCmdShow) Line 1032	C++
 	[Inline Frame] generalszh.exe!invoke_main() Line 102	C++
 	generalszh.exe!__scrt_common_main_seh() Line 288	C++
 	kernel32.dll!75fffcc9()	Unknown
 	[Frames below may be incorrect and/or missing, no symbols loaded for kernel32.dll]	
 	ntdll.dll!778782ae()	Unknown
 	ntdll.dll!7787827e()	Unknown
 	generalszh.exe!std::vector<std::pair<AsciiString,Object *>,std::allocator<std::pair<AsciiString,Object *>>>::_Emplace_reallocate<std::pair<AsciiString,Object *> const &>(std::pair<AsciiString,Object *> * const _Whereptr, const std::pair<AsciiString,Object *> & <_Val_0>) Line 872	C++
 	1050b1af()	Unknown
```

### Memory log

```
Leaked a block of size 676, tagstring W3D_D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\Libraries\Source\WWVegas\WW3D2\sortingrenderer.cpp, from pool/dma SortingNodeStruct
Leaked a block of size 676, tagstring W3D_D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\Libraries\Source\WWVegas\WW3D2\sortingrenderer.cpp, from pool/dma SortingNodeStruct
Leaked a block of size 676, tagstring W3D_D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\Libraries\Source\WWVegas\WW3D2\sortingrenderer.cpp, from pool/dma SortingNodeStruct
...
ASSERTION FAILURE: There were 129044 memory leaks. Please fix them.
```