### PR TITLE
feat: Update stealthed radar objects for observers

### DIFF
--- a/Generals/Code/GameEngine/Include/GameClient/ControlBar.h
+++ b/Generals/Code/GameEngine/Include/GameClient/ControlBar.h
@@ -733,6 +733,8 @@ public:
 
 	/// Returns the currently viewed player. May return NULL if no player is selected while observing.
 	Player* getCurrentlyViewedPlayer();
+	/// Returns the relationship with the currently viewed player. May return NEUTRAL if no player is selected while observing.
+	Relationship getCurrentlyViewedPlayerRelationship(const Team* team);
 
 //	ControlBarResizer *getControlBarResizer( void ) {return m_controlBarResizer;}
 

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -167,18 +167,15 @@ Player* ControlBar::getCurrentlyViewedPlayer()
 
 Relationship ControlBar::getCurrentlyViewedPlayerRelationship(const Team* team)
 {
-	Player* player = NULL;
-
 	if (TheControlBar->isObserverControlBarOn())
 	{
-		player = TheControlBar->getObserverLookAtPlayer();
-		if (!player)
+		if (!TheControlBar->getObserverLookAtPlayer())
 			return NEUTRAL;
-	}
-	else
-		player = ThePlayerList->getLocalPlayer();
 
-	return player->getRelationship(team);
+		return TheControlBar->getObserverLookAtPlayer()->getRelationship(team);
+	}
+
+	return ThePlayerList->getLocalPlayer()->getRelationship(team);
 }
 
 void ControlBar::populatePurchaseScience( Player* player )

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -165,6 +165,22 @@ Player* ControlBar::getCurrentlyViewedPlayer()
 	return ThePlayerList->getLocalPlayer();
 }
 
+Relationship ControlBar::getCurrentlyViewedPlayerRelationship(const Team* team)
+{
+	Player* player = NULL;
+
+	if (TheControlBar->isObserverControlBarOn())
+	{
+		player = TheControlBar->getObserverLookAtPlayer();
+		if (!player)
+			return NEUTRAL;
+	}
+	else
+		player = ThePlayerList->getLocalPlayer();
+
+	return player->getRelationship(team);
+}
+
 void ControlBar::populatePurchaseScience( Player* player )
 {
 //	TheInGameUI->deselectAllDrawables();

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/Common/System/W3DRadar.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/Common/System/W3DRadar.cpp
@@ -42,6 +42,7 @@
 #include "GameLogic/Module/StealthUpdate.h"
 
 #include "GameClient/Color.h"
+#include "GameClient/ControlBar.h"
 #include "GameClient/Display.h"
 #include "GameClient/GameClient.h"
 #include "GameClient/GameWindow.h"
@@ -696,7 +697,7 @@ void W3DRadar::renderObjectList( const RadarObject *listHead, TextureClass *text
 			if( !stealth )
 				continue;
 
-      if ( ThePlayerList->getLocalPlayer()->getRelationship(obj->getTeam()) == ENEMIES )
+      if ( TheControlBar->getCurrentlyViewedPlayerRelationship(obj->getTeam()) == ENEMIES )
         if( !obj->testStatus( OBJECT_STATUS_DETECTED ) && !stealth->isDisguised() )
 				  skip = TRUE;
 

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/ControlBar.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/ControlBar.h
@@ -747,6 +747,8 @@ public:
 
 	/// Returns the currently viewed player. May return NULL if no player is selected while observing.
 	Player* getCurrentlyViewedPlayer();
+	/// Returns the relationship with the currently viewed player. May return NEUTRAL if no player is selected while observing.
+	Relationship getCurrentlyViewedPlayerRelationship(const Team* team);
 
 //	ControlBarResizer *getControlBarResizer( void ) {return m_controlBarResizer;}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -166,6 +166,22 @@ Player* ControlBar::getCurrentlyViewedPlayer()
 	return ThePlayerList->getLocalPlayer();
 }
 
+Relationship ControlBar::getCurrentlyViewedPlayerRelationship(const Team* team)
+{
+	Player* player = NULL;
+
+	if (TheControlBar->isObserverControlBarOn())
+	{
+		player = TheControlBar->getObserverLookAtPlayer();
+		if (!player)
+			return NEUTRAL;
+	}
+	else
+		player = ThePlayerList->getLocalPlayer();
+
+	return player->getRelationship(team);
+}
+
 void ControlBar::populatePurchaseScience( Player* player )
 {
 //	TheInGameUI->deselectAllDrawables();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -168,18 +168,15 @@ Player* ControlBar::getCurrentlyViewedPlayer()
 
 Relationship ControlBar::getCurrentlyViewedPlayerRelationship(const Team* team)
 {
-	Player* player = NULL;
-
 	if (TheControlBar->isObserverControlBarOn())
 	{
-		player = TheControlBar->getObserverLookAtPlayer();
-		if (!player)
+		if (!TheControlBar->getObserverLookAtPlayer())
 			return NEUTRAL;
-	}
-	else
-		player = ThePlayerList->getLocalPlayer();
 
-	return player->getRelationship(team);
+		return TheControlBar->getObserverLookAtPlayer()->getRelationship(team);
+	}
+
+	return ThePlayerList->getLocalPlayer()->getRelationship(team);
 }
 
 void ControlBar::populatePurchaseScience( Player* player )

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/Common/System/W3DRadar.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/Common/System/W3DRadar.cpp
@@ -40,6 +40,7 @@
 #include "GameLogic/Object.h"
 
 #include "GameClient/Color.h"
+#include "GameClient/ControlBar.h"
 #include "GameClient/Display.h"
 #include "GameClient/GameClient.h"
 #include "GameClient/GameWindow.h"
@@ -690,7 +691,7 @@ void W3DRadar::renderObjectList( const RadarObject *listHead, TextureClass *text
 		// Now it twinkles for any stealthed object, whether locally controlled or neutral-observier-viewed
 		if( obj->testStatus( OBJECT_STATUS_STEALTHED ) )
 		{
-      if ( ThePlayerList->getLocalPlayer()->getRelationship(obj->getTeam()) == ENEMIES )
+      if ( TheControlBar->getCurrentlyViewedPlayerRelationship(obj->getTeam()) == ENEMIES )
         if( !obj->testStatus( OBJECT_STATUS_DETECTED ) && !obj->testStatus( OBJECT_STATUS_DISGUISED ) )
 				  skip = TRUE;
 


### PR DESCRIPTION
Fixes #137

This change allows observers to see stealthed enemy units on the radar.

**While globally observing:** All stealthed units are shown on the radar
**While observing a specific player:** Only stealthed units that the selected player can see are displayed on the radar

In the retail build, only the relationship of the current (and observing) player is considered, causing enemy stealthed units to never show on the radar for observers, while allies' stealthed units always do. In replays, stealthed units are always displayed on the radar and selecting a player makes no difference.