### PR TITLE
[GEN][ZH] Implement fake CRC for Generals CD 1.08, Zero Hour CD 1.04 executable compatibility

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/crc.h
+++ b/Generals/Code/GameEngine/Include/Common/crc.h
@@ -47,6 +47,13 @@ public:
 //	UnsignedInt get( void ) { return htonl(crc); }	///< Get the combined CRC
 	UnsignedInt get( void );
 
+#if (defined(_MSC_VER) && _MSC_VER < 1300)
+  void set( UnsignedInt v )
+  {
+    crc = v;
+  }
+#endif
+
 private:
 	void addCRC( UnsignedByte val );									///< CRC a 4-byte block
 
@@ -119,6 +126,13 @@ public:
   {
     return crc;
   }
+
+#if (defined(_MSC_VER) && _MSC_VER < 1300)
+  void set( UnsignedInt v )
+  {
+    crc = v;
+  }
+#endif
 
 private:
 	UnsignedInt crc;

--- a/Generals/Code/GameEngine/Include/Common/crc.h
+++ b/Generals/Code/GameEngine/Include/Common/crc.h
@@ -47,7 +47,7 @@ public:
 //	UnsignedInt get( void ) { return htonl(crc); }	///< Get the combined CRC
 	UnsignedInt get( void );
 
-#if (defined(_MSC_VER) && _MSC_VER < 1300)
+#if (defined(_MSC_VER) && _MSC_VER < 1300) && defined(RETAIL_COMPATIBLE_CRC)
   void set( UnsignedInt v )
   {
     crc = v;
@@ -127,7 +127,7 @@ public:
     return crc;
   }
 
-#if (defined(_MSC_VER) && _MSC_VER < 1300)
+#if (defined(_MSC_VER) && _MSC_VER < 1300) && defined(RETAIL_COMPATIBLE_CRC)
   void set( UnsignedInt v )
   {
     crc = v;

--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -988,7 +988,7 @@ GlobalData::GlobalData()
 	const Int blockSize = 65536;
 	CRC exeCRC;
 	File *fp;
-	// TheSuperHackers @tweak 27/05/2025 SkyAero/xezon
+	// TheSuperHackers @tweak SkyAero/xezon 27/05/2025
 	// Simulate the EXE's CRC value to force Network and Replay compatibility with another build.
 #if (defined(_MSC_VER) && _MSC_VER < 1300)
 

--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -990,7 +990,7 @@ GlobalData::GlobalData()
 	File *fp;
 	// TheSuperHackers @tweak SkyAero/xezon 27/05/2025
 	// Simulate the EXE's CRC value to force Network and Replay compatibility with another build.
-#if (defined(_MSC_VER) && _MSC_VER < 1300)
+#if (defined(_MSC_VER) && _MSC_VER < 1300) && defined(RETAIL_COMPATIBLE_CRC)
 
 #define GENERALS_108_CD_EXE_CRC    0x93d1eab4
 #define GENERALS_108_STEAM_EXE_CRC 0x8d6e4dd7

--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -986,23 +986,42 @@ GlobalData::GlobalData()
 	
 	// lets CRC the executable!  Whee!
 	const Int blockSize = 65536;
-	Char buffer[ _MAX_PATH ];
 	CRC exeCRC;
-	GetModuleFileName( NULL, buffer, sizeof( buffer ) );
-	File *fp = TheFileSystem->openFile(buffer, File::READ | File::BINARY);
-	if (fp != NULL) {
-		unsigned char crcBlock[blockSize];
-		Int amtRead = 0;
-		while ( (amtRead=fp->read(crcBlock, blockSize)) > 0 )
-		{
-			exeCRC.computeCRC(crcBlock, amtRead);
+	File *fp;
+	// TheSuperHackers @tweak 27/05/2025 SkyAero/xezon
+	// Simulate the EXE's CRC value to force Network and Replay compatibility with another build.
+#if (defined(_MSC_VER) && _MSC_VER < 1300)
+
+#define GENERALS_108_CD_EXE_CRC    0x93d1eab4
+#define GENERALS_108_STEAM_EXE_CRC 0x8d6e4dd7
+#define GENERALS_108_EAAPP_EXE_CRC 0xb07fbd50
+
+	exeCRC.set(GENERALS_108_CD_EXE_CRC);
+	DEBUG_LOG(("Fake EXE CRC is 0x%8.8X\n", exeCRC.get()));
+
+#else
+	{
+		Char buffer[ _MAX_PATH ];
+		GetModuleFileName( NULL, buffer, sizeof( buffer ) );
+		fp = TheFileSystem->openFile(buffer, File::READ | File::BINARY);
+		if (fp != NULL) {
+			unsigned char crcBlock[blockSize];
+			Int amtRead = 0;
+			while ( (amtRead=fp->read(crcBlock, blockSize)) > 0 )
+			{
+				exeCRC.computeCRC(crcBlock, amtRead);
+			}
+			DEBUG_LOG(("EXE CRC is 0x%8.8X\n", exeCRC.get()));
+			fp->close();
+			fp = NULL;
 		}
-		fp->close();
-		fp = NULL;
 	}
+#endif
+
+	UnsignedInt version = 0;
 	if (TheVersion)
 	{
-		UnsignedInt version = TheVersion->getVersionNumber();
+		version = TheVersion->getVersionNumber();
 		exeCRC.computeCRC( &version, sizeof(UnsignedInt) );
 	}
 	// Add in MP scripts to the EXE CRC, since the game will go out of sync if they change
@@ -1030,7 +1049,7 @@ GlobalData::GlobalData()
 	}
 
 	m_exeCRC = exeCRC.get();
-	DEBUG_LOG(("EXE CRC: 0x%8.8X\n", m_exeCRC));
+	DEBUG_LOG(("EXE+Version(%d.%d)+SCB CRC is 0x%8.8X\n", version >> 16, version & 0xffff, m_exeCRC));
 	
 	m_movementPenaltyDamageState = BODY_REALLYDAMAGED;
 	

--- a/Generals/Code/Main/CMakeLists.txt
+++ b/Generals/Code/Main/CMakeLists.txt
@@ -35,6 +35,16 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/GeneratedVersion.h
 )
 
 # Based on original binary values for these variables.
+if (IS_VS6_BUILD)
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/BuildVersion.h
+"#pragma once
+
+#define VERSION_MAJOR 1
+#define VERSION_MINOR 7
+#define VERSION_BUILDNUM 601
+"
+)
+else()
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/BuildVersion.h
 "#pragma once
 
@@ -43,6 +53,7 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/BuildVersion.h
 #define VERSION_BUILDNUM 601
 "
 )
+endif()
 
 target_link_options(g_generals PRIVATE "/NODEFAULTLIB:libci.lib")
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/crc.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/crc.h
@@ -47,6 +47,13 @@ public:
 //	UnsignedInt get( void ) { return htonl(crc); }	///< Get the combined CRC
 	UnsignedInt get( void );
 
+#if (defined(_MSC_VER) && _MSC_VER < 1300)
+  void set( UnsignedInt v )
+  {
+    crc = v;
+  }
+#endif
+
 private:
 	void addCRC( UnsignedByte val );									///< CRC a 4-byte block
 
@@ -119,6 +126,13 @@ public:
   {
     return crc;
   }
+
+#if (defined(_MSC_VER) && _MSC_VER < 1300)
+  void set( UnsignedInt v )
+  {
+    crc = v;
+  }
+#endif
 
 private:
 	UnsignedInt crc;

--- a/GeneralsMD/Code/GameEngine/Include/Common/crc.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/crc.h
@@ -47,7 +47,7 @@ public:
 //	UnsignedInt get( void ) { return htonl(crc); }	///< Get the combined CRC
 	UnsignedInt get( void );
 
-#if (defined(_MSC_VER) && _MSC_VER < 1300)
+#if (defined(_MSC_VER) && _MSC_VER < 1300) && defined(RETAIL_COMPATIBLE_CRC)
   void set( UnsignedInt v )
   {
     crc = v;
@@ -127,7 +127,7 @@ public:
     return crc;
   }
 
-#if (defined(_MSC_VER) && _MSC_VER < 1300)
+#if (defined(_MSC_VER) && _MSC_VER < 1300) && defined(RETAIL_COMPATIBLE_CRC)
   void set( UnsignedInt v )
   {
     crc = v;

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -995,23 +995,42 @@ GlobalData::GlobalData()
 	
 	// lets CRC the executable!  Whee!
 	const Int blockSize = 65536;
-	Char buffer[ _MAX_PATH ];
 	CRC exeCRC;
-	GetModuleFileName( NULL, buffer, sizeof( buffer ) );
-	File *fp = TheFileSystem->openFile(buffer, File::READ | File::BINARY);
-	if (fp != NULL) {
-		unsigned char crcBlock[blockSize];
-		Int amtRead = 0;
-		while ( (amtRead=fp->read(crcBlock, blockSize)) > 0 )
-		{
-			exeCRC.computeCRC(crcBlock, amtRead);
+	File *fp;
+	// TheSuperHackers @tweak 27/05/2025 SkyAero/xezon
+	// Simulate the EXE's CRC value to force Network and Replay compatibility with another build.
+#if (defined(_MSC_VER) && _MSC_VER < 1300)   && 0 // NOT
+
+#define GENERALSMD_104_CD_EXE_CRC    0x4f6c5afe
+#define GENERALSMD_104_STEAM_EXE_CRC 0xcb430f5f
+#define GENERALSMD_104_EAAPP_EXE_CRC 0x488d90f9
+
+	exeCRC.set(GENERALSMD_104_CD_EXE_CRC);
+	DEBUG_LOG(("Fake EXE CRC is 0x%8.8X\n", exeCRC.get()));
+
+#else
+	{
+		Char buffer[ _MAX_PATH ];
+		GetModuleFileName( NULL, buffer, sizeof( buffer ) );
+		fp = TheFileSystem->openFile(buffer, File::READ | File::BINARY);
+		if (fp != NULL) {
+			unsigned char crcBlock[blockSize];
+			Int amtRead = 0;
+			while ( (amtRead=fp->read(crcBlock, blockSize)) > 0 )
+			{
+				exeCRC.computeCRC(crcBlock, amtRead);
+			}
+			DEBUG_LOG(("EXE CRC is 0x%8.8X\n", exeCRC.get()));
+			fp->close();
+			fp = NULL;
 		}
-		fp->close();
-		fp = NULL;
 	}
+#endif
+
+	UnsignedInt version = 0;
 	if (TheVersion)
 	{
-		UnsignedInt version = TheVersion->getVersionNumber();
+		version = TheVersion->getVersionNumber();
 		exeCRC.computeCRC( &version, sizeof(UnsignedInt) );
 	}
 	// Add in MP scripts to the EXE CRC, since the game will go out of sync if they change
@@ -1039,7 +1058,7 @@ GlobalData::GlobalData()
 	}
 
 	m_exeCRC = exeCRC.get();
-	DEBUG_LOG(("EXE CRC: 0x%8.8X\n", m_exeCRC));
+	DEBUG_LOG(("EXE+Version(%d.%d)+SCB CRC is 0x%8.8X\n", version >> 16, version & 0xffff, m_exeCRC));
 	
 	m_movementPenaltyDamageState = BODY_REALLYDAMAGED;
 	

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -997,9 +997,9 @@ GlobalData::GlobalData()
 	const Int blockSize = 65536;
 	CRC exeCRC;
 	File *fp;
-	// TheSuperHackers @tweak 27/05/2025 SkyAero/xezon
+	// TheSuperHackers @tweak SkyAero/xezon 27/05/2025
 	// Simulate the EXE's CRC value to force Network and Replay compatibility with another build.
-#if (defined(_MSC_VER) && _MSC_VER < 1300)   && 0 // NOT
+#if (defined(_MSC_VER) && _MSC_VER < 1300)
 
 #define GENERALSMD_104_CD_EXE_CRC    0x4f6c5afe
 #define GENERALSMD_104_STEAM_EXE_CRC 0xcb430f5f

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -999,7 +999,7 @@ GlobalData::GlobalData()
 	File *fp;
 	// TheSuperHackers @tweak SkyAero/xezon 27/05/2025
 	// Simulate the EXE's CRC value to force Network and Replay compatibility with another build.
-#if (defined(_MSC_VER) && _MSC_VER < 1300)
+#if (defined(_MSC_VER) && _MSC_VER < 1300) && defined(RETAIL_COMPATIBLE_CRC)
 
 #define GENERALSMD_104_CD_EXE_CRC    0x4f6c5afe
 #define GENERALSMD_104_STEAM_EXE_CRC 0xcb430f5f


### PR DESCRIPTION
* Merge after #874
* Resolves #525
* Closes #852
* Relates to #981

This change implements fake exe CRC for Generals CD 1.08 and Zero Hour CD 1.04 and allows VC6 builds to matchmake with retail builds in the Network Lobby and Online Lobby. It also suppresses version mismatch warnings in the Replay Load menu when loading compatible replays.

| Game | Is CRC compatible to | Is CRC compatible with this project (VC6 build) |
|----------------------|------------|-----|
| Generals CD 1.08     | CD 1.08    | Yes |
| Generals TFD 1.08    | CD 1.08    | Yes |
| Generals Steam 1.08  | Steam 1.08 | No  |
| Generals EAApp 1.08  | EAApp 1.08 | No  |
| Zero Hour CD 1.04    | CD 1.04    | Yes |
| Zero Hour TFD 1.04   | CD 1.04    | Yes |
| Zero Hour Steam 1.04 | CD 1.04    | Yes |
| Zero Hour EAApp 1.04 | CD 1.04    | Yes |
