### PR TITLE
bugfix: Singular right-click logic now always executes after a double right-click

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -3533,6 +3533,7 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 		}
 
 		//-----------------------------------------------------------------------------
+		case GameMessage::MSG_RAW_MOUSE_RIGHT_DOUBLE_CLICK:
  		case GameMessage::MSG_RAW_MOUSE_RIGHT_BUTTON_DOWN:
  		{
  			// There are two ways in which we can ignore this as a deselect:
@@ -3556,10 +3557,6 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 
  		//-----------------------------------------------------------------------------
  		case GameMessage::MSG_MOUSE_RIGHT_DOUBLE_CLICK:
-		{
-			m_mouseRightDown = m_mouseRightUp; // Allow isClick to succeed on fall through
-			FALLTHROUGH; //intentional fall through
-		}
  		case GameMessage::MSG_MOUSE_RIGHT_CLICK:
  		{
  			// right click is only actioned here if we're in alternate mouse mode

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -3874,6 +3874,7 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 		}
 
 		//-----------------------------------------------------------------------------
+		case GameMessage::MSG_RAW_MOUSE_RIGHT_DOUBLE_CLICK:
 		case GameMessage::MSG_RAW_MOUSE_RIGHT_BUTTON_DOWN:
 		{
 			// There are two ways in which we can ignore this as a deselect:
@@ -3922,8 +3923,6 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 
 				break;
 			}
-
-			m_mouseRightDown = m_mouseRightUp; // Allow isClick to succeed on fall through
 			FALLTHROUGH; //intentional fall through
 		}
 		case GameMessage::MSG_MOUSE_RIGHT_CLICK:


### PR DESCRIPTION
This change fixes single right-click behaviour not being performed on a double right-click.

When a double right-click is performed, the singular right-click logic is potentially not executed as the `isClick` condition may return false. This is due to the double-click logic not updating the mouse down and mouse up timestamps that determine whether the user is holding down the mouse button (for camera dragging purposes). This means that there is a brief window after cancelling a context command (unit abilities, Beacon placement, General's Powers, etc.) that a unit will not perform the respective right-click action on the second right-click.

Note: Double-clicking very fast will cause the double-click to be within the first click's timestamp window and `isClick` will thus succeed. The issue is most noticeable when exiting context modes via a 'slower' double right-click.