### PR TITLE
[GEN][ZH] Refactor logical expression in SelectionTranslator::translateGameMessage()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
@@ -929,9 +929,7 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 			delta.y = m_deselectFeedbackAnchor.y - pixel.y;
 
 			Bool isClick = TRUE;
-			if (isClick && 
-					abs(delta.x) > TheMouse->m_dragTolerance || 
-					abs(delta.y) > TheMouse->m_dragTolerance)
+			if (abs(delta.x) > TheMouse->m_dragTolerance || abs(delta.y) > TheMouse->m_dragTolerance)
 			{
 				isClick = FALSE;
 			}

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
@@ -1004,9 +1004,7 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 			delta.y = m_deselectFeedbackAnchor.y - pixel.y;
 
 			Bool isClick = TRUE;
-			if (isClick && 
-					abs(delta.x) > TheMouse->m_dragTolerance || 
-					abs(delta.y) > TheMouse->m_dragTolerance)
+			if (abs(delta.x) > TheMouse->m_dragTolerance || abs(delta.y) > TheMouse->m_dragTolerance)
 			{
 				isClick = FALSE;
 			}


### PR DESCRIPTION
`if (isClick && abs(delta.x) > TheMouse->m_dragTolerance || abs(delta.y) > TheMouse->m_dragTolerance)` 
is a bug due to AND / OR operator precedence.