### PR TITLE
[GEN][ZH] Decouple tree, water and wave movements from client FPS

### DIFF
--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
@@ -1199,23 +1199,21 @@ void WaterRenderObjClass::update( void )
 	if( TheGameLogic )
 		currLogicFrame = TheGameLogic->getFrame();
 
-	m_riverVOrigin += 0.002f;
-	m_riverXOffset += (Real)(0.0125*33/5000);
-	m_riverYOffset += (Real)(2*0.0125*33/5000);
-	if (m_riverXOffset > 1) m_riverXOffset -= 1;
-	if (m_riverYOffset > 1) m_riverYOffset -= 1;
-	if (m_riverXOffset < -1) m_riverXOffset += 1;
-	if (m_riverYOffset < -1) m_riverYOffset += 1;
- 	m_iBumpFrame++;
-	if (m_iBumpFrame >= NUM_BUMP_FRAMES) {
-		m_iBumpFrame = 0;
-	}
-
-
-
-	// we only process some things if the logic frame has changed
+	// we only process things if the logic frame has changed
 	if( lastLogicFrame != currLogicFrame )
 	{
+
+		m_riverVOrigin += 0.002f;
+		m_riverXOffset += (Real)(0.0125*33/5000);
+		m_riverYOffset += (Real)(2*0.0125*33/5000);
+		if (m_riverXOffset > 1) m_riverXOffset -= 1;
+		if (m_riverYOffset > 1) m_riverYOffset -= 1;
+		if (m_riverXOffset < -1) m_riverXOffset += 1;
+		if (m_riverYOffset < -1) m_riverYOffset += 1;
+ 		m_iBumpFrame++;
+		if (m_iBumpFrame >= NUM_BUMP_FRAMES) {
+			m_iBumpFrame = 0;
+		}
 
 		// for vertex animated water we need to update the vector field
 		if( m_doWaterGrid && m_meshInMotion == TRUE )

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWaterTracks.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWaterTracks.cpp
@@ -832,9 +832,6 @@ void WaterTracksRenderSystem::update()
 	Int timeDiff = timeGetTime()-iLastTime;
 	iLastTime += timeDiff;
 
-	//Lock framerate to 30 fps
-	timeDiff = 1.0f/30.0f*1000.0f;
-
 	//first update all the tracks
 	while( mod )
 	{

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DTreeBuffer.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DTreeBuffer.h
@@ -254,6 +254,7 @@ private:
 	Real		m_curSwayOffset[MAX_SWAY_TYPES];
 	Real		m_curSwayStep[MAX_SWAY_TYPES];
 	Real		m_curSwayFactor[MAX_SWAY_TYPES];
+	Int			m_lastLogicFrame;
 
 	W3DProjectedShadow *m_shadow;
 	

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DTreeBuffer.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DTreeBuffer.cpp
@@ -1286,6 +1286,8 @@ void W3DTreeBuffer::clearAllTrees(void)
 		m_areaPartition[i] = END_OF_PARTITION;
 	}
 	m_numTreeTypes = 0;
+
+	m_lastLogicFrame = 0;
 }
 
 //=============================================================================
@@ -1551,6 +1553,16 @@ void W3DTreeBuffer::drawTrees(CameraClass * camera, RefRenderObjListIterator *pD
 	if (TheGameLogic && TheGameLogic->isGamePaused()) {
 		pause = true;
 	}
+
+	// TheSuperHackers @bugfix Mauller 04/07/2025 decouple the tree sway position updates from the client fps
+	if (TheGameLogic) {
+		UnsignedInt currentFrame = TheGameLogic->getFrame();
+		if (m_lastLogicFrame == currentFrame) {
+			pause = true;
+		}
+		m_lastLogicFrame = currentFrame;
+	}
+
 	Int i;
 	if (!pause) {
 		if (info.m_breezeVersion != m_curSwayVersion) 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
@@ -1222,23 +1222,21 @@ void WaterRenderObjClass::update( void )
 	if( TheGameLogic )
 		currLogicFrame = TheGameLogic->getFrame();
 
-	m_riverVOrigin += 0.002f;
-	m_riverXOffset += (Real)(0.0125*33/5000);
-	m_riverYOffset += (Real)(2*0.0125*33/5000);
-	if (m_riverXOffset > 1) m_riverXOffset -= 1;
-	if (m_riverYOffset > 1) m_riverYOffset -= 1;
-	if (m_riverXOffset < -1) m_riverXOffset += 1;
-	if (m_riverYOffset < -1) m_riverYOffset += 1;
- 	m_iBumpFrame++;
-	if (m_iBumpFrame >= NUM_BUMP_FRAMES) {
-		m_iBumpFrame = 0;
-	}
-
-
-
-	// we only process some things if the logic frame has changed
+	// we only process things if the logic frame has changed
 	if( lastLogicFrame != currLogicFrame )
 	{
+
+		m_riverVOrigin += 0.002f;
+		m_riverXOffset += (Real)(0.0125*33/5000);
+		m_riverYOffset += (Real)(2*0.0125*33/5000);
+		if (m_riverXOffset > 1) m_riverXOffset -= 1;
+		if (m_riverYOffset > 1) m_riverYOffset -= 1;
+		if (m_riverXOffset < -1) m_riverXOffset += 1;
+		if (m_riverYOffset < -1) m_riverYOffset += 1;
+ 		m_iBumpFrame++;
+		if (m_iBumpFrame >= NUM_BUMP_FRAMES) {
+			m_iBumpFrame = 0;
+		}
 
 		// for vertex animated water we need to update the vector field
 		if( m_doWaterGrid && m_meshInMotion == TRUE )

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWaterTracks.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWaterTracks.cpp
@@ -835,9 +835,6 @@ void WaterTracksRenderSystem::update()
 	Int timeDiff = timeGetTime()-iLastTime;
 	iLastTime += timeDiff;
 
-	//Lock framerate to 30 fps
-	timeDiff = 1.0f/30.0f*1000.0f;
-
 	//first update all the tracks
 	while( mod )
 	{


### PR DESCRIPTION
- Fixes: https://github.com/TheSuperHackers/GeneralsGameCode/issues/117

This PR fixes the abnormal animations of Trees, water and waves within Zero Hour and Partly within Generals.
Generals does not have the same Tree managment code that Zero Hour has.

For the Water movement, it only required moving a block of code into the already present block that limited the updates to the logic tick rate.

For waves, they had naively added a fixed update time of 33ms, even though the code already functioned properly if it had the actual time since last update passed into the render functions. This resulted in the waves updating quicker than they should when the client FPS went above 30.

The tree code required little extra code to limit the update of the tree sway without affecting the rendering.
I took advantage of the already present `pause` functionality that was included to pause updating the tree sway. This way i could lock the sway to the logic tick rate while alowing the rest of the code to update shadows and tree rendering with little extra code.