### PR TITLE
[CORE] Reduce cost of XferCRC::xferImplementation by 60%

### DIFF
--- a/Core/GameEngine/Include/Common/XferCRC.h
+++ b/Core/GameEngine/Include/Common/XferCRC.h
@@ -64,7 +64,7 @@ protected:
 
 	virtual void xferImplementation( void *data, Int dataSize );
 
-	void addCRC( UnsignedInt val );								///< CRC a 4-byte block
+	inline void addCRC( UnsignedInt val );								///< CRC a 4-byte block
 
 	UnsignedInt m_crc;
 


### PR DESCRIPTION
This PR refactors the XferCRC to make the code branchless and to remove the winsock dependency within it.

There may be minimal performance improvement from this as other factors will need changing in the data being passed to the CRC to further improve the performance.

The winsock dependency has been replaced with the endian compat library instead.