### PR TITLE
[ZH] Fix crash in OpenContain::killAllContained() when killed occupants kill the host container

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -434,16 +434,26 @@ void OpenContain::removeAllContained( Bool exposeStealthUnits )
 //-------------------------------------------------------------------------------------------------
 void OpenContain::killAllContained( void )
 {
-	ContainedItemsList::iterator it = m_containList.begin();
+	// TheSuperHackers @bugfix xezon 23/05/2025 Empty m_containList straight away
+	// to prevent a potential child call to catastrophically modify the m_containList as well.
+	// This scenario can happen if the killed occupant(s) apply deadly damage on death
+	// to the host container, which then attempts to remove all remaining occupants
+	// on the death of the host container. This is reproducible by shooting with
+	// Neutron Shells on a GLA Technical containing GLA Terrorists.
+	ContainedItemsList list;
+	list.swap(m_containList);
+	m_containListSize = 0;
 
- 	while ( it != m_containList.end() )
+	ContainedItemsList::iterator it = list.begin();
+
+ 	while ( it != list.end() )
 	{
     Object *rider = *it;
 
-
+    DEBUG_ASSERTCRASH( rider, ("Contain list must not contain NULL element"));
     if ( rider )
     {
-	    it = m_containList.erase(it);
+	    it = list.erase(it);
 	    m_containListSize--;
 
       onRemoving( rider );
@@ -472,6 +482,7 @@ void OpenContain::harmAndForceExitAllContained( DamageInfo *info )
 	{
 		Object *rider = *it;
 
+		DEBUG_ASSERTCRASH( rider, ("Contain list must not contain NULL element"));
 		if ( rider )
 		{
 		  removeFromContain( rider, true );
@@ -490,7 +501,7 @@ void OpenContain::harmAndForceExitAllContained( DamageInfo *info )
 
   DEBUG_ASSERTCRASH( m_containListSize == 0, ("harmAndForceExitAllContained just made a booboo, list size != zero.") );
 
-}  // end removeAllContained
+}  // end harmAndForceExitAllContained
 
 
 //-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This change fixes a crash when occupants kill their container and force the remaining occupants to evacuate. This problem is Zero Hour specific. Generals does not have this code.

The technical mistake here is calling `OpenContain::removeAllContained` within the process of iterating `OpenContain::m_containList` in `OpenContain::killAllContained`. It is catastophic to modify the list in recursive calls.

To fix this problem, the recursive modification is avoided. All occupants will be killed before the code ever reaches `OpenContain::removeAllContained`.

This change carries risk of mismatch with retail game, IF there is a code path that **reads** `OpenContain::m_containList` while occupants are killed in `OpenContain::killAllContained`. Reads are legal. This change needs to be tested well. If we find a mismatch, we need to hack-fix this problem elsewhere.

## Asan report

```
==1828==ERROR: AddressSanitizer: heap-use-after-free on address 0x114011f8 at pc 0x008cd33b bp 0x0044dc7c sp 0x0044dc70
READ of size 4 at 0x114011f8 thread T0
==1828==WARNING: Failed to use and restart external symbolizer!
    #0 0x008cd33a in OpenContain::killAllContained D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Contain\OpenContain.cpp:441
    #1 0x008ae738 in NeutronBlastBehavior::neutronBlastToObject D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Behavior\NeutonBlastBehavior.cpp:131
    #2 0x008aead4 in NeutronBlastBehavior::onDie D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Behavior\NeutonBlastBehavior.cpp:91
    #3 0x00727dde in Object::onDie D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Object.cpp:4567
    #4 0x009c78ca in ActiveBody::attemptDamage D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Body\ActiveBody.cpp:673
    #5 0x0071cce6 in Object::attemptDamage D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Object.cpp:1820
    #6 0x005f6d4b in WeaponTemplate::dealDamageInternal D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp:1494
    #7 0x005f88da in WeaponTemplate::fireWeaponTemplate D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp:1066
    #8 0x005fc7f9 in Weapon::privateFireWeapon D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp:2641
    #9 0x005f9a5c in WeaponStore::handleProjectileDetonation D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp:1532
    #10 0x008b8df4 in DumbProjectileBehavior::detonate D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Behavior\DumbProjectileBehavior.cpp:541
    #11 0x008b9899 in DumbProjectileBehavior::projectileHandleCollision D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Behavior\DumbProjectileBehavior.cpp:525
    #12 0x0081396f in PhysicsBehavior::onCollide D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Update\PhysicsUpdate.cpp:1171
    #13 0x00727886 in Object::onCollide D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Object.cpp:2410
    #14 0x00816cef in PhysicsBehavior::update D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Update\PhysicsUpdate.cpp:855
    #15 0x0060d43e in GameLogic::update D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\System\GameLogic.cpp:3759
    #16 0x0051934d in GameEngine::update D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\GameEngine.cpp:754
    #17 0x00b4a76d in Win32GameEngine::update D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngineDevice\Source\Win32Device\Common\Win32GameEngine.cpp:90
    #18 0x005169ba in GameEngine::execute D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\GameEngine.cpp:815
    #19 0x00506da5 in GameMain D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\GameMain.cpp:44
    #20 0x005036f3 in WinMain D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\Main\WinMain.cpp:1031
    #21 0x00efbb26 in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #22 0x763cfcc8 in BaseThreadInitThunk+0x18 (C:\WINDOWS\System32\KERNEL32.DLL+0x6b81fcc8)
    #23 0x777c82ad in RtlGetAppContainerNamedObjectPath+0x11d (C:\WINDOWS\SYSTEM32\ntdll.dll+0x4b2e82ad)
    #24 0x777c827d in RtlGetAppContainerNamedObjectPath+0xed (C:\WINDOWS\SYSTEM32\ntdll.dll+0x4b2e827d)

0x114011f8 is located 8 bytes inside of 12-byte region [0x114011f0,0x114011fc)
freed by thread T0 here:
    #0 0x53dde6ed in free D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_malloc_win.cpp:125
    #1 0x53df081c in __asan::__RuntimeFunctions<__asan::Ucrtbase>::Free D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_win_runtime_functions.cpp:273
    #2 0x00efb203 in operator delete D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_win_delete_scalar_size_thunk.cpp:44
    #3 0x006a24f2 in std::list<KindOfPercentProductionChange *,std::allocator<KindOfPercentProductionChange *> >::erase C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.43.34808\include\list:1422
    #4 0x008d2936 in OpenContain::removeFromContainViaIterator D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Contain\OpenContain.cpp:645
    #5 0x008d2451 in OpenContain::removeAllContained D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Contain\OpenContain.cpp:426
    #6 0x008cf256 in OpenContain::onDie D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Contain\OpenContain.cpp:874
    #7 0x00727dde in Object::onDie D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Object.cpp:4567
    #8 0x009c78ca in ActiveBody::attemptDamage D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Body\ActiveBody.cpp:673
    #9 0x0071cce6 in Object::attemptDamage D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Object.cpp:1820
    #10 0x005f6d4b in WeaponTemplate::dealDamageInternal D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp:1494
    #11 0x005f88da in WeaponTemplate::fireWeaponTemplate D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp:1066
    #12 0x005fc7f9 in Weapon::privateFireWeapon D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp:2641
    #13 0x005f5b62 in WeaponStore::createAndFireTempWeapon D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp:1543
    #14 0x008f5914 in FireWeaponWhenDeadBehavior::onDie D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Behavior\FireWeaponWhenDeadBehavior.cpp:117
    #15 0x00727dde in Object::onDie D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Object.cpp:4567
    #16 0x009c78ca in ActiveBody::attemptDamage D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Body\ActiveBody.cpp:673
    #17 0x0071cce6 in Object::attemptDamage D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Object.cpp:1820
    #18 0x00726ddb in Object::kill D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Object.cpp:1962
    #19 0x008cd5c0 in OpenContain::killAllContained D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Contain\OpenContain.cpp:451
    #20 0x008ae738 in NeutronBlastBehavior::neutronBlastToObject D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Behavior\NeutonBlastBehavior.cpp:131
    #21 0x008aead4 in NeutronBlastBehavior::onDie D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Behavior\NeutonBlastBehavior.cpp:91
    #22 0x00727dde in Object::onDie D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Object.cpp:4567
    #23 0x009c78ca in ActiveBody::attemptDamage D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Body\ActiveBody.cpp:673
    #24 0x0071cce6 in Object::attemptDamage D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Object.cpp:1820
    #25 0x005f6d4b in WeaponTemplate::dealDamageInternal D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp:1494
    #26 0x005f88da in WeaponTemplate::fireWeaponTemplate D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp:1066
    #27 0x005fc7f9 in Weapon::privateFireWeapon D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp:2641

previously allocated by thread T0 here:
    #0 0x53dde7ed in malloc D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_malloc_win.cpp:134
    #1 0x0050429a in operator new D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\System\GameMemoryNull.cpp:158
    #2 0x005901a2 in std::list<Object *,std::allocator<Object *> >::_Emplace<Object * const &> C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.43.34808\include\list:1024
    #3 0x008cdc2b in OpenContain::loadPostProcess D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Contain\OpenContain.cpp:1808
    #4 0x008e203e in TransportContain::loadPostProcess D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Contain\TransportContain.cpp:702
    #5 0x005becaf in GameState::gameStatePostProcessLoad D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\System\SaveGame\GameState.cpp:1545
    #6 0x005c06bb in GameState::loadGame D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\System\SaveGame\GameState.cpp:712
    #7 0x00a02954 in doLoadGame D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameClient\GUI\GUICallbacks\Menus\PopupSaveLoad.cpp:417
    #8 0x00a02b41 in processLoadButtonPress D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameClient\GUI\GUICallbacks\Menus\PopupSaveLoad.cpp:502
    #9 0x00a025d5 in SaveLoadMenuSystem D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameClient\GUI\GUICallbacks\Menus\PopupSaveLoad.cpp:920
    #10 0x0068bd5f in GameWindowManager::winSendSystemMsg D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameClient\GUI\GameWindowManager.cpp:709
    #11 0x0081c7bf in GadgetListBoxInput D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameClient\GUI\Gadget\GadgetListBox.cpp:838
    #12 0x0068bccf in GameWindowManager::winSendInputMsg D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameClient\GUI\GameWindowManager.cpp:728
    #13 0x0068ace7 in GameWindowManager::winProcessMouseEvent D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameClient\GUI\GameWindowManager.cpp:930
    #14 0x00a6efe3 in WindowTranslator::translateGameMessage D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameClient\MessageStream\WindowXlat.cpp:247
    #15 0x0052a58c in MessageStream::propagateMessages D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\MessageStream.cpp:1095
    #16 0x0051925a in GameEngine::update D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\GameEngine.cpp:741
    #17 0x00b4a76d in Win32GameEngine::update D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngineDevice\Source\Win32Device\Common\Win32GameEngine.cpp:90
    #18 0x005169ba in GameEngine::execute D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\GameEngine.cpp:815
    #19 0x00506da5 in GameMain D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\GameMain.cpp:44
    #20 0x005036f3 in WinMain D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\Main\WinMain.cpp:1031
    #21 0x00efbb26 in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #22 0x763cfcc8 in BaseThreadInitThunk+0x18 (C:\WINDOWS\System32\KERNEL32.DLL+0x6b81fcc8)
    #23 0x777c82ad in RtlGetAppContainerNamedObjectPath+0x11d (C:\WINDOWS\SYSTEM32\ntdll.dll+0x4b2e82ad)
    #24 0x777c827d in RtlGetAppContainerNamedObjectPath+0xed (C:\WINDOWS\SYSTEM32\ntdll.dll+0x4b2e827d)

SUMMARY: AddressSanitizer: heap-use-after-free D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Contain\OpenContain.cpp:441 in OpenContain::killAllContained
Shadow bytes around the buggy address:
  0x11400f00: fa fa fd fd fa fa fd fd fa fa 00 04 fa fa 00 06
  0x11400f80: fa fa 00 04 fa fa 00 00 fa fa fd fd fa fa fd fd
  0x11401000: fa fa fd fd fa fa fd fd fa fa 00 04 fa fa fd fd
  0x11401080: fa fa fd fd fa fa fd fd fa fa fd fd fa fa fd fd
  0x11401100: fa fa fd fd fa fa fd fd fa fa fd fd fa fa fd fd
=>0x11401180: fa fa fd fd fa fa fd fd fa fa fd fd fa fa fd[fd]
  0x11401200: fa fa fd fd fa fa fd fd fa fa fd fd fa fa fd fd
  0x11401280: fa fa fd fd fa fa fd fd fa fa fd fd fa fa fd fd
  0x11401300: fa fa 00 00 fa fa fd fd fa fa fd fd fa fa fd fd
  0x11401380: fa fa 00 00 fa fa 00 00 fa fa 00 04 fa fa 00 00
  0x11401400: fa fa 00 00 fa fa 00 00 fa fa 00 00 fa fa 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
Address Sanitizer Error: Use of deallocated memory
```

## TODO

- [x] Test in VC6 Golden Replay
- [ ] Test in more Replays
