### PR TITLE
game mismatch: ask for 64-bit precision

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -200,7 +200,7 @@ void setFPMode( void )
 	UnsignedInt newVal = curVal;
 	newVal = (newVal & ~_MCW_RC) | (_RC_NEAR & _MCW_RC);
 	//newVal = (newVal & ~_MCW_RC) | (_RC_CHOP & _MCW_RC);
-	newVal = (newVal & ~_MCW_PC) | (_PC_24   & _MCW_PC);
+	newVal = (newVal & ~_MCW_PC) | (_PC_64   & _MCW_PC);
 
 	_controlfp(newVal, _MCW_PC | _MCW_RC);
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -211,7 +211,7 @@ void setFPMode( void )
 	UnsignedInt newVal = curVal;
 	newVal = (newVal & ~_MCW_RC) | (_RC_NEAR & _MCW_RC);
 	//newVal = (newVal & ~_MCW_RC) | (_RC_CHOP & _MCW_RC);
-	newVal = (newVal & ~_MCW_PC) | (_PC_24   & _MCW_PC);
+	newVal = (newVal & ~_MCW_PC) | (_PC_64   & _MCW_PC);
 
 	_controlfp(newVal, _MCW_PC | _MCW_RC);
 }


### PR DESCRIPTION
At a local LAN, we were 4 people playing Zero Hour. Two of us on Linux via Wine, two native on Windows. As soon as we got into a bit of action, the game "detected a mismatch". The two playing on wine could play a full game without issues, same for the two playing on Windows.

By my own admission, a bit of guess-work, we switched the requested precision in setFPMode() into 64 bit. After this change, we haven't seen the "mismatch" error and have been able to play several games to the end.