### PR TITLE
bugfix(input): Prevent mouse wheel from stopping camera scrolling

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
@@ -377,6 +377,8 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 				for ( ;spin < 0; spin++ )
 					TheTacticalView->zoomOut();
 			}
+
+			break;
 		}
 
 		//-----------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
@@ -376,6 +376,8 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 				for ( ;spin < 0; spin++ )
 					TheTacticalView->zoomOut();
 			}
+
+			break;
 		}
 
 		//-----------------------------------------------------------------------------


### PR DESCRIPTION
Spinning the mouse wheel to zoom the camera in / out no longer stops any active camera scrolling.