### PR TITLE
[GEN][ZH] Remove unnecessary 3 seconds delay from game startup

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/LoadScreen.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/LoadScreen.cpp
@@ -648,74 +648,10 @@ void ShellGameLoadScreen::init( GameInfo *game )
 		m_loadScreen->winSetEnabledImage(0, TheMappedImageCollection->findImageByName("TitleScreen"));
 		TheWritableGlobalData->m_breakTheMovie = FALSE;
 
-//		m_videoStream = TheVideoPlayer->open( "Sizzle" );
-//		if ( m_videoStream == NULL )
-//		{
-//			m_progressBar->winHide(FALSE);
-//			return;
-//		}
-//
-//		// Create the new buffer
-//		m_videoBuffer = TheDisplay->createVideoBuffer();
-//		if (	m_videoBuffer == NULL || 
-//					!m_videoBuffer->allocate(	m_videoStream->width(), 
-//														m_videoStream->height())
-//			)
-//		{
-//			delete m_videoBuffer;
-//			m_videoBuffer = NULL;
-//
-//			if ( m_videoStream )
-//				m_videoStream->close();
-//			m_videoStream = NULL;
-//
-//			return;
-//		}
-//		TheGlobalData->m_isBreakableMovie = TRUE;
-//		TheGlobalData->m_breakTheMovie = FALSE;
-//		while (m_videoStream->frameIndex() < m_videoStream->frameCount() - 1 )
-//		{
-//			if(TheGlobalData->m_breakTheMovie)
-//			{
-//				TheGlobalData->m_breakTheMovie = FALSE;
-//				m_videoStream->frameGoto(m_videoStream->frameCount() - 1);
-//			}
-//			if(m_videoStream->frameIndex() < m_videoStream->frameCount() - 1)
-//			{
-//				if(!m_videoStream->isFrameReady())
-//					continue;
-//
-//				m_videoStream->frameDecompress();
-//				m_videoStream->frameRender(m_videoBuffer);
-//				m_videoStream->frameNext();
-//				if(m_videoBuffer)
-//					m_loadScreen->winGetInstanceData()->setVideoBuffer(m_videoBuffer);
-//			}
-//
-//			TheWindowManager->update();
-//		//	TheShell->update();
-//			//TheDisplay->update();
-//			// redraw all views, update the GUI
-//			TheDisplay->draw();
-//		}
-//		TheGlobalData->m_isBreakableMovie = FALSE;
-//		TheGlobalData->m_breakTheMovie = FALSE;
-//		GameWindow *win = TheWindowManager->winGetWindowFromId( m_loadScreen,TheNameKeyGenerator->nameToKey( AsciiString( "ShellGameLoadScreen.wnd:EAGamesLogo" ) ));
-//		if(win)
-//			win->winHide(FALSE);
-
 		GameWindow *win = TheWindowManager->winGetWindowFromId( m_loadScreen,TheNameKeyGenerator->nameToKey( AsciiString( "ShellGameLoadScreen.wnd:StaticTextLegal" ) ));
 		if(win)
 			win->winHide(FALSE);
 		firstLoad = FALSE;
-
-		UnsignedInt showTime = timeGetTime();
-		while(showTime + 3000 > timeGetTime())
-		{	
-			LoadScreen::update(0);
-			Sleep(100);
-		}
-
 	}
 	m_progressBar->winHide(FALSE);	
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/LoadScreen.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/LoadScreen.cpp
@@ -1195,62 +1195,6 @@ void ShellGameLoadScreen::init( GameInfo *game )
 		m_loadScreen->winSetEnabledImage(0, TheMappedImageCollection->findImageByName("TitleScreen"));
 		TheWritableGlobalData->m_breakTheMovie = FALSE;
 
-//		m_videoStream = TheVideoPlayer->open( "Sizzle" );
-//		if ( m_videoStream == NULL )
-//		{
-//			m_progressBar->winHide(FALSE);
-//			return;
-//		}
-//
-//		// Create the new buffer
-//		m_videoBuffer = TheDisplay->createVideoBuffer();
-//		if (	m_videoBuffer == NULL || 
-//					!m_videoBuffer->allocate(	m_videoStream->width(), 
-//														m_videoStream->height())
-//			)
-//		{
-//			delete m_videoBuffer;
-//			m_videoBuffer = NULL;
-//
-//			if ( m_videoStream )
-//				m_videoStream->close();
-//			m_videoStream = NULL;
-//
-//			return;
-//		}
-//		TheGlobalData->m_isBreakableMovie = TRUE;
-//		TheGlobalData->m_breakTheMovie = FALSE;
-//		while (m_videoStream->frameIndex() < m_videoStream->frameCount() - 1 )
-//		{
-//			if(TheGlobalData->m_breakTheMovie)
-//			{
-//				TheGlobalData->m_breakTheMovie = FALSE;
-//				m_videoStream->frameGoto(m_videoStream->frameCount() - 1);
-//			}
-//			if(m_videoStream->frameIndex() < m_videoStream->frameCount() - 1)
-//			{
-//				if(!m_videoStream->isFrameReady())
-//					continue;
-//
-//				m_videoStream->frameDecompress();
-//				m_videoStream->frameRender(m_videoBuffer);
-//				m_videoStream->frameNext();
-//				if(m_videoBuffer)
-//					m_loadScreen->winGetInstanceData()->setVideoBuffer(m_videoBuffer);
-//			}
-//
-//			TheWindowManager->update();
-//		//	TheShell->update();
-//			//TheDisplay->update();
-//			// redraw all views, update the GUI
-//			TheDisplay->draw();
-//		}
-//		TheGlobalData->m_isBreakableMovie = FALSE;
-//		TheGlobalData->m_breakTheMovie = FALSE;
-//		GameWindow *win = TheWindowManager->winGetWindowFromId( m_loadScreen,TheNameKeyGenerator->nameToKey( AsciiString( "ShellGameLoadScreen.wnd:EAGamesLogo" ) ));
-//		if(win)
-//			win->winHide(FALSE);
-
 		GameWindow *win = TheWindowManager->winGetWindowFromId( m_loadScreen,TheNameKeyGenerator->nameToKey( AsciiString( "ShellGameLoadScreen.wnd:StaticTextLegal" ) ));
 		if(win)
 			win->winHide(FALSE);

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/LoadScreen.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/LoadScreen.cpp
@@ -1255,14 +1255,6 @@ void ShellGameLoadScreen::init( GameInfo *game )
 		if(win)
 			win->winHide(FALSE);
 		firstLoad = FALSE;
-
-		UnsignedInt showTime = timeGetTime();
-		while(showTime + 3000 > timeGetTime())
-		{	
-			LoadScreen::update(0);
-			Sleep(100);
-		}
-
 	}
 	m_progressBar->winHide(FALSE);	
 }


### PR DESCRIPTION
The initial progressbar after the intro is delayed 3 seconds for no reason. I don't know why they included this. Maybe they intended to implement a fadein effect and never got to it. Didn't happen for `-quickstart`. This PR removes the delay and also some commented code.

## TODO

- [x] Replicate in Generals