### PR TITLE
[GEN][ZH] Prevent dereferencing NULL pointer 'font' in W3DFontLibrary::releaseFontData()

### DIFF
--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/W3DGameFont.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/W3DGameFont.cpp
@@ -137,10 +137,11 @@ void W3DFontLibrary::releaseFontData( GameFont *font )
 		if(((FontCharsClass *)(font->fontData))->AlternateUnicodeFont)
 			((FontCharsClass *)(font->fontData))->AlternateUnicodeFont->Release_Ref();
 		((FontCharsClass *)(font->fontData))->Release_Ref();
+
+		font->fontData = NULL;
 	}
-	font->fontData = NULL;
-	
-}  // end releaseFont
+
+}  // end releaseFontData
 
 // PUBLIC FUNCTIONS ///////////////////////////////////////////////////////////
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/W3DGameFont.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/W3DGameFont.cpp
@@ -137,10 +137,11 @@ void W3DFontLibrary::releaseFontData( GameFont *font )
 		if(((FontCharsClass *)(font->fontData))->AlternateUnicodeFont)
 			((FontCharsClass *)(font->fontData))->AlternateUnicodeFont->Release_Ref();
 		((FontCharsClass *)(font->fontData))->Release_Ref();
+
+		font->fontData = NULL;
 	}
-	font->fontData = NULL;
-	
-}  // end releaseFont
+
+}  // end releaseFontData
 
 // PUBLIC FUNCTIONS ///////////////////////////////////////////////////////////
 


### PR DESCRIPTION
This change prevents dereferencing NULL pointer 'font' in W3DFontLibrary::releaseFontData() and makes the compiler happy.

It looks like this function is never called with a NULL font, so no user facing problem.

> GeneralsMD\Code\GameEngineDevice\Source\W3DDevice\GameClient\GUI\W3DGameFont.cpp(141): warning C6011: Dereferencing NULL pointer 'font'.