### PR TITLE
refactor(recorder): Replace fopen with FileSystem in Replay Recorder

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/Recorder.h
+++ b/Generals/Code/GameEngine/Include/Common/Recorder.h
@@ -28,6 +28,8 @@
 #include "Common/MessageStream.h"
 #include "GameNetwork/GameInfo.h"
 
+class File;
+
 /**
   * The ReplayGameInfo class holds information about the replay game and
 	* the contents of its slot list for reconstructing multiplayer games.
@@ -154,7 +156,7 @@ protected:
 
 	CullBadCommandsResult cullBadCommands(); ///< prevent the user from giving mouse commands that he shouldn't be able to do during playback.
 
-	FILE *m_file;
+	File* m_file;
 	AsciiString m_fileName;
 	Int m_currentFilePosition;
 	RecorderModeType m_mode;

--- a/GeneralsMD/Code/GameEngine/Include/Common/Recorder.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Recorder.h
@@ -28,6 +28,8 @@
 #include "Common/MessageStream.h"
 #include "GameNetwork/GameInfo.h"
 
+class File;
+
 /**
   * The ReplayGameInfo class holds information about the replay game and
 	* the contents of its slot list for reconstructing multiplayer games.
@@ -154,7 +156,7 @@ protected:
 
 	CullBadCommandsResult cullBadCommands(); ///< prevent the user from giving mouse commands that he shouldn't be able to do during playback.
 
-	FILE *m_file;
+	File* m_file;
 	AsciiString m_fileName;
 	Int m_currentFilePosition;
 	RecorderModeType m_mode;

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -25,6 +25,7 @@
 #include "PreRTS.h"	// This must go first in EVERY cpp file int the GameEngine
 
 #include "Common/Recorder.h"
+#include "Common/file.h"
 #include "Common/FileSystem.h"
 #include "Common/PlayerList.h"
 #include "Common/Player.h"
@@ -46,6 +47,7 @@
 #include "Common/CRCDebug.h"
 #include "Common/version.h"
 
+CONSTEXPR const char s_genrep[] = "GENREP";
 
 Int REPLAY_CRC_INTERVAL = 100;
 
@@ -73,20 +75,20 @@ void RecorderClass::logGameStart(AsciiString options)
 		return;
 
 	time(&startTime);
-	UnsignedInt fileSize = ftell(m_file);
+	UnsignedInt fileSize = m_file->size();
 	// move to appropriate offset
-	if (!fseek(m_file, startTimeOffset, SEEK_SET))
+	if ( m_file->seek(startTimeOffset, File::seekMode::START) == startTimeOffset )
 	{
 		// save off start time
 		replay_time_t tmp = (replay_time_t)startTime;
-		fwrite(&tmp, sizeof(replay_time_t), 1, m_file);
+		m_file->write(&tmp, sizeof(tmp));
 	}
 	// move back to end of stream
 #ifdef DEBUG_CRASHING
 	Int res =
 #endif
-		fseek(m_file, fileSize, SEEK_SET);
-	DEBUG_ASSERTCRASH(res == 0, ("Could not seek to end of file!"));
+	m_file->seek(fileSize, File::seekMode::START);
+	DEBUG_ASSERTCRASH(res == fileSize, ("Could not seek to end of file!"));
 
 #if defined(RTS_DEBUG)
 	if (TheNetwork && TheGlobalData->m_saveStats)
@@ -134,20 +136,21 @@ void RecorderClass::logPlayerDisconnect(UnicodeString player, Int slot)
 	{
 		return;
 	}
-	UnsignedInt fileSize = ftell(m_file);
+	UnsignedInt fileSize = m_file->size();
 	// move to appropriate offset
-	if (!fseek(m_file, disconOffset + slot*sizeof(Bool), SEEK_SET))
+	Int playerSlotDisconOffset = disconOffset + slot * sizeof(Bool);
+	if ( m_file->seek(playerSlotDisconOffset, File::seekMode::START) == playerSlotDisconOffset )
 	{
 		// save off discon status
-		Bool b = TRUE;
-		fwrite(&b, sizeof(Bool), 1, m_file);
+		Bool flag = TRUE;
+		m_file->write(&flag, sizeof(flag));
 	}
 	// move back to end of stream
 #ifdef DEBUG_CRASHING
 	Int res =
 #endif
-		fseek(m_file, fileSize, SEEK_SET);
-	DEBUG_ASSERTCRASH(res == 0, ("Could not seek to end of file!"));
+	m_file->seek(fileSize, File::seekMode::START);
+	DEBUG_ASSERTCRASH(res == fileSize, ("Could not seek to end of file!"));
 
 #if defined(RTS_DEBUG)
 	if (TheGlobalData->m_saveStats)
@@ -179,20 +182,20 @@ void RecorderClass::logCRCMismatch( void )
 	if (!m_file)
 		return;
 
-	UnsignedInt fileSize = ftell(m_file);
+	UnsignedInt fileSize = m_file->size();
 	// move to appropriate offset
-	if (!fseek(m_file, desyncOffset, SEEK_SET))
+	if ( m_file->seek(desyncOffset, File::seekMode::START) == desyncOffset )
 	{
 		// save off desync status
-		Bool b = TRUE;
-		fwrite(&b, sizeof(Bool), 1, m_file);
+		Bool flag = TRUE;
+		m_file->write(&flag, sizeof(flag));
 	}
 	// move back to end of stream
 #ifdef DEBUG_CRASHING
 	Int res =
 #endif
-		fseek(m_file, fileSize, SEEK_SET);
-	DEBUG_ASSERTCRASH(res == 0, ("Could not seek to end of file!"));
+	m_file->seek(fileSize, File::seekMode::START);
+	DEBUG_ASSERTCRASH(res == fileSize, ("Could not seek to end of file!"));
 
 #if defined(RTS_DEBUG)
 	if (TheGlobalData->m_saveStats)
@@ -228,26 +231,26 @@ void RecorderClass::logGameEnd( void )
 	time_t t;
 	time(&t);
 	UnsignedInt frameCount = TheGameLogic->getFrame();
-	UnsignedInt fileSize = ftell(m_file);
+	UnsignedInt fileSize = m_file->size();
 	// move to appropriate offset
-	if (!fseek(m_file, endTimeOffset, SEEK_SET))
+	if ( m_file->seek(endTimeOffset, File::seekMode::START) == endTimeOffset )
 	{
 		// save off end time
 		replay_time_t tmp = (replay_time_t)t;
-		fwrite(&tmp, sizeof(replay_time_t), 1, m_file);
+		m_file->write(&tmp, sizeof(tmp));
 	}
 	// move to appropriate offset
-	if (!fseek(m_file, frameCountOffset, SEEK_SET))
+	if ( m_file->seek(frameCountOffset, File::seekMode::START) == frameCountOffset )
 	{
 		// save off frameCount
-		fwrite(&frameCount, sizeof(UnsignedInt), 1, m_file);
+		m_file->write(&frameCount, sizeof(frameCount));
 	}
 	// move back to end of stream
 #ifdef DEBUG_CRASHING
 	Int res =
 #endif
-		fseek(m_file, fileSize, SEEK_SET);
-	DEBUG_ASSERTCRASH(res == 0, ("Could not seek to end of file!"));
+	m_file->seek(fileSize, File::seekMode::START);
+	DEBUG_ASSERTCRASH(res == fileSize, ("Could not seek to end of file!"));
 
 #if defined(RTS_DEBUG)
 	if (TheNetwork && TheGlobalData->m_saveStats)
@@ -409,7 +412,7 @@ void RecorderClass::init() {
  */
 void RecorderClass::reset() {
 	if (m_file != NULL) {
-		fclose(m_file);
+		m_file->close();
 		m_file = NULL;
 	}
 	m_fileName.clear();
@@ -466,7 +469,7 @@ void RecorderClass::updatePlayback() {
  */
 void RecorderClass::stopPlayback() {
 	if (m_file != NULL) {
-		fclose(m_file);
+		m_file->close();
 		m_file = NULL;
 	}
 	m_fileName.clear();
@@ -529,7 +532,7 @@ void RecorderClass::updateRecord()
 
 	if (needFlush) {
 		DEBUG_ASSERTCRASH(m_file != NULL, ("RecorderClass::updateRecord() - unexpected call to fflush(m_file)"));
-		fflush(m_file);
+		m_file->flush();
 	}
 }
 
@@ -552,55 +555,56 @@ void RecorderClass::startRecording(GameDifficulty diff, Int originalGameMode, In
 	m_fileName = getLastReplayFileName();
 	m_fileName.concat(getReplayExtention());
 	filepath.concat(m_fileName);
-	m_file = fopen(filepath.str(), "wb");
+	m_file = TheFileSystem->openFile(filepath.str(), File::WRITE | File::BINARY);
 	if (m_file == NULL) {
 		DEBUG_ASSERTCRASH(m_file != NULL, ("Failed to create replay file"));
 		return;
 	}
-	fprintf(m_file, "GENREP");
+	// TheSuperHackers @info the null terminator needs to be ignored to maintain retail replay file layout
+	m_file->writeFormat("%s", s_genrep);
 
 	//
 	// save space for stats to be filled in.
 	//
 	// **** if this changes, change the LAN code above ****
 	//
-	replay_time_t t = 0;
-	fwrite(&t, sizeof(replay_time_t), 1, m_file);	// reserve space for start time
-	fwrite(&t, sizeof(replay_time_t), 1, m_file);	// reserve space for end time
+	replay_time_t time = 0;
+	m_file->write(&time, sizeof(time));	// reserve space for start time
+	m_file->write(&time, sizeof(time));	// reserve space for end time
 
 	UnsignedInt frames = 0;
-	fwrite(&frames, sizeof(UnsignedInt), 1, m_file);	// reserve space for duration in frames
+	m_file->write(&frames, sizeof(frames));	// reserve space for duration in frames
 
-	Bool b = FALSE;
-	fwrite(&b, sizeof(Bool), 1, m_file);	// reserve space for flag (true if we desync)
-	fwrite(&b, sizeof(Bool), 1, m_file);	// reserve space for flag (true if we quit early)
+	Bool flag = FALSE;
+	m_file->write(&flag, sizeof(flag));	// reserve space for flag (true if we desync)
+	m_file->write(&flag, sizeof(flag));	// reserve space for flag (true if we quit early)
 	for (Int i=0; i<MAX_SLOTS; ++i)
 	{
-		fwrite(&b, sizeof(Bool), 1, m_file);	// reserve space for flag (true if player i disconnects)
+		m_file->write(&flag, sizeof(flag));	// reserve space for flag (true if player i disconnects)
 	}
 
 	// Print out the name of the replay.
 	UnicodeString replayName;
 	replayName = TheGameText->fetch("GUI:LastReplay");
-	fwprintf(m_file, L"%ws", replayName.str());
-	fputwc(0, m_file);
+	m_file->writeFormat(L"%s", replayName.str());
+	m_file->writeChar(L"\0");
 
 	// Date and Time
 	SYSTEMTIME systemTime;
 	GetLocalTime( &systemTime );
-	fwrite(&systemTime, sizeof(SYSTEMTIME), 1, m_file);
+	m_file->write(&systemTime, sizeof(systemTime));
 
 	// write out version info
 	UnicodeString versionString = TheVersion->getUnicodeVersion();
 	UnicodeString versionTimeString = TheVersion->getUnicodeBuildTime();
 	UnsignedInt versionNumber = TheVersion->getVersionNumber();
-	fwprintf(m_file, L"%ws", versionString.str());
-	fputwc(0, m_file);
-	fwprintf(m_file, L"%ws", versionTimeString.str());
-	fputwc(0, m_file);
-	fwrite(&versionNumber, sizeof(UnsignedInt), 1, m_file);
-	fwrite(&(TheGlobalData->m_exeCRC), sizeof(UnsignedInt), 1, m_file);
-	fwrite(&(TheGlobalData->m_iniCRC), sizeof(UnsignedInt), 1, m_file);
+	m_file->writeFormat(L"%s", versionString.str());
+	m_file->writeChar(L"\0");
+	m_file->writeFormat(L"%s", versionTimeString.str());
+	m_file->writeChar(L"\0");
+	m_file->write(&versionNumber, sizeof(versionNumber));
+	m_file->write(&(TheGlobalData->m_exeCRC), sizeof(TheGlobalData->m_exeCRC));
+	m_file->write(&(TheGlobalData->m_iniCRC), sizeof(TheGlobalData->m_iniCRC));
 
 	// Number of players
 	/*
@@ -654,9 +658,11 @@ void RecorderClass::startRecording(GameDifficulty diff, Int originalGameMode, In
 	DEBUG_LOG(("RecorderClass::startRecording - theSlotList = %s", theSlotList.str()));
 
 	// write slot list (starting spots, color, alliances, etc
-	fwrite(theSlotList.str(), theSlotList.getLength() + 1, 1, m_file);
-	fprintf(m_file, "%d", localIndex);
-	fputc(0, m_file);
+	m_file->writeFormat("%s", theSlotList.str());
+	m_file->writeChar("\0");
+
+	m_file->writeFormat("%d", localIndex);
+	m_file->writeChar("\0");
 
 	/*
 	/// @todo fix this to use starting spots and player alliances when those are put in the game.
@@ -681,16 +687,16 @@ void RecorderClass::startRecording(GameDifficulty diff, Int originalGameMode, In
 	*/
 
 	// Write the game difficulty.
-	fwrite(&diff, sizeof(Int), 1, m_file);
+	m_file->write(&diff, sizeof(diff));
 
 	// Write original game mode
-	fwrite(&originalGameMode, sizeof(originalGameMode), 1, m_file);
+	m_file->write(&originalGameMode, sizeof(originalGameMode));
 
 	// Write rank points to add at game start
-	fwrite(&rankPoints, sizeof(rankPoints), 1, m_file);
+	m_file->write(&rankPoints, sizeof(rankPoints));
 
 	// Write maxFPS chosen
-	fwrite(&maxFPS, sizeof(maxFPS), 1, m_file);
+	m_file->write(&maxFPS, sizeof(maxFPS));
 
 	DEBUG_LOG(("RecorderClass::startRecording() - diff=%d, mode=%d, FPS=%d", diff, originalGameMode, maxFPS));
 
@@ -719,7 +725,7 @@ void RecorderClass::stopRecording() {
 		}
 	}
 	if (m_file != NULL) {
-		fclose(m_file);
+		m_file->close();
 		m_file = NULL;
 	}
 	m_fileName.clear();
@@ -731,15 +737,15 @@ void RecorderClass::stopRecording() {
 void RecorderClass::writeToFile(GameMessage * msg) {
 	// Write the frame number for this command.
 	UnsignedInt frame = TheGameLogic->getFrame();
-	fwrite(&frame, sizeof(frame), 1, m_file);
+	m_file->write(&frame, sizeof(frame));
 
 	// Write the command type
 	GameMessage::Type type = msg->getType();
-	fwrite(&type, sizeof(type), 1, m_file);
+	m_file->write(&type, sizeof(type));
 
 	// Write the player index
 	Int playerIndex = msg->getPlayerIndex();
-	fwrite(&playerIndex, sizeof(playerIndex), 1, m_file);
+	m_file->write(&playerIndex, sizeof(playerIndex));
 
 #ifdef DEBUG_LOGGING
 	AsciiString commandName = msg->getCommandAsString();
@@ -760,15 +766,15 @@ void RecorderClass::writeToFile(GameMessage * msg) {
 
 	GameMessageParser *parser = newInstance(GameMessageParser)(msg);
 	UnsignedByte numTypes = parser->getNumTypes();
-	fwrite(&numTypes, sizeof(numTypes), 1, m_file);
+	m_file->write(&numTypes, sizeof(numTypes));
 
 	GameMessageParserArgumentType *argType = parser->getFirstArgumentType();
 	while (argType != NULL) {
 		UnsignedByte type = (UnsignedByte)(argType->getType());
-		fwrite(&type, sizeof(type), 1, m_file);
+		m_file->write(&type, sizeof(type));
 
 		UnsignedByte argTypeCount = (UnsignedByte)(argType->getArgCount());
-		fwrite(&argTypeCount, sizeof(argTypeCount), 1, m_file);
+		m_file->write(&argTypeCount, sizeof(argTypeCount));
 
 		argType = argType->getNext();
 	}
@@ -790,28 +796,45 @@ void RecorderClass::writeToFile(GameMessage * msg) {
 }
 
 void RecorderClass::writeArgument(GameMessageArgumentDataType type, const GameMessageArgumentType arg) {
-	if (type == ARGUMENTDATATYPE_INTEGER) {
-		fwrite(&(arg.integer), sizeof(arg.integer), 1, m_file);
-	} else if (type == ARGUMENTDATATYPE_REAL) {
-		fwrite(&(arg.real), sizeof(arg.real), 1, m_file);
-	} else if (type == ARGUMENTDATATYPE_BOOLEAN) {
-		fwrite(&(arg.boolean), sizeof(arg.boolean), 1, m_file);
-	} else if (type == ARGUMENTDATATYPE_OBJECTID) {
-		fwrite(&(arg.objectID), sizeof(arg.objectID), 1, m_file);
-	} else if (type == ARGUMENTDATATYPE_DRAWABLEID) {
-		fwrite(&(arg.drawableID), sizeof(arg.drawableID), 1, m_file);
-	} else if (type == ARGUMENTDATATYPE_TEAMID) {
-		fwrite(&(arg.teamID), sizeof(arg.teamID), 1, m_file);
-	} else if (type == ARGUMENTDATATYPE_LOCATION) {
-		fwrite(&(arg.location), sizeof(arg.location), 1, m_file);
-	} else if (type == ARGUMENTDATATYPE_PIXEL) {
-		fwrite(&(arg.pixel), sizeof(arg.pixel), 1, m_file);
-	} else if (type == ARGUMENTDATATYPE_PIXELREGION) {
-		fwrite(&(arg.pixelRegion), sizeof(arg.pixelRegion), 1, m_file);
-	} else if (type == ARGUMENTDATATYPE_TIMESTAMP) {
-		fwrite(&(arg.timestamp), sizeof(arg.timestamp), 1, m_file);
-	} else if (type == ARGUMENTDATATYPE_WIDECHAR) {
-		fwrite(&(arg.wChar), sizeof(arg.wChar), 1, m_file);
+
+	switch (type) {
+
+		case ARGUMENTDATATYPE_INTEGER:
+			m_file->write( &(arg.integer), sizeof(arg.integer) );
+			break;
+		case ARGUMENTDATATYPE_REAL:
+			m_file->write( &(arg.real), sizeof(arg.real) );
+			break;
+		case ARGUMENTDATATYPE_BOOLEAN:
+			m_file->write( &(arg.boolean), sizeof(arg.boolean) );
+			break;
+		case ARGUMENTDATATYPE_OBJECTID:
+			m_file->write( &(arg.objectID), sizeof(arg.objectID) );
+			break;
+		case ARGUMENTDATATYPE_DRAWABLEID:
+			m_file->write( &(arg.drawableID), sizeof(arg.drawableID) );
+			break;
+		case ARGUMENTDATATYPE_TEAMID:
+			m_file->write( &(arg.teamID), sizeof(arg.teamID) );
+			break;
+		case ARGUMENTDATATYPE_LOCATION:
+			m_file->write( &(arg.location), sizeof(arg.location) );
+			break;
+		case ARGUMENTDATATYPE_PIXEL:
+			m_file->write( &(arg.pixel), sizeof(arg.pixel) );
+			break;
+		case ARGUMENTDATATYPE_PIXELREGION:
+			m_file->write( &(arg.pixelRegion), sizeof(arg.pixelRegion) );
+			break;
+		case ARGUMENTDATATYPE_TIMESTAMP:
+			m_file->write( &(arg.timestamp), sizeof(arg.timestamp) );
+			break;
+		case ARGUMENTDATATYPE_WIDECHAR:
+			m_file->write( &(arg.wChar), sizeof(arg.wChar) );
+			break;
+		default:
+			DEBUG_LOG(("Unknown GameMessageArgumentDataType in RecorderClass::writeArgument"));
+			break;
 	}
 }
 
@@ -823,7 +846,9 @@ Bool RecorderClass::readReplayHeader(ReplayHeader& header)
 {
 	AsciiString filepath = getReplayDir();
 	filepath.concat(header.filename.str());
-	m_file = fopen(filepath.str(), "rb");
+
+	m_file = TheFileSystem->openFile(filepath.str(), File::READ | File::BINARY );
+
 	if (m_file == NULL)
 	{
 		DEBUG_LOG(("Can't open %s (%s)", filepath.str(), header.filename.str()));
@@ -831,44 +856,43 @@ Bool RecorderClass::readReplayHeader(ReplayHeader& header)
 	}
 
 	// Read the GENREP header.
-	char genrep[7];
-	fread(&genrep, sizeof(char), 6, m_file);
-	genrep[6] = 0;
-	if (strncmp(genrep, "GENREP", 6)) {
+	char genrep[sizeof(s_genrep) - 1] = {0};
+	m_file->read( &genrep, sizeof(s_genrep) - 1 );
+	if ( strncmp(genrep, s_genrep, sizeof(s_genrep) - 1 ) ) {
 		DEBUG_LOG(("RecorderClass::readReplayHeader - replay file did not have GENREP at the start."));
-		fclose(m_file);
+		m_file->close();
 		m_file = NULL;
 		return FALSE;
 	}
 
 	// read in some stats
 	replay_time_t tmp;
-	fread(&tmp, sizeof(replay_time_t), 1, m_file);
+	m_file->read(&tmp, sizeof(tmp));
 	header.startTime = tmp;
-	fread(&tmp, sizeof(replay_time_t), 1, m_file);
+	m_file->read(&tmp, sizeof(tmp));
 	header.endTime = tmp;
 
-	fread(&header.frameCount, sizeof(UnsignedInt), 1, m_file);
+	m_file->read(&header.frameCount, sizeof(header.frameCount));
 
-	fread(&header.desyncGame, sizeof(Bool), 1, m_file);
-	fread(&header.quitEarly, sizeof(Bool), 1, m_file);
+	m_file->read(&header.desyncGame, sizeof(header.desyncGame));
+	m_file->read(&header.quitEarly, sizeof(header.quitEarly));
 	for (Int i=0; i<MAX_SLOTS; ++i)
 	{
-		fread(&(header.playerDiscons[i]), sizeof(Bool), 1, m_file);
+		m_file->read(&(header.playerDiscons[i]), sizeof(Bool));
 	}
 
 	// Read the Replay Name.  We don't actually do anything with it.  Oh well.
 	header.replayName = readUnicodeString();
 
 	// Read the date and time.  We don't really do anything with this either. Oh well.
-	fread(&header.timeVal, sizeof(SYSTEMTIME), 1, m_file);
+	m_file->read(&header.timeVal, sizeof(header.timeVal));
 
 	// Read in the Version info
 	header.versionString = readUnicodeString();
 	header.versionTimeString = readUnicodeString();
-	fread(&header.versionNumber, sizeof(UnsignedInt), 1, m_file);
-	fread(&header.exeCRC, sizeof(UnsignedInt), 1, m_file);
-	fread(&header.iniCRC, sizeof(UnsignedInt), 1, m_file);
+	m_file->read(&header.versionNumber, sizeof(header.versionNumber));
+	m_file->read(&header.exeCRC, sizeof(header.exeCRC));
+	m_file->read(&header.iniCRC, sizeof(header.iniCRC));
 
 	// Read in the GameInfo
 	header.gameOptions = readAsciiString();
@@ -878,7 +902,7 @@ Bool RecorderClass::readReplayHeader(ReplayHeader& header)
 	if (!ParseAsciiStringToGameInfo(&m_gameInfo, header.gameOptions))
 	{
 		DEBUG_LOG(("RecorderClass::readReplayHeader - replay file did not have a valid GameInfo string."));
-		fclose(m_file);
+		m_file->close();
 		m_file = NULL;
 		return FALSE;
 	}
@@ -891,7 +915,7 @@ Bool RecorderClass::readReplayHeader(ReplayHeader& header)
 		DEBUG_LOG(("RecorderClass::readReplayHeader - invalid local slot number."));
 		m_gameInfo.endGame();
 		m_gameInfo.reset();
-		fclose(m_file);
+		m_file->close();
 		m_file = NULL;
 		return FALSE;
 	}
@@ -905,9 +929,10 @@ Bool RecorderClass::readReplayHeader(ReplayHeader& header)
 	{
 		m_gameInfo.endGame();
 		m_gameInfo.reset();
-		fclose(m_file);
+		m_file->close();
 		m_file = NULL;
 	}
+
 	return TRUE;
 }
 
@@ -1211,15 +1236,15 @@ Bool RecorderClass::playbackFile(AsciiString filename)
 	DEBUG_LOG(("Player index is %d, replay CRC interval is %d", m_crcInfo->getLocalPlayer(), REPLAY_CRC_INTERVAL));
 
 	Int difficulty = 0;
-	fread(&difficulty, sizeof(difficulty), 1, m_file);
+	m_file->read(&difficulty, sizeof(difficulty));
 
-	fread(&m_originalGameMode, sizeof(m_originalGameMode), 1, m_file);
+	m_file->read(&m_originalGameMode, sizeof(m_originalGameMode));
 
 	Int rankPoints = 0;
-	fread(&rankPoints, sizeof(rankPoints), 1, m_file);
-
+	m_file->read(&rankPoints, sizeof(rankPoints));
+	
 	Int maxFPS = 0;
-	fread(&maxFPS, sizeof(maxFPS), 1, m_file);
+	m_file->read(&maxFPS, sizeof(maxFPS));
 
 	DEBUG_LOG(("RecorderClass::playbackFile() - original game was mode %d", m_originalGameMode));
 
@@ -1260,7 +1285,7 @@ UnicodeString RecorderClass::readUnicodeString() {
 	WideChar str[1024] = L"";
 	Int index = 0;
 
-	Int c = fgetwc(m_file);
+	Int c = m_file->readWideChar();
 	if (c == EOF) {
 		str[index] = 0;
 	}
@@ -1268,7 +1293,7 @@ UnicodeString RecorderClass::readUnicodeString() {
 
 	while (index < 1024 && str[index] != 0) {
 		++index;
-		Int c = fgetwc(m_file);
+		Int c = m_file->readWideChar();
 		if (c == EOF) {
 			str[index] = 0;
 			break;
@@ -1288,7 +1313,7 @@ AsciiString RecorderClass::readAsciiString() {
 	char str[1024] = "";
 	Int index = 0;
 
-	Int c = fgetc(m_file);
+	Int c =	m_file->readChar();
 	if (c == EOF) {
 		str[index] = 0;
 	}
@@ -1296,7 +1321,7 @@ AsciiString RecorderClass::readAsciiString() {
 
 	while (index < 1024 && str[index] != 0) {
 		++index;
-		Int c = fgetc(m_file);
+		Int c = m_file->readChar();
 		if (c == EOF) {
 			str[index] = 0;
 			break;
@@ -1314,9 +1339,9 @@ AsciiString RecorderClass::readAsciiString() {
  * is stopped and the next frame is said to be -1.
  */
 void RecorderClass::readNextFrame() {
-	Int retcode = fread(&m_nextFrame, sizeof(m_nextFrame), 1, m_file);
-	if (retcode != 1) {
-		DEBUG_LOG(("RecorderClass::readNextFrame - fread failed on frame %d", TheGameLogic->getFrame()));
+	Int bytesRead = m_file->read(&m_nextFrame, sizeof(m_nextFrame));
+	if (bytesRead != sizeof(m_nextFrame)) {
+		DEBUG_LOG(("RecorderClass::readNextFrame - read failed on frame %d", TheGameLogic->getFrame()));
 		m_nextFrame = -1;
 		stopPlayback();
 	}
@@ -1327,9 +1352,9 @@ void RecorderClass::readNextFrame() {
  */
 void RecorderClass::appendNextCommand() {
 	GameMessage::Type type;
-	Int retcode = fread(&type, sizeof(type), 1, m_file);
-	if (retcode != 1) {
-		DEBUG_LOG(("RecorderClass::appendNextCommand - fread failed on frame %d", m_nextFrame/*TheGameLogic->getFrame()*/));
+	Int bytesRead = m_file->read(&type, sizeof(type));
+	if (bytesRead != sizeof(type)) {
+		DEBUG_LOG(("RecorderClass::appendNextCommand - read failed on frame %d", m_nextFrame/*TheGameLogic->getFrame()*/));
 		return;
 	}
 
@@ -1348,7 +1373,7 @@ void RecorderClass::appendNextCommand() {
 #endif // DEBUG_LOGGING
 
 	Int playerIndex = -1;
-	fread(&playerIndex, sizeof(playerIndex), 1, m_file);
+	m_file->read(&playerIndex, sizeof(playerIndex));
 	msg->friend_setPlayerIndex(playerIndex);
 
 	// don't debug log this if we're debugging sync errors, as it will cause diff problems between a game and it's replay...
@@ -1367,14 +1392,14 @@ void RecorderClass::appendNextCommand() {
 
 	UnsignedByte numTypes = 0;
 	Int totalArgs = 0;
-	fread(&numTypes, sizeof(numTypes), 1, m_file);
+	m_file->read(&numTypes, sizeof(numTypes));
 
 	GameMessageParser *parser = newInstance(GameMessageParser)();
 	for (UnsignedByte i = 0; i < numTypes; ++i) {
 		UnsignedByte type = (UnsignedByte)ARGUMENTDATATYPE_UNKNOWN;
-		fread(&type, sizeof(type), 1, m_file);
+		m_file->read(&type, sizeof(type));
 		UnsignedByte numArgs = 0;
-		fread(&numArgs, sizeof(numArgs), 1, m_file);
+		m_file->read(&numArgs, sizeof(numArgs));
 		parser->addArgType((GameMessageArgumentDataType)type, numArgs);
 		totalArgs += numArgs;
 	}
@@ -1422,7 +1447,7 @@ void RecorderClass::appendNextCommand() {
 void RecorderClass::readArgument(GameMessageArgumentDataType type, GameMessage *msg) {
 	if (type == ARGUMENTDATATYPE_INTEGER) {
 		Int theint;
-		fread(&theint, sizeof(theint), 1, m_file);
+		m_file->read(&theint, sizeof(theint));
 		msg->appendIntegerArgument(theint);
 #ifdef DEBUG_LOGGING
 		if (m_doingAnalysis)
@@ -1432,7 +1457,7 @@ void RecorderClass::readArgument(GameMessageArgumentDataType type, GameMessage *
 #endif
 	} else if (type == ARGUMENTDATATYPE_REAL) {
 		Real thereal;
-		fread(&thereal, sizeof(thereal), 1, m_file);
+		m_file->read(&thereal, sizeof(thereal));
 		msg->appendRealArgument(thereal);
 #ifdef DEBUG_LOGGING
 		if (m_doingAnalysis)
@@ -1442,7 +1467,7 @@ void RecorderClass::readArgument(GameMessageArgumentDataType type, GameMessage *
 #endif
 	} else if (type == ARGUMENTDATATYPE_BOOLEAN) {
 		Bool thebool;
-		fread(&thebool, sizeof(thebool), 1, m_file);
+		m_file->read(&thebool, sizeof(thebool));
 		msg->appendBooleanArgument(thebool);
 #ifdef DEBUG_LOGGING
 		if (m_doingAnalysis)
@@ -1452,7 +1477,7 @@ void RecorderClass::readArgument(GameMessageArgumentDataType type, GameMessage *
 #endif
 	} else if (type == ARGUMENTDATATYPE_OBJECTID) {
 		ObjectID theid;
-		fread(&theid, sizeof(theid), 1, m_file);
+		m_file->read(&theid, sizeof(theid));
 		msg->appendObjectIDArgument(theid);
 #ifdef DEBUG_LOGGING
 		if (m_doingAnalysis)
@@ -1462,7 +1487,7 @@ void RecorderClass::readArgument(GameMessageArgumentDataType type, GameMessage *
 #endif
 	} else if (type == ARGUMENTDATATYPE_DRAWABLEID) {
 		DrawableID theid;
-		fread(&theid, sizeof(theid), 1, m_file);
+		m_file->read(&theid, sizeof(theid));
 		msg->appendDrawableIDArgument(theid);
 #ifdef DEBUG_LOGGING
 		if (m_doingAnalysis)
@@ -1472,7 +1497,7 @@ void RecorderClass::readArgument(GameMessageArgumentDataType type, GameMessage *
 #endif
 	} else if (type == ARGUMENTDATATYPE_TEAMID) {
 		UnsignedInt theid;
-		fread(&theid, sizeof(theid), 1, m_file);
+		m_file->read(&theid, sizeof(theid));
 		msg->appendTeamIDArgument(theid);
 #ifdef DEBUG_LOGGING
 		if (m_doingAnalysis)
@@ -1482,7 +1507,7 @@ void RecorderClass::readArgument(GameMessageArgumentDataType type, GameMessage *
 #endif
 	} else if (type == ARGUMENTDATATYPE_LOCATION) {
 		Coord3D loc;
-		fread(&loc, sizeof(loc), 1, m_file);
+		m_file->read(&loc, sizeof(loc));
 		msg->appendLocationArgument(loc);
 #ifdef DEBUG_LOGGING
 		if (m_doingAnalysis)
@@ -1493,7 +1518,7 @@ void RecorderClass::readArgument(GameMessageArgumentDataType type, GameMessage *
 #endif
 	} else if (type == ARGUMENTDATATYPE_PIXEL) {
 		ICoord2D pixel;
-		fread(&pixel, sizeof(pixel), 1, m_file);
+		m_file->read(&pixel, sizeof(pixel));
 		msg->appendPixelArgument(pixel);
 #ifdef DEBUG_LOGGING
 		if (m_doingAnalysis)
@@ -1503,7 +1528,7 @@ void RecorderClass::readArgument(GameMessageArgumentDataType type, GameMessage *
 #endif
 	} else if (type == ARGUMENTDATATYPE_PIXELREGION) {
 		IRegion2D reg;
-		fread(&reg, sizeof(reg), 1, m_file);
+		m_file->read(&reg, sizeof(reg));
 		msg->appendPixelRegionArgument(reg);
 #ifdef DEBUG_LOGGING
 		if (m_doingAnalysis)
@@ -1513,7 +1538,7 @@ void RecorderClass::readArgument(GameMessageArgumentDataType type, GameMessage *
 #endif
 	} else if (type == ARGUMENTDATATYPE_TIMESTAMP) {  // Not to be confused with Terrance Stamp... Kneel before Zod!!!
 		UnsignedInt stamp;
-		fread(&stamp, sizeof(stamp), 1, m_file);
+		m_file->read(&stamp, sizeof(stamp));
 		msg->appendTimestampArgument(stamp);
 #ifdef DEBUG_LOGGING
 		if (m_doingAnalysis)
@@ -1523,7 +1548,7 @@ void RecorderClass::readArgument(GameMessageArgumentDataType type, GameMessage *
 #endif
 	} else if (type == ARGUMENTDATATYPE_WIDECHAR) {
 		WideChar theid;
-		fread(&theid, sizeof(theid), 1, m_file);
+		m_file->read(&theid, sizeof(theid));
 		msg->appendWideCharArgument(theid);
 #ifdef DEBUG_LOGGING
 		if (m_doingAnalysis)


### PR DESCRIPTION
- Merge After: #1385 
- Merge After: #1414

This PR converts the Recorder class to use the game file system for replay saving and playback.

This was done to cleanup the implementation and to eventually make use of data buffering during playback.
With this change, streaming of replays that are actively being recorded should still be possible.

~~I set the replay file buffer to 8192 bytes, this is 16x larger than the standard buffer size.~~

~~When other bottlenecks are removed in future, this change should show bigger contributions to replay playback speed.~~

- EDIT: The File buffer tweak will be split out into a seperate PR: #1389 
