### PR TITLE
[GEN][ZH] Fix crash when exiting Replay playback while a player places a beacon (2)

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -1577,7 +1577,8 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 		// --------------------------------------------------------------------------------------------
 		case GameMessage::MSG_PLACE_BEACON:
 		{
-			// how many does this player have active?
+			if (thisPlayer->getPlayerTemplate() == NULL)
+				break;
 			Coord3D pos = msg->getArgument( 0 )->location;
 			Region3D r;
 			TheTerrainLogic->getExtent(&r);
@@ -1586,6 +1587,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			const ThingTemplate *thing = TheThingFactory->findTemplate( thisPlayer->getPlayerTemplate()->getBeaconTemplate() );
 			if (thing && !TheVictoryConditions->hasSinglePlayerBeenDefeated(thisPlayer))
 			{
+				// how many does this player have active?
 				Int count;
 				thisPlayer->countObjectsByThingTemplate( 1, &thing, false, &count );
 				DEBUG_LOG(("Player already has %d beacons active\n", count));

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -1605,7 +1605,8 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 		// --------------------------------------------------------------------------------------------
 		case GameMessage::MSG_PLACE_BEACON:
 		{
-			// how many does this player have active?
+			if (thisPlayer->getPlayerTemplate() == NULL)
+				break;
 			Coord3D pos = msg->getArgument( 0 )->location;
 			Region3D r;
 			TheTerrainLogic->getExtent(&r);
@@ -1614,6 +1615,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			const ThingTemplate *thing = TheThingFactory->findTemplate( thisPlayer->getPlayerTemplate()->getBeaconTemplate() );
 			if (thing && !TheVictoryConditions->hasSinglePlayerBeenDefeated(thisPlayer))
 			{
+				// how many does this player have active?
 				Int count;
 				thisPlayer->countObjectsByThingTemplate( 1, &thing, false, &count );
 				DEBUG_LOG(("Player already has %d beacons active\n", count));


### PR DESCRIPTION
* Merge after #969
* Fixes #76
* Relates to #850
* Relates to #971

This change fixes a game crash when exiting a Replay playback while a player places a beacon.

This change is not strictly necessary with #971, but it looks reasonable here to always test NULL, for robustness. Other code places also test `getPlayerTemplate()`.
