### PR TITLE
[GEN][ZH] Prevent executing death modules and spawning new objects to avoid asserts and crashes when unloading a map and destroying all objects

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -296,7 +296,7 @@ void GameLogic::destroyAllObjectsImmediate()
 	Object *obj;
 	Object *nextObj;
 
-	// TheSuperHackers @bugfix Set all remaining objects effectively dead to avoid triggering their
+	// TheSuperHackers @bugfix xezon 22/05/2025 Set all remaining objects effectively dead to avoid triggering their
 	// death modules that eventually would spawn new objects, such as debris, which could then crash the game.
 	// See https://github.com/TheSuperHackers/GeneralsGameCode/issues/896
 	for( obj = m_objList; obj; obj = obj->getNextObject() )

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -293,9 +293,18 @@ Bool GameLogic::isInSinglePlayerGame( void )
 //-------------------------------------------------------------------------------------------------
 void GameLogic::destroyAllObjectsImmediate()
 {
-	// destroy all remaining objects
 	Object *obj;
 	Object *nextObj;
+
+	// TheSuperHackers @bugfix Set all remaining objects effectively dead to avoid triggering their
+	// death modules that eventually would spawn new objects, such as debris, which could then crash the game.
+	// See https://github.com/TheSuperHackers/GeneralsGameCode/issues/896
+	for( obj = m_objList; obj; obj = obj->getNextObject() )
+	{
+		obj->setEffectivelyDead(true);
+	}
+
+	// destroy all remaining objects
 	for( obj = m_objList; obj; obj = nextObj )
 	{
 		nextObj = obj->getNextObject();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -311,7 +311,7 @@ void GameLogic::destroyAllObjectsImmediate()
 	Object *obj;
 	Object *nextObj;
 
-	// TheSuperHackers @bugfix Set all remaining objects effectively dead to avoid triggering their
+	// TheSuperHackers @bugfix xezon 22/05/2025 Set all remaining objects effectively dead to avoid triggering their
 	// death modules that eventually would spawn new objects, such as debris, which could then crash the game.
 	// See https://github.com/TheSuperHackers/GeneralsGameCode/issues/896
 	for( obj = m_objList; obj; obj = obj->getNextObject() )

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -308,9 +308,18 @@ Bool GameLogic::isInSinglePlayerGame( void )
 //-------------------------------------------------------------------------------------------------
 void GameLogic::destroyAllObjectsImmediate()
 {
-	// destroy all remaining objects
 	Object *obj;
 	Object *nextObj;
+
+	// TheSuperHackers @bugfix Set all remaining objects effectively dead to avoid triggering their
+	// death modules that eventually would spawn new objects, such as debris, which could then crash the game.
+	// See https://github.com/TheSuperHackers/GeneralsGameCode/issues/896
+	for( obj = m_objList; obj; obj = obj->getNextObject() )
+	{
+		obj->setEffectivelyDead(true);
+	}
+
+	// destroy all remaining objects
 	for( obj = m_objList; obj; obj = nextObj )
 	{
 		nextObj = obj->getNextObject();


### PR DESCRIPTION
* Fixes #896
* Closes #881
* Follow up for #809

This change fixes asserts and crashes from unloading maps and destroying all objects.

It does so by setting all objects effectively dead before deleting them. This way they do not apply terminal damage to other objects and no longer trigger death modules, that would eventually attempt to spawn new objects.
```
...
 	generalszh.exe!WeaponStore::createAndFireTempWeapon(const WeaponTemplate * wt, const Object * source, const Coord3D * pos) Line 1544	C++
 	generalszh.exe!FireWeaponWhenDeadBehavior::onDie(const DamageInfo * damageInfo) Line 119	C++
 	generalszh.exe!Object::onDie(DamageInfo * damageInfo) Line 4563	C++
 	generalszh.exe!ActiveBody::attemptDamage(DamageInfo * damageInfo) Line 677	C++
 	generalszh.exe!Object::attemptDamage(DamageInfo * damageInfo) Line 1823	C++
...
```
```cpp
void ActiveBody::attemptDamage( DamageInfo *damageInfo )
{
...
	if( obj->isEffectivelyDead() ) // <--- This change will prevent damages
		return;
```

Spawning new Objects fails at this time, because all `Player::getDefaultTeam` return null, which in turn will crash creating a new Object.
```cpp
>	generalszh.exe!Player::getProductionVeterancyLevel(AsciiString buildTemplateName) Line 1997	C++
 	generalszh.exe!Object::Object(const ThingTemplate * tt, const BitFlags<45> & objectStatusMask, Team * team) Line 478	C++
 	generalszh.exe!GameLogic::friend_createObject(const ThingTemplate * thing, const BitFlags<45> & statusBits, Team * team) Line 3964	C++
 	generalszh.exe!ThingFactory::newObject(const ThingTemplate * tmplate, Team * team, BitFlags<45> statusBits) Line 329	C++
 	generalszh.exe!GenericObjectCreationNugget::reallyCreate(const Coord3D * pos, const Matrix3D * mtx, float orientation, const Object * sourceObj, unsigned int lifetimeFrames) Line 1369	C++
 	generalszh.exe!GenericObjectCreationNugget::create(const Object * primary, const Object * secondary, unsigned int lifetimeFrames) Line 797	C++
 	generalszh.exe!ObjectCreationList::createInternal(const Object * primary, const Object * secondary, unsigned int lifetimeFrames) Line 1569	C++
 	[Inline Frame] generalszh.exe!ObjectCreationList::create(const ObjectCreationList *) Line 163	C++
 	generalszh.exe!WeaponTemplate::fireWeaponTemplate(const Object * sourceObj, WeaponSlotType wslot, int specificBarrelToUse, Object * victimObj, const Coord3D * victimPos, const WeaponBonus & bonus, bool isProjectileDetonation, bool ignoreRanges, Weapon * firingWeapon, ObjectID * projectileID, bool inflictDamage) Line 976	C++
...
```