### PR TITLE
[CMAKE][GEN][ZH] Make all builds compatible with retail

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -6650,11 +6650,11 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 		Bool neighborFlags[8] = {false, false, false, false, false, false, false};
 
 		// TheSuperHackers @fix Mauller 23/05/2025 Fixes uninitialized variable.
-		// To keep retail compatibility it needs to be uninitialized in VC6 builds.
-#if defined(_MSC_VER) && _MSC_VER < 1300
-		UnsignedInt newCostSoFar;
-#else
+		// To keep retail compatibility it needs to be uninitialized.
+#if defined IGNORE_COMPATABILITY
 		UnsignedInt newCostSoFar = 0;
+#else
+		UnsignedInt newCostSoFar;
 #endif
 
 		for( int i=0; i<numNeighbors; i++ )

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -1042,11 +1042,11 @@ void AIPlayer::onUnitProduced( Object *factory, Object *unit )
 {
 	Bool found = false;
 	// TheSuperHackers @fix Mauller 26/04/2025 Fixes uninitialized variable.
-	// To keep retail compatibility it needs to be set true in VS6 builds.
-#if defined(_MSC_VER) && _MSC_VER < 1300
-	Bool supplyTruck = true;
-#else
+	// To keep retail compatibility it needs to be set true.
+#if defined IGNORE_COMPATABILITY
 	Bool supplyTruck = false;
+#else
+	Bool supplyTruck = true;
 #endif
 
 	// factory could be NULL at the start of the game.

--- a/GeneralsMD/Code/GameEngine/Source/Common/Thing/Thing.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Thing/Thing.cpp
@@ -195,10 +195,10 @@ void Thing::setPosition( const Coord3D *pos )
 }
 
 //=============================================================================
-void Thing::setOrientation( Real angle )
+//
+// TheSuperHackers @bugfix Aliendroid1 05/May/2025 Fix mismatching due to floating point innacuracies
+void Thing::setOrientation(Real angle) 
 {
-	//USE_PERF_TIMER(ThingMatrixStuff)
-	Coord3D u, x, y, z, pos;
 
 	// setOrientation always forces us straight up in the Z axis,
 	// or aligned with the terrain if we have the magic flag set.
@@ -208,40 +208,26 @@ void Thing::setOrientation( Real angle )
 	Coord3D oldPos = m_cachedPos;
 	Matrix3D oldMtx = m_transform;
 
-	pos.x = m_transform.Get_X_Translation();
-	pos.y = m_transform.Get_Y_Translation();
-	pos.z = m_transform.Get_Z_Translation();
-	if( m_template->isKindOf( KINDOF_STICK_TO_TERRAIN_SLOPE) )
+	m_cachedAngle = normalizeAngle(angle);
+	Coord3D pos = { m_transform[0][3], m_transform[1][3] ,m_transform[2][3] };
+	m_cachedPos = pos;
+
+	if (m_template->isKindOf(KINDOF_STICK_TO_TERRAIN_SLOPE))
 	{
-		Matrix3D mtx;
-		const Bool stickToGround = true;	// yes, set the "z" pos				
-		TheTerrainLogic->alignOnTerrain(angle, pos, stickToGround, m_transform );
+		TheTerrainLogic->alignOnTerrain(angle, m_cachedPos, true, m_transform);
 	}
 	else
 	{
-		z.x = 0.0f;
-		z.y = 0.0f;
-		z.z = 1.0f;
-
-		u.x = Cos(angle);
-		u.y = Sin(angle);
-		u.z = 0.0f;
-
-		y.crossProduct( &z, &u, &y );
-		x.crossProduct( &y, &z, &x );
-
-		m_transform.Set(  x.x, y.x, z.x, pos.x,
-											x.y, y.y, z.y, pos.y,
-											x.z, y.z, z.z, pos.z );
+		Real a = Sin(angle);
+		Real b = Cos(angle);
+		m_transform[0][0] = b; m_transform[0][1] = -a; m_transform[0][2] = 0;
+		m_transform[1][0] = a; m_transform[1][1] = b; m_transform[1][2] = 0;
+		m_transform[2][0] = 0; m_transform[2][1] = 0; m_transform[2][2] = 1;
 	}
 
-	//DEBUG_ASSERTCRASH(-PI <= angle && angle <= PI, ("Please pass only normalized (-PI..PI) angles to setOrientation (%f).\n", angle));
-	m_cachedAngle = normalizeAngle(angle);
-	m_cachedPos = pos;
 	m_cacheFlags &= ~VALID_DIRVECTOR;	// but don't clear the altitude flags.
 
 	reactToTransformChange(&oldMtx, &oldPos, oldAngle);
-	DEBUG_ASSERTCRASH(!(_isnan(getPosition()->x) || _isnan(getPosition()->y) || _isnan(getPosition()->z)), ("Drawable/Object position NAN! '%s'\n", m_template->getName().str() ));
 }
 
 //=============================================================================

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -7194,11 +7194,11 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 		Bool neighborFlags[8] = {false, false, false, false, false, false, false};
 
 		// TheSuperHackers @fix Mauller 23/05/2025 Fixes uninitialized variable.
-		// To keep retail compatibility it needs to be uninitialized in VC6 builds.
-#if defined(_MSC_VER) && _MSC_VER < 1300
-		UnsignedInt newCostSoFar;
-#else
+		// To keep retail compatibility it needs to be uninitialized.
+#if defined IGNORE_COMPATABILITY
 		UnsignedInt newCostSoFar = 0;
+#else
+		UnsignedInt newCostSoFar;
 #endif
 
 		for( int i=0; i<numNeighbors; i++ )

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -1049,11 +1049,11 @@ void AIPlayer::onUnitProduced( Object *factory, Object *unit )
 {
 	Bool found = false;
 	// TheSuperHackers @fix Mauller 26/04/2025 Fixes uninitialized variable.
-	// To keep retail compatibility it needs to be set true in VS6 builds.
-#if defined(_MSC_VER) && _MSC_VER < 1300
-	Bool supplyTruck = true;
-#else
+	// To keep retail compatibility it needs to be set true.
+#if defined IGNORE_COMPATABILITY
 	Bool supplyTruck = false;
+#else
+	Bool supplyTruck = true;
 #endif
 
 	// factory could be NULL at the start of the game.

--- a/cmake/config-build.cmake
+++ b/cmake/config-build.cmake
@@ -8,6 +8,7 @@ option(RTS_BUILD_OPTION_PROFILE "Build code with the \"Profile\" configuration."
 option(RTS_BUILD_OPTION_DEBUG "Build code with the \"Debug\" configuration." OFF)
 option(RTS_BUILD_OPTION_ASAN "Build code with Address Sanitizer." OFF)
 option(RTS_BUILD_OPTION_FFMPEG "Enable FFmpeg support" OFF)
+option(RTS_BUILD_OPTION_IGNORE_COMPATABILITY "Enable fixes that break retail compatibility" OFF)
 
 if(NOT RTS_BUILD_ZEROHOUR AND NOT RTS_BUILD_GENERALS)
     set(RTS_BUILD_ZEROHOUR TRUE)
@@ -23,6 +24,7 @@ add_feature_info(ProfileBuild RTS_BUILD_OPTION_PROFILE "Building as a \"Profile\
 add_feature_info(DebugBuild RTS_BUILD_OPTION_DEBUG "Building as a \"Debug\" build")
 add_feature_info(AddressSanitizer RTS_BUILD_OPTION_ASAN "Building with address sanitizer")
 add_feature_info(FFmpegSupport RTS_BUILD_OPTION_FFMPEG "Building with FFmpeg support")
+add_feature_info(IGNORE_COMPATABILITY RTS_BUILD_OPTION_IGNORE_COMPATABILITY "Building with retal-incompatibile fixes")
 
 if(RTS_BUILD_ZEROHOUR)
     option(RTS_BUILD_ZEROHOUR_TOOLS "Build tools for Zero Hour" ON)
@@ -47,6 +49,10 @@ endif()
 if(NOT IS_VS6_BUILD)
     # Because we set CMAKE_CXX_STANDARD_REQUIRED and CMAKE_CXX_EXTENSIONS in the compilers.cmake this should be enforced.
     target_compile_features(core_config INTERFACE cxx_std_20)
+endif()
+
+if(RTS_BUILD_OPTION_IGNORE_COMPATABILITY)
+    target_compile_definitions(core_config INTERFACE IGNORE_COMPATABILITY)
 endif()
 
 target_compile_options(core_config INTERFACE ${RTS_FLAGS})


### PR DESCRIPTION
- This fix makes all builds including modern C++20 builds and debug builds compatible with the retail game and with each other.

- Fixes a floating point determinism bug in Thing::setOrientation that caused CRC mismatches when built with different compilers or optimization flags.

- The cross product-based transformation code has been replaced with an equivalent, algebraically simplified implementation.

- This new implementation is not only more efficient, but also eliminates intermediate floating point steps that were prone to subtle inaccuracies.

- Also added the IGNORE_COMPATIBILITY macro (settable via CMake) for enabling future fixes that would break compatibility, rather than applying them unconditionally on modern builds.