### PR TITLE
[GEN][ZH] Fix undefined behavior with MemoryPoolObject::deleteInstance

### DIFF
--- a/Core/GameEngine/Source/Common/System/XferSave.cpp
+++ b/Core/GameEngine/Source/Common/System/XferSave.cpp
@@ -91,7 +91,7 @@ XferSave::~XferSave( void )
 		{
 
 			next = m_blockStack->next;
-			m_blockStack->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_blockStack);
 			m_blockStack = next;
 
 		}  // end while
@@ -247,7 +247,7 @@ void XferSave::endBlock( void )
 	fseek( m_fileFP, currentFilePos, SEEK_SET );
 
 	// delete the block data as it's all used up now
-	top->deleteInstance();
+	MemoryPoolObject::deleteInstance(top);
 
 }  // end endBlock
 

--- a/Core/GameEngine/Source/Common/System/XferSave.cpp
+++ b/Core/GameEngine/Source/Common/System/XferSave.cpp
@@ -91,7 +91,7 @@ XferSave::~XferSave( void )
 		{
 
 			next = m_blockStack->next;
-			MemoryPoolObject::deleteInstance(m_blockStack);
+			deleteInstance(m_blockStack);
 			m_blockStack = next;
 
 		}  // end while
@@ -247,7 +247,7 @@ void XferSave::endBlock( void )
 	fseek( m_fileFP, currentFilePos, SEEK_SET );
 
 	// delete the block data as it's all used up now
-	MemoryPoolObject::deleteInstance(top);
+	deleteInstance(top);
 
 }  // end endBlock
 

--- a/Generals/Code/GameEngine/Include/Common/GameMemory.h
+++ b/Generals/Code/GameEngine/Include/Common/GameMemory.h
@@ -767,6 +767,10 @@ public:
 	} 
 };
 
+inline void deleteInstance(MemoryPoolObject* mpo)
+{
+	MemoryPoolObject::deleteInstance(mpo);
+}
 
 
 // INLINING ///////////////////////////////////////////////////////////////////
@@ -906,7 +910,7 @@ public:
 	MemoryPoolObjectHolder(MemoryPoolObject *mpo = NULL) : m_mpo(mpo) { }
 	void hold(MemoryPoolObject *mpo) { DEBUG_ASSERTCRASH(!m_mpo, ("already holding")); m_mpo = mpo; }
 	void release() { m_mpo = NULL; }
-	~MemoryPoolObjectHolder() { MemoryPoolObject::deleteInstance(m_mpo); }
+	~MemoryPoolObjectHolder() { deleteInstance(m_mpo); }
 };
 
 

--- a/Generals/Code/GameEngine/Include/Common/GameMemory.h
+++ b/Generals/Code/GameEngine/Include/Common/GameMemory.h
@@ -914,22 +914,6 @@ public:
 };
 
 
-// ----------------------------------------------------------------------------
-/**
-	Sometimes you want to make a class's destructor protected so that it can only
-	be destroyed under special circumstances. MemoryPoolObject short-circuits this
-	by making the destructor always be protected, and the true delete technique
-	(namely, deleteInstance) always public by default. You can simulate the behavior
-	you really want by including this macro 
-*/
-#define MEMORY_POOL_DELETEINSTANCE_VISIBILITY(ARGVIS)\
-ARGVIS: \
-	static void deleteInstance(MemoryPoolObject* object) { \
-		MemoryPoolObject::deleteInstance(object); \
-	} \
-public: 
-
-
 #define EMPTY_DTOR(CLASS) inline CLASS::~CLASS() { }
 
 #endif // _GAME_MEMORY_H_

--- a/Generals/Code/GameEngine/Include/Common/GameMemory.h
+++ b/Generals/Code/GameEngine/Include/Common/GameMemory.h
@@ -756,13 +756,13 @@ protected:
 	
 public: 
 
-	void deleteInstance() 
+	static void deleteInstance(MemoryPoolObject* mpo) 
 	{	
-		if (this)
+		if (mpo)
 		{
-			MemoryPool *pool = this->getObjectMemoryPool(); // save this, since the dtor will nuke our vtbl
-			this->~MemoryPoolObject();	// it's virtual, so the right one will be called.
-			pool->freeBlock((void *)this); 
+			MemoryPool *pool = mpo->getObjectMemoryPool(); // save this, since the dtor will nuke our vtbl
+			mpo->~MemoryPoolObject();	// it's virtual, so the right one will be called.
+			pool->freeBlock((void *)mpo); 
 		}
 	} 
 };
@@ -906,7 +906,7 @@ public:
 	MemoryPoolObjectHolder(MemoryPoolObject *mpo = NULL) : m_mpo(mpo) { }
 	void hold(MemoryPoolObject *mpo) { DEBUG_ASSERTCRASH(!m_mpo, ("already holding")); m_mpo = mpo; }
 	void release() { m_mpo = NULL; }
-	~MemoryPoolObjectHolder() { m_mpo->deleteInstance(); }
+	~MemoryPoolObjectHolder() { MemoryPoolObject::deleteInstance(m_mpo); }
 };
 
 
@@ -919,7 +919,11 @@ public:
 	you really want by including this macro 
 */
 #define MEMORY_POOL_DELETEINSTANCE_VISIBILITY(ARGVIS)\
-ARGVIS:	void deleteInstance() { MemoryPoolObject::deleteInstance(); } public: 
+ARGVIS: \
+	static void deleteInstance(MemoryPoolObject* object) { \
+		MemoryPoolObject::deleteInstance(object); \
+	} \
+public: 
 
 
 #define EMPTY_DTOR(CLASS) inline CLASS::~CLASS() { }

--- a/Generals/Code/GameEngine/Include/Common/GameMemoryNull.h
+++ b/Generals/Code/GameEngine/Include/Common/GameMemoryNull.h
@@ -114,6 +114,11 @@ public:
 	}
 };
 
+inline void deleteInstance(MemoryPoolObject* mpo)
+{
+	MemoryPoolObject::deleteInstance(mpo);
+}
+
 
 /**
 	Initialize the memory manager. Construct a new MemoryPoolFactory and 

--- a/Generals/Code/GameEngine/Include/Common/GameMemoryNull.h
+++ b/Generals/Code/GameEngine/Include/Common/GameMemoryNull.h
@@ -108,9 +108,9 @@ protected:
 
 public:
 
-	void deleteInstance() 
+	static void deleteInstance(MemoryPoolObject* mpo) 
 	{
-		delete this;
+		delete mpo;
 	}
 };
 

--- a/Generals/Code/GameEngine/Include/Common/Overridable.h
+++ b/Generals/Code/GameEngine/Include/Common/Overridable.h
@@ -108,7 +108,7 @@ class Overridable : public MemoryPoolObject
 		{
 			if ( m_isOverride )
 			{
-				deleteInstance();
+				MemoryPoolObject::deleteInstance(this);
 				return NULL;
 			}
 			else if ( m_nextOverride )
@@ -123,7 +123,7 @@ class Overridable : public MemoryPoolObject
 __inline Overridable::~Overridable() 
 {
 	if (m_nextOverride) 
-		m_nextOverride->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_nextOverride);
 }
 
 

--- a/Generals/Code/GameEngine/Include/Common/Overridable.h
+++ b/Generals/Code/GameEngine/Include/Common/Overridable.h
@@ -108,7 +108,7 @@ class Overridable : public MemoryPoolObject
 		{
 			if ( m_isOverride )
 			{
-				MemoryPoolObject::deleteInstance(this);
+				deleteInstance(this);
 				return NULL;
 			}
 			else if ( m_nextOverride )
@@ -123,7 +123,7 @@ class Overridable : public MemoryPoolObject
 __inline Overridable::~Overridable() 
 {
 	if (m_nextOverride) 
-		MemoryPoolObject::deleteInstance(m_nextOverride);
+		deleteInstance(m_nextOverride);
 }
 
 

--- a/Generals/Code/GameEngine/Include/Common/ThingTemplate.h
+++ b/Generals/Code/GameEngine/Include/Common/ThingTemplate.h
@@ -159,7 +159,7 @@ public:
 	{
 		for (Int i = 0; i < TTAUDIO_COUNT; ++i)
 			if (m_audio[i])
-				MemoryPoolObject::deleteInstance(m_audio[i]);
+				deleteInstance(m_audio[i]);
 	}
 
 	AudioArray(const AudioArray& that)

--- a/Generals/Code/GameEngine/Include/Common/ThingTemplate.h
+++ b/Generals/Code/GameEngine/Include/Common/ThingTemplate.h
@@ -159,7 +159,7 @@ public:
 	{
 		for (Int i = 0; i < TTAUDIO_COUNT; ++i)
 			if (m_audio[i])
-				m_audio[i]->deleteInstance();
+				MemoryPoolObject::deleteInstance(m_audio[i]);
 	}
 
 	AudioArray(const AudioArray& that)

--- a/Generals/Code/GameEngine/Include/GameLogic/Object.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Object.h
@@ -386,7 +386,7 @@ public:
 	Bool isInList(Object **pListHead) const;
 
 	// this is intended for use ONLY by GameLogic.
-	void friend_deleteInstance() { deleteInstance(); }
+	static void friend_deleteInstance(MemoryPoolObject* object) { MemoryPoolObject::deleteInstance(object); }
 
 	/// cache the partition module (should be called only by PartitionData)
 	void friend_setPartitionData(PartitionData *pd) { m_partitionData = pd; }

--- a/Generals/Code/GameEngine/Include/GameLogic/Object.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Object.h
@@ -158,8 +158,6 @@ class Object : public Thing, public Snapshot
 {
 
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(Object, "ObjectPool" )		
-	/// destructor is non-public in order to require the use of TheGameLogic->destroyObject()
-	MEMORY_POOL_DELETEINSTANCE_VISIBILITY(protected)
 
 public:
 
@@ -764,6 +762,9 @@ private:
 	Bool													m_isReceivingDifficultyBonus;
 
 };  // end class Object
+
+// deleteInstance is not meant to be used with Object in order to require the use of TheGameLogic->destroyObject()
+void deleteInstance(Object* object) CPP_11(= delete);
 
 // describe an object as an AsciiString: e.g. "Object 102 (KillerBuggy) [GLARocketBuggy, owned by player 2 (GLAIntroPlayer)]"
 AsciiString DebugDescribeObject(const Object *obj);

--- a/Generals/Code/GameEngine/Include/GameLogic/Object.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Object.h
@@ -386,7 +386,7 @@ public:
 	Bool isInList(Object **pListHead) const;
 
 	// this is intended for use ONLY by GameLogic.
-	static void friend_deleteInstance(MemoryPoolObject* object) { MemoryPoolObject::deleteInstance(object); }
+	static void friend_deleteInstance(Object* object) { deleteInstance(object); }
 
 	/// cache the partition module (should be called only by PartitionData)
 	void friend_setPartitionData(PartitionData *pd) { m_partitionData = pd; }

--- a/Generals/Code/GameEngine/Include/GameLogic/ObjectIter.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/ObjectIter.h
@@ -67,7 +67,7 @@ enum IterOrderType CPP_11(: Int)
 	{
 		// do something with other
 	}
-	iter->deleteInstance();								// you own it, so you must delete it
+	MemoryPoolObject::deleteInstance(iter);								// you own it, so you must delete it
 
 	note that the iterator is required to deal intelligently with deleted objects; 
 	in particular, next() will check if an obj has been killed and simply skip it.

--- a/Generals/Code/GameEngine/Include/GameLogic/ObjectIter.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/ObjectIter.h
@@ -67,7 +67,7 @@ enum IterOrderType CPP_11(: Int)
 	{
 		// do something with other
 	}
-	MemoryPoolObject::deleteInstance(iter);								// you own it, so you must delete it
+	deleteInstance(iter);								// you own it, so you must delete it
 
 	note that the iterator is required to deal intelligently with deleted objects; 
 	in particular, next() will check if an obj has been killed and simply skip it.

--- a/Generals/Code/GameEngine/Source/Common/Audio/GameAudio.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Audio/GameAudio.cpp
@@ -188,7 +188,7 @@ AudioManager::~AudioManager()
 	for (it = m_allAudioEventInfo.begin(); it != m_allAudioEventInfo.end(); ++it) {
 		AudioEventInfo *eventInfo = (*it).second;
 		if (eventInfo) {
-			eventInfo->deleteInstance();
+			MemoryPoolObject::deleteInstance(eventInfo);
 			eventInfo = NULL;
 		}
 	}
@@ -811,7 +811,7 @@ AudioRequest *AudioManager::allocateAudioRequest( Bool useAudioEvent )
 void AudioManager::releaseAudioRequest( AudioRequest *requestToRelease )
 {
 	if (requestToRelease) {
-		requestToRelease->deleteInstance();
+		MemoryPoolObject::deleteInstance(requestToRelease);
 	}
 }
 
@@ -894,7 +894,7 @@ void AudioManager::removeLevelSpecificAudioEventInfos(void)
 
     if ( it->second->isLevelSpecific() )
     {
-      it->second->deleteInstance();
+      MemoryPoolObject::deleteInstance(it->second);
       m_allAudioEventInfo.erase( it );
     }
 

--- a/Generals/Code/GameEngine/Source/Common/Audio/GameAudio.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Audio/GameAudio.cpp
@@ -188,7 +188,7 @@ AudioManager::~AudioManager()
 	for (it = m_allAudioEventInfo.begin(); it != m_allAudioEventInfo.end(); ++it) {
 		AudioEventInfo *eventInfo = (*it).second;
 		if (eventInfo) {
-			MemoryPoolObject::deleteInstance(eventInfo);
+			deleteInstance(eventInfo);
 			eventInfo = NULL;
 		}
 	}
@@ -811,7 +811,7 @@ AudioRequest *AudioManager::allocateAudioRequest( Bool useAudioEvent )
 void AudioManager::releaseAudioRequest( AudioRequest *requestToRelease )
 {
 	if (requestToRelease) {
-		MemoryPoolObject::deleteInstance(requestToRelease);
+		deleteInstance(requestToRelease);
 	}
 }
 
@@ -894,7 +894,7 @@ void AudioManager::removeLevelSpecificAudioEventInfos(void)
 
     if ( it->second->isLevelSpecific() )
     {
-      MemoryPoolObject::deleteInstance(it->second);
+      deleteInstance(it->second);
       m_allAudioEventInfo.erase( it );
     }
 

--- a/Generals/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -536,7 +536,7 @@ void GameEngine::reset( void )
 	if(background)
 	{
 		background->destroyWindows();
-		MemoryPoolObject::deleteInstance(background);
+		deleteInstance(background);
 		background = NULL;
 	}
 }

--- a/Generals/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -536,7 +536,7 @@ void GameEngine::reset( void )
 	if(background)
 	{
 		background->destroyWindows();
-		background->deleteInstance();
+		MemoryPoolObject::deleteInstance(background);
 		background = NULL;
 	}
 }

--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -1061,7 +1061,7 @@ GlobalData::~GlobalData( void )
 	DEBUG_ASSERTCRASH( TheWritableGlobalData->m_next == NULL, ("~GlobalData: theOriginal is not original\n") );
 
 	if (m_weaponBonusSet)
-		m_weaponBonusSet->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_weaponBonusSet);
 
 	if( m_theOriginal == this )	{
 		m_theOriginal = NULL;

--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -1061,7 +1061,7 @@ GlobalData::~GlobalData( void )
 	DEBUG_ASSERTCRASH( TheWritableGlobalData->m_next == NULL, ("~GlobalData: theOriginal is not original\n") );
 
 	if (m_weaponBonusSet)
-		MemoryPoolObject::deleteInstance(m_weaponBonusSet);
+		deleteInstance(m_weaponBonusSet);
 
 	if( m_theOriginal == this )	{
 		m_theOriginal = NULL;

--- a/Generals/Code/GameEngine/Source/Common/INI/INI.cpp
+++ b/Generals/Code/GameEngine/Source/Common/INI/INI.cpp
@@ -1151,7 +1151,7 @@ void INI::parseDynamicAudioEventRTS( INI *ini, void * /*instance*/, void *store,
 	{
 		if (*theSound)
 		{
-			MemoryPoolObject::deleteInstance((*theSound));
+			deleteInstance(*theSound);
 			*theSound = NULL;
 		}
 	}

--- a/Generals/Code/GameEngine/Source/Common/INI/INI.cpp
+++ b/Generals/Code/GameEngine/Source/Common/INI/INI.cpp
@@ -1151,7 +1151,7 @@ void INI::parseDynamicAudioEventRTS( INI *ini, void * /*instance*/, void *store,
 	{
 		if (*theSound)
 		{
-			(*theSound)->deleteInstance();
+			MemoryPoolObject::deleteInstance((*theSound));
 			*theSound = NULL;
 		}
 	}

--- a/Generals/Code/GameEngine/Source/Common/MessageStream.cpp
+++ b/Generals/Code/GameEngine/Source/Common/MessageStream.cpp
@@ -79,7 +79,7 @@ GameMessage::~GameMessage( )
 	for( arg = m_argList; arg; arg=nextArg )
 	{
 		nextArg = arg->m_next;
-		arg->deleteInstance();
+		MemoryPoolObject::deleteInstance(arg);
 	}
 
 	// detach message from list
@@ -678,7 +678,7 @@ GameMessageList::~GameMessageList()
 		// set list ptr to null to avoid it trying to remove itself from the list
 		// that we are in the process of nuking...
 		msg->friend_setList(NULL);
-		msg->deleteInstance();
+		MemoryPoolObject::deleteInstance(msg);
 	}
 }
 
@@ -1064,7 +1064,7 @@ void MessageStream::propagateMessages( void )
 				next = msg->next();
 				if (disp == DESTROY_MESSAGE)
 				{
-					msg->deleteInstance();
+					MemoryPoolObject::deleteInstance(msg);
 				}
 			} 
 			else 
@@ -1151,7 +1151,7 @@ void CommandList::destroyAllMessages( void )
 	for( msg=m_firstMessage; msg; msg=next )
 	{
 		next = msg->next();
-		msg->deleteInstance();
+		MemoryPoolObject::deleteInstance(msg);
 	}
 	
 	m_firstMessage = NULL;

--- a/Generals/Code/GameEngine/Source/Common/MessageStream.cpp
+++ b/Generals/Code/GameEngine/Source/Common/MessageStream.cpp
@@ -79,7 +79,7 @@ GameMessage::~GameMessage( )
 	for( arg = m_argList; arg; arg=nextArg )
 	{
 		nextArg = arg->m_next;
-		MemoryPoolObject::deleteInstance(arg);
+		deleteInstance(arg);
 	}
 
 	// detach message from list
@@ -678,7 +678,7 @@ GameMessageList::~GameMessageList()
 		// set list ptr to null to avoid it trying to remove itself from the list
 		// that we are in the process of nuking...
 		msg->friend_setList(NULL);
-		MemoryPoolObject::deleteInstance(msg);
+		deleteInstance(msg);
 	}
 }
 
@@ -1064,7 +1064,7 @@ void MessageStream::propagateMessages( void )
 				next = msg->next();
 				if (disp == DESTROY_MESSAGE)
 				{
-					MemoryPoolObject::deleteInstance(msg);
+					deleteInstance(msg);
 				}
 			} 
 			else 
@@ -1151,7 +1151,7 @@ void CommandList::destroyAllMessages( void )
 	for( msg=m_firstMessage; msg; msg=next )
 	{
 		next = msg->next();
-		MemoryPoolObject::deleteInstance(msg);
+		deleteInstance(msg);
 	}
 	
 	m_firstMessage = NULL;

--- a/Generals/Code/GameEngine/Source/Common/NameKeyGenerator.cpp
+++ b/Generals/Code/GameEngine/Source/Common/NameKeyGenerator.cpp
@@ -81,7 +81,7 @@ void NameKeyGenerator::freeSockets()
 		for (Bucket *b = m_sockets[i]; b; b = next)
 		{
 			next = b->m_nextInSocket;
-			b->deleteInstance();
+			MemoryPoolObject::deleteInstance(b);
 		}
 		m_sockets[i] = NULL;
 	}

--- a/Generals/Code/GameEngine/Source/Common/NameKeyGenerator.cpp
+++ b/Generals/Code/GameEngine/Source/Common/NameKeyGenerator.cpp
@@ -81,7 +81,7 @@ void NameKeyGenerator::freeSockets()
 		for (Bucket *b = m_sockets[i]; b; b = next)
 		{
 			next = b->m_nextInSocket;
-			MemoryPoolObject::deleteInstance(b);
+			deleteInstance(b);
 		}
 		m_sockets[i] = NULL;
 	}

--- a/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -375,7 +375,7 @@ void Player::init(const PlayerTemplate* pt)
 	m_searchAndDestroyBattlePlans = 0;
 	if( m_battlePlanBonuses )
 	{
-		MemoryPoolObject::deleteInstance(m_battlePlanBonuses);
+		deleteInstance(m_battlePlanBonuses);
 		m_battlePlanBonuses = NULL;
 	}
 
@@ -385,40 +385,40 @@ void Player::init(const PlayerTemplate* pt)
 	m_stats.init();
 	if (m_pBuildList != NULL) 
 	{
-		MemoryPoolObject::deleteInstance(m_pBuildList);
+		deleteInstance(m_pBuildList);
 		m_pBuildList = NULL;
 	}
 	m_defaultTeam = NULL;
 
 	if (m_ai)
 	{
-		MemoryPoolObject::deleteInstance(m_ai);
+		deleteInstance(m_ai);
 	}
 	m_ai = NULL;
 
 	if( m_resourceGatheringManager )
 	{
-		MemoryPoolObject::deleteInstance(m_resourceGatheringManager);
+		deleteInstance(m_resourceGatheringManager);
 		m_resourceGatheringManager = NULL;
 	}
 
 	for (Int i = 0; i < NUM_HOTKEY_SQUADS; ++i) {
 		if (m_squads[i] != NULL) {
-			MemoryPoolObject::deleteInstance(m_squads[i]);
+			deleteInstance(m_squads[i]);
 			m_squads[i] = NULL;
 		}
 		m_squads[i] = newInstance(Squad);	
 	}
 
 	if (m_currentSelection != NULL) {
-		MemoryPoolObject::deleteInstance(m_currentSelection) ;
+		deleteInstance(m_currentSelection) ;
 		m_currentSelection = NULL;
 	}
 	m_currentSelection = newInstance(Squad);
 	
 	if( m_tunnelSystem )
 	{
-		MemoryPoolObject::deleteInstance(m_tunnelSystem);
+		deleteInstance(m_tunnelSystem);
 		m_tunnelSystem = NULL;
 	}
 	
@@ -500,7 +500,7 @@ void Player::init(const PlayerTemplate* pt)
 		KindOfPercentProductionChange *tof = *it;
 		it = m_kindOfPercentProductionChangeList.erase( it );
 		if(tof)
-			MemoryPoolObject::deleteInstance(tof);
+			deleteInstance(tof);
 	}
 
 }
@@ -519,24 +519,24 @@ Player::~Player()
 	m_playerTeamPrototypes.clear();	// empty, but don't free the contents
 
 	// delete the relation maps (the destructor clears the actual map if any data is present)
-	MemoryPoolObject::deleteInstance(m_teamRelations);
-	MemoryPoolObject::deleteInstance(m_playerRelations);
+	deleteInstance(m_teamRelations);
+	deleteInstance(m_playerRelations);
 
 	for (Int i = 0; i < NUM_HOTKEY_SQUADS; ++i) {
 		if (m_squads[i] != NULL) {
-			MemoryPoolObject::deleteInstance(m_squads[i]);
+			deleteInstance(m_squads[i]);
 			m_squads[i] = NULL;
 		}
 	}
 
 	if (m_currentSelection != NULL) {
-		MemoryPoolObject::deleteInstance(m_currentSelection);
+		deleteInstance(m_currentSelection);
 		m_currentSelection = NULL;
 	}
 
 	if( m_battlePlanBonuses )
 	{
-		MemoryPoolObject::deleteInstance(m_battlePlanBonuses);
+		deleteInstance(m_battlePlanBonuses);
 		m_battlePlanBonuses = NULL;
 	}
 }
@@ -647,7 +647,7 @@ void Player::setBuildList(BuildListInfo *pBuildList)
 
 	if (m_pBuildList != NULL) 
 	{
-		MemoryPoolObject::deleteInstance(m_pBuildList);
+		deleteInstance(m_pBuildList);
 	}
 	m_pBuildList = pBuildList;
 
@@ -713,7 +713,7 @@ void Player::setPlayerType(PlayerType t, Bool skirmish)
 
 	if (m_ai)
 	{
-		MemoryPoolObject::deleteInstance(m_ai);
+		deleteInstance(m_ai);
 	}
 	m_ai = NULL;
 
@@ -749,7 +749,7 @@ void Player::deletePlayerAI()
 {
 	if (m_ai)
 	{
-		MemoryPoolObject::deleteInstance(m_ai);
+		deleteInstance(m_ai);
 		m_ai = NULL;
 	}
 }
@@ -826,10 +826,10 @@ void Player::initFromDict(const Dict* d)
 				ScriptList *scripts = TheSidesList->getSkirmishSideInfo(i)->getScriptList()->duplicateAndQualify(
 							qualifier, qualTemplatePlayerName, pname);
 				if (TheSidesList->getSideInfo(getPlayerIndex())->getScriptList()) {
-					MemoryPoolObject::deleteInstance(TheSidesList->getSideInfo(getPlayerIndex())->getScriptList());
+					deleteInstance(TheSidesList->getSideInfo(getPlayerIndex())->getScriptList());
 				}
 				TheSidesList->getSideInfo(getPlayerIndex())->setScriptList(scripts);
-				MemoryPoolObject::deleteInstance(TheSidesList->getSkirmishSideInfo(i)->getScriptList());
+				deleteInstance(TheSidesList->getSkirmishSideInfo(i)->getScriptList());
 				TheSidesList->getSkirmishSideInfo(i)->setScriptList(NULL);
 			}
 
@@ -877,7 +877,7 @@ void Player::initFromDict(const Dict* d)
 			ScriptList* slist = TheSidesList->getSideInfo(getPlayerIndex())->getScriptList();
 			if (slist) 
 			{
-				MemoryPoolObject::deleteInstance(slist);
+				deleteInstance(slist);
 			}
 			TheSidesList->getSideInfo(getPlayerIndex())->setScriptList(scripts);
 			for (i=0; i<TheSidesList->getNumTeams(); i++) {
@@ -948,14 +948,14 @@ void Player::initFromDict(const Dict* d)
 	}																																 
 	if( m_resourceGatheringManager )
 	{
-		MemoryPoolObject::deleteInstance(m_resourceGatheringManager);
+		deleteInstance(m_resourceGatheringManager);
 		m_resourceGatheringManager = NULL;
 	}
 	m_resourceGatheringManager = newInstance(ResourceGatheringManager);
 
 	if( m_tunnelSystem )
 	{
-		MemoryPoolObject::deleteInstance(m_tunnelSystem);
+		deleteInstance(m_tunnelSystem);
 		m_tunnelSystem = NULL;
 	}
 	m_tunnelSystem = newInstance(TunnelTracker);
@@ -994,14 +994,14 @@ void Player::initFromDict(const Dict* d)
 	for ( i = 0; i < NUM_HOTKEY_SQUADS; ++i ) {
 		if (m_squads[i] != NULL)
 		{
-			MemoryPoolObject::deleteInstance(m_squads[i]);
+			deleteInstance(m_squads[i]);
 			m_squads[i] = NULL;
 		}
 		m_squads[i] = newInstance( Squad );
 	}
 
 	if (m_currentSelection != NULL) {
-		MemoryPoolObject::deleteInstance(m_currentSelection);
+		deleteInstance(m_currentSelection);
 		m_currentSelection = NULL;
 	}
 	m_currentSelection = newInstance( Squad );
@@ -1119,7 +1119,7 @@ void Player::becomingLocalPlayer(Bool yes)
 					}
 				}
 			}
-			MemoryPoolObject::deleteInstance(iter);
+			deleteInstance(iter);
 		}
 	}
 	else
@@ -2493,7 +2493,7 @@ void Player::deleteUpgradeList( void )
 	{
 
 		next = m_upgradeList->friend_getNext();
-		MemoryPoolObject::deleteInstance(m_upgradeList);
+		deleteInstance(m_upgradeList);
 		m_upgradeList = next;
 
 	}  // end while
@@ -3122,7 +3122,7 @@ void Player::removeBattlePlanBonusesForObject( Object *obj ) const
 	DUMPBATTLEPLANBONUSES(bonus, this, obj);
 	localApplyBattlePlanBonusesToObject( obj, bonus );
 
-	MemoryPoolObject::deleteInstance(bonus);
+	deleteInstance(bonus);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -3360,7 +3360,7 @@ void Player::removeKindOfProductionCostChange(	KindOfMaskType kindOf, Real perce
 			{
 				m_kindOfPercentProductionChangeList.erase( it );
 				if(tof)
-					MemoryPoolObject::deleteInstance(tof);
+					deleteInstance(tof);
 			}
 			return;
 		}
@@ -3698,7 +3698,7 @@ void Player::xfer( Xfer *xfer )
 		// the head of these structures automatically deletes any links attached
 		//
 		if( m_pBuildList)
-			MemoryPoolObject::deleteInstance(m_pBuildList);
+			deleteInstance(m_pBuildList);
 		m_pBuildList = NULL;
 
 		// read each build list info
@@ -4050,7 +4050,7 @@ void Player::xfer( Xfer *xfer )
 	{
 		if (m_battlePlanBonuses)
 		{
-			MemoryPoolObject::deleteInstance(m_battlePlanBonuses);
+			deleteInstance(m_battlePlanBonuses);
 			m_battlePlanBonuses = NULL;
 		}
 		if ( battlePlanBonus )

--- a/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -375,7 +375,7 @@ void Player::init(const PlayerTemplate* pt)
 	m_searchAndDestroyBattlePlans = 0;
 	if( m_battlePlanBonuses )
 	{
-		m_battlePlanBonuses->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_battlePlanBonuses);
 		m_battlePlanBonuses = NULL;
 	}
 
@@ -385,40 +385,40 @@ void Player::init(const PlayerTemplate* pt)
 	m_stats.init();
 	if (m_pBuildList != NULL) 
 	{
-		m_pBuildList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_pBuildList);
 		m_pBuildList = NULL;
 	}
 	m_defaultTeam = NULL;
 
 	if (m_ai)
 	{
-		m_ai->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_ai);
 	}
 	m_ai = NULL;
 
 	if( m_resourceGatheringManager )
 	{
-		m_resourceGatheringManager->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_resourceGatheringManager);
 		m_resourceGatheringManager = NULL;
 	}
 
 	for (Int i = 0; i < NUM_HOTKEY_SQUADS; ++i) {
 		if (m_squads[i] != NULL) {
-			m_squads[i]->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_squads[i]);
 			m_squads[i] = NULL;
 		}
 		m_squads[i] = newInstance(Squad);	
 	}
 
 	if (m_currentSelection != NULL) {
-		m_currentSelection->deleteInstance() ;
+		MemoryPoolObject::deleteInstance(m_currentSelection) ;
 		m_currentSelection = NULL;
 	}
 	m_currentSelection = newInstance(Squad);
 	
 	if( m_tunnelSystem )
 	{
-		m_tunnelSystem->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_tunnelSystem);
 		m_tunnelSystem = NULL;
 	}
 	
@@ -500,7 +500,7 @@ void Player::init(const PlayerTemplate* pt)
 		KindOfPercentProductionChange *tof = *it;
 		it = m_kindOfPercentProductionChangeList.erase( it );
 		if(tof)
-			tof->deleteInstance();
+			MemoryPoolObject::deleteInstance(tof);
 	}
 
 }
@@ -519,24 +519,24 @@ Player::~Player()
 	m_playerTeamPrototypes.clear();	// empty, but don't free the contents
 
 	// delete the relation maps (the destructor clears the actual map if any data is present)
-	m_teamRelations->deleteInstance();
-	m_playerRelations->deleteInstance();
+	MemoryPoolObject::deleteInstance(m_teamRelations);
+	MemoryPoolObject::deleteInstance(m_playerRelations);
 
 	for (Int i = 0; i < NUM_HOTKEY_SQUADS; ++i) {
 		if (m_squads[i] != NULL) {
-			m_squads[i]->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_squads[i]);
 			m_squads[i] = NULL;
 		}
 	}
 
 	if (m_currentSelection != NULL) {
-		m_currentSelection->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_currentSelection);
 		m_currentSelection = NULL;
 	}
 
 	if( m_battlePlanBonuses )
 	{
-		m_battlePlanBonuses->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_battlePlanBonuses);
 		m_battlePlanBonuses = NULL;
 	}
 }
@@ -647,7 +647,7 @@ void Player::setBuildList(BuildListInfo *pBuildList)
 
 	if (m_pBuildList != NULL) 
 	{
-		m_pBuildList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_pBuildList);
 	}
 	m_pBuildList = pBuildList;
 
@@ -713,7 +713,7 @@ void Player::setPlayerType(PlayerType t, Bool skirmish)
 
 	if (m_ai)
 	{
-		m_ai->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_ai);
 	}
 	m_ai = NULL;
 
@@ -749,7 +749,7 @@ void Player::deletePlayerAI()
 {
 	if (m_ai)
 	{
-		m_ai->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_ai);
 		m_ai = NULL;
 	}
 }
@@ -826,10 +826,10 @@ void Player::initFromDict(const Dict* d)
 				ScriptList *scripts = TheSidesList->getSkirmishSideInfo(i)->getScriptList()->duplicateAndQualify(
 							qualifier, qualTemplatePlayerName, pname);
 				if (TheSidesList->getSideInfo(getPlayerIndex())->getScriptList()) {
-					TheSidesList->getSideInfo(getPlayerIndex())->getScriptList()->deleteInstance();
+					MemoryPoolObject::deleteInstance(TheSidesList->getSideInfo(getPlayerIndex())->getScriptList());
 				}
 				TheSidesList->getSideInfo(getPlayerIndex())->setScriptList(scripts);
-				TheSidesList->getSkirmishSideInfo(i)->getScriptList()->deleteInstance();
+				MemoryPoolObject::deleteInstance(TheSidesList->getSkirmishSideInfo(i)->getScriptList());
 				TheSidesList->getSkirmishSideInfo(i)->setScriptList(NULL);
 			}
 
@@ -877,7 +877,7 @@ void Player::initFromDict(const Dict* d)
 			ScriptList* slist = TheSidesList->getSideInfo(getPlayerIndex())->getScriptList();
 			if (slist) 
 			{
-				slist->deleteInstance();
+				MemoryPoolObject::deleteInstance(slist);
 			}
 			TheSidesList->getSideInfo(getPlayerIndex())->setScriptList(scripts);
 			for (i=0; i<TheSidesList->getNumTeams(); i++) {
@@ -948,14 +948,14 @@ void Player::initFromDict(const Dict* d)
 	}																																 
 	if( m_resourceGatheringManager )
 	{
-		m_resourceGatheringManager->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_resourceGatheringManager);
 		m_resourceGatheringManager = NULL;
 	}
 	m_resourceGatheringManager = newInstance(ResourceGatheringManager);
 
 	if( m_tunnelSystem )
 	{
-		m_tunnelSystem->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_tunnelSystem);
 		m_tunnelSystem = NULL;
 	}
 	m_tunnelSystem = newInstance(TunnelTracker);
@@ -994,14 +994,14 @@ void Player::initFromDict(const Dict* d)
 	for ( i = 0; i < NUM_HOTKEY_SQUADS; ++i ) {
 		if (m_squads[i] != NULL)
 		{
-			m_squads[i]->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_squads[i]);
 			m_squads[i] = NULL;
 		}
 		m_squads[i] = newInstance( Squad );
 	}
 
 	if (m_currentSelection != NULL) {
-		m_currentSelection->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_currentSelection);
 		m_currentSelection = NULL;
 	}
 	m_currentSelection = newInstance( Squad );
@@ -1119,7 +1119,7 @@ void Player::becomingLocalPlayer(Bool yes)
 					}
 				}
 			}
-			iter->deleteInstance();
+			MemoryPoolObject::deleteInstance(iter);
 		}
 	}
 	else
@@ -2493,7 +2493,7 @@ void Player::deleteUpgradeList( void )
 	{
 
 		next = m_upgradeList->friend_getNext();
-		m_upgradeList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_upgradeList);
 		m_upgradeList = next;
 
 	}  // end while
@@ -3122,7 +3122,7 @@ void Player::removeBattlePlanBonusesForObject( Object *obj ) const
 	DUMPBATTLEPLANBONUSES(bonus, this, obj);
 	localApplyBattlePlanBonusesToObject( obj, bonus );
 
-	bonus->deleteInstance();
+	MemoryPoolObject::deleteInstance(bonus);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -3360,7 +3360,7 @@ void Player::removeKindOfProductionCostChange(	KindOfMaskType kindOf, Real perce
 			{
 				m_kindOfPercentProductionChangeList.erase( it );
 				if(tof)
-					tof->deleteInstance();
+					MemoryPoolObject::deleteInstance(tof);
 			}
 			return;
 		}
@@ -3698,7 +3698,7 @@ void Player::xfer( Xfer *xfer )
 		// the head of these structures automatically deletes any links attached
 		//
 		if( m_pBuildList)
-			m_pBuildList->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_pBuildList);
 		m_pBuildList = NULL;
 
 		// read each build list info
@@ -4050,7 +4050,7 @@ void Player::xfer( Xfer *xfer )
 	{
 		if (m_battlePlanBonuses)
 		{
-			m_battlePlanBonuses->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_battlePlanBonuses);
 			m_battlePlanBonuses = NULL;
 		}
 		if ( battlePlanBonus )

--- a/Generals/Code/GameEngine/Source/Common/RTS/Science.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/Science.cpp
@@ -60,7 +60,7 @@ ScienceStore::~ScienceStore()
 		ScienceInfo* si = *it;
 		++it;
 		if (si) {
-			si->deleteInstance();
+			MemoryPoolObject::deleteInstance(si);
 		}
 	}
 }

--- a/Generals/Code/GameEngine/Source/Common/RTS/Science.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/Science.cpp
@@ -60,7 +60,7 @@ ScienceStore::~ScienceStore()
 		ScienceInfo* si = *it;
 		++it;
 		if (si) {
-			MemoryPoolObject::deleteInstance(si);
+			deleteInstance(si);
 		}
 	}
 }

--- a/Generals/Code/GameEngine/Source/Common/RTS/SpecialPower.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/SpecialPower.cpp
@@ -226,7 +226,7 @@ SpecialPowerStore::~SpecialPowerStore( void )
 
 	// delete all templates
 	for( Int i = 0; i < m_specialPowerTemplates.size(); ++i )
-		MemoryPoolObject::deleteInstance(m_specialPowerTemplates[ i ]);
+		deleteInstance(m_specialPowerTemplates[ i ]);
 
 	// erase the list
 	m_specialPowerTemplates.clear();

--- a/Generals/Code/GameEngine/Source/Common/RTS/SpecialPower.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/SpecialPower.cpp
@@ -226,7 +226,7 @@ SpecialPowerStore::~SpecialPowerStore( void )
 
 	// delete all templates
 	for( Int i = 0; i < m_specialPowerTemplates.size(); ++i )
-		m_specialPowerTemplates[ i ]->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_specialPowerTemplates[ i ]);
 
 	// erase the list
 	m_specialPowerTemplates.clear();

--- a/Generals/Code/GameEngine/Source/Common/RTS/Team.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/Team.cpp
@@ -214,7 +214,7 @@ void TeamFactory::clear()
 	m_prototypes.clear();
 	for (TeamPrototypeMap::iterator it = tmp.begin(); it != tmp.end(); ++it)
 	{
-		it->second->deleteInstance();
+		MemoryPoolObject::deleteInstance(it->second);
 	}
 }
 
@@ -836,7 +836,7 @@ TeamPrototype::TeamPrototype( TeamFactory *tf,
 		if (o)
 		{
 			TheTeamFactory->teamAboutToBeDeleted(o);
-			o->deleteInstance();
+			MemoryPoolObject::deleteInstance(o);
 		}
 	}
 
@@ -852,7 +852,7 @@ TeamPrototype::~TeamPrototype()
 
 	if (m_productionConditionScript) 
 	{
-		m_productionConditionScript->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_productionConditionScript);
 	}
 	m_productionConditionScript = NULL;
 
@@ -860,7 +860,7 @@ TeamPrototype::~TeamPrototype()
 	{
 		if (m_genericScriptsToRun[i]) 
 		{
-			m_genericScriptsToRun[i]->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_genericScriptsToRun[i]);
 			m_genericScriptsToRun[i] = NULL;
 		}
 	}
@@ -1086,7 +1086,7 @@ void TeamPrototype::updateState(void)
 
 				// So remove it
 				TheTeamFactory->teamAboutToBeDeleted(iter.cur());
-				iter.cur()->deleteInstance();
+				MemoryPoolObject::deleteInstance(iter.cur());
 
 				done = false;
 				break; // Not sure what state the iterator is in after deleting a member of the list. jba
@@ -1385,8 +1385,8 @@ Team::~Team()
 		m_proto->removeFrom_TeamInstanceList(this);
 
 	// delete the relation maps (the destructor clears the actual map if any data is present)
-	m_teamRelations->deleteInstance();
-	m_playerRelations->deleteInstance();
+	MemoryPoolObject::deleteInstance(m_teamRelations);
+	MemoryPoolObject::deleteInstance(m_playerRelations);
 
 	// make sure the xfer list is clear
 	m_xferMemberIDList.clear();

--- a/Generals/Code/GameEngine/Source/Common/RTS/Team.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/Team.cpp
@@ -214,7 +214,7 @@ void TeamFactory::clear()
 	m_prototypes.clear();
 	for (TeamPrototypeMap::iterator it = tmp.begin(); it != tmp.end(); ++it)
 	{
-		MemoryPoolObject::deleteInstance(it->second);
+		deleteInstance(it->second);
 	}
 }
 
@@ -836,7 +836,7 @@ TeamPrototype::TeamPrototype( TeamFactory *tf,
 		if (o)
 		{
 			TheTeamFactory->teamAboutToBeDeleted(o);
-			MemoryPoolObject::deleteInstance(o);
+			deleteInstance(o);
 		}
 	}
 
@@ -852,7 +852,7 @@ TeamPrototype::~TeamPrototype()
 
 	if (m_productionConditionScript) 
 	{
-		MemoryPoolObject::deleteInstance(m_productionConditionScript);
+		deleteInstance(m_productionConditionScript);
 	}
 	m_productionConditionScript = NULL;
 
@@ -860,7 +860,7 @@ TeamPrototype::~TeamPrototype()
 	{
 		if (m_genericScriptsToRun[i]) 
 		{
-			MemoryPoolObject::deleteInstance(m_genericScriptsToRun[i]);
+			deleteInstance(m_genericScriptsToRun[i]);
 			m_genericScriptsToRun[i] = NULL;
 		}
 	}
@@ -1086,7 +1086,7 @@ void TeamPrototype::updateState(void)
 
 				// So remove it
 				TheTeamFactory->teamAboutToBeDeleted(iter.cur());
-				MemoryPoolObject::deleteInstance(iter.cur());
+				deleteInstance(iter.cur());
 
 				done = false;
 				break; // Not sure what state the iterator is in after deleting a member of the list. jba
@@ -1385,8 +1385,8 @@ Team::~Team()
 		m_proto->removeFrom_TeamInstanceList(this);
 
 	// delete the relation maps (the destructor clears the actual map if any data is present)
-	MemoryPoolObject::deleteInstance(m_teamRelations);
-	MemoryPoolObject::deleteInstance(m_playerRelations);
+	deleteInstance(m_teamRelations);
+	deleteInstance(m_playerRelations);
 
 	// make sure the xfer list is clear
 	m_xferMemberIDList.clear();

--- a/Generals/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Recorder.cpp
@@ -777,7 +777,7 @@ void RecorderClass::writeToFile(GameMessage * msg) {
 		writeArgument(msg->getArgumentDataType(i), *(msg->getArgument(i)));
 	}
 
-	MemoryPoolObject::deleteInstance(parser);
+	deleteInstance(parser);
 	parser = NULL;
 
 	fflush(m_file); ///< @todo should this be in the final release?
@@ -1366,17 +1366,17 @@ void RecorderClass::appendNextCommand() {
 
 	if (type == GameMessage::MSG_CLEAR_GAME_DATA || type == GameMessage::MSG_BEGIN_NETWORK_MESSAGES)
 	{
-		MemoryPoolObject::deleteInstance(msg);
+		deleteInstance(msg);
 		msg = NULL;
 	}
 
 	if (m_doingAnalysis)
 	{
-		MemoryPoolObject::deleteInstance(msg);
+		deleteInstance(msg);
 		msg = NULL;
 	}
 
-	MemoryPoolObject::deleteInstance(parser);
+	deleteInstance(parser);
 	parser = NULL;
 }
 
@@ -1511,7 +1511,7 @@ void RecorderClass::cullBadCommands() {
 				(msg->getType() < GameMessage::MSG_END_NETWORK_MESSAGES) &&
 				(msg->getType() != GameMessage::MSG_LOGIC_CRC)) {
 
-			MemoryPoolObject::deleteInstance(msg);
+			deleteInstance(msg);
 		}
 
 		msg = next;

--- a/Generals/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Recorder.cpp
@@ -777,7 +777,7 @@ void RecorderClass::writeToFile(GameMessage * msg) {
 		writeArgument(msg->getArgumentDataType(i), *(msg->getArgument(i)));
 	}
 
-	parser->deleteInstance();
+	MemoryPoolObject::deleteInstance(parser);
 	parser = NULL;
 
 	fflush(m_file); ///< @todo should this be in the final release?
@@ -1366,17 +1366,17 @@ void RecorderClass::appendNextCommand() {
 
 	if (type == GameMessage::MSG_CLEAR_GAME_DATA || type == GameMessage::MSG_BEGIN_NETWORK_MESSAGES)
 	{
-		msg->deleteInstance();
+		MemoryPoolObject::deleteInstance(msg);
 		msg = NULL;
 	}
 
 	if (m_doingAnalysis)
 	{
-		msg->deleteInstance();
+		MemoryPoolObject::deleteInstance(msg);
 		msg = NULL;
 	}
 
-	parser->deleteInstance();
+	MemoryPoolObject::deleteInstance(parser);
 	parser = NULL;
 }
 
@@ -1511,7 +1511,7 @@ void RecorderClass::cullBadCommands() {
 				(msg->getType() < GameMessage::MSG_END_NETWORK_MESSAGES) &&
 				(msg->getType() != GameMessage::MSG_LOGIC_CRC)) {
 
-			msg->deleteInstance();
+			MemoryPoolObject::deleteInstance(msg);
 		}
 
 		msg = next;

--- a/Generals/Code/GameEngine/Source/Common/StateMachine.cpp
+++ b/Generals/Code/GameEngine/Source/Common/StateMachine.cpp
@@ -297,7 +297,7 @@ StateMachine::~StateMachine()
 	for( i = m_stateMap.begin(); i != m_stateMap.end(); ++i )
 	{
 		if ((*i).second)
-			(*i).second->deleteInstance();
+			MemoryPoolObject::deleteInstance((*i).second);
 	}
 }
 

--- a/Generals/Code/GameEngine/Source/Common/StateMachine.cpp
+++ b/Generals/Code/GameEngine/Source/Common/StateMachine.cpp
@@ -297,7 +297,7 @@ StateMachine::~StateMachine()
 	for( i = m_stateMap.begin(); i != m_stateMap.end(); ++i )
 	{
 		if ((*i).second)
-			MemoryPoolObject::deleteInstance((*i).second);
+			deleteInstance((*i).second);
 	}
 }
 

--- a/Generals/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
@@ -164,7 +164,7 @@ void BuildAssistant::reset( void )
 		sellInfo = (*it);
 
 		// delete our data and erase this entry from the list
-		sellInfo->deleteInstance();
+		MemoryPoolObject::deleteInstance(sellInfo);
 
 	}  // end for
 
@@ -205,7 +205,7 @@ void BuildAssistant::update( void )
 		if( obj == NULL )
 		{
 
-			sellInfo->deleteInstance();			
+			MemoryPoolObject::deleteInstance(sellInfo);			
 			m_sellList.erase( thisIterator );		
 			continue;
 
@@ -281,7 +281,7 @@ void BuildAssistant::update( void )
 			TheGameLogic->destroyObject( obj );
 
 			// remove this object from the sell list
-			sellInfo->deleteInstance();
+			MemoryPoolObject::deleteInstance(sellInfo);
 			m_sellList.erase( thisIterator );
 
 		}  // end if

--- a/Generals/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
@@ -164,7 +164,7 @@ void BuildAssistant::reset( void )
 		sellInfo = (*it);
 
 		// delete our data and erase this entry from the list
-		MemoryPoolObject::deleteInstance(sellInfo);
+		deleteInstance(sellInfo);
 
 	}  // end for
 
@@ -205,7 +205,7 @@ void BuildAssistant::update( void )
 		if( obj == NULL )
 		{
 
-			MemoryPoolObject::deleteInstance(sellInfo);			
+			deleteInstance(sellInfo);			
 			m_sellList.erase( thisIterator );		
 			continue;
 
@@ -281,7 +281,7 @@ void BuildAssistant::update( void )
 			TheGameLogic->destroyObject( obj );
 
 			// remove this object from the sell list
-			MemoryPoolObject::deleteInstance(sellInfo);
+			deleteInstance(sellInfo);
 			m_sellList.erase( thisIterator );
 
 		}  // end if

--- a/Generals/Code/GameEngine/Source/Common/System/DataChunk.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/DataChunk.cpp
@@ -331,7 +331,7 @@ void DataChunkOutput::closeDataChunk( void )
 	DEBUG_LOG(("Closing chunk %s at %d (%x)\n", m_contents.getName(c->id).str(), here, here));
 #endif
 	m_chunkStack = m_chunkStack->next;
-	c->deleteInstance();
+	MemoryPoolObject::deleteInstance(c);
 }
 
 void DataChunkOutput::writeReal( Real r ) 
@@ -437,7 +437,7 @@ DataChunkTableOfContents::~DataChunkTableOfContents()
 	for( m=m_list; m; m=next )
 	{
 		next = m->next;
-		m->deleteInstance();
+		MemoryPoolObject::deleteInstance(m);
 	}
 }
 
@@ -601,7 +601,7 @@ DataChunkInput::~DataChunkInput()
 	UserParser *p, *next;
 	for (p=m_parserList; p; p=next) {
 		next = p->next;
-		p->deleteInstance();
+		MemoryPoolObject::deleteInstance(p);
 	}
 
 }
@@ -699,7 +699,7 @@ void DataChunkInput::clearChunkStack( void )
 	for( c=m_chunkStack; c; c=next )
 	{
 		next = c->next;
-		c->deleteInstance();
+		MemoryPoolObject::deleteInstance(c);
 	}
 
 	m_chunkStack = NULL;
@@ -772,7 +772,7 @@ void DataChunkInput::closeDataChunk( void )
 	// pop the chunk off the stack
 	InputChunk *c = m_chunkStack;
 	m_chunkStack = m_chunkStack->next;
-	c->deleteInstance();
+	MemoryPoolObject::deleteInstance(c);
 }
 
 

--- a/Generals/Code/GameEngine/Source/Common/System/DataChunk.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/DataChunk.cpp
@@ -331,7 +331,7 @@ void DataChunkOutput::closeDataChunk( void )
 	DEBUG_LOG(("Closing chunk %s at %d (%x)\n", m_contents.getName(c->id).str(), here, here));
 #endif
 	m_chunkStack = m_chunkStack->next;
-	MemoryPoolObject::deleteInstance(c);
+	deleteInstance(c);
 }
 
 void DataChunkOutput::writeReal( Real r ) 
@@ -437,7 +437,7 @@ DataChunkTableOfContents::~DataChunkTableOfContents()
 	for( m=m_list; m; m=next )
 	{
 		next = m->next;
-		MemoryPoolObject::deleteInstance(m);
+		deleteInstance(m);
 	}
 }
 
@@ -601,7 +601,7 @@ DataChunkInput::~DataChunkInput()
 	UserParser *p, *next;
 	for (p=m_parserList; p; p=next) {
 		next = p->next;
-		MemoryPoolObject::deleteInstance(p);
+		deleteInstance(p);
 	}
 
 }
@@ -699,7 +699,7 @@ void DataChunkInput::clearChunkStack( void )
 	for( c=m_chunkStack; c; c=next )
 	{
 		next = c->next;
-		MemoryPoolObject::deleteInstance(c);
+		deleteInstance(c);
 	}
 
 	m_chunkStack = NULL;
@@ -772,7 +772,7 @@ void DataChunkInput::closeDataChunk( void )
 	// pop the chunk off the stack
 	InputChunk *c = m_chunkStack;
 	m_chunkStack = m_chunkStack->next;
-	MemoryPoolObject::deleteInstance(c);
+	deleteInstance(c);
 }
 
 

--- a/Generals/Code/GameEngine/Source/Common/System/File.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/File.cpp
@@ -192,7 +192,7 @@ void File::close( void )
 		m_open = FALSE;
 		if ( m_deleteOnClose )
 		{
-			this->deleteInstance(); // on special cases File object will delete itself when closing
+			MemoryPoolObject::deleteInstance(this); // on special cases File object will delete itself when closing
 		}
 	}
 }

--- a/Generals/Code/GameEngine/Source/Common/System/File.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/File.cpp
@@ -192,7 +192,7 @@ void File::close( void )
 		m_open = FALSE;
 		if ( m_deleteOnClose )
 		{
-			MemoryPoolObject::deleteInstance(this); // on special cases File object will delete itself when closing
+			deleteInstance(this); // on special cases File object will delete itself when closing
 		}
 	}
 }

--- a/Generals/Code/GameEngine/Source/Common/System/LocalFile.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/LocalFile.cpp
@@ -592,14 +592,14 @@ File* LocalFile::convertToRAMFile()
 		else
 		{
 			this->close();
-			MemoryPoolObject::deleteInstance(this);
+			deleteInstance(this);
 		}
 		return ramFile;
 	}	
 	else 
 	{
 		ramFile->close();
-		MemoryPoolObject::deleteInstance(ramFile);
+		deleteInstance(ramFile);
 		return this;
 	}
 }

--- a/Generals/Code/GameEngine/Source/Common/System/LocalFile.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/LocalFile.cpp
@@ -592,14 +592,14 @@ File* LocalFile::convertToRAMFile()
 		else
 		{
 			this->close();
-			this->deleteInstance();
+			MemoryPoolObject::deleteInstance(this);
 		}
 		return ramFile;
 	}	
 	else 
 	{
 		ramFile->close();
-		ramFile->deleteInstance();
+		MemoryPoolObject::deleteInstance(ramFile);
 		return this;
 	}
 }

--- a/Generals/Code/GameEngine/Source/Common/System/Radar.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/Radar.cpp
@@ -83,7 +83,7 @@ void Radar::deleteListResources( void )
 		m_localObjectList->friend_getObject()->friend_setRadarData( NULL );
 
 		// delete the head of the list
-		MemoryPoolObject::deleteInstance(m_localObjectList);
+		deleteInstance(m_localObjectList);
 
 		// set head of the list to the next object
 		m_localObjectList = nextObject;
@@ -101,7 +101,7 @@ void Radar::deleteListResources( void )
 		m_objectList->friend_getObject()->friend_setRadarData( NULL );
 
 		// delete the head of the list
-		MemoryPoolObject::deleteInstance(m_objectList);
+		deleteInstance(m_objectList);
 
 		// set head of the list to the next object
 		m_objectList = nextObject;
@@ -570,7 +570,7 @@ Bool Radar::deleteFromList( Object *obj, RadarObject **list )
 			obj->friend_setRadarData( NULL );
 
 			// delete the object instance
-			MemoryPoolObject::deleteInstance(radarObject);
+			deleteInstance(radarObject);
 
 			// all done, object found and deleted
 			return TRUE;

--- a/Generals/Code/GameEngine/Source/Common/System/Radar.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/Radar.cpp
@@ -83,7 +83,7 @@ void Radar::deleteListResources( void )
 		m_localObjectList->friend_getObject()->friend_setRadarData( NULL );
 
 		// delete the head of the list
-		m_localObjectList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_localObjectList);
 
 		// set head of the list to the next object
 		m_localObjectList = nextObject;
@@ -101,7 +101,7 @@ void Radar::deleteListResources( void )
 		m_objectList->friend_getObject()->friend_setRadarData( NULL );
 
 		// delete the head of the list
-		m_objectList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_objectList);
 
 		// set head of the list to the next object
 		m_objectList = nextObject;
@@ -570,7 +570,7 @@ Bool Radar::deleteFromList( Object *obj, RadarObject **list )
 			obj->friend_setRadarData( NULL );
 
 			// delete the object instance
-			radarObject->deleteInstance();
+			MemoryPoolObject::deleteInstance(radarObject);
 
 			// all done, object found and deleted
 			return TRUE;

--- a/Generals/Code/GameEngine/Source/Common/System/Upgrade.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/Upgrade.cpp
@@ -244,7 +244,7 @@ UpgradeCenter::~UpgradeCenter( void )
 		next = m_upgradeList->friend_getNext();
 
 		// delete head of list
-		MemoryPoolObject::deleteInstance(m_upgradeList);
+		deleteInstance(m_upgradeList);
 
 		// set head to next element
 		m_upgradeList = next;

--- a/Generals/Code/GameEngine/Source/Common/System/Upgrade.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/Upgrade.cpp
@@ -244,7 +244,7 @@ UpgradeCenter::~UpgradeCenter( void )
 		next = m_upgradeList->friend_getNext();
 
 		// delete head of list
-		m_upgradeList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_upgradeList);
 
 		// set head to next element
 		m_upgradeList = next;

--- a/Generals/Code/GameEngine/Source/Common/TerrainTypes.cpp
+++ b/Generals/Code/GameEngine/Source/Common/TerrainTypes.cpp
@@ -99,7 +99,7 @@ TerrainTypeCollection::~TerrainTypeCollection( void )
 		temp = m_terrainList->friend_getNext();
 
 		// delete the head of the type list
-		MemoryPoolObject::deleteInstance(m_terrainList);
+		deleteInstance(m_terrainList);
 
 		// set the new head of the type list
 		m_terrainList = temp;

--- a/Generals/Code/GameEngine/Source/Common/TerrainTypes.cpp
+++ b/Generals/Code/GameEngine/Source/Common/TerrainTypes.cpp
@@ -99,7 +99,7 @@ TerrainTypeCollection::~TerrainTypeCollection( void )
 		temp = m_terrainList->friend_getNext();
 
 		// delete the head of the type list
-		m_terrainList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_terrainList);
 
 		// set the new head of the type list
 		m_terrainList = temp;

--- a/Generals/Code/GameEngine/Source/Common/Thing/ThingFactory.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Thing/ThingFactory.cpp
@@ -74,7 +74,7 @@ void ThingFactory::freeDatabase( void )
 	{
 		ThingTemplate* tmpl = m_firstTemplate;
 		m_firstTemplate = m_firstTemplate->friend_getNextTemplate();
-		MemoryPoolObject::deleteInstance(tmpl);
+		deleteInstance(tmpl);
 	}
 
 	m_templateHashMap.clear();

--- a/Generals/Code/GameEngine/Source/Common/Thing/ThingFactory.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Thing/ThingFactory.cpp
@@ -74,7 +74,7 @@ void ThingFactory::freeDatabase( void )
 	{
 		ThingTemplate* tmpl = m_firstTemplate;
 		m_firstTemplate = m_firstTemplate->friend_getNextTemplate();
-		tmpl->deleteInstance();
+		MemoryPoolObject::deleteInstance(tmpl);
 	}
 
 	m_templateHashMap.clear();

--- a/Generals/Code/GameEngine/Source/GameClient/Display.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Display.cpp
@@ -309,7 +309,7 @@ void Display::update( void )
 				{
 					//display the copyrighttext;		
 					if(m_copyrightDisplayString)
-						m_copyrightDisplayString->deleteInstance();
+						MemoryPoolObject::deleteInstance(m_copyrightDisplayString);
 					m_copyrightDisplayString = TheDisplayStringManager->newDisplayString();
 					m_copyrightDisplayString->setText(TheGameText->fetch("GUI:EACopyright"));
 					if (TheGlobalLanguageData && TheGlobalLanguageData->m_copyrightFont.name.isNotEmpty())

--- a/Generals/Code/GameEngine/Source/GameClient/Display.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Display.cpp
@@ -309,7 +309,7 @@ void Display::update( void )
 				{
 					//display the copyrighttext;		
 					if(m_copyrightDisplayString)
-						MemoryPoolObject::deleteInstance(m_copyrightDisplayString);
+						deleteInstance(m_copyrightDisplayString);
 					m_copyrightDisplayString = TheDisplayStringManager->newDisplayString();
 					m_copyrightDisplayString->setText(TheGameText->fetch("GUI:EACopyright"));
 					if (TheGlobalLanguageData && TheGlobalLanguageData->m_copyrightFont.name.isNotEmpty())

--- a/Generals/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -136,7 +136,7 @@ void DrawableIconInfo::clear()
 	for (int i = 0; i < MAX_ICONS; ++i)
 	{
 		if (m_icon[i])
-			MemoryPoolObject::deleteInstance(m_icon[i]);
+			deleteInstance(m_icon[i]);
 		m_icon[i] = NULL;
 		m_keepTillFrame[i] = 0;
 	}
@@ -148,7 +148,7 @@ void DrawableIconInfo::killIcon(DrawableIconType t)
 {
 	if (m_icon[t])
 	{
-		MemoryPoolObject::deleteInstance(m_icon[t]);
+		deleteInstance(m_icon[t]);
 		m_icon[t] = NULL;
 		m_keepTillFrame[t] = 0;
 	}
@@ -500,7 +500,7 @@ Drawable::~Drawable()
 	{
 		for (Module** m = m_modules[i]; m && *m; ++m)
 		{
-			MemoryPoolObject::deleteInstance((*m));
+			deleteInstance(*m);
 			*m = NULL;	// in case other modules call findModule from their dtor!
 		}
 		delete [] m_modules[i]; 
@@ -510,7 +510,7 @@ Drawable::~Drawable()
 	stopAmbientSound();
 	if (m_ambientSound)
 	{
-		MemoryPoolObject::deleteInstance(m_ambientSound);
+		deleteInstance(m_ambientSound);
 		m_ambientSound = NULL;
 	}
 
@@ -524,17 +524,17 @@ Drawable::~Drawable()
 
 	// delete any icons present
 	if (m_iconInfo)
-		MemoryPoolObject::deleteInstance(m_iconInfo);
+		deleteInstance(m_iconInfo);
 
 	if (m_selectionFlashEnvelope)
-		MemoryPoolObject::deleteInstance(m_selectionFlashEnvelope);
+		deleteInstance(m_selectionFlashEnvelope);
 
 	if (m_colorTintEnvelope)
-		MemoryPoolObject::deleteInstance(m_colorTintEnvelope);
+		deleteInstance(m_colorTintEnvelope);
 
 	if (m_locoInfo)
 	{
-		MemoryPoolObject::deleteInstance(m_locoInfo);
+		deleteInstance(m_locoInfo);
 		m_locoInfo = NULL;
 	}
 }
@@ -3916,7 +3916,7 @@ void Drawable::startAmbientSound(BodyDamageType dt, TimeOfDay tod)
 		else
 		{
 			DEBUG_CRASH( ("Ambient sound %s missing! Skipping...", m_ambientSound->m_event.getEventName().str() ) );
-			MemoryPoolObject::deleteInstance(m_ambientSound);
+			deleteInstance(m_ambientSound);
 			m_ambientSound = NULL;
 		}
 	}
@@ -4277,7 +4277,7 @@ void Drawable::xfer( Xfer *xfer )
 	if( xfer->getXferMode() == XFER_LOAD && m_ambientSound )
 	{
 		TheAudio->killAudioEventImmediately( m_ambientSound->m_event.getPlayingHandle() );
-		MemoryPoolObject::deleteInstance(m_ambientSound);
+		deleteInstance(m_ambientSound);
 		m_ambientSound = NULL;
 	}
 

--- a/Generals/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -136,7 +136,7 @@ void DrawableIconInfo::clear()
 	for (int i = 0; i < MAX_ICONS; ++i)
 	{
 		if (m_icon[i])
-			m_icon[i]->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_icon[i]);
 		m_icon[i] = NULL;
 		m_keepTillFrame[i] = 0;
 	}
@@ -148,7 +148,7 @@ void DrawableIconInfo::killIcon(DrawableIconType t)
 {
 	if (m_icon[t])
 	{
-		m_icon[t]->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_icon[t]);
 		m_icon[t] = NULL;
 		m_keepTillFrame[t] = 0;
 	}
@@ -500,7 +500,7 @@ Drawable::~Drawable()
 	{
 		for (Module** m = m_modules[i]; m && *m; ++m)
 		{
-			(*m)->deleteInstance();
+			MemoryPoolObject::deleteInstance((*m));
 			*m = NULL;	// in case other modules call findModule from their dtor!
 		}
 		delete [] m_modules[i]; 
@@ -510,7 +510,7 @@ Drawable::~Drawable()
 	stopAmbientSound();
 	if (m_ambientSound)
 	{
-		m_ambientSound->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_ambientSound);
 		m_ambientSound = NULL;
 	}
 
@@ -524,17 +524,17 @@ Drawable::~Drawable()
 
 	// delete any icons present
 	if (m_iconInfo)
-		m_iconInfo->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_iconInfo);
 
 	if (m_selectionFlashEnvelope)
-		m_selectionFlashEnvelope->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_selectionFlashEnvelope);
 
 	if (m_colorTintEnvelope)
-		m_colorTintEnvelope->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_colorTintEnvelope);
 
 	if (m_locoInfo)
 	{
-		m_locoInfo->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_locoInfo);
 		m_locoInfo = NULL;
 	}
 }
@@ -3916,7 +3916,7 @@ void Drawable::startAmbientSound(BodyDamageType dt, TimeOfDay tod)
 		else
 		{
 			DEBUG_CRASH( ("Ambient sound %s missing! Skipping...", m_ambientSound->m_event.getEventName().str() ) );
-			m_ambientSound->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_ambientSound);
 			m_ambientSound = NULL;
 		}
 	}
@@ -4277,7 +4277,7 @@ void Drawable::xfer( Xfer *xfer )
 	if( xfer->getXferMode() == XFER_LOAD && m_ambientSound )
 	{
 		TheAudio->killAudioEventImmediately( m_ambientSound->m_event.getPlayingHandle() );
-		m_ambientSound->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_ambientSound);
 		m_ambientSound = NULL;
 	}
 

--- a/Generals/Code/GameEngine/Source/GameClient/Eva.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Eva.cpp
@@ -178,7 +178,7 @@ Eva::~Eva()
 	EvaCheckInfoPtrVecIt it;
 	for (it = m_allCheckInfos.begin(); it != m_allCheckInfos.end(); ++it) {
 		if (*it)
-			MemoryPoolObject::deleteInstance((*it));
+			deleteInstance(*it);
 	}
 }
 

--- a/Generals/Code/GameEngine/Source/GameClient/Eva.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Eva.cpp
@@ -178,7 +178,7 @@ Eva::~Eva()
 	EvaCheckInfoPtrVecIt it;
 	for (it = m_allCheckInfos.begin(); it != m_allCheckInfos.end(); ++it) {
 		if (*it)
-			(*it)->deleteInstance();
+			MemoryPoolObject::deleteInstance((*it));
 	}
 }
 

--- a/Generals/Code/GameEngine/Source/GameClient/FXList.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/FXList.cpp
@@ -797,7 +797,7 @@ void FXList::clear()
 	for (FXNuggetList::iterator it = m_nuggets.begin(); it != m_nuggets.end(); ++it)
 	{
 		if (*it)
-			MemoryPoolObject::deleteInstance((*it));
+			deleteInstance(*it);
 	}
 	m_nuggets.clear();
 }

--- a/Generals/Code/GameEngine/Source/GameClient/FXList.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/FXList.cpp
@@ -797,7 +797,7 @@ void FXList::clear()
 	for (FXNuggetList::iterator it = m_nuggets.begin(); it != m_nuggets.end(); ++it)
 	{
 		if (*it)
-			(*it)->deleteInstance();
+			MemoryPoolObject::deleteInstance((*it));
 	}
 	m_nuggets.clear();
 }

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/AnimateWindowManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/AnimateWindowManager.cpp
@@ -117,7 +117,7 @@ static void clearWinList(AnimateWindowList &winList)
 		win = *(winList.begin());
 		winList.pop_front();
 		if (win)
-			win->deleteInstance();
+			MemoryPoolObject::deleteInstance(win);
 		win = NULL;
 	}
 }

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/AnimateWindowManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/AnimateWindowManager.cpp
@@ -117,7 +117,7 @@ static void clearWinList(AnimateWindowList &winList)
 		win = *(winList.begin());
 		winList.pop_front();
 		if (win)
-			MemoryPoolObject::deleteInstance(win);
+			deleteInstance(win);
 		win = NULL;
 	}
 }

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -953,7 +953,7 @@ ControlBar::~ControlBar( void )
 	if(m_scienceLayout)
 	{
 		m_scienceLayout->destroyWindows();
-		m_scienceLayout->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_scienceLayout);
 	}
 	m_scienceLayout = NULL;
 	m_genArrow = NULL;
@@ -985,7 +985,7 @@ ControlBar::~ControlBar( void )
 	while( m_commandSets )
 	{
 		set = m_commandSets->friend_getNext();
-		m_commandSets->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_commandSets);
 		m_commandSets = set;
 
 	}  // end while
@@ -995,21 +995,21 @@ ControlBar::~ControlBar( void )
 	while( m_commandButtons )
 	{
 		button = m_commandButtons->friend_getNext();
-		m_commandButtons->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_commandButtons);
 		m_commandButtons = button;
 
 	}  // end while
 	if(m_buildToolTipLayout)
 	{
 		m_buildToolTipLayout->destroyWindows();
-		m_buildToolTipLayout->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_buildToolTipLayout);
 		m_buildToolTipLayout = NULL;
 	}
 
 	if(m_specialPowerLayout)
 	{
 		m_specialPowerLayout->destroyWindows();
-		m_specialPowerLayout->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_specialPowerLayout);
 		m_specialPowerLayout = NULL;
 	}
 
@@ -3193,7 +3193,7 @@ void ControlBar::initSpecialPowershortcutBar( Player *player)
 	if(m_specialPowerLayout)
 	{
 		m_specialPowerLayout->destroyWindows();
-		m_specialPowerLayout->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_specialPowerLayout);
 		m_specialPowerLayout = NULL;
 	}
 	m_specialPowerShortcutParent = NULL;

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -953,7 +953,7 @@ ControlBar::~ControlBar( void )
 	if(m_scienceLayout)
 	{
 		m_scienceLayout->destroyWindows();
-		MemoryPoolObject::deleteInstance(m_scienceLayout);
+		deleteInstance(m_scienceLayout);
 	}
 	m_scienceLayout = NULL;
 	m_genArrow = NULL;
@@ -985,7 +985,7 @@ ControlBar::~ControlBar( void )
 	while( m_commandSets )
 	{
 		set = m_commandSets->friend_getNext();
-		MemoryPoolObject::deleteInstance(m_commandSets);
+		deleteInstance(m_commandSets);
 		m_commandSets = set;
 
 	}  // end while
@@ -995,21 +995,21 @@ ControlBar::~ControlBar( void )
 	while( m_commandButtons )
 	{
 		button = m_commandButtons->friend_getNext();
-		MemoryPoolObject::deleteInstance(m_commandButtons);
+		deleteInstance(m_commandButtons);
 		m_commandButtons = button;
 
 	}  // end while
 	if(m_buildToolTipLayout)
 	{
 		m_buildToolTipLayout->destroyWindows();
-		MemoryPoolObject::deleteInstance(m_buildToolTipLayout);
+		deleteInstance(m_buildToolTipLayout);
 		m_buildToolTipLayout = NULL;
 	}
 
 	if(m_specialPowerLayout)
 	{
 		m_specialPowerLayout->destroyWindows();
-		MemoryPoolObject::deleteInstance(m_specialPowerLayout);
+		deleteInstance(m_specialPowerLayout);
 		m_specialPowerLayout = NULL;
 	}
 
@@ -3193,7 +3193,7 @@ void ControlBar::initSpecialPowershortcutBar( Player *player)
 	if(m_specialPowerLayout)
 	{
 		m_specialPowerLayout->destroyWindows();
-		MemoryPoolObject::deleteInstance(m_specialPowerLayout);
+		deleteInstance(m_specialPowerLayout);
 		m_specialPowerLayout = NULL;
 	}
 	m_specialPowerShortcutParent = NULL;

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarPrintPositions.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarPrintPositions.cpp
@@ -95,7 +95,7 @@ void PrintOffsetsFromControlBarParent( void )
 
 	fclose(fp);
 	layout->destroyWindows();
-	layout->deleteInstance();
+	MemoryPoolObject::deleteInstance(layout);
 }
 
 

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarPrintPositions.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarPrintPositions.cpp
@@ -95,7 +95,7 @@ void PrintOffsetsFromControlBarParent( void )
 
 	fclose(fp);
 	layout->destroyWindows();
-	MemoryPoolObject::deleteInstance(layout);
+	deleteInstance(layout);
 }
 
 

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/ControlBarPopupDescription.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/ControlBarPopupDescription.cpp
@@ -163,7 +163,7 @@ void ControlBar::showBuildTooltipLayout( GameWindow *cmdButton )
 		else
 		{
 //			m_buildToolTipLayout->destroyWindows();
-//			MemoryPoolObject::deleteInstance(m_buildToolTipLayout);
+//			deleteInstance(m_buildToolTipLayout);
 //			m_buildToolTipLayout = NULL;
 			m_buildToolTipLayout->hide(TRUE);
 			prevWindow = NULL;
@@ -206,7 +206,7 @@ void ControlBar::showBuildTooltipLayout( GameWindow *cmdButton )
 		//	if (m_buildToolTipLayout)
 		//	{
 		//		m_buildToolTipLayout->destroyWindows();
-		//		MemoryPoolObject::deleteInstance(m_buildToolTipLayout);
+		//		deleteInstance(m_buildToolTipLayout);
 		//
 		//	}
 
@@ -649,7 +649,7 @@ void ControlBar::deleteBuildTooltipLayout( void )
 //		return;
 //	
 //	m_buildToolTipLayout->destroyWindows();
-//	MemoryPoolObject::deleteInstance(m_buildToolTipLayout);
+//	deleteInstance(m_buildToolTipLayout);
 //	m_buildToolTipLayout = NULL;
 	if(theAnimateWindowManager)
 		delete theAnimateWindowManager;

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/ControlBarPopupDescription.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/ControlBarPopupDescription.cpp
@@ -163,7 +163,7 @@ void ControlBar::showBuildTooltipLayout( GameWindow *cmdButton )
 		else
 		{
 //			m_buildToolTipLayout->destroyWindows();
-//			m_buildToolTipLayout->deleteInstance();
+//			MemoryPoolObject::deleteInstance(m_buildToolTipLayout);
 //			m_buildToolTipLayout = NULL;
 			m_buildToolTipLayout->hide(TRUE);
 			prevWindow = NULL;
@@ -206,7 +206,7 @@ void ControlBar::showBuildTooltipLayout( GameWindow *cmdButton )
 		//	if (m_buildToolTipLayout)
 		//	{
 		//		m_buildToolTipLayout->destroyWindows();
-		//		m_buildToolTipLayout->deleteInstance();
+		//		MemoryPoolObject::deleteInstance(m_buildToolTipLayout);
 		//
 		//	}
 
@@ -649,7 +649,7 @@ void ControlBar::deleteBuildTooltipLayout( void )
 //		return;
 //	
 //	m_buildToolTipLayout->destroyWindows();
-//	m_buildToolTipLayout->deleteInstance();
+//	MemoryPoolObject::deleteInstance(m_buildToolTipLayout);
 //	m_buildToolTipLayout = NULL;
 	if(theAnimateWindowManager)
 		delete theAnimateWindowManager;

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Diplomacy.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Diplomacy.cpp
@@ -290,7 +290,7 @@ void ResetDiplomacy( void )
 	{
 		TheInGameUI->unregisterWindowLayout(theLayout);
 		theLayout->destroyWindows();
-		theLayout->deleteInstance();
+		MemoryPoolObject::deleteInstance(theLayout);
 		InitBuddyControls(-1);
 	}
 	theLayout = NULL;

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Diplomacy.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Diplomacy.cpp
@@ -290,7 +290,7 @@ void ResetDiplomacy( void )
 	{
 		TheInGameUI->unregisterWindowLayout(theLayout);
 		theLayout->destroyWindows();
-		MemoryPoolObject::deleteInstance(theLayout);
+		deleteInstance(theLayout);
 		InitBuddyControls(-1);
 	}
 	theLayout = NULL;

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/DifficultySelect.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/DifficultySelect.cpp
@@ -259,7 +259,7 @@ WindowMsgHandledType DifficultySelectSystem( GameWindow *window, UnsignedInt msg
 				//TheScriptEngine->setGlobalDifficulty(s_AIDiff); // CANNOT DO THIS! REPLAYS WILL BREAK!
 				WindowLayout *layout = window->winGetLayout();
 				layout->destroyWindows();
-				layout->deleteInstance();
+				MemoryPoolObject::deleteInstance(layout);
 				setupGameStart(TheCampaignManager->getCurrentMap(), s_AIDiff);
 				// start the game
 			}
@@ -269,7 +269,7 @@ WindowMsgHandledType DifficultySelectSystem( GameWindow *window, UnsignedInt msg
 				TheWindowManager->winUnsetModal(window);
 				WindowLayout *layout = window->winGetLayout();
 				layout->destroyWindows();
-				layout->deleteInstance();
+				MemoryPoolObject::deleteInstance(layout);
 				
 			}
 			else if ( controlID == radioButtonEasyAIID )

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/DifficultySelect.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/DifficultySelect.cpp
@@ -259,7 +259,7 @@ WindowMsgHandledType DifficultySelectSystem( GameWindow *window, UnsignedInt msg
 				//TheScriptEngine->setGlobalDifficulty(s_AIDiff); // CANNOT DO THIS! REPLAYS WILL BREAK!
 				WindowLayout *layout = window->winGetLayout();
 				layout->destroyWindows();
-				MemoryPoolObject::deleteInstance(layout);
+				deleteInstance(layout);
 				setupGameStart(TheCampaignManager->getCurrentMap(), s_AIDiff);
 				// start the game
 			}
@@ -269,7 +269,7 @@ WindowMsgHandledType DifficultySelectSystem( GameWindow *window, UnsignedInt msg
 				TheWindowManager->winUnsetModal(window);
 				WindowLayout *layout = window->winGetLayout();
 				layout->destroyWindows();
-				MemoryPoolObject::deleteInstance(layout);
+				deleteInstance(layout);
 				
 			}
 			else if ( controlID == radioButtonEasyAIID )

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/DownloadMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/DownloadMenu.cpp
@@ -85,7 +85,7 @@ static void closeDownloadWindow( void )
   WindowLayout *menuLayout = parent->winGetLayout();
 	menuLayout->runShutdown();
   menuLayout->destroyWindows();
-	MemoryPoolObject::deleteInstance(menuLayout);
+	deleteInstance(menuLayout);
 	menuLayout = NULL;
 
 	GameWindow *mainWin = TheWindowManager->winGetWindowFromId( NULL, NAMEKEY("MainMenu.wnd:MainMenuParent") );

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/DownloadMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/DownloadMenu.cpp
@@ -85,7 +85,7 @@ static void closeDownloadWindow( void )
   WindowLayout *menuLayout = parent->winGetLayout();
 	menuLayout->runShutdown();
   menuLayout->destroyWindows();
-	menuLayout->deleteInstance();
+	MemoryPoolObject::deleteInstance(menuLayout);
 	menuLayout = NULL;
 
 	GameWindow *mainWin = TheWindowManager->winGetWindowFromId( NULL, NAMEKEY("MainMenu.wnd:MainMenuParent") );

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/EstablishConnectionsWindow.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/EstablishConnectionsWindow.cpp
@@ -157,7 +157,7 @@ void HideEstablishConnectionsWindow( void ) {
 //	establishConnectionsLayout->hide(TRUE);
 //	TheWindowManager->winDestroy(establishConnectionsLayout);
 	establishConnectionsLayout->destroyWindows();
-	establishConnectionsLayout->deleteInstance();
+	MemoryPoolObject::deleteInstance(establishConnectionsLayout);
 	establishConnectionsLayout = NULL;
 	if (!TheGameSpyGame->isQMGame())
 	{

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/EstablishConnectionsWindow.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/EstablishConnectionsWindow.cpp
@@ -157,7 +157,7 @@ void HideEstablishConnectionsWindow( void ) {
 //	establishConnectionsLayout->hide(TRUE);
 //	TheWindowManager->winDestroy(establishConnectionsLayout);
 	establishConnectionsLayout->destroyWindows();
-	MemoryPoolObject::deleteInstance(establishConnectionsLayout);
+	deleteInstance(establishConnectionsLayout);
 	establishConnectionsLayout = NULL;
 	if (!TheGameSpyGame->isQMGame())
 	{

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/GameInfoWindow.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/GameInfoWindow.cpp
@@ -94,7 +94,7 @@ void DestroyGameInfoWindow(void)
 	if (gameInfoWindowLayout)
 	{
 		gameInfoWindowLayout->destroyWindows();
-		MemoryPoolObject::deleteInstance(gameInfoWindowLayout);
+		deleteInstance(gameInfoWindowLayout);
 		gameInfoWindowLayout = NULL;		
 	}
 }

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/GameInfoWindow.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/GameInfoWindow.cpp
@@ -94,7 +94,7 @@ void DestroyGameInfoWindow(void)
 	if (gameInfoWindowLayout)
 	{
 		gameInfoWindowLayout->destroyWindows();
-		gameInfoWindowLayout->deleteInstance();
+		MemoryPoolObject::deleteInstance(gameInfoWindowLayout);
 		gameInfoWindowLayout = NULL;		
 	}
 }

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanGameOptionsMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanGameOptionsMenu.cpp
@@ -1113,7 +1113,7 @@ WindowMsgHandledType LanGameOptionsMenuSystem( GameWindow *window, UnsignedInt m
 					if( mapSelectLayout )
 						{
 							mapSelectLayout->destroyWindows();
-							mapSelectLayout->deleteInstance();
+							MemoryPoolObject::deleteInstance(mapSelectLayout);
 							mapSelectLayout = NULL;
 						}
 					TheLAN->RequestGameLeave();

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanGameOptionsMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanGameOptionsMenu.cpp
@@ -1113,7 +1113,7 @@ WindowMsgHandledType LanGameOptionsMenuSystem( GameWindow *window, UnsignedInt m
 					if( mapSelectLayout )
 						{
 							mapSelectLayout->destroyWindows();
-							MemoryPoolObject::deleteInstance(mapSelectLayout);
+							deleteInstance(mapSelectLayout);
 							mapSelectLayout = NULL;
 						}
 					TheLAN->RequestGameLeave();

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanMapSelectMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanMapSelectMenu.cpp
@@ -345,7 +345,7 @@ WindowMsgHandledType LanMapSelectMenuSystem( GameWindow *window, UnsignedInt msg
 			{
 				
 				mapSelectLayout->destroyWindows();
-				MemoryPoolObject::deleteInstance(mapSelectLayout);
+				deleteInstance(mapSelectLayout);
 				mapSelectLayout = NULL;
 				// set the controls to NULL since they've been destroyed.
 				NullifyControls();
@@ -391,7 +391,7 @@ WindowMsgHandledType LanMapSelectMenuSystem( GameWindow *window, UnsignedInt msg
 
 					
 					mapSelectLayout->destroyWindows();
-					MemoryPoolObject::deleteInstance(mapSelectLayout);
+					deleteInstance(mapSelectLayout);
 					mapSelectLayout = NULL;
 
 					// set the controls to NULL since they've been destroyed.

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanMapSelectMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanMapSelectMenu.cpp
@@ -345,7 +345,7 @@ WindowMsgHandledType LanMapSelectMenuSystem( GameWindow *window, UnsignedInt msg
 			{
 				
 				mapSelectLayout->destroyWindows();
-				mapSelectLayout->deleteInstance();
+				MemoryPoolObject::deleteInstance(mapSelectLayout);
 				mapSelectLayout = NULL;
 				// set the controls to NULL since they've been destroyed.
 				NullifyControls();
@@ -391,7 +391,7 @@ WindowMsgHandledType LanMapSelectMenuSystem( GameWindow *window, UnsignedInt msg
 
 					
 					mapSelectLayout->destroyWindows();
-					mapSelectLayout->deleteInstance();
+					MemoryPoolObject::deleteInstance(mapSelectLayout);
 					mapSelectLayout = NULL;
 
 					// set the controls to NULL since they've been destroyed.

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupCommunicator.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupCommunicator.cpp
@@ -186,7 +186,7 @@ WindowMsgHandledType PopupCommunicatorSystem( GameWindow *window, UnsignedInt ms
 			{
         WindowLayout *popupCommunicatorLayout = window->winGetLayout();
         popupCommunicatorLayout->destroyWindows();
-				popupCommunicatorLayout->deleteInstance();
+				MemoryPoolObject::deleteInstance(popupCommunicatorLayout);
 				popupCommunicatorLayout = NULL;
 			}  // end if
 	

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupCommunicator.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupCommunicator.cpp
@@ -186,7 +186,7 @@ WindowMsgHandledType PopupCommunicatorSystem( GameWindow *window, UnsignedInt ms
 			{
         WindowLayout *popupCommunicatorLayout = window->winGetLayout();
         popupCommunicatorLayout->destroyWindows();
-				MemoryPoolObject::deleteInstance(popupCommunicatorLayout);
+				deleteInstance(popupCommunicatorLayout);
 				popupCommunicatorLayout = NULL;
 			}  // end if
 	

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupLadderSelect.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupLadderSelect.cpp
@@ -596,7 +596,7 @@ static void closeRightClickMenu(GameWindow *win)
 		if(!winLay)
 			return;
 		winLay->destroyWindows();					
-		MemoryPoolObject::deleteInstance(winLay);
+		deleteInstance(winLay);
 		winLay = NULL;
 
 	}

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupLadderSelect.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupLadderSelect.cpp
@@ -596,7 +596,7 @@ static void closeRightClickMenu(GameWindow *win)
 		if(!winLay)
 			return;
 		winLay->destroyWindows();					
-		winLay->deleteInstance();
+		MemoryPoolObject::deleteInstance(winLay);
 		winLay = NULL;
 
 	}

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/QuitMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/QuitMenu.cpp
@@ -121,13 +121,13 @@ void destroyQuitMenu()
 	if(fullQuitMenuLayout)
 	{
 		fullQuitMenuLayout->destroyWindows();
-		MemoryPoolObject::deleteInstance(fullQuitMenuLayout);
+		deleteInstance(fullQuitMenuLayout);
 	}
 	fullQuitMenuLayout = NULL;
 	if(noSaveLoadQuitMenuLayout)
 	{
 		noSaveLoadQuitMenuLayout->destroyWindows();
-		MemoryPoolObject::deleteInstance(noSaveLoadQuitMenuLayout);
+		deleteInstance(noSaveLoadQuitMenuLayout);
 	}
 	noSaveLoadQuitMenuLayout = NULL;
 	quitMenuLayout = NULL;

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/QuitMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/QuitMenu.cpp
@@ -121,13 +121,13 @@ void destroyQuitMenu()
 	if(fullQuitMenuLayout)
 	{
 		fullQuitMenuLayout->destroyWindows();
-		fullQuitMenuLayout->deleteInstance();
+		MemoryPoolObject::deleteInstance(fullQuitMenuLayout);
 	}
 	fullQuitMenuLayout = NULL;
 	if(noSaveLoadQuitMenuLayout)
 	{
 		noSaveLoadQuitMenuLayout->destroyWindows();
-		noSaveLoadQuitMenuLayout->deleteInstance();
+		MemoryPoolObject::deleteInstance(noSaveLoadQuitMenuLayout);
 	}
 	noSaveLoadQuitMenuLayout = NULL;
 	quitMenuLayout = NULL;

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
@@ -760,7 +760,7 @@ void finishSinglePlayerInit( void )
 
 	//
 	s_blankLayout->destroyWindows();
-	MemoryPoolObject::deleteInstance(s_blankLayout);
+	deleteInstance(s_blankLayout);
 	s_blankLayout = NULL;
 
 	// set keyboard focus to main parent

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
@@ -760,7 +760,7 @@ void finishSinglePlayerInit( void )
 
 	//
 	s_blankLayout->destroyWindows();
-	s_blankLayout->deleteInstance();
+	MemoryPoolObject::deleteInstance(s_blankLayout);
 	s_blankLayout = NULL;
 
 	// set keyboard focus to main parent

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishGameOptionsMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishGameOptionsMenu.cpp
@@ -1507,7 +1507,7 @@ WindowMsgHandledType SkirmishGameOptionsMenuSystem( GameWindow *window, Unsigned
 					if( skirmishMapSelectLayout )
 						{
 							skirmishMapSelectLayout->destroyWindows();
-							skirmishMapSelectLayout->deleteInstance();
+							MemoryPoolObject::deleteInstance(skirmishMapSelectLayout);
 							skirmishMapSelectLayout = NULL;
 						}
 					TheShell->pop();

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishGameOptionsMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishGameOptionsMenu.cpp
@@ -1507,7 +1507,7 @@ WindowMsgHandledType SkirmishGameOptionsMenuSystem( GameWindow *window, Unsigned
 					if( skirmishMapSelectLayout )
 						{
 							skirmishMapSelectLayout->destroyWindows();
-							MemoryPoolObject::deleteInstance(skirmishMapSelectLayout);
+							deleteInstance(skirmishMapSelectLayout);
 							skirmishMapSelectLayout = NULL;
 						}
 					TheShell->pop();

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishMapSelectMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishMapSelectMenu.cpp
@@ -522,7 +522,7 @@ WindowMsgHandledType SkirmishMapSelectMenuSystem( GameWindow *window, UnsignedIn
 				showSkirmishGameOptionsUnderlyingGUIElements(TRUE);
 
 				skirmishMapSelectLayout->destroyWindows();
-				MemoryPoolObject::deleteInstance(skirmishMapSelectLayout);
+				deleteInstance(skirmishMapSelectLayout);
 				skirmishMapSelectLayout = NULL;
 				skirmishPositionStartSpots();
 				//TheShell->pop();
@@ -584,7 +584,7 @@ WindowMsgHandledType SkirmishMapSelectMenuSystem( GameWindow *window, UnsignedIn
 					skirmishUpdateSlotList();
 
 					skirmishMapSelectLayout->destroyWindows();
-					MemoryPoolObject::deleteInstance(skirmishMapSelectLayout);
+					deleteInstance(skirmishMapSelectLayout);
 					skirmishMapSelectLayout = NULL;
 					//TheShell->pop();
 

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishMapSelectMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishMapSelectMenu.cpp
@@ -522,7 +522,7 @@ WindowMsgHandledType SkirmishMapSelectMenuSystem( GameWindow *window, UnsignedIn
 				showSkirmishGameOptionsUnderlyingGUIElements(TRUE);
 
 				skirmishMapSelectLayout->destroyWindows();
-				skirmishMapSelectLayout->deleteInstance();
+				MemoryPoolObject::deleteInstance(skirmishMapSelectLayout);
 				skirmishMapSelectLayout = NULL;
 				skirmishPositionStartSpots();
 				//TheShell->pop();
@@ -584,7 +584,7 @@ WindowMsgHandledType SkirmishMapSelectMenuSystem( GameWindow *window, UnsignedIn
 					skirmishUpdateSlotList();
 
 					skirmishMapSelectLayout->destroyWindows();
-					skirmishMapSelectLayout->deleteInstance();
+					MemoryPoolObject::deleteInstance(skirmishMapSelectLayout);
 					skirmishMapSelectLayout = NULL;
 					//TheShell->pop();
 

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLBuddyOverlay.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLBuddyOverlay.cpp
@@ -696,7 +696,7 @@ void deleteNotificationBox( void )
 	if(noticeLayout)
 	{
 		noticeLayout->destroyWindows();
-		MemoryPoolObject::deleteInstance(noticeLayout);
+		deleteInstance(noticeLayout);
 		noticeLayout = NULL;
 	}
 }
@@ -1178,7 +1178,7 @@ static void closeRightClickMenu(GameWindow *win)
 		if(!winLay)
 			return;
 		winLay->destroyWindows();					
-		MemoryPoolObject::deleteInstance(winLay);
+		deleteInstance(winLay);
 		winLay = NULL;
 
 	}

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLBuddyOverlay.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLBuddyOverlay.cpp
@@ -696,7 +696,7 @@ void deleteNotificationBox( void )
 	if(noticeLayout)
 	{
 		noticeLayout->destroyWindows();
-		noticeLayout->deleteInstance();
+		MemoryPoolObject::deleteInstance(noticeLayout);
 		noticeLayout = NULL;
 	}
 }
@@ -1178,7 +1178,7 @@ static void closeRightClickMenu(GameWindow *win)
 		if(!winLay)
 			return;
 		winLay->destroyWindows();					
-		winLay->deleteInstance();
+		MemoryPoolObject::deleteInstance(winLay);
 		winLay = NULL;
 
 	}

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLGameSetupMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLGameSetupMenu.cpp
@@ -1375,7 +1375,7 @@ void WOLGameSetupMenuShutdown( WindowLayout *layout, void *userData )
 	if( WOLMapSelectLayout )
 	{
 		WOLMapSelectLayout->destroyWindows();
-		MemoryPoolObject::deleteInstance(WOLMapSelectLayout);
+		deleteInstance(WOLMapSelectLayout);
 		WOLMapSelectLayout = NULL;
 	}
 	parentWOLGameSetup = NULL;
@@ -2503,7 +2503,7 @@ WindowMsgHandledType WOLGameSetupMenuSystem( GameWindow *window, UnsignedInt msg
 					if( WOLMapSelectLayout )
 					{
 						WOLMapSelectLayout->destroyWindows();
-						MemoryPoolObject::deleteInstance(WOLMapSelectLayout);
+						deleteInstance(WOLMapSelectLayout);
 						WOLMapSelectLayout = NULL;
 					}
 

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLGameSetupMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLGameSetupMenu.cpp
@@ -1375,7 +1375,7 @@ void WOLGameSetupMenuShutdown( WindowLayout *layout, void *userData )
 	if( WOLMapSelectLayout )
 	{
 		WOLMapSelectLayout->destroyWindows();
-		WOLMapSelectLayout->deleteInstance();
+		MemoryPoolObject::deleteInstance(WOLMapSelectLayout);
 		WOLMapSelectLayout = NULL;
 	}
 	parentWOLGameSetup = NULL;
@@ -2503,7 +2503,7 @@ WindowMsgHandledType WOLGameSetupMenuSystem( GameWindow *window, UnsignedInt msg
 					if( WOLMapSelectLayout )
 					{
 						WOLMapSelectLayout->destroyWindows();
-						WOLMapSelectLayout->deleteInstance();
+						MemoryPoolObject::deleteInstance(WOLMapSelectLayout);
 						WOLMapSelectLayout = NULL;
 					}
 

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLMapSelectMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLMapSelectMenu.cpp
@@ -382,7 +382,7 @@ WindowMsgHandledType WOLMapSelectMenuSystem( GameWindow *window, UnsignedInt msg
 				showGameSpyGameOptionsUnderlyingGUIElements( TRUE );
 
 				WOLMapSelectLayout->destroyWindows();
-				MemoryPoolObject::deleteInstance(WOLMapSelectLayout);
+				deleteInstance(WOLMapSelectLayout);
 				WOLMapSelectLayout = NULL;
 				WOLPositionStartSpots();
 			}  // end if
@@ -446,7 +446,7 @@ WindowMsgHandledType WOLMapSelectMenuSystem( GameWindow *window, UnsignedInt msg
 					WOLDisplayGameOptions();
 
 					WOLMapSelectLayout->destroyWindows();
-					MemoryPoolObject::deleteInstance(WOLMapSelectLayout);
+					deleteInstance(WOLMapSelectLayout);
 					WOLMapSelectLayout = NULL;
 
 					showGameSpyGameOptionsUnderlyingGUIElements( TRUE );

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLMapSelectMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLMapSelectMenu.cpp
@@ -382,7 +382,7 @@ WindowMsgHandledType WOLMapSelectMenuSystem( GameWindow *window, UnsignedInt msg
 				showGameSpyGameOptionsUnderlyingGUIElements( TRUE );
 
 				WOLMapSelectLayout->destroyWindows();
-				WOLMapSelectLayout->deleteInstance();
+				MemoryPoolObject::deleteInstance(WOLMapSelectLayout);
 				WOLMapSelectLayout = NULL;
 				WOLPositionStartSpots();
 			}  // end if
@@ -446,7 +446,7 @@ WindowMsgHandledType WOLMapSelectMenuSystem( GameWindow *window, UnsignedInt msg
 					WOLDisplayGameOptions();
 
 					WOLMapSelectLayout->destroyWindows();
-					WOLMapSelectLayout->deleteInstance();
+					MemoryPoolObject::deleteInstance(WOLMapSelectLayout);
 					WOLMapSelectLayout = NULL;
 
 					showGameSpyGameOptionsUnderlyingGUIElements( TRUE );

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GameFont.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GameFont.cpp
@@ -123,7 +123,7 @@ void FontLibrary::deleteAllFonts( void )
 		releaseFontData( font );
 
 		// delete the font list element
-		MemoryPoolObject::deleteInstance(font);
+		deleteInstance(font);
 
 	}  // end while
 
@@ -214,7 +214,7 @@ GameFont *FontLibrary::getFont( AsciiString name, Int pointSize, Bool bold )
 	{
 
 		DEBUG_CRASH(( "getFont: Unable to load font data pointer '%s'\n", name ));
-		MemoryPoolObject::deleteInstance(font);
+		deleteInstance(font);
 		return NULL;
 
 	}  // end if

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GameFont.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GameFont.cpp
@@ -123,7 +123,7 @@ void FontLibrary::deleteAllFonts( void )
 		releaseFontData( font );
 
 		// delete the font list element
-		font->deleteInstance();
+		MemoryPoolObject::deleteInstance(font);
 
 	}  // end while
 
@@ -214,7 +214,7 @@ GameFont *FontLibrary::getFont( AsciiString name, Int pointSize, Bool bold )
 	{
 
 		DEBUG_CRASH(( "getFont: Unable to load font data pointer '%s'\n", name ));
-		font->deleteInstance();
+		MemoryPoolObject::deleteInstance(font);
 		return NULL;
 
 	}  // end if

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GameWindowManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GameWindowManager.cpp
@@ -122,7 +122,7 @@ void GameWindowManager::processDestroyList( void )
 
 		// free the memory
 		if (doDestroy)
-			doDestroy->deleteInstance();
+			MemoryPoolObject::deleteInstance(doDestroy);
 
 	}  // end for
 
@@ -1613,7 +1613,7 @@ Int GameWindowManager::winUnsetModal( GameWindow *window )
 
 	// remove from top of list
 	next = m_modalHead->next;
-	m_modalHead->deleteInstance();
+	MemoryPoolObject::deleteInstance(m_modalHead);
 	m_modalHead = next;
 
 	return WIN_ERR_OK;

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GameWindowManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GameWindowManager.cpp
@@ -122,7 +122,7 @@ void GameWindowManager::processDestroyList( void )
 
 		// free the memory
 		if (doDestroy)
-			MemoryPoolObject::deleteInstance(doDestroy);
+			deleteInstance(doDestroy);
 
 	}  // end for
 
@@ -1613,7 +1613,7 @@ Int GameWindowManager::winUnsetModal( GameWindow *window )
 
 	// remove from top of list
 	next = m_modalHead->next;
-	MemoryPoolObject::deleteInstance(m_modalHead);
+	deleteInstance(m_modalHead);
 	m_modalHead = next;
 
 	return WIN_ERR_OK;

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GameWindowManagerScript.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GameWindowManagerScript.cpp
@@ -2652,7 +2652,7 @@ WindowLayout *GameWindowManager::winCreateLayout( AsciiString filename )
 	if( layout->load( filename ) == FALSE )
 	{
 
-		layout->deleteInstance();
+		MemoryPoolObject::deleteInstance(layout);
 		return NULL;
 
 	}  // end if

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GameWindowManagerScript.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GameWindowManagerScript.cpp
@@ -2652,7 +2652,7 @@ WindowLayout *GameWindowManager::winCreateLayout( AsciiString filename )
 	if( layout->load( filename ) == FALSE )
 	{
 
-		MemoryPoolObject::deleteInstance(layout);
+		deleteInstance(layout);
 		return NULL;
 
 	}  // end if

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/Shell/Shell.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/Shell/Shell.cpp
@@ -95,7 +95,7 @@ Shell::~Shell( void )
 	if(m_background)
 	{
 		m_background->destroyWindows();
-		MemoryPoolObject::deleteInstance(m_background);
+		deleteInstance(m_background);
 		m_background = NULL;
 	}
 
@@ -112,7 +112,7 @@ Shell::~Shell( void )
 	{
 
 		m_saveLoadMenuLayout->destroyWindows();
-		MemoryPoolObject::deleteInstance(m_saveLoadMenuLayout);
+		deleteInstance(m_saveLoadMenuLayout);
 		m_saveLoadMenuLayout = NULL;
 
 	}  //end if
@@ -122,7 +122,7 @@ Shell::~Shell( void )
 	{
 
 		m_popupReplayLayout->destroyWindows();
-		MemoryPoolObject::deleteInstance(m_popupReplayLayout);
+		deleteInstance(m_popupReplayLayout);
 		m_popupReplayLayout = NULL;
 
 	}  //end if
@@ -130,7 +130,7 @@ Shell::~Shell( void )
 	// delete the options menu if present.
 	if (m_optionsLayout != NULL) {
 		m_optionsLayout->destroyWindows();
-		MemoryPoolObject::deleteInstance(m_optionsLayout);
+		deleteInstance(m_optionsLayout);
 		m_optionsLayout = NULL;
 	}
 
@@ -198,7 +198,7 @@ void Shell::update( void )
 		{
 			
 			m_background->destroyWindows();
-			MemoryPoolObject::deleteInstance(m_background);
+			deleteInstance(m_background);
 			m_background = NULL;
 			
 		}
@@ -637,7 +637,7 @@ void Shell::doPop( Bool impendingPush )
 	currentTop->destroyWindows();
 
 	// release the screen object back to the memory pool
-	MemoryPoolObject::deleteInstance(currentTop);
+	deleteInstance(currentTop);
 
 	// run the init for the new top of the stack if present
 	WindowLayout *newTop = top();
@@ -700,7 +700,7 @@ void Shell::shutdownComplete( WindowLayout *screen, Bool impendingPush )
 		if(m_background)
 		{
 			m_background->destroyWindows();
-			MemoryPoolObject::deleteInstance(m_background);
+			deleteInstance(m_background);
 			m_background = NULL;
 			m_clearBackground = FALSE;
 		}
@@ -827,7 +827,7 @@ WindowLayout *Shell::getOptionsLayout( Bool create )
 void Shell::destroyOptionsLayout() {
 	if (m_optionsLayout != NULL) {
 		m_optionsLayout->destroyWindows();
-		MemoryPoolObject::deleteInstance(m_optionsLayout);
+		deleteInstance(m_optionsLayout);
 		m_optionsLayout = NULL;
 	}
 }

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/Shell/Shell.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/Shell/Shell.cpp
@@ -95,7 +95,7 @@ Shell::~Shell( void )
 	if(m_background)
 	{
 		m_background->destroyWindows();
-		m_background->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_background);
 		m_background = NULL;
 	}
 
@@ -112,7 +112,7 @@ Shell::~Shell( void )
 	{
 
 		m_saveLoadMenuLayout->destroyWindows();
-		m_saveLoadMenuLayout->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_saveLoadMenuLayout);
 		m_saveLoadMenuLayout = NULL;
 
 	}  //end if
@@ -122,7 +122,7 @@ Shell::~Shell( void )
 	{
 
 		m_popupReplayLayout->destroyWindows();
-		m_popupReplayLayout->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_popupReplayLayout);
 		m_popupReplayLayout = NULL;
 
 	}  //end if
@@ -130,7 +130,7 @@ Shell::~Shell( void )
 	// delete the options menu if present.
 	if (m_optionsLayout != NULL) {
 		m_optionsLayout->destroyWindows();
-		m_optionsLayout->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_optionsLayout);
 		m_optionsLayout = NULL;
 	}
 
@@ -198,7 +198,7 @@ void Shell::update( void )
 		{
 			
 			m_background->destroyWindows();
-			m_background->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_background);
 			m_background = NULL;
 			
 		}
@@ -637,7 +637,7 @@ void Shell::doPop( Bool impendingPush )
 	currentTop->destroyWindows();
 
 	// release the screen object back to the memory pool
-	currentTop->deleteInstance();
+	MemoryPoolObject::deleteInstance(currentTop);
 
 	// run the init for the new top of the stack if present
 	WindowLayout *newTop = top();
@@ -700,7 +700,7 @@ void Shell::shutdownComplete( WindowLayout *screen, Bool impendingPush )
 		if(m_background)
 		{
 			m_background->destroyWindows();
-			m_background->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_background);
 			m_background = NULL;
 			m_clearBackground = FALSE;
 		}
@@ -827,7 +827,7 @@ WindowLayout *Shell::getOptionsLayout( Bool create )
 void Shell::destroyOptionsLayout() {
 	if (m_optionsLayout != NULL) {
 		m_optionsLayout->destroyWindows();
-		m_optionsLayout->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_optionsLayout);
 		m_optionsLayout = NULL;
 	}
 }

--- a/Generals/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -549,7 +549,7 @@ void GameClient::update( void )
 
 
 					legal->destroyWindows();
-					legal->deleteInstance();
+					MemoryPoolObject::deleteInstance(legal);
 
 				}
 				TheWritableGlobalData->m_breakTheMovie = TRUE;
@@ -812,7 +812,7 @@ void GameClient::destroyDrawable( Drawable *draw )
 	removeDrawableFromLookupTable( draw );
 
 	// free storage
-	draw->deleteInstance();
+	MemoryPoolObject::deleteInstance(draw);
 
 }
 

--- a/Generals/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -549,7 +549,7 @@ void GameClient::update( void )
 
 
 					legal->destroyWindows();
-					MemoryPoolObject::deleteInstance(legal);
+					deleteInstance(legal);
 
 				}
 				TheWritableGlobalData->m_breakTheMovie = TRUE;
@@ -812,7 +812,7 @@ void GameClient::destroyDrawable( Drawable *draw )
 	removeDrawableFromLookupTable( draw );
 
 	// free storage
-	MemoryPoolObject::deleteInstance(draw);
+	deleteInstance(draw);
 
 }
 

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -594,7 +594,7 @@ Bool InGameUI::removeSuperweapon(Int playerIndex, const AsciiString& powerName, 
 			{
 				SuperweaponInfo *info = *listIt;
 				swList.erase(listIt);
-				info->deleteInstance();
+				MemoryPoolObject::deleteInstance(info);
 				if (swList.size() == 0)
 				{
 					m_superweapons[playerIndex].erase(mapIt);
@@ -734,7 +734,7 @@ void InGameUI::removeNamedTimer( const AsciiString& timerName )
 	if (mapIt != m_namedTimers.end())
 	{
 		TheDisplayStringManager->freeDisplayString( mapIt->second->displayString );
-		mapIt->second->deleteInstance();
+		MemoryPoolObject::deleteInstance(mapIt->second);
 		m_namedTimers.erase(mapIt);
 		return;
 	}
@@ -1876,7 +1876,7 @@ void InGameUI::reset( void )
 			for (SuperweaponList::iterator listIt = mapIt->second.begin(); listIt != mapIt->second.end(); ++listIt)
 			{
 				SuperweaponInfo *info = *listIt;
-				info->deleteInstance();
+				MemoryPoolObject::deleteInstance(info);
 			}
 			mapIt->second.clear();
 		}
@@ -1887,7 +1887,7 @@ void InGameUI::reset( void )
 	{
 		NamedTimerInfo *info = timerIt->second;
 		TheDisplayStringManager->freeDisplayString(info->displayString);
-		info->deleteInstance();
+		MemoryPoolObject::deleteInstance(info);
 	}
 	m_namedTimers.clear();
 	m_namedTimerLastFlashFrame = 0;
@@ -4931,7 +4931,7 @@ void InGameUI::updateFloatingText( void )
 			if( a <= 0)
 			{
 				it = m_floatingTextList.erase(it);
-				ftd->deleteInstance();
+				MemoryPoolObject::deleteInstance(ftd);
 				continue; // don't do the ++it below
 			}
 
@@ -4993,7 +4993,7 @@ void InGameUI::clearFloatingText( void )
 	{
 		ftd = *it;
 		it = m_floatingTextList.erase(it);
-		ftd->deleteInstance();
+		MemoryPoolObject::deleteInstance(ftd);
 	}
 	
 }
@@ -5058,12 +5058,12 @@ void InGameUI::clearPopupMessageData( void )
 	if(m_popupMessageData->layout)
 	{
 		m_popupMessageData->layout->destroyWindows();
-		m_popupMessageData->layout->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_popupMessageData->layout);
 		m_popupMessageData->layout = NULL;
 	}
 	if( m_popupMessageData->pause )
 		TheGameLogic->setGamePaused(FALSE, m_popupMessageData->pauseMusic);
-	m_popupMessageData->deleteInstance();
+	MemoryPoolObject::deleteInstance(m_popupMessageData);
 	m_popupMessageData = NULL;
 	
 }
@@ -5170,7 +5170,7 @@ void InGameUI::clearWorldAnimations( void )
 		{
 
 			// delete the animation instance
-			wad->m_anim->deleteInstance();
+			MemoryPoolObject::deleteInstance(wad->m_anim);
 
 			// delete the world animation data
 			delete wad;
@@ -5213,7 +5213,7 @@ void InGameUI::updateAndDrawWorldAnimations( void )
 			{
 
 				// delete this element and continue
-				wad->m_anim->deleteInstance();
+				MemoryPoolObject::deleteInstance(wad->m_anim);
 				delete wad;
 				it = m_worldAnimationList.erase( it );
 				continue;
@@ -5484,7 +5484,7 @@ void InGameUI::recreateControlBar( void )
 {
 	GameWindow *win = TheWindowManager->winGetWindowFromId(NULL, TheNameKeyGenerator->nameToKey(AsciiString("ControlBar.wnd")));
 	if(win)
-		win->deleteInstance();
+		MemoryPoolObject::deleteInstance(win);
 	
 	m_idleWorkerWin = NULL;	
 	

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -594,7 +594,7 @@ Bool InGameUI::removeSuperweapon(Int playerIndex, const AsciiString& powerName, 
 			{
 				SuperweaponInfo *info = *listIt;
 				swList.erase(listIt);
-				MemoryPoolObject::deleteInstance(info);
+				deleteInstance(info);
 				if (swList.size() == 0)
 				{
 					m_superweapons[playerIndex].erase(mapIt);
@@ -734,7 +734,7 @@ void InGameUI::removeNamedTimer( const AsciiString& timerName )
 	if (mapIt != m_namedTimers.end())
 	{
 		TheDisplayStringManager->freeDisplayString( mapIt->second->displayString );
-		MemoryPoolObject::deleteInstance(mapIt->second);
+		deleteInstance(mapIt->second);
 		m_namedTimers.erase(mapIt);
 		return;
 	}
@@ -1876,7 +1876,7 @@ void InGameUI::reset( void )
 			for (SuperweaponList::iterator listIt = mapIt->second.begin(); listIt != mapIt->second.end(); ++listIt)
 			{
 				SuperweaponInfo *info = *listIt;
-				MemoryPoolObject::deleteInstance(info);
+				deleteInstance(info);
 			}
 			mapIt->second.clear();
 		}
@@ -1887,7 +1887,7 @@ void InGameUI::reset( void )
 	{
 		NamedTimerInfo *info = timerIt->second;
 		TheDisplayStringManager->freeDisplayString(info->displayString);
-		MemoryPoolObject::deleteInstance(info);
+		deleteInstance(info);
 	}
 	m_namedTimers.clear();
 	m_namedTimerLastFlashFrame = 0;
@@ -4931,7 +4931,7 @@ void InGameUI::updateFloatingText( void )
 			if( a <= 0)
 			{
 				it = m_floatingTextList.erase(it);
-				MemoryPoolObject::deleteInstance(ftd);
+				deleteInstance(ftd);
 				continue; // don't do the ++it below
 			}
 
@@ -4993,7 +4993,7 @@ void InGameUI::clearFloatingText( void )
 	{
 		ftd = *it;
 		it = m_floatingTextList.erase(it);
-		MemoryPoolObject::deleteInstance(ftd);
+		deleteInstance(ftd);
 	}
 	
 }
@@ -5058,12 +5058,12 @@ void InGameUI::clearPopupMessageData( void )
 	if(m_popupMessageData->layout)
 	{
 		m_popupMessageData->layout->destroyWindows();
-		MemoryPoolObject::deleteInstance(m_popupMessageData->layout);
+		deleteInstance(m_popupMessageData->layout);
 		m_popupMessageData->layout = NULL;
 	}
 	if( m_popupMessageData->pause )
 		TheGameLogic->setGamePaused(FALSE, m_popupMessageData->pauseMusic);
-	MemoryPoolObject::deleteInstance(m_popupMessageData);
+	deleteInstance(m_popupMessageData);
 	m_popupMessageData = NULL;
 	
 }
@@ -5170,7 +5170,7 @@ void InGameUI::clearWorldAnimations( void )
 		{
 
 			// delete the animation instance
-			MemoryPoolObject::deleteInstance(wad->m_anim);
+			deleteInstance(wad->m_anim);
 
 			// delete the world animation data
 			delete wad;
@@ -5213,7 +5213,7 @@ void InGameUI::updateAndDrawWorldAnimations( void )
 			{
 
 				// delete this element and continue
-				MemoryPoolObject::deleteInstance(wad->m_anim);
+				deleteInstance(wad->m_anim);
 				delete wad;
 				it = m_worldAnimationList.erase( it );
 				continue;
@@ -5484,7 +5484,7 @@ void InGameUI::recreateControlBar( void )
 {
 	GameWindow *win = TheWindowManager->winGetWindowFromId(NULL, TheNameKeyGenerator->nameToKey(AsciiString("ControlBar.wnd")));
 	if(win)
-		MemoryPoolObject::deleteInstance(win);
+		deleteInstance(win);
 	
 	m_idleWorkerWin = NULL;	
 	

--- a/Generals/Code/GameEngine/Source/GameClient/MapUtil.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MapUtil.cpp
@@ -171,7 +171,7 @@ static Bool ParseObjectDataChunk(DataChunkInput &file, DataChunkInfo *info, void
 		m_supplyPositions.push_back(loc);
 	}
 
-	pThisOne->deleteInstance();
+	MemoryPoolObject::deleteInstance(pThisOne);
 	return TRUE;
 }
 
@@ -1155,7 +1155,7 @@ Image *getMapPreviewImage( AsciiString mapName )
 	Region2D uv;
 	mapPreviewImage = TheMappedImageCollection->findImageByName("MapPreview");
 	if(mapPreviewImage)
-		mapPreviewImage->deleteInstance();
+		MemoryPoolObject::deleteInstance(mapPreviewImage);
 	
 	mapPreviewImage = TheMappedImageCollection->newImage();
 	mapPreviewImage->setName("MapPreview");
@@ -1186,7 +1186,7 @@ Image *getMapPreviewImage( AsciiString mapName )
 			file.registerParser( AsciiString("MapPreview"), AsciiString::TheEmptyString, parseMapPreviewChunk );
 			if (!file.parse(NULL)) {
 				DEBUG_ASSERTCRASH(false,("Unable to read MapPreview info."));
-				mapPreviewImage->deleteInstance();
+				MemoryPoolObject::deleteInstance(mapPreviewImage);
 				return NULL;
 			}
 		}
@@ -1194,7 +1194,7 @@ Image *getMapPreviewImage( AsciiString mapName )
 	}
 	else
 	{
-		mapPreviewImage->deleteInstance();
+		MemoryPoolObject::deleteInstance(mapPreviewImage);
 		return NULL;
 	}
 	

--- a/Generals/Code/GameEngine/Source/GameClient/MapUtil.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MapUtil.cpp
@@ -171,7 +171,7 @@ static Bool ParseObjectDataChunk(DataChunkInput &file, DataChunkInfo *info, void
 		m_supplyPositions.push_back(loc);
 	}
 
-	MemoryPoolObject::deleteInstance(pThisOne);
+	deleteInstance(pThisOne);
 	return TRUE;
 }
 
@@ -1155,7 +1155,7 @@ Image *getMapPreviewImage( AsciiString mapName )
 	Region2D uv;
 	mapPreviewImage = TheMappedImageCollection->findImageByName("MapPreview");
 	if(mapPreviewImage)
-		MemoryPoolObject::deleteInstance(mapPreviewImage);
+		deleteInstance(mapPreviewImage);
 	
 	mapPreviewImage = TheMappedImageCollection->newImage();
 	mapPreviewImage->setName("MapPreview");
@@ -1186,7 +1186,7 @@ Image *getMapPreviewImage( AsciiString mapName )
 			file.registerParser( AsciiString("MapPreview"), AsciiString::TheEmptyString, parseMapPreviewChunk );
 			if (!file.parse(NULL)) {
 				DEBUG_ASSERTCRASH(false,("Unable to read MapPreview info."));
-				MemoryPoolObject::deleteInstance(mapPreviewImage);
+				deleteInstance(mapPreviewImage);
 				return NULL;
 			}
 		}
@@ -1194,7 +1194,7 @@ Image *getMapPreviewImage( AsciiString mapName )
 	}
 	else
 	{
-		MemoryPoolObject::deleteInstance(mapPreviewImage);
+		deleteInstance(mapPreviewImage);
 		return NULL;
 	}
 	

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/MetaEvent.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/MetaEvent.cpp
@@ -598,7 +598,7 @@ MetaMap::~MetaMap()
 	while (m_metaMaps)
 	{
 		MetaMapRec *next = m_metaMaps->m_next;
-		MemoryPoolObject::deleteInstance(m_metaMaps);
+		deleteInstance(m_metaMaps);
 		m_metaMaps = next;
 	}
 }

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/MetaEvent.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/MetaEvent.cpp
@@ -598,7 +598,7 @@ MetaMap::~MetaMap()
 	while (m_metaMaps)
 	{
 		MetaMapRec *next = m_metaMaps->m_next;
-		m_metaMaps->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_metaMaps);
 		m_metaMaps = next;
 	}
 }

--- a/Generals/Code/GameEngine/Source/GameClient/System/Anim2D.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/System/Anim2D.cpp
@@ -744,7 +744,7 @@ Anim2DCollection::~Anim2DCollection( void )
 		nextTemplate = m_templateList->friend_getNextTemplate();
 
 		// delete this template
-		m_templateList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_templateList);
 
 		// set the head of our list to the next template
 		m_templateList = nextTemplate;

--- a/Generals/Code/GameEngine/Source/GameClient/System/Anim2D.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/System/Anim2D.cpp
@@ -744,7 +744,7 @@ Anim2DCollection::~Anim2DCollection( void )
 		nextTemplate = m_templateList->friend_getNextTemplate();
 
 		// delete this template
-		MemoryPoolObject::deleteInstance(m_templateList);
+		deleteInstance(m_templateList);
 
 		// set the head of our list to the next template
 		m_templateList = nextTemplate;

--- a/Generals/Code/GameEngine/Source/GameClient/System/CampaignManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/System/CampaignManager.cpp
@@ -129,7 +129,7 @@ Campaign::~Campaign( void )
 		Mission *mission = *it;
 		it = m_missions.erase( it );
 		if(mission)
-			MemoryPoolObject::deleteInstance(mission);
+			deleteInstance(mission);
 	}
 }
 
@@ -150,7 +150,7 @@ Mission *Campaign::newMission( AsciiString name )
 		if(mission->m_name.compare(name) == 0)
 		{
 			m_missions.erase( it );
-			MemoryPoolObject::deleteInstance(mission);
+			deleteInstance(mission);
 			break;
 		}
 		else
@@ -234,7 +234,7 @@ CampaignManager::~CampaignManager( void )
 		Campaign *campaign = *it;
 		it = m_campaignList.erase( it );
 		if(campaign)
-			MemoryPoolObject::deleteInstance(campaign);
+			deleteInstance(campaign);
 	}
 }
 
@@ -396,7 +396,7 @@ Campaign *CampaignManager::newCampaign(AsciiString name)
 		if(campaign->m_name.compare(name) == 0)
 		{
 			m_campaignList.erase( it );
-			MemoryPoolObject::deleteInstance(campaign);
+			deleteInstance(campaign);
 			break;
 		}
 		else

--- a/Generals/Code/GameEngine/Source/GameClient/System/CampaignManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/System/CampaignManager.cpp
@@ -129,7 +129,7 @@ Campaign::~Campaign( void )
 		Mission *mission = *it;
 		it = m_missions.erase( it );
 		if(mission)
-			mission->deleteInstance();
+			MemoryPoolObject::deleteInstance(mission);
 	}
 }
 
@@ -150,7 +150,7 @@ Mission *Campaign::newMission( AsciiString name )
 		if(mission->m_name.compare(name) == 0)
 		{
 			m_missions.erase( it );
-			mission->deleteInstance();
+			MemoryPoolObject::deleteInstance(mission);
 			break;
 		}
 		else
@@ -234,7 +234,7 @@ CampaignManager::~CampaignManager( void )
 		Campaign *campaign = *it;
 		it = m_campaignList.erase( it );
 		if(campaign)
-			campaign->deleteInstance();
+			MemoryPoolObject::deleteInstance(campaign);
 	}
 }
 
@@ -396,7 +396,7 @@ Campaign *CampaignManager::newCampaign(AsciiString name)
 		if(campaign->m_name.compare(name) == 0)
 		{
 			m_campaignList.erase( it );
-			campaign->deleteInstance();
+			MemoryPoolObject::deleteInstance(campaign);
 			break;
 		}
 		else

--- a/Generals/Code/GameEngine/Source/GameClient/System/Image.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/System/Image.cpp
@@ -216,7 +216,7 @@ ImageCollection::~ImageCollection( void )
 	{
 
 		next = image->m_next;
-		MemoryPoolObject::deleteInstance(image);
+		deleteInstance(image);
 		image = next;
 
 	}  // end while

--- a/Generals/Code/GameEngine/Source/GameClient/System/Image.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/System/Image.cpp
@@ -216,7 +216,7 @@ ImageCollection::~ImageCollection( void )
 	{
 
 		next = image->m_next;
-		image->deleteInstance();
+		MemoryPoolObject::deleteInstance(image);
 		image = next;
 
 	}  // end while

--- a/Generals/Code/GameEngine/Source/GameClient/System/ParticleSys.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/System/ParticleSys.cpp
@@ -1315,7 +1315,7 @@ ParticleSystem::~ParticleSystem()
 
 	// destroy all particles "in the air"
 	while (m_systemParticlesHead)
-		m_systemParticlesHead->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_systemParticlesHead);
 
 	m_attachedToDrawableID = INVALID_DRAWABLE_ID;
 	m_attachedToObjectID = INVALID_ID;
@@ -2162,7 +2162,7 @@ Bool ParticleSystem::update( Int localPlayerIndex  )
 		{
 			oldParticle = p;
 			p = p->m_systemNext;
-			oldParticle->deleteInstance();
+			MemoryPoolObject::deleteInstance(oldParticle);
 		} else {
 			p = p->m_systemNext;
 		}
@@ -2958,7 +2958,7 @@ ParticleSystemManager::~ParticleSystemManager()
 	TemplateMap::iterator begin(m_templateMap.begin());
 	TemplateMap::iterator end(m_templateMap.end());
 	for (; begin != end; ++begin) {
-		(*begin).second->deleteInstance();
+		MemoryPoolObject::deleteInstance((*begin).second);
 	}
 }
 
@@ -2994,7 +2994,7 @@ void ParticleSystemManager::reset( void )
 {
 	while (getParticleSystemCount()) {
 		if (m_allParticleSystemList.front()) {
-			m_allParticleSystemList.front()->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_allParticleSystemList.front());
 		}
 	}
 
@@ -3048,7 +3048,7 @@ void ParticleSystemManager::update( void )
 		if (sys->update(m_localPlayerIndex) == false)
 		{
 			++it;
-			sys->deleteInstance();
+			MemoryPoolObject::deleteInstance(sys);
 		} else {
 			++it;
 		}
@@ -3151,7 +3151,7 @@ ParticleSystemTemplate *ParticleSystemManager::newTemplate( const AsciiString &n
 		sysTemplate = newInstance(ParticleSystemTemplate)( name );
 
 		if (! m_templateMap.insert(std::make_pair(name, sysTemplate)).second) {
-			sysTemplate->deleteInstance();
+			MemoryPoolObject::deleteInstance(sysTemplate);
 			sysTemplate = NULL;
 		}
 	}
@@ -3312,7 +3312,7 @@ Int ParticleSystemManager::removeOldestParticles( UnsignedInt count,
 		{
 			if( m_allParticlesHead[ i ] ) 
 			{
-				m_allParticlesHead[ i ]->deleteInstance();
+				MemoryPoolObject::deleteInstance(m_allParticlesHead[ i ]);
 				break;  // exit for
 			}
 		}

--- a/Generals/Code/GameEngine/Source/GameClient/System/ParticleSys.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/System/ParticleSys.cpp
@@ -1315,7 +1315,7 @@ ParticleSystem::~ParticleSystem()
 
 	// destroy all particles "in the air"
 	while (m_systemParticlesHead)
-		MemoryPoolObject::deleteInstance(m_systemParticlesHead);
+		deleteInstance(m_systemParticlesHead);
 
 	m_attachedToDrawableID = INVALID_DRAWABLE_ID;
 	m_attachedToObjectID = INVALID_ID;
@@ -2162,7 +2162,7 @@ Bool ParticleSystem::update( Int localPlayerIndex  )
 		{
 			oldParticle = p;
 			p = p->m_systemNext;
-			MemoryPoolObject::deleteInstance(oldParticle);
+			deleteInstance(oldParticle);
 		} else {
 			p = p->m_systemNext;
 		}
@@ -2958,7 +2958,7 @@ ParticleSystemManager::~ParticleSystemManager()
 	TemplateMap::iterator begin(m_templateMap.begin());
 	TemplateMap::iterator end(m_templateMap.end());
 	for (; begin != end; ++begin) {
-		MemoryPoolObject::deleteInstance((*begin).second);
+		deleteInstance((*begin).second);
 	}
 }
 
@@ -2994,7 +2994,7 @@ void ParticleSystemManager::reset( void )
 {
 	while (getParticleSystemCount()) {
 		if (m_allParticleSystemList.front()) {
-			MemoryPoolObject::deleteInstance(m_allParticleSystemList.front());
+			deleteInstance(m_allParticleSystemList.front());
 		}
 	}
 
@@ -3048,7 +3048,7 @@ void ParticleSystemManager::update( void )
 		if (sys->update(m_localPlayerIndex) == false)
 		{
 			++it;
-			MemoryPoolObject::deleteInstance(sys);
+			deleteInstance(sys);
 		} else {
 			++it;
 		}
@@ -3151,7 +3151,7 @@ ParticleSystemTemplate *ParticleSystemManager::newTemplate( const AsciiString &n
 		sysTemplate = newInstance(ParticleSystemTemplate)( name );
 
 		if (! m_templateMap.insert(std::make_pair(name, sysTemplate)).second) {
-			MemoryPoolObject::deleteInstance(sysTemplate);
+			deleteInstance(sysTemplate);
 			sysTemplate = NULL;
 		}
 	}
@@ -3312,7 +3312,7 @@ Int ParticleSystemManager::removeOldestParticles( UnsignedInt count,
 		{
 			if( m_allParticlesHead[ i ] ) 
 			{
-				MemoryPoolObject::deleteInstance(m_allParticlesHead[ i ]);
+				deleteInstance(m_allParticlesHead[ i ]);
 				break;  // exit for
 			}
 		}

--- a/Generals/Code/GameEngine/Source/GameClient/Terrain/TerrainRoads.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Terrain/TerrainRoads.cpp
@@ -258,7 +258,7 @@ TerrainRoadCollection::~TerrainRoadCollection( void )
 		temp = m_roadList->friend_getNext();
 
 		// delete this road
-		MemoryPoolObject::deleteInstance(m_roadList);
+		deleteInstance(m_roadList);
 
 		// set the new head of the list
 		m_roadList = temp;
@@ -273,7 +273,7 @@ TerrainRoadCollection::~TerrainRoadCollection( void )
 		temp = m_bridgeList->friend_getNext();
 
 		// delete this bridge
-		MemoryPoolObject::deleteInstance(m_bridgeList);
+		deleteInstance(m_bridgeList);
 
 		// set the new head of the list
 		m_bridgeList = temp;

--- a/Generals/Code/GameEngine/Source/GameClient/Terrain/TerrainRoads.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Terrain/TerrainRoads.cpp
@@ -258,7 +258,7 @@ TerrainRoadCollection::~TerrainRoadCollection( void )
 		temp = m_roadList->friend_getNext();
 
 		// delete this road
-		m_roadList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_roadList);
 
 		// set the new head of the list
 		m_roadList = temp;
@@ -273,7 +273,7 @@ TerrainRoadCollection::~TerrainRoadCollection( void )
 		temp = m_bridgeList->friend_getNext();
 
 		// delete this bridge
-		m_bridgeList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_bridgeList);
 
 		// set the new head of the list
 		m_bridgeList = temp;

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AI.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AI.cpp
@@ -69,11 +69,11 @@ void TAiData::addFactionBuildList(AISideBuildList *buildList)
 	while (info) {
 		if (buildList->m_side == info->m_side) {
 			if (info->m_buildList)
-				MemoryPoolObject::deleteInstance(info->m_buildList);
+				deleteInstance(info->m_buildList);
 			info->m_buildList = buildList->m_buildList;
 			buildList->m_buildList = NULL;
 			buildList->m_next = NULL;
-			MemoryPoolObject::deleteInstance(buildList);
+			deleteInstance(buildList);
 			return;
 		}
 		info = info->m_next;
@@ -89,7 +89,7 @@ TAiData::~TAiData()
 	while (info) { 
 		AISideInfo *cur = info;
 		info = info->m_next;
-		MemoryPoolObject::deleteInstance(cur);
+		deleteInstance(cur);
 	}
 
 	AISideBuildList *build = m_sideBuildLists;
@@ -97,7 +97,7 @@ TAiData::~TAiData()
 	while (build) { 
 		AISideBuildList *cur = build;
 		build = build->m_next;
-		MemoryPoolObject::deleteInstance(cur);
+		deleteInstance(cur);
 	}
 
 }
@@ -115,7 +115,7 @@ AISideBuildList::AISideBuildList( AsciiString side ) :
 AISideBuildList::~AISideBuildList()
 {
 	if (m_buildList) {
-		MemoryPoolObject::deleteInstance(m_buildList); // note - deletes all in the list.
+		deleteInstance(m_buildList); // note - deletes all in the list.
 	}
 	m_buildList = NULL;
 }
@@ -471,7 +471,7 @@ void AI::destroyGroup( AIGroup *group )
 	m_groupList.erase( i );
 
 	// destroy group
-	MemoryPoolObject::deleteInstance(group);
+	deleteInstance(group);
 }
 
 /**

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AI.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AI.cpp
@@ -69,11 +69,11 @@ void TAiData::addFactionBuildList(AISideBuildList *buildList)
 	while (info) {
 		if (buildList->m_side == info->m_side) {
 			if (info->m_buildList)
-				info->m_buildList->deleteInstance();
+				MemoryPoolObject::deleteInstance(info->m_buildList);
 			info->m_buildList = buildList->m_buildList;
 			buildList->m_buildList = NULL;
 			buildList->m_next = NULL;
-			buildList->deleteInstance();
+			MemoryPoolObject::deleteInstance(buildList);
 			return;
 		}
 		info = info->m_next;
@@ -89,7 +89,7 @@ TAiData::~TAiData()
 	while (info) { 
 		AISideInfo *cur = info;
 		info = info->m_next;
-		cur->deleteInstance();
+		MemoryPoolObject::deleteInstance(cur);
 	}
 
 	AISideBuildList *build = m_sideBuildLists;
@@ -97,7 +97,7 @@ TAiData::~TAiData()
 	while (build) { 
 		AISideBuildList *cur = build;
 		build = build->m_next;
-		cur->deleteInstance();
+		MemoryPoolObject::deleteInstance(cur);
 	}
 
 }
@@ -115,7 +115,7 @@ AISideBuildList::AISideBuildList( AsciiString side ) :
 AISideBuildList::~AISideBuildList()
 {
 	if (m_buildList) {
-		m_buildList->deleteInstance(); // note - deletes all in the list.
+		MemoryPoolObject::deleteInstance(m_buildList); // note - deletes all in the list.
 	}
 	m_buildList = NULL;
 }
@@ -471,7 +471,7 @@ void AI::destroyGroup( AIGroup *group )
 	m_groupList.erase( i );
 
 	// destroy group
-	group->deleteInstance();
+	MemoryPoolObject::deleteInstance(group);
 }
 
 /**

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
@@ -107,7 +107,7 @@ AIGroup::~AIGroup()
 		}
 	}
 	if (m_groundPath) {
-		m_groundPath->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_groundPath);
 		m_groundPath = NULL;
 	}
 	//DEBUG_LOG(( "AIGroup #%d destroyed\n", m_id ));
@@ -409,7 +409,7 @@ void AIGroup::recompute( void )
 	getCenter( &center );
 
 	if (m_groundPath) {
-		m_groundPath->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_groundPath);
 		m_groundPath = NULL;
 	}
 
@@ -714,7 +714,7 @@ Bool AIGroup::friend_moveInfantryToPos( const Coord3D *pos, CommandSourceType cm
 		}
 	}
 	if (startNode==NULL || endNode==NULL) {
-		m_groundPath->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_groundPath);
 		m_groundPath = NULL;
 		return false;
 	}
@@ -1071,7 +1071,7 @@ void AIGroup::friend_moveFormationToPos( const Coord3D *pos, CommandSourceType c
 			tmpNode = tmpNode->getNextOptimized();
 		}
 		if (startNode==NULL || endNode==NULL) {
-			m_groundPath->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_groundPath);
 			m_groundPath = NULL;
 			startNode = NULL;
 			endNode = NULL;
@@ -1178,7 +1178,7 @@ Bool AIGroup::friend_moveVehicleToPos( const Coord3D *pos, CommandSourceType cmd
 		endNode = NULL;
 	}
 	if (startNode==NULL || endNode==NULL) {
-		m_groundPath->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_groundPath);
 		m_groundPath = NULL;
 		return false;
 	}

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
@@ -107,7 +107,7 @@ AIGroup::~AIGroup()
 		}
 	}
 	if (m_groundPath) {
-		MemoryPoolObject::deleteInstance(m_groundPath);
+		deleteInstance(m_groundPath);
 		m_groundPath = NULL;
 	}
 	//DEBUG_LOG(( "AIGroup #%d destroyed\n", m_id ));
@@ -409,7 +409,7 @@ void AIGroup::recompute( void )
 	getCenter( &center );
 
 	if (m_groundPath) {
-		MemoryPoolObject::deleteInstance(m_groundPath);
+		deleteInstance(m_groundPath);
 		m_groundPath = NULL;
 	}
 
@@ -714,7 +714,7 @@ Bool AIGroup::friend_moveInfantryToPos( const Coord3D *pos, CommandSourceType cm
 		}
 	}
 	if (startNode==NULL || endNode==NULL) {
-		MemoryPoolObject::deleteInstance(m_groundPath);
+		deleteInstance(m_groundPath);
 		m_groundPath = NULL;
 		return false;
 	}
@@ -1071,7 +1071,7 @@ void AIGroup::friend_moveFormationToPos( const Coord3D *pos, CommandSourceType c
 			tmpNode = tmpNode->getNextOptimized();
 		}
 		if (startNode==NULL || endNode==NULL) {
-			MemoryPoolObject::deleteInstance(m_groundPath);
+			deleteInstance(m_groundPath);
 			m_groundPath = NULL;
 			startNode = NULL;
 			endNode = NULL;
@@ -1178,7 +1178,7 @@ Bool AIGroup::friend_moveVehicleToPos( const Coord3D *pos, CommandSourceType cmd
 		endNode = NULL;
 	}
 	if (startNode==NULL || endNode==NULL) {
-		MemoryPoolObject::deleteInstance(m_groundPath);
+		deleteInstance(m_groundPath);
 		m_groundPath = NULL;
 		return false;
 	}

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIGuard.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIGuard.cpp
@@ -404,7 +404,7 @@ void AIGuardInnerState::onExit( StateExitType status )
 	if (m_attackState) 
 	{
 		m_attackState->onExit(status);
-		m_attackState->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_attackState);
 		m_attackState = NULL;
 	}
 	if (obj->getTeam()) 
@@ -525,7 +525,7 @@ void AIGuardOuterState::onExit( StateExitType status )
 	if (m_attackState) 
 	{
 		m_attackState->onExit(status);
-		m_attackState->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_attackState);
 		m_attackState = NULL;
 	}
 }
@@ -799,7 +799,7 @@ void AIGuardAttackAggressorState::onExit( StateExitType status )
 	if (m_attackState) 
 	{
 		m_attackState->onExit(status);
-		m_attackState->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_attackState);
 		m_attackState = NULL;
 	}
 

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIGuard.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIGuard.cpp
@@ -404,7 +404,7 @@ void AIGuardInnerState::onExit( StateExitType status )
 	if (m_attackState) 
 	{
 		m_attackState->onExit(status);
-		MemoryPoolObject::deleteInstance(m_attackState);
+		deleteInstance(m_attackState);
 		m_attackState = NULL;
 	}
 	if (obj->getTeam()) 
@@ -525,7 +525,7 @@ void AIGuardOuterState::onExit( StateExitType status )
 	if (m_attackState) 
 	{
 		m_attackState->onExit(status);
-		MemoryPoolObject::deleteInstance(m_attackState);
+		deleteInstance(m_attackState);
 		m_attackState = NULL;
 	}
 }
@@ -799,7 +799,7 @@ void AIGuardAttackAggressorState::onExit( StateExitType status )
 	if (m_attackState) 
 	{
 		m_attackState->onExit(status);
-		MemoryPoolObject::deleteInstance(m_attackState);
+		deleteInstance(m_attackState);
 		m_attackState = NULL;
 	}
 

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -246,7 +246,7 @@ Path::~Path( void )
 	for( node = m_path; node; node = nextNode )
 	{
 		nextNode = node->getNext();
-		node->deleteInstance();
+		MemoryPoolObject::deleteInstance(node);
 	}
 }
 
@@ -3435,7 +3435,7 @@ void Pathfinder::reset( void )
 	debugPathPos.z = 0.0f;
 
 	if (debugPath)
-		debugPath->deleteInstance();
+		MemoryPoolObject::deleteInstance(debugPath);
 
 	debugPath = NULL;
 	m_frameToShowObstacles = 0;
@@ -5884,7 +5884,7 @@ Path *Pathfinder::findPath( Object *obj, const LocomotorSet& locomotorSet, const
 	m_zoneManager.clearPassableFlags();
 	Path *hPat = findHierarchicalPath(isHuman, locomotorSet, from, rawTo, false);
 	if (hPat) {
-		hPat->deleteInstance();
+		MemoryPoolObject::deleteInstance(hPat);
 	}	else {
 		m_zoneManager.setAllPassable();
 	}
@@ -5926,11 +5926,11 @@ Path *Pathfinder::findPath( Object *obj, const LocomotorSet& locomotorSet, const
 					path->getFirstNode()->setCanOptimize(linkNode->getCanOptimize());
 					path->getFirstNode()->setNextOptimized(path->getFirstNode()->getNext());
 				}
-				linkPath->deleteInstance();
+				MemoryPoolObject::deleteInstance(linkPath);
 			}
 			prior = node;
 		}
-		pat->deleteInstance();
+		MemoryPoolObject::deleteInstance(pat);
 		path->optimize(obj, locomotorSet.getValidSurfaces(), false);
 		if (TheGlobalData->m_debugAI) {
 			setDebugPath(path);
@@ -6485,7 +6485,7 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 
 	Path *hPat = internal_findHierarchicalPath(isHuman, LOCOMOTORSURFACE_GROUND, from, rawTo, false, false);
 	if (hPat) {
-		hPat->deleteInstance();
+		MemoryPoolObject::deleteInstance(hPat);
 	}	else {
 		m_zoneManager.setAllPassable();
 	}
@@ -7541,7 +7541,7 @@ Bool Pathfinder::slowDoesPathExist( Object *obj,
 	m_ignoreObstacleID = INVALID_ID;
 	Bool found = (path!=NULL);
 	if (path) {
-		path->deleteInstance();
+		MemoryPoolObject::deleteInstance(path);
 		path = NULL;
 	}
 	return found;
@@ -8161,7 +8161,7 @@ Path *Pathfinder::findClosestPath( Object *obj, const LocomotorSet& locomotorSet
 		m_zoneManager.clearPassableFlags();
 		Path *hPat = findClosestHierarchicalPath(isHuman, locomotorSet, from, rawTo, false);
 		if (hPat) {
-			hPat->deleteInstance();
+			MemoryPoolObject::deleteInstance(hPat);
 			gotHierarchicalPath = true;
 		}	else {
 			m_zoneManager.setAllPassable();
@@ -8485,7 +8485,7 @@ void Pathfinder::setDebugPath(Path *newDebugpath)
 	{
 		// copy the path for debugging
 		if (debugPath)
-			debugPath->deleteInstance();
+			MemoryPoolObject::deleteInstance(debugPath);
 
 		debugPath = newInstance(Path);
 					
@@ -10019,7 +10019,7 @@ Path *Pathfinder::findAttackPath( const Object *obj, const LocomotorSet& locomot
 	m_zoneManager.clearPassableFlags();
 	Path *hPat = findClosestHierarchicalPath(isHuman, locomotorSet, from, victimPos, isCrusher);
 	if (hPat) {
-		hPat->deleteInstance();
+		MemoryPoolObject::deleteInstance(hPat);
 	}	else {
 		m_zoneManager.setAllPassable();
 	}

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -246,7 +246,7 @@ Path::~Path( void )
 	for( node = m_path; node; node = nextNode )
 	{
 		nextNode = node->getNext();
-		MemoryPoolObject::deleteInstance(node);
+		deleteInstance(node);
 	}
 }
 
@@ -3435,7 +3435,7 @@ void Pathfinder::reset( void )
 	debugPathPos.z = 0.0f;
 
 	if (debugPath)
-		MemoryPoolObject::deleteInstance(debugPath);
+		deleteInstance(debugPath);
 
 	debugPath = NULL;
 	m_frameToShowObstacles = 0;
@@ -5884,7 +5884,7 @@ Path *Pathfinder::findPath( Object *obj, const LocomotorSet& locomotorSet, const
 	m_zoneManager.clearPassableFlags();
 	Path *hPat = findHierarchicalPath(isHuman, locomotorSet, from, rawTo, false);
 	if (hPat) {
-		MemoryPoolObject::deleteInstance(hPat);
+		deleteInstance(hPat);
 	}	else {
 		m_zoneManager.setAllPassable();
 	}
@@ -5926,11 +5926,11 @@ Path *Pathfinder::findPath( Object *obj, const LocomotorSet& locomotorSet, const
 					path->getFirstNode()->setCanOptimize(linkNode->getCanOptimize());
 					path->getFirstNode()->setNextOptimized(path->getFirstNode()->getNext());
 				}
-				MemoryPoolObject::deleteInstance(linkPath);
+				deleteInstance(linkPath);
 			}
 			prior = node;
 		}
-		MemoryPoolObject::deleteInstance(pat);
+		deleteInstance(pat);
 		path->optimize(obj, locomotorSet.getValidSurfaces(), false);
 		if (TheGlobalData->m_debugAI) {
 			setDebugPath(path);
@@ -6485,7 +6485,7 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 
 	Path *hPat = internal_findHierarchicalPath(isHuman, LOCOMOTORSURFACE_GROUND, from, rawTo, false, false);
 	if (hPat) {
-		MemoryPoolObject::deleteInstance(hPat);
+		deleteInstance(hPat);
 	}	else {
 		m_zoneManager.setAllPassable();
 	}
@@ -7541,7 +7541,7 @@ Bool Pathfinder::slowDoesPathExist( Object *obj,
 	m_ignoreObstacleID = INVALID_ID;
 	Bool found = (path!=NULL);
 	if (path) {
-		MemoryPoolObject::deleteInstance(path);
+		deleteInstance(path);
 		path = NULL;
 	}
 	return found;
@@ -8161,7 +8161,7 @@ Path *Pathfinder::findClosestPath( Object *obj, const LocomotorSet& locomotorSet
 		m_zoneManager.clearPassableFlags();
 		Path *hPat = findClosestHierarchicalPath(isHuman, locomotorSet, from, rawTo, false);
 		if (hPat) {
-			MemoryPoolObject::deleteInstance(hPat);
+			deleteInstance(hPat);
 			gotHierarchicalPath = true;
 		}	else {
 			m_zoneManager.setAllPassable();
@@ -8485,7 +8485,7 @@ void Pathfinder::setDebugPath(Path *newDebugpath)
 	{
 		// copy the path for debugging
 		if (debugPath)
-			MemoryPoolObject::deleteInstance(debugPath);
+			deleteInstance(debugPath);
 
 		debugPath = newInstance(Path);
 					
@@ -10019,7 +10019,7 @@ Path *Pathfinder::findAttackPath( const Object *obj, const LocomotorSet& locomot
 	m_zoneManager.clearPassableFlags();
 	Path *hPat = findClosestHierarchicalPath(isHuman, locomotorSet, from, victimPos, isCrusher);
 	if (hPat) {
-		MemoryPoolObject::deleteInstance(hPat);
+		deleteInstance(hPat);
 	}	else {
 		m_zoneManager.setAllPassable();
 	}

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -432,7 +432,7 @@ static void deleteQueue(TeamInQueue* o)
 {
 	if (o)
 	{
-		MemoryPoolObject::deleteInstance(o);
+		deleteInstance(o);
 	}
 }
 
@@ -859,7 +859,7 @@ void AIPlayer::aiPreTeamDestroy( const Team *deletedTeam )
 			if (team->m_team == deletedTeam) {
 				// The members of the team all got killed before we could finish building the team.
 				removeFrom_TeamBuildQueue(team);
-				MemoryPoolObject::deleteInstance(team);
+				deleteInstance(team);
 				iter = iterate_TeamBuildQueue();
 			}
 		}
@@ -871,7 +871,7 @@ void AIPlayer::aiPreTeamDestroy( const Team *deletedTeam )
 			if (team->m_team == deletedTeam) {
 				// The members of the team all got killed before we could activate the team.
 				removeFrom_TeamReadyQueue(team);
-				MemoryPoolObject::deleteInstance(team);
+				deleteInstance(team);
 				iter = iterate_TeamReadyQueue();
 			}
 		}
@@ -2305,7 +2305,7 @@ void AIPlayer::recruitSpecificAITeam(TeamPrototype *teamProto, Real recruitRadiu
 		}	else {
 			//disband.
 			if (!theTeam->getPrototype()->getIsSingleton()) {
-				MemoryPoolObject::deleteInstance(theTeam);
+				deleteInstance(theTeam);
 				theTeam = NULL;
 			}
 			AsciiString teamName = teamProto->getName();
@@ -2497,7 +2497,7 @@ void AIPlayer::checkReadyTeams( void )
 						TheScriptEngine->AppendDebugMessage(teamName, false);
 					}
 				}
-				MemoryPoolObject::deleteInstance(team);
+				deleteInstance(team);
 				iter = iterate_TeamReadyQueue();
 			}																		 
 		}
@@ -2529,7 +2529,7 @@ void AIPlayer::checkQueuedTeams( void )
 					// Disband.
 					removeFrom_TeamBuildQueue(team);
 					team->disband();
-					MemoryPoolObject::deleteInstance(team);
+					deleteInstance(team);
 					if (isSkirmishAI()) {
 						TheScriptEngine->clearTeamFlags();
 					}
@@ -3160,7 +3160,7 @@ TeamInQueue::~TeamInQueue()
 	for( order = m_workOrders; order; order = next )
 	{
 		next = order->m_next;
-		MemoryPoolObject::deleteInstance(order);
+		deleteInstance(order);
 	}
 	// If we have a team, activate it.  If it is empty, Team.cpp will remove empty active teams.
 	if (m_team) m_team->setActive();
@@ -3261,7 +3261,7 @@ void TeamInQueue::disband()
 	if (m_team != newTeam) {
 		m_team->transferUnitsTo(newTeam);
 		if (!m_team->getPrototype()->getIsSingleton()) {
-			MemoryPoolObject::deleteInstance(m_team);
+			deleteInstance(m_team);
 		}
 		m_team = NULL;
 	}

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -432,7 +432,7 @@ static void deleteQueue(TeamInQueue* o)
 {
 	if (o)
 	{
-		o->deleteInstance();
+		MemoryPoolObject::deleteInstance(o);
 	}
 }
 
@@ -859,7 +859,7 @@ void AIPlayer::aiPreTeamDestroy( const Team *deletedTeam )
 			if (team->m_team == deletedTeam) {
 				// The members of the team all got killed before we could finish building the team.
 				removeFrom_TeamBuildQueue(team);
-				team->deleteInstance();
+				MemoryPoolObject::deleteInstance(team);
 				iter = iterate_TeamBuildQueue();
 			}
 		}
@@ -871,7 +871,7 @@ void AIPlayer::aiPreTeamDestroy( const Team *deletedTeam )
 			if (team->m_team == deletedTeam) {
 				// The members of the team all got killed before we could activate the team.
 				removeFrom_TeamReadyQueue(team);
-				team->deleteInstance();
+				MemoryPoolObject::deleteInstance(team);
 				iter = iterate_TeamReadyQueue();
 			}
 		}
@@ -2305,7 +2305,7 @@ void AIPlayer::recruitSpecificAITeam(TeamPrototype *teamProto, Real recruitRadiu
 		}	else {
 			//disband.
 			if (!theTeam->getPrototype()->getIsSingleton()) {
-				theTeam->deleteInstance();
+				MemoryPoolObject::deleteInstance(theTeam);
 				theTeam = NULL;
 			}
 			AsciiString teamName = teamProto->getName();
@@ -2497,7 +2497,7 @@ void AIPlayer::checkReadyTeams( void )
 						TheScriptEngine->AppendDebugMessage(teamName, false);
 					}
 				}
-				team->deleteInstance();
+				MemoryPoolObject::deleteInstance(team);
 				iter = iterate_TeamReadyQueue();
 			}																		 
 		}
@@ -2529,7 +2529,7 @@ void AIPlayer::checkQueuedTeams( void )
 					// Disband.
 					removeFrom_TeamBuildQueue(team);
 					team->disband();
-					team->deleteInstance();
+					MemoryPoolObject::deleteInstance(team);
 					if (isSkirmishAI()) {
 						TheScriptEngine->clearTeamFlags();
 					}
@@ -3160,7 +3160,7 @@ TeamInQueue::~TeamInQueue()
 	for( order = m_workOrders; order; order = next )
 	{
 		next = order->m_next;
-		order->deleteInstance();
+		MemoryPoolObject::deleteInstance(order);
 	}
 	// If we have a team, activate it.  If it is empty, Team.cpp will remove empty active teams.
 	if (m_team) m_team->setActive();
@@ -3261,7 +3261,7 @@ void TeamInQueue::disband()
 	if (m_team != newTeam) {
 		m_team->transferUnitsTo(newTeam);
 		if (!m_team->getPrototype()->getIsSingleton()) {
-			m_team->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_team);
 		}
 		m_team = NULL;
 	}

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AISkirmishPlayer.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AISkirmishPlayer.cpp
@@ -831,7 +831,7 @@ void AISkirmishPlayer::recruitSpecificAITeam(TeamPrototype *teamProto, Real recr
 		}	else {
 			//disband.
 			if (!theTeam->getPrototype()->getIsSingleton()) {
-				MemoryPoolObject::deleteInstance(theTeam);
+				deleteInstance(theTeam);
 				theTeam = NULL;
 			}
 			AsciiString teamName = teamProto->getName();

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AISkirmishPlayer.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AISkirmishPlayer.cpp
@@ -831,7 +831,7 @@ void AISkirmishPlayer::recruitSpecificAITeam(TeamPrototype *teamProto, Real recr
 		}	else {
 			//disband.
 			if (!theTeam->getPrototype()->getIsSingleton()) {
-				theTeam->deleteInstance();
+				MemoryPoolObject::deleteInstance(theTeam);
 				theTeam = NULL;
 			}
 			AsciiString teamName = teamProto->getName();

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -733,7 +733,7 @@ AIStateMachine::~AIStateMachine()
 {
 	if (m_goalSquad) 
 	{
-		m_goalSquad->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_goalSquad);
 	}
 }
 
@@ -3428,7 +3428,7 @@ AIAttackMoveToState::AIAttackMoveToState( StateMachine *machine ) : AIMoveToStat
 //----------------------------------------------------------------------------------------------------------
 AIAttackMoveToState::~AIAttackMoveToState()
 {
-	m_attackMoveMachine->deleteInstance();
+	MemoryPoolObject::deleteInstance(m_attackMoveMachine);
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -4256,7 +4256,7 @@ AIFollowWaypointPathState ( machine, asGroup, false )
 //-------------------------------------------------------------------------------------------------
 AIAttackFollowWaypointPathState::~AIAttackFollowWaypointPathState()
 {
-	m_attackFollowMachine->deleteInstance();
+	MemoryPoolObject::deleteInstance(m_attackFollowMachine);
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -5190,7 +5190,7 @@ AIAttackState::~AIAttackState()
 	if (m_attackMachine) 
 	{
 		m_attackMachine->halt();
-		m_attackMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_attackMachine);
 	}
 }
 
@@ -5480,7 +5480,7 @@ void AIAttackState::onExit( StateExitType status )
 	// destroy the attack machine
 	if (m_attackMachine)
 	{
-		m_attackMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_attackMachine);
 		m_attackMachine = NULL;
 	}
 
@@ -5574,7 +5574,7 @@ AIAttackSquadState::~AIAttackSquadState()
 {
 	if (m_attackSquadMachine)	{
 		m_attackSquadMachine->halt();
-		m_attackSquadMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_attackSquadMachine);
 	}
 }
 
@@ -5699,7 +5699,7 @@ void AIAttackSquadState::onExit( StateExitType status )
 	if( m_attackSquadMachine )
 	{
 		// destroy the attack machine
-		m_attackSquadMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_attackSquadMachine);
 		m_attackSquadMachine = NULL;
 	}
 }
@@ -5811,7 +5811,7 @@ AIDockState::~AIDockState()
 {
 	if (m_dockMachine) {
 		m_dockMachine->halt();
-		m_dockMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_dockMachine);
 	}
 }
 
@@ -5915,7 +5915,7 @@ void AIDockState::onExit( StateExitType status )
 	// destroy the dock machine
 	if (m_dockMachine) {
 		m_dockMachine->halt();// GS, you have to halt before you delete to do cleanup.
-		m_dockMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_dockMachine);
 		m_dockMachine = NULL;
 	}	else {
 		DEBUG_LOG(("Dock exited immediately\n"));
@@ -6295,7 +6295,7 @@ AIGuardState::~AIGuardState()
 {
 	if (m_guardMachine)	{
 		m_guardMachine->halt();
-		m_guardMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_guardMachine);
 	}
 }
 
@@ -6380,7 +6380,7 @@ StateReturnType AIGuardState::onEnter()
 //----------------------------------------------------------------------------------------------------------
 void AIGuardState::onExit( StateExitType status )
 {
-	m_guardMachine->deleteInstance();
+	MemoryPoolObject::deleteInstance(m_guardMachine);
 	m_guardMachine = NULL;
 
 	Object *obj = getMachineOwner();
@@ -6421,7 +6421,7 @@ AITunnelNetworkGuardState::~AITunnelNetworkGuardState()
 {
 	if (m_guardMachine)	{
 		m_guardMachine->halt();
-		m_guardMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_guardMachine);
 	}
 }
 
@@ -6501,7 +6501,7 @@ StateReturnType AITunnelNetworkGuardState::onEnter()
 //----------------------------------------------------------------------------------------------------------
 void AITunnelNetworkGuardState::onExit( StateExitType status )
 {
-	m_guardMachine->deleteInstance();
+	MemoryPoolObject::deleteInstance(m_guardMachine);
 	m_guardMachine = NULL;
 
 	Object *obj = getMachineOwner();
@@ -6547,7 +6547,7 @@ AIHuntState::~AIHuntState()
 	if (m_huntMachine) 
 	{
 		m_huntMachine->halt();
-		m_huntMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_huntMachine);
 	}
 }
 
@@ -6614,7 +6614,7 @@ StateReturnType AIHuntState::onEnter()
 void AIHuntState::onExit( StateExitType status )
 {
 	// destroy the hunt machine
-	m_huntMachine->deleteInstance();
+	MemoryPoolObject::deleteInstance(m_huntMachine);
 	m_huntMachine = NULL;
 
 	Object *obj = getMachineOwner();
@@ -6743,7 +6743,7 @@ AIAttackAreaState::~AIAttackAreaState()
 {
 	if (m_attackMachine) {
 		m_attackMachine->halt();
-		m_attackMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_attackMachine);
 	}
 }
 
@@ -6818,7 +6818,7 @@ StateReturnType AIAttackAreaState::onEnter()
 void AIAttackAreaState::onExit( StateExitType status )
 {
 	// destroy the hunt machine
-	m_attackMachine->deleteInstance();
+	MemoryPoolObject::deleteInstance(m_attackMachine);
 	m_attackMachine = NULL;
 }
 

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -733,7 +733,7 @@ AIStateMachine::~AIStateMachine()
 {
 	if (m_goalSquad) 
 	{
-		MemoryPoolObject::deleteInstance(m_goalSquad);
+		deleteInstance(m_goalSquad);
 	}
 }
 
@@ -3428,7 +3428,7 @@ AIAttackMoveToState::AIAttackMoveToState( StateMachine *machine ) : AIMoveToStat
 //----------------------------------------------------------------------------------------------------------
 AIAttackMoveToState::~AIAttackMoveToState()
 {
-	MemoryPoolObject::deleteInstance(m_attackMoveMachine);
+	deleteInstance(m_attackMoveMachine);
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -4256,7 +4256,7 @@ AIFollowWaypointPathState ( machine, asGroup, false )
 //-------------------------------------------------------------------------------------------------
 AIAttackFollowWaypointPathState::~AIAttackFollowWaypointPathState()
 {
-	MemoryPoolObject::deleteInstance(m_attackFollowMachine);
+	deleteInstance(m_attackFollowMachine);
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -5190,7 +5190,7 @@ AIAttackState::~AIAttackState()
 	if (m_attackMachine) 
 	{
 		m_attackMachine->halt();
-		MemoryPoolObject::deleteInstance(m_attackMachine);
+		deleteInstance(m_attackMachine);
 	}
 }
 
@@ -5480,7 +5480,7 @@ void AIAttackState::onExit( StateExitType status )
 	// destroy the attack machine
 	if (m_attackMachine)
 	{
-		MemoryPoolObject::deleteInstance(m_attackMachine);
+		deleteInstance(m_attackMachine);
 		m_attackMachine = NULL;
 	}
 
@@ -5574,7 +5574,7 @@ AIAttackSquadState::~AIAttackSquadState()
 {
 	if (m_attackSquadMachine)	{
 		m_attackSquadMachine->halt();
-		MemoryPoolObject::deleteInstance(m_attackSquadMachine);
+		deleteInstance(m_attackSquadMachine);
 	}
 }
 
@@ -5699,7 +5699,7 @@ void AIAttackSquadState::onExit( StateExitType status )
 	if( m_attackSquadMachine )
 	{
 		// destroy the attack machine
-		MemoryPoolObject::deleteInstance(m_attackSquadMachine);
+		deleteInstance(m_attackSquadMachine);
 		m_attackSquadMachine = NULL;
 	}
 }
@@ -5811,7 +5811,7 @@ AIDockState::~AIDockState()
 {
 	if (m_dockMachine) {
 		m_dockMachine->halt();
-		MemoryPoolObject::deleteInstance(m_dockMachine);
+		deleteInstance(m_dockMachine);
 	}
 }
 
@@ -5915,7 +5915,7 @@ void AIDockState::onExit( StateExitType status )
 	// destroy the dock machine
 	if (m_dockMachine) {
 		m_dockMachine->halt();// GS, you have to halt before you delete to do cleanup.
-		MemoryPoolObject::deleteInstance(m_dockMachine);
+		deleteInstance(m_dockMachine);
 		m_dockMachine = NULL;
 	}	else {
 		DEBUG_LOG(("Dock exited immediately\n"));
@@ -6295,7 +6295,7 @@ AIGuardState::~AIGuardState()
 {
 	if (m_guardMachine)	{
 		m_guardMachine->halt();
-		MemoryPoolObject::deleteInstance(m_guardMachine);
+		deleteInstance(m_guardMachine);
 	}
 }
 
@@ -6380,7 +6380,7 @@ StateReturnType AIGuardState::onEnter()
 //----------------------------------------------------------------------------------------------------------
 void AIGuardState::onExit( StateExitType status )
 {
-	MemoryPoolObject::deleteInstance(m_guardMachine);
+	deleteInstance(m_guardMachine);
 	m_guardMachine = NULL;
 
 	Object *obj = getMachineOwner();
@@ -6421,7 +6421,7 @@ AITunnelNetworkGuardState::~AITunnelNetworkGuardState()
 {
 	if (m_guardMachine)	{
 		m_guardMachine->halt();
-		MemoryPoolObject::deleteInstance(m_guardMachine);
+		deleteInstance(m_guardMachine);
 	}
 }
 
@@ -6501,7 +6501,7 @@ StateReturnType AITunnelNetworkGuardState::onEnter()
 //----------------------------------------------------------------------------------------------------------
 void AITunnelNetworkGuardState::onExit( StateExitType status )
 {
-	MemoryPoolObject::deleteInstance(m_guardMachine);
+	deleteInstance(m_guardMachine);
 	m_guardMachine = NULL;
 
 	Object *obj = getMachineOwner();
@@ -6547,7 +6547,7 @@ AIHuntState::~AIHuntState()
 	if (m_huntMachine) 
 	{
 		m_huntMachine->halt();
-		MemoryPoolObject::deleteInstance(m_huntMachine);
+		deleteInstance(m_huntMachine);
 	}
 }
 
@@ -6614,7 +6614,7 @@ StateReturnType AIHuntState::onEnter()
 void AIHuntState::onExit( StateExitType status )
 {
 	// destroy the hunt machine
-	MemoryPoolObject::deleteInstance(m_huntMachine);
+	deleteInstance(m_huntMachine);
 	m_huntMachine = NULL;
 
 	Object *obj = getMachineOwner();
@@ -6743,7 +6743,7 @@ AIAttackAreaState::~AIAttackAreaState()
 {
 	if (m_attackMachine) {
 		m_attackMachine->halt();
-		MemoryPoolObject::deleteInstance(m_attackMachine);
+		deleteInstance(m_attackMachine);
 	}
 }
 
@@ -6818,7 +6818,7 @@ StateReturnType AIAttackAreaState::onEnter()
 void AIAttackAreaState::onExit( StateExitType status )
 {
 	// destroy the hunt machine
-	MemoryPoolObject::deleteInstance(m_attackMachine);
+	deleteInstance(m_attackMachine);
 	m_attackMachine = NULL;
 }
 

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AITNGuard.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AITNGuard.cpp
@@ -429,7 +429,7 @@ void AITNGuardInnerState::onExit( StateExitType status )
 	if (m_attackState) 
 	{
 		m_attackState->onExit(status);
-		m_attackState->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_attackState);
 		m_attackState = NULL;
 	}
 }
@@ -526,7 +526,7 @@ void AITNGuardOuterState::onExit( StateExitType status )
 	if (m_attackState) 
 	{
 		m_attackState->onExit(status);
-		m_attackState->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_attackState);
 		m_attackState = NULL;
 	}
 }
@@ -832,7 +832,7 @@ void AITNGuardAttackAggressorState::onExit( StateExitType status )
 	if (m_attackState) 
 	{
 		m_attackState->onExit(status);
-		m_attackState->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_attackState);
 		m_attackState = NULL;
 	}
 

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AITNGuard.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AITNGuard.cpp
@@ -429,7 +429,7 @@ void AITNGuardInnerState::onExit( StateExitType status )
 	if (m_attackState) 
 	{
 		m_attackState->onExit(status);
-		MemoryPoolObject::deleteInstance(m_attackState);
+		deleteInstance(m_attackState);
 		m_attackState = NULL;
 	}
 }
@@ -526,7 +526,7 @@ void AITNGuardOuterState::onExit( StateExitType status )
 	if (m_attackState) 
 	{
 		m_attackState->onExit(status);
-		MemoryPoolObject::deleteInstance(m_attackState);
+		deleteInstance(m_attackState);
 		m_attackState = NULL;
 	}
 }
@@ -832,7 +832,7 @@ void AITNGuardAttackAggressorState::onExit( StateExitType status )
 	if (m_attackState) 
 	{
 		m_attackState->onExit(status);
-		MemoryPoolObject::deleteInstance(m_attackState);
+		deleteInstance(m_attackState);
 		m_attackState = NULL;
 	}
 

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/TurretAI.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/TurretAI.cpp
@@ -327,7 +327,7 @@ TurretAI::~TurretAI()
 	stopRotOrPitchSound();
 
 	if (m_turretStateMachine)
-		m_turretStateMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_turretStateMachine);
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/TurretAI.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/TurretAI.cpp
@@ -327,7 +327,7 @@ TurretAI::~TurretAI()
 	stopRotOrPitchSound();
 
 	if (m_turretStateMachine)
-		MemoryPoolObject::deleteInstance(m_turretStateMachine);
+		deleteInstance(m_turretStateMachine);
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
@@ -79,7 +79,7 @@ PolygonTrigger::~PolygonTrigger(void)
 		while (cur) {
 			next = cur->getNext();
 			cur->setNextPoly(NULL); // prevents recursion. 
-			cur->deleteInstance();
+			MemoryPoolObject::deleteInstance(cur);
 			cur = next; 
 		}
 	}
@@ -320,7 +320,7 @@ void PolygonTrigger::deleteTriggers(void)
 	PolygonTrigger *pList = ThePolygonTriggerListPtr;	
 	ThePolygonTriggerListPtr = NULL;
 	s_currentID = 1;
-	pList->deleteInstance();
+	MemoryPoolObject::deleteInstance(pList);
 }
 
 /**

--- a/Generals/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
@@ -79,7 +79,7 @@ PolygonTrigger::~PolygonTrigger(void)
 		while (cur) {
 			next = cur->getNext();
 			cur->setNextPoly(NULL); // prevents recursion. 
-			MemoryPoolObject::deleteInstance(cur);
+			deleteInstance(cur);
 			cur = next; 
 		}
 	}
@@ -320,7 +320,7 @@ void PolygonTrigger::deleteTriggers(void)
 	PolygonTrigger *pList = ThePolygonTriggerListPtr;	
 	ThePolygonTriggerListPtr = NULL;
 	s_currentID = 1;
-	MemoryPoolObject::deleteInstance(pList);
+	deleteInstance(pList);
 }
 
 /**

--- a/Generals/Code/GameEngine/Source/GameLogic/Map/SidesList.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Map/SidesList.cpp
@@ -85,11 +85,11 @@ SidesInfo::~SidesInfo(void)
 
 void SidesInfo::init(const Dict* d)
 {
-	m_pBuildList->deleteInstance();
+	MemoryPoolObject::deleteInstance(m_pBuildList);
 	m_pBuildList = NULL;
 	m_dict.clear();
 	if (m_scripts) 
-		m_scripts->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_scripts);
 	m_scripts = NULL;
 	if (d)
 		m_dict = *d;
@@ -303,12 +303,12 @@ Bool SidesList::ParseSidesDataChunk(DataChunkInput &file, DataChunkInfo *info, v
 	for (i=0; i<count; i++) {
 		if (i<TheSidesList->getNumSides()) {
 			ScriptList *pSL = TheSidesList->getSideInfo(i)->getScriptList();
-			pSL->deleteInstance();
+			MemoryPoolObject::deleteInstance(pSL);
 			TheSidesList->getSideInfo(i)->setScriptList(scripts[i]);
 			scripts[i] = NULL;
 		} else {
 			// Read in more players worth than we have.
-			scripts[i]->deleteInstance();
+			MemoryPoolObject::deleteInstance(scripts[i]);
 			scripts[i] = NULL;
 		}
 	}
@@ -539,7 +539,7 @@ void SidesList::prepareForMP_or_Skirmish(void)
 					getSkirmishSideInfo(curSide)->setScriptList(scripts[i]);
 					scripts[i] = NULL;
 					if (pSL) 
-						pSL->deleteInstance();
+						MemoryPoolObject::deleteInstance(pSL);
 					scripts[i] = NULL;
 				}
 				for (i=0; i<MAX_PLAYER_COUNT; i++) {
@@ -945,7 +945,7 @@ BuildListInfo::~BuildListInfo(void)
 		while (cur) {
 			next = cur->getNext();
 			cur->setNextBuildList(NULL); // prevents recursion. 
-			cur->deleteInstance();
+			MemoryPoolObject::deleteInstance(cur);
 			cur = next; 
 		}
 	}

--- a/Generals/Code/GameEngine/Source/GameLogic/Map/SidesList.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Map/SidesList.cpp
@@ -85,11 +85,11 @@ SidesInfo::~SidesInfo(void)
 
 void SidesInfo::init(const Dict* d)
 {
-	MemoryPoolObject::deleteInstance(m_pBuildList);
+	deleteInstance(m_pBuildList);
 	m_pBuildList = NULL;
 	m_dict.clear();
 	if (m_scripts) 
-		MemoryPoolObject::deleteInstance(m_scripts);
+		deleteInstance(m_scripts);
 	m_scripts = NULL;
 	if (d)
 		m_dict = *d;
@@ -303,12 +303,12 @@ Bool SidesList::ParseSidesDataChunk(DataChunkInput &file, DataChunkInfo *info, v
 	for (i=0; i<count; i++) {
 		if (i<TheSidesList->getNumSides()) {
 			ScriptList *pSL = TheSidesList->getSideInfo(i)->getScriptList();
-			MemoryPoolObject::deleteInstance(pSL);
+			deleteInstance(pSL);
 			TheSidesList->getSideInfo(i)->setScriptList(scripts[i]);
 			scripts[i] = NULL;
 		} else {
 			// Read in more players worth than we have.
-			MemoryPoolObject::deleteInstance(scripts[i]);
+			deleteInstance(scripts[i]);
 			scripts[i] = NULL;
 		}
 	}
@@ -539,7 +539,7 @@ void SidesList::prepareForMP_or_Skirmish(void)
 					getSkirmishSideInfo(curSide)->setScriptList(scripts[i]);
 					scripts[i] = NULL;
 					if (pSL) 
-						MemoryPoolObject::deleteInstance(pSL);
+						deleteInstance(pSL);
 					scripts[i] = NULL;
 				}
 				for (i=0; i<MAX_PLAYER_COUNT; i++) {
@@ -945,7 +945,7 @@ BuildListInfo::~BuildListInfo(void)
 		while (cur) {
 			next = cur->getNext();
 			cur->setNextBuildList(NULL); // prevents recursion. 
-			MemoryPoolObject::deleteInstance(cur);
+			deleteInstance(cur);
 			cur = next; 
 		}
 	}

--- a/Generals/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
@@ -1420,7 +1420,7 @@ void TerrainLogic::deleteWaypoints(void)
 	for (pWay = getFirstWaypoint(); pWay; pWay = pNext) {
 		pNext = pWay->getNext();
 		pWay->setNext(NULL);
-		MemoryPoolObject::deleteInstance(pWay);
+		deleteInstance(pWay);
 	}
 	m_waypointListHead = NULL;
 }
@@ -1994,7 +1994,7 @@ void TerrainLogic::deleteBridges(void)
 	for (pBridge = getFirstBridge(); pBridge; pBridge = pNext) {
 		pNext = pBridge->getNext();
 		pBridge->setNext(NULL);
-		MemoryPoolObject::deleteInstance(pBridge);
+		deleteInstance(pBridge);
 	}
 	m_bridgeListHead = NULL;
 }
@@ -2050,7 +2050,7 @@ void TerrainLogic::deleteBridge( Bridge *bridge )
 		TheGameLogic->destroyObject( bridgeObj );
 
 	// delete the bridge in question
-	MemoryPoolObject::deleteInstance(bridge);
+	deleteInstance(bridge);
 
 }  // end deleteBridge
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
@@ -1420,7 +1420,7 @@ void TerrainLogic::deleteWaypoints(void)
 	for (pWay = getFirstWaypoint(); pWay; pWay = pNext) {
 		pNext = pWay->getNext();
 		pWay->setNext(NULL);
-		pWay->deleteInstance();
+		MemoryPoolObject::deleteInstance(pWay);
 	}
 	m_waypointListHead = NULL;
 }
@@ -1994,7 +1994,7 @@ void TerrainLogic::deleteBridges(void)
 	for (pBridge = getFirstBridge(); pBridge; pBridge = pNext) {
 		pNext = pBridge->getNext();
 		pBridge->setNext(NULL);
-		pBridge->deleteInstance();
+		MemoryPoolObject::deleteInstance(pBridge);
 	}
 	m_bridgeListHead = NULL;
 }
@@ -2050,7 +2050,7 @@ void TerrainLogic::deleteBridge( Bridge *bridge )
 		TheGameLogic->destroyObject( bridgeObj );
 
 	// delete the bridge in question
-	bridge->deleteInstance();
+	MemoryPoolObject::deleteInstance(bridge);
 
 }  // end deleteBridge
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/FireWeaponWhenDamagedBehavior.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/FireWeaponWhenDamagedBehavior.cpp
@@ -147,22 +147,22 @@ FireWeaponWhenDamagedBehavior::FireWeaponWhenDamagedBehavior( Thing *thing, cons
 FireWeaponWhenDamagedBehavior::~FireWeaponWhenDamagedBehavior( void )
 {
 	if (m_reactionWeaponPristine)
-		m_reactionWeaponPristine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_reactionWeaponPristine);
 	if (m_reactionWeaponDamaged)
-		m_reactionWeaponDamaged->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_reactionWeaponDamaged);
 	if (m_reactionWeaponReallyDamaged)
-		m_reactionWeaponReallyDamaged->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_reactionWeaponReallyDamaged);
 	if (m_reactionWeaponRubble)
-		m_reactionWeaponRubble->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_reactionWeaponRubble);
 
 	if (m_continuousWeaponPristine)
-		m_continuousWeaponPristine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_continuousWeaponPristine);
 	if (m_continuousWeaponDamaged)
-		m_continuousWeaponDamaged->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_continuousWeaponDamaged);
 	if (m_continuousWeaponReallyDamaged)
-		m_continuousWeaponReallyDamaged->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_continuousWeaponReallyDamaged);
 	if (m_continuousWeaponRubble)
-		m_continuousWeaponRubble->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_continuousWeaponRubble);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/FireWeaponWhenDamagedBehavior.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/FireWeaponWhenDamagedBehavior.cpp
@@ -147,22 +147,22 @@ FireWeaponWhenDamagedBehavior::FireWeaponWhenDamagedBehavior( Thing *thing, cons
 FireWeaponWhenDamagedBehavior::~FireWeaponWhenDamagedBehavior( void )
 {
 	if (m_reactionWeaponPristine)
-		MemoryPoolObject::deleteInstance(m_reactionWeaponPristine);
+		deleteInstance(m_reactionWeaponPristine);
 	if (m_reactionWeaponDamaged)
-		MemoryPoolObject::deleteInstance(m_reactionWeaponDamaged);
+		deleteInstance(m_reactionWeaponDamaged);
 	if (m_reactionWeaponReallyDamaged)
-		MemoryPoolObject::deleteInstance(m_reactionWeaponReallyDamaged);
+		deleteInstance(m_reactionWeaponReallyDamaged);
 	if (m_reactionWeaponRubble)
-		MemoryPoolObject::deleteInstance(m_reactionWeaponRubble);
+		deleteInstance(m_reactionWeaponRubble);
 
 	if (m_continuousWeaponPristine)
-		MemoryPoolObject::deleteInstance(m_continuousWeaponPristine);
+		deleteInstance(m_continuousWeaponPristine);
 	if (m_continuousWeaponDamaged)
-		MemoryPoolObject::deleteInstance(m_continuousWeaponDamaged);
+		deleteInstance(m_continuousWeaponDamaged);
 	if (m_continuousWeaponReallyDamaged)
-		MemoryPoolObject::deleteInstance(m_continuousWeaponReallyDamaged);
+		deleteInstance(m_continuousWeaponReallyDamaged);
 	if (m_continuousWeaponRubble)
-		MemoryPoolObject::deleteInstance(m_continuousWeaponRubble);
+		deleteInstance(m_continuousWeaponRubble);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/PrisonBehavior.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/PrisonBehavior.cpp
@@ -157,7 +157,7 @@ void PrisonBehavior::onDelete( void )
 
 		// delete element and set next to head
 		visual = m_visualList->m_next;
-		MemoryPoolObject::deleteInstance(m_visualList);
+		deleteInstance(m_visualList);
 		m_visualList = visual;
 
 	}  // end while
@@ -363,7 +363,7 @@ void PrisonBehavior::removeVisual( Object *obj )
 				m_visualList = visual->m_next;
 
 			// delete the element
-			MemoryPoolObject::deleteInstance(visual);
+			deleteInstance(visual);
 
 			break;  // exit for
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/PrisonBehavior.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/PrisonBehavior.cpp
@@ -157,7 +157,7 @@ void PrisonBehavior::onDelete( void )
 
 		// delete element and set next to head
 		visual = m_visualList->m_next;
-		m_visualList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_visualList);
 		m_visualList = visual;
 
 	}  // end while
@@ -363,7 +363,7 @@ void PrisonBehavior::removeVisual( Object *obj )
 				m_visualList = visual->m_next;
 
 			// delete the element
-			visual->deleteInstance();
+			MemoryPoolObject::deleteInstance(visual);
 
 			break;  // exit for
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/PropagandaTowerBehavior.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/PropagandaTowerBehavior.cpp
@@ -263,7 +263,7 @@ UpdateSleepTime PropagandaTowerBehavior::update( void )
 				prev->next = curr->next;
 			else
 				m_insideList = curr->next;
-			MemoryPoolObject::deleteInstance(curr);
+			deleteInstance(curr);
 				
 		}  // end else
 
@@ -371,7 +371,7 @@ void PropagandaTowerBehavior::removeAllInfluence( void )
 	{
 
 		o = m_insideList->next;
-		MemoryPoolObject::deleteInstance(m_insideList);
+		deleteInstance(m_insideList);
 		m_insideList = o;
 
 	}  // end while
@@ -503,7 +503,7 @@ void PropagandaTowerBehavior::doScan( void )
 	{
 
 		next = m_insideList->next;
-		MemoryPoolObject::deleteInstance(m_insideList);
+		deleteInstance(m_insideList);
 		m_insideList = next;
 
 	}  // end while

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/PropagandaTowerBehavior.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/PropagandaTowerBehavior.cpp
@@ -263,7 +263,7 @@ UpdateSleepTime PropagandaTowerBehavior::update( void )
 				prev->next = curr->next;
 			else
 				m_insideList = curr->next;
-			curr->deleteInstance();
+			MemoryPoolObject::deleteInstance(curr);
 				
 		}  // end else
 
@@ -371,7 +371,7 @@ void PropagandaTowerBehavior::removeAllInfluence( void )
 	{
 
 		o = m_insideList->next;
-		m_insideList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_insideList);
 		m_insideList = o;
 
 	}  // end while
@@ -503,7 +503,7 @@ void PropagandaTowerBehavior::doScan( void )
 	{
 
 		next = m_insideList->next;
-		m_insideList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_insideList);
 		m_insideList = next;
 
 	}  // end while

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp
@@ -850,7 +850,7 @@ void ActiveBody::deleteAllParticleSystems( void )
 		nextBodySystem = m_particleSystems->m_next;
 
 		// destroy this entry
-		m_particleSystems->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_particleSystems);
 
 		// set the body systems head to the next
 		m_particleSystems = nextBodySystem;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp
@@ -850,7 +850,7 @@ void ActiveBody::deleteAllParticleSystems( void )
 		nextBodySystem = m_particleSystems->m_next;
 
 		// destroy this entry
-		MemoryPoolObject::deleteInstance(m_particleSystems);
+		deleteInstance(m_particleSystems);
 
 		// set the body systems head to the next
 		m_particleSystems = nextBodySystem;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Collide/FireWeaponCollide.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Collide/FireWeaponCollide.cpp
@@ -67,7 +67,7 @@ FireWeaponCollide::FireWeaponCollide( Thing *thing, const ModuleData* moduleData
 FireWeaponCollide::~FireWeaponCollide( void )
 {
 	if (m_collideWeapon)
-		MemoryPoolObject::deleteInstance(m_collideWeapon);
+		deleteInstance(m_collideWeapon);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Collide/FireWeaponCollide.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Collide/FireWeaponCollide.cpp
@@ -67,7 +67,7 @@ FireWeaponCollide::FireWeaponCollide( Thing *thing, const ModuleData* moduleData
 FireWeaponCollide::~FireWeaponCollide( void )
 {
 	if (m_collideWeapon)
-		m_collideWeapon->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_collideWeapon);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Locomotor.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Locomotor.cpp
@@ -512,7 +512,7 @@ LocomotorStore::~LocomotorStore()
 	// delete all the templates, then clear out the table.
 	LocomotorTemplateMap::iterator it;
 	for (it = m_locomotorTemplates.begin(); it != m_locomotorTemplates.end(); ++it) {
-		it->second->deleteInstance();
+		MemoryPoolObject::deleteInstance(it->second);
 	}
 
 	m_locomotorTemplates.clear();
@@ -2727,7 +2727,7 @@ void LocomotorSet::clear()
 	for (int i = 0; i < m_locomotors.size(); ++i)
 	{
 		if (m_locomotors[i])
-			m_locomotors[i]->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_locomotors[i]);
 	}
 	m_locomotors.clear();
 	m_validLocomotorSurfaces = 0;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Locomotor.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Locomotor.cpp
@@ -512,7 +512,7 @@ LocomotorStore::~LocomotorStore()
 	// delete all the templates, then clear out the table.
 	LocomotorTemplateMap::iterator it;
 	for (it = m_locomotorTemplates.begin(); it != m_locomotorTemplates.end(); ++it) {
-		MemoryPoolObject::deleteInstance(it->second);
+		deleteInstance(it->second);
 	}
 
 	m_locomotorTemplates.clear();
@@ -2727,7 +2727,7 @@ void LocomotorSet::clear()
 	for (int i = 0; i < m_locomotors.size(); ++i)
 	{
 		if (m_locomotors[i])
-			MemoryPoolObject::deleteInstance(m_locomotors[i]);
+			deleteInstance(m_locomotors[i]);
 	}
 	m_locomotors.clear();
 	m_validLocomotorSurfaces = 0;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -549,13 +549,13 @@ Object::~Object()
 	setTeam( NULL );
 
 	// Object's set of these persist for the life of the object.
-	m_partitionLastLook->deleteInstance();
+	MemoryPoolObject::deleteInstance(m_partitionLastLook);
 	m_partitionLastLook = NULL;
-	m_partitionLastShroud->deleteInstance();
+	MemoryPoolObject::deleteInstance(m_partitionLastShroud);
 	m_partitionLastShroud = NULL;
-	m_partitionLastThreat->deleteInstance();
+	MemoryPoolObject::deleteInstance(m_partitionLastThreat);
 	m_partitionLastThreat = NULL;
-	m_partitionLastValue->deleteInstance();
+	MemoryPoolObject::deleteInstance(m_partitionLastValue);
 	m_partitionLastValue = NULL;
 
 	// remove the object from the partition system if present
@@ -573,7 +573,7 @@ Object::~Object()
 	// delete any modules present
 	for (BehaviorModule** b = m_behaviors; *b; ++b)
 	{
-		(*b)->deleteInstance();
+		MemoryPoolObject::deleteInstance((*b));
 		*b = NULL;	// in case other modules call findModule from their dtor!
 	}
 
@@ -581,7 +581,7 @@ Object::~Object()
 	m_behaviors = NULL;
 
 	if( m_experienceTracker )
-		m_experienceTracker->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_experienceTracker);
 
 	m_experienceTracker = NULL;
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -549,13 +549,13 @@ Object::~Object()
 	setTeam( NULL );
 
 	// Object's set of these persist for the life of the object.
-	MemoryPoolObject::deleteInstance(m_partitionLastLook);
+	deleteInstance(m_partitionLastLook);
 	m_partitionLastLook = NULL;
-	MemoryPoolObject::deleteInstance(m_partitionLastShroud);
+	deleteInstance(m_partitionLastShroud);
 	m_partitionLastShroud = NULL;
-	MemoryPoolObject::deleteInstance(m_partitionLastThreat);
+	deleteInstance(m_partitionLastThreat);
 	m_partitionLastThreat = NULL;
-	MemoryPoolObject::deleteInstance(m_partitionLastValue);
+	deleteInstance(m_partitionLastValue);
 	m_partitionLastValue = NULL;
 
 	// remove the object from the partition system if present
@@ -573,7 +573,7 @@ Object::~Object()
 	// delete any modules present
 	for (BehaviorModule** b = m_behaviors; *b; ++b)
 	{
-		MemoryPoolObject::deleteInstance((*b));
+		deleteInstance(*b);
 		*b = NULL;	// in case other modules call findModule from their dtor!
 	}
 
@@ -581,7 +581,7 @@ Object::~Object()
 	m_behaviors = NULL;
 
 	if( m_experienceTracker )
-		MemoryPoolObject::deleteInstance(m_experienceTracker);
+		deleteInstance(m_experienceTracker);
 
 	m_experienceTracker = NULL;
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
@@ -1500,7 +1500,7 @@ ObjectCreationListStore::~ObjectCreationListStore()
 	for (ObjectCreationNuggetVector::iterator i = m_nuggets.begin(); i != m_nuggets.end(); ++i)
 	{
 		if (*i)
-			MemoryPoolObject::deleteInstance((*i));
+			deleteInstance(*i);
 	}
 	m_nuggets.clear();
 }

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
@@ -1500,7 +1500,7 @@ ObjectCreationListStore::~ObjectCreationListStore()
 	for (ObjectCreationNuggetVector::iterator i = m_nuggets.begin(); i != m_nuggets.end(); ++i)
 	{
 		if (*i)
-			(*i)->deleteInstance();
+			MemoryPoolObject::deleteInstance((*i));
 	}
 	m_nuggets.clear();
 }

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
@@ -2472,7 +2472,7 @@ void PartitionContactList::resetContactList()
 	for (PartitionContactListNode* cd = m_contactList; cd; cd = cdnext)
 	{
 		cdnext = cd->m_next;
-		cd->deleteInstance();
+		MemoryPoolObject::deleteInstance(cd);
 	}
 
 	memset(m_contactHash, 0, sizeof(m_contactHash));
@@ -2906,7 +2906,7 @@ void PartitionManager::unRegisterObject( Object* object )
 		m_moduleList = next;
 
 	// delete module
-	mod->deleteInstance();
+	MemoryPoolObject::deleteInstance(mod);
 
 }
 
@@ -2964,7 +2964,7 @@ void PartitionManager::unRegisterGhostObject( GhostObject* object )
 		m_moduleList = next;
 
 	// delete module
-	mod->deleteInstance();
+	MemoryPoolObject::deleteInstance(mod);
 }
 
 /** 
@@ -3978,7 +3978,7 @@ void PartitionManager::processPendingUndoShroudRevealQueue( Bool considerTimesta
 
 		undoShroudReveal( thisInfo->m_where.x, thisInfo->m_where.y, thisInfo->m_howFar, thisInfo->m_forWhom );
 
-		thisInfo->deleteInstance();
+		MemoryPoolObject::deleteInstance(thisInfo);
 		m_pendingUndoShroudReveals.pop();
 	}
 }
@@ -3999,7 +3999,7 @@ void PartitionManager::resetPendingUndoShroudRevealQueue()
 	while( !m_pendingUndoShroudReveals.empty() )
 	{
 		SightingInfo *thisInfo = m_pendingUndoShroudReveals.front();
-		thisInfo->deleteInstance();
+		MemoryPoolObject::deleteInstance(thisInfo);
 		m_pendingUndoShroudReveals.pop();
 	}
 }

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
@@ -2472,7 +2472,7 @@ void PartitionContactList::resetContactList()
 	for (PartitionContactListNode* cd = m_contactList; cd; cd = cdnext)
 	{
 		cdnext = cd->m_next;
-		MemoryPoolObject::deleteInstance(cd);
+		deleteInstance(cd);
 	}
 
 	memset(m_contactHash, 0, sizeof(m_contactHash));
@@ -2906,7 +2906,7 @@ void PartitionManager::unRegisterObject( Object* object )
 		m_moduleList = next;
 
 	// delete module
-	MemoryPoolObject::deleteInstance(mod);
+	deleteInstance(mod);
 
 }
 
@@ -2964,7 +2964,7 @@ void PartitionManager::unRegisterGhostObject( GhostObject* object )
 		m_moduleList = next;
 
 	// delete module
-	MemoryPoolObject::deleteInstance(mod);
+	deleteInstance(mod);
 }
 
 /** 
@@ -3978,7 +3978,7 @@ void PartitionManager::processPendingUndoShroudRevealQueue( Bool considerTimesta
 
 		undoShroudReveal( thisInfo->m_where.x, thisInfo->m_where.y, thisInfo->m_howFar, thisInfo->m_forWhom );
 
-		MemoryPoolObject::deleteInstance(thisInfo);
+		deleteInstance(thisInfo);
 		m_pendingUndoShroudReveals.pop();
 	}
 }
@@ -3999,7 +3999,7 @@ void PartitionManager::resetPendingUndoShroudRevealQueue()
 	while( !m_pendingUndoShroudReveals.empty() )
 	{
 		SightingInfo *thisInfo = m_pendingUndoShroudReveals.front();
-		MemoryPoolObject::deleteInstance(thisInfo);
+		deleteInstance(thisInfo);
 		m_pendingUndoShroudReveals.pop();
 	}
 }

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/SimpleObjectIterator.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/SimpleObjectIterator.cpp
@@ -115,7 +115,7 @@ void SimpleObjectIterator::makeEmpty()
 	while (m_firstClump)
 	{
 		Clump *next = m_firstClump->m_nextClump;
-		m_firstClump->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_firstClump);
 		m_firstClump = next;
 		--m_clumpCount;
 	}

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/SimpleObjectIterator.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/SimpleObjectIterator.cpp
@@ -115,7 +115,7 @@ void SimpleObjectIterator::makeEmpty()
 	while (m_firstClump)
 	{
 		Clump *next = m_firstClump->m_nextClump;
-		MemoryPoolObject::deleteInstance(m_firstClump);
+		deleteInstance(m_firstClump);
 		m_firstClump = next;
 		--m_clumpCount;
 	}

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -101,7 +101,7 @@ AIUpdateModuleData::~AIUpdateModuleData()
 		{
 			TurretAIData* td = const_cast<TurretAIData*>(m_turretData[i]);
 			if (td)
-				MemoryPoolObject::deleteInstance(td);
+				deleteInstance(td);
 		}
 	}
 }
@@ -638,13 +638,13 @@ AIUpdateInterface::~AIUpdateInterface( void )
 
 	if( m_stateMachine ) {
 		m_stateMachine->halt();
-		MemoryPoolObject::deleteInstance(m_stateMachine);
+		deleteInstance(m_stateMachine);
 	}
 
 	for (int i = 0; i < MAX_TURRETS; i++)
 	{
 		if (m_turretAI[i])
-			MemoryPoolObject::deleteInstance(m_turretAI[i]);
+			deleteInstance(m_turretAI[i]);
 		m_turretAI[i] = NULL;
 	}
 	m_stateMachine = NULL;
@@ -1984,7 +1984,7 @@ void AIUpdateInterface::destroyPath( void )
 {
 	// destroy previous path
 	if (m_path)
-		MemoryPoolObject::deleteInstance(m_path);
+		deleteInstance(m_path);
 
 	m_path = NULL;
 	m_waitingForPath = FALSE; // we no longer need it.

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -101,7 +101,7 @@ AIUpdateModuleData::~AIUpdateModuleData()
 		{
 			TurretAIData* td = const_cast<TurretAIData*>(m_turretData[i]);
 			if (td)
-				td->deleteInstance();
+				MemoryPoolObject::deleteInstance(td);
 		}
 	}
 }
@@ -638,13 +638,13 @@ AIUpdateInterface::~AIUpdateInterface( void )
 
 	if( m_stateMachine ) {
 		m_stateMachine->halt();
-		m_stateMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_stateMachine);
 	}
 
 	for (int i = 0; i < MAX_TURRETS; i++)
 	{
 		if (m_turretAI[i])
-			m_turretAI[i]->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_turretAI[i]);
 		m_turretAI[i] = NULL;
 	}
 	m_stateMachine = NULL;
@@ -1984,7 +1984,7 @@ void AIUpdateInterface::destroyPath( void )
 {
 	// destroy previous path
 	if (m_path)
-		m_path->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_path);
 
 	m_path = NULL;
 	m_waitingForPath = FALSE; // we no longer need it.

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DeliverPayloadAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DeliverPayloadAIUpdate.cpp
@@ -138,7 +138,7 @@ DeliverPayloadAIUpdate::~DeliverPayloadAIUpdate( void )
 	m_deliveryDecal.clear();
 
 	if (m_deliverPayloadStateMachine)
-		MemoryPoolObject::deleteInstance(m_deliverPayloadStateMachine);
+		deleteInstance(m_deliverPayloadStateMachine);
 } 
 
 //-------------------------------------------------------------------------------------------------
@@ -261,7 +261,7 @@ void DeliverPayloadAIUpdate::deliverPayload(
 	//****************************************************
 	
 	if (m_deliverPayloadStateMachine)
-		MemoryPoolObject::deleteInstance(m_deliverPayloadStateMachine);
+		deleteInstance(m_deliverPayloadStateMachine);
 	m_deliverPayloadStateMachine = NULL;
 
 	m_moveToPos = *moveToPos;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DeliverPayloadAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DeliverPayloadAIUpdate.cpp
@@ -138,7 +138,7 @@ DeliverPayloadAIUpdate::~DeliverPayloadAIUpdate( void )
 	m_deliveryDecal.clear();
 
 	if (m_deliverPayloadStateMachine)
-		m_deliverPayloadStateMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_deliverPayloadStateMachine);
 } 
 
 //-------------------------------------------------------------------------------------------------
@@ -261,7 +261,7 @@ void DeliverPayloadAIUpdate::deliverPayload(
 	//****************************************************
 	
 	if (m_deliverPayloadStateMachine)
-		m_deliverPayloadStateMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_deliverPayloadStateMachine);
 	m_deliverPayloadStateMachine = NULL;
 
 	m_moveToPos = *moveToPos;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -1178,7 +1178,7 @@ protected:
 	StateMachine *m_actionMachine;
 
 };
-inline DozerActionState::~DozerActionState( void ) { if (m_actionMachine) MemoryPoolObject::deleteInstance(m_actionMachine); }
+inline DozerActionState::~DozerActionState( void ) { if (m_actionMachine) deleteInstance(m_actionMachine); }
 
 // ------------------------------------------------------------------------------------------------
 /** CRC */
@@ -1478,7 +1478,7 @@ DozerAIUpdate::~DozerAIUpdate( void )
 
 	// delete our behavior state machine
 	if( m_dozerMachine )
-		MemoryPoolObject::deleteInstance(m_dozerMachine);
+		deleteInstance(m_dozerMachine);
 
 	// no orders
 	for( Int i = 0; i < DOZER_NUM_TASKS; i++ )

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -1178,7 +1178,7 @@ protected:
 	StateMachine *m_actionMachine;
 
 };
-inline DozerActionState::~DozerActionState( void ) { if (m_actionMachine) m_actionMachine->deleteInstance(); }
+inline DozerActionState::~DozerActionState( void ) { if (m_actionMachine) MemoryPoolObject::deleteInstance(m_actionMachine); }
 
 // ------------------------------------------------------------------------------------------------
 /** CRC */
@@ -1478,7 +1478,7 @@ DozerAIUpdate::~DozerAIUpdate( void )
 
 	// delete our behavior state machine
 	if( m_dozerMachine )
-		m_dozerMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_dozerMachine);
 
 	// no orders
 	for( Int i = 0; i < DOZER_NUM_TASKS; i++ )

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/HackInternetAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/HackInternetAIUpdate.cpp
@@ -158,7 +158,7 @@ void HackInternetAIUpdate::aiDoCommand(const AICommandParms* parms)
 void HackInternetAIUpdate::hackInternet()
 {
 	//if (m_hackInternetStateMachine)
-	//	MemoryPoolObject::deleteInstance(m_hackInternetStateMachine);
+	//	deleteInstance(m_hackInternetStateMachine);
 	//m_hackInternetStateMachine = NULL;
 
 	// must make the state machine AFTER initing the other stuff, since it may inquire of its values...

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/HackInternetAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/HackInternetAIUpdate.cpp
@@ -158,7 +158,7 @@ void HackInternetAIUpdate::aiDoCommand(const AICommandParms* parms)
 void HackInternetAIUpdate::hackInternet()
 {
 	//if (m_hackInternetStateMachine)
-	//	m_hackInternetStateMachine->deleteInstance();
+	//	MemoryPoolObject::deleteInstance(m_hackInternetStateMachine);
 	//m_hackInternetStateMachine = NULL;
 
 	// must make the state machine AFTER initing the other stuff, since it may inquire of its values...

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cpp
@@ -88,7 +88,7 @@ SupplyTruckAIUpdate::SupplyTruckAIUpdate( Thing *thing, const ModuleData* module
 //-------------------------------------------------------------------------------------------------
 SupplyTruckAIUpdate::~SupplyTruckAIUpdate( void )
 {
-	MemoryPoolObject::deleteInstance(m_supplyTruckStateMachine);
+	deleteInstance(m_supplyTruckStateMachine);
 } 
 
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cpp
@@ -88,7 +88,7 @@ SupplyTruckAIUpdate::SupplyTruckAIUpdate( Thing *thing, const ModuleData* module
 //-------------------------------------------------------------------------------------------------
 SupplyTruckAIUpdate::~SupplyTruckAIUpdate( void )
 {
-	m_supplyTruckStateMachine->deleteInstance();
+	MemoryPoolObject::deleteInstance(m_supplyTruckStateMachine);
 } 
 
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -132,13 +132,13 @@ WorkerAIUpdate::~WorkerAIUpdate( void )
 
 	// delete our behavior state machine
 	if( m_dozerMachine )
-		MemoryPoolObject::deleteInstance(m_dozerMachine);
+		deleteInstance(m_dozerMachine);
 
 	if( m_supplyTruckStateMachine )
-		MemoryPoolObject::deleteInstance(m_supplyTruckStateMachine);
+		deleteInstance(m_supplyTruckStateMachine);
 
 	if( m_workerMachine )
-		MemoryPoolObject::deleteInstance(m_workerMachine);
+		deleteInstance(m_workerMachine);
 
 }
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -132,13 +132,13 @@ WorkerAIUpdate::~WorkerAIUpdate( void )
 
 	// delete our behavior state machine
 	if( m_dozerMachine )
-		m_dozerMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_dozerMachine);
 
 	if( m_supplyTruckStateMachine )
-		m_supplyTruckStateMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_supplyTruckStateMachine);
 
 	if( m_workerMachine )
-		m_workerMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_workerMachine);
 
 }
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/FireWeaponUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/FireWeaponUpdate.cpp
@@ -79,7 +79,7 @@ FireWeaponUpdate::FireWeaponUpdate( Thing *thing, const ModuleData* moduleData )
 FireWeaponUpdate::~FireWeaponUpdate( void )
 {
 	if (m_weapon)
-		MemoryPoolObject::deleteInstance(m_weapon);
+		deleteInstance(m_weapon);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/FireWeaponUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/FireWeaponUpdate.cpp
@@ -79,7 +79,7 @@ FireWeaponUpdate::FireWeaponUpdate( Thing *thing, const ModuleData* moduleData )
 FireWeaponUpdate::~FireWeaponUpdate( void )
 {
 	if (m_weapon)
-		m_weapon->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_weapon);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
@@ -244,7 +244,7 @@ PhysicsBehavior::~PhysicsBehavior()
 {
 	if (m_bounceSound)
 	{
-		MemoryPoolObject::deleteInstance(m_bounceSound);
+		deleteInstance(m_bounceSound);
 		m_bounceSound = NULL;
 	}
 }
@@ -528,7 +528,7 @@ void PhysicsBehavior::setBounceSound(const AudioEventRTS* bounceSound)
 	{
 		if (m_bounceSound)
 		{
-			MemoryPoolObject::deleteInstance(m_bounceSound);
+			deleteInstance(m_bounceSound);
 			m_bounceSound = NULL;
 		}
 	}

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
@@ -244,7 +244,7 @@ PhysicsBehavior::~PhysicsBehavior()
 {
 	if (m_bounceSound)
 	{
-		m_bounceSound->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_bounceSound);
 		m_bounceSound = NULL;
 	}
 }
@@ -528,7 +528,7 @@ void PhysicsBehavior::setBounceSound(const AudioEventRTS* bounceSound)
 	{
 		if (m_bounceSound)
 		{
-			m_bounceSound->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_bounceSound);
 			m_bounceSound = NULL;
 		}
 	}

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/PointDefenseLaserUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/PointDefenseLaserUpdate.cpp
@@ -216,7 +216,7 @@ void PointDefenseLaserUpdate::fireWhenReady()
 				Weapon* w = TheWeaponStore->allocateNewWeapon( wt, TERTIARY_WEAPON );
 				w->loadAmmoNow( getObject() );
 				w->fireWeapon( getObject(), target );
-				MemoryPoolObject::deleteInstance(w);
+				deleteInstance(w);
 
 				// And now that we have shot, set our internal reload timer.
 				m_nextShotAvailableInFrames = wt->getDelayBetweenShots( bonus );

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/PointDefenseLaserUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/PointDefenseLaserUpdate.cpp
@@ -216,7 +216,7 @@ void PointDefenseLaserUpdate::fireWhenReady()
 				Weapon* w = TheWeaponStore->allocateNewWeapon( wt, TERTIARY_WEAPON );
 				w->loadAmmoNow( getObject() );
 				w->fireWeapon( getObject(), target );
-				w->deleteInstance();
+				MemoryPoolObject::deleteInstance(w);
 
 				// And now that we have shot, set our internal reload timer.
 				m_nextShotAvailableInFrames = wt->getDelayBetweenShots( bonus );

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
@@ -218,7 +218,7 @@ ProductionUpdate::~ProductionUpdate( void )
 		production = m_productionQueue;
 		removeFromProductionQueue( production );
 		// TheSuperHackers @fix Mauller 13/04/2025 Delete instance of production item
-		production->deleteInstance();
+		MemoryPoolObject::deleteInstance(production);
 
 	}  // end while
 
@@ -370,7 +370,7 @@ void ProductionUpdate::cancelUpgrade( const UpgradeTemplate *upgrade )
 	removeFromProductionQueue( production );
 
 	// delete production instance
-	production->deleteInstance();
+	MemoryPoolObject::deleteInstance(production);
 
 	//
 	// remove the IN_PRODUCTION status of this upgrade from the player, object upgrades don't
@@ -486,7 +486,7 @@ void ProductionUpdate::cancelUnitCreate( ProductionID productionID )
 			removeFromProductionQueue( production );
 
 			// delete the production entry
-			production->deleteInstance();
+			MemoryPoolObject::deleteInstance(production);
 
 			return;
 
@@ -683,7 +683,7 @@ UpdateSleepTime ProductionUpdate::update( void )
 		removeFromProductionQueue( production );
 
 		// delete the production entry
-		production->deleteInstance();
+		MemoryPoolObject::deleteInstance(production);
 
 		return UPDATE_SLEEP_NONE;
 
@@ -873,7 +873,7 @@ UpdateSleepTime ProductionUpdate::update( void )
 					removeFromProductionQueue( production );
 					
 					// delete the production entry
-					production->deleteInstance();
+					MemoryPoolObject::deleteInstance(production);
 				}
 
 			}  // end if we found an exit interface
@@ -889,7 +889,7 @@ UpdateSleepTime ProductionUpdate::update( void )
 				removeFromProductionQueue( production );
 
 				// delete the production entry
-				production->deleteInstance();
+				MemoryPoolObject::deleteInstance(production);
 
 			}  // end else
 	
@@ -974,7 +974,7 @@ UpdateSleepTime ProductionUpdate::update( void )
 			removeFromProductionQueue( production );
 
 			// delete the production entry
-			production->deleteInstance();
+			MemoryPoolObject::deleteInstance(production);
 
 		}  // end else, production upgrade
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
@@ -218,7 +218,7 @@ ProductionUpdate::~ProductionUpdate( void )
 		production = m_productionQueue;
 		removeFromProductionQueue( production );
 		// TheSuperHackers @fix Mauller 13/04/2025 Delete instance of production item
-		MemoryPoolObject::deleteInstance(production);
+		deleteInstance(production);
 
 	}  // end while
 
@@ -370,7 +370,7 @@ void ProductionUpdate::cancelUpgrade( const UpgradeTemplate *upgrade )
 	removeFromProductionQueue( production );
 
 	// delete production instance
-	MemoryPoolObject::deleteInstance(production);
+	deleteInstance(production);
 
 	//
 	// remove the IN_PRODUCTION status of this upgrade from the player, object upgrades don't
@@ -486,7 +486,7 @@ void ProductionUpdate::cancelUnitCreate( ProductionID productionID )
 			removeFromProductionQueue( production );
 
 			// delete the production entry
-			MemoryPoolObject::deleteInstance(production);
+			deleteInstance(production);
 
 			return;
 
@@ -683,7 +683,7 @@ UpdateSleepTime ProductionUpdate::update( void )
 		removeFromProductionQueue( production );
 
 		// delete the production entry
-		MemoryPoolObject::deleteInstance(production);
+		deleteInstance(production);
 
 		return UPDATE_SLEEP_NONE;
 
@@ -873,7 +873,7 @@ UpdateSleepTime ProductionUpdate::update( void )
 					removeFromProductionQueue( production );
 					
 					// delete the production entry
-					MemoryPoolObject::deleteInstance(production);
+					deleteInstance(production);
 				}
 
 			}  // end if we found an exit interface
@@ -889,7 +889,7 @@ UpdateSleepTime ProductionUpdate::update( void )
 				removeFromProductionQueue( production );
 
 				// delete the production entry
-				MemoryPoolObject::deleteInstance(production);
+				deleteInstance(production);
 
 			}  // end else
 	
@@ -974,7 +974,7 @@ UpdateSleepTime ProductionUpdate::update( void )
 			removeFromProductionQueue( production );
 
 			// delete the production entry
-			MemoryPoolObject::deleteInstance(production);
+			deleteInstance(production);
 
 		}  // end else, production upgrade
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -320,12 +320,12 @@ WeaponTemplate::WeaponTemplate() : m_nextTemplate(NULL)
 WeaponTemplate::~WeaponTemplate()
 {
 	if (m_nextTemplate) {
-		MemoryPoolObject::deleteInstance(m_nextTemplate);
+		deleteInstance(m_nextTemplate);
 	}
 
 	// delete any extra-bonus that's present
 	if (m_extraBonus)
-		MemoryPoolObject::deleteInstance(m_extraBonus);
+		deleteInstance(m_extraBonus);
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -1373,7 +1373,7 @@ WeaponStore::~WeaponStore()
 	{
 		WeaponTemplate* wt = m_weaponTemplateVector[i];
 		if (wt)
-			MemoryPoolObject::deleteInstance(wt);
+			deleteInstance(wt);
 	}
 	m_weaponTemplateVector.clear();
 }
@@ -1384,7 +1384,7 @@ void WeaponStore::handleProjectileDetonation(const WeaponTemplate* wt, const Obj
 	Weapon* w = TheWeaponStore->allocateNewWeapon(wt, PRIMARY_WEAPON);
 	w->loadAmmoNow(source);
 	w->fireProjectileDetonationWeapon(source, pos, extraBonusFlags);
-	MemoryPoolObject::deleteInstance(w);
+	deleteInstance(w);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1395,7 +1395,7 @@ void WeaponStore::createAndFireTempWeapon(const WeaponTemplate* wt, const Object
 	Weapon* w = TheWeaponStore->allocateNewWeapon(wt, PRIMARY_WEAPON);
 	w->loadAmmoNow(source);
 	w->fireWeapon(source, pos);
-	MemoryPoolObject::deleteInstance(w);
+	deleteInstance(w);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1407,7 +1407,7 @@ void WeaponStore::createAndFireTempWeapon(const WeaponTemplate* wt, const Object
 	Weapon* w = TheWeaponStore->allocateNewWeapon(wt, PRIMARY_WEAPON);
 	w->loadAmmoNow(source);
 	w->fireWeapon(source, target);
-	MemoryPoolObject::deleteInstance(w);
+	deleteInstance(w);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1512,7 +1512,7 @@ void WeaponStore::reset()
 		{
 			WeaponTemplate *override = wt;
 			wt = wt->friend_clearNextTemplate();
-			MemoryPoolObject::deleteInstance(override);
+			deleteInstance(override);
 		}
 	}
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -320,12 +320,12 @@ WeaponTemplate::WeaponTemplate() : m_nextTemplate(NULL)
 WeaponTemplate::~WeaponTemplate()
 {
 	if (m_nextTemplate) {
-		m_nextTemplate->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_nextTemplate);
 	}
 
 	// delete any extra-bonus that's present
 	if (m_extraBonus)
-		m_extraBonus->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_extraBonus);
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -1373,7 +1373,7 @@ WeaponStore::~WeaponStore()
 	{
 		WeaponTemplate* wt = m_weaponTemplateVector[i];
 		if (wt)
-			wt->deleteInstance();
+			MemoryPoolObject::deleteInstance(wt);
 	}
 	m_weaponTemplateVector.clear();
 }
@@ -1384,7 +1384,7 @@ void WeaponStore::handleProjectileDetonation(const WeaponTemplate* wt, const Obj
 	Weapon* w = TheWeaponStore->allocateNewWeapon(wt, PRIMARY_WEAPON);
 	w->loadAmmoNow(source);
 	w->fireProjectileDetonationWeapon(source, pos, extraBonusFlags);
-	w->deleteInstance();
+	MemoryPoolObject::deleteInstance(w);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1395,7 +1395,7 @@ void WeaponStore::createAndFireTempWeapon(const WeaponTemplate* wt, const Object
 	Weapon* w = TheWeaponStore->allocateNewWeapon(wt, PRIMARY_WEAPON);
 	w->loadAmmoNow(source);
 	w->fireWeapon(source, pos);
-	w->deleteInstance();
+	MemoryPoolObject::deleteInstance(w);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1407,7 +1407,7 @@ void WeaponStore::createAndFireTempWeapon(const WeaponTemplate* wt, const Object
 	Weapon* w = TheWeaponStore->allocateNewWeapon(wt, PRIMARY_WEAPON);
 	w->loadAmmoNow(source);
 	w->fireWeapon(source, target);
-	w->deleteInstance();
+	MemoryPoolObject::deleteInstance(w);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1512,7 +1512,7 @@ void WeaponStore::reset()
 		{
 			WeaponTemplate *override = wt;
 			wt = wt->friend_clearNextTemplate();
-			override->deleteInstance();
+			MemoryPoolObject::deleteInstance(override);
 		}
 	}
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/WeaponSet.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/WeaponSet.cpp
@@ -188,7 +188,7 @@ WeaponSet::~WeaponSet()
 {
 	for (Int i = 0; i < WEAPONSLOT_COUNT; ++i)
 		if (m_weapons[i])
-			MemoryPoolObject::deleteInstance(m_weapons[i]);
+			deleteInstance(m_weapons[i]);
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -309,7 +309,7 @@ void WeaponSet::updateWeaponSet(const Object* obj)
 		{
 			if (m_weapons[i] != NULL)
 			{
-				MemoryPoolObject::deleteInstance(m_weapons[i]);
+				deleteInstance(m_weapons[i]);
 				m_weapons[i] = NULL;
 			}
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/WeaponSet.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/WeaponSet.cpp
@@ -188,7 +188,7 @@ WeaponSet::~WeaponSet()
 {
 	for (Int i = 0; i < WEAPONSLOT_COUNT; ++i)
 		if (m_weapons[i])
-			m_weapons[i]->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_weapons[i]);
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -309,7 +309,7 @@ void WeaponSet::updateWeaponSet(const Object* obj)
 		{
 			if (m_weapons[i] != NULL)
 			{
-				m_weapons[i]->deleteInstance();
+				MemoryPoolObject::deleteInstance(m_weapons[i]);
 				m_weapons[i] = NULL;
 			}
 

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
@@ -4367,7 +4367,7 @@ void ScriptActions::doUnitStartSequentialScript(const AsciiString& unitName, con
 	
 	TheScriptEngine->appendSequentialScript(seqScript);
 
-	MemoryPoolObject::deleteInstance(seqScript);
+	deleteInstance(seqScript);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -4464,7 +4464,7 @@ void ScriptActions::doTeamStartSequentialScript(const AsciiString& teamName, con
 	
 	TheScriptEngine->appendSequentialScript(seqScript);
 
-	MemoryPoolObject::deleteInstance(seqScript);
+	deleteInstance(seqScript);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
@@ -4367,7 +4367,7 @@ void ScriptActions::doUnitStartSequentialScript(const AsciiString& unitName, con
 	
 	TheScriptEngine->appendSequentialScript(seqScript);
 
-	seqScript->deleteInstance();
+	MemoryPoolObject::deleteInstance(seqScript);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -4464,7 +4464,7 @@ void ScriptActions::doTeamStartSequentialScript(const AsciiString& teamName, con
 	
 	TheScriptEngine->appendSequentialScript(seqScript);
 
-	seqScript->deleteInstance();
+	MemoryPoolObject::deleteInstance(seqScript);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptConditions.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptConditions.cpp
@@ -80,7 +80,7 @@ public:
 	~ObjectTypesTemp()
 	{
 		if (m_types)
-			MemoryPoolObject::deleteInstance(m_types);
+			deleteInstance(m_types);
 	}
 };
 
@@ -120,7 +120,7 @@ public:
 TransportStatus::~TransportStatus() 
 { 
 	if (m_nextStatus) 
-		MemoryPoolObject::deleteInstance(m_nextStatus); 
+		deleteInstance(m_nextStatus); 
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -156,7 +156,7 @@ void ScriptConditions::init( void )
 void ScriptConditions::reset( void )
 {
 
-	MemoryPoolObject::deleteInstance(s_transportStatuses);
+	deleteInstance(s_transportStatuses);
 	s_transportStatuses = NULL;
 	// Empty for now.  jba.
 }  // end reset

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptConditions.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptConditions.cpp
@@ -80,7 +80,7 @@ public:
 	~ObjectTypesTemp()
 	{
 		if (m_types)
-			m_types->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_types);
 	}
 };
 
@@ -120,7 +120,7 @@ public:
 TransportStatus::~TransportStatus() 
 { 
 	if (m_nextStatus) 
-		m_nextStatus->deleteInstance(); 
+		MemoryPoolObject::deleteInstance(m_nextStatus); 
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -156,7 +156,7 @@ void ScriptConditions::init( void )
 void ScriptConditions::reset( void )
 {
 
-	s_transportStatuses->deleteInstance();
+	MemoryPoolObject::deleteInstance(s_transportStatuses);
 	s_transportStatuses = NULL;
 	// Empty for now.  jba.
 }  // end reset

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
@@ -5985,7 +5985,7 @@ void ScriptEngine::removeObjectTypes(ObjectTypes *typesToRemove)
 	}
 
 	// delete it.
-	typesToRemove->deleteInstance();
+	MemoryPoolObject::deleteInstance(typesToRemove);
 
 	// remove it from the main array of stuff
 	m_allObjectTypeLists.erase(it);
@@ -7354,14 +7354,14 @@ ScriptEngine::VecSequentialScriptPtrIt ScriptEngine::cleanupSequentialScript(Vec
 		while (seqScript) {
 			scriptToDelete = seqScript;
 			seqScript = seqScript->m_nextScriptInSequence;
-			scriptToDelete->deleteInstance();
+			MemoryPoolObject::deleteInstance(scriptToDelete);
 			scriptToDelete = NULL;
 		}
 		(*it) = NULL;
 	} else {
 		// we want to make sure to not delete any dangling scripts.
 		(*it) = scriptToDelete->m_nextScriptInSequence;
-		scriptToDelete->deleteInstance();
+		MemoryPoolObject::deleteInstance(scriptToDelete);
 		scriptToDelete = NULL;
 	}
 

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
@@ -5985,7 +5985,7 @@ void ScriptEngine::removeObjectTypes(ObjectTypes *typesToRemove)
 	}
 
 	// delete it.
-	MemoryPoolObject::deleteInstance(typesToRemove);
+	deleteInstance(typesToRemove);
 
 	// remove it from the main array of stuff
 	m_allObjectTypeLists.erase(it);
@@ -7354,14 +7354,14 @@ ScriptEngine::VecSequentialScriptPtrIt ScriptEngine::cleanupSequentialScript(Vec
 		while (seqScript) {
 			scriptToDelete = seqScript;
 			seqScript = seqScript->m_nextScriptInSequence;
-			MemoryPoolObject::deleteInstance(scriptToDelete);
+			deleteInstance(scriptToDelete);
 			scriptToDelete = NULL;
 		}
 		(*it) = NULL;
 	} else {
 		// we want to make sure to not delete any dangling scripts.
 		(*it) = scriptToDelete->m_nextScriptInSequence;
-		MemoryPoolObject::deleteInstance(scriptToDelete);
+		deleteInstance(scriptToDelete);
 		scriptToDelete = NULL;
 	}
 

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/Scripts.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/Scripts.cpp
@@ -199,7 +199,7 @@ void ScriptList::reset(void)
 	{
 		ScriptList* pList = TheSidesList->getSideInfo(i)->getScriptList();
 		TheSidesList->getSideInfo(i)->setScriptList(NULL);
-		MemoryPoolObject::deleteInstance(pList);
+		deleteInstance(pList);
 	}
 }
 
@@ -221,11 +221,11 @@ m_firstScript(NULL)
 ScriptList::~ScriptList(void) 
 {
 	if (m_firstGroup) {
-		MemoryPoolObject::deleteInstance(m_firstGroup);
+		deleteInstance(m_firstGroup);
 		m_firstGroup = NULL;
 	}
 	if (m_firstScript) {
-		MemoryPoolObject::deleteInstance(m_firstScript);
+		deleteInstance(m_firstScript);
 		m_firstScript = NULL;
 	}
 }
@@ -418,7 +418,7 @@ void ScriptList::discard(void)
 {
 	m_firstGroup = NULL;
 	m_firstScript = NULL;
-	MemoryPoolObject::deleteInstance(this);
+	deleteInstance(this);
 }
 
 /**
@@ -490,7 +490,7 @@ void ScriptList::deleteScript(Script *pScr)
 	}
 	// Clear the link & delete.
 	pCur->setNextScript(NULL);
-	MemoryPoolObject::deleteInstance(pCur);
+	deleteInstance(pCur);
 }
 
 /**
@@ -515,7 +515,7 @@ void ScriptList::deleteGroup(ScriptGroup *pGrp)
 	}
 	// Clear the link & delete.
 	pCur->setNextGroup(NULL);
-	MemoryPoolObject::deleteInstance(pCur);
+	deleteInstance(pCur);
 }
 
 /**
@@ -532,7 +532,7 @@ Bool ScriptList::ParseScriptsDataChunk(DataChunkInput &file, DataChunkInfo *info
 	DEBUG_ASSERTCRASH(s_numInReadList==0, ("Leftover scripts floating aroung."));
 	for (i=0; i<s_numInReadList; i++) {
 		if (s_readLists[i]) {
-			MemoryPoolObject::deleteInstance(s_readLists[i]);
+			deleteInstance(s_readLists[i]);
 			s_readLists[i] = NULL;
 		}
 	}
@@ -656,7 +656,7 @@ ScriptGroup::~ScriptGroup(void)
 {
 	if (m_firstScript) {
 		// Delete the first script.  m_firstScript deletes the entire list.
-		MemoryPoolObject::deleteInstance(m_firstScript);
+		deleteInstance(m_firstScript);
 		m_firstScript = NULL;
 	}
 	if (m_nextGroup) {
@@ -666,7 +666,7 @@ ScriptGroup::~ScriptGroup(void)
 		while (cur) {
 			next = cur->getNext();
 			cur->setNextGroup(NULL); // prevents recursion. 
-			MemoryPoolObject::deleteInstance(cur);
+			deleteInstance(cur);
 			cur = next; 
 		}
 	}
@@ -822,7 +822,7 @@ void ScriptGroup::deleteScript(Script *pScr)
 	}
 	// Clear link & delete.
 	pCur->setNextScript(NULL);
-	MemoryPoolObject::deleteInstance(pCur);
+	deleteInstance(pCur);
 }
 
 /**
@@ -935,19 +935,19 @@ Script::~Script(void)
 		while (cur) {
 			next = cur->getNext();
 			cur->setNextScript(NULL); // prevents recursion. 
-			MemoryPoolObject::deleteInstance(cur);
+			deleteInstance(cur);
 			cur = next; 
 		}
 	}
 	if (m_condition) {
-		MemoryPoolObject::deleteInstance(m_condition);
+		deleteInstance(m_condition);
 	}
 	if (m_action) {
-		MemoryPoolObject::deleteInstance(m_action);
+		deleteInstance(m_action);
 	}
 
 	if (m_actionFalse) {
-		MemoryPoolObject::deleteInstance(m_actionFalse);
+		deleteInstance(m_actionFalse);
 	}
 }
 
@@ -996,10 +996,10 @@ Script *Script::duplicate(void) const
 {
 	Script *pNew = newInstance(Script);	
 	if (pNew->m_condition) {
-		MemoryPoolObject::deleteInstance(pNew->m_condition);
+		deleteInstance(pNew->m_condition);
 	}
 	if (pNew->m_action) {
-		MemoryPoolObject::deleteInstance(pNew->m_action);
+		deleteInstance(pNew->m_action);
 	}
 	pNew->m_scriptName = m_scriptName;
 	pNew->m_comment = m_comment;
@@ -1035,10 +1035,10 @@ Script *Script::duplicateAndQualify(const AsciiString& qualifier,
 {
 	Script *pNew = newInstance(Script);
 	if (pNew->m_condition) {
-		MemoryPoolObject::deleteInstance(pNew->m_condition);
+		deleteInstance(pNew->m_condition);
 	}
 	if (pNew->m_action) {
-		MemoryPoolObject::deleteInstance(pNew->m_action);
+		deleteInstance(pNew->m_action);
 	}
 	pNew->m_scriptName = m_scriptName;
 	pNew->m_scriptName.concat(qualifier);
@@ -1084,17 +1084,17 @@ void Script::updateFrom(Script *pSrc)
 	this->m_normal = pSrc->m_normal;
 	this->m_hard = pSrc->m_hard;
 	if (this->m_condition) {
-		MemoryPoolObject::deleteInstance(this->m_condition);
+		deleteInstance(this->m_condition);
 	}
 	this->m_condition = pSrc->m_condition;
 	pSrc->m_condition = NULL;
 	if (this->m_action) {
-		MemoryPoolObject::deleteInstance(this->m_action);
+		deleteInstance(this->m_action);
 	}
 	this->m_action = pSrc->m_action;
 	pSrc->m_action = NULL;
 	if (this->m_actionFalse) {
-		MemoryPoolObject::deleteInstance(this->m_actionFalse);
+		deleteInstance(this->m_actionFalse);
 	}
 	this->m_actionFalse = pSrc->m_actionFalse;
 	pSrc->m_actionFalse = NULL;
@@ -1119,7 +1119,7 @@ void Script::deleteOrCondition(OrCondition *pCond)
 		m_condition = pCur->getNextOrCondition();
 	}
 	pCur->setNextOrCondition(NULL);
-	MemoryPoolObject::deleteInstance(pCur);
+	deleteInstance(pCur);
 }
 
 
@@ -1142,7 +1142,7 @@ void Script::deleteAction(ScriptAction *pAct)
 		m_action = pCur->getNext();
 	}
 	pCur->setNextAction(NULL);
-	MemoryPoolObject::deleteInstance(pCur);
+	deleteInstance(pCur);
 }
 
 
@@ -1165,7 +1165,7 @@ void Script::deleteFalseAction(ScriptAction *pAct)
 		m_actionFalse = pCur->getNext();
 	}
 	pCur->setNextAction(NULL);
-	MemoryPoolObject::deleteInstance(pCur);
+	deleteInstance(pCur);
 }
 
 
@@ -1344,7 +1344,7 @@ OrCondition *Script::findPreviousOrCondition( OrCondition *curOr )
 OrCondition::~OrCondition(void) 
 {
 	if (m_firstAnd) {
-		MemoryPoolObject::deleteInstance(m_firstAnd);
+		deleteInstance(m_firstAnd);
 		m_firstAnd = NULL;
 	}
 	if (m_nextOr) {
@@ -1353,7 +1353,7 @@ OrCondition::~OrCondition(void)
 		while (cur) {
 			next = cur->getNextOrCondition();
 			cur->setNextOrCondition(NULL); // prevents recursion. 
-			MemoryPoolObject::deleteInstance(cur);
+			deleteInstance(cur);
 			cur = next; 
 		}
 	}
@@ -1426,7 +1426,7 @@ void OrCondition::deleteCondition(Condition *pCond)
 	DEBUG_ASSERTCRASH(pCur, ("Couldn't find condition."));
 	if (pCur==NULL) 
 		return;
-	MemoryPoolObject::deleteInstance(pCur);
+	deleteInstance(pCur);
 }
 
 
@@ -1532,7 +1532,7 @@ void Condition::setConditionType(enum ConditionType type)
 	Int i;
 	for (i=0; i<m_numParms; i++) {
 		if (m_parms[i]) 
-			MemoryPoolObject::deleteInstance(m_parms[i]);
+			deleteInstance(m_parms[i]);
 		m_parms[i] = NULL;
 	}
 	m_conditionType = type;
@@ -1590,7 +1590,7 @@ Condition::~Condition(void)
 {
 	Int i;
 	for (i=0; i<m_numParms; i++) {
-		MemoryPoolObject::deleteInstance(m_parms[i]);
+		deleteInstance(m_parms[i]);
 		m_parms[i] = NULL;
 	}
 	if (m_nextAndCondition) {
@@ -1599,7 +1599,7 @@ Condition::~Condition(void)
 		while (cur) {
 			next = cur->getNext();
 			cur->setNextCondition(NULL); // prevents recursion. 
-			MemoryPoolObject::deleteInstance(cur);
+			deleteInstance(cur);
 			cur = next; 
 		}
 	}
@@ -2223,7 +2223,7 @@ void ScriptAction::setActionType(enum ScriptActionType type)
 	Int i;
 	for (i=0; i<m_numParms; i++) {
 		if (m_parms[i]) 
-			MemoryPoolObject::deleteInstance(m_parms[i]);
+			deleteInstance(m_parms[i]);
 		m_parms[i] = NULL;
 	}
 	m_actionType = type;
@@ -2289,7 +2289,7 @@ ScriptAction::~ScriptAction(void)
 {
 	Int i;
 	for (i=0; i<m_numParms; i++) {
-		MemoryPoolObject::deleteInstance(m_parms[i]);
+		deleteInstance(m_parms[i]);
 		m_parms[i] = NULL;
 	}
 	if (m_nextAction) {
@@ -2298,7 +2298,7 @@ ScriptAction::~ScriptAction(void)
 		while (cur) {
 			next = cur->getNext();
 			cur->setNextAction(NULL); // prevents recursion. 
-			MemoryPoolObject::deleteInstance(cur);
+			deleteInstance(cur);
 			cur = next; 
 		}
 	}
@@ -2409,7 +2409,7 @@ Bool ScriptAction::ParseActionDataChunk(DataChunkInput &file, DataChunkInfo *inf
 			if (pScriptAction->m_numParms == 1)
 			{		
 				Bool flank = pScriptAction->m_parms[0]->getInt()!=0;
-				MemoryPoolObject::deleteInstance(pScriptAction->m_parms[0]);
+				deleteInstance(pScriptAction->m_parms[0]);
 				pScriptAction->m_numParms = 0;
 				if (flank) pScriptAction->m_actionType = SKIRMISH_BUILD_BASE_DEFENSE_FLANK;
 			}

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/Scripts.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/Scripts.cpp
@@ -199,7 +199,7 @@ void ScriptList::reset(void)
 	{
 		ScriptList* pList = TheSidesList->getSideInfo(i)->getScriptList();
 		TheSidesList->getSideInfo(i)->setScriptList(NULL);
-		pList->deleteInstance();
+		MemoryPoolObject::deleteInstance(pList);
 	}
 }
 
@@ -221,11 +221,11 @@ m_firstScript(NULL)
 ScriptList::~ScriptList(void) 
 {
 	if (m_firstGroup) {
-		m_firstGroup->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_firstGroup);
 		m_firstGroup = NULL;
 	}
 	if (m_firstScript) {
-		m_firstScript->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_firstScript);
 		m_firstScript = NULL;
 	}
 }
@@ -418,7 +418,7 @@ void ScriptList::discard(void)
 {
 	m_firstGroup = NULL;
 	m_firstScript = NULL;
-	this->deleteInstance();
+	MemoryPoolObject::deleteInstance(this);
 }
 
 /**
@@ -490,7 +490,7 @@ void ScriptList::deleteScript(Script *pScr)
 	}
 	// Clear the link & delete.
 	pCur->setNextScript(NULL);
-	pCur->deleteInstance();
+	MemoryPoolObject::deleteInstance(pCur);
 }
 
 /**
@@ -515,7 +515,7 @@ void ScriptList::deleteGroup(ScriptGroup *pGrp)
 	}
 	// Clear the link & delete.
 	pCur->setNextGroup(NULL);
-	pCur->deleteInstance();
+	MemoryPoolObject::deleteInstance(pCur);
 }
 
 /**
@@ -532,7 +532,7 @@ Bool ScriptList::ParseScriptsDataChunk(DataChunkInput &file, DataChunkInfo *info
 	DEBUG_ASSERTCRASH(s_numInReadList==0, ("Leftover scripts floating aroung."));
 	for (i=0; i<s_numInReadList; i++) {
 		if (s_readLists[i]) {
-			s_readLists[i]->deleteInstance();
+			MemoryPoolObject::deleteInstance(s_readLists[i]);
 			s_readLists[i] = NULL;
 		}
 	}
@@ -656,7 +656,7 @@ ScriptGroup::~ScriptGroup(void)
 {
 	if (m_firstScript) {
 		// Delete the first script.  m_firstScript deletes the entire list.
-		m_firstScript->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_firstScript);
 		m_firstScript = NULL;
 	}
 	if (m_nextGroup) {
@@ -666,7 +666,7 @@ ScriptGroup::~ScriptGroup(void)
 		while (cur) {
 			next = cur->getNext();
 			cur->setNextGroup(NULL); // prevents recursion. 
-			cur->deleteInstance();
+			MemoryPoolObject::deleteInstance(cur);
 			cur = next; 
 		}
 	}
@@ -822,7 +822,7 @@ void ScriptGroup::deleteScript(Script *pScr)
 	}
 	// Clear link & delete.
 	pCur->setNextScript(NULL);
-	pCur->deleteInstance();
+	MemoryPoolObject::deleteInstance(pCur);
 }
 
 /**
@@ -935,19 +935,19 @@ Script::~Script(void)
 		while (cur) {
 			next = cur->getNext();
 			cur->setNextScript(NULL); // prevents recursion. 
-			cur->deleteInstance();
+			MemoryPoolObject::deleteInstance(cur);
 			cur = next; 
 		}
 	}
 	if (m_condition) {
-		m_condition->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_condition);
 	}
 	if (m_action) {
-		m_action->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_action);
 	}
 
 	if (m_actionFalse) {
-		m_actionFalse->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_actionFalse);
 	}
 }
 
@@ -996,10 +996,10 @@ Script *Script::duplicate(void) const
 {
 	Script *pNew = newInstance(Script);	
 	if (pNew->m_condition) {
-		pNew->m_condition->deleteInstance();
+		MemoryPoolObject::deleteInstance(pNew->m_condition);
 	}
 	if (pNew->m_action) {
-		pNew->m_action->deleteInstance();
+		MemoryPoolObject::deleteInstance(pNew->m_action);
 	}
 	pNew->m_scriptName = m_scriptName;
 	pNew->m_comment = m_comment;
@@ -1035,10 +1035,10 @@ Script *Script::duplicateAndQualify(const AsciiString& qualifier,
 {
 	Script *pNew = newInstance(Script);
 	if (pNew->m_condition) {
-		pNew->m_condition->deleteInstance();
+		MemoryPoolObject::deleteInstance(pNew->m_condition);
 	}
 	if (pNew->m_action) {
-		pNew->m_action->deleteInstance();
+		MemoryPoolObject::deleteInstance(pNew->m_action);
 	}
 	pNew->m_scriptName = m_scriptName;
 	pNew->m_scriptName.concat(qualifier);
@@ -1084,17 +1084,17 @@ void Script::updateFrom(Script *pSrc)
 	this->m_normal = pSrc->m_normal;
 	this->m_hard = pSrc->m_hard;
 	if (this->m_condition) {
-		this->m_condition->deleteInstance();
+		MemoryPoolObject::deleteInstance(this->m_condition);
 	}
 	this->m_condition = pSrc->m_condition;
 	pSrc->m_condition = NULL;
 	if (this->m_action) {
-		this->m_action->deleteInstance();
+		MemoryPoolObject::deleteInstance(this->m_action);
 	}
 	this->m_action = pSrc->m_action;
 	pSrc->m_action = NULL;
 	if (this->m_actionFalse) {
-		this->m_actionFalse->deleteInstance();
+		MemoryPoolObject::deleteInstance(this->m_actionFalse);
 	}
 	this->m_actionFalse = pSrc->m_actionFalse;
 	pSrc->m_actionFalse = NULL;
@@ -1119,7 +1119,7 @@ void Script::deleteOrCondition(OrCondition *pCond)
 		m_condition = pCur->getNextOrCondition();
 	}
 	pCur->setNextOrCondition(NULL);
-	pCur->deleteInstance();
+	MemoryPoolObject::deleteInstance(pCur);
 }
 
 
@@ -1142,7 +1142,7 @@ void Script::deleteAction(ScriptAction *pAct)
 		m_action = pCur->getNext();
 	}
 	pCur->setNextAction(NULL);
-	pCur->deleteInstance();
+	MemoryPoolObject::deleteInstance(pCur);
 }
 
 
@@ -1165,7 +1165,7 @@ void Script::deleteFalseAction(ScriptAction *pAct)
 		m_actionFalse = pCur->getNext();
 	}
 	pCur->setNextAction(NULL);
-	pCur->deleteInstance();
+	MemoryPoolObject::deleteInstance(pCur);
 }
 
 
@@ -1344,7 +1344,7 @@ OrCondition *Script::findPreviousOrCondition( OrCondition *curOr )
 OrCondition::~OrCondition(void) 
 {
 	if (m_firstAnd) {
-		m_firstAnd->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_firstAnd);
 		m_firstAnd = NULL;
 	}
 	if (m_nextOr) {
@@ -1353,7 +1353,7 @@ OrCondition::~OrCondition(void)
 		while (cur) {
 			next = cur->getNextOrCondition();
 			cur->setNextOrCondition(NULL); // prevents recursion. 
-			cur->deleteInstance();
+			MemoryPoolObject::deleteInstance(cur);
 			cur = next; 
 		}
 	}
@@ -1426,7 +1426,7 @@ void OrCondition::deleteCondition(Condition *pCond)
 	DEBUG_ASSERTCRASH(pCur, ("Couldn't find condition."));
 	if (pCur==NULL) 
 		return;
-	pCur->deleteInstance();
+	MemoryPoolObject::deleteInstance(pCur);
 }
 
 
@@ -1532,7 +1532,7 @@ void Condition::setConditionType(enum ConditionType type)
 	Int i;
 	for (i=0; i<m_numParms; i++) {
 		if (m_parms[i]) 
-			m_parms[i]->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_parms[i]);
 		m_parms[i] = NULL;
 	}
 	m_conditionType = type;
@@ -1590,7 +1590,7 @@ Condition::~Condition(void)
 {
 	Int i;
 	for (i=0; i<m_numParms; i++) {
-		m_parms[i]->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_parms[i]);
 		m_parms[i] = NULL;
 	}
 	if (m_nextAndCondition) {
@@ -1599,7 +1599,7 @@ Condition::~Condition(void)
 		while (cur) {
 			next = cur->getNext();
 			cur->setNextCondition(NULL); // prevents recursion. 
-			cur->deleteInstance();
+			MemoryPoolObject::deleteInstance(cur);
 			cur = next; 
 		}
 	}
@@ -2223,7 +2223,7 @@ void ScriptAction::setActionType(enum ScriptActionType type)
 	Int i;
 	for (i=0; i<m_numParms; i++) {
 		if (m_parms[i]) 
-			m_parms[i]->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_parms[i]);
 		m_parms[i] = NULL;
 	}
 	m_actionType = type;
@@ -2289,7 +2289,7 @@ ScriptAction::~ScriptAction(void)
 {
 	Int i;
 	for (i=0; i<m_numParms; i++) {
-		m_parms[i]->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_parms[i]);
 		m_parms[i] = NULL;
 	}
 	if (m_nextAction) {
@@ -2298,7 +2298,7 @@ ScriptAction::~ScriptAction(void)
 		while (cur) {
 			next = cur->getNext();
 			cur->setNextAction(NULL); // prevents recursion. 
-			cur->deleteInstance();
+			MemoryPoolObject::deleteInstance(cur);
 			cur = next; 
 		}
 	}
@@ -2409,7 +2409,7 @@ Bool ScriptAction::ParseActionDataChunk(DataChunkInput &file, DataChunkInfo *inf
 			if (pScriptAction->m_numParms == 1)
 			{		
 				Bool flank = pScriptAction->m_parms[0]->getInt()!=0;
-				pScriptAction->m_parms[0]->deleteInstance();
+				MemoryPoolObject::deleteInstance(pScriptAction->m_parms[0]);
 				pScriptAction->m_numParms = 0;
 				if (flank) pScriptAction->m_actionType = SKIRMISH_BUILD_BASE_DEFENSE_FLANK;
 			}

--- a/Generals/Code/GameEngine/Source/GameLogic/System/CaveSystem.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/CaveSystem.cpp
@@ -55,7 +55,7 @@ void CaveSystem::reset()
 		TunnelTracker *currentTracker = *iter;
 		if( currentTracker )// could be NULL, since we don't slide back to fill deleted entries so offsets don't shift
 		{
-			currentTracker->deleteInstance();
+			MemoryPoolObject::deleteInstance(currentTracker);
 		}
 	}
 	m_tunnelTrackerVector.clear();

--- a/Generals/Code/GameEngine/Source/GameLogic/System/CaveSystem.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/CaveSystem.cpp
@@ -55,7 +55,7 @@ void CaveSystem::reset()
 		TunnelTracker *currentTracker = *iter;
 		if( currentTracker )// could be NULL, since we don't slide back to fill deleted entries so offsets don't shift
 		{
-			MemoryPoolObject::deleteInstance(currentTracker);
+			deleteInstance(currentTracker);
 		}
 	}
 	m_tunnelTrackerVector.clear();

--- a/Generals/Code/GameEngine/Source/GameLogic/System/CrateSystem.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/CrateSystem.cpp
@@ -49,7 +49,7 @@ CrateSystem::~CrateSystem()
 		CrateTemplate *currentTemplate = m_crateTemplateVector[templateIndex];
 		if( currentTemplate )
 		{
-			MemoryPoolObject::deleteInstance(currentTemplate);
+			deleteInstance(currentTemplate);
 		}
 	}
 	m_crateTemplateVector.clear();

--- a/Generals/Code/GameEngine/Source/GameLogic/System/CrateSystem.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/CrateSystem.cpp
@@ -49,7 +49,7 @@ CrateSystem::~CrateSystem()
 		CrateTemplate *currentTemplate = m_crateTemplateVector[templateIndex];
 		if( currentTemplate )
 		{
-			currentTemplate->deleteInstance();
+			MemoryPoolObject::deleteInstance(currentTemplate);
 		}
 	}
 	m_crateTemplateVector.clear();

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -321,7 +321,7 @@ GameLogic::~GameLogic()
 	if (m_background)
 	{
 		m_background->destroyWindows();
-		MemoryPoolObject::deleteInstance(m_background);
+		deleteInstance(m_background);
 		m_background = NULL;
 	}
 
@@ -1014,7 +1014,7 @@ void GameLogic::startNewGame( Bool saveGame )
 				if(m_background)
 				{
 					m_background->destroyWindows();
-					MemoryPoolObject::deleteInstance(m_background);
+					deleteInstance(m_background);
 					m_background = NULL;
 				}
 				m_loadScreen = getLoadScreen( saveGame );
@@ -1121,7 +1121,7 @@ void GameLogic::startNewGame( Bool saveGame )
 	if(m_background)
 	{
 		m_background->destroyWindows();
-		MemoryPoolObject::deleteInstance(m_background);
+		deleteInstance(m_background);
 		m_background = NULL;
 	}
 	setFPMode();
@@ -1398,7 +1398,7 @@ void GameLogic::startNewGame( Bool saveGame )
 				}
 				for (Int i=0; i<count; ++i)
 				{
-					MemoryPoolObject::deleteInstance(scripts[i]);
+					deleteInstance(scripts[i]);
 				}
 			}
 		}

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -321,7 +321,7 @@ GameLogic::~GameLogic()
 	if (m_background)
 	{
 		m_background->destroyWindows();
-		m_background->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_background);
 		m_background = NULL;
 	}
 
@@ -1014,7 +1014,7 @@ void GameLogic::startNewGame( Bool saveGame )
 				if(m_background)
 				{
 					m_background->destroyWindows();
-					m_background->deleteInstance();
+					MemoryPoolObject::deleteInstance(m_background);
 					m_background = NULL;
 				}
 				m_loadScreen = getLoadScreen( saveGame );
@@ -1121,7 +1121,7 @@ void GameLogic::startNewGame( Bool saveGame )
 	if(m_background)
 	{
 		m_background->destroyWindows();
-		m_background->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_background);
 		m_background = NULL;
 	}
 	setFPMode();
@@ -1398,7 +1398,7 @@ void GameLogic::startNewGame( Bool saveGame )
 				}
 				for (Int i=0; i<count; ++i)
 				{
-					scripts[i]->deleteInstance();
+					MemoryPoolObject::deleteInstance(scripts[i]);
 				}
 			}
 		}
@@ -2217,7 +2217,7 @@ void GameLogic::processDestroyList( void )
 		// remove object from lookup table
 		removeObjectFromLookupTable( currentObject );
 
-		currentObject->friend_deleteInstance();//actual delete
+		Object::friend_deleteInstance(currentObject);//actual delete
 	}
 
 	m_objectsToDestroy.clear();//list full of bad pointers now, clear it.  If anyone's deletion resulted

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -291,7 +291,7 @@ void GameLogic::clearGameData( Bool showScoreScreen )
 	if(m_background)
 	{
 		m_background->destroyWindows();
-		m_background->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_background);
 		m_background = NULL;
 	}
 	

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -291,7 +291,7 @@ void GameLogic::clearGameData( Bool showScoreScreen )
 	if(m_background)
 	{
 		m_background->destroyWindows();
-		MemoryPoolObject::deleteInstance(m_background);
+		deleteInstance(m_background);
 		m_background = NULL;
 	}
 	

--- a/Generals/Code/GameEngine/Source/GameLogic/System/RankInfo.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/RankInfo.cpp
@@ -56,7 +56,7 @@ RankInfoStore::~RankInfoStore()
 		RankInfo* ri = m_rankInfos[level];
 		if (ri)
 		{
-			ri->deleteInstance();
+			MemoryPoolObject::deleteInstance(ri);
 		}
 	}
 	m_rankInfos.clear();

--- a/Generals/Code/GameEngine/Source/GameLogic/System/RankInfo.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/RankInfo.cpp
@@ -56,7 +56,7 @@ RankInfoStore::~RankInfoStore()
 		RankInfo* ri = m_rankInfos[level];
 		if (ri)
 		{
-			MemoryPoolObject::deleteInstance(ri);
+			deleteInstance(ri);
 		}
 	}
 	m_rankInfos.clear();

--- a/Generals/Code/GameEngine/Source/GameNetwork/Connection.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/Connection.cpp
@@ -59,12 +59,12 @@ Connection::Connection() {
  */
 Connection::~Connection() {
 	if (m_user != NULL) {
-		m_user->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_user);
 		m_user = NULL;
 	}
 
 	if (m_netCommandList != NULL) {
-		m_netCommandList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_netCommandList);
 		m_netCommandList = NULL;
 	}
 }
@@ -76,7 +76,7 @@ void Connection::init() {
 	m_transport = NULL;
 
 	if (m_user != NULL) {
-		m_user->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_user);
 		m_user = NULL;
 	}
 
@@ -124,7 +124,7 @@ void Connection::attachTransport(Transport *transport) {
  */
 void Connection::setUser(User *user) {
 	if (m_user != NULL) {
-		m_user->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_user);
 	}
 
 	m_user = user;
@@ -164,7 +164,7 @@ void Connection::sendNetCommandMsg(NetCommandMsg *msg, UnsignedByte relay) {
 		NetCommandRef *tempref = NEW_NETCOMMANDREF(msg);
 
 		Bool msgFits = packet->addCommand(tempref);
-		tempref->deleteInstance(); // delete the temporary reference.
+		MemoryPoolObject::deleteInstance(tempref); // delete the temporary reference.
 		tempref = NULL;
 
 		if (!msgFits) {
@@ -186,15 +186,15 @@ void Connection::sendNetCommandMsg(NetCommandMsg *msg, UnsignedByte relay) {
 					ref1 = ref1->getNext();
 				}
 
-				tempPacket->deleteInstance();
+				MemoryPoolObject::deleteInstance(tempPacket);
 				tempPacket = NULL;
 				++tempPacketPtr;
 
-				list->deleteInstance();
+				MemoryPoolObject::deleteInstance(list);
 				list = NULL;
 			}
 
-			origref->deleteInstance();
+			MemoryPoolObject::deleteInstance(origref);
 			origref = NULL;
 
 			return;
@@ -234,7 +234,7 @@ void Connection::clearCommandsExceptFrom( Int playerIndex )
 			m_netCommandList->removeMessage(tmp);
 			NetCommandRef *toDelete = tmp;
 			tmp = tmp->getNext();
-			toDelete->deleteInstance();
+			MemoryPoolObject::deleteInstance(toDelete);
 		} else {
 			tmp = tmp->getNext();
 		}
@@ -305,7 +305,7 @@ UnsignedInt Connection::doSend() {
 						msg->setTimeLastSent(curtime);
 					} else {
 						m_netCommandList->removeMessage(msg);
-						msg->deleteInstance();
+						MemoryPoolObject::deleteInstance(msg);
 					}
 				}
 			}
@@ -326,7 +326,7 @@ UnsignedInt Connection::doSend() {
 			m_lastTimeSent = curtime;
 		}
 		if (packet != NULL) {
-			packet->deleteInstance(); // delete the packet now that we're done with it.
+			MemoryPoolObject::deleteInstance(packet); // delete the packet now that we're done with it.
 		}
 	}
 

--- a/Generals/Code/GameEngine/Source/GameNetwork/Connection.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/Connection.cpp
@@ -59,12 +59,12 @@ Connection::Connection() {
  */
 Connection::~Connection() {
 	if (m_user != NULL) {
-		MemoryPoolObject::deleteInstance(m_user);
+		deleteInstance(m_user);
 		m_user = NULL;
 	}
 
 	if (m_netCommandList != NULL) {
-		MemoryPoolObject::deleteInstance(m_netCommandList);
+		deleteInstance(m_netCommandList);
 		m_netCommandList = NULL;
 	}
 }
@@ -76,7 +76,7 @@ void Connection::init() {
 	m_transport = NULL;
 
 	if (m_user != NULL) {
-		MemoryPoolObject::deleteInstance(m_user);
+		deleteInstance(m_user);
 		m_user = NULL;
 	}
 
@@ -124,7 +124,7 @@ void Connection::attachTransport(Transport *transport) {
  */
 void Connection::setUser(User *user) {
 	if (m_user != NULL) {
-		MemoryPoolObject::deleteInstance(m_user);
+		deleteInstance(m_user);
 	}
 
 	m_user = user;
@@ -164,7 +164,7 @@ void Connection::sendNetCommandMsg(NetCommandMsg *msg, UnsignedByte relay) {
 		NetCommandRef *tempref = NEW_NETCOMMANDREF(msg);
 
 		Bool msgFits = packet->addCommand(tempref);
-		MemoryPoolObject::deleteInstance(tempref); // delete the temporary reference.
+		deleteInstance(tempref); // delete the temporary reference.
 		tempref = NULL;
 
 		if (!msgFits) {
@@ -186,15 +186,15 @@ void Connection::sendNetCommandMsg(NetCommandMsg *msg, UnsignedByte relay) {
 					ref1 = ref1->getNext();
 				}
 
-				MemoryPoolObject::deleteInstance(tempPacket);
+				deleteInstance(tempPacket);
 				tempPacket = NULL;
 				++tempPacketPtr;
 
-				MemoryPoolObject::deleteInstance(list);
+				deleteInstance(list);
 				list = NULL;
 			}
 
-			MemoryPoolObject::deleteInstance(origref);
+			deleteInstance(origref);
 			origref = NULL;
 
 			return;
@@ -234,7 +234,7 @@ void Connection::clearCommandsExceptFrom( Int playerIndex )
 			m_netCommandList->removeMessage(tmp);
 			NetCommandRef *toDelete = tmp;
 			tmp = tmp->getNext();
-			MemoryPoolObject::deleteInstance(toDelete);
+			deleteInstance(toDelete);
 		} else {
 			tmp = tmp->getNext();
 		}
@@ -305,7 +305,7 @@ UnsignedInt Connection::doSend() {
 						msg->setTimeLastSent(curtime);
 					} else {
 						m_netCommandList->removeMessage(msg);
-						MemoryPoolObject::deleteInstance(msg);
+						deleteInstance(msg);
 					}
 				}
 			}
@@ -326,7 +326,7 @@ UnsignedInt Connection::doSend() {
 			m_lastTimeSent = curtime;
 		}
 		if (packet != NULL) {
-			MemoryPoolObject::deleteInstance(packet); // delete the packet now that we're done with it.
+			deleteInstance(packet); // delete the packet now that we're done with it.
 		}
 	}
 

--- a/Generals/Code/GameEngine/Source/GameNetwork/ConnectionManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/ConnectionManager.cpp
@@ -65,7 +65,7 @@
 ConnectionManager::~ConnectionManager(void)
 {
 	if (m_localUser != NULL) {
-		MemoryPoolObject::deleteInstance(m_localUser);
+		deleteInstance(m_localUser);
 		m_localUser = NULL;
 	}
 
@@ -78,14 +78,14 @@ ConnectionManager::~ConnectionManager(void)
 	Int i = 0;
 	for (; i < MAX_SLOTS; ++i) {
 		if (m_frameData[i] != NULL) {
-			MemoryPoolObject::deleteInstance(m_frameData[i]);
+			deleteInstance(m_frameData[i]);
 			m_frameData[i] = NULL;
 		}
 	}
 
 	for (i = 0; i < NUM_CONNECTIONS; ++i) {
 		if (m_connections[i] != NULL) {
-			MemoryPoolObject::deleteInstance(m_connections[i]);
+			deleteInstance(m_connections[i]);
 			m_connections[i] = NULL;
 		}
 	}
@@ -102,17 +102,17 @@ ConnectionManager::~ConnectionManager(void)
 	}
 
 	if (m_pendingCommands != NULL) {
-		MemoryPoolObject::deleteInstance(m_pendingCommands);
+		deleteInstance(m_pendingCommands);
 		m_pendingCommands = NULL;
 	}
 
 	if (m_relayedCommands != NULL) {
-		MemoryPoolObject::deleteInstance(m_relayedCommands);
+		deleteInstance(m_relayedCommands);
 		m_relayedCommands = NULL;
 	}
 
 	if (m_netCommandWrapperList != NULL) {
-		MemoryPoolObject::deleteInstance(m_netCommandWrapperList);
+		deleteInstance(m_netCommandWrapperList);
 		m_netCommandWrapperList = NULL;
 	}
 
@@ -180,7 +180,7 @@ void ConnectionManager::init()
 
 	for (i = 0; i < MAX_SLOTS; ++i) {
 		if (m_frameData[i] != NULL) {
-			MemoryPoolObject::deleteInstance(m_frameData[i]);
+			deleteInstance(m_frameData[i]);
 			m_frameData[i] = NULL;
 		}
 	}
@@ -234,7 +234,7 @@ void ConnectionManager::reset()
 	Int i = 0;
 	for (; i < NUM_CONNECTIONS; ++i) {
 		if (m_connections[i] != NULL) {
-			MemoryPoolObject::deleteInstance(m_connections[i]);
+			deleteInstance(m_connections[i]);
 			m_connections[i] = NULL;
 		}
 	}
@@ -242,7 +242,7 @@ void ConnectionManager::reset()
 	for (i=0; i<MAX_SLOTS; ++i)
 	{
 		if (m_frameData[i] != NULL) {
-			MemoryPoolObject::deleteInstance(m_frameData[i]);
+			deleteInstance(m_frameData[i]);
 			m_frameData[i] = NULL;
 		}
 	}
@@ -383,10 +383,10 @@ void ConnectionManager::doRelay() {
 			++numPackets;
 
 			// Delete this packet since we won't be needing it anymore.
-			MemoryPoolObject::deleteInstance(packet);
+			deleteInstance(packet);
 			packet = NULL;
 
-			MemoryPoolObject::deleteInstance(cmdList);
+			deleteInstance(cmdList);
 			cmdList = NULL;
 
 			// signal that this has been processed.
@@ -410,10 +410,10 @@ void ConnectionManager::doRelay() {
 	++numPackets;
 
 	// Delete this packet since we won't be needing it anymore.
-	MemoryPoolObject::deleteInstance(packet);
+	deleteInstance(packet);
 	packet = NULL;
 
-	MemoryPoolObject::deleteInstance(cmdList);
+	deleteInstance(cmdList);
 	cmdList = NULL;
 }
 
@@ -853,7 +853,7 @@ void ConnectionManager::processAckStage1(NetCommandMsg *msg) {
 			m_frameMetrics.processLatencyResponse(((NetFrameCommandMsg *)(ref->getCommand()))->getExecutionFrame());
 		}
 
-		MemoryPoolObject::deleteInstance(ref);
+		deleteInstance(ref);
 		ref = NULL;
 	}
 }
@@ -880,7 +880,7 @@ void ConnectionManager::processAckStage2(NetCommandMsg *msg) {
 		//DEBUG_LOG(("ConnectionManager::processAckStage2 - removing command %d from the pending commands list.\n", commandID));
 		DEBUG_ASSERTCRASH((m_localSlot == playerID), ("Found a command in the pending commands list that wasn't originated by the local player"));
 		m_pendingCommands->removeMessage(ref);
-		MemoryPoolObject::deleteInstance(ref);
+		deleteInstance(ref);
 		ref = NULL;
 	} else {
 		//DEBUG_LOG(("ConnectionManager::processAckStage2 - Couldn't find command %d from player %d in the pending commands list.\n", commandID, playerID));
@@ -898,7 +898,7 @@ void ConnectionManager::processAckStage2(NetCommandMsg *msg) {
 			m_relayedCommands->removeMessage(ref);
 			NetAckStage2CommandMsg *ackmsg = newInstance(NetAckStage2CommandMsg)(ref->getCommand());
 			sendLocalCommand(ackmsg, 1 << ackmsg->getOriginalPlayerID());
-			MemoryPoolObject::deleteInstance(ref);
+			deleteInstance(ref);
 			ref = NULL;
 
 			ackmsg->detach();
@@ -1196,7 +1196,7 @@ void ConnectionManager::update(Bool isInGame) {
 			if (m_connections[i]->isQuitting() && m_connections[i]->isQueueEmpty())
 			{
 				DEBUG_LOG(("ConnectionManager::update - deleting connection for slot %d\n", i));
-				MemoryPoolObject::deleteInstance(m_connections[i]);
+				deleteInstance(m_connections[i]);
 				m_connections[i] = NULL;
 			}
 		}
@@ -1204,7 +1204,7 @@ void ConnectionManager::update(Bool isInGame) {
 		if ((m_frameData[i] != NULL) && (m_frameData[i]->getIsQuitting() == TRUE)) {
 			if (m_frameData[i]->getQuitFrame() == TheGameLogic->getFrame()) {
 				DEBUG_LOG(("ConnectionManager::update - deleting frame data for slot %d on quitting frame %d\n", i, m_frameData[i]->getQuitFrame()));
-				MemoryPoolObject::deleteInstance(m_frameData[i]);
+				deleteInstance(m_frameData[i]);
 				m_frameData[i] = NULL;
 			}
 		}
@@ -1730,13 +1730,13 @@ PlayerLeaveCode ConnectionManager::disconnectPlayer(Int slot) {
 
 	if ((m_frameData[slot] != NULL) && (m_frameData[slot]->getIsQuitting() == FALSE)) {
 		DEBUG_LOG(("ConnectionManager::disconnectPlayer - deleting player %d frame data\n", slot));
-		MemoryPoolObject::deleteInstance(m_frameData[slot]);
+		deleteInstance(m_frameData[slot]);
 		m_frameData[slot] = NULL;
 	}
 
 	if (m_connections[slot] != NULL && !m_connections[slot]->isQuitting()) {
 		DEBUG_LOG(("ConnectionManager::disconnectPlayer - deleting player %d connection\n", slot));
-		MemoryPoolObject::deleteInstance(m_connections[slot]);
+		deleteInstance(m_connections[slot]);
 		m_connections[slot] = NULL;
 	}
 
@@ -2356,7 +2356,7 @@ void ConnectionManager::notifyOthersOfCurrentFrame(Int frame) {
 	NetCommandRef *ref = NEW_NETCOMMANDREF(msg);
 	ref->setRelay(1 << m_localSlot);
 	m_disconnectManager->processDisconnectCommand(ref, this);
-	MemoryPoolObject::deleteInstance(ref);
+	deleteInstance(ref);
 
 	msg->detach();
 
@@ -2379,7 +2379,7 @@ void ConnectionManager::notifyOthersOfNewFrame(UnsignedInt frame) {
 	NetCommandRef *ref = NEW_NETCOMMANDREF(msg);
 	ref->setRelay(1 << m_localSlot);
 	m_disconnectManager->processDisconnectCommand(ref, this);
-	MemoryPoolObject::deleteInstance(ref);
+	deleteInstance(ref);
 
 	msg->detach();
 }

--- a/Generals/Code/GameEngine/Source/GameNetwork/ConnectionManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/ConnectionManager.cpp
@@ -65,7 +65,7 @@
 ConnectionManager::~ConnectionManager(void)
 {
 	if (m_localUser != NULL) {
-		m_localUser->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_localUser);
 		m_localUser = NULL;
 	}
 
@@ -78,14 +78,14 @@ ConnectionManager::~ConnectionManager(void)
 	Int i = 0;
 	for (; i < MAX_SLOTS; ++i) {
 		if (m_frameData[i] != NULL) {
-			m_frameData[i]->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_frameData[i]);
 			m_frameData[i] = NULL;
 		}
 	}
 
 	for (i = 0; i < NUM_CONNECTIONS; ++i) {
 		if (m_connections[i] != NULL) {
-			m_connections[i]->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_connections[i]);
 			m_connections[i] = NULL;
 		}
 	}
@@ -102,17 +102,17 @@ ConnectionManager::~ConnectionManager(void)
 	}
 
 	if (m_pendingCommands != NULL) {
-		m_pendingCommands->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_pendingCommands);
 		m_pendingCommands = NULL;
 	}
 
 	if (m_relayedCommands != NULL) {
-		m_relayedCommands->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_relayedCommands);
 		m_relayedCommands = NULL;
 	}
 
 	if (m_netCommandWrapperList != NULL) {
-		m_netCommandWrapperList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_netCommandWrapperList);
 		m_netCommandWrapperList = NULL;
 	}
 
@@ -180,7 +180,7 @@ void ConnectionManager::init()
 
 	for (i = 0; i < MAX_SLOTS; ++i) {
 		if (m_frameData[i] != NULL) {
-			m_frameData[i]->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_frameData[i]);
 			m_frameData[i] = NULL;
 		}
 	}
@@ -234,7 +234,7 @@ void ConnectionManager::reset()
 	Int i = 0;
 	for (; i < NUM_CONNECTIONS; ++i) {
 		if (m_connections[i] != NULL) {
-			m_connections[i]->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_connections[i]);
 			m_connections[i] = NULL;
 		}
 	}
@@ -242,7 +242,7 @@ void ConnectionManager::reset()
 	for (i=0; i<MAX_SLOTS; ++i)
 	{
 		if (m_frameData[i] != NULL) {
-			m_frameData[i]->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_frameData[i]);
 			m_frameData[i] = NULL;
 		}
 	}
@@ -383,10 +383,10 @@ void ConnectionManager::doRelay() {
 			++numPackets;
 
 			// Delete this packet since we won't be needing it anymore.
-			packet->deleteInstance();
+			MemoryPoolObject::deleteInstance(packet);
 			packet = NULL;
 
-			cmdList->deleteInstance();
+			MemoryPoolObject::deleteInstance(cmdList);
 			cmdList = NULL;
 
 			// signal that this has been processed.
@@ -410,10 +410,10 @@ void ConnectionManager::doRelay() {
 	++numPackets;
 
 	// Delete this packet since we won't be needing it anymore.
-	packet->deleteInstance();
+	MemoryPoolObject::deleteInstance(packet);
 	packet = NULL;
 
-	cmdList->deleteInstance();
+	MemoryPoolObject::deleteInstance(cmdList);
 	cmdList = NULL;
 }
 
@@ -853,7 +853,7 @@ void ConnectionManager::processAckStage1(NetCommandMsg *msg) {
 			m_frameMetrics.processLatencyResponse(((NetFrameCommandMsg *)(ref->getCommand()))->getExecutionFrame());
 		}
 
-		ref->deleteInstance();
+		MemoryPoolObject::deleteInstance(ref);
 		ref = NULL;
 	}
 }
@@ -880,7 +880,7 @@ void ConnectionManager::processAckStage2(NetCommandMsg *msg) {
 		//DEBUG_LOG(("ConnectionManager::processAckStage2 - removing command %d from the pending commands list.\n", commandID));
 		DEBUG_ASSERTCRASH((m_localSlot == playerID), ("Found a command in the pending commands list that wasn't originated by the local player"));
 		m_pendingCommands->removeMessage(ref);
-		ref->deleteInstance();
+		MemoryPoolObject::deleteInstance(ref);
 		ref = NULL;
 	} else {
 		//DEBUG_LOG(("ConnectionManager::processAckStage2 - Couldn't find command %d from player %d in the pending commands list.\n", commandID, playerID));
@@ -898,7 +898,7 @@ void ConnectionManager::processAckStage2(NetCommandMsg *msg) {
 			m_relayedCommands->removeMessage(ref);
 			NetAckStage2CommandMsg *ackmsg = newInstance(NetAckStage2CommandMsg)(ref->getCommand());
 			sendLocalCommand(ackmsg, 1 << ackmsg->getOriginalPlayerID());
-			ref->deleteInstance();
+			MemoryPoolObject::deleteInstance(ref);
 			ref = NULL;
 
 			ackmsg->detach();
@@ -1196,7 +1196,7 @@ void ConnectionManager::update(Bool isInGame) {
 			if (m_connections[i]->isQuitting() && m_connections[i]->isQueueEmpty())
 			{
 				DEBUG_LOG(("ConnectionManager::update - deleting connection for slot %d\n", i));
-				m_connections[i]->deleteInstance();
+				MemoryPoolObject::deleteInstance(m_connections[i]);
 				m_connections[i] = NULL;
 			}
 		}
@@ -1204,7 +1204,7 @@ void ConnectionManager::update(Bool isInGame) {
 		if ((m_frameData[i] != NULL) && (m_frameData[i]->getIsQuitting() == TRUE)) {
 			if (m_frameData[i]->getQuitFrame() == TheGameLogic->getFrame()) {
 				DEBUG_LOG(("ConnectionManager::update - deleting frame data for slot %d on quitting frame %d\n", i, m_frameData[i]->getQuitFrame()));
-				m_frameData[i]->deleteInstance();
+				MemoryPoolObject::deleteInstance(m_frameData[i]);
 				m_frameData[i] = NULL;
 			}
 		}
@@ -1730,13 +1730,13 @@ PlayerLeaveCode ConnectionManager::disconnectPlayer(Int slot) {
 
 	if ((m_frameData[slot] != NULL) && (m_frameData[slot]->getIsQuitting() == FALSE)) {
 		DEBUG_LOG(("ConnectionManager::disconnectPlayer - deleting player %d frame data\n", slot));
-		m_frameData[slot]->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_frameData[slot]);
 		m_frameData[slot] = NULL;
 	}
 
 	if (m_connections[slot] != NULL && !m_connections[slot]->isQuitting()) {
 		DEBUG_LOG(("ConnectionManager::disconnectPlayer - deleting player %d connection\n", slot));
-		m_connections[slot]->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_connections[slot]);
 		m_connections[slot] = NULL;
 	}
 
@@ -2356,7 +2356,7 @@ void ConnectionManager::notifyOthersOfCurrentFrame(Int frame) {
 	NetCommandRef *ref = NEW_NETCOMMANDREF(msg);
 	ref->setRelay(1 << m_localSlot);
 	m_disconnectManager->processDisconnectCommand(ref, this);
-	ref->deleteInstance();
+	MemoryPoolObject::deleteInstance(ref);
 
 	msg->detach();
 
@@ -2379,7 +2379,7 @@ void ConnectionManager::notifyOthersOfNewFrame(UnsignedInt frame) {
 	NetCommandRef *ref = NEW_NETCOMMANDREF(msg);
 	ref->setRelay(1 << m_localSlot);
 	m_disconnectManager->processDisconnectCommand(ref, this);
-	ref->deleteInstance();
+	MemoryPoolObject::deleteInstance(ref);
 
 	msg->detach();
 }

--- a/Generals/Code/GameEngine/Source/GameNetwork/FrameData.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/FrameData.cpp
@@ -50,7 +50,7 @@ FrameData::FrameData()
 FrameData::~FrameData() 
 {
 	if (m_commandList != NULL) {
-		m_commandList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_commandList);
 		m_commandList = NULL;
 	}
 }

--- a/Generals/Code/GameEngine/Source/GameNetwork/FrameData.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/FrameData.cpp
@@ -50,7 +50,7 @@ FrameData::FrameData()
 FrameData::~FrameData() 
 {
 	if (m_commandList != NULL) {
-		MemoryPoolObject::deleteInstance(m_commandList);
+		deleteInstance(m_commandList);
 		m_commandList = NULL;
 	}
 }

--- a/Generals/Code/GameEngine/Source/GameNetwork/GameMessageParser.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/GameMessageParser.cpp
@@ -68,7 +68,7 @@ GameMessageParser::~GameMessageParser()
 	GameMessageParserArgumentType *temp = NULL;
 	while (m_first != NULL) {
 		temp = m_first->getNext();
-		m_first->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_first);
 		m_first = temp;
 	}
 }

--- a/Generals/Code/GameEngine/Source/GameNetwork/GameMessageParser.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/GameMessageParser.cpp
@@ -68,7 +68,7 @@ GameMessageParser::~GameMessageParser()
 	GameMessageParserArgumentType *temp = NULL;
 	while (m_first != NULL) {
 		temp = m_first->getNext();
-		MemoryPoolObject::deleteInstance(m_first);
+		deleteInstance(m_first);
 		m_first = temp;
 	}
 }

--- a/Generals/Code/GameEngine/Source/GameNetwork/GameSpyOverlay.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/GameSpyOverlay.cpp
@@ -267,7 +267,7 @@ void GameSpyCloseOverlay( GSOverlayType overlay )
 	{
 		overlayLayouts[overlay]->runShutdown();
 		overlayLayouts[overlay]->destroyWindows();
-		MemoryPoolObject::deleteInstance(overlayLayouts[overlay]);
+		deleteInstance(overlayLayouts[overlay]);
 		overlayLayouts[overlay] = NULL;
 	}
 }

--- a/Generals/Code/GameEngine/Source/GameNetwork/GameSpyOverlay.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/GameSpyOverlay.cpp
@@ -267,7 +267,7 @@ void GameSpyCloseOverlay( GSOverlayType overlay )
 	{
 		overlayLayouts[overlay]->runShutdown();
 		overlayLayouts[overlay]->destroyWindows();
-		overlayLayouts[overlay]->deleteInstance();
+		MemoryPoolObject::deleteInstance(overlayLayouts[overlay]);
 		overlayLayouts[overlay] = NULL;
 	}
 }

--- a/Generals/Code/GameEngine/Source/GameNetwork/IPEnumeration.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/IPEnumeration.cpp
@@ -44,7 +44,7 @@ IPEnumeration::~IPEnumeration( void )
 	while (ip)
 	{
 		ip = ip->getNext();
-		MemoryPoolObject::deleteInstance(m_IPlist);
+		deleteInstance(m_IPlist);
 		m_IPlist = ip;
 	}
 }

--- a/Generals/Code/GameEngine/Source/GameNetwork/IPEnumeration.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/IPEnumeration.cpp
@@ -44,7 +44,7 @@ IPEnumeration::~IPEnumeration( void )
 	while (ip)
 	{
 		ip = ip->getNext();
-		m_IPlist->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_IPlist);
 		m_IPlist = ip;
 	}
 }

--- a/Generals/Code/GameEngine/Source/GameNetwork/NetCommandList.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/NetCommandList.cpp
@@ -115,7 +115,7 @@ void NetCommandList::reset() {
 		temp = m_first->getNext();
 		m_first->setNext(NULL);
 		m_first->setPrev(NULL);
-		m_first->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_first);
 		m_first = temp;
 	}
 	m_last = NULL;
@@ -160,7 +160,7 @@ NetCommandRef * NetCommandList::addMessage(NetCommandMsg *cmdMsg) {
 			if (isEqualCommandMsg(m_lastMessageInserted->getCommand(), msg->getCommand())) {
 
 				// This command is already in the list, don't duplicate it.
-				msg->deleteInstance();
+				MemoryPoolObject::deleteInstance(msg);
 				msg = NULL;
 				return NULL;
 			}
@@ -191,7 +191,7 @@ NetCommandRef * NetCommandList::addMessage(NetCommandMsg *cmdMsg) {
 		if (isEqualCommandMsg(m_last->getCommand(), msg->getCommand())) {
 
 			// This command is already in the list, don't duplicate it.
-			msg->deleteInstance();
+			MemoryPoolObject::deleteInstance(msg);
 			msg = NULL;
 			return NULL;
 		}
@@ -209,7 +209,7 @@ NetCommandRef * NetCommandList::addMessage(NetCommandMsg *cmdMsg) {
 		if (isEqualCommandMsg(m_first->getCommand(), msg->getCommand())) {
 
 			// This command is already in the list, don't duplicate it.
-			msg->deleteInstance();
+			MemoryPoolObject::deleteInstance(msg);
 			msg = NULL;
 			return NULL;
 		}
@@ -235,7 +235,7 @@ NetCommandRef * NetCommandList::addMessage(NetCommandMsg *cmdMsg) {
 		if (isEqualCommandMsg(m_last->getCommand(), msg->getCommand())) {
 
 			// This command is already in the list, don't duplicate it.
-			msg->deleteInstance();
+			MemoryPoolObject::deleteInstance(msg);
 			msg = NULL;
 			return NULL;
 		}
@@ -259,7 +259,7 @@ NetCommandRef * NetCommandList::addMessage(NetCommandMsg *cmdMsg) {
 		if (isEqualCommandMsg(m_last->getCommand(), msg->getCommand())) {
 
 			// This command is already in the list, don't duplicate it.
-			msg->deleteInstance();
+			MemoryPoolObject::deleteInstance(msg);
 			msg = NULL;
 			return NULL;
 		}
@@ -284,7 +284,7 @@ NetCommandRef * NetCommandList::addMessage(NetCommandMsg *cmdMsg) {
 		if (isEqualCommandMsg(m_last->getCommand(), msg->getCommand())) {
 
 			// This command is already in the list, don't duplicate it.
-			msg->deleteInstance();
+			MemoryPoolObject::deleteInstance(msg);
 			msg = NULL;
 			return NULL;
 		}
@@ -303,7 +303,7 @@ NetCommandRef * NetCommandList::addMessage(NetCommandMsg *cmdMsg) {
 		if (isEqualCommandMsg(m_first->getCommand(), msg->getCommand())) {
 
 			// This command is already in the list, don't duplicate it.
-			msg->deleteInstance();
+			MemoryPoolObject::deleteInstance(msg);
 			return NULL;
 		}
 
@@ -320,7 +320,7 @@ NetCommandRef * NetCommandList::addMessage(NetCommandMsg *cmdMsg) {
 		if (isEqualCommandMsg(tempmsg->getCommand(), msg->getCommand())) {
 
 		// This command is already in the list, don't duplicate it.
-		msg->deleteInstance();
+		MemoryPoolObject::deleteInstance(msg);
 		msg = NULL;
 		return NULL;
 	}

--- a/Generals/Code/GameEngine/Source/GameNetwork/NetCommandList.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/NetCommandList.cpp
@@ -115,7 +115,7 @@ void NetCommandList::reset() {
 		temp = m_first->getNext();
 		m_first->setNext(NULL);
 		m_first->setPrev(NULL);
-		MemoryPoolObject::deleteInstance(m_first);
+		deleteInstance(m_first);
 		m_first = temp;
 	}
 	m_last = NULL;
@@ -160,7 +160,7 @@ NetCommandRef * NetCommandList::addMessage(NetCommandMsg *cmdMsg) {
 			if (isEqualCommandMsg(m_lastMessageInserted->getCommand(), msg->getCommand())) {
 
 				// This command is already in the list, don't duplicate it.
-				MemoryPoolObject::deleteInstance(msg);
+				deleteInstance(msg);
 				msg = NULL;
 				return NULL;
 			}
@@ -191,7 +191,7 @@ NetCommandRef * NetCommandList::addMessage(NetCommandMsg *cmdMsg) {
 		if (isEqualCommandMsg(m_last->getCommand(), msg->getCommand())) {
 
 			// This command is already in the list, don't duplicate it.
-			MemoryPoolObject::deleteInstance(msg);
+			deleteInstance(msg);
 			msg = NULL;
 			return NULL;
 		}
@@ -209,7 +209,7 @@ NetCommandRef * NetCommandList::addMessage(NetCommandMsg *cmdMsg) {
 		if (isEqualCommandMsg(m_first->getCommand(), msg->getCommand())) {
 
 			// This command is already in the list, don't duplicate it.
-			MemoryPoolObject::deleteInstance(msg);
+			deleteInstance(msg);
 			msg = NULL;
 			return NULL;
 		}
@@ -235,7 +235,7 @@ NetCommandRef * NetCommandList::addMessage(NetCommandMsg *cmdMsg) {
 		if (isEqualCommandMsg(m_last->getCommand(), msg->getCommand())) {
 
 			// This command is already in the list, don't duplicate it.
-			MemoryPoolObject::deleteInstance(msg);
+			deleteInstance(msg);
 			msg = NULL;
 			return NULL;
 		}
@@ -259,7 +259,7 @@ NetCommandRef * NetCommandList::addMessage(NetCommandMsg *cmdMsg) {
 		if (isEqualCommandMsg(m_last->getCommand(), msg->getCommand())) {
 
 			// This command is already in the list, don't duplicate it.
-			MemoryPoolObject::deleteInstance(msg);
+			deleteInstance(msg);
 			msg = NULL;
 			return NULL;
 		}
@@ -284,7 +284,7 @@ NetCommandRef * NetCommandList::addMessage(NetCommandMsg *cmdMsg) {
 		if (isEqualCommandMsg(m_last->getCommand(), msg->getCommand())) {
 
 			// This command is already in the list, don't duplicate it.
-			MemoryPoolObject::deleteInstance(msg);
+			deleteInstance(msg);
 			msg = NULL;
 			return NULL;
 		}
@@ -303,7 +303,7 @@ NetCommandRef * NetCommandList::addMessage(NetCommandMsg *cmdMsg) {
 		if (isEqualCommandMsg(m_first->getCommand(), msg->getCommand())) {
 
 			// This command is already in the list, don't duplicate it.
-			MemoryPoolObject::deleteInstance(msg);
+			deleteInstance(msg);
 			return NULL;
 		}
 
@@ -320,7 +320,7 @@ NetCommandRef * NetCommandList::addMessage(NetCommandMsg *cmdMsg) {
 		if (isEqualCommandMsg(tempmsg->getCommand(), msg->getCommand())) {
 
 		// This command is already in the list, don't duplicate it.
-		MemoryPoolObject::deleteInstance(msg);
+		deleteInstance(msg);
 		msg = NULL;
 		return NULL;
 	}

--- a/Generals/Code/GameEngine/Source/GameNetwork/NetCommandMsg.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/NetCommandMsg.cpp
@@ -66,12 +66,12 @@ void NetCommandMsg::attach() {
 void NetCommandMsg::detach() {
 	--m_referenceCount;
 	if (m_referenceCount == 0) {
-		deleteInstance();
+		MemoryPoolObject::deleteInstance(this);
 		return;
 	}
 	DEBUG_ASSERTCRASH(m_referenceCount > 0, ("Invalid reference count for NetCommandMsg")); // Just to make sure...
 	if (m_referenceCount < 0) {
-		deleteInstance();
+		MemoryPoolObject::deleteInstance(this);
 	}
 }
 
@@ -123,7 +123,7 @@ NetGameCommandMsg::~NetGameCommandMsg() {
 	GameMessageArgument *arg = m_argList;
 	while (arg != NULL) {
 		m_argList = m_argList->m_next;
-		arg->deleteInstance();
+		MemoryPoolObject::deleteInstance(arg);
 		arg = m_argList;
 	}
 }

--- a/Generals/Code/GameEngine/Source/GameNetwork/NetCommandMsg.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/NetCommandMsg.cpp
@@ -66,12 +66,12 @@ void NetCommandMsg::attach() {
 void NetCommandMsg::detach() {
 	--m_referenceCount;
 	if (m_referenceCount == 0) {
-		MemoryPoolObject::deleteInstance(this);
+		deleteInstance(this);
 		return;
 	}
 	DEBUG_ASSERTCRASH(m_referenceCount > 0, ("Invalid reference count for NetCommandMsg")); // Just to make sure...
 	if (m_referenceCount < 0) {
-		MemoryPoolObject::deleteInstance(this);
+		deleteInstance(this);
 	}
 }
 
@@ -123,7 +123,7 @@ NetGameCommandMsg::~NetGameCommandMsg() {
 	GameMessageArgument *arg = m_argList;
 	while (arg != NULL) {
 		m_argList = m_argList->m_next;
-		MemoryPoolObject::deleteInstance(arg);
+		deleteInstance(arg);
 		arg = m_argList;
 	}
 }

--- a/Generals/Code/GameEngine/Source/GameNetwork/NetCommandWrapperList.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/NetCommandWrapperList.cpp
@@ -128,7 +128,7 @@ NetCommandWrapperList::~NetCommandWrapperList() {
 	NetCommandWrapperListNode *temp;
 	while (m_list != NULL) {
 		temp = m_list->m_next;
-		MemoryPoolObject::deleteInstance(m_list);
+		deleteInstance(m_list);
 		m_list = temp;
 	}
 }
@@ -141,7 +141,7 @@ void NetCommandWrapperList::reset() {
 	NetCommandWrapperListNode *temp;
 	while (m_list != NULL) {
 		temp = m_list->m_next;
-		MemoryPoolObject::deleteInstance(m_list);
+		deleteInstance(m_list);
 		m_list = temp;
 	}
 }
@@ -192,7 +192,7 @@ NetCommandList * NetCommandWrapperList::getReadyCommands()
 			NetCommandRef *ret = retlist->addMessage(msg->getCommand());
 			ret->setRelay(msg->getRelay());
 
-			MemoryPoolObject::deleteInstance(msg);
+			deleteInstance(msg);
 			msg = NULL;
 
 			removeFromList(temp);
@@ -223,11 +223,11 @@ void NetCommandWrapperList::removeFromList(NetCommandWrapperListNode *node) {
 
 	if (prev == NULL) {
 		m_list = temp->m_next;
-		MemoryPoolObject::deleteInstance(temp);
+		deleteInstance(temp);
 		temp = NULL;
 	} else {
 		prev->m_next = temp->m_next;
-		MemoryPoolObject::deleteInstance(temp);
+		deleteInstance(temp);
 		temp = NULL;
 	}
 }

--- a/Generals/Code/GameEngine/Source/GameNetwork/NetCommandWrapperList.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/NetCommandWrapperList.cpp
@@ -128,7 +128,7 @@ NetCommandWrapperList::~NetCommandWrapperList() {
 	NetCommandWrapperListNode *temp;
 	while (m_list != NULL) {
 		temp = m_list->m_next;
-		m_list->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_list);
 		m_list = temp;
 	}
 }
@@ -141,7 +141,7 @@ void NetCommandWrapperList::reset() {
 	NetCommandWrapperListNode *temp;
 	while (m_list != NULL) {
 		temp = m_list->m_next;
-		m_list->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_list);
 		m_list = temp;
 	}
 }
@@ -192,7 +192,7 @@ NetCommandList * NetCommandWrapperList::getReadyCommands()
 			NetCommandRef *ret = retlist->addMessage(msg->getCommand());
 			ret->setRelay(msg->getRelay());
 
-			msg->deleteInstance();
+			MemoryPoolObject::deleteInstance(msg);
 			msg = NULL;
 
 			removeFromList(temp);
@@ -223,11 +223,11 @@ void NetCommandWrapperList::removeFromList(NetCommandWrapperListNode *node) {
 
 	if (prev == NULL) {
 		m_list = temp->m_next;
-		temp->deleteInstance();
+		MemoryPoolObject::deleteInstance(temp);
 		temp = NULL;
 	} else {
 		prev->m_next = temp->m_next;
-		temp->deleteInstance();
+		MemoryPoolObject::deleteInstance(temp);
 		temp = NULL;
 	}
 }

--- a/Generals/Code/GameEngine/Source/GameNetwork/NetPacket.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/NetPacket.cpp
@@ -216,7 +216,7 @@ NetPacketList NetPacket::ConstructBigCommandPacketList(NetCommandRef *ref) {
 
 		packetList.push_back(packet);
 
-		ref->deleteInstance();
+		MemoryPoolObject::deleteInstance(ref);
 		ref = NULL;
 
 		++currentChunk;
@@ -346,10 +346,10 @@ UnsignedInt NetPacket::GetGameCommandSize(NetCommandMsg *msg) {
 		arg = arg->getNext();
 	}
 
-	parser->deleteInstance();
+	MemoryPoolObject::deleteInstance(parser);
 	parser = NULL;
 
-	gmsg->deleteInstance();
+	MemoryPoolObject::deleteInstance(gmsg);
 	gmsg = NULL;
 
 	return msglen;
@@ -931,13 +931,13 @@ void NetPacket::FillBufferWithGameCommand(UnsignedByte *buffer, NetCommandRef *m
 		}
 	}
 
-	parser->deleteInstance();
+	MemoryPoolObject::deleteInstance(parser);
 	parser = NULL;
 
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addGameMessage - added game message, frame %d, player %d, command ID %d\n", m_lastFrame, m_lastPlayerID, m_lastCommandID));
 
 	if (gmsg)
-		gmsg->deleteInstance();
+		MemoryPoolObject::deleteInstance(gmsg);
 	gmsg = NULL;
 }
 
@@ -1921,7 +1921,7 @@ NetPacket::NetPacket(TransportMessage *msg) {
  */
 NetPacket::~NetPacket() {
 	if (m_lastCommand != NULL) {
-		m_lastCommand->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_lastCommand);
 		m_lastCommand = NULL;
 	}
 }
@@ -1947,7 +1947,7 @@ void NetPacket::init() {
 
 void NetPacket::reset() {
 	if (m_lastCommand != NULL) {
-		m_lastCommand->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_lastCommand);
 		m_lastCommand = NULL;
 	}
 	init();
@@ -2116,7 +2116,7 @@ Bool NetPacket::addFrameResendRequestCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -2227,7 +2227,7 @@ Bool NetPacket::addDisconnectScreenOffCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -2336,7 +2336,7 @@ Bool NetPacket::addDisconnectFrameCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -2444,7 +2444,7 @@ Bool NetPacket::addFileCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -2549,7 +2549,7 @@ Bool NetPacket::addFileAnnounceCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -2654,7 +2654,7 @@ Bool NetPacket::addFileProgressCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -2786,7 +2786,7 @@ Bool NetPacket::addWrapperCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -2885,7 +2885,7 @@ Bool NetPacket::addTimeOutGameStartMessage(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -2979,7 +2979,7 @@ Bool NetPacket::addLoadCompleteMessage(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -3065,7 +3065,7 @@ Bool NetPacket::addProgressMessage(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -3176,7 +3176,7 @@ Bool NetPacket::addDisconnectVoteCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -3275,7 +3275,7 @@ Bool NetPacket::addDisconnectChatCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -3392,7 +3392,7 @@ Bool NetPacket::addChatCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -3483,7 +3483,7 @@ Bool NetPacket::addPacketRouterAckCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -3565,7 +3565,7 @@ Bool NetPacket::addPacketRouterQueryCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());	
@@ -3670,7 +3670,7 @@ Bool NetPacket::addDisconnectPlayerCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -3755,7 +3755,7 @@ Bool NetPacket::addDisconnectKeepAliveCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -3835,7 +3835,7 @@ Bool NetPacket::addKeepAliveCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -3954,7 +3954,7 @@ Bool NetPacket::addRunAheadCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -4075,7 +4075,7 @@ Bool NetPacket::addDestroyPlayerCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -4187,7 +4187,7 @@ Bool NetPacket::addRunAheadMetricsCommand(NetCommandRef *msg) {
 		m_packetLen += sizeof(averageFps);
 
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -4306,7 +4306,7 @@ Bool NetPacket::addPlayerLeaveCommand(NetCommandRef *msg) {
 		m_packetLen += sizeof(UnsignedByte);
 
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -4364,7 +4364,7 @@ Bool NetPacket::addFrameCommand(NetCommandRef *msg) {
 		m_packet[m_packetLen] = 'Z';
 		++m_packetLen;
 		m_lastCommandID = msg->getCommand()->getID();
-		m_lastCommand->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_lastCommand);
 		m_lastCommand = newInstance(NetCommandRef)(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 		++m_lastFrame;		// need this cause we're actually advancing to the next frame by adding this command.
@@ -4445,7 +4445,7 @@ Bool NetPacket::addFrameCommand(NetCommandRef *msg) {
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("outgoing - added frame %d, player %d, command count = %d, command id = %d\n", cmdMsg->getExecutionFrame(), cmdMsg->getPlayerID(), cmdMsg->getCommandCount(), cmdMsg->getID()));
 
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -4550,7 +4550,7 @@ Bool NetPacket::addAckCommand(NetCommandRef *msg, UnsignedShort commandID, Unsig
 		m_packet[m_packetLen] = 'Z';
 		++m_packetLen;
 		++m_numCommands;
-		m_lastCommand->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_lastCommand);
 		m_lastCommand = NULL;
 
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -4588,7 +4588,7 @@ Bool NetPacket::addAckCommand(NetCommandRef *msg, UnsignedShort commandID, Unsig
 		m_packetLen += sizeof(UnsignedByte);
 
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -4793,7 +4793,7 @@ Bool NetPacket::addGameCommand(NetCommandRef *msg) {
 			writeGameMessageArgumentToPacket(type, arg);
 		}
 
-		parser->deleteInstance();
+		MemoryPoolObject::deleteInstance(parser);
 		parser = NULL;
 
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addGameMessage - added game message, frame %d, player %d, command ID %d\n", m_lastFrame, m_lastPlayerID, m_lastCommandID));
@@ -4801,7 +4801,7 @@ Bool NetPacket::addGameCommand(NetCommandRef *msg) {
 		++m_numCommands;
 
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -4811,7 +4811,7 @@ Bool NetPacket::addGameCommand(NetCommandRef *msg) {
 	}
 
 	if (gmsg) {
-		gmsg->deleteInstance();
+		MemoryPoolObject::deleteInstance(gmsg);
 		gmsg = NULL;
 	}
 
@@ -4919,7 +4919,7 @@ Bool NetPacket::isRoomForGameMessage(NetCommandRef *msg, GameMessage *gmsg) {
 		arg = arg->getNext();
 	}
 
-	parser->deleteInstance();
+	MemoryPoolObject::deleteInstance(parser);
 	parser = NULL;
 
 	// Is there enough room in the packet for this message?
@@ -5112,7 +5112,7 @@ NetCommandList * NetPacket::getCommandList() {
 			}
 
 			if (lastCommand != NULL) {
-				lastCommand->deleteInstance();
+				MemoryPoolObject::deleteInstance(lastCommand);
 				lastCommand = NULL;
 			}
 			lastCommand = newInstance(NetCommandRef)(msg);
@@ -5171,7 +5171,7 @@ NetCommandList * NetPacket::getCommandList() {
 				ref->setRelay(relay);
 			}
 
-			lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(lastCommand);
 			lastCommand = NULL;
 //			lastCommand = newInstance(NetCommandRef)(msg);
 			lastCommand = NEW_NETCOMMANDREF(msg);
@@ -5190,7 +5190,7 @@ NetCommandList * NetPacket::getCommandList() {
 	}
 
 	if (lastCommand != NULL) {
-		lastCommand->deleteInstance();
+		MemoryPoolObject::deleteInstance(lastCommand);
 		lastCommand = NULL;
 	}
 	return retval;
@@ -5259,7 +5259,7 @@ NetCommandMsg * NetPacket::readGameMessage(UnsignedByte *data, Int &i)
 		}
 	}
 
-	parser->deleteInstance();
+	MemoryPoolObject::deleteInstance(parser);
 	parser = NULL;
 
 	return (NetCommandMsg *)msg;

--- a/Generals/Code/GameEngine/Source/GameNetwork/NetPacket.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/NetPacket.cpp
@@ -216,7 +216,7 @@ NetPacketList NetPacket::ConstructBigCommandPacketList(NetCommandRef *ref) {
 
 		packetList.push_back(packet);
 
-		MemoryPoolObject::deleteInstance(ref);
+		deleteInstance(ref);
 		ref = NULL;
 
 		++currentChunk;
@@ -346,10 +346,10 @@ UnsignedInt NetPacket::GetGameCommandSize(NetCommandMsg *msg) {
 		arg = arg->getNext();
 	}
 
-	MemoryPoolObject::deleteInstance(parser);
+	deleteInstance(parser);
 	parser = NULL;
 
-	MemoryPoolObject::deleteInstance(gmsg);
+	deleteInstance(gmsg);
 	gmsg = NULL;
 
 	return msglen;
@@ -931,13 +931,13 @@ void NetPacket::FillBufferWithGameCommand(UnsignedByte *buffer, NetCommandRef *m
 		}
 	}
 
-	MemoryPoolObject::deleteInstance(parser);
+	deleteInstance(parser);
 	parser = NULL;
 
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addGameMessage - added game message, frame %d, player %d, command ID %d\n", m_lastFrame, m_lastPlayerID, m_lastCommandID));
 
 	if (gmsg)
-		MemoryPoolObject::deleteInstance(gmsg);
+		deleteInstance(gmsg);
 	gmsg = NULL;
 }
 
@@ -1921,7 +1921,7 @@ NetPacket::NetPacket(TransportMessage *msg) {
  */
 NetPacket::~NetPacket() {
 	if (m_lastCommand != NULL) {
-		MemoryPoolObject::deleteInstance(m_lastCommand);
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NULL;
 	}
 }
@@ -1947,7 +1947,7 @@ void NetPacket::init() {
 
 void NetPacket::reset() {
 	if (m_lastCommand != NULL) {
-		MemoryPoolObject::deleteInstance(m_lastCommand);
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NULL;
 	}
 	init();
@@ -2116,7 +2116,7 @@ Bool NetPacket::addFrameResendRequestCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -2227,7 +2227,7 @@ Bool NetPacket::addDisconnectScreenOffCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -2336,7 +2336,7 @@ Bool NetPacket::addDisconnectFrameCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -2444,7 +2444,7 @@ Bool NetPacket::addFileCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -2549,7 +2549,7 @@ Bool NetPacket::addFileAnnounceCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -2654,7 +2654,7 @@ Bool NetPacket::addFileProgressCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -2786,7 +2786,7 @@ Bool NetPacket::addWrapperCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -2885,7 +2885,7 @@ Bool NetPacket::addTimeOutGameStartMessage(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -2979,7 +2979,7 @@ Bool NetPacket::addLoadCompleteMessage(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -3065,7 +3065,7 @@ Bool NetPacket::addProgressMessage(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -3176,7 +3176,7 @@ Bool NetPacket::addDisconnectVoteCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -3275,7 +3275,7 @@ Bool NetPacket::addDisconnectChatCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -3392,7 +3392,7 @@ Bool NetPacket::addChatCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -3483,7 +3483,7 @@ Bool NetPacket::addPacketRouterAckCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -3565,7 +3565,7 @@ Bool NetPacket::addPacketRouterQueryCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());	
@@ -3670,7 +3670,7 @@ Bool NetPacket::addDisconnectPlayerCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -3755,7 +3755,7 @@ Bool NetPacket::addDisconnectKeepAliveCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -3835,7 +3835,7 @@ Bool NetPacket::addKeepAliveCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -3954,7 +3954,7 @@ Bool NetPacket::addRunAheadCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -4075,7 +4075,7 @@ Bool NetPacket::addDestroyPlayerCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -4187,7 +4187,7 @@ Bool NetPacket::addRunAheadMetricsCommand(NetCommandRef *msg) {
 		m_packetLen += sizeof(averageFps);
 
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -4306,7 +4306,7 @@ Bool NetPacket::addPlayerLeaveCommand(NetCommandRef *msg) {
 		m_packetLen += sizeof(UnsignedByte);
 
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -4364,7 +4364,7 @@ Bool NetPacket::addFrameCommand(NetCommandRef *msg) {
 		m_packet[m_packetLen] = 'Z';
 		++m_packetLen;
 		m_lastCommandID = msg->getCommand()->getID();
-		MemoryPoolObject::deleteInstance(m_lastCommand);
+		deleteInstance(m_lastCommand);
 		m_lastCommand = newInstance(NetCommandRef)(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 		++m_lastFrame;		// need this cause we're actually advancing to the next frame by adding this command.
@@ -4445,7 +4445,7 @@ Bool NetPacket::addFrameCommand(NetCommandRef *msg) {
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("outgoing - added frame %d, player %d, command count = %d, command id = %d\n", cmdMsg->getExecutionFrame(), cmdMsg->getPlayerID(), cmdMsg->getCommandCount(), cmdMsg->getID()));
 
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -4550,7 +4550,7 @@ Bool NetPacket::addAckCommand(NetCommandRef *msg, UnsignedShort commandID, Unsig
 		m_packet[m_packetLen] = 'Z';
 		++m_packetLen;
 		++m_numCommands;
-		MemoryPoolObject::deleteInstance(m_lastCommand);
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NULL;
 
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -4588,7 +4588,7 @@ Bool NetPacket::addAckCommand(NetCommandRef *msg, UnsignedShort commandID, Unsig
 		m_packetLen += sizeof(UnsignedByte);
 
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -4793,7 +4793,7 @@ Bool NetPacket::addGameCommand(NetCommandRef *msg) {
 			writeGameMessageArgumentToPacket(type, arg);
 		}
 
-		MemoryPoolObject::deleteInstance(parser);
+		deleteInstance(parser);
 		parser = NULL;
 
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addGameMessage - added game message, frame %d, player %d, command ID %d\n", m_lastFrame, m_lastPlayerID, m_lastCommandID));
@@ -4801,7 +4801,7 @@ Bool NetPacket::addGameCommand(NetCommandRef *msg) {
 		++m_numCommands;
 
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -4811,7 +4811,7 @@ Bool NetPacket::addGameCommand(NetCommandRef *msg) {
 	}
 
 	if (gmsg) {
-		MemoryPoolObject::deleteInstance(gmsg);
+		deleteInstance(gmsg);
 		gmsg = NULL;
 	}
 
@@ -4919,7 +4919,7 @@ Bool NetPacket::isRoomForGameMessage(NetCommandRef *msg, GameMessage *gmsg) {
 		arg = arg->getNext();
 	}
 
-	MemoryPoolObject::deleteInstance(parser);
+	deleteInstance(parser);
 	parser = NULL;
 
 	// Is there enough room in the packet for this message?
@@ -5112,7 +5112,7 @@ NetCommandList * NetPacket::getCommandList() {
 			}
 
 			if (lastCommand != NULL) {
-				MemoryPoolObject::deleteInstance(lastCommand);
+				deleteInstance(lastCommand);
 				lastCommand = NULL;
 			}
 			lastCommand = newInstance(NetCommandRef)(msg);
@@ -5171,7 +5171,7 @@ NetCommandList * NetPacket::getCommandList() {
 				ref->setRelay(relay);
 			}
 
-			MemoryPoolObject::deleteInstance(lastCommand);
+			deleteInstance(lastCommand);
 			lastCommand = NULL;
 //			lastCommand = newInstance(NetCommandRef)(msg);
 			lastCommand = NEW_NETCOMMANDREF(msg);
@@ -5190,7 +5190,7 @@ NetCommandList * NetPacket::getCommandList() {
 	}
 
 	if (lastCommand != NULL) {
-		MemoryPoolObject::deleteInstance(lastCommand);
+		deleteInstance(lastCommand);
 		lastCommand = NULL;
 	}
 	return retval;
@@ -5259,7 +5259,7 @@ NetCommandMsg * NetPacket::readGameMessage(UnsignedByte *data, Int &i)
 		}
 	}
 
-	MemoryPoolObject::deleteInstance(parser);
+	deleteInstance(parser);
 	parser = NULL;
 
 	return (NetCommandMsg *)msg;

--- a/Generals/Code/GameEngine/Source/GameNetwork/Network.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/Network.cpp
@@ -476,11 +476,11 @@ void Network::GetCommandsFromCommandList() {
 				m_conMgr->sendLocalGameMessage(msg, getExecutionFrame());
 			}
 			TheCommandList->removeMessage(msg); // This does not destroy msg's prev and next pointers, so they should still be valid.
-			msg->deleteInstance();
+			MemoryPoolObject::deleteInstance(msg);
 		} else {
 			if (processCommand(msg)) {
 				TheCommandList->removeMessage(msg);
-				msg->deleteInstance();
+				MemoryPoolObject::deleteInstance(msg);
 			}
 		}
 		msg = next;
@@ -514,7 +514,7 @@ Bool Network::processCommand(GameMessage *msg)
 			if (TheGameLogic->getFrame() == 1) {
 				m_localStatus = NETLOCALSTATUS_INGAME;
 				NetCommandList *netcmdlist = m_conMgr->getFrameCommandList(0); // clear out frame 0 since we skipped it
-				netcmdlist->deleteInstance();
+				MemoryPoolObject::deleteInstance(netcmdlist);
 			} else {
 				return FALSE;
 			}
@@ -611,7 +611,7 @@ void Network::RelayCommandsToCommandList(UnsignedInt frame) {
 	}
 	m_playersToDisconnect.clear();
 
-	netcmdlist->deleteInstance();
+	MemoryPoolObject::deleteInstance(netcmdlist);
 }
 
 /**

--- a/Generals/Code/GameEngine/Source/GameNetwork/Network.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/Network.cpp
@@ -476,11 +476,11 @@ void Network::GetCommandsFromCommandList() {
 				m_conMgr->sendLocalGameMessage(msg, getExecutionFrame());
 			}
 			TheCommandList->removeMessage(msg); // This does not destroy msg's prev and next pointers, so they should still be valid.
-			MemoryPoolObject::deleteInstance(msg);
+			deleteInstance(msg);
 		} else {
 			if (processCommand(msg)) {
 				TheCommandList->removeMessage(msg);
-				MemoryPoolObject::deleteInstance(msg);
+				deleteInstance(msg);
 			}
 		}
 		msg = next;
@@ -514,7 +514,7 @@ Bool Network::processCommand(GameMessage *msg)
 			if (TheGameLogic->getFrame() == 1) {
 				m_localStatus = NETLOCALSTATUS_INGAME;
 				NetCommandList *netcmdlist = m_conMgr->getFrameCommandList(0); // clear out frame 0 since we skipped it
-				MemoryPoolObject::deleteInstance(netcmdlist);
+				deleteInstance(netcmdlist);
 			} else {
 				return FALSE;
 			}
@@ -611,7 +611,7 @@ void Network::RelayCommandsToCommandList(UnsignedInt frame) {
 	}
 	m_playersToDisconnect.clear();
 
-	MemoryPoolObject::deleteInstance(netcmdlist);
+	deleteInstance(netcmdlist);
 }
 
 /**

--- a/Generals/Code/GameEngine/Source/GameNetwork/WOLBrowser/WebBrowser.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/WOLBrowser/WebBrowser.cpp
@@ -126,7 +126,7 @@ WebBrowser::~WebBrowser()
 	while (url != NULL) {
 		WebBrowserURL *temp = url;
 		url = url->m_next;
-		temp->deleteInstance();
+		MemoryPoolObject::deleteInstance(temp);
 		temp = NULL;
 	}
 }

--- a/Generals/Code/GameEngine/Source/GameNetwork/WOLBrowser/WebBrowser.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/WOLBrowser/WebBrowser.cpp
@@ -126,7 +126,7 @@ WebBrowser::~WebBrowser()
 	while (url != NULL) {
 		WebBrowserURL *temp = url;
 		url = url->m_next;
-		MemoryPoolObject::deleteInstance(temp);
+		deleteInstance(temp);
 		temp = NULL;
 	}
 }

--- a/Generals/Code/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
+++ b/Generals/Code/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
@@ -597,7 +597,7 @@ void MilesAudioManager::pauseAudio( AudioAffect which )
 		AudioRequest *req = (*ait);
 		if( req && req->m_request == AR_Play ) 
 		{
-			req->deleteInstance();
+			MemoryPoolObject::deleteInstance(req);
 			ait = m_audioRequests.erase(ait);
 		}
 		else
@@ -983,7 +983,7 @@ void MilesAudioManager::killAudioEventImmediately( AudioHandle audioEvent )
 		AudioRequest *req = (*ait);
 		if( req && req->m_request == AR_Play && req->m_handleToInteractOn == audioEvent ) 
 		{
-			req->deleteInstance();
+			MemoryPoolObject::deleteInstance(req);
 			ait = m_audioRequests.erase(ait);
 			return;
 		}
@@ -2257,7 +2257,7 @@ void MilesAudioManager::processRequestList( void )
 		if (!req->m_requiresCheckForSample || checkForSample(req)) {
 			processRequest(req);
 		}
-		req->deleteInstance();
+		MemoryPoolObject::deleteInstance(req);
 		it = m_audioRequests.erase(it);
 	}
 }

--- a/Generals/Code/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
+++ b/Generals/Code/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
@@ -597,7 +597,7 @@ void MilesAudioManager::pauseAudio( AudioAffect which )
 		AudioRequest *req = (*ait);
 		if( req && req->m_request == AR_Play ) 
 		{
-			MemoryPoolObject::deleteInstance(req);
+			deleteInstance(req);
 			ait = m_audioRequests.erase(ait);
 		}
 		else
@@ -983,7 +983,7 @@ void MilesAudioManager::killAudioEventImmediately( AudioHandle audioEvent )
 		AudioRequest *req = (*ait);
 		if( req && req->m_request == AR_Play && req->m_handleToInteractOn == audioEvent ) 
 		{
-			MemoryPoolObject::deleteInstance(req);
+			deleteInstance(req);
 			ait = m_audioRequests.erase(ait);
 			return;
 		}
@@ -2257,7 +2257,7 @@ void MilesAudioManager::processRequestList( void )
 		if (!req->m_requiresCheckForSample || checkForSample(req)) {
 			processRequest(req);
 		}
-		MemoryPoolObject::deleteInstance(req);
+		deleteInstance(req);
 		it = m_audioRequests.erase(it);
 	}
 }

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/Common/System/W3DRadar.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/Common/System/W3DRadar.cpp
@@ -149,7 +149,7 @@ void W3DRadar::deleteResources( void )
 		m_terrainTexture->Release_Ref();
 	m_terrainTexture = NULL;
 	if( m_terrainImage )
-		MemoryPoolObject::deleteInstance(m_terrainImage);
+		deleteInstance(m_terrainImage);
 	m_terrainImage = NULL;
 
 	//
@@ -159,7 +159,7 @@ void W3DRadar::deleteResources( void )
 		m_overlayTexture->Release_Ref();
 	m_overlayTexture = NULL;
 	if( m_overlayImage )
-		MemoryPoolObject::deleteInstance(m_overlayImage);
+		deleteInstance(m_overlayImage);
 	m_overlayImage = NULL;
 
 	//
@@ -169,7 +169,7 @@ void W3DRadar::deleteResources( void )
 		m_shroudTexture->Release_Ref();
 	m_shroudTexture = NULL;
 	if( m_shroudImage )
-		MemoryPoolObject::deleteInstance(m_shroudImage);
+		deleteInstance(m_shroudImage);
 	m_shroudImage = NULL;
 
 }  // end deleteResources

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/Common/System/W3DRadar.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/Common/System/W3DRadar.cpp
@@ -149,7 +149,7 @@ void W3DRadar::deleteResources( void )
 		m_terrainTexture->Release_Ref();
 	m_terrainTexture = NULL;
 	if( m_terrainImage )
-		m_terrainImage->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_terrainImage);
 	m_terrainImage = NULL;
 
 	//
@@ -159,7 +159,7 @@ void W3DRadar::deleteResources( void )
 		m_overlayTexture->Release_Ref();
 	m_overlayTexture = NULL;
 	if( m_overlayImage )
-		m_overlayImage->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_overlayImage);
 	m_overlayImage = NULL;
 
 	//
@@ -169,7 +169,7 @@ void W3DRadar::deleteResources( void )
 		m_shroudTexture->Release_Ref();
 	m_shroudTexture = NULL;
 	if( m_shroudImage )
-		m_shroudImage->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_shroudImage);
 	m_shroudImage = NULL;
 
 }  // end deleteResources

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DAssetManager.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DAssetManager.cpp
@@ -109,7 +109,7 @@ public:
 	virtual const char*					Get_Name(void) const			{ return Name.str(); }
 	virtual int									Get_Class_ID(void) const	{ return Proto->Class_ID(); }
 	virtual RenderObjClass *		Create(void);
-	virtual void								DeleteSelf()							{	deleteInstance(); }
+	virtual void								DeleteSelf()							{	MemoryPoolObject::deleteInstance(this); }
 
 protected:
 	//virtual ~W3DPrototypeClass(void);

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DAssetManager.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DAssetManager.cpp
@@ -109,7 +109,7 @@ public:
 	virtual const char*					Get_Name(void) const			{ return Name.str(); }
 	virtual int									Get_Class_ID(void) const	{ return Proto->Class_ID(); }
 	virtual RenderObjClass *		Create(void);
-	virtual void								DeleteSelf()							{	MemoryPoolObject::deleteInstance(this); }
+	virtual void								DeleteSelf()							{	deleteInstance(this); }
 
 protected:
 	//virtual ~W3DPrototypeClass(void);

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayStringManager.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayStringManager.cpp
@@ -160,7 +160,7 @@ void W3DDisplayStringManager::freeDisplayString( DisplayString *string )
 	}
 
 	// free data
-	MemoryPoolObject::deleteInstance(string);
+	deleteInstance(string);
 
 }  // end freeDisplayString
 

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayStringManager.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayStringManager.cpp
@@ -160,7 +160,7 @@ void W3DDisplayStringManager::freeDisplayString( DisplayString *string )
 	}
 
 	// free data
-	string->deleteInstance();
+	MemoryPoolObject::deleteInstance(string);
 
 }  // end freeDisplayString
 

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
@@ -307,7 +307,7 @@ WaterRenderObjClass::~WaterRenderObjClass(void)
 	{	WaterSettings[i].m_skyTextureFile.clear();
 		WaterSettings[i].m_waterTextureFile.clear();
 	}
-	((WaterTransparencySetting*)TheWaterTransparency.getNonOverloadedPointer())->deleteInstance();
+	MemoryPoolObject::deleteInstance(((WaterTransparencySetting*)TheWaterTransparency.getNonOverloadedPointer()));
 	TheWaterTransparency = NULL;
 	ReleaseResources();
 

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
@@ -307,7 +307,7 @@ WaterRenderObjClass::~WaterRenderObjClass(void)
 	{	WaterSettings[i].m_skyTextureFile.clear();
 		WaterSettings[i].m_waterTextureFile.clear();
 	}
-	MemoryPoolObject::deleteInstance(((WaterTransparencySetting*)TheWaterTransparency.getNonOverloadedPointer()));
+	deleteInstance((WaterTransparencySetting*)TheWaterTransparency.getNonOverloadedPointer());
 	TheWaterTransparency = NULL;
 	ReleaseResources();
 

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/WorldHeightMap.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/WorldHeightMap.cpp
@@ -138,7 +138,7 @@ MapObject::~MapObject(void)
 		while (cur) {
 			next = cur->getNext();
 			cur->setNextMap(NULL); // prevents recursion. 
-			MemoryPoolObject::deleteInstance(cur);
+			deleteInstance(cur);
 			cur = next;
 		}
 	}
@@ -424,7 +424,7 @@ void WorldHeightMap::freeListOfMapObjects(void)
 {
 	if (MapObject::TheMapObjectListPtr) 
 	{
-		MemoryPoolObject::deleteInstance(MapObject::TheMapObjectListPtr);
+		deleteInstance(MapObject::TheMapObjectListPtr);
 		MapObject::TheMapObjectListPtr = NULL;
 	}
 	MapObject::getWorldDict()->clear();

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/WorldHeightMap.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/WorldHeightMap.cpp
@@ -138,7 +138,7 @@ MapObject::~MapObject(void)
 		while (cur) {
 			next = cur->getNext();
 			cur->setNextMap(NULL); // prevents recursion. 
-			cur->deleteInstance();
+			MemoryPoolObject::deleteInstance(cur);
 			cur = next;
 		}
 	}
@@ -424,7 +424,7 @@ void WorldHeightMap::freeListOfMapObjects(void)
 {
 	if (MapObject::TheMapObjectListPtr) 
 	{
-		MapObject::TheMapObjectListPtr->deleteInstance();
+		MemoryPoolObject::deleteInstance(MapObject::TheMapObjectListPtr);
 		MapObject::TheMapObjectListPtr = NULL;
 	}
 	MapObject::getWorldDict()->clear();

--- a/Generals/Code/GameEngineDevice/Source/Win32Device/Common/Win32LocalFileSystem.cpp
+++ b/Generals/Code/GameEngineDevice/Source/Win32Device/Common/Win32LocalFileSystem.cpp
@@ -73,7 +73,7 @@ File * Win32LocalFileSystem::openFile(const Char *filename, Int access /* = 0 */
 
 	if (file->open(filename, access) == FALSE) {
 		file->close();
-		file->deleteInstance();
+		MemoryPoolObject::deleteInstance(file);
 		file = NULL;
 	} else {
 		file->deleteOnClose();
@@ -94,7 +94,7 @@ File * Win32LocalFileSystem::openFile(const Char *filename, Int access /* = 0 */
 //			return ramFile;
 //		}	else {
 //			ramFile->close();
-//			ramFile->deleteInstance();
+//			MemoryPoolObject::deleteInstance(ramFile);
 //		}
 //	}
 

--- a/Generals/Code/GameEngineDevice/Source/Win32Device/Common/Win32LocalFileSystem.cpp
+++ b/Generals/Code/GameEngineDevice/Source/Win32Device/Common/Win32LocalFileSystem.cpp
@@ -73,7 +73,7 @@ File * Win32LocalFileSystem::openFile(const Char *filename, Int access /* = 0 */
 
 	if (file->open(filename, access) == FALSE) {
 		file->close();
-		MemoryPoolObject::deleteInstance(file);
+		deleteInstance(file);
 		file = NULL;
 	} else {
 		file->deleteOnClose();
@@ -94,7 +94,7 @@ File * Win32LocalFileSystem::openFile(const Char *filename, Int access /* = 0 */
 //			return ramFile;
 //		}	else {
 //			ramFile->close();
-//			MemoryPoolObject::deleteInstance(ramFile);
+//			deleteInstance(ramFile);
 //		}
 //	}
 

--- a/Generals/Code/Tools/WorldBuilder/include/WorldBuilder.h
+++ b/Generals/Code/Tools/WorldBuilder/include/WorldBuilder.h
@@ -140,7 +140,7 @@ protected:
 	void deletePasteObjList(void) 
 	{ 
 		if (m_pasteMapObjList) 
-			MemoryPoolObject::deleteInstance(m_pasteMapObjList); 
+			deleteInstance(m_pasteMapObjList); 
 		m_pasteMapObjList = NULL; 
 	};
 

--- a/Generals/Code/Tools/WorldBuilder/include/WorldBuilder.h
+++ b/Generals/Code/Tools/WorldBuilder/include/WorldBuilder.h
@@ -140,7 +140,7 @@ protected:
 	void deletePasteObjList(void) 
 	{ 
 		if (m_pasteMapObjList) 
-			m_pasteMapObjList->deleteInstance(); 
+			MemoryPoolObject::deleteInstance(m_pasteMapObjList); 
 		m_pasteMapObjList = NULL; 
 	};
 

--- a/Generals/Code/Tools/WorldBuilder/src/CUndoable.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/CUndoable.cpp
@@ -208,7 +208,7 @@ AddObjectUndoable::~AddObjectUndoable(void)
 {
 	m_pDoc = NULL;  // not ref counted.
 	if (m_objectToAdd && !m_addedToList) {
-		m_objectToAdd->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_objectToAdd);
 		m_objectToAdd=NULL;
 	}
 }
@@ -858,7 +858,7 @@ void DictItemUndoable::Undo(void)
 DeleteInfo::~DeleteInfo(void)
 {
 	if (m_didDelete && m_objectToDelete) {
-		m_objectToDelete->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_objectToDelete);
 	}
 	DeleteInfo *pCur = m_next;
 	DeleteInfo *tmp;
@@ -1050,7 +1050,7 @@ AddPolygonUndoable::~AddPolygonUndoable(void)
 {
 	if (m_trigger && !m_isTriggerInList) {
 		DEBUG_ASSERTCRASH(m_trigger->getNext()==NULL, ("Logic error."));
-		m_trigger->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_trigger);
 	}
 	m_trigger=NULL;
 }
@@ -1318,7 +1318,7 @@ DeletePolygonUndoable::~DeletePolygonUndoable(void)
 {
 	if (m_trigger && !m_isTriggerInList) {
 		DEBUG_ASSERTCRASH(m_trigger->getNext()==NULL, ("Logic error."));
-		m_trigger->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_trigger);
 	}
 	m_trigger=NULL;
 }

--- a/Generals/Code/Tools/WorldBuilder/src/CUndoable.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/CUndoable.cpp
@@ -208,7 +208,7 @@ AddObjectUndoable::~AddObjectUndoable(void)
 {
 	m_pDoc = NULL;  // not ref counted.
 	if (m_objectToAdd && !m_addedToList) {
-		MemoryPoolObject::deleteInstance(m_objectToAdd);
+		deleteInstance(m_objectToAdd);
 		m_objectToAdd=NULL;
 	}
 }
@@ -858,7 +858,7 @@ void DictItemUndoable::Undo(void)
 DeleteInfo::~DeleteInfo(void)
 {
 	if (m_didDelete && m_objectToDelete) {
-		MemoryPoolObject::deleteInstance(m_objectToDelete);
+		deleteInstance(m_objectToDelete);
 	}
 	DeleteInfo *pCur = m_next;
 	DeleteInfo *tmp;
@@ -1050,7 +1050,7 @@ AddPolygonUndoable::~AddPolygonUndoable(void)
 {
 	if (m_trigger && !m_isTriggerInList) {
 		DEBUG_ASSERTCRASH(m_trigger->getNext()==NULL, ("Logic error."));
-		MemoryPoolObject::deleteInstance(m_trigger);
+		deleteInstance(m_trigger);
 	}
 	m_trigger=NULL;
 }
@@ -1318,7 +1318,7 @@ DeletePolygonUndoable::~DeletePolygonUndoable(void)
 {
 	if (m_trigger && !m_isTriggerInList) {
 		DEBUG_ASSERTCRASH(m_trigger->getNext()==NULL, ("Logic error."));
-		MemoryPoolObject::deleteInstance(m_trigger);
+		deleteInstance(m_trigger);
 	}
 	m_trigger=NULL;
 }

--- a/Generals/Code/Tools/WorldBuilder/src/FenceOptions.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/FenceOptions.cpp
@@ -69,7 +69,7 @@ FenceOptions::FenceOptions(CWnd* pParent /*=NULL*/)
 FenceOptions::~FenceOptions(void)
 {
 	if (m_objectsList) {
-		MemoryPoolObject::deleteInstance(m_objectsList);
+		deleteInstance(m_objectsList);
 	}
 	m_objectsList = NULL;
 }

--- a/Generals/Code/Tools/WorldBuilder/src/FenceOptions.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/FenceOptions.cpp
@@ -69,7 +69,7 @@ FenceOptions::FenceOptions(CWnd* pParent /*=NULL*/)
 FenceOptions::~FenceOptions(void)
 {
 	if (m_objectsList) {
-		m_objectsList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_objectsList);
 	}
 	m_objectsList = NULL;
 }

--- a/Generals/Code/Tools/WorldBuilder/src/FenceTool.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/FenceTool.cpp
@@ -50,7 +50,7 @@ FenceTool::FenceTool(void) :
 FenceTool::~FenceTool(void) 
 {
 	if (m_mapObjectList) {
-		m_mapObjectList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_mapObjectList);
 	}
 	m_mapObjectList = NULL;
 }
@@ -99,7 +99,7 @@ void FenceTool::updateMapObjectList(Coord3D downPt, Coord3D curPt, WbView* pView
 	pCurObj->setNextMap(NULL);
 	if (pXtraObjects) {
 		p3View->removeFenceListObjects(pXtraObjects);
-		pXtraObjects->deleteInstance();
+		MemoryPoolObject::deleteInstance(pXtraObjects);
 		pXtraObjects = NULL;
 	}
 
@@ -155,7 +155,7 @@ void FenceTool::mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldB
 	m_downPt2d = viewPt;
 	m_downPt3d = cpt;
 	if (m_mapObjectList) {
-		m_mapObjectList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_mapObjectList);
 		m_mapObjectList = NULL;
 	}
 	if (FenceOptions::hasSelectedObject()) {

--- a/Generals/Code/Tools/WorldBuilder/src/FenceTool.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/FenceTool.cpp
@@ -50,7 +50,7 @@ FenceTool::FenceTool(void) :
 FenceTool::~FenceTool(void) 
 {
 	if (m_mapObjectList) {
-		MemoryPoolObject::deleteInstance(m_mapObjectList);
+		deleteInstance(m_mapObjectList);
 	}
 	m_mapObjectList = NULL;
 }
@@ -99,7 +99,7 @@ void FenceTool::updateMapObjectList(Coord3D downPt, Coord3D curPt, WbView* pView
 	pCurObj->setNextMap(NULL);
 	if (pXtraObjects) {
 		p3View->removeFenceListObjects(pXtraObjects);
-		MemoryPoolObject::deleteInstance(pXtraObjects);
+		deleteInstance(pXtraObjects);
 		pXtraObjects = NULL;
 	}
 
@@ -155,7 +155,7 @@ void FenceTool::mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldB
 	m_downPt2d = viewPt;
 	m_downPt3d = cpt;
 	if (m_mapObjectList) {
-		MemoryPoolObject::deleteInstance(m_mapObjectList);
+		deleteInstance(m_mapObjectList);
 		m_mapObjectList = NULL;
 	}
 	if (FenceOptions::hasSelectedObject()) {

--- a/Generals/Code/Tools/WorldBuilder/src/GroveTool.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/GroveTool.cpp
@@ -245,7 +245,7 @@ GroveTool::GroveTool(void) :
 GroveTool::~GroveTool(void) 
 {
 	if (m_headMapObj) {
-		MemoryPoolObject::deleteInstance(m_headMapObj);
+		deleteInstance(m_headMapObj);
 	}
 }
 

--- a/Generals/Code/Tools/WorldBuilder/src/GroveTool.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/GroveTool.cpp
@@ -245,7 +245,7 @@ GroveTool::GroveTool(void) :
 GroveTool::~GroveTool(void) 
 {
 	if (m_headMapObj) {
-		m_headMapObj->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_headMapObj);
 	}
 }
 

--- a/Generals/Code/Tools/WorldBuilder/src/ObjectOptions.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/ObjectOptions.cpp
@@ -65,7 +65,7 @@ ObjectOptions::ObjectOptions(CWnd* pParent /*=NULL*/)
 ObjectOptions::~ObjectOptions(void)
 {
 	if (m_objectsList) {
-		m_objectsList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_objectsList);
 	}
 	m_objectsList = NULL;
 }

--- a/Generals/Code/Tools/WorldBuilder/src/ObjectOptions.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/ObjectOptions.cpp
@@ -65,7 +65,7 @@ ObjectOptions::ObjectOptions(CWnd* pParent /*=NULL*/)
 ObjectOptions::~ObjectOptions(void)
 {
 	if (m_objectsList) {
-		MemoryPoolObject::deleteInstance(m_objectsList);
+		deleteInstance(m_objectsList);
 	}
 	m_objectsList = NULL;
 }

--- a/Generals/Code/Tools/WorldBuilder/src/PickUnitDialog.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/PickUnitDialog.cpp
@@ -95,7 +95,7 @@ PickUnitDialog::PickUnitDialog(UINT id, CWnd* pParent /*=NULL*/)
 PickUnitDialog::~PickUnitDialog()
 {
 	if (m_objectsList) {
-		MemoryPoolObject::deleteInstance(m_objectsList);
+		deleteInstance(m_objectsList);
 	}
 	m_objectsList = NULL;
 }

--- a/Generals/Code/Tools/WorldBuilder/src/PickUnitDialog.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/PickUnitDialog.cpp
@@ -95,7 +95,7 @@ PickUnitDialog::PickUnitDialog(UINT id, CWnd* pParent /*=NULL*/)
 PickUnitDialog::~PickUnitDialog()
 {
 	if (m_objectsList) {
-		m_objectsList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_objectsList);
 	}
 	m_objectsList = NULL;
 }

--- a/Generals/Code/Tools/WorldBuilder/src/ScriptActionsFalse.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/ScriptActionsFalse.cpp
@@ -190,7 +190,7 @@ void ScriptActionsFalse::OnNew()
 		m_index++;
 		loadList();
 	} else {
-		pAct->deleteInstance();
+		MemoryPoolObject::deleteInstance(pAct);
 	}
 }
 

--- a/Generals/Code/Tools/WorldBuilder/src/ScriptActionsFalse.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/ScriptActionsFalse.cpp
@@ -190,7 +190,7 @@ void ScriptActionsFalse::OnNew()
 		m_index++;
 		loadList();
 	} else {
-		MemoryPoolObject::deleteInstance(pAct);
+		deleteInstance(pAct);
 	}
 }
 

--- a/Generals/Code/Tools/WorldBuilder/src/ScriptActionsTrue.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/ScriptActionsTrue.cpp
@@ -190,7 +190,7 @@ void ScriptActionsTrue::OnNew()
 		m_index++;
 		loadList();
 	} else {
-		MemoryPoolObject::deleteInstance(pAct);
+		deleteInstance(pAct);
 	}
 }
 

--- a/Generals/Code/Tools/WorldBuilder/src/ScriptActionsTrue.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/ScriptActionsTrue.cpp
@@ -190,7 +190,7 @@ void ScriptActionsTrue::OnNew()
 		m_index++;
 		loadList();
 	} else {
-		pAct->deleteInstance();
+		MemoryPoolObject::deleteInstance(pAct);
 	}
 }
 

--- a/Generals/Code/Tools/WorldBuilder/src/ScriptConditions.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/ScriptConditions.cpp
@@ -258,7 +258,7 @@ void ScriptConditionsDlg::OnNew()
 		loadList();
 		setSel(pSavOr, pCond);
 	} else {
-		MemoryPoolObject::deleteInstance(pCond);
+		deleteInstance(pCond);
 	}
 }
 

--- a/Generals/Code/Tools/WorldBuilder/src/ScriptConditions.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/ScriptConditions.cpp
@@ -258,7 +258,7 @@ void ScriptConditionsDlg::OnNew()
 		loadList();
 		setSel(pSavOr, pCond);
 	} else {
-		pCond->deleteInstance();
+		MemoryPoolObject::deleteInstance(pCond);
 	}
 }
 

--- a/Generals/Code/Tools/WorldBuilder/src/ScriptDialog.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/ScriptDialog.cpp
@@ -772,7 +772,7 @@ void ScriptDialog::OnNewFolder()
 			savSel.m_objType = ListType::GROUP_TYPE;
 			updateSelection(savSel);
 		} else {
-			pNewGroup->deleteInstance();
+			MemoryPoolObject::deleteInstance(pNewGroup);
 		}
 	}
 	updateIcons(TVI_ROOT);
@@ -813,7 +813,7 @@ void ScriptDialog::OnNewScript()
 	if (IDOK == editDialog.DoModal()) {
 		insertScript(pNewScript);
 	}	else {
-		pNewScript->deleteInstance();
+		MemoryPoolObject::deleteInstance(pNewScript);
 	}
 	updateIcons(TVI_ROOT);
 }		
@@ -912,7 +912,7 @@ void ScriptDialog::OnEditScript()
 		}
 	}
 	updateIcons(TVI_ROOT);
-	pDup->deleteInstance();
+	MemoryPoolObject::deleteInstance(pDup);
 }
 
 void ScriptDialog::OnCopyScript() 
@@ -1341,7 +1341,7 @@ void ScriptDialog::OnSave()
 			DEBUG_CRASH(("threw exception in ScriptDialog::OnSave"));
 	}
 	if (!doAllScripts) {
-		scripts[0]->deleteInstance();
+		MemoryPoolObject::deleteInstance(scripts[0]);
 	}
 	theFile.Close();
 }
@@ -1548,7 +1548,7 @@ Bool ScriptDialog::ParseObjectDataChunk(DataChunkInput &file, DataChunkInfo *inf
 		if (duplicate) break;
 	}
 	if (duplicate) {
-		pThisOne->deleteInstance();
+		MemoryPoolObject::deleteInstance(pThisOne);
 		return true;
 	}
 
@@ -1712,7 +1712,7 @@ Bool ScriptDialog::ParsePolygonTriggersDataChunk(DataChunkInput &file, DataChunk
 			}
 		}
 		if (duplicate ) {
-			pTrig->deleteInstance();
+			MemoryPoolObject::deleteInstance(pTrig);
 		} else {
 			if (pPrevTrig) {
 				pPrevTrig->setNextPoly(pTrig);

--- a/Generals/Code/Tools/WorldBuilder/src/ScriptDialog.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/ScriptDialog.cpp
@@ -772,7 +772,7 @@ void ScriptDialog::OnNewFolder()
 			savSel.m_objType = ListType::GROUP_TYPE;
 			updateSelection(savSel);
 		} else {
-			MemoryPoolObject::deleteInstance(pNewGroup);
+			deleteInstance(pNewGroup);
 		}
 	}
 	updateIcons(TVI_ROOT);
@@ -813,7 +813,7 @@ void ScriptDialog::OnNewScript()
 	if (IDOK == editDialog.DoModal()) {
 		insertScript(pNewScript);
 	}	else {
-		MemoryPoolObject::deleteInstance(pNewScript);
+		deleteInstance(pNewScript);
 	}
 	updateIcons(TVI_ROOT);
 }		
@@ -912,7 +912,7 @@ void ScriptDialog::OnEditScript()
 		}
 	}
 	updateIcons(TVI_ROOT);
-	MemoryPoolObject::deleteInstance(pDup);
+	deleteInstance(pDup);
 }
 
 void ScriptDialog::OnCopyScript() 
@@ -1341,7 +1341,7 @@ void ScriptDialog::OnSave()
 			DEBUG_CRASH(("threw exception in ScriptDialog::OnSave"));
 	}
 	if (!doAllScripts) {
-		MemoryPoolObject::deleteInstance(scripts[0]);
+		deleteInstance(scripts[0]);
 	}
 	theFile.Close();
 }
@@ -1548,7 +1548,7 @@ Bool ScriptDialog::ParseObjectDataChunk(DataChunkInput &file, DataChunkInfo *inf
 		if (duplicate) break;
 	}
 	if (duplicate) {
-		MemoryPoolObject::deleteInstance(pThisOne);
+		deleteInstance(pThisOne);
 		return true;
 	}
 
@@ -1712,7 +1712,7 @@ Bool ScriptDialog::ParsePolygonTriggersDataChunk(DataChunkInput &file, DataChunk
 			}
 		}
 		if (duplicate ) {
-			MemoryPoolObject::deleteInstance(pTrig);
+			deleteInstance(pTrig);
 		} else {
 			if (pPrevTrig) {
 				pPrevTrig->setNextPoly(pTrig);

--- a/Generals/Code/Tools/WorldBuilder/src/WHeightMapEdit.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/WHeightMapEdit.cpp
@@ -2014,7 +2014,7 @@ void WorldHeightMapEdit::removeFirstObject(void)
 	MapObject *firstObj = MapObject::TheMapObjectListPtr;
 	MapObject::TheMapObjectListPtr = firstObj->getNext();
 	firstObj->setNextMap(NULL); // so we don't delete the whole list.
-	MemoryPoolObject::deleteInstance(firstObj);
+	deleteInstance(firstObj);
 }
 
 //=============================================================================

--- a/Generals/Code/Tools/WorldBuilder/src/WHeightMapEdit.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/WHeightMapEdit.cpp
@@ -2014,7 +2014,7 @@ void WorldHeightMapEdit::removeFirstObject(void)
 	MapObject *firstObj = MapObject::TheMapObjectListPtr;
 	MapObject::TheMapObjectListPtr = firstObj->getNext();
 	firstObj->setNextMap(NULL); // so we don't delete the whole list.
-	firstObj->deleteInstance();
+	MemoryPoolObject::deleteInstance(firstObj);
 }
 
 //=============================================================================

--- a/Generals/Code/Tools/WorldBuilder/src/WaterOptions.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/WaterOptions.cpp
@@ -255,7 +255,7 @@ void WaterOptions::OnMakeRiver()
 					for (i=0; i<pNew->getNumPoints(); i++) {
 						theTrigger->addPoint(*pNew->getPoint(i));
 					}
-					MemoryPoolObject::deleteInstance(pNew);
+					deleteInstance(pNew);
 				}
 			}
 		}

--- a/Generals/Code/Tools/WorldBuilder/src/WaterOptions.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/WaterOptions.cpp
@@ -255,7 +255,7 @@ void WaterOptions::OnMakeRiver()
 					for (i=0; i<pNew->getNumPoints(); i++) {
 						theTrigger->addPoint(*pNew->getPoint(i));
 					}
-					pNew->deleteInstance();
+					MemoryPoolObject::deleteInstance(pNew);
 				}
 			}
 		}

--- a/Generals/Code/Tools/WorldBuilder/src/WaterTool.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/WaterTool.cpp
@@ -473,7 +473,7 @@ void WaterTool::fillTheArea(TTrackingMode m, CPoint viewPt, WbView* pView, CWorl
 	
 	if (pNew->getNumPoints()>2) {
 		PolygonTrigger *pBetter = adjustSpacing(pNew, WaterOptions::getSpacing());
-		MemoryPoolObject::deleteInstance(pNew);
+		deleteInstance(pNew);
 		pNew = pBetter;
 		pNew->setWaterArea(true);
 		AddPolygonUndoable *pUndo = new AddPolygonUndoable(pNew);
@@ -483,7 +483,7 @@ void WaterTool::fillTheArea(TTrackingMode m, CPoint viewPt, WbView* pView, CWorl
 		m_poly_dragPointNdx = -1;
 		WaterOptions::update();
 	}	else {
-		MemoryPoolObject::deleteInstance(pNew);
+		deleteInstance(pNew);
 	}
 
 }

--- a/Generals/Code/Tools/WorldBuilder/src/WaterTool.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/WaterTool.cpp
@@ -473,7 +473,7 @@ void WaterTool::fillTheArea(TTrackingMode m, CPoint viewPt, WbView* pView, CWorl
 	
 	if (pNew->getNumPoints()>2) {
 		PolygonTrigger *pBetter = adjustSpacing(pNew, WaterOptions::getSpacing());
-		pNew->deleteInstance();
+		MemoryPoolObject::deleteInstance(pNew);
 		pNew = pBetter;
 		pNew->setWaterArea(true);
 		AddPolygonUndoable *pUndo = new AddPolygonUndoable(pNew);
@@ -483,7 +483,7 @@ void WaterTool::fillTheArea(TTrackingMode m, CPoint viewPt, WbView* pView, CWorl
 		m_poly_dragPointNdx = -1;
 		WaterOptions::update();
 	}	else {
-		pNew->deleteInstance();
+		MemoryPoolObject::deleteInstance(pNew);
 	}
 
 }

--- a/GeneralsMD/Code/GameEngine/Include/Common/GameMemory.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GameMemory.h
@@ -755,13 +755,13 @@ protected:
 	
 public: 
 
-	void deleteInstance() 
+	static void deleteInstance(MemoryPoolObject* mpo) 
 	{	
-		if (this)
+		if (mpo)
 		{
-			MemoryPool *pool = this->getObjectMemoryPool(); // save this, since the dtor will nuke our vtbl
-			this->~MemoryPoolObject();	// it's virtual, so the right one will be called.
-			pool->freeBlock((void *)this); 
+			MemoryPool *pool = mpo->getObjectMemoryPool(); // save this, since the dtor will nuke our vtbl
+			mpo->~MemoryPoolObject();	// it's virtual, so the right one will be called.
+			pool->freeBlock((void *)mpo); 
 		}
 	} 
 };
@@ -903,7 +903,7 @@ public:
 	MemoryPoolObjectHolder(MemoryPoolObject *mpo = NULL) : m_mpo(mpo) { }
 	void hold(MemoryPoolObject *mpo) { DEBUG_ASSERTCRASH(!m_mpo, ("already holding")); m_mpo = mpo; }
 	void release() { m_mpo = NULL; }
-	~MemoryPoolObjectHolder() { m_mpo->deleteInstance(); }
+	~MemoryPoolObjectHolder() { MemoryPoolObject::deleteInstance(m_mpo); }
 };
 
 
@@ -915,7 +915,11 @@ public:
 	you really want by including this macro 
 */
 #define MEMORY_POOL_DELETEINSTANCE_VISIBILITY(ARGVIS)\
-ARGVIS:	void deleteInstance() { MemoryPoolObject::deleteInstance(); } public: 
+ARGVIS: \
+	static void deleteInstance(MemoryPoolObject* object) { \
+		MemoryPoolObject::deleteInstance(object); \
+	} \
+public: 
 
 
 #define EMPTY_DTOR(CLASS) inline CLASS::~CLASS() { }

--- a/GeneralsMD/Code/GameEngine/Include/Common/GameMemory.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GameMemory.h
@@ -912,21 +912,6 @@ public:
 };
 
 
-/**
-	Sometimes you want to make a class's destructor protected so that it can only
-	be destroyed under special circumstances. MemoryPoolObject short-circuits this
-	by making the destructor always be protected, and the true delete technique
-	(namely, deleteInstance) always public by default. You can simulate the behavior
-	you really want by including this macro 
-*/
-#define MEMORY_POOL_DELETEINSTANCE_VISIBILITY(ARGVIS)\
-ARGVIS: \
-	static void deleteInstance(MemoryPoolObject* object) { \
-		MemoryPoolObject::deleteInstance(object); \
-	} \
-public: 
-
-
 #define EMPTY_DTOR(CLASS) inline CLASS::~CLASS() { }
 
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/GameMemory.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GameMemory.h
@@ -766,6 +766,11 @@ public:
 	} 
 };
 
+inline void deleteInstance(MemoryPoolObject* mpo)
+{
+	MemoryPoolObject::deleteInstance(mpo);
+}
+
 
 // INLINING ///////////////////////////////////////////////////////////////////
 
@@ -903,7 +908,7 @@ public:
 	MemoryPoolObjectHolder(MemoryPoolObject *mpo = NULL) : m_mpo(mpo) { }
 	void hold(MemoryPoolObject *mpo) { DEBUG_ASSERTCRASH(!m_mpo, ("already holding")); m_mpo = mpo; }
 	void release() { m_mpo = NULL; }
-	~MemoryPoolObjectHolder() { MemoryPoolObject::deleteInstance(m_mpo); }
+	~MemoryPoolObjectHolder() { deleteInstance(m_mpo); }
 };
 
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/GameMemoryNull.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GameMemoryNull.h
@@ -114,6 +114,11 @@ public:
 	}
 };
 
+inline void deleteInstance(MemoryPoolObject* mpo)
+{
+	MemoryPoolObject::deleteInstance(mpo);
+}
+
 
 /**
 	Initialize the memory manager. Construct a new MemoryPoolFactory and 

--- a/GeneralsMD/Code/GameEngine/Include/Common/GameMemoryNull.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GameMemoryNull.h
@@ -108,9 +108,9 @@ protected:
 
 public:
 
-	void deleteInstance() 
+	static void deleteInstance(MemoryPoolObject* mpo) 
 	{
-		delete this;
+		delete mpo;
 	}
 };
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/Overridable.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Overridable.h
@@ -108,7 +108,7 @@ class Overridable : public MemoryPoolObject
 		{
 			if ( m_isOverride )
 			{
-				deleteInstance();
+				MemoryPoolObject::deleteInstance(this);
 				return NULL;
 			}
 			else if ( m_nextOverride )
@@ -123,7 +123,7 @@ class Overridable : public MemoryPoolObject
 __inline Overridable::~Overridable() 
 {
 	if (m_nextOverride) 
-		m_nextOverride->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_nextOverride);
 }
 
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/Overridable.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Overridable.h
@@ -108,7 +108,7 @@ class Overridable : public MemoryPoolObject
 		{
 			if ( m_isOverride )
 			{
-				MemoryPoolObject::deleteInstance(this);
+				deleteInstance(this);
 				return NULL;
 			}
 			else if ( m_nextOverride )
@@ -123,7 +123,7 @@ class Overridable : public MemoryPoolObject
 __inline Overridable::~Overridable() 
 {
 	if (m_nextOverride) 
-		MemoryPoolObject::deleteInstance(m_nextOverride);
+		deleteInstance(m_nextOverride);
 }
 
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/ThingTemplate.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/ThingTemplate.h
@@ -155,7 +155,7 @@ public:
 	{
 		for (Int i = 0; i < TTAUDIO_COUNT; ++i)
 			if (m_audio[i])
-				m_audio[i]->deleteInstance();
+				MemoryPoolObject::deleteInstance(m_audio[i]);
 	}
 
 	AudioArray(const AudioArray& that)

--- a/GeneralsMD/Code/GameEngine/Include/Common/ThingTemplate.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/ThingTemplate.h
@@ -155,7 +155,7 @@ public:
 	{
 		for (Int i = 0; i < TTAUDIO_COUNT; ++i)
 			if (m_audio[i])
-				MemoryPoolObject::deleteInstance(m_audio[i]);
+				deleteInstance(m_audio[i]);
 	}
 
 	AudioArray(const AudioArray& that)

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
@@ -411,7 +411,7 @@ public:
 	Bool isInList(Object **pListHead) const;
 
 	// this is intended for use ONLY by GameLogic.
-	static void friend_deleteInstance(MemoryPoolObject* object) { MemoryPoolObject::deleteInstance(object); }
+	static void friend_deleteInstance(Object* object) { deleteInstance(object); }
 
 	/// cache the partition module (should be called only by PartitionData)
 	void friend_setPartitionData(PartitionData *pd) { m_partitionData = pd; }

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
@@ -411,7 +411,7 @@ public:
 	Bool isInList(Object **pListHead) const;
 
 	// this is intended for use ONLY by GameLogic.
-	void friend_deleteInstance() { deleteInstance(); }
+	static void friend_deleteInstance(MemoryPoolObject* object) { MemoryPoolObject::deleteInstance(object); }
 
 	/// cache the partition module (should be called only by PartitionData)
 	void friend_setPartitionData(PartitionData *pd) { m_partitionData = pd; }

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
@@ -164,8 +164,6 @@ class Object : public Thing, public Snapshot
 {
 
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(Object, "ObjectPool" )		
-	/// destructor is non-public in order to require the use of TheGameLogic->destroyObject()
-	MEMORY_POOL_DELETEINSTANCE_VISIBILITY(protected)
 
 public:
 
@@ -810,6 +808,9 @@ private:
 	Bool													m_isReceivingDifficultyBonus;
 
 };  // end class Object
+
+// deleteInstance is not meant to be used with Object in order to require the use of TheGameLogic->destroyObject()
+void deleteInstance(Object* object) CPP_11(= delete);
 
 // describe an object as an AsciiString: e.g. "Object 102 (KillerBuggy) [GLARocketBuggy, owned by player 2 (GLAIntroPlayer)]"
 AsciiString DebugDescribeObject(const Object *obj);

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/ObjectIter.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/ObjectIter.h
@@ -67,7 +67,7 @@ enum IterOrderType CPP_11(: Int)
 	{
 		// do something with other
 	}
-	iter->deleteInstance();								// you own it, so you must delete it
+	MemoryPoolObject::deleteInstance(iter);								// you own it, so you must delete it
 
 	note that the iterator is required to deal intelligently with deleted objects; 
 	in particular, next() will check if an obj has been killed and simply skip it.

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/ObjectIter.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/ObjectIter.h
@@ -67,7 +67,7 @@ enum IterOrderType CPP_11(: Int)
 	{
 		// do something with other
 	}
-	MemoryPoolObject::deleteInstance(iter);								// you own it, so you must delete it
+	deleteInstance(iter);								// you own it, so you must delete it
 
 	note that the iterator is required to deal intelligently with deleted objects; 
 	in particular, next() will check if an obj has been killed and simply skip it.

--- a/GeneralsMD/Code/GameEngine/Source/Common/Audio/GameAudio.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Audio/GameAudio.cpp
@@ -188,7 +188,7 @@ AudioManager::~AudioManager()
 	for (it = m_allAudioEventInfo.begin(); it != m_allAudioEventInfo.end(); ++it) {
 		AudioEventInfo *eventInfo = (*it).second;
 		if (eventInfo) {
-			eventInfo->deleteInstance();
+			MemoryPoolObject::deleteInstance(eventInfo);
 			eventInfo = NULL;
 		}
 	}
@@ -811,7 +811,7 @@ AudioRequest *AudioManager::allocateAudioRequest( Bool useAudioEvent )
 void AudioManager::releaseAudioRequest( AudioRequest *requestToRelease )
 {
 	if (requestToRelease) {
-		requestToRelease->deleteInstance();
+		MemoryPoolObject::deleteInstance(requestToRelease);
 	}
 }
 
@@ -894,7 +894,7 @@ void AudioManager::removeLevelSpecificAudioEventInfos(void)
 
     if ( it->second->isLevelSpecific() )
     {
-      it->second->deleteInstance();
+      MemoryPoolObject::deleteInstance(it->second);
       m_allAudioEventInfo.erase( it );
     }
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/Audio/GameAudio.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Audio/GameAudio.cpp
@@ -188,7 +188,7 @@ AudioManager::~AudioManager()
 	for (it = m_allAudioEventInfo.begin(); it != m_allAudioEventInfo.end(); ++it) {
 		AudioEventInfo *eventInfo = (*it).second;
 		if (eventInfo) {
-			MemoryPoolObject::deleteInstance(eventInfo);
+			deleteInstance(eventInfo);
 			eventInfo = NULL;
 		}
 	}
@@ -811,7 +811,7 @@ AudioRequest *AudioManager::allocateAudioRequest( Bool useAudioEvent )
 void AudioManager::releaseAudioRequest( AudioRequest *requestToRelease )
 {
 	if (requestToRelease) {
-		MemoryPoolObject::deleteInstance(requestToRelease);
+		deleteInstance(requestToRelease);
 	}
 }
 
@@ -894,7 +894,7 @@ void AudioManager::removeLevelSpecificAudioEventInfos(void)
 
     if ( it->second->isLevelSpecific() )
     {
-      MemoryPoolObject::deleteInstance(it->second);
+      deleteInstance(it->second);
       m_allAudioEventInfo.erase( it );
     }
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -709,7 +709,7 @@ void GameEngine::reset( void )
 	if(background)
 	{
 		background->destroyWindows();
-		MemoryPoolObject::deleteInstance(background);
+		deleteInstance(background);
 		background = NULL;
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -709,7 +709,7 @@ void GameEngine::reset( void )
 	if(background)
 	{
 		background->destroyWindows();
-		background->deleteInstance();
+		MemoryPoolObject::deleteInstance(background);
 		background = NULL;
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -1099,7 +1099,7 @@ GlobalData::~GlobalData( void )
 	DEBUG_ASSERTCRASH( TheWritableGlobalData->m_next == NULL, ("~GlobalData: theOriginal is not original\n") );
 
 	if (m_weaponBonusSet)
-		m_weaponBonusSet->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_weaponBonusSet);
 
 	if( m_theOriginal == this )	{
 		m_theOriginal = NULL;

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -1099,7 +1099,7 @@ GlobalData::~GlobalData( void )
 	DEBUG_ASSERTCRASH( TheWritableGlobalData->m_next == NULL, ("~GlobalData: theOriginal is not original\n") );
 
 	if (m_weaponBonusSet)
-		MemoryPoolObject::deleteInstance(m_weaponBonusSet);
+		deleteInstance(m_weaponBonusSet);
 
 	if( m_theOriginal == this )	{
 		m_theOriginal = NULL;

--- a/GeneralsMD/Code/GameEngine/Source/Common/INI/INI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/INI/INI.cpp
@@ -1150,7 +1150,7 @@ void INI::parseDynamicAudioEventRTS( INI *ini, void * /*instance*/, void *store,
 	{
 		if (*theSound)
 		{
-			(*theSound)->deleteInstance();
+			MemoryPoolObject::deleteInstance((*theSound));
 			*theSound = NULL;
 		}
 	}

--- a/GeneralsMD/Code/GameEngine/Source/Common/INI/INI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/INI/INI.cpp
@@ -1150,7 +1150,7 @@ void INI::parseDynamicAudioEventRTS( INI *ini, void * /*instance*/, void *store,
 	{
 		if (*theSound)
 		{
-			MemoryPoolObject::deleteInstance((*theSound));
+			deleteInstance(*theSound);
 			*theSound = NULL;
 		}
 	}

--- a/GeneralsMD/Code/GameEngine/Source/Common/MessageStream.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/MessageStream.cpp
@@ -79,7 +79,7 @@ GameMessage::~GameMessage( )
 	for( arg = m_argList; arg; arg=nextArg )
 	{
 		nextArg = arg->m_next;
-		arg->deleteInstance();
+		MemoryPoolObject::deleteInstance(arg);
 	}
 
 	// detach message from list
@@ -711,7 +711,7 @@ GameMessageList::~GameMessageList()
 		// set list ptr to null to avoid it trying to remove itself from the list
 		// that we are in the process of nuking...
 		msg->friend_setList(NULL);
-		msg->deleteInstance();
+		MemoryPoolObject::deleteInstance(msg);
 	}
 }
 
@@ -1096,7 +1096,7 @@ void MessageStream::propagateMessages( void )
 				next = msg->next();
 				if (disp == DESTROY_MESSAGE)
 				{
-					msg->deleteInstance();
+					MemoryPoolObject::deleteInstance(msg);
 				}
 			} 
 			else 
@@ -1183,7 +1183,7 @@ void CommandList::destroyAllMessages( void )
 	for( msg=m_firstMessage; msg; msg=next )
 	{
 		next = msg->next();
-		msg->deleteInstance();
+		MemoryPoolObject::deleteInstance(msg);
 	}
 	
 	m_firstMessage = NULL;

--- a/GeneralsMD/Code/GameEngine/Source/Common/MessageStream.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/MessageStream.cpp
@@ -79,7 +79,7 @@ GameMessage::~GameMessage( )
 	for( arg = m_argList; arg; arg=nextArg )
 	{
 		nextArg = arg->m_next;
-		MemoryPoolObject::deleteInstance(arg);
+		deleteInstance(arg);
 	}
 
 	// detach message from list
@@ -711,7 +711,7 @@ GameMessageList::~GameMessageList()
 		// set list ptr to null to avoid it trying to remove itself from the list
 		// that we are in the process of nuking...
 		msg->friend_setList(NULL);
-		MemoryPoolObject::deleteInstance(msg);
+		deleteInstance(msg);
 	}
 }
 
@@ -1096,7 +1096,7 @@ void MessageStream::propagateMessages( void )
 				next = msg->next();
 				if (disp == DESTROY_MESSAGE)
 				{
-					MemoryPoolObject::deleteInstance(msg);
+					deleteInstance(msg);
 				}
 			} 
 			else 
@@ -1183,7 +1183,7 @@ void CommandList::destroyAllMessages( void )
 	for( msg=m_firstMessage; msg; msg=next )
 	{
 		next = msg->next();
-		MemoryPoolObject::deleteInstance(msg);
+		deleteInstance(msg);
 	}
 	
 	m_firstMessage = NULL;

--- a/GeneralsMD/Code/GameEngine/Source/Common/NameKeyGenerator.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/NameKeyGenerator.cpp
@@ -81,7 +81,7 @@ void NameKeyGenerator::freeSockets()
 		for (Bucket *b = m_sockets[i]; b; b = next)
 		{
 			next = b->m_nextInSocket;
-			b->deleteInstance();
+			MemoryPoolObject::deleteInstance(b);
 		}
 		m_sockets[i] = NULL;
 	}

--- a/GeneralsMD/Code/GameEngine/Source/Common/NameKeyGenerator.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/NameKeyGenerator.cpp
@@ -81,7 +81,7 @@ void NameKeyGenerator::freeSockets()
 		for (Bucket *b = m_sockets[i]; b; b = next)
 		{
 			next = b->m_nextInSocket;
-			MemoryPoolObject::deleteInstance(b);
+			deleteInstance(b);
 		}
 		m_sockets[i] = NULL;
 	}

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -376,7 +376,7 @@ void Player::init(const PlayerTemplate* pt)
 	m_searchAndDestroyBattlePlans = 0;
 	if( m_battlePlanBonuses )
 	{
-		m_battlePlanBonuses->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_battlePlanBonuses);
 		m_battlePlanBonuses = NULL;
 	}
 
@@ -386,40 +386,40 @@ void Player::init(const PlayerTemplate* pt)
 	m_stats.init();
 	if (m_pBuildList != NULL) 
 	{
-		m_pBuildList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_pBuildList);
 		m_pBuildList = NULL;
 	}
 	m_defaultTeam = NULL;
 
 	if (m_ai)
 	{
-		m_ai->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_ai);
 	}
 	m_ai = NULL;
 
 	if( m_resourceGatheringManager )
 	{
-		m_resourceGatheringManager->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_resourceGatheringManager);
 		m_resourceGatheringManager = NULL;
 	}
 
 	for (Int i = 0; i < NUM_HOTKEY_SQUADS; ++i) {
 		if (m_squads[i] != NULL) {
-			m_squads[i]->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_squads[i]);
 			m_squads[i] = NULL;
 		}
 		m_squads[i] = newInstance(Squad);	
 	}
 
 	if (m_currentSelection != NULL) {
-		m_currentSelection->deleteInstance() ;
+		MemoryPoolObject::deleteInstance(m_currentSelection) ;
 		m_currentSelection = NULL;
 	}
 	m_currentSelection = newInstance(Squad);
 	
 	if( m_tunnelSystem )
 	{
-		m_tunnelSystem->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_tunnelSystem);
 		m_tunnelSystem = NULL;
 	}
 	
@@ -513,7 +513,7 @@ void Player::init(const PlayerTemplate* pt)
 		KindOfPercentProductionChange *tof = *it;
 		it = m_kindOfPercentProductionChangeList.erase( it );
 		if(tof)
-			tof->deleteInstance();
+			MemoryPoolObject::deleteInstance(tof);
 	}
 
 	getAcademyStats()->init( this );
@@ -537,24 +537,24 @@ Player::~Player()
 	m_playerTeamPrototypes.clear();	// empty, but don't free the contents
 
 	// delete the relation maps (the destructor clears the actual map if any data is present)
-	m_teamRelations->deleteInstance();
-	m_playerRelations->deleteInstance();
+	MemoryPoolObject::deleteInstance(m_teamRelations);
+	MemoryPoolObject::deleteInstance(m_playerRelations);
 
 	for (Int i = 0; i < NUM_HOTKEY_SQUADS; ++i) {
 		if (m_squads[i] != NULL) {
-			m_squads[i]->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_squads[i]);
 			m_squads[i] = NULL;
 		}
 	}
 
 	if (m_currentSelection != NULL) {
-		m_currentSelection->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_currentSelection);
 		m_currentSelection = NULL;
 	}
 
 	if( m_battlePlanBonuses )
 	{
-		m_battlePlanBonuses->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_battlePlanBonuses);
 		m_battlePlanBonuses = NULL;
 	}
 }
@@ -665,7 +665,7 @@ void Player::setBuildList(BuildListInfo *pBuildList)
 
 	if (m_pBuildList != NULL) 
 	{
-		m_pBuildList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_pBuildList);
 	}
 	m_pBuildList = pBuildList;
 
@@ -761,7 +761,7 @@ void Player::setPlayerType(PlayerType t, Bool skirmish)
 
 	if (m_ai)
 	{
-		m_ai->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_ai);
 	}
 	m_ai = NULL;
 
@@ -797,7 +797,7 @@ void Player::deletePlayerAI()
 {
 	if (m_ai)
 	{
-		m_ai->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_ai);
 		m_ai = NULL;
 	}
 }
@@ -874,10 +874,10 @@ void Player::initFromDict(const Dict* d)
 				ScriptList *scripts = TheSidesList->getSkirmishSideInfo(i)->getScriptList()->duplicateAndQualify(
 							qualifier, qualTemplatePlayerName, pname);
 				if (TheSidesList->getSideInfo(getPlayerIndex())->getScriptList()) {
-					TheSidesList->getSideInfo(getPlayerIndex())->getScriptList()->deleteInstance();
+					MemoryPoolObject::deleteInstance(TheSidesList->getSideInfo(getPlayerIndex())->getScriptList());
 				}
 				TheSidesList->getSideInfo(getPlayerIndex())->setScriptList(scripts);
-				TheSidesList->getSkirmishSideInfo(i)->getScriptList()->deleteInstance();
+				MemoryPoolObject::deleteInstance(TheSidesList->getSkirmishSideInfo(i)->getScriptList());
 				TheSidesList->getSkirmishSideInfo(i)->setScriptList(NULL);
 			}
 
@@ -928,7 +928,7 @@ void Player::initFromDict(const Dict* d)
 			ScriptList* slist = TheSidesList->getSideInfo(getPlayerIndex())->getScriptList();
 			if (slist) 
 			{
-				slist->deleteInstance();
+				MemoryPoolObject::deleteInstance(slist);
 			}
 			TheSidesList->getSideInfo(getPlayerIndex())->setScriptList(scripts);
 			for (i=0; i<TheSidesList->getNumTeams(); i++) {
@@ -999,14 +999,14 @@ void Player::initFromDict(const Dict* d)
 	}																																 
 	if( m_resourceGatheringManager )
 	{
-		m_resourceGatheringManager->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_resourceGatheringManager);
 		m_resourceGatheringManager = NULL;
 	}
 	m_resourceGatheringManager = newInstance(ResourceGatheringManager);
 
 	if( m_tunnelSystem )
 	{
-		m_tunnelSystem->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_tunnelSystem);
 		m_tunnelSystem = NULL;
 	}
 	m_tunnelSystem = newInstance(TunnelTracker);
@@ -1043,14 +1043,14 @@ void Player::initFromDict(const Dict* d)
 	for ( i = 0; i < NUM_HOTKEY_SQUADS; ++i ) {
 		if (m_squads[i] != NULL)
 		{
-			m_squads[i]->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_squads[i]);
 			m_squads[i] = NULL;
 		}
 		m_squads[i] = newInstance( Squad );
 	}
 
 	if (m_currentSelection != NULL) {
-		m_currentSelection->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_currentSelection);
 		m_currentSelection = NULL;
 	}
 	m_currentSelection = newInstance( Squad );
@@ -1170,7 +1170,7 @@ void Player::becomingLocalPlayer(Bool yes)
 					}
 				}
 			}
-			iter->deleteInstance();
+			MemoryPoolObject::deleteInstance(iter);
 		}
 
 		if( TheControlBar )
@@ -2982,7 +2982,7 @@ void Player::deleteUpgradeList( void )
 	{
 
 		next = m_upgradeList->friend_getNext();
-		m_upgradeList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_upgradeList);
 		m_upgradeList = next;
 
 	}  // end while
@@ -3621,7 +3621,7 @@ void Player::removeBattlePlanBonusesForObject( Object *obj ) const
 	DUMPBATTLEPLANBONUSES(bonus, this, obj);
 	localApplyBattlePlanBonusesToObject( obj, bonus );
 
-	bonus->deleteInstance();
+	MemoryPoolObject::deleteInstance(bonus);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -3866,7 +3866,7 @@ void Player::removeKindOfProductionCostChange(	KindOfMaskType kindOf, Real perce
 			{
 				m_kindOfPercentProductionChangeList.erase( it );
 				if(tof)
-					tof->deleteInstance();
+					MemoryPoolObject::deleteInstance(tof);
 			}
 			return;
 		}
@@ -4180,7 +4180,7 @@ void Player::xfer( Xfer *xfer )
 		// the head of these structures automatically deletes any links attached
 		//
 		if( m_pBuildList)
-			m_pBuildList->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_pBuildList);
 		m_pBuildList = NULL;
 
 		// read each build list info
@@ -4521,7 +4521,7 @@ void Player::xfer( Xfer *xfer )
 	{
 		if (m_battlePlanBonuses)
 		{
-			m_battlePlanBonuses->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_battlePlanBonuses);
 			m_battlePlanBonuses = NULL;
 		}
 		if ( battlePlanBonus )

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -376,7 +376,7 @@ void Player::init(const PlayerTemplate* pt)
 	m_searchAndDestroyBattlePlans = 0;
 	if( m_battlePlanBonuses )
 	{
-		MemoryPoolObject::deleteInstance(m_battlePlanBonuses);
+		deleteInstance(m_battlePlanBonuses);
 		m_battlePlanBonuses = NULL;
 	}
 
@@ -386,40 +386,40 @@ void Player::init(const PlayerTemplate* pt)
 	m_stats.init();
 	if (m_pBuildList != NULL) 
 	{
-		MemoryPoolObject::deleteInstance(m_pBuildList);
+		deleteInstance(m_pBuildList);
 		m_pBuildList = NULL;
 	}
 	m_defaultTeam = NULL;
 
 	if (m_ai)
 	{
-		MemoryPoolObject::deleteInstance(m_ai);
+		deleteInstance(m_ai);
 	}
 	m_ai = NULL;
 
 	if( m_resourceGatheringManager )
 	{
-		MemoryPoolObject::deleteInstance(m_resourceGatheringManager);
+		deleteInstance(m_resourceGatheringManager);
 		m_resourceGatheringManager = NULL;
 	}
 
 	for (Int i = 0; i < NUM_HOTKEY_SQUADS; ++i) {
 		if (m_squads[i] != NULL) {
-			MemoryPoolObject::deleteInstance(m_squads[i]);
+			deleteInstance(m_squads[i]);
 			m_squads[i] = NULL;
 		}
 		m_squads[i] = newInstance(Squad);	
 	}
 
 	if (m_currentSelection != NULL) {
-		MemoryPoolObject::deleteInstance(m_currentSelection) ;
+		deleteInstance(m_currentSelection) ;
 		m_currentSelection = NULL;
 	}
 	m_currentSelection = newInstance(Squad);
 	
 	if( m_tunnelSystem )
 	{
-		MemoryPoolObject::deleteInstance(m_tunnelSystem);
+		deleteInstance(m_tunnelSystem);
 		m_tunnelSystem = NULL;
 	}
 	
@@ -513,7 +513,7 @@ void Player::init(const PlayerTemplate* pt)
 		KindOfPercentProductionChange *tof = *it;
 		it = m_kindOfPercentProductionChangeList.erase( it );
 		if(tof)
-			MemoryPoolObject::deleteInstance(tof);
+			deleteInstance(tof);
 	}
 
 	getAcademyStats()->init( this );
@@ -537,24 +537,24 @@ Player::~Player()
 	m_playerTeamPrototypes.clear();	// empty, but don't free the contents
 
 	// delete the relation maps (the destructor clears the actual map if any data is present)
-	MemoryPoolObject::deleteInstance(m_teamRelations);
-	MemoryPoolObject::deleteInstance(m_playerRelations);
+	deleteInstance(m_teamRelations);
+	deleteInstance(m_playerRelations);
 
 	for (Int i = 0; i < NUM_HOTKEY_SQUADS; ++i) {
 		if (m_squads[i] != NULL) {
-			MemoryPoolObject::deleteInstance(m_squads[i]);
+			deleteInstance(m_squads[i]);
 			m_squads[i] = NULL;
 		}
 	}
 
 	if (m_currentSelection != NULL) {
-		MemoryPoolObject::deleteInstance(m_currentSelection);
+		deleteInstance(m_currentSelection);
 		m_currentSelection = NULL;
 	}
 
 	if( m_battlePlanBonuses )
 	{
-		MemoryPoolObject::deleteInstance(m_battlePlanBonuses);
+		deleteInstance(m_battlePlanBonuses);
 		m_battlePlanBonuses = NULL;
 	}
 }
@@ -665,7 +665,7 @@ void Player::setBuildList(BuildListInfo *pBuildList)
 
 	if (m_pBuildList != NULL) 
 	{
-		MemoryPoolObject::deleteInstance(m_pBuildList);
+		deleteInstance(m_pBuildList);
 	}
 	m_pBuildList = pBuildList;
 
@@ -761,7 +761,7 @@ void Player::setPlayerType(PlayerType t, Bool skirmish)
 
 	if (m_ai)
 	{
-		MemoryPoolObject::deleteInstance(m_ai);
+		deleteInstance(m_ai);
 	}
 	m_ai = NULL;
 
@@ -797,7 +797,7 @@ void Player::deletePlayerAI()
 {
 	if (m_ai)
 	{
-		MemoryPoolObject::deleteInstance(m_ai);
+		deleteInstance(m_ai);
 		m_ai = NULL;
 	}
 }
@@ -874,10 +874,10 @@ void Player::initFromDict(const Dict* d)
 				ScriptList *scripts = TheSidesList->getSkirmishSideInfo(i)->getScriptList()->duplicateAndQualify(
 							qualifier, qualTemplatePlayerName, pname);
 				if (TheSidesList->getSideInfo(getPlayerIndex())->getScriptList()) {
-					MemoryPoolObject::deleteInstance(TheSidesList->getSideInfo(getPlayerIndex())->getScriptList());
+					deleteInstance(TheSidesList->getSideInfo(getPlayerIndex())->getScriptList());
 				}
 				TheSidesList->getSideInfo(getPlayerIndex())->setScriptList(scripts);
-				MemoryPoolObject::deleteInstance(TheSidesList->getSkirmishSideInfo(i)->getScriptList());
+				deleteInstance(TheSidesList->getSkirmishSideInfo(i)->getScriptList());
 				TheSidesList->getSkirmishSideInfo(i)->setScriptList(NULL);
 			}
 
@@ -928,7 +928,7 @@ void Player::initFromDict(const Dict* d)
 			ScriptList* slist = TheSidesList->getSideInfo(getPlayerIndex())->getScriptList();
 			if (slist) 
 			{
-				MemoryPoolObject::deleteInstance(slist);
+				deleteInstance(slist);
 			}
 			TheSidesList->getSideInfo(getPlayerIndex())->setScriptList(scripts);
 			for (i=0; i<TheSidesList->getNumTeams(); i++) {
@@ -999,14 +999,14 @@ void Player::initFromDict(const Dict* d)
 	}																																 
 	if( m_resourceGatheringManager )
 	{
-		MemoryPoolObject::deleteInstance(m_resourceGatheringManager);
+		deleteInstance(m_resourceGatheringManager);
 		m_resourceGatheringManager = NULL;
 	}
 	m_resourceGatheringManager = newInstance(ResourceGatheringManager);
 
 	if( m_tunnelSystem )
 	{
-		MemoryPoolObject::deleteInstance(m_tunnelSystem);
+		deleteInstance(m_tunnelSystem);
 		m_tunnelSystem = NULL;
 	}
 	m_tunnelSystem = newInstance(TunnelTracker);
@@ -1043,14 +1043,14 @@ void Player::initFromDict(const Dict* d)
 	for ( i = 0; i < NUM_HOTKEY_SQUADS; ++i ) {
 		if (m_squads[i] != NULL)
 		{
-			MemoryPoolObject::deleteInstance(m_squads[i]);
+			deleteInstance(m_squads[i]);
 			m_squads[i] = NULL;
 		}
 		m_squads[i] = newInstance( Squad );
 	}
 
 	if (m_currentSelection != NULL) {
-		MemoryPoolObject::deleteInstance(m_currentSelection);
+		deleteInstance(m_currentSelection);
 		m_currentSelection = NULL;
 	}
 	m_currentSelection = newInstance( Squad );
@@ -1170,7 +1170,7 @@ void Player::becomingLocalPlayer(Bool yes)
 					}
 				}
 			}
-			MemoryPoolObject::deleteInstance(iter);
+			deleteInstance(iter);
 		}
 
 		if( TheControlBar )
@@ -2982,7 +2982,7 @@ void Player::deleteUpgradeList( void )
 	{
 
 		next = m_upgradeList->friend_getNext();
-		MemoryPoolObject::deleteInstance(m_upgradeList);
+		deleteInstance(m_upgradeList);
 		m_upgradeList = next;
 
 	}  // end while
@@ -3621,7 +3621,7 @@ void Player::removeBattlePlanBonusesForObject( Object *obj ) const
 	DUMPBATTLEPLANBONUSES(bonus, this, obj);
 	localApplyBattlePlanBonusesToObject( obj, bonus );
 
-	MemoryPoolObject::deleteInstance(bonus);
+	deleteInstance(bonus);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -3866,7 +3866,7 @@ void Player::removeKindOfProductionCostChange(	KindOfMaskType kindOf, Real perce
 			{
 				m_kindOfPercentProductionChangeList.erase( it );
 				if(tof)
-					MemoryPoolObject::deleteInstance(tof);
+					deleteInstance(tof);
 			}
 			return;
 		}
@@ -4180,7 +4180,7 @@ void Player::xfer( Xfer *xfer )
 		// the head of these structures automatically deletes any links attached
 		//
 		if( m_pBuildList)
-			MemoryPoolObject::deleteInstance(m_pBuildList);
+			deleteInstance(m_pBuildList);
 		m_pBuildList = NULL;
 
 		// read each build list info
@@ -4521,7 +4521,7 @@ void Player::xfer( Xfer *xfer )
 	{
 		if (m_battlePlanBonuses)
 		{
-			MemoryPoolObject::deleteInstance(m_battlePlanBonuses);
+			deleteInstance(m_battlePlanBonuses);
 			m_battlePlanBonuses = NULL;
 		}
 		if ( battlePlanBonus )

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Science.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Science.cpp
@@ -60,7 +60,7 @@ ScienceStore::~ScienceStore()
 		ScienceInfo* si = *it;
 		++it;
 		if (si) {
-			si->deleteInstance();
+			MemoryPoolObject::deleteInstance(si);
 		}
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Science.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Science.cpp
@@ -60,7 +60,7 @@ ScienceStore::~ScienceStore()
 		ScienceInfo* si = *it;
 		++it;
 		if (si) {
-			MemoryPoolObject::deleteInstance(si);
+			deleteInstance(si);
 		}
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/SpecialPower.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/SpecialPower.cpp
@@ -256,7 +256,7 @@ SpecialPowerStore::~SpecialPowerStore( void )
 
 	// delete all templates
 	for( Int i = 0; i < m_specialPowerTemplates.size(); ++i )
-		m_specialPowerTemplates[ i ]->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_specialPowerTemplates[ i ]);
 
 	// erase the list
 	m_specialPowerTemplates.clear();

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/SpecialPower.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/SpecialPower.cpp
@@ -256,7 +256,7 @@ SpecialPowerStore::~SpecialPowerStore( void )
 
 	// delete all templates
 	for( Int i = 0; i < m_specialPowerTemplates.size(); ++i )
-		MemoryPoolObject::deleteInstance(m_specialPowerTemplates[ i ]);
+		deleteInstance(m_specialPowerTemplates[ i ]);
 
 	// erase the list
 	m_specialPowerTemplates.clear();

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Team.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Team.cpp
@@ -214,7 +214,7 @@ void TeamFactory::clear()
 	m_prototypes.clear();
 	for (TeamPrototypeMap::iterator it = tmp.begin(); it != tmp.end(); ++it)
 	{
-		it->second->deleteInstance();
+		MemoryPoolObject::deleteInstance(it->second);
 	}
 }
 
@@ -836,7 +836,7 @@ TeamPrototype::TeamPrototype( TeamFactory *tf,
 		if (o)
 		{
 			TheTeamFactory->teamAboutToBeDeleted(o);
-			o->deleteInstance();
+			MemoryPoolObject::deleteInstance(o);
 		}
 	}
 
@@ -852,7 +852,7 @@ TeamPrototype::~TeamPrototype()
 
 	if (m_productionConditionScript) 
 	{
-		m_productionConditionScript->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_productionConditionScript);
 	}
 	m_productionConditionScript = NULL;
 
@@ -860,7 +860,7 @@ TeamPrototype::~TeamPrototype()
 	{
 		if (m_genericScriptsToRun[i]) 
 		{
-			m_genericScriptsToRun[i]->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_genericScriptsToRun[i]);
 			m_genericScriptsToRun[i] = NULL;
 		}
 	}
@@ -1086,7 +1086,7 @@ void TeamPrototype::updateState(void)
 
 				// So remove it
 				TheTeamFactory->teamAboutToBeDeleted(iter.cur());
-				iter.cur()->deleteInstance();
+				MemoryPoolObject::deleteInstance(iter.cur());
 
 				done = false;
 				break; // Not sure what state the iterator is in after deleting a member of the list. jba
@@ -1385,8 +1385,8 @@ Team::~Team()
 		m_proto->removeFrom_TeamInstanceList(this);
 
 	// delete the relation maps (the destructor clears the actual map if any data is present)
-	m_teamRelations->deleteInstance();
-	m_playerRelations->deleteInstance();
+	MemoryPoolObject::deleteInstance(m_teamRelations);
+	MemoryPoolObject::deleteInstance(m_playerRelations);
 
 	// make sure the xfer list is clear
 	m_xferMemberIDList.clear();

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Team.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Team.cpp
@@ -214,7 +214,7 @@ void TeamFactory::clear()
 	m_prototypes.clear();
 	for (TeamPrototypeMap::iterator it = tmp.begin(); it != tmp.end(); ++it)
 	{
-		MemoryPoolObject::deleteInstance(it->second);
+		deleteInstance(it->second);
 	}
 }
 
@@ -836,7 +836,7 @@ TeamPrototype::TeamPrototype( TeamFactory *tf,
 		if (o)
 		{
 			TheTeamFactory->teamAboutToBeDeleted(o);
-			MemoryPoolObject::deleteInstance(o);
+			deleteInstance(o);
 		}
 	}
 
@@ -852,7 +852,7 @@ TeamPrototype::~TeamPrototype()
 
 	if (m_productionConditionScript) 
 	{
-		MemoryPoolObject::deleteInstance(m_productionConditionScript);
+		deleteInstance(m_productionConditionScript);
 	}
 	m_productionConditionScript = NULL;
 
@@ -860,7 +860,7 @@ TeamPrototype::~TeamPrototype()
 	{
 		if (m_genericScriptsToRun[i]) 
 		{
-			MemoryPoolObject::deleteInstance(m_genericScriptsToRun[i]);
+			deleteInstance(m_genericScriptsToRun[i]);
 			m_genericScriptsToRun[i] = NULL;
 		}
 	}
@@ -1086,7 +1086,7 @@ void TeamPrototype::updateState(void)
 
 				// So remove it
 				TheTeamFactory->teamAboutToBeDeleted(iter.cur());
-				MemoryPoolObject::deleteInstance(iter.cur());
+				deleteInstance(iter.cur());
 
 				done = false;
 				break; // Not sure what state the iterator is in after deleting a member of the list. jba
@@ -1385,8 +1385,8 @@ Team::~Team()
 		m_proto->removeFrom_TeamInstanceList(this);
 
 	// delete the relation maps (the destructor clears the actual map if any data is present)
-	MemoryPoolObject::deleteInstance(m_teamRelations);
-	MemoryPoolObject::deleteInstance(m_playerRelations);
+	deleteInstance(m_teamRelations);
+	deleteInstance(m_playerRelations);
 
 	// make sure the xfer list is clear
 	m_xferMemberIDList.clear();

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -779,7 +779,7 @@ void RecorderClass::writeToFile(GameMessage * msg) {
 		writeArgument(msg->getArgumentDataType(i), *(msg->getArgument(i)));
 	}
 
-	MemoryPoolObject::deleteInstance(parser);
+	deleteInstance(parser);
 	parser = NULL;
 
 	fflush(m_file); ///< @todo should this be in the final release?
@@ -1369,17 +1369,17 @@ void RecorderClass::appendNextCommand() {
 
 	if (type == GameMessage::MSG_CLEAR_GAME_DATA || type == GameMessage::MSG_BEGIN_NETWORK_MESSAGES)
 	{
-		MemoryPoolObject::deleteInstance(msg);
+		deleteInstance(msg);
 		msg = NULL;
 	}
 
 	if (m_doingAnalysis)
 	{
-		MemoryPoolObject::deleteInstance(msg);
+		deleteInstance(msg);
 		msg = NULL;
 	}
 
-	MemoryPoolObject::deleteInstance(parser);
+	deleteInstance(parser);
 	parser = NULL;
 }
 
@@ -1514,7 +1514,7 @@ void RecorderClass::cullBadCommands() {
 				(msg->getType() < GameMessage::MSG_END_NETWORK_MESSAGES) &&
 				(msg->getType() != GameMessage::MSG_LOGIC_CRC)) {
 
-			MemoryPoolObject::deleteInstance(msg);
+			deleteInstance(msg);
 		}
 
 		msg = next;

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -779,7 +779,7 @@ void RecorderClass::writeToFile(GameMessage * msg) {
 		writeArgument(msg->getArgumentDataType(i), *(msg->getArgument(i)));
 	}
 
-	parser->deleteInstance();
+	MemoryPoolObject::deleteInstance(parser);
 	parser = NULL;
 
 	fflush(m_file); ///< @todo should this be in the final release?
@@ -1369,17 +1369,17 @@ void RecorderClass::appendNextCommand() {
 
 	if (type == GameMessage::MSG_CLEAR_GAME_DATA || type == GameMessage::MSG_BEGIN_NETWORK_MESSAGES)
 	{
-		msg->deleteInstance();
+		MemoryPoolObject::deleteInstance(msg);
 		msg = NULL;
 	}
 
 	if (m_doingAnalysis)
 	{
-		msg->deleteInstance();
+		MemoryPoolObject::deleteInstance(msg);
 		msg = NULL;
 	}
 
-	parser->deleteInstance();
+	MemoryPoolObject::deleteInstance(parser);
 	parser = NULL;
 }
 
@@ -1514,7 +1514,7 @@ void RecorderClass::cullBadCommands() {
 				(msg->getType() < GameMessage::MSG_END_NETWORK_MESSAGES) &&
 				(msg->getType() != GameMessage::MSG_LOGIC_CRC)) {
 
-			msg->deleteInstance();
+			MemoryPoolObject::deleteInstance(msg);
 		}
 
 		msg = next;

--- a/GeneralsMD/Code/GameEngine/Source/Common/StateMachine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/StateMachine.cpp
@@ -297,7 +297,7 @@ StateMachine::~StateMachine()
 	for( i = m_stateMap.begin(); i != m_stateMap.end(); ++i )
 	{
 		if ((*i).second)
-			(*i).second->deleteInstance();
+			MemoryPoolObject::deleteInstance((*i).second);
 	}
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/StateMachine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/StateMachine.cpp
@@ -297,7 +297,7 @@ StateMachine::~StateMachine()
 	for( i = m_stateMap.begin(); i != m_stateMap.end(); ++i )
 	{
 		if ((*i).second)
-			MemoryPoolObject::deleteInstance((*i).second);
+			deleteInstance((*i).second);
 	}
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
@@ -164,7 +164,7 @@ void BuildAssistant::reset( void )
 		sellInfo = (*it);
 
 		// delete our data and erase this entry from the list
-		sellInfo->deleteInstance();
+		MemoryPoolObject::deleteInstance(sellInfo);
 
 	}  // end for
 
@@ -205,7 +205,7 @@ void BuildAssistant::update( void )
 		if( obj == NULL )
 		{
 
-			sellInfo->deleteInstance();			
+			MemoryPoolObject::deleteInstance(sellInfo);			
 			m_sellList.erase( thisIterator );		
 			continue;
 
@@ -281,7 +281,7 @@ void BuildAssistant::update( void )
 			TheGameLogic->destroyObject( obj );
 
 			// remove this object from the sell list
-			sellInfo->deleteInstance();
+			MemoryPoolObject::deleteInstance(sellInfo);
 			m_sellList.erase( thisIterator );
 
 		}  // end if

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
@@ -164,7 +164,7 @@ void BuildAssistant::reset( void )
 		sellInfo = (*it);
 
 		// delete our data and erase this entry from the list
-		MemoryPoolObject::deleteInstance(sellInfo);
+		deleteInstance(sellInfo);
 
 	}  // end for
 
@@ -205,7 +205,7 @@ void BuildAssistant::update( void )
 		if( obj == NULL )
 		{
 
-			MemoryPoolObject::deleteInstance(sellInfo);			
+			deleteInstance(sellInfo);			
 			m_sellList.erase( thisIterator );		
 			continue;
 
@@ -281,7 +281,7 @@ void BuildAssistant::update( void )
 			TheGameLogic->destroyObject( obj );
 
 			// remove this object from the sell list
-			MemoryPoolObject::deleteInstance(sellInfo);
+			deleteInstance(sellInfo);
 			m_sellList.erase( thisIterator );
 
 		}  // end if

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/DataChunk.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/DataChunk.cpp
@@ -331,7 +331,7 @@ void DataChunkOutput::closeDataChunk( void )
 	DEBUG_LOG(("Closing chunk %s at %d (%x)\n", m_contents.getName(c->id).str(), here, here));
 #endif
 	m_chunkStack = m_chunkStack->next;
-	c->deleteInstance();
+	MemoryPoolObject::deleteInstance(c);
 }
 
 void DataChunkOutput::writeReal( Real r ) 
@@ -437,7 +437,7 @@ DataChunkTableOfContents::~DataChunkTableOfContents()
 	for( m=m_list; m; m=next )
 	{
 		next = m->next;
-		m->deleteInstance();
+		MemoryPoolObject::deleteInstance(m);
 	}
 }
 
@@ -601,7 +601,7 @@ DataChunkInput::~DataChunkInput()
 	UserParser *p, *next;
 	for (p=m_parserList; p; p=next) {
 		next = p->next;
-		p->deleteInstance();
+		MemoryPoolObject::deleteInstance(p);
 	}
 
 }
@@ -699,7 +699,7 @@ void DataChunkInput::clearChunkStack( void )
 	for( c=m_chunkStack; c; c=next )
 	{
 		next = c->next;
-		c->deleteInstance();
+		MemoryPoolObject::deleteInstance(c);
 	}
 
 	m_chunkStack = NULL;
@@ -772,7 +772,7 @@ void DataChunkInput::closeDataChunk( void )
 	// pop the chunk off the stack
 	InputChunk *c = m_chunkStack;
 	m_chunkStack = m_chunkStack->next;
-	c->deleteInstance();
+	MemoryPoolObject::deleteInstance(c);
 }
 
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/DataChunk.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/DataChunk.cpp
@@ -331,7 +331,7 @@ void DataChunkOutput::closeDataChunk( void )
 	DEBUG_LOG(("Closing chunk %s at %d (%x)\n", m_contents.getName(c->id).str(), here, here));
 #endif
 	m_chunkStack = m_chunkStack->next;
-	MemoryPoolObject::deleteInstance(c);
+	deleteInstance(c);
 }
 
 void DataChunkOutput::writeReal( Real r ) 
@@ -437,7 +437,7 @@ DataChunkTableOfContents::~DataChunkTableOfContents()
 	for( m=m_list; m; m=next )
 	{
 		next = m->next;
-		MemoryPoolObject::deleteInstance(m);
+		deleteInstance(m);
 	}
 }
 
@@ -601,7 +601,7 @@ DataChunkInput::~DataChunkInput()
 	UserParser *p, *next;
 	for (p=m_parserList; p; p=next) {
 		next = p->next;
-		MemoryPoolObject::deleteInstance(p);
+		deleteInstance(p);
 	}
 
 }
@@ -699,7 +699,7 @@ void DataChunkInput::clearChunkStack( void )
 	for( c=m_chunkStack; c; c=next )
 	{
 		next = c->next;
-		MemoryPoolObject::deleteInstance(c);
+		deleteInstance(c);
 	}
 
 	m_chunkStack = NULL;
@@ -772,7 +772,7 @@ void DataChunkInput::closeDataChunk( void )
 	// pop the chunk off the stack
 	InputChunk *c = m_chunkStack;
 	m_chunkStack = m_chunkStack->next;
-	MemoryPoolObject::deleteInstance(c);
+	deleteInstance(c);
 }
 
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/File.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/File.cpp
@@ -192,7 +192,7 @@ void File::close( void )
 		m_open = FALSE;
 		if ( m_deleteOnClose )
 		{
-			this->deleteInstance(); // on special cases File object will delete itself when closing
+			MemoryPoolObject::deleteInstance(this); // on special cases File object will delete itself when closing
 		}
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/File.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/File.cpp
@@ -192,7 +192,7 @@ void File::close( void )
 		m_open = FALSE;
 		if ( m_deleteOnClose )
 		{
-			MemoryPoolObject::deleteInstance(this); // on special cases File object will delete itself when closing
+			deleteInstance(this); // on special cases File object will delete itself when closing
 		}
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/LocalFile.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/LocalFile.cpp
@@ -592,14 +592,14 @@ File* LocalFile::convertToRAMFile()
 		else
 		{
 			this->close();
-			MemoryPoolObject::deleteInstance(this);
+			deleteInstance(this);
 		}
 		return ramFile;
 	}	
 	else 
 	{
 		ramFile->close();
-		MemoryPoolObject::deleteInstance(ramFile);
+		deleteInstance(ramFile);
 		return this;
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/LocalFile.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/LocalFile.cpp
@@ -592,14 +592,14 @@ File* LocalFile::convertToRAMFile()
 		else
 		{
 			this->close();
-			this->deleteInstance();
+			MemoryPoolObject::deleteInstance(this);
 		}
 		return ramFile;
 	}	
 	else 
 	{
 		ramFile->close();
-		ramFile->deleteInstance();
+		MemoryPoolObject::deleteInstance(ramFile);
 		return this;
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/Radar.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/Radar.cpp
@@ -83,7 +83,7 @@ void Radar::deleteListResources( void )
 		m_localObjectList->friend_getObject()->friend_setRadarData( NULL );
 
 		// delete the head of the list
-		m_localObjectList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_localObjectList);
 
 		// set head of the list to the next object
 		m_localObjectList = nextObject;
@@ -101,7 +101,7 @@ void Radar::deleteListResources( void )
 		m_objectList->friend_getObject()->friend_setRadarData( NULL );
 
 		// delete the head of the list
-		m_objectList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_objectList);
 
 		// set head of the list to the next object
 		m_objectList = nextObject;
@@ -573,7 +573,7 @@ Bool Radar::deleteFromList( Object *obj, RadarObject **list )
 			obj->friend_setRadarData( NULL );
 
 			// delete the object instance
-			radarObject->deleteInstance();
+			MemoryPoolObject::deleteInstance(radarObject);
 
 			// all done, object found and deleted
 			return TRUE;

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/Radar.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/Radar.cpp
@@ -83,7 +83,7 @@ void Radar::deleteListResources( void )
 		m_localObjectList->friend_getObject()->friend_setRadarData( NULL );
 
 		// delete the head of the list
-		MemoryPoolObject::deleteInstance(m_localObjectList);
+		deleteInstance(m_localObjectList);
 
 		// set head of the list to the next object
 		m_localObjectList = nextObject;
@@ -101,7 +101,7 @@ void Radar::deleteListResources( void )
 		m_objectList->friend_getObject()->friend_setRadarData( NULL );
 
 		// delete the head of the list
-		MemoryPoolObject::deleteInstance(m_objectList);
+		deleteInstance(m_objectList);
 
 		// set head of the list to the next object
 		m_objectList = nextObject;
@@ -573,7 +573,7 @@ Bool Radar::deleteFromList( Object *obj, RadarObject **list )
 			obj->friend_setRadarData( NULL );
 
 			// delete the object instance
-			MemoryPoolObject::deleteInstance(radarObject);
+			deleteInstance(radarObject);
 
 			// all done, object found and deleted
 			return TRUE;

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/Upgrade.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/Upgrade.cpp
@@ -245,7 +245,7 @@ UpgradeCenter::~UpgradeCenter( void )
 		next = m_upgradeList->friend_getNext();
 
 		// delete head of list
-		MemoryPoolObject::deleteInstance(m_upgradeList);
+		deleteInstance(m_upgradeList);
 
 		// set head to next element
 		m_upgradeList = next;

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/Upgrade.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/Upgrade.cpp
@@ -245,7 +245,7 @@ UpgradeCenter::~UpgradeCenter( void )
 		next = m_upgradeList->friend_getNext();
 
 		// delete head of list
-		m_upgradeList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_upgradeList);
 
 		// set head to next element
 		m_upgradeList = next;

--- a/GeneralsMD/Code/GameEngine/Source/Common/TerrainTypes.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/TerrainTypes.cpp
@@ -99,7 +99,7 @@ TerrainTypeCollection::~TerrainTypeCollection( void )
 		temp = m_terrainList->friend_getNext();
 
 		// delete the head of the type list
-		MemoryPoolObject::deleteInstance(m_terrainList);
+		deleteInstance(m_terrainList);
 
 		// set the new head of the type list
 		m_terrainList = temp;

--- a/GeneralsMD/Code/GameEngine/Source/Common/TerrainTypes.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/TerrainTypes.cpp
@@ -99,7 +99,7 @@ TerrainTypeCollection::~TerrainTypeCollection( void )
 		temp = m_terrainList->friend_getNext();
 
 		// delete the head of the type list
-		m_terrainList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_terrainList);
 
 		// set the new head of the type list
 		m_terrainList = temp;

--- a/GeneralsMD/Code/GameEngine/Source/Common/Thing/ThingFactory.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Thing/ThingFactory.cpp
@@ -74,7 +74,7 @@ void ThingFactory::freeDatabase( void )
 	{
 		ThingTemplate* tmpl = m_firstTemplate;
 		m_firstTemplate = m_firstTemplate->friend_getNextTemplate();
-		MemoryPoolObject::deleteInstance(tmpl);
+		deleteInstance(tmpl);
 	}
 
 	m_templateHashMap.clear();

--- a/GeneralsMD/Code/GameEngine/Source/Common/Thing/ThingFactory.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Thing/ThingFactory.cpp
@@ -74,7 +74,7 @@ void ThingFactory::freeDatabase( void )
 	{
 		ThingTemplate* tmpl = m_firstTemplate;
 		m_firstTemplate = m_firstTemplate->friend_getNextTemplate();
-		tmpl->deleteInstance();
+		MemoryPoolObject::deleteInstance(tmpl);
 	}
 
 	m_templateHashMap.clear();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Display.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Display.cpp
@@ -309,7 +309,7 @@ void Display::update( void )
 				{
 					//display the copyrighttext;		
 					if(m_copyrightDisplayString)
-						m_copyrightDisplayString->deleteInstance();
+						MemoryPoolObject::deleteInstance(m_copyrightDisplayString);
 					m_copyrightDisplayString = TheDisplayStringManager->newDisplayString();
 					m_copyrightDisplayString->setText(TheGameText->fetch("GUI:EACopyright"));
 					if (TheGlobalLanguageData && TheGlobalLanguageData->m_copyrightFont.name.isNotEmpty())

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Display.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Display.cpp
@@ -309,7 +309,7 @@ void Display::update( void )
 				{
 					//display the copyrighttext;		
 					if(m_copyrightDisplayString)
-						MemoryPoolObject::deleteInstance(m_copyrightDisplayString);
+						deleteInstance(m_copyrightDisplayString);
 					m_copyrightDisplayString = TheDisplayStringManager->newDisplayString();
 					m_copyrightDisplayString->setText(TheGameText->fetch("GUI:EACopyright"));
 					if (TheGlobalLanguageData && TheGlobalLanguageData->m_copyrightFont.name.isNotEmpty())

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -162,7 +162,7 @@ void DrawableIconInfo::clear()
 	for (int i = 0; i < MAX_ICONS; ++i)
 	{
 		if (m_icon[i])
-			m_icon[i]->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_icon[i]);
 		m_icon[i] = NULL;
 		m_keepTillFrame[i] = 0;
 	}
@@ -174,7 +174,7 @@ void DrawableIconInfo::killIcon(DrawableIconType t)
 {
 	if (m_icon[t])
 	{
-		m_icon[t]->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_icon[t]);
 		m_icon[t] = NULL;
 		m_keepTillFrame[t] = 0;
 	}
@@ -549,7 +549,7 @@ Drawable::~Drawable()
 	{
 		for (Module** m = m_modules[i]; m && *m; ++m)
 		{
-			(*m)->deleteInstance();
+			MemoryPoolObject::deleteInstance((*m));
 			*m = NULL;	// in case other modules call findModule from their dtor!
 		}
 		delete [] m_modules[i]; 
@@ -559,7 +559,7 @@ Drawable::~Drawable()
 	stopAmbientSound();
 	if (m_ambientSound)
 	{
-		m_ambientSound->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_ambientSound);
 		m_ambientSound = NULL;
 	}
 
@@ -574,17 +574,17 @@ Drawable::~Drawable()
 
 	// delete any icons present
 	if (m_iconInfo)
-		m_iconInfo->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_iconInfo);
 
 	if (m_selectionFlashEnvelope)
-		m_selectionFlashEnvelope->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_selectionFlashEnvelope);
 
 	if (m_colorTintEnvelope)
-		m_colorTintEnvelope->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_colorTintEnvelope);
 
 	if (m_locoInfo)
 	{
-		m_locoInfo->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_locoInfo);
 		m_locoInfo = NULL;
 	}
 }
@@ -4540,7 +4540,7 @@ void Drawable::startAmbientSound(BodyDamageType dt, TimeOfDay tod, Bool onlyIfPe
 		else
 		{
 			DEBUG_CRASH( ("Ambient sound %s missing! Skipping...", m_ambientSound->m_event.getEventName().str() ) );
-			m_ambientSound->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_ambientSound);
 			m_ambientSound = NULL;
 		}
 	}
@@ -4935,7 +4935,7 @@ void Drawable::xfer( Xfer *xfer )
 	if( xfer->getXferMode() == XFER_LOAD && m_ambientSound )
 	{
 		TheAudio->killAudioEventImmediately( m_ambientSound->m_event.getPlayingHandle() );
-		m_ambientSound->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_ambientSound);
 		m_ambientSound = NULL;
 	}
 
@@ -5387,7 +5387,7 @@ void Drawable::xfer( Xfer *xfer )
             }
             else
             {
-              customizedInfo->deleteInstance();
+              MemoryPoolObject::deleteInstance(customizedInfo);
               customizedInfo = NULL;
             }
           }
@@ -5395,7 +5395,7 @@ void Drawable::xfer( Xfer *xfer )
           {
             // since Xfer can throw exceptions -- don't leak memory!
             if ( customizedInfo != NULL ) 
-              customizedInfo->deleteInstance();
+              MemoryPoolObject::deleteInstance(customizedInfo);
 
             throw; //rethrow
           }

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -162,7 +162,7 @@ void DrawableIconInfo::clear()
 	for (int i = 0; i < MAX_ICONS; ++i)
 	{
 		if (m_icon[i])
-			MemoryPoolObject::deleteInstance(m_icon[i]);
+			deleteInstance(m_icon[i]);
 		m_icon[i] = NULL;
 		m_keepTillFrame[i] = 0;
 	}
@@ -174,7 +174,7 @@ void DrawableIconInfo::killIcon(DrawableIconType t)
 {
 	if (m_icon[t])
 	{
-		MemoryPoolObject::deleteInstance(m_icon[t]);
+		deleteInstance(m_icon[t]);
 		m_icon[t] = NULL;
 		m_keepTillFrame[t] = 0;
 	}
@@ -549,7 +549,7 @@ Drawable::~Drawable()
 	{
 		for (Module** m = m_modules[i]; m && *m; ++m)
 		{
-			MemoryPoolObject::deleteInstance((*m));
+			deleteInstance(*m);
 			*m = NULL;	// in case other modules call findModule from their dtor!
 		}
 		delete [] m_modules[i]; 
@@ -559,7 +559,7 @@ Drawable::~Drawable()
 	stopAmbientSound();
 	if (m_ambientSound)
 	{
-		MemoryPoolObject::deleteInstance(m_ambientSound);
+		deleteInstance(m_ambientSound);
 		m_ambientSound = NULL;
 	}
 
@@ -574,17 +574,17 @@ Drawable::~Drawable()
 
 	// delete any icons present
 	if (m_iconInfo)
-		MemoryPoolObject::deleteInstance(m_iconInfo);
+		deleteInstance(m_iconInfo);
 
 	if (m_selectionFlashEnvelope)
-		MemoryPoolObject::deleteInstance(m_selectionFlashEnvelope);
+		deleteInstance(m_selectionFlashEnvelope);
 
 	if (m_colorTintEnvelope)
-		MemoryPoolObject::deleteInstance(m_colorTintEnvelope);
+		deleteInstance(m_colorTintEnvelope);
 
 	if (m_locoInfo)
 	{
-		MemoryPoolObject::deleteInstance(m_locoInfo);
+		deleteInstance(m_locoInfo);
 		m_locoInfo = NULL;
 	}
 }
@@ -4540,7 +4540,7 @@ void Drawable::startAmbientSound(BodyDamageType dt, TimeOfDay tod, Bool onlyIfPe
 		else
 		{
 			DEBUG_CRASH( ("Ambient sound %s missing! Skipping...", m_ambientSound->m_event.getEventName().str() ) );
-			MemoryPoolObject::deleteInstance(m_ambientSound);
+			deleteInstance(m_ambientSound);
 			m_ambientSound = NULL;
 		}
 	}
@@ -4935,7 +4935,7 @@ void Drawable::xfer( Xfer *xfer )
 	if( xfer->getXferMode() == XFER_LOAD && m_ambientSound )
 	{
 		TheAudio->killAudioEventImmediately( m_ambientSound->m_event.getPlayingHandle() );
-		MemoryPoolObject::deleteInstance(m_ambientSound);
+		deleteInstance(m_ambientSound);
 		m_ambientSound = NULL;
 	}
 
@@ -5387,7 +5387,7 @@ void Drawable::xfer( Xfer *xfer )
             }
             else
             {
-              MemoryPoolObject::deleteInstance(customizedInfo);
+              deleteInstance(customizedInfo);
               customizedInfo = NULL;
             }
           }
@@ -5395,7 +5395,7 @@ void Drawable::xfer( Xfer *xfer )
           {
             // since Xfer can throw exceptions -- don't leak memory!
             if ( customizedInfo != NULL ) 
-              MemoryPoolObject::deleteInstance(customizedInfo);
+              deleteInstance(customizedInfo);
 
             throw; //rethrow
           }

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Eva.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Eva.cpp
@@ -251,7 +251,7 @@ Eva::~Eva()
 	EvaCheckInfoPtrVecIt it;
 	for (it = m_allCheckInfos.begin(); it != m_allCheckInfos.end(); ++it) {
 		if (*it)
-			(*it)->deleteInstance();
+			MemoryPoolObject::deleteInstance((*it));
 	}
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Eva.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Eva.cpp
@@ -251,7 +251,7 @@ Eva::~Eva()
 	EvaCheckInfoPtrVecIt it;
 	for (it = m_allCheckInfos.begin(); it != m_allCheckInfos.end(); ++it) {
 		if (*it)
-			MemoryPoolObject::deleteInstance((*it));
+			deleteInstance(*it);
 	}
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/FXList.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/FXList.cpp
@@ -797,7 +797,7 @@ void FXList::clear()
 	for (FXNuggetList::iterator it = m_nuggets.begin(); it != m_nuggets.end(); ++it)
 	{
 		if (*it)
-			MemoryPoolObject::deleteInstance((*it));
+			deleteInstance(*it);
 	}
 	m_nuggets.clear();
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/FXList.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/FXList.cpp
@@ -797,7 +797,7 @@ void FXList::clear()
 	for (FXNuggetList::iterator it = m_nuggets.begin(); it != m_nuggets.end(); ++it)
 	{
 		if (*it)
-			(*it)->deleteInstance();
+			MemoryPoolObject::deleteInstance((*it));
 	}
 	m_nuggets.clear();
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/AnimateWindowManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/AnimateWindowManager.cpp
@@ -117,7 +117,7 @@ static void clearWinList(AnimateWindowList &winList)
 		win = *(winList.begin());
 		winList.pop_front();
 		if (win)
-			win->deleteInstance();
+			MemoryPoolObject::deleteInstance(win);
 		win = NULL;
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/AnimateWindowManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/AnimateWindowManager.cpp
@@ -117,7 +117,7 @@ static void clearWinList(AnimateWindowList &winList)
 		win = *(winList.begin());
 		winList.pop_front();
 		if (win)
-			MemoryPoolObject::deleteInstance(win);
+			deleteInstance(win);
 		win = NULL;
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -976,7 +976,7 @@ ControlBar::~ControlBar( void )
 	if(m_scienceLayout)
 	{
 		m_scienceLayout->destroyWindows();
-		MemoryPoolObject::deleteInstance(m_scienceLayout);
+		deleteInstance(m_scienceLayout);
 	}
 	m_scienceLayout = NULL;
 	m_genArrow = NULL;
@@ -1008,7 +1008,7 @@ ControlBar::~ControlBar( void )
 	while( m_commandSets )
 	{
 		set = m_commandSets->friend_getNext();
-		MemoryPoolObject::deleteInstance(m_commandSets);
+		deleteInstance(m_commandSets);
 		m_commandSets = set;
 
 	}  // end while
@@ -1018,21 +1018,21 @@ ControlBar::~ControlBar( void )
 	while( m_commandButtons )
 	{
 		button = m_commandButtons->friend_getNext();
-		MemoryPoolObject::deleteInstance(m_commandButtons);
+		deleteInstance(m_commandButtons);
 		m_commandButtons = button;
 
 	}  // end while
 	if(m_buildToolTipLayout)
 	{
 		m_buildToolTipLayout->destroyWindows();
-		MemoryPoolObject::deleteInstance(m_buildToolTipLayout);
+		deleteInstance(m_buildToolTipLayout);
 		m_buildToolTipLayout = NULL;
 	}
 
 	if(m_specialPowerLayout)
 	{
 		m_specialPowerLayout->destroyWindows();
-		MemoryPoolObject::deleteInstance(m_specialPowerLayout);
+		deleteInstance(m_specialPowerLayout);
 		m_specialPowerLayout = NULL;
 	}
 
@@ -3234,7 +3234,7 @@ void ControlBar::initSpecialPowershortcutBar( Player *player)
 	if(m_specialPowerLayout)
 	{
 		m_specialPowerLayout->destroyWindows();
-		MemoryPoolObject::deleteInstance(m_specialPowerLayout);
+		deleteInstance(m_specialPowerLayout);
 		m_specialPowerLayout = NULL;
 	}
 	m_specialPowerShortcutParent = NULL;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -976,7 +976,7 @@ ControlBar::~ControlBar( void )
 	if(m_scienceLayout)
 	{
 		m_scienceLayout->destroyWindows();
-		m_scienceLayout->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_scienceLayout);
 	}
 	m_scienceLayout = NULL;
 	m_genArrow = NULL;
@@ -1008,7 +1008,7 @@ ControlBar::~ControlBar( void )
 	while( m_commandSets )
 	{
 		set = m_commandSets->friend_getNext();
-		m_commandSets->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_commandSets);
 		m_commandSets = set;
 
 	}  // end while
@@ -1018,21 +1018,21 @@ ControlBar::~ControlBar( void )
 	while( m_commandButtons )
 	{
 		button = m_commandButtons->friend_getNext();
-		m_commandButtons->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_commandButtons);
 		m_commandButtons = button;
 
 	}  // end while
 	if(m_buildToolTipLayout)
 	{
 		m_buildToolTipLayout->destroyWindows();
-		m_buildToolTipLayout->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_buildToolTipLayout);
 		m_buildToolTipLayout = NULL;
 	}
 
 	if(m_specialPowerLayout)
 	{
 		m_specialPowerLayout->destroyWindows();
-		m_specialPowerLayout->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_specialPowerLayout);
 		m_specialPowerLayout = NULL;
 	}
 
@@ -3234,7 +3234,7 @@ void ControlBar::initSpecialPowershortcutBar( Player *player)
 	if(m_specialPowerLayout)
 	{
 		m_specialPowerLayout->destroyWindows();
-		m_specialPowerLayout->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_specialPowerLayout);
 		m_specialPowerLayout = NULL;
 	}
 	m_specialPowerShortcutParent = NULL;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarPrintPositions.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarPrintPositions.cpp
@@ -95,7 +95,7 @@ void PrintOffsetsFromControlBarParent( void )
 
 	fclose(fp);
 	layout->destroyWindows();
-	layout->deleteInstance();
+	MemoryPoolObject::deleteInstance(layout);
 }
 
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarPrintPositions.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarPrintPositions.cpp
@@ -95,7 +95,7 @@ void PrintOffsetsFromControlBarParent( void )
 
 	fclose(fp);
 	layout->destroyWindows();
-	MemoryPoolObject::deleteInstance(layout);
+	deleteInstance(layout);
 }
 
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/ControlBarPopupDescription.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/ControlBarPopupDescription.cpp
@@ -163,7 +163,7 @@ void ControlBar::showBuildTooltipLayout( GameWindow *cmdButton )
 		else
 		{
 //			m_buildToolTipLayout->destroyWindows();
-//			m_buildToolTipLayout->deleteInstance();
+//			MemoryPoolObject::deleteInstance(m_buildToolTipLayout);
 //			m_buildToolTipLayout = NULL;
 			m_buildToolTipLayout->hide(TRUE);
 			prevWindow = NULL;
@@ -206,7 +206,7 @@ void ControlBar::showBuildTooltipLayout( GameWindow *cmdButton )
 		//	if (m_buildToolTipLayout)
 		//	{
 		//		m_buildToolTipLayout->destroyWindows();
-		//		m_buildToolTipLayout->deleteInstance();
+		//		MemoryPoolObject::deleteInstance(m_buildToolTipLayout);
 		//
 		//	}
 
@@ -707,7 +707,7 @@ void ControlBar::deleteBuildTooltipLayout( void )
 //		return;
 //	
 //	m_buildToolTipLayout->destroyWindows();
-//	m_buildToolTipLayout->deleteInstance();
+//	MemoryPoolObject::deleteInstance(m_buildToolTipLayout);
 //	m_buildToolTipLayout = NULL;
 	if(theAnimateWindowManager)
 		delete theAnimateWindowManager;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/ControlBarPopupDescription.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/ControlBarPopupDescription.cpp
@@ -163,7 +163,7 @@ void ControlBar::showBuildTooltipLayout( GameWindow *cmdButton )
 		else
 		{
 //			m_buildToolTipLayout->destroyWindows();
-//			MemoryPoolObject::deleteInstance(m_buildToolTipLayout);
+//			deleteInstance(m_buildToolTipLayout);
 //			m_buildToolTipLayout = NULL;
 			m_buildToolTipLayout->hide(TRUE);
 			prevWindow = NULL;
@@ -206,7 +206,7 @@ void ControlBar::showBuildTooltipLayout( GameWindow *cmdButton )
 		//	if (m_buildToolTipLayout)
 		//	{
 		//		m_buildToolTipLayout->destroyWindows();
-		//		MemoryPoolObject::deleteInstance(m_buildToolTipLayout);
+		//		deleteInstance(m_buildToolTipLayout);
 		//
 		//	}
 
@@ -707,7 +707,7 @@ void ControlBar::deleteBuildTooltipLayout( void )
 //		return;
 //	
 //	m_buildToolTipLayout->destroyWindows();
-//	MemoryPoolObject::deleteInstance(m_buildToolTipLayout);
+//	deleteInstance(m_buildToolTipLayout);
 //	m_buildToolTipLayout = NULL;
 	if(theAnimateWindowManager)
 		delete theAnimateWindowManager;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Diplomacy.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Diplomacy.cpp
@@ -290,7 +290,7 @@ void ResetDiplomacy( void )
 	{
 		TheInGameUI->unregisterWindowLayout(theLayout);
 		theLayout->destroyWindows();
-		theLayout->deleteInstance();
+		MemoryPoolObject::deleteInstance(theLayout);
 		InitBuddyControls(-1);
 	}
 	theLayout = NULL;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Diplomacy.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Diplomacy.cpp
@@ -290,7 +290,7 @@ void ResetDiplomacy( void )
 	{
 		TheInGameUI->unregisterWindowLayout(theLayout);
 		theLayout->destroyWindows();
-		MemoryPoolObject::deleteInstance(theLayout);
+		deleteInstance(theLayout);
 		InitBuddyControls(-1);
 	}
 	theLayout = NULL;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/DifficultySelect.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/DifficultySelect.cpp
@@ -259,7 +259,7 @@ WindowMsgHandledType DifficultySelectSystem( GameWindow *window, UnsignedInt msg
 				//TheScriptEngine->setGlobalDifficulty(s_AIDiff); // CANNOT DO THIS! REPLAYS WILL BREAK!
 				WindowLayout *layout = window->winGetLayout();
 				layout->destroyWindows();
-				layout->deleteInstance();
+				MemoryPoolObject::deleteInstance(layout);
 				setupGameStart(TheCampaignManager->getCurrentMap(), s_AIDiff);
 				// start the game
 			}
@@ -269,7 +269,7 @@ WindowMsgHandledType DifficultySelectSystem( GameWindow *window, UnsignedInt msg
 				TheWindowManager->winUnsetModal(window);
 				WindowLayout *layout = window->winGetLayout();
 				layout->destroyWindows();
-				layout->deleteInstance();
+				MemoryPoolObject::deleteInstance(layout);
 				
 			}
 			else if ( controlID == radioButtonEasyAIID )

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/DifficultySelect.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/DifficultySelect.cpp
@@ -259,7 +259,7 @@ WindowMsgHandledType DifficultySelectSystem( GameWindow *window, UnsignedInt msg
 				//TheScriptEngine->setGlobalDifficulty(s_AIDiff); // CANNOT DO THIS! REPLAYS WILL BREAK!
 				WindowLayout *layout = window->winGetLayout();
 				layout->destroyWindows();
-				MemoryPoolObject::deleteInstance(layout);
+				deleteInstance(layout);
 				setupGameStart(TheCampaignManager->getCurrentMap(), s_AIDiff);
 				// start the game
 			}
@@ -269,7 +269,7 @@ WindowMsgHandledType DifficultySelectSystem( GameWindow *window, UnsignedInt msg
 				TheWindowManager->winUnsetModal(window);
 				WindowLayout *layout = window->winGetLayout();
 				layout->destroyWindows();
-				MemoryPoolObject::deleteInstance(layout);
+				deleteInstance(layout);
 				
 			}
 			else if ( controlID == radioButtonEasyAIID )

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/DownloadMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/DownloadMenu.cpp
@@ -85,7 +85,7 @@ static void closeDownloadWindow( void )
   WindowLayout *menuLayout = parent->winGetLayout();
 	menuLayout->runShutdown();
   menuLayout->destroyWindows();
-	MemoryPoolObject::deleteInstance(menuLayout);
+	deleteInstance(menuLayout);
 	menuLayout = NULL;
 
 	GameWindow *mainWin = TheWindowManager->winGetWindowFromId( NULL, NAMEKEY("MainMenu.wnd:MainMenuParent") );

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/DownloadMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/DownloadMenu.cpp
@@ -85,7 +85,7 @@ static void closeDownloadWindow( void )
   WindowLayout *menuLayout = parent->winGetLayout();
 	menuLayout->runShutdown();
   menuLayout->destroyWindows();
-	menuLayout->deleteInstance();
+	MemoryPoolObject::deleteInstance(menuLayout);
 	menuLayout = NULL;
 
 	GameWindow *mainWin = TheWindowManager->winGetWindowFromId( NULL, NAMEKEY("MainMenu.wnd:MainMenuParent") );

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/EstablishConnectionsWindow.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/EstablishConnectionsWindow.cpp
@@ -157,7 +157,7 @@ void HideEstablishConnectionsWindow( void ) {
 //	establishConnectionsLayout->hide(TRUE);
 //	TheWindowManager->winDestroy(establishConnectionsLayout);
 	establishConnectionsLayout->destroyWindows();
-	establishConnectionsLayout->deleteInstance();
+	MemoryPoolObject::deleteInstance(establishConnectionsLayout);
 	establishConnectionsLayout = NULL;
 	if (!TheGameSpyGame->isQMGame())
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/EstablishConnectionsWindow.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/EstablishConnectionsWindow.cpp
@@ -157,7 +157,7 @@ void HideEstablishConnectionsWindow( void ) {
 //	establishConnectionsLayout->hide(TRUE);
 //	TheWindowManager->winDestroy(establishConnectionsLayout);
 	establishConnectionsLayout->destroyWindows();
-	MemoryPoolObject::deleteInstance(establishConnectionsLayout);
+	deleteInstance(establishConnectionsLayout);
 	establishConnectionsLayout = NULL;
 	if (!TheGameSpyGame->isQMGame())
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/GameInfoWindow.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/GameInfoWindow.cpp
@@ -94,7 +94,7 @@ void DestroyGameInfoWindow(void)
 	if (gameInfoWindowLayout)
 	{
 		gameInfoWindowLayout->destroyWindows();
-		MemoryPoolObject::deleteInstance(gameInfoWindowLayout);
+		deleteInstance(gameInfoWindowLayout);
 		gameInfoWindowLayout = NULL;		
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/GameInfoWindow.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/GameInfoWindow.cpp
@@ -94,7 +94,7 @@ void DestroyGameInfoWindow(void)
 	if (gameInfoWindowLayout)
 	{
 		gameInfoWindowLayout->destroyWindows();
-		gameInfoWindowLayout->deleteInstance();
+		MemoryPoolObject::deleteInstance(gameInfoWindowLayout);
 		gameInfoWindowLayout = NULL;		
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanGameOptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanGameOptionsMenu.cpp
@@ -1216,7 +1216,7 @@ WindowMsgHandledType LanGameOptionsMenuSystem( GameWindow *window, UnsignedInt m
 					if( mapSelectLayout )
 						{
 							mapSelectLayout->destroyWindows();
-							MemoryPoolObject::deleteInstance(mapSelectLayout);
+							deleteInstance(mapSelectLayout);
 							mapSelectLayout = NULL;
 						}
 					TheLAN->RequestGameLeave();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanGameOptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanGameOptionsMenu.cpp
@@ -1216,7 +1216,7 @@ WindowMsgHandledType LanGameOptionsMenuSystem( GameWindow *window, UnsignedInt m
 					if( mapSelectLayout )
 						{
 							mapSelectLayout->destroyWindows();
-							mapSelectLayout->deleteInstance();
+							MemoryPoolObject::deleteInstance(mapSelectLayout);
 							mapSelectLayout = NULL;
 						}
 					TheLAN->RequestGameLeave();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanMapSelectMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanMapSelectMenu.cpp
@@ -345,7 +345,7 @@ WindowMsgHandledType LanMapSelectMenuSystem( GameWindow *window, UnsignedInt msg
 			{
 				
 				mapSelectLayout->destroyWindows();
-				MemoryPoolObject::deleteInstance(mapSelectLayout);
+				deleteInstance(mapSelectLayout);
 				mapSelectLayout = NULL;
 				// set the controls to NULL since they've been destroyed.
 				NullifyControls();
@@ -391,7 +391,7 @@ WindowMsgHandledType LanMapSelectMenuSystem( GameWindow *window, UnsignedInt msg
 
 					
 					mapSelectLayout->destroyWindows();
-					MemoryPoolObject::deleteInstance(mapSelectLayout);
+					deleteInstance(mapSelectLayout);
 					mapSelectLayout = NULL;
 
 					// set the controls to NULL since they've been destroyed.

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanMapSelectMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanMapSelectMenu.cpp
@@ -345,7 +345,7 @@ WindowMsgHandledType LanMapSelectMenuSystem( GameWindow *window, UnsignedInt msg
 			{
 				
 				mapSelectLayout->destroyWindows();
-				mapSelectLayout->deleteInstance();
+				MemoryPoolObject::deleteInstance(mapSelectLayout);
 				mapSelectLayout = NULL;
 				// set the controls to NULL since they've been destroyed.
 				NullifyControls();
@@ -391,7 +391,7 @@ WindowMsgHandledType LanMapSelectMenuSystem( GameWindow *window, UnsignedInt msg
 
 					
 					mapSelectLayout->destroyWindows();
-					mapSelectLayout->deleteInstance();
+					MemoryPoolObject::deleteInstance(mapSelectLayout);
 					mapSelectLayout = NULL;
 
 					// set the controls to NULL since they've been destroyed.

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupCommunicator.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupCommunicator.cpp
@@ -186,7 +186,7 @@ WindowMsgHandledType PopupCommunicatorSystem( GameWindow *window, UnsignedInt ms
 			{
         WindowLayout *popupCommunicatorLayout = window->winGetLayout();
         popupCommunicatorLayout->destroyWindows();
-				popupCommunicatorLayout->deleteInstance();
+				MemoryPoolObject::deleteInstance(popupCommunicatorLayout);
 				popupCommunicatorLayout = NULL;
 			}  // end if
 	

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupCommunicator.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupCommunicator.cpp
@@ -186,7 +186,7 @@ WindowMsgHandledType PopupCommunicatorSystem( GameWindow *window, UnsignedInt ms
 			{
         WindowLayout *popupCommunicatorLayout = window->winGetLayout();
         popupCommunicatorLayout->destroyWindows();
-				MemoryPoolObject::deleteInstance(popupCommunicatorLayout);
+				deleteInstance(popupCommunicatorLayout);
 				popupCommunicatorLayout = NULL;
 			}  // end if
 	

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupLadderSelect.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupLadderSelect.cpp
@@ -596,7 +596,7 @@ static void closeRightClickMenu(GameWindow *win)
 		if(!winLay)
 			return;
 		winLay->destroyWindows();					
-		MemoryPoolObject::deleteInstance(winLay);
+		deleteInstance(winLay);
 		winLay = NULL;
 
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupLadderSelect.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupLadderSelect.cpp
@@ -596,7 +596,7 @@ static void closeRightClickMenu(GameWindow *win)
 		if(!winLay)
 			return;
 		winLay->destroyWindows();					
-		winLay->deleteInstance();
+		MemoryPoolObject::deleteInstance(winLay);
 		winLay = NULL;
 
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/QuitMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/QuitMenu.cpp
@@ -121,13 +121,13 @@ void destroyQuitMenu()
 	if(fullQuitMenuLayout)
 	{
 		fullQuitMenuLayout->destroyWindows();
-		MemoryPoolObject::deleteInstance(fullQuitMenuLayout);
+		deleteInstance(fullQuitMenuLayout);
 	}
 	fullQuitMenuLayout = NULL;
 	if(noSaveLoadQuitMenuLayout)
 	{
 		noSaveLoadQuitMenuLayout->destroyWindows();
-		MemoryPoolObject::deleteInstance(noSaveLoadQuitMenuLayout);
+		deleteInstance(noSaveLoadQuitMenuLayout);
 	}
 	noSaveLoadQuitMenuLayout = NULL;
 	quitMenuLayout = NULL;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/QuitMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/QuitMenu.cpp
@@ -121,13 +121,13 @@ void destroyQuitMenu()
 	if(fullQuitMenuLayout)
 	{
 		fullQuitMenuLayout->destroyWindows();
-		fullQuitMenuLayout->deleteInstance();
+		MemoryPoolObject::deleteInstance(fullQuitMenuLayout);
 	}
 	fullQuitMenuLayout = NULL;
 	if(noSaveLoadQuitMenuLayout)
 	{
 		noSaveLoadQuitMenuLayout->destroyWindows();
-		noSaveLoadQuitMenuLayout->deleteInstance();
+		MemoryPoolObject::deleteInstance(noSaveLoadQuitMenuLayout);
 	}
 	noSaveLoadQuitMenuLayout = NULL;
 	quitMenuLayout = NULL;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
@@ -936,7 +936,7 @@ void finishSinglePlayerInit( void )
 
 	//
 	s_blankLayout->destroyWindows();
-	MemoryPoolObject::deleteInstance(s_blankLayout);
+	deleteInstance(s_blankLayout);
 	s_blankLayout = NULL;
 
 	// set keyboard focus to main parent

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
@@ -936,7 +936,7 @@ void finishSinglePlayerInit( void )
 
 	//
 	s_blankLayout->destroyWindows();
-	s_blankLayout->deleteInstance();
+	MemoryPoolObject::deleteInstance(s_blankLayout);
 	s_blankLayout = NULL;
 
 	// set keyboard focus to main parent

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishGameOptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishGameOptionsMenu.cpp
@@ -1647,7 +1647,7 @@ WindowMsgHandledType SkirmishGameOptionsMenuSystem( GameWindow *window, Unsigned
 					if( skirmishMapSelectLayout )
 						{
 							skirmishMapSelectLayout->destroyWindows();
-							skirmishMapSelectLayout->deleteInstance();
+							MemoryPoolObject::deleteInstance(skirmishMapSelectLayout);
 							skirmishMapSelectLayout = NULL;
 						}
 					TheShell->pop();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishGameOptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishGameOptionsMenu.cpp
@@ -1647,7 +1647,7 @@ WindowMsgHandledType SkirmishGameOptionsMenuSystem( GameWindow *window, Unsigned
 					if( skirmishMapSelectLayout )
 						{
 							skirmishMapSelectLayout->destroyWindows();
-							MemoryPoolObject::deleteInstance(skirmishMapSelectLayout);
+							deleteInstance(skirmishMapSelectLayout);
 							skirmishMapSelectLayout = NULL;
 						}
 					TheShell->pop();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishMapSelectMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishMapSelectMenu.cpp
@@ -525,7 +525,7 @@ WindowMsgHandledType SkirmishMapSelectMenuSystem( GameWindow *window, UnsignedIn
 				showSkirmishGameOptionsUnderlyingGUIElements(TRUE);
 
 				skirmishMapSelectLayout->destroyWindows();
-				MemoryPoolObject::deleteInstance(skirmishMapSelectLayout);
+				deleteInstance(skirmishMapSelectLayout);
 				skirmishMapSelectLayout = NULL;
 				skirmishPositionStartSpots();
 				//TheShell->pop();
@@ -587,7 +587,7 @@ WindowMsgHandledType SkirmishMapSelectMenuSystem( GameWindow *window, UnsignedIn
 				skirmishUpdateSlotList();
 
 				skirmishMapSelectLayout->destroyWindows();
-				MemoryPoolObject::deleteInstance(skirmishMapSelectLayout);
+				deleteInstance(skirmishMapSelectLayout);
 				skirmishMapSelectLayout = NULL;
 					//TheShell->pop();
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishMapSelectMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishMapSelectMenu.cpp
@@ -525,7 +525,7 @@ WindowMsgHandledType SkirmishMapSelectMenuSystem( GameWindow *window, UnsignedIn
 				showSkirmishGameOptionsUnderlyingGUIElements(TRUE);
 
 				skirmishMapSelectLayout->destroyWindows();
-				skirmishMapSelectLayout->deleteInstance();
+				MemoryPoolObject::deleteInstance(skirmishMapSelectLayout);
 				skirmishMapSelectLayout = NULL;
 				skirmishPositionStartSpots();
 				//TheShell->pop();
@@ -587,7 +587,7 @@ WindowMsgHandledType SkirmishMapSelectMenuSystem( GameWindow *window, UnsignedIn
 				skirmishUpdateSlotList();
 
 				skirmishMapSelectLayout->destroyWindows();
-				skirmishMapSelectLayout->deleteInstance();
+				MemoryPoolObject::deleteInstance(skirmishMapSelectLayout);
 				skirmishMapSelectLayout = NULL;
 					//TheShell->pop();
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLBuddyOverlay.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLBuddyOverlay.cpp
@@ -696,7 +696,7 @@ void deleteNotificationBox( void )
 	if(noticeLayout)
 	{
 		noticeLayout->destroyWindows();
-		MemoryPoolObject::deleteInstance(noticeLayout);
+		deleteInstance(noticeLayout);
 		noticeLayout = NULL;
 	}
 }
@@ -1178,7 +1178,7 @@ static void closeRightClickMenu(GameWindow *win)
 		if(!winLay)
 			return;
 		winLay->destroyWindows();					
-		MemoryPoolObject::deleteInstance(winLay);
+		deleteInstance(winLay);
 		winLay = NULL;
 
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLBuddyOverlay.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLBuddyOverlay.cpp
@@ -696,7 +696,7 @@ void deleteNotificationBox( void )
 	if(noticeLayout)
 	{
 		noticeLayout->destroyWindows();
-		noticeLayout->deleteInstance();
+		MemoryPoolObject::deleteInstance(noticeLayout);
 		noticeLayout = NULL;
 	}
 }
@@ -1178,7 +1178,7 @@ static void closeRightClickMenu(GameWindow *win)
 		if(!winLay)
 			return;
 		winLay->destroyWindows();					
-		winLay->deleteInstance();
+		MemoryPoolObject::deleteInstance(winLay);
 		winLay = NULL;
 
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLGameSetupMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLGameSetupMenu.cpp
@@ -1554,7 +1554,7 @@ void WOLGameSetupMenuShutdown( WindowLayout *layout, void *userData )
 	if( WOLMapSelectLayout )
 	{
 		WOLMapSelectLayout->destroyWindows();
-		WOLMapSelectLayout->deleteInstance();
+		MemoryPoolObject::deleteInstance(WOLMapSelectLayout);
 		WOLMapSelectLayout = NULL;
 	}
 	parentWOLGameSetup = NULL;
@@ -2698,7 +2698,7 @@ WindowMsgHandledType WOLGameSetupMenuSystem( GameWindow *window, UnsignedInt msg
 					if( WOLMapSelectLayout )
 					{
 						WOLMapSelectLayout->destroyWindows();
-						WOLMapSelectLayout->deleteInstance();
+						MemoryPoolObject::deleteInstance(WOLMapSelectLayout);
 						WOLMapSelectLayout = NULL;
 					}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLGameSetupMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLGameSetupMenu.cpp
@@ -1554,7 +1554,7 @@ void WOLGameSetupMenuShutdown( WindowLayout *layout, void *userData )
 	if( WOLMapSelectLayout )
 	{
 		WOLMapSelectLayout->destroyWindows();
-		MemoryPoolObject::deleteInstance(WOLMapSelectLayout);
+		deleteInstance(WOLMapSelectLayout);
 		WOLMapSelectLayout = NULL;
 	}
 	parentWOLGameSetup = NULL;
@@ -2698,7 +2698,7 @@ WindowMsgHandledType WOLGameSetupMenuSystem( GameWindow *window, UnsignedInt msg
 					if( WOLMapSelectLayout )
 					{
 						WOLMapSelectLayout->destroyWindows();
-						MemoryPoolObject::deleteInstance(WOLMapSelectLayout);
+						deleteInstance(WOLMapSelectLayout);
 						WOLMapSelectLayout = NULL;
 					}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLMapSelectMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLMapSelectMenu.cpp
@@ -394,7 +394,7 @@ WindowMsgHandledType WOLMapSelectMenuSystem( GameWindow *window, UnsignedInt msg
 				showGameSpyGameOptionsUnderlyingGUIElements( TRUE );
 
 				WOLMapSelectLayout->destroyWindows();
-				WOLMapSelectLayout->deleteInstance();
+				MemoryPoolObject::deleteInstance(WOLMapSelectLayout);
 				WOLMapSelectLayout = NULL;
 				WOLPositionStartSpots();
 			}  // end if
@@ -458,7 +458,7 @@ WindowMsgHandledType WOLMapSelectMenuSystem( GameWindow *window, UnsignedInt msg
 					WOLDisplayGameOptions();
 
 					WOLMapSelectLayout->destroyWindows();
-					WOLMapSelectLayout->deleteInstance();
+					MemoryPoolObject::deleteInstance(WOLMapSelectLayout);
 					WOLMapSelectLayout = NULL;
 
 					showGameSpyGameOptionsUnderlyingGUIElements( TRUE );

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLMapSelectMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLMapSelectMenu.cpp
@@ -394,7 +394,7 @@ WindowMsgHandledType WOLMapSelectMenuSystem( GameWindow *window, UnsignedInt msg
 				showGameSpyGameOptionsUnderlyingGUIElements( TRUE );
 
 				WOLMapSelectLayout->destroyWindows();
-				MemoryPoolObject::deleteInstance(WOLMapSelectLayout);
+				deleteInstance(WOLMapSelectLayout);
 				WOLMapSelectLayout = NULL;
 				WOLPositionStartSpots();
 			}  // end if
@@ -458,7 +458,7 @@ WindowMsgHandledType WOLMapSelectMenuSystem( GameWindow *window, UnsignedInt msg
 					WOLDisplayGameOptions();
 
 					WOLMapSelectLayout->destroyWindows();
-					MemoryPoolObject::deleteInstance(WOLMapSelectLayout);
+					deleteInstance(WOLMapSelectLayout);
 					WOLMapSelectLayout = NULL;
 
 					showGameSpyGameOptionsUnderlyingGUIElements( TRUE );

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameFont.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameFont.cpp
@@ -123,7 +123,7 @@ void FontLibrary::deleteAllFonts( void )
 		releaseFontData( font );
 
 		// delete the font list element
-		MemoryPoolObject::deleteInstance(font);
+		deleteInstance(font);
 
 	}  // end while
 
@@ -214,7 +214,7 @@ GameFont *FontLibrary::getFont( AsciiString name, Int pointSize, Bool bold )
 	{
 
 		DEBUG_CRASH(( "getFont: Unable to load font data pointer '%s'\n", name ));
-		MemoryPoolObject::deleteInstance(font);
+		deleteInstance(font);
 		return NULL;
 
 	}  // end if

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameFont.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameFont.cpp
@@ -123,7 +123,7 @@ void FontLibrary::deleteAllFonts( void )
 		releaseFontData( font );
 
 		// delete the font list element
-		font->deleteInstance();
+		MemoryPoolObject::deleteInstance(font);
 
 	}  // end while
 
@@ -214,7 +214,7 @@ GameFont *FontLibrary::getFont( AsciiString name, Int pointSize, Bool bold )
 	{
 
 		DEBUG_CRASH(( "getFont: Unable to load font data pointer '%s'\n", name ));
-		font->deleteInstance();
+		MemoryPoolObject::deleteInstance(font);
 		return NULL;
 
 	}  // end if

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowManager.cpp
@@ -122,7 +122,7 @@ void GameWindowManager::processDestroyList( void )
 
 		// free the memory
 		if (doDestroy)
-			doDestroy->deleteInstance();
+			MemoryPoolObject::deleteInstance(doDestroy);
 
 	}  // end for
 
@@ -1613,7 +1613,7 @@ Int GameWindowManager::winUnsetModal( GameWindow *window )
 
 	// remove from top of list
 	next = m_modalHead->next;
-	m_modalHead->deleteInstance();
+	MemoryPoolObject::deleteInstance(m_modalHead);
 	m_modalHead = next;
 
 	return WIN_ERR_OK;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowManager.cpp
@@ -122,7 +122,7 @@ void GameWindowManager::processDestroyList( void )
 
 		// free the memory
 		if (doDestroy)
-			MemoryPoolObject::deleteInstance(doDestroy);
+			deleteInstance(doDestroy);
 
 	}  // end for
 
@@ -1613,7 +1613,7 @@ Int GameWindowManager::winUnsetModal( GameWindow *window )
 
 	// remove from top of list
 	next = m_modalHead->next;
-	MemoryPoolObject::deleteInstance(m_modalHead);
+	deleteInstance(m_modalHead);
 	m_modalHead = next;
 
 	return WIN_ERR_OK;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowManagerScript.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowManagerScript.cpp
@@ -2660,7 +2660,7 @@ WindowLayout *GameWindowManager::winCreateLayout( AsciiString filename )
 	if( layout->load( filename ) == FALSE )
 	{
 
-		MemoryPoolObject::deleteInstance(layout);
+		deleteInstance(layout);
 		return NULL;
 
 	}  // end if

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowManagerScript.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowManagerScript.cpp
@@ -2660,7 +2660,7 @@ WindowLayout *GameWindowManager::winCreateLayout( AsciiString filename )
 	if( layout->load( filename ) == FALSE )
 	{
 
-		layout->deleteInstance();
+		MemoryPoolObject::deleteInstance(layout);
 		return NULL;
 
 	}  // end if

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/Shell/Shell.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/Shell/Shell.cpp
@@ -97,7 +97,7 @@ Shell::~Shell( void )
 	if(m_background)
 	{
 		m_background->destroyWindows();
-		m_background->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_background);
 		m_background = NULL;
 	}
 
@@ -114,7 +114,7 @@ Shell::~Shell( void )
 	{
 
 		m_saveLoadMenuLayout->destroyWindows();
-		m_saveLoadMenuLayout->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_saveLoadMenuLayout);
 		m_saveLoadMenuLayout = NULL;
 
 	}  //end if
@@ -124,7 +124,7 @@ Shell::~Shell( void )
 	{
 
 		m_popupReplayLayout->destroyWindows();
-		m_popupReplayLayout->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_popupReplayLayout);
 		m_popupReplayLayout = NULL;
 
 	}  //end if
@@ -132,7 +132,7 @@ Shell::~Shell( void )
 	// delete the options menu if present.
 	if (m_optionsLayout != NULL) {
 		m_optionsLayout->destroyWindows();
-		m_optionsLayout->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_optionsLayout);
 		m_optionsLayout = NULL;
 	}
 
@@ -200,7 +200,7 @@ void Shell::update( void )
 		{
 			
 			m_background->destroyWindows();
-			m_background->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_background);
 			m_background = NULL;
 			
 		}
@@ -644,7 +644,7 @@ void Shell::doPop( Bool impendingPush )
 	currentTop->destroyWindows();
 
 	// release the screen object back to the memory pool
-	currentTop->deleteInstance();
+	MemoryPoolObject::deleteInstance(currentTop);
 
 	// run the init for the new top of the stack if present
 	WindowLayout *newTop = top();
@@ -707,7 +707,7 @@ void Shell::shutdownComplete( WindowLayout *screen, Bool impendingPush )
 		if(m_background)
 		{
 			m_background->destroyWindows();
-			m_background->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_background);
 			m_background = NULL;
 			m_clearBackground = FALSE;
 		}
@@ -834,7 +834,7 @@ WindowLayout *Shell::getOptionsLayout( Bool create )
 void Shell::destroyOptionsLayout() {
 	if (m_optionsLayout != NULL) {
 		m_optionsLayout->destroyWindows();
-		m_optionsLayout->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_optionsLayout);
 		m_optionsLayout = NULL;
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/Shell/Shell.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/Shell/Shell.cpp
@@ -97,7 +97,7 @@ Shell::~Shell( void )
 	if(m_background)
 	{
 		m_background->destroyWindows();
-		MemoryPoolObject::deleteInstance(m_background);
+		deleteInstance(m_background);
 		m_background = NULL;
 	}
 
@@ -114,7 +114,7 @@ Shell::~Shell( void )
 	{
 
 		m_saveLoadMenuLayout->destroyWindows();
-		MemoryPoolObject::deleteInstance(m_saveLoadMenuLayout);
+		deleteInstance(m_saveLoadMenuLayout);
 		m_saveLoadMenuLayout = NULL;
 
 	}  //end if
@@ -124,7 +124,7 @@ Shell::~Shell( void )
 	{
 
 		m_popupReplayLayout->destroyWindows();
-		MemoryPoolObject::deleteInstance(m_popupReplayLayout);
+		deleteInstance(m_popupReplayLayout);
 		m_popupReplayLayout = NULL;
 
 	}  //end if
@@ -132,7 +132,7 @@ Shell::~Shell( void )
 	// delete the options menu if present.
 	if (m_optionsLayout != NULL) {
 		m_optionsLayout->destroyWindows();
-		MemoryPoolObject::deleteInstance(m_optionsLayout);
+		deleteInstance(m_optionsLayout);
 		m_optionsLayout = NULL;
 	}
 
@@ -200,7 +200,7 @@ void Shell::update( void )
 		{
 			
 			m_background->destroyWindows();
-			MemoryPoolObject::deleteInstance(m_background);
+			deleteInstance(m_background);
 			m_background = NULL;
 			
 		}
@@ -644,7 +644,7 @@ void Shell::doPop( Bool impendingPush )
 	currentTop->destroyWindows();
 
 	// release the screen object back to the memory pool
-	MemoryPoolObject::deleteInstance(currentTop);
+	deleteInstance(currentTop);
 
 	// run the init for the new top of the stack if present
 	WindowLayout *newTop = top();
@@ -707,7 +707,7 @@ void Shell::shutdownComplete( WindowLayout *screen, Bool impendingPush )
 		if(m_background)
 		{
 			m_background->destroyWindows();
-			MemoryPoolObject::deleteInstance(m_background);
+			deleteInstance(m_background);
 			m_background = NULL;
 			m_clearBackground = FALSE;
 		}
@@ -834,7 +834,7 @@ WindowLayout *Shell::getOptionsLayout( Bool create )
 void Shell::destroyOptionsLayout() {
 	if (m_optionsLayout != NULL) {
 		m_optionsLayout->destroyWindows();
-		MemoryPoolObject::deleteInstance(m_optionsLayout);
+		deleteInstance(m_optionsLayout);
 		m_optionsLayout = NULL;
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -570,7 +570,7 @@ void GameClient::update( void )
 
 
 					legal->destroyWindows();
-					MemoryPoolObject::deleteInstance(legal);
+					deleteInstance(legal);
 
 				}
 				TheWritableGlobalData->m_breakTheMovie = TRUE;
@@ -850,7 +850,7 @@ void GameClient::destroyDrawable( Drawable *draw )
 	removeDrawableFromLookupTable( draw );
 
 	// free storage
-	MemoryPoolObject::deleteInstance(draw);
+	deleteInstance(draw);
 
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -570,7 +570,7 @@ void GameClient::update( void )
 
 
 					legal->destroyWindows();
-					legal->deleteInstance();
+					MemoryPoolObject::deleteInstance(legal);
 
 				}
 				TheWritableGlobalData->m_breakTheMovie = TRUE;
@@ -850,7 +850,7 @@ void GameClient::destroyDrawable( Drawable *draw )
 	removeDrawableFromLookupTable( draw );
 
 	// free storage
-	draw->deleteInstance();
+	MemoryPoolObject::deleteInstance(draw);
 
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -618,7 +618,7 @@ Bool InGameUI::removeSuperweapon(Int playerIndex, const AsciiString& powerName, 
 			{
 				SuperweaponInfo *info = *listIt;
 				swList.erase(listIt);
-				info->deleteInstance();
+				MemoryPoolObject::deleteInstance(info);
 				if (swList.size() == 0)
 				{
 					m_superweapons[playerIndex].erase(mapIt);
@@ -758,7 +758,7 @@ void InGameUI::removeNamedTimer( const AsciiString& timerName )
 	if (mapIt != m_namedTimers.end())
 	{
 		TheDisplayStringManager->freeDisplayString( mapIt->second->displayString );
-		mapIt->second->deleteInstance();
+		MemoryPoolObject::deleteInstance(mapIt->second);
 		m_namedTimers.erase(mapIt);
 		return;
 	}
@@ -1932,7 +1932,7 @@ void InGameUI::reset( void )
 			for (SuperweaponList::iterator listIt = mapIt->second.begin(); listIt != mapIt->second.end(); ++listIt)
 			{
 				SuperweaponInfo *info = *listIt;
-				info->deleteInstance();
+				MemoryPoolObject::deleteInstance(info);
 			}
 			mapIt->second.clear();
 		}
@@ -1943,7 +1943,7 @@ void InGameUI::reset( void )
 	{
 		NamedTimerInfo *info = timerIt->second;
 		TheDisplayStringManager->freeDisplayString(info->displayString);
-		info->deleteInstance();
+		MemoryPoolObject::deleteInstance(info);
 	}
 	m_namedTimers.clear();
 	m_namedTimerLastFlashFrame = 0;
@@ -5103,7 +5103,7 @@ void InGameUI::updateFloatingText( void )
 			if( a <= 0)
 			{
 				it = m_floatingTextList.erase(it);
-				ftd->deleteInstance();
+				MemoryPoolObject::deleteInstance(ftd);
 				continue; // don't do the ++it below
 			}
 
@@ -5165,7 +5165,7 @@ void InGameUI::clearFloatingText( void )
 	{
 		ftd = *it;
 		it = m_floatingTextList.erase(it);
-		ftd->deleteInstance();
+		MemoryPoolObject::deleteInstance(ftd);
 	}
 	
 }
@@ -5230,12 +5230,12 @@ void InGameUI::clearPopupMessageData( void )
 	if(m_popupMessageData->layout)
 	{
 		m_popupMessageData->layout->destroyWindows();
-		m_popupMessageData->layout->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_popupMessageData->layout);
 		m_popupMessageData->layout = NULL;
 	}
 	if( m_popupMessageData->pause )
 		TheGameLogic->setGamePaused(FALSE, m_popupMessageData->pauseMusic);
-	m_popupMessageData->deleteInstance();
+	MemoryPoolObject::deleteInstance(m_popupMessageData);
 	m_popupMessageData = NULL;
 	
 }
@@ -5342,7 +5342,7 @@ void InGameUI::clearWorldAnimations( void )
 		{
 
 			// delete the animation instance
-			wad->m_anim->deleteInstance();
+			MemoryPoolObject::deleteInstance(wad->m_anim);
 
 			// delete the world animation data
 			delete wad;
@@ -5385,7 +5385,7 @@ void InGameUI::updateAndDrawWorldAnimations( void )
 			{
 
 				// delete this element and continue
-				wad->m_anim->deleteInstance();
+				MemoryPoolObject::deleteInstance(wad->m_anim);
 				delete wad;
 				it = m_worldAnimationList.erase( it );
 				continue;
@@ -5656,7 +5656,7 @@ void InGameUI::recreateControlBar( void )
 {
 	GameWindow *win = TheWindowManager->winGetWindowFromId(NULL, TheNameKeyGenerator->nameToKey(AsciiString("ControlBar.wnd")));
 	if(win)
-		win->deleteInstance();
+		MemoryPoolObject::deleteInstance(win);
 	
 	m_idleWorkerWin = NULL;	
 	

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -618,7 +618,7 @@ Bool InGameUI::removeSuperweapon(Int playerIndex, const AsciiString& powerName, 
 			{
 				SuperweaponInfo *info = *listIt;
 				swList.erase(listIt);
-				MemoryPoolObject::deleteInstance(info);
+				deleteInstance(info);
 				if (swList.size() == 0)
 				{
 					m_superweapons[playerIndex].erase(mapIt);
@@ -758,7 +758,7 @@ void InGameUI::removeNamedTimer( const AsciiString& timerName )
 	if (mapIt != m_namedTimers.end())
 	{
 		TheDisplayStringManager->freeDisplayString( mapIt->second->displayString );
-		MemoryPoolObject::deleteInstance(mapIt->second);
+		deleteInstance(mapIt->second);
 		m_namedTimers.erase(mapIt);
 		return;
 	}
@@ -1932,7 +1932,7 @@ void InGameUI::reset( void )
 			for (SuperweaponList::iterator listIt = mapIt->second.begin(); listIt != mapIt->second.end(); ++listIt)
 			{
 				SuperweaponInfo *info = *listIt;
-				MemoryPoolObject::deleteInstance(info);
+				deleteInstance(info);
 			}
 			mapIt->second.clear();
 		}
@@ -1943,7 +1943,7 @@ void InGameUI::reset( void )
 	{
 		NamedTimerInfo *info = timerIt->second;
 		TheDisplayStringManager->freeDisplayString(info->displayString);
-		MemoryPoolObject::deleteInstance(info);
+		deleteInstance(info);
 	}
 	m_namedTimers.clear();
 	m_namedTimerLastFlashFrame = 0;
@@ -5103,7 +5103,7 @@ void InGameUI::updateFloatingText( void )
 			if( a <= 0)
 			{
 				it = m_floatingTextList.erase(it);
-				MemoryPoolObject::deleteInstance(ftd);
+				deleteInstance(ftd);
 				continue; // don't do the ++it below
 			}
 
@@ -5165,7 +5165,7 @@ void InGameUI::clearFloatingText( void )
 	{
 		ftd = *it;
 		it = m_floatingTextList.erase(it);
-		MemoryPoolObject::deleteInstance(ftd);
+		deleteInstance(ftd);
 	}
 	
 }
@@ -5230,12 +5230,12 @@ void InGameUI::clearPopupMessageData( void )
 	if(m_popupMessageData->layout)
 	{
 		m_popupMessageData->layout->destroyWindows();
-		MemoryPoolObject::deleteInstance(m_popupMessageData->layout);
+		deleteInstance(m_popupMessageData->layout);
 		m_popupMessageData->layout = NULL;
 	}
 	if( m_popupMessageData->pause )
 		TheGameLogic->setGamePaused(FALSE, m_popupMessageData->pauseMusic);
-	MemoryPoolObject::deleteInstance(m_popupMessageData);
+	deleteInstance(m_popupMessageData);
 	m_popupMessageData = NULL;
 	
 }
@@ -5342,7 +5342,7 @@ void InGameUI::clearWorldAnimations( void )
 		{
 
 			// delete the animation instance
-			MemoryPoolObject::deleteInstance(wad->m_anim);
+			deleteInstance(wad->m_anim);
 
 			// delete the world animation data
 			delete wad;
@@ -5385,7 +5385,7 @@ void InGameUI::updateAndDrawWorldAnimations( void )
 			{
 
 				// delete this element and continue
-				MemoryPoolObject::deleteInstance(wad->m_anim);
+				deleteInstance(wad->m_anim);
 				delete wad;
 				it = m_worldAnimationList.erase( it );
 				continue;
@@ -5656,7 +5656,7 @@ void InGameUI::recreateControlBar( void )
 {
 	GameWindow *win = TheWindowManager->winGetWindowFromId(NULL, TheNameKeyGenerator->nameToKey(AsciiString("ControlBar.wnd")));
 	if(win)
-		MemoryPoolObject::deleteInstance(win);
+		deleteInstance(win);
 	
 	m_idleWorkerWin = NULL;	
 	

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MapUtil.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MapUtil.cpp
@@ -171,7 +171,7 @@ static Bool ParseObjectDataChunk(DataChunkInput &file, DataChunkInfo *info, void
 		m_supplyPositions.push_back(loc);
 	}
 
-	MemoryPoolObject::deleteInstance(pThisOne);
+	deleteInstance(pThisOne);
 	return TRUE;
 }
 
@@ -1236,7 +1236,7 @@ Image *getMapPreviewImage( AsciiString mapName )
 	Region2D uv;
 	mapPreviewImage = TheMappedImageCollection->findImageByName("MapPreview");
 	if(mapPreviewImage)
-		MemoryPoolObject::deleteInstance(mapPreviewImage);
+		deleteInstance(mapPreviewImage);
 	
 	mapPreviewImage = TheMappedImageCollection->newImage();
 	mapPreviewImage->setName("MapPreview");
@@ -1267,7 +1267,7 @@ Image *getMapPreviewImage( AsciiString mapName )
 			file.registerParser( AsciiString("MapPreview"), AsciiString::TheEmptyString, parseMapPreviewChunk );
 			if (!file.parse(NULL)) {
 				DEBUG_ASSERTCRASH(false,("Unable to read MapPreview info."));
-				MemoryPoolObject::deleteInstance(mapPreviewImage);
+				deleteInstance(mapPreviewImage);
 				return NULL;
 			}
 		}
@@ -1275,7 +1275,7 @@ Image *getMapPreviewImage( AsciiString mapName )
 	}
 	else
 	{
-		MemoryPoolObject::deleteInstance(mapPreviewImage);
+		deleteInstance(mapPreviewImage);
 		return NULL;
 	}
 	

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MapUtil.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MapUtil.cpp
@@ -171,7 +171,7 @@ static Bool ParseObjectDataChunk(DataChunkInput &file, DataChunkInfo *info, void
 		m_supplyPositions.push_back(loc);
 	}
 
-	pThisOne->deleteInstance();
+	MemoryPoolObject::deleteInstance(pThisOne);
 	return TRUE;
 }
 
@@ -1236,7 +1236,7 @@ Image *getMapPreviewImage( AsciiString mapName )
 	Region2D uv;
 	mapPreviewImage = TheMappedImageCollection->findImageByName("MapPreview");
 	if(mapPreviewImage)
-		mapPreviewImage->deleteInstance();
+		MemoryPoolObject::deleteInstance(mapPreviewImage);
 	
 	mapPreviewImage = TheMappedImageCollection->newImage();
 	mapPreviewImage->setName("MapPreview");
@@ -1267,7 +1267,7 @@ Image *getMapPreviewImage( AsciiString mapName )
 			file.registerParser( AsciiString("MapPreview"), AsciiString::TheEmptyString, parseMapPreviewChunk );
 			if (!file.parse(NULL)) {
 				DEBUG_ASSERTCRASH(false,("Unable to read MapPreview info."));
-				mapPreviewImage->deleteInstance();
+				MemoryPoolObject::deleteInstance(mapPreviewImage);
 				return NULL;
 			}
 		}
@@ -1275,7 +1275,7 @@ Image *getMapPreviewImage( AsciiString mapName )
 	}
 	else
 	{
-		mapPreviewImage->deleteInstance();
+		MemoryPoolObject::deleteInstance(mapPreviewImage);
 		return NULL;
 	}
 	

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/MetaEvent.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/MetaEvent.cpp
@@ -660,7 +660,7 @@ MetaMap::~MetaMap()
 	while (m_metaMaps)
 	{
 		MetaMapRec *next = m_metaMaps->m_next;
-		m_metaMaps->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_metaMaps);
 		m_metaMaps = next;
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/MetaEvent.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/MetaEvent.cpp
@@ -660,7 +660,7 @@ MetaMap::~MetaMap()
 	while (m_metaMaps)
 	{
 		MetaMapRec *next = m_metaMaps->m_next;
-		MemoryPoolObject::deleteInstance(m_metaMaps);
+		deleteInstance(m_metaMaps);
 		m_metaMaps = next;
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Snow.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Snow.cpp
@@ -103,7 +103,7 @@ SnowManager::~SnowManager()
 	// TheSuperHackers @fix Mauller 13/04/2025 Delete the instance of the weather settings
 	if (TheWeatherSetting)
 	{
-		MemoryPoolObject::deleteInstance(((WeatherSetting*)TheWeatherSetting.getNonOverloadedPointer()));
+		deleteInstance((WeatherSetting*)TheWeatherSetting.getNonOverloadedPointer());
 		TheWeatherSetting=NULL;
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Snow.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Snow.cpp
@@ -103,7 +103,7 @@ SnowManager::~SnowManager()
 	// TheSuperHackers @fix Mauller 13/04/2025 Delete the instance of the weather settings
 	if (TheWeatherSetting)
 	{
-		((WeatherSetting*)TheWeatherSetting.getNonOverloadedPointer())->deleteInstance();
+		MemoryPoolObject::deleteInstance(((WeatherSetting*)TheWeatherSetting.getNonOverloadedPointer()));
 		TheWeatherSetting=NULL;
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/System/Anim2D.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/System/Anim2D.cpp
@@ -744,7 +744,7 @@ Anim2DCollection::~Anim2DCollection( void )
 		nextTemplate = m_templateList->friend_getNextTemplate();
 
 		// delete this template
-		m_templateList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_templateList);
 
 		// set the head of our list to the next template
 		m_templateList = nextTemplate;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/System/Anim2D.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/System/Anim2D.cpp
@@ -744,7 +744,7 @@ Anim2DCollection::~Anim2DCollection( void )
 		nextTemplate = m_templateList->friend_getNextTemplate();
 
 		// delete this template
-		MemoryPoolObject::deleteInstance(m_templateList);
+		deleteInstance(m_templateList);
 
 		// set the head of our list to the next template
 		m_templateList = nextTemplate;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/System/CampaignManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/System/CampaignManager.cpp
@@ -136,7 +136,7 @@ Campaign::~Campaign( void )
 		Mission *mission = *it;
 		it = m_missions.erase( it );
 		if(mission)
-			MemoryPoolObject::deleteInstance(mission);
+			deleteInstance(mission);
 	}
 }
 
@@ -157,7 +157,7 @@ Mission *Campaign::newMission( AsciiString name )
 		if(mission->m_name.compare(name) == 0)
 		{
 			m_missions.erase( it );
-			MemoryPoolObject::deleteInstance(mission);
+			deleteInstance(mission);
 			break;
 		}
 		else
@@ -242,7 +242,7 @@ CampaignManager::~CampaignManager( void )
 		Campaign *campaign = *it;
 		it = m_campaignList.erase( it );
 		if(campaign)
-			MemoryPoolObject::deleteInstance(campaign);
+			deleteInstance(campaign);
 	}
 }
 
@@ -404,7 +404,7 @@ Campaign *CampaignManager::newCampaign(AsciiString name)
 		if(campaign->m_name.compare(name) == 0)
 		{
 			m_campaignList.erase( it );
-			MemoryPoolObject::deleteInstance(campaign);
+			deleteInstance(campaign);
 			break;
 		}
 		else

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/System/CampaignManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/System/CampaignManager.cpp
@@ -136,7 +136,7 @@ Campaign::~Campaign( void )
 		Mission *mission = *it;
 		it = m_missions.erase( it );
 		if(mission)
-			mission->deleteInstance();
+			MemoryPoolObject::deleteInstance(mission);
 	}
 }
 
@@ -157,7 +157,7 @@ Mission *Campaign::newMission( AsciiString name )
 		if(mission->m_name.compare(name) == 0)
 		{
 			m_missions.erase( it );
-			mission->deleteInstance();
+			MemoryPoolObject::deleteInstance(mission);
 			break;
 		}
 		else
@@ -242,7 +242,7 @@ CampaignManager::~CampaignManager( void )
 		Campaign *campaign = *it;
 		it = m_campaignList.erase( it );
 		if(campaign)
-			campaign->deleteInstance();
+			MemoryPoolObject::deleteInstance(campaign);
 	}
 }
 
@@ -404,7 +404,7 @@ Campaign *CampaignManager::newCampaign(AsciiString name)
 		if(campaign->m_name.compare(name) == 0)
 		{
 			m_campaignList.erase( it );
-			campaign->deleteInstance();
+			MemoryPoolObject::deleteInstance(campaign);
 			break;
 		}
 		else

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/System/Image.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/System/Image.cpp
@@ -205,7 +205,7 @@ ImageCollection::ImageCollection( void )
 ImageCollection::~ImageCollection( void )
 {
   for (std::map<unsigned,Image *>::iterator i=m_imageMap.begin();i!=m_imageMap.end();++i)
-    MemoryPoolObject::deleteInstance(i->second);
+    deleteInstance(i->second);
 }  // end ~ImageCollection
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/System/Image.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/System/Image.cpp
@@ -205,7 +205,7 @@ ImageCollection::ImageCollection( void )
 ImageCollection::~ImageCollection( void )
 {
   for (std::map<unsigned,Image *>::iterator i=m_imageMap.begin();i!=m_imageMap.end();++i)
-    i->second->deleteInstance();
+    MemoryPoolObject::deleteInstance(i->second);
 }  // end ~ImageCollection
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/System/ParticleSys.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/System/ParticleSys.cpp
@@ -1215,7 +1215,7 @@ ParticleSystem::~ParticleSystem()
 
 	// destroy all particles "in the air"
 	while (m_systemParticlesHead)
-		MemoryPoolObject::deleteInstance(m_systemParticlesHead);
+		deleteInstance(m_systemParticlesHead);
 
 	m_attachedToDrawableID = INVALID_DRAWABLE_ID;
 	m_attachedToObjectID = INVALID_ID;
@@ -2072,7 +2072,7 @@ Bool ParticleSystem::update( Int localPlayerIndex  )
 		{
 			oldParticle = p;
 			p = p->m_systemNext;
-			MemoryPoolObject::deleteInstance(oldParticle);
+			deleteInstance(oldParticle);
 		} else {
 			p = p->m_systemNext;
 		}
@@ -2860,7 +2860,7 @@ ParticleSystemManager::~ParticleSystemManager()
 	TemplateMap::iterator begin(m_templateMap.begin());
 	TemplateMap::iterator end(m_templateMap.end());
 	for (; begin != end; ++begin) {
-		MemoryPoolObject::deleteInstance((*begin).second);
+		deleteInstance((*begin).second);
 	}
 }
 
@@ -2896,7 +2896,7 @@ void ParticleSystemManager::reset( void )
 {
 	while (getParticleSystemCount()) {
 		if (m_allParticleSystemList.front()) {
-			MemoryPoolObject::deleteInstance(m_allParticleSystemList.front());
+			deleteInstance(m_allParticleSystemList.front());
 		}
 	}
 
@@ -2950,7 +2950,7 @@ void ParticleSystemManager::update( void )
 		if (sys->update(m_localPlayerIndex) == false)
 		{
 			++it;
-			MemoryPoolObject::deleteInstance(sys);
+			deleteInstance(sys);
 		} else {
 			++it;
 		}
@@ -3053,7 +3053,7 @@ ParticleSystemTemplate *ParticleSystemManager::newTemplate( const AsciiString &n
 		sysTemplate = newInstance(ParticleSystemTemplate)( name );
 
 		if (! m_templateMap.insert(std::make_pair(name, sysTemplate)).second) {
-			MemoryPoolObject::deleteInstance(sysTemplate);
+			deleteInstance(sysTemplate);
 			sysTemplate = NULL;
 		}
 	}
@@ -3214,7 +3214,7 @@ Int ParticleSystemManager::removeOldestParticles( UnsignedInt count,
 		{
 			if( m_allParticlesHead[ i ] ) 
 			{
-				MemoryPoolObject::deleteInstance(m_allParticlesHead[ i ]);
+				deleteInstance(m_allParticlesHead[ i ]);
 				break;  // exit for
 			}
 		}

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/System/ParticleSys.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/System/ParticleSys.cpp
@@ -1215,7 +1215,7 @@ ParticleSystem::~ParticleSystem()
 
 	// destroy all particles "in the air"
 	while (m_systemParticlesHead)
-		m_systemParticlesHead->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_systemParticlesHead);
 
 	m_attachedToDrawableID = INVALID_DRAWABLE_ID;
 	m_attachedToObjectID = INVALID_ID;
@@ -2072,7 +2072,7 @@ Bool ParticleSystem::update( Int localPlayerIndex  )
 		{
 			oldParticle = p;
 			p = p->m_systemNext;
-			oldParticle->deleteInstance();
+			MemoryPoolObject::deleteInstance(oldParticle);
 		} else {
 			p = p->m_systemNext;
 		}
@@ -2860,7 +2860,7 @@ ParticleSystemManager::~ParticleSystemManager()
 	TemplateMap::iterator begin(m_templateMap.begin());
 	TemplateMap::iterator end(m_templateMap.end());
 	for (; begin != end; ++begin) {
-		(*begin).second->deleteInstance();
+		MemoryPoolObject::deleteInstance((*begin).second);
 	}
 }
 
@@ -2896,7 +2896,7 @@ void ParticleSystemManager::reset( void )
 {
 	while (getParticleSystemCount()) {
 		if (m_allParticleSystemList.front()) {
-			m_allParticleSystemList.front()->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_allParticleSystemList.front());
 		}
 	}
 
@@ -2950,7 +2950,7 @@ void ParticleSystemManager::update( void )
 		if (sys->update(m_localPlayerIndex) == false)
 		{
 			++it;
-			sys->deleteInstance();
+			MemoryPoolObject::deleteInstance(sys);
 		} else {
 			++it;
 		}
@@ -3053,7 +3053,7 @@ ParticleSystemTemplate *ParticleSystemManager::newTemplate( const AsciiString &n
 		sysTemplate = newInstance(ParticleSystemTemplate)( name );
 
 		if (! m_templateMap.insert(std::make_pair(name, sysTemplate)).second) {
-			sysTemplate->deleteInstance();
+			MemoryPoolObject::deleteInstance(sysTemplate);
 			sysTemplate = NULL;
 		}
 	}
@@ -3214,7 +3214,7 @@ Int ParticleSystemManager::removeOldestParticles( UnsignedInt count,
 		{
 			if( m_allParticlesHead[ i ] ) 
 			{
-				m_allParticlesHead[ i ]->deleteInstance();
+				MemoryPoolObject::deleteInstance(m_allParticlesHead[ i ]);
 				break;  // exit for
 			}
 		}

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Terrain/TerrainRoads.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Terrain/TerrainRoads.cpp
@@ -258,7 +258,7 @@ TerrainRoadCollection::~TerrainRoadCollection( void )
 		temp = m_roadList->friend_getNext();
 
 		// delete this road
-		MemoryPoolObject::deleteInstance(m_roadList);
+		deleteInstance(m_roadList);
 
 		// set the new head of the list
 		m_roadList = temp;
@@ -273,7 +273,7 @@ TerrainRoadCollection::~TerrainRoadCollection( void )
 		temp = m_bridgeList->friend_getNext();
 
 		// delete this bridge
-		MemoryPoolObject::deleteInstance(m_bridgeList);
+		deleteInstance(m_bridgeList);
 
 		// set the new head of the list
 		m_bridgeList = temp;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Terrain/TerrainRoads.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Terrain/TerrainRoads.cpp
@@ -258,7 +258,7 @@ TerrainRoadCollection::~TerrainRoadCollection( void )
 		temp = m_roadList->friend_getNext();
 
 		// delete this road
-		m_roadList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_roadList);
 
 		// set the new head of the list
 		m_roadList = temp;
@@ -273,7 +273,7 @@ TerrainRoadCollection::~TerrainRoadCollection( void )
 		temp = m_bridgeList->friend_getNext();
 
 		// delete this bridge
-		m_bridgeList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_bridgeList);
 
 		// set the new head of the list
 		m_bridgeList = temp;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AI.cpp
@@ -69,11 +69,11 @@ void TAiData::addFactionBuildList(AISideBuildList *buildList)
 	while (info) {
 		if (buildList->m_side == info->m_side) {
 			if (info->m_buildList)
-				info->m_buildList->deleteInstance();
+				MemoryPoolObject::deleteInstance(info->m_buildList);
 			info->m_buildList = buildList->m_buildList;
 			buildList->m_buildList = NULL;
 			buildList->m_next = NULL;
-			buildList->deleteInstance();
+			MemoryPoolObject::deleteInstance(buildList);
 			return;
 		}
 		info = info->m_next;
@@ -89,7 +89,7 @@ TAiData::~TAiData()
 	while (info) { 
 		AISideInfo *cur = info;
 		info = info->m_next;
-		cur->deleteInstance();
+		MemoryPoolObject::deleteInstance(cur);
 	}
 
 	AISideBuildList *build = m_sideBuildLists;
@@ -97,7 +97,7 @@ TAiData::~TAiData()
 	while (build) { 
 		AISideBuildList *cur = build;
 		build = build->m_next;
-		cur->deleteInstance();
+		MemoryPoolObject::deleteInstance(cur);
 	}
 
 }
@@ -115,7 +115,7 @@ AISideBuildList::AISideBuildList( AsciiString side ) :
 AISideBuildList::~AISideBuildList()
 {
 	if (m_buildList) {
-		m_buildList->deleteInstance(); // note - deletes all in the list.
+		MemoryPoolObject::deleteInstance(m_buildList); // note - deletes all in the list.
 	}
 	m_buildList = NULL;
 }
@@ -474,7 +474,7 @@ void AI::destroyGroup( AIGroup *group )
 	m_groupList.erase( i );
 
 	// destroy group
-	group->deleteInstance();
+	MemoryPoolObject::deleteInstance(group);
 }
 
 /**

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AI.cpp
@@ -69,11 +69,11 @@ void TAiData::addFactionBuildList(AISideBuildList *buildList)
 	while (info) {
 		if (buildList->m_side == info->m_side) {
 			if (info->m_buildList)
-				MemoryPoolObject::deleteInstance(info->m_buildList);
+				deleteInstance(info->m_buildList);
 			info->m_buildList = buildList->m_buildList;
 			buildList->m_buildList = NULL;
 			buildList->m_next = NULL;
-			MemoryPoolObject::deleteInstance(buildList);
+			deleteInstance(buildList);
 			return;
 		}
 		info = info->m_next;
@@ -89,7 +89,7 @@ TAiData::~TAiData()
 	while (info) { 
 		AISideInfo *cur = info;
 		info = info->m_next;
-		MemoryPoolObject::deleteInstance(cur);
+		deleteInstance(cur);
 	}
 
 	AISideBuildList *build = m_sideBuildLists;
@@ -97,7 +97,7 @@ TAiData::~TAiData()
 	while (build) { 
 		AISideBuildList *cur = build;
 		build = build->m_next;
-		MemoryPoolObject::deleteInstance(cur);
+		deleteInstance(cur);
 	}
 
 }
@@ -115,7 +115,7 @@ AISideBuildList::AISideBuildList( AsciiString side ) :
 AISideBuildList::~AISideBuildList()
 {
 	if (m_buildList) {
-		MemoryPoolObject::deleteInstance(m_buildList); // note - deletes all in the list.
+		deleteInstance(m_buildList); // note - deletes all in the list.
 	}
 	m_buildList = NULL;
 }
@@ -474,7 +474,7 @@ void AI::destroyGroup( AIGroup *group )
 	m_groupList.erase( i );
 
 	// destroy group
-	MemoryPoolObject::deleteInstance(group);
+	deleteInstance(group);
 }
 
 /**

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
@@ -107,7 +107,7 @@ AIGroup::~AIGroup()
 		}
 	}
 	if (m_groundPath) {
-		m_groundPath->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_groundPath);
 		m_groundPath = NULL;
 	}
 	//DEBUG_LOG(( "AIGroup #%d destroyed\n", m_id ));
@@ -409,7 +409,7 @@ void AIGroup::recompute( void )
 	getCenter( &center );
 
 	if (m_groundPath) {
-		m_groundPath->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_groundPath);
 		m_groundPath = NULL;
 	}
 
@@ -714,7 +714,7 @@ Bool AIGroup::friend_moveInfantryToPos( const Coord3D *pos, CommandSourceType cm
 		}
 	}
 	if (startNode==NULL || endNode==NULL) {
-		m_groundPath->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_groundPath);
 		m_groundPath = NULL;
 		return false;
 	}
@@ -1076,7 +1076,7 @@ void AIGroup::friend_moveFormationToPos( const Coord3D *pos, CommandSourceType c
 			tmpNode = tmpNode->getNextOptimized();
 		}
 		if (startNode==NULL || endNode==NULL) {
-			m_groundPath->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_groundPath);
 			m_groundPath = NULL;
 			startNode = NULL;
 			endNode = NULL;
@@ -1183,7 +1183,7 @@ Bool AIGroup::friend_moveVehicleToPos( const Coord3D *pos, CommandSourceType cmd
 		endNode = NULL;
 	}
 	if (startNode==NULL || endNode==NULL) {
-		m_groundPath->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_groundPath);
 		m_groundPath = NULL;
 		return false;
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
@@ -107,7 +107,7 @@ AIGroup::~AIGroup()
 		}
 	}
 	if (m_groundPath) {
-		MemoryPoolObject::deleteInstance(m_groundPath);
+		deleteInstance(m_groundPath);
 		m_groundPath = NULL;
 	}
 	//DEBUG_LOG(( "AIGroup #%d destroyed\n", m_id ));
@@ -409,7 +409,7 @@ void AIGroup::recompute( void )
 	getCenter( &center );
 
 	if (m_groundPath) {
-		MemoryPoolObject::deleteInstance(m_groundPath);
+		deleteInstance(m_groundPath);
 		m_groundPath = NULL;
 	}
 
@@ -714,7 +714,7 @@ Bool AIGroup::friend_moveInfantryToPos( const Coord3D *pos, CommandSourceType cm
 		}
 	}
 	if (startNode==NULL || endNode==NULL) {
-		MemoryPoolObject::deleteInstance(m_groundPath);
+		deleteInstance(m_groundPath);
 		m_groundPath = NULL;
 		return false;
 	}
@@ -1076,7 +1076,7 @@ void AIGroup::friend_moveFormationToPos( const Coord3D *pos, CommandSourceType c
 			tmpNode = tmpNode->getNextOptimized();
 		}
 		if (startNode==NULL || endNode==NULL) {
-			MemoryPoolObject::deleteInstance(m_groundPath);
+			deleteInstance(m_groundPath);
 			m_groundPath = NULL;
 			startNode = NULL;
 			endNode = NULL;
@@ -1183,7 +1183,7 @@ Bool AIGroup::friend_moveVehicleToPos( const Coord3D *pos, CommandSourceType cmd
 		endNode = NULL;
 	}
 	if (startNode==NULL || endNode==NULL) {
-		MemoryPoolObject::deleteInstance(m_groundPath);
+		deleteInstance(m_groundPath);
 		m_groundPath = NULL;
 		return false;
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGuard.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGuard.cpp
@@ -462,13 +462,13 @@ void AIGuardInnerState::onExit( StateExitType status )
 	if (m_attackState) 
 	{
 		m_attackState->onExit(status);
-		m_attackState->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_attackState);
 		m_attackState = NULL;
 	}
 	else if (m_enterState)
 	{
 		m_enterState->onExit(status);
-		m_enterState->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_enterState);
 		m_enterState = NULL;
 	}
 	
@@ -590,7 +590,7 @@ void AIGuardOuterState::onExit( StateExitType status )
 	if (m_attackState) 
 	{
 		m_attackState->onExit(status);
-		m_attackState->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_attackState);
 		m_attackState = NULL;
 	}
 }
@@ -870,7 +870,7 @@ void AIGuardAttackAggressorState::onExit( StateExitType status )
 	if (m_attackState) 
 	{
 		m_attackState->onExit(status);
-		m_attackState->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_attackState);
 		m_attackState = NULL;
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGuard.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGuard.cpp
@@ -462,13 +462,13 @@ void AIGuardInnerState::onExit( StateExitType status )
 	if (m_attackState) 
 	{
 		m_attackState->onExit(status);
-		MemoryPoolObject::deleteInstance(m_attackState);
+		deleteInstance(m_attackState);
 		m_attackState = NULL;
 	}
 	else if (m_enterState)
 	{
 		m_enterState->onExit(status);
-		MemoryPoolObject::deleteInstance(m_enterState);
+		deleteInstance(m_enterState);
 		m_enterState = NULL;
 	}
 	
@@ -590,7 +590,7 @@ void AIGuardOuterState::onExit( StateExitType status )
 	if (m_attackState) 
 	{
 		m_attackState->onExit(status);
-		MemoryPoolObject::deleteInstance(m_attackState);
+		deleteInstance(m_attackState);
 		m_attackState = NULL;
 	}
 }
@@ -870,7 +870,7 @@ void AIGuardAttackAggressorState::onExit( StateExitType status )
 	if (m_attackState) 
 	{
 		m_attackState->onExit(status);
-		MemoryPoolObject::deleteInstance(m_attackState);
+		deleteInstance(m_attackState);
 		m_attackState = NULL;
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGuardRetaliate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGuardRetaliate.cpp
@@ -436,13 +436,13 @@ void AIGuardRetaliateInnerState::onExit( StateExitType status )
 	if (m_attackState) 
 	{
 		m_attackState->onExit(status);
-		m_attackState->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_attackState);
 		m_attackState = NULL;
 	}
 	else if (m_enterState)
 	{
 		m_enterState->onExit(status);
-		m_enterState->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_enterState);
 		m_enterState = NULL;
 	}
 	
@@ -549,7 +549,7 @@ void AIGuardRetaliateOuterState::onExit( StateExitType status )
 	if (m_attackState) 
 	{
 		m_attackState->onExit(status);
-		m_attackState->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_attackState);
 		m_attackState = NULL;
 	}
 }
@@ -826,7 +826,7 @@ void AIGuardRetaliateAttackAggressorState::onExit( StateExitType status )
 	if (m_attackState) 
 	{
 		m_attackState->onExit(status);
-		m_attackState->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_attackState);
 		m_attackState = NULL;
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGuardRetaliate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGuardRetaliate.cpp
@@ -436,13 +436,13 @@ void AIGuardRetaliateInnerState::onExit( StateExitType status )
 	if (m_attackState) 
 	{
 		m_attackState->onExit(status);
-		MemoryPoolObject::deleteInstance(m_attackState);
+		deleteInstance(m_attackState);
 		m_attackState = NULL;
 	}
 	else if (m_enterState)
 	{
 		m_enterState->onExit(status);
-		MemoryPoolObject::deleteInstance(m_enterState);
+		deleteInstance(m_enterState);
 		m_enterState = NULL;
 	}
 	
@@ -549,7 +549,7 @@ void AIGuardRetaliateOuterState::onExit( StateExitType status )
 	if (m_attackState) 
 	{
 		m_attackState->onExit(status);
-		MemoryPoolObject::deleteInstance(m_attackState);
+		deleteInstance(m_attackState);
 		m_attackState = NULL;
 	}
 }
@@ -826,7 +826,7 @@ void AIGuardRetaliateAttackAggressorState::onExit( StateExitType status )
 	if (m_attackState) 
 	{
 		m_attackState->onExit(status);
-		MemoryPoolObject::deleteInstance(m_attackState);
+		deleteInstance(m_attackState);
 		m_attackState = NULL;
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -264,7 +264,7 @@ Path::~Path( void )
 	for( node = m_path; node; node = nextNode )
 	{
 		nextNode = node->getNext();
-		node->deleteInstance();
+		MemoryPoolObject::deleteInstance(node);
 	}
 }
 
@@ -3877,7 +3877,7 @@ void Pathfinder::reset( void )
 	debugPathPos.z = 0.0f;
 
 	if (debugPath)
-		debugPath->deleteInstance();
+		MemoryPoolObject::deleteInstance(debugPath);
 
 	debugPath = NULL;
 	m_frameToShowObstacles = 0;
@@ -6402,7 +6402,7 @@ Path *Pathfinder::findPath( Object *obj, const LocomotorSet& locomotorSet, const
 	m_zoneManager.clearPassableFlags();
 	Path *hPat = findHierarchicalPath(isHuman, locomotorSet, from, rawTo, false);
 	if (hPat) {
-		hPat->deleteInstance();
+		MemoryPoolObject::deleteInstance(hPat);
 	}	else {
 		m_zoneManager.setAllPassable();
 	}
@@ -6444,11 +6444,11 @@ Path *Pathfinder::findPath( Object *obj, const LocomotorSet& locomotorSet, const
 					path->getFirstNode()->setCanOptimize(linkNode->getCanOptimize());
 					path->getFirstNode()->setNextOptimized(path->getFirstNode()->getNext());
 				}
-				linkPath->deleteInstance();
+				MemoryPoolObject::deleteInstance(linkPath);
 			}
 			prior = node;
 		}
-		pat->deleteInstance();
+		MemoryPoolObject::deleteInstance(pat);
 		path->optimize(obj, locomotorSet.getValidSurfaces(), false);
 		if (TheGlobalData->m_debugAI) {
 			setDebugPath(path);
@@ -7029,7 +7029,7 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 
 	Path *hPat = internal_findHierarchicalPath(isHuman, LOCOMOTORSURFACE_GROUND, from, rawTo, false, false);
 	if (hPat) {
-		hPat->deleteInstance();
+		MemoryPoolObject::deleteInstance(hPat);
 	}	else {
 		m_zoneManager.setAllPassable();
 	}
@@ -8161,7 +8161,7 @@ Bool Pathfinder::slowDoesPathExist( Object *obj,
 	m_ignoreObstacleID = INVALID_ID;
 	Bool found = (path!=NULL);
 	if (path) {
-		path->deleteInstance();
+		MemoryPoolObject::deleteInstance(path);
 		path = NULL;
 	}
 	return found;
@@ -8781,7 +8781,7 @@ Path *Pathfinder::findClosestPath( Object *obj, const LocomotorSet& locomotorSet
 		m_zoneManager.clearPassableFlags();
 		Path *hPat = findClosestHierarchicalPath(isHuman, locomotorSet, from, rawTo, false);
 		if (hPat) {
-			hPat->deleteInstance();
+			MemoryPoolObject::deleteInstance(hPat);
 			gotHierarchicalPath = true;
 		}	else {
 			m_zoneManager.setAllPassable();
@@ -9108,7 +9108,7 @@ void Pathfinder::setDebugPath(Path *newDebugpath)
 	{
 		// copy the path for debugging
 		if (debugPath)
-			debugPath->deleteInstance();
+			MemoryPoolObject::deleteInstance(debugPath);
 
 		debugPath = newInstance(Path);
 					
@@ -10664,7 +10664,7 @@ Path *Pathfinder::findAttackPath( const Object *obj, const LocomotorSet& locomot
 	m_zoneManager.clearPassableFlags();
 	Path *hPat = findClosestHierarchicalPath(isHuman, locomotorSet, from, victimPos, isCrusher);
 	if (hPat) {
-		hPat->deleteInstance();
+		MemoryPoolObject::deleteInstance(hPat);
 	}	else {
 		m_zoneManager.setAllPassable();
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -264,7 +264,7 @@ Path::~Path( void )
 	for( node = m_path; node; node = nextNode )
 	{
 		nextNode = node->getNext();
-		MemoryPoolObject::deleteInstance(node);
+		deleteInstance(node);
 	}
 }
 
@@ -3877,7 +3877,7 @@ void Pathfinder::reset( void )
 	debugPathPos.z = 0.0f;
 
 	if (debugPath)
-		MemoryPoolObject::deleteInstance(debugPath);
+		deleteInstance(debugPath);
 
 	debugPath = NULL;
 	m_frameToShowObstacles = 0;
@@ -6402,7 +6402,7 @@ Path *Pathfinder::findPath( Object *obj, const LocomotorSet& locomotorSet, const
 	m_zoneManager.clearPassableFlags();
 	Path *hPat = findHierarchicalPath(isHuman, locomotorSet, from, rawTo, false);
 	if (hPat) {
-		MemoryPoolObject::deleteInstance(hPat);
+		deleteInstance(hPat);
 	}	else {
 		m_zoneManager.setAllPassable();
 	}
@@ -6444,11 +6444,11 @@ Path *Pathfinder::findPath( Object *obj, const LocomotorSet& locomotorSet, const
 					path->getFirstNode()->setCanOptimize(linkNode->getCanOptimize());
 					path->getFirstNode()->setNextOptimized(path->getFirstNode()->getNext());
 				}
-				MemoryPoolObject::deleteInstance(linkPath);
+				deleteInstance(linkPath);
 			}
 			prior = node;
 		}
-		MemoryPoolObject::deleteInstance(pat);
+		deleteInstance(pat);
 		path->optimize(obj, locomotorSet.getValidSurfaces(), false);
 		if (TheGlobalData->m_debugAI) {
 			setDebugPath(path);
@@ -7029,7 +7029,7 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 
 	Path *hPat = internal_findHierarchicalPath(isHuman, LOCOMOTORSURFACE_GROUND, from, rawTo, false, false);
 	if (hPat) {
-		MemoryPoolObject::deleteInstance(hPat);
+		deleteInstance(hPat);
 	}	else {
 		m_zoneManager.setAllPassable();
 	}
@@ -8161,7 +8161,7 @@ Bool Pathfinder::slowDoesPathExist( Object *obj,
 	m_ignoreObstacleID = INVALID_ID;
 	Bool found = (path!=NULL);
 	if (path) {
-		MemoryPoolObject::deleteInstance(path);
+		deleteInstance(path);
 		path = NULL;
 	}
 	return found;
@@ -8781,7 +8781,7 @@ Path *Pathfinder::findClosestPath( Object *obj, const LocomotorSet& locomotorSet
 		m_zoneManager.clearPassableFlags();
 		Path *hPat = findClosestHierarchicalPath(isHuman, locomotorSet, from, rawTo, false);
 		if (hPat) {
-			MemoryPoolObject::deleteInstance(hPat);
+			deleteInstance(hPat);
 			gotHierarchicalPath = true;
 		}	else {
 			m_zoneManager.setAllPassable();
@@ -9108,7 +9108,7 @@ void Pathfinder::setDebugPath(Path *newDebugpath)
 	{
 		// copy the path for debugging
 		if (debugPath)
-			MemoryPoolObject::deleteInstance(debugPath);
+			deleteInstance(debugPath);
 
 		debugPath = newInstance(Path);
 					
@@ -10664,7 +10664,7 @@ Path *Pathfinder::findAttackPath( const Object *obj, const LocomotorSet& locomot
 	m_zoneManager.clearPassableFlags();
 	Path *hPat = findClosestHierarchicalPath(isHuman, locomotorSet, from, victimPos, isCrusher);
 	if (hPat) {
-		MemoryPoolObject::deleteInstance(hPat);
+		deleteInstance(hPat);
 	}	else {
 		m_zoneManager.setAllPassable();
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -436,7 +436,7 @@ static void deleteQueue(TeamInQueue* o)
 {
 	if (o)
 	{
-		o->deleteInstance();
+		MemoryPoolObject::deleteInstance(o);
 	}
 }
 
@@ -866,7 +866,7 @@ void AIPlayer::aiPreTeamDestroy( const Team *deletedTeam )
 			if (team->m_team == deletedTeam) {
 				// The members of the team all got killed before we could finish building the team.
 				removeFrom_TeamBuildQueue(team);
-				team->deleteInstance();
+				MemoryPoolObject::deleteInstance(team);
 				iter = iterate_TeamBuildQueue();
 			}
 		}
@@ -878,7 +878,7 @@ void AIPlayer::aiPreTeamDestroy( const Team *deletedTeam )
 			if (team->m_team == deletedTeam) {
 				// The members of the team all got killed before we could activate the team.
 				removeFrom_TeamReadyQueue(team);
-				team->deleteInstance();
+				MemoryPoolObject::deleteInstance(team);
 				iter = iterate_TeamReadyQueue();
 			}
 		}
@@ -2634,7 +2634,7 @@ void AIPlayer::recruitSpecificAITeam(TeamPrototype *teamProto, Real recruitRadiu
 		}	else {
 			//disband.
 			if (!theTeam->getPrototype()->getIsSingleton()) {
-				theTeam->deleteInstance();
+				MemoryPoolObject::deleteInstance(theTeam);
 				theTeam = NULL;
 			}
 			AsciiString teamName = teamProto->getName();
@@ -2826,7 +2826,7 @@ void AIPlayer::checkReadyTeams( void )
 						TheScriptEngine->AppendDebugMessage(teamName, false);
 					}
 				}
-				team->deleteInstance();
+				MemoryPoolObject::deleteInstance(team);
 				iter = iterate_TeamReadyQueue();
 			}																		 
 		}
@@ -2858,7 +2858,7 @@ void AIPlayer::checkQueuedTeams( void )
 					// Disband.
 					removeFrom_TeamBuildQueue(team);
 					team->disband();
-					team->deleteInstance();
+					MemoryPoolObject::deleteInstance(team);
 					if (isSkirmishAI()) {
 						TheScriptEngine->clearTeamFlags();
 					}
@@ -3489,7 +3489,7 @@ TeamInQueue::~TeamInQueue()
 	for( order = m_workOrders; order; order = next )
 	{
 		next = order->m_next;
-		order->deleteInstance();
+		MemoryPoolObject::deleteInstance(order);
 	}
 	// If we have a team, activate it.  If it is empty, Team.cpp will remove empty active teams.
 	if (m_team) m_team->setActive();
@@ -3590,7 +3590,7 @@ void TeamInQueue::disband()
 	if (m_team != newTeam) {
 		m_team->transferUnitsTo(newTeam);
 		if (!m_team->getPrototype()->getIsSingleton()) {
-			m_team->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_team);
 		}
 		m_team = NULL;
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -436,7 +436,7 @@ static void deleteQueue(TeamInQueue* o)
 {
 	if (o)
 	{
-		MemoryPoolObject::deleteInstance(o);
+		deleteInstance(o);
 	}
 }
 
@@ -866,7 +866,7 @@ void AIPlayer::aiPreTeamDestroy( const Team *deletedTeam )
 			if (team->m_team == deletedTeam) {
 				// The members of the team all got killed before we could finish building the team.
 				removeFrom_TeamBuildQueue(team);
-				MemoryPoolObject::deleteInstance(team);
+				deleteInstance(team);
 				iter = iterate_TeamBuildQueue();
 			}
 		}
@@ -878,7 +878,7 @@ void AIPlayer::aiPreTeamDestroy( const Team *deletedTeam )
 			if (team->m_team == deletedTeam) {
 				// The members of the team all got killed before we could activate the team.
 				removeFrom_TeamReadyQueue(team);
-				MemoryPoolObject::deleteInstance(team);
+				deleteInstance(team);
 				iter = iterate_TeamReadyQueue();
 			}
 		}
@@ -2634,7 +2634,7 @@ void AIPlayer::recruitSpecificAITeam(TeamPrototype *teamProto, Real recruitRadiu
 		}	else {
 			//disband.
 			if (!theTeam->getPrototype()->getIsSingleton()) {
-				MemoryPoolObject::deleteInstance(theTeam);
+				deleteInstance(theTeam);
 				theTeam = NULL;
 			}
 			AsciiString teamName = teamProto->getName();
@@ -2826,7 +2826,7 @@ void AIPlayer::checkReadyTeams( void )
 						TheScriptEngine->AppendDebugMessage(teamName, false);
 					}
 				}
-				MemoryPoolObject::deleteInstance(team);
+				deleteInstance(team);
 				iter = iterate_TeamReadyQueue();
 			}																		 
 		}
@@ -2858,7 +2858,7 @@ void AIPlayer::checkQueuedTeams( void )
 					// Disband.
 					removeFrom_TeamBuildQueue(team);
 					team->disband();
-					MemoryPoolObject::deleteInstance(team);
+					deleteInstance(team);
 					if (isSkirmishAI()) {
 						TheScriptEngine->clearTeamFlags();
 					}
@@ -3489,7 +3489,7 @@ TeamInQueue::~TeamInQueue()
 	for( order = m_workOrders; order; order = next )
 	{
 		next = order->m_next;
-		MemoryPoolObject::deleteInstance(order);
+		deleteInstance(order);
 	}
 	// If we have a team, activate it.  If it is empty, Team.cpp will remove empty active teams.
 	if (m_team) m_team->setActive();
@@ -3590,7 +3590,7 @@ void TeamInQueue::disband()
 	if (m_team != newTeam) {
 		m_team->transferUnitsTo(newTeam);
 		if (!m_team->getPrototype()->getIsSingleton()) {
-			MemoryPoolObject::deleteInstance(m_team);
+			deleteInstance(m_team);
 		}
 		m_team = NULL;
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AISkirmishPlayer.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AISkirmishPlayer.cpp
@@ -840,7 +840,7 @@ void AISkirmishPlayer::recruitSpecificAITeam(TeamPrototype *teamProto, Real recr
 		}	else {
 			//disband.
 			if (!theTeam->getPrototype()->getIsSingleton()) {
-				MemoryPoolObject::deleteInstance(theTeam);
+				deleteInstance(theTeam);
 				theTeam = NULL;
 			}
 			AsciiString teamName = teamProto->getName();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AISkirmishPlayer.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AISkirmishPlayer.cpp
@@ -840,7 +840,7 @@ void AISkirmishPlayer::recruitSpecificAITeam(TeamPrototype *teamProto, Real recr
 		}	else {
 			//disband.
 			if (!theTeam->getPrototype()->getIsSingleton()) {
-				theTeam->deleteInstance();
+				MemoryPoolObject::deleteInstance(theTeam);
 				theTeam = NULL;
 			}
 			AsciiString teamName = teamProto->getName();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -738,7 +738,7 @@ AIStateMachine::~AIStateMachine()
 {
 	if (m_goalSquad) 
 	{
-		MemoryPoolObject::deleteInstance(m_goalSquad);
+		deleteInstance(m_goalSquad);
 	}
 }
 
@@ -3522,7 +3522,7 @@ AIAttackMoveToState::AIAttackMoveToState( StateMachine *machine ) : AIMoveToStat
 //----------------------------------------------------------------------------------------------------------
 AIAttackMoveToState::~AIAttackMoveToState()
 {
-	MemoryPoolObject::deleteInstance(m_attackMoveMachine);
+	deleteInstance(m_attackMoveMachine);
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -4377,7 +4377,7 @@ AIFollowWaypointPathState ( machine, asGroup, false )
 //-------------------------------------------------------------------------------------------------
 AIAttackFollowWaypointPathState::~AIAttackFollowWaypointPathState()
 {
-	MemoryPoolObject::deleteInstance(m_attackFollowMachine);
+	deleteInstance(m_attackFollowMachine);
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -5385,7 +5385,7 @@ AIAttackState::~AIAttackState()
 	if (m_attackMachine) 
 	{
 		m_attackMachine->halt();
-		MemoryPoolObject::deleteInstance(m_attackMachine);
+		deleteInstance(m_attackMachine);
 	}
 }
 
@@ -5700,7 +5700,7 @@ void AIAttackState::onExit( StateExitType status )
 	// destroy the attack machine
 	if (m_attackMachine)
 	{
-		MemoryPoolObject::deleteInstance(m_attackMachine);
+		deleteInstance(m_attackMachine);
 		m_attackMachine = NULL;
 	}
 
@@ -5794,7 +5794,7 @@ AIAttackSquadState::~AIAttackSquadState()
 {
 	if (m_attackSquadMachine)	{
 		m_attackSquadMachine->halt();
-		MemoryPoolObject::deleteInstance(m_attackSquadMachine);
+		deleteInstance(m_attackSquadMachine);
 	}
 }
 
@@ -5919,7 +5919,7 @@ void AIAttackSquadState::onExit( StateExitType status )
 	if( m_attackSquadMachine )
 	{
 		// destroy the attack machine
-		MemoryPoolObject::deleteInstance(m_attackSquadMachine);
+		deleteInstance(m_attackSquadMachine);
 		m_attackSquadMachine = NULL;
 	}
 }
@@ -6031,7 +6031,7 @@ AIDockState::~AIDockState()
 {
 	if (m_dockMachine) {
 		m_dockMachine->halt();
-		MemoryPoolObject::deleteInstance(m_dockMachine);
+		deleteInstance(m_dockMachine);
 	}
 }
 
@@ -6135,7 +6135,7 @@ void AIDockState::onExit( StateExitType status )
 	// destroy the dock machine
 	if (m_dockMachine) {
 		m_dockMachine->halt();// GS, you have to halt before you delete to do cleanup.
-		MemoryPoolObject::deleteInstance(m_dockMachine);
+		deleteInstance(m_dockMachine);
 		m_dockMachine = NULL;
 	}	else {
 		DEBUG_LOG(("Dock exited immediately\n"));
@@ -6611,7 +6611,7 @@ AIGuardState::~AIGuardState()
 {
 	if (m_guardMachine)	{
 		m_guardMachine->halt();
-		MemoryPoolObject::deleteInstance(m_guardMachine);
+		deleteInstance(m_guardMachine);
 	}
 }
 
@@ -6721,7 +6721,7 @@ StateReturnType AIGuardState::onEnter()
 //----------------------------------------------------------------------------------------------------------
 void AIGuardState::onExit( StateExitType status )
 {
-	MemoryPoolObject::deleteInstance(m_guardMachine);
+	deleteInstance(m_guardMachine);
 	m_guardMachine = NULL;
 
 	Object *obj = getMachineOwner();
@@ -6762,7 +6762,7 @@ AIGuardRetaliateState::~AIGuardRetaliateState()
 {
 	if (m_guardRetaliateMachine)	{
 		m_guardRetaliateMachine->halt();
-		MemoryPoolObject::deleteInstance(m_guardRetaliateMachine);
+		deleteInstance(m_guardRetaliateMachine);
 	}
 }
 
@@ -6868,7 +6868,7 @@ StateReturnType AIGuardRetaliateState::onEnter()
 //----------------------------------------------------------------------------------------------------------
 void AIGuardRetaliateState::onExit( StateExitType status )
 {
-	MemoryPoolObject::deleteInstance(m_guardRetaliateMachine);
+	deleteInstance(m_guardRetaliateMachine);
 	m_guardRetaliateMachine = NULL;
 
 	Object *obj = getMachineOwner();
@@ -6907,7 +6907,7 @@ AITunnelNetworkGuardState::~AITunnelNetworkGuardState()
 {
 	if (m_guardMachine)	{
 		m_guardMachine->halt();
-		MemoryPoolObject::deleteInstance(m_guardMachine);
+		deleteInstance(m_guardMachine);
 	}
 }
 
@@ -6999,7 +6999,7 @@ StateReturnType AITunnelNetworkGuardState::onEnter()
 //----------------------------------------------------------------------------------------------------------
 void AITunnelNetworkGuardState::onExit( StateExitType status )
 {
-	MemoryPoolObject::deleteInstance(m_guardMachine);
+	deleteInstance(m_guardMachine);
 	m_guardMachine = NULL;
 
 	Object *obj = getMachineOwner();
@@ -7045,7 +7045,7 @@ AIHuntState::~AIHuntState()
 	if (m_huntMachine) 
 	{
 		m_huntMachine->halt();
-		MemoryPoolObject::deleteInstance(m_huntMachine);
+		deleteInstance(m_huntMachine);
 	}
 }
 
@@ -7123,7 +7123,7 @@ StateReturnType AIHuntState::onEnter()
 void AIHuntState::onExit( StateExitType status )
 {
 	// destroy the hunt machine
-	MemoryPoolObject::deleteInstance(m_huntMachine);
+	deleteInstance(m_huntMachine);
 	m_huntMachine = NULL;
 
 	Object *obj = getMachineOwner();
@@ -7252,7 +7252,7 @@ AIAttackAreaState::~AIAttackAreaState()
 {
 	if (m_attackMachine) {
 		m_attackMachine->halt();
-		MemoryPoolObject::deleteInstance(m_attackMachine);
+		deleteInstance(m_attackMachine);
 	}
 }
 
@@ -7327,7 +7327,7 @@ StateReturnType AIAttackAreaState::onEnter()
 void AIAttackAreaState::onExit( StateExitType status )
 {
 	// destroy the hunt machine
-	MemoryPoolObject::deleteInstance(m_attackMachine);
+	deleteInstance(m_attackMachine);
 	m_attackMachine = NULL;
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -738,7 +738,7 @@ AIStateMachine::~AIStateMachine()
 {
 	if (m_goalSquad) 
 	{
-		m_goalSquad->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_goalSquad);
 	}
 }
 
@@ -3522,7 +3522,7 @@ AIAttackMoveToState::AIAttackMoveToState( StateMachine *machine ) : AIMoveToStat
 //----------------------------------------------------------------------------------------------------------
 AIAttackMoveToState::~AIAttackMoveToState()
 {
-	m_attackMoveMachine->deleteInstance();
+	MemoryPoolObject::deleteInstance(m_attackMoveMachine);
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -4377,7 +4377,7 @@ AIFollowWaypointPathState ( machine, asGroup, false )
 //-------------------------------------------------------------------------------------------------
 AIAttackFollowWaypointPathState::~AIAttackFollowWaypointPathState()
 {
-	m_attackFollowMachine->deleteInstance();
+	MemoryPoolObject::deleteInstance(m_attackFollowMachine);
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -5385,7 +5385,7 @@ AIAttackState::~AIAttackState()
 	if (m_attackMachine) 
 	{
 		m_attackMachine->halt();
-		m_attackMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_attackMachine);
 	}
 }
 
@@ -5700,7 +5700,7 @@ void AIAttackState::onExit( StateExitType status )
 	// destroy the attack machine
 	if (m_attackMachine)
 	{
-		m_attackMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_attackMachine);
 		m_attackMachine = NULL;
 	}
 
@@ -5794,7 +5794,7 @@ AIAttackSquadState::~AIAttackSquadState()
 {
 	if (m_attackSquadMachine)	{
 		m_attackSquadMachine->halt();
-		m_attackSquadMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_attackSquadMachine);
 	}
 }
 
@@ -5919,7 +5919,7 @@ void AIAttackSquadState::onExit( StateExitType status )
 	if( m_attackSquadMachine )
 	{
 		// destroy the attack machine
-		m_attackSquadMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_attackSquadMachine);
 		m_attackSquadMachine = NULL;
 	}
 }
@@ -6031,7 +6031,7 @@ AIDockState::~AIDockState()
 {
 	if (m_dockMachine) {
 		m_dockMachine->halt();
-		m_dockMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_dockMachine);
 	}
 }
 
@@ -6135,7 +6135,7 @@ void AIDockState::onExit( StateExitType status )
 	// destroy the dock machine
 	if (m_dockMachine) {
 		m_dockMachine->halt();// GS, you have to halt before you delete to do cleanup.
-		m_dockMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_dockMachine);
 		m_dockMachine = NULL;
 	}	else {
 		DEBUG_LOG(("Dock exited immediately\n"));
@@ -6611,7 +6611,7 @@ AIGuardState::~AIGuardState()
 {
 	if (m_guardMachine)	{
 		m_guardMachine->halt();
-		m_guardMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_guardMachine);
 	}
 }
 
@@ -6721,7 +6721,7 @@ StateReturnType AIGuardState::onEnter()
 //----------------------------------------------------------------------------------------------------------
 void AIGuardState::onExit( StateExitType status )
 {
-	m_guardMachine->deleteInstance();
+	MemoryPoolObject::deleteInstance(m_guardMachine);
 	m_guardMachine = NULL;
 
 	Object *obj = getMachineOwner();
@@ -6762,7 +6762,7 @@ AIGuardRetaliateState::~AIGuardRetaliateState()
 {
 	if (m_guardRetaliateMachine)	{
 		m_guardRetaliateMachine->halt();
-		m_guardRetaliateMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_guardRetaliateMachine);
 	}
 }
 
@@ -6868,7 +6868,7 @@ StateReturnType AIGuardRetaliateState::onEnter()
 //----------------------------------------------------------------------------------------------------------
 void AIGuardRetaliateState::onExit( StateExitType status )
 {
-	m_guardRetaliateMachine->deleteInstance();
+	MemoryPoolObject::deleteInstance(m_guardRetaliateMachine);
 	m_guardRetaliateMachine = NULL;
 
 	Object *obj = getMachineOwner();
@@ -6907,7 +6907,7 @@ AITunnelNetworkGuardState::~AITunnelNetworkGuardState()
 {
 	if (m_guardMachine)	{
 		m_guardMachine->halt();
-		m_guardMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_guardMachine);
 	}
 }
 
@@ -6999,7 +6999,7 @@ StateReturnType AITunnelNetworkGuardState::onEnter()
 //----------------------------------------------------------------------------------------------------------
 void AITunnelNetworkGuardState::onExit( StateExitType status )
 {
-	m_guardMachine->deleteInstance();
+	MemoryPoolObject::deleteInstance(m_guardMachine);
 	m_guardMachine = NULL;
 
 	Object *obj = getMachineOwner();
@@ -7045,7 +7045,7 @@ AIHuntState::~AIHuntState()
 	if (m_huntMachine) 
 	{
 		m_huntMachine->halt();
-		m_huntMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_huntMachine);
 	}
 }
 
@@ -7123,7 +7123,7 @@ StateReturnType AIHuntState::onEnter()
 void AIHuntState::onExit( StateExitType status )
 {
 	// destroy the hunt machine
-	m_huntMachine->deleteInstance();
+	MemoryPoolObject::deleteInstance(m_huntMachine);
 	m_huntMachine = NULL;
 
 	Object *obj = getMachineOwner();
@@ -7252,7 +7252,7 @@ AIAttackAreaState::~AIAttackAreaState()
 {
 	if (m_attackMachine) {
 		m_attackMachine->halt();
-		m_attackMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_attackMachine);
 	}
 }
 
@@ -7327,7 +7327,7 @@ StateReturnType AIAttackAreaState::onEnter()
 void AIAttackAreaState::onExit( StateExitType status )
 {
 	// destroy the hunt machine
-	m_attackMachine->deleteInstance();
+	MemoryPoolObject::deleteInstance(m_attackMachine);
 	m_attackMachine = NULL;
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AITNGuard.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AITNGuard.cpp
@@ -429,7 +429,7 @@ void AITNGuardInnerState::onExit( StateExitType status )
 	if (m_attackState) 
 	{
 		m_attackState->onExit(status);
-		MemoryPoolObject::deleteInstance(m_attackState);
+		deleteInstance(m_attackState);
 		m_attackState = NULL;
 	}
 }
@@ -526,7 +526,7 @@ void AITNGuardOuterState::onExit( StateExitType status )
 	if (m_attackState) 
 	{
 		m_attackState->onExit(status);
-		MemoryPoolObject::deleteInstance(m_attackState);
+		deleteInstance(m_attackState);
 		m_attackState = NULL;
 	}
 }
@@ -844,7 +844,7 @@ void AITNGuardAttackAggressorState::onExit( StateExitType status )
 	if (m_attackState) 
 	{
 		m_attackState->onExit(status);
-		MemoryPoolObject::deleteInstance(m_attackState);
+		deleteInstance(m_attackState);
 		m_attackState = NULL;
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AITNGuard.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AITNGuard.cpp
@@ -429,7 +429,7 @@ void AITNGuardInnerState::onExit( StateExitType status )
 	if (m_attackState) 
 	{
 		m_attackState->onExit(status);
-		m_attackState->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_attackState);
 		m_attackState = NULL;
 	}
 }
@@ -526,7 +526,7 @@ void AITNGuardOuterState::onExit( StateExitType status )
 	if (m_attackState) 
 	{
 		m_attackState->onExit(status);
-		m_attackState->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_attackState);
 		m_attackState = NULL;
 	}
 }
@@ -844,7 +844,7 @@ void AITNGuardAttackAggressorState::onExit( StateExitType status )
 	if (m_attackState) 
 	{
 		m_attackState->onExit(status);
-		m_attackState->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_attackState);
 		m_attackState = NULL;
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/TurretAI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/TurretAI.cpp
@@ -327,7 +327,7 @@ TurretAI::~TurretAI()
 	stopRotOrPitchSound();
 
 	if (m_turretStateMachine)
-		m_turretStateMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_turretStateMachine);
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/TurretAI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/TurretAI.cpp
@@ -327,7 +327,7 @@ TurretAI::~TurretAI()
 	stopRotOrPitchSound();
 
 	if (m_turretStateMachine)
-		MemoryPoolObject::deleteInstance(m_turretStateMachine);
+		deleteInstance(m_turretStateMachine);
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
@@ -81,7 +81,7 @@ PolygonTrigger::~PolygonTrigger(void)
 		while (cur) {
 			next = cur->getNext();
 			cur->setNextPoly(NULL); // prevents recursion. 
-			cur->deleteInstance();
+			MemoryPoolObject::deleteInstance(cur);
 			cur = next; 
 		}
 	}
@@ -189,7 +189,7 @@ Bool PolygonTrigger::ParsePolygonTriggersDataChunk(DataChunkInput &file, DataChu
 		if (numPoints<2) {
 			DEBUG_LOG(("Deleting polygon trigger '%s' with %d points.\n", 
 					pTrig->getTriggerName().str(), numPoints));
-			pTrig->deleteInstance();
+			MemoryPoolObject::deleteInstance(pTrig);
 			continue;
 		}
 		if (pPrevTrig) {
@@ -336,7 +336,7 @@ void PolygonTrigger::deleteTriggers(void)
 	PolygonTrigger *pList = ThePolygonTriggerListPtr;	
 	ThePolygonTriggerListPtr = NULL;
 	s_currentID = 1;
-	pList->deleteInstance();
+	MemoryPoolObject::deleteInstance(pList);
 }
 
 /**

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
@@ -81,7 +81,7 @@ PolygonTrigger::~PolygonTrigger(void)
 		while (cur) {
 			next = cur->getNext();
 			cur->setNextPoly(NULL); // prevents recursion. 
-			MemoryPoolObject::deleteInstance(cur);
+			deleteInstance(cur);
 			cur = next; 
 		}
 	}
@@ -189,7 +189,7 @@ Bool PolygonTrigger::ParsePolygonTriggersDataChunk(DataChunkInput &file, DataChu
 		if (numPoints<2) {
 			DEBUG_LOG(("Deleting polygon trigger '%s' with %d points.\n", 
 					pTrig->getTriggerName().str(), numPoints));
-			MemoryPoolObject::deleteInstance(pTrig);
+			deleteInstance(pTrig);
 			continue;
 		}
 		if (pPrevTrig) {
@@ -336,7 +336,7 @@ void PolygonTrigger::deleteTriggers(void)
 	PolygonTrigger *pList = ThePolygonTriggerListPtr;	
 	ThePolygonTriggerListPtr = NULL;
 	s_currentID = 1;
-	MemoryPoolObject::deleteInstance(pList);
+	deleteInstance(pList);
 }
 
 /**

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/SidesList.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/SidesList.cpp
@@ -85,11 +85,11 @@ SidesInfo::~SidesInfo(void)
 
 void SidesInfo::init(const Dict* d)
 {
-	MemoryPoolObject::deleteInstance(m_pBuildList);
+	deleteInstance(m_pBuildList);
 	m_pBuildList = NULL;
 	m_dict.clear();
 	if (m_scripts) 
-		MemoryPoolObject::deleteInstance(m_scripts);
+		deleteInstance(m_scripts);
 	m_scripts = NULL;
 	if (d)
 		m_dict = *d;
@@ -303,12 +303,12 @@ Bool SidesList::ParseSidesDataChunk(DataChunkInput &file, DataChunkInfo *info, v
 	for (i=0; i<count; i++) {
 		if (i<TheSidesList->getNumSides()) {
 			ScriptList *pSL = TheSidesList->getSideInfo(i)->getScriptList();
-			MemoryPoolObject::deleteInstance(pSL);
+			deleteInstance(pSL);
 			TheSidesList->getSideInfo(i)->setScriptList(scripts[i]);
 			scripts[i] = NULL;
 		} else {
 			// Read in more players worth than we have.
-			MemoryPoolObject::deleteInstance(scripts[i]);
+			deleteInstance(scripts[i]);
 			scripts[i] = NULL;
 		}
 	}
@@ -549,7 +549,7 @@ void SidesList::prepareForMP_or_Skirmish(void)
 					getSkirmishSideInfo(curSide)->setScriptList(scripts[i]);
 					scripts[i] = NULL;
 					if (pSL) 
-						MemoryPoolObject::deleteInstance(pSL);
+						deleteInstance(pSL);
 					scripts[i] = NULL;
 				}
 				for (i=0; i<MAX_PLAYER_COUNT; i++) {
@@ -955,7 +955,7 @@ BuildListInfo::~BuildListInfo(void)
 		while (cur) {
 			next = cur->getNext();
 			cur->setNextBuildList(NULL); // prevents recursion. 
-			MemoryPoolObject::deleteInstance(cur);
+			deleteInstance(cur);
 			cur = next; 
 		}
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/SidesList.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/SidesList.cpp
@@ -85,11 +85,11 @@ SidesInfo::~SidesInfo(void)
 
 void SidesInfo::init(const Dict* d)
 {
-	m_pBuildList->deleteInstance();
+	MemoryPoolObject::deleteInstance(m_pBuildList);
 	m_pBuildList = NULL;
 	m_dict.clear();
 	if (m_scripts) 
-		m_scripts->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_scripts);
 	m_scripts = NULL;
 	if (d)
 		m_dict = *d;
@@ -303,12 +303,12 @@ Bool SidesList::ParseSidesDataChunk(DataChunkInput &file, DataChunkInfo *info, v
 	for (i=0; i<count; i++) {
 		if (i<TheSidesList->getNumSides()) {
 			ScriptList *pSL = TheSidesList->getSideInfo(i)->getScriptList();
-			pSL->deleteInstance();
+			MemoryPoolObject::deleteInstance(pSL);
 			TheSidesList->getSideInfo(i)->setScriptList(scripts[i]);
 			scripts[i] = NULL;
 		} else {
 			// Read in more players worth than we have.
-			scripts[i]->deleteInstance();
+			MemoryPoolObject::deleteInstance(scripts[i]);
 			scripts[i] = NULL;
 		}
 	}
@@ -549,7 +549,7 @@ void SidesList::prepareForMP_or_Skirmish(void)
 					getSkirmishSideInfo(curSide)->setScriptList(scripts[i]);
 					scripts[i] = NULL;
 					if (pSL) 
-						pSL->deleteInstance();
+						MemoryPoolObject::deleteInstance(pSL);
 					scripts[i] = NULL;
 				}
 				for (i=0; i<MAX_PLAYER_COUNT; i++) {
@@ -955,7 +955,7 @@ BuildListInfo::~BuildListInfo(void)
 		while (cur) {
 			next = cur->getNext();
 			cur->setNextBuildList(NULL); // prevents recursion. 
-			cur->deleteInstance();
+			MemoryPoolObject::deleteInstance(cur);
 			cur = next; 
 		}
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
@@ -1420,7 +1420,7 @@ void TerrainLogic::deleteWaypoints(void)
 	for (pWay = getFirstWaypoint(); pWay; pWay = pNext) {
 		pNext = pWay->getNext();
 		pWay->setNext(NULL);
-		MemoryPoolObject::deleteInstance(pWay);
+		deleteInstance(pWay);
 	}
 	m_waypointListHead = NULL;
 }
@@ -1994,7 +1994,7 @@ void TerrainLogic::deleteBridges(void)
 	for (pBridge = getFirstBridge(); pBridge; pBridge = pNext) {
 		pNext = pBridge->getNext();
 		pBridge->setNext(NULL);
-		MemoryPoolObject::deleteInstance(pBridge);
+		deleteInstance(pBridge);
 	}
 	m_bridgeListHead = NULL;
 }
@@ -2050,7 +2050,7 @@ void TerrainLogic::deleteBridge( Bridge *bridge )
 		TheGameLogic->destroyObject( bridgeObj );
 
 	// delete the bridge in question
-	MemoryPoolObject::deleteInstance(bridge);
+	deleteInstance(bridge);
 
 }  // end deleteBridge
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
@@ -1420,7 +1420,7 @@ void TerrainLogic::deleteWaypoints(void)
 	for (pWay = getFirstWaypoint(); pWay; pWay = pNext) {
 		pNext = pWay->getNext();
 		pWay->setNext(NULL);
-		pWay->deleteInstance();
+		MemoryPoolObject::deleteInstance(pWay);
 	}
 	m_waypointListHead = NULL;
 }
@@ -1994,7 +1994,7 @@ void TerrainLogic::deleteBridges(void)
 	for (pBridge = getFirstBridge(); pBridge; pBridge = pNext) {
 		pNext = pBridge->getNext();
 		pBridge->setNext(NULL);
-		pBridge->deleteInstance();
+		MemoryPoolObject::deleteInstance(pBridge);
 	}
 	m_bridgeListHead = NULL;
 }
@@ -2050,7 +2050,7 @@ void TerrainLogic::deleteBridge( Bridge *bridge )
 		TheGameLogic->destroyObject( bridgeObj );
 
 	// delete the bridge in question
-	bridge->deleteInstance();
+	MemoryPoolObject::deleteInstance(bridge);
 
 }  // end deleteBridge
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/FireWeaponWhenDamagedBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/FireWeaponWhenDamagedBehavior.cpp
@@ -147,22 +147,22 @@ FireWeaponWhenDamagedBehavior::FireWeaponWhenDamagedBehavior( Thing *thing, cons
 FireWeaponWhenDamagedBehavior::~FireWeaponWhenDamagedBehavior( void )
 {
 	if (m_reactionWeaponPristine)
-		m_reactionWeaponPristine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_reactionWeaponPristine);
 	if (m_reactionWeaponDamaged)
-		m_reactionWeaponDamaged->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_reactionWeaponDamaged);
 	if (m_reactionWeaponReallyDamaged)
-		m_reactionWeaponReallyDamaged->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_reactionWeaponReallyDamaged);
 	if (m_reactionWeaponRubble)
-		m_reactionWeaponRubble->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_reactionWeaponRubble);
 
 	if (m_continuousWeaponPristine)
-		m_continuousWeaponPristine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_continuousWeaponPristine);
 	if (m_continuousWeaponDamaged)
-		m_continuousWeaponDamaged->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_continuousWeaponDamaged);
 	if (m_continuousWeaponReallyDamaged)
-		m_continuousWeaponReallyDamaged->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_continuousWeaponReallyDamaged);
 	if (m_continuousWeaponRubble)
-		m_continuousWeaponRubble->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_continuousWeaponRubble);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/FireWeaponWhenDamagedBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/FireWeaponWhenDamagedBehavior.cpp
@@ -147,22 +147,22 @@ FireWeaponWhenDamagedBehavior::FireWeaponWhenDamagedBehavior( Thing *thing, cons
 FireWeaponWhenDamagedBehavior::~FireWeaponWhenDamagedBehavior( void )
 {
 	if (m_reactionWeaponPristine)
-		MemoryPoolObject::deleteInstance(m_reactionWeaponPristine);
+		deleteInstance(m_reactionWeaponPristine);
 	if (m_reactionWeaponDamaged)
-		MemoryPoolObject::deleteInstance(m_reactionWeaponDamaged);
+		deleteInstance(m_reactionWeaponDamaged);
 	if (m_reactionWeaponReallyDamaged)
-		MemoryPoolObject::deleteInstance(m_reactionWeaponReallyDamaged);
+		deleteInstance(m_reactionWeaponReallyDamaged);
 	if (m_reactionWeaponRubble)
-		MemoryPoolObject::deleteInstance(m_reactionWeaponRubble);
+		deleteInstance(m_reactionWeaponRubble);
 
 	if (m_continuousWeaponPristine)
-		MemoryPoolObject::deleteInstance(m_continuousWeaponPristine);
+		deleteInstance(m_continuousWeaponPristine);
 	if (m_continuousWeaponDamaged)
-		MemoryPoolObject::deleteInstance(m_continuousWeaponDamaged);
+		deleteInstance(m_continuousWeaponDamaged);
 	if (m_continuousWeaponReallyDamaged)
-		MemoryPoolObject::deleteInstance(m_continuousWeaponReallyDamaged);
+		deleteInstance(m_continuousWeaponReallyDamaged);
 	if (m_continuousWeaponRubble)
-		MemoryPoolObject::deleteInstance(m_continuousWeaponRubble);
+		deleteInstance(m_continuousWeaponRubble);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/PrisonBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/PrisonBehavior.cpp
@@ -157,7 +157,7 @@ void PrisonBehavior::onDelete( void )
 
 		// delete element and set next to head
 		visual = m_visualList->m_next;
-		MemoryPoolObject::deleteInstance(m_visualList);
+		deleteInstance(m_visualList);
 		m_visualList = visual;
 
 	}  // end while
@@ -363,7 +363,7 @@ void PrisonBehavior::removeVisual( Object *obj )
 				m_visualList = visual->m_next;
 
 			// delete the element
-			MemoryPoolObject::deleteInstance(visual);
+			deleteInstance(visual);
 
 			break;  // exit for
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/PrisonBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/PrisonBehavior.cpp
@@ -157,7 +157,7 @@ void PrisonBehavior::onDelete( void )
 
 		// delete element and set next to head
 		visual = m_visualList->m_next;
-		m_visualList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_visualList);
 		m_visualList = visual;
 
 	}  // end while
@@ -363,7 +363,7 @@ void PrisonBehavior::removeVisual( Object *obj )
 				m_visualList = visual->m_next;
 
 			// delete the element
-			visual->deleteInstance();
+			MemoryPoolObject::deleteInstance(visual);
 
 			break;  // exit for
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/PropagandaTowerBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/PropagandaTowerBehavior.cpp
@@ -265,7 +265,7 @@ UpdateSleepTime PropagandaTowerBehavior::update( void )
 				prev->next = curr->next;
 			else
 				m_insideList = curr->next;
-			MemoryPoolObject::deleteInstance(curr);
+			deleteInstance(curr);
 				
 		}  // end else
 
@@ -373,7 +373,7 @@ void PropagandaTowerBehavior::removeAllInfluence( void )
 	{
 
 		o = m_insideList->next;
-		MemoryPoolObject::deleteInstance(m_insideList);
+		deleteInstance(m_insideList);
 		m_insideList = o;
 
 	}  // end while
@@ -548,7 +548,7 @@ void PropagandaTowerBehavior::doScan( void )
 	{
 
 		next = m_insideList->next;
-		MemoryPoolObject::deleteInstance(m_insideList);
+		deleteInstance(m_insideList);
 		m_insideList = next;
 
 	}  // end while

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/PropagandaTowerBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/PropagandaTowerBehavior.cpp
@@ -265,7 +265,7 @@ UpdateSleepTime PropagandaTowerBehavior::update( void )
 				prev->next = curr->next;
 			else
 				m_insideList = curr->next;
-			curr->deleteInstance();
+			MemoryPoolObject::deleteInstance(curr);
 				
 		}  // end else
 
@@ -373,7 +373,7 @@ void PropagandaTowerBehavior::removeAllInfluence( void )
 	{
 
 		o = m_insideList->next;
-		m_insideList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_insideList);
 		m_insideList = o;
 
 	}  // end while
@@ -548,7 +548,7 @@ void PropagandaTowerBehavior::doScan( void )
 	{
 
 		next = m_insideList->next;
-		m_insideList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_insideList);
 		m_insideList = next;
 
 	}  // end while

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp
@@ -1097,7 +1097,7 @@ void ActiveBody::deleteAllParticleSystems( void )
 		nextBodySystem = m_particleSystems->m_next;
 
 		// destroy this entry
-		MemoryPoolObject::deleteInstance(m_particleSystems);
+		deleteInstance(m_particleSystems);
 
 		// set the body systems head to the next
 		m_particleSystems = nextBodySystem;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp
@@ -1097,7 +1097,7 @@ void ActiveBody::deleteAllParticleSystems( void )
 		nextBodySystem = m_particleSystems->m_next;
 
 		// destroy this entry
-		m_particleSystems->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_particleSystems);
 
 		// set the body systems head to the next
 		m_particleSystems = nextBodySystem;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Collide/FireWeaponCollide.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Collide/FireWeaponCollide.cpp
@@ -67,7 +67,7 @@ FireWeaponCollide::FireWeaponCollide( Thing *thing, const ModuleData* moduleData
 FireWeaponCollide::~FireWeaponCollide( void )
 {
 	if (m_collideWeapon)
-		MemoryPoolObject::deleteInstance(m_collideWeapon);
+		deleteInstance(m_collideWeapon);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Collide/FireWeaponCollide.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Collide/FireWeaponCollide.cpp
@@ -67,7 +67,7 @@ FireWeaponCollide::FireWeaponCollide( Thing *thing, const ModuleData* moduleData
 FireWeaponCollide::~FireWeaponCollide( void )
 {
 	if (m_collideWeapon)
-		m_collideWeapon->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_collideWeapon);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Locomotor.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Locomotor.cpp
@@ -524,7 +524,7 @@ LocomotorStore::~LocomotorStore()
 	// delete all the templates, then clear out the table.
 	LocomotorTemplateMap::iterator it;
 	for (it = m_locomotorTemplates.begin(); it != m_locomotorTemplates.end(); ++it) {
-		it->second->deleteInstance();
+		MemoryPoolObject::deleteInstance(it->second);
 	}
 
 	m_locomotorTemplates.clear();
@@ -2766,7 +2766,7 @@ void LocomotorSet::clear()
 	for (int i = 0; i < m_locomotors.size(); ++i)
 	{
 		if (m_locomotors[i])
-			m_locomotors[i]->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_locomotors[i]);
 	}
 	m_locomotors.clear();
 	m_validLocomotorSurfaces = 0;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Locomotor.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Locomotor.cpp
@@ -524,7 +524,7 @@ LocomotorStore::~LocomotorStore()
 	// delete all the templates, then clear out the table.
 	LocomotorTemplateMap::iterator it;
 	for (it = m_locomotorTemplates.begin(); it != m_locomotorTemplates.end(); ++it) {
-		MemoryPoolObject::deleteInstance(it->second);
+		deleteInstance(it->second);
 	}
 
 	m_locomotorTemplates.clear();
@@ -2766,7 +2766,7 @@ void LocomotorSet::clear()
 	for (int i = 0; i < m_locomotors.size(); ++i)
 	{
 		if (m_locomotors[i])
-			MemoryPoolObject::deleteInstance(m_locomotors[i]);
+			deleteInstance(m_locomotors[i]);
 	}
 	m_locomotors.clear();
 	m_validLocomotorSurfaces = 0;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -629,15 +629,15 @@ Object::~Object()
 	setTeam( NULL );
 
 	// Object's set of these persist for the life of the object.
-	m_partitionLastLook->deleteInstance();
+	MemoryPoolObject::deleteInstance(m_partitionLastLook);
 	m_partitionLastLook = NULL;
-	m_partitionRevealAllLastLook->deleteInstance();
+	MemoryPoolObject::deleteInstance(m_partitionRevealAllLastLook);
 	m_partitionRevealAllLastLook = NULL;
-	m_partitionLastShroud->deleteInstance();
+	MemoryPoolObject::deleteInstance(m_partitionLastShroud);
 	m_partitionLastShroud = NULL;
-	m_partitionLastThreat->deleteInstance();
+	MemoryPoolObject::deleteInstance(m_partitionLastThreat);
 	m_partitionLastThreat = NULL;
-	m_partitionLastValue->deleteInstance();
+	MemoryPoolObject::deleteInstance(m_partitionLastValue);
 	m_partitionLastValue = NULL;
 
 	// remove the object from the partition system if present
@@ -655,7 +655,7 @@ Object::~Object()
 	// delete any modules present
 	for (BehaviorModule** b = m_behaviors; *b; ++b)
 	{
-		(*b)->deleteInstance();
+		MemoryPoolObject::deleteInstance((*b));
 		*b = NULL;	// in case other modules call findModule from their dtor!
 	}
 
@@ -663,7 +663,7 @@ Object::~Object()
 	m_behaviors = NULL;
 
 	if( m_experienceTracker )
-		m_experienceTracker->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_experienceTracker);
 
 	m_experienceTracker = NULL;
 
@@ -3771,7 +3771,7 @@ void Object::updateObjValuesFromMapProperties(Dict* properties)
 
     if ( audioToModify != NULL )
     {
-      audioToModify->deleteInstance();
+      MemoryPoolObject::deleteInstance(audioToModify);
       audioToModify = NULL;
     }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -629,15 +629,15 @@ Object::~Object()
 	setTeam( NULL );
 
 	// Object's set of these persist for the life of the object.
-	MemoryPoolObject::deleteInstance(m_partitionLastLook);
+	deleteInstance(m_partitionLastLook);
 	m_partitionLastLook = NULL;
-	MemoryPoolObject::deleteInstance(m_partitionRevealAllLastLook);
+	deleteInstance(m_partitionRevealAllLastLook);
 	m_partitionRevealAllLastLook = NULL;
-	MemoryPoolObject::deleteInstance(m_partitionLastShroud);
+	deleteInstance(m_partitionLastShroud);
 	m_partitionLastShroud = NULL;
-	MemoryPoolObject::deleteInstance(m_partitionLastThreat);
+	deleteInstance(m_partitionLastThreat);
 	m_partitionLastThreat = NULL;
-	MemoryPoolObject::deleteInstance(m_partitionLastValue);
+	deleteInstance(m_partitionLastValue);
 	m_partitionLastValue = NULL;
 
 	// remove the object from the partition system if present
@@ -655,7 +655,7 @@ Object::~Object()
 	// delete any modules present
 	for (BehaviorModule** b = m_behaviors; *b; ++b)
 	{
-		MemoryPoolObject::deleteInstance((*b));
+		deleteInstance(*b);
 		*b = NULL;	// in case other modules call findModule from their dtor!
 	}
 
@@ -663,7 +663,7 @@ Object::~Object()
 	m_behaviors = NULL;
 
 	if( m_experienceTracker )
-		MemoryPoolObject::deleteInstance(m_experienceTracker);
+		deleteInstance(m_experienceTracker);
 
 	m_experienceTracker = NULL;
 
@@ -3771,7 +3771,7 @@ void Object::updateObjValuesFromMapProperties(Dict* properties)
 
     if ( audioToModify != NULL )
     {
-      MemoryPoolObject::deleteInstance(audioToModify);
+      deleteInstance(audioToModify);
       audioToModify = NULL;
     }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
@@ -1589,7 +1589,7 @@ ObjectCreationListStore::~ObjectCreationListStore()
 	for (ObjectCreationNuggetVector::iterator i = m_nuggets.begin(); i != m_nuggets.end(); ++i)
 	{
 		if (*i)
-			MemoryPoolObject::deleteInstance((*i));
+			deleteInstance(*i);
 	}
 	m_nuggets.clear();
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
@@ -1589,7 +1589,7 @@ ObjectCreationListStore::~ObjectCreationListStore()
 	for (ObjectCreationNuggetVector::iterator i = m_nuggets.begin(); i != m_nuggets.end(); ++i)
 	{
 		if (*i)
-			(*i)->deleteInstance();
+			MemoryPoolObject::deleteInstance((*i));
 	}
 	m_nuggets.clear();
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
@@ -2479,7 +2479,7 @@ void PartitionContactList::resetContactList()
 	for (PartitionContactListNode* cd = m_contactList; cd; cd = cdnext)
 	{
 		cdnext = cd->m_next;
-		cd->deleteInstance();
+		MemoryPoolObject::deleteInstance(cd);
 	}
 
 	memset(m_contactHash, 0, sizeof(m_contactHash));
@@ -2913,7 +2913,7 @@ void PartitionManager::unRegisterObject( Object* object )
 		m_moduleList = next;
 
 	// delete module
-	mod->deleteInstance();
+	MemoryPoolObject::deleteInstance(mod);
 
 }
 
@@ -2971,7 +2971,7 @@ void PartitionManager::unRegisterGhostObject( GhostObject* object )
 		m_moduleList = next;
 
 	// delete module
-	mod->deleteInstance();
+	MemoryPoolObject::deleteInstance(mod);
 }
 
 /** 
@@ -4014,7 +4014,7 @@ void PartitionManager::processPendingUndoShroudRevealQueue( Bool considerTimesta
 
 		undoShroudReveal( thisInfo->m_where.x, thisInfo->m_where.y, thisInfo->m_howFar, thisInfo->m_forWhom );
 
-		thisInfo->deleteInstance();
+		MemoryPoolObject::deleteInstance(thisInfo);
 		m_pendingUndoShroudReveals.pop();
 	}
 }
@@ -4035,7 +4035,7 @@ void PartitionManager::resetPendingUndoShroudRevealQueue()
 	while( !m_pendingUndoShroudReveals.empty() )
 	{
 		SightingInfo *thisInfo = m_pendingUndoShroudReveals.front();
-		thisInfo->deleteInstance();
+		MemoryPoolObject::deleteInstance(thisInfo);
 		m_pendingUndoShroudReveals.pop();
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
@@ -2479,7 +2479,7 @@ void PartitionContactList::resetContactList()
 	for (PartitionContactListNode* cd = m_contactList; cd; cd = cdnext)
 	{
 		cdnext = cd->m_next;
-		MemoryPoolObject::deleteInstance(cd);
+		deleteInstance(cd);
 	}
 
 	memset(m_contactHash, 0, sizeof(m_contactHash));
@@ -2913,7 +2913,7 @@ void PartitionManager::unRegisterObject( Object* object )
 		m_moduleList = next;
 
 	// delete module
-	MemoryPoolObject::deleteInstance(mod);
+	deleteInstance(mod);
 
 }
 
@@ -2971,7 +2971,7 @@ void PartitionManager::unRegisterGhostObject( GhostObject* object )
 		m_moduleList = next;
 
 	// delete module
-	MemoryPoolObject::deleteInstance(mod);
+	deleteInstance(mod);
 }
 
 /** 
@@ -4014,7 +4014,7 @@ void PartitionManager::processPendingUndoShroudRevealQueue( Bool considerTimesta
 
 		undoShroudReveal( thisInfo->m_where.x, thisInfo->m_where.y, thisInfo->m_howFar, thisInfo->m_forWhom );
 
-		MemoryPoolObject::deleteInstance(thisInfo);
+		deleteInstance(thisInfo);
 		m_pendingUndoShroudReveals.pop();
 	}
 }
@@ -4035,7 +4035,7 @@ void PartitionManager::resetPendingUndoShroudRevealQueue()
 	while( !m_pendingUndoShroudReveals.empty() )
 	{
 		SightingInfo *thisInfo = m_pendingUndoShroudReveals.front();
-		MemoryPoolObject::deleteInstance(thisInfo);
+		deleteInstance(thisInfo);
 		m_pendingUndoShroudReveals.pop();
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/SimpleObjectIterator.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/SimpleObjectIterator.cpp
@@ -115,7 +115,7 @@ void SimpleObjectIterator::makeEmpty()
 	while (m_firstClump)
 	{
 		Clump *next = m_firstClump->m_nextClump;
-		m_firstClump->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_firstClump);
 		m_firstClump = next;
 		--m_clumpCount;
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/SimpleObjectIterator.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/SimpleObjectIterator.cpp
@@ -115,7 +115,7 @@ void SimpleObjectIterator::makeEmpty()
 	while (m_firstClump)
 	{
 		Clump *next = m_firstClump->m_nextClump;
-		MemoryPoolObject::deleteInstance(m_firstClump);
+		deleteInstance(m_firstClump);
 		m_firstClump = next;
 		--m_clumpCount;
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -104,7 +104,7 @@ AIUpdateModuleData::~AIUpdateModuleData()
 		{
 			TurretAIData* td = const_cast<TurretAIData*>(m_turretData[i]);
 			if (td)
-				MemoryPoolObject::deleteInstance(td);
+				deleteInstance(td);
 		}
 	}
 }
@@ -644,13 +644,13 @@ AIUpdateInterface::~AIUpdateInterface( void )
 
 	if( m_stateMachine ) {
 		m_stateMachine->halt();
-		MemoryPoolObject::deleteInstance(m_stateMachine);
+		deleteInstance(m_stateMachine);
 	}
 
 	for (int i = 0; i < MAX_TURRETS; i++)
 	{
 		if (m_turretAI[i])
-			MemoryPoolObject::deleteInstance(m_turretAI[i]);
+			deleteInstance(m_turretAI[i]);
 		m_turretAI[i] = NULL;
 	}
 	m_stateMachine = NULL;
@@ -2026,7 +2026,7 @@ void AIUpdateInterface::destroyPath( void )
 {
 	// destroy previous path
 	if (m_path)
-		MemoryPoolObject::deleteInstance(m_path);
+		deleteInstance(m_path);
 
 	m_path = NULL;
 	m_waitingForPath = FALSE; // we no longer need it.

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -104,7 +104,7 @@ AIUpdateModuleData::~AIUpdateModuleData()
 		{
 			TurretAIData* td = const_cast<TurretAIData*>(m_turretData[i]);
 			if (td)
-				td->deleteInstance();
+				MemoryPoolObject::deleteInstance(td);
 		}
 	}
 }
@@ -644,13 +644,13 @@ AIUpdateInterface::~AIUpdateInterface( void )
 
 	if( m_stateMachine ) {
 		m_stateMachine->halt();
-		m_stateMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_stateMachine);
 	}
 
 	for (int i = 0; i < MAX_TURRETS; i++)
 	{
 		if (m_turretAI[i])
-			m_turretAI[i]->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_turretAI[i]);
 		m_turretAI[i] = NULL;
 	}
 	m_stateMachine = NULL;
@@ -2026,7 +2026,7 @@ void AIUpdateInterface::destroyPath( void )
 {
 	// destroy previous path
 	if (m_path)
-		m_path->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_path);
 
 	m_path = NULL;
 	m_waitingForPath = FALSE; // we no longer need it.

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DeliverPayloadAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DeliverPayloadAIUpdate.cpp
@@ -139,7 +139,7 @@ DeliverPayloadAIUpdate::~DeliverPayloadAIUpdate( void )
 	m_deliveryDecal.clear();
 
 	if (m_deliverPayloadStateMachine)
-		MemoryPoolObject::deleteInstance(m_deliverPayloadStateMachine);
+		deleteInstance(m_deliverPayloadStateMachine);
 } 
 
 //-------------------------------------------------------------------------------------------------
@@ -262,7 +262,7 @@ void DeliverPayloadAIUpdate::deliverPayload(
 	//****************************************************
 	
 	if (m_deliverPayloadStateMachine)
-		MemoryPoolObject::deleteInstance(m_deliverPayloadStateMachine);
+		deleteInstance(m_deliverPayloadStateMachine);
 	m_deliverPayloadStateMachine = NULL;
 
 	m_moveToPos = *moveToPos;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DeliverPayloadAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DeliverPayloadAIUpdate.cpp
@@ -139,7 +139,7 @@ DeliverPayloadAIUpdate::~DeliverPayloadAIUpdate( void )
 	m_deliveryDecal.clear();
 
 	if (m_deliverPayloadStateMachine)
-		m_deliverPayloadStateMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_deliverPayloadStateMachine);
 } 
 
 //-------------------------------------------------------------------------------------------------
@@ -262,7 +262,7 @@ void DeliverPayloadAIUpdate::deliverPayload(
 	//****************************************************
 	
 	if (m_deliverPayloadStateMachine)
-		m_deliverPayloadStateMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_deliverPayloadStateMachine);
 	m_deliverPayloadStateMachine = NULL;
 
 	m_moveToPos = *moveToPos;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -1183,7 +1183,7 @@ protected:
 	StateMachine *m_actionMachine;
 
 };
-inline DozerActionState::~DozerActionState( void ) { if (m_actionMachine) MemoryPoolObject::deleteInstance(m_actionMachine); }
+inline DozerActionState::~DozerActionState( void ) { if (m_actionMachine) deleteInstance(m_actionMachine); }
 
 // ------------------------------------------------------------------------------------------------
 /** CRC */
@@ -1483,7 +1483,7 @@ DozerAIUpdate::~DozerAIUpdate( void )
 
 	// delete our behavior state machine
 	if( m_dozerMachine )
-		MemoryPoolObject::deleteInstance(m_dozerMachine);
+		deleteInstance(m_dozerMachine);
 
 	// no orders
 	for( Int i = 0; i < DOZER_NUM_TASKS; i++ )

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -1183,7 +1183,7 @@ protected:
 	StateMachine *m_actionMachine;
 
 };
-inline DozerActionState::~DozerActionState( void ) { if (m_actionMachine) m_actionMachine->deleteInstance(); }
+inline DozerActionState::~DozerActionState( void ) { if (m_actionMachine) MemoryPoolObject::deleteInstance(m_actionMachine); }
 
 // ------------------------------------------------------------------------------------------------
 /** CRC */
@@ -1483,7 +1483,7 @@ DozerAIUpdate::~DozerAIUpdate( void )
 
 	// delete our behavior state machine
 	if( m_dozerMachine )
-		m_dozerMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_dozerMachine);
 
 	// no orders
 	for( Int i = 0; i < DOZER_NUM_TASKS; i++ )

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/HackInternetAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/HackInternetAIUpdate.cpp
@@ -158,7 +158,7 @@ void HackInternetAIUpdate::aiDoCommand(const AICommandParms* parms)
 void HackInternetAIUpdate::hackInternet()
 {
 	//if (m_hackInternetStateMachine)
-	//	MemoryPoolObject::deleteInstance(m_hackInternetStateMachine);
+	//	deleteInstance(m_hackInternetStateMachine);
 	//m_hackInternetStateMachine = NULL;
 
 	// must make the state machine AFTER initing the other stuff, since it may inquire of its values...

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/HackInternetAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/HackInternetAIUpdate.cpp
@@ -158,7 +158,7 @@ void HackInternetAIUpdate::aiDoCommand(const AICommandParms* parms)
 void HackInternetAIUpdate::hackInternet()
 {
 	//if (m_hackInternetStateMachine)
-	//	m_hackInternetStateMachine->deleteInstance();
+	//	MemoryPoolObject::deleteInstance(m_hackInternetStateMachine);
 	//m_hackInternetStateMachine = NULL;
 
 	// must make the state machine AFTER initing the other stuff, since it may inquire of its values...

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cpp
@@ -94,7 +94,7 @@ SupplyTruckAIUpdate::SupplyTruckAIUpdate( Thing *thing, const ModuleData* module
 //-------------------------------------------------------------------------------------------------
 SupplyTruckAIUpdate::~SupplyTruckAIUpdate( void )
 {
-	m_supplyTruckStateMachine->deleteInstance();
+	MemoryPoolObject::deleteInstance(m_supplyTruckStateMachine);
 } 
 
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cpp
@@ -94,7 +94,7 @@ SupplyTruckAIUpdate::SupplyTruckAIUpdate( Thing *thing, const ModuleData* module
 //-------------------------------------------------------------------------------------------------
 SupplyTruckAIUpdate::~SupplyTruckAIUpdate( void )
 {
-	MemoryPoolObject::deleteInstance(m_supplyTruckStateMachine);
+	deleteInstance(m_supplyTruckStateMachine);
 } 
 
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -132,13 +132,13 @@ WorkerAIUpdate::~WorkerAIUpdate( void )
 
 	// delete our behavior state machine
 	if( m_dozerMachine )
-		MemoryPoolObject::deleteInstance(m_dozerMachine);
+		deleteInstance(m_dozerMachine);
 
 	if( m_supplyTruckStateMachine )
-		MemoryPoolObject::deleteInstance(m_supplyTruckStateMachine);
+		deleteInstance(m_supplyTruckStateMachine);
 
 	if( m_workerMachine )
-		MemoryPoolObject::deleteInstance(m_workerMachine);
+		deleteInstance(m_workerMachine);
 
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -132,13 +132,13 @@ WorkerAIUpdate::~WorkerAIUpdate( void )
 
 	// delete our behavior state machine
 	if( m_dozerMachine )
-		m_dozerMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_dozerMachine);
 
 	if( m_supplyTruckStateMachine )
-		m_supplyTruckStateMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_supplyTruckStateMachine);
 
 	if( m_workerMachine )
-		m_workerMachine->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_workerMachine);
 
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/FireWeaponUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/FireWeaponUpdate.cpp
@@ -89,7 +89,7 @@ FireWeaponUpdate::FireWeaponUpdate( Thing *thing, const ModuleData* moduleData )
 FireWeaponUpdate::~FireWeaponUpdate( void )
 {
 	if (m_weapon)
-		m_weapon->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_weapon);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/FireWeaponUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/FireWeaponUpdate.cpp
@@ -89,7 +89,7 @@ FireWeaponUpdate::FireWeaponUpdate( Thing *thing, const ModuleData* moduleData )
 FireWeaponUpdate::~FireWeaponUpdate( void )
 {
 	if (m_weapon)
-		MemoryPoolObject::deleteInstance(m_weapon);
+		deleteInstance(m_weapon);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
@@ -262,7 +262,7 @@ PhysicsBehavior::~PhysicsBehavior()
 {
 	if (m_bounceSound)
 	{
-		m_bounceSound->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_bounceSound);
 		m_bounceSound = NULL;
 	}
 }
@@ -611,7 +611,7 @@ void PhysicsBehavior::setBounceSound(const AudioEventRTS* bounceSound)
 	{
 		if (m_bounceSound)
 		{
-			m_bounceSound->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_bounceSound);
 			m_bounceSound = NULL;
 		}
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
@@ -262,7 +262,7 @@ PhysicsBehavior::~PhysicsBehavior()
 {
 	if (m_bounceSound)
 	{
-		MemoryPoolObject::deleteInstance(m_bounceSound);
+		deleteInstance(m_bounceSound);
 		m_bounceSound = NULL;
 	}
 }
@@ -611,7 +611,7 @@ void PhysicsBehavior::setBounceSound(const AudioEventRTS* bounceSound)
 	{
 		if (m_bounceSound)
 		{
-			MemoryPoolObject::deleteInstance(m_bounceSound);
+			deleteInstance(m_bounceSound);
 			m_bounceSound = NULL;
 		}
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PointDefenseLaserUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PointDefenseLaserUpdate.cpp
@@ -216,7 +216,7 @@ void PointDefenseLaserUpdate::fireWhenReady()
 				Weapon* w = TheWeaponStore->allocateNewWeapon( wt, TERTIARY_WEAPON );
 				w->loadAmmoNow( getObject() );
 				w->fireWeapon( getObject(), target );
-				MemoryPoolObject::deleteInstance(w);
+				deleteInstance(w);
 
 				// And now that we have shot, set our internal reload timer.
 				m_nextShotAvailableInFrames = wt->getDelayBetweenShots( bonus );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PointDefenseLaserUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PointDefenseLaserUpdate.cpp
@@ -216,7 +216,7 @@ void PointDefenseLaserUpdate::fireWhenReady()
 				Weapon* w = TheWeaponStore->allocateNewWeapon( wt, TERTIARY_WEAPON );
 				w->loadAmmoNow( getObject() );
 				w->fireWeapon( getObject(), target );
-				w->deleteInstance();
+				MemoryPoolObject::deleteInstance(w);
 
 				// And now that we have shot, set our internal reload timer.
 				m_nextShotAvailableInFrames = wt->getDelayBetweenShots( bonus );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
@@ -219,7 +219,7 @@ ProductionUpdate::~ProductionUpdate( void )
 		production = m_productionQueue;
 		removeFromProductionQueue( production );
 		// TheSuperHackers @fix Mauller 13/04/2025 Delete instance of production item
-		production->deleteInstance();
+		MemoryPoolObject::deleteInstance(production);
 
 	}  // end while
 
@@ -371,7 +371,7 @@ void ProductionUpdate::cancelUpgrade( const UpgradeTemplate *upgrade )
 	removeFromProductionQueue( production );
 
 	// delete production instance
-	production->deleteInstance();
+	MemoryPoolObject::deleteInstance(production);
 
 	//
 	// remove the IN_PRODUCTION status of this upgrade from the player, object upgrades don't
@@ -487,7 +487,7 @@ void ProductionUpdate::cancelUnitCreate( ProductionID productionID )
 			removeFromProductionQueue( production );
 
 			// delete the production entry
-			production->deleteInstance();
+			MemoryPoolObject::deleteInstance(production);
 
 			return;
 
@@ -684,7 +684,7 @@ UpdateSleepTime ProductionUpdate::update( void )
 		removeFromProductionQueue( production );
 
 		// delete the production entry
-		production->deleteInstance();
+		MemoryPoolObject::deleteInstance(production);
 
 		return UPDATE_SLEEP_NONE;
 
@@ -876,7 +876,7 @@ UpdateSleepTime ProductionUpdate::update( void )
 					removeFromProductionQueue( production );
 					
 					// delete the production entry
-					production->deleteInstance();
+					MemoryPoolObject::deleteInstance(production);
 				}
 
 			}  // end if we found an exit interface
@@ -892,7 +892,7 @@ UpdateSleepTime ProductionUpdate::update( void )
 				removeFromProductionQueue( production );
 
 				// delete the production entry
-				production->deleteInstance();
+				MemoryPoolObject::deleteInstance(production);
 
 			}  // end else
 	
@@ -979,7 +979,7 @@ UpdateSleepTime ProductionUpdate::update( void )
 			removeFromProductionQueue( production );
 
 			// delete the production entry
-			production->deleteInstance();
+			MemoryPoolObject::deleteInstance(production);
 
 		}  // end else, production upgrade
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
@@ -219,7 +219,7 @@ ProductionUpdate::~ProductionUpdate( void )
 		production = m_productionQueue;
 		removeFromProductionQueue( production );
 		// TheSuperHackers @fix Mauller 13/04/2025 Delete instance of production item
-		MemoryPoolObject::deleteInstance(production);
+		deleteInstance(production);
 
 	}  // end while
 
@@ -371,7 +371,7 @@ void ProductionUpdate::cancelUpgrade( const UpgradeTemplate *upgrade )
 	removeFromProductionQueue( production );
 
 	// delete production instance
-	MemoryPoolObject::deleteInstance(production);
+	deleteInstance(production);
 
 	//
 	// remove the IN_PRODUCTION status of this upgrade from the player, object upgrades don't
@@ -487,7 +487,7 @@ void ProductionUpdate::cancelUnitCreate( ProductionID productionID )
 			removeFromProductionQueue( production );
 
 			// delete the production entry
-			MemoryPoolObject::deleteInstance(production);
+			deleteInstance(production);
 
 			return;
 
@@ -684,7 +684,7 @@ UpdateSleepTime ProductionUpdate::update( void )
 		removeFromProductionQueue( production );
 
 		// delete the production entry
-		MemoryPoolObject::deleteInstance(production);
+		deleteInstance(production);
 
 		return UPDATE_SLEEP_NONE;
 
@@ -876,7 +876,7 @@ UpdateSleepTime ProductionUpdate::update( void )
 					removeFromProductionQueue( production );
 					
 					// delete the production entry
-					MemoryPoolObject::deleteInstance(production);
+					deleteInstance(production);
 				}
 
 			}  // end if we found an exit interface
@@ -892,7 +892,7 @@ UpdateSleepTime ProductionUpdate::update( void )
 				removeFromProductionQueue( production );
 
 				// delete the production entry
-				MemoryPoolObject::deleteInstance(production);
+				deleteInstance(production);
 
 			}  // end else
 	
@@ -979,7 +979,7 @@ UpdateSleepTime ProductionUpdate::update( void )
 			removeFromProductionQueue( production );
 
 			// delete the production entry
-			MemoryPoolObject::deleteInstance(production);
+			deleteInstance(production);
 
 		}  // end else, production upgrade
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -333,12 +333,12 @@ WeaponTemplate::WeaponTemplate() : m_nextTemplate(NULL)
 WeaponTemplate::~WeaponTemplate()
 {
 	if (m_nextTemplate) {
-		MemoryPoolObject::deleteInstance(m_nextTemplate);
+		deleteInstance(m_nextTemplate);
 	}
 
 	// delete any extra-bonus that's present
 	if (m_extraBonus)
-		MemoryPoolObject::deleteInstance(m_extraBonus);
+		deleteInstance(m_extraBonus);
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -1519,7 +1519,7 @@ WeaponStore::~WeaponStore()
 	{
 		WeaponTemplate* wt = m_weaponTemplateVector[i];
 		if (wt)
-			MemoryPoolObject::deleteInstance(wt);
+			deleteInstance(wt);
 	}
 	m_weaponTemplateVector.clear();
 }
@@ -1530,7 +1530,7 @@ void WeaponStore::handleProjectileDetonation(const WeaponTemplate* wt, const Obj
 	Weapon* w = TheWeaponStore->allocateNewWeapon(wt, PRIMARY_WEAPON);
 	w->loadAmmoNow(source);
 	w->fireProjectileDetonationWeapon( source, pos, extraBonusFlags, inflictDamage );
-	MemoryPoolObject::deleteInstance(w);
+	deleteInstance(w);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1541,7 +1541,7 @@ void WeaponStore::createAndFireTempWeapon(const WeaponTemplate* wt, const Object
 	Weapon* w = TheWeaponStore->allocateNewWeapon(wt, PRIMARY_WEAPON);
 	w->loadAmmoNow(source);
 	w->fireWeapon(source, pos);
-	MemoryPoolObject::deleteInstance(w);
+	deleteInstance(w);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1553,7 +1553,7 @@ void WeaponStore::createAndFireTempWeapon(const WeaponTemplate* wt, const Object
 	Weapon* w = TheWeaponStore->allocateNewWeapon(wt, PRIMARY_WEAPON);
 	w->loadAmmoNow(source);
 	w->fireWeapon(source, target);
-	MemoryPoolObject::deleteInstance(w);
+	deleteInstance(w);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1658,7 +1658,7 @@ void WeaponStore::reset()
 		{
 			WeaponTemplate *override = wt;
 			wt = wt->friend_clearNextTemplate();
-			MemoryPoolObject::deleteInstance(override);
+			deleteInstance(override);
 		}
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -333,12 +333,12 @@ WeaponTemplate::WeaponTemplate() : m_nextTemplate(NULL)
 WeaponTemplate::~WeaponTemplate()
 {
 	if (m_nextTemplate) {
-		m_nextTemplate->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_nextTemplate);
 	}
 
 	// delete any extra-bonus that's present
 	if (m_extraBonus)
-		m_extraBonus->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_extraBonus);
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -1519,7 +1519,7 @@ WeaponStore::~WeaponStore()
 	{
 		WeaponTemplate* wt = m_weaponTemplateVector[i];
 		if (wt)
-			wt->deleteInstance();
+			MemoryPoolObject::deleteInstance(wt);
 	}
 	m_weaponTemplateVector.clear();
 }
@@ -1530,7 +1530,7 @@ void WeaponStore::handleProjectileDetonation(const WeaponTemplate* wt, const Obj
 	Weapon* w = TheWeaponStore->allocateNewWeapon(wt, PRIMARY_WEAPON);
 	w->loadAmmoNow(source);
 	w->fireProjectileDetonationWeapon( source, pos, extraBonusFlags, inflictDamage );
-	w->deleteInstance();
+	MemoryPoolObject::deleteInstance(w);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1541,7 +1541,7 @@ void WeaponStore::createAndFireTempWeapon(const WeaponTemplate* wt, const Object
 	Weapon* w = TheWeaponStore->allocateNewWeapon(wt, PRIMARY_WEAPON);
 	w->loadAmmoNow(source);
 	w->fireWeapon(source, pos);
-	w->deleteInstance();
+	MemoryPoolObject::deleteInstance(w);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1553,7 +1553,7 @@ void WeaponStore::createAndFireTempWeapon(const WeaponTemplate* wt, const Object
 	Weapon* w = TheWeaponStore->allocateNewWeapon(wt, PRIMARY_WEAPON);
 	w->loadAmmoNow(source);
 	w->fireWeapon(source, target);
-	w->deleteInstance();
+	MemoryPoolObject::deleteInstance(w);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1658,7 +1658,7 @@ void WeaponStore::reset()
 		{
 			WeaponTemplate *override = wt;
 			wt = wt->friend_clearNextTemplate();
-			override->deleteInstance();
+			MemoryPoolObject::deleteInstance(override);
 		}
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/WeaponSet.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/WeaponSet.cpp
@@ -195,7 +195,7 @@ WeaponSet::~WeaponSet()
 {
 	for (Int i = 0; i < WEAPONSLOT_COUNT; ++i)
 		if (m_weapons[i])
-			m_weapons[i]->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_weapons[i]);
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -317,7 +317,7 @@ void WeaponSet::updateWeaponSet(const Object* obj)
 		{
 			if (m_weapons[i] != NULL)
 			{
-				m_weapons[i]->deleteInstance();
+				MemoryPoolObject::deleteInstance(m_weapons[i]);
 				m_weapons[i] = NULL;
 			}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/WeaponSet.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/WeaponSet.cpp
@@ -195,7 +195,7 @@ WeaponSet::~WeaponSet()
 {
 	for (Int i = 0; i < WEAPONSLOT_COUNT; ++i)
 		if (m_weapons[i])
-			MemoryPoolObject::deleteInstance(m_weapons[i]);
+			deleteInstance(m_weapons[i]);
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -317,7 +317,7 @@ void WeaponSet::updateWeaponSet(const Object* obj)
 		{
 			if (m_weapons[i] != NULL)
 			{
-				MemoryPoolObject::deleteInstance(m_weapons[i]);
+				deleteInstance(m_weapons[i]);
 				m_weapons[i] = NULL;
 			}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
@@ -4698,7 +4698,7 @@ void ScriptActions::doUnitStartSequentialScript(const AsciiString& unitName, con
 	
 	TheScriptEngine->appendSequentialScript(seqScript);
 
-	MemoryPoolObject::deleteInstance(seqScript);
+	deleteInstance(seqScript);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -4795,7 +4795,7 @@ void ScriptActions::doTeamStartSequentialScript(const AsciiString& teamName, con
 	
 	TheScriptEngine->appendSequentialScript(seqScript);
 
-	MemoryPoolObject::deleteInstance(seqScript);
+	deleteInstance(seqScript);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
@@ -4698,7 +4698,7 @@ void ScriptActions::doUnitStartSequentialScript(const AsciiString& unitName, con
 	
 	TheScriptEngine->appendSequentialScript(seqScript);
 
-	seqScript->deleteInstance();
+	MemoryPoolObject::deleteInstance(seqScript);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -4795,7 +4795,7 @@ void ScriptActions::doTeamStartSequentialScript(const AsciiString& teamName, con
 	
 	TheScriptEngine->appendSequentialScript(seqScript);
 
-	seqScript->deleteInstance();
+	MemoryPoolObject::deleteInstance(seqScript);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptConditions.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptConditions.cpp
@@ -80,7 +80,7 @@ public:
 	~ObjectTypesTemp()
 	{
 		if (m_types)
-			MemoryPoolObject::deleteInstance(m_types);
+			deleteInstance(m_types);
 	}
 };
 
@@ -120,7 +120,7 @@ public:
 TransportStatus::~TransportStatus() 
 { 
 	if (m_nextStatus) 
-		MemoryPoolObject::deleteInstance(m_nextStatus); 
+		deleteInstance(m_nextStatus); 
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -156,7 +156,7 @@ void ScriptConditions::init( void )
 void ScriptConditions::reset( void )
 {
 
-	MemoryPoolObject::deleteInstance(s_transportStatuses);
+	deleteInstance(s_transportStatuses);
 	s_transportStatuses = NULL;
 	// Empty for now.  jba.
 }  // end reset

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptConditions.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptConditions.cpp
@@ -80,7 +80,7 @@ public:
 	~ObjectTypesTemp()
 	{
 		if (m_types)
-			m_types->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_types);
 	}
 };
 
@@ -120,7 +120,7 @@ public:
 TransportStatus::~TransportStatus() 
 { 
 	if (m_nextStatus) 
-		m_nextStatus->deleteInstance(); 
+		MemoryPoolObject::deleteInstance(m_nextStatus); 
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -156,7 +156,7 @@ void ScriptConditions::init( void )
 void ScriptConditions::reset( void )
 {
 
-	s_transportStatuses->deleteInstance();
+	MemoryPoolObject::deleteInstance(s_transportStatuses);
 	s_transportStatuses = NULL;
 	// Empty for now.  jba.
 }  // end reset

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
@@ -6706,7 +6706,7 @@ void ScriptEngine::removeObjectTypes(ObjectTypes *typesToRemove)
 	}
 
 	// delete it.
-	MemoryPoolObject::deleteInstance(typesToRemove);
+	deleteInstance(typesToRemove);
 
 	// remove it from the main array of stuff
 	m_allObjectTypeLists.erase(it);
@@ -8077,14 +8077,14 @@ ScriptEngine::VecSequentialScriptPtrIt ScriptEngine::cleanupSequentialScript(Vec
 		while (seqScript) {
 			scriptToDelete = seqScript;
 			seqScript = seqScript->m_nextScriptInSequence;
-			MemoryPoolObject::deleteInstance(scriptToDelete);
+			deleteInstance(scriptToDelete);
 			scriptToDelete = NULL;
 		}
 		(*it) = NULL;
 	} else {
 		// we want to make sure to not delete any dangling scripts.
 		(*it) = scriptToDelete->m_nextScriptInSequence;
-		MemoryPoolObject::deleteInstance(scriptToDelete);
+		deleteInstance(scriptToDelete);
 		scriptToDelete = NULL;
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
@@ -6706,7 +6706,7 @@ void ScriptEngine::removeObjectTypes(ObjectTypes *typesToRemove)
 	}
 
 	// delete it.
-	typesToRemove->deleteInstance();
+	MemoryPoolObject::deleteInstance(typesToRemove);
 
 	// remove it from the main array of stuff
 	m_allObjectTypeLists.erase(it);
@@ -8077,14 +8077,14 @@ ScriptEngine::VecSequentialScriptPtrIt ScriptEngine::cleanupSequentialScript(Vec
 		while (seqScript) {
 			scriptToDelete = seqScript;
 			seqScript = seqScript->m_nextScriptInSequence;
-			scriptToDelete->deleteInstance();
+			MemoryPoolObject::deleteInstance(scriptToDelete);
 			scriptToDelete = NULL;
 		}
 		(*it) = NULL;
 	} else {
 		// we want to make sure to not delete any dangling scripts.
 		(*it) = scriptToDelete->m_nextScriptInSequence;
-		scriptToDelete->deleteInstance();
+		MemoryPoolObject::deleteInstance(scriptToDelete);
 		scriptToDelete = NULL;
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/Scripts.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/Scripts.cpp
@@ -202,7 +202,7 @@ void ScriptList::reset(void)
 	{
 		ScriptList* pList = TheSidesList->getSideInfo(i)->getScriptList();
 		TheSidesList->getSideInfo(i)->setScriptList(NULL);
-		pList->deleteInstance();
+		MemoryPoolObject::deleteInstance(pList);
 	}
 }
 
@@ -224,11 +224,11 @@ m_firstScript(NULL)
 ScriptList::~ScriptList(void) 
 {
 	if (m_firstGroup) {
-		m_firstGroup->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_firstGroup);
 		m_firstGroup = NULL;
 	}
 	if (m_firstScript) {
-		m_firstScript->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_firstScript);
 		m_firstScript = NULL;
 	}
 }
@@ -421,7 +421,7 @@ void ScriptList::discard(void)
 {
 	m_firstGroup = NULL;
 	m_firstScript = NULL;
-	this->deleteInstance();
+	MemoryPoolObject::deleteInstance(this);
 }
 
 /**
@@ -493,7 +493,7 @@ void ScriptList::deleteScript(Script *pScr)
 	}
 	// Clear the link & delete.
 	pCur->setNextScript(NULL);
-	pCur->deleteInstance();
+	MemoryPoolObject::deleteInstance(pCur);
 }
 
 /**
@@ -518,7 +518,7 @@ void ScriptList::deleteGroup(ScriptGroup *pGrp)
 	}
 	// Clear the link & delete.
 	pCur->setNextGroup(NULL);
-	pCur->deleteInstance();
+	MemoryPoolObject::deleteInstance(pCur);
 }
 
 /**
@@ -535,7 +535,7 @@ Bool ScriptList::ParseScriptsDataChunk(DataChunkInput &file, DataChunkInfo *info
 	DEBUG_ASSERTCRASH(s_numInReadList==0, ("Leftover scripts floating aroung."));
 	for (i=0; i<s_numInReadList; i++) {
 		if (s_readLists[i]) {
-			s_readLists[i]->deleteInstance();
+			MemoryPoolObject::deleteInstance(s_readLists[i]);
 			s_readLists[i] = NULL;
 		}
 	}
@@ -659,7 +659,7 @@ ScriptGroup::~ScriptGroup(void)
 {
 	if (m_firstScript) {
 		// Delete the first script.  m_firstScript deletes the entire list.
-		m_firstScript->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_firstScript);
 		m_firstScript = NULL;
 	}
 	if (m_nextGroup) {
@@ -669,7 +669,7 @@ ScriptGroup::~ScriptGroup(void)
 		while (cur) {
 			next = cur->getNext();
 			cur->setNextGroup(NULL); // prevents recursion. 
-			cur->deleteInstance();
+			MemoryPoolObject::deleteInstance(cur);
 			cur = next; 
 		}
 	}
@@ -830,7 +830,7 @@ void ScriptGroup::deleteScript(Script *pScr)
 	}
 	// Clear link & delete.
 	pCur->setNextScript(NULL);
-	pCur->deleteInstance();
+	MemoryPoolObject::deleteInstance(pCur);
 }
 
 /**
@@ -943,19 +943,19 @@ Script::~Script(void)
 		while (cur) {
 			next = cur->getNext();
 			cur->setNextScript(NULL); // prevents recursion. 
-			cur->deleteInstance();
+			MemoryPoolObject::deleteInstance(cur);
 			cur = next; 
 		}
 	}
 	if (m_condition) {
-		m_condition->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_condition);
 	}
 	if (m_action) {
-		m_action->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_action);
 	}
 
 	if (m_actionFalse) {
-		m_actionFalse->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_actionFalse);
 	}
 }
 
@@ -1004,10 +1004,10 @@ Script *Script::duplicate(void) const
 {
 	Script *pNew = newInstance(Script);	
 	if (pNew->m_condition) {
-		pNew->m_condition->deleteInstance();
+		MemoryPoolObject::deleteInstance(pNew->m_condition);
 	}
 	if (pNew->m_action) {
-		pNew->m_action->deleteInstance();
+		MemoryPoolObject::deleteInstance(pNew->m_action);
 	}
 	pNew->m_scriptName = m_scriptName;
 	pNew->m_comment = m_comment;
@@ -1043,10 +1043,10 @@ Script *Script::duplicateAndQualify(const AsciiString& qualifier,
 {
 	Script *pNew = newInstance(Script);
 	if (pNew->m_condition) {
-		pNew->m_condition->deleteInstance();
+		MemoryPoolObject::deleteInstance(pNew->m_condition);
 	}
 	if (pNew->m_action) {
-		pNew->m_action->deleteInstance();
+		MemoryPoolObject::deleteInstance(pNew->m_action);
 	}
 	pNew->m_scriptName = m_scriptName;
 	pNew->m_scriptName.concat(qualifier);
@@ -1092,17 +1092,17 @@ void Script::updateFrom(Script *pSrc)
 	this->m_normal = pSrc->m_normal;
 	this->m_hard = pSrc->m_hard;
 	if (this->m_condition) {
-		this->m_condition->deleteInstance();
+		MemoryPoolObject::deleteInstance(this->m_condition);
 	}
 	this->m_condition = pSrc->m_condition;
 	pSrc->m_condition = NULL;
 	if (this->m_action) {
-		this->m_action->deleteInstance();
+		MemoryPoolObject::deleteInstance(this->m_action);
 	}
 	this->m_action = pSrc->m_action;
 	pSrc->m_action = NULL;
 	if (this->m_actionFalse) {
-		this->m_actionFalse->deleteInstance();
+		MemoryPoolObject::deleteInstance(this->m_actionFalse);
 	}
 	this->m_actionFalse = pSrc->m_actionFalse;
 	pSrc->m_actionFalse = NULL;
@@ -1127,7 +1127,7 @@ void Script::deleteOrCondition(OrCondition *pCond)
 		m_condition = pCur->getNextOrCondition();
 	}
 	pCur->setNextOrCondition(NULL);
-	pCur->deleteInstance();
+	MemoryPoolObject::deleteInstance(pCur);
 }
 
 
@@ -1150,7 +1150,7 @@ void Script::deleteAction(ScriptAction *pAct)
 		m_action = pCur->getNext();
 	}
 	pCur->setNextAction(NULL);
-	pCur->deleteInstance();
+	MemoryPoolObject::deleteInstance(pCur);
 }
 
 
@@ -1173,7 +1173,7 @@ void Script::deleteFalseAction(ScriptAction *pAct)
 		m_actionFalse = pCur->getNext();
 	}
 	pCur->setNextAction(NULL);
-	pCur->deleteInstance();
+	MemoryPoolObject::deleteInstance(pCur);
 }
 
 
@@ -1352,7 +1352,7 @@ OrCondition *Script::findPreviousOrCondition( OrCondition *curOr )
 OrCondition::~OrCondition(void) 
 {
 	if (m_firstAnd) {
-		m_firstAnd->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_firstAnd);
 		m_firstAnd = NULL;
 	}
 	if (m_nextOr) {
@@ -1361,7 +1361,7 @@ OrCondition::~OrCondition(void)
 		while (cur) {
 			next = cur->getNextOrCondition();
 			cur->setNextOrCondition(NULL); // prevents recursion. 
-			cur->deleteInstance();
+			MemoryPoolObject::deleteInstance(cur);
 			cur = next; 
 		}
 	}
@@ -1434,7 +1434,7 @@ void OrCondition::deleteCondition(Condition *pCond)
 	DEBUG_ASSERTCRASH(pCur, ("Couldn't find condition."));
 	if (pCur==NULL) 
 		return;
-	pCur->deleteInstance();
+	MemoryPoolObject::deleteInstance(pCur);
 }
 
 
@@ -1545,7 +1545,7 @@ void Condition::setConditionType(enum ConditionType type)
 	Int i;
 	for (i=0; i<m_numParms; i++) {
 		if (m_parms[i]) 
-			m_parms[i]->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_parms[i]);
 		m_parms[i] = NULL;
 	}
 	m_conditionType = type;
@@ -1603,7 +1603,7 @@ Condition::~Condition(void)
 {
 	Int i;
 	for (i=0; i<m_numParms; i++) {
-		m_parms[i]->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_parms[i]);
 		m_parms[i] = NULL;
 	}
 	if (m_nextAndCondition) {
@@ -1612,7 +1612,7 @@ Condition::~Condition(void)
 		while (cur) {
 			next = cur->getNext();
 			cur->setNextCondition(NULL); // prevents recursion. 
-			cur->deleteInstance();
+			MemoryPoolObject::deleteInstance(cur);
 			cur = next; 
 		}
 	}
@@ -2298,7 +2298,7 @@ void ScriptAction::setActionType(enum ScriptActionType type)
 	Int i;
 	for (i=0; i<m_numParms; i++) {
 		if (m_parms[i]) 
-			m_parms[i]->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_parms[i]);
 		m_parms[i] = NULL;
 	}
 	m_actionType = type;
@@ -2364,7 +2364,7 @@ ScriptAction::~ScriptAction(void)
 {
 	Int i;
 	for (i=0; i<m_numParms; i++) {
-		m_parms[i]->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_parms[i]);
 		m_parms[i] = NULL;
 	}
 	if (m_nextAction) {
@@ -2373,7 +2373,7 @@ ScriptAction::~ScriptAction(void)
 		while (cur) {
 			next = cur->getNext();
 			cur->setNextAction(NULL); // prevents recursion. 
-			cur->deleteInstance();
+			MemoryPoolObject::deleteInstance(cur);
 			cur = next; 
 		}
 	}
@@ -2520,7 +2520,7 @@ ScriptAction *ScriptAction::ParseAction(DataChunkInput &file, DataChunkInfo *inf
 			if (pScriptAction->m_numParms == 1)
 			{		
 				Bool flank = pScriptAction->m_parms[0]->getInt()!=0;
-				pScriptAction->m_parms[0]->deleteInstance();
+				MemoryPoolObject::deleteInstance(pScriptAction->m_parms[0]);
 				pScriptAction->m_numParms = 0;
 				if (flank) pScriptAction->m_actionType = SKIRMISH_BUILD_BASE_DEFENSE_FLANK;
 			}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/Scripts.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/Scripts.cpp
@@ -202,7 +202,7 @@ void ScriptList::reset(void)
 	{
 		ScriptList* pList = TheSidesList->getSideInfo(i)->getScriptList();
 		TheSidesList->getSideInfo(i)->setScriptList(NULL);
-		MemoryPoolObject::deleteInstance(pList);
+		deleteInstance(pList);
 	}
 }
 
@@ -224,11 +224,11 @@ m_firstScript(NULL)
 ScriptList::~ScriptList(void) 
 {
 	if (m_firstGroup) {
-		MemoryPoolObject::deleteInstance(m_firstGroup);
+		deleteInstance(m_firstGroup);
 		m_firstGroup = NULL;
 	}
 	if (m_firstScript) {
-		MemoryPoolObject::deleteInstance(m_firstScript);
+		deleteInstance(m_firstScript);
 		m_firstScript = NULL;
 	}
 }
@@ -421,7 +421,7 @@ void ScriptList::discard(void)
 {
 	m_firstGroup = NULL;
 	m_firstScript = NULL;
-	MemoryPoolObject::deleteInstance(this);
+	deleteInstance(this);
 }
 
 /**
@@ -493,7 +493,7 @@ void ScriptList::deleteScript(Script *pScr)
 	}
 	// Clear the link & delete.
 	pCur->setNextScript(NULL);
-	MemoryPoolObject::deleteInstance(pCur);
+	deleteInstance(pCur);
 }
 
 /**
@@ -518,7 +518,7 @@ void ScriptList::deleteGroup(ScriptGroup *pGrp)
 	}
 	// Clear the link & delete.
 	pCur->setNextGroup(NULL);
-	MemoryPoolObject::deleteInstance(pCur);
+	deleteInstance(pCur);
 }
 
 /**
@@ -535,7 +535,7 @@ Bool ScriptList::ParseScriptsDataChunk(DataChunkInput &file, DataChunkInfo *info
 	DEBUG_ASSERTCRASH(s_numInReadList==0, ("Leftover scripts floating aroung."));
 	for (i=0; i<s_numInReadList; i++) {
 		if (s_readLists[i]) {
-			MemoryPoolObject::deleteInstance(s_readLists[i]);
+			deleteInstance(s_readLists[i]);
 			s_readLists[i] = NULL;
 		}
 	}
@@ -659,7 +659,7 @@ ScriptGroup::~ScriptGroup(void)
 {
 	if (m_firstScript) {
 		// Delete the first script.  m_firstScript deletes the entire list.
-		MemoryPoolObject::deleteInstance(m_firstScript);
+		deleteInstance(m_firstScript);
 		m_firstScript = NULL;
 	}
 	if (m_nextGroup) {
@@ -669,7 +669,7 @@ ScriptGroup::~ScriptGroup(void)
 		while (cur) {
 			next = cur->getNext();
 			cur->setNextGroup(NULL); // prevents recursion. 
-			MemoryPoolObject::deleteInstance(cur);
+			deleteInstance(cur);
 			cur = next; 
 		}
 	}
@@ -830,7 +830,7 @@ void ScriptGroup::deleteScript(Script *pScr)
 	}
 	// Clear link & delete.
 	pCur->setNextScript(NULL);
-	MemoryPoolObject::deleteInstance(pCur);
+	deleteInstance(pCur);
 }
 
 /**
@@ -943,19 +943,19 @@ Script::~Script(void)
 		while (cur) {
 			next = cur->getNext();
 			cur->setNextScript(NULL); // prevents recursion. 
-			MemoryPoolObject::deleteInstance(cur);
+			deleteInstance(cur);
 			cur = next; 
 		}
 	}
 	if (m_condition) {
-		MemoryPoolObject::deleteInstance(m_condition);
+		deleteInstance(m_condition);
 	}
 	if (m_action) {
-		MemoryPoolObject::deleteInstance(m_action);
+		deleteInstance(m_action);
 	}
 
 	if (m_actionFalse) {
-		MemoryPoolObject::deleteInstance(m_actionFalse);
+		deleteInstance(m_actionFalse);
 	}
 }
 
@@ -1004,10 +1004,10 @@ Script *Script::duplicate(void) const
 {
 	Script *pNew = newInstance(Script);	
 	if (pNew->m_condition) {
-		MemoryPoolObject::deleteInstance(pNew->m_condition);
+		deleteInstance(pNew->m_condition);
 	}
 	if (pNew->m_action) {
-		MemoryPoolObject::deleteInstance(pNew->m_action);
+		deleteInstance(pNew->m_action);
 	}
 	pNew->m_scriptName = m_scriptName;
 	pNew->m_comment = m_comment;
@@ -1043,10 +1043,10 @@ Script *Script::duplicateAndQualify(const AsciiString& qualifier,
 {
 	Script *pNew = newInstance(Script);
 	if (pNew->m_condition) {
-		MemoryPoolObject::deleteInstance(pNew->m_condition);
+		deleteInstance(pNew->m_condition);
 	}
 	if (pNew->m_action) {
-		MemoryPoolObject::deleteInstance(pNew->m_action);
+		deleteInstance(pNew->m_action);
 	}
 	pNew->m_scriptName = m_scriptName;
 	pNew->m_scriptName.concat(qualifier);
@@ -1092,17 +1092,17 @@ void Script::updateFrom(Script *pSrc)
 	this->m_normal = pSrc->m_normal;
 	this->m_hard = pSrc->m_hard;
 	if (this->m_condition) {
-		MemoryPoolObject::deleteInstance(this->m_condition);
+		deleteInstance(this->m_condition);
 	}
 	this->m_condition = pSrc->m_condition;
 	pSrc->m_condition = NULL;
 	if (this->m_action) {
-		MemoryPoolObject::deleteInstance(this->m_action);
+		deleteInstance(this->m_action);
 	}
 	this->m_action = pSrc->m_action;
 	pSrc->m_action = NULL;
 	if (this->m_actionFalse) {
-		MemoryPoolObject::deleteInstance(this->m_actionFalse);
+		deleteInstance(this->m_actionFalse);
 	}
 	this->m_actionFalse = pSrc->m_actionFalse;
 	pSrc->m_actionFalse = NULL;
@@ -1127,7 +1127,7 @@ void Script::deleteOrCondition(OrCondition *pCond)
 		m_condition = pCur->getNextOrCondition();
 	}
 	pCur->setNextOrCondition(NULL);
-	MemoryPoolObject::deleteInstance(pCur);
+	deleteInstance(pCur);
 }
 
 
@@ -1150,7 +1150,7 @@ void Script::deleteAction(ScriptAction *pAct)
 		m_action = pCur->getNext();
 	}
 	pCur->setNextAction(NULL);
-	MemoryPoolObject::deleteInstance(pCur);
+	deleteInstance(pCur);
 }
 
 
@@ -1173,7 +1173,7 @@ void Script::deleteFalseAction(ScriptAction *pAct)
 		m_actionFalse = pCur->getNext();
 	}
 	pCur->setNextAction(NULL);
-	MemoryPoolObject::deleteInstance(pCur);
+	deleteInstance(pCur);
 }
 
 
@@ -1352,7 +1352,7 @@ OrCondition *Script::findPreviousOrCondition( OrCondition *curOr )
 OrCondition::~OrCondition(void) 
 {
 	if (m_firstAnd) {
-		MemoryPoolObject::deleteInstance(m_firstAnd);
+		deleteInstance(m_firstAnd);
 		m_firstAnd = NULL;
 	}
 	if (m_nextOr) {
@@ -1361,7 +1361,7 @@ OrCondition::~OrCondition(void)
 		while (cur) {
 			next = cur->getNextOrCondition();
 			cur->setNextOrCondition(NULL); // prevents recursion. 
-			MemoryPoolObject::deleteInstance(cur);
+			deleteInstance(cur);
 			cur = next; 
 		}
 	}
@@ -1434,7 +1434,7 @@ void OrCondition::deleteCondition(Condition *pCond)
 	DEBUG_ASSERTCRASH(pCur, ("Couldn't find condition."));
 	if (pCur==NULL) 
 		return;
-	MemoryPoolObject::deleteInstance(pCur);
+	deleteInstance(pCur);
 }
 
 
@@ -1545,7 +1545,7 @@ void Condition::setConditionType(enum ConditionType type)
 	Int i;
 	for (i=0; i<m_numParms; i++) {
 		if (m_parms[i]) 
-			MemoryPoolObject::deleteInstance(m_parms[i]);
+			deleteInstance(m_parms[i]);
 		m_parms[i] = NULL;
 	}
 	m_conditionType = type;
@@ -1603,7 +1603,7 @@ Condition::~Condition(void)
 {
 	Int i;
 	for (i=0; i<m_numParms; i++) {
-		MemoryPoolObject::deleteInstance(m_parms[i]);
+		deleteInstance(m_parms[i]);
 		m_parms[i] = NULL;
 	}
 	if (m_nextAndCondition) {
@@ -1612,7 +1612,7 @@ Condition::~Condition(void)
 		while (cur) {
 			next = cur->getNext();
 			cur->setNextCondition(NULL); // prevents recursion. 
-			MemoryPoolObject::deleteInstance(cur);
+			deleteInstance(cur);
 			cur = next; 
 		}
 	}
@@ -2298,7 +2298,7 @@ void ScriptAction::setActionType(enum ScriptActionType type)
 	Int i;
 	for (i=0; i<m_numParms; i++) {
 		if (m_parms[i]) 
-			MemoryPoolObject::deleteInstance(m_parms[i]);
+			deleteInstance(m_parms[i]);
 		m_parms[i] = NULL;
 	}
 	m_actionType = type;
@@ -2364,7 +2364,7 @@ ScriptAction::~ScriptAction(void)
 {
 	Int i;
 	for (i=0; i<m_numParms; i++) {
-		MemoryPoolObject::deleteInstance(m_parms[i]);
+		deleteInstance(m_parms[i]);
 		m_parms[i] = NULL;
 	}
 	if (m_nextAction) {
@@ -2373,7 +2373,7 @@ ScriptAction::~ScriptAction(void)
 		while (cur) {
 			next = cur->getNext();
 			cur->setNextAction(NULL); // prevents recursion. 
-			MemoryPoolObject::deleteInstance(cur);
+			deleteInstance(cur);
 			cur = next; 
 		}
 	}
@@ -2520,7 +2520,7 @@ ScriptAction *ScriptAction::ParseAction(DataChunkInput &file, DataChunkInfo *inf
 			if (pScriptAction->m_numParms == 1)
 			{		
 				Bool flank = pScriptAction->m_parms[0]->getInt()!=0;
-				MemoryPoolObject::deleteInstance(pScriptAction->m_parms[0]);
+				deleteInstance(pScriptAction->m_parms[0]);
 				pScriptAction->m_numParms = 0;
 				if (flank) pScriptAction->m_actionType = SKIRMISH_BUILD_BASE_DEFENSE_FLANK;
 			}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/CaveSystem.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/CaveSystem.cpp
@@ -55,7 +55,7 @@ void CaveSystem::reset()
 		TunnelTracker *currentTracker = *iter;
 		if( currentTracker )// could be NULL, since we don't slide back to fill deleted entries so offsets don't shift
 		{
-			currentTracker->deleteInstance();
+			MemoryPoolObject::deleteInstance(currentTracker);
 		}
 	}
 	m_tunnelTrackerVector.clear();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/CaveSystem.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/CaveSystem.cpp
@@ -55,7 +55,7 @@ void CaveSystem::reset()
 		TunnelTracker *currentTracker = *iter;
 		if( currentTracker )// could be NULL, since we don't slide back to fill deleted entries so offsets don't shift
 		{
-			MemoryPoolObject::deleteInstance(currentTracker);
+			deleteInstance(currentTracker);
 		}
 	}
 	m_tunnelTrackerVector.clear();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/CrateSystem.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/CrateSystem.cpp
@@ -49,7 +49,7 @@ CrateSystem::~CrateSystem()
 		CrateTemplate *currentTemplate = m_crateTemplateVector[templateIndex];
 		if( currentTemplate )
 		{
-			MemoryPoolObject::deleteInstance(currentTemplate);
+			deleteInstance(currentTemplate);
 		}
 	}
 	m_crateTemplateVector.clear();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/CrateSystem.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/CrateSystem.cpp
@@ -49,7 +49,7 @@ CrateSystem::~CrateSystem()
 		CrateTemplate *currentTemplate = m_crateTemplateVector[templateIndex];
 		if( currentTemplate )
 		{
-			currentTemplate->deleteInstance();
+			MemoryPoolObject::deleteInstance(currentTemplate);
 		}
 	}
 	m_crateTemplateVector.clear();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -336,7 +336,7 @@ GameLogic::~GameLogic()
 	if (m_background)
 	{
 		m_background->destroyWindows();
-		m_background->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_background);
 		m_background = NULL;
 	}
 
@@ -1151,7 +1151,7 @@ void GameLogic::startNewGame( Bool loadingSaveGame )
 				if(m_background)
 				{
 					m_background->destroyWindows();
-					m_background->deleteInstance();
+					MemoryPoolObject::deleteInstance(m_background);
 					m_background = NULL;
 				}
 				m_loadScreen = getLoadScreen( loadingSaveGame );
@@ -1281,7 +1281,7 @@ void GameLogic::startNewGame( Bool loadingSaveGame )
 	if(m_background)
 	{
 		m_background->destroyWindows();
-		m_background->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_background);
 		m_background = NULL;
 	}
 	setFPMode();
@@ -1558,7 +1558,7 @@ void GameLogic::startNewGame( Bool loadingSaveGame )
 				}
 				for (Int i=0; i<count; ++i)
 				{
-					scripts[i]->deleteInstance();
+					MemoryPoolObject::deleteInstance(scripts[i]);
 				}
 			}
 		}
@@ -2537,7 +2537,7 @@ void GameLogic::processDestroyList( void )
 		// remove object from lookup table
 		removeObjectFromLookupTable( currentObject );
 
-		currentObject->friend_deleteInstance();//actual delete
+		Object::friend_deleteInstance(currentObject);//actual delete
 	}
 
 	m_objectsToDestroy.clear();//list full of bad pointers now, clear it.  If anyone's deletion resulted

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -336,7 +336,7 @@ GameLogic::~GameLogic()
 	if (m_background)
 	{
 		m_background->destroyWindows();
-		MemoryPoolObject::deleteInstance(m_background);
+		deleteInstance(m_background);
 		m_background = NULL;
 	}
 
@@ -1151,7 +1151,7 @@ void GameLogic::startNewGame( Bool loadingSaveGame )
 				if(m_background)
 				{
 					m_background->destroyWindows();
-					MemoryPoolObject::deleteInstance(m_background);
+					deleteInstance(m_background);
 					m_background = NULL;
 				}
 				m_loadScreen = getLoadScreen( loadingSaveGame );
@@ -1281,7 +1281,7 @@ void GameLogic::startNewGame( Bool loadingSaveGame )
 	if(m_background)
 	{
 		m_background->destroyWindows();
-		MemoryPoolObject::deleteInstance(m_background);
+		deleteInstance(m_background);
 		m_background = NULL;
 	}
 	setFPMode();
@@ -1558,7 +1558,7 @@ void GameLogic::startNewGame( Bool loadingSaveGame )
 				}
 				for (Int i=0; i<count; ++i)
 				{
-					MemoryPoolObject::deleteInstance(scripts[i]);
+					deleteInstance(scripts[i]);
 				}
 			}
 		}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -296,7 +296,7 @@ void GameLogic::clearGameData( Bool showScoreScreen )
 	if(m_background)
 	{
 		m_background->destroyWindows();
-		m_background->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_background);
 		m_background = NULL;
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -296,7 +296,7 @@ void GameLogic::clearGameData( Bool showScoreScreen )
 	if(m_background)
 	{
 		m_background->destroyWindows();
-		MemoryPoolObject::deleteInstance(m_background);
+		deleteInstance(m_background);
 		m_background = NULL;
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/RankInfo.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/RankInfo.cpp
@@ -56,7 +56,7 @@ RankInfoStore::~RankInfoStore()
 		RankInfo* ri = m_rankInfos[level];
 		if (ri)
 		{
-			ri->deleteInstance();
+			MemoryPoolObject::deleteInstance(ri);
 		}
 	}
 	m_rankInfos.clear();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/RankInfo.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/RankInfo.cpp
@@ -56,7 +56,7 @@ RankInfoStore::~RankInfoStore()
 		RankInfo* ri = m_rankInfos[level];
 		if (ri)
 		{
-			MemoryPoolObject::deleteInstance(ri);
+			deleteInstance(ri);
 		}
 	}
 	m_rankInfos.clear();

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/Connection.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/Connection.cpp
@@ -59,12 +59,12 @@ Connection::Connection() {
  */
 Connection::~Connection() {
 	if (m_user != NULL) {
-		m_user->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_user);
 		m_user = NULL;
 	}
 
 	if (m_netCommandList != NULL) {
-		m_netCommandList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_netCommandList);
 		m_netCommandList = NULL;
 	}
 }
@@ -76,7 +76,7 @@ void Connection::init() {
 	m_transport = NULL;
 
 	if (m_user != NULL) {
-		m_user->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_user);
 		m_user = NULL;
 	}
 
@@ -124,7 +124,7 @@ void Connection::attachTransport(Transport *transport) {
  */
 void Connection::setUser(User *user) {
 	if (m_user != NULL) {
-		m_user->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_user);
 	}
 
 	m_user = user;
@@ -164,7 +164,7 @@ void Connection::sendNetCommandMsg(NetCommandMsg *msg, UnsignedByte relay) {
 		NetCommandRef *tempref = NEW_NETCOMMANDREF(msg);
 
 		Bool msgFits = packet->addCommand(tempref);
-		tempref->deleteInstance(); // delete the temporary reference.
+		MemoryPoolObject::deleteInstance(tempref); // delete the temporary reference.
 		tempref = NULL;
 
 		if (!msgFits) {
@@ -186,15 +186,15 @@ void Connection::sendNetCommandMsg(NetCommandMsg *msg, UnsignedByte relay) {
 					ref1 = ref1->getNext();
 				}
 
-				tempPacket->deleteInstance();
+				MemoryPoolObject::deleteInstance(tempPacket);
 				tempPacket = NULL;
 				++tempPacketPtr;
 
-				list->deleteInstance();
+				MemoryPoolObject::deleteInstance(list);
 				list = NULL;
 			}
 
-			origref->deleteInstance();
+			MemoryPoolObject::deleteInstance(origref);
 			origref = NULL;
 
 			return;
@@ -234,7 +234,7 @@ void Connection::clearCommandsExceptFrom( Int playerIndex )
 			m_netCommandList->removeMessage(tmp);
 			NetCommandRef *toDelete = tmp;
 			tmp = tmp->getNext();
-			toDelete->deleteInstance();
+			MemoryPoolObject::deleteInstance(toDelete);
 		} else {
 			tmp = tmp->getNext();
 		}
@@ -305,7 +305,7 @@ UnsignedInt Connection::doSend() {
 						msg->setTimeLastSent(curtime);
 					} else {
 						m_netCommandList->removeMessage(msg);
-						msg->deleteInstance();
+						MemoryPoolObject::deleteInstance(msg);
 					}
 				}
 			}
@@ -326,7 +326,7 @@ UnsignedInt Connection::doSend() {
 			m_lastTimeSent = curtime;
 		}
 		if (packet != NULL) {
-			packet->deleteInstance(); // delete the packet now that we're done with it.
+			MemoryPoolObject::deleteInstance(packet); // delete the packet now that we're done with it.
 		}
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/Connection.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/Connection.cpp
@@ -59,12 +59,12 @@ Connection::Connection() {
  */
 Connection::~Connection() {
 	if (m_user != NULL) {
-		MemoryPoolObject::deleteInstance(m_user);
+		deleteInstance(m_user);
 		m_user = NULL;
 	}
 
 	if (m_netCommandList != NULL) {
-		MemoryPoolObject::deleteInstance(m_netCommandList);
+		deleteInstance(m_netCommandList);
 		m_netCommandList = NULL;
 	}
 }
@@ -76,7 +76,7 @@ void Connection::init() {
 	m_transport = NULL;
 
 	if (m_user != NULL) {
-		MemoryPoolObject::deleteInstance(m_user);
+		deleteInstance(m_user);
 		m_user = NULL;
 	}
 
@@ -124,7 +124,7 @@ void Connection::attachTransport(Transport *transport) {
  */
 void Connection::setUser(User *user) {
 	if (m_user != NULL) {
-		MemoryPoolObject::deleteInstance(m_user);
+		deleteInstance(m_user);
 	}
 
 	m_user = user;
@@ -164,7 +164,7 @@ void Connection::sendNetCommandMsg(NetCommandMsg *msg, UnsignedByte relay) {
 		NetCommandRef *tempref = NEW_NETCOMMANDREF(msg);
 
 		Bool msgFits = packet->addCommand(tempref);
-		MemoryPoolObject::deleteInstance(tempref); // delete the temporary reference.
+		deleteInstance(tempref); // delete the temporary reference.
 		tempref = NULL;
 
 		if (!msgFits) {
@@ -186,15 +186,15 @@ void Connection::sendNetCommandMsg(NetCommandMsg *msg, UnsignedByte relay) {
 					ref1 = ref1->getNext();
 				}
 
-				MemoryPoolObject::deleteInstance(tempPacket);
+				deleteInstance(tempPacket);
 				tempPacket = NULL;
 				++tempPacketPtr;
 
-				MemoryPoolObject::deleteInstance(list);
+				deleteInstance(list);
 				list = NULL;
 			}
 
-			MemoryPoolObject::deleteInstance(origref);
+			deleteInstance(origref);
 			origref = NULL;
 
 			return;
@@ -234,7 +234,7 @@ void Connection::clearCommandsExceptFrom( Int playerIndex )
 			m_netCommandList->removeMessage(tmp);
 			NetCommandRef *toDelete = tmp;
 			tmp = tmp->getNext();
-			MemoryPoolObject::deleteInstance(toDelete);
+			deleteInstance(toDelete);
 		} else {
 			tmp = tmp->getNext();
 		}
@@ -305,7 +305,7 @@ UnsignedInt Connection::doSend() {
 						msg->setTimeLastSent(curtime);
 					} else {
 						m_netCommandList->removeMessage(msg);
-						MemoryPoolObject::deleteInstance(msg);
+						deleteInstance(msg);
 					}
 				}
 			}
@@ -326,7 +326,7 @@ UnsignedInt Connection::doSend() {
 			m_lastTimeSent = curtime;
 		}
 		if (packet != NULL) {
-			MemoryPoolObject::deleteInstance(packet); // delete the packet now that we're done with it.
+			deleteInstance(packet); // delete the packet now that we're done with it.
 		}
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/ConnectionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/ConnectionManager.cpp
@@ -65,7 +65,7 @@
 ConnectionManager::~ConnectionManager(void)
 {
 	if (m_localUser != NULL) {
-		m_localUser->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_localUser);
 		m_localUser = NULL;
 	}
 
@@ -78,14 +78,14 @@ ConnectionManager::~ConnectionManager(void)
 	Int i = 0;
 	for (; i < MAX_SLOTS; ++i) {
 		if (m_frameData[i] != NULL) {
-			m_frameData[i]->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_frameData[i]);
 			m_frameData[i] = NULL;
 		}
 	}
 
 	for (i = 0; i < NUM_CONNECTIONS; ++i) {
 		if (m_connections[i] != NULL) {
-			m_connections[i]->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_connections[i]);
 			m_connections[i] = NULL;
 		}
 	}
@@ -102,17 +102,17 @@ ConnectionManager::~ConnectionManager(void)
 	}
 
 	if (m_pendingCommands != NULL) {
-		m_pendingCommands->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_pendingCommands);
 		m_pendingCommands = NULL;
 	}
 
 	if (m_relayedCommands != NULL) {
-		m_relayedCommands->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_relayedCommands);
 		m_relayedCommands = NULL;
 	}
 
 	if (m_netCommandWrapperList != NULL) {
-		m_netCommandWrapperList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_netCommandWrapperList);
 		m_netCommandWrapperList = NULL;
 	}
 
@@ -180,7 +180,7 @@ void ConnectionManager::init()
 
 	for (i = 0; i < MAX_SLOTS; ++i) {
 		if (m_frameData[i] != NULL) {
-			m_frameData[i]->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_frameData[i]);
 			m_frameData[i] = NULL;
 		}
 	}
@@ -234,7 +234,7 @@ void ConnectionManager::reset()
 	Int i = 0;
 	for (; i < NUM_CONNECTIONS; ++i) {
 		if (m_connections[i] != NULL) {
-			m_connections[i]->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_connections[i]);
 			m_connections[i] = NULL;
 		}
 	}
@@ -242,7 +242,7 @@ void ConnectionManager::reset()
 	for (i=0; i<MAX_SLOTS; ++i)
 	{
 		if (m_frameData[i] != NULL) {
-			m_frameData[i]->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_frameData[i]);
 			m_frameData[i] = NULL;
 		}
 	}
@@ -383,10 +383,10 @@ void ConnectionManager::doRelay() {
 			++numPackets;
 
 			// Delete this packet since we won't be needing it anymore.
-			packet->deleteInstance();
+			MemoryPoolObject::deleteInstance(packet);
 			packet = NULL;
 
-			cmdList->deleteInstance();
+			MemoryPoolObject::deleteInstance(cmdList);
 			cmdList = NULL;
 
 			// signal that this has been processed.
@@ -410,10 +410,10 @@ void ConnectionManager::doRelay() {
 	++numPackets;
 
 	// Delete this packet since we won't be needing it anymore.
-	packet->deleteInstance();
+	MemoryPoolObject::deleteInstance(packet);
 	packet = NULL;
 
-	cmdList->deleteInstance();
+	MemoryPoolObject::deleteInstance(cmdList);
 	cmdList = NULL;
 }
 
@@ -853,7 +853,7 @@ void ConnectionManager::processAckStage1(NetCommandMsg *msg) {
 			m_frameMetrics.processLatencyResponse(((NetFrameCommandMsg *)(ref->getCommand()))->getExecutionFrame());
 		}
 
-		ref->deleteInstance();
+		MemoryPoolObject::deleteInstance(ref);
 		ref = NULL;
 	}
 }
@@ -880,7 +880,7 @@ void ConnectionManager::processAckStage2(NetCommandMsg *msg) {
 		//DEBUG_LOG(("ConnectionManager::processAckStage2 - removing command %d from the pending commands list.\n", commandID));
 		DEBUG_ASSERTCRASH((m_localSlot == playerID), ("Found a command in the pending commands list that wasn't originated by the local player"));
 		m_pendingCommands->removeMessage(ref);
-		ref->deleteInstance();
+		MemoryPoolObject::deleteInstance(ref);
 		ref = NULL;
 	} else {
 		//DEBUG_LOG(("ConnectionManager::processAckStage2 - Couldn't find command %d from player %d in the pending commands list.\n", commandID, playerID));
@@ -898,7 +898,7 @@ void ConnectionManager::processAckStage2(NetCommandMsg *msg) {
 			m_relayedCommands->removeMessage(ref);
 			NetAckStage2CommandMsg *ackmsg = newInstance(NetAckStage2CommandMsg)(ref->getCommand());
 			sendLocalCommand(ackmsg, 1 << ackmsg->getOriginalPlayerID());
-			ref->deleteInstance();
+			MemoryPoolObject::deleteInstance(ref);
 			ref = NULL;
 
 			ackmsg->detach();
@@ -1196,7 +1196,7 @@ void ConnectionManager::update(Bool isInGame) {
 			if (m_connections[i]->isQuitting() && m_connections[i]->isQueueEmpty())
 			{
 				DEBUG_LOG(("ConnectionManager::update - deleting connection for slot %d\n", i));
-				m_connections[i]->deleteInstance();
+				MemoryPoolObject::deleteInstance(m_connections[i]);
 				m_connections[i] = NULL;
 			}
 		}
@@ -1204,7 +1204,7 @@ void ConnectionManager::update(Bool isInGame) {
 		if ((m_frameData[i] != NULL) && (m_frameData[i]->getIsQuitting() == TRUE)) {
 			if (m_frameData[i]->getQuitFrame() == TheGameLogic->getFrame()) {
 				DEBUG_LOG(("ConnectionManager::update - deleting frame data for slot %d on quitting frame %d\n", i, m_frameData[i]->getQuitFrame()));
-				m_frameData[i]->deleteInstance();
+				MemoryPoolObject::deleteInstance(m_frameData[i]);
 				m_frameData[i] = NULL;
 			}
 		}
@@ -1730,13 +1730,13 @@ PlayerLeaveCode ConnectionManager::disconnectPlayer(Int slot) {
 
 	if ((m_frameData[slot] != NULL) && (m_frameData[slot]->getIsQuitting() == FALSE)) {
 		DEBUG_LOG(("ConnectionManager::disconnectPlayer - deleting player %d frame data\n", slot));
-		m_frameData[slot]->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_frameData[slot]);
 		m_frameData[slot] = NULL;
 	}
 
 	if (m_connections[slot] != NULL && !m_connections[slot]->isQuitting()) {
 		DEBUG_LOG(("ConnectionManager::disconnectPlayer - deleting player %d connection\n", slot));
-		m_connections[slot]->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_connections[slot]);
 		m_connections[slot] = NULL;
 	}
 
@@ -2342,7 +2342,7 @@ void ConnectionManager::notifyOthersOfCurrentFrame(Int frame) {
 	NetCommandRef *ref = NEW_NETCOMMANDREF(msg);
 	ref->setRelay(1 << m_localSlot);
 	m_disconnectManager->processDisconnectCommand(ref, this);
-	ref->deleteInstance();
+	MemoryPoolObject::deleteInstance(ref);
 
 	msg->detach();
 
@@ -2365,7 +2365,7 @@ void ConnectionManager::notifyOthersOfNewFrame(UnsignedInt frame) {
 	NetCommandRef *ref = NEW_NETCOMMANDREF(msg);
 	ref->setRelay(1 << m_localSlot);
 	m_disconnectManager->processDisconnectCommand(ref, this);
-	ref->deleteInstance();
+	MemoryPoolObject::deleteInstance(ref);
 
 	msg->detach();
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/ConnectionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/ConnectionManager.cpp
@@ -65,7 +65,7 @@
 ConnectionManager::~ConnectionManager(void)
 {
 	if (m_localUser != NULL) {
-		MemoryPoolObject::deleteInstance(m_localUser);
+		deleteInstance(m_localUser);
 		m_localUser = NULL;
 	}
 
@@ -78,14 +78,14 @@ ConnectionManager::~ConnectionManager(void)
 	Int i = 0;
 	for (; i < MAX_SLOTS; ++i) {
 		if (m_frameData[i] != NULL) {
-			MemoryPoolObject::deleteInstance(m_frameData[i]);
+			deleteInstance(m_frameData[i]);
 			m_frameData[i] = NULL;
 		}
 	}
 
 	for (i = 0; i < NUM_CONNECTIONS; ++i) {
 		if (m_connections[i] != NULL) {
-			MemoryPoolObject::deleteInstance(m_connections[i]);
+			deleteInstance(m_connections[i]);
 			m_connections[i] = NULL;
 		}
 	}
@@ -102,17 +102,17 @@ ConnectionManager::~ConnectionManager(void)
 	}
 
 	if (m_pendingCommands != NULL) {
-		MemoryPoolObject::deleteInstance(m_pendingCommands);
+		deleteInstance(m_pendingCommands);
 		m_pendingCommands = NULL;
 	}
 
 	if (m_relayedCommands != NULL) {
-		MemoryPoolObject::deleteInstance(m_relayedCommands);
+		deleteInstance(m_relayedCommands);
 		m_relayedCommands = NULL;
 	}
 
 	if (m_netCommandWrapperList != NULL) {
-		MemoryPoolObject::deleteInstance(m_netCommandWrapperList);
+		deleteInstance(m_netCommandWrapperList);
 		m_netCommandWrapperList = NULL;
 	}
 
@@ -180,7 +180,7 @@ void ConnectionManager::init()
 
 	for (i = 0; i < MAX_SLOTS; ++i) {
 		if (m_frameData[i] != NULL) {
-			MemoryPoolObject::deleteInstance(m_frameData[i]);
+			deleteInstance(m_frameData[i]);
 			m_frameData[i] = NULL;
 		}
 	}
@@ -234,7 +234,7 @@ void ConnectionManager::reset()
 	Int i = 0;
 	for (; i < NUM_CONNECTIONS; ++i) {
 		if (m_connections[i] != NULL) {
-			MemoryPoolObject::deleteInstance(m_connections[i]);
+			deleteInstance(m_connections[i]);
 			m_connections[i] = NULL;
 		}
 	}
@@ -242,7 +242,7 @@ void ConnectionManager::reset()
 	for (i=0; i<MAX_SLOTS; ++i)
 	{
 		if (m_frameData[i] != NULL) {
-			MemoryPoolObject::deleteInstance(m_frameData[i]);
+			deleteInstance(m_frameData[i]);
 			m_frameData[i] = NULL;
 		}
 	}
@@ -383,10 +383,10 @@ void ConnectionManager::doRelay() {
 			++numPackets;
 
 			// Delete this packet since we won't be needing it anymore.
-			MemoryPoolObject::deleteInstance(packet);
+			deleteInstance(packet);
 			packet = NULL;
 
-			MemoryPoolObject::deleteInstance(cmdList);
+			deleteInstance(cmdList);
 			cmdList = NULL;
 
 			// signal that this has been processed.
@@ -410,10 +410,10 @@ void ConnectionManager::doRelay() {
 	++numPackets;
 
 	// Delete this packet since we won't be needing it anymore.
-	MemoryPoolObject::deleteInstance(packet);
+	deleteInstance(packet);
 	packet = NULL;
 
-	MemoryPoolObject::deleteInstance(cmdList);
+	deleteInstance(cmdList);
 	cmdList = NULL;
 }
 
@@ -853,7 +853,7 @@ void ConnectionManager::processAckStage1(NetCommandMsg *msg) {
 			m_frameMetrics.processLatencyResponse(((NetFrameCommandMsg *)(ref->getCommand()))->getExecutionFrame());
 		}
 
-		MemoryPoolObject::deleteInstance(ref);
+		deleteInstance(ref);
 		ref = NULL;
 	}
 }
@@ -880,7 +880,7 @@ void ConnectionManager::processAckStage2(NetCommandMsg *msg) {
 		//DEBUG_LOG(("ConnectionManager::processAckStage2 - removing command %d from the pending commands list.\n", commandID));
 		DEBUG_ASSERTCRASH((m_localSlot == playerID), ("Found a command in the pending commands list that wasn't originated by the local player"));
 		m_pendingCommands->removeMessage(ref);
-		MemoryPoolObject::deleteInstance(ref);
+		deleteInstance(ref);
 		ref = NULL;
 	} else {
 		//DEBUG_LOG(("ConnectionManager::processAckStage2 - Couldn't find command %d from player %d in the pending commands list.\n", commandID, playerID));
@@ -898,7 +898,7 @@ void ConnectionManager::processAckStage2(NetCommandMsg *msg) {
 			m_relayedCommands->removeMessage(ref);
 			NetAckStage2CommandMsg *ackmsg = newInstance(NetAckStage2CommandMsg)(ref->getCommand());
 			sendLocalCommand(ackmsg, 1 << ackmsg->getOriginalPlayerID());
-			MemoryPoolObject::deleteInstance(ref);
+			deleteInstance(ref);
 			ref = NULL;
 
 			ackmsg->detach();
@@ -1196,7 +1196,7 @@ void ConnectionManager::update(Bool isInGame) {
 			if (m_connections[i]->isQuitting() && m_connections[i]->isQueueEmpty())
 			{
 				DEBUG_LOG(("ConnectionManager::update - deleting connection for slot %d\n", i));
-				MemoryPoolObject::deleteInstance(m_connections[i]);
+				deleteInstance(m_connections[i]);
 				m_connections[i] = NULL;
 			}
 		}
@@ -1204,7 +1204,7 @@ void ConnectionManager::update(Bool isInGame) {
 		if ((m_frameData[i] != NULL) && (m_frameData[i]->getIsQuitting() == TRUE)) {
 			if (m_frameData[i]->getQuitFrame() == TheGameLogic->getFrame()) {
 				DEBUG_LOG(("ConnectionManager::update - deleting frame data for slot %d on quitting frame %d\n", i, m_frameData[i]->getQuitFrame()));
-				MemoryPoolObject::deleteInstance(m_frameData[i]);
+				deleteInstance(m_frameData[i]);
 				m_frameData[i] = NULL;
 			}
 		}
@@ -1730,13 +1730,13 @@ PlayerLeaveCode ConnectionManager::disconnectPlayer(Int slot) {
 
 	if ((m_frameData[slot] != NULL) && (m_frameData[slot]->getIsQuitting() == FALSE)) {
 		DEBUG_LOG(("ConnectionManager::disconnectPlayer - deleting player %d frame data\n", slot));
-		MemoryPoolObject::deleteInstance(m_frameData[slot]);
+		deleteInstance(m_frameData[slot]);
 		m_frameData[slot] = NULL;
 	}
 
 	if (m_connections[slot] != NULL && !m_connections[slot]->isQuitting()) {
 		DEBUG_LOG(("ConnectionManager::disconnectPlayer - deleting player %d connection\n", slot));
-		MemoryPoolObject::deleteInstance(m_connections[slot]);
+		deleteInstance(m_connections[slot]);
 		m_connections[slot] = NULL;
 	}
 
@@ -2342,7 +2342,7 @@ void ConnectionManager::notifyOthersOfCurrentFrame(Int frame) {
 	NetCommandRef *ref = NEW_NETCOMMANDREF(msg);
 	ref->setRelay(1 << m_localSlot);
 	m_disconnectManager->processDisconnectCommand(ref, this);
-	MemoryPoolObject::deleteInstance(ref);
+	deleteInstance(ref);
 
 	msg->detach();
 
@@ -2365,7 +2365,7 @@ void ConnectionManager::notifyOthersOfNewFrame(UnsignedInt frame) {
 	NetCommandRef *ref = NEW_NETCOMMANDREF(msg);
 	ref->setRelay(1 << m_localSlot);
 	m_disconnectManager->processDisconnectCommand(ref, this);
-	MemoryPoolObject::deleteInstance(ref);
+	deleteInstance(ref);
 
 	msg->detach();
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/FrameData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/FrameData.cpp
@@ -50,7 +50,7 @@ FrameData::FrameData()
 FrameData::~FrameData() 
 {
 	if (m_commandList != NULL) {
-		m_commandList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_commandList);
 		m_commandList = NULL;
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/FrameData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/FrameData.cpp
@@ -50,7 +50,7 @@ FrameData::FrameData()
 FrameData::~FrameData() 
 {
 	if (m_commandList != NULL) {
-		MemoryPoolObject::deleteInstance(m_commandList);
+		deleteInstance(m_commandList);
 		m_commandList = NULL;
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameMessageParser.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameMessageParser.cpp
@@ -68,7 +68,7 @@ GameMessageParser::~GameMessageParser()
 	GameMessageParserArgumentType *temp = NULL;
 	while (m_first != NULL) {
 		temp = m_first->getNext();
-		m_first->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_first);
 		m_first = temp;
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameMessageParser.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameMessageParser.cpp
@@ -68,7 +68,7 @@ GameMessageParser::~GameMessageParser()
 	GameMessageParserArgumentType *temp = NULL;
 	while (m_first != NULL) {
 		temp = m_first->getNext();
-		MemoryPoolObject::deleteInstance(m_first);
+		deleteInstance(m_first);
 		m_first = temp;
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameSpyOverlay.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameSpyOverlay.cpp
@@ -267,7 +267,7 @@ void GameSpyCloseOverlay( GSOverlayType overlay )
 	{
 		overlayLayouts[overlay]->runShutdown();
 		overlayLayouts[overlay]->destroyWindows();
-		MemoryPoolObject::deleteInstance(overlayLayouts[overlay]);
+		deleteInstance(overlayLayouts[overlay]);
 		overlayLayouts[overlay] = NULL;
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameSpyOverlay.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameSpyOverlay.cpp
@@ -267,7 +267,7 @@ void GameSpyCloseOverlay( GSOverlayType overlay )
 	{
 		overlayLayouts[overlay]->runShutdown();
 		overlayLayouts[overlay]->destroyWindows();
-		overlayLayouts[overlay]->deleteInstance();
+		MemoryPoolObject::deleteInstance(overlayLayouts[overlay]);
 		overlayLayouts[overlay] = NULL;
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/IPEnumeration.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/IPEnumeration.cpp
@@ -44,7 +44,7 @@ IPEnumeration::~IPEnumeration( void )
 	while (ip)
 	{
 		ip = ip->getNext();
-		MemoryPoolObject::deleteInstance(m_IPlist);
+		deleteInstance(m_IPlist);
 		m_IPlist = ip;
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/IPEnumeration.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/IPEnumeration.cpp
@@ -44,7 +44,7 @@ IPEnumeration::~IPEnumeration( void )
 	while (ip)
 	{
 		ip = ip->getNext();
-		m_IPlist->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_IPlist);
 		m_IPlist = ip;
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/NetCommandList.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/NetCommandList.cpp
@@ -115,7 +115,7 @@ void NetCommandList::reset() {
 		temp = m_first->getNext();
 		m_first->setNext(NULL);
 		m_first->setPrev(NULL);
-		m_first->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_first);
 		m_first = temp;
 	}
 	m_last = NULL;
@@ -160,7 +160,7 @@ NetCommandRef * NetCommandList::addMessage(NetCommandMsg *cmdMsg) {
 			if (isEqualCommandMsg(m_lastMessageInserted->getCommand(), msg->getCommand())) {
 
 				// This command is already in the list, don't duplicate it.
-				msg->deleteInstance();
+				MemoryPoolObject::deleteInstance(msg);
 				msg = NULL;
 				return NULL;
 			}
@@ -191,7 +191,7 @@ NetCommandRef * NetCommandList::addMessage(NetCommandMsg *cmdMsg) {
 		if (isEqualCommandMsg(m_last->getCommand(), msg->getCommand())) {
 
 			// This command is already in the list, don't duplicate it.
-			msg->deleteInstance();
+			MemoryPoolObject::deleteInstance(msg);
 			msg = NULL;
 			return NULL;
 		}
@@ -209,7 +209,7 @@ NetCommandRef * NetCommandList::addMessage(NetCommandMsg *cmdMsg) {
 		if (isEqualCommandMsg(m_first->getCommand(), msg->getCommand())) {
 
 			// This command is already in the list, don't duplicate it.
-			msg->deleteInstance();
+			MemoryPoolObject::deleteInstance(msg);
 			msg = NULL;
 			return NULL;
 		}
@@ -235,7 +235,7 @@ NetCommandRef * NetCommandList::addMessage(NetCommandMsg *cmdMsg) {
 		if (isEqualCommandMsg(m_last->getCommand(), msg->getCommand())) {
 
 			// This command is already in the list, don't duplicate it.
-			msg->deleteInstance();
+			MemoryPoolObject::deleteInstance(msg);
 			msg = NULL;
 			return NULL;
 		}
@@ -259,7 +259,7 @@ NetCommandRef * NetCommandList::addMessage(NetCommandMsg *cmdMsg) {
 		if (isEqualCommandMsg(m_last->getCommand(), msg->getCommand())) {
 
 			// This command is already in the list, don't duplicate it.
-			msg->deleteInstance();
+			MemoryPoolObject::deleteInstance(msg);
 			msg = NULL;
 			return NULL;
 		}
@@ -284,7 +284,7 @@ NetCommandRef * NetCommandList::addMessage(NetCommandMsg *cmdMsg) {
 		if (isEqualCommandMsg(m_last->getCommand(), msg->getCommand())) {
 
 			// This command is already in the list, don't duplicate it.
-			msg->deleteInstance();
+			MemoryPoolObject::deleteInstance(msg);
 			msg = NULL;
 			return NULL;
 		}
@@ -303,7 +303,7 @@ NetCommandRef * NetCommandList::addMessage(NetCommandMsg *cmdMsg) {
 		if (isEqualCommandMsg(m_first->getCommand(), msg->getCommand())) {
 
 			// This command is already in the list, don't duplicate it.
-			msg->deleteInstance();
+			MemoryPoolObject::deleteInstance(msg);
 			return NULL;
 		}
 
@@ -320,7 +320,7 @@ NetCommandRef * NetCommandList::addMessage(NetCommandMsg *cmdMsg) {
 		if (isEqualCommandMsg(tempmsg->getCommand(), msg->getCommand())) {
 
 		// This command is already in the list, don't duplicate it.
-		msg->deleteInstance();
+		MemoryPoolObject::deleteInstance(msg);
 		msg = NULL;
 		return NULL;
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/NetCommandList.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/NetCommandList.cpp
@@ -115,7 +115,7 @@ void NetCommandList::reset() {
 		temp = m_first->getNext();
 		m_first->setNext(NULL);
 		m_first->setPrev(NULL);
-		MemoryPoolObject::deleteInstance(m_first);
+		deleteInstance(m_first);
 		m_first = temp;
 	}
 	m_last = NULL;
@@ -160,7 +160,7 @@ NetCommandRef * NetCommandList::addMessage(NetCommandMsg *cmdMsg) {
 			if (isEqualCommandMsg(m_lastMessageInserted->getCommand(), msg->getCommand())) {
 
 				// This command is already in the list, don't duplicate it.
-				MemoryPoolObject::deleteInstance(msg);
+				deleteInstance(msg);
 				msg = NULL;
 				return NULL;
 			}
@@ -191,7 +191,7 @@ NetCommandRef * NetCommandList::addMessage(NetCommandMsg *cmdMsg) {
 		if (isEqualCommandMsg(m_last->getCommand(), msg->getCommand())) {
 
 			// This command is already in the list, don't duplicate it.
-			MemoryPoolObject::deleteInstance(msg);
+			deleteInstance(msg);
 			msg = NULL;
 			return NULL;
 		}
@@ -209,7 +209,7 @@ NetCommandRef * NetCommandList::addMessage(NetCommandMsg *cmdMsg) {
 		if (isEqualCommandMsg(m_first->getCommand(), msg->getCommand())) {
 
 			// This command is already in the list, don't duplicate it.
-			MemoryPoolObject::deleteInstance(msg);
+			deleteInstance(msg);
 			msg = NULL;
 			return NULL;
 		}
@@ -235,7 +235,7 @@ NetCommandRef * NetCommandList::addMessage(NetCommandMsg *cmdMsg) {
 		if (isEqualCommandMsg(m_last->getCommand(), msg->getCommand())) {
 
 			// This command is already in the list, don't duplicate it.
-			MemoryPoolObject::deleteInstance(msg);
+			deleteInstance(msg);
 			msg = NULL;
 			return NULL;
 		}
@@ -259,7 +259,7 @@ NetCommandRef * NetCommandList::addMessage(NetCommandMsg *cmdMsg) {
 		if (isEqualCommandMsg(m_last->getCommand(), msg->getCommand())) {
 
 			// This command is already in the list, don't duplicate it.
-			MemoryPoolObject::deleteInstance(msg);
+			deleteInstance(msg);
 			msg = NULL;
 			return NULL;
 		}
@@ -284,7 +284,7 @@ NetCommandRef * NetCommandList::addMessage(NetCommandMsg *cmdMsg) {
 		if (isEqualCommandMsg(m_last->getCommand(), msg->getCommand())) {
 
 			// This command is already in the list, don't duplicate it.
-			MemoryPoolObject::deleteInstance(msg);
+			deleteInstance(msg);
 			msg = NULL;
 			return NULL;
 		}
@@ -303,7 +303,7 @@ NetCommandRef * NetCommandList::addMessage(NetCommandMsg *cmdMsg) {
 		if (isEqualCommandMsg(m_first->getCommand(), msg->getCommand())) {
 
 			// This command is already in the list, don't duplicate it.
-			MemoryPoolObject::deleteInstance(msg);
+			deleteInstance(msg);
 			return NULL;
 		}
 
@@ -320,7 +320,7 @@ NetCommandRef * NetCommandList::addMessage(NetCommandMsg *cmdMsg) {
 		if (isEqualCommandMsg(tempmsg->getCommand(), msg->getCommand())) {
 
 		// This command is already in the list, don't duplicate it.
-		MemoryPoolObject::deleteInstance(msg);
+		deleteInstance(msg);
 		msg = NULL;
 		return NULL;
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/NetCommandMsg.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/NetCommandMsg.cpp
@@ -66,12 +66,12 @@ void NetCommandMsg::attach() {
 void NetCommandMsg::detach() {
 	--m_referenceCount;
 	if (m_referenceCount == 0) {
-		deleteInstance();
+		MemoryPoolObject::deleteInstance(this);
 		return;
 	}
 	DEBUG_ASSERTCRASH(m_referenceCount > 0, ("Invalid reference count for NetCommandMsg")); // Just to make sure...
 	if (m_referenceCount < 0) {
-		deleteInstance();
+		MemoryPoolObject::deleteInstance(this);
 	}
 }
 
@@ -123,7 +123,7 @@ NetGameCommandMsg::~NetGameCommandMsg() {
 	GameMessageArgument *arg = m_argList;
 	while (arg != NULL) {
 		m_argList = m_argList->m_next;
-		arg->deleteInstance();
+		MemoryPoolObject::deleteInstance(arg);
 		arg = m_argList;
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/NetCommandMsg.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/NetCommandMsg.cpp
@@ -66,12 +66,12 @@ void NetCommandMsg::attach() {
 void NetCommandMsg::detach() {
 	--m_referenceCount;
 	if (m_referenceCount == 0) {
-		MemoryPoolObject::deleteInstance(this);
+		deleteInstance(this);
 		return;
 	}
 	DEBUG_ASSERTCRASH(m_referenceCount > 0, ("Invalid reference count for NetCommandMsg")); // Just to make sure...
 	if (m_referenceCount < 0) {
-		MemoryPoolObject::deleteInstance(this);
+		deleteInstance(this);
 	}
 }
 
@@ -123,7 +123,7 @@ NetGameCommandMsg::~NetGameCommandMsg() {
 	GameMessageArgument *arg = m_argList;
 	while (arg != NULL) {
 		m_argList = m_argList->m_next;
-		MemoryPoolObject::deleteInstance(arg);
+		deleteInstance(arg);
 		arg = m_argList;
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/NetCommandWrapperList.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/NetCommandWrapperList.cpp
@@ -128,7 +128,7 @@ NetCommandWrapperList::~NetCommandWrapperList() {
 	NetCommandWrapperListNode *temp;
 	while (m_list != NULL) {
 		temp = m_list->m_next;
-		MemoryPoolObject::deleteInstance(m_list);
+		deleteInstance(m_list);
 		m_list = temp;
 	}
 }
@@ -141,7 +141,7 @@ void NetCommandWrapperList::reset() {
 	NetCommandWrapperListNode *temp;
 	while (m_list != NULL) {
 		temp = m_list->m_next;
-		MemoryPoolObject::deleteInstance(m_list);
+		deleteInstance(m_list);
 		m_list = temp;
 	}
 }
@@ -192,7 +192,7 @@ NetCommandList * NetCommandWrapperList::getReadyCommands()
 			NetCommandRef *ret = retlist->addMessage(msg->getCommand());
 			ret->setRelay(msg->getRelay());
 
-			MemoryPoolObject::deleteInstance(msg);
+			deleteInstance(msg);
 			msg = NULL;
 
 			removeFromList(temp);
@@ -223,11 +223,11 @@ void NetCommandWrapperList::removeFromList(NetCommandWrapperListNode *node) {
 
 	if (prev == NULL) {
 		m_list = temp->m_next;
-		MemoryPoolObject::deleteInstance(temp);
+		deleteInstance(temp);
 		temp = NULL;
 	} else {
 		prev->m_next = temp->m_next;
-		MemoryPoolObject::deleteInstance(temp);
+		deleteInstance(temp);
 		temp = NULL;
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/NetCommandWrapperList.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/NetCommandWrapperList.cpp
@@ -128,7 +128,7 @@ NetCommandWrapperList::~NetCommandWrapperList() {
 	NetCommandWrapperListNode *temp;
 	while (m_list != NULL) {
 		temp = m_list->m_next;
-		m_list->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_list);
 		m_list = temp;
 	}
 }
@@ -141,7 +141,7 @@ void NetCommandWrapperList::reset() {
 	NetCommandWrapperListNode *temp;
 	while (m_list != NULL) {
 		temp = m_list->m_next;
-		m_list->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_list);
 		m_list = temp;
 	}
 }
@@ -192,7 +192,7 @@ NetCommandList * NetCommandWrapperList::getReadyCommands()
 			NetCommandRef *ret = retlist->addMessage(msg->getCommand());
 			ret->setRelay(msg->getRelay());
 
-			msg->deleteInstance();
+			MemoryPoolObject::deleteInstance(msg);
 			msg = NULL;
 
 			removeFromList(temp);
@@ -223,11 +223,11 @@ void NetCommandWrapperList::removeFromList(NetCommandWrapperListNode *node) {
 
 	if (prev == NULL) {
 		m_list = temp->m_next;
-		temp->deleteInstance();
+		MemoryPoolObject::deleteInstance(temp);
 		temp = NULL;
 	} else {
 		prev->m_next = temp->m_next;
-		temp->deleteInstance();
+		MemoryPoolObject::deleteInstance(temp);
 		temp = NULL;
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/NetPacket.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/NetPacket.cpp
@@ -216,7 +216,7 @@ NetPacketList NetPacket::ConstructBigCommandPacketList(NetCommandRef *ref) {
 
 		packetList.push_back(packet);
 
-		ref->deleteInstance();
+		MemoryPoolObject::deleteInstance(ref);
 		ref = NULL;
 
 		++currentChunk;
@@ -346,10 +346,10 @@ UnsignedInt NetPacket::GetGameCommandSize(NetCommandMsg *msg) {
 		arg = arg->getNext();
 	}
 
-	parser->deleteInstance();
+	MemoryPoolObject::deleteInstance(parser);
 	parser = NULL;
 
-	gmsg->deleteInstance();
+	MemoryPoolObject::deleteInstance(gmsg);
 	gmsg = NULL;
 
 	return msglen;
@@ -931,13 +931,13 @@ void NetPacket::FillBufferWithGameCommand(UnsignedByte *buffer, NetCommandRef *m
 		}
 	}
 
-	parser->deleteInstance();
+	MemoryPoolObject::deleteInstance(parser);
 	parser = NULL;
 
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addGameMessage - added game message, frame %d, player %d, command ID %d\n", m_lastFrame, m_lastPlayerID, m_lastCommandID));
 
 	if (gmsg)
-		gmsg->deleteInstance();
+		MemoryPoolObject::deleteInstance(gmsg);
 	gmsg = NULL;
 }
 
@@ -1921,7 +1921,7 @@ NetPacket::NetPacket(TransportMessage *msg) {
  */
 NetPacket::~NetPacket() {
 	if (m_lastCommand != NULL) {
-		m_lastCommand->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_lastCommand);
 		m_lastCommand = NULL;
 	}
 }
@@ -1947,7 +1947,7 @@ void NetPacket::init() {
 
 void NetPacket::reset() {
 	if (m_lastCommand != NULL) {
-		m_lastCommand->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_lastCommand);
 		m_lastCommand = NULL;
 	}
 	init();
@@ -2116,7 +2116,7 @@ Bool NetPacket::addFrameResendRequestCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -2227,7 +2227,7 @@ Bool NetPacket::addDisconnectScreenOffCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -2336,7 +2336,7 @@ Bool NetPacket::addDisconnectFrameCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -2444,7 +2444,7 @@ Bool NetPacket::addFileCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -2549,7 +2549,7 @@ Bool NetPacket::addFileAnnounceCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -2654,7 +2654,7 @@ Bool NetPacket::addFileProgressCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -2786,7 +2786,7 @@ Bool NetPacket::addWrapperCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -2885,7 +2885,7 @@ Bool NetPacket::addTimeOutGameStartMessage(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -2979,7 +2979,7 @@ Bool NetPacket::addLoadCompleteMessage(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -3065,7 +3065,7 @@ Bool NetPacket::addProgressMessage(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -3176,7 +3176,7 @@ Bool NetPacket::addDisconnectVoteCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -3275,7 +3275,7 @@ Bool NetPacket::addDisconnectChatCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -3392,7 +3392,7 @@ Bool NetPacket::addChatCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -3483,7 +3483,7 @@ Bool NetPacket::addPacketRouterAckCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -3565,7 +3565,7 @@ Bool NetPacket::addPacketRouterQueryCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());	
@@ -3670,7 +3670,7 @@ Bool NetPacket::addDisconnectPlayerCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -3755,7 +3755,7 @@ Bool NetPacket::addDisconnectKeepAliveCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -3835,7 +3835,7 @@ Bool NetPacket::addKeepAliveCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -3954,7 +3954,7 @@ Bool NetPacket::addRunAheadCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -4075,7 +4075,7 @@ Bool NetPacket::addDestroyPlayerCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -4187,7 +4187,7 @@ Bool NetPacket::addRunAheadMetricsCommand(NetCommandRef *msg) {
 		m_packetLen += sizeof(averageFps);
 
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -4306,7 +4306,7 @@ Bool NetPacket::addPlayerLeaveCommand(NetCommandRef *msg) {
 		m_packetLen += sizeof(UnsignedByte);
 
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -4364,7 +4364,7 @@ Bool NetPacket::addFrameCommand(NetCommandRef *msg) {
 		m_packet[m_packetLen] = 'Z';
 		++m_packetLen;
 		m_lastCommandID = msg->getCommand()->getID();
-		m_lastCommand->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_lastCommand);
 		m_lastCommand = newInstance(NetCommandRef)(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 		++m_lastFrame;		// need this cause we're actually advancing to the next frame by adding this command.
@@ -4445,7 +4445,7 @@ Bool NetPacket::addFrameCommand(NetCommandRef *msg) {
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("outgoing - added frame %d, player %d, command count = %d, command id = %d\n", cmdMsg->getExecutionFrame(), cmdMsg->getPlayerID(), cmdMsg->getCommandCount(), cmdMsg->getID()));
 
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -4550,7 +4550,7 @@ Bool NetPacket::addAckCommand(NetCommandRef *msg, UnsignedShort commandID, Unsig
 		m_packet[m_packetLen] = 'Z';
 		++m_packetLen;
 		++m_numCommands;
-		m_lastCommand->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_lastCommand);
 		m_lastCommand = NULL;
 
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -4588,7 +4588,7 @@ Bool NetPacket::addAckCommand(NetCommandRef *msg, UnsignedShort commandID, Unsig
 		m_packetLen += sizeof(UnsignedByte);
 
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -4793,7 +4793,7 @@ Bool NetPacket::addGameCommand(NetCommandRef *msg) {
 			writeGameMessageArgumentToPacket(type, arg);
 		}
 
-		parser->deleteInstance();
+		MemoryPoolObject::deleteInstance(parser);
 		parser = NULL;
 
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addGameMessage - added game message, frame %d, player %d, command ID %d\n", m_lastFrame, m_lastPlayerID, m_lastCommandID));
@@ -4801,7 +4801,7 @@ Bool NetPacket::addGameCommand(NetCommandRef *msg) {
 		++m_numCommands;
 
 		if (m_lastCommand != NULL) {
-			m_lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -4811,7 +4811,7 @@ Bool NetPacket::addGameCommand(NetCommandRef *msg) {
 	}
 
 	if (gmsg) {
-		gmsg->deleteInstance();
+		MemoryPoolObject::deleteInstance(gmsg);
 		gmsg = NULL;
 	}
 
@@ -4919,7 +4919,7 @@ Bool NetPacket::isRoomForGameMessage(NetCommandRef *msg, GameMessage *gmsg) {
 		arg = arg->getNext();
 	}
 
-	parser->deleteInstance();
+	MemoryPoolObject::deleteInstance(parser);
 	parser = NULL;
 
 	// Is there enough room in the packet for this message?
@@ -5112,7 +5112,7 @@ NetCommandList * NetPacket::getCommandList() {
 			}
 
 			if (lastCommand != NULL) {
-				lastCommand->deleteInstance();
+				MemoryPoolObject::deleteInstance(lastCommand);
 				lastCommand = NULL;
 			}
 			lastCommand = newInstance(NetCommandRef)(msg);
@@ -5171,7 +5171,7 @@ NetCommandList * NetPacket::getCommandList() {
 				ref->setRelay(relay);
 			}
 
-			lastCommand->deleteInstance();
+			MemoryPoolObject::deleteInstance(lastCommand);
 			lastCommand = NULL;
 //			lastCommand = newInstance(NetCommandRef)(msg);
 			lastCommand = NEW_NETCOMMANDREF(msg);
@@ -5190,7 +5190,7 @@ NetCommandList * NetPacket::getCommandList() {
 	}
 
 	if (lastCommand != NULL) {
-		lastCommand->deleteInstance();
+		MemoryPoolObject::deleteInstance(lastCommand);
 		lastCommand = NULL;
 	}
 	return retval;
@@ -5259,7 +5259,7 @@ NetCommandMsg * NetPacket::readGameMessage(UnsignedByte *data, Int &i)
 		}
 	}
 
-	parser->deleteInstance();
+	MemoryPoolObject::deleteInstance(parser);
 	parser = NULL;
 
 	return (NetCommandMsg *)msg;

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/NetPacket.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/NetPacket.cpp
@@ -216,7 +216,7 @@ NetPacketList NetPacket::ConstructBigCommandPacketList(NetCommandRef *ref) {
 
 		packetList.push_back(packet);
 
-		MemoryPoolObject::deleteInstance(ref);
+		deleteInstance(ref);
 		ref = NULL;
 
 		++currentChunk;
@@ -346,10 +346,10 @@ UnsignedInt NetPacket::GetGameCommandSize(NetCommandMsg *msg) {
 		arg = arg->getNext();
 	}
 
-	MemoryPoolObject::deleteInstance(parser);
+	deleteInstance(parser);
 	parser = NULL;
 
-	MemoryPoolObject::deleteInstance(gmsg);
+	deleteInstance(gmsg);
 	gmsg = NULL;
 
 	return msglen;
@@ -931,13 +931,13 @@ void NetPacket::FillBufferWithGameCommand(UnsignedByte *buffer, NetCommandRef *m
 		}
 	}
 
-	MemoryPoolObject::deleteInstance(parser);
+	deleteInstance(parser);
 	parser = NULL;
 
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addGameMessage - added game message, frame %d, player %d, command ID %d\n", m_lastFrame, m_lastPlayerID, m_lastCommandID));
 
 	if (gmsg)
-		MemoryPoolObject::deleteInstance(gmsg);
+		deleteInstance(gmsg);
 	gmsg = NULL;
 }
 
@@ -1921,7 +1921,7 @@ NetPacket::NetPacket(TransportMessage *msg) {
  */
 NetPacket::~NetPacket() {
 	if (m_lastCommand != NULL) {
-		MemoryPoolObject::deleteInstance(m_lastCommand);
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NULL;
 	}
 }
@@ -1947,7 +1947,7 @@ void NetPacket::init() {
 
 void NetPacket::reset() {
 	if (m_lastCommand != NULL) {
-		MemoryPoolObject::deleteInstance(m_lastCommand);
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NULL;
 	}
 	init();
@@ -2116,7 +2116,7 @@ Bool NetPacket::addFrameResendRequestCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -2227,7 +2227,7 @@ Bool NetPacket::addDisconnectScreenOffCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -2336,7 +2336,7 @@ Bool NetPacket::addDisconnectFrameCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -2444,7 +2444,7 @@ Bool NetPacket::addFileCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -2549,7 +2549,7 @@ Bool NetPacket::addFileAnnounceCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -2654,7 +2654,7 @@ Bool NetPacket::addFileProgressCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -2786,7 +2786,7 @@ Bool NetPacket::addWrapperCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -2885,7 +2885,7 @@ Bool NetPacket::addTimeOutGameStartMessage(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -2979,7 +2979,7 @@ Bool NetPacket::addLoadCompleteMessage(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -3065,7 +3065,7 @@ Bool NetPacket::addProgressMessage(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -3176,7 +3176,7 @@ Bool NetPacket::addDisconnectVoteCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -3275,7 +3275,7 @@ Bool NetPacket::addDisconnectChatCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -3392,7 +3392,7 @@ Bool NetPacket::addChatCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -3483,7 +3483,7 @@ Bool NetPacket::addPacketRouterAckCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -3565,7 +3565,7 @@ Bool NetPacket::addPacketRouterQueryCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());	
@@ -3670,7 +3670,7 @@ Bool NetPacket::addDisconnectPlayerCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -3755,7 +3755,7 @@ Bool NetPacket::addDisconnectKeepAliveCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -3835,7 +3835,7 @@ Bool NetPacket::addKeepAliveCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -3954,7 +3954,7 @@ Bool NetPacket::addRunAheadCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -4075,7 +4075,7 @@ Bool NetPacket::addDestroyPlayerCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -4187,7 +4187,7 @@ Bool NetPacket::addRunAheadMetricsCommand(NetCommandRef *msg) {
 		m_packetLen += sizeof(averageFps);
 
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -4306,7 +4306,7 @@ Bool NetPacket::addPlayerLeaveCommand(NetCommandRef *msg) {
 		m_packetLen += sizeof(UnsignedByte);
 
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -4364,7 +4364,7 @@ Bool NetPacket::addFrameCommand(NetCommandRef *msg) {
 		m_packet[m_packetLen] = 'Z';
 		++m_packetLen;
 		m_lastCommandID = msg->getCommand()->getID();
-		MemoryPoolObject::deleteInstance(m_lastCommand);
+		deleteInstance(m_lastCommand);
 		m_lastCommand = newInstance(NetCommandRef)(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 		++m_lastFrame;		// need this cause we're actually advancing to the next frame by adding this command.
@@ -4445,7 +4445,7 @@ Bool NetPacket::addFrameCommand(NetCommandRef *msg) {
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("outgoing - added frame %d, player %d, command count = %d, command id = %d\n", cmdMsg->getExecutionFrame(), cmdMsg->getPlayerID(), cmdMsg->getCommandCount(), cmdMsg->getID()));
 
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -4550,7 +4550,7 @@ Bool NetPacket::addAckCommand(NetCommandRef *msg, UnsignedShort commandID, Unsig
 		m_packet[m_packetLen] = 'Z';
 		++m_packetLen;
 		++m_numCommands;
-		MemoryPoolObject::deleteInstance(m_lastCommand);
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NULL;
 
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -4588,7 +4588,7 @@ Bool NetPacket::addAckCommand(NetCommandRef *msg, UnsignedShort commandID, Unsig
 		m_packetLen += sizeof(UnsignedByte);
 
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -4793,7 +4793,7 @@ Bool NetPacket::addGameCommand(NetCommandRef *msg) {
 			writeGameMessageArgumentToPacket(type, arg);
 		}
 
-		MemoryPoolObject::deleteInstance(parser);
+		deleteInstance(parser);
 		parser = NULL;
 
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addGameMessage - added game message, frame %d, player %d, command ID %d\n", m_lastFrame, m_lastPlayerID, m_lastCommandID));
@@ -4801,7 +4801,7 @@ Bool NetPacket::addGameCommand(NetCommandRef *msg) {
 		++m_numCommands;
 
 		if (m_lastCommand != NULL) {
-			MemoryPoolObject::deleteInstance(m_lastCommand);
+			deleteInstance(m_lastCommand);
 			m_lastCommand = NULL;
 		}
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
@@ -4811,7 +4811,7 @@ Bool NetPacket::addGameCommand(NetCommandRef *msg) {
 	}
 
 	if (gmsg) {
-		MemoryPoolObject::deleteInstance(gmsg);
+		deleteInstance(gmsg);
 		gmsg = NULL;
 	}
 
@@ -4919,7 +4919,7 @@ Bool NetPacket::isRoomForGameMessage(NetCommandRef *msg, GameMessage *gmsg) {
 		arg = arg->getNext();
 	}
 
-	MemoryPoolObject::deleteInstance(parser);
+	deleteInstance(parser);
 	parser = NULL;
 
 	// Is there enough room in the packet for this message?
@@ -5112,7 +5112,7 @@ NetCommandList * NetPacket::getCommandList() {
 			}
 
 			if (lastCommand != NULL) {
-				MemoryPoolObject::deleteInstance(lastCommand);
+				deleteInstance(lastCommand);
 				lastCommand = NULL;
 			}
 			lastCommand = newInstance(NetCommandRef)(msg);
@@ -5171,7 +5171,7 @@ NetCommandList * NetPacket::getCommandList() {
 				ref->setRelay(relay);
 			}
 
-			MemoryPoolObject::deleteInstance(lastCommand);
+			deleteInstance(lastCommand);
 			lastCommand = NULL;
 //			lastCommand = newInstance(NetCommandRef)(msg);
 			lastCommand = NEW_NETCOMMANDREF(msg);
@@ -5190,7 +5190,7 @@ NetCommandList * NetPacket::getCommandList() {
 	}
 
 	if (lastCommand != NULL) {
-		MemoryPoolObject::deleteInstance(lastCommand);
+		deleteInstance(lastCommand);
 		lastCommand = NULL;
 	}
 	return retval;
@@ -5259,7 +5259,7 @@ NetCommandMsg * NetPacket::readGameMessage(UnsignedByte *data, Int &i)
 		}
 	}
 
-	MemoryPoolObject::deleteInstance(parser);
+	deleteInstance(parser);
 	parser = NULL;
 
 	return (NetCommandMsg *)msg;

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/Network.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/Network.cpp
@@ -476,11 +476,11 @@ void Network::GetCommandsFromCommandList() {
 				m_conMgr->sendLocalGameMessage(msg, getExecutionFrame());
 			}
 			TheCommandList->removeMessage(msg); // This does not destroy msg's prev and next pointers, so they should still be valid.
-			msg->deleteInstance();
+			MemoryPoolObject::deleteInstance(msg);
 		} else {
 			if (processCommand(msg)) {
 				TheCommandList->removeMessage(msg);
-				msg->deleteInstance();
+				MemoryPoolObject::deleteInstance(msg);
 			}
 		}
 		msg = next;
@@ -514,7 +514,7 @@ Bool Network::processCommand(GameMessage *msg)
 			if (TheGameLogic->getFrame() == 1) {
 				m_localStatus = NETLOCALSTATUS_INGAME;
 				NetCommandList *netcmdlist = m_conMgr->getFrameCommandList(0); // clear out frame 0 since we skipped it
-				netcmdlist->deleteInstance();
+				MemoryPoolObject::deleteInstance(netcmdlist);
 			} else {
 				return FALSE;
 			}
@@ -611,7 +611,7 @@ void Network::RelayCommandsToCommandList(UnsignedInt frame) {
 	}
 	m_playersToDisconnect.clear();
 
-	netcmdlist->deleteInstance();
+	MemoryPoolObject::deleteInstance(netcmdlist);
 }
 
 /**

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/Network.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/Network.cpp
@@ -476,11 +476,11 @@ void Network::GetCommandsFromCommandList() {
 				m_conMgr->sendLocalGameMessage(msg, getExecutionFrame());
 			}
 			TheCommandList->removeMessage(msg); // This does not destroy msg's prev and next pointers, so they should still be valid.
-			MemoryPoolObject::deleteInstance(msg);
+			deleteInstance(msg);
 		} else {
 			if (processCommand(msg)) {
 				TheCommandList->removeMessage(msg);
-				MemoryPoolObject::deleteInstance(msg);
+				deleteInstance(msg);
 			}
 		}
 		msg = next;
@@ -514,7 +514,7 @@ Bool Network::processCommand(GameMessage *msg)
 			if (TheGameLogic->getFrame() == 1) {
 				m_localStatus = NETLOCALSTATUS_INGAME;
 				NetCommandList *netcmdlist = m_conMgr->getFrameCommandList(0); // clear out frame 0 since we skipped it
-				MemoryPoolObject::deleteInstance(netcmdlist);
+				deleteInstance(netcmdlist);
 			} else {
 				return FALSE;
 			}
@@ -611,7 +611,7 @@ void Network::RelayCommandsToCommandList(UnsignedInt frame) {
 	}
 	m_playersToDisconnect.clear();
 
-	MemoryPoolObject::deleteInstance(netcmdlist);
+	deleteInstance(netcmdlist);
 }
 
 /**

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/WOLBrowser/WebBrowser.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/WOLBrowser/WebBrowser.cpp
@@ -126,7 +126,7 @@ WebBrowser::~WebBrowser()
 	while (url != NULL) {
 		WebBrowserURL *temp = url;
 		url = url->m_next;
-		temp->deleteInstance();
+		MemoryPoolObject::deleteInstance(temp);
 		temp = NULL;
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/WOLBrowser/WebBrowser.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/WOLBrowser/WebBrowser.cpp
@@ -126,7 +126,7 @@ WebBrowser::~WebBrowser()
 	while (url != NULL) {
 		WebBrowserURL *temp = url;
 		url = url->m_next;
-		MemoryPoolObject::deleteInstance(temp);
+		deleteInstance(temp);
 		temp = NULL;
 	}
 }

--- a/GeneralsMD/Code/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
@@ -597,7 +597,7 @@ void MilesAudioManager::pauseAudio( AudioAffect which )
 		AudioRequest *req = (*ait);
 		if( req && req->m_request == AR_Play ) 
 		{
-			req->deleteInstance();
+			MemoryPoolObject::deleteInstance(req);
 			ait = m_audioRequests.erase(ait);
 		}
 		else
@@ -983,7 +983,7 @@ void MilesAudioManager::killAudioEventImmediately( AudioHandle audioEvent )
 		AudioRequest *req = (*ait);
 		if( req && req->m_request == AR_Play && req->m_handleToInteractOn == audioEvent ) 
 		{
-			req->deleteInstance();
+			MemoryPoolObject::deleteInstance(req);
 			ait = m_audioRequests.erase(ait);
 			return;
 		}
@@ -2257,7 +2257,7 @@ void MilesAudioManager::processRequestList( void )
 		if (!req->m_requiresCheckForSample || checkForSample(req)) {
 			processRequest(req);
 		}
-		req->deleteInstance();
+		MemoryPoolObject::deleteInstance(req);
 		it = m_audioRequests.erase(it);
 	}
 }

--- a/GeneralsMD/Code/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
@@ -597,7 +597,7 @@ void MilesAudioManager::pauseAudio( AudioAffect which )
 		AudioRequest *req = (*ait);
 		if( req && req->m_request == AR_Play ) 
 		{
-			MemoryPoolObject::deleteInstance(req);
+			deleteInstance(req);
 			ait = m_audioRequests.erase(ait);
 		}
 		else
@@ -983,7 +983,7 @@ void MilesAudioManager::killAudioEventImmediately( AudioHandle audioEvent )
 		AudioRequest *req = (*ait);
 		if( req && req->m_request == AR_Play && req->m_handleToInteractOn == audioEvent ) 
 		{
-			MemoryPoolObject::deleteInstance(req);
+			deleteInstance(req);
 			ait = m_audioRequests.erase(ait);
 			return;
 		}
@@ -2257,7 +2257,7 @@ void MilesAudioManager::processRequestList( void )
 		if (!req->m_requiresCheckForSample || checkForSample(req)) {
 			processRequest(req);
 		}
-		MemoryPoolObject::deleteInstance(req);
+		deleteInstance(req);
 		it = m_audioRequests.erase(it);
 	}
 }

--- a/GeneralsMD/Code/GameEngineDevice/Source/StdDevice/Common/StdLocalFileSystem.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/StdDevice/Common/StdLocalFileSystem.cpp
@@ -157,7 +157,7 @@ File * StdLocalFileSystem::openFile(const Char *filename, Int access /* = 0 */)
 	
 	if (file->open(path.string().c_str(), access) == FALSE) {
 		file->close();
-		file->deleteInstance();
+		MemoryPoolObject::deleteInstance(file);
 		file = NULL;
 	} else {
 		file->deleteOnClose();
@@ -178,7 +178,7 @@ File * StdLocalFileSystem::openFile(const Char *filename, Int access /* = 0 */)
 //			return ramFile;
 //		}	else {
 //			ramFile->close();
-//			ramFile->deleteInstance();
+//			MemoryPoolObject::deleteInstance(ramFile);
 //		}
 //	}
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/StdDevice/Common/StdLocalFileSystem.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/StdDevice/Common/StdLocalFileSystem.cpp
@@ -157,7 +157,7 @@ File * StdLocalFileSystem::openFile(const Char *filename, Int access /* = 0 */)
 	
 	if (file->open(path.string().c_str(), access) == FALSE) {
 		file->close();
-		MemoryPoolObject::deleteInstance(file);
+		deleteInstance(file);
 		file = NULL;
 	} else {
 		file->deleteOnClose();
@@ -178,7 +178,7 @@ File * StdLocalFileSystem::openFile(const Char *filename, Int access /* = 0 */)
 //			return ramFile;
 //		}	else {
 //			ramFile->close();
-//			MemoryPoolObject::deleteInstance(ramFile);
+//			deleteInstance(ramFile);
 //		}
 //	}
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/Common/System/W3DRadar.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/Common/System/W3DRadar.cpp
@@ -147,7 +147,7 @@ void W3DRadar::deleteResources( void )
 		m_terrainTexture->Release_Ref();
 	m_terrainTexture = NULL;
 	if( m_terrainImage )
-		m_terrainImage->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_terrainImage);
 	m_terrainImage = NULL;
 
 	//
@@ -157,7 +157,7 @@ void W3DRadar::deleteResources( void )
 		m_overlayTexture->Release_Ref();
 	m_overlayTexture = NULL;
 	if( m_overlayImage )
-		m_overlayImage->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_overlayImage);
 	m_overlayImage = NULL;
 
 	//
@@ -167,7 +167,7 @@ void W3DRadar::deleteResources( void )
 		m_shroudTexture->Release_Ref();
 	m_shroudTexture = NULL;
 	if( m_shroudImage )
-		m_shroudImage->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_shroudImage);
 	m_shroudImage = NULL;
 
 }  // end deleteResources

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/Common/System/W3DRadar.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/Common/System/W3DRadar.cpp
@@ -147,7 +147,7 @@ void W3DRadar::deleteResources( void )
 		m_terrainTexture->Release_Ref();
 	m_terrainTexture = NULL;
 	if( m_terrainImage )
-		MemoryPoolObject::deleteInstance(m_terrainImage);
+		deleteInstance(m_terrainImage);
 	m_terrainImage = NULL;
 
 	//
@@ -157,7 +157,7 @@ void W3DRadar::deleteResources( void )
 		m_overlayTexture->Release_Ref();
 	m_overlayTexture = NULL;
 	if( m_overlayImage )
-		MemoryPoolObject::deleteInstance(m_overlayImage);
+		deleteInstance(m_overlayImage);
 	m_overlayImage = NULL;
 
 	//
@@ -167,7 +167,7 @@ void W3DRadar::deleteResources( void )
 		m_shroudTexture->Release_Ref();
 	m_shroudTexture = NULL;
 	if( m_shroudImage )
-		MemoryPoolObject::deleteInstance(m_shroudImage);
+		deleteInstance(m_shroudImage);
 	m_shroudImage = NULL;
 
 }  // end deleteResources

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DAssetManager.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DAssetManager.cpp
@@ -110,7 +110,7 @@ public:
 	virtual const char*					Get_Name(void) const			{ return Name.str(); }
 	virtual int									Get_Class_ID(void) const	{ return Proto->Class_ID(); }
 	virtual RenderObjClass *		Create(void);
-	virtual void								DeleteSelf()							{	deleteInstance(); }
+	virtual void								DeleteSelf()							{	MemoryPoolObject::deleteInstance(this); }
 
 protected:
 	//virtual ~W3DPrototypeClass(void);

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DAssetManager.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DAssetManager.cpp
@@ -110,7 +110,7 @@ public:
 	virtual const char*					Get_Name(void) const			{ return Name.str(); }
 	virtual int									Get_Class_ID(void) const	{ return Proto->Class_ID(); }
 	virtual RenderObjClass *		Create(void);
-	virtual void								DeleteSelf()							{	MemoryPoolObject::deleteInstance(this); }
+	virtual void								DeleteSelf()							{	deleteInstance(this); }
 
 protected:
 	//virtual ~W3DPrototypeClass(void);

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayStringManager.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayStringManager.cpp
@@ -160,7 +160,7 @@ void W3DDisplayStringManager::freeDisplayString( DisplayString *string )
 	}
 
 	// free data
-	MemoryPoolObject::deleteInstance(string);
+	deleteInstance(string);
 
 }  // end freeDisplayString
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayStringManager.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayStringManager.cpp
@@ -160,7 +160,7 @@ void W3DDisplayStringManager::freeDisplayString( DisplayString *string )
 	}
 
 	// free data
-	string->deleteInstance();
+	MemoryPoolObject::deleteInstance(string);
 
 }  // end freeDisplayString
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
@@ -314,7 +314,7 @@ WaterRenderObjClass::~WaterRenderObjClass(void)
 	{	WaterSettings[i].m_skyTextureFile.clear();
 		WaterSettings[i].m_waterTextureFile.clear();
 	}
-	((WaterTransparencySetting*)TheWaterTransparency.getNonOverloadedPointer())->deleteInstance();
+	MemoryPoolObject::deleteInstance(((WaterTransparencySetting*)TheWaterTransparency.getNonOverloadedPointer()));
 	TheWaterTransparency = NULL;
 	ReleaseResources();
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
@@ -314,7 +314,7 @@ WaterRenderObjClass::~WaterRenderObjClass(void)
 	{	WaterSettings[i].m_skyTextureFile.clear();
 		WaterSettings[i].m_waterTextureFile.clear();
 	}
-	MemoryPoolObject::deleteInstance(((WaterTransparencySetting*)TheWaterTransparency.getNonOverloadedPointer()));
+	deleteInstance((WaterTransparencySetting*)TheWaterTransparency.getNonOverloadedPointer());
 	TheWaterTransparency = NULL;
 	ReleaseResources();
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/WorldHeightMap.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/WorldHeightMap.cpp
@@ -134,7 +134,7 @@ MapObject::~MapObject(void)
 		while (cur) {
 			next = cur->getNext();
 			cur->setNextMap(NULL); // prevents recursion. 
-			cur->deleteInstance();
+			MemoryPoolObject::deleteInstance(cur);
 			cur = next;
 		}
 	}
@@ -432,7 +432,7 @@ void WorldHeightMap::freeListOfMapObjects(void)
 {
 	if (MapObject::TheMapObjectListPtr) 
 	{
-		MapObject::TheMapObjectListPtr->deleteInstance();
+		MemoryPoolObject::deleteInstance(MapObject::TheMapObjectListPtr);
 		MapObject::TheMapObjectListPtr = NULL;
 	}
 	MapObject::getWorldDict()->clear();

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/WorldHeightMap.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/WorldHeightMap.cpp
@@ -134,7 +134,7 @@ MapObject::~MapObject(void)
 		while (cur) {
 			next = cur->getNext();
 			cur->setNextMap(NULL); // prevents recursion. 
-			MemoryPoolObject::deleteInstance(cur);
+			deleteInstance(cur);
 			cur = next;
 		}
 	}
@@ -432,7 +432,7 @@ void WorldHeightMap::freeListOfMapObjects(void)
 {
 	if (MapObject::TheMapObjectListPtr) 
 	{
-		MemoryPoolObject::deleteInstance(MapObject::TheMapObjectListPtr);
+		deleteInstance(MapObject::TheMapObjectListPtr);
 		MapObject::TheMapObjectListPtr = NULL;
 	}
 	MapObject::getWorldDict()->clear();

--- a/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/Common/Win32LocalFileSystem.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/Common/Win32LocalFileSystem.cpp
@@ -73,7 +73,7 @@ File * Win32LocalFileSystem::openFile(const Char *filename, Int access /* = 0 */
 
 	if (file->open(filename, access) == FALSE) {
 		file->close();
-		file->deleteInstance();
+		MemoryPoolObject::deleteInstance(file);
 		file = NULL;
 	} else {
 		file->deleteOnClose();
@@ -94,7 +94,7 @@ File * Win32LocalFileSystem::openFile(const Char *filename, Int access /* = 0 */
 //			return ramFile;
 //		}	else {
 //			ramFile->close();
-//			ramFile->deleteInstance();
+//			MemoryPoolObject::deleteInstance(ramFile);
 //		}
 //	}
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/Common/Win32LocalFileSystem.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/Common/Win32LocalFileSystem.cpp
@@ -73,7 +73,7 @@ File * Win32LocalFileSystem::openFile(const Char *filename, Int access /* = 0 */
 
 	if (file->open(filename, access) == FALSE) {
 		file->close();
-		MemoryPoolObject::deleteInstance(file);
+		deleteInstance(file);
 		file = NULL;
 	} else {
 		file->deleteOnClose();
@@ -94,7 +94,7 @@ File * Win32LocalFileSystem::openFile(const Char *filename, Int access /* = 0 */
 //			return ramFile;
 //		}	else {
 //			ramFile->close();
-//			MemoryPoolObject::deleteInstance(ramFile);
+//			deleteInstance(ramFile);
 //		}
 //	}
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/WorldBuilder.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/WorldBuilder.h
@@ -142,7 +142,7 @@ protected:
 	void deletePasteObjList(void) 
 	{ 
 		if (m_pasteMapObjList) 
-			MemoryPoolObject::deleteInstance(m_pasteMapObjList); 
+			deleteInstance(m_pasteMapObjList); 
 		m_pasteMapObjList = NULL; 
 	};
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/WorldBuilder.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/WorldBuilder.h
@@ -142,7 +142,7 @@ protected:
 	void deletePasteObjList(void) 
 	{ 
 		if (m_pasteMapObjList) 
-			m_pasteMapObjList->deleteInstance(); 
+			MemoryPoolObject::deleteInstance(m_pasteMapObjList); 
 		m_pasteMapObjList = NULL; 
 	};
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/CUndoable.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/CUndoable.cpp
@@ -208,7 +208,7 @@ AddObjectUndoable::~AddObjectUndoable(void)
 {
 	m_pDoc = NULL;  // not ref counted.
 	if (m_objectToAdd && !m_addedToList) {
-		MemoryPoolObject::deleteInstance(m_objectToAdd);
+		deleteInstance(m_objectToAdd);
 		m_objectToAdd=NULL;
 	}
 }
@@ -858,7 +858,7 @@ void DictItemUndoable::Undo(void)
 DeleteInfo::~DeleteInfo(void)
 {
 	if (m_didDelete && m_objectToDelete) {
-		MemoryPoolObject::deleteInstance(m_objectToDelete);
+		deleteInstance(m_objectToDelete);
 	}
 	DeleteInfo *pCur = m_next;
 	DeleteInfo *tmp;
@@ -1050,7 +1050,7 @@ AddPolygonUndoable::~AddPolygonUndoable(void)
 {
 	if (m_trigger && !m_isTriggerInList) {
 		DEBUG_ASSERTCRASH(m_trigger->getNext()==NULL, ("Logic error."));
-		MemoryPoolObject::deleteInstance(m_trigger);
+		deleteInstance(m_trigger);
 	}
 	m_trigger=NULL;
 }
@@ -1322,7 +1322,7 @@ DeletePolygonUndoable::~DeletePolygonUndoable(void)
 {
 	if (m_trigger && !m_isTriggerInList) {
 		DEBUG_ASSERTCRASH(m_trigger->getNext()==NULL, ("Logic error."));
-		MemoryPoolObject::deleteInstance(m_trigger);
+		deleteInstance(m_trigger);
 	}
 	m_trigger=NULL;
 }

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/CUndoable.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/CUndoable.cpp
@@ -208,7 +208,7 @@ AddObjectUndoable::~AddObjectUndoable(void)
 {
 	m_pDoc = NULL;  // not ref counted.
 	if (m_objectToAdd && !m_addedToList) {
-		m_objectToAdd->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_objectToAdd);
 		m_objectToAdd=NULL;
 	}
 }
@@ -858,7 +858,7 @@ void DictItemUndoable::Undo(void)
 DeleteInfo::~DeleteInfo(void)
 {
 	if (m_didDelete && m_objectToDelete) {
-		m_objectToDelete->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_objectToDelete);
 	}
 	DeleteInfo *pCur = m_next;
 	DeleteInfo *tmp;
@@ -1050,7 +1050,7 @@ AddPolygonUndoable::~AddPolygonUndoable(void)
 {
 	if (m_trigger && !m_isTriggerInList) {
 		DEBUG_ASSERTCRASH(m_trigger->getNext()==NULL, ("Logic error."));
-		m_trigger->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_trigger);
 	}
 	m_trigger=NULL;
 }
@@ -1322,7 +1322,7 @@ DeletePolygonUndoable::~DeletePolygonUndoable(void)
 {
 	if (m_trigger && !m_isTriggerInList) {
 		DEBUG_ASSERTCRASH(m_trigger->getNext()==NULL, ("Logic error."));
-		m_trigger->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_trigger);
 	}
 	m_trigger=NULL;
 }

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/FenceOptions.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/FenceOptions.cpp
@@ -69,7 +69,7 @@ FenceOptions::FenceOptions(CWnd* pParent /*=NULL*/)
 FenceOptions::~FenceOptions(void)
 {
 	if (m_objectsList) {
-		MemoryPoolObject::deleteInstance(m_objectsList);
+		deleteInstance(m_objectsList);
 	}
 	m_objectsList = NULL;
 }

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/FenceOptions.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/FenceOptions.cpp
@@ -69,7 +69,7 @@ FenceOptions::FenceOptions(CWnd* pParent /*=NULL*/)
 FenceOptions::~FenceOptions(void)
 {
 	if (m_objectsList) {
-		m_objectsList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_objectsList);
 	}
 	m_objectsList = NULL;
 }

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/FenceTool.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/FenceTool.cpp
@@ -50,7 +50,7 @@ FenceTool::FenceTool(void) :
 FenceTool::~FenceTool(void) 
 {
 	if (m_mapObjectList) {
-		m_mapObjectList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_mapObjectList);
 	}
 	m_mapObjectList = NULL;
 }
@@ -99,7 +99,7 @@ void FenceTool::updateMapObjectList(Coord3D downPt, Coord3D curPt, WbView* pView
 	pCurObj->setNextMap(NULL);
 	if (pXtraObjects) {
 		p3View->removeFenceListObjects(pXtraObjects);
-		pXtraObjects->deleteInstance();
+		MemoryPoolObject::deleteInstance(pXtraObjects);
 		pXtraObjects = NULL;
 	}
 
@@ -155,7 +155,7 @@ void FenceTool::mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldB
 	m_downPt2d = viewPt;
 	m_downPt3d = cpt;
 	if (m_mapObjectList) {
-		m_mapObjectList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_mapObjectList);
 		m_mapObjectList = NULL;
 	}
 	if (FenceOptions::hasSelectedObject()) {

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/FenceTool.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/FenceTool.cpp
@@ -50,7 +50,7 @@ FenceTool::FenceTool(void) :
 FenceTool::~FenceTool(void) 
 {
 	if (m_mapObjectList) {
-		MemoryPoolObject::deleteInstance(m_mapObjectList);
+		deleteInstance(m_mapObjectList);
 	}
 	m_mapObjectList = NULL;
 }
@@ -99,7 +99,7 @@ void FenceTool::updateMapObjectList(Coord3D downPt, Coord3D curPt, WbView* pView
 	pCurObj->setNextMap(NULL);
 	if (pXtraObjects) {
 		p3View->removeFenceListObjects(pXtraObjects);
-		MemoryPoolObject::deleteInstance(pXtraObjects);
+		deleteInstance(pXtraObjects);
 		pXtraObjects = NULL;
 	}
 
@@ -155,7 +155,7 @@ void FenceTool::mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldB
 	m_downPt2d = viewPt;
 	m_downPt3d = cpt;
 	if (m_mapObjectList) {
-		MemoryPoolObject::deleteInstance(m_mapObjectList);
+		deleteInstance(m_mapObjectList);
 		m_mapObjectList = NULL;
 	}
 	if (FenceOptions::hasSelectedObject()) {

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/GroveTool.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/GroveTool.cpp
@@ -245,7 +245,7 @@ GroveTool::GroveTool(void) :
 GroveTool::~GroveTool(void) 
 {
 	if (m_headMapObj) {
-		MemoryPoolObject::deleteInstance(m_headMapObj);
+		deleteInstance(m_headMapObj);
 	}
 }
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/GroveTool.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/GroveTool.cpp
@@ -245,7 +245,7 @@ GroveTool::GroveTool(void) :
 GroveTool::~GroveTool(void) 
 {
 	if (m_headMapObj) {
-		m_headMapObj->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_headMapObj);
 	}
 }
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/ObjectOptions.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/ObjectOptions.cpp
@@ -65,7 +65,7 @@ ObjectOptions::ObjectOptions(CWnd* pParent /*=NULL*/)
 ObjectOptions::~ObjectOptions(void)
 {
 	if (m_objectsList) {
-		m_objectsList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_objectsList);
 	}
 	m_objectsList = NULL;
 }

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/ObjectOptions.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/ObjectOptions.cpp
@@ -65,7 +65,7 @@ ObjectOptions::ObjectOptions(CWnd* pParent /*=NULL*/)
 ObjectOptions::~ObjectOptions(void)
 {
 	if (m_objectsList) {
-		MemoryPoolObject::deleteInstance(m_objectsList);
+		deleteInstance(m_objectsList);
 	}
 	m_objectsList = NULL;
 }

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/PickUnitDialog.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/PickUnitDialog.cpp
@@ -95,7 +95,7 @@ PickUnitDialog::PickUnitDialog(UINT id, CWnd* pParent /*=NULL*/)
 PickUnitDialog::~PickUnitDialog()
 {
 	if (m_objectsList) {
-		MemoryPoolObject::deleteInstance(m_objectsList);
+		deleteInstance(m_objectsList);
 	}
 	m_objectsList = NULL;
 }

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/PickUnitDialog.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/PickUnitDialog.cpp
@@ -95,7 +95,7 @@ PickUnitDialog::PickUnitDialog(UINT id, CWnd* pParent /*=NULL*/)
 PickUnitDialog::~PickUnitDialog()
 {
 	if (m_objectsList) {
-		m_objectsList->deleteInstance();
+		MemoryPoolObject::deleteInstance(m_objectsList);
 	}
 	m_objectsList = NULL;
 }

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/ScriptActionsFalse.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/ScriptActionsFalse.cpp
@@ -190,7 +190,7 @@ void ScriptActionsFalse::OnNew()
 		m_index++;
 		loadList();
 	} else {
-		pAct->deleteInstance();
+		MemoryPoolObject::deleteInstance(pAct);
 	}
 }
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/ScriptActionsFalse.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/ScriptActionsFalse.cpp
@@ -190,7 +190,7 @@ void ScriptActionsFalse::OnNew()
 		m_index++;
 		loadList();
 	} else {
-		MemoryPoolObject::deleteInstance(pAct);
+		deleteInstance(pAct);
 	}
 }
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/ScriptActionsTrue.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/ScriptActionsTrue.cpp
@@ -190,7 +190,7 @@ void ScriptActionsTrue::OnNew()
 		m_index++;
 		loadList();
 	} else {
-		MemoryPoolObject::deleteInstance(pAct);
+		deleteInstance(pAct);
 	}
 }
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/ScriptActionsTrue.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/ScriptActionsTrue.cpp
@@ -190,7 +190,7 @@ void ScriptActionsTrue::OnNew()
 		m_index++;
 		loadList();
 	} else {
-		pAct->deleteInstance();
+		MemoryPoolObject::deleteInstance(pAct);
 	}
 }
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/ScriptConditions.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/ScriptConditions.cpp
@@ -258,7 +258,7 @@ void ScriptConditionsDlg::OnNew()
 		loadList();
 		setSel(pSavOr, pCond);
 	} else {
-		MemoryPoolObject::deleteInstance(pCond);
+		deleteInstance(pCond);
 	}
 }
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/ScriptConditions.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/ScriptConditions.cpp
@@ -258,7 +258,7 @@ void ScriptConditionsDlg::OnNew()
 		loadList();
 		setSel(pSavOr, pCond);
 	} else {
-		pCond->deleteInstance();
+		MemoryPoolObject::deleteInstance(pCond);
 	}
 }
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/ScriptDialog.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/ScriptDialog.cpp
@@ -929,7 +929,7 @@ void ScriptDialog::OnNewFolder()
 			savSel.m_objType = ListType::GROUP_TYPE;
 			updateSelection(savSel);
 		} else {
-			MemoryPoolObject::deleteInstance(pNewGroup);
+			deleteInstance(pNewGroup);
 		}
 	}
 	updateIcons(TVI_ROOT);
@@ -970,7 +970,7 @@ void ScriptDialog::OnNewScript()
 	if (IDOK == editDialog.DoModal()) {
 		insertScript(pNewScript);
 	}	else {
-		MemoryPoolObject::deleteInstance(pNewScript);
+		deleteInstance(pNewScript);
 	}
 	updateIcons(TVI_ROOT);
 }		
@@ -1069,7 +1069,7 @@ void ScriptDialog::OnEditScript()
 		}
 	}
 	updateIcons(TVI_ROOT);
-	MemoryPoolObject::deleteInstance(pDup);
+	deleteInstance(pDup);
 }
 
 void ScriptDialog::OnCopyScript() 
@@ -1508,7 +1508,7 @@ void ScriptDialog::OnSave()
 			DEBUG_CRASH(("threw exception in ScriptDialog::OnSave"));
 	}
 	if (!doAllScripts) {
-		MemoryPoolObject::deleteInstance(scripts[0]);
+		deleteInstance(scripts[0]);
 	}
 	theFile.Close();
 }
@@ -1725,7 +1725,7 @@ Bool ScriptDialog::ParseObjectDataChunk(DataChunkInput &file, DataChunkInfo *inf
 		if (duplicate) break;
 	}
 	if (duplicate) {
-		MemoryPoolObject::deleteInstance(pThisOne);
+		deleteInstance(pThisOne);
 		return true;
 	}
 
@@ -1920,7 +1920,7 @@ Bool ScriptDialog::ParsePolygonTriggersDataChunk(DataChunkInput &file, DataChunk
 			}
 		}
 		if (duplicate ) {
-			MemoryPoolObject::deleteInstance(pTrig);
+			deleteInstance(pTrig);
 		} else {
 			if (pPrevTrig) {
 				pPrevTrig->setNextPoly(pTrig);

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/ScriptDialog.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/ScriptDialog.cpp
@@ -929,7 +929,7 @@ void ScriptDialog::OnNewFolder()
 			savSel.m_objType = ListType::GROUP_TYPE;
 			updateSelection(savSel);
 		} else {
-			pNewGroup->deleteInstance();
+			MemoryPoolObject::deleteInstance(pNewGroup);
 		}
 	}
 	updateIcons(TVI_ROOT);
@@ -970,7 +970,7 @@ void ScriptDialog::OnNewScript()
 	if (IDOK == editDialog.DoModal()) {
 		insertScript(pNewScript);
 	}	else {
-		pNewScript->deleteInstance();
+		MemoryPoolObject::deleteInstance(pNewScript);
 	}
 	updateIcons(TVI_ROOT);
 }		
@@ -1069,7 +1069,7 @@ void ScriptDialog::OnEditScript()
 		}
 	}
 	updateIcons(TVI_ROOT);
-	pDup->deleteInstance();
+	MemoryPoolObject::deleteInstance(pDup);
 }
 
 void ScriptDialog::OnCopyScript() 
@@ -1508,7 +1508,7 @@ void ScriptDialog::OnSave()
 			DEBUG_CRASH(("threw exception in ScriptDialog::OnSave"));
 	}
 	if (!doAllScripts) {
-		scripts[0]->deleteInstance();
+		MemoryPoolObject::deleteInstance(scripts[0]);
 	}
 	theFile.Close();
 }
@@ -1725,7 +1725,7 @@ Bool ScriptDialog::ParseObjectDataChunk(DataChunkInput &file, DataChunkInfo *inf
 		if (duplicate) break;
 	}
 	if (duplicate) {
-		pThisOne->deleteInstance();
+		MemoryPoolObject::deleteInstance(pThisOne);
 		return true;
 	}
 
@@ -1920,7 +1920,7 @@ Bool ScriptDialog::ParsePolygonTriggersDataChunk(DataChunkInput &file, DataChunk
 			}
 		}
 		if (duplicate ) {
-			pTrig->deleteInstance();
+			MemoryPoolObject::deleteInstance(pTrig);
 		} else {
 			if (pPrevTrig) {
 				pPrevTrig->setNextPoly(pTrig);

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/WHeightMapEdit.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/WHeightMapEdit.cpp
@@ -1991,7 +1991,7 @@ void WorldHeightMapEdit::removeFirstObject(void)
 	MapObject *firstObj = MapObject::TheMapObjectListPtr;
 	MapObject::TheMapObjectListPtr = firstObj->getNext();
 	firstObj->setNextMap(NULL); // so we don't delete the whole list.
-	firstObj->deleteInstance();
+	MemoryPoolObject::deleteInstance(firstObj);
 }
 
 //=============================================================================

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/WHeightMapEdit.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/WHeightMapEdit.cpp
@@ -1991,7 +1991,7 @@ void WorldHeightMapEdit::removeFirstObject(void)
 	MapObject *firstObj = MapObject::TheMapObjectListPtr;
 	MapObject::TheMapObjectListPtr = firstObj->getNext();
 	firstObj->setNextMap(NULL); // so we don't delete the whole list.
-	MemoryPoolObject::deleteInstance(firstObj);
+	deleteInstance(firstObj);
 }
 
 //=============================================================================

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/WaterOptions.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/WaterOptions.cpp
@@ -255,7 +255,7 @@ void WaterOptions::OnMakeRiver()
 					for (i=0; i<pNew->getNumPoints(); i++) {
 						theTrigger->addPoint(*pNew->getPoint(i));
 					}
-					MemoryPoolObject::deleteInstance(pNew);
+					deleteInstance(pNew);
 				}
 			}
 		}

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/WaterOptions.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/WaterOptions.cpp
@@ -255,7 +255,7 @@ void WaterOptions::OnMakeRiver()
 					for (i=0; i<pNew->getNumPoints(); i++) {
 						theTrigger->addPoint(*pNew->getPoint(i));
 					}
-					pNew->deleteInstance();
+					MemoryPoolObject::deleteInstance(pNew);
 				}
 			}
 		}

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/WaterTool.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/WaterTool.cpp
@@ -473,7 +473,7 @@ void WaterTool::fillTheArea(TTrackingMode m, CPoint viewPt, WbView* pView, CWorl
 	
 	if (pNew->getNumPoints()>2) {
 		PolygonTrigger *pBetter = adjustSpacing(pNew, WaterOptions::getSpacing());
-		MemoryPoolObject::deleteInstance(pNew);
+		deleteInstance(pNew);
 		pNew = pBetter;
 		pNew->setWaterArea(true);
 		AddPolygonUndoable *pUndo = new AddPolygonUndoable(pNew);
@@ -483,7 +483,7 @@ void WaterTool::fillTheArea(TTrackingMode m, CPoint viewPt, WbView* pView, CWorl
 		m_poly_dragPointNdx = -1;
 		WaterOptions::update();
 	}	else {
-		MemoryPoolObject::deleteInstance(pNew);
+		deleteInstance(pNew);
 	}
 
 }

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/WaterTool.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/WaterTool.cpp
@@ -473,7 +473,7 @@ void WaterTool::fillTheArea(TTrackingMode m, CPoint viewPt, WbView* pView, CWorl
 	
 	if (pNew->getNumPoints()>2) {
 		PolygonTrigger *pBetter = adjustSpacing(pNew, WaterOptions::getSpacing());
-		pNew->deleteInstance();
+		MemoryPoolObject::deleteInstance(pNew);
 		pNew = pBetter;
 		pNew->setWaterArea(true);
 		AddPolygonUndoable *pUndo = new AddPolygonUndoable(pNew);
@@ -483,7 +483,7 @@ void WaterTool::fillTheArea(TTrackingMode m, CPoint viewPt, WbView* pView, CWorl
 		m_poly_dragPointNdx = -1;
 		WaterOptions::update();
 	}	else {
-		pNew->deleteInstance();
+		MemoryPoolObject::deleteInstance(pNew);
 	}
 
 }

--- a/scripts/cpp/refactor_delete_instance.py
+++ b/scripts/cpp/refactor_delete_instance.py
@@ -1,0 +1,93 @@
+# Created with python 3.11.4
+
+import glob
+import os
+
+
+def modifyLine(line: str) -> str:
+    if 'friend_deleteInstance()' in line:
+        return line
+
+    deleteInstanceBegin = line.find('deleteInstance()')
+    deleteInstanceEnd = deleteInstanceBegin + len('deleteInstance()')
+    if deleteInstanceBegin >= 0:
+        i = deleteInstanceBegin
+
+        # Skip MemoryPoolObject::deleteInstance()
+        if i >= 2 and line[i-2:i] == '::':
+            return line
+
+        # Skip void deleteInstance()
+        if i >= 5 and line[i-5:i] == 'void ':
+            return line
+
+        # Skip void friend_deleteInstance()
+        if i >= 5 and line[i-5:i] == 'void ':
+            return line
+
+        # Walk back to object end
+        i -= 1
+        while i >= 0:
+            ch = line[i]
+            if ch != '>' and ch != '-' and not ch.isspace():
+                break
+            i -= 1
+        objectEnd = i + 1
+
+        # Walk back to object begin
+        while i >= 0:
+            ch = line[i]
+            if ch.isspace() or ch == '{' or ch == '}':
+                break
+            i -= 1
+        objectBegin = i + 1
+        objectName = line[objectBegin:objectEnd]
+
+        if objectName:
+            lineCopy = line[:objectBegin]
+            lineCopy += f'MemoryPoolObject::deleteInstance({objectName})'
+            lineCopy += line[deleteInstanceEnd:]
+            return lineCopy
+        else:
+            lineCopy = line[:deleteInstanceBegin]
+            lineCopy += 'MemoryPoolObject::deleteInstance(this)'
+            lineCopy += line[deleteInstanceEnd:]
+            return lineCopy
+
+    return line
+
+
+def main():
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    root_dir = os.path.join(current_dir, "..", "..")
+    root_dir = os.path.normpath(root_dir)
+    core_dir = os.path.join(root_dir, "Core")
+    generals_dir = os.path.join(root_dir, "Generals")
+    generalsmd_dir = os.path.join(root_dir, "GeneralsMD")
+    fileNames = []
+    fileNames.extend(glob.glob(os.path.join(core_dir, '**', '*.h'), recursive=True))
+    fileNames.extend(glob.glob(os.path.join(core_dir, '**', '*.cpp'), recursive=True))
+    fileNames.extend(glob.glob(os.path.join(core_dir, '**', '*.inl'), recursive=True))
+    fileNames.extend(glob.glob(os.path.join(generals_dir, '**', '*.h'), recursive=True))
+    fileNames.extend(glob.glob(os.path.join(generals_dir, '**', '*.cpp'), recursive=True))
+    fileNames.extend(glob.glob(os.path.join(generals_dir, '**', '*.inl'), recursive=True))
+    fileNames.extend(glob.glob(os.path.join(generalsmd_dir, '**', '*.h'), recursive=True))
+    fileNames.extend(glob.glob(os.path.join(generalsmd_dir, '**', '*.cpp'), recursive=True))
+    fileNames.extend(glob.glob(os.path.join(generalsmd_dir, '**', '*.inl'), recursive=True))
+
+    for fileName in fileNames:
+        with open(fileName, 'r', encoding="cp1252") as file:
+            try:
+                lines = file.readlines()
+            except UnicodeDecodeError:
+                continue # Not good.
+        with open(fileName, 'w', encoding="cp1252") as file:
+            for line in lines:
+                line = modifyLine(line)
+                file.write(line)
+
+    return
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
**Merge with Rebase**

* Closes #865

This change fixes the undefined behaviour in `MemoryPoolObject::deleteInstance` by making it a static function. This way null pointers are no longer dereferenced when calling it. This change was mostly applied with a python script to avoid editing 1000 lines by hand.

`MemoryPoolObject::deleteInstance` also gets an alias function `deleteInstance` for simplicity.

The `MEMORY_POOL_DELETEINSTANCE_VISIBILITY` macro was removed because it no longer is applicable with the static function. Instead, accidental calls to `deleteInstance(Object*)` are prevented with a deleted function.
