### PR TITLE
[ZH] Refactor logical expression in AcademyStats::init()

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/AcademyStats.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/AcademyStats.cpp
@@ -115,9 +115,9 @@ void AcademyStats::init( const Player *player )
 	const PlayerTemplate *plyrTemplate = player->getPlayerTemplate();
 
 	if( !plyrTemplate ||
-			plyrTemplate->getBaseSide().compareNoCase( "USA" ) &&
+			( plyrTemplate->getBaseSide().compareNoCase( "USA" ) &&
 			plyrTemplate->getBaseSide().compareNoCase( "China" ) &&
-			plyrTemplate->getBaseSide().compareNoCase( "GLA" ) )
+			plyrTemplate->getBaseSide().compareNoCase( "GLA" ) ) )
 	{
 		//Admittedly, this is a massive violation of data driven design. Shame on me!
 		//Unknown side... don't provide ANY advice. Simplicity reasons.


### PR DESCRIPTION
https://github.com/TheSuperHackers/GeneralsGameCode/blob/92ea8b3c4407430f3cf47b557714605924b93c5a/GeneralsMD/Code/GameEngine/Source/Common/RTS/AcademyStats.cpp#L115-L121

This is a bug because `plyrTemplate->getBaseSide()` may be accessed without checking if `plyrTemplate != NULL`.