### PR TITLE
[ZH] Fix iterator decrement before container begin in CountermeasuresBehavior::calculateCountermeasureToDivertTo

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/CountermeasuresBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/CountermeasuresBehavior.cpp
@@ -180,6 +180,11 @@ ObjectID CountermeasuresBehavior::calculateCountermeasureToDivertTo( const Objec
 			}
 			else
 			{
+				if (it == m_counterMeasures.begin())
+				{
+					break;
+				}
+
 				--it;
 			}
 		}


### PR DESCRIPTION
Fixed an iterator underflow crash in the Countermeasures Behavior that could occur if a `CountermeasuresVec` object could not be found within the loop.