### PR TITLE
[GEN][ZH] Prevent dereferencing NULL pointer 'theTemplate' in UpgradeMuxData::getUpgradeActivationMasks()

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/Thing/Module.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Thing/Module.cpp
@@ -261,9 +261,9 @@ void UpgradeMuxData::getUpgradeActivationMasks(UpgradeMaskType& activation, Upgr
 					it++)
 		{
 			const UpgradeTemplate* theTemplate = TheUpgradeCenter->findUpgrade( *it );
-			if( !theTemplate && !it->isEmpty() && !it->isNone())
+			if( !theTemplate )
 			{
-				DEBUG_CRASH(("An upgrade module references %s, which is not an Upgrade", it->str()));
+				DEBUG_CRASH(("An upgrade module references '%s', which is not an Upgrade", it->str()));
 				throw INI_INVALID_DATA;
 			}
 
@@ -275,11 +275,12 @@ void UpgradeMuxData::getUpgradeActivationMasks(UpgradeMaskType& activation, Upgr
 					it++)
 		{
 			const UpgradeTemplate* theTemplate = TheUpgradeCenter->findUpgrade( *it );
-			if( !theTemplate && !it->isEmpty() && !it->isNone())
+			if( !theTemplate )
 			{
-				DEBUG_CRASH(("An upgrade module references %s, which is not an Upgrade", it->str()));
+				DEBUG_CRASH(("An upgrade module references '%s', which is not an Upgrade", it->str()));
 				throw INI_INVALID_DATA;
 			}
+
 			m_conflictingMask.set( theTemplate->getUpgradeMask() );
 		}
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/Thing/Module.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Thing/Module.cpp
@@ -259,7 +259,7 @@ void UpgradeMuxData::muxDataProcessUpgradeRemoval(Object* obj) const
 			const UpgradeTemplate* theTemplate = TheUpgradeCenter->findUpgrade( *it );
 			if( !theTemplate )
 			{
-				DEBUG_CRASH(("An upgrade module references %s, which is not an Upgrade", it->str()));
+				DEBUG_CRASH(("An upgrade module references '%s', which is not an Upgrade", it->str()));
 				throw INI_INVALID_DATA;
 			}
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/Thing/Module.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Thing/Module.cpp
@@ -257,7 +257,7 @@ void UpgradeMuxData::muxDataProcessUpgradeRemoval(Object* obj) const
 					it++)
 		{
 			const UpgradeTemplate* theTemplate = TheUpgradeCenter->findUpgrade( *it );
-			if( !theTemplate && !it->isEmpty() && !it->isNone())
+			if( !theTemplate )
 			{
 				DEBUG_CRASH(("An upgrade module references %s, which is not an Upgrade", it->str()));
 				throw INI_INVALID_DATA;

--- a/GeneralsMD/Code/GameEngine/Source/Common/Thing/Module.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Thing/Module.cpp
@@ -299,9 +299,9 @@ void UpgradeMuxData::getUpgradeActivationMasks(UpgradeMaskType& activation, Upgr
 					it++)
 		{
 			const UpgradeTemplate* theTemplate = TheUpgradeCenter->findUpgrade( *it );
-			if( !theTemplate && !it->isEmpty() && !it->isNone())
+			if( !theTemplate )
 			{
-				DEBUG_CRASH(("An upgrade module references %s, which is not an Upgrade", it->str()));
+				DEBUG_CRASH(("An upgrade module references '%s', which is not an Upgrade", it->str()));
 				throw INI_INVALID_DATA;
 			}
 
@@ -313,11 +313,12 @@ void UpgradeMuxData::getUpgradeActivationMasks(UpgradeMaskType& activation, Upgr
 					it++)
 		{
 			const UpgradeTemplate* theTemplate = TheUpgradeCenter->findUpgrade( *it );
-			if( !theTemplate && !it->isEmpty() && !it->isNone())
+			if( !theTemplate )
 			{
-				DEBUG_CRASH(("An upgrade module references %s, which is not an Upgrade", it->str()));
+				DEBUG_CRASH(("An upgrade module references '%s', which is not an Upgrade", it->str()));
 				throw INI_INVALID_DATA;
 			}
+
 			m_conflictingMask.set( theTemplate->getUpgradeMask() );
 		}
 


### PR DESCRIPTION
This change prevents dereferencing NULL pointer 'theTemplate' in UpgradeMuxData::getUpgradeActivationMasks() and makes the compiler happy.

> GeneralsMD\Code\GameEngine\Source\Common\Thing\Module.cpp(321): warning C6011: Dereferencing NULL pointer 'theTemplate'.

It looks like this code could crash the game when specifying a bad string in the CommandButton.ini
```
CommandButton Command_UpgradeChinaFanaticism
  Upgrade       = Upgrade_Fanaticism // Make this empty or NONE
...
```

The crash probably makes no difference to the user facing outcome, because it would do `throw INI_INVALID_DATA` anyway.