### PR TITLE
[GEN][ZH] Suppress compile warning about buffer overrun while writing to 'm_structuresToRepair' in AIPlayer::repairStructure()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -1972,7 +1972,7 @@ void AIPlayer::repairStructure(ObjectID structure)
 			return;
 		}
 	}
-	if (m_structuresInQueue==MAX_STRUCTURES_TO_REPAIR) {
+	if (m_structuresInQueue>=MAX_STRUCTURES_TO_REPAIR) {
 		DEBUG_LOG(("Structure repair queue is full, ignoring repair request. JBA\n"));
 		return;
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -2301,7 +2301,7 @@ void AIPlayer::repairStructure(ObjectID structure)
 			return;
 		}
 	}
-	if (m_structuresInQueue==MAX_STRUCTURES_TO_REPAIR) {
+	if (m_structuresInQueue>=MAX_STRUCTURES_TO_REPAIR) {
 		DEBUG_LOG(("Structure repair queue is full, ignoring repair request. JBA\n"));
 		return;
 	}


### PR DESCRIPTION
This change suppresses a compile warning about a buffer overrun while writing to 'this->m_structuresToRepair' in AIPlayer::repairStructure()

m_structuresInQueue should never become larger than MAX_STRUCTURES_TO_REPAIR in practice. But the static analyzer does not see this. So rewriting the condition helps the compiler understand.

> GeneralsMD\Code\GameEngine\Source\GameLogic\AI\AIPlayer.cpp(2308): warning C6386: Buffer overrun while writing to 'this->m_structuresToRepair':  the writable size is '8' bytes, but 'm_structuresInQueue' bytes might be written.
