### PR TITLE
[GEN][ZH] Fix wrong returned name for D3DTSS_TEXTURETRANSFORMFLAGS in DX8Wrapper::Get_DX8_Texture_Stage_State_Value_Name()

### DIFF
--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
@@ -3397,6 +3397,7 @@ void DX8Wrapper::Get_DX8_Texture_Stage_State_Value_Name(StringClass& name, D3DTE
 
 	case D3DTSS_TEXTURETRANSFORMFLAGS:
 		name=Get_DX8_Texture_Transform_Flag_Name(value);
+		break;
 
 	// Floating point values
 	case D3DTSS_MIPMAPLODBIAS:

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
@@ -4182,6 +4182,7 @@ void DX8Wrapper::Get_DX8_Texture_Stage_State_Value_Name(StringClass& name, D3DTE
 
 	case D3DTSS_TEXTURETRANSFORMFLAGS:
 		name=Get_DX8_Texture_Transform_Flag_Name(value);
+		break;
 
 	// Floating point values
 	case D3DTSS_MIPMAPLODBIAS:


### PR DESCRIPTION
This change fixes a wrong returned name for D3DTSS_TEXTURETRANSFORMFLAGS in DX8Wrapper::Get_DX8_Texture_Stage_State_Value_Name() because of a missing break label.

This affects some debug logging and is not important.