### PR TITLE
[ZH] Prevent hang in network lobby with long player names

### DIFF
--- a/Core/GameEngine/Include/Common/AsciiString.h
+++ b/Core/GameEngine/Include/Common/AsciiString.h
@@ -377,6 +377,20 @@ public:
 	AsciiString& operator=(const AsciiString& stringSrc);	///< the same as set()
 	AsciiString& operator=(const char* s);				///< the same as set()
 
+	const Char& operator[](Int index) const
+	{
+		DEBUG_ASSERTCRASH(index >= 0 && index < getLength(), ("bad index in AsciiString::operator[]"));
+		return peek()[index];
+	}
+
+	Char& operator[](Int index)
+	{
+		Int length = getLength();
+		DEBUG_ASSERTCRASH(index >= 0 && index < length, ("bad index in AsciiString::operator[]"));
+		ensureUniqueBufferOfSize(length + 1, true, NULL, NULL);
+		return peek()[index];
+	}
+
 	void debugIgnoreLeaks();
 
 };

--- a/Core/GameEngine/Include/Common/AsciiString.h
+++ b/Core/GameEngine/Include/Common/AsciiString.h
@@ -385,9 +385,8 @@ public:
 
 	Char& operator[](Int index)
 	{
-		Int length = getLength();
-		DEBUG_ASSERTCRASH(index >= 0 && index < length, ("bad index in AsciiString::operator[]"));
-		ensureUniqueBufferOfSize(length + 1, true, NULL, NULL);
+		DEBUG_ASSERTCRASH(index >= 0 && index < getLength(), ("bad index in AsciiString::operator[]"));
+		ensureUniqueBufferOfSize(m_data->m_numCharsAllocated, true, NULL, NULL);
 		return peek()[index];
 	}
 

--- a/Core/GameEngine/Include/Common/UnicodeString.h
+++ b/Core/GameEngine/Include/Common/UnicodeString.h
@@ -337,8 +337,7 @@ public:
 
 	WideChar& operator[](Int index)
 	{
-		DEBUG_ASSERTCRASH(m_data && m_data->m_numCharsAllocated > index && index >= 0, ("bad index in UnicodeString::operator[]"));
-
+		DEBUG_ASSERTCRASH(index >= 0 && index < getLength(), ("bad index in UnicodeString::operator[]"));
 		ensureUniqueBufferOfSize(m_data->m_numCharsAllocated, true, NULL, NULL);
 		return peek()[index];
 	}

--- a/Core/GameEngine/Include/Common/UnicodeString.h
+++ b/Core/GameEngine/Include/Common/UnicodeString.h
@@ -328,6 +328,20 @@ public:
 
 	UnicodeString& operator=(const UnicodeString& stringSrc);	///< the same as set()
 	UnicodeString& operator=(const WideChar* s);				///< the same as set()
+
+	const WideChar& operator[](Int index) const
+	{
+		DEBUG_ASSERTCRASH(index >= 0 && index < getLength(), ("bad index in UnicodeString::operator[]"));
+		return peek()[index];
+	}
+
+	WideChar& operator[](Int index)
+	{
+		Int length = getLength();
+		DEBUG_ASSERTCRASH(index >= 0 && index < length, ("bad index in UnicodeString::operator[]"));
+		ensureUniqueBufferOfSize(length + 1, true, NULL, NULL);
+		return peek()[index];
+	}
 };
 
 

--- a/Core/GameEngine/Include/Common/UnicodeString.h
+++ b/Core/GameEngine/Include/Common/UnicodeString.h
@@ -337,9 +337,9 @@ public:
 
 	WideChar& operator[](Int index)
 	{
-		Int length = getLength();
-		DEBUG_ASSERTCRASH(index >= 0 && index < length, ("bad index in UnicodeString::operator[]"));
-		ensureUniqueBufferOfSize(length + 1, true, NULL, NULL);
+		DEBUG_ASSERTCRASH(m_data && m_data->m_numCharsAllocated > index && index >= 0, ("bad index in UnicodeString::operator[]"));
+
+		ensureUniqueBufferOfSize(m_data->m_numCharsAllocated, true, NULL, NULL);
 		return peek()[index];
 	}
 };

--- a/Core/GameEngine/Include/GameNetwork/LANAPI.h
+++ b/Core/GameEngine/Include/GameNetwork/LANAPI.h
@@ -406,6 +406,7 @@ struct LANMessage
 		{
 			char options[m_lanMaxOptionsLength+1];
 		} GameOptions;
+		static_assert(ARRAY_SIZE(GameOptions.options) > m_lanMaxOptionsLength, "GameOptions.options buffer must be larger than m_lanMaxOptionsLength");
 
 	};
 };

--- a/Core/GameEngine/Source/GameNetwork/GameInfo.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameInfo.cpp
@@ -959,22 +959,20 @@ static Bool TruncatePlayerNames(AsciiStringVec& playerNames, Int truncateAmount)
 	// sort based on length in ascending order
 	std::sort(lengthIndex.begin(), lengthIndex.end());
 
-	Int truncateNameAmount = 0;
 	for (size_t i = 0; i < lengthIndex.size(); ++i)
 	{
 		const Int playerIndex = lengthIndex[i].Index;
 		const Int playerLength = lengthIndex[i].Length;
 
 		// round avg name length up, which will penalize the final entry (longest name) as it will have to account for the roundings
-		const Int avgNameLength = ((remainingNamesLength - truncateAmount) + (playerNames.size() - i - 1)) / (playerNames.size() - i);
+		const Int avgNameLength = WWMath::Div_Ceil((remainingNamesLength - truncateAmount), (playerNames.size() - i));
 		remainingNamesLength -= playerLength;
 		if (playerLength <= avgNameLength)
 		{
 			continue;
 		}
 
-		// ensure a longer name is not truncated less than a previous, shorter name
-		truncateNameAmount = std::max(truncateNameAmount, playerLength - avgNameLength);
+		Int truncateNameAmount = playerLength - avgNameLength;
 		if (i == lengthIndex.size() - 1)
 		{
 			// ensure we account for rounding errors when truncating the last, longest entry

--- a/Core/GameEngine/Source/GameNetwork/LANAPI.cpp
+++ b/Core/GameEngine/Source/GameNetwork/LANAPI.cpp
@@ -831,7 +831,7 @@ void LANAPI::RequestGameStartTimer( Int seconds )
 
 void LANAPI::RequestGameOptions( AsciiString gameOptions, Bool isPublic, UnsignedInt ip /* = 0 */ )
 {
-	DEBUG_ASSERTCRASH(gameOptions.getLength() < m_lanMaxOptionsLength, ("Game options string is too long!"));
+	DEBUG_ASSERTCRASH(gameOptions.getLength() <= m_lanMaxOptionsLength, ("Game options string is too long!"));
 
 	if (!m_currentGame)
 		return;

--- a/Core/Libraries/Source/WWVegas/WWMath/wwmath.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/wwmath.h
@@ -168,6 +168,8 @@ static WWINLINE bool			Is_Valid_Double(double x);
 
 static WWINLINE float Normalize_Angle(float angle); // Normalizes the angle to the range -PI..PI
 
+static WWINLINE int				Div_Ceil(const int num, const int den);
+
 };
 
 WWINLINE float WWMath::Sign(float val)
@@ -653,4 +655,14 @@ WWINLINE float WWMath::Inv_Sqrt(float val)
 WWINLINE float WWMath::Normalize_Angle(float angle)
 {
 	return angle - (WWMATH_TWO_PI * Floor((angle + WWMATH_PI) / WWMATH_TWO_PI));
+}
+
+// ----------------------------------------------------------------------------
+// Ceil rounded int division
+// Rounding away from 0 for positive values, towards 0 for negative values
+// ----------------------------------------------------------------------------
+WWINLINE int WWMath::Div_Ceil(const int num, const int den)
+{
+	const div_t res = std::div(num, den);
+	return (res.rem != 0 && res.quot >= 0) ? res.quot + 1 : res.quot;
 }

--- a/Core/Libraries/Source/WWVegas/WWMath/wwmath.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/wwmath.h
@@ -663,6 +663,6 @@ WWINLINE float WWMath::Normalize_Angle(float angle)
 // ----------------------------------------------------------------------------
 WWINLINE int WWMath::Div_Ceil(const int num, const int den)
 {
-	const div_t res = std::div(num, den);
+	const div_t res = ::div(num, den);
 	return (res.rem != 0 && res.quot >= 0) ? res.quot + 1 : res.quot;
 }


### PR DESCRIPTION
* Fixes #79 

# The Problem
When many players with long names join a lobby, the host can hang. This is caused by an eternal loop while trying to truncate player names in order to fit the entire game info within a network packet (476 bytes, with 400 for the game info).
The eternal looping is a result of having overflowed the total packet size and thus requiring a player name to have negative length in order to fit within the packet. The truncation is done with a while loop checking if the string is longer than the required value, and if so removing the last character. Removing the last character on an AsciiString is a no-op, and thus the loop continues.

This name truncation is not implemented in Generals, and is therefore not affected by this issue either.

# The Solution
Instead of attempting to truncate the player names "on the fly", first try to construct the game options string with full names. If the resulting string is within the size limits, use that string.
If the resulting string is too long, use the size difference to determine how much truncation needs to happen with the player names to fit.
Player names are sorted based on length in descending order, and the longer names are truncated first. An example of this truncation could be player A with a 10 char name and player B with a 7 char name need to be truncated by a total of 6 chars, then player A would end up with a 5 char name and B with a 6 char name.

A lower limit of 2 characters for player names has been added, meaning that no name will be truncated shorter than that. If all names are truncated to 2 characters and the string is still too long, the serialization will fail and return an empty string for the game options. This will result in the empty string being sent to the player that attempts to join, where it cannot be parsed, and  joining the game times out for that player.

The host will know the full names of all the players, as it's the game options send to the other players that needs truncation. Truncation will therefore not be visible to the host.