### PR TITLE
[CORE][GEN][ZH] Make tools compile with clang-cl in VS2022

### DIFF
--- a/Core/Tools/ImagePacker/Source/WindowProcedures/PreviewProc.cpp
+++ b/Core/Tools/ImagePacker/Source/WindowProcedures/PreviewProc.cpp
@@ -112,7 +112,7 @@ LRESULT CALLBACK PreviewProc( HWND hWnd, UINT message,
 							page->getPixel( x, y, &r, &g, &b );
 
 							// create a new pen of the right color
-							pen = CreatePen( 1, 1, RGB( r, g, b, ) );
+							pen = CreatePen( 1, 1, RGB( r, g, b ) );
 							
 							// select pen into hdc
 							prevPen = (HPEN)SelectObject( hdc, pen );

--- a/Core/Tools/W3DView/BoneMgrDialog.cpp
+++ b/Core/Tools/W3DView/BoneMgrDialog.cpp
@@ -373,7 +373,7 @@ BoneMgrDialogClass::Update_Controls (HTREEITEM selected_item)
 
 	// Change the text of the group box to reflect the bone name
 	CString text;
-	text.Format ("Bone: %s", m_BoneName);
+	text.Format ("Bone: %s", m_BoneName.GetString());
 	SetDlgItemText (IDC_BONE_GROUPBOX, text);
 	return ;
 }

--- a/Core/Tools/W3DView/BoneMgrDialog.cpp
+++ b/Core/Tools/W3DView/BoneMgrDialog.cpp
@@ -373,7 +373,7 @@ BoneMgrDialogClass::Update_Controls (HTREEITEM selected_item)
 
 	// Change the text of the group box to reflect the bone name
 	CString text;
-	text.Format ("Bone: %s", m_BoneName.GetString());
+	text.Format ("Bone: %s", static_cast<const char*>(m_BoneName));
 	SetDlgItemText (IDC_BONE_GROUPBOX, text);
 	return ;
 }

--- a/Core/Tools/W3DView/HierarchyPropPage.cpp
+++ b/Core/Tools/W3DView/HierarchyPropPage.cpp
@@ -106,7 +106,7 @@ CHierarchyPropPage::OnInitDialog (void)
         if (pCHierarchy)
         {
             CString stringDesc;
-            stringDesc.Format (IDS_HIERARCHY_PROP_DESC, m_stringHierarchyName.GetString());
+            stringDesc.Format (IDS_HIERARCHY_PROP_DESC, static_cast<const char*>(m_stringHierarchyName));
 
             // Put the description onto the dialog
             SetDlgItemText (IDC_DESCRIPTION, stringDesc);

--- a/Core/Tools/W3DView/HierarchyPropPage.cpp
+++ b/Core/Tools/W3DView/HierarchyPropPage.cpp
@@ -106,7 +106,7 @@ CHierarchyPropPage::OnInitDialog (void)
         if (pCHierarchy)
         {
             CString stringDesc;
-            stringDesc.Format (IDS_HIERARCHY_PROP_DESC, m_stringHierarchyName);
+            stringDesc.Format (IDS_HIERARCHY_PROP_DESC, m_stringHierarchyName.GetString());
 
             // Put the description onto the dialog
             SetDlgItemText (IDC_DESCRIPTION, stringDesc);

--- a/Core/Tools/W3DView/MainFrm.cpp
+++ b/Core/Tools/W3DView/MainFrm.cpp
@@ -3847,7 +3847,7 @@ CMainFrame::OnAddToLineup (void)
 		{
 			// Tell the user that the render object could not be created.
 			CString msg;
-			msg.Format("Unable to create render object '%s'!", dlg.m_Object.GetString());
+			msg.Format("Unable to create render object '%s'!", static_cast<const char*>(dlg.m_Object));
 			::AfxMessageBox(msg, MB_OK | MB_ICONINFORMATION);
 		}
 	}

--- a/Core/Tools/W3DView/MainFrm.cpp
+++ b/Core/Tools/W3DView/MainFrm.cpp
@@ -3847,7 +3847,7 @@ CMainFrame::OnAddToLineup (void)
 		{
 			// Tell the user that the render object could not be created.
 			CString msg;
-			msg.Format("Unable to create render object '%s'!", dlg.m_Object);
+			msg.Format("Unable to create render object '%s'!", dlg.m_Object.GetString());
 			::AfxMessageBox(msg, MB_OK | MB_ICONINFORMATION);
 		}
 	}

--- a/Core/Tools/W3DView/MeshPropPage.cpp
+++ b/Core/Tools/W3DView/MeshPropPage.cpp
@@ -107,7 +107,7 @@ CMeshPropPage::OnInitDialog (void)
         if (pCMesh)
         {
             CString stringDesc;
-            stringDesc.Format (IDS_MESH_PROP_DESC, m_stringMeshName.GetString());
+            stringDesc.Format (IDS_MESH_PROP_DESC, static_cast<const char*>(m_stringMeshName));
 
             // Put the description onto the dialog
             SetDlgItemText (IDC_DESCRIPTION, stringDesc);

--- a/Core/Tools/W3DView/MeshPropPage.cpp
+++ b/Core/Tools/W3DView/MeshPropPage.cpp
@@ -107,7 +107,7 @@ CMeshPropPage::OnInitDialog (void)
         if (pCMesh)
         {
             CString stringDesc;
-            stringDesc.Format (IDS_MESH_PROP_DESC, m_stringMeshName);
+            stringDesc.Format (IDS_MESH_PROP_DESC, m_stringMeshName.GetString());
 
             // Put the description onto the dialog
             SetDlgItemText (IDC_DESCRIPTION, stringDesc);

--- a/Generals/Code/Tools/ParticleEditor/CColorAlphaDialog.cpp
+++ b/Generals/Code/Tools/ParticleEditor/CColorAlphaDialog.cpp
@@ -219,7 +219,7 @@ BOOL CColorAlphaDialog::OnInitDialog()
 	return CDialog::OnInitDialog();
 }
 
-#define ONCOLORDLG(x) void CColorAlphaDialog::OnColor##x##() { onColorPress( x ); }
+#define ONCOLORDLG(x) void CColorAlphaDialog::OnColor##x() { onColorPress( x ); }
 ONCOLORDLG(1)
 ONCOLORDLG(2)
 ONCOLORDLG(3)

--- a/Generals/Code/Tools/WorldBuilder/include/wbview3d.h
+++ b/Generals/Code/Tools/WorldBuilder/include/wbview3d.h
@@ -39,7 +39,7 @@
 #include "dx8wrapper.h"
 
 //#include "GameLogic/Module/BodyModule.h" -- Yikes... not necessary to include this! (KM)
-enum BodyDamageType; //Ahhhh much better!
+enum BodyDamageType CPP_11(: Int); //Ahhhh much better!
 
 class WorldHeightMap;
 class LayerClass;

--- a/Generals/Code/Tools/WorldBuilder/src/DrawObject.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/DrawObject.cpp
@@ -264,7 +264,7 @@ Int DrawObject::initData(void)
 	m_vertexMaterialClass=VertexMaterialClass::Get_Preset(VertexMaterialClass::PRELIT_DIFFUSE);
 
 	//use a multi-texture shader: (text1*diffuse)*text2.
-	m_shaderClass = ShaderClass::ShaderClass(SC_OPAQUE);//_PresetOpaque2DShader;//ShaderClass(SC_OPAQUE); //_PresetOpaqueShader;
+	m_shaderClass = ShaderClass(SC_OPAQUE);//_PresetOpaque2DShader;//ShaderClass(SC_OPAQUE); //_PresetOpaqueShader;
 
 	m_shaderClass = ShaderClass::_PresetOpaque2DShader;
 	updateForWater();			 

--- a/Generals/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp
@@ -620,11 +620,11 @@ void CWorldBuilderDoc::OnJumpToGame()
 		CString filename;
 		DEBUG_LOG(("strTitle=%s strPathName=%s\n", m_strTitle, m_strPathName));
 		if (strstr(m_strPathName, TheGlobalData->getPath_UserData().str()) != NULL)
-			filename.Format("%sMaps\\%s", TheGlobalData->getPath_UserData().str(), m_strTitle.GetString());
+			filename.Format("%sMaps\\%s", TheGlobalData->getPath_UserData().str(), static_cast<const char*>(m_strTitle));
 		else
-			filename.Format("Maps\\%s", m_strTitle.GetString());
+			filename.Format("Maps\\%s", static_cast<const char*>(m_strTitle));
 
-		/*int retval =*/ _spawnl(_P_NOWAIT, "\\projects\\rts\\run\\rtsi.exe", "ignored", "-scriptDebug", "-win", "-file", filename.GetString(), NULL);
+		/*int retval =*/ _spawnl(_P_NOWAIT, "\\projects\\rts\\run\\rtsi.exe", "ignored", "-scriptDebug", "-win", "-file", static_cast<const char*>(filename), NULL);
 	} catch (...) {
 	}
 }

--- a/Generals/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp
@@ -620,11 +620,11 @@ void CWorldBuilderDoc::OnJumpToGame()
 		CString filename;
 		DEBUG_LOG(("strTitle=%s strPathName=%s\n", m_strTitle, m_strPathName));
 		if (strstr(m_strPathName, TheGlobalData->getPath_UserData().str()) != NULL)
-			filename.Format("%sMaps\\%s", TheGlobalData->getPath_UserData().str(), m_strTitle);
+			filename.Format("%sMaps\\%s", TheGlobalData->getPath_UserData().str(), m_strTitle.GetString());
 		else
-			filename.Format("Maps\\%s", m_strTitle);
+			filename.Format("Maps\\%s", m_strTitle.GetString());
 
-		/*int retval =*/ _spawnl(_P_NOWAIT, "\\projects\\rts\\run\\rtsi.exe", "ignored", "-scriptDebug", "-win", "-file", filename, NULL);
+		/*int retval =*/ _spawnl(_P_NOWAIT, "\\projects\\rts\\run\\rtsi.exe", "ignored", "-scriptDebug", "-win", "-file", filename.GetString(), NULL);
 	} catch (...) {
 	}
 }

--- a/GeneralsMD/Code/Tools/ParticleEditor/CColorAlphaDialog.cpp
+++ b/GeneralsMD/Code/Tools/ParticleEditor/CColorAlphaDialog.cpp
@@ -219,7 +219,7 @@ BOOL CColorAlphaDialog::OnInitDialog()
 	return CDialog::OnInitDialog();
 }
 
-#define ONCOLORDLG(x) void CColorAlphaDialog::OnColor##x##() { onColorPress( x ); }
+#define ONCOLORDLG(x) void CColorAlphaDialog::OnColor##x() { onColorPress( x ); }
 ONCOLORDLG(1)
 ONCOLORDLG(2)
 ONCOLORDLG(3)

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/wbview3d.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/wbview3d.h
@@ -40,7 +40,7 @@
 #include "dx8wrapper.h"
 
 //#include "GameLogic/Module/BodyModule.h" -- Yikes... not necessary to include this! (KM)
-enum BodyDamageType; //Ahhhh much better!
+enum BodyDamageType CPP_11(: Int); //Ahhhh much better!
 
 class WorldHeightMap;
 class LayerClass;

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/DrawObject.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/DrawObject.cpp
@@ -279,7 +279,7 @@ Int DrawObject::initData(void)
 	m_vertexMaterialClass=VertexMaterialClass::Get_Preset(VertexMaterialClass::PRELIT_DIFFUSE);
 
 	//use a multi-texture shader: (text1*diffuse)*text2.
-	m_shaderClass = ShaderClass::ShaderClass(SC_OPAQUE);//_PresetOpaque2DShader;//ShaderClass(SC_OPAQUE); //_PresetOpaqueShader;
+	m_shaderClass = ShaderClass(SC_OPAQUE);//_PresetOpaque2DShader;//ShaderClass(SC_OPAQUE); //_PresetOpaqueShader;
 
 	m_shaderClass = ShaderClass::_PresetOpaque2DShader;
 	updateForWater();			 

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp
@@ -681,11 +681,11 @@ void CWorldBuilderDoc::OnJumpToGame()
 		CString filename;
 		DEBUG_LOG(("strTitle=%s strPathName=%s\n", m_strTitle, m_strPathName));
 		if (strstr(m_strPathName, TheGlobalData->getPath_UserData().str()) != NULL)
-			filename.Format("%sMaps\\%s", TheGlobalData->getPath_UserData().str(), m_strTitle.GetString());
+			filename.Format("%sMaps\\%s", TheGlobalData->getPath_UserData().str(), static_cast<const char*>(m_strTitle));
 		else
-			filename.Format("Maps\\%s", m_strTitle.GetString());
+			filename.Format("Maps\\%s", static_cast<const char*>(m_strTitle));
 
-		/*int retval =*/ _spawnl(_P_NOWAIT, "\\projects\\rts\\run\\rtsi.exe", "ignored", "-scriptDebug", "-win", "-file", filename.GetString(), NULL);
+		/*int retval =*/ _spawnl(_P_NOWAIT, "\\projects\\rts\\run\\rtsi.exe", "ignored", "-scriptDebug", "-win", "-file", static_cast<const char*>(filename), NULL);
 	} catch (...) {
 	}
 }

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp
@@ -681,11 +681,11 @@ void CWorldBuilderDoc::OnJumpToGame()
 		CString filename;
 		DEBUG_LOG(("strTitle=%s strPathName=%s\n", m_strTitle, m_strPathName));
 		if (strstr(m_strPathName, TheGlobalData->getPath_UserData().str()) != NULL)
-			filename.Format("%sMaps\\%s", TheGlobalData->getPath_UserData().str(), m_strTitle);
+			filename.Format("%sMaps\\%s", TheGlobalData->getPath_UserData().str(), m_strTitle.GetString());
 		else
-			filename.Format("Maps\\%s", m_strTitle);
+			filename.Format("Maps\\%s", m_strTitle.GetString());
 
-		/*int retval =*/ _spawnl(_P_NOWAIT, "\\projects\\rts\\run\\rtsi.exe", "ignored", "-scriptDebug", "-win", "-file", filename, NULL);
+		/*int retval =*/ _spawnl(_P_NOWAIT, "\\projects\\rts\\run\\rtsi.exe", "ignored", "-scriptDebug", "-win", "-file", filename.GetString(), NULL);
 	} catch (...) {
 	}
 }

--- a/GeneralsMD/Code/Tools/wdump/chunk_d.cpp
+++ b/GeneralsMD/Code/Tools/wdump/chunk_d.cpp
@@ -2397,7 +2397,7 @@ void ChunkData::Add_Chunk(ChunkLoadClass & cload, ChunkItem *Parent)
 
 				if(theApp.TextureDumpFile != 0) 
 					fprintf(theApp.TextureDumpFile, "%s,%s\n", (LPCTSTR)theApp.Filename, data);
-				TRACE("%s,%s\n", theApp.Filename, data);
+				TRACE("%s,%s\n", theApp.Filename.GetString(), data);
 			}
 		}
 	}

--- a/GeneralsMD/Code/Tools/wdump/chunk_d.cpp
+++ b/GeneralsMD/Code/Tools/wdump/chunk_d.cpp
@@ -2397,7 +2397,7 @@ void ChunkData::Add_Chunk(ChunkLoadClass & cload, ChunkItem *Parent)
 
 				if(theApp.TextureDumpFile != 0) 
 					fprintf(theApp.TextureDumpFile, "%s,%s\n", (LPCTSTR)theApp.Filename, data);
-				TRACE("%s,%s\n", theApp.Filename.GetString(), data);
+				TRACE("%s,%s\n", static_cast<const char*>(theApp.Filename), data);
 			}
 		}
 	}


### PR DESCRIPTION
* Relates to: https://github.com/TheSuperHackers/GeneralsGameCode/pull/888

This PR fixes a couple of compiler errors when compiling with clang-cl. None of these changes are in projects required to build the game executables.

There are still a few projects that cannot be compiled with clang-cl, because they're full of MFC code. The most glaring issue is attempting to store a pointer to a non-static member function from within a static member function.