### PR TITLE
[GEN][ZH] Fix compiler warnings for redundant parentheses in if statement

### DIFF
--- a/Generals/Code/GameEngine/Include/GameNetwork/WOLBrowser/FEBDispatch.h
+++ b/Generals/Code/GameEngine/Include/GameNetwork/WOLBrowser/FEBDispatch.h
@@ -82,7 +82,7 @@ public:
 			}
 		}
 		
-		if ( (m_dispatch == NULL) )
+		if ( m_dispatch == NULL )
 		{
 			DEBUG_LOG(("Error creating Dispatch for Web interface\n"));
 		}

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/Gadget/GadgetTabControl.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/Gadget/GadgetTabControl.cpp
@@ -302,7 +302,7 @@ void GadgetTabControlCreateSubPanes( GameWindow *tabControl )///< Create User Wi
 
 	for( Int paneIndex = 0; paneIndex < NUM_TAB_PANES; paneIndex++ )
 	{
-		if( (tabData->subPanes[paneIndex] == NULL) )//This one is blank
+		if( tabData->subPanes[paneIndex] == NULL )//This one is blank
 		{
 			tabData->subPanes[paneIndex] = TheWindowManager->winCreate( tabControl,
 																																	WIN_STATUS_NONE, x, y,

--- a/Generals/Code/GameEngine/Source/GameClient/GameText.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GameText.cpp
@@ -323,7 +323,7 @@ void GameTextManager::init( void )
 		return;
 	}
 
-	if( (m_textCount == 0) )
+	if( m_textCount == 0 )
 	{
 		return;
 	}

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -4287,7 +4287,7 @@ Locomotor* Pathfinder::chooseBestLocomotorForPosition(PathfindLayerEnum layer, L
 	if (t == PathfindCell::CELL_RUBBLE) {
 		return LOCOMOTORSURFACE_RUBBLE | LOCOMOTORSURFACE_AIR;
 	}
-	if ( (t == PathfindCell::CELL_CLIFF) ) {
+	if ( t == PathfindCell::CELL_CLIFF ) {
 		return LOCOMOTORSURFACE_CLIFF | LOCOMOTORSURFACE_AIR;
 	}
 	return NO_SURFACES;

--- a/Generals/Code/GameEngine/Source/GameNetwork/Network.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/Network.cpp
@@ -710,7 +710,7 @@ void Network::update( void )
 
 	liteupdate();
 
-	if ((m_localStatus == NETLOCALSTATUS_LEFT)) {// || (m_localStatus == NETLOCALSTATUS_LEAVING)) {
+	if (m_localStatus == NETLOCALSTATUS_LEFT) {// || (m_localStatus == NETLOCALSTATUS_LEAVING)) {
 		endOfGameCheck();
 	}
 

--- a/GeneralsMD/Code/GameEngine/Include/GameNetwork/WOLBrowser/FEBDispatch.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameNetwork/WOLBrowser/FEBDispatch.h
@@ -82,7 +82,7 @@ public:
 			}
 		}
 		
-		if ( (m_dispatch == NULL) )
+		if ( m_dispatch == NULL )
 		{
 			DEBUG_LOG(("Error creating Dispatch for Web interface\n"));
 		}

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/Gadget/GadgetTabControl.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/Gadget/GadgetTabControl.cpp
@@ -302,7 +302,7 @@ void GadgetTabControlCreateSubPanes( GameWindow *tabControl )///< Create User Wi
 
 	for( Int paneIndex = 0; paneIndex < NUM_TAB_PANES; paneIndex++ )
 	{
-		if( (tabData->subPanes[paneIndex] == NULL) )//This one is blank
+		if( tabData->subPanes[paneIndex] == NULL )//This one is blank
 		{
 			tabData->subPanes[paneIndex] = TheWindowManager->winCreate( tabControl,
 																																	WIN_STATUS_NONE, x, y,

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GameText.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GameText.cpp
@@ -323,7 +323,7 @@ void GameTextManager::init( void )
 		return;
 	}
 
-	if( (m_textCount == 0) )
+	if( m_textCount == 0 )
 	{
 		return;
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -4778,7 +4778,7 @@ Locomotor* Pathfinder::chooseBestLocomotorForPosition(PathfindLayerEnum layer, L
 	if (t == PathfindCell::CELL_RUBBLE) {
 		return LOCOMOTORSURFACE_RUBBLE | LOCOMOTORSURFACE_AIR;
 	}
-	if ( (t == PathfindCell::CELL_CLIFF) ) {
+	if ( t == PathfindCell::CELL_CLIFF ) {
 		return LOCOMOTORSURFACE_CLIFF | LOCOMOTORSURFACE_AIR;
 	}
 	return NO_SURFACES;

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/Network.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/Network.cpp
@@ -710,7 +710,7 @@ void Network::update( void )
 
 	liteupdate();
 
-	if ((m_localStatus == NETLOCALSTATUS_LEFT)) {// || (m_localStatus == NETLOCALSTATUS_LEAVING)) {
+	if (m_localStatus == NETLOCALSTATUS_LEFT) {// || (m_localStatus == NETLOCALSTATUS_LEAVING)) {
 		endOfGameCheck();
 	}
 


### PR DESCRIPTION
If statements such as `if( (m_textCount == 0) )` generate a compiler warning for redundant parentheses.