### PR TITLE
bugfix(scrolling): Fix vertical scroll speed discrepancies with different aspect ratios

### DIFF
--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -1652,7 +1652,7 @@ void W3DView::scrollBy( Coord2D *delta )
 
 		start.X = getWidth();
 		start.Y = getHeight();
-		Real aspect = getHeight() == 0 ? 1 : getWidth()/getHeight();
+		Real aspect = getHeight() == 0 ? 1 : (Real)getWidth() / (Real)getHeight();
 		end.X = start.X + delta->x * SCROLL_RESOLUTION;
 		end.Y = start.Y + delta->y * SCROLL_RESOLUTION*aspect;
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -1815,7 +1815,7 @@ void W3DView::scrollBy( Coord2D *delta )
 
 		start.X = getWidth();
 		start.Y = getHeight();
-		Real aspect = getHeight() == 0 ? 1 : getWidth()/getHeight();
+		Real aspect = getHeight() == 0 ? 1 : (Real)getWidth() / (Real)getHeight();
 		end.X = start.X + delta->x * SCROLL_RESOLUTION;
 		end.Y = start.Y + delta->y * SCROLL_RESOLUTION*aspect;
 


### PR DESCRIPTION
This change corrects the vertical scroll speed for different screen heights, which was using integer division and losing the fractional part of the aspect ratio.