### PR TITLE
[GEN][ZH] Fix undefined behavior in WindowLayout::destroyWindows

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -954,8 +954,8 @@ ControlBar::~ControlBar( void )
 	{
 		m_scienceLayout->destroyWindows();
 		deleteInstance(m_scienceLayout);
+		m_scienceLayout = NULL;
 	}
-	m_scienceLayout = NULL;
 	m_genArrow = NULL;
 	if(m_videoManager)
 		delete m_videoManager;

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Diplomacy.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Diplomacy.cpp
@@ -292,8 +292,8 @@ void ResetDiplomacy( void )
 		theLayout->destroyWindows();
 		deleteInstance(theLayout);
 		InitBuddyControls(-1);
+		theLayout = NULL;
 	}
-	theLayout = NULL;
 	theWindow = NULL;
 	if (theAnimateWindowManager)
 		delete theAnimateWindowManager;

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/DifficultySelect.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/DifficultySelect.cpp
@@ -258,8 +258,12 @@ WindowMsgHandledType DifficultySelectSystem( GameWindow *window, UnsignedInt msg
 				pref.write();
 				//TheScriptEngine->setGlobalDifficulty(s_AIDiff); // CANNOT DO THIS! REPLAYS WILL BREAK!
 				WindowLayout *layout = window->winGetLayout();
-				layout->destroyWindows();
-				deleteInstance(layout);
+				if (layout)
+				{
+					layout->destroyWindows();
+					deleteInstance(layout);
+				}
+
 				setupGameStart(TheCampaignManager->getCurrentMap(), s_AIDiff);
 				// start the game
 			}
@@ -268,8 +272,11 @@ WindowMsgHandledType DifficultySelectSystem( GameWindow *window, UnsignedInt msg
 				TheCampaignManager->setCampaign( AsciiString::TheEmptyString );
 				TheWindowManager->winUnsetModal(window);
 				WindowLayout *layout = window->winGetLayout();
-				layout->destroyWindows();
-				deleteInstance(layout);
+				if (layout)
+				{
+					layout->destroyWindows();
+					deleteInstance(layout);
+				}
 				
 			}
 			else if ( controlID == radioButtonEasyAIID )

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/DownloadMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/DownloadMenu.cpp
@@ -82,11 +82,14 @@ static void closeDownloadWindow( void )
 	if (!parent)
 		return;
 
-  WindowLayout *menuLayout = parent->winGetLayout();
-	menuLayout->runShutdown();
-  menuLayout->destroyWindows();
-	deleteInstance(menuLayout);
-	menuLayout = NULL;
+	WindowLayout *menuLayout = parent->winGetLayout();
+	if (menuLayout)
+	{
+		menuLayout->runShutdown();
+		menuLayout->destroyWindows();
+		deleteInstance(menuLayout);
+		menuLayout = NULL;
+	}
 
 	GameWindow *mainWin = TheWindowManager->winGetWindowFromId( NULL, NAMEKEY("MainMenu.wnd:MainMenuParent") );
 	if (mainWin)

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanMapSelectMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanMapSelectMenu.cpp
@@ -344,9 +344,13 @@ WindowMsgHandledType LanMapSelectMenuSystem( GameWindow *window, UnsignedInt msg
 			else if ( controlID == buttonBack )
 			{
 				
-				mapSelectLayout->destroyWindows();
-				deleteInstance(mapSelectLayout);
-				mapSelectLayout = NULL;
+				if (mapSelectLayout)
+				{
+					mapSelectLayout->destroyWindows();
+					deleteInstance(mapSelectLayout);
+					mapSelectLayout = NULL;
+				}
+
 				// set the controls to NULL since they've been destroyed.
 				NullifyControls();
 				showLANGameOptionsUnderlyingGUIElements(TRUE);
@@ -390,9 +394,12 @@ WindowMsgHandledType LanMapSelectMenuSystem( GameWindow *window, UnsignedInt msg
 					}
 
 					
-					mapSelectLayout->destroyWindows();
-					deleteInstance(mapSelectLayout);
-					mapSelectLayout = NULL;
+					if (mapSelectLayout)
+					{
+						mapSelectLayout->destroyWindows();
+						deleteInstance(mapSelectLayout);
+						mapSelectLayout = NULL;
+					}
 
 					// set the controls to NULL since they've been destroyed.
 					NullifyControls();

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupCommunicator.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupCommunicator.cpp
@@ -184,10 +184,13 @@ WindowMsgHandledType PopupCommunicatorSystem( GameWindow *window, UnsignedInt ms
       
 			if( controlID == buttonOkID )
 			{
-        WindowLayout *popupCommunicatorLayout = window->winGetLayout();
-        popupCommunicatorLayout->destroyWindows();
-				deleteInstance(popupCommunicatorLayout);
-				popupCommunicatorLayout = NULL;
+				WindowLayout *popupCommunicatorLayout = window->winGetLayout();
+				if (popupCommunicatorLayout)
+				{
+					popupCommunicatorLayout->destroyWindows();
+					deleteInstance(popupCommunicatorLayout);
+					popupCommunicatorLayout = NULL;
+				}
 			}  // end if
 	
 			break;

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/QuitMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/QuitMenu.cpp
@@ -122,14 +122,14 @@ void destroyQuitMenu()
 	{
 		fullQuitMenuLayout->destroyWindows();
 		deleteInstance(fullQuitMenuLayout);
+		fullQuitMenuLayout = NULL;
 	}
-	fullQuitMenuLayout = NULL;
 	if(noSaveLoadQuitMenuLayout)
 	{
 		noSaveLoadQuitMenuLayout->destroyWindows();
 		deleteInstance(noSaveLoadQuitMenuLayout);
+		noSaveLoadQuitMenuLayout = NULL;
 	}
-	noSaveLoadQuitMenuLayout = NULL;
 	quitMenuLayout = NULL;
 	isVisible = FALSE;
 }

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
@@ -759,9 +759,12 @@ void finishSinglePlayerInit( void )
 	TheInGameUI->freeMessageResources();
 
 	//
-	s_blankLayout->destroyWindows();
-	deleteInstance(s_blankLayout);
-	s_blankLayout = NULL;
+	if (s_blankLayout)
+	{
+		s_blankLayout->destroyWindows();
+		deleteInstance(s_blankLayout);
+		s_blankLayout = NULL;
+	}
 
 	// set keyboard focus to main parent
 	TheWindowManager->winSetFocus( parent );

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishMapSelectMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishMapSelectMenu.cpp
@@ -521,9 +521,13 @@ WindowMsgHandledType SkirmishMapSelectMenuSystem( GameWindow *window, UnsignedIn
 			{
 				showSkirmishGameOptionsUnderlyingGUIElements(TRUE);
 
-				skirmishMapSelectLayout->destroyWindows();
-				deleteInstance(skirmishMapSelectLayout);
-				skirmishMapSelectLayout = NULL;
+				if (skirmishMapSelectLayout)
+				{
+					skirmishMapSelectLayout->destroyWindows();
+					deleteInstance(skirmishMapSelectLayout);
+					skirmishMapSelectLayout = NULL;
+				}
+
 				skirmishPositionStartSpots();
 				//TheShell->pop();
 				//do you need this ??
@@ -583,9 +587,12 @@ WindowMsgHandledType SkirmishMapSelectMenuSystem( GameWindow *window, UnsignedIn
 					skirmishPositionStartSpots();
 					skirmishUpdateSlotList();
 
-					skirmishMapSelectLayout->destroyWindows();
-					deleteInstance(skirmishMapSelectLayout);
-					skirmishMapSelectLayout = NULL;
+					if (skirmishMapSelectLayout)
+					{
+						skirmishMapSelectLayout->destroyWindows();
+						deleteInstance(skirmishMapSelectLayout);
+						skirmishMapSelectLayout = NULL;
+					}
 					//TheShell->pop();
 
 				}  // end if

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLMapSelectMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLMapSelectMenu.cpp
@@ -381,9 +381,13 @@ WindowMsgHandledType WOLMapSelectMenuSystem( GameWindow *window, UnsignedInt msg
 			{
 				showGameSpyGameOptionsUnderlyingGUIElements( TRUE );
 
-				WOLMapSelectLayout->destroyWindows();
-				deleteInstance(WOLMapSelectLayout);
-				WOLMapSelectLayout = NULL;
+				if (WOLMapSelectLayout)
+				{
+					WOLMapSelectLayout->destroyWindows();
+					deleteInstance(WOLMapSelectLayout);
+					WOLMapSelectLayout = NULL;
+				}
+
 				WOLPositionStartSpots();
 			}  // end if
 			else if ( controlID == radioButtonSystemMapsID )
@@ -445,9 +449,12 @@ WindowMsgHandledType WOLMapSelectMenuSystem( GameWindow *window, UnsignedInt msg
 					WOLDisplaySlotList();
 					WOLDisplayGameOptions();
 
-					WOLMapSelectLayout->destroyWindows();
-					deleteInstance(WOLMapSelectLayout);
-					WOLMapSelectLayout = NULL;
+					if (WOLMapSelectLayout)
+					{
+						WOLMapSelectLayout->destroyWindows();
+						deleteInstance(WOLMapSelectLayout);
+						WOLMapSelectLayout = NULL;
+					}
 
 					showGameSpyGameOptionsUnderlyingGUIElements( TRUE );
 

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/Shell/Shell.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/Shell/Shell.cpp
@@ -629,15 +629,18 @@ void Shell::doPop( Bool impendingPush )
 
 	// there better be a top of the stack since we're popping
 	DEBUG_ASSERTCRASH( currentTop, ("Shell: No top of stack and we want to pop!\n") );
-		
-	// remove this screen from our list
-	unlinkScreen( currentTop );
 
-	// delete all the windows in the screen
-	currentTop->destroyWindows();
+	if (currentTop)
+	{
+		// remove this screen from our list
+		unlinkScreen(currentTop);
 
-	// release the screen object back to the memory pool
-	deleteInstance(currentTop);
+		// delete all the windows in the screen
+		currentTop->destroyWindows();
+
+		// release the screen object back to the memory pool
+		deleteInstance(currentTop);
+	}
 
 	// run the init for the new top of the stack if present
 	WindowLayout *newTop = top();

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/WindowLayout.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/WindowLayout.cpp
@@ -173,10 +173,6 @@ void WindowLayout::removeWindow( GameWindow *window )
 //-------------------------------------------------------------------------------------------------
 void WindowLayout::destroyWindows( void )
 {
-	if (this == NULL)
-	{
-		return;
-	}
 	GameWindow *window;
 
 	while( (window = getFirstWindow()) != 0 )

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -977,8 +977,8 @@ ControlBar::~ControlBar( void )
 	{
 		m_scienceLayout->destroyWindows();
 		deleteInstance(m_scienceLayout);
+		m_scienceLayout = NULL;
 	}
-	m_scienceLayout = NULL;
 	m_genArrow = NULL;
 	if(m_videoManager)
 		delete m_videoManager;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Diplomacy.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Diplomacy.cpp
@@ -292,8 +292,8 @@ void ResetDiplomacy( void )
 		theLayout->destroyWindows();
 		deleteInstance(theLayout);
 		InitBuddyControls(-1);
+		theLayout = NULL;
 	}
-	theLayout = NULL;
 	theWindow = NULL;
 	if (theAnimateWindowManager)
 		delete theAnimateWindowManager;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/DifficultySelect.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/DifficultySelect.cpp
@@ -258,8 +258,12 @@ WindowMsgHandledType DifficultySelectSystem( GameWindow *window, UnsignedInt msg
 				pref.write();
 				//TheScriptEngine->setGlobalDifficulty(s_AIDiff); // CANNOT DO THIS! REPLAYS WILL BREAK!
 				WindowLayout *layout = window->winGetLayout();
-				layout->destroyWindows();
-				deleteInstance(layout);
+				if (layout)
+				{
+					layout->destroyWindows();
+					deleteInstance(layout);
+				}
+
 				setupGameStart(TheCampaignManager->getCurrentMap(), s_AIDiff);
 				// start the game
 			}
@@ -268,8 +272,11 @@ WindowMsgHandledType DifficultySelectSystem( GameWindow *window, UnsignedInt msg
 				TheCampaignManager->setCampaign( AsciiString::TheEmptyString );
 				TheWindowManager->winUnsetModal(window);
 				WindowLayout *layout = window->winGetLayout();
-				layout->destroyWindows();
-				deleteInstance(layout);
+				if (layout)
+				{
+					layout->destroyWindows();
+					deleteInstance(layout);
+				}
 				
 			}
 			else if ( controlID == radioButtonEasyAIID )

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/DownloadMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/DownloadMenu.cpp
@@ -82,11 +82,14 @@ static void closeDownloadWindow( void )
 	if (!parent)
 		return;
 
-  WindowLayout *menuLayout = parent->winGetLayout();
-	menuLayout->runShutdown();
-  menuLayout->destroyWindows();
-	deleteInstance(menuLayout);
-	menuLayout = NULL;
+	WindowLayout *menuLayout = parent->winGetLayout();
+	if (menuLayout)
+	{
+		menuLayout->runShutdown();
+		menuLayout->destroyWindows();
+		deleteInstance(menuLayout);
+		menuLayout = NULL;
+	}
 
 	GameWindow *mainWin = TheWindowManager->winGetWindowFromId( NULL, NAMEKEY("MainMenu.wnd:MainMenuParent") );
 	if (mainWin)

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanMapSelectMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanMapSelectMenu.cpp
@@ -344,9 +344,13 @@ WindowMsgHandledType LanMapSelectMenuSystem( GameWindow *window, UnsignedInt msg
 			else if ( controlID == buttonBack )
 			{
 				
-				mapSelectLayout->destroyWindows();
-				deleteInstance(mapSelectLayout);
-				mapSelectLayout = NULL;
+				if (mapSelectLayout)
+				{
+					mapSelectLayout->destroyWindows();
+					deleteInstance(mapSelectLayout);
+					mapSelectLayout = NULL;
+				}
+
 				// set the controls to NULL since they've been destroyed.
 				NullifyControls();
 				showLANGameOptionsUnderlyingGUIElements(TRUE);
@@ -390,9 +394,12 @@ WindowMsgHandledType LanMapSelectMenuSystem( GameWindow *window, UnsignedInt msg
 					}
 
 					
-					mapSelectLayout->destroyWindows();
-					deleteInstance(mapSelectLayout);
-					mapSelectLayout = NULL;
+					if (mapSelectLayout)
+					{
+						mapSelectLayout->destroyWindows();
+						deleteInstance(mapSelectLayout);
+						mapSelectLayout = NULL;
+					}
 
 					// set the controls to NULL since they've been destroyed.
 					NullifyControls();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupCommunicator.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupCommunicator.cpp
@@ -184,10 +184,13 @@ WindowMsgHandledType PopupCommunicatorSystem( GameWindow *window, UnsignedInt ms
       
 			if( controlID == buttonOkID )
 			{
-        WindowLayout *popupCommunicatorLayout = window->winGetLayout();
-        popupCommunicatorLayout->destroyWindows();
-				deleteInstance(popupCommunicatorLayout);
-				popupCommunicatorLayout = NULL;
+				WindowLayout *popupCommunicatorLayout = window->winGetLayout();
+				if (popupCommunicatorLayout)
+				{
+					popupCommunicatorLayout->destroyWindows();
+					deleteInstance(popupCommunicatorLayout);
+					popupCommunicatorLayout = NULL;
+				}
 			}  // end if
 	
 			break;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/QuitMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/QuitMenu.cpp
@@ -122,14 +122,14 @@ void destroyQuitMenu()
 	{
 		fullQuitMenuLayout->destroyWindows();
 		deleteInstance(fullQuitMenuLayout);
+		fullQuitMenuLayout = NULL;
 	}
-	fullQuitMenuLayout = NULL;
 	if(noSaveLoadQuitMenuLayout)
 	{
 		noSaveLoadQuitMenuLayout->destroyWindows();
 		deleteInstance(noSaveLoadQuitMenuLayout);
+		noSaveLoadQuitMenuLayout = NULL;
 	}
-	noSaveLoadQuitMenuLayout = NULL;
 	quitMenuLayout = NULL;
 	isVisible = FALSE;
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
@@ -935,9 +935,12 @@ void finishSinglePlayerInit( void )
 	TheInGameUI->freeMessageResources();
 
 	//
-	s_blankLayout->destroyWindows();
-	deleteInstance(s_blankLayout);
-	s_blankLayout = NULL;
+	if (s_blankLayout)
+	{
+		s_blankLayout->destroyWindows();
+		deleteInstance(s_blankLayout);
+		s_blankLayout = NULL;
+	}
 
 	// set keyboard focus to main parent
 	TheWindowManager->winSetFocus( parent );

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishMapSelectMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishMapSelectMenu.cpp
@@ -524,9 +524,13 @@ WindowMsgHandledType SkirmishMapSelectMenuSystem( GameWindow *window, UnsignedIn
 			{
 				showSkirmishGameOptionsUnderlyingGUIElements(TRUE);
 
-				skirmishMapSelectLayout->destroyWindows();
-				deleteInstance(skirmishMapSelectLayout);
-				skirmishMapSelectLayout = NULL;
+				if (skirmishMapSelectLayout)
+				{
+					skirmishMapSelectLayout->destroyWindows();
+					deleteInstance(skirmishMapSelectLayout);
+					skirmishMapSelectLayout = NULL;
+				}
+
 				skirmishPositionStartSpots();
 				//TheShell->pop();
 				//do you need this ??
@@ -586,9 +590,12 @@ WindowMsgHandledType SkirmishMapSelectMenuSystem( GameWindow *window, UnsignedIn
 				skirmishPositionStartSpots();
 				skirmishUpdateSlotList();
 
-				skirmishMapSelectLayout->destroyWindows();
-				deleteInstance(skirmishMapSelectLayout);
-				skirmishMapSelectLayout = NULL;
+				if (skirmishMapSelectLayout)
+				{
+					skirmishMapSelectLayout->destroyWindows();
+					deleteInstance(skirmishMapSelectLayout);
+					skirmishMapSelectLayout = NULL;
+				}
 					//TheShell->pop();
 
 				}  // end if

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLMapSelectMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLMapSelectMenu.cpp
@@ -393,9 +393,13 @@ WindowMsgHandledType WOLMapSelectMenuSystem( GameWindow *window, UnsignedInt msg
 			{
 				showGameSpyGameOptionsUnderlyingGUIElements( TRUE );
 
-				WOLMapSelectLayout->destroyWindows();
-				deleteInstance(WOLMapSelectLayout);
-				WOLMapSelectLayout = NULL;
+				if (WOLMapSelectLayout)
+				{
+					WOLMapSelectLayout->destroyWindows();
+					deleteInstance(WOLMapSelectLayout);
+					WOLMapSelectLayout = NULL;
+				}
+
 				WOLPositionStartSpots();
 			}  // end if
 			else if ( controlID == radioButtonSystemMapsID )
@@ -457,9 +461,12 @@ WindowMsgHandledType WOLMapSelectMenuSystem( GameWindow *window, UnsignedInt msg
 					WOLDisplaySlotList();
 					WOLDisplayGameOptions();
 
-					WOLMapSelectLayout->destroyWindows();
-					deleteInstance(WOLMapSelectLayout);
-					WOLMapSelectLayout = NULL;
+					if (WOLMapSelectLayout)
+					{
+						WOLMapSelectLayout->destroyWindows();
+						deleteInstance(WOLMapSelectLayout);
+						WOLMapSelectLayout = NULL;
+					}
 
 					showGameSpyGameOptionsUnderlyingGUIElements( TRUE );
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/Shell/Shell.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/Shell/Shell.cpp
@@ -636,15 +636,18 @@ void Shell::doPop( Bool impendingPush )
 
 	// there better be a top of the stack since we're popping
 	DEBUG_ASSERTCRASH( currentTop, ("Shell: No top of stack and we want to pop!\n") );
-		
-	// remove this screen from our list
-	unlinkScreen( currentTop );
 
-	// delete all the windows in the screen
-	currentTop->destroyWindows();
+	if (currentTop)
+	{
+		// remove this screen from our list
+		unlinkScreen(currentTop);
 
-	// release the screen object back to the memory pool
-	deleteInstance(currentTop);
+		// delete all the windows in the screen
+		currentTop->destroyWindows();
+
+		// release the screen object back to the memory pool
+		deleteInstance(currentTop);
+	}
 
 	// run the init for the new top of the stack if present
 	WindowLayout *newTop = top();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/WindowLayout.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/WindowLayout.cpp
@@ -173,10 +173,6 @@ void WindowLayout::removeWindow( GameWindow *window )
 //-------------------------------------------------------------------------------------------------
 void WindowLayout::destroyWindows( void )
 {
-	if (this == NULL)
-	{
-		return;
-	}
 	GameWindow *window;
 
 	while( (window = getFirstWindow()) != 0 )


### PR DESCRIPTION
Same issue as: https://github.com/TheSuperHackers/GeneralsGameCode/pull/870

https://github.com/TheSuperHackers/GeneralsGameCode/blob/e61cef2ce5b1a04e288bfb0c3220e94c2e4c99ae/Generals/Code/GameEngine/Source/GameClient/GUI/WindowLayout.cpp#L174-L179

This pr removes the explicit `if (this == NULL)` check in `WindowLayout::destroyWindows`, and added `nullptr` checks at the call sites where needed.