### PR TITLE
[GEN][ZH] Fix crash in AIUpdateInterface::privateMoveAwayFromUnit() when a delayed AICommandParms relates to a then deleted object

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -2564,6 +2564,9 @@ Bool AIUpdateInterface::isAllowedToRespondToAiCommands(const AICommandParms* par
 //-------------------------------------------------------------------------------------------------
 void AIUpdateInterface::aiDoCommand(const AICommandParms* parms)
 {
+	// TheSuperHackers @info The AiCommandParms for m_obj, m_otherObj and m_team should be null tested before use.
+	// These variables could relate to a deleted object when a pending command is reconstituted.
+
 	if (!isAllowedToRespondToAiCommands(parms))
 		return;
 
@@ -3074,6 +3077,12 @@ void AIUpdateInterface::privateMoveAwayFromUnit( Object *unit, CommandSourceType
 	{
 		return;
 	}
+
+	// TheSuperHacker @bugfix Mauller 26/05/2025 Fix dereferencing a nullptr when a delayed ai command refers to a deleted object.
+	// This can occur when a hacker is told to move away from an object when in its hacking state and is transitioning to a movement state.
+	if (!unit)
+		return;
+
 	ObjectID id = unit->getID();
 	if (m_stateMachine->getTemporaryState() == AI_MOVE_OUT_OF_THE_WAY) {
 		if (m_moveOutOfWay1 == id) {

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -2625,6 +2625,9 @@ Bool AIUpdateInterface::isAllowedToRespondToAiCommands(const AICommandParms* par
 //-------------------------------------------------------------------------------------------------
 void AIUpdateInterface::aiDoCommand(const AICommandParms* parms)
 {
+	// TheSuperHackers @info The AiCommandParms for m_obj, m_otherObj and m_team should be null tested before use.
+	// These variables could relate to a deleted object when a pending command is reconstituted.
+
 	if (!isAllowedToRespondToAiCommands(parms))
 		return;
 
@@ -3215,6 +3218,12 @@ void AIUpdateInterface::privateMoveAwayFromUnit( Object *unit, CommandSourceType
 	{
 		return;
 	}
+
+	// TheSuperHacker @bugfix Mauller 26/05/2025 Fix dereferencing a nullptr when a delayed ai command refers to a deleted object.
+	// This can occur when a hacker is told to move away from an object when in its hacking state and is transitioning to a movement state.
+	if (!unit)
+		return;
+
 	ObjectID id = unit->getID();
 	if (m_stateMachine->getTemporaryState() == AI_MOVE_OUT_OF_THE_WAY) {
 		if (m_moveOutOfWay1 == id) {


### PR DESCRIPTION
- Resolves: #924 

The Issue contains a full list of my workings and findings on for this particular bug.


The problem stems from a race condition in which a pending AI command on an object can end up containing the ID of an object that has already been destroyed.

Many of the private action commands in ```aiupdate.cpp``` already have checks for null pointers in them. Or the object is passed internally into another function that checks for a null pointer.
But the ```privateMoveAwayFrom()``` function did not have a check, this was the cause of the crash in the attached replay in the issue. 

~~I also added a check in the ```privateguardObject()``` function as this also lacked any protection from a null pointer dereference on the passed object.~~

The AI commands are generic and not all fields are populated, so the most sensible place for this fix is within the affected functions themselves.
