### PR TITLE
[GEN][ZH] Fix dereferencing NULL pointer 'victimObj' in WeaponTemplate::estimateWeaponTemplateDamage()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -584,7 +584,7 @@ Real WeaponTemplate::estimateWeaponTemplateDamage(
 	}
 
 // this stays, even if ALLOW_SURRENDER is not defed, since flashbangs still use 'em
-	if (damageType == DAMAGE_SURRENDER || m_allowAttackGarrisonedBldgs)
+	if ( victimObj && (damageType == DAMAGE_SURRENDER || m_allowAttackGarrisonedBldgs) )
 	{
 		ContainModuleInterface* contain = victimObj->getContain();
 		if( contain && contain->getContainCount() > 0 && contain->isGarrisonable() && !contain->isImmuneToClearBuildingAttacks() )

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -567,10 +567,16 @@ Real WeaponTemplate::estimateWeaponTemplateDamage(
 		return 0.0f;
 	}
 
+	const Real damageAmount = getPrimaryDamage(bonus);
+	if ( victimObj == NULL )
+	{
+		return damageAmount;
+	}
+
 	DamageType damageType = getDamageType();
 	DeathType deathType = getDeathType();
 
-	if (victimObj && victimObj->isKindOf(KINDOF_SHRUBBERY))
+	if ( victimObj->isKindOf(KINDOF_SHRUBBERY) )
 	{
 		if (deathType == DEATH_BURNED)
 		{
@@ -584,7 +590,7 @@ Real WeaponTemplate::estimateWeaponTemplateDamage(
 	}
 
 // this stays, even if ALLOW_SURRENDER is not defed, since flashbangs still use 'em
-	if ( victimObj && (damageType == DAMAGE_SURRENDER || m_allowAttackGarrisonedBldgs) )
+	if ( damageType == DAMAGE_SURRENDER || m_allowAttackGarrisonedBldgs )
 	{
 		ContainModuleInterface* contain = victimObj->getContain();
 		if( contain && contain->getContainCount() > 0 && contain->isGarrisonable() && !contain->isImmuneToClearBuildingAttacks() )
@@ -594,42 +600,25 @@ Real WeaponTemplate::estimateWeaponTemplateDamage(
 		}
 	}
 
-	if( victimObj )
+	if( victimObj->isKindOf(KINDOF_MINE) && damageType == DAMAGE_DISARM )
 	{
-		if( victimObj->isKindOf(KINDOF_MINE) && damageType == DAMAGE_DISARM )
-		{
-			// this is just a nonzero value, to ensure we can target mines with disarm weapons, regardless...
-			return 1.0f;
-		}
-		if( damageType == DAMAGE_DEPLOY && !victimObj->isAirborneTarget() )
-		{
-			return 1.0f;
-		}
+		// this is just a nonzero value, to ensure we can target mines with disarm weapons, regardless...
+		return 1.0f;
+	}
+	if( damageType == DAMAGE_DEPLOY && !victimObj->isAirborneTarget() )
+	{
+		return 1.0f;
 	}
 
 	//@todo Kris need to examine the DAMAGE_HACK type for damage estimation purposes.
 	//Likely this damage type will have threat implications that won't properly be dealt with until resolved.
 
-//	const Coord3D* sourcePos = sourceObj->getPosition();
-	if (victimPos == NULL)
-	{
-		victimPos = victimObj->getPosition();
-	}
-
-	Real damageAmount = getPrimaryDamage(bonus);
-	if (victimObj == NULL)
-	{
-		return damageAmount;
-	}
-	else
-	{
-		DamageInfoInput damageInfo;
-		damageInfo.m_damageType = damageType;
-		damageInfo.m_deathType = deathType;
-		damageInfo.m_sourceID = sourceObj->getID();
-		damageInfo.m_amount = damageAmount;
-		return victimObj->estimateDamage(damageInfo);
-	}
+	DamageInfoInput damageInfo;
+	damageInfo.m_damageType = damageType;
+	damageInfo.m_deathType = deathType;
+	damageInfo.m_sourceID = sourceObj->getID();
+	damageInfo.m_amount = damageAmount;
+	return victimObj->estimateDamage(damageInfo);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -598,7 +598,7 @@ Real WeaponTemplate::estimateWeaponTemplateDamage(
 
   
   // hmm.. must be shooting a firebase or such, if there is noone home to take the bullet, return 0!
-  if ( victimObj->isKindOf( KINDOF_STRUCTURE) && damageType == DAMAGE_SNIPER )
+  if ( victimObj && victimObj->isKindOf( KINDOF_STRUCTURE) && damageType == DAMAGE_SNIPER )
   {
     if ( victimObj->getContain() )
     {
@@ -610,7 +610,7 @@ Real WeaponTemplate::estimateWeaponTemplateDamage(
 
 
 
-	if (damageType == DAMAGE_SURRENDER || m_allowAttackGarrisonedBldgs)
+	if ( victimObj && (damageType == DAMAGE_SURRENDER || m_allowAttackGarrisonedBldgs) )
 	{
 		ContainModuleInterface* contain = victimObj->getContain();
 		if( contain && contain->getContainCount() > 0 && contain->isGarrisonable() && !contain->isImmuneToClearBuildingAttacks() )

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -580,10 +580,16 @@ Real WeaponTemplate::estimateWeaponTemplateDamage(
 		return 0.0f;
 	}
 
+	const Real damageAmount = getPrimaryDamage(bonus);
+	if ( victimObj == NULL )
+	{
+		return damageAmount;
+	}
+
 	DamageType damageType = getDamageType();
 	DeathType deathType = getDeathType();
 
-	if (victimObj && victimObj->isKindOf(KINDOF_SHRUBBERY))
+	if ( victimObj->isKindOf(KINDOF_SHRUBBERY) )
 	{
 		if (deathType == DEATH_BURNED)
 		{
@@ -598,7 +604,7 @@ Real WeaponTemplate::estimateWeaponTemplateDamage(
 
   
   // hmm.. must be shooting a firebase or such, if there is noone home to take the bullet, return 0!
-  if ( victimObj && victimObj->isKindOf( KINDOF_STRUCTURE) && damageType == DAMAGE_SNIPER )
+  if ( victimObj->isKindOf( KINDOF_STRUCTURE) && damageType == DAMAGE_SNIPER )
   {
     if ( victimObj->getContain() )
     {
@@ -610,7 +616,7 @@ Real WeaponTemplate::estimateWeaponTemplateDamage(
 
 
 
-	if ( victimObj && (damageType == DAMAGE_SURRENDER || m_allowAttackGarrisonedBldgs) )
+	if ( damageType == DAMAGE_SURRENDER || m_allowAttackGarrisonedBldgs )
 	{
 		ContainModuleInterface* contain = victimObj->getContain();
 		if( contain && contain->getContainCount() > 0 && contain->isGarrisonable() && !contain->isImmuneToClearBuildingAttacks() )
@@ -620,46 +626,29 @@ Real WeaponTemplate::estimateWeaponTemplateDamage(
 		}
 	}
 
-	if( victimObj )
+	if( damageType == DAMAGE_DISARM )
 	{
-		if( damageType == DAMAGE_DISARM )
+		if( victimObj->isKindOf( KINDOF_MINE ) || victimObj->isKindOf( KINDOF_BOOBY_TRAP ) || victimObj->isKindOf( KINDOF_DEMOTRAP ) )
 		{
-			if( victimObj->isKindOf( KINDOF_MINE ) || victimObj->isKindOf( KINDOF_BOOBY_TRAP ) || victimObj->isKindOf( KINDOF_DEMOTRAP ) )
-			{
-				// this is just a nonzero value, to ensure we can target mines with disarm weapons, regardless...
-				return 1.0f;
-			}
-			return 0.0f;
-		}
-		if( damageType == DAMAGE_DEPLOY && !victimObj->isAirborneTarget() )
-		{
+			// this is just a nonzero value, to ensure we can target mines with disarm weapons, regardless...
 			return 1.0f;
 		}
+		return 0.0f;
+	}
+	if( damageType == DAMAGE_DEPLOY && !victimObj->isAirborneTarget() )
+	{
+		return 1.0f;
 	}
 
 	//@todo Kris need to examine the DAMAGE_HACK type for damage estimation purposes.
 	//Likely this damage type will have threat implications that won't properly be dealt with until resolved.
 
-//	const Coord3D* sourcePos = sourceObj->getPosition();
-	if (victimPos == NULL)
-	{
-		victimPos = victimObj->getPosition();
-	}
-
-	Real damageAmount = getPrimaryDamage(bonus);
-	if (victimObj == NULL)
-	{
-		return damageAmount;
-	}
-	else
-	{
-		DamageInfoInput damageInfo;
-		damageInfo.m_damageType = damageType;
-		damageInfo.m_deathType = deathType;
-		damageInfo.m_sourceID = sourceObj->getID();
-		damageInfo.m_amount = damageAmount;
-		return victimObj->estimateDamage(damageInfo);
-	}
+	DamageInfoInput damageInfo;
+	damageInfo.m_damageType = damageType;
+	damageInfo.m_deathType = deathType;
+	damageInfo.m_sourceID = sourceObj->getID();
+	damageInfo.m_amount = damageAmount;
+	return victimObj->estimateDamage(damageInfo);
 }
 
 //-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This change fixes dereferencing NULL pointer 'victimObj' in WeaponTemplate::estimateWeaponTemplateDamage() and makes the compiler happy.

This would be a 100% crash if this function was called with the positional argument, but it appears this is only ever called with the object argument, so it does not crash in the current game.

```
GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp(601): warning C6011: Dereferencing NULL pointer 'victimObj'.
GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Weapon.cpp(615): warning C6011: Dereferencing NULL pointer 'victimObj'.
```