### PR TITLE
bugfix(asciistring): Fix thread unsafe reference counting of AsciiString

### DIFF
--- a/GeneralsMD/Code/Main/WinMain.cpp
+++ b/GeneralsMD/Code/Main/WinMain.cpp
@@ -774,6 +774,7 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 		// default in a DevStudio project
 		//
 
+		TheAsciiStringCriticalSection = &critSec1;
 		TheUnicodeStringCriticalSection = &critSec2;
 		TheDmaCriticalSection = &critSec3;
 		TheMemoryPoolCriticalSection = &critSec4;


### PR DESCRIPTION
* Fixes #1394
* Follow up for #799

This change fixes the thread unsafe reference counting of AsciiString.

It was previously introduced by merging Generals code into Zero Hour code.