### PR TITLE
[GEN][ZH] Fix incorrect default Resolution selection in the Options Menu when the loaded Resolution does not match the active Display Resolution

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -1586,7 +1586,7 @@ void OptionsMenuInit( WindowLayout *layout, void *userData )
 		TheDisplay->getDisplayModeDescription(i,&xres,&yres,&bitDepth);
 		str.format(L"%d x %d",xres,yres);
 		GadgetComboBoxAddEntry( comboBoxResolution, str, color);
-		// TheSuperHackers @fix xezon 12/06/2025 Now makes a selection with the active display resolution
+		// TheSuperHackers @bugfix xezon 12/06/2025 Now makes a selection with the active display resolution
 		// instead of the resolution read from the Option Preferences, because the active display resolution
 		// is the most relevant to make a selection with and the Option Preferences could be wrong.
 		if ( xres == displayWidth && yres == displayHeight )

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -1652,7 +1652,7 @@ void OptionsMenuInit( WindowLayout *layout, void *userData )
 		TheDisplay->getDisplayModeDescription(i,&xres,&yres,&bitDepth);
 		str.format(L"%d x %d",xres,yres);
 		GadgetComboBoxAddEntry( comboBoxResolution, str, color);
-		// TheSuperHackers @fix xezon 12/06/2025 Now makes a selection with the active display resolution
+		// TheSuperHackers @bugfix xezon 12/06/2025 Now makes a selection with the active display resolution
 		// instead of the resolution read from the Option Preferences, because the active display resolution
 		// is the most relevant to make a selection with and the Option Preferences could be wrong.
 		if ( xres == displayWidth && yres == displayHeight )


### PR DESCRIPTION
* Follow up for #1055

This change fixes the incorrect default Resolution selection in the Options Menu when the loaded Resolution does not match the active Display Resolution.

## Bug before this change

The last entry is a duplicate of the first entry.

![shot_20250612_184010_1](https://github.com/user-attachments/assets/28afb8b4-2ba3-45bb-91ca-81f4b6e1f9b0)
