### PR TITLE
tweak(eva): Enable EVA events for the observed player

### DIFF
--- a/Generals/Code/GameEngine/Include/GameClient/ControlBar.h
+++ b/Generals/Code/GameEngine/Include/GameClient/ControlBar.h
@@ -735,6 +735,8 @@ public:
 	Player* getCurrentlyViewedPlayer();
 	/// Returns the relationship with the currently viewed player. May return NEUTRAL if no player is selected while observing.
 	Relationship getCurrentlyViewedPlayerRelationship(const Team* team);
+	/// Returns the currently viewed player. Returns "Observer" if no player is selected while observing.
+	AsciiString getCurrentlyViewedPlayerSide();
 
 //	ControlBarResizer *getControlBarResizer( void ) {return m_controlBarResizer;}
 

--- a/Generals/Code/GameEngine/Source/GameClient/Eva.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Eva.cpp
@@ -25,6 +25,7 @@
 // GameClient/Eva.cpp /////////////////////////////////////////////////////////////////////////////
 
 #include "PreRTS.h"	// This must go first in EVERY cpp file int the GameEngine
+#include "GameClient/ControlBar.h"
 #include "GameClient/Eva.h"
 
 #include "Common/Player.h"
@@ -213,7 +214,7 @@ void Eva::update()
 		return;
 	}
 
-	m_localPlayer = ThePlayerList->getLocalPlayer();
+	m_localPlayer = TheControlBar->getCurrentlyViewedPlayer();
 	UnsignedInt frame = TheGameLogic->getFrame();
 
 	// Don't update for the first few frames. This way, we don't have to deal with our initial power
@@ -428,7 +429,7 @@ void Eva::processPlayingMessages(UnsignedInt currentFrame)
 	}
 
 	// We've got a winner!
-	AsciiString side = ThePlayerList->getLocalPlayer()->getSide();
+	AsciiString side = TheControlBar->getCurrentlyViewedPlayerSide();
 	Int numSides = storedIt->m_evaInfo->m_evaSideSounds.size();
 
 	for (Int i = 0; i < numSides; ++i) {

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -173,6 +173,14 @@ Relationship ControlBar::getCurrentlyViewedPlayerRelationship(const Team* team)
 	return NEUTRAL;
 }
 
+AsciiString ControlBar::getCurrentlyViewedPlayerSide()
+{
+	if (Player* player = getCurrentlyViewedPlayer())
+		player->getSide();
+
+	return ThePlayerList->getLocalPlayer()->getSide();
+}
+
 void ControlBar::populatePurchaseScience( Player* player )
 {
 //	TheInGameUI->deselectAllDrawables();

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/ControlBar.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/ControlBar.h
@@ -749,6 +749,8 @@ public:
 	Player* getCurrentlyViewedPlayer();
 	/// Returns the relationship with the currently viewed player. May return NEUTRAL if no player is selected while observing.
 	Relationship getCurrentlyViewedPlayerRelationship(const Team* team);
+	/// Returns the currently viewed player. Returns "Observer" if no player is selected while observing.
+	AsciiString getCurrentlyViewedPlayerSide();
 
 //	ControlBarResizer *getControlBarResizer( void ) {return m_controlBarResizer;}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Eva.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Eva.cpp
@@ -25,6 +25,7 @@
 // GameClient/Eva.cpp /////////////////////////////////////////////////////////////////////////////
 
 #include "PreRTS.h"	// This must go first in EVERY cpp file int the GameEngine
+#include "GameClient/ControlBar.h"
 #include "GameClient/Eva.h"
 
 #include "Common/Player.h"
@@ -286,7 +287,7 @@ void Eva::update()
 		return;
 	}
 
-	m_localPlayer = ThePlayerList->getLocalPlayer();
+	m_localPlayer = TheControlBar->getCurrentlyViewedPlayer();
 	UnsignedInt frame = TheGameLogic->getFrame();
 
 	// Don't update for the first few frames. This way, we don't have to deal with our initial power
@@ -515,7 +516,7 @@ void Eva::processPlayingMessages(UnsignedInt currentFrame)
 	}
 
 	// We've got a winner!
-	AsciiString side = ThePlayerList->getLocalPlayer()->getSide();
+	AsciiString side = TheControlBar->getCurrentlyViewedPlayerSide();
 	Int numSides = storedIt->m_evaInfo->m_evaSideSounds.size();
 
   // clear it. If we can't find the side we want, don't play anything

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -174,6 +174,14 @@ Relationship ControlBar::getCurrentlyViewedPlayerRelationship(const Team* team)
 	return NEUTRAL;
 }
 
+AsciiString ControlBar::getCurrentlyViewedPlayerSide()
+{
+	if (Player* player = getCurrentlyViewedPlayer())
+		return player->getSide();
+
+	return ThePlayerList->getLocalPlayer()->getSide();
+}
+
 void ControlBar::populatePurchaseScience( Player* player )
 {
 //	TheInGameUI->deselectAllDrawables();


### PR DESCRIPTION
This change allows EVA events to be processed for the observed player. This only includes `EVA_LowPower` for now as the other events are handled differently and will be added in follow-up changes.