### PR TITLE
bugfix(specialpower): Fix availability of building based special powers

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/SpecialPower/SpecialPowerModule.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/SpecialPower/SpecialPowerModule.cpp
@@ -166,6 +166,17 @@ SpecialPowerModule::~SpecialPowerModule()
 //-------------------------------------------------------------------------------------------------
 void SpecialPowerModule::resolveSpecialPower( void )
 {
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @info some building based special powers are immediately available
+	// This means we need to set their available frame to the current frame to make them usable
+	// The check for a public timer excludes super weapons from the selection criteria
+	if (getSpecialPowerModuleData()->m_specialPowerTemplate->hasPublicTimer() == FALSE &&
+		getObject()->isKindOf(KINDOF_STRUCTURE)	)
+	{
+		m_availableOnFrame = TheGameLogic->getFrame();
+	}
+#endif
+
 	/*
 
 	// if we're pre-built, and not from a command center, and a building register us with the UI

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/SpecialPower/SpecialPowerModule.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/SpecialPower/SpecialPowerModule.cpp
@@ -178,6 +178,17 @@ void SpecialPowerModule::setReadyFrame( UnsignedInt frame )
 //-------------------------------------------------------------------------------------------------
 void SpecialPowerModule::resolveSpecialPower( void )
 {
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @info some building based special powers are immediately available
+	// This means we need to set their available frame to the current frame to make them usable
+	// The check for a public timer excludes super weapons from the selection criteria
+	if (getSpecialPowerModuleData()->m_specialPowerTemplate->hasPublicTimer() == FALSE &&
+		getObject()->isKindOf(KINDOF_STRUCTURE)	)
+	{
+		m_availableOnFrame = TheGameLogic->getFrame();
+	}
+#endif
+
 	/*
 
 	// if we're pre-built, and not from a command center, and a building register us with the UI


### PR DESCRIPTION
* Relates To: #1218

This PR fixes some issues that cropped up in Generals Online, caused by an earlier fix that was meant to prevent some special power exploits in non retail code. The earlier fix initialises the available frame to max int to prevent some exploits.

Essentially most of the USA special powers stopped working and the battleplans on the strategy center also stopped working.

This PR fixes this by checking if we are a special power module for a building that does not have a public timer, then setting the available frame for the power to the current frame.

The public timer case prevents super weapons from getting their timers reset to zero again and the building check means it only affects building based special powers. These special powers are typically immediately available once the building is constructed and do not have any other form of initialisation code.

---
TODO

- [ ] Check unlocked special powers still work the same way as retail