### PR TITLE
[GEN][ZH] Prevent using uninitialized memory 'start', 'end' in BridgeScaffoldBehavior::update()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/BridgeScaffoldBehavior.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/BridgeScaffoldBehavior.cpp
@@ -192,6 +192,10 @@ UpdateSleepTime BridgeScaffoldBehavior::update( void )
 			end = &m_riseToPos;
 			break;
 
+		default:
+			DEBUG_CRASH(("Unhandled case in BridgeScaffoldBehavior::update()"));
+			return UPDATE_SLEEP_NONE;
+
 	}  // end switch
 
 	// adjust speed so it's slower at the end of motion

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/BridgeScaffoldBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/BridgeScaffoldBehavior.cpp
@@ -192,6 +192,10 @@ UpdateSleepTime BridgeScaffoldBehavior::update( void )
 			end = &m_riseToPos;
 			break;
 
+		default:
+			DEBUG_CRASH(("Unhandled case in BridgeScaffoldBehavior::update()"));
+			return UPDATE_SLEEP_NONE;
+
 	}  // end switch
 
 	// adjust speed so it's slower at the end of motion


### PR DESCRIPTION
This change prevents using uninitialized memory 'start', 'end' in BridgeScaffoldBehavior::update()

It mostly keeps the compiler happy, and is not expected to hit on runtime ever.

```
GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Behavior\BridgeScaffoldBehavior.cpp(199): warning C6001: Using uninitialized memory 'end'.
GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Behavior\BridgeScaffoldBehavior.cpp(199): warning C6001: Using uninitialized memory 'start'.
```