### PR TITLE
[CMAKE] Enable VC6 compatibility with Visual Studio 2022 generator

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -6,25 +6,29 @@
         "patch": 0
     },
     "configurePresets": [
-        {
-            "name": "vc6",
-            "displayName": "Windows 32bit VC6 Release",
-            "generator": "NMake Makefiles",
-            "hidden": false,
-            "binaryDir": "${sourceDir}/build/${presetName}",
-            "cacheVariables": {
-                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
-                "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL",
-                "CMAKE_MSVC_DEBUG_INFORMATION_FORMAT": "$<$<CONFIG:Release,Debug,RelWithDebInfo>:ProgramDatabase>",
-                "CMAKE_BUILD_TYPE": "Release",
-                "RTS_FLAGS": "/W3"
-            },
-            "vendor": {
-                "jetbrains.com/clion": {
-                    "toolchain": "Visual Studio 6"
-                }
-            }
+      {
+        "name": "vc6",
+        "displayName": "Windows 32bit VC6 Release",
+        "generator": "Visual Studio 17 2022",
+        "architecture": {
+          "value": "Win32"
         },
+        "toolset": "v60",
+        "hidden": false,
+        "binaryDir": "${sourceDir}/build/${presetName}",
+        "cacheVariables": {
+          "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+          "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL",
+          "CMAKE_MSVC_DEBUG_INFORMATION_FORMAT": "$<$<CONFIG:Release,Debug,RelWithDebInfo>:ProgramDatabase>",
+          "CMAKE_BUILD_TYPE": "Release",
+          "RTS_FLAGS": "/W3"
+        },
+        "vendor": {
+          "jetbrains.com/clion": {
+            "toolchain": "Visual Studio 6"
+          }
+        }
+      },
         {
             "name": "vc6-profile",
             "displayName": "Windows 32bit VC6 Profile",

--- a/Core/GameEngine/CMakeLists.txt
+++ b/Core/GameEngine/CMakeLists.txt
@@ -1167,6 +1167,10 @@ target_precompile_headers(corei_gameengine_private INTERFACE
 #    Include/Precompiled/PreRTS.h
 )
 
+if (IS_VS6_BUILD)
+    target_compile_options(corei_gameengine_private INTERFACE $<$<CXX_COMPILER_ID:MSVC>:/Zm500>)
+endif()
+
 target_include_directories(corei_gameengine_public INTERFACE
     Include
 )


### PR DESCRIPTION
- Updated the vc6 configure preset to use the v60 toolset and the "Visual Studio 17 2022" generator.

- Requires Daffodil (https://github.com/manusoft-gh/manusoft-daffodil/releases) for v60 toolset support.

- Added the /Zm500 compiler flag to avoid heap space errors with the VC6 compiler.