### PR TITLE
[GEN][ZH] Revert to uninitialized variable in AiPathFind::findGroundPath for VC6 builds to avoid mismatch with retail builds

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -6649,7 +6649,13 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 		const Int adjacent[5] = {0, 1, 2, 3, 0};
 		Bool neighborFlags[8] = {false, false, false, false, false, false, false};
 
+		// TheSuperHackers @fix Mauller 23/05/2025 Fixes uninitialized variable.
+		// To keep retail compatibility it needs to be uninitialized in VC6 builds.
+#if defined(_MSC_VER) && _MSC_VER < 1300
+		UnsignedInt newCostSoFar;
+#else
 		UnsignedInt newCostSoFar = 0;
+#endif
 
 		for( int i=0; i<numNeighbors; i++ )
 		{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -7193,7 +7193,13 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 		const Int adjacent[5] = {0, 1, 2, 3, 0};
 		Bool neighborFlags[8] = {false, false, false, false, false, false, false};
 
+		// TheSuperHackers @fix Mauller 23/05/2025 Fixes uninitialized variable.
+		// To keep retail compatibility it needs to be uninitialized in VC6 builds.
+#if defined(_MSC_VER) && _MSC_VER < 1300
+		UnsignedInt newCostSoFar;
+#else
 		UnsignedInt newCostSoFar = 0;
+#endif
 
 		for( int i=0; i<numNeighbors; i++ )
 		{


### PR DESCRIPTION
* Follow up for #632

This PR adds conditional initialisation to the ```costSoFar``` variable in ```Pathfinder::findGroundPath``` within AiPathfind.cpp.

It came to light recently that the Golden Replays did not catch this issue, but some other replays could mismatch compared to retail due to the initialisation of this varaible.

For builds other than the VC6 build, the variable will be initialised to prevent throwing an uninitialised variable exception during debug.