### PR TITLE
[GEN][ZH] Significantly improve runtime performance by removing extraneous call to fflush in RecorderClass::writeToFile()

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Recorder.cpp
@@ -789,7 +789,6 @@ void RecorderClass::writeToFile(GameMessage * msg) {
 	deleteInstance(parser);
 	parser = NULL;
 
-	fflush(m_file); ///< @todo should this be in the final release?
 }
 
 void RecorderClass::writeArgument(GameMessageArgumentDataType type, const GameMessageArgumentType arg) {

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -791,7 +791,6 @@ void RecorderClass::writeToFile(GameMessage * msg) {
 	deleteInstance(parser);
 	parser = NULL;
 
-	fflush(m_file); ///< @todo should this be in the final release?
 }
 
 void RecorderClass::writeArgument(GameMessageArgumentDataType type, const GameMessageArgumentType arg) {


### PR DESCRIPTION
- Relates To: #1074 

This PR removes an extranous call to flush data to disk within the recorder class.
This extraneous ```fflush()``` call prevents the file system from buffering data before writing to disc which can cause performance issues on some systems when recording replays.

Only the ```RecorderClass::updateRecord()``` calls ```writeToFile``` and at the end it calls ```fflush()``` once the command stream has been processed. Therefore the command stream is always flushed to disc at least once each frame.