### PR TITLE
[GEN][ZH] Fix missing OLDER REPLAY VERSION dialog when double clicking a replay to load

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
@@ -444,6 +444,26 @@ void reallyLoadReplay(void)
 	}	
 }
 
+static void loadReplay(UnicodeString filename)
+{
+	AsciiString asciiFilename;
+	asciiFilename.translate(filename);
+
+	if(TheRecorder->testVersionPlayback(asciiFilename))
+	{
+		MessageBoxOkCancel(TheGameText->fetch("GUI:OlderReplayVersionTitle"), TheGameText->fetch("GUI:OlderReplayVersion"), reallyLoadReplay, NULL);
+	}
+	else
+	{
+		TheRecorder->playbackFile(asciiFilename);
+
+		if(parentReplayMenu != NULL)
+		{
+			parentReplayMenu->winHide(TRUE);
+		}
+	}
+}
+
 //-------------------------------------------------------------------------------------------------
 /** single player menu window system callback */
 //-------------------------------------------------------------------------------------------------
@@ -490,28 +510,11 @@ WindowMsgHandledType ReplayMenuSystem( GameWindow *window, UnsignedInt msg,
 				if( controlID == listboxReplayFilesID ) 
 				{
 					int rowSelected = mData2;
-				
+
 					if (rowSelected >= 0)
 					{
-						UnicodeString filename;
-						filename = GetReplayFilenameFromListbox(listboxReplayFiles, rowSelected);
-
-						AsciiString asciiFilename;
-						asciiFilename.translate(filename);
-
-						if(TheRecorder->testVersionPlayback(asciiFilename))
-						{
-							MessageBoxOkCancel(TheGameText->fetch("GUI:OlderReplayVersionTitle"), TheGameText->fetch("GUI:OlderReplayVersion"),reallyLoadReplay ,NULL);
-						}
-						else
-						{
-							TheRecorder->playbackFile(asciiFilename);
-
-							if(parentReplayMenu != NULL)
-							{
-								parentReplayMenu->winHide(TRUE);
-							}
-						}
+						UnicodeString filename = GetReplayFilenameFromListbox(listboxReplayFiles, rowSelected);
+						loadReplay(filename);
 					}
 				}
 				break;
@@ -564,25 +567,8 @@ WindowMsgHandledType ReplayMenuSystem( GameWindow *window, UnsignedInt msg,
 					}
 
 					filename = GetReplayFilenameFromListbox(listboxReplayFiles, selected);
-
-					AsciiString asciiFilename;
-					asciiFilename.translate(filename);
-
-					if(TheRecorder->testVersionPlayback(asciiFilename))
-					{
-						MessageBoxOkCancel(TheGameText->fetch("GUI:OlderReplayVersionTitle"), TheGameText->fetch("GUI:OlderReplayVersion"),reallyLoadReplay ,NULL);
-					}
-					else
-					{
-						TheRecorder->playbackFile(asciiFilename);
-
-						if(parentReplayMenu != NULL)
-						{
-							parentReplayMenu->winHide(TRUE);
-						}	
-					}
-					
-				}				
+					loadReplay(filename);
+				}
 			}  // end else if
 			else if( controlID == buttonBackID )
 			{

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
@@ -475,7 +475,7 @@ WindowMsgHandledType ReplayMenuSystem( GameWindow *window, UnsignedInt msg,
 		case GWM_INPUT_FOCUS:
 		{
 
-			// if we're givin the opportunity to take the keyboard focus we must say we want it
+			// if we're given the opportunity to take the keyboard focus we must say we want it
 			if( mData1 == TRUE )
 				*(Bool *)mData2 = TRUE;
 
@@ -498,11 +498,19 @@ WindowMsgHandledType ReplayMenuSystem( GameWindow *window, UnsignedInt msg,
 
 						AsciiString asciiFilename;
 						asciiFilename.translate(filename);
-						TheRecorder->playbackFile(asciiFilename);
 
-						if(parentReplayMenu != NULL)
+						if(TheRecorder->testVersionPlayback(asciiFilename))
 						{
-							parentReplayMenu->winHide(TRUE);
+							MessageBoxOkCancel(TheGameText->fetch("GUI:OlderReplayVersionTitle"), TheGameText->fetch("GUI:OlderReplayVersion"),reallyLoadReplay ,NULL);
+						}
+						else
+						{
+							TheRecorder->playbackFile(asciiFilename);
+
+							if(parentReplayMenu != NULL)
+							{
+								parentReplayMenu->winHide(TRUE);
+							}
 						}
 					}
 				}

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
@@ -475,7 +475,7 @@ WindowMsgHandledType ReplayMenuSystem( GameWindow *window, UnsignedInt msg,
 		case GWM_INPUT_FOCUS:
 		{
 
-			// if we're givin the opportunity to take the keyboard focus we must say we want it
+			// if we're given the opportunity to take the keyboard focus we must say we want it
 			if( mData1 == TRUE )
 				*(Bool *)mData2 = TRUE;
 
@@ -498,11 +498,19 @@ WindowMsgHandledType ReplayMenuSystem( GameWindow *window, UnsignedInt msg,
 
 						AsciiString asciiFilename;
 						asciiFilename.translate(filename);
-						TheRecorder->playbackFile(asciiFilename);
 
-						if(parentReplayMenu != NULL)
+						if(TheRecorder->testVersionPlayback(asciiFilename))
 						{
-							parentReplayMenu->winHide(TRUE);
+							MessageBoxOkCancel(TheGameText->fetch("GUI:OlderReplayVersionTitle"), TheGameText->fetch("GUI:OlderReplayVersion"),reallyLoadReplay ,NULL);
+						}
+						else
+						{
+							TheRecorder->playbackFile(asciiFilename);
+
+							if(parentReplayMenu != NULL)
+							{
+								parentReplayMenu->winHide(TRUE);
+							}	
 						}
 					}
 				}

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
@@ -444,6 +444,26 @@ void reallyLoadReplay(void)
 	}	
 }
 
+static void loadReplay(UnicodeString filename)
+{
+	AsciiString asciiFilename;
+	asciiFilename.translate(filename);
+
+	if(TheRecorder->testVersionPlayback(asciiFilename))
+	{
+		MessageBoxOkCancel(TheGameText->fetch("GUI:OlderReplayVersionTitle"), TheGameText->fetch("GUI:OlderReplayVersion"), reallyLoadReplay, NULL);
+	}
+	else
+	{
+		TheRecorder->playbackFile(asciiFilename);
+
+		if(parentReplayMenu != NULL)
+		{
+			parentReplayMenu->winHide(TRUE);
+		}
+	}
+}
+
 //-------------------------------------------------------------------------------------------------
 /** single player menu window system callback */
 //-------------------------------------------------------------------------------------------------
@@ -490,28 +510,11 @@ WindowMsgHandledType ReplayMenuSystem( GameWindow *window, UnsignedInt msg,
 				if( controlID == listboxReplayFilesID ) 
 				{
 					int rowSelected = mData2;
-				
+
 					if (rowSelected >= 0)
 					{
-						UnicodeString filename;
-						filename = GetReplayFilenameFromListbox(listboxReplayFiles, rowSelected);
-
-						AsciiString asciiFilename;
-						asciiFilename.translate(filename);
-
-						if(TheRecorder->testVersionPlayback(asciiFilename))
-						{
-							MessageBoxOkCancel(TheGameText->fetch("GUI:OlderReplayVersionTitle"), TheGameText->fetch("GUI:OlderReplayVersion"),reallyLoadReplay ,NULL);
-						}
-						else
-						{
-							TheRecorder->playbackFile(asciiFilename);
-
-							if(parentReplayMenu != NULL)
-							{
-								parentReplayMenu->winHide(TRUE);
-							}	
-						}
+						UnicodeString filename = GetReplayFilenameFromListbox(listboxReplayFiles, rowSelected);
+						loadReplay(filename);
 					}
 				}
 				break;
@@ -564,25 +567,8 @@ WindowMsgHandledType ReplayMenuSystem( GameWindow *window, UnsignedInt msg,
 					}
 
 					filename = GetReplayFilenameFromListbox(listboxReplayFiles, selected);
-
-					AsciiString asciiFilename;
-					asciiFilename.translate(filename);
-
-					if(TheRecorder->testVersionPlayback(asciiFilename))
-					{
-						MessageBoxOkCancel(TheGameText->fetch("GUI:OlderReplayVersionTitle"), TheGameText->fetch("GUI:OlderReplayVersion"),reallyLoadReplay ,NULL);
-					}
-					else
-					{
-						TheRecorder->playbackFile(asciiFilename);
-
-						if(parentReplayMenu != NULL)
-						{
-							parentReplayMenu->winHide(TRUE);
-						}	
-					}
-					
-				}				
+					loadReplay(filename);
+				}
 			}  // end else if
 			else if( controlID == buttonBackID )
 			{


### PR DESCRIPTION
**Merge with Rebase**

* Split off of #398

This change fixes the missing OLDER REPLAY VERSION dialog when double clicking a replay to load.

Additionally, it moves the duplicate load replay code into a new function as a separate commit.

## TODO

- [x] Replicate in Generals