### PR TITLE
[ZH] Fix mistakenly ignored test in comma-separated expression in FlightDeckBehavior::buildInfo()

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/FlightDeckBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/FlightDeckBehavior.cpp
@@ -195,7 +195,7 @@ void FlightDeckBehavior::buildInfo(Bool createUnits)
 			std::vector<AsciiString>::const_iterator it;
 
 			Int counter = 0; 
-			for( it = spaces.begin(); it != spaces.end(), counter < row;	it++, counter++ )
+			for( it = spaces.begin(); it != spaces.end() && counter < row; it++, counter++ )
 			{
 				//just iterate to the spaces.
 			}


### PR DESCRIPTION
`it != spaces.end(), counter < row;`
Only the second expression is evaluated with the comma operator. This would allow the loop to continue after the iterator has reached the end iterator.

MSVC says
```
GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Behavior\FlightDeckBehavior.cpp(198): warning C6319: Use of the comma-operator in a tested expression causes the left argument to be ignored when it has no side-effects.
GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Behavior\FlightDeckBehavior.cpp(198): warning C6031: Return value ignored: 'std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<AsciiString> > >::=='.
```