### PR TITLE
[GEN][ZH] Fix dereferencing NULL pointer 'CBScheme->m_buttonQueueImage' in ControlBarSchemeManager::preloadAssets()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarScheme.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarScheme.cpp
@@ -991,7 +991,7 @@ void ControlBarSchemeManager::preloadAssets( TimeOfDay timeOfDay )
 
 		if (CBScheme->m_rightHUDImage)
 		{
-			TheDisplay->preloadTextureAssets(CBScheme->m_buttonQueueImage->getFilename());
+			TheDisplay->preloadTextureAssets(CBScheme->m_rightHUDImage->getFilename());
 		}
 
 		for (Int layer = 0; layer < MAX_CONTROL_BAR_SCHEME_IMAGE_LAYERS; ++layer)

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarScheme.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarScheme.cpp
@@ -1004,7 +1004,7 @@ void ControlBarSchemeManager::preloadAssets( TimeOfDay timeOfDay )
 
 		if (CBScheme->m_rightHUDImage)
 		{
-			TheDisplay->preloadTextureAssets(CBScheme->m_buttonQueueImage->getFilename());
+			TheDisplay->preloadTextureAssets(CBScheme->m_rightHUDImage->getFilename());
 		}
 
 		for (Int layer = 0; layer < MAX_CONTROL_BAR_SCHEME_IMAGE_LAYERS; ++layer)


### PR DESCRIPTION
This change fixes dereferencing NULL pointer 'CBScheme->m_buttonQueueImage' in ControlBarSchemeManager::preloadAssets().

```
GeneralsMD\Code\GameEngine\Source\GameClient\GUI\ControlBar\ControlBarScheme.cpp(1007): warning C6011: Dereferencing NULL pointer 'CBScheme->m_buttonQueueImage'.
```