### PR TITLE
[GEN][ZH] Prevent reading invalid data from 'nti', 'm_teams' in TeamsInfoRec::addTeam()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Map/SidesList.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Map/SidesList.cpp
@@ -1124,20 +1124,21 @@ void TeamsInfoRec::addTeam(const Dict* d)
 	if (m_numTeams >= m_numTeamsAllocated)
 	{
 	// pool[]ify
-		TeamsInfo* nti = NEW TeamsInfo[m_numTeamsAllocated + TEAM_ALLOC_CHUNK];	// throws on failure
+		const Int newNumTeamsAllocated = max(m_numTeams, m_numTeamsAllocated + TEAM_ALLOC_CHUNK);
+		TeamsInfo* nti = NEW TeamsInfo[newNumTeamsAllocated];	// throws on failure
 		
 		Int i;
 
 		for (i = 0; i < m_numTeams; i++)
 			nti[i] = m_teams[i];
 
-		for ( ; i < m_numTeamsAllocated + TEAM_ALLOC_CHUNK; i++) 
+		for ( ; i < newNumTeamsAllocated; i++)
 			nti[i].clear(); 
 		
 		delete [] m_teams;
 
 		m_teams = nti;
-		m_numTeamsAllocated += TEAM_ALLOC_CHUNK;
+		m_numTeamsAllocated = newNumTeamsAllocated;
 	}
 
 	m_teams[m_numTeams++].init(d);

--- a/Generals/Code/GameEngine/Source/GameLogic/Map/SidesList.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Map/SidesList.cpp
@@ -1125,7 +1125,7 @@ void TeamsInfoRec::addTeam(const Dict* d)
 	{
 		// pool[]ify
 		const Int newNumTeamsAllocated = m_numTeams + TEAM_ALLOC_CHUNK;
-		TeamsInfo* nti = NEW TeamsInfo[newNumTeamsAllocated];	// throws on failure
+		TeamsInfo* nti = NEW TeamsInfo[newNumTeamsAllocated];
 		Int i;
 
 		for (i = 0; i < m_numTeams; ++i)

--- a/Generals/Code/GameEngine/Source/GameLogic/Map/SidesList.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Map/SidesList.cpp
@@ -1124,7 +1124,7 @@ void TeamsInfoRec::addTeam(const Dict* d)
 	if (m_numTeams >= m_numTeamsAllocated)
 	{
 	// pool[]ify
-		const Int newNumTeamsAllocated = max(m_numTeams, m_numTeamsAllocated + TEAM_ALLOC_CHUNK);
+		const Int newNumTeamsAllocated = m_numTeams + TEAM_ALLOC_CHUNK;
 		TeamsInfo* nti = NEW TeamsInfo[newNumTeamsAllocated];	// throws on failure
 		
 		Int i;
@@ -1132,9 +1132,6 @@ void TeamsInfoRec::addTeam(const Dict* d)
 		for (i = 0; i < m_numTeams; i++)
 			nti[i] = m_teams[i];
 
-		for ( ; i < newNumTeamsAllocated; i++)
-			nti[i].clear(); 
-		
 		delete [] m_teams;
 
 		m_teams = nti;
@@ -1152,7 +1149,7 @@ void TeamsInfoRec::removeTeam(Int i)
 	for ( ; i < m_numTeams-1; i++)
 		m_teams[i] = m_teams[i+1];
 
-	for ( ; i < m_numTeamsAllocated; i++)
+	for ( ; i < m_numTeams; i++)
 		m_teams[i].clear();
 
 	--m_numTeams;

--- a/Generals/Code/GameEngine/Source/GameLogic/Map/SidesList.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Map/SidesList.cpp
@@ -1090,7 +1090,7 @@ void TeamsInfoRec::clear()
 { 
 	Int i;
 
-	for (i = 0; i < m_numTeamsAllocated; i++) 
+	for (i = 0; i < m_numTeams; ++i)
 		m_teams[i].clear(); 
 
 	m_numTeams = 0; 
@@ -1101,7 +1101,7 @@ void TeamsInfoRec::clear()
 
 TeamsInfo *TeamsInfoRec::findTeamInfo(AsciiString name, Int* index /*= NULL*/)
 {
-	for (int i = 0; i < m_numTeams; i++) 
+	for (int i = 0; i < m_numTeams; ++i)
 	{
 		if (m_teams[i].getDict()->getAsciiString(TheKey_teamName) == name)
 		{
@@ -1123,22 +1123,22 @@ void TeamsInfoRec::addTeam(const Dict* d)
 	DEBUG_ASSERTCRASH(m_numTeams < 1024, ("hmm, seems like an awful lot of teams..."));
 	if (m_numTeams >= m_numTeamsAllocated)
 	{
-	// pool[]ify
+		// pool[]ify
 		const Int newNumTeamsAllocated = m_numTeams + TEAM_ALLOC_CHUNK;
 		TeamsInfo* nti = NEW TeamsInfo[newNumTeamsAllocated];	// throws on failure
-		
 		Int i;
 
-		for (i = 0; i < m_numTeams; i++)
+		for (i = 0; i < m_numTeams; ++i)
 			nti[i] = m_teams[i];
 
 		delete [] m_teams;
-
 		m_teams = nti;
 		m_numTeamsAllocated = newNumTeamsAllocated;
 	}
 
-	m_teams[m_numTeams++].init(d);
+	m_teams[m_numTeams].init(d);
+
+	++m_numTeams;
 }
 
 void TeamsInfoRec::removeTeam(Int i)
@@ -1146,11 +1146,10 @@ void TeamsInfoRec::removeTeam(Int i)
 	if (i < 0 || i >= m_numTeams || m_numTeams <= 1)
 		return;
 
-	for ( ; i < m_numTeams-1; i++)
+	--m_numTeams;
+
+	for ( ; i < m_numTeams; ++i)
 		m_teams[i] = m_teams[i+1];
 
-	for ( ; i < m_numTeams; i++)
-		m_teams[i].clear();
-
-	--m_numTeams;
+	m_teams[m_numTeams].clear();
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/SidesList.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/SidesList.cpp
@@ -1134,20 +1134,21 @@ void TeamsInfoRec::addTeam(const Dict* d)
 	if (m_numTeams >= m_numTeamsAllocated)
 	{
 	// pool[]ify
-		TeamsInfo* nti = NEW TeamsInfo[m_numTeamsAllocated + TEAM_ALLOC_CHUNK];	// throws on failure
+		const Int newNumTeamsAllocated = max(m_numTeams, m_numTeamsAllocated + TEAM_ALLOC_CHUNK);
+		TeamsInfo* nti = NEW TeamsInfo[newNumTeamsAllocated];	// throws on failure
 		
 		Int i;
 
 		for (i = 0; i < m_numTeams; i++)
 			nti[i] = m_teams[i];
 
-		for ( ; i < m_numTeamsAllocated + TEAM_ALLOC_CHUNK; i++) 
+		for ( ; i < newNumTeamsAllocated; i++) 
 			nti[i].clear(); 
 		
 		delete [] m_teams;
 
 		m_teams = nti;
-		m_numTeamsAllocated += TEAM_ALLOC_CHUNK;
+		m_numTeamsAllocated = newNumTeamsAllocated;
 	}
 
 	m_teams[m_numTeams++].init(d);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/SidesList.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/SidesList.cpp
@@ -1100,7 +1100,7 @@ void TeamsInfoRec::clear()
 { 
 	Int i;
 
-	for (i = 0; i < m_numTeamsAllocated; i++) 
+	for (i = 0; i < m_numTeams; ++i) 
 		m_teams[i].clear(); 
 
 	m_numTeams = 0; 
@@ -1111,7 +1111,7 @@ void TeamsInfoRec::clear()
 
 TeamsInfo *TeamsInfoRec::findTeamInfo(AsciiString name, Int* index /*= NULL*/)
 {
-	for (int i = 0; i < m_numTeams; i++) 
+	for (int i = 0; i < m_numTeams; ++i) 
 	{
 		if (m_teams[i].getDict()->getAsciiString(TheKey_teamName) == name)
 		{
@@ -1133,22 +1133,22 @@ void TeamsInfoRec::addTeam(const Dict* d)
 	DEBUG_ASSERTCRASH(m_numTeams < 2048, ("%d teams have been allocated (so far). This seems excessive.", m_numTeams ));
 	if (m_numTeams >= m_numTeamsAllocated)
 	{
-	// pool[]ify
+		// pool[]ify
 		const Int newNumTeamsAllocated = m_numTeams + TEAM_ALLOC_CHUNK;
 		TeamsInfo* nti = NEW TeamsInfo[newNumTeamsAllocated];	// throws on failure
-		
 		Int i;
 
-		for (i = 0; i < m_numTeams; i++)
+		for (i = 0; i < m_numTeams; ++i)
 			nti[i] = m_teams[i];
 
 		delete [] m_teams;
-
 		m_teams = nti;
 		m_numTeamsAllocated = newNumTeamsAllocated;
 	}
 
-	m_teams[m_numTeams++].init(d);
+	m_teams[m_numTeams].init(d);
+
+	++m_numTeams;
 }
 
 void TeamsInfoRec::removeTeam(Int i)
@@ -1156,11 +1156,10 @@ void TeamsInfoRec::removeTeam(Int i)
 	if (i < 0 || i >= m_numTeams || m_numTeams <= 1)
 		return;
 
-	for ( ; i < m_numTeams-1; i++)
+	--m_numTeams;
+
+	for ( ; i < m_numTeams; ++i)
 		m_teams[i] = m_teams[i+1];
 
-	for ( ; i < m_numTeams; i++)
-		m_teams[i].clear();
-
-	--m_numTeams;
+	m_teams[m_numTeams].clear();
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/SidesList.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/SidesList.cpp
@@ -1134,7 +1134,7 @@ void TeamsInfoRec::addTeam(const Dict* d)
 	if (m_numTeams >= m_numTeamsAllocated)
 	{
 	// pool[]ify
-		const Int newNumTeamsAllocated = max(m_numTeams, m_numTeamsAllocated + TEAM_ALLOC_CHUNK);
+		const Int newNumTeamsAllocated = m_numTeams + TEAM_ALLOC_CHUNK;
 		TeamsInfo* nti = NEW TeamsInfo[newNumTeamsAllocated];	// throws on failure
 		
 		Int i;
@@ -1142,9 +1142,6 @@ void TeamsInfoRec::addTeam(const Dict* d)
 		for (i = 0; i < m_numTeams; i++)
 			nti[i] = m_teams[i];
 
-		for ( ; i < newNumTeamsAllocated; i++) 
-			nti[i].clear(); 
-		
 		delete [] m_teams;
 
 		m_teams = nti;
@@ -1162,7 +1159,7 @@ void TeamsInfoRec::removeTeam(Int i)
 	for ( ; i < m_numTeams-1; i++)
 		m_teams[i] = m_teams[i+1];
 
-	for ( ; i < m_numTeamsAllocated; i++)
+	for ( ; i < m_numTeams; i++)
 		m_teams[i].clear();
 
 	--m_numTeams;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/SidesList.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/SidesList.cpp
@@ -1135,7 +1135,7 @@ void TeamsInfoRec::addTeam(const Dict* d)
 	{
 		// pool[]ify
 		const Int newNumTeamsAllocated = m_numTeams + TEAM_ALLOC_CHUNK;
-		TeamsInfo* nti = NEW TeamsInfo[newNumTeamsAllocated];	// throws on failure
+		TeamsInfo* nti = NEW TeamsInfo[newNumTeamsAllocated];
 		Int i;
 
 		for (i = 0; i < m_numTeams; ++i)


### PR DESCRIPTION
This change prevents reading invalid data from 'nti', 'm_teams' in TeamsInfoRec::addTeam() to make the compiler happy.

This never is a runtime problem with the way m_teams is currently allocated in this class, but the compiler rightfully warns about this because the code would not have been safe in cases where `m_numTeams` could have been larger than `m_numTeamsAllocated + 8`.

I also simplified/optimized some other code, but it is all in the realms of refactoring and no logic changes.

```
GeneralsMD\Code\GameEngine\Source\GameLogic\Map\SidesList.cpp(1145): warning C6385: Reading invalid data from 'nti':  the readable size is '(unsigned int)*4' bytes, but '8' bytes may be read.
GeneralsMD\Code\GameEngine\Source\GameLogic\Map\SidesList.cpp(1153): warning C6385: Reading invalid data from 'm_teams':  the readable size is '(unsigned int)*4' bytes, but 'm_numTeams++' bytes may be read.
```

## TODO

- [x] Tested against Golden Replay
- [x] Tested against AI Replays