### PR TITLE
[ZH] Fix broken money deposit and withdraw audio and academy income record

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -452,6 +452,8 @@ void Player::init(const PlayerTemplate* pt)
 
 		if( m_money.countMoney() == 0 )
 		{
+			// TheSuperHacker @bugfix Now correctly deposits the money and fixes its audio and academy issues.
+			// Note that copying the entire Money class instead would also copy the player index inside of it.
 			if ( TheGameInfo )
 			{
 				m_money.deposit( TheGameInfo->getStartingCash().countMoney(), FALSE );

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -452,14 +452,14 @@ void Player::init(const PlayerTemplate* pt)
 
 		if( m_money.countMoney() == 0 )
 		{
-      if ( TheGameInfo )
-      {
-        m_money = TheGameInfo->getStartingCash();
-      }
-      else
-      {
-  			m_money = TheGlobalData->m_defaultStartingCash;
-      }
+			if ( TheGameInfo )
+			{
+				m_money.deposit( TheGameInfo->getStartingCash().countMoney(), FALSE );
+			}
+			else
+			{
+				m_money.deposit( TheGlobalData->m_defaultStartingCash.countMoney(), FALSE );
+			}
 		}
 
 		m_playerDisplayName.clear();


### PR DESCRIPTION
This fixes the broken money deposit and withdraw audio and academy income record.

The issue is caused by copying the Money class after the Money player index was already set. It is Zero Hour specific, because Generals does deposit the money correctly.

An alternative/supplementary fix here would be to exclude `Money::m_playerIndex` from copying in the Money class. I am not 100% sure if that meets expectations for Money.

I noticed this Money issue when testing the "Free Build" debug command.