### PR TITLE
[GEN][ZH] Suppress compiler warning about buffer overrun while writing to 'newIndices' in PopulateLobbyPlayerListbox()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLobbyMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLobbyMenu.cpp
@@ -568,14 +568,16 @@ void PopulateLobbyPlayerListbox(void)
 		// restore selection
 		if (indicesToSelect.size())
 		{
-			std::set<Int>::const_iterator indexIt;
-			Int *newIndices = NEW Int[indicesToSelect.size()];
-			for (i=0, indexIt = indicesToSelect.begin(); indexIt != indicesToSelect.end(); ++i, ++indexIt)
+			std::set<Int>::const_iterator indexIt = indicesToSelect.begin();
+			const size_t count = indicesToSelect.size();
+			size_t index = 0;
+			Int *newIndices = NEW Int[count];
+			for (; index < count; ++index, ++indexIt)
 			{
-				newIndices[i] = *indexIt;
+				newIndices[index] = *indexIt;
 				DEBUG_LOG(("Queueing up index %d to re-select\n", *indexIt));
 			}
-			GadgetListBoxSetSelected(listboxLobbyPlayers, newIndices, indicesToSelect.size());
+			GadgetListBoxSetSelected(listboxLobbyPlayers, newIndices, count);
 			delete[] newIndices;
 		}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLobbyMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLobbyMenu.cpp
@@ -585,14 +585,16 @@ void PopulateLobbyPlayerListbox(void)
 		// restore selection
 		if (indicesToSelect.size())
 		{
-			std::set<Int>::const_iterator indexIt;
-			Int *newIndices = NEW Int[indicesToSelect.size()];
-			for (i=0, indexIt = indicesToSelect.begin(); indexIt != indicesToSelect.end(); ++i, ++indexIt)
+			std::set<Int>::const_iterator indexIt = indicesToSelect.begin();
+			const size_t count = indicesToSelect.size();
+			size_t index = 0;
+			Int *newIndices = NEW Int[count];
+			for (; index < count; ++index, ++indexIt)
 			{
-				newIndices[i] = *indexIt;
+				newIndices[index] = *indexIt;
 				DEBUG_LOG(("Queueing up index %d to re-select\n", *indexIt));
 			}
-			GadgetListBoxSetSelected(listboxLobbyPlayers, newIndices, indicesToSelect.size());
+			GadgetListBoxSetSelected(listboxLobbyPlayers, newIndices, count);
 			delete[] newIndices;
 		}
 


### PR DESCRIPTION
This change suppresses a compiler warning about buffer overrun while writing to 'newIndices' in PopulateLobbyPlayerListbox()

I do not understand or forgot why the compiler is warning about it but refactoring this code a bit will suppress this warning. Functionality wise nothing should change.

```
GeneralsMD\Code\GameEngine\Source\GameClient\GUI\GUICallbacks\Menus\WOLLobbyMenu.cpp(592): warning C6386: Buffer overrun while writing to 'newIndices':  the writable size is 'indicesToSelect.public: unsigned int __thiscall std::_Tree<class std::_Tset_traits<int,struct std::less<int>,class std::allocator<int>,0> >::size(void)const ()*4' bytes, but '8' bytes might be written.
```