### PR TITLE
[ZH] Fix compiler warning about incorrect order of operations in WorldHeightMap::getPointerToTileData()

### DIFF
--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/WorldHeightMap.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/WorldHeightMap.cpp
@@ -2434,7 +2434,7 @@ UnsignedByte * WorldHeightMap::getPointerToTileData(Int xIndex, Int yIndex, Int 
 					Int r,g,b,a;
 					b = *pBlendData++;
 					g = *pBlendData++;
-					r = *pBlendData++; *pBlendData++;
+					r = *pBlendData++; pBlendData++;
 					a = *pAlpha; pAlpha += 4;
 					*pDestData++ = ((b*a)/255) + (((*pDestData)*(255-a))/255);
 					*pDestData++ = ((g*a)/255) + (((*pDestData)*(255-a))/255);


### PR DESCRIPTION
This change fixes a compiler warning about possibly incorrect order of operations in WorldHeightMap::getPointerToTileData()

```
GeneralsMD\Code\GameEngineDevice\Source\W3DDevice\GameClient\WorldHeightMap.cpp(2437): warning C6269: Possibly incorrect order of operations.
```