### PR TITLE
[GEN][ZH] Prevent buffer overrun while writing to 'new_types', 'new_lensflares' in DazzleRenderObjClass

### DIFF
--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dazzle.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dazzle.cpp
@@ -669,7 +669,8 @@ void DazzleRenderObjClass::Init_Type(const DazzleInitClass& i)
 		unsigned new_count=i.type+1;
 		DazzleTypeClass** new_types=W3DNEWARRAY DazzleTypeClass*[new_count];
 		unsigned a=0;
-		for (;a<type_count;++a) {
+		unsigned copy_count = min(type_count, new_count);
+		for (;a<copy_count;++a) {
 			new_types[a]=types[a];
 		}
 		for (;a<new_count;++a) {
@@ -693,7 +694,8 @@ void DazzleRenderObjClass::Init_Lensflare(const LensflareInitClass& i)
 		unsigned new_count=i.type+1;
 		LensflareTypeClass** new_lensflares=W3DNEWARRAY LensflareTypeClass*[new_count];
 		unsigned a=0;
-		for (;a<lensflare_count;++a) {
+		unsigned copy_count = min(lensflare_count, new_count);
+		for (;a<copy_count;++a) {
 			new_lensflares[a]=lensflares[a];
 		}
 		for (;a<new_count;++a) {

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dazzle.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dazzle.cpp
@@ -685,7 +685,8 @@ void DazzleRenderObjClass::Init_Type(const DazzleInitClass& i)
 		unsigned new_count=i.type+1;
 		DazzleTypeClass** new_types=W3DNEWARRAY DazzleTypeClass*[new_count];
 		unsigned a=0;
-		for (;a<type_count;++a) {
+		unsigned copy_count = min(type_count, new_count);
+		for (;a<copy_count;++a) {
 			new_types[a]=types[a];
 		}
 		for (;a<new_count;++a) {
@@ -709,7 +710,8 @@ void DazzleRenderObjClass::Init_Lensflare(const LensflareInitClass& i)
 		unsigned new_count=i.type+1;
 		LensflareTypeClass** new_lensflares=W3DNEWARRAY LensflareTypeClass*[new_count];
 		unsigned a=0;
-		for (;a<lensflare_count;++a) {
+		unsigned copy_count = min(lensflare_count, new_count);
+		for (;a<copy_count;++a) {
 			new_lensflares[a]=lensflares[a];
 		}
 		for (;a<new_count;++a) {


### PR DESCRIPTION
This change prevents buffer overrun while writing to 'new_types', 'new_lensflares' in DazzleRenderObjClass.

Dazzle is unused code, so this should be inconsequential for the game.

```
GeneralsMD\Code\Libraries\Source\WWVegas\WW3D2\dazzle.cpp(689): warning C6386: Buffer overrun while writing to 'new_types':  the writable size is 'new_count*4' bytes, but '8' bytes might be written.
GeneralsMD\Code\Libraries\Source\WWVegas\WW3D2\dazzle.cpp(713): warning C6386: Buffer overrun while writing to 'new_lensflares':  the writable size is 'new_count*4' bytes, but '8' bytes might be written.
```