### PR TITLE
[GEN][ZH] Prevent dereferencing NULL pointer 'pbmi' and memory leaks in CreateBMPFile()

### DIFF
--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -2792,6 +2792,8 @@ static void CreateBMPFile(LPTSTR pszFile, char *image, Int width, Int height)
     PBITMAPINFO pbmi; 
 
     pbmi = (PBITMAPINFO) LocalAlloc(LPTR,sizeof(BITMAPINFOHEADER));
+    if (pbmi == NULL)
+        return;
     pbmi->bmiHeader.biSize = sizeof(BITMAPINFOHEADER); 
     pbmi->bmiHeader.biWidth = width; 
     pbmi->bmiHeader.biHeight = height; 

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -2779,77 +2779,77 @@ void W3DDisplay::setShroudLevel( Int x, Int y, CellShroudStatus setting )
 //=============================================================================
 ///Utility function to dump data into a .BMP file
 static void CreateBMPFile(LPTSTR pszFile, char *image, Int width, Int height)
-{ 
-     HANDLE hf;                 // file handle 
-    BITMAPFILEHEADER hdr;       // bitmap file-header 
-    PBITMAPINFOHEADER pbih;     // bitmap info-header 
-    LPBYTE lpBits;              // memory pointer 
-    DWORD dwTotal;              // total count of bytes 
-    DWORD cb;                   // incremental count of bytes 
-    BYTE *hp;                   // byte pointer 
-    DWORD dwTmp; 
+{
+	HANDLE hf;                  // file handle 
+	BITMAPFILEHEADER hdr;       // bitmap file-header 
+	PBITMAPINFOHEADER pbih;     // bitmap info-header 
+	LPBYTE lpBits;              // memory pointer 
+	DWORD dwTotal;              // total count of bytes 
+	DWORD cb;                   // incremental count of bytes 
+	BYTE *hp;                   // byte pointer 
+	DWORD dwTmp;
 
-    PBITMAPINFO pbmi; 
+	PBITMAPINFO pbmi;
 
-    pbmi = (PBITMAPINFO) LocalAlloc(LPTR,sizeof(BITMAPINFOHEADER));
-    if (pbmi == NULL)
-        return;
-    pbmi->bmiHeader.biSize = sizeof(BITMAPINFOHEADER); 
-    pbmi->bmiHeader.biWidth = width; 
-    pbmi->bmiHeader.biHeight = height; 
-    pbmi->bmiHeader.biPlanes = 1; 
-    pbmi->bmiHeader.biBitCount = 24;
-    pbmi->bmiHeader.biCompression = BI_RGB;
-    pbmi->bmiHeader.biSizeImage = (pbmi->bmiHeader.biWidth + 7) /8 * pbmi->bmiHeader.biHeight * 24;
-    pbmi->bmiHeader.biClrImportant = 0; 
-
-
-    pbih = (PBITMAPINFOHEADER) pbmi; 
-    lpBits = (LPBYTE) image;
-
-    // Create the .BMP file. 
-    hf = CreateFile(pszFile, 
-                   GENERIC_READ | GENERIC_WRITE, 
-                   (DWORD) 0, 
-                    NULL, 
-                   CREATE_ALWAYS, 
-                   FILE_ATTRIBUTE_NORMAL, 
-                   (HANDLE) NULL); 
-    if (hf == INVALID_HANDLE_VALUE) 
-		return;
-    hdr.bfType = 0x4d42;        // 0x42 = "B" 0x4d = "M" 
-    // Compute the size of the entire file. 
-    hdr.bfSize = (DWORD) (sizeof(BITMAPFILEHEADER) + 
-                 pbih->biSize + pbih->biClrUsed 
-                 * sizeof(RGBQUAD) + pbih->biSizeImage); 
-    hdr.bfReserved1 = 0; 
-    hdr.bfReserved2 = 0; 
-
-    // Compute the offset to the array of color indices. 
-    hdr.bfOffBits = (DWORD) sizeof(BITMAPFILEHEADER) + 
-                    pbih->biSize + pbih->biClrUsed 
-                    * sizeof (RGBQUAD); 
-
-    // Copy the BITMAPFILEHEADER into the .BMP file. 
-    if (!WriteFile(hf, (LPVOID) &hdr, sizeof(BITMAPFILEHEADER), 
-        (LPDWORD) &dwTmp,  NULL)) 
+	pbmi = (PBITMAPINFO) LocalAlloc(LPTR,sizeof(BITMAPINFOHEADER));
+	if (pbmi == NULL)
 		return;
 
-    // Copy the BITMAPINFOHEADER and RGBQUAD array into the file. 
-    if (!WriteFile(hf, (LPVOID) pbih, sizeof(BITMAPINFOHEADER) + pbih->biClrUsed * sizeof (RGBQUAD),(LPDWORD) &dwTmp, NULL)) 
-		return;
+	pbmi->bmiHeader.biSize = sizeof(BITMAPINFOHEADER); 
+	pbmi->bmiHeader.biWidth = width; 
+	pbmi->bmiHeader.biHeight = height; 
+	pbmi->bmiHeader.biPlanes = 1; 
+	pbmi->bmiHeader.biBitCount = 24;
+	pbmi->bmiHeader.biCompression = BI_RGB;
+	pbmi->bmiHeader.biSizeImage = (pbmi->bmiHeader.biWidth + 7) /8 * pbmi->bmiHeader.biHeight * 24;
+	pbmi->bmiHeader.biClrImportant = 0; 
 
-    // Copy the array of color indices into the .BMP file. 
-    dwTotal = cb = pbih->biSizeImage; 
-    hp = lpBits; 
-    if (!WriteFile(hf, (LPSTR) hp, (int) cb, (LPDWORD) &dwTmp,NULL)) 
-		return;
+	pbih = (PBITMAPINFOHEADER) pbmi; 
+	lpBits = (LPBYTE) image;
 
-    // Close the .BMP file. 
-     if (!CloseHandle(hf))
-		 return;
+	// Create the .BMP file. 
+	hf = CreateFile(pszFile, 
+		GENERIC_READ | GENERIC_WRITE, 
+		(DWORD) 0, 
+		NULL, 
+		CREATE_ALWAYS, 
+		FILE_ATTRIBUTE_NORMAL, 
+		(HANDLE) NULL); 
 
-    // Free memory. 
+	if (hf != INVALID_HANDLE_VALUE) 
+	{
+		hdr.bfType = 0x4d42;        // 0x42 = "B" 0x4d = "M" 
+		// Compute the size of the entire file. 
+		hdr.bfSize = (DWORD) (sizeof(BITMAPFILEHEADER) + 
+									pbih->biSize + pbih->biClrUsed 
+									* sizeof(RGBQUAD) + pbih->biSizeImage); 
+		hdr.bfReserved1 = 0; 
+		hdr.bfReserved2 = 0; 
+
+		// Compute the offset to the array of color indices. 
+		hdr.bfOffBits = (DWORD) sizeof(BITMAPFILEHEADER) + 
+										pbih->biSize + pbih->biClrUsed 
+										* sizeof (RGBQUAD); 
+
+		// Copy the BITMAPFILEHEADER into the .BMP file. 
+		if (WriteFile(hf, (LPVOID) &hdr, sizeof(BITMAPFILEHEADER), 
+				(LPDWORD) &dwTmp,  NULL))
+		{
+			// Copy the BITMAPINFOHEADER and RGBQUAD array into the file. 
+			if (WriteFile(hf, (LPVOID) pbih, sizeof(BITMAPINFOHEADER) + pbih->biClrUsed * sizeof (RGBQUAD),(LPDWORD) &dwTmp, NULL)) 
+			{
+				// Copy the array of color indices into the .BMP file. 
+				dwTotal = cb = pbih->biSizeImage; 
+				hp = lpBits; 
+				WriteFile(hf, (LPSTR) hp, (int) cb, (LPDWORD) &dwTmp, NULL);
+			}
+		}
+
+		// Close the .BMP file. 
+		CloseHandle(hf);
+	}
+
+	// Free memory.
 	LocalFree( (HLOCAL) pbmi);
 }
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -2919,77 +2919,77 @@ void W3DDisplay::setShroudLevel( Int x, Int y, CellShroudStatus setting )
 //=============================================================================
 ///Utility function to dump data into a .BMP file
 static void CreateBMPFile(LPTSTR pszFile, char *image, Int width, Int height)
-{ 
-     HANDLE hf;                 // file handle 
-    BITMAPFILEHEADER hdr;       // bitmap file-header 
-    PBITMAPINFOHEADER pbih;     // bitmap info-header 
-    LPBYTE lpBits;              // memory pointer 
-    DWORD dwTotal;              // total count of bytes 
-    DWORD cb;                   // incremental count of bytes 
-    BYTE *hp;                   // byte pointer 
-    DWORD dwTmp; 
+{
+	HANDLE hf;                  // file handle 
+	BITMAPFILEHEADER hdr;       // bitmap file-header 
+	PBITMAPINFOHEADER pbih;     // bitmap info-header 
+	LPBYTE lpBits;              // memory pointer 
+	DWORD dwTotal;              // total count of bytes 
+	DWORD cb;                   // incremental count of bytes 
+	BYTE *hp;                   // byte pointer 
+	DWORD dwTmp;
 
-    PBITMAPINFO pbmi; 
+	PBITMAPINFO pbmi;
 
-    pbmi = (PBITMAPINFO) LocalAlloc(LPTR,sizeof(BITMAPINFOHEADER));
-    if (pbmi == NULL)
-        return;
-    pbmi->bmiHeader.biSize = sizeof(BITMAPINFOHEADER); 
-    pbmi->bmiHeader.biWidth = width; 
-    pbmi->bmiHeader.biHeight = height; 
-    pbmi->bmiHeader.biPlanes = 1; 
-    pbmi->bmiHeader.biBitCount = 24;
-    pbmi->bmiHeader.biCompression = BI_RGB;
-    pbmi->bmiHeader.biSizeImage = (pbmi->bmiHeader.biWidth + 7) /8 * pbmi->bmiHeader.biHeight * 24;
-    pbmi->bmiHeader.biClrImportant = 0; 
-
-
-    pbih = (PBITMAPINFOHEADER) pbmi; 
-    lpBits = (LPBYTE) image;
-
-    // Create the .BMP file. 
-    hf = CreateFile(pszFile, 
-                   GENERIC_READ | GENERIC_WRITE, 
-                   (DWORD) 0, 
-                    NULL, 
-                   CREATE_ALWAYS, 
-                   FILE_ATTRIBUTE_NORMAL, 
-                   (HANDLE) NULL); 
-    if (hf == INVALID_HANDLE_VALUE) 
-		return;
-    hdr.bfType = 0x4d42;        // 0x42 = "B" 0x4d = "M" 
-    // Compute the size of the entire file. 
-    hdr.bfSize = (DWORD) (sizeof(BITMAPFILEHEADER) + 
-                 pbih->biSize + pbih->biClrUsed 
-                 * sizeof(RGBQUAD) + pbih->biSizeImage); 
-    hdr.bfReserved1 = 0; 
-    hdr.bfReserved2 = 0; 
-
-    // Compute the offset to the array of color indices. 
-    hdr.bfOffBits = (DWORD) sizeof(BITMAPFILEHEADER) + 
-                    pbih->biSize + pbih->biClrUsed 
-                    * sizeof (RGBQUAD); 
-
-    // Copy the BITMAPFILEHEADER into the .BMP file. 
-    if (!WriteFile(hf, (LPVOID) &hdr, sizeof(BITMAPFILEHEADER), 
-        (LPDWORD) &dwTmp,  NULL)) 
+	pbmi = (PBITMAPINFO) LocalAlloc(LPTR,sizeof(BITMAPINFOHEADER));
+	if (pbmi == NULL)
 		return;
 
-    // Copy the BITMAPINFOHEADER and RGBQUAD array into the file. 
-    if (!WriteFile(hf, (LPVOID) pbih, sizeof(BITMAPINFOHEADER) + pbih->biClrUsed * sizeof (RGBQUAD),(LPDWORD) &dwTmp, NULL)) 
-		return;
+	pbmi->bmiHeader.biSize = sizeof(BITMAPINFOHEADER); 
+	pbmi->bmiHeader.biWidth = width; 
+	pbmi->bmiHeader.biHeight = height; 
+	pbmi->bmiHeader.biPlanes = 1; 
+	pbmi->bmiHeader.biBitCount = 24;
+	pbmi->bmiHeader.biCompression = BI_RGB;
+	pbmi->bmiHeader.biSizeImage = (pbmi->bmiHeader.biWidth + 7) /8 * pbmi->bmiHeader.biHeight * 24;
+	pbmi->bmiHeader.biClrImportant = 0; 
 
-    // Copy the array of color indices into the .BMP file. 
-    dwTotal = cb = pbih->biSizeImage; 
-    hp = lpBits; 
-    if (!WriteFile(hf, (LPSTR) hp, (int) cb, (LPDWORD) &dwTmp,NULL)) 
-		return;
+	pbih = (PBITMAPINFOHEADER) pbmi; 
+	lpBits = (LPBYTE) image;
 
-    // Close the .BMP file. 
-     if (!CloseHandle(hf))
-		 return;
+	// Create the .BMP file. 
+	hf = CreateFile(pszFile, 
+		GENERIC_READ | GENERIC_WRITE, 
+		(DWORD) 0, 
+		NULL, 
+		CREATE_ALWAYS, 
+		FILE_ATTRIBUTE_NORMAL, 
+		(HANDLE) NULL); 
 
-    // Free memory. 
+	if (hf != INVALID_HANDLE_VALUE) 
+	{
+		hdr.bfType = 0x4d42;        // 0x42 = "B" 0x4d = "M" 
+		// Compute the size of the entire file. 
+		hdr.bfSize = (DWORD) (sizeof(BITMAPFILEHEADER) + 
+									pbih->biSize + pbih->biClrUsed 
+									* sizeof(RGBQUAD) + pbih->biSizeImage); 
+		hdr.bfReserved1 = 0; 
+		hdr.bfReserved2 = 0; 
+
+		// Compute the offset to the array of color indices. 
+		hdr.bfOffBits = (DWORD) sizeof(BITMAPFILEHEADER) + 
+										pbih->biSize + pbih->biClrUsed 
+										* sizeof (RGBQUAD); 
+
+		// Copy the BITMAPFILEHEADER into the .BMP file. 
+		if (WriteFile(hf, (LPVOID) &hdr, sizeof(BITMAPFILEHEADER), 
+				(LPDWORD) &dwTmp,  NULL))
+		{
+			// Copy the BITMAPINFOHEADER and RGBQUAD array into the file. 
+			if (WriteFile(hf, (LPVOID) pbih, sizeof(BITMAPINFOHEADER) + pbih->biClrUsed * sizeof (RGBQUAD),(LPDWORD) &dwTmp, NULL)) 
+			{
+				// Copy the array of color indices into the .BMP file. 
+				dwTotal = cb = pbih->biSizeImage; 
+				hp = lpBits; 
+				WriteFile(hf, (LPSTR) hp, (int) cb, (LPDWORD) &dwTmp, NULL);
+			}
+		}
+
+		// Close the .BMP file. 
+		CloseHandle(hf);
+	}
+
+	// Free memory.
 	LocalFree( (HLOCAL) pbmi);
 }
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -2932,6 +2932,8 @@ static void CreateBMPFile(LPTSTR pszFile, char *image, Int width, Int height)
     PBITMAPINFO pbmi; 
 
     pbmi = (PBITMAPINFO) LocalAlloc(LPTR,sizeof(BITMAPINFOHEADER));
+    if (pbmi == NULL)
+        return;
     pbmi->bmiHeader.biSize = sizeof(BITMAPINFOHEADER); 
     pbmi->bmiHeader.biWidth = width; 
     pbmi->bmiHeader.biHeight = height; 


### PR DESCRIPTION
This change prevents dereferencing NULL pointer 'pbmi' in CreateBMPFile() and makes the compiler happy.

This is no practical issue.

```
GeneralsMD\Code\GameEngineDevice\Source\W3DDevice\GameClient\W3DDisplay.cpp(2913): warning C28182: Dereferencing NULL pointer. 'pbmi' contains the same NULL value as 'LocalAlloc()`2912' did.
GeneralsMD\Code\GameEngineDevice\Source\W3DDevice\GameClient\W3DDisplay.cpp(2938): warning C28182: Dereferencing NULL pointer. 'pbih' contains the same NULL value as 'LocalAlloc()`2912' did. See line 2913 for an earlier location where this can occur
```