### PR TITLE
[GEN][ZH] Fix crash in W3DBufferManager when a shadow buffer limit is exceeded

### DIFF
--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DBufferManager.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DBufferManager.cpp
@@ -210,8 +210,8 @@ Bool W3DBufferManager::ReAcquireResources(void)
 }
 
 /**Searches through previously allocated vertex buffer slots and returns a matching type.  If none found,
-   creates a new slot and adds it to the pool.  Returns an integer slotId used to reference the VB.
-   Returns -1 in case of failure.
+   creates a new slot and adds it to the pool.  Returns a pointer to the VB slot.
+   Returns NULL in case of failure.
 */
 W3DBufferManager::W3DVertexBufferSlot *W3DBufferManager::getSlot(VBM_FVF_TYPES fvfType, Int size)
 {
@@ -222,9 +222,14 @@ W3DBufferManager::W3DVertexBufferSlot *W3DBufferManager::getSlot(VBM_FVF_TYPES f
 	size = (size + (MIN_SLOT_SIZE-1)) & (~(MIN_SLOT_SIZE-1));
 	Int sizeIndex = (size >> MIN_SLOT_SIZE_SHIFT)-1;
 
-	DEBUG_ASSERTCRASH(sizeIndex < MAX_VB_SIZES && size, ("Allocating too large vertex buffer slot"));
+	DEBUG_ASSERTCRASH(sizeIndex < MAX_VB_SIZES && size > 0, ("Allocating too large vertex buffer slot"));
+	// TheSuperHackers @bugfix xezon 18/05/2025 Protect against indexing slots beyond the max size.
+	// This will happen when a mesh is too complex to draw shadows with.
+	if (sizeIndex >= MAX_VB_SIZES || size <= 0) {
+		return NULL;
+	}
 
-	if ((vbSlot=m_W3DVertexBufferSlots[fvfType][sizeIndex]) != 0)
+	if ((vbSlot=m_W3DVertexBufferSlots[fvfType][sizeIndex]) != NULL)
 	{	//found a previously allocated slot matching required size
 		m_W3DVertexBufferSlots[fvfType][sizeIndex]=vbSlot->m_nextSameSize;
 		if (vbSlot->m_nextSameSize)
@@ -260,31 +265,32 @@ W3DBufferManager::W3DVertexBufferSlot * W3DBufferManager::allocateSlotStorage(VB
 	W3DVertexBufferSlot *vbSlot;
 //	Int sizeIndex = (size >> MIN_SLOT_SIZE_SHIFT)-1;
 
-	DEBUG_ASSERTCRASH(m_numEmptySlotsAllocated < MAX_NUMBER_SLOTS, ("Nore more VB Slots"));
+	DEBUG_ASSERTCRASH(m_numEmptySlotsAllocated < MAX_NUMBER_SLOTS, ("No more VB Slots"));
+	// TheSuperHackers @bugfix xezon 18/05/2025 Protect against allocating slot storage beyond the max size.
+	// This will happen when there are too many meshes in the scene to draw shadows with.
+	if (m_numEmptySlotsAllocated >= MAX_NUMBER_SLOTS) {
+		return NULL;
+	}
 
 	pVB=m_W3DVertexBuffers[fvfType];
 	while (pVB)
 	{
 		if ((pVB->m_size - pVB->m_startFreeIndex) >= size)
 		{	//found enough free space in this vertex buffer
-
-			if (m_numEmptySlotsAllocated < MAX_NUMBER_SLOTS)
-			{	//we're allowing more slots to be allocated.
-				vbSlot=&m_W3DVertexBufferEmptySlots[m_numEmptySlotsAllocated];
-				vbSlot->m_size=size;
-				vbSlot->m_start=pVB->m_startFreeIndex;
-				vbSlot->m_VB=pVB;
-				//Link to VB list of slots
-				vbSlot->m_nextSameVB=pVB->m_usedSlots;
-				vbSlot->m_prevSameVB=NULL;	//this will be the new head
-				if (pVB->m_usedSlots)
-					pVB->m_usedSlots->m_prevSameVB=vbSlot;
-				vbSlot->m_prevSameSize=vbSlot->m_nextSameSize=NULL;
-				pVB->m_usedSlots=vbSlot;
-				pVB->m_startFreeIndex += size;
-				m_numEmptySlotsAllocated++;
-				return vbSlot;
-			}
+			vbSlot=&m_W3DVertexBufferEmptySlots[m_numEmptySlotsAllocated];
+			vbSlot->m_size=size;
+			vbSlot->m_start=pVB->m_startFreeIndex;
+			vbSlot->m_VB=pVB;
+			//Link to VB list of slots
+			vbSlot->m_nextSameVB=pVB->m_usedSlots;
+			vbSlot->m_prevSameVB=NULL;	//this will be the new head
+			if (pVB->m_usedSlots)
+				pVB->m_usedSlots->m_prevSameVB=vbSlot;
+			vbSlot->m_prevSameSize=vbSlot->m_nextSameSize=NULL;
+			pVB->m_usedSlots=vbSlot;
+			pVB->m_startFreeIndex += size;
+			m_numEmptySlotsAllocated++;
+			return vbSlot;
 		}
 		pVB = pVB->m_nextVB;
 	}
@@ -324,8 +330,8 @@ W3DBufferManager::W3DVertexBufferSlot * W3DBufferManager::allocateSlotStorage(VB
 
 //******************************** Index Buffer code ******************************************************
 /**Searches through previously allocated index buffer slots and returns a matching type.  If none found,
-   creates a new slot and adds it to the pool.  Returns an integer slotId used to reference the VB.
-   Returns -1 in case of failure.
+   creates a new slot and adds it to the pool.  Returns a pointer to the VB slot.
+   Returns NULL in case of failure.
 */
 W3DBufferManager::W3DIndexBufferSlot *W3DBufferManager::getSlot(Int size)
 {
@@ -336,9 +342,14 @@ W3DBufferManager::W3DIndexBufferSlot *W3DBufferManager::getSlot(Int size)
 	size = (size + (MIN_SLOT_SIZE-1)) & (~(MIN_SLOT_SIZE-1));
 	Int sizeIndex = (size >> MIN_SLOT_SIZE_SHIFT)-1;
 
-	DEBUG_ASSERTCRASH(sizeIndex < MAX_IB_SIZES && size, ("Allocating too large index buffer slot"));
+	DEBUG_ASSERTCRASH(sizeIndex < MAX_IB_SIZES && size > 0, ("Allocating too large index buffer slot"));
+	// TheSuperHackers @bugfix xezon 18/05/2025 Protect against indexing slots beyond the max size.
+	// This will happen when a mesh is too complex to draw shadows with.
+	if (sizeIndex >= MAX_IB_SIZES || size <= 0) {
+		return NULL;
+	}
 
-	if ((ibSlot=m_W3DIndexBufferSlots[sizeIndex]) != 0)
+	if ((ibSlot=m_W3DIndexBufferSlots[sizeIndex]) != NULL)
 	{	//found a previously allocated slot matching required size
 		m_W3DIndexBufferSlots[sizeIndex]=ibSlot->m_nextSameSize;
 		if (ibSlot->m_nextSameSize)
@@ -374,31 +385,32 @@ W3DBufferManager::W3DIndexBufferSlot * W3DBufferManager::allocateSlotStorage(Int
 	W3DIndexBufferSlot *ibSlot;
 //	Int sizeIndex = (size >> MIN_SLOT_SIZE_SHIFT)-1;
 
-	DEBUG_ASSERTCRASH(m_numEmptyIndexSlotsAllocated < MAX_NUMBER_SLOTS, ("Nore more IB Slots"));
+	DEBUG_ASSERTCRASH(m_numEmptyIndexSlotsAllocated < MAX_NUMBER_SLOTS, ("No more IB Slots"));
+	// TheSuperHackers @bugfix xezon 18/05/2025 Protect against allocating slot storage beyond the max size.
+	// This will happen when there are too many meshes in the scene to draw shadows with.
+	if (m_numEmptyIndexSlotsAllocated >= MAX_NUMBER_SLOTS) {
+		return NULL;
+	}
 
 	pIB=m_W3DIndexBuffers;
 	while (pIB)
 	{
 		if ((pIB->m_size - pIB->m_startFreeIndex) >= size)
 		{	//found enough free space in this index buffer
-
-			if (m_numEmptyIndexSlotsAllocated < MAX_NUMBER_SLOTS)
-			{	//we're allowing more slots to be allocated.
-				ibSlot=&m_W3DIndexBufferEmptySlots[m_numEmptyIndexSlotsAllocated];
-				ibSlot->m_size=size;
-				ibSlot->m_start=pIB->m_startFreeIndex;
-				ibSlot->m_IB=pIB;
-				//Link to IB list of slots
-				ibSlot->m_nextSameIB=pIB->m_usedSlots;
-				ibSlot->m_prevSameIB=NULL;	//this will be the new head
-				if (pIB->m_usedSlots)
-					pIB->m_usedSlots->m_prevSameIB=ibSlot;
-				ibSlot->m_prevSameSize=ibSlot->m_nextSameSize=NULL;
-				pIB->m_usedSlots=ibSlot;
-				pIB->m_startFreeIndex += size;
-				m_numEmptyIndexSlotsAllocated++;
-				return ibSlot;
-			}
+			ibSlot=&m_W3DIndexBufferEmptySlots[m_numEmptyIndexSlotsAllocated];
+			ibSlot->m_size=size;
+			ibSlot->m_start=pIB->m_startFreeIndex;
+			ibSlot->m_IB=pIB;
+			//Link to IB list of slots
+			ibSlot->m_nextSameIB=pIB->m_usedSlots;
+			ibSlot->m_prevSameIB=NULL;	//this will be the new head
+			if (pIB->m_usedSlots)
+				pIB->m_usedSlots->m_prevSameIB=ibSlot;
+			ibSlot->m_prevSameSize=ibSlot->m_nextSameSize=NULL;
+			pIB->m_usedSlots=ibSlot;
+			pIB->m_startFreeIndex += size;
+			m_numEmptyIndexSlotsAllocated++;
+			return ibSlot;
 		}
 		pIB = pIB->m_nextIB;
 	}

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DBufferManager.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DBufferManager.cpp
@@ -330,7 +330,7 @@ W3DBufferManager::W3DVertexBufferSlot * W3DBufferManager::allocateSlotStorage(VB
 
 //******************************** Index Buffer code ******************************************************
 /**Searches through previously allocated index buffer slots and returns a matching type.  If none found,
-   creates a new slot and adds it to the pool.  Returns a pointer to the VB slot.
+   creates a new slot and adds it to the pool.  Returns a pointer to the IB slot.
    Returns NULL in case of failure.
 */
 W3DBufferManager::W3DIndexBufferSlot *W3DBufferManager::getSlot(Int size)

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp
@@ -2808,8 +2808,10 @@ void W3DVolumetricShadow::constructVolumeVB( Vector3 *lightPosObject,Real shadow
 		vertexCount);
 
 	DEBUG_ASSERTCRASH(vbSlot != NULL, ("Can't allocate vertex buffer slot for shadow volume"));
-
-	DEBUG_ASSERTCRASH(vbSlot->m_size >= vertexCount,("Overflowing Shadow Vertex Buffer Slot"));
+	if (vbSlot != NULL)
+	{
+		DEBUG_ASSERTCRASH(vbSlot->m_size >= vertexCount,("Overflowing Shadow Vertex Buffer Slot"));
+	}
 
 	DEBUG_ASSERTCRASH(m_shadowVolume[ volumeIndex ][meshIndex]->GetNumPolygon() == 0,("Updating Existing Static Shadow Volume"));
 
@@ -2817,8 +2819,10 @@ void W3DVolumetricShadow::constructVolumeVB( Vector3 *lightPosObject,Real shadow
 	ibSlot=m_shadowVolumeIB[ volumeIndex ][meshIndex] = TheW3DBufferManager->getSlot(polygonCount*3);
 
 	DEBUG_ASSERTCRASH(ibSlot != NULL, ("Can't allocate index buffer slot for shadow volume"));
-
-	DEBUG_ASSERTCRASH(ibSlot->m_size >= (polygonCount*3),("Overflowing Shadow Index Buffer Slot"));
+	if (ibSlot != NULL)
+	{
+		DEBUG_ASSERTCRASH(ibSlot->m_size >= (polygonCount*3),("Overflowing Shadow Index Buffer Slot"));
+	}
 
 	if (!ibSlot || !vbSlot)
 	{	//could not allocate storage to hold buffers

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DBufferManager.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DBufferManager.cpp
@@ -210,8 +210,8 @@ Bool W3DBufferManager::ReAcquireResources(void)
 }
 
 /**Searches through previously allocated vertex buffer slots and returns a matching type.  If none found,
-   creates a new slot and adds it to the pool.  Returns an integer slotId used to reference the VB.
-   Returns -1 in case of failure.
+   creates a new slot and adds it to the pool.  Returns a pointer to the VB slot.
+   Returns NULL in case of failure.
 */
 W3DBufferManager::W3DVertexBufferSlot *W3DBufferManager::getSlot(VBM_FVF_TYPES fvfType, Int size)
 {
@@ -222,9 +222,14 @@ W3DBufferManager::W3DVertexBufferSlot *W3DBufferManager::getSlot(VBM_FVF_TYPES f
 	size = (size + (MIN_SLOT_SIZE-1)) & (~(MIN_SLOT_SIZE-1));
 	Int sizeIndex = (size >> MIN_SLOT_SIZE_SHIFT)-1;
 
-	DEBUG_ASSERTCRASH(sizeIndex < MAX_VB_SIZES && size, ("Allocating too large vertex buffer slot"));
+	DEBUG_ASSERTCRASH(sizeIndex < MAX_VB_SIZES && size > 0, ("Allocating too large vertex buffer slot"));
+	// TheSuperHackers @bugfix xezon 18/05/2025 Protect against indexing slots beyond the max size.
+	// This will happen when a mesh is too complex to draw shadows with.
+	if (sizeIndex >= MAX_VB_SIZES || size <= 0) {
+		return NULL;
+	}
 
-	if ((vbSlot=m_W3DVertexBufferSlots[fvfType][sizeIndex]) != 0)
+	if ((vbSlot=m_W3DVertexBufferSlots[fvfType][sizeIndex]) != NULL)
 	{	//found a previously allocated slot matching required size
 		m_W3DVertexBufferSlots[fvfType][sizeIndex]=vbSlot->m_nextSameSize;
 		if (vbSlot->m_nextSameSize)
@@ -260,31 +265,32 @@ W3DBufferManager::W3DVertexBufferSlot * W3DBufferManager::allocateSlotStorage(VB
 	W3DVertexBufferSlot *vbSlot;
 //	Int sizeIndex = (size >> MIN_SLOT_SIZE_SHIFT)-1;
 
-	DEBUG_ASSERTCRASH(m_numEmptySlotsAllocated < MAX_NUMBER_SLOTS, ("Nore more VB Slots"));
+	DEBUG_ASSERTCRASH(m_numEmptySlotsAllocated < MAX_NUMBER_SLOTS, ("No more VB Slots"));
+	// TheSuperHackers @bugfix xezon 18/05/2025 Protect against allocating slot storage beyond the max size.
+	// This will happen when there are too many meshes in the scene to draw shadows with.
+	if (m_numEmptySlotsAllocated >= MAX_NUMBER_SLOTS) {
+		return NULL;
+	}
 
 	pVB=m_W3DVertexBuffers[fvfType];
 	while (pVB)
 	{
 		if ((pVB->m_size - pVB->m_startFreeIndex) >= size)
 		{	//found enough free space in this vertex buffer
-
-			if (m_numEmptySlotsAllocated < MAX_NUMBER_SLOTS)
-			{	//we're allowing more slots to be allocated.
-				vbSlot=&m_W3DVertexBufferEmptySlots[m_numEmptySlotsAllocated];
-				vbSlot->m_size=size;
-				vbSlot->m_start=pVB->m_startFreeIndex;
-				vbSlot->m_VB=pVB;
-				//Link to VB list of slots
-				vbSlot->m_nextSameVB=pVB->m_usedSlots;
-				vbSlot->m_prevSameVB=NULL;	//this will be the new head
-				if (pVB->m_usedSlots)
-					pVB->m_usedSlots->m_prevSameVB=vbSlot;
-				vbSlot->m_prevSameSize=vbSlot->m_nextSameSize=NULL;
-				pVB->m_usedSlots=vbSlot;
-				pVB->m_startFreeIndex += size;
-				m_numEmptySlotsAllocated++;
-				return vbSlot;
-			}
+			vbSlot=&m_W3DVertexBufferEmptySlots[m_numEmptySlotsAllocated];
+			vbSlot->m_size=size;
+			vbSlot->m_start=pVB->m_startFreeIndex;
+			vbSlot->m_VB=pVB;
+			//Link to VB list of slots
+			vbSlot->m_nextSameVB=pVB->m_usedSlots;
+			vbSlot->m_prevSameVB=NULL;	//this will be the new head
+			if (pVB->m_usedSlots)
+				pVB->m_usedSlots->m_prevSameVB=vbSlot;
+			vbSlot->m_prevSameSize=vbSlot->m_nextSameSize=NULL;
+			pVB->m_usedSlots=vbSlot;
+			pVB->m_startFreeIndex += size;
+			m_numEmptySlotsAllocated++;
+			return vbSlot;
 		}
 		pVB = pVB->m_nextVB;
 	}
@@ -324,8 +330,8 @@ W3DBufferManager::W3DVertexBufferSlot * W3DBufferManager::allocateSlotStorage(VB
 
 //******************************** Index Buffer code ******************************************************
 /**Searches through previously allocated index buffer slots and returns a matching type.  If none found,
-   creates a new slot and adds it to the pool.  Returns an integer slotId used to reference the VB.
-   Returns -1 in case of failure.
+   creates a new slot and adds it to the pool.  Returns a pointer to the VB slot.
+   Returns NULL in case of failure.
 */
 W3DBufferManager::W3DIndexBufferSlot *W3DBufferManager::getSlot(Int size)
 {
@@ -336,9 +342,14 @@ W3DBufferManager::W3DIndexBufferSlot *W3DBufferManager::getSlot(Int size)
 	size = (size + (MIN_SLOT_SIZE-1)) & (~(MIN_SLOT_SIZE-1));
 	Int sizeIndex = (size >> MIN_SLOT_SIZE_SHIFT)-1;
 
-	DEBUG_ASSERTCRASH(sizeIndex < MAX_IB_SIZES && size, ("Allocating too large index buffer slot"));
+	DEBUG_ASSERTCRASH(sizeIndex < MAX_IB_SIZES && size > 0, ("Allocating too large index buffer slot"));
+	// TheSuperHackers @bugfix xezon 18/05/2025 Protect against indexing slots beyond the max size.
+	// This will happen when a mesh is too complex to draw shadows with.
+	if (sizeIndex >= MAX_IB_SIZES || size <= 0) {
+		return NULL;
+	}
 
-	if ((ibSlot=m_W3DIndexBufferSlots[sizeIndex]) != 0)
+	if ((ibSlot=m_W3DIndexBufferSlots[sizeIndex]) != NULL)
 	{	//found a previously allocated slot matching required size
 		m_W3DIndexBufferSlots[sizeIndex]=ibSlot->m_nextSameSize;
 		if (ibSlot->m_nextSameSize)
@@ -374,31 +385,32 @@ W3DBufferManager::W3DIndexBufferSlot * W3DBufferManager::allocateSlotStorage(Int
 	W3DIndexBufferSlot *ibSlot;
 //	Int sizeIndex = (size >> MIN_SLOT_SIZE_SHIFT)-1;
 
-	DEBUG_ASSERTCRASH(m_numEmptyIndexSlotsAllocated < MAX_NUMBER_SLOTS, ("Nore more IB Slots"));
+	DEBUG_ASSERTCRASH(m_numEmptyIndexSlotsAllocated < MAX_NUMBER_SLOTS, ("No more IB Slots"));
+	// TheSuperHackers @bugfix xezon 18/05/2025 Protect against allocating slot storage beyond the max size.
+	// This will happen when there are too many meshes in the scene to draw shadows with.
+	if (m_numEmptyIndexSlotsAllocated >= MAX_NUMBER_SLOTS) {
+		return NULL;
+	}
 
 	pIB=m_W3DIndexBuffers;
 	while (pIB)
 	{
 		if ((pIB->m_size - pIB->m_startFreeIndex) >= size)
 		{	//found enough free space in this index buffer
-
-			if (m_numEmptyIndexSlotsAllocated < MAX_NUMBER_SLOTS)
-			{	//we're allowing more slots to be allocated.
-				ibSlot=&m_W3DIndexBufferEmptySlots[m_numEmptyIndexSlotsAllocated];
-				ibSlot->m_size=size;
-				ibSlot->m_start=pIB->m_startFreeIndex;
-				ibSlot->m_IB=pIB;
-				//Link to IB list of slots
-				ibSlot->m_nextSameIB=pIB->m_usedSlots;
-				ibSlot->m_prevSameIB=NULL;	//this will be the new head
-				if (pIB->m_usedSlots)
-					pIB->m_usedSlots->m_prevSameIB=ibSlot;
-				ibSlot->m_prevSameSize=ibSlot->m_nextSameSize=NULL;
-				pIB->m_usedSlots=ibSlot;
-				pIB->m_startFreeIndex += size;
-				m_numEmptyIndexSlotsAllocated++;
-				return ibSlot;
-			}
+			ibSlot=&m_W3DIndexBufferEmptySlots[m_numEmptyIndexSlotsAllocated];
+			ibSlot->m_size=size;
+			ibSlot->m_start=pIB->m_startFreeIndex;
+			ibSlot->m_IB=pIB;
+			//Link to IB list of slots
+			ibSlot->m_nextSameIB=pIB->m_usedSlots;
+			ibSlot->m_prevSameIB=NULL;	//this will be the new head
+			if (pIB->m_usedSlots)
+				pIB->m_usedSlots->m_prevSameIB=ibSlot;
+			ibSlot->m_prevSameSize=ibSlot->m_nextSameSize=NULL;
+			pIB->m_usedSlots=ibSlot;
+			pIB->m_startFreeIndex += size;
+			m_numEmptyIndexSlotsAllocated++;
+			return ibSlot;
 		}
 		pIB = pIB->m_nextIB;
 	}

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DBufferManager.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DBufferManager.cpp
@@ -330,7 +330,7 @@ W3DBufferManager::W3DVertexBufferSlot * W3DBufferManager::allocateSlotStorage(VB
 
 //******************************** Index Buffer code ******************************************************
 /**Searches through previously allocated index buffer slots and returns a matching type.  If none found,
-   creates a new slot and adds it to the pool.  Returns a pointer to the VB slot.
+   creates a new slot and adds it to the pool.  Returns a pointer to the IB slot.
    Returns NULL in case of failure.
 */
 W3DBufferManager::W3DIndexBufferSlot *W3DBufferManager::getSlot(Int size)

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp
@@ -2952,8 +2952,10 @@ void W3DVolumetricShadow::constructVolumeVB( Vector3 *lightPosObject,Real shadow
 		vertexCount);
 
 	DEBUG_ASSERTCRASH(vbSlot != NULL, ("Can't allocate vertex buffer slot for shadow volume"));
-
-	DEBUG_ASSERTCRASH(vbSlot->m_size >= vertexCount,("Overflowing Shadow Vertex Buffer Slot"));
+	if (vbSlot != NULL)
+	{
+		DEBUG_ASSERTCRASH(vbSlot->m_size >= vertexCount,("Overflowing Shadow Vertex Buffer Slot"));
+	}
 
 	DEBUG_ASSERTCRASH(m_shadowVolume[ volumeIndex ][meshIndex]->GetNumPolygon() == 0,("Updating Existing Static Shadow Volume"));
 
@@ -2961,8 +2963,10 @@ void W3DVolumetricShadow::constructVolumeVB( Vector3 *lightPosObject,Real shadow
 	ibSlot=m_shadowVolumeIB[ volumeIndex ][meshIndex] = TheW3DBufferManager->getSlot(polygonCount*3);
 
 	DEBUG_ASSERTCRASH(ibSlot != NULL, ("Can't allocate index buffer slot for shadow volume"));
-
-	DEBUG_ASSERTCRASH(ibSlot->m_size >= (polygonCount*3),("Overflowing Shadow Index Buffer Slot"));
+	if (ibSlot != NULL)
+	{
+		DEBUG_ASSERTCRASH(ibSlot->m_size >= (polygonCount*3),("Overflowing Shadow Index Buffer Slot"));
+	}
 
 	if (!ibSlot || !vbSlot)
 	{	//could not allocate storage to hold buffers


### PR DESCRIPTION
* Fixes #22
* Relates to #TheAssemblyArmada/Thyme#1101

This change fixes game crashes from exceeding the limits of `MAX_VB_SIZES`, `MAX_IB_SIZES` and `MAX_NUMBER_SLOTS`.

`MAX_NUMBER_SLOTS` is exceeded in the original game when more than 512 Scorpion tanks are rendered in the scene. This is just a sample test case.

This change also fixes errors in nearby strings and source code comments.

## Callstack for when buffer limit is exceeded

```cpp
> 	generalszh.exe!W3DVolumetricShadow::RenderMeshVolume(int meshIndex, int lightIndex, const Matrix3D * meshXform) Line 1392	C++
 	generalszh.exe!W3DVolumetricShadow::RenderVolume(int meshIndex, int lightIndex) Line 1337	C++
 	generalszh.exe!W3DVolumetricShadowManager::renderShadows(bool forceStencilFill) Line 3563	C++
 	generalszh.exe!DoShadows(RenderInfoClass & rinfo, bool stencilPass) Line 91	C++
 	generalszh.exe!RTS3DScene::Flush(RenderInfoClass & rinfo) Line 857	C++
 	generalszh.exe!RTS3DScene::Render(RenderInfoClass & rinfo) Line 1074	C++
 	generalszh.exe!WW3D::Render(SceneClass * scene, CameraClass * cam, bool clear, bool clearz, const Vector3 & color) Line 979	C++
 	generalszh.exe!RTS3DScene::draw() Line 1724	C++
 	generalszh.exe!SubsystemInterface::DRAW() Line 105	C++
 	generalszh.exe!RTS3DScene::doRender(CameraClass * cam) Line 1708	C++
 	generalszh.exe!W3DView::draw() Line 1565	C++
 	generalszh.exe!SubsystemInterface::DRAW() Line 105	C++
 	generalszh.exe!Display::drawViews() Line 118	C++
 	generalszh.exe!W3DDisplay::draw() Line 1910	C++
 	generalszh.exe!SubsystemInterface::DRAW() Line 105	C++
 	generalszh.exe!GameClient::update() Line 767	C++
 	generalszh.exe!SubsystemInterface::UPDATE() Line 79	C++
 	generalszh.exe!GameEngine::update() Line 741	C++
 	generalszh.exe!Win32GameEngine::update() Line 93	C++
 	generalszh.exe!GameEngine::execute() Line 816	C++
 	generalszh.exe!GameMain(int argc, char * * argv) Line 47	C++
 	generalszh.exe!WinMain(HINSTANCE__ * hInstance, HINSTANCE__ * hPrevInstance, char * lpCmdLine, int nCmdShow) Line 1034	C++
 	[Inline Frame] generalszh.exe!invoke_main() Line 102	C++
 	generalszh.exe!__scrt_common_main_seh() Line 288	C++
 	kernel32.dll!75eefcc9()	Unknown
 	ntdll.dll!770e82ae()	Unknown
 	ntdll.dll!770e827e()	Unknown
```

## Callstack for DEBUG_ASSERTCRASH crash

```
>	generalszh.exe!W3DVolumetricShadow::constructVolumeVB(Vector3 * lightPosObject, float shadowExtrudeDistance, int volumeIndex, int meshIndex) Line 2965	C++
 	generalszh.exe!W3DVolumetricShadow::updateMeshVolume(int meshIndex, int lightIndex, const Matrix3D * meshXform, const AABoxClass & meshBox, float floorZ) Line 2190	C++
 	generalszh.exe!W3DVolumetricShadow::updateVolumes(float zoffset) Line 1886	C++
 	generalszh.exe!W3DVolumetricShadow::Update() Line 1843	C++
 	generalszh.exe!W3DVolumetricShadowManager::renderShadows(bool forceStencilFill) Line 3538	C++
 	generalszh.exe!DoShadows(RenderInfoClass & rinfo, bool stencilPass) Line 91	C++
 	generalszh.exe!RTS3DScene::Flush(RenderInfoClass & rinfo) Line 857	C++
 	generalszh.exe!RTS3DScene::Render(RenderInfoClass & rinfo) Line 1074	C++
 	generalszh.exe!WW3D::Render(SceneClass * scene, CameraClass * cam, bool clear, bool clearz, const Vector3 & color) Line 979	C++
 	generalszh.exe!RTS3DScene::draw() Line 1724	C++
 	generalszh.exe!SubsystemInterface::DRAW() Line 105	C++
 	generalszh.exe!RTS3DScene::doRender(CameraClass * cam) Line 1708	C++
 	generalszh.exe!W3DView::draw() Line 1565	C++
 	generalszh.exe!SubsystemInterface::DRAW() Line 105	C++
 	generalszh.exe!Display::drawViews() Line 118	C++
 	generalszh.exe!W3DDisplay::draw() Line 1910	C++
 	generalszh.exe!SubsystemInterface::DRAW() Line 105	C++
 	generalszh.exe!GameClient::update() Line 767	C++
 	generalszh.exe!SubsystemInterface::UPDATE() Line 79	C++
 	generalszh.exe!GameEngine::update() Line 741	C++
 	generalszh.exe!Win32GameEngine::update() Line 93	C++
 	generalszh.exe!GameEngine::execute() Line 816	C++
 	generalszh.exe!GameMain(int argc, char * * argv) Line 47	C++
 	generalszh.exe!WinMain(HINSTANCE__ * hInstance, HINSTANCE__ * hPrevInstance, char * lpCmdLine, int nCmdShow) Line 1034	C++
 	[Inline Frame] generalszh.exe!invoke_main() Line 102	C++
 	generalszh.exe!__scrt_common_main_seh() Line 288	C++
 	kernel32.dll!75eefcc9()	Unknown
 	[Frames below may be incorrect and/or missing, no symbols loaded for kernel32.dll]	
 	ntdll.dll!770e82ae()	Unknown
 	ntdll.dll!770e827e()	Unknown
```
