### PR TITLE
[CORE] Make game compile in VS2019

### DIFF
--- a/Core/Libraries/Source/WWVegas/WW3D2/prim_anim.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/prim_anim.h
@@ -45,6 +45,14 @@
 #include "simplevec.h"
 #include "chunkio.h"
 
+// TheSuperHackers VS 2019 and earlier require a hack in order to compile this
+#if defined(_MSC_VER) && _MSC_VER <= 1929
+#define TYPENAME_HACK1 typename
+#define TYPENAME_HACK2
+#else
+#define TYPENAME_HACK1
+#define TYPENAME_HACK2 typename
+#endif
 
 // Forward declarations
 class ChunkSaveClass;
@@ -163,7 +171,7 @@ class LERPAnimationChannelClass : public PrimitiveAnimationChannelClass<T>
 	using PrimitiveAnimationChannelClass<T>::m_Data;
 	using PrimitiveAnimationChannelClass<T>::m_LastIndex;
 public:
-	using typename PrimitiveAnimationChannelClass<T>::KeyClass;
+	using TYPENAME_HACK2 PrimitiveAnimationChannelClass<T>::KeyClass;
 
 public:
 
@@ -187,7 +195,7 @@ int PrimitiveAnimationChannelClass<T>::Get_Key_Count (void) const
 //	Set_Key_Value
 /////////////////////////////////////////////////////////
 template<class T>
-const PrimitiveAnimationChannelClass<T>::KeyClass &PrimitiveAnimationChannelClass<T>::Get_Key (int index) const
+TYPENAME_HACK1 const PrimitiveAnimationChannelClass<T>::KeyClass &PrimitiveAnimationChannelClass<T>::Get_Key (int index) const
 {
 	return m_Data[index];
 }
@@ -387,5 +395,8 @@ LERPAnimationChannelClass<T>::Evaluate (float time)
 
 	return value;
 }
+
+#undef TYPENAME_HACK1
+#undef TYPENAME_HACK2
 
 #endif //__PRIM_ANIM_H

--- a/Core/Libraries/Source/WWVegas/WW3D2/prim_anim.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/prim_anim.h
@@ -45,14 +45,6 @@
 #include "simplevec.h"
 #include "chunkio.h"
 
-// TheSuperHackers VS 2019 and earlier require a hack in order to compile this
-#if defined(_MSC_VER) && _MSC_VER <= 1929
-#define TYPENAME_HACK1 typename
-#define TYPENAME_HACK2
-#else
-#define TYPENAME_HACK1
-#define TYPENAME_HACK2 typename
-#endif
 
 // Forward declarations
 class ChunkSaveClass;
@@ -171,7 +163,7 @@ class LERPAnimationChannelClass : public PrimitiveAnimationChannelClass<T>
 	using PrimitiveAnimationChannelClass<T>::m_Data;
 	using PrimitiveAnimationChannelClass<T>::m_LastIndex;
 public:
-	using TYPENAME_HACK2 PrimitiveAnimationChannelClass<T>::KeyClass;
+	using typename PrimitiveAnimationChannelClass<T>::KeyClass;
 
 public:
 
@@ -195,7 +187,7 @@ int PrimitiveAnimationChannelClass<T>::Get_Key_Count (void) const
 //	Set_Key_Value
 /////////////////////////////////////////////////////////
 template<class T>
-TYPENAME_HACK1 const PrimitiveAnimationChannelClass<T>::KeyClass &PrimitiveAnimationChannelClass<T>::Get_Key (int index) const
+const typename PrimitiveAnimationChannelClass<T>::KeyClass &PrimitiveAnimationChannelClass<T>::Get_Key (int index) const
 {
 	return m_Data[index];
 }
@@ -395,8 +387,5 @@ LERPAnimationChannelClass<T>::Evaluate (float time)
 
 	return value;
 }
-
-#undef TYPENAME_HACK1
-#undef TYPENAME_HACK2
 
 #endif //__PRIM_ANIM_H


### PR DESCRIPTION
Followup for #888

The PR above made the codebase compatible with clang, but also incompatible with VS2019. This PR should make it work on all relevant compilers: VC6, VS2019, VS2022 and clang.