### PR TITLE
[GEN][ZH] Fix some RTS_DEBUG and RTS_INTERNAL defines

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanGameOptionsMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanGameOptionsMenu.cpp
@@ -221,7 +221,7 @@ static void playerTooltip(GameWindow *window,
 	}
 	UnicodeString tooltip;
 	tooltip.format(TheGameText->fetch("TOOLTIP:LANPlayer"), player->getName().str(), player->getLogin().str(), player->getHost().str());
-#if defined(_DEBUG) || defined(_INTERNAL)
+#if defined(RTS_DEBUG) || defined(RTS_INTERNAL)
 	UnicodeString ip;
 	ip.format(L" - %d.%d.%d.%d", PRINTF_IP_AS_4_INTS(player->getIP()));
 	tooltip.concat(ip);

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanLobbyMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanLobbyMenu.cpp
@@ -312,7 +312,7 @@ static void playerTooltip(GameWindow *window,
 	}
 	UnicodeString tooltip;
 	tooltip.format(TheGameText->fetch("TOOLTIP:LANPlayer"), player->getName().str(), player->getLogin().str(), player->getHost().str());
-#if defined(_DEBUG) || defined(_INTERNAL)
+#if defined(RTS_DEBUG) || defined(RTS_INTERNAL)
 	UnicodeString ip;
 	ip.format(L" - %d.%d.%d.%d", PRINTF_IP_AS_4_INTS(player->getIP()));
 	tooltip.concat(ip);
@@ -405,7 +405,7 @@ void LanLobbyMenuInit( WindowLayout *layout, void *userData )
 	{
 		IPSource = L"Default local IP";
 	}
-#if defined(_DEBUG) || defined(_INTERNAL)
+#if defined(RTS_DEBUG) || defined(RTS_INTERNAL)
 	UnicodeString str;
 	str.format(L"%s: %d.%d.%d.%d", IPSource, PRINTF_IP_AS_4_INTS(IP));
 	GadgetListBoxAddEntryText(listboxChatWindow, str, chatSystemColor, -1, 0);

--- a/Generals/Code/GameEngine/Source/GameNetwork/Connection.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/Connection.cpp
@@ -411,7 +411,7 @@ void Connection::doRetryMetrics() {
 	}
 }
 
-#if defined(RTS_DEBUG) || (RTS_INTERNAL)
+#if defined(RTS_DEBUG) || defined(RTS_INTERNAL)
 void Connection::debugPrintCommands() {
 	NetCommandRef *ref = m_netCommandList->getFirstMessage();
 	while (ref != NULL) {

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanGameOptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanGameOptionsMenu.cpp
@@ -228,7 +228,7 @@ static void playerTooltip(GameWindow *window,
 	}
 	UnicodeString tooltip;
 	tooltip.format(TheGameText->fetch("TOOLTIP:LANPlayer"), player->getName().str(), player->getLogin().str(), player->getHost().str());
-#if defined(_DEBUG) || defined(_INTERNAL)
+#if defined(RTS_DEBUG) || defined(RTS_INTERNAL)
 	UnicodeString ip;
 	ip.format(L" - %d.%d.%d.%d", PRINTF_IP_AS_4_INTS(player->getIP()));
 	tooltip.concat(ip);

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanLobbyMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanLobbyMenu.cpp
@@ -354,7 +354,7 @@ static void playerTooltip(GameWindow *window,
 	}
 	UnicodeString tooltip;
 	tooltip.format(TheGameText->fetch("TOOLTIP:LANPlayer"), player->getName().str(), player->getLogin().str(), player->getHost().str());
-#if defined(_DEBUG) || defined(_INTERNAL)
+#if defined(RTS_DEBUG) || defined(RTS_INTERNAL)
 	UnicodeString ip;
 	ip.format(L" - %d.%d.%d.%d", PRINTF_IP_AS_4_INTS(player->getIP()));
 	tooltip.concat(ip);
@@ -447,7 +447,7 @@ void LanLobbyMenuInit( WindowLayout *layout, void *userData )
 	{
 		IPSource = L"Default local IP";
 	}
-#if defined(_DEBUG) || defined(_INTERNAL)
+#if defined(RTS_DEBUG) || defined(RTS_INTERNAL)
 	UnicodeString str;
 	str.format(L"%s: %d.%d.%d.%d", IPSource, PRINTF_IP_AS_4_INTS(IP));
 	GadgetListBoxAddEntryText(listboxChatWindow, str, chatSystemColor, -1, 0);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/GarrisonContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/GarrisonContain.cpp
@@ -283,7 +283,7 @@ Bool GarrisonContain::calcBestGarrisonPosition( Coord3D *sourcePos, const Coord3
 	if( !sourcePos || !targetPos )
 		return FALSE;
 
-#if defined __DEBUG || defined RTS_INTERNAL
+#ifdef DEBUG_CRASHING
   const GarrisonContainModuleData *modData = getGarrisonContainModuleData();
   DEBUG_ASSERTCRASH(modData->m_isEnclosingContainer, ("calcBestGarrisonPosition... SHOULD NOT GET HERE, since this container is non-enclosing") );
 #endif
@@ -317,7 +317,7 @@ Bool GarrisonContain::attemptBestFirePointPosition( Object *source, Weapon *weap
 		return FALSE;
 	}
 
-#if defined __DEBUG || defined RTS_INTERNAL
+#ifdef DEBUG_CRASHING
   const GarrisonContainModuleData *modData = getGarrisonContainModuleData();
   DEBUG_ASSERTCRASH(modData->m_isEnclosingContainer, ("calcBestGarrisonPosition... SHOULD NOT GET HERE, since this container is non-enclosing") );
 #endif
@@ -357,7 +357,7 @@ Bool GarrisonContain::attemptBestFirePointPosition( Object *source, Weapon *weap
 	{
 		return FALSE;
 	}
-#if defined __DEBUG || defined RTS_INTERNAL
+#ifdef DEBUG_CRASHING
   const GarrisonContainModuleData *modData = getGarrisonContainModuleData();
   DEBUG_ASSERTCRASH(modData->m_isEnclosingContainer, ("calcBestGarrisonPosition... SHOULD NOT GET HERE, since this container is non-enclosing") );
 #endif
@@ -398,7 +398,7 @@ void GarrisonContain::putObjectAtBestGarrisonPoint( Object *obj, Object *target,
 	if( obj == NULL || (target == NULL && targetPos == NULL) )
 		return;
 
-#if defined __DEBUG || defined RTS_INTERNAL
+#ifdef DEBUG_CRASHING
   const GarrisonContainModuleData *modData = getGarrisonContainModuleData();
   DEBUG_ASSERTCRASH(modData->m_isEnclosingContainer, ("calcBestGarrisonPosition... SHOULD NOT GET HERE, since this container is non-enclosing") );
 #endif
@@ -433,7 +433,7 @@ void GarrisonContain::removeObjectFromGarrisonPoint( Object *obj, Int index )
   if ( ! isEnclosingContainerFor(obj) )
     return;// since I am not enclosed, I am not at a garrison point!
 
-#if defined __DEBUG || defined RTS_INTERNAL
+#ifdef DEBUG_CRASHING
   const GarrisonContainModuleData *modData = getGarrisonContainModuleData();
   DEBUG_ASSERTCRASH(modData->m_isEnclosingContainer, ("calcBestGarrisonPosition... SHOULD NOT GET HERE, since this container is non-enclosing") );
 #endif
@@ -587,7 +587,7 @@ Bool GarrisonContain::isValidContainerFor(const Object* obj, Bool checkCapacity)
 // ------------------------------------------------------------------------------------------------
 void GarrisonContain::removeInvalidObjectsFromGarrisonPoints( void )
 {
-#if defined __DEBUG || defined RTS_INTERNAL
+#ifdef DEBUG_CRASHING
   const GarrisonContainModuleData *modData = getGarrisonContainModuleData();
   DEBUG_ASSERTCRASH(modData->m_isEnclosingContainer, ("removeinvalidobjFromGarrisonPoint... SHOULD NOT GET HERE, since this container is non-enclosing") );
 #endif
@@ -638,7 +638,7 @@ void GarrisonContain::addValidObjectsToGarrisonPoints( void )
 {
 
 
-#if defined __DEBUG || defined RTS_INTERNAL
+#ifdef DEBUG_CRASHING
   const GarrisonContainModuleData *modData = getGarrisonContainModuleData();
   DEBUG_ASSERTCRASH(modData->m_isEnclosingContainer, ("addvalidobjtoGarrisonPoint... SHOULD NOT GET HERE, since this container is non-enclosing") );
 #endif
@@ -833,7 +833,7 @@ void GarrisonContain::updateEffects( void )
 {
 
 
-#if defined __DEBUG || defined RTS_INTERNAL
+#ifdef DEBUG_CRASHING
   const GarrisonContainModuleData *modData = getGarrisonContainModuleData();
   DEBUG_ASSERTCRASH(modData->m_isEnclosingContainer, ("updateeffects... SHOULD NOT GET HERE, since this container is non-enclosing") );
 #endif

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/Connection.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/Connection.cpp
@@ -411,7 +411,7 @@ void Connection::doRetryMetrics() {
 	}
 }
 
-#if defined(RTS_DEBUG) || (RTS_INTERNAL)
+#if defined(RTS_DEBUG) || defined(RTS_INTERNAL)
 void Connection::debugPrintCommands() {
 	NetCommandRef *ref = m_netCommandList->getFirstMessage();
 	while (ref != NULL) {


### PR DESCRIPTION
Fix some wrong #if expressions.

I changed `#if defined __DEBUG || defined RTS_INTERNAL` because those were not compiling with RTS_INTERNAL and DEBUG_CRASHING disabled.

## TODO

- [x] Replicate in Generals