### PR TITLE
[GEN][ZH] Prevent AMD/ATI driver crash on game launch by temporarily unloading and renaming dbghelp.dll

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,6 @@ if((WIN32 OR "${CMAKE_SYSTEM}" MATCHES "Windows") AND ${CMAKE_SIZEOF_VOID_P} EQU
     include(cmake/miles.cmake)
     include(cmake/bink.cmake)
     include(cmake/dx8.cmake)
-    include(cmake/dbghelp.cmake)
 endif()
 
 # Define a dummy stlport target when not on VC6.

--- a/Core/Libraries/Source/WWVegas/WWLib/CMakeLists.txt
+++ b/Core/Libraries/Source/WWVegas/WWLib/CMakeLists.txt
@@ -32,6 +32,10 @@ set(WWLIB_SRC
     #crcstraw.h
     cstraw.cpp
     cstraw.h
+    DbgHelpGuard.cpp
+    DbgHelpGuard.h
+    DbgHelpLoader.cpp
+    DbgHelpLoader.h
     Except.cpp
     Except.h
     FastAllocator.cpp
@@ -66,6 +70,7 @@ set(WWLIB_SRC
     #lzostraw.cpp
     #lzostraw.h
     #lzo_conf.h
+    MallocAllocator.h
     #md5.cpp
     #md5.h
     mempool.h
@@ -98,6 +103,8 @@ set(WWLIB_SRC
     #regexpr.cpp
     #regexpr.h
     #search.h
+    ScopedFileRenamer.cpp
+    ScopedFileRenamer.h
     sharebuf.h
     Signaler.h
     simplevec.h

--- a/Core/Libraries/Source/WWVegas/WWLib/DbgHelpGuard.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/DbgHelpGuard.cpp
@@ -1,0 +1,63 @@
+/*
+**	Command & Conquer Generals Zero Hour(tm)
+**	Copyright 2025 TheSuperHackers
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "DbgHelpGuard.h"
+
+#include "DbgHelpLoader.h"
+
+
+DbgHelpGuard::DbgHelpGuard()
+{
+	deactivate();
+}
+
+DbgHelpGuard::~DbgHelpGuard()
+{
+	reactivate();
+}
+
+void DbgHelpGuard::deactivate()
+{
+	DbgHelpLoader::blockLoad();
+
+	if (DbgHelpLoader::isLoadedFromSystem())
+	{
+		// This is ok. Do nothing.
+	}
+	else if (DbgHelpLoader::isLoaded())
+	{
+		DbgHelpLoader::unload();
+		m_wasLoaded = true;
+		m_dbgHelpRenamer.rename("dbghelp.dll", "dbghelp.dll.bak");
+	}
+	else
+	{
+		m_dbgHelpRenamer.rename("dbghelp.dll", "dbghelp.dll.bak");
+	}
+}
+
+void DbgHelpGuard::reactivate()
+{
+	m_dbgHelpRenamer.revert();
+	DbgHelpLoader::unblockLoad();
+
+	if (m_wasLoaded)
+	{
+		DbgHelpLoader::load();
+	}
+}

--- a/Core/Libraries/Source/WWVegas/WWLib/DbgHelpGuard.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/DbgHelpGuard.h
@@ -1,0 +1,47 @@
+/*
+**	Command & Conquer Generals Zero Hour(tm)
+**	Copyright 2025 TheSuperHackers
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "always.h"
+
+#include "ScopedFileRenamer.h"
+
+
+// This class temporarily unloads dbghelp.dll and prevents it from loading during its lifetime.
+// This helps avoid crashing on boot using recent AMD/ATI drivers, which attempt to load and use
+// dbghelp.dll from the game install directory but are unable to do so correctly because
+// the dbghelp.dll that ships with the game is very old and the AMD/ATI code does not handle
+// that correctly. This workaround is not required if the dbghelp.dll was loaded from the system
+// directory.
+
+class DbgHelpGuard
+{
+public:
+
+	DbgHelpGuard();
+	~DbgHelpGuard();
+
+	void deactivate();
+	void reactivate();
+
+private:
+
+	ScopedFileRenamer m_dbgHelpRenamer;
+	bool m_wasLoaded;
+};

--- a/Core/Libraries/Source/WWVegas/WWLib/DbgHelpLoader.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/DbgHelpLoader.cpp
@@ -1,0 +1,283 @@
+/*
+**	Command & Conquer Generals Zero Hour(tm)
+**	Copyright 2025 TheSuperHackers
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "DbgHelpLoader.h"
+
+
+int DbgHelpLoader::BlockLoadCounter = 0;
+DbgHelpLoader* DbgHelpLoader::Inst = NULL;
+
+DbgHelpLoader::DbgHelpLoader()
+  : m_symInitialize(NULL)
+  , m_symCleanup(NULL)
+  , m_symLoadModule(NULL)
+  , m_symUnloadModule(NULL)
+  , m_symGetModuleBase(NULL)
+  , m_symGetSymFromAddr(NULL)
+  , m_symGetLineFromAddr(NULL)
+  , m_symSetOptions(NULL)
+  , m_symFunctionTableAccess(NULL)
+  , m_stackWalk(NULL)
+  , m_dllModule(HMODULE(0))
+  , m_failed(false)
+  , m_loadedFromSystem(false)
+{
+}
+
+DbgHelpLoader::~DbgHelpLoader()
+{
+}
+
+bool DbgHelpLoader::isLoaded()
+{
+  return Inst != NULL && Inst->m_dllModule != HMODULE(0);
+}
+
+bool DbgHelpLoader::isLoadedFromSystem()
+{
+  return Inst != NULL && Inst->m_loadedFromSystem;
+}
+
+void DbgHelpLoader::blockLoad()
+{
+  ++BlockLoadCounter;
+}
+
+bool DbgHelpLoader::unblockLoad()
+{
+  return --BlockLoadCounter == 0;
+}
+
+bool DbgHelpLoader::load()
+{
+  if (BlockLoadCounter > 0)
+    return false;
+
+  if (Inst == NULL)
+  {
+    // Cannot use new/delete here when this is loaded during game memory initialization.
+    void* p = ::malloc(sizeof(DbgHelpLoader));
+    Inst = new (p) DbgHelpLoader();
+  }
+
+  // Optimization: return early if it failed before.
+  if (Inst->m_failed)
+    return false;
+
+  // Try load dbghelp.dll from the system directory first.
+  char dllFilename[MAX_PATH];
+  ::GetSystemDirectoryA(dllFilename, ARRAY_SIZE(dllFilename));
+  strcat(dllFilename, "\\dbghelp.dll");
+
+  Inst->m_dllModule = ::LoadLibraryA(dllFilename);
+  if (Inst->m_dllModule == HMODULE(0))
+  {
+    // Not found. Try load dbghelp.dll from the work directory.
+    Inst->m_dllModule = ::LoadLibraryA("dbghelp.dll");
+    if (Inst->m_dllModule == HMODULE(0))
+    {
+      Inst->m_failed = true;
+      return false;
+    }
+  }
+  else
+  {
+    Inst->m_loadedFromSystem = true;
+  }
+
+  Inst->m_symInitialize = reinterpret_cast<SymInitialize_t>(::GetProcAddress(Inst->m_dllModule, "SymInitialize"));
+  Inst->m_symCleanup = reinterpret_cast<SymCleanup_t>(::GetProcAddress(Inst->m_dllModule, "SymCleanup"));
+  Inst->m_symLoadModule = reinterpret_cast<SymLoadModule_t>(::GetProcAddress(Inst->m_dllModule, "SymLoadModule"));
+  Inst->m_symUnloadModule = reinterpret_cast<SymUnloadModule_t>(::GetProcAddress(Inst->m_dllModule, "SymUnloadModule"));
+  Inst->m_symGetModuleBase = reinterpret_cast<SymGetModuleBase_t>(::GetProcAddress(Inst->m_dllModule, "SymGetModuleBase"));
+  Inst->m_symGetSymFromAddr = reinterpret_cast<SymGetSymFromAddr_t>(::GetProcAddress(Inst->m_dllModule, "SymGetSymFromAddr"));
+  Inst->m_symGetLineFromAddr = reinterpret_cast<SymGetLineFromAddr_t>(::GetProcAddress(Inst->m_dllModule, "SymGetLineFromAddr"));
+  Inst->m_symSetOptions = reinterpret_cast<SymSetOptions_t>(::GetProcAddress(Inst->m_dllModule, "SymSetOptions"));
+  Inst->m_symFunctionTableAccess = reinterpret_cast<SymFunctionTableAccess_t>(::GetProcAddress(Inst->m_dllModule, "SymFunctionTableAccess"));
+  Inst->m_stackWalk = reinterpret_cast<StackWalk_t>(::GetProcAddress(Inst->m_dllModule, "StackWalk"));
+
+  if (Inst->m_symInitialize == NULL || Inst->m_symCleanup == NULL)
+  {
+    unload();
+    Inst->m_failed = true;
+    return false;
+  }
+
+  return true;
+}
+
+bool DbgHelpLoader::reload()
+{
+  unload();
+  return load();
+}
+
+void DbgHelpLoader::unload()
+{
+  if (Inst == NULL)
+    return;
+
+  while (!Inst->m_initializedProcesses.empty())
+  {
+    symCleanup(*Inst->m_initializedProcesses.begin());
+  }
+
+  if (Inst->m_dllModule != HMODULE(0))
+  {
+    ::FreeLibrary(Inst->m_dllModule);
+    Inst->m_dllModule = HMODULE(0);
+  }
+
+  Inst->~DbgHelpLoader();
+  ::free(Inst);
+  Inst = NULL;
+}
+
+BOOL DbgHelpLoader::symInitialize(
+  HANDLE hProcess,
+  LPSTR UserSearchPath,
+  BOOL fInvadeProcess)
+{
+  if (Inst == NULL)
+    return FALSE;
+
+  if (Inst->m_initializedProcesses.find(hProcess) != Inst->m_initializedProcesses.end())
+    return FALSE;
+
+  if (Inst->m_symInitialize)
+  {
+    if (Inst->m_symInitialize(hProcess, UserSearchPath, fInvadeProcess) != FALSE)
+    {
+      Inst->m_initializedProcesses.insert(hProcess);
+      return TRUE;
+    }
+  }
+
+  return FALSE;
+}
+
+BOOL DbgHelpLoader::symCleanup(
+  HANDLE hProcess)
+{
+  if (Inst == NULL)
+    return FALSE;
+
+  // @todo stl::find_and_erase
+  Processes::iterator it = Inst->m_initializedProcesses.find(hProcess);
+  if (it != Inst->m_initializedProcesses.end())
+    Inst->m_initializedProcesses.erase(it);
+
+  if (Inst->m_symCleanup)
+    return Inst->m_symCleanup(hProcess);
+
+  return FALSE;
+}
+
+BOOL DbgHelpLoader::symLoadModule(
+  HANDLE hProcess,
+  HANDLE hFile,
+  LPSTR ImageName,
+  LPSTR ModuleName,
+  DWORD BaseOfDll,
+  DWORD SizeOfDll)
+{
+  if (Inst != NULL && Inst->m_symLoadModule)
+    return Inst->m_symLoadModule(hProcess, hFile, ImageName, ModuleName, BaseOfDll, SizeOfDll);
+
+  return FALSE;
+}
+
+DWORD DbgHelpLoader::symGetModuleBase(
+  HANDLE hProcess,
+  DWORD dwAddr)
+{
+  if (Inst != NULL && Inst->m_symGetModuleBase)
+    return Inst->m_symGetModuleBase(hProcess, dwAddr);
+
+  return 0u;
+}
+
+BOOL DbgHelpLoader::symUnloadModule(
+  HANDLE hProcess,
+  DWORD BaseOfDll)
+{
+  if (Inst != NULL && Inst->m_symUnloadModule)
+    return Inst->m_symUnloadModule(hProcess, BaseOfDll);
+
+  return FALSE;
+}
+
+BOOL DbgHelpLoader::symGetSymFromAddr(
+  HANDLE hProcess,
+  DWORD Address,
+  LPDWORD Displacement,
+  PIMAGEHLP_SYMBOL Symbol)
+{
+  if (Inst != NULL && Inst->m_symGetSymFromAddr)
+    return Inst->m_symGetSymFromAddr(hProcess, Address, Displacement, Symbol);
+
+  return FALSE;
+}
+
+BOOL DbgHelpLoader::symGetLineFromAddr(
+  HANDLE hProcess,
+  DWORD dwAddr,
+  PDWORD pdwDisplacement,
+  PIMAGEHLP_LINE Line)
+{
+  if (Inst != NULL && Inst->m_symGetLineFromAddr)
+    return Inst->m_symGetLineFromAddr(hProcess, dwAddr, pdwDisplacement, Line);
+
+  return FALSE;
+}
+
+DWORD DbgHelpLoader::symSetOptions(
+  DWORD SymOptions)
+{
+  if (Inst != NULL && Inst->m_symSetOptions)
+    return Inst->m_symSetOptions(SymOptions);
+
+  return 0u;
+}
+
+LPVOID DbgHelpLoader::symFunctionTableAccess(
+  HANDLE hProcess,
+  DWORD AddrBase)
+{
+  if (Inst != NULL && Inst->m_symFunctionTableAccess)
+    return Inst->m_symFunctionTableAccess(hProcess, AddrBase);
+
+  return NULL;
+}
+
+BOOL DbgHelpLoader::stackWalk(
+  DWORD MachineType,
+  HANDLE hProcess,
+  HANDLE hThread,
+  LPSTACKFRAME StackFrame,
+  LPVOID ContextRecord,
+  PREAD_PROCESS_MEMORY_ROUTINE ReadMemoryRoutine,
+  PFUNCTION_TABLE_ACCESS_ROUTINE FunctionTableAccessRoutine,
+  PGET_MODULE_BASE_ROUTINE GetModuleBaseRoutine,
+  PTRANSLATE_ADDRESS_ROUTINE TranslateAddress)
+{
+  if (Inst != NULL && Inst->m_stackWalk)
+    return Inst->m_stackWalk(MachineType, hProcess, hThread, StackFrame, ContextRecord, ReadMemoryRoutine, FunctionTableAccessRoutine, GetModuleBaseRoutine, TranslateAddress);
+
+  return FALSE;
+}

--- a/Core/Libraries/Source/WWVegas/WWLib/DbgHelpLoader.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/DbgHelpLoader.h
@@ -1,0 +1,187 @@
+/*
+**	Command & Conquer Generals Zero Hour(tm)
+**	Copyright 2025 TheSuperHackers
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "always.h"
+
+#include <win.h>
+#include <imagehlp.h> // Must be included after Windows.h
+#include <set>
+
+#include "MallocAllocator.h"
+
+// This static class can load and unload dbghelp.dll
+// Internally it must not use new and delete because it can be created during game memory initialization.
+
+class DbgHelpLoader
+{
+private:
+
+  static int BlockLoadCounter;
+  static DbgHelpLoader* Inst; // Is singleton class
+
+  DbgHelpLoader();
+  ~DbgHelpLoader();
+
+public:
+
+  // Returns whether dbghelp.dll is loaded
+  static bool isLoaded();
+
+  // Returns whether dbghelp.dll is loaded from the system directory
+  static bool isLoadedFromSystem();
+
+  // Blocks loading a dbghelp.dll
+  static void blockLoad();
+
+  // Unblocks loading a dbghelp.dll. Returns true if unblocked.
+  static bool unblockLoad();
+
+  static bool load();
+  static bool reload();
+  static void unload();
+
+  static BOOL WINAPI symInitialize(
+    HANDLE hProcess,
+    LPSTR UserSearchPath,
+    BOOL fInvadeProcess);
+
+  static BOOL WINAPI symCleanup(
+    HANDLE hProcess);
+
+  static BOOL WINAPI symLoadModule(
+    HANDLE hProcess,
+    HANDLE hFile,
+    LPSTR ImageName,
+    LPSTR ModuleName,
+    DWORD BaseOfDll,
+    DWORD SizeOfDll);
+
+  static DWORD WINAPI symGetModuleBase(
+    HANDLE hProcess,
+    DWORD dwAddr);
+
+  static BOOL WINAPI symUnloadModule(
+    HANDLE hProcess,
+    DWORD BaseOfDll);
+
+  static BOOL WINAPI symGetSymFromAddr(
+    HANDLE hProcess,
+    DWORD Address,
+    LPDWORD Displacement,
+    PIMAGEHLP_SYMBOL Symbol);
+
+  static BOOL WINAPI symGetLineFromAddr(
+    HANDLE hProcess,
+    DWORD dwAddr,
+    PDWORD pdwDisplacement,
+    PIMAGEHLP_LINE Line);
+
+  static DWORD WINAPI symSetOptions(
+    DWORD SymOptions);
+
+  static LPVOID WINAPI symFunctionTableAccess(
+    HANDLE hProcess,
+    DWORD AddrBase);
+
+  static BOOL WINAPI stackWalk(
+    DWORD MachineType,
+    HANDLE hProcess,
+    HANDLE hThread,
+    LPSTACKFRAME StackFrame,
+    LPVOID ContextRecord,
+    PREAD_PROCESS_MEMORY_ROUTINE ReadMemoryRoutine,
+    PFUNCTION_TABLE_ACCESS_ROUTINE FunctionTableAccessRoutine,
+    PGET_MODULE_BASE_ROUTINE GetModuleBaseRoutine,
+    PTRANSLATE_ADDRESS_ROUTINE TranslateAddress);
+
+private:
+
+  typedef BOOL (WINAPI *SymInitialize_t) (
+    HANDLE hProcess,
+    LPSTR UserSearchPath,
+    BOOL fInvadeProcess);
+
+  typedef BOOL (WINAPI *SymCleanup_t) (
+    HANDLE hProcess);
+
+  typedef BOOL (WINAPI *SymLoadModule_t) (
+    HANDLE hProcess,
+    HANDLE hFile,
+    LPSTR ImageName,
+    LPSTR ModuleName,
+    DWORD BaseOfDll,
+    DWORD SizeOfDll);
+
+  typedef DWORD (WINAPI *SymGetModuleBase_t) (
+    HANDLE hProcess,
+    DWORD dwAddr);
+
+  typedef BOOL (WINAPI *SymUnloadModule_t) (
+    HANDLE hProcess,
+    DWORD BaseOfDll);
+
+  typedef BOOL (WINAPI *SymGetSymFromAddr_t) (
+    HANDLE hProcess,
+    DWORD Address,
+    LPDWORD Displacement,
+    PIMAGEHLP_SYMBOL Symbol);
+
+  typedef BOOL (WINAPI* SymGetLineFromAddr_t) (
+    HANDLE hProcess,
+    DWORD dwAddr,
+    PDWORD pdwDisplacement,
+    PIMAGEHLP_LINE Line);
+
+  typedef DWORD (WINAPI *SymSetOptions_t) (
+    DWORD SymOptions);
+
+  typedef LPVOID (WINAPI *SymFunctionTableAccess_t) (
+    HANDLE hProcess,
+    DWORD AddrBase);
+
+  typedef BOOL (WINAPI *StackWalk_t) (
+    DWORD MachineType,
+    HANDLE hProcess,
+    HANDLE hThread,
+    LPSTACKFRAME StackFrame,
+    LPVOID ContextRecord,
+    PREAD_PROCESS_MEMORY_ROUTINE ReadMemoryRoutine,
+    PFUNCTION_TABLE_ACCESS_ROUTINE FunctionTableAccessRoutine,
+    PGET_MODULE_BASE_ROUTINE GetModuleBaseRoutine,
+    PTRANSLATE_ADDRESS_ROUTINE TranslateAddress);
+
+  SymInitialize_t m_symInitialize;
+  SymCleanup_t m_symCleanup;
+  SymLoadModule_t m_symLoadModule;
+  SymUnloadModule_t m_symUnloadModule;
+  SymGetModuleBase_t m_symGetModuleBase;
+  SymGetSymFromAddr_t m_symGetSymFromAddr;
+  SymGetLineFromAddr_t m_symGetLineFromAddr;
+  SymSetOptions_t m_symSetOptions;
+  SymFunctionTableAccess_t m_symFunctionTableAccess;
+  StackWalk_t m_stackWalk;
+
+  typedef std::set<HANDLE, std::less<HANDLE>, stl::malloc_allocator<HANDLE> > Processes;
+
+  Processes m_initializedProcesses;
+  HMODULE m_dllModule;
+  bool m_failed;
+  bool m_loadedFromSystem;
+};

--- a/Core/Libraries/Source/WWVegas/WWLib/MallocAllocator.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/MallocAllocator.h
@@ -1,0 +1,129 @@
+/*
+**	Command & Conquer Generals Zero Hour(tm)
+**	Copyright 2025 TheSuperHackers
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <cstdlib> // malloc, free
+#include <cstddef> // std::size_t, std::ptrdiff_t
+#include <new> // std::bad_alloc
+
+
+namespace stl
+{
+
+// STL allocator that uses malloc and free. Useful if allocations are meant to bypass new and delete.
+
+template <typename T>
+class malloc_allocator
+{
+public:
+
+  typedef T value_type;
+  typedef T* pointer;
+  typedef const T* const_pointer;
+  typedef T& reference;
+  typedef const T& const_reference;
+  typedef std::size_t size_type;
+  typedef std::ptrdiff_t difference_type;
+
+  template <typename U>
+  struct rebind
+  {
+    typedef malloc_allocator<U> other;
+  };
+
+  malloc_allocator() throw() {}
+
+#if !(defined(_MSC_VER) && _MSC_VER < 1300)
+  malloc_allocator(const malloc_allocator&) throw() {}
+#endif
+
+  template <typename U>
+  malloc_allocator(const malloc_allocator<U>&) throw() {}
+
+  ~malloc_allocator() throw() {}
+
+  pointer address(reference x) const { return &x; }
+  const_pointer address(const_reference x) const { return &x; }
+
+  pointer allocate(size_type n, const void* = 0)
+  {
+    if (n > max_size())
+      throw std::bad_alloc();
+
+    void* p = ::malloc(n * sizeof(T));
+    if (!p)
+      throw std::bad_alloc();
+    return static_cast<pointer>(p);
+  }
+
+  void deallocate(pointer p, size_type)
+  {
+    ::free(p);
+  }
+
+  void construct(pointer p, const T& val)
+  {
+    new (static_cast<void*>(p)) T(val);
+  }
+
+  void destroy(pointer p)
+  {
+    p->~T();
+  }
+
+  size_type max_size() const throw()
+  {
+    return ~size_type(0) / sizeof(T);
+  }
+};
+
+// Allocators of same type are always equal
+template <typename T1, typename T2>
+bool operator==(const malloc_allocator<T1>&, const malloc_allocator<T2>&) throw() {
+  return true;
+}
+
+template <typename T1, typename T2>
+bool operator!=(const malloc_allocator<T1>&, const malloc_allocator<T2>&) throw() {
+  return false;
+}
+
+} // namespace stl
+
+
+#if defined(USING_STLPORT)
+
+// This tells STLport how to rebind malloc_allocator
+namespace std
+{
+  template <class _Tp1, class _Tp2>
+  struct __stl_alloc_rebind_helper;
+
+  template <class Tp1, class Tp2>
+  inline stl::malloc_allocator<Tp2>& __stl_alloc_rebind(stl::malloc_allocator<Tp1>& a, const Tp2*) {
+    return *reinterpret_cast<stl::malloc_allocator<Tp2>*>(&a);
+  }
+
+  template <class Tp1, class Tp2>
+  inline const stl::malloc_allocator<Tp2>& __stl_alloc_rebind(const stl::malloc_allocator<Tp1>& a, const Tp2*) {
+    return *reinterpret_cast<const stl::malloc_allocator<Tp2>*>(&a);
+  }
+}
+
+#endif

--- a/Core/Libraries/Source/WWVegas/WWLib/ScopedFileRenamer.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/ScopedFileRenamer.cpp
@@ -1,0 +1,98 @@
+/*
+**	Command & Conquer Generals Zero Hour(tm)
+**	Copyright 2025 TheSuperHackers
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "ScopedFileRenamer.h"
+
+
+ScopedFileRenamer::ScopedFileRenamer()
+	: m_file(NULL)
+{
+}
+
+ScopedFileRenamer::ScopedFileRenamer(const char* oldName, const char* newName)
+	: m_file(NULL)
+{
+	this->rename(oldName, newName);
+}
+
+ScopedFileRenamer::~ScopedFileRenamer()
+{
+	revert();
+}
+
+bool ScopedFileRenamer::rename(const char* oldName, const char* newName)
+{
+	revert();
+
+	m_oldName = oldName;
+	m_newName = newName;
+
+	if (0 == ::rename(m_oldName.c_str(), m_newName.c_str()))
+	{
+		// Creates an empty *.tmp dummy file to remember that this program has renamed the file.
+		// If the program would crash before the file was renamed back to the previous name, then
+		// the rename condition will be able to recover the next time this code runs successfully.
+		std::string tmpFilename = createTmpName();
+		m_file = ::fopen(tmpFilename.c_str(), "wb");
+
+		return true;
+	}
+
+	return false;
+}
+
+bool ScopedFileRenamer::revert()
+{
+	if (m_oldName.empty())
+		return false;
+
+	bool success = false;
+	std::string tmpName;
+
+	if (m_file == NULL)
+	{
+		tmpName = createTmpName();
+		m_file = ::fopen(tmpName.c_str(), "rb");
+	}
+
+	if (m_file != NULL)
+	{
+		::fclose(m_file);
+		m_file = NULL;
+
+		if (0 == ::rename(m_newName.c_str(), m_oldName.c_str()))
+			success = true;
+
+		if (tmpName.empty())
+			tmpName = createTmpName();
+
+		::remove(tmpName.c_str());
+	}
+
+	m_oldName.clear();
+	m_newName.clear();
+
+	return success;
+}
+
+std::string ScopedFileRenamer::createTmpName() const
+{
+	std::string tmpFilename = m_oldName;
+	tmpFilename.append(".tmp");
+	return tmpFilename;
+}

--- a/Core/Libraries/Source/WWVegas/WWLib/ScopedFileRenamer.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/ScopedFileRenamer.h
@@ -1,0 +1,47 @@
+/*
+**	Command & Conquer Generals Zero Hour(tm)
+**	Copyright 2025 TheSuperHackers
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "always.h"
+
+#include <stdio.h>
+#include <string>
+
+
+class ScopedFileRenamer
+{
+public:
+
+	ScopedFileRenamer();
+	ScopedFileRenamer(const char* oldName, const char* newName);
+	~ScopedFileRenamer();
+
+	bool rename(const char* oldName, const char* newName);
+	bool revert();
+
+private:
+
+	std::string createTmpName() const;
+
+private:
+
+	std::string m_oldName;
+	std::string m_newName;
+	FILE* m_file;
+};

--- a/Core/Tools/ImagePacker/CMakeLists.txt
+++ b/Core/Tools/ImagePacker/CMakeLists.txt
@@ -30,7 +30,6 @@ target_link_libraries(corei_imagepacker INTERFACE
     comctl32
     core_debug
     core_profile
-    dbghelplib
     imm32
     vfw32
     winmm

--- a/Core/Tools/MapCacheBuilder/CMakeLists.txt
+++ b/Core/Tools/MapCacheBuilder/CMakeLists.txt
@@ -17,7 +17,6 @@ target_link_libraries(corei_mapcachebuilder INTERFACE
     comctl32
     core_debug
     core_profile
-    dbghelplib
     imm32
     vfw32
     winmm

--- a/Core/Tools/PATCHGET/CMakeLists.txt
+++ b/Core/Tools/PATCHGET/CMakeLists.txt
@@ -25,7 +25,6 @@ target_link_libraries(corei_patchgrabber INTERFACE
     comctl32
     core_debug
     core_profile
-    dbghelplib
     gamespy::gamespy
     imm32
     vfw32

--- a/Generals/Code/GameEngine/Source/Common/System/StackDump.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/StackDump.cpp
@@ -31,6 +31,7 @@
 #include "Common/StackDump.h"
 #include "Common/Debug.h"
 
+#include "DbgHelpLoader.h"
 
 //*****************************************************************************
 //	Prototypes
@@ -45,14 +46,6 @@ void WriteStackLine(void*address, void (*callback)(const char*));
 //	Mis-named globals :-)
 //*****************************************************************************
 static CONTEXT gsContext;
-static Bool gsInit=FALSE;
-
-BOOL (__stdcall *gsSymGetLineFromAddr)(
-		IN  HANDLE                  hProcess,
-		IN  DWORD                   dwAddr,
-		OUT PDWORD                  pdwDisplacement,
-		OUT PIMAGEHLP_LINE          Line
-			);
 
 
 //*****************************************************************************
@@ -72,7 +65,8 @@ void StackDump(void (*callback)(const char*))
 		callback = StackDumpDefaultHandler;
 	}
 
-	InitSymbolInfo();
+	if (!InitSymbolInfo())
+		return;
 
 	DWORD myeip,myesp,myebp;
 
@@ -101,7 +95,8 @@ void StackDumpFromContext(DWORD eip,DWORD esp,DWORD ebp, void (*callback)(const 
 		callback = StackDumpDefaultHandler;
 	}
 
-	InitSymbolInfo();
+	if (!InitSymbolInfo())
+		return;
 
 	MakeStackTrace(eip,esp,ebp, 0,  callback);
 }
@@ -111,27 +106,20 @@ void StackDumpFromContext(DWORD eip,DWORD esp,DWORD ebp, void (*callback)(const 
 //*****************************************************************************
 BOOL InitSymbolInfo()
 {
-	if (gsInit == TRUE) 
+	if (DbgHelpLoader::isLoaded())
 		return TRUE;
 
-	gsInit = TRUE;
+	if (!DbgHelpLoader::load())
+		return FALSE;
 
 	atexit(UninitSymbolInfo);
-
-	// See if we have the line from address function
-	// We use GetProcAddress to stop link failures at dll loadup
-	HINSTANCE hInstDebugHlp = GetModuleHandle("dbghelp.dll");
-
-	gsSymGetLineFromAddr = (BOOL (__stdcall *)(	IN  HANDLE,IN  DWORD,OUT PDWORD,OUT PIMAGEHLP_LINE))
-							GetProcAddress(hInstDebugHlp , "SymGetLineFromAddr");
 
 	char pathname[_MAX_PATH+1];
 	char drive[10];
 	char directory[_MAX_PATH+1];
 	HANDLE process;
 
-
-	::SymSetOptions(SYMOPT_DEFERRED_LOADS | SYMOPT_UNDNAME | SYMOPT_LOAD_LINES | SYMOPT_OMAP_FIND_NEAREST);
+	DbgHelpLoader::symSetOptions(SYMOPT_DEFERRED_LOADS | SYMOPT_UNDNAME | SYMOPT_LOAD_LINES | SYMOPT_OMAP_FIND_NEAREST);
 
 	process = GetCurrentProcess();
 
@@ -145,18 +133,18 @@ BOOL InitSymbolInfo()
 	// append the current directory to build a search path for SymInit
 	::lstrcat(pathname, ";.;");
 
-	if(::SymInitialize(process, pathname, FALSE))
+	if(DbgHelpLoader::symInitialize(process, pathname, FALSE))
 	{
 		// regenerate the name of the app
 		::GetModuleFileName(NULL, pathname, _MAX_PATH);
-		if(::SymLoadModule(process, NULL, pathname, NULL, 0, 0))
+		if(DbgHelpLoader::symLoadModule(process, NULL, pathname, NULL, 0, 0))
 		{
 				//Load any other relevant modules (ie dlls) here
 				return TRUE;
 		}
-		::SymCleanup(process);
 	}
 
+	DbgHelpLoader::unload();
 	return(FALSE);
 }
 
@@ -165,14 +153,7 @@ BOOL InitSymbolInfo()
 //*****************************************************************************
 void UninitSymbolInfo(void)
 {
-	if (gsInit == FALSE)
-	{
-		return;
-	}
-
-	gsInit = FALSE;
-
-	::SymCleanup(GetCurrentProcess());
+	DbgHelpLoader::unload();
 }
 
 
@@ -217,14 +198,14 @@ stack_frame.AddrFrame.Offset = myebp;
 			unsigned int skip = skipFrames;
 			while (b_ret&&skip)
 			{
-					b_ret = StackWalk(      IMAGE_FILE_MACHINE_I386,
+					b_ret = DbgHelpLoader::stackWalk(      IMAGE_FILE_MACHINE_I386,
 											process,
 											thread,
 											&stack_frame,
 											NULL, //&gsContext,
 											NULL,
-											SymFunctionTableAccess,
-											SymGetModuleBase,
+											DbgHelpLoader::symFunctionTableAccess,
+											DbgHelpLoader::symGetModuleBase,
 											NULL);
 					skip--;
 			}
@@ -233,14 +214,14 @@ stack_frame.AddrFrame.Offset = myebp;
 			while(b_ret&&skip)
 			{
 
-					b_ret = StackWalk(      IMAGE_FILE_MACHINE_I386,
+					b_ret = DbgHelpLoader::stackWalk(      IMAGE_FILE_MACHINE_I386,
 											process,
 											thread,
 											&stack_frame,
 											NULL, //&gsContext,
 											NULL,
-											SymFunctionTableAccess,
-											SymGetModuleBase,
+											DbgHelpLoader::symFunctionTableAccess,
+											DbgHelpLoader::symGetModuleBase,
 											NULL);
 					
 
@@ -256,7 +237,9 @@ stack_frame.AddrFrame.Offset = myebp;
 //*****************************************************************************
 void GetFunctionDetails(void *pointer, char*name, char*filename, unsigned int* linenumber, unsigned int* address)
 {
-	InitSymbolInfo();
+	if (!InitSymbolInfo())
+		return;
+
 	if (name)
 	{
 		strcpy(name, "<Unknown>");
@@ -285,8 +268,8 @@ void GetFunctionDetails(void *pointer, char*name, char*filename, unsigned int* l
     psymbol->SizeOfStruct = sizeof(symbol_buffer);
     psymbol->MaxNameLength = 512;
 
-    if (SymGetSymFromAddr(process, (DWORD) pointer, &displacement, psymbol))
-    {
+	if (DbgHelpLoader::symGetSymFromAddr(process, (DWORD) pointer, &displacement, psymbol))
+	{
 		if (name)
 		{
 			strcpy(name, psymbol->Name);
@@ -294,32 +277,27 @@ void GetFunctionDetails(void *pointer, char*name, char*filename, unsigned int* l
 		}
 
 		// Get line now
-		if (gsSymGetLineFromAddr)
+
+		IMAGEHLP_LINE line;
+		memset(&line,0,sizeof(line));
+		line.SizeOfStruct = sizeof(line);
+
+		if (DbgHelpLoader::symGetLineFromAddr(process, (DWORD) pointer, &displacement, &line))
 		{
-			// Unsupported for win95/98 at least with my current dbghelp.dll
-
-			IMAGEHLP_LINE line;
-			memset(&line,0,sizeof(line));
-			line.SizeOfStruct = sizeof(line);
-
-		
-			if (gsSymGetLineFromAddr(process, (DWORD) pointer, &displacement, &line))
+			if (filename)
 			{
-				if (filename)
-				{
-					strcpy(filename, line.FileName);
-				}
-				if (linenumber)
-				{
-					*linenumber = (unsigned int)line.LineNumber;
-				}
-				if (address)
-				{
-					*address = (unsigned int)line.Address;
-				}
-			} 					
+				strcpy(filename, line.FileName);
+			}
+			if (linenumber)
+			{
+				*linenumber = (unsigned int)line.LineNumber;
+			}
+			if (address)
+			{
+				*address = (unsigned int)line.Address;
+			}
 		}
-    }
+	}
 }
 
 
@@ -328,7 +306,8 @@ void GetFunctionDetails(void *pointer, char*name, char*filename, unsigned int* l
 //*****************************************************************************
 void FillStackAddresses(void**addresses, unsigned int count, unsigned int skip)
 {
-	InitSymbolInfo();
+	if (!InitSymbolInfo())
+		return;
 
 	STACKFRAME	stack_frame;
 
@@ -378,28 +357,28 @@ stack_frame.AddrFrame.Offset = myebp;
 		// Skip some?
 		while (stillgoing&&skip)
 		{
-			stillgoing = StackWalk(IMAGE_FILE_MACHINE_I386,
+			stillgoing = DbgHelpLoader::stackWalk(IMAGE_FILE_MACHINE_I386,
 								process,
 								thread,
 								&stack_frame,
 								NULL,	//&gsContext,
 								NULL,
-								SymFunctionTableAccess,
-								SymGetModuleBase,
+								DbgHelpLoader::symFunctionTableAccess,
+								DbgHelpLoader::symGetModuleBase,
 								NULL) != 0;
 			skip--;
 		}
 
 		while(stillgoing&&count)
 		{
-			stillgoing = StackWalk(IMAGE_FILE_MACHINE_I386,
+			stillgoing = DbgHelpLoader::stackWalk(IMAGE_FILE_MACHINE_I386,
 								process,
 								thread,
 								&stack_frame,
 								NULL, //&gsContext,
 								NULL,
-								SymFunctionTableAccess,
-								SymGetModuleBase,
+								DbgHelpLoader::symFunctionTableAccess,
+								DbgHelpLoader::symGetModuleBase,
 								NULL) != 0;
 			if (stillgoing)
 			{
@@ -438,7 +417,8 @@ void StackDumpFromAddresses(void**addresses, unsigned int count, void (*callback
 		callback = StackDumpDefaultHandler;
 	}
 
-	InitSymbolInfo();
+	if (!InitSymbolInfo())
+		return;
 
 	while ((count--) && (*addresses!=NULL))
 	{

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
@@ -81,6 +81,7 @@
 #include "dx8texman.h"
 #include "bound.h"
 #include "dx8webbrowser.h"
+#include "DbgHelpGuard.h"
 
 
 const int DEFAULT_RESOLUTION_WIDTH = 640;
@@ -312,7 +313,12 @@ bool DX8Wrapper::Init(void * hwnd, bool lite)
 		** Create the D3D interface object
 		*/
 		WWDEBUG_SAY(("Create Direct3D8\n"));
-		D3DInterface = Direct3DCreate8Ptr(D3D_SDK_VERSION);		// TODO: handle failure cases...
+		{
+			// TheSuperHackers @bugfix xezon 13/06/2025 Temporarily unload dbghelp.dll and prevent it from loading.
+			DbgHelpGuard dbgHelpGuard;
+
+			D3DInterface = Direct3DCreate8Ptr(D3D_SDK_VERSION);		// TODO: handle failure cases...
+		}
 		if (D3DInterface == NULL) {
 			return(false);
 		}
@@ -560,15 +566,21 @@ bool DX8Wrapper::Create_Device(void)
 	Vertex_Processing_Behavior|=D3DCREATE_FPU_PRESERVE;
 #endif
 
-	HRESULT hr=D3DInterface->CreateDevice
-	(
-		CurRenderDevice,
-		WW3D_DEVTYPE,
-		_Hwnd,
-		Vertex_Processing_Behavior,
-		&_PresentParameters,
-		&D3DDevice 
-	);
+	HRESULT hr;
+	{
+		// TheSuperHackers @bugfix xezon 13/06/2025 Temporarily unload dbghelp.dll and prevent it from loading.
+		DbgHelpGuard dbgHelpGuard;
+
+		hr=D3DInterface->CreateDevice
+		(
+			CurRenderDevice,
+			WW3D_DEVTYPE,
+			_Hwnd,
+			Vertex_Processing_Behavior,
+			&_PresentParameters,
+			&D3DDevice 
+		);
+	}
 
 	if (FAILED(hr)) 
 	{

--- a/Generals/Code/Main/CMakeLists.txt
+++ b/Generals/Code/Main/CMakeLists.txt
@@ -12,7 +12,6 @@ target_link_libraries(g_generals PRIVATE
     comctl32
     d3d8
     d3dx8
-    dbghelplib
     dinput8
     dxguid
     g_gameengine

--- a/Generals/Code/Tools/GUIEdit/CMakeLists.txt
+++ b/Generals/Code/Tools/GUIEdit/CMakeLists.txt
@@ -49,7 +49,6 @@ target_link_libraries(g_guiedit PRIVATE
     benchmark
     comctl32
     d3d8lib
-    dbghelplib
     g_gameengine
     g_gameenginedevice
     g_wwvegas

--- a/Generals/Code/Tools/ParticleEditor/CMakeLists.txt
+++ b/Generals/Code/Tools/ParticleEditor/CMakeLists.txt
@@ -42,7 +42,6 @@ target_link_libraries(g_particleeditor PRIVATE
     corei_libraries_source_wwvegas
     corei_libraries_source_wwvegas_wwlib
     d3d8lib
-    dbghelplib
     gi_gameengine_include
     gi_always
     gi_libraries_source_wwvegas

--- a/Generals/Code/Tools/W3DView/CMakeLists.txt
+++ b/Generals/Code/Tools/W3DView/CMakeLists.txt
@@ -8,7 +8,6 @@ target_link_libraries(g_w3dview PRIVATE
     d3d8
     d3d8lib
     d3dx8
-    dbghelplib
     imm32
     milesstub
     Version

--- a/Generals/Code/Tools/WorldBuilder/CMakeLists.txt
+++ b/Generals/Code/Tools/WorldBuilder/CMakeLists.txt
@@ -206,7 +206,6 @@ target_compile_definitions(g_worldbuilder PRIVATE _AFXDLL)
 
 target_link_libraries(g_worldbuilder PRIVATE
     d3d8lib
-    dbghelplib
     core_browserdispatch
     g_gameengine
     g_gameenginedevice

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/StackDump.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/StackDump.cpp
@@ -31,6 +31,7 @@
 #include "Common/StackDump.h"
 #include "Common/Debug.h"
 
+#include "DbgHelpLoader.h"
 
 //*****************************************************************************
 //	Prototypes
@@ -45,14 +46,6 @@ void WriteStackLine(void*address, void (*callback)(const char*));
 //	Mis-named globals :-)
 //*****************************************************************************
 static CONTEXT gsContext;
-static Bool gsInit=FALSE;
-
-BOOL (__stdcall *gsSymGetLineFromAddr)(
-		IN  HANDLE                  hProcess,
-		IN  DWORD                   dwAddr,
-		OUT PDWORD                  pdwDisplacement,
-		OUT PIMAGEHLP_LINE          Line
-			);
 
 
 //*****************************************************************************
@@ -72,7 +65,8 @@ void StackDump(void (*callback)(const char*))
 		callback = StackDumpDefaultHandler;
 	}
 
-	InitSymbolInfo();
+	if (!InitSymbolInfo())
+		return;
 
 	DWORD myeip,myesp,myebp;
 
@@ -101,7 +95,8 @@ void StackDumpFromContext(DWORD eip,DWORD esp,DWORD ebp, void (*callback)(const 
 		callback = StackDumpDefaultHandler;
 	}
 
-	InitSymbolInfo();
+	if (!InitSymbolInfo())
+		return;
 
 	MakeStackTrace(eip,esp,ebp, 0,  callback);
 }
@@ -111,27 +106,20 @@ void StackDumpFromContext(DWORD eip,DWORD esp,DWORD ebp, void (*callback)(const 
 //*****************************************************************************
 BOOL InitSymbolInfo()
 {
-	if (gsInit == TRUE) 
+	if (DbgHelpLoader::isLoaded())
 		return TRUE;
 
-	gsInit = TRUE;
+	if (!DbgHelpLoader::load())
+		return FALSE;
 
 	atexit(UninitSymbolInfo);
-
-	// See if we have the line from address function
-	// We use GetProcAddress to stop link failures at dll loadup
-	HINSTANCE hInstDebugHlp = GetModuleHandle("dbghelp.dll");
-
-	gsSymGetLineFromAddr = (BOOL (__stdcall *)(	IN  HANDLE,IN  DWORD,OUT PDWORD,OUT PIMAGEHLP_LINE))
-							GetProcAddress(hInstDebugHlp , "SymGetLineFromAddr");
 
 	char pathname[_MAX_PATH+1];
 	char drive[10];
 	char directory[_MAX_PATH+1];
 	HANDLE process;
 
-
-	::SymSetOptions(SYMOPT_DEFERRED_LOADS | SYMOPT_UNDNAME | SYMOPT_LOAD_LINES | SYMOPT_OMAP_FIND_NEAREST);
+	DbgHelpLoader::symSetOptions(SYMOPT_DEFERRED_LOADS | SYMOPT_UNDNAME | SYMOPT_LOAD_LINES | SYMOPT_OMAP_FIND_NEAREST);
 
 	process = GetCurrentProcess();
 
@@ -145,18 +133,18 @@ BOOL InitSymbolInfo()
 	// append the current directory to build a search path for SymInit
 	::lstrcat(pathname, ";.;");
 
-	if(::SymInitialize(process, pathname, FALSE))
+	if(DbgHelpLoader::symInitialize(process, pathname, FALSE))
 	{
 		// regenerate the name of the app
 		::GetModuleFileName(NULL, pathname, _MAX_PATH);
-		if(::SymLoadModule(process, NULL, pathname, NULL, 0, 0))
+		if(DbgHelpLoader::symLoadModule(process, NULL, pathname, NULL, 0, 0))
 		{
 				//Load any other relevant modules (ie dlls) here
 				return TRUE;
 		}
-		::SymCleanup(process);
 	}
 
+	DbgHelpLoader::unload();
 	return(FALSE);
 }
 
@@ -165,14 +153,7 @@ BOOL InitSymbolInfo()
 //*****************************************************************************
 void UninitSymbolInfo(void)
 {
-	if (gsInit == FALSE)
-	{
-		return;
-	}
-
-	gsInit = FALSE;
-
-	::SymCleanup(GetCurrentProcess());
+	DbgHelpLoader::unload();
 }
 
 
@@ -217,14 +198,14 @@ stack_frame.AddrFrame.Offset = myebp;
 			unsigned int skip = skipFrames;
 			while (b_ret&&skip)
 			{
-					b_ret = StackWalk(      IMAGE_FILE_MACHINE_I386,
+					b_ret = DbgHelpLoader::stackWalk(      IMAGE_FILE_MACHINE_I386,
 											process,
 											thread,
 											&stack_frame,
 											NULL, //&gsContext,
 											NULL,
-											SymFunctionTableAccess,
-											SymGetModuleBase,
+											DbgHelpLoader::symFunctionTableAccess,
+											DbgHelpLoader::symGetModuleBase,
 											NULL);
 					skip--;
 			}
@@ -233,14 +214,14 @@ stack_frame.AddrFrame.Offset = myebp;
 			while(b_ret&&skip)
 			{
 
-					b_ret = StackWalk(      IMAGE_FILE_MACHINE_I386,
+					b_ret = DbgHelpLoader::stackWalk(      IMAGE_FILE_MACHINE_I386,
 											process,
 											thread,
 											&stack_frame,
 											NULL, //&gsContext,
 											NULL,
-											SymFunctionTableAccess,
-											SymGetModuleBase,
+											DbgHelpLoader::symFunctionTableAccess,
+											DbgHelpLoader::symGetModuleBase,
 											NULL);
 					
 
@@ -256,7 +237,9 @@ stack_frame.AddrFrame.Offset = myebp;
 //*****************************************************************************
 void GetFunctionDetails(void *pointer, char*name, char*filename, unsigned int* linenumber, unsigned int* address)
 {
-	InitSymbolInfo();
+	if (!InitSymbolInfo())
+		return;
+
 	if (name)
 	{
 		strcpy(name, "<Unknown>");
@@ -285,8 +268,8 @@ void GetFunctionDetails(void *pointer, char*name, char*filename, unsigned int* l
     psymbol->SizeOfStruct = sizeof(symbol_buffer);
     psymbol->MaxNameLength = 512;
 
-    if (SymGetSymFromAddr(process, (DWORD) pointer, &displacement, psymbol))
-    {
+	if (DbgHelpLoader::symGetSymFromAddr(process, (DWORD) pointer, &displacement, psymbol))
+	{
 		if (name)
 		{
 			strcpy(name, psymbol->Name);
@@ -294,32 +277,27 @@ void GetFunctionDetails(void *pointer, char*name, char*filename, unsigned int* l
 		}
 
 		// Get line now
-		if (gsSymGetLineFromAddr)
+
+		IMAGEHLP_LINE line;
+		memset(&line,0,sizeof(line));
+		line.SizeOfStruct = sizeof(line);
+
+		if (DbgHelpLoader::symGetLineFromAddr(process, (DWORD) pointer, &displacement, &line))
 		{
-			// Unsupported for win95/98 at least with my current dbghelp.dll
-
-			IMAGEHLP_LINE line;
-			memset(&line,0,sizeof(line));
-			line.SizeOfStruct = sizeof(line);
-
-		
-			if (gsSymGetLineFromAddr(process, (DWORD) pointer, &displacement, &line))
+			if (filename)
 			{
-				if (filename)
-				{
-					strcpy(filename, line.FileName);
-				}
-				if (linenumber)
-				{
-					*linenumber = (unsigned int)line.LineNumber;
-				}
-				if (address)
-				{
-					*address = (unsigned int)line.Address;
-				}
-			} 					
+				strcpy(filename, line.FileName);
+			}
+			if (linenumber)
+			{
+				*linenumber = (unsigned int)line.LineNumber;
+			}
+			if (address)
+			{
+				*address = (unsigned int)line.Address;
+			}
 		}
-    }
+	}
 }
 
 
@@ -328,7 +306,8 @@ void GetFunctionDetails(void *pointer, char*name, char*filename, unsigned int* l
 //*****************************************************************************
 void FillStackAddresses(void**addresses, unsigned int count, unsigned int skip)
 {
-	InitSymbolInfo();
+	if (!InitSymbolInfo())
+		return;
 
 	STACKFRAME	stack_frame;
 
@@ -378,28 +357,28 @@ stack_frame.AddrFrame.Offset = myebp;
 		// Skip some?
 		while (stillgoing&&skip)
 		{
-			stillgoing = StackWalk(IMAGE_FILE_MACHINE_I386,
+			stillgoing = DbgHelpLoader::stackWalk(IMAGE_FILE_MACHINE_I386,
 								process,
 								thread,
 								&stack_frame,
 								NULL,	//&gsContext,
 								NULL,
-								SymFunctionTableAccess,
-								SymGetModuleBase,
+								DbgHelpLoader::symFunctionTableAccess,
+								DbgHelpLoader::symGetModuleBase,
 								NULL) != 0;
 			skip--;
 		}
 
 		while(stillgoing&&count)
 		{
-			stillgoing = StackWalk(IMAGE_FILE_MACHINE_I386,
+			stillgoing = DbgHelpLoader::stackWalk(IMAGE_FILE_MACHINE_I386,
 								process,
 								thread,
 								&stack_frame,
 								NULL, //&gsContext,
 								NULL,
-								SymFunctionTableAccess,
-								SymGetModuleBase,
+								DbgHelpLoader::symFunctionTableAccess,
+								DbgHelpLoader::symGetModuleBase,
 								NULL) != 0;
 			if (stillgoing)
 			{
@@ -438,7 +417,8 @@ void StackDumpFromAddresses(void**addresses, unsigned int count, void (*callback
 		callback = StackDumpDefaultHandler;
 	}
 
-	InitSymbolInfo();
+	if (!InitSymbolInfo())
+		return;
 
 	while ((count--) && (*addresses!=NULL))
 	{

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
@@ -85,6 +85,7 @@
 #include "dx8texman.h"
 #include "bound.h"
 #include "dx8webbrowser.h"
+#include "DbgHelpGuard.h"
 
 #include "shdlib.h"
 
@@ -331,7 +332,12 @@ bool DX8Wrapper::Init(void * hwnd, bool lite)
 		** Create the D3D interface object
 		*/
 		WWDEBUG_SAY(("Create Direct3D8\n"));
-		D3DInterface = Direct3DCreate8Ptr(D3D_SDK_VERSION);		// TODO: handle failure cases...
+		{
+			// TheSuperHackers @bugfix xezon 13/06/2025 Temporarily unload dbghelp.dll and prevent it from loading.
+			DbgHelpGuard dbgHelpGuard;
+
+			D3DInterface = Direct3DCreate8Ptr(D3D_SDK_VERSION);		// TODO: handle failure cases...
+		}
 		if (D3DInterface == NULL) {
 			return(false);
 		}
@@ -592,15 +598,21 @@ bool DX8Wrapper::Create_Device(void)
 	Vertex_Processing_Behavior|=D3DCREATE_FPU_PRESERVE;
 #endif
 
-	HRESULT hr=D3DInterface->CreateDevice
-	(
-		CurRenderDevice,
-		WW3D_DEVTYPE,
-		_Hwnd,
-		Vertex_Processing_Behavior,
-		&_PresentParameters,
-		&D3DDevice 
-	);
+	HRESULT hr;
+	{
+		// TheSuperHackers @bugfix xezon 13/06/2025 Temporarily unload dbghelp.dll and prevent it from loading.
+		DbgHelpGuard dbgHelpGuard;
+
+		hr=D3DInterface->CreateDevice
+		(
+			CurRenderDevice,
+			WW3D_DEVTYPE,
+			_Hwnd,
+			Vertex_Processing_Behavior,
+			&_PresentParameters,
+			&D3DDevice 
+		);
+	}
 
 	if (FAILED(hr)) 
 	{

--- a/GeneralsMD/Code/Main/CMakeLists.txt
+++ b/GeneralsMD/Code/Main/CMakeLists.txt
@@ -14,7 +14,6 @@ target_link_libraries(z_generals PRIVATE
     core_profile
     d3d8
     d3dx8
-    dbghelplib
     dinput8
     dxguid
     imm32

--- a/GeneralsMD/Code/Tools/GUIEdit/CMakeLists.txt
+++ b/GeneralsMD/Code/Tools/GUIEdit/CMakeLists.txt
@@ -51,7 +51,6 @@ target_link_libraries(z_guiedit PRIVATE
     core_debug
     core_profile
     d3d8lib
-    dbghelplib
     imm32
     stlport
     vfw32

--- a/GeneralsMD/Code/Tools/ParticleEditor/CMakeLists.txt
+++ b/GeneralsMD/Code/Tools/ParticleEditor/CMakeLists.txt
@@ -42,7 +42,6 @@ target_link_libraries(z_particleeditor PRIVATE
     corei_libraries_source_wwvegas
     corei_libraries_source_wwvegas_wwlib
     d3d8lib
-    dbghelplib
     imm32
     core_config
     stlport

--- a/GeneralsMD/Code/Tools/W3DView/CMakeLists.txt
+++ b/GeneralsMD/Code/Tools/W3DView/CMakeLists.txt
@@ -8,7 +8,6 @@ target_link_libraries(z_w3dview PRIVATE
     d3d8
     d3d8lib
     d3dx8
-    dbghelplib
     imm32
     milesstub
     Version

--- a/GeneralsMD/Code/Tools/WorldBuilder/CMakeLists.txt
+++ b/GeneralsMD/Code/Tools/WorldBuilder/CMakeLists.txt
@@ -213,7 +213,6 @@ target_link_libraries(z_worldbuilder PRIVATE
     core_debug
     core_profile
     d3d8lib
-    dbghelplib
     imm32
     vfw32
     winmm

--- a/GeneralsMD/Code/Tools/wdump/CMakeLists.txt
+++ b/GeneralsMD/Code/Tools/wdump/CMakeLists.txt
@@ -21,7 +21,6 @@ target_link_libraries(z_wdump PRIVATE
     core_config
     core_utility
     core_wwstub # avoid linking GameEngine
-    dbghelplib
     imm32
     vfw32
     winmm

--- a/cmake/dbghelp.cmake
+++ b/cmake/dbghelp.cmake
@@ -1,7 +1,0 @@
-FetchContent_Declare(
-    dbghelp
-    GIT_REPOSITORY https://github.com/TheSuperHackers/dbghelp-import-lib.git
-    GIT_TAG        afeb423d4597167c8fa94215f4574f3ae310f920
-)
-
-FetchContent_MakeAvailable(dbghelp)


### PR DESCRIPTION
* Fixes #96

This change prevents the AMD/ATI driver crash on game launch by temporarily unloading and renaming the dbghelp.dll, that resides in the game install directory, before the driver would try to load and use it - if the user did not delete this file.

The crash workaround is quite a bit more complicated and intricate and adds a few new classes. On a positive note, it does get rid of the legacy dbghelp.lib link dependency.

dbghelp.dll is now loaded dynamically in WWLib code. This allows to unload it. And skip loading it if it is not even used. By default it will now also first try to load dbghelp.dll from Windows system32 directory which does not cause this crash. It appears that the AMD/ATI drivers are only incompatible with this old dbghelp.dll, likely because of insufficient error handling.

The `DbgHelpLoader` has a specific requirement, where it is not allowed to use new/delete, because of the timing it can be activated with `MEMORYPOOL_DEBUG_STACKTRACE` during game memory initialization. That is why the `stl::malloc_allocator` was added.

The `ScopedFileRenamer` was added to help safely rename and revert the dbghelp.dll on game launch.

The `DbgHelpGuard` was added to unload and rename in RAII fashion at the 2 necessary places.

- [x] Tested in VC6
- [x] Tested in VS2022
- [x] Tested with MEMORYPOOL_DEBUG_STACKTRACE
- [x] Tested without MEMORYPOOL_DEBUG_STACKTRACE