### PR TITLE
[GEN][ZH] Fix China Hackers unnecessarily packing and unpacking when ordered to hack while already hacking

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/HackInternetAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/HackInternetAIUpdate.cpp
@@ -126,16 +126,26 @@ void HackInternetAIUpdate::aiDoCommand(const AICommandParms* parms)
 	if (!isAllowedToRespondToAiCommands(parms))
 		return;
 
+	const StateID currentState = getStateMachine()->getCurrentStateID();
+
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix andrew-2e128 / Mauller 14/07/2025 prevent hacking hackers packing and unpacking when commanded to hack the internet
+	if (parms->m_cmd == AICMD_HACK_INTERNET && ( currentState == HACK_INTERNET || currentState == UNPACKING ) )
+	{
+		return;
+	}
+#endif
+
 	//If our hacker is currently packing up his gear, we need to prevent him
 	//from moving until completed. In order to accomplish this, we'll detect,
 	//then 
-	if( getStateMachine()->getCurrentStateID() == HACK_INTERNET || getStateMachine()->getCurrentStateID() == PACKING )
+	if( currentState == HACK_INTERNET || currentState == PACKING )
 	{
 		// nuke any existing pending cmd
 		m_pendingCommand.store(*parms);
 		m_hasPendingCommand = true;
 
-		if( getStateMachine()->getCurrentStateID() == HACK_INTERNET )
+		if( currentState == HACK_INTERNET )
 		{
 			getStateMachine()->clear();
 			setLastCommandSource( CMD_FROM_AI );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/HackInternetAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/HackInternetAIUpdate.cpp
@@ -126,16 +126,26 @@ void HackInternetAIUpdate::aiDoCommand(const AICommandParms* parms)
 	if (!isAllowedToRespondToAiCommands(parms))
 		return;
 
+	const StateID currentState = getStateMachine()->getCurrentStateID();
+
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix andrew-2e128 / Mauller 14/07/2025 prevent hacking hackers packing and unpacking when commanded to hack the internet
+	if (parms->m_cmd == AICMD_HACK_INTERNET && ( currentState == HACK_INTERNET || currentState == UNPACKING ) )
+	{
+		return;
+	}
+#endif
+
 	//If our hacker is currently packing up his gear, we need to prevent him
 	//from moving until completed. In order to accomplish this, we'll detect,
 	//then 
-	if( getStateMachine()->getCurrentStateID() == HACK_INTERNET || getStateMachine()->getCurrentStateID() == PACKING )
+	if( currentState == HACK_INTERNET || currentState == PACKING )
 	{
 		// nuke any existing pending cmd
 		m_pendingCommand.store(*parms);
 		m_hasPendingCommand = true;
 
-		if( getStateMachine()->getCurrentStateID() == HACK_INTERNET )
+		if( currentState == HACK_INTERNET )
 		{
 			getStateMachine()->clear();
 			setLastCommandSource( CMD_FROM_AI );


### PR DESCRIPTION
- Fixes: #223
- Closes: #399 

This PR is an alternate / updated implementation of an earlier orphaned PR

This PR prevents hackers that are currently hacking from packing then unpacking again when told to hack the internet.
This often occurs when they are part of a selection of hackers which are idling or hacking and are ordered to hack the internet.