### PR TITLE
[GEN][ZH] Fix memory leak in SpecialAbilityUpdate::isWithinStartAbilityRange()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
@@ -776,6 +776,7 @@ Bool SpecialAbilityUpdate::isWithinStartAbilityRange() const
 			PartitionFilterLineOfSight	filterLOS( self );
 			PartitionFilter *filters[] = { &filterLOS, NULL };
 			ObjectIterator *iter = ThePartitionManager->iterateObjectsInRange( self, range, FROM_BOUNDINGSPHERE_2D, filters, ITER_SORTED_NEAR_TO_FAR );
+			MemoryPoolObjectHolder hold(iter);
 			for( Object *theTarget = iter->first(); theTarget; theTarget = iter->next() ) 
 			{
 				//LOS check succeeded.

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
@@ -880,6 +880,7 @@ Bool SpecialAbilityUpdate::isWithinStartAbilityRange() const
       PartitionFilterLineOfSight  filterLOS( self );
       PartitionFilter *filters[] = { &filterLOS, NULL };
       ObjectIterator *iter = ThePartitionManager->iterateObjectsInRange( self, range, FROM_BOUNDINGSPHERE_2D, filters, ITER_SORTED_NEAR_TO_FAR );
+      MemoryPoolObjectHolder hold(iter);
       for( Object *theTarget = iter->first(); theTarget; theTarget = iter->next() ) 
       {
         //LOS check succeeded.


### PR DESCRIPTION
* Relates to #181

This change fixes a minor memory leak in SpecialAbilityUpdate::isWithinStartAbilityRange(). It is reproducible when using the China Hacker to disable buildings.

```
Leaked a block of size 16, tagstring D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\SimpleObjectIterator.cpp, from pool/dma SimpleObjectIteratorClumpPool
Leaked a block of size 16, tagstring D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\SimpleObjectIterator.cpp, from pool/dma SimpleObjectIteratorClumpPool
Leaked a block of size 16, tagstring D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\SimpleObjectIterator.cpp, from pool/dma SimpleObjectIteratorClumpPool
...
Leaked a block of size 16, tagstring D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\PartitionManager.cpp, from pool/dma SimpleObjectIteratorPool
Leaked a block of size 16, tagstring D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\PartitionManager.cpp, from pool/dma SimpleObjectIteratorPool
Leaked a block of size 16, tagstring D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\PartitionManager.cpp, from pool/dma SimpleObjectIteratorPool
...
ASSERTION FAILURE: There were 5089 memory leaks. Please fix them.
```