### PR TITLE
tweak(ini): No longer terminate application if an INI data field is not found

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/INI/INI.cpp
+++ b/Generals/Code/GameEngine/Source/Common/INI/INI.cpp
@@ -1528,10 +1528,6 @@ void INI::initFromINIMulti( void *what, const MultiIniFieldParse& parseTableList
 				{
 					DEBUG_ASSERTCRASH( 0, ("[LINE: %d - FILE: '%s'] Unknown field '%s' in block '%s'",
 														 INI::getLineNum(), INI::getFilename().str(), field, m_curBlockStart) );
-#if !defined(RTS_DEBUG)
-					// Just ignore unknown fields in debug builds
-					throw INI_UNKNOWN_TOKEN;
-#endif
 				}
 
 			}  // end else

--- a/GeneralsMD/Code/GameEngine/Source/Common/INI/INI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/INI/INI.cpp
@@ -1530,10 +1530,6 @@ void INI::initFromINIMulti( void *what, const MultiIniFieldParse& parseTableList
 				{
 					DEBUG_ASSERTCRASH( 0, ("[LINE: %d - FILE: '%s'] Unknown field '%s' in block '%s'",
 														 INI::getLineNum(), INI::getFilename().str(), field, m_curBlockStart) );
-#if !defined(RTS_DEBUG)
-					// Just ignore unknown fields in debug builds
-					throw INI_UNKNOWN_TOKEN;
-#endif
 				}
 
 			}  // end else


### PR DESCRIPTION
This change prevents a crash that occurs when an unknown field is read in the INI data for debug builds.

For example, the below addition to `Upgrade.ini` will currently cause a crash. After this change, the new field is simply ignored (an assertion is still triggered).

<img width="476" height="107" alt="image" src="https://github.com/user-attachments/assets/9117c0f6-9174-4c8f-a8d9-d62fca3b6cb4" />

This can help streamline development as modified INI data from other features or branches no longer blocks the user. The crash prevention is restricted to debug builds so that there is still feedback for mistyped fields in the release build.