### PR TITLE
feat: Add ability to snap building rotation to 45 degree angles

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -1415,6 +1415,13 @@ void InGameUI::handleBuildPlacements( void )
 				v.y = worldEnd.y - worldStart.y;
 				angle = v.toAngle();
 
+				// Use force attack mode to control snapping for convenience
+				if (isInForceAttackMode())
+				{
+					// TheSuperHackers @tweak Stubbjax 04/08/2025 Snap angle to nearest 45 degrees (pi/4 radians)
+					const Real snapRadians = PI / 4.0f;
+					angle = floor((angle / snapRadians) + 0.5f) * snapRadians;
+				}
 			}  // end if
 
 		}  // end if

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -1470,6 +1470,13 @@ void InGameUI::handleBuildPlacements( void )
 				v.y = worldEnd.y - worldStart.y;
 				angle = v.toAngle();
 
+				// Use force attack mode to control snapping for convenience
+				if (isInForceAttackMode())
+				{
+					// TheSuperHackers @tweak Stubbjax 04/08/2025 Snap angle to nearest 45 degrees (pi/4 radians)
+					const Real snapRadians = PI / 4.0f;
+					angle = floor((angle / snapRadians) + 0.5f) * snapRadians;
+				}
 			}  // end if
 
 		}  // end if


### PR DESCRIPTION
This change adds the ability to snap building rotation to 45 degree angles while holding the force-attack modifier key. This can be used to help improve the look / layout of some bases.

https://github.com/user-attachments/assets/b6f604f3-5d77-4189-9040-75aefaaf7222

A configurable snapping angle may be introduced in a second-pass if desired.