### PR TITLE
bugfix(audio): Fix muted audio after regaining window focus

### DIFF
--- a/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
+++ b/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
@@ -1098,7 +1098,9 @@ void AudioManager::releaseAudioEventRTS( AudioEventRTS *&eventToRelease )
 //-------------------------------------------------------------------------------------------------
 void AudioManager::loseFocus( void )
 {
-	DEBUG_ASSERTLOG(m_savedValues == NULL, ("AudioManager::loseFocus() - leak - jkmcd"));
+	if (m_savedValues)
+		return;
+
 	// In this case, make all the audio go silent.
 	m_savedValues = NEW Real[NUM_VOLUME_TYPES];
 	m_savedValues[0] = m_systemMusicVolume;


### PR DESCRIPTION
* Fixes #169

This change fixes muted audio after regaining window focus. Does not happen always.

This issue can happen because `AudioManager::loseFocus` can be called twice (depending on what Windows sends us), in which case `m_savedValues` would be written a second time, with all 0 values, and therefore restore 0 values on regaining focus.