### PR TITLE
bugfix(render): Fix Supply Dock shadowed in replay playback

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -1994,6 +1994,8 @@ void GameLogic::startNewGame( Bool saveGame )
 		{
 
 			ThePlayerList->setLocalPlayer(ThePlayerList->findPlayerWithNameKey(TheNameKeyGenerator->nameToKey("ReplayObserver")));
+			// TheSuperHackers @bugfix L3-M 03/09/2025 fix supply dock shadowed in replay playback
+			TheGhostObjectManager->setLocalPlayerIndex(ThePlayerList->getLocalPlayer()->getPlayerIndex());
 			TheRadar->forceOn(TRUE);
 			ThePartitionManager->refreshShroudForLocalPlayer();
 			TheControlBar->setControlBarSchemeByPlayer( ThePlayerList->getLocalPlayer());

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -2298,6 +2298,8 @@ void GameLogic::startNewGame( Bool loadingSaveGame )
 		{
 
 			ThePlayerList->setLocalPlayer(ThePlayerList->findPlayerWithNameKey(TheNameKeyGenerator->nameToKey("ReplayObserver")));
+			// TheSuperHackers @bugfix L3-M 03/09/2025 fix supply dock shadowed in replay playback
+			TheGhostObjectManager->setLocalPlayerIndex(ThePlayerList->getLocalPlayer()->getPlayerIndex());
 			TheRadar->forceOn(TRUE);
 			ThePartitionManager->refreshShroudForLocalPlayer();
 			TheControlBar->setControlBarSchemeByPlayer( ThePlayerList->getLocalPlayer());


### PR DESCRIPTION
* Relates to https://github.com/TheSuperHackers/GeneralsGameCode/issues/850
* Fixes https://github.com/TheSuperHackers/GeneralsGameCode/issues/439

This change fixes Supply Dock from being shadowed in replay playback in Generals and Zero Hour.


