### PR TITLE
[ZH] Set correct fake CRC for Zero Hour CD 1.04

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -992,9 +992,9 @@ GlobalData::GlobalData()
 	// Simulate the EXE's CRC value to force Network and Replay compatibility with another build.
 #if (defined(_MSC_VER) && _MSC_VER < 1300) && RETAIL_COMPATIBLE_CRC
 
-#define GENERALS_108_CD_EXE_CRC    0x93d1eab4
-#define GENERALS_108_STEAM_EXE_CRC 0x8d6e4dd7
-#define GENERALS_108_EAAPP_EXE_CRC 0xb07fbd50
+#define GENERALS_108_CD_EXE_CRC    0x93d1eab4u
+#define GENERALS_108_STEAM_EXE_CRC 0x8d6e4dd7u
+#define GENERALS_108_EAAPP_EXE_CRC 0xb07fbd50u
 
 	exeCRC.set(GENERALS_108_CD_EXE_CRC);
 	DEBUG_LOG(("Fake EXE CRC is 0x%8.8X\n", exeCRC.get()));

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -1001,9 +1001,9 @@ GlobalData::GlobalData()
 	// Simulate the EXE's CRC value to force Network and Replay compatibility with another build.
 #if (defined(_MSC_VER) && _MSC_VER < 1300) && RETAIL_COMPATIBLE_CRC
 
-#define GENERALSMD_104_CD_EXE_CRC    0x4f6c5afe
-#define GENERALSMD_104_STEAM_EXE_CRC 0xcb430f5f
-#define GENERALSMD_104_EAAPP_EXE_CRC 0x488d90f9
+#define GENERALSMD_104_CD_EXE_CRC    0x3b6fb2cfu
+#define GENERALSMD_104_STEAM_EXE_CRC 0xf6a4221bu
+#define GENERALSMD_104_EAAPP_EXE_CRC 0xc4181eb9u
 
 	exeCRC.set(GENERALSMD_104_CD_EXE_CRC);
 	DEBUG_LOG(("Fake EXE CRC is 0x%8.8X\n", exeCRC.get()));


### PR DESCRIPTION
* Follow up for #965

This change sets the correct fake CRC value for Zero Hour CD 1.04 (and the other unused ones). Unclear why I had these wrong. The ones for Generals are correct.