### PR TITLE
[ZH] Fix RenderObjClass memory leaks in W3DPropBuffer

### DIFF
--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DPropBuffer.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DPropBuffer.cpp
@@ -101,10 +101,7 @@ void W3DPropBuffer::cull(CameraClass * camera)
 //=============================================================================
 W3DPropBuffer::~W3DPropBuffer(void)
 {
-	Int i;
-	for (i=0; i<MAX_TYPES; i++) {
-		REF_PTR_RELEASE(m_propTypes[i].m_robj);
-	}
+	clearAllProps();
 	REF_PTR_RELEASE(m_light);
 	REF_PTR_RELEASE(m_propShroudMaterialPass);
 }
@@ -119,7 +116,8 @@ W3DPropBuffer::W3DPropBuffer(void)
 {
 	memset(this, sizeof(W3DPropBuffer), 0);
 	m_initialized = false;
-	clearAllProps();
+	m_numProps = 0;
+	m_numPropTypes = 0;
 	m_light = NEW_REF( LightClass, (LightClass::DIRECTIONAL) );
 	m_propShroudMaterialPass = NEW_REF(W3DShroudMaterialPassClass,());
 	m_initialized = true;
@@ -136,13 +134,16 @@ W3DPropBuffer::W3DPropBuffer(void)
 //=============================================================================
 void W3DPropBuffer::clearAllProps(void)
 {
-	m_numProps=0;
 	Int i;
-	for (i=0; i<MAX_TYPES; i++) {
+	for (i=0; i<m_numPropTypes; i++) {
 		REF_PTR_RELEASE(m_propTypes[i].m_robj);
 		m_propTypes[i].m_robjName.clear();
 	}
+	for (i=0; i<m_numProps; i++) {
+		REF_PTR_RELEASE(m_props[i].m_robj);
+	}
 	m_numPropTypes = 0;
+	m_numProps = 0;
 }
 
 //=============================================================================


### PR DESCRIPTION
This change fixes the RenderObjClass memory leaks in W3DPropBuffer. Is Zero Hour specific issue.

Tested by loading into Shell Map, into 1 Skirmish Map, and exit game. It would leak about 200 kb in this test.

## Roughly the leaks marked with red are related to this

<img width="884" height="928" alt="image" src="https://github.com/user-attachments/assets/f2b6bd2d-857f-4df2-93c9-f2c39f0424bb" />

