### PR TITLE
[GEN][ZH] Fix heap-use-after-free in DisconnectManager::update()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameNetwork/DisconnectManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/DisconnectManager.cpp
@@ -139,10 +139,13 @@ void DisconnectManager::update(ConnectionManager *conMgr) {
 					//use next ping server
 					static size_t serverIndex = 0;
 					serverIndex++;
-					if( serverIndex >= TheGameSpyConfig->getPingServers().size() )
+
+					AsciiStringList pingServers = TheGameSpyConfig->getPingServers();
+
+					if( serverIndex >= pingServers.size() )
 						serverIndex = 0;  //wrap back to first ping server
 
-					std::list<AsciiString>::iterator it = TheGameSpyConfig->getPingServers().begin();
+					std::list<AsciiString>::iterator it = pingServers.begin();
 					for( size_t i = 0;  i < serverIndex;  i++ )
 						it++;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/DisconnectManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/DisconnectManager.cpp
@@ -139,10 +139,13 @@ void DisconnectManager::update(ConnectionManager *conMgr) {
 					//use next ping server
 					static size_t serverIndex = 0;
 					serverIndex++;
-					if( serverIndex >= TheGameSpyConfig->getPingServers().size() )
+
+					AsciiStringList pingServers = TheGameSpyConfig->getPingServers();
+
+					if( serverIndex >= pingServers.size() )
 						serverIndex = 0;  //wrap back to first ping server
 
-					std::list<AsciiString>::iterator it = TheGameSpyConfig->getPingServers().begin();
+					std::list<AsciiString>::iterator it = pingServers.begin();
 					for( size_t i = 0;  i < serverIndex;  i++ )
 						it++;
 


### PR DESCRIPTION
This change fixes a heap-use-after-free in DisconnectManager::update().

This problem would only happen in Online matches when the Disconnect Menu pops up.

> **GeneralsMD\Code\GameEngine\Source\GameNetwork\DisconnectManager.cpp(145): warning C26815: The pointer is dangling because it points at a temporary instance which was destroyed.**
