### PR TITLE
[GEN][ZH] Prevent dereferencing NULL pointer 'drawable' in BoneFXUpdate::resolveBoneLocations()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/BoneFXUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/BoneFXUpdate.cpp
@@ -508,9 +508,6 @@ void BoneFXUpdate::resolveBoneLocations() {
 	Drawable *drawable = building->getDrawable();
 	if (drawable == NULL) {
 		DEBUG_ASSERTCRASH(drawable != NULL, ("There is no drawable?"));
-	}
-
-	if (d == NULL) {
 		return;
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/BoneFXUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/BoneFXUpdate.cpp
@@ -511,9 +511,6 @@ void BoneFXUpdate::resolveBoneLocations() {
 	Drawable *drawable = building->getDrawable();
 	if (drawable == NULL) {
 		DEBUG_ASSERTCRASH(drawable != NULL, ("There is no drawable?"));
-	}
-
-	if (d == NULL) {
 		return;
 	}
 


### PR DESCRIPTION
This change prevents dereferencing NULL pointer 'drawable' in BoneFXUpdate::resolveBoneLocations()

I do not know if this would have ever crashed the game. Probably not.

I removed the NULL check for Module Data because that is unnecessary. Other functions in this class also do not test it.

> GeneralsMD\Code\GameEngine\Source\GameLogic\Object\Update\BoneFXUpdate.cpp(536): warning C6011: Dereferencing NULL pointer 'drawable'.