### PR TITLE
[ZH] Fix crash with USA Particle Cannon when the last scripted target waypoint is reached before the end of the firing sequence

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
@@ -593,8 +593,16 @@ UpdateSleepTime ParticleUplinkCannonUpdate::update()
 							Int linkCount = way->getNumLinks();
 							Int which = GameLogicRandomValue( 0, linkCount-1 );
 							way = way->getLink( which );
-							m_nextDestWaypointID = way->getID();
-							m_overrideTargetDestination.set( way->getLocation() );
+
+							if ( way )
+							{
+								m_nextDestWaypointID = way->getID();
+								m_overrideTargetDestination.set(way->getLocation());
+							}
+							else
+							{
+								m_nextDestWaypointID = INVALID_WAYPOINT_ID;
+							}
 						}
 					}
 				}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
@@ -594,6 +594,7 @@ UpdateSleepTime ParticleUplinkCannonUpdate::update()
 							Int which = GameLogicRandomValue( 0, linkCount-1 );
 							way = way->getLink( which );
 
+							// TheSuperHackers @bugfix Caball009 27/06/2025 Check if the last way point has been reached before attempting to access the next way point.
 							if ( way )
 							{
 								m_nextDestWaypointID = way->getID();


### PR DESCRIPTION
* Fixes https://github.com/TheSuperHackers/GeneralsGameCode/issues/1204

If a scripted Particle Cannon reaches its last way point before it stops firing, it'll attempt to access a non-existing way point. This is a `nullptr` dereference and crashes the game.