### PR TITLE
[GEN][ZH] Fix AIGroup memory management and game crash when a player is selected in Replay playback due heap-use-after-free in GameLogic::logicMessageDispatcher()

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/Player.h
+++ b/Generals/Code/GameEngine/Include/Common/Player.h
@@ -608,7 +608,7 @@ public:
 	// add to the player's current selection this hotkey team.
 	void processAddTeamGameMessage(Int hotkeyNum, GameMessage *msg);
 
-	// returns an AIGroup object that is the currently selected group.
+	// fills an AIGroup object that is the currently selected group.
 	void getCurrentSelectionAsAIGroup(AIGroup *group);
 
 	// sets the currently selected group to be the given AIGroup

--- a/Generals/Code/GameEngine/Include/GameLogic/AI.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AI.h
@@ -855,7 +855,7 @@ public:
 
 	void Add_Ref() const { m_refCount.Add_Ref(); }
 	void Release_Ref() const { m_refCount.Release_Ref(destroy, this); }
-	Int Num_Refs() const { return m_refCount.Num_Refs(); }
+	UnsignedShort Num_Refs() const { return m_refCount.Num_Refs(); }
 
 	void groupMoveToPosition( const Coord3D *pos, Bool addWaypoint, CommandSourceType cmdSource );
 	void groupMoveToAndEvacuate( const Coord3D *pos, CommandSourceType cmdSource );			///< move to given position(s)

--- a/Generals/Code/GameEngine/Include/GameLogic/AI.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AI.h
@@ -855,7 +855,7 @@ public:
 
 	void Add_Ref() const { m_refCount.Add_Ref(); }
 	void Release_Ref() const { m_refCount.Release_Ref(destroy, this); }
-	void Num_Refs() const { m_refCount.Num_Refs(); }
+	Int Num_Refs() const { return m_refCount.Num_Refs(); }
 
 	void groupMoveToPosition( const Coord3D *pos, Bool addWaypoint, CommandSourceType cmdSource );
 	void groupMoveToAndEvacuate( const Coord3D *pos, CommandSourceType cmdSource );			///< move to given position(s)

--- a/Generals/Code/GameEngine/Include/GameLogic/Object.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Object.h
@@ -31,6 +31,7 @@
 #define _OBJECT_H_
 
 #include "Lib/BaseType.h"
+#include "ref_ptr.h"
 
 #include "Common/Geometry.h"
 #include "Common/Snapshot.h"
@@ -663,7 +664,7 @@ private:
 
 	GeometryInfo	m_geometryInfo;
 
-	AIGroup*			m_group;								///< if non-NULL, we are part of this group of agents
+	RefCountPtr<AIGroup> m_group;								///< if non-NULL, we are part of this group of agents
 
 	// These will last for my lifetime.  I will reuse them and reset them.  The truly dynamic ones are in PartitionManager
 	SightingInfo	*m_partitionLastLook;		///< Where and for whom I last looked, so I can undo its effects when I stop

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AI.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AI.cpp
@@ -330,18 +330,11 @@ void AI::reset( void )
 		m_aiData = m_aiData->m_next;
 		delete cur;
 	}
-	while (m_groupList.size())
-	{
-		AIGroup *groupToRemove = m_groupList.front();
-		if (groupToRemove)
-		{
-			destroyGroup(groupToRemove);
-		}
-		else
-		{
-			m_groupList.pop_front(); // NULL group, just kill from list.  Shouldn't really happen, but just in case.
-		}
-	}
+
+	DEBUG_ASSERTCRASH(m_groupList.empty(), ("AI::m_groupList is expected empty already\n"));
+
+	m_groupList.clear(); // Clear just in case...
+
 	m_nextGroupID = 0;
 	m_nextFormationID = NO_FORMATION_ID;
 	getNextFormationID(); // increment once past NO_FORMATION_ID.  jba.
@@ -440,14 +433,14 @@ void AI::parseAiDataDefinition( INI* ini )
 /**
  * Create a new AI Group
  */
-AIGroup *AI::createGroup( void )
+RefCountPtr<AIGroup> AI::createGroup( void )
 {
 	// create a new instance
-	AIGroup *group = newInstance(AIGroup);
+	RefCountPtr<AIGroup> group = RefCountPtr<AIGroup>::Create_NoAddRef(newInstance(AIGroup));
 
 	// add it to the list
 //	DEBUG_LOG(("***AIGROUP %x is being added to m_groupList.\n", group ));
-	m_groupList.push_back( group );
+	m_groupList.push_back( group.Peek() );
 
 	return group;
 }

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
@@ -92,20 +92,8 @@ AIGroup::~AIGroup()
 {
 //	DEBUG_LOG(("***AIGROUP %x is being destructed.\n", this));
 	// disassociate each member from the group
-	std::list<Object *>::iterator i;
-	for( i = m_memberList.begin(); i != m_memberList.end(); /* empty */ )
-	{
-		Object *member = *i;
-		if (member)
-		{
-			member->leaveGroup();
-			i = m_memberList.begin();	// jump back to the beginning, cause ai->leaveGroup will remove this element. 
-		}
-		else
-		{
-			i = m_memberList.erase(i);
-		}
-	}
+	removeAll();
+
 	if (m_groundPath) {
 		deleteInstance(m_groundPath);
 		m_groundPath = NULL;
@@ -223,13 +211,31 @@ Bool AIGroup::remove( Object *obj )
 	// list has changed, properties need recomputation
 	m_dirty = true;
 
-	// if the group is empty, no-one is using it any longer, so destroy it
 	if (isEmpty()) {
-		TheAI->destroyGroup( this );
 		return TRUE;
 	}
 
 	return FALSE;
+}
+
+/**
+ * Remove all objects from group
+ */
+void AIGroup::removeAll( void )
+{
+	std::list<Object *> memberList;
+	memberList.swap(m_memberList);
+	m_memberListSize = 0;
+
+	std::list<Object *>::iterator i;
+	for ( i = memberList.begin(); i != memberList.end(); ++i )
+	{
+		Object *member = *i;
+		if (member)
+			member->leaveGroup();
+	}
+
+	m_dirty = true;
 }
 
 /**

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -893,11 +893,11 @@ void AIPlayer::guardSupplyCenter( Team *team, Int minSupplies )
 	}
 	if (warehouse) {
 
-		AIGroup* theGroup = TheAI->createGroup();
+		RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 		if (!theGroup) {
 			return;
 		}
-		team->getTeamAsAIGroup(theGroup);
+		team->getTeamAsAIGroup(theGroup.Peek());
 		Coord3D location = *warehouse->getPosition();
 		// It's probably a defensive move - position towards the enemy.
 		Region2D bounds;
@@ -2467,9 +2467,9 @@ void AIPlayer::checkReadyTeams( void )
 					/*
 					if (team->m_team->getPrototype()->getTemplateInfo()->m_hasHomeLocation && 
 							!team->m_reinforcement) {
- 						AIGroup* theGroup = TheAI->createGroup();
+						RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 						if (theGroup) {
-							team->m_team->getTeamAsAIGroup(theGroup);
+							team->m_team->getTeamAsAIGroup(theGroup.Peek());
 							Coord3D destination = team->m_team->getPrototype()->getTemplateInfo()->m_homeLocation;
 							theGroup->groupTightenToPosition( &destination, false, CMD_FROM_AI );
 							team->m_frameStarted = TheGameLogic->getFrame();

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -4050,8 +4050,8 @@ StateReturnType AIFollowWaypointPathState::update()
 	if (m_moveAsGroup) {
 		if (obj->getControllingPlayer()->isSkirmishAIPlayer()) {
 			Team *team = obj->getTeam();
-			AIGroup *group = TheAI->createGroup();
-			team->getTeamAsAIGroup(group);
+			RefCountPtr<AIGroup> group = TheAI->createGroup();
+			team->getTeamAsAIGroup(group.Peek());
 
 			Coord3D pos;
 			group->getCenter(&pos);

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -563,9 +563,8 @@ Object::~Object()
 		ThePartitionManager->unRegisterObject( this );
 
 	// if we are in a group, remove us
-	if (m_group)
-		m_group->remove( this );
-	
+	leaveGroup();
+
 	// note, do NOT free these, there are just a shadow copy!
 	m_ai = NULL;
 	m_physics = NULL;
@@ -3841,7 +3840,7 @@ void Object::xfer( Xfer *xfer )
 	}
 
 	// Doesn't need to be saved.  These are created as needed.  jba.
-	//AIGroup*		m_group;															///< if non-NULL, we are part of this group of agents
+	//m_group;
 
 	// don't need to save m_partitionData.
 	DEBUG_ASSERTCRASH(!(xfer->getXferMode() == XFER_LOAD && m_partitionData == NULL), ("should not be in partitionmgr yet"));
@@ -5446,7 +5445,7 @@ RadarPriorityType Object::getRadarPriority( void ) const
 // ------------------------------------------------------------------------------------------------
 AIGroup *Object::getGroup(void)
 {
-	return m_group;
+	return m_group.Peek();
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -5456,7 +5455,7 @@ void Object::enterGroup( AIGroup *group )
 	// if we are in another group, remove ourselves from it first
 	leaveGroup();
 
-	m_group = group;
+	m_group = RefCountPtr<AIGroup>::Create_AddRef(group);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -5467,7 +5466,7 @@ void Object::leaveGroup( void )
 	if (m_group)
 	{
 		// to avoid recursion, set m_group to NULL before removing
-		AIGroup *group = m_group;
+		RefCountPtr<AIGroup> group = m_group;
 		m_group = NULL;
 		group->remove( this );
 	}

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
@@ -394,12 +394,12 @@ void ScriptActions::doMoveToWaypoint(const AsciiString& team, const AsciiString&
 	// The team is the team based on the name, and the calling team (if any) and the team that
 	// triggered the condition.  jba. :)
 	if (theTeam) {
-		AIGroup* theGroup = TheAI->createGroup();
+		RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 		if (!theGroup) {
 			return;
 		}
 
-		theTeam->getTeamAsAIGroup(theGroup);
+		theTeam->getTeamAsAIGroup(theGroup.Peek());
 		Waypoint *way = TheTerrainLogic->getWaypointByName(waypoint);
 		if (way) {
 			Coord3D destination = *way->getLocation();
@@ -756,12 +756,12 @@ void ScriptActions::doCreateReinforcements(const AsciiString& team, const AsciiS
 			theTeam->setActive();
 			if (needToMoveToDestination) 
 			{
-				AIGroup* theGroup = TheAI->createGroup();
+				RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 				if (!theGroup) 
 				{
 					return;
 				}
-				theTeam->getTeamAsAIGroup(theGroup);
+				theTeam->getTeamAsAIGroup(theGroup.Peek());
 				theGroup->groupMoveToPosition( &destination, false, CMD_FROM_SCRIPT );
 			}
 		}
@@ -1015,12 +1015,12 @@ void ScriptActions::doAttack(const AsciiString& attackerName, const AsciiString&
 	if( attackingTeam == NULL || victimTeam == NULL )
 		return;
 
-	AIGroup *aiGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> aiGroup = TheAI->createGroup();
 	if (!aiGroup) {
 		return;
 	}
 
-	attackingTeam->getTeamAsAIGroup(aiGroup);
+	attackingTeam->getTeamAsAIGroup(aiGroup.Peek());
 	aiGroup->groupAttackTeam(victimTeam, NO_MAX_SHOTS_LIMIT, CMD_FROM_SCRIPT);
 
 }
@@ -1260,12 +1260,12 @@ void ScriptActions::updateTeamSetAttitude(const AsciiString& teamName, Int attit
 		return;
 	}
 
-	AIGroup *pAIGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> pAIGroup = TheAI->createGroup();
 	if (!pAIGroup) {
 		return;
 	}
 
-	theSrcTeam->getTeamAsAIGroup(pAIGroup);
+	theSrcTeam->getTeamAsAIGroup(pAIGroup.Peek());
 	pAIGroup->setAttitude((AttitudeType) attitude);
 }
 
@@ -1369,12 +1369,12 @@ void ScriptActions::doTeamAttackArea(const AsciiString& teamName, const AsciiStr
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
 
-	theTeam->getTeamAsAIGroup(theGroup);
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
 
 	PolygonTrigger *pTrig = TheScriptEngine->getQualifiedTriggerAreaByName(areaName);
 	if (!pTrig) {
@@ -1401,12 +1401,12 @@ void ScriptActions::doTeamAttackNamed(const AsciiString& teamName, const AsciiSt
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
 
-	theTeam->getTeamAsAIGroup(theGroup);
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
 	theGroup->groupAttackObject(theVictim, NO_MAX_SHOTS_LIMIT, CMD_FROM_SCRIPT);
 }
 
@@ -1508,8 +1508,8 @@ void ScriptActions::doTeamEnterNamed(const AsciiString& teamName, const AsciiStr
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
-	theSrcTeam->getTeamAsAIGroup(theGroup);
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
+	theSrcTeam->getTeamAsAIGroup(theGroup.Peek());
 
 	theGroup->groupEnter(theTransport, CMD_FROM_SCRIPT);
 }
@@ -1544,8 +1544,8 @@ void ScriptActions::doTeamExitAll(const AsciiString& teamName)
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
-	theTeamOfTransports->getTeamAsAIGroup(theGroup);
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
+	theTeamOfTransports->getTeamAsAIGroup(theGroup.Peek());
 
 	theGroup->groupEvacuate( CMD_FROM_SCRIPT );
 }
@@ -1614,11 +1614,11 @@ void ScriptActions::doTeamFollowSkirmishApproachPath(const AsciiString& teamName
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
-	theTeam->getTeamAsAIGroup(theGroup);
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
 	Int count = 0;
 	Coord3D pos;
 	pos.x=pos.y=pos.z=0;
@@ -1677,11 +1677,11 @@ void ScriptActions::doTeamMoveToSkirmishApproachPath(const AsciiString& teamName
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
-	theTeam->getTeamAsAIGroup(theGroup);
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
 	Int count = 0;
 	Coord3D pos;
 	pos.x=pos.y=pos.z=0;
@@ -1725,11 +1725,11 @@ void ScriptActions::doTeamFollowWaypoints(const AsciiString& teamName, const Asc
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
-	theTeam->getTeamAsAIGroup(theGroup);
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
 	Int count = 0;
 	Coord3D pos;
 	pos.x=pos.y=pos.z=0;
@@ -1772,11 +1772,11 @@ void ScriptActions::doTeamFollowWaypointsExact(const AsciiString& teamName, cons
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
-	theTeam->getTeamAsAIGroup(theGroup);
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
 	Int count = 0;
 	Coord3D pos;
 	pos.x=pos.y=pos.z=0;
@@ -1864,11 +1864,11 @@ void ScriptActions::doTeamGuardPosition(const AsciiString& teamName, const Ascii
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
-	theTeam->getTeamAsAIGroup(theGroup);
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
 	Coord3D position = *way->getLocation();
 
 	theGroup->groupGuardPosition( &position, GUARDMODE_NORMAL, CMD_FROM_SCRIPT );
@@ -1885,11 +1885,11 @@ void ScriptActions::doTeamGuardObject(const AsciiString& teamName, const AsciiSt
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
-	theTeam->getTeamAsAIGroup(theGroup);
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
 
 	theGroup->groupGuardObject( theUnit, GUARDMODE_NORMAL, CMD_FROM_SCRIPT );
 }
@@ -1905,11 +1905,11 @@ void ScriptActions::doTeamGuardArea(const AsciiString& teamName, const AsciiStri
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
-	theTeam->getTeamAsAIGroup(theGroup);
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
 
 	theGroup->groupGuardArea( pTrig, GUARDMODE_NORMAL, CMD_FROM_SCRIPT );
 }
@@ -1943,11 +1943,11 @@ void ScriptActions::doTeamHunt(const AsciiString& teamName)
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
-	theTeam->getTeamAsAIGroup(theGroup);
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
 
 	theGroup->groupHunt( CMD_FROM_SCRIPT );
 }
@@ -3242,12 +3242,12 @@ void ScriptActions::doTeamGarrisonSpecificBuilding(const AsciiString& teamName, 
 		return;
 	}
 	
-	AIGroup* theGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
 	
-	theTeam->getTeamAsAIGroup(theGroup);
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
 	theGroup->groupEnter(theBuilding, CMD_FROM_SCRIPT);
 }
 
@@ -4082,13 +4082,13 @@ void ScriptActions::doTeamUseCommandButtonAbility( const AsciiString& team, cons
 	}
 
 
-	AIGroup* theGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 	if( !theGroup ) 
 	{
 		return;
 	}
 
-	theTeam->getTeamAsAIGroup( theGroup );
+	theTeam->getTeamAsAIGroup( theGroup.Peek() );
 	
 	theGroup->groupDoCommandButton( commandButton, CMD_FROM_SCRIPT );
 }
@@ -4117,13 +4117,13 @@ void ScriptActions::doTeamUseCommandButtonAbilityOnNamed( const AsciiString& tea
 	}
 
 
-	AIGroup* theGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 	if( !theGroup ) 
 	{
 		return;
 	}
 
-	theTeam->getTeamAsAIGroup( theGroup );
+	theTeam->getTeamAsAIGroup( theGroup.Peek() );
 	
 	theGroup->groupDoCommandButtonAtObject( commandButton, theObj, CMD_FROM_SCRIPT );
 }
@@ -4152,13 +4152,13 @@ void ScriptActions::doTeamUseCommandButtonAbilityAtWaypoint( const AsciiString& 
 	}
 
 
-	AIGroup* theGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 	if( !theGroup ) 
 	{
 		return;
 	}
 
-	theTeam->getTeamAsAIGroup( theGroup );
+	theTeam->getTeamAsAIGroup( theGroup.Peek() );
 	
 	theGroup->groupDoCommandButtonAtPosition( commandButton, pWaypoint->getLocation(), CMD_FROM_SCRIPT );
 }
@@ -4236,12 +4236,12 @@ void ScriptActions::doTeamStop(const AsciiString& teamName, Bool shouldDisband)
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
 
-	theTeam->getTeamAsAIGroup(theGroup);
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
 	theGroup->groupIdle(CMD_FROM_SCRIPT);
 
 	if (shouldDisband) {
@@ -4449,12 +4449,12 @@ void ScriptActions::doTeamStartSequentialScript(const AsciiString& teamName, con
 	}
 
 	// Idle the team so the seq script will start executing. jba.
-	AIGroup* theGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
 
-	team->getTeamAsAIGroup(theGroup);
+	team->getTeamAsAIGroup(theGroup.Peek());
 	theGroup->groupIdle(CMD_FROM_SCRIPT);
 
 
@@ -4556,12 +4556,12 @@ void ScriptActions::doTeamIdleForFramecount(const AsciiString& teamName, Int fra
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
 
-	theTeam->getTeamAsAIGroup(theGroup);
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
 	Coord3D center;
 	theGroup->getCenter(&center);
 
@@ -4942,8 +4942,8 @@ void ScriptActions::doSkirmishAttackNearestGroupWithValue( const AsciiString& te
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
-	team->getTeamAsAIGroup(theGroup);
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
+	team->getTeamAsAIGroup(theGroup.Peek());
 
 	Player *player = team->getControllingPlayer();
 
@@ -4971,8 +4971,8 @@ void ScriptActions::doSkirmishCommandButtonOnMostValuable( const AsciiString& te
 		return;
 	}
 
-	AIGroup *theGroup = TheAI->createGroup();
-	team->getTeamAsAIGroup(theGroup);
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
+	team->getTeamAsAIGroup(theGroup.Peek());
 
 	Player *player = team->getControllingPlayer();
 	if (!player)
@@ -5034,8 +5034,8 @@ void ScriptActions::doTeamUseCommandButtonOnNamed( const AsciiString& teamName, 
 		return;
 	}
 
-	AIGroup *theGroup = TheAI->createGroup();
-	team->getTeamAsAIGroup(theGroup);
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
+	team->getTeamAsAIGroup(theGroup.Peek());
 
 	const CommandButton *commandButton = TheControlBar->findCommandButton(commandAbility);
 	if(!commandButton) {
@@ -5073,8 +5073,8 @@ void ScriptActions::doTeamUseCommandButtonOnNearestEnemy( const AsciiString& tea
 		return;
 	}
 
-	AIGroup *theGroup = TheAI->createGroup();
-	team->getTeamAsAIGroup(theGroup);
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
+	team->getTeamAsAIGroup(theGroup.Peek());
 
 	const CommandButton *commandButton = TheControlBar->findCommandButton(commandAbility);
 	if(!commandButton) {
@@ -5119,8 +5119,8 @@ void ScriptActions::doTeamUseCommandButtonOnNearestGarrisonedBuilding( const Asc
 		return;
 	}
 
-	AIGroup *theGroup = TheAI->createGroup();
-	team->getTeamAsAIGroup(theGroup);
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
+	team->getTeamAsAIGroup(theGroup.Peek());
 
 	const CommandButton *commandButton = TheControlBar->findCommandButton(commandAbility);
 	if(!commandButton) {
@@ -5167,8 +5167,8 @@ void ScriptActions::doTeamUseCommandButtonOnNearestKindof( const AsciiString& te
 		return;
 	}
 
-	AIGroup *theGroup = TheAI->createGroup();
-	team->getTeamAsAIGroup(theGroup);
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
+	team->getTeamAsAIGroup(theGroup.Peek());
 
 	const CommandButton *commandButton = TheControlBar->findCommandButton(commandAbility);
 	if (!commandButton) {
@@ -5214,8 +5214,8 @@ void ScriptActions::doTeamUseCommandButtonOnNearestBuilding( const AsciiString& 
 		return;
 	}
 
-	AIGroup *theGroup = TheAI->createGroup();
-	team->getTeamAsAIGroup(theGroup);
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
+	team->getTeamAsAIGroup(theGroup.Peek());
 
 	const CommandButton *commandButton = TheControlBar->findCommandButton(commandAbility);
 	if (!commandButton) {
@@ -5261,8 +5261,8 @@ void ScriptActions::doTeamUseCommandButtonOnNearestBuildingClass( const AsciiStr
 		return;
 	}
 
-	AIGroup *theGroup = TheAI->createGroup();
-	team->getTeamAsAIGroup(theGroup);
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
+	team->getTeamAsAIGroup(theGroup.Peek());
 
 	const CommandButton *commandButton = TheControlBar->findCommandButton(commandAbility);
 	if (!commandButton) {
@@ -5309,8 +5309,8 @@ void ScriptActions::doTeamUseCommandButtonOnNearestObjectType( const AsciiString
 		return;
 	}
 
-	AIGroup *theGroup = TheAI->createGroup();
-	team->getTeamAsAIGroup(theGroup);
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
+	team->getTeamAsAIGroup(theGroup.Peek());
 
 	const CommandButton *commandButton = TheControlBar->findCommandButton(commandAbility);
 	if (!commandButton) {
@@ -5400,8 +5400,8 @@ void ScriptActions::doTeamCaptureNearestUnownedFactionUnit( const AsciiString& t
 		return;
 	}
 
-	AIGroup *theGroup = TheAI->createGroup();
-	team->getTeamAsAIGroup(theGroup);
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
+	team->getTeamAsAIGroup(theGroup.Peek());
 
 	PartitionFilterPlayerAffiliation f1(team->getControllingPlayer(), ALLOW_ENEMIES | ALLOW_NEUTRAL, true);
 	PartitionFilterUnmannedObject f2(true);
@@ -5516,12 +5516,12 @@ void ScriptActions::doTeamEmoticon(const AsciiString& teamName, const AsciiStrin
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 	if( !theGroup ) 
 	{
 		return;
 	}
-	theTeam->getTeamAsAIGroup( theGroup );
+	theTeam->getTeamAsAIGroup( theGroup.Peek() );
 	
 	Int frames = (Int)( duration * LOGICFRAMES_PER_SECOND );
 	theGroup->groupSetEmoticon( emoticonName, frames );

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
@@ -7210,9 +7210,9 @@ void ScriptEngine::evaluateAndProgressAllSequentialScripts( void )
 		}
 
 		AIUpdateInterface *ai = obj ? obj->getAIUpdateInterface() : NULL;
-		AIGroup *aigroup = (team ? TheAI->createGroup() : NULL);
+		RefCountPtr<AIGroup> aigroup = team ? TheAI->createGroup() : NULL;
 		if (aigroup) {
-			team->getTeamAsAIGroup(aigroup);
+			team->getTeamAsAIGroup(aigroup.Peek());
 		}
 
 		if( ai || aigroup ) {
@@ -7296,8 +7296,8 @@ void ScriptEngine::evaluateAndProgressAllSequentialScripts( void )
 						itAdvanced = true;
 					} else if (team) {
 						// attempt to rebuild the aigroup, as it probably expired during the action execution
-						aigroup = (team ? TheAI->createGroup() : NULL);
-						team->getTeamAsAIGroup(aigroup);
+						aigroup = team ? TheAI->createGroup() : NULL;
+						team->getTeamAsAIGroup(aigroup.Peek());
 					}
 
 					if (aigroup && aigroup->isIdle()) {

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -2355,19 +2355,18 @@ void GameLogic::selectObject(Object *obj, Bool createNewSelection, PlayerMaskTyp
 			return;
 		}
 
-		AIGroup *group = NULL;
 		CRCGEN_LOG(( "Creating AIGroup in GameLogic::selectObject()\n" ));
-		group = TheAI->createGroup();
+		RefCountPtr<AIGroup> group = TheAI->createGroup();
 		group->add(obj);
 
 		// add all selected agents to the AI group
 		if (createNewSelection)	{
-			player->setCurrentlySelectedAIGroup(group);
+			player->setCurrentlySelectedAIGroup(group.Peek());
 		} else {
-			player->addAIGroupToCurrentSelection(group);
+			player->addAIGroupToCurrentSelection(group.Peek());
 		}
 
-		TheAI->destroyGroup(group);
+		group->removeAll();
 
 		if (affectClient) {
 			Drawable *draw = obj->getDrawable();
@@ -2392,35 +2391,26 @@ void GameLogic::deselectObject(Object *obj, PlayerMaskType playerMask, Bool affe
 			return;
 		}
 
-		AIGroup *group = NULL;
 		CRCGEN_LOG(( "Removing a unit from a selected group in GameLogic::deselectObject()\n" ));
-		group = TheAI->createGroup();
-		player->getCurrentSelectionAsAIGroup(group);
-		
-		Bool deleted = FALSE;
-		Bool actuallyRemoved = FALSE;
-		
-		if (group) {
-			deleted = group->remove(obj);
-			actuallyRemoved = TRUE;
-		}
-		
-		if (actuallyRemoved) {
-			// Set this to be the currently selected group.
-			if (!deleted) {
-				player->setCurrentlySelectedAIGroup(group);
-				// Then, cleanup the group.
-				TheAI->destroyGroup(group);
-			} else {
-				// NULL will clear the group.
-				player->setCurrentlySelectedAIGroup(NULL);
-			}
+		RefCountPtr<AIGroup> group = TheAI->createGroup();
+		player->getCurrentSelectionAsAIGroup(group.Peek());
 
-			if (affectClient) {
-				Drawable *draw = obj->getDrawable();
-				if (draw) {
-					TheInGameUI->deselectDrawable(draw);
-				}
+		Bool emptied = group->remove(obj);
+
+		// Set this to be the currently selected group.
+		if (!emptied) {
+			player->setCurrentlySelectedAIGroup(group.Peek());
+			// Cleanup the group.
+			group->removeAll();
+		} else {
+			// NULL will clear the group.
+			player->setCurrentlySelectedAIGroup(NULL);
+		}
+
+		if (affectClient) {
+			Drawable *draw = obj->getDrawable();
+			if (draw) {
+				TheInGameUI->deselectDrawable(draw);
 			}
 		}
 	}

--- a/GeneralsMD/Code/GameEngine/Include/Common/Player.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Player.h
@@ -634,7 +634,7 @@ public:
 	// add to the player's current selection this hotkey team.
 	void processAddTeamGameMessage(Int hotkeyNum, GameMessage *msg);
 
-	// returns an AIGroup object that is the currently selected group.
+	// fills an AIGroup object that is the currently selected group.
 	void getCurrentSelectionAsAIGroup(AIGroup *group);
 
 	// sets the currently selected group to be the given AIGroup

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
@@ -1046,4 +1046,11 @@ private:
 };
 
 
+#if RETAIL_COMPATIBLE_CRC
+#define LEAK_AIGROUP_IF_EMPTY(theGroup) if (theGroup && theGroup->isEmpty()) { theGroup.Release(); }
+#else
+#define LEAK_AIGROUP_IF_EMPTY(theGroup)
+#endif
+
+
 #endif // _AI_H_

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
@@ -896,7 +896,7 @@ public:
 
 	void Add_Ref() const { m_refCount.Add_Ref(); }
 	void Release_Ref() const { m_refCount.Release_Ref(destroy, this); }
-	void Num_Refs() const { m_refCount.Num_Refs(); }
+	Int Num_Refs() const { return m_refCount.Num_Refs(); }
 
 	void groupMoveToPosition( const Coord3D *pos, Bool addWaypoint, CommandSourceType cmdSource );
 	void groupMoveToAndEvacuate( const Coord3D *pos, CommandSourceType cmdSource );			///< move to given position(s)

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
@@ -896,7 +896,7 @@ public:
 
 	void Add_Ref() const { m_refCount.Add_Ref(); }
 	void Release_Ref() const { m_refCount.Release_Ref(destroy, this); }
-	Int Num_Refs() const { return m_refCount.Num_Refs(); }
+	UnsignedShort Num_Refs() const { return m_refCount.Num_Refs(); }
 
 	void groupMoveToPosition( const Coord3D *pos, Bool addWaypoint, CommandSourceType cmdSource );
 	void groupMoveToAndEvacuate( const Coord3D *pos, CommandSourceType cmdSource );			///< move to given position(s)

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
@@ -31,6 +31,7 @@
 #define _OBJECT_H_
 
 #include "Lib/BaseType.h"
+#include "ref_ptr.h"
 
 #include "Common/Geometry.h"
 #include "Common/Snapshot.h"
@@ -702,7 +703,7 @@ private:
 
 	GeometryInfo	m_geometryInfo;
 
-	AIGroup*			m_group;								///< if non-NULL, we are part of this group of agents
+	RefCountPtr<AIGroup> m_group;								///< if non-NULL, we are part of this group of agents
 
 	// These will last for my lifetime.  I will reuse them and reset them.  The truly dynamic ones are in PartitionManager
 	SightingInfo		*m_partitionLastLook;								///< Where and for whom I last looked, so I can undo its effects when I stop

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AI.cpp
@@ -333,18 +333,11 @@ void AI::reset( void )
 		m_aiData = m_aiData->m_next;
 		delete cur;
 	}
-	while (m_groupList.size())
-	{
-		AIGroup *groupToRemove = m_groupList.front();
-		if (groupToRemove)
-		{
-			destroyGroup(groupToRemove);
-		}
-		else
-		{
-			m_groupList.pop_front(); // NULL group, just kill from list.  Shouldn't really happen, but just in case.
-		}
-	}
+
+	DEBUG_ASSERTCRASH(m_groupList.empty(), ("AI::m_groupList is expected empty already\n"));
+
+	m_groupList.clear(); // Clear just in case...
+
 	m_nextGroupID = 0;
 	m_nextFormationID = NO_FORMATION_ID;
 	getNextFormationID(); // increment once past NO_FORMATION_ID.  jba.
@@ -443,14 +436,14 @@ void AI::parseAiDataDefinition( INI* ini )
 /**
  * Create a new AI Group
  */
-AIGroup *AI::createGroup( void )
+RefCountPtr<AIGroup> AI::createGroup( void )
 {
 	// create a new instance
-	AIGroup *group = newInstance(AIGroup);
+	RefCountPtr<AIGroup> group = RefCountPtr<AIGroup>::Create_NoAddRef(newInstance(AIGroup));
 
 	// add it to the list
 //	DEBUG_LOG(("***AIGROUP %x is being added to m_groupList.\n", group ));
-	m_groupList.push_back( group );
+	m_groupList.push_back( group.Peek() );
 
 	return group;
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AI.cpp
@@ -334,9 +334,24 @@ void AI::reset( void )
 		delete cur;
 	}
 
+#if RETAIL_COMPATIBLE_CRC
+	while (m_groupList.size())
+	{
+		AIGroup *groupToRemove = m_groupList.front();
+		if (groupToRemove)
+		{
+			destroyGroup(groupToRemove);
+		}
+		else
+		{
+			m_groupList.pop_front(); // NULL group, just kill from list.  Shouldn't really happen, but just in case.
+		}
+	}
+#else
 	DEBUG_ASSERTCRASH(m_groupList.empty(), ("AI::m_groupList is expected empty already\n"));
 
 	m_groupList.clear(); // Clear just in case...
+#endif
 
 	m_nextGroupID = 0;
 	m_nextFormationID = NO_FORMATION_ID;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
@@ -92,20 +92,8 @@ AIGroup::~AIGroup()
 {
 //	DEBUG_LOG(("***AIGROUP %x is being destructed.\n", this));
 	// disassociate each member from the group
-	std::list<Object *>::iterator i;
-	for( i = m_memberList.begin(); i != m_memberList.end(); /* empty */ )
-	{
-		Object *member = *i;
-		if (member)
-		{
-			member->leaveGroup();
-			i = m_memberList.begin();	// jump back to the beginning, cause ai->leaveGroup will remove this element. 
-		}
-		else
-		{
-			i = m_memberList.erase(i);
-		}
-	}
+	removeAll();
+
 	if (m_groundPath) {
 		deleteInstance(m_groundPath);
 		m_groundPath = NULL;
@@ -223,13 +211,31 @@ Bool AIGroup::remove( Object *obj )
 	// list has changed, properties need recomputation
 	m_dirty = true;
 
-	// if the group is empty, no-one is using it any longer, so destroy it
 	if (isEmpty()) {
-		TheAI->destroyGroup( this );
 		return TRUE;
 	}
 
 	return FALSE;
+}
+
+/**
+ * Remove all objects from group
+ */
+void AIGroup::removeAll( void )
+{
+	std::list<Object *> memberList;
+	memberList.swap(m_memberList);
+	m_memberListSize = 0;
+	
+	std::list<Object *>::iterator i = memberList.begin();
+	for ( ; i != memberList.end(); ++i)
+	{
+		Object *member = *i;
+		if (member)
+			member->leaveGroup();
+	}
+
+	m_dirty = true;
 }
 
 /**

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
@@ -227,8 +227,8 @@ void AIGroup::removeAll( void )
 	memberList.swap(m_memberList);
 	m_memberListSize = 0;
 	
-	std::list<Object *>::iterator i = memberList.begin();
-	for ( ; i != memberList.end(); ++i)
+	std::list<Object *>::iterator i;
+	for ( i = memberList.begin(); i != memberList.end(); ++i )
 	{
 		Object *member = *i;
 		if (member)

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -921,6 +921,7 @@ void AIPlayer::guardSupplyCenter( Team *team, Int minSupplies )
 		location.y -= offset.y*radius;
 		theGroup->groupGuardPosition( &location, GUARDMODE_NORMAL, CMD_FROM_SCRIPT );
 
+		LEAK_AIGROUP_IF_EMPTY(theGroup);
 	}
 }
 
@@ -2804,6 +2805,7 @@ void AIPlayer::checkReadyTeams( void )
 							team->m_frameStarted = TheGameLogic->getFrame();
 							continue;
 						}
+						LEAK_AIGROUP_IF_EMPTY(theGroup);
 					}
 					*/
 				}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -900,11 +900,11 @@ void AIPlayer::guardSupplyCenter( Team *team, Int minSupplies )
 	}
 	if (warehouse) {
 
-		AIGroup* theGroup = TheAI->createGroup();
+		RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 		if (!theGroup) {
 			return;
 		}
-		team->getTeamAsAIGroup(theGroup);
+		team->getTeamAsAIGroup(theGroup.Peek());
 		Coord3D location = *warehouse->getPosition();
 		// It's probably a defensive move - position towards the enemy.
 		Region2D bounds;
@@ -2796,9 +2796,9 @@ void AIPlayer::checkReadyTeams( void )
 					/*
 					if (team->m_team->getPrototype()->getTemplateInfo()->m_hasHomeLocation && 
 							!team->m_reinforcement) {
- 						AIGroup* theGroup = TheAI->createGroup();
+						RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 						if (theGroup) {
-							team->m_team->getTeamAsAIGroup(theGroup);
+							team->m_team->getTeamAsAIGroup(theGroup.Peek());
 							Coord3D destination = team->m_team->getPrototype()->getTemplateInfo()->m_homeLocation;
 							theGroup->groupTightenToPosition( &destination, false, CMD_FROM_AI );
 							team->m_frameStarted = TheGameLogic->getFrame();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -4171,8 +4171,8 @@ StateReturnType AIFollowWaypointPathState::update()
 	if (m_moveAsGroup) {
 		if (obj->getControllingPlayer()->isSkirmishAIPlayer()) {
 			Team *team = obj->getTeam();
-			AIGroup *group = TheAI->createGroup();
-			team->getTeamAsAIGroup(group);
+			RefCountPtr<AIGroup> group = TheAI->createGroup();
+			team->getTeamAsAIGroup(group.Peek());
 
 			Coord3D pos;
 			group->getCenter(&pos);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -4186,6 +4186,8 @@ StateReturnType AIFollowWaypointPathState::update()
 				// Consider ourselves close enough.
 				status = STATE_SUCCESS;
 			}
+
+			LEAK_AIGROUP_IF_EMPTY(group);
 		}
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -645,9 +645,8 @@ Object::~Object()
 		ThePartitionManager->unRegisterObject( this );
 
 	// if we are in a group, remove us
-	if (m_group)
-		m_group->remove( this );
-	
+	leaveGroup();
+
 	// note, do NOT free these, there are just a shadow copy!
 	m_ai = NULL;
 	m_physics = NULL;
@@ -4371,7 +4370,7 @@ void Object::xfer( Xfer *xfer )
 	}
 
 	// Doesn't need to be saved.  These are created as needed.  jba.
-	//AIGroup*		m_group;															///< if non-NULL, we are part of this group of agents
+	//m_group;
 
 	// don't need to save m_partitionData.
 	DEBUG_ASSERTCRASH(!(xfer->getXferMode() == XFER_LOAD && m_partitionData == NULL), ("should not be in partitionmgr yet"));
@@ -6284,7 +6283,7 @@ RadarPriorityType Object::getRadarPriority( void ) const
 // ------------------------------------------------------------------------------------------------
 AIGroup *Object::getGroup(void)
 {
-	return m_group;
+	return m_group.Peek();
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -6294,7 +6293,7 @@ void Object::enterGroup( AIGroup *group )
 	// if we are in another group, remove ourselves from it first
 	leaveGroup();
 
-	m_group = group;
+	m_group = RefCountPtr<AIGroup>::Create_AddRef(group);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -6305,7 +6304,7 @@ void Object::leaveGroup( void )
 	if (m_group)
 	{
 		// to avoid recursion, set m_group to NULL before removing
-		AIGroup *group = m_group;
+		RefCountPtr<AIGroup> group = m_group;
 		m_group = NULL;
 		group->remove( this );
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
@@ -419,12 +419,12 @@ void ScriptActions::doMoveToWaypoint(const AsciiString& team, const AsciiString&
 	// The team is the team based on the name, and the calling team (if any) and the team that
 	// triggered the condition.  jba. :)
 	if (theTeam) {
-		AIGroup* theGroup = TheAI->createGroup();
+		RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 		if (!theGroup) {
 			return;
 		}
 
-		theTeam->getTeamAsAIGroup(theGroup);
+		theTeam->getTeamAsAIGroup(theGroup.Peek());
 		Waypoint *way = TheTerrainLogic->getWaypointByName(waypoint);
 		if (way) {
 			Coord3D destination = *way->getLocation();
@@ -783,12 +783,12 @@ void ScriptActions::doCreateReinforcements(const AsciiString& team, const AsciiS
 			theTeam->setActive();
 			if (needToMoveToDestination) 
 			{
-				AIGroup* theGroup = TheAI->createGroup();
+				RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 				if (!theGroup) 
 				{
 					return;
 				}
-				theTeam->getTeamAsAIGroup(theGroup);
+				theTeam->getTeamAsAIGroup(theGroup.Peek());
 				theGroup->groupMoveToPosition( &destination, false, CMD_FROM_SCRIPT );
 			}
 		}
@@ -1050,12 +1050,12 @@ void ScriptActions::doAttack(const AsciiString& attackerName, const AsciiString&
 	if( attackingTeam == NULL || victimTeam == NULL )
 		return;
 
-	AIGroup *aiGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> aiGroup = TheAI->createGroup();
 	if (!aiGroup) {
 		return;
 	}
 
-	attackingTeam->getTeamAsAIGroup(aiGroup);
+	attackingTeam->getTeamAsAIGroup(aiGroup.Peek());
 	aiGroup->groupAttackTeam(victimTeam, NO_MAX_SHOTS_LIMIT, CMD_FROM_SCRIPT);
 
 }
@@ -1308,12 +1308,12 @@ void ScriptActions::updateTeamSetAttitude(const AsciiString& teamName, Int attit
 		return;
 	}
 
-	AIGroup *pAIGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> pAIGroup = TheAI->createGroup();
 	if (!pAIGroup) {
 		return;
 	}
 
-	theSrcTeam->getTeamAsAIGroup(pAIGroup);
+	theSrcTeam->getTeamAsAIGroup(pAIGroup.Peek());
 	pAIGroup->setAttitude((AttitudeType) attitude);
 }
 
@@ -1417,12 +1417,12 @@ void ScriptActions::doTeamAttackArea(const AsciiString& teamName, const AsciiStr
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
 
-	theTeam->getTeamAsAIGroup(theGroup);
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
 
 	PolygonTrigger *pTrig = TheScriptEngine->getQualifiedTriggerAreaByName(areaName);
 	if (!pTrig) {
@@ -1449,12 +1449,12 @@ void ScriptActions::doTeamAttackNamed(const AsciiString& teamName, const AsciiSt
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
 
-	theTeam->getTeamAsAIGroup(theGroup);
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
 	theGroup->groupAttackObject(theVictim, NO_MAX_SHOTS_LIMIT, CMD_FROM_SCRIPT);
 }
 
@@ -1556,8 +1556,8 @@ void ScriptActions::doTeamEnterNamed(const AsciiString& teamName, const AsciiStr
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
-	theSrcTeam->getTeamAsAIGroup(theGroup);
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
+	theSrcTeam->getTeamAsAIGroup(theGroup.Peek());
 
 	theGroup->groupEnter(theTransport, CMD_FROM_SCRIPT);
 }
@@ -1592,8 +1592,8 @@ void ScriptActions::doTeamExitAll(const AsciiString& teamName)
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
-	theTeamOfTransports->getTeamAsAIGroup(theGroup);
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
+	theTeamOfTransports->getTeamAsAIGroup(theGroup.Peek());
 
 	theGroup->groupEvacuate( CMD_FROM_SCRIPT );
 }
@@ -1684,11 +1684,11 @@ void ScriptActions::doTeamFollowSkirmishApproachPath(const AsciiString& teamName
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
-	theTeam->getTeamAsAIGroup(theGroup);
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
 	Int count = 0;
 	Coord3D pos;
 	pos.x=pos.y=pos.z=0;
@@ -1747,11 +1747,11 @@ void ScriptActions::doTeamMoveToSkirmishApproachPath(const AsciiString& teamName
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
-	theTeam->getTeamAsAIGroup(theGroup);
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
 	Int count = 0;
 	Coord3D pos;
 	pos.x=pos.y=pos.z=0;
@@ -1795,11 +1795,11 @@ void ScriptActions::doTeamFollowWaypoints(const AsciiString& teamName, const Asc
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
-	theTeam->getTeamAsAIGroup(theGroup);
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
 	Int count = 0;
 	Coord3D pos;
 	pos.x=pos.y=pos.z=0;
@@ -1842,11 +1842,11 @@ void ScriptActions::doTeamFollowWaypointsExact(const AsciiString& teamName, cons
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
-	theTeam->getTeamAsAIGroup(theGroup);
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
 	Int count = 0;
 	Coord3D pos;
 	pos.x=pos.y=pos.z=0;
@@ -1934,11 +1934,11 @@ void ScriptActions::doTeamGuardPosition(const AsciiString& teamName, const Ascii
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
-	theTeam->getTeamAsAIGroup(theGroup);
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
 	Coord3D position = *way->getLocation();
 
 	theGroup->groupGuardPosition( &position, GUARDMODE_NORMAL, CMD_FROM_SCRIPT );
@@ -1955,11 +1955,11 @@ void ScriptActions::doTeamGuardObject(const AsciiString& teamName, const AsciiSt
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
-	theTeam->getTeamAsAIGroup(theGroup);
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
 
 	theGroup->groupGuardObject( theUnit, GUARDMODE_NORMAL, CMD_FROM_SCRIPT );
 }
@@ -1975,11 +1975,11 @@ void ScriptActions::doTeamGuardArea(const AsciiString& teamName, const AsciiStri
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
-	theTeam->getTeamAsAIGroup(theGroup);
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
 
 	theGroup->groupGuardArea( pTrig, GUARDMODE_NORMAL, CMD_FROM_SCRIPT );
 }
@@ -2013,11 +2013,11 @@ void ScriptActions::doTeamHunt(const AsciiString& teamName)
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
-	theTeam->getTeamAsAIGroup(theGroup);
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
 
 	theGroup->groupHunt( CMD_FROM_SCRIPT );
 }
@@ -3338,12 +3338,12 @@ void ScriptActions::doTeamGarrisonSpecificBuilding(const AsciiString& teamName, 
 		return;
 	}
 	
-	AIGroup* theGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
 	
-	theTeam->getTeamAsAIGroup(theGroup);
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
 	theGroup->groupEnter(theBuilding, CMD_FROM_SCRIPT);
 }
 
@@ -4413,13 +4413,13 @@ void ScriptActions::doTeamUseCommandButtonAbility( const AsciiString& team, cons
 	}
 
 
-	AIGroup* theGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 	if( !theGroup ) 
 	{
 		return;
 	}
 
-	theTeam->getTeamAsAIGroup( theGroup );
+	theTeam->getTeamAsAIGroup( theGroup.Peek() );
 	
 	theGroup->groupDoCommandButton( commandButton, CMD_FROM_SCRIPT );
 }
@@ -4448,13 +4448,13 @@ void ScriptActions::doTeamUseCommandButtonAbilityOnNamed( const AsciiString& tea
 	}
 
 
-	AIGroup* theGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 	if( !theGroup ) 
 	{
 		return;
 	}
 
-	theTeam->getTeamAsAIGroup( theGroup );
+	theTeam->getTeamAsAIGroup( theGroup.Peek() );
 	
 	theGroup->groupDoCommandButtonAtObject( commandButton, theObj, CMD_FROM_SCRIPT );
 }
@@ -4483,13 +4483,13 @@ void ScriptActions::doTeamUseCommandButtonAbilityAtWaypoint( const AsciiString& 
 	}
 
 
-	AIGroup* theGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 	if( !theGroup ) 
 	{
 		return;
 	}
 
-	theTeam->getTeamAsAIGroup( theGroup );
+	theTeam->getTeamAsAIGroup( theGroup.Peek() );
 	
 	theGroup->groupDoCommandButtonAtPosition( commandButton, pWaypoint->getLocation(), CMD_FROM_SCRIPT );
 }
@@ -4567,12 +4567,12 @@ void ScriptActions::doTeamStop(const AsciiString& teamName, Bool shouldDisband)
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
 
-	theTeam->getTeamAsAIGroup(theGroup);
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
 	theGroup->groupIdle(CMD_FROM_SCRIPT);
 
 	if (shouldDisband) {
@@ -4780,12 +4780,12 @@ void ScriptActions::doTeamStartSequentialScript(const AsciiString& teamName, con
 	}
 
 	// Idle the team so the seq script will start executing. jba.
-	AIGroup* theGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
 
-	team->getTeamAsAIGroup(theGroup);
+	team->getTeamAsAIGroup(theGroup.Peek());
 	theGroup->groupIdle(CMD_FROM_SCRIPT);
 
 
@@ -4887,12 +4887,12 @@ void ScriptActions::doTeamIdleForFramecount(const AsciiString& teamName, Int fra
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
 
-	theTeam->getTeamAsAIGroup(theGroup);
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
 	Coord3D center;
 	theGroup->getCenter(&center);
 
@@ -5366,8 +5366,8 @@ void ScriptActions::doSkirmishAttackNearestGroupWithValue( const AsciiString& te
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
-	team->getTeamAsAIGroup(theGroup);
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
+	team->getTeamAsAIGroup(theGroup.Peek());
 
 	Player *player = team->getControllingPlayer();
 
@@ -5395,8 +5395,8 @@ void ScriptActions::doSkirmishCommandButtonOnMostValuable( const AsciiString& te
 		return;
 	}
 
-	AIGroup *theGroup = TheAI->createGroup();
-	team->getTeamAsAIGroup(theGroup);
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
+	team->getTeamAsAIGroup(theGroup.Peek());
 
 	Player *player = team->getControllingPlayer();
 	if (!player)
@@ -5458,8 +5458,8 @@ void ScriptActions::doTeamUseCommandButtonOnNamed( const AsciiString& teamName, 
 		return;
 	}
 
-	AIGroup *theGroup = TheAI->createGroup();
-	team->getTeamAsAIGroup(theGroup);
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
+	team->getTeamAsAIGroup(theGroup.Peek());
 
 	const CommandButton *commandButton = TheControlBar->findCommandButton(commandAbility);
 	if(!commandButton) {
@@ -5497,8 +5497,8 @@ void ScriptActions::doTeamUseCommandButtonOnNearestEnemy( const AsciiString& tea
 		return;
 	}
 
-	AIGroup *theGroup = TheAI->createGroup();
-	team->getTeamAsAIGroup(theGroup);
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
+	team->getTeamAsAIGroup(theGroup.Peek());
 
 	const CommandButton *commandButton = TheControlBar->findCommandButton(commandAbility);
 	if(!commandButton) {
@@ -5543,8 +5543,8 @@ void ScriptActions::doTeamUseCommandButtonOnNearestGarrisonedBuilding( const Asc
 		return;
 	}
 
-	AIGroup *theGroup = TheAI->createGroup();
-	team->getTeamAsAIGroup(theGroup);
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
+	team->getTeamAsAIGroup(theGroup.Peek());
 
 	const CommandButton *commandButton = TheControlBar->findCommandButton(commandAbility);
 	if(!commandButton) {
@@ -5591,8 +5591,8 @@ void ScriptActions::doTeamUseCommandButtonOnNearestKindof( const AsciiString& te
 		return;
 	}
 
-	AIGroup *theGroup = TheAI->createGroup();
-	team->getTeamAsAIGroup(theGroup);
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
+	team->getTeamAsAIGroup(theGroup.Peek());
 
 	const CommandButton *commandButton = TheControlBar->findCommandButton(commandAbility);
 	if (!commandButton) {
@@ -5638,8 +5638,8 @@ void ScriptActions::doTeamUseCommandButtonOnNearestBuilding( const AsciiString& 
 		return;
 	}
 
-	AIGroup *theGroup = TheAI->createGroup();
-	team->getTeamAsAIGroup(theGroup);
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
+	team->getTeamAsAIGroup(theGroup.Peek());
 
 	const CommandButton *commandButton = TheControlBar->findCommandButton(commandAbility);
 	if (!commandButton) {
@@ -5685,8 +5685,8 @@ void ScriptActions::doTeamUseCommandButtonOnNearestBuildingClass( const AsciiStr
 		return;
 	}
 
-	AIGroup *theGroup = TheAI->createGroup();
-	team->getTeamAsAIGroup(theGroup);
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
+	team->getTeamAsAIGroup(theGroup.Peek());
 
 	const CommandButton *commandButton = TheControlBar->findCommandButton(commandAbility);
 	if (!commandButton) {
@@ -5733,8 +5733,8 @@ void ScriptActions::doTeamUseCommandButtonOnNearestObjectType( const AsciiString
 		return;
 	}
 
-	AIGroup *theGroup = TheAI->createGroup();
-	team->getTeamAsAIGroup(theGroup);
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
+	team->getTeamAsAIGroup(theGroup.Peek());
 
 	const CommandButton *commandButton = TheControlBar->findCommandButton(commandAbility);
 	if (!commandButton) {
@@ -5863,8 +5863,8 @@ void ScriptActions::doTeamCaptureNearestUnownedFactionUnit( const AsciiString& t
 		return;
 	}
 
-	AIGroup *theGroup = TheAI->createGroup();
-	team->getTeamAsAIGroup(theGroup);
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
+	team->getTeamAsAIGroup(theGroup.Peek());
 
 	PartitionFilterPlayerAffiliation f1(team->getControllingPlayer(), ALLOW_ENEMIES | ALLOW_NEUTRAL, true);
 	PartitionFilterUnmannedObject f2(true);
@@ -5979,12 +5979,12 @@ void ScriptActions::doTeamEmoticon(const AsciiString& teamName, const AsciiStrin
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 	if( !theGroup ) 
 	{
 		return;
 	}
-	theTeam->getTeamAsAIGroup( theGroup );
+	theTeam->getTeamAsAIGroup( theGroup.Peek() );
 	
 	Int frames = (Int)( duration * LOGICFRAMES_PER_SECOND );
 	theGroup->groupSetEmoticon( emoticonName, frames );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
@@ -7933,9 +7933,9 @@ void ScriptEngine::evaluateAndProgressAllSequentialScripts( void )
 		}
 
 		AIUpdateInterface *ai = obj ? obj->getAIUpdateInterface() : NULL;
-		AIGroup *aigroup = (team ? TheAI->createGroup() : NULL);
+		RefCountPtr<AIGroup> aigroup = team ? TheAI->createGroup() : NULL;
 		if (aigroup) {
-			team->getTeamAsAIGroup(aigroup);
+			team->getTeamAsAIGroup(aigroup.Peek());
 		}
 
 		if( ai || aigroup ) {
@@ -8019,8 +8019,8 @@ void ScriptEngine::evaluateAndProgressAllSequentialScripts( void )
 						itAdvanced = true;
 					} else if (team) {
 						// attempt to rebuild the aigroup, as it probably expired during the action execution
-						aigroup = (team ? TheAI->createGroup() : NULL);
-						team->getTeamAsAIGroup(aigroup);
+						aigroup = team ? TheAI->createGroup() : NULL;
+						team->getTeamAsAIGroup(aigroup.Peek());
 					}
 
 					if (aigroup && aigroup->isIdle()) {

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
@@ -8060,6 +8060,8 @@ void ScriptEngine::evaluateAndProgressAllSequentialScripts( void )
 		if (!itAdvanced) {
 			++it;
 		}
+
+		LEAK_AIGROUP_IF_EMPTY(aigroup);
 	}
 	m_currentPlayer = NULL;
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -347,7 +347,7 @@ void GameLogic::prepareNewGame( Int gameMode, GameDifficulty diff, Int rankPoint
 //-------------------------------------------------------------------------------------------------
 /** This message handles dispatches object command messages to the
   * appropriate objects.
-	* @todo Rename this to "CommandProcessor", or similiar. */
+	* @todo Rename this to "CommandProcessor", or similar. */
 //-------------------------------------------------------------------------------------------------
 void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 {
@@ -359,7 +359,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 	DEBUG_ASSERTCRASH( thisPlayer, ("logicMessageDispatcher: Processing message from unknown player (player index '%d')\n", 
 																	msg->getPlayerIndex()) );
 	
-	AIGroup *currentlySelectedGroup = NULL;
+	RefCountPtr<AIGroup> currentlySelectedGroup;
 
 	if (isInGame())
 	{
@@ -369,16 +369,13 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			{
 				currentlySelectedGroup = TheAI->createGroup(); // can't do this outside a game - it'll cause sync errors galore.
 				CRCGEN_LOG(( "Creating AIGroup %d in GameLogic::logicMessageDispatcher()\n", (currentlySelectedGroup)?currentlySelectedGroup->getID():0 ));
-				thisPlayer->getCurrentSelectionAsAIGroup(currentlySelectedGroup);
+				thisPlayer->getCurrentSelectionAsAIGroup(currentlySelectedGroup.Peek());
 
-				// We can't issue commands to groups that contain units that don't belong the issuing player, so pretend like 
+				// We can't issue commands to groups that contain units that don't belong to the issuing player, so pretend like 
 				// there's nothing selected. Also, if currentlySelectedGroup is empty, go ahead and delete it, so that we can skip
 				// any processing on it.
 				if (currentlySelectedGroup->isEmpty())
-				{
-					TheAI->destroyGroup(currentlySelectedGroup);
 					currentlySelectedGroup = NULL;
-				}
 
 				// If there are any units that the player doesn't own, then remove them from the "currentlySelectedGroup"
 				if (currentlySelectedGroup)
@@ -458,8 +455,10 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 #endif
 
 			if (currentlySelectedGroup)
-				TheAI->destroyGroup(currentlySelectedGroup);
-			currentlySelectedGroup = NULL;
+			{
+				currentlySelectedGroup->removeAll();
+				currentlySelectedGroup = NULL;
+			}
 			TheGameLogic->clearGameData();
 			break;
 
@@ -674,10 +673,10 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Object* source = TheGameLogic->findObjectByID(sourceID);
 			if (source != NULL)
 			{
-				AIGroup* theGroup = TheAI->createGroup();
+				RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 				theGroup->add(source);
 				theGroup->groupDoSpecialPower( specialPowerID, options );
-				TheAI->destroyGroup(theGroup);
+				theGroup->removeAll();
 			}
 			else
 			{
@@ -715,10 +714,10 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Object* source = TheGameLogic->findObjectByID(sourceID);
 			if (source != NULL)
 			{
-				AIGroup* theGroup = TheAI->createGroup();
+				RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 				theGroup->add(source);
 				theGroup->groupDoSpecialPowerAtLocation( specialPowerID, &targetCoord, angle, objectInWay, options );
-				TheAI->destroyGroup(theGroup);
+				theGroup->removeAll();
 			}
 			else
 			{
@@ -754,10 +753,10 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Object* source = TheGameLogic->findObjectByID(sourceID);
 			if (source != NULL)
 			{
-				AIGroup* theGroup = TheAI->createGroup();
+				RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 				theGroup->add(source);
 				theGroup->groupDoSpecialPowerAtObject( specialPowerID, target, options );
-				TheAI->destroyGroup(theGroup);
+				theGroup->removeAll();
 			}
 			else
 			{
@@ -1002,7 +1001,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 		case GameMessage::MSG_EXIT:
 		{
 			Object *objectWantingToExit = TheGameLogic->findObjectByID( msg->getArgument( 0 )->objectID );
-			Object *objectContainingExiter = getSingleObjectFromSelection(currentlySelectedGroup);
+			Object *objectContainingExiter = getSingleObjectFromSelection(currentlySelectedGroup.Peek());
 
 			// sanity
 			if( objectWantingToExit == NULL )
@@ -1189,10 +1188,10 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Object* source = TheGameLogic->findObjectByID(sourceID);
 			if (source != NULL)
 			{
-				AIGroup* theGroup = TheAI->createGroup();
+				RefCountPtr<AIGroup> theGroup = TheAI->createGroup();
 				theGroup->add(source);
 				theGroup->groupOverrideSpecialPowerDestination( spType, loc, CMD_FROM_PLAYER );
-				TheAI->destroyGroup(theGroup);
+				theGroup->removeAll();
 			}
 			else
 			{
@@ -1301,7 +1300,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 		//---------------------------------------------------------------------------------------------
 		case GameMessage::MSG_CANCEL_UPGRADE:
 		{
-			Object *producer = getSingleObjectFromSelection(currentlySelectedGroup);
+			Object *producer = getSingleObjectFromSelection(currentlySelectedGroup.Peek());
 			const UpgradeTemplate *upgradeT = TheUpgradeCenter->findUpgradeByKey( (NameKeyType)(msg->getArgument( 0 )->integer) );
 
 			// sanity
@@ -1327,7 +1326,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 		//---------------------------------------------------------------------------------------------
 		case GameMessage::MSG_QUEUE_UNIT_CREATE:
 		{
-			Object *producer = getSingleObjectFromSelection(currentlySelectedGroup);
+			Object *producer = getSingleObjectFromSelection(currentlySelectedGroup.Peek());
 			const ThingTemplate *whatToCreate;
 			ProductionID productionID;
 
@@ -1360,7 +1359,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 		//-------------------------------------------------------------------------------------------------
 		case GameMessage::MSG_CANCEL_UNIT_CREATE:
 		{
-			Object *producer = getSingleObjectFromSelection(currentlySelectedGroup);
+			Object *producer = getSingleObjectFromSelection(currentlySelectedGroup.Peek());
 			ProductionID productionID = (ProductionID)msg->getArgument( 0 )->integer;
 			
 			// sanity
@@ -1392,7 +1391,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Real angle;
 
 			// get player, what to place, and location
-			Object *constructorObject = getSingleObjectFromSelection(currentlySelectedGroup);
+			Object *constructorObject = getSingleObjectFromSelection(currentlySelectedGroup.Peek());
 			place = TheThingFactory->findByTemplateID( msg->getArgument( 0 )->integer );
 			loc = msg->getArgument( 1 )->location;
 			angle = msg->getArgument( 2 )->real;
@@ -1439,7 +1438,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 		{
 
 			// get the building to cancel construction on
-			Object *building = getSingleObjectFromSelection(currentlySelectedGroup);
+			Object *building = getSingleObjectFromSelection(currentlySelectedGroup.Peek());
 			if( building == NULL )
 				break;
 
@@ -1563,7 +1562,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Player *player = ThePlayerList->getNthPlayer(msg->getPlayerIndex());
 
 			if (player == NULL) {
-				DEBUG_CRASH(("GameLogicDispatch - MSG_CREATE_SELECTED_GROUP had an invalid player nubmer"));
+				DEBUG_CRASH(("GameLogicDispatch - MSG_REMOVE_FROM_SELECTED_GROUP had an invalid player nubmer"));
 				break;
 			}
 
@@ -1573,7 +1572,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 				if (!objToRemove) {
 					continue;
 				}
-				
+
 				TheGameLogic->deselectObject(objToRemove, player->getPlayerMask());
 			}
 
@@ -1700,10 +1699,8 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 		// --------------------------------------------------------------------------------------------
 		case GameMessage::MSG_REMOVE_BEACON:
 		{
-	
-			AIGroup *allSelectedObjects = NULL;
-			allSelectedObjects = TheAI->createGroup();
-			thisPlayer->getCurrentSelectionAsAIGroup(allSelectedObjects); // need to act on all objects, so we can hide teammates' beacons.
+			RefCountPtr<AIGroup> allSelectedObjects = TheAI->createGroup();
+			thisPlayer->getCurrentSelectionAsAIGroup(allSelectedObjects.Peek()); // need to act on all objects, so we can hide teammates' beacons.
 			if( allSelectedObjects )
 			{
 				const VecObjectID& selectedObjects = allSelectedObjects->getAllIDs();
@@ -1743,11 +1740,6 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 							}
 						}
 					}
-				}
-				if (allSelectedObjects->isEmpty())
-				{
-					TheAI->destroyGroup(allSelectedObjects);
-					allSelectedObjects = NULL;
 				}
 			}
 			break;
@@ -2011,9 +2003,10 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 	}
 	/**/
 
-	if( currentlySelectedGroup != NULL )
+	if( currentlySelectedGroup )
 	{
-		TheAI->destroyGroup(currentlySelectedGroup);
+		currentlySelectedGroup->removeAll();
+		currentlySelectedGroup = NULL;
 	}
 
 }  // end logicMessageDispatches

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -1373,6 +1373,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			// get the unit production interface
 			ProductionUpdateInterface *pu = producer->getProductionUpdateInterface();
 			if( pu == NULL )
+				LEAK_AIGROUP_IF_EMPTY(currentlySelectedGroup);
 				return;
 
 			// cancel the production


### PR DESCRIPTION
* Follow up for #1002
* Fixes #75
* Relates to #850

This change fixes a critical problem with AIGroup, that happens all the time in any match, but only crashes the Replay playback when a player is selected.

## The Problem

AIGroup has a fundamental memory management flaw with its `AIGroup::remove` function. It deletes itself when all members are removed, which means that any non-AIGroup members holding a reference to that AIGroup will dangle when it is deleted.

This happens all the time in `GameLogic::logicMessageDispatcher` with its `currentlySelectedGroup` variable. It holds objects in a AIGroup, but that AIGroup can be deleted by external events, for example

```cpp
void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
{
...
  AIGroup* currentlySelectedGroup = NULL;

  if (isInGame())
  {
    if (msg->getType() >= GameMessage::MSG_BEGIN_NETWORK_MESSAGES && msg->getType() <= GameMessage::MSG_END_NETWORK_MESSAGES)
    {
      if (msg->getType() != GameMessage::MSG_LOGIC_CRC && msg->getType() != GameMessage::MSG_SET_REPLAY_CAMERA)
      {
        currentlySelectedGroup = TheAI->createGroup(); // can't do this outside a game - it'll cause sync errors galore.
        CRCGEN_LOG(( "Creating AIGroup %d in GameLogic::logicMessageDispatcher()\n", (currentlySelectedGroup)?currentlySelectedGroup->getID():0 ));
        thisPlayer->getCurrentSelectionAsAIGroup(currentlySelectedGroup);

...
  // process the message
  GameMessage::Type msgType = msg->getType();
  switch( msgType )
  {
...
    case GameMessage::MSG_REMOVE_BEACON:
    {
      AIGroup* allSelectedObjects = TheAI->createGroup();
      thisPlayer->getCurrentSelectionAsAIGroup(allSelectedObjects); // <----- xezon: this will delete the AIGroup pointed to by currentlySelectedGroup
```

There are multiple code paths like this that can delete `currentlySelectedGroup`.

## The Solution

Properly reference count AIGroup so that an AIGroup is only destroyed when all owners let go off it. This fixes all problems, any potential leaks, crashes. It also makes the code simpler in some places.

## TODO

- [x] Test against VC6 Golden Replay
- [x] Replace RefCountClass with RefCountValue
- [ ] Replicate in Generals
- [ ] Test against more replays