### PR TITLE
fix(partition): Fix circle fill algorithm in PartitionManager

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
@@ -1860,7 +1860,9 @@ void PartitionData::doCircleFill(
 
 #if RETAIL_COMPATIBLE_CRC
 	// Cell coverage diverges at radii >= 240 between algorithms.
-	for (Int x = 0; (cellRadius < 240) ? (x <= y) : (x < cellRadius); ++x)
+	Int end = cellRadius - 1;
+	Int& endRef = (cellRadius < 240) ? y : end;
+	for (Int x = 0; x <= endRef; ++x)
 #else
 	for (Int x = 0; x <= y; ++x)
 #endif

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
@@ -1864,7 +1864,9 @@ void PartitionData::doCircleFill(
 
 #if RETAIL_COMPATIBLE_CRC
 	// Cell coverage diverges at radii >= 240 between algorithms.
-	for (Int x = 0; (cellRadius < 240) ? (x <= y) : (x < cellRadius); ++x)
+	Int end = cellRadius - 1;
+	Int& endRef = (cellRadius < 240) ? y : end;
+	for (Int x = 0; x <= endRef; ++x)
 #else
 	for (Int x = 0; x <= y; ++x)
 #endif


### PR DESCRIPTION
This change brings a small performance boost and logic optimisation to the `doCircleFill` method in the `PartitionManager`, which is the process used to determine which cells of the grid a medium to large cylindrical or spherical object occupies.

The original implementation is incorrect in that it uses the fixed cell radius in the loop condition instead of the decreasing y value. This means that the circle fill is not only performing redundant iterations on repeated rows, but also erroneously filling trapezoidal shapes along the top and bottom of the circle (as the x is not being curbed along each scan line). Cells occupy 40×40 world units.

In reality (retail), the trapezoidal shapes do not cover any additional cells as no object geometry has a large enough radius to be affected, with identical cell coverage at a radius of 240 and below. (The largest circular geometry in the game is the Anthrax Bomb poison field with a radius of 150.) Regardless, the fixed logic is behind a `!RETAIL_COMPATIBLE_CRC` flag to guarantee no mods or maps that introduce gigantic geometries cause any mismatches due to different cell coverage. See below for comparisons between the original and fixed implementations.

### Comparison 1
![h_anim](https://github.com/user-attachments/assets/38b81b82-da00-45a3-88e7-b859a0c1efa7)
Demonstration of the trapezoidal issue at large scale

### Comparison 2
![s_anim](https://github.com/user-attachments/assets/22d11984-41eb-4167-9124-0d32d622b450)
At radii <= 240, cell coverage is identical</p>

### Comparison 3
![s_anim](https://github.com/user-attachments/assets/52bc0342-f317-4491-9af2-92bf5c4fa371)
At radii > 240, cell coverage diverges

### Tabulated differences

<img width="708" height="208" alt="image" src="https://github.com/user-attachments/assets/d5b4fb84-85fe-40eb-ba47-01217d842729" />

Loops: Total number of for-loop iterations, including nested scan line iterations
Checks: Total number of cell checks performed
Cells: Total number of cells covered

Green cells: Reduced calculations
Yellow cells: Divergent cell coverage

## TODO

- [ ] Replicate in Generals