### PR TITLE
[GEN][ZH] Prevent dereferencing NULL pointer 'TheAI' in AI::parseAiDataDefinition()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AI.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AI.cpp
@@ -427,11 +427,10 @@ void AI::parseAiDataDefinition( INI* ini )
 		if( ini->getLoadType() == INI_LOAD_CREATE_OVERRIDES )
 			TheAI->newOverride();
 
+		// parse the ini weapon definition
+		ini->initFromINI( TheAI->m_aiData, TheAIFieldParseTable );
+
 	}  // end if
-
-	// parse the ini weapon definition
-	ini->initFromINI( TheAI->m_aiData, TheAIFieldParseTable );
-
 }
 
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AI.cpp
@@ -430,11 +430,10 @@ void AI::parseAiDataDefinition( INI* ini )
 		if( ini->getLoadType() == INI_LOAD_CREATE_OVERRIDES )
 			TheAI->newOverride();
 
+		// parse the ini weapon definition
+		ini->initFromINI( TheAI->m_aiData, TheAIFieldParseTable );
+
 	}  // end if
-
-	// parse the ini weapon definition
-	ini->initFromINI( TheAI->m_aiData, TheAIFieldParseTable );
-
 }
 
 


### PR DESCRIPTION
This change prevents dereferencing NULL pointer 'TheAI' in AI::parseAiDataDefinition() and makes the compiler happy.

```
GeneralsMD\Code\GameEngine\Source\GameLogic\AI\AI.cpp(436): warning C6011: Dereferencing NULL pointer 'TheAI'.
```