### PR TITLE
[GEN][ZH] Add missing break keywords between switch labels in W3DProjectedShadow, W3DDisplay, W3DWater

### DIFF
--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DProjectedShadow.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DProjectedShadow.cpp
@@ -1575,6 +1575,7 @@ Shadow* W3DProjectedShadowManager::addDecal(Shadow::ShadowTypeInfo *shadowInfo)
 			break;
 		case SHADOW_PROJECTION:
 			m_numProjectionShadows++;
+			break;
 		default:
 			break;
 	}
@@ -1711,6 +1712,7 @@ Shadow* W3DProjectedShadowManager::addDecal(RenderObjClass *robj, Shadow::Shadow
 			break;
 		case SHADOW_PROJECTION:
 			m_numProjectionShadows++;
+			break;
 		default:
 			break;
 	}
@@ -1907,6 +1909,7 @@ W3DProjectedShadow* W3DProjectedShadowManager::addShadow(RenderObjClass *robj, S
 			break;
 		case SHADOW_PROJECTION:
 			m_numProjectionShadows++;
+			break;
 		default:
 			break;
 	}
@@ -2037,6 +2040,7 @@ void W3DProjectedShadowManager::removeShadow (W3DProjectedShadow *shadow)
 						break;
 					case SHADOW_PROJECTION:
 						m_numProjectionShadows--;
+						break;
 					default:
 						break;
 				}
@@ -2062,6 +2066,7 @@ void W3DProjectedShadowManager::removeShadow (W3DProjectedShadow *shadow)
 					break;
 				case SHADOW_PROJECTION:
 					m_numProjectionShadows--;
+					break;
 				default:
 					break;
 			}

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -2525,6 +2525,7 @@ void W3DDisplay::drawImage( const Image *image, Int startX, Int startY,
 			m_2DRender->Enable_Additive(false);
 			m_2DRender->Enable_Alpha(false);
 			doAlphaReset = TRUE;
+			break;
 		default:
 			break;
 	}

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
@@ -1695,6 +1695,7 @@ void WaterRenderObjClass::Render(RenderInfoClass & rinfo)
 
 				renderWater();
 			}	//WATER_TYPE_1
+			break;
 
 		default:
 			break;

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DProjectedShadow.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DProjectedShadow.cpp
@@ -1575,6 +1575,7 @@ Shadow* W3DProjectedShadowManager::addDecal(Shadow::ShadowTypeInfo *shadowInfo)
 			break;
 		case SHADOW_PROJECTION:
 			m_numProjectionShadows++;
+			break;
 		default:
 			break;
 	}
@@ -1711,6 +1712,7 @@ Shadow* W3DProjectedShadowManager::addDecal(RenderObjClass *robj, Shadow::Shadow
 			break;
 		case SHADOW_PROJECTION:
 			m_numProjectionShadows++;
+			break;
 		default:
 			break;
 	}
@@ -1907,6 +1909,7 @@ W3DProjectedShadow* W3DProjectedShadowManager::addShadow(RenderObjClass *robj, S
 			break;
 		case SHADOW_PROJECTION:
 			m_numProjectionShadows++;
+			break;
 		default:
 			break;
 	}
@@ -2037,6 +2040,7 @@ void W3DProjectedShadowManager::removeShadow (W3DProjectedShadow *shadow)
 						break;
 					case SHADOW_PROJECTION:
 						m_numProjectionShadows--;
+						break;
 					default:
 						break;
 				}
@@ -2062,6 +2066,7 @@ void W3DProjectedShadowManager::removeShadow (W3DProjectedShadow *shadow)
 					break;
 				case SHADOW_PROJECTION:
 					m_numProjectionShadows--;
+					break;
 				default:
 					break;
 			}

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -2662,6 +2662,7 @@ void W3DDisplay::drawImage( const Image *image, Int startX, Int startY,
 			m_2DRender->Enable_Additive(false);
 			m_2DRender->Enable_Alpha(false);
 			doAlphaReset = TRUE;
+			break;
 		default:
 			break;
 	}

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
@@ -1718,6 +1718,7 @@ void WaterRenderObjClass::Render(RenderInfoClass & rinfo)
 
 				renderWater();
 			}	//WATER_TYPE_1
+			break;
 
 		default:
 			break;


### PR DESCRIPTION
This change just adds missing break keywords between switch labels in W3DProjectedShadow, W3DDisplay, W3DWater to make the compiler happy.

There is no functional change at all.
