### PR TITLE
unify(object): Merge the unit veterancy effect changes including the veterancy effect fix for detected stealth units from Zero Hour

### DIFF
--- a/Generals/Code/GameEngine/Include/GameLogic/ExperienceTracker.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/ExperienceTracker.h
@@ -51,12 +51,12 @@ public:
 	Bool isTrainable() const;																						///< Can I gain experience?
 	Bool isAcceptingExperiencePoints() const;														///< Either I am trainable, or I have a Sink set up
 
-	void setVeterancyLevel( VeterancyLevel newLevel );						///< Set Level to this
+	void setVeterancyLevel( VeterancyLevel newLevel, Bool provideFeedback = TRUE );						///< Set Level to this
 	void setMinVeterancyLevel( VeterancyLevel newLevel );					///< Set Level to AT LEAST this... if we are already >= this level, do nothing.
 	void addExperiencePoints( Int experienceGain, Bool canScaleForBonus = TRUE );	///< Gain this many exp.
 	Bool gainExpForLevel(Int levelsToGain, Bool canScaleForBonus = TRUE );			  ///< Gain enough exp to gain a level. return false if can't gain a level.
 	Bool canGainExpForLevel(Int levelsToGain) const;															///< return same value as gainExpForLevel, but don't change anything
-	void setExperienceAndLevel(Int experienceIn);
+	void setExperienceAndLevel(Int experienceIn, Bool provideFeedback = TRUE );
 	void setExperienceSink( ObjectID sink );											///< My experience actually goes to this person (loose couple)
 
 	Real getExperienceScalar() const { return m_experienceScalar; }

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/ActiveBody.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/ActiveBody.h
@@ -87,7 +87,7 @@ public:
 	virtual ObjectID getClearableLastAttacker() const { return (m_lastDamageCleared ? INVALID_ID : m_lastDamageInfo.in.m_sourceID); }
 	virtual void clearLastAttacker() { m_lastDamageCleared = true; }
 
-	void onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel newLevel );
+	void onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel newLevel, Bool provideFeedback = TRUE );
 
 	virtual void setArmorSetFlag(ArmorSetType ast) { m_curArmorSetFlags.set(ast, 1); }
 	virtual void clearArmorSetFlag(ArmorSetType ast) { m_curArmorSetFlags.set(ast, 0); }

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/BodyModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/BodyModule.h
@@ -150,7 +150,7 @@ public:
 	virtual void setDamageState( BodyDamageType newState ) = 0;	///< control damage state directly.  Will adjust hitpoints.
 	virtual void setAflame( Bool setting ) = 0;///< This is a major change like a damage state.
 
-	virtual void onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel newLevel ) = 0;	///< I just achieved this level right this moment
+	virtual void onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel newLevel, Bool provideFeedback ) = 0;	///< I just achieved this level right this moment
 
 	virtual void setArmorSetFlag(ArmorSetType ast) = 0;
 	virtual void clearArmorSetFlag(ArmorSetType ast) = 0;
@@ -237,7 +237,7 @@ public:
 	virtual void setDamageState( BodyDamageType newState ) = 0;	///< control damage state directly.  Will adjust hitpoints.
 	virtual void setAflame( Bool setting ) = 0;///< This is a major change like a damage state.
 
-	virtual void onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel newLevel ) = 0;	///< I just achieved this level right this moment
+	virtual void onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel newLevel, Bool provideFeedback = FALSE ) = 0;	///< I just achieved this level right this moment
 
 	virtual void setArmorSetFlag(ArmorSetType ast) = 0;
 	virtual void clearArmorSetFlag(ArmorSetType ast) = 0;

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/InactiveBody.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/InactiveBody.h
@@ -58,7 +58,7 @@ public:
 	virtual void setDamageState( BodyDamageType newState );	///< control damage state directly.  Will adjust hitpoints.
 	virtual void setAflame( Bool setting ){}///< This is a major change like a damage state.
 
-	void onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel newLevel ) { /* nothing */ }
+	void onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel newLevel, Bool provideFeedback ) { /* nothing */ }
 
 	virtual void setArmorSetFlag(ArmorSetType ast) { /* nothing */ }
 	virtual void clearArmorSetFlag(ArmorSetType ast) { /* nothing */ }

--- a/Generals/Code/GameEngine/Include/GameLogic/Object.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Object.h
@@ -217,7 +217,7 @@ public:
 	void healCompletely();														///< Restore max health to this Object
 
 	void scoreTheKill( const Object *victim );						///< I just killed this object.
-	void onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel newLevel );	///< I just achieved this level right this moment
+	void onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel newLevel, Bool provideFeedback = TRUE );	///< I just achieved this level right this moment
 	ExperienceTracker* getExperienceTracker() {return m_experienceTracker;}
 	const ExperienceTracker* getExperienceTracker() const {return m_experienceTracker;}
 	VeterancyLevel getVeterancyLevel() const;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp
@@ -1070,29 +1070,32 @@ void ActiveBody::setIndestructible( Bool indestructible )
 
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
-void ActiveBody::onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel newLevel )
+void ActiveBody::onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel newLevel, Bool provideFeedback )
 {
 	if (oldLevel == newLevel)
 		return;
 
 	if (oldLevel < newLevel)
 	{
-		AudioEventRTS veterancyChanged;
-		switch (newLevel)
+		if (provideFeedback)
 		{
-			case LEVEL_VETERAN:
-				veterancyChanged = *getObject()->getTemplate()->getSoundPromotedVeteran();
-				break;
-			case LEVEL_ELITE:
-				veterancyChanged = *getObject()->getTemplate()->getSoundPromotedElite();
-				break;
-			case LEVEL_HEROIC:
-				veterancyChanged = *getObject()->getTemplate()->getSoundPromotedHero();
-				break;
-		}
+			AudioEventRTS veterancyChanged;
+			switch (newLevel)
+			{
+				case LEVEL_VETERAN:
+					veterancyChanged = *getObject()->getTemplate()->getSoundPromotedVeteran();
+					break;
+				case LEVEL_ELITE:
+					veterancyChanged = *getObject()->getTemplate()->getSoundPromotedElite();
+					break;
+				case LEVEL_HEROIC:
+					veterancyChanged = *getObject()->getTemplate()->getSoundPromotedHero();
+					break;
+			}
 
-		veterancyChanged.setObjectID(getObject()->getID());
-		TheAudio->addAudioEvent(&veterancyChanged);
+			veterancyChanged.setObjectID(getObject()->getID());
+			TheAudio->addAudioEvent(&veterancyChanged);
+		}
 
 		//Also mark the UI dirty -- incase the object is selected or contained.
 		Object *obj = getObject();

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/ExperienceTracker.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/ExperienceTracker.cpp
@@ -98,7 +98,7 @@ void ExperienceTracker::setMinVeterancyLevel( VeterancyLevel newLevel )
 }
 
 //-------------------------------------------------------------------------------------------------
-void ExperienceTracker::setVeterancyLevel( VeterancyLevel newLevel )
+void ExperienceTracker::setVeterancyLevel( VeterancyLevel newLevel, Bool provideFeedback )
 {
 	// This does not check for IsTrainable, because this function is for explicit setting,
 	// so the setter is assumed to know what they are doing.  The game function
@@ -109,7 +109,7 @@ void ExperienceTracker::setVeterancyLevel( VeterancyLevel newLevel )
 		m_currentLevel = newLevel;
 		m_currentExperience = m_parent->getTemplate()->getExperienceRequired(m_currentLevel); //Minimum for this level
 		if (m_parent)
-			m_parent->onVeterancyLevelChanged( oldLevel, newLevel );
+			m_parent->onVeterancyLevelChanged( oldLevel, newLevel, provideFeedback );
 	}
 }
 
@@ -185,7 +185,7 @@ void ExperienceTracker::addExperiencePoints( Int experienceGain, Bool canScaleFo
 
 }
 //-------------------------------------------------------------------------------------------------
-void ExperienceTracker::setExperienceAndLevel( Int experienceIn )
+void ExperienceTracker::setExperienceAndLevel( Int experienceIn, Bool provideFeedback )
 {
 	if( m_experienceSink != INVALID_ID )
 	{
@@ -194,7 +194,7 @@ void ExperienceTracker::setExperienceAndLevel( Int experienceIn )
 		if( sinkPointer )
 		{
 			// Not a fatal failure if not valid, he died when I was in the air.
-			sinkPointer->getExperienceTracker()->setExperienceAndLevel( experienceIn );
+			sinkPointer->getExperienceTracker()->setExperienceAndLevel( experienceIn, provideFeedback );
 			return;
 		}
 	}
@@ -220,7 +220,7 @@ void ExperienceTracker::setExperienceAndLevel( Int experienceIn )
 	if( oldLevel != m_currentLevel )
 	{
 		// Edge trigger special level gain effects.
-		m_parent->onVeterancyLevelChanged( oldLevel, m_currentLevel ); //<<== paradox! this may be a level lost!
+		m_parent->onVeterancyLevelChanged( oldLevel, m_currentLevel, provideFeedback ); //<<== paradox! this may be a level lost!
 	}
 
 }

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -2775,8 +2775,13 @@ void Object::onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel ne
 	if (body)
 		body->onVeterancyLevelChanged(oldLevel, newLevel, provideFeedback);
 
-
-	Bool hideAnimationForStealth = ( ! isLocallyControlled() && testStatus(OBJECT_STATUS_STEALTHED));
+	Bool hideAnimationForStealth = FALSE;
+	if( !isLocallyControlled() &&
+			testStatus( OBJECT_STATUS_STEALTHED ) &&
+			!testStatus( OBJECT_STATUS_DETECTED ) )
+	{
+		hideAnimationForStealth = TRUE;
+	}
 
 	Bool doAnimation = ( ! hideAnimationForStealth
 											&& (newLevel > oldLevel)

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -2763,7 +2763,7 @@ Bool Object::hasSpecialPower( SpecialPowerType type ) const
 }
 
 //-------------------------------------------------------------------------------------------------
-void Object::onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel newLevel )
+void Object::onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel newLevel, Bool provideFeedback )
 {
 	updateUpgradeModules();
 
@@ -2773,7 +2773,7 @@ void Object::onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel ne
 
 	BodyModuleInterface* body = getBodyModule();
 	if (body)
-		body->onVeterancyLevelChanged(oldLevel, newLevel);
+		body->onVeterancyLevelChanged(oldLevel, newLevel, provideFeedback);
 
 
 	Bool hideAnimationForStealth = ( ! isLocallyControlled() && testStatus(OBJECT_STATUS_STEALTHED));
@@ -2819,7 +2819,7 @@ void Object::onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel ne
 			break;
 	}
 
-	if( doAnimation && TheGameLogic->getDrawIconUI() )
+	if( doAnimation && TheGameLogic->getDrawIconUI() && provideFeedback )
 	{
 		if( TheAnim2DCollection && TheGlobalData->m_levelGainAnimationName.isEmpty() == FALSE )
 		{


### PR DESCRIPTION
This change ports the `provideFeedback` parameter and respective logic regarding the veterancy effect from Zero Hour to Generals. It also fixes a bug in Generals where detected stealth units would not play the veterancy effect.