### PR TITLE
[GEN][ZH] Do not acquire money transaction audio if the play sound parameter is false

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/RTS/Money.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/Money.cpp
@@ -59,13 +59,14 @@ UnsignedInt Money::withdraw(UnsignedInt amountToWithdraw, Bool playSound)
 	if (amountToWithdraw == 0)
 		return amountToWithdraw;
 
-	//@todo: Do we do this frequently enough that it is a performance hit?
-	AudioEventRTS event = TheAudio->getMiscAudio()->m_moneyWithdrawSound;
-	event.setPlayerIndex(m_playerIndex);
-
 	// Play a sound
 	if (playSound)
+	{
+		//@todo: Do we do this frequently enough that it is a performance hit?
+		AudioEventRTS event = TheAudio->getMiscAudio()->m_moneyWithdrawSound;
+		event.setPlayerIndex(m_playerIndex);
 		TheAudio->addAudioEvent(&event);
+	}
 
 	m_money -= amountToWithdraw;
 
@@ -78,13 +79,14 @@ void Money::deposit(UnsignedInt amountToDeposit, Bool playSound)
 	if (amountToDeposit == 0)
 		return;
 
-	//@todo: Do we do this frequently enough that it is a performance hit?
-	AudioEventRTS event = TheAudio->getMiscAudio()->m_moneyDepositSound;
-	event.setPlayerIndex(m_playerIndex);
-
 	// Play a sound
 	if (playSound)
+	{
+		//@todo: Do we do this frequently enough that it is a performance hit?
+		AudioEventRTS event = TheAudio->getMiscAudio()->m_moneyDepositSound;
+		event.setPlayerIndex(m_playerIndex);
 		TheAudio->addAudioEvent(&event);
+	}
 	
 	m_money += amountToDeposit;
 }

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Money.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Money.cpp
@@ -60,13 +60,14 @@ UnsignedInt Money::withdraw(UnsignedInt amountToWithdraw, Bool playSound)
 	if (amountToWithdraw == 0)
 		return amountToWithdraw;
 
-	//@todo: Do we do this frequently enough that it is a performance hit?
-	AudioEventRTS event = TheAudio->getMiscAudio()->m_moneyWithdrawSound;
-	event.setPlayerIndex(m_playerIndex);
-
 	// Play a sound
 	if (playSound)
+	{
+		//@todo: Do we do this frequently enough that it is a performance hit?
+		AudioEventRTS event = TheAudio->getMiscAudio()->m_moneyWithdrawSound;
+		event.setPlayerIndex(m_playerIndex);
 		TheAudio->addAudioEvent(&event);
+	}
 
 	m_money -= amountToWithdraw;
 
@@ -79,13 +80,14 @@ void Money::deposit(UnsignedInt amountToDeposit, Bool playSound)
 	if (amountToDeposit == 0)
 		return;
 
-	//@todo: Do we do this frequently enough that it is a performance hit?
-	AudioEventRTS event = TheAudio->getMiscAudio()->m_moneyDepositSound;
-	event.setPlayerIndex(m_playerIndex);
-
 	// Play a sound
 	if (playSound)
+	{
+		//@todo: Do we do this frequently enough that it is a performance hit?
+		AudioEventRTS event = TheAudio->getMiscAudio()->m_moneyDepositSound;
+		event.setPlayerIndex(m_playerIndex);
 		TheAudio->addAudioEvent(&event);
+	}
 	
 	m_money += amountToDeposit;
 


### PR DESCRIPTION
Money withdraw and deposit audio is no longer accessed if it ends up unused due to `playSound` being false. Not a massive performance implication. The code reads somewhat cleaner.