### PR TITLE
[CORE] Fix dereferencing NULL pointer 'ptemp_obj' in AggregateDefClass::Find_Subobject()

### DIFF
--- a/Core/Libraries/Source/WWVegas/WW3D2/agg_def.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/agg_def.cpp
@@ -256,6 +256,8 @@ AggregateDefClass::Find_Subobject
 				
 				// Is this the subobject we were looking for?
 				RenderObjClass *ptemp_obj = parent_model->Get_Sub_Object_On_Bone (subobj_index, bone_index);
+				if (ptemp_obj == NULL)
+					continue;
 				if (::lstrcmpi (ptemp_obj->Get_Name (), mesh_path[index]) == 0) {
 					sub_obj = ptemp_obj;
 				} else {


### PR DESCRIPTION
This change fixes dereferencing NULL pointer 'ptemp_obj' in AggregateDefClass::Find_Subobject() and makes the compiler happy.

`Get_Sub_Object_On_Bone` can return NULL so this maybe could crash the game in some scenario. We do not know.

> Core\Libraries\Source\WWVegas\WW3D2\agg_def.cpp(259): warning C6011: Dereferencing NULL pointer 'ptemp_obj'.