### PR TITLE
[GEN][ZH] Prevent using uninitialized memory 'locked_rects' in TextureLoader::Load_Thumbnail()

### DIFF
--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/textureloader.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/textureloader.cpp
@@ -199,7 +199,7 @@ IDirect3DTexture8* TextureLoader::Load_Thumbnail(const StringClass& filename,WW3
 		MIP_LEVELS_ALL);
 
 	unsigned level=0;
-	D3DLOCKED_RECT locked_rects[12];
+	D3DLOCKED_RECT locked_rects[12]={0};
 	WWASSERT(d3d_texture->GetLevelCount()<=12);
 
 	// Lock all surfaces

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/textureloader.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/textureloader.cpp
@@ -452,7 +452,7 @@ IDirect3DTexture8* TextureLoader::Load_Thumbnail(const StringClass& filename, co
 #endif
 
 	unsigned level=0;
-	D3DLOCKED_RECT locked_rects[12];
+	D3DLOCKED_RECT locked_rects[12]={0};
 	WWASSERT(sysmem_texture->GetLevelCount()<=12);
 
 	// Lock all surfaces


### PR DESCRIPTION
This change prevents using uninitialized memory 'locked_rects' in TextureLoader::Load_Thumbnail().

```
GeneralsMD\Code\Libraries\Source\WWVegas\WW3D2\textureloader.cpp(485): warning C6001: Using uninitialized memory 'locked_rects'.
```