### PR TITLE
tweak(command): Allow observer to view the Hero unit of the currently observed player with a button press

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -926,7 +926,7 @@ void amIAHero(Object* obj, void* heroHolder)
 
 static Object *iNeedAHero( void )
 {
-	Player* localPlayer = ThePlayerList->getLocalPlayer();
+	Player* localPlayer = TheControlBar->getCurrentlyViewedPlayer();
 	if (!localPlayer)
 		return NULL;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -985,7 +985,7 @@ void amIAHero(Object* obj, void* heroHolder)
 
 static Object *iNeedAHero( void )
 {
-	Player* localPlayer = ThePlayerList->getLocalPlayer();
+	Player* localPlayer = TheControlBar->getCurrentlyViewedPlayer();
 	if (!localPlayer)
 		return NULL;
 


### PR DESCRIPTION
This change allows pressing CTRL+H to navigate to the currently observed player's hero unit.