### PR TITLE
[GEN][ZH] Initialize all uninitialized variables in AIPathfind

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -6586,6 +6586,11 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 	// "closed" list is initially empty
 	m_closedList = NULL;
 
+	// TheSuperHackers @fix helmutbuhler This was originally uninitialized and in the loop below.
+#if RETAIL_COMPATIBLE_CRC
+	UnsignedInt newCostSoFar = 0;
+#endif
+
 	//
 	// Continue search until "open" list is empty, or
 	// until goal is found.
@@ -7660,11 +7665,6 @@ Bool Pathfinder::pathDestination( 	Object *obj, const LocomotorSet& locomotorSet
 
 	// "closed" list is initially empty
 	m_closedList = NULL;
-
-	// TheSuperHackers @fix helmutbuhler This was originally uninitialized and in the loop below.
-#if RETAIL_COMPATIBLE_CRC
-	UnsignedInt newCostSoFar = 0;
-#endif
 
 	//
 	// Continue search until "open" list is empty, or

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -5645,9 +5645,9 @@ Int Pathfinder::examineNeighboringCells(PathfindCell *parentCell, PathfindCell *
 		ICoord2D newCellCoord;
 		PathfindCell *newCell;
 		const Int adjacent[5] = {0, 1, 2, 3, 0};
-		Bool neighborFlags[8] = {false, false, false, false, false, false, false};
+		Bool neighborFlags[8] = { 0 };
 
-		UnsignedInt newCostSoFar;
+		UnsignedInt newCostSoFar = 0;
 
 
 
@@ -6647,12 +6647,11 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 		ICoord2D newCellCoord;
 		PathfindCell *newCell;
 		const Int adjacent[5] = {0, 1, 2, 3, 0};
-		Bool neighborFlags[8] = {false, false, false, false, false, false, false};
+		Bool neighborFlags[8] = { 0 };
 
 		// TheSuperHackers @fix Mauller 23/05/2025 Fixes uninitialized variable.
-		// To keep retail compatibility it needs to be uninitialized in VC6 builds.
-#if defined(_MSC_VER) && _MSC_VER < 1300
-		UnsignedInt newCostSoFar;
+#if RETAIL_COMPATIBLE_CRC
+		// newCostSoFar defined in outer block.
 #else
 		UnsignedInt newCostSoFar = 0;
 #endif
@@ -6717,6 +6716,8 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 				}								
 				cellCount++;
 
+#if RETAIL_COMPATIBLE_CRC
+				// TheSuperHackers @fix helmutbuhler 11/06/2025 The indentation was wrong on retail here.
 				newCostSoFar = newCell->costSoFar( parentCell );
 				if (clearDiameter<pathDiameter) {
 					int delta = pathDiameter-clearDiameter;
@@ -6724,6 +6725,15 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 				}
 				newCell->setBlockedByAlly(false);
 			}
+#else
+			}
+			newCostSoFar = newCell->costSoFar( parentCell );
+			if (clearDiameter<pathDiameter) {
+				int delta = pathDiameter-clearDiameter;
+				newCostSoFar += 0.6f*(delta*COST_ORTHOGONAL);
+			}
+			newCell->setBlockedByAlly(false);
+#endif
 			Int costRemaining = 0;
 			costRemaining = newCell->costToGoal( goalCell );
 
@@ -7651,6 +7661,11 @@ Bool Pathfinder::pathDestination( 	Object *obj, const LocomotorSet& locomotorSet
 	// "closed" list is initially empty
 	m_closedList = NULL;
 
+	// TheSuperHackers @fix helmutbuhler This was originally uninitialized and in the loop below.
+#if RETAIL_COMPATIBLE_CRC
+	UnsignedInt newCostSoFar = 0;
+#endif
+
 	//
 	// Continue search until "open" list is empty, or
 	// until goal is found.
@@ -7699,9 +7714,9 @@ Bool Pathfinder::pathDestination( 	Object *obj, const LocomotorSet& locomotorSet
 		ICoord2D newCellCoord;
 		PathfindCell *newCell;
 		const Int adjacent[5] = {0, 1, 2, 3, 0};
-		Bool neighborFlags[8] = {false, false, false, false, false, false, false};
+		Bool neighborFlags[8] = { 0 };
 
-		UnsignedInt newCostSoFar;
+		UnsignedInt newCostSoFar = 0;
 
 		for( int i=0; i<numNeighbors; i++ )
 		{
@@ -7952,9 +7967,9 @@ Int Pathfinder::checkPathCost(Object *obj, const LocomotorSet& locomotorSet, con
 		ICoord2D newCellCoord;
 		PathfindCell *newCell;
 		const Int adjacent[5] = {0, 1, 2, 3, 0};
-		Bool neighborFlags[8] = {false, false, false, false, false, false, false};
+		Bool neighborFlags[8] = { 0 };
 
-		UnsignedInt newCostSoFar;
+		UnsignedInt newCostSoFar = 0;
 
 		for( int i=0; i<numNeighbors; i++ )
 		{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -7131,7 +7131,7 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 	m_closedList = NULL;
 
 	// TheSuperHackers @fix helmutbuhler This was originally uninitialized and in the loop below.
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if RETAIL_COMPATIBLE_CRC
 	UnsignedInt newCostSoFar = 0;
 #endif
 
@@ -7199,8 +7199,7 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 		Bool neighborFlags[8] = { 0 };
 
 		// TheSuperHackers @fix Mauller 23/05/2025 Fixes uninitialized variable.
-		// To keep retail compatibility it needs to be uninitialized in VC6 builds.
-#if defined(_MSC_VER) && _MSC_VER < 1300
+#if RETAIL_COMPATIBLE_CRC
 		// newCostSoFar defined in outer block.
 #else
 		UnsignedInt newCostSoFar = 0;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -6159,9 +6159,9 @@ Int Pathfinder::examineNeighboringCells(PathfindCell *parentCell, PathfindCell *
 		ICoord2D newCellCoord;
 		PathfindCell *newCell;
 		const Int adjacent[5] = {0, 1, 2, 3, 0};
-		Bool neighborFlags[8] = {false, false, false, false, false, false, false};
+		Bool neighborFlags[8] = {false, false, false, false, false, false, false, false};
 
-		UnsignedInt newCostSoFar;
+		UnsignedInt newCostSoFar = 0;
 
 
 
@@ -7130,6 +7130,11 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 	// "closed" list is initially empty
 	m_closedList = NULL;
 
+	// TheSuperHackers @fix helmutbuhler This was originally uninitialized and in the loop below.
+#if defined(_MSC_VER) && _MSC_VER < 1300
+	UnsignedInt newCostSoFar = 0;
+#endif
+
 	//
 	// Continue search until "open" list is empty, or
 	// until goal is found.
@@ -7191,12 +7196,12 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 		ICoord2D newCellCoord;
 		PathfindCell *newCell;
 		const Int adjacent[5] = {0, 1, 2, 3, 0};
-		Bool neighborFlags[8] = {false, false, false, false, false, false, false};
+		Bool neighborFlags[8] = {false, false, false, false, false, false, false, false};
 
 		// TheSuperHackers @fix Mauller 23/05/2025 Fixes uninitialized variable.
 		// To keep retail compatibility it needs to be uninitialized in VC6 builds.
 #if defined(_MSC_VER) && _MSC_VER < 1300
-		UnsignedInt newCostSoFar;
+		// newCostSoFar defined in outer block.
 #else
 		UnsignedInt newCostSoFar = 0;
 #endif
@@ -8319,9 +8324,9 @@ Bool Pathfinder::pathDestination( 	Object *obj, const LocomotorSet& locomotorSet
 		ICoord2D newCellCoord;
 		PathfindCell *newCell;
 		const Int adjacent[5] = {0, 1, 2, 3, 0};
-		Bool neighborFlags[8] = {false, false, false, false, false, false, false};
+		Bool neighborFlags[8] = {false, false, false, false, false, false, false, false};
 
-		UnsignedInt newCostSoFar;
+		UnsignedInt newCostSoFar = 0;
 
 		for( int i=0; i<numNeighbors; i++ )
 		{
@@ -8572,9 +8577,9 @@ Int Pathfinder::checkPathCost(Object *obj, const LocomotorSet& locomotorSet, con
 		ICoord2D newCellCoord;
 		PathfindCell *newCell;
 		const Int adjacent[5] = {0, 1, 2, 3, 0};
-		Bool neighborFlags[8] = {false, false, false, false, false, false, false};
+		Bool neighborFlags[8] = {false, false, false, false, false, false, false, false};
 
-		UnsignedInt newCostSoFar;
+		UnsignedInt newCostSoFar = 0;
 
 		for( int i=0; i<numNeighbors; i++ )
 		{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -7265,6 +7265,8 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 				}								
 				cellCount++;
 
+#if RETAIL_COMPATIBLE_CRC
+				// TheSuperHackers @fix helmutbuhler 11/06/2025 The indentation was wrong on retail here.
 				newCostSoFar = newCell->costSoFar( parentCell );
 				if (clearDiameter<pathDiameter) {
 					int delta = pathDiameter-clearDiameter;
@@ -7272,6 +7274,15 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 				}
 				newCell->setBlockedByAlly(false);
 			}
+#else
+			}
+			newCostSoFar = newCell->costSoFar( parentCell );
+			if (clearDiameter<pathDiameter) {
+				int delta = pathDiameter-clearDiameter;
+				newCostSoFar += 0.6f*(delta*COST_ORTHOGONAL);
+			}
+			newCell->setBlockedByAlly(false);
+#endif
 			Int costRemaining = 0;
 			costRemaining = newCell->costToGoal( goalCell );
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -6159,7 +6159,7 @@ Int Pathfinder::examineNeighboringCells(PathfindCell *parentCell, PathfindCell *
 		ICoord2D newCellCoord;
 		PathfindCell *newCell;
 		const Int adjacent[5] = {0, 1, 2, 3, 0};
-		Bool neighborFlags[8] = {false, false, false, false, false, false, false, false};
+		Bool neighborFlags[8] = { 0 };
 
 		UnsignedInt newCostSoFar = 0;
 
@@ -7196,7 +7196,7 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 		ICoord2D newCellCoord;
 		PathfindCell *newCell;
 		const Int adjacent[5] = {0, 1, 2, 3, 0};
-		Bool neighborFlags[8] = {false, false, false, false, false, false, false, false};
+		Bool neighborFlags[8] = { 0 };
 
 		// TheSuperHackers @fix Mauller 23/05/2025 Fixes uninitialized variable.
 		// To keep retail compatibility it needs to be uninitialized in VC6 builds.
@@ -8324,7 +8324,7 @@ Bool Pathfinder::pathDestination( 	Object *obj, const LocomotorSet& locomotorSet
 		ICoord2D newCellCoord;
 		PathfindCell *newCell;
 		const Int adjacent[5] = {0, 1, 2, 3, 0};
-		Bool neighborFlags[8] = {false, false, false, false, false, false, false, false};
+		Bool neighborFlags[8] = { 0 };
 
 		UnsignedInt newCostSoFar = 0;
 
@@ -8577,7 +8577,7 @@ Int Pathfinder::checkPathCost(Object *obj, const LocomotorSet& locomotorSet, con
 		ICoord2D newCellCoord;
 		PathfindCell *newCell;
 		const Int adjacent[5] = {0, 1, 2, 3, 0};
-		Bool neighborFlags[8] = {false, false, false, false, false, false, false, false};
+		Bool neighborFlags[8] = { 0 };
 
 		UnsignedInt newCostSoFar = 0;
 


### PR DESCRIPTION
Followup for #904

I found a way to initialize newCostSoFar in `Pathfinder::findGroundPath` without breaking compat. Because the variable is used in a loop, it stays the same when it is not assigned. Moving the variable up one scope in VC6 allows us to initialize it properly. This can, at least theoretically, fix mismatches.

This PR also initializes some more variables in the same file. Those variables don't seem to be used before assigning to them, but better safe than sorry.

## TODO

- [x] Replicate in Generals