### PR TITLE
[GEN][ZH] Fix crash in StateMachine when a chained StateMachine update deletes the executor StateMachine

### DIFF
--- a/Core/Libraries/Source/WWVegas/WWLib/ref_ptr.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/ref_ptr.h
@@ -216,6 +216,8 @@
 					};
 */
 
+#define ALLOW_AUTOMATIC_REF_COUNT_PTR_CONSTRUCTION
+
 class DummyPtrType;
 
 template <class T>
@@ -416,7 +418,7 @@ bool operator <(const RefCountPtr<LHS> & lhs, const RefCountPtr<RHS> & rhs)
 template <class RHS>
 bool operator ==(DummyPtrType * dummy, const RefCountPtr<RHS> & rhs)
 {
-	FAIL_IF(0 != dummy) {
+	if (0 != dummy) {
 		return false;
 	}
 
@@ -428,7 +430,7 @@ bool operator ==(DummyPtrType * dummy, const RefCountPtr<RHS> & rhs)
 template <class RHS>
 bool operator !=(DummyPtrType * dummy, const RefCountPtr<RHS> & rhs)
 {
-	FAIL_IF(0 != dummy) {
+	if (0 != dummy) {
 		return true;
 	}
 

--- a/Core/Libraries/Source/WWVegas/WWLib/ref_ptr.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/ref_ptr.h
@@ -419,6 +419,7 @@ template <class RHS>
 bool operator ==(DummyPtrType * dummy, const RefCountPtr<RHS> & rhs)
 {
 	if (0 != dummy) {
+		WWASSERT(0);
 		return false;
 	}
 
@@ -431,6 +432,7 @@ template <class RHS>
 bool operator !=(DummyPtrType * dummy, const RefCountPtr<RHS> & rhs)
 {
 	if (0 != dummy) {
+		WWASSERT(0);
 		return true;
 	}
 

--- a/Generals/Code/GameEngine/Include/Common/StateMachine.h
+++ b/Generals/Code/GameEngine/Include/Common/StateMachine.h
@@ -37,6 +37,8 @@
 #include "Common/Snapshot.h"
 #include "Common/Xfer.h"
 
+#include "refcount.h"
+
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
@@ -236,7 +238,7 @@ inline State::~State() { }
 /**
  * A finite state machine.
  */
-class StateMachine : public MemoryPoolObject, public Snapshot
+class StateMachine : public MemoryPoolObject, public Snapshot, public RefCountClass
 {
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( StateMachine, "StateMachinePool" );
 
@@ -339,6 +341,12 @@ protected:
 	virtual void crc( Xfer *xfer );
 	virtual void xfer( Xfer *xfer );
 	virtual void loadPostProcess();	
+
+	// RefCountClass interface
+	virtual void Delete_This()
+	{
+		MemoryPoolObject::deleteInstanceInternal(this);
+	}
 
 protected:
 
@@ -471,6 +479,15 @@ protected:
 	virtual void loadPostProcess(){};
 };
 EMPTY_DTOR(SleepState)
+
+
+//-----------------------------------------------------------------------------------------------------------
+// TheSuperHackers @info Misappropriates deleteInstance to call Release_Ref to keep the StateMachine fix small.
+// @todo Replace calls to deleteInstance with RefCountPtr<StateMachine> when so appropriate.
+inline void deleteInstance(StateMachine* state)
+{
+	state->Release_Ref();
+}
 
 
 #endif // _STATE_MACHINE_H_

--- a/Generals/Code/GameEngine/Include/Common/StateMachine.h
+++ b/Generals/Code/GameEngine/Include/Common/StateMachine.h
@@ -484,9 +484,9 @@ EMPTY_DTOR(SleepState)
 //-----------------------------------------------------------------------------------------------------------
 // TheSuperHackers @info Misappropriates deleteInstance to call Release_Ref to keep the StateMachine fix small.
 // @todo Replace calls to deleteInstance with RefCountPtr<StateMachine> when so appropriate.
-inline void deleteInstance(StateMachine* state)
+inline void deleteInstance(StateMachine* machine)
 {
-	state->Release_Ref();
+	machine->Release_Ref();
 }
 
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/StateMachine.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/StateMachine.h
@@ -37,6 +37,8 @@
 #include "Common/Snapshot.h"
 #include "Common/Xfer.h"
 
+#include "refcount.h"
+
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
@@ -237,7 +239,7 @@ inline State::~State() { }
 /**
  * A finite state machine.
  */
-class StateMachine : public MemoryPoolObject, public Snapshot
+class StateMachine : public MemoryPoolObject, public Snapshot, public RefCountClass
 {
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( StateMachine, "StateMachinePool" );
 
@@ -341,6 +343,12 @@ protected:
 	virtual void crc( Xfer *xfer );
 	virtual void xfer( Xfer *xfer );
 	virtual void loadPostProcess();	
+
+	// RefCountClass interface
+	virtual void Delete_This()
+	{
+		MemoryPoolObject::deleteInstanceInternal(this);
+	}
 
 protected:
 
@@ -473,6 +481,15 @@ protected:
 	virtual void loadPostProcess(){};
 };
 EMPTY_DTOR(SleepState)
+
+
+//-----------------------------------------------------------------------------------------------------------
+// TheSuperHackers @info Misappropriates deleteInstance to call Release_Ref to keep the StateMachine fix small.
+// @todo Replace calls to deleteInstance with RefCountPtr<StateMachine> when so appropriate.
+inline void deleteInstance(StateMachine* state)
+{
+	state->Release_Ref();
+}
 
 
 #endif // _STATE_MACHINE_H_

--- a/GeneralsMD/Code/GameEngine/Include/Common/StateMachine.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/StateMachine.h
@@ -486,9 +486,9 @@ EMPTY_DTOR(SleepState)
 //-----------------------------------------------------------------------------------------------------------
 // TheSuperHackers @info Misappropriates deleteInstance to call Release_Ref to keep the StateMachine fix small.
 // @todo Replace calls to deleteInstance with RefCountPtr<StateMachine> when so appropriate.
-inline void deleteInstance(StateMachine* state)
+inline void deleteInstance(StateMachine* machine)
 {
-	state->Release_Ref();
+	machine->Release_Ref();
 }
 
 


### PR DESCRIPTION
* Merge after #889 
* Fixes #212

This change fixes a crash in `StateMachine` that happens when a chained `StateMachine` update destroys the prior executor `StateMachine`. This issue happened with #212, where the Ranger's `StateMachine` in the Bus would kill the Power Plant, and then the Power Plant weapon would kill the Bus, which would then delete the `StateMachine` of the Ranger.