### PR TITLE
bugfix(module): Consistently yield experience for direct poison kills

### DIFF
--- a/Generals/Code/GameEngine/Include/GameLogic/Module/PoisonedBehavior.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/PoisonedBehavior.h
@@ -92,6 +92,7 @@ private:
 	UnsignedInt		m_poisonDamageFrame;
 	UnsignedInt		m_poisonOverallStopFrame;
 	Real					m_poisonDamageAmount;
+	ObjectID			m_poisonSource;
 	DeathType			m_deathType;
 
 };

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/PoisonedBehavior.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/PoisonedBehavior.cpp
@@ -159,6 +159,7 @@ void PoisonedBehavior::startPoisonedEffects( const DamageInfo *damageInfo )
 	// We are going to take the damage dealt by the original poisoner every so often for a while.
 	m_poisonDamageAmount = damageInfo->out.m_actualDamageDealt;
 #if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix Stubbjax 03/09/2025 Allow poison damage to award xp to the poison source.
 	m_poisonSource = damageInfo->in.m_sourceID;
 #endif
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/PoisonedBehavior.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/PoisonedBehavior.cpp
@@ -70,6 +70,7 @@ PoisonedBehavior::PoisonedBehavior( Thing *thing, const ModuleData* moduleData )
 	m_poisonDamageFrame = 0;
 	m_poisonOverallStopFrame = 0;
 	m_poisonDamageAmount = 0.0f;
+	m_poisonSource = INVALID_ID;
 	m_deathType = DEATH_POISONED;
 	setWakeFrame(getObject(), UPDATE_SLEEP_FOREVER);
 }
@@ -117,7 +118,7 @@ UpdateSleepTime PoisonedBehavior::update()
 		// If it is time to do damage, then do it and reset the damage timer
 		DamageInfo damage;
 		damage.in.m_amount = m_poisonDamageAmount;
-		damage.in.m_sourceID = INVALID_ID;
+		damage.in.m_sourceID = m_poisonSource;
 		damage.in.m_damageType = DAMAGE_UNRESISTABLE; // Not poison, as that will infect us again
 		damage.in.m_deathType = m_deathType;
 		getObject()->attemptDamage( &damage );
@@ -157,6 +158,9 @@ void PoisonedBehavior::startPoisonedEffects( const DamageInfo *damageInfo )
 
 	// We are going to take the damage dealt by the original poisoner every so often for a while.
 	m_poisonDamageAmount = damageInfo->out.m_actualDamageDealt;
+#if !RETAIL_COMPATIBLE_CRC
+	m_poisonSource = damageInfo->in.m_sourceID;
+#endif
 
 	m_poisonOverallStopFrame = now + d->m_poisonDurationData;
 
@@ -182,6 +186,7 @@ void PoisonedBehavior::stopPoisonedEffects()
 	m_poisonDamageFrame = 0;
 	m_poisonOverallStopFrame = 0;
 	m_poisonDamageAmount = 0.0f;
+	m_poisonSource = INVALID_ID;
 
 	Drawable *myDrawable = getObject()->getDrawable();
 	if( myDrawable )
@@ -208,7 +213,7 @@ void PoisonedBehavior::xfer( Xfer *xfer )
 {
 
 	// version
-	const XferVersion currentVersion = 2;
+	const XferVersion currentVersion = 3;
 	XferVersion version = currentVersion;
 	xfer->xferVersion( &version, currentVersion );
 
@@ -229,6 +234,10 @@ void PoisonedBehavior::xfer( Xfer *xfer )
 		xfer->xferUser(&m_deathType, sizeof(m_deathType));
 	}
 
+	if (version >= 3)
+	{
+		xfer->xferObjectID(&m_poisonSource);
+	}
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/PoisonedBehavior.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/PoisonedBehavior.cpp
@@ -213,7 +213,11 @@ void PoisonedBehavior::xfer( Xfer *xfer )
 {
 
 	// version
+#if RETAIL_COMPATIBLE_XFER_SAVE
+	const XferVersion currentVersion = 2;
+#else
 	const XferVersion currentVersion = 3;
+#endif
 	XferVersion version = currentVersion;
 	xfer->xferVersion( &version, currentVersion );
 
@@ -234,10 +238,12 @@ void PoisonedBehavior::xfer( Xfer *xfer )
 		xfer->xferUser(&m_deathType, sizeof(m_deathType));
 	}
 
+#if !RETAIL_COMPATIBLE_XFER_SAVE
 	if (version >= 3)
 	{
 		xfer->xferObjectID(&m_poisonSource);
 	}
+#endif
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/PoisonedBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/PoisonedBehavior.h
@@ -92,6 +92,7 @@ private:
 	UnsignedInt		m_poisonDamageFrame;
 	UnsignedInt		m_poisonOverallStopFrame;
 	Real					m_poisonDamageAmount;
+	ObjectID			m_poisonSource;
 	DeathType			m_deathType;
 
 };

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/PoisonedBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/PoisonedBehavior.cpp
@@ -70,6 +70,7 @@ PoisonedBehavior::PoisonedBehavior( Thing *thing, const ModuleData* moduleData )
 	m_poisonDamageFrame = 0;
 	m_poisonOverallStopFrame = 0;
 	m_poisonDamageAmount = 0.0f;
+	m_poisonSource = INVALID_ID;
 	m_deathType = DEATH_POISONED;
 	setWakeFrame(getObject(), UPDATE_SLEEP_FOREVER);
 }
@@ -117,7 +118,7 @@ UpdateSleepTime PoisonedBehavior::update()
 		// If it is time to do damage, then do it and reset the damage timer
 		DamageInfo damage;
 		damage.in.m_amount = m_poisonDamageAmount;
-		damage.in.m_sourceID = INVALID_ID;
+		damage.in.m_sourceID = m_poisonSource;
 		damage.in.m_damageType = DAMAGE_UNRESISTABLE; // Not poison, as that will infect us again
 		damage.in.m_damageFXOverride = DAMAGE_POISON; // but this will ensure that the right effect is played
 		damage.in.m_deathType = m_deathType;
@@ -158,6 +159,9 @@ void PoisonedBehavior::startPoisonedEffects( const DamageInfo *damageInfo )
 
 	// We are going to take the damage dealt by the original poisoner every so often for a while.
 	m_poisonDamageAmount = damageInfo->out.m_actualDamageDealt;
+#if !RETAIL_COMPATIBLE_CRC
+	m_poisonSource = damageInfo->in.m_sourceID;
+#endif
 
 	m_poisonOverallStopFrame = now + d->m_poisonDurationData;
 
@@ -183,6 +187,7 @@ void PoisonedBehavior::stopPoisonedEffects()
 	m_poisonDamageFrame = 0;
 	m_poisonOverallStopFrame = 0;
 	m_poisonDamageAmount = 0.0f;
+	m_poisonSource = INVALID_ID;
 
 	Drawable *myDrawable = getObject()->getDrawable();
 	if( myDrawable )
@@ -209,7 +214,7 @@ void PoisonedBehavior::xfer( Xfer *xfer )
 {
 
 	// version
-	const XferVersion currentVersion = 2;
+	const XferVersion currentVersion = 3;
 	XferVersion version = currentVersion;
 	xfer->xferVersion( &version, currentVersion );
 
@@ -230,6 +235,10 @@ void PoisonedBehavior::xfer( Xfer *xfer )
 		xfer->xferUser(&m_deathType, sizeof(m_deathType));
 	}
 
+	if (version >= 3)
+	{
+		xfer->xferObjectID(&m_poisonSource);
+	}
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/PoisonedBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/PoisonedBehavior.cpp
@@ -160,6 +160,7 @@ void PoisonedBehavior::startPoisonedEffects( const DamageInfo *damageInfo )
 	// We are going to take the damage dealt by the original poisoner every so often for a while.
 	m_poisonDamageAmount = damageInfo->out.m_actualDamageDealt;
 #if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix Stubbjax 03/09/2025 Allow poison damage to award xp to the poison source.
 	m_poisonSource = damageInfo->in.m_sourceID;
 #endif
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/PoisonedBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/PoisonedBehavior.cpp
@@ -214,7 +214,11 @@ void PoisonedBehavior::xfer( Xfer *xfer )
 {
 
 	// version
+#if RETAIL_COMPATIBLE_XFER_SAVE
+	const XferVersion currentVersion = 2;
+#else
 	const XferVersion currentVersion = 3;
+#endif
 	XferVersion version = currentVersion;
 	xfer->xferVersion( &version, currentVersion );
 
@@ -235,10 +239,12 @@ void PoisonedBehavior::xfer( Xfer *xfer )
 		xfer->xferUser(&m_deathType, sizeof(m_deathType));
 	}
 
+#if !RETAIL_COMPATIBLE_XFER_SAVE
 	if (version >= 3)
 	{
 		xfer->xferObjectID(&m_poisonSource);
 	}
+#endif
 }
 
 // ------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This change causes units who die via poisoned status to consistently yield experience to the poison status source.

This is only applicable to poison damage dealt directly, rather than via a spawned OCL such as a poison field. It is _not_ applicable to poison damage that is applied _after_ the source has been destroyed - i.e. if a toxin stream projectile no longer exists at the time of poison death, no experience is awarded (which happens when lightly spraying an infantry unit and then running away - the infantry unit does not yield experience when succumbing to the poison damage tick as the toxin stream no longer exists).

This change essentially makes experience yields consistent for units directly killed by poison damage weapons. The below test scenario highlights the severity of the inconsistency.

**Scenario:** A Toxin Rebel fires at a continuous conga line of Missile Defenders
**Sample size:** 1,000
**Results:** 397 kills rewarded experience, 603 kills did not
**Percentage:** 39.7%

This demonstrates that Toxin Rebels (and Toxin Tractors) only receive experience from direct infantry kills roughly 40% of the time in the retail game. Given that this 40% modifier does _not_ apply when killing vehicles or garrisoned infantry (nor when capturing buildings), the impact of this fix is not as straightforward as one might expect.

### Before
The Toxin Rebel has to kill 5 Tank Hunters to rank up, as 3 of them do not yield xp due to poison damage tick scoring the kill

https://github.com/user-attachments/assets/e65f60d9-601a-45d9-bfda-d2c57af484ba

### After
The Toxin Rebel consistently gains experience when scoring a kill, ranking up after killing 2 Tank Hunters as expected

https://github.com/user-attachments/assets/c17061c2-f996-4912-a598-38b6124362cf