### PR TITLE
bugfix(controls): Fix double-press group selection logic not reselecting deselected groups

### DIFF
--- a/Generals/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/Generals/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -440,6 +440,7 @@ public:  // ********************************************************************
 	virtual Drawable *getFirstSelectedDrawable( void );							///< get the first selected drawable (if any)
 	virtual DrawableID getSoloNexusSelectedDrawableID( void ) { return m_soloNexusSelectedDrawableID; }  ///< Return the one drawable of the nexus if only 1 angry mob is selected 
 	virtual Bool isDrawableSelected( DrawableID idToCheck ) const;	///< Return true if the selected ID is in the drawable list
+	virtual Bool areAllObjectsSelected(std::vector<Object*> objectsToCheck) const;	///< Return true if all of the selected objects are in the drawable list
 	virtual Bool isAnySelectedKindOf( KindOfType kindOf ) const;		///< is any selected object a kind of 
 	virtual Bool isAllSelectedKindOf( KindOfType kindOf ) const;		///< are all selected objects a kind of
 

--- a/Generals/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/Generals/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -440,7 +440,7 @@ public:  // ********************************************************************
 	virtual Drawable *getFirstSelectedDrawable( void );							///< get the first selected drawable (if any)
 	virtual DrawableID getSoloNexusSelectedDrawableID( void ) { return m_soloNexusSelectedDrawableID; }  ///< Return the one drawable of the nexus if only 1 angry mob is selected 
 	virtual Bool isDrawableSelected( DrawableID idToCheck ) const;	///< Return true if the selected ID is in the drawable list
-	virtual Bool areAllObjectsSelected(std::vector<Object*> objectsToCheck) const;	///< Return true if all of the selected objects are in the drawable list
+	virtual Bool areAllObjectsSelected(const ObjectPtrVector& objectsToCheck) const;	///< Return true if all of the selected objects are in the drawable list
 	virtual Bool isAnySelectedKindOf( KindOfType kindOf ) const;		///< is any selected object a kind of 
 	virtual Bool isAllSelectedKindOf( KindOfType kindOf ) const;		///< are all selected objects a kind of
 

--- a/Generals/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/Generals/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -440,7 +440,7 @@ public:  // ********************************************************************
 	virtual Drawable *getFirstSelectedDrawable( void );							///< get the first selected drawable (if any)
 	virtual DrawableID getSoloNexusSelectedDrawableID( void ) { return m_soloNexusSelectedDrawableID; }  ///< Return the one drawable of the nexus if only 1 angry mob is selected 
 	virtual Bool isDrawableSelected( DrawableID idToCheck ) const;	///< Return true if the selected ID is in the drawable list
-	virtual Bool areAllObjectsSelected(const ObjectPtrVector& objectsToCheck) const;	///< Return true if all of the selected objects are in the drawable list
+	virtual Bool areAllObjectsSelected(const std::vector<Object*>& objectsToCheck) const;	///< Return true if all of the selected objects are in the drawable list
 	virtual Bool isAnySelectedKindOf( KindOfType kindOf ) const;		///< is any selected object a kind of 
 	virtual Bool isAllSelectedKindOf( KindOfType kindOf ) const;		///< are all selected objects a kind of
 

--- a/Generals/Code/GameEngine/Include/GameLogic/GameLogic.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/GameLogic.h
@@ -93,6 +93,7 @@ typedef void (*GameLogicFuncPtr)( Object *obj, void *userData );
 typedef std::hash_map<ObjectID, Object *, rts::hash<ObjectID>, rts::equal_to<ObjectID> > ObjectPtrHash;
 typedef ObjectPtrHash::const_iterator ObjectPtrIter;
 
+typedef std::vector<Object*> ObjectPtrVector;
 
 // ------------------------------------------------------------------------------------------------
 /**

--- a/Generals/Code/GameEngine/Include/GameLogic/GameLogic.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/GameLogic.h
@@ -93,7 +93,6 @@ typedef void (*GameLogicFuncPtr)( Object *obj, void *userData );
 typedef std::hash_map<ObjectID, Object *, rts::hash<ObjectID>, rts::equal_to<ObjectID> > ObjectPtrHash;
 typedef ObjectPtrHash::const_iterator ObjectPtrIter;
 
-typedef std::vector<Object*> ObjectPtrVector;
 
 // ------------------------------------------------------------------------------------------------
 /**

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -3336,7 +3336,7 @@ Bool InGameUI::isDrawableSelected( DrawableID idToCheck ) const
 }  // end isDrawableSelected
 
 //-------------------------------------------------------------------------------------------------
-/** Return true if all of the selected objects are in the drawable list */
+/** Return true if all of the given objects are selected */
 //-------------------------------------------------------------------------------------------------
 Bool InGameUI::areAllObjectsSelected(const std::vector<Object*>& objectsToCheck) const
 {

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -3338,9 +3338,9 @@ Bool InGameUI::isDrawableSelected( DrawableID idToCheck ) const
 //-------------------------------------------------------------------------------------------------
 /** Return true if all of the selected objects are in the drawable list */
 //-------------------------------------------------------------------------------------------------
-Bool InGameUI::areAllObjectsSelected(const ObjectPtrVector& objectsToCheck) const
+Bool InGameUI::areAllObjectsSelected(const std::vector<Object*>& objectsToCheck) const
 {
-	for (ObjectPtrVector::const_iterator it = objectsToCheck.begin(); it != objectsToCheck.end(); ++it)
+	for (std::vector<Object*>::const_iterator it = objectsToCheck.begin(); it != objectsToCheck.end(); ++it)
 	{
 		if (!(*it)->getDrawable()->isSelected())
 			return FALSE;

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -3338,11 +3338,11 @@ Bool InGameUI::isDrawableSelected( DrawableID idToCheck ) const
 //-------------------------------------------------------------------------------------------------
 /** Return true if all of the selected objects are in the drawable list */
 //-------------------------------------------------------------------------------------------------
-Bool InGameUI::areAllObjectsSelected(std::vector<Object*> objectsToCheck) const
+Bool InGameUI::areAllObjectsSelected(const ObjectPtrVector& objectsToCheck) const
 {
-	for (DrawableListCIt it = m_selectedDrawables.begin(); it != m_selectedDrawables.end(); ++it)
+	for (ObjectPtrVector::const_iterator it = objectsToCheck.begin(); it != objectsToCheck.end(); ++it)
 	{
-		if (std::find(objectsToCheck.begin(), objectsToCheck.end(), (*it)->getObject()) == objectsToCheck.end())
+		if (!(*it)->getDrawable()->isSelected())
 			return FALSE;
 	}
 

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -3335,6 +3335,21 @@ Bool InGameUI::isDrawableSelected( DrawableID idToCheck ) const
 
 }  // end isDrawableSelected
 
+//-------------------------------------------------------------------------------------------------
+/** Return true if all of the selected objects are in the drawable list */
+//-------------------------------------------------------------------------------------------------
+Bool InGameUI::areAllObjectsSelected(std::vector<Object*> objectsToCheck) const
+{
+	for (DrawableListCIt it = m_selectedDrawables.begin(); it != m_selectedDrawables.end(); ++it)
+	{
+		if (std::find(objectsToCheck.begin(), objectsToCheck.end(), (*it)->getObject()) == objectsToCheck.end())
+			return FALSE;
+	}
+
+	return TRUE;
+
+}  // end areAllObjectsSelected
+
 // ------------------------------------------------------------------------------------------------
 // ------------------------------------------------------------------------------------------------
 Bool InGameUI::isAnySelectedKindOf( KindOfType kindOf ) const

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
@@ -1024,10 +1024,13 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 					m_lastGroupSelTime = now;
 				}
 
+				Bool performSelection = TRUE;
+
 				// check for double-press to jump view
 				if ( now - m_lastGroupSelTime < 20 && group == m_lastGroupSelGroup )
 				{
 					DEBUG_LOG(("META: DOUBLETAP select team %d",group));
+					performSelection = FALSE;
 					Player *player = ThePlayerList->getLocalPlayer();
 					if (player)
 					{
@@ -1039,12 +1042,15 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 							if (numObjs > 0)
 							{
 								// if theres someone in the group, center the camera on them.
-								TheTacticalView->lookAt( objlist[numObjs-1]->getDrawable()->getPosition() );
+								Drawable* drawable = objlist[numObjs - 1]->getDrawable();
+								TheTacticalView->lookAt( drawable->getPosition() );
+								performSelection = !TheInGameUI->isDrawableSelected( drawable->getID() );
 							}
 						}
 					}
 				} 
-				else 
+
+				if ( performSelection )
 				{
 					TheInGameUI->deselectAllDrawables( false ); //No need to post message because we're just creating a new group!
 

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
@@ -962,6 +962,7 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
  					if (! TheGlobalData->m_useAlternateMouse || TheInGameUI->getPendingPlaceSourceObjectID() != INVALID_ID)
  					{
  						deselectAll();
+						m_lastGroupSelGroup = -1;
  					}
  				}
 			}

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
@@ -1045,7 +1045,7 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 								// if theres someone in the group, center the camera on them.
 								Drawable* drawable = objlist[numObjs - 1]->getDrawable();
 								TheTacticalView->lookAt( drawable->getPosition() );
-								performSelection = !TheInGameUI->isDrawableSelected( drawable->getID() );
+								performSelection = !TheInGameUI->areAllObjectsSelected( objlist );
 							}
 						}
 					}

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
@@ -1031,6 +1031,8 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 				if ( now - m_lastGroupSelTime < 20 && group == m_lastGroupSelGroup )
 				{
 					DEBUG_LOG(("META: DOUBLETAP select team %d",group));
+					// TheSuperHackers @bugfix Stubbjax 26/05/2025 Perform selection on double-press
+					// if the group or part of it is somehow deselected between presses.
 					performSelection = FALSE;
 					Player *player = ThePlayerList->getLocalPlayer();
 					if (player)

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -455,6 +455,7 @@ public:  // ********************************************************************
 	virtual Drawable *getFirstSelectedDrawable( void );							///< get the first selected drawable (if any)
 	virtual DrawableID getSoloNexusSelectedDrawableID( void ) { return m_soloNexusSelectedDrawableID; }  ///< Return the one drawable of the nexus if only 1 angry mob is selected 
 	virtual Bool isDrawableSelected( DrawableID idToCheck ) const;	///< Return true if the selected ID is in the drawable list
+	virtual Bool areAllObjectsSelected(std::vector<Object*> objectsToCheck) const;	///< Return true if all of the selected objects are in the drawable list
 	virtual Bool isAnySelectedKindOf( KindOfType kindOf ) const;		///< is any selected object a kind of 
 	virtual Bool isAllSelectedKindOf( KindOfType kindOf ) const;		///< are all selected objects a kind of
 

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -455,7 +455,7 @@ public:  // ********************************************************************
 	virtual Drawable *getFirstSelectedDrawable( void );							///< get the first selected drawable (if any)
 	virtual DrawableID getSoloNexusSelectedDrawableID( void ) { return m_soloNexusSelectedDrawableID; }  ///< Return the one drawable of the nexus if only 1 angry mob is selected 
 	virtual Bool isDrawableSelected( DrawableID idToCheck ) const;	///< Return true if the selected ID is in the drawable list
-	virtual Bool areAllObjectsSelected(std::vector<Object*> objectsToCheck) const;	///< Return true if all of the selected objects are in the drawable list
+	virtual Bool areAllObjectsSelected(const ObjectPtrVector& objectsToCheck) const;	///< Return true if all of the selected objects are in the drawable list
 	virtual Bool isAnySelectedKindOf( KindOfType kindOf ) const;		///< is any selected object a kind of 
 	virtual Bool isAllSelectedKindOf( KindOfType kindOf ) const;		///< are all selected objects a kind of
 

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -455,7 +455,7 @@ public:  // ********************************************************************
 	virtual Drawable *getFirstSelectedDrawable( void );							///< get the first selected drawable (if any)
 	virtual DrawableID getSoloNexusSelectedDrawableID( void ) { return m_soloNexusSelectedDrawableID; }  ///< Return the one drawable of the nexus if only 1 angry mob is selected 
 	virtual Bool isDrawableSelected( DrawableID idToCheck ) const;	///< Return true if the selected ID is in the drawable list
-	virtual Bool areAllObjectsSelected(const ObjectPtrVector& objectsToCheck) const;	///< Return true if all of the selected objects are in the drawable list
+	virtual Bool areAllObjectsSelected(const std::vector<Object*>& objectsToCheck) const;	///< Return true if all of the selected objects are in the drawable list
 	virtual Bool isAnySelectedKindOf( KindOfType kindOf ) const;		///< is any selected object a kind of 
 	virtual Bool isAllSelectedKindOf( KindOfType kindOf ) const;		///< are all selected objects a kind of
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -3425,6 +3425,21 @@ Bool InGameUI::isDrawableSelected( DrawableID idToCheck ) const
 
 }  // end isDrawableSelected
 
+//-------------------------------------------------------------------------------------------------
+/** Return true if all of the selected objects are in the drawable list */
+//-------------------------------------------------------------------------------------------------
+Bool InGameUI::areAllObjectsSelected(std::vector<Object*> objectsToCheck) const
+{
+	for (DrawableListCIt it = m_selectedDrawables.begin(); it != m_selectedDrawables.end(); ++it)
+	{
+		if (std::find(objectsToCheck.begin(), objectsToCheck.end(), (*it)->getObject()) == objectsToCheck.end())
+			return FALSE;
+	}
+
+	return TRUE;
+
+}  // end areAllObjectsSelected
+
 // ------------------------------------------------------------------------------------------------
 // ------------------------------------------------------------------------------------------------
 Bool InGameUI::isAnySelectedKindOf( KindOfType kindOf ) const

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -3428,11 +3428,11 @@ Bool InGameUI::isDrawableSelected( DrawableID idToCheck ) const
 //-------------------------------------------------------------------------------------------------
 /** Return true if all of the selected objects are in the drawable list */
 //-------------------------------------------------------------------------------------------------
-Bool InGameUI::areAllObjectsSelected(std::vector<Object*> objectsToCheck) const
+Bool InGameUI::areAllObjectsSelected(const ObjectPtrVector& objectsToCheck) const
 {
-	for (DrawableListCIt it = m_selectedDrawables.begin(); it != m_selectedDrawables.end(); ++it)
+	for (ObjectPtrVector::const_iterator it = objectsToCheck.begin(); it != objectsToCheck.end(); ++it)
 	{
-		if (std::find(objectsToCheck.begin(), objectsToCheck.end(), (*it)->getObject()) == objectsToCheck.end())
+		if (!(*it)->getDrawable()->isSelected())
 			return FALSE;
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -3426,7 +3426,7 @@ Bool InGameUI::isDrawableSelected( DrawableID idToCheck ) const
 }  // end isDrawableSelected
 
 //-------------------------------------------------------------------------------------------------
-/** Return true if all of the selected objects are in the drawable list */
+/** Return true if all of the given objects are selected */
 //-------------------------------------------------------------------------------------------------
 Bool InGameUI::areAllObjectsSelected(const std::vector<Object*>& objectsToCheck) const
 {

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -3428,9 +3428,9 @@ Bool InGameUI::isDrawableSelected( DrawableID idToCheck ) const
 //-------------------------------------------------------------------------------------------------
 /** Return true if all of the selected objects are in the drawable list */
 //-------------------------------------------------------------------------------------------------
-Bool InGameUI::areAllObjectsSelected(const ObjectPtrVector& objectsToCheck) const
+Bool InGameUI::areAllObjectsSelected(const std::vector<Object*>& objectsToCheck) const
 {
-	for (ObjectPtrVector::const_iterator it = objectsToCheck.begin(); it != objectsToCheck.end(); ++it)
+	for (std::vector<Object*>::const_iterator it = objectsToCheck.begin(); it != objectsToCheck.end(); ++it)
 	{
 		if (!(*it)->getDrawable()->isSelected())
 			return FALSE;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
@@ -954,6 +954,7 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 						if( !TheInGameUI->getPreventLeftClickDeselectionInAlternateMouseModeForOneClick() )
 						{
 							deselectAll();
+							m_lastGroupSelGroup = -1;
 						}
 						else
 						{

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
@@ -1120,7 +1120,7 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 								// if theres someone in the group, center the camera on them.
 								Drawable* drawable = objlist[numObjs - 1]->getDrawable();
 								TheTacticalView->lookAt( drawable->getPosition() );
-								performSelection = !TheInGameUI->isDrawableSelected( drawable->getID() );
+								performSelection = !TheInGameUI->areAllObjectsSelected( objlist );
 							}
 						}
 					}

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
@@ -1099,10 +1099,13 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 					m_lastGroupSelTime = now;
 				}
 
+				Bool performSelection = TRUE;
+
 				// check for double-press to jump view
 				if ( now - m_lastGroupSelTime < 20 && group == m_lastGroupSelGroup )
 				{
 					DEBUG_LOG(("META: DOUBLETAP select team %d",group));
+					performSelection = FALSE;
 					Player *player = ThePlayerList->getLocalPlayer();
 					if (player)
 					{
@@ -1114,12 +1117,15 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 							if (numObjs > 0)
 							{
 								// if theres someone in the group, center the camera on them.
-								TheTacticalView->lookAt( objlist[numObjs-1]->getDrawable()->getPosition() );
+								Drawable* drawable = objlist[numObjs - 1]->getDrawable();
+								TheTacticalView->lookAt( drawable->getPosition() );
+								performSelection = !TheInGameUI->isDrawableSelected( drawable->getID() );
 							}
 						}
 					}
 				} 
-				else 
+				
+				if ( performSelection )
 				{
 					TheInGameUI->deselectAllDrawables( false ); //No need to post message because we're just creating a new group!
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
@@ -1106,6 +1106,8 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 				if ( now - m_lastGroupSelTime < 20 && group == m_lastGroupSelGroup )
 				{
 					DEBUG_LOG(("META: DOUBLETAP select team %d",group));
+					// TheSuperHackers @bugfix Stubbjax 26/05/2025 Perform selection on double-press
+					// if the group or part of it is somehow deselected between presses.
 					performSelection = FALSE;
 					Player *player = ThePlayerList->getLocalPlayer();
 					if (player)


### PR DESCRIPTION
* Fixes #1332

* Alternative solution to #1334

Centering the camera on a group by double-pressing a group selection hotkey (0 - 9) will now reselect the group if it was deselected.

Technically either one of the two commits fixes the issue. Setting `m_lastGroupSelGroup = -1;` on global deselect is essentially replicating the existing behaviour of selecting something else (where the last group is also set to -1) - which also allows the group to be selected again - whereas the `performSelection` logic adjustment acts as more of a safer catch-all in case the selection can be lost by other means.