### PR TITLE
[GEN][ZH] Prevent dereferencing NULL pointer 'damageSource' in TransitionDamageFX::onBodyDamageStateChange()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Damage/TransitionDamageFX.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Damage/TransitionDamageFX.cpp
@@ -363,7 +363,7 @@ void TransitionDamageFX::onBodyDamageStateChange( const DamageInfo* damageInfo,
 			}  // end if
 					
 			// do any object creation list for our new state
-			if( modData->m_OCL[ newState ][ i ].ocl )
+			if( damageSource && modData->m_OCL[ newState ][ i ].ocl )
 			{
 
 				if( lastDamageInfo == NULL || 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Damage/TransitionDamageFX.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Damage/TransitionDamageFX.cpp
@@ -366,7 +366,7 @@ void TransitionDamageFX::onBodyDamageStateChange( const DamageInfo* damageInfo,
 			}  // end if
 					
 			// do any object creation list for our new state
-			if( modData->m_OCL[ newState ][ i ].ocl )
+			if( damageSource && modData->m_OCL[ newState ][ i ].ocl )
 			{
 
 				if( lastDamageInfo == NULL || 


### PR DESCRIPTION
This change prevents dereferencing NULL pointer 'damageSource' in TransitionDamageFX::onBodyDamageStateChange() and makes the compiler happy.

In practice, `damageSource` is not NULL.

> GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Damage\TransitionDamageFX.cpp(378): warning C6011: Dereferencing NULL pointer 'damageSource'.
