### PR TITLE
[GEN][ZH] Fix static initialization order for StatDumpClass and LogClass

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/Dict.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Dict.cpp
@@ -160,6 +160,7 @@ Dict::DictPair *Dict::ensureUnique(int numPairsNeeded, Bool preserveData, DictPa
 	Dict::DictPairData* newData = NULL;
 	if (numPairsNeeded > 0)
 	{
+		DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != NULL, ("Cannot use dynamic memory allocator before its initialization. Check static initialization order."));
 		DEBUG_ASSERTCRASH(numPairsNeeded <= MAX_LEN, ("Dict::ensureUnique exceeds max pairs length %d with requested length %d", MAX_LEN, numPairsNeeded));
 		int minBytes = sizeof(Dict::DictPairData) + numPairsNeeded*sizeof(Dict::DictPair);
 		int actualBytes = TheDynamicMemoryAllocator->getActualAllocationSize(minBytes);

--- a/Generals/Code/GameEngine/Source/Common/Dict.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Dict.cpp
@@ -160,7 +160,7 @@ Dict::DictPair *Dict::ensureUnique(int numPairsNeeded, Bool preserveData, DictPa
 	Dict::DictPairData* newData = NULL;
 	if (numPairsNeeded > 0)
 	{
-		DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != NULL, ("Cannot use dynamic memory allocator before its initialization. Check static initialization order."));
+		DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != NULL, ("Cannot use dynamic memory allocator before its initialization. Check static initialization order.\n"));
 		DEBUG_ASSERTCRASH(numPairsNeeded <= MAX_LEN, ("Dict::ensureUnique exceeds max pairs length %d with requested length %d", MAX_LEN, numPairsNeeded));
 		int minBytes = sizeof(Dict::DictPairData) + numPairsNeeded*sizeof(Dict::DictPair);
 		int actualBytes = TheDynamicMemoryAllocator->getActualAllocationSize(minBytes);

--- a/Generals/Code/GameEngine/Source/Common/MiniLog.cpp
+++ b/Generals/Code/GameEngine/Source/Common/MiniLog.cpp
@@ -46,9 +46,10 @@ LogClass::LogClass(const char *fname)
 		}
 		pEnd--;
 	}
-	AsciiString fullPath;
-	fullPath.format("%s\\%s", buffer, fname);
-	m_fp = fopen(fullPath.str(), "wt");
+	// TheSuperHackers @bugfix Caball009 03/06/2025 Use std::string instead of AsciiString here to avoid possible static initialization order fiasco
+	// TheDynamicMemoryAllocator is used by AsciiString and may not have been initialized yet
+	const std::string fullPath = std::string(buffer) + "\\" + fname;
+	m_fp = fopen(fullPath.c_str(), "wt");
 }
 
 LogClass::~LogClass()

--- a/Generals/Code/GameEngine/Source/Common/MiniLog.cpp
+++ b/Generals/Code/GameEngine/Source/Common/MiniLog.cpp
@@ -46,8 +46,7 @@ LogClass::LogClass(const char *fname)
 		}
 		pEnd--;
 	}
-	// TheSuperHackers @bugfix Caball009 03/06/2025 Use std::string instead of AsciiString here to avoid possible static initialization order fiasco
-	// TheDynamicMemoryAllocator is used by AsciiString and may not have been initialized yet
+	// TheSuperHackers @fix Caball009 03/06/2025 Don't use AsciiString here anymore because its memory allocator may not have been initialized yet.
 	const std::string fullPath = std::string(buffer) + "\\" + fname;
 	m_fp = fopen(fullPath.c_str(), "wt");
 }

--- a/Generals/Code/GameEngine/Source/Common/System/AsciiString.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/AsciiString.cpp
@@ -138,7 +138,7 @@ void AsciiString::ensureUniqueBufferOfSize(int numCharsNeeded, Bool preserveData
 		return;
 	}
 
-	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != NULL, ("Cannot use dynamic memory allocator before its initialization. Check static initialization order."));
+	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != NULL, ("Cannot use dynamic memory allocator before its initialization. Check static initialization order.\n"));
 	DEBUG_ASSERTCRASH(numCharsNeeded <= MAX_LEN, ("AsciiString::ensureUniqueBufferOfSize exceeds max string length %d with requested length %d", MAX_LEN, numCharsNeeded));
 	int minBytes = sizeof(AsciiStringData) + numCharsNeeded*sizeof(char);
 	int actualBytes = TheDynamicMemoryAllocator->getActualAllocationSize(minBytes);

--- a/Generals/Code/GameEngine/Source/Common/System/AsciiString.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/AsciiString.cpp
@@ -138,6 +138,7 @@ void AsciiString::ensureUniqueBufferOfSize(int numCharsNeeded, Bool preserveData
 		return;
 	}
 
+	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != NULL, ("Cannot use dynamic memory allocator before its initialization. Check static initialization order."));
 	DEBUG_ASSERTCRASH(numCharsNeeded <= MAX_LEN, ("AsciiString::ensureUniqueBufferOfSize exceeds max string length %d with requested length %d", MAX_LEN, numCharsNeeded));
 	int minBytes = sizeof(AsciiStringData) + numCharsNeeded*sizeof(char);
 	int actualBytes = TheDynamicMemoryAllocator->getActualAllocationSize(minBytes);

--- a/Generals/Code/GameEngine/Source/Common/System/UnicodeString.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/UnicodeString.cpp
@@ -94,7 +94,7 @@ void UnicodeString::ensureUniqueBufferOfSize(int numCharsNeeded, Bool preserveDa
 		return;
 	}
 
-	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != NULL, ("Cannot use dynamic memory allocator before its initialization. Check static initialization order."));
+	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != NULL, ("Cannot use dynamic memory allocator before its initialization. Check static initialization order.\n"));
 	DEBUG_ASSERTCRASH(numCharsNeeded <= MAX_LEN, ("UnicodeString::ensureUniqueBufferOfSize exceeds max string length %d with requested length %d", MAX_LEN, numCharsNeeded));
 	int minBytes = sizeof(UnicodeStringData) + numCharsNeeded*sizeof(WideChar);
 	int actualBytes = TheDynamicMemoryAllocator->getActualAllocationSize(minBytes);

--- a/Generals/Code/GameEngine/Source/Common/System/UnicodeString.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/UnicodeString.cpp
@@ -94,6 +94,7 @@ void UnicodeString::ensureUniqueBufferOfSize(int numCharsNeeded, Bool preserveDa
 		return;
 	}
 
+	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != NULL, ("Cannot use dynamic memory allocator before its initialization. Check static initialization order."));
 	DEBUG_ASSERTCRASH(numCharsNeeded <= MAX_LEN, ("UnicodeString::ensureUniqueBufferOfSize exceeds max string length %d with requested length %d", MAX_LEN, numCharsNeeded));
 	int minBytes = sizeof(UnicodeStringData) + numCharsNeeded*sizeof(WideChar);
 	int actualBytes = TheDynamicMemoryAllocator->getActualAllocationSize(minBytes);

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
@@ -114,9 +114,10 @@ LogClass::LogClass(const char *fname)
 		}
 		pEnd--;
 	}
-	AsciiString fullPath;
-	fullPath.format("%s\\%s", buffer, fname);
-	m_fp = fopen(fullPath.str(), "wt");
+	// TheSuperHackers @bugfix Caball009 03/06/2025 Use std::string instead of AsciiString here to avoid possible static initialization order fiasco
+	// TheDynamicMemoryAllocator is used by AsciiString and may not have been initialized yet
+	const std::string fullPath = std::string(buffer) + "\\" + fname;
+	m_fp = fopen(fullPath.c_str(), "wt");
 }
 
 LogClass::~LogClass()

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
@@ -114,8 +114,7 @@ LogClass::LogClass(const char *fname)
 		}
 		pEnd--;
 	}
-	// TheSuperHackers @bugfix Caball009 03/06/2025 Use std::string instead of AsciiString here to avoid possible static initialization order fiasco
-	// TheDynamicMemoryAllocator is used by AsciiString and may not have been initialized yet
+	// TheSuperHackers @fix Caball009 03/06/2025 Don't use AsciiString here anymore because its memory allocator may not have been initialized yet.
 	const std::string fullPath = std::string(buffer) + "\\" + fname;
 	m_fp = fopen(fullPath.c_str(), "wt");
 }

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -162,8 +162,7 @@ StatDumpClass::StatDumpClass( const char *fname )
 		}
 		pEnd--;
 	}
-	// TheSuperHackers @bugfix Caball009 03/06/2025 Use std::string instead of AsciiString here to avoid possible static initialization order fiasco
-	// TheDynamicMemoryAllocator is used by AsciiString and may not have been initialized yet
+	// TheSuperHackers @fix Caball009 03/06/2025 Don't use AsciiString here anymore because its memory allocator may not have been initialized yet.
 	const std::string fullPath = std::string(buffer) + "\\" + fname;
 	m_fp = fopen(fullPath.c_str(), "wt");
 }

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -162,9 +162,10 @@ StatDumpClass::StatDumpClass( const char *fname )
 		}
 		pEnd--;
 	}
-	AsciiString fullPath;
-	fullPath.format( "%s\\%s", buffer, fname );
-	m_fp = fopen( fullPath.str(), "wt" );
+	// TheSuperHackers @bugfix Caball009 03/06/2025 Use std::string instead of AsciiString here to avoid possible static initialization order fiasco
+	// TheDynamicMemoryAllocator is used by AsciiString and may not have been initialized yet
+	const std::string fullPath = std::string(buffer) + "\\" + fname;
+	m_fp = fopen(fullPath.c_str(), "wt");
 }
 
 //=============================================================================

--- a/GeneralsMD/Code/GameEngine/Source/Common/Dict.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Dict.cpp
@@ -160,6 +160,7 @@ Dict::DictPair *Dict::ensureUnique(int numPairsNeeded, Bool preserveData, DictPa
 	Dict::DictPairData* newData = NULL;
 	if (numPairsNeeded > 0)
 	{
+		DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != NULL, ("Cannot use dynamic memory allocator before its initialization. Check static initialization order."));
 		DEBUG_ASSERTCRASH(numPairsNeeded <= MAX_LEN, ("Dict::ensureUnique exceeds max pairs length %d with requested length %d", MAX_LEN, numPairsNeeded));
 		int minBytes = sizeof(Dict::DictPairData) + numPairsNeeded*sizeof(Dict::DictPair);
 		int actualBytes = TheDynamicMemoryAllocator->getActualAllocationSize(minBytes);

--- a/GeneralsMD/Code/GameEngine/Source/Common/Dict.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Dict.cpp
@@ -160,7 +160,7 @@ Dict::DictPair *Dict::ensureUnique(int numPairsNeeded, Bool preserveData, DictPa
 	Dict::DictPairData* newData = NULL;
 	if (numPairsNeeded > 0)
 	{
-		DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != NULL, ("Cannot use dynamic memory allocator before its initialization. Check static initialization order."));
+		DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != NULL, ("Cannot use dynamic memory allocator before its initialization. Check static initialization order.\n"));
 		DEBUG_ASSERTCRASH(numPairsNeeded <= MAX_LEN, ("Dict::ensureUnique exceeds max pairs length %d with requested length %d", MAX_LEN, numPairsNeeded));
 		int minBytes = sizeof(Dict::DictPairData) + numPairsNeeded*sizeof(Dict::DictPair);
 		int actualBytes = TheDynamicMemoryAllocator->getActualAllocationSize(minBytes);

--- a/GeneralsMD/Code/GameEngine/Source/Common/MiniLog.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/MiniLog.cpp
@@ -46,9 +46,10 @@ LogClass::LogClass(const char *fname)
 		}
 		pEnd--;
 	}
-	AsciiString fullPath;
-	fullPath.format("%s\\%s", buffer, fname);
-	m_fp = fopen(fullPath.str(), "wt");
+	// TheSuperHackers @bugfix Caball009 03/06/2025 Use std::string instead of AsciiString here to avoid possible static initialization order fiasco
+	// TheDynamicMemoryAllocator is used by AsciiString and may not have been initialized yet
+	const std::string fullPath = std::string(buffer) + "\\" + fname;
+	m_fp = fopen(fullPath.c_str(), "wt");
 }
 
 LogClass::~LogClass()

--- a/GeneralsMD/Code/GameEngine/Source/Common/MiniLog.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/MiniLog.cpp
@@ -46,8 +46,7 @@ LogClass::LogClass(const char *fname)
 		}
 		pEnd--;
 	}
-	// TheSuperHackers @bugfix Caball009 03/06/2025 Use std::string instead of AsciiString here to avoid possible static initialization order fiasco
-	// TheDynamicMemoryAllocator is used by AsciiString and may not have been initialized yet
+	// TheSuperHackers @fix Caball009 03/06/2025 Don't use AsciiString here anymore because its memory allocator may not have been initialized yet.
 	const std::string fullPath = std::string(buffer) + "\\" + fname;
 	m_fp = fopen(fullPath.c_str(), "wt");
 }

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/AsciiString.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/AsciiString.cpp
@@ -138,7 +138,7 @@ void AsciiString::ensureUniqueBufferOfSize(int numCharsNeeded, Bool preserveData
 		return;
 	}
 
-	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != NULL, ("Cannot use dynamic memory allocator before its initialization. Check static initialization order."));
+	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != NULL, ("Cannot use dynamic memory allocator before its initialization. Check static initialization order.\n"));
 	DEBUG_ASSERTCRASH(numCharsNeeded <= MAX_LEN, ("AsciiString::ensureUniqueBufferOfSize exceeds max string length %d with requested length %d", MAX_LEN, numCharsNeeded));
 	int minBytes = sizeof(AsciiStringData) + numCharsNeeded*sizeof(char);
 	int actualBytes = TheDynamicMemoryAllocator->getActualAllocationSize(minBytes);

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/AsciiString.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/AsciiString.cpp
@@ -138,6 +138,7 @@ void AsciiString::ensureUniqueBufferOfSize(int numCharsNeeded, Bool preserveData
 		return;
 	}
 
+	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != NULL, ("Cannot use dynamic memory allocator before its initialization. Check static initialization order."));
 	DEBUG_ASSERTCRASH(numCharsNeeded <= MAX_LEN, ("AsciiString::ensureUniqueBufferOfSize exceeds max string length %d with requested length %d", MAX_LEN, numCharsNeeded));
 	int minBytes = sizeof(AsciiStringData) + numCharsNeeded*sizeof(char);
 	int actualBytes = TheDynamicMemoryAllocator->getActualAllocationSize(minBytes);

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/UnicodeString.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/UnicodeString.cpp
@@ -94,7 +94,7 @@ void UnicodeString::ensureUniqueBufferOfSize(int numCharsNeeded, Bool preserveDa
 		return;
 	}
 
-	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != NULL, ("Cannot use dynamic memory allocator before its initialization. Check static initialization order."));
+	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != NULL, ("Cannot use dynamic memory allocator before its initialization. Check static initialization order.\n"));
 	DEBUG_ASSERTCRASH(numCharsNeeded <= MAX_LEN, ("UnicodeString::ensureUniqueBufferOfSize exceeds max string length %d with requested length %d", MAX_LEN, numCharsNeeded));
 	int minBytes = sizeof(UnicodeStringData) + numCharsNeeded*sizeof(WideChar);
 	int actualBytes = TheDynamicMemoryAllocator->getActualAllocationSize(minBytes);

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/UnicodeString.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/UnicodeString.cpp
@@ -94,6 +94,7 @@ void UnicodeString::ensureUniqueBufferOfSize(int numCharsNeeded, Bool preserveDa
 		return;
 	}
 
+	DEBUG_ASSERTCRASH(TheDynamicMemoryAllocator != NULL, ("Cannot use dynamic memory allocator before its initialization. Check static initialization order."));
 	DEBUG_ASSERTCRASH(numCharsNeeded <= MAX_LEN, ("UnicodeString::ensureUniqueBufferOfSize exceeds max string length %d with requested length %d", MAX_LEN, numCharsNeeded));
 	int minBytes = sizeof(UnicodeStringData) + numCharsNeeded*sizeof(WideChar);
 	int actualBytes = TheDynamicMemoryAllocator->getActualAllocationSize(minBytes);

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
@@ -114,9 +114,10 @@ LogClass::LogClass(const char *fname)
 		}
 		pEnd--;
 	}
-	AsciiString fullPath;
-	fullPath.format("%s\\%s", buffer, fname);
-	m_fp = fopen(fullPath.str(), "wt");
+	// TheSuperHackers @bugfix Caball009 03/06/2025 Use std::string instead of AsciiString here to avoid possible static initialization order fiasco
+	// TheDynamicMemoryAllocator is used by AsciiString and may not have been initialized yet
+	const std::string fullPath = std::string(buffer) + "\\" + fname;
+	m_fp = fopen(fullPath.c_str(), "wt");
 }
 
 LogClass::~LogClass()

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
@@ -114,8 +114,7 @@ LogClass::LogClass(const char *fname)
 		}
 		pEnd--;
 	}
-	// TheSuperHackers @bugfix Caball009 03/06/2025 Use std::string instead of AsciiString here to avoid possible static initialization order fiasco
-	// TheDynamicMemoryAllocator is used by AsciiString and may not have been initialized yet
+	// TheSuperHackers @fix Caball009 03/06/2025 Don't use AsciiString here anymore because its memory allocator may not have been initialized yet.
 	const std::string fullPath = std::string(buffer) + "\\" + fname;
 	m_fp = fopen(fullPath.c_str(), "wt");
 }

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -163,9 +163,10 @@ StatDumpClass::StatDumpClass( const char *fname )
 		}
 		pEnd--;
 	}
-	AsciiString fullPath;
-	fullPath.format( "%s\\%s", buffer, fname );
-	m_fp = fopen( fullPath.str(), "wt" );
+	// TheSuperHackers @bugfix Caball009 03/06/2025 Use std::string instead of AsciiString here to avoid possible static initialization order fiasco
+	// TheDynamicMemoryAllocator is used by AsciiString and may not have been initialized yet
+	const std::string fullPath = std::string(buffer) + "\\" + fname;
+	m_fp = fopen(fullPath.c_str(), "wt");
 }
 
 //=============================================================================

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -163,8 +163,7 @@ StatDumpClass::StatDumpClass( const char *fname )
 		}
 		pEnd--;
 	}
-	// TheSuperHackers @bugfix Caball009 03/06/2025 Use std::string instead of AsciiString here to avoid possible static initialization order fiasco
-	// TheDynamicMemoryAllocator is used by AsciiString and may not have been initialized yet
+	// TheSuperHackers @fix Caball009 03/06/2025 Don't use AsciiString here anymore because its memory allocator may not have been initialized yet.
 	const std::string fullPath = std::string(buffer) + "\\" + fname;
 	m_fp = fopen(fullPath.c_str(), "wt");
 }


### PR DESCRIPTION
Static / global variable:
https://github.com/TheSuperHackers/GeneralsGameCode/blob/08b06e3616cb20897bb3c4d6a6f1abaa53686be3/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp#L353
https://github.com/TheSuperHackers/GeneralsGameCode/blob/08b06e3616cb20897bb3c4d6a6f1abaa53686be3/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp#L152-L169

I ran into an issue where the initialization of  global `TheStatDump` happened before the initialization of global `TheDynamicMemoryAllocator` which is used for `AsciiString` (aka static initialization order fiasco). This PR fixes a couple of places where that may happen, though I only noticed it for `TheStatDump`.

I've also added a couple of `DEBUG_ASSERTCRASH`. They'll work better with https://github.com/TheSuperHackers/GeneralsGameCode/pull/1000 accepted, which was created exactly for assertions like these.

EDIT: I can't seem to find how the issue surfaced for me naturally, but it's possible to force the issue to occur.

> `TheDynamicMemoryAllocator` is part of the game engine and `TheStatDump` is part of the game engine device. You can force the issue to occur when you modify the dependency list of `z_generals`:
> Go to `Properties` - `Configuration Properties` - `Linker` - `Input` - `Additional Dependencies` and reverse the order of:
> `..\GameEngineDevice\RelWithDebInfo\z_gameenginedevice.lib`
> `..\GameEngine\RelWithDebInfo\z_gameengine.lib`