### PR TITLE
[CORE] Prevent using uninitialized memory 'name' in RenderObjPersistFactoryClass::Load()

### DIFF
--- a/Core/Libraries/Source/WWVegas/WW3D2/rendobj.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/rendobj.cpp
@@ -1221,6 +1221,7 @@ PersistClass *	RenderObjPersistFactoryClass::Load(ChunkLoadClass & cload) const
 	RenderObjClass * old_obj = NULL;
 	Matrix3D tm(1);
 	char name[64];
+	name[0] = '\0';
 
 	while (cload.Open_Chunk()) {
 		switch (cload.Cur_Chunk_ID()) {


### PR DESCRIPTION
This change prevents using uninitialized memory 'name' in RenderObjPersistFactoryClass::Load() and makes the compiler happy.

```
Core\Libraries\Source\WWVegas\WW3D2\rendobj.cpp(1248): warning C6001: Using uninitialized memory 'name'.
Core\Libraries\Source\WWVegas\WW3D2\rendobj.cpp(1248): warning C6054: String 'name' might not be zero-terminated.
```