### PR TITLE
bugfix(script): Fix crash if nearest command button target is not found

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -5536,9 +5536,7 @@ void Object::doCommandButtonAtObject( const CommandButton *commandButton, Object
 			case GUI_COMMAND_COMBATDROP:
 #if RETAIL_COMPATIBLE_CRC
 				if (!obj)
-				{
 					return;
-				}
 #endif
 
 				if( ai )
@@ -5550,9 +5548,7 @@ void Object::doCommandButtonAtObject( const CommandButton *commandButton, Object
 			{
 #if RETAIL_COMPATIBLE_CRC
 				if (!obj)
-				{
 					return;
-				}
 #endif
 				
 				if( commandButton->getSpecialPowerTemplate() )

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -5534,6 +5534,13 @@ void Object::doCommandButtonAtObject( const CommandButton *commandButton, Object
 		switch( commandButton->getCommandType() )
 		{
 			case GUI_COMMAND_COMBATDROP:
+#if RETAIL_COMPATIBLE_CRC
+				if (!obj)
+				{
+					return;
+				}
+#endif
+
 				if( ai )
 				{
 					ai->aiCombatDrop( obj, *(obj->getPosition()), cmdSource );
@@ -5541,6 +5548,13 @@ void Object::doCommandButtonAtObject( const CommandButton *commandButton, Object
 				return;
 			case GUI_COMMAND_SPECIAL_POWER:
 			{
+#if RETAIL_COMPATIBLE_CRC
+				if (!obj)
+				{
+					return;
+				}
+#endif
+				
 				if( commandButton->getSpecialPowerTemplate() )
 				{
 					CommandOption commandOptions = (CommandOption)(commandButton->getOptions() | COMMAND_FIRED_BY_SCRIPT);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
@@ -5890,9 +5890,7 @@ void ScriptActions::doTeamUseCommandButtonOnNearestObjectType( const AsciiString
 		bestObj = ThePartitionManager->getClosestObject(&pos, REALLY_FAR, FROM_CENTER_2D, filters);
 #if RETAIL_COMPATIBLE_CRC
 		if (!bestObj)
-		{
 			return;
-		}
 #endif
 	}
 	else
@@ -5934,9 +5932,7 @@ void ScriptActions::doTeamUseCommandButtonOnNearestObjectType( const AsciiString
 
 #if !RETAIL_COMPATIBLE_CRC
 	if (!bestObj)
-	{
 		return;
-	}
 #endif
 
 	// already been checked for validity

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
@@ -5888,6 +5888,12 @@ void ScriptActions::doTeamUseCommandButtonOnNearestObjectType( const AsciiString
 		theGroup->getCenter(&pos);
 
 		bestObj = ThePartitionManager->getClosestObject(&pos, REALLY_FAR, FROM_CENTER_2D, filters);
+#if RETAIL_COMPATIBLE_CRC
+		if (!bestObj)
+		{
+			return;
+		}
+#endif
 	}
 	else
 	{
@@ -5926,10 +5932,12 @@ void ScriptActions::doTeamUseCommandButtonOnNearestObjectType( const AsciiString
 		}
 	}
 
+#if !RETAIL_COMPATIBLE_CRC
 	if (!bestObj)
 	{
 		return;
 	}
+#endif
 
 	// already been checked for validity
 	theGroup->groupDoCommandButtonAtObject(commandButton, bestObj, CMD_FROM_SCRIPT);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
@@ -5888,10 +5888,6 @@ void ScriptActions::doTeamUseCommandButtonOnNearestObjectType( const AsciiString
 		theGroup->getCenter(&pos);
 
 		bestObj = ThePartitionManager->getClosestObject(&pos, REALLY_FAR, FROM_CENTER_2D, filters);
-		if( !bestObj )
-		{
-			return;
-		}
 	}
 	else
 	{
@@ -5928,11 +5924,11 @@ void ScriptActions::doTeamUseCommandButtonOnNearestObjectType( const AsciiString
 				}
 			}
 		}
+	}
 
-		if (!bestObj)
-		{
-			return;
-		}
+	if (!bestObj)
+	{
+		return;
 	}
 
 	// already been checked for validity

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
@@ -5928,6 +5928,11 @@ void ScriptActions::doTeamUseCommandButtonOnNearestObjectType( const AsciiString
 				}
 			}
 		}
+
+		if (!bestObj)
+		{
+			return;
+		}
 	}
 
 	// already been checked for validity


### PR DESCRIPTION
* Fixes #1419

This change fixes a missing null check on the best object in the else block of `ScriptActions::doTeamUseCommandButtonOnNearestObjectType`, which leads to a crash.