### PR TITLE
[GEN][ZH] Fix crash on GameEngine shutdown when GameLogic::clearGameData() was not called before

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -209,6 +209,10 @@ GameEngine::~GameEngine()
 
 	TheGameResultsQueue->endThreads();
 
+	// TheSuperHackers @fix helmutbuhler 03/06/2025
+	// Reset all subsystems before deletion to prevent crashing due to cross dependencies.
+	reset();
+
 	TheSubsystemList->shutdownAll();
 	delete TheSubsystemList;
 	TheSubsystemList = NULL;

--- a/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -207,6 +207,10 @@ GameEngine::~GameEngine()
 
 	TheGameResultsQueue->endThreads();
 
+	// TheSuperHackers @fix helmutbuhler 03/06/2025
+	// We need to reset all subsystems before shutdown to fix crashes due to circular dependencies
+	reset();
+
 	TheSubsystemList->shutdownAll();
 	delete TheSubsystemList;
 	TheSubsystemList = NULL;

--- a/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -208,7 +208,7 @@ GameEngine::~GameEngine()
 	TheGameResultsQueue->endThreads();
 
 	// TheSuperHackers @fix helmutbuhler 03/06/2025
-	// We need to reset all subsystems before shutdown to fix crashes due to circular dependencies
+	// Reset all subsystems before deletion to prevent crashing due to cross dependencies.
 	reset();
 
 	TheSubsystemList->shutdownAll();


### PR DESCRIPTION
Fixes: #995

This fixes a crash when shutting down the GameEngine without calling `TheGameEngine->reset()` first. This happens during Replay Simulation (see #923).

During normal shutdown in the existing game this cannot happen because shutdown only occurs with the `GameMessage::MSG_CLEAR_GAME_DATA` message, which calls `GameLogic::clearGameData`, which in turn calls `TheGameEngine->reset()`

Why does it crash otherwise?
GameEngine has (among others) two subsystems: `TeamFactory` and `PlayerList`, which it initializes in that order. During shutdown (in opposite order) `~TeamFactory()` calls `~TeamPrototype()`, which calls `~Team()`, which calls `ThePlayerList->getPlayerCount()` (which then will crash because the PlayerList is already destructed).

Resetting first fixes this because it clears all the team prototypes in the TeamFactory.

Changing the order of `TeamFactory` and `PlayerList` would probably not work because some other dependency would then likely show up. It also would be a scary change that could break other things. I think resetting first is a valid approach to fix these dependencies and to make sure shutdown always works properly.