### PR TITLE
[ZH] Separate ParticleUplinkCannonUpdate's damage radius calculation from LaserUpdate's client update

### DIFF
--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/LaserUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/LaserUpdate.h
@@ -59,11 +59,47 @@ private:
 
 };
 
+//-------------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------------------
+class LaserRadiusUpdateBase
+{
+protected:
+	LaserRadiusUpdateBase();
+
+	void initRadius( Int sizeDeltaFrames );
+	bool updateRadius();
+	void setDecayFrames( UnsignedInt decayFrames );
+	void xfer( Xfer *xfer );
+	void setLaserRadiusUpdateBase(const LaserRadiusUpdateBase& other);
+	Real getWidthScale() const { return m_currentWidthScalar; }
+
+private:
+	Bool m_widening;
+	Bool m_decaying;
+	UnsignedInt m_widenStartFrame;
+	UnsignedInt m_widenFinishFrame;
+	Real m_currentWidthScalar;
+	UnsignedInt m_decayStartFrame;
+	UnsignedInt m_decayFinishFrame;
+};
 
 //-------------------------------------------------------------------------------------------------
-/** The default	update module */
 //-------------------------------------------------------------------------------------------------
-class LaserUpdate : public ClientUpdateModule
+class LaserRadiusUpdate : private LaserRadiusUpdateBase
+{
+public:
+	using LaserRadiusUpdateBase::initRadius;
+	using LaserRadiusUpdateBase::updateRadius;
+	using LaserRadiusUpdateBase::setDecayFrames;
+	using LaserRadiusUpdateBase::xfer;
+	using LaserRadiusUpdateBase::setLaserRadiusUpdateBase;
+	using LaserRadiusUpdateBase::getWidthScale;
+};
+
+//-------------------------------------------------------------------------------------------------
+/** The laser update module */
+//-------------------------------------------------------------------------------------------------
+class LaserUpdate : public ClientUpdateModule, private LaserRadiusUpdateBase
 {
 
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( LaserUpdate, "LaserUpdate" )
@@ -76,17 +112,19 @@ public:
 
 	//Actually puts the laser in the world.
 	void initLaser( const Object *parent, const Object *target, const Coord3D *startPos, const Coord3D *endPos, AsciiString parentBoneName, Int sizeDeltaFrames = 0 );
-	void setDecayFrames( UnsignedInt decayFrames );
 
-	const Coord3D* getStartPos() { return &m_startPos; }
-	const Coord3D* getEndPos() { return &m_endPos; }
+	const LaserRadiusUpdateBase& getLaserRadiusUpdateBase() const;
+	using LaserRadiusUpdateBase::setDecayFrames;
+	using LaserRadiusUpdateBase::getWidthScale;
 
+	const Coord3D* getStartPos() const { return &m_startPos; }
+	const Coord3D* getEndPos() const { return &m_endPos; }
+
+	Real getTemplateLaserRadius() const;
 	Real getCurrentLaserRadius() const;
 
 	void setDirty( Bool dirty ) { m_dirty = dirty; }
-	Bool isDirty() { return m_dirty; }
-
-	Real getWidthScale() const { return m_currentWidthScalar; }
+	Bool isDirty() const { return m_dirty; }
 
 	virtual void clientUpdate();
 
@@ -105,13 +143,6 @@ protected:
 	Bool m_dirty;
 	ParticleSystemID m_particleSystemID;
 	ParticleSystemID m_targetParticleSystemID;
-	Bool m_widening;
-	Bool m_decaying;
-	UnsignedInt m_widenStartFrame;
-	UnsignedInt m_widenFinishFrame;
-	Real m_currentWidthScalar;
-	UnsignedInt m_decayStartFrame;
-	UnsignedInt m_decayFinishFrame;
 	AsciiString m_parentBoneName;
 };
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ParticleUplinkCannonUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ParticleUplinkCannonUpdate.h
@@ -35,6 +35,7 @@
 // INCLUDES ///////////////////////////////////////////////////////////////////////////////////////
 #include "Common/KindOf.h"
 #include "Common/Science.h"
+#include "GameLogic/Module/LaserUpdate.h"
 #include "GameLogic/Module/SpecialPowerUpdateModule.h"
 
 // FORWARD REFERENCES /////////////////////////////////////////////////////////////////////////////
@@ -218,6 +219,7 @@ protected:
 	DrawableID				m_laserBeamIDs[ MAX_OUTER_NODES ];
 	DrawableID				m_groundToOrbitBeamID;
 	DrawableID				m_orbitToTargetBeamID;
+	LaserRadiusUpdate	m_orbitToTargetLaserRadius;
 	ParticleSystemID	m_connectorSystemID;
 	ParticleSystemID	m_laserBaseSystemID;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/LaserUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/LaserUpdate.cpp
@@ -71,6 +71,20 @@ LaserUpdateModuleData::LaserUpdateModuleData()
 	p.add(dataFieldParse);
 }
 
+
+//-------------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------------------
+LaserRadiusUpdateBase::LaserRadiusUpdateBase()
+{
+	m_widening = false;
+	m_widenStartFrame = 0;
+	m_widenFinishFrame = 0;
+	m_currentWidthScalar = 1.0f;
+	m_decaying = false;
+	m_decayStartFrame = 0;
+	m_decayFinishFrame = 0;
+}
+
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
 LaserUpdate::LaserUpdate( Thing *thing, const ModuleData* moduleData ) : ClientUpdateModule( thing, moduleData )
@@ -83,13 +97,6 @@ LaserUpdate::LaserUpdate( Thing *thing, const ModuleData* moduleData ) : ClientU
 	//
 	m_particleSystemID = INVALID_PARTICLE_SYSTEM_ID;
 	m_targetParticleSystemID = INVALID_PARTICLE_SYSTEM_ID;
-	m_widening = false;
-	m_widenStartFrame = 0;
-	m_widenFinishFrame = 0;
-	m_currentWidthScalar = 1.0f;
-	m_decaying = false;
-	m_decayStartFrame = 0;
-	m_decayFinishFrame = 0;
 	m_parentID = INVALID_DRAWABLE_ID;
 	m_targetID = INVALID_DRAWABLE_ID;
 	m_parentBoneName.clear();
@@ -201,19 +208,22 @@ void LaserUpdate::clientUpdate( void )
 {
 	updateStartPos();
 	updateEndPos();
+	m_dirty |= updateRadius();
+}
 
+//-------------------------------------------------------------------------------------------------
+bool LaserRadiusUpdateBase::updateRadius()
+{
+	bool updated = false;
 	if( m_decaying )
 	{
 		UnsignedInt now = TheGameLogic->getFrame();
 		m_currentWidthScalar = 1.0f - (Real)(now - m_decayStartFrame) / (Real)(m_decayFinishFrame - m_decayStartFrame);
-		m_dirty = true;
+		updated = true;
 		if( m_currentWidthScalar <= 0.0f )
 		{
 			m_currentWidthScalar = 0.0f;
-
-			//When decay is finished... delete the laser.
-			//TheGameLogic->destroyObject( getObject() );
-			return;
+			//m_decaying = false // ?????
 		}
 	}
 	else if( m_widening )
@@ -221,17 +231,19 @@ void LaserUpdate::clientUpdate( void )
 		//We need to resize our laser width based on the growth ratio completed.
 		UnsignedInt now = TheGameLogic->getFrame();
 		m_currentWidthScalar = (Real)(now - m_widenStartFrame) / (Real)(m_widenFinishFrame - m_widenStartFrame);
-		m_dirty = true;
+		updated = true;
 		if( m_currentWidthScalar >= 1.0f )
 		{
 			m_currentWidthScalar = 1.0f;
 			m_widening = false;
 		}
 	}
-	return;
+
+	return updated;
 }
 
-void LaserUpdate::setDecayFrames( UnsignedInt decayFrames )
+//-------------------------------------------------------------------------------------------------
+void LaserRadiusUpdateBase::setDecayFrames( UnsignedInt decayFrames )
 {
 	if( decayFrames > 0 )
 	{
@@ -242,12 +254,9 @@ void LaserUpdate::setDecayFrames( UnsignedInt decayFrames )
 	}
 }
 
-
 //-------------------------------------------------------------------------------------------------
-void LaserUpdate::initLaser( const Object *parent, const Object *target, const Coord3D *startPos, const Coord3D *endPos, AsciiString parentBoneName, Int sizeDeltaFrames )
+void LaserRadiusUpdateBase::initRadius( Int sizeDeltaFrames )
 {
-	const LaserUpdateModuleData *data = getLaserUpdateModuleData();
-	ParticleSystem *system;
 	if( sizeDeltaFrames > 0 )
 	{
 		m_widening = true;
@@ -262,6 +271,52 @@ void LaserUpdate::initLaser( const Object *parent, const Object *target, const C
 		m_decayFinishFrame = m_decayStartFrame - sizeDeltaFrames;
 		m_currentWidthScalar = 1.0f;
 	}
+}
+
+//-------------------------------------------------------------------------------------------------
+void LaserRadiusUpdateBase::xfer( Xfer *xfer )
+{
+	// widening
+	xfer->xferBool( &m_widening );
+
+	// decaying
+	xfer->xferBool( &m_decaying );
+
+	// widen start frame
+	xfer->xferUnsignedInt( &m_widenStartFrame );
+
+	// widen finish frame
+	xfer->xferUnsignedInt( &m_widenFinishFrame );
+
+	// current width scalar
+	xfer->xferReal( &m_currentWidthScalar );
+
+	// decay start frame
+	xfer->xferUnsignedInt( &m_decayStartFrame );
+
+	// decay finish frame
+	xfer->xferUnsignedInt( &m_decayFinishFrame );
+}
+
+//-------------------------------------------------------------------------------------------------
+void LaserRadiusUpdateBase::setLaserRadiusUpdateBase(const LaserRadiusUpdateBase& other)
+{
+	static_cast<LaserRadiusUpdateBase&>(*this) = other;
+}
+
+//-------------------------------------------------------------------------------------------------
+const LaserRadiusUpdateBase& LaserUpdate::getLaserRadiusUpdateBase() const
+{
+	return static_cast<const LaserRadiusUpdateBase&>(*this);
+}
+
+//-------------------------------------------------------------------------------------------------
+void LaserUpdate::initLaser( const Object *parent, const Object *target, const Coord3D *startPos, const Coord3D *endPos, AsciiString parentBoneName, Int sizeDeltaFrames )
+{
+	const LaserUpdateModuleData *data = getLaserUpdateModuleData();
+	ParticleSystem *system;
+
+	initRadius( sizeDeltaFrames );
 
 	// Write down the bone name override
 	m_parentBoneName = parentBoneName;
@@ -393,7 +448,7 @@ void LaserUpdate::initLaser( const Object *parent, const Object *target, const C
 }
 
 //-------------------------------------------------------------------------------------------------
-Real LaserUpdate::getCurrentLaserRadius() const
+Real LaserUpdate::getTemplateLaserRadius() const
 {
 	const Drawable *draw = getDrawable();
 	const LaserDrawInterface* ldi = NULL;
@@ -406,10 +461,16 @@ Real LaserUpdate::getCurrentLaserRadius() const
 			//While it appears the logic is accessing client data, it is actually accessing template module
 			//data from the client. This value is INI constant thus can't change. It's grouped with other 
 			//laser defining attributes and having it there makes it easier for artists.
-			return ldi->getLaserTemplateWidth() * m_currentWidthScalar;
+			return ldi->getLaserTemplateWidth();
 		}
 	}
 	return 0.0f;
+}
+
+//-------------------------------------------------------------------------------------------------
+Real LaserUpdate::getCurrentLaserRadius() const
+{
+	return getTemplateLaserRadius() * getWidthScale();
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -454,26 +515,7 @@ void LaserUpdate::xfer( Xfer *xfer )
 	// target particle system id
 	xfer->xferUser( &m_targetParticleSystemID, sizeof( ParticleSystemID ) );
 
-	// widening
-	xfer->xferBool( &m_widening );
-
-	// decaying
-	xfer->xferBool( &m_decaying );
-
-	// widen start frame
-	xfer->xferUnsignedInt( &m_widenStartFrame );
-
-	// widen finish frame
-	xfer->xferUnsignedInt( &m_widenFinishFrame );
-
-	// current width scalar
-	xfer->xferReal( &m_currentWidthScalar );
-
-	// decay start frame
-	xfer->xferUnsignedInt( &m_decayStartFrame );
-
-	// decay finish frame
-	xfer->xferUnsignedInt( &m_decayFinishFrame );
+	LaserRadiusUpdateBase::xfer( xfer );
 
 	xfer->xferDrawableID(&m_parentID);
 	xfer->xferDrawableID(&m_targetID);


### PR DESCRIPTION
* Closes #862

This change is an alternative to #862 and a more rigorous first approach for separating the damage radius calculation in `ParticleUplinkCannonUpdate` from `LaserUpdate`. It does so by having `ParticleUplinkCannonUpdate` calculate its own laser radius, which is identical to the original laser radius calculation.

There will be a follow up change for `ParticleUplinkCannonUpdate` which will reduce its logic dependency to the Orbit to Target Drawable a bit.

This change was tested with
* VC6 golden replay
* xfer save/load in VC6, VS2022
* Skirmish VS2022

## TODO

- [ ] Replicate in Generals