### PR TITLE
[GEN][ZH] Check vector size before accessing first element in World Builder's MapObjectProps and ScorchOptions

### DIFF
--- a/Generals/Code/Tools/WorldBuilder/include/ScorchOptions.h
+++ b/Generals/Code/Tools/WorldBuilder/include/ScorchOptions.h
@@ -80,6 +80,7 @@ private:
 	void changeSize(void);
 	void changeScorch(void);
 	void getAllSelectedDicts(void);
+	Dict** getAllSelectedDictsData();
 
 public:
 	static void update(void);

--- a/Generals/Code/Tools/WorldBuilder/include/mapobjectprops.h
+++ b/Generals/Code/Tools/WorldBuilder/include/mapobjectprops.h
@@ -65,6 +65,7 @@ public:
 // Implementation
 protected:
 	void getAllSelectedDicts(void);
+	Dict** getAllSelectedDictsData();
 
 	static MapObjectProps *TheMapObjectProps; 
 
@@ -149,9 +150,6 @@ public:
 
 	static MapObject *getSingleSelectedMapObject(void);
 	static void update(void);
-
-private:
-	Dict** getAllSelectedDictsData();
 
 };
 

--- a/Generals/Code/Tools/WorldBuilder/include/mapobjectprops.h
+++ b/Generals/Code/Tools/WorldBuilder/include/mapobjectprops.h
@@ -150,6 +150,9 @@ public:
 	static MapObject *getSingleSelectedMapObject(void);
 	static void update(void);
 
+private:
+	Dict** getAllSelectedDictsData();
+
 };
 
 //{{AFX_INSERT_LOCATION}}

--- a/Generals/Code/Tools/WorldBuilder/src/ScorchOptions.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/ScorchOptions.cpp
@@ -222,7 +222,7 @@ void ScorchOptions::changeScorch(void)
 
 	Dict newDict;
 	newDict.setInt(TheKey_scorchType, (Int)m_scorchtype);
-	DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
+	DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
 	CWorldBuilderDoc* pDoc = CWorldBuilderDoc::GetActiveDoc();
 	pDoc->AddAndDoUndoable(pUndo);
 	REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
@@ -237,7 +237,7 @@ void ScorchOptions::changeSize(void)
 
 	Dict newDict;
 	newDict.setReal(TheKey_objectRadius, m_scorchsize);
-	DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
+	DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
 	CWorldBuilderDoc* pDoc = CWorldBuilderDoc::GetActiveDoc();
 	pDoc->AddAndDoUndoable(pUndo);
 	REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
@@ -256,4 +256,13 @@ void ScorchOptions::getAllSelectedDicts(void)
 		}
 		m_allSelectedDicts.push_back(pMapObj->getProperties());
 	}
+}
+
+Dict** ScorchOptions::getAllSelectedDictsData()
+{
+#if defined(USING_STLPORT) || __cplusplus < 201103L
+	return !m_allSelectedDicts.empty() ? &m_allSelectedDicts.front() : NULL;
+#else
+	return m_allSelectedDicts.data();
+#endif
 }

--- a/Generals/Code/Tools/WorldBuilder/src/mapobjectprops.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/mapobjectprops.cpp
@@ -194,6 +194,15 @@ BOOL MapObjectProps::OnInitDialog()
 	}
 }
 
+Dict** MapObjectProps::getAllSelectedDictsData()
+{
+#if defined(USING_STLPORT) || __cplusplus < 201103L
+	return !m_allSelectedDicts.empty() ? &m_allSelectedDicts.front() : NULL;
+#else
+	return m_allSelectedDicts.data();
+#endif
+}
+
 void MapObjectProps::updateTheUI(void) 
 {
 	if (this != TheMapObjectProps) {
@@ -810,7 +819,7 @@ void MapObjectProps::_TeamToDict(void)
 	CWorldBuilderDoc* pDoc = CWorldBuilderDoc::GetActiveDoc();
 	Dict newDict;
 	newDict.setAsciiString(TheKey_originalOwner, AsciiString(buf));
-	DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
+	DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
 	pDoc->AddAndDoUndoable(pUndo);
 	REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	// Update is called by Do
@@ -827,7 +836,7 @@ void MapObjectProps::_NameToDict(void)
 	CWorldBuilderDoc* pDoc = CWorldBuilderDoc::GetActiveDoc();
 	Dict newDict;
 	newDict.setAsciiString(TheKey_objectName, cstr.GetBuffer(0));
-	DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
+	DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
 	pDoc->AddAndDoUndoable(pUndo);
 	REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	// Update is called by Do
@@ -865,7 +874,7 @@ void MapObjectProps::_HealthToDict(void)
 	CWorldBuilderDoc* pDoc = CWorldBuilderDoc::GetActiveDoc();
 	Dict newDict;
 	newDict.setInt(TheKey_objectInitialHealth, value);
-	DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
+	DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
 	pDoc->AddAndDoUndoable(pUndo);
 	REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	// Update is called by Do
@@ -929,7 +938,7 @@ void MapObjectProps::_PrebuiltUpgradesToDict(void)
 
 	// Now, do the Undoable
 	CWorldBuilderDoc* pDoc = CWorldBuilderDoc::GetActiveDoc();
-	DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, NAMEKEY_INVALID, m_allSelectedDicts.size(), pDoc, true);
+	DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, NAMEKEY_INVALID, m_allSelectedDicts.size(), pDoc, true);
 	pDoc->AddAndDoUndoable(pUndo);
 	REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 }
@@ -944,7 +953,7 @@ void MapObjectProps::_EnabledToDict(void)
 	CWorldBuilderDoc* pDoc = CWorldBuilderDoc::GetActiveDoc();
 	Dict newDict;
 	newDict.setBool(TheKey_objectEnabled, isChecked);
-	DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
+	DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
 	pDoc->AddAndDoUndoable(pUndo);
 	REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	// Update is called by Do
@@ -961,7 +970,7 @@ void MapObjectProps::_ScriptToDict(void)
 	CWorldBuilderDoc* pDoc = CWorldBuilderDoc::GetActiveDoc();
 	Dict newDict;
 	newDict.setAsciiString(TheKey_objectScriptAttachment, AsciiString(buf));
-	DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
+	DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
 	pDoc->AddAndDoUndoable(pUndo);
 	REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	// Update is called by Do	
@@ -977,7 +986,7 @@ void MapObjectProps::_IndestructibleToDict(void)
 	CWorldBuilderDoc* pDoc = CWorldBuilderDoc::GetActiveDoc();
 	Dict newDict;
 	newDict.setBool(TheKey_objectIndestructible, isChecked);
-	DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
+	DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
 	pDoc->AddAndDoUndoable(pUndo);
 	REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	// Update is called by Do	
@@ -993,7 +1002,7 @@ void MapObjectProps::_UnsellableToDict(void)
 	CWorldBuilderDoc* pDoc = CWorldBuilderDoc::GetActiveDoc();
 	Dict newDict;
 	newDict.setBool(TheKey_objectUnsellable, isChecked);
-	DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
+	DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
 	pDoc->AddAndDoUndoable(pUndo);
 	REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	// Update is called by Do
@@ -1010,7 +1019,7 @@ void MapObjectProps::_TargetableToDict()
 	CWorldBuilderDoc* pDoc = CWorldBuilderDoc::GetActiveDoc();
 	Dict newDict;
 	newDict.setBool( TheKey_objectTargetable, isChecked );
-	DictItemUndoable *pUndo = new DictItemUndoable( &m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size() );
+	DictItemUndoable *pUndo = new DictItemUndoable( getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size() );
 	pDoc->AddAndDoUndoable( pUndo );
 	REF_PTR_RELEASE( pUndo ); // belongs to pDoc now.
 	// Update is called by Do
@@ -1027,7 +1036,7 @@ void MapObjectProps::_PoweredToDict(void)
 	CWorldBuilderDoc* pDoc = CWorldBuilderDoc::GetActiveDoc();
 	Dict newDict;
 	newDict.setBool(TheKey_objectPowered, isChecked);
-	DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
+	DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
 	pDoc->AddAndDoUndoable(pUndo);
 	REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	// Update is called by Do
@@ -1058,7 +1067,7 @@ void MapObjectProps::_AggressivenessToDict(void)
 	CWorldBuilderDoc* pDoc = CWorldBuilderDoc::GetActiveDoc();
 	Dict newDict;
 	newDict.setInt(TheKey_objectAggressiveness, value);
-	DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
+	DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
 	pDoc->AddAndDoUndoable(pUndo);
 	REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	// Update is called by Do		
@@ -1082,7 +1091,7 @@ void MapObjectProps::_VisibilityToDict(void)
 	if (value != -1) {
 		newDict.setInt(TheKey_objectVisualRange, value);
 	}
-	DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, TheKey_objectVisualRange, m_allSelectedDicts.size());
+	DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, TheKey_objectVisualRange, m_allSelectedDicts.size());
 	pDoc->AddAndDoUndoable(pUndo);
 	REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	// Update is called by Do
@@ -1103,7 +1112,7 @@ void MapObjectProps::_VeterancyToDict(void)
 	CWorldBuilderDoc* pDoc = CWorldBuilderDoc::GetActiveDoc();
 	Dict newDict;
 	newDict.setInt(TheKey_objectVeterancy, value);
-	DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
+	DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
 	pDoc->AddAndDoUndoable(pUndo);
 	REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	// Update is called by Do	
@@ -1121,7 +1130,7 @@ void MapObjectProps::_WeatherToDict(void)
 	CWorldBuilderDoc* pDoc = CWorldBuilderDoc::GetActiveDoc();
 	Dict newDict;
 	newDict.setInt(TheKey_objectWeather, curSel);
-	DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
+	DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
 	pDoc->AddAndDoUndoable(pUndo);
 	REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	// Update is called by Do	
@@ -1139,7 +1148,7 @@ void MapObjectProps::_TimeToDict(void)
 	CWorldBuilderDoc* pDoc = CWorldBuilderDoc::GetActiveDoc();
 	Dict newDict;
 	newDict.setInt(TheKey_objectTime, curSel);
-	DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
+	DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
 	pDoc->AddAndDoUndoable(pUndo);
 	REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	// Update is called by Do	
@@ -1164,7 +1173,7 @@ void MapObjectProps::_ShroudClearingDistanceToDict(void)
 	if (value != -1) {
 		newDict.setInt(TheKey_objectShroudClearingDistance, value);
 	}
-	DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, TheKey_objectShroudClearingDistance, m_allSelectedDicts.size());
+	DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, TheKey_objectShroudClearingDistance, m_allSelectedDicts.size());
 	pDoc->AddAndDoUndoable(pUndo);
 	REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	// Update is called by Do
@@ -1180,7 +1189,7 @@ void MapObjectProps::_RecruitableAIToDict(void)
 	CWorldBuilderDoc* pDoc = CWorldBuilderDoc::GetActiveDoc();
 	Dict newDict;
 	newDict.setBool(TheKey_objectRecruitableAI, isChecked);
-	DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
+	DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
 	pDoc->AddAndDoUndoable(pUndo);
 	REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	// Update is called by Do
@@ -1196,7 +1205,7 @@ void MapObjectProps::_SelectableToDict(void)
 	CWorldBuilderDoc* pDoc = CWorldBuilderDoc::GetActiveDoc();
 	Dict newDict;
 	newDict.setBool(TheKey_objectSelectable, isChecked);
-	DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
+	DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
 	pDoc->AddAndDoUndoable(pUndo);
 	REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	// Update is called by Do
@@ -1219,7 +1228,7 @@ void MapObjectProps::_HPsToDict()
 	Dict newDict;
 
 	newDict.setInt(TheKey_objectMaxHPs, value);
-	DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
+	DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
 	pDoc->AddAndDoUndoable(pUndo);
 	REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 }
@@ -1242,7 +1251,7 @@ void MapObjectProps::_StoppingDistanceToDict(void)
 	CWorldBuilderDoc* pDoc = CWorldBuilderDoc::GetActiveDoc();
 	Dict newDict;
 	newDict.setReal(TheKey_objectStoppingDistance, value);
-	DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
+	DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
 	pDoc->AddAndDoUndoable(pUndo);
 	REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	// Update is called by Do

--- a/Generals/Code/Tools/WorldBuilder/src/mapobjectprops.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/mapobjectprops.cpp
@@ -194,15 +194,6 @@ BOOL MapObjectProps::OnInitDialog()
 	}
 }
 
-Dict** MapObjectProps::getAllSelectedDictsData()
-{
-#if defined(USING_STLPORT) || __cplusplus < 201103L
-	return !m_allSelectedDicts.empty() ? &m_allSelectedDicts.front() : NULL;
-#else
-	return m_allSelectedDicts.data();
-#endif
-}
-
 void MapObjectProps::updateTheUI(void) 
 {
 	if (this != TheMapObjectProps) {
@@ -1351,6 +1342,14 @@ void MapObjectProps::getAllSelectedDicts(void)
 	}
 }
 
+Dict** MapObjectProps::getAllSelectedDictsData()
+{
+#if defined(USING_STLPORT) || __cplusplus < 201103L
+	return !m_allSelectedDicts.empty() ? &m_allSelectedDicts.front() : NULL;
+#else
+	return m_allSelectedDicts.data();
+#endif
+}
 
 void MapObjectProps::GetPopSliderInfo(const long sliderID, long *pMin, long *pMax, long *pLineSize, long *pInitial)
 {

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/ScorchOptions.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/ScorchOptions.h
@@ -80,7 +80,7 @@ private:
 	void changeSize(void);
 	void changeScorch(void);
 	void getAllSelectedDicts(void);
-	Dict** getFrontSelectedDicts();
+	Dict** getAllSelectedDictsData();
 
 public:
 	static void update(void);

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/ScorchOptions.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/ScorchOptions.h
@@ -80,6 +80,7 @@ private:
 	void changeSize(void);
 	void changeScorch(void);
 	void getAllSelectedDicts(void);
+	Dict** getFrontSelectedDicts();
 
 public:
 	static void update(void);

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/mapobjectprops.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/mapobjectprops.h
@@ -206,6 +206,7 @@ private:
   MapObjectProps & operator=( const MapObjectProps & other ); // Deliberately undefined
 	void updateTheUI(MapObject *pMapObj);
 	void InitSound(void);
+	Dict** getFrontSelectedDicts();
 };
 
 //{{AFX_INSERT_LOCATION}}

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/mapobjectprops.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/mapobjectprops.h
@@ -68,6 +68,7 @@ public:
 // Implementation
 protected:
 	void getAllSelectedDicts(void);
+	Dict** getAllSelectedDictsData();
 
 	static MapObjectProps *TheMapObjectProps; 
 
@@ -206,7 +207,6 @@ private:
   MapObjectProps & operator=( const MapObjectProps & other ); // Deliberately undefined
 	void updateTheUI(MapObject *pMapObj);
 	void InitSound(void);
-	Dict** getAllSelectedDictsData();
 };
 
 //{{AFX_INSERT_LOCATION}}

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/mapobjectprops.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/mapobjectprops.h
@@ -206,7 +206,7 @@ private:
   MapObjectProps & operator=( const MapObjectProps & other ); // Deliberately undefined
 	void updateTheUI(MapObject *pMapObj);
 	void InitSound(void);
-	Dict** getFrontSelectedDicts();
+	Dict** getAllSelectedDictsData();
 };
 
 //{{AFX_INSERT_LOCATION}}

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/ScorchOptions.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/ScorchOptions.cpp
@@ -222,7 +222,7 @@ void ScorchOptions::changeScorch(void)
 
 	Dict newDict;
 	newDict.setInt(TheKey_scorchType, (Int)m_scorchtype);
-	DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
+	DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
 	CWorldBuilderDoc* pDoc = CWorldBuilderDoc::GetActiveDoc();
 	pDoc->AddAndDoUndoable(pUndo);
 	REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
@@ -237,7 +237,7 @@ void ScorchOptions::changeSize(void)
 
 	Dict newDict;
 	newDict.setReal(TheKey_objectRadius, m_scorchsize);
-	DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
+	DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
 	CWorldBuilderDoc* pDoc = CWorldBuilderDoc::GetActiveDoc();
 	pDoc->AddAndDoUndoable(pUndo);
 	REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
@@ -256,4 +256,9 @@ void ScorchOptions::getAllSelectedDicts(void)
 		}
 		m_allSelectedDicts.push_back(pMapObj->getProperties());
 	}
+}
+
+Dict** ScorchOptions::getFrontSelectedDicts()
+{
+	return (!m_allSelectedDicts.empty()) ? &m_allSelectedDicts.front() : NULL;
 }

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/ScorchOptions.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/ScorchOptions.cpp
@@ -222,7 +222,7 @@ void ScorchOptions::changeScorch(void)
 
 	Dict newDict;
 	newDict.setInt(TheKey_scorchType, (Int)m_scorchtype);
-	DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
+	DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
 	CWorldBuilderDoc* pDoc = CWorldBuilderDoc::GetActiveDoc();
 	pDoc->AddAndDoUndoable(pUndo);
 	REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
@@ -237,7 +237,7 @@ void ScorchOptions::changeSize(void)
 
 	Dict newDict;
 	newDict.setReal(TheKey_objectRadius, m_scorchsize);
-	DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
+	DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
 	CWorldBuilderDoc* pDoc = CWorldBuilderDoc::GetActiveDoc();
 	pDoc->AddAndDoUndoable(pUndo);
 	REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
@@ -258,7 +258,11 @@ void ScorchOptions::getAllSelectedDicts(void)
 	}
 }
 
-Dict** ScorchOptions::getFrontSelectedDicts()
+Dict** ScorchOptions::getAllSelectedDictsData()
 {
-	return (!m_allSelectedDicts.empty()) ? &m_allSelectedDicts.front() : NULL;
+#if defined(USING_STLPORT) || __cplusplus < 201103L
+	return !m_allSelectedDicts.empty() ? &m_allSelectedDicts.front() : NULL;
+#else
+	return m_allSelectedDicts.data();
+#endif
 }

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/mapobjectprops.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/mapobjectprops.cpp
@@ -278,7 +278,7 @@ void MapObjectProps::_TeamToDict(void)
   {
     Dict newDict;
     newDict.setAsciiString(TheKey_originalOwner, AsciiString(buf));
-    DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
+    DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
     pDoc->AddAndDoUndoable(pUndo);
     REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
     // Update is called by Do
@@ -301,7 +301,7 @@ void MapObjectProps::_NameToDict(void)
   {
     Dict newDict;
     newDict.setAsciiString(TheKey_objectName, cstr.GetBuffer(0));
-    DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
+    DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
     pDoc->AddAndDoUndoable(pUndo);
     REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
     // Update is called by Do																																																						
@@ -322,7 +322,7 @@ void MapObjectProps::_ScriptToDict(void)
   {
     Dict newDict;
     newDict.setAsciiString(TheKey_objectScriptAttachment, AsciiString(buf));
-    DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
+    DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
     pDoc->AddAndDoUndoable(pUndo);
     REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
     // Update is called by Do	
@@ -410,7 +410,7 @@ void MapObjectProps::_WeatherToDict(void)
   {
     Dict newDict;
     newDict.setInt(TheKey_objectWeather, curSel);
-    DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
+    DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
     pDoc->AddAndDoUndoable(pUndo);
     REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
     // Update is called by Do	
@@ -431,7 +431,7 @@ void MapObjectProps::_TimeToDict(void)
   {
     Dict newDict;
     newDict.setInt(TheKey_objectTime, curSel);
-    DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
+    DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
     pDoc->AddAndDoUndoable(pUndo);
     REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
     // Update is called by Do	
@@ -465,7 +465,7 @@ void MapObjectProps::_ScaleToDict(void)
     } else {
       newDict.setReal(TheKey_objectPrototypeScale, m_scale);
     }
-    DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
+    DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
     pDoc->AddAndDoUndoable(pUndo);
     REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
     // Update is called by Do
@@ -748,7 +748,7 @@ void MapObjectProps::_PrebuiltUpgradesToDict(void)
   CWorldBuilderDoc* pDoc = CWorldBuilderDoc::GetActiveDoc();
   if ( pDoc != NULL )
   {
-    DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, NAMEKEY_INVALID, m_allSelectedDicts.size(), pDoc, true);
+    DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, NAMEKEY_INVALID, m_allSelectedDicts.size(), pDoc, true);
     pDoc->AddAndDoUndoable(pUndo);
     REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
   }
@@ -1171,7 +1171,7 @@ void MapObjectProps::_HealthToDict(void)
   {
 	  Dict newDict;
 	  newDict.setInt(TheKey_objectInitialHealth, value);
-	  DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
+	  DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
 	  pDoc->AddAndDoUndoable(pUndo);
 	  REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	  // Update is called by Do
@@ -1192,7 +1192,7 @@ void MapObjectProps::_EnabledToDict(void)
   {
 	  Dict newDict;
 	  newDict.setBool(TheKey_objectEnabled, isChecked);
-	  DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
+	  DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
 	  pDoc->AddAndDoUndoable(pUndo);
 	  REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	  // Update is called by Do
@@ -1212,7 +1212,7 @@ void MapObjectProps::_IndestructibleToDict(void)
   {
 	  Dict newDict;
 	  newDict.setBool(TheKey_objectIndestructible, isChecked);
-	  DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
+	  DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
 	  pDoc->AddAndDoUndoable(pUndo);
 	  REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	  // Update is called by Do	
@@ -1232,7 +1232,7 @@ void MapObjectProps::_UnsellableToDict(void)
   {
 	  Dict newDict;
 	  newDict.setBool(TheKey_objectUnsellable, isChecked);
-	  DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
+	  DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
 	  pDoc->AddAndDoUndoable(pUndo);
 	  REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	  // Update is called by Do
@@ -1252,7 +1252,7 @@ void MapObjectProps::_TargetableToDict()
   {
 	  Dict newDict;
 	  newDict.setBool( TheKey_objectTargetable, isChecked );
-	  DictItemUndoable *pUndo = new DictItemUndoable( &m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size() );
+	  DictItemUndoable *pUndo = new DictItemUndoable( getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size() );
 	  pDoc->AddAndDoUndoable( pUndo );
 	  REF_PTR_RELEASE( pUndo ); // belongs to pDoc now.
 	  // Update is called by Do
@@ -1273,7 +1273,7 @@ void MapObjectProps::_PoweredToDict(void)
   {
 	  Dict newDict;
 	  newDict.setBool(TheKey_objectPowered, isChecked);
-	  DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
+	  DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
 	  pDoc->AddAndDoUndoable(pUndo);
 	  REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	  // Update is called by Do
@@ -1307,7 +1307,7 @@ void MapObjectProps::_AggressivenessToDict(void)
   {
 	  Dict newDict;
 	  newDict.setInt(TheKey_objectAggressiveness, value);
-	  DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
+	  DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
 	  pDoc->AddAndDoUndoable(pUndo);
 	  REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	  // Update is called by Do		
@@ -1335,7 +1335,7 @@ void MapObjectProps::_VisibilityToDict(void)
 	  if (value != -1) {
 		  newDict.setInt(TheKey_objectVisualRange, value);
 	  }
-	  DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, TheKey_objectVisualRange, m_allSelectedDicts.size());
+	  DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, TheKey_objectVisualRange, m_allSelectedDicts.size());
 	  pDoc->AddAndDoUndoable(pUndo);
 	  REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	  // Update is called by Do
@@ -1360,7 +1360,7 @@ void MapObjectProps::_VeterancyToDict(void)
   {
 	  Dict newDict;
 	  newDict.setInt(TheKey_objectVeterancy, value);
-	  DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
+	  DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
 	  pDoc->AddAndDoUndoable(pUndo);
 	  REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	  // Update is called by Do	
@@ -1388,7 +1388,7 @@ void MapObjectProps::_ShroudClearingDistanceToDict(void)
 	  if (value != -1) {
 		  newDict.setInt(TheKey_objectShroudClearingDistance, value);
 	  }
-	  DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, TheKey_objectShroudClearingDistance, m_allSelectedDicts.size());
+	  DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, TheKey_objectShroudClearingDistance, m_allSelectedDicts.size());
 	  pDoc->AddAndDoUndoable(pUndo);
 	  REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	  // Update is called by Do
@@ -1408,7 +1408,7 @@ void MapObjectProps::_RecruitableAIToDict(void)
   {
 	  Dict newDict;
 	  newDict.setBool(TheKey_objectRecruitableAI, isChecked);
-	  DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
+	  DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
 	  pDoc->AddAndDoUndoable(pUndo);
 	  REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	  // Update is called by Do
@@ -1433,7 +1433,7 @@ void MapObjectProps::_SelectableToDict(void)
 	  } else {
 		  newDict.setBool(TheKey_objectSelectable, isChecked);
 	  }
-	  DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
+	  DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
 	  pDoc->AddAndDoUndoable(pUndo);
 	  REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	  // Update is called by Do
@@ -1460,7 +1460,7 @@ void MapObjectProps::_HPsToDict()
     Dict newDict;
 
 	  newDict.setInt(TheKey_objectMaxHPs, value);
-	  DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
+	  DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
 	  pDoc->AddAndDoUndoable(pUndo);
 	  REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
   }
@@ -1487,7 +1487,7 @@ void MapObjectProps::_StoppingDistanceToDict(void)
   {
 	  Dict newDict;
 	  newDict.setReal(TheKey_objectStoppingDistance, value);
-	  DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
+	  DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
 	  pDoc->AddAndDoUndoable(pUndo);
 	  REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	  // Update is called by Doc
@@ -1740,6 +1740,11 @@ void MapObjectProps::InitSound(void)
 	
 } // end InitSound
 
+Dict** MapObjectProps::getFrontSelectedDicts()
+{
+	return (!m_allSelectedDicts.empty()) ? &m_allSelectedDicts.front() : NULL;
+}
+
 
 // Adds a series of Undoable's to the given MultipleUndoable which clears the
 // objectSoundAmbientCustomized flag and all the customization flags out of 
@@ -1749,37 +1754,37 @@ void MapObjectProps::clearCustomizeFlag( CWorldBuilderDoc* pDoc, MultipleUndoabl
 {
   Dict empty;
 
-  DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), empty, TheKey_objectSoundAmbientCustomized, m_allSelectedDicts.size(), pDoc, true);
+  DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), empty, TheKey_objectSoundAmbientCustomized, m_allSelectedDicts.size(), pDoc, true);
   ownerUndoable->addUndoable(pUndo);
   REF_PTR_RELEASE(pUndo); // belongs to ownerUndoable now.
 
   // Note: we can set all the undoes in between the first and last undo to not invalidate,
   // since the first (last for doing) and last invalidate after these changes anyway
-  pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), empty, TheKey_objectSoundAmbientMaxRange, m_allSelectedDicts.size(), pDoc, false);
+  pUndo = new DictItemUndoable(getFrontSelectedDicts(), empty, TheKey_objectSoundAmbientMaxRange, m_allSelectedDicts.size(), pDoc, false);
   ownerUndoable->addUndoable(pUndo);
   REF_PTR_RELEASE(pUndo); // belongs to ownerUndoable now.
   
-  pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), empty, TheKey_objectSoundAmbientMinVolume, m_allSelectedDicts.size(), pDoc, false);
+  pUndo = new DictItemUndoable(getFrontSelectedDicts(), empty, TheKey_objectSoundAmbientMinVolume, m_allSelectedDicts.size(), pDoc, false);
   ownerUndoable->addUndoable(pUndo);
   REF_PTR_RELEASE(pUndo); // belongs to ownerUndoable now.
   
-  pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), empty, TheKey_objectSoundAmbientVolume, m_allSelectedDicts.size(), pDoc, false);
+  pUndo = new DictItemUndoable(getFrontSelectedDicts(), empty, TheKey_objectSoundAmbientVolume, m_allSelectedDicts.size(), pDoc, false);
   ownerUndoable->addUndoable(pUndo);
   REF_PTR_RELEASE(pUndo); // belongs to ownerUndoable now.
   
-  pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), empty, TheKey_objectSoundAmbientMinRange, m_allSelectedDicts.size(), pDoc, false);
+  pUndo = new DictItemUndoable(getFrontSelectedDicts(), empty, TheKey_objectSoundAmbientMinRange, m_allSelectedDicts.size(), pDoc, false);
   ownerUndoable->addUndoable(pUndo);
   REF_PTR_RELEASE(pUndo); // belongs to ownerUndoable now.
 
-  pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), empty, TheKey_objectSoundAmbientLooping, m_allSelectedDicts.size(), pDoc, false);
+  pUndo = new DictItemUndoable(getFrontSelectedDicts(), empty, TheKey_objectSoundAmbientLooping, m_allSelectedDicts.size(), pDoc, false);
   ownerUndoable->addUndoable(pUndo);
   REF_PTR_RELEASE(pUndo); // belongs to ownerUndoable now.
 
-  pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), empty, TheKey_objectSoundAmbientLoopCount, m_allSelectedDicts.size(), pDoc, false);
+  pUndo = new DictItemUndoable(getFrontSelectedDicts(), empty, TheKey_objectSoundAmbientLoopCount, m_allSelectedDicts.size(), pDoc, false);
   ownerUndoable->addUndoable(pUndo);
   REF_PTR_RELEASE(pUndo); // belongs to ownerUndoable now.
 
-  pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), empty, TheKey_objectSoundAmbientPriority, m_allSelectedDicts.size(), pDoc, true);
+  pUndo = new DictItemUndoable(getFrontSelectedDicts(), empty, TheKey_objectSoundAmbientPriority, m_allSelectedDicts.size(), pDoc, true);
   ownerUndoable->addUndoable(pUndo);
   REF_PTR_RELEASE(pUndo); // belongs to ownerUndoable now.
 }
@@ -1822,7 +1827,7 @@ void MapObjectProps::attachedSoundToDict(void)
       clearCustomizeFlag( pDoc, pUndo );
     }
 
-    DictItemUndoable *pDictUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, TheKey_objectSoundAmbient, m_allSelectedDicts.size(), pDoc, true);
+    DictItemUndoable *pDictUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, TheKey_objectSoundAmbient, m_allSelectedDicts.size(), pDoc, true);
     pUndo->addUndoable( pDictUndo );
     pDoc->AddAndDoUndoable( pUndo );
     REF_PTR_RELEASE( pDictUndo ); // belongs to pUndo
@@ -1849,7 +1854,7 @@ void MapObjectProps::customizeToDict(void)
     if ( customizeCheckbox->GetCheck() == 1 )
     {
       newDict.setBool( TheKey_objectSoundAmbientCustomized, true );
-      DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, TheKey_objectSoundAmbientCustomized, m_allSelectedDicts.size(), pDoc, true);
+      DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, TheKey_objectSoundAmbientCustomized, m_allSelectedDicts.size(), pDoc, true);
       pDoc->AddAndDoUndoable(pUndo);
       REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
       // Update is called by Doc
@@ -1881,7 +1886,7 @@ void MapObjectProps::enabledToDict(void)
     
     newDict.setBool( TheKey_objectSoundAmbientEnabled, enabledCheckbox->GetCheck() != 0 );
     
-    DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
+    DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
     pDoc->AddAndDoUndoable(pUndo);
     REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
     // Update is called by Doc
@@ -1904,7 +1909,7 @@ void MapObjectProps::loopingToDict(void)
     
     newDict.setBool( TheKey_objectSoundAmbientLooping, loopingCheckbox->GetCheck() != 0 );
     
-    DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
+    DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
     pDoc->AddAndDoUndoable(pUndo);
     REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
     // Update is called by Doc
@@ -1930,7 +1935,7 @@ void MapObjectProps::loopCountToDict(void)
     
     newDict.setInt( TheKey_objectSoundAmbientLoopCount, atoi( loopCountString ) );
     
-    DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
+    DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
     pDoc->AddAndDoUndoable(pUndo);
     REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
     // Update is called by Doc
@@ -1957,7 +1962,7 @@ void MapObjectProps::minVolumeToDict(void)
     // Note: min volume is stored as Real between 0.0 and 1.0, but displayed as a percentage from 0 to 100
     newDict.setReal( TheKey_objectSoundAmbientMinVolume, INT_TO_REAL( atoi( minVolumeString ) ) / 100.0f );
     
-    DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
+    DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
     pDoc->AddAndDoUndoable(pUndo);
     REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
     // Update is called by Doc
@@ -1984,7 +1989,7 @@ void MapObjectProps::volumeToDict(void)
     // Note: volume is stored as Real between 0.0 and 1.0, but displayed as a percentage from 0 to 100
     newDict.setReal( TheKey_objectSoundAmbientVolume, INT_TO_REAL( atoi( volumeString ) ) / 100.0f );
     
-    DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
+    DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
     pDoc->AddAndDoUndoable(pUndo);
     REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
     // Update is called by Doc
@@ -2011,7 +2016,7 @@ void MapObjectProps::minRangeToDict(void)
     
     newDict.setReal( TheKey_objectSoundAmbientMinRange, INT_TO_REAL( atoi( minRangeString ) ) );
     
-    DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
+    DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
     pDoc->AddAndDoUndoable(pUndo);
     REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
     // Update is called by Doc
@@ -2037,7 +2042,7 @@ void MapObjectProps::maxRangeToDict(void)
     
     newDict.setReal( TheKey_objectSoundAmbientMaxRange, INT_TO_REAL( atoi( maxRangeString ) ) );
     
-    DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
+    DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
     pDoc->AddAndDoUndoable(pUndo);
     REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
     // Update is called by Doc
@@ -2060,7 +2065,7 @@ void MapObjectProps::priorityToDict(void)
     
     newDict.setInt( TheKey_objectSoundAmbientPriority, priorityComboBox->GetCurSel() );
     
-    DictItemUndoable *pUndo = new DictItemUndoable(&m_allSelectedDicts.front(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
+    DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
     pDoc->AddAndDoUndoable(pUndo);
     REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
     // Update is called by Doc

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/mapobjectprops.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/mapobjectprops.cpp
@@ -1740,15 +1740,6 @@ void MapObjectProps::InitSound(void)
 	
 } // end InitSound
 
-Dict** MapObjectProps::getAllSelectedDictsData()
-{
-#if defined(USING_STLPORT) || __cplusplus < 201103L
-	return !m_allSelectedDicts.empty() ? &m_allSelectedDicts.front() : NULL;
-#else
-	return m_allSelectedDicts.data();
-#endif
-}
-
 
 // Adds a series of Undoable's to the given MultipleUndoable which clears the
 // objectSoundAmbientCustomized flag and all the customization flags out of 
@@ -2878,6 +2869,14 @@ void MapObjectProps::getAllSelectedDicts(void)
 	}
 }
 
+Dict** MapObjectProps::getAllSelectedDictsData()
+{
+#if defined(USING_STLPORT) || __cplusplus < 201103L
+	return !m_allSelectedDicts.empty() ? &m_allSelectedDicts.front() : NULL;
+#else
+	return m_allSelectedDicts.data();
+#endif
+}
 
 /// Move data from dialog controls to object
 void MapObjectProps::OnScaleOn() 

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/mapobjectprops.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/mapobjectprops.cpp
@@ -278,7 +278,7 @@ void MapObjectProps::_TeamToDict(void)
   {
     Dict newDict;
     newDict.setAsciiString(TheKey_originalOwner, AsciiString(buf));
-    DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
+    DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
     pDoc->AddAndDoUndoable(pUndo);
     REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
     // Update is called by Do
@@ -301,7 +301,7 @@ void MapObjectProps::_NameToDict(void)
   {
     Dict newDict;
     newDict.setAsciiString(TheKey_objectName, cstr.GetBuffer(0));
-    DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
+    DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
     pDoc->AddAndDoUndoable(pUndo);
     REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
     // Update is called by Do																																																						
@@ -322,7 +322,7 @@ void MapObjectProps::_ScriptToDict(void)
   {
     Dict newDict;
     newDict.setAsciiString(TheKey_objectScriptAttachment, AsciiString(buf));
-    DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
+    DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
     pDoc->AddAndDoUndoable(pUndo);
     REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
     // Update is called by Do	
@@ -410,7 +410,7 @@ void MapObjectProps::_WeatherToDict(void)
   {
     Dict newDict;
     newDict.setInt(TheKey_objectWeather, curSel);
-    DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
+    DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
     pDoc->AddAndDoUndoable(pUndo);
     REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
     // Update is called by Do	
@@ -431,7 +431,7 @@ void MapObjectProps::_TimeToDict(void)
   {
     Dict newDict;
     newDict.setInt(TheKey_objectTime, curSel);
-    DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
+    DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
     pDoc->AddAndDoUndoable(pUndo);
     REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
     // Update is called by Do	
@@ -465,7 +465,7 @@ void MapObjectProps::_ScaleToDict(void)
     } else {
       newDict.setReal(TheKey_objectPrototypeScale, m_scale);
     }
-    DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
+    DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
     pDoc->AddAndDoUndoable(pUndo);
     REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
     // Update is called by Do
@@ -748,7 +748,7 @@ void MapObjectProps::_PrebuiltUpgradesToDict(void)
   CWorldBuilderDoc* pDoc = CWorldBuilderDoc::GetActiveDoc();
   if ( pDoc != NULL )
   {
-    DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, NAMEKEY_INVALID, m_allSelectedDicts.size(), pDoc, true);
+    DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, NAMEKEY_INVALID, m_allSelectedDicts.size(), pDoc, true);
     pDoc->AddAndDoUndoable(pUndo);
     REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
   }
@@ -1171,7 +1171,7 @@ void MapObjectProps::_HealthToDict(void)
   {
 	  Dict newDict;
 	  newDict.setInt(TheKey_objectInitialHealth, value);
-	  DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
+	  DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
 	  pDoc->AddAndDoUndoable(pUndo);
 	  REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	  // Update is called by Do
@@ -1192,7 +1192,7 @@ void MapObjectProps::_EnabledToDict(void)
   {
 	  Dict newDict;
 	  newDict.setBool(TheKey_objectEnabled, isChecked);
-	  DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
+	  DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
 	  pDoc->AddAndDoUndoable(pUndo);
 	  REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	  // Update is called by Do
@@ -1212,7 +1212,7 @@ void MapObjectProps::_IndestructibleToDict(void)
   {
 	  Dict newDict;
 	  newDict.setBool(TheKey_objectIndestructible, isChecked);
-	  DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
+	  DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
 	  pDoc->AddAndDoUndoable(pUndo);
 	  REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	  // Update is called by Do	
@@ -1232,7 +1232,7 @@ void MapObjectProps::_UnsellableToDict(void)
   {
 	  Dict newDict;
 	  newDict.setBool(TheKey_objectUnsellable, isChecked);
-	  DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
+	  DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
 	  pDoc->AddAndDoUndoable(pUndo);
 	  REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	  // Update is called by Do
@@ -1252,7 +1252,7 @@ void MapObjectProps::_TargetableToDict()
   {
 	  Dict newDict;
 	  newDict.setBool( TheKey_objectTargetable, isChecked );
-	  DictItemUndoable *pUndo = new DictItemUndoable( getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size() );
+	  DictItemUndoable *pUndo = new DictItemUndoable( getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size() );
 	  pDoc->AddAndDoUndoable( pUndo );
 	  REF_PTR_RELEASE( pUndo ); // belongs to pDoc now.
 	  // Update is called by Do
@@ -1273,7 +1273,7 @@ void MapObjectProps::_PoweredToDict(void)
   {
 	  Dict newDict;
 	  newDict.setBool(TheKey_objectPowered, isChecked);
-	  DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
+	  DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
 	  pDoc->AddAndDoUndoable(pUndo);
 	  REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	  // Update is called by Do
@@ -1307,7 +1307,7 @@ void MapObjectProps::_AggressivenessToDict(void)
   {
 	  Dict newDict;
 	  newDict.setInt(TheKey_objectAggressiveness, value);
-	  DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
+	  DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
 	  pDoc->AddAndDoUndoable(pUndo);
 	  REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	  // Update is called by Do		
@@ -1335,7 +1335,7 @@ void MapObjectProps::_VisibilityToDict(void)
 	  if (value != -1) {
 		  newDict.setInt(TheKey_objectVisualRange, value);
 	  }
-	  DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, TheKey_objectVisualRange, m_allSelectedDicts.size());
+	  DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, TheKey_objectVisualRange, m_allSelectedDicts.size());
 	  pDoc->AddAndDoUndoable(pUndo);
 	  REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	  // Update is called by Do
@@ -1360,7 +1360,7 @@ void MapObjectProps::_VeterancyToDict(void)
   {
 	  Dict newDict;
 	  newDict.setInt(TheKey_objectVeterancy, value);
-	  DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
+	  DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
 	  pDoc->AddAndDoUndoable(pUndo);
 	  REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	  // Update is called by Do	
@@ -1388,7 +1388,7 @@ void MapObjectProps::_ShroudClearingDistanceToDict(void)
 	  if (value != -1) {
 		  newDict.setInt(TheKey_objectShroudClearingDistance, value);
 	  }
-	  DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, TheKey_objectShroudClearingDistance, m_allSelectedDicts.size());
+	  DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, TheKey_objectShroudClearingDistance, m_allSelectedDicts.size());
 	  pDoc->AddAndDoUndoable(pUndo);
 	  REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	  // Update is called by Do
@@ -1408,7 +1408,7 @@ void MapObjectProps::_RecruitableAIToDict(void)
   {
 	  Dict newDict;
 	  newDict.setBool(TheKey_objectRecruitableAI, isChecked);
-	  DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
+	  DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
 	  pDoc->AddAndDoUndoable(pUndo);
 	  REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	  // Update is called by Do
@@ -1433,7 +1433,7 @@ void MapObjectProps::_SelectableToDict(void)
 	  } else {
 		  newDict.setBool(TheKey_objectSelectable, isChecked);
 	  }
-	  DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
+	  DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
 	  pDoc->AddAndDoUndoable(pUndo);
 	  REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	  // Update is called by Do
@@ -1460,7 +1460,7 @@ void MapObjectProps::_HPsToDict()
     Dict newDict;
 
 	  newDict.setInt(TheKey_objectMaxHPs, value);
-	  DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
+	  DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size());
 	  pDoc->AddAndDoUndoable(pUndo);
 	  REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
   }
@@ -1487,7 +1487,7 @@ void MapObjectProps::_StoppingDistanceToDict(void)
   {
 	  Dict newDict;
 	  newDict.setReal(TheKey_objectStoppingDistance, value);
-	  DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
+	  DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
 	  pDoc->AddAndDoUndoable(pUndo);
 	  REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
 	  // Update is called by Doc
@@ -1740,9 +1740,13 @@ void MapObjectProps::InitSound(void)
 	
 } // end InitSound
 
-Dict** MapObjectProps::getFrontSelectedDicts()
+Dict** MapObjectProps::getAllSelectedDictsData()
 {
-	return (!m_allSelectedDicts.empty()) ? &m_allSelectedDicts.front() : NULL;
+#if defined(USING_STLPORT) || __cplusplus < 201103L
+	return !m_allSelectedDicts.empty() ? &m_allSelectedDicts.front() : NULL;
+#else
+	return m_allSelectedDicts.data();
+#endif
 }
 
 
@@ -1754,37 +1758,37 @@ void MapObjectProps::clearCustomizeFlag( CWorldBuilderDoc* pDoc, MultipleUndoabl
 {
   Dict empty;
 
-  DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), empty, TheKey_objectSoundAmbientCustomized, m_allSelectedDicts.size(), pDoc, true);
+  DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), empty, TheKey_objectSoundAmbientCustomized, m_allSelectedDicts.size(), pDoc, true);
   ownerUndoable->addUndoable(pUndo);
   REF_PTR_RELEASE(pUndo); // belongs to ownerUndoable now.
 
   // Note: we can set all the undoes in between the first and last undo to not invalidate,
   // since the first (last for doing) and last invalidate after these changes anyway
-  pUndo = new DictItemUndoable(getFrontSelectedDicts(), empty, TheKey_objectSoundAmbientMaxRange, m_allSelectedDicts.size(), pDoc, false);
+  pUndo = new DictItemUndoable(getAllSelectedDictsData(), empty, TheKey_objectSoundAmbientMaxRange, m_allSelectedDicts.size(), pDoc, false);
   ownerUndoable->addUndoable(pUndo);
   REF_PTR_RELEASE(pUndo); // belongs to ownerUndoable now.
   
-  pUndo = new DictItemUndoable(getFrontSelectedDicts(), empty, TheKey_objectSoundAmbientMinVolume, m_allSelectedDicts.size(), pDoc, false);
+  pUndo = new DictItemUndoable(getAllSelectedDictsData(), empty, TheKey_objectSoundAmbientMinVolume, m_allSelectedDicts.size(), pDoc, false);
   ownerUndoable->addUndoable(pUndo);
   REF_PTR_RELEASE(pUndo); // belongs to ownerUndoable now.
   
-  pUndo = new DictItemUndoable(getFrontSelectedDicts(), empty, TheKey_objectSoundAmbientVolume, m_allSelectedDicts.size(), pDoc, false);
+  pUndo = new DictItemUndoable(getAllSelectedDictsData(), empty, TheKey_objectSoundAmbientVolume, m_allSelectedDicts.size(), pDoc, false);
   ownerUndoable->addUndoable(pUndo);
   REF_PTR_RELEASE(pUndo); // belongs to ownerUndoable now.
   
-  pUndo = new DictItemUndoable(getFrontSelectedDicts(), empty, TheKey_objectSoundAmbientMinRange, m_allSelectedDicts.size(), pDoc, false);
+  pUndo = new DictItemUndoable(getAllSelectedDictsData(), empty, TheKey_objectSoundAmbientMinRange, m_allSelectedDicts.size(), pDoc, false);
   ownerUndoable->addUndoable(pUndo);
   REF_PTR_RELEASE(pUndo); // belongs to ownerUndoable now.
 
-  pUndo = new DictItemUndoable(getFrontSelectedDicts(), empty, TheKey_objectSoundAmbientLooping, m_allSelectedDicts.size(), pDoc, false);
+  pUndo = new DictItemUndoable(getAllSelectedDictsData(), empty, TheKey_objectSoundAmbientLooping, m_allSelectedDicts.size(), pDoc, false);
   ownerUndoable->addUndoable(pUndo);
   REF_PTR_RELEASE(pUndo); // belongs to ownerUndoable now.
 
-  pUndo = new DictItemUndoable(getFrontSelectedDicts(), empty, TheKey_objectSoundAmbientLoopCount, m_allSelectedDicts.size(), pDoc, false);
+  pUndo = new DictItemUndoable(getAllSelectedDictsData(), empty, TheKey_objectSoundAmbientLoopCount, m_allSelectedDicts.size(), pDoc, false);
   ownerUndoable->addUndoable(pUndo);
   REF_PTR_RELEASE(pUndo); // belongs to ownerUndoable now.
 
-  pUndo = new DictItemUndoable(getFrontSelectedDicts(), empty, TheKey_objectSoundAmbientPriority, m_allSelectedDicts.size(), pDoc, true);
+  pUndo = new DictItemUndoable(getAllSelectedDictsData(), empty, TheKey_objectSoundAmbientPriority, m_allSelectedDicts.size(), pDoc, true);
   ownerUndoable->addUndoable(pUndo);
   REF_PTR_RELEASE(pUndo); // belongs to ownerUndoable now.
 }
@@ -1827,7 +1831,7 @@ void MapObjectProps::attachedSoundToDict(void)
       clearCustomizeFlag( pDoc, pUndo );
     }
 
-    DictItemUndoable *pDictUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, TheKey_objectSoundAmbient, m_allSelectedDicts.size(), pDoc, true);
+    DictItemUndoable *pDictUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, TheKey_objectSoundAmbient, m_allSelectedDicts.size(), pDoc, true);
     pUndo->addUndoable( pDictUndo );
     pDoc->AddAndDoUndoable( pUndo );
     REF_PTR_RELEASE( pDictUndo ); // belongs to pUndo
@@ -1854,7 +1858,7 @@ void MapObjectProps::customizeToDict(void)
     if ( customizeCheckbox->GetCheck() == 1 )
     {
       newDict.setBool( TheKey_objectSoundAmbientCustomized, true );
-      DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, TheKey_objectSoundAmbientCustomized, m_allSelectedDicts.size(), pDoc, true);
+      DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, TheKey_objectSoundAmbientCustomized, m_allSelectedDicts.size(), pDoc, true);
       pDoc->AddAndDoUndoable(pUndo);
       REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
       // Update is called by Doc
@@ -1886,7 +1890,7 @@ void MapObjectProps::enabledToDict(void)
     
     newDict.setBool( TheKey_objectSoundAmbientEnabled, enabledCheckbox->GetCheck() != 0 );
     
-    DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
+    DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
     pDoc->AddAndDoUndoable(pUndo);
     REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
     // Update is called by Doc
@@ -1909,7 +1913,7 @@ void MapObjectProps::loopingToDict(void)
     
     newDict.setBool( TheKey_objectSoundAmbientLooping, loopingCheckbox->GetCheck() != 0 );
     
-    DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
+    DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
     pDoc->AddAndDoUndoable(pUndo);
     REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
     // Update is called by Doc
@@ -1935,7 +1939,7 @@ void MapObjectProps::loopCountToDict(void)
     
     newDict.setInt( TheKey_objectSoundAmbientLoopCount, atoi( loopCountString ) );
     
-    DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
+    DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
     pDoc->AddAndDoUndoable(pUndo);
     REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
     // Update is called by Doc
@@ -1962,7 +1966,7 @@ void MapObjectProps::minVolumeToDict(void)
     // Note: min volume is stored as Real between 0.0 and 1.0, but displayed as a percentage from 0 to 100
     newDict.setReal( TheKey_objectSoundAmbientMinVolume, INT_TO_REAL( atoi( minVolumeString ) ) / 100.0f );
     
-    DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
+    DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
     pDoc->AddAndDoUndoable(pUndo);
     REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
     // Update is called by Doc
@@ -1989,7 +1993,7 @@ void MapObjectProps::volumeToDict(void)
     // Note: volume is stored as Real between 0.0 and 1.0, but displayed as a percentage from 0 to 100
     newDict.setReal( TheKey_objectSoundAmbientVolume, INT_TO_REAL( atoi( volumeString ) ) / 100.0f );
     
-    DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
+    DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
     pDoc->AddAndDoUndoable(pUndo);
     REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
     // Update is called by Doc
@@ -2016,7 +2020,7 @@ void MapObjectProps::minRangeToDict(void)
     
     newDict.setReal( TheKey_objectSoundAmbientMinRange, INT_TO_REAL( atoi( minRangeString ) ) );
     
-    DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
+    DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
     pDoc->AddAndDoUndoable(pUndo);
     REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
     // Update is called by Doc
@@ -2042,7 +2046,7 @@ void MapObjectProps::maxRangeToDict(void)
     
     newDict.setReal( TheKey_objectSoundAmbientMaxRange, INT_TO_REAL( atoi( maxRangeString ) ) );
     
-    DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
+    DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
     pDoc->AddAndDoUndoable(pUndo);
     REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
     // Update is called by Doc
@@ -2065,7 +2069,7 @@ void MapObjectProps::priorityToDict(void)
     
     newDict.setInt( TheKey_objectSoundAmbientPriority, priorityComboBox->GetCurSel() );
     
-    DictItemUndoable *pUndo = new DictItemUndoable(getFrontSelectedDicts(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
+    DictItemUndoable *pUndo = new DictItemUndoable(getAllSelectedDictsData(), newDict, newDict.getNthKey(0), m_allSelectedDicts.size(), pDoc, true);
     pDoc->AddAndDoUndoable(pUndo);
     REF_PTR_RELEASE(pUndo); // belongs to pDoc now.
     // Update is called by Doc


### PR DESCRIPTION
**Reproduction steps: Start World Builder (debug build) and tick "Enabled" in the "Object Properties" window. This will result in a debug assertion: "front() called on empty vector".**

Notice how a pointer to the first element of `m_allSelectedDicts` is taken without checking whether the vector is empty or not (line 1436):
https://github.com/TheSuperHackers/GeneralsGameCode/blob/51afe0c6d2f5ab1debc801e414db8fc1b7a03d49/GeneralsMD/Code/Tools/WorldBuilder/src/mapobjectprops.cpp#L1418-L1441

I chose to not add size checks everywhere but keep the code functionally the same except calling front() on an empty vector. As long as the vector is empty, the code in `DictItemUndoable::DictItemUndoable` won't attempt to dereference the front pointer so it can be `NULL`.

Would need to be replicated in Generals.

## TODO

- [x] Replicate in Generals