### PR TITLE
[GEN][ZH] Fix Memory Manager initialization issues (old)

### DIFF
--- a/Core/Libraries/Source/WWVegas/WWLib/CMakeLists.txt
+++ b/Core/Libraries/Source/WWVegas/WWLib/CMakeLists.txt
@@ -66,6 +66,7 @@ set(WWLIB_SRC
     #lzostraw.cpp
     #lzostraw.h
     #lzo_conf.h
+    MallocAllocator.h
     #md5.cpp
     #md5.h
     mempool.h

--- a/Core/Libraries/Source/WWVegas/WWLib/MallocAllocator.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/MallocAllocator.h
@@ -1,0 +1,129 @@
+/*
+**	Command & Conquer Generals Zero Hour(tm)
+**	Copyright 2025 TheSuperHackers
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <cstdlib> // malloc, free
+#include <cstddef> // std::size_t, std::ptrdiff_t
+#include <new> // std::bad_alloc
+
+
+namespace stl
+{
+
+// STL allocator that uses malloc and free. Useful if allocations are meant to bypass new and delete.
+
+template <typename T>
+class malloc_allocator
+{
+public:
+
+  typedef T value_type;
+  typedef T* pointer;
+  typedef const T* const_pointer;
+  typedef T& reference;
+  typedef const T& const_reference;
+  typedef std::size_t size_type;
+  typedef std::ptrdiff_t difference_type;
+
+  template <typename U>
+  struct rebind
+  {
+    typedef malloc_allocator<U> other;
+  };
+
+  malloc_allocator() throw() {}
+
+#if !(defined(_MSC_VER) && _MSC_VER < 1300)
+  malloc_allocator(const malloc_allocator&) throw() {}
+#endif
+
+  template <typename U>
+  malloc_allocator(const malloc_allocator<U>&) throw() {}
+
+  ~malloc_allocator() throw() {}
+
+  pointer address(reference x) const { return &x; }
+  const_pointer address(const_reference x) const { return &x; }
+
+  pointer allocate(size_type n, const void* = 0)
+  {
+    if (n > max_size())
+      throw std::bad_alloc();
+
+    void* p = ::malloc(n * sizeof(T));
+    if (!p)
+      throw std::bad_alloc();
+    return static_cast<pointer>(p);
+  }
+
+  void deallocate(pointer p, size_type)
+  {
+    ::free(p);
+  }
+
+  void construct(pointer p, const T& val)
+  {
+    new (static_cast<void*>(p)) T(val);
+  }
+
+  void destroy(pointer p)
+  {
+    p->~T();
+  }
+
+  size_type max_size() const throw()
+  {
+    return ~size_type(0) / sizeof(T);
+  }
+};
+
+// Allocators of same type are always equal
+template <typename T1, typename T2>
+bool operator==(const malloc_allocator<T1>&, const malloc_allocator<T2>&) throw() {
+  return true;
+}
+
+template <typename T1, typename T2>
+bool operator!=(const malloc_allocator<T1>&, const malloc_allocator<T2>&) throw() {
+  return false;
+}
+
+} // namespace stl
+
+
+#if defined(USING_STLPORT)
+
+// This tells STLport how to rebind malloc_allocator
+namespace std
+{
+  template <class _Tp1, class _Tp2>
+  struct __stl_alloc_rebind_helper;
+
+  template <class Tp1, class Tp2>
+  inline stl::malloc_allocator<Tp2>& __stl_alloc_rebind(stl::malloc_allocator<Tp1>& a, const Tp2*) {
+    return *reinterpret_cast<stl::malloc_allocator<Tp2>*>(&a);
+  }
+
+  template <class Tp1, class Tp2>
+  inline const stl::malloc_allocator<Tp2>& __stl_alloc_rebind(const stl::malloc_allocator<Tp1>& a, const Tp2*) {
+    return *reinterpret_cast<const stl::malloc_allocator<Tp2>*>(&a);
+  }
+}
+
+#endif

--- a/GeneralsMD/Code/GameEngine/Include/Common/CommandLine.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/CommandLine.h
@@ -35,6 +35,7 @@ class CommandLine
 {
 public:
 
+	static void parseCommandLineForClientInstance();
 	static void parseCommandLineForStartup();
 	static void parseCommandLineForEngineInit();
 };

--- a/GeneralsMD/Code/GameEngine/Include/Common/STLTypedefs.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/STLTypedefs.h
@@ -79,6 +79,7 @@ enum DrawableID CPP_11(: Int);
 #include <stack>
 #include <string>
 #include <vector>
+#include "MallocAllocator.h"
 
 // List of AsciiStrings to allow list of ThingTemplate names from INI and such
 typedef std::list< AsciiString >													AsciiStringList;
@@ -112,6 +113,13 @@ typedef std::vector<Bool>::iterator												BoolVectorIterator;
 
 typedef std::map< NameKeyType, Real, std::less<NameKeyType> > ProductionChangeMap;
 typedef std::map< NameKeyType, VeterancyLevel, std::less<NameKeyType> > ProductionVeterancyMap;
+
+namespace stl
+{
+typedef std::basic_string<char, std::char_traits<char>, malloc_allocator<char> > malloc_string;
+typedef std::basic_string<wchar_t, std::char_traits<wchar_t>, malloc_allocator<wchar_t> > malloc_wstring;
+
+} // namespace stl
 
 // Some useful, common hash and equal_to functors for use with hash_map
 namespace rts 

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/ClientInstance.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/ClientInstance.h
@@ -21,6 +21,7 @@ namespace rts
 {
 
 // TheSuperHackers @feature Adds support for launching multiple game clients and keeping track of their instance id.
+// This class must not allocate using 'new' because it can be used before the Memory Manager is initialized.
 
 class ClientInstance
 {

--- a/GeneralsMD/Code/GameEngine/Source/Common/CommandLine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/CommandLine.cpp
@@ -1399,7 +1399,7 @@ char *nextParam(char *newSource, const char *seps)
 
 static void parseCommandLine(const CommandLineParam* params, int numParams)
 {
-	std::vector<char*, stl::malloc_allocator<char*>> argv;
+	std::vector<char*, stl::malloc_allocator<char*> > argv;
 
 	stl::malloc_string cmdLine = GetCommandLineA();
 	char *token = nextParam(&cmdLine[0], "\" ");

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/Debug.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/Debug.cpp
@@ -367,8 +367,9 @@ void DebugInit(int flags)
 	#ifdef DEBUG_LOGGING
 
 		// TheSuperHackers @info Debug initialization can happen very early.
-		// Therefore, parse initial commandline and initialize the client instance now.
-		CommandLine::parseCommandLineForStartup();
+		// Determine the client instance id before creating the log file with an instance specific name.
+		CommandLine::parseCommandLineForClientInstance();
+
 		if (!rts::ClientInstance::initialize())
 			return;
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/GameMemory.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/GameMemory.cpp
@@ -3412,6 +3412,8 @@ void initMemoryManager()
 {
 	if (TheMemoryPoolFactory == NULL) 
 	{
+		DEBUG_LOG(("*** Initing Memory Manager"));
+
 		Int numSubPools;
 		const PoolInitRec *pParms;
 		userMemoryManagerGetDmaParms(&numSubPools, &pParms);

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/ClientInstance.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/ClientInstance.cpp
@@ -37,14 +37,14 @@ bool ClientInstance::initialize()
 	{
 		return true;
 	}
-	
+
 	// Create a mutex with a unique name to Generals in order to determine if our app is already running.
 	// WARNING: DO NOT use this number for any other application except Generals.
 	while (true)
 	{
 		if (isMultiInstance())
 		{
-			std::string guidStr = getFirstInstanceName();
+			stl::malloc_string guidStr = getFirstInstanceName();
 			if (s_instanceIndex > 0u)
 			{
 				char idStr[33];

--- a/GeneralsMD/Code/Main/WinMain.cpp
+++ b/GeneralsMD/Code/Main/WinMain.cpp
@@ -799,7 +799,6 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 		}
 		::SetCurrentDirectory(buffer);
 
-		CommandLine::parseCommandLineForStartup();
 
 		#ifdef RTS_DEBUG
 			// Turn on Memory heap tracking
@@ -839,6 +838,12 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 		gLoadScreenBitmap = (HBITMAP)LoadImage(hInstance, "Install_Final.bmp", IMAGE_BITMAP, 0, 0, LR_SHARED|LR_LOADFROMFILE);
 #endif
 
+		// start the log
+		DEBUG_INIT(DEBUG_FLAGS_DEFAULT);
+		initMemoryManager();
+
+		CommandLine::parseCommandLineForStartup();
+
 		// register windows class and create application window
 		if(!TheGlobalData->m_headless && initializeAppWindows(hInstance, nCmdShow, TheGlobalData->m_windowed) == false)
 			return exitcode;
@@ -855,11 +860,7 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 		// BGC - initialize COM
 	//	OleInitialize(NULL);
 
-		// start the log
-		DEBUG_INIT(DEBUG_FLAGS_DEFAULT);
-		initMemoryManager();
 
- 
 		// Set up version info
 		TheVersion = NEW Version;
 		TheVersion->setVersion(VERSION_MAJOR, VERSION_MINOR, VERSION_BUILDNUM, VERSION_LOCALBUILDNUM,
@@ -867,6 +868,8 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 			AsciiString(__TIME__), AsciiString(__DATE__));
 
 		// TheSuperHackers @refactor The instance mutex now lives in its own class.
+
+		CommandLine::parseCommandLineForClientInstance();
 
 		if (!rts::ClientInstance::initialize())
 		{


### PR DESCRIPTION
* Fixes #1203
* Follow up for #1068

This change fixes Memory Manager initialization issues.

Problems identified: `ClientInstance::initialize` and `CommandLine::parseCommandLineForStartup` both used 'new' allocator before the Memory Manager was initialized, in both Debug and Release. This caused the Memory Manager to actually be created twice, and trigger 1 assert on game launch and 1 assert on game quit.

This is now fixed by fixing initialization ordering and preventing some allocations with 'new'.

This change also uses the `stl::malloc_allocator` that was added to the pending Pull Request #1066.

## TODO

- [ ] Replicate in Generals