### PR TITLE
feat(savegames): Use frame rate from skirmish settings as max frame rate after loading a save game

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
@@ -677,7 +677,7 @@ SaveCode GameState::loadGame( AvailableGameInfo gameInfo )
 	TheGameEngine->reset();
 
 	// TheSuperHackers @tweak Caball009 03/08/2025 Use the fps preference from the skirmish settings as fps limit after game engine reset.
-	if (!gameInfo.saveGameInfo.saveFileType == SAVE_FILE_TYPE_MISSION)
+	if (gameInfo.saveGameInfo.saveFileType != SAVE_FILE_TYPE_MISSION)
 		TheGameEngine->setFramesPerSecondLimit(SkirmishPreferences().getInt("FPS", TheGlobalData->m_framesPerSecondLimit));
 
 	// lock creation of new ghost objects


### PR DESCRIPTION
* Fixes: https://github.com/TheSuperHackers/GeneralsGameCode/issues/1285
* Closes: https://github.com/TheSuperHackers/GeneralsGameCode/issues/446

Loaded skirmish (and mission) save games play at the default frame rate. This ignores whatever frame rate they were started with, and it ignores the current frame rate (the value of Game Speed) in the skirmish menu. This PR uses the latter value as max frame rate when loading save games.

### TODO:
- [ ] Replicate in Generals.