### PR TITLE
[GEN][ZH] Change TheGlobalData macro to variable in debug mode for debugging convenience

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/GlobalData.h
+++ b/Generals/Code/GameEngine/Include/Common/GlobalData.h
@@ -542,11 +542,11 @@ private:
 #if defined(_DEBUG) || defined(RTS_DEBUG) || defined(RTS_INTERNAL)
 	static union
 	{
-		GlobalData* TheWritableGlobalData;								///< The global data singleton
-		const GlobalData* TheGlobalData;								///< Const shorthand for above singleton
+		GlobalData* TheWritableGlobalData;				///< The global data singleton
+		const GlobalData* TheGlobalData;				///< Const shorthand for above singleton
 	};
 #else
-	inline GlobalData* TheWritableGlobalData = NULL;					///< The global data singleton
+	extern GlobalData* TheWritableGlobalData;			///< The global data singleton
 	#define TheGlobalData ((const GlobalData*)TheWritableGlobalData)	///< Const shorthand for above singleton
 #endif
 

--- a/Generals/Code/GameEngine/Include/Common/GlobalData.h
+++ b/Generals/Code/GameEngine/Include/Common/GlobalData.h
@@ -539,13 +539,15 @@ private:
 
 };
 
-// singleton
-extern GlobalData* TheWritableGlobalData;
-
 #if defined(_DEBUG) || defined(RTS_DEBUG) || defined(RTS_INTERNAL)
-	extern const GlobalData* TheGlobalData;
+	static union
+	{
+		GlobalData* TheWritableGlobalData = NULL;						///< The global data singleton
+		const GlobalData* TheGlobalData;								///< Const shorthand for above singleton
+	};
 #else
-	#define TheGlobalData ((const GlobalData*)TheWritableGlobalData)
+	inline GlobalData* TheWritableGlobalData = NULL;					///< The global data singleton
+	#define TheGlobalData ((const GlobalData*)TheWritableGlobalData)	///< Const shorthand for above singleton
 #endif
 
 #endif

--- a/Generals/Code/GameEngine/Include/Common/GlobalData.h
+++ b/Generals/Code/GameEngine/Include/Common/GlobalData.h
@@ -542,6 +542,10 @@ private:
 // singleton
 extern GlobalData* TheWritableGlobalData;
 
-#define TheGlobalData ((const GlobalData*)TheWritableGlobalData)
+#if defined(_DEBUG) || defined(RTS_DEBUG) || defined(RTS_INTERNAL)
+	extern const GlobalData* TheGlobalData;
+#else
+	#define TheGlobalData ((const GlobalData*)TheWritableGlobalData)
+#endif
 
 #endif

--- a/Generals/Code/GameEngine/Include/Common/GlobalData.h
+++ b/Generals/Code/GameEngine/Include/Common/GlobalData.h
@@ -542,7 +542,7 @@ private:
 #if defined(_DEBUG) || defined(RTS_DEBUG) || defined(RTS_INTERNAL)
 	static union
 	{
-		GlobalData* TheWritableGlobalData = NULL;						///< The global data singleton
+		GlobalData* TheWritableGlobalData;								///< The global data singleton
 		const GlobalData* TheGlobalData;								///< Const shorthand for above singleton
 	};
 #else

--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -57,6 +57,9 @@
 
 // PUBLIC DATA ////////////////////////////////////////////////////////////////////////////////////
 GlobalData* TheWritableGlobalData = NULL;				///< The global data singleton
+#if defined(_DEBUG) || defined(RTS_DEBUG) || defined(RTS_INTERNAL)
+	const GlobalData* TheGlobalData = NULL;
+#endif
 
 //-------------------------------------------------------------------------------------------------
 GlobalData* GlobalData::m_theOriginal = NULL;
@@ -1086,6 +1089,10 @@ GlobalData::~GlobalData( void )
 	if( m_theOriginal == this )	{
 		m_theOriginal = NULL;
 		TheWritableGlobalData = NULL;
+
+#if defined(_DEBUG) || defined(RTS_DEBUG) || defined(RTS_INTERNAL)
+		TheGlobalData = TheWritableGlobalData;
+#endif
 	}
 
 }  // end ~GlobalData
@@ -1134,6 +1141,10 @@ GlobalData *GlobalData::newOverride( void )
 	// set this new instance as the 'most current override' where we will access all data from
 	TheWritableGlobalData = override;
 
+#if defined(_DEBUG) || defined(RTS_DEBUG) || defined(RTS_INTERNAL)
+	TheGlobalData = TheWritableGlobalData;
+#endif
+
 	return override;
 
 }  // end newOveride
@@ -1170,6 +1181,10 @@ void GlobalData::reset( void )
 
 	}  // end while
 
+#if defined(_DEBUG) || defined(RTS_DEBUG) || defined(RTS_INTERNAL)
+	TheGlobalData = TheWritableGlobalData;
+#endif
+
 	//
 	// we now have the one single global data in TheWritableGlobalData singleton, lets sanity check
 	// some of all that
@@ -1203,6 +1218,10 @@ void GlobalData::parseGameDataDefinition( INI* ini )
 
 	}  // end else
 	// If we're multifile, then continue loading stuff into the Global Data as normal.
+
+#if defined(_DEBUG) || defined(RTS_DEBUG) || defined(RTS_INTERNAL)
+	TheGlobalData = TheWritableGlobalData;
+#endif
 
 	// parse the ini weapon definition
 	ini->initFromINI( TheWritableGlobalData, s_GlobalDataFieldParseTable );

--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -56,12 +56,6 @@
 #include "GameNetwork/FirewallHelper.h"
 
 // PUBLIC DATA ////////////////////////////////////////////////////////////////////////////////////
-GlobalData* TheWritableGlobalData = NULL;				///< The global data singleton
-#if defined(_DEBUG) || defined(RTS_DEBUG) || defined(RTS_INTERNAL)
-	const GlobalData* TheGlobalData = NULL;
-#endif
-
-//-------------------------------------------------------------------------------------------------
 GlobalData* GlobalData::m_theOriginal = NULL;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1090,9 +1084,6 @@ GlobalData::~GlobalData( void )
 		m_theOriginal = NULL;
 		TheWritableGlobalData = NULL;
 
-#if defined(_DEBUG) || defined(RTS_DEBUG) || defined(RTS_INTERNAL)
-		TheGlobalData = TheWritableGlobalData;
-#endif
 	}
 
 }  // end ~GlobalData
@@ -1141,10 +1132,6 @@ GlobalData *GlobalData::newOverride( void )
 	// set this new instance as the 'most current override' where we will access all data from
 	TheWritableGlobalData = override;
 
-#if defined(_DEBUG) || defined(RTS_DEBUG) || defined(RTS_INTERNAL)
-	TheGlobalData = TheWritableGlobalData;
-#endif
-
 	return override;
 
 }  // end newOveride
@@ -1181,10 +1168,6 @@ void GlobalData::reset( void )
 
 	}  // end while
 
-#if defined(_DEBUG) || defined(RTS_DEBUG) || defined(RTS_INTERNAL)
-	TheGlobalData = TheWritableGlobalData;
-#endif
-
 	//
 	// we now have the one single global data in TheWritableGlobalData singleton, lets sanity check
 	// some of all that
@@ -1218,10 +1201,6 @@ void GlobalData::parseGameDataDefinition( INI* ini )
 
 	}  // end else
 	// If we're multifile, then continue loading stuff into the Global Data as normal.
-
-#if defined(_DEBUG) || defined(RTS_DEBUG) || defined(RTS_INTERNAL)
-	TheGlobalData = TheWritableGlobalData;
-#endif
 
 	// parse the ini weapon definition
 	ini->initFromINI( TheWritableGlobalData, s_GlobalDataFieldParseTable );

--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -56,6 +56,11 @@
 #include "GameNetwork/FirewallHelper.h"
 
 // PUBLIC DATA ////////////////////////////////////////////////////////////////////////////////////
+#if !defined(_DEBUG) && !defined(RTS_DEBUG) && !defined(RTS_INTERNAL)
+	GlobalData* TheWritableGlobalData = NULL;				///< The global data singleton
+#endif
+
+//-------------------------------------------------------------------------------------------------
 GlobalData* GlobalData::m_theOriginal = NULL;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -1083,7 +1083,6 @@ GlobalData::~GlobalData( void )
 	if( m_theOriginal == this )	{
 		m_theOriginal = NULL;
 		TheWritableGlobalData = NULL;
-
 	}
 
 }  // end ~GlobalData

--- a/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
@@ -555,6 +555,10 @@ private:
 // singleton
 extern GlobalData* TheWritableGlobalData;
 
-#define TheGlobalData ((const GlobalData*)TheWritableGlobalData)
+#if defined(_DEBUG) || defined(RTS_DEBUG) || defined(RTS_INTERNAL)
+	extern const GlobalData* TheGlobalData;
+#else
+	#define TheGlobalData ((const GlobalData*)TheWritableGlobalData)
+#endif
 
 #endif

--- a/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
@@ -555,7 +555,7 @@ private:
 #if defined(_DEBUG) || defined(RTS_DEBUG) || defined(RTS_INTERNAL)
 	static union
 	{
-		GlobalData* TheWritableGlobalData = NULL;						///< The global data singleton
+		GlobalData* TheWritableGlobalData;								///< The global data singleton
 		const GlobalData* TheGlobalData;								///< Const shorthand for above singleton
 	};
 #else

--- a/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
@@ -552,13 +552,15 @@ private:
 
 };
 
-// singleton
-extern GlobalData* TheWritableGlobalData;
-
 #if defined(_DEBUG) || defined(RTS_DEBUG) || defined(RTS_INTERNAL)
-	extern const GlobalData* TheGlobalData;
+	static union
+	{
+		GlobalData* TheWritableGlobalData = NULL;						///< The global data singleton
+		const GlobalData* TheGlobalData;								///< Const shorthand for above singleton
+	};
 #else
-	#define TheGlobalData ((const GlobalData*)TheWritableGlobalData)
+	inline GlobalData* TheWritableGlobalData = NULL;					///< The global data singleton
+	#define TheGlobalData ((const GlobalData*)TheWritableGlobalData)	///< Const shorthand for above singleton
 #endif
 
 #endif

--- a/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
@@ -555,11 +555,11 @@ private:
 #if defined(_DEBUG) || defined(RTS_DEBUG) || defined(RTS_INTERNAL)
 	static union
 	{
-		GlobalData* TheWritableGlobalData;								///< The global data singleton
-		const GlobalData* TheGlobalData;								///< Const shorthand for above singleton
+		GlobalData* TheWritableGlobalData;				///< The global data singleton
+		const GlobalData* TheGlobalData;				///< Const shorthand for above singleton
 	};
 #else
-	inline GlobalData* TheWritableGlobalData = NULL;					///< The global data singleton
+	extern GlobalData* TheWritableGlobalData;			///< The global data singleton
 	#define TheGlobalData ((const GlobalData*)TheWritableGlobalData)	///< Const shorthand for above singleton
 #endif
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -57,6 +57,11 @@
 #include "GameNetwork/FirewallHelper.h"
 
 // PUBLIC DATA ////////////////////////////////////////////////////////////////////////////////////
+#if !defined(_DEBUG) && !defined(RTS_DEBUG) && !defined(RTS_INTERNAL)
+	GlobalData* TheWritableGlobalData = NULL;				///< The global data singleton
+#endif
+
+//-------------------------------------------------------------------------------------------------
 GlobalData* GlobalData::m_theOriginal = NULL;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -58,6 +58,9 @@
 
 // PUBLIC DATA ////////////////////////////////////////////////////////////////////////////////////
 GlobalData* TheWritableGlobalData = NULL;				///< The global data singleton
+#if defined(_DEBUG) || defined(RTS_DEBUG) || defined(RTS_INTERNAL)
+	const GlobalData* TheGlobalData = NULL;
+#endif
 
 //-------------------------------------------------------------------------------------------------
 GlobalData* GlobalData::m_theOriginal = NULL;
@@ -1124,6 +1127,10 @@ GlobalData::~GlobalData( void )
 	if( m_theOriginal == this )	{
 		m_theOriginal = NULL;
 		TheWritableGlobalData = NULL;
+
+#if defined(_DEBUG) || defined(RTS_DEBUG) || defined(RTS_INTERNAL)
+		TheGlobalData = TheWritableGlobalData;
+#endif
 	}
 
 }  // end ~GlobalData
@@ -1172,6 +1179,10 @@ GlobalData *GlobalData::newOverride( void )
 	// set this new instance as the 'most current override' where we will access all data from
 	TheWritableGlobalData = override;
 
+#if defined(_DEBUG) || defined(RTS_DEBUG) || defined(RTS_INTERNAL)
+	TheGlobalData = TheWritableGlobalData;
+#endif
+
 	return override;
 
 }  // end newOveride
@@ -1208,6 +1219,10 @@ void GlobalData::reset( void )
 
 	}  // end while
 
+#if defined(_DEBUG) || defined(RTS_DEBUG) || defined(RTS_INTERNAL)
+	TheGlobalData = TheWritableGlobalData;
+#endif
+
 	//
 	// we now have the one single global data in TheWritableGlobalData singleton, lets sanity check
 	// some of all that
@@ -1241,6 +1256,10 @@ void GlobalData::parseGameDataDefinition( INI* ini )
 
 	}  // end else
 	// If we're multifile, then continue loading stuff into the Global Data as normal.
+
+#if defined(_DEBUG) || defined(RTS_DEBUG) || defined(RTS_INTERNAL)
+	TheGlobalData = TheWritableGlobalData;
+#endif
 
 	// parse the ini weapon definition
 	ini->initFromINI( TheWritableGlobalData, s_GlobalDataFieldParseTable );

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -57,12 +57,6 @@
 #include "GameNetwork/FirewallHelper.h"
 
 // PUBLIC DATA ////////////////////////////////////////////////////////////////////////////////////
-GlobalData* TheWritableGlobalData = NULL;				///< The global data singleton
-#if defined(_DEBUG) || defined(RTS_DEBUG) || defined(RTS_INTERNAL)
-	const GlobalData* TheGlobalData = NULL;
-#endif
-
-//-------------------------------------------------------------------------------------------------
 GlobalData* GlobalData::m_theOriginal = NULL;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1127,10 +1121,6 @@ GlobalData::~GlobalData( void )
 	if( m_theOriginal == this )	{
 		m_theOriginal = NULL;
 		TheWritableGlobalData = NULL;
-
-#if defined(_DEBUG) || defined(RTS_DEBUG) || defined(RTS_INTERNAL)
-		TheGlobalData = TheWritableGlobalData;
-#endif
 	}
 
 }  // end ~GlobalData
@@ -1179,10 +1169,6 @@ GlobalData *GlobalData::newOverride( void )
 	// set this new instance as the 'most current override' where we will access all data from
 	TheWritableGlobalData = override;
 
-#if defined(_DEBUG) || defined(RTS_DEBUG) || defined(RTS_INTERNAL)
-	TheGlobalData = TheWritableGlobalData;
-#endif
-
 	return override;
 
 }  // end newOveride
@@ -1219,10 +1205,6 @@ void GlobalData::reset( void )
 
 	}  // end while
 
-#if defined(_DEBUG) || defined(RTS_DEBUG) || defined(RTS_INTERNAL)
-	TheGlobalData = TheWritableGlobalData;
-#endif
-
 	//
 	// we now have the one single global data in TheWritableGlobalData singleton, lets sanity check
 	// some of all that
@@ -1256,10 +1238,6 @@ void GlobalData::parseGameDataDefinition( INI* ini )
 
 	}  // end else
 	// If we're multifile, then continue loading stuff into the Global Data as normal.
-
-#if defined(_DEBUG) || defined(RTS_DEBUG) || defined(RTS_INTERNAL)
-	TheGlobalData = TheWritableGlobalData;
-#endif
 
 	// parse the ini weapon definition
 	ini->initFromINI( TheWritableGlobalData, s_GlobalDataFieldParseTable );


### PR DESCRIPTION
> Preprocessor macros aren't supported in the debugger. For instance, if a constant VALUE is declared as: #define VALUE 3, you can't use VALUE in the Watch window.

The value of a macro cannot be inspected with the VS22 debugger: https://learn.microsoft.com/en-us/visualstudio/debugger/expressions-in-the-debugger

 This PR makes it more convenient to see the values of the `TheGlobalData` macro when `_DEBUG`, `RTS_DEBUG` or `RTS_INTERNAL` is defined. ~~The second pointer should not be used in release mode because of the potential for missed optimizations.~~ (not relevant for the version with `static union`)