### PR TITLE
fix(draw): Fix wheel rotation math

### DIFF
--- a/Core/Libraries/Source/WWVegas/WWMath/wwmath.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/wwmath.h
@@ -52,7 +52,8 @@
 */
 #define WWMATH_EPSILON		0.0001f
 #define WWMATH_EPSILON2		WWMATH_EPSILON * WWMATH_EPSILON
-#define WWMATH_PI				3.141592654f
+#define WWMATH_PI					3.141592654f
+#define WWMATH_TWO_PI			6.283185308f
 #define WWMATH_FLOAT_MAX	(FLT_MAX)
 #define WWMATH_FLOAT_MIN	(FLT_MIN)
 #define WWMATH_SQRT2			1.414213562f
@@ -170,6 +171,8 @@ static WWINLINE float			Byte_To_Unit_Float(unsigned char byte) { return ((float)
 
 static WWINLINE bool			Is_Valid_Float(float x);
 static WWINLINE bool			Is_Valid_Double(double x);
+
+static WWINLINE float Normalize_Angle(float angle); // Normalizes the angle to the range -PI..PI
 
 };
 
@@ -653,5 +656,9 @@ WWINLINE float WWMath::Inv_Sqrt(float val)
 }
 #endif
 
+WWINLINE float WWMath::Normalize_Angle(float angle)
+{
+	return angle - (WWMATH_TWO_PI * Floor((angle + WWMATH_PI) / WWMATH_TWO_PI));
+}
 
 #endif

--- a/GeneralsMD/Code/GameEngine/Include/Common/GameCommon.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GameCommon.h
@@ -487,6 +487,7 @@ enum WhichTurretType CPP_11(: Int)
 
 // ------------------------------------------------------------------------
 // this normalizes an angle to the range -PI...PI.
+// TheSuperHackers @todo DO NOT USE THIS FUNCTION! Use WWMath::Normalize_Angle instead. Delete this.
 extern Real normalizeAngle(Real angle);
 
 // ------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/GameCommon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/GameCommon.cpp
@@ -48,6 +48,7 @@ const char *TheRelationshipNames[] =
 };
 
 //-------------------------------------------------------------------------------------------------
+// TheSuperHackers @todo DO NOT USE THIS FUNCTION! Use WWMath::Normalize_Angle instead. Delete this.
 Real normalizeAngle(Real angle)
 {
 	DEBUG_ASSERTCRASH(!_isnan(angle), ("Angle is NAN in normalizeAngle!"));

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankTruckDraw.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankTruckDraw.cpp
@@ -540,21 +540,17 @@ void W3DTankTruckDraw::doDrawModule(const Matrix3D* transformMtx)
 	const Coord3D *vel = physics->getVelocity();
 	Real speed = physics->getVelocityMagnitude();
 
-
 	const TWheelInfo *wheelInfo = getDrawable()->getWheelInfo();	// note, can return null!
 	if (wheelInfo && (m_frontLeftTireBone || m_rearLeftTireBone))
 	{
-		static Real rotation = 0;
 		const Real rotationFactor = getW3DTankTruckDrawModuleData()->m_rotationSpeedMultiplier;
+		const Real powerslideRotationAddition = getW3DTankTruckDrawModuleData()->m_powerslideRotationAddition * m_isPowersliding;
+
 		m_frontWheelRotation += rotationFactor*speed;
-		if (m_isPowersliding)
-		{
-			m_rearWheelRotation += rotationFactor*(speed+getW3DTankTruckDrawModuleData()->m_powerslideRotationAddition);
-		}
-		else
-		{
-			m_rearWheelRotation += rotationFactor*speed;
-		}
+		m_rearWheelRotation += rotationFactor*(speed+powerslideRotationAddition);
+		m_frontWheelRotation = WWMath::Normalize_Angle(m_frontWheelRotation);
+		m_rearWheelRotation = WWMath::Normalize_Angle(m_rearWheelRotation);
+
 		Matrix3D wheelXfrm(1);
 		if (m_frontLeftTireBone)
 		{

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTruckDraw.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTruckDraw.cpp
@@ -461,7 +461,9 @@ void W3DTruckDraw::doDrawModule(const Matrix3D* transformMtx)
 
 	if (m_frontLeftTireBone || m_rearLeftTireBone)
 	{
-		Real powerslideRotationAddition = moduleData->m_powerslideRotationAddition;
+		const Real rotationFactor = moduleData->m_rotationSpeedMultiplier;
+		Real powerslideRotationAddition = moduleData->m_powerslideRotationAddition * m_isPowersliding;
+
 		if (ai) {
 			Locomotor *loco = ai->getCurLocomotor();
 			if (loco) {
@@ -471,16 +473,11 @@ void W3DTruckDraw::doDrawModule(const Matrix3D* transformMtx)
 				}
 			}
 		}
-		const Real rotationFactor = moduleData->m_rotationSpeedMultiplier;
+
 		m_frontWheelRotation += rotationFactor*speed;
-		if (m_isPowersliding)
-		{
-			m_rearWheelRotation += rotationFactor*(speed + powerslideRotationAddition);
-		}
-		else
-		{
-			m_rearWheelRotation += rotationFactor*speed;
-		}
+		m_rearWheelRotation += rotationFactor*(speed + powerslideRotationAddition);
+		m_frontWheelRotation = WWMath::Normalize_Angle(m_frontWheelRotation);
+		m_rearWheelRotation = WWMath::Normalize_Angle(m_rearWheelRotation);
 
 		// For now, just use the same values for mid wheels -- may want to do independent calcs later...
 		m_midFrontWheelRotation = m_frontWheelRotation;


### PR DESCRIPTION
This change just fixes the wheel rotation math. Is unlikely to be user facing but could be if a unit would drive forward for very long distances. Essentially the wheel rotation will keep accumulating and if the float number grows larger enough, then the float imprecision eventually would make the wheels no longer spin.

## TODO

- [ ] Replicate in Generals