### PR TITLE
[GEN][ZH] Pause replay on CRC mismatch

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Recorder.cpp
@@ -1041,6 +1041,9 @@ void RecorderClass::handleCRCMessage(UnsignedInt newCRC, Int playerIndex, Bool f
 			// the mismatch first happened in case the NetCRCInterval is set to 1 during the game.
 			DEBUG_CRASH(("Replay has gone out of sync!  All bets are off!\nInGame:%8.8X Replay:%8.8X\nFrame:%d",
 				playbackCRC, newCRC, TheGameLogic->getFrame()-m_crcInfo->GetQueueSize()-1));
+
+			// TheSuperHackers @tweak Pause the game on mismatch.
+			TheGameLogic->setGamePaused(true);
 		}
 		return;
 	}

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -1044,6 +1044,9 @@ void RecorderClass::handleCRCMessage(UnsignedInt newCRC, Int playerIndex, Bool f
 			// the mismatch first happened in case the NetCRCInterval is set to 1 during the game.
 			DEBUG_CRASH(("Replay has gone out of sync!  All bets are off!\nInGame:%8.8X Replay:%8.8X\nFrame:%d",
 				playbackCRC, newCRC, TheGameLogic->getFrame()-m_crcInfo->GetQueueSize()-1));
+
+			// TheSuperHackers @tweak Pause the game on mismatch.
+			TheGameLogic->setGamePaused(true);
 		}
 		return;
 	}


### PR DESCRIPTION
This change pauses replay playback on CRC mismatch. The mismatch text message is visible when the game is paused. The replay can be unpaused by pressing ESC twice to open and close the exit menu.