### PR TITLE
[GEN][ZH] Enable Control Bar toggle for Replay playback and match observers

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -2982,8 +2982,6 @@ void ControlBar::switchControlBarStage( ControlBarStages stage )
 {
 	if(stage < CONTROL_BAR_STAGE_DEFAULT || stage >= MAX_CONTROL_BAR_STAGES)
 		return;
-	if (TheRecorder && TheRecorder->getMode() == RECORDERMODETYPE_PLAYBACK)
-		return;
 	switch (stage) {
 	case CONTROL_BAR_STAGE_DEFAULT:
 		setDefaultControlBarConfig();

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -2991,20 +2991,17 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 			}
 			else
 			{
-				if (!(TheRecorder && TheRecorder->getMode() == RECORDERMODETYPE_PLAYBACK))
+				Bool hide = false;
+				if (TheWindowManager)
 				{
-					Bool hide = false;
-					if (TheWindowManager)
-					{
-						Int id = (Int)TheNameKeyGenerator->nameToKey(AsciiString("ControlBar.wnd:ControlBarParent"));
-						GameWindow *window = TheWindowManager->winGetWindowFromId(NULL, id);
+					Int id = (Int)TheNameKeyGenerator->nameToKey(AsciiString("ControlBar.wnd:ControlBarParent"));
+					GameWindow *window = TheWindowManager->winGetWindowFromId(NULL, id);
 
-						if (window)
-							hide = !window->winIsHidden();
-					}
-
-					ToggleControlBar();
+					if (window)
+						hide = !window->winIsHidden();
 				}
+
+				ToggleControlBar();
 			}
 			disp = DESTROY_MESSAGE;
 			break;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -3005,8 +3005,6 @@ void ControlBar::switchControlBarStage( ControlBarStages stage )
 {
 	if(stage < CONTROL_BAR_STAGE_DEFAULT || stage >= MAX_CONTROL_BAR_STAGES)
 		return;
-	if (TheRecorder && TheRecorder->getMode() == RECORDERMODETYPE_PLAYBACK)
-		return;
 	switch (stage) {
 	case CONTROL_BAR_STAGE_DEFAULT:
 		setDefaultControlBarConfig();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -3178,20 +3178,17 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 			}
 			else
 			{
-				if (!(TheRecorder && TheRecorder->getMode() == RECORDERMODETYPE_PLAYBACK))
+				Bool hide = false;
+				if (TheWindowManager)
 				{
-					Bool hide = false;
-					if (TheWindowManager)
-					{
-						Int id = (Int)TheNameKeyGenerator->nameToKey(AsciiString("ControlBar.wnd:ControlBarParent"));
-						GameWindow *window = TheWindowManager->winGetWindowFromId(NULL, id);
+					Int id = (Int)TheNameKeyGenerator->nameToKey(AsciiString("ControlBar.wnd:ControlBarParent"));
+					GameWindow *window = TheWindowManager->winGetWindowFromId(NULL, id);
 
-						if (window)
-							hide = !window->winIsHidden();
-					}
-
-					ToggleControlBar();
+					if (window)
+						hide = !window->winIsHidden();
 				}
+
+				ToggleControlBar();
 			}
 			disp = DESTROY_MESSAGE;
 			break;


### PR DESCRIPTION
*Squash and merge*

- Closes: #73 
- Related To: #850 

This PR removes the early return that was preventing the command bar size control from working during replays.