### PR TITLE
[ZH] Fix multiplayer mismatch in a new game after exiting the previous game while a player was power sabotaged

### DIFF
--- a/GeneralsMD/Code/GameEngine/Include/Common/Energy.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Energy.h
@@ -73,6 +73,7 @@ public:
 	{
 		m_energyProduction = 0;
 		m_energyConsumption = 0;
+		m_powerSabotagedTillFrame = 0;
 		m_owner = owner;
 	}
 


### PR DESCRIPTION
- Fixes: https://github.com/TheSuperHackers/GeneralsGameCode/issues/53

This PR prevents a mismatch from occuring in a new game when a previous game had the players power sabotaged.

Since the `m_powerSabotagedTillFrame` variable was not being reset, the game would think the players power was still sabotaged when starting a new game. 
This is due to the `m_powerSabotagedTillFrame` value being greater than the current frame number, this then makes the game think the power is sabotaged.