### PR TITLE
fix(options): Fix System Time and Game Time settings not loading and applying correctly

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -1228,8 +1228,8 @@ static void saveOptions( void )
 
 	//-------------------------------------------------------------------------------------------------
 	// Set System Time Font Size
-	val = TheWritableGlobalData->m_systemTimeFontSize; // TheSuperHackers @todo replace with options input when applicable
-	if (val)
+	val = pref->getSystemTimeFontSize(); // TheSuperHackers @todo replace with options input when applicable
+	if (val >= 0)
 	{
 		AsciiString prefString;
 		prefString.format("%d", val);
@@ -1239,8 +1239,8 @@ static void saveOptions( void )
 
 	//-------------------------------------------------------------------------------------------------
 	// Set Game Time Font Size
-	val = TheWritableGlobalData->m_gameTimeFontSize; // TheSuperHackers @todo replace with options input when applicable
-	if (val)
+	val = pref->getGameTimeFontSize(); // TheSuperHackers @todo replace with options input when applicable
+	if (val >= 0)
 	{
 		AsciiString prefString;
 		prefString.format("%d", val);

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -1288,8 +1288,8 @@ static void saveOptions( void )
 
 	//-------------------------------------------------------------------------------------------------
 	// Set System Time Font Size
-	val = TheWritableGlobalData->m_systemTimeFontSize; // TheSuperHackers @todo replace with options input when applicable
-	if (val)
+	val = pref->getSystemTimeFontSize(); // TheSuperHackers @todo replace with options input when applicable
+	if (val >= 0)
 	{
 		AsciiString prefString;
 		prefString.format("%d", val);
@@ -1299,8 +1299,8 @@ static void saveOptions( void )
 
 	//-------------------------------------------------------------------------------------------------
 	// Set Game Time Font Size
-	val = TheWritableGlobalData->m_gameTimeFontSize; // TheSuperHackers @todo replace with options input when applicable
-	if (val)
+	val = pref->getGameTimeFontSize(); // TheSuperHackers @todo replace with options input when applicable
+	if (val >= 0)
 	{
 		AsciiString prefString;
 		prefString.format("%d", val);


### PR DESCRIPTION
* Follow up for #1170

This PR is a small fixup pr in which the value zero was not being considered when saving the game and sytem time font sizes in the game options.

Zero is used to disabled the game time and will eventually be input by the user through the options menu.