### PR TITLE
feat(system): Add command line option to skip force set of cwd

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/GlobalData.h
+++ b/Generals/Code/GameEngine/Include/Common/GlobalData.h
@@ -121,6 +121,10 @@ public:
 	// Run game without graphics, input or audio.
 	Bool m_headless;
 
+	// TheSuperHackers @feature 11/08/2025
+	// On startup change the current working directory to the executable's location.
+	Bool m_changeCurrentWorkingDirectoryToExecutablePath;
+
 	Bool m_windowed;
 	Int m_xResolution;
 	Int m_yResolution;

--- a/Generals/Code/GameEngine/Source/Common/CommandLine.cpp
+++ b/Generals/Code/GameEngine/Source/Common/CommandLine.cpp
@@ -458,6 +458,12 @@ Int parseJobs(char *args[], int num)
 	return 1;
 }
 
+Int parseCwd(char* args[], int num)
+{
+	TheWritableGlobalData->m_changeCurrentWorkingDirectoryToExecutablePath = FALSE;
+	return 1;
+}
+
 Int parseXRes(char *args[], int num)
 {
 	if (num > 1)
@@ -1163,6 +1169,10 @@ static CommandLineParam paramsForStartup[] =
 	// (If you have 4 cores, call it with -jobs 4)
 	// If you do not call this, all replays will be simulated in sequence in the same process.
 	{ "-jobs", parseJobs },
+
+	// TheSuperHackers @feature 11/08/2025
+	// Use current working directory as provided by the OS.
+	{ "-cwd", parseCwd },
 };
 
 // These Params are parsed during Engine Init before INI data is loaded

--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -613,6 +613,7 @@ GlobalData::GlobalData()
 	m_framesPerSecondLimit = 0;
 	m_chipSetType = 0;
 	m_headless = FALSE;
+	m_changeCurrentWorkingDirectoryToExecutablePath = TRUE;
 	m_windowed = 0;
 	m_xResolution = 800;
 	m_yResolution = 600;

--- a/Generals/Code/Main/WinMain.cpp
+++ b/Generals/Code/Main/WinMain.cpp
@@ -764,21 +764,26 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 
 		// initialize the memory manager early
 		initMemoryManager();
-
-		/// @todo remove this force set of working directory later
-		Char buffer[ _MAX_PATH ];
-		GetModuleFileName( NULL, buffer, sizeof( buffer ) );
-		Char *pEnd = buffer + strlen( buffer );
-		while( pEnd != buffer )
+		
+		CommandLine::parseCommandLineForStartup();
+		
+		if (TheGlobalData->m_changeCurrentWorkingDirectoryToExecutablePath)
 		{
-			if( *pEnd == '\\' )
+			/// @todo remove this force set of working directory later
+			Char buffer[ _MAX_PATH ];
+			GetModuleFileName( NULL, buffer, sizeof( buffer ) );
+			Char *pEnd = buffer + strlen( buffer );
+			while( pEnd != buffer )
 			{
-				*pEnd = 0;
-				break;
+				if( *pEnd == '\\' )
+				{
+					*pEnd = 0;
+					break;
+				}
+				pEnd--;
 			}
-			pEnd--;
+			::SetCurrentDirectory(buffer);
 		}
-		::SetCurrentDirectory(buffer);
 
 
 		#ifdef RTS_DEBUG
@@ -799,7 +804,6 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 		// Force to be loaded from a file, not a resource so same exe can be used in germany and retail.
  		gLoadScreenBitmap = (HBITMAP)LoadImage(hInstance, "Install_Final.bmp",	IMAGE_BITMAP, 0, 0, LR_SHARED|LR_LOADFROMFILE);
 
-		CommandLine::parseCommandLineForStartup();
 
 		// register windows class and create application window
 		if(!TheGlobalData->m_headless && initializeAppWindows(hInstance, nCmdShow, TheGlobalData->m_windowed) == false)

--- a/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
@@ -124,6 +124,10 @@ public:
 	// Run game without graphics, input or audio.
 	Bool m_headless;
 
+	// TheSuperHackers @feature 11/08/2025
+	// On startup change the current working directory to the executable's location.
+	Bool m_changeCurrentWorkingDirectoryToExecutablePath;
+
 	Bool m_windowed;
 	Int m_xResolution;
 	Int m_yResolution;

--- a/GeneralsMD/Code/GameEngine/Source/Common/CommandLine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/CommandLine.cpp
@@ -458,6 +458,12 @@ Int parseJobs(char *args[], int num)
 	return 1;
 }
 
+Int parseCwd(char* args[], int num)
+{
+	TheWritableGlobalData->m_changeCurrentWorkingDirectoryToExecutablePath = FALSE;
+	return 1;
+}
+
 Int parseXRes(char *args[], int num)
 {
 	if (num > 1)
@@ -1163,6 +1169,10 @@ static CommandLineParam paramsForStartup[] =
 	// (If you have 4 cores, call it with -jobs 4)
 	// If you do not call this, all replays will be simulated in sequence in the same process.
 	{ "-jobs", parseJobs },
+
+	// TheSuperHackers @feature 11/08/2025
+	// Use current working directory as provided by the OS.
+	{ "-cwd", parseCwd },
 };
 
 // These Params are parsed during Engine Init before INI data is loaded

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -618,6 +618,7 @@ GlobalData::GlobalData()
 	m_framesPerSecondLimit = 0;
 	m_chipSetType = 0;
 	m_headless = FALSE;
+	m_changeCurrentWorkingDirectoryToExecutablePath = TRUE;
 	m_windowed = 0;
 	m_xResolution = 800;
 	m_yResolution = 600;

--- a/GeneralsMD/Code/Main/WinMain.cpp
+++ b/GeneralsMD/Code/Main/WinMain.cpp
@@ -792,20 +792,25 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 		// initialize the memory manager early
 		initMemoryManager();
 
-		/// @todo remove this force set of working directory later
-		Char buffer[ _MAX_PATH ];
-		GetModuleFileName( NULL, buffer, sizeof( buffer ) );
-		Char *pEnd = buffer + strlen( buffer );
-		while( pEnd != buffer )
+		CommandLine::parseCommandLineForStartup();
+
+		if (TheGlobalData->m_changeCurrentWorkingDirectoryToExecutablePath)
 		{
-			if( *pEnd == '\\' )
+			/// @todo remove this force set of working directory later
+			Char buffer[ _MAX_PATH ];
+			GetModuleFileName( NULL, buffer, sizeof( buffer ) );
+			Char *pEnd = buffer + strlen( buffer );
+			while( pEnd != buffer )
 			{
-				*pEnd = 0;
-				break;
+				if( *pEnd == '\\' )
+				{
+					*pEnd = 0;
+					break;
+				}
+				pEnd--;
 			}
-			pEnd--;
+			::SetCurrentDirectory(buffer);
 		}
-		::SetCurrentDirectory(buffer);
 
 
 		#ifdef RTS_DEBUG
@@ -845,8 +850,6 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 		// in release, the file only ever lives in the root dir
 		gLoadScreenBitmap = (HBITMAP)LoadImage(hInstance, "Install_Final.bmp", IMAGE_BITMAP, 0, 0, LR_SHARED|LR_LOADFROMFILE);
 #endif
-
-		CommandLine::parseCommandLineForStartup();
 
 		// register windows class and create application window
 		if(!TheGlobalData->m_headless && initializeAppWindows(hInstance, nCmdShow, TheGlobalData->m_windowed) == false)


### PR DESCRIPTION
This PR introduces the possiblity to put the game executable outside of the Generals/ZeroHour installation path.

Considerations regarding:

- DLLs: The current working directory is simply also part of the DLL search path order. But now not before the system folders but afterwards. Since there are no system DLLs using mss32.dll and BINKW32.DLL, this is fine. See [Win32 Docu - DLL Standard search order](https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order#search-order-for-unpackaged-apps)
- Win32 File Access: ~~I am not able to find any documentation on that.~~ But debugging it with Process Monitor will show when using a Win32 file access function like LoadImageA or LoadCursorFromFile with a relative path, first the executable path, then current working directory, then all paths in %PATH% are searched. See https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-openfile#remarks
- C runtime functions like fopen: Will always work based on current working directory.

Example usage with VS:

<img width="908" height="369" alt="grafik" src="https://github.com/user-attachments/assets/966a32df-d8a7-48ef-8ee8-87631861f60c" />

(Sorry for German version, I added "-cwd" to "Command Arguments" and the install path to "Working Directory")