### PR TITLE
[GEN][ZH] Implement REPLAY NOT FOUND and MAP NOT FOUND dialogs when attempting to load a Replay that was deleted or whose map is missing

### DIFF
--- a/Core/GameEngine/Include/Common/GameDefines.h
+++ b/Core/GameEngine/Include/Common/GameDefines.h
@@ -28,3 +28,7 @@
 #ifndef RETAIL_COMPATIBLE_XFER_SAVE
 #define RETAIL_COMPATIBLE_XFER_SAVE (1) // Game is expected to be Xfer Save compatible with retail Generals 1.08, Zero Hour 1.04
 #endif
+
+#ifndef ENABLE_GAMETEXT_SUBSTITUTES
+#define ENABLE_GAMETEXT_SUBSTITUTES (1) // The code can provide substitute texts when labels and strings are missing in the STR or CSF translation file
+#endif

--- a/Generals/Code/GameEngine/Include/GameClient/GameText.h
+++ b/Generals/Code/GameEngine/Include/GameClient/GameText.h
@@ -78,6 +78,10 @@ class GameTextInterface : public SubsystemInterface
 
 		virtual UnicodeString fetch( const Char *label, Bool *exists = NULL ) = 0;		///< Returns the associated labeled unicode text
 		virtual UnicodeString fetch( AsciiString label, Bool *exists = NULL ) = 0;		///< Returns the associated labeled unicode text
+
+		// Do not call this directly, but use the FETCH_OR_SUBSTITUTE macro
+		virtual UnicodeString fetchOrSubstitute( const Char *label, const WideChar *substituteText ) = 0;
+
 		// This function is not performance tuned.. Its really only for Worldbuilder. jkmcd
 		virtual AsciiStringVec& getStringsWithLabelPrefix(AsciiString label) = 0;
 
@@ -91,6 +95,15 @@ extern GameTextInterface* CreateGameTextInterface( void );
 //----------------------------------------------------------------------------
 //           Inlining                                                       
 //----------------------------------------------------------------------------
+
+// TheSuperHackers @info This is meant to be used like:
+// TheGameText->FETCH_OR_SUBSTITUTE("GUI:LabelName", L"Substitute Fallback Text")
+// The substitute text will be compiled out if ENABLE_GAMETEXT_SUBSTITUTES is not defined.
+#if ENABLE_GAMETEXT_SUBSTITUTES
+#define FETCH_OR_SUBSTITUTE(labelA, substituteTextW) fetchOrSubstitute(labelA, substituteTextW)
+#else
+#define FETCH_OR_SUBSTITUTE(labelA, substituteTextW) fetch(labelA)
+#endif
 
 
 #endif // __GAMECLIENT_GAMETEXT_H_

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
@@ -491,8 +491,32 @@ static void loadReplay(UnicodeString filename)
 	AsciiString asciiFilename;
 	asciiFilename.translate(filename);
 
-	if(!TheRecorder->replayMatchesGameVersion(asciiFilename))
+	RecorderClass::ReplayHeader header;
+	ReplayGameInfo info;
+	const MapMetaData *mapData;
+
+	if(!readReplayMapInfo(asciiFilename, header, info, mapData))
 	{
+		// TheSuperHackers @bugfix Prompts a message box when the replay was deleted by the user while the Replay Menu was opened.
+
+		UnicodeString title = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayFileNotFoundTitle", L"REPLAY NOT FOUND");
+		UnicodeString body = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayFileNotFound", L"This replay cannot be loaded because the file no longer exists on this device.");
+
+		MessageBoxOk(title, body, NULL);
+	}
+	else if(mapData == NULL)
+	{
+		// TheSuperHackers @bugfix Prompts a message box when the map used by the replay was not found.
+
+		UnicodeString title = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayMapNotFoundTitle", L"MAP NOT FOUND");
+		UnicodeString body = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayMapNotFound", L"This replay cannot be loaded because the map was not found on this device.");
+
+		MessageBoxOk(title, body, NULL);
+	}
+	else if(!TheRecorder->replayMatchesGameVersion(header))
+	{
+		// Pressing OK loads the replay.
+
 		MessageBoxOkCancel(TheGameText->fetch("GUI:OlderReplayVersionTitle"), TheGameText->fetch("GUI:OlderReplayVersion"), reallyLoadReplay, NULL);
 	}
 	else

--- a/Generals/Code/GameEngine/Source/GameClient/GameText.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GameText.cpp
@@ -152,6 +152,8 @@ class GameTextManager : public GameTextInterface
 
 		virtual UnicodeString fetch( const Char *label, Bool *exists = NULL );		///< Returns the associated labeled unicode text
 		virtual UnicodeString fetch( AsciiString label, Bool *exists = NULL );		///< Returns the associated labeled unicode text
+		virtual UnicodeString fetchOrSubstitute( const Char *label, const WideChar *substituteText );
+
 		virtual AsciiStringVec& getStringsWithLabelPrefix(AsciiString label);
 
 		virtual void					initMapStringFile( const AsciiString& filename );
@@ -1339,6 +1341,19 @@ UnicodeString GameTextManager::fetch( const Char *label, Bool *exists )
 UnicodeString GameTextManager::fetch( AsciiString label, Bool *exists )
 {
 	return fetch(label.str(), exists);
+}
+
+//============================================================================
+// GameTextManager::fetchOrSubstitute
+//============================================================================
+
+UnicodeString GameTextManager::fetchOrSubstitute( const Char *label, const WideChar *substituteText )
+{
+	Bool exists;
+	UnicodeString str = fetch(label, &exists);
+	if (!exists)
+		str = substituteText;
+	return str;
 }
 
 //============================================================================

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/GameText.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/GameText.h
@@ -78,6 +78,10 @@ class GameTextInterface : public SubsystemInterface
 
 		virtual UnicodeString fetch( const Char *label, Bool *exists = NULL ) = 0;		///< Returns the associated labeled unicode text
 		virtual UnicodeString fetch( AsciiString label, Bool *exists = NULL ) = 0;		///< Returns the associated labeled unicode text
+
+		// Do not call this directly, but use the FETCH_OR_SUBSTITUTE macro
+		virtual UnicodeString fetchOrSubstitute( const Char *label, const WideChar *substituteText ) = 0;
+
 		// This function is not performance tuned.. Its really only for Worldbuilder. jkmcd
 		virtual AsciiStringVec& getStringsWithLabelPrefix(AsciiString label) = 0;
 
@@ -91,6 +95,15 @@ extern GameTextInterface* CreateGameTextInterface( void );
 //----------------------------------------------------------------------------
 //           Inlining                                                       
 //----------------------------------------------------------------------------
+
+// TheSuperHackers @info This is meant to be used like:
+// TheGameText->FETCH_OR_SUBSTITUTE("GUI:LabelName", L"Substitute Fallback Text")
+// The substitute text will be compiled out if ENABLE_GAMETEXT_SUBSTITUTES is not defined.
+#if ENABLE_GAMETEXT_SUBSTITUTES
+#define FETCH_OR_SUBSTITUTE(labelA, substituteTextW) fetchOrSubstitute(labelA, substituteTextW)
+#else
+#define FETCH_OR_SUBSTITUTE(labelA, substituteTextW) fetch(labelA)
+#endif
 
 
 #endif // __GAMECLIENT_GAMETEXT_H_

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
@@ -491,8 +491,32 @@ static void loadReplay(UnicodeString filename)
 	AsciiString asciiFilename;
 	asciiFilename.translate(filename);
 
-	if(!TheRecorder->replayMatchesGameVersion(asciiFilename))
+	RecorderClass::ReplayHeader header;
+	ReplayGameInfo info;
+	const MapMetaData *mapData;
+
+	if(!readReplayMapInfo(asciiFilename, header, info, mapData))
 	{
+		// TheSuperHackers @bugfix Prompts a message box when the replay was deleted by the user while the Replay Menu was opened.
+
+		UnicodeString title = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayFileNotFoundTitle", L"REPLAY NOT FOUND");
+		UnicodeString body = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayFileNotFound", L"This replay cannot be loaded because the file no longer exists on this device.");
+
+		MessageBoxOk(title, body, NULL);
+	}
+	else if(mapData == NULL)
+	{
+		// TheSuperHackers @bugfix Prompts a message box when the map used by the replay was not found.
+
+		UnicodeString title = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayMapNotFoundTitle", L"MAP NOT FOUND");
+		UnicodeString body = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayMapNotFound", L"This replay cannot be loaded because the map was not found on this device.");
+
+		MessageBoxOk(title, body, NULL);
+	}
+	else if(!TheRecorder->replayMatchesGameVersion(header))
+	{
+		// Pressing OK loads the replay.
+
 		MessageBoxOkCancel(TheGameText->fetch("GUI:OlderReplayVersionTitle"), TheGameText->fetch("GUI:OlderReplayVersion"), reallyLoadReplay, NULL);
 	}
 	else

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GameText.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GameText.cpp
@@ -152,6 +152,8 @@ class GameTextManager : public GameTextInterface
 
 		virtual UnicodeString fetch( const Char *label, Bool *exists = NULL );		///< Returns the associated labeled unicode text
 		virtual UnicodeString fetch( AsciiString label, Bool *exists = NULL );		///< Returns the associated labeled unicode text
+		virtual UnicodeString fetchOrSubstitute( const Char *label, const WideChar *substituteText );
+
 		virtual AsciiStringVec& getStringsWithLabelPrefix(AsciiString label);
 
 		virtual void					initMapStringFile( const AsciiString& filename );
@@ -1339,6 +1341,19 @@ UnicodeString GameTextManager::fetch( const Char *label, Bool *exists )
 UnicodeString GameTextManager::fetch( AsciiString label, Bool *exists )
 {
 	return fetch(label.str(), exists);
+}
+
+//============================================================================
+// GameTextManager::fetchOrSubstitute
+//============================================================================
+
+UnicodeString GameTextManager::fetchOrSubstitute( const Char *label, const WideChar *substituteText )
+{
+	Bool exists;
+	UnicodeString str = fetch(label, &exists);
+	if (!exists)
+		str = substituteText;
+	return str;
 }
 
 //============================================================================


### PR DESCRIPTION
**Merge with Rebase**

* Merge after #993
* Fixes #126
* Follow up for #984
* Split off of #398

This change implements a new MAP NOT FOUND dialog when the user attempts to load a Replay whose map is missing in the user data (or game install). Originally the game would crash when trying to start a new game with a missing map.

Additionally it implements a new REPLAY NOT FOUND dialog when the user attempts to load a Replay that was deleted after the Replay Menu was opened.

This change has 2 commits. The first commit is a refactor to help implement the fix efficiently. The second commit contains new code for GameText to allow looking up localization texts with substitute texts when those localizations are not found (which they currently are not because we do not touch game data). The substitution code can be compiled out cleanly when so desired (via GameDefines.h).

## TODO

- [x] Replicate in Generals

## Tip

Ignore whitespace in diff viewer to ease reviewing this change.

## Dialog Image

![shot_20250601_164828_1](https://github.com/user-attachments/assets/b1d8e9cc-c464-4468-88a2-7da5b3d6a5ac)
