### PR TITLE
bugfix(object): Fix crash when an object is created with veterancy and an upgrade that applies a terrain decal

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -430,7 +430,11 @@ Object::Object( const ThingTemplate *tt, const ObjectStatusMaskType &objectStatu
 	m_soleHealingBenefactorID = INVALID_ID; ///< who is the only other object that can give me this non-stacking heal benefit?
 	m_soleHealingBenefactorExpirationFrame = 0; ///< on what frame can I accept healing (thus to switch) from a new benefactor
 
+	// TheSuperHackers @bugfix Mauller/xezon 02/08/2025 sendObjectCreated needs calling before CreateModule's are initialized to prevent drawable related crashes
+	// This predominantly occurs with the veterancy create module when the chemical suits upgrade is unlocked as it tries to set the terrain decal.
 
+	// emit message announcing object's creation
+	TheGameLogic->sendObjectCreated( this );
 
 }  // end Object
 
@@ -454,9 +458,6 @@ void Object::initObject()
 
 	// If I have a valid team assigned, I can run through my Upgrade modules with his flags
 	updateUpgradeModules();
-
-	// emit message announcing object's creation
-	TheGameLogic->sendObjectCreated( this );
 
 	//If the player has battle plans (America Strategy Center), then apply those bonuses
 	//to this object if applicable. Internally it validates certain kinds of objects.

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -499,7 +499,11 @@ Object::Object( const ThingTemplate *tt, const ObjectStatusMaskType &objectStatu
 	m_soleHealingBenefactorID = INVALID_ID; ///< who is the only other object that can give me this non-stacking heal benefit?
 	m_soleHealingBenefactorExpirationFrame = 0; ///< on what frame can I accept healing (thus to switch) from a new benefactor
 
+	// TheSuperHackers @bugfix Mauller/xezon 02/08/2025 sendObjectCreated needs calling before CreateModule's are initialized to prevent drawable related crashes
+	// This predominantly occurs with the veterancy create module when the chemical suits upgrade is unlocked as it tries to set the terrain decal.
 
+	// emit message announcing object's creation
+	TheGameLogic->sendObjectCreated( this );
 
 }  // end Object
 
@@ -523,9 +527,6 @@ void Object::initObject()
 
 	for (int i = 0; i < WEAPONSLOT_COUNT; ++i)
 		m_lastWeaponCondition[i] = WSF_INVALID;
-
-	// emit message announcing object's creation
-	TheGameLogic->sendObjectCreated( this );
 
 	// If I have a valid team assigned, I can run through my Upgrade modules with his flags
 	updateUpgradeModules();


### PR DESCRIPTION
- Fixes: #999 
- Relates to TheSuperHackers/GeneralsGamePatch#404

This PR fixes a game crash caused when a unit is created with veterancy and the object has an upgrade unlocked that attempts to apply a terrain decal. This can be reproduced with the chemical suits upgrade of the USA and is likely the reason why the chemical suit upgrade is disabled on USA pilots.

When an object is created the thing factory runs through all of it's behaviour modules and calls their `onCreate()` function if there is one available.

Units created with veterancy have the veterancyGainCreate module applied to them. This module iterates over all of the objects behaviour modules and forces them to update their status.

If the chemical suits upgrade or any other upgrade that applies a terrain decal is unlocked then it will crash the game. This is due to the objects drawable not being applied yet.


Normally the object will get its drawble created and bound to it after the behaviour modules have been iterated over. But to get around the veterancyGainCreate issue, we call the `sendObjectCreated()` at the end of the objects constructor.
originally it would be called within `initObject` that gets called after the behaviour modules `onCreate` loop within `ThingFactory::newObject`.

This then allows modules that would update the drawable to do so without crashing the game.

This is also fully retail compatible due to the ordering being maintained in the original initialisation sequence beyond creating the drawable and applying it to the object.

