### PR TITLE
[GEN][ZH] Prevent using uninitialized memory 'delta' in Dict::ensureUnique()

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/Dict.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Dict.cpp
@@ -182,7 +182,7 @@ Dict::DictPair *Dict::ensureUnique(int numPairsNeeded, Bool preserveData, DictPa
 		}
 	}
 
-	Int delta;
+	Int delta = 0;
 	if (pairToTranslate && m_data)
 		delta = pairToTranslate - m_data->peek();
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/Dict.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Dict.cpp
@@ -182,7 +182,7 @@ Dict::DictPair *Dict::ensureUnique(int numPairsNeeded, Bool preserveData, DictPa
 		}
 	}
 
-	Int delta;
+	Int delta = 0;
 	if (pairToTranslate && m_data)
 		delta = pairToTranslate - m_data->peek();
 


### PR DESCRIPTION
This change prevents using uninitialized memory 'delta' in Dict::ensureUnique()

```
GeneralsMD\Code\GameEngine\Source\Common\Dict.cpp(192): warning C6001: Using uninitialized memory 'delta'.
```