### PR TITLE
[GEN][ZH] Remove unnecessary NULL pointer tests in InGameUI

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5158,24 +5158,18 @@ void InGameUI::addWorldAnimation( Anim2DTemplate *animTemplate,
 // ------------------------------------------------------------------------------------------------
 void InGameUI::clearWorldAnimations( void )
 {
-	WorldAnimationData *wad;
-
 	// iterate through all entries and delete the animation data
 	for( WorldAnimationListIterator it = m_worldAnimationList.begin();	
 			 it != m_worldAnimationList.end(); /*empty*/ )
 	{
 
-		wad = *it;
-		if( wad )
-		{
+		WorldAnimationData *wad = *it;
 
-			// delete the animation instance
-			deleteInstance(wad->m_anim);
+		// delete the animation instance
+		deleteInstance(wad->m_anim);
 
-			// delete the world animation data
-			delete wad;
-
-		}  // end if
+		// delete the world animation data
+		delete wad;
 
 		it = m_worldAnimationList.erase( it );
 
@@ -5189,15 +5183,13 @@ static const UnsignedInt FRAMES_BEFORE_EXPIRE_TO_FADE = LOGICFRAMES_PER_SECOND *
 // ------------------------------------------------------------------------------------------------
 void InGameUI::updateAndDrawWorldAnimations( void )
 {
-	WorldAnimationData *wad;
-
 	// go through all animations
 	for( WorldAnimationListIterator it = m_worldAnimationList.begin();
 			 it != m_worldAnimationList.end(); /*empty*/ )
 	{
 
 		// get data
-		wad = *it;
+		WorldAnimationData *wad = *it;
 
 		// update portion ... only when the game is in motion
 		if( TheGameLogic->isGamePaused() == FALSE )
@@ -5525,9 +5517,10 @@ WindowMsgHandledType IdleWorkerSystem( GameWindow *window, UnsignedInt msg,
 		//---------------------------------------------------------------------------------------------
 		case GWM_INPUT_FOCUS:
 		{	
-			// if we're givin the opportunity to take the keyboard focus we must say we don't want it
+			// if we're given the opportunity to take the keyboard focus we must say we don't want it
 			if( mData1 == TRUE )
 				*(Bool *)mData2 = FALSE;
+			break;
 		}
 		//---------------------------------------------------------------------------------------------
 		case GBM_SELECTED:

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5517,10 +5517,9 @@ WindowMsgHandledType IdleWorkerSystem( GameWindow *window, UnsignedInt msg,
 		//---------------------------------------------------------------------------------------------
 		case GWM_INPUT_FOCUS:
 		{	
-			// if we're given the opportunity to take the keyboard focus we must say we don't want it
+			// if we're givin the opportunity to take the keyboard focus we must say we don't want it
 			if( mData1 == TRUE )
 				*(Bool *)mData2 = FALSE;
-			break;
 		}
 		//---------------------------------------------------------------------------------------------
 		case GBM_SELECTED:

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5689,10 +5689,9 @@ WindowMsgHandledType IdleWorkerSystem( GameWindow *window, UnsignedInt msg,
 		//---------------------------------------------------------------------------------------------
 		case GWM_INPUT_FOCUS:
 		{	
-			// if we're given the opportunity to take the keyboard focus we must say we don't want it
+			// if we're givin the opportunity to take the keyboard focus we must say we don't want it
 			if( mData1 == TRUE )
 				*(Bool *)mData2 = FALSE;
-			break;
 		}
 		//---------------------------------------------------------------------------------------------
 		case GBM_SELECTED:

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5330,24 +5330,18 @@ void InGameUI::addWorldAnimation( Anim2DTemplate *animTemplate,
 // ------------------------------------------------------------------------------------------------
 void InGameUI::clearWorldAnimations( void )
 {
-	WorldAnimationData *wad;
-
 	// iterate through all entries and delete the animation data
 	for( WorldAnimationListIterator it = m_worldAnimationList.begin();	
 			 it != m_worldAnimationList.end(); /*empty*/ )
 	{
 
-		wad = *it;
-		if( wad )
-		{
+		WorldAnimationData *wad = *it;
 
-			// delete the animation instance
-			deleteInstance(wad->m_anim);
+		// delete the animation instance
+		deleteInstance(wad->m_anim);
 
-			// delete the world animation data
-			delete wad;
-
-		}  // end if
+		// delete the world animation data
+		delete wad;
 
 		it = m_worldAnimationList.erase( it );
 
@@ -5361,18 +5355,16 @@ static const UnsignedInt FRAMES_BEFORE_EXPIRE_TO_FADE = LOGICFRAMES_PER_SECOND *
 // ------------------------------------------------------------------------------------------------
 void InGameUI::updateAndDrawWorldAnimations( void )
 {
-	WorldAnimationData *wad;
-
 	// go through all animations
 	for( WorldAnimationListIterator it = m_worldAnimationList.begin();
 			 it != m_worldAnimationList.end(); /*empty*/ )
 	{
 
 		// get data
-		wad = *it;
+		WorldAnimationData *wad = *it;
 
 		// update portion ... only when the game is in motion
-		if( wad && TheGameLogic->isGamePaused() == FALSE )
+		if( TheGameLogic->isGamePaused() == FALSE )
 		{
 
 			//
@@ -5697,9 +5689,10 @@ WindowMsgHandledType IdleWorkerSystem( GameWindow *window, UnsignedInt msg,
 		//---------------------------------------------------------------------------------------------
 		case GWM_INPUT_FOCUS:
 		{	
-			// if we're givin the opportunity to take the keyboard focus we must say we don't want it
+			// if we're given the opportunity to take the keyboard focus we must say we don't want it
 			if( mData1 == TRUE )
 				*(Bool *)mData2 = FALSE;
+			break;
 		}
 		//---------------------------------------------------------------------------------------------
 		case GBM_SELECTED:


### PR DESCRIPTION
This change removes unnecessary NULL pointer tests in InGameUI and makes the compiler happy.

Unnecessary because `m_worldAnimationList` will not accept adding null elements and will not write null to its elements.

```
GeneralsMD\Code\GameEngine\Source\GameClient\InGameUI.cpp(5406): warning C6011: Dereferencing NULL pointer 'wad'.
```