### PR TITLE
[GEN][ZH] Fix crash when using a Civilian Ferry that has no waypoint path

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/RailedTransportAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/RailedTransportAIUpdate.cpp
@@ -229,21 +229,28 @@ UpdateSleepTime RailedTransportAIUpdate::update( void )
 		// sanity
 		DEBUG_ASSERTCRASH( waypoint, ("RailedTransportAIUpdate: Invalid target waypoint\n") );
 
-		// how far away are we from the target waypoint
-		const Coord3D *start = us->getPosition();
-		const Coord3D *end = waypoint->getLocation();
-		Coord3D v;
-		v.x = end->x - start->x;
-		v.y = end->y - start->y;
-		v.z = end->z - start->z;
-		Real dist = v.length();
-		if( dist <= 5.0f || isIdle() )
+		if (waypoint)
 		{
+			// how far away are we from the target waypoint
+			const Coord3D *start = us->getPosition();
+			const Coord3D *end = waypoint->getLocation();
+			Coord3D v;
+			v.x = end->x - start->x;
+			v.y = end->y - start->y;
+			v.z = end->z - start->z;
+			Real dist = v.length();
+			if( dist <= 5.0f || isIdle() )
+			{
 
-			// we are no longer in transit
+				// we are no longer in transit
+				setInTransit( FALSE );
+
+			}  // end if
+		}
+		else
+		{
 			setInTransit( FALSE );
-
-		}  // end if
+		}
 
 	}  // end if
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/RailedTransportAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/RailedTransportAIUpdate.cpp
@@ -229,21 +229,28 @@ UpdateSleepTime RailedTransportAIUpdate::update( void )
 		// sanity
 		DEBUG_ASSERTCRASH( waypoint, ("RailedTransportAIUpdate: Invalid target waypoint\n") );
 
-		// how far away are we from the target waypoint
-		const Coord3D *start = us->getPosition();
-		const Coord3D *end = waypoint->getLocation();
-		Coord3D v;
-		v.x = end->x - start->x;
-		v.y = end->y - start->y;
-		v.z = end->z - start->z;
-		Real dist = v.length();
-		if( dist <= 5.0f || isIdle() )
+		if (waypoint)
 		{
+			// how far away are we from the target waypoint
+			const Coord3D *start = us->getPosition();
+			const Coord3D *end = waypoint->getLocation();
+			Coord3D v;
+			v.x = end->x - start->x;
+			v.y = end->y - start->y;
+			v.z = end->z - start->z;
+			Real dist = v.length();
+			if( dist <= 5.0f || isIdle() )
+			{
 
-			// we are no longer in transit
+				// we are no longer in transit
+				setInTransit( FALSE );
+
+			}  // end if
+		}
+		else
+		{
 			setInTransit( FALSE );
-
-		}  // end if
+		}
 
 	}  // end if
 


### PR DESCRIPTION
- Fixes: #1072 

This PR fixes a crash that occurs when a civilian ferry is being used without being properly setup. 
When the go button is pressed the ferry will cause a crash if it is missing the waypoints for the path that it would travel along.

So we have to test that we have a valid waypoint from the path before choosing to move, if we have no valid waypoints then we also need to reset the `inTransit` variable.