### PR TITLE
tweak(input): Remove input latency for group creation in multiplayer games

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/Player.h
+++ b/Generals/Code/GameEngine/Include/Common/Player.h
@@ -603,7 +603,7 @@ public:
 	ScoreKeeper* getScoreKeeper( void ) { return &m_scoreKeeper; }
 
 	/// time to create a hotkey team based on this GameMessage
-	void processCreateTeamGameMessage(Int hotkeyNum, GameMessage *msg);
+	void processCreateTeamGameMessage(Int hotkeyNum, const GameMessage *msg);
 
 	/// time to select a hotkey team based on this GameMessage
 	void processSelectTeamGameMessage(Int hotkeyNum, GameMessage *msg);

--- a/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -3181,7 +3181,7 @@ void Player::applyBattlePlanBonusesForPlayerObjects( const BattlePlanBonuses *bo
 //-------------------------------------------------------------------------------------------------
 /** Create a hotkey team based on this GameMessage */
 //-------------------------------------------------------------------------------------------------
-void Player::processCreateTeamGameMessage(Int hotkeyNum, GameMessage *msg) {
+void Player::processCreateTeamGameMessage(Int hotkeyNum, const GameMessage *msg) {
 	// GameMessage arguments are the object ID's of the objects that are to be in this team.
 
 	if ((hotkeyNum < 0) || (hotkeyNum >= NUM_HOTKEY_SQUADS)) {

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -3281,7 +3281,11 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 		case GameMessage::MSG_CREATE_TEAM8:
 		case GameMessage::MSG_CREATE_TEAM9:
 		{
-			ThePlayerList->getLocalPlayer()->processCreateTeamGameMessage(t - GameMessage::MSG_CREATE_TEAM0, msg);
+			Int playerIndex = msg->getPlayerIndex();
+			Player* player = ThePlayerList->getNthPlayer(playerIndex);
+			if (player->isLocalPlayer())
+				player->processCreateTeamGameMessage(t - GameMessage::MSG_CREATE_TEAM0, msg);
+
 			break;
 		}
 

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -3270,6 +3270,22 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 		}
 
 		// --------------------------------------------------------------------------------------------
+		case GameMessage::MSG_CREATE_TEAM0:
+		case GameMessage::MSG_CREATE_TEAM1:
+		case GameMessage::MSG_CREATE_TEAM2:
+		case GameMessage::MSG_CREATE_TEAM3:
+		case GameMessage::MSG_CREATE_TEAM4:
+		case GameMessage::MSG_CREATE_TEAM5:
+		case GameMessage::MSG_CREATE_TEAM6:
+		case GameMessage::MSG_CREATE_TEAM7:
+		case GameMessage::MSG_CREATE_TEAM8:
+		case GameMessage::MSG_CREATE_TEAM9:
+		{
+			ThePlayerList->getLocalPlayer()->processCreateTeamGameMessage(t - GameMessage::MSG_CREATE_TEAM0, msg);
+			break;
+		}
+
+		// --------------------------------------------------------------------------------------------
 		case GameMessage::MSG_CREATE_SELECTED_GROUP:
 		case GameMessage::MSG_SELECT_TEAM0:
 		case GameMessage::MSG_SELECT_TEAM1:

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -3283,7 +3283,7 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 		{
 			Int playerIndex = msg->getPlayerIndex();
 			Player* player = ThePlayerList->getNthPlayer(playerIndex);
-			if (player->isLocalPlayer())
+			if (player && player->isLocalPlayer())
 				player->processCreateTeamGameMessage(t - GameMessage::MSG_CREATE_TEAM0, msg);
 
 			break;

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -1901,16 +1901,10 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Player *player = ThePlayerList->getNthPlayer(playerIndex);
 			DEBUG_ASSERTCRASH(player != NULL, ("Could not find player for create team message"));
 
-			if (player == NULL)
-			{
-				break;
-			}
-
 			// TheSuperHackers @tweak Stubbjax 17/08/2025 The local player processes this message in CommandXlat for immediate assignment.
-			if (player->isLocalPlayer())
-				break;
+			if (player && !player->isLocalPlayer())
+				player->processCreateTeamGameMessage(msg->getType() - GameMessage::MSG_CREATE_TEAM0, msg);
 
-			player->processCreateTeamGameMessage(msg->getType() - GameMessage::MSG_CREATE_TEAM0, msg);
 			break;
 		} // end create team command
 

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -1906,6 +1906,10 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 				break;
 			}
 
+			// TheSuperHackers @tweak Stubbjax 17/08/2025 The local player processes this message in CommandXlat for immediate assignment.
+			if (player->isLocalPlayer())
+				break;
+
 			player->processCreateTeamGameMessage(msg->getType() - GameMessage::MSG_CREATE_TEAM0, msg);
 			break;
 		} // end create team command

--- a/GeneralsMD/Code/GameEngine/Include/Common/Player.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Player.h
@@ -629,7 +629,7 @@ public:
 	ScoreKeeper* getScoreKeeper( void ) { return &m_scoreKeeper; }
 
 	/// time to create a hotkey team based on this GameMessage
-	void processCreateTeamGameMessage(Int hotkeyNum, GameMessage *msg);
+	void processCreateTeamGameMessage(Int hotkeyNum, const GameMessage *msg);
 
 	/// time to select a hotkey team based on this GameMessage
 	void processSelectTeamGameMessage(Int hotkeyNum, GameMessage *msg);

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -3682,7 +3682,7 @@ void Player::applyBattlePlanBonusesForPlayerObjects( const BattlePlanBonuses *bo
 //-------------------------------------------------------------------------------------------------
 /** Create a hotkey team based on this GameMessage */
 //-------------------------------------------------------------------------------------------------
-void Player::processCreateTeamGameMessage(Int hotkeyNum, GameMessage *msg) {
+void Player::processCreateTeamGameMessage(Int hotkeyNum, const GameMessage *msg) {
 	// GameMessage arguments are the object ID's of the objects that are to be in this team.
 
 	if ((hotkeyNum < 0) || (hotkeyNum >= NUM_HOTKEY_SQUADS)) {

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -3622,7 +3622,11 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 		case GameMessage::MSG_CREATE_TEAM8:
 		case GameMessage::MSG_CREATE_TEAM9:
 		{
-			ThePlayerList->getLocalPlayer()->processCreateTeamGameMessage(t - GameMessage::MSG_CREATE_TEAM0, msg);
+			Int playerIndex = msg->getPlayerIndex();
+			Player* player = ThePlayerList->getNthPlayer(playerIndex);
+			if (player->isLocalPlayer())
+				player->processCreateTeamGameMessage(t - GameMessage::MSG_CREATE_TEAM0, msg);
+
 			break;
 		}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -3624,7 +3624,7 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 		{
 			Int playerIndex = msg->getPlayerIndex();
 			Player* player = ThePlayerList->getNthPlayer(playerIndex);
-			if (player->isLocalPlayer())
+			if (player && player->isLocalPlayer())
 				player->processCreateTeamGameMessage(t - GameMessage::MSG_CREATE_TEAM0, msg);
 
 			break;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -3611,6 +3611,22 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 		}
 
 		// --------------------------------------------------------------------------------------------
+		case GameMessage::MSG_CREATE_TEAM0:
+		case GameMessage::MSG_CREATE_TEAM1:
+		case GameMessage::MSG_CREATE_TEAM2:
+		case GameMessage::MSG_CREATE_TEAM3:
+		case GameMessage::MSG_CREATE_TEAM4:
+		case GameMessage::MSG_CREATE_TEAM5:
+		case GameMessage::MSG_CREATE_TEAM6:
+		case GameMessage::MSG_CREATE_TEAM7:
+		case GameMessage::MSG_CREATE_TEAM8:
+		case GameMessage::MSG_CREATE_TEAM9:
+		{
+			ThePlayerList->getLocalPlayer()->processCreateTeamGameMessage(t - GameMessage::MSG_CREATE_TEAM0, msg);
+			break;
+		}
+
+		// --------------------------------------------------------------------------------------------
 		case GameMessage::MSG_CREATE_SELECTED_GROUP:
 		case GameMessage::MSG_SELECT_TEAM0:
 		case GameMessage::MSG_SELECT_TEAM1:

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -1934,6 +1934,10 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 				break;
 			}
 
+			// TheSuperHackers @tweak Stubbjax 17/08/2025 The local player processes this message in CommandXlat for immediate assignment.
+			if (player->isLocalPlayer())
+				break;
+
 			player->processCreateTeamGameMessage(msg->getType() - GameMessage::MSG_CREATE_TEAM0, msg);
 			break;
 		} // end create team command

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -1929,16 +1929,10 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Player *player = ThePlayerList->getNthPlayer(playerIndex);
 			DEBUG_ASSERTCRASH(player != NULL, ("Could not find player for create team message"));
 
-			if (player == NULL)
-			{
-				break;
-			}
-
 			// TheSuperHackers @tweak Stubbjax 17/08/2025 The local player processes this message in CommandXlat for immediate assignment.
-			if (player->isLocalPlayer())
-				break;
+			if (player && !player->isLocalPlayer())
+				player->processCreateTeamGameMessage(msg->getType() - GameMessage::MSG_CREATE_TEAM0, msg);
 
-			player->processCreateTeamGameMessage(msg->getType() - GameMessage::MSG_CREATE_TEAM0, msg);
 			break;
 		} // end create team command
 


### PR DESCRIPTION
The local player no longer has to wait for their group assignment commands to be processed by `GameLogicDispatch`, which is typically 10 - 64 logic frames after sending the command in multiplayer games. They are instead now immediately processed by `CommandXlat` for the local player.

This change makes gameplay feel smoother and more responsive. It has no effect on the synchronicity of multiplayer games.