### PR TITLE
[GEN][ZH] Fix array new / scalar delete mismatches in GameEngine, GameEngineDevice

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLoginMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLoginMenu.cpp
@@ -130,7 +130,7 @@ static AsciiString obfuscate( AsciiString in )
 			c++, c2++;
 	}
 	AsciiString out = buf;
-	delete buf;
+	delete[] buf;
 	return out;
 }
 
@@ -1467,7 +1467,7 @@ WindowMsgHandledType WOLLoginMenuSystem( GameWindow *window, UnsignedInt msg,
 
 							}
 
-							delete fileBuf;
+							delete[] fileBuf;
 							fileBuf = NULL;
 
 							theFile->close();

--- a/Generals/Code/GameEngine/Source/GameNetwork/GameSpy/Thread/ThreadUtils.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/GameSpy/Thread/ThreadUtils.cpp
@@ -58,7 +58,7 @@ std::wstring MultiByteToWideCharSingleLine( const char *orig )
 
 	dest[len] = 0;
 	std::wstring ret = dest;
-	delete dest;
+	delete[] dest;
 	return ret;
 }
 
@@ -72,7 +72,7 @@ std::string WideCharStringToMultiByte( const WideChar *orig )
 		WideCharToMultiByte( CP_UTF8, 0, orig, -1, dest, len, NULL, NULL );
 		dest[len-1] = 0;
 		ret = dest;
-		delete dest;
+		delete[] dest;
 	}
 	return ret;
 }

--- a/Generals/Code/GameEngine/Source/GameNetwork/NetPacket.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/NetPacket.cpp
@@ -224,7 +224,7 @@ NetPacketList NetPacket::ConstructBigCommandPacketList(NetCommandRef *ref) {
 	wrapperMsg->detach();
 	wrapperMsg = NULL;
 
-	delete bigPacketData;
+	delete[] bigPacketData;
 	bigPacketData = NULL;
 
 	return packetList;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLoginMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLoginMenu.cpp
@@ -130,7 +130,7 @@ static AsciiString obfuscate( AsciiString in )
 			c++, c2++;
 	}
 	AsciiString out = buf;
-	delete buf;
+	delete[] buf;
 	return out;
 }
 
@@ -1467,7 +1467,7 @@ WindowMsgHandledType WOLLoginMenuSystem( GameWindow *window, UnsignedInt msg,
 
 							}
 
-							delete fileBuf;
+							delete[] fileBuf;
 							fileBuf = NULL;
 
 							theFile->close();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Terrain/TerrainVisual.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Terrain/TerrainVisual.cpp
@@ -164,7 +164,7 @@ SeismicSimulationFilterBase::SeismicSimStatusCode DomeStyleSeismicFilter::filter
     Int centerY = node->m_center.y + border ;
 
     UnsignedInt workspaceWidth = radius*2;
-    Real *workspace = NEW( Real[ sqr(workspaceWidth) ] );
+    Real *workspace = NEW Real[ sqr(workspaceWidth) ];
     Real *workspaceEnd = workspace + sqr(workspaceWidth);
 
 

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameSpy/Thread/ThreadUtils.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameSpy/Thread/ThreadUtils.cpp
@@ -58,7 +58,7 @@ std::wstring MultiByteToWideCharSingleLine( const char *orig )
 
 	dest[len] = 0;
 	std::wstring ret = dest;
-	delete dest;
+	delete[] dest;
 	return ret;
 }
 
@@ -72,7 +72,7 @@ std::string WideCharStringToMultiByte( const WideChar *orig )
 		WideCharToMultiByte( CP_UTF8, 0, orig, -1, dest, len, NULL, NULL );
 		dest[len-1] = 0;
 		ret = dest;
-		delete dest;
+		delete[] dest;
 	}
 	return ret;
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/NetPacket.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/NetPacket.cpp
@@ -224,7 +224,7 @@ NetPacketList NetPacket::ConstructBigCommandPacketList(NetCommandRef *ref) {
 	wrapperMsg->detach();
 	wrapperMsg = NULL;
 
-	delete bigPacketData;
+	delete[] bigPacketData;
 	bigPacketData = NULL;
 
 	return packetList;

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DTerrainBackground.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DTerrainBackground.cpp
@@ -562,7 +562,7 @@ void W3DTerrainBackground::doTesselatedUpdate(const IRegion2D &partialRange, Wor
 	DX8IndexBufferClass::WriteLockClass lockIdxBuffer(m_indexTerrain);
 	ib = lockIdxBuffer.Get_Index_Array();
 	fillVBRecursive(ib, 0, 0, m_width, ndx, m_curNumTerrainIndices);
-	delete ndx;
+	delete[] ndx;
 	ndx = NULL;
 
 	MinMaxAABoxClass bounds;

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DTerrainVisual.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DTerrainVisual.cpp
@@ -95,7 +95,7 @@ class TestSeismicFilter : public SeismicSimulationFilterBase
       Int centerY = node->m_center.y + border ;
   
       UnsignedInt workspaceWidth = radius*2;
-      Real *workspace = NEW( Real[ sqr(workspaceWidth) ] );
+      Real *workspace = NEW Real[ sqr(workspaceWidth) ];
       Real *workspaceEnd = workspace + sqr(workspaceWidth);
 
 


### PR DESCRIPTION
Fixes some mismatches where `delete[]` would need to be used instead of `delete`, and a single case where `new( ... )` was used instead of `new ...`.