### PR TITLE
[GEN][ZH] Prevent using uninitialized memory 'closestVec' in PartitionManager::getClosestObjects()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
@@ -3231,6 +3231,11 @@ Object *PartitionManager::getClosestObjects(
 	Object* closestObj = NULL;
 	Real closestDistSqr = maxDist * maxDist;	// if it's not closer than this, we shouldn't consider it anyway...
 	Coord3D closestVec;
+#if !RETAIL_COMPATIBLE_CRC // TheSuperHackers @info This should be safe to initialize because it is unused, but let us be extra safe for now.
+	closestVec.x = maxDist;
+	closestVec.y = maxDist;
+	closestVec.z = maxDist;
+#endif
 
 #ifdef FASTER_GCO
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
@@ -3264,6 +3264,11 @@ Object *PartitionManager::getClosestObjects(
 	Object* closestObj = NULL;
 	Real closestDistSqr = maxDist * maxDist;	// if it's not closer than this, we shouldn't consider it anyway...
 	Coord3D closestVec;
+#if !RETAIL_COMPATIBLE_CRC // TheSuperHackers @info This should be safe to initialize because it is unused, but let us be extra safe for now.
+	closestVec.x = maxDist;
+	closestVec.y = maxDist;
+	closestVec.z = maxDist;
+#endif
 
 #ifdef FASTER_GCO
 


### PR DESCRIPTION
This change prevents using uninitialized memory 'closestVec' in PartitionManager::getClosestObjects() and makes the compiler happy.

I looked at all users of this function and found none that actually uses the `closestVecArg` output argument. So this appears to be inconsequential, but I wrapped it into !RETAIL_COMPATIBLE_CRC anyway to play it safe.

> GeneralsMD\Code\GameEngine\Source\GameLogic\Object\PartitionManager.cpp(3435): warning C6001: Using uninitialized memory 'closestVec'.