### PR TITLE
[GEN][ZH] Clip Cursor In Windowed Mode

### DIFF
--- a/Generals/Code/Main/WinMain.cpp
+++ b/Generals/Code/Main/WinMain.cpp
@@ -540,6 +540,14 @@ LRESULT CALLBACK WndProc( HWND hWnd, UINT message,
 			//-------------------------------------------------------------------------
 			case WM_MOUSEMOVE:
 			{
+
+				if (ApplicationIsWindowed && TheGameEngine && TheGameEngine->isActive())
+				{
+					static RECT originalRect;
+					GetWindowRect(ApplicationHWnd, &originalRect);
+					ClipCursor(&originalRect);
+				}
+
 				Int x = (Int)LOWORD( lParam );
 				Int y = (Int)HIWORD( lParam );
 				RECT rect;

--- a/GeneralsMD/Code/Main/WinMain.cpp
+++ b/GeneralsMD/Code/Main/WinMain.cpp
@@ -562,6 +562,14 @@ LRESULT CALLBACK WndProc( HWND hWnd, UINT message,
 			//-------------------------------------------------------------------------
 			case WM_MOUSEMOVE:
 			{
+
+				if (ApplicationIsWindowed && TheGameEngine && TheGameEngine->isActive())
+				{
+					static RECT originalRect;
+					GetWindowRect(ApplicationHWnd, &originalRect);
+					ClipCursor(&originalRect);
+				}
+
 				Int x = (Int)LOWORD( lParam );
 				Int y = (Int)HIWORD( lParam );
 				RECT rect;


### PR DESCRIPTION
- Closes: #104 

This PR adds cursor clipping to window mode, this keeps the cursor within the bounds of the game window for easier use.

The mouse is freed and focus lost when you tab away from the game window.