### PR TITLE
[GEN][ZH] Fix Hero Radar icon garrison issues introduced by #1035

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/Radar.h
+++ b/Generals/Code/GameEngine/Include/Common/Radar.h
@@ -80,6 +80,13 @@ enum RadarEventType CPP_11(: Int)
  	
 };
 
+enum RadarObjectType CPP_11(: Int)
+{
+	RadarObjectType_None = 0,
+	RadarObjectType_Regular,
+	RadarObjectType_Local,
+};
+
 // PROTOTYPES /////////////////////////////////////////////////////////////////////////////////////
 
 //-------------------------------------------------------------------------------------------------
@@ -109,6 +116,7 @@ public:
 	inline const RadarObject *friend_getNext( void ) const { return m_next; }
 
 	Bool isTemporarilyHidden() const;
+	static Bool isTemporarilyHidden(const Object* obj);
 
 protected:
 
@@ -178,7 +186,7 @@ public:
 													ICoord2D *ul, ICoord2D *lr );					///< make translation for screen area of radar square to scaled aspect ratio preserving points inside the radar area
 
 	// priority inquiry
-	Bool isPriorityVisible( RadarPriorityType priority ) const;		///< is the priority passed in a "visible" one on the radar
+	static Bool isPriorityVisible( RadarPriorityType priority );		///< is the priority passed in a "visible" one on the radar
 
 	// radar events
 	void createEvent( const Coord3D *world, RadarEventType type, Real secondsToLive = 4.0f );	///< create radar event at location in world
@@ -190,8 +198,8 @@ public:
  	Bool tryEvent( RadarEventType event, const Coord3D *pos );	///< try to make a "stealth" event
 
 	// adding and removing objects from the radar
-	virtual bool addObject( Object *obj );									///< add object to radar
-	virtual bool removeObject( Object *obj );								///< remove object from radar
+	virtual RadarObjectType addObject( Object *obj );									///< add object to radar
+	virtual RadarObjectType removeObject( Object *obj );								///< remove object from radar
 
 	// radar options
 	void hide( Bool hide ) { m_radarHidden = hide; }				///< hide/unhide the radar
@@ -225,9 +233,6 @@ protected:
 	virtual void crc( Xfer *xfer );
 	virtual void xfer( Xfer *xfer );
 	virtual void loadPostProcess( void );
-
-	virtual void onLocalRadarObjectAdded( const RadarObject* radarObject ) = 0;
-	virtual void onLocalRadarObjectRemoved( const RadarObject* radarObject ) = 0;
 
 	/// internal method for creating a radar event with specific colors
 	void internalCreateEvent( const Coord3D *world, RadarEventType type, Real secondsToLive,
@@ -301,8 +306,6 @@ public:
 	virtual void draw(Int pixelX, Int pixelY, Int width, Int height) { }
 	virtual void clearShroud() { }
 	virtual void setShroudLevel(Int x, Int y, CellShroudStatus setting) { }
-	virtual void onLocalRadarObjectAdded(const RadarObject*) { }
-	virtual void onLocalRadarObjectRemoved(const RadarObject*) { }
 };
 
 #endif  // __RADAR_H_

--- a/Generals/Code/GameEngine/Source/Common/System/Radar.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/Radar.cpp
@@ -71,8 +71,6 @@ void Radar::deleteListResources( void )
 	while( m_localObjectList )
 	{
 
-		onLocalRadarObjectRemoved( m_localObjectList );
-
 		// get next object
 		nextObject = m_localObjectList->friend_getNext();
 
@@ -138,8 +136,15 @@ RadarObject::~RadarObject( void )
 //-------------------------------------------------------------------------------------------------
 Bool RadarObject::isTemporarilyHidden() const
 {
-	Drawable* draw = m_object->getDrawable();
-	if (draw->getStealthLook() == STEALTHLOOK_INVISIBLE || draw->isDrawableEffectivelyHidden())
+	return isTemporarilyHidden(m_object);
+}
+
+//-------------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------------------
+Bool RadarObject::isTemporarilyHidden(const Object* obj)
+{
+	Drawable* draw = obj->getDrawable();
+	if (draw == NULL || draw->getStealthLook() == STEALTHLOOK_INVISIBLE || draw->isDrawableEffectivelyHidden())
 		return true;
 
 	return false;
@@ -391,13 +396,13 @@ void Radar::newMap( TerrainLogic *terrain )
 /** Add an object to the radar list.  The object will be sorted in the list to be grouped
 	* using it's radar priority */
 //-------------------------------------------------------------------------------------------------
-bool Radar::addObject( Object *obj )
+RadarObjectType Radar::addObject( Object *obj )
 {
 
 	// get the radar priority for this object
 	RadarPriorityType newPriority = obj->getRadarPriority();
 	if( isPriorityVisible( newPriority ) == FALSE )
-		return false;
+		return RadarObjectType_None;
 
 	// if this object is on the radar, remove it in favor of the new add
 	RadarObject **list;
@@ -463,14 +468,21 @@ bool Radar::addObject( Object *obj )
 	// set a chunk of radar data in the object
 	obj->friend_setRadarData( newObj );
 
+	RadarObjectType objectType;
 	//
 	// we will put this on either the local object list for objects that belong to the
 	// local player, or on the regular object list for all other objects
 	//
 	if( obj->isLocallyControlled() )
+	{
 		list = &m_localObjectList;
+		objectType = RadarObjectType_Local;
+	}
 	else
+	{
 		list = &m_objectList;
+		objectType = RadarObjectType_Regular;
+	}
 
 	// link object to master list at the head of it's priority section
 	if( *list == NULL )
@@ -541,12 +553,7 @@ bool Radar::addObject( Object *obj )
 
 	}  // end else
 
-	if (list == &m_localObjectList)
-	{
-		onLocalRadarObjectAdded(newObj);
-	}
-
-	return true;
+	return objectType;
 }  // end addObject
 
 //-------------------------------------------------------------------------------------------------
@@ -562,10 +569,6 @@ Bool Radar::deleteFromList( Object *obj, RadarObject **list )
 		
 		if( radarObject->friend_getObject() == obj )
 		{
-			if (list == &m_localObjectList)
-			{
-				onLocalRadarObjectRemoved( radarObject );
-			}
 
 			// unlink the object from list
 			if( prevObject == NULL )
@@ -597,24 +600,24 @@ Bool Radar::deleteFromList( Object *obj, RadarObject **list )
 //-------------------------------------------------------------------------------------------------
 /** Remove an object from the radar, the object may reside in any list */
 //-------------------------------------------------------------------------------------------------
-bool Radar::removeObject( Object *obj )
+RadarObjectType Radar::removeObject( Object *obj )
 {
 
 	// sanity
 	if( obj->friend_getRadarData() == NULL )
-		return false;
+		return RadarObjectType_None;
 
 	if( deleteFromList( obj, &m_localObjectList ) == TRUE )
-		return true;
+		return RadarObjectType_Local;
 	else if( deleteFromList( obj, &m_objectList ) == TRUE )
-		return true;
+		return RadarObjectType_Regular;
 	else
 	{
 
 		// sanity
 		DEBUG_ASSERTCRASH( 0, ("Radar: Tried to remove object '%s' which was not found",
 											 obj->getTemplate()->getName().str()) );
-		return false;
+		return RadarObjectType_None;
 	}  // end else
 
 }  // end removeObject
@@ -1555,7 +1558,7 @@ void Radar::loadPostProcess( void )
 // ------------------------------------------------------------------------------------------------
 /** Is the priority type passed in a "visible" one that can show up on the radar */
 // ------------------------------------------------------------------------------------------------
-Bool Radar::isPriorityVisible( RadarPriorityType priority ) const 
+Bool Radar::isPriorityVisible( RadarPriorityType priority )
 {
 
 	switch( priority )

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/Common/W3DRadar.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/Common/W3DRadar.h
@@ -61,9 +61,12 @@ public:
 	virtual void update( void );																	///< subsystem update
 	virtual void reset( void );																		///< subsystem reset
 
+	virtual RadarObjectType addObject( Object *obj ); ///< add object to radar
+	virtual RadarObjectType removeObject( Object *obj ); ///< remove object from radar
+
 	virtual void newMap( TerrainLogic *terrain );				///< reset radar for new map
 
-	void draw( Int pixelX, Int pixelY, Int width, Int height );		///< draw the radar
+	virtual void draw( Int pixelX, Int pixelY, Int width, Int height );		///< draw the radar
 
 	virtual void clearShroud();
 	virtual void setShroudLevel(Int x, Int y, CellShroudStatus setting);
@@ -71,11 +74,6 @@ public:
 	virtual void refreshTerrain( TerrainLogic *terrain );
 
 protected:
-
-	virtual void onLocalRadarObjectAdded( const RadarObject* radarObject );
-	virtual void onLocalRadarObjectRemoved( const RadarObject* radarObject );
-
-	void rebuildCachedHeroObjectList();
 
 	void drawSingleBeaconEvent( Int pixelX, Int pixelY, Int width, Int height, Int index );
 	void drawSingleGenericEvent( Int pixelX, Int pixelY, Int width, Int height, Int index );
@@ -87,7 +85,7 @@ protected:
 	void drawViewBox( Int pixelX, Int pixelY, Int width, Int height );  ///< draw view box
 	void buildTerrainTexture( TerrainLogic *terrain );	 ///< create the terrain texture of the radar
 	void drawIcons( Int pixelX, Int pixelY, Int width, Int height );	///< draw all of the radar icons
-	void renderObjectList( const RadarObject *listHead, TextureClass *texture );			 ///< render an object list to the texture
+	void renderObjectList( const RadarObject *listHead, TextureClass *texture, Bool calcHero = FALSE );			 ///< render an object list to the texture
 	void interpolateColorForHeight( RGBColor *color, 
 																	Real height, 
 																	Real hiZ, 

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/Common/System/W3DRadar.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/Common/System/W3DRadar.cpp
@@ -614,7 +614,7 @@ void W3DRadar::drawIcons( Int pixelX, Int pixelY, Int width, Int height )
 //-------------------------------------------------------------------------------------------------
 /** Render an object list into the texture passed in */
 //-------------------------------------------------------------------------------------------------
-void W3DRadar::renderObjectList( const RadarObject *listHead, TextureClass *texture )
+void W3DRadar::renderObjectList( const RadarObject *listHead, TextureClass *texture, Bool calcHero )
 {
 
 	// sanity
@@ -632,6 +632,12 @@ void W3DRadar::renderObjectList( const RadarObject *listHead, TextureClass *text
 	if (player)
 		playerIndex=player->getPlayerIndex();
 
+	if( calcHero )
+	{
+		// clear all entries from the cached hero object list
+		m_cachedHeroObjectList.clear();
+	}
+
 	for( const RadarObject *rObj = listHead; rObj; rObj = rObj->friend_getNext() )
 	{
 
@@ -641,6 +647,11 @@ void W3DRadar::renderObjectList( const RadarObject *listHead, TextureClass *text
 		// get object
 		const Object *obj = rObj->friend_getObject();
 
+		// cache hero objects for drawing in icon layer
+		if( calcHero && obj->isHero() )
+		{
+			m_cachedHeroObjectList.push_back(obj);
+		}
     Bool skip = FALSE;
 
 		// check for shrouded status
@@ -856,11 +867,6 @@ W3DRadar::~W3DRadar( void )
 void W3DRadar::xfer( Xfer *xfer )
 {
 	Radar::xfer(xfer);
-
-	if (xfer->getXferMode() == XFER_LOAD)
-	{
-		rebuildCachedHeroObjectList();
-	}
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -963,6 +969,8 @@ void W3DRadar::reset( void )
 	// extending functionality, call base class
 	Radar::reset();
 
+	m_cachedHeroObjectList.clear();
+
 	// clear our texture data, but do not delete the resources
 	SurfaceClass *surface;
 
@@ -996,6 +1004,37 @@ void W3DRadar::update( void )
 	Radar::update();
 
 }  // end update
+
+//-------------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------------------
+RadarObjectType W3DRadar::addObject( Object* obj )
+{
+	RadarObjectType addedType = Radar::addObject(obj);
+
+	if (addedType == RadarObjectType_Local)
+	{
+		if (obj->isHero() && !RadarObject::isTemporarilyHidden(obj))
+		{
+			m_cachedHeroObjectList.push_back(obj);
+		}
+	}
+
+	return addedType;
+}
+
+//-------------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------------------
+RadarObjectType W3DRadar::removeObject( Object* obj )
+{
+	RadarObjectType removedType = Radar::removeObject(obj);
+
+	if (removedType == RadarObjectType_Local)
+	{
+		stl::find_and_erase_unordered(m_cachedHeroObjectList, obj);
+	}
+
+	return removedType;
+}
 
 //-------------------------------------------------------------------------------------------------
 /** Reset the radar for the new map data being given to it */
@@ -1412,7 +1451,7 @@ void W3DRadar::draw( Int pixelX, Int pixelY, Int width, Int height )
 
 		// rebuild the object overlay
 		renderObjectList( getObjectList(), m_overlayTexture );
-		renderObjectList( getLocalObjectList(), m_overlayTexture );
+		renderObjectList( getLocalObjectList(), m_overlayTexture, TRUE );
 		
 	}  // end if
 
@@ -1462,41 +1501,6 @@ void W3DRadar::refreshTerrain( TerrainLogic *terrain )
 
 }  // end refreshTerrain
 
-//-------------------------------------------------------------------------------------------------
-//-------------------------------------------------------------------------------------------------
-void W3DRadar::onLocalRadarObjectAdded( const RadarObject* radarObject )
-{
-	const Object* obj = radarObject->friend_getObject();
-	if (obj->isHero())
-	{
-		m_cachedHeroObjectList.push_back(obj);
-	}
-}
-
-//-------------------------------------------------------------------------------------------------
-//-------------------------------------------------------------------------------------------------
-void W3DRadar::onLocalRadarObjectRemoved( const RadarObject* radarObject )
-{
-	const Object* obj = radarObject->friend_getObject();
-	if (obj->isHero())
-	{
-		stl::find_and_erase_unordered(m_cachedHeroObjectList, obj);
-	}
-}
-
-//-------------------------------------------------------------------------------------------------
-//-------------------------------------------------------------------------------------------------
-void W3DRadar::rebuildCachedHeroObjectList()
-{
-	m_cachedHeroObjectList.clear();
-	const RadarObject* radarObject = getLocalObjectList();
-
-	while (radarObject != NULL)
-	{
-		onLocalRadarObjectAdded(radarObject);
-		radarObject = radarObject->friend_getNext();
-	}
-}
 
 
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/Radar.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Radar.h
@@ -80,6 +80,13 @@ enum RadarEventType CPP_11(: Int)
  	
 };
 
+enum RadarObjectType CPP_11(: Int)
+{
+	RadarObjectType_None = 0,
+	RadarObjectType_Regular,
+	RadarObjectType_Local,
+};
+
 // PROTOTYPES /////////////////////////////////////////////////////////////////////////////////////
 
 //-------------------------------------------------------------------------------------------------
@@ -109,6 +116,7 @@ public:
 	inline const RadarObject *friend_getNext( void ) const { return m_next; }
 
 	Bool isTemporarilyHidden() const;
+	static Bool isTemporarilyHidden(const Object* obj);
 
 protected:
 
@@ -178,7 +186,7 @@ public:
 													ICoord2D *ul, ICoord2D *lr );					///< make translation for screen area of radar square to scaled aspect ratio preserving points inside the radar area
 
 	// priority inquiry
-	Bool isPriorityVisible( RadarPriorityType priority ) const;		///< is the priority passed in a "visible" one on the radar
+	static Bool isPriorityVisible( RadarPriorityType priority );		///< is the priority passed in a "visible" one on the radar
 
 	// radar events
 	void createEvent( const Coord3D *world, RadarEventType type, Real secondsToLive = 4.0f );	///< create radar event at location in world
@@ -190,8 +198,8 @@ public:
  	Bool tryEvent( RadarEventType event, const Coord3D *pos );	///< try to make a "stealth" event
 
 	// adding and removing objects from the radar
-	virtual bool addObject( Object *obj );									///< add object to radar
-	virtual bool removeObject( Object *obj );								///< remove object from radar
+	virtual RadarObjectType addObject( Object *obj );									///< add object to radar
+	virtual RadarObjectType removeObject( Object *obj );								///< remove object from radar
 
 	// radar options
 	void hide( Bool hide ) { m_radarHidden = hide; }				///< hide/unhide the radar
@@ -225,9 +233,6 @@ protected:
 	virtual void crc( Xfer *xfer );
 	virtual void xfer( Xfer *xfer );
 	virtual void loadPostProcess( void );
-
-	virtual void onLocalRadarObjectAdded( const RadarObject* radarObject ) = 0;
-	virtual void onLocalRadarObjectRemoved( const RadarObject* radarObject ) = 0;
 
 	/// internal method for creating a radar event with specific colors
 	void internalCreateEvent( const Coord3D *world, RadarEventType type, Real secondsToLive,
@@ -303,8 +308,6 @@ public:
 	virtual void draw(Int pixelX, Int pixelY, Int width, Int height) { }
 	virtual void clearShroud() { }
 	virtual void setShroudLevel(Int x, Int y, CellShroudStatus setting) { }
-	virtual void onLocalRadarObjectAdded(const RadarObject*) { }
-	virtual void onLocalRadarObjectRemoved(const RadarObject*) { }
 };
 
 #endif  // __RADAR_H_

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/Common/W3DRadar.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/Common/W3DRadar.h
@@ -61,9 +61,12 @@ public:
 	virtual void update( void );																	///< subsystem update
 	virtual void reset( void );																		///< subsystem reset
 
+	virtual RadarObjectType addObject( Object *obj ); ///< add object to radar
+	virtual RadarObjectType removeObject( Object *obj ); ///< remove object from radar
+
 	virtual void newMap( TerrainLogic *terrain );				///< reset radar for new map
 
-	void draw( Int pixelX, Int pixelY, Int width, Int height );		///< draw the radar
+	virtual void draw( Int pixelX, Int pixelY, Int width, Int height );		///< draw the radar
 
 	virtual void clearShroud();
 	virtual void setShroudLevel(Int x, Int y, CellShroudStatus setting);
@@ -71,11 +74,6 @@ public:
 	virtual void refreshTerrain( TerrainLogic *terrain );
 
 protected:
-
-	virtual void onLocalRadarObjectAdded( const RadarObject* radarObject );
-	virtual void onLocalRadarObjectRemoved( const RadarObject* radarObject );
-
-	void rebuildCachedHeroObjectList();
 
 	void drawSingleBeaconEvent( Int pixelX, Int pixelY, Int width, Int height, Int index );
 	void drawSingleGenericEvent( Int pixelX, Int pixelY, Int width, Int height, Int index );
@@ -87,7 +85,7 @@ protected:
 	void drawViewBox( Int pixelX, Int pixelY, Int width, Int height );  ///< draw view box
 	void buildTerrainTexture( TerrainLogic *terrain );	 ///< create the terrain texture of the radar
 	void drawIcons( Int pixelX, Int pixelY, Int width, Int height );	///< draw all of the radar icons
-	void renderObjectList( const RadarObject *listHead, TextureClass *texture );			 ///< render an object list to the texture
+	void renderObjectList( const RadarObject *listHead, TextureClass *texture, Bool calcHero = FALSE );			 ///< render an object list to the texture
 	void interpolateColorForHeight( RGBColor *color, 
 																	Real height, 
 																	Real hiZ, 


### PR DESCRIPTION
* Fixes #1246
* Follow up for #1240
* Follow up for #1035

This change fixes #1246, which was introduced with #1035 and #1240. There were actually 3 bugs remaining:
1. Hero Radar icons on garrisoned building were not removed or updated from the Radar
2. Hero Radar icons would stack inside garrisons
3. Hero Radar icons would move to fire ports when shooting, which looked irritating

To fix that, I reinstanted the "calcHero" code that the original EA code had, in combination with code that takes care of cleaning up the object pointers to avoid dangling.

---

I did experiment with several implementations and there are many pitfalls when doing it just not the right way. I tried removing and adding Geros and Buildings containing Heros on containing and uncontaining, but that was doomed with Saveload, because after Load the order of containment is not favourable for this to work.

## TODO

- [x] Replicate in Generals
