### PR TITLE
[ZH] Remove unnecessary NULL pointer tests in ..CrateCollide::executeCrateBehavior()

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Collide/CrateCollide/SabotageSupplyCenterCrateCollide.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Collide/CrateCollide/SabotageSupplyCenterCrateCollide.cpp
@@ -149,7 +149,7 @@ Bool SabotageSupplyCenterCrateCollide::executeCrateBehavior( Object *other )
 				controller->getScoreKeeper()->addMoneyEarned( cash );
 
 			//Play the "cash stolen" EVA event if the local player is the victim!
-			if( other && other->isLocallyControlled() )
+			if( other->isLocallyControlled() )
 			{
 				TheEva->setShouldPlay( EVA_CashStolen );
 			}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Collide/CrateCollide/SabotageSupplyDropzoneCrateCollide.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Collide/CrateCollide/SabotageSupplyDropzoneCrateCollide.cpp
@@ -159,7 +159,7 @@ Bool SabotageSupplyDropzoneCrateCollide::executeCrateBehavior( Object *other )
 				controller->getScoreKeeper()->addMoneyEarned( cash );
 
 			//Play the "cash stolen" EVA event if the local player is the victim!
-			if( other && other->isLocallyControlled() )
+			if( other->isLocallyControlled() )
 			{
 				TheEva->setShouldPlay( EVA_CashStolen );
 			}


### PR DESCRIPTION
This change removes unnecessary NULL pointer tests in ..CrateCollide::executeCrateBehavior() and makes the compiler happy.

Zero Hour only.

> **GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Collide\CrateCollide\SabotageSupplyCenterCrateCollide.cpp(167): warning C6011: Dereferencing NULL pointer 'other'. See line 134 for an earlier location where this can occur
GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Collide\CrateCollide\SabotageSupplyDropzoneCrateCollide.cpp(177): warning C6011: Dereferencing NULL pointer 'other'. See line 137 for an earlier location where this can occur**