### PR TITLE
bugfix(rendering): Fix the bugged Heat Haze (Smudge) effect of the USA Microwave Tank

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DSmudge.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DSmudge.cpp
@@ -239,16 +239,20 @@ Bool W3DSmudgeManager::testHardwareSupport(void)
 
 		//bottom right
 		v[0].p = Vector4( BLOCK_SIZE-0.5f, BLOCK_SIZE-0.5f, 0.0f, 1.0f );
-		v[0].u = BLOCK_SIZE/(Real)TheDisplay->getWidth();	v[0].v = BLOCK_SIZE/(Real)TheDisplay->getHeight();
+		v[0].u = BLOCK_SIZE/(Real)TheDisplay->getWidth();
+		v[0].v = BLOCK_SIZE/(Real)TheDisplay->getHeight();
 		//top right
 		v[1].p = Vector4( BLOCK_SIZE-0.5f, 0-0.5f, 0.0f, 1.0f );
-		v[1].u = BLOCK_SIZE/(Real)TheDisplay->getWidth();	v[1].v = 0;
+		v[1].u = BLOCK_SIZE/(Real)TheDisplay->getWidth();
+		v[1].v = 0;
 		//bottom left
 		v[2].p = Vector4(  0-0.5f, BLOCK_SIZE-0.5f, 0.0f, 1.0f );
-		v[2].u = 0;	v[2].v = BLOCK_SIZE/(Real)TheDisplay->getHeight();
+		v[2].u = 0;
+		v[2].v = BLOCK_SIZE/(Real)TheDisplay->getHeight();
 		//top left
 		v[3].p = Vector4(  0-0.5f,  0-0.5f, 0.0f, 1.0f );
-		v[3].u = 0;	v[3].v = 0;
+		v[3].u = 0;
+		v[3].v = 0;
 
 		v[0].color = UNIQUE_COLOR;
 		v[1].color = UNIQUE_COLOR;

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DSmudge.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DSmudge.cpp
@@ -72,10 +72,10 @@ void W3DSmudgeManager::ReleaseResources(void)
 	REF_PTR_RELEASE(m_indexBuffer);
 }
 
-//Make sure (SMUDGE_DRAW_SIZE * 12) < 65535 because that's the max index buffer size.
+
 #define SMUDGE_DRAW_SIZE	500	//draw at most 50 smudges per call. Tweak value to improve CPU/GPU parallelism.
 
-static_assert(SMUDGE_DRAW_SIZE * 12 < 65535, "Must not exceed the max index buffer size");
+static_assert(SMUDGE_DRAW_SIZE * 5 < 0x10000, "Vertex index exceeds 16-bit limit");
 
 
 void W3DSmudgeManager::ReAcquireResources(void)

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DSmudge.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DSmudge.cpp
@@ -403,7 +403,7 @@ void W3DSmudgeManager::render(RenderInfoClass &rinfo)
 			uvSpanX=verts[3].uv.X - verts[0].uv.X;
 			uvSpanY=verts[1].uv.Y - verts[0].uv.Y;
 			verts[4].uv.X=verts[0].uv.X+uvSpanX*(0.5f+smudge->m_offset.X);
-			verts[4].uv.Y=verts[0].uv.Y+uvSpanY*(0.5f+smudge->m_offset.X);
+			verts[4].uv.Y=verts[0].uv.Y+uvSpanY*(0.5f+smudge->m_offset.Y);
 
 			count++;	//increment visible smudge count.
 			smudge=smudge->Succ();

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DSmudge.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DSmudge.cpp
@@ -394,18 +394,8 @@ void W3DSmudgeManager::render(RenderInfoClass &rinfo)
 				Vector2 &thisUV=verts[i].uv;
 
 				//Clamp coordinates so we're not referencing texels outside the view.
-				if (thisUV.X > texClampX)
-					smudge->m_offset.X = 0;
-				else
-				if (thisUV.X < 0)
-					smudge->m_offset.X = 0;
-
-				if (thisUV.Y > texClampY)
-					smudge->m_offset.Y = 0;
-				else
-				if (thisUV.Y < 0)
-					smudge->m_offset.Y = 0;
-
+				WWMath::Clamp(thisUV.X, 0, texClampX);
+				WWMath::Clamp(thisUV.Y, 0, texClampY);
 			}
 
 			//Finish center vertex

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
@@ -455,6 +455,8 @@ public:
 	static void _Enable_Triangle_Draw(bool enable) { _EnableTriangleDraw=enable; }
 	static bool _Is_Triangle_Draw_Enabled() { return _EnableTriangleDraw; }
 
+	static unsigned int Bytes_Per_Pixel(D3DFORMAT format);
+
 	/*
 	** Additional swap chain interface
 	**
@@ -1159,6 +1161,85 @@ WWINLINE void DX8Wrapper::Set_Alpha (const float alpha, unsigned int &color)
 	unsigned char *component = (unsigned char*) &color;
 
 	component [3] = 255.0f * alpha;
+}
+
+WWINLINE unsigned int DX8Wrapper::Bytes_Per_Pixel(D3DFORMAT format)
+{
+	switch (format)
+	{
+	// 8-bit formats
+	case D3DFMT_A8:
+	case D3DFMT_P8:
+	case D3DFMT_L8:
+		return 1;
+
+	// 16-bit formats
+	case D3DFMT_R5G6B5:
+	case D3DFMT_X1R5G5B5:
+	case D3DFMT_A1R5G5B5:
+	case D3DFMT_A4R4G4B4:
+	case D3DFMT_X4R4G4B4:
+	case D3DFMT_A8L8:
+	case D3DFMT_A4L4:
+	case D3DFMT_V8U8:
+	case D3DFMT_L6V5U5:
+		return 2;
+
+	// 24-bit formats
+	case D3DFMT_R8G8B8:
+		return 3;
+
+	// 32-bit formats
+	case D3DFMT_A8R8G8B8:
+	case D3DFMT_X8R8G8B8:
+	case D3DFMT_A8R3G3B2:
+	case D3DFMT_A2B10G10R10:
+	case D3DFMT_G16R16:
+	case D3DFMT_X8L8V8U8:
+	case D3DFMT_Q8W8V8U8:
+	case D3DFMT_W11V11U10:
+	case D3DFMT_A2W10V10U10:
+	case D3DFMT_V16U16:
+		return 4;
+
+	// Palette-based alpha
+	case D3DFMT_A8P8:
+		return 0;
+
+	// Packed YUV
+	case D3DFMT_UYVY:
+	case D3DFMT_YUY2:
+		return 0;
+
+	// Block-compressed
+	case D3DFMT_DXT1:
+	case D3DFMT_DXT2:
+	case D3DFMT_DXT3:
+	case D3DFMT_DXT4:
+	case D3DFMT_DXT5:
+		return 0;
+
+	// Depth / stencil
+	case D3DFMT_D16_LOCKABLE:
+	case D3DFMT_D16:
+	case D3DFMT_D15S1:
+	case D3DFMT_D24S8:
+	case D3DFMT_D24X8:
+	case D3DFMT_D24X4S4:
+	case D3DFMT_D32:
+		return 0;
+
+	// Non-image data
+	case D3DFMT_VERTEXDATA:
+	case D3DFMT_INDEX16:
+	case D3DFMT_INDEX32:
+		return 0;
+
+	// Unknown / invalid
+	case D3DFMT_UNKNOWN:
+	default:
+		return 0;
+	}
 }
 
 WWINLINE void DX8Wrapper::Get_Render_State(RenderStateStruct& state)

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
@@ -527,6 +527,7 @@ public:
 	static IDirect3D8* _Get_D3D8() { return D3DInterface; }
 	/// Returns the display format - added by TR for video playback - not part of W3D
 	static WW3DFormat	getBackBufferFormat( void );
+	static D3DFORMAT _Get_D3D_Back_Buffer_Format() { return DisplayFormat; }
 	static bool Reset_Device(bool reload_assets=true);
 
 	static const DX8Caps*	Get_Current_Caps() { WWASSERT(CurrentCaps); return CurrentCaps; }


### PR DESCRIPTION
* Maybe fixes #90

This change fixes the bugged Heat Haze (aka Smudge) effect of the USA Microwave Tank as far as I can reproduce it on my machine.

I have an AMD RX 590. I am unable to reproduce the black screen portion of the issue, but I can reliably reproduce the missing effect.

After a lot of testing and trying different code changes, I figured that this only happens when there is just a single draw call for the smudges. As soon as there were 2, everything worked perfectly. I agreed with Chat Gippity that perhaps this is some GPU driver issue that does not commit to a single draw call and needs some help to commit to it by issuing another dummy draw call.

In my tests, this avoided the issue.

We can only hope that it also fixes the black screen, unless we find a person that can reliably reproduce the black screen.

## Original

https://github.com/user-attachments/assets/787afc57-af64-4b55-a3b7-9b1afb903805

## This change

https://github.com/user-attachments/assets/dfb0258a-39ae-4376-966f-b76701f6abc7
