### PR TITLE
[GEN][ZH] Fix beacon mouse cursor not showing while nothing is selected

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -1393,7 +1393,8 @@ GameMessage::Type CommandTranslator::evaluateContextCommand( Drawable *draw,
 	// Kris: Now that we can select non-controllable units/structures, don't allow any actions to be performed.
 	const CommandButton *command = TheInGameUI->getGUICommand();
 	if( TheInGameUI->areSelectedObjectsControllable() 
-			|| (command && command->getCommandType() == GUI_COMMAND_SPECIAL_POWER_FROM_COMMAND_CENTER))
+			|| (command && (command->getCommandType() == GUI_COMMAND_SPECIAL_POWER_FROM_COMMAND_CENTER
+			|| command->getCommandType() == GUICOMMANDMODE_PLACE_BEACON)))
 	{
 		GameMessage *hintMessage;
 
@@ -1421,7 +1422,8 @@ GameMessage::Type CommandTranslator::evaluateContextCommand( Drawable *draw,
 		if(command && 
 			(command->isContextCommand() 
 				|| command->getCommandType() == GUI_COMMAND_SPECIAL_POWER
-				|| command->getCommandType() == GUI_COMMAND_SPECIAL_POWER_FROM_COMMAND_CENTER))
+				|| command->getCommandType() == GUI_COMMAND_SPECIAL_POWER_FROM_COMMAND_CENTER
+				|| command->getCommandType() == GUICOMMANDMODE_PLACE_BEACON))
 		{
 			if( obj && obj->isKindOf( KINDOF_SHRUBBERY ) && !BitIsSet( command->getOptions(), ALLOW_SHRUBBERY_TARGET ) )
 			{
@@ -1492,6 +1494,9 @@ GameMessage::Type CommandTranslator::evaluateContextCommand( Drawable *draw,
 					currentlyValid = TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_PICK_UP_PRISONER, obj, InGameUI::SELECTION_ANY );
 					break;
 #endif
+				case GUICOMMANDMODE_PLACE_BEACON:
+					currentlyValid = true;
+					break;
 				case GUI_COMMAND_SPECIAL_POWER_FROM_COMMAND_CENTER:
 				{
 					Object* cmdCenter = ThePlayerList->getLocalPlayer()->findNaturalCommandCenter();

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -1392,9 +1392,14 @@ GameMessage::Type CommandTranslator::evaluateContextCommand( Drawable *draw,
 
 	// Kris: Now that we can select non-controllable units/structures, don't allow any actions to be performed.
 	const CommandButton *command = TheInGameUI->getGUICommand();
-	if( TheInGameUI->areSelectedObjectsControllable() 
-			|| (command && (command->getCommandType() == GUI_COMMAND_SPECIAL_POWER_FROM_COMMAND_CENTER
-			|| command->getCommandType() == GUICOMMANDMODE_PLACE_BEACON)))
+
+	if (command && command->getCommandType() == GUICOMMANDMODE_PLACE_BEACON)
+	{
+		msgType = GameMessage::MSG_VALID_GUICOMMAND_HINT;
+		TheMessageStream->appendMessage(msgType);
+	}
+	else if( TheInGameUI->areSelectedObjectsControllable() 
+			|| (command && command->getCommandType() == GUI_COMMAND_SPECIAL_POWER_FROM_COMMAND_CENTER))
 	{
 		GameMessage *hintMessage;
 
@@ -1422,8 +1427,7 @@ GameMessage::Type CommandTranslator::evaluateContextCommand( Drawable *draw,
 		if(command && 
 			(command->isContextCommand() 
 				|| command->getCommandType() == GUI_COMMAND_SPECIAL_POWER
-				|| command->getCommandType() == GUI_COMMAND_SPECIAL_POWER_FROM_COMMAND_CENTER
-				|| command->getCommandType() == GUICOMMANDMODE_PLACE_BEACON))
+				|| command->getCommandType() == GUI_COMMAND_SPECIAL_POWER_FROM_COMMAND_CENTER))
 		{
 			if( obj && obj->isKindOf( KINDOF_SHRUBBERY ) && !BitIsSet( command->getOptions(), ALLOW_SHRUBBERY_TARGET ) )
 			{
@@ -1494,9 +1498,6 @@ GameMessage::Type CommandTranslator::evaluateContextCommand( Drawable *draw,
 					currentlyValid = TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_PICK_UP_PRISONER, obj, InGameUI::SELECTION_ANY );
 					break;
 #endif
-				case GUICOMMANDMODE_PLACE_BEACON:
-					currentlyValid = true;
-					break;
 				case GUI_COMMAND_SPECIAL_POWER_FROM_COMMAND_CENTER:
 				{
 					Object* cmdCenter = ThePlayerList->getLocalPlayer()->findNaturalCommandCenter();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -1474,9 +1474,14 @@ GameMessage::Type CommandTranslator::evaluateContextCommand( Drawable *draw,
 
 	// Kris: Now that we can select non-controllable units/structures, don't allow any actions to be performed.
 	const CommandButton *command = TheInGameUI->getGUICommand();
-	if( TheInGameUI->areSelectedObjectsControllable() 
-			|| (command && (command->getCommandType() == GUI_COMMAND_SPECIAL_POWER_FROM_SHORTCUT
-			|| command->getCommandType() == GUICOMMANDMODE_PLACE_BEACON)))
+
+	if (command && command->getCommandType() == GUICOMMANDMODE_PLACE_BEACON)
+	{
+		msgType = GameMessage::MSG_VALID_GUICOMMAND_HINT;
+		TheMessageStream->appendMessage(msgType);
+	}
+	else if( TheInGameUI->areSelectedObjectsControllable() 
+			|| (command && command->getCommandType() == GUI_COMMAND_SPECIAL_POWER_FROM_SHORTCUT))
 	{
 		GameMessage *hintMessage;
 
@@ -1504,8 +1509,7 @@ GameMessage::Type CommandTranslator::evaluateContextCommand( Drawable *draw,
 		if(command && 
 			(command->isContextCommand() 
 				|| command->getCommandType() == GUI_COMMAND_SPECIAL_POWER
-				|| command->getCommandType() == GUI_COMMAND_SPECIAL_POWER_FROM_SHORTCUT
-				|| command->getCommandType() == GUICOMMANDMODE_PLACE_BEACON))
+				|| command->getCommandType() == GUI_COMMAND_SPECIAL_POWER_FROM_SHORTCUT))
 		{
 			if( obj && obj->isKindOf( KINDOF_SHRUBBERY ) && !BitIsSet( command->getOptions(), ALLOW_SHRUBBERY_TARGET ) )
 			{
@@ -1579,9 +1583,6 @@ GameMessage::Type CommandTranslator::evaluateContextCommand( Drawable *draw,
 					currentlyValid = TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_PICK_UP_PRISONER, obj, InGameUI::SELECTION_ANY );
 					break;
 #endif
-				case GUICOMMANDMODE_PLACE_BEACON:
-					currentlyValid = true;
-					break;
 				case GUI_COMMAND_SPECIAL_POWER_FROM_SHORTCUT:
 				{
 					Object* unit = ThePlayerList->getLocalPlayer()->findMostReadyShortcutSpecialPowerOfType( command->getSpecialPowerTemplate()->getSpecialPowerType() );

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -1475,7 +1475,8 @@ GameMessage::Type CommandTranslator::evaluateContextCommand( Drawable *draw,
 	// Kris: Now that we can select non-controllable units/structures, don't allow any actions to be performed.
 	const CommandButton *command = TheInGameUI->getGUICommand();
 	if( TheInGameUI->areSelectedObjectsControllable() 
-			|| (command && command->getCommandType() == GUI_COMMAND_SPECIAL_POWER_FROM_SHORTCUT))
+			|| (command && (command->getCommandType() == GUI_COMMAND_SPECIAL_POWER_FROM_SHORTCUT
+			|| command->getCommandType() == GUICOMMANDMODE_PLACE_BEACON)))
 	{
 		GameMessage *hintMessage;
 
@@ -1503,7 +1504,8 @@ GameMessage::Type CommandTranslator::evaluateContextCommand( Drawable *draw,
 		if(command && 
 			(command->isContextCommand() 
 				|| command->getCommandType() == GUI_COMMAND_SPECIAL_POWER
-				|| command->getCommandType() == GUI_COMMAND_SPECIAL_POWER_FROM_SHORTCUT))
+				|| command->getCommandType() == GUI_COMMAND_SPECIAL_POWER_FROM_SHORTCUT
+				|| command->getCommandType() == GUICOMMANDMODE_PLACE_BEACON))
 		{
 			if( obj && obj->isKindOf( KINDOF_SHRUBBERY ) && !BitIsSet( command->getOptions(), ALLOW_SHRUBBERY_TARGET ) )
 			{
@@ -1577,6 +1579,9 @@ GameMessage::Type CommandTranslator::evaluateContextCommand( Drawable *draw,
 					currentlyValid = TheInGameUI->canSelectedObjectsDoAction( InGameUI::ACTIONTYPE_PICK_UP_PRISONER, obj, InGameUI::SELECTION_ANY );
 					break;
 #endif
+				case GUICOMMANDMODE_PLACE_BEACON:
+					currentlyValid = true;
+					break;
 				case GUI_COMMAND_SPECIAL_POWER_FROM_SHORTCUT:
 				{
 					Object* unit = ThePlayerList->getLocalPlayer()->findMostReadyShortcutSpecialPowerOfType( command->getSpecialPowerTemplate()->getSpecialPowerType() );


### PR DESCRIPTION
Fixes #1174

The mouse cursor now correctly changes to its beacon placement state when the user is in a beacon placement context _without requiring an object to be selected_.

https://github.com/user-attachments/assets/7220b622-1db9-403b-a9d3-9394f5b9d3c0

This is achieved by adding a case to allow a `MSG_VALID_GUICOMMAND_HINT` message to be returned from `CommandXlat` when the user is in a beacon placement context, which is then received by the `HintSpyTranslator` and sent to the `InGameUI` where the cursor is appropriately updated.