### PR TITLE
[ZH] Fix ini file not being loaded for maps that was just transferred

### DIFF
--- a/GeneralsMD/Code/GameEngine/Include/Common/FileSystem.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/FileSystem.h
@@ -131,7 +131,7 @@ public:
 	void update();
 
 	File* openFile( const Char *filename, Int access = 0 );		///< opens a File interface to the specified file
-	Bool doesFileExist(const Char *filename) const;								///< returns TRUE if the file exists.  filename should have no directory.
+	Bool doesFileExist(const Char *filename, Bool cacheAbsence = TRUE) const;	///< returns TRUE if the file exists.  filename should have no directory.
 	void getFileListInDirectory(const AsciiString& directory, const AsciiString& searchName, FilenameList &filenameList, Bool searchSubdirectories) const; ///< search the given directory for files matching the searchName (egs. *.ini, *.rep).  Possibly search subdirectories.
 	Bool getFileInfo(const AsciiString& filename, FileInfo *fileInfo) const; ///< fills in the FileInfo struct for the file given. returns TRUE if successful.
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/FileSystem.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/FileSystem.cpp
@@ -193,7 +193,7 @@ File*		FileSystem::openFile( const Char *filename, Int access )
 // FileSystem::doesFileExist
 //============================================================================
 
-Bool FileSystem::doesFileExist(const Char *filename) const
+Bool FileSystem::doesFileExist(const Char *filename, Bool cacheAbsence) const
 {
 	USE_PERF_TIMER(FileSystem)
 
@@ -212,8 +212,9 @@ Bool FileSystem::doesFileExist(const Char *filename) const
     m_fileExist[key]=true;
 		return TRUE;
 	}
-
-  m_fileExist[key]=false;
+	if (cacheAbsence) {
+		m_fileExist[key] = false;
+	}
 	return FALSE;
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/ConnectionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/ConnectionManager.cpp
@@ -688,7 +688,7 @@ void ConnectionManager::processFile(NetFileCommandMsg *msg)
 	DEBUG_LOG(("%ls\n", log.str()));
 #endif
 
-	if (TheFileSystem->doesFileExist(msg->getRealFilename().str()))
+	if (TheFileSystem->doesFileExist(msg->getRealFilename().str(), FALSE))
 	{
 		DEBUG_LOG(("File exists already!\n"));
 		//return;


### PR DESCRIPTION
Fixes #70 

This change fixes a mismatch that can occur after transferring a multiplayer map containing a map.ini file. The problem is that the FileSystem implementation contains a cache of file names and their presence, which is kept for the FileSystem instance lifetime.

When transferring a file, the ConnectionManager validates that the file is not already present before accepting it, which then results in all the transferred files being added to the cache as not present.

When the map is then loaded on game start, GameLogic::loadMapINI will call TheFileSystem->doesFileExist for the map.ini, solo.ini and map.str before actually loading the files. Since they are already cached as not present, they will not be loaded, and the mismatch potential is established.

The issue does not occur in Generals, as the cache only exists in Zero Hour.

### Solution
Add a flag to FileSystem::doesFileExist that controls if the absence of a file should be added to the cache or not. The default value is to add it, but the call in ConnectionManager specifically sets it to not add the entries.