### PR TITLE
[GEN][ZH] Prevent reading invalid data from 'this->m_staticGameLODInfo' in GameLODManager::getRecommendedTextureReduction()

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/GameLOD.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GameLOD.cpp
@@ -688,6 +688,9 @@ Int GameLODManager::getRecommendedTextureReduction(void)
 	if (!m_memPassed)	//if they have < 256 MB, force them to low res textures.
 		return m_staticGameLODInfo[STATIC_GAME_LOD_LOW].m_textureReduction;
 
+	if (m_idealDetailLevel < 0 || m_idealDetailLevel >= STATIC_GAME_LOD_COUNT)
+		return m_staticGameLODInfo[STATIC_GAME_LOD_LOW].m_textureReduction;
+
 	return m_staticGameLODInfo[m_idealDetailLevel].m_textureReduction;
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/GameLOD.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GameLOD.cpp
@@ -693,6 +693,9 @@ Int GameLODManager::getRecommendedTextureReduction(void)
 	if (!m_memPassed)	//if they have < 256 MB, force them to low res textures.
 		return m_staticGameLODInfo[STATIC_GAME_LOD_LOW].m_textureReduction;
 
+	if (m_idealDetailLevel < 0 || m_idealDetailLevel >= STATIC_GAME_LOD_COUNT)
+		return m_staticGameLODInfo[STATIC_GAME_LOD_LOW].m_textureReduction;
+
 	return m_staticGameLODInfo[m_idealDetailLevel].m_textureReduction;
 }
 


### PR DESCRIPTION
* Relates to #1150

This change prevents reading invalid data from 'this->m_staticGameLODInfo' in GameLODManager::getRecommendedTextureReduction() and makes the compiler happy.

> GeneralsMD\Code\GameEngine\Source\Common\GameLOD.cpp(701): warning C6385: Reading invalid data from 'this->m_staticGameLODInfo':  the readable size is '224' bytes, but 'm_idealDetailLevel' bytes may be read.

In practice this is no issue, but the compiler rightfully warns about this because the enum has a value with a negative numeral and enum value that is reserved for the count.