### PR TITLE
build(debug): Add CMake option to generate full debug information for VC6 builds

### DIFF
--- a/cmake/compilers.cmake
+++ b/cmake/compilers.cmake
@@ -40,8 +40,13 @@ if (NOT IS_VS6_BUILD)
         add_compile_options(/Zc:__cplusplus)
     endif()
 else()
-    # Define two pools: 'compile' with plenty of slots, 'link' with just one
-    set_property(GLOBAL PROPERTY JOB_POOLS compile=0 link=1)
+    if(RTS_BUILD_OPTION_VC6_FULL_DEBUG)
+        set_property(GLOBAL PROPERTY JOB_POOLS compile=1 link=1)
+    else()
+        # Define two pools: 'compile' with plenty of slots, 'link' with just one
+        set_property(GLOBAL PROPERTY JOB_POOLS compile=0 link=1)
+    endif()
+
     # Tell CMake that all compile steps go into 'compile'
     set(CMAKE_JOB_POOL_COMPILE compile)
     # and all link steps go into 'link' (so only one link ever runs since vc6 can't handle multithreaded linking)

--- a/cmake/config-build.cmake
+++ b/cmake/config-build.cmake
@@ -6,6 +6,7 @@ option(RTS_BUILD_GENERALS "Build Generals code." ON)
 option(RTS_BUILD_OPTION_PROFILE "Build code with the \"Profile\" configuration." OFF)
 option(RTS_BUILD_OPTION_DEBUG "Build code with the \"Debug\" configuration." OFF)
 option(RTS_BUILD_OPTION_ASAN "Build code with Address Sanitizer." OFF)
+option(RTS_BUILD_OPTION_VC6_FULL_DEBUG "Build VC6 with full debug info." OFF)
 option(RTS_BUILD_OPTION_FFMPEG "Enable FFmpeg support" OFF)
 
 if(NOT RTS_BUILD_ZEROHOUR AND NOT RTS_BUILD_GENERALS)
@@ -20,6 +21,7 @@ add_feature_info(GeneralsStuff RTS_BUILD_GENERALS "Build Generals code")
 add_feature_info(ProfileBuild RTS_BUILD_OPTION_PROFILE "Building as a \"Profile\" build")
 add_feature_info(DebugBuild RTS_BUILD_OPTION_DEBUG "Building as a \"Debug\" build")
 add_feature_info(AddressSanitizer RTS_BUILD_OPTION_ASAN "Building with address sanitizer")
+add_feature_info(Vc6FullDebug RTS_BUILD_OPTION_VC6_FULL_DEBUG "Building VC6 with full debug info")
 add_feature_info(FFmpegSupport RTS_BUILD_OPTION_FFMPEG "Building with FFmpeg support")
 
 if(RTS_BUILD_ZEROHOUR)
@@ -47,7 +49,11 @@ if(NOT IS_VS6_BUILD)
     target_compile_features(core_config INTERFACE cxx_std_20)
 endif()
 
-target_compile_options(core_config INTERFACE ${RTS_FLAGS})
+if(IS_VS6_BUILD AND RTS_BUILD_OPTION_VC6_FULL_DEBUG)
+    target_compile_options(core_config INTERFACE ${RTS_FLAGS} /Zi)
+else()
+    target_compile_options(core_config INTERFACE ${RTS_FLAGS})
+endif()
 
 # This disables a lot of warnings steering developers to use windows only functions/function names.
 if(MSVC)


### PR DESCRIPTION
This PR adds a cmake option to make VC6 generate builds with full debug information.

This does slow down the build process so it disabled by default.

This sets the compiler options `/Zi` and sets the build pools to 1 as generating the full debug info is not supported with VC6 when multi-threaded builds are used.