### PR TITLE
[GEN][ZH] Write correct call to super class in constructor of GameSpyGameSlot

### DIFF
--- a/Generals/Code/GameEngine/Source/GameNetwork/GameSpy/StagingRoomGameInfo.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/GameSpy/StagingRoomGameInfo.cpp
@@ -57,8 +57,8 @@
 // GameSpyGameSlot -------------------------------------------
 
 GameSpyGameSlot::GameSpyGameSlot()
+	: GameSlot()
 {
-	GameSlot();
 	m_gameSpyLogin.clear();
 	m_gameSpyLocale.clear();
 	m_profileID = 0;

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameSpy/StagingRoomGameInfo.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameSpy/StagingRoomGameInfo.cpp
@@ -57,8 +57,8 @@
 // GameSpyGameSlot -------------------------------------------
 
 GameSpyGameSlot::GameSpyGameSlot()
+	: GameSlot()
 {
-	GameSlot();
 	m_gameSpyLogin.clear();
 	m_gameSpyLocale.clear();
 	m_profileID = 0;


### PR DESCRIPTION
This change writes the correct call to the super class in the constructor of GameSpyGameSlot to make the compiler happy.

```
GeneralsMD\Code\GameEngine\Source\GameNetwork\GameSpy\StagingRoomGameInfo.cpp(61): warning C26444: Don't try to declare a local variable with no name (es.84).
```