### PR TITLE
[GEN][ZH] Fix crash in OpenContain::processDamageToContained() when killed occupants kill the host container

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -1339,7 +1339,7 @@ void OpenContain::processDamageToContained()
 
 	while ( it != list.end() )
 	{
-		Object *object = *it++;
+		Object *object = *it;
 
 		DEBUG_ASSERTCRASH( object, ("Contain list must not contain NULL element\n") );
 
@@ -1355,20 +1355,12 @@ void OpenContain::processDamageToContained()
 
 		if( !object->isEffectivelyDead() && percentDamage == 1.0f )
 			object->kill(); // in case we are carrying flame proof troops we have been asked to kill
-	}
 
-	// Now remove all killed objects from the list.
-	it = list.begin();
-
-	while ( it != list.end() )
-	{
-		Object *object = *it;
-
-		if (object->isEffectivelyDead())
+		if ( object->isEffectivelyDead() )
 		{
 			onRemoving( object );
 			object->onRemovedFrom( getObject() );
-			it = list.erase(it);
+			it = list.erase( it );
 		}
 		else
 		{

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -1274,20 +1274,17 @@ void OpenContain::orderAllPassengersToExit( CommandSourceType commandSource )
 //-------------------------------------------------------------------------------------------------
 void OpenContain::processDamageToContained()
 {
+#if RETAIL_COMPATIBLE_CRC
+
 	const ContainedItemsList* items = getContainedItemsList();
 	if( items )
 	{
-		ContainedItemsList::const_iterator it;
-		it = items->begin();
+		ContainedItemsList::const_iterator it = items->begin();
+		const size_t listSize = items->size();
 
 		while( it != items->end() )
 		{
-			Object *object = *it;
-
-			//Advance to the next iterator before we apply the damage.
-			//It's possible that the damage will kill the unit and foobar
-			//the iterator list.
-			++it;
+			Object *object = *it++;
 
 			//Calculate the damage to be inflicted on each unit.
 			Real damage = object->getBodyModule()->getMaxHealth() * getOpenContainModuleData()->m_damagePercentageToUnits;
@@ -1300,9 +1297,90 @@ void OpenContain::processDamageToContained()
 			object->attemptDamage( &damageInfo );
 
 			if( !object->isEffectivelyDead() && getOpenContainModuleData()->m_damagePercentageToUnits == 1.0f )
-				object->kill(); // in case we are carrying flame proof troops we have been asked to kill			
+				object->kill(); // in case we are carrying flame proof troops we have been asked to kill
+
+			// TheSuperHackers @info Calls to Object::attemptDamage and Object::kill will not remove
+			// the occupant from the host container straight away. Instead it will be removed when the
+			// Object deletion is finalized in a Game Logic update. This will lead to strange behavior
+			// where the occupant will be removed after death with a delay. This behavior cannot be
+			// changed without breaking retail compatibility.
+
+			// TheSuperHackers @bugfix xezon 05/06/2025 Stop iterating when the list was cleared.
+			// This scenario can happen if the killed occupant(s) apply deadly damage on death
+			// to the host container, which then attempts to remove all remaining occupants
+			// on the death of the host container. This is reproducible by destroying a
+			// GLA Battle Bus with at least 2 half damaged GLA Terrorists inside.
+			if (listSize != items->size())
+			{
+				DEBUG_ASSERTCRASH( listSize == 0, ("List is expected empty\n") );
+				break;
+			}
 		}
 	}
+
+#else
+
+	// TheSuperHackers @bugfix xezon 05/06/2025 Temporarily empty the m_containList
+	// to prevent a potential child call to catastrophically modify the m_containList.
+	// This scenario can happen if the killed occupant(s) apply deadly damage on death
+	// to the host container, which then attempts to remove all remaining occupants
+	// on the death of the host container. This is reproducible by destroying a
+	// GLA Battle Bus with at least 2 half damaged GLA Terrorists inside.
+
+	// Caveat: While the m_containList is empty, it will not be possible to apply damage
+	// on death of a unit to another unit in the host container. If this functionality
+	// is desired, then this implementation needs to be revisited.
+
+	ContainedItemsList list;
+	m_containList.swap(list);
+	m_containListSize = 0;
+
+	ContainedItemsList::iterator it = list.begin();
+
+	while ( it != list.end() )
+	{
+		Object *object = *it++;
+
+		DEBUG_ASSERTCRASH( object, ("Contain list must not contain NULL element\n") );
+
+		// Calculate the damage to be inflicted on each unit.
+		Real damage = object->getBodyModule()->getMaxHealth() * percentDamage;
+
+		DamageInfo damageInfo;
+		damageInfo.in.m_damageType = DAMAGE_UNRESISTABLE;
+		damageInfo.in.m_deathType = data->m_isBurnedDeathToUnits ? DEATH_BURNED : DEATH_NORMAL;
+		damageInfo.in.m_sourceID = getObject()->getID();
+		damageInfo.in.m_amount = damage;
+		object->attemptDamage( &damageInfo );
+
+		if( !object->isEffectivelyDead() && percentDamage == 1.0f )
+			object->kill(); // in case we are carrying flame proof troops we have been asked to kill
+	}
+
+	// Now remove all killed objects from the list.
+	it = list.begin();
+
+	while ( it != list.end() )
+	{
+		Object *object = *it;
+
+		if (object->isEffectivelyDead())
+		{
+			onRemoving( object );
+			object->onRemovedFrom( getObject() );
+			it = list.erase(it);
+		}
+		else
+		{
+			++it;
+		}
+	}
+
+	// Swap the list back where it belongs.
+	m_containList.swap(list);
+	m_containListSize = (UnsignedInt)m_containList.size();
+
+#endif // RETAIL_COMPATIBLE_CRC
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -1517,7 +1517,7 @@ void OpenContain::processDamageToContained(Real percentDamage)
 
 	while ( it != list.end() )
 	{
-		Object *object = *it++;
+		Object *object = *it;
 
 		DEBUG_ASSERTCRASH( object, ("Contain list must not contain NULL element\n") );
 
@@ -1533,20 +1533,12 @@ void OpenContain::processDamageToContained(Real percentDamage)
 
 		if( !object->isEffectivelyDead() && percentDamage == 1.0f )
 			object->kill(); // in case we are carrying flame proof troops we have been asked to kill
-	}
 
-	// Now remove all killed objects from the list.
-	it = list.begin();
-
-	while ( it != list.end() )
-	{
-		Object *object = *it;
-
-		if (object->isEffectivelyDead())
+		if ( object->isEffectivelyDead() )
 		{
 			onRemoving( object );
 			object->onRemovedFrom( getObject() );
-			it = list.erase(it);
+			it = list.erase( it );
 		}
 		else
 		{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -1452,20 +1452,17 @@ void OpenContain::processDamageToContained(Real percentDamage)
 {
 	const OpenContainModuleData *data = getOpenContainModuleData();
 
+#if RETAIL_COMPATIBLE_CRC
+
 	const ContainedItemsList* items = getContainedItemsList();
 	if( items )
 	{
-		ContainedItemsList::const_iterator it;
-		it = items->begin();
+		ContainedItemsList::const_iterator it = items->begin();
+		const size_t listSize = items->size();
 
 		while( it != items->end() )
 		{
-			Object *object = *it;
-
-			//Advance to the next iterator before we apply the damage.
-			//It's possible that the damage will kill the unit and foobar
-			//the iterator list.
-			++it;
+			Object *object = *it++;
 
 			//Calculate the damage to be inflicted on each unit.
 			Real damage = object->getBodyModule()->getMaxHealth() * percentDamage;
@@ -1478,9 +1475,90 @@ void OpenContain::processDamageToContained(Real percentDamage)
 			object->attemptDamage( &damageInfo );
 
 			if( !object->isEffectivelyDead() && percentDamage == 1.0f )
-				object->kill(); // in case we are carrying flame proof troops we have been asked to kill			
+				object->kill(); // in case we are carrying flame proof troops we have been asked to kill
+
+			// TheSuperHackers @info Calls to Object::attemptDamage and Object::kill will not remove
+			// the occupant from the host container straight away. Instead it will be removed when the
+			// Object deletion is finalized in a Game Logic update. This will lead to strange behavior
+			// where the occupant will be removed after death with a delay. This behavior cannot be
+			// changed without breaking retail compatibility.
+
+			// TheSuperHackers @bugfix xezon 05/06/2025 Stop iterating when the list was cleared.
+			// This scenario can happen if the killed occupant(s) apply deadly damage on death
+			// to the host container, which then attempts to remove all remaining occupants
+			// on the death of the host container. This is reproducible by destroying a
+			// GLA Battle Bus with at least 2 half damaged GLA Terrorists inside.
+			if (listSize != items->size())
+			{
+				DEBUG_ASSERTCRASH( listSize == 0, ("List is expected empty\n") );
+				break;
+			}
 		}
 	}
+
+#else
+
+	// TheSuperHackers @bugfix xezon 05/06/2025 Temporarily empty the m_containList
+	// to prevent a potential child call to catastrophically modify the m_containList.
+	// This scenario can happen if the killed occupant(s) apply deadly damage on death
+	// to the host container, which then attempts to remove all remaining occupants
+	// on the death of the host container. This is reproducible by destroying a
+	// GLA Battle Bus with at least 2 half damaged GLA Terrorists inside.
+
+	// Caveat: While the m_containList is empty, it will not be possible to apply damage
+	// on death of a unit to another unit in the host container. If this functionality
+	// is desired, then this implementation needs to be revisited.
+
+	ContainedItemsList list;
+	m_containList.swap(list);
+	m_containListSize = 0;
+
+	ContainedItemsList::iterator it = list.begin();
+
+	while ( it != list.end() )
+	{
+		Object *object = *it++;
+
+		DEBUG_ASSERTCRASH( object, ("Contain list must not contain NULL element\n") );
+
+		// Calculate the damage to be inflicted on each unit.
+		Real damage = object->getBodyModule()->getMaxHealth() * percentDamage;
+
+		DamageInfo damageInfo;
+		damageInfo.in.m_damageType = DAMAGE_UNRESISTABLE;
+		damageInfo.in.m_deathType = data->m_isBurnedDeathToUnits ? DEATH_BURNED : DEATH_NORMAL;
+		damageInfo.in.m_sourceID = getObject()->getID();
+		damageInfo.in.m_amount = damage;
+		object->attemptDamage( &damageInfo );
+
+		if( !object->isEffectivelyDead() && percentDamage == 1.0f )
+			object->kill(); // in case we are carrying flame proof troops we have been asked to kill
+	}
+
+	// Now remove all killed objects from the list.
+	it = list.begin();
+
+	while ( it != list.end() )
+	{
+		Object *object = *it;
+
+		if (object->isEffectivelyDead())
+		{
+			onRemoving( object );
+			object->onRemovedFrom( getObject() );
+			it = list.erase(it);
+		}
+		else
+		{
+			++it;
+		}
+	}
+
+	// Swap the list back where it belongs.
+	m_containList.swap(list);
+	m_containListSize = (UnsignedInt)m_containList.size();
+
+#endif // RETAIL_COMPATIBLE_CRC
 }
 
 //-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
* Relates to #921

This change fixes a crash when occupants kill their container and force the remaining occupants to evacuate. This problem is Zero Hour specific. Generals does have this code, but does not have the faction unit to trigger the observed crash with.

The technical mistake here is calling `OpenContain::removeAllContained` within the process of iterating `OpenContain::m_containList` in `OpenContain::processDamageToContained`. It is catastophic to modify the list in recursive calls.

To fix this problem in RETAIL_COMPATIBLE_CRC builds, the loop is exited when the container is discovered empty, which happens when the unit has died.

In non-RETAIL_COMPATIBLE_CRC build we have a different (better) implementation.

This change carries risk of mismatch with retail game, IF there is a code path that **reads** `OpenContain::m_containList` while occupants are damaged/killed in `OpenContain::processDamageToContained`. Reads are legal. This change needs to be tested well. If we find a mismatch, we need to hack-fix this problem elsewhere.

## RETAIL_COMPATIBLE_CRC fix

The logic in `OpenContain::processDamageToContained` is intricate and cannot be freely changed. It has this unique quirk:

https://github.com/user-attachments/assets/6c1db2d3-2b1d-4fee-b1d2-b234ca309e7e

This quirk needs to be preserved in retail compatible builds, otherwise we can expect a mismatch.

## Non RETAIL_COMPATIBLE_CRC fix

The non retail compatible fix has a different implementation, which is more straight forward and prevents this quirk among other potential quirks, while also fixing the crash.

https://github.com/user-attachments/assets/8293988e-db80-45d4-b49e-6d7bfe6a66cb

## Asan report

```
==20280==ERROR: AddressSanitizer: heap-use-after-free on address 0x15668f98 at pc 0x007c9624 bp 0x013de5b0 sp 0x013de5b0
READ of size 4 at 0x15668f98 thread T0
==20280==WARNING: Failed to use and restart external symbolizer!
    #0 0x007c9623 in OpenContain::processDamageToContained D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Contain\OpenContain.cpp:1463
    #1 0x008086eb in BattleBusSlowDeathBehavior::beginSlowDeath D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Behavior\BattleBusSlowDeathBehavior.cpp:179
    #2 0x008c39b6 in UndeadBody::startSecondLife D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Body\UndeadBody.cpp:139
    #3 0x008c3684 in UndeadBody::attemptDamage D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Body\UndeadBody.cpp:96
    #4 0x0061e086 in Object::attemptDamage D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Object.cpp:1820
    #5 0x004fb84b in WeaponTemplate::dealDamageInternal D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp:1494
    #6 0x004fd3da in WeaponTemplate::fireWeaponTemplate D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp:1066
    #7 0x005012f9 in Weapon::privateFireWeapon D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp:2643
    #8 0x004fd5f2 in Weapon::forceFireWeapon D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp:2757
    #9 0x00830076 in FireWeaponUpdate::update D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Update\FireWeaponUpdate.cpp:107
    #10 0x0051237e in GameLogic::update D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\System\GameLogic.cpp:3788
    #11 0x00419838 in GameEngine::update D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\GameEngine.cpp:757
    #12 0x00a4156d in Win32GameEngine::update D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngineDevice\Source\Win32Device\Common\Win32GameEngine.cpp:90
    #13 0x00416a9a in GameEngine::execute D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\GameEngine.cpp:818
    #14 0x00406da5 in GameMain D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\GameMain.cpp:44
    #15 0x004036b9 in WinMain D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\Main\WinMain.cpp:986
    #16 0x00df2ae6 in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #17 0x77bcfcc8 in BaseThreadInitThunk+0x18 (C:\WINDOWS\System32\KERNEL32.DLL+0x6b81fcc8)
    #18 0x77dd82ad in RtlGetAppContainerNamedObjectPath+0x11d (C:\WINDOWS\SYSTEM32\ntdll.dll+0x4b2e82ad)
    #19 0x77dd827d in RtlGetAppContainerNamedObjectPath+0xed (C:\WINDOWS\SYSTEM32\ntdll.dll+0x4b2e827d)

0x15668f98 is located 8 bytes inside of 12-byte region [0x15668f90,0x15668f9c)
freed by thread T0 here:
    #0 0x5b8de6ed in free D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_malloc_win.cpp:125
    #1 0x5b8f081c in __asan::__RuntimeFunctions<__asan::Ucrtbase>::Free D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_win_runtime_functions.cpp:273
    #2 0x00df21c3 in operator delete D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_win_delete_scalar_size_thunk.cpp:44
    #3 0x005a39b2 in std::list<KindOfPercentProductionChange *,std::allocator<KindOfPercentProductionChange *> >::erase C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.43.34808\include\list:1422
    #4 0x007ca7a8 in OpenContain::removeFromContainViaIterator D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Contain\OpenContain.cpp:655
    #5 0x007ca4e1 in OpenContain::removeAllContained D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Contain\OpenContain.cpp:426
    #6 0x007c83ce in OpenContain::onDie D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Contain\OpenContain.cpp:884
    #7 0x0062917e in Object::onDie D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Object.cpp:4567
    #8 0x008bdb5a in ActiveBody::attemptDamage D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Body\ActiveBody.cpp:673
    #9 0x008c3697 in UndeadBody::attemptDamage D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Body\UndeadBody.cpp:97
    #10 0x0061e086 in Object::attemptDamage D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Object.cpp:1820
    #11 0x004fb84b in WeaponTemplate::dealDamageInternal D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp:1494
    #12 0x004fd3da in WeaponTemplate::fireWeaponTemplate D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp:1066
    #13 0x005012f9 in Weapon::privateFireWeapon D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp:2643
    #14 0x004fa662 in WeaponStore::createAndFireTempWeapon D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp:1543
    #15 0x007eb694 in FireWeaponWhenDeadBehavior::onDie D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Behavior\FireWeaponWhenDeadBehavior.cpp:117
    #16 0x0062917e in Object::onDie D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Object.cpp:4567
    #17 0x008bdb5a in ActiveBody::attemptDamage D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Body\ActiveBody.cpp:673
    #18 0x0061e086 in Object::attemptDamage D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Object.cpp:1820
    #19 0x007c9789 in OpenContain::processDamageToContained D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Contain\OpenContain.cpp:1478
    #20 0x008086eb in BattleBusSlowDeathBehavior::beginSlowDeath D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Behavior\BattleBusSlowDeathBehavior.cpp:179
    #21 0x008c39b6 in UndeadBody::startSecondLife D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Body\UndeadBody.cpp:139
    #22 0x008c3684 in UndeadBody::attemptDamage D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Body\UndeadBody.cpp:96
    #23 0x0061e086 in Object::attemptDamage D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Object.cpp:1820
    #24 0x004fb84b in WeaponTemplate::dealDamageInternal D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp:1494
    #25 0x004fd3da in WeaponTemplate::fireWeaponTemplate D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp:1066
    #26 0x005012f9 in Weapon::privateFireWeapon D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp:2643
    #27 0x004fd5f2 in Weapon::forceFireWeapon D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp:2757

previously allocated by thread T0 here:
    #0 0x5b8de7ed in malloc D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_malloc_win.cpp:134
    #1 0x0040429a in operator new D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\System\GameMemoryNull.cpp:158
    #2 0x00494952 in std::list<Object *,std::allocator<Object *> >::_Emplace<Object * const &> C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.43.34808\include\list:1024
    #3 0x007c46ac in OpenContain::addToContainList D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Contain\OpenContain.cpp:369
    #4 0x007c4578 in OpenContain::addToContain D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Contain\OpenContain.cpp:340
    #5 0x007c7e4a in OpenContain::onCollide D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Contain\OpenContain.cpp:848
    #6 0x00628c26 in Object::onCollide D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Object.cpp:2410
    #7 0x00659ca9 in PartitionContactList::processContactList D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\PartitionManager.cpp:2528
    #8 0x0065ed98 in PartitionManager::update D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\PartitionManager.cpp:2773
    #9 0x0051244c in GameLogic::update D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\System\GameLogic.cpp:3817
    #10 0x00419838 in GameEngine::update D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\GameEngine.cpp:757
    #11 0x00a4156d in Win32GameEngine::update D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngineDevice\Source\Win32Device\Common\Win32GameEngine.cpp:90
    #12 0x00416a9a in GameEngine::execute D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\GameEngine.cpp:818
    #13 0x00406da5 in GameMain D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\GameMain.cpp:44
    #14 0x004036b9 in WinMain D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\Main\WinMain.cpp:986
    #15 0x00df2ae6 in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #16 0x77bcfcc8 in BaseThreadInitThunk+0x18 (C:\WINDOWS\System32\KERNEL32.DLL+0x6b81fcc8)
    #17 0x77dd82ad in RtlGetAppContainerNamedObjectPath+0x11d (C:\WINDOWS\SYSTEM32\ntdll.dll+0x4b2e82ad)
    #18 0x77dd827d in RtlGetAppContainerNamedObjectPath+0xed (C:\WINDOWS\SYSTEM32\ntdll.dll+0x4b2e827d)

SUMMARY: AddressSanitizer: heap-use-after-free D:\Projects\TheSuperHackers\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Contain\OpenContain.cpp:1463 in OpenContain::processDamageToContained
Shadow bytes around the buggy address:
  0x15668d00: fa fa 00 00 fa fa 00 00 fa fa 00 00 fa fa 00 00
  0x15668d80: fa fa 00 00 fa fa 00 00 fa fa 00 00 fa fa 00 00
  0x15668e00: fa fa 00 00 fa fa 00 00 fa fa 00 04 fa fa 00 04
  0x15668e80: fa fa 00 04 fa fa fd fd fa fa 00 04 fa fa fd fd
  0x15668f00: fa fa 00 03 fa fa fd fd fa fa fd fd fa fa fd fa
=>0x15668f80: fa fa fd[fd]fa fa fd fa fa fa 00 04 fa fa 00 04
  0x15669000: fa fa 00 04 fa fa fd fd fa fa 00 04 fa fa fd fd
  0x15669080: fa fa 00 03 fa fa fd fd fa fa fd fd fa fa fd fd
  0x15669100: fa fa fd fd fa fa fd fa fa fa fd fa fa fa fd fa
  0x15669180: fa fa fd fa fa fa 00 02 fa fa fd fa fa fa fd fa
  0x15669200: fa fa fd fd fa fa fd fa fa fa fd fd fa fa fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
Address Sanitizer Error: Use of deallocated memory
```

## TODO

- [x] Test in VC6 Golden Replay
- [ ] Test in more Replays
- [ ] Test this crash bug in Retail + this build