### PR TITLE
[GEN][ZH] Fix missing break at switch case SPEECH_PLAY in ScriptAction::ParseAction()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/Scripts.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/Scripts.cpp
@@ -2445,8 +2445,8 @@ Bool ScriptAction::ParseActionDataChunk(DataChunkInput &file, DataChunkInfo *inf
 				pScriptAction->m_numParms = 2;
 				// Default it to TRUE, as per conversation with JohnL
 				pScriptAction->m_parms[1] = newInstance(Parameter)(Parameter::BOOLEAN, 1);
-				break;
 			}
+			break;
 	}
 
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/Scripts.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/Scripts.cpp
@@ -2556,8 +2556,8 @@ ScriptAction *ScriptAction::ParseAction(DataChunkInput &file, DataChunkInfo *inf
 				pScriptAction->m_numParms = 2;
 				// Default it to TRUE, as per conversation with JohnL
 				pScriptAction->m_parms[1] = newInstance(Parameter)(Parameter::BOOLEAN, 1);
-				break;
 			}
+			break;
 		case CAMERA_MOD_SET_FINAL_ZOOM:
 		case CAMERA_MOD_SET_FINAL_PITCH:
 			if (pScriptAction->getNumParameters() == 1)


### PR DESCRIPTION
This change fixes a missing break at switch case SPEECH_PLAY in ScriptAction::ParseAction()

Technically this is just a refactor, because the fall through into case CAMERA_MOD_SET_FINAL_PITCH would have had no side effects.
