### PR TITLE
[GEN][ZH] Fix crash when exiting Replay playback while a player places a beacon

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/Recorder.h
+++ b/Generals/Code/GameEngine/Include/Common/Recorder.h
@@ -137,7 +137,13 @@ protected:
 	void writeArgument(GameMessageArgumentDataType type, const GameMessageArgumentType arg);
 	void readArgument(GameMessageArgumentDataType type, GameMessage *msg);
 
-	void cullBadCommands();														///< prevent the user from giving mouse commands that he shouldn't be able to do during playback.
+	struct CullBadCommandsResult
+	{
+		CullBadCommandsResult() : hasClearGameDataMessage(false) {}
+		Bool hasClearGameDataMessage;
+	};
+
+	CullBadCommandsResult cullBadCommands(); ///< prevent the user from giving mouse commands that he shouldn't be able to do during playback.
 
 	FILE *m_file;
 	AsciiString m_fileName;

--- a/Generals/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Recorder.cpp
@@ -1527,8 +1527,7 @@ RecorderClass::CullBadCommandsResult RecorderClass::cullBadCommands() {
 
 			deleteInstance(msg);
 		}
-
-		if (msg->getType() == GameMessage::MSG_CLEAR_GAME_DATA)
+		else if (msg->getType() == GameMessage::MSG_CLEAR_GAME_DATA)
 		{
 			result.hasClearGameDataMessage = true;
 		}

--- a/Generals/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Recorder.cpp
@@ -439,8 +439,17 @@ void RecorderClass::update() {
  * Do the update for the next frame of this playback.
  */
 void RecorderClass::updatePlayback() {
-	cullBadCommands();	// Remove any bad commands that have been inserted by the local user that shouldn't be
-											// executed during playback.
+	// Remove any bad commands that have been inserted by the local user that shouldn't be
+	// executed during playback.
+	CullBadCommandsResult result = cullBadCommands();
+
+	if (result.hasClearGameDataMessage) {
+		// TheSuperHackers @bugfix Stop appending more commands if the replay playback is about to end.
+		// Previously this would be able to append more commands, which could have unintended consequences,
+		// such as crashing the game when a MSG_PLACE_BEACON is appended after MSG_CLEAR_GAME_DATA.
+		// MSG_CLEAR_GAME_DATA is supposed to be processed later this frame, which will then stop this playback.
+		return;
+	}
 
 	if (m_nextFrame == -1) {
 		// This is reached if there are no more commands to be executed.
@@ -1501,9 +1510,11 @@ void RecorderClass::readArgument(GameMessageArgumentDataType type, GameMessage *
 /**
  * This needs to be called for every frame during playback. Basically it prevents the user from inserting.
  */
-void RecorderClass::cullBadCommands() {
+RecorderClass::CullBadCommandsResult RecorderClass::cullBadCommands() {
+	CullBadCommandsResult result;
+
 	if (m_doingAnalysis)
-		return;
+		return result;
 
 	GameMessage *msg = TheCommandList->getFirstMessage();
 	GameMessage *next = NULL;
@@ -1517,8 +1528,15 @@ void RecorderClass::cullBadCommands() {
 			deleteInstance(msg);
 		}
 
+		if (msg->getType() == GameMessage::MSG_CLEAR_GAME_DATA)
+		{
+			result.hasClearGameDataMessage = true;
+		}
+
 		msg = next;
 	}
+
+	return result;
 }
 
 /**

--- a/GeneralsMD/Code/GameEngine/Include/Common/Recorder.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Recorder.h
@@ -137,7 +137,13 @@ protected:
 	void writeArgument(GameMessageArgumentDataType type, const GameMessageArgumentType arg);
 	void readArgument(GameMessageArgumentDataType type, GameMessage *msg);
 
-	void cullBadCommands();														///< prevent the user from giving mouse commands that he shouldn't be able to do during playback.
+	struct CullBadCommandsResult
+	{
+		CullBadCommandsResult() : hasClearGameDataMessage(false) {}
+		Bool hasClearGameDataMessage;
+	};
+
+	CullBadCommandsResult cullBadCommands(); ///< prevent the user from giving mouse commands that he shouldn't be able to do during playback.
 
 	FILE *m_file;
 	AsciiString m_fileName;

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -1530,8 +1530,7 @@ RecorderClass::CullBadCommandsResult RecorderClass::cullBadCommands() {
 
 			deleteInstance(msg);
 		}
-
-		if (msg->getType() == GameMessage::MSG_CLEAR_GAME_DATA)
+		else if (msg->getType() == GameMessage::MSG_CLEAR_GAME_DATA)
 		{
 			result.hasClearGameDataMessage = true;
 		}

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -439,8 +439,17 @@ void RecorderClass::update() {
  * Do the update for the next frame of this playback.
  */
 void RecorderClass::updatePlayback() {
-	cullBadCommands();	// Remove any bad commands that have been inserted by the local user that shouldn't be
-											// executed during playback.
+	// Remove any bad commands that have been inserted by the local user that shouldn't be
+	// executed during playback.
+	CullBadCommandsResult result = cullBadCommands();
+
+	if (result.hasClearGameDataMessage) {
+		// TheSuperHackers @bugfix Stop appending more commands if the replay playback is about to end.
+		// Previously this would be able to append more commands, which could have unintended consequences,
+		// such as crashing the game when a MSG_PLACE_BEACON is appended after MSG_CLEAR_GAME_DATA.
+		// MSG_CLEAR_GAME_DATA is supposed to be processed later this frame, which will then stop this playback.
+		return;
+	}
 
 	if (m_nextFrame == -1) {
 		// This is reached if there are no more commands to be executed.
@@ -1504,9 +1513,11 @@ void RecorderClass::readArgument(GameMessageArgumentDataType type, GameMessage *
 /**
  * This needs to be called for every frame during playback. Basically it prevents the user from inserting.
  */
-void RecorderClass::cullBadCommands() {
+RecorderClass::CullBadCommandsResult RecorderClass::cullBadCommands() {
+	CullBadCommandsResult result;
+
 	if (m_doingAnalysis)
-		return;
+		return result;
 
 	GameMessage *msg = TheCommandList->getFirstMessage();
 	GameMessage *next = NULL;
@@ -1520,8 +1531,15 @@ void RecorderClass::cullBadCommands() {
 			deleteInstance(msg);
 		}
 
+		if (msg->getType() == GameMessage::MSG_CLEAR_GAME_DATA)
+		{
+			result.hasClearGameDataMessage = true;
+		}
+
 		msg = next;
 	}
+
+	return result;
 }
 
 /**


### PR DESCRIPTION
* Merge after #969
* Fixes #76
* Relates to #850

This change fixes a game crash when exiting Replay playback while a player places a beacon.

The null crash does occur in GameLogic::logicMessageDispatcher, but the root cause of the problem already starts earlier.

The `RecorderClass` can still push replay commands to the CommandList before the final `MSG_CLEAR_GAME_DATA` is processed in the same frame. `MSG_CLEAR_GAME_DATA` will destroy the match session.

## Callstack for when MSG_CLEAR_GAME_DATA is processed

```
 	generalszh.exe!GameLogic::reset() Line 453	C++
 	generalszh.exe!SubsystemInterfaceList::resetAll() Line 188	C++
 	[Inline Frame] generalszh.exe!GameLogic::isInMultiplayerGame() Line 418	C++
 	generalszh.exe!GameEngine::reset() Line 699	C++
 	generalszh.exe!GameLogic::clearGameData(bool showScoreScreen) Line 281	C++
 	generalszh.exe!GameLogic::logicMessageDispatcher(GameMessage * msg, void * userData) Line 464	C++
>	generalszh.exe!GameLogic::processCommandList(CommandList * list) Line 2594	C++
 	generalszh.exe!GameLogic::update() Line 3764	C++
 	generalszh.exe!Win32GameEngine::update() Line 93	C++
 	generalszh.exe!GameEngine::execute() Line 819	C++
 	generalszh.exe!GameMain(int argc, char * * argv) Line 47	C++
 	generalszh.exe!WinMain(HINSTANCE__ * hInstance, HINSTANCE__ * hPrevInstance, char * lpCmdLine, int nCmdShow) Line 988	C++
 	[Inline Frame] generalszh.exe!invoke_main() Line 102	C++
 	generalszh.exe!__scrt_common_main_seh() Line 288	C++
 	kernel32.dll!764cfcc9()	Unknown
 	[Frames below may be incorrect and/or missing, no symbols loaded for kernel32.dll]	
 	ntdll.dll!77ca82ae()	Unknown
 	ntdll.dll!77ca827e()	Unknown
```

## Code for when MSG_PLACE_BEACON is appended, MSG_CLEAR_GAME_DATA is processed

```cpp
void GameLogic::update( void )
{
...
  // Update the Recorder
  {
    TheRecorder->UPDATE(); // <--- Pushes MSG_PLACE_BEACON in the last frame
  }

  // process client commands
  {
    processCommandList( TheCommandList ); // <--- Processes MSG_CLEAR_GAME_DATA, calls GameLogic::reset() which deletes all things, then processes MSG_PLACE_BEACON, then crashes the game
  }
...
}
```

## Solution

Stop appending Replay commands after MSG_CLEAR_GAME_DATA command was appended.