### PR TITLE
bugfix(ai): Fix game crash caused by an AI player not finding a valid Sneak Attack location

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -1244,9 +1244,13 @@ Bool AIPlayer::computeSuperweaponTarget(const SpecialPowerTemplate *power, Coord
 			{
 				cash = curCash;
 				bestPos = pos;
+				success = true;
 			}
 		}
 	}
+
+	if (!success)
+		return false;
 
 	//Fine tune that position by looking at a even smaller radius.
 	Coord3D veryBestPos;


### PR DESCRIPTION
This change fixes a crash that can occur if an AI player cannot find a valid place to spawn a Sneak Attack (`bestPos` may be accessed without being initialised).