### PR TITLE
[GEN][ZH] Fix AIGroup memory management and leaks

### DIFF
--- a/Core/GameEngine/Include/Common/GameDefines.h
+++ b/Core/GameEngine/Include/Common/GameDefines.h
@@ -29,6 +29,14 @@
 #define RETAIL_COMPATIBLE_XFER_SAVE (1) // Game is expected to be Xfer Save compatible with retail Generals 1.08, Zero Hour 1.04
 #endif
 
+// This is essentially synonymous for RETAIL_COMPATIBLE_CRC. There is a lot wrong with AIGroup, such as use-after-free, double-free, leaks,
+// but we cannot touch it much without breaking retail compatibility. Do not shy away from using massive hacks when fixing issues with AIGroup,
+// but put them behind this macro.
+
+#ifndef RETAIL_COMPATIBLE_AIGROUP
+#define RETAIL_COMPATIBLE_AIGROUP (1) // AIGroup logic is expected to be CRC compatible with retail Generals 1.08, Zero Hour 1.04
+#endif
+
 #ifndef ENABLE_GAMETEXT_SUBSTITUTES
 #define ENABLE_GAMETEXT_SUBSTITUTES (1) // The code can provide substitute texts when labels and strings are missing in the STR or CSF translation file
 #endif

--- a/Generals/Code/GameEngine/Include/Common/Player.h
+++ b/Generals/Code/GameEngine/Include/Common/Player.h
@@ -608,7 +608,7 @@ public:
 	// add to the player's current selection this hotkey team.
 	void processAddTeamGameMessage(Int hotkeyNum, GameMessage *msg);
 
-	// returns an AIGroup object that is the currently selected group.
+	// fills an AIGroup object that is the currently selected group.
 	void getCurrentSelectionAsAIGroup(AIGroup *group);
 
 	// sets the currently selected group to be the given AIGroup

--- a/Generals/Code/GameEngine/Include/GameLogic/AI.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AI.h
@@ -37,6 +37,8 @@
 #include "Common/GameType.h"
 #include "GameLogic/Damage.h"
 #include "Common/STLTypedefs.h"
+#include "refcount.h"
+#include "ref_ptr.h"
 
 class AIGroup;
 class AttackPriorityInfo;
@@ -56,6 +58,12 @@ enum HackerAttackMode CPP_11(: Int);
 enum WeaponSetType CPP_11(: Int);
 enum WeaponLockType CPP_11(: Int);
 enum SpecialPowerType CPP_11(: Int);
+
+#if RETAIL_COMPATIBLE_AIGROUP
+typedef AIGroup* AIGroupPtr;
+#else
+typedef RefCountPtr<AIGroup> AIGroupPtr;
+#endif
 
 typedef std::vector<ObjectID> VecObjectID;
 typedef VecObjectID::iterator VecObjectIDIt;
@@ -265,7 +273,7 @@ public:
 	void loadPostProcess( void );
 
 	// AI Groups -----------------------------------------------------------------------------------------------
-	AIGroup *createGroup( void );					///< instantiate a new AI Group
+	AIGroupPtr createGroup( void ); ///< instantiate a new AI Group
 	void destroyGroup( AIGroup *group );	///< destroy the given AI Group
 	AIGroup *findGroup( UnsignedInt id );	///< return the AI Group with the given ID
 
@@ -851,6 +859,12 @@ public:
 	void xfer( Xfer *xfer );
 	void loadPostProcess( void );
 
+#if !RETAIL_COMPATIBLE_AIGROUP
+	void Add_Ref() const { m_refCount.Add_Ref(); }
+	void Release_Ref() const { m_refCount.Release_Ref(destroy, this); }
+	UnsignedShort Num_Refs() const { return m_refCount.Num_Refs(); }
+#endif
+
 	void groupMoveToPosition( const Coord3D *pos, Bool addWaypoint, CommandSourceType cmdSource );
 	void groupMoveToAndEvacuate( const Coord3D *pos, CommandSourceType cmdSource );			///< move to given position(s)
 	void groupMoveToAndEvacuateAndExit( const Coord3D *pos, CommandSourceType cmdSource );			///< move to given position & unload transport.
@@ -938,13 +952,15 @@ public:
 
 	void add( Object *obj );								///< add object to group
 	
-	// returns true if remove destroyed the group for us.
+	// Returns true if the group was emptied.
 	Bool remove( Object *obj);
+
+	void removeAll( void );
 	
 	// If the group contains any objects not owned by ownerPlayer, return TRUE.
 	Bool containsAnyObjectsNotOwnedByPlayer( const Player *ownerPlayer );
 
-	// Remove any objects that aren't owned by the player, and return true if the group was destroyed due to emptiness
+	// Removes any objects that aren't owned by the player, and returns true if the group was emptied.
 	Bool removeAnyObjectsNotOwnedByPlayer( const Player *ownerPlayer );
 	
 	UnsignedInt getID( void );
@@ -974,6 +990,13 @@ private:
 	friend class AI;
 	AIGroup( void );
 
+#if !RETAIL_COMPATIBLE_AIGROUP
+	static void destroy(AIGroup* self)
+	{
+		TheAI->destroyGroup(self);
+	}
+#endif
+
 	void recompute( void );									///< recompute various group info, such as speed, leader, etc
 
 	ListObjectPtr m_memberList;							///< the list of member Objects
@@ -981,6 +1004,10 @@ private:
 
 	Real m_speed;														///< maximum speed of group (slowest member)
 	Bool m_dirty;														///< "dirty bit" - if true then group speed, leader, needs recompute
+
+#if !RETAIL_COMPATIBLE_AIGROUP
+	RefCountValue<UnsignedShort> m_refCount; ///< the reference counter
+#endif
 
 	UnsignedInt m_id;												///< the unique ID of this group
 	Path *m_groundPath;											///< Group ground path.

--- a/Generals/Code/GameEngine/Include/GameLogic/Object.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Object.h
@@ -31,6 +31,7 @@
 #define _OBJECT_H_
 
 #include "Lib/BaseType.h"
+#include "ref_ptr.h"
 
 #include "Common/Geometry.h"
 #include "Common/Snapshot.h"
@@ -663,7 +664,11 @@ private:
 
 	GeometryInfo	m_geometryInfo;
 
+#if RETAIL_COMPATIBLE_AIGROUP
 	AIGroup*			m_group;								///< if non-NULL, we are part of this group of agents
+#else
+	RefCountPtr<AIGroup> m_group; ///< if non-NULL, we are part of this group of agents
+#endif
 
 	// These will last for my lifetime.  I will reuse them and reset them.  The truly dynamic ones are in PartitionManager
 	SightingInfo	*m_partitionLastLook;		///< Where and for whom I last looked, so I can undo its effects when I stop

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AI.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AI.cpp
@@ -330,6 +330,8 @@ void AI::reset( void )
 		m_aiData = m_aiData->m_next;
 		delete cur;
 	}
+
+#if RETAIL_COMPATIBLE_AIGROUP
 	while (m_groupList.size())
 	{
 		AIGroup *groupToRemove = m_groupList.front();
@@ -342,6 +344,12 @@ void AI::reset( void )
 			m_groupList.pop_front(); // NULL group, just kill from list.  Shouldn't really happen, but just in case.
 		}
 	}
+#else
+	DEBUG_ASSERTCRASH(m_groupList.empty(), ("AI::m_groupList is expected empty already\n"));
+
+	m_groupList.clear(); // Clear just in case...
+#endif
+
 	m_nextGroupID = 0;
 	m_nextFormationID = NO_FORMATION_ID;
 	getNextFormationID(); // increment once past NO_FORMATION_ID.  jba.
@@ -440,14 +448,22 @@ void AI::parseAiDataDefinition( INI* ini )
 /**
  * Create a new AI Group
  */
-AIGroup *AI::createGroup( void )
+AIGroupPtr AI::createGroup( void )
 {
 	// create a new instance
+#if RETAIL_COMPATIBLE_AIGROUP
 	AIGroup *group = newInstance(AIGroup);
+#else
+	AIGroupPtr group = AIGroupPtr::Create_NoAddRef(newInstance(AIGroup));
+#endif
 
 	// add it to the list
 //	DEBUG_LOG(("***AIGROUP %x is being added to m_groupList.\n", group ));
+#if RETAIL_COMPATIBLE_AIGROUP
 	m_groupList.push_back( group );
+#else
+	m_groupList.push_back( group.Peek() );
+#endif
 
 	return group;
 }

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
@@ -238,9 +238,9 @@ Bool AIGroup::remove( Object *obj )
 	// list has changed, properties need recomputation
 	m_dirty = true;
 
-	// if the group is empty, no-one is using it any longer, so destroy it
 	if (isEmpty()) {
 #if RETAIL_COMPATIBLE_AIGROUP
+		// if the group is empty, no-one is using it any longer, so destroy it
 		TheAI->destroyGroup( this );
 #endif
 		return TRUE;

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
@@ -92,6 +92,9 @@ AIGroup::~AIGroup()
 {
 //	DEBUG_LOG(("***AIGROUP %x is being destructed.\n", this));
 	// disassociate each member from the group
+
+#if RETAIL_COMPATIBLE_AIGROUP
+
 	std::list<Object *>::iterator i;
 	for( i = m_memberList.begin(); i != m_memberList.end(); /* empty */ )
 	{
@@ -106,6 +109,13 @@ AIGroup::~AIGroup()
 			i = m_memberList.erase(i);
 		}
 	}
+
+#else
+
+	removeAll();
+
+#endif
+
 	if (m_groundPath) {
 		deleteInstance(m_groundPath);
 		m_groundPath = NULL;
@@ -205,6 +215,11 @@ void AIGroup::add( Object *obj )
  */
 Bool AIGroup::remove( Object *obj )
 {
+#if !RETAIL_COMPATIBLE_AIGROUP
+	// Defer deletion until the end of this function.
+	AIGroupPtr refThis = AIGroupPtr::Create_AddRef(this);
+#endif
+
 //	DEBUG_LOG(("***AIGROUP %x is removing Object %x (%s).\n", this, obj, obj->getTemplate()->getName().str()));
 	std::list<Object *>::iterator i = std::find( m_memberList.begin(), m_memberList.end(), obj );
 
@@ -225,11 +240,38 @@ Bool AIGroup::remove( Object *obj )
 
 	// if the group is empty, no-one is using it any longer, so destroy it
 	if (isEmpty()) {
+#if RETAIL_COMPATIBLE_AIGROUP
 		TheAI->destroyGroup( this );
+#endif
 		return TRUE;
 	}
 
 	return FALSE;
+}
+
+/**
+ * Remove all objects from group
+ */
+void AIGroup::removeAll( void )
+{
+#if !RETAIL_COMPATIBLE_AIGROUP
+	// Defer deletion until the end of this function.
+	AIGroupPtr refThis = AIGroupPtr::Create_AddRef(this);
+#endif
+
+	std::list<Object *> memberList;
+	memberList.swap(m_memberList);
+	m_memberListSize = 0;
+
+	std::list<Object *>::iterator i;
+	for ( i = memberList.begin(); i != memberList.end(); ++i )
+	{
+		Object *member = *i;
+		if (member)
+			member->leaveGroup();
+	}
+
+	m_dirty = true;
 }
 
 /**
@@ -2722,6 +2764,11 @@ void AIGroup::groupCheer( CommandSourceType cmdSource )
 	*/
 void AIGroup::groupSell( CommandSourceType cmdSource )
 {
+#if !RETAIL_COMPATIBLE_AIGROUP
+	// Defer deletion until the end of this function.
+	AIGroupPtr refThis = AIGroupPtr::Create_AddRef(this);
+#endif
+
 	std::list<Object *>::iterator i;
 	std::vector<Object *> groupObjectsCopy;
 	groupObjectsCopy.reserve(m_memberListSize);

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -893,11 +893,15 @@ void AIPlayer::guardSupplyCenter( Team *team, Int minSupplies )
 	}
 	if (warehouse) {
 
-		AIGroup* theGroup = TheAI->createGroup();
+		AIGroupPtr theGroup = TheAI->createGroup();
 		if (!theGroup) {
 			return;
 		}
+#if RETAIL_COMPATIBLE_AIGROUP
 		team->getTeamAsAIGroup(theGroup);
+#else
+		team->getTeamAsAIGroup(theGroup.Peek());
+#endif
 		Coord3D location = *warehouse->getPosition();
 		// It's probably a defensive move - position towards the enemy.
 		Region2D bounds;

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -2471,9 +2471,9 @@ void AIPlayer::checkReadyTeams( void )
 					/*
 					if (team->m_team->getPrototype()->getTemplateInfo()->m_hasHomeLocation && 
 							!team->m_reinforcement) {
- 						AIGroup* theGroup = TheAI->createGroup();
+ 						AIGroupPtr theGroup = TheAI->createGroup();
 						if (theGroup) {
-							team->m_team->getTeamAsAIGroup(theGroup);
+							team->m_team->getTeamAsAIGroup(theGroup.Peek());
 							Coord3D destination = team->m_team->getPrototype()->getTemplateInfo()->m_homeLocation;
 							theGroup->groupTightenToPosition( &destination, false, CMD_FROM_AI );
 							team->m_frameStarted = TheGameLogic->getFrame();

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -4053,8 +4053,12 @@ StateReturnType AIFollowWaypointPathState::update()
 	if (m_moveAsGroup) {
 		if (obj->getControllingPlayer()->isSkirmishAIPlayer()) {
 			Team *team = obj->getTeam();
-			AIGroup *group = TheAI->createGroup();
+			AIGroupPtr group = TheAI->createGroup();
+#if RETAIL_COMPATIBLE_AIGROUP
 			team->getTeamAsAIGroup(group);
+#else
+			team->getTeamAsAIGroup(group.Peek());
+#endif
 
 			Coord3D pos;
 			group->getCenter(&pos);

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -563,8 +563,7 @@ Object::~Object()
 		ThePartitionManager->unRegisterObject( this );
 
 	// if we are in a group, remove us
-	if (m_group)
-		m_group->remove( this );
+	leaveGroup();
 	
 	// note, do NOT free these, there are just a shadow copy!
 	m_ai = NULL;
@@ -3841,7 +3840,7 @@ void Object::xfer( Xfer *xfer )
 	}
 
 	// Doesn't need to be saved.  These are created as needed.  jba.
-	//AIGroup*		m_group;															///< if non-NULL, we are part of this group of agents
+	//m_group;
 
 	// don't need to save m_partitionData.
 	DEBUG_ASSERTCRASH(!(xfer->getXferMode() == XFER_LOAD && m_partitionData == NULL), ("should not be in partitionmgr yet"));
@@ -5446,7 +5445,11 @@ RadarPriorityType Object::getRadarPriority( void ) const
 // ------------------------------------------------------------------------------------------------
 AIGroup *Object::getGroup(void)
 {
+#if RETAIL_COMPATIBLE_AIGROUP
 	return m_group;
+#else
+	return m_group.Peek();
+#endif
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -5456,7 +5459,11 @@ void Object::enterGroup( AIGroup *group )
 	// if we are in another group, remove ourselves from it first
 	leaveGroup();
 
+#if RETAIL_COMPATIBLE_AIGROUP
 	m_group = group;
+#else
+	m_group = AIGroupPtr::Create_AddRef(group);
+#endif
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -5467,7 +5474,7 @@ void Object::leaveGroup( void )
 	if (m_group)
 	{
 		// to avoid recursion, set m_group to NULL before removing
-		AIGroup *group = m_group;
+		AIGroupPtr group = m_group;
 		m_group = NULL;
 		group->remove( this );
 	}

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
@@ -394,12 +394,15 @@ void ScriptActions::doMoveToWaypoint(const AsciiString& team, const AsciiString&
 	// The team is the team based on the name, and the calling team (if any) and the team that
 	// triggered the condition.  jba. :)
 	if (theTeam) {
-		AIGroup* theGroup = TheAI->createGroup();
+		AIGroupPtr theGroup = TheAI->createGroup();
 		if (!theGroup) {
 			return;
 		}
-
+#if RETAIL_COMPATIBLE_AIGROUP
 		theTeam->getTeamAsAIGroup(theGroup);
+#else
+		theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 		Waypoint *way = TheTerrainLogic->getWaypointByName(waypoint);
 		if (way) {
 			Coord3D destination = *way->getLocation();
@@ -756,12 +759,16 @@ void ScriptActions::doCreateReinforcements(const AsciiString& team, const AsciiS
 			theTeam->setActive();
 			if (needToMoveToDestination) 
 			{
-				AIGroup* theGroup = TheAI->createGroup();
+				AIGroupPtr theGroup = TheAI->createGroup();
 				if (!theGroup) 
 				{
 					return;
 				}
+#if RETAIL_COMPATIBLE_AIGROUP
 				theTeam->getTeamAsAIGroup(theGroup);
+#else
+				theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 				theGroup->groupMoveToPosition( &destination, false, CMD_FROM_SCRIPT );
 			}
 		}
@@ -1015,12 +1022,16 @@ void ScriptActions::doAttack(const AsciiString& attackerName, const AsciiString&
 	if( attackingTeam == NULL || victimTeam == NULL )
 		return;
 
-	AIGroup *aiGroup = TheAI->createGroup();
+	AIGroupPtr aiGroup = TheAI->createGroup();
 	if (!aiGroup) {
 		return;
 	}
 
+#if RETAIL_COMPATIBLE_AIGROUP
 	attackingTeam->getTeamAsAIGroup(aiGroup);
+#else
+	attackingTeam->getTeamAsAIGroup(aiGroup.Peek());
+#endif
 	aiGroup->groupAttackTeam(victimTeam, NO_MAX_SHOTS_LIMIT, CMD_FROM_SCRIPT);
 
 }
@@ -1260,12 +1271,16 @@ void ScriptActions::updateTeamSetAttitude(const AsciiString& teamName, Int attit
 		return;
 	}
 
-	AIGroup *pAIGroup = TheAI->createGroup();
+	AIGroupPtr pAIGroup = TheAI->createGroup();
 	if (!pAIGroup) {
 		return;
 	}
 
+#if RETAIL_COMPATIBLE_AIGROUP
 	theSrcTeam->getTeamAsAIGroup(pAIGroup);
+#else
+	theSrcTeam->getTeamAsAIGroup(pAIGroup.Peek());
+#endif
 	pAIGroup->setAttitude((AttitudeType) attitude);
 }
 
@@ -1369,12 +1384,16 @@ void ScriptActions::doTeamAttackArea(const AsciiString& teamName, const AsciiStr
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
 
+#if RETAIL_COMPATIBLE_AIGROUP
 	theTeam->getTeamAsAIGroup(theGroup);
+#else
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 
 	PolygonTrigger *pTrig = TheScriptEngine->getQualifiedTriggerAreaByName(areaName);
 	if (!pTrig) {
@@ -1401,12 +1420,16 @@ void ScriptActions::doTeamAttackNamed(const AsciiString& teamName, const AsciiSt
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
 
+#if RETAIL_COMPATIBLE_AIGROUP
 	theTeam->getTeamAsAIGroup(theGroup);
+#else
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	theGroup->groupAttackObject(theVictim, NO_MAX_SHOTS_LIMIT, CMD_FROM_SCRIPT);
 }
 
@@ -1508,9 +1531,13 @@ void ScriptActions::doTeamEnterNamed(const AsciiString& teamName, const AsciiStr
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
-	theSrcTeam->getTeamAsAIGroup(theGroup);
+	AIGroupPtr theGroup = TheAI->createGroup();
 
+#if RETAIL_COMPATIBLE_AIGROUP
+	theSrcTeam->getTeamAsAIGroup(theGroup);
+#else
+	theSrcTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	theGroup->groupEnter(theTransport, CMD_FROM_SCRIPT);
 }
 
@@ -1544,9 +1571,13 @@ void ScriptActions::doTeamExitAll(const AsciiString& teamName)
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
-	theTeamOfTransports->getTeamAsAIGroup(theGroup);
+	AIGroupPtr theGroup = TheAI->createGroup();
 
+#if RETAIL_COMPATIBLE_AIGROUP
+	theTeamOfTransports->getTeamAsAIGroup(theGroup);
+#else
+	theTeamOfTransports->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	theGroup->groupEvacuate( CMD_FROM_SCRIPT );
 }
 
@@ -1614,11 +1645,15 @@ void ScriptActions::doTeamFollowSkirmishApproachPath(const AsciiString& teamName
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
+#if RETAIL_COMPATIBLE_AIGROUP
 	theTeam->getTeamAsAIGroup(theGroup);
+#else
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	Int count = 0;
 	Coord3D pos;
 	pos.x=pos.y=pos.z=0;
@@ -1677,11 +1712,15 @@ void ScriptActions::doTeamMoveToSkirmishApproachPath(const AsciiString& teamName
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
+#if RETAIL_COMPATIBLE_AIGROUP
 	theTeam->getTeamAsAIGroup(theGroup);
+#else
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	Int count = 0;
 	Coord3D pos;
 	pos.x=pos.y=pos.z=0;
@@ -1725,11 +1764,15 @@ void ScriptActions::doTeamFollowWaypoints(const AsciiString& teamName, const Asc
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
+#if RETAIL_COMPATIBLE_AIGROUP
 	theTeam->getTeamAsAIGroup(theGroup);
+#else
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	Int count = 0;
 	Coord3D pos;
 	pos.x=pos.y=pos.z=0;
@@ -1772,11 +1815,15 @@ void ScriptActions::doTeamFollowWaypointsExact(const AsciiString& teamName, cons
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
+#if RETAIL_COMPATIBLE_AIGROUP
 	theTeam->getTeamAsAIGroup(theGroup);
+#else
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	Int count = 0;
 	Coord3D pos;
 	pos.x=pos.y=pos.z=0;
@@ -1864,11 +1911,15 @@ void ScriptActions::doTeamGuardPosition(const AsciiString& teamName, const Ascii
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
+#if RETAIL_COMPATIBLE_AIGROUP
 	theTeam->getTeamAsAIGroup(theGroup);
+#else
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	Coord3D position = *way->getLocation();
 
 	theGroup->groupGuardPosition( &position, GUARDMODE_NORMAL, CMD_FROM_SCRIPT );
@@ -1885,12 +1936,15 @@ void ScriptActions::doTeamGuardObject(const AsciiString& teamName, const AsciiSt
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
+#if RETAIL_COMPATIBLE_AIGROUP
 	theTeam->getTeamAsAIGroup(theGroup);
-
+#else
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	theGroup->groupGuardObject( theUnit, GUARDMODE_NORMAL, CMD_FROM_SCRIPT );
 }
 
@@ -1905,12 +1959,15 @@ void ScriptActions::doTeamGuardArea(const AsciiString& teamName, const AsciiStri
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
+#if RETAIL_COMPATIBLE_AIGROUP
 	theTeam->getTeamAsAIGroup(theGroup);
-
+#else
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	theGroup->groupGuardArea( pTrig, GUARDMODE_NORMAL, CMD_FROM_SCRIPT );
 }
 
@@ -1943,12 +2000,15 @@ void ScriptActions::doTeamHunt(const AsciiString& teamName)
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
+#if RETAIL_COMPATIBLE_AIGROUP
 	theTeam->getTeamAsAIGroup(theGroup);
-
+#else
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	theGroup->groupHunt( CMD_FROM_SCRIPT );
 }
 //-------------------------------------------------------------------------------------------------
@@ -3242,12 +3302,15 @@ void ScriptActions::doTeamGarrisonSpecificBuilding(const AsciiString& teamName, 
 		return;
 	}
 	
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
-	
+#if RETAIL_COMPATIBLE_AIGROUP
 	theTeam->getTeamAsAIGroup(theGroup);
+#else
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	theGroup->groupEnter(theBuilding, CMD_FROM_SCRIPT);
 }
 
@@ -4082,14 +4145,17 @@ void ScriptActions::doTeamUseCommandButtonAbility( const AsciiString& team, cons
 	}
 
 
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
 	if( !theGroup ) 
 	{
 		return;
 	}
 
-	theTeam->getTeamAsAIGroup( theGroup );
-	
+#if RETAIL_COMPATIBLE_AIGROUP
+	theTeam->getTeamAsAIGroup(theGroup);
+#else
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	theGroup->groupDoCommandButton( commandButton, CMD_FROM_SCRIPT );
 }
 
@@ -4117,14 +4183,17 @@ void ScriptActions::doTeamUseCommandButtonAbilityOnNamed( const AsciiString& tea
 	}
 
 
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
 	if( !theGroup ) 
 	{
 		return;
 	}
 
-	theTeam->getTeamAsAIGroup( theGroup );
-	
+#if RETAIL_COMPATIBLE_AIGROUP
+	theTeam->getTeamAsAIGroup(theGroup);
+#else
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	theGroup->groupDoCommandButtonAtObject( commandButton, theObj, CMD_FROM_SCRIPT );
 }
 
@@ -4152,14 +4221,17 @@ void ScriptActions::doTeamUseCommandButtonAbilityAtWaypoint( const AsciiString& 
 	}
 
 
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
 	if( !theGroup ) 
 	{
 		return;
 	}
 
-	theTeam->getTeamAsAIGroup( theGroup );
-	
+#if RETAIL_COMPATIBLE_AIGROUP
+	theTeam->getTeamAsAIGroup(theGroup);
+#else
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	theGroup->groupDoCommandButtonAtPosition( commandButton, pWaypoint->getLocation(), CMD_FROM_SCRIPT );
 }
 
@@ -4236,12 +4308,15 @@ void ScriptActions::doTeamStop(const AsciiString& teamName, Bool shouldDisband)
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
-
+#if RETAIL_COMPATIBLE_AIGROUP
 	theTeam->getTeamAsAIGroup(theGroup);
+#else
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	theGroup->groupIdle(CMD_FROM_SCRIPT);
 
 	if (shouldDisband) {
@@ -4449,12 +4524,15 @@ void ScriptActions::doTeamStartSequentialScript(const AsciiString& teamName, con
 	}
 
 	// Idle the team so the seq script will start executing. jba.
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
-
+#if RETAIL_COMPATIBLE_AIGROUP
 	team->getTeamAsAIGroup(theGroup);
+#else
+	team->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	theGroup->groupIdle(CMD_FROM_SCRIPT);
 
 
@@ -4556,12 +4634,15 @@ void ScriptActions::doTeamIdleForFramecount(const AsciiString& teamName, Int fra
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
-
+#if RETAIL_COMPATIBLE_AIGROUP
 	theTeam->getTeamAsAIGroup(theGroup);
+#else
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	Coord3D center;
 	theGroup->getCenter(&center);
 
@@ -4942,8 +5023,12 @@ void ScriptActions::doSkirmishAttackNearestGroupWithValue( const AsciiString& te
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
+#if RETAIL_COMPATIBLE_AIGROUP
 	team->getTeamAsAIGroup(theGroup);
+#else
+	team->getTeamAsAIGroup(theGroup.Peek());
+#endif
 
 	Player *player = team->getControllingPlayer();
 
@@ -4971,8 +5056,12 @@ void ScriptActions::doSkirmishCommandButtonOnMostValuable( const AsciiString& te
 		return;
 	}
 
-	AIGroup *theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
+#if RETAIL_COMPATIBLE_AIGROUP
 	team->getTeamAsAIGroup(theGroup);
+#else
+	team->getTeamAsAIGroup(theGroup.Peek());
+#endif
 
 	Player *player = team->getControllingPlayer();
 	if (!player)
@@ -5034,8 +5123,12 @@ void ScriptActions::doTeamUseCommandButtonOnNamed( const AsciiString& teamName, 
 		return;
 	}
 
-	AIGroup *theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
+#if RETAIL_COMPATIBLE_AIGROUP
 	team->getTeamAsAIGroup(theGroup);
+#else
+	team->getTeamAsAIGroup(theGroup.Peek());
+#endif
 
 	const CommandButton *commandButton = TheControlBar->findCommandButton(commandAbility);
 	if(!commandButton) {
@@ -5073,8 +5166,12 @@ void ScriptActions::doTeamUseCommandButtonOnNearestEnemy( const AsciiString& tea
 		return;
 	}
 
-	AIGroup *theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
+#if RETAIL_COMPATIBLE_AIGROUP
 	team->getTeamAsAIGroup(theGroup);
+#else
+	team->getTeamAsAIGroup(theGroup.Peek());
+#endif
 
 	const CommandButton *commandButton = TheControlBar->findCommandButton(commandAbility);
 	if(!commandButton) {
@@ -5119,8 +5216,12 @@ void ScriptActions::doTeamUseCommandButtonOnNearestGarrisonedBuilding( const Asc
 		return;
 	}
 
-	AIGroup *theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
+#if RETAIL_COMPATIBLE_AIGROUP
 	team->getTeamAsAIGroup(theGroup);
+#else
+	team->getTeamAsAIGroup(theGroup.Peek());
+#endif
 
 	const CommandButton *commandButton = TheControlBar->findCommandButton(commandAbility);
 	if(!commandButton) {
@@ -5167,8 +5268,12 @@ void ScriptActions::doTeamUseCommandButtonOnNearestKindof( const AsciiString& te
 		return;
 	}
 
-	AIGroup *theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
+#if RETAIL_COMPATIBLE_AIGROUP
 	team->getTeamAsAIGroup(theGroup);
+#else
+	team->getTeamAsAIGroup(theGroup.Peek());
+#endif
 
 	const CommandButton *commandButton = TheControlBar->findCommandButton(commandAbility);
 	if (!commandButton) {
@@ -5214,8 +5319,12 @@ void ScriptActions::doTeamUseCommandButtonOnNearestBuilding( const AsciiString& 
 		return;
 	}
 
-	AIGroup *theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
+#if RETAIL_COMPATIBLE_AIGROUP
 	team->getTeamAsAIGroup(theGroup);
+#else
+	team->getTeamAsAIGroup(theGroup.Peek());
+#endif
 
 	const CommandButton *commandButton = TheControlBar->findCommandButton(commandAbility);
 	if (!commandButton) {
@@ -5261,8 +5370,12 @@ void ScriptActions::doTeamUseCommandButtonOnNearestBuildingClass( const AsciiStr
 		return;
 	}
 
-	AIGroup *theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
+#if RETAIL_COMPATIBLE_AIGROUP
 	team->getTeamAsAIGroup(theGroup);
+#else
+	team->getTeamAsAIGroup(theGroup.Peek());
+#endif
 
 	const CommandButton *commandButton = TheControlBar->findCommandButton(commandAbility);
 	if (!commandButton) {
@@ -5309,8 +5422,12 @@ void ScriptActions::doTeamUseCommandButtonOnNearestObjectType( const AsciiString
 		return;
 	}
 
-	AIGroup *theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
+#if RETAIL_COMPATIBLE_AIGROUP
 	team->getTeamAsAIGroup(theGroup);
+#else
+	team->getTeamAsAIGroup(theGroup.Peek());
+#endif
 
 	const CommandButton *commandButton = TheControlBar->findCommandButton(commandAbility);
 	if (!commandButton) {
@@ -5400,8 +5517,12 @@ void ScriptActions::doTeamCaptureNearestUnownedFactionUnit( const AsciiString& t
 		return;
 	}
 
-	AIGroup *theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
+#if RETAIL_COMPATIBLE_AIGROUP
 	team->getTeamAsAIGroup(theGroup);
+#else
+	team->getTeamAsAIGroup(theGroup.Peek());
+#endif
 
 	PartitionFilterPlayerAffiliation f1(team->getControllingPlayer(), ALLOW_ENEMIES | ALLOW_NEUTRAL, true);
 	PartitionFilterUnmannedObject f2(true);
@@ -5516,12 +5637,16 @@ void ScriptActions::doTeamEmoticon(const AsciiString& teamName, const AsciiStrin
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
 	if( !theGroup ) 
 	{
 		return;
 	}
-	theTeam->getTeamAsAIGroup( theGroup );
+#if RETAIL_COMPATIBLE_AIGROUP
+	theTeam->getTeamAsAIGroup(theGroup);
+#else
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	
 	Int frames = (Int)( duration * LOGICFRAMES_PER_SECOND );
 	theGroup->groupSetEmoticon( emoticonName, frames );

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
@@ -7210,9 +7210,13 @@ void ScriptEngine::evaluateAndProgressAllSequentialScripts( void )
 		}
 
 		AIUpdateInterface *ai = obj ? obj->getAIUpdateInterface() : NULL;
-		AIGroup *aigroup = (team ? TheAI->createGroup() : NULL);
+		AIGroupPtr aigroup = (team ? TheAI->createGroup() : NULL);
 		if (aigroup) {
+#if RETAIL_COMPATIBLE_AIGROUP
 			team->getTeamAsAIGroup(aigroup);
+#else
+			team->getTeamAsAIGroup(aigroup.Peek());
+#endif
 		}
 
 		if( ai || aigroup ) {
@@ -7297,7 +7301,11 @@ void ScriptEngine::evaluateAndProgressAllSequentialScripts( void )
 					} else if (team) {
 						// attempt to rebuild the aigroup, as it probably expired during the action execution
 						aigroup = (team ? TheAI->createGroup() : NULL);
+#if RETAIL_COMPATIBLE_AIGROUP
 						team->getTeamAsAIGroup(aigroup);
+#else
+						team->getTeamAsAIGroup(aigroup.Peek());
+#endif
 					}
 
 					if (aigroup && aigroup->isIdle()) {

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -2355,19 +2355,30 @@ void GameLogic::selectObject(Object *obj, Bool createNewSelection, PlayerMaskTyp
 			return;
 		}
 
-		AIGroup *group = NULL;
 		CRCGEN_LOG(( "Creating AIGroup in GameLogic::selectObject()\n" ));
-		group = TheAI->createGroup();
+		AIGroupPtr group = TheAI->createGroup();
 		group->add(obj);
 
 		// add all selected agents to the AI group
 		if (createNewSelection)	{
+#if RETAIL_COMPATIBLE_AIGROUP
 			player->setCurrentlySelectedAIGroup(group);
+#else
+			player->setCurrentlySelectedAIGroup(group.Peek());
+#endif
 		} else {
+#if RETAIL_COMPATIBLE_AIGROUP
 			player->addAIGroupToCurrentSelection(group);
+#else
+			player->addAIGroupToCurrentSelection(group.Peek());
+#endif
 		}
 
+#if RETAIL_COMPATIBLE_AIGROUP
 		TheAI->destroyGroup(group);
+#else
+		group->removeAll();
+#endif
 
 		if (affectClient) {
 			Drawable *draw = obj->getDrawable();
@@ -2392,25 +2403,28 @@ void GameLogic::deselectObject(Object *obj, PlayerMaskType playerMask, Bool affe
 			return;
 		}
 
-		AIGroup *group = NULL;
 		CRCGEN_LOG(( "Removing a unit from a selected group in GameLogic::deselectObject()\n" ));
-		group = TheAI->createGroup();
+		AIGroupPtr group = TheAI->createGroup();
+#if RETAIL_COMPATIBLE_AIGROUP
 		player->getCurrentSelectionAsAIGroup(group);
-		
-		Bool deleted = FALSE;
-		Bool actuallyRemoved = FALSE;
-		
+#else
+		player->getCurrentSelectionAsAIGroup(group.Peek());
+#endif
+
 		if (group) {
-			deleted = group->remove(obj);
-			actuallyRemoved = TRUE;
-		}
-		
-		if (actuallyRemoved) {
+			Bool emptied = group->remove(obj);
+
 			// Set this to be the currently selected group.
-			if (!deleted) {
+			if (!emptied) {
+#if RETAIL_COMPATIBLE_AIGROUP
 				player->setCurrentlySelectedAIGroup(group);
 				// Then, cleanup the group.
 				TheAI->destroyGroup(group);
+#else
+				player->setCurrentlySelectedAIGroup(group.Peek());
+				// Then, cleanup the group.
+				group->removeAll();
+#endif
 			} else {
 				// NULL will clear the group.
 				player->setCurrentlySelectedAIGroup(NULL);

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -339,7 +339,7 @@ void GameLogic::prepareNewGame( Int gameMode, GameDifficulty diff, Int rankPoint
 //-------------------------------------------------------------------------------------------------
 /** This message handles dispatches object command messages to the
   * appropriate objects.
-	* @todo Rename this to "CommandProcessor", or similiar. */
+	* @todo Rename this to "CommandProcessor", or similar. */
 //-------------------------------------------------------------------------------------------------
 void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 {
@@ -351,7 +351,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 	DEBUG_ASSERTCRASH( thisPlayer, ("logicMessageDispatcher: Processing message from unknown player (player index '%d')\n", 
 																	msg->getPlayerIndex()) );
 	
-	AIGroup *currentlySelectedGroup = NULL;
+	AIGroupPtr currentlySelectedGroup = NULL;
 
 	if (isInGame())
 	{
@@ -360,15 +360,21 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			if (msg->getType() != GameMessage::MSG_LOGIC_CRC && msg->getType() != GameMessage::MSG_SET_REPLAY_CAMERA)
 			{
 				currentlySelectedGroup = TheAI->createGroup(); // can't do this outside a game - it'll cause sync errors galore.
-				CRCGEN_LOG(( "Creating AIGroup %d in GameLogic::logicMessageDispatcher()\n", (currentlySelectedGroup)?currentlySelectedGroup->getID():0 ));
+				CRCGEN_LOG(( "Creating AIGroup %d in GameLogic::logicMessageDispatcher()\n", currentlySelectedGroup?currentlySelectedGroup->getID():0 ));
+#if RETAIL_COMPATIBLE_AIGROUP
 				thisPlayer->getCurrentSelectionAsAIGroup(currentlySelectedGroup);
+#else
+				thisPlayer->getCurrentSelectionAsAIGroup(currentlySelectedGroup.Peek());
+#endif
 
-				// We can't issue commands to groups that contain units that don't belong the issuing player, so pretend like 
+				// We can't issue commands to groups that contain units that don't belong to the issuing player, so pretend like
 				// there's nothing selected. Also, if currentlySelectedGroup is empty, go ahead and delete it, so that we can skip
 				// any processing on it.
 				if (currentlySelectedGroup->isEmpty())
 				{
+#if RETAIL_COMPATIBLE_AIGROUP
 					TheAI->destroyGroup(currentlySelectedGroup);
+#endif
 					currentlySelectedGroup = NULL;
 				}
 
@@ -450,7 +456,13 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 #endif
 
 			if (currentlySelectedGroup)
+			{
+#if RETAIL_COMPATIBLE_AIGROUP
 				TheAI->destroyGroup(currentlySelectedGroup);
+#else
+				currentlySelectedGroup->removeAll();
+#endif
+			}
 			currentlySelectedGroup = NULL;
 			TheGameLogic->clearGameData();
 			break;
@@ -652,10 +664,14 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Object* source = TheGameLogic->findObjectByID(sourceID);
 			if (source != NULL)
 			{
-				AIGroup* theGroup = TheAI->createGroup();
+				AIGroupPtr theGroup = TheAI->createGroup();
 				theGroup->add(source);
 				theGroup->groupDoSpecialPower( specialPowerID, options );
+#if RETAIL_COMPATIBLE_AIGROUP
 				TheAI->destroyGroup(theGroup);
+#else
+				theGroup->removeAll();
+#endif
 			}
 			else
 			{
@@ -690,10 +706,14 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Object* source = TheGameLogic->findObjectByID(sourceID);
 			if (source != NULL)
 			{
-				AIGroup* theGroup = TheAI->createGroup();
+				AIGroupPtr theGroup = TheAI->createGroup();
 				theGroup->add(source);
 				theGroup->groupDoSpecialPowerAtLocation( specialPowerID, &targetCoord, INVALID_ANGLE, objectInWay, options );
+#if RETAIL_COMPATIBLE_AIGROUP
 				TheAI->destroyGroup(theGroup);
+#else
+				theGroup->removeAll();
+#endif
 			}
 			else
 			{
@@ -729,10 +749,14 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Object* source = TheGameLogic->findObjectByID(sourceID);
 			if (source != NULL)
 			{
-				AIGroup* theGroup = TheAI->createGroup();
+				AIGroupPtr theGroup = TheAI->createGroup();
 				theGroup->add(source);
 				theGroup->groupDoSpecialPowerAtObject( specialPowerID, target, options );
+#if RETAIL_COMPATIBLE_AIGROUP
 				TheAI->destroyGroup(theGroup);
+#else
+				theGroup->removeAll();
+#endif
 			}
 			else
 			{
@@ -975,7 +999,11 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 		case GameMessage::MSG_EXIT:
 		{
 			Object *objectWantingToExit = TheGameLogic->findObjectByID( msg->getArgument( 0 )->objectID );
+#if RETAIL_COMPATIBLE_AIGROUP
 			Object *objectContainingExiter = getSingleObjectFromSelection(currentlySelectedGroup);
+#else
+			Object *objectContainingExiter = getSingleObjectFromSelection(currentlySelectedGroup.Peek());
+#endif
 
 			// sanity
 			if( objectWantingToExit == NULL )
@@ -1162,10 +1190,14 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Object* source = TheGameLogic->findObjectByID(sourceID);
 			if (source != NULL)
 			{
-				AIGroup* theGroup = TheAI->createGroup();
+				AIGroupPtr theGroup = TheAI->createGroup();
 				theGroup->add(source);
 				theGroup->groupOverrideSpecialPowerDestination( spType, loc, CMD_FROM_PLAYER );
+#if RETAIL_COMPATIBLE_AIGROUP
 				TheAI->destroyGroup(theGroup);
+#else
+				theGroup->removeAll();
+#endif
 			}
 			else
 			{
@@ -1277,7 +1309,11 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 		//---------------------------------------------------------------------------------------------
 		case GameMessage::MSG_CANCEL_UPGRADE:
 		{
+#if RETAIL_COMPATIBLE_AIGROUP
 			Object *producer = getSingleObjectFromSelection(currentlySelectedGroup);
+#else
+			Object *producer = getSingleObjectFromSelection(currentlySelectedGroup.Peek());
+#endif
 			const UpgradeTemplate *upgradeT = TheUpgradeCenter->findUpgradeByKey( (NameKeyType)(msg->getArgument( 0 )->integer) );
 
 			// sanity
@@ -1303,7 +1339,11 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 		//---------------------------------------------------------------------------------------------
 		case GameMessage::MSG_QUEUE_UNIT_CREATE:
 		{
+#if RETAIL_COMPATIBLE_AIGROUP
 			Object *producer = getSingleObjectFromSelection(currentlySelectedGroup);
+#else
+			Object *producer = getSingleObjectFromSelection(currentlySelectedGroup.Peek());
+#endif
 			const ThingTemplate *whatToCreate;
 			ProductionID productionID;
 
@@ -1336,7 +1376,11 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 		//-------------------------------------------------------------------------------------------------
 		case GameMessage::MSG_CANCEL_UNIT_CREATE:
 		{
+#if RETAIL_COMPATIBLE_AIGROUP
 			Object *producer = getSingleObjectFromSelection(currentlySelectedGroup);
+#else
+			Object *producer = getSingleObjectFromSelection(currentlySelectedGroup.Peek());
+#endif
 			ProductionID productionID = (ProductionID)msg->getArgument( 0 )->integer;
 			
 			// sanity
@@ -1368,7 +1412,11 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Real angle;
 
 			// get player, what to place, and location
+#if RETAIL_COMPATIBLE_AIGROUP
 			Object *constructorObject = getSingleObjectFromSelection(currentlySelectedGroup);
+#else
+			Object *constructorObject = getSingleObjectFromSelection(currentlySelectedGroup.Peek());
+#endif
 			place = TheThingFactory->findByTemplateID( msg->getArgument( 0 )->integer );
 			loc = msg->getArgument( 1 )->location;
 			angle = msg->getArgument( 2 )->real;
@@ -1415,7 +1463,11 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 		{
 
 			// get the building to cancel construction on
+#if RETAIL_COMPATIBLE_AIGROUP
 			Object *building = getSingleObjectFromSelection(currentlySelectedGroup);
+#else
+			Object *building = getSingleObjectFromSelection(currentlySelectedGroup.Peek());
+#endif
 			if( building == NULL )
 				break;
 
@@ -1676,10 +1728,12 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 		// --------------------------------------------------------------------------------------------
 		case GameMessage::MSG_REMOVE_BEACON:
 		{
-	
-			AIGroup *allSelectedObjects = NULL;
-			allSelectedObjects = TheAI->createGroup();
+			AIGroupPtr allSelectedObjects = TheAI->createGroup();
+#if RETAIL_COMPATIBLE_AIGROUP
 			thisPlayer->getCurrentSelectionAsAIGroup(allSelectedObjects); // need to act on all objects, so we can hide teammates' beacons.
+#else
+			thisPlayer->getCurrentSelectionAsAIGroup(allSelectedObjects.Peek()); // need to act on all objects, so we can hide teammates' beacons.
+#endif
 			if( allSelectedObjects )
 			{
 				const VecObjectID& selectedObjects = allSelectedObjects->getAllIDs();
@@ -1720,11 +1774,13 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 						}
 					}
 				}
+#if RETAIL_COMPATIBLE_AIGROUP
 				if (allSelectedObjects->isEmpty())
 				{
 					TheAI->destroyGroup(allSelectedObjects);
 					allSelectedObjects = NULL;
 				}
+#endif
 			}
 			break;
 		} // end beacon removal
@@ -1969,7 +2025,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 
 	}  // end switch
 
-#if RETAIL_COMPATIBLE_CRC
+#if RETAIL_COMPATIBLE_AIGROUP
 	// TheSuperHackers @bugfix xezon 28/06/2025 This hack avoids crashing when players are selected during Replay playback.
 	// It can read data from an already deleted AIGroup and return this function when its member size is 0, signifying that
 	// it is indeed deleted.
@@ -1997,7 +2053,11 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 
 	if( currentlySelectedGroup != NULL )
 	{
+#if RETAIL_COMPATIBLE_AIGROUP
 		TheAI->destroyGroup(currentlySelectedGroup);
+#else
+		currentlySelectedGroup->removeAll();
+#endif
 	}
 
 }  // end logicMessageDispatches

--- a/GeneralsMD/Code/GameEngine/Include/Common/Player.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Player.h
@@ -634,7 +634,7 @@ public:
 	// add to the player's current selection this hotkey team.
 	void processAddTeamGameMessage(Int hotkeyNum, GameMessage *msg);
 
-	// returns an AIGroup object that is the currently selected group.
+	// fills an AIGroup object that is the currently selected group.
 	void getCurrentSelectionAsAIGroup(AIGroup *group);
 
 	// sets the currently selected group to be the given AIGroup

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
@@ -31,6 +31,7 @@
 #define _OBJECT_H_
 
 #include "Lib/BaseType.h"
+#include "ref_ptr.h"
 
 #include "Common/Geometry.h"
 #include "Common/Snapshot.h"
@@ -702,7 +703,11 @@ private:
 
 	GeometryInfo	m_geometryInfo;
 
+#if RETAIL_COMPATIBLE_AIGROUP
 	AIGroup*			m_group;								///< if non-NULL, we are part of this group of agents
+#else
+	RefCountPtr<AIGroup> m_group; ///< if non-NULL, we are part of this group of agents
+#endif
 
 	// These will last for my lifetime.  I will reuse them and reset them.  The truly dynamic ones are in PartitionManager
 	SightingInfo		*m_partitionLastLook;								///< Where and for whom I last looked, so I can undo its effects when I stop

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AI.cpp
@@ -333,6 +333,8 @@ void AI::reset( void )
 		m_aiData = m_aiData->m_next;
 		delete cur;
 	}
+
+#if RETAIL_COMPATIBLE_AIGROUP
 	while (m_groupList.size())
 	{
 		AIGroup *groupToRemove = m_groupList.front();
@@ -345,6 +347,12 @@ void AI::reset( void )
 			m_groupList.pop_front(); // NULL group, just kill from list.  Shouldn't really happen, but just in case.
 		}
 	}
+#else
+	DEBUG_ASSERTCRASH(m_groupList.empty(), ("AI::m_groupList is expected empty already\n"));
+
+	m_groupList.clear(); // Clear just in case...
+#endif
+
 	m_nextGroupID = 0;
 	m_nextFormationID = NO_FORMATION_ID;
 	getNextFormationID(); // increment once past NO_FORMATION_ID.  jba.
@@ -443,14 +451,22 @@ void AI::parseAiDataDefinition( INI* ini )
 /**
  * Create a new AI Group
  */
-AIGroup *AI::createGroup( void )
+AIGroupPtr AI::createGroup( void )
 {
 	// create a new instance
+#if RETAIL_COMPATIBLE_AIGROUP
 	AIGroup *group = newInstance(AIGroup);
+#else
+	AIGroupPtr group = AIGroupPtr::Create_NoAddRef(newInstance(AIGroup));
+#endif
 
 	// add it to the list
 //	DEBUG_LOG(("***AIGROUP %x is being added to m_groupList.\n", group ));
+#if RETAIL_COMPATIBLE_AIGROUP
 	m_groupList.push_back( group );
+#else
+	m_groupList.push_back( group.Peek() );
+#endif
 
 	return group;
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
@@ -238,9 +238,9 @@ Bool AIGroup::remove( Object *obj )
 	// list has changed, properties need recomputation
 	m_dirty = true;
 
-	// if the group is empty, no-one is using it any longer, so destroy it
 	if (isEmpty()) {
 #if RETAIL_COMPATIBLE_AIGROUP
+		// if the group is empty, no-one is using it any longer, so destroy it
 		TheAI->destroyGroup( this );
 #endif
 		return TRUE;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
@@ -92,6 +92,9 @@ AIGroup::~AIGroup()
 {
 //	DEBUG_LOG(("***AIGROUP %x is being destructed.\n", this));
 	// disassociate each member from the group
+
+#if RETAIL_COMPATIBLE_AIGROUP
+
 	std::list<Object *>::iterator i;
 	for( i = m_memberList.begin(); i != m_memberList.end(); /* empty */ )
 	{
@@ -106,6 +109,13 @@ AIGroup::~AIGroup()
 			i = m_memberList.erase(i);
 		}
 	}
+
+#else
+
+	removeAll();
+
+#endif
+
 	if (m_groundPath) {
 		deleteInstance(m_groundPath);
 		m_groundPath = NULL;
@@ -205,6 +215,11 @@ void AIGroup::add( Object *obj )
  */
 Bool AIGroup::remove( Object *obj )
 {
+#if !RETAIL_COMPATIBLE_AIGROUP
+	// Defer deletion until the end of this function.
+	AIGroupPtr refThis = AIGroupPtr::Create_AddRef(this);
+#endif
+
 //	DEBUG_LOG(("***AIGROUP %x is removing Object %x (%s).\n", this, obj, obj->getTemplate()->getName().str()));
 	std::list<Object *>::iterator i = std::find( m_memberList.begin(), m_memberList.end(), obj );
 
@@ -225,11 +240,38 @@ Bool AIGroup::remove( Object *obj )
 
 	// if the group is empty, no-one is using it any longer, so destroy it
 	if (isEmpty()) {
+#if RETAIL_COMPATIBLE_AIGROUP
 		TheAI->destroyGroup( this );
+#endif
 		return TRUE;
 	}
 
 	return FALSE;
+}
+
+/**
+ * Remove all objects from group
+ */
+void AIGroup::removeAll( void )
+{
+#if !RETAIL_COMPATIBLE_AIGROUP
+	// Defer deletion until the end of this function.
+	AIGroupPtr refThis = AIGroupPtr::Create_AddRef(this);
+#endif
+
+	std::list<Object *> memberList;
+	memberList.swap(m_memberList);
+	m_memberListSize = 0;
+	
+	std::list<Object *>::iterator i;
+	for ( i = memberList.begin(); i != memberList.end(); ++i )
+	{
+		Object *member = *i;
+		if (member)
+			member->leaveGroup();
+	}
+
+	m_dirty = true;
 }
 
 /**
@@ -2795,6 +2837,11 @@ void AIGroup::groupCheer( CommandSourceType cmdSource )
 	*/
 void AIGroup::groupSell( CommandSourceType cmdSource )
 {
+#if !RETAIL_COMPATIBLE_AIGROUP
+	// Defer deletion until the end of this function.
+	AIGroupPtr refThis = AIGroupPtr::Create_AddRef(this);
+#endif
+
 	std::list<Object *>::iterator i;
 	std::vector<Object *> groupObjectsCopy;
 	groupObjectsCopy.reserve(m_memberListSize);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -900,11 +900,15 @@ void AIPlayer::guardSupplyCenter( Team *team, Int minSupplies )
 	}
 	if (warehouse) {
 
-		AIGroup* theGroup = TheAI->createGroup();
+		AIGroupPtr theGroup = TheAI->createGroup();
 		if (!theGroup) {
 			return;
 		}
+#if RETAIL_COMPATIBLE_AIGROUP
 		team->getTeamAsAIGroup(theGroup);
+#else
+		team->getTeamAsAIGroup(theGroup.Peek());
+#endif
 		Coord3D location = *warehouse->getPosition();
 		// It's probably a defensive move - position towards the enemy.
 		Region2D bounds;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -2800,9 +2800,9 @@ void AIPlayer::checkReadyTeams( void )
 					/*
 					if (team->m_team->getPrototype()->getTemplateInfo()->m_hasHomeLocation && 
 							!team->m_reinforcement) {
- 						AIGroup* theGroup = TheAI->createGroup();
+ 						AIGroupPtr theGroup = TheAI->createGroup();
 						if (theGroup) {
-							team->m_team->getTeamAsAIGroup(theGroup);
+							team->m_team->getTeamAsAIGroup(theGroup.Peek());
 							Coord3D destination = team->m_team->getPrototype()->getTemplateInfo()->m_homeLocation;
 							theGroup->groupTightenToPosition( &destination, false, CMD_FROM_AI );
 							team->m_frameStarted = TheGameLogic->getFrame();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -4174,8 +4174,12 @@ StateReturnType AIFollowWaypointPathState::update()
 	if (m_moveAsGroup) {
 		if (obj->getControllingPlayer()->isSkirmishAIPlayer()) {
 			Team *team = obj->getTeam();
-			AIGroup *group = TheAI->createGroup();
+			AIGroupPtr group = TheAI->createGroup();
+#if RETAIL_COMPATIBLE_AIGROUP
 			team->getTeamAsAIGroup(group);
+#else
+			team->getTeamAsAIGroup(group.Peek());
+#endif
 
 			Coord3D pos;
 			group->getCenter(&pos);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
@@ -419,12 +419,15 @@ void ScriptActions::doMoveToWaypoint(const AsciiString& team, const AsciiString&
 	// The team is the team based on the name, and the calling team (if any) and the team that
 	// triggered the condition.  jba. :)
 	if (theTeam) {
-		AIGroup* theGroup = TheAI->createGroup();
+		AIGroupPtr theGroup = TheAI->createGroup();
 		if (!theGroup) {
 			return;
 		}
-
+#if RETAIL_COMPATIBLE_AIGROUP
 		theTeam->getTeamAsAIGroup(theGroup);
+#else
+		theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 		Waypoint *way = TheTerrainLogic->getWaypointByName(waypoint);
 		if (way) {
 			Coord3D destination = *way->getLocation();
@@ -783,12 +786,16 @@ void ScriptActions::doCreateReinforcements(const AsciiString& team, const AsciiS
 			theTeam->setActive();
 			if (needToMoveToDestination) 
 			{
-				AIGroup* theGroup = TheAI->createGroup();
+				AIGroupPtr theGroup = TheAI->createGroup();
 				if (!theGroup) 
 				{
 					return;
 				}
+#if RETAIL_COMPATIBLE_AIGROUP
 				theTeam->getTeamAsAIGroup(theGroup);
+#else
+				theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 				theGroup->groupMoveToPosition( &destination, false, CMD_FROM_SCRIPT );
 			}
 		}
@@ -1050,12 +1057,16 @@ void ScriptActions::doAttack(const AsciiString& attackerName, const AsciiString&
 	if( attackingTeam == NULL || victimTeam == NULL )
 		return;
 
-	AIGroup *aiGroup = TheAI->createGroup();
+	AIGroupPtr aiGroup = TheAI->createGroup();
 	if (!aiGroup) {
 		return;
 	}
 
+#if RETAIL_COMPATIBLE_AIGROUP
 	attackingTeam->getTeamAsAIGroup(aiGroup);
+#else
+	attackingTeam->getTeamAsAIGroup(aiGroup.Peek());
+#endif
 	aiGroup->groupAttackTeam(victimTeam, NO_MAX_SHOTS_LIMIT, CMD_FROM_SCRIPT);
 
 }
@@ -1308,12 +1319,16 @@ void ScriptActions::updateTeamSetAttitude(const AsciiString& teamName, Int attit
 		return;
 	}
 
-	AIGroup *pAIGroup = TheAI->createGroup();
+	AIGroupPtr pAIGroup = TheAI->createGroup();
 	if (!pAIGroup) {
 		return;
 	}
 
+#if RETAIL_COMPATIBLE_AIGROUP
 	theSrcTeam->getTeamAsAIGroup(pAIGroup);
+#else
+	theSrcTeam->getTeamAsAIGroup(pAIGroup.Peek());
+#endif
 	pAIGroup->setAttitude((AttitudeType) attitude);
 }
 
@@ -1417,12 +1432,16 @@ void ScriptActions::doTeamAttackArea(const AsciiString& teamName, const AsciiStr
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
 
+#if RETAIL_COMPATIBLE_AIGROUP
 	theTeam->getTeamAsAIGroup(theGroup);
+#else
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 
 	PolygonTrigger *pTrig = TheScriptEngine->getQualifiedTriggerAreaByName(areaName);
 	if (!pTrig) {
@@ -1449,12 +1468,16 @@ void ScriptActions::doTeamAttackNamed(const AsciiString& teamName, const AsciiSt
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
 
+#if RETAIL_COMPATIBLE_AIGROUP
 	theTeam->getTeamAsAIGroup(theGroup);
+#else
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	theGroup->groupAttackObject(theVictim, NO_MAX_SHOTS_LIMIT, CMD_FROM_SCRIPT);
 }
 
@@ -1556,9 +1579,13 @@ void ScriptActions::doTeamEnterNamed(const AsciiString& teamName, const AsciiStr
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
-	theSrcTeam->getTeamAsAIGroup(theGroup);
+	AIGroupPtr theGroup = TheAI->createGroup();
 
+#if RETAIL_COMPATIBLE_AIGROUP
+	theSrcTeam->getTeamAsAIGroup(theGroup);
+#else
+	theSrcTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	theGroup->groupEnter(theTransport, CMD_FROM_SCRIPT);
 }
 
@@ -1592,9 +1619,13 @@ void ScriptActions::doTeamExitAll(const AsciiString& teamName)
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
-	theTeamOfTransports->getTeamAsAIGroup(theGroup);
+	AIGroupPtr theGroup = TheAI->createGroup();
 
+#if RETAIL_COMPATIBLE_AIGROUP
+	theTeamOfTransports->getTeamAsAIGroup(theGroup);
+#else
+	theTeamOfTransports->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	theGroup->groupEvacuate( CMD_FROM_SCRIPT );
 }
 
@@ -1684,11 +1715,15 @@ void ScriptActions::doTeamFollowSkirmishApproachPath(const AsciiString& teamName
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
+#if RETAIL_COMPATIBLE_AIGROUP
 	theTeam->getTeamAsAIGroup(theGroup);
+#else
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	Int count = 0;
 	Coord3D pos;
 	pos.x=pos.y=pos.z=0;
@@ -1747,11 +1782,15 @@ void ScriptActions::doTeamMoveToSkirmishApproachPath(const AsciiString& teamName
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
+#if RETAIL_COMPATIBLE_AIGROUP
 	theTeam->getTeamAsAIGroup(theGroup);
+#else
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	Int count = 0;
 	Coord3D pos;
 	pos.x=pos.y=pos.z=0;
@@ -1795,11 +1834,15 @@ void ScriptActions::doTeamFollowWaypoints(const AsciiString& teamName, const Asc
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
+#if RETAIL_COMPATIBLE_AIGROUP
 	theTeam->getTeamAsAIGroup(theGroup);
+#else
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	Int count = 0;
 	Coord3D pos;
 	pos.x=pos.y=pos.z=0;
@@ -1842,11 +1885,15 @@ void ScriptActions::doTeamFollowWaypointsExact(const AsciiString& teamName, cons
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
+#if RETAIL_COMPATIBLE_AIGROUP
 	theTeam->getTeamAsAIGroup(theGroup);
+#else
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	Int count = 0;
 	Coord3D pos;
 	pos.x=pos.y=pos.z=0;
@@ -1934,11 +1981,15 @@ void ScriptActions::doTeamGuardPosition(const AsciiString& teamName, const Ascii
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
+#if RETAIL_COMPATIBLE_AIGROUP
 	theTeam->getTeamAsAIGroup(theGroup);
+#else
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	Coord3D position = *way->getLocation();
 
 	theGroup->groupGuardPosition( &position, GUARDMODE_NORMAL, CMD_FROM_SCRIPT );
@@ -1955,12 +2006,15 @@ void ScriptActions::doTeamGuardObject(const AsciiString& teamName, const AsciiSt
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
+#if RETAIL_COMPATIBLE_AIGROUP
 	theTeam->getTeamAsAIGroup(theGroup);
-
+#else
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	theGroup->groupGuardObject( theUnit, GUARDMODE_NORMAL, CMD_FROM_SCRIPT );
 }
 
@@ -1975,12 +2029,15 @@ void ScriptActions::doTeamGuardArea(const AsciiString& teamName, const AsciiStri
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
+#if RETAIL_COMPATIBLE_AIGROUP
 	theTeam->getTeamAsAIGroup(theGroup);
-
+#else
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	theGroup->groupGuardArea( pTrig, GUARDMODE_NORMAL, CMD_FROM_SCRIPT );
 }
 
@@ -2013,12 +2070,15 @@ void ScriptActions::doTeamHunt(const AsciiString& teamName)
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
+#if RETAIL_COMPATIBLE_AIGROUP
 	theTeam->getTeamAsAIGroup(theGroup);
-
+#else
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	theGroup->groupHunt( CMD_FROM_SCRIPT );
 }
 //-------------------------------------------------------------------------------------------------
@@ -3338,12 +3398,15 @@ void ScriptActions::doTeamGarrisonSpecificBuilding(const AsciiString& teamName, 
 		return;
 	}
 	
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
-	
+#if RETAIL_COMPATIBLE_AIGROUP
 	theTeam->getTeamAsAIGroup(theGroup);
+#else
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	theGroup->groupEnter(theBuilding, CMD_FROM_SCRIPT);
 }
 
@@ -4413,14 +4476,17 @@ void ScriptActions::doTeamUseCommandButtonAbility( const AsciiString& team, cons
 	}
 
 
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
 	if( !theGroup ) 
 	{
 		return;
 	}
 
-	theTeam->getTeamAsAIGroup( theGroup );
-	
+#if RETAIL_COMPATIBLE_AIGROUP
+	theTeam->getTeamAsAIGroup(theGroup);
+#else
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	theGroup->groupDoCommandButton( commandButton, CMD_FROM_SCRIPT );
 }
 
@@ -4448,14 +4514,17 @@ void ScriptActions::doTeamUseCommandButtonAbilityOnNamed( const AsciiString& tea
 	}
 
 
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
 	if( !theGroup ) 
 	{
 		return;
 	}
 
-	theTeam->getTeamAsAIGroup( theGroup );
-	
+#if RETAIL_COMPATIBLE_AIGROUP
+	theTeam->getTeamAsAIGroup(theGroup);
+#else
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	theGroup->groupDoCommandButtonAtObject( commandButton, theObj, CMD_FROM_SCRIPT );
 }
 
@@ -4483,14 +4552,17 @@ void ScriptActions::doTeamUseCommandButtonAbilityAtWaypoint( const AsciiString& 
 	}
 
 
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
 	if( !theGroup ) 
 	{
 		return;
 	}
 
-	theTeam->getTeamAsAIGroup( theGroup );
-	
+#if RETAIL_COMPATIBLE_AIGROUP
+	theTeam->getTeamAsAIGroup(theGroup);
+#else
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	theGroup->groupDoCommandButtonAtPosition( commandButton, pWaypoint->getLocation(), CMD_FROM_SCRIPT );
 }
 
@@ -4567,12 +4639,15 @@ void ScriptActions::doTeamStop(const AsciiString& teamName, Bool shouldDisband)
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
-
+#if RETAIL_COMPATIBLE_AIGROUP
 	theTeam->getTeamAsAIGroup(theGroup);
+#else
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	theGroup->groupIdle(CMD_FROM_SCRIPT);
 
 	if (shouldDisband) {
@@ -4780,12 +4855,15 @@ void ScriptActions::doTeamStartSequentialScript(const AsciiString& teamName, con
 	}
 
 	// Idle the team so the seq script will start executing. jba.
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
-
+#if RETAIL_COMPATIBLE_AIGROUP
 	team->getTeamAsAIGroup(theGroup);
+#else
+	team->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	theGroup->groupIdle(CMD_FROM_SCRIPT);
 
 
@@ -4887,12 +4965,15 @@ void ScriptActions::doTeamIdleForFramecount(const AsciiString& teamName, Int fra
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
 	if (!theGroup) {
 		return;
 	}
-
+#if RETAIL_COMPATIBLE_AIGROUP
 	theTeam->getTeamAsAIGroup(theGroup);
+#else
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	Coord3D center;
 	theGroup->getCenter(&center);
 
@@ -5366,8 +5447,12 @@ void ScriptActions::doSkirmishAttackNearestGroupWithValue( const AsciiString& te
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
+#if RETAIL_COMPATIBLE_AIGROUP
 	team->getTeamAsAIGroup(theGroup);
+#else
+	team->getTeamAsAIGroup(theGroup.Peek());
+#endif
 
 	Player *player = team->getControllingPlayer();
 
@@ -5395,8 +5480,12 @@ void ScriptActions::doSkirmishCommandButtonOnMostValuable( const AsciiString& te
 		return;
 	}
 
-	AIGroup *theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
+#if RETAIL_COMPATIBLE_AIGROUP
 	team->getTeamAsAIGroup(theGroup);
+#else
+	team->getTeamAsAIGroup(theGroup.Peek());
+#endif
 
 	Player *player = team->getControllingPlayer();
 	if (!player)
@@ -5458,8 +5547,12 @@ void ScriptActions::doTeamUseCommandButtonOnNamed( const AsciiString& teamName, 
 		return;
 	}
 
-	AIGroup *theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
+#if RETAIL_COMPATIBLE_AIGROUP
 	team->getTeamAsAIGroup(theGroup);
+#else
+	team->getTeamAsAIGroup(theGroup.Peek());
+#endif
 
 	const CommandButton *commandButton = TheControlBar->findCommandButton(commandAbility);
 	if(!commandButton) {
@@ -5497,8 +5590,12 @@ void ScriptActions::doTeamUseCommandButtonOnNearestEnemy( const AsciiString& tea
 		return;
 	}
 
-	AIGroup *theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
+#if RETAIL_COMPATIBLE_AIGROUP
 	team->getTeamAsAIGroup(theGroup);
+#else
+	team->getTeamAsAIGroup(theGroup.Peek());
+#endif
 
 	const CommandButton *commandButton = TheControlBar->findCommandButton(commandAbility);
 	if(!commandButton) {
@@ -5543,8 +5640,12 @@ void ScriptActions::doTeamUseCommandButtonOnNearestGarrisonedBuilding( const Asc
 		return;
 	}
 
-	AIGroup *theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
+#if RETAIL_COMPATIBLE_AIGROUP
 	team->getTeamAsAIGroup(theGroup);
+#else
+	team->getTeamAsAIGroup(theGroup.Peek());
+#endif
 
 	const CommandButton *commandButton = TheControlBar->findCommandButton(commandAbility);
 	if(!commandButton) {
@@ -5591,8 +5692,12 @@ void ScriptActions::doTeamUseCommandButtonOnNearestKindof( const AsciiString& te
 		return;
 	}
 
-	AIGroup *theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
+#if RETAIL_COMPATIBLE_AIGROUP
 	team->getTeamAsAIGroup(theGroup);
+#else
+	team->getTeamAsAIGroup(theGroup.Peek());
+#endif
 
 	const CommandButton *commandButton = TheControlBar->findCommandButton(commandAbility);
 	if (!commandButton) {
@@ -5638,8 +5743,12 @@ void ScriptActions::doTeamUseCommandButtonOnNearestBuilding( const AsciiString& 
 		return;
 	}
 
-	AIGroup *theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
+#if RETAIL_COMPATIBLE_AIGROUP
 	team->getTeamAsAIGroup(theGroup);
+#else
+	team->getTeamAsAIGroup(theGroup.Peek());
+#endif
 
 	const CommandButton *commandButton = TheControlBar->findCommandButton(commandAbility);
 	if (!commandButton) {
@@ -5685,8 +5794,12 @@ void ScriptActions::doTeamUseCommandButtonOnNearestBuildingClass( const AsciiStr
 		return;
 	}
 
-	AIGroup *theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
+#if RETAIL_COMPATIBLE_AIGROUP
 	team->getTeamAsAIGroup(theGroup);
+#else
+	team->getTeamAsAIGroup(theGroup.Peek());
+#endif
 
 	const CommandButton *commandButton = TheControlBar->findCommandButton(commandAbility);
 	if (!commandButton) {
@@ -5733,8 +5846,12 @@ void ScriptActions::doTeamUseCommandButtonOnNearestObjectType( const AsciiString
 		return;
 	}
 
-	AIGroup *theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
+#if RETAIL_COMPATIBLE_AIGROUP
 	team->getTeamAsAIGroup(theGroup);
+#else
+	team->getTeamAsAIGroup(theGroup.Peek());
+#endif
 
 	const CommandButton *commandButton = TheControlBar->findCommandButton(commandAbility);
 	if (!commandButton) {
@@ -5863,8 +5980,12 @@ void ScriptActions::doTeamCaptureNearestUnownedFactionUnit( const AsciiString& t
 		return;
 	}
 
-	AIGroup *theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
+#if RETAIL_COMPATIBLE_AIGROUP
 	team->getTeamAsAIGroup(theGroup);
+#else
+	team->getTeamAsAIGroup(theGroup.Peek());
+#endif
 
 	PartitionFilterPlayerAffiliation f1(team->getControllingPlayer(), ALLOW_ENEMIES | ALLOW_NEUTRAL, true);
 	PartitionFilterUnmannedObject f2(true);
@@ -5979,12 +6100,16 @@ void ScriptActions::doTeamEmoticon(const AsciiString& teamName, const AsciiStrin
 		return;
 	}
 
-	AIGroup* theGroup = TheAI->createGroup();
+	AIGroupPtr theGroup = TheAI->createGroup();
 	if( !theGroup ) 
 	{
 		return;
 	}
-	theTeam->getTeamAsAIGroup( theGroup );
+#if RETAIL_COMPATIBLE_AIGROUP
+	theTeam->getTeamAsAIGroup(theGroup);
+#else
+	theTeam->getTeamAsAIGroup(theGroup.Peek());
+#endif
 	
 	Int frames = (Int)( duration * LOGICFRAMES_PER_SECOND );
 	theGroup->groupSetEmoticon( emoticonName, frames );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
@@ -7933,9 +7933,13 @@ void ScriptEngine::evaluateAndProgressAllSequentialScripts( void )
 		}
 
 		AIUpdateInterface *ai = obj ? obj->getAIUpdateInterface() : NULL;
-		AIGroup *aigroup = (team ? TheAI->createGroup() : NULL);
+		AIGroupPtr aigroup = (team ? TheAI->createGroup() : NULL);
 		if (aigroup) {
+#if RETAIL_COMPATIBLE_AIGROUP
 			team->getTeamAsAIGroup(aigroup);
+#else
+			team->getTeamAsAIGroup(aigroup.Peek());
+#endif
 		}
 
 		if( ai || aigroup ) {
@@ -8020,7 +8024,11 @@ void ScriptEngine::evaluateAndProgressAllSequentialScripts( void )
 					} else if (team) {
 						// attempt to rebuild the aigroup, as it probably expired during the action execution
 						aigroup = (team ? TheAI->createGroup() : NULL);
+#if RETAIL_COMPATIBLE_AIGROUP
 						team->getTeamAsAIGroup(aigroup);
+#else
+						team->getTeamAsAIGroup(aigroup.Peek());
+#endif
 					}
 
 					if (aigroup && aigroup->isIdle()) {

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -348,7 +348,7 @@ void GameLogic::prepareNewGame( Int gameMode, GameDifficulty diff, Int rankPoint
 //-------------------------------------------------------------------------------------------------
 /** This message handles dispatches object command messages to the
   * appropriate objects.
-	* @todo Rename this to "CommandProcessor", or similiar. */
+	* @todo Rename this to "CommandProcessor", or similar. */
 //-------------------------------------------------------------------------------------------------
 void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 {
@@ -360,7 +360,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 	DEBUG_ASSERTCRASH( thisPlayer, ("logicMessageDispatcher: Processing message from unknown player (player index '%d')\n", 
 																	msg->getPlayerIndex()) );
 	
-	AIGroup *currentlySelectedGroup = NULL;
+	AIGroupPtr currentlySelectedGroup = NULL;
 
 	if (isInGame())
 	{
@@ -369,15 +369,21 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			if (msg->getType() != GameMessage::MSG_LOGIC_CRC && msg->getType() != GameMessage::MSG_SET_REPLAY_CAMERA)
 			{
 				currentlySelectedGroup = TheAI->createGroup(); // can't do this outside a game - it'll cause sync errors galore.
-				CRCGEN_LOG(( "Creating AIGroup %d in GameLogic::logicMessageDispatcher()\n", (currentlySelectedGroup)?currentlySelectedGroup->getID():0 ));
+				CRCGEN_LOG(( "Creating AIGroup %d in GameLogic::logicMessageDispatcher()\n", currentlySelectedGroup?currentlySelectedGroup->getID():0 ));
+#if RETAIL_COMPATIBLE_AIGROUP
 				thisPlayer->getCurrentSelectionAsAIGroup(currentlySelectedGroup);
+#else
+				thisPlayer->getCurrentSelectionAsAIGroup(currentlySelectedGroup.Peek());
+#endif
 
-				// We can't issue commands to groups that contain units that don't belong the issuing player, so pretend like 
+				// We can't issue commands to groups that contain units that don't belong to the issuing player, so pretend like 
 				// there's nothing selected. Also, if currentlySelectedGroup is empty, go ahead and delete it, so that we can skip
 				// any processing on it.
 				if (currentlySelectedGroup->isEmpty())
 				{
+#if RETAIL_COMPATIBLE_AIGROUP
 					TheAI->destroyGroup(currentlySelectedGroup);
+#endif
 					currentlySelectedGroup = NULL;
 				}
 
@@ -459,7 +465,13 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 #endif
 
 			if (currentlySelectedGroup)
+			{
+#if RETAIL_COMPATIBLE_AIGROUP
 				TheAI->destroyGroup(currentlySelectedGroup);
+#else
+				currentlySelectedGroup->removeAll();
+#endif
+			}
 			currentlySelectedGroup = NULL;
 			TheGameLogic->clearGameData();
 			break;
@@ -675,10 +687,14 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Object* source = TheGameLogic->findObjectByID(sourceID);
 			if (source != NULL)
 			{
-				AIGroup* theGroup = TheAI->createGroup();
+				AIGroupPtr theGroup = TheAI->createGroup();
 				theGroup->add(source);
 				theGroup->groupDoSpecialPower( specialPowerID, options );
+#if RETAIL_COMPATIBLE_AIGROUP
 				TheAI->destroyGroup(theGroup);
+#else
+				theGroup->removeAll();
+#endif
 			}
 			else
 			{
@@ -716,10 +732,14 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Object* source = TheGameLogic->findObjectByID(sourceID);
 			if (source != NULL)
 			{
-				AIGroup* theGroup = TheAI->createGroup();
+				AIGroupPtr theGroup = TheAI->createGroup();
 				theGroup->add(source);
 				theGroup->groupDoSpecialPowerAtLocation( specialPowerID, &targetCoord, angle, objectInWay, options );
+#if RETAIL_COMPATIBLE_AIGROUP
 				TheAI->destroyGroup(theGroup);
+#else
+				theGroup->removeAll();
+#endif
 			}
 			else
 			{
@@ -755,10 +775,14 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Object* source = TheGameLogic->findObjectByID(sourceID);
 			if (source != NULL)
 			{
-				AIGroup* theGroup = TheAI->createGroup();
+				AIGroupPtr theGroup = TheAI->createGroup();
 				theGroup->add(source);
 				theGroup->groupDoSpecialPowerAtObject( specialPowerID, target, options );
+#if RETAIL_COMPATIBLE_AIGROUP
 				TheAI->destroyGroup(theGroup);
+#else
+				theGroup->removeAll();
+#endif
 			}
 			else
 			{
@@ -1003,7 +1027,11 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 		case GameMessage::MSG_EXIT:
 		{
 			Object *objectWantingToExit = TheGameLogic->findObjectByID( msg->getArgument( 0 )->objectID );
+#if RETAIL_COMPATIBLE_AIGROUP
 			Object *objectContainingExiter = getSingleObjectFromSelection(currentlySelectedGroup);
+#else
+			Object *objectContainingExiter = getSingleObjectFromSelection(currentlySelectedGroup.Peek());
+#endif
 
 			// sanity
 			if( objectWantingToExit == NULL )
@@ -1190,10 +1218,14 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Object* source = TheGameLogic->findObjectByID(sourceID);
 			if (source != NULL)
 			{
-				AIGroup* theGroup = TheAI->createGroup();
+				AIGroupPtr theGroup = TheAI->createGroup();
 				theGroup->add(source);
 				theGroup->groupOverrideSpecialPowerDestination( spType, loc, CMD_FROM_PLAYER );
+#if RETAIL_COMPATIBLE_AIGROUP
 				TheAI->destroyGroup(theGroup);
+#else
+				theGroup->removeAll();
+#endif
 			}
 			else
 			{
@@ -1305,7 +1337,11 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 		//---------------------------------------------------------------------------------------------
 		case GameMessage::MSG_CANCEL_UPGRADE:
 		{
+#if RETAIL_COMPATIBLE_AIGROUP
 			Object *producer = getSingleObjectFromSelection(currentlySelectedGroup);
+#else
+			Object *producer = getSingleObjectFromSelection(currentlySelectedGroup.Peek());
+#endif
 			const UpgradeTemplate *upgradeT = TheUpgradeCenter->findUpgradeByKey( (NameKeyType)(msg->getArgument( 0 )->integer) );
 
 			// sanity
@@ -1331,7 +1367,11 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 		//---------------------------------------------------------------------------------------------
 		case GameMessage::MSG_QUEUE_UNIT_CREATE:
 		{
+#if RETAIL_COMPATIBLE_AIGROUP
 			Object *producer = getSingleObjectFromSelection(currentlySelectedGroup);
+#else
+			Object *producer = getSingleObjectFromSelection(currentlySelectedGroup.Peek());
+#endif
 			const ThingTemplate *whatToCreate;
 			ProductionID productionID;
 
@@ -1364,7 +1404,11 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 		//-------------------------------------------------------------------------------------------------
 		case GameMessage::MSG_CANCEL_UNIT_CREATE:
 		{
+#if RETAIL_COMPATIBLE_AIGROUP
 			Object *producer = getSingleObjectFromSelection(currentlySelectedGroup);
+#else
+			Object *producer = getSingleObjectFromSelection(currentlySelectedGroup.Peek());
+#endif
 			ProductionID productionID = (ProductionID)msg->getArgument( 0 )->integer;
 			
 			// sanity
@@ -1396,7 +1440,11 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Real angle;
 
 			// get player, what to place, and location
+#if RETAIL_COMPATIBLE_AIGROUP
 			Object *constructorObject = getSingleObjectFromSelection(currentlySelectedGroup);
+#else
+			Object *constructorObject = getSingleObjectFromSelection(currentlySelectedGroup.Peek());
+#endif
 			place = TheThingFactory->findByTemplateID( msg->getArgument( 0 )->integer );
 			loc = msg->getArgument( 1 )->location;
 			angle = msg->getArgument( 2 )->real;
@@ -1443,7 +1491,11 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 		{
 
 			// get the building to cancel construction on
+#if RETAIL_COMPATIBLE_AIGROUP
 			Object *building = getSingleObjectFromSelection(currentlySelectedGroup);
+#else
+			Object *building = getSingleObjectFromSelection(currentlySelectedGroup.Peek());
+#endif
 			if( building == NULL )
 				break;
 
@@ -1704,10 +1756,12 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 		// --------------------------------------------------------------------------------------------
 		case GameMessage::MSG_REMOVE_BEACON:
 		{
-	
-			AIGroup *allSelectedObjects = NULL;
-			allSelectedObjects = TheAI->createGroup();
+			AIGroupPtr allSelectedObjects = TheAI->createGroup();
+#if RETAIL_COMPATIBLE_AIGROUP
 			thisPlayer->getCurrentSelectionAsAIGroup(allSelectedObjects); // need to act on all objects, so we can hide teammates' beacons.
+#else
+			thisPlayer->getCurrentSelectionAsAIGroup(allSelectedObjects.Peek()); // need to act on all objects, so we can hide teammates' beacons.
+#endif
 			if( allSelectedObjects )
 			{
 				const VecObjectID& selectedObjects = allSelectedObjects->getAllIDs();
@@ -1748,11 +1802,13 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 						}
 					}
 				}
+#if RETAIL_COMPATIBLE_AIGROUP
 				if (allSelectedObjects->isEmpty())
 				{
 					TheAI->destroyGroup(allSelectedObjects);
 					allSelectedObjects = NULL;
 				}
+#endif
 			}
 			break;
 		} // end beacon removal
@@ -1997,7 +2053,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 
 	}  // end switch
 
-#if RETAIL_COMPATIBLE_CRC
+#if RETAIL_COMPATIBLE_AIGROUP
 	// TheSuperHackers @bugfix xezon 28/06/2025 This hack avoids crashing when players are selected during Replay playback.
 	// It can read data from an already deleted AIGroup and return this function when its member size is 0, signifying that
 	// it is indeed deleted.
@@ -2025,7 +2081,11 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 
 	if( currentlySelectedGroup != NULL )
 	{
+#if RETAIL_COMPATIBLE_AIGROUP
 		TheAI->destroyGroup(currentlySelectedGroup);
+#else
+		currentlySelectedGroup->removeAll();
+#endif
 	}
 
 }  // end logicMessageDispatches


### PR DESCRIPTION
* Merge after #1212
* Replaces #1004
* Fixes #75

This change fixes a critical problem with AIGroup, that happens all the time in any match, but only crashes the Replay playback when a player is selected. The memory management of AIGroup is totally broken, and it will leak many AIGroups in AI matches (or matches that use AI scripts) and that will slow down iterating over `std::list<AIGroup *> m_groupList`.

## The Problem

AIGroup has a fundamental memory management flaw with its `AIGroup::remove` function. It deletes itself when all members are removed, which means that any non-AIGroup members holding a reference to that AIGroup will dangle when it is deleted.

This happens all the time in `GameLogic::logicMessageDispatcher` with its `currentlySelectedGroup` variable. It holds objects in a AIGroup, but that AIGroup can be deleted by external events, for example

```cpp
void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
{
...
  AIGroup* currentlySelectedGroup = NULL;

  if (isInGame())
  {
    if (msg->getType() >= GameMessage::MSG_BEGIN_NETWORK_MESSAGES && msg->getType() <= GameMessage::MSG_END_NETWORK_MESSAGES)
    {
      if (msg->getType() != GameMessage::MSG_LOGIC_CRC && msg->getType() != GameMessage::MSG_SET_REPLAY_CAMERA)
      {
        currentlySelectedGroup = TheAI->createGroup(); // can't do this outside a game - it'll cause sync errors galore.
        CRCGEN_LOG(( "Creating AIGroup %d in GameLogic::logicMessageDispatcher()\n", (currentlySelectedGroup)?currentlySelectedGroup->getID():0 ));
        thisPlayer->getCurrentSelectionAsAIGroup(currentlySelectedGroup);

...
  // process the message
  GameMessage::Type msgType = msg->getType();
  switch( msgType )
  {
...
    case GameMessage::MSG_REMOVE_BEACON:
    {
      AIGroup* allSelectedObjects = TheAI->createGroup();
      thisPlayer->getCurrentSelectionAsAIGroup(allSelectedObjects); // <----- xezon: this will delete the AIGroup pointed to by currentlySelectedGroup
```

There are multiple code paths like this that can delete `currentlySelectedGroup`.

## The Solution

Properly reference count AIGroup so that an AIGroup is only destroyed when all owners let go off it. This fixes all problems, any potential leaks, crashes. It also makes the code simpler in some places.

The reference counted AIGroup is compiled out with RETAIL_COMPATIBLE_AIGROUP, because it WILL mismatch with Retail, because of all the memory leaks and whatever else happens when touching this code. However, !RETAIL_COMPATIBLE_AIGROUP is compatible with the Golden Replay 1, likely because the humans do not use all the scripts that leak AIGroups.

## TODO

- [x] Test against VC6 Golden Replay
- [x] Replicate in Generals
- [x] Test against more replays