### PR TITLE
[GEN][ZH] No longer adjust the power level for disabled Power Plants that are still under construction

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -3318,6 +3318,12 @@ void Object::onDisabledEdge(Bool becomingDisabled)
 		}
 	}
 
+	// TheSuperHackers @bugfix Caball009 18/07/2025 Don't adjust the power for power plants that are still under construction.
+#if !RETAIL_COMPATIBLE_CRC
+	if (testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
+		return;
+#endif
+
 	// We will need to adjust power ... somehow ...
 	Int powerToAdjust = getTemplate()->getEnergyProduction();
 	

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -3318,17 +3318,15 @@ void Object::onDisabledEdge(Bool becomingDisabled)
 		}
 	}
 
-	// TheSuperHackers @bugfix Caball009 18/07/2025 Don't adjust the power for power plants that are still under construction.
-#if RETAIL_COMPATIBLE_CRC
-	const Bool underConstruction = false;
-#else
-	const Bool underConstruction = testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION);
-#endif
-
 	// We will need to adjust power ... somehow ...
 	Int powerToAdjust = getTemplate()->getEnergyProduction();
 	
-	if( !underConstruction && powerToAdjust > 0 )
+	// TheSuperHackers @bugfix Caball009 18/07/2025 Don't adjust the power for power plants that are still under construction.
+#if !RETAIL_COMPATIBLE_CRC
+	if ( powerToAdjust > 0 && !testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION) )
+#else
+	if ( powerToAdjust > 0 )
+#endif
 	{
 		// We can't affect something that consumes, or else we go low power which removes the consumption
 		// which makes us not low power so we add the consumption so we go low power...

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -3319,15 +3319,16 @@ void Object::onDisabledEdge(Bool becomingDisabled)
 	}
 
 	// TheSuperHackers @bugfix Caball009 18/07/2025 Don't adjust the power for power plants that are still under construction.
-#if !RETAIL_COMPATIBLE_CRC
-	if (testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
-		return;
+#if RETAIL_COMPATIBLE_CRC
+	const Bool underConstruction = false;
+#else
+	const Bool underConstruction = testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION);
 #endif
 
 	// We will need to adjust power ... somehow ...
 	Int powerToAdjust = getTemplate()->getEnergyProduction();
 	
-	if( powerToAdjust > 0 )
+	if( !underConstruction && powerToAdjust > 0 )
 	{
 		// We can't affect something that consumes, or else we go low power which removes the consumption
 		// which makes us not low power so we add the consumption so we go low power...

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -3838,17 +3838,15 @@ void Object::onDisabledEdge(Bool becomingDisabled)
 		}
 	}
 
-	// TheSuperHackers @bugfix Caball009 18/07/2025 Don't adjust the power for power plants that are still under construction.
-#if RETAIL_COMPATIBLE_CRC
-	const Bool underConstruction = false;
-#else
-	const Bool underConstruction = testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION);
-#endif
-
 	// We will need to adjust power ... somehow ...
 	Int powerToAdjust = getTemplate()->getEnergyProduction();
 	
-	if( !underConstruction && powerToAdjust > 0 )
+	// TheSuperHackers @bugfix Caball009 18/07/2025 Don't adjust the power for power plants that are still under construction.
+#if !RETAIL_COMPATIBLE_CRC
+	if ( powerToAdjust > 0 && !testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION) )
+#else
+	if ( powerToAdjust > 0 )
+#endif
 	{
 		// We can't affect something that consumes, or else we go low power which removes the consumption
 		// which makes us not low power so we add the consumption so we go low power...

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -3838,6 +3838,12 @@ void Object::onDisabledEdge(Bool becomingDisabled)
 		}
 	}
 
+	// TheSuperHackers @bugfix Caball009 18/07/2025 Don't adjust the power for power plants that are still under construction.
+#if !RETAIL_COMPATIBLE_CRC
+	if (testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
+		return;
+#endif
+
 	// We will need to adjust power ... somehow ...
 	Int powerToAdjust = getTemplate()->getEnergyProduction();
 	

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -3839,15 +3839,16 @@ void Object::onDisabledEdge(Bool becomingDisabled)
 	}
 
 	// TheSuperHackers @bugfix Caball009 18/07/2025 Don't adjust the power for power plants that are still under construction.
-#if !RETAIL_COMPATIBLE_CRC
-	if (testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION))
-		return;
+#if RETAIL_COMPATIBLE_CRC
+	const Bool underConstruction = false;
+#else
+	const Bool underConstruction = testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION);
 #endif
 
 	// We will need to adjust power ... somehow ...
 	Int powerToAdjust = getTemplate()->getEnergyProduction();
 	
-	if( powerToAdjust > 0 )
+	if( !underConstruction && powerToAdjust > 0 )
 	{
 		// We can't affect something that consumes, or else we go low power which removes the consumption
 		// which makes us not low power so we add the consumption so we go low power...


### PR DESCRIPTION
* Fixes https://github.com/TheSuperHackers/GeneralsGameCode/issues/937

Disabling a power plant with a microwave tank immediately decreases the power level even if that power plant is still under construction. If the power plant is destroyed while disabled the reduction becomes permanent.