### PR TITLE
[GEN][ZH] Improve product title information for Window title, Options Menu (and Main Menu)

### DIFF
--- a/GeneralsMD/Code/GameEngine/Include/Common/version.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/version.h
@@ -47,8 +47,8 @@ public:
 
 	UnsignedInt getVersionNumber() const;           ///< Return a 4-byte integer suitable for WOLAPI
 
-	AsciiString getAsciiVersion() const;            ///< Return a human-readable version number
-	UnicodeString getUnicodeVersion() const;        ///< Return a human-readable version number. Is decorated with localized string
+	AsciiString getAsciiVersion() const;            ///< Return a human-readable game version number
+	UnicodeString getUnicodeVersion() const;        ///< Return a human-readable game version number. Is decorated with localized string
 
 	AsciiString getAsciiBuildTime() const;          ///< Return a formated date/time string for build time
 	UnicodeString getUnicodeBuildTime() const;      ///< Return a formated date/time string for build time. Is decorated with localized string
@@ -72,11 +72,15 @@ public:
 	AsciiString getAsciiGitCommitTime() const;         ///< Returns the git head commit time in YYYY-mm-dd HH:MM:SS format
 	UnicodeString getUnicodeGitCommitTime() const;     ///< Returns the git head commit time in YYYY-mm-dd HH:MM:SS format
 
-	AsciiString getAsciiGameAndGitVersion() const;     ///< Returns the game and git version
-	UnicodeString getUnicodeGameAndGitVersion() const; ///< Returns the game and git version. Is decorated with localized string
+	AsciiString getAsciiGitVersion() const;            ///< Returns the git version
+	UnicodeString getUnicodeGitVersion() const;        ///< Returns the git version
 
 	AsciiString getAsciiBuildUserOrGitCommitAuthorName() const;
 	UnicodeString getUnicodeBuildUserOrGitCommitAuthorName() const; ///< Is decorated with localized string
+
+	UnicodeString getUnicodeProductTitle() const;
+	UnicodeString getUnicodeProductVersion() const;
+	UnicodeString getUnicodeProductAuthor() const; ///< Is decorated with localized string
 
 	Bool showFullVersion() const { return m_showFullVersion; }
 	void setShowFullVersion( Bool val ) { m_showFullVersion = val; }

--- a/GeneralsMD/Code/GameEngine/Source/Common/version.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/version.cpp
@@ -245,39 +245,35 @@ UnicodeString Version::getUnicodeGitCommitTime() const
 	return m_unicodeGitCommitTime;
 }
 
-AsciiString Version::getAsciiGameAndGitVersion() const
+AsciiString Version::getAsciiGitVersion() const
 {
 	AsciiString str;
 	if (m_showFullVersion)
 	{
-		str.format("%s R %s %s",
-			getAsciiVersion().str(),
+		str.format("%s %s",
 			getAsciiGitCommitCount().str(),
 			getAsciiGitTagOrHash().str());
 	}
 	else
 	{
-		str.format("%s R %s",
-			getAsciiVersion().str(),
+		str.format("%s",
 			getAsciiGitCommitCount().str());
 	}
 	return str;
 }
 
-UnicodeString Version::getUnicodeGameAndGitVersion() const
+UnicodeString Version::getUnicodeGitVersion() const
 {
 	UnicodeString str;
 	if (m_showFullVersion)
 	{
-		str.format(L"%s R %s %s",
-			getUnicodeVersion().str(),
+		str.format(L"%s %s",
 			getUnicodeGitCommitCount().str(),
 			getUnicodeGitTagOrHash().str());
 	}
 	else
 	{
-		str.format(L"%s R %s",
-			getUnicodeVersion().str(),
+		str.format(L"%s",
 			getUnicodeGitCommitCount().str());
 	}
 	return str;
@@ -308,6 +304,22 @@ UnicodeString Version::getUnicodeBuildUserOrGitCommitAuthorName() const
 	}
 
 	return str;
+}
+
+UnicodeString Version::getUnicodeProductTitle() const
+{
+	// @todo Make configurable
+	return UnicodeString(L"Community Patch");
+}
+
+UnicodeString Version::getUnicodeProductVersion() const
+{
+	return getUnicodeGitVersion();
+}
+
+UnicodeString Version::getUnicodeProductAuthor() const
+{
+	return getUnicodeBuildUserOrGitCommitAuthorName();
 }
 
 AsciiString Version::buildAsciiGitCommitCount()

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/MainMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/MainMenu.cpp
@@ -454,16 +454,39 @@ static void initLabelVersion()
 	{
 		if (TheVersion && TheGlobalData)
 		{
-			UnicodeString version;
-			version.format(
-				L"%s %s exe:%08X ini:%08X %s",
-				TheVersion->getUnicodeGameAndGitVersion().str(),
-				TheVersion->getUnicodeGitCommitTime().str(),
-				TheGlobalData->m_exeCRC,
-				TheGlobalData->m_iniCRC,
-				TheVersion->getUnicodeBuildUserOrGitCommitAuthorName().str()
-			);
-			GadgetStaticTextSetText( labelVersion, version );
+			UnicodeString productTitle = TheGameText->FETCH_OR_SUBSTITUTE("Version:ProductTitle", TheVersion->getUnicodeProductTitle().str());
+			UnicodeString productVersion = TheGameText->FETCH_OR_SUBSTITUTE("Version:ProductVersion", TheVersion->getUnicodeProductVersion().str());
+			UnicodeString productAuthor = TheGameText->FETCH_OR_SUBSTITUTE("Version:ProductAuthor", TheVersion->getUnicodeProductAuthor().str());
+
+			UnicodeString gameVersion = TheVersion->getUnicodeVersion();
+			UnicodeString gameHash;
+			gameHash.format(L"exe:%08X ini:%08X", TheGlobalData->m_exeCRC, TheGlobalData->m_iniCRC);
+
+			UnicodeString text;
+			text.concat(gameVersion);
+
+			if (!productTitle.isEmpty())
+			{
+				text.concat(L" ");
+				text.concat(productTitle);
+
+				if (!productVersion.isEmpty())
+				{
+					text.concat(L" ");
+					text.concat(productVersion);
+				}
+			}
+
+			text.concat(L" ");
+			text.concat(gameHash);
+
+			if (!productAuthor.isEmpty())
+			{
+				text.concat(L" ");
+				text.concat(productAuthor);
+			}
+
+			GadgetStaticTextSetText( labelVersion, text );
 		}
 		else
 		{

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -1410,16 +1410,39 @@ static void initLabelVersion()
 	{
 		if (TheVersion && TheGlobalData)
 		{
-			UnicodeString version;
-			version.format(
-				L"%s %s exe:%08X ini:%08X %s",
-				TheVersion->getUnicodeGameAndGitVersion().str(),
-				TheVersion->getUnicodeGitCommitTime().str(),
-				TheGlobalData->m_exeCRC,
-				TheGlobalData->m_iniCRC,
-				TheVersion->getUnicodeBuildUserOrGitCommitAuthorName().str()
-			);
-			GadgetStaticTextSetText( labelVersion, version );
+			UnicodeString productTitle = TheGameText->FETCH_OR_SUBSTITUTE("Version:ProductTitle", TheVersion->getUnicodeProductTitle().str());
+			UnicodeString productVersion = TheGameText->FETCH_OR_SUBSTITUTE("Version:ProductVersion", TheVersion->getUnicodeProductVersion().str());
+			UnicodeString productAuthor = TheGameText->FETCH_OR_SUBSTITUTE("Version:ProductAuthor", TheVersion->getUnicodeProductAuthor().str());
+
+			UnicodeString gameVersion = TheVersion->getUnicodeVersion();
+			UnicodeString gameHash;
+			gameHash.format(L"exe:%08X ini:%08X", TheGlobalData->m_exeCRC, TheGlobalData->m_iniCRC);
+
+			UnicodeString text;
+			text.concat(gameVersion);
+
+			if (!productTitle.isEmpty())
+			{
+				text.concat(L" ");
+				text.concat(productTitle);
+
+				if (!productVersion.isEmpty())
+				{
+					text.concat(L" ");
+					text.concat(productVersion);
+				}
+			}
+
+			text.concat(L" ");
+			text.concat(gameHash);
+
+			if (!productAuthor.isEmpty())
+			{
+				text.concat(L" ");
+				text.concat(productAuthor);
+			}
+
+			GadgetStaticTextSetText( labelVersion, text );
 		}
 		else
 		{


### PR DESCRIPTION
* Follow up for #1219

This change is a follow up for #1219 and the feedback we received.

The Window title now clarifies that the product is for the original game, but is NOT the original game.

The version title texts now print a product title with default "Community Patch". The code always uses default values if no overrides are found.

Most of the title fields are customizable via game text (generals.str). Mods can customize:

- Edit or remove product title
- Edit or remove product version
- Edit or remove product author
- Edit or remove game title (as per original setup)

It is not possible to edit the game version. It is hardcoded in the executable.

It is not possible to edit the exe and ini hashes. They are generated on runtime.

## TODO

- [ ] Replicate in Generals