### PR TITLE
[CORE] Fix VC6 compile error in max2w3d pluglib

### DIFF
--- a/Core/Tools/WW3D/pluglib/CMakeLists.txt
+++ b/Core/Tools/WW3D/pluglib/CMakeLists.txt
@@ -58,4 +58,10 @@ set_target_properties(core_pluglib PROPERTIES OUTPUT_NAME pluglib)
 
 target_sources(core_pluglib PRIVATE ${PLUGLIB_SRC})
 
-target_link_libraries(core_pluglib PRIVATE maxsdk)
+target_link_libraries(core_pluglib PUBLIC
+    core_utility
+)
+
+target_link_libraries(core_pluglib PRIVATE
+    maxsdk
+)

--- a/Core/Tools/WW3D/pluglib/Vector.H
+++ b/Core/Tools/WW3D/pluglib/Vector.H
@@ -59,6 +59,7 @@
 #include	<string.h>
 #include	<stddef.h>
 #include	<stdlib.h>
+#include	<Utility/stdint_adapter.h>
 
 
 /**************************************************************************


### PR DESCRIPTION
* Follow up for #712

This change fixes a VC6 compile error in max2w3d pluglib that was introduced by #712.