### PR TITLE
[GEN][ZH] Decouple the Game Logic update in ParticleUplinkCannonUpdate from the Orbit To Ground Laser drawable

### DIFF
--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -1,13 +1,15 @@
-# c stands for core, i stands for Interface
+# i stands for Interface
+add_library(corei_gameengine_include INTERFACE)
+add_library(corei_gameenginedevice_include INTERFACE)
 add_library(corei_libraries_include INTERFACE)
 add_library(corei_libraries_source_wwvegas INTERFACE)
-add_library(corei_libraries_source_wwvegas_wwdebug INTERFACE)
 add_library(corei_libraries_source_wwvegas_wwlib INTERFACE)
 add_library(corei_always INTERFACE)
 
+target_include_directories(corei_gameengine_include INTERFACE "GameEngine/Include")
+target_include_directories(corei_gameenginedevice_include INTERFACE "GameEngineDevice/Source")
 target_include_directories(corei_libraries_include INTERFACE "Libraries/Include")
 target_include_directories(corei_libraries_source_wwvegas INTERFACE "Libraries/Source/WWVegas")
-target_include_directories(corei_libraries_source_wwvegas_wwdebug INTERFACE "Libraries/Source/WWVegas/WWDebug")
 target_include_directories(corei_libraries_source_wwvegas_wwlib INTERFACE "Libraries/Source/WWVegas/WWLib")
 target_link_libraries(corei_always INTERFACE
     core_utility

--- a/Core/Libraries/Source/WWVegas/CMakeLists.txt
+++ b/Core/Libraries/Source/WWVegas/CMakeLists.txt
@@ -9,6 +9,7 @@ target_compile_definitions(core_wwcommon INTERFACE
 target_link_libraries(core_wwcommon INTERFACE
     core_config
     core_utility
+    corei_gameengine_include
     d3d8lib
     milesstub
     stlport

--- a/Dependencies/Utility/CMakeLists.txt
+++ b/Dependencies/Utility/CMakeLists.txt
@@ -1,3 +1,5 @@
 add_library(core_utility INTERFACE)
 
-target_include_directories(core_utility INTERFACE ".")
+target_include_directories(core_utility INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/Generals/Code/CMakeLists.txt
+++ b/Generals/Code/CMakeLists.txt
@@ -1,23 +1,15 @@
 # g stands for Generals, i stands for Interface
-add_library(gi_gameengine INTERFACE)
 add_library(gi_gameengine_include INTERFACE)
 add_library(gi_gameenginedevice_include INTERFACE)
 add_library(gi_libraries_include INTERFACE)
 add_library(gi_libraries_source_wwvegas INTERFACE)
-add_library(gi_libraries_source_wwvegas_ww3d2 INTERFACE)
-add_library(gi_libraries_source_wwvegas_wwmath INTERFACE)
-add_library(gi_libraries_source_wwvegas_wwsaveload INTERFACE)
 add_library(gi_main INTERFACE)
 add_library(gi_always INTERFACE)
 
-target_include_directories(gi_gameengine INTERFACE "GameEngine")
 target_include_directories(gi_gameengine_include INTERFACE "GameEngine/Include")
 target_include_directories(gi_gameenginedevice_include INTERFACE "GameEngineDevice/Source")
 target_include_directories(gi_libraries_include INTERFACE "Libraries/Include")
 target_include_directories(gi_libraries_source_wwvegas INTERFACE "Libraries/Source/WWVegas")
-target_include_directories(gi_libraries_source_wwvegas_ww3d2 INTERFACE "Libraries/Source/WWVegas/WW3D2")
-target_include_directories(gi_libraries_source_wwvegas_wwmath INTERFACE "Libraries/Source/WWVegas/WWMath")
-target_include_directories(gi_libraries_source_wwvegas_wwsaveload INTERFACE "Libraries/Source/WWVegas/WWSaveLoad")
 target_include_directories(gi_main INTERFACE "Main")
 
 target_compile_definitions(gi_always INTERFACE

--- a/Generals/Code/GameEngine/Include/Common/Debug.h
+++ b/Generals/Code/GameEngine/Include/Common/Debug.h
@@ -48,6 +48,8 @@
 #ifndef __DEBUG_H_
 #define __DEBUG_H_
 
+#include "Common/GameDefines.h"
+
 class AsciiString;
 
 #if defined(RTS_DEBUG) && defined(RTS_INTERNAL)
@@ -212,6 +214,15 @@ class AsciiString;
 //	#define RELEASE_CRASH(m)				do { ReleaseCrash(m); } while (0)
 
 #endif
+
+#if defined(RETAIL_COMPATIBLE_CRC)
+	#define DEBUG_CRASH_RETAIL_COMPATIBLE_CRC(c, m) DEBUG_CRASH(m)
+	#define DEBUG_ASSERTCRASH_RETAIL_COMPATIBLE_CRC(c, m) DEBUG_ASSERTCRASH(c, m)
+#else
+	#define DEBUG_CRASH_RETAIL_COMPATIBLE_CRC(c, m) ((void)0)
+	#define DEBUG_ASSERTCRASH_RETAIL_COMPATIBLE_CRC(c, m) ((void)0)
+#endif
+
 
 DEBUG_EXTERN_C void ReleaseCrash(const char* reason);
 DEBUG_EXTERN_C void ReleaseCrashLocalized(const AsciiString& p, const AsciiString& m);

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
@@ -211,7 +211,7 @@ void ParticleUplinkCannonUpdate::killEverything()
 	removeAllEffects();
 
 	//This laser is independent from the other effects and needs to be specially handled.
-	if( m_orbitToTargetBeamID )
+	if( m_orbitToTargetBeamID != INVALID_DRAWABLE_ID )
 	{
 		Drawable *beam = TheGameClient->findDrawableByID( m_orbitToTargetBeamID );
 		if( beam )
@@ -219,8 +219,8 @@ void ParticleUplinkCannonUpdate::killEverything()
 			TheGameClient->destroyDrawable( beam );
 		}
 		m_orbitToTargetBeamID = INVALID_DRAWABLE_ID;
-		m_orbitToTargetLaserRadius = LaserRadiusUpdate();
 	}
+	m_orbitToTargetLaserRadius = LaserRadiusUpdate();
 
 	TheAudio->removeAudioEvent( m_powerupSound.getPlayingHandle() );
 	TheAudio->removeAudioEvent( m_unpackToReadySound.getPlayingHandle() );
@@ -410,40 +410,43 @@ UpdateSleepTime ParticleUplinkCannonUpdate::update()
 				break;
 			case LASERSTATUS_BORN:
 			{
-				Drawable *beam = TheGameClient->findDrawableByID( m_orbitToTargetBeamID );
-				if( beam )
+				if( orbitalDecayStart <= now )
 				{
-					//m_annihilationSound.setPosition( beam->getPosition() );
-					if( orbitalDecayStart <= now )
+					Drawable *beam = TheGameClient->findDrawableByID( m_orbitToTargetBeamID );
+					if( beam )
 					{
+						//m_annihilationSound.setPosition( beam->getPosition() );
 						static NameKeyType nameKeyClientUpdate = NAMEKEY( "LaserUpdate" );
 						LaserUpdate *update = (LaserUpdate*)beam->findClientUpdateModule( nameKeyClientUpdate );
 						if( update )
 						{
 							update->setDecayFrames( data->m_widthGrowFrames );
-							m_orbitToTargetLaserRadius.setDecayFrames( data->m_widthGrowFrames );
 						}
-						m_laserStatus = LASERSTATUS_DECAYING;
 					}
+					m_orbitToTargetLaserRadius.setDecayFrames( data->m_widthGrowFrames );
+					m_laserStatus = LASERSTATUS_DECAYING;
 				}
 				break;
 			}
 			case LASERSTATUS_DECAYING:
 			{
-				Drawable *beam = TheGameClient->findDrawableByID( m_orbitToTargetBeamID );
-				if( beam )
+				if( orbitalDeathFrame <= now )
 				{
-					//m_annihilationSound.setPosition( beam->getPosition() );
 					TheAudio->removeAudioEvent( m_annihilationSound.getPlayingHandle() );
-					if( orbitalDeathFrame <= now )
+					if ( m_orbitToTargetBeamID != INVALID_DRAWABLE_ID )
 					{
-						TheGameClient->destroyDrawable( beam );
+						Drawable *beam = TheGameClient->findDrawableByID( m_orbitToTargetBeamID );
+						if( beam )
+						{
+							//m_annihilationSound.setPosition( beam->getPosition() );
+							TheGameClient->destroyDrawable( beam );
+						}
 						m_orbitToTargetBeamID = INVALID_DRAWABLE_ID;
-						m_orbitToTargetLaserRadius = LaserRadiusUpdate();
-						m_laserStatus = LASERSTATUS_DEAD;
-						m_startAttackFrame = 0;
-						setLogicalStatus( STATUS_IDLE );
 					}
+					m_orbitToTargetLaserRadius = LaserRadiusUpdate();
+					m_laserStatus = LASERSTATUS_DEAD;
+					m_startAttackFrame = 0;
+					setLogicalStatus( STATUS_IDLE );
 				}
 				break;
 			}
@@ -452,8 +455,7 @@ UpdateSleepTime ParticleUplinkCannonUpdate::update()
 				break;
 		}
 
-		Drawable *beam = TheGameClient->findDrawableByID( m_orbitToTargetBeamID );
-		if( beam && orbitalBirthFrame <= now && now <= orbitalDeathFrame )
+		if( orbitalBirthFrame <= now && now < orbitalDeathFrame )
 		{
 		
 			if( !m_manualTargetMode )
@@ -548,27 +550,33 @@ UpdateSleepTime ParticleUplinkCannonUpdate::update()
 
 			Real scorchRadius = 0.0f;
 			Real damageRadius = 0.0f;
+			Real templateLaserRadius = 13.0f;
+			Real visualLaserRadius = 0.0f;
 
 			//Reset the laser position
-			static NameKeyType nameKeyClientUpdate = NAMEKEY( "LaserUpdate" );
-			LaserUpdate *update = (LaserUpdate*)beam->findClientUpdateModule( nameKeyClientUpdate );
-			if( update )
+			Drawable *beam = TheGameClient->findDrawableByID( m_orbitToTargetBeamID );
+			if ( beam )
 			{
-				update->initLaser( NULL, &orbitPosition, &m_currentTargetPosition );
-				const Real visualLaserRadius = update->getCurrentLaserRadius();
-				scorchRadius = visualLaserRadius * data->m_scorchMarkScalar;
-
-				// TheSuperHackers @refactor helmutbuhler/xezon 17/05/2025
-				// Originally the damage radius was calculated with a value updated by LaserUpdate::clientUpdate().
-				// To no longer rely on client updates, this class now maintains a logical copy of the visual laser radius.
-				m_orbitToTargetLaserRadius.updateRadius();
-				const Real logicalLaserRadius = update->getTemplateLaserRadius() * m_orbitToTargetLaserRadius.getWidthScale();
-				damageRadius = logicalLaserRadius * data->m_damageRadiusScalar;
-#if RETAIL_COMPATIBLE_CRC
-				DEBUG_ASSERTCRASH(logicalLaserRadius == visualLaserRadius,
-					("ParticleUplinkCannonUpdate's laser radius does not match LaserUpdate's laser radius - will cause mismatch in VS6 retail compatible builds\n"));
-#endif
+				static NameKeyType nameKeyClientUpdate = NAMEKEY( "LaserUpdate" );
+				LaserUpdate *update = (LaserUpdate*)beam->findClientUpdateModule( nameKeyClientUpdate );
+				if( update )
+				{
+					update->initLaser( NULL, &orbitPosition, &m_currentTargetPosition );
+					// TheSuperHackers @info The GameLogic has a dependency on this drawable.
+					// @todo The logical laser radius for the damage should probably be part of ParticleUplinkCannonUpdateModuleData.
+					templateLaserRadius = update->getTemplateLaserRadius();
+					visualLaserRadius = update->getCurrentLaserRadius();
+				}
 			}
+			// TheSuperHackers @refactor helmutbuhler/xezon 17/05/2025
+			// Originally the damageRadius was calculated with a value updated by LaserUpdate::clientUpdate.
+			// To no longer rely on GameClient updates, this class now maintains a copy of the LaserRadiusUpdate.
+			m_orbitToTargetLaserRadius.updateRadius();
+			const Real logicalLaserRadius = templateLaserRadius * m_orbitToTargetLaserRadius.getWidthScale();
+			damageRadius = logicalLaserRadius * data->m_damageRadiusScalar;
+			scorchRadius = logicalLaserRadius * data->m_scorchMarkScalar;
+			DEBUG_ASSERTCRASH_RETAIL_COMPATIBLE_CRC(logicalLaserRadius == visualLaserRadius,
+				("ParticleUplinkCannonUpdate's laser radius does not match LaserUpdate's laser radius - will cause mismatch in VS6 retail compatible builds\n"));
 
 			//Create scorch marks periodically
 			if( m_nextScorchMarkFrame <= now )
@@ -917,13 +925,15 @@ void ParticleUplinkCannonUpdate::createOrbitToTargetLaser( UnsignedInt growthFra
 {
 	const ParticleUplinkCannonUpdateModuleData *data = getParticleUplinkCannonUpdateModuleData();
 
-	Drawable *beam = TheGameClient->findDrawableByID( m_orbitToTargetBeamID );
-	if( beam )
+	if ( m_orbitToTargetBeamID != INVALID_DRAWABLE_ID )
 	{
-		TheAudio->removeAudioEvent( m_annihilationSound.getPlayingHandle() );
-		TheGameClient->destroyDrawable( beam );
+		Drawable *beam = TheGameClient->findDrawableByID( m_orbitToTargetBeamID );
+		if( beam )
+		{
+			TheAudio->removeAudioEvent( m_annihilationSound.getPlayingHandle() );
+			TheGameClient->destroyDrawable( beam );
+		}
 		m_orbitToTargetBeamID = INVALID_DRAWABLE_ID;
-		m_orbitToTargetLaserRadius = LaserRadiusUpdate();
 	}
 
 	if( data->m_particleBeamLaserName.isNotEmpty() )
@@ -943,7 +953,6 @@ void ParticleUplinkCannonUpdate::createOrbitToTargetLaser( UnsignedInt growthFra
 					orbitPosition.set( &m_initialTargetPosition );
 					orbitPosition.z += 500.0f;
 					update->initLaser( NULL, &orbitPosition, &m_initialTargetPosition, growthFrames );
-					m_orbitToTargetLaserRadius.initRadius( growthFrames );
 				}
 			}
 		}
@@ -954,6 +963,9 @@ void ParticleUplinkCannonUpdate::createOrbitToTargetLaser( UnsignedInt growthFra
 			m_annihilationSound.setPlayingHandle( TheAudio->addAudioEvent( &m_annihilationSound ) );
 		}
 	}
+
+	m_orbitToTargetLaserRadius = LaserRadiusUpdate();
+	m_orbitToTargetLaserRadius.initRadius( growthFrames );
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/Libraries/Source/WWVegas/WWDownload/CMakeLists.txt
+++ b/Generals/Code/Libraries/Source/WWVegas/WWDownload/CMakeLists.txt
@@ -3,6 +3,7 @@ set_target_properties(g_wwdownload PROPERTIES OUTPUT_NAME wwdownload)
 
 target_link_libraries(g_wwdownload PRIVATE
     corei_wwdownload
+    corei_gameengine_include
     gi_always
     gi_gameengine_include
 )

--- a/Generals/Code/Tools/ParticleEditor/CMakeLists.txt
+++ b/Generals/Code/Tools/ParticleEditor/CMakeLists.txt
@@ -39,6 +39,7 @@ target_include_directories(g_particleeditor PRIVATE
 target_compile_definitions(g_particleeditor PRIVATE _AFXDLL)
 
 target_link_libraries(g_particleeditor PRIVATE
+    corei_gameengine_include
     corei_libraries_source_wwvegas
     corei_libraries_source_wwvegas_wwlib
     d3d8lib

--- a/Generals/Code/Tools/W3DView/CMakeLists.txt
+++ b/Generals/Code/Tools/W3DView/CMakeLists.txt
@@ -4,6 +4,7 @@ target_link_libraries(g_w3dview PRIVATE
     core_config
     core_utility
     core_wwstub # avoid linking GameEngine
+    corei_gameengine_include
     corei_w3dview # this interface gets the source files for the tool
     d3d8
     d3d8lib

--- a/Generals/Code/Tools/WorldBuilder/CMakeLists.txt
+++ b/Generals/Code/Tools/WorldBuilder/CMakeLists.txt
@@ -208,6 +208,8 @@ target_link_libraries(g_worldbuilder PRIVATE
     d3d8lib
     dbghelplib
     core_browserdispatch
+    corei_gameengine_include
+    corei_gameenginedevice_include
     g_gameengine
     g_gameenginedevice
     gi_gameengine_include

--- a/GeneralsMD/Code/CMakeLists.txt
+++ b/GeneralsMD/Code/CMakeLists.txt
@@ -1,23 +1,15 @@
 # z stands for Zero Hour, i stands for Interface
-add_library(zi_gameengine INTERFACE)
 add_library(zi_gameengine_include INTERFACE)
 add_library(zi_gameenginedevice_include INTERFACE)
 add_library(zi_libraries_include INTERFACE)
 add_library(zi_libraries_source_wwvegas INTERFACE)
-add_library(zi_libraries_source_wwvegas_ww3d2 INTERFACE)
-add_library(zi_libraries_source_wwvegas_wwmath INTERFACE)
-add_library(zi_libraries_source_wwvegas_wwsaveload INTERFACE)
 add_library(zi_main INTERFACE)
 add_library(zi_always INTERFACE)
 
-target_include_directories(zi_gameengine INTERFACE "GameEngine")
 target_include_directories(zi_gameengine_include INTERFACE "GameEngine/Include")
 target_include_directories(zi_gameenginedevice_include INTERFACE "GameEngineDevice/Source")
 target_include_directories(zi_libraries_include INTERFACE "Libraries/Include")
 target_include_directories(zi_libraries_source_wwvegas INTERFACE "Libraries/Source/WWVegas")
-target_include_directories(zi_libraries_source_wwvegas_ww3d2 INTERFACE "Libraries/Source/WWVegas/WW3D2")
-target_include_directories(zi_libraries_source_wwvegas_wwmath INTERFACE "Libraries/Source/WWVegas/WWMath")
-target_include_directories(zi_libraries_source_wwvegas_wwsaveload INTERFACE "Libraries/Source/WWVegas/WWSaveLoad")
 target_include_directories(zi_main INTERFACE "Main")
 
 target_compile_definitions(zi_always INTERFACE

--- a/GeneralsMD/Code/GameEngine/Include/Common/Debug.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Debug.h
@@ -48,6 +48,8 @@
 #ifndef __DEBUG_H_
 #define __DEBUG_H_
 
+#include "Common/GameDefines.h"
+
 class AsciiString;
 
 #if defined(RTS_DEBUG) && defined(RTS_INTERNAL)
@@ -218,6 +220,15 @@ class AsciiString;
 //	#define RELEASE_CRASH(m)				do { ReleaseCrash(m); } while (0)
 
 #endif
+
+#if defined(RETAIL_COMPATIBLE_CRC)
+	#define DEBUG_CRASH_RETAIL_COMPATIBLE_CRC(c, m) DEBUG_CRASH(m)
+	#define DEBUG_ASSERTCRASH_RETAIL_COMPATIBLE_CRC(c, m) DEBUG_ASSERTCRASH(c, m)
+#else
+	#define DEBUG_CRASH_RETAIL_COMPATIBLE_CRC(c, m) ((void)0)
+	#define DEBUG_ASSERTCRASH_RETAIL_COMPATIBLE_CRC(c, m) ((void)0)
+#endif
+
 
 DEBUG_EXTERN_C void ReleaseCrash(const char* reason);
 DEBUG_EXTERN_C void ReleaseCrashLocalized(const AsciiString& p, const AsciiString& m);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
@@ -212,7 +212,7 @@ void ParticleUplinkCannonUpdate::killEverything()
 	removeAllEffects();
 
 	//This laser is independent from the other effects and needs to be specially handled.
-	if( m_orbitToTargetBeamID )
+	if( m_orbitToTargetBeamID != INVALID_DRAWABLE_ID )
 	{
 		Drawable *beam = TheGameClient->findDrawableByID( m_orbitToTargetBeamID );
 		if( beam )
@@ -220,8 +220,8 @@ void ParticleUplinkCannonUpdate::killEverything()
 			TheGameClient->destroyDrawable( beam );
 		}
 		m_orbitToTargetBeamID = INVALID_DRAWABLE_ID;
-		m_orbitToTargetLaserRadius = LaserRadiusUpdate();
 	}
+	m_orbitToTargetLaserRadius = LaserRadiusUpdate();
 
 	TheAudio->removeAudioEvent( m_powerupSound.getPlayingHandle() );
 	TheAudio->removeAudioEvent( m_unpackToReadySound.getPlayingHandle() );
@@ -457,40 +457,43 @@ UpdateSleepTime ParticleUplinkCannonUpdate::update()
 				break;
 			case LASERSTATUS_BORN:
 			{
-				Drawable *beam = TheGameClient->findDrawableByID( m_orbitToTargetBeamID );
-				if( beam )
+				if( orbitalDecayStart <= now )
 				{
-					//m_annihilationSound.setPosition( beam->getPosition() );
-					if( orbitalDecayStart <= now )
+					Drawable *beam = TheGameClient->findDrawableByID( m_orbitToTargetBeamID );
+					if( beam )
 					{
+						//m_annihilationSound.setPosition( beam->getPosition() );
 						static NameKeyType nameKeyClientUpdate = NAMEKEY( "LaserUpdate" );
 						LaserUpdate *update = (LaserUpdate*)beam->findClientUpdateModule( nameKeyClientUpdate );
 						if( update )
 						{
 							update->setDecayFrames( data->m_widthGrowFrames );
-							m_orbitToTargetLaserRadius.setDecayFrames( data->m_widthGrowFrames );
 						}
-						m_laserStatus = LASERSTATUS_DECAYING;
 					}
+					m_orbitToTargetLaserRadius.setDecayFrames( data->m_widthGrowFrames );
+					m_laserStatus = LASERSTATUS_DECAYING;
 				}
 				break;
 			}
 			case LASERSTATUS_DECAYING:
 			{
-				Drawable *beam = TheGameClient->findDrawableByID( m_orbitToTargetBeamID );
-				if( beam )
+				if( orbitalDeathFrame <= now )
 				{
-					//m_annihilationSound.setPosition( beam->getPosition() );
 					TheAudio->removeAudioEvent( m_annihilationSound.getPlayingHandle() );
-					if( orbitalDeathFrame <= now )
+					if ( m_orbitToTargetBeamID != INVALID_DRAWABLE_ID )
 					{
-						TheGameClient->destroyDrawable( beam );
+						Drawable *beam = TheGameClient->findDrawableByID( m_orbitToTargetBeamID );
+						if( beam )
+						{
+							//m_annihilationSound.setPosition( beam->getPosition() );
+							TheGameClient->destroyDrawable( beam );
+						}
 						m_orbitToTargetBeamID = INVALID_DRAWABLE_ID;
-						m_orbitToTargetLaserRadius = LaserRadiusUpdate();
-						m_laserStatus = LASERSTATUS_DEAD;
-						m_startAttackFrame = 0;
-						setLogicalStatus( STATUS_IDLE );
 					}
+					m_orbitToTargetLaserRadius = LaserRadiusUpdate();
+					m_laserStatus = LASERSTATUS_DEAD;
+					m_startAttackFrame = 0;
+					setLogicalStatus( STATUS_IDLE );
 				}
 				break;
 			}
@@ -499,8 +502,7 @@ UpdateSleepTime ParticleUplinkCannonUpdate::update()
 				break;
 		}
 
-		Drawable *beam = TheGameClient->findDrawableByID( m_orbitToTargetBeamID );
-		if( beam && orbitalBirthFrame <= now && now <= orbitalDeathFrame )
+		if( orbitalBirthFrame <= now && now < orbitalDeathFrame )
 		{
 		
 			if( !m_manualTargetMode && !m_scriptedWaypointMode )
@@ -609,27 +611,33 @@ UpdateSleepTime ParticleUplinkCannonUpdate::update()
 
 			Real scorchRadius = 0.0f;
 			Real damageRadius = 0.0f;
+			Real templateLaserRadius = 13.0f;
+			Real visualLaserRadius = 0.0f;
 
 			//Reset the laser position
-			static NameKeyType nameKeyClientUpdate = NAMEKEY( "LaserUpdate" );
-			LaserUpdate *update = (LaserUpdate*)beam->findClientUpdateModule( nameKeyClientUpdate );
-			if( update )
+			Drawable *beam = TheGameClient->findDrawableByID( m_orbitToTargetBeamID );
+			if ( beam )
 			{
-				update->initLaser( NULL, NULL, &orbitPosition, &m_currentTargetPosition, "" );
-				const Real visualLaserRadius = update->getCurrentLaserRadius();
-				scorchRadius = visualLaserRadius * data->m_scorchMarkScalar;
-
-				// TheSuperHackers @refactor helmutbuhler/xezon 17/05/2025
-				// Originally the damage radius was calculated with a value updated by LaserUpdate::clientUpdate().
-				// To no longer rely on client updates, this class now maintains a logical copy of the visual laser radius.
-				m_orbitToTargetLaserRadius.updateRadius();
-				const Real logicalLaserRadius = update->getTemplateLaserRadius() * m_orbitToTargetLaserRadius.getWidthScale();
-				damageRadius = logicalLaserRadius * data->m_damageRadiusScalar;
-#if RETAIL_COMPATIBLE_XFER_CRC
-				DEBUG_ASSERTCRASH(logicalLaserRadius == visualLaserRadius,
-					("ParticleUplinkCannonUpdate's laser radius does not match LaserUpdate's laser radius - will cause mismatch in VS6 retail compatible builds\n"));
-#endif
+				static NameKeyType nameKeyClientUpdate = NAMEKEY( "LaserUpdate" );
+				LaserUpdate *update = (LaserUpdate*)beam->findClientUpdateModule( nameKeyClientUpdate );
+				if( update )
+				{
+					update->initLaser( NULL, NULL, &orbitPosition, &m_currentTargetPosition, "" );
+					// TheSuperHackers @info The GameLogic has a dependency on this drawable.
+					// @todo The logical laser radius for the damage should probably be part of ParticleUplinkCannonUpdateModuleData.
+					templateLaserRadius = update->getTemplateLaserRadius();
+					visualLaserRadius = update->getCurrentLaserRadius();
+				}
 			}
+			// TheSuperHackers @refactor helmutbuhler/xezon 17/05/2025
+			// Originally the damageRadius was calculated with a value updated by LaserUpdate::clientUpdate.
+			// To no longer rely on GameClient updates, this class now maintains a copy of the LaserRadiusUpdate.
+			m_orbitToTargetLaserRadius.updateRadius();
+			const Real logicalLaserRadius = templateLaserRadius * m_orbitToTargetLaserRadius.getWidthScale();
+			damageRadius = logicalLaserRadius * data->m_damageRadiusScalar;
+			scorchRadius = logicalLaserRadius * data->m_scorchMarkScalar;
+			DEBUG_ASSERTCRASH_RETAIL_COMPATIBLE_CRC(logicalLaserRadius == visualLaserRadius,
+				("ParticleUplinkCannonUpdate's laser radius does not match LaserUpdate's laser radius - will cause mismatch in VS6 retail compatible builds\n"));
 
 			//Create scorch marks periodically
 			if( m_nextScorchMarkFrame <= now )
@@ -988,13 +996,15 @@ void ParticleUplinkCannonUpdate::createOrbitToTargetLaser( UnsignedInt growthFra
 {
 	const ParticleUplinkCannonUpdateModuleData *data = getParticleUplinkCannonUpdateModuleData();
 
-	Drawable *beam = TheGameClient->findDrawableByID( m_orbitToTargetBeamID );
-	if( beam )
+	if ( m_orbitToTargetBeamID != INVALID_DRAWABLE_ID )
 	{
-		TheAudio->removeAudioEvent( m_annihilationSound.getPlayingHandle() );
-		TheGameClient->destroyDrawable( beam );
+		Drawable *beam = TheGameClient->findDrawableByID( m_orbitToTargetBeamID );
+		if( beam )
+		{
+			TheAudio->removeAudioEvent( m_annihilationSound.getPlayingHandle() );
+			TheGameClient->destroyDrawable( beam );
+		}
 		m_orbitToTargetBeamID = INVALID_DRAWABLE_ID;
-		m_orbitToTargetLaserRadius = LaserRadiusUpdate();
 	}
 
 	if( data->m_particleBeamLaserName.isNotEmpty() )
@@ -1014,7 +1024,6 @@ void ParticleUplinkCannonUpdate::createOrbitToTargetLaser( UnsignedInt growthFra
 					orbitPosition.set( &m_initialTargetPosition );
 					orbitPosition.z += 500.0f;
 					update->initLaser( NULL, NULL, &orbitPosition, &m_initialTargetPosition, "", growthFrames );
-					m_orbitToTargetLaserRadius.initRadius( growthFrames );
 				}
 			}
 		}
@@ -1025,6 +1034,9 @@ void ParticleUplinkCannonUpdate::createOrbitToTargetLaser( UnsignedInt growthFra
 			m_annihilationSound.setPlayingHandle( TheAudio->addAudioEvent( &m_annihilationSound ) );
 		}
 	}
+
+	m_orbitToTargetLaserRadius = LaserRadiusUpdate();
+	m_orbitToTargetLaserRadius.initRadius( growthFrames );
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWDownload/CMakeLists.txt
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWDownload/CMakeLists.txt
@@ -3,6 +3,7 @@ set_target_properties(z_wwdownload PROPERTIES OUTPUT_NAME wwdownload)
 
 target_link_libraries(z_wwdownload PRIVATE
     corei_wwdownload
+    corei_gameengine_include
     zi_always
     zi_gameengine_include
 )

--- a/GeneralsMD/Code/Tools/ParticleEditor/CMakeLists.txt
+++ b/GeneralsMD/Code/Tools/ParticleEditor/CMakeLists.txt
@@ -39,6 +39,7 @@ target_include_directories(z_particleeditor PRIVATE
 target_link_libraries(z_particleeditor PRIVATE
     core_debug
     core_profile
+    corei_gameengine_include
     corei_libraries_source_wwvegas
     corei_libraries_source_wwvegas_wwlib
     d3d8lib

--- a/GeneralsMD/Code/Tools/W3DView/CMakeLists.txt
+++ b/GeneralsMD/Code/Tools/W3DView/CMakeLists.txt
@@ -4,6 +4,7 @@ target_link_libraries(z_w3dview PRIVATE
     core_config
     core_utility
     core_wwstub # avoid linking GameEngine
+    corei_gameengine_include
     corei_w3dview # this interface gets the source files for the tool
     d3d8
     d3d8lib

--- a/GeneralsMD/Code/Tools/WorldBuilder/CMakeLists.txt
+++ b/GeneralsMD/Code/Tools/WorldBuilder/CMakeLists.txt
@@ -212,6 +212,8 @@ target_include_directories(z_worldbuilder PRIVATE
 target_link_libraries(z_worldbuilder PRIVATE
     core_debug
     core_profile
+    corei_gameengine_include
+    corei_gameenginedevice_include
     d3d8lib
     dbghelplib
     imm32


### PR DESCRIPTION
* Merge after #974
* Follow up for #874

- [x] Tested against VC6 Release Golden Replay

## Description

This change further decouples the Game Logic update in `ParticleUplinkCannonUpdate` from the Orbit To Ground Laser drawable.

It is now possible to use the Particle Cannon without the Laser.

The only remaining dependency is `update->getTemplateLaserRadius()` from the Laser, which can be decoupled in a future change by moving the damage radius to `ParticleUplinkCannonUpdateModuleData`.

## Particle Cannon test without Orbit To Ground Laser

The invisible laser applies the expected damage. The scorch is now also coupled to the logical laser radius.

https://github.com/user-attachments/assets/9bff887e-8156-4f52-8190-7d053b077f16

