### PR TITLE
tweak(font): Redesign and fix the font scaling for large resolutions and non 4:3 aspect ratios

### DIFF
--- a/Core/GameEngine/Include/Common/GameDefines.h
+++ b/Core/GameEngine/Include/Common/GameDefines.h
@@ -67,3 +67,8 @@
 #define USE_OBSOLETE_GENERALS_CODE (1)
 #endif
 #endif
+
+#define MIN_DISPLAY_BIT_DEPTH       16
+#define DEFAULT_DISPLAY_BIT_DEPTH   32
+#define DEFAULT_DISPLAY_WIDTH      800 // The standard resolution this game was designed for
+#define DEFAULT_DISPLAY_HEIGHT     600 // The standard resolution this game was designed for

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -619,8 +619,8 @@ GlobalData::GlobalData()
 	m_chipSetType = 0;
 	m_headless = FALSE;
 	m_windowed = 0;
-	m_xResolution = 800;
-	m_yResolution = 600;
+	m_xResolution = DEFAULT_DISPLAY_WIDTH;
+	m_yResolution = DEFAULT_DISPLAY_HEIGHT;
 	m_maxShellScreens = 0;
 	m_useCloudMap = FALSE;
 	m_use3WayTerrainBlends = 1;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarResizer.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarResizer.cpp
@@ -180,8 +180,8 @@ void ControlBarResizer::sizeWindowsAlt( void )
 {
 	ResizerWindowList::iterator it = m_resizerWindowsList.begin();
 	GameWindow *win = NULL;
-	Real x = (Real)TheDisplay->getWidth() / 800;
-	Real y = (Real)TheDisplay->getHeight() / 600;
+	Real x = (Real)TheDisplay->getWidth() / DEFAULT_DISPLAY_WIDTH;
+	Real y = (Real)TheDisplay->getHeight() / DEFAULT_DISPLAY_HEIGHT;
 	while (it != m_resizerWindowsList.end())
 	{
 		ResizerWindow *rWin = *it;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -880,7 +880,7 @@ static void setDefaults( void )
 		for( Int i = 0; i < numResolutions; ++i )
 		{	Int xres,yres,bitDepth;
 			TheDisplay->getDisplayModeDescription(i,&xres,&yres,&bitDepth);
-			if (xres == 800 && yres == 600)	//keep track of default mode in case we need it.
+			if (xres == DEFAULT_DISPLAY_WIDTH && yres == DEFAULT_DISPLAY_HEIGHT)	//keep track of default mode in case we need it.
 			{	defaultResIndex=i;
 				break;
 			}
@@ -1715,12 +1715,15 @@ void OptionsMenuInit( WindowLayout *layout, void *userData )
 
 	// get resolution from saved preferences file
 	AsciiString selectedResolution = (*pref) ["Resolution"];
-	Int selectedXRes=800,selectedYRes=600;
+	Int selectedXRes=DEFAULT_DISPLAY_WIDTH;
+	Int selectedYRes=DEFAULT_DISPLAY_HEIGHT;
 	Int selectedResIndex=-1;
 	if (!selectedResolution.isEmpty())
 	{	//try to parse 2 integers out of string
 		if (sscanf(selectedResolution.str(),"%d%d", &selectedXRes, &selectedYRes) != 2)
-		{	selectedXRes=800; selectedYRes=600;
+		{
+			selectedXRes=DEFAULT_DISPLAY_WIDTH;
+			selectedYRes=DEFAULT_DISPLAY_HEIGHT;
 		}
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupPlayerInfo.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/PopupPlayerInfo.cpp
@@ -468,8 +468,8 @@ void ResetBattleHonorInsertion(void)
 }
 void InsertBattleHonor(GameWindow *list, const Image *image, Bool enabled, Int itemData, Int& row, Int& column, UnicodeString text = UnicodeString::TheEmptyString, Int extra = 0)
 {
-	Int width = MAX_BATTLE_HONOR_IMAGE_WIDTH * (TheDisplay->getWidth() / 800.0f);
-	Int height = MAX_BATTLE_HONOR_IMAGE_HEIGHT * (TheDisplay->getHeight() / 600.0f);
+	Int width = MAX_BATTLE_HONOR_IMAGE_WIDTH * (TheDisplay->getWidth() / (Real)DEFAULT_DISPLAY_WIDTH);
+	Int height = MAX_BATTLE_HONOR_IMAGE_HEIGHT * (TheDisplay->getHeight() / (Real)DEFAULT_DISPLAY_HEIGHT);
 
 	static Int enabledColor = 0xFFFFFFFF;
 	static Int disabledColor = GameMakeColor(80, 80, 80, 255);

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLWelcomeMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLWelcomeMenu.cpp
@@ -829,7 +829,7 @@ WindowMsgHandledType WOLWelcomeMenuSystem( GameWindow *window, UnsignedInt msg,
 				else if (controlID == buttonQuickMatchID)
 				{
 					GameSpyMiscPreferences mPref;
-					if ((TheDisplay->getWidth() != 800 || TheDisplay->getHeight() != 600) && mPref.getQuickMatchResLocked())
+					if ((TheDisplay->getWidth() != DEFAULT_DISPLAY_WIDTH || TheDisplay->getHeight() != DEFAULT_DISPLAY_HEIGHT) && mPref.getQuickMatchResLocked())
 					{
 						GSMessageBoxOk(TheGameText->fetch("GUI:GSErrorTitle"), TheGameText->fetch("GUI:QuickMatch800x600"));
 					}

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GlobalLanguage.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GlobalLanguage.cpp
@@ -52,10 +52,12 @@
 //-----------------------------------------------------------------------------
 #include "PreRTS.h"
 
+#include "Common/FileSystem.h"
 #include "Common/INI.h"
 #include "Common/Registry.h"
+
+#include "GameClient/Display.h"
 #include "GameClient/GlobalLanguage.h"
-#include "Common/FileSystem.h"
 
 //-----------------------------------------------------------------------------
 // DEFINES ////////////////////////////////////////////////////////////////////
@@ -191,10 +193,34 @@ void GlobalLanguage::parseFontFileName( INI *ini, void * instance, void *store, 
 
 Int GlobalLanguage::adjustFontSize(Int theFontSize)
 {
-	Real adjustFactor = TheGlobalData->m_xResolution/800.0f;
+	// TheSuperHackers @tweak xezon 16/08/2025 The size adjustment now also weighs in
+	// the display height for a balanced rescale on non 4:3 resolutions.
+	// The aspect ratio scaling is clamped between 1 and 2 to avoid oversizing.
+	// The scaler no longer clamps at max 2, which makes it work properly for
+	// 4k Resolutions and beyond.
+
+	Real w = TheDisplay->getWidth();
+	Real h = TheDisplay->getHeight();
+	const Real aspect = w / h;
+	Real wScale = w / DEFAULT_DISPLAY_WIDTH;
+	Real hScale = h / DEFAULT_DISPLAY_HEIGHT;
+
+	if (aspect > 2.0f)
+	{
+		// Recompute width at aspect=2
+		w = 2.0f * h;
+		wScale = w / DEFAULT_DISPLAY_WIDTH;
+	}
+	else if (aspect < 1.0f)
+	{
+		// Recompute height at aspect=1
+		h = 1.0f * w;
+		hScale = h / DEFAULT_DISPLAY_HEIGHT;
+	}
+
+	Real adjustFactor = (wScale + hScale) * 0.5f;
 	adjustFactor = 1.0f + (adjustFactor-1.0f) * m_resolutionFontSizeAdjustment;
-	if (adjustFactor<1.0f) adjustFactor = 1.0f;
-	if (adjustFactor>2.0f) adjustFactor = 2.0f;
+	if (adjustFactor < 1.0f) adjustFactor = 1.0f;
 	Int pointSize = REAL_TO_INT_FLOOR(theFontSize*adjustFactor);
 	return pointSize;
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -4183,8 +4183,8 @@ void InGameUI::militarySubtitle( const AsciiString& label, Int duration )
 
 	// calculate where this screen position should be since the position being passed in is based off 8x6
 	Coord2D multiplier;
-	multiplier.x = (float)TheDisplay->getWidth() / 800.0f;
-	multiplier.y = (float)TheDisplay->getHeight() / 600.0f;
+	multiplier.x = (Real)TheDisplay->getWidth() / (Real)DEFAULT_DISPLAY_WIDTH;
+	multiplier.y = (Real)TheDisplay->getHeight() / (Real)DEFAULT_DISPLAY_HEIGHT;
 
 	// lets bring out the data structure!
 	m_militarySubtitle = NEW MilitarySubtitleData;

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -111,10 +111,6 @@ static void drawFramerateBar(void);
 
 
 // DEFINE AND ENUMS ///////////////////////////////////////////////////////////
-#define DEFAULT_DISPLAY_BIT_DEPTH 32
-#define MIN_DISPLAY_BIT_DEPTH 16
-#define MIN_DISPLAY_RESOLUTION_X 800
-#define MIN_DISPLAY_RESOLUTION_Y 600
 
 #define no_SAMPLE_DYNAMIC_LIGHT	1
 #ifdef SAMPLE_DYNAMIC_LIGHT
@@ -481,7 +477,7 @@ inline Bool isResolutionSupported(const ResolutionDescClass &res)
 {
 	static const Int minBitDepth = 24;
 
-	return res.Width >= MIN_DISPLAY_RESOLUTION_X && res.BitDepth >= minBitDepth;
+	return res.Width >= DEFAULT_DISPLAY_WIDTH && res.BitDepth >= minBitDepth;
 }
 
 /*Return number of screen modes supported by the current device*/
@@ -751,15 +747,15 @@ void W3DDisplay::init( void )
 				// if the custom resolution did not succeed. This is unlikely to happen but is possible
 				// if the user writes an unsupported resolution in the Option Preferences or if the
 				// graphics adapter does not support the minimum display resolution to begin with.
-				Int xres = MIN_DISPLAY_RESOLUTION_X;
-				Int yres = MIN_DISPLAY_RESOLUTION_Y;
+				Int xres = DEFAULT_DISPLAY_WIDTH;
+				Int yres = DEFAULT_DISPLAY_HEIGHT;
 				Int bitDepth = DEFAULT_DISPLAY_BIT_DEPTH;
 				Int displayModeCount = getDisplayModeCount();
 				Int displayModeIndex = 0;
 				for (; displayModeIndex < displayModeCount; ++displayModeIndex)
 				{
 					getDisplayModeDescription(displayModeIndex, &xres, &yres, &bitDepth);
-					if (xres * yres >= MIN_DISPLAY_RESOLUTION_X * MIN_DISPLAY_RESOLUTION_Y)
+					if (xres * yres >= DEFAULT_DISPLAY_WIDTH * DEFAULT_DISPLAY_HEIGHT)
 						break; // Is good enough. Use it.
 				}
 				TheWritableGlobalData->m_xResolution = xres;

--- a/GeneralsMD/Code/Main/WinMain.cpp
+++ b/GeneralsMD/Code/Main/WinMain.cpp
@@ -79,9 +79,6 @@ const Char *g_strFile = "data\\Generals.str";
 const Char *g_csfFile = "data\\%s\\Generals.csf";
 const char *gAppPrefix = ""; /// So WB can have a different debug log file name.
 
-#define DEFAULT_XRESOLUTION 800
-#define DEFAULT_YRESOLUTION 600
-
 static Bool gInitializing = false;
 static Bool gDoPaint = true;
 static Bool isWinMainActive = false;
@@ -601,7 +598,7 @@ LRESULT CALLBACK WndProc( HWND hWnd, UINT message,
 						Int savContext = ::SaveDC(dc);
 						HDC tmpDC = ::CreateCompatibleDC(dc);
 						HBITMAP savBitmap = (HBITMAP)::SelectObject(tmpDC, gLoadScreenBitmap);
-						::BitBlt(dc, 0, 0, DEFAULT_XRESOLUTION, DEFAULT_YRESOLUTION, tmpDC, 0, 0, SRCCOPY);
+						::BitBlt(dc, 0, 0, DEFAULT_DISPLAY_WIDTH, DEFAULT_DISPLAY_HEIGHT, tmpDC, 0, 0, SRCCOPY);
 						::SelectObject(tmpDC, savBitmap);
 						::DeleteDC(tmpDC);
 						::RestoreDC(dc, savContext);
@@ -683,8 +680,8 @@ LRESULT CALLBACK WndProc( HWND hWnd, UINT message,
 static Bool initializeAppWindows( HINSTANCE hInstance, Int nCmdShow, Bool runWindowed )
 {
 	DWORD windowStyle;
-	Int startWidth = DEFAULT_XRESOLUTION,
-			startHeight = DEFAULT_YRESOLUTION;
+	Int startWidth = DEFAULT_DISPLAY_WIDTH,
+			startHeight = DEFAULT_DISPLAY_HEIGHT;
 
 	// register the window class
 
@@ -710,8 +707,8 @@ static Bool initializeAppWindows( HINSTANCE hInstance, Int nCmdShow, Bool runWin
 	AdjustWindowRect (&rect, windowStyle, FALSE);
 	if (runWindowed) {
 		// Makes the normal debug 800x600 window center in the screen.
-		startWidth = DEFAULT_XRESOLUTION;
-		startHeight= DEFAULT_YRESOLUTION;
+		startWidth = DEFAULT_DISPLAY_WIDTH;
+		startHeight= DEFAULT_DISPLAY_HEIGHT;
 	}
 
 	gInitializing = true;


### PR DESCRIPTION
* Merge after #1465
* Closes #1442
* Fixes #107
* Fixes #875

This change is an alternative implementation for #1442.

The disadvantage of #1442 is that the proposed new font scaling for 1920 x 1080 is noticably smaller than the original font scaling: 21%. This is an inconvenience, because 1920 x 1080 and other 16:9 resolutions are the most popular resolutions to play with and their font scales are generally ok.

With this change, the font scaling is redesigned to scale better in different resolutions and aspect ratios. In 1920x1080 the font size will be just 11% smaller than originally.

| Resolution         | Original factor | #1442 factor  | This change factor |
|--------------------|-----------------|---------------|--------------------|
|  800 x  600 (4:3)  | 1.00            | 1.00          | 1.00               |
| 1600 x 1200 (4:3)  | 1.70            | 1.70          | 1.70               |
| 1920 x 1080 (16:9) | 1.98            | 1.56          | 1.77               |
| 3840 x 2160 (16:9) | 2.00 (capped)   | 2.00 (capped) | 3.24               |

Additionally, the maximum scale limit is removed, which makes the font look prettier in 4k Resolution and beyond.

## TODO

- [ ] Replicate in Generals