### PR TITLE
[GEN][ZH] Prevent dereferencing NULL pointer 'TheControlBar', 'window' in ControlBarCallback

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/ControlBarCallback.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/ControlBarCallback.cpp
@@ -501,121 +501,114 @@ extern void toggleReplayControls( void );
 //-------------------------------------------------------------------------------------------------
 void ShowControlBar( Bool immediate )
 {
-	showReplayControls();
-	if(TheControlBar)
-		TheControlBar->showSpecialPowerShortcut();
-	if (TheWindowManager)
-	{
-		Int id = (Int)TheNameKeyGenerator->nameToKey(AsciiString("ControlBar.wnd:ControlBarParent"));
-		GameWindow *window = TheWindowManager->winGetWindowFromId(NULL, id);
+	if (!TheWindowManager || !TheControlBar || !TheTacticalView)
+		return;
 
-		if (window)
-		{	
-			TheControlBar->switchControlBarStage(CONTROL_BAR_STAGE_DEFAULT);
-			TheTacticalView->setHeight((Int)(TheDisplay->getHeight() * 0.80f));
-			if (TheControlBar->m_animateWindowManager && !immediate)
-			{
-				TheControlBar->m_animateWindowManager->reset();
-				//TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM_TIMED, TRUE, 1000, 0);
-				TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM, TRUE, 500, 0);
-				TheControlBar->animateSpecialPowerShortcut(TRUE);
-			}
-			window->winHide(FALSE);
+	showReplayControls();
+
+	TheControlBar->showSpecialPowerShortcut();
+
+	Int id = (Int)TheNameKeyGenerator->nameToKey(AsciiString("ControlBar.wnd:ControlBarParent"));
+	GameWindow *window = TheWindowManager->winGetWindowFromId(NULL, id);
+
+	if (window)
+	{
+		TheControlBar->switchControlBarStage(CONTROL_BAR_STAGE_DEFAULT);
+		TheTacticalView->setHeight((Int)(TheDisplay->getHeight() * 0.80f));
+
+		if (TheControlBar->m_animateWindowManager && !immediate)
+		{
+			TheControlBar->m_animateWindowManager->reset();
+			//TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM_TIMED, TRUE, 1000, 0);
+			TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM, TRUE, 500, 0);
+			TheControlBar->animateSpecialPowerShortcut(TRUE);
 		}
 
-	}  
+		window->winHide(FALSE);
+	}
 
 	// We want to get everything recalced since this is a major state change.
-	if(TheControlBar)
-		TheControlBar->markUIDirty();
-
-}// void ShowControlBar(void)
+	TheControlBar->markUIDirty();
+}
 
 //-------------------------------------------------------------------------------------------------
 /** Force the control bar to be hidden */
 //-------------------------------------------------------------------------------------------------
 void HideControlBar( Bool immediate )
 {
-	hideReplayControls();
-	if(TheControlBar)
-		TheControlBar->hideSpecialPowerShortcut();
-	if (TheWindowManager)
-	{
-		Int id = (Int)TheNameKeyGenerator->nameToKey(AsciiString("ControlBar.wnd:ControlBarParent"));
-		GameWindow *window = TheWindowManager->winGetWindowFromId(NULL, id);
+	if (!TheWindowManager || !TheControlBar || !TheTacticalView)
+		return;
 
-		if (window)
-		{
+	hideReplayControls();
+
+	TheControlBar->hideSpecialPowerShortcut();
+
+	Int id = (Int)TheNameKeyGenerator->nameToKey(AsciiString("ControlBar.wnd:ControlBarParent"));
+	GameWindow *window = TheWindowManager->winGetWindowFromId(NULL, id);
+
+	if (window)
+	{
 #ifdef SLIDE_LETTERBOX
-				TheTacticalView->setHeight((Int)(TheDisplay->getHeight() * 0.80f)); 
+		TheTacticalView->setHeight((Int)(TheDisplay->getHeight() * 0.80f)); 
 #else
-				TheTacticalView->setHeight(TheDisplay->getHeight());
+		TheTacticalView->setHeight(TheDisplay->getHeight());
 #endif
-		}
 		if (immediate)
 		{
 			window->winHide(TRUE);
-			if(TheControlBar)
-				TheControlBar->hideSpecialPowerShortcut();
-	
 		}
-		else
-		{
-			TheControlBar->m_animateWindowManager->reverseAnimateWindow();
-			TheControlBar->animateSpecialPowerShortcut(FALSE);
-		}
+	}
 
-		//Always get rid of the purchase science screen!
-		if( TheControlBar )
-		{
-			TheControlBar->hidePurchaseScience();
-		}
-	}  
-}//void HideControlBar( void )
+	if (TheControlBar->m_animateWindowManager && !immediate)
+	{
+		TheControlBar->m_animateWindowManager->reverseAnimateWindow();
+		TheControlBar->animateSpecialPowerShortcut(FALSE);
+	}
+
+	//Always get rid of the purchase science screen!
+	TheControlBar->hidePurchaseScience();
+}
 
 //-------------------------------------------------------------------------------------------------
 /** Toggle the control bar on or off */
 //-------------------------------------------------------------------------------------------------
 void ToggleControlBar( Bool immediate )
 {
+	if (!TheWindowManager || !TheControlBar || !TheTacticalView)
+		return;
+
 	toggleReplayControls();
 
-	if (TheWindowManager)
+	Int id = (Int)TheNameKeyGenerator->nameToKey(AsciiString("ControlBar.wnd:ControlBarParent"));
+	GameWindow *window = TheWindowManager->winGetWindowFromId(NULL, id);
+
+	if (window)
 	{
-		Int id = (Int)TheNameKeyGenerator->nameToKey(AsciiString("ControlBar.wnd:ControlBarParent"));
-		GameWindow *window = TheWindowManager->winGetWindowFromId(NULL, id);
-
-		if (window)
+		if (window->winIsHidden())
 		{
-			if (window->winIsHidden())
-			{
-				if(TheControlBar)	
-					TheControlBar->showSpecialPowerShortcut();
+			TheControlBar->showSpecialPowerShortcut();
 
-				//now hidden, we're making it visible again so shrink viewport under the window
-				TheTacticalView->setHeight((Int)(TheDisplay->getHeight() * 0.80f)); 
-				window->winHide(!window->winIsHidden());
-				TheControlBar->switchControlBarStage(CONTROL_BAR_STAGE_DEFAULT);
-				if (TheControlBar->m_animateWindowManager && !immediate)
-				{
-					TheControlBar->m_animateWindowManager->reset();
-					//TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM_TIMED, FALSE, 500, 0);
-					TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM, TRUE, 500, 0);
-					TheControlBar->animateSpecialPowerShortcut(TRUE);
-				}
-			}
-			else
+			//now hidden, we're making it visible again so shrink viewport under the window
+			TheTacticalView->setHeight((Int)(TheDisplay->getHeight() * 0.80f));
+			window->winHide(FALSE);
+			TheControlBar->switchControlBarStage(CONTROL_BAR_STAGE_DEFAULT);
+
+			if (TheControlBar->m_animateWindowManager && !immediate)
 			{
-				if(TheControlBar)
-					TheControlBar->hideSpecialPowerShortcut();
-				TheTacticalView->setHeight(TheDisplay->getHeight());
-				window->winHide(!window->winIsHidden());
+				TheControlBar->m_animateWindowManager->reset();
+				//TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM_TIMED, FALSE, 500, 0);
+				TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM, TRUE, 500, 0);
+				TheControlBar->animateSpecialPowerShortcut(TRUE);
 			}
-			
 		}
-
+		else
+		{
+			TheControlBar->hideSpecialPowerShortcut();
+			TheTacticalView->setHeight(TheDisplay->getHeight());
+			window->winHide(TRUE);
+		}
 	}
-}// end void ToggleControlBar( void )
+}
 
 //-------------------------------------------------------------------------------------------------
 /** Resize the control bar */

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/ControlBarCallback.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/ControlBarCallback.cpp
@@ -502,34 +502,39 @@ extern void toggleReplayControls( void );
 void ShowControlBar( Bool immediate )
 {
 	showReplayControls();
-	if(TheControlBar)
-		TheControlBar->showSpecialPowerShortcut();
+
 	if (TheWindowManager)
 	{
 		Int id = (Int)TheNameKeyGenerator->nameToKey(AsciiString("ControlBar.wnd:ControlBarParent"));
 		GameWindow *window = TheWindowManager->winGetWindowFromId(NULL, id);
 
 		if (window)
-		{	
-			TheControlBar->switchControlBarStage(CONTROL_BAR_STAGE_DEFAULT);
+		{
 			TheTacticalView->setHeight((Int)(TheDisplay->getHeight() * 0.80f));
-			if (TheControlBar->m_animateWindowManager && !immediate)
+
+			if (TheControlBar)
 			{
-				TheControlBar->m_animateWindowManager->reset();
-				//TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM_TIMED, TRUE, 1000, 0);
-				TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM, TRUE, 500, 0);
-				TheControlBar->animateSpecialPowerShortcut(TRUE);
+				TheControlBar->switchControlBarStage(CONTROL_BAR_STAGE_DEFAULT);
+
+				if (TheControlBar->m_animateWindowManager && !immediate)
+				{
+					TheControlBar->m_animateWindowManager->reset();
+					//TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM_TIMED, TRUE, 1000, 0);
+					TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM, TRUE, 500, 0);
+					TheControlBar->animateSpecialPowerShortcut(TRUE);
+				}
 			}
+
 			window->winHide(FALSE);
 		}
+	}
 
-	}  
-
-	// We want to get everything recalced since this is a major state change.
-	if(TheControlBar)
+	if (TheControlBar)
+	{
+		TheControlBar->showSpecialPowerShortcut();
 		TheControlBar->markUIDirty();
-
-}// void ShowControlBar(void)
+	}
+}
 
 //-------------------------------------------------------------------------------------------------
 /** Force the control bar to be hidden */
@@ -537,8 +542,7 @@ void ShowControlBar( Bool immediate )
 void HideControlBar( Bool immediate )
 {
 	hideReplayControls();
-	if(TheControlBar)
-		TheControlBar->hideSpecialPowerShortcut();
+
 	if (TheWindowManager)
 	{
 		Int id = (Int)TheNameKeyGenerator->nameToKey(AsciiString("ControlBar.wnd:ControlBarParent"));
@@ -547,31 +551,34 @@ void HideControlBar( Bool immediate )
 		if (window)
 		{
 #ifdef SLIDE_LETTERBOX
-				TheTacticalView->setHeight((Int)(TheDisplay->getHeight() * 0.80f)); 
+			TheTacticalView->setHeight((Int)(TheDisplay->getHeight() * 0.80f)); 
 #else
-				TheTacticalView->setHeight(TheDisplay->getHeight());
+			TheTacticalView->setHeight(TheDisplay->getHeight());
 #endif
-		}
-		if (immediate)
-		{
-			window->winHide(TRUE);
-			if(TheControlBar)
-				TheControlBar->hideSpecialPowerShortcut();
-	
-		}
-		else
-		{
-			TheControlBar->m_animateWindowManager->reverseAnimateWindow();
-			TheControlBar->animateSpecialPowerShortcut(FALSE);
-		}
 
-		//Always get rid of the purchase science screen!
-		if( TheControlBar )
-		{
-			TheControlBar->hidePurchaseScience();
+			if (immediate)
+			{
+				window->winHide(TRUE);
+			}
+			else
+			{
+				if (TheControlBar->m_animateWindowManager)
+				{
+					TheControlBar->m_animateWindowManager->reverseAnimateWindow();
+					TheControlBar->animateSpecialPowerShortcut(FALSE);
+				}
+			}
 		}
-	}  
-}//void HideControlBar( void )
+	}
+
+	if (TheControlBar)
+	{
+		TheControlBar->hideSpecialPowerShortcut();
+
+		// Always get rid of the purchase science screen!
+		TheControlBar->hidePurchaseScience();
+	}
+}
 
 //-------------------------------------------------------------------------------------------------
 /** Toggle the control bar on or off */
@@ -589,33 +596,35 @@ void ToggleControlBar( Bool immediate )
 		{
 			if (window->winIsHidden())
 			{
-				if(TheControlBar)	
-					TheControlBar->showSpecialPowerShortcut();
-
 				//now hidden, we're making it visible again so shrink viewport under the window
 				TheTacticalView->setHeight((Int)(TheDisplay->getHeight() * 0.80f)); 
 				window->winHide(!window->winIsHidden());
-				TheControlBar->switchControlBarStage(CONTROL_BAR_STAGE_DEFAULT);
-				if (TheControlBar->m_animateWindowManager && !immediate)
+
+				if (TheControlBar)
 				{
-					TheControlBar->m_animateWindowManager->reset();
-					//TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM_TIMED, FALSE, 500, 0);
-					TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM, TRUE, 500, 0);
-					TheControlBar->animateSpecialPowerShortcut(TRUE);
+					TheControlBar->showSpecialPowerShortcut();
+					TheControlBar->switchControlBarStage(CONTROL_BAR_STAGE_DEFAULT);
+
+					if (TheControlBar->m_animateWindowManager && !immediate)
+					{
+						TheControlBar->m_animateWindowManager->reset();
+						//TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM_TIMED, FALSE, 500, 0);
+						TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM, TRUE, 500, 0);
+						TheControlBar->animateSpecialPowerShortcut(TRUE);
+					}
 				}
 			}
 			else
 			{
-				if(TheControlBar)
-					TheControlBar->hideSpecialPowerShortcut();
 				TheTacticalView->setHeight(TheDisplay->getHeight());
 				window->winHide(!window->winIsHidden());
-			}
-			
-		}
 
+				if(TheControlBar)
+					TheControlBar->hideSpecialPowerShortcut();
+			}
+		}
 	}
-}// end void ToggleControlBar( void )
+}
 
 //-------------------------------------------------------------------------------------------------
 /** Resize the control bar */

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/ControlBarCallback.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/ControlBarCallback.cpp
@@ -502,39 +502,34 @@ extern void toggleReplayControls( void );
 void ShowControlBar( Bool immediate )
 {
 	showReplayControls();
-
+	if(TheControlBar)
+		TheControlBar->showSpecialPowerShortcut();
 	if (TheWindowManager)
 	{
 		Int id = (Int)TheNameKeyGenerator->nameToKey(AsciiString("ControlBar.wnd:ControlBarParent"));
 		GameWindow *window = TheWindowManager->winGetWindowFromId(NULL, id);
 
 		if (window)
-		{
+		{	
+			TheControlBar->switchControlBarStage(CONTROL_BAR_STAGE_DEFAULT);
 			TheTacticalView->setHeight((Int)(TheDisplay->getHeight() * 0.80f));
-
-			if (TheControlBar)
+			if (TheControlBar->m_animateWindowManager && !immediate)
 			{
-				TheControlBar->switchControlBarStage(CONTROL_BAR_STAGE_DEFAULT);
-
-				if (TheControlBar->m_animateWindowManager && !immediate)
-				{
-					TheControlBar->m_animateWindowManager->reset();
-					//TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM_TIMED, TRUE, 1000, 0);
-					TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM, TRUE, 500, 0);
-					TheControlBar->animateSpecialPowerShortcut(TRUE);
-				}
+				TheControlBar->m_animateWindowManager->reset();
+				//TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM_TIMED, TRUE, 1000, 0);
+				TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM, TRUE, 500, 0);
+				TheControlBar->animateSpecialPowerShortcut(TRUE);
 			}
-
 			window->winHide(FALSE);
 		}
-	}
 
-	if (TheControlBar)
-	{
-		TheControlBar->showSpecialPowerShortcut();
+	}  
+
+	// We want to get everything recalced since this is a major state change.
+	if(TheControlBar)
 		TheControlBar->markUIDirty();
-	}
-}
+
+}// void ShowControlBar(void)
 
 //-------------------------------------------------------------------------------------------------
 /** Force the control bar to be hidden */
@@ -542,7 +537,8 @@ void ShowControlBar( Bool immediate )
 void HideControlBar( Bool immediate )
 {
 	hideReplayControls();
-
+	if(TheControlBar)
+		TheControlBar->hideSpecialPowerShortcut();
 	if (TheWindowManager)
 	{
 		Int id = (Int)TheNameKeyGenerator->nameToKey(AsciiString("ControlBar.wnd:ControlBarParent"));
@@ -551,34 +547,31 @@ void HideControlBar( Bool immediate )
 		if (window)
 		{
 #ifdef SLIDE_LETTERBOX
-			TheTacticalView->setHeight((Int)(TheDisplay->getHeight() * 0.80f)); 
+				TheTacticalView->setHeight((Int)(TheDisplay->getHeight() * 0.80f)); 
 #else
-			TheTacticalView->setHeight(TheDisplay->getHeight());
+				TheTacticalView->setHeight(TheDisplay->getHeight());
 #endif
-
-			if (immediate)
-			{
-				window->winHide(TRUE);
-			}
-			else
-			{
-				if (TheControlBar->m_animateWindowManager)
-				{
-					TheControlBar->m_animateWindowManager->reverseAnimateWindow();
-					TheControlBar->animateSpecialPowerShortcut(FALSE);
-				}
-			}
 		}
-	}
+		if (immediate)
+		{
+			window->winHide(TRUE);
+			if(TheControlBar)
+				TheControlBar->hideSpecialPowerShortcut();
+	
+		}
+		else
+		{
+			TheControlBar->m_animateWindowManager->reverseAnimateWindow();
+			TheControlBar->animateSpecialPowerShortcut(FALSE);
+		}
 
-	if (TheControlBar)
-	{
-		TheControlBar->hideSpecialPowerShortcut();
-
-		// Always get rid of the purchase science screen!
-		TheControlBar->hidePurchaseScience();
-	}
-}
+		//Always get rid of the purchase science screen!
+		if( TheControlBar )
+		{
+			TheControlBar->hidePurchaseScience();
+		}
+	}  
+}//void HideControlBar( void )
 
 //-------------------------------------------------------------------------------------------------
 /** Toggle the control bar on or off */
@@ -596,35 +589,33 @@ void ToggleControlBar( Bool immediate )
 		{
 			if (window->winIsHidden())
 			{
+				if(TheControlBar)	
+					TheControlBar->showSpecialPowerShortcut();
+
 				//now hidden, we're making it visible again so shrink viewport under the window
 				TheTacticalView->setHeight((Int)(TheDisplay->getHeight() * 0.80f)); 
 				window->winHide(!window->winIsHidden());
-
-				if (TheControlBar)
+				TheControlBar->switchControlBarStage(CONTROL_BAR_STAGE_DEFAULT);
+				if (TheControlBar->m_animateWindowManager && !immediate)
 				{
-					TheControlBar->showSpecialPowerShortcut();
-					TheControlBar->switchControlBarStage(CONTROL_BAR_STAGE_DEFAULT);
-
-					if (TheControlBar->m_animateWindowManager && !immediate)
-					{
-						TheControlBar->m_animateWindowManager->reset();
-						//TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM_TIMED, FALSE, 500, 0);
-						TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM, TRUE, 500, 0);
-						TheControlBar->animateSpecialPowerShortcut(TRUE);
-					}
+					TheControlBar->m_animateWindowManager->reset();
+					//TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM_TIMED, FALSE, 500, 0);
+					TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM, TRUE, 500, 0);
+					TheControlBar->animateSpecialPowerShortcut(TRUE);
 				}
 			}
 			else
 			{
-				TheTacticalView->setHeight(TheDisplay->getHeight());
-				window->winHide(!window->winIsHidden());
-
 				if(TheControlBar)
 					TheControlBar->hideSpecialPowerShortcut();
+				TheTacticalView->setHeight(TheDisplay->getHeight());
+				window->winHide(!window->winIsHidden());
 			}
+			
 		}
+
 	}
-}
+}// end void ToggleControlBar( void )
 
 //-------------------------------------------------------------------------------------------------
 /** Resize the control bar */

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/ControlBarCallback.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/ControlBarCallback.cpp
@@ -500,121 +500,114 @@ extern void toggleReplayControls( void );
 //-------------------------------------------------------------------------------------------------
 void ShowControlBar( Bool immediate )
 {
-	showReplayControls();
-	if(TheControlBar)
-		TheControlBar->showSpecialPowerShortcut();
-	if (TheWindowManager)
-	{
-		Int id = (Int)TheNameKeyGenerator->nameToKey(AsciiString("ControlBar.wnd:ControlBarParent"));
-		GameWindow *window = TheWindowManager->winGetWindowFromId(NULL, id);
+	if (!TheWindowManager || !TheControlBar || !TheTacticalView)
+		return;
 
-		if (window)
-		{	
-			TheControlBar->switchControlBarStage(CONTROL_BAR_STAGE_DEFAULT);
-			TheTacticalView->setHeight((Int)(TheDisplay->getHeight() * 0.80f));
-			if (TheControlBar->m_animateWindowManager && !immediate)
-			{
-				TheControlBar->m_animateWindowManager->reset();
-				//TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM_TIMED, TRUE, 1000, 0);
-				TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM, TRUE, 500, 0);
-				TheControlBar->animateSpecialPowerShortcut(TRUE);
-			}
-			window->winHide(FALSE);
+	showReplayControls();
+
+	TheControlBar->showSpecialPowerShortcut();
+
+	Int id = (Int)TheNameKeyGenerator->nameToKey(AsciiString("ControlBar.wnd:ControlBarParent"));
+	GameWindow *window = TheWindowManager->winGetWindowFromId(NULL, id);
+
+	if (window)
+	{
+		TheControlBar->switchControlBarStage(CONTROL_BAR_STAGE_DEFAULT);
+		TheTacticalView->setHeight((Int)(TheDisplay->getHeight() * 0.80f));
+
+		if (TheControlBar->m_animateWindowManager && !immediate)
+		{
+			TheControlBar->m_animateWindowManager->reset();
+			//TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM_TIMED, TRUE, 1000, 0);
+			TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM, TRUE, 500, 0);
+			TheControlBar->animateSpecialPowerShortcut(TRUE);
 		}
 
-	}  
+		window->winHide(FALSE);
+	}
 
 	// We want to get everything recalced since this is a major state change.
-	if(TheControlBar)
-		TheControlBar->markUIDirty();
-
-}// void ShowControlBar(void)
+	TheControlBar->markUIDirty();
+}
 
 //-------------------------------------------------------------------------------------------------
 /** Force the control bar to be hidden */
 //-------------------------------------------------------------------------------------------------
 void HideControlBar( Bool immediate )
 {
-	hideReplayControls();
-	if(TheControlBar)
-		TheControlBar->hideSpecialPowerShortcut();
-	if (TheWindowManager)
-	{
-		Int id = (Int)TheNameKeyGenerator->nameToKey(AsciiString("ControlBar.wnd:ControlBarParent"));
-		GameWindow *window = TheWindowManager->winGetWindowFromId(NULL, id);
+	if (!TheWindowManager || !TheControlBar || !TheTacticalView)
+		return;
 
-		if (window)
-		{
+	hideReplayControls();
+
+	TheControlBar->hideSpecialPowerShortcut();
+
+	Int id = (Int)TheNameKeyGenerator->nameToKey(AsciiString("ControlBar.wnd:ControlBarParent"));
+	GameWindow *window = TheWindowManager->winGetWindowFromId(NULL, id);
+
+	if (window)
+	{
 #ifdef SLIDE_LETTERBOX
-				TheTacticalView->setHeight((Int)(TheDisplay->getHeight() * 0.80f)); 
+		TheTacticalView->setHeight((Int)(TheDisplay->getHeight() * 0.80f)); 
 #else
-				TheTacticalView->setHeight(TheDisplay->getHeight());
+		TheTacticalView->setHeight(TheDisplay->getHeight());
 #endif
-		}
 		if (immediate)
 		{
 			window->winHide(TRUE);
-			if(TheControlBar)
-				TheControlBar->hideSpecialPowerShortcut();
-	
 		}
-		else
-		{
-			TheControlBar->m_animateWindowManager->reverseAnimateWindow();
-			TheControlBar->animateSpecialPowerShortcut(FALSE);
-		}
+	}
 
-		//Always get rid of the purchase science screen!
-		if( TheControlBar )
-		{
-			TheControlBar->hidePurchaseScience();
-		}
-	}  
-}//void HideControlBar( void )
+	if (TheControlBar->m_animateWindowManager && !immediate)
+	{
+		TheControlBar->m_animateWindowManager->reverseAnimateWindow();
+		TheControlBar->animateSpecialPowerShortcut(FALSE);
+	}
+
+	//Always get rid of the purchase science screen!
+	TheControlBar->hidePurchaseScience();
+}
 
 //-------------------------------------------------------------------------------------------------
 /** Toggle the control bar on or off */
 //-------------------------------------------------------------------------------------------------
 void ToggleControlBar( Bool immediate )
 {
+	if (!TheWindowManager || !TheControlBar || !TheTacticalView)
+		return;
+
 	toggleReplayControls();
 
-	if (TheWindowManager)
+	Int id = (Int)TheNameKeyGenerator->nameToKey(AsciiString("ControlBar.wnd:ControlBarParent"));
+	GameWindow *window = TheWindowManager->winGetWindowFromId(NULL, id);
+
+	if (window)
 	{
-		Int id = (Int)TheNameKeyGenerator->nameToKey(AsciiString("ControlBar.wnd:ControlBarParent"));
-		GameWindow *window = TheWindowManager->winGetWindowFromId(NULL, id);
-
-		if (window)
+		if (window->winIsHidden())
 		{
-			if (window->winIsHidden())
-			{
-				if(TheControlBar)	
-					TheControlBar->showSpecialPowerShortcut();
+			TheControlBar->showSpecialPowerShortcut();
 
-				//now hidden, we're making it visible again so shrink viewport under the window
-				TheTacticalView->setHeight((Int)(TheDisplay->getHeight() * 0.80f)); 
-				window->winHide(!window->winIsHidden());
-				TheControlBar->switchControlBarStage(CONTROL_BAR_STAGE_DEFAULT);
-				if (TheControlBar->m_animateWindowManager && !immediate)
-				{
-					TheControlBar->m_animateWindowManager->reset();
-					//TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM_TIMED, FALSE, 500, 0);
-					TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM, TRUE, 500, 0);
-					TheControlBar->animateSpecialPowerShortcut(TRUE);
-				}
-			}
-			else
+			//now hidden, we're making it visible again so shrink viewport under the window
+			TheTacticalView->setHeight((Int)(TheDisplay->getHeight() * 0.80f));
+			window->winHide(FALSE);
+			TheControlBar->switchControlBarStage(CONTROL_BAR_STAGE_DEFAULT);
+
+			if (TheControlBar->m_animateWindowManager && !immediate)
 			{
-				if(TheControlBar)
-					TheControlBar->hideSpecialPowerShortcut();
-				TheTacticalView->setHeight(TheDisplay->getHeight());
-				window->winHide(!window->winIsHidden());
+				TheControlBar->m_animateWindowManager->reset();
+				//TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM_TIMED, FALSE, 500, 0);
+				TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM, TRUE, 500, 0);
+				TheControlBar->animateSpecialPowerShortcut(TRUE);
 			}
-			
 		}
-
+		else
+		{
+			TheControlBar->hideSpecialPowerShortcut();
+			TheTacticalView->setHeight(TheDisplay->getHeight());
+			window->winHide(TRUE);
+		}
 	}
-}// end void ToggleControlBar( void )
+}
 
 //-------------------------------------------------------------------------------------------------
 /** Resize the control bar */

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/ControlBarCallback.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/ControlBarCallback.cpp
@@ -501,34 +501,39 @@ extern void toggleReplayControls( void );
 void ShowControlBar( Bool immediate )
 {
 	showReplayControls();
-	if(TheControlBar)
-		TheControlBar->showSpecialPowerShortcut();
+
 	if (TheWindowManager)
 	{
 		Int id = (Int)TheNameKeyGenerator->nameToKey(AsciiString("ControlBar.wnd:ControlBarParent"));
 		GameWindow *window = TheWindowManager->winGetWindowFromId(NULL, id);
 
 		if (window)
-		{	
-			TheControlBar->switchControlBarStage(CONTROL_BAR_STAGE_DEFAULT);
+		{
 			TheTacticalView->setHeight((Int)(TheDisplay->getHeight() * 0.80f));
-			if (TheControlBar->m_animateWindowManager && !immediate)
+
+			if (TheControlBar)
 			{
-				TheControlBar->m_animateWindowManager->reset();
-				//TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM_TIMED, TRUE, 1000, 0);
-				TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM, TRUE, 500, 0);
-				TheControlBar->animateSpecialPowerShortcut(TRUE);
+				TheControlBar->switchControlBarStage(CONTROL_BAR_STAGE_DEFAULT);
+
+				if (TheControlBar->m_animateWindowManager && !immediate)
+				{
+					TheControlBar->m_animateWindowManager->reset();
+					//TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM_TIMED, TRUE, 1000, 0);
+					TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM, TRUE, 500, 0);
+					TheControlBar->animateSpecialPowerShortcut(TRUE);
+				}
 			}
+
 			window->winHide(FALSE);
 		}
+	}
 
-	}  
-
-	// We want to get everything recalced since this is a major state change.
-	if(TheControlBar)
+	if (TheControlBar)
+	{
+		TheControlBar->showSpecialPowerShortcut();
 		TheControlBar->markUIDirty();
-
-}// void ShowControlBar(void)
+	}
+}
 
 //-------------------------------------------------------------------------------------------------
 /** Force the control bar to be hidden */
@@ -536,8 +541,7 @@ void ShowControlBar( Bool immediate )
 void HideControlBar( Bool immediate )
 {
 	hideReplayControls();
-	if(TheControlBar)
-		TheControlBar->hideSpecialPowerShortcut();
+
 	if (TheWindowManager)
 	{
 		Int id = (Int)TheNameKeyGenerator->nameToKey(AsciiString("ControlBar.wnd:ControlBarParent"));
@@ -546,31 +550,34 @@ void HideControlBar( Bool immediate )
 		if (window)
 		{
 #ifdef SLIDE_LETTERBOX
-				TheTacticalView->setHeight((Int)(TheDisplay->getHeight() * 0.80f)); 
+			TheTacticalView->setHeight((Int)(TheDisplay->getHeight() * 0.80f)); 
 #else
-				TheTacticalView->setHeight(TheDisplay->getHeight());
+			TheTacticalView->setHeight(TheDisplay->getHeight());
 #endif
-		}
-		if (immediate)
-		{
-			window->winHide(TRUE);
-			if(TheControlBar)
-				TheControlBar->hideSpecialPowerShortcut();
-	
-		}
-		else
-		{
-			TheControlBar->m_animateWindowManager->reverseAnimateWindow();
-			TheControlBar->animateSpecialPowerShortcut(FALSE);
-		}
 
-		//Always get rid of the purchase science screen!
-		if( TheControlBar )
-		{
-			TheControlBar->hidePurchaseScience();
+			if (immediate)
+			{
+				window->winHide(TRUE);
+			}
+			else
+			{
+				if (TheControlBar->m_animateWindowManager)
+				{
+					TheControlBar->m_animateWindowManager->reverseAnimateWindow();
+					TheControlBar->animateSpecialPowerShortcut(FALSE);
+				}
+			}
 		}
-	}  
-}//void HideControlBar( void )
+	}
+
+	if (TheControlBar)
+	{
+		TheControlBar->hideSpecialPowerShortcut();
+
+		// Always get rid of the purchase science screen!
+		TheControlBar->hidePurchaseScience();
+	}
+}
 
 //-------------------------------------------------------------------------------------------------
 /** Toggle the control bar on or off */
@@ -588,33 +595,35 @@ void ToggleControlBar( Bool immediate )
 		{
 			if (window->winIsHidden())
 			{
-				if(TheControlBar)	
-					TheControlBar->showSpecialPowerShortcut();
-
 				//now hidden, we're making it visible again so shrink viewport under the window
 				TheTacticalView->setHeight((Int)(TheDisplay->getHeight() * 0.80f)); 
 				window->winHide(!window->winIsHidden());
-				TheControlBar->switchControlBarStage(CONTROL_BAR_STAGE_DEFAULT);
-				if (TheControlBar->m_animateWindowManager && !immediate)
+
+				if (TheControlBar)
 				{
-					TheControlBar->m_animateWindowManager->reset();
-					//TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM_TIMED, FALSE, 500, 0);
-					TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM, TRUE, 500, 0);
-					TheControlBar->animateSpecialPowerShortcut(TRUE);
+					TheControlBar->showSpecialPowerShortcut();
+					TheControlBar->switchControlBarStage(CONTROL_BAR_STAGE_DEFAULT);
+
+					if (TheControlBar->m_animateWindowManager && !immediate)
+					{
+						TheControlBar->m_animateWindowManager->reset();
+						//TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM_TIMED, FALSE, 500, 0);
+						TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM, TRUE, 500, 0);
+						TheControlBar->animateSpecialPowerShortcut(TRUE);
+					}
 				}
 			}
 			else
 			{
-				if(TheControlBar)
-					TheControlBar->hideSpecialPowerShortcut();
 				TheTacticalView->setHeight(TheDisplay->getHeight());
 				window->winHide(!window->winIsHidden());
-			}
-			
-		}
 
+				if(TheControlBar)
+					TheControlBar->hideSpecialPowerShortcut();
+			}
+		}
 	}
-}// end void ToggleControlBar( void )
+}
 
 //-------------------------------------------------------------------------------------------------
 /** Resize the control bar */

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/ControlBarCallback.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/ControlBarCallback.cpp
@@ -501,39 +501,34 @@ extern void toggleReplayControls( void );
 void ShowControlBar( Bool immediate )
 {
 	showReplayControls();
-
+	if(TheControlBar)
+		TheControlBar->showSpecialPowerShortcut();
 	if (TheWindowManager)
 	{
 		Int id = (Int)TheNameKeyGenerator->nameToKey(AsciiString("ControlBar.wnd:ControlBarParent"));
 		GameWindow *window = TheWindowManager->winGetWindowFromId(NULL, id);
 
 		if (window)
-		{
+		{	
+			TheControlBar->switchControlBarStage(CONTROL_BAR_STAGE_DEFAULT);
 			TheTacticalView->setHeight((Int)(TheDisplay->getHeight() * 0.80f));
-
-			if (TheControlBar)
+			if (TheControlBar->m_animateWindowManager && !immediate)
 			{
-				TheControlBar->switchControlBarStage(CONTROL_BAR_STAGE_DEFAULT);
-
-				if (TheControlBar->m_animateWindowManager && !immediate)
-				{
-					TheControlBar->m_animateWindowManager->reset();
-					//TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM_TIMED, TRUE, 1000, 0);
-					TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM, TRUE, 500, 0);
-					TheControlBar->animateSpecialPowerShortcut(TRUE);
-				}
+				TheControlBar->m_animateWindowManager->reset();
+				//TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM_TIMED, TRUE, 1000, 0);
+				TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM, TRUE, 500, 0);
+				TheControlBar->animateSpecialPowerShortcut(TRUE);
 			}
-
 			window->winHide(FALSE);
 		}
-	}
 
-	if (TheControlBar)
-	{
-		TheControlBar->showSpecialPowerShortcut();
+	}  
+
+	// We want to get everything recalced since this is a major state change.
+	if(TheControlBar)
 		TheControlBar->markUIDirty();
-	}
-}
+
+}// void ShowControlBar(void)
 
 //-------------------------------------------------------------------------------------------------
 /** Force the control bar to be hidden */
@@ -541,7 +536,8 @@ void ShowControlBar( Bool immediate )
 void HideControlBar( Bool immediate )
 {
 	hideReplayControls();
-
+	if(TheControlBar)
+		TheControlBar->hideSpecialPowerShortcut();
 	if (TheWindowManager)
 	{
 		Int id = (Int)TheNameKeyGenerator->nameToKey(AsciiString("ControlBar.wnd:ControlBarParent"));
@@ -550,34 +546,31 @@ void HideControlBar( Bool immediate )
 		if (window)
 		{
 #ifdef SLIDE_LETTERBOX
-			TheTacticalView->setHeight((Int)(TheDisplay->getHeight() * 0.80f)); 
+				TheTacticalView->setHeight((Int)(TheDisplay->getHeight() * 0.80f)); 
 #else
-			TheTacticalView->setHeight(TheDisplay->getHeight());
+				TheTacticalView->setHeight(TheDisplay->getHeight());
 #endif
-
-			if (immediate)
-			{
-				window->winHide(TRUE);
-			}
-			else
-			{
-				if (TheControlBar->m_animateWindowManager)
-				{
-					TheControlBar->m_animateWindowManager->reverseAnimateWindow();
-					TheControlBar->animateSpecialPowerShortcut(FALSE);
-				}
-			}
 		}
-	}
+		if (immediate)
+		{
+			window->winHide(TRUE);
+			if(TheControlBar)
+				TheControlBar->hideSpecialPowerShortcut();
+	
+		}
+		else
+		{
+			TheControlBar->m_animateWindowManager->reverseAnimateWindow();
+			TheControlBar->animateSpecialPowerShortcut(FALSE);
+		}
 
-	if (TheControlBar)
-	{
-		TheControlBar->hideSpecialPowerShortcut();
-
-		// Always get rid of the purchase science screen!
-		TheControlBar->hidePurchaseScience();
-	}
-}
+		//Always get rid of the purchase science screen!
+		if( TheControlBar )
+		{
+			TheControlBar->hidePurchaseScience();
+		}
+	}  
+}//void HideControlBar( void )
 
 //-------------------------------------------------------------------------------------------------
 /** Toggle the control bar on or off */
@@ -595,35 +588,33 @@ void ToggleControlBar( Bool immediate )
 		{
 			if (window->winIsHidden())
 			{
+				if(TheControlBar)	
+					TheControlBar->showSpecialPowerShortcut();
+
 				//now hidden, we're making it visible again so shrink viewport under the window
 				TheTacticalView->setHeight((Int)(TheDisplay->getHeight() * 0.80f)); 
 				window->winHide(!window->winIsHidden());
-
-				if (TheControlBar)
+				TheControlBar->switchControlBarStage(CONTROL_BAR_STAGE_DEFAULT);
+				if (TheControlBar->m_animateWindowManager && !immediate)
 				{
-					TheControlBar->showSpecialPowerShortcut();
-					TheControlBar->switchControlBarStage(CONTROL_BAR_STAGE_DEFAULT);
-
-					if (TheControlBar->m_animateWindowManager && !immediate)
-					{
-						TheControlBar->m_animateWindowManager->reset();
-						//TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM_TIMED, FALSE, 500, 0);
-						TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM, TRUE, 500, 0);
-						TheControlBar->animateSpecialPowerShortcut(TRUE);
-					}
+					TheControlBar->m_animateWindowManager->reset();
+					//TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM_TIMED, FALSE, 500, 0);
+					TheControlBar->m_animateWindowManager->registerGameWindow(window, WIN_ANIMATION_SLIDE_BOTTOM, TRUE, 500, 0);
+					TheControlBar->animateSpecialPowerShortcut(TRUE);
 				}
 			}
 			else
 			{
-				TheTacticalView->setHeight(TheDisplay->getHeight());
-				window->winHide(!window->winIsHidden());
-
 				if(TheControlBar)
 					TheControlBar->hideSpecialPowerShortcut();
+				TheTacticalView->setHeight(TheDisplay->getHeight());
+				window->winHide(!window->winIsHidden());
 			}
+			
 		}
+
 	}
-}
+}// end void ToggleControlBar( void )
 
 //-------------------------------------------------------------------------------------------------
 /** Resize the control bar */


### PR DESCRIPTION
This change prevents dereferencing NULL pointer 'TheControlBar', 'window' in ControlBarCallback and makes the compiler happy.

Practically this never crashes because these globals are not meant to be null. At least not in the regular game client.

```
GeneralsMD\Code\GameEngine\Source\GameClient\GUI\GUICallbacks\ControlBarCallback.cpp(515): warning C6011: Dereferencing NULL pointer 'TheControlBar'.
GeneralsMD\Code\GameEngine\Source\GameClient\GUI\GUICallbacks\ControlBarCallback.cpp(563): warning C6011: Dereferencing NULL pointer 'TheControlBar'.
GeneralsMD\Code\GameEngine\Source\GameClient\GUI\GUICallbacks\ControlBarCallback.cpp(598): warning C6011: Dereferencing NULL pointer 'TheControlBar'.
```