### PR TITLE
[GEN] Backport fix to prevent building multi-selection from Zero Hour

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
@@ -1122,6 +1122,15 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 				else
 				{
 
+					Drawable *draw = TheInGameUI->getFirstSelectedDrawable();
+					if( draw && draw->isKindOf( KINDOF_STRUCTURE ) )
+					{
+						//Kris: Jan 12, 2005
+						//Can't select other units if you have a structure selected. So deselect the structure to prevent
+						//group force attack exploit.
+						TheInGameUI->deselectAllDrawables();
+					}
+
 					// no need to send two messages for selecting the same group.
 					TheMessageStream->appendMessage((GameMessage::Type)(GameMessage::MSG_ADD_TEAM0 + group));
 					Player *player = ThePlayerList->getLocalPlayer();

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -5312,6 +5312,14 @@ StateReturnType AIAttackState::onEnter()
 	if (m_attackParameters && m_attackParameters->shouldExit(getMachine())) 
 		return STATE_SUCCESS;
 
+	//Kris: Jan 12, 2005
+	//Don't allow units under construction to attack! The selection/action manager system was responsible for preventing this
+	//from ever happening, but failed in two cases which I fixed. This is an extra check to mitigate cheats.
+	if( source->testStatus( OBJECT_STATUS_UNDER_CONSTRUCTION ) )
+	{
+		return STATE_FAILURE;
+	}
+
 	// if all of our weapons are out of ammo, can't attack.
 	// (this can happen for units which never auto-reload, like the Raptor)
 	if (source->isOutOfAmmo() && !source->isKindOf(KINDOF_PROJECTILE))


### PR DESCRIPTION
- closes: #334 

This PR is an updated implementation of an earlier orphaned PR

This PR backports the multi selection blocks put in place by Kris Morness that make it harder to perform the scud bug and other building related bugs.