### PR TITLE
[GEN][ZH] Prevent dereferencing NULL pointer 'TheWritableGlobalData' in GameLODManager::applyStaticLODLevel()

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/GameLOD.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GameLOD.cpp
@@ -577,9 +577,10 @@ void GameLODManager::applyStaticLODLevel(StaticGameLODLevel level)
 		TheWritableGlobalData->m_enableDynamicLOD = lodInfo->m_enableDynamicLOD;
 		TheWritableGlobalData->m_useFpsLimit = lodInfo->m_useFpsLimit;
 		TheWritableGlobalData->m_useTrees = requestedTrees;
-	}
-	if (!m_memPassed || isReallyLowMHz()) {
-		TheWritableGlobalData->m_shellMapOn = false;
+
+		if (!m_memPassed || isReallyLowMHz()) {
+			TheWritableGlobalData->m_shellMapOn = false;
+		}
 	}
 	if (TheTerrainVisual)
 		TheTerrainVisual->setTerrainTracksDetail();

--- a/GeneralsMD/Code/GameEngine/Source/Common/GameLOD.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GameLOD.cpp
@@ -582,9 +582,10 @@ void GameLODManager::applyStaticLODLevel(StaticGameLODLevel level)
 		TheWritableGlobalData->m_enableDynamicLOD = lodInfo->m_enableDynamicLOD;
 		TheWritableGlobalData->m_useFpsLimit = lodInfo->m_useFpsLimit;
 		TheWritableGlobalData->m_useTrees = requestedTrees;
-	}
-	if (!m_memPassed || isReallyLowMHz()) {
-		TheWritableGlobalData->m_shellMapOn = false;
+
+		if (!m_memPassed || isReallyLowMHz()) {
+			TheWritableGlobalData->m_shellMapOn = false;
+		}
 	}
 	if (TheTerrainVisual)
 		TheTerrainVisual->setTerrainTracksDetail();


### PR DESCRIPTION
This change prevents dereferencing NULL pointer 'TheWritableGlobalData' in GameLODManager::applyStaticLODLevel() and makes the compiler happy.

> GeneralsMD\Code\GameEngine\Source\Common\GameLOD.cpp(587): warning C6011: Dereferencing NULL pointer 'TheWritableGlobalData'.