### PR TITLE
ci(build): Ensure runner uses windows-2022 image for build jobs

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -29,7 +29,7 @@ on:
 jobs:
   build:
     name: Preset ${{ inputs.preset }}${{ inputs.tools && '+t' || '' }}${{ inputs.extras && '+e' || '' }}
-    runs-on: windows-latest
+    runs-on: windows-2022
     timeout-minutes: 40
     steps:
       - name: Checkout Code
@@ -66,7 +66,7 @@ jobs:
           $fileHash = (Get-FileHash -Path VS6_VisualStudio6.7z -Algorithm SHA256).Hash
           Write-Host "Downloaded file SHA256: $fileHash"
           Write-Host "Expected file SHA256: $env:EXPECTED_HASH"
-          if ($hash -ne $env:EXPECTED_HASH) {
+          if ($fileHash -ne $env:EXPECTED_HASH) {
               Write-Error "Hash verification failed! File may be corrupted or tampered with."
               exit 1
           }


### PR DESCRIPTION
GitHub has announced that `windows-latest` label in GitHub Actions will migrate from Windows Server 2022 to Windows Server 2025 beginning September 2, 2025: [GitHub Announcement](https://github.blog/changelog/2025-07-31-github-actions-new-apis-and-windows-latest-migration-notice/#windows-latest-image-label-migration)

To maintain the stability of the builds we should remain on `windows-2022` until we ourselves are at a stable state.