### PR TITLE
[GEN][ZH] Suppress warning for dereferencing NULL pointer 'otherNeighbor' in W3DVolumetricShadow::buildSilhouette()

### DIFF
--- a/Dependencies/Utility/Utility/CppMacros.h
+++ b/Dependencies/Utility/Utility/CppMacros.h
@@ -25,6 +25,12 @@
 #define NOEXCEPT_17
 #endif
 
+#if __cplusplus >= 202302L
+#define ASSUME(c) [[assume(c)]]
+#else
+#define ASSUME(c)
+#endif
+
 // noexcept for methods of IUNKNOWN interface
 #if defined(_MSC_VER)
 #define IUNKNOWN_NOEXCEPT NOEXCEPT_17

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp
@@ -2336,6 +2336,7 @@ void W3DVolumetricShadow::buildSilhouette(Int meshIndex, Vector3 *lightPosObject
 					geomMesh->GetPolyNeighbor( 
 						polyNeighbor->neighbor[ j ].neighborIndex );
 
+				ASSUME(otherNeighbor != NULL);
 				//
 				// ignore neighbors that are marked as processed as those
 				// onces have already detected edges if present

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp
@@ -2480,6 +2480,7 @@ void W3DVolumetricShadow::buildSilhouette(Int meshIndex, Vector3 *lightPosObject
 					geomMesh->GetPolyNeighbor( 
 						polyNeighbor->neighbor[ j ].neighborIndex );
 
+				ASSUME(otherNeighbor != NULL);
 				//
 				// ignore neighbors that are marked as processed as those
 				// onces have already detected edges if present


### PR DESCRIPTION
This change suppresses a compiler warning for dereferencing NULL pointer 'otherNeighbor' in W3DVolumetricShadow::buildSilhouette()

This would only work in c++23 (untested). It is done this way to help the compiler understand what the expectation is.

> GeneralsMD\Code\GameEngineDevice\Source\W3DDevice\GameClient\Shadow\W3DVolumetricShadow.cpp(2487): warning C6011: Dereferencing NULL pointer 'otherNeighbor'.