### PR TITLE
tweak(gui): Disable the combo box for the host's player name

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanGameOptionsMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanGameOptionsMenu.cpp
@@ -816,7 +816,7 @@ void LanGameOptionsMenuInit( WindowLayout *layout, void *userData )
 		updateGameOptions();
 		start = 1; // leave my combo boxes usable
 
-		// disable the combo box for the host's player name
+		// TheSuperHackers @tweak disable the combo box for the host's player name
 		comboBoxPlayer[0]->winEnable(FALSE);
 	}
 	else

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanGameOptionsMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanGameOptionsMenu.cpp
@@ -671,11 +671,7 @@ void InitLanGameGadgets( void )
 		GadgetComboBoxReset(comboBoxPlayer[i]);
 		GadgetComboBoxGetEditBox(comboBoxPlayer[i])->winSetTooltipFunc(playerTooltip);
 
-		if(localSlotNum == i)
-		{
-			GadgetComboBoxAddEntry(comboBoxPlayer[i],TheLAN->GetMyName(),white);
-		}
-		else
+		if(localSlotNum != i)
 		{
 			GadgetComboBoxAddEntry(comboBoxPlayer[i],TheGameText->fetch("GUI:Open"),white);
 			GadgetComboBoxAddEntry(comboBoxPlayer[i],TheGameText->fetch("GUI:Closed"),white);
@@ -819,6 +815,9 @@ void LanGameOptionsMenuInit( WindowLayout *layout, void *userData )
 		lanUpdateSlotList();
 		updateGameOptions();
 		start = 1; // leave my combo boxes usable
+
+		// disable the combo box for the host's player name
+		comboBoxPlayer[0]->winEnable(FALSE);
 	}
 	else
 	{

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLGameSetupMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLGameSetupMenu.cpp
@@ -1251,7 +1251,7 @@ void WOLGameSetupMenuInit( WindowLayout *layout, void *userData )
 		WOLDisplaySlotList();
 		WOLDisplayGameOptions();
 
-		// disable the combo box for the host's player name
+		// TheSuperHackers @tweak disable the combo box for the host's player name
 		comboBoxPlayer[0]->winEnable(FALSE);
 	}
 	else

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLGameSetupMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLGameSetupMenu.cpp
@@ -1057,14 +1057,7 @@ void InitWOLGameGadgets( void )
 		if (TheGameSpyInfo->amIHost())
 			staticTextPlayer[i]->winHide(TRUE);
 
-		if(i==0 && TheGameSpyInfo->amIHost())
-		{
-			UnicodeString uName;
-			uName.translate(TheGameSpyInfo->getLocalName());
-			GadgetComboBoxAddEntry(comboBoxPlayer[i],uName,GameSpyColor[GSCOLOR_PLAYER_OWNER]);
-			GadgetComboBoxSetSelectedPos(comboBoxPlayer[0],0);
-		}
-		else
+		if(theGameInfo->getLocalSlotNum() != i)
 		{
 			GadgetComboBoxAddEntry(comboBoxPlayer[i],TheGameText->fetch("GUI:Open"),GameSpyColor[GSCOLOR_PLAYER_NORMAL]);
 			GadgetComboBoxAddEntry(comboBoxPlayer[i],TheGameText->fetch("GUI:Closed"),GameSpyColor[GSCOLOR_PLAYER_NORMAL]);
@@ -1257,6 +1250,9 @@ void WOLGameSetupMenuInit( WindowLayout *layout, void *userData )
 
 		WOLDisplaySlotList();
 		WOLDisplayGameOptions();
+
+		// disable the combo box for the host's player name
+		comboBoxPlayer[0]->winEnable(FALSE);
 	}
 	else
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanGameOptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanGameOptionsMenu.cpp
@@ -894,7 +894,7 @@ void LanGameOptionsMenuInit( WindowLayout *layout, void *userData )
 		updateGameOptions();
 		start = 1; // leave my combo boxes usable
 
-		// disable the combo box for the host's player name
+		// TheSuperHackers @tweak disable the combo box for the host's player name
 		comboBoxPlayer[0]->winEnable(FALSE);
 	}
 	else

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanGameOptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanGameOptionsMenu.cpp
@@ -741,11 +741,7 @@ void InitLanGameGadgets( void )
 		GadgetComboBoxReset(comboBoxPlayer[i]);
 		GadgetComboBoxGetEditBox(comboBoxPlayer[i])->winSetTooltipFunc(playerTooltip);
 
-		if(localSlotNum == i)
-		{
-			GadgetComboBoxAddEntry(comboBoxPlayer[i],TheLAN->GetMyName(),white);
-		}
-		else
+		if(localSlotNum != i)
 		{
 			GadgetComboBoxAddEntry(comboBoxPlayer[i],TheGameText->fetch("GUI:Open"),white);
 			GadgetComboBoxAddEntry(comboBoxPlayer[i],TheGameText->fetch("GUI:Closed"),white);
@@ -897,6 +893,9 @@ void LanGameOptionsMenuInit( WindowLayout *layout, void *userData )
 		lanUpdateSlotList();
 		updateGameOptions();
 		start = 1; // leave my combo boxes usable
+
+		// disable the combo box for the host's player name
+		comboBoxPlayer[0]->winEnable(FALSE);
 	}
 	else
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLGameSetupMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLGameSetupMenu.cpp
@@ -1206,14 +1206,7 @@ void InitWOLGameGadgets( void )
 		if (TheGameSpyInfo->amIHost())
 			staticTextPlayer[i]->winHide(TRUE);
 
-		if(i==0 && TheGameSpyInfo->amIHost())
-		{
-			UnicodeString uName;
-			uName.translate(TheGameSpyInfo->getLocalName());
-			GadgetComboBoxAddEntry(comboBoxPlayer[i],uName,GameSpyColor[GSCOLOR_PLAYER_OWNER]);
-			GadgetComboBoxSetSelectedPos(comboBoxPlayer[0],0);
-		}
-		else
+		if(theGameInfo->getLocalSlotNum() != i)
 		{
 			GadgetComboBoxAddEntry(comboBoxPlayer[i],TheGameText->fetch("GUI:Open"),GameSpyColor[GSCOLOR_PLAYER_NORMAL]);
 			GadgetComboBoxAddEntry(comboBoxPlayer[i],TheGameText->fetch("GUI:Closed"),GameSpyColor[GSCOLOR_PLAYER_NORMAL]);
@@ -1434,6 +1427,9 @@ void WOLGameSetupMenuInit( WindowLayout *layout, void *userData )
 
 		WOLDisplaySlotList();
 		WOLDisplayGameOptions();
+
+		// disable the combo box for the host's player name
+		comboBoxPlayer[0]->winEnable(FALSE);
 	}
 	else
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLGameSetupMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLGameSetupMenu.cpp
@@ -1428,7 +1428,7 @@ void WOLGameSetupMenuInit( WindowLayout *layout, void *userData )
 		WOLDisplaySlotList();
 		WOLDisplayGameOptions();
 
-		// disable the combo box for the host's player name
+		// TheSuperHackers @tweak disable the combo box for the host's player name
 		comboBoxPlayer[0]->winEnable(FALSE);
 	}
 	else


### PR DESCRIPTION
This PR disables the drop down menu under the host's player name when setting up a match. There's no need for it to be enabled for the host.

**BEFORE:**
<img width="549" height="212" alt="image" src="https://github.com/user-attachments/assets/af6f5e8d-9c1a-4cd5-862e-23ff2142ed3b" />

**AFTER:**
<img width="542" height="215" alt="image" src="https://github.com/user-attachments/assets/b0c17526-995f-4c2c-9b92-9aa1fffa565b" />

I only tested this on LAN and that part works as intended; the changes to the 'WOL' logic are untested.
