### PR TITLE
[GEN][ZH] Remove unnecessary try catch block in ~PlayerList()

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/RTS/PlayerList.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/PlayerList.cpp
@@ -83,13 +83,10 @@ PlayerList::PlayerList() :
 //-----------------------------------------------------------------------------
 PlayerList::~PlayerList() 
 {
-	try {
-		// the world is happier if we reinit things before destroying them,
-		// to avoid debug warnings
-		init();
-	} catch (...) {
-		// nothing
-	}
+	// the world is happier if we reinit things before destroying them,
+	// to avoid debug warnings
+	init();
+
 	for( Int i = 0; i < MAX_PLAYER_COUNT; ++i )
 		delete m_players[ i ];
 }

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/PlayerList.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/PlayerList.cpp
@@ -83,13 +83,10 @@ PlayerList::PlayerList() :
 //-----------------------------------------------------------------------------
 PlayerList::~PlayerList() 
 {
-	try {
-		// the world is happier if we reinit things before destroying them,
-		// to avoid debug warnings
-		init();
-	} catch (...) {
-		// nothing
-	}
+	// the world is happier if we reinit things before destroying them,
+	// to avoid debug warnings
+	init();
+
 	for( Int i = 0; i < MAX_PLAYER_COUNT; ++i )
 		delete m_players[ i ];
 }


### PR DESCRIPTION
Remove silly catch block. Just to be sure, I tested this on all my replays, and they all work fine without this.

## TODO

- [ ] Replicate in Generals