### PR TITLE
bugfix(debug): Fix memory corruption in DebugCrash()

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/System/Debug.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/Debug.cpp
@@ -499,9 +499,10 @@ void DebugCrash(const char *format, ...)
 	strcat(theCrashBuffer, "ASSERTION FAILURE: ");
 
 	va_list arg;
-  va_start(arg, format);
-  vsnprintf(theCrashBuffer + strlen(theCrashBuffer), LARGE_BUFFER, format, arg);
-  va_end(arg);
+	va_start(arg, format);
+	size_t offset =  strlen(theCrashBuffer);
+	vsnprintf(theCrashBuffer + offset, ARRAY_SIZE(theCrashBuffer) - offset, format, arg);
+	va_end(arg);
 
 	whackFunnyCharacters(theCrashBuffer);
 

--- a/Generals/Code/GameEngine/Source/Common/System/Debug.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/Debug.cpp
@@ -192,7 +192,7 @@ static const char *getCurrentTimeString(void)
 static const char *getCurrentTickString(void)
 {
 	static char TheTickString[32];
-	sprintf(TheTickString, "(T=%08lx)",::GetTickCount());
+	snprintf(TheTickString, ARRAY_SIZE(TheTickString), "(T=%08lx)", ::GetTickCount());
 	return TheTickString;
 }
 
@@ -385,14 +385,20 @@ void DebugInit(int flags)
 		strcat(theLogFileNamePrev, gAppPrefix);
 		strcat(theLogFileNamePrev, DEBUG_FILE_NAME_PREV);
 		if (rts::ClientInstance::getInstanceId() > 1u)
-			sprintf(theLogFileNamePrev + strlen(theLogFileNamePrev), "_Instance%.2u", rts::ClientInstance::getInstanceId());
+		{
+			size_t offset = strlen(theLogFileNamePrev);
+			snprintf(theLogFileNamePrev + offset, ARRAY_SIZE(theLogFileNamePrev) - offset, "_Instance%.2u", rts::ClientInstance::getInstanceId());
+		}
 		strcat(theLogFileNamePrev, ".txt");
 
 		strcpy(theLogFileName, dirbuf);
 		strcat(theLogFileName, gAppPrefix);
 		strcat(theLogFileName, DEBUG_FILE_NAME);
 		if (rts::ClientInstance::getInstanceId() > 1u)
-			sprintf(theLogFileName + strlen(theLogFileName), "_Instance%.2u", rts::ClientInstance::getInstanceId());
+		{
+			size_t offset = strlen(theLogFileNamePrev);
+			snprintf(theLogFileName + offset, ARRAY_SIZE(theLogFileName) - offset, "_Instance%.2u", rts::ClientInstance::getInstanceId());
+		}
 		strcat(theLogFileName, ".txt");
 
 		remove(theLogFileNamePrev);
@@ -428,7 +434,8 @@ void DebugLog(const char *format, ...)
 
 	va_list args;
 	va_start(args, format);
-	vsprintf(theBuffer + strlen(theBuffer), format, args);
+	size_t offset = strlen(theBuffer);
+	vsnprintf(theBuffer + offset, ARRAY_SIZE(theBuffer) - offset, format, args);
 	va_end(args);
 
 	if (strlen(theBuffer) >= sizeof(theBuffer))
@@ -454,7 +461,7 @@ void DebugLogRaw(const char *format, ...)
 
 	va_list args;
 	va_start(args, format);
-	vsprintf(theBuffer, format, args);
+	vsnprintf(theBuffer, ARRAY_SIZE(theBuffer), format, args);
 	va_end(args);
 
 	if (strlen(theBuffer) >= sizeof(theBuffer))

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/Debug.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/Debug.cpp
@@ -193,7 +193,7 @@ static const char *getCurrentTimeString(void)
 static const char *getCurrentTickString(void)
 {
 	static char TheTickString[32];
-	sprintf(TheTickString, "(T=%08lx)",::GetTickCount());
+	snprintf(TheTickString, ARRAY_SIZE(TheTickString), "(T=%08lx)", ::GetTickCount());
 	return TheTickString;
 }
 
@@ -386,14 +386,20 @@ void DebugInit(int flags)
 		strcat(theLogFileNamePrev, gAppPrefix);
 		strcat(theLogFileNamePrev, DEBUG_FILE_NAME_PREV);
 		if (rts::ClientInstance::getInstanceId() > 1u)
-			sprintf(theLogFileNamePrev + strlen(theLogFileNamePrev), "_Instance%.2u", rts::ClientInstance::getInstanceId());
+		{
+			size_t offset = strlen(theLogFileNamePrev);
+			snprintf(theLogFileNamePrev + offset, ARRAY_SIZE(theLogFileNamePrev) - offset, "_Instance%.2u", rts::ClientInstance::getInstanceId());
+		}
 		strcat(theLogFileNamePrev, ".txt");
 
 		strcpy(theLogFileName, dirbuf);
 		strcat(theLogFileName, gAppPrefix);
 		strcat(theLogFileName, DEBUG_FILE_NAME);
 		if (rts::ClientInstance::getInstanceId() > 1u)
-			sprintf(theLogFileName + strlen(theLogFileName), "_Instance%.2u", rts::ClientInstance::getInstanceId());
+		{
+			size_t offset = strlen(theLogFileNamePrev);
+			snprintf(theLogFileName + offset, ARRAY_SIZE(theLogFileName) - offset, "_Instance%.2u", rts::ClientInstance::getInstanceId());
+		}
 		strcat(theLogFileName, ".txt");
 
 		remove(theLogFileNamePrev);
@@ -429,7 +435,8 @@ void DebugLog(const char *format, ...)
 
 	va_list args;
 	va_start(args, format);
-	vsprintf(theBuffer + strlen(theBuffer), format, args);
+	size_t offset = strlen(theBuffer);
+	vsnprintf(theBuffer + offset, ARRAY_SIZE(theBuffer) - offset, format, args);
 	va_end(args);
 
 	if (strlen(theBuffer) >= sizeof(theBuffer))
@@ -455,7 +462,7 @@ void DebugLogRaw(const char *format, ...)
 
 	va_list args;
 	va_start(args, format);
-	vsprintf(theBuffer, format, args);
+	vsnprintf(theBuffer, ARRAY_SIZE(theBuffer), format, args);
 	va_end(args);
 
 	if (strlen(theBuffer) >= sizeof(theBuffer))

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/Debug.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/Debug.cpp
@@ -500,9 +500,10 @@ void DebugCrash(const char *format, ...)
 	strcat(theCrashBuffer, "ASSERTION FAILURE: ");
 
 	va_list arg;
-  va_start(arg, format);
-  vsnprintf(theCrashBuffer + strlen(theCrashBuffer), LARGE_BUFFER, format, arg);
-  va_end(arg);
+	va_start(arg, format);
+	size_t offset =  strlen(theCrashBuffer);
+	vsnprintf(theCrashBuffer + offset, ARRAY_SIZE(theCrashBuffer) - offset, format, arg);
+	va_end(arg);
 
 	whackFunnyCharacters(theCrashBuffer);
 


### PR DESCRIPTION
**Merge with Rebase**

* Fixes #1365
* Follow up for #1275

This change fixes the memory corruption in DebugCrash().

It has 2 commits. The first is the bug fix. The second is fixing a few more theoretical offenders in Debug.cpp.

The corruption was introduced by #1275 and only manifested as a runtime issue in VC6 Debug because of #858.
