### PR TITLE
feat(controlbar): Implement full viewport support for 'Control Bar Pro' Addons

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/GlobalData.h
+++ b/Generals/Code/GameEngine/Include/Common/GlobalData.h
@@ -91,6 +91,7 @@ public:
 	Bool setTimeOfDay( TimeOfDay tod );		///< Use this function to set the Time of day;
 
 	static void parseGameDataDefinition( INI* ini );
+	void parseCustomDefinition();
 
 	//-----------------------------------------------------------------------------------------------
 	struct TerrainLighting
@@ -178,6 +179,7 @@ public:
 	Real m_skyBoxPositionZ;
 	Real m_drawSkyBox;
 	Real m_skyBoxScale;
+	Real m_viewportHeightScale; // The height scale of the tactical view ranging 0..1. Used to hide the world behind the Control Bar.
 	Real m_cameraPitch;
 	Real m_cameraYaw;
 	Real m_cameraHeight;

--- a/Generals/Code/GameEngine/Include/GameClient/ControlBar.h
+++ b/Generals/Code/GameEngine/Include/GameClient/ControlBar.h
@@ -690,7 +690,9 @@ public:
 	void showSpecialPowerShortcut( void );
 	void hideSpecialPowerShortcut( void );
 	void animateSpecialPowerShortcut( Bool isOn );
-	
+
+	void setFullViewportHeight();
+	void setScaledViewportHeight();
 
 	/// set the control bar to the proper scheme based off a player template that's passed in
 	ControlBarSchemeManager *getControlBarSchemeManager( void ) { return m_controlBarSchemeManager; }

--- a/Generals/Code/GameEngine/Source/Common/CommandLine.cpp
+++ b/Generals/Code/GameEngine/Source/Common/CommandLine.cpp
@@ -161,6 +161,15 @@ Int parseUseWaveEditor(char *args[], int num)
 	return 1;
 }
 
+//=============================================================================
+//=============================================================================
+Int parseFullViewport(char *args[], int num)
+{
+	TheWritableGlobalData->m_viewportHeightScale = 1.0f;
+
+	return 1;
+}
+
 #if defined(RTS_DEBUG)
 
 //=============================================================================
@@ -1170,6 +1179,9 @@ static CommandLineParam paramsForEngineInit[] =
 	{ "-noshaders", parseNoShaders },
 	{ "-quickstart", parseQuickStart },
 	{ "-useWaveEditor", parseUseWaveEditor },
+
+	// TheSuperHackers @feature xezon 03/08/2025 Force full viewport for 'Control Bar Pro' Addons like GenTool did it.
+	{ "-forcefullviewport", parseFullViewport },
 
 #if defined(RTS_DEBUG)
 	{ "-noaudio", parseNoAudio },

--- a/Generals/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -364,7 +364,8 @@ void GameEngine::init()
 		
 		DEBUG_ASSERTCRASH(TheWritableGlobalData,("TheWritableGlobalData expected to be created"));
 		initSubsystem(TheWritableGlobalData, "TheWritableGlobalData", TheWritableGlobalData, &xferCRC, "Data\\INI\\Default\\GameData.ini", "Data\\INI\\GameData.ini");
-		
+		TheWritableGlobalData->parseCustomDefinition();
+
 		// TheSuperHackers @bugfix helmutbuhler 14/04/2025
 		// Pump messages during startup to ensure that the application window is correctly
 		// positioned on slower computers and in debug builds by a later call to SetWindowPos.

--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -176,6 +176,7 @@ GlobalData* GlobalData::m_theOriginal = NULL;
 	{ "SkyBoxPositionZ",				INI::parseReal,				NULL,			offsetof( GlobalData, m_skyBoxPositionZ ) },
 	{ "SkyBoxScale",				INI::parseReal,				NULL,			offsetof( GlobalData, m_skyBoxScale ) },
 	{ "DrawSkyBox",				INI::parseBool,				NULL,			offsetof( GlobalData, m_drawSkyBox ) },
+	{ "ViewportHeightScale", INI::parseReal, NULL, offsetof( GlobalData, m_viewportHeightScale ) },
 	{ "CameraPitch",								INI::parseReal,				NULL,			offsetof( GlobalData, m_cameraPitch ) },
 	{ "CameraYaw",									INI::parseReal,				NULL,			offsetof( GlobalData, m_cameraYaw ) },
 	{ "CameraHeight",								INI::parseReal,				NULL,			offsetof( GlobalData, m_cameraHeight ) },
@@ -824,6 +825,8 @@ GlobalData::GlobalData()
 
 	m_particleEdit = FALSE;
 
+	m_viewportHeightScale = 0.80f; // Default value for the original Control Bar.
+
 	m_cameraPitch = 0.0f;
 	m_cameraYaw = 0.0f;
 	m_cameraHeight = 0.0f;
@@ -1193,6 +1196,22 @@ void GlobalData::parseGameDataDefinition( INI* ini )
 	TheWritableGlobalData->m_yResolution = yres;
 }
 
+void GlobalData::parseCustomDefinition()
+{
+	{
+		// TheSuperHackers @feature xezon 03/08/2025 Force full viewport for 'Control Bar Pro' Addons like GenTool did it.
+		File* file = TheFileSystem->openFile("GenTool/fullviewport.dat", File::READ | File::BINARY);
+		if (file != NULL)
+		{
+			Char value = '0';
+			file->read(&value, 1);
+			if (value != '0')
+			{
+				m_viewportHeightScale = 1.0f;
+			}
+		}
+	}
+}
 
 UnsignedInt GlobalData::generateExeCRC()
 {

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -3008,7 +3008,7 @@ void ControlBar::setDefaultControlBarConfig( void )
 //		m_controlBarSchemeManager->setControlBarSchemeByPlayerTemplate(ThePlayerList->getLocalPlayer()->getPlayerTemplate(), FALSE);
 //	}
 	m_currentControlBarStage = CONTROL_BAR_STAGE_DEFAULT;
-	TheTacticalView->setHeight((Int)(TheDisplay->getHeight() * 0.80f)); 
+	setScaledViewportHeight();
 	m_contextParent[ CP_MASTER ]->winSetPosition(m_defaultControlBarPosition.x, m_defaultControlBarPosition.y);
 	m_contextParent[ CP_MASTER ]->winHide(FALSE);
 	repopulateBuildTooltipLayout();
@@ -3025,7 +3025,7 @@ void ControlBar::setSquishedControlBarConfig( void )
 	
 //	m_controlBarResizer->sizeWindowsAlt();
 	repopulateBuildTooltipLayout();	
-	TheTacticalView->setHeight((Int)(TheDisplay->getHeight())); 
+	setFullViewportHeight();
 	m_controlBarSchemeManager->setControlBarSchemeByPlayerTemplate(ThePlayerList->getLocalPlayer()->getPlayerTemplate(), TRUE);
 }
 
@@ -3041,7 +3041,7 @@ void ControlBar::setLowControlBarConfig( void )
 	ICoord2D pos;
 	pos.x = m_defaultControlBarPosition.x;
 	pos.y = TheDisplay->getHeight() - .1 * TheDisplay->getHeight();
-	TheTacticalView->setHeight((Int)(TheDisplay->getHeight())); 
+	setFullViewportHeight();
 	m_contextParent[ CP_MASTER ]->winSetPosition(pos.x, pos.y);
 	m_contextParent[ CP_MASTER ]->winHide(FALSE);
 	setUpDownImages();
@@ -3505,4 +3505,14 @@ void ControlBar::hideSpecialPowerShortcut( void )
 	
 	m_specialPowerShortcutParent->winHide(TRUE);
 		
+}
+
+void ControlBar::setFullViewportHeight()
+{
+	TheTacticalView->setHeight(TheDisplay->getHeight());
+}
+
+void ControlBar::setScaledViewportHeight()
+{
+	TheTacticalView->setHeight(TheDisplay->getHeight() * TheGlobalData->m_viewportHeightScale);
 }

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/ControlBarCallback.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/ControlBarCallback.cpp
@@ -501,7 +501,7 @@ extern void toggleReplayControls( void );
 //-------------------------------------------------------------------------------------------------
 void ShowControlBar( Bool immediate )
 {
-	if (!TheWindowManager || !TheControlBar || !TheTacticalView)
+	if (!TheWindowManager || !TheControlBar)
 		return;
 
 	showReplayControls();
@@ -514,7 +514,7 @@ void ShowControlBar( Bool immediate )
 	if (window)
 	{
 		TheControlBar->switchControlBarStage(CONTROL_BAR_STAGE_DEFAULT);
-		TheTacticalView->setHeight((Int)(TheDisplay->getHeight() * 0.80f));
+		TheControlBar->setScaledViewportHeight();
 
 		if (TheControlBar->m_animateWindowManager && !immediate)
 		{
@@ -536,7 +536,7 @@ void ShowControlBar( Bool immediate )
 //-------------------------------------------------------------------------------------------------
 void HideControlBar( Bool immediate )
 {
-	if (!TheWindowManager || !TheControlBar || !TheTacticalView)
+	if (!TheWindowManager || !TheControlBar)
 		return;
 
 	hideReplayControls();
@@ -549,9 +549,9 @@ void HideControlBar( Bool immediate )
 	if (window)
 	{
 #ifdef SLIDE_LETTERBOX
-		TheTacticalView->setHeight((Int)(TheDisplay->getHeight() * 0.80f)); 
+		TheControlBar->setScaledViewportHeight();
 #else
-		TheTacticalView->setHeight(TheDisplay->getHeight());
+		TheControlBar->setFullViewportHeight();
 #endif
 		if (immediate)
 		{
@@ -574,7 +574,7 @@ void HideControlBar( Bool immediate )
 //-------------------------------------------------------------------------------------------------
 void ToggleControlBar( Bool immediate )
 {
-	if (!TheWindowManager || !TheControlBar || !TheTacticalView)
+	if (!TheWindowManager || !TheControlBar)
 		return;
 
 	toggleReplayControls();
@@ -589,7 +589,7 @@ void ToggleControlBar( Bool immediate )
 			TheControlBar->showSpecialPowerShortcut();
 
 			//now hidden, we're making it visible again so shrink viewport under the window
-			TheTacticalView->setHeight((Int)(TheDisplay->getHeight() * 0.80f));
+			TheControlBar->setScaledViewportHeight();
 			window->winHide(FALSE);
 			TheControlBar->switchControlBarStage(CONTROL_BAR_STAGE_DEFAULT);
 
@@ -604,7 +604,7 @@ void ToggleControlBar( Bool immediate )
 		else
 		{
 			TheControlBar->hideSpecialPowerShortcut();
-			TheTacticalView->setHeight(TheDisplay->getHeight());
+			TheControlBar->setFullViewportHeight();
 			window->winHide(TRUE);
 		}
 	}

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -1166,10 +1166,9 @@ void InGameUI::init( void )
 		TheTacticalView->init();
 		TheDisplay->attachView( TheTacticalView );
 
-		// make the tactical display the full screen width for now
-		TheTacticalView->setWidth( TheDisplay->getWidth());
-		// make the tactical display 0.76 of full screen so no drawing under GUI.
-		TheTacticalView->setHeight( TheDisplay->getHeight() * 0.77f);
+		// make the tactical display the full screen width and height
+		TheTacticalView->setWidth( TheDisplay->getWidth() );
+		TheTacticalView->setHeight( TheDisplay->getHeight() );
 	}
 	TheTacticalView->setDefaultView(0.0f, 0.0f, 1.0f);
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
@@ -93,6 +93,7 @@ public:
 	Bool setTimeOfDay( TimeOfDay tod );		///< Use this function to set the Time of day;
 
 	static void parseGameDataDefinition( INI* ini );
+	void parseCustomDefinition();
 
 	//-----------------------------------------------------------------------------------------------
 	struct TerrainLighting
@@ -184,6 +185,7 @@ public:
 	Real m_skyBoxPositionZ;
 	Real m_drawSkyBox;
 	Real m_skyBoxScale;
+	Real m_viewportHeightScale; // The height scale of the tactical view ranging 0..1. Used to hide the world behind the Control Bar.
 	Real m_cameraPitch;
 	Real m_cameraYaw;
 	Real m_cameraHeight;

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/ControlBar.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/ControlBar.h
@@ -704,7 +704,9 @@ public:
 	void showSpecialPowerShortcut( void );
 	void hideSpecialPowerShortcut( void );
 	void animateSpecialPowerShortcut( Bool isOn );
-	
+
+	void setFullViewportHeight();
+	void setScaledViewportHeight();
 
 	/// set the control bar to the proper scheme based off a player template that's passed in
 	ControlBarSchemeManager *getControlBarSchemeManager( void ) { return m_controlBarSchemeManager; }

--- a/GeneralsMD/Code/GameEngine/Source/Common/CommandLine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/CommandLine.cpp
@@ -161,6 +161,15 @@ Int parseUseWaveEditor(char *args[], int num)
 	return 1;
 }
 
+//=============================================================================
+//=============================================================================
+Int parseFullViewport(char *args[], int num)
+{
+	TheWritableGlobalData->m_viewportHeightScale = 1.0f;
+
+	return 1;
+}
+
 #if defined(RTS_DEBUG)
 
 //=============================================================================
@@ -1170,6 +1179,9 @@ static CommandLineParam paramsForEngineInit[] =
 	{ "-noshaders", parseNoShaders },
 	{ "-quickstart", parseQuickStart },
 	{ "-useWaveEditor", parseUseWaveEditor },
+
+	// TheSuperHackers @feature xezon 03/08/2025 Force full viewport for 'Control Bar Pro' Addons like GenTool did it.
+	{ "-forcefullviewport", parseFullViewport },
 
 #if defined(RTS_DEBUG)
 	{ "-noaudio", parseNoAudio },

--- a/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -428,6 +428,7 @@ void GameEngine::init()
 
 		DEBUG_ASSERTCRASH(TheWritableGlobalData,("TheWritableGlobalData expected to be created"));
 		initSubsystem(TheWritableGlobalData, "TheWritableGlobalData", TheWritableGlobalData, &xferCRC, "Data\\INI\\Default\\GameData.ini", "Data\\INI\\GameData.ini");
+		TheWritableGlobalData->parseCustomDefinition();
 
 
 	#ifdef DUMP_PERF_STATS///////////////////////////////////////////////////////////////////////////

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -176,6 +176,7 @@ GlobalData* GlobalData::m_theOriginal = NULL;
 	{ "SkyBoxPositionZ",				INI::parseReal,				NULL,			offsetof( GlobalData, m_skyBoxPositionZ ) },
 	{ "SkyBoxScale",				INI::parseReal,				NULL,			offsetof( GlobalData, m_skyBoxScale ) },
 	{ "DrawSkyBox",				INI::parseBool,				NULL,			offsetof( GlobalData, m_drawSkyBox ) },
+	{ "ViewportHeightScale", INI::parseReal, NULL, offsetof( GlobalData, m_viewportHeightScale ) },
 	{ "CameraPitch",								INI::parseReal,				NULL,			offsetof( GlobalData, m_cameraPitch ) },
 	{ "CameraYaw",									INI::parseReal,				NULL,			offsetof( GlobalData, m_cameraYaw ) },
 	{ "CameraHeight",								INI::parseReal,				NULL,			offsetof( GlobalData, m_cameraHeight ) },
@@ -830,6 +831,8 @@ GlobalData::GlobalData()
 
 	m_particleEdit = FALSE;
 
+	m_viewportHeightScale = 0.80f; // Default value for the original Control Bar.
+
 	m_cameraPitch = 0.0f;
 	m_cameraYaw = 0.0f;
 	m_cameraHeight = 0.0f;
@@ -1221,6 +1224,22 @@ void GlobalData::parseGameDataDefinition( INI* ini )
 	TheWritableGlobalData->m_yResolution = yres;
 }
 
+void GlobalData::parseCustomDefinition()
+{
+	{
+		// TheSuperHackers @feature xezon 03/08/2025 Force full viewport for 'Control Bar Pro' Addons like GenTool did it.
+		File* file = TheFileSystem->openFile("GenTool/fullviewport.dat", File::READ | File::BINARY);
+		if (file != NULL)
+		{
+			Char value = '0';
+			file->read(&value, 1);
+			if (value != '0')
+			{
+				m_viewportHeightScale = 1.0f;
+			}
+		}
+	}
+}
 
 UnsignedInt GlobalData::generateExeCRC()
 {

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -3031,7 +3031,7 @@ void ControlBar::setDefaultControlBarConfig( void )
 //		m_controlBarSchemeManager->setControlBarSchemeByPlayerTemplate(ThePlayerList->getLocalPlayer()->getPlayerTemplate(), FALSE);
 //	}
 	m_currentControlBarStage = CONTROL_BAR_STAGE_DEFAULT;
-	TheTacticalView->setHeight((Int)(TheDisplay->getHeight() * 0.80f)); 
+	setScaledViewportHeight();
 	m_contextParent[ CP_MASTER ]->winSetPosition(m_defaultControlBarPosition.x, m_defaultControlBarPosition.y);
 	m_contextParent[ CP_MASTER ]->winHide(FALSE);
 	repopulateBuildTooltipLayout();
@@ -3048,7 +3048,7 @@ void ControlBar::setSquishedControlBarConfig( void )
 	
 //	m_controlBarResizer->sizeWindowsAlt();
 	repopulateBuildTooltipLayout();	
-	TheTacticalView->setHeight((Int)(TheDisplay->getHeight())); 
+	setFullViewportHeight();
 	m_controlBarSchemeManager->setControlBarSchemeByPlayerTemplate(ThePlayerList->getLocalPlayer()->getPlayerTemplate(), TRUE);
 }
 
@@ -3064,7 +3064,7 @@ void ControlBar::setLowControlBarConfig( void )
 	ICoord2D pos;
 	pos.x = m_defaultControlBarPosition.x;
 	pos.y = TheDisplay->getHeight() - .1 * TheDisplay->getHeight();
-	TheTacticalView->setHeight((Int)(TheDisplay->getHeight())); 
+	setFullViewportHeight();
 	m_contextParent[ CP_MASTER ]->winSetPosition(pos.x, pos.y);
 	m_contextParent[ CP_MASTER ]->winHide(FALSE);
 	setUpDownImages();
@@ -3769,4 +3769,14 @@ void ControlBar::hideSpecialPowerShortcut( void )
 	
 	m_specialPowerShortcutParent->winHide(TRUE);
 		
+}
+
+void ControlBar::setFullViewportHeight()
+{
+	TheTacticalView->setHeight(TheDisplay->getHeight());
+}
+
+void ControlBar::setScaledViewportHeight()
+{
+	TheTacticalView->setHeight(TheDisplay->getHeight() * TheGlobalData->m_viewportHeightScale);
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/ControlBarCallback.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/ControlBarCallback.cpp
@@ -500,7 +500,7 @@ extern void toggleReplayControls( void );
 //-------------------------------------------------------------------------------------------------
 void ShowControlBar( Bool immediate )
 {
-	if (!TheWindowManager || !TheControlBar || !TheTacticalView)
+	if (!TheWindowManager || !TheControlBar)
 		return;
 
 	showReplayControls();
@@ -513,7 +513,7 @@ void ShowControlBar( Bool immediate )
 	if (window)
 	{
 		TheControlBar->switchControlBarStage(CONTROL_BAR_STAGE_DEFAULT);
-		TheTacticalView->setHeight((Int)(TheDisplay->getHeight() * 0.80f));
+		TheControlBar->setScaledViewportHeight();
 
 		if (TheControlBar->m_animateWindowManager && !immediate)
 		{
@@ -535,7 +535,7 @@ void ShowControlBar( Bool immediate )
 //-------------------------------------------------------------------------------------------------
 void HideControlBar( Bool immediate )
 {
-	if (!TheWindowManager || !TheControlBar || !TheTacticalView)
+	if (!TheWindowManager || !TheControlBar)
 		return;
 
 	hideReplayControls();
@@ -548,9 +548,9 @@ void HideControlBar( Bool immediate )
 	if (window)
 	{
 #ifdef SLIDE_LETTERBOX
-		TheTacticalView->setHeight((Int)(TheDisplay->getHeight() * 0.80f)); 
+		TheControlBar->setScaledViewportHeight();
 #else
-		TheTacticalView->setHeight(TheDisplay->getHeight());
+		TheControlBar->setFullViewportHeight();
 #endif
 		if (immediate)
 		{
@@ -573,7 +573,7 @@ void HideControlBar( Bool immediate )
 //-------------------------------------------------------------------------------------------------
 void ToggleControlBar( Bool immediate )
 {
-	if (!TheWindowManager || !TheControlBar || !TheTacticalView)
+	if (!TheWindowManager || !TheControlBar)
 		return;
 
 	toggleReplayControls();
@@ -588,7 +588,7 @@ void ToggleControlBar( Bool immediate )
 			TheControlBar->showSpecialPowerShortcut();
 
 			//now hidden, we're making it visible again so shrink viewport under the window
-			TheTacticalView->setHeight((Int)(TheDisplay->getHeight() * 0.80f));
+			TheControlBar->setScaledViewportHeight();
 			window->winHide(FALSE);
 			TheControlBar->switchControlBarStage(CONTROL_BAR_STAGE_DEFAULT);
 
@@ -603,7 +603,7 @@ void ToggleControlBar( Bool immediate )
 		else
 		{
 			TheControlBar->hideSpecialPowerShortcut();
-			TheTacticalView->setHeight(TheDisplay->getHeight());
+			TheControlBar->setFullViewportHeight();
 			window->winHide(TRUE);
 		}
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -1196,10 +1196,9 @@ void InGameUI::init( void )
 		TheTacticalView->init();
 		TheDisplay->attachView( TheTacticalView );
 
-		// make the tactical display the full screen width for now
-		TheTacticalView->setWidth( TheDisplay->getWidth());
-		// make the tactical display 0.76 of full screen so no drawing under GUI.
-		TheTacticalView->setHeight( TheDisplay->getHeight() * 0.77f);
+		// make the tactical display the full screen width and height
+		TheTacticalView->setWidth( TheDisplay->getWidth() );
+		TheTacticalView->setHeight( TheDisplay->getHeight() );
 	}
 	TheTacticalView->setDefaultView(0.0f, 0.0f, 1.0f);
 


### PR DESCRIPTION
* Relates to #850
* Resolves #1284

This change implements the fullviewport support for 'Control Bar Pro' Addons like GenTool did.

New command line argument is "-forcefullviewport"

And file at "GenTool/fullviewport.dat" is read too.

## TODO

- [x] Replicate in Generals