### PR TITLE
[GEN][ZH] Prevent reading invalid data from 'm_numLevelPresets' in GameLODManager::newLODPreset()

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/GameLOD.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GameLOD.cpp
@@ -260,6 +260,7 @@ LODPresetInfo *GameLODManager::newLODPreset(StaticGameLODLevel index)
 			m_numLevelPresets[index]++;
 			return &m_lodPresets[index][m_numLevelPresets[index]-1];
 		}
+
 		DEBUG_CRASH(( "GameLODManager::newLODPreset - Too many presets defined for '%s'\n", TheGameLODManager->getStaticGameLODLevelName(index)));
 	}
 

--- a/Generals/Code/GameEngine/Source/Common/GameLOD.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GameLOD.cpp
@@ -253,13 +253,16 @@ BenchProfile *GameLODManager::newBenchProfile(void)
 
 LODPresetInfo *GameLODManager::newLODPreset(StaticGameLODLevel index)
 {
-	if (m_numLevelPresets[index] < MAX_LOD_PRESETS_PER_LEVEL)
-	{	
-		m_numLevelPresets[index]++;
-		return &m_lodPresets[index][m_numLevelPresets[index]-1];
+	if (index >= 0 && index < STATIC_GAME_LOD_COUNT)
+	{
+		if (m_numLevelPresets[index] < MAX_LOD_PRESETS_PER_LEVEL)
+		{
+			m_numLevelPresets[index]++;
+			return &m_lodPresets[index][m_numLevelPresets[index]-1];
+		}
+		DEBUG_CRASH(( "GameLODManager::newLODPreset - Too many presets defined for '%s'\n", TheGameLODManager->getStaticGameLODLevelName(index)));
 	}
 
-	DEBUG_CRASH(( "GameLODManager::newLODPreset - Too many presets defined for '%s'\n", TheGameLODManager->getStaticGameLODLevelName(index)));
 	return NULL;
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/GameLOD.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GameLOD.cpp
@@ -255,13 +255,16 @@ BenchProfile *GameLODManager::newBenchProfile(void)
 
 LODPresetInfo *GameLODManager::newLODPreset(StaticGameLODLevel index)
 {
-	if (m_numLevelPresets[index] < MAX_LOD_PRESETS_PER_LEVEL)
-	{	
-		m_numLevelPresets[index]++;
-		return &m_lodPresets[index][m_numLevelPresets[index]-1];
+	if (index >= 0 && index < STATIC_GAME_LOD_COUNT)
+	{
+		if (m_numLevelPresets[index] < MAX_LOD_PRESETS_PER_LEVEL)
+		{
+			m_numLevelPresets[index]++;
+			return &m_lodPresets[index][m_numLevelPresets[index]-1];
+		}
+		DEBUG_CRASH(( "GameLODManager::newLODPreset - Too many presets defined for '%s'\n", TheGameLODManager->getStaticGameLODLevelName(index)));
 	}
 
-	DEBUG_CRASH(( "GameLODManager::newLODPreset - Too many presets defined for '%s'\n", TheGameLODManager->getStaticGameLODLevelName(index)));
 	return NULL;
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/GameLOD.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GameLOD.cpp
@@ -262,6 +262,7 @@ LODPresetInfo *GameLODManager::newLODPreset(StaticGameLODLevel index)
 			m_numLevelPresets[index]++;
 			return &m_lodPresets[index][m_numLevelPresets[index]-1];
 		}
+
 		DEBUG_CRASH(( "GameLODManager::newLODPreset - Too many presets defined for '%s'\n", TheGameLODManager->getStaticGameLODLevelName(index)));
 	}
 


### PR DESCRIPTION
This change prevents reading invalid data from 'this->m_numLevelPresets' in GameLODManager::newLODPreset() and makes the compiler happy.

```
GeneralsMD\Code\GameEngine\Source\Common\GameLOD.cpp(261): warning C6385: Reading invalid data from 'this->m_numLevelPresets':  the readable size is '12' bytes, but 'index' bytes may be read.
GeneralsMD\Code\GameEngine\Source\Common\GameLOD.cpp(264): warning C6385: Reading invalid data from 'this->m_lodPresets':  the readable size is '1920' bytes, but 'index' bytes may be read.
GeneralsMD\Code\GameEngine\Source\Common\GameLOD.cpp(261): warning C33011: Unchecked upper bound for enum index used as index..
```

In practice this is no issue, but the compiler rightfully warns about this because the enum has a value with a negative numeral and enum value that is reserved for the count.

```cpp
enum StaticGameLODLevel CPP_11(: Int)
{
	STATIC_GAME_LOD_UNKNOWN=-1, // <---- this triggers compile warning
	STATIC_GAME_LOD_LOW,
	STATIC_GAME_LOD_MEDIUM,
	STATIC_GAME_LOD_HIGH,
	STATIC_GAME_LOD_CUSTOM,
	STATIC_GAME_LOD_COUNT // <---- this triggers compile warning
};
```