### PR TITLE
[GEN][ZH] Fix broken Player muting for Observer

### DIFF
--- a/Generals/Code/GameEngine/Source/GameNetwork/ConnectionManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/ConnectionManager.cpp
@@ -661,7 +661,7 @@ void ConnectionManager::processChat(NetChatCommandMsg *msg)
 	
 	Bool fromObserver = !player->isPlayerActive();
 	Bool amIObserver = !ThePlayerList->getLocalPlayer()->isPlayerActive();
-	Bool canSeeChat = amIObserver || !fromObserver && !TheGameInfo->getConstSlot(playerID)->isMuted();
+	Bool canSeeChat = (amIObserver || !fromObserver) && !TheGameInfo->getConstSlot(playerID)->isMuted();
 	
 	if ( ((1<<m_localSlot) & msg->getPlayerMask() ) && canSeeChat  )
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/ConnectionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/ConnectionManager.cpp
@@ -661,7 +661,7 @@ void ConnectionManager::processChat(NetChatCommandMsg *msg)
 	
 	Bool fromObserver = !player->isPlayerActive();
 	Bool amIObserver = !ThePlayerList->getLocalPlayer()->isPlayerActive();
-	Bool canSeeChat = amIObserver || !fromObserver && !TheGameInfo->getConstSlot(playerID)->isMuted();
+	Bool canSeeChat = (amIObserver || !fromObserver) && !TheGameInfo->getConstSlot(playerID)->isMuted();
 	
 	if ( ((1<<m_localSlot) & msg->getPlayerMask() ) && canSeeChat  )
 	{


### PR DESCRIPTION
- Resolves #66
- Related to #850  

Issue caused by and operator having higher precedence and therefore missing parenthesis.