### PR TITLE
fix(cpudetect): Fix version and memory detection

### DIFF
--- a/Core/Libraries/Source/WWVegas/WWLib/cpudetect.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/cpudetect.cpp
@@ -78,12 +78,21 @@ unsigned CPUDetectClass::L1InstructionCacheSetAssociative;
 unsigned CPUDetectClass::L1InstructionTraceCacheSize;
 unsigned CPUDetectClass::L1InstructionTraceCacheSetAssociative;
 
+#if defined(_MSC_VER) && _MSC_VER < 1300
 unsigned CPUDetectClass::TotalPhysicalMemory;
 unsigned CPUDetectClass::AvailablePhysicalMemory;
 unsigned CPUDetectClass::TotalPageMemory;
 unsigned CPUDetectClass::AvailablePageMemory;
 unsigned CPUDetectClass::TotalVirtualMemory;
 unsigned CPUDetectClass::AvailableVirtualMemory;
+#else
+unsigned long long CPUDetectClass::TotalPhysicalMemory;
+unsigned long long CPUDetectClass::AvailablePhysicalMemory;
+unsigned long long CPUDetectClass::TotalPageMemory;
+unsigned long long CPUDetectClass::AvailablePageMemory;
+unsigned long long CPUDetectClass::TotalVirtualMemory;
+unsigned long long CPUDetectClass::AvailableVirtualMemory;
+#endif
 
 unsigned CPUDetectClass::OSVersionNumberMajor;
 unsigned CPUDetectClass::OSVersionNumberMinor;
@@ -885,6 +894,7 @@ void CPUDetectClass::Init_Memory()
 {
 #ifdef WIN32
 
+#if defined(_MSC_VER) && _MSC_VER < 1300
 	MEMORYSTATUS mem;
    GlobalMemoryStatus(&mem);
 
@@ -894,14 +904,32 @@ void CPUDetectClass::Init_Memory()
    AvailablePageMemory     = mem.dwAvailPageFile;
    TotalVirtualMemory      = mem.dwTotalVirtual;
    AvailableVirtualMemory  = mem.dwAvailVirtual;
-#elif defined(_UNIX)
+#else
+	MEMORYSTATUSEX mem;
+	mem.dwLength = sizeof(mem);
+   GlobalMemoryStatusEx(&mem);
+
+   TotalPhysicalMemory     = mem.ullTotalPhys;
+   AvailablePhysicalMemory = mem.ullAvailPhys;
+   TotalPageMemory         = mem.ullTotalPageFile;
+   AvailablePageMemory     = mem.ullAvailPageFile;
+   TotalVirtualMemory      = mem.ullTotalVirtual;
+   AvailableVirtualMemory  = mem.ullAvailVirtual;
+#endif // defined(_MSC_VER) && _MSC_VER < 1300
+
+#else
 #warning FIX Init_Memory()
-#endif
+#endif // WIN32
 }
 
 void CPUDetectClass::Init_OS()
 {
 #ifdef WIN32
+
+// TheSuperHackers @fix OmniBlade 30/07/2025
+// GetVersionEx only returns the version of Windows it was manifested for since Windows 8.
+// RtlGetVersion returns the correct information at least at the time of writing.	
+#if defined(_MSC_VER) && _MSC_VER < 1300
 	OSVERSIONINFO os;
    os.dwOSVersionInfoSize = sizeof(os);
 	GetVersionEx(&os);
@@ -911,7 +939,33 @@ void CPUDetectClass::Init_OS()
    OSVersionBuildNumber = os.dwBuildNumber;
    OSVersionPlatformId  = os.dwPlatformId;
    OSVersionExtraInfo   = os.szCSDVersion;
-#elif defined(_UNIX)
+#else
+	typedef LONG(WINAPI * RtlGetVersionPtr)(PRTL_OSVERSIONINFOW);
+    HMODULE ntdll = LoadLibraryExA("ntdll", NULL, 0);
+    if (ntdll != nullptr) {
+        RtlGetVersionPtr RtlGetVersion = (RtlGetVersionPtr)::GetProcAddress(ntdll, "RtlGetVersion");
+
+        if (RtlGetVersion != nullptr) {
+            RTL_OSVERSIONINFOW os = {0};
+            os.dwOSVersionInfoSize = sizeof(os);
+            RtlGetVersion(&os);
+            OSVersionNumberMajor = os.dwMajorVersion;
+            OSVersionNumberMinor = os.dwMinorVersion;
+            OSVersionBuildNumber = os.dwBuildNumber;
+            OSVersionPlatformId = os.dwPlatformId;
+            OSVersionExtraInfo = os.szCSDVersion;
+            return;
+        }
+    }
+
+	// GetVersionEx will return this info if no manifest is present so seems a safe fallback.
+    OSVersionNumberMajor = 6;
+    OSVersionNumberMinor = 2;
+    OSVersionBuildNumber = 0;
+    OSVersionPlatformId = 2;
+    OSVersionExtraInfo = "";
+#endif // defined(_MSC_VER) && _MSC_VER < 1300
+#else
 #warning FIX Init_OS()
 #endif
 }

--- a/Core/Libraries/Source/WWVegas/WWLib/cpudetect.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/cpudetect.h
@@ -194,12 +194,22 @@ public:
 	static unsigned Get_L1_Instruction_Trace_Cache_Set_Associative() { return L1InstructionTraceCacheSetAssociative; }
 
 	// System memory
+	
+#if defined(_MSC_VER) && _MSC_VER < 1300
 	static unsigned Get_Total_Physical_Memory() { return TotalPhysicalMemory; }
 	static unsigned Get_Available_Physical_Memory() { return AvailablePhysicalMemory; }
 	static unsigned Get_Total_Page_File_Size() { return TotalPageMemory; }
 	static unsigned Get_Available_Page_File_Size() { return AvailablePageMemory; }
 	static unsigned Get_Total_Virtual_Memory() { return TotalVirtualMemory; }
 	static unsigned Get_Available_Virtual_Memory() { return AvailableVirtualMemory; }
+#else
+	static unsigned long long Get_Total_Physical_Memory() { return TotalPhysicalMemory; }
+	static unsigned long long Get_Available_Physical_Memory() { return AvailablePhysicalMemory; }
+	static unsigned long long Get_Total_Page_File_Size() { return TotalPageMemory; }
+	static unsigned long long Get_Available_Page_File_Size() { return AvailablePageMemory; }
+	static unsigned long long Get_Total_Virtual_Memory() { return TotalVirtualMemory; }
+	static unsigned long long Get_Available_Virtual_Memory() { return AvailableVirtualMemory; }
+#endif
 
 	static unsigned Get_Processor_Type() { return ProcessorType; }
 
@@ -278,14 +288,21 @@ private:
 	// L1 instruction trace cache information
 	static unsigned L1InstructionTraceCacheSize;
 	static unsigned L1InstructionTraceCacheSetAssociative;
-
+#if defined(_MSC_VER) && _MSC_VER < 1300
 	static unsigned TotalPhysicalMemory;
 	static unsigned AvailablePhysicalMemory;
 	static unsigned TotalPageMemory;
 	static unsigned AvailablePageMemory;
 	static unsigned TotalVirtualMemory;
 	static unsigned AvailableVirtualMemory;
-
+#else
+	static unsigned long long TotalPhysicalMemory;
+	static unsigned long long AvailablePhysicalMemory;
+	static unsigned long long TotalPageMemory;
+	static unsigned long long AvailablePageMemory;
+	static unsigned long long TotalVirtualMemory;
+	static unsigned long long AvailableVirtualMemory;
+#endif
 	static unsigned OSVersionNumberMajor;
 	static unsigned OSVersionNumberMinor;
 	static unsigned OSVersionBuildNumber;


### PR DESCRIPTION
Memory detection would be incorrect on systems with > 4GB. Verson info detection is incorrect on Windows 8 and later and if manifested for an earlier version than currently running on.