### PR TITLE
[GEN][ZH] Fix global-buffer-overflow at GUI_COMMAND_EXIT_CONTAINER in ControlBar::processCommandUI()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarCommandProcessing.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarCommandProcessing.cpp
@@ -516,20 +516,29 @@ CBCommandStatus ControlBar::processCommandUI( GameWindow *control,
 		case GUI_COMMAND_EXIT_CONTAINER:
 		{
 			Int i;
-			ObjectID objID;
+			// TheSuperHackers @fix Caball009/Mauller 23/05/2025 Fix uninitialized variable and control lookup behaviour to prevent a buffer-overflow when the control container is empty
+			ObjectID objID = INVALID_ID;
 
 			//
 			// find the object ID that wants to exit by scanning through the transport data and looking
 			// for the matching control button
 			//
-			for( i = 0; i < MAX_COMMANDS_PER_SET; i++ )
-				if( m_containData[ i ].control == control )
+			for (i = 0; i < MAX_COMMANDS_PER_SET; i++)
+			{
+				if (m_containData[i].control == control)
+				{
 					objID = m_containData[ i ].objectID;
+					break;
+				}
+			}
+
+			if (objID == INVALID_ID)
+				break;
 
 			// get the actual object
 			Object *objWantingExit = TheGameLogic->findObjectByID( objID );
 			
-			// if object is not found remove inventory entry and exit
+			// if the control container returns an object ID but the object is not found, remove the control entry and exit
 			if( objWantingExit == NULL )
 			{
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarCommandProcessing.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarCommandProcessing.cpp
@@ -681,20 +681,29 @@ CBCommandStatus ControlBar::processCommandUI( GameWindow *control,
 		case GUI_COMMAND_EXIT_CONTAINER:
 		{
 			Int i;
-			ObjectID objID;
+			// TheSuperHackers @fix Caball009/Mauller 23/05/2025 Fix uninitialized variable and control lookup behaviour to prevent a buffer-overflow when the control container is empty
+			ObjectID objID = INVALID_ID;
 
 			//
 			// find the object ID that wants to exit by scanning through the transport data and looking
 			// for the matching control button
 			//
-			for( i = 0; i < MAX_COMMANDS_PER_SET; i++ )
-				if( m_containData[ i ].control == control )
+			for (i = 0; i < MAX_COMMANDS_PER_SET; i++)
+			{
+				if (m_containData[i].control == control)
+				{
 					objID = m_containData[ i ].objectID;
+					break;
+				}
+			}
+
+			if (objID == INVALID_ID)
+				break;
 
 			// get the actual object
 			Object *objWantingExit = TheGameLogic->findObjectByID( objID );
 			
-			// if object is not found remove inventory entry and exit
+			// if the control container returns an object ID but the object is not found, remove the control entry and exit
 			if( objWantingExit == NULL )
 			{
 


### PR DESCRIPTION
- Closes: #914

This PR corrects an uninitialised variable access that can occur when selecting an empty button on a building or vehicle that has a contain element.

If no match is made for the selected button against elements in the contain list, the object ID variable used to lookup the required object will be uninitialised which could cause unexpected behaviour if the value were to match a valid object.

Setting the object variable prevents this behaviour as we can return early if the ```objID``` variable is still the ```INVALID_ID```.