### PR TITLE
[GEN][ZH] Workaround for checking 'this' pointer

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/GameMemory.h
+++ b/Generals/Code/GameEngine/Include/Common/GameMemory.h
@@ -758,7 +758,8 @@ public:
 
 	void deleteInstance() 
 	{	
-		if (this)
+		void * volatile checkThisPtr = this; // mitigate undefined behavior because this function is called on nullptrs
+		if (checkThisPtr)
 		{
 			MemoryPool *pool = this->getObjectMemoryPool(); // save this, since the dtor will nuke our vtbl
 			this->~MemoryPoolObject();	// it's virtual, so the right one will be called.

--- a/GeneralsMD/Code/GameEngine/Include/Common/GameMemory.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GameMemory.h
@@ -757,7 +757,8 @@ public:
 
 	void deleteInstance() 
 	{	
-		if (this)
+		void * volatile checkThisPtr = this; // mitigate undefined behavior because this function is called on nullptrs
+		if (checkThisPtr)
 		{
 			MemoryPool *pool = this->getObjectMemoryPool(); // save this, since the dtor will nuke our vtbl
 			this->~MemoryPoolObject();	// it's virtual, so the right one will be called.


### PR DESCRIPTION
Checking the `this` pointer is undefined behavior and such checks may be elided by the compiler at any moment. Clang-cl doesn't check the pointer value (at higher optimization levels, at least), so the game crashes before it can get to the main menu.

Using a volatile pointer will force the compiler to emit more instructions, so there'll be a very small but inevitable inefficiency. 
This is a workaround, not a fix. The issue is that fixing this would probably require changing all 1000+ calls to `deleteInstance`.