### PR TITLE
bugfix(contain): Fix unit attachments being visible in fog after exiting a GLA Tunnel Network

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
@@ -163,12 +163,16 @@ void TunnelContain::onRemoving( Object *obj )
 	obj->clearDisabled( DISABLED_HELD );
 
 	/// place the object in the world at position of the container m_object
+#if RETAIL_COMPATIBLE_CRC
 	ThePartitionManager->registerObject( obj );
+#endif
 	obj->setPosition( getObject()->getPosition() );
 	if( obj->getDrawable() )
 	{
 		obj->setSafeOcclusionFrame(TheGameLogic->getFrame()+obj->getTemplate()->getOcclusionDelay());
+#if RETAIL_COMPATIBLE_CRC
 		obj->getDrawable()->setDrawableHidden( false );
+#endif
 	}
 
 	doUnloadSound();

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
@@ -172,6 +172,7 @@ void TunnelContain::onRemoving( Object *obj )
 		obj->getDrawable()->setDrawableHidden( false );
 	}
 #else
+	// TheSuperHackers @bugfix Now correctly adds the objects to the world without issues with shrouded portable structures.
 	obj->setPosition(getObject()->getPosition());
 	obj->setSafeOcclusionFrame(TheGameLogic->getFrame() + obj->getTemplate()->getOcclusionDelay());
 	addOrRemoveObjFromWorld(obj, TRUE);

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
@@ -165,21 +165,19 @@ void TunnelContain::onRemoving( Object *obj )
 	/// place the object in the world at position of the container m_object
 #if RETAIL_COMPATIBLE_CRC
 	ThePartitionManager->registerObject( obj );
-#endif
 	obj->setPosition( getObject()->getPosition() );
 	if( obj->getDrawable() )
 	{
 		obj->setSafeOcclusionFrame(TheGameLogic->getFrame()+obj->getTemplate()->getOcclusionDelay());
-#if RETAIL_COMPATIBLE_CRC
 		obj->getDrawable()->setDrawableHidden( false );
-#endif
 	}
-
-	doUnloadSound();
-
-#if !RETAIL_COMPATIBLE_CRC
+#else
+	obj->setPosition(getObject()->getPosition());
+	obj->setSafeOcclusionFrame(TheGameLogic->getFrame() + obj->getTemplate()->getOcclusionDelay());
 	addOrRemoveObjFromWorld(obj, TRUE);
 #endif
+
+	doUnloadSound();
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
@@ -105,10 +105,6 @@ void TunnelContain::removeFromContain( Object *obj, Bool exposeStealthUnits )
 		return;
 
 	owningPlayer->getTunnelSystem()->removeFromContain( obj, exposeStealthUnits );
-
-#if !RETAIL_COMPATIBLE_CRC
-	addOrRemoveObjFromWorld(obj, TRUE);
-#endif
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -176,6 +172,10 @@ void TunnelContain::onRemoving( Object *obj )
 	}
 
 	doUnloadSound();
+
+#if !RETAIL_COMPATIBLE_CRC
+	addOrRemoveObjFromWorld(obj, TRUE);
+#endif
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
@@ -106,6 +106,20 @@ void TunnelContain::removeFromContain( Object *obj, Bool exposeStealthUnits )
 
 	owningPlayer->getTunnelSystem()->removeFromContain( obj, exposeStealthUnits );
 
+#if !RETAIL_COMPATIBLE_CRC
+	if (obj->getContain())
+	{
+		const ContainedItemsList* items = obj->getContain()->getContainedItemsList();
+		if (items)
+		{
+			for (ContainedItemsList::const_iterator it = items->begin(); it != items->end(); ++it)
+			{
+				if (!obj->getContain()->isEnclosingContainerFor(*it))
+					ThePartitionManager->registerObject(*it);
+			}
+		}
+	}
+#endif
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
@@ -107,18 +107,7 @@ void TunnelContain::removeFromContain( Object *obj, Bool exposeStealthUnits )
 	owningPlayer->getTunnelSystem()->removeFromContain( obj, exposeStealthUnits );
 
 #if !RETAIL_COMPATIBLE_CRC
-	if (obj->getContain())
-	{
-		const ContainedItemsList* items = obj->getContain()->getContainedItemsList();
-		if (items)
-		{
-			for (ContainedItemsList::const_iterator it = items->begin(); it != items->end(); ++it)
-			{
-				if (!obj->getContain()->isEnclosingContainerFor(*it))
-					ThePartitionManager->registerObject(*it);
-			}
-		}
-	}
+	addOrRemoveObjFromWorld(obj, TRUE);
 #endif
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
@@ -242,21 +242,19 @@ void TunnelContain::onRemoving( Object *obj )
 	/// place the object in the world at position of the container m_object
 #if RETAIL_COMPATIBLE_CRC
 	ThePartitionManager->registerObject( obj );
-#endif
 	obj->setPosition( getObject()->getPosition() );
 	if( obj->getDrawable() )
 	{
 		obj->setSafeOcclusionFrame(TheGameLogic->getFrame()+obj->getTemplate()->getOcclusionDelay());
-#if RETAIL_COMPATIBLE_CRC
 		obj->getDrawable()->setDrawableHidden( false );
-#endif
 	}
-
-	doUnloadSound();
-
-#if !RETAIL_COMPATIBLE_CRC
+#else
+	obj->setPosition(getObject()->getPosition());
+	obj->setSafeOcclusionFrame(TheGameLogic->getFrame() + obj->getTemplate()->getOcclusionDelay());
 	addOrRemoveObjFromWorld(obj, TRUE);
 #endif
+
+	doUnloadSound();
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
@@ -240,12 +240,16 @@ void TunnelContain::onRemoving( Object *obj )
 	obj->clearDisabled( DISABLED_HELD );
 
 	/// place the object in the world at position of the container m_object
+#if RETAIL_COMPATIBLE_CRC
 	ThePartitionManager->registerObject( obj );
+#endif
 	obj->setPosition( getObject()->getPosition() );
 	if( obj->getDrawable() )
 	{
 		obj->setSafeOcclusionFrame(TheGameLogic->getFrame()+obj->getTemplate()->getOcclusionDelay());
+#if RETAIL_COMPATIBLE_CRC
 		obj->getDrawable()->setDrawableHidden( false );
+#endif
 	}
 
 	doUnloadSound();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
@@ -105,10 +105,6 @@ void TunnelContain::removeFromContain( Object *obj, Bool exposeStealthUnits )
 		return;
 
 	owningPlayer->getTunnelSystem()->removeFromContain( obj, exposeStealthUnits );
-
-#if !RETAIL_COMPATIBLE_CRC
-	addOrRemoveObjFromWorld(obj, TRUE);
-#endif
 }
 
 
@@ -254,7 +250,9 @@ void TunnelContain::onRemoving( Object *obj )
 
 	doUnloadSound();
 
-
+#if !RETAIL_COMPATIBLE_CRC
+	addOrRemoveObjFromWorld(obj, TRUE);
+#endif
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
@@ -106,6 +106,20 @@ void TunnelContain::removeFromContain( Object *obj, Bool exposeStealthUnits )
 
 	owningPlayer->getTunnelSystem()->removeFromContain( obj, exposeStealthUnits );
 
+#if !RETAIL_COMPATIBLE_CRC
+	if (obj->getContain())
+	{
+		const ContainedItemsList* items = obj->getContain()->getContainedItemsList();
+		if (items)
+		{
+			for (ContainedItemsList::const_iterator it = items->begin(); it != items->end(); ++it)
+			{
+				if (!obj->getContain()->isEnclosingContainerFor(*it))
+					ThePartitionManager->registerObject(*it);
+			}
+		}
+	}
+#endif
 }
 
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
@@ -107,18 +107,7 @@ void TunnelContain::removeFromContain( Object *obj, Bool exposeStealthUnits )
 	owningPlayer->getTunnelSystem()->removeFromContain( obj, exposeStealthUnits );
 
 #if !RETAIL_COMPATIBLE_CRC
-	if (obj->getContain())
-	{
-		const ContainedItemsList* items = obj->getContain()->getContainedItemsList();
-		if (items)
-		{
-			for (ContainedItemsList::const_iterator it = items->begin(); it != items->end(); ++it)
-			{
-				if (!obj->getContain()->isEnclosingContainerFor(*it))
-					ThePartitionManager->registerObject(*it);
-			}
-		}
-	}
+	addOrRemoveObjFromWorld(obj, TRUE);
 #endif
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TunnelContain.cpp
@@ -249,6 +249,7 @@ void TunnelContain::onRemoving( Object *obj )
 		obj->getDrawable()->setDrawableHidden( false );
 	}
 #else
+	// TheSuperHackers @bugfix Now correctly adds the objects to the world without issues with shrouded portable structures.
 	obj->setPosition(getObject()->getPosition());
 	obj->setSafeOcclusionFrame(TheGameLogic->getFrame() + obj->getTemplate()->getOcclusionDelay());
 	addOrRemoveObjFromWorld(obj, TRUE);


### PR DESCRIPTION
Fixes #29

This change prevents unit attachments from being visible through fog after exiting a Tunnel Network. The tunnel garrison logic goes through a different pathway and does not add the occupants of open containers (e.g. Avenger turrets) to the partition manager on exit. Unfortunately, this change is not retail compatible (though maybe for the best as it would introduce a disadvantage over retail).

See the comparison below:

https://github.com/user-attachments/assets/dbd376eb-7b99-4634-a709-8a00814e6b86

**Left client:** This change - the blue player cannot see the turret attachment of the green Avenger through the fog ✔️
**Right client:** Retail build - the green player can see the turret attachment of the blue Avenger through the fog ❌