### PR TITLE
[GEN][ZH] Fix CONTINUE button mistakenly shown in Replay Score Screen

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
@@ -412,9 +412,12 @@ WindowMsgHandledType ScoreScreenInput( GameWindow *window, UnsignedInt msg,
 
 }  // end MainMenuInput
 
-static Bool showButtonContinue()
+static Bool showReplayButtonContinue()
 {
-	return ReplaySimulation::getCurrentReplayIndex() != ReplaySimulation::getReplayCount()-1;
+	bool hasSimulationReplay = ReplaySimulation::getReplayCount() > 0;
+	bool isLastSimulationReplay = ReplaySimulation::getCurrentReplayIndex() == ReplaySimulation::getReplayCount()-1;
+
+	return hasSimulationReplay && !isLastSimulationReplay;
 }
 
 /** System Function for the ScoreScreen */
@@ -819,7 +822,7 @@ void initReplaySinglePlayer( void )
 	if (chatBoxBorder)
 		chatBoxBorder->winHide(TRUE);
 	if (buttonContinue)
-		buttonContinue->winHide(!showButtonContinue());
+		buttonContinue->winHide(!showReplayButtonContinue());
 	if (buttonBuddies)
 		buttonBuddies->winHide(TRUE);
 	if (listboxChatWindowScoreScreen)
@@ -905,7 +908,7 @@ void initReplayMultiPlayer(void)
 	if (chatBoxBorder)
 		chatBoxBorder->winHide(TRUE);
 	if (buttonContinue)
-		buttonContinue->winHide(!showButtonContinue());
+		buttonContinue->winHide(!showReplayButtonContinue());
 	if (buttonBuddies)
 		buttonBuddies->winHide(TRUE);
 //	if (buttonRehost)

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
@@ -504,9 +504,12 @@ WindowMsgHandledType ScoreScreenInput( GameWindow *window, UnsignedInt msg,
 
 }  // end MainMenuInput
 
-static Bool showButtonContinue()
+static Bool showReplayButtonContinue()
 {
-	return ReplaySimulation::getCurrentReplayIndex() != ReplaySimulation::getReplayCount()-1;
+	bool hasSimulationReplay = ReplaySimulation::getReplayCount() > 0;
+	bool isLastSimulationReplay = ReplaySimulation::getCurrentReplayIndex() == ReplaySimulation::getReplayCount()-1;
+
+	return hasSimulationReplay && !isLastSimulationReplay;
 }
 
 /** System Function for the ScoreScreen */
@@ -1003,7 +1006,7 @@ void initReplaySinglePlayer( void )
 	if (chatBoxBorder)
 		chatBoxBorder->winHide(TRUE);
 	if (buttonContinue)
-		buttonContinue->winHide(!showButtonContinue());
+		buttonContinue->winHide(!showReplayButtonContinue());
 	if (buttonBuddies)
 		buttonBuddies->winHide(TRUE);
 	if (listboxChatWindowScoreScreen)
@@ -1110,7 +1113,7 @@ void initReplayMultiPlayer(void)
 	if (chatBoxBorder)
 		chatBoxBorder->winHide(TRUE);
 	if (buttonContinue)
-		buttonContinue->winHide(!showButtonContinue());
+		buttonContinue->winHide(!showReplayButtonContinue());
 	if (buttonBuddies)
 		buttonBuddies->winHide(TRUE);
 //	if (buttonRehost)


### PR DESCRIPTION
* Fixes #1172
* Follow up for #923

This change fixes the CONTINUE button mistakenly shown in Replay Score Screen. It was introduced with #923.

- [x] Test regular Replay Playback
- [x] Test visual Replay Simulator