### PR TITLE
[GEN][ZH] Remove unnecessary NULL pointer test in SaveLoadMenuSystem()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupSaveLoad.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupSaveLoad.cpp
@@ -772,8 +772,7 @@ WindowMsgHandledType SaveLoadMenuSystem( GameWindow *window, UnsignedInt msg,
 
 					// save the game
 					AsciiString filename;
-					if( selectedGameInfo )
-						filename = selectedGameInfo->filename;
+					filename = selectedGameInfo->filename;
 					TheGameState->saveGame( filename, selectedGameInfo->saveGameInfo.description, fileType );
 
 /*

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupSaveLoad.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupSaveLoad.cpp
@@ -791,8 +791,7 @@ WindowMsgHandledType SaveLoadMenuSystem( GameWindow *window, UnsignedInt msg,
 
 					// save the game
 					AsciiString filename;
-					if( selectedGameInfo )
-						filename = selectedGameInfo->filename;
+					filename = selectedGameInfo->filename;
 					TheGameState->saveGame( filename, selectedGameInfo->saveGameInfo.description, fileType );
 
 /*


### PR DESCRIPTION
This change removes a unnecessary NULL pointer test in SaveLoadMenuSystem() and makes the compiler happy.

> GeneralsMD\Code\GameEngine\Source\GameClient\GUI\GUICallbacks\Menus\PopupSaveLoad.cpp(796): warning C6011: Dereferencing NULL pointer 'selectedGameInfo'.
