### PR TITLE
[GEN][ZH] Fix broken List Box when it contains tall rows

### DIFF
--- a/Generals/Code/GameEngine/Include/GameClient/Gadget.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Gadget.h
@@ -333,7 +333,7 @@ typedef struct _ListEntryRow
 	// The following fields are for internal use and
 	// should not be initialized by the user
 	Int							listHeight;		// calculated total Height at the bottom of this entry
-	Byte						height;				// Maintain the height of the row
+	Int							height;				// Maintain the height of the row
 	ListEntryCell		*cell;				// Holds the array of ListEntry Cells
 	
 } ListEntryRow;

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Gadget.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Gadget.h
@@ -336,7 +336,7 @@ typedef struct _ListEntryRow
 	// The following fields are for internal use and
 	// should not be initialized by the user
 	Int							listHeight;		// calculated total Height at the bottom of this entry
-	Byte						height;				// Maintain the height of the row
+	Int							height;				// Maintain the height of the row
 	ListEntryCell		*cell;				// Holds the array of ListEntry Cells
 	
 } ListEntryRow;


### PR DESCRIPTION
* Fixes #126
* Relates to #732

This change fixes broken List Boxes when they contain tall rows.

This happens because a 1 byte integer value overflows in `struct _ListEntryRow`.

## Original

![shot_20250607_120059_1](https://github.com/user-attachments/assets/ffb76cc7-bfcf-4033-b155-7603c2f3d5bd)

## Fixed

![shot_20250607_115834_1](https://github.com/user-attachments/assets/f4a0ef44-3f3c-466c-a719-1e03c8fe4e88)