### PR TITLE
[GEN][ZH] Fix missing break at switch case GEM_UPDATE_TEXT in PopupReplaySystem()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupReplay.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupReplay.cpp
@@ -476,6 +476,8 @@ WindowMsgHandledType PopupReplaySystem( GameWindow *window, UnsignedInt msg,
 					}
 				}
 			}
+
+			break;
 		}
 
 		default:

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupReplay.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupReplay.cpp
@@ -476,6 +476,8 @@ WindowMsgHandledType PopupReplaySystem( GameWindow *window, UnsignedInt msg,
 					}
 				}
 			}
+
+			break;
 		}
 
 		default:


### PR DESCRIPTION
This change fixes a missing break label at switch case GEM_UPDATE_TEXT in PopupReplaySystem()

I tested the replay save text update (in front of the LAN ScoreScreen) and it worked fine before and after this change, so this appears to have had no user facing issue.

![shot_20250619_121949_1](https://github.com/user-attachments/assets/2280f907-8a59-44ea-b8bc-76a98896207d)
