### PR TITLE
[GEN][ZH] Prevent duplicate replays from being shown in the Replay Menu

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
@@ -210,7 +210,7 @@ void PopulateReplayFileListbox(GameWindow *listbox)
 	FilenameList replayFilenames;
 	FilenameListIter it;
 
-	TheFileSystem->getFileListInDirectory(TheRecorder->getReplayDir(), asciisearch, replayFilenames, TRUE);
+	TheFileSystem->getFileListInDirectory(TheRecorder->getReplayDir(), asciisearch, replayFilenames, FALSE);
 
 	TheMapCache->updateCache();
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
@@ -210,7 +210,7 @@ void PopulateReplayFileListbox(GameWindow *listbox)
 	FilenameList replayFilenames;
 	FilenameListIter it;
 
-	TheFileSystem->getFileListInDirectory(TheRecorder->getReplayDir(), asciisearch, replayFilenames, TRUE);
+	TheFileSystem->getFileListInDirectory(TheRecorder->getReplayDir(), asciisearch, replayFilenames, FALSE);
 
 	TheMapCache->updateCache();
 


### PR DESCRIPTION
https://github.com/TheSuperHackers/GeneralsGameCode/blob/7e18d29f7270a362caa4df34eebc1a76518f5cc7/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp#L213-L227

The current logic to show the list of replay files is divided into two parts. First it collects all replay files, and then it attempts to open any found replay files. The former searches all sub directories, but the latter uses only the replay file name and tries to open the file from the base directory.

Considering the following directory layout, GR2 isn't shown but GR1 is shown twice even if the second file is different or empty:
- GoldenReplay1.rep
- SubDirectory:
   - GoldenReplay1.rep
   - GoldenReplay2.rep
   
This PR disables the search in sub directories.
