### PR TITLE
bugfix(pathfinder): Fix various crashes in Pathfinder due to inadequate cleanup of pathfinding resources

### DIFF
--- a/Core/GameEngine/Include/Common/GameDefines.h
+++ b/Core/GameEngine/Include/Common/GameDefines.h
@@ -35,6 +35,13 @@
 #define RETAIL_COMPATIBLE_XFER_SAVE (1) // Game is expected to be Xfer Save compatible with retail Generals 1.08, Zero Hour 1.04
 #endif
 
+// This is here to easily toggle between the retail compatible with fixed pathfinding fallback and pure fixed pathfinding mode
+#if RETAIL_COMPATIBLE_CRC
+#define RETAIL_COMPATIBLE_PATHFINDING (1)
+#else
+#define RETAIL_COMPATIBLE_PATHFINDING (0)
+#endif
+
 // This is essentially synonymous for RETAIL_COMPATIBLE_CRC. There is a lot wrong with AIGroup, such as use-after-free, double-free, leaks,
 // but we cannot touch it much without breaking retail compatibility. Do not shy away from using massive hacks when fixing issues with AIGroup,
 // but put them behind this macro.

--- a/Generals/Code/GameEngine/Include/GameLogic/AIPathfind.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AIPathfind.h
@@ -207,6 +207,9 @@ class PathfindCellInfo
 {
 	friend class PathfindCell;
 public:
+#if RETAIL_COMPATIBLE_PATHFINDING
+	static void forceCleanPathFindCellInfos(void);
+#endif
 	static void allocateCellInfos(void);
 	static void releaseCellInfos(void);
 
@@ -691,6 +694,9 @@ public:
 	Path *getDebugPath( void );
 	void setDebugPath( Path *debugpath );
 
+#if RETAIL_COMPATIBLE_PATHFINDING
+	void forceCleanCells(void);
+#endif
 	void cleanOpenAndClosedLists(void);
 
 	// Adjusts the destination to a spot near dest that is not occupied by other units.

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -1082,6 +1082,39 @@ enum { PATHFIND_CELLS_PER_FRAME=5000}; // Number of cells we will search pathfin
 enum {CELL_INFOS_TO_ALLOCATE = 30000};
 PathfindCellInfo *PathfindCellInfo::s_infoArray = NULL;
 PathfindCellInfo *PathfindCellInfo::s_firstFree = NULL;
+
+#if RETAIL_COMPATIBLE_PATHFINDING
+// TheSuperHackers @info This variable is here so the code will run down the retail compatible path till a failure mode is hit
+// The pathfinding will then switch over to the corrected pathfinding code for SH clients
+Bool s_useFixedPathfinding = false;
+Bool s_forceCleanCells = false;
+
+void PathfindCellInfo::forceCleanPathFindCellInfos()
+{
+	for (Int i = 0; i < CELL_INFOS_TO_ALLOCATE - 1; i++) {
+		s_infoArray[i].m_nextOpen = NULL;
+		s_infoArray[i].m_prevOpen = NULL;
+		s_infoArray[i].m_open = FALSE;
+		s_infoArray[i].m_closed = FALSE;
+	}
+}
+
+void Pathfinder::forceCleanCells()
+{
+	PathfindCellInfo::forceCleanPathFindCellInfos();
+	m_openList = NULL;
+	m_closedList = NULL;
+
+	for (int j = 0; j <= m_extent.hi.y; ++j) {
+		for (int i = 0; i <= m_extent.hi.x; ++i) {
+			if (m_map[i][j].hasInfo()) {
+				m_map[i][j].releaseInfo();
+			}
+		}
+	}
+}
+#endif
+
 /**
  * Allocates a pool of pathfind cell infos.
  */
@@ -1220,7 +1253,14 @@ Bool PathfindCell::startPathfind( PathfindCell *goalCell  )
 	if (goalCell) {
 		m_info->m_totalCost = costToGoal( goalCell );
 	}
-	m_info->m_open = TRUE;
+#if RETAIL_COMPATIBLE_PATHFINDING
+	if (!s_useFixedPathfinding) {
+		m_info->m_open = TRUE;
+	} else
+#endif
+	{
+		m_info->m_open = FALSE;
+	}
 	m_info->m_closed = FALSE;
 	return true;
 }
@@ -1274,6 +1314,17 @@ Bool PathfindCell::allocateInfo( const ICoord2D &pos )
  */
 void PathfindCell::releaseInfo( void )
 {
+	// TheSuperHackers @bugfix Mauller/SkyAero 05/06/2025 Parent cell links need clearing to prevent dangling pointers on starting points that can link them to an invalid parent cell.
+	// Parent cells are only cleared within Pathfinder::prependCells, so cells that do not make it onto the final path do not get their parent cell cleared.
+	// Cells with a special flags also do not get their PathfindCellInfo cleared and therefore can leave a parent cell set on a starting cell.
+#if RETAIL_COMPATIBLE_PATHFINDING
+	if (s_useFixedPathfinding)
+#endif
+	{
+		if (m_info) {
+			m_info->m_pathParent = NULL;
+		}
+	}
 	if (m_type==PathfindCell::CELL_OBSTACLE) {
 		return;
 	}
@@ -1566,9 +1617,21 @@ Int PathfindCell::releaseOpenList( PathfindCell *list )
 		DEBUG_ASSERTCRASH(list->m_info->m_closed==FALSE && list->m_info->m_open==TRUE, ("Serious error - Invalid flags. jba"));
 		PathfindCell *cur = list;
 		PathfindCellInfo *curInfo = list->m_info;
+
+#if RETAIL_COMPATIBLE_PATHFINDING
+		// TheSuperHackers @info This is only here to catch a crash point in the retail compatible pathfinding
+		// One crash mode is where a cell has no PathfindCellInfo, resulting in a nullptr access and a crash.
+		// Therefore we signal that we need to clean the maps cells and the PathfindCellInfos
+		if(!curInfo && !s_useFixedPathfinding) {
+			s_useFixedPathfinding = true;
+			s_forceCleanCells = true;
+			return count;
+		}
+#endif
+
 		if (curInfo->m_nextOpen) {
 			list = curInfo->m_nextOpen->m_cell;
-		}	else {
+		} else {
 			list = NULL;
 		}
 		DEBUG_ASSERTCRASH(cur == curInfo->m_cell, ("Bad backpointer in PathfindCellInfo"));
@@ -1590,9 +1653,20 @@ Int PathfindCell::releaseClosedList( PathfindCell *list )
 		DEBUG_ASSERTCRASH(list->m_info->m_closed==TRUE && list->m_info->m_open==FALSE, ("Serious error - Invalid flags. jba"));
 		PathfindCell *cur = list;
 		PathfindCellInfo *curInfo = list->m_info;
+#if RETAIL_COMPATIBLE_PATHFINDING
+		// TheSuperHackers @info This is only here to catch a crash point in the retail compatible pathfinding
+		// One crash mode is where a cell has no PathfindCellInfo, resulting in a nullptr access and a crash.
+		// Therefore we signal that we need to clean the maps cells and the PathfindCellInfos
+		if(!curInfo && !s_useFixedPathfinding) {
+			s_useFixedPathfinding = true;
+			s_forceCleanCells = true;
+			return count;
+		}
+#endif
+
 		if (curInfo->m_nextOpen) {
 			list = curInfo->m_nextOpen->m_cell;
-		}	else {
+		} else {
 			list = NULL;
 		}
 		DEBUG_ASSERTCRASH(cur == curInfo->m_cell, ("Bad backpointer in PathfindCellInfo"));
@@ -1712,6 +1786,16 @@ UnsignedInt PathfindCell::costSoFar( PathfindCell *parent )
 	Int numTurns = 0;
 	PathfindCell *prevCell = parent->getParentCell();
 	if (prevCell) {
+
+#if RETAIL_COMPATIBLE_PATHFINDING
+		// TheSuperHackers @info this is a possible crash point in the retail pathfinding, we just prevent the crash at this point
+		// External code should catch the issue in another block and cleanup the pathfinding before switching to the fixed pathfinding.
+		if (!prevCell->hasInfo())
+		{
+			return cost;
+		}
+#endif
+
 		ICoord2D dir;
 		dir.x = prevCell->getXIndex() - parent->getXIndex();
 		dir.y = prevCell->getYIndex() - parent->getYIndex();
@@ -3438,6 +3522,11 @@ void Pathfinder::reset( void )
 		m_wallHeight = 0.0f;
 	}
 	m_zoneManager.reset();
+
+#if RETAIL_COMPATIBLE_PATHFINDING
+	s_useFixedPathfinding = false;
+	s_forceCleanCells = false;
+#endif
 }
 
 /**
@@ -4241,10 +4330,31 @@ void Pathfinder::cleanOpenAndClosedLists(void) {
 		count += PathfindCell::releaseOpenList(m_openList);
 		m_openList = NULL;
 	}
+
+#if RETAIL_COMPATIBLE_PATHFINDING
+	// TheSuperHackers @info this is here as the map cells are contained within the pathfinder and cannot be cleaned externally.
+	// If the crash mode within PathfindCell::releaseOpenList is hit, it will set s_forceCleanCells to allow the system to cleanly recover.
+	if (s_forceCleanCells) {
+		forceCleanCells();
+		// TheSuperHackers @info cells on the closed list are forcefully cleaned up by this point
+		s_forceCleanCells = false;
+	}
+#endif
+
 	if (m_closedList) {
 		count += PathfindCell::releaseClosedList(m_closedList);
 		m_closedList = NULL;
 	}
+
+#if RETAIL_COMPATIBLE_PATHFINDING
+	// TheSuperHackers @info this is here and performs the same function as the above block, but for when the crash occurs within the closed list.
+	// If the crash mode within PathfindCell::releaseClosedList is hit, it will set s_forceCleanCells to allow the system to cleanly recover.
+	if (s_forceCleanCells) {
+		forceCleanCells();
+		s_forceCleanCells = false;
+	}
+#endif
+
 	m_cumulativeCellsAllocated += count;
 //#ifdef RTS_DEBUG
 #if 0
@@ -5955,10 +6065,24 @@ Path *Pathfinder::internalFindPath( Object *obj, const LocomotorSet& locomotorSe
 	zone2 =  m_zoneManager.getEffectiveZone(locomotorSet.getValidSurfaces(), isCrusher, goalCell->getZone());
 
 	if (layer==LAYER_WALL && zone1 == 0) {
+#if RETAIL_COMPATIBLE_PATHFINDING
+		if (s_useFixedPathfinding)
+#endif
+		{
+			goalCell->releaseInfo();
+			parentCell->releaseInfo();
+		}
 		return NULL;
 	}
 
 	if (destinationLayer==LAYER_WALL && zone2 == 0) {
+#if RETAIL_COMPATIBLE_PATHFINDING
+		if (s_useFixedPathfinding)
+#endif
+		{
+			goalCell->releaseInfo();
+			parentCell->releaseInfo();
+		}
 		return NULL;
 	}
 
@@ -6038,8 +6162,18 @@ Path *Pathfinder::internalFindPath( Object *obj, const LocomotorSet& locomotorSe
 			m_isTunneling = false;
 			// construct and return path
 			Path *path =  buildActualPath( obj, locomotorSet.getValidSurfaces(), from, goalCell, centerInCell, false );
-			parentCell->releaseInfo();
-			cleanOpenAndClosedLists();
+#if RETAIL_COMPATIBLE_PATHFINDING
+			if (!s_useFixedPathfinding)
+			{
+				parentCell->releaseInfo();
+				cleanOpenAndClosedLists();
+			}
+			else
+#endif
+			{
+				cleanOpenAndClosedLists();
+				parentCell->releaseInfo();
+			}
 			return path;
 		}
 
@@ -6115,8 +6249,19 @@ Path *Pathfinder::internalFindPath( Object *obj, const LocomotorSet& locomotorSe
 #endif
 
 	m_isTunneling = false;
-	goalCell->releaseInfo();
-	cleanOpenAndClosedLists();
+#if RETAIL_COMPATIBLE_PATHFINDING
+	if (!s_useFixedPathfinding)
+	{
+		goalCell->releaseInfo();
+		cleanOpenAndClosedLists();
+	}
+	else
+#endif
+	{
+		cleanOpenAndClosedLists();
+		parentCell->releaseInfo();
+		goalCell->releaseInfo();
+	}
 	return NULL;
 }
 
@@ -6466,6 +6611,12 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 	PathfindLayerEnum layer = TheTerrainLogic->getLayerForDestination(from);
 	PathfindCell *parentCell = getClippedCell( layer,&clipFrom );
 	if (parentCell == NULL) {
+#if RETAIL_COMPATIBLE_PATHFINDING
+		if (s_useFixedPathfinding)
+#endif
+		{
+			goalCell->releaseInfo();
+		}
 		return NULL;
 	}
 	if (parentCell!=goalCell) {
@@ -6528,8 +6679,18 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 			m_isTunneling = false;
 			// construct and return path
 			Path *path =  buildGroundPath(crusher, from, goalCell, centerInCell, pathDiameter );
-			parentCell->releaseInfo();
-			cleanOpenAndClosedLists();
+#if RETAIL_COMPATIBLE_PATHFINDING
+			if (!s_useFixedPathfinding)
+			{
+				parentCell->releaseInfo();
+				cleanOpenAndClosedLists();
+			}
+			else
+#endif
+			{
+				cleanOpenAndClosedLists();
+				parentCell->releaseInfo();
+			}
 			return path;
 		}
 
@@ -6733,8 +6894,19 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 	TheGameLogic->incrementOverallFailedPathfinds();
 #endif
 	m_isTunneling = false;
-	goalCell->releaseInfo();
-	cleanOpenAndClosedLists();
+#if RETAIL_COMPATIBLE_PATHFINDING
+	if (!s_useFixedPathfinding)
+	{
+		goalCell->releaseInfo();
+		cleanOpenAndClosedLists();
+	}
+	else
+#endif
+	{
+		cleanOpenAndClosedLists();
+		parentCell->releaseInfo();
+		goalCell->releaseInfo();
+	}
 	return NULL;
 }
 
@@ -6788,8 +6960,19 @@ void Pathfinder::processHierarchicalCell( const ICoord2D &scanCell, const ICoord
 		}
 
 		newCell->allocateInfo(scanCell);
-		if (!newCell->getClosed() && !newCell->getOpen()) {
-			m_closedList = newCell->putOnClosedList(m_closedList);
+#if RETAIL_COMPATIBLE_PATHFINDING
+		if (!s_useFixedPathfinding)
+		{
+			if (!newCell->getClosed() && !newCell->getOpen()) {
+				m_closedList = newCell->putOnClosedList(m_closedList);
+			}
+		}
+		else
+#endif
+		{
+			if (newCell->hasInfo() && !newCell->getClosed() && !newCell->getOpen()) {
+				m_closedList = newCell->putOnClosedList(m_closedList);
+			}
 		}
 
 		adjNewCell->allocateInfo(adjacentCell);
@@ -6942,7 +7125,22 @@ Path *Pathfinder::internal_findHierarchicalPath( Bool isHuman, const LocomotorSu
 			// Close parent cell;
 			m_openList = parentCell->removeFromOpenList(m_openList);
 			m_closedList = parentCell->putOnClosedList(m_closedList);
-			startCell->allocateInfo(ndx);
+			if (!startCell->allocateInfo(ndx)) {
+				// TheSuperHackers @info We need to forcefully cleanup dangling pathfinding cells if this failure condition is hit in retail
+				// Retail clients will crash beyond this point, but we attempt to recover by performing a full cleanup then enabling the fixed pathfinding codepath
+#if RETAIL_COMPATIBLE_PATHFINDING
+				if (!s_useFixedPathfinding) {
+					s_useFixedPathfinding = true;
+					forceCleanCells();
+				}
+				else
+#endif
+				{
+					cleanOpenAndClosedLists();
+					goalCell->releaseInfo();
+				}
+				return NULL;
+			}
 			startCell->setParentCellHierarchical(parentCell);
 			cellCount++;
 			Int curCost = startCell->costToHierGoal(parentCell);
@@ -6954,7 +7152,22 @@ Path *Pathfinder::internal_findHierarchicalPath( Bool isHuman, const LocomotorSu
 			m_openList = startCell->putOnSortedOpenList( m_openList );
 
 			cellCount++;
-			cell->allocateInfo(toNdx);
+			if(!cell->allocateInfo(toNdx)) {
+				// TheSuperHackers @info We need to forcefully cleanup dangling pathfinding cells if this failure condition is hit in retail
+				// Retail clients will crash beyond this point, but we attempt to recover by performing a full cleanup then enabling the fixed pathfinding codepath
+#if RETAIL_COMPATIBLE_PATHFINDING
+				if (!s_useFixedPathfinding) {
+					s_useFixedPathfinding = true;
+					forceCleanCells();
+				}
+				else
+#endif
+				{
+					cleanOpenAndClosedLists();
+					goalCell->releaseInfo();
+				}
+				return NULL;
+			}
 			curCost = cell->costToHierGoal(parentCell);
 			remCost = cell->costToHierGoal(goalCell);
 			cell->setCostSoFar(curCost);
@@ -7038,13 +7251,43 @@ Path *Pathfinder::internal_findHierarchicalPath( Bool isHuman, const LocomotorSu
 					PathfindCell *startCell = getCell(LAYER_GROUND, ndx.x, ndx.y);
 					if (startCell==NULL) continue;
 					if (startCell != parentCell) {
-						startCell->allocateInfo(ndx);
+						if(!startCell->allocateInfo(ndx)) {
+							// TheSuperHackers @info We need to forcefully cleanup dangling pathfinding cells if this failure condition is hit in retail
+							// Retail clients will crash beyond this point, but we attempt to recover by performing a full cleanup then enabling the fixed pathfinding codepath
+#if RETAIL_COMPATIBLE_PATHFINDING
+							if (!s_useFixedPathfinding) {
+								s_useFixedPathfinding = true;
+								forceCleanCells();
+							}
+							else
+#endif
+							{
+								cleanOpenAndClosedLists();
+								goalCell->releaseInfo();
+							}
+							return NULL;
+						}
 						startCell->setParentCellHierarchical(parentCell);
 						if (!startCell->getClosed() && !startCell->getOpen()) {
 							m_closedList = startCell->putOnClosedList(m_closedList);
 						}
 					}
-					cell->allocateInfo(toNdx);
+					if(!cell->allocateInfo(toNdx)) {
+						// TheSuperHackers @info We need to forcefully cleanup dangling pathfinding cells if this failure condition is hit in retail
+						// Retail clients will crash beyond this point, but we attempt to recover by performing a full cleanup then enabling the fixed pathfinding codepath
+#if RETAIL_COMPATIBLE_PATHFINDING
+						if (!s_useFixedPathfinding) {
+							s_useFixedPathfinding = true;
+							forceCleanCells();
+						}
+						else
+#endif
+						{
+							cleanOpenAndClosedLists();
+							goalCell->releaseInfo();
+						}
+						return NULL;
+					}
 					cell->setParentCellHierarchical(startCell);
 
 					cellCount++;
@@ -7098,11 +7341,22 @@ Path *Pathfinder::internal_findHierarchicalPath( Bool isHuman, const LocomotorSu
 #endif
 			}
 #endif
-			if (goalCell->hasInfo() && !goalCell->getClosed() && !goalCell->getOpen()) {
+#if RETAIL_COMPATIBLE_PATHFINDING
+			if (!s_useFixedPathfinding)
+			{
+				if (goalCell->hasInfo() && !goalCell->getClosed() && !goalCell->getOpen()) {
+					goalCell->releaseInfo();
+				}
+				parentCell->releaseInfo();
+				cleanOpenAndClosedLists();
+			}
+			else
+#endif
+			{
+				cleanOpenAndClosedLists();
+				parentCell->releaseInfo();
 				goalCell->releaseInfo();
 			}
-			parentCell->releaseInfo();
-			cleanOpenAndClosedLists();
 			return path;
 		}
 
@@ -7299,10 +7553,21 @@ Path *Pathfinder::internal_findHierarchicalPath( Bool isHuman, const LocomotorSu
 		}
 #endif
 #endif
-		if (goalCell->hasInfo() && !goalCell->getClosed() && !goalCell->getOpen()) {
+#if RETAIL_COMPATIBLE_PATHFINDING
+		if (!s_useFixedPathfinding)
+		{
+			if (goalCell->hasInfo() && !goalCell->getClosed() && !goalCell->getOpen()) {
+				goalCell->releaseInfo();
+			}
+			cleanOpenAndClosedLists();
+		}
+		else
+#endif
+		{
+			cleanOpenAndClosedLists();
+			parentCell->releaseInfo();
 			goalCell->releaseInfo();
 		}
-		cleanOpenAndClosedLists();
 		return path;
 	}
 
@@ -7348,8 +7613,20 @@ Path *Pathfinder::internal_findHierarchicalPath( Bool isHuman, const LocomotorSu
 	TheGameLogic->incrementOverallFailedPathfinds();
 #endif
 	m_isTunneling = false;
-	goalCell->releaseInfo();
-	cleanOpenAndClosedLists();
+#if RETAIL_COMPATIBLE_PATHFINDING
+	if (!s_useFixedPathfinding)
+	{
+		goalCell->releaseInfo();
+		cleanOpenAndClosedLists();
+	}
+	else
+#endif
+	{
+		cleanOpenAndClosedLists();
+		parentCell->releaseInfo();
+		goalCell->releaseInfo();
+	}
+
 	return NULL;
 }
 
@@ -7551,7 +7828,11 @@ Bool Pathfinder::pathDestination( 	Object *obj, const LocomotorSet& locomotorSet
 
 	if (parentCell!=goalCell) {
 		if (!parentCell->allocateInfo(startCellNdx)) {
-			desiredCell->releaseInfo();
+#if RETAIL_COMPATIBLE_PATHFINDING
+			if (!s_useFixedPathfinding)	{
+				desiredCell->releaseInfo();
+			}
+#endif
 			goalCell->releaseInfo();
 			return FALSE;
 		}
@@ -7666,6 +7947,13 @@ Bool Pathfinder::pathDestination( 	Object *obj, const LocomotorSet& locomotorSet
 
 			if (!newCell->allocateInfo(newCellCoord)) {
 				// Out of cells for pathing...
+#if RETAIL_COMPATIBLE_PATHFINDING
+				if (s_useFixedPathfinding)
+#endif
+				{
+					cleanOpenAndClosedLists();
+					goalCell->releaseInfo();
+				}
  				return cellCount;
 			}
 			cellCount++;
@@ -7722,8 +8010,19 @@ Bool Pathfinder::pathDestination( 	Object *obj, const LocomotorSet& locomotorSet
 	}
 #endif
 	m_isTunneling = false;
-	cleanOpenAndClosedLists();
-	goalCell->releaseInfo();
+#if RETAIL_COMPATIBLE_PATHFINDING
+	if (!s_useFixedPathfinding) {
+		cleanOpenAndClosedLists();
+		goalCell->releaseInfo();
+	}
+	else
+#endif
+	{
+		cleanOpenAndClosedLists();
+		parentCell->releaseInfo();
+		goalCell->releaseInfo();
+	}
+
 	return false;
 }
 
@@ -7849,14 +8148,32 @@ Int Pathfinder::checkPathCost(Object *obj, const LocomotorSet& locomotorSet, con
 		parentCell = m_openList;
 		m_openList = parentCell->removeFromOpenList(m_openList);
 
-		// put parent cell onto closed list - its evaluation is finished
-		m_closedList = parentCell->putOnClosedList( m_closedList );
+		// put parent cell onto closed list - its evaluation is finished - Retail compatible behaviour
+#if RETAIL_COMPATIBLE_PATHFINDING
+		if (!s_useFixedPathfinding) {
+			m_closedList = parentCell->putOnClosedList( m_closedList );
+		}
+#endif
 
 		if (parentCell==goalCell) {
 			Int cost = parentCell->getTotalCost();
 			m_isTunneling = false;
 			cleanOpenAndClosedLists();
+#if RETAIL_COMPATIBLE_PATHFINDING
+			if (s_useFixedPathfinding)
+#endif
+			{
+				parentCell->releaseInfo();
+			}
 			return cost;
+		}
+
+		// put parent cell onto closed list - its evaluation is finished - Fixed behaviour
+#if RETAIL_COMPATIBLE_PATHFINDING
+		if (s_useFixedPathfinding)
+#endif
+		{
+			m_closedList = parentCell->putOnClosedList( m_closedList );
 		}
 
 		if (cellCount > MAX_CELL_COUNT) {
@@ -7919,6 +8236,14 @@ Int Pathfinder::checkPathCost(Object *obj, const LocomotorSet& locomotorSet, con
 
 			if (!newCell->allocateInfo(newCellCoord)) {
 				// Out of cells for pathing...
+#if RETAIL_COMPATIBLE_PATHFINDING
+				if (s_useFixedPathfinding)
+#endif
+				{
+					cleanOpenAndClosedLists();
+					parentCell->releaseInfo();
+					goalCell->releaseInfo();
+				}
  				return cellCount;
 			}
 			cellCount++;
@@ -7961,16 +8286,36 @@ Int Pathfinder::checkPathCost(Object *obj, const LocomotorSet& locomotorSet, con
 			if (newCell->getOpen())
 				m_openList = newCell->removeFromOpenList( m_openList );
 
+#if RETAIL_COMPATIBLE_PATHFINDING
+			// TheSuperHacker @info This is here to catch a retail pathfinding crash point and to recover from it
+			// A cell has gotten onto the open list without pathfinding info due to a danling m_open pointer on the previous listed cell so we need to force a cleanup
+			if (!s_useFixedPathfinding && m_openList && !m_openList->hasInfo()) {
+				s_useFixedPathfinding = true;
+				forceCleanCells();
+				return MAX_COST;
+			}
+#endif
+
 			// insert newCell in open list such that open list is sorted, smallest total path cost first
 			m_openList = newCell->putOnSortedOpenList( m_openList );
 		}
 	}
 
 	m_isTunneling = false;
-	if (goalCell->hasInfo() && !goalCell->getClosed() && !goalCell->getOpen()) {
+#if RETAIL_COMPATIBLE_PATHFINDING
+	if (!s_useFixedPathfinding) {
+		if (goalCell->hasInfo() && !goalCell->getClosed() && !goalCell->getOpen()) {
+			goalCell->releaseInfo();
+		}
+		cleanOpenAndClosedLists();
+	}
+	else
+#endif
+	{
+		cleanOpenAndClosedLists();
+		parentCell->releaseInfo();
 		goalCell->releaseInfo();
 	}
-	cleanOpenAndClosedLists();
 	return MAX_COST;
 }
 
@@ -8107,6 +8452,12 @@ Path *Pathfinder::findClosestPath( Object *obj, const LocomotorSet& locomotorSet
 	if (parentCell!=goalCell) {
 		worldToCell(&clipFrom, &pos2d);
 		if (!parentCell->allocateInfo(pos2d)) {
+#if RETAIL_COMPATIBLE_PATHFINDING
+			if (s_useFixedPathfinding)
+#endif
+			{
+				goalCell->releaseInfo();
+			}
 			return NULL;
 		}
 	}
@@ -8169,9 +8520,20 @@ Path *Pathfinder::findClosestPath( Object *obj, const LocomotorSet& locomotorSet
 			m_isTunneling = false;
 			// construct and return path
 			Path *path = buildActualPath( obj, locomotorSet.getValidSurfaces(), from, goalCell, centerInCell, blocked);
-			parentCell->releaseInfo();
-			goalCell->releaseInfo();
-			cleanOpenAndClosedLists();
+#if RETAIL_COMPATIBLE_PATHFINDING
+			if (!s_useFixedPathfinding) {
+				parentCell->releaseInfo();
+				goalCell->releaseInfo();
+				cleanOpenAndClosedLists();
+			}
+			else
+#endif
+			{
+				cleanOpenAndClosedLists();
+				parentCell->releaseInfo();
+				goalCell->releaseInfo();
+			}
+
 			return path;
 		}
 		// put parent cell onto closed list - its evaluation is finished
@@ -8250,8 +8612,18 @@ Path *Pathfinder::findClosestPath( Object *obj, const LocomotorSet& locomotorSet
 		rawTo->y = closesetCell->getYIndex()*PATHFIND_CELL_SIZE_F + PATHFIND_CELL_SIZE_F/2.0f;
 		// construct and return path
 		Path *path = buildActualPath( obj, locomotorSet.getValidSurfaces(), from, closesetCell, centerInCell, blocked );
-		goalCell->releaseInfo();
-		cleanOpenAndClosedLists();
+#if RETAIL_COMPATIBLE_PATHFINDING
+		if (!s_useFixedPathfinding) {
+			goalCell->releaseInfo();
+			cleanOpenAndClosedLists();
+		}
+		else
+#endif
+		{
+			cleanOpenAndClosedLists();
+			parentCell->releaseInfo();
+			goalCell->releaseInfo();
+		}
 		return path;
 	}
 
@@ -8271,8 +8643,18 @@ Path *Pathfinder::findClosestPath( Object *obj, const LocomotorSet& locomotorSet
 	TheGameLogic->incrementOverallFailedPathfinds();
 #endif
 	m_isTunneling = false;
-	goalCell->releaseInfo();
-	cleanOpenAndClosedLists();
+#if RETAIL_COMPATIBLE_PATHFINDING
+	if (!s_useFixedPathfinding) {
+		goalCell->releaseInfo();
+		cleanOpenAndClosedLists();
+	}
+	else
+#endif
+	{
+		cleanOpenAndClosedLists();
+		parentCell->releaseInfo();
+		goalCell->releaseInfo();
+	}
 	return NULL;
 }
 
@@ -8394,6 +8776,33 @@ void Pathfinder::prependCells( Path *path, const Coord3D *fromPos,
 		}
 		prevCell = cell;
 	}
+
+#if RETAIL_COMPATIBLE_PATHFINDING
+	// TheSuperHackers @info This pathway is here for retail compatibility, it is to catch when a starting cell has a dangling parent that contains no pathing information
+	// Beyond this point a retail client will crash due to a null pointer access within cell->getXIndex()
+	// To recover from this we set the cell to the previous cell, which should be the actual starting cell then set to use the fixed pathing and perform a forced cleanup
+	if (!s_useFixedPathfinding) {
+		if (!cell->hasInfo()) {
+			cell = prevCell;
+
+			m_zoneManager.setPassable(cell->getXIndex(), cell->getYIndex(), true);
+			if (goalCellNull) {
+				// Very short path.
+				adjustCoordToCell(cell->getXIndex(), cell->getYIndex(), center, pos, cell->getLayer());
+				path->prependNode( &pos, cell->getLayer() );
+			}
+			// put actual start position as first node on the path, so it begins right at the unit's feet
+			if (fromPos->x != path->getFirstNode()->getPosition()->x || fromPos->y != path->getFirstNode()->getPosition()->y) {
+				path->prependNode( fromPos, cell->getLayer() );
+			}
+
+			s_useFixedPathfinding = true;
+			forceCleanCells();
+			return;
+		}
+	}
+#endif
+
 	m_zoneManager.setPassable(cell->getXIndex(), cell->getYIndex(), true);
 	if (goalCellNull) {
 		// Very short path.
@@ -9633,8 +10042,17 @@ Path *Pathfinder::getMoveAwayFromPath(Object* obj, Object *otherObj,
 			m_isTunneling = false;
 			// construct and return path
 			Path *newPath = buildActualPath( obj, locomotorSet.getValidSurfaces(), obj->getPosition(), parentCell, centerInCell, false);
-			parentCell->releaseInfo();
-			cleanOpenAndClosedLists();
+#if RETAIL_COMPATIBLE_PATHFINDING
+			if (!s_useFixedPathfinding) {
+				parentCell->releaseInfo();
+				cleanOpenAndClosedLists();
+			}
+			else
+#endif
+			{
+				cleanOpenAndClosedLists();
+				parentCell->releaseInfo();
+			}
 			return newPath;
 		}
 		// put parent cell onto closed list - its evaluation is finished
@@ -9655,7 +10073,16 @@ Path *Pathfinder::getMoveAwayFromPath(Object* obj, Object *otherObj,
 	DEBUG_LOG(("Unit '%s', time %f", obj->getTemplate()->getName().str(), (::GetTickCount()-startTimeMS)/1000.0f));
 
 	m_isTunneling = false;
-	cleanOpenAndClosedLists();
+#if RETAIL_COMPATIBLE_PATHFINDING
+	if (!s_useFixedPathfinding) {
+		cleanOpenAndClosedLists();
+	}
+	else
+#endif
+	{
+		cleanOpenAndClosedLists();
+		parentCell->releaseInfo();
+	}
 	return NULL;
 }
 
@@ -9771,7 +10198,15 @@ Path *Pathfinder::patchPath( const Object *obj, const LocomotorSet& locomotorSet
 
 	}
 	if (startNode == originalPath->getLastNode()) {
-		cleanOpenAndClosedLists();
+#if RETAIL_COMPATIBLE_PATHFINDING
+		if (!s_useFixedPathfinding) {
+			cleanOpenAndClosedLists();
+		}
+		else
+#endif
+		{
+			parentCell->releaseInfo();
+		}
 		return NULL; // no open nodes.
 	}
 	PathfindCell *candidateGoal;
@@ -9779,6 +10214,12 @@ Path *Pathfinder::patchPath( const Object *obj, const LocomotorSet& locomotorSet
 	ICoord2D goalCellNdx;
 	worldToCell(&goalPos, &goalCellNdx);
 	if (!candidateGoal->allocateInfo(goalCellNdx)) {
+#if RETAIL_COMPATIBLE_PATHFINDING
+		if (s_useFixedPathfinding)
+#endif
+		{
+			parentCell->releaseInfo();
+		}
 		return NULL;
 	}
 
@@ -9813,9 +10254,19 @@ Path *Pathfinder::patchPath( const Object *obj, const LocomotorSet& locomotorSet
 
 			// cleanup the path by checking line of sight
 			path->optimize(obj, locomotorSet.getValidSurfaces(), blocked);
-			parentCell->releaseInfo();
-			cleanOpenAndClosedLists();
-			candidateGoal->releaseInfo();
+#if RETAIL_COMPATIBLE_PATHFINDING
+			if (!s_useFixedPathfinding) {
+				parentCell->releaseInfo();
+				cleanOpenAndClosedLists();
+				candidateGoal->releaseInfo();
+			}
+			else
+#endif
+			{
+				cleanOpenAndClosedLists();
+				parentCell->releaseInfo();
+				candidateGoal->releaseInfo();
+			}
 
 			return path;
 		}
@@ -9838,12 +10289,22 @@ Path *Pathfinder::patchPath( const Object *obj, const LocomotorSet& locomotorSet
 	}
 #endif
 	m_isTunneling = false;
-	if (!candidateGoal->getOpen() && !candidateGoal->getClosed())
+#if RETAIL_COMPATIBLE_PATHFINDING
+	if (!s_useFixedPathfinding) {
+		if (!candidateGoal->getOpen() && !candidateGoal->getClosed())
+		{
+			// Not on one of the lists 
+			candidateGoal->releaseInfo();
+		}
+		cleanOpenAndClosedLists();
+	}
+	else
+#endif
 	{
-		// Not on one of the lists
+		cleanOpenAndClosedLists();
+		parentCell->releaseInfo();
 		candidateGoal->releaseInfo();
 	}
-	cleanOpenAndClosedLists();
 	return NULL;
 }
 
@@ -10077,11 +10538,20 @@ Path *Pathfinder::findAttackPath( const Object *obj, const LocomotorSet& locomot
 	#endif
 				// construct and return path
 				Path *path = buildActualPath( obj, locomotorSet.getValidSurfaces(), obj->getPosition(), parentCell, centerInCell, false);
-				parentCell->releaseInfo();
-				if (goalCell->hasInfo() && !goalCell->getClosed() && !goalCell->getOpen()) {
+#if RETAIL_COMPATIBLE_PATHFINDING
+				if (!s_useFixedPathfinding) {
+					if (goalCell->hasInfo() && !goalCell->getClosed() && !goalCell->getOpen()) {
+						goalCell->releaseInfo();
+					}
+					cleanOpenAndClosedLists();
+				}
+				else
+#endif
+				{
+					cleanOpenAndClosedLists();
+					parentCell->releaseInfo();
 					goalCell->releaseInfo();
 				}
-				cleanOpenAndClosedLists();
 				return path;
 			}
 		}
@@ -10137,10 +10607,20 @@ Path *Pathfinder::findAttackPath( const Object *obj, const LocomotorSet& locomot
 	TheGameLogic->incrementOverallFailedPathfinds();
 #endif
 	m_isTunneling = false;
-	if (goalCell->hasInfo() && !goalCell->getClosed() && !goalCell->getOpen()) {
+#if RETAIL_COMPATIBLE_PATHFINDING
+	if (!s_useFixedPathfinding) {
+		if (goalCell->hasInfo() && !goalCell->getClosed() && !goalCell->getOpen()) {
+			goalCell->releaseInfo();
+		}
+		cleanOpenAndClosedLists();
+	}
+	else
+#endif
+	{
+		cleanOpenAndClosedLists();
+		parentCell->releaseInfo();
 		goalCell->releaseInfo();
 	}
-	cleanOpenAndClosedLists();
 	return NULL;
 }
 
@@ -10262,8 +10742,17 @@ Path *Pathfinder::findSafePath( const Object *obj, const LocomotorSet& locomotor
 #endif
 			// construct and return path
 			Path *path = buildActualPath( obj, locomotorSet.getValidSurfaces(), obj->getPosition(), parentCell, centerInCell, false);
-			parentCell->releaseInfo();
-			cleanOpenAndClosedLists();
+#if RETAIL_COMPATIBLE_PATHFINDING
+			if (!s_useFixedPathfinding) {
+				parentCell->releaseInfo();
+				cleanOpenAndClosedLists();
+			}
+			else
+#endif
+			{
+				cleanOpenAndClosedLists();
+				parentCell->releaseInfo();
+			}
 			return path;
 		}
 
@@ -10297,7 +10786,16 @@ Path *Pathfinder::findSafePath( const Object *obj, const LocomotorSet& locomotor
 	TheGameLogic->incrementOverallFailedPathfinds();
 #endif
 	m_isTunneling = false;
-	cleanOpenAndClosedLists();
+#if RETAIL_COMPATIBLE_PATHFINDING
+	if (!s_useFixedPathfinding) {
+		cleanOpenAndClosedLists();
+	}
+	else
+#endif
+	{
+		cleanOpenAndClosedLists();
+		parentCell->releaseInfo();
+	}
 	return NULL;
 }
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AIPathfind.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AIPathfind.h
@@ -208,6 +208,9 @@ class PathfindCellInfo
 {
 	friend class PathfindCell;
 public:
+#if RETAIL_COMPATIBLE_PATHFINDING
+	static void forceCleanPathFindCellInfos(void);
+#endif
 	static void allocateCellInfos(void);
 	static void releaseCellInfos(void);
 
@@ -699,6 +702,9 @@ public:
 	Path *getDebugPath( void );
 	void setDebugPath( Path *debugpath );
 
+#if RETAIL_COMPATIBLE_PATHFINDING
+	void forceCleanCells(void);
+#endif
 	void cleanOpenAndClosedLists(void);
 
 	// Adjusts the destination to a spot near dest that is not occupied by other units.

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -1238,7 +1238,7 @@ Bool PathfindCell::startPathfind( PathfindCell *goalCell  )
 	if (goalCell) {
 		m_info->m_totalCost = costToGoal( goalCell );
 	}
-	m_info->m_open = TRUE;
+	m_info->m_open = FALSE;
 	m_info->m_closed = FALSE;
 	return true;
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -7359,7 +7359,7 @@ void Pathfinder::processHierarchicalCell( const ICoord2D &scanCell, const ICoord
 		}
 
 		newCell->allocateInfo(scanCell);
-		if (!newCell->getClosed() && !newCell->getOpen()) {
+		if (newCell->hasInfo() && !newCell->getClosed() && !newCell->getOpen()) {
 			m_closedList = newCell->putOnClosedList(m_closedList);
 		}
 
@@ -7517,7 +7517,11 @@ Path *Pathfinder::internal_findHierarchicalPath( Bool isHuman, const LocomotorSu
 			// Close parent cell;
 			m_openList = parentCell->removeFromOpenList(m_openList);
 			m_closedList = parentCell->putOnClosedList(m_closedList);
-			startCell->allocateInfo(ndx);
+			if (!startCell->allocateInfo(ndx)) {
+				cleanOpenAndClosedLists();
+				goalCell->releaseInfo();
+				return NULL;
+			}
 			startCell->setParentCellHierarchical(parentCell);
 			cellCount++;
 			Int curCost = startCell->costToHierGoal(parentCell);
@@ -7529,7 +7533,11 @@ Path *Pathfinder::internal_findHierarchicalPath( Bool isHuman, const LocomotorSu
 			m_openList = startCell->putOnSortedOpenList( m_openList );
 
 			cellCount++;
-			cell->allocateInfo(toNdx);
+			if(!cell->allocateInfo(toNdx)) {
+				cleanOpenAndClosedLists();
+				goalCell->releaseInfo();
+				return NULL;
+			}
 			curCost = cell->costToHierGoal(parentCell);
 			remCost = cell->costToHierGoal(goalCell);
 			cell->setCostSoFar(curCost);
@@ -7613,13 +7621,21 @@ Path *Pathfinder::internal_findHierarchicalPath( Bool isHuman, const LocomotorSu
 					PathfindCell *startCell = getCell(LAYER_GROUND, ndx.x, ndx.y);
 					if (startCell==NULL) continue;
 					if (startCell != parentCell) {
-						startCell->allocateInfo(ndx);
+						if(!startCell->allocateInfo(ndx)) {
+							cleanOpenAndClosedLists();
+							goalCell->releaseInfo();
+							return NULL;
+						}
 						startCell->setParentCellHierarchical(parentCell);
 						if (!startCell->getClosed() && !startCell->getOpen()) {
 							m_closedList = startCell->putOnClosedList(m_closedList);
 						}
 					}
-					cell->allocateInfo(toNdx);
+					if(!cell->allocateInfo(toNdx)) {
+						cleanOpenAndClosedLists();
+						goalCell->releaseInfo();
+						return NULL;
+					}
 					cell->setParentCellHierarchical(startCell);
 
 					cellCount++;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -1100,6 +1100,39 @@ enum { PATHFIND_CELLS_PER_FRAME=5000}; // Number of cells we will search pathfin
 enum {CELL_INFOS_TO_ALLOCATE = 30000};
 PathfindCellInfo *PathfindCellInfo::s_infoArray = NULL;
 PathfindCellInfo *PathfindCellInfo::s_firstFree = NULL;
+
+#if RETAIL_COMPATIBLE_PATHFINDING
+// TheSuperHackers @info This variable is here so the code will run down the retail compatible path till a failure mode is hit
+// The pathfinding will then switch over to the corrected pathfinding code for SH clients
+Bool s_useFixedPathfinding = false;
+Bool s_forceCleanCells = false;
+
+void PathfindCellInfo::forceCleanPathFindCellInfos()
+{
+	for (Int i = 0; i < CELL_INFOS_TO_ALLOCATE - 1; i++) {
+		s_infoArray[i].m_nextOpen = NULL;
+		s_infoArray[i].m_prevOpen = NULL;
+		s_infoArray[i].m_open = FALSE;
+		s_infoArray[i].m_closed = FALSE;
+	}
+}
+
+void Pathfinder::forceCleanCells()
+{
+	PathfindCellInfo::forceCleanPathFindCellInfos();
+	m_openList = NULL;
+	m_closedList = NULL;
+
+	for (int j = 0; j <= m_extent.hi.y; ++j) {
+		for (int i = 0; i <= m_extent.hi.x; ++i) {
+			if (m_map[i][j].hasInfo()) {
+				m_map[i][j].releaseInfo();
+			}
+		}
+	}
+}
+#endif
+
 /**
  * Allocates a pool of pathfind cell infos.
  */
@@ -1238,7 +1271,14 @@ Bool PathfindCell::startPathfind( PathfindCell *goalCell  )
 	if (goalCell) {
 		m_info->m_totalCost = costToGoal( goalCell );
 	}
-	m_info->m_open = FALSE;
+#if RETAIL_COMPATIBLE_PATHFINDING
+	if (!s_useFixedPathfinding) {
+		m_info->m_open = TRUE;
+	} else
+#endif
+	{
+		m_info->m_open = FALSE;
+	}
 	m_info->m_closed = FALSE;
 	return true;
 }
@@ -1294,9 +1334,14 @@ void PathfindCell::releaseInfo( void )
 { 
 	// TheSuperHackers @bugfix Mauller/SkyAero 05/06/2025 Parent cell links need clearing to prevent dangling pointers on starting points that can link them to an invalid parent cell.
 	// Parent cells are only cleared within Pathfinder::prependCells, so cells that do not make it onto the final path do not get their parent cell cleared.
-	// Cells with a special flags also do not get their pathfindinfo cleared and therefore can leave a parent cell set on a starting cell.
-	if (m_info) {
-		m_info->m_pathParent = NULL;
+	// Cells with a special flags also do not get their PathfindCellInfo cleared and therefore can leave a parent cell set on a starting cell.
+#if RETAIL_COMPATIBLE_PATHFINDING
+	if (s_useFixedPathfinding)
+#endif
+	{
+		if (m_info) {
+			m_info->m_pathParent = NULL;
+		}
 	}
 	if (m_type==PathfindCell::CELL_OBSTACLE) {
 		return;
@@ -1592,9 +1637,21 @@ Int PathfindCell::releaseOpenList( PathfindCell *list )
 		DEBUG_ASSERTCRASH(list->m_info->m_closed==FALSE && list->m_info->m_open==TRUE, ("Serious error - Invalid flags. jba"));
 		PathfindCell *cur = list;
 		PathfindCellInfo *curInfo = list->m_info;
+
+#if RETAIL_COMPATIBLE_PATHFINDING
+		// TheSuperHackers @info This is only here to catch a crash point in the retail compatible pathfinding
+		// One crash mode is where a cell has no PathfindCellInfo, resulting in a nullptr access and a crash.
+		// Therefore we signal that we need to clean the maps cells and the PathfindCellInfos
+		if(!curInfo && !s_useFixedPathfinding) {
+			s_useFixedPathfinding = true;
+			s_forceCleanCells = true;
+			return count;
+		}
+#endif
+
 		if (curInfo->m_nextOpen) {
 			list = curInfo->m_nextOpen->m_cell;
-		}	else {
+		} else {
 			list = NULL;
 		}
 		DEBUG_ASSERTCRASH(cur == curInfo->m_cell, ("Bad backpointer in PathfindCellInfo"));
@@ -1616,9 +1673,20 @@ Int PathfindCell::releaseClosedList( PathfindCell *list )
 		DEBUG_ASSERTCRASH(list->m_info->m_closed==TRUE && list->m_info->m_open==FALSE, ("Serious error - Invalid flags. jba"));
 		PathfindCell *cur = list;
 		PathfindCellInfo *curInfo = list->m_info;
+#if RETAIL_COMPATIBLE_PATHFINDING
+		// TheSuperHackers @info This is only here to catch a crash point in the retail compatible pathfinding
+		// One crash mode is where a cell has no PathfindCellInfo, resulting in a nullptr access and a crash.
+		// Therefore we signal that we need to clean the maps cells and the PathfindCellInfos
+		if(!curInfo && !s_useFixedPathfinding) {
+			s_useFixedPathfinding = true;
+			s_forceCleanCells = true;
+			return count;
+		}
+#endif
+
 		if (curInfo->m_nextOpen) {
 			list = curInfo->m_nextOpen->m_cell;
-		}	else {
+		} else {
 			list = NULL;
 		}
 		DEBUG_ASSERTCRASH(cur == curInfo->m_cell, ("Bad backpointer in PathfindCellInfo"));
@@ -1742,6 +1810,16 @@ UnsignedInt PathfindCell::costSoFar( PathfindCell *parent )
 	Int numTurns = 0;
 	PathfindCell *prevCell = parent->getParentCell();
 	if (prevCell) {
+
+#if RETAIL_COMPATIBLE_PATHFINDING
+		// TheSuperHackers @info this is a possible crash point in the retail pathfinding, we just prevent the crash at this point
+		// External code should catch the issue in another block and cleanup the pathfinding before switching to the fixed pathfinding.
+		if (!prevCell->hasInfo())
+		{
+			return cost;
+		}
+#endif
+
 		ICoord2D dir;
 		dir.x = prevCell->getXIndex() - parent->getXIndex();
 		dir.y = prevCell->getYIndex() - parent->getYIndex();
@@ -3886,6 +3964,11 @@ void Pathfinder::reset( void )
 		m_wallHeight = 0.0f;
 	}
 	m_zoneManager.reset();
+
+#if RETAIL_COMPATIBLE_PATHFINDING
+	s_useFixedPathfinding = false;
+	s_forceCleanCells = false;
+#endif
 }
 
 /**
@@ -4741,10 +4824,31 @@ void Pathfinder::cleanOpenAndClosedLists(void) {
 		count += PathfindCell::releaseOpenList(m_openList);
 		m_openList = NULL;
 	}
+
+#if RETAIL_COMPATIBLE_PATHFINDING
+	// TheSuperHackers @info this is here as the map cells are contained within the pathfinder and cannot be cleaned externally.
+	// If the crash mode within PathfindCell::releaseOpenList is hit, it will set s_forceCleanCells to allow the system to cleanly recover.
+	if (s_forceCleanCells) {
+		forceCleanCells();
+		// TheSuperHackers @info cells on the closed list are forcefully cleaned up by this point
+		s_forceCleanCells = false;
+	}
+#endif
+
 	if (m_closedList) {
 		count += PathfindCell::releaseClosedList(m_closedList);
 		m_closedList = NULL;
 	}
+
+#if RETAIL_COMPATIBLE_PATHFINDING
+	// TheSuperHackers @info this is here and performs the same function as the above block, but for when the crash occurs within the closed list.
+	// If the crash mode within PathfindCell::releaseClosedList is hit, it will set s_forceCleanCells to allow the system to cleanly recover.
+	if (s_forceCleanCells) {
+		forceCleanCells();
+		s_forceCleanCells = false;
+	}
+#endif
+
 	m_cumulativeCellsAllocated += count;
 //#ifdef RTS_DEBUG
 #if 0
@@ -6483,14 +6587,24 @@ Path *Pathfinder::internalFindPath( Object *obj, const LocomotorSet& locomotorSe
 	zone2 =  m_zoneManager.getEffectiveZone(locomotorSet.getValidSurfaces(), isCrusher, goalCell->getZone());
 
 	if (layer==LAYER_WALL && zone1 == 0) {
-		goalCell->releaseInfo();
-		parentCell->releaseInfo();
+#if RETAIL_COMPATIBLE_PATHFINDING
+		if (s_useFixedPathfinding)
+#endif
+		{
+			goalCell->releaseInfo();
+			parentCell->releaseInfo();
+		}
 		return NULL;
 	}
 
 	if (destinationLayer==LAYER_WALL && zone2 == 0) {
-		goalCell->releaseInfo();
-		parentCell->releaseInfo();
+#if RETAIL_COMPATIBLE_PATHFINDING
+		if (s_useFixedPathfinding)
+#endif
+		{
+			goalCell->releaseInfo();
+			parentCell->releaseInfo();
+		}
 		return NULL;
 	}
 
@@ -6570,8 +6684,18 @@ Path *Pathfinder::internalFindPath( Object *obj, const LocomotorSet& locomotorSe
 			m_isTunneling = false;
 			// construct and return path
 			Path *path =  buildActualPath( obj, locomotorSet.getValidSurfaces(), from, goalCell, centerInCell, false );
-			cleanOpenAndClosedLists();
-			parentCell->releaseInfo();
+#if RETAIL_COMPATIBLE_PATHFINDING
+			if (!s_useFixedPathfinding)
+			{
+				parentCell->releaseInfo();
+				cleanOpenAndClosedLists();
+			}
+			else
+#endif
+			{
+				cleanOpenAndClosedLists();
+				parentCell->releaseInfo();
+			}
 			return path;
 		}
 
@@ -6647,9 +6771,19 @@ Path *Pathfinder::internalFindPath( Object *obj, const LocomotorSet& locomotorSe
 #endif
 
 	m_isTunneling = false;
-	cleanOpenAndClosedLists();
-	parentCell->releaseInfo();
-	goalCell->releaseInfo();
+#if RETAIL_COMPATIBLE_PATHFINDING
+	if (!s_useFixedPathfinding)
+	{
+		goalCell->releaseInfo();
+		cleanOpenAndClosedLists();
+	}
+	else
+#endif
+	{
+		cleanOpenAndClosedLists();
+		parentCell->releaseInfo();
+		goalCell->releaseInfo();
+	}
 	return NULL;
 }
 
@@ -7025,7 +7159,12 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 	PathfindLayerEnum layer = TheTerrainLogic->getLayerForDestination(from);
 	PathfindCell *parentCell = getClippedCell( layer,&clipFrom );
 	if (parentCell == NULL) {
-		goalCell->releaseInfo();
+#if RETAIL_COMPATIBLE_PATHFINDING
+		if (s_useFixedPathfinding)
+#endif
+		{
+			goalCell->releaseInfo();
+		}
 		return NULL;
 	}
 	if (parentCell!=goalCell) {
@@ -7088,8 +7227,18 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 			m_isTunneling = false;
 			// construct and return path
 			Path *path =  buildGroundPath(crusher, from, goalCell, centerInCell, pathDiameter );
-			cleanOpenAndClosedLists();
-			parentCell->releaseInfo();
+#if RETAIL_COMPATIBLE_PATHFINDING
+			if (!s_useFixedPathfinding)
+			{
+				parentCell->releaseInfo();
+				cleanOpenAndClosedLists();
+			}
+			else
+#endif
+			{
+				cleanOpenAndClosedLists();
+				parentCell->releaseInfo();
+			}
 			return path;
 		}
 
@@ -7293,9 +7442,19 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 	TheGameLogic->incrementOverallFailedPathfinds();
 #endif
 	m_isTunneling = false;
-	cleanOpenAndClosedLists();
-	parentCell->releaseInfo();
-	goalCell->releaseInfo();
+#if RETAIL_COMPATIBLE_PATHFINDING
+	if (!s_useFixedPathfinding)
+	{
+		goalCell->releaseInfo();
+		cleanOpenAndClosedLists();
+	}
+	else
+#endif
+	{
+		cleanOpenAndClosedLists();
+		parentCell->releaseInfo();
+		goalCell->releaseInfo();
+	}
 	return NULL;
 }
 
@@ -7359,8 +7518,19 @@ void Pathfinder::processHierarchicalCell( const ICoord2D &scanCell, const ICoord
 		}
 
 		newCell->allocateInfo(scanCell);
-		if (newCell->hasInfo() && !newCell->getClosed() && !newCell->getOpen()) {
-			m_closedList = newCell->putOnClosedList(m_closedList);
+#if RETAIL_COMPATIBLE_PATHFINDING
+		if (!s_useFixedPathfinding)
+		{
+			if (!newCell->getClosed() && !newCell->getOpen()) {
+				m_closedList = newCell->putOnClosedList(m_closedList);
+			}
+		}
+		else
+#endif
+		{
+			if (newCell->hasInfo() && !newCell->getClosed() && !newCell->getOpen()) {
+				m_closedList = newCell->putOnClosedList(m_closedList);
+			}
 		}
 
 		adjNewCell->allocateInfo(adjacentCell);
@@ -7518,8 +7688,19 @@ Path *Pathfinder::internal_findHierarchicalPath( Bool isHuman, const LocomotorSu
 			m_openList = parentCell->removeFromOpenList(m_openList);
 			m_closedList = parentCell->putOnClosedList(m_closedList);
 			if (!startCell->allocateInfo(ndx)) {
-				cleanOpenAndClosedLists();
-				goalCell->releaseInfo();
+				// TheSuperHackers @info We need to forcefully cleanup dangling pathfinding cells if this failure condition is hit in retail
+				// Retail clients will crash beyond this point, but we attempt to recover by performing a full cleanup then enabling the fixed pathfinding codepath
+#if RETAIL_COMPATIBLE_PATHFINDING
+				if (!s_useFixedPathfinding) {
+					s_useFixedPathfinding = true;
+					forceCleanCells();
+				}
+				else
+#endif
+				{
+					cleanOpenAndClosedLists();
+					goalCell->releaseInfo();
+				}
 				return NULL;
 			}
 			startCell->setParentCellHierarchical(parentCell);
@@ -7534,8 +7715,19 @@ Path *Pathfinder::internal_findHierarchicalPath( Bool isHuman, const LocomotorSu
 
 			cellCount++;
 			if(!cell->allocateInfo(toNdx)) {
-				cleanOpenAndClosedLists();
-				goalCell->releaseInfo();
+				// TheSuperHackers @info We need to forcefully cleanup dangling pathfinding cells if this failure condition is hit in retail
+				// Retail clients will crash beyond this point, but we attempt to recover by performing a full cleanup then enabling the fixed pathfinding codepath
+#if RETAIL_COMPATIBLE_PATHFINDING
+				if (!s_useFixedPathfinding) {
+					s_useFixedPathfinding = true;
+					forceCleanCells();
+				}
+				else
+#endif
+				{
+					cleanOpenAndClosedLists();
+					goalCell->releaseInfo();
+				}
 				return NULL;
 			}
 			curCost = cell->costToHierGoal(parentCell);
@@ -7622,8 +7814,19 @@ Path *Pathfinder::internal_findHierarchicalPath( Bool isHuman, const LocomotorSu
 					if (startCell==NULL) continue;
 					if (startCell != parentCell) {
 						if(!startCell->allocateInfo(ndx)) {
-							cleanOpenAndClosedLists();
-							goalCell->releaseInfo();
+							// TheSuperHackers @info We need to forcefully cleanup dangling pathfinding cells if this failure condition is hit in retail
+							// Retail clients will crash beyond this point, but we attempt to recover by performing a full cleanup then enabling the fixed pathfinding codepath
+#if RETAIL_COMPATIBLE_PATHFINDING
+							if (!s_useFixedPathfinding) {
+								s_useFixedPathfinding = true;
+								forceCleanCells();
+							}
+							else
+#endif
+							{
+								cleanOpenAndClosedLists();
+								goalCell->releaseInfo();
+							}
 							return NULL;
 						}
 						startCell->setParentCellHierarchical(parentCell);
@@ -7632,8 +7835,19 @@ Path *Pathfinder::internal_findHierarchicalPath( Bool isHuman, const LocomotorSu
 						}
 					}
 					if(!cell->allocateInfo(toNdx)) {
-						cleanOpenAndClosedLists();
-						goalCell->releaseInfo();
+						// TheSuperHackers @info We need to forcefully cleanup dangling pathfinding cells if this failure condition is hit in retail
+						// Retail clients will crash beyond this point, but we attempt to recover by performing a full cleanup then enabling the fixed pathfinding codepath
+#if RETAIL_COMPATIBLE_PATHFINDING
+						if (!s_useFixedPathfinding) {
+							s_useFixedPathfinding = true;
+							forceCleanCells();
+						}
+						else
+#endif
+						{
+							cleanOpenAndClosedLists();
+							goalCell->releaseInfo();
+						}
 						return NULL;
 					}
 					cell->setParentCellHierarchical(startCell);
@@ -7689,9 +7903,22 @@ Path *Pathfinder::internal_findHierarchicalPath( Bool isHuman, const LocomotorSu
 #endif
 			}
 #endif
-			cleanOpenAndClosedLists();
-			parentCell->releaseInfo();
-			goalCell->releaseInfo();
+#if RETAIL_COMPATIBLE_PATHFINDING
+			if (!s_useFixedPathfinding)
+			{
+				if (goalCell->hasInfo() && !goalCell->getClosed() && !goalCell->getOpen()) {
+					goalCell->releaseInfo();
+				}
+				parentCell->releaseInfo();
+				cleanOpenAndClosedLists();
+			}
+			else
+#endif
+			{
+				cleanOpenAndClosedLists();
+				parentCell->releaseInfo();
+				goalCell->releaseInfo();
+			}
 			return path;
 		}
 
@@ -7888,9 +8115,21 @@ Path *Pathfinder::internal_findHierarchicalPath( Bool isHuman, const LocomotorSu
 		}
 #endif
 #endif
-		cleanOpenAndClosedLists();
-		parentCell->releaseInfo();
-		goalCell->releaseInfo();
+#if RETAIL_COMPATIBLE_PATHFINDING
+		if (!s_useFixedPathfinding)
+		{
+			if (goalCell->hasInfo() && !goalCell->getClosed() && !goalCell->getOpen()) {
+				goalCell->releaseInfo();
+			}
+			cleanOpenAndClosedLists();
+		}
+		else
+#endif
+		{
+			cleanOpenAndClosedLists();
+			parentCell->releaseInfo();
+			goalCell->releaseInfo();
+		}
 		return path;
 	}
 
@@ -7936,9 +8175,20 @@ Path *Pathfinder::internal_findHierarchicalPath( Bool isHuman, const LocomotorSu
 	TheGameLogic->incrementOverallFailedPathfinds();
 #endif
 	m_isTunneling = false;
-	cleanOpenAndClosedLists();
-	parentCell->releaseInfo();
-	goalCell->releaseInfo();
+#if RETAIL_COMPATIBLE_PATHFINDING
+	if (!s_useFixedPathfinding)
+	{
+		goalCell->releaseInfo();
+		cleanOpenAndClosedLists();
+	}
+	else
+#endif
+	{
+		cleanOpenAndClosedLists();
+		parentCell->releaseInfo();
+		goalCell->releaseInfo();
+	}
+
 	return NULL;
 }
 
@@ -8202,6 +8452,11 @@ Bool Pathfinder::pathDestination( 	Object *obj, const LocomotorSet& locomotorSet
 
 	if (parentCell!=goalCell) {
 		if (!parentCell->allocateInfo(startCellNdx)) {
+#if RETAIL_COMPATIBLE_PATHFINDING
+			if (!s_useFixedPathfinding)	{
+				desiredCell->releaseInfo();
+			}
+#endif
 			goalCell->releaseInfo();
 			return FALSE;
 		}
@@ -8316,8 +8571,13 @@ Bool Pathfinder::pathDestination( 	Object *obj, const LocomotorSet& locomotorSet
 
 			if (!newCell->allocateInfo(newCellCoord)) {
 				// Out of cells for pathing...
-				cleanOpenAndClosedLists();
-				goalCell->releaseInfo();
+#if RETAIL_COMPATIBLE_PATHFINDING
+				if (s_useFixedPathfinding)
+#endif
+				{
+					cleanOpenAndClosedLists();
+					goalCell->releaseInfo();
+				}
  				return cellCount;
 			}
 			cellCount++;
@@ -8374,9 +8634,19 @@ Bool Pathfinder::pathDestination( 	Object *obj, const LocomotorSet& locomotorSet
 	}
 #endif
 	m_isTunneling = false;
-	cleanOpenAndClosedLists();
-	parentCell->releaseInfo();
-	goalCell->releaseInfo();
+#if RETAIL_COMPATIBLE_PATHFINDING
+	if (!s_useFixedPathfinding) {
+		cleanOpenAndClosedLists();
+		goalCell->releaseInfo();
+	}
+	else
+#endif
+	{
+		cleanOpenAndClosedLists();
+		parentCell->releaseInfo();
+		goalCell->releaseInfo();
+	}
+
 	return false;
 }
 
@@ -8502,16 +8772,33 @@ Int Pathfinder::checkPathCost(Object *obj, const LocomotorSet& locomotorSet, con
 		parentCell = m_openList;
 		m_openList = parentCell->removeFromOpenList(m_openList);
 
+		// put parent cell onto closed list - its evaluation is finished - Retail compatible behaviour
+#if RETAIL_COMPATIBLE_PATHFINDING
+		if (!s_useFixedPathfinding) {
+			m_closedList = parentCell->putOnClosedList( m_closedList );
+		}
+#endif
+
 		if (parentCell==goalCell) {
 			Int cost = parentCell->getTotalCost();
 			m_isTunneling = false;
 			cleanOpenAndClosedLists();
-			parentCell->releaseInfo();
+#if RETAIL_COMPATIBLE_PATHFINDING
+			if (s_useFixedPathfinding)
+#endif
+			{
+				parentCell->releaseInfo();
+			}
 			return cost;
 		}
 
-		// put parent cell onto closed list - its evaluation is finished
-		m_closedList = parentCell->putOnClosedList( m_closedList );
+		// put parent cell onto closed list - its evaluation is finished - Fixed behaviour
+#if RETAIL_COMPATIBLE_PATHFINDING
+		if (s_useFixedPathfinding)
+#endif
+		{
+			m_closedList = parentCell->putOnClosedList( m_closedList );
+		}
 
 		if (cellCount > MAX_CELL_COUNT) {
 			continue;
@@ -8573,9 +8860,14 @@ Int Pathfinder::checkPathCost(Object *obj, const LocomotorSet& locomotorSet, con
 
 			if (!newCell->allocateInfo(newCellCoord)) {
 				// Out of cells for pathing...
-				cleanOpenAndClosedLists();
-				parentCell->releaseInfo();
-				goalCell->releaseInfo();
+#if RETAIL_COMPATIBLE_PATHFINDING
+				if (s_useFixedPathfinding)
+#endif
+				{
+					cleanOpenAndClosedLists();
+					parentCell->releaseInfo();
+					goalCell->releaseInfo();
+				}
  				return cellCount;
 			}
 			cellCount++;
@@ -8618,15 +8910,36 @@ Int Pathfinder::checkPathCost(Object *obj, const LocomotorSet& locomotorSet, con
 			if (newCell->getOpen())
 				m_openList = newCell->removeFromOpenList( m_openList );
 
+#if RETAIL_COMPATIBLE_PATHFINDING
+			// TheSuperHacker @info This is here to catch a retail pathfinding crash point and to recover from it
+			// A cell has gotten onto the open list without pathfinding info due to a danling m_open pointer on the previous listed cell so we need to force a cleanup
+			if (!s_useFixedPathfinding && m_openList && !m_openList->hasInfo()) {
+				s_useFixedPathfinding = true;
+				forceCleanCells();
+				return MAX_COST;
+			}
+#endif
+
 			// insert newCell in open list such that open list is sorted, smallest total path cost first
 			m_openList = newCell->putOnSortedOpenList( m_openList );
 		}
 	}
 
 	m_isTunneling = false;
-	cleanOpenAndClosedLists();
-	parentCell->releaseInfo();
-	goalCell->releaseInfo();
+#if RETAIL_COMPATIBLE_PATHFINDING
+	if (!s_useFixedPathfinding) {
+		if (goalCell->hasInfo() && !goalCell->getClosed() && !goalCell->getOpen()) {
+			goalCell->releaseInfo();
+		}
+		cleanOpenAndClosedLists();
+	}
+	else
+#endif
+	{
+		cleanOpenAndClosedLists();
+		parentCell->releaseInfo();
+		goalCell->releaseInfo();
+	}
 	return MAX_COST;
 }
 
@@ -8763,7 +9076,12 @@ Path *Pathfinder::findClosestPath( Object *obj, const LocomotorSet& locomotorSet
 	if (parentCell!=goalCell) {
 		worldToCell(&clipFrom, &pos2d);
 		if (!parentCell->allocateInfo(pos2d)) {
-			goalCell->releaseInfo();
+#if RETAIL_COMPATIBLE_PATHFINDING
+			if (s_useFixedPathfinding)
+#endif
+			{
+				goalCell->releaseInfo();
+			}
 			return NULL;
 		}
 	}
@@ -8829,9 +9147,20 @@ Path *Pathfinder::findClosestPath( Object *obj, const LocomotorSet& locomotorSet
 			m_isTunneling = false;
 			// construct and return path
 			Path *path = buildActualPath( obj, locomotorSet.getValidSurfaces(), from, goalCell, centerInCell, blocked);
-			cleanOpenAndClosedLists();
-			parentCell->releaseInfo();
-			goalCell->releaseInfo();
+#if RETAIL_COMPATIBLE_PATHFINDING
+			if (!s_useFixedPathfinding) {
+				parentCell->releaseInfo();
+				goalCell->releaseInfo();
+				cleanOpenAndClosedLists();
+			}
+			else
+#endif
+			{
+				cleanOpenAndClosedLists();
+				parentCell->releaseInfo();
+				goalCell->releaseInfo();
+			}
+
 			return path;
 		}
 		// put parent cell onto closed list - its evaluation is finished
@@ -8910,9 +9239,18 @@ Path *Pathfinder::findClosestPath( Object *obj, const LocomotorSet& locomotorSet
 		rawTo->y = closesetCell->getYIndex()*PATHFIND_CELL_SIZE_F + PATHFIND_CELL_SIZE_F/2.0f;
 		// construct and return path
 		Path *path = buildActualPath( obj, locomotorSet.getValidSurfaces(), from, closesetCell, centerInCell, blocked );
-		cleanOpenAndClosedLists();
-		parentCell->releaseInfo();
-		goalCell->releaseInfo();
+#if RETAIL_COMPATIBLE_PATHFINDING
+		if (!s_useFixedPathfinding) {
+			goalCell->releaseInfo();
+			cleanOpenAndClosedLists();
+		}
+		else
+#endif
+		{
+			cleanOpenAndClosedLists();
+			parentCell->releaseInfo();
+			goalCell->releaseInfo();
+		}
 		return path;
 	}
 
@@ -8932,9 +9270,18 @@ Path *Pathfinder::findClosestPath( Object *obj, const LocomotorSet& locomotorSet
 	TheGameLogic->incrementOverallFailedPathfinds();
 #endif
 	m_isTunneling = false;
-	cleanOpenAndClosedLists();
-	parentCell->releaseInfo();
-	goalCell->releaseInfo();
+#if RETAIL_COMPATIBLE_PATHFINDING
+	if (!s_useFixedPathfinding) {
+		goalCell->releaseInfo();
+		cleanOpenAndClosedLists();
+	}
+	else
+#endif
+	{
+		cleanOpenAndClosedLists();
+		parentCell->releaseInfo();
+		goalCell->releaseInfo();
+	}
 	return NULL;
 }
 
@@ -9056,6 +9403,33 @@ void Pathfinder::prependCells( Path *path, const Coord3D *fromPos,
 		}
 		prevCell = cell;
 	}
+
+#if RETAIL_COMPATIBLE_PATHFINDING
+	// TheSuperHackers @info This pathway is here for retail compatibility, it is to catch when a starting cell has a dangling parent that contains no pathing information
+	// Beyond this point a retail client will crash due to a null pointer access within cell->getXIndex()
+	// To recover from this we set the cell to the previous cell, which should be the actual starting cell then set to use the fixed pathing and perform a forced cleanup
+	if (!s_useFixedPathfinding) {
+		if (!cell->hasInfo()) {
+			cell = prevCell;
+
+			m_zoneManager.setPassable(cell->getXIndex(), cell->getYIndex(), true);
+			if (goalCellNull) {
+				// Very short path.
+				adjustCoordToCell(cell->getXIndex(), cell->getYIndex(), center, pos, cell->getLayer());
+				path->prependNode( &pos, cell->getLayer() );
+			}
+			// put actual start position as first node on the path, so it begins right at the unit's feet
+			if (fromPos->x != path->getFirstNode()->getPosition()->x || fromPos->y != path->getFirstNode()->getPosition()->y) {
+				path->prependNode( fromPos, cell->getLayer() );
+			}
+
+			s_useFixedPathfinding = true;
+			forceCleanCells();
+			return;
+		}
+	}
+#endif
+
 	m_zoneManager.setPassable(cell->getXIndex(), cell->getYIndex(), true);
 	if (goalCellNull) {
 		// Very short path.
@@ -10317,8 +10691,17 @@ Path *Pathfinder::getMoveAwayFromPath(Object* obj, Object *otherObj,
 			m_isTunneling = false;
 			// construct and return path
 			Path *newPath = buildActualPath( obj, locomotorSet.getValidSurfaces(), obj->getPosition(), parentCell, centerInCell, false);
-			cleanOpenAndClosedLists();
-			parentCell->releaseInfo();
+#if RETAIL_COMPATIBLE_PATHFINDING
+			if (!s_useFixedPathfinding) {
+				parentCell->releaseInfo();
+				cleanOpenAndClosedLists();
+			}
+			else
+#endif
+			{
+				cleanOpenAndClosedLists();
+				parentCell->releaseInfo();
+			}
 			return newPath;
 		}
 		// put parent cell onto closed list - its evaluation is finished
@@ -10339,8 +10722,16 @@ Path *Pathfinder::getMoveAwayFromPath(Object* obj, Object *otherObj,
 	DEBUG_LOG(("Unit '%s', time %f", obj->getTemplate()->getName().str(), (::GetTickCount()-startTimeMS)/1000.0f));
 
 	m_isTunneling = false;
-	cleanOpenAndClosedLists();
-	parentCell->releaseInfo();
+#if RETAIL_COMPATIBLE_PATHFINDING
+	if (!s_useFixedPathfinding) {
+		cleanOpenAndClosedLists();
+	}
+	else
+#endif
+	{
+		cleanOpenAndClosedLists();
+		parentCell->releaseInfo();
+	}
 	return NULL;
 }
 
@@ -10456,7 +10847,15 @@ Path *Pathfinder::patchPath( const Object *obj, const LocomotorSet& locomotorSet
 
 	}
 	if (startNode == originalPath->getLastNode()) {
-		parentCell->releaseInfo();
+#if RETAIL_COMPATIBLE_PATHFINDING
+		if (!s_useFixedPathfinding) {
+			cleanOpenAndClosedLists();
+		}
+		else
+#endif
+		{
+			parentCell->releaseInfo();
+		}
 		return NULL; // no open nodes.
 	}
 	PathfindCell *candidateGoal;
@@ -10464,7 +10863,12 @@ Path *Pathfinder::patchPath( const Object *obj, const LocomotorSet& locomotorSet
 	ICoord2D goalCellNdx;
 	worldToCell(&goalPos, &goalCellNdx);
 	if (!candidateGoal->allocateInfo(goalCellNdx)) {
-		parentCell->releaseInfo();
+#if RETAIL_COMPATIBLE_PATHFINDING
+		if (s_useFixedPathfinding)
+#endif
+		{
+			parentCell->releaseInfo();
+		}
 		return NULL;
 	}
 
@@ -10499,9 +10903,19 @@ Path *Pathfinder::patchPath( const Object *obj, const LocomotorSet& locomotorSet
 
 			// cleanup the path by checking line of sight
 			path->optimize(obj, locomotorSet.getValidSurfaces(), blocked);
-			cleanOpenAndClosedLists();
-			parentCell->releaseInfo();
-			candidateGoal->releaseInfo();
+#if RETAIL_COMPATIBLE_PATHFINDING
+			if (!s_useFixedPathfinding) {
+				parentCell->releaseInfo();
+				cleanOpenAndClosedLists();
+				candidateGoal->releaseInfo();
+			}
+			else
+#endif
+			{
+				cleanOpenAndClosedLists();
+				parentCell->releaseInfo();
+				candidateGoal->releaseInfo();
+			}
 
 			return path;
 		}
@@ -10524,9 +10938,22 @@ Path *Pathfinder::patchPath( const Object *obj, const LocomotorSet& locomotorSet
 	}
 #endif
 	m_isTunneling = false;
-	cleanOpenAndClosedLists();
-	parentCell->releaseInfo();
-	candidateGoal->releaseInfo();
+#if RETAIL_COMPATIBLE_PATHFINDING
+	if (!s_useFixedPathfinding) {
+		if (!candidateGoal->getOpen() && !candidateGoal->getClosed())
+		{
+			// Not on one of the lists 
+			candidateGoal->releaseInfo();
+		}
+		cleanOpenAndClosedLists();
+	}
+	else
+#endif
+	{
+		cleanOpenAndClosedLists();
+		parentCell->releaseInfo();
+		candidateGoal->releaseInfo();
+	}
 	return NULL;
 }
 
@@ -10819,9 +11246,20 @@ Path *Pathfinder::findAttackPath( const Object *obj, const LocomotorSet& locomot
 					}
 				}
 				Path *path = buildActualPath( obj, locomotorSet.getValidSurfaces(), obj->getPosition(), parentCell, centerInCell, false);
-				cleanOpenAndClosedLists();
-				parentCell->releaseInfo();
-				goalCell->releaseInfo();
+#if RETAIL_COMPATIBLE_PATHFINDING
+				if (!s_useFixedPathfinding) {
+					if (goalCell->hasInfo() && !goalCell->getClosed() && !goalCell->getOpen()) {
+						goalCell->releaseInfo();
+					}
+					cleanOpenAndClosedLists();
+				}
+				else
+#endif
+				{
+					cleanOpenAndClosedLists();
+					parentCell->releaseInfo();
+					goalCell->releaseInfo();
+				}
 				return path;
 			}
 		}
@@ -10877,9 +11315,20 @@ Path *Pathfinder::findAttackPath( const Object *obj, const LocomotorSet& locomot
 	TheGameLogic->incrementOverallFailedPathfinds();
 #endif
 	m_isTunneling = false;
-	cleanOpenAndClosedLists();
-	parentCell->releaseInfo();
-	goalCell->releaseInfo();
+#if RETAIL_COMPATIBLE_PATHFINDING
+	if (!s_useFixedPathfinding) {
+		if (goalCell->hasInfo() && !goalCell->getClosed() && !goalCell->getOpen()) {
+			goalCell->releaseInfo();
+		}
+		cleanOpenAndClosedLists();
+	}
+	else
+#endif
+	{
+		cleanOpenAndClosedLists();
+		parentCell->releaseInfo();
+		goalCell->releaseInfo();
+	}
 	return NULL;
 }
 
@@ -11001,8 +11450,17 @@ Path *Pathfinder::findSafePath( const Object *obj, const LocomotorSet& locomotor
 #endif
 			// construct and return path
 			Path *path = buildActualPath( obj, locomotorSet.getValidSurfaces(), obj->getPosition(), parentCell, centerInCell, false);
-			cleanOpenAndClosedLists();
-			parentCell->releaseInfo();
+#if RETAIL_COMPATIBLE_PATHFINDING
+			if (!s_useFixedPathfinding) {
+				parentCell->releaseInfo();
+				cleanOpenAndClosedLists();
+			}
+			else
+#endif
+			{
+				cleanOpenAndClosedLists();
+				parentCell->releaseInfo();
+			}
 			return path;
 		}
 
@@ -11036,8 +11494,16 @@ Path *Pathfinder::findSafePath( const Object *obj, const LocomotorSet& locomotor
 	TheGameLogic->incrementOverallFailedPathfinds();
 #endif
 	m_isTunneling = false;
-	cleanOpenAndClosedLists();
-	parentCell->releaseInfo();
+#if RETAIL_COMPATIBLE_PATHFINDING
+	if (!s_useFixedPathfinding) {
+		cleanOpenAndClosedLists();
+	}
+	else
+#endif
+	{
+		cleanOpenAndClosedLists();
+		parentCell->releaseInfo();
+	}
 	return NULL;
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -1290,8 +1290,14 @@ Bool PathfindCell::allocateInfo( const ICoord2D &pos )
 /**
  * Releases an info record for a cell.
  */
-void PathfindCell::releaseInfo( void )
-{
+void PathfindCell::releaseInfo( void ) 
+{ 
+	// TheSuperHackers @bugfix Mauller/SkyAero 05/06/2025 Parent cell links need clearing to prevent dangling pointers on starting points that can link them to an invalid parent cell.
+	// Parent cells are only cleared within Pathfinder::prependCells, so cells that do not make it onto the final path do not get their parent cell cleared.
+	// Cells with a special flags also do not get their pathfindinfo cleared and therefore can leave a parent cell set on a starting cell.
+	if (m_info) {
+		m_info->m_pathParent = NULL;
+	}
 	if (m_type==PathfindCell::CELL_OBSTACLE) {
 		return;
 	}
@@ -6564,8 +6570,8 @@ Path *Pathfinder::internalFindPath( Object *obj, const LocomotorSet& locomotorSe
 			m_isTunneling = false;
 			// construct and return path
 			Path *path =  buildActualPath( obj, locomotorSet.getValidSurfaces(), from, goalCell, centerInCell, false );
-			parentCell->releaseInfo();
 			cleanOpenAndClosedLists();
+			parentCell->releaseInfo();
 			return path;
 		}
 
@@ -6641,8 +6647,8 @@ Path *Pathfinder::internalFindPath( Object *obj, const LocomotorSet& locomotorSe
 #endif
 
 	m_isTunneling = false;
-	parentCell->releaseInfo();
 	cleanOpenAndClosedLists();
+	parentCell->releaseInfo();
 	goalCell->releaseInfo();
 	return NULL;
 }
@@ -7082,8 +7088,8 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 			m_isTunneling = false;
 			// construct and return path
 			Path *path =  buildGroundPath(crusher, from, goalCell, centerInCell, pathDiameter );
-			parentCell->releaseInfo();
 			cleanOpenAndClosedLists();
+			parentCell->releaseInfo();
 			return path;
 		}
 
@@ -7287,8 +7293,8 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 	TheGameLogic->incrementOverallFailedPathfinds();
 #endif
 	m_isTunneling = false;
-	parentCell->releaseInfo();
 	cleanOpenAndClosedLists();
+	parentCell->releaseInfo();
 	goalCell->releaseInfo();
 	return NULL;
 }
@@ -7667,8 +7673,8 @@ Path *Pathfinder::internal_findHierarchicalPath( Bool isHuman, const LocomotorSu
 #endif
 			}
 #endif
-			parentCell->releaseInfo();
 			cleanOpenAndClosedLists();
+			parentCell->releaseInfo();
 			goalCell->releaseInfo();
 			return path;
 		}
@@ -7866,8 +7872,8 @@ Path *Pathfinder::internal_findHierarchicalPath( Bool isHuman, const LocomotorSu
 		}
 #endif
 #endif
-		parentCell->releaseInfo();
 		cleanOpenAndClosedLists();
+		parentCell->releaseInfo();
 		goalCell->releaseInfo();
 		return path;
 	}
@@ -7914,8 +7920,8 @@ Path *Pathfinder::internal_findHierarchicalPath( Bool isHuman, const LocomotorSu
 	TheGameLogic->incrementOverallFailedPathfinds();
 #endif
 	m_isTunneling = false;
-	parentCell->releaseInfo();
 	cleanOpenAndClosedLists();
+	parentCell->releaseInfo();
 	goalCell->releaseInfo();
 	return NULL;
 }
@@ -8352,8 +8358,8 @@ Bool Pathfinder::pathDestination( 	Object *obj, const LocomotorSet& locomotorSet
 	}
 #endif
 	m_isTunneling = false;
-	parentCell->releaseInfo();
 	cleanOpenAndClosedLists();
+	parentCell->releaseInfo();
 	goalCell->releaseInfo();
 	return false;
 }
@@ -8483,8 +8489,8 @@ Int Pathfinder::checkPathCost(Object *obj, const LocomotorSet& locomotorSet, con
 		if (parentCell==goalCell) {
 			Int cost = parentCell->getTotalCost();
 			m_isTunneling = false;
-			parentCell->releaseInfo();
 			cleanOpenAndClosedLists();
+			parentCell->releaseInfo();
 			return cost;
 		}
 
@@ -8551,8 +8557,8 @@ Int Pathfinder::checkPathCost(Object *obj, const LocomotorSet& locomotorSet, con
 
 			if (!newCell->allocateInfo(newCellCoord)) {
 				// Out of cells for pathing...
-				parentCell->releaseInfo();
 				cleanOpenAndClosedLists();
+				parentCell->releaseInfo();
 				goalCell->releaseInfo();
  				return cellCount;
 			}
@@ -8602,8 +8608,8 @@ Int Pathfinder::checkPathCost(Object *obj, const LocomotorSet& locomotorSet, con
 	}
 
 	m_isTunneling = false;
-	parentCell->releaseInfo();
 	cleanOpenAndClosedLists();
+	parentCell->releaseInfo();
 	goalCell->releaseInfo();
 	return MAX_COST;
 }
@@ -8807,8 +8813,8 @@ Path *Pathfinder::findClosestPath( Object *obj, const LocomotorSet& locomotorSet
 			m_isTunneling = false;
 			// construct and return path
 			Path *path = buildActualPath( obj, locomotorSet.getValidSurfaces(), from, goalCell, centerInCell, blocked);
-			parentCell->releaseInfo();
 			cleanOpenAndClosedLists();
+			parentCell->releaseInfo();
 			goalCell->releaseInfo();
 			return path;
 		}
@@ -8888,8 +8894,8 @@ Path *Pathfinder::findClosestPath( Object *obj, const LocomotorSet& locomotorSet
 		rawTo->y = closesetCell->getYIndex()*PATHFIND_CELL_SIZE_F + PATHFIND_CELL_SIZE_F/2.0f;
 		// construct and return path
 		Path *path = buildActualPath( obj, locomotorSet.getValidSurfaces(), from, closesetCell, centerInCell, blocked );
-		parentCell->releaseInfo();
 		cleanOpenAndClosedLists();
+		parentCell->releaseInfo();
 		goalCell->releaseInfo();
 		return path;
 	}
@@ -8910,8 +8916,8 @@ Path *Pathfinder::findClosestPath( Object *obj, const LocomotorSet& locomotorSet
 	TheGameLogic->incrementOverallFailedPathfinds();
 #endif
 	m_isTunneling = false;
-	parentCell->releaseInfo();
 	cleanOpenAndClosedLists();
+	parentCell->releaseInfo();
 	goalCell->releaseInfo();
 	return NULL;
 }
@@ -9034,14 +9040,12 @@ void Pathfinder::prependCells( Path *path, const Coord3D *fromPos,
 		}
 		prevCell = cell;
 	}
-
 	m_zoneManager.setPassable(cell->getXIndex(), cell->getYIndex(), true);
 	if (goalCellNull) {
 		// Very short path.
 		adjustCoordToCell(cell->getXIndex(), cell->getYIndex(), center, pos, cell->getLayer());
 		path->prependNode( &pos, cell->getLayer() );
 	}
-
 	// put actual start position as first node on the path, so it begins right at the unit's feet
 	if (fromPos->x != path->getFirstNode()->getPosition()->x || fromPos->y != path->getFirstNode()->getPosition()->y) {
 		path->prependNode( fromPos, cell->getLayer() );
@@ -10297,8 +10301,8 @@ Path *Pathfinder::getMoveAwayFromPath(Object* obj, Object *otherObj,
 			m_isTunneling = false;
 			// construct and return path
 			Path *newPath = buildActualPath( obj, locomotorSet.getValidSurfaces(), obj->getPosition(), parentCell, centerInCell, false);
-			parentCell->releaseInfo();
 			cleanOpenAndClosedLists();
+			parentCell->releaseInfo();
 			return newPath;
 		}
 		// put parent cell onto closed list - its evaluation is finished
@@ -10319,8 +10323,8 @@ Path *Pathfinder::getMoveAwayFromPath(Object* obj, Object *otherObj,
 	DEBUG_LOG(("Unit '%s', time %f", obj->getTemplate()->getName().str(), (::GetTickCount()-startTimeMS)/1000.0f));
 
 	m_isTunneling = false;
-	parentCell->releaseInfo();
 	cleanOpenAndClosedLists();
+	parentCell->releaseInfo();
 	return NULL;
 }
 
@@ -10479,8 +10483,8 @@ Path *Pathfinder::patchPath( const Object *obj, const LocomotorSet& locomotorSet
 
 			// cleanup the path by checking line of sight
 			path->optimize(obj, locomotorSet.getValidSurfaces(), blocked);
-			parentCell->releaseInfo();
 			cleanOpenAndClosedLists();
+			parentCell->releaseInfo();
 			candidateGoal->releaseInfo();
 
 			return path;
@@ -10504,8 +10508,8 @@ Path *Pathfinder::patchPath( const Object *obj, const LocomotorSet& locomotorSet
 	}
 #endif
 	m_isTunneling = false;
-	parentCell->releaseInfo();
 	cleanOpenAndClosedLists();
+	parentCell->releaseInfo();
 	candidateGoal->releaseInfo();
 	return NULL;
 }
@@ -10799,8 +10803,8 @@ Path *Pathfinder::findAttackPath( const Object *obj, const LocomotorSet& locomot
 					}
 				}
 				Path *path = buildActualPath( obj, locomotorSet.getValidSurfaces(), obj->getPosition(), parentCell, centerInCell, false);
-				parentCell->releaseInfo();
 				cleanOpenAndClosedLists();
+				parentCell->releaseInfo();
 				goalCell->releaseInfo();
 				return path;
 			}
@@ -10857,8 +10861,8 @@ Path *Pathfinder::findAttackPath( const Object *obj, const LocomotorSet& locomot
 	TheGameLogic->incrementOverallFailedPathfinds();
 #endif
 	m_isTunneling = false;
-	parentCell->releaseInfo();
 	cleanOpenAndClosedLists();
+	parentCell->releaseInfo();
 	goalCell->releaseInfo();
 	return NULL;
 }
@@ -10981,8 +10985,8 @@ Path *Pathfinder::findSafePath( const Object *obj, const LocomotorSet& locomotor
 #endif
 			// construct and return path
 			Path *path = buildActualPath( obj, locomotorSet.getValidSurfaces(), obj->getPosition(), parentCell, centerInCell, false);
-			parentCell->releaseInfo();
 			cleanOpenAndClosedLists();
+			parentCell->releaseInfo();
 			return path;
 		}
 
@@ -11016,8 +11020,8 @@ Path *Pathfinder::findSafePath( const Object *obj, const LocomotorSet& locomotor
 	TheGameLogic->incrementOverallFailedPathfinds();
 #endif
 	m_isTunneling = false;
-	parentCell->releaseInfo();
 	cleanOpenAndClosedLists();
+	parentCell->releaseInfo();
 	return NULL;
 }
 


### PR DESCRIPTION
- Fixes: #968 
- Fixes: #980 
- Fixes: #979

These issues are likely also fixed by this, it does not appear to be an issue with moving units on mass but a cascade failure in the pathfinding that can finally get triggered by moving units.
- Fixes: #330 
- Fixes: #81 

--- 
**TODO**

- [x]  Replicate in Generals

---

This PR fixes the crashing within AI pathing. Which is being caused by a lack of cleanup of pathfinding resources in some return paths. This then results in resource exhaustion and dangling parent cell information that points to invalid cells when a new path is calculated.

It can appear to be triggered when units get stuck or there are mass unit movements. But the pathing can start to fail long before the point of the actual crash in some circumstances.

I am keeping it as a draft for now as better ways of fixing this issue may crop up as more time is spent on it.

---
UPDATE1: So it appears the crashes within ```prependCells``` is being caused by a cell having dangling information to a parent cell that does not contain any pathing info. These may be getting into the pathing early on in the game according to some recent logging by roos. It could also be due to the starting and goal cell having dangling info on them when they are selected. They are then pointing to an invalid parent cell at this point.


UPDATE2: So i have removed all of the workarounds that we considered before as i believe i came across the place which was causing the majority of the issues for some of the replays. The ```checkPathCost``` function and ```pathDestination``` functions had returns that failed to cleanup the open and closed cell lists. This was likely the major cause of the problems overall.


UPDATE3: It looks as though the ```checkPathCost``` and ```pathDestination``` functions were the last and main cause of the issue for some of the maps. The replays now mismatch at some point halfway through or 3/4 of the way through where the cascading failure starts in the pathfinding. But the replay appears to continue normally till the score screen appears.


UPDATE4: We noticed that pathing parent cell pointers were not being cleared after pathing. So we have also added cleanup for this when pathfinding info is deallocated. This helps to prevent cells that did not make it into the final path having a dangling pointer to an invalid parent cell. These invalid dangling pointers were part of the reason for the failures within prepend cells.


UPDATE5: A new crashing replay revealed that some code could crash within ```internal_findHierarchicalPath``` when trying to allocate path finding cell information. So added checks and cleanup code around this.


UPDATE6: The entire pathfinding has been altered to have two modes of operation, the initial is a retail compatible mode which it starts within, Then if the game hits a retail crash site, we recover by catching the failure mode, cleaning up the pathfinding information, then set a flag so all pathfinding from then on uses the fully fixed codepath.


Having tested the changes with replays that don't crash due to pathfinding, i have not come across any mismatches yet, which is a good sign that the changes only affect games where the circumstances that trigger the pathfinding failure occurs. But will need further testing with more replays, some may possibly mismatch before the end, but these games could have failed if they continued and did not end.

N.b For games where the pathfinding does hit a failure path, we have noticed that the failure can start anywhere from 30 seconds to a few minutes before the crash occurs. This shows as a mismatch in the replay but the replay continues to play as normal after.

---
So far it minimises the amount of crashing by making sure pathing resources are cleaned properly when pathing fails, along with making sure that resources are properly released on successful paths. This resolves 2/5 of the crashes such as with the Legi Han Dynasty replay.

This also helped to alleviate some crashes that were occurring when the open and closed lists were cleaned up due to dangling cells being on the list without any pathing information attached to them.

In some circumstances we still run out of pathing resources resulting in crashes within ```prependCells```, this is alleviated by checking that the cell being used has pathing information associated with it. But i am still investigating if we can prevent cells without pathing information getting this far in the chain.


So far i have attempted to alter the pathfinding code to exit early if no pathing info is assigned to new cells, this ended up mismatching very early in some games. This also caused the golden replay to mismatch as well. This would have been the best solution, fail pathing early if we detect that pathing resources have been exhausted.

I still have to test if the above fixes coupled with increasing available pathing resources helps. Previous testing by increasing pathing resources without the above didn't appear to make a difference. But the above fixes help alleviate dangling pathing resources.


In one replay there is still a crash in some instances within ```checkPathCost``` There is some mis-ordering in which the parent cell is put onto the closed path before it has been checked to see if it has matched the goal cell.  I managed to reorder this without issue but it has not prevented crashing, although it is the correct order of operation at this point.

There are also blocks within ```checkPathCost``` that appear to have been placed there to stop pathing if the path cost has exceeded 500 cells. It appears that there was a copying mistake as within the code it simply calls ```continue```.

Overall i don't think this is going to be an easy one to fix 100% till we drop compat without having some null checks in places.
