### PR TITLE
tweak(network): Reduce the minimum runahead latency limit from 10 to 4

### DIFF
--- a/Generals/Code/GameEngine/Source/GameNetwork/NetworkUtil.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/NetworkUtil.cpp
@@ -27,8 +27,10 @@
 
 #include "GameNetwork/networkutil.h"
 
+// TheSuperHackers @tweak Mauller 26/08/2025 reduce the minimum runahead from 10
+// This lets network games run at latencies down to 133ms when the network conditions allow
 Int MAX_FRAMES_AHEAD = 128;
-Int MIN_RUNAHEAD = 10;
+Int MIN_RUNAHEAD = 4;
 Int FRAME_DATA_LENGTH = (MAX_FRAMES_AHEAD+1)*2;
 Int FRAMES_TO_KEEP = (MAX_FRAMES_AHEAD/2) + 1;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/NetworkUtil.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/NetworkUtil.cpp
@@ -27,8 +27,10 @@
 
 #include "GameNetwork/networkutil.h"
 
+// TheSuperHackers @tweak Mauller 26/08/2025 reduce the minimum runahead from 10
+// This lets network games run at latencies down to 133ms when the network conditions allow
 Int MAX_FRAMES_AHEAD = 128;
-Int MIN_RUNAHEAD = 10;
+Int MIN_RUNAHEAD = 4;
 Int FRAME_DATA_LENGTH = (MAX_FRAMES_AHEAD+1)*2;
 Int FRAMES_TO_KEEP = (MAX_FRAMES_AHEAD/2) + 1;
 


### PR DESCRIPTION
- Fixes: #233 

This PR reduces the minimum run ahead limit.

This then allows the game to run with a lower input latency when the network latency allows.

The limit for now has been reduced by 6 frames. If the limit is set too low it can start to introduce stutter to the game where the game starts waiting on data. So a 4 frame window, resulting in 133ms of latency minimum compared to 333ms of retail provides a reasonable lower buffer.

The added advantage of this change is that when a SH client is the host, it can push the runahead below the 10 frames minimum cap for retail clients as well.