### PR TITLE
[GEN][ZH] Prevent dereferencing NULL pointer 'that' in PhysicsBehavior::transferVelocityTo()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
@@ -942,8 +942,10 @@ void PhysicsBehavior::addOverlap(Object *obj)
 void PhysicsBehavior::transferVelocityTo(PhysicsBehavior* that) const
 {
 	if (that != NULL)
+	{
 		that->m_vel.add(&m_vel);
-	that->m_velMag = INVALID_VEL_MAG;
+		that->m_velMag = INVALID_VEL_MAG;
+	}
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
@@ -1067,8 +1067,10 @@ void PhysicsBehavior::addOverlap(Object *obj)
 void PhysicsBehavior::transferVelocityTo(PhysicsBehavior* that) const
 {
 	if (that != NULL)
+	{
 		that->m_vel.add(&m_vel);
-	that->m_velMag = INVALID_VEL_MAG;
+		that->m_velMag = INVALID_VEL_MAG;
+	}
 }
 
 //-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This change prevents dereferencing NULL pointer 'that' in PhysicsBehavior::transferVelocityTo() to make the compiler happy.

```
GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Update\PhysicsUpdate.cpp(1071): warning C6011: Dereferencing NULL pointer 'that'.
```