### PR TITLE
chore: Add .editorconfig to set default whitespacing rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root=true
+
+[*]
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[{*.h,*.cpp,*.inl}]
+indent_style = unset
+indent_size = 2
+
+[{CMakeLists.txt,*.cmake,*.py}]
+indent_style = spaces
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-# Ignore everything starting with dot, except git files.
+# Ignore everything starting with dot, except specific files.
 .*
+!.editorconfig
 !.gitignore
 !.gitattributes
 !.github


### PR DESCRIPTION
* Merge after #1425

This change adds a .editorconfig file to set default whitespacing rules.