### PR TITLE
[GEN][ZH] Set correct size for array parameter in BezierSegment function declaration

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/BezierSegment.h
+++ b/Generals/Code/GameEngine/Include/Common/BezierSegment.h
@@ -49,7 +49,7 @@ class BezierSegment
 									Real x2, Real y2, Real z2,
 									Real x3, Real y3, Real z3);
 
-		BezierSegment(Real cp[16]);
+		BezierSegment(Real cp[12]);
 
 
 		BezierSegment(const Coord3D& cp0, 

--- a/GeneralsMD/Code/GameEngine/Include/Common/BezierSegment.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/BezierSegment.h
@@ -49,7 +49,7 @@ class BezierSegment
 									Real x2, Real y2, Real z2,
 									Real x3, Real y3, Real z3);
 
-		BezierSegment(Real cp[16]);
+		BezierSegment(Real cp[12]);
 
 
 		BezierSegment(const Coord3D& cp0, 


### PR DESCRIPTION
Function declaration and definition are inconsistent:
`BezierSegment(Real cp[16]);` and `BezierSegment(Real cp[12]);`

The function only uses 12, so that should be correct one of the two options:
https://github.com/TheSuperHackers/GeneralsGameCode/blob/9c20c27be58463a755b8c67a50f1fdf146a33b68/Generals/Code/GameEngine/Source/Common/Bezier/BezierSegment.cpp#L62-L79