### PR TITLE
[CORE][GEN][ZH] Add missing virtual destructors for virtual classes

### DIFF
--- a/Core/Libraries/Source/WWVegas/WWDownload/Download.h
+++ b/Core/Libraries/Source/WWVegas/WWDownload/Download.h
@@ -64,7 +64,7 @@ public:
 			m_predictionTimes[i] = 0;
 		}
 	}
-	~CDownload() { delete m_Ftp; }
+	virtual ~CDownload() { delete m_Ftp; }
 
 public:
 	virtual HRESULT PumpMessages();

--- a/Core/Libraries/Source/profile/internal_result.h
+++ b/Core/Libraries/Source/profile/internal_result.h
@@ -36,6 +36,7 @@
 class ProfileResultFileCSV: public ProfileResultInterface
 {
   ProfileResultFileCSV(void) {}
+  virtual ~ProfileResultFileCSV() {}
 
   void WriteThread(ProfileFuncLevel::Thread &thread);
   
@@ -84,6 +85,7 @@ public:
 private:
 
   ProfileResultFileDOT(const char *fileName, const char *frameName, int foldThreshold);
+  virtual ~ProfileResultFileDOT() {}
 
   struct FoldHelper
   {

--- a/Generals/Code/GameEngine/Include/GameClient/CampaignManager.h
+++ b/Generals/Code/GameEngine/Include/GameClient/CampaignManager.h
@@ -114,7 +114,7 @@ class CampaignManager : public Snapshot
 {
 public:
 	CampaignManager( void );
-	~CampaignManager( void );
+	virtual ~CampaignManager( void );
 
 	// snapshot methods
 	virtual void crc( Xfer *xfer ) { }

--- a/Generals/Code/GameEngine/Include/GameLogic/AI.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AI.h
@@ -136,7 +136,7 @@ class TAiData : public Snapshot
 {
 public:
 	TAiData();
-	~TAiData();
+	virtual ~TAiData();
 
 	void addSideInfo(AISideInfo *info);
 	void addFactionBuildList(AISideBuildList *buildList);

--- a/Generals/Code/GameEngine/Include/GameLogic/AIPathfind.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AIPathfind.h
@@ -608,7 +608,7 @@ private:
 
 public:
 	Pathfinder( void );
-	~Pathfinder() ;
+	virtual ~Pathfinder();
 
 	void reset( void );														///< Reset system in preparation for new map
 

--- a/Generals/Code/GameEngine/Include/GameNetwork/ConnectionManager.h
+++ b/Generals/Code/GameEngine/Include/GameNetwork/ConnectionManager.h
@@ -51,7 +51,7 @@ class ConnectionManager
 {
 public:
 	ConnectionManager();
-	~ConnectionManager();
+	virtual ~ConnectionManager();
 
 	virtual void init();				///< Initialize this instance.
 	virtual void reset();				///< Take this instance back to the initial state.

--- a/Generals/Code/GameEngine/Include/GameNetwork/GameInfo.h
+++ b/Generals/Code/GameEngine/Include/GameNetwork/GameInfo.h
@@ -281,6 +281,7 @@ public:
 		for (Int i = 0; i< MAX_SLOTS; ++i)
 			setSlotPointer(i, &m_skirmishSlot[i]);
 	}
+	virtual ~SkirmishGameInfo(){}
 };
 
 extern SkirmishGameInfo *TheSkirmishGameInfo;

--- a/Generals/Code/GameEngine/Include/GameNetwork/GameSpy/StagingRoomGameInfo.h
+++ b/Generals/Code/GameEngine/Include/GameNetwork/GameSpy/StagingRoomGameInfo.h
@@ -99,6 +99,7 @@ private:
 
 public:
 	GameSpyStagingRoom();
+	virtual ~GameSpyStagingRoom(){}
 	virtual void reset( void );
 
 	void cleanUpSlotPointers(void);

--- a/Generals/Code/GameEngine/Include/GameNetwork/LANGameInfo.h
+++ b/Generals/Code/GameEngine/Include/GameNetwork/LANGameInfo.h
@@ -82,6 +82,7 @@ private:
 
 public:
 	LANGameInfo();
+	virtual ~LANGameInfo(){}
 	void setSlot( Int slotNum, LANGameSlot slotInfo );	///< Set the slot state (human, open, AI, etc)
 	LANGameSlot* getLANSlot( Int slotNum );							///< Get the slot
 	const LANGameSlot* getConstLANSlot( Int slotNum ) const;							///< Get the slot

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DProjectedShadow.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DProjectedShadow.h
@@ -99,7 +99,7 @@ class W3DProjectedShadow	: public Shadow
 
 	public:
 		W3DProjectedShadow(void);
-		~W3DProjectedShadow(void);
+		virtual ~W3DProjectedShadow(void);
 		void setRenderObject( RenderObjClass	*robj) {m_robj=robj;}
 		void setObjPosHistory(const Vector3 &pos)	{m_lastObjPosition=pos;}	///<position of object when projection matrix was updated.
 		void setTexture(Int lightIndex,W3DShadowTexture *texture)	{m_shadowTexture[lightIndex]=texture;}	///<textur with light's shadow

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DVolumetricShadow.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DVolumetricShadow.h
@@ -102,7 +102,7 @@ class W3DVolumetricShadow	: public Shadow
 	public:
 
 		W3DVolumetricShadow( void );
-		~W3DVolumetricShadow( void );
+		virtual ~W3DVolumetricShadow( void );
 
 	protected:
 

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DWaterTracks.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DWaterTracks.h
@@ -42,7 +42,7 @@ class WaterTracksObj
 public:
 
 	WaterTracksObj(void);
-	~WaterTracksObj(void);
+	virtual ~WaterTracksObj(void);
 
 	virtual void					Render(void) {};	///<draw this object
 	virtual void					Get_Obj_Space_Bounding_Sphere(SphereClass & sphere) const;	///<bounding sphere of this object

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameLogic/W3DGhostObject.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameLogic/W3DGhostObject.cpp
@@ -64,7 +64,7 @@ class W3DRenderObjectSnapshot : public Snapshot
 	friend W3DGhostObject;
 
 	W3DRenderObjectSnapshot(RenderObjClass *m_parentRobj, DrawableInfo *drawInfo, Bool cloneParentRobj = TRUE);
-	~W3DRenderObjectSnapshot() {REF_PTR_RELEASE(m_robj);}
+	virtual ~W3DRenderObjectSnapshot() {REF_PTR_RELEASE(m_robj);}
 	inline void update(RenderObjClass *robj, DrawableInfo *drawInfo, Bool cloneParentRobj=TRUE);	///<refresh the current snapshot with latest state
 	inline void addToScene(void);	///< add this fogged renderobject to the scene.
 protected:

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/CampaignManager.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/CampaignManager.h
@@ -118,7 +118,7 @@ class CampaignManager : public Snapshot
 {
 public:
 	CampaignManager( void );
-	~CampaignManager( void );
+	virtual ~CampaignManager( void );
 
 	// snapshot methods
 	virtual void crc( Xfer *xfer ) { }

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
@@ -137,7 +137,7 @@ class TAiData : public Snapshot
 {
 public:
 	TAiData();
-	~TAiData();
+	virtual ~TAiData();
 
 	void addSideInfo(AISideInfo *info);
 	void addFactionBuildList(AISideBuildList *buildList);

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AIPathfind.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AIPathfind.h
@@ -615,7 +615,7 @@ private:
 
 public:
 	Pathfinder( void );
-	~Pathfinder() ;
+	virtual ~Pathfinder();
 
 	void reset( void );														///< Reset system in preparation for new map
 

--- a/GeneralsMD/Code/GameEngine/Include/GameNetwork/ConnectionManager.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameNetwork/ConnectionManager.h
@@ -51,7 +51,7 @@ class ConnectionManager
 {
 public:
 	ConnectionManager();
-	~ConnectionManager();
+	virtual ~ConnectionManager();
 
 	virtual void init();				///< Initialize this instance.
 	virtual void reset();				///< Take this instance back to the initial state.

--- a/GeneralsMD/Code/GameEngine/Include/GameNetwork/GameInfo.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameNetwork/GameInfo.h
@@ -302,6 +302,7 @@ public:
 		for (Int i = 0; i< MAX_SLOTS; ++i)
 			setSlotPointer(i, &m_skirmishSlot[i]);
 	}
+	virtual ~SkirmishGameInfo(){}
 };
 
 extern SkirmishGameInfo *TheSkirmishGameInfo;

--- a/GeneralsMD/Code/GameEngine/Include/GameNetwork/GameSpy/StagingRoomGameInfo.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameNetwork/GameSpy/StagingRoomGameInfo.h
@@ -99,6 +99,7 @@ private:
 
 public:
 	GameSpyStagingRoom();
+	virtual ~GameSpyStagingRoom(){}
 	virtual void reset( void );
 
 	void cleanUpSlotPointers(void);

--- a/GeneralsMD/Code/GameEngine/Include/GameNetwork/LANGameInfo.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameNetwork/LANGameInfo.h
@@ -82,6 +82,7 @@ private:
 
 public:
 	LANGameInfo();
+	virtual ~LANGameInfo(){}
 	void setSlot( Int slotNum, LANGameSlot slotInfo );	///< Set the slot state (human, open, AI, etc)
 	LANGameSlot* getLANSlot( Int slotNum );							///< Get the slot
 	const LANGameSlot* getConstLANSlot( Int slotNum ) const;							///< Get the slot

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DProjectedShadow.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DProjectedShadow.h
@@ -99,7 +99,7 @@ class W3DProjectedShadow	: public Shadow
 
 	public:
 		W3DProjectedShadow(void);
-		~W3DProjectedShadow(void);
+		virtual ~W3DProjectedShadow(void);
 		void setRenderObject( RenderObjClass	*robj) {m_robj=robj;}
 		void setObjPosHistory(const Vector3 &pos)	{m_lastObjPosition=pos;}	///<position of object when projection matrix was updated.
 		void setTexture(Int lightIndex,W3DShadowTexture *texture)	{m_shadowTexture[lightIndex]=texture;}	///<textur with light's shadow

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DPropBuffer.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DPropBuffer.h
@@ -101,7 +101,7 @@ friend class BaseHeightMapRenderObjClass;
 public:
 
 	W3DPropBuffer(void);
-	~W3DPropBuffer(void);
+	virtual ~W3DPropBuffer(void);
 	/// Add a prop at location.  Name is the w3d model name.
 	void addProp(Int id, Coord3D location, Real angle, Real scale, const AsciiString &modelName);
 	/// Remove a prop.

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DTreeBuffer.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DTreeBuffer.h
@@ -171,7 +171,7 @@ public:
 public:
  
 	W3DTreeBuffer(void);
-	~W3DTreeBuffer(void); 
+	virtual ~W3DTreeBuffer(void); 
 	/// Add a tree at location.  Name is the w3d model name.
 	void addTree(DrawableID id, Coord3D location, Real scale, Real angle,
 								Real randomScaleAmount, const W3DTreeDrawModuleData *data);

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DVolumetricShadow.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DVolumetricShadow.h
@@ -102,7 +102,7 @@ class W3DVolumetricShadow	: public Shadow
 	public:
 
 		W3DVolumetricShadow( void );
-		~W3DVolumetricShadow( void );
+		virtual ~W3DVolumetricShadow( void );
 
 	protected:
 

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DWaterTracks.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DWaterTracks.h
@@ -42,7 +42,7 @@ class WaterTracksObj
 public:
 
 	WaterTracksObj(void);
-	~WaterTracksObj(void);
+	virtual ~WaterTracksObj(void);
 
 	virtual void					Render(void) {};	///<draw this object
 	virtual void					Get_Obj_Space_Bounding_Sphere(SphereClass & sphere) const;	///<bounding sphere of this object

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameLogic/W3DGhostObject.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameLogic/W3DGhostObject.cpp
@@ -64,7 +64,7 @@ class W3DRenderObjectSnapshot : public Snapshot
 	friend W3DGhostObject;
 
 	W3DRenderObjectSnapshot(RenderObjClass *m_parentRobj, DrawableInfo *drawInfo, Bool cloneParentRobj = TRUE);
-	~W3DRenderObjectSnapshot() {REF_PTR_RELEASE(m_robj);}
+	virtual ~W3DRenderObjectSnapshot() {REF_PTR_RELEASE(m_robj);}
 	inline void update(RenderObjClass *robj, DrawableInfo *drawInfo, Bool cloneParentRobj=TRUE);	///<refresh the current snapshot with latest state
 	inline void addToScene(void);	///< add this fogged renderobject to the scene.
 protected:

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/textureloader.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/textureloader.h
@@ -207,7 +207,7 @@ class TextureLoadTaskClass : public TextureLoadTaskListNodeClass
 
 
 		TextureLoadTaskClass(void);
-		~TextureLoadTaskClass(void);
+		virtual ~TextureLoadTaskClass(void);
 
 		static TextureLoadTaskClass *	Create			(TextureBaseClass *tc, TaskType type, PriorityType priority);
 		static void				Delete_Free_Pool			(void);


### PR DESCRIPTION
Some virtual classes have no virtual destructor, which leads to compiler warnings when an object of such a class is manually deleted:
`delete called on non-final 'Class' that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]`
`destructor called on non-final 'Class' that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]`

If it helps with the review process, I could provide a list with class name + filename + line number where the delete happens. I can also provide that in the form of an url.