### PR TITLE
[GEN][ZH] Add new ARRAY_SIZE macro in utilities

### DIFF
--- a/Core/Libraries/Include/Lib/BaseTypeCore.h
+++ b/Core/Libraries/Include/Lib/BaseTypeCore.h
@@ -37,6 +37,7 @@
 // TheSuperHackers @compile feliwir 07/04/2025 Adds utility macros for cross-platform compatibility
 #include <Utility/compat.h>
 #include <Utility/CppMacros.h>
+#include <Utility/macros.h>
 #include <Utility/stdint_adapter.h>
 
 /*

--- a/Core/Libraries/Source/WWVegas/WWLib/always.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/always.h
@@ -45,6 +45,7 @@
 
 // TheSuperHackers @compile feliwir 17/04/2025 include utility macros for cross-platform compatibility
 #include <Utility/compat.h>
+#include <Utility/macros.h>
 #include <Utility/stdint_adapter.h>
 
 // Disable warning about exception handling not being enabled. It's used as part of STL - in a part of STL we don't use.
@@ -250,13 +251,6 @@ template <class T> T max(T a,T b)
 	#define	NULL		0
 #endif
 
-/**********************************************************************
-**	This macro serves as a general way to determine the number of elements
-**	within an array.
-*/
-#ifndef ARRAY_SIZE
-#define	ARRAY_SIZE(x)		int(sizeof(x)/sizeof(x[0]))
-#endif
 
 #ifndef size_of
 #define size_of(typ,id) sizeof(((typ*)0)->id)

--- a/Core/Tools/WW3D/pluglib/always.h
+++ b/Core/Tools/WW3D/pluglib/always.h
@@ -55,6 +55,7 @@
 #include	<crtdbg.h>
 #include <stdlib.h>
 #include <malloc.h>
+#include <Utility/macros.h>
 
 #define   malloc(s)         _malloc_dbg(s, _NORMAL_BLOCK, __FILE__, __LINE__)
 #define   calloc(c, s)      _calloc_dbg(c, s, _NORMAL_BLOCK, __FILE__, __LINE__)
@@ -154,13 +155,6 @@ template <class T> T max(T a,T b)
 	#define	NULL		0
 #endif
 
-/**********************************************************************
-**	This macro serves as a general way to determine the number of elements
-**	within an array.
-*/
-#ifndef ARRAY_SIZE
-#define	ARRAY_SIZE(x)		int(sizeof(x)/sizeof(x[0]))
-#endif
 
 #ifndef size_of
 #define size_of(typ,id) sizeof(((typ*)0)->id)

--- a/Dependencies/Utility/Utility/macros.h
+++ b/Dependencies/Utility/Utility/macros.h
@@ -1,0 +1,30 @@
+/*
+**	Command & Conquer Generals Zero Hour(tm)
+**	Copyright 2025 TheSuperHackers
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// This file contains general purpose macros.
+
+#pragma once
+
+/**********************************************************************
+**	This macro serves as a general way to determine the number of elements
+**	within an array.
+*/
+#ifndef ARRAY_SIZE
+extern "C++" template <typename T, size_t N> char (*__NumberOf( T (&)[N] ))[N];
+#define ARRAY_SIZE(A) (sizeof(*__NumberOf(A)))
+#endif

--- a/Generals/Code/GameEngine/Source/GameNetwork/GameSpy/StagingRoomGameInfo.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/GameSpy/StagingRoomGameInfo.cpp
@@ -91,10 +91,6 @@ typedef struct tConnInfoStruct {
 	unsigned short RemotePort;
 } ConnInfoStruct;
 
-#ifndef ARRAY_SIZE
-#define ARRAY_SIZE(a) (sizeof(a)/sizeof(a[0]))
-#endif
-
 /***********************************************************************************************
  * Get_Local_Chat_Connection_Address -- Which address are we using to talk to the chat server? *
  *                                                                                             *

--- a/Generals/Code/GameEngine/Source/GameNetwork/GameSpyGameInfo.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/GameSpyGameInfo.cpp
@@ -76,10 +76,6 @@ typedef struct tConnInfoStruct {
 	unsigned short RemotePort;
 } ConnInfoStruct;
 
-#ifndef ARRAY_SIZE
-#define ARRAY_SIZE(a) (sizeof(a)/sizeof(a[0]))
-#endif
-
 /***********************************************************************************************
  * Get_Local_Chat_Connection_Address -- Which address are we using to talk to the chat server? *
  *                                                                                             *

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameSpy/StagingRoomGameInfo.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameSpy/StagingRoomGameInfo.cpp
@@ -91,10 +91,6 @@ typedef struct tConnInfoStruct {
 	unsigned short RemotePort;
 } ConnInfoStruct;
 
-#ifndef ARRAY_SIZE
-#define ARRAY_SIZE(a) (sizeof(a)/sizeof(a[0]))
-#endif
-
 /***********************************************************************************************
  * Get_Local_Chat_Connection_Address -- Which address are we using to talk to the chat server? *
  *                                                                                             *

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameSpyGameInfo.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameSpyGameInfo.cpp
@@ -76,10 +76,6 @@ typedef struct tConnInfoStruct {
 	unsigned short RemotePort;
 } ConnInfoStruct;
 
-#ifndef ARRAY_SIZE
-#define ARRAY_SIZE(a) (sizeof(a)/sizeof(a[0]))
-#endif
-
 /***********************************************************************************************
  * Get_Local_Chat_Connection_Address -- Which address are we using to talk to the chat server? *
  *                                                                                             *


### PR DESCRIPTION
This change adds a new `ARRAY_SIZE` macro in Utility/macro.h and removes duplicated ones across the code base.