### PR TITLE
bugfix(input): Prevent drag-selecting enemy beacons and enable selecting stealthed units while observing

### DIFF
--- a/Core/GameEngine/Include/Common/GameDefines.h
+++ b/Core/GameEngine/Include/Common/GameDefines.h
@@ -21,6 +21,10 @@
 // Note: Retail compatibility must not be broken before this project officially does.
 // Use RETAIL_COMPATIBLE_CRC and RETAIL_COMPATIBLE_XFER_SAVE to guard breaking changes.
 
+#ifndef RETAIL_COMPATIBLE_BUG
+#define RETAIL_COMPATIBLE_BUG (1) // Retain bugs present in retail Generals 1.08 and Zero Hour 1.04
+#endif
+
 #ifndef RETAIL_COMPATIBLE_CRC
 #define RETAIL_COMPATIBLE_CRC (1) // Game is expected to be CRC compatible with retail Generals 1.08, Zero Hour 1.04
 #endif

--- a/Generals/Code/GameEngine/Source/GameClient/SelectionInfo.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/SelectionInfo.cpp
@@ -348,6 +348,7 @@ Bool addDrawableToList( Drawable *draw, void *userData )
 		return FALSE;
 
 #if !RETAIL_COMPATIBLE_BUG
+	// TheSuperHackers @info
 	// In retail, drag-selecting allows the player to select stealthed objects and objects through the
 	// fog. Some players exploit this bug to determine where an opponent's units are and consider this
 	// an important feature and an advanced skill to pull off, so we must leave the exploit.

--- a/Generals/Code/GameEngine/Source/GameClient/SelectionInfo.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/SelectionInfo.cpp
@@ -347,7 +347,7 @@ Bool addDrawableToList( Drawable *draw, void *userData )
 	if (!pds->drawableListToFill)
 		return FALSE;
 
-#if !RETAIL_COMPATIBLE_BUG
+#if !RTS_GENERALS || !RETAIL_COMPATIBLE_BUG
 	// TheSuperHackers @info
 	// In retail, drag-selecting allows the player to select stealthed objects and objects through the
 	// fog. Some players exploit this bug to determine where an opponent's units are and consider this

--- a/Generals/Code/GameEngine/Source/GameClient/SelectionInfo.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/SelectionInfo.cpp
@@ -347,6 +347,17 @@ Bool addDrawableToList( Drawable *draw, void *userData )
 	if (!pds->drawableListToFill)
 		return FALSE;
 
+#if !RETAIL_COMPATIBLE_BUG
+	// In retail, drag-selecting allows the player to select stealthed objects and objects through the
+	// fog. Some players exploit this bug to determine where an opponent's units are and consider this
+	// an important feature and an advanced skill to pull off, so we must leave the exploit.
+	if (draw->getFullyObscuredByShroud())
+		return FALSE;
+
+	if (draw->isDrawableEffectivelyHidden())
+		return FALSE;
+#endif
+
 	if (!draw->getTemplate()->isAnyKindOf(pds->kindofsToMatch))
 		return FALSE;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/SelectionInfo.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/SelectionInfo.cpp
@@ -374,6 +374,15 @@ Bool addDrawableToList( Drawable *draw, void *userData )
       return FALSE;
   }
 
+#if RETAIL_COMPATIBLE_BUG
+	// In retail, hidden objects such as passengers are included here when drag-selected, which causes
+	// enemy selection logic to exit early (only 1 enemy unit can be selected at a time). Some players
+	// exploit this bug to determine if a transport contains passengers and consider this an important
+	// feature and an advanced skill to pull off, so we must leave the exploit.
+	if (draw->getObject() && draw->getObject()->getContain() && draw->getObject()->getContain()->getContainCount() > 0)
+		pds->drawableListToFill->push_back(draw); // Just add the unit twice to prevent enemy selections
+#endif
+
 	pds->drawableListToFill->push_back(draw);
 	return TRUE;
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/SelectionInfo.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/SelectionInfo.cpp
@@ -375,6 +375,7 @@ Bool addDrawableToList( Drawable *draw, void *userData )
   }
 
 #if RETAIL_COMPATIBLE_BUG
+	// TheSuperHackers @info
 	// In retail, hidden objects such as passengers are included here when drag-selected, which causes
 	// enemy selection logic to exit early (only 1 enemy unit can be selected at a time). Some players
 	// exploit this bug to determine if a transport contains passengers and consider this an important

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/SelectionInfo.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/SelectionInfo.cpp
@@ -349,6 +349,9 @@ Bool addDrawableToList( Drawable *draw, void *userData )
 	if (!pds->drawableListToFill)
 		return FALSE;
 
+	if (draw->getFullyObscuredByShroud())
+		return FALSE;
+
 	if (draw->isDrawableEffectivelyHidden())
 		return FALSE;
 
@@ -370,23 +373,6 @@ Bool addDrawableToList( Drawable *draw, void *userData )
     else
       return FALSE;
   }
-
-	//Kris: Aug 9, 2003!!! Wow, this bug has been around a LONG time!!
-	//Basically, it was possible to drag select a single enemy/neutral unit even if you couldn't see it
-	//including stealthed units.
-	const Object *obj = draw->getObject();
-	if( obj )
-	{
-		const Player *player = ThePlayerList->getLocalPlayer();
-		Relationship rel = player->getRelationship( obj->getTeam() );
-		if( rel == NEUTRAL || rel == ENEMIES )
-		{
-			if( obj->getShroudedStatus( player->getPlayerIndex() ) >= OBJECTSHROUD_FOGGED )
-			{
-				return FALSE;
-			}
-		}
-	}
 
 	pds->drawableListToFill->push_back(draw);
 	return TRUE;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/SelectionInfo.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/SelectionInfo.cpp
@@ -349,6 +349,9 @@ Bool addDrawableToList( Drawable *draw, void *userData )
 	if (!pds->drawableListToFill)
 		return FALSE;
 
+	if (draw->isDrawableEffectivelyHidden())
+		return FALSE;
+
 	if (!draw->getTemplate()->isAnyKindOf(pds->kindofsToMatch))
 		return FALSE;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/SelectionInfo.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/SelectionInfo.cpp
@@ -385,12 +385,6 @@ Bool addDrawableToList( Drawable *draw, void *userData )
 			{
 				return FALSE;
 			}
-
-			//If stealthed, no way!
-			if( obj->testStatus( OBJECT_STATUS_STEALTHED ) && !obj->testStatus( OBJECT_STATUS_DETECTED ) )
-			{
-				return FALSE;
-			}
 		}
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/SelectionInfo.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/SelectionInfo.cpp
@@ -349,11 +349,13 @@ Bool addDrawableToList( Drawable *draw, void *userData )
 	if (!pds->drawableListToFill)
 		return FALSE;
 
+#if !RTS_GENERALS || !RETAIL_COMPATIBLE_BUG
 	if (draw->getFullyObscuredByShroud())
 		return FALSE;
 
 	if (draw->isDrawableEffectivelyHidden())
 		return FALSE;
+#endif
 
 	if (!draw->getTemplate()->isAnyKindOf(pds->kindofsToMatch))
 		return FALSE;
@@ -374,7 +376,7 @@ Bool addDrawableToList( Drawable *draw, void *userData )
       return FALSE;
   }
 
-#if RETAIL_COMPATIBLE_BUG
+#if !RTS_GENERALS && RETAIL_COMPATIBLE_BUG
 	// TheSuperHackers @info
 	// In retail, hidden objects such as passengers are included here when drag-selected, which causes
 	// enemy selection logic to exit early (only 1 enemy unit can be selected at a time). Some players


### PR DESCRIPTION
* Fixes #119
* Fixes #128

This change fixes several user-facing bugs:

- Enemy beacons can no longer be drag-selected
- Stealthed units can now be freely selected during replays / while observing
- Shrouded passengers / occupants of a partially visible open-contain object can no longer be drag-selected
- Singular enemy / neutral transport units containing occupants can now be drag-selected

And a few internal benefits:

- Passengers / occupants are no longer added to the selection info's `DrawableList` via drag-selections (e.g. selecting 10 full Battle Buses now only adds 10 objects to the draw list instead of 80)
- Fewer allocations and conditional branches

The original fix by Kris to prevent drag-selecting stealth / shrouded units was a bit of a complicated band-aid fix that also resulted in stealthed units being unselectable during replays / while observing.