### PR TITLE
[GEN][ZH] Fix ThingTemplate copying to prevent multiplayer mismatch with original Shell Map and custom Maps

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/SparseMatchFinder.h
+++ b/Generals/Code/GameEngine/Include/Common/SparseMatchFinder.h
@@ -42,8 +42,14 @@
 	#undef SPARSEMATCH_DEBUG
 #endif
 
+typedef UnsignedInt SparseMatchFinderFlags;
+enum SparseMatchFinderFlags_ CPP_11(: SparseMatchFinderFlags)
+{
+	SparseMatchFinderFlags_NoCopy = 1<<0,
+};
+
 //-------------------------------------------------------------------------------------------------
-template<class MATCHABLE, class BITSET>
+template<class MATCHABLE, class BITSET, SparseMatchFinderFlags FLAGS = 0>
 class SparseMatchFinder
 {
 private:
@@ -183,8 +189,28 @@ private:
 		return result;
 	}
 
-	//-------------------------------------------------------------------------------------------------
 public:
+
+
+	//-------------------------------------------------------------------------------------------------
+	SparseMatchFinder() {}
+	SparseMatchFinder(const SparseMatchFinder& other)
+	{
+		*this = other;
+	}
+
+	//-------------------------------------------------------------------------------------------------
+	SparseMatchFinder& operator=(const SparseMatchFinder& other)
+	{
+		if CONSTEXPR ((FLAGS & SparseMatchFinderFlags_NoCopy) == 0)
+		{
+			if (this != &other)
+			{
+				m_bestMatches = other.m_bestMatches;
+			}
+		}
+		return *this;
+	}
 
 	//-------------------------------------------------------------------------------------------------
 	void clear()

--- a/Generals/Code/GameEngine/Include/Common/ThingTemplate.h
+++ b/Generals/Code/GameEngine/Include/Common/ThingTemplate.h
@@ -681,6 +681,11 @@ private:
 	//Code renderer handles these states now.
 	//AsciiString							m_inventoryImage[ INV_IMAGE_NUM_IMAGES ];  ///< portrait inventory pictures
 
+	// TheSuperHackers @bugfix Caball009/xezon 06/07/2025 No longer copy SparseMatchFinder to prevent copied instances linking to unrelated data.
+	// This avoids mismatching in certain maps, for example those that spawn units with veterancy.
+	typedef SparseMatchFinder<WeaponTemplateSet, WeaponSetFlags, SparseMatchFinderFlags_NoCopy> WeaponTemplateSetFinder;
+	typedef SparseMatchFinder<ArmorTemplateSet, ArmorSetFlags, SparseMatchFinderFlags_NoCopy> ArmorTemplateSetFinder;
+
 	// ---- STL-sized things
 	std::vector<ProductionPrerequisite>	m_prereqInfo;				///< the unit Prereqs for this tech
 	std::vector<AsciiString>						m_buildVariations;	/**< if we build a unit of this type via script or ui, randomly choose one

--- a/Generals/Code/GameEngine/Include/GameLogic/ArmorSet.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/ArmorSet.h
@@ -94,7 +94,4 @@ public:
 //-------------------------------------------------------------------------------------------------
 typedef std::vector<ArmorTemplateSet> ArmorTemplateSetVector;
 
-//-------------------------------------------------------------------------------------------------
-typedef SparseMatchFinder<ArmorTemplateSet, ArmorSetFlags> ArmorTemplateSetFinder;
-
 #endif	// _ArmorSet_H_

--- a/Generals/Code/GameEngine/Include/GameLogic/WeaponSet.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/WeaponSet.h
@@ -147,9 +147,6 @@ public:
 typedef std::vector<WeaponTemplateSet> WeaponTemplateSetVector;
 
 //-------------------------------------------------------------------------------------------------
-typedef SparseMatchFinder<WeaponTemplateSet, WeaponSetFlags> WeaponTemplateSetFinder;
-
-//-------------------------------------------------------------------------------------------------
 enum WeaponChoiceCriteria CPP_11(: Int)
 {
 	PREFER_MOST_DAMAGE,		///< choose the weapon that will do the most damage

--- a/GeneralsMD/Code/GameEngine/Include/Common/SparseMatchFinder.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/SparseMatchFinder.h
@@ -42,8 +42,14 @@
 	#undef SPARSEMATCH_DEBUG
 #endif
 
+typedef UnsignedInt SparseMatchFinderFlags;
+enum SparseMatchFinderFlags_ CPP_11(: SparseMatchFinderFlags)
+{
+	SparseMatchFinderFlags_NoCopy = 1<<0,
+};
+
 //-------------------------------------------------------------------------------------------------
-template<class MATCHABLE, class BITSET>
+template<class MATCHABLE, class BITSET, SparseMatchFinderFlags FLAGS = 0>
 class SparseMatchFinder
 {
 private:
@@ -185,8 +191,25 @@ private:
 		return result;
 	}
 
-	//-------------------------------------------------------------------------------------------------
 public:
+
+
+	//-------------------------------------------------------------------------------------------------
+	SparseMatchFinder() {}
+	SparseMatchFinder(const SparseMatchFinder& other)
+	{
+		*this = other;
+	}
+
+	//-------------------------------------------------------------------------------------------------
+	SparseMatchFinder& operator=(const SparseMatchFinder& other)
+	{
+		if ((FLAGS & SparseMatchFinderFlags_NoCopy) == 0 && this != &other)
+		{
+			m_bestMatches = other.m_bestMatches;
+		}
+		return *this;
+	}
 
 	//-------------------------------------------------------------------------------------------------
 	void clear()

--- a/GeneralsMD/Code/GameEngine/Include/Common/SparseMatchFinder.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/SparseMatchFinder.h
@@ -204,9 +204,12 @@ public:
 	//-------------------------------------------------------------------------------------------------
 	SparseMatchFinder& operator=(const SparseMatchFinder& other)
 	{
-		if ((FLAGS & SparseMatchFinderFlags_NoCopy) == 0 && this != &other)
+		if CONSTEXPR ((FLAGS & SparseMatchFinderFlags_NoCopy) == 0)
 		{
-			m_bestMatches = other.m_bestMatches;
+			if (this != &other)
+			{
+				m_bestMatches = other.m_bestMatches;
+			}
 		}
 		return *this;
 	}

--- a/GeneralsMD/Code/GameEngine/Include/Common/ThingTemplate.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/ThingTemplate.h
@@ -698,6 +698,11 @@ private:
 	//Code renderer handles these states now.
 	//AsciiString							m_inventoryImage[ INV_IMAGE_NUM_IMAGES ];  ///< portrait inventory pictures
 
+	// TheSuperHackers @bugfix Caball009/xezon 06/07/2025 No longer copy SparseMatchFinder to prevent copied instances linking to unrelated data.
+	// This avoids mismatching in certain maps, for example those that spawn units with veterancy.
+	typedef SparseMatchFinder<WeaponTemplateSet, WeaponSetFlags, SparseMatchFinderFlags_NoCopy> WeaponTemplateSetFinder;
+	typedef SparseMatchFinder<ArmorTemplateSet, ArmorSetFlags, SparseMatchFinderFlags_NoCopy> ArmorTemplateSetFinder;
+
 	// ---- STL-sized things
 	std::vector<ProductionPrerequisite>	m_prereqInfo;				///< the unit Prereqs for this tech
 	std::vector<AsciiString>						m_buildVariations;	/**< if we build a unit of this type via script or ui, randomly choose one

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/ArmorSet.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/ArmorSet.h
@@ -97,7 +97,4 @@ public:
 //-------------------------------------------------------------------------------------------------
 typedef std::vector<ArmorTemplateSet> ArmorTemplateSetVector;
 
-//-------------------------------------------------------------------------------------------------
-typedef SparseMatchFinder<ArmorTemplateSet, ArmorSetFlags> ArmorTemplateSetFinder;
-
 #endif	// _ArmorSet_H_

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/WeaponSet.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/WeaponSet.h
@@ -167,9 +167,6 @@ public:
 typedef std::vector<WeaponTemplateSet> WeaponTemplateSetVector;
 
 //-------------------------------------------------------------------------------------------------
-typedef SparseMatchFinder<WeaponTemplateSet, WeaponSetFlags> WeaponTemplateSetFinder;
-
-//-------------------------------------------------------------------------------------------------
 enum WeaponChoiceCriteria CPP_11(: Int)
 {
 	PREFER_MOST_DAMAGE,		///< choose the weapon that will do the most damage


### PR DESCRIPTION
* Fixes #856
* Closes #1194

This change fixes #856 and is an alternative implementation to #1194.

## TODO

- [x] Replicate in Generals
- [x] Test against replays in VC6