### PR TITLE
[CORE] Prevent using uninitialized memory 'listline' in Cftp::FindFile()

### DIFF
--- a/Core/Libraries/Source/WWVegas/WWDownload/FTP.CPP
+++ b/Core/Libraries/Source/WWVegas/WWDownload/FTP.CPP
@@ -659,7 +659,7 @@ HRESULT  Cftp::LogoffFromServer( void )
 HRESULT  Cftp::FindFile( LPCSTR szRemoteFileName, int * piSize )
 {
 	char command[ 256 ];
-	static char listline[ 256 ];
+	static char listline[ 256 ] = {0};
 
 	int i, iReply;
 	char ext[ 10 ];


### PR DESCRIPTION
This change prevents using uninitialized memory 'listline' in Cftp::FindFile() and makes the compiler happy.

I do not know why `listline` is static, but it does not matter for this fix. Maybe there is a reason. Whether this invalid read happened on runtime, I do not know. Maybe it never hit.

> Core\Libraries\Source\WWVegas\WWDownload\FTP.CPP(822): warning C6054: String 'listline' might not be zero-terminated.