### PR TITLE
[GEN][ZH] Fix missing unit voice when attacking the ground

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -422,20 +422,6 @@ void pickAndPlayUnitVoiceResponse( const DrawableList *list, GameMessage::Type m
 				break;
 			}
 
-			case GameMessage::MSG_DO_FORCE_ATTACK_GROUND:
-			{
-				soundToPlayPtr = templ->getPerUnitSound( "VoiceBombard" );
-				objectWithSound = obj;
-				skip = true;
-
-				if (TheAudio->isValidAudioEvent(soundToPlayPtr)) {
-					break;
-				} else {
-					// clear out the sound to play, and drop into the attack object logic.
-					soundToPlayPtr = NULL;
-				}
-			}
-			
 			case GameMessage::MSG_SWITCH_WEAPONS:
 			{
 				if( info && info->m_weaponSlot )
@@ -457,7 +443,21 @@ void pickAndPlayUnitVoiceResponse( const DrawableList *list, GameMessage::Type m
 				}
 				break;
 			}
-			
+
+			case GameMessage::MSG_DO_FORCE_ATTACK_GROUND:
+			{
+				soundToPlayPtr = templ->getPerUnitSound( "VoiceBombard" );
+				objectWithSound = obj;
+				skip = true;
+
+				if (TheAudio->isValidAudioEvent(soundToPlayPtr)) {
+					break;
+				} else {
+					// clear out the sound to play, and drop into the attack object logic.
+					soundToPlayPtr = NULL;
+					FALLTHROUGH;
+				}
+			}
 			case GameMessage::MSG_DO_FORCE_ATTACK_OBJECT:
 			case GameMessage::MSG_DO_ATTACK_OBJECT:
 			case GameMessage::MSG_DO_WEAPON_AT_OBJECT:

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -481,20 +481,6 @@ void pickAndPlayUnitVoiceResponse( const DrawableList *list, GameMessage::Type m
 				break;
 			}
 
-			case GameMessage::MSG_DO_FORCE_ATTACK_GROUND:
-			{
-				soundToPlayPtr = templ->getPerUnitSound( "VoiceBombard" );
-				objectWithSound = obj;
-				skip = true;
-
-				if (TheAudio->isValidAudioEvent(soundToPlayPtr)) {
-					break;
-				} else {
-					// clear out the sound to play, and drop into the attack object logic.
-					soundToPlayPtr = NULL;
-				}
-			}
-			
 			case GameMessage::MSG_SWITCH_WEAPONS:
 			{
 				if( info && info->m_weaponSlot )
@@ -516,7 +502,21 @@ void pickAndPlayUnitVoiceResponse( const DrawableList *list, GameMessage::Type m
 				}
 				break;
 			}
-			
+
+			case GameMessage::MSG_DO_FORCE_ATTACK_GROUND:
+			{
+				soundToPlayPtr = templ->getPerUnitSound( "VoiceBombard" );
+				objectWithSound = obj;
+				skip = true;
+
+				if (TheAudio->isValidAudioEvent(soundToPlayPtr)) {
+					break;
+				} else {
+					// clear out the sound to play, and drop into the attack object logic.
+					soundToPlayPtr = NULL;
+					FALLTHROUGH;
+				}
+			}
 			case GameMessage::MSG_DO_FORCE_ATTACK_OBJECT:
 			case GameMessage::MSG_DO_ATTACK_OBJECT:
 			case GameMessage::MSG_DO_WEAPON_AT_OBJECT:


### PR DESCRIPTION
This change fixes the missing unit voice when attacking the ground due wrong fallthrough at switch case GameMessage::MSG_DO_FORCE_ATTACK_GROUND in pickAndPlayUnitVoiceResponse()

In the original game, units would not play their attack voice when attacking the ground, except for the USA Tomahawk because it uses the VoiceBombard audio.

This issue is caused by a wrong switch case setup. It was introduced by an original developer who incorrectly added the `case GameMessage::MSG_SWITCH_WEAPONS` between the case `GameMessage::MSG_DO_FORCE_ATTACK_GROUND` and `case GameMessage::MSG_DO_FORCE_ATTACK_OBJECT`.

## Fixed attack audio

https://github.com/user-attachments/assets/401aeefe-1f89-4de6-8f88-34260a98bbb6
