### PR TITLE
perf(ini): Decrease cost of INI::isDeclarationOfType by around 10%

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/INI/INI.cpp
+++ b/Generals/Code/GameEngine/Source/Common/INI/INI.cpp
@@ -1882,7 +1882,7 @@ Bool INI::isDeclarationOfType( AsciiString blockType, AsciiString blockName, cha
 
 	tempBuff += blockTypeLength;
 
-	if (!isspace(*tempBuff))
+	if (!isspace(*tempBuff++))
 		return false;
 
 	while (isspace(*tempBuff))
@@ -1894,13 +1894,11 @@ Bool INI::isDeclarationOfType( AsciiString blockType, AsciiString blockName, cha
 
 	tempBuff += blockNameLength;
 
-	while (*tempBuff)
-	{
-		if (!isspace(*tempBuff))
-			return false;
-
+	while (isspace(*tempBuff))
 		++tempBuff;
-	}
+
+	if (*tempBuff != '\0')
+		return false;
 
 	return true;
 }

--- a/Generals/Code/GameEngine/Source/Common/INI/INI.cpp
+++ b/Generals/Code/GameEngine/Source/Common/INI/INI.cpp
@@ -1917,8 +1917,8 @@ Bool INI::isDeclarationOfType( AsciiString blockType, AsciiString blockName, cha
 		retVal = false;
 	}
 
-	while (strlen(tempBuff)) {
-		retVal = retVal && isspace(tempBuff[0]);
+	while (*tempBuff) {
+		retVal = retVal && isspace(*tempBuff);
 		++tempBuff;
 	}
 
@@ -1963,8 +1963,8 @@ Bool INI::isEndOfBlock( char *bufferToCheck )
 		retVal = false;
 	}
 
-	while (strlen(tempBuff)) {
-		retVal = retVal && isspace(tempBuff[0]);
+	while (*tempBuff) {
+		retVal = retVal && isspace(*tempBuff);
 		++tempBuff;
 	}
 

--- a/Generals/Code/GameEngine/Source/Common/INI/INI.cpp
+++ b/Generals/Code/GameEngine/Source/Common/INI/INI.cpp
@@ -1917,8 +1917,8 @@ Bool INI::isDeclarationOfType( AsciiString blockType, AsciiString blockName, cha
 		retVal = false;
 	}
 
-	while (*tempBuff) {
-		retVal = retVal && isspace(*tempBuff);
+	while (*tempBuff && retVal) {
+		retVal = isspace(*tempBuff);
 		++tempBuff;
 	}
 
@@ -1963,8 +1963,8 @@ Bool INI::isEndOfBlock( char *bufferToCheck )
 		retVal = false;
 	}
 
-	while (*tempBuff) {
-		retVal = retVal && isspace(*tempBuff);
+	while (*tempBuff && retVal) {
+		retVal = isspace(*tempBuff);
 		++tempBuff;
 	}
 

--- a/Generals/Code/GameEngine/Source/Common/INI/INI.cpp
+++ b/Generals/Code/GameEngine/Source/Common/INI/INI.cpp
@@ -1885,7 +1885,10 @@ Bool INI::isDeclarationOfType( AsciiString blockType, AsciiString blockName, cha
 		++tempBuff;
 	}
 
-	if (strlen(tempBuff) > blockTypeLength) {
+	size_t tempBuffLen = strlen(tempBuff);
+	char* tempBuffEnd = tempBuff + tempBuffLen;
+
+	if (tempBuffLen > blockTypeLength) {
 		restoreChar = tempBuff[blockTypeLength];
 		tempBuff[blockTypeLength] = 0;
 
@@ -1903,7 +1906,8 @@ Bool INI::isDeclarationOfType( AsciiString blockType, AsciiString blockName, cha
 		++tempBuff;
 	}
 
-	if (strlen(tempBuff) > blockNameLength) {
+	tempBuffLen = tempBuffEnd - tempBuff;
+	if (tempBuffLen > blockNameLength) {
 		restoreChar = tempBuff[blockNameLength];
 		tempBuff[blockNameLength] = 0;
 

--- a/Generals/Code/GameEngine/Source/Common/INI/INI.cpp
+++ b/Generals/Code/GameEngine/Source/Common/INI/INI.cpp
@@ -1868,65 +1868,41 @@ void INI::parseDeathTypeFlags(INI* ini, void* /*instance*/, void* store, const v
 // both blockType and blockName are case insensitive
 Bool INI::isDeclarationOfType( AsciiString blockType, AsciiString blockName, char *bufferToCheck )
 {
-	Bool retVal = true;
-	if (!bufferToCheck || blockType.isEmpty() || blockName.isEmpty()) {
+	if (!bufferToCheck || blockType.isEmpty() || blockName.isEmpty())
 		return false;
-	}
-	// DO NOT RETURN EARLY FROM THIS FUNCTION. (beyond this point)
-	// we have to restore the bufferToCheck to its previous state before returning, so
-	// it is important to get through all the checks.
 
-	char restoreChar;
-	char *tempBuff = bufferToCheck;
-	int blockTypeLength = blockType.getLength();
-	int blockNameLength = blockName.getLength();
+	const char* tempBuff = bufferToCheck;
 
-	while (isspace(*tempBuff)) {
+	while (isspace(*tempBuff))
+		++tempBuff;
+
+	const int blockTypeLength = blockType.getLength();
+	if (strnicmp(tempBuff, blockType.str(), blockTypeLength) != 0)
+		return false;
+
+	tempBuff += blockTypeLength;
+
+	if (!isspace(*tempBuff))
+		return false;
+
+	while (isspace(*tempBuff))
+		++tempBuff;
+
+	const int blockNameLength = blockName.getLength();
+	if (strnicmp(tempBuff, blockName.str(), blockNameLength) != 0)
+		return false;
+
+	tempBuff += blockNameLength;
+
+	while (*tempBuff)
+	{
+		if (!isspace(*tempBuff))
+			return false;
+
 		++tempBuff;
 	}
 
-	size_t tempBuffLen = strlen(tempBuff);
-	char* tempBuffEnd = tempBuff + tempBuffLen;
-
-	if (tempBuffLen > blockTypeLength) {
-		restoreChar = tempBuff[blockTypeLength];
-		tempBuff[blockTypeLength] = 0;
-
-		if (stricmp(blockType.str(), tempBuff) != 0) {
-			retVal = false;
-		}
-
-		tempBuff[blockTypeLength] = restoreChar;
-		tempBuff = tempBuff + blockTypeLength;
-	} else {
-		retVal = false;
-	}
-
-	while (isspace(*tempBuff)) {
-		++tempBuff;
-	}
-
-	tempBuffLen = tempBuffEnd - tempBuff;
-	if (tempBuffLen > blockNameLength) {
-		restoreChar = tempBuff[blockNameLength];
-		tempBuff[blockNameLength] = 0;
-
-		if (stricmp(blockName.str(), tempBuff) != 0) {
-			retVal = false;
-		}
-
-		tempBuff[blockNameLength] = restoreChar;
-		tempBuff = tempBuff + blockNameLength;
-	} else {
-		retVal = false;
-	}
-
-	while (*tempBuff && retVal) {
-		retVal = isspace(*tempBuff);
-		++tempBuff;
-	}
-
-	return retVal;
+	return true;
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/Common/INI/INI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/INI/INI.cpp
@@ -1922,8 +1922,8 @@ Bool INI::isDeclarationOfType( AsciiString blockType, AsciiString blockName, cha
 		retVal = false;
 	}
 
-	while (*tempBuff) {
-		retVal = retVal && isspace(*tempBuff);
+	while (*tempBuff && retVal) {
+		retVal = isspace(*tempBuff);
 		++tempBuff;
 	}
 
@@ -1968,8 +1968,8 @@ Bool INI::isEndOfBlock( char *bufferToCheck )
 		retVal = false;
 	}
 
-	while (*tempBuff) {
-		retVal = retVal && isspace(*tempBuff);
+	while (*tempBuff && retVal) {
+		retVal = isspace(*tempBuff);
 		++tempBuff;
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/INI/INI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/INI/INI.cpp
@@ -1887,7 +1887,7 @@ Bool INI::isDeclarationOfType( AsciiString blockType, AsciiString blockName, cha
 
 	tempBuff += blockTypeLength;
 
-	if (!isspace(*tempBuff))
+	if (!isspace(*tempBuff++))
 		return false;
 
 	while (isspace(*tempBuff))
@@ -1899,13 +1899,11 @@ Bool INI::isDeclarationOfType( AsciiString blockType, AsciiString blockName, cha
 
 	tempBuff += blockNameLength;
 
-	while (*tempBuff)
-	{
-		if (!isspace(*tempBuff))
-			return false;
-
+	while (isspace(*tempBuff))
 		++tempBuff;
-	}
+
+	if (*tempBuff != '\0')
+		return false;
 
 	return true;
 }

--- a/GeneralsMD/Code/GameEngine/Source/Common/INI/INI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/INI/INI.cpp
@@ -1873,65 +1873,41 @@ void INI::parseDeathTypeFlags(INI* ini, void* /*instance*/, void* store, const v
 // both blockType and blockName are case insensitive
 Bool INI::isDeclarationOfType( AsciiString blockType, AsciiString blockName, char *bufferToCheck )
 {
-	Bool retVal = true;
-	if (!bufferToCheck || blockType.isEmpty() || blockName.isEmpty()) {
+	if (!bufferToCheck || blockType.isEmpty() || blockName.isEmpty())
 		return false;
-	}
-	// DO NOT RETURN EARLY FROM THIS FUNCTION. (beyond this point)
-	// we have to restore the bufferToCheck to its previous state before returning, so
-	// it is important to get through all the checks.
 
-	char restoreChar;
-	char *tempBuff = bufferToCheck;
-	int blockTypeLength = blockType.getLength();
-	int blockNameLength = blockName.getLength();
+	const char* tempBuff = bufferToCheck;
 
-	while (isspace(*tempBuff)) {
+	while (isspace(*tempBuff))
+		++tempBuff;
+
+	const int blockTypeLength = blockType.getLength();
+	if (strnicmp(tempBuff, blockType.str(), blockTypeLength) != 0)
+		return false;
+
+	tempBuff += blockTypeLength;
+
+	if (!isspace(*tempBuff))
+		return false;
+
+	while (isspace(*tempBuff))
+		++tempBuff;
+
+	const int blockNameLength = blockName.getLength();
+	if (strnicmp(tempBuff, blockName.str(), blockNameLength) != 0)
+		return false;
+
+	tempBuff += blockNameLength;
+
+	while (*tempBuff)
+	{
+		if (!isspace(*tempBuff))
+			return false;
+
 		++tempBuff;
 	}
 
-	size_t tempBuffLen = strlen(tempBuff);
-	char* tempBuffEnd = tempBuff + tempBuffLen;
-
-	if (tempBuffLen > blockTypeLength) {
-		restoreChar = tempBuff[blockTypeLength];
-		tempBuff[blockTypeLength] = 0;
-
-		if (stricmp(blockType.str(), tempBuff) != 0) {
-			retVal = false;
-		}
-
-		tempBuff[blockTypeLength] = restoreChar;
-		tempBuff = tempBuff + blockTypeLength;
-	} else {
-		retVal = false;
-	}
-
-	while (isspace(*tempBuff)) {
-		++tempBuff;
-	}
-
-	tempBuffLen = tempBuffEnd - tempBuff;
-	if (tempBuffLen > blockNameLength) {
-		restoreChar = tempBuff[blockNameLength];
-		tempBuff[blockNameLength] = 0;
-
-		if (stricmp(blockName.str(), tempBuff) != 0) {
-			retVal = false;
-		}
-
-		tempBuff[blockNameLength] = restoreChar;
-		tempBuff = tempBuff + blockNameLength;
-	} else {
-		retVal = false;
-	}
-
-	while (*tempBuff && retVal) {
-		retVal = isspace(*tempBuff);
-		++tempBuff;
-	}
-
-	return retVal;
+	return true;
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/Common/INI/INI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/INI/INI.cpp
@@ -1890,7 +1890,10 @@ Bool INI::isDeclarationOfType( AsciiString blockType, AsciiString blockName, cha
 		++tempBuff;
 	}
 
-	if (strlen(tempBuff) > blockTypeLength) {
+	size_t tempBuffLen = strlen(tempBuff);
+	char* tempBuffEnd = tempBuff + tempBuffLen;
+
+	if (tempBuffLen > blockTypeLength) {
 		restoreChar = tempBuff[blockTypeLength];
 		tempBuff[blockTypeLength] = 0;
 
@@ -1908,7 +1911,8 @@ Bool INI::isDeclarationOfType( AsciiString blockType, AsciiString blockName, cha
 		++tempBuff;
 	}
 
-	if (strlen(tempBuff) > blockNameLength) {
+	tempBuffLen = tempBuffEnd - tempBuff;
+	if (tempBuffLen > blockNameLength) {
 		restoreChar = tempBuff[blockNameLength];
 		tempBuff[blockNameLength] = 0;
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/INI/INI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/INI/INI.cpp
@@ -1922,8 +1922,8 @@ Bool INI::isDeclarationOfType( AsciiString blockType, AsciiString blockName, cha
 		retVal = false;
 	}
 
-	while (strlen(tempBuff)) {
-		retVal = retVal && isspace(tempBuff[0]);
+	while (*tempBuff) {
+		retVal = retVal && isspace(*tempBuff);
 		++tempBuff;
 	}
 
@@ -1968,8 +1968,8 @@ Bool INI::isEndOfBlock( char *bufferToCheck )
 		retVal = false;
 	}
 
-	while (strlen(tempBuff)) {
-		retVal = retVal && isspace(tempBuff[0]);
+	while (*tempBuff) {
+		retVal = retVal && isspace(*tempBuff);
 		++tempBuff;
 	}
 


### PR DESCRIPTION
This change improves INI whitespace read performance. The existing logic is inefficient as `strlen(tempBuff)` is O(n) and called on every loop iteration, making the loop O(n²). The null terminator is now checked directly and each character is iterated only once, reducing loop complexity to O(n).