### PR TITLE
[CMAKE] Enable multithreaded compilation for VC6 builds

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -48,9 +48,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: build\${{ inputs.preset }}\_deps
-          key: cmake-deps-${{ inputs.preset }}-${{ hashFiles('cmake/**/*.cmake', '**/CMakeLists.txt') }}
-          restore-keys: |
-            cmake-deps-${{ inputs.preset }}-
+          key: cmake-deps-${{ inputs.preset }}-${{ hashFiles('CMakePresets.json','cmake/**/*.cmake','**/CMakeLists.txt') }}
 
       - name: Download VC6 Portable from Cloudflare R2
         if: ${{ startsWith(inputs.preset, 'vc6') && steps.cache-vc6.outputs.cache-hit != 'true' }}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -9,13 +9,13 @@
         {
             "name": "vc6",
             "displayName": "Windows 32bit VC6 Release",
-            "generator": "NMake Makefiles",
+            "generator": "Ninja",
             "hidden": false,
             "binaryDir": "${sourceDir}/build/${presetName}",
             "cacheVariables": {
                 "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
                 "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL",
-                "CMAKE_MSVC_DEBUG_INFORMATION_FORMAT": "$<$<CONFIG:Release,Debug,RelWithDebInfo>:ProgramDatabase>",
+                "CMAKE_MSVC_DEBUG_INFORMATION_FORMAT": "",
                 "CMAKE_BUILD_TYPE": "Release",
                 "RTS_FLAGS": "/W3"
             },

--- a/cmake/compilers.cmake
+++ b/cmake/compilers.cmake
@@ -36,6 +36,13 @@ if (NOT IS_VS6_BUILD)
         # Enforce strict __cplusplus version
         add_compile_options(/Zc:__cplusplus)
     endif()
+else()
+    # Define two pools: 'compile' with plenty of slots, 'link' with just one
+    set_property(GLOBAL PROPERTY JOB_POOLS compile=0 link=1)
+    # Tell CMake that all compile steps go into 'compile'
+    set(CMAKE_JOB_POOL_COMPILE compile)
+    # and all link steps go into 'link' (so only one link ever runs since vc6 can't handle multithreaded linking)
+    set(CMAKE_JOB_POOL_LINK link)
 endif()
 
 if(RTS_BUILD_OPTION_ASAN)


### PR DESCRIPTION
~~Created a custom cmake toolchain file for using the vc6 compiler with the ninja generator~~

Switching from nmake to multithreaded ninja reduces compile times by an order of magnitude