### PR TITLE
bugfix(object): Healing no longer prevents stealthed objects from revealing when taking damage

### DIFF
--- a/Core/GameEngine/Include/Common/GameDefines.h
+++ b/Core/GameEngine/Include/Common/GameDefines.h
@@ -21,6 +21,10 @@
 // Note: Retail compatibility must not be broken before this project officially does.
 // Use RETAIL_COMPATIBLE_CRC and RETAIL_COMPATIBLE_XFER_SAVE to guard breaking changes.
 
+#ifndef RETAIL_COMPATIBLE_BUG
+#define RETAIL_COMPATIBLE_BUG (1) // Retain bugs present in retail Generals 1.08 and Zero Hour 1.04
+#endif
+
 #ifndef RETAIL_COMPATIBLE_CRC
 #define RETAIL_COMPATIBLE_CRC (1) // Game is expected to be CRC compatible with retail Generals 1.08, Zero Hour 1.04
 #endif

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp
@@ -593,7 +593,7 @@ void ActiveBody::attemptHealing( DamageInfo *damageInfo )
 		//(object pointer loses scope as soon as atteptdamage's caller ends)
 		m_lastDamageInfo = *damageInfo;
 		m_lastDamageCleared = false;
-#if RETAIL_COMPATIBLE_CRC
+#if RETAIL_COMPATIBLE_BUG
 		m_lastDamageTimestamp = TheGameLogic->getFrame();
 #endif
 		m_lastHealingTimestamp = TheGameLogic->getFrame();

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp
@@ -593,7 +593,9 @@ void ActiveBody::attemptHealing( DamageInfo *damageInfo )
 		//(object pointer loses scope as soon as atteptdamage's caller ends)
 		m_lastDamageInfo = *damageInfo;
 		m_lastDamageCleared = false;
+#if RETAIL_COMPATIBLE_CRC
 		m_lastDamageTimestamp = TheGameLogic->getFrame();
+#endif
 		m_lastHealingTimestamp = TheGameLogic->getFrame();
 
 		// if our health has gone UP then do run the damage module callback

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp
@@ -835,7 +835,9 @@ void ActiveBody::attemptHealing( DamageInfo *damageInfo )
 		//(object pointer loses scope as soon as atteptdamage's caller ends)
 		m_lastDamageInfo = *damageInfo;
 		m_lastDamageCleared = false;
+#if RETAIL_COMPATIBLE_CRC
 		m_lastDamageTimestamp = TheGameLogic->getFrame();
+#endif
 		m_lastHealingTimestamp = TheGameLogic->getFrame();
 
 		// if our health has gone UP then do run the damage module callback

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp
@@ -835,7 +835,7 @@ void ActiveBody::attemptHealing( DamageInfo *damageInfo )
 		//(object pointer loses scope as soon as atteptdamage's caller ends)
 		m_lastDamageInfo = *damageInfo;
 		m_lastDamageCleared = false;
-#if RETAIL_COMPATIBLE_CRC
+#if RETAIL_COMPATIBLE_BUG
 		m_lastDamageTimestamp = TheGameLogic->getFrame();
 #endif
 		m_lastHealingTimestamp = TheGameLogic->getFrame();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/StealthUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/StealthUpdate.cpp
@@ -317,8 +317,10 @@ Bool StealthUpdate::allowedToStealth( Object *stealthOwner ) const
 
 	if( flags & STEALTH_NOT_WHILE_TAKING_DAMAGE && self->getBodyModule()->getLastDamageTimestamp() >= now - 1 )
 	{
+#if RETAIL_COMPATIBLE_CRC
 		//Only if it's not healing damage.
 		if( self->getBodyModule()->getLastDamageInfo()->in.m_damageType != DAMAGE_HEALING )
+#endif
 		{
 			//Can't stealth if we just took damage in the last frame or two.
 			if( self->getBodyModule()->getLastDamageTimestamp() != 0xffffffff )

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/StealthUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/StealthUpdate.cpp
@@ -317,7 +317,7 @@ Bool StealthUpdate::allowedToStealth( Object *stealthOwner ) const
 
 	if( flags & STEALTH_NOT_WHILE_TAKING_DAMAGE && self->getBodyModule()->getLastDamageTimestamp() >= now - 1 )
 	{
-#if RETAIL_COMPATIBLE_CRC
+#if RETAIL_COMPATIBLE_BUG
 		//Only if it's not healing damage.
 		if( self->getBodyModule()->getLastDamageInfo()->in.m_damageType != DAMAGE_HEALING )
 #endif


### PR DESCRIPTION
This change stops healing from negating the `STEALTH_WHILE_NOT_TAKING_DAMAGE` status of stealthed objects.

In 1.04, if a stealthed object is being healed / repaired, it will not become visible when receiving damage despite having the `STEALTH_WHILE_NOT_TAKING_DAMAGE` status bit set (which all stealth structures - and Prince Kassad's GLA Rebel - do).

This happens due to the `m_lastDamageTimestamp` being erroneously updated when the object is _healed_, despite healing being tracked separately via `m_lastHealingTimestamp`. It seems as though this was either a lazy copy/paste or the healing timestamp was a later addition. The healing damage condition in the stealth update was likely added in an (unfortunately inadequate) attempt to counteract this oversight.

The bug fix itself - when isolated - is in fact retail compatible, but is nevertheless checked for `RETAIL_COMPATIBLE_BUG` to avoid any unforeseen consequences and maintain fairness with retail players.

Note: Generals does not have the `STEALTH_WHILE_NOT_TAKING_DAMAGE` status, so the fix does not fully apply there. However, the erroneous assignment also exists there and is corrected.

### Before
The building is not revealed when being actively repaired

https://github.com/user-attachments/assets/2d607cc1-ca7c-4a7d-bc5c-22aaae63846b

### After
The building is revealed even when being repaired

https://github.com/user-attachments/assets/29c5dbbf-0c86-4208-9deb-12575ecc64b7