### PR TITLE
bugfix(network): Set SO_REUSEADDR for network socket in multi-instance

### DIFF
--- a/Generals/Code/GameEngine/Source/GameNetwork/udp.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/udp.cpp
@@ -34,6 +34,7 @@
 #include "Common/GameEngine.h"
 //#include "GameNetwork/NetworkInterface.h"
 #include "GameNetwork/udp.h"
+#include "GameClient/ClientInstance.h"
 
 
 //-------------------------------------------------------------------------
@@ -163,6 +164,18 @@ Int UDP::Bind(UnsignedInt IP,UnsignedShort Port)
   #endif
   if (fd==-1)
     return(UNKNOWN);
+
+#if defined (RTS_MULTI_INSTANCE)
+  // set SO_REUSEADDR so multiple instances can bind to the same port
+  const Int val = TRUE;
+  retval = setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (char*)&val, sizeof(Int));
+  if (retval == SOCKET_ERROR)
+  {
+    m_lastError = WSAGetLastError();
+    status = GetStatus();
+    return status;
+  }
+#endif
 
   retval=bind(fd,(struct sockaddr *)&addr,sizeof(addr));
 

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/udp.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/udp.cpp
@@ -34,6 +34,7 @@
 #include "Common/GameEngine.h"
 //#include "GameNetwork/NetworkInterface.h"
 #include "GameNetwork/udp.h"
+#include "GameClient/ClientInstance.h"
 
 
 //-------------------------------------------------------------------------
@@ -163,6 +164,18 @@ Int UDP::Bind(UnsignedInt IP,UnsignedShort Port)
   #endif
   if (fd==-1)
     return(UNKNOWN);
+
+#if defined (RTS_MULTI_INSTANCE)
+  // set SO_REUSEADDR so multiple instances can bind to the same port
+  const Int val = TRUE;
+  retval = setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (char*)&val, sizeof(Int));
+  if (retval == SOCKET_ERROR)
+  {
+    m_lastError = WSAGetLastError();
+    status = GetStatus();
+    return status;
+  }
+#endif
 
   retval=bind(fd,(struct sockaddr *)&addr,sizeof(addr));
 


### PR DESCRIPTION
When launching multiple instances of the game,  an assertion will trigger for all instances except the first one when navigating to the Network menu:

> ASSERTION FAILURE: Could not bind to 0x00000000:8086

This change sets the socket option SO_REUSEADDR to allow multiple instances of the game to bind to the socket, but only when RTS_MULTI_INSTANCE is defined.

Validated by running a multi instance network game.