### PR TITLE
[GEN][ZH] Fix dereferencing NULL pointer 'ext' in DX8Wrapper::_Create_DX8_Surface()

### DIFF
--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
@@ -2404,8 +2404,9 @@ IDirect3DSurface8 * DX8Wrapper::_Create_DX8_Surface(const char *filename_)
 			// else create a surface with missing texture in it
 			char compressed_name[200];
 			strncpy(compressed_name,filename_, 200);
+			compressed_name[200-1] = '\0';
 			char *ext = strstr(compressed_name, ".");
-			if ( (strlen(ext)==4) && 
+			if ( ext && (strlen(ext)==4) &&
 				  ( (ext[1] == 't') || (ext[1] == 'T') ) && 
 				  ( (ext[2] == 'g') || (ext[2] == 'G') ) && 
 				  ( (ext[3] == 'a') || (ext[3] == 'A') ) ) {

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
@@ -2403,8 +2403,8 @@ IDirect3DSurface8 * DX8Wrapper::_Create_DX8_Surface(const char *filename_)
 			// If file not found, try the dds format
 			// else create a surface with missing texture in it
 			char compressed_name[200];
-			strncpy(compressed_name,filename_, 200);
-			compressed_name[200-1] = '\0';
+			strncpy(compressed_name,filename_, ARRAY_SIZE(compressed_name));
+			compressed_name[ARRAY_SIZE(compressed_name)-1] = '\0';
 			char *ext = strstr(compressed_name, ".");
 			if ( ext && (strlen(ext)==4) &&
 				  ( (ext[1] == 't') || (ext[1] == 'T') ) && 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
@@ -2943,8 +2943,9 @@ IDirect3DSurface8 * DX8Wrapper::_Create_DX8_Surface(const char *filename_)
 			// else create a surface with missing texture in it
 			char compressed_name[200];
 			strncpy(compressed_name,filename_, 200);
+			compressed_name[200-1] = '\0';
 			char *ext = strstr(compressed_name, ".");
-			if ( (strlen(ext)==4) && 
+			if ( ext && (strlen(ext)==4) && 
 				  ( (ext[1] == 't') || (ext[1] == 'T') ) && 
 				  ( (ext[2] == 'g') || (ext[2] == 'G') ) && 
 				  ( (ext[3] == 'a') || (ext[3] == 'A') ) ) {

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
@@ -2942,8 +2942,8 @@ IDirect3DSurface8 * DX8Wrapper::_Create_DX8_Surface(const char *filename_)
 			// If file not found, try the dds format
 			// else create a surface with missing texture in it
 			char compressed_name[200];
-			strncpy(compressed_name,filename_, 200);
-			compressed_name[200-1] = '\0';
+			strncpy(compressed_name,filename_, ARRAY_SIZE(compressed_name));
+			compressed_name[ARRAY_SIZE(compressed_name)-1] = '\0';
 			char *ext = strstr(compressed_name, ".");
 			if ( ext && (strlen(ext)==4) && 
 				  ( (ext[1] == 't') || (ext[1] == 'T') ) && 


### PR DESCRIPTION
This change fixes dereferencing NULL pointer 'ext' in DX8Wrapper::_Create_DX8_Surface()

```
GeneralsMD\Code\Libraries\Source\WWVegas\WW3D2\dx8wrapper.cpp(2949): warning C6011: Dereferencing NULL pointer 'ext'. See line 2947 for an earlier location where this can occur
GeneralsMD\Code\Libraries\Source\WWVegas\WW3D2\dx8wrapper.cpp(2949): warning C6387: 'ext' could be '0':  this does not adhere to the specification for the function 'strlen'.
```