### PR TITLE
[GEN][ZH] Fix unsafe calls to _vsnprintf, _vsnwprintf, _snprintf, _snwprintf

### DIFF
--- a/Core/Libraries/Source/WWVegas/WW3D2/statistics.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/statistics.cpp
@@ -24,7 +24,7 @@
 #include "dx8caps.h"
 #include "textureloader.h"
 #include "texture.h"
-#include <cstdio>
+#include <Utility/stdio_adapter.h>
 
 #include <memory.h>
 #ifdef _UNIX
@@ -94,7 +94,7 @@ static void Record_Texture_End()
 	texture_statistics_string="";
 	if (record_texture_mode==Debug_Statistics::RECORD_TEXTURE_DETAILS) {
 		char tmp_text[1024];
-		_snprintf(tmp_text,sizeof(tmp_text),
+		snprintf(tmp_text,sizeof(tmp_text),
 			"Set_DX8_Texture count: %d\nactual changes: %d\n\n"
 			"id      refs changes  size      name\n"
 			"--------------------------------------\n",

--- a/Core/Libraries/Source/WWVegas/WWDownload/urlBuilder.cpp
+++ b/Core/Libraries/Source/WWVegas/WWDownload/urlBuilder.cpp
@@ -17,7 +17,7 @@
 */
 
 #include <string>
-#include <stdio.h>
+#include <Utility/stdio_adapter.h>
 #include "Registry.h"
 
 void FormatURLFromRegistry( std::string& gamePatchURL, std::string& mapPatchURL,
@@ -41,13 +41,13 @@ void FormatURLFromRegistry( std::string& gamePatchURL, std::string& mapPatchURL,
 	GetUnsignedIntFromRegistry("", "MapPackVersion", mapVersion);
 
 	char buf[256];
-	_snprintf(buf, 256, "%s%s-%d.txt", baseURL.c_str(), language.c_str(), version);
+	snprintf(buf, 256, "%s%s-%d.txt", baseURL.c_str(), language.c_str(), version);
 	gamePatchURL = buf;
-	_snprintf(buf, 256, "%smaps-%d.txt", baseURL.c_str(), mapVersion);
+	snprintf(buf, 256, "%smaps-%d.txt", baseURL.c_str(), mapVersion);
 	mapPatchURL = buf;
-	_snprintf(buf, 256, "%sconfig.txt", baseURL.c_str());
+	snprintf(buf, 256, "%sconfig.txt", baseURL.c_str());
 	configURL = buf;
-	_snprintf(buf, 256, "%sMOTD-%s.txt", baseURL.c_str(), language.c_str());
+	snprintf(buf, 256, "%sMOTD-%s.txt", baseURL.c_str(), language.c_str());
 	motdURL = buf;
 }
 

--- a/Core/Libraries/Source/WWVegas/WWLib/ini.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/ini.cpp
@@ -94,7 +94,7 @@
 #include	"win.h"
 #include	"XPIPE.H"
 #include	"XSTRAW.H"
-#include	<stdio.h>
+#include	<Utility/stdio_adapter.h>
 #include <malloc.h>
 #ifdef _UNIX
 #include <ctype.h>
@@ -2281,7 +2281,7 @@ int INIClass::CRC(const char *string)
 void INIClass::DuplicateCRCError(const char *message, const char *section, const char *entry)
 {
 	char buffer[512];
-	_snprintf(buffer, sizeof(buffer), "%s - Duplicate Entry \"%s\" in section \"%s\" (%s)\n", message,
+	snprintf(buffer, sizeof(buffer), "%s - Duplicate Entry \"%s\" in section \"%s\" (%s)\n", message,
 		entry, section, Filename);
 
 	OutputDebugString(buffer);

--- a/Core/Libraries/Source/WWVegas/WWLib/widestring.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/widestring.cpp
@@ -38,7 +38,7 @@
 
 #include "widestring.h"
 #include "win.h"
-#include <stdio.h>
+#include <Utility/stdio_adapter.h>
 
 
 ///////////////////////////////////////////////////////////////////
@@ -258,7 +258,7 @@ WideStringClass::Format_Args (const WCHAR *format, va_list arg_list )
 	//
 	//	Format the string
 	//
-	int retval = _vsnwprintf (temp_buffer, 512, format, arg_list);
+	int retval = vswprintf (temp_buffer, 512, format, arg_list);
 	
 	//
 	//	Copy the string into our buffer
@@ -292,7 +292,7 @@ WideStringClass::Format (const WCHAR *format, ...)
 	//
 	//	Format the string
 	//
-	int retval = _vsnwprintf (temp_buffer, 512, format, arg_list);
+	int retval = vswprintf (temp_buffer, 512, format, arg_list);
 	
 	//
 	//	Copy the string into our buffer

--- a/Core/Libraries/Source/WWVegas/WWLib/wwfile.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/wwfile.cpp
@@ -34,13 +34,10 @@
  * Functions:                                                                                  *
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-#include <stdio.h>
+#include <Utility/stdio_adapter.h>
 #include <stdarg.h>
 #include <memory.h>
 #include "WWFILE.H"
-
-// TheSuperHackers @compile feliwir 17/04/2025 include _vsnprintf macros
-#include <Utility/compat.h>
 
 #pragma warning(disable : 4514)
 
@@ -49,7 +46,7 @@ int FileClass::Printf(char *str, ...)
 	char text[PRINTF_BUFFER_SIZE];
 	va_list args;
 	va_start(args, str);
-	int length = _vsnprintf(text, PRINTF_BUFFER_SIZE, str, args);
+	int length = vsnprintf(text, PRINTF_BUFFER_SIZE, str, args);
 	va_end(args);
 	return Write(text, length);
 }
@@ -58,7 +55,7 @@ int FileClass::Printf(char *buffer, int bufferSize, char *str, ...)
 {
 	va_list args;
 	va_start(args, str);
-	int length = _vsnprintf(buffer, bufferSize, str, args);
+	int length = vsnprintf(buffer, bufferSize, str, args);
 	va_end(args);
 	return Write(buffer, length);
 }
@@ -76,7 +73,7 @@ int FileClass::Printf_Indented(unsigned depth, char *str, ...)
 
 	int length;
 	if(depth < PRINTF_BUFFER_SIZE) 
-		length = _vsnprintf(text + depth, PRINTF_BUFFER_SIZE - depth, str, args);
+		length = vsnprintf(text + depth, PRINTF_BUFFER_SIZE - depth, str, args);
 	else
 		length = PRINTF_BUFFER_SIZE;
 

--- a/Core/Libraries/Source/WWVegas/WWLib/wwstring.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/wwstring.cpp
@@ -37,7 +37,7 @@
 #include "wwstring.h"
 #include "wwmemlog.h"
 #include "mutex.h"
-#include <stdio.h>
+#include <Utility/stdio_adapter.h>
 
 
 ///////////////////////////////////////////////////////////////////
@@ -249,9 +249,9 @@ StringClass::Format_Args (const TCHAR *format, va_list arg_list )
 	//	Format the string
 	//
 	#ifdef _UNICODE
-		retval = _vsnwprintf (temp_buffer, 512, format, arg_list);
+		retval = vswprintf (temp_buffer, 512, format, arg_list);
 	#else
-		retval = _vsnprintf (temp_buffer, 512, format, arg_list);
+		retval = vsnprintf (temp_buffer, 512, format, arg_list);
 	#endif
 	
 	//
@@ -284,9 +284,9 @@ StringClass::Format (const TCHAR *format, ...)
 	//	Format the string
 	//
 	#ifdef _UNICODE
-		retval = _vsnwprintf (temp_buffer, 512, format, arg_list);
+		retval = vswprintf (temp_buffer, 512, format, arg_list);
 	#else
-		retval = _vsnprintf (temp_buffer, 512, format, arg_list);
+		retval = vsnprintf (temp_buffer, 512, format, arg_list);
 	#endif
 	
 	//

--- a/Core/Libraries/Source/debug/debug_debug.cpp
+++ b/Core/Libraries/Source/debug/debug_debug.cpp
@@ -28,7 +28,7 @@
 //////////////////////////////////////////////////////////////////////////////
 #include "_pch.h"
 #include <stdlib.h>
-#include <stdio.h>
+#include <Utility/stdio_adapter.h>
 #include <string.h>
 #include <new>      // needed for placement new prototype
 
@@ -240,7 +240,7 @@ Debug::Format::Format(const char *format, ...)
 {
   va_list va;
   va_start(va,format);
-  _vsnprintf(m_buffer,sizeof(m_buffer)-1,format,va);
+  vsnprintf(m_buffer,sizeof(m_buffer)-1,format,va);
   va_end(va);
 }
 
@@ -783,7 +783,7 @@ Debug& Debug::operator<<(float val)
 {
   /// @todo_opt shouldn't use snprintf here - brings in most of the old C IO lib...
   char help[200];
-  _snprintf(help,sizeof(help),"%f",val);
+  snprintf(help,sizeof(help),"%f",val);
   return (*this) << help;
 }
 
@@ -791,7 +791,7 @@ Debug& Debug::operator<<(double val)
 {
   /// @todo_opt shouldn't use snprintf here - brings in most of the old C IO lib...
   char help[200];
-  _snprintf(help,sizeof(help),"%f",val);
+  snprintf(help,sizeof(help),"%f",val);
   return (*this) << help;
 }
 

--- a/Core/Libraries/Source/profile/profile_highlevel.cpp
+++ b/Core/Libraries/Source/profile/profile_highlevel.cpp
@@ -28,7 +28,7 @@
 //////////////////////////////////////////////////////////////////////////////
 #include "_pch.h"
 #include <new>
-#include <stdio.h>
+#include <Utility/stdio_adapter.h>
 
 // our own fast critical section
 static ProfileFastCS cs;
@@ -202,7 +202,7 @@ const char *ProfileId::AsString(double v) const
   for (k=m_exp10;k<0;k++) mul*=10.0;
   for (;k>0;k--) mul/=10.0;
 
-  unsigned len=_snprintf(help,sizeof(help),help1,v*mul)+1;
+  unsigned len=snprintf(help,sizeof(help),help1,v*mul)+1;
 
   ProfileFastCS::Lock lock(cs);
   if (stringBufUnused+len>STRING_BUFFER_SIZE)

--- a/Core/Tools/Autorun/CMakeLists.txt
+++ b/Core/Tools/Autorun/CMakeLists.txt
@@ -54,6 +54,7 @@ target_sources(corei_autorun INTERFACE ${AUTORUN_SRC})
 
 target_link_libraries(corei_autorun INTERFACE
     core_config
+    core_utility
     winmm
 )
 

--- a/Core/Tools/Autorun/GameText.cpp
+++ b/Core/Tools/Autorun/GameText.cpp
@@ -38,7 +38,7 @@
 //----------------------------------------------------------------------------
 
 #include <stdlib.h>
-#include <stdio.h>
+#include <Utility/stdio_adapter.h>
 #include <ctype.h>
 #include <string.h>
 
@@ -1072,8 +1072,7 @@ const wchar_t * GameTextManager::fetch( const Char *label )
 	{
 		// See if we already have the missing string
 		wchar_t tmp[256];
-		_snwprintf(tmp, 256, L"MISSING: '%hs'", label);
-		tmp[255] = 0;
+		swprintf(tmp, 256, L"MISSING: '%hs'", label);
 		std::wstring missingString = tmp;
 
 		NoString *noString = m_noStringList;

--- a/Core/Tools/Autorun/autorun.cpp
+++ b/Core/Tools/Autorun/autorun.cpp
@@ -86,7 +86,7 @@
 #include <process.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdio.h>
+#include <Utility/stdio_adapter.h>
 #include <sys/stat.h>
 #include <time.h>
 #include <winuser.h>
@@ -3730,7 +3730,7 @@ BOOL CALLBACK  Dialog_Box_Proc( HWND window_handle, UINT message, WPARAM w_param
 						unsigned int success;
 
 						char filepath[MAX_PATH];
-						_snprintf(filepath, MAX_PATH, "%s%s", szArgvPath, SC4AVI_FILENAME);
+						snprintf(filepath, MAX_PATH, "%s%s", szArgvPath, SC4AVI_FILENAME);
 
 						success = GlobalMainWindow->Run_OpenFile(cd_drive, filepath, true);
 //						if (success != 0) {
@@ -3771,10 +3771,10 @@ BOOL CALLBACK  Dialog_Box_Proc( HWND window_handle, UINT message, WPARAM w_param
 
 						GetCurrentDirectory(MAX_PATH, olddir);
 
-						_snprintf(newdir, MAX_PATH, "%ssupport", szArgvPath);
+						snprintf(newdir, MAX_PATH, "%ssupport", szArgvPath);
 						SetCurrentDirectory(newdir);
 
-						_snprintf(filepath, MAX_PATH, "%s%s", szArgvPath, fname.c_str());
+						snprintf(filepath, MAX_PATH, "%s%s", szArgvPath, fname.c_str());
 
 						unsigned int success;
 						success = GlobalMainWindow->Run_OpenFile(cd_drive, filepath, false);

--- a/Core/Tools/Compress/CMakeLists.txt
+++ b/Core/Tools/Compress/CMakeLists.txt
@@ -14,8 +14,5 @@ target_link_libraries(core_compress PRIVATE
 )
 
 if(WIN32 OR "${CMAKE_SYSTEM}" MATCHES "Windows")
-    if(IS_VS6_BUILD)
-        target_compile_definitions(core_compress PRIVATE vsnprintf=_vsnprintf)
-    endif()
     target_link_options(core_compress PRIVATE /subsystem:console)
 endif()

--- a/Core/Tools/textureCompress/CMakeLists.txt
+++ b/Core/Tools/textureCompress/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(core_texturecompress PRIVATE ${TEXTURECOMPRESS_SRC})
 
 target_link_libraries(core_texturecompress PRIVATE
     core_config
+    core_utility
     core_wwlib
 )
 

--- a/Core/Tools/textureCompress/textureCompress.cpp
+++ b/Core/Tools/textureCompress/textureCompress.cpp
@@ -25,7 +25,7 @@
 #include <windows.h>
 #include <lmcons.h>
 #include <stdlib.h>
-#include <stdio.h>
+#include <Utility/stdio_adapter.h>
 #include <string.h>
 
 #include "resource.h"
@@ -57,8 +57,7 @@ static void logStuff(const char *fmt, ...)
 	static char buffer[1024];
 	va_list va;
 	va_start( va, fmt );
-	_vsnprintf(buffer, 1024, fmt, va );
-	buffer[1023] = 0;
+	vsnprintf(buffer, 1024, fmt, va );
 	va_end( va );
 
 	puts(buffer);
@@ -84,8 +83,7 @@ static void debugLog(const char *fmt, ...)
 	static char buffer[1024];
 	va_list va;
 	va_start( va, fmt );
-	_vsnprintf(buffer, 1024, fmt, va );
-	buffer[1023] = 0;
+	vsnprintf(buffer, 1024, fmt, va );
 	va_end( va );
 
 	OutputDebugString( buffer );

--- a/Dependencies/Utility/Utility/stdio_adapter.h
+++ b/Dependencies/Utility/Utility/stdio_adapter.h
@@ -24,7 +24,7 @@
 
 #include <stdarg.h>
 
-extern "C" inline int vsnprintf(char* _Buffer, size_t _BufferCount, const char* _Format, va_list _ArgList)
+inline int vsnprintf(char* _Buffer, size_t _BufferCount, const char* _Format, va_list _ArgList)
 {
     // Microsoft's _vsnprintf does not null terminate when writing the entire length.
     int result = _vsnprintf(_Buffer, _BufferCount, _Format, _ArgList);
@@ -33,7 +33,7 @@ extern "C" inline int vsnprintf(char* _Buffer, size_t _BufferCount, const char* 
 }
 
 // Yes, this is called vswprintf instead of vsnwprintf
-extern "C" inline int vswprintf(wchar_t* _Buffer, size_t _BufferCount, const wchar_t* _Format, va_list _ArgList)
+inline int vswprintf(wchar_t* _Buffer, size_t _BufferCount, const wchar_t* _Format, va_list _ArgList)
 {
     // Microsoft's _vsnwprintf does not null terminate when writing the entire length.
     int result = _vsnwprintf(_Buffer, _BufferCount, _Format, _ArgList);
@@ -41,7 +41,7 @@ extern "C" inline int vswprintf(wchar_t* _Buffer, size_t _BufferCount, const wch
     return result;
 }
 
-extern "C" inline int snprintf(char* _Buffer, size_t _BufferCount, const char* _Format, ...)
+inline int snprintf(char* _Buffer, size_t _BufferCount, const char* _Format, ...)
 {
     va_list _ArgList;
     va_start(_ArgList, _Format);
@@ -51,7 +51,7 @@ extern "C" inline int snprintf(char* _Buffer, size_t _BufferCount, const char* _
 }
 
 // Yes, this is called swprintf instead of snwprintf
-extern "C" inline int swprintf(wchar_t* _Buffer, size_t _BufferCount, const wchar_t* _Format, ...)
+inline int swprintf(wchar_t* _Buffer, size_t _BufferCount, const wchar_t* _Format, ...)
 {
     va_list _ArgList;
     va_start(_ArgList, _Format);

--- a/Dependencies/Utility/Utility/stdio_adapter.h
+++ b/Dependencies/Utility/Utility/stdio_adapter.h
@@ -1,0 +1,63 @@
+/*
+**	Command & Conquer Generals Zero Hour(tm)
+**	Copyright 2025 TheSuperHackers
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <stdio.h>
+
+#if defined(_MSC_VER) && _MSC_VER < 1300
+
+#include <stdarg.h>
+
+extern "C" inline int vsnprintf(char* _Buffer, size_t _BufferCount, const char* _Format, va_list _ArgList)
+{
+    // Microsoft's _vsnprintf does not null terminate when writing the entire length.
+    int result = _vsnprintf(_Buffer, _BufferCount, _Format, _ArgList);
+    _Buffer[_BufferCount - 1] = '\0';
+    return result;
+}
+
+// Yes, this is called vswprintf instead of vsnwprintf
+extern "C" inline int vswprintf(wchar_t* _Buffer, size_t _BufferCount, const wchar_t* _Format, va_list _ArgList)
+{
+    // Microsoft's _vsnwprintf does not null terminate when writing the entire length.
+    int result = _vsnwprintf(_Buffer, _BufferCount, _Format, _ArgList);
+    _Buffer[_BufferCount - 1] = L'\0';
+    return result;
+}
+
+extern "C" inline int snprintf(char* _Buffer, size_t _BufferCount, const char* _Format, ...)
+{
+    va_list _ArgList;
+    va_start(_ArgList, _Format);
+    int result = vsnprintf(_Buffer, _BufferCount, _Format, _ArgList);
+    va_end(_ArgList);
+    return result;
+}
+
+// Yes, this is called swprintf instead of snwprintf
+extern "C" inline int swprintf(wchar_t* _Buffer, size_t _BufferCount, const wchar_t* _Format, ...)
+{
+    va_list _ArgList;
+    va_start(_ArgList, _Format);
+    int result = vswprintf(_Buffer, _BufferCount, _Format, _ArgList);
+    va_end(_ArgList);
+    return result;
+}
+
+#endif

--- a/Dependencies/Utility/Utility/string_compat.h
+++ b/Dependencies/Utility/Utility/string_compat.h
@@ -32,8 +32,6 @@ inline char *_strlwr(char *str) {
 }
 
 #define strlwr _strlwr
-#define _vsnprintf vsnprintf
-#define _snprintf snprintf
 #define stricmp strcasecmp
 #define strnicmp strncasecmp
 #define strcmpi strcasecmp

--- a/Dependencies/Utility/Utility/wchar_compat.h
+++ b/Dependencies/Utility/Utility/wchar_compat.h
@@ -26,7 +26,6 @@ typedef WCHAR* LPWSTR;
 
 #define _wcsicmp wcscasecmp
 #define wcsicmp wcscasecmp
-#define _vsnwprintf vswprintf
 
 // MultiByteToWideChar
 #define CP_ACP 0

--- a/Generals/Code/GameEngine/Include/Precompiled/PreRTS.h
+++ b/Generals/Code/GameEngine/Include/Precompiled/PreRTS.h
@@ -69,7 +69,7 @@ class STLSpecialAlloc;
 #include <snmp.h>
 #include <stdarg.h>
 #include <stddef.h>
-#include <stdio.h>
+#include <Utility/stdio_adapter.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>

--- a/Generals/Code/GameEngine/Source/Common/CRCDebug.cpp
+++ b/Generals/Code/GameEngine/Source/Common/CRCDebug.cpp
@@ -209,8 +209,7 @@ static void addCRCDebugLineInternal(bool count, const char *fmt, va_list args)
 		DebugStrings[nextDebugString][0] = 0;
 	Int len = strlen(DebugStrings[nextDebugString]);
 
-	_vsnprintf(DebugStrings[nextDebugString]+len, MaxStringLen-len, fmt, args);
-	DebugStrings[nextDebugString][MaxStringLen-1] = 0;
+	vsnprintf(DebugStrings[nextDebugString]+len, MaxStringLen-len, fmt, args);
 
 	char *tmp = DebugStrings[nextDebugString];
 	while (tmp && *tmp)
@@ -258,9 +257,8 @@ void addCRCGenLine(const char *fmt, ...)
 	static char buf[MaxStringLen];
 	va_list va;
 	va_start( va, fmt );
-	_vsnprintf(buf, MaxStringLen, fmt, va );
+	vsnprintf(buf, MaxStringLen, fmt, va );
 	va_end( va );
-	buf[MaxStringLen-1] = 0;
 	addCRCDebugLine("%s", buf);
 
 	//DEBUG_LOG(("%s", buf));
@@ -271,8 +269,7 @@ void addCRCDumpLine(const char *fmt, ...)
 	/*
 	va_list va;
 	va_start( va, fmt );
-	_vsnprintf(DumpStrings[nextDumpString], MaxStringLen, fmt, va );
-	DumpStrings[nextDumpString][MaxStringLen-1] = 0;
+	vsnprintf(DumpStrings[nextDumpString], MaxStringLen, fmt, va );
 	va_end( va );
 
 	++nextDumpString;

--- a/Generals/Code/GameEngine/Source/Common/MiniLog.cpp
+++ b/Generals/Code/GameEngine/Source/Common/MiniLog.cpp
@@ -74,8 +74,7 @@ void LogClass::log(const char *fmt, ...)
 
 	va_list va;
 	va_start( va, fmt );
-	_vsnprintf(buf, 1024, fmt, va );
-	buf[1023] = 0;
+	vsnprintf(buf, 1024, fmt, va );
 	va_end( va );
 
 	char *tmp = buf;

--- a/Generals/Code/GameEngine/Source/Common/System/AsciiString.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/AsciiString.cpp
@@ -377,7 +377,7 @@ void AsciiString::format_va(const char* format, va_list args)
 {
 	validate();
 	char buf[MAX_FORMAT_BUF_LEN];
-	const int result = _vsnprintf(buf, sizeof(buf)/sizeof(char)-1, format, args);
+	const int result = vsnprintf(buf, sizeof(buf)/sizeof(char), format, args);
 	if (result >= 0)
 	{
 		set(buf);

--- a/Generals/Code/GameEngine/Source/Common/System/Debug.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/Debug.cpp
@@ -736,8 +736,7 @@ void ReleaseCrash(const char *reason)
 
 #if defined(RTS_DEBUG) || defined(RTS_INTERNAL)
 	/* static */ char buff[8192]; // not so static so we can be threadsafe
-	_snprintf(buff, 8192, "Sorry, a serious error occurred. (%s)", reason);
-	buff[8191] = 0;
+	snprintf(buff, 8192, "Sorry, a serious error occurred. (%s)", reason);
 	::MessageBox(NULL, buff, "Technical Difficulties...", MB_OK|MB_SYSTEMMODAL|MB_ICONERROR);
 #else
 // crash error messaged changed 3/6/03 BGC

--- a/Generals/Code/GameEngine/Source/Common/System/UnicodeString.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/UnicodeString.cpp
@@ -314,7 +314,7 @@ void UnicodeString::format_va(const WideChar* format, va_list args)
 {
 	validate();
 	WideChar buf[MAX_FORMAT_BUF_LEN];
-	const int result = _vsnwprintf(buf, sizeof(buf)/sizeof(WideChar)-1, format, args);
+	const int result = vswprintf(buf, sizeof(buf)/sizeof(WideChar), format, args);
 	if (result >= 0)
 	{
 		set(buf);

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLGameSetupMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLGameSetupMenu.cpp
@@ -82,9 +82,8 @@ void slotListDebugLog(const char *fmt, ...)
 	static char buf[1024];
 	va_list va;
 	va_start( va, fmt );
-	_vsnprintf(buf, 1024, fmt, va );
+	vsnprintf(buf, 1024, fmt, va );
 	va_end( va );
-	buf[1023] = 0;
 
 	DEBUG_LOG(("%s", buf));
 	if (g_debugSlots)

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLWelcomeMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLWelcomeMenu.cpp
@@ -509,9 +509,9 @@ void WOLWelcomeMenuInit( WindowLayout *layout, void *userData )
 		const char *keys[3] = { "locale", "wins", "losses" };
 		char valueStrings[3][20];
 		char *values[3] = { valueStrings[0], valueStrings[1], valueStrings[2] };
-		_snprintf(values[0], 20, "%s", TheGameSpyPlayerInfo->getLocale().str());
-		_snprintf(values[1], 20, "%d", TheGameSpyPlayerInfo->getWins());
-		_snprintf(values[2], 20, "%d", TheGameSpyPlayerInfo->getLosses());
+		snprintf(values[0], 20, "%s", TheGameSpyPlayerInfo->getLocale().str());
+		snprintf(values[1], 20, "%d", TheGameSpyPlayerInfo->getWins());
+		snprintf(values[2], 20, "%d", TheGameSpyPlayerInfo->getLosses());
 		peerSetGlobalKeys(TheGameSpyChat->getPeer(), 3, (const char **)keys, (const char **)values);
 		peerSetGlobalWatchKeys(TheGameSpyChat->getPeer(), GroupRoom,   3, keys, PEERFalse);
 		peerSetGlobalWatchKeys(TheGameSpyChat->getPeer(), StagingRoom, 3, keys, PEERFalse);

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -1970,7 +1970,7 @@ void InGameUI::message( AsciiString stringManagerLabel, ... )
 	va_list args;
 	va_start( args, stringManagerLabel );
 	WideChar buf[ UnicodeString::MAX_FORMAT_BUF_LEN ];
-	int result = _vsnwprintf(buf, sizeof( buf )/sizeof( WideChar ) - 1, stringManagerString.str(), args );
+	int result = vswprintf(buf, sizeof( buf )/sizeof( WideChar ), stringManagerString.str(), args );
 	va_end(args);
 
 	if( result >= 0 )
@@ -1997,7 +1997,7 @@ void InGameUI::message( UnicodeString format, ... )
 	va_list args;
 	va_start( args, format );
 	WideChar buf[ UnicodeString::MAX_FORMAT_BUF_LEN ];
-	int result = _vsnwprintf(buf, sizeof( buf )/sizeof( WideChar ) - 1, format.str(), args );
+	int result = vswprintf(buf, sizeof( buf )/sizeof( WideChar ), format.str(), args );
 	va_end(args);
 
 	if( result >= 0 )
@@ -2024,7 +2024,7 @@ void InGameUI::messageColor( const RGBColor *rgbColor, UnicodeString format, ...
 	va_list args;
 	va_start( args, format );
 	WideChar buf[ UnicodeString::MAX_FORMAT_BUF_LEN ];
-	int result = _vsnwprintf(buf, sizeof( buf )/sizeof( WideChar ) - 1, format.str(), args );
+	int result = vswprintf(buf, sizeof( buf )/sizeof( WideChar ), format.str(), args );
 	va_end(args);
 
 	if( result >= 0 )

--- a/Generals/Code/GameEngine/Source/GameNetwork/GameSpy.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/GameSpy.cpp
@@ -806,9 +806,8 @@ static void PlayerUTMCallback(PEER peer, const char * nick,
 void GOABasicCallback(PEER peer, PEERBool playing, char * outbuf,
 											int maxlen, void * param)
 {
-	_snprintf(outbuf, maxlen, "\\gamename\\c&cgenerals\\gamever\\%s\\location\\%d",
+	snprintf(outbuf, maxlen, "\\gamename\\c&cgenerals\\gamever\\%s\\location\\%d",
 		TheVersion->getAsciiVersion().str(), 0);
-	outbuf[maxlen-1] = 0;
 	DEBUG_LOG(("GOABasicCallback: [%s]\n", outbuf));
 	TheGameSpyGame->gotGOACall();
 }
@@ -816,9 +815,8 @@ void GOABasicCallback(PEER peer, PEERBool playing, char * outbuf,
 void GOAInfoCallback(PEER peer, PEERBool playing, char * outbuf,
 										 int maxlen, void * param)
 {
-	_snprintf(outbuf, maxlen, "\\hostname\\%s\\hostport\\%d\\mapname\\%s\\gametype\\%s\\numplayers\\%d\\maxplayers\\%d\\gamemode\\%s",
+	snprintf(outbuf, maxlen, "\\hostname\\%s\\hostport\\%d\\mapname\\%s\\gametype\\%s\\numplayers\\%d\\maxplayers\\%d\\gamemode\\%s",
 		TheGameSpyChat->getLoginName().str(), 0, TheGameSpyGame->getMap().str(), "battle", TheGameSpyGame->getNumPlayers(), TheGameSpyGame->getMaxPlayers(), "wait");
-	outbuf[maxlen-1] = 0;
 	DEBUG_LOG(("GOAInfoCallback: [%s]\n", outbuf));
 	TheGameSpyGame->gotGOACall();
 }
@@ -826,9 +824,8 @@ void GOAInfoCallback(PEER peer, PEERBool playing, char * outbuf,
 void GOARulesCallback(PEER peer, PEERBool playing, char * outbuf,
 											int maxlen, void * param)
 {
-	_snprintf(outbuf, maxlen, "\\password\\0\\seed\\%d",
+	snprintf(outbuf, maxlen, "\\password\\0\\seed\\%d",
 		TheGameSpyGame->getSeed());
-	outbuf[maxlen-1] = 0;
 	DEBUG_LOG(("GOARulesCallback: [%s]\n", outbuf));
 	TheGameSpyGame->gotGOACall();
 }
@@ -878,8 +875,7 @@ void GOAPlayersCallback(PEER peer, PEERBool playing, char * outbuf,
 			i, slot->getStartPos());
 		buf.concat(tmp);
 	}
-	_snprintf(outbuf, maxlen, buf.str());
-	outbuf[maxlen-1] = 0;
+	snprintf(outbuf, maxlen, buf.str());
 	DEBUG_LOG(("GOAPlayersCallback: [%s]\n", outbuf));
 	TheGameSpyGame->gotGOACall();
 }

--- a/Generals/Code/GameEngine/Source/GameNetwork/GameSpy/Thread/GameResultsThread.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/GameSpy/Thread/GameResultsThread.cpp
@@ -217,8 +217,8 @@ static void WrapHTTP( const std::string& hostname, std::string& results )
 		"Content-Length: %d\r\n"
 		"\r\n";
 
-	char szHdr[256] = {0};
-	_snprintf( szHdr, 255, HEADER, hostname.c_str(), results.length() );
+	char szHdr[256];
+	snprintf( szHdr, 256, HEADER, hostname.c_str(), results.length() );
 	results = szHdr + results;
 } //WrapHTTP
 

--- a/Generals/Code/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
@@ -1476,24 +1476,24 @@ void PeerThreadClass::Thread_Function()
 
 					// Testing alternate way to push stats
 #ifdef USE_BROADCAST_KEYS
-					_snprintf(s_valueBuffers[0], 20, "%d", incomingRequest.statsToPush.locale);
-					_snprintf(s_valueBuffers[1], 20, "%d", incomingRequest.statsToPush.wins);
-					_snprintf(s_valueBuffers[2], 20, "%d", incomingRequest.statsToPush.losses);
-					_snprintf(s_valueBuffers[3], 20, "%d", incomingRequest.statsToPush.rankPoints);
-					_snprintf(s_valueBuffers[4], 20, "%d", incomingRequest.statsToPush.side);
-					_snprintf(s_valueBuffers[5], 20, "%d", incomingRequest.statsToPush.preorder);
+					snprintf(s_valueBuffers[0], 20, "%d", incomingRequest.statsToPush.locale);
+					snprintf(s_valueBuffers[1], 20, "%d", incomingRequest.statsToPush.wins);
+					snprintf(s_valueBuffers[2], 20, "%d", incomingRequest.statsToPush.losses);
+					snprintf(s_valueBuffers[3], 20, "%d", incomingRequest.statsToPush.rankPoints);
+					snprintf(s_valueBuffers[4], 20, "%d", incomingRequest.statsToPush.side);
+					snprintf(s_valueBuffers[5], 20, "%d", incomingRequest.statsToPush.preorder);
 					pushStatsToRoom(peer);
 #else
 					const char *keys[6] = { "locale", "wins", "losses", "points", "side", "pre" };
 					char valueStrings[6][20];
 					char *values[6] = { valueStrings[0], valueStrings[1], valueStrings[2],
 						valueStrings[3], valueStrings[4], valueStrings[5]};
-					_snprintf(values[0], 20, "%d", incomingRequest.statsToPush.locale);
-					_snprintf(values[1], 20, "%d", incomingRequest.statsToPush.wins);
-					_snprintf(values[2], 20, "%d", incomingRequest.statsToPush.losses);
-					_snprintf(values[3], 20, "%d", incomingRequest.statsToPush.rankPoints);
-					_snprintf(values[4], 20, "%d", incomingRequest.statsToPush.side);
-					_snprintf(values[5], 20, "%d", incomingRequest.statsToPush.preorder);
+					snprintf(values[0], 20, "%d", incomingRequest.statsToPush.locale);
+					snprintf(values[1], 20, "%d", incomingRequest.statsToPush.wins);
+					snprintf(values[2], 20, "%d", incomingRequest.statsToPush.losses);
+					snprintf(values[3], 20, "%d", incomingRequest.statsToPush.rankPoints);
+					snprintf(values[4], 20, "%d", incomingRequest.statsToPush.side);
+					snprintf(values[5], 20, "%d", incomingRequest.statsToPush.preorder);
 					peerSetGlobalKeys(peer, 6, (const char **)keys, (const char **)values);
 					peerSetGlobalWatchKeys(peer, GroupRoom,   0, NULL, PEERFalse);
 					peerSetGlobalWatchKeys(peer, StagingRoom, 0, NULL, PEERFalse);
@@ -1973,39 +1973,38 @@ void PeerThreadClass::doQuickMatch( PEER peer )
 							if (m_sawMatchbot)
 							{
 								char buf[64];
-								buf[63] = '\0';
 								std::string msg = "\\CINFO";
-								_snprintf(buf, 63, "\\Widen\\%d", m_qmInfo.QM.widenTime);
+								snprintf(buf, 64, "\\Widen\\%d", m_qmInfo.QM.widenTime);
 								msg.append(buf);
-								_snprintf(buf, 63, "\\LadID\\%d", m_qmInfo.QM.ladderID);
+								snprintf(buf, 64, "\\LadID\\%d", m_qmInfo.QM.ladderID);
 								msg.append(buf);
-								_snprintf(buf, 63, "\\LadPass\\%d", m_qmInfo.QM.ladderPassCRC);
+								snprintf(buf, 64, "\\LadPass\\%d", m_qmInfo.QM.ladderPassCRC);
 								msg.append(buf);
-								_snprintf(buf, 63, "\\PointsMin\\%d", m_qmInfo.QM.minPointPercentage);
+								snprintf(buf, 64, "\\PointsMin\\%d", m_qmInfo.QM.minPointPercentage);
 								msg.append(buf);
-								_snprintf(buf, 63, "\\PointsMax\\%d", m_qmInfo.QM.maxPointPercentage);
+								snprintf(buf, 64, "\\PointsMax\\%d", m_qmInfo.QM.maxPointPercentage);
 								msg.append(buf);
-								_snprintf(buf, 63, "\\Points\\%d", m_qmInfo.QM.points);
+								snprintf(buf, 64, "\\Points\\%d", m_qmInfo.QM.points);
 								msg.append(buf);
-								_snprintf(buf, 63, "\\Discons\\%d", m_qmInfo.QM.discons);
+								snprintf(buf, 64, "\\Discons\\%d", m_qmInfo.QM.discons);
 								msg.append(buf);
-								_snprintf(buf, 63, "\\DisconMax\\%d", m_qmInfo.QM.maxDiscons);
+								snprintf(buf, 64, "\\DisconMax\\%d", m_qmInfo.QM.maxDiscons);
 								msg.append(buf);
-								_snprintf(buf, 63, "\\NumPlayers\\%d", m_qmInfo.QM.numPlayers);
+								snprintf(buf, 64, "\\NumPlayers\\%d", m_qmInfo.QM.numPlayers);
 								msg.append(buf);
-								_snprintf(buf, 63, "\\Pings\\%s", m_qmInfo.QM.pings);
+								snprintf(buf, 64, "\\Pings\\%s", m_qmInfo.QM.pings);
 								msg.append(buf);
-								_snprintf(buf, 63, "\\IP\\%d", ntohl(peerGetLocalIP(peer)));// not ntohl(localIP), as we need EXTERNAL address for proper NAT negotiation!
+								snprintf(buf, 64, "\\IP\\%d", ntohl(peerGetLocalIP(peer)));// not ntohl(localIP), as we need EXTERNAL address for proper NAT negotiation!
 								msg.append(buf);
-								_snprintf(buf, 63, "\\Side\\%d", m_qmInfo.QM.side);
+								snprintf(buf, 64, "\\Side\\%d", m_qmInfo.QM.side);
 								msg.append(buf);
-								_snprintf(buf, 63, "\\Color\\%d", m_qmInfo.QM.color);
+								snprintf(buf, 64, "\\Color\\%d", m_qmInfo.QM.color);
 								msg.append(buf);
-								_snprintf(buf, 63, "\\NAT\\%d", m_qmInfo.QM.NAT);
+								snprintf(buf, 64, "\\NAT\\%d", m_qmInfo.QM.NAT);
 								msg.append(buf);
-								_snprintf(buf, 63, "\\EXE\\%d", m_qmInfo.QM.exeCRC);
+								snprintf(buf, 64, "\\EXE\\%d", m_qmInfo.QM.exeCRC);
 								msg.append(buf);
-								_snprintf(buf, 63, "\\INI\\%d", m_qmInfo.QM.iniCRC);
+								snprintf(buf, 64, "\\INI\\%d", m_qmInfo.QM.iniCRC);
 								msg.append(buf);
 								buf[0] = 0;
 								msg.append("\\Maps\\");

--- a/Generals/Code/GameEngine/Source/GameNetwork/GameSpy/Thread/PersistentStorageThread.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/GameSpy/Thread/PersistentStorageThread.cpp
@@ -1401,15 +1401,13 @@ std::string GameSpyPSMessageQueueInterface::formatPlayerKVPairs( PSPlayerStats s
 
 	if (stats.options.length())
 	{
-		_snprintf(kvbuf, 256, "\\options\\%s", stats.options.c_str());
-		kvbuf[255] = 0;
+		snprintf(kvbuf, 256, "\\options\\%s", stats.options.c_str());
 		s.append(kvbuf);
 	}
 
 	if (stats.systemSpec.length())
 	{
-		_snprintf(kvbuf, 256, "\\systemSpec\\%s", stats.systemSpec.c_str());
-		kvbuf[255] = 0;
+		snprintf(kvbuf, 256, "\\systemSpec\\%s", stats.systemSpec.c_str());
 		s.append(kvbuf);
 	}
 
@@ -1505,8 +1503,7 @@ std::string GameSpyPSMessageQueueInterface::formatPlayerKVPairs( PSPlayerStats s
 	}
 	if (stats.lastLadderHost.length())
 	{
-		_snprintf(kvbuf, 256, "\\ladderHost\\%s", stats.lastLadderHost.c_str());
-		kvbuf[255] = 0;
+		snprintf(kvbuf, 256, "\\ladderHost\\%s", stats.lastLadderHost.c_str());
 		s.append(kvbuf);
 	}
 

--- a/Generals/Code/GameEngine/Source/GameNetwork/GameSpyPersistentStorage.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/GameSpyPersistentStorage.cpp
@@ -288,9 +288,9 @@ static void getPersistentDataCallback(int localid, int profileid, persisttype_t 
 	const char *keys[3] = { "locale", "wins", "losses" };
 	char valueStrings[3][20];
 	char *values[3] = { valueStrings[0], valueStrings[1], valueStrings[2] };
-	_snprintf(values[0], 20, "%s", TheGameSpyPlayerInfo->getLocale().str());
-	_snprintf(values[1], 20, "%d", TheGameSpyPlayerInfo->getWins());
-	_snprintf(values[2], 20, "%d", TheGameSpyPlayerInfo->getLosses());
+	snprintf(values[0], 20, "%s", TheGameSpyPlayerInfo->getLocale().str());
+	snprintf(values[1], 20, "%d", TheGameSpyPlayerInfo->getWins());
+	snprintf(values[2], 20, "%d", TheGameSpyPlayerInfo->getLosses());
 	peerSetGlobalKeys(TheGameSpyChat->getPeer(), 3, (const char **)keys, (const char **)values);
 	peerSetGlobalWatchKeys(TheGameSpyChat->getPeer(), GroupRoom,   3, keys, PEERTrue);
 	peerSetGlobalWatchKeys(TheGameSpyChat->getPeer(), StagingRoom, 3, keys, PEERTrue);

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
@@ -143,8 +143,7 @@ void LogClass::log(const char *fmt, ...)
 
 	va_list va;
 	va_start( va, fmt );
-	_vsnprintf(buf, 1024, fmt, va );
-	buf[1023] = 0;
+	vsnprintf(buf, 1024, fmt, va );
 	va_end( va );
 
 	char *tmp = buf;

--- a/GeneralsMD/Code/GameEngine/Include/Precompiled/PreRTS.h
+++ b/GeneralsMD/Code/GameEngine/Include/Precompiled/PreRTS.h
@@ -69,7 +69,7 @@ class STLSpecialAlloc;
 #include <snmp.h>
 #include <stdarg.h>
 #include <stddef.h>
-#include <stdio.h>
+#include <Utility/stdio_adapter.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>

--- a/GeneralsMD/Code/GameEngine/Source/Common/CRCDebug.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/CRCDebug.cpp
@@ -209,8 +209,7 @@ static void addCRCDebugLineInternal(bool count, const char *fmt, va_list args)
 		DebugStrings[nextDebugString][0] = 0;
 	Int len = strlen(DebugStrings[nextDebugString]);
 
-	_vsnprintf(DebugStrings[nextDebugString]+len, MaxStringLen-len, fmt, args);
-	DebugStrings[nextDebugString][MaxStringLen-1] = 0;
+	vsnprintf(DebugStrings[nextDebugString]+len, MaxStringLen-len, fmt, args);
 
 	char *tmp = DebugStrings[nextDebugString];
 	while (tmp && *tmp)
@@ -258,9 +257,8 @@ void addCRCGenLine(const char *fmt, ...)
 	static char buf[MaxStringLen];
 	va_list va;
 	va_start( va, fmt );
-	_vsnprintf(buf, MaxStringLen, fmt, va );
+	vsnprintf(buf, MaxStringLen, fmt, va );
 	va_end( va );
-	buf[MaxStringLen-1] = 0;
 	addCRCDebugLine("%s", buf);
 
 	//DEBUG_LOG(("%s", buf));
@@ -271,8 +269,7 @@ void addCRCDumpLine(const char *fmt, ...)
 	/*
 	va_list va;
 	va_start( va, fmt );
-	_vsnprintf(DumpStrings[nextDumpString], MaxStringLen, fmt, va );
-	DumpStrings[nextDumpString][MaxStringLen-1] = 0;
+	vsnprintf(DumpStrings[nextDumpString], MaxStringLen, fmt, va );
 	va_end( va );
 
 	++nextDumpString;

--- a/GeneralsMD/Code/GameEngine/Source/Common/MiniLog.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/MiniLog.cpp
@@ -74,8 +74,7 @@ void LogClass::log(const char *fmt, ...)
 
 	va_list va;
 	va_start( va, fmt );
-	_vsnprintf(buf, 1024, fmt, va );
-	buf[1023] = 0;
+	vsnprintf(buf, 1024, fmt, va );
 	va_end( va );
 
 	char *tmp = buf;

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/AsciiString.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/AsciiString.cpp
@@ -290,7 +290,7 @@ void AsciiString::format_va(const char* format, va_list args)
 {
 	validate();
 	char buf[MAX_FORMAT_BUF_LEN];
-	const int result = _vsnprintf(buf, sizeof(buf)/sizeof(char)-1, format, args);
+	const int result = vsnprintf(buf, sizeof(buf)/sizeof(char), format, args);
 	if (result >= 0)
 	{
 		set(buf);

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/Debug.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/Debug.cpp
@@ -704,8 +704,7 @@ void ReleaseCrash(const char *reason)
 	}
 //#if defined(RTS_DEBUG) || defined(RTS_INTERNAL)
 //	/* static */ char buff[8192]; // not so static so we can be threadsafe
-//	_snprintf(buff, 8192, "Sorry, a serious error occurred. (%s)", reason);/
-//	buff[8191] = 0;
+//	snprintf(buff, 8192, "Sorry, a serious error occurred. (%s)", reason);/
 //	::MessageBox(NULL, buff, "Technical Difficulties...", MB_OK|MB_SYSTEMMODAL|MB_ICONERROR);
 //#else
 //	::MessageBox(NULL, "Sorry, a serious error occurred.", "Technical Difficulties...", MB_OK|MB_TASKMODAL|MB_ICONERROR);
@@ -749,8 +748,7 @@ void ReleaseCrash(const char *reason)
 	}
 #if defined(RTS_DEBUG) || defined(RTS_INTERNAL)
 	/* static */ char buff[8192]; // not so static so we can be threadsafe
-	_snprintf(buff, 8192, "Sorry, a serious error occurred. (%s)", reason);
-	buff[8191] = 0;
+	snprintf(buff, 8192, "Sorry, a serious error occurred. (%s)", reason);
 	::MessageBox(NULL, buff, "Technical Difficulties...", MB_OK|MB_SYSTEMMODAL|MB_ICONERROR);
 #else
 // crash error messaged changed 3/6/03 BGC

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/UnicodeString.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/UnicodeString.cpp
@@ -314,7 +314,7 @@ void UnicodeString::format_va(const WideChar* format, va_list args)
 {
 	validate();
 	WideChar buf[MAX_FORMAT_BUF_LEN];
-	const int result = _vsnwprintf(buf, sizeof(buf)/sizeof(WideChar)-1, format, args);
+	const int result = vswprintf(buf, sizeof(buf)/sizeof(WideChar), format, args);
 	if (result >= 0)
 	{
 		set(buf);

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLGameSetupMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLGameSetupMenu.cpp
@@ -84,9 +84,8 @@ void slotListDebugLog(const char *fmt, ...)
 	static char buf[1024];
 	va_list va;
 	va_start( va, fmt );
-	_vsnprintf(buf, 1024, fmt, va );
+	vsnprintf(buf, 1024, fmt, va );
 	va_end( va );
-	buf[1023] = 0;
 
 	DEBUG_LOG(("%s", buf));
 	if (g_debugSlots)

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLWelcomeMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLWelcomeMenu.cpp
@@ -526,9 +526,9 @@ void WOLWelcomeMenuInit( WindowLayout *layout, void *userData )
 		const char *keys[3] = { "locale", "wins", "losses" };
 		char valueStrings[3][20];
 		char *values[3] = { valueStrings[0], valueStrings[1], valueStrings[2] };
-		_snprintf(values[0], 20, "%s", TheGameSpyPlayerInfo->getLocale().str());
-		_snprintf(values[1], 20, "%d", TheGameSpyPlayerInfo->getWins());
-		_snprintf(values[2], 20, "%d", TheGameSpyPlayerInfo->getLosses());
+		snprintf(values[0], 20, "%s", TheGameSpyPlayerInfo->getLocale().str());
+		snprintf(values[1], 20, "%d", TheGameSpyPlayerInfo->getWins());
+		snprintf(values[2], 20, "%d", TheGameSpyPlayerInfo->getLosses());
 		peerSetGlobalKeys(TheGameSpyChat->getPeer(), 3, (const char **)keys, (const char **)values);
 		peerSetGlobalWatchKeys(TheGameSpyChat->getPeer(), GroupRoom,   3, keys, PEERFalse);
 		peerSetGlobalWatchKeys(TheGameSpyChat->getPeer(), StagingRoom, 3, keys, PEERFalse);

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -2026,7 +2026,7 @@ void InGameUI::message( AsciiString stringManagerLabel, ... )
 	va_list args;
 	va_start( args, stringManagerLabel );
 	WideChar buf[ UnicodeString::MAX_FORMAT_BUF_LEN ];
-	int result = _vsnwprintf(buf, sizeof( buf )/sizeof( WideChar ) - 1, stringManagerString.str(), args );
+	int result = vswprintf(buf, sizeof( buf )/sizeof( WideChar ), stringManagerString.str(), args );
 	va_end(args);
 
 	if( result >= 0 )
@@ -2053,7 +2053,7 @@ void InGameUI::message( UnicodeString format, ... )
 	va_list args;
 	va_start( args, format );
 	WideChar buf[ UnicodeString::MAX_FORMAT_BUF_LEN ];
-	int result = _vsnwprintf(buf, sizeof( buf )/sizeof( WideChar ) - 1, format.str(), args );
+	int result = vswprintf(buf, sizeof( buf )/sizeof( WideChar ), format.str(), args );
 	va_end(args);
 
 	if( result >= 0 )
@@ -2080,7 +2080,7 @@ void InGameUI::messageColor( const RGBColor *rgbColor, UnicodeString format, ...
 	va_list args;
 	va_start( args, format );
 	WideChar buf[ UnicodeString::MAX_FORMAT_BUF_LEN ];
-	int result = _vsnwprintf(buf, sizeof( buf )/sizeof( WideChar ) - 1, format.str(), args );
+	int result = vswprintf(buf, sizeof( buf )/sizeof( WideChar ), format.str(), args );
 	va_end(args);
 
 	if( result >= 0 )

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
@@ -1486,24 +1486,24 @@ void PeerThreadClass::Thread_Function()
 
 					// Testing alternate way to push stats
 #ifdef USE_BROADCAST_KEYS
-					_snprintf(s_valueBuffers[0], 20, "%d", incomingRequest.statsToPush.locale);
-					_snprintf(s_valueBuffers[1], 20, "%d", incomingRequest.statsToPush.wins);
-					_snprintf(s_valueBuffers[2], 20, "%d", incomingRequest.statsToPush.losses);
-					_snprintf(s_valueBuffers[3], 20, "%d", incomingRequest.statsToPush.rankPoints);
-					_snprintf(s_valueBuffers[4], 20, "%d", incomingRequest.statsToPush.side);
-					_snprintf(s_valueBuffers[5], 20, "%d", incomingRequest.statsToPush.preorder);
+					snprintf(s_valueBuffers[0], 20, "%d", incomingRequest.statsToPush.locale);
+					snprintf(s_valueBuffers[1], 20, "%d", incomingRequest.statsToPush.wins);
+					snprintf(s_valueBuffers[2], 20, "%d", incomingRequest.statsToPush.losses);
+					snprintf(s_valueBuffers[3], 20, "%d", incomingRequest.statsToPush.rankPoints);
+					snprintf(s_valueBuffers[4], 20, "%d", incomingRequest.statsToPush.side);
+					snprintf(s_valueBuffers[5], 20, "%d", incomingRequest.statsToPush.preorder);
 					pushStatsToRoom(peer);
 #else
 					const char *keys[6] = { "locale", "wins", "losses", "points", "side", "pre" };
 					char valueStrings[6][20];
 					char *values[6] = { valueStrings[0], valueStrings[1], valueStrings[2],
 						valueStrings[3], valueStrings[4], valueStrings[5]};
-					_snprintf(values[0], 20, "%d", incomingRequest.statsToPush.locale);
-					_snprintf(values[1], 20, "%d", incomingRequest.statsToPush.wins);
-					_snprintf(values[2], 20, "%d", incomingRequest.statsToPush.losses);
-					_snprintf(values[3], 20, "%d", incomingRequest.statsToPush.rankPoints);
-					_snprintf(values[4], 20, "%d", incomingRequest.statsToPush.side);
-					_snprintf(values[5], 20, "%d", incomingRequest.statsToPush.preorder);
+					snprintf(values[0], 20, "%d", incomingRequest.statsToPush.locale);
+					snprintf(values[1], 20, "%d", incomingRequest.statsToPush.wins);
+					snprintf(values[2], 20, "%d", incomingRequest.statsToPush.losses);
+					snprintf(values[3], 20, "%d", incomingRequest.statsToPush.rankPoints);
+					snprintf(values[4], 20, "%d", incomingRequest.statsToPush.side);
+					snprintf(values[5], 20, "%d", incomingRequest.statsToPush.preorder);
 					peerSetGlobalKeys(peer, 6, (const char **)keys, (const char **)values);
 					peerSetGlobalWatchKeys(peer, GroupRoom,   0, NULL, PEERFalse);
 					peerSetGlobalWatchKeys(peer, StagingRoom, 0, NULL, PEERFalse);
@@ -1984,39 +1984,38 @@ void PeerThreadClass::doQuickMatch( PEER peer )
 							if (m_sawMatchbot)
 							{
 								char buf[64];
-								buf[63] = '\0';
 								std::string msg = "\\CINFO";
-								_snprintf(buf, 63, "\\Widen\\%d", m_qmInfo.QM.widenTime);
+								snprintf(buf, 64, "\\Widen\\%d", m_qmInfo.QM.widenTime);
 								msg.append(buf);
-								_snprintf(buf, 63, "\\LadID\\%d", m_qmInfo.QM.ladderID);
+								snprintf(buf, 64, "\\LadID\\%d", m_qmInfo.QM.ladderID);
 								msg.append(buf);
-								_snprintf(buf, 63, "\\LadPass\\%d", m_qmInfo.QM.ladderPassCRC);
+								snprintf(buf, 64, "\\LadPass\\%d", m_qmInfo.QM.ladderPassCRC);
 								msg.append(buf);
-								_snprintf(buf, 63, "\\PointsMin\\%d", m_qmInfo.QM.minPointPercentage);
+								snprintf(buf, 64, "\\PointsMin\\%d", m_qmInfo.QM.minPointPercentage);
 								msg.append(buf);
-								_snprintf(buf, 63, "\\PointsMax\\%d", m_qmInfo.QM.maxPointPercentage);
+								snprintf(buf, 64, "\\PointsMax\\%d", m_qmInfo.QM.maxPointPercentage);
 								msg.append(buf);
-								_snprintf(buf, 63, "\\Points\\%d", m_qmInfo.QM.points);
+								snprintf(buf, 64, "\\Points\\%d", m_qmInfo.QM.points);
 								msg.append(buf);
-								_snprintf(buf, 63, "\\Discons\\%d", m_qmInfo.QM.discons);
+								snprintf(buf, 64, "\\Discons\\%d", m_qmInfo.QM.discons);
 								msg.append(buf);
-								_snprintf(buf, 63, "\\DisconMax\\%d", m_qmInfo.QM.maxDiscons);
+								snprintf(buf, 64, "\\DisconMax\\%d", m_qmInfo.QM.maxDiscons);
 								msg.append(buf);
-								_snprintf(buf, 63, "\\NumPlayers\\%d", m_qmInfo.QM.numPlayers);
+								snprintf(buf, 64, "\\NumPlayers\\%d", m_qmInfo.QM.numPlayers);
 								msg.append(buf);
-								_snprintf(buf, 63, "\\Pings\\%s", m_qmInfo.QM.pings);
+								snprintf(buf, 64, "\\Pings\\%s", m_qmInfo.QM.pings);
 								msg.append(buf);
-								_snprintf(buf, 63, "\\IP\\%d", ntohl(peerGetLocalIP(peer)));// not ntohl(localIP), as we need EXTERNAL address for proper NAT negotiation!
+								snprintf(buf, 64, "\\IP\\%d", ntohl(peerGetLocalIP(peer)));// not ntohl(localIP), as we need EXTERNAL address for proper NAT negotiation!
 								msg.append(buf);
-								_snprintf(buf, 63, "\\Side\\%d", m_qmInfo.QM.side);
+								snprintf(buf, 64, "\\Side\\%d", m_qmInfo.QM.side);
 								msg.append(buf);
-								_snprintf(buf, 63, "\\Color\\%d", m_qmInfo.QM.color);
+								snprintf(buf, 64, "\\Color\\%d", m_qmInfo.QM.color);
 								msg.append(buf);
-								_snprintf(buf, 63, "\\NAT\\%d", m_qmInfo.QM.NAT);
+								snprintf(buf, 64, "\\NAT\\%d", m_qmInfo.QM.NAT);
 								msg.append(buf);
-								_snprintf(buf, 63, "\\EXE\\%d", m_qmInfo.QM.exeCRC);
+								snprintf(buf, 64, "\\EXE\\%d", m_qmInfo.QM.exeCRC);
 								msg.append(buf);
-								_snprintf(buf, 63, "\\INI\\%d", m_qmInfo.QM.iniCRC);
+								snprintf(buf, 64, "\\INI\\%d", m_qmInfo.QM.iniCRC);
 								msg.append(buf);
 								buf[0] = 0;
 								msg.append("\\Maps\\");

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameSpy/Thread/PersistentStorageThread.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameSpy/Thread/PersistentStorageThread.cpp
@@ -1367,15 +1367,13 @@ std::string GameSpyPSMessageQueueInterface::formatPlayerKVPairs( PSPlayerStats s
 
 	if (stats.options.length())
 	{
-		_snprintf(kvbuf, 256, "\\options\\%s", stats.options.c_str());
-		kvbuf[255] = 0;
+		snprintf(kvbuf, 256, "\\options\\%s", stats.options.c_str());
 		s.append(kvbuf);
 	}
 
 	if (stats.systemSpec.length())
 	{
-		_snprintf(kvbuf, 256, "\\systemSpec\\%s", stats.systemSpec.c_str());
-		kvbuf[255] = 0;
+		snprintf(kvbuf, 256, "\\systemSpec\\%s", stats.systemSpec.c_str());
 		s.append(kvbuf);
 	}
 
@@ -1471,8 +1469,7 @@ std::string GameSpyPSMessageQueueInterface::formatPlayerKVPairs( PSPlayerStats s
 	}
 	if (stats.lastLadderHost.length())
 	{
-		_snprintf(kvbuf, 256, "\\ladderHost\\%s", stats.lastLadderHost.c_str());
-		kvbuf[255] = 0;
+		snprintf(kvbuf, 256, "\\ladderHost\\%s", stats.lastLadderHost.c_str());
 		s.append(kvbuf);
 	}
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
@@ -143,8 +143,7 @@ void LogClass::log(const char *fmt, ...)
 
 	va_list va;
 	va_start( va, fmt );
-	_vsnprintf(buf, 1024, fmt, va );
-	buf[1023] = 0;
+	vsnprintf(buf, 1024, fmt, va );
 	va_end( va );
 
 	char *tmp = buf;


### PR DESCRIPTION
* Fixes #826

This change fixes all unsafe calls to `_vsnprintf`, `_vsnwprintf`, `_snprintf`, `_snwprintf`. In practice most or all of these probably were no problem, but there was a small chance because these Microsoft specific versions do not null terminate when the whole buffer length is written to.

All code now calls the standard stdio functions. For VC6, an adapter header was added.

The following functions contained potentially unsafe calls:

| File                     | Function |
|--------------------------|----------|
| debug_debug              | Debug::Format::Format |
| debug_debug              | Debug::operator<< |
| profile_highlevel        | ProfileId::AsString |
| statistics               | Record_Texture_End |
| urlBuilder               | FormatURLFromRegistry |
| ini                      | INIClass::DuplicateCRCError |
| widestring               | WideStringClass::Format_Args |
| widestring               | WideStringClass::Format |
| wwfile                   | FileClass::Printf |
| wwfile                   | FileClass::Printf_Indented |
| wwstring                 | StringClass::Format_Args |
| wwstring                 | StringClass::Format |
| autorun                  | Dialog_Box_Proc |
| GameText                 | GameTextManager::fetch |
| AsciiString              | AsciiString::format_va |
| UnicodeString            | UnicodeString::format_va |
| InGameUI                 | InGameUI::message |
| PeerThread               | PeerThreadClass::Thread_Function |
| GameSpyPersistentStorage | getPersistentDataCallback |
