### PR TITLE
refactor(controlbar): Simplify code for acquiring the currently viewed player

### DIFF
--- a/Generals/Code/GameEngine/Include/GameClient/ControlBar.h
+++ b/Generals/Code/GameEngine/Include/GameClient/ControlBar.h
@@ -731,6 +731,9 @@ public:
 	void populateObserverList( void );
 	Bool isObserverControlBarOn( void ) { return m_isObserverCommandBar;}
 
+	/// Returns the currently viewed player. May return NULL if no player is selected while observing.
+	Player* getCurrentlyViewedPlayer();
+
 //	ControlBarResizer *getControlBarResizer( void ) {return m_controlBarResizer;}
 
 	// Functions for repositioning/resizing the control bar

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -157,6 +157,13 @@ void ControlBar::markUIDirty( void )
 #endif
 }
 
+Player* ControlBar::getCurrentlyViewedPlayer()
+{
+	if (TheControlBar->isObserverControlBarOn())
+		return TheControlBar->getObserverLookAtPlayer();
+
+	return ThePlayerList->getLocalPlayer();
+}
 
 void ControlBar::populatePurchaseScience( Player* player )
 {

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/ControlBarPopupDescription.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/ControlBarPopupDescription.cpp
@@ -518,11 +518,7 @@ void ControlBar::populateBuildTooltipLayout( const CommandButton *commandButton,
 			name = TheGameText->fetch("CONTROLBAR:Power");
 			descrip = TheGameText->fetch("CONTROLBAR:PowerDescription");
 
-			Player *playerToDisplay = NULL;
-			if(TheControlBar->isObserverControlBarOn())
-				playerToDisplay = TheControlBar->getObserverLookAtPlayer();
-			else
-				playerToDisplay = ThePlayerList->getLocalPlayer();
+			Player* playerToDisplay = TheControlBar->getCurrentlyViewedPlayer();
 
 			if( playerToDisplay && playerToDisplay->getEnergy() )
 			{

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -1786,11 +1786,7 @@ void InGameUI::update( void )
 //		moneyWin = TheWindowManager->winGetWindowFromId( NULL, moneyWindowKey );
 //
 //	}  // end if
-	Player *moneyPlayer = NULL;
-	if( TheControlBar->isObserverControlBarOn())
-		moneyPlayer = TheControlBar->getObserverLookAtPlayer();
-	else
-		moneyPlayer = ThePlayerList->getLocalPlayer();
+	Player* moneyPlayer = TheControlBar->getCurrentlyViewedPlayer();
 	if( moneyPlayer)
 	{
 		Int currentMoney = moneyPlayer->getMoney()->countMoney();

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/GUICallbacks/W3DControlBar.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/GUICallbacks/W3DControlBar.cpp
@@ -125,15 +125,7 @@ void W3DPowerDraw( GameWindow *window, WinInstanceData *instData )
 	//const Image *beginBar = NULL;
 	const Image *centerBar = NULL;
 	static const Image *slider = TheMappedImageCollection->findImageByName("PowerBarSlider");
-	Player *player = NULL;
-	if(TheControlBar->isObserverControlBarOn())
-	{
-		player = TheControlBar->getObserverLookAtPlayer();
-	}
-	else
-		player = ThePlayerList->getLocalPlayer();
-
-
+	Player* player = TheControlBar->getCurrentlyViewedPlayer();
 
 	if(!player || !TheGlobalData)
 		return;
@@ -292,15 +284,7 @@ void W3DPowerDrawA( GameWindow *window, WinInstanceData *instData )
 	const Image *beginBar = NULL;
 	const Image *centerBar = NULL;
 	static const Image *slider = TheMappedImageCollection->findImageByName("PowerBarSlider");
-	Player *player = NULL;
-	if(TheControlBar->isObserverControlBarOn())
-	{
-		player = TheControlBar->getObserverLookAtPlayer();
-	}
-	else
-		player = ThePlayerList->getLocalPlayer();
-
-
+	Player* player = TheControlBar->getCurrentlyViewedPlayer();
 
 	if(!player || !TheGlobalData)
 		return;
@@ -486,13 +470,8 @@ void W3DCommandBarGridDraw( GameWindow *window, WinInstanceData *instData )
 
 void W3DCommandBarGenExpDraw( GameWindow *window, WinInstanceData *instData )
 {
-	Player* player = NULL;
-
 	// TheSuperHackers @bugfix Stubbjax 08/08/2025 Show the experience bar for observers
-	if (TheControlBar->isObserverControlBarOn())
-		player = TheControlBar->getObserverLookAtPlayer();
-	else
-		player = ThePlayerList->getLocalPlayer();
+	Player* player = TheControlBar->getCurrentlyViewedPlayer();
 
 	if (!player)
 		return;

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/ControlBar.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/ControlBar.h
@@ -745,6 +745,9 @@ public:
 	void populateObserverList( void );
 	Bool isObserverControlBarOn( void ) { return m_isObserverCommandBar;}
 
+	/// Returns the currently viewed player. May return NULL if no player is selected while observing.
+	Player* getCurrentlyViewedPlayer();
+
 //	ControlBarResizer *getControlBarResizer( void ) {return m_controlBarResizer;}
 
 	// Functions for repositioning/resizing the control bar

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -158,6 +158,13 @@ void ControlBar::markUIDirty( void )
 #endif
 }
 
+Player* ControlBar::getCurrentlyViewedPlayer()
+{
+	if (TheControlBar->isObserverControlBarOn())
+		return TheControlBar->getObserverLookAtPlayer();
+
+	return ThePlayerList->getLocalPlayer();
+}
 
 void ControlBar::populatePurchaseScience( Player* player )
 {

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/ControlBarPopupDescription.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/ControlBarPopupDescription.cpp
@@ -567,11 +567,7 @@ void ControlBar::populateBuildTooltipLayout( const CommandButton *commandButton,
 			name = TheGameText->fetch("CONTROLBAR:Power");
 			descrip = TheGameText->fetch("CONTROLBAR:PowerDescription");
 
-			Player *playerToDisplay = NULL;
-			if(TheControlBar->isObserverControlBarOn())
-				playerToDisplay = TheControlBar->getObserverLookAtPlayer();
-			else
-				playerToDisplay = ThePlayerList->getLocalPlayer();
+			Player* playerToDisplay = TheControlBar->getCurrentlyViewedPlayer();
 
 			if( playerToDisplay && playerToDisplay->getEnergy() )
 			{

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -1842,11 +1842,7 @@ void InGameUI::update( void )
 //		moneyWin = TheWindowManager->winGetWindowFromId( NULL, moneyWindowKey );
 //
 //	}  // end if
-	Player *moneyPlayer = NULL;
-	if( TheControlBar->isObserverControlBarOn())
-		moneyPlayer = TheControlBar->getObserverLookAtPlayer();
-	else
-		moneyPlayer = ThePlayerList->getLocalPlayer();
+	Player* moneyPlayer = TheControlBar->getCurrentlyViewedPlayer();
 	if( moneyPlayer)
 	{
 		Int currentMoney = moneyPlayer->getMoney()->countMoney();

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/GUICallbacks/W3DControlBar.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/GUICallbacks/W3DControlBar.cpp
@@ -125,15 +125,7 @@ void W3DPowerDraw( GameWindow *window, WinInstanceData *instData )
 	//const Image *beginBar = NULL;
 	const Image *centerBar = NULL;
 	static const Image *slider = TheMappedImageCollection->findImageByName("PowerBarSlider");
-	Player *player = NULL;
-	if(TheControlBar->isObserverControlBarOn())
-	{
-		player = TheControlBar->getObserverLookAtPlayer();
-	}
-	else
-		player = ThePlayerList->getLocalPlayer();
-
-
+	Player* player = TheControlBar->getCurrentlyViewedPlayer();
 
 	if(!player || !TheGlobalData)
 		return;
@@ -292,15 +284,7 @@ void W3DPowerDrawA( GameWindow *window, WinInstanceData *instData )
 	const Image *beginBar = NULL;
 	const Image *centerBar = NULL;
 	static const Image *slider = TheMappedImageCollection->findImageByName("PowerBarSlider");
-	Player *player = NULL;
-	if(TheControlBar->isObserverControlBarOn())
-	{
-		player = TheControlBar->getObserverLookAtPlayer();
-	}
-	else
-		player = ThePlayerList->getLocalPlayer();
-
-
+	Player* player = TheControlBar->getCurrentlyViewedPlayer();
 
 	if(!player || !TheGlobalData)
 		return;
@@ -486,13 +470,8 @@ void W3DCommandBarGridDraw( GameWindow *window, WinInstanceData *instData )
 
 void W3DCommandBarGenExpDraw( GameWindow *window, WinInstanceData *instData )
 {
-	Player* player = NULL;
-
 	// TheSuperHackers @bugfix Stubbjax 08/08/2025 Show the experience bar for observers
-	if (TheControlBar->isObserverControlBarOn())
-		player = TheControlBar->getObserverLookAtPlayer();
-	else
-		player = ThePlayerList->getLocalPlayer();
+	Player* player = TheControlBar->getCurrentlyViewedPlayer();
 
 	if (!player)
 		return;


### PR DESCRIPTION
This change adds a convenience function to the `ControlBar` for acquiring the currently viewed player.