### PR TITLE
tweak(menu): Show mouse and menu immediately when shellmap is disabled

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/MainMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/MainMenu.cpp
@@ -951,7 +951,7 @@ WindowMsgHandledType MainMenuInput( GameWindow *window, UnsignedInt msg,
 			mouse.x = mData1 & 0xFFFF;
 			mouse.y = mData1 >> 16;
 
-			// TheSuperHackers @tweak 20/08/2025 show mouse and menu immediately when shellmap is disabled
+			// TheSuperHackers @tweak 20/08/2025 Show mouse and menu immediately when shellmap is disabled.
 			if (TheGlobalData->m_shellMapOn && mouse.x == 0 && mouse.y == 0)
 				break;
 

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/MainMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/MainMenu.cpp
@@ -950,7 +950,9 @@ WindowMsgHandledType MainMenuInput( GameWindow *window, UnsignedInt msg,
 			ICoord2D mouse;
 			mouse.x = mData1 & 0xFFFF;
 			mouse.y = mData1 >> 16;
-			if( mouse.x == 0 && mouse.y == 0)
+
+			// TheSuperHackers @tweak 20/08/2025 show mouse and menu immediately when shellmap is disabled
+			if (TheGlobalData->m_shellMapOn && mouse.x == 0 && mouse.y == 0)
 				break;
 
 			static Int mousePosX = mouse.x;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/MainMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/MainMenu.cpp
@@ -987,7 +987,9 @@ WindowMsgHandledType MainMenuInput( GameWindow *window, UnsignedInt msg,
 			ICoord2D mouse;
 			mouse.x = mData1 & 0xFFFF;
 			mouse.y = mData1 >> 16;
-			if( mouse.x == 0 && mouse.y == 0)
+
+			// TheSuperHackers @tweak 20/08/2025 show mouse and menu immediately when shellmap is disabled
+			if(TheGlobalData->m_shellMapOn && mouse.x == 0 && mouse.y == 0)
 				break;
 
 			static Int mousePosX = mouse.x;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/MainMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/MainMenu.cpp
@@ -988,7 +988,7 @@ WindowMsgHandledType MainMenuInput( GameWindow *window, UnsignedInt msg,
 			mouse.x = mData1 & 0xFFFF;
 			mouse.y = mData1 >> 16;
 
-			// TheSuperHackers @tweak 20/08/2025 show mouse and menu immediately when shellmap is disabled
+			// TheSuperHackers @tweak 20/08/2025 Show mouse and menu immediately when shellmap is disabled.
 			if (TheGlobalData->m_shellMapOn && mouse.x == 0 && mouse.y == 0)
 				break;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/MainMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/MainMenu.cpp
@@ -989,7 +989,7 @@ WindowMsgHandledType MainMenuInput( GameWindow *window, UnsignedInt msg,
 			mouse.y = mData1 >> 16;
 
 			// TheSuperHackers @tweak 20/08/2025 show mouse and menu immediately when shellmap is disabled
-			if(TheGlobalData->m_shellMapOn && mouse.x == 0 && mouse.y == 0)
+			if (TheGlobalData->m_shellMapOn && mouse.x == 0 && mouse.y == 0)
 				break;
 
 			static Int mousePosX = mouse.x;


### PR DESCRIPTION
By default, the cursor and menu are hidden to display the shell map. When using the `--quickstart` option, the shell map is replaced with a static background, but the player still had to move the mouse before the cursor and menu appeared.

This change explicitly checks if the shell map is enabled, ensuring the mouse and menu are shown immediately when it is not.