### PR TITLE
[GEN][ZH] Prevent debris objects from being created after teams have been destroyed

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
@@ -1236,8 +1236,9 @@ protected:
 			return NULL; // don't spawn useful objects for dead players.  Avoid the zombie units from Yuri's.
 
 		// Object type debris might need this information to process visual UpgradeModules.
-		Team *debrisOwner = NULL;
-		if( sourceObj )
+		Team *debrisOwner = ThePlayerList->getNeutralPlayer() ? ThePlayerList->getNeutralPlayer()->getDefaultTeam() : NULL;
+
+		if( sourceObj && sourceObj->getControllingPlayer() )
 			debrisOwner = sourceObj->getControllingPlayer()->getDefaultTeam();
 		
 		Object* container = NULL;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
@@ -1243,8 +1243,7 @@ protected:
 
 		if (!debrisOwner)
 		{
-			// TheSuperHackers @bugfix Caball009 2025-05-19 Do not create debris objects without a valid team pointer
-			// the default team pointer may have been reset in Player::preTeamDestroy
+			// TheSuperHackers @fix Caball009 19/05/2025 Do not create debris objects without a valid team pointer
 			return NULL;
 		}
 		

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
@@ -1240,6 +1240,13 @@ protected:
 
 		if( sourceObj && sourceObj->getControllingPlayer() )
 			debrisOwner = sourceObj->getControllingPlayer()->getDefaultTeam();
+
+		if (!debrisOwner)
+		{
+			// TheSuperHackers @bugfix Caball009 2025-05-19 Do not create debris objects without a valid team pointer
+			// the default team pointer may have been reset in Player::preTeamDestroy
+			return NULL;
+		}
 		
 		Object* container = NULL;
 		Object *firstObject = NULL;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
@@ -1327,6 +1327,13 @@ protected:
 
 		if( sourceObj && sourceObj->getControllingPlayer() )
 			debrisOwner = sourceObj->getControllingPlayer()->getDefaultTeam();
+
+		if (!debrisOwner)
+		{
+			// TheSuperHackers @bugfix Caball009 2025-05-19 Do not create debris objects without a valid team pointer
+			// the default team pointer may have been reset in Player::preTeamDestroy
+			return NULL;
+		}
 		
 		Object* container = NULL;
 		Object *firstObject = NULL;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
@@ -1330,8 +1330,7 @@ protected:
 
 		if (!debrisOwner)
 		{
-			// TheSuperHackers @bugfix Caball009 2025-05-19 Do not create debris objects without a valid team pointer
-			// the default team pointer may have been reset in Player::preTeamDestroy
+			// TheSuperHackers @fix Caball009 19/05/2025 Do not create debris objects without a valid team pointer
 			return NULL;
 		}
 		


### PR DESCRIPTION
**Squash and merge**

EDIT: Build was possibly created using Clang-cl.
EDIT2: Build was confirmed to be created using Clang-cl (though it doesn't appear relevant to the issue at hand).

Issue likely introduced with pr https://github.com/TheSuperHackers/GeneralsGameCode/pull/809

https://github.com/TheSuperHackers/GeneralsGameCode/blob/ce9d3d765566007a4fd6e9db1ead8bf930fa5bdc/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp#L1656-L1658

Debris objects require an owning team and use the default team pointer for that. Destroying the teams reset the default team pointer. It's possible that debris objects are created after the teams are destroyed. If that happens, the new debris object uses a nullptr as its owner and attempts to dereference it and crash the game here:
https://github.com/TheSuperHackers/GeneralsGameCode/blob/ce9d3d765566007a4fd6e9db1ead8bf930fa5bdc/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp#L476-L478

It's possible that the issue extends beyond just debris objects and includes other kinds of objects, but I haven't looked at that.