### PR TITLE
bugfix(input): No longer require two clicks to deselect worker after cancelling building placement in alternate mouse mode

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
@@ -962,6 +962,7 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 					if (TheInGameUI->getPendingPlaceSourceObjectID() != INVALID_ID)
 					{
 						TheInGameUI->placeBuildAvailable(NULL, NULL);
+						TheInGameUI->setPreventLeftClickDeselectionInAlternateMouseModeForOneClick(FALSE);
 						disp = DESTROY_MESSAGE;
 						TheInGameUI->setScrolling(FALSE);
 					}

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
@@ -1038,6 +1038,7 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 					if (TheInGameUI->getPendingPlaceSourceObjectID() != INVALID_ID)
 					{
 						TheInGameUI->placeBuildAvailable(NULL, NULL);
+						TheInGameUI->setPreventLeftClickDeselectionInAlternateMouseModeForOneClick(FALSE);
 						disp = DESTROY_MESSAGE;
 						TheInGameUI->setScrolling(FALSE);
 					}


### PR DESCRIPTION
Fixes #1447
Follow-up to #1430

This change disables the "set prevention of left click deselection in alternate mouse mode for one click" logic when cancelling building placement - a leftover side-effect from the improvement introduced with #1430.

The respective `setPreventLeftClickDeselectionInAlternateMouseModeForOneClick` method is used to prevent a worker from being deselected when placing a structure, which is considered a click on empty terrain that would otherwise deselect the unit. In this case, as building placement has been cancelled, it is set back to false so that clicking an empty area will deselect the worker as expected.