### PR TITLE
[ZH] Fix heap-use-after-free in LayersList::updateUIFromList() when creating a new map in World Builder

### DIFF
--- a/GeneralsMD/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp
@@ -1277,6 +1277,8 @@ BOOL CWorldBuilderDoc::OnNewDocument()
 	TheLayersList->enableUpdates();
 	TheLayersList->resetLayers();
 	TheLayersList->disableUpdates();
+
+	// TheSuperHackers @bugfix Caball009 20/06/2025 Must not delete polygon triggers before calling enableUpdates.
 	PolygonTrigger::deleteTriggers();
 
 	TheSidesList->clear();

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp
@@ -1271,13 +1271,13 @@ BOOL CWorldBuilderDoc::OnNewDocument()
 	m_waypointTableNeedsUpdate = true;
 	m_curWaypointID = 0;
 	WbApp()->selectPointerTool();
-	PolygonTrigger::deleteTriggers();
 
 	// Make sure that all the old units are removed from the list.
 	// Bug fix by MLL 1/14/03
 	TheLayersList->enableUpdates();
 	TheLayersList->resetLayers();
 	TheLayersList->disableUpdates();
+	PolygonTrigger::deleteTriggers();
 
 	TheSidesList->clear();
 	TheSidesList->validateSides();


### PR DESCRIPTION
**Can be reproduced by starting the World Builder (using a debug build) and creating a new map.**

`PolygonTrigger::deleteTriggers()` deallocates an instance of `PolygonTrigger` here:
https://github.com/TheSuperHackers/GeneralsGameCode/blob/ef5fea1e4c5e7aaa95f1e4c1c1134888fc5fb0b4/GeneralsMD/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp#L1274-L1278
 but there may still be pointers to this object in `TheLayersList->mLayers`, so there would be use-after-free and crash here (line 450):
https://github.com/TheSuperHackers/GeneralsGameCode/blob/ef5fea1e4c5e7aaa95f1e4c1c1134888fc5fb0b4/GeneralsMD/Code/Tools/WorldBuilder/src/LayersList.cpp#L449-L452

`triggerIt` no longer points to a valid instance of `PolygonTrigger` because that had been deallocated.