### PR TITLE
[GEN][ZH] Fix compiler warnings about missing return values for non-void functions

### DIFF
--- a/Core/Libraries/Source/WWVegas/WWAudio/WWAudio.h
+++ b/Core/Libraries/Source/WWVegas/WWAudio/WWAudio.h
@@ -386,7 +386,7 @@ public:
 	// Note:  The cache sizes are in kilo-bytes.  The default
 	// is currently set to 1MB.
 	//
-	void				Set_Cache_Size (int kbytes = DEF_CACHE_SIZE)	{ m_MaxCacheSize = (kbytes * 1024); }
+	void					Set_Cache_Size (int kbytes = DEF_CACHE_SIZE)	{ m_MaxCacheSize = (kbytes * 1024); }
 	int					Get_Cache_Size (void) const						{ return m_MaxCacheSize / 1024; }
 	int					Get_Current_Cache_Size (void) const				{ return m_CurrentCacheSize; }
 

--- a/Core/Libraries/Source/WWVegas/WWAudio/WWAudio.h
+++ b/Core/Libraries/Source/WWVegas/WWAudio/WWAudio.h
@@ -386,7 +386,7 @@ public:
 	// Note:  The cache sizes are in kilo-bytes.  The default
 	// is currently set to 1MB.
 	//
-	bool					Set_Cache_Size (int kbytes = DEF_CACHE_SIZE)	{ m_MaxCacheSize = (kbytes * 1024); }
+	void				Set_Cache_Size (int kbytes = DEF_CACHE_SIZE)	{ m_MaxCacheSize = (kbytes * 1024); }
 	int					Get_Cache_Size (void) const						{ return m_MaxCacheSize / 1024; }
 	int					Get_Current_Cache_Size (void) const				{ return m_CurrentCacheSize; }
 

--- a/Core/Libraries/Source/WWVegas/WWLib/always.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/always.h
@@ -47,6 +47,8 @@
 #include <Utility/compat.h>
 #include <Utility/stdint_adapter.h>
 
+#include <Utility/CppMacros.h>
+
 // Disable warning about exception handling not being enabled. It's used as part of STL - in a part of STL we don't use.
 #pragma warning(disable : 4530)
 

--- a/Core/Libraries/Source/profile/internal.h
+++ b/Core/Libraries/Source/profile/internal.h
@@ -37,6 +37,7 @@
 #include "internal_highlevel.h"
 #include "internal_cmd.h"
 #include "internal_result.h"
+#include "Utility/CppMacros.h"
 
 #if !(defined(_MSC_VER) && _MSC_VER < 1300)
 #include <atomic>

--- a/Core/Libraries/Source/profile/internal.h
+++ b/Core/Libraries/Source/profile/internal.h
@@ -46,7 +46,7 @@
 class ProfileFastCS
 {
   ProfileFastCS(const ProfileFastCS&);
-  ProfileFastCS& operator=(const ProfileFastCS&) {};
+  ProfileFastCS& operator=(const ProfileFastCS&) { return *this; }
   
 	static HANDLE testEvent;
 
@@ -111,7 +111,7 @@ public:
 	class Lock
 	{
     Lock(const Lock&);
-	Lock& operator=(const Lock&) {};
+	Lock& operator=(const Lock&) { return *this; }
 
 		ProfileFastCS& CriticalSection;
 

--- a/Core/Libraries/Source/profile/internal.h
+++ b/Core/Libraries/Source/profile/internal.h
@@ -46,8 +46,8 @@
 
 class ProfileFastCS
 {
-  ProfileFastCS(const ProfileFastCS&);
-  ProfileFastCS& operator=(const ProfileFastCS&) { return *this; }
+  ProfileFastCS(const ProfileFastCS&) CPP_11(= delete);
+  ProfileFastCS& operator=(const ProfileFastCS&) CPP_11(= delete);
   
 	static HANDLE testEvent;
 
@@ -111,8 +111,8 @@ public:
 
 	class Lock
 	{
-    Lock(const Lock&);
-	Lock& operator=(const Lock&) { return *this; }
+    Lock(const Lock&) CPP_11(= delete);
+	Lock& operator=(const Lock&) CPP_11(= delete);
 
 		ProfileFastCS& CriticalSection;
 

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/meshmdl.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/meshmdl.h
@@ -135,7 +135,7 @@ class GapFillerClass : public W3DMPO
 	ShaderClass* ShaderArray[MeshMatDescClass::MAX_PASSES];
 	MeshModelClass* mmc;
 
-	GapFillerClass& operator = (const GapFillerClass & that) {}
+	GapFillerClass& operator = (const GapFillerClass&) { return *this; }
 public:
 	GapFillerClass(MeshModelClass* mmc);
 	GapFillerClass(const GapFillerClass& that);

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/meshmdl.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/meshmdl.h
@@ -135,7 +135,7 @@ class GapFillerClass : public W3DMPO
 	ShaderClass* ShaderArray[MeshMatDescClass::MAX_PASSES];
 	MeshModelClass* mmc;
 
-	GapFillerClass& operator = (const GapFillerClass&) { return *this; }
+	GapFillerClass& operator = (const GapFillerClass&) CPP_11(= delete);
 public:
 	GapFillerClass(MeshModelClass* mmc);
 	GapFillerClass(const GapFillerClass& that);

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmdl.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmdl.h
@@ -135,7 +135,7 @@ class GapFillerClass : public W3DMPO
 	ShaderClass* ShaderArray[MeshMatDescClass::MAX_PASSES];
 	MeshModelClass* mmc;
 
-	GapFillerClass& operator = (const GapFillerClass & that) {}
+	GapFillerClass& operator = (const GapFillerClass&) { return *this; }
 public:
 	GapFillerClass(MeshModelClass* mmc);
 	GapFillerClass(const GapFillerClass& that);

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmdl.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmdl.h
@@ -135,7 +135,7 @@ class GapFillerClass : public W3DMPO
 	ShaderClass* ShaderArray[MeshMatDescClass::MAX_PASSES];
 	MeshModelClass* mmc;
 
-	GapFillerClass& operator = (const GapFillerClass&) { return *this; }
+	GapFillerClass& operator = (const GapFillerClass&) CPP_11(= delete);
 public:
 	GapFillerClass(MeshModelClass* mmc);
 	GapFillerClass(const GapFillerClass& that);


### PR DESCRIPTION
A few functions or operators that are missing a valid return statement which generates compiler warnings. 

The operators seem to have been made private in an attempt to achieve the same as C++11 `= delete`, so they shouldn't need to actually copy anything.