### PR TITLE
[GEN][ZH] Prevent reading invalid data in LoadScreen

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/LoadScreen.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/LoadScreen.cpp
@@ -886,6 +886,7 @@ void MultiPlayerLoadScreen::processProgress(Int playerId, Int percentage)
 	if( percentage < 0 || percentage > 100 || playerId >= MAX_SLOTS || playerId < 0 || m_playerLookup[playerId] == -1)
 	{
 		DEBUG_ASSERTCRASH(FALSE, ("Percentage %d was passed in for Player %d\n", percentage, playerId));
+		return;
 	}
 	//DEBUG_LOG(("Percentage %d was passed in for Player %d (in loadscreen position %d)\n", percentage, playerId, m_playerLookup[playerId]));
 	if(m_progressBars[m_playerLookup[playerId]])
@@ -1213,6 +1214,7 @@ void GameSpyLoadScreen::processProgress(Int playerId, Int percentage)
 	if( percentage < 0 || percentage > 100 || playerId >= MAX_SLOTS || playerId < 0 || m_playerLookup[playerId] == -1)
 	{
 		DEBUG_ASSERTCRASH(FALSE, ("Percentage %d was passed in for Player %d\n", percentage, playerId));
+		return;
 	}
 	//DEBUG_LOG(("Percentage %d was passed in for Player %d (in loadscreen position %d)\n", percentage, playerId, m_playerLookup[playerId]));
 	if(m_progressBars[m_playerLookup[playerId]])
@@ -1365,6 +1367,7 @@ void MapTransferLoadScreen::processProgress(Int playerId, Int percentage, AsciiS
 	if( percentage < 0 || percentage > 100 || playerId >= MAX_SLOTS || playerId < 0 || m_playerLookup[playerId] == -1)
 	{
 		DEBUG_ASSERTCRASH(FALSE, ("Percentage %d was passed in for Player %d\n", percentage, playerId));
+		return;
 	}
 
 	if (m_oldProgress[playerId] == percentage)

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/LoadScreen.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/LoadScreen.cpp
@@ -1476,6 +1476,7 @@ void MultiPlayerLoadScreen::processProgress(Int playerId, Int percentage)
 	if( percentage < 0 || percentage > 100 || playerId >= MAX_SLOTS || playerId < 0 || m_playerLookup[playerId] == -1)
 	{
 		DEBUG_ASSERTCRASH(FALSE, ("Percentage %d was passed in for Player %d\n", percentage, playerId));
+		return;
 	}
 	//DEBUG_LOG(("Percentage %d was passed in for Player %d (in loadscreen position %d)\n", percentage, playerId, m_playerLookup[playerId]));
 	if(m_progressBars[m_playerLookup[playerId]])
@@ -1843,6 +1844,7 @@ void GameSpyLoadScreen::processProgress(Int playerId, Int percentage)
 	if( percentage < 0 || percentage > 100 || playerId >= MAX_SLOTS || playerId < 0 || m_playerLookup[playerId] == -1)
 	{
 		DEBUG_ASSERTCRASH(FALSE, ("Percentage %d was passed in for Player %d\n", percentage, playerId));
+		return;
 	}
 	//DEBUG_LOG(("Percentage %d was passed in for Player %d (in loadscreen position %d)\n", percentage, playerId, m_playerLookup[playerId]));
 	if(m_progressBars[m_playerLookup[playerId]])
@@ -1995,6 +1997,7 @@ void MapTransferLoadScreen::processProgress(Int playerId, Int percentage, AsciiS
 	if( percentage < 0 || percentage > 100 || playerId >= MAX_SLOTS || playerId < 0 || m_playerLookup[playerId] == -1)
 	{
 		DEBUG_ASSERTCRASH(FALSE, ("Percentage %d was passed in for Player %d\n", percentage, playerId));
+		return;
 	}
 
 	if (m_oldProgress[playerId] == percentage)


### PR DESCRIPTION
This change prevents reading some invalid data in LoadScreen on exceptional code paths.

This likely is no issue in the runtime.

```
GeneralsMD\Code\GameEngine\Source\GameClient\GUI\LoadScreen.cpp(1540): warning C6385: Reading invalid data from 'this->m_progressBars':  the readable size is '32' bytes, but 'this->m_playerLookup[playerId]' bytes may be read.
GeneralsMD\Code\GameEngine\Source\GameClient\GUI\LoadScreen.cpp(1540): warning C6385: Reading invalid data from 'this->m_playerLookup':  the readable size is '32' bytes, but 'playerId' bytes may be read.
GeneralsMD\Code\GameEngine\Source\GameClient\GUI\LoadScreen.cpp(1902): warning C6385: Reading invalid data from 'this->m_progressBars':  the readable size is '32' bytes, but 'this->m_playerLookup[playerId]' bytes may be read.
GeneralsMD\Code\GameEngine\Source\GameClient\GUI\LoadScreen.cpp(1902): warning C6385: Reading invalid data from 'this->m_playerLookup':  the readable size is '32' bytes, but 'playerId' bytes may be read.
GeneralsMD\Code\GameEngine\Source\GameClient\GUI\LoadScreen.cpp(2054): warning C6385: Reading invalid data from 'this->m_oldProgress':  the readable size is '32' bytes, but 'playerId' bytes may be read.
GeneralsMD\Code\GameEngine\Source\GameClient\GUI\LoadScreen.cpp(2056): warning C6386: Buffer overrun while writing to 'this->m_oldProgress':  the writable size is '32' bytes, but 'playerId' bytes might be written.
GeneralsMD\Code\GameEngine\Source\GameClient\GUI\LoadScreen.cpp(2058): warning C6385: Reading invalid data from 'this->m_playerLookup':  the readable size is '32' bytes, but 'playerId' bytes may be read.
GeneralsMD\Code\GameEngine\Source\GameClient\GUI\LoadScreen.cpp(2059): warning C6385: Reading invalid data from 'this->m_progressBars':  the readable size is '32' bytes, but 'translatedSlot' bytes may be read.
GeneralsMD\Code\GameEngine\Source\GameClient\GUI\LoadScreen.cpp(2061): warning C6385: Reading invalid data from 'this->m_progressText':  the readable size is '32' bytes, but 'translatedSlot' bytes may be read.
```