### PR TITLE
[GEN][ZH] Add a few checks to warn of memory leaks

### DIFF
--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8renderer.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8renderer.h
@@ -99,7 +99,7 @@ public:
 
 	void									Render(void);
 	bool									Anything_To_Render() { return (render_task_head != NULL); }
-	void									Clear_Render_List() { render_task_head = NULL; }
+	void									Clear_Render_List();
 
 	TextureClass *						Peek_Texture(int stage)	{ return textures[stage]; }
 	const VertexMaterialClass *	Peek_Material() { return material; }	

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/hlod.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/hlod.cpp
@@ -813,6 +813,9 @@ bool HLodDefClass::SubObjectArrayClass::Load_W3D(ChunkLoadClass & cload)
 
 	ModelCount = header.ModelCount;
 	MaxScreenSize = header.MaxScreenSize;
+
+	DEBUG_ASSERTCRASH(ModelName == NULL, ("HLodDefClass::SubObjectArrayClass::Load_W3D: Leaking ModelName"));
+	DEBUG_ASSERTCRASH(BoneIndex == NULL, ("HLodDefClass::SubObjectArrayClass::Load_W3D: Leaking BoneIndex"));
 	ModelName = W3DNEWARRAY char * [ModelCount];
 	BoneIndex = W3DNEWARRAY int [ModelCount];
 

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/meshgeometry.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/meshgeometry.cpp
@@ -1539,7 +1539,8 @@ void MeshGeometryClass::Generate_Culling_Tree(void)
 	{
 		AABTreeBuilderClass builder;
 		builder.Build_AABTree(PolyCount,Poly->Get_Array(),VertexCount,Vertex->Get_Array());
-	
+
+		DEBUG_ASSERTCRASH(CullTree == NULL, ("MeshGeometryClass::Generate_Culling_Tree: Leaking CullTree"));
 		CullTree = NEW_REF(AABTreeClass,(&builder));
 		CullTree->Set_Mesh(this);
 	}

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/BaseHeightMap.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/BaseHeightMap.cpp
@@ -2260,7 +2260,7 @@ void BaseHeightMapRenderObjClass::addProp(Int id, Coord3D location, Real angle, 
 //=============================================================================
 // BaseHeightMapRenderObjClass::removeProp
 //=============================================================================
-/** Adds a prop to the prop buffer.*/
+/** Removes a prop from the prop buffer.*/
 //=============================================================================
 void BaseHeightMapRenderObjClass::removeProp(Int id)
 {
@@ -2272,7 +2272,7 @@ void BaseHeightMapRenderObjClass::removeProp(Int id)
 //=============================================================================
 // BaseHeightMapRenderObjClass::removeAllProps
 //=============================================================================
-/** Adds a prop to the prop buffer.*/
+/** Removes all props from the prop buffer.*/
 //=============================================================================
 void BaseHeightMapRenderObjClass::removeAllProps()
 {

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8renderer.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8renderer.cpp
@@ -222,6 +222,8 @@ DX8TextureCategoryClass::~DX8TextureCategoryClass()
 	}
 
 	REF_PTR_RELEASE(material);
+
+	DEBUG_ASSERTCRASH(render_task_head == NULL, ("~DX8TextureCategoryClass: Leaking render tasks"));
 }
 
 void DX8TextureCategoryClass::Add_Render_Task(DX8PolygonRendererClass * p_renderer,MeshClass * p_mesh)
@@ -1957,8 +1959,19 @@ void DX8TextureCategoryClass::Render(void)
 	}
 
 	if (!renderTasksRemaining)
-	{	WWASSERT(!render_task_head);
+	{
+		WWASSERT(!render_task_head);
 		Clear_Render_List();
+	}
+}
+
+void DX8TextureCategoryClass::Clear_Render_List()
+{
+	while (render_task_head != NULL)
+	{
+		PolyRenderTaskClass* next = render_task_head->Get_Next_Visible();
+		delete render_task_head;
+		render_task_head = next;
 	}
 }
 
@@ -1974,22 +1987,20 @@ DX8MeshRendererClass::DX8MeshRendererClass()
 
 DX8MeshRendererClass::~DX8MeshRendererClass()
 {
-	Invalidate(true);
-	Clear_Pending_Delete_Lists();
-	if (texture_category_container_list_skin != NULL) {
-		delete texture_category_container_list_skin;
-	}
+	Shutdown();
 }
 
 void DX8MeshRendererClass::Init(void)
 {
-	// DMS - Only allocate one if we havent already (leak fix)
+	// DMS - Only allocate one if we have not already (leak fix)
 	if(!texture_category_container_list_skin)
 		texture_category_container_list_skin = W3DNEW FVFCategoryList;
 }
 
 void DX8MeshRendererClass::Shutdown(void)
 {
+	camera = NULL;
+	visible_decal_meshes = NULL;
 	Invalidate(true);
 	Clear_Pending_Delete_Lists();
 	_TempVertexBuffer.Clear();	//free memory

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8renderer.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8renderer.h
@@ -101,7 +101,7 @@ public:
 
 	void									Render(void);
 	bool									Anything_To_Render() { return (render_task_head != NULL); }
-	void									Clear_Render_List() { render_task_head = NULL; }
+	void									Clear_Render_List();
 
 	TextureClass *						Peek_Texture(int stage)	{ return textures[stage]; }
 	const VertexMaterialClass *	Peek_Material() { return material; }	

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/hlod.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/hlod.cpp
@@ -813,6 +813,9 @@ bool HLodDefClass::SubObjectArrayClass::Load_W3D(ChunkLoadClass & cload)
 
 	ModelCount = header.ModelCount;
 	MaxScreenSize = header.MaxScreenSize;
+
+	DEBUG_ASSERTCRASH(ModelName == NULL, ("HLodDefClass::SubObjectArrayClass::Load_W3D: Leaking ModelName"));
+	DEBUG_ASSERTCRASH(BoneIndex == NULL, ("HLodDefClass::SubObjectArrayClass::Load_W3D: Leaking BoneIndex"));
 	ModelName = W3DNEWARRAY char * [ModelCount];
 	BoneIndex = W3DNEWARRAY int [ModelCount];
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshgeometry.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshgeometry.cpp
@@ -1551,7 +1551,8 @@ void MeshGeometryClass::Generate_Culling_Tree(void)
 	{
 		AABTreeBuilderClass builder;
 		builder.Build_AABTree(PolyCount,Poly->Get_Array(),VertexCount,Vertex->Get_Array());
-	
+
+		DEBUG_ASSERTCRASH(CullTree == NULL, ("MeshGeometryClass::Generate_Culling_Tree: Leaking CullTree"));
 		CullTree = NEW_REF(AABTreeClass,(&builder));
 		CullTree->Set_Mesh(this);
 	}


### PR DESCRIPTION
As I was investigating memory leaks I saw a few places that warranted adding asserts for null pointers, just to be safe. This change fixes nothing.

There currently is a memory leak with render tasks but I have not been able to figure out what the problem is. The `DX8TextureCategoryClass::Clear_Render_List` function is now properly implemented and an assert was added to the destructor: It did not solve it. But it is a start for further investigations.

## TODO

- [x] Replicate in Generals