### PR TITLE
[GEN][ZH] Fix game crash in AIGroup::friend_moveFormationToPos()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
@@ -1089,6 +1089,11 @@ void AIGroup::friend_moveFormationToPos( const Coord3D *pos, CommandSourceType c
 		}
 		Object *theUnit = (*i);
 		AIUpdateInterface *ai = theUnit->getAIUpdateInterface();
+		if (ai == NULL)
+		{
+			continue;
+		}
+
 		Bool isDifferentFormation = false;
 		Coord2D offset;
 		if (isDifferentFormation) {

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
@@ -1094,6 +1094,11 @@ void AIGroup::friend_moveFormationToPos( const Coord3D *pos, CommandSourceType c
 		}
 		Object *theUnit = (*i);
 		AIUpdateInterface *ai = theUnit->getAIUpdateInterface();
+		if (ai == NULL)
+		{
+			continue;
+		}
+
 		Bool isDifferentFormation = false;
 		Coord2D offset;
 		if (isDifferentFormation) {


### PR DESCRIPTION
This change fixes a game crash in AIGroup::friend_moveFormationToPos(). The repro steps are undisclosed due its severity.

I looked at all other movement functions in AIGroup and they already test AIUpdateInterface correctly.

### Callstack

```cpp
 	[Inline Frame] generalszh.exe!AICommandInterface::aiMoveToPosition(const Coord3D *) Line 472	C++
 	generalszh.exe!AIGroup::friend_moveFormationToPos(const Coord3D * pos, CommandSourceType cmdSource) Line 1131	C++
 	generalszh.exe!AIGroup::groupMoveToPosition(const Coord3D * p_posIn, bool addWaypoint, CommandSourceType cmdSource) Line 1639	C++
>	generalszh.exe!GameLogic::logicMessageDispatcher(GameMessage * msg, void * userData) Line 1995	C++
 	generalszh.exe!GameLogic::processCommandList(CommandList * list) Line 2591	C++
 	generalszh.exe!GameLogic::update() Line 3761	C++
 	generalszh.exe!Win32GameEngine::update() Line 93	C++
 	generalszh.exe!GameEngine::execute() Line 819	C++
 	generalszh.exe!GameMain(int argc, char * * argv) Line 47	C++
 	generalszh.exe!WinMain(HINSTANCE__ * hInstance, HINSTANCE__ * hPrevInstance, char * lpCmdLine, int nCmdShow) Line 988	C++
 	[Inline Frame] generalszh.exe!invoke_main() Line 102	C++
 	generalszh.exe!__scrt_common_main_seh() Line 288	C++
 	kernel32.dll!7598fcc9()	Unknown
 	[Frames below may be incorrect and/or missing, no symbols loaded for kernel32.dll]	
 	ntdll.dll!772e82ae()	Unknown
 	ntdll.dll!772e827e()	Unknown
```
```
Exception thrown at 0x010B3B58 in generalszh.exe: 0xC0000005: Access violation reading location 0x00000020.
```