### PR TITLE
[GEN][ZH] Remove unnecessary NULL pointer test in CrateCollide::isValidToExecute()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Collide/CrateCollide/CrateCollide.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Collide/CrateCollide/CrateCollide.cpp
@@ -163,7 +163,7 @@ Bool CrateCollide::isValidToExecute( const Object *other ) const
 		return FALSE;
 
 	// must match our kindof flags (if any)
-	if (md && !other->isKindOfMulti(md->m_kindof, md->m_kindofnot))
+	if ( !other->isKindOfMulti(md->m_kindof, md->m_kindofnot) )
 		return FALSE;
 
 	if( other->isEffectivelyDead() )

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Collide/CrateCollide/CrateCollide.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Collide/CrateCollide/CrateCollide.cpp
@@ -166,7 +166,7 @@ Bool CrateCollide::isValidToExecute( const Object *other ) const
 		return FALSE;
 
 	// must match our kindof flags (if any)
-	if (md && !other->isKindOfMulti(md->m_kindof, md->m_kindofnot))
+	if ( !other->isKindOfMulti(md->m_kindof, md->m_kindofnot) )
 		return FALSE;
 
 	if( other->isEffectivelyDead() )


### PR DESCRIPTION
This change removes an unnecessary NULL pointer test in CrateCollide::isValidToExecute() and makes the compiler happy.

```
GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Collide\CrateCollide\CrateCollide.cpp(179): warning C6011: Dereferencing NULL pointer 'md'. See line 162 for an earlier location where this can occur
```