### PR TITLE
tweak(network): Transfer assets of disconnected players to allies

### DIFF
--- a/Generals/Code/GameEngine/Source/GameNetwork/Network.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/Network.cpp
@@ -665,7 +665,11 @@ void Network::processDestroyPlayerCommand(NetDestroyPlayerCommandMsg *msg)
 	if (pPlayer)
 	{
 		GameMessage *msg = newInstance(GameMessage)(GameMessage::MSG_SELF_DESTRUCT);
+#if RETAIL_COMPATIBLE_CRC
 		msg->appendBooleanArgument(FALSE);
+#else
+		msg->appendBooleanArgument(TRUE);
+#endif
 		msg->friend_setPlayerIndex(pPlayer->getPlayerIndex());
 		TheCommandList->appendMessage(msg);
 	}

--- a/Generals/Code/GameEngine/Source/GameNetwork/Network.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/Network.cpp
@@ -666,10 +666,11 @@ void Network::processDestroyPlayerCommand(NetDestroyPlayerCommandMsg *msg)
 	{
 		GameMessage *msg = newInstance(GameMessage)(GameMessage::MSG_SELF_DESTRUCT);
 #if RETAIL_COMPATIBLE_CRC
-		msg->appendBooleanArgument(FALSE);
+		const Bool transferAssets = FALSE;
 #else
-		msg->appendBooleanArgument(TRUE);
+		const Bool transferAssets = TRUE;
 #endif
+		msg->appendBooleanArgument(transferAssets);
 		msg->friend_setPlayerIndex(pPlayer->getPlayerIndex());
 		TheCommandList->appendMessage(msg);
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/Network.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/Network.cpp
@@ -665,7 +665,11 @@ void Network::processDestroyPlayerCommand(NetDestroyPlayerCommandMsg *msg)
 	if (pPlayer)
 	{
 		GameMessage *msg = newInstance(GameMessage)(GameMessage::MSG_SELF_DESTRUCT);
+#if RETAIL_COMPATIBLE_CRC
 		msg->appendBooleanArgument(FALSE);
+#else
+		msg->appendBooleanArgument(TRUE);
+#endif
 		msg->friend_setPlayerIndex(pPlayer->getPlayerIndex());
 		TheCommandList->appendMessage(msg);
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/Network.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/Network.cpp
@@ -666,10 +666,11 @@ void Network::processDestroyPlayerCommand(NetDestroyPlayerCommandMsg *msg)
 	{
 		GameMessage *msg = newInstance(GameMessage)(GameMessage::MSG_SELF_DESTRUCT);
 #if RETAIL_COMPATIBLE_CRC
-		msg->appendBooleanArgument(FALSE);
+		const Bool transferAssets = FALSE;
 #else
-		msg->appendBooleanArgument(TRUE);
+		const Bool transferAssets = TRUE;
 #endif
+		msg->appendBooleanArgument(transferAssets);
 		msg->friend_setPlayerIndex(pPlayer->getPlayerIndex());
 		TheCommandList->appendMessage(msg);
 	}


### PR DESCRIPTION
Fixes #162

This change allows a player's assets to be transferred to their allies upon disconnect.