### PR TITLE
[GEN][ZH] Fix incorrect garrison points debug assert hit in Shell Map

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/GarrisonContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/GarrisonContain.cpp
@@ -638,7 +638,7 @@ void GarrisonContain::trackTargets( void )
 	AIUpdateInterface *ai;
 	Object *obj;
 
-	DEBUG_ASSERTCRASH(m_garrisonPointsInitialized, ("garrisonPoints are not inited"));
+	DEBUG_ASSERTCRASH(m_garrisonPointsInitialized || containList.empty(), ("garrisonPoints are not inited"));
 
 	for( ContainedItemsList::const_iterator it = containList.begin(); it != containList.end(); ++it )
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/GarrisonContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/GarrisonContain.cpp
@@ -692,7 +692,7 @@ void GarrisonContain::trackTargets( void )
 	AIUpdateInterface *ai;
 	Object *obj;
 
-	DEBUG_ASSERTCRASH(m_garrisonPointsInitialized, ("garrisonPoints are not inited"));
+	DEBUG_ASSERTCRASH(m_garrisonPointsInitialized || containList.empty(), ("garrisonPoints are not inited"));
 
 	for( ContainedItemsList::const_iterator it = containList.begin(); it != containList.end(); ++it )
 	{


### PR DESCRIPTION
- Resolves #1282 
- Follow up on #783 

**Context**: PR #783 relocated a `DEBUG_ASSERTCRASH` outside the `for`-loop, which now triggers unexpectedly in the shell map scenario. This occurs because `containList` is empty in the shell map, meaning the assertion—previously nested and bypassed when the loop was skipped—is now always evaluated.

**Fix**: Update the assertion to also validate that `containList` is empty, ensuring consistent behavior regardless of loop execution. 