### PR TITLE
[GEN][ZH] Remove unnecessary NULL pointer tests in UpdateSlotList()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameNetwork/GUIUtil.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/GUIUtil.cpp
@@ -339,13 +339,14 @@ void UpdateSlotList( GameInfo *myGame, GameWindow *comboPlayer[],
 		for( int i =0; i < MAX_SLOTS; i++ )
 		{
 			GameSlot * slot = myGame->getSlot(i);
+
 			// if i'm host, enable the controls for AI
-			if(myGame->amIHost() && slot && slot->isAI())
+			if(myGame->amIHost() && slot->isAI())
 			{
 				EnableAcceptControls(TRUE, myGame, comboPlayer, comboColor, comboPlayerTemplate,
 					comboTeam, buttonAccept, buttonStart, buttonMapStartPosition, i);
 			}
-			else if (slot && myGame->getLocalSlotNum() == i)
+			else if (myGame->getLocalSlotNum() == i)
 			{
 				if(slot->isAccepted() && !myGame->amIHost())
 				{
@@ -371,7 +372,7 @@ void UpdateSlotList( GameInfo *myGame, GameWindow *comboPlayer[],
 				EnableAcceptControls(FALSE, myGame, comboPlayer, comboColor, comboPlayerTemplate,
 					comboTeam, buttonAccept, buttonStart, buttonMapStartPosition, i);
 			}
-			if(slot && slot->isHuman())
+			if(slot->isHuman())
 			{
 				UnicodeString newName = slot->getName();
 				UnicodeString oldName = GadgetComboBoxGetText(comboPlayer[i]);

--- a/Generals/Code/GameEngine/Source/GameNetwork/GameInfo.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/GameInfo.cpp
@@ -449,6 +449,7 @@ GameSlot* GameInfo::getSlot( Int slotNum )
 	if (slotNum < 0 || slotNum >= MAX_SLOTS)
 		return NULL;
 
+	DEBUG_ASSERTCRASH( m_slot[slotNum], ("NULL slot pointer") );
 	return m_slot[slotNum];
 }
 
@@ -458,6 +459,7 @@ const GameSlot* GameInfo::getConstSlot( Int slotNum ) const
 	if (slotNum < 0 || slotNum >= MAX_SLOTS)
 		return NULL;
 
+	DEBUG_ASSERTCRASH( m_slot[slotNum], ("NULL slot pointer") );
 	return m_slot[slotNum];
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/GUIUtil.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/GUIUtil.cpp
@@ -393,13 +393,14 @@ void UpdateSlotList( GameInfo *myGame, GameWindow *comboPlayer[],
 		for( int i =0; i < MAX_SLOTS; i++ )
 		{
 			GameSlot * slot = myGame->getSlot(i);
+
 			// if i'm host, enable the controls for AI
-			if(myGame->amIHost() && slot && slot->isAI())
+			if(myGame->amIHost() && slot->isAI())
 			{
 				EnableAcceptControls(TRUE, myGame, comboPlayer, comboColor, comboPlayerTemplate,
 					comboTeam, buttonAccept, buttonStart, buttonMapStartPosition, i);
 			}
-			else if (slot && myGame->getLocalSlotNum() == i)
+			else if (myGame->getLocalSlotNum() == i)
 			{
 				if(slot->isAccepted() && !myGame->amIHost())
 				{
@@ -425,7 +426,7 @@ void UpdateSlotList( GameInfo *myGame, GameWindow *comboPlayer[],
 				EnableAcceptControls(FALSE, myGame, comboPlayer, comboColor, comboPlayerTemplate,
 					comboTeam, buttonAccept, buttonStart, buttonMapStartPosition, i);
 			}
-			if(slot && slot->isHuman())
+			if(slot->isHuman())
 			{
 				UnicodeString newName = slot->getName();
 				UnicodeString oldName = GadgetComboBoxGetText(comboPlayer[i]);

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameInfo.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameInfo.cpp
@@ -454,6 +454,7 @@ GameSlot* GameInfo::getSlot( Int slotNum )
 	if (slotNum < 0 || slotNum >= MAX_SLOTS)
 		return NULL;
 
+	DEBUG_ASSERTCRASH( m_slot[slotNum], ("NULL slot pointer") );
 	return m_slot[slotNum];
 }
 
@@ -463,6 +464,7 @@ const GameSlot* GameInfo::getConstSlot( Int slotNum ) const
 	if (slotNum < 0 || slotNum >= MAX_SLOTS)
 		return NULL;
 
+	DEBUG_ASSERTCRASH( m_slot[slotNum], ("NULL slot pointer") );
 	return m_slot[slotNum];
 }
 


### PR DESCRIPTION
This change removes unnecessary NULL pointer tests in UpdateSlotList() and makes the compiler happy.

The slot pointers are always initialized and not expected to be NULL ever.

```
GeneralsMD\Code\GameEngine\Source\GameNetwork\GUIUtil.cpp(458): warning C6011: Dereferencing NULL pointer 'slot'.
```