### PR TITLE
[GEN][ZH] Fix missing break at switch case REVERSESOUNDTRANSITION_FIRESOUND in ReverseSoundTransition::update()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GameWindowTransitionsStyles.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GameWindowTransitionsStyles.cpp
@@ -2027,8 +2027,9 @@ void ReverseSoundTransition::update( Int frame )
 			{
 				TheAudio->addAudioEvent( &buttonClick );
 			}  // end if		
-
 		}
+		break;
+
 	case REVERSESOUNDTRANSITION_END:
 		{
 			if(!m_isForward  )

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowTransitionsStyles.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowTransitionsStyles.cpp
@@ -2027,8 +2027,9 @@ void ReverseSoundTransition::update( Int frame )
 			{
 				TheAudio->addAudioEvent( &buttonClick );
 			}  // end if		
-
 		}
+		break;
+
 	case REVERSESOUNDTRANSITION_END:
 		{
 			if(!m_isForward  )


### PR DESCRIPTION
This change fixes a missing break at switch case REVERSESOUNDTRANSITION_FIRESOUND in ReverseSoundTransition::update()

I tested in a bunch of menus if this fall through would have caused side effects but it never reached `m_isFinished = TRUE;` when `frame==REVERSESOUNDTRANSITION_FIRESOUND`. So perhaps it caused no user facing audio issue.