### PR TITLE
[GEN][ZH] Fix unannotated fallthrough at switch case GameMessage::MSG_DEFECTOR_HINT in HintSpyTranslator::translateGameMessage()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/HintSpy.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/HintSpy.cpp
@@ -64,9 +64,6 @@ GameMessageDisposition HintSpyTranslator::translateGameMessage(const GameMessage
 
 		//-----------------------------------------------------------------------------
 		case GameMessage::MSG_DEFECTOR_HINT:
-
-			disp = DESTROY_MESSAGE; //hint no longer needed by anyone.  Eat it.
-
 		case GameMessage::MSG_DO_MOVETO_HINT:
 		case GameMessage::MSG_DO_ATTACKMOVETO_HINT:
 		case GameMessage::MSG_DO_ATTACK_OBJECT_HINT:

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/HintSpy.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/HintSpy.cpp
@@ -64,9 +64,6 @@ GameMessageDisposition HintSpyTranslator::translateGameMessage(const GameMessage
 
 		//-----------------------------------------------------------------------------
 		case GameMessage::MSG_DEFECTOR_HINT:
-
-			disp = DESTROY_MESSAGE; //hint no longer needed by anyone.  Eat it.
-
 		case GameMessage::MSG_DO_MOVETO_HINT:
 		case GameMessage::MSG_DO_ATTACKMOVETO_HINT:
 		case GameMessage::MSG_DO_ATTACK_OBJECT_HINT:


### PR DESCRIPTION
This change fixes the unannotated fallthrough at switch case GameMessage::MSG_DEFECTOR_HINT in HintSpyTranslator::translateGameMessage()