### PR TITLE
feat(gui): Add user option to adjust scale of game fonts in relation to resolution

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/UserPreferences.h
+++ b/Generals/Code/GameEngine/Include/Common/UserPreferences.h
@@ -131,6 +131,8 @@ public:
 
 	Int getSystemTimeFontSize(void);
 	Int getGameTimeFontSize(void);
+
+	Real getResolutionFontAdjustment(void);
 };
 
 //-----------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Include/GameClient/GlobalLanguage.h
+++ b/Generals/Code/GameEngine/Include/GameClient/GlobalLanguage.h
@@ -100,9 +100,11 @@ public:
 	FontDesc  m_creditsNormalFont;
 
 	Real			m_resolutionFontSizeAdjustment;
+	Real			m_userResolutionFontSizeAdjustment;
 
 	//UnicodeString	m_unicodeFontNameUStr;
 
+	float getResolutionFontSizeAdjustment() const;
 	Int adjustFontSize(Int theFontSize);	// Adjusts font size for resolution. jba.
 
 	typedef std::list<AsciiString> StringList;					// Used for our font file names that we want to load

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -62,6 +62,7 @@
 #include "GameClient/IMEManager.h"
 #include "GameClient/ShellHooks.h"
 #include "GameClient/GUICallbacks.h"
+#include "GameClient/GlobalLanguage.h"
 #include "GameNetwork/FirewallHelper.h"
 #include "GameNetwork/IPEnumeration.h"
 #include "GameNetwork/GameSpyOverlay.h"
@@ -784,6 +785,20 @@ Int OptionPreferences::getGameTimeFontSize(void)
 	return fontSize;
 }
 
+Real OptionPreferences::getResolutionFontAdjustment(void)
+{
+	OptionPreferences::const_iterator it = find("ResolutionFontAdjustment");
+	if (it == end())
+		return -1.0f;
+
+	Real fontScale = (Real)atof(it->second.str()) / 100.0f;
+	if (fontScale < 0.0f)
+	{
+		fontScale = -1.0f;
+	}
+	return fontScale;
+}
+
 static OptionPreferences *pref = NULL;
 
 static void setDefaults( void )
@@ -1292,6 +1307,17 @@ static void saveOptions( void )
 		prefString.format("%d", val);
 		(*pref)["GameTimeFontSize"] = prefString;
 		TheInGameUI->refreshGameTimeResources();
+	}
+
+	//-------------------------------------------------------------------------------------------------
+	// Set User Font Scaling Percentage
+	val = pref->getResolutionFontAdjustment() * 100.0f; // TheSuperHackers @todo replace with options input when applicable
+	if (val >= 0 || val == -100)
+	{
+		AsciiString prefString;
+		prefString.format("%d", REAL_TO_INT( val ) );
+		(*pref)["ResolutionFontAdjustment"] = prefString;
+		TheGlobalLanguageData->m_userResolutionFontSizeAdjustment = (Real)val / 100.0f;
 	}
 
 	//-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameClient/GlobalLanguage.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GlobalLanguage.cpp
@@ -54,8 +54,10 @@
 
 #include "Common/INI.h"
 #include "Common/Registry.h"
-#include "GameClient/GlobalLanguage.h"
 #include "Common/FileSystem.h"
+#include "Common/UserPreferences.h"
+
+#include "GameClient/GlobalLanguage.h"
 
 //-----------------------------------------------------------------------------
 // DEFINES ////////////////////////////////////////////////////////////////////
@@ -117,6 +119,8 @@ GlobalLanguage::GlobalLanguage()
 	m_useHardWrap = FALSE;
 	m_resolutionFontSizeAdjustment = 0.7f;
 	//End Add
+
+	m_userResolutionFontSizeAdjustment = -1.0f;
 }
 
 GlobalLanguage::~GlobalLanguage()
@@ -165,6 +169,9 @@ void GlobalLanguage::init( void )
 		++it;
 	}
 
+	// override values with user preferences
+	OptionPreferences optionPref;
+	m_userResolutionFontSizeAdjustment = optionPref.getResolutionFontAdjustment();
 
 }
 void GlobalLanguage::reset( void ) {}
@@ -185,10 +192,18 @@ void GlobalLanguage::parseFontFileName( INI *ini, void * instance, void *store, 
 	monkey->m_localFonts.push_front(asciiString);
 }
 
+float GlobalLanguage::getResolutionFontSizeAdjustment( void ) const
+{
+	if (m_userResolutionFontSizeAdjustment >= 0.0f)
+		return m_userResolutionFontSizeAdjustment;
+	else
+		return m_resolutionFontSizeAdjustment;
+}
+
 Int GlobalLanguage::adjustFontSize(Int theFontSize)
 {
 	Real adjustFactor = TheGlobalData->m_xResolution / (Real)DEFAULT_DISPLAY_WIDTH;
-	adjustFactor = 1.0f + (adjustFactor-1.0f) * m_resolutionFontSizeAdjustment;
+	adjustFactor = 1.0f + (adjustFactor-1.0f) * getResolutionFontSizeAdjustment();
 	if (adjustFactor<1.0f) adjustFactor = 1.0f;
 	if (adjustFactor>2.0f) adjustFactor = 2.0f;
 	Int pointSize = REAL_TO_INT_FLOOR(theFontSize*adjustFactor);

--- a/GeneralsMD/Code/GameEngine/Include/Common/UserPreferences.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/UserPreferences.h
@@ -135,6 +135,8 @@ public:
 
 	Int getSystemTimeFontSize(void);
 	Int getGameTimeFontSize(void);
+
+	Real getResolutionFontAdjustment(void);
 };
 
 //-----------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/GlobalLanguage.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/GlobalLanguage.h
@@ -101,9 +101,11 @@ public:
 	FontDesc  m_creditsNormalFont;
 
 	Real			m_resolutionFontSizeAdjustment;
+	Real			m_userResolutionFontSizeAdjustment;
 
 	//UnicodeString	m_unicodeFontNameUStr;
 
+	float getResolutionFontSizeAdjustment() const;
 	Int adjustFontSize(Int theFontSize);	// Adjusts font size for resolution. jba.
 
 	typedef std::list<AsciiString> StringList;					// Used for our font file names that we want to load

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -62,6 +62,7 @@
 #include "GameClient/IMEManager.h"
 #include "GameClient/ShellHooks.h"
 #include "GameClient/GUICallbacks.h"
+#include "GameClient/GlobalLanguage.h"
 #include "GameNetwork/FirewallHelper.h"
 #include "GameNetwork/IPEnumeration.h"
 #include "GameNetwork/GameSpyOverlay.h"
@@ -828,6 +829,20 @@ Int OptionPreferences::getGameTimeFontSize(void)
 	return fontSize;
 }
 
+Real OptionPreferences::getResolutionFontAdjustment(void)
+{
+	OptionPreferences::const_iterator it = find("ResolutionFontAdjustment");
+	if (it == end())
+		return -1.0f;
+
+	Real fontScale = (Real)atof(it->second.str()) / 100.0f;
+	if (fontScale < 0.0f)
+	{
+		fontScale = -1.0f;
+	}
+	return fontScale;
+}
+
 static OptionPreferences *pref = NULL;
 
 static void setDefaults( void )
@@ -1352,6 +1367,17 @@ static void saveOptions( void )
 		prefString.format("%d", val);
 		(*pref)["GameTimeFontSize"] = prefString;
 		TheInGameUI->refreshGameTimeResources();
+	}
+
+	//-------------------------------------------------------------------------------------------------
+	// Set User Font Scaling Percentage
+	val = pref->getResolutionFontAdjustment() * 100.0f; // TheSuperHackers @todo replace with options input when applicable
+	if (val >= 0 || val == -100)
+	{
+		AsciiString prefString;
+		prefString.format("%d", REAL_TO_INT( val ) );
+		(*pref)["ResolutionFontAdjustment"] = prefString;
+		TheGlobalLanguageData->m_userResolutionFontSizeAdjustment = (Real)val / 100.0f;
 	}
 
 	//-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GlobalLanguage.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GlobalLanguage.cpp
@@ -54,8 +54,10 @@
 
 #include "Common/INI.h"
 #include "Common/Registry.h"
-#include "GameClient/GlobalLanguage.h"
 #include "Common/FileSystem.h"
+#include "Common/UserPreferences.h"
+
+#include "GameClient/GlobalLanguage.h"
 
 //-----------------------------------------------------------------------------
 // DEFINES ////////////////////////////////////////////////////////////////////
@@ -119,6 +121,8 @@ GlobalLanguage::GlobalLanguage()
 	m_resolutionFontSizeAdjustment = 0.7f;
 	m_militaryCaptionDelayMS = 750;
 	//End Add
+
+	m_userResolutionFontSizeAdjustment = -1.0f;
 }
 
 GlobalLanguage::~GlobalLanguage()
@@ -169,6 +173,9 @@ void GlobalLanguage::init( void )
 		++it;
 	}
 
+	// override values with user preferences
+	OptionPreferences optionPref;
+	m_userResolutionFontSizeAdjustment = optionPref.getResolutionFontAdjustment();
 
 }
 void GlobalLanguage::reset( void ) {}
@@ -189,10 +196,18 @@ void GlobalLanguage::parseFontFileName( INI *ini, void * instance, void *store, 
 	monkey->m_localFonts.push_front(asciiString);
 }
 
+float GlobalLanguage::getResolutionFontSizeAdjustment( void ) const
+{
+	if (m_userResolutionFontSizeAdjustment >= 0.0f)
+		return m_userResolutionFontSizeAdjustment;
+	else
+		return m_resolutionFontSizeAdjustment;
+}
+
 Int GlobalLanguage::adjustFontSize(Int theFontSize)
 {
 	Real adjustFactor = TheGlobalData->m_xResolution / (Real)DEFAULT_DISPLAY_WIDTH;
-	adjustFactor = 1.0f + (adjustFactor-1.0f) * m_resolutionFontSizeAdjustment;
+	adjustFactor = 1.0f + (adjustFactor-1.0f) * getResolutionFontSizeAdjustment();
 	if (adjustFactor<1.0f) adjustFactor = 1.0f;
 	if (adjustFactor>2.0f) adjustFactor = 2.0f;
 	Int pointSize = REAL_TO_INT_FLOOR(theFontSize*adjustFactor);


### PR DESCRIPTION
This PR adds user based font scaling adjustment to the game.

The value can be set within the options.ini by setting `ResolutionFontAdjustment = 10` etc, where the value is a percentage increase, the default being 0% of the original scale.

This value acts on the normal ini based resolution scaling to give some user flexibility.

----
TODO:

- [x] Replicate in generals