### PR TITLE
[GEN][ZH] Add parentheses around bit operations in locoSetMatches()

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/RTS/Team.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/Team.cpp
@@ -165,7 +165,7 @@ void TeamRelationMap::loadPostProcess( void )
 // STATIC FUNCTIONS ///////////////////////////////////////////////////////////
 static Bool locoSetMatches(LocomotorSurfaceTypeMask lstm, UnsignedInt surfaceBitFlags)
 {
-	surfaceBitFlags = surfaceBitFlags & 0x01 | ((surfaceBitFlags & 0x02) << 2);
+	surfaceBitFlags = (surfaceBitFlags & 0x01) | ((surfaceBitFlags & 0x02) << 2);
 	return (surfaceBitFlags & lstm) != 0;
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Team.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Team.cpp
@@ -165,7 +165,7 @@ void TeamRelationMap::loadPostProcess( void )
 // STATIC FUNCTIONS ///////////////////////////////////////////////////////////
 static Bool locoSetMatches(LocomotorSurfaceTypeMask lstm, UnsignedInt surfaceBitFlags)
 {
-	surfaceBitFlags = surfaceBitFlags & 0x01 | ((surfaceBitFlags & 0x02) << 2);
+	surfaceBitFlags = (surfaceBitFlags & 0x01) | ((surfaceBitFlags & 0x02) << 2);
 	return (surfaceBitFlags & lstm) != 0;
 }
 


### PR DESCRIPTION
Operator precedence for bit operations can be unexpected, so it'd be best to wrap them in parentheses.