### PR TITLE
[ZH] Fix game crash in MissileLauncherBuildingUpdate::initiateIntentToDoSpecialPower()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/SpecialPower/SpecialPowerModule.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/SpecialPower/SpecialPowerModule.cpp
@@ -99,7 +99,11 @@ SpecialPowerModule::SpecialPowerModule( Thing *thing, const ModuleData *moduleDa
 									: BehaviorModule( thing, moduleData )
 {
 
+#if RETAIL_COMPATIBLE_CRC
 	m_availableOnFrame = 0;
+#else
+	m_availableOnFrame = 0xFFFFFFFF;
+#endif
 	m_pausedCount = 0;
 	m_pausedOnFrame = 0;
 	m_pausedPercent = 0.0f;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/SpecialPower/OCLSpecialPower.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/SpecialPower/OCLSpecialPower.cpp
@@ -180,6 +180,12 @@ void OCLSpecialPower::doSpecialPowerAtLocation( const Coord3D *loc, Real angle, 
 	// call the base class action cause we are *EXTENDING* functionality
 	SpecialPowerModule::doSpecialPowerAtLocation( &targetCoord, angle, commandOptions );
 
+#if RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @info we need to leave early if we are in the MissileLauncherBuildingUpdate crash fix codepath
+	if (m_availableOnFrame == 0xFFFFFFFF)
+		return;
+#endif
+
 	const ObjectCreationList* ocl = findOCL();
 
 	// at what point will the "deliverer" come in

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/SpecialPower/SpecialPowerModule.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/SpecialPower/SpecialPowerModule.cpp
@@ -101,7 +101,11 @@ SpecialPowerModule::SpecialPowerModule( Thing *thing, const ModuleData *moduleDa
 									: BehaviorModule( thing, moduleData )
 {
 
+#if RETAIL_COMPATIBLE_CRC
 	m_availableOnFrame = 0;
+#else
+	m_availableOnFrame = 0xFFFFFFFF;
+#endif
 	m_pausedCount = 0;
 	m_pausedOnFrame = 0;
 	m_pausedPercent = 0.0f;
@@ -455,6 +459,15 @@ Bool SpecialPowerModule::initiateIntentToDoSpecialPower( const Object *targetObj
 		}
 	}
 
+#if RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @info we need to leave early if we are in the MissileLauncherBuildingUpdate crash fix codepath
+	if (m_availableOnFrame == 0xFFFFFFFF)
+	{
+		DEBUG_ASSERTCRASH(!valid, ("Using MissileLauncherBuildingUpdate escape path when valid is set to true"));
+		return false;
+	}
+#endif
+
 	getObject()->getControllingPlayer()->getAcademyStats()->recordSpecialPowerUsed( getSpecialPowerModuleData()->m_specialPowerTemplate );
 	
 	//If we depend on our update module to trigger the special power, make sure we have the
@@ -714,6 +727,12 @@ void SpecialPowerModule::doSpecialPowerAtLocation( const Coord3D *loc, Real angl
 	//This tells the update module that we want to do our special power. The update modules
 	//will then start processing each frame.
 	initiateIntentToDoSpecialPower( NULL, loc, NULL, commandOptions );
+
+#if RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @info we need to leave early if we are in the MissileLauncherBuildingUpdate crash fix codepath
+	if (m_availableOnFrame == 0xFFFFFFFF)
+		return;
+#endif
 
 	//Only trigger the special power immediately if the updatemodule doesn't start the attack.
 	//An example of a case that wouldn't trigger immediately is for a unit that needs to 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/MissileLauncherBuildingUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/MissileLauncherBuildingUpdate.cpp
@@ -206,6 +206,15 @@ void MissileLauncherBuildingUpdate::switchToState(DoorStateType dst)
 //-------------------------------------------------------------------------------------------------
 Bool MissileLauncherBuildingUpdate::initiateIntentToDoSpecialPower( const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions )
 {
+#if RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix Mauller 29/06/2025 prevent a game crash when told to launch before ready to do so
+	if (!m_specialPowerModule) {
+		Object* us = getObject();
+		us->getSpecialPowerModule(specialPowerTemplate)->setReadyFrame(0xFFFFFFFF);
+		return FALSE;
+	}
+#endif
+
 	if( m_specialPowerModule->getSpecialPowerTemplate() != specialPowerTemplate )
 	{
 		return FALSE;


### PR DESCRIPTION
This fixes a crash due to the nuke launcher not having its special power module loaded till it is fully constructed. 
This was possibly intentional due to reasons described further on. The hack could have been avoided in other ways if the returns from quite a few functions were used and checked properly, but the hack i put in place is the only way to keep retail compatibility for now while preventing the crash.

The crash occurs within MissileLauncherBuildingUpdate::initiateIntentToDoSpecialPower() when attempting to retrieve the special power template from the special power module.

The issue occurs due to special power timers being initialised to zero instead of max uint. This is relevant as special power timers are set into the future for when the special power is ready based on the current frame.

The game then counts down to the future `m_availableOnFrame` value, where it then considers the special power available. By it being set to zero it can allow activation before it is meant to be usable.

The full fix for this is setting the special power ready frame to be initialised to max uint, this prevents the messages activating the special power from being sent long before the point of the crash.
But `m_availableOnFrame` is part of the CRC check, so i had to instead catch the crash point and set the ready frame into the future and then add some code to escape the activation of the power.

In this instance the full escape is required as fixing the crash introduced an exploit where the power will immediately activate.

I won't post the reproduction steps here due to the nature of this bug.
Talk to me outside of this PR to learn the reproduction steps.

EDIT:

This PR also adds the special power timers exploit fix to generals behind a retail compatible CRC conditional.

## TODO
- [x] Check and replicate in generals if necessary