### PR TITLE
[GEN][ZH] Downgrade debug assertion to log for isPathInDirectory

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/System/FileSystem.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/FileSystem.cpp
@@ -367,7 +367,6 @@ Bool FileSystem::isPathInDirectory(const AsciiString& testPath, const AsciiStrin
 	if (!testPathNormalized.startsWith(basePathNormalized))
 #endif
 	{
-		DEBUG_LOG(("Normalized file path for '%s': '%s' was outside the expected base path of '%s' (normalized: '%s').\n", testPath.str(), testPathNormalized.str(), basePath.str(), basePathNormalized.str()));
 		return false;
 	}
 

--- a/Generals/Code/GameEngine/Source/Common/System/FileSystem.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/FileSystem.cpp
@@ -367,7 +367,7 @@ Bool FileSystem::isPathInDirectory(const AsciiString& testPath, const AsciiStrin
 	if (!testPathNormalized.startsWith(basePathNormalized))
 #endif
 	{
-		DEBUG_CRASH(("Normalized file path for '%s': '%s' was outside the expected base path of '%s' (normalized: '%s').\n", testPath.str(), testPathNormalized.str(), basePath.str(), basePathNormalized.str()));
+		DEBUG_LOG(("Normalized file path for '%s': '%s' was outside the expected base path of '%s' (normalized: '%s').\n", testPath.str(), testPathNormalized.str(), basePath.str(), basePathNormalized.str()));
 		return false;
 	}
 

--- a/Generals/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
@@ -936,6 +936,7 @@ AsciiString GameState::portableMapPathToRealMapPath(const AsciiString& in) const
 
 	if (!FileSystem::isPathInDirectory(prefix, containingBasePath))
 	{
+		DEBUG_LOG(("Normalized file path for '%s' was outside the expected base path of '%s'.\n", prefix.str(), containingBasePath.str()));
 		return AsciiString::TheEmptyString;
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/FileSystem.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/FileSystem.cpp
@@ -384,7 +384,6 @@ Bool FileSystem::isPathInDirectory(const AsciiString& testPath, const AsciiStrin
 	if (!testPathNormalized.startsWith(basePathNormalized))
 #endif
 	{
-		DEBUG_LOG(("Normalized file path for '%s': '%s' was outside the expected base path of '%s' (normalized: '%s').\n", testPath.str(), testPathNormalized.str(), basePath.str(), basePathNormalized.str()));
 		return false;
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/FileSystem.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/FileSystem.cpp
@@ -384,7 +384,7 @@ Bool FileSystem::isPathInDirectory(const AsciiString& testPath, const AsciiStrin
 	if (!testPathNormalized.startsWith(basePathNormalized))
 #endif
 	{
-		DEBUG_CRASH(("Normalized file path for '%s': '%s' was outside the expected base path of '%s' (normalized: '%s').\n", testPath.str(), testPathNormalized.str(), basePath.str(), basePathNormalized.str()));
+		DEBUG_LOG(("Normalized file path for '%s': '%s' was outside the expected base path of '%s' (normalized: '%s').\n", testPath.str(), testPathNormalized.str(), basePath.str(), basePathNormalized.str()));
 		return false;
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
@@ -936,6 +936,7 @@ AsciiString GameState::portableMapPathToRealMapPath(const AsciiString& in) const
 
 	if (!FileSystem::isPathInDirectory(prefix, containingBasePath))
 	{
+		DEBUG_LOG(("Normalized file path for '%s' was outside the expected base path of '%s'.\n", prefix.str(), containingBasePath.str()));
 		return AsciiString::TheEmptyString;
 	}
 


### PR DESCRIPTION
* Follow up for #1058

#1058 added a new check for testing if a file is under a specific base path. In case it was not, a DEBUG_CRASH was triggered, before returning false.
This leads to an assert when starting the shell map, as the code in `GameLogic::startNewGame` explicitly sanity checks that the map is not in the save directory.
This type of sanity checking should not cause assertion failures or debug logging, so it's better to move the responsibility for reacting to those cases to the caller. This change removes the DEBUG_CRASH from `FileSystem::isPathInDirectory`, downgrades is to a DEBUG_LOG and places it in `GameState::portableMapPathToRealMapPath`.