### PR TITLE
[ZH] Separate logic and client in ParticleUplinkCannonUpdate

### DIFF
--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/LaserUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/LaserUpdate.h
@@ -75,7 +75,7 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	//Actually puts the laser in the world.
-	void initLaser( const Object *parent, const Object *target, const Coord3D *startPos, const Coord3D *endPos, AsciiString parentBoneName, Int sizeDeltaFrames = 0 );
+	void initLaser( const Object *parent, const Object *target, const Coord3D *startPos, const Coord3D *endPos, AsciiString parentBoneName, Int sizeDeltaFrames = 0, Bool explicitLogicUpdate = false);
 	void setDecayFrames( UnsignedInt decayFrames );
 
 	const Coord3D* getStartPos() { return &m_startPos; }
@@ -89,6 +89,7 @@ public:
 	Real getWidthScale() const { return m_currentWidthScalar; }
 
 	virtual void clientUpdate();
+	void logicUpdate();
 
 protected:
 
@@ -113,6 +114,14 @@ protected:
 	UnsignedInt m_decayStartFrame;
 	UnsignedInt m_decayFinishFrame;
 	AsciiString m_parentBoneName;
+
+	// TheSuperHackers @logic-client-separation helmutbuhler 04/19/2025
+	// LaserUpdate belongs to the client, but some members here are used by GameLogic.
+	// Sadly these members were originally updated in clientUpdate, which doesn't run
+	// in headless mode. To make it work, this new bool can be set to true to disable updating
+	// gamelogic relevant updates in clientUpdate. These variables can then be updated explicitely
+	// with logicUpdate from gamelogic.
+	Bool m_explicitLogicUpdate;
 };
 
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/LaserUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/LaserUpdate.h
@@ -115,7 +115,7 @@ protected:
 	UnsignedInt m_decayFinishFrame;
 	AsciiString m_parentBoneName;
 
-	// TheSuperHackers @logic-client-separation helmutbuhler 04/19/2025
+	// TheSuperHackers @logic-client-separation helmutbuhler 19/04/2025
 	// LaserUpdate belongs to the client, but some members here are used by GameLogic.
 	// Sadly these members were originally updated in clientUpdate, which doesn't run
 	// in headless mode. To make it work, this new bool can be set to true to disable updating

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/LaserUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/LaserUpdate.cpp
@@ -93,6 +93,8 @@ LaserUpdate::LaserUpdate( Thing *thing, const ModuleData* moduleData ) : ClientU
 	m_parentID = INVALID_DRAWABLE_ID;
 	m_targetID = INVALID_DRAWABLE_ID;
 	m_parentBoneName.clear();
+
+	m_explicitLogicUpdate = false;
 } 
 
 //-------------------------------------------------------------------------------------------------
@@ -201,7 +203,12 @@ void LaserUpdate::clientUpdate( void )
 {
 	updateStartPos();
 	updateEndPos();
+	if (!m_explicitLogicUpdate)
+		logicUpdate();
+}
 
+void LaserUpdate::logicUpdate()
+{
 	if( m_decaying )
 	{
 		UnsignedInt now = TheGameLogic->getFrame();
@@ -244,7 +251,7 @@ void LaserUpdate::setDecayFrames( UnsignedInt decayFrames )
 
 
 //-------------------------------------------------------------------------------------------------
-void LaserUpdate::initLaser( const Object *parent, const Object *target, const Coord3D *startPos, const Coord3D *endPos, AsciiString parentBoneName, Int sizeDeltaFrames )
+void LaserUpdate::initLaser( const Object *parent, const Object *target, const Coord3D *startPos, const Coord3D *endPos, AsciiString parentBoneName, Int sizeDeltaFrames, Bool explicitLogicUpdate )
 {
 	const LaserUpdateModuleData *data = getLaserUpdateModuleData();
 	ParticleSystem *system;
@@ -265,6 +272,8 @@ void LaserUpdate::initLaser( const Object *parent, const Object *target, const C
 
 	// Write down the bone name override
 	m_parentBoneName = parentBoneName;
+
+	m_explicitLogicUpdate = explicitLogicUpdate;
 
 	//Record IDs if we have them, then figure out starting points
 	if( parent )
@@ -406,6 +415,11 @@ Real LaserUpdate::getCurrentLaserRadius() const
 			//While it appears the logic is accessing client data, it is actually accessing template module
 			//data from the client. This value is INI constant thus can't change. It's grouped with other 
 			//laser defining attributes and having it there makes it easier for artists.
+			
+			// TheSuperHackers @logic-client-separation helmutbuhler 04/19/2025
+			// Sadly the comment above is only true for ldi->getLaserTemplateWidth()
+			// For m_currentWidthScalar we fix this with m_explicitLogicUpdate.
+
 			return ldi->getLaserTemplateWidth() * m_currentWidthScalar;
 		}
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/LaserUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/LaserUpdate.cpp
@@ -416,7 +416,7 @@ Real LaserUpdate::getCurrentLaserRadius() const
 			//data from the client. This value is INI constant thus can't change. It's grouped with other 
 			//laser defining attributes and having it there makes it easier for artists.
 			
-			// TheSuperHackers @logic-client-separation helmutbuhler 04/19/2025
+			// TheSuperHackers @logic-client-separation helmutbuhler 19/04/2025
 			// Sadly the comment above is only true for ldi->getLaserTemplateWidth()
 			// For m_currentWidthScalar we fix this with m_explicitLogicUpdate.
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
@@ -390,6 +390,17 @@ UpdateSleepTime ParticleUplinkCannonUpdate::update()
 		///return UPDATE_SLEEP_FOREVER;
 	}
 
+	{
+		// TheSuperHackers @logic-client-separation helmutbuhler 04/19/2025
+		// This class originally depended on some members of LaserUpdate that is attached to
+		// m_orbitToTargetBeamID for GameLogic. We fix that here by calling LogicUpdate of that
+		// instance here explicitely.
+		static NameKeyType nameKeyClientUpdate = NAMEKEY("LaserUpdate");
+		Drawable* beam = TheGameClient->findDrawableByID(m_orbitToTargetBeamID);
+		LaserUpdate* update = beam ? (LaserUpdate*)beam->findClientUpdateModule(nameKeyClientUpdate) : NULL;
+		if (update) update->logicUpdate();
+	}
+
 	const ParticleUplinkCannonUpdateModuleData *data = getParticleUplinkCannonUpdateModuleData();
 
 	Object *me = getObject();
@@ -608,12 +619,15 @@ UpdateSleepTime ParticleUplinkCannonUpdate::update()
 			Real scorchRadius = 0.0f;
 			Real damageRadius = 0.0f;
 
+			// TheSuperHackers @logic-client-separation helmutbuhler 04/19/2025
+			// damageRadius affects gamelogic and shouldn't depend on LaserUpdate
+
 			//Reset the laser position
 			static NameKeyType nameKeyClientUpdate = NAMEKEY( "LaserUpdate" );
 			LaserUpdate *update = (LaserUpdate*)beam->findClientUpdateModule( nameKeyClientUpdate );
 			if( update )
 			{
-				update->initLaser( NULL, NULL, &orbitPosition, &m_currentTargetPosition, "" );
+				update->initLaser( NULL, NULL, &orbitPosition, &m_currentTargetPosition, "", 0, /*m_explicitLogicUpdate=*/true );
 				scorchRadius = update->getCurrentLaserRadius() * data->m_scorchMarkScalar;
 				damageRadius = update->getCurrentLaserRadius() * data->m_damageRadiusScalar;
 			}
@@ -998,7 +1012,7 @@ void ParticleUplinkCannonUpdate::createOrbitToTargetLaser( UnsignedInt growthFra
 					Coord3D orbitPosition;
 					orbitPosition.set( &m_initialTargetPosition );
 					orbitPosition.z += 500.0f;
-					update->initLaser( NULL, NULL, &orbitPosition, &m_initialTargetPosition, "", growthFrames );
+					update->initLaser( NULL, NULL, &orbitPosition, &m_initialTargetPosition, "", growthFrames, /*m_explicitLogicUpdate=*/true );
 				}
 			}
 		}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
@@ -391,14 +391,15 @@ UpdateSleepTime ParticleUplinkCannonUpdate::update()
 	}
 
 	{
-		// TheSuperHackers @logic-client-separation helmutbuhler 04/19/2025
+		// TheSuperHackers @logic-client-separation helmutbuhler 19/04/2025
 		// This class originally depended on some members of LaserUpdate that is attached to
 		// m_orbitToTargetBeamID for GameLogic. We fix that here by calling LogicUpdate of that
 		// instance here explicitely.
 		static NameKeyType nameKeyClientUpdate = NAMEKEY("LaserUpdate");
 		Drawable* beam = TheGameClient->findDrawableByID(m_orbitToTargetBeamID);
 		LaserUpdate* update = beam ? (LaserUpdate*)beam->findClientUpdateModule(nameKeyClientUpdate) : NULL;
-		if (update) update->logicUpdate();
+		if (update)
+			update->logicUpdate();
 	}
 
 	const ParticleUplinkCannonUpdateModuleData *data = getParticleUplinkCannonUpdateModuleData();
@@ -619,7 +620,7 @@ UpdateSleepTime ParticleUplinkCannonUpdate::update()
 			Real scorchRadius = 0.0f;
 			Real damageRadius = 0.0f;
 
-			// TheSuperHackers @logic-client-separation helmutbuhler 04/19/2025
+			// TheSuperHackers @logic-client-separation helmutbuhler 19/04/2025
 			// damageRadius affects gamelogic and shouldn't depend on LaserUpdate
 
 			//Reset the laser position


### PR DESCRIPTION
This is a bit of a strange PR, but it's required for headless replay simulation. And since this is a non-trivial change I figured I put this into a separate PR.

So for context, the game is architecturally separated into logic and client. Ideally you only need to run logic to simulate a replay and still get all correct CRCs. Client is for stuff like rendering, audio, input.

Unfortunately the code breaks this separation in some places, which result in mismatches when client update is skipped. We need to fix all of those in order to simulate replays as fast as possible, and this PR fixes the code that handles the Particle SW.

The class ParticleUplinkCannonUpdate handles the logic for this building, and it handles, among other things, some drawables responsible for rendering lasers:
```
	DrawableID				m_laserBeamIDs[ MAX_OUTER_NODES ];
	DrawableID				m_groundToOrbitBeamID;
	DrawableID				m_orbitToTargetBeamID;
```
All these drawables have a LaserUpdate module attached, which is the class that handles the client side of rendering these lasers.

The invalid separation happens with the m_orbitToTargetBeamID drawable. The logic depends on some members of the LaserUpdate instance that is attached to that drawable to calculate the damage radius (the radius where units get damaged by the SW).
When Client Update is skipped, those members are not updated and the calculated radius will be wrong, thus causing mismatch. This PR fixes that by calling the update function of LaserUpdate for that drawable during Gamelogic Update.

Other than this PR, all other separatation fixes that I did are relatively simple and are in the headless PR (which I will update soon). My testing also indicates that they are complete, once this PR and the headless PR are merged.
(Headless PR is here: #651)