### PR TITLE
[GEN][ZH] Fix missing break at switch case GameMessage::MSG_DO_SPECIAL_POWER_OVERRIDE_DESTINATION in GameLogic::logicMessageDispatcher()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -1173,7 +1173,10 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 					currentlySelectedGroup->groupOverrideSpecialPowerDestination( spType, loc, CMD_FROM_PLAYER );
 				}
 			}
-		}
+
+			break;
+
+		}  // end GameMessage::MSG_DO_SPECIAL_POWER_OVERRIDE_DESTINATION
 
 		//---------------------------------------------------------------------------------------------
 		case GameMessage::MSG_DO_ATTACK_OBJECT:
@@ -1195,7 +1198,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 
 			break;
 
-		}  // end GameMessage::MSG_DO_ATTACK_GROUND_OBJECT
+		}  // end GameMessage::MSG_DO_ATTACK_OBJECT
 
 		//---------------------------------------------------------------------------------------------
 		case GameMessage::MSG_DO_FORCE_ATTACK_OBJECT:
@@ -1215,7 +1218,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 
 			break;
 
-		}  // end GameMessage::MSG_DO_ATTACK_GROUND_OBJECT
+		}  // end GameMessage::MSG_DO_FORCE_ATTACK_OBJECT
 
 		//---------------------------------------------------------------------------------------------
 		case GameMessage::MSG_DO_FORCE_ATTACK_GROUND:
@@ -1254,7 +1257,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 
 			break;
 
-		}  // end GameMessage::MSG_DO_ATTACK_GROUND_OBJECT
+		}  // end GameMessage::MSG_DO_FORCE_ATTACK_GROUND
 
 		//---------------------------------------------------------------------------------------------
 		case GameMessage::MSG_QUEUE_UPGRADE:

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -1201,7 +1201,10 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 					currentlySelectedGroup->groupOverrideSpecialPowerDestination( spType, loc, CMD_FROM_PLAYER );
 				}
 			}
-		}
+
+			break;
+
+		}  // end GameMessage::MSG_DO_SPECIAL_POWER_OVERRIDE_DESTINATION
 
 		//---------------------------------------------------------------------------------------------
 		case GameMessage::MSG_DO_ATTACK_OBJECT:
@@ -1223,7 +1226,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 
 			break;
 
-		}  // end GameMessage::MSG_DO_ATTACK_GROUND_OBJECT
+		}  // end GameMessage::MSG_DO_ATTACK_OBJECT
 
 		//---------------------------------------------------------------------------------------------
 		case GameMessage::MSG_DO_FORCE_ATTACK_OBJECT:
@@ -1243,7 +1246,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 
 			break;
 
-		}  // end GameMessage::MSG_DO_ATTACK_GROUND_OBJECT
+		}  // end GameMessage::MSG_DO_FORCE_ATTACK_OBJECT
 
 		//---------------------------------------------------------------------------------------------
 		case GameMessage::MSG_DO_FORCE_ATTACK_GROUND:
@@ -1282,7 +1285,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 
 			break;
 
-		}  // end GameMessage::MSG_DO_ATTACK_GROUND_OBJECT
+		}  // end GameMessage::MSG_DO_FORCE_ATTACK_GROUND
 
 		//---------------------------------------------------------------------------------------------
 		case GameMessage::MSG_QUEUE_UPGRADE:


### PR DESCRIPTION
- Closes: https://github.com/TheSuperHackers/GeneralsGameCode/issues/638

This change fixes a missing break label at switch case GameMessage::MSG_DO_SPECIAL_POWER_OVERRIDE_DESTINATION in GameLogic::logicMessageDispatcher()

The fall through was practically inconsequential because there were no bad side effects. Only the Particle Cannon's movable laser is using this GameMessage and when it falls through the enemy pointer will be null and nothing bad happens in the wrong case.

![image](https://github.com/user-attachments/assets/9a8ae185-d3d2-4557-86a6-01724c0d28ec)
