### PR TITLE
[GEN][ZH] Re-initialize pathfinding information cells into a known state in Pathfinder::reset()

### DIFF
--- a/Generals/Code/GameEngine/Include/GameLogic/AIPathfind.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AIPathfind.h
@@ -207,6 +207,7 @@ class PathfindCellInfo
 {
 	friend class PathfindCell;
 public:
+	static void initializeCellInfos(void);
 	static void allocateCellInfos(void);
 	static void releaseCellInfos(void);
 

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -1086,7 +1086,7 @@ Real Path::computeFlightDistToGoal( const Coord3D *pos, Coord3D& goalPos )
 enum { PATHFIND_CELLS_PER_FRAME=5000}; // Number of cells we will search pathfinding per frame.
 enum {CELL_INFOS_TO_ALLOCATE = 30000};
 PathfindCellInfo *PathfindCellInfo::s_infoArray = NULL;
-PathfindCellInfo *PathfindCellInfo::s_firstFree = NULL;						
+PathfindCellInfo *PathfindCellInfo::s_firstFree = NULL;
 /**
  * Allocates a pool of pathfind cell infos.
  */
@@ -1094,13 +1094,7 @@ void PathfindCellInfo::allocateCellInfos(void)
 {
 	releaseCellInfos();
 	s_infoArray = MSGNEW("PathfindCellInfo") PathfindCellInfo[CELL_INFOS_TO_ALLOCATE];	// pool[]ify
-	s_infoArray[CELL_INFOS_TO_ALLOCATE-1].m_pathParent = NULL;
-	s_infoArray[CELL_INFOS_TO_ALLOCATE-1].m_isFree = true;
-	s_firstFree = s_infoArray;
-	for (Int i=0; i<CELL_INFOS_TO_ALLOCATE-1; i++) {
-		s_infoArray[i].m_pathParent = &s_infoArray[i+1];
-		s_infoArray[i].m_isFree = true; 
-	}
+	initializeCellInfos();
 }
 
 /**
@@ -1121,6 +1115,20 @@ void PathfindCellInfo::releaseCellInfos(void)
 	delete[] s_infoArray;
 	s_infoArray = NULL;
 	s_firstFree = NULL;
+}
+
+/**
+ * Initializes a pool of pathfind cell infos.
+ */
+void PathfindCellInfo::initializeCellInfos(void) 
+{
+	s_infoArray[CELL_INFOS_TO_ALLOCATE-1].m_pathParent = NULL;
+	s_infoArray[CELL_INFOS_TO_ALLOCATE-1].m_isFree = true;
+	s_firstFree = s_infoArray;
+	for (Int i=0; i<CELL_INFOS_TO_ALLOCATE-1; i++) {
+		s_infoArray[i].m_pathParent = &s_infoArray[i+1];
+		s_infoArray[i].m_isFree = true; 
+	}
 }
 
 /**
@@ -3460,6 +3468,9 @@ void Pathfinder::reset( void )
 		m_wallHeight = 0.0f;
 	}
 	m_zoneManager.reset();
+
+	// TheSuperHackers @fix Mauller 09/06/2025 Re-initialize pathfinding cell info objects so they are in a known clean state
+	PathfindCellInfo::initializeCellInfos();
 }
 
 /** 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AIPathfind.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AIPathfind.h
@@ -208,6 +208,7 @@ class PathfindCellInfo
 {
 	friend class PathfindCell;
 public:
+	static void initializeCellInfos(void);
 	static void allocateCellInfos(void);
 	static void releaseCellInfos(void);
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -1104,7 +1104,7 @@ Real Path::computeFlightDistToGoal( const Coord3D *pos, Coord3D& goalPos )
 enum { PATHFIND_CELLS_PER_FRAME=5000}; // Number of cells we will search pathfinding per frame.
 enum {CELL_INFOS_TO_ALLOCATE = 30000};
 PathfindCellInfo *PathfindCellInfo::s_infoArray = NULL;
-PathfindCellInfo *PathfindCellInfo::s_firstFree = NULL;						
+PathfindCellInfo *PathfindCellInfo::s_firstFree = NULL;
 /**
  * Allocates a pool of pathfind cell infos.
  */
@@ -1112,13 +1112,7 @@ void PathfindCellInfo::allocateCellInfos(void)
 {
 	releaseCellInfos();
 	s_infoArray = MSGNEW("PathfindCellInfo") PathfindCellInfo[CELL_INFOS_TO_ALLOCATE];	// pool[]ify
-	s_infoArray[CELL_INFOS_TO_ALLOCATE-1].m_pathParent = NULL;
-	s_infoArray[CELL_INFOS_TO_ALLOCATE-1].m_isFree = true;
-	s_firstFree = s_infoArray;
-	for (Int i=0; i<CELL_INFOS_TO_ALLOCATE-1; i++) {
-		s_infoArray[i].m_pathParent = &s_infoArray[i+1];
-		s_infoArray[i].m_isFree = true; 
-	}
+	initializeCellInfos();
 }
 
 /**
@@ -1139,6 +1133,20 @@ void PathfindCellInfo::releaseCellInfos(void)
 	delete[] s_infoArray;
 	s_infoArray = NULL;
 	s_firstFree = NULL;
+}
+
+/**
+ * Initializes a pool of pathfind cell infos.
+ */
+void PathfindCellInfo::initializeCellInfos(void) 
+{
+	s_infoArray[CELL_INFOS_TO_ALLOCATE-1].m_pathParent = NULL;
+	s_infoArray[CELL_INFOS_TO_ALLOCATE-1].m_isFree = true;
+	s_firstFree = s_infoArray;
+	for (Int i=0; i<CELL_INFOS_TO_ALLOCATE-1; i++) {
+		s_infoArray[i].m_pathParent = &s_infoArray[i+1];
+		s_infoArray[i].m_isFree = true; 
+	}
 }
 
 /**
@@ -3902,6 +3910,9 @@ void Pathfinder::reset( void )
 		m_wallHeight = 0.0f;
 	}
 	m_zoneManager.reset();
+
+	// TheSuperHackers @fix Mauller 09/06/2025 Re-initialize pathfinding cell info objects so they are in a known clean state
+	PathfindCellInfo::initializeCellInfos();
 }
 
 /** 


### PR DESCRIPTION
Just a simple tweak, very minimal on the surface, but it's just to keep the initial state of the pathfinding information cells consistent between games.