### PR TITLE
[CMAKE] Fix Core GameEngine include directories

### DIFF
--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -1,13 +1,15 @@
-# c stands for core, i stands for Interface
+# i stands for Interface
+add_library(corei_gameengine_include INTERFACE)
+add_library(corei_gameenginedevice_include INTERFACE)
 add_library(corei_libraries_include INTERFACE)
 add_library(corei_libraries_source_wwvegas INTERFACE)
-add_library(corei_libraries_source_wwvegas_wwdebug INTERFACE)
 add_library(corei_libraries_source_wwvegas_wwlib INTERFACE)
 add_library(corei_always INTERFACE)
 
+target_include_directories(corei_gameengine_include INTERFACE "GameEngine/Include")
+target_include_directories(corei_gameenginedevice_include INTERFACE "GameEngineDevice/Source")
 target_include_directories(corei_libraries_include INTERFACE "Libraries/Include")
 target_include_directories(corei_libraries_source_wwvegas INTERFACE "Libraries/Source/WWVegas")
-target_include_directories(corei_libraries_source_wwvegas_wwdebug INTERFACE "Libraries/Source/WWVegas/WWDebug")
 target_include_directories(corei_libraries_source_wwvegas_wwlib INTERFACE "Libraries/Source/WWVegas/WWLib")
 target_link_libraries(corei_always INTERFACE
     core_utility

--- a/Core/Libraries/Source/WWVegas/CMakeLists.txt
+++ b/Core/Libraries/Source/WWVegas/CMakeLists.txt
@@ -9,6 +9,7 @@ target_compile_definitions(core_wwcommon INTERFACE
 target_link_libraries(core_wwcommon INTERFACE
     core_config
     core_utility
+    corei_gameengine_include
     d3d8lib
     milesstub
     stlport

--- a/Dependencies/Utility/CMakeLists.txt
+++ b/Dependencies/Utility/CMakeLists.txt
@@ -1,3 +1,5 @@
 add_library(core_utility INTERFACE)
 
-target_include_directories(core_utility INTERFACE ".")
+target_include_directories(core_utility INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/Generals/Code/CMakeLists.txt
+++ b/Generals/Code/CMakeLists.txt
@@ -1,23 +1,15 @@
 # g stands for Generals, i stands for Interface
-add_library(gi_gameengine INTERFACE)
 add_library(gi_gameengine_include INTERFACE)
 add_library(gi_gameenginedevice_include INTERFACE)
 add_library(gi_libraries_include INTERFACE)
 add_library(gi_libraries_source_wwvegas INTERFACE)
-add_library(gi_libraries_source_wwvegas_ww3d2 INTERFACE)
-add_library(gi_libraries_source_wwvegas_wwmath INTERFACE)
-add_library(gi_libraries_source_wwvegas_wwsaveload INTERFACE)
 add_library(gi_main INTERFACE)
 add_library(gi_always INTERFACE)
 
-target_include_directories(gi_gameengine INTERFACE "GameEngine")
 target_include_directories(gi_gameengine_include INTERFACE "GameEngine/Include")
 target_include_directories(gi_gameenginedevice_include INTERFACE "GameEngineDevice/Source")
 target_include_directories(gi_libraries_include INTERFACE "Libraries/Include")
 target_include_directories(gi_libraries_source_wwvegas INTERFACE "Libraries/Source/WWVegas")
-target_include_directories(gi_libraries_source_wwvegas_ww3d2 INTERFACE "Libraries/Source/WWVegas/WW3D2")
-target_include_directories(gi_libraries_source_wwvegas_wwmath INTERFACE "Libraries/Source/WWVegas/WWMath")
-target_include_directories(gi_libraries_source_wwvegas_wwsaveload INTERFACE "Libraries/Source/WWVegas/WWSaveLoad")
 target_include_directories(gi_main INTERFACE "Main")
 
 target_compile_definitions(gi_always INTERFACE

--- a/Generals/Code/Libraries/Source/WWVegas/WWDownload/CMakeLists.txt
+++ b/Generals/Code/Libraries/Source/WWVegas/WWDownload/CMakeLists.txt
@@ -3,6 +3,7 @@ set_target_properties(g_wwdownload PROPERTIES OUTPUT_NAME wwdownload)
 
 target_link_libraries(g_wwdownload PRIVATE
     corei_wwdownload
+    corei_gameengine_include
     gi_always
     gi_gameengine_include
 )

--- a/Generals/Code/Tools/ParticleEditor/CMakeLists.txt
+++ b/Generals/Code/Tools/ParticleEditor/CMakeLists.txt
@@ -39,6 +39,7 @@ target_include_directories(g_particleeditor PRIVATE
 target_compile_definitions(g_particleeditor PRIVATE _AFXDLL)
 
 target_link_libraries(g_particleeditor PRIVATE
+    corei_gameengine_include
     corei_libraries_source_wwvegas
     corei_libraries_source_wwvegas_wwlib
     d3d8lib

--- a/Generals/Code/Tools/W3DView/CMakeLists.txt
+++ b/Generals/Code/Tools/W3DView/CMakeLists.txt
@@ -4,6 +4,7 @@ target_link_libraries(g_w3dview PRIVATE
     core_config
     core_utility
     core_wwstub # avoid linking GameEngine
+    corei_gameengine_include
     corei_w3dview # this interface gets the source files for the tool
     d3d8
     d3d8lib

--- a/Generals/Code/Tools/WorldBuilder/CMakeLists.txt
+++ b/Generals/Code/Tools/WorldBuilder/CMakeLists.txt
@@ -208,6 +208,8 @@ target_link_libraries(g_worldbuilder PRIVATE
     d3d8lib
     dbghelplib
     core_browserdispatch
+    corei_gameengine_include
+    corei_gameenginedevice_include
     g_gameengine
     g_gameenginedevice
     gi_gameengine_include

--- a/GeneralsMD/Code/CMakeLists.txt
+++ b/GeneralsMD/Code/CMakeLists.txt
@@ -1,23 +1,15 @@
 # z stands for Zero Hour, i stands for Interface
-add_library(zi_gameengine INTERFACE)
 add_library(zi_gameengine_include INTERFACE)
 add_library(zi_gameenginedevice_include INTERFACE)
 add_library(zi_libraries_include INTERFACE)
 add_library(zi_libraries_source_wwvegas INTERFACE)
-add_library(zi_libraries_source_wwvegas_ww3d2 INTERFACE)
-add_library(zi_libraries_source_wwvegas_wwmath INTERFACE)
-add_library(zi_libraries_source_wwvegas_wwsaveload INTERFACE)
 add_library(zi_main INTERFACE)
 add_library(zi_always INTERFACE)
 
-target_include_directories(zi_gameengine INTERFACE "GameEngine")
 target_include_directories(zi_gameengine_include INTERFACE "GameEngine/Include")
 target_include_directories(zi_gameenginedevice_include INTERFACE "GameEngineDevice/Source")
 target_include_directories(zi_libraries_include INTERFACE "Libraries/Include")
 target_include_directories(zi_libraries_source_wwvegas INTERFACE "Libraries/Source/WWVegas")
-target_include_directories(zi_libraries_source_wwvegas_ww3d2 INTERFACE "Libraries/Source/WWVegas/WW3D2")
-target_include_directories(zi_libraries_source_wwvegas_wwmath INTERFACE "Libraries/Source/WWVegas/WWMath")
-target_include_directories(zi_libraries_source_wwvegas_wwsaveload INTERFACE "Libraries/Source/WWVegas/WWSaveLoad")
 target_include_directories(zi_main INTERFACE "Main")
 
 target_compile_definitions(zi_always INTERFACE

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWDownload/CMakeLists.txt
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWDownload/CMakeLists.txt
@@ -3,6 +3,7 @@ set_target_properties(z_wwdownload PROPERTIES OUTPUT_NAME wwdownload)
 
 target_link_libraries(z_wwdownload PRIVATE
     corei_wwdownload
+    corei_gameengine_include
     zi_always
     zi_gameengine_include
 )

--- a/GeneralsMD/Code/Tools/ParticleEditor/CMakeLists.txt
+++ b/GeneralsMD/Code/Tools/ParticleEditor/CMakeLists.txt
@@ -39,6 +39,7 @@ target_include_directories(z_particleeditor PRIVATE
 target_link_libraries(z_particleeditor PRIVATE
     core_debug
     core_profile
+    corei_gameengine_include
     corei_libraries_source_wwvegas
     corei_libraries_source_wwvegas_wwlib
     d3d8lib

--- a/GeneralsMD/Code/Tools/W3DView/CMakeLists.txt
+++ b/GeneralsMD/Code/Tools/W3DView/CMakeLists.txt
@@ -4,6 +4,7 @@ target_link_libraries(z_w3dview PRIVATE
     core_config
     core_utility
     core_wwstub # avoid linking GameEngine
+    corei_gameengine_include
     corei_w3dview # this interface gets the source files for the tool
     d3d8
     d3d8lib

--- a/GeneralsMD/Code/Tools/WorldBuilder/CMakeLists.txt
+++ b/GeneralsMD/Code/Tools/WorldBuilder/CMakeLists.txt
@@ -212,6 +212,8 @@ target_include_directories(z_worldbuilder PRIVATE
 target_link_libraries(z_worldbuilder PRIVATE
     core_debug
     core_profile
+    corei_gameengine_include
+    corei_gameenginedevice_include
     d3d8lib
     dbghelplib
     imm32


### PR DESCRIPTION
Various libraries were not able to see files in `Core/GameEngine/include`. This fixes that.

I also removed a couple unused INTERFACE libraries.

Side note: I have no clue how some of the libraries see files in `GeneralsMD/Code/GameEngine/include`. For example `core_wwmath`. If someone can explain to me how this magic works, that would be great.
