### PR TITLE
feat: Do not deselect worker on cancelling building placement mode

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
@@ -959,7 +959,13 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 				{
  					//No GUI command mode, so deselect everyone if we're in regular mouse mode.
  					//In alternate mouse mode, right click still cancels building placement.
- 					if (! TheGlobalData->m_useAlternateMouse || TheInGameUI->getPendingPlaceSourceObjectID() != INVALID_ID)
+					if (TheInGameUI->getPendingPlaceSourceObjectID() != INVALID_ID)
+					{
+						TheInGameUI->placeBuildAvailable(NULL, NULL);
+						disp = DESTROY_MESSAGE;
+						TheInGameUI->setScrolling(FALSE);
+					}
+					else if (!TheGlobalData->m_useAlternateMouse)
  					{
  						deselectAll();
 						m_lastGroupSelGroup = -1;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
@@ -1035,7 +1035,13 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 				{
 					//No GUI command mode, so deselect everyone if we're in regular mouse mode.
 					//In alternate mouse mode, right click still cancels building placement.
-					if (! TheGlobalData->m_useAlternateMouse || TheInGameUI->getPendingPlaceSourceObjectID() != INVALID_ID)
+					if (TheInGameUI->getPendingPlaceSourceObjectID() != INVALID_ID)
+					{
+						TheInGameUI->placeBuildAvailable(NULL, NULL);
+						disp = DESTROY_MESSAGE;
+						TheInGameUI->setScrolling(FALSE);
+					}
+					else if (!TheGlobalData->m_useAlternateMouse)
 					{
 						deselectAll();
 					}


### PR DESCRIPTION
This change makes pressing the right-mouse button to cancel building placement no longer deselect the worker. It is quite frustrating to anchor and begin rotating a building, only to realise it is not in an optimal position and cancel it, but have to reselect the worker in order to place the building again. This is especially annoying if the worker is off-screen or requires effort to find.

The change makes unit deselection more intentional and improves UI input consistency (imagine if units were deselected when cancelling special powers or ability contexts such as Laser Lock or Rocket Pods... the horror!).

### Before
The worker has to be reselected after cancelling placement every time.

https://github.com/user-attachments/assets/4dbff5e6-fe4c-4227-853b-ac65147bc645

### After
The worker no longer needs to be reselected after cancelling placement.

https://github.com/user-attachments/assets/857a9a9a-c747-4888-b6fe-1d567132d31f