### PR TITLE
[GEN][ZH] Annotate fallthrough between various switch case labels

### DIFF
--- a/Core/Libraries/Source/WWVegas/WWLib/always.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/always.h
@@ -46,7 +46,6 @@
 // TheSuperHackers @compile feliwir 17/04/2025 include utility macros for cross-platform compatibility
 #include <Utility/compat.h>
 #include <Utility/stdint_adapter.h>
-
 #include <Utility/CppMacros.h>
 
 // Disable warning about exception handling not being enabled. It's used as part of STL - in a part of STL we don't use.

--- a/Dependencies/Utility/Utility/CppMacros.h
+++ b/Dependencies/Utility/Utility/CppMacros.h
@@ -21,8 +21,12 @@
 
 #if __cplusplus >= 201703L
 #define NOEXCEPT_17 noexcept
+#define REGISTER
+#define FALLTHROUGH [[fallthrough]]
 #else
 #define NOEXCEPT_17
+#define REGISTER register
+#define FALLTHROUGH
 #endif
 
 // noexcept for methods of IUNKNOWN interface
@@ -36,12 +40,6 @@
     #define CPP_11(code) code
 #else
     #define CPP_11(code)
-#endif
-
-#if __cplusplus >= 201703L
-#define REGISTER
-#else
-#define REGISTER register
 #endif
 
 #if __cplusplus < 201103L

--- a/Generals/Code/GameEngine/Source/Common/RandomValue.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RandomValue.cpp
@@ -383,6 +383,7 @@ Real GameClientRandomVariable::getValue( void ) const
 			if (m_low == m_high) {
 				return m_low;
 			} // else return as though a UNIFORM.
+			FALLTHROUGH;
 
 		case UNIFORM:
 			return GameClientRandomValueReal( m_low, m_high );
@@ -427,6 +428,7 @@ Real GameLogicRandomVariable::getValue( void ) const
 			if (m_low == m_high) {
 				return m_low;
 			} // else return as though a UNIFORM.
+			FALLTHROUGH;
 
 		case UNIFORM:
 			return GameLogicRandomValueReal( m_low, m_high );

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
@@ -1877,20 +1877,23 @@ void grabSinglePlayerInfo( void )
 	{
 		Bool isFriend = TRUE;
 		
-		// set the string we'll be compairing to
+		// set the string we'll be comparing to
 		switch (j) {
 		case USA_ENEMY:
 			isFriend = FALSE;
+			FALLTHROUGH;
 		case USA_FRIEND:
 			side.set("America");
 			break;
 		case CHINA_ENEMY:
 			isFriend = FALSE;
+			FALLTHROUGH;
 		case CHINA_FRIEND:
 			side.set("China");
 			break;
 		case GLA_ENEMY:
-			isFriend = FALSE;	
+			isFriend = FALSE;
+			FALLTHROUGH;
 		case GLA_FRIEND:
 			side.set("GLA");
 			break;

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GameWindowTransitionsStyles.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GameWindowTransitionsStyles.cpp
@@ -142,6 +142,8 @@ void FlashTransition::update( Int frame )
 			}  // end if
 		
 		}
+		FALLTHROUGH;
+
 	case FLASHTRANSITION_FADE_IN_2:
 	case FLASHTRANSITION_FADE_IN_3:
 		{
@@ -810,8 +812,8 @@ void ScaleUpTransition::update( Int frame )
 				TheAudio->addAudioEvent( &buttonClick );
 			}  // end if
 
-			
 		}
+		FALLTHROUGH;
 
 	case SCALEUPTRANSITION_2:
 	case SCALEUPTRANSITION_3:
@@ -933,8 +935,8 @@ void ScoreScaleUpTransition::update( Int frame )
 				TheAudio->addAudioEvent( &buttonClick );
 			}  // end if
 
-			
 		}
+		FALLTHROUGH;
 
 	case SCORESCALEUPTRANSITION_2:
 	case SCORESCALEUPTRANSITION_3:

--- a/Generals/Code/GameEngine/Source/GameClient/GameText.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GameText.cpp
@@ -630,6 +630,7 @@ void GameTextManager::readToEndOfQuote( File *file, Char *in, Char *out, Char *w
 				}
 
 				state = 1;
+				FALLTHROUGH;
 			case 1:
 				if ( ( ch >= 'a' && ch <= 'z') || ( ch >= 'A' && ch <='Z') || (ch >= '0' && ch <= '9') || ch == '_' )
 				{
@@ -638,6 +639,7 @@ void GameTextManager::readToEndOfQuote( File *file, Char *in, Char *out, Char *w
 					break;
 				}
 				state = 2;
+				FALLTHROUGH;
 			case 2:
 				break;
 		}

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/WindowXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/WindowXlat.cpp
@@ -204,7 +204,7 @@ GameMessageDisposition WindowTranslator::translateGameMessage(const GameMessage 
 				//If we release the button outside
 				forceKeepMessage = TRUE;
 			}
-			//FALL THROUGH INTENTIONALLY!
+			FALLTHROUGH; //FALL THROUGH INTENTIONALLY!
 		}
 		case GameMessage::MSG_RAW_MOUSE_POSITION:
 		case GameMessage::MSG_RAW_MOUSE_LEFT_BUTTON_DOWN:

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/HackInternetAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/HackInternetAIUpdate.cpp
@@ -494,28 +494,28 @@ StateReturnType HackInternetState::update()
 						{
 							break;
 						}
-						//If entry missing, fall through!
+						FALLTHROUGH; //If entry missing, fall through!
 					case LEVEL_ELITE:
 						amount = ai->getEliteCashAmount();
 						if( amount )
 						{
 							break;
 						}
-						//If entry missing, fall through!
+						FALLTHROUGH; //If entry missing, fall through!
 					case LEVEL_VETERAN:
 						amount = ai->getVeteranCashAmount();
 						if( amount )
 						{
 							break;
 						}
-						//If entry missing, fall through!
+						FALLTHROUGH; //If entry missing, fall through!
 					case LEVEL_REGULAR:
 						amount = ai->getRegularCashAmount();
 						if( amount )
 						{
 							break;
 						}
-						//If entry missing, fall through!
+						FALLTHROUGH; //If entry missing, fall through!
 					default:
 						amount = 1;
 						break;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -2216,7 +2216,7 @@ void JetAIUpdate::aiDoCommand(const AICommandParms* parms)
 				if (isParkedAt(parms->m_obj))
 					return;
 			
-				// else fall thru to the default case!
+				FALLTHROUGH; // else fall thru to the default case!
 
 			default:
 			{

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/MissileAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/MissileAIUpdate.cpp
@@ -652,6 +652,8 @@ UpdateSleepTime MissileAIUpdate::update()
 			{
 				break;
 			}
+			FALLTHROUGH;
+
 		case IGNITION:
 			doIgnitionState();
 			break;

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/Scripts.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/Scripts.cpp
@@ -1776,7 +1776,7 @@ void Parameter::qualify(const AsciiString& qualifier,
 			if (m_string == THIS_TEAM) {
 				break;
 			}
-			/// otherwise drop down & qualify.
+			FALLTHROUGH; /// otherwise drop down & qualify.
 		case SCRIPT:
 		case COUNTER:
 		case FLAG:

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/meshmdlio.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/meshmdlio.cpp
@@ -344,7 +344,7 @@ WW3DErrorType MeshModelClass::Load_W3D(ChunkLoadClass & cload)
 					Set_Flag (PRELIT_LIGHTMAP_MULTI_TEXTURE, true);
 					break;
 				}
-				// Else fall thru...
+				FALLTHROUGH; // Else fall thru...
 
 			case WW3D::PRELIT_MODE_LIGHTMAP_MULTI_PASS:
 				if (context->Header.Attributes & W3D_MESH_FLAG_PRELIT_LIGHTMAP_MULTI_PASS) {
@@ -352,7 +352,7 @@ WW3DErrorType MeshModelClass::Load_W3D(ChunkLoadClass & cload)
 					Set_Flag (PRELIT_LIGHTMAP_MULTI_PASS, true);
 					break;
 				}
-				// Else fall thru...
+				FALLTHROUGH; // Else fall thru...
 
 			case WW3D::PRELIT_MODE_VERTEX:
 				if (context->Header.Attributes & W3D_MESH_FLAG_PRELIT_VERTEX) {
@@ -360,7 +360,7 @@ WW3DErrorType MeshModelClass::Load_W3D(ChunkLoadClass & cload)
 					Set_Flag (PRELIT_VERTEX, true);
 					break;
 				}
-				// Else fall thru...
+				FALLTHROUGH; // Else fall thru...
 
 			default:
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/RandomValue.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RandomValue.cpp
@@ -383,6 +383,7 @@ Real GameClientRandomVariable::getValue( void ) const
 			if (m_low == m_high) {
 				return m_low;
 			} // else return as though a UNIFORM.
+			FALLTHROUGH;
 
 		case UNIFORM:
 			return GameClientRandomValueReal( m_low, m_high );
@@ -427,6 +428,7 @@ Real GameLogicRandomVariable::getValue( void ) const
 			if (m_low == m_high) {
 				return m_low;
 			} // else return as though a UNIFORM.
+			FALLTHROUGH;
 
 		case UNIFORM:
 			return GameLogicRandomValueReal( m_low, m_high );

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
@@ -2145,20 +2145,23 @@ void grabSinglePlayerInfo( void )
 	{
 		Bool isFriend = TRUE;
 		
-		// set the string we'll be compairing to
+		// set the string we'll be comparing to
 		switch (j) {
 		case USA_ENEMY:
 			isFriend = FALSE;
+			FALLTHROUGH;
 		case USA_FRIEND:
 			side.set("USA");
 			break;
 		case CHINA_ENEMY:
 			isFriend = FALSE;
+			FALLTHROUGH;
 		case CHINA_FRIEND:
 			side.set("China");
 			break;
 		case GLA_ENEMY:
-			isFriend = FALSE;	
+			isFriend = FALSE;
+			FALLTHROUGH;
 		case GLA_FRIEND:
 			side.set("GLA");
 			break;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowTransitionsStyles.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowTransitionsStyles.cpp
@@ -142,6 +142,8 @@ void FlashTransition::update( Int frame )
 			}  // end if
 		
 		}
+		FALLTHROUGH;
+
 	case FLASHTRANSITION_FADE_IN_2:
 	case FLASHTRANSITION_FADE_IN_3:
 		{
@@ -810,8 +812,8 @@ void ScaleUpTransition::update( Int frame )
 				TheAudio->addAudioEvent( &buttonClick );
 			}  // end if
 
-			
 		}
+		FALLTHROUGH;
 
 	case SCALEUPTRANSITION_2:
 	case SCALEUPTRANSITION_3:
@@ -933,8 +935,8 @@ void ScoreScaleUpTransition::update( Int frame )
 				TheAudio->addAudioEvent( &buttonClick );
 			}  // end if
 
-			
 		}
+		FALLTHROUGH;
 
 	case SCORESCALEUPTRANSITION_2:
 	case SCORESCALEUPTRANSITION_3:

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GameText.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GameText.cpp
@@ -630,6 +630,7 @@ void GameTextManager::readToEndOfQuote( File *file, Char *in, Char *out, Char *w
 				}
 
 				state = 1;
+				FALLTHROUGH;
 			case 1:
 				if ( ( ch >= 'a' && ch <= 'z') || ( ch >= 'A' && ch <='Z') || (ch >= '0' && ch <= '9') || ch == '_' )
 				{
@@ -638,6 +639,7 @@ void GameTextManager::readToEndOfQuote( File *file, Char *in, Char *out, Char *w
 					break;
 				}
 				state = 2;
+				FALLTHROUGH;
 			case 2:
 				break;
 		}

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -3704,7 +3704,7 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 
 				break;
 			}
-			//intentional fall through
+			FALLTHROUGH; //intentional fall through
 		}
 		case GameMessage::MSG_MOUSE_RIGHT_CLICK:
 		{
@@ -3767,7 +3767,7 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 
 				break;
 			}
-			//intentional fall through
+			FALLTHROUGH; //intentional fall through
 		}
 		case GameMessage::MSG_MOUSE_LEFT_CLICK:
 		{

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/WindowXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/WindowXlat.cpp
@@ -222,7 +222,7 @@ GameMessageDisposition WindowTranslator::translateGameMessage(const GameMessage 
 				//If we release the button outside
 				forceKeepMessage = TRUE;
 			}
-			//FALL THROUGH INTENTIONALLY!
+			FALLTHROUGH; //FALL THROUGH INTENTIONALLY!
 		}
 		case GameMessage::MSG_RAW_MOUSE_POSITION:
 		case GameMessage::MSG_RAW_MOUSE_LEFT_BUTTON_DOWN:

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/HackInternetAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/HackInternetAIUpdate.cpp
@@ -506,28 +506,28 @@ StateReturnType HackInternetState::update()
 						{
 							break;
 						}
-						//If entry missing, fall through!
+						FALLTHROUGH; //If entry missing, fall through!
 					case LEVEL_ELITE:
 						amount = ai->getEliteCashAmount();
 						if( amount )
 						{
 							break;
 						}
-						//If entry missing, fall through!
+						FALLTHROUGH; //If entry missing, fall through!
 					case LEVEL_VETERAN:
 						amount = ai->getVeteranCashAmount();
 						if( amount )
 						{
 							break;
 						}
-						//If entry missing, fall through!
+						FALLTHROUGH; //If entry missing, fall through!
 					case LEVEL_REGULAR:
 						amount = ai->getRegularCashAmount();
 						if( amount )
 						{
 							break;
 						}
-						//If entry missing, fall through!
+						FALLTHROUGH; //If entry missing, fall through!
 					default:
 						amount = 1;
 						break;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -2450,7 +2450,7 @@ void JetAIUpdate::aiDoCommand(const AICommandParms* parms)
 				if (isParkedAt(parms->m_obj))
 					return;
 			
-				// else fall thru to the default case!
+				FALLTHROUGH; // else fall thru to the default case!
 
 			default:
 			{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/MissileAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/MissileAIUpdate.cpp
@@ -707,6 +707,8 @@ UpdateSleepTime MissileAIUpdate::update()
 			{
 				break;
 			}
+			FALLTHROUGH;
+
 		case IGNITION:
 			doIgnitionState();
 			break;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
@@ -280,7 +280,7 @@ UpdateSleepTime SpecialAbilityUpdate::update( void )
             // it's been captured by a colleague! we should stop.
             shouldAbort = TRUE;
           }
-          //deliberately falling through...
+          FALLTHROUGH; //deliberately falling through...
         }
         case SPECIAL_BLACKLOTUS_STEAL_CASH_HACK:
         case SPECIAL_BOOBY_TRAP:
@@ -309,7 +309,7 @@ UpdateSleepTime SpecialAbilityUpdate::update( void )
         {
           if ( target->isKindOf( KINDOF_STRUCTURE ) )
             shouldAbort = TRUE;
-          //deliberately falling through
+          FALLTHROUGH; //deliberately falling through
         }
         case SPECIAL_BLACKLOTUS_DISABLE_VEHICLE_HACK:
         {

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/Scripts.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/Scripts.cpp
@@ -1837,7 +1837,7 @@ void Parameter::qualify(const AsciiString& qualifier,
 			if (m_string == THIS_TEAM) {
 				break;
 			}
-			/// otherwise drop down & qualify.
+			FALLTHROUGH; /// otherwise drop down & qualify.
 		case SCRIPT:
 		case COUNTER:
 		case FLAG:

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmdlio.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmdlio.cpp
@@ -344,7 +344,7 @@ WW3DErrorType MeshModelClass::Load_W3D(ChunkLoadClass & cload)
 					Set_Flag (PRELIT_LIGHTMAP_MULTI_TEXTURE, true);
 					break;
 				}
-				// Else fall thru...
+				FALLTHROUGH; // Else fall thru...
 
 			case WW3D::PRELIT_MODE_LIGHTMAP_MULTI_PASS:
 				if (context->Header.Attributes & W3D_MESH_FLAG_PRELIT_LIGHTMAP_MULTI_PASS) {
@@ -352,7 +352,7 @@ WW3DErrorType MeshModelClass::Load_W3D(ChunkLoadClass & cload)
 					Set_Flag (PRELIT_LIGHTMAP_MULTI_PASS, true);
 					break;
 				}
-				// Else fall thru...
+				FALLTHROUGH; // Else fall thru...
 
 			case WW3D::PRELIT_MODE_VERTEX:
 				if (context->Header.Attributes & W3D_MESH_FLAG_PRELIT_VERTEX) {
@@ -360,7 +360,7 @@ WW3DErrorType MeshModelClass::Load_W3D(ChunkLoadClass & cload)
 					Set_Flag (PRELIT_VERTEX, true);
 					break;
 				}
-				// Else fall thru...
+				FALLTHROUGH; // Else fall thru...
 
 			default:
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/textureloader.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/textureloader.cpp
@@ -895,7 +895,7 @@ void TextureLoader::Process_Foreground_Thumbnail(TextureLoadTaskClass *task)
 	switch (task->Get_State()) {
 		case TextureLoadTaskClass::STATE_NONE:
 			Load_Thumbnail(task->Peek_Texture());
-			// NOTE: fall-through is intentional
+			FALLTHROUGH; // NOTE: fall-through is intentional
 
 		case TextureLoadTaskClass::STATE_COMPLETE:
 			task->Destroy();
@@ -1260,12 +1260,15 @@ void TextureLoadTaskClass::Finish_Load(void)
 				Apply_Missing_Texture();
 				break;
 			}
+			FALLTHROUGH;
 
 		case STATE_LOAD_BEGUN:
 			Load();
+			FALLTHROUGH;
 
 		case STATE_LOAD_MIPMAP:
 			End_Load();
+			FALLTHROUGH;
 
 		default:
 			break;


### PR DESCRIPTION
This change annotates fallthroughs in GameEngine to suppress warnings and make the intent clear.

```
GeneralsMD\Code\GameEngine\Source\Common\RandomValue.cpp(387): warning C26819: Unannotated fallthrough between switch labels (es.78).
```