### PR TITLE
[GEN][ZH] Demote throw to assert in InGameUI::message, InGameUI::messageColor

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/System/AsciiString.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/AsciiString.cpp
@@ -387,7 +387,7 @@ void AsciiString::format_va(const char* format, va_list args)
 	}
 	else
 	{
-		DEBUG_ASSERTCRASH(false, ("AsciiString::format_va failed with code:%d format:\"%s\"", result, format));
+		DEBUG_CRASH(("AsciiString::format_va failed with code:%d format:\"%s\"", result, format));
 	}
 }
 

--- a/Generals/Code/GameEngine/Source/Common/System/UnicodeString.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/UnicodeString.cpp
@@ -324,7 +324,7 @@ void UnicodeString::format_va(const WideChar* format, va_list args)
 	}
 	else
 	{
-		DEBUG_ASSERTCRASH(false, ("UnicodeString::format_va failed with code:%d", result));
+		DEBUG_CRASH(("UnicodeString::format_va failed with code:%d", result));
 	}
 }
 

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -1968,16 +1968,21 @@ void InGameUI::message( AsciiString stringManagerLabel, ... )
 
 	// construct the final text after formatting
 	va_list args;
-  va_start( args, stringManagerLabel );
+	va_start( args, stringManagerLabel );
 	WideChar buf[ UnicodeString::MAX_FORMAT_BUF_LEN ];
-  if( _vsnwprintf(buf, sizeof( buf )/sizeof( WideChar ) - 1, stringManagerString.str(), args ) < 0 )
-			throw ERROR_OUT_OF_MEMORY;
-	formattedMessage.set( buf );
-  va_end(args);
+	int result = _vsnwprintf(buf, sizeof( buf )/sizeof( WideChar ) - 1, stringManagerString.str(), args );
+	va_end(args);
 
-	// add the text to the ui
-	addMessageText( formattedMessage );
-
+	if( result >= 0 )
+	{
+		formattedMessage.set( buf );
+		// add the text to the ui
+		addMessageText( formattedMessage );
+	}
+	else
+	{
+		DEBUG_CRASH(("InGameUI::message failed with code:%d", result));
+	}
 }  // end 
 
 //-------------------------------------------------------------------------------------------------
@@ -1990,16 +1995,21 @@ void InGameUI::message( UnicodeString format, ... )
 
 	// construct the final text after formatting
 	va_list args;
-  va_start( args, format );
+	va_start( args, format );
 	WideChar buf[ UnicodeString::MAX_FORMAT_BUF_LEN ];
-  if( _vsnwprintf(buf, sizeof( buf )/sizeof( WideChar ) - 1, format.str(), args ) < 0 )
-			throw ERROR_OUT_OF_MEMORY;
-	formattedMessage.set( buf );
-  va_end(args);
+	int result = _vsnwprintf(buf, sizeof( buf )/sizeof( WideChar ) - 1, format.str(), args );
+	va_end(args);
 
-	// add the text to the ui
-	addMessageText( formattedMessage );
-
+	if( result >= 0 )
+	{
+		formattedMessage.set( buf );
+		// add the text to the ui
+		addMessageText( formattedMessage );
+	}
+	else
+	{
+		DEBUG_CRASH(("InGameUI::message failed with code:%d", result));
+	}
 }  // end message
 
 //-------------------------------------------------------------------------------------------------
@@ -2012,16 +2022,20 @@ void InGameUI::messageColor( const RGBColor *rgbColor, UnicodeString format, ...
 
 	// construct the final text after formatting
 	va_list args;
-  va_start( args, format );
+	va_start( args, format );
 	WideChar buf[ UnicodeString::MAX_FORMAT_BUF_LEN ];
-  if( _vsnwprintf(buf, sizeof( buf )/sizeof( WideChar ) - 1, format.str(), args ) < 0 )
-			throw ERROR_OUT_OF_MEMORY;
-	formattedMessage.set( buf );
-  va_end(args);
+	int result = _vsnwprintf(buf, sizeof( buf )/sizeof( WideChar ) - 1, format.str(), args );
 
-	// add the text to the ui
-	addMessageText( formattedMessage, rgbColor );
-
+	if( result >= 0 )
+	{
+		formattedMessage.set( buf );
+		// add the text to the ui
+		addMessageText( formattedMessage, rgbColor );
+	}
+	else
+	{
+		DEBUG_CRASH(("InGameUI::messageColor failed with code:%d", result));
+	}
 }  // end message
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/AsciiString.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/AsciiString.cpp
@@ -300,7 +300,7 @@ void AsciiString::format_va(const char* format, va_list args)
 	}
 	else
 	{
-		DEBUG_ASSERTCRASH(false, ("AsciiString::format_va failed with code:%d format:\"%s\"", result, format));
+		DEBUG_CRASH(("AsciiString::format_va failed with code:%d format:\"%s\"", result, format));
 	}
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/UnicodeString.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/UnicodeString.cpp
@@ -324,7 +324,7 @@ void UnicodeString::format_va(const WideChar* format, va_list args)
 	}
 	else
 	{
-		DEBUG_ASSERTCRASH(false, ("UnicodeString::format_va failed with code:%d", result));
+		DEBUG_CRASH(("UnicodeString::format_va failed with code:%d", result));
 	}
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -2024,16 +2024,21 @@ void InGameUI::message( AsciiString stringManagerLabel, ... )
 
 	// construct the final text after formatting
 	va_list args;
-  va_start( args, stringManagerLabel );
+	va_start( args, stringManagerLabel );
 	WideChar buf[ UnicodeString::MAX_FORMAT_BUF_LEN ];
-  if( _vsnwprintf(buf, sizeof( buf )/sizeof( WideChar ) - 1, stringManagerString.str(), args ) < 0 )
-			throw ERROR_OUT_OF_MEMORY;
-	formattedMessage.set( buf );
-  va_end(args);
+	int result = _vsnwprintf(buf, sizeof( buf )/sizeof( WideChar ) - 1, stringManagerString.str(), args );
+	va_end(args);
 
-	// add the text to the ui
-	addMessageText( formattedMessage );
-
+	if( result >= 0 )
+	{
+		formattedMessage.set( buf );
+		// add the text to the ui
+		addMessageText( formattedMessage );
+	}
+	else
+	{
+		DEBUG_CRASH(("InGameUI::message failed with code:%d", result));
+	}
 }  // end 
 
 //-------------------------------------------------------------------------------------------------
@@ -2046,16 +2051,21 @@ void InGameUI::message( UnicodeString format, ... )
 
 	// construct the final text after formatting
 	va_list args;
-  va_start( args, format );
+	va_start( args, format );
 	WideChar buf[ UnicodeString::MAX_FORMAT_BUF_LEN ];
-  if( _vsnwprintf(buf, sizeof( buf )/sizeof( WideChar ) - 1, format.str(), args ) < 0 )
-			throw ERROR_OUT_OF_MEMORY;
-	formattedMessage.set( buf );
-  va_end(args);
+	int result = _vsnwprintf(buf, sizeof( buf )/sizeof( WideChar ) - 1, format.str(), args );
+	va_end(args);
 
-	// add the text to the ui
-	addMessageText( formattedMessage );
-
+	if( result >= 0 )
+	{
+		formattedMessage.set( buf );
+		// add the text to the ui
+		addMessageText( formattedMessage );
+	}
+	else
+	{
+		DEBUG_CRASH(("InGameUI::message failed with code:%d", result));
+	}
 }  // end message
 
 //-------------------------------------------------------------------------------------------------
@@ -2068,16 +2078,20 @@ void InGameUI::messageColor( const RGBColor *rgbColor, UnicodeString format, ...
 
 	// construct the final text after formatting
 	va_list args;
-  va_start( args, format );
+	va_start( args, format );
 	WideChar buf[ UnicodeString::MAX_FORMAT_BUF_LEN ];
-  if( _vsnwprintf(buf, sizeof( buf )/sizeof( WideChar ) - 1, format.str(), args ) < 0 )
-			throw ERROR_OUT_OF_MEMORY;
-	formattedMessage.set( buf );
-  va_end(args);
+	int result = _vsnwprintf(buf, sizeof( buf )/sizeof( WideChar ) - 1, format.str(), args );
 
-	// add the text to the ui
-	addMessageText( formattedMessage, rgbColor );
-
+	if( result >= 0 )
+	{
+		formattedMessage.set( buf );
+		// add the text to the ui
+		addMessageText( formattedMessage, rgbColor );
+	}
+	else
+	{
+		DEBUG_CRASH(("InGameUI::messageColor failed with code:%d", result));
+	}
 }  // end message
 
 //-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
* Follow up for #835
* Relates to #857

This change demotes unnecessary throw to debug assert in functions InGameUI::message and InGameUI::messageColor. Unnecessary throw because this format error is not necessarily a fatal error that needs to terminate the process. The program may just run fine with this error. The debug assert is enough to see the error.