### PR TITLE
[GEN][ZH] Assign missing player index to the unable-to-set-rally-point audio event

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -166,6 +166,7 @@ static void doSetRallyPoint( Object *obj, const Coord3D& pos )
 			// play the no can do sound
 			static AudioEventRTS rallyNotSet("UnableToSetRallyPoint");
 			rallyNotSet.setPosition(&pos);
+			rallyNotSet.setPlayerIndex(obj->getControllingPlayer()->getPlayerIndex());
 			TheAudio->addAudioEvent(&rallyNotSet);
 
 		}  // end if

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -167,6 +167,7 @@ static void doSetRallyPoint( Object *obj, const Coord3D& pos )
 			// play the no can do sound
 			static AudioEventRTS rallyNotSet("UnableToSetRallyPoint");
 			rallyNotSet.setPosition(&pos);
+			rallyNotSet.setPlayerIndex(obj->getControllingPlayer()->getPlayerIndex());
 			TheAudio->addAudioEvent(&rallyNotSet);
 
 		}  // end if


### PR DESCRIPTION
The `UnableToSetRallyPoint` audio event cannot be heard because its player index is unassigned. This is now rectified and the logic matches the `RallyPointSet` audio event. This is a user-facing change - the player will now correctly hear the ['invalid action' sound when a rally point placement fails](https://github.com/user-attachments/assets/795aba27-4214-41ea-93ac-9b8afefaeb39), similarly to when a building placement fails.

Audio events that do not specify an owning player are not expected to be valid.
```
if (owningPlayer == NULL) {
    DEBUG_CRASH(("Sound '%s' expects an owning player, but the audio event that created it didn't specify one.\n", ei->m_audioName.str()));
    return FALSE;
}
```