### PR TITLE
[GEN][ZH] Prevent a custom Display Resolution from changing when making other changes in the Options Menu

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -1569,7 +1569,7 @@ void OptionsMenuInit( WindowLayout *layout, void *userData )
 
 	if (selectedResIndex == -1)	//check if saved mode no longer available
 	{
-		// TheSuperHackers @tweak xezon 08/06/2025 Now adds the current resolution instead of defaulting to 800 x 600.
+		// TheSuperHackers @bugfix xezon 08/06/2025 Now adds the current resolution instead of defaulting to 800 x 600.
 		// This avoids force changing the resolution when the user has set a custom resolution in the Option Preferences.
 		Int xres = TheDisplay->getWidth();
 		Int yres = TheDisplay->getHeight();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -1635,7 +1635,7 @@ void OptionsMenuInit( WindowLayout *layout, void *userData )
 
 	if (selectedResIndex == -1)	//check if saved mode no longer available
 	{
-		// TheSuperHackers @tweak xezon 08/06/2025 Now adds the current resolution instead of defaulting to 800 x 600.
+		// TheSuperHackers @bugfix xezon 08/06/2025 Now adds the current resolution instead of defaulting to 800 x 600.
 		// This avoids force changing the resolution when the user has set a custom resolution in the Option Preferences.
 		Int xres = TheDisplay->getWidth();
 		Int yres = TheDisplay->getHeight();


### PR DESCRIPTION
* Fixes #453
* Relates to #1028

This change prevents a custom display resolution from changing when making changes in the Options Menu.

Originally, the Display Resolution combo box in the Options Menu did not recognize custom resolutions that were set in the Options.ini. This would force the resolution to change when applying any changes in the Options Menu. When this happened in-game, then the game crashed.

### A custom resolution now shows in the Combo Box

![shot_20250608_085936_1](https://github.com/user-attachments/assets/0bc79dc6-cdbf-405e-a1eb-da0960ef5b2c)

## TODO

- [x] Replicate in Generals