### PR TITLE
[GEN][ZH] Change reference counter implementation for StateMachine to avoid mismatch with Retail

### DIFF
--- a/Core/Libraries/Source/WWVegas/WWLib/refcount.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/refcount.h
@@ -277,9 +277,9 @@ public:
 		++NumRefs;
 	}
 
-	// Can pass static function or 'operator delete'.
-	template <typename ObjectType, typename DeleteType>
-	void Release_Ref(void(*deleteFunction)(DeleteType*), const ObjectType* objectToDelete) const
+	// Can pass static function of type void(*)(DeleteType*) or 'operator delete'.
+	template <typename DeleteFunction, typename ObjectType>
+	void Release_Ref(DeleteFunction deleteFunction, const ObjectType* objectToDelete) const
 	{
 		WWASSERT(NumRefs != IntegerType(0));
 		if (--NumRefs == IntegerType(0))

--- a/Core/Libraries/Source/WWVegas/WWLib/refcount.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/refcount.h
@@ -103,6 +103,10 @@ struct ActiveRefStruct
 typedef DataNode<RefCountClass *>	RefCountNodeClass;
 typedef List<RefCountNodeClass *>	RefCountListClass;
 
+/*
+** Note that Add_Ref and Release_Ref are always const, because copying, destroying and reference
+** counting const objects is meant to work.
+*/
 class RefCountClass
 {
 public:
@@ -254,8 +258,13 @@ public:
 };
 
 
-// This template class is meant to be used as a class member for compact reference counter placements.
-// A 1 byte reference counter can be alright if the counter is not reaching the boundaries.
+/*
+** This template class is meant to be used as a class member for compact reference counter placements.
+** A 1 byte reference counter can be alright if the counter is not reaching the value limits.
+* 
+** Note that Add_Ref and Release_Ref are always const, because copying, destroying and reference
+** counting const objects is meant to work.
+*/
 template <typename IntegerType>
 class RefCountValue
 {
@@ -271,13 +280,22 @@ public:
 		WWASSERT(NumRefs == IntegerType(0));
 	}
 
+	/*
+	** Add_Ref, call this function if you are going to keep a pointer to this object.
+	*/
 	void Add_Ref(void) const
 	{
 		WWASSERT(NumRefs != ~IntegerType(0));
 		++NumRefs;
 	}
 
-	// Can pass static function of type void(*)(DeleteType*) or 'operator delete'.
+	/*
+	** Release_Ref, call this function when you no longer need the pointer to this object.
+	** You can pass a static function of type void(*)(DeleteType*) or 'operator delete'.
+	**
+	** Note that this function takes a const ObjectType*, because this function is expected
+	** to be called from within a const function as well.
+	*/
 	template <typename DeleteFunction, typename ObjectType>
 	void Release_Ref(DeleteFunction deleteFunction, const ObjectType* objectToDelete) const
 	{
@@ -288,6 +306,9 @@ public:
 		}
 	}
 
+	/*
+	** Check the number of references to this object.
+	*/
 	IntegerType Num_Refs(void) const
 	{
 		return NumRefs;

--- a/Core/Libraries/Source/WWVegas/WWLib/refcount.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/refcount.h
@@ -279,12 +279,12 @@ public:
 
 	// Can pass static function or 'operator delete'.
 	template <typename ObjectType, typename DeleteType>
-	void Release_Ref(void(*deleteFunction)(DeleteType*), ObjectType* objectToDelete) const
+	void Release_Ref(void(*deleteFunction)(DeleteType*), const ObjectType* objectToDelete) const
 	{
 		WWASSERT(NumRefs != IntegerType(0));
 		if (--NumRefs == IntegerType(0))
 		{
-			deleteFunction(objectToDelete);
+			deleteFunction(const_cast<ObjectType*>(objectToDelete));
 		}
 	}
 

--- a/Core/Libraries/Source/WWVegas/WWLib/refcount.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/refcount.h
@@ -273,7 +273,7 @@ public:
 
 	void Add_Ref(void) const
 	{
-		WWASSERT(NumRefs < IntegerType(0)-1);
+		WWASSERT(NumRefs != ~IntegerType(0));
 		++NumRefs;
 	}
 
@@ -294,6 +294,7 @@ public:
 	}
 
 private:
+
 	mutable IntegerType NumRefs;
 };
 

--- a/Generals/Code/GameEngine/Include/Common/StateMachine.h
+++ b/Generals/Code/GameEngine/Include/Common/StateMachine.h
@@ -238,7 +238,7 @@ inline State::~State() { }
 /**
  * A finite state machine.
  */
-class StateMachine : public MemoryPoolObject, public Snapshot, public RefCountClass
+class StateMachine : public MemoryPoolObject, public Snapshot
 {
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( StateMachine, "StateMachinePool" );
 
@@ -263,6 +263,10 @@ public:
 	virtual StateReturnType initDefaultState();	
 
 	virtual StateReturnType setState( StateID newStateID );			///< change the current state of the machine (which may cause further state changes, due to onEnter)
+
+	void Add_Ref() const { m_refCount.Add_Ref(); }
+	void Release_Ref() const { m_refCount.Release_Ref(MemoryPoolObject::deleteInstanceInternal, this); }
+	void Num_Refs() const { m_refCount.Num_Refs(); }
 
 	StateID getCurrentStateID() const { return m_currentState ? m_currentState->getID() : INVALID_STATE_ID; }	///< return the id of the current state of the machine
 	Bool isInIdleState() const { return m_currentState ? m_currentState->isIdle() : true; }	// stateless things are considered 'idle'
@@ -342,12 +346,6 @@ protected:
 	virtual void xfer( Xfer *xfer );
 	virtual void loadPostProcess();	
 
-	// RefCountClass interface
-	virtual void Delete_This()
-	{
-		MemoryPoolObject::deleteInstanceInternal(this);
-	}
-
 protected:
 
 	/**
@@ -383,6 +381,8 @@ private:
 
 	Bool					m_locked;													///< whether this machine is locked or not
 	Bool					m_defaultStateInited;							///< if initDefaultState has been called
+
+	RefCountValue<UnsignedByte> m_refCount;
 
 #ifdef STATE_MACHINE_DEBUG
 	Bool					m_debugOutput;

--- a/GeneralsMD/Code/GameEngine/Include/Common/StateMachine.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/StateMachine.h
@@ -239,7 +239,7 @@ inline State::~State() { }
 /**
  * A finite state machine.
  */
-class StateMachine : public MemoryPoolObject, public Snapshot, public RefCountClass
+class StateMachine : public MemoryPoolObject, public Snapshot
 {
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( StateMachine, "StateMachinePool" );
 
@@ -264,6 +264,10 @@ public:
 	virtual StateReturnType initDefaultState();	
 
 	virtual StateReturnType setState( StateID newStateID );			///< change the current state of the machine (which may cause further state changes, due to onEnter)
+
+	void Add_Ref() const { m_refCount.Add_Ref(); }
+	void Release_Ref() const { m_refCount.Release_Ref(MemoryPoolObject::deleteInstanceInternal, const_cast<StateMachine*>(this)); }
+	void Num_Refs() const { m_refCount.Num_Refs(); }
 
 	StateID getCurrentStateID() const { return m_currentState ? m_currentState->getID() : INVALID_STATE_ID; }	///< return the id of the current state of the machine
 	Bool isInIdleState() const { return m_currentState ? m_currentState->isIdle() : true; }	// stateless things are considered 'idle'
@@ -344,12 +348,6 @@ protected:
 	virtual void xfer( Xfer *xfer );
 	virtual void loadPostProcess();	
 
-	// RefCountClass interface
-	virtual void Delete_This()
-	{
-		MemoryPoolObject::deleteInstanceInternal(this);
-	}
-
 protected:
 
 	/**
@@ -385,6 +383,8 @@ private:
 
 	Bool					m_locked;													///< whether this machine is locked or not
 	Bool					m_defaultStateInited;							///< if initDefaultState has been called
+
+	RefCountValue<UnsignedByte> m_refCount;
 
 #ifdef STATE_MACHINE_DEBUG
 	Bool					m_debugOutput;

--- a/GeneralsMD/Code/GameEngine/Include/Common/StateMachine.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/StateMachine.h
@@ -266,7 +266,7 @@ public:
 	virtual StateReturnType setState( StateID newStateID );			///< change the current state of the machine (which may cause further state changes, due to onEnter)
 
 	void Add_Ref() const { m_refCount.Add_Ref(); }
-	void Release_Ref() const { m_refCount.Release_Ref(MemoryPoolObject::deleteInstanceInternal, const_cast<StateMachine*>(this)); }
+	void Release_Ref() const { m_refCount.Release_Ref(MemoryPoolObject::deleteInstanceInternal, this); }
 	void Num_Refs() const { m_refCount.Num_Refs(); }
 
 	StateID getCurrentStateID() const { return m_currentState ? m_currentState->getID() : INVALID_STATE_ID; }	///< return the id of the current state of the machine


### PR DESCRIPTION
* Fixes #1064
* Follow up for #890

This changes the reference counter implementation for `StateMachine` to avoid mismatch with Retail.

The previous reference counter changes the struct layout of `StateMachine`, which then changed the generated assembler code of many functions that interact with `StateMachine`.

## TODO

- [x] Test and confirm that this fixes the observed mismatch
- [x] Replicate in Generals