### PR TITLE
[CORE] Change memory order for std::atomic_flag::test_and_set in FastCriticalSectionClass and ProfileFastCS

### DIFF
--- a/Core/Libraries/Source/WWVegas/WWLib/mutex.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/mutex.h
@@ -184,7 +184,7 @@ public:
       BitSet:
         ;
 #else
-        while (cs.Flag.test_and_set(std::memory_order_acquire)) {
+        while (cs.Flag.test_and_set(std::memory_order_acq_rel)) {
             cs.Flag.wait(true, std::memory_order_relaxed);
         }
 #endif

--- a/Core/Libraries/Source/profile/internal.h
+++ b/Core/Libraries/Source/profile/internal.h
@@ -93,7 +93,7 @@ public:
 
 	void ThreadSafeSetFlag()
 	{
-		while (Flag.test_and_set(std::memory_order_acquire)) {
+		while (Flag.test_and_set(std::memory_order_acq_rel)) {
 			Flag.wait(true, std::memory_order_relaxed);
 		}
 	}


### PR DESCRIPTION
`std::atomic_flag::test_and_set` is an atomic read-modify-write (RMW) operation. I think it makes more sense to use `std::memory_order_acq_rel` instead of `std::memory_order_acquire`, though in my experience x86 doesn't seem particularly sensitive to using the appropriate memory order.