### PR TITLE
bugfix: Prevent command execution when attempting to exit context while moving the camera

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
@@ -917,10 +917,8 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 			ICoord2D pixel = msg->getArgument( 0 )->pixel;
 			UnsignedInt currentTime = (UnsignedInt) msg->getArgument( 2 )->integer;
 
-			Bool isClick = TheMouse->isClick(&m_deselectFeedbackAnchor, &pixel, m_lastClick, currentTime);
-
 			// right click behavior (not right drag)
-			if (isClick)
+			if (TheMouse->isClick(&m_deselectFeedbackAnchor, &pixel, m_lastClick, currentTime))
 			{
 				//Added support to cancel the GUI command without deselecting the unit(s) involved
 				//when you right click.

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
@@ -919,12 +919,6 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 
 			Bool isClick = TheMouse->isClick(&m_deselectFeedbackAnchor, &pixel, m_lastClick, currentTime);
 
-			if (isClick &&
-					cameraPos.length() > TheMouse->m_dragTolerance3D)
-			{
-				isClick = FALSE;
-			}
-
 			// right click behavior (not right drag)
 			if (isClick)
 			{

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
@@ -993,10 +993,8 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 			ICoord2D pixel = msg->getArgument( 0 )->pixel;
 			UnsignedInt currentTime = (UnsignedInt) msg->getArgument( 2 )->integer;
 
-			Bool isClick = TheMouse->isClick(&m_deselectFeedbackAnchor, &pixel, m_lastClick, currentTime);
-
 			// right click behavior (not right drag)
-			if (isClick)
+			if (TheMouse->isClick(&m_deselectFeedbackAnchor, &pixel, m_lastClick, currentTime))
 			{
 				//Added support to cancel the GUI command without deselecting the unit(s) involved
 				//when you right click.

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
@@ -995,12 +995,6 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 
 			Bool isClick = TheMouse->isClick(&m_deselectFeedbackAnchor, &pixel, m_lastClick, currentTime);
 
-			if (isClick &&
-					cameraPos.length() > TheMouse->m_dragTolerance3D)
-			{
-				isClick = FALSE;
-			}
-
 			// right click behavior (not right drag)
 			if (isClick)
 			{


### PR DESCRIPTION
This change resolves a bug where right-clicking to cancel a context command such as a super weapon will actually trigger it if the camera is moving with a high enough scroll speed. This occurs because `MSG_RAW_MOUSE_RIGHT_BUTTON_UP` is not consumed for clicks determined to be invalid due to camera movement, allowing the message to be processed in `CommandXlat` where the same condition is not present.

An alternative approach would be to add the same camera movement condition to `CommandXlat`, but it feels counterintuitive to be unable to cancel context commands while the camera is moving with a high enough scroll speed. There are no apparent consequences to removing the condition.