### PR TITLE
[GEN][ZH] Prevent using uninitialized memory 'result' in PartitionData::calcMaxCoiForShape()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
@@ -2168,8 +2168,12 @@ Int PartitionData::calcMaxCoiForShape(GeometryType geom, Real majorRadius, Real 
 				Real diagonal = (Real)(sqrtf(majorRadius*majorRadius + minorRadius*minorRadius));
 				Int cells = ThePartitionManager->worldToCellDist(diagonal*2) + 1;
 				result = cells * cells;
+				break;
 			}
+			default:
+				return 4;
 		};
+		static_assert(GEOMETRY_NUM_TYPES == 3, "GEOMETRY_NUM_TYPES has changed");
 	}
 	if (result < 4)
 		result = 4;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
@@ -2175,8 +2175,12 @@ Int PartitionData::calcMaxCoiForShape(GeometryType geom, Real majorRadius, Real 
 				Real diagonal = (Real)(sqrtf(majorRadius*majorRadius + minorRadius*minorRadius));
 				Int cells = ThePartitionManager->worldToCellDist(diagonal*2) + 1;
 				result = cells * cells;
+				break;
 			}
+			default:
+				return 4;
 		};
+		static_assert(GEOMETRY_NUM_TYPES == 3, "GEOMETRY_NUM_TYPES has changed");
 	}
 	if (result < 4)
 		result = 4;


### PR DESCRIPTION
This change prevents using uninitialized memory 'result' in PartitionData::calcMaxCoiForShape() to make the compiler happy.

This is effectively just a refactor because this is impossible to happen because we expect passing valid enum values only. Handling default case is just courtesy.

```
GeneralsMD\Code\GameEngine\Source\GameLogic\Object\PartitionManager.cpp(2181): warning C6001: Using uninitialized memory 'result'.
```