### PR TITLE
[CORE] Prevent dereferencing NULL pointer 't' in Record_Texture_End()

### DIFF
--- a/Core/Libraries/Source/WWVegas/WW3D2/statistics.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/statistics.cpp
@@ -132,11 +132,11 @@ static void Record_Texture_End()
 //				int percents=100-100*bytes/non_red_bytes;
 				working_string.Format("%4.4dkb         ",bytes/1024);
 				texture_statistics_string+=working_string;
+				texture_statistics_string+=t->Get_Texture_Name();//getTextureName();
 			}
 			else {
 				texture_statistics_string+="N/A  ";
 			}
-			texture_statistics_string+=t->Get_Texture_Name();//getTextureName();
 			texture_statistics_string+=error;
 			texture_statistics_string+="\n";
 		}


### PR DESCRIPTION
This change prevent dereferencing NULL pointer 't' in Record_Texture_End().

> **Core\Libraries\Source\WWVegas\WW3D2\statistics.cpp(139): warning C6011: Dereferencing NULL pointer 't'.**