### PR TITLE
[ZH] Add missing call to IDirect3DSurface8::UnlockRect in W3DSmudge's copyRect

### DIFF
--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DSmudge.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DSmudge.cpp
@@ -192,6 +192,8 @@ Int copyRect(unsigned char *buf, Int bufSize, int oX, int oY, int width, int hei
 	memcpy(buf,lrect.pBits,bufSize);
 	result = bufSize;
 
+	tempSurface->UnlockRect();
+
 error:
 	if (surface)
 		surface->Release();


### PR DESCRIPTION
This change fixes a missing call to IDirect3DSurface8::UnlockRect in W3DSmudge's copyRect. There was no observed issue.

## Chat GPT

Yes, in **DirectX 8**, if you successfully call `IDirect3DSurface8::LockRect`, **you must call `UnlockRect` before releasing the surface**, even if you're about to call `Release()`.

---

### Why `UnlockRect` is required before `Release`

* Locking a surface gives you **direct access to memory** (CPU-side), and **locks GPU access** to the surface.
* **`UnlockRect()` is required to release that lock** and signal that you're done with the CPU-side access.
* If you skip `UnlockRect` and call `Release()` directly, you're violating the interface contract. The behavior is **undefined**:

  * Some drivers may crash.
  * Others may leak memory or hang the GPU.
  * It may work in debug builds but crash in release (or vice versa).

---

### Correct usage pattern:

```cpp
IDirect3DSurface8* pSurface;
device->CreateImageSurface(..., &pSurface);

D3DLOCKED_RECT locked;
if (SUCCEEDED(pSurface->LockRect(&locked, NULL, 0))) {
    // Use locked.pBits here...

    pSurface->UnlockRect();  // <-- Must be called after successful LockRect
}

pSurface->Release(); // Safe to release now
```

---

### Summary:

> ✅ **Always call `UnlockRect` if `LockRect` succeeds.**
> 🚫 **Do NOT skip `UnlockRect` even if you plan to call `Release` immediately.**

