### PR TITLE
[GEN][ZH] Refactor evacuation code in OpenContain, TunnelContain

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/TunnelTracker.h
+++ b/Generals/Code/GameEngine/Include/Common/TunnelTracker.h
@@ -49,6 +49,7 @@ public:
 	UnsignedInt getContainCount() const { return m_containListSize; }
 	Int getContainMax() const;
 	const ContainedItemsList* getContainedItemsList() const { return &m_containList; }	
+	void swapContainedItemsList(ContainedItemsList& newList);
 
 	Bool isValidContainerFor(const Object* obj, Bool checkCapacity) const;
 	void addToContainList( Object *obj );				///< add 'obj' to contain list

--- a/Generals/Code/GameEngine/Source/Common/RTS/TunnelTracker.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/TunnelTracker.cpp
@@ -108,6 +108,13 @@ Int TunnelTracker::getContainMax() const
 }
 
 // ------------------------------------------------------------------------
+void TunnelTracker::swapContainedItemsList(ContainedItemsList& newList)
+{
+	m_containList.swap(newList);
+	m_containListSize = (Int)m_containList.size();
+}
+
+// ------------------------------------------------------------------------
 void TunnelTracker::updateNemesis(const Object *target)
 {
 	if (getCurNemesis()==NULL) {

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
@@ -102,11 +102,6 @@ void TunnelContain::removeFromContain( Object *obj, Bool exposeStealthUnits )
 	if( owningPlayer == NULL )
 		return; //game tear down.  We do the onRemove* stuff first because this is allowed to fail but that still needs to be done
 
-	if( ! owningPlayer->getTunnelSystem()->isInContainer( obj ) )
-	{
-		return;
-	}
-
 	owningPlayer->getTunnelSystem()->removeFromContain( obj, exposeStealthUnits );
 
 }
@@ -116,16 +111,17 @@ void TunnelContain::removeFromContain( Object *obj, Bool exposeStealthUnits )
 //-------------------------------------------------------------------------------------------------
 void TunnelContain::removeAllContained( Bool exposeStealthUnits )
 {
+	ContainedItemsList list;
 	Player *owningPlayer = getObject()->getControllingPlayer();
-	const ContainedItemsList *fullList = owningPlayer->getTunnelSystem()->getContainedItemsList();
+	owningPlayer->getTunnelSystem()->swapContainedItemsList(list);
 
-	Object *obj;
-	ContainedItemsList::const_iterator it;
-	it = (*fullList).begin();
-	while( it != (*fullList).end() )
+	ContainedItemsList::iterator it = list.begin();
+
+	while ( it != list.end() )
 	{
-		obj = *it;
-		it++;
+		Object *obj = *it++;
+		DEBUG_ASSERTCRASH( obj, ("Contain list must not contain NULL element"));
+
 		removeFromContain( obj, exposeStealthUnits );
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -440,33 +440,25 @@ void OpenContain::killAllContained( void )
 	// to the host container, which then attempts to remove all remaining occupants
 	// on the death of the host container. This is reproducible by shooting with
 	// Neutron Shells on a GLA Technical containing GLA Terrorists.
+
 	ContainedItemsList list;
 	list.swap(m_containList);
 	m_containListSize = 0;
 
 	ContainedItemsList::iterator it = list.begin();
 
- 	while ( it != list.end() )
+	while ( it != list.end() )
 	{
-    Object *rider = *it;
+		Object *rider = *it++;
 
-    DEBUG_ASSERTCRASH( rider, ("Contain list must not contain NULL element"));
-    if ( rider )
-    {
-	    it = list.erase(it);
-
-      onRemoving( rider );
-	    rider->onRemovedFrom( getObject() );
-      rider->kill();
-
-    }
-    else
-      ++it;
-
-	}  // end while
-
-
-  DEBUG_ASSERTCRASH( m_containListSize == 0, ("killallcontain just made a booboo, list size != zero.") );
+		DEBUG_ASSERTCRASH( rider, ("Contain list must not contain NULL element"));
+		if ( rider )
+		{
+			onRemoving( rider );
+			rider->onRemovedFrom( getObject() );
+			rider->kill();
+		}
+	}
 
 }  // end killAllContained
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
@@ -102,11 +102,6 @@ void TunnelContain::removeFromContain( Object *obj, Bool exposeStealthUnits )
 	if( owningPlayer == NULL )
 		return; //game tear down.  We do the onRemove* stuff first because this is allowed to fail but that still needs to be done
 
-	if( ! owningPlayer->getTunnelSystem()->isInContainer( obj ) )
-	{
-		return;
-	}
-
 	owningPlayer->getTunnelSystem()->removeFromContain( obj, exposeStealthUnits );
 
 }
@@ -177,16 +172,17 @@ void TunnelContain::killAllContained( void )
 //-------------------------------------------------------------------------------------------------
 void TunnelContain::removeAllContained( Bool exposeStealthUnits )
 {
+	ContainedItemsList list;
 	Player *owningPlayer = getObject()->getControllingPlayer();
-	const ContainedItemsList *fullList = owningPlayer->getTunnelSystem()->getContainedItemsList();
+	owningPlayer->getTunnelSystem()->swapContainedItemsList(list);
 
-	Object *obj;
-	ContainedItemsList::const_iterator it;
-	it = (*fullList).begin();
-	while( it != (*fullList).end() )
+	ContainedItemsList::iterator it = list.begin();
+
+	while ( it != list.end() )
 	{
-		obj = *it;
-		it++;
+		Object *obj = *it++;
+		DEBUG_ASSERTCRASH( obj, ("Contain list must not contain NULL element"));
+
 		removeFromContain( obj, exposeStealthUnits );
 	}
 }


### PR DESCRIPTION
* Follow up for #921
* Follow up for #1006

This change is a minor refactor to make the code in OpenContain and TunnelContain a bit more consistent.  It also removes a redundant `owningPlayer->getTunnelSystem()->isInContainer()` test. It intents to not change functionality.