### PR TITLE
[GEN][ZH] Prevent unlikely buffer overrun while writing to 'newPts' in PolygonTrigger::reallocate()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
@@ -95,6 +95,10 @@ void PolygonTrigger::reallocate(void)
 {	
 	DEBUG_ASSERTCRASH(m_numPoints <= m_sizePoints, ("Invalid m_numPoints."));
 	if (m_numPoints == m_sizePoints) {
+		if (m_sizePoints > INT_MAX / 2) {
+			DEBUG_CRASH(("Too many points to allocate."));
+			return;
+		}
 		// Reallocate.
 		m_sizePoints += m_sizePoints;
 		ICoord3D *newPts = NEW ICoord3D[m_sizePoints];

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
@@ -97,6 +97,10 @@ void PolygonTrigger::reallocate(void)
 {	
 	DEBUG_ASSERTCRASH(m_numPoints <= m_sizePoints, ("Invalid m_numPoints."));
 	if (m_numPoints == m_sizePoints) {
+		if (m_sizePoints > INT_MAX / 2) {
+			DEBUG_CRASH(("Too many points to allocate."));
+			return;
+		}
 		// Reallocate.
 		m_sizePoints += m_sizePoints;
 		ICoord3D *newPts = NEW ICoord3D[m_sizePoints];


### PR DESCRIPTION
This change prevents an unlikely buffer overrun while writing to 'newPts' in PolygonTrigger::reallocate() and makes the compiler happy.

```
GeneralsMD\Code\GameEngine\Source\GameLogic\Map\PolygonTrigger.cpp(105): warning C6386: Buffer overrun while writing to 'newPts':  the writable size is 'm_sizePoints*12' bytes, but '24' bytes might be written.
```