### PR TITLE
[GEN][ZH] Prevent game crash when a player is selected in Replay playback

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -1969,6 +1969,14 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 
 	}  // end switch
 
+#if RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix xezon 28/06/2025 This hack avoids crashing when players are selected during Replay playback.
+	// It can read data from an already deleted AIGroup and return this function when its member size is 0, signifying that
+	// it is indeed deleted.
+	if (currentlySelectedGroup && currentlySelectedGroup->getCount() == 0)
+		return;
+#endif
+
 	/**/ /// @todo: multiplayer semantics
 	if (currentlySelectedGroup && TheRecorder->isPlaybackMode() && TheGlobalData->m_useCameraInReplay && TheControlBar->getObserverLookAtPlayer() == thisPlayer /*&& !TheRecorder->isMultiplayer()*/)
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -1997,6 +1997,14 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 
 	}  // end switch
 
+#if RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix xezon 28/06/2025 This hack avoids crashing when players are selected during Replay playback.
+	// It can read data from an already deleted AIGroup and return this function when its member size is 0, signifying that
+	// it is indeed deleted.
+	if (currentlySelectedGroup && currentlySelectedGroup->getCount() == 0)
+		return;
+#endif
+
 	/**/ /// @todo: multiplayer semantics
 	if (currentlySelectedGroup && TheRecorder->isPlaybackMode() && TheGlobalData->m_useCameraInReplay && TheControlBar->getObserverLookAtPlayer() == thisPlayer /*&& !TheRecorder->isMultiplayer()*/)
 	{


### PR DESCRIPTION
* Merge after #1002
* Replaces #1004
* Fixes #75
* Relates to #850

This change fixes a critical problem with AIGroup, that happens all the time in any match, but only crashes the Replay playback when a player is selected. The memory management of AIGroup is totally broken, and it will leak many AIGroups in AI matches (or matches that use AI scripts) and that will slow down iterating over `std::list<AIGroup *> m_groupList`.

## The Problem

AIGroup has a fundamental memory management flaw with its `AIGroup::remove` function. It deletes itself when all members are removed, which means that any non-AIGroup members holding a reference to that AIGroup will dangle when it is deleted.

This happens all the time in `GameLogic::logicMessageDispatcher` with its `currentlySelectedGroup` variable. It holds objects in a AIGroup, but that AIGroup can be deleted by external events, for example

```cpp
void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
{
...
  AIGroup* currentlySelectedGroup = NULL;

  if (isInGame())
  {
    if (msg->getType() >= GameMessage::MSG_BEGIN_NETWORK_MESSAGES && msg->getType() <= GameMessage::MSG_END_NETWORK_MESSAGES)
    {
      if (msg->getType() != GameMessage::MSG_LOGIC_CRC && msg->getType() != GameMessage::MSG_SET_REPLAY_CAMERA)
      {
        currentlySelectedGroup = TheAI->createGroup(); // can't do this outside a game - it'll cause sync errors galore.
        CRCGEN_LOG(( "Creating AIGroup %d in GameLogic::logicMessageDispatcher()\n", (currentlySelectedGroup)?currentlySelectedGroup->getID():0 ));
        thisPlayer->getCurrentSelectionAsAIGroup(currentlySelectedGroup);

...
  // process the message
  GameMessage::Type msgType = msg->getType();
  switch( msgType )
  {
...
    case GameMessage::MSG_REMOVE_BEACON:
    {
      AIGroup* allSelectedObjects = TheAI->createGroup();
      thisPlayer->getCurrentSelectionAsAIGroup(allSelectedObjects); // <----- xezon: this will delete the AIGroup pointed to by currentlySelectedGroup
```

There are multiple code paths like this that can delete `currentlySelectedGroup`.

## The Solution

With RETAIL_COMPATIBLE_CRC, `GameLogic::logicMessageDispatcher` now uses a massive hack to avoid crashing. It uses this hack because fixing AIGroup properly will mismatch with Retail. GenTool applies this exact hack since more than a decade.

## TODO

- [x] Test against VC6 Golden Replay
- [x] Replicate in Generals
- ~~Test against more replays~~