### PR TITLE
[GEN][ZH] Fix ThingTemplate override copy to prevent mismatch with mod map and quickstart

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/ThingTemplate.h
+++ b/Generals/Code/GameEngine/Include/Common/ThingTemplate.h
@@ -369,6 +369,9 @@ public:
 	// copy the guts of that into this, but preserve this' name, id, and list-links.
 	void copyFrom(const ThingTemplate* that);
 
+	// clear data that's only valid for the 'parent' template but not the override.
+	void clearOnNewOverride();
+
 	/// called by ThingFactory after all templates have been loaded.
 	void resolveNames();
 

--- a/Generals/Code/GameEngine/Source/Common/Thing/ThingFactory.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Thing/ThingFactory.cpp
@@ -194,6 +194,9 @@ ThingTemplate* ThingFactory::newOverride( ThingTemplate *thingTemplate )
 	newTemplate->markAsOverride();
 	child->setNextOverride(newTemplate);
 
+	// TheSuperHackers @bugfix Caball009 25/06/2025 Clear data that was valid for the 'parent' template but not for the override.
+	newTemplate->clearOnNewOverride();
+
 	// return the newly created override for us to set values with etc
 	return newTemplate;
 

--- a/Generals/Code/GameEngine/Source/Common/Thing/ThingTemplate.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Thing/ThingTemplate.cpp
@@ -1094,6 +1094,14 @@ void ThingTemplate::copyFrom(const ThingTemplate* that)
 }
 
 //-------------------------------------------------------------------------------------------------
+void ThingTemplate::clearOnNewOverride()
+{
+	// TheSuperHackers @info Clear containers that may contain pointers to data in the 'parent' template for memoization purposes.
+	m_weaponTemplateSetFinder.clear();
+	m_armorTemplateSetFinder.clear();
+}
+
+//-------------------------------------------------------------------------------------------------
 void ThingTemplate::setCopiedFromDefault()
 {
 	m_armorCopiedFromDefault = true;

--- a/GeneralsMD/Code/GameEngine/Include/Common/ThingTemplate.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/ThingTemplate.h
@@ -369,6 +369,9 @@ public:
 	// copy the guts of that into this, but preserve this' name, id, and list-links.
 	void copyFrom(const ThingTemplate* that);
 
+	// clear data that's only valid for the 'parent' template but not the override.
+	void clearOnNewOverride();
+
 	/// called by ThingFactory after all templates have been loaded.
 	void resolveNames();
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/Thing/ThingFactory.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Thing/ThingFactory.cpp
@@ -194,6 +194,9 @@ ThingTemplate* ThingFactory::newOverride( ThingTemplate *thingTemplate )
 	newTemplate->markAsOverride();
 	child->setNextOverride(newTemplate);
 
+	// TheSuperHackers @bugfix Caball009 25/06/2025 Clear data that was valid for the 'parent' template but not for the override.
+	newTemplate->clearOnNewOverride();
+
 	// return the newly created override for us to set values with etc
 	return newTemplate;
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/Thing/ThingTemplate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Thing/ThingTemplate.cpp
@@ -1233,6 +1233,14 @@ void ThingTemplate::copyFrom(const ThingTemplate* that)
 }
 
 //-------------------------------------------------------------------------------------------------
+void ThingTemplate::clearOnNewOverride()
+{
+	// TheSuperHackers @info Clear containers that may contain pointers to data in the 'parent' template for memoization purposes.
+	m_weaponTemplateSetFinder.clear();
+	m_armorTemplateSetFinder.clear();
+}
+
+//-------------------------------------------------------------------------------------------------
 void ThingTemplate::setCopiedFromDefault()
 {
 	m_armorCopiedFromDefault = true;


### PR DESCRIPTION
* Fixes #856
* Superseded by #1234

Check out the information in the issue: https://github.com/TheSuperHackers/GeneralsGameCode/issues/856#issuecomment-2994333088

**Note: While this should fix all mismatching issues related to the default shellmap, custom map mismatches are not fixed. Custom maps with a map.ini file may still overwrite default data like `UpgradeTemplate`, which would almost certainly cause a mismatch on another map.**