### PR TITLE
[GEN][ZH] Make aircraft takeoff order deterministic

### DIFF
--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ParkingPlaceBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ParkingPlaceBehavior.h
@@ -140,6 +140,7 @@ public:
 	virtual Bool reserveSpace(ObjectID id, Real parkingOffset, PPInfo* info);
 	virtual void releaseSpace(ObjectID id); 
 	virtual Bool reserveRunway(ObjectID id, Bool forLanding);
+	Bool deferUnsequencedRunwayReservationForTakeoff(UnsignedInt index, Bool forLanding);
 	virtual void releaseRunway(ObjectID id); 
 	virtual void calcPPInfo( ObjectID id, PPInfo *info );
 	virtual Int getRunwayCount() const { return m_runways.size(); }
@@ -158,15 +159,16 @@ private:
 
 	struct ParkingPlaceInfo
 	{
-		Coord3D				m_hangarStart;
-		Real					m_hangarStartOrient;
-		Coord3D				m_location;
-		Coord3D				m_prep;
-		Real					m_orientation;
-		Int						m_runway;
+		Coord3D			m_hangarStart;
+		Real			m_hangarStartOrient;
+		Coord3D			m_location;
+		Coord3D			m_prep;
+		Real			m_orientation;
+		Int				m_runway;
 		ExitDoorType	m_door;
-		ObjectID			m_objectInSpace;
-		Bool					m_reservedForExit;
+		ObjectID		m_objectInSpace;
+		Bool			m_reservedForExit;
+		Bool			m_deferredRunwayReservationForTakeoff;
 
 		ParkingPlaceInfo()
 		{
@@ -179,6 +181,7 @@ private:
 			m_door = DOOR_NONE_AVAILABLE;
 			m_objectInSpace = INVALID_ID;
 			m_reservedForExit = false;
+			m_deferredRunwayReservationForTakeoff = false;
 		} 
 	};
 


### PR DESCRIPTION
* Closes https://github.com/TheSuperHackers/GeneralsGameCode/issues/939

The order in which aircraft take off from airfields is non-deterministic, which can cause delays between sets of two aircraft taking off. This PR defers an airfield runway reservation request once, if that request came from a 'lower priority' space.

## TODO

- [ ] Replicate in Generals
- [ ] Add code comments
