### PR TITLE
tweak(recorder): Improve performance of Replay playback slightly by increasing the Replay file read buffer to 8192 bytes

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Recorder.cpp
@@ -48,6 +48,7 @@
 #include "Common/version.h"
 
 CONSTEXPR const char s_genrep[] = "GENREP";
+CONSTEXPR const UnsignedInt replayBufferBytes = 8192;
 
 Int REPLAY_CRC_INTERVAL = 100;
 
@@ -845,7 +846,9 @@ Bool RecorderClass::readReplayHeader(ReplayHeader& header)
 	AsciiString filepath = getReplayDir();
 	filepath.concat(header.filename.str());
 
-	m_file = TheFileSystem->openFile(filepath.str(), File::READ | File::BINARY );
+	// TheSuperHackers @performance More buffered data reduces disk overhead and will improve fast forward playback
+	const UnsignedInt buffersize = header.forPlayback ? replayBufferBytes : File::BUFFERSIZE;
+	m_file = TheFileSystem->openFile(filepath.str(), File::READ | File::BINARY, buffersize);
 
 	if (m_file == NULL)
 	{

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -48,6 +48,7 @@
 #include "Common/version.h"
 
 CONSTEXPR const char s_genrep[] = "GENREP";
+CONSTEXPR const UnsignedInt replayBufferBytes = 8192;
 
 Int REPLAY_CRC_INTERVAL = 100;
 
@@ -847,7 +848,9 @@ Bool RecorderClass::readReplayHeader(ReplayHeader& header)
 	AsciiString filepath = getReplayDir();
 	filepath.concat(header.filename.str());
 
-	m_file = TheFileSystem->openFile(filepath.str(), File::READ | File::BINARY );
+	// TheSuperHackers @performance More buffered data reduces disk overhead and will improve fast forward playback
+	const UnsignedInt buffersize = header.forPlayback ? replayBufferBytes : File::BUFFERSIZE;
+	m_file = TheFileSystem->openFile(filepath.str(), File::READ | File::BINARY, buffersize);
 
 	if (m_file == NULL)
 	{


### PR DESCRIPTION
- Merge After: #1233 

This PR changes how replay files are opened so they open with a larger than standard file buffer.

This is to help reduce disk access and aid replay playback speed in the long run.
As other bottlenecks are removed in the future, this PR should present a biffer performance boost.