### PR TITLE
[GEN][ZH] Fix using uninitialized memory 'curVictim' in EMPUpdate

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/EMPUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/EMPUpdate.cpp
@@ -180,8 +180,8 @@ void EMPUpdate::doDisableAttack( void )
 	Real curVictimDistSqr;
 	const Coord3D *pos = object->getPosition();
 
-	SimpleObjectIterator *iter;
-	Object *curVictim;
+	SimpleObjectIterator *iter = NULL;
+	Object *curVictim = NULL;
 
 	if (radius > 0.0f)
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/EMPUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/EMPUpdate.cpp
@@ -198,8 +198,8 @@ void EMPUpdate::doDisableAttack( void )
 		}
 	}
 
-	SimpleObjectIterator *iter;
-	Object *curVictim;
+	SimpleObjectIterator *iter = NULL;
+	Object *curVictim = NULL;
 
 	if (radius > 0.0f)
 	{
@@ -499,8 +499,8 @@ void LeafletDropBehavior::doDisableAttack( void )
 	Real curVictimDistSqr;
 	const Coord3D *pos = object->getPosition();
 
-	SimpleObjectIterator *iter;
-	Object *curVictim;
+	SimpleObjectIterator *iter = NULL;
+	Object *curVictim = NULL;
 
 	if (radius > 0.0f)
 	{


### PR DESCRIPTION
This change fixes using uninitialized memory 'curVictim' in EMPUpdate and makes the compiler happy.

This is only a theoretical or Mod issue. The default EffectRadius is larger than 0 and the ones specified in INI files are larger than 0 as well.

```
GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Update\EMPUpdate.cpp(214): warning C6001: Using uninitialized memory 'curVictim'.
GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Update\EMPUpdate.cpp(515): warning C6001: Using uninitialized memory 'curVictim'.
```