### PR TITLE
[GEN][ZH] Fix GEOMETRY_SPHERE & GEOMETRY_CYLINDER treated as GEOMETRY_BOX in PartitionData::calcMaxCoiForShape()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
@@ -2162,7 +2162,9 @@ Int PartitionData::calcMaxCoiForShape(GeometryType geom, Real majorRadius, Real 
 				// this actually allocates a few too many, but that's ok.
 				Int cells = ThePartitionManager->worldToCellDist(majorRadius*2) + 1;
 				result = cells * cells;
+#if !RETAIL_COMPATIBLE_CRC
 				break;
+#endif
 			}
 			case GEOMETRY_BOX:
 			{

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
@@ -2162,12 +2162,14 @@ Int PartitionData::calcMaxCoiForShape(GeometryType geom, Real majorRadius, Real 
 				// this actually allocates a few too many, but that's ok.
 				Int cells = ThePartitionManager->worldToCellDist(majorRadius*2) + 1;
 				result = cells * cells;
+				break;
 			}
 			case GEOMETRY_BOX:
 			{
 				Real diagonal = (Real)(sqrtf(majorRadius*majorRadius + minorRadius*minorRadius));
 				Int cells = ThePartitionManager->worldToCellDist(diagonal*2) + 1;
 				result = cells * cells;
+				break;
 			}
 		};
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
@@ -2169,12 +2169,14 @@ Int PartitionData::calcMaxCoiForShape(GeometryType geom, Real majorRadius, Real 
 				// this actually allocates a few too many, but that's ok.
 				Int cells = ThePartitionManager->worldToCellDist(majorRadius*2) + 1;
 				result = cells * cells;
+				break;
 			}
 			case GEOMETRY_BOX:
 			{
 				Real diagonal = (Real)(sqrtf(majorRadius*majorRadius + minorRadius*minorRadius));
 				Int cells = ThePartitionManager->worldToCellDist(diagonal*2) + 1;
 				result = cells * cells;
+				break;
 			}
 		};
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
@@ -2169,7 +2169,9 @@ Int PartitionData::calcMaxCoiForShape(GeometryType geom, Real majorRadius, Real 
 				// this actually allocates a few too many, but that's ok.
 				Int cells = ThePartitionManager->worldToCellDist(majorRadius*2) + 1;
 				result = cells * cells;
+#if !RETAIL_COMPATIBLE_CRC
 				break;
+#endif
 			}
 			case GEOMETRY_BOX:
 			{


### PR DESCRIPTION
This change fixes GEOMETRY_SPHERE & GEOMETRY_CYLINDER treated as GEOMETRY_BOX in PartitionData::calcMaxCoiForShape()

I do not know the implications of this change, so I put this behind the !RETAIL_COMPATIBLE_CRC macro.

I did load a map with all faction units and tested if the result would be different for the 2 cases but that breakpoint never hit. So the missing break is perhaps inconsequential in the game.

```
GeneralsMD\Code\GameEngine\Source\GameLogic\Object\PartitionManager.cpp(2173): warning C26819: Unannotated fallthrough between switch labels (es.78).
```