### PR TITLE
bugfix(textureloader): Fix Generals game hang with TextureLoader::Validate_Texture_Size

### DIFF
--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/textureloader.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/textureloader.cpp
@@ -1046,7 +1046,7 @@ void TextureLoadTaskClass::Begin_Texture_Load()
 			DDSFileClass dds_file(Texture->Get_Full_Path(),Get_Reduction());
 			if (dds_file.Is_Available()) {
 				// Destination size will be the next power of two square from the larger width and height...
-				unsigned width, height, depth;
+				unsigned width=0, height=0, depth=0; // Depth is not used.
 				width=dds_file.Get_Width(0);
 				height=dds_file.Get_Height(0);
 				TextureLoader::Validate_Texture_Size(width,height,depth);
@@ -1120,7 +1120,7 @@ void TextureLoadTaskClass::Begin_Texture_Load()
 			}
 
 			// Destination size will be the next power of two square from the larger width and height...
-			unsigned width=targa.Header.Width, height=targa.Header.Height, depth;
+			unsigned width=targa.Header.Width, height=targa.Header.Height, depth=0; // Depth is not used.
 			int ReductionFactor=Get_Reduction();
 			int MipLevels=0;
 

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/textureloader.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/textureloader.cpp
@@ -1046,7 +1046,7 @@ void TextureLoadTaskClass::Begin_Texture_Load()
 			DDSFileClass dds_file(Texture->Get_Full_Path(),Get_Reduction());
 			if (dds_file.Is_Available()) {
 				// Destination size will be the next power of two square from the larger width and height...
-				unsigned width=0, height=0, depth=0; // Depth is not used.
+				unsigned width=0, height=0, depth=1;
 				width=dds_file.Get_Width(0);
 				height=dds_file.Get_Height(0);
 				TextureLoader::Validate_Texture_Size(width,height,depth);
@@ -1120,7 +1120,7 @@ void TextureLoadTaskClass::Begin_Texture_Load()
 			}
 
 			// Destination size will be the next power of two square from the larger width and height...
-			unsigned width=targa.Header.Width, height=targa.Header.Height, depth=0; // Depth is not used.
+			unsigned width=targa.Header.Width, height=targa.Header.Height, depth=1;
 			int ReductionFactor=Get_Reduction();
 			int MipLevels=0;
 

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/texturethumbnail.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/texturethumbnail.cpp
@@ -92,7 +92,7 @@ ThumbnailClass::ThumbnailClass(const StringClass& filename)
 		// Destination size will be the next power of two square from the larger width and height...
 		Width=targa.Header.Width>>reduction_factor;
 		Height=targa.Header.Height>>reduction_factor;
-		unsigned depth;
+		unsigned depth=1;
 		TextureLoader::Validate_Texture_Size(Width,Height,depth);
 		unsigned src_width=targa.Header.Width;
 		unsigned src_height=targa.Header.Height;


### PR DESCRIPTION
* Follow up for #1410

Texture loader has an infinite loop:
```
    while (poweroftwodepth< depth)
    {
        poweroftwodepth <<= 1;
    }
```
where depth is 3435973836 (uninitialised) and poweroftwodepth is 0

There was two spots where depth was uninitialized, setting to 0 fixed it. The depth is not actually used by the code so its safe to be 0. Unfortunately ZH code is significantly different, maybe it should be unified soon (it calls Get_Texture_Information to get the depth, which is better if we need depth later).