### PR TITLE
[CORE] Fix bugs in comparison expression in OBBoxClass

### DIFF
--- a/Core/Libraries/Source/WWVegas/WWMath/obbox.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/obbox.h
@@ -265,7 +265,7 @@ inline bool OBBoxClass::operator== (const OBBoxClass &src)
  *=============================================================================================*/
 inline bool OBBoxClass::operator!= (const OBBoxClass &src)
 {
-	return (Center != src.Center) || (Extent != src.Extent) && (Basis == src.Basis);
+	return (Center != src.Center) || (Extent != src.Extent) || (Basis != src.Basis);
 }
 
 #endif


### PR DESCRIPTION
https://github.com/TheSuperHackers/GeneralsGameCode/blob/92ea8b3c4407430f3cf47b557714605924b93c5a/Core/Libraries/Source/WWVegas/WWMath/obbox.h#L248-L251

https://github.com/TheSuperHackers/GeneralsGameCode/blob/92ea8b3c4407430f3cf47b557714605924b93c5a/Core/Libraries/Source/WWVegas/WWMath/obbox.h#L266-L269

`operator!=` is not the inverted version of `operator==`, but it should be.