### PR TITLE
[GEN][ZH] Remove unnecessary NULL pointer tests in RTS3DScene::RTS3DScene()

### DIFF
--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DScene.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DScene.cpp
@@ -136,7 +136,7 @@ RTS3DScene::RTS3DScene()
 	//Allocate memory to hold queue of visible renderobjects that need to be drawn last
 	//because they are forced translucent.
 	m_translucentObjectsCount = 0;
-	if (TheGlobalData && TheGlobalData->m_maxVisibleTranslucentObjects)
+	if (TheGlobalData->m_maxVisibleTranslucentObjects > 0)
 		m_translucentObjectsBuffer = NEW RenderObjClass* [TheGlobalData->m_maxVisibleTranslucentObjects];
 	else
 		m_translucentObjectsBuffer = NULL;
@@ -146,18 +146,26 @@ RTS3DScene::RTS3DScene()
 	m_numNonOccluderOrOccludee=0;
 	m_occludedObjectsCount=0;
 
-	m_potentialOccluders=NULL;
-	m_potentialOccludees=NULL;
-	m_nonOccludersOrOccludees=NULL;
+	if (TheGlobalData->m_maxVisibleOccluderObjects > 0)
+		m_potentialOccluders = NEW RenderObjClass* [TheGlobalData->m_maxVisibleOccluderObjects];
+	else
+		m_potentialOccluders = NULL;
+
+	if (TheGlobalData->m_maxVisibleOccludeeObjects > 0)
+		m_potentialOccludees = NEW RenderObjClass* [TheGlobalData->m_maxVisibleOccludeeObjects];
+	else
+		m_potentialOccludees = NULL;
+
+	if (TheGlobalData->m_maxVisibleNonOccluderOrOccludeeObjects > 0)
+		m_nonOccludersOrOccludees = NEW RenderObjClass* [TheGlobalData->m_maxVisibleNonOccluderOrOccludeeObjects];
+	else
+		m_nonOccludersOrOccludees = NULL;
 
 	//Modify the shader to make occlusion transparent
 	ShaderClass shader = PlayerColorShader;
 	shader.Set_Src_Blend_Func(ShaderClass::SRCBLEND_SRC_ALPHA);
 	shader.Set_Dst_Blend_Func(ShaderClass::DSTBLEND_ONE_MINUS_SRC_ALPHA);
 
-    m_potentialOccluders = NEW RenderObjClass* [TheGlobalData->m_maxVisibleOccluderObjects];
-	m_potentialOccludees = NEW RenderObjClass* [TheGlobalData->m_maxVisibleOccludeeObjects];
-	m_nonOccludersOrOccludees = NEW RenderObjClass* [TheGlobalData->m_maxVisibleNonOccluderOrOccludeeObjects];
 #ifdef USE_NON_STENCIL_OCCLUSION	
 		for (i=0; i<MAX_PLAYER_COUNT; i++)
 		{	m_occludedMaterialPass[i]=NEW_REF(MaterialPassClass,());

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DScene.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DScene.cpp
@@ -152,7 +152,7 @@ RTS3DScene::RTS3DScene()
 	//Allocate memory to hold queue of visible renderobjects that need to be drawn last
 	//because they are forced translucent.
 	m_translucentObjectsCount = 0;
-	if (TheGlobalData && TheGlobalData->m_maxVisibleTranslucentObjects)
+	if (TheGlobalData->m_maxVisibleTranslucentObjects > 0)
 		m_translucentObjectsBuffer = NEW RenderObjClass* [TheGlobalData->m_maxVisibleTranslucentObjects];
 	else
 		m_translucentObjectsBuffer = NULL;
@@ -162,18 +162,25 @@ RTS3DScene::RTS3DScene()
 	m_numNonOccluderOrOccludee=0;
 	m_occludedObjectsCount=0;
 
-	m_potentialOccluders=NULL;
-	m_potentialOccludees=NULL;
-	m_nonOccludersOrOccludees=NULL;
+	if (TheGlobalData->m_maxVisibleOccluderObjects > 0)
+		m_potentialOccluders = NEW RenderObjClass* [TheGlobalData->m_maxVisibleOccluderObjects];
+	else
+		m_potentialOccluders = NULL;
+
+	if (TheGlobalData->m_maxVisibleOccludeeObjects > 0)
+		m_potentialOccludees = NEW RenderObjClass* [TheGlobalData->m_maxVisibleOccludeeObjects];
+	else
+		m_potentialOccludees = NULL;
+
+	if (TheGlobalData->m_maxVisibleNonOccluderOrOccludeeObjects > 0)
+		m_nonOccludersOrOccludees = NEW RenderObjClass* [TheGlobalData->m_maxVisibleNonOccluderOrOccludeeObjects];
+	else
+		m_nonOccludersOrOccludees = NULL;
 
 	//Modify the shader to make occlusion transparent
 	ShaderClass shader = PlayerColorShader;
 	shader.Set_Src_Blend_Func(ShaderClass::SRCBLEND_SRC_ALPHA);
 	shader.Set_Dst_Blend_Func(ShaderClass::DSTBLEND_ONE_MINUS_SRC_ALPHA);
-
-    m_potentialOccluders = NEW RenderObjClass* [TheGlobalData->m_maxVisibleOccluderObjects];
-	m_potentialOccludees = NEW RenderObjClass* [TheGlobalData->m_maxVisibleOccludeeObjects];
-	m_nonOccludersOrOccludees = NEW RenderObjClass* [TheGlobalData->m_maxVisibleNonOccluderOrOccludeeObjects];
 
 #ifdef USE_NON_STENCIL_OCCLUSION
 	for (i=0; i<MAX_PLAYER_COUNT; i++)


### PR DESCRIPTION
This change removes unnecessary NULL pointer tests in RTS3DScene::RTS3DScene() to make the compiler happy.

Instead I added tests for the array sizes and only allocate the arrays when the value is larger than 0, which is currently always the case anyway. This does not change game behaviour.

> **GeneralsMD\Code\GameEngineDevice\Source\W3DDevice\GameClient\W3DScene.cpp(174): warning C6011: Dereferencing NULL pointer 'TheWritableGlobalData'.**