### PR TITLE
tweak(client): Show additional information for selected objects while observing

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -63,6 +63,7 @@
 #include "GameLogic/Weapon.h"
 
 #include "GameClient/Anim2D.h"
+#include "GameClient/ControlBar.h"
 #include "GameClient/Display.h"
 #include "GameClient/DisplayStringManager.h"
 #include "GameClient/Drawable.h"
@@ -2285,7 +2286,7 @@ Bool Drawable::drawsAnyUIText( void )
 		return FALSE;
 
 	const Object *obj = getObject();
-	if ( !obj || !obj->isLocallyControlled() )
+	if ( !obj || obj->getControllingPlayer() != TheControlBar->getCurrentlyViewedPlayer())
 		return FALSE;
 
 	Player *owner = obj->getControllingPlayer();
@@ -2434,7 +2435,7 @@ void Drawable::drawAmmo( const IRegion2D *healthBarRegion )
 	if (!(
 				TheGlobalData->m_showObjectHealth &&
 				(isSelected() || (TheInGameUI && (TheInGameUI->getMousedOverDrawableID() == getID()))) &&
-				obj->getControllingPlayer() == ThePlayerList->getLocalPlayer()
+				obj->getControllingPlayer() == TheControlBar->getCurrentlyViewedPlayer()
 			))
 		return;
 
@@ -2492,7 +2493,7 @@ void Drawable::drawContained( const IRegion2D *healthBarRegion )
 	if (!(
 				TheGlobalData->m_showObjectHealth &&
 				(isSelected() || (TheInGameUI && (TheInGameUI->getMousedOverDrawableID() == getID()))) &&
-				obj->getControllingPlayer() == ThePlayerList->getLocalPlayer()
+				obj->getControllingPlayer() == TheControlBar->getCurrentlyViewedPlayer()
 			))
 		return;
 
@@ -2965,7 +2966,7 @@ void Drawable::drawBombed(const IRegion2D* healthBarRegion)
 	UnsignedInt now = TheGameLogic->getFrame();
 
 	if( obj->testWeaponSetFlag( WEAPONSET_CARBOMB ) &&
-				obj->getControllingPlayer() == ThePlayerList->getLocalPlayer())
+				obj->getControllingPlayer() == TheControlBar->getCurrentlyViewedPlayer())
 	{
 		if( !getIconInfo()->m_icon[ ICON_CARBOMB ] )
 			getIconInfo()->m_icon[ ICON_CARBOMB ] = newInstance(Anim2D)( s_animationTemplates[ ICON_CARBOMB ], TheAnim2DCollection );

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -1439,17 +1439,11 @@ void ControlBar::update( void )
 		Object* obj = drawToEvaluateFor ? drawToEvaluateFor->getObject() : NULL;
 		setPortraitByObject(obj);
 
-		if (obj && obj->getControllingPlayer() == getCurrentlyViewedPlayer())
-		{
-			ExitInterface* exit = obj->getObjectExitInterface();
-			if (exit)
-				showRallyPoint(exit->getRallyPoint());
-			else
-				showRallyPoint(NULL);
-		}
-		else
-			showRallyPoint(NULL);
+		const Coord3D* exitPosition = NULL;
+		if (obj && obj->getControllingPlayer() == getCurrentlyViewedPlayer() && obj->getObjectExitInterface())
+			exitPosition = obj->getObjectExitInterface()->getRallyPoint();
 
+		showRallyPoint(exitPosition);
 		return;
 	}
 

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -2688,43 +2688,43 @@ void ControlBar::showRallyPoint( const Coord3D *loc )
 		// destroy rally point drawable if present
 		if( m_rallyPointDrawableID != INVALID_DRAWABLE_ID )
 			TheGameClient->destroyDrawable( TheGameClient->findDrawableByID( m_rallyPointDrawableID ) );
+
 		m_rallyPointDrawableID = INVALID_DRAWABLE_ID;
+		return;
+	}
+
+	Drawable *marker = NULL;
+
+	// create a rally point drawble if necessary
+	if( m_rallyPointDrawableID == INVALID_DRAWABLE_ID )
+	{
+		const ThingTemplate* ttn = TheThingFactory->findTemplate("RallyPointMarker");
+		marker = TheThingFactory->newDrawable( ttn );
+		DEBUG_ASSERTCRASH( marker, ("showRallyPoint: Unable to create rally point drawable") );
+		if (marker)
+		{
+			marker->setDrawableStatus(DRAWABLE_STATUS_NO_SAVE);
+			m_rallyPointDrawableID = marker->getID();
+		}
 	}
 	else
+		marker = TheGameClient->findDrawableByID( m_rallyPointDrawableID );
+
+	// sanity
+	DEBUG_ASSERTCRASH( marker, ("showRallyPoint: No rally point marker found" ) );
+
+	// set the position of the rally point drawble to the position passed in
+	marker->setPosition( loc );
+	marker->setOrientation( TheGlobalData->m_downwindAngle );//To blow down wind -- ML
+
+	// set the marker colors to that of the local player
+	Player* player = TheControlBar->getCurrentlyViewedPlayer();
+	if (player)
 	{
-		Drawable *marker = NULL;
-
-		// create a rally point drawble if necessary
-		if( m_rallyPointDrawableID == INVALID_DRAWABLE_ID )
-		{
-			const ThingTemplate* ttn = TheThingFactory->findTemplate("RallyPointMarker");
-			marker = TheThingFactory->newDrawable( ttn );
-			DEBUG_ASSERTCRASH( marker, ("showRallyPoint: Unable to create rally point drawable") );
-			if (marker)
-			{
-				marker->setDrawableStatus(DRAWABLE_STATUS_NO_SAVE);
-				m_rallyPointDrawableID = marker->getID();
-			}
-		}
+		if (TheGlobalData->m_timeOfDay == TIME_OF_DAY_NIGHT)
+			marker->setIndicatorColor(player->getPlayerNightColor());
 		else
-			marker = TheGameClient->findDrawableByID( m_rallyPointDrawableID );
-
-		// sanity
-		DEBUG_ASSERTCRASH( marker, ("showRallyPoint: No rally point marker found" ) );
-
-		// set the position of the rally point drawble to the position passed in
-		marker->setPosition( loc );
-		marker->setOrientation( TheGlobalData->m_downwindAngle );//To blow down wind -- ML
-
-		// set the marker colors to that of the local player
-		Player* player = TheControlBar->getCurrentlyViewedPlayer();
-		if (player)
-		{
-			if (TheGlobalData->m_timeOfDay == TIME_OF_DAY_NIGHT)
-				marker->setIndicatorColor(player->getPlayerNightColor());
-			else
-				marker->setIndicatorColor(player->getPlayerColor());
-		}
+			marker->setIndicatorColor(player->getPlayerColor());
 	}
 }
 

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -2723,13 +2723,13 @@ void ControlBar::showRallyPoint( const Coord3D *loc )
 
 		// set the marker colors to that of the local player
 		Player* player = TheControlBar->getCurrentlyViewedPlayer();
-		if (!player)
-			return;
-
-		if (TheGlobalData->m_timeOfDay == TIME_OF_DAY_NIGHT)
-			marker->setIndicatorColor( player->getPlayerNightColor() );
-		else
-			marker->setIndicatorColor( player->getPlayerColor() );
+		if (player)
+		{
+			if (TheGlobalData->m_timeOfDay == TIME_OF_DAY_NIGHT)
+				marker->setIndicatorColor(player->getPlayerNightColor());
+			else
+				marker->setIndicatorColor(player->getPlayerColor());
+		}
 
 	}  // end else
 

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -2680,27 +2680,27 @@ void ControlBar::setPortraitByObject( Object *obj )
 /** Show a rally point marker at the world location specified.  If no location is specified
 	* any marker that we might have visible is hidden */
 // ------------------------------------------------------------------------------------------------
-void ControlBar::showRallyPoint( const Coord3D *loc )
+void ControlBar::showRallyPoint(const Coord3D* loc)
 {
 	// if loc is NULL, destroy any rally point drawble we have shown
-	if( loc == NULL )
+	if (loc == NULL)
 	{
 		// destroy rally point drawable if present
-		if( m_rallyPointDrawableID != INVALID_DRAWABLE_ID )
-			TheGameClient->destroyDrawable( TheGameClient->findDrawableByID( m_rallyPointDrawableID ) );
+		if (m_rallyPointDrawableID != INVALID_DRAWABLE_ID)
+			TheGameClient->destroyDrawable(TheGameClient->findDrawableByID(m_rallyPointDrawableID));
 
 		m_rallyPointDrawableID = INVALID_DRAWABLE_ID;
 		return;
 	}
 
-	Drawable *marker = NULL;
+	Drawable* marker = NULL;
 
 	// create a rally point drawble if necessary
-	if( m_rallyPointDrawableID == INVALID_DRAWABLE_ID )
+	if (m_rallyPointDrawableID == INVALID_DRAWABLE_ID)
 	{
 		const ThingTemplate* ttn = TheThingFactory->findTemplate("RallyPointMarker");
-		marker = TheThingFactory->newDrawable( ttn );
-		DEBUG_ASSERTCRASH( marker, ("showRallyPoint: Unable to create rally point drawable") );
+		marker = TheThingFactory->newDrawable(ttn);
+		DEBUG_ASSERTCRASH(marker, ("showRallyPoint: Unable to create rally point drawable"));
 		if (marker)
 		{
 			marker->setDrawableStatus(DRAWABLE_STATUS_NO_SAVE);
@@ -2708,14 +2708,14 @@ void ControlBar::showRallyPoint( const Coord3D *loc )
 		}
 	}
 	else
-		marker = TheGameClient->findDrawableByID( m_rallyPointDrawableID );
+		marker = TheGameClient->findDrawableByID(m_rallyPointDrawableID);
 
 	// sanity
-	DEBUG_ASSERTCRASH( marker, ("showRallyPoint: No rally point marker found" ) );
+	DEBUG_ASSERTCRASH(marker, ("showRallyPoint: No rally point marker found"));
 
 	// set the position of the rally point drawble to the position passed in
-	marker->setPosition( loc );
-	marker->setOrientation( TheGlobalData->m_downwindAngle );//To blow down wind -- ML
+	marker->setPosition(loc);
+	marker->setOrientation(TheGlobalData->m_downwindAngle); // To blow down wind -- ML
 
 	// set the marker colors to that of the local player
 	Player* player = TheControlBar->getCurrentlyViewedPlayer();

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -2682,16 +2682,13 @@ void ControlBar::setPortraitByObject( Object *obj )
 // ------------------------------------------------------------------------------------------------
 void ControlBar::showRallyPoint( const Coord3D *loc )
 {
-
 	// if loc is NULL, destroy any rally point drawble we have shown
 	if( loc == NULL )
 	{
-
 		// destroy rally point drawable if present
 		if( m_rallyPointDrawableID != INVALID_DRAWABLE_ID )
 			TheGameClient->destroyDrawable( TheGameClient->findDrawableByID( m_rallyPointDrawableID ) );
 		m_rallyPointDrawableID = INVALID_DRAWABLE_ID;
-
 	}  // end if
 	else
 	{
@@ -2700,7 +2697,6 @@ void ControlBar::showRallyPoint( const Coord3D *loc )
 		// create a rally point drawble if necessary
 		if( m_rallyPointDrawableID == INVALID_DRAWABLE_ID )
 		{
-
 			const ThingTemplate* ttn = TheThingFactory->findTemplate("RallyPointMarker");
 			marker = TheThingFactory->newDrawable( ttn );
 			DEBUG_ASSERTCRASH( marker, ("showRallyPoint: Unable to create rally point drawable") );
@@ -2709,7 +2705,6 @@ void ControlBar::showRallyPoint( const Coord3D *loc )
 				marker->setDrawableStatus(DRAWABLE_STATUS_NO_SAVE);
 				m_rallyPointDrawableID = marker->getID();
 			}
-
 		}  // end if
 		else
 			marker = TheGameClient->findDrawableByID( m_rallyPointDrawableID );
@@ -2730,9 +2725,7 @@ void ControlBar::showRallyPoint( const Coord3D *loc )
 			else
 				marker->setIndicatorColor(player->getPlayerColor());
 		}
-
 	}  // end else
-
 }  // end showRallyPoint
 
 // ------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -1438,6 +1438,18 @@ void ControlBar::update( void )
 
 		Object* obj = drawToEvaluateFor ? drawToEvaluateFor->getObject() : NULL;
 		setPortraitByObject(obj);
+
+		if (obj && obj->getControllingPlayer() == getCurrentlyViewedPlayer())
+		{
+			ExitInterface* exit = obj->getObjectExitInterface();
+			if (exit)
+				showRallyPoint(exit->getRallyPoint());
+			else
+				showRallyPoint(NULL);
+		}
+		else
+			showRallyPoint(NULL);
+
 		return;
 	}
 
@@ -2716,7 +2728,9 @@ void ControlBar::showRallyPoint( const Coord3D *loc )
 		marker->setOrientation( TheGlobalData->m_downwindAngle );//To blow down wind -- ML
 
 		// set the marker colors to that of the local player
-		Player *player = ThePlayerList->getLocalPlayer();
+		Player* player = TheControlBar->getCurrentlyViewedPlayer();
+		if (!player)
+			return;
 
 		if (TheGlobalData->m_timeOfDay == TIME_OF_DAY_NIGHT)
 			marker->setIndicatorColor( player->getPlayerNightColor() );

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -2689,7 +2689,7 @@ void ControlBar::showRallyPoint( const Coord3D *loc )
 		if( m_rallyPointDrawableID != INVALID_DRAWABLE_ID )
 			TheGameClient->destroyDrawable( TheGameClient->findDrawableByID( m_rallyPointDrawableID ) );
 		m_rallyPointDrawableID = INVALID_DRAWABLE_ID;
-	}  // end if
+	}
 	else
 	{
 		Drawable *marker = NULL;
@@ -2705,7 +2705,7 @@ void ControlBar::showRallyPoint( const Coord3D *loc )
 				marker->setDrawableStatus(DRAWABLE_STATUS_NO_SAVE);
 				m_rallyPointDrawableID = marker->getID();
 			}
-		}  // end if
+		}
 		else
 			marker = TheGameClient->findDrawableByID( m_rallyPointDrawableID );
 
@@ -2725,8 +2725,8 @@ void ControlBar::showRallyPoint( const Coord3D *loc )
 			else
 				marker->setIndicatorColor(player->getPlayerColor());
 		}
-	}  // end else
-}  // end showRallyPoint
+	}
+}
 
 // ------------------------------------------------------------------------------------------------
 /** Show a rally point marker at the world location specified.  If no location is specified

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3dWaypointBuffer.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3dWaypointBuffer.cpp
@@ -63,6 +63,7 @@
 #include "Common/ThingFactory.h"
 #include "Common/ThingTemplate.h"
 
+#include "GameClient/ControlBar.h"
 #include "GameClient/Drawable.h"
 #include "GameClient/GameClient.h"
 #include "GameClient/InGameUI.h"
@@ -224,7 +225,7 @@ void W3DWaypointBuffer::drawWaypoints(RenderInfoClass &rinfo)
 			Int numPoints = 0;
 			if( obj )
 			{
-				if ( ! obj->isLocallyControlled())
+				if ( obj->getControllingPlayer() != TheControlBar->getCurrentlyViewedPlayer())
 					continue;
 
 				ExitInterface *exitInterface = obj->getObjectExitInterface();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -64,6 +64,7 @@
 #include "GameLogic/Weapon.h"
 
 #include "GameClient/Anim2D.h"
+#include "GameClient/ControlBar.h"
 #include "GameClient/Display.h"
 #include "GameClient/DisplayStringManager.h"
 #include "GameClient/Drawable.h"
@@ -2731,7 +2732,7 @@ Bool Drawable::drawsAnyUIText( void )
 		return FALSE;
 
 	const Object *obj = getObject();
-	if ( !obj || !obj->isLocallyControlled() )
+	if ( !obj || obj->getControllingPlayer() != TheControlBar->getCurrentlyViewedPlayer())
 		return FALSE;
 
 	Player *owner = obj->getControllingPlayer();
@@ -2884,7 +2885,7 @@ void Drawable::drawAmmo( const IRegion2D *healthBarRegion )
 	if (!(
 				TheGlobalData->m_showObjectHealth &&
 				(isSelected() || (TheInGameUI && (TheInGameUI->getMousedOverDrawableID() == getID()))) &&
-				obj->getControllingPlayer() == ThePlayerList->getLocalPlayer()
+				obj->getControllingPlayer() == TheControlBar->getCurrentlyViewedPlayer()
 			))
 		return;
 
@@ -2942,7 +2943,7 @@ void Drawable::drawContained( const IRegion2D *healthBarRegion )
 	if (!(
 				TheGlobalData->m_showObjectHealth &&
 				(isSelected() || (TheInGameUI && (TheInGameUI->getMousedOverDrawableID() == getID()))) &&
-				obj->getControllingPlayer() == ThePlayerList->getLocalPlayer()
+				obj->getControllingPlayer() == TheControlBar->getCurrentlyViewedPlayer()
 			))
 		return;
 
@@ -3460,7 +3461,7 @@ void Drawable::drawBombed(const IRegion2D* healthBarRegion)
 	UnsignedInt now = TheGameLogic->getFrame();
 
 	if( obj->testWeaponSetFlag( WEAPONSET_CARBOMB ) &&
-				obj->getControllingPlayer() == ThePlayerList->getLocalPlayer())
+				obj->getControllingPlayer() == TheControlBar->getCurrentlyViewedPlayer())
 	{
 		if( !getIconInfo()->m_icon[ ICON_CARBOMB ] )
 			getIconInfo()->m_icon[ ICON_CARBOMB ] = newInstance(Anim2D)( s_animationTemplates[ ICON_CARBOMB ], TheAnim2DCollection );

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -2703,27 +2703,27 @@ void ControlBar::setPortraitByObject( Object *obj )
 /** Show a rally point marker at the world location specified.  If no location is specified
 	* any marker that we might have visible is hidden */
 // ------------------------------------------------------------------------------------------------
-void ControlBar::showRallyPoint( const Coord3D *loc )
+void ControlBar::showRallyPoint(const Coord3D* loc)
 {
 	// if loc is NULL, destroy any rally point drawble we have shown
-	if( loc == NULL )
+	if (loc == NULL)
 	{
 		// destroy rally point drawable if present
-		if( m_rallyPointDrawableID != INVALID_DRAWABLE_ID )
-			TheGameClient->destroyDrawable( TheGameClient->findDrawableByID( m_rallyPointDrawableID ) );
+		if (m_rallyPointDrawableID != INVALID_DRAWABLE_ID)
+			TheGameClient->destroyDrawable(TheGameClient->findDrawableByID(m_rallyPointDrawableID));
 
 		m_rallyPointDrawableID = INVALID_DRAWABLE_ID;
 		return;
 	}
 
-	Drawable *marker = NULL;
+	Drawable* marker = NULL;
 
 	// create a rally point drawble if necessary
-	if( m_rallyPointDrawableID == INVALID_DRAWABLE_ID )
+	if (m_rallyPointDrawableID == INVALID_DRAWABLE_ID)
 	{
 		const ThingTemplate* ttn = TheThingFactory->findTemplate("RallyPointMarker");
-		marker = TheThingFactory->newDrawable( ttn );
-		DEBUG_ASSERTCRASH( marker, ("showRallyPoint: Unable to create rally point drawable") );
+		marker = TheThingFactory->newDrawable(ttn);
+		DEBUG_ASSERTCRASH(marker, ("showRallyPoint: Unable to create rally point drawable"));
 		if (marker)
 		{
 			marker->setDrawableStatus(DRAWABLE_STATUS_NO_SAVE);
@@ -2731,14 +2731,14 @@ void ControlBar::showRallyPoint( const Coord3D *loc )
 		}
 	}
 	else
-		marker = TheGameClient->findDrawableByID( m_rallyPointDrawableID );
+		marker = TheGameClient->findDrawableByID(m_rallyPointDrawableID);
 
 	// sanity
-	DEBUG_ASSERTCRASH( marker, ("showRallyPoint: No rally point marker found" ) );
+	DEBUG_ASSERTCRASH(marker, ("showRallyPoint: No rally point marker found"));
 
 	// set the position of the rally point drawble to the position passed in
-	marker->setPosition( loc );
-	marker->setOrientation( TheGlobalData->m_downwindAngle );//To blow down wind -- ML
+	marker->setPosition(loc);
+	marker->setOrientation(TheGlobalData->m_downwindAngle); // To blow down wind -- ML
 
 	// set the marker colors to that of the local player
 	Player* player = TheControlBar->getCurrentlyViewedPlayer();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -2746,13 +2746,13 @@ void ControlBar::showRallyPoint( const Coord3D *loc )
 
 		// set the marker colors to that of the local player
 		Player* player = TheControlBar->getCurrentlyViewedPlayer();
-		if (!player)
-			return;
-
-		if (TheGlobalData->m_timeOfDay == TIME_OF_DAY_NIGHT)
-			marker->setIndicatorColor( player->getPlayerNightColor() );
-		else
-			marker->setIndicatorColor( player->getPlayerColor() );
+		if (player)
+		{
+			if (TheGlobalData->m_timeOfDay == TIME_OF_DAY_NIGHT)
+				marker->setIndicatorColor(player->getPlayerNightColor());
+			else
+				marker->setIndicatorColor(player->getPlayerColor());
+		}
 
 	}  // end else
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -1461,6 +1461,18 @@ void ControlBar::update( void )
 
 		Object* obj = drawToEvaluateFor ? drawToEvaluateFor->getObject() : NULL;
 		setPortraitByObject(obj);
+
+		if (obj && obj->getControllingPlayer() == getCurrentlyViewedPlayer())
+		{
+			ExitInterface* exit = obj->getObjectExitInterface();
+			if (exit)
+				showRallyPoint(exit->getRallyPoint());
+			else
+				showRallyPoint(NULL);
+		}
+		else
+			showRallyPoint(NULL);
+
 		return;
 	}
 
@@ -2739,7 +2751,9 @@ void ControlBar::showRallyPoint( const Coord3D *loc )
 		marker->setOrientation( TheGlobalData->m_downwindAngle );//To blow down wind -- ML
 
 		// set the marker colors to that of the local player
-		Player *player = ThePlayerList->getLocalPlayer();
+		Player* player = TheControlBar->getCurrentlyViewedPlayer();
+		if (!player)
+			return;
 
 		if (TheGlobalData->m_timeOfDay == TIME_OF_DAY_NIGHT)
 			marker->setIndicatorColor( player->getPlayerNightColor() );

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -2711,43 +2711,43 @@ void ControlBar::showRallyPoint( const Coord3D *loc )
 		// destroy rally point drawable if present
 		if( m_rallyPointDrawableID != INVALID_DRAWABLE_ID )
 			TheGameClient->destroyDrawable( TheGameClient->findDrawableByID( m_rallyPointDrawableID ) );
+
 		m_rallyPointDrawableID = INVALID_DRAWABLE_ID;
+		return;
+	}
+
+	Drawable *marker = NULL;
+
+	// create a rally point drawble if necessary
+	if( m_rallyPointDrawableID == INVALID_DRAWABLE_ID )
+	{
+		const ThingTemplate* ttn = TheThingFactory->findTemplate("RallyPointMarker");
+		marker = TheThingFactory->newDrawable( ttn );
+		DEBUG_ASSERTCRASH( marker, ("showRallyPoint: Unable to create rally point drawable") );
+		if (marker)
+		{
+			marker->setDrawableStatus(DRAWABLE_STATUS_NO_SAVE);
+			m_rallyPointDrawableID = marker->getID();
+		}
 	}
 	else
+		marker = TheGameClient->findDrawableByID( m_rallyPointDrawableID );
+
+	// sanity
+	DEBUG_ASSERTCRASH( marker, ("showRallyPoint: No rally point marker found" ) );
+
+	// set the position of the rally point drawble to the position passed in
+	marker->setPosition( loc );
+	marker->setOrientation( TheGlobalData->m_downwindAngle );//To blow down wind -- ML
+
+	// set the marker colors to that of the local player
+	Player* player = TheControlBar->getCurrentlyViewedPlayer();
+	if (player)
 	{
-		Drawable *marker = NULL;
-
-		// create a rally point drawble if necessary
-		if( m_rallyPointDrawableID == INVALID_DRAWABLE_ID )
-		{
-			const ThingTemplate* ttn = TheThingFactory->findTemplate("RallyPointMarker");
-			marker = TheThingFactory->newDrawable( ttn );
-			DEBUG_ASSERTCRASH( marker, ("showRallyPoint: Unable to create rally point drawable") );
-			if (marker)
-			{
-				marker->setDrawableStatus(DRAWABLE_STATUS_NO_SAVE);
-				m_rallyPointDrawableID = marker->getID();
-			}
-		}
+		if (TheGlobalData->m_timeOfDay == TIME_OF_DAY_NIGHT)
+			marker->setIndicatorColor(player->getPlayerNightColor());
 		else
-			marker = TheGameClient->findDrawableByID( m_rallyPointDrawableID );
-
-		// sanity
-		DEBUG_ASSERTCRASH( marker, ("showRallyPoint: No rally point marker found" ) );
-
-		// set the position of the rally point drawble to the position passed in
-		marker->setPosition( loc );
-		marker->setOrientation( TheGlobalData->m_downwindAngle );//To blow down wind -- ML
-
-		// set the marker colors to that of the local player
-		Player* player = TheControlBar->getCurrentlyViewedPlayer();
-		if (player)
-		{
-			if (TheGlobalData->m_timeOfDay == TIME_OF_DAY_NIGHT)
-				marker->setIndicatorColor(player->getPlayerNightColor());
-			else
-				marker->setIndicatorColor(player->getPlayerColor());
-		}
+			marker->setIndicatorColor(player->getPlayerColor());
 	}
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -2712,7 +2712,7 @@ void ControlBar::showRallyPoint( const Coord3D *loc )
 		if( m_rallyPointDrawableID != INVALID_DRAWABLE_ID )
 			TheGameClient->destroyDrawable( TheGameClient->findDrawableByID( m_rallyPointDrawableID ) );
 		m_rallyPointDrawableID = INVALID_DRAWABLE_ID;
-	}  // end if
+	}
 	else
 	{
 		Drawable *marker = NULL;
@@ -2728,7 +2728,7 @@ void ControlBar::showRallyPoint( const Coord3D *loc )
 				marker->setDrawableStatus(DRAWABLE_STATUS_NO_SAVE);
 				m_rallyPointDrawableID = marker->getID();
 			}
-		}  // end if
+		}
 		else
 			marker = TheGameClient->findDrawableByID( m_rallyPointDrawableID );
 
@@ -2748,8 +2748,8 @@ void ControlBar::showRallyPoint( const Coord3D *loc )
 			else
 				marker->setIndicatorColor(player->getPlayerColor());
 		}
-	}  // end else
-}  // end showRallyPoint
+	}
+}
 
 // ------------------------------------------------------------------------------------------------
 /** Show a rally point marker at the world location specified.  If no location is specified

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -1462,17 +1462,11 @@ void ControlBar::update( void )
 		Object* obj = drawToEvaluateFor ? drawToEvaluateFor->getObject() : NULL;
 		setPortraitByObject(obj);
 
-		if (obj && obj->getControllingPlayer() == getCurrentlyViewedPlayer())
-		{
-			ExitInterface* exit = obj->getObjectExitInterface();
-			if (exit)
-				showRallyPoint(exit->getRallyPoint());
-			else
-				showRallyPoint(NULL);
-		}
-		else
-			showRallyPoint(NULL);
+		const Coord3D* exitPosition = NULL;
+		if (obj && obj->getControllingPlayer() == getCurrentlyViewedPlayer() && obj->getObjectExitInterface())
+			exitPosition = obj->getObjectExitInterface()->getRallyPoint();
 
+		showRallyPoint(exitPosition);
 		return;
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -2705,16 +2705,13 @@ void ControlBar::setPortraitByObject( Object *obj )
 // ------------------------------------------------------------------------------------------------
 void ControlBar::showRallyPoint( const Coord3D *loc )
 {
-
 	// if loc is NULL, destroy any rally point drawble we have shown
 	if( loc == NULL )
 	{
-
 		// destroy rally point drawable if present
 		if( m_rallyPointDrawableID != INVALID_DRAWABLE_ID )
 			TheGameClient->destroyDrawable( TheGameClient->findDrawableByID( m_rallyPointDrawableID ) );
 		m_rallyPointDrawableID = INVALID_DRAWABLE_ID;
-
 	}  // end if
 	else
 	{
@@ -2723,7 +2720,6 @@ void ControlBar::showRallyPoint( const Coord3D *loc )
 		// create a rally point drawble if necessary
 		if( m_rallyPointDrawableID == INVALID_DRAWABLE_ID )
 		{
-
 			const ThingTemplate* ttn = TheThingFactory->findTemplate("RallyPointMarker");
 			marker = TheThingFactory->newDrawable( ttn );
 			DEBUG_ASSERTCRASH( marker, ("showRallyPoint: Unable to create rally point drawable") );
@@ -2732,7 +2728,6 @@ void ControlBar::showRallyPoint( const Coord3D *loc )
 				marker->setDrawableStatus(DRAWABLE_STATUS_NO_SAVE);
 				m_rallyPointDrawableID = marker->getID();
 			}
-
 		}  // end if
 		else
 			marker = TheGameClient->findDrawableByID( m_rallyPointDrawableID );
@@ -2753,9 +2748,7 @@ void ControlBar::showRallyPoint( const Coord3D *loc )
 			else
 				marker->setIndicatorColor(player->getPlayerColor());
 		}
-
 	}  // end else
-
 }  // end showRallyPoint
 
 // ------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3dWaypointBuffer.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3dWaypointBuffer.cpp
@@ -63,6 +63,7 @@
 #include "Common/ThingFactory.h"
 #include "Common/ThingTemplate.h"
 
+#include "GameClient/ControlBar.h"
 #include "GameClient/Drawable.h"
 #include "GameClient/GameClient.h"
 #include "GameClient/InGameUI.h"
@@ -231,7 +232,7 @@ void W3DWaypointBuffer::drawWaypoints(RenderInfoClass &rinfo)
 			Int numPoints = 0;
 			if( obj )
 			{
-				if ( ! obj->isLocallyControlled())
+				if ( obj->getControllingPlayer() != TheControlBar->getCurrentlyViewedPlayer())
 					continue;
 
 


### PR DESCRIPTION
This change expands object selection information for observers. While a player is selected, the following information is now displayed for selected objects:

- Group numbers / formations
- Ammo
- Passengers / occupants
- Car bombs
- Rally points