### PR TITLE
[GEN][ZH] Demote throw to assert in AsciiString::ensureUniqueBufferOfSize, UnicodeString::ensureUniqueBufferOfSize, Dict::ensureUnique

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/Dict.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Dict.cpp
@@ -157,12 +157,10 @@ Dict::DictPair *Dict::ensureUnique(int numPairsNeeded, Bool preserveData, DictPa
 		return pairToTranslate;
 	}
 
-	if (numPairsNeeded > MAX_LEN)
-		throw ERROR_OUT_OF_MEMORY;
-
 	Dict::DictPairData* newData = NULL;
 	if (numPairsNeeded > 0)
 	{
+		DEBUG_ASSERTCRASH(numPairsNeeded <= MAX_LEN, ("Dict::ensureUnique exceeds max pairs length %d with requested length %d", MAX_LEN, numPairsNeeded));
 		int minBytes = sizeof(Dict::DictPairData) + numPairsNeeded*sizeof(Dict::DictPair);
 		int actualBytes = TheDynamicMemoryAllocator->getActualAllocationSize(minBytes);
 		// note: be certain to alloc with zero; we'll take advantage of the fact that all-zero

--- a/Generals/Code/GameEngine/Source/Common/System/AsciiString.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/AsciiString.cpp
@@ -138,10 +138,8 @@ void AsciiString::ensureUniqueBufferOfSize(int numCharsNeeded, Bool preserveData
 		return;
 	}
 
+	DEBUG_ASSERTCRASH(numCharsNeeded <= MAX_LEN, ("AsciiString::ensureUniqueBufferOfSize exceeds max string length %d with requested length %d", MAX_LEN, numCharsNeeded));
 	int minBytes = sizeof(AsciiStringData) + numCharsNeeded*sizeof(char);
-	if (minBytes > MAX_LEN)
-		throw ERROR_OUT_OF_MEMORY;
-
 	int actualBytes = TheDynamicMemoryAllocator->getActualAllocationSize(minBytes);
 	AsciiStringData* newData = (AsciiStringData*)TheDynamicMemoryAllocator->allocateBytesDoNotZero(actualBytes, "STR_AsciiString::ensureUniqueBufferOfSize");
 	newData->m_refCount = 1;

--- a/Generals/Code/GameEngine/Source/Common/System/UnicodeString.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/UnicodeString.cpp
@@ -94,10 +94,8 @@ void UnicodeString::ensureUniqueBufferOfSize(int numCharsNeeded, Bool preserveDa
 		return;
 	}
 
+	DEBUG_ASSERTCRASH(numCharsNeeded <= MAX_LEN, ("UnicodeString::ensureUniqueBufferOfSize exceeds max string length %d with requested length %d", MAX_LEN, numCharsNeeded));
 	int minBytes = sizeof(UnicodeStringData) + numCharsNeeded*sizeof(WideChar);
-	if (minBytes > MAX_LEN)
-		throw ERROR_OUT_OF_MEMORY;
-
 	int actualBytes = TheDynamicMemoryAllocator->getActualAllocationSize(minBytes);
 	UnicodeStringData* newData = (UnicodeStringData*)TheDynamicMemoryAllocator->allocateBytesDoNotZero(actualBytes, "STR_UnicodeString::ensureUniqueBufferOfSize");
 	newData->m_refCount = 1;

--- a/GeneralsMD/Code/GameEngine/Source/Common/Dict.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Dict.cpp
@@ -157,12 +157,10 @@ Dict::DictPair *Dict::ensureUnique(int numPairsNeeded, Bool preserveData, DictPa
 		return pairToTranslate;
 	}
 
-	if (numPairsNeeded > MAX_LEN)
-		throw ERROR_OUT_OF_MEMORY;
-
 	Dict::DictPairData* newData = NULL;
 	if (numPairsNeeded > 0)
 	{
+		DEBUG_ASSERTCRASH(numPairsNeeded <= MAX_LEN, ("Dict::ensureUnique exceeds max pairs length %d with requested length %d", MAX_LEN, numPairsNeeded));
 		int minBytes = sizeof(Dict::DictPairData) + numPairsNeeded*sizeof(Dict::DictPair);
 		int actualBytes = TheDynamicMemoryAllocator->getActualAllocationSize(minBytes);
 		// note: be certain to alloc with zero; we'll take advantage of the fact that all-zero

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/AsciiString.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/AsciiString.cpp
@@ -134,10 +134,8 @@ void AsciiString::ensureUniqueBufferOfSize(int numCharsNeeded, Bool preserveData
 		return;
 	}
 
+	DEBUG_ASSERTCRASH(numCharsNeeded <= MAX_LEN, ("AsciiString::ensureUniqueBufferOfSize exceeds max string length %d with requested length %d", MAX_LEN, numCharsNeeded));
 	int minBytes = sizeof(AsciiStringData) + numCharsNeeded*sizeof(char);
-	if (minBytes > MAX_LEN)
-		throw ERROR_OUT_OF_MEMORY;
-
 	int actualBytes = TheDynamicMemoryAllocator->getActualAllocationSize(minBytes);
 	AsciiStringData* newData = (AsciiStringData*)TheDynamicMemoryAllocator->allocateBytesDoNotZero(actualBytes, "STR_AsciiString::ensureUniqueBufferOfSize");
 	newData->m_refCount = 1;

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/UnicodeString.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/UnicodeString.cpp
@@ -94,10 +94,8 @@ void UnicodeString::ensureUniqueBufferOfSize(int numCharsNeeded, Bool preserveDa
 		return;
 	}
 
+	DEBUG_ASSERTCRASH(numCharsNeeded <= MAX_LEN, ("UnicodeString::ensureUniqueBufferOfSize exceeds max string length %d with requested length %d", MAX_LEN, numCharsNeeded));
 	int minBytes = sizeof(UnicodeStringData) + numCharsNeeded*sizeof(WideChar);
-	if (minBytes > MAX_LEN)
-		throw ERROR_OUT_OF_MEMORY;
-
 	int actualBytes = TheDynamicMemoryAllocator->getActualAllocationSize(minBytes);
 	UnicodeStringData* newData = (UnicodeStringData*)TheDynamicMemoryAllocator->allocateBytesDoNotZero(actualBytes, "STR_UnicodeString::ensureUniqueBufferOfSize");
 	newData->m_refCount = 1;


### PR DESCRIPTION
* Relates to #857

This change demotes unnecessary throw to debug assert in functions

* AsciiString::ensureUniqueBufferOfSize
* UnicodeString::ensureUniqueBufferOfSize
* Dict::ensureUnique

Unnecessary throw because it is not necessary to terminate the process if the string is a bit longer than an arbitrary limit. The program may just run fine when the limit is exceeed. The debug assert is enough to see the error.

This change also fixes a logical issue in ensureUniqueBufferOfSize, most notably for UnicodeString, where MAX_LEN was effectively halved.