### PR TITLE
[GEN][ZH] Prevent using uninitialized memory 'relationDescriber' in ScriptConditions::evaluateEnemySighted()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptConditions.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptConditions.cpp
@@ -1025,6 +1025,9 @@ Bool ScriptConditions::evaluateEnemySighted(Parameter *pItemParm, Parameter *pAl
 	// filter out appropriately based on alliances
 	Int relationDescriber;
 	switch (pAllianceParm->getInt()) {
+		default:
+			relationDescriber = 0;
+			break;
 		case Parameter::REL_NEUTRAL:
 			relationDescriber = PartitionFilterRelationship::ALLOW_NEUTRAL;
 			break;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptConditions.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptConditions.cpp
@@ -1066,6 +1066,9 @@ Bool ScriptConditions::evaluateEnemySighted(Parameter *pItemParm, Parameter *pAl
 	// filter out appropriately based on alliances
 	Int relationDescriber;
 	switch (pAllianceParm->getInt()) {
+		default:
+			relationDescriber = 0;
+			break;
 		case Parameter::REL_NEUTRAL:
 			relationDescriber = PartitionFilterRelationship::ALLOW_NEUTRAL;
 			break;


### PR DESCRIPTION
This change prevents using uninitialized memory 'relationDescriber' in ScriptConditions::evaluateEnemySighted() and makes the compiler happy.

Practically this is no bug, because there are only these 3 handled parameter values but the compiler does not know that.

> GeneralsMD\Code\GameEngine\Source\GameLogic\ScriptEngine\ScriptConditions.cpp(1079): warning C6001: Using uninitialized memory 'relationDescriber'.