### PR TITLE
feat: Pressing H can now navigate to the currently observed player's Command Center

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -884,7 +884,7 @@ void findCommandCenterOrMostExpensiveBuilding(Object* obj, void* vccl)
 
 static void viewCommandCenter( void )
 {
-	Player* localPlayer = ThePlayerList->getLocalPlayer();
+	Player* localPlayer = TheControlBar->getCurrentlyViewedPlayer();
 	if (!localPlayer)
 		return;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -943,7 +943,7 @@ void findCommandCenterOrMostExpensiveBuilding(Object* obj, void* vccl)
 
 static void viewCommandCenter( void )
 {
-	Player* localPlayer = ThePlayerList->getLocalPlayer();
+	Player* localPlayer = TheControlBar->getCurrentlyViewedPlayer();
 	if (!localPlayer)
 		return;
 


### PR DESCRIPTION
This change allows pressing H to navigate to the currently observed player's Command Center or highest value building.