### PR TITLE
[GEN][ZH] Fix debug vTune ini parsing issue caused by #1231

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/GlobalData.h
+++ b/Generals/Code/GameEngine/Include/Common/GlobalData.h
@@ -466,7 +466,7 @@ public:
 
   Bool m_TiVOFastMode;            ///< When true, the client speeds up the framerate... set by HOTKEY!
 
-#if defined(RTS_PROFILE)
+#if defined(RTS_DEBUG) || defined(RTS_PROFILE)
 	Bool m_vTune;
 #endif
 

--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -488,7 +488,7 @@ GlobalData* GlobalData::m_theOriginal = NULL;
 	{ "KeyboardCameraRotateSpeed", INI::parseReal, NULL, offsetof( GlobalData, m_keyboardCameraRotateSpeed ) },
 	{ "PlayStats",									INI::parseInt,				NULL,			offsetof( GlobalData, m_playStats ) },
 
-#if defined(RTS_PROFILE)
+#if defined(RTS_DEBUG) || defined(RTS_PROFILE)
 	{ "VTune", INI::parseBool,	NULL,			offsetof( GlobalData, m_vTune ) },
 #endif
 
@@ -548,7 +548,7 @@ GlobalData::GlobalData()
 
   m_TiVOFastMode = FALSE;
 
-#if defined(RTS_PROFILE)
+#if defined(RTS_DEBUG) || defined(RTS_PROFILE)
 	m_vTune = false;
 #endif
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
@@ -481,7 +481,7 @@ public:
 #endif
   Bool m_TiVOFastMode;            ///< When true, the client speeds up the framerate... set by HOTKEY!
 
-#if defined(RTS_PROFILE)
+#if defined(RTS_DEBUG) || defined(RTS_PROFILE)
 	Bool m_vTune;
 #endif
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -488,7 +488,7 @@ GlobalData* GlobalData::m_theOriginal = NULL;
 	{ "KeyboardCameraRotateSpeed", INI::parseReal, NULL, offsetof( GlobalData, m_keyboardCameraRotateSpeed ) },
 	{ "PlayStats",									INI::parseInt,				NULL,			offsetof( GlobalData, m_playStats ) },
 
-#if defined(RTS_PROFILE)
+#if defined(RTS_DEBUG) || defined(RTS_PROFILE)
 	{ "VTune", INI::parseBool,	NULL,			offsetof( GlobalData, m_vTune ) },
 #endif
 
@@ -551,7 +551,7 @@ GlobalData::GlobalData()
 #endif
   m_TiVOFastMode = FALSE;
 
-#if defined(RTS_PROFILE)
+#if defined(RTS_DEBUG) || defined(RTS_PROFILE)
 	m_vTune = false;
 #endif
 


### PR DESCRIPTION
- Relates to: #1231 

This PR fixes an issue introduced by the previous PR to cleanup RTS internal and profile.

![image](https://github.com/user-attachments/assets/684d039b-5bfc-4430-a571-304b1c206e3f)

The game under debug would not get any further than trying to parse the debug ini data.
Ignoring the assert would not work either and the game would instead hang.