### PR TITLE
[GEN][ZH] Prevent dereferencing NULL pointer 'tex' in WW3DAssetManager::Get_Texture()

### DIFF
--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/assetmgr.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/assetmgr.cpp
@@ -1145,6 +1145,12 @@ TextureClass * WW3DAssetManager::Get_Texture
 		{
 			tex = NEW_REF (TextureClass, (lower_case_name, NULL, mip_level_count, texture_format, allow_compression));
 		}
+		else
+		{
+			WWASSERT_PRINT(false, ("Unhandled case"));
+			return NULL;
+		}
+
 		TextureHash.Insert(tex->Get_Texture_Name(),tex);
 	}
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/assetmgr.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/assetmgr.cpp
@@ -1122,6 +1122,12 @@ TextureClass * WW3DAssetManager::Get_Texture
 		{
 			tex = NEW_REF (VolumeTextureClass, (lower_case_name, NULL, mip_level_count, texture_format, allow_compression, allow_reduction));
 		}
+		else
+		{
+			WWASSERT_PRINT(false, ("Unhandled case"));
+			return NULL;
+		}
+
 		TextureHash.Insert(tex->Get_Texture_Name(),tex);
 	}
 


### PR DESCRIPTION
This change prevents dereferencing NULL pointer 'tex' in WW3DAssetManager::Get_Texture().

It likely is no actual problem in the runtime.

```
GeneralsMD\Code\Libraries\Source\WWVegas\WW3D2\assetmgr.cpp(1125): warning C6011: Dereferencing NULL pointer 'tex'.
```