### PR TITLE
bugfix(object): Fix veterancy effect spawning at the map origin when a veteran unit is produced

### DIFF
--- a/Generals/Code/GameEngine/Include/GameLogic/ExperienceTracker.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/ExperienceTracker.h
@@ -52,7 +52,7 @@ public:
 	Bool isAcceptingExperiencePoints() const;														///< Either I am trainable, or I have a Sink set up
 
 	void setVeterancyLevel( VeterancyLevel newLevel, Bool provideFeedback = TRUE );						///< Set Level to this
-	void setMinVeterancyLevel( VeterancyLevel newLevel );					///< Set Level to AT LEAST this... if we are already >= this level, do nothing.
+	void setMinVeterancyLevel( VeterancyLevel newLevel, Bool provideFeedback = TRUE );					///< Set Level to AT LEAST this... if we are already >= this level, do nothing.
 	void addExperiencePoints( Int experienceGain, Bool canScaleForBonus = TRUE );	///< Gain this many exp.
 	Bool gainExpForLevel(Int levelsToGain, Bool canScaleForBonus = TRUE );			  ///< Gain enough exp to gain a level. return false if can't gain a level.
 	Bool canGainExpForLevel(Int levelsToGain) const;															///< return same value as gainExpForLevel, but don't change anything

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Create/VeterancyGainCreate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Create/VeterancyGainCreate.cpp
@@ -92,7 +92,7 @@ void VeterancyGainCreate::onCreate( void )
 		if( myExp  &&  myExp->isTrainable() )
 		{
 			// srj sez: use "setMin" here so that we never lose levels
-			myExp->setMinVeterancyLevel( md->m_startingLevel );// sVL can override isTrainable, but this module should not.
+			myExp->setMinVeterancyLevel( md->m_startingLevel, false );// sVL can override isTrainable, but this module should not.
 		}
 	}
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/ExperienceTracker.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/ExperienceTracker.cpp
@@ -82,7 +82,7 @@ void ExperienceTracker::setExperienceSink( ObjectID sink )
 
 //-------------------------------------------------------------------------------------------------
 // Set Level to AT LEAST this... if we are already >= this level, do nothing.
-void ExperienceTracker::setMinVeterancyLevel( VeterancyLevel newLevel )
+void ExperienceTracker::setMinVeterancyLevel( VeterancyLevel newLevel, Bool provideFeedback )
 {
 	// This does not check for IsTrainable, because this function is for explicit setting,
 	// so the setter is assumed to know what they are doing.  The game function
@@ -93,7 +93,7 @@ void ExperienceTracker::setMinVeterancyLevel( VeterancyLevel newLevel )
 		m_currentLevel = newLevel;
 		m_currentExperience = m_parent->getTemplate()->getExperienceRequired(m_currentLevel); //Minimum for this level
 		if (m_parent)
-			m_parent->onVeterancyLevelChanged( oldLevel, newLevel, false );
+			m_parent->onVeterancyLevelChanged( oldLevel, newLevel, provideFeedback );
 	}
 }
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/ExperienceTracker.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/ExperienceTracker.cpp
@@ -93,7 +93,7 @@ void ExperienceTracker::setMinVeterancyLevel( VeterancyLevel newLevel )
 		m_currentLevel = newLevel;
 		m_currentExperience = m_parent->getTemplate()->getExperienceRequired(m_currentLevel); //Minimum for this level
 		if (m_parent)
-			m_parent->onVeterancyLevelChanged( oldLevel, newLevel );
+			m_parent->onVeterancyLevelChanged( oldLevel, newLevel, false );
 	}
 }
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/ExperienceTracker.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/ExperienceTracker.h
@@ -52,7 +52,7 @@ public:
 	Bool isAcceptingExperiencePoints() const;														///< Either I am trainable, or I have a Sink set up
 
 	void setVeterancyLevel( VeterancyLevel newLevel, Bool provideFeedback = TRUE );						///< Set Level to this
-	void setMinVeterancyLevel( VeterancyLevel newLevel );					///< Set Level to AT LEAST this... if we are already >= this level, do nothing.
+	void setMinVeterancyLevel( VeterancyLevel newLevel, Bool provideFeedback = TRUE );					///< Set Level to AT LEAST this... if we are already >= this level, do nothing.
 	void addExperiencePoints( Int experienceGain, Bool canScaleForBonus = TRUE );	///< Gain this many exp.
 	Bool gainExpForLevel(Int levelsToGain, Bool canScaleForBonus = TRUE );			  ///< Gain enough exp to gain a level. return false if can't gain a level.
 	Bool canGainExpForLevel(Int levelsToGain) const;															///< return same value as gainExpForLevel, but don't change anything

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Create/VeterancyGainCreate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Create/VeterancyGainCreate.cpp
@@ -92,7 +92,7 @@ void VeterancyGainCreate::onCreate( void )
 		if( myExp  &&  myExp->isTrainable() )
 		{
 			// srj sez: use "setMin" here so that we never lose levels
-			myExp->setMinVeterancyLevel( md->m_startingLevel );// sVL can override isTrainable, but this module should not.
+			myExp->setMinVeterancyLevel( md->m_startingLevel, false );// sVL can override isTrainable, but this module should not.
 		}
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/ExperienceTracker.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/ExperienceTracker.cpp
@@ -82,7 +82,7 @@ void ExperienceTracker::setExperienceSink( ObjectID sink )
 
 //-------------------------------------------------------------------------------------------------
 // Set Level to AT LEAST this... if we are already >= this level, do nothing.
-void ExperienceTracker::setMinVeterancyLevel( VeterancyLevel newLevel )
+void ExperienceTracker::setMinVeterancyLevel( VeterancyLevel newLevel, Bool provideFeedback )
 {
 	// This does not check for IsTrainable, because this function is for explicit setting,
 	// so the setter is assumed to know what they are doing.  The game function
@@ -93,7 +93,7 @@ void ExperienceTracker::setMinVeterancyLevel( VeterancyLevel newLevel )
 		m_currentLevel = newLevel;
 		m_currentExperience = m_parent->getTemplate()->getExperienceRequired(m_currentLevel); //Minimum for this level
 		if (m_parent)
-			m_parent->onVeterancyLevelChanged( oldLevel, newLevel, false );
+			m_parent->onVeterancyLevelChanged( oldLevel, newLevel, provideFeedback );
 	}
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/ExperienceTracker.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/ExperienceTracker.cpp
@@ -93,7 +93,7 @@ void ExperienceTracker::setMinVeterancyLevel( VeterancyLevel newLevel )
 		m_currentLevel = newLevel;
 		m_currentExperience = m_parent->getTemplate()->getExperienceRequired(m_currentLevel); //Minimum for this level
 		if (m_parent)
-			m_parent->onVeterancyLevelChanged( oldLevel, newLevel );
+			m_parent->onVeterancyLevelChanged( oldLevel, newLevel, false );
 	}
 }
 


### PR DESCRIPTION
Fixes #51

This change fixes the veterancy effect appearing at the map origin for spawned units (produced from buildings, dropped from planes, spawned by scripts, etc.).

It turns out `Object::onVeterancyLevelChanged` has an optional `provideFeedback` parameter for playing the veterancy effect, so the solution was to simply pass `false` to it when called via `ExperienceTracker::setMinVeterancyLevel` (which is only called from the offending `VeterancyGainCreate` module).