### PR TITLE
refactor(language): Remove obsolete code for loading Language9x.ini, HeaderTemplate9x.ini

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/HeaderTemplate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/HeaderTemplate.cpp
@@ -136,22 +136,13 @@ HeaderTemplateManager::~HeaderTemplateManager( void )
 
 void HeaderTemplateManager::init( void )
 {
-	INI ini;
-	AsciiString fname;
-	fname.format("Data\\%s\\HeaderTemplate.ini", GetRegistryLanguage().str());
-	OSVERSIONINFO	osvi;
-	osvi.dwOSVersionInfoSize=sizeof(OSVERSIONINFO);
-	if (GetVersionEx(&osvi))
-	{	//check if we're running Win9x variant since they may need different fonts
-		if (osvi.dwPlatformId == VER_PLATFORM_WIN32_WINDOWS)
-		{	AsciiString tempName;
-
-			tempName.format("Data\\%s\\HeaderTemplate9x.ini", GetRegistryLanguage().str());
-			if (TheFileSystem->doesFileExist(tempName.str()))
-				fname = tempName;
-		}
+	{
+		INI ini;
+		AsciiString fname;
+		fname.format("Data\\%s\\HeaderTemplate.ini", GetRegistryLanguage().str());
+		ini.load( fname, INI_LOAD_OVERWRITE, NULL );
 	}
-	ini.load( fname, INI_LOAD_OVERWRITE, NULL );
+
 	populateGameFonts();
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GlobalLanguage.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GlobalLanguage.cpp
@@ -135,25 +135,13 @@ GlobalLanguage::~GlobalLanguage()
 
 void GlobalLanguage::init( void )
 {
-
-	INI ini;
-	AsciiString fname;
-	fname.format("Data\\%s\\Language.ini", GetRegistryLanguage().str());
-
-	OSVERSIONINFO	osvi;
-	osvi.dwOSVersionInfoSize=sizeof(OSVERSIONINFO);
-
-	//GS NOTE: Must call doesFileExist in either case so that NameKeyGenerator will stay in sync
-	AsciiString tempName;
-	tempName.format("Data\\%s\\Language9x.ini", GetRegistryLanguage().str());
-	bool isExist = TheFileSystem->doesFileExist(tempName.str());
-	if (GetVersionEx(&osvi)  &&  osvi.dwPlatformId == VER_PLATFORM_WIN32_WINDOWS  && isExist)
-	{	//check if we're running Win9x variant since they may need different fonts
-		fname = tempName;
+	{
+		INI ini;
+		AsciiString fname;
+		fname.format("Data\\%s\\Language.ini", GetRegistryLanguage().str());
+		ini.load( fname, INI_LOAD_OVERWRITE, NULL );
 	}
 
-
-	ini.load( fname, INI_LOAD_OVERWRITE, NULL );
 	StringListIt it = m_localFonts.begin();
 	while( it != m_localFonts.end())
 	{


### PR DESCRIPTION
This change removes the obsolete code for loading Language9x.ini, HeaderTemplate9x.ini for Windows 95, 98, ME systems. It was used by Chinese and Korean localizations only.