### PR TITLE
[GEN][ZH] Fix crash when taking a screenshot while the Game Window clips over the screen edge

### DIFF
--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -2850,32 +2850,27 @@ void W3DDisplay::takeScreenShot(void)
 			done = true;
 	}
 
-	// Lock front buffer and copy
+	// TheSuperHackers @bugfix xezon 21/05/2025 Get the back buffer and create a copy of the surface.
+	// Originally this code took the front buffer and tried to lock it. This does not work when the
+	// render view clips outside the desktop boundaries. It crashed the game.
+	SurfaceClass* surface = DX8Wrapper::_Get_DX8_Back_Buffer();
 
-	IDirect3DSurface8 *fb;
-	fb=DX8Wrapper::_Get_DX8_Front_Buffer();
-	D3DSURFACE_DESC desc;
-	fb->GetDesc(&desc);
+	SurfaceClass::SurfaceDescription surfaceDesc;
+	surface->Get_Description(surfaceDesc);
 
-	RECT bounds;
-	POINT point;
+	SurfaceClass* surfaceCopy = NEW_REF(SurfaceClass, (DX8Wrapper::_Create_DX8_Surface(surfaceDesc.Width, surfaceDesc.Height, surfaceDesc.Format)));
+	DX8Wrapper::_Copy_DX8_Rects(surface->Peek_D3D_Surface(), NULL, 0, surfaceCopy->Peek_D3D_Surface(), NULL);
 
-	GetClientRect(ApplicationHWnd,&bounds);
-	point.x=bounds.left; point.y=bounds.top;
-	ClientToScreen(ApplicationHWnd, &point);
-	bounds.left=point.x; bounds.top=point.y; 
-	point.x=bounds.right; point.y=bounds.bottom;
-	ClientToScreen(ApplicationHWnd, &point);
-	bounds.right=point.x; bounds.bottom=point.y;
- 
+	surface->Release_Ref();
+	surface = NULL;
+
 	D3DLOCKED_RECT lrect;
-
-	DX8_ErrorCode(fb->LockRect(&lrect,&bounds,D3DLOCK_READONLY));
+	lrect.pBits = surfaceCopy->Lock(&lrect.Pitch);
 
 	unsigned int x,y,index,index2,width,height;
 
-	width=bounds.right-bounds.left;
-	height=bounds.bottom-bounds.top;
+	width = surfaceDesc.Width;
+	height = surfaceDesc.Height;
 
 	char *image=NEW char[3*width*height];
 #ifdef CAPTURE_TO_TARGA
@@ -2895,7 +2890,9 @@ void W3DDisplay::takeScreenShot(void)
 		}
 	}
 
-	fb->Release();
+	surfaceCopy->Unlock();
+	surfaceCopy->Release_Ref();
+	surfaceCopy = NULL;
 
 	Targa targ;
 	memset(&targ.Header,0,sizeof(targ.Header));
@@ -2924,7 +2921,9 @@ void W3DDisplay::takeScreenShot(void)
 		}
 	}
 
-	fb->Release();
+	surfaceCopy->Unlock();
+	surfaceCopy->Release_Ref();
+	surfaceCopy = NULL;
 
 	//Flip the image
 	char *ptr,*ptr1;
@@ -2958,7 +2957,7 @@ void W3DDisplay::takeScreenShot(void)
 	TheInGameUI->message(TheGameText->fetch("GUI:ScreenCapture"), ufileName.str());
 }
 
-/** Start/Stop campturing an AVI movie*/
+/** Start/Stop capturing an AVI movie*/
 void W3DDisplay::toggleMovieCapture(void)
 {
 	WW3D::Toggle_Movie_Capture("Movie",30);

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -2864,8 +2864,18 @@ void W3DDisplay::takeScreenShot(void)
 	surface->Release_Ref();
 	surface = NULL;
 
-	D3DLOCKED_RECT lrect;
+	struct Rect
+	{
+		int Pitch;
+		void* pBits;
+	} lrect;
+
 	lrect.pBits = surfaceCopy->Lock(&lrect.Pitch);
+	if (lrect.pBits == NULL)
+	{
+		surfaceCopy->Release_Ref();
+		return;
+	}
 
 	unsigned int x,y,index,index2,width,height;
 

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
@@ -1361,8 +1361,18 @@ void WW3D::Make_Screen_Shot( const char * filename_base , const float gamma, con
 	surface->Release_Ref();
 	surface = NULL;
 
-	D3DLOCKED_RECT lrect;
+	struct Rect
+	{
+		int Pitch;
+		void* pBits;
+	} lrect;
+
 	lrect.pBits = surfaceCopy->Lock(&lrect.Pitch);
+	if (lrect.pBits == NULL)
+	{
+		surfaceCopy->Release_Ref();
+		return;
+	}
 
 	unsigned int x,y,index,index2,width,height;
 
@@ -1701,8 +1711,18 @@ void WW3D::Update_Movie_Capture( void )
 	surface->Release_Ref();
 	surface = NULL;
 
-	D3DLOCKED_RECT lrect;
+	struct Rect
+	{
+		int Pitch;
+		void* pBits;
+	} lrect;
+
 	lrect.pBits = surfaceCopy->Lock(&lrect.Pitch);
+	if (lrect.pBits == NULL)
+	{
+		surfaceCopy->Release_Ref();
+		return;
+	}
 
 	unsigned int x,y,index,index2,width,height;
 

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
@@ -1347,24 +1347,27 @@ void WW3D::Make_Screen_Shot( const char * filename_base , const float gamma, con
 		gamma_lut[i] = (unsigned char) (256.0f * powf(i / 256.0f, recip));
 	}
 
-	// Lock front buffer and copy
+	// TheSuperHackers @bugfix xezon 21/05/2025 Get the back buffer and create a copy of the surface.
+	// Originally this code took the front buffer and tried to lock it. This does not work when the
+	// render view clips outside the desktop boundaries. It crashed the game.
+	SurfaceClass* surface = DX8Wrapper::_Get_DX8_Back_Buffer();
 
-	IDirect3DSurface8 *fb;
-	fb=DX8Wrapper::_Get_DX8_Front_Buffer();
-	D3DSURFACE_DESC desc;
-	fb->GetDesc(&desc);
+	SurfaceClass::SurfaceDescription surfaceDesc;
+	surface->Get_Description(surfaceDesc);
 
-	RECT bounds;
-	GetWindowRect(_Hwnd,&bounds);
+	SurfaceClass* surfaceCopy = NEW_REF(SurfaceClass, (DX8Wrapper::_Create_DX8_Surface(surfaceDesc.Width, surfaceDesc.Height, surfaceDesc.Format)));
+	DX8Wrapper::_Copy_DX8_Rects(surface->Peek_D3D_Surface(), NULL, 0, surfaceCopy->Peek_D3D_Surface(), NULL);
+
+	surface->Release_Ref();
+	surface = NULL;
 
 	D3DLOCKED_RECT lrect;
-
-	DX8_ErrorCode(fb->LockRect(&lrect,&bounds,D3DLOCK_READONLY));
+	lrect.pBits = surfaceCopy->Lock(&lrect.Pitch);
 
 	unsigned int x,y,index,index2,width,height;
 
-	width=bounds.right-bounds.left;
-	height=bounds.bottom-bounds.top;
+	width = surfaceDesc.Width;
+	height = surfaceDesc.Height;
 
 	unsigned char *image=W3DNEWARRAY unsigned char[3*width*height];
 
@@ -1383,7 +1386,9 @@ void WW3D::Make_Screen_Shot( const char * filename_base , const float gamma, con
 		}
 	}
 
-	fb->Release();
+	surfaceCopy->Unlock();
+	surfaceCopy->Release_Ref();
+	surfaceCopy = NULL;
 
 	switch (format) {
 		case TGA:
@@ -1682,24 +1687,27 @@ void WW3D::Update_Movie_Capture( void )
 	WWPROFILE("WW3D::Update_Movie_Capture");
 	WWDEBUG_SAY(( "Updating\n"));
 
-		// Lock front buffer and copy
+	// TheSuperHackers @bugfix xezon 21/05/2025 Get the back buffer and create a copy of the surface.
+	// Originally this code took the front buffer and tried to lock it. This does not work when the
+	// render view clips outside the desktop boundaries. It crashed the game.
+	SurfaceClass* surface = DX8Wrapper::_Get_DX8_Back_Buffer();
 
-	IDirect3DSurface8 *fb;
-	fb=DX8Wrapper::_Get_DX8_Front_Buffer();
-	D3DSURFACE_DESC desc;
-	fb->GetDesc(&desc);
+	SurfaceClass::SurfaceDescription surfaceDesc;
+	surface->Get_Description(surfaceDesc);
 
-	RECT bounds;
-	GetWindowRect(_Hwnd,&bounds);
+	SurfaceClass* surfaceCopy = NEW_REF(SurfaceClass, (DX8Wrapper::_Create_DX8_Surface(surfaceDesc.Width, surfaceDesc.Height, surfaceDesc.Format)));
+	DX8Wrapper::_Copy_DX8_Rects(surface->Peek_D3D_Surface(), NULL, 0, surfaceCopy->Peek_D3D_Surface(), NULL);
+
+	surface->Release_Ref();
+	surface = NULL;
 
 	D3DLOCKED_RECT lrect;
-
-	DX8_ErrorCode(fb->LockRect(&lrect,&bounds,D3DLOCK_READONLY));
+	lrect.pBits = surfaceCopy->Lock(&lrect.Pitch);
 
 	unsigned int x,y,index,index2,width,height;
 
-	width=bounds.right-bounds.left;
-	height=bounds.bottom-bounds.top;
+	width = surfaceDesc.Width;
+	height = surfaceDesc.Height;
 
 	char *image=(char *)Movie->GetBuffer();
 
@@ -1718,7 +1726,9 @@ void WW3D::Update_Movie_Capture( void )
 		}
 	}
 
-	fb->Release();
+	surfaceCopy->Unlock();
+	surfaceCopy->Release_Ref();
+	surfaceCopy = NULL;
 
 	Movie->Grab(image);
 #endif

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -3004,8 +3004,18 @@ void W3DDisplay::takeScreenShot(void)
 	surface->Release_Ref();
 	surface = NULL;
 
-	D3DLOCKED_RECT lrect;
+	struct Rect
+	{
+		int Pitch;
+		void* pBits;
+	} lrect;
+
 	lrect.pBits = surfaceCopy->Lock(&lrect.Pitch);
+	if (lrect.pBits == NULL)
+	{
+		surfaceCopy->Release_Ref();
+		return;
+	}
 
 	unsigned int x,y,index,index2,width,height;
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -2990,32 +2990,27 @@ void W3DDisplay::takeScreenShot(void)
 			done = true;
 	}
 
-	// Lock front buffer and copy
+	// TheSuperHackers @bugfix xezon 21/05/2025 Get the back buffer and create a copy of the surface.
+	// Originally this code took the front buffer and tried to lock it. This does not work when the
+	// render view clips outside the desktop boundaries. It crashed the game.
+	SurfaceClass* surface = DX8Wrapper::_Get_DX8_Back_Buffer();
 
-	IDirect3DSurface8 *fb;
-	fb=DX8Wrapper::_Get_DX8_Front_Buffer();
-	D3DSURFACE_DESC desc;
-	fb->GetDesc(&desc);
+	SurfaceClass::SurfaceDescription surfaceDesc;
+	surface->Get_Description(surfaceDesc);
 
-	RECT bounds;
-	POINT point;
+	SurfaceClass* surfaceCopy = NEW_REF(SurfaceClass, (DX8Wrapper::_Create_DX8_Surface(surfaceDesc.Width, surfaceDesc.Height, surfaceDesc.Format)));
+	DX8Wrapper::_Copy_DX8_Rects(surface->Peek_D3D_Surface(), NULL, 0, surfaceCopy->Peek_D3D_Surface(), NULL);
 
-	GetClientRect(ApplicationHWnd,&bounds);
-	point.x=bounds.left; point.y=bounds.top;
-	ClientToScreen(ApplicationHWnd, &point);
-	bounds.left=point.x; bounds.top=point.y; 
-	point.x=bounds.right; point.y=bounds.bottom;
-	ClientToScreen(ApplicationHWnd, &point);
-	bounds.right=point.x; bounds.bottom=point.y;
- 
+	surface->Release_Ref();
+	surface = NULL;
+
 	D3DLOCKED_RECT lrect;
-
-	DX8_ErrorCode(fb->LockRect(&lrect,&bounds,D3DLOCK_READONLY));
+	lrect.pBits = surfaceCopy->Lock(&lrect.Pitch);
 
 	unsigned int x,y,index,index2,width,height;
 
-	width=bounds.right-bounds.left;
-	height=bounds.bottom-bounds.top;
+	width = surfaceDesc.Width;
+	height = surfaceDesc.Height;
 
 	char *image=NEW char[3*width*height];
 #ifdef CAPTURE_TO_TARGA
@@ -3035,7 +3030,9 @@ void W3DDisplay::takeScreenShot(void)
 		}
 	}
 
-	fb->Release();
+	surfaceCopy->Unlock();
+	surfaceCopy->Release_Ref();
+	surfaceCopy = NULL;
 
 	Targa targ;
 	memset(&targ.Header,0,sizeof(targ.Header));
@@ -3064,7 +3061,9 @@ void W3DDisplay::takeScreenShot(void)
 		}
 	}
 
-	fb->Release();
+	surfaceCopy->Unlock();
+	surfaceCopy->Release_Ref();
+	surfaceCopy = NULL;
 
 	//Flip the image
 	char *ptr,*ptr1;
@@ -3098,7 +3097,7 @@ void W3DDisplay::takeScreenShot(void)
 	TheInGameUI->message(TheGameText->fetch("GUI:ScreenCapture"), ufileName.str());
 }
 
-/** Start/Stop campturing an AVI movie*/
+/** Start/Stop capturing an AVI movie*/
 void W3DDisplay::toggleMovieCapture(void)
 {
 	WW3D::Toggle_Movie_Capture("Movie",30);

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
@@ -1342,24 +1342,27 @@ void WW3D::Make_Screen_Shot( const char * filename_base , const float gamma, con
 		gamma_lut[i] = (unsigned char) (256.0f * powf(i / 256.0f, recip));
 	}
 
-	// Lock front buffer and copy
+	// TheSuperHackers @bugfix xezon 21/05/2025 Get the back buffer and create a copy of the surface.
+	// Originally this code took the front buffer and tried to lock it. This does not work when the
+	// render view clips outside the desktop boundaries. It crashed the game.
+	SurfaceClass* surface = DX8Wrapper::_Get_DX8_Back_Buffer();
 
-	IDirect3DSurface8 *fb;
-	fb=DX8Wrapper::_Get_DX8_Front_Buffer();
-	D3DSURFACE_DESC desc;
-	fb->GetDesc(&desc);
+	SurfaceClass::SurfaceDescription surfaceDesc;
+	surface->Get_Description(surfaceDesc);
 
-	RECT bounds;
-	GetWindowRect(_Hwnd,&bounds);
+	SurfaceClass* surfaceCopy = NEW_REF(SurfaceClass, (DX8Wrapper::_Create_DX8_Surface(surfaceDesc.Width, surfaceDesc.Height, surfaceDesc.Format)));
+	DX8Wrapper::_Copy_DX8_Rects(surface->Peek_D3D_Surface(), NULL, 0, surfaceCopy->Peek_D3D_Surface(), NULL);
+
+	surface->Release_Ref();
+	surface = NULL;
 
 	D3DLOCKED_RECT lrect;
-
-	DX8_ErrorCode(fb->LockRect(&lrect,&bounds,D3DLOCK_READONLY));
+	lrect.pBits = surfaceCopy->Lock(&lrect.Pitch);
 
 	unsigned int x,y,index,index2,width,height;
 
-	width=bounds.right-bounds.left;
-	height=bounds.bottom-bounds.top;
+	width = surfaceDesc.Width;
+	height = surfaceDesc.Height;
 
 	unsigned char *image=W3DNEWARRAY unsigned char[3*width*height];
 
@@ -1378,7 +1381,9 @@ void WW3D::Make_Screen_Shot( const char * filename_base , const float gamma, con
 		}
 	}
 
-	fb->Release();
+	surfaceCopy->Unlock();
+	surfaceCopy->Release_Ref();
+	surfaceCopy = NULL;
 
 	switch (format) {
 		case TGA:
@@ -1677,24 +1682,27 @@ void WW3D::Update_Movie_Capture( void )
 	WWPROFILE("WW3D::Update_Movie_Capture");
 	WWDEBUG_SAY(( "Updating\n"));
 
-		// Lock front buffer and copy
+	// TheSuperHackers @bugfix xezon 21/05/2025 Get the back buffer and create a copy of the surface.
+	// Originally this code took the front buffer and tried to lock it. This does not work when the
+	// render view clips outside the desktop boundaries. It crashed the game.
+	SurfaceClass* surface = DX8Wrapper::_Get_DX8_Back_Buffer();
 
-	IDirect3DSurface8 *fb;
-	fb=DX8Wrapper::_Get_DX8_Front_Buffer();
-	D3DSURFACE_DESC desc;
-	fb->GetDesc(&desc);
+	SurfaceClass::SurfaceDescription surfaceDesc;
+	surface->Get_Description(surfaceDesc);
 
-	RECT bounds;
-	GetWindowRect(_Hwnd,&bounds);
+	SurfaceClass* surfaceCopy = NEW_REF(SurfaceClass, (DX8Wrapper::_Create_DX8_Surface(surfaceDesc.Width, surfaceDesc.Height, surfaceDesc.Format)));
+	DX8Wrapper::_Copy_DX8_Rects(surface->Peek_D3D_Surface(), NULL, 0, surfaceCopy->Peek_D3D_Surface(), NULL);
+
+	surface->Release_Ref();
+	surface = NULL;
 
 	D3DLOCKED_RECT lrect;
-
-	DX8_ErrorCode(fb->LockRect(&lrect,&bounds,D3DLOCK_READONLY));
+	lrect.pBits = surfaceCopy->Lock(&lrect.Pitch);
 
 	unsigned int x,y,index,index2,width,height;
 
-	width=bounds.right-bounds.left;
-	height=bounds.bottom-bounds.top;
+	width = surfaceDesc.Width;
+	height = surfaceDesc.Height;
 
 	char *image=(char *)Movie->GetBuffer();
 
@@ -1713,7 +1721,9 @@ void WW3D::Update_Movie_Capture( void )
 		}
 	}
 
-	fb->Release();
+	surfaceCopy->Unlock();
+	surfaceCopy->Release_Ref();
+	surfaceCopy = NULL;
 
 	Movie->Grab(image);
 #endif

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
@@ -1356,8 +1356,18 @@ void WW3D::Make_Screen_Shot( const char * filename_base , const float gamma, con
 	surface->Release_Ref();
 	surface = NULL;
 
-	D3DLOCKED_RECT lrect;
+	struct Rect
+	{
+		int Pitch;
+		void* pBits;
+	} lrect;
+
 	lrect.pBits = surfaceCopy->Lock(&lrect.Pitch);
+	if (lrect.pBits == NULL)
+	{
+		surfaceCopy->Release_Ref();
+		return;
+	}
 
 	unsigned int x,y,index,index2,width,height;
 
@@ -1696,8 +1706,18 @@ void WW3D::Update_Movie_Capture( void )
 	surface->Release_Ref();
 	surface = NULL;
 
-	D3DLOCKED_RECT lrect;
+	struct Rect
+	{
+		int Pitch;
+		void* pBits;
+	} lrect;
+
 	lrect.pBits = surfaceCopy->Lock(&lrect.Pitch);
+	if (lrect.pBits == NULL)
+	{
+		surfaceCopy->Release_Ref();
+		return;
+	}
 
 	unsigned int x,y,index,index2,width,height;
 


### PR DESCRIPTION
This change fixes the crash when taking a screenshot with F12 while the Game Window clips over the outer boundaries of the screen.

## Crash callstack

```
>	generalszh.exe!W3DDisplay::takeScreenShot() Line 3061	C++
 	generalszh.exe!CommandTranslator::translateGameMessage(const GameMessage * msg) Line 5163	C++
 	generalszh.exe!MessageStream::propagateMessages() Line 1096	C++
 	generalszh.exe!GameEngine::update() Line 743	C++
 	generalszh.exe!Win32GameEngine::update() Line 93	C++
 	generalszh.exe!GameEngine::execute() Line 816	C++
 	generalszh.exe!GameMain(int argc, char * * argv) Line 47	C++
 	generalszh.exe!WinMain(HINSTANCE__ * hInstance, HINSTANCE__ * hPrevInstance, char * lpCmdLine, int nCmdShow) Line 1038	C++
 	[Inline Frame] generalszh.exe!invoke_main() Line 102	C++
 	generalszh.exe!__scrt_common_main_seh() Line 288	C++
 	kernel32.dll!76abfcc9()	Unknown
 	[Frames below may be incorrect and/or missing, no symbols loaded for kernel32.dll]	
 	ntdll.dll!77ab82ae()	Unknown
 	ntdll.dll!77ab827e()	Unknown
```
```
Exception thrown at 0x01144B16 in generalszh.exe: 0xC0000005: Access violation reading location 0x00000000.
```

## The Fix

To fix the problem, the surface taken from the back (or front) buffer needs to be copied before locking. Locking the back buffer directly does not work reliably.

GenTool implements that part the same way.

It is also using the back buffer instead of front buffer.

The function used for taking a screenshot is `W3DDisplay::takeScreenShot`. Functions `WW3D::Make_Screen_Shot` and `WW3D::Update_Movie_Capture` are unused, but I applied the same fix there as well.

## Chat GPT:

In **DirectX 8**, you should use the **back buffer**—**not the front buffer**—to create a screenshot of the scene **after rendering but before presenting** the frame.

### Why the Back Buffer Is Better:

* **Accurate Image**: The back buffer contains the final rendered scene **before** it's presented to the screen. It's the exact image your application just rendered.
* **Front Buffer Issues**: The front buffer may have already changed or may contain **tearing artifacts**, especially if vertical sync is disabled. It might not reflect a complete frame.
* **Access Support**: Accessing the front buffer is often **slower**, less supported, or even **unsupported** depending on the hardware and drivers. Back buffers are more predictable and under your control.

---

### How to Capture from the Back Buffer

To take a screenshot from the back buffer in DirectX 8:

1. **Get the back buffer surface** using `IDirect3DDevice8::GetBackBuffer`.
2. **Create a system memory surface** with matching format and size using `IDirect3DDevice8::CreateImageSurface`.
3. **Use `IDirect3DDevice8::CopyRects` or `IDirect3DDevice8::GetRenderTargetData`** (if supported) to copy the contents of the back buffer to the system memory surface.
4. Save or manipulate the image data from the system memory surface.

---

### Summary

> ✅ **Use the back buffer** for screenshots in DirectX 8.
> ❌ Avoid using the front buffer—it's unreliable for this purpose.

## Next Steps

It is recommended to take the screenshot before calling IDirect3DDevice8::Present. Currently it is taken after Present. I was unable to observe issues with the new code, but we can look into that in a follow up change.
