### PR TITLE
[ZH] Fix case sensitivity for some wdump header includes

### DIFF
--- a/GeneralsMD/Code/Tools/wdump/chunk_d.cpp
+++ b/GeneralsMD/Code/Tools/wdump/chunk_d.cpp
@@ -37,9 +37,9 @@
 #include "w3d_file.h"
 #include "stdafx.h"
 #include "wdump.h"
-#include "Chunk_D.h"
+#include "chunk_d.h"
 #include "rawfilem.h"
-#include "finddialog.h"
+#include "FindDialog.h"
 
 #ifdef RTS_DEBUG
 #undef THIS_FILE

--- a/GeneralsMD/Code/Tools/wdump/mainfrm.cpp
+++ b/GeneralsMD/Code/Tools/wdump/mainfrm.cpp
@@ -22,9 +22,9 @@
 #include "stdafx.h"
 #include "wdump.h"
 #include "wdtview.h"
-#include "wdLview.h"
+#include "wdlview.h"
 
-#include "MainFrm.h"
+#include "mainfrm.h"
 
 #ifdef RTS_DEBUG
 #define new DEBUG_NEW

--- a/GeneralsMD/Code/Tools/wdump/rawfilem.h
+++ b/GeneralsMD/Code/Tools/wdump/rawfilem.h
@@ -51,7 +51,7 @@
 #define	NULL_HANDLE		INVALID_HANDLE_VALUE
 #define	HANDLE_TYPE		HANDLE
 
-#include	"wwfile.h"
+#include	"WWFILE.H"
 
 #ifdef NEVER
 	/*

--- a/GeneralsMD/Code/Tools/wdump/stdafx.h
+++ b/GeneralsMD/Code/Tools/wdump/stdafx.h
@@ -40,7 +40,7 @@
 #include <afxdlgs.h> // FileDialog class
 
 #include "chunkio.h"
-#include "vector3i.h"
+#include "Vector3i.h"
 #include "w3d_file.h"
 
 

--- a/GeneralsMD/Code/Tools/wdump/wdeview.cpp
+++ b/GeneralsMD/Code/Tools/wdump/wdeview.cpp
@@ -21,7 +21,7 @@
 
 #include "stdafx.h"
 #include "wdump.h"
-#include "WDEView.h"
+#include "wdeview.h"
 #include "wdumpdoc.h"
 #include "chunk_d.h"
 

--- a/GeneralsMD/Code/Tools/wdump/wdlview.cpp
+++ b/GeneralsMD/Code/Tools/wdump/wdlview.cpp
@@ -21,8 +21,8 @@
 
 #include "stdafx.h"
 #include "wdump.h"
-#include "WDLView.h"
-#include "WDumpDoc.h"
+#include "wdlview.h"
+#include "wdumpdoc.h"
 #ifdef RTS_DEBUG
 #define new DEBUG_NEW
 #undef THIS_FILE

--- a/GeneralsMD/Code/Tools/wdump/wdtview.cpp
+++ b/GeneralsMD/Code/Tools/wdump/wdtview.cpp
@@ -21,10 +21,10 @@
 
 #include "stdafx.h"
 #include "wdump.h"
-#include "WDTView.h"
+#include "wdtview.h"
 #include "wdumpdoc.h"
 #include "chunk_d.h"
-#include "finddialog.h"
+#include "FindDialog.h"
 
 #ifdef RTS_DEBUG
 #define new DEBUG_NEW

--- a/GeneralsMD/Code/Tools/wdump/wdump.cpp
+++ b/GeneralsMD/Code/Tools/wdump/wdump.cpp
@@ -22,11 +22,11 @@
 #include "stdafx.h"
 #include "wdump.h"
 
-#include "MainFrm.h"
-#include "wdumpDoc.h"
-#include "wdView.h"
+#include "mainfrm.h"
+#include "wdumpdoc.h"
+#include "wdview.h"
 
-#include "FCNTL.H"
+#include "fcntl.h"
 
 #ifdef RTS_DEBUG
 #define new DEBUG_NEW

--- a/GeneralsMD/Code/Tools/wdump/wdumpdoc.cpp
+++ b/GeneralsMD/Code/Tools/wdump/wdumpdoc.cpp
@@ -21,7 +21,7 @@
 
 #include "stdafx.h"
 #include "wdump.h"
-#include "wdumpDoc.h"
+#include "wdumpdoc.h"
 
 
 #ifdef RTS_DEBUG

--- a/GeneralsMD/Code/Tools/wdump/wdview.cpp
+++ b/GeneralsMD/Code/Tools/wdump/wdview.cpp
@@ -22,8 +22,8 @@
 #include "stdafx.h"
 #include "wdump.h"
 
-#include "wdumpDoc.h"
-#include "wdView.h"
+#include "wdumpdoc.h"
+#include "wdview.h"
 
 #ifdef RTS_DEBUG
 #define new DEBUG_NEW


### PR DESCRIPTION
* Relates to: https://github.com/TheSuperHackers/GeneralsGameCode/pull/1040

There are some header includes in `wdump` that don't have the right case sensitivity. That leads to compiler warnings: `non-portable path to file '"file.h"'; specified path differs in case from file name on disk [-Wnonportable-include-path]`. It may also lead to issues on operating systems that are more sensitive to case than Windows.