### PR TITLE
[GITHUB] Update build-toolchain to use public VC6 from itsmattkc repo

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -52,30 +52,28 @@ jobs:
           restore-keys: |
             cmake-deps-${{ inputs.preset }}-
 
-      - name: Download VC6 Portable from Cloudflare R2
+      - name: Download VC6 Portable from itsmattkc repo
         if: ${{ startsWith(inputs.preset, 'vc6') && steps.cache-vc6.outputs.cache-hit != 'true' }}
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          AWS_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
-          EXPECTED_HASH: "118D0F1ACBBD70C3F8B081CA4DBAF955FE0C6C359A76636E930AA89FDC551091"
+          EXPECTED_HASH: "5FA2FB0FE61FD0E0FE08DC2C77EA33DF9947A39ED13670DD14B30DA5997F9315"
         shell: pwsh
         run: |
           Write-Host "Downloading VC6 Portable Installation" -ForegroundColor Cyan
-          aws s3 cp s3://github-ci/VS6_VisualStudio6.7z VS6_VisualStudio6.7z --endpoint-url $env:AWS_ENDPOINT_URL
+          Invoke-WebRequest -Uri https://github.com/itsmattkc/MSVC600/archive/refs/heads/master.zip -OutFile VS6_VisualStudio6.zip
 
           Write-Host "Verifying File Integrity" -ForegroundColor Cyan
-          $fileHash = (Get-FileHash -Path VS6_VisualStudio6.7z -Algorithm SHA256).Hash
+          $fileHash = (Get-FileHash -Path VS6_VisualStudio6.zip -Algorithm SHA256).Hash
           Write-Host "Downloaded file SHA256: $fileHash"
           Write-Host "Expected file SHA256: $env:EXPECTED_HASH"
-          if ($hash -ne $env:EXPECTED_HASH) {
+          if ($fileHash -ne $env:EXPECTED_HASH) {
               Write-Error "Hash verification failed! File may be corrupted or tampered with."
               exit 1
           }
 
           Write-Host "Extracting Archive" -ForegroundColor Cyan
-          & 7z x VS6_VisualStudio6.7z -oC:\VC6
-          Remove-Item VS6_VisualStudio6.7z -Verbose
+          & Expand-Archive -Path VS6_VisualStudio6.zip -DestinationPath C:\VC6
+          Move-Item -Path C:\VC6\MSVC600-master -Destination C:\VC6\VC6SP6
+          Remove-Item VS6_VisualStudio6.zip -Verbose
 
       - name: Set Up VC6 Environment
         if: startsWith(inputs.preset, 'vc6')


### PR DESCRIPTION
This pull request updates the build workflow to download the VC6 toolchain from a public repository.

**Key changes:**
- Uses the public itsmattkc/MSVC600 repository to fetch the VC6 portable toolchain.
- Removes the need to maintain or use any secrets for toolchain downloads in CI builds.
- Simplifies maintenance and improves transparency for all contributors.

This change makes the build process more secure and easier to reproduce for everyone.