### PR TITLE
[GEN][ZH] Fix erroneous fflush(NULL) in RecorderClass::updateRecord()

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Recorder.cpp
@@ -515,6 +515,7 @@ void RecorderClass::updateRecord()
 				lastFrame = -1;
 				writeToFile(msg);
 				stopRecording();
+				needFlush = FALSE;
 			}
 			m_fileName.clear();
 		} else {
@@ -531,6 +532,7 @@ void RecorderClass::updateRecord()
 	}
 
 	if (needFlush) {
+		DEBUG_ASSERTCRASH(m_file != NULL, ("RecorderClass::updateRecord() - unexpected call to fflush(m_file)\n"));
 		fflush(m_file);
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -517,6 +517,7 @@ void RecorderClass::updateRecord()
 				lastFrame = -1;
 				writeToFile(msg);
 				stopRecording();
+				needFlush = FALSE;
 			}
 			m_fileName.clear();
 		} else {
@@ -533,6 +534,7 @@ void RecorderClass::updateRecord()
 	}
 
 	if (needFlush) {
+		DEBUG_ASSERTCRASH(m_file != NULL, ("RecorderClass::updateRecord() - unexpected call to fflush(m_file)\n"));
 		fflush(m_file);
 	}
 }


### PR DESCRIPTION
While reviewing #1076, I noticed that fflush can be called with NULL in RecorderClass::updateRecord() after processing MSG_CLEAR_GAME_DATA.

![image](https://github.com/user-attachments/assets/6deac808-f608-4fd9-bc6b-7b0d5526df14)

According to https://en.cppreference.com/w/c/io/fflush it does

> If stream is a null pointer, all open output streams are flushed, including the ones manipulated within library packages or otherwise not directly accessible to the program.

This cannot be the intention here. This change fixes it.