### PR TITLE
bugfix(ai): Fix call sites to AICommandInterface::aiAttackPosition with invalid function parameter

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -5435,7 +5435,8 @@ void Object::doCommandButton( const CommandButton *commandButton, CommandSourceT
 					{
 						setWeaponLock( commandButton->getWeaponSlot(), LOCKED_TEMPORARILY );
 						//LOCATION BASED FIRE WEAPON
-						ai->aiAttackPosition( NULL, commandButton->getMaxShotsToFire(), cmdSource );
+						// TheSuperHackers @bugfix Caball009 09/08/2025 Position should be irrelevant, but aiAttackPosition requires a valid position pointer to avoid a crash.
+						ai->aiAttackPosition( getPosition(), commandButton->getMaxShotsToFire(), cmdSource );
 					}
 					else
 					{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/SpecialPower/FireWeaponPower.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/SpecialPower/FireWeaponPower.cpp
@@ -109,7 +109,8 @@ void FireWeaponPower::doSpecialPower( UnsignedInt commandOptions )
 	AIUpdateInterface *ai = self->getAI();
 	if( ai )
 	{
-		ai->aiAttackPosition( NULL, data->m_maxShotsToFire, CMD_FROM_AI );
+		// TheSuperHackers @bugfix Caball009 09/08/2025 Position should be irrelevant, but aiAttackPosition requires a valid position pointer to avoid a crash.
+		ai->aiAttackPosition( self->getPosition(), data->m_maxShotsToFire, CMD_FROM_AI );
 
 		//Order any turrets to attack as well.
 		for( Int i = 0; i < MAX_TURRETS; i++ )


### PR DESCRIPTION
* Fixes: https://github.com/TheSuperHackers/GeneralsGameCode/issues/1434

https://github.com/TheSuperHackers/GeneralsGameCode/blob/02fdf4f76e8820065bf9bfa2a632866e6f21440f/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h#L614-L620

This PR fixes two call sites that call  `AICommandInterface::aiAttackPosition` with a `NULL` parameter which gets dereferenced causing a crash.