### PR TITLE
[GEN][ZH] Fix incorrect grid resolution update condition in WaterRenderObjClass::setGridResolution()

### DIFF
--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
@@ -2609,7 +2609,7 @@ void WaterRenderObjClass::setGridResolution(Real gridCellsX, Real gridCellsY, Re
 	m_gridCellSize=cellSize;
 
 	if (m_gridCellsX != gridCellsX || m_gridCellsY != gridCellsY)
-	{	//resolutoin has changed
+	{	//resolution has changed
 		m_gridCellsX=gridCellsX;
 		m_gridCellsY=gridCellsY;
 

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
@@ -2608,7 +2608,7 @@ void WaterRenderObjClass::setGridResolution(Real gridCellsX, Real gridCellsY, Re
 {
 	m_gridCellSize=cellSize;
 
-	if (m_gridCellsX != gridCellsX || m_gridCellsY != m_gridCellsY)
+	if (m_gridCellsX != gridCellsX || m_gridCellsY != gridCellsY)
 	{	//resolutoin has changed
 		m_gridCellsX=gridCellsX;
 		m_gridCellsY=gridCellsY;

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
@@ -2631,7 +2631,7 @@ void WaterRenderObjClass::setGridResolution(Real gridCellsX, Real gridCellsY, Re
 {
 	m_gridCellSize=cellSize;
 
-	if (m_gridCellsX != gridCellsX || m_gridCellsY != m_gridCellsY)
+	if (m_gridCellsX != gridCellsX || m_gridCellsY != gridCellsY)
 	{	//resolutoin has changed
 		m_gridCellsX=gridCellsX;
 		m_gridCellsY=gridCellsY;

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
@@ -2632,7 +2632,7 @@ void WaterRenderObjClass::setGridResolution(Real gridCellsX, Real gridCellsY, Re
 	m_gridCellSize=cellSize;
 
 	if (m_gridCellsX != gridCellsX || m_gridCellsY != gridCellsY)
-	{	//resolutoin has changed
+	{	//resolution has changed
 		m_gridCellsX=gridCellsX;
 		m_gridCellsY=gridCellsY;
 


### PR DESCRIPTION
Fixes a typo where the same variable was used for a comparison:
`(m_gridCellsX != gridCellsX || m_gridCellsY != m_gridCellsY)` instead of the function parameter: `gridCellsY`.