### PR TITLE
[GEN][ZH] Fix missing break at switch case GSM_SLIDER_TRACK in SkirmishGameOptionsMenuSystem()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishGameOptionsMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishGameOptionsMenu.cpp
@@ -1504,6 +1504,7 @@ WindowMsgHandledType SkirmishGameOptionsMenuSystem( GameWindow *window, Unsigned
 			{
 				setFPSTextBox(sliderPos);
 			}
+			break;
 		}
 		//-------------------------------------------------------------------------------------------------
 		case GBM_SELECTED:

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishGameOptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishGameOptionsMenu.cpp
@@ -1644,6 +1644,7 @@ WindowMsgHandledType SkirmishGameOptionsMenuSystem( GameWindow *window, Unsigned
 			{
 				setFPSTextBox(sliderPos);
 			}
+			break;
 		}
 		//-------------------------------------------------------------------------------------------------
 		case GBM_SELECTED:


### PR DESCRIPTION
This change fixes a missing break label at switch case GSM_SLIDER_TRACK in SkirmishGameOptionsMenuSystem()

The fall through was practically inconsequential because there were no bad side effects.