### PR TITLE
[GEN][ZH] Add TheSuperHackers version to options screen

### DIFF
--- a/Generals/Code/GameEngine/CMakeLists.txt
+++ b/Generals/Code/GameEngine/CMakeLists.txt
@@ -1077,6 +1077,7 @@ target_include_directories(g_gameengine PUBLIC
 
 target_include_directories(g_gameengine PRIVATE
     Include/Precompiled
+    ${CMAKE_BINARY_DIR}/Generals/Code/Main
 )
 
 target_link_libraries(g_gameengine PRIVATE

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -40,6 +40,7 @@
 #include "Common/GameLOD.h"
 #include "Common/Registry.h"
 #include "Common/version.h"
+#include "GeneratedVersion.h"
 
 #include "GameClient/ClientInstance.h"
 #include "GameClient/GameClient.h"
@@ -1440,7 +1441,9 @@ void OptionsMenuInit( WindowLayout *layout, void *userData )
 	}
 	else
 	{
-		GadgetStaticTextSetText( labelVersion, versionString );
+		UnicodeString fullVersion;
+		fullVersion.format(L"%s - TheSuperHackers %s", versionString.str(), SUPERHACKERS_VERSION_WIDE);
+		GadgetStaticTextSetText(labelVersion, fullVersion);
 	}
 
 

--- a/Generals/Code/Main/CMakeLists.txt
+++ b/Generals/Code/Main/CMakeLists.txt
@@ -24,13 +24,33 @@ target_link_libraries(g_generals PRIVATE
     winmm
 )
 
+if(EXISTS "${CMAKE_SOURCE_DIR}/next_tag.txt")
+    file(READ "${CMAKE_SOURCE_DIR}/next_tag.txt" GAME_VERSION)
+    string(STRIP "${GAME_VERSION}" GAME_VERSION)
+    string(REGEX MATCH "^([0-9]+)\\.([0-9]+)\\.([0-9]+)" _ "${GAME_VERSION}")
+    set(VERSION_MAJOR "${CMAKE_MATCH_1}")
+    set(VERSION_MINOR "${CMAKE_MATCH_2}")
+    set(VERSION_BUILDNUM "${CMAKE_MATCH_3}")
+else()
+    set(GAME_VERSION "")
+    if (IS_VS6_BUILD)
+        set(VERSION_MAJOR "1")
+        set(VERSION_MINOR "7")
+        set(VERSION_BUILDNUM "601")
+    else()
+        set(VERSION_MAJOR "1")
+        set(VERSION_MINOR "8")
+        set(VERSION_BUILDNUM "601")
+    endif()
+endif()
+
 # TODO Originally referred to build host and user, replace with git info perhaps?
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/GeneratedVersion.h
 "#pragma once
 
-#define VERSION_LOCALBUILDNUM 0
-#define VERSION_BUILDUSER \"Someone\"
-#define VERSION_BUILDLOC \"Someplace\"
+#define VERSION_BUILDUSER \"TheSuperHackers\"
+#define VERSION_BUILDLOC \"GitHub\"
+#define SUPERHACKERS_VERSION_WIDE L\"${GAME_VERSION}\"
 "
 )
 
@@ -39,18 +59,20 @@ if (IS_VS6_BUILD)
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/BuildVersion.h
 "#pragma once
 
-#define VERSION_MAJOR 1
-#define VERSION_MINOR 7
-#define VERSION_BUILDNUM 601
+#define VERSION_MAJOR ${VERSION_MAJOR}
+#define VERSION_MINOR ${VERSION_MINOR}
+#define VERSION_BUILDNUM ${VERSION_BUILDNUM}
+#define VERSION_LOCALBUILDNUM 9001 // it's over 9000!
 "
 )
 else()
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/BuildVersion.h
 "#pragma once
 
-#define VERSION_MAJOR 1
-#define VERSION_MINOR 8
-#define VERSION_BUILDNUM 601
+#define VERSION_MAJOR ${VERSION_MAJOR}
+#define VERSION_MINOR ${VERSION_MINOR}
+#define VERSION_BUILDNUM ${VERSION_BUILDNUM}
+#define VERSION_LOCALBUILDNUM 602
 "
 )
 endif()

--- a/GeneralsMD/Code/GameEngine/CMakeLists.txt
+++ b/GeneralsMD/Code/GameEngine/CMakeLists.txt
@@ -1156,6 +1156,7 @@ target_include_directories(z_gameengine PUBLIC
 
 target_include_directories(z_gameengine PRIVATE
     Include/Precompiled
+    ${CMAKE_BINARY_DIR}/GeneralsMD/Code/Main
 )
 
 target_link_libraries(z_gameengine PRIVATE

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -40,6 +40,7 @@
 #include "Common/GameLOD.h"
 #include "Common/Registry.h"
 #include "Common/version.h"
+#include "GeneratedVersion.h"
 
 #include "GameClient/ClientInstance.h"
 #include "GameClient/GameClient.h"
@@ -1506,7 +1507,9 @@ void OptionsMenuInit( WindowLayout *layout, void *userData )
 	}
 	else
 	{
-		GadgetStaticTextSetText( labelVersion, versionString );
+		UnicodeString fullVersion;
+		fullVersion.format(L"%s - TheSuperHackers %s", versionString.str(), SUPERHACKERS_VERSION_WIDE);
+		GadgetStaticTextSetText(labelVersion, fullVersion);
 	}
 
 

--- a/GeneralsMD/Code/Main/CMakeLists.txt
+++ b/GeneralsMD/Code/Main/CMakeLists.txt
@@ -26,13 +26,27 @@ target_link_libraries(z_generals PRIVATE
     zi_always
 )
 
+if(EXISTS "${CMAKE_SOURCE_DIR}/next_tag.txt")
+    file(READ "${CMAKE_SOURCE_DIR}/next_tag.txt" GAME_VERSION)
+    string(STRIP "${GAME_VERSION}" GAME_VERSION)
+    string(REGEX MATCH "^([0-9]+)\\.([0-9]+)\\.([0-9]+)" _ "${GAME_VERSION}")
+    set(VERSION_MAJOR "${CMAKE_MATCH_1}")
+    set(VERSION_MINOR "${CMAKE_MATCH_2}")
+    set(VERSION_BUILDNUM "${CMAKE_MATCH_3}")
+else()
+    set(GAME_VERSION "")
+    set(VERSION_MAJOR "1")
+    set(VERSION_MINOR "4")
+    set(VERSION_BUILDNUM "601")
+endif()
+
 # TODO Originally referred to build host and user, replace with git info perhaps?
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/GeneratedVersion.h
 "#pragma once
 
-#define VERSION_LOCALBUILDNUM 0
-#define VERSION_BUILDUSER \"Someone\"
-#define VERSION_BUILDLOC \"Someplace\"
+#define VERSION_BUILDUSER \"TheSuperHackers\"
+#define VERSION_BUILDLOC \"GitHub\"
+#define SUPERHACKERS_VERSION_WIDE L\"${GAME_VERSION}\"
 "
 )
 
@@ -40,9 +54,10 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/GeneratedVersion.h
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/BuildVersion.h
 "#pragma once
 
-#define VERSION_MAJOR 1
-#define VERSION_MINOR 4
-#define VERSION_BUILDNUM 601
+#define VERSION_MAJOR ${VERSION_MAJOR}
+#define VERSION_MINOR ${VERSION_MINOR}
+#define VERSION_BUILDNUM ${VERSION_BUILDNUM}
+#define VERSION_LOCALBUILDNUM 9001 // it's over 9000!
 "
 )
 


### PR DESCRIPTION
This PR complements https://github.com/TheSuperHackers/GeneralsGameCode/pull/929 and its related to ISSUE https://github.com/TheSuperHackers/GeneralsGameCode/issues/1010

What this PR does?

Reads the file `next_tag.txt` generated by [ci process](https://github.com/TheSuperHackers/GeneralsGameCode/pull/929/files#diff-eb9efb0587ee039e45385fc42bb8ab27e4fa1636e43175d8305e5f5ca8d35ff2R85) and add it to options screen.

If the file does not exists by the build process, GAME_VERSION variable will be set to a blank and will add just "TheSuperHackers" to the game version in options screen.

<img width="816" alt="image" src="https://github.com/user-attachments/assets/08c9c47e-97c6-4bf8-89c7-308cfda1182d" />


