### PR TITLE
[GEN][ZH] Fix using uninitialized memory 'window' in createGadget()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GameWindowManagerScript.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GameWindowManagerScript.cpp
@@ -1621,7 +1621,7 @@ static GameWindow *createGadget( char *type,
 																 WinInstanceData *instData, 
 																 void *data )
 {
-  GameWindow *window;
+  GameWindow *window = NULL;
 
   instData->m_owner = parent;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowManagerScript.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowManagerScript.cpp
@@ -1629,7 +1629,7 @@ static GameWindow *createGadget( char *type,
 																 WinInstanceData *instData, 
 																 void *data )
 {
-  GameWindow *window;
+  GameWindow *window = NULL;
 
   instData->m_owner = parent;
 


### PR DESCRIPTION
This change fixes using uninitialized memory 'window' in GameWindowManagerScript's createGadget() and makes the compiler happy.

Basically this function would return an uninitialized pointer if the gadget type was not recognized. I put a breakpoint and visited a few menus and was unable to hit this. It probably is no concern for the game runtime.

```
GeneralsMD\Code\GameEngine\Source\GameClient\GUI\GameWindowManagerScript.cpp(2019): warning C6001: Using uninitialized memory 'window'.
```