### PR TITLE
[GEN][ZH] Remove unnecessary NULL pointer test in RTS3DScene::Visibility_Check()

### DIFF
--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DScene.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DScene.cpp
@@ -391,8 +391,7 @@ void RTS3DScene::Visibility_Check(CameraClass * camera)
 	m_translucentObjectsCount=0;
 	m_numNonOccluderOrOccludee=0;
 
-	Int currentFrame=0;
-	if (TheGameLogic) currentFrame = TheGameLogic->getFrame();
+	Int currentFrame=TheGameLogic->getFrame();
 	if (currentFrame <= TheGlobalData->m_defaultOcclusionDelay)
 		currentFrame = TheGlobalData->m_defaultOcclusionDelay+1;	//make sure occlusion is enabled when game starts (frame 0).
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DScene.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DScene.cpp
@@ -408,8 +408,7 @@ void RTS3DScene::Visibility_Check(CameraClass * camera)
 	m_translucentObjectsCount=0;
 	m_numNonOccluderOrOccludee=0;
 
-	Int currentFrame=0;
-	if (TheGameLogic) currentFrame = TheGameLogic->getFrame();
+	Int currentFrame=TheGameLogic->getFrame();
 	if (currentFrame <= TheGlobalData->m_defaultOcclusionDelay)
 		currentFrame = TheGlobalData->m_defaultOcclusionDelay+1;	//make sure occlusion is enabled when game starts (frame 0).
 


### PR DESCRIPTION
This change removes an unnecessary NULL pointer test in RTS3DScene::Visibility_Check() and makes the compiler happy.

> GeneralsMD\Code\GameEngineDevice\Source\W3DDevice\GameClient\W3DScene.cpp(487): warning C6011: Dereferencing NULL pointer 'TheGameLogic'.