### PR TITLE
[GEN][ZH] Show the game splash screen image for at least 3 seconds

### DIFF
--- a/GeneralsMD/Code/GameEngine/Include/Common/GameEngine.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GameEngine.h
@@ -108,6 +108,8 @@ protected:
 inline void GameEngine::setQuitting( Bool quitting ) { m_quitting = quitting; }
 inline Bool GameEngine::getQuitting(void) { return m_quitting; }
 
+extern UnsignedInt TheGameStartTime;
+
 // the game engine singleton
 extern GameEngine *TheGameEngine;
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
@@ -361,6 +361,7 @@ public:
 
 	AsciiString m_shellMapName;				///< Holds the shell map name
 	Bool m_shellMapOn;								///< User can set the shell map not to load
+	Bool m_quickstart;								///< Game was launched with quick start
 	Bool m_playIntro;									///< Flag to say if we're to play the intro or not
 	Bool m_playSizzle;								///< Flag to say whether we play the sizzle movie after the logo movie.
 	Bool m_afterIntro;								///< we need to tell the game our intro is done

--- a/GeneralsMD/Code/GameEngine/Source/Common/CommandLine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/CommandLine.cpp
@@ -402,6 +402,7 @@ Int parseMapName(char *args[], int num)
 Int parseHeadless(char *args[], int num)
 {
 	TheWritableGlobalData->m_headless = TRUE;
+	TheWritableGlobalData->m_quickstart = TRUE;
 	TheWritableGlobalData->m_playIntro = FALSE;
 	TheWritableGlobalData->m_afterIntro = TRUE;
 	TheWritableGlobalData->m_playSizzle = FALSE;
@@ -823,6 +824,8 @@ Int parseQuickStart( char *args[], int num )
 #endif
 	parseNoShellMap( args, num );
 	parseNoWindowAnimation( args, num );
+	TheWritableGlobalData->m_quickstart = TRUE;
+
 	return 1;
 }
 
@@ -1138,6 +1141,7 @@ static CommandLineParam paramsForStartup[] =
 {
 	{ "-win", parseWin },
 	{ "-fullscreen", parseNoWin },
+	{ "-quickstart", parseQuickStart },
 
 	// TheSuperHackers @feature helmutbuhler 11/04/2025
 	// This runs the game without a window, graphics, input and audio. You can combine this with -replay
@@ -1168,7 +1172,6 @@ static CommandLineParam paramsForEngineInit[] =
 	{ "-playStats", parsePlayStats },
 	{ "-mod", parseMod },
 	{ "-noshaders", parseNoShaders },
-	{ "-quickstart", parseQuickStart },
 	{ "-useWaveEditor", parseUseWaveEditor },
 
 #if defined(RTS_DEBUG)

--- a/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -146,6 +146,8 @@ void DeepCRCSanityCheck::reset(void)
 }
 #endif // DEBUG_CRC
 
+UnsignedInt TheGameStartTime = timeGetTime();
+
 //-------------------------------------------------------------------------------------------------
 /// The GameEngine singleton instance
 GameEngine *TheGameEngine = NULL;

--- a/GeneralsMD/Code/GameEngine/Source/Common/GameMain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GameMain.cpp
@@ -32,6 +32,16 @@
 #include "Common/ReplaySimulation.h"
 
 
+static void delayGameInit()
+{
+	const UnsignedInt showTime = TheGameStartTime + 3000;
+	while (showTime > timeGetTime())
+	{
+		TheGameEngine->serviceWindowsOS();
+		Sleep(100);
+	}
+}
+
 /**
  * This is the entry point for the game system.
  */
@@ -40,6 +50,11 @@ Int GameMain()
 	int exitcode = 0;
 	// initialize the game engine using factory function
 	TheGameEngine = CreateGameEngine();
+
+	// TheSuperHackers @tweak Delay the game launch for a moment to present the game splash screen.
+	if (!TheGlobalData->m_quickstart)
+		delayGameInit();
+
 	TheGameEngine->init();
 
 	if (!TheGlobalData->m_simulateReplays.empty())
@@ -48,7 +63,6 @@ Int GameMain()
 	}
 	else
 	{
-		// run it
 		TheGameEngine->execute();
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/GameMain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GameMain.cpp
@@ -38,7 +38,7 @@ static void delayGameInit()
 	while (showTime > timeGetTime())
 	{
 		TheGameEngine->serviceWindowsOS();
-		Sleep(100);
+		Sleep(5);
 	}
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -981,6 +981,7 @@ GlobalData::GlobalData()
 
 	m_shellMapName.set("Maps\\ShellMap1\\ShellMap1.map");
 	m_shellMapOn =TRUE;
+	m_quickstart = FALSE;
 	m_playIntro = TRUE;
 	m_playSizzle = TRUE;
 	m_afterIntro = FALSE;

--- a/GeneralsMD/Code/Main/WinMain.cpp
+++ b/GeneralsMD/Code/Main/WinMain.cpp
@@ -841,7 +841,10 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 		// register windows class and create application window
 		if(!TheGlobalData->m_headless && initializeAppWindows(hInstance, nCmdShow, TheGlobalData->m_windowed) == false)
 			return exitcode;
-		
+
+		// set game start time after window is visible for the first time
+		TheGameStartTime = timeGetTime();
+
 		// save our application instance for future use
 		ApplicationHInstance = hInstance;
 


### PR DESCRIPTION
With this change the game splash screen image is shown for at least 3 seconds.

Reason being, on my machine Engine initializes in under 1 second now, likely because of some performance optimizations we did, and it looks bad when the splash screen image is barely visible. A user should at least see it for a moment to see that he launched the correct game title.

The artifical delay is removed with -quickstart and -headless

## TODO

- [ ] Replicate in Generals