### PR TITLE
[GEN][ZH] Implement Network Lobby support for multi instance clients

### DIFF
--- a/Generals/Code/GameEngine/Include/GameNetwork/IPEnumeration.h
+++ b/Generals/Code/GameEngine/Include/GameNetwork/IPEnumeration.h
@@ -73,6 +73,7 @@ public:
 	AsciiString getMachineName( void );			///< Return the Network Neighborhood machine name
 
 protected:
+	void addNewIP( UnsignedByte a, UnsignedByte b, UnsignedByte c, UnsignedByte d );
 
 	EnumeratedIP *m_IPlist;
 	Bool m_isWinsockInitialized;

--- a/Generals/Code/GameEngine/Include/GameNetwork/networkutil.h
+++ b/Generals/Code/GameEngine/Include/GameNetwork/networkutil.h
@@ -30,6 +30,7 @@
 #include "GameNetwork/NetworkDefs.h"
 #include "GameNetwork/NetworkInterface.h"
 
+UnsignedInt AssembleIp(UnsignedByte a, UnsignedByte b, UnsignedByte c, UnsignedByte d);
 UnsignedInt ResolveIP(AsciiString host);
 UnsignedShort GenerateNextCommandID();
 Bool DoesCommandRequireACommandID(NetCommandType type);
@@ -46,5 +47,13 @@ void dumpBufferToLog(const void *vBuf, Int len, const char *fname, Int line);
 #else
 #define LOGBUFFER(buf, len) {}
 #endif // DEBUG_LOGGING
+
+inline UnsignedInt AssembleIp(UnsignedByte a, UnsignedByte b, UnsignedByte c, UnsignedByte d)
+{
+    return ((UnsignedInt)(a) << 24) |
+           ((UnsignedInt)(b) << 16) |
+           ((UnsignedInt)(c) << 8) |
+           ((UnsignedInt)(d));
+}
 
 #endif

--- a/Generals/Code/GameEngine/Source/GameClient/ClientInstance.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/ClientInstance.cpp
@@ -36,7 +36,7 @@ bool ClientInstance::initialize()
 	// WARNING: DO NOT use this number for any other application except Generals.
 	while (true)
 	{
-#ifdef RTS_MULTI_INSTANCE
+#if defined(RTS_MULTI_INSTANCE)
 		std::string guidStr = getFirstInstanceName();
 		if (s_instanceIndex > 0u)
 		{

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanLobbyMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanLobbyMenu.cpp
@@ -96,23 +96,30 @@ Bool LANPreferences::loadFromIniFile()
 UnicodeString LANPreferences::getUserName(void)
 {
 	UnicodeString ret;
+
 	LANPreferences::const_iterator it = find("UserName");
-	if (it == end())
+	if (it != end())
 	{
-		IPEnumeration IPs;
-		ret.translate(IPs.getMachineName());
+		// Found an user name. Use it if valid.
+		ret = QuotedPrintableToUnicodeString(it->second);
+		ret.trim();
+		if (!ret.isEmpty())
+		{
+			return ret;
+		}
+	}
+
+	if (rts::ClientInstance::getInstanceId() > 1u)
+	{
+		// TheSuperHackers @feature Use the instance id as default user name
+		// to avoid duplicate names for multiple client instances.
+		ret.format(L"Instance%.2d", rts::ClientInstance::getInstanceId());
 		return ret;
 	}
 
-	ret = QuotedPrintableToUnicodeString(it->second);
-	ret.trim();
-	if (ret.isEmpty())
-	{
-		IPEnumeration IPs;
-		ret.translate(IPs.getMachineName());
-		return ret;
-	}
-	
+	// Use machine name as default user name.
+	IPEnumeration IPs;
+	ret.translate(IPs.getMachineName());
 	return ret;
 }
 

--- a/GeneralsMD/Code/GameEngine/Include/GameNetwork/IPEnumeration.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameNetwork/IPEnumeration.h
@@ -73,6 +73,7 @@ public:
 	AsciiString getMachineName( void );			///< Return the Network Neighborhood machine name
 
 protected:
+	void addNewIP( UnsignedByte a, UnsignedByte b, UnsignedByte c, UnsignedByte d );
 
 	EnumeratedIP *m_IPlist;
 	Bool m_isWinsockInitialized;

--- a/GeneralsMD/Code/GameEngine/Include/GameNetwork/networkutil.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameNetwork/networkutil.h
@@ -30,6 +30,7 @@
 #include "GameNetwork/NetworkDefs.h"
 #include "GameNetwork/NetworkInterface.h"
 
+UnsignedInt AssembleIp(UnsignedByte a, UnsignedByte b, UnsignedByte c, UnsignedByte d);
 UnsignedInt ResolveIP(AsciiString host);
 UnsignedShort GenerateNextCommandID();
 Bool DoesCommandRequireACommandID(NetCommandType type);
@@ -46,5 +47,13 @@ void dumpBufferToLog(const void *vBuf, Int len, const char *fname, Int line);
 #else
 #define LOGBUFFER(buf, len) {}
 #endif // DEBUG_LOGGING
+
+inline UnsignedInt AssembleIp(UnsignedByte a, UnsignedByte b, UnsignedByte c, UnsignedByte d)
+{
+    return ((UnsignedInt)(a) << 24) |
+           ((UnsignedInt)(b) << 16) |
+           ((UnsignedInt)(c) << 8) |
+           ((UnsignedInt)(d));
+}
 
 #endif

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/ClientInstance.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/ClientInstance.cpp
@@ -36,7 +36,7 @@ bool ClientInstance::initialize()
 	// WARNING: DO NOT use this number for any other application except Generals.
 	while (true)
 	{
-#ifdef RTS_MULTI_INSTANCE
+#if defined(RTS_MULTI_INSTANCE)
 		std::string guidStr = getFirstInstanceName();
 		if (s_instanceIndex > 0u)
 		{

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanLobbyMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanLobbyMenu.cpp
@@ -96,23 +96,30 @@ Bool LANPreferences::loadFromIniFile()
 UnicodeString LANPreferences::getUserName(void)
 {
 	UnicodeString ret;
+
 	LANPreferences::const_iterator it = find("UserName");
-	if (it == end())
+	if (it != end())
 	{
-		IPEnumeration IPs;
-		ret.translate(IPs.getMachineName());
+		// Found an user name. Use it if valid.
+		ret = QuotedPrintableToUnicodeString(it->second);
+		ret.trim();
+		if (!ret.isEmpty())
+		{
+			return ret;
+		}
+	}
+
+	if (rts::ClientInstance::getInstanceId() > 1u)
+	{
+		// TheSuperHackers @feature Use the instance id as default user name
+		// to avoid duplicate names for multiple client instances.
+		ret.format(L"Instance%.2d", rts::ClientInstance::getInstanceId());
 		return ret;
 	}
 
-	ret = QuotedPrintableToUnicodeString(it->second);
-	ret.trim();
-	if (ret.isEmpty())
-	{
-		IPEnumeration IPs;
-		ret.translate(IPs.getMachineName());
-		return ret;
-	}
-	
+	// Use machine name as default user name.
+	IPEnumeration IPs;
+	ret.translate(IPs.getMachineName());
 	return ret;
 }
 


### PR DESCRIPTION
* Merge after #905
* Closes #407

This change enables multi instance clients to connect in Network matches and is an alternative implementation to #407. It does not change the Network protocol and therefore is using the Network as if these were normal clients. To achieve that, it adds one unique local host IP address to each client that the Network can use to connect multiple local clients with each other.

Credits to @jaapdeheer for this idea.

This change also implements a new default Network user name for the multi instance clients.

Credits to @helmutbuhler for the first implementation.

### 127.0.0.N IP address in Options Menu

![shot_20250523_194745_1](https://github.com/user-attachments/assets/3cc14528-9217-43a2-84c6-654a13fedb28)

### 2 clients matched together

![multiclientnetwork](https://github.com/user-attachments/assets/6f5aa2b7-0452-4eea-92db-247b9c27dcf6)

## TODO

- [x] Replicate in Generals