### PR TITLE
[GEN][ZH] Add null pointer tests in AIUpdateInterface::privateCommandButtonObject(), privateGuardObject()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -3881,6 +3881,9 @@ void AIUpdateInterface::privateGuardTunnelNetwork( GuardMode guardMode, CommandS
  */
 void AIUpdateInterface::privateGuardObject( Object *objectToGuard, GuardMode guardMode, CommandSourceType cmdSource )
 {
+	if (!objectToGuard)
+		return;
+
 	if (getObject()->isMobile() == FALSE)
 		return;
 
@@ -4657,10 +4660,8 @@ void AIUpdateInterface::privateCommandButtonPosition( const CommandButton *comma
 // ------------------------------------------------------------------------------------------------
 void AIUpdateInterface::privateCommandButtonObject( const CommandButton *commandButton, Object *obj, CommandSourceType cmdSource )
 {
-	if( !commandButton )
-	{
+	if( !commandButton || !obj )
 		return;
-	}
 
 	if (getObject()->isKindOf(KINDOF_PROJECTILE))
 		return;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -4100,6 +4100,9 @@ void AIUpdateInterface::privateGuardTunnelNetwork( GuardMode guardMode, CommandS
  */
 void AIUpdateInterface::privateGuardObject( Object *objectToGuard, GuardMode guardMode, CommandSourceType cmdSource )
 {
+	if (!objectToGuard)
+		return;
+
 	if (getObject()->isMobile() == FALSE)
 		return;
 
@@ -4936,10 +4939,8 @@ void AIUpdateInterface::privateCommandButtonPosition( const CommandButton *comma
 // ------------------------------------------------------------------------------------------------
 void AIUpdateInterface::privateCommandButtonObject( const CommandButton *commandButton, Object *obj, CommandSourceType cmdSource )
 {
-	if( !commandButton )
-	{
+	if( !commandButton || !obj )
 		return;
-	}
 
 	if (getObject()->isKindOf(KINDOF_PROJECTILE))
 		return;


### PR DESCRIPTION
- Merge After: #964

This PR is a followup Pr from the Hackers delayed ai command crash PR. It adds null pointer checks to two other functions that were observed as missing them. These functions did not cause any known crashes in the game, but it is safer to add the checks.