### PR TITLE
[CORE] Fix compile error "friend cannot be used with static" in mangler's and matchbot's threadfac.h

### DIFF
--- a/Core/Tools/mangler/wlib/threadfac.h
+++ b/Core/Tools/mangler/wlib/threadfac.h
@@ -97,7 +97,7 @@ class Runnable
 
    // So do the threadClassLaunchers
    #ifdef _WIN32
-      friend static unsigned __stdcall threadClassLauncher(void *temp);
+     friend unsigned __stdcall threadClassLauncher(void *temp);
    #else  // UNIX
      friend void *threadClassLauncher(void *temp);
    #endif

--- a/Core/Tools/matchbot/wlib/threadfac.h
+++ b/Core/Tools/matchbot/wlib/threadfac.h
@@ -97,7 +97,7 @@ class Runnable
 
    // So do the threadClassLaunchers
    #ifdef _WIN32
-      friend static unsigned __stdcall threadClassLauncher(void *temp);
+     friend unsigned __stdcall threadClassLauncher(void *temp);
    #else  // UNIX
      friend void *threadClassLauncher(void *temp);
    #endif


### PR DESCRIPTION
Fix the recent Pipeline build issues caused by the misused friend and static declarations within threadfac.h.

This exists within mangler and matchbot but appeared to be failing at random.