### PR TITLE
[GEN][ZH] Prevent using uninitialized memory 'hr' in W3DShaderManager::LoadAndCreateD3DShader()

### DIFF
--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DShaderManager.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DShaderManager.cpp
@@ -2773,11 +2773,11 @@ HRESULT W3DShaderManager::LoadAndCreateD3DShader(const char* strFilePath, const 
 		file->close();
 		file = NULL;
 
-		if (ShaderType == TRUE)//SHADERTYPE_VERTEX)
+		if (ShaderType) // SHADERTYPE_VERTEX
 		{
 			hr = DX8Wrapper::_Get_D3D_Device8()->CreateVertexShader(pDeclaration, pShader, pHandle, Usage);
 		}
-		else if (ShaderType == FALSE)//SHADERTYPE_PIXEL)
+		else // SHADERTYPE_PIXEL
 		{
 			hr = DX8Wrapper::_Get_D3D_Device8()->CreatePixelShader(pShader, pHandle);
 		}

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DShaderManager.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DShaderManager.cpp
@@ -3043,11 +3043,11 @@ HRESULT W3DShaderManager::LoadAndCreateD3DShader(const char* strFilePath, const 
 		file->close();
 		file = NULL;
 
-		if (ShaderType == TRUE)//SHADERTYPE_VERTEX)
+		if (ShaderType) // SHADERTYPE_VERTEX
 		{
 			hr = DX8Wrapper::_Get_D3D_Device8()->CreateVertexShader(pDeclaration, pShader, pHandle, Usage);
 		}
-		else if (ShaderType == FALSE)//SHADERTYPE_PIXEL)
+		else // SHADERTYPE_PIXEL
 		{
 			hr = DX8Wrapper::_Get_D3D_Device8()->CreatePixelShader(pShader, pHandle);
 		}


### PR DESCRIPTION
This change prevents using uninitialized memory 'hr' in W3DShaderManager::LoadAndCreateD3DShader() and makes the compiler happy.

This will not happen in practice but the compiler complained here because technically a Bool could be different from values TRUE and FALSE.

```
GeneralsMD\Code\GameEngineDevice\Source\W3DDevice\GameClient\W3DShaderManager.cpp(3057): warning C6001: Using uninitialized memory 'hr'.
```