### PR TITLE
[GEN][ZH] Fix incorrect size argument for memset

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/System/FileSystem.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/FileSystem.cpp
@@ -224,7 +224,7 @@ Bool FileSystem::getFileInfo(const AsciiString& filename, FileInfo *fileInfo) co
 	if (fileInfo == NULL) {
 		return FALSE;
 	}
-	memset(fileInfo, 0, sizeof(fileInfo));
+	memset(fileInfo, 0, sizeof(*fileInfo));
 	
 	if (TheLocalFileSystem->getFileInfo(filename, fileInfo)) {
 		return TRUE;

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/FileSystem.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/FileSystem.cpp
@@ -236,7 +236,7 @@ Bool FileSystem::getFileInfo(const AsciiString& filename, FileInfo *fileInfo) co
 	if (fileInfo == NULL) {
 		return FALSE;
 	}
-	memset(fileInfo, 0, sizeof(fileInfo));
+	memset(fileInfo, 0, sizeof(*fileInfo));
 	
 	if (TheLocalFileSystem->getFileInfo(filename, fileInfo)) {
 		return TRUE;


### PR DESCRIPTION
The original code uses the size of the pointer instead of the type or dereferenced pointer.