### PR TITLE
refactor: Improve veterancy effect conditions

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -2776,16 +2776,21 @@ void Object::onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel ne
 		body->onVeterancyLevelChanged(oldLevel, newLevel, provideFeedback);
 
 	Bool hideAnimationForStealth = FALSE;
-	if( !isLocallyControlled() &&
-			testStatus( OBJECT_STATUS_STEALTHED ) &&
-			!testStatus( OBJECT_STATUS_DETECTED ) )
-	{
-		hideAnimationForStealth = TRUE;
-	}
+	Bool doAnimation = FALSE;
 
-	Bool doAnimation = ( ! hideAnimationForStealth
-											&& (newLevel > oldLevel)
-											&& ( ! isKindOf(KINDOF_IGNORED_IN_GUI))); //First, we plan to do the animation if the level went up
+	if (provideFeedback)
+	{
+		if( !isLocallyControlled() &&
+				testStatus( OBJECT_STATUS_STEALTHED ) &&
+				!testStatus( OBJECT_STATUS_DETECTED ) )
+		{
+			hideAnimationForStealth = TRUE;
+		}
+
+		doAnimation = ( ! hideAnimationForStealth
+									&& (newLevel > oldLevel)
+									&& ( ! isKindOf(KINDOF_IGNORED_IN_GUI))); //First, we plan to do the animation if the level went up
+	}
 
 	switch (newLevel)
 	{

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -2791,7 +2791,6 @@ void Object::onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel ne
 			clearWeaponBonusCondition(WEAPONBONUSCONDITION_VETERAN);
 			clearWeaponBonusCondition(WEAPONBONUSCONDITION_ELITE);
 			clearWeaponBonusCondition(WEAPONBONUSCONDITION_HERO);
-			doAnimation = FALSE;//... but not if somehow up to Regular
 			break;
 		case LEVEL_VETERAN:
 			setWeaponSetFlag(WEAPONSET_VETERAN);

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -2775,22 +2775,12 @@ void Object::onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel ne
 	if (body)
 		body->onVeterancyLevelChanged(oldLevel, newLevel, provideFeedback);
 
-	Bool hideAnimationForStealth = FALSE;
-	Bool doAnimation = FALSE;
-
-	if (provideFeedback)
-	{
-		if( !isLocallyControlled() &&
-				testStatus( OBJECT_STATUS_STEALTHED ) &&
-				!testStatus( OBJECT_STATUS_DETECTED ) )
-		{
-			hideAnimationForStealth = TRUE;
-		}
-
-		doAnimation = ( ! hideAnimationForStealth
-									&& (newLevel > oldLevel)
-									&& ( ! isKindOf(KINDOF_IGNORED_IN_GUI))); //First, we plan to do the animation if the level went up
-	}
+	Bool doAnimation = provideFeedback
+		&& newLevel > oldLevel
+		&& !isKindOf(KINDOF_IGNORED_IN_GUI)
+		&& (isLocallyControlled()
+			|| !testStatus(OBJECT_STATUS_STEALTHED)
+			|| testStatus(OBJECT_STATUS_DETECTED));
 
 	switch (newLevel)
 	{
@@ -2829,7 +2819,7 @@ void Object::onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel ne
 			break;
 	}
 
-	if( doAnimation && TheGameLogic->getDrawIconUI() && provideFeedback )
+	if( doAnimation && TheGameLogic->getDrawIconUI() )
 	{
 		if( TheAnim2DCollection && TheGlobalData->m_levelGainAnimationName.isEmpty() == FALSE )
 		{

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -2775,13 +2775,6 @@ void Object::onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel ne
 	if (body)
 		body->onVeterancyLevelChanged(oldLevel, newLevel, provideFeedback);
 
-	Bool doAnimation = provideFeedback
-		&& newLevel > oldLevel
-		&& !isKindOf(KINDOF_IGNORED_IN_GUI)
-		&& (isLocallyControlled()
-			|| !testStatus(OBJECT_STATUS_STEALTHED)
-			|| testStatus(OBJECT_STATUS_DETECTED));
-
 	switch (newLevel)
 	{
 		case LEVEL_REGULAR:
@@ -2817,6 +2810,13 @@ void Object::onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel ne
 			setWeaponBonusCondition(WEAPONBONUSCONDITION_HERO);
 			break;
 	}
+
+	Bool doAnimation = provideFeedback
+		&& newLevel > oldLevel
+		&& !isKindOf(KINDOF_IGNORED_IN_GUI)
+		&& (isLocallyControlled()
+			|| !testStatus(OBJECT_STATUS_STEALTHED)
+			|| testStatus(OBJECT_STATUS_DETECTED));
 
 	if( doAnimation && TheGameLogic->getDrawIconUI() )
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -3090,14 +3090,6 @@ void Object::onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel ne
 	if (body)
 		body->onVeterancyLevelChanged( oldLevel, newLevel, provideFeedback );
 
-	Bool doAnimation = provideFeedback
-		&& newLevel > oldLevel
-		&& !isKindOf(KINDOF_IGNORED_IN_GUI)
-		&& (isLocallyControlled()
-			|| !testStatus(OBJECT_STATUS_STEALTHED)
-			|| testStatus(OBJECT_STATUS_DETECTED)
-			|| testStatus(OBJECT_STATUS_DISGUISED));
-
 	switch (newLevel)
 	{
 		case LEVEL_REGULAR:
@@ -3133,6 +3125,14 @@ void Object::onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel ne
 			setWeaponBonusCondition(WEAPONBONUSCONDITION_HERO);
 			break;
 	}
+
+	Bool doAnimation = provideFeedback
+		&& newLevel > oldLevel
+		&& !isKindOf(KINDOF_IGNORED_IN_GUI)
+		&& (isLocallyControlled()
+			|| !testStatus(OBJECT_STATUS_STEALTHED)
+			|| testStatus(OBJECT_STATUS_DETECTED)
+			|| testStatus(OBJECT_STATUS_DISGUISED));
 
 	if( doAnimation && TheGameLogic->getDrawIconUI() )
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -3091,17 +3091,22 @@ void Object::onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel ne
 		body->onVeterancyLevelChanged( oldLevel, newLevel, provideFeedback );
 
 	Bool hideAnimationForStealth = FALSE;
-	if( !isLocallyControlled() &&
-			testStatus( OBJECT_STATUS_STEALTHED ) &&
-			!testStatus( OBJECT_STATUS_DETECTED ) &&
-			!testStatus( OBJECT_STATUS_DISGUISED ) )
-	{
-		hideAnimationForStealth = TRUE;
-	}
+	Bool doAnimation = FALSE;
 
-	Bool doAnimation = ( ! hideAnimationForStealth
-											&& (newLevel > oldLevel)
-											&& ( ! isKindOf(KINDOF_IGNORED_IN_GUI))); //First, we plan to do the animation if the level went up
+	if (provideFeedback)
+	{
+		if( !isLocallyControlled() &&
+				testStatus( OBJECT_STATUS_STEALTHED ) &&
+				!testStatus( OBJECT_STATUS_DETECTED ) &&
+				!testStatus( OBJECT_STATUS_DISGUISED ) )
+		{
+			hideAnimationForStealth = TRUE;
+		}
+
+		doAnimation = ( ! hideAnimationForStealth
+									&& (newLevel > oldLevel)
+									&& ( ! isKindOf(KINDOF_IGNORED_IN_GUI))); //First, we plan to do the animation if the level went up
+	}
 
 	switch (newLevel)
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -3090,23 +3090,13 @@ void Object::onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel ne
 	if (body)
 		body->onVeterancyLevelChanged( oldLevel, newLevel, provideFeedback );
 
-	Bool hideAnimationForStealth = FALSE;
-	Bool doAnimation = FALSE;
-
-	if (provideFeedback)
-	{
-		if( !isLocallyControlled() &&
-				testStatus( OBJECT_STATUS_STEALTHED ) &&
-				!testStatus( OBJECT_STATUS_DETECTED ) &&
-				!testStatus( OBJECT_STATUS_DISGUISED ) )
-		{
-			hideAnimationForStealth = TRUE;
-		}
-
-		doAnimation = ( ! hideAnimationForStealth
-									&& (newLevel > oldLevel)
-									&& ( ! isKindOf(KINDOF_IGNORED_IN_GUI))); //First, we plan to do the animation if the level went up
-	}
+	Bool doAnimation = provideFeedback
+		&& newLevel > oldLevel
+		&& !isKindOf(KINDOF_IGNORED_IN_GUI)
+		&& (isLocallyControlled()
+			|| !testStatus(OBJECT_STATUS_STEALTHED)
+			|| testStatus(OBJECT_STATUS_DETECTED)
+			|| testStatus(OBJECT_STATUS_DISGUISED));
 
 	switch (newLevel)
 	{
@@ -3145,7 +3135,7 @@ void Object::onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel ne
 			break;
 	}
 
-	if( doAnimation && TheGameLogic->getDrawIconUI() && provideFeedback )
+	if( doAnimation && TheGameLogic->getDrawIconUI() )
 	{
 		if( TheAnim2DCollection && TheGlobalData->m_levelGainAnimationName.isEmpty() == FALSE )
 		{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -3107,7 +3107,6 @@ void Object::onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel ne
 			clearWeaponBonusCondition(WEAPONBONUSCONDITION_VETERAN);
 			clearWeaponBonusCondition(WEAPONBONUSCONDITION_ELITE);
 			clearWeaponBonusCondition(WEAPONBONUSCONDITION_HERO);
-			doAnimation = FALSE;//... but not if somehow up to Regular
 			break;
 		case LEVEL_VETERAN:
 			setWeaponSetFlag(WEAPONSET_VETERAN);


### PR DESCRIPTION
Follow-up to #1455 and #1458. Condenses three separate bools into a single condition block and avoids unnecessary checks if `provideFeedback` is false.