### PR TITLE
[GEN][ZH] Prevent dereferencing NULL pointer 'button' in ScriptActions::doCameoFlash()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
@@ -2551,6 +2551,7 @@ void ScriptActions::doCameoFlash(const AsciiString& name, Int timeInSeconds)
 	if( button == NULL )
 	{
 		DEBUG_CRASH(( "ScriptActions::doCameoFlash can't find AsciiString cameoflash" ));
+		return;
 	}
 
 	Int frames = LOGICFRAMES_PER_SECOND * timeInSeconds;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
@@ -2628,6 +2628,7 @@ void ScriptActions::doCameoFlash(const AsciiString& name, Int timeInSeconds)
 	if( button == NULL )
 	{
 		DEBUG_CRASH(( "ScriptActions::doCameoFlash can't find AsciiString cameoflash" ));
+		return;
 	}
 
 	Int frames = LOGICFRAMES_PER_SECOND * timeInSeconds;


### PR DESCRIPTION
This change prevents dereferencing NULL pointer 'button' in ScriptActions::doCameoFlash() and makes the compiler happy.

I think this code path could be reached by handing over a button name that does not exist. Whether this happens in the original game, I do not know. Probably does not.

```
GeneralsMD\Code\GameEngine\Source\GameLogic\ScriptEngine\ScriptActions.cpp(2640): warning C6011: Dereferencing NULL pointer 'button'.
```