### PR TITLE
[GEN][ZH] Fix using uninitialized memory 'buff' in INI::getNextQuotedAsciiString()

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/INI/INI.cpp
+++ b/Generals/Code/GameEngine/Source/Common/INI/INI.cpp
@@ -725,6 +725,7 @@ AsciiString INI::getNextQuotedAsciiString()
 {
 	AsciiString result;
 	char buff[INI_MAX_CHARS_PER_LINE];
+	buff[0] = '\0';
 
 	const char *token = getNextTokenOrNull();	// if null, just leave an empty string
 	if (token != NULL)

--- a/GeneralsMD/Code/GameEngine/Source/Common/INI/INI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/INI/INI.cpp
@@ -717,6 +717,7 @@ AsciiString INI::getNextQuotedAsciiString()
 {
 	AsciiString result;
 	char buff[INI_MAX_CHARS_PER_LINE];
+	buff[0] = '\0';
 
 	const char *token = getNextTokenOrNull();	// if null, just leave an empty string
 	if (token != NULL)


### PR DESCRIPTION
This change fixes using uninitialized memory 'buff' in INI::getNextQuotedAsciiString() and makes the compiler happy.

It appears to be a theoretical issue only.

```
GeneralsMD\Code\GameEngine\Source\Common\INI\INI.cpp(752): warning C6054: String 'buff' might not be zero-terminated.
GeneralsMD\Code\GameEngine\Source\Common\INI\INI.cpp(752): warning C6001: Using uninitialized memory 'buff'.
```