### PR TITLE
[GEN][ZH] Enable Chat for Observers

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -2914,7 +2914,8 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 			if (TheGameLogic->isInMultiplayerGame() && !TheGameLogic->isInReplayGame())
 			{
 				Player *localPlayer = ThePlayerList->getLocalPlayer();
-				if (localPlayer && localPlayer->isPlayerActive() || !TheGlobalData->m_netMinPlayers)
+				// TheSuperHackers @tweak skyaero 19/07/2025 Observers can now chat
+				if (localPlayer || !TheGlobalData->m_netMinPlayers)
 				{
 					ToggleInGameChat();
 					SetInGameChatType( INGAME_CHAT_EVERYONE );

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -3061,7 +3061,8 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 			if (TheGameLogic->isInMultiplayerGame() && !TheGameLogic->isInReplayGame())
 			{
 				Player *localPlayer = ThePlayerList->getLocalPlayer();
-				if (localPlayer && localPlayer->isPlayerActive() || !TheGlobalData->m_netMinPlayers)
+				// TheSuperHackers @tweak skyaero 19/07/2025 Observers can now chat
+				if (localPlayer || !TheGlobalData->m_netMinPlayers)
 				{
 					ToggleInGameChat();
 					SetInGameChatType( INGAME_CHAT_EVERYONE );


### PR DESCRIPTION
- Merge after #1306
- Resolves #74 
- Related to #850  

The chat toggle function is blocked by a the `isActivePlayer` check, which checks if a player is either an observer or dead (note that an observer is also classified as a 'dead' player).

I have not removed this check from team chat functionality (backspace), because observers are not in a team. Observer messages are never send to active players anyways. There is a safeguard for that further on in the chat logic.

~~An additional blocker prevented the observer chat to work after surrender. The player template is changed to observer and resets a number of data entries related to network information. This information is used to determine the value of `player->IsMultiplayer()`, causing it to return false. The chat function uses this to check if chat can be enabled. This is resolved by adding an entry that checks if  the player is dead~~
