### PR TITLE
[ZH] Reset movement mode when firing Particle Cannon

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
@@ -287,6 +287,7 @@ Bool ParticleUplinkCannonUpdate::initiateIntentToDoSpecialPower(const SpecialPow
 		m_startAttackFrame = TheGameLogic->getFrame();
 		m_laserStatus = LASERSTATUS_NONE;
 		m_manualTargetMode = TRUE;
+		m_scriptedWaypointMode = FALSE;
 		m_initialTargetPosition.set( targetPos );
 		m_overrideTargetDestination.set( targetPos );
 		m_currentTargetPosition.set( targetPos );
@@ -306,6 +307,7 @@ Bool ParticleUplinkCannonUpdate::initiateIntentToDoSpecialPower(const SpecialPow
 			pos.set( targetObj->getPosition() );
 		}
    	m_startAttackFrame = max( now, (UnsignedInt)1 );
+		m_manualTargetMode = FALSE;
 		m_scriptedWaypointMode = TRUE;
    	m_laserStatus = LASERSTATUS_NONE;
 		setLogicalStatus( STATUS_READY_TO_FIRE );
@@ -338,6 +340,8 @@ Bool ParticleUplinkCannonUpdate::initiateIntentToDoSpecialPower(const SpecialPow
 		{
 			pos.set( targetObj->getPosition() );
 		}
+		m_manualTargetMode = FALSE;
+		m_scriptedWaypointMode = FALSE;
    	m_initialTargetPosition.set( &pos );
    	m_startAttackFrame = max( now, (UnsignedInt)1 );
    	m_laserStatus = LASERSTATUS_NONE;


### PR DESCRIPTION
* Fixes https://github.com/TheSuperHackers/GeneralsGameCode/issues/1205

If the AI fires the Particle Cannon with way point mode the `m_scriptedWaypointMode` flag is enabled. This flag isn't reset for the 'S' curve, so the way point mode is used again.