### PR TITLE
[GEN][ZH] Remove obsolete and wrong code in listGroupRoomsCallback()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
@@ -2221,7 +2221,7 @@ static void listGroupRoomsCallback(PEER peer, PEERBool success,
 		}
 		else
 		{
-			resp.groupRoomName.empty();
+			resp.groupRoomName.clear();
 		}
 		TheGameSpyPeerMessageQueue->addResponse(resp);
 #ifdef SERVER_DEBUGGING

--- a/Generals/Code/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
@@ -2219,10 +2219,6 @@ static void listGroupRoomsCallback(PEER peer, PEERBool success,
 			resp.groupRoomName = name;
 			//t->setQMGroupRoom(groupID);
 		}
-		else
-		{
-			resp.groupRoomName.clear();
-		}
 		TheGameSpyPeerMessageQueue->addResponse(resp);
 #ifdef SERVER_DEBUGGING
 		CheckServers(peer);

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
@@ -2230,10 +2230,6 @@ static void listGroupRoomsCallback(PEER peer, PEERBool success,
 			resp.groupRoomName = name;
 			//t->setQMGroupRoom(groupID);
 		}
-		else
-		{
-			resp.groupRoomName.clear();
-		}
 		TheGameSpyPeerMessageQueue->addResponse(resp);
 #ifdef SERVER_DEBUGGING
 		CheckServers(peer);

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
@@ -2232,7 +2232,7 @@ static void listGroupRoomsCallback(PEER peer, PEERBool success,
 		}
 		else
 		{
-			resp.groupRoomName.empty();
+			resp.groupRoomName.clear();
 		}
 		TheGameSpyPeerMessageQueue->addResponse(resp);
 #ifdef SERVER_DEBUGGING


### PR DESCRIPTION
EDIT: Calling `std::string::empty` and then discarding the result has to be a bug. Clearing a `std::string` is done using `clear` not `empty`.