### PR TITLE
[GEN][ZH] Fix ParticleUplinkCannonUpdate mismatch, introduced by previous refactoring

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
@@ -455,7 +455,8 @@ UpdateSleepTime ParticleUplinkCannonUpdate::update()
 				break;
 		}
 
-		if( orbitalBirthFrame <= now && now < orbitalDeathFrame )
+		const Bool isFiring = m_laserStatus != LASERSTATUS_NONE && m_laserStatus != LASERSTATUS_DEAD;
+		if ( isFiring )
 		{
 		
 			if( !m_manualTargetMode )

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
@@ -502,7 +502,8 @@ UpdateSleepTime ParticleUplinkCannonUpdate::update()
 				break;
 		}
 
-		if( orbitalBirthFrame <= now && now < orbitalDeathFrame )
+		const Bool isFiring = m_laserStatus != LASERSTATUS_NONE && m_laserStatus != LASERSTATUS_DEAD;
+		if ( isFiring )
 		{
 		
 			if( !m_manualTargetMode && !m_scriptedWaypointMode )


### PR DESCRIPTION
* Follow up for #976

This change fixes the ParticleUplinkCannonUpdate mismatch with Retail, which was introduced by #976.

Reproducible with Replay:

[00-03-45_2v6_PC03_ss_HardAI_HardAI_HardAI_HardAI_HardAI_HardAI.zip](https://github.com/user-attachments/files/20615100/00-03-45_2v6_PC03_ss_HardAI_HardAI_HardAI_HardAI_HardAI_HardAI.zip)

The problem was in the damage update loop not being correctly tied to the real lifetime of the drawable laser. The laser timers can mismatch from the actual creation of the drawable laser. Not clear to me in what constellation that happens, but it happens at the beginning of the firing, probably applying damage while `m_laserStatus` was `LASERSTATUS_NONE`.

## TODO

- [ ] Test against many Replays