### PR TITLE
bugfix(controls): Fix and improve next idle worker selection with contained workers

### DIFF
--- a/Core/GameEngine/Include/Common/STLUtils.h
+++ b/Core/GameEngine/Include/Common/STLUtils.h
@@ -20,6 +20,7 @@
 
 #include <Utility/CppMacros.h>
 #include <utility>
+#include <algorithm>
 
 namespace stl
 {
@@ -55,6 +56,20 @@ bool find_and_erase_unordered(Container& container, const typename Container::va
 			return true;
 		}
 	}
+	return false;
+}
+
+// Push back value into vector-like container if it does not yet contain that value.
+template <typename Container>
+bool push_back_unique(Container& container, const typename Container::value_type& value)
+{
+	typename Container::iterator it = std::find(container.begin(), container.end(), value);
+	if (it == container.end())
+	{
+		container.push_back(value);
+		return true;
+	}
+
 	return false;
 }
 

--- a/Generals/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/Generals/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -309,7 +309,12 @@ class InGameUI : public SubsystemInterface, public Snapshot
 {
 	
 friend class Drawable;	// for selection/deselection transactions
-		
+
+protected:
+
+	typedef std::list<Object*> ObjectList;
+	typedef std::list<Object*>::iterator ObjectListIt;
+
 public:  // ***************************************************************************************
 
 	enum SelectionRules
@@ -544,6 +549,7 @@ public:  // ********************************************************************
 	virtual void addIdleWorker( Object *obj );
 	virtual void removeIdleWorker( Object *obj, Int playerNumber );
 	virtual void selectNextIdleWorker( void );
+	static std::vector<Object*> getUniqueIdleWorkers(const ObjectList& idleWorkers);
 
 	virtual void recreateControlBar( void );
 	virtual void refreshCustomUiResources( void );
@@ -650,9 +656,6 @@ protected:
 		Color color;															///< what color should we display the military subtitles
 	};
 
-	typedef std::list<Object *> ObjectList;
-	typedef std::list<Object *>::iterator ObjectListIt;
-	
 	// ----------------------------------------------------------------------------------------------
 	// Protected Methods ----------------------------------------------------------------------------
 	// ----------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Include/GameLogic/GameLogic.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/GameLogic.h
@@ -93,6 +93,7 @@ typedef void (*GameLogicFuncPtr)( Object *obj, void *userData );
 typedef std::hash_map<ObjectID, Object *, rts::hash<ObjectID>, rts::equal_to<ObjectID> > ObjectPtrHash;
 typedef ObjectPtrHash::const_iterator ObjectPtrIter;
 
+typedef std::vector<Object*> ObjectPtrVector;
 
 // ------------------------------------------------------------------------------------------------
 /**

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5431,7 +5431,7 @@ void InGameUI::selectNextIdleWorker( void )
 	else
 	{
 		Drawable *selectedDrawable = TheInGameUI->getFirstSelectedDrawable();	
-		std::vector<Object*> uniqueIdleWorkers = getUniqueIdleWorkers(m_idleWorkers[index]);
+		ObjectPtrVector uniqueIdleWorkers = getUniqueIdleWorkers(m_idleWorkers[index]);
 
 		ObjectPtrVector::iterator uit = uniqueIdleWorkers.begin();
 		while(uit != uniqueIdleWorkers.end())
@@ -5480,9 +5480,9 @@ void InGameUI::selectNextIdleWorker( void )
 }
 
 // Finds unique selectables to avoid selecting the same or a previous container if multiple idle workers are contained
-std::vector<Object*> InGameUI::getUniqueIdleWorkers(const ObjectList& idleWorkers)
+ObjectPtrVector InGameUI::getUniqueIdleWorkers(const ObjectList& idleWorkers)
 {
-	std::vector<Object*> uniqueIdleWorkers;
+	ObjectPtrVector uniqueIdleWorkers;
 	uniqueIdleWorkers.reserve(idleWorkers.size());
 
 	for (ObjectList::const_iterator it = idleWorkers.begin(); it != idleWorkers.end(); ++it)

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5424,6 +5424,9 @@ void InGameUI::selectNextIdleWorker( void )
 	if(getSelectCount() == 0 || getSelectCount() > 1)
 	{
 		selectThisObject = *m_idleWorkers[index].begin();
+		// If our idle worker is contained by anything, we need to select the container instead.
+		while (selectThisObject->getContainedBy())
+			selectThisObject = selectThisObject->getContainedBy();
 	}
 	else
 	{
@@ -5446,19 +5449,12 @@ void InGameUI::selectNextIdleWorker( void )
 			++uit;
 		}
 		// if we had something selected that wasn't a worker, we'll get here
-		if(!selectThisObject)
-			selectThisObject = *m_idleWorkers[index].begin();
-
+		if (!selectThisObject)
+			selectThisObject = uniqueIdleWorkers.front();
 	}
 	DEBUG_ASSERTCRASH(selectThisObject, ("InGameUI::selectNextIdleWorker Could not select the next IDLE worker"));
 	if(selectThisObject)
 	{	
-		
-		//If our idle worker is contained by anything, we need to select the container instead.
-		while (selectThisObject->getContainedBy()) {
-			selectThisObject = selectThisObject->getContainedBy();
-		}
-
 		deselectAllDrawables();
 		GameMessage *teamMsg = TheMessageStream->appendMessage( GameMessage::MSG_CREATE_SELECTED_GROUP );
 

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5438,8 +5438,7 @@ void InGameUI::selectNextIdleWorker( void )
 			while (itObj->getContainedBy())
 				itObj = itObj->getContainedBy(); // Treat containers as a single idle selectable
 
-			if (std::find(uniqueIdleWorkers.begin(), uniqueIdleWorkers.end(), itObj) == uniqueIdleWorkers.end())
-				uniqueIdleWorkers.push_back(itObj);
+			stl::push_back_unique(uniqueIdleWorkers, itObj);
 		}
 		
 		ObjectPtrVector::iterator uit = uniqueIdleWorkers.begin();

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5428,21 +5428,33 @@ void InGameUI::selectNextIdleWorker( void )
 	else
 	{
 		Drawable *selectedDrawable = TheInGameUI->getFirstSelectedDrawable();	
-		
-		ObjectListIt it = m_idleWorkers[index].begin();
-		while(it != m_idleWorkers[index].end())
+		ObjectList uniqueIdleWorkers;
+
+		// Find unique selectables to avoid selecting the same or a previous container if multiple idle workers are contained
+		for (ObjectListIt it = m_idleWorkers[index].begin(); it != m_idleWorkers[index].end(); ++it)
 		{
-			Object *itObj = *it;
+			Object* itObj = *it;
+			while (itObj->getContainedBy())
+				itObj = itObj->getContainedBy(); // Treat containers as a single idle selectable
+
+			if (std::find(uniqueIdleWorkers.begin(), uniqueIdleWorkers.end(), itObj) == uniqueIdleWorkers.end())
+				uniqueIdleWorkers.push_back(itObj);
+		}
+		
+		ObjectListIt uit = uniqueIdleWorkers.begin();
+		while(uit != uniqueIdleWorkers.end())
+		{
+			Object *itObj = *uit;
 			if(itObj == selectedDrawable->getObject())
 			{
-				++it;
-				if(it != m_idleWorkers[index].end())
-					selectThisObject = *it;
+				++uit;
+				if(uit != uniqueIdleWorkers.end())
+					selectThisObject = *uit;
 				else
-					selectThisObject = *m_idleWorkers[index].begin();
+					selectThisObject = *uniqueIdleWorkers.begin();
 				break;
 			}
-			++it;
+			++uit;
 		}
 		// if we had something selected that wasn't a worker, we'll get here
 		if(!selectThisObject)
@@ -5454,10 +5466,8 @@ void InGameUI::selectNextIdleWorker( void )
 	{	
 		
 		//If our idle worker is contained by anything, we need to select the container instead.
-		Object *containedBy = selectThisObject->getContainedBy();
-		if( containedBy )
-		{
-			selectThisObject = containedBy;
+		while (selectThisObject->getContainedBy()) {
+			selectThisObject = selectThisObject->getContainedBy();
 		}
 
 		deselectAllDrawables();

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5428,7 +5428,8 @@ void InGameUI::selectNextIdleWorker( void )
 	else
 	{
 		Drawable *selectedDrawable = TheInGameUI->getFirstSelectedDrawable();	
-		ObjectList uniqueIdleWorkers;
+		std::vector<Object*> uniqueIdleWorkers;
+		uniqueIdleWorkers.reserve(m_idleWorkers->size());
 
 		// Find unique selectables to avoid selecting the same or a previous container if multiple idle workers are contained
 		for (ObjectListIt it = m_idleWorkers[index].begin(); it != m_idleWorkers[index].end(); ++it)
@@ -5441,7 +5442,7 @@ void InGameUI::selectNextIdleWorker( void )
 				uniqueIdleWorkers.push_back(itObj);
 		}
 		
-		ObjectListIt uit = uniqueIdleWorkers.begin();
+		ObjectPtrVector::iterator uit = uniqueIdleWorkers.begin();
 		while(uit != uniqueIdleWorkers.end())
 		{
 			Object *itObj = *uit;

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5431,7 +5431,7 @@ void InGameUI::selectNextIdleWorker( void )
 	else
 	{
 		Drawable *selectedDrawable = TheInGameUI->getFirstSelectedDrawable();
-		// The SuperHackers @tweak Stubbjax 22/07/2025 Idle worker iteration now correctly identifies and
+		// TheSuperHackers @tweak Stubbjax 22/07/2025 Idle worker iteration now correctly identifies and
 		// iterates contained idle workers. Previous iteration logic would not go past contained workers,
 		// and was not guaranteed to select top-level containers.
 		ObjectPtrVector uniqueIdleWorkers = getUniqueIdleWorkers(m_idleWorkers[index]);

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5430,7 +5430,10 @@ void InGameUI::selectNextIdleWorker( void )
 	}
 	else
 	{
-		Drawable *selectedDrawable = TheInGameUI->getFirstSelectedDrawable();	
+		Drawable *selectedDrawable = TheInGameUI->getFirstSelectedDrawable();
+		// The SuperHackers @tweak Stubbjax 22/07/2025 Idle worker iteration now correctly identifies and
+		// iterates contained idle workers. Previous iteration logic would not go past contained workers,
+		// and was not guaranteed to select top-level containers.
 		ObjectPtrVector uniqueIdleWorkers = getUniqueIdleWorkers(m_idleWorkers[index]);
 
 		ObjectPtrVector::iterator it = uniqueIdleWorkers.begin();
@@ -5455,6 +5458,7 @@ void InGameUI::selectNextIdleWorker( void )
 	DEBUG_ASSERTCRASH(selectThisObject, ("InGameUI::selectNextIdleWorker Could not select the next IDLE worker"));
 	if(selectThisObject)
 	{	
+		DEBUG_ASSERTCRASH(selectThisObject->getContainedBy() == NULL, ("InGameUI::selectNextIdleWorker Selected idle object should not be contained"));
 		deselectAllDrawables();
 		GameMessage *teamMsg = TheMessageStream->appendMessage( GameMessage::MSG_CREATE_SELECTED_GROUP );
 
@@ -5479,7 +5483,7 @@ void InGameUI::selectNextIdleWorker( void )
 	}
 }
 
-// Finds unique selectables to avoid selecting the same or a previous container if multiple idle workers are contained
+// Finds unique selectables to avoid selecting the same or a previous container if multiple idle workers are contained.
 ObjectPtrVector InGameUI::getUniqueIdleWorkers(const ObjectList& idleWorkers)
 {
 	ObjectPtrVector uniqueIdleWorkers;

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5428,19 +5428,8 @@ void InGameUI::selectNextIdleWorker( void )
 	else
 	{
 		Drawable *selectedDrawable = TheInGameUI->getFirstSelectedDrawable();	
-		std::vector<Object*> uniqueIdleWorkers;
-		uniqueIdleWorkers.reserve(m_idleWorkers->size());
+		std::vector<Object*> uniqueIdleWorkers = getUniqueIdleWorkers(m_idleWorkers[index]);
 
-		// Find unique selectables to avoid selecting the same or a previous container if multiple idle workers are contained
-		for (ObjectListIt it = m_idleWorkers[index].begin(); it != m_idleWorkers[index].end(); ++it)
-		{
-			Object* itObj = *it;
-			while (itObj->getContainedBy())
-				itObj = itObj->getContainedBy(); // Treat containers as a single idle selectable
-
-			stl::push_back_unique(uniqueIdleWorkers, itObj);
-		}
-		
 		ObjectPtrVector::iterator uit = uniqueIdleWorkers.begin();
 		while(uit != uniqueIdleWorkers.end())
 		{
@@ -5492,6 +5481,24 @@ void InGameUI::selectNextIdleWorker( void )
 		// center on the unit
 		TheTacticalView->lookAt(selectThisObject->getPosition());
 	}
+}
+
+// Finds unique selectables to avoid selecting the same or a previous container if multiple idle workers are contained
+std::vector<Object*> InGameUI::getUniqueIdleWorkers(const ObjectList& idleWorkers)
+{
+	std::vector<Object*> uniqueIdleWorkers;
+	uniqueIdleWorkers.reserve(idleWorkers.size());
+
+	for (ObjectList::const_iterator it = idleWorkers.begin(); it != idleWorkers.end(); ++it)
+	{
+		Object* itObj = *it;
+		while (itObj->getContainedBy())
+			itObj = itObj->getContainedBy();
+
+		stl::push_back_unique(uniqueIdleWorkers, itObj);
+	}
+
+	return uniqueIdleWorkers;
 }
 
 Int InGameUI::getIdleWorkerCount( void )

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5433,20 +5433,20 @@ void InGameUI::selectNextIdleWorker( void )
 		Drawable *selectedDrawable = TheInGameUI->getFirstSelectedDrawable();	
 		ObjectPtrVector uniqueIdleWorkers = getUniqueIdleWorkers(m_idleWorkers[index]);
 
-		ObjectPtrVector::iterator uit = uniqueIdleWorkers.begin();
-		while(uit != uniqueIdleWorkers.end())
+		ObjectPtrVector::iterator it = uniqueIdleWorkers.begin();
+		while(it != uniqueIdleWorkers.end())
 		{
-			Object *itObj = *uit;
+			Object *itObj = *it;
 			if(itObj == selectedDrawable->getObject())
 			{
-				++uit;
-				if(uit != uniqueIdleWorkers.end())
-					selectThisObject = *uit;
+				++it;
+				if(it != uniqueIdleWorkers.end())
+					selectThisObject = *it;
 				else
 					selectThisObject = *uniqueIdleWorkers.begin();
 				break;
 			}
-			++uit;
+			++it;
 		}
 		// if we had something selected that wasn't a worker, we'll get here
 		if (!selectThisObject)

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -323,7 +323,12 @@ class InGameUI : public SubsystemInterface, public Snapshot
 {
 	
 friend class Drawable;	// for selection/deselection transactions
-		
+
+protected:
+
+	typedef std::list<Object*> ObjectList;
+	typedef std::list<Object*>::iterator ObjectListIt;
+
 public:  // ***************************************************************************************
 
 	enum SelectionRules
@@ -561,6 +566,7 @@ public:  // ********************************************************************
 	virtual void addIdleWorker( Object *obj );
 	virtual void removeIdleWorker( Object *obj, Int playerNumber );
 	virtual void selectNextIdleWorker( void );
+	static std::vector<Object*> getUniqueIdleWorkers(const ObjectList& idleWorkers);
 
 	virtual void recreateControlBar( void );
 	virtual void refreshCustomUiResources( void );
@@ -670,9 +676,6 @@ protected:
 		Color color;															///< what color should we display the military subtitles
 	};
 
-	typedef std::list<Object *> ObjectList;
-	typedef std::list<Object *>::iterator ObjectListIt;
-	
 	// ----------------------------------------------------------------------------------------------
 	// Protected Methods ----------------------------------------------------------------------------
 	// ----------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5602,7 +5602,10 @@ void InGameUI::selectNextIdleWorker( void )
 	}
 	else
 	{
-		Drawable *selectedDrawable = TheInGameUI->getFirstSelectedDrawable();	
+		Drawable *selectedDrawable = TheInGameUI->getFirstSelectedDrawable();
+		// The SuperHackers @tweak Stubbjax 22/07/2025 Idle worker iteration now correctly identifies and
+		// iterates contained idle workers. Previous iteration logic would not go past contained workers,
+		// and was not guaranteed to select top-level containers.
 		ObjectPtrVector uniqueIdleWorkers = getUniqueIdleWorkers(m_idleWorkers[index]);
 
 		ObjectPtrVector::iterator it = uniqueIdleWorkers.begin();
@@ -5627,6 +5630,7 @@ void InGameUI::selectNextIdleWorker( void )
 	DEBUG_ASSERTCRASH(selectThisObject, ("InGameUI::selectNextIdleWorker Could not select the next IDLE worker"));
 	if(selectThisObject)
 	{	
+		DEBUG_ASSERTCRASH(selectThisObject->getContainedBy() == NULL, ("InGameUI::selectNextIdleWorker Selected idle object should not be contained"));
 		deselectAllDrawables();
 		GameMessage *teamMsg = TheMessageStream->appendMessage( GameMessage::MSG_CREATE_SELECTED_GROUP );
 
@@ -5651,7 +5655,7 @@ void InGameUI::selectNextIdleWorker( void )
 	}
 }
 
-// Finds unique selectables to avoid selecting the same or a previous container if multiple idle workers are contained
+// Finds unique selectables to avoid selecting the same or a previous container if multiple idle workers are contained.
 ObjectPtrVector InGameUI::getUniqueIdleWorkers(const ObjectList& idleWorkers)
 {
 	ObjectPtrVector uniqueIdleWorkers;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5603,7 +5603,7 @@ void InGameUI::selectNextIdleWorker( void )
 	else
 	{
 		Drawable *selectedDrawable = TheInGameUI->getFirstSelectedDrawable();	
-		std::vector<Object*> uniqueIdleWorkers = getUniqueIdleWorkers(m_idleWorkers[index]);
+		ObjectPtrVector uniqueIdleWorkers = getUniqueIdleWorkers(m_idleWorkers[index]);
 
 		ObjectPtrVector::iterator uit = uniqueIdleWorkers.begin();
 		while(uit != uniqueIdleWorkers.end())
@@ -5652,9 +5652,9 @@ void InGameUI::selectNextIdleWorker( void )
 }
 
 // Finds unique selectables to avoid selecting the same or a previous container if multiple idle workers are contained
-std::vector<Object*> InGameUI::getUniqueIdleWorkers(const ObjectList& idleWorkers)
+ObjectPtrVector InGameUI::getUniqueIdleWorkers(const ObjectList& idleWorkers)
 {
-	std::vector<Object*> uniqueIdleWorkers;
+	ObjectPtrVector uniqueIdleWorkers;
 	uniqueIdleWorkers.reserve(idleWorkers.size());
 
 	for (ObjectList::const_iterator it = idleWorkers.begin(); it != idleWorkers.end(); ++it)

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5600,7 +5600,8 @@ void InGameUI::selectNextIdleWorker( void )
 	else
 	{
 		Drawable *selectedDrawable = TheInGameUI->getFirstSelectedDrawable();	
-		ObjectList uniqueIdleWorkers;
+		std::vector<Object*> uniqueIdleWorkers;
+		uniqueIdleWorkers.reserve(m_idleWorkers->size());
 
 		// Find unique selectables to avoid selecting the same or a previous container if multiple idle workers are contained
 		for (ObjectListIt it = m_idleWorkers[index].begin(); it != m_idleWorkers[index].end(); ++it)
@@ -5613,7 +5614,7 @@ void InGameUI::selectNextIdleWorker( void )
 				uniqueIdleWorkers.push_back(itObj);
 		}
 		
-		ObjectListIt uit = uniqueIdleWorkers.begin();
+		ObjectPtrVector::iterator uit = uniqueIdleWorkers.begin();
 		while(uit != uniqueIdleWorkers.end())
 		{
 			Object *itObj = *uit;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5600,19 +5600,8 @@ void InGameUI::selectNextIdleWorker( void )
 	else
 	{
 		Drawable *selectedDrawable = TheInGameUI->getFirstSelectedDrawable();	
-		std::vector<Object*> uniqueIdleWorkers;
-		uniqueIdleWorkers.reserve(m_idleWorkers->size());
+		std::vector<Object*> uniqueIdleWorkers = getUniqueIdleWorkers(m_idleWorkers[index]);
 
-		// Find unique selectables to avoid selecting the same or a previous container if multiple idle workers are contained
-		for (ObjectListIt it = m_idleWorkers[index].begin(); it != m_idleWorkers[index].end(); ++it)
-		{
-			Object* itObj = *it;
-			while (itObj->getContainedBy())
-				itObj = itObj->getContainedBy(); // Treat containers as a single idle selectable
-
-			stl::push_back_unique(uniqueIdleWorkers, itObj);
-		}
-		
 		ObjectPtrVector::iterator uit = uniqueIdleWorkers.begin();
 		while(uit != uniqueIdleWorkers.end())
 		{
@@ -5664,6 +5653,24 @@ void InGameUI::selectNextIdleWorker( void )
 		// center on the unit
 		TheTacticalView->lookAt(selectThisObject->getPosition());
 	}
+}
+
+// Finds unique selectables to avoid selecting the same or a previous container if multiple idle workers are contained
+std::vector<Object*> InGameUI::getUniqueIdleWorkers(const ObjectList& idleWorkers)
+{
+	std::vector<Object*> uniqueIdleWorkers;
+	uniqueIdleWorkers.reserve(idleWorkers.size());
+
+	for (ObjectList::const_iterator it = idleWorkers.begin(); it != idleWorkers.end(); ++it)
+	{
+		Object* itObj = *it;
+		while (itObj->getContainedBy())
+			itObj = itObj->getContainedBy();
+
+		stl::push_back_unique(uniqueIdleWorkers, itObj);
+	}
+
+	return uniqueIdleWorkers;
 }
 
 Int InGameUI::getIdleWorkerCount( void )

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5596,6 +5596,9 @@ void InGameUI::selectNextIdleWorker( void )
 	if(getSelectCount() == 0 || getSelectCount() > 1)
 	{
 		selectThisObject = *m_idleWorkers[index].begin();
+		// If our idle worker is contained by anything, we need to select the container instead.
+		while (selectThisObject->getContainedBy())
+			selectThisObject = selectThisObject->getContainedBy();
 	}
 	else
 	{
@@ -5618,19 +5621,12 @@ void InGameUI::selectNextIdleWorker( void )
 			++uit;
 		}
 		// if we had something selected that wasn't a worker, we'll get here
-		if(!selectThisObject)
-			selectThisObject = *m_idleWorkers[index].begin();
-
+		if (!selectThisObject)
+			selectThisObject = uniqueIdleWorkers.front();
 	}
 	DEBUG_ASSERTCRASH(selectThisObject, ("InGameUI::selectNextIdleWorker Could not select the next IDLE worker"));
 	if(selectThisObject)
 	{	
-		
-		//If our idle worker is contained by anything, we need to select the container instead.
-		while (selectThisObject->getContainedBy()) {
-			selectThisObject = selectThisObject->getContainedBy();
-		}
-
 		deselectAllDrawables();
 		GameMessage *teamMsg = TheMessageStream->appendMessage( GameMessage::MSG_CREATE_SELECTED_GROUP );
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5603,7 +5603,7 @@ void InGameUI::selectNextIdleWorker( void )
 	else
 	{
 		Drawable *selectedDrawable = TheInGameUI->getFirstSelectedDrawable();
-		// The SuperHackers @tweak Stubbjax 22/07/2025 Idle worker iteration now correctly identifies and
+		// TheSuperHackers @tweak Stubbjax 22/07/2025 Idle worker iteration now correctly identifies and
 		// iterates contained idle workers. Previous iteration logic would not go past contained workers,
 		// and was not guaranteed to select top-level containers.
 		ObjectPtrVector uniqueIdleWorkers = getUniqueIdleWorkers(m_idleWorkers[index]);

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5610,8 +5610,7 @@ void InGameUI::selectNextIdleWorker( void )
 			while (itObj->getContainedBy())
 				itObj = itObj->getContainedBy(); // Treat containers as a single idle selectable
 
-			if (std::find(uniqueIdleWorkers.begin(), uniqueIdleWorkers.end(), itObj) == uniqueIdleWorkers.end())
-				uniqueIdleWorkers.push_back(itObj);
+			stl::push_back_unique(uniqueIdleWorkers, itObj);
 		}
 		
 		ObjectPtrVector::iterator uit = uniqueIdleWorkers.begin();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5605,20 +5605,20 @@ void InGameUI::selectNextIdleWorker( void )
 		Drawable *selectedDrawable = TheInGameUI->getFirstSelectedDrawable();	
 		ObjectPtrVector uniqueIdleWorkers = getUniqueIdleWorkers(m_idleWorkers[index]);
 
-		ObjectPtrVector::iterator uit = uniqueIdleWorkers.begin();
-		while(uit != uniqueIdleWorkers.end())
+		ObjectPtrVector::iterator it = uniqueIdleWorkers.begin();
+		while(it != uniqueIdleWorkers.end())
 		{
-			Object *itObj = *uit;
+			Object *itObj = *it;
 			if(itObj == selectedDrawable->getObject())
 			{
-				++uit;
-				if(uit != uniqueIdleWorkers.end())
-					selectThisObject = *uit;
+				++it;
+				if(it != uniqueIdleWorkers.end())
+					selectThisObject = *it;
 				else
 					selectThisObject = *uniqueIdleWorkers.begin();
 				break;
 			}
-			++uit;
+			++it;
 		}
 		// if we had something selected that wasn't a worker, we'll get here
 		if (!selectThisObject)


### PR DESCRIPTION
Fixes #1333

Selecting idle workers via the Select Next Idle Worker button now always selects the next unique selectable and correctly selects top-level containers.

https://github.com/user-attachments/assets/183eddde-ef1f-4c45-863a-0f9b7c32d73a