### PR TITLE
[GEN][ZH] Fix missing break at switch case GWM_INPUT_FOCUS in IdleWorkerSystem()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5528,6 +5528,8 @@ WindowMsgHandledType IdleWorkerSystem( GameWindow *window, UnsignedInt msg,
 			// if we're givin the opportunity to take the keyboard focus we must say we don't want it
 			if( mData1 == TRUE )
 				*(Bool *)mData2 = FALSE;
+			break;
+
 		}
 		//---------------------------------------------------------------------------------------------
 		case GBM_SELECTED:

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5700,6 +5700,8 @@ WindowMsgHandledType IdleWorkerSystem( GameWindow *window, UnsignedInt msg,
 			// if we're givin the opportunity to take the keyboard focus we must say we don't want it
 			if( mData1 == TRUE )
 				*(Bool *)mData2 = FALSE;
+			break;
+
 		}
 		//---------------------------------------------------------------------------------------------
 		case GBM_SELECTED:


### PR DESCRIPTION
This change fixes a missing break label at switch case GWM_INPUT_FOCUS in IdleWorkerSystem()

The fall through would be catastrophic when trying to use `mData1` as a pointer, but this is practically inconsequential because the `IdleWorkerSystem` is not used in the game. The Idle Worker is part of the Control Bar instead.