### PR TITLE
tweak(behavior): Improve synchronization of pairs of aircraft taking off

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -1350,8 +1350,15 @@ public:
 		// always call this.
 		StateReturnType superStatus = AIFaceState::update();
 
+		// TheSuperHackers @tweak Don't wait for the next aircraft in line to finish taxiing, but follow scheduled takeoff to avoid delays.
+		// Otherwise aircraft may miss their original takeoff frame and take off in an unsynchronized fashion.
+#if RETAIL_COMPATIBLE_CRC
 		if (findWaiter())
 			return STATE_CONTINUE;
+#else
+		if (!m_resetTimer && findWaiter())
+			return STATE_CONTINUE;
+#endif
 
 		UnsignedInt now = TheGameLogic->getFrame();
 		if (!m_resetTimer)


### PR DESCRIPTION
* Follow up: https://github.com/TheSuperHackers/GeneralsGameCode/pull/1297

_The enhancement in this PR works better if the takeoff order is deterministic._

Sometimes when ordering 4 aircraft to take off, one of the aircraft takes off earlier than the other. This happens because aircraft will wait for the next aircraft in line to finish taxiing instead of taking off at the scheduled frame.

## TODO

- [ ] Replicate in Generals
- [x] Add code comments