### PR TITLE
Fix compiler warnings for const qualifier on value return type

### DIFF
--- a/Core/Libraries/Source/WWVegas/WW3D2/rendobj.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/rendobj.h
@@ -452,9 +452,9 @@ public:
 	virtual void					Scale(float scale) 															{ };
 	virtual void					Scale(float scalex, float scaley, float scalez)						{ };
  	virtual void					Set_ObjectScale(float scale) { ObjectScale=scale;}	//set's a scale factor that's factored into transform matrix.									{ScaleFactor=scale; };
-	const float						Get_ObjectScale( void ) const { return ObjectScale; };
+	float							Get_ObjectScale( void ) const { return ObjectScale; };
  	void							Set_ObjectColor(unsigned int color) { ObjectColor=color;}	//the color that was used to modify the asset for player team color (for Generals). -MW
-	const unsigned int				Get_ObjectColor( void ) const { return ObjectColor; };
+	unsigned int					Get_ObjectColor( void ) const { return ObjectColor; };
 
    virtual int						Get_Sort_Level(void) const													{ return 0; /* SORT_LEVEL_NONE */ }
    virtual void					Set_Sort_Level(int level)													{ }

--- a/Generals/Code/GameEngine/Include/GameClient/Drawable.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Drawable.h
@@ -337,7 +337,7 @@ public:
 
 	void reactToBodyDamageStateChange(BodyDamageType newState);
 	
-	const Real getScale (void) const ;
+	Real getScale (void) const ;
 
 	// access to modules
 	//---------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/Generals/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -416,7 +416,7 @@ public:  // ********************************************************************
 	// build interface
 	virtual void placeBuildAvailable( const ThingTemplate *build, Drawable *buildDrawable );				///< built thing being placed
 	virtual const ThingTemplate *getPendingPlaceType( void );					///< get item we're trying to place
-	virtual const ObjectID getPendingPlaceSourceObjectID( void );			///< get producing object
+	virtual ObjectID getPendingPlaceSourceObjectID( void );			///< get producing object
 	virtual Bool getPreventLeftClickDeselectionInAlternateMouseModeForOneClick() const { return m_preventLeftClickDeselectionInAlternateMouseModeForOneClick; }
 	virtual void setPreventLeftClickDeselectionInAlternateMouseModeForOneClick( Bool set ) { m_preventLeftClickDeselectionInAlternateMouseModeForOneClick = set; }
 	virtual void setPlacementStart( const ICoord2D *start );					///< placement anchor point (for choosing angles)

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/AIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/AIUpdate.h
@@ -344,7 +344,7 @@ public:
 	virtual void aiDoCommand(const AICommandParms* parms);
 	
 	virtual const Coord3D *getGuardLocation( void ) const { return &m_locationToGuard;	}
-	virtual const ObjectID getGuardObject( void ) const { return m_objectToGuard; }
+	virtual ObjectID getGuardObject( void ) const { return m_objectToGuard; }
 	virtual const PolygonTrigger *getAreaToGuard( void ) const { return m_areaToGuard; }
 	virtual GuardTargetType getGuardTargetType() const { return m_guardTargetType[1]; }
 	virtual void clearGuardTargetType() { m_guardTargetType[1] = m_guardTargetType[0]; m_guardTargetType[0] = GUARDTARGET_NONE; }

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/RailroadGuideAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/RailroadGuideAIUpdate.h
@@ -129,7 +129,7 @@ struct TrackPoint
 	};
 
 
-	const Int getHandle( void )
+	Int getHandle( void )
 	{
 		return m_handle;
 	};

--- a/Generals/Code/GameEngine/Include/GameLogic/Object.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Object.h
@@ -452,7 +452,7 @@ public:
 	Weapon* getWeaponInWeaponSlot(WeaponSlotType wslot) const { return m_weaponSet.getWeaponInWeaponSlot(wslot); }
 
 	// see if this current weapon set's weapons has shared reload times
-	const Bool isReloadTimeShared() const { return m_weaponSet.isSharedReloadTime(); }
+	Bool isReloadTimeShared() const { return m_weaponSet.isSharedReloadTime(); }
 
 	Weapon* getCurrentWeapon(WeaponSlotType* wslot = NULL);
 	const Weapon* getCurrentWeapon(WeaponSlotType* wslot = NULL) const;

--- a/Generals/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -1042,7 +1042,7 @@ void Drawable::fadeIn( UnsignedInt frames )		///< decloak object
 
 
 //-------------------------------------------------------------------------------------------------
-const Real Drawable::getScale (void) const 
+Real Drawable::getScale (void) const
 { 
 	return m_instanceScale; 
 //	return getTemplate()->getAssetScale(); 

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -3036,7 +3036,7 @@ const ThingTemplate *InGameUI::getPendingPlaceType( void )
 
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
-const ObjectID InGameUI::getPendingPlaceSourceObjectID( void )
+ObjectID InGameUI::getPendingPlaceSourceObjectID( void )
 {
 
 	return m_pendingPlaceSourceObjectID;

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
@@ -592,7 +592,7 @@ const RenderDeviceDescClass & WW3D::Get_Render_Device_Desc(int deviceidx)
  *   5/19/99    GTH : Created.                                                                 *
  *   1/25/2001  gth : converted to DX8                                                         *
  *=============================================================================================*/
-const int WW3D::Get_Render_Device_Count(void)
+int WW3D::Get_Render_Device_Count(void)
 {
 	return DX8Wrapper::Get_Render_Device_Count();
 }

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/ww3d.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/ww3d.h
@@ -110,7 +110,7 @@ public:
 	static WW3DErrorType		Shutdown(void);
 	static bool					Is_Initted(void)								{ return IsInitted; }
 
-	static const int			Get_Render_Device_Count(void);
+	static int					Get_Render_Device_Count(void);
 	static const char *		Get_Render_Device_Name(int device_index);
 	static const RenderDeviceDescClass &								Get_Render_Device_Desc(int device = -1);
 

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/ChallengeGenerals.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/ChallengeGenerals.h
@@ -86,7 +86,7 @@ public:
 	}
 //	~GeneralPersona( void );
 	
-	const Bool	isStartingEnabled() const { return m_bStartsEnabled; }
+	Bool isStartingEnabled() const { return m_bStartsEnabled; }
 	const AsciiString& getBioName() const { return m_strBioName; }
 	const AsciiString& getBioDOB() const { return m_strBioDOB; }
 	const AsciiString& getBioBirthplace() const { return m_strBioBirthplace; }
@@ -145,7 +145,7 @@ public:
 	Int getCurrentPlayerTemplateNum( void ) { return m_PlayerTemplateNum; }
 
 	void setCurrentDifficulty( GameDifficulty diff ) { m_currentDifficulty = diff; }
-	const GameDifficulty getCurrentDifficulty( void ) { return m_currentDifficulty; }
+	GameDifficulty getCurrentDifficulty( void ) { return m_currentDifficulty; }
 protected:
 	static const FieldParse s_fieldParseTable[];
 

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Drawable.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Drawable.h
@@ -349,7 +349,7 @@ public:
 
 	void reactToBodyDamageStateChange(BodyDamageType newState);
 	
-	const Real getScale (void) const ;
+	Real getScale (void) const ;
 
 	// access to modules
 	//---------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -431,7 +431,7 @@ public:  // ********************************************************************
 	// build interface
 	virtual void placeBuildAvailable( const ThingTemplate *build, Drawable *buildDrawable );				///< built thing being placed
 	virtual const ThingTemplate *getPendingPlaceType( void );					///< get item we're trying to place
-	virtual const ObjectID getPendingPlaceSourceObjectID( void );			///< get producing object
+	virtual ObjectID getPendingPlaceSourceObjectID( void );			///< get producing object
 	virtual Bool getPreventLeftClickDeselectionInAlternateMouseModeForOneClick() const { return m_preventLeftClickDeselectionInAlternateMouseModeForOneClick; }
 	virtual void setPreventLeftClickDeselectionInAlternateMouseModeForOneClick( Bool set ) { m_preventLeftClickDeselectionInAlternateMouseModeForOneClick = set; }
 	virtual void setPlacementStart( const ICoord2D *start );					///< placement anchor point (for choosing angles)

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/AIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/AIUpdate.h
@@ -357,7 +357,7 @@ public:
 	virtual void aiDoCommand(const AICommandParms* parms);
 	
 	virtual const Coord3D *getGuardLocation( void ) const { return &m_locationToGuard;	}
-	virtual const ObjectID getGuardObject( void ) const { return m_objectToGuard; }
+	virtual ObjectID getGuardObject( void ) const { return m_objectToGuard; }
 	virtual const PolygonTrigger *getAreaToGuard( void ) const { return m_areaToGuard; }
 	virtual GuardTargetType getGuardTargetType() const { return m_guardTargetType[1]; }
 	virtual void clearGuardTargetType() { m_guardTargetType[1] = m_guardTargetType[0]; m_guardTargetType[0] = GUARDTARGET_NONE; }

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/RailroadGuideAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/RailroadGuideAIUpdate.h
@@ -129,7 +129,7 @@ struct TrackPoint
 	};
 
 
-	const Int getHandle( void )
+	Int getHandle( void )
 	{
 		return m_handle;
 	};

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
@@ -481,7 +481,7 @@ public:
 	UnsignedInt getWeaponInWeaponSlotCommandSourceMask( WeaponSlotType wSlot ) const { return m_weaponSet.getNthCommandSourceMask( wSlot ); }
 
 	// see if this current weapon set's weapons has shared reload times
-	const Bool isReloadTimeShared() const { return m_weaponSet.isSharedReloadTime(); }
+	Bool isReloadTimeShared() const { return m_weaponSet.isSharedReloadTime(); }
 
 	Weapon* getCurrentWeapon(WeaponSlotType* wslot = NULL);
 	const Weapon* getCurrentWeapon(WeaponSlotType* wslot = NULL) const;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -1090,7 +1090,7 @@ void Drawable::fadeIn( UnsignedInt frames )		///< decloak object
 
 
 //-------------------------------------------------------------------------------------------------
-const Real Drawable::getScale (void) const 
+Real Drawable::getScale (void) const
 { 
 	return m_instanceScale; 
 //	return getTemplate()->getAssetScale(); 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -3126,7 +3126,7 @@ const ThingTemplate *InGameUI::getPendingPlaceType( void )
 
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
-const ObjectID InGameUI::getPendingPlaceSourceObjectID( void )
+ObjectID InGameUI::getPendingPlaceSourceObjectID( void )
 {
 
 	return m_pendingPlaceSourceObjectID;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
@@ -585,7 +585,7 @@ const RenderDeviceDescClass & WW3D::Get_Render_Device_Desc(int deviceidx)
  *   5/19/99    GTH : Created.                                                                 *
  *   1/25/2001  gth : converted to DX8                                                         *
  *=============================================================================================*/
-const int WW3D::Get_Render_Device_Count(void)
+int WW3D::Get_Render_Device_Count(void)
 {
 	return DX8Wrapper::Get_Render_Device_Count();
 }

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/ww3d.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/ww3d.h
@@ -110,7 +110,7 @@ public:
 	static WW3DErrorType		Shutdown(void);
 	static bool					Is_Initted(void)								{ return IsInitted; }
 
-	static const int			Get_Render_Device_Count(void);
+	static int					Get_Render_Device_Count(void);
 	static const char *		Get_Render_Device_Name(int device_index);
 	static const RenderDeviceDescClass &								Get_Render_Device_Desc(int device = -1);
 


### PR DESCRIPTION
In cases such as `const bool foo() const;` the first `const` qualifier is meaningless and generates a compiler warning.