### PR TITLE
[GEN][ZH] Fix logical errors with RecorderClass::testVersionPlayback()

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/Recorder.h
+++ b/Generals/Code/GameEngine/Include/Common/Recorder.h
@@ -55,6 +55,9 @@ class CRCInfo;
 
 class RecorderClass : public SubsystemInterface {
 public:
+	struct ReplayHeader;
+
+public:
 	RecorderClass();																	///< Constructor.
 	virtual ~RecorderClass();													///< Destructor.
 
@@ -68,7 +71,8 @@ public:
 	// Methods dealing with playback.
 	void updatePlayback();														///< The update function for playing back a file.
 	Bool playbackFile(AsciiString filename);					///< Starts playback of the specified file.
-	Bool testVersionPlayback(AsciiString filename);   ///< Returns if the playback is a valid playback file for this version or not.
+	Bool replayMatchesGameVersion(AsciiString filename); ///< Returns true if the playback is a valid playback file for this version.
+	static Bool replayMatchesGameVersion(const ReplayHeader& header); ///< Returns true if the playback is a valid playback file for this version.
 	AsciiString getCurrentReplayFilename( void );			///< valid during playback only
 	void stopPlayback();															///< Stops playback.  Its fine to call this even if not playing back a file.
 #if defined RTS_DEBUG || defined RTS_INTERNAL

--- a/Generals/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Recorder.cpp
@@ -1055,19 +1055,22 @@ void RecorderClass::handleCRCMessage(UnsignedInt newCRC, Int playerIndex, Bool f
 }
 
 /**
- * Return true if this version of the file is the same as our version of the game
+ * Returns true if this version of the file is the same as our version of the game
  */
-Bool RecorderClass::testVersionPlayback(AsciiString filename)
+Bool RecorderClass::replayMatchesGameVersion(AsciiString filename)
 {
-
 	ReplayHeader header;
 	header.forPlayback = TRUE;
 	header.filename = filename;
-	Bool success = readReplayHeader( header );
-	if (!success)
+	if ( readReplayHeader( header ) )
 	{
-		return FALSE;
+		return replayMatchesGameVersion( header );
 	}
+	return FALSE;
+}
+
+Bool RecorderClass::replayMatchesGameVersion(const ReplayHeader& header)
+{
 	Bool versionStringDiff = header.versionString != TheVersion->getUnicodeVersion();
 	Bool versionTimeStringDiff = header.versionTimeString != TheVersion->getUnicodeBuildTime();
 	Bool versionNumberDiff = header.versionNumber != TheVersion->getVersionNumber();
@@ -1077,10 +1080,9 @@ Bool RecorderClass::testVersionPlayback(AsciiString filename)
 
 	if(exeDifferent || iniDifferent)
 	{
-		return TRUE;
+		return FALSE;
 	}
-	return FALSE;
-
+	return TRUE;
 }
 
 /**

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
@@ -449,7 +449,7 @@ static void loadReplay(UnicodeString filename)
 	AsciiString asciiFilename;
 	asciiFilename.translate(filename);
 
-	if(TheRecorder->testVersionPlayback(asciiFilename))
+	if(!TheRecorder->replayMatchesGameVersion(asciiFilename))
 	{
 		MessageBoxOkCancel(TheGameText->fetch("GUI:OlderReplayVersionTitle"), TheGameText->fetch("GUI:OlderReplayVersion"), reallyLoadReplay, NULL);
 	}

--- a/GeneralsMD/Code/GameEngine/Include/Common/Recorder.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Recorder.h
@@ -55,6 +55,9 @@ class CRCInfo;
 
 class RecorderClass : public SubsystemInterface {
 public:
+	struct ReplayHeader;
+
+public:
 	RecorderClass();																	///< Constructor.
 	virtual ~RecorderClass();													///< Destructor.
 
@@ -68,7 +71,8 @@ public:
 	// Methods dealing with playback.
 	void updatePlayback();														///< The update function for playing back a file.
 	Bool playbackFile(AsciiString filename);					///< Starts playback of the specified file.
-	Bool testVersionPlayback(AsciiString filename);   ///< Returns if the playback is a valid playback file for this version or not.
+	Bool replayMatchesGameVersion(AsciiString filename); ///< Returns true if the playback is a valid playback file for this version.
+	static Bool replayMatchesGameVersion(const ReplayHeader& header); ///< Returns true if the playback is a valid playback file for this version.
 	AsciiString getCurrentReplayFilename( void );			///< valid during playback only
 	void stopPlayback();															///< Stops playback.  Its fine to call this even if not playing back a file.
 #if defined RTS_DEBUG || defined RTS_INTERNAL

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -1058,19 +1058,22 @@ void RecorderClass::handleCRCMessage(UnsignedInt newCRC, Int playerIndex, Bool f
 }
 
 /**
- * Return true if this version of the file is the same as our version of the game
+ * Returns true if this version of the file is the same as our version of the game
  */
-Bool RecorderClass::testVersionPlayback(AsciiString filename)
+Bool RecorderClass::replayMatchesGameVersion(AsciiString filename)
 {
-
 	ReplayHeader header;
 	header.forPlayback = TRUE;
 	header.filename = filename;
-	Bool success = readReplayHeader( header );
-	if (!success)
+	if ( readReplayHeader( header ) )
 	{
-		return FALSE;
+		return replayMatchesGameVersion( header );
 	}
+	return FALSE;
+}
+
+Bool RecorderClass::replayMatchesGameVersion(const ReplayHeader& header)
+{
 	Bool versionStringDiff = header.versionString != TheVersion->getUnicodeVersion();
 	Bool versionTimeStringDiff = header.versionTimeString != TheVersion->getUnicodeBuildTime();
 	Bool versionNumberDiff = header.versionNumber != TheVersion->getVersionNumber();
@@ -1080,10 +1083,9 @@ Bool RecorderClass::testVersionPlayback(AsciiString filename)
 
 	if(exeDifferent || iniDifferent)
 	{
-		return TRUE;
+		return FALSE;
 	}
-	return FALSE;
-
+	return TRUE;
 }
 
 /**

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
@@ -449,7 +449,7 @@ static void loadReplay(UnicodeString filename)
 	AsciiString asciiFilename;
 	asciiFilename.translate(filename);
 
-	if(TheRecorder->testVersionPlayback(asciiFilename))
+	if(!TheRecorder->replayMatchesGameVersion(asciiFilename))
 	{
 		MessageBoxOkCancel(TheGameText->fetch("GUI:OlderReplayVersionTitle"), TheGameText->fetch("GUI:OlderReplayVersion"), reallyLoadReplay, NULL);
 	}


### PR DESCRIPTION
* Follow up for #984

This change fixes the `RecorderClass::testVersionPlayback` function.

The following problems were identified:

1. The return values do not match what the EA comments say about it (*1)
2. If a Replay header was not recognized, then the function would return success (*2)

(*1) The function now matches what the comment says and has been given a better name to tell what it does.

(*2) This is only a theoretical issue. The replay would not show up in the replay list anyway if its header was not read correctly.

Additionally the function was split in 2 so that it can also be called with a `ReplayHeader` (to be used in the next change after this). Reason being, `replayMatchesGameVersion(AsciiString filename)` is expensive, because it reads a physical Replay file on disk.

## TODO

- [x] Replicate in Generals