### PR TITLE
[GEN][ZH] Fix infinite loop in ParticleSystemManager::update

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/System/ParticleSys.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/System/ParticleSys.cpp
@@ -3036,18 +3036,19 @@ void ParticleSystemManager::update( void )
 	m_lastLogicFrameUpdate = TheGameLogic->getFrame();
 
 	//USE_PERF_TIMER(ParticleSystemManager)
-	ParticleSystem *sys;
-
-	for(ParticleSystemListIt it = m_allParticleSystemList.begin(); it != m_allParticleSystemList.end();) 
+	ParticleSystemListIt it = m_allParticleSystemList.begin(); 
+	while( it != m_allParticleSystemList.end() )  
 	{
-		sys = (*it++); // increase iterator before potential erasure from the container!
+		// TheSuperHackers @info Must increment the list iterator before potential element erasure from the list.
+		ParticleSystem* sys = *it++;
+
 		if (!sys) {
 			continue;
 		}
 
 		if (sys->update(m_localPlayerIndex) == false)
 		{
-			sys->deleteInstance();
+			deleteInstance(sys);
 		}
 	}
 }

--- a/Generals/Code/GameEngine/Source/GameClient/System/ParticleSys.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/System/ParticleSys.cpp
@@ -3040,17 +3040,14 @@ void ParticleSystemManager::update( void )
 
 	for(ParticleSystemListIt it = m_allParticleSystemList.begin(); it != m_allParticleSystemList.end();) 
 	{
-		sys = (*it);
+		sys = (*it++); // increase iterator before potential erasure from the container!
 		if (!sys) {
 			continue;
 		}
 
 		if (sys->update(m_localPlayerIndex) == false)
 		{
-			++it;
 			sys->deleteInstance();
-		} else {
-			++it;
 		}
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/System/ParticleSys.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/System/ParticleSys.cpp
@@ -2938,18 +2938,19 @@ void ParticleSystemManager::update( void )
 	m_lastLogicFrameUpdate = TheGameLogic->getFrame();
 
 	//USE_PERF_TIMER(ParticleSystemManager)
-	ParticleSystem *sys;
-
-	for(ParticleSystemListIt it = m_allParticleSystemList.begin(); it != m_allParticleSystemList.end();) 
+	ParticleSystemListIt it = m_allParticleSystemList.begin(); 
+	while( it != m_allParticleSystemList.end() )  
 	{
-		sys = (*it++); // increase iterator before potential erasure from the container!
+		// TheSuperHackers @info Must increment the list iterator before potential element erasure from the list.
+		ParticleSystem* sys = *it++;
+
 		if (!sys) {
 			continue;
 		}
 
 		if (sys->update(m_localPlayerIndex) == false)
 		{
-			sys->deleteInstance();
+			deleteInstance(sys);
 		}
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/System/ParticleSys.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/System/ParticleSys.cpp
@@ -2942,17 +2942,14 @@ void ParticleSystemManager::update( void )
 
 	for(ParticleSystemListIt it = m_allParticleSystemList.begin(); it != m_allParticleSystemList.end();) 
 	{
-		sys = (*it);
+		sys = (*it++); // increase iterator before potential erasure from the container!
 		if (!sys) {
 			continue;
 		}
 
 		if (sys->update(m_localPlayerIndex) == false)
 		{
-			++it;
 			sys->deleteInstance();
-		} else {
-			++it;
 		}
 	}
 }


### PR DESCRIPTION
* Fixes #841

The following loop contains undefined behavior:
https://github.com/TheSuperHackers/GeneralsGameCode/blob/696cb63bd92b58962bc6618a39771ee36f069ace/Generals/Code/GameEngine/Source/GameClient/System/ParticleSys.cpp#L3039-L3055

The compiler can see that the forward progress guarantee is violated if the iterator (`*it`) points to a `nullptr`. In other words, this could become an infinite loop, which is undefined behavior in C++20 and the compiler is likely to get rid of the entire `!= nullptr` check:
https://github.com/TheSuperHackers/GeneralsGameCode/blob/696cb63bd92b58962bc6618a39771ee36f069ace/Generals/Code/GameEngine/Source/GameClient/System/ParticleSys.cpp#L3043-L3046