### PR TITLE
[GEN][ZH] Fix missing call to va_end in InGameUI::messageColor()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -2025,6 +2025,7 @@ void InGameUI::messageColor( const RGBColor *rgbColor, UnicodeString format, ...
 	va_start( args, format );
 	WideChar buf[ UnicodeString::MAX_FORMAT_BUF_LEN ];
 	int result = _vsnwprintf(buf, sizeof( buf )/sizeof( WideChar ) - 1, format.str(), args );
+	va_end(args);
 
 	if( result >= 0 )
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -2081,6 +2081,7 @@ void InGameUI::messageColor( const RGBColor *rgbColor, UnicodeString format, ...
 	va_start( args, format );
 	WideChar buf[ UnicodeString::MAX_FORMAT_BUF_LEN ];
 	int result = _vsnwprintf(buf, sizeof( buf )/sizeof( WideChar ) - 1, format.str(), args );
+	va_end(args);
 
 	if( result >= 0 )
 	{


### PR DESCRIPTION
* Follow up for #860

This change readds a call to `va_end` that was mistakenly removed in a previous change #860.