### PR TITLE
[GEN][ZH] Do not pause Replay playback on CRC mismatch if a Game Window has focus to avoid input problems

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Recorder.cpp
@@ -1072,10 +1072,14 @@ void RecorderClass::handleCRCMessage(UnsignedInt newCRC, Int playerIndex, Bool f
 			printf("CRC Mismatch in Frame %d\n", mismatchFrame);
 
 			// TheSuperHackers @tweak Pause the game on mismatch.
-			Bool pause = TRUE;
-			Bool pauseMusic = FALSE;
-			Bool pauseInput = FALSE;
-			TheGameLogic->setGamePaused(pause, pauseMusic, pauseInput);
+			// But not when a window with focus is opened, because that can make resuming difficult.
+			if (TheWindowManager->winGetFocus() == NULL)
+			{
+				Bool pause = TRUE;
+				Bool pauseMusic = FALSE;
+				Bool pauseInput = FALSE;
+				TheGameLogic->setGamePaused(pause, pauseMusic, pauseInput);
+			}
 		}
 		return;
 	}

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -1075,10 +1075,14 @@ void RecorderClass::handleCRCMessage(UnsignedInt newCRC, Int playerIndex, Bool f
 			printf("CRC Mismatch in Frame %d\n", mismatchFrame);
 
 			// TheSuperHackers @tweak Pause the game on mismatch.
-			Bool pause = TRUE;
-			Bool pauseMusic = FALSE;
-			Bool pauseInput = FALSE;
-			TheGameLogic->setGamePaused(pause, pauseMusic, pauseInput);
+			// But not when a window with focus is opened, because that can make resuming difficult.
+			if (TheWindowManager->winGetFocus() == NULL)
+			{
+				Bool pause = TRUE;
+				Bool pauseMusic = FALSE;
+				Bool pauseInput = FALSE;
+				TheGameLogic->setGamePaused(pause, pauseMusic, pauseInput);
+			}
 		}
 		return;
 	}


### PR DESCRIPTION
* Closes #1209

This change is an alternative fix to #1209. It prevents the pausing on Replay playback CRC mismatch if there is an active Game Window that has focus and eventually blocks input.