### PR TITLE
[ZH] Fix crash in TunnelContain::killAllContained() when killed occupants kill the host container

### DIFF
--- a/GeneralsMD/Code/GameEngine/Include/Common/TunnelTracker.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/TunnelTracker.h
@@ -49,6 +49,7 @@ public:
 	UnsignedInt getContainCount() const { return m_containListSize; }
 	Int getContainMax() const;
 	const ContainedItemsList* getContainedItemsList() const { return &m_containList; }	
+	void swapContainedItemsList(ContainedItemsList& newList);
 
 	Bool isValidContainerFor(const Object* obj, Bool checkCapacity) const;
 	void addToContainList( Object *obj );				///< add 'obj' to contain list

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/TunnelTracker.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/TunnelTracker.cpp
@@ -108,6 +108,13 @@ Int TunnelTracker::getContainMax() const
 }
 
 // ------------------------------------------------------------------------
+void TunnelTracker::swapContainedItemsList(ContainedItemsList& newList)
+{
+	m_containList.swap(newList);
+	m_containListSize = (Int)m_containList.size();
+}
+
+// ------------------------------------------------------------------------
 void TunnelTracker::updateNemesis(const Object *target)
 {
 	if (getCurNemesis()==NULL) {

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
@@ -149,8 +149,8 @@ void TunnelContain::harmAndForceExitAllContained( DamageInfo *info )
 //-------------------------------------------------------------------------------------------------
 void TunnelContain::killAllContained( void )
 {
-	// TheSuperHackers @bugfix xezon 04/06/2025 Empty the TunnelSystem's m_containList straight away
-	// to prevent a potential child call to catastrophically modify the m_containList as well.
+	// TheSuperHackers @bugfix xezon 04/06/2025 Empty the TunnelSystem's Contained Items List
+	// straight away to prevent a potential child call to catastrophically modify it as well.
 	// This scenario can happen if the killed occupant(s) apply deadly damage on death
 	// to the host container, which then attempts to remove all remaining occupants
 	// on the death of the host container. This is reproducible by shooting with

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
@@ -149,18 +149,27 @@ void TunnelContain::harmAndForceExitAllContained( DamageInfo *info )
 //-------------------------------------------------------------------------------------------------
 void TunnelContain::killAllContained( void )
 {
-	Player *owningPlayer = getObject()->getControllingPlayer();
-	const ContainedItemsList *fullList = owningPlayer->getTunnelSystem()->getContainedItemsList();
+	// TheSuperHackers @bugfix xezon 04/06/2025 Empty the TunnelSystem's m_containList straight away
+	// to prevent a potential child call to catastrophically modify the m_containList as well.
+	// This scenario can happen if the killed occupant(s) apply deadly damage on death
+	// to the host container, which then attempts to remove all remaining occupants
+	// on the death of the host container. This is reproducible by shooting with
+	// Neutron Shells on a GLA Tunnel containing GLA Terrorists.
 
-	Object *obj;
-	ContainedItemsList::const_iterator it;
-	it = (*fullList).begin();
-	while( it != (*fullList).end() )
+	ContainedItemsList list;
+	Player *owningPlayer = getObject()->getControllingPlayer();
+	owningPlayer->getTunnelSystem()->swapContainedItemsList(list);
+
+	ContainedItemsList::iterator it = list.begin();
+
+	while ( it != list.end() )
 	{
-		obj = *it;
-		it++;
+		Object *obj = *it++;
+		DEBUG_ASSERTCRASH( obj, ("Contain list must not contain NULL element"));
+
 		removeFromContain( obj, true );
-    obj->kill();
+
+		obj->kill();
 	}
 }
 //-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
* Relates to #921

This change fixes another crash when occupants kill their container and force the remaining occupants to evacuate. This time it concerns the TunnelContain module. This problem is Zero Hour specific. Generals does not have this code.

The technical mistake here is calling `TunnelTracker::onTunnelDestroyed` within the process of iterating `TunnelTracker::m_containList` in `TunnelContain::killAllContained`. It is catastophic to modify the list in recursive calls.

To fix this problem, the recursive modification is avoided. The `TunnelTracker::m_containList` will be long empty before the code ever reaches `TunnelTracker::onTunnelDestroyed`.

This change carries risk of mismatch with retail game, IF there is a code path that **reads** `TunnelTracker::m_containList` while occupants are killed in `OpenContain::killAllContained`. Reads are legal. This change needs to be tested well. If we find a mismatch, we need to hack-fix this problem elsewhere.

## Asan Report

```
==23248==ERROR: AddressSanitizer: heap-use-after-free on address 0x0cb38778 at pc 0x00a3e9fd bp 0x015ad93c sp 0x015ad930
READ of size 4 at 0x0cb38778 thread T0
==23248==WARNING: Failed to use and restart external symbolizer!
    #0 0x00a3e9fc in TunnelContain::killAllContained D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Contain\TunnelContain.cpp:160
    #1 0x00a0f59f in NeutronBlastBehavior::neutronBlastToObject D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Behavior\NeutonBlastBehavior.cpp:131
    #2 0x00a0fb17 in NeutronBlastBehavior::onDie D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Behavior\NeutonBlastBehavior.cpp:91
    #3 0x00888fde in Object::onDie D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Object.cpp:4567
    #4 0x00b1da7a in ActiveBody::attemptDamage D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Body\ActiveBody.cpp:673
    #5 0x0087ded6 in Object::attemptDamage D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Object.cpp:1820
    #6 0x0075b70b in WeaponTemplate::dealDamageInternal D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp:1494
    #7 0x0075d29a in WeaponTemplate::fireWeaponTemplate D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp:1066
    #8 0x007611b9 in Weapon::privateFireWeapon D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp:2643
    #9 0x0075e41c in WeaponStore::handleProjectileDetonation D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp:1532
    #10 0x00a19de4 in DumbProjectileBehavior::detonate D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Behavior\DumbProjectileBehavior.cpp:541
    #11 0x00a1a889 in DumbProjectileBehavior::projectileHandleCollision D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Behavior\DumbProjectileBehavior.cpp:525
    #12 0x00974e9f in PhysicsBehavior::onCollide D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Update\PhysicsUpdate.cpp:1171
    #13 0x00888a76 in Object::onCollide D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Object.cpp:2410
    #14 0x0097821f in PhysicsBehavior::update D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Update\PhysicsUpdate.cpp:855
    #15 0x0077223e in GameLogic::update D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\System\GameLogic.cpp:3788
    #16 0x00679838 in GameEngine::update D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\GameEngine.cpp:757
    #17 0x00ca14cd in Win32GameEngine::update D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngineDevice\Source\Win32Device\Common\Win32GameEngine.cpp:90
    #18 0x00676a9a in GameEngine::execute D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\GameEngine.cpp:818
    #19 0x00666da5 in GameMain D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\GameMain.cpp:44
    #20 0x006636b9 in WinMain D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\Main\WinMain.cpp:986
    #21 0x01052ad6 in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #22 0x76a8fcc8 in BaseThreadInitThunk+0x18 (C:\WINDOWS\System32\KERNEL32.DLL+0x6b81fcc8)
    #23 0x772b82ad in RtlGetAppContainerNamedObjectPath+0x11d (C:\WINDOWS\SYSTEM32\ntdll.dll+0x4b2e82ad)
    #24 0x772b827d in RtlGetAppContainerNamedObjectPath+0xed (C:\WINDOWS\SYSTEM32\ntdll.dll+0x4b2e827d)

0x0cb38778 is located 8 bytes inside of 12-byte region [0x0cb38770,0x0cb3877c)
freed by thread T0 here:
    #0 0x5365e6ed in free D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_malloc_win.cpp:125
    #1 0x5367081c in __asan::__RuntimeFunctions<__asan::Ucrtbase>::Free D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_win_runtime_functions.cpp:273
    #2 0x010521b3 in operator delete D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_win_delete_scalar_size_thunk.cpp:44
    #3 0x0067bae4 in std::_List_node<AudioRequest *,void *>::_Free_non_head<std::allocator<std::_List_node<AudioRequest *,void *> > > C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.43.34808\include\list:329
    #4 0x009ceb6e in TunnelTracker::onTunnelDestroyed D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\RTS\TunnelTracker.cpp:220
    #5 0x00a3eeea in TunnelContain::onDie D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Contain\TunnelContain.cpp:366
    #6 0x00888fde in Object::onDie D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Object.cpp:4567
    #7 0x00b1da7a in ActiveBody::attemptDamage D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Body\ActiveBody.cpp:673
    #8 0x0087ded6 in Object::attemptDamage D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Object.cpp:1820
    #9 0x0075b70b in WeaponTemplate::dealDamageInternal D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp:1494
    #10 0x0075d29a in WeaponTemplate::fireWeaponTemplate D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp:1066
    #11 0x007611b9 in Weapon::privateFireWeapon D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp:2643
    #12 0x0075a522 in WeaponStore::createAndFireTempWeapon D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp:1543
    #13 0x00a4b5d4 in FireWeaponWhenDeadBehavior::onDie D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Behavior\FireWeaponWhenDeadBehavior.cpp:117
    #14 0x00888fde in Object::onDie D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Object.cpp:4567
    #15 0x00b1da7a in ActiveBody::attemptDamage D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Body\ActiveBody.cpp:673
    #16 0x0087ded6 in Object::attemptDamage D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Object.cpp:1820
    #17 0x00887fcb in Object::kill D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Object.cpp:1962
    #18 0x00a3ea6e in TunnelContain::killAllContained D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Contain\TunnelContain.cpp:163
    #19 0x00a0f59f in NeutronBlastBehavior::neutronBlastToObject D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Behavior\NeutonBlastBehavior.cpp:131
    #20 0x00a0fb17 in NeutronBlastBehavior::onDie D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Behavior\NeutonBlastBehavior.cpp:91
    #21 0x00888fde in Object::onDie D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Object.cpp:4567
    #22 0x00b1da7a in ActiveBody::attemptDamage D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Body\ActiveBody.cpp:673
    #23 0x0087ded6 in Object::attemptDamage D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Object.cpp:1820
    #24 0x0075b70b in WeaponTemplate::dealDamageInternal D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp:1494
    #25 0x0075d29a in WeaponTemplate::fireWeaponTemplate D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp:1066
    #26 0x007611b9 in Weapon::privateFireWeapon D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp:2643
    #27 0x0075e41c in WeaponStore::handleProjectileDetonation D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp:1532

previously allocated by thread T0 here:
    #0 0x5365e7ed in malloc D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_malloc_win.cpp:134
    #1 0x0066429a in operator new D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\System\GameMemoryNull.cpp:158
    #2 0x006f4952 in std::list<Object *,std::allocator<Object *> >::_Emplace<Object * const &> C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.43.34808\include\list:1024
    #3 0x009cd78c in TunnelTracker::addToContainList D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\RTS\TunnelTracker.cpp:179
    #4 0x00a3e2bd in TunnelContain::addToContainList D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Contain\TunnelContain.cpp:73
    #5 0x00a24498 in OpenContain::addToContain D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Contain\OpenContain.cpp:340
    #6 0x00a27d6a in OpenContain::onCollide D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Contain\OpenContain.cpp:848
    #7 0x00888a76 in Object::onCollide D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Object.cpp:2410
    #8 0x008b9b09 in PartitionContactList::processContactList D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\PartitionManager.cpp:2528
    #9 0x008bebf8 in PartitionManager::update D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\PartitionManager.cpp:2773
    #10 0x0077230c in GameLogic::update D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\System\GameLogic.cpp:3817
    #11 0x00679838 in GameEngine::update D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\GameEngine.cpp:757
    #12 0x00ca14cd in Win32GameEngine::update D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngineDevice\Source\Win32Device\Common\Win32GameEngine.cpp:90
    #13 0x00676a9a in GameEngine::execute D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\GameEngine.cpp:818
    #14 0x00666da5 in GameMain D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\GameMain.cpp:44
    #15 0x006636b9 in WinMain D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\Main\WinMain.cpp:986
    #16 0x01052ad6 in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #17 0x76a8fcc8 in BaseThreadInitThunk+0x18 (C:\WINDOWS\System32\KERNEL32.DLL+0x6b81fcc8)
    #18 0x772b82ad in RtlGetAppContainerNamedObjectPath+0x11d (C:\WINDOWS\SYSTEM32\ntdll.dll+0x4b2e82ad)
    #19 0x772b827d in RtlGetAppContainerNamedObjectPath+0xed (C:\WINDOWS\SYSTEM32\ntdll.dll+0x4b2e827d)

SUMMARY: AddressSanitizer: heap-use-after-free D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Contain\TunnelContain.cpp:160 in TunnelContain::killAllContained
Shadow bytes around the buggy address:
  0x0cb38480: fa fa fd fd fa fa fd fd fa fa fd fa fa fa fd fa
  0x0cb38500: fa fa fd fa fa fa fd fa fa fa fd fa fa fa fd fa
  0x0cb38580: fa fa fd fa fa fa fd fd fa fa fd fa fa fa fd fa
  0x0cb38600: fa fa fd fa fa fa fd fd fa fa fd fd fa fa fd fa
  0x0cb38680: fa fa fd fa fa fa fd fd fa fa fd fd fa fa fd fa
=>0x0cb38700: fa fa fd fd fa fa fd fa fa fa fd fa fa fa fd[fd]
  0x0cb38780: fa fa fd fd fa fa fd fd fa fa fd fa fa fa fd fd
  0x0cb38800: fa fa fd fd fa fa fd fa fa fa fd fa fa fa fd fd
  0x0cb38880: fa fa fd fa fa fa fd fd fa fa fd fa fa fa fd fa
  0x0cb38900: fa fa fd fd fa fa fd fd fa fa fd fa fa fa fd fa
  0x0cb38980: fa fa fd fd fa fa fd fa fa fa fd fa fa fa fd fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
Address Sanitizer Error: Use of deallocated memory
```

## TODO

- [x] Test in VC6 Golden Replay
- [x] Test in more Replays
