### PR TITLE
[CORE] Remove unused variables in assignment operators of Vector3Randomizer classes

### DIFF
--- a/Core/Libraries/Source/WWVegas/WWLib/always.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/always.h
@@ -47,6 +47,8 @@
 #include <Utility/compat.h>
 #include <Utility/stdint_adapter.h>
 
+#include <Utility/CppMacros.h>
+
 // Disable warning about exception handling not being enabled. It's used as part of STL - in a part of STL we don't use.
 #pragma warning(disable : 4530)
 

--- a/Core/Libraries/Source/WWVegas/WWMath/v3_rnd.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/v3_rnd.h
@@ -129,7 +129,7 @@ class Vector3SolidBoxRandomizer : public Vector3Randomizer {
 	private:
 
 		// Derived classes should have a private dummy assignment operator to block usage
-		Vector3SolidBoxRandomizer & operator = (const Vector3SolidBoxRandomizer &that) { that; return *this; }
+		Vector3SolidBoxRandomizer & operator = (const Vector3SolidBoxRandomizer&) { return *this; }
 
 		Vector3	Extents;
 };
@@ -160,7 +160,7 @@ class Vector3SolidSphereRandomizer : public Vector3Randomizer {
 	private:
 
 		// Derived classes should have a private dummy assignment operator to block usage
-		Vector3SolidSphereRandomizer & operator = (const Vector3SolidSphereRandomizer &that) { that; return *this; }
+		Vector3SolidSphereRandomizer & operator = (const Vector3SolidSphereRandomizer&) { return *this; }
 
 		float	Radius;
 };
@@ -191,7 +191,7 @@ class Vector3HollowSphereRandomizer : public Vector3Randomizer {
 	private:
 
 		// Derived classes should have a private dummy assignment operator to block usage
-		Vector3HollowSphereRandomizer & operator = (const Vector3HollowSphereRandomizer &that) { that; return *this; }
+		Vector3HollowSphereRandomizer & operator = (const Vector3HollowSphereRandomizer&) { return *this; }
 
 		float	Radius;
 };
@@ -223,7 +223,7 @@ class Vector3SolidCylinderRandomizer : public Vector3Randomizer {
 	private:
 
 		// Derived classes should have a private dummy assignment operator to block usage
-		Vector3SolidCylinderRandomizer & operator = (const Vector3SolidCylinderRandomizer &that) { that; return *this; }
+		Vector3SolidCylinderRandomizer & operator = (const Vector3SolidCylinderRandomizer&) { return *this; }
 
 		float	Extent;
 		float	Radius;

--- a/Core/Libraries/Source/WWVegas/WWMath/v3_rnd.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/v3_rnd.h
@@ -129,7 +129,7 @@ class Vector3SolidBoxRandomizer : public Vector3Randomizer {
 	private:
 
 		// Derived classes should have a private dummy assignment operator to block usage
-		Vector3SolidBoxRandomizer & operator = (const Vector3SolidBoxRandomizer&) { return *this; }
+		Vector3SolidBoxRandomizer& operator = (const Vector3SolidBoxRandomizer&) CPP_11(= delete);
 
 		Vector3	Extents;
 };
@@ -160,7 +160,7 @@ class Vector3SolidSphereRandomizer : public Vector3Randomizer {
 	private:
 
 		// Derived classes should have a private dummy assignment operator to block usage
-		Vector3SolidSphereRandomizer & operator = (const Vector3SolidSphereRandomizer&) { return *this; }
+		Vector3SolidSphereRandomizer & operator = (const Vector3SolidSphereRandomizer&) CPP_11(= delete);
 
 		float	Radius;
 };
@@ -191,7 +191,7 @@ class Vector3HollowSphereRandomizer : public Vector3Randomizer {
 	private:
 
 		// Derived classes should have a private dummy assignment operator to block usage
-		Vector3HollowSphereRandomizer & operator = (const Vector3HollowSphereRandomizer&) { return *this; }
+		Vector3HollowSphereRandomizer & operator = (const Vector3HollowSphereRandomizer&) CPP_11(= delete);
 
 		float	Radius;
 };
@@ -223,7 +223,7 @@ class Vector3SolidCylinderRandomizer : public Vector3Randomizer {
 	private:
 
 		// Derived classes should have a private dummy assignment operator to block usage
-		Vector3SolidCylinderRandomizer & operator = (const Vector3SolidCylinderRandomizer&) { return *this; }
+		Vector3SolidCylinderRandomizer & operator = (const Vector3SolidCylinderRandomizer&) CPP_11(= delete);
 
 		float	Extent;
 		float	Radius;

--- a/Core/Libraries/Source/WWVegas/WWMath/v3_rnd.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/v3_rnd.h
@@ -129,7 +129,7 @@ class Vector3SolidBoxRandomizer : public Vector3Randomizer {
 	private:
 
 		// Derived classes should have a private dummy assignment operator to block usage
-		Vector3SolidBoxRandomizer& operator = (const Vector3SolidBoxRandomizer&) CPP_11(= delete);
+		Vector3SolidBoxRandomizer & operator = (const Vector3SolidBoxRandomizer&) CPP_11(= delete);
 
 		Vector3	Extents;
 };


### PR DESCRIPTION
The compiler generates two warnings for the following line as `that` is unused twice:
`Vector3SolidBoxRandomizer & operator = (const Vector3SolidBoxRandomizer &that) { that; return *this; }`

Because these are dummy operators (imitating `= delete`) they shouldn't need to copy anything.