### PR TITLE
[GEN][ZH] Fix missing break at switch case BuddyRequest::BUDDYREQUEST_DENYADD in BuddyThreadClass::Thread_Function()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameNetwork/GameSpy/Thread/BuddyThread.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/GameSpy/Thread/BuddyThread.cpp
@@ -360,6 +360,7 @@ void BuddyThreadClass::Thread_Function()
 				{
 					gpDenyBuddyRequest( con, incomingRequest.arg.profile.id );
 				}
+				break;
 			case BuddyRequest::BUDDYREQUEST_SETSTATUS:
 				{
 					//don't blast our 'Loading' status with 'Online'.

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameSpy/Thread/BuddyThread.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/GameSpy/Thread/BuddyThread.cpp
@@ -360,6 +360,7 @@ void BuddyThreadClass::Thread_Function()
 				{
 					gpDenyBuddyRequest( con, incomingRequest.arg.profile.id );
 				}
+				break;
 			case BuddyRequest::BUDDYREQUEST_SETSTATUS:
 				{
 					//don't blast our 'Loading' status with 'Online'.


### PR DESCRIPTION
This change adds the missing break label at switch case BuddyRequest::BUDDYREQUEST_DENYADD in BuddyThreadClass::Thread_Function()

I am not able to test this but I think this missing break label has the potential to crash the game, depending on the uninitialized memory read. It also may or may not be user facing.

`BuddyRequest::BUDDYREQUEST_SETSTATUS` is used to inform the local user about the status of his buddies. When entering this code through switch case `BuddyRequest::BUDDYREQUEST_DENYADD` then `incomingRequest.arg.status` will not be initialized to what it should be, so this will read garbage and the behaviour will be undefined. The local player may see a garbage status updates when their buddy request is rejected.

```cpp
case BuddyRequest::BUDDYREQUEST_DENYADD:
    {
        gpDenyBuddyRequest( con, incomingRequest.arg.profile.id );
    }
    // <--- falls through here
case BuddyRequest::BUDDYREQUEST_SETSTATUS:
    {
        //don't blast our 'Loading' status with 'Online'.
        if (lastStatus == GP_PLAYING && lastStatusString == "Loading" && incomingRequest.arg.status.status == GP_ONLINE)
            break;

        DEBUG_LOG(("BUDDYREQUEST_SETSTATUS: status is now %d:%s/%s\n",
            incomingRequest.arg.status.status, incomingRequest.arg.status.statusString, incomingRequest.arg.status.locationString));
        gpSetStatus( con, incomingRequest.arg.status.status, incomingRequest.arg.status.statusString,
            incomingRequest.arg.status.locationString );
        lastStatus = incomingRequest.arg.status.status; // <--- reads profile.id as status.status
        lastStatusString = incomingRequest.arg.status.statusString; // <--- reads uninitialized memory, could perhaps crash when unlucky
    }
    break;
```