### PR TITLE
[GEN] Allows user to choose secondary GPU

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/GlobalData.h
+++ b/Generals/Code/GameEngine/Include/Common/GlobalData.h
@@ -99,6 +99,7 @@ public:
 	Bool m_windowed;
 	Int m_xResolution;
 	Int m_yResolution;
+	Int m_renderDeviceIndex;
 	Int m_maxShellScreens;  ///< this many shells layouts can be loaded at once
 	Bool m_useCloudMap;
 	Int  m_use3WayTerrainBlends;	///< 0 is none, 1 is normal, 2 is debug.

--- a/Generals/Code/GameEngine/Include/Common/UserPreferences.h
+++ b/Generals/Code/GameEngine/Include/Common/UserPreferences.h
@@ -105,6 +105,7 @@ public:
  	Real getGammaValue(void);
 	Int	 getTextureReduction(void);
 	void getResolution(Int *xres, Int *yres);
+	void getRenderDeviceIndex(Int* index);
 	Bool get3DShadowsEnabled(void);
 	Bool get2DShadowsEnabled(void);
 	Bool getCloudShadowsEnabled(void);

--- a/Generals/Code/GameEngine/Include/GameClient/Display.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Display.h
@@ -80,8 +80,10 @@ public:
 	// Display attribute methods
 	virtual void setWidth( UnsignedInt width );										///< Sets the width of the display		
 	virtual void setHeight( UnsignedInt height );									///< Sets the height of the display
+	virtual void setRenderDevice(UnsignedInt device);									///< Sets the render device to use (0 = default, 1 = 2nd device, etc.)
 	virtual UnsignedInt getWidth( void ) { return m_width; }			///< Returns the width of the display
 	virtual UnsignedInt getHeight( void ) { return m_height; }		///< Returns the height of the display
+	virtual UnsignedInt getRenderDevice( void) { return m_renderDeviceIndex; };
 	virtual void setBitDepth( UnsignedInt bitDepth ) { m_bitDepth = bitDepth; }
 	virtual UnsignedInt getBitDepth( void ) { return m_bitDepth; }
 	virtual void setWindowed( Bool windowed ) { m_windowed = windowed; }  ///< set windowd/fullscreen flag
@@ -187,6 +189,7 @@ protected:
 	virtual void deleteViews( void );   ///< delete all views
 	UnsignedInt m_width, m_height;			///< Dimensions of the display
 	UnsignedInt m_bitDepth;							///< bit depth of the display
+	UnsignedInt m_renderDeviceIndex;			///< index of the render device to use
 	Bool m_windowed;										///< TRUE when windowed, FALSE when fullscreen
 	View *m_viewList;										///< All of the views into the world
 

--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -76,6 +76,7 @@ GlobalData* GlobalData::m_theOriginal = NULL;
 	{ "DumpAssetUsage",						INI::parseBool,				NULL,			offsetof( GlobalData, m_dumpAssetUsage ) },
 	{ "FramesPerSecondLimit",			INI::parseInt,				NULL,			offsetof( GlobalData, m_framesPerSecondLimit ) },
 	{ "ChipsetType",							INI::parseInt,				NULL,			offsetof( GlobalData, m_chipSetType ) },
+	{ "RenderDeviceIndex",							INI::parseInt,				NULL,			offsetof(GlobalData, m_renderDeviceIndex) },
 	{ "MaxShellScreens",					INI::parseInt,				NULL,			offsetof( GlobalData, m_maxShellScreens ) },
 	{ "UseCloudMap",							INI::parseBool,				NULL,			offsetof( GlobalData, m_useCloudMap ) },
 	{ "UseLightMap",							INI::parseBool,				NULL,			offsetof( GlobalData, m_useLightMap ) },
@@ -1231,5 +1232,9 @@ void GlobalData::parseGameDataDefinition( INI* ini )
 
 	TheWritableGlobalData->m_xResolution = xres;
 	TheWritableGlobalData->m_yResolution = yres;
+
+	Int renderDeviceIndex = 0;
+	optionPref.getRenderDeviceIndex(&renderDeviceIndex);
+	TheWritableGlobalData->m_renderDeviceIndex = renderDeviceIndex;
 }
 

--- a/Generals/Code/GameEngine/Source/GameClient/Display.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Display.cpp
@@ -194,6 +194,18 @@ void Display::setHeight( UnsignedInt height )
 
 }  // end setHeight
 
+
+// Display::setRenderDevice =========================================================
+/** Set the render device for the display */
+//=============================================================================
+void Display::setRenderDevice(UnsignedInt dev)
+{
+	m_renderDeviceIndex = dev;
+}
+
+
+
+
 //============================================================================
 // Display::playLogoMovie
 // minMovieLength is in milliseconds

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -702,7 +702,21 @@ void OptionPreferences::getResolution(Int *xres, Int *yres)
 	*xres=selectedXRes;
 	*yres=selectedYRes;
 }
+void OptionPreferences::getRenderDeviceIndex(Int* index)
+{
+	*index = TheGlobalData->m_renderDeviceIndex;
 
+
+	OptionPreferences::const_iterator it = find("RenderDeviceIndex");
+	if (it == end())
+		return;
+
+	Int selectedDev;
+	if (sscanf(it->second.str(), "%d", &selectedDev) != 1)
+		return;
+
+	*index = selectedDev;
+}
 Real OptionPreferences::getMusicVolume(void)
 {
 	OptionPreferences::const_iterator it = find("MusicVolume");

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -564,6 +564,9 @@ void W3DDisplay::setHeight( UnsignedInt height )
 
 }  // end set height
 
+
+
+
 // W3DDisplay::initAssets =====================================================
 /** */
 //=============================================================================
@@ -690,9 +693,10 @@ void W3DDisplay::init( void )
 	/// @todo we should set this according to options read from a file
 	setWidth( TheGlobalData->m_xResolution );
 	setHeight( TheGlobalData->m_yResolution );
+	setRenderDevice(TheGlobalData->m_renderDeviceIndex);
 	setBitDepth( W3D_DISPLAY_DEFAULT_BIT_DEPTH );
 
-	if( WW3D::Set_Render_Device( 0, 
+	if( WW3D::Set_Render_Device(							 getRenderDevice(),
 															 getWidth(), 
 															 getHeight(), 
 															 getBitDepth(), 
@@ -702,7 +706,7 @@ void W3DDisplay::init( void )
 		// Getting the device at the default bit depth (32) didn't work, so try
 		// getting a 16 bit display.  (Voodoo 1-3 only supported 16 bit.) jba.
 		setBitDepth( 16 );
-		if( WW3D::Set_Render_Device( 0, 
+		if( WW3D::Set_Render_Device(							 getRenderDevice(),
 																 getWidth(), 
 																 getHeight(), 
 																 getBitDepth(), 

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
@@ -883,7 +883,13 @@ bool DX8Wrapper::Set_Render_Device(int dev, int width, int height, int bits, int
 	WWASSERT(IsInitted);
 	WWASSERT(dev >= -1);
 	WWASSERT(dev < _RenderDeviceNameTable.Count());
+	DEBUG_LOG(("Render device number '%d' selected\n", dev));
 
+	if (dev >= _RenderDeviceNameTable.Count())
+	{
+		WWDEBUG_SAY(("Invalid render device number '%d' selected. \nDefaulting to primary render device\n", dev));
+		dev = 0;
+	}
 	/*
 	** If user has never selected a render device, start out with device 0
 	*/


### PR DESCRIPTION
Added RenderDeviceIndex token parsing for options.ini .

Users can add the text "RenderDeviceIndex = 1" to select secondary GPU.

If the index specified is higher than the highest device index,
then device 0 is chosen by default.