### PR TITLE
[GEN][ZH] Prevent using uninitialized memory in PartitionData::updateCellsTouched()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
@@ -2039,7 +2039,6 @@ void PartitionData::updateCellsTouched()
 
 
 	Object *obj = getObject();
-	DEBUG_ASSERTCRASH(obj != NULL || m_ghostObject != NULL, ("must be attached to an Object here 1"));
 
 	if (obj)
 	{	
@@ -2059,6 +2058,11 @@ void PartitionData::updateCellsTouched()
 		angle = m_ghostObject->getParentAngle();
 		majorRadius = m_ghostObject->getGeometryMajorRadius();
 		minorRadius = m_ghostObject->getGeometryMinorRadius();
+	}
+	else
+	{
+		DEBUG_CRASH(("must be attached to an Object here"));
+		return;
 	}
 
 	removeAllTouchedCells();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
@@ -2043,7 +2043,6 @@ void PartitionData::updateCellsTouched()
 
 
 	Object *obj = getObject();
-	DEBUG_ASSERTCRASH(obj != NULL || m_ghostObject != NULL, ("must be attached to an Object here 1"));
 
 	if (obj)
 	{	
@@ -2063,6 +2062,11 @@ void PartitionData::updateCellsTouched()
 		angle = m_ghostObject->getParentAngle();
 		majorRadius = m_ghostObject->getGeometryMajorRadius();
 		minorRadius = m_ghostObject->getGeometryMinorRadius();
+	}
+	else
+	{
+		DEBUG_CRASH(("must be attached to an Object here"));
+		return;
 	}
 
 	removeAllTouchedCells();


### PR DESCRIPTION
This change prevents using uninitialized memory in PartitionData::updateCellsTouched() to make the compiler happy.

Effectively this changes nothing other than preventing crashing if an unexpected code path was taken. We do not expect this to happen in the game.

```
GeneralsMD\Code\GameEngine\Source\GameLogic\Object\PartitionManager.cpp(2069): warning C6001: Using uninitialized memory 'isSmall'.
GeneralsMD\Code\GameEngine\Source\GameLogic\Object\PartitionManager.cpp(2075): warning C6001: Using uninitialized memory 'geom'.
GeneralsMD\Code\GameEngine\Source\GameLogic\Object\PartitionManager.cpp(2080): warning C6001: Using uninitialized memory 'pos'.
GeneralsMD\Code\GameEngine\Source\GameLogic\Object\PartitionManager.cpp(2080): warning C6001: Using uninitialized memory 'majorRadius'.
GeneralsMD\Code\GameEngine\Source\GameLogic\Object\PartitionManager.cpp(2086): warning C6001: Using uninitialized memory 'minorRadius'.
GeneralsMD\Code\GameEngine\Source\GameLogic\Object\PartitionManager.cpp(2086): warning C6001: Using uninitialized memory 'angle'.
```