### PR TITLE
Improve use of RETAIL_COMPATIBLE_CRC macro

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/crc.h
+++ b/Generals/Code/GameEngine/Include/Common/crc.h
@@ -47,7 +47,7 @@ public:
 //	UnsignedInt get( void ) { return htonl(crc); }	///< Get the combined CRC
 	UnsignedInt get( void );
 
-#if (defined(_MSC_VER) && _MSC_VER < 1300) && defined(RETAIL_COMPATIBLE_CRC)
+#if (defined(_MSC_VER) && _MSC_VER < 1300) && RETAIL_COMPATIBLE_CRC
   void set( UnsignedInt v )
   {
     crc = v;
@@ -127,7 +127,7 @@ public:
     return crc;
   }
 
-#if (defined(_MSC_VER) && _MSC_VER < 1300) && defined(RETAIL_COMPATIBLE_CRC)
+#if (defined(_MSC_VER) && _MSC_VER < 1300) && RETAIL_COMPATIBLE_CRC
   void set( UnsignedInt v )
   {
     crc = v;

--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -990,7 +990,7 @@ GlobalData::GlobalData()
 	File *fp;
 	// TheSuperHackers @tweak SkyAero/xezon 27/05/2025
 	// Simulate the EXE's CRC value to force Network and Replay compatibility with another build.
-#if (defined(_MSC_VER) && _MSC_VER < 1300) && defined(RETAIL_COMPATIBLE_CRC)
+#if (defined(_MSC_VER) && _MSC_VER < 1300) && RETAIL_COMPATIBLE_CRC
 
 #define GENERALS_108_CD_EXE_CRC    0x93d1eab4
 #define GENERALS_108_STEAM_EXE_CRC 0x8d6e4dd7

--- a/GeneralsMD/Code/GameEngine/Include/Common/crc.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/crc.h
@@ -47,7 +47,7 @@ public:
 //	UnsignedInt get( void ) { return htonl(crc); }	///< Get the combined CRC
 	UnsignedInt get( void );
 
-#if (defined(_MSC_VER) && _MSC_VER < 1300) && defined(RETAIL_COMPATIBLE_CRC)
+#if (defined(_MSC_VER) && _MSC_VER < 1300) && RETAIL_COMPATIBLE_CRC
   void set( UnsignedInt v )
   {
     crc = v;
@@ -127,7 +127,7 @@ public:
     return crc;
   }
 
-#if (defined(_MSC_VER) && _MSC_VER < 1300) && defined(RETAIL_COMPATIBLE_CRC)
+#if (defined(_MSC_VER) && _MSC_VER < 1300) && RETAIL_COMPATIBLE_CRC
   void set( UnsignedInt v )
   {
     crc = v;

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -999,7 +999,7 @@ GlobalData::GlobalData()
 	File *fp;
 	// TheSuperHackers @tweak SkyAero/xezon 27/05/2025
 	// Simulate the EXE's CRC value to force Network and Replay compatibility with another build.
-#if (defined(_MSC_VER) && _MSC_VER < 1300) && defined(RETAIL_COMPATIBLE_CRC)
+#if (defined(_MSC_VER) && _MSC_VER < 1300) && RETAIL_COMPATIBLE_CRC
 
 #define GENERALSMD_104_CD_EXE_CRC    0x4f6c5afe
 #define GENERALSMD_104_STEAM_EXE_CRC 0xcb430f5f


### PR DESCRIPTION
* Follow up for #965

I used RETAIL_COMPATIBLE_CRC macro slightly incorrectly. Flipping that macro to 0, would not compile out the code in VC6 builds.