### PR TITLE
[GEN][ZH] Fix use of invalidated iterator in ScriptEngine::reset()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
@@ -4639,10 +4639,18 @@ void ScriptEngine::reset( void )
 
 	_updateCurrentParticleCap();
 
-	VecSequentialScriptPtrIt seqScriptIt;
-	for (seqScriptIt = m_sequentialScripts.begin(); seqScriptIt != m_sequentialScripts.end(); ) {
-		cleanupSequentialScript(seqScriptIt, TRUE);
+	// delete and clear all sequential scripts.
+	VecSequentialScriptPtrIt seqScriptIt = m_sequentialScripts.begin();
+	while (seqScriptIt != m_sequentialScripts.end()) {
+		SequentialScript* seqScript = *seqScriptIt;
+		while (seqScript != NULL) {
+			SequentialScript* scriptToDelete = seqScript;
+			seqScript = seqScript->m_nextScriptInSequence;
+			deleteInstance(scriptToDelete);
+		}
+		++seqScriptIt;
 	}
+	m_sequentialScripts.clear();
 
 	// clear out all the lists of object types that were in the old map.
 	for (AllObjectTypesIt it = m_allObjectTypeLists.begin(); it != m_allObjectTypeLists.end(); it = m_allObjectTypeLists.begin() ) {

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
@@ -5374,10 +5374,18 @@ void ScriptEngine::reset( void )
 
 	_updateCurrentParticleCap();
 
-	VecSequentialScriptPtrIt seqScriptIt;
-	for (seqScriptIt = m_sequentialScripts.begin(); seqScriptIt != m_sequentialScripts.end(); ) {
-		cleanupSequentialScript(seqScriptIt, TRUE);
+	// delete and clear all sequential scripts.
+	VecSequentialScriptPtrIt seqScriptIt = m_sequentialScripts.begin();
+	while (seqScriptIt != m_sequentialScripts.end()) {
+		SequentialScript* seqScript = *seqScriptIt;
+		while (seqScript != NULL) {
+			SequentialScript* scriptToDelete = seqScript;
+			seqScript = seqScript->m_nextScriptInSequence;
+			deleteInstance(scriptToDelete);
+		}
+		++seqScriptIt;
 	}
+	m_sequentialScripts.clear();
 
 	// clear out all the lists of object types that were in the old map.
 	for (AllObjectTypesIt it = m_allObjectTypeLists.begin(); it != m_allObjectTypeLists.end(); it = m_allObjectTypeLists.begin() ) {


### PR DESCRIPTION
* Fixes #1271

This change fixes use of invalidated iterator in `ScriptEngine::reset()`.

The problem is that `cleanupSequentialScript()` erases the iterator and invalidates it. In practice it is not a problem, but it is technically illegal.

The simpler fix here would have been:

```cpp
	VecSequentialScriptPtrIt seqScriptIt;
	for (seqScriptIt = m_sequentialScripts.begin(); seqScriptIt != m_sequentialScripts.end(); ) {
		seqScriptIt = cleanupSequentialScript(seqScriptIt, TRUE);
```

But I chose against this because `cleanupSequentialScript` is risky. It has a null check at the beginning which will lead to no erasure, in which case this loop would never finish.

So I fixed it safe.