### PR TITLE
bugfix: While observing, allow Angry Mobs to be selected and any objects to be deselected again

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -1447,16 +1447,15 @@ void ControlBar::update( void )
 			// so we must isolate and evaluate only the Nexus
 			drawToEvaluateFor = TheGameClient->findDrawableByID( TheInGameUI->getSoloNexusSelectedDrawableID() ) ;
 			multiSelect = ( drawToEvaluateFor == NULL );
-
 		}
 		else // get the first and only drawble in the selection list
 			// TheSuperHackers @fix Mauller 07/04/2025 The first access to this can return an empty list
 			if (!TheInGameUI->getAllSelectedDrawables()->empty()) {
 				drawToEvaluateFor = TheInGameUI->getAllSelectedDrawables()->front();
-				Object *obj = drawToEvaluateFor ? drawToEvaluateFor->getObject() : NULL;
-				setPortraitByObject( obj );
 			}
 
+		Object* obj = drawToEvaluateFor ? drawToEvaluateFor->getObject() : NULL;
+		setPortraitByObject(obj);
 		return;
 	}
 


### PR DESCRIPTION
This change fixes a bug introduced by #630 that prevents Angry Mobs from being selected as well as any objects from being deselected (the portrait cleared) while observing (including replays).