### PR TITLE
[CORE] Cleanup wwmath header for consistency

### DIFF
--- a/Core/Libraries/Source/WWVegas/WWMath/wwmath.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/wwmath.h
@@ -46,6 +46,7 @@
 #include <math.h>
 #include <float.h>
 #include <assert.h>
+#include <float.h>
 
 /*
 ** Some global constants.
@@ -123,15 +124,16 @@ static WWINLINE int Float_To_Int_Floor(const float& f);
 static WWINLINE float Cos(float val);
 static WWINLINE float Sin(float val);
 static WWINLINE float Sqrt(float val);
-static WWINLINE float Inv_Sqrt(float a);	// Some 30% faster inverse square root than regular C++ compiled, from Intel's math library
+static float __fastcall Inv_Sqrt(float a);	// Some 30% faster inverse square root than regular C++ compiled, from Intel's math library
 static WWINLINE long	 Float_To_Long(float f);
 #else
-static WWINLINE float Cos(float val);
-static WWINLINE float Sin(float val);
-static WWINLINE float Sqrt(float val);
-static WWINLINE float Inv_Sqrt(float a);
-static WWINLINE long	Float_To_Long(float f);
+static float Cos(float val);
+static float Sin(float val);
+static float Sqrt(float val);
+static float Inv_Sqrt(float a);
+static long	Float_To_Long(float f);
 #endif
+
 
 static WWINLINE float Fast_Sin(float val);
 static WWINLINE float Fast_Inv_Sin(float val);
@@ -600,9 +602,9 @@ WWINLINE int WWMath::Float_To_Int_Floor (const float& f)
 // ----------------------------------------------------------------------------
 
 #if defined(_MSC_VER) && defined(_M_IX86)
-WWINLINE float WWMath::Inv_Sqrt(float a)
+WWINLINE float __fastcall WWMath::Inv_Sqrt(float a)
 {
-	float result;
+	float retval;
 
 	__asm {
 		mov		eax, 0be6eb508h
@@ -645,10 +647,10 @@ WWINLINE float WWMath::Inv_Sqrt(float a)
 		;r3 = st(0)
 		fmulp	st(1), st
 
-		fstp result
+		fstp retval
 	}
 
-	return result;
+	return retval;
 }
 #else
 WWINLINE float WWMath::Inv_Sqrt(float val)

--- a/Core/Libraries/Source/WWVegas/WWMath/wwmath.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/wwmath.h
@@ -43,7 +43,6 @@
 #define WWMATH_H
 
 #include "always.h"
-#include <string.h>
 #include <math.h>
 #include <float.h>
 #include <assert.h>

--- a/Core/Libraries/Source/WWVegas/WWMath/wwmath.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/wwmath.h
@@ -116,14 +116,14 @@ static WWINLINE int Float_To_Int_Floor(const float& f);
 static WWINLINE float Cos(float val);
 static WWINLINE float Sin(float val);
 static WWINLINE float Sqrt(float val);
-static float Inv_Sqrt(float a);	// Some 30% faster inverse square root than regular C++ compiled, from Intel's math library
+static WWINLINE float Inv_Sqrt(float a);	// Some 30% faster inverse square root than regular C++ compiled, from Intel's math library
 static WWINLINE long	 Float_To_Long(float f);
 #else
-static float Cos(float val);
-static float Sin(float val);
-static float Sqrt(float val);
-static float Inv_Sqrt(float a);
-static long	Float_To_Long(float f);
+static WWINLINE float Cos(float val);
+static WWINLINE float Sin(float val);
+static WWINLINE float Sqrt(float val);
+static WWINLINE float Inv_Sqrt(float a);
+static WWINLINE long	Float_To_Long(float f);
 #endif
 
 
@@ -138,36 +138,37 @@ static WWINLINE float Fast_Asin(float val);
 static WWINLINE float Asin(float val);
 
 
-static float		Atan(float x) { return static_cast<float>(atan(x)); }
-static float		Atan2(float y,float x) { return static_cast<float>(atan2(y,x)); }
-static float		Sign(float val);
-static float		Ceil(float val) { return ceilf(val); }
-static float		Floor(float val) { return floorf(val); }
-static bool			Fast_Is_Float_Positive(const float & val);
-static bool			Is_Power_Of_2(const unsigned int val);
+static WWINLINE float		Atan(float x) { return static_cast<float>(atan(x)); }
+static WWINLINE float		Atan2(float y,float x) { return static_cast<float>(atan2(y,x)); }
+static WWINLINE float		Sign(float val);
+static WWINLINE float		Ceil(float val) { return ceilf(val); }
+static WWINLINE float		Floor(float val) { return floorf(val); }
+static WWINLINE bool			Fast_Is_Float_Positive(const float & val);
+static WWINLINE bool			Is_Power_Of_2(const unsigned int val);
 
 static float		Random_Float(void);
-static float		Random_Float(float min,float max);
-static float		Clamp(float val, float min = 0.0f, float max = 1.0f);
-static double		Clamp(double val, double min = 0.0f, double max = 1.0f);
-static int			Clamp_Int(int val, int min_val, int max_val);
-static float		Wrap(float val, float min = 0.0f, float max = 1.0f);
-static double		Wrap(double val, double min = 0.0f, double max = 1.0f);
-static float		Min(float a, float b);
-static float		Max(float a, float b);
 
-static int			Float_As_Int(const float f) { return *((int*)&f); }
+static WWINLINE float		Random_Float(float min,float max);
+static WWINLINE float		Clamp(float val, float min = 0.0f, float max = 1.0f);
+static WWINLINE double		Clamp(double val, double min = 0.0f, double max = 1.0f);
+static WWINLINE int			Clamp_Int(int val, int min_val, int max_val);
+static WWINLINE float		Wrap(float val, float min = 0.0f, float max = 1.0f);
+static WWINLINE double		Wrap(double val, double min = 0.0f, double max = 1.0f);
+static WWINLINE float		Min(float a, float b);
+static WWINLINE float		Max(float a, float b);
 
-static float		Lerp(float a, float b, float lerp );
-static double		Lerp(double a, double b, float lerp );
+static WWINLINE int			Float_As_Int(const float f) { return *((int*)&f); }
 
-static long			Float_To_Long(double f);
+static WWINLINE float		Lerp(float a, float b, float lerp );
+static WWINLINE double		Lerp(double a, double b, float lerp );
 
-static unsigned char Unit_Float_To_Byte(float f) { return (unsigned char)(f*255.0f); }
-static float			Byte_To_Unit_Float(unsigned char byte) { return ((float)byte) / 255.0f; }
+static WWINLINE long			Float_To_Long(double f);
 
-static bool			Is_Valid_Float(float x);
-static bool			Is_Valid_Double(double x);
+static WWINLINE unsigned char Unit_Float_To_Byte(float f) { return (unsigned char)(f*255.0f); }
+static WWINLINE float			Byte_To_Unit_Float(unsigned char byte) { return ((float)byte) / 255.0f; }
+
+static WWINLINE bool			Is_Valid_Float(float x);
+static WWINLINE bool			Is_Valid_Double(double x);
 
 };
 

--- a/Core/Libraries/Source/WWVegas/WWMath/wwmath.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/wwmath.h
@@ -45,6 +45,7 @@
 #include "always.h"
 //#include <bit>
 //#include <limits>
+#include <string.h>
 #include <math.h>
 #include <float.h>
 #include <assert.h>

--- a/Core/Libraries/Source/WWVegas/WWMath/wwmath.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/wwmath.h
@@ -60,13 +60,6 @@
 #define WWMATH_OOSQRT2		0.707106781f
 #define WWMATH_OOSQRT3		0.577350269f
 
-// (DRM 05/07/01) Temporarily eliminated _fastcall
-// on non-Microsoft compatible compilers. Jani
-// should be replacing this soon.
-#ifndef _MSC_VER
-#define __fastcall
-#endif // _MSC_VER
-
 /* 
 **	Macros to convert between degrees and radians
 */
@@ -123,7 +116,7 @@ static WWINLINE int Float_To_Int_Floor(const float& f);
 static WWINLINE float Cos(float val);
 static WWINLINE float Sin(float val);
 static WWINLINE float Sqrt(float val);
-static float __fastcall Inv_Sqrt(float a);	// Some 30% faster inverse square root than regular C++ compiled, from Intel's math library
+static float Inv_Sqrt(float a);	// Some 30% faster inverse square root than regular C++ compiled, from Intel's math library
 static WWINLINE long	 Float_To_Long(float f);
 #else
 static float Cos(float val);
@@ -601,7 +594,7 @@ WWINLINE int WWMath::Float_To_Int_Floor (const float& f)
 // ----------------------------------------------------------------------------
 
 #if defined(_MSC_VER) && defined(_M_IX86)
-WWINLINE float __fastcall WWMath::Inv_Sqrt(float a)
+WWINLINE float WWMath::Inv_Sqrt(float a)
 {
 	float retval;
 

--- a/Core/Libraries/Source/WWVegas/WWMath/wwmath.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/wwmath.h
@@ -654,3 +654,4 @@ WWINLINE float WWMath::Inv_Sqrt(float val)
 
 
 #endif
+

--- a/Core/Libraries/Source/WWVegas/WWMath/wwmath.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/wwmath.h
@@ -46,7 +46,6 @@
 #include <math.h>
 #include <float.h>
 #include <assert.h>
-#include <float.h>
 
 /*
 ** Some global constants.

--- a/Core/Libraries/Source/WWVegas/WWMath/wwmath.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/wwmath.h
@@ -43,13 +43,10 @@
 #define WWMATH_H
 
 #include "always.h"
-//#include <bit>
-//#include <limits>
 #include <string.h>
 #include <math.h>
 #include <float.h>
 #include <assert.h>
-//#include <float.h>
 
 /*
 ** Some global constants.

--- a/Core/Libraries/Source/WWVegas/WWMath/wwmath.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/wwmath.h
@@ -135,7 +135,7 @@ static float Sqrt(float val);
 static long	Float_To_Long(float f);
 #endif
 
-#if defined(_MSC_VER) && _MSC_VER < 1300 && 0
+#if defined(_MSC_VER) && _MSC_VER < 1300
 static WWINLINE float __fastcall Inv_Sqrt(float val);	// Some 30% faster inverse square root than regular C++ compiled, from Intel's math library
 #else
 static WWINLINE float __fastcall Inv_Sqrt(float val);
@@ -607,14 +607,16 @@ WWINLINE int WWMath::Float_To_Int_Floor (const float& f)
 // Inverse square root
 // ----------------------------------------------------------------------------
 
-#if defined(_MSC_VER) && _MSC_VER < 1300 && 0
-WWINLINE __declspec(naked) float __fastcall WWMath::Inv_Sqrt(float val)
+#if defined(_MSC_VER) && _MSC_VER < 1300
+WWINLINE float __fastcall WWMath::Inv_Sqrt(float val)
 {
+	float result;
+
 	__asm {
 		mov		eax, 0be6eb508h
 		mov		DWORD PTR [esp-12],03fc00000h ;  1.5 on the stack
-		sub		eax, DWORD PTR [esp+4]; val
-		sub		DWORD PTR [esp+4], 800000h ; val/2 a=Y0
+		sub		eax, DWORD PTR [val]; val
+		sub		DWORD PTR [val], 800000h ; val/2 a=Y0
 		shr		eax, 1     ; firs approx in eax=R0
 		mov		DWORD PTR [esp-8], eax
 
@@ -622,7 +624,7 @@ WWINLINE __declspec(naked) float __fastcall WWMath::Inv_Sqrt(float val)
 		fmul	st, st            ;r*r
 		fld		DWORD PTR [esp-8] ;r
 		fxch	st(1)
-		fmul	DWORD PTR [esp+4];val ;r*r*y0
+		fmul	DWORD PTR [val];val ;r*r*y0
 		fld		DWORD PTR [esp-12];load 1.5
 		fld		st(0)
 		fsub	st,st(2)			   ;r1 = 1.5 - y1
@@ -650,8 +652,10 @@ WWINLINE __declspec(naked) float __fastcall WWMath::Inv_Sqrt(float val)
 		;x3 = st(1)
 		;r3 = st(0)
 		fmulp	st(1), st
-		ret 4
+		fstp result
 	}
+
+	return result;
 }
 #else
 WWINLINE float __fastcall WWMath::Inv_Sqrt(float val)

--- a/Core/Libraries/Source/WWVegas/WWMath/wwmath.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/wwmath.h
@@ -654,4 +654,3 @@ WWINLINE float WWMath::Inv_Sqrt(float val)
 
 
 #endif
-

--- a/Core/Libraries/Source/WWVegas/WWMath/wwmath.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/wwmath.h
@@ -43,10 +43,12 @@
 #define WWMATH_H
 
 #include "always.h"
+//#include <bit>
+//#include <limits>
 #include <math.h>
 #include <float.h>
 #include <assert.h>
-#include <float.h>
+//#include <float.h>
 
 /*
 ** Some global constants.
@@ -124,16 +126,19 @@ static WWINLINE int Float_To_Int_Floor(const float& f);
 static WWINLINE float Cos(float val);
 static WWINLINE float Sin(float val);
 static WWINLINE float Sqrt(float val);
-static float __fastcall Inv_Sqrt(float a);	// Some 30% faster inverse square root than regular C++ compiled, from Intel's math library
 static WWINLINE long	 Float_To_Long(float f);
 #else
 static float Cos(float val);
 static float Sin(float val);
 static float Sqrt(float val);
-static float Inv_Sqrt(float a);
 static long	Float_To_Long(float f);
 #endif
 
+#if defined(_MSC_VER) && _MSC_VER < 1300 && 0
+static WWINLINE float __fastcall Inv_Sqrt(float val);	// Some 30% faster inverse square root than regular C++ compiled, from Intel's math library
+#else
+static WWINLINE float __fastcall Inv_Sqrt(float val);
+#endif
 
 static WWINLINE float Fast_Sin(float val);
 static WWINLINE float Fast_Inv_Sin(float val);
@@ -601,14 +606,14 @@ WWINLINE int WWMath::Float_To_Int_Floor (const float& f)
 // Inverse square root
 // ----------------------------------------------------------------------------
 
-#if defined(_MSC_VER) && defined(_M_IX86)
-WWINLINE __declspec(naked) float __fastcall WWMath::Inv_Sqrt(float a)
+#if defined(_MSC_VER) && _MSC_VER < 1300 && 0
+WWINLINE __declspec(naked) float __fastcall WWMath::Inv_Sqrt(float val)
 {
 	__asm {
 		mov		eax, 0be6eb508h
 		mov		DWORD PTR [esp-12],03fc00000h ;  1.5 on the stack
-		sub		eax, DWORD PTR [esp+4]; a
-		sub		DWORD PTR [esp+4], 800000h ; a/2 a=Y0
+		sub		eax, DWORD PTR [esp+4]; val
+		sub		DWORD PTR [esp+4], 800000h ; val/2 a=Y0
 		shr		eax, 1     ; firs approx in eax=R0
 		mov		DWORD PTR [esp-8], eax
 
@@ -616,7 +621,7 @@ WWINLINE __declspec(naked) float __fastcall WWMath::Inv_Sqrt(float a)
 		fmul	st, st            ;r*r
 		fld		DWORD PTR [esp-8] ;r
 		fxch	st(1)
-		fmul	DWORD PTR [esp+4];a ;r*r*y0
+		fmul	DWORD PTR [esp+4];val ;r*r*y0
 		fld		DWORD PTR [esp-12];load 1.5
 		fld		st(0)
 		fsub	st,st(2)			   ;r1 = 1.5 - y1
@@ -648,9 +653,42 @@ WWINLINE __declspec(naked) float __fastcall WWMath::Inv_Sqrt(float a)
 	}
 }
 #else
-WWINLINE float WWMath::Inv_Sqrt(float val)
+WWINLINE float __fastcall WWMath::Inv_Sqrt(float val)
 {
-	return 1.0f / (float)sqrt(val);
+	//static_assert(std::endian::native == std::endian::little);
+	//static_assert(std::numeric_limits<float>::is_iec559 && std::numeric_limits<double>::is_iec559);
+
+	uint32_t input_bits;
+	memcpy(&input_bits, &val, sizeof(input_bits));
+
+	const uint32_t half_input_bits = input_bits - 0x800000;
+	const uint32_t approx_bits = (0xBE6EB508 - input_bits) >> 1;
+
+	float half_input;
+	float approx_float;
+	memcpy(&half_input, &half_input_bits, sizeof(half_input));
+	memcpy(&approx_float, &approx_bits, sizeof(approx_float));
+
+	const double d00 = approx_float;
+	const double d01 = half_input;
+
+	const double d02 = static_cast<float>(d00 * d00);
+	const double d03 = static_cast<float>(d01 * d02);
+	const double d04 = static_cast<float>(1.5 - d03);
+
+	const double d05 = static_cast<float>(d03 * d04);
+	const double d06 = static_cast<float>(d04 * d05);
+	const double d07 = static_cast<float>(1.5 - d06);
+
+	const double d08 = static_cast<float>(d06 * d07);
+	const double d09 = static_cast<float>(d07 * d08);
+	const double d10 = static_cast<float>(1.5 - d09);
+
+	const double mul1 = static_cast<float>(d00 * d04);
+	const double mul2 = static_cast<float>(mul1 * d07);
+	const double mul3 = static_cast<float>(mul2 * d10);
+
+	return static_cast<float>(mul3);
 }
 #endif
 


### PR DESCRIPTION
* Follow-up to https://github.com/TheSuperHackers/GeneralsGameCode/pull/1009

I noticed some inconsistencies in `wwmath.h`. This pr makes the following changes to fix that:
### 1. Removed `fastcall` calling convention from `Inv_Sqrt` function.
https://github.com/TheSuperHackers/GeneralsGameCode/blob/ef17abf6928309698a7262c2b178f5a1a07bc880/Core/Libraries/Source/WWVegas/WWMath/wwmath.h#L605-L610

The `fastcall` calling convention appears to be ignored here as `a`, the function parameter, is accessed on the stack (`[esp+4]`). Functions with `fastcall` calling convention use registers for their function parameters, per https://learn.microsoft.com/en-us/cpp/cpp/fastcall:
> The first two DWORD or smaller arguments that are found in the argument list from left to right are passed in ECX and EDX registers; all other arguments are passed on the stack from right to left.

EDIT: Maybe the difference is that function parameter `a` is a float and not an integral type, but either way, using `fastcall` doesn't seem to add anything meaningful here.

### 2. Added `WWINLINE` to some function declarations because it's already used for the function definitions.
### 3. Removed duplicate `float.h` header include.