### PR TITLE
[GEN][ZH] Fix nationalism and patriotism/fanaticism being applied when not in a horde

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -4473,17 +4473,17 @@ void AIUpdateInterface::evaluateMoraleBonus( void )
 		//if ( draw && !us->isKindOf( KINDOF_PORTABLE_STRUCTURE ) )
 		//	draw->setTerrainDecal(TERRAIN_DECAL_NONE);
 
-		// horde
 		if( horde )
-		{
 			us->setWeaponBonusCondition( WEAPONBONUSCONDITION_HORDE );
-
-		}  // end if
 		else
 			us->clearWeaponBonusCondition( WEAPONBONUSCONDITION_HORDE );
 
-		// nationalism
+#if RETAIL_COMPATIBLE_CRC
 		if( nationalism )
+#else
+		//TheSuperHackers @bugfix GeneralCamo/Mauller nationalism should only be applied when within a horde
+		if( horde && nationalism )
+#endif
 			us->setWeaponBonusCondition( WEAPONBONUSCONDITION_NATIONALISM );
 		else
 			us->clearWeaponBonusCondition( WEAPONBONUSCONDITION_NATIONALISM );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -4742,29 +4742,32 @@ void AIUpdateInterface::evaluateMoraleBonus( void )
 		//if ( draw && !us->isKindOf( KINDOF_PORTABLE_STRUCTURE ) )
 		//	draw->setTerrainDecal(TERRAIN_DECAL_NONE);
 
-		// horde
 		if( horde )
-		{
 			us->setWeaponBonusCondition( WEAPONBONUSCONDITION_HORDE );
-
-		}  // end if
 		else
 			us->clearWeaponBonusCondition( WEAPONBONUSCONDITION_HORDE );
 
-		// nationalism
+#if RETAIL_COMPATIBLE_CRC
 		if( nationalism )
-    {
+#else
+		//TheSuperHackers @bugfix GeneralCamo/Mauller nationalism and fanaticism should only be applied when within a horde
+		if( horde && nationalism )
+#endif
+		{
 			us->setWeaponBonusCondition( WEAPONBONUSCONDITION_NATIONALISM );
-      // fanaticism
-      if ( fanaticism )
-        us->setWeaponBonusCondition( WEAPONBONUSCONDITION_FANATICISM );// FOR THE NEW GC INFANTRY GENERAL
-      else 
-        us->clearWeaponBonusCondition( WEAPONBONUSCONDITION_FANATICISM );
-    }
+
+			if ( fanaticism )
+				us->setWeaponBonusCondition( WEAPONBONUSCONDITION_FANATICISM );
+			else
+				us->clearWeaponBonusCondition( WEAPONBONUSCONDITION_FANATICISM );
+		}
 		else
+		{
 			us->clearWeaponBonusCondition( WEAPONBONUSCONDITION_NATIONALISM );
-
-
+#if !RETAIL_COMPATIBLE_CRC
+			us->clearWeaponBonusCondition( WEAPONBONUSCONDITION_FANATICISM );
+#endif
+		}
 
 	}  // end if
 #ifdef ALLOW_DEMORALIZE


### PR DESCRIPTION
- Fixes: #173 
- Closes: #385 

This PR is an alternate / updated implementation of an earlier orphaned PR

This PR cleans up some of the code and prevents unlocked horde bonuses being applied when affected units are not within a horde.

Currently when nationalism is unlocked it gets blanket applied to all units regardless of horde status, this affects generals and zero hour.

For zero hour as an extension of nationalism being applied, the patriotism/fanaticism upgrade also gets blanket applied regardless of horde status.