### PR TITLE
fix(log): Fix missing debug log arguments

### DIFF
--- a/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
+++ b/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
@@ -1042,7 +1042,7 @@ Bool AudioManager::shouldPlayLocally(const AudioEventRTS *audioEvent)
 	Player *owningPlayer = ThePlayerList->getNthPlayer(audioEvent->getPlayerIndex());
 
 	if (BitIsSet(ei->m_type, ST_PLAYER) && BitIsSet(ei->m_type, ST_UI) && owningPlayer == NULL) {
-		DEBUG_ASSERTCRASH(!TheGameLogic->isInGameLogicUpdate(), ("Playing %s sound -- player-based UI sound without specifying a player."));
+		DEBUG_ASSERTCRASH(!TheGameLogic->isInGameLogicUpdate(), ("Playing %s sound -- player-based UI sound without specifying a player.", ei->m_audioName.str()));
 		return TRUE;
 	}
 

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLobbyMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLobbyMenu.cpp
@@ -862,7 +862,7 @@ static void refreshGameList( Bool forceRefresh )
 			//DEBUG_LOG(("-"));
 		}
 	} else {
-		//DEBUG_LOG(("gameListRefreshTime: %d refreshInterval: %d"));
+		//DEBUG_LOG(("gameListRefreshTime: %d refreshInterval: %d", gameListRefreshTime, refreshInterval));
 	}
 }
 //-------------------------------------------------------------------------------------------------
@@ -1301,7 +1301,7 @@ void WOLLobbyMenuUpdate( WindowLayout * layout, void *userData)
 				//DEBUG_LOG(("-"));
 			}
 		} else {
-			//DEBUG_LOG(("gameListRefreshTime: %d refreshInterval: %d"));
+			//DEBUG_LOG(("gameListRefreshTime: %d refreshInterval: %d", gameListRefreshTime, refreshInterval));
 		}
 #else
 	refreshGameList();

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -4188,7 +4188,7 @@ CanAttackResult InGameUI::getCanSelectedObjectsAttack( ActionType action, const 
 			case ACTIONTYPE_MAKE_DEFECTOR:
 			case ACTIONTYPE_SET_RALLY_POINT:
 			default:
-				DEBUG_CRASH( ("Called InGameUI::getCanSelectedObjectsAttack() with actiontype %d. Only accepts attack types! Should you be calling InGameUI::canSelectedObjectsDoAction() instead?") );
+				DEBUG_CRASH( ("Called InGameUI::getCanSelectedObjectsAttack() with actiontype %d. Only accepts attack types! Should you be calling InGameUI::canSelectedObjectsDoAction() instead?", action) );
 				return ATTACKRESULT_INVALID_SHOT;
 
 		}

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/MetaEvent.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/MetaEvent.cpp
@@ -353,7 +353,7 @@ static const char * findGameMessageNameByType(GameMessage::Type type)
 		if (metaNames->value == (Int)type)
 			return metaNames->name;
 
-	DEBUG_CRASH(("MetaTypeName %d not found -- did you remember to add it to GameMessageMetaTypeNames[] ?"));
+	DEBUG_CRASH(("MetaTypeName %d not found -- did you remember to add it to GameMessageMetaTypeNames[] ?", (Int)type));
 	return "???";
 }
 

--- a/Generals/Code/GameEngine/Source/GameNetwork/ConnectionManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/ConnectionManager.cpp
@@ -850,7 +850,7 @@ void ConnectionManager::processAckStage1(NetCommandMsg *msg) {
 			ref = m_connections[playerID]->processAck(msg);
 		}
 	} else {
-		DEBUG_ASSERTCRASH((playerID >= 0) && (playerID < NUM_CONNECTIONS), ("ConnectionManager::processAck - %d is an invalid player number"));
+		DEBUG_ASSERTCRASH((playerID >= 0) && (playerID < NUM_CONNECTIONS), ("ConnectionManager::processAck - %d is an invalid player number", playerID));
 	}
 
 	if (ref != NULL) {

--- a/Generals/Code/GameEngine/Source/GameNetwork/FirewallHelper.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/FirewallHelper.cpp
@@ -291,7 +291,7 @@ UnsignedShort FirewallHelperClass::getNextTemporarySourcePort(Int skip)
 			closeSpareSocket(return_port);
 			return(return_port);
 		} else {
-			DEBUG_LOG(("FirewallHelperClass::getNextTemporarySourcePort - failed to open socket on port %d"));
+			DEBUG_LOG(("FirewallHelperClass::getNextTemporarySourcePort - failed to open socket on port %d", return_port));
 		}
 	}
 
@@ -998,7 +998,7 @@ Bool FirewallHelperClass::detectionTest3WaitForResponsesUpdate() {
 			*/
 			m_sourcePortAllocationDelta = m_lastSourcePortAllocationDelta;
 		}
-		DEBUG_LOG(("FirewallHelperClass::detectionTest3WaitForResponsesUpdate - didn't get enough responses, using %d as the source port allocation delta, finished test"));
+		DEBUG_LOG(("FirewallHelperClass::detectionTest3WaitForResponsesUpdate - didn't get enough responses, using %d as the source port allocation delta, finished test", m_sourcePortAllocationDelta));
 		m_currentState = DETECTIONSTATE_DONE;
 		return TRUE;
 	}

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameLogic/W3DGhostObject.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameLogic/W3DGhostObject.cpp
@@ -671,7 +671,7 @@ void W3DGhostObject::xfer( Xfer *xfer )
 		if( snapshotCount == 0 && m_parentSnapshots[ i ] != NULL )
 		{
 
-			DEBUG_CRASH(( "W3DGhostObject::xfer - m_parentShapshots[ %d ] has data present but the count from the xfer stream is empty" ));
+			DEBUG_CRASH(( "W3DGhostObject::xfer - m_parentShapshots[ %d ] has data present but the count from the xfer stream is empty", i ));
 			throw INI_INVALID_DATA;
 
 		}  // end if

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLobbyMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLobbyMenu.cpp
@@ -880,7 +880,7 @@ static void refreshGameList( Bool forceRefresh )
 			//DEBUG_LOG(("-"));
 		}
 	} else {
-		//DEBUG_LOG(("gameListRefreshTime: %d refreshInterval: %d"));
+		//DEBUG_LOG(("gameListRefreshTime: %d refreshInterval: %d", gameListRefreshTime, refreshInterval));
 	}
 }
 //-------------------------------------------------------------------------------------------------
@@ -1320,7 +1320,7 @@ void WOLLobbyMenuUpdate( WindowLayout * layout, void *userData)
 				//DEBUG_LOG(("-"));
 			}
 		} else {
-			//DEBUG_LOG(("gameListRefreshTime: %d refreshInterval: %d"));
+			//DEBUG_LOG(("gameListRefreshTime: %d refreshInterval: %d", gameListRefreshTime, refreshInterval));
 		}
 #else
 	refreshGameList();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -4348,7 +4348,7 @@ CanAttackResult InGameUI::getCanSelectedObjectsAttack( ActionType action, const 
 			case ACTIONTYPE_MAKE_DEFECTOR:
 			case ACTIONTYPE_SET_RALLY_POINT:
 			default:
-				DEBUG_CRASH( ("Called InGameUI::getCanSelectedObjectsAttack() with actiontype %d. Only accepts attack types! Should you be calling InGameUI::canSelectedObjectsDoAction() instead?") );
+				DEBUG_CRASH( ("Called InGameUI::getCanSelectedObjectsAttack() with actiontype %d. Only accepts attack types! Should you be calling InGameUI::canSelectedObjectsDoAction() instead?", action) );
 				return ATTACKRESULT_INVALID_SHOT;
 
 		}

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/MetaEvent.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/MetaEvent.cpp
@@ -391,7 +391,7 @@ static const char * findGameMessageNameByType(GameMessage::Type type)
 		if (metaNames->value == (Int)type)
 			return metaNames->name;
 
-	DEBUG_CRASH(("MetaTypeName %d not found -- did you remember to add it to GameMessageMetaTypeNames[] ?"));
+	DEBUG_CRASH(("MetaTypeName %d not found -- did you remember to add it to GameMessageMetaTypeNames[] ?", (Int)type));
 	return "???";
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/ConnectionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/ConnectionManager.cpp
@@ -850,7 +850,7 @@ void ConnectionManager::processAckStage1(NetCommandMsg *msg) {
 			ref = m_connections[playerID]->processAck(msg);
 		}
 	} else {
-		DEBUG_ASSERTCRASH((playerID >= 0) && (playerID < NUM_CONNECTIONS), ("ConnectionManager::processAck - %d is an invalid player number"));
+		DEBUG_ASSERTCRASH((playerID >= 0) && (playerID < NUM_CONNECTIONS), ("ConnectionManager::processAck - %d is an invalid player number", playerID));
 	}
 
 	if (ref != NULL) {

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/FirewallHelper.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/FirewallHelper.cpp
@@ -291,7 +291,7 @@ UnsignedShort FirewallHelperClass::getNextTemporarySourcePort(Int skip)
 			closeSpareSocket(return_port);
 			return(return_port);
 		} else {
-			DEBUG_LOG(("FirewallHelperClass::getNextTemporarySourcePort - failed to open socket on port %d"));
+			DEBUG_LOG(("FirewallHelperClass::getNextTemporarySourcePort - failed to open socket on port %d", return_port));
 		}
 	}
 
@@ -997,7 +997,7 @@ Bool FirewallHelperClass::detectionTest3WaitForResponsesUpdate() {
 			*/
 			m_sourcePortAllocationDelta = m_lastSourcePortAllocationDelta;
 		}
-		DEBUG_LOG(("FirewallHelperClass::detectionTest3WaitForResponsesUpdate - didn't get enough responses, using %d as the source port allocation delta, finished test"));
+		DEBUG_LOG(("FirewallHelperClass::detectionTest3WaitForResponsesUpdate - didn't get enough responses, using %d as the source port allocation delta, finished test", m_sourcePortAllocationDelta));
 		m_currentState = DETECTIONSTATE_DONE;
 		return TRUE;
 	}

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameLogic/W3DGhostObject.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameLogic/W3DGhostObject.cpp
@@ -675,7 +675,7 @@ void W3DGhostObject::xfer( Xfer *xfer )
 		if( snapshotCount == 0 && m_parentSnapshots[ i ] != NULL )
 		{
 
-			DEBUG_CRASH(( "W3DGhostObject::xfer - m_parentShapshots[ %d ] has data present but the count from the xfer stream is empty" ));
+			DEBUG_CRASH(( "W3DGhostObject::xfer - m_parentShapshots[ %d ] has data present but the count from the xfer stream is empty", i ));
 			throw INI_INVALID_DATA;
 
 		}  // end if


### PR DESCRIPTION
Observed a crash when using a Saboteur to steal cash in a debug build - caused by a missing object in a call to `DEBUG_ASSERTCRASH` in `GameAudio.cpp`. This change adds the missing object and a few others (found via regex expression - `DEBUG_.+\(\s*("([^"]*%[^"]*)")\s*\)`).

Affected assertions are now correctly shown instead of crashing the game.

<img width="379" height="167" alt="image" src="https://github.com/user-attachments/assets/77c7ca25-c7b9-413b-8e6b-245f64536f8f" />