### PR TITLE
bugfix(controlbar): Show the experience bar for the selected player when observing

### DIFF
--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/GUICallbacks/W3DControlBar.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/GUICallbacks/W3DControlBar.cpp
@@ -488,6 +488,7 @@ void W3DCommandBarGenExpDraw( GameWindow *window, WinInstanceData *instData )
 {
 	Player* player = NULL;
 
+	// TheSuperHackers @bugfix Stubbjax 08/08/2025 Show the experience bar for observers
 	if (TheControlBar->isObserverControlBarOn())
 		player = TheControlBar->getObserverLookAtPlayer();
 	else

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/GUICallbacks/W3DControlBar.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/GUICallbacks/W3DControlBar.cpp
@@ -486,9 +486,16 @@ void W3DCommandBarGridDraw( GameWindow *window, WinInstanceData *instData )
 
 void W3DCommandBarGenExpDraw( GameWindow *window, WinInstanceData *instData )
 {
-	Player *player = ThePlayerList->getLocalPlayer();
-	if(!player->isPlayerActive())
+	Player* player = NULL;
+
+	if (TheControlBar->isObserverControlBarOn())
+		player = TheControlBar->getObserverLookAtPlayer();
+	else
+		player = ThePlayerList->getLocalPlayer();
+
+	if (!player)
 		return;
+
 	static const Image *endBar = TheMappedImageCollection->findImageByName("GenExpBarTop1");
 	static const Image *beginBar = TheMappedImageCollection->findImageByName("GenExpBarBottom1");
 	static const Image *centerBar = TheMappedImageCollection->findImageByName("GenExpBar1");

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/GUICallbacks/W3DControlBar.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/GUICallbacks/W3DControlBar.cpp
@@ -488,6 +488,7 @@ void W3DCommandBarGenExpDraw( GameWindow *window, WinInstanceData *instData )
 {
 	Player* player = NULL;
 
+	// TheSuperHackers @bugfix Stubbjax 08/08/2025 Show the experience bar for observers
 	if (TheControlBar->isObserverControlBarOn())
 		player = TheControlBar->getObserverLookAtPlayer();
 	else

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/GUICallbacks/W3DControlBar.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/GUICallbacks/W3DControlBar.cpp
@@ -486,9 +486,16 @@ void W3DCommandBarGridDraw( GameWindow *window, WinInstanceData *instData )
 
 void W3DCommandBarGenExpDraw( GameWindow *window, WinInstanceData *instData )
 {
-	Player *player = ThePlayerList->getLocalPlayer();
-	if(!player->isPlayerActive())
+	Player* player = NULL;
+
+	if (TheControlBar->isObserverControlBarOn())
+		player = TheControlBar->getObserverLookAtPlayer();
+	else
+		player = ThePlayerList->getLocalPlayer();
+
+	if (!player)
 		return;
+
 	static const Image *endBar = TheMappedImageCollection->findImageByName("GenExpBarTop1");
 	static const Image *beginBar = TheMappedImageCollection->findImageByName("GenExpBarBottom1");
 	static const Image *centerBar = TheMappedImageCollection->findImageByName("GenExpBar1");


### PR DESCRIPTION
This change shows the experience bar for the selected player when observing (both live matches and replays). The conditions are identical to the power bar display conditions.

<img width="484" height="348" alt="image" src="https://github.com/user-attachments/assets/bbbb5d68-ba48-4588-856e-b9fcd33199e3" />