### PR TITLE
fix(ai): Fix memory leaks in AIGuard states

### DIFF
--- a/Generals/Code/GameEngine/Include/GameLogic/AIGuard.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AIGuard.h
@@ -140,7 +140,10 @@ class AIGuardInnerState : public State
 {
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIGuardInnerState, "AIGuardInnerState")		
 public:
-	AIGuardInnerState( StateMachine *machine ) : State( machine, "AIGuardInner" ) { }
+	AIGuardInnerState( StateMachine *machine ) : State( machine, "AIGuardInner" ) 
+	{
+		m_attackState = NULL;
+	}
 	virtual StateReturnType onEnter( void );
 	virtual StateReturnType update( void );
 	virtual void onExit( StateExitType status );
@@ -155,7 +158,6 @@ private:
 	ExitConditions m_exitConditions; 
 	AIAttackState *m_attackState;
 };
-EMPTY_DTOR(AIGuardInnerState)
 
 //--------------------------------------------------------------------------------------
 class AIGuardIdleState : public State
@@ -202,7 +204,6 @@ private:
 	ExitConditions m_exitConditions; 
 	AIAttackState *m_attackState;
 };
-EMPTY_DTOR(AIGuardOuterState)
 
 //--------------------------------------------------------------------------------------
 class AIGuardReturnState : public AIInternalMoveToState
@@ -260,8 +261,6 @@ private:
 	ExitConditions m_exitConditions; 
 	AIAttackState *m_attackState;
 };
-
-EMPTY_DTOR(AIGuardAttackAggressorState)
 
 //--------------------------------------------------------------------------------------
 

--- a/Generals/Code/GameEngine/Include/GameLogic/AITNGuard.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AITNGuard.h
@@ -120,7 +120,10 @@ class AITNGuardInnerState : public State
 {
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AITNGuardInnerState, "AITNGuardInnerState")		
 public:
-	AITNGuardInnerState( StateMachine *machine ) : State( machine, "AITNGuardInner" ) { }
+	AITNGuardInnerState( StateMachine *machine ) : State( machine, "AITNGuardInner" ) 
+	{
+		m_attackState = NULL;
+	}
 	virtual StateReturnType onEnter( void );
 	virtual StateReturnType update( void );
 	virtual void onExit( StateExitType status );
@@ -136,7 +139,6 @@ private:
 	Bool			m_scanForEnemy;
 	AIAttackState *m_attackState;
 };
-EMPTY_DTOR(AITNGuardInnerState)
 
 //--------------------------------------------------------------------------------------
 class AITNGuardIdleState : public State
@@ -183,7 +185,6 @@ private:
 	TunnelNetworkExitConditions m_exitConditions; 
 	AIAttackState *m_attackState;
 };
-EMPTY_DTOR(AITNGuardOuterState)
 
 //--------------------------------------------------------------------------------------
 class AITNGuardReturnState : public AIEnterState
@@ -243,8 +244,6 @@ private:
 	TunnelNetworkExitConditions m_exitConditions; 
 	AIAttackState *m_attackState;
 };
-
-EMPTY_DTOR(AITNGuardAttackAggressorState)
 
 //--------------------------------------------------------------------------------------
 

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIGuard.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIGuard.cpp
@@ -349,6 +349,12 @@ void AIGuardInnerState::loadPostProcess( void )
 	onEnter();
 }  // end loadPostProcess
 
+// ------------------------------------------------------------------------------------------------
+AIGuardInnerState::~AIGuardInnerState(void)
+{
+	deleteInstance(m_attackState);
+}
+
 //--------------------------------------------------------------------------------------
 StateReturnType AIGuardInnerState::onEnter( void )
 {
@@ -435,6 +441,12 @@ void AIGuardOuterState::loadPostProcess( void )
 {						 AIGuardOuterState
 	onEnter();
 }  // end loadPostProcess
+
+// ------------------------------------------------------------------------------------------------
+AIGuardOuterState::~AIGuardOuterState(void)
+{
+	deleteInstance(m_attackState);
+}
 
 //--------------------------------------------------------------------------------------
 StateReturnType AIGuardOuterState::onEnter( void )
@@ -737,6 +749,12 @@ AIGuardAttackAggressorState::AIGuardAttackAggressorState( StateMachine *machine 
 	State( machine, "AIGuardAttackAggressorState" )
 {
 	m_attackState = NULL;
+}
+
+// ------------------------------------------------------------------------------------------------
+AIGuardAttackAggressorState::~AIGuardAttackAggressorState(void)
+{
+	deleteInstance(m_attackState);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AITNGuard.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AITNGuard.cpp
@@ -319,6 +319,12 @@ void AITNGuardInnerState::loadPostProcess( void )
 	onEnter();
 }  // end loadPostProcess
 
+// ------------------------------------------------------------------------------------------------
+AITNGuardInnerState::~AITNGuardInnerState(void)
+{
+	deleteInstance(m_attackState);
+}
+
 //--------------------------------------------------------------------------------------
 StateReturnType AITNGuardInnerState::onEnter( void )
 {
@@ -456,6 +462,12 @@ void AITNGuardOuterState::loadPostProcess( void )
 {						 AITNGuardOuterState
 	onEnter();
 }  // end loadPostProcess
+
+// ------------------------------------------------------------------------------------------------
+AITNGuardOuterState::~AITNGuardOuterState(void)
+{
+	deleteInstance(m_attackState);
+}
 
 //--------------------------------------------------------------------------------------
 StateReturnType AITNGuardOuterState::onEnter( void )
@@ -764,6 +776,12 @@ AITNGuardAttackAggressorState::AITNGuardAttackAggressorState( StateMachine *mach
 	State( machine, "AITNGuardAttackAggressorState" )
 {
 	m_attackState = NULL;
+}
+
+// ------------------------------------------------------------------------------------------------
+AITNGuardAttackAggressorState::~AITNGuardAttackAggressorState(void)
+{
+	deleteInstance(m_attackState);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AIGuard.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AIGuard.h
@@ -142,8 +142,8 @@ class AIGuardInnerState : public State
 public:
 	AIGuardInnerState( StateMachine *machine ) : State( machine, "AIGuardInner" ) 
 	{ 
-		m_attackState = 0;
-		m_enterState = 0;
+		m_attackState = NULL;
+		m_enterState = NULL;
 	}
 	virtual Bool isAttack() const { return m_attackState ? m_attackState->isAttack() : FALSE; }
 	virtual StateReturnType onEnter( void );
@@ -161,7 +161,6 @@ private:
 	AIAttackState *m_attackState;
 	AIEnterState *m_enterState;
 };
-EMPTY_DTOR(AIGuardInnerState)
 
 //--------------------------------------------------------------------------------------
 class AIGuardIdleState : public State
@@ -211,7 +210,6 @@ private:
 	ExitConditions m_exitConditions; 
 	AIAttackState *m_attackState;
 };
-EMPTY_DTOR(AIGuardOuterState)
 
 //--------------------------------------------------------------------------------------
 class AIGuardReturnState : public AIInternalMoveToState
@@ -272,8 +270,6 @@ private:
 	ExitConditions m_exitConditions; 
 	AIAttackState *m_attackState;
 };
-
-EMPTY_DTOR(AIGuardAttackAggressorState)
 
 //--------------------------------------------------------------------------------------
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AIGuardRetaliate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AIGuardRetaliate.h
@@ -149,7 +149,6 @@ private:
 	AIAttackState *m_attackState;
 	AIEnterState *m_enterState;
 };
-EMPTY_DTOR(AIGuardRetaliateInnerState)
 
 //--------------------------------------------------------------------------------------
 class AIGuardRetaliateIdleState : public State
@@ -196,7 +195,6 @@ private:
 	GuardRetaliateExitConditions m_exitConditions; 
 	AIAttackState *m_attackState;
 };
-EMPTY_DTOR(AIGuardRetaliateOuterState)
 
 //--------------------------------------------------------------------------------------
 class AIGuardRetaliateReturnState : public AIInternalMoveToState
@@ -257,8 +255,6 @@ private:
 	GuardRetaliateExitConditions m_exitConditions; 
 	AIAttackState *m_attackState;
 };
-
-EMPTY_DTOR(AIGuardRetaliateAttackAggressorState)
 
 //--------------------------------------------------------------------------------------
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AITNGuard.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AITNGuard.h
@@ -120,7 +120,10 @@ class AITNGuardInnerState : public State
 {
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AITNGuardInnerState, "AITNGuardInnerState")		
 public:
-	AITNGuardInnerState( StateMachine *machine ) : State( machine, "AITNGuardInner" ) { }
+	AITNGuardInnerState( StateMachine *machine ) : State( machine, "AITNGuardInner" ) 
+	{
+		m_attackState = NULL;
+	}
 	virtual StateReturnType onEnter( void );
 	virtual StateReturnType update( void );
 	virtual void onExit( StateExitType status );
@@ -136,7 +139,6 @@ private:
 	Bool			m_scanForEnemy;
 	AIAttackState *m_attackState;
 };
-EMPTY_DTOR(AITNGuardInnerState)
 
 //--------------------------------------------------------------------------------------
 class AITNGuardIdleState : public State
@@ -183,7 +185,6 @@ private:
 	TunnelNetworkExitConditions m_exitConditions; 
 	AIAttackState *m_attackState;
 };
-EMPTY_DTOR(AITNGuardOuterState)
 
 //--------------------------------------------------------------------------------------
 class AITNGuardReturnState : public AIEnterState
@@ -243,8 +244,6 @@ private:
 	TunnelNetworkExitConditions m_exitConditions; 
 	AIAttackState *m_attackState;
 };
-
-EMPTY_DTOR(AITNGuardAttackAggressorState)
 
 //--------------------------------------------------------------------------------------
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGuard.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGuard.cpp
@@ -377,6 +377,13 @@ void AIGuardInnerState::loadPostProcess( void )
 	onEnter();
 }  // end loadPostProcess
 
+// ------------------------------------------------------------------------------------------------
+AIGuardInnerState::~AIGuardInnerState(void)
+{
+	deleteInstance(m_attackState);
+	deleteInstance(m_enterState);
+}
+
 //--------------------------------------------------------------------------------------
 StateReturnType AIGuardInnerState::onEnter( void )
 {
@@ -500,6 +507,12 @@ void AIGuardOuterState::loadPostProcess( void )
 {						 AIGuardOuterState
 	onEnter();
 }  // end loadPostProcess
+
+// ------------------------------------------------------------------------------------------------
+AIGuardOuterState::~AIGuardOuterState(void)
+{
+	deleteInstance(m_attackState);
+}
 
 //--------------------------------------------------------------------------------------
 StateReturnType AIGuardOuterState::onEnter( void )
@@ -802,6 +815,12 @@ AIGuardAttackAggressorState::AIGuardAttackAggressorState( StateMachine *machine 
 	State( machine, "AIGuardAttackAggressorState" )
 {
 	m_attackState = NULL;
+}
+
+// ------------------------------------------------------------------------------------------------
+AIGuardAttackAggressorState::~AIGuardAttackAggressorState(void)
+{
+	deleteInstance(m_attackState);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGuardRetaliate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGuardRetaliate.cpp
@@ -359,6 +359,13 @@ void AIGuardRetaliateInnerState::loadPostProcess( void )
 	onEnter();
 }  // end loadPostProcess
 
+// ------------------------------------------------------------------------------------------------
+AIGuardRetaliateInnerState::~AIGuardRetaliateInnerState(void)
+{
+	deleteInstance(m_attackState);
+	deleteInstance(m_enterState);
+}
+
 //--------------------------------------------------------------------------------------
 StateReturnType AIGuardRetaliateInnerState::onEnter( void )
 {
@@ -474,6 +481,12 @@ void AIGuardRetaliateOuterState::loadPostProcess( void )
 {						 AIGuardRetaliateOuterState
 	onEnter();
 }  // end loadPostProcess
+
+// ------------------------------------------------------------------------------------------------
+AIGuardRetaliateOuterState::~AIGuardRetaliateOuterState(void)
+{
+	deleteInstance(m_attackState);
+}
 
 //--------------------------------------------------------------------------------------
 StateReturnType AIGuardRetaliateOuterState::onEnter( void )
@@ -755,6 +768,12 @@ AsciiString AIGuardRetaliateAttackAggressorState::getName(  ) const
 	return name;
 }
 #endif
+
+// ------------------------------------------------------------------------------------------------
+AIGuardRetaliateAttackAggressorState::~AIGuardRetaliateAttackAggressorState(void)
+{
+	deleteInstance(m_attackState);
+}
 
 //-------------------------------------------------------------------------------------------------
 StateReturnType AIGuardRetaliateAttackAggressorState::onEnter( void )

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AITNGuard.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AITNGuard.cpp
@@ -319,6 +319,12 @@ void AITNGuardInnerState::loadPostProcess( void )
 	onEnter();
 }  // end loadPostProcess
 
+// ------------------------------------------------------------------------------------------------
+AITNGuardInnerState::~AITNGuardInnerState(void)
+{
+	deleteInstance(m_attackState);
+}
+
 //--------------------------------------------------------------------------------------
 StateReturnType AITNGuardInnerState::onEnter( void )
 {
@@ -456,6 +462,12 @@ void AITNGuardOuterState::loadPostProcess( void )
 {						 AITNGuardOuterState
 	onEnter();
 }  // end loadPostProcess
+
+// ------------------------------------------------------------------------------------------------
+AITNGuardOuterState::~AITNGuardOuterState(void)
+{
+	deleteInstance(m_attackState);
+}
 
 //--------------------------------------------------------------------------------------
 StateReturnType AITNGuardOuterState::onEnter( void )
@@ -776,6 +788,12 @@ AITNGuardAttackAggressorState::AITNGuardAttackAggressorState( StateMachine *mach
 	State( machine, "AITNGuardAttackAggressorState" )
 {
 	m_attackState = NULL;
+}
+
+// ------------------------------------------------------------------------------------------------
+AITNGuardAttackAggressorState::~AITNGuardAttackAggressorState(void)
+{
+	deleteInstance(m_attackState);
 }
 
 //-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes memory leaks within AiGuard states that internally allocate other states.

These leaks occur when an AI state machine is destroyed due to the state machines only calling `onExit` on their currently selected state. All other states are simply deleted from the state machines state map.

As none of the states cleaned up within their destructors, this resulted in the observed leaking child states.