### PR TITLE
[GEN] Backport bug fixes in CWorldBuilderDoc::OnNewDocument from Zero Hour

### DIFF
--- a/Generals/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp
@@ -1210,7 +1210,14 @@ BOOL CWorldBuilderDoc::OnNewDocument()
 	m_waypointTableNeedsUpdate = true;
 	m_curWaypointID = 0;
 	WbApp()->selectPointerTool();
+
+	// Make sure that all the old units are removed from the list.
+	// Bug fix by MLL 1/14/03
+	TheLayersList->enableUpdates();
+	TheLayersList->resetLayers();
+	TheLayersList->disableUpdates();
 	PolygonTrigger::deleteTriggers();
+
 	TheSidesList->clear();
 	TheSidesList->validateSides();
 

--- a/Generals/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp
@@ -1216,6 +1216,8 @@ BOOL CWorldBuilderDoc::OnNewDocument()
 	TheLayersList->enableUpdates();
 	TheLayersList->resetLayers();
 	TheLayersList->disableUpdates();
+
+	// TheSuperHackers @bugfix Caball009 20/06/2025 Must not delete polygon triggers before calling enableUpdates.
 	PolygonTrigger::deleteTriggers();
 
 	TheSidesList->clear();


### PR DESCRIPTION
* Relates to: https://github.com/TheSuperHackers/GeneralsGameCode/pull/1098

This PR ports an old bug fix from ZH to Gen and a new one described in the above PR.

Code in ZH:
https://github.com/TheSuperHackers/GeneralsGameCode/blob/ef5fea1e4c5e7aaa95f1e4c1c1134888fc5fb0b4/GeneralsMD/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp#L1273-L1283