### PR TITLE
refactor: Remove superfluous null tests before calls to deleteInstance()

### DIFF
--- a/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
+++ b/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
@@ -184,11 +184,9 @@ AudioManager::~AudioManager()
 	AudioEventInfoHashIt it;
 	for (it = m_allAudioEventInfo.begin(); it != m_allAudioEventInfo.end(); ++it) {
 		AudioEventInfo *eventInfo = (*it).second;
-		if (eventInfo) {
-			deleteInstance(eventInfo);
-			eventInfo = NULL;
-		}
+		deleteInstance(eventInfo);
 	}
+	m_allAudioEventInfo.clear();
 
 	delete m_silentAudioEvent;
 	m_silentAudioEvent = NULL;
@@ -807,9 +805,7 @@ AudioRequest *AudioManager::allocateAudioRequest( Bool useAudioEvent )
 //-------------------------------------------------------------------------------------------------
 void AudioManager::releaseAudioRequest( AudioRequest *requestToRelease )
 {
-	if (requestToRelease) {
-		deleteInstance(requestToRelease);
-	}
+	deleteInstance(requestToRelease);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Include/Common/Overridable.h
+++ b/Generals/Code/GameEngine/Include/Common/Overridable.h
@@ -122,8 +122,7 @@ class Overridable : public MemoryPoolObject
 // cleans up and dangling overrides.
 __inline Overridable::~Overridable()
 {
-	if (m_nextOverride)
-		deleteInstance(m_nextOverride);
+	deleteInstance(m_nextOverride);
 }
 
 

--- a/Generals/Code/GameEngine/Include/Common/StateMachine.h
+++ b/Generals/Code/GameEngine/Include/Common/StateMachine.h
@@ -483,7 +483,8 @@ EMPTY_DTOR(SleepState)
 // @todo Replace calls to deleteInstance with RefCountPtr<StateMachine> when so appropriate.
 inline void deleteInstance(StateMachine* machine)
 {
-	machine->Release_Ref();
+	if (machine != NULL)
+		machine->Release_Ref();
 }
 
 

--- a/Generals/Code/GameEngine/Include/Common/ThingTemplate.h
+++ b/Generals/Code/GameEngine/Include/Common/ThingTemplate.h
@@ -158,8 +158,7 @@ public:
 	~AudioArray()
 	{
 		for (Int i = 0; i < TTAUDIO_COUNT; ++i)
-			if (m_audio[i])
-				deleteInstance(m_audio[i]);
+			deleteInstance(m_audio[i]);
 	}
 
 	AudioArray(const AudioArray& that)

--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -1022,8 +1022,7 @@ GlobalData::~GlobalData( void )
 {
 	DEBUG_ASSERTCRASH( TheWritableGlobalData->m_next == NULL, ("~GlobalData: theOriginal is not original") );
 
-	if (m_weaponBonusSet)
-		deleteInstance(m_weaponBonusSet);
+	deleteInstance(m_weaponBonusSet);
 
 	if( m_theOriginal == this )	{
 		m_theOriginal = NULL;

--- a/Generals/Code/GameEngine/Source/Common/INI/INI.cpp
+++ b/Generals/Code/GameEngine/Source/Common/INI/INI.cpp
@@ -1186,11 +1186,8 @@ void INI::parseDynamicAudioEventRTS( INI *ini, void * /*instance*/, void *store,
 	// translate the string into a sound
 	if (stricmp(token, "NoSound") == 0)
 	{
-		if (*theSound)
-		{
-			deleteInstance(*theSound);
-			*theSound = NULL;
-		}
+		deleteInstance(*theSound);
+		*theSound = NULL;
 	}
 	else
 	{

--- a/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -368,54 +368,36 @@ void Player::init(const PlayerTemplate* pt)
 	m_bombardBattlePlans = 0;
 	m_holdTheLineBattlePlans = 0;
 	m_searchAndDestroyBattlePlans = 0;
-	if( m_battlePlanBonuses )
-	{
-		deleteInstance(m_battlePlanBonuses);
-		m_battlePlanBonuses = NULL;
-	}
+
+	deleteInstance(m_battlePlanBonuses);
+	m_battlePlanBonuses = NULL;
 
 	deleteUpgradeList();
 
 	m_energy.init(this);
 	m_stats.init();
-	if (m_pBuildList != NULL)
-	{
-		deleteInstance(m_pBuildList);
-		m_pBuildList = NULL;
-	}
+
+	deleteInstance(m_pBuildList);
+	m_pBuildList = NULL;
+
 	m_defaultTeam = NULL;
 
-	if (m_ai)
-	{
-		deleteInstance(m_ai);
-	}
+	deleteInstance(m_ai);
 	m_ai = NULL;
 
-	if( m_resourceGatheringManager )
-	{
-		deleteInstance(m_resourceGatheringManager);
-		m_resourceGatheringManager = NULL;
-	}
+	deleteInstance(m_resourceGatheringManager);
+	m_resourceGatheringManager = NULL;
 
 	for (Int i = 0; i < NUM_HOTKEY_SQUADS; ++i) {
-		if (m_squads[i] != NULL) {
-			deleteInstance(m_squads[i]);
-			m_squads[i] = NULL;
-		}
+		deleteInstance(m_squads[i]);
 		m_squads[i] = newInstance(Squad);
 	}
 
-	if (m_currentSelection != NULL) {
-		deleteInstance(m_currentSelection) ;
-		m_currentSelection = NULL;
-	}
+	deleteInstance(m_currentSelection);
 	m_currentSelection = newInstance(Squad);
 
-	if( m_tunnelSystem )
-	{
-		deleteInstance(m_tunnelSystem);
-		m_tunnelSystem = NULL;
-	}
+	deleteInstance(m_tunnelSystem);
+	m_tunnelSystem = NULL;
 
 	m_canBuildBase = true;
 	m_canBuildUnits = true;
@@ -494,8 +476,7 @@ void Player::init(const PlayerTemplate* pt)
 	{
 		KindOfPercentProductionChange *tof = *it;
 		it = m_kindOfPercentProductionChangeList.erase( it );
-		if(tof)
-			deleteInstance(tof);
+		deleteInstance(tof);
 	}
 
 }
@@ -515,25 +496,21 @@ Player::~Player()
 
 	// delete the relation maps (the destructor clears the actual map if any data is present)
 	deleteInstance(m_teamRelations);
+	m_teamRelations = NULL;
+
 	deleteInstance(m_playerRelations);
+	m_playerRelations = NULL;
 
 	for (Int i = 0; i < NUM_HOTKEY_SQUADS; ++i) {
-		if (m_squads[i] != NULL) {
-			deleteInstance(m_squads[i]);
-			m_squads[i] = NULL;
-		}
+		deleteInstance(m_squads[i]);
+		m_squads[i] = NULL;
 	}
 
-	if (m_currentSelection != NULL) {
-		deleteInstance(m_currentSelection);
-		m_currentSelection = NULL;
-	}
+	deleteInstance(m_currentSelection);
+	m_currentSelection = NULL;
 
-	if( m_battlePlanBonuses )
-	{
-		deleteInstance(m_battlePlanBonuses);
-		m_battlePlanBonuses = NULL;
-	}
+	deleteInstance(m_battlePlanBonuses);
+	m_battlePlanBonuses = NULL;
 }
 
 //=============================================================================
@@ -640,10 +617,7 @@ Bool Player::removeTeamRelationship(const Team *that)
 void Player::setBuildList(BuildListInfo *pBuildList)
 {
 
-	if (m_pBuildList != NULL)
-	{
-		deleteInstance(m_pBuildList);
-	}
+	deleteInstance(m_pBuildList);
 	m_pBuildList = pBuildList;
 
 }
@@ -706,10 +680,7 @@ void Player::setPlayerType(PlayerType t, Bool skirmish)
 {
 	m_playerType = t;
 
-	if (m_ai)
-	{
-		deleteInstance(m_ai);
-	}
+	deleteInstance(m_ai);
 	m_ai = NULL;
 
 	if (t == PLAYER_COMPUTER)
@@ -742,11 +713,8 @@ void Player::setDefaultTeam(void) {
 //=============================================================================
 void Player::deletePlayerAI()
 {
-	if (m_ai)
-	{
-		deleteInstance(m_ai);
-		m_ai = NULL;
-	}
+	deleteInstance(m_ai);
+	m_ai = NULL;
 }
 
 //=============================================================================
@@ -820,10 +788,10 @@ void Player::initFromDict(const Dict* d)
 
 				ScriptList *scripts = TheSidesList->getSkirmishSideInfo(i)->getScriptList()->duplicateAndQualify(
 							qualifier, qualTemplatePlayerName, pname);
-				if (TheSidesList->getSideInfo(getPlayerIndex())->getScriptList()) {
-					deleteInstance(TheSidesList->getSideInfo(getPlayerIndex())->getScriptList());
-				}
+
+				deleteInstance(TheSidesList->getSideInfo(getPlayerIndex())->getScriptList());
 				TheSidesList->getSideInfo(getPlayerIndex())->setScriptList(scripts);
+
 				deleteInstance(TheSidesList->getSkirmishSideInfo(i)->getScriptList());
 				TheSidesList->getSkirmishSideInfo(i)->setScriptList(NULL);
 			}
@@ -869,12 +837,10 @@ void Player::initFromDict(const Dict* d)
 			qualifier.format("%d", m_mpStartIndex);
 			ScriptList *scripts = TheSidesList->getSkirmishSideInfo(skirmishNdx)->getScriptList()->duplicateAndQualify(
 						qualifier, qualTemplatePlayerName, pname);
-			ScriptList* slist = TheSidesList->getSideInfo(getPlayerIndex())->getScriptList();
-			if (slist)
-			{
-				deleteInstance(slist);
-			}
+
+			deleteInstance(TheSidesList->getSideInfo(getPlayerIndex())->getScriptList());
 			TheSidesList->getSideInfo(getPlayerIndex())->setScriptList(scripts);
+
 			for (i=0; i<TheSidesList->getNumTeams(); i++) {
 				if (TheSidesList->getTeamInfo(i)->getDict()->getAsciiString(TheKey_teamOwner) == pname)
 				{
@@ -941,18 +907,11 @@ void Player::initFromDict(const Dict* d)
 			}
 		}
 	}
-	if( m_resourceGatheringManager )
-	{
-		deleteInstance(m_resourceGatheringManager);
-		m_resourceGatheringManager = NULL;
-	}
+
+	deleteInstance(m_resourceGatheringManager);
 	m_resourceGatheringManager = newInstance(ResourceGatheringManager);
 
-	if( m_tunnelSystem )
-	{
-		deleteInstance(m_tunnelSystem);
-		m_tunnelSystem = NULL;
-	}
+	deleteInstance(m_tunnelSystem);
 	m_tunnelSystem = newInstance(TunnelTracker);
 
 	m_handicap.readFromDict(d);
@@ -987,18 +946,11 @@ void Player::initFromDict(const Dict* d)
 		m_money.deposit(m);
 
 	for ( i = 0; i < NUM_HOTKEY_SQUADS; ++i ) {
-		if (m_squads[i] != NULL)
-		{
-			deleteInstance(m_squads[i]);
-			m_squads[i] = NULL;
-		}
+		deleteInstance(m_squads[i]);
 		m_squads[i] = newInstance( Squad );
 	}
 
-	if (m_currentSelection != NULL) {
-		deleteInstance(m_currentSelection);
-		m_currentSelection = NULL;
-	}
+	deleteInstance(m_currentSelection);
 	m_currentSelection = newInstance( Squad );
 }
 
@@ -3376,8 +3328,7 @@ void Player::removeKindOfProductionCostChange(	KindOfMaskType kindOf, Real perce
 			if(tof->m_ref == 0)
 			{
 				m_kindOfPercentProductionChangeList.erase( it );
-				if(tof)
-					deleteInstance(tof);
+				deleteInstance(tof);
 			}
 			return;
 		}
@@ -3714,8 +3665,7 @@ void Player::xfer( Xfer *xfer )
 		// destroy any build list that we got from loading the bare bones map, note that deleting
 		// the head of these structures automatically deletes any links attached
 		//
-		if( m_pBuildList)
-			deleteInstance(m_pBuildList);
+		deleteInstance(m_pBuildList);
 		m_pBuildList = NULL;
 
 		// read each build list info
@@ -4065,11 +4015,9 @@ void Player::xfer( Xfer *xfer )
 	xfer->xferBool( &battlePlanBonus ); //If we're loading, it just replaces the bool
 	if( xfer->getXferMode() == XFER_LOAD )
 	{
-		if (m_battlePlanBonuses)
-		{
-			deleteInstance(m_battlePlanBonuses);
-			m_battlePlanBonuses = NULL;
-		}
+		deleteInstance(m_battlePlanBonuses);
+		m_battlePlanBonuses = NULL;
+
 		if ( battlePlanBonus )
 		{
 			m_battlePlanBonuses = newInstance( BattlePlanBonuses );

--- a/Generals/Code/GameEngine/Source/Common/RTS/Science.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/Science.cpp
@@ -54,9 +54,7 @@ ScienceStore::~ScienceStore()
 	{
 		ScienceInfo* si = *it;
 		++it;
-		if (si) {
-			deleteInstance(si);
-		}
+		deleteInstance(si);
 	}
 }
 

--- a/Generals/Code/GameEngine/Source/Common/RTS/Team.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/Team.cpp
@@ -849,19 +849,13 @@ TeamPrototype::~TeamPrototype()
 	if (m_factory)
 		m_factory->removeTeamPrototypeFromList(this);
 
-	if (m_productionConditionScript)
-	{
-		deleteInstance(m_productionConditionScript);
-	}
+	deleteInstance(m_productionConditionScript);
 	m_productionConditionScript = NULL;
 
 	for (Int i = 0; i < MAX_GENERIC_SCRIPTS; ++i)
 	{
-		if (m_genericScriptsToRun[i])
-		{
-			deleteInstance(m_genericScriptsToRun[i]);
-			m_genericScriptsToRun[i] = NULL;
-		}
+		deleteInstance(m_genericScriptsToRun[i]);
+		m_genericScriptsToRun[i] = NULL;
 	}
 }
 

--- a/Generals/Code/GameEngine/Source/Common/StateMachine.cpp
+++ b/Generals/Code/GameEngine/Source/Common/StateMachine.cpp
@@ -292,8 +292,7 @@ StateMachine::~StateMachine()
 	// delete all states in the mapping
 	for( i = m_stateMap.begin(); i != m_stateMap.end(); ++i )
 	{
-		if ((*i).second)
-			deleteInstance((*i).second);
+		deleteInstance((*i).second);
 	}
 }
 

--- a/Generals/Code/GameEngine/Source/GameClient/Display.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Display.cpp
@@ -316,8 +316,7 @@ void Display::update( void )
 				if( m_elapsedCopywriteTime == 0 && m_elapsedCopywriteTime >= 0)
 				{
 					//display the copyrighttext;
-					if(m_copyrightDisplayString)
-						deleteInstance(m_copyrightDisplayString);
+					deleteInstance(m_copyrightDisplayString);
 					m_copyrightDisplayString = TheDisplayStringManager->newDisplayString();
 					m_copyrightDisplayString->setText(TheGameText->fetch("GUI:EACopyright"));
 					if (TheGlobalLanguageData && TheGlobalLanguageData->m_copyrightFont.name.isNotEmpty())

--- a/Generals/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -131,8 +131,7 @@ void DrawableIconInfo::clear()
 {
 	for (int i = 0; i < MAX_ICONS; ++i)
 	{
-		if (m_icon[i])
-			deleteInstance(m_icon[i]);
+		deleteInstance(m_icon[i]);
 		m_icon[i] = NULL;
 		m_keepTillFrame[i] = 0;
 	}
@@ -504,11 +503,9 @@ Drawable::~Drawable()
 	}
 
 	stopAmbientSound();
-	if (m_ambientSound)
-	{
-		deleteInstance(m_ambientSound);
-		m_ambientSound = NULL;
-	}
+
+	deleteInstance(m_ambientSound);
+	m_ambientSound = NULL;
 
 	/// @todo this is nasty, we need a real general effects system
 	// remove any entries that might be present from the ray effect system
@@ -519,20 +516,17 @@ Drawable::~Drawable()
 	m_particle = NULL;
 
 	// delete any icons present
-	if (m_iconInfo)
-		deleteInstance(m_iconInfo);
+	deleteInstance(m_iconInfo);
+	m_iconInfo = NULL;
 
-	if (m_selectionFlashEnvelope)
-		deleteInstance(m_selectionFlashEnvelope);
+	deleteInstance(m_selectionFlashEnvelope);
+	m_selectionFlashEnvelope = NULL;
 
-	if (m_colorTintEnvelope)
-		deleteInstance(m_colorTintEnvelope);
+	deleteInstance(m_colorTintEnvelope);
+	m_colorTintEnvelope = NULL;
 
-	if (m_locoInfo)
-	{
-		deleteInstance(m_locoInfo);
-		m_locoInfo = NULL;
-	}
+	deleteInstance(m_locoInfo);
+	m_locoInfo = NULL;
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameClient/Eva.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Eva.cpp
@@ -173,8 +173,7 @@ Eva::~Eva()
 {
 	EvaCheckInfoPtrVecIt it;
 	for (it = m_allCheckInfos.begin(); it != m_allCheckInfos.end(); ++it) {
-		if (*it)
-			deleteInstance(*it);
+		deleteInstance(*it);
 	}
 }
 

--- a/Generals/Code/GameEngine/Source/GameClient/FXList.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/FXList.cpp
@@ -791,8 +791,7 @@ void FXList::clear()
 {
 	for (FXNuggetList::iterator it = m_nuggets.begin(); it != m_nuggets.end(); ++it)
 	{
-		if (*it)
-			deleteInstance(*it);
+		deleteInstance(*it);
 	}
 	m_nuggets.clear();
 }

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/AnimateWindowManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/AnimateWindowManager.cpp
@@ -111,14 +111,11 @@ void AnimateWindow::setAnimData( 	ICoord2D startPos, ICoord2D endPos,
 
 static void clearWinList(AnimateWindowList &winList)
 {
-	wnd::AnimateWindow *win = NULL;
 	while (!winList.empty())
 	{
-		win = *(winList.begin());
+		wnd::AnimateWindow *win = *(winList.begin());
 		winList.pop_front();
-		if (win)
-			deleteInstance(win);
-		win = NULL;
+		deleteInstance(win);
 	}
 }
 

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GameWindowManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GameWindowManager.cpp
@@ -118,8 +118,7 @@ void GameWindowManager::processDestroyList( void )
 		DEBUG_ASSERTCRASH(doDestroy->winGetUserData() == NULL, ("Win user data is expected to be deleted now"));
 
 		// free the memory
-		if (doDestroy)
-			deleteInstance(doDestroy);
+		deleteInstance(doDestroy);
 
 	}  // end for
 

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5581,8 +5581,7 @@ void InGameUI::resetIdleWorker( void )
 void InGameUI::recreateControlBar( void )
 {
 	GameWindow *win = TheWindowManager->winGetWindowFromId(NULL, TheNameKeyGenerator->nameToKey(AsciiString("ControlBar.wnd")));
-	if(win)
-		deleteInstance(win);
+	deleteInstance(win);
 
 	m_idleWorkerWin = NULL;
 

--- a/Generals/Code/GameEngine/Source/GameClient/System/CampaignManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/System/CampaignManager.cpp
@@ -123,8 +123,7 @@ Campaign::~Campaign( void )
 	{
 		Mission *mission = *it;
 		it = m_missions.erase( it );
-		if(mission)
-			deleteInstance(mission);
+		deleteInstance(mission);
 	}
 }
 
@@ -228,8 +227,7 @@ CampaignManager::~CampaignManager( void )
 	{
 		Campaign *campaign = *it;
 		it = m_campaignList.erase( it );
-		if(campaign)
-			deleteInstance(campaign);
+		deleteInstance(campaign);
 	}
 }
 

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AI.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AI.cpp
@@ -63,8 +63,7 @@ void TAiData::addFactionBuildList(AISideBuildList *buildList)
 	AISideBuildList *info = m_sideBuildLists;
 	while (info) {
 		if (buildList->m_side == info->m_side) {
-			if (info->m_buildList)
-				deleteInstance(info->m_buildList);
+			deleteInstance(info->m_buildList);
 			info->m_buildList = buildList->m_buildList;
 			buildList->m_buildList = NULL;
 			buildList->m_next = NULL;
@@ -109,9 +108,7 @@ AISideBuildList::AISideBuildList( AsciiString side ) :
 
 AISideBuildList::~AISideBuildList()
 {
-	if (m_buildList) {
-		deleteInstance(m_buildList); // note - deletes all in the list.
-	}
+	deleteInstance(m_buildList); // note - deletes all in the list.
 	m_buildList = NULL;
 }
 

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
@@ -111,10 +111,9 @@ AIGroup::~AIGroup()
 
 #endif
 
-	if (m_groundPath) {
-		deleteInstance(m_groundPath);
-		m_groundPath = NULL;
-	}
+	deleteInstance(m_groundPath);
+	m_groundPath = NULL;
+
 	//DEBUG_LOG(( "AIGroup #%d destroyed", m_id ));
 }
 
@@ -445,10 +444,8 @@ void AIGroup::recompute( void )
 
 	getCenter( &center );
 
-	if (m_groundPath) {
-		deleteInstance(m_groundPath);
-		m_groundPath = NULL;
-	}
+	deleteInstance(m_groundPath);
+	m_groundPath = NULL;
 
 	m_speed = 9999999999.9f;
 

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -3429,10 +3429,9 @@ void Pathfinder::reset( void )
 	debugPathPos.y = 0.0f;
 	debugPathPos.z = 0.0f;
 
-	if (debugPath)
-		deleteInstance(debugPath);
-
+	deleteInstance(debugPath);
 	debugPath = NULL;
+
 	m_frameToShowObstacles = 0;
 
 	for (m_queuePRHead=0; m_queuePRHead<PATHFIND_QUEUE_LEN; m_queuePRHead++) {
@@ -7552,10 +7551,10 @@ Bool Pathfinder::slowDoesPathExist( Object *obj,
 	Path *path = findPath(obj, locoSet, from, to);
 	m_ignoreObstacleID = INVALID_ID;
 	Bool found = (path!=NULL);
-	if (path) {
-		deleteInstance(path);
-		path = NULL;
-	}
+
+	deleteInstance(path);
+	path = NULL;
+
 	return found;
 }
 
@@ -8494,9 +8493,7 @@ void Pathfinder::setDebugPath(Path *newDebugpath)
 	if (TheGlobalData->m_debugAI)
 	{
 		// copy the path for debugging
-		if (debugPath)
-			deleteInstance(debugPath);
-
+		deleteInstance(debugPath);
 		debugPath = newInstance(Path);
 
 		for( PathNode *copyNode = newDebugpath->getFirstNode(); copyNode; copyNode = copyNode->getNextOptimized() )

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -726,10 +726,7 @@ AIStateMachine::AIStateMachine( Object *obj, AsciiString name ) : StateMachine( 
 //----------------------------------------------------------------------------------------------------------
 AIStateMachine::~AIStateMachine()
 {
-	if (m_goalSquad)
-	{
-		deleteInstance(m_goalSquad);
-	}
+	deleteInstance(m_goalSquad);
 }
 
 
@@ -5491,11 +5488,8 @@ void AIAttackState::onExit( StateExitType status )
 	//addSelfAsTargeter(false);
 
 	// destroy the attack machine
-	if (m_attackMachine)
-	{
-		deleteInstance(m_attackMachine);
-		m_attackMachine = NULL;
-	}
+	deleteInstance(m_attackMachine);
+	m_attackMachine = NULL;
 
 	Object *obj = getMachineOwner();
 	obj->clearStatus( MAKE_OBJECT_STATUS_MASK4( OBJECT_STATUS_IS_FIRING_WEAPON,
@@ -5709,12 +5703,9 @@ StateReturnType AIAttackSquadState::update( void )
 //----------------------------------------------------------------------------------------------------------
 void AIAttackSquadState::onExit( StateExitType status )
 {
-	if( m_attackSquadMachine )
-	{
-		// destroy the attack machine
-		deleteInstance(m_attackSquadMachine);
-		m_attackSquadMachine = NULL;
-	}
+	// destroy the attack machine
+	deleteInstance(m_attackSquadMachine);
+	m_attackSquadMachine = NULL;
 }
 
 //----------------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/TurretAI.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/TurretAI.cpp
@@ -321,8 +321,7 @@ TurretAI::~TurretAI()
 {
 	stopRotOrPitchSound();
 
-	if (m_turretStateMachine)
-		deleteInstance(m_turretStateMachine);
+	deleteInstance(m_turretStateMachine);
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Map/SidesList.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Map/SidesList.cpp
@@ -87,10 +87,12 @@ void SidesInfo::init(const Dict* d)
 {
 	deleteInstance(m_pBuildList);
 	m_pBuildList = NULL;
+
 	m_dict.clear();
-	if (m_scripts)
-		deleteInstance(m_scripts);
+
+	deleteInstance(m_scripts);
 	m_scripts = NULL;
+
 	if (d)
 		m_dict = *d;
 }
@@ -302,8 +304,7 @@ Bool SidesList::ParseSidesDataChunk(DataChunkInput &file, DataChunkInfo *info, v
 	count = ScriptList::getReadScripts(scripts);
 	for (i=0; i<count; i++) {
 		if (i<TheSidesList->getNumSides()) {
-			ScriptList *pSL = TheSidesList->getSideInfo(i)->getScriptList();
-			deleteInstance(pSL);
+			deleteInstance(TheSidesList->getSideInfo(i)->getScriptList());
 			TheSidesList->getSideInfo(i)->setScriptList(scripts[i]);
 			scripts[i] = NULL;
 		} else {
@@ -535,11 +536,8 @@ void SidesList::prepareForMP_or_Skirmish(void)
 					}
 					if (curSide == -1) continue;
 
-					ScriptList *pSL = getSkirmishSideInfo(curSide)->getScriptList();
+					deleteInstance(getSkirmishSideInfo(curSide)->getScriptList());
 					getSkirmishSideInfo(curSide)->setScriptList(scripts[i]);
-					scripts[i] = NULL;
-					if (pSL)
-						deleteInstance(pSL);
 					scripts[i] = NULL;
 				}
 				for (i=0; i<MAX_PLAYER_COUNT; i++) {

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/FireWeaponWhenDamagedBehavior.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/FireWeaponWhenDamagedBehavior.cpp
@@ -146,23 +146,15 @@ FireWeaponWhenDamagedBehavior::FireWeaponWhenDamagedBehavior( Thing *thing, cons
 //-------------------------------------------------------------------------------------------------
 FireWeaponWhenDamagedBehavior::~FireWeaponWhenDamagedBehavior( void )
 {
-	if (m_reactionWeaponPristine)
-		deleteInstance(m_reactionWeaponPristine);
-	if (m_reactionWeaponDamaged)
-		deleteInstance(m_reactionWeaponDamaged);
-	if (m_reactionWeaponReallyDamaged)
-		deleteInstance(m_reactionWeaponReallyDamaged);
-	if (m_reactionWeaponRubble)
-		deleteInstance(m_reactionWeaponRubble);
+	deleteInstance(m_reactionWeaponPristine);
+	deleteInstance(m_reactionWeaponDamaged);
+	deleteInstance(m_reactionWeaponReallyDamaged);
+	deleteInstance(m_reactionWeaponRubble);
 
-	if (m_continuousWeaponPristine)
-		deleteInstance(m_continuousWeaponPristine);
-	if (m_continuousWeaponDamaged)
-		deleteInstance(m_continuousWeaponDamaged);
-	if (m_continuousWeaponReallyDamaged)
-		deleteInstance(m_continuousWeaponReallyDamaged);
-	if (m_continuousWeaponRubble)
-		deleteInstance(m_continuousWeaponRubble);
+	deleteInstance(m_continuousWeaponPristine);
+	deleteInstance(m_continuousWeaponDamaged);
+	deleteInstance(m_continuousWeaponReallyDamaged);
+	deleteInstance(m_continuousWeaponRubble);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Collide/FireWeaponCollide.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Collide/FireWeaponCollide.cpp
@@ -66,8 +66,7 @@ FireWeaponCollide::FireWeaponCollide( Thing *thing, const ModuleData* moduleData
 //-------------------------------------------------------------------------------------------------
 FireWeaponCollide::~FireWeaponCollide( void )
 {
-	if (m_collideWeapon)
-		deleteInstance(m_collideWeapon);
+	deleteInstance(m_collideWeapon);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Locomotor.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Locomotor.cpp
@@ -2721,8 +2721,7 @@ void LocomotorSet::clear()
 {
 	for (size_t i = 0; i < m_locomotors.size(); ++i)
 	{
-		if (m_locomotors[i])
-			deleteInstance(m_locomotors[i]);
+		deleteInstance(m_locomotors[i]);
 	}
 	m_locomotors.clear();
 	m_validLocomotorSurfaces = 0;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -575,9 +575,7 @@ Object::~Object()
 	delete [] m_behaviors;
 	m_behaviors = NULL;
 
-	if( m_experienceTracker )
-		deleteInstance(m_experienceTracker);
-
+	deleteInstance(m_experienceTracker);
 	m_experienceTracker = NULL;
 
 	// we don't need to delete these, there were deleted on the m_behaviors list

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
@@ -1494,8 +1494,7 @@ ObjectCreationListStore::~ObjectCreationListStore()
 {
 	for (ObjectCreationNuggetVector::iterator i = m_nuggets.begin(); i != m_nuggets.end(); ++i)
 	{
-		if (*i)
-			deleteInstance(*i);
+		deleteInstance(*i);
 	}
 	m_nuggets.clear();
 }

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -95,8 +95,7 @@ AIUpdateModuleData::~AIUpdateModuleData()
 		if (m_turretData[i])
 		{
 			TurretAIData* td = const_cast<TurretAIData*>(m_turretData[i]);
-			if (td)
-				deleteInstance(td);
+			deleteInstance(td);
 		}
 	}
 }
@@ -638,8 +637,7 @@ AIUpdateInterface::~AIUpdateInterface( void )
 
 	for (int i = 0; i < MAX_TURRETS; i++)
 	{
-		if (m_turretAI[i])
-			deleteInstance(m_turretAI[i]);
+		deleteInstance(m_turretAI[i]);
 		m_turretAI[i] = NULL;
 	}
 	m_stateMachine = NULL;
@@ -1978,10 +1976,9 @@ Bool AIUpdateInterface::computeAttackPath( PathfindServicesInterface *pathServic
 void AIUpdateInterface::destroyPath( void )
 {
 	// destroy previous path
-	if (m_path)
-		deleteInstance(m_path);
-
+	deleteInstance(m_path);
 	m_path = NULL;
+
 	m_waitingForPath = FALSE; // we no longer need it.
 	//CRCDEBUG_LOG(("AIUpdateInterface::destroyPath() - m_isAttackPath = FALSE for object %d", getObject()->getID()));
 	m_isAttackPath = FALSE;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DeliverPayloadAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DeliverPayloadAIUpdate.cpp
@@ -132,8 +132,7 @@ DeliverPayloadAIUpdate::~DeliverPayloadAIUpdate( void )
 {
 	m_deliveryDecal.clear();
 
-	if (m_deliverPayloadStateMachine)
-		deleteInstance(m_deliverPayloadStateMachine);
+	deleteInstance(m_deliverPayloadStateMachine);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -255,8 +254,7 @@ void DeliverPayloadAIUpdate::deliverPayload(
 	//THIS GETS CALLED VIA OBJECT CREATION LISTS ONLY!!!
 	//****************************************************
 
-	if (m_deliverPayloadStateMachine)
-		deleteInstance(m_deliverPayloadStateMachine);
+	deleteInstance(m_deliverPayloadStateMachine);
 	m_deliverPayloadStateMachine = NULL;
 
 	m_moveToPos = *moveToPos;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -1173,7 +1173,7 @@ protected:
 	StateMachine *m_actionMachine;
 
 };
-inline DozerActionState::~DozerActionState( void ) { if (m_actionMachine) deleteInstance(m_actionMachine); }
+inline DozerActionState::~DozerActionState( void ) { deleteInstance(m_actionMachine); }
 
 // ------------------------------------------------------------------------------------------------
 /** CRC */
@@ -1472,8 +1472,7 @@ DozerAIUpdate::~DozerAIUpdate( void )
 {
 
 	// delete our behavior state machine
-	if( m_dozerMachine )
-		deleteInstance(m_dozerMachine);
+	deleteInstance(m_dozerMachine);
 
 	// no orders
 	for( Int i = 0; i < DOZER_NUM_TASKS; i++ )

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -126,14 +126,9 @@ WorkerAIUpdate::~WorkerAIUpdate( void )
 {
 
 	// delete our behavior state machine
-	if( m_dozerMachine )
-		deleteInstance(m_dozerMachine);
-
-	if( m_supplyTruckStateMachine )
-		deleteInstance(m_supplyTruckStateMachine);
-
-	if( m_workerMachine )
-		deleteInstance(m_workerMachine);
+	deleteInstance(m_dozerMachine);
+	deleteInstance(m_supplyTruckStateMachine);
+	deleteInstance(m_workerMachine);
 
 }
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/FireWeaponUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/FireWeaponUpdate.cpp
@@ -73,8 +73,7 @@ FireWeaponUpdate::FireWeaponUpdate( Thing *thing, const ModuleData* moduleData )
 //-------------------------------------------------------------------------------------------------
 FireWeaponUpdate::~FireWeaponUpdate( void )
 {
-	if (m_weapon)
-		deleteInstance(m_weapon);
+	deleteInstance(m_weapon);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
@@ -237,11 +237,8 @@ void PhysicsBehavior::onObjectCreated()
 //-------------------------------------------------------------------------------------------------
 PhysicsBehavior::~PhysicsBehavior()
 {
-	if (m_bounceSound)
-	{
-		deleteInstance(m_bounceSound);
-		m_bounceSound = NULL;
-	}
+	deleteInstance(m_bounceSound);
+	m_bounceSound = NULL;
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -524,11 +521,8 @@ void PhysicsBehavior::setBounceSound(const AudioEventRTS* bounceSound)
 	}
 	else
 	{
-		if (m_bounceSound)
-		{
-			deleteInstance(m_bounceSound);
-			m_bounceSound = NULL;
-		}
+		deleteInstance(m_bounceSound);
+		m_bounceSound = NULL;
 	}
 }
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -314,13 +314,10 @@ WeaponTemplate::WeaponTemplate() : m_nextTemplate(NULL)
 //-------------------------------------------------------------------------------------------------
 WeaponTemplate::~WeaponTemplate()
 {
-	if (m_nextTemplate) {
-		deleteInstance(m_nextTemplate);
-	}
+	deleteInstance(m_nextTemplate);
 
 	// delete any extra-bonus that's present
-	if (m_extraBonus)
-		deleteInstance(m_extraBonus);
+	deleteInstance(m_extraBonus);
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -1356,8 +1353,7 @@ WeaponStore::~WeaponStore()
 	for (size_t i = 0; i < m_weaponTemplateVector.size(); i++)
 	{
 		WeaponTemplate* wt = m_weaponTemplateVector[i];
-		if (wt)
-			deleteInstance(wt);
+		deleteInstance(wt);
 	}
 	m_weaponTemplateVector.clear();
 }

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/WeaponSet.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/WeaponSet.cpp
@@ -183,8 +183,7 @@ WeaponSet::WeaponSet()
 WeaponSet::~WeaponSet()
 {
 	for (Int i = 0; i < WEAPONSLOT_COUNT; ++i)
-		if (m_weapons[i])
-			deleteInstance(m_weapons[i]);
+		deleteInstance(m_weapons[i]);
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -303,11 +302,8 @@ void WeaponSet::updateWeaponSet(const Object* obj)
 		m_hasDamageWeapon = false;
 		for (Int i = WEAPONSLOT_COUNT - 1; i >= PRIMARY_WEAPON ; --i)
 		{
-			if (m_weapons[i] != NULL)
-			{
-				deleteInstance(m_weapons[i]);
-				m_weapons[i] = NULL;
-			}
+			deleteInstance(m_weapons[i]);
+			m_weapons[i] = NULL;
 
 			if (set->getNth((WeaponSlotType)i))
 			{

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptConditions.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptConditions.cpp
@@ -74,8 +74,7 @@ public:
 
 	~ObjectTypesTemp()
 	{
-		if (m_types)
-			deleteInstance(m_types);
+		deleteInstance(m_types);
 	}
 };
 
@@ -114,8 +113,7 @@ public:
 //-------------------------------------------------------------------------------------------------
 TransportStatus::~TransportStatus()
 {
-	if (m_nextStatus)
-		deleteInstance(m_nextStatus);
+	deleteInstance(m_nextStatus);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/Scripts.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/Scripts.cpp
@@ -215,14 +215,11 @@ m_firstScript(NULL)
 */
 ScriptList::~ScriptList(void)
 {
-	if (m_firstGroup) {
-		deleteInstance(m_firstGroup);
-		m_firstGroup = NULL;
-	}
-	if (m_firstScript) {
-		deleteInstance(m_firstScript);
-		m_firstScript = NULL;
-	}
+	deleteInstance(m_firstGroup);
+	m_firstGroup = NULL;
+
+	deleteInstance(m_firstScript);
+	m_firstScript = NULL;
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -526,10 +523,8 @@ Bool ScriptList::ParseScriptsDataChunk(DataChunkInput &file, DataChunkInfo *info
 	file.registerParser( AsciiString("ScriptList"), info->label, ScriptList::ParseScriptListDataChunk );
 	DEBUG_ASSERTCRASH(s_numInReadList==0, ("Leftover scripts floating aroung."));
 	for (i=0; i<s_numInReadList; i++) {
-		if (s_readLists[i]) {
-			deleteInstance(s_readLists[i]);
-			s_readLists[i] = NULL;
-		}
+		deleteInstance(s_readLists[i]);
+		s_readLists[i] = NULL;
 	}
 	TScriptListReadInfo readInfo;
 	for (i=0; i<MAX_PLAYER_COUNT; i++) {
@@ -649,11 +644,10 @@ m_nextGroup(NULL)
 */
 ScriptGroup::~ScriptGroup(void)
 {
-	if (m_firstScript) {
-		// Delete the first script.  m_firstScript deletes the entire list.
-		deleteInstance(m_firstScript);
-		m_firstScript = NULL;
-	}
+	// Delete the first script.  m_firstScript deletes the entire list.
+	deleteInstance(m_firstScript);
+	m_firstScript = NULL;
+
 	if (m_nextGroup) {
 		// Delete all the subsequent groups in our list.
 		ScriptGroup *cur = m_nextGroup;
@@ -934,16 +928,10 @@ Script::~Script(void)
 			cur = next;
 		}
 	}
-	if (m_condition) {
-		deleteInstance(m_condition);
-	}
-	if (m_action) {
-		deleteInstance(m_action);
-	}
 
-	if (m_actionFalse) {
-		deleteInstance(m_actionFalse);
-	}
+	deleteInstance(m_condition);
+	deleteInstance(m_action);
+	deleteInstance(m_actionFalse);
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -990,12 +978,7 @@ void Script::loadPostProcess( void )
 Script *Script::duplicate(void) const
 {
 	Script *pNew = newInstance(Script);
-	if (pNew->m_condition) {
-		deleteInstance(pNew->m_condition);
-	}
-	if (pNew->m_action) {
-		deleteInstance(pNew->m_action);
-	}
+
 	pNew->m_scriptName = m_scriptName;
 	pNew->m_comment = m_comment;
 	pNew->m_conditionComment = m_conditionComment;
@@ -1007,6 +990,7 @@ Script *Script::duplicate(void) const
 	pNew->m_normal = m_normal;
 	pNew->m_hard = m_hard;
 	pNew->m_delayEvaluationSeconds = m_delayEvaluationSeconds;
+
 	if (m_condition) {
 		pNew->m_condition = m_condition->duplicate();
 	}
@@ -1029,12 +1013,7 @@ Script *Script::duplicateAndQualify(const AsciiString& qualifier,
 			const AsciiString& playerTemplateName, const AsciiString& newPlayerName) const
 {
 	Script *pNew = newInstance(Script);
-	if (pNew->m_condition) {
-		deleteInstance(pNew->m_condition);
-	}
-	if (pNew->m_action) {
-		deleteInstance(pNew->m_action);
-	}
+
 	pNew->m_scriptName = m_scriptName;
 	pNew->m_scriptName.concat(qualifier);
 	pNew->m_comment = m_comment;
@@ -1047,6 +1026,7 @@ Script *Script::duplicateAndQualify(const AsciiString& qualifier,
 	pNew->m_normal = m_normal;
 	pNew->m_hard = m_hard;
 	pNew->m_delayEvaluationSeconds = m_delayEvaluationSeconds;
+
 	if (m_condition) {
 		pNew->m_condition = m_condition->duplicateAndQualify(qualifier, playerTemplateName, newPlayerName);
 	}
@@ -1078,19 +1058,16 @@ void Script::updateFrom(Script *pSrc)
 	this->m_easy = pSrc->m_easy;
 	this->m_normal = pSrc->m_normal;
 	this->m_hard = pSrc->m_hard;
-	if (this->m_condition) {
-		deleteInstance(this->m_condition);
-	}
+
+	deleteInstance(this->m_condition);
 	this->m_condition = pSrc->m_condition;
 	pSrc->m_condition = NULL;
-	if (this->m_action) {
-		deleteInstance(this->m_action);
-	}
+
+	deleteInstance(this->m_action);
 	this->m_action = pSrc->m_action;
 	pSrc->m_action = NULL;
-	if (this->m_actionFalse) {
-		deleteInstance(this->m_actionFalse);
-	}
+
+	deleteInstance(this->m_actionFalse);
 	this->m_actionFalse = pSrc->m_actionFalse;
 	pSrc->m_actionFalse = NULL;
 }
@@ -1338,10 +1315,9 @@ OrCondition *Script::findPreviousOrCondition( OrCondition *curOr )
 //-------------------------------------------------------------------------------------------------
 OrCondition::~OrCondition(void)
 {
-	if (m_firstAnd) {
-		deleteInstance(m_firstAnd);
-		m_firstAnd = NULL;
-	}
+	deleteInstance(m_firstAnd);
+	m_firstAnd = NULL;
+
 	if (m_nextOr) {
 		OrCondition *cur = m_nextOr;
 		OrCondition *next;
@@ -1526,8 +1502,7 @@ void Condition::setConditionType(enum ConditionType type)
 {
 	Int i;
 	for (i=0; i<m_numParms; i++) {
-		if (m_parms[i])
-			deleteInstance(m_parms[i]);
+		deleteInstance(m_parms[i]);
 		m_parms[i] = NULL;
 	}
 	m_conditionType = type;
@@ -2217,8 +2192,7 @@ void ScriptAction::setActionType(enum ScriptActionType type)
 {
 	Int i;
 	for (i=0; i<m_numParms; i++) {
-		if (m_parms[i])
-			deleteInstance(m_parms[i]);
+		deleteInstance(m_parms[i]);
 		m_parms[i] = NULL;
 	}
 	m_actionType = type;

--- a/Generals/Code/GameEngine/Source/GameLogic/System/CaveSystem.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/CaveSystem.cpp
@@ -52,11 +52,8 @@ void CaveSystem::reset()
 {
 	for( std::vector<TunnelTracker*>::iterator iter = m_tunnelTrackerVector.begin(); iter != m_tunnelTrackerVector.end(); iter++ )
 	{
-		TunnelTracker *currentTracker = *iter;
-		if( currentTracker )// could be NULL, since we don't slide back to fill deleted entries so offsets don't shift
-		{
-			deleteInstance(currentTracker);
-		}
+		TunnelTracker *currentTracker = *iter; // could be NULL, since we don't slide back to fill deleted entries so offsets don't shift
+		deleteInstance(currentTracker);
 	}
 	m_tunnelTrackerVector.clear();
 }

--- a/Generals/Code/GameEngine/Source/GameLogic/System/CrateSystem.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/CrateSystem.cpp
@@ -47,10 +47,7 @@ CrateSystem::~CrateSystem()
 	for( Int templateIndex = 0; templateIndex < count; templateIndex ++ )
 	{
 		CrateTemplate *currentTemplate = m_crateTemplateVector[templateIndex];
-		if( currentTemplate )
-		{
-			deleteInstance(currentTemplate);
-		}
+		deleteInstance(currentTemplate);
 	}
 	m_crateTemplateVector.clear();
 }

--- a/Generals/Code/GameEngine/Source/GameLogic/System/RankInfo.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/RankInfo.cpp
@@ -49,10 +49,7 @@ RankInfoStore::~RankInfoStore()
 	for (level =0; level < getRankLevelCount(); level++)
 	{
 		RankInfo* ri = m_rankInfos[level];
-		if (ri)
-		{
-			deleteInstance(ri);
-		}
+		deleteInstance(ri);
 	}
 	m_rankInfos.clear();
 }

--- a/Generals/Code/GameEngine/Source/GameNetwork/Connection.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/Connection.cpp
@@ -58,15 +58,11 @@ Connection::Connection() {
  * The destructor.
  */
 Connection::~Connection() {
-	if (m_user != NULL) {
-		deleteInstance(m_user);
-		m_user = NULL;
-	}
+	deleteInstance(m_user);
+	m_user = NULL;
 
-	if (m_netCommandList != NULL) {
-		deleteInstance(m_netCommandList);
-		m_netCommandList = NULL;
-	}
+	deleteInstance(m_netCommandList);
+	m_netCommandList = NULL;
 }
 
 /**
@@ -75,10 +71,8 @@ Connection::~Connection() {
 void Connection::init() {
 	m_transport = NULL;
 
-	if (m_user != NULL) {
-		deleteInstance(m_user);
-		m_user = NULL;
-	}
+	deleteInstance(m_user);
+	m_user = NULL;
 
 	if (m_netCommandList == NULL) {
 		m_netCommandList = newInstance(NetCommandList);
@@ -123,10 +117,7 @@ void Connection::attachTransport(Transport *transport) {
  * Assign this connection a user.  This is the user to whome we send all our packetized goodies.
  */
 void Connection::setUser(User *user) {
-	if (m_user != NULL) {
-		deleteInstance(m_user);
-	}
-
+	deleteInstance(m_user);
 	m_user = user;
 }
 
@@ -325,9 +316,8 @@ UnsignedInt Connection::doSend() {
 			couldQueue = m_transport->queueSend(packet->getAddr(), packet->getPort(), packet->getData(), packet->getLength());
 			m_lastTimeSent = curtime;
 		}
-		if (packet != NULL) {
-			deleteInstance(packet); // delete the packet now that we're done with it.
-		}
+
+		deleteInstance(packet); // delete the packet now that we're done with it.
 	}
 
 	return numpackets;

--- a/Generals/Code/GameEngine/Source/GameNetwork/ConnectionManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/ConnectionManager.cpp
@@ -59,57 +59,39 @@
  */
 ConnectionManager::~ConnectionManager(void)
 {
-	if (m_localUser != NULL) {
-		deleteInstance(m_localUser);
-		m_localUser = NULL;
-	}
+	deleteInstance(m_localUser);
+	m_localUser = NULL;
 
-//	m_transport = NULL; // Network will delete transports; we just forget them
-	if (m_transport != NULL) {
-		delete m_transport;
-		m_transport = NULL;
-	}
+	// Network will delete transports; we just forget them
+	delete m_transport;
+	m_transport = NULL;
 
 	Int i = 0;
 	for (; i < MAX_SLOTS; ++i) {
-		if (m_frameData[i] != NULL) {
-			deleteInstance(m_frameData[i]);
-			m_frameData[i] = NULL;
-		}
+		deleteInstance(m_frameData[i]);
+		m_frameData[i] = NULL;
 	}
 
 	for (i = 0; i < NUM_CONNECTIONS; ++i) {
-		if (m_connections[i] != NULL) {
-			deleteInstance(m_connections[i]);
-			m_connections[i] = NULL;
-		}
+		deleteInstance(m_connections[i]);
+		m_connections[i] = NULL;
 	}
 
-	if (TheDisconnectMenu != NULL) {
-		// This is done here since TheDisconnectMenu should only be there if we are in a network game.
-		delete TheDisconnectMenu;
-		TheDisconnectMenu = NULL;
-	}
+	// This is done here since TheDisconnectMenu should only be there if we are in a network game.
+	delete TheDisconnectMenu;
+	TheDisconnectMenu = NULL;
 
-	if (m_disconnectManager != NULL) {
-		delete m_disconnectManager;
-		m_disconnectManager = NULL;
-	}
+	delete m_disconnectManager;
+	m_disconnectManager = NULL;
 
-	if (m_pendingCommands != NULL) {
-		deleteInstance(m_pendingCommands);
-		m_pendingCommands = NULL;
-	}
+	deleteInstance(m_pendingCommands);
+	m_pendingCommands = NULL;
 
-	if (m_relayedCommands != NULL) {
-		deleteInstance(m_relayedCommands);
-		m_relayedCommands = NULL;
-	}
+	deleteInstance(m_relayedCommands);
+	m_relayedCommands = NULL;
 
-	if (m_netCommandWrapperList != NULL) {
-		deleteInstance(m_netCommandWrapperList);
-		m_netCommandWrapperList = NULL;
-	}
+	deleteInstance(m_netCommandWrapperList);
+	m_netCommandWrapperList = NULL;
 
 	s_fileCommandMap.clear();
 	s_fileRecipientMaskMap.clear();
@@ -174,10 +156,8 @@ void ConnectionManager::init()
 	}
 
 	for (i = 0; i < MAX_SLOTS; ++i) {
-		if (m_frameData[i] != NULL) {
-			deleteInstance(m_frameData[i]);
-			m_frameData[i] = NULL;
-		}
+		deleteInstance(m_frameData[i]);
+		m_frameData[i] = NULL;
 	}
 
 //	m_averageFps = 30;			// since 30 fps is the desired rate, we'll start off at that.
@@ -228,18 +208,14 @@ void ConnectionManager::reset()
 
 	UnsignedInt i = 0;
 	for (; i < (UnsignedInt)NUM_CONNECTIONS; ++i) {
-		if (m_connections[i] != NULL) {
-			deleteInstance(m_connections[i]);
-			m_connections[i] = NULL;
-		}
+		deleteInstance(m_connections[i]);
+		m_connections[i] = NULL;
 	}
 
 	for (i=0; i<(UnsignedInt)MAX_SLOTS; ++i)
 	{
-		if (m_frameData[i] != NULL) {
-			deleteInstance(m_frameData[i]);
-			m_frameData[i] = NULL;
-		}
+		deleteInstance(m_frameData[i]);
+		m_frameData[i] = NULL;
 	}
 
 	if (m_pendingCommands == NULL) {

--- a/Generals/Code/GameEngine/Source/GameNetwork/FrameData.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/FrameData.cpp
@@ -49,10 +49,8 @@ FrameData::FrameData()
  */
 FrameData::~FrameData()
 {
-	if (m_commandList != NULL) {
-		deleteInstance(m_commandList);
-		m_commandList = NULL;
-	}
+	deleteInstance(m_commandList);
+	m_commandList = NULL;
 }
 
 /**

--- a/Generals/Code/GameEngine/Source/GameNetwork/NetPacket.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/NetPacket.cpp
@@ -1005,8 +1005,7 @@ void NetPacket::FillBufferWithGameCommand(UnsignedByte *buffer, NetCommandRef *m
 
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addGameMessage - added game message, frame %d, player %d, command ID %d", m_lastFrame, m_lastPlayerID, m_lastCommandID));
 
-	if (gmsg)
-		deleteInstance(gmsg);
+	deleteInstance(gmsg);
 	gmsg = NULL;
 }
 
@@ -2002,10 +2001,8 @@ NetPacket::NetPacket(TransportMessage *msg) {
  * Destructor
  */
 NetPacket::~NetPacket() {
-	if (m_lastCommand != NULL) {
-		deleteInstance(m_lastCommand);
-		m_lastCommand = NULL;
-	}
+	deleteInstance(m_lastCommand);
+	m_lastCommand = NULL;
 }
 
 /**
@@ -2028,10 +2025,9 @@ void NetPacket::init() {
 }
 
 void NetPacket::reset() {
-	if (m_lastCommand != NULL) {
-		deleteInstance(m_lastCommand);
-		m_lastCommand = NULL;
-	}
+	deleteInstance(m_lastCommand);
+	m_lastCommand = NULL;
+
 	init();
 }
 
@@ -2197,10 +2193,8 @@ Bool NetPacket::addFrameResendRequestCommand(NetCommandRef *msg) {
 		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addFrameResendRequest - added frame resend request command from player %d for frame %d, command id = %d", m_lastPlayerID, frameToResend, m_lastCommandID));
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 
@@ -2308,10 +2302,8 @@ Bool NetPacket::addDisconnectScreenOffCommand(NetCommandRef *msg) {
 		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addDisconnectScreenOff - added disconnect screen off command from player %d for frame %d, command id = %d", m_lastPlayerID, newFrame, m_lastCommandID));
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 
@@ -2417,10 +2409,8 @@ Bool NetPacket::addDisconnectFrameCommand(NetCommandRef *msg) {
 		m_packetLen += sizeof(disconnectFrame);
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 
@@ -2525,10 +2515,8 @@ Bool NetPacket::addFileCommand(NetCommandRef *msg) {
 		m_packetLen += fileLength;
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 		return TRUE;
@@ -2630,10 +2618,8 @@ Bool NetPacket::addFileAnnounceCommand(NetCommandRef *msg) {
 		m_packetLen += sizeof(playerMask);
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 
@@ -2735,10 +2721,8 @@ Bool NetPacket::addFileProgressCommand(NetCommandRef *msg) {
 		m_packetLen += sizeof(progress);
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 
@@ -2867,10 +2851,8 @@ Bool NetPacket::addWrapperCommand(NetCommandRef *msg) {
 		m_packetLen += dataLength;
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 
@@ -2966,10 +2948,8 @@ Bool NetPacket::addTimeOutGameStartMessage(NetCommandRef *msg) {
 		++m_packetLen;
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 
@@ -3060,10 +3040,8 @@ Bool NetPacket::addLoadCompleteMessage(NetCommandRef *msg) {
 		++m_packetLen;
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 
@@ -3146,10 +3124,8 @@ Bool NetPacket::addProgressMessage(NetCommandRef *msg) {
 		++m_packetLen;
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 
@@ -3257,10 +3233,8 @@ Bool NetPacket::addDisconnectVoteCommand(NetCommandRef *msg) {
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addDisconnectVoteCommand - added disconnect vote command, player id %d command id %d, voted slot %d", m_lastPlayerID, m_lastCommandID, slot));
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 		return TRUE;
@@ -3356,10 +3330,8 @@ Bool NetPacket::addDisconnectChatCommand(NetCommandRef *msg) {
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket - added disconnect chat command"));
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 		return TRUE;
@@ -3473,10 +3445,8 @@ Bool NetPacket::addChatCommand(NetCommandRef *msg) {
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket - added chat command"));
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 		return TRUE;
@@ -3564,10 +3534,8 @@ Bool NetPacket::addPacketRouterAckCommand(NetCommandRef *msg) {
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket - added packet router ack command, player id %d", m_lastPlayerID));
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 		return TRUE;
@@ -3646,10 +3614,8 @@ Bool NetPacket::addPacketRouterQueryCommand(NetCommandRef *msg) {
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket - added packet router query command, player id %d", m_lastPlayerID));
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 		return TRUE;
@@ -3751,10 +3717,8 @@ Bool NetPacket::addDisconnectPlayerCommand(NetCommandRef *msg) {
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addDisconnectPlayerCommand - added disconnect player command, player id %d command id %d, disconnecting slot %d", m_lastPlayerID, m_lastCommandID, slot));
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 		return TRUE;
@@ -3836,10 +3800,8 @@ Bool NetPacket::addDisconnectKeepAliveCommand(NetCommandRef *msg) {
 		++m_packetLen;
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 
@@ -3916,10 +3878,8 @@ Bool NetPacket::addKeepAliveCommand(NetCommandRef *msg) {
 		++m_packetLen;
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 
@@ -4035,10 +3995,8 @@ Bool NetPacket::addRunAheadCommand(NetCommandRef *msg) {
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket - added run ahead command, frame %d, player id %d command id %d", m_lastFrame, m_lastPlayerID, m_lastCommandID));
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 		return TRUE;
@@ -4156,10 +4114,8 @@ Bool NetPacket::addDestroyPlayerCommand(NetCommandRef *msg) {
 		//DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket - added CRC:0x%8.8X info command, frame %d, player id %d command id %d", newCRC, m_lastFrame, m_lastPlayerID, m_lastCommandID));
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 		return TRUE;
@@ -4268,10 +4224,7 @@ Bool NetPacket::addRunAheadMetricsCommand(NetCommandRef *msg) {
 		memcpy(m_packet + m_packetLen, &averageFps, sizeof(averageFps));
 		m_packetLen += sizeof(averageFps);
 
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 
@@ -4387,10 +4340,7 @@ Bool NetPacket::addPlayerLeaveCommand(NetCommandRef *msg) {
 		memcpy(m_packet + m_packetLen, &leavingPlayerID, sizeof(UnsignedByte));
 		m_packetLen += sizeof(UnsignedByte);
 
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 
@@ -4526,10 +4476,7 @@ Bool NetPacket::addFrameCommand(NetCommandRef *msg) {
 		// frameinfodebug
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("outgoing - added frame %d, player %d, command count = %d, command id = %d", cmdMsg->getExecutionFrame(), cmdMsg->getPlayerID(), cmdMsg->getCommandCount(), cmdMsg->getID()));
 
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 
@@ -4632,9 +4579,8 @@ Bool NetPacket::addAckCommand(NetCommandRef *msg, UnsignedShort commandID, Unsig
 		m_packet[m_packetLen] = 'Z';
 		++m_packetLen;
 		++m_numCommands;
-		deleteInstance(m_lastCommand);
-		m_lastCommand = NULL;
 
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 		return TRUE;
@@ -4669,10 +4615,7 @@ Bool NetPacket::addAckCommand(NetCommandRef *msg, UnsignedShort commandID, Unsig
 		memcpy(m_packet + m_packetLen, &originalPlayerID, sizeof(UnsignedByte));
 		m_packetLen += sizeof(UnsignedByte);
 
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 
@@ -4882,20 +4825,15 @@ Bool NetPacket::addGameCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 
 		retval = TRUE;
 	}
 
-	if (gmsg) {
-		deleteInstance(gmsg);
-		gmsg = NULL;
-	}
+	deleteInstance(gmsg);
+	gmsg = NULL;
 
 	return retval;
 }
@@ -5233,10 +5171,7 @@ NetCommandList * NetPacket::getCommandList() {
 				DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::getCommandList - failed to set relay for message %d", msg->getID()));
 			}
 
-			if (lastCommand != NULL) {
-				deleteInstance(lastCommand);
-				lastCommand = NULL;
-			}
+			deleteInstance(lastCommand);
 			lastCommand = newInstance(NetCommandRef)(msg);
 
 			msg->detach();  // Need to detach from new NetCommandMsg created by the "readXMessage" above.
@@ -5311,7 +5246,6 @@ NetCommandList * NetPacket::getCommandList() {
 			}
 
 			deleteInstance(lastCommand);
-			lastCommand = NULL;
 //			lastCommand = newInstance(NetCommandRef)(msg);
 			lastCommand = NEW_NETCOMMANDREF(msg);
 
@@ -5334,10 +5268,9 @@ NetCommandList * NetPacket::getCommandList() {
 
 	}
 
-	if (lastCommand != NULL) {
-		deleteInstance(lastCommand);
-		lastCommand = NULL;
-	}
+	deleteInstance(lastCommand);
+	lastCommand = NULL;
+
 	return retval;
 }
 

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/Common/System/W3DRadar.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/Common/System/W3DRadar.cpp
@@ -144,8 +144,8 @@ void W3DRadar::deleteResources( void )
 	if( m_terrainTexture )
 		m_terrainTexture->Release_Ref();
 	m_terrainTexture = NULL;
-	if( m_terrainImage )
-		deleteInstance(m_terrainImage);
+
+	deleteInstance(m_terrainImage);
 	m_terrainImage = NULL;
 
 	//
@@ -154,8 +154,8 @@ void W3DRadar::deleteResources( void )
 	if( m_overlayTexture )
 		m_overlayTexture->Release_Ref();
 	m_overlayTexture = NULL;
-	if( m_overlayImage )
-		deleteInstance(m_overlayImage);
+
+	deleteInstance(m_overlayImage);
 	m_overlayImage = NULL;
 
 	//
@@ -164,8 +164,8 @@ void W3DRadar::deleteResources( void )
 	if( m_shroudTexture )
 		m_shroudTexture->Release_Ref();
 	m_shroudTexture = NULL;
-	if( m_shroudImage )
-		deleteInstance(m_shroudImage);
+
+	deleteInstance(m_shroudImage);
 	m_shroudImage = NULL;
 
 }  // end deleteResources

--- a/Generals/Code/Tools/WorldBuilder/include/WorldBuilder.h
+++ b/Generals/Code/Tools/WorldBuilder/include/WorldBuilder.h
@@ -139,8 +139,7 @@ protected:
 protected:
 	void deletePasteObjList(void)
 	{
-		if (m_pasteMapObjList)
-			deleteInstance(m_pasteMapObjList);
+		deleteInstance(m_pasteMapObjList);
 		m_pasteMapObjList = NULL;
 	};
 

--- a/Generals/Code/Tools/WorldBuilder/src/CUndoable.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/CUndoable.cpp
@@ -207,7 +207,7 @@ void WBDocUndoable::Undo(void)
 AddObjectUndoable::~AddObjectUndoable(void)
 {
 	m_pDoc = NULL;  // not ref counted.
-	if (m_objectToAdd && !m_addedToList) {
+	if (!m_addedToList) {
 		deleteInstance(m_objectToAdd);
 		m_objectToAdd=NULL;
 	}
@@ -857,7 +857,7 @@ void DictItemUndoable::Undo(void)
 ***************************************************************************/
 DeleteInfo::~DeleteInfo(void)
 {
-	if (m_didDelete && m_objectToDelete) {
+	if (m_didDelete) {
 		deleteInstance(m_objectToDelete);
 	}
 	DeleteInfo *pCur = m_next;

--- a/Generals/Code/Tools/WorldBuilder/src/FenceOptions.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/FenceOptions.cpp
@@ -68,9 +68,7 @@ FenceOptions::FenceOptions(CWnd* pParent /*=NULL*/)
 
 FenceOptions::~FenceOptions(void)
 {
-	if (m_objectsList) {
-		deleteInstance(m_objectsList);
-	}
+	deleteInstance(m_objectsList);
 	m_objectsList = NULL;
 }
 

--- a/Generals/Code/Tools/WorldBuilder/src/FenceTool.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/FenceTool.cpp
@@ -49,9 +49,7 @@ FenceTool::FenceTool(void) :
 /// Destructor
 FenceTool::~FenceTool(void)
 {
-	if (m_mapObjectList) {
-		deleteInstance(m_mapObjectList);
-	}
+	deleteInstance(m_mapObjectList);
 	m_mapObjectList = NULL;
 }
 
@@ -154,10 +152,10 @@ void FenceTool::mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldB
 	pView->snapPoint(&cpt);
 	m_downPt2d = viewPt;
 	m_downPt3d = cpt;
-	if (m_mapObjectList) {
-		deleteInstance(m_mapObjectList);
-		m_mapObjectList = NULL;
-	}
+
+	deleteInstance(m_mapObjectList);
+	m_mapObjectList = NULL;
+
 	if (FenceOptions::hasSelectedObject()) {
 		FenceOptions::update();
 		m_curObjectWidth = FenceOptions::getFenceSpacing();

--- a/Generals/Code/Tools/WorldBuilder/src/GroveTool.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/GroveTool.cpp
@@ -244,9 +244,7 @@ GroveTool::GroveTool(void) :
 /// Destructor
 GroveTool::~GroveTool(void)
 {
-	if (m_headMapObj) {
-		deleteInstance(m_headMapObj);
-	}
+	deleteInstance(m_headMapObj);
 }
 
 /** Execute the tool on mouse down - Place an object. */

--- a/Generals/Code/Tools/WorldBuilder/src/ObjectOptions.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/ObjectOptions.cpp
@@ -64,9 +64,7 @@ ObjectOptions::ObjectOptions(CWnd* pParent /*=NULL*/)
 
 ObjectOptions::~ObjectOptions(void)
 {
-	if (m_objectsList) {
-		deleteInstance(m_objectsList);
-	}
+	deleteInstance(m_objectsList);
 	m_objectsList = NULL;
 }
 

--- a/Generals/Code/Tools/WorldBuilder/src/PickUnitDialog.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/PickUnitDialog.cpp
@@ -94,9 +94,7 @@ PickUnitDialog::PickUnitDialog(UINT id, CWnd* pParent /*=NULL*/)
 
 PickUnitDialog::~PickUnitDialog()
 {
-	if (m_objectsList) {
-		deleteInstance(m_objectsList);
-	}
+	deleteInstance(m_objectsList);
 	m_objectsList = NULL;
 }
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/Overridable.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Overridable.h
@@ -122,8 +122,7 @@ class Overridable : public MemoryPoolObject
 // cleans up and dangling overrides.
 __inline Overridable::~Overridable()
 {
-	if (m_nextOverride)
-		deleteInstance(m_nextOverride);
+	deleteInstance(m_nextOverride);
 }
 
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/StateMachine.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/StateMachine.h
@@ -485,7 +485,8 @@ EMPTY_DTOR(SleepState)
 // @todo Replace calls to deleteInstance with RefCountPtr<StateMachine> when so appropriate.
 inline void deleteInstance(StateMachine* machine)
 {
-	machine->Release_Ref();
+	if (machine != NULL)
+		machine->Release_Ref();
 }
 
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/ThingTemplate.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/ThingTemplate.h
@@ -154,8 +154,7 @@ public:
 	~AudioArray()
 	{
 		for (Int i = 0; i < TTAUDIO_COUNT; ++i)
-			if (m_audio[i])
-				deleteInstance(m_audio[i]);
+			deleteInstance(m_audio[i]);
 	}
 
 	AudioArray(const AudioArray& that)

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -1060,8 +1060,7 @@ GlobalData::~GlobalData( void )
 {
 	DEBUG_ASSERTCRASH( TheWritableGlobalData->m_next == NULL, ("~GlobalData: theOriginal is not original") );
 
-	if (m_weaponBonusSet)
-		deleteInstance(m_weaponBonusSet);
+	deleteInstance(m_weaponBonusSet);
 
 	if( m_theOriginal == this )	{
 		m_theOriginal = NULL;

--- a/GeneralsMD/Code/GameEngine/Source/Common/INI/INI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/INI/INI.cpp
@@ -1185,11 +1185,8 @@ void INI::parseDynamicAudioEventRTS( INI *ini, void * /*instance*/, void *store,
 	// translate the string into a sound
 	if (stricmp(token, "NoSound") == 0)
 	{
-		if (*theSound)
-		{
-			deleteInstance(*theSound);
-			*theSound = NULL;
-		}
+		deleteInstance(*theSound);
+		*theSound = NULL;
 	}
 	else
 	{

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -369,54 +369,36 @@ void Player::init(const PlayerTemplate* pt)
 	m_bombardBattlePlans = 0;
 	m_holdTheLineBattlePlans = 0;
 	m_searchAndDestroyBattlePlans = 0;
-	if( m_battlePlanBonuses )
-	{
-		deleteInstance(m_battlePlanBonuses);
-		m_battlePlanBonuses = NULL;
-	}
+
+	deleteInstance(m_battlePlanBonuses);
+	m_battlePlanBonuses = NULL;
 
 	deleteUpgradeList();
 
 	m_energy.init(this);
 	m_stats.init();
-	if (m_pBuildList != NULL)
-	{
-		deleteInstance(m_pBuildList);
-		m_pBuildList = NULL;
-	}
+
+	deleteInstance(m_pBuildList);
+	m_pBuildList = NULL;
+
 	m_defaultTeam = NULL;
 
-	if (m_ai)
-	{
-		deleteInstance(m_ai);
-	}
+	deleteInstance(m_ai);
 	m_ai = NULL;
 
-	if( m_resourceGatheringManager )
-	{
-		deleteInstance(m_resourceGatheringManager);
-		m_resourceGatheringManager = NULL;
-	}
+	deleteInstance(m_resourceGatheringManager);
+	m_resourceGatheringManager = NULL;
 
 	for (Int i = 0; i < NUM_HOTKEY_SQUADS; ++i) {
-		if (m_squads[i] != NULL) {
-			deleteInstance(m_squads[i]);
-			m_squads[i] = NULL;
-		}
+		deleteInstance(m_squads[i]);
 		m_squads[i] = newInstance(Squad);
 	}
 
-	if (m_currentSelection != NULL) {
-		deleteInstance(m_currentSelection) ;
-		m_currentSelection = NULL;
-	}
+	deleteInstance(m_currentSelection);
 	m_currentSelection = newInstance(Squad);
 
-	if( m_tunnelSystem )
-	{
-		deleteInstance(m_tunnelSystem);
-		m_tunnelSystem = NULL;
-	}
+	deleteInstance(m_tunnelSystem);
+	m_tunnelSystem = NULL;
 
 	m_canBuildBase = true;
 	m_canBuildUnits = true;
@@ -509,8 +491,7 @@ void Player::init(const PlayerTemplate* pt)
 	{
 		KindOfPercentProductionChange *tof = *it;
 		it = m_kindOfPercentProductionChangeList.erase( it );
-		if(tof)
-			deleteInstance(tof);
+		deleteInstance(tof);
 	}
 
 	getAcademyStats()->init( this );
@@ -535,25 +516,21 @@ Player::~Player()
 
 	// delete the relation maps (the destructor clears the actual map if any data is present)
 	deleteInstance(m_teamRelations);
+	m_teamRelations = NULL;
+
 	deleteInstance(m_playerRelations);
+	m_playerRelations = NULL;
 
 	for (Int i = 0; i < NUM_HOTKEY_SQUADS; ++i) {
-		if (m_squads[i] != NULL) {
-			deleteInstance(m_squads[i]);
-			m_squads[i] = NULL;
-		}
+		deleteInstance(m_squads[i]);
+		m_squads[i] = NULL;
 	}
 
-	if (m_currentSelection != NULL) {
-		deleteInstance(m_currentSelection);
-		m_currentSelection = NULL;
-	}
+	deleteInstance(m_currentSelection);
+	m_currentSelection = NULL;
 
-	if( m_battlePlanBonuses )
-	{
-		deleteInstance(m_battlePlanBonuses);
-		m_battlePlanBonuses = NULL;
-	}
+	deleteInstance(m_battlePlanBonuses);
+	m_battlePlanBonuses = NULL;
 }
 
 //=============================================================================
@@ -660,10 +637,7 @@ Bool Player::removeTeamRelationship(const Team *that)
 void Player::setBuildList(BuildListInfo *pBuildList)
 {
 
-	if (m_pBuildList != NULL)
-	{
-		deleteInstance(m_pBuildList);
-	}
+	deleteInstance(m_pBuildList);
 	m_pBuildList = pBuildList;
 
 }
@@ -756,10 +730,7 @@ void Player::setPlayerType(PlayerType t, Bool skirmish)
 {
 	m_playerType = t;
 
-	if (m_ai)
-	{
-		deleteInstance(m_ai);
-	}
+	deleteInstance(m_ai);
 	m_ai = NULL;
 
 	if (t == PLAYER_COMPUTER)
@@ -792,11 +763,8 @@ void Player::setDefaultTeam(void) {
 //=============================================================================
 void Player::deletePlayerAI()
 {
-	if (m_ai)
-	{
-		deleteInstance(m_ai);
-		m_ai = NULL;
-	}
+	deleteInstance(m_ai);
+	m_ai = NULL;
 }
 
 //=============================================================================
@@ -870,10 +838,10 @@ void Player::initFromDict(const Dict* d)
 
 				ScriptList *scripts = TheSidesList->getSkirmishSideInfo(i)->getScriptList()->duplicateAndQualify(
 							qualifier, qualTemplatePlayerName, pname);
-				if (TheSidesList->getSideInfo(getPlayerIndex())->getScriptList()) {
-					deleteInstance(TheSidesList->getSideInfo(getPlayerIndex())->getScriptList());
-				}
+
+				deleteInstance(TheSidesList->getSideInfo(getPlayerIndex())->getScriptList());
 				TheSidesList->getSideInfo(getPlayerIndex())->setScriptList(scripts);
+
 				deleteInstance(TheSidesList->getSkirmishSideInfo(i)->getScriptList());
 				TheSidesList->getSkirmishSideInfo(i)->setScriptList(NULL);
 			}
@@ -922,12 +890,10 @@ void Player::initFromDict(const Dict* d)
 			qualifier.format("%d", m_mpStartIndex);
 			ScriptList *scripts = TheSidesList->getSkirmishSideInfo(skirmishNdx)->getScriptList()->duplicateAndQualify(
 						qualifier, qualTemplatePlayerName, pname);
-			ScriptList* slist = TheSidesList->getSideInfo(getPlayerIndex())->getScriptList();
-			if (slist)
-			{
-				deleteInstance(slist);
-			}
+
+			deleteInstance(TheSidesList->getSideInfo(getPlayerIndex())->getScriptList());
 			TheSidesList->getSideInfo(getPlayerIndex())->setScriptList(scripts);
+
 			for (i=0; i<TheSidesList->getNumTeams(); i++) {
 				if (TheSidesList->getTeamInfo(i)->getDict()->getAsciiString(TheKey_teamOwner) == pname)
 				{
@@ -994,18 +960,11 @@ void Player::initFromDict(const Dict* d)
 			}
 		}
 	}
-	if( m_resourceGatheringManager )
-	{
-		deleteInstance(m_resourceGatheringManager);
-		m_resourceGatheringManager = NULL;
-	}
+
+	deleteInstance(m_resourceGatheringManager);
 	m_resourceGatheringManager = newInstance(ResourceGatheringManager);
 
-	if( m_tunnelSystem )
-	{
-		deleteInstance(m_tunnelSystem);
-		m_tunnelSystem = NULL;
-	}
+	deleteInstance(m_tunnelSystem);
 	m_tunnelSystem = newInstance(TunnelTracker);
 
 	m_handicap.readFromDict(d);
@@ -1038,18 +997,11 @@ void Player::initFromDict(const Dict* d)
 		m_money.deposit(m);
 
 	for ( i = 0; i < NUM_HOTKEY_SQUADS; ++i ) {
-		if (m_squads[i] != NULL)
-		{
-			deleteInstance(m_squads[i]);
-			m_squads[i] = NULL;
-		}
+		deleteInstance(m_squads[i]);
 		m_squads[i] = newInstance( Squad );
 	}
 
-	if (m_currentSelection != NULL) {
-		deleteInstance(m_currentSelection);
-		m_currentSelection = NULL;
-	}
+	deleteInstance(m_currentSelection);
 	m_currentSelection = newInstance( Squad );
 }
 
@@ -3884,8 +3836,7 @@ void Player::removeKindOfProductionCostChange(	KindOfMaskType kindOf, Real perce
 			if(tof->m_ref == 0)
 			{
 				m_kindOfPercentProductionChangeList.erase( it );
-				if(tof)
-					deleteInstance(tof);
+				deleteInstance(tof);
 			}
 			return;
 		}
@@ -4198,8 +4149,7 @@ void Player::xfer( Xfer *xfer )
 		// destroy any build list that we got from loading the bare bones map, note that deleting
 		// the head of these structures automatically deletes any links attached
 		//
-		if( m_pBuildList)
-			deleteInstance(m_pBuildList);
+		deleteInstance(m_pBuildList);
 		m_pBuildList = NULL;
 
 		// read each build list info
@@ -4538,11 +4488,9 @@ void Player::xfer( Xfer *xfer )
 	xfer->xferBool( &battlePlanBonus ); //If we're loading, it just replaces the bool
 	if( xfer->getXferMode() == XFER_LOAD )
 	{
-		if (m_battlePlanBonuses)
-		{
-			deleteInstance(m_battlePlanBonuses);
-			m_battlePlanBonuses = NULL;
-		}
+		deleteInstance(m_battlePlanBonuses);
+		m_battlePlanBonuses = NULL;
+
 		if ( battlePlanBonus )
 		{
 			m_battlePlanBonuses = newInstance( BattlePlanBonuses );

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Science.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Science.cpp
@@ -54,9 +54,7 @@ ScienceStore::~ScienceStore()
 	{
 		ScienceInfo* si = *it;
 		++it;
-		if (si) {
-			deleteInstance(si);
-		}
+		deleteInstance(si);
 	}
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Team.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Team.cpp
@@ -849,19 +849,13 @@ TeamPrototype::~TeamPrototype()
 	if (m_factory)
 		m_factory->removeTeamPrototypeFromList(this);
 
-	if (m_productionConditionScript)
-	{
-		deleteInstance(m_productionConditionScript);
-	}
+	deleteInstance(m_productionConditionScript);
 	m_productionConditionScript = NULL;
 
 	for (Int i = 0; i < MAX_GENERIC_SCRIPTS; ++i)
 	{
-		if (m_genericScriptsToRun[i])
-		{
-			deleteInstance(m_genericScriptsToRun[i]);
-			m_genericScriptsToRun[i] = NULL;
-		}
+		deleteInstance(m_genericScriptsToRun[i]);
+		m_genericScriptsToRun[i] = NULL;
 	}
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/StateMachine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/StateMachine.cpp
@@ -292,8 +292,7 @@ StateMachine::~StateMachine()
 	// delete all states in the mapping
 	for( i = m_stateMap.begin(); i != m_stateMap.end(); ++i )
 	{
-		if ((*i).second)
-			deleteInstance((*i).second);
+		deleteInstance((*i).second);
 	}
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Display.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Display.cpp
@@ -316,8 +316,7 @@ void Display::update( void )
 				if( m_elapsedCopywriteTime == 0 && m_elapsedCopywriteTime >= 0)
 				{
 					//display the copyrighttext;
-					if(m_copyrightDisplayString)
-						deleteInstance(m_copyrightDisplayString);
+					deleteInstance(m_copyrightDisplayString);
 					m_copyrightDisplayString = TheDisplayStringManager->newDisplayString();
 					m_copyrightDisplayString->setText(TheGameText->fetch("GUI:EACopyright"));
 					if (TheGlobalLanguageData && TheGlobalLanguageData->m_copyrightFont.name.isNotEmpty())

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -157,8 +157,7 @@ void DrawableIconInfo::clear()
 {
 	for (int i = 0; i < MAX_ICONS; ++i)
 	{
-		if (m_icon[i])
-			deleteInstance(m_icon[i]);
+		deleteInstance(m_icon[i]);
 		m_icon[i] = NULL;
 		m_keepTillFrame[i] = 0;
 	}
@@ -553,11 +552,9 @@ Drawable::~Drawable()
 	}
 
 	stopAmbientSound();
-	if (m_ambientSound)
-	{
-		deleteInstance(m_ambientSound);
-		m_ambientSound = NULL;
-	}
+
+	deleteInstance(m_ambientSound);
+	m_ambientSound = NULL;
 
   clearCustomSoundAmbient( false );
 
@@ -569,20 +566,17 @@ Drawable::~Drawable()
 	m_object = NULL;
 
 	// delete any icons present
-	if (m_iconInfo)
-		deleteInstance(m_iconInfo);
+	deleteInstance(m_iconInfo);
+	m_iconInfo = NULL;
 
-	if (m_selectionFlashEnvelope)
-		deleteInstance(m_selectionFlashEnvelope);
+	deleteInstance(m_selectionFlashEnvelope);
+	m_selectionFlashEnvelope = NULL;
 
-	if (m_colorTintEnvelope)
-		deleteInstance(m_colorTintEnvelope);
+	deleteInstance(m_colorTintEnvelope);
+	m_colorTintEnvelope = NULL;
 
-	if (m_locoInfo)
-	{
-		deleteInstance(m_locoInfo);
-		m_locoInfo = NULL;
-	}
+	deleteInstance(m_locoInfo);
+	m_locoInfo = NULL;
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -5390,8 +5384,7 @@ void Drawable::xfer( Xfer *xfer )
           catch( ... )
           {
             // since Xfer can throw exceptions -- don't leak memory!
-            if ( customizedInfo != NULL )
-              deleteInstance(customizedInfo);
+            deleteInstance(customizedInfo);
 
             throw; //rethrow
           }

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Eva.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Eva.cpp
@@ -246,8 +246,7 @@ Eva::~Eva()
 {
 	EvaCheckInfoPtrVecIt it;
 	for (it = m_allCheckInfos.begin(); it != m_allCheckInfos.end(); ++it) {
-		if (*it)
-			deleteInstance(*it);
+		deleteInstance(*it);
 	}
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/FXList.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/FXList.cpp
@@ -791,8 +791,7 @@ void FXList::clear()
 {
 	for (FXNuggetList::iterator it = m_nuggets.begin(); it != m_nuggets.end(); ++it)
 	{
-		if (*it)
-			deleteInstance(*it);
+		deleteInstance(*it);
 	}
 	m_nuggets.clear();
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/AnimateWindowManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/AnimateWindowManager.cpp
@@ -111,14 +111,11 @@ void AnimateWindow::setAnimData( 	ICoord2D startPos, ICoord2D endPos,
 
 static void clearWinList(AnimateWindowList &winList)
 {
-	wnd::AnimateWindow *win = NULL;
 	while (!winList.empty())
 	{
-		win = *(winList.begin());
+		wnd::AnimateWindow *win = *(winList.begin());
 		winList.pop_front();
-		if (win)
-			deleteInstance(win);
-		win = NULL;
+		deleteInstance(win);
 	}
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowManager.cpp
@@ -118,8 +118,7 @@ void GameWindowManager::processDestroyList( void )
 		DEBUG_ASSERTCRASH(doDestroy->winGetUserData() == NULL, ("Win user data is expected to be deleted now"));
 
 		// free the memory
-		if (doDestroy)
-			deleteInstance(doDestroy);
+		deleteInstance(doDestroy);
 
 	}  // end for
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5753,8 +5753,7 @@ void InGameUI::resetIdleWorker( void )
 void InGameUI::recreateControlBar( void )
 {
 	GameWindow *win = TheWindowManager->winGetWindowFromId(NULL, TheNameKeyGenerator->nameToKey(AsciiString("ControlBar.wnd")));
-	if(win)
-		deleteInstance(win);
+	deleteInstance(win);
 
 	m_idleWorkerWin = NULL;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Snow.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Snow.cpp
@@ -96,11 +96,8 @@ SnowManager::~SnowManager()
 	m_startingHeights=NULL;
 
 	// TheSuperHackers @fix Mauller 13/04/2025 Delete the instance of the weather settings
-	if (TheWeatherSetting)
-	{
-		deleteInstance((WeatherSetting*)TheWeatherSetting.getNonOverloadedPointer());
-		TheWeatherSetting=NULL;
-	}
+	deleteInstance((WeatherSetting*)TheWeatherSetting.getNonOverloadedPointer());
+	TheWeatherSetting=NULL;
 }
 
 OVERRIDE<WeatherSetting> TheWeatherSetting = NULL;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/System/CampaignManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/System/CampaignManager.cpp
@@ -130,8 +130,7 @@ Campaign::~Campaign( void )
 	{
 		Mission *mission = *it;
 		it = m_missions.erase( it );
-		if(mission)
-			deleteInstance(mission);
+		deleteInstance(mission);
 	}
 }
 
@@ -236,8 +235,7 @@ CampaignManager::~CampaignManager( void )
 	{
 		Campaign *campaign = *it;
 		it = m_campaignList.erase( it );
-		if(campaign)
-			deleteInstance(campaign);
+		deleteInstance(campaign);
 	}
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AI.cpp
@@ -63,8 +63,7 @@ void TAiData::addFactionBuildList(AISideBuildList *buildList)
 	AISideBuildList *info = m_sideBuildLists;
 	while (info) {
 		if (buildList->m_side == info->m_side) {
-			if (info->m_buildList)
-				deleteInstance(info->m_buildList);
+			deleteInstance(info->m_buildList);
 			info->m_buildList = buildList->m_buildList;
 			buildList->m_buildList = NULL;
 			buildList->m_next = NULL;
@@ -109,9 +108,7 @@ AISideBuildList::AISideBuildList( AsciiString side ) :
 
 AISideBuildList::~AISideBuildList()
 {
-	if (m_buildList) {
-		deleteInstance(m_buildList); // note - deletes all in the list.
-	}
+	deleteInstance(m_buildList); // note - deletes all in the list.
 	m_buildList = NULL;
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
@@ -111,10 +111,9 @@ AIGroup::~AIGroup()
 
 #endif
 
-	if (m_groundPath) {
-		deleteInstance(m_groundPath);
-		m_groundPath = NULL;
-	}
+	deleteInstance(m_groundPath);
+	m_groundPath = NULL;
+
 	//DEBUG_LOG(( "AIGroup #%d destroyed", m_id ));
 }
 
@@ -445,10 +444,8 @@ void AIGroup::recompute( void )
 
 	getCenter( &center );
 
-	if (m_groundPath) {
-		deleteInstance(m_groundPath);
-		m_groundPath = NULL;
-	}
+	deleteInstance(m_groundPath);
+	m_groundPath = NULL;
 
 	m_speed = 9999999999.9f;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -3871,10 +3871,9 @@ void Pathfinder::reset( void )
 	debugPathPos.y = 0.0f;
 	debugPathPos.z = 0.0f;
 
-	if (debugPath)
-		deleteInstance(debugPath);
-
+	deleteInstance(debugPath);
 	debugPath = NULL;
+
 	m_frameToShowObstacles = 0;
 
 	for (m_queuePRHead=0; m_queuePRHead<PATHFIND_QUEUE_LEN; m_queuePRHead++) {
@@ -8176,10 +8175,10 @@ Bool Pathfinder::slowDoesPathExist( Object *obj,
 	Path *path = findPath(obj, locoSet, from, to);
 	m_ignoreObstacleID = INVALID_ID;
 	Bool found = (path!=NULL);
-	if (path) {
-		deleteInstance(path);
-		path = NULL;
-	}
+
+	deleteInstance(path);
+	path = NULL;
+
 	return found;
 }
 
@@ -9121,9 +9120,7 @@ void Pathfinder::setDebugPath(Path *newDebugpath)
 	if (TheGlobalData->m_debugAI)
 	{
 		// copy the path for debugging
-		if (debugPath)
-			deleteInstance(debugPath);
-
+		deleteInstance(debugPath);
 		debugPath = newInstance(Path);
 
 		for( PathNode *copyNode = newDebugpath->getFirstNode(); copyNode; copyNode = copyNode->getNextOptimized() )

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -731,10 +731,7 @@ AIStateMachine::AIStateMachine( Object *obj, AsciiString name ) : StateMachine( 
 //----------------------------------------------------------------------------------------------------------
 AIStateMachine::~AIStateMachine()
 {
-	if (m_goalSquad)
-	{
-		deleteInstance(m_goalSquad);
-	}
+	deleteInstance(m_goalSquad);
 }
 
 
@@ -5703,11 +5700,8 @@ void AIAttackState::onExit( StateExitType status )
 	//addSelfAsTargeter(false);
 
 	// destroy the attack machine
-	if (m_attackMachine)
-	{
-		deleteInstance(m_attackMachine);
-		m_attackMachine = NULL;
-	}
+	deleteInstance(m_attackMachine);
+	m_attackMachine = NULL;
 
 	Object *obj = getMachineOwner();
 	obj->clearStatus( MAKE_OBJECT_STATUS_MASK4( OBJECT_STATUS_IS_FIRING_WEAPON,
@@ -5921,12 +5915,9 @@ StateReturnType AIAttackSquadState::update( void )
 //----------------------------------------------------------------------------------------------------------
 void AIAttackSquadState::onExit( StateExitType status )
 {
-	if( m_attackSquadMachine )
-	{
-		// destroy the attack machine
-		deleteInstance(m_attackSquadMachine);
-		m_attackSquadMachine = NULL;
-	}
+	// destroy the attack machine
+	deleteInstance(m_attackSquadMachine);
+	m_attackSquadMachine = NULL;
 }
 
 //----------------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/TurretAI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/TurretAI.cpp
@@ -321,8 +321,7 @@ TurretAI::~TurretAI()
 {
 	stopRotOrPitchSound();
 
-	if (m_turretStateMachine)
-		deleteInstance(m_turretStateMachine);
+	deleteInstance(m_turretStateMachine);
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/SidesList.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/SidesList.cpp
@@ -87,10 +87,12 @@ void SidesInfo::init(const Dict* d)
 {
 	deleteInstance(m_pBuildList);
 	m_pBuildList = NULL;
+
 	m_dict.clear();
-	if (m_scripts)
-		deleteInstance(m_scripts);
+
+	deleteInstance(m_scripts);
 	m_scripts = NULL;
+
 	if (d)
 		m_dict = *d;
 }
@@ -302,8 +304,7 @@ Bool SidesList::ParseSidesDataChunk(DataChunkInput &file, DataChunkInfo *info, v
 	count = ScriptList::getReadScripts(scripts);
 	for (i=0; i<count; i++) {
 		if (i<TheSidesList->getNumSides()) {
-			ScriptList *pSL = TheSidesList->getSideInfo(i)->getScriptList();
-			deleteInstance(pSL);
+			deleteInstance(TheSidesList->getSideInfo(i)->getScriptList());
 			TheSidesList->getSideInfo(i)->setScriptList(scripts[i]);
 			scripts[i] = NULL;
 		} else {
@@ -545,11 +546,8 @@ void SidesList::prepareForMP_or_Skirmish(void)
 					}
 					if (curSide == -1) continue;
 
-					ScriptList *pSL = getSkirmishSideInfo(curSide)->getScriptList();
+					deleteInstance(getSkirmishSideInfo(curSide)->getScriptList());
 					getSkirmishSideInfo(curSide)->setScriptList(scripts[i]);
-					scripts[i] = NULL;
-					if (pSL)
-						deleteInstance(pSL);
 					scripts[i] = NULL;
 				}
 				for (i=0; i<MAX_PLAYER_COUNT; i++) {

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/FireWeaponWhenDamagedBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/FireWeaponWhenDamagedBehavior.cpp
@@ -146,23 +146,15 @@ FireWeaponWhenDamagedBehavior::FireWeaponWhenDamagedBehavior( Thing *thing, cons
 //-------------------------------------------------------------------------------------------------
 FireWeaponWhenDamagedBehavior::~FireWeaponWhenDamagedBehavior( void )
 {
-	if (m_reactionWeaponPristine)
-		deleteInstance(m_reactionWeaponPristine);
-	if (m_reactionWeaponDamaged)
-		deleteInstance(m_reactionWeaponDamaged);
-	if (m_reactionWeaponReallyDamaged)
-		deleteInstance(m_reactionWeaponReallyDamaged);
-	if (m_reactionWeaponRubble)
-		deleteInstance(m_reactionWeaponRubble);
+	deleteInstance(m_reactionWeaponPristine);
+	deleteInstance(m_reactionWeaponDamaged);
+	deleteInstance(m_reactionWeaponReallyDamaged);
+	deleteInstance(m_reactionWeaponRubble);
 
-	if (m_continuousWeaponPristine)
-		deleteInstance(m_continuousWeaponPristine);
-	if (m_continuousWeaponDamaged)
-		deleteInstance(m_continuousWeaponDamaged);
-	if (m_continuousWeaponReallyDamaged)
-		deleteInstance(m_continuousWeaponReallyDamaged);
-	if (m_continuousWeaponRubble)
-		deleteInstance(m_continuousWeaponRubble);
+	deleteInstance(m_continuousWeaponPristine);
+	deleteInstance(m_continuousWeaponDamaged);
+	deleteInstance(m_continuousWeaponReallyDamaged);
+	deleteInstance(m_continuousWeaponRubble);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Collide/FireWeaponCollide.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Collide/FireWeaponCollide.cpp
@@ -66,8 +66,7 @@ FireWeaponCollide::FireWeaponCollide( Thing *thing, const ModuleData* moduleData
 //-------------------------------------------------------------------------------------------------
 FireWeaponCollide::~FireWeaponCollide( void )
 {
-	if (m_collideWeapon)
-		deleteInstance(m_collideWeapon);
+	deleteInstance(m_collideWeapon);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Locomotor.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Locomotor.cpp
@@ -2760,8 +2760,7 @@ void LocomotorSet::clear()
 {
 	for (size_t i = 0; i < m_locomotors.size(); ++i)
 	{
-		if (m_locomotors[i])
-			deleteInstance(m_locomotors[i]);
+		deleteInstance(m_locomotors[i]);
 	}
 	m_locomotors.clear();
 	m_validLocomotorSurfaces = 0;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -657,9 +657,7 @@ Object::~Object()
 	delete [] m_behaviors;
 	m_behaviors = NULL;
 
-	if( m_experienceTracker )
-		deleteInstance(m_experienceTracker);
-
+	deleteInstance(m_experienceTracker);
 	m_experienceTracker = NULL;
 
 	// we don't need to delete these, there were deleted on the m_behaviors list
@@ -3758,11 +3756,8 @@ void Object::updateObjValuesFromMapProperties(Dict* properties)
       audioToModify = NULL; // Belongs to TheAudio now
     }
 
-    if ( audioToModify != NULL )
-    {
-      deleteInstance(audioToModify);
-      audioToModify = NULL;
-    }
+    deleteInstance(audioToModify);
+    audioToModify = NULL;
 
     if ( soundEnabledExists && soundEnabled )
     {

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
@@ -1583,8 +1583,7 @@ ObjectCreationListStore::~ObjectCreationListStore()
 {
 	for (ObjectCreationNuggetVector::iterator i = m_nuggets.begin(); i != m_nuggets.end(); ++i)
 	{
-		if (*i)
-			deleteInstance(*i);
+		deleteInstance(*i);
 	}
 	m_nuggets.clear();
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -98,8 +98,7 @@ AIUpdateModuleData::~AIUpdateModuleData()
 		if (m_turretData[i])
 		{
 			TurretAIData* td = const_cast<TurretAIData*>(m_turretData[i]);
-			if (td)
-				deleteInstance(td);
+			deleteInstance(td);
 		}
 	}
 }
@@ -644,8 +643,7 @@ AIUpdateInterface::~AIUpdateInterface( void )
 
 	for (int i = 0; i < MAX_TURRETS; i++)
 	{
-		if (m_turretAI[i])
-			deleteInstance(m_turretAI[i]);
+		deleteInstance(m_turretAI[i]);
 		m_turretAI[i] = NULL;
 	}
 	m_stateMachine = NULL;
@@ -2020,10 +2018,9 @@ Bool AIUpdateInterface::computeAttackPath( PathfindServicesInterface *pathServic
 void AIUpdateInterface::destroyPath( void )
 {
 	// destroy previous path
-	if (m_path)
-		deleteInstance(m_path);
-
+	deleteInstance(m_path);
 	m_path = NULL;
+
 	m_waitingForPath = FALSE; // we no longer need it.
 	//CRCDEBUG_LOG(("AIUpdateInterface::destroyPath() - m_isAttackPath = FALSE for object %d", getObject()->getID()));
 	m_isAttackPath = FALSE;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DeliverPayloadAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DeliverPayloadAIUpdate.cpp
@@ -133,8 +133,7 @@ DeliverPayloadAIUpdate::~DeliverPayloadAIUpdate( void )
 {
 	m_deliveryDecal.clear();
 
-	if (m_deliverPayloadStateMachine)
-		deleteInstance(m_deliverPayloadStateMachine);
+	deleteInstance(m_deliverPayloadStateMachine);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -256,8 +255,7 @@ void DeliverPayloadAIUpdate::deliverPayload(
 	//THIS GETS CALLED VIA OBJECT CREATION LISTS ONLY!!!
 	//****************************************************
 
-	if (m_deliverPayloadStateMachine)
-		deleteInstance(m_deliverPayloadStateMachine);
+	deleteInstance(m_deliverPayloadStateMachine);
 	m_deliverPayloadStateMachine = NULL;
 
 	m_moveToPos = *moveToPos;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -1178,7 +1178,7 @@ protected:
 	StateMachine *m_actionMachine;
 
 };
-inline DozerActionState::~DozerActionState( void ) { if (m_actionMachine) deleteInstance(m_actionMachine); }
+inline DozerActionState::~DozerActionState( void ) { deleteInstance(m_actionMachine); }
 
 // ------------------------------------------------------------------------------------------------
 /** CRC */
@@ -1477,8 +1477,7 @@ DozerAIUpdate::~DozerAIUpdate( void )
 {
 
 	// delete our behavior state machine
-	if( m_dozerMachine )
-		deleteInstance(m_dozerMachine);
+	deleteInstance(m_dozerMachine);
 
 	// no orders
 	for( Int i = 0; i < DOZER_NUM_TASKS; i++ )

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -126,14 +126,9 @@ WorkerAIUpdate::~WorkerAIUpdate( void )
 {
 
 	// delete our behavior state machine
-	if( m_dozerMachine )
-		deleteInstance(m_dozerMachine);
-
-	if( m_supplyTruckStateMachine )
-		deleteInstance(m_supplyTruckStateMachine);
-
-	if( m_workerMachine )
-		deleteInstance(m_workerMachine);
+	deleteInstance(m_dozerMachine);
+	deleteInstance(m_supplyTruckStateMachine);
+	deleteInstance(m_workerMachine);
 
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/FireWeaponUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/FireWeaponUpdate.cpp
@@ -83,8 +83,7 @@ FireWeaponUpdate::FireWeaponUpdate( Thing *thing, const ModuleData* moduleData )
 //-------------------------------------------------------------------------------------------------
 FireWeaponUpdate::~FireWeaponUpdate( void )
 {
-	if (m_weapon)
-		deleteInstance(m_weapon);
+	deleteInstance(m_weapon);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
@@ -255,11 +255,8 @@ void PhysicsBehavior::onObjectCreated()
 //-------------------------------------------------------------------------------------------------
 PhysicsBehavior::~PhysicsBehavior()
 {
-	if (m_bounceSound)
-	{
-		deleteInstance(m_bounceSound);
-		m_bounceSound = NULL;
-	}
+	deleteInstance(m_bounceSound);
+	m_bounceSound = NULL;
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -607,11 +604,8 @@ void PhysicsBehavior::setBounceSound(const AudioEventRTS* bounceSound)
 	}
 	else
 	{
-		if (m_bounceSound)
-		{
-			deleteInstance(m_bounceSound);
-			m_bounceSound = NULL;
-		}
+		deleteInstance(m_bounceSound);
+		m_bounceSound = NULL;
 	}
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -327,13 +327,10 @@ WeaponTemplate::WeaponTemplate() : m_nextTemplate(NULL)
 //-------------------------------------------------------------------------------------------------
 WeaponTemplate::~WeaponTemplate()
 {
-	if (m_nextTemplate) {
-		deleteInstance(m_nextTemplate);
-	}
+	deleteInstance(m_nextTemplate);
 
 	// delete any extra-bonus that's present
-	if (m_extraBonus)
-		deleteInstance(m_extraBonus);
+	deleteInstance(m_extraBonus);
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -1502,8 +1499,7 @@ WeaponStore::~WeaponStore()
 	for (size_t i = 0; i < m_weaponTemplateVector.size(); i++)
 	{
 		WeaponTemplate* wt = m_weaponTemplateVector[i];
-		if (wt)
-			deleteInstance(wt);
+		deleteInstance(wt);
 	}
 	m_weaponTemplateVector.clear();
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/WeaponSet.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/WeaponSet.cpp
@@ -190,8 +190,7 @@ WeaponSet::WeaponSet()
 WeaponSet::~WeaponSet()
 {
 	for (Int i = 0; i < WEAPONSLOT_COUNT; ++i)
-		if (m_weapons[i])
-			deleteInstance(m_weapons[i]);
+		deleteInstance(m_weapons[i]);
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -311,11 +310,8 @@ void WeaponSet::updateWeaponSet(const Object* obj)
 		m_hasDamageWeapon = false;
 		for (Int i = WEAPONSLOT_COUNT - 1; i >= PRIMARY_WEAPON ; --i)
 		{
-			if (m_weapons[i] != NULL)
-			{
-				deleteInstance(m_weapons[i]);
-				m_weapons[i] = NULL;
-			}
+			deleteInstance(m_weapons[i]);
+			m_weapons[i] = NULL;
 
 			if (set->getNth((WeaponSlotType)i))
 			{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptConditions.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptConditions.cpp
@@ -74,8 +74,7 @@ public:
 
 	~ObjectTypesTemp()
 	{
-		if (m_types)
-			deleteInstance(m_types);
+		deleteInstance(m_types);
 	}
 };
 
@@ -114,8 +113,7 @@ public:
 //-------------------------------------------------------------------------------------------------
 TransportStatus::~TransportStatus()
 {
-	if (m_nextStatus)
-		deleteInstance(m_nextStatus);
+	deleteInstance(m_nextStatus);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/Scripts.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/Scripts.cpp
@@ -218,14 +218,11 @@ m_firstScript(NULL)
 */
 ScriptList::~ScriptList(void)
 {
-	if (m_firstGroup) {
-		deleteInstance(m_firstGroup);
-		m_firstGroup = NULL;
-	}
-	if (m_firstScript) {
-		deleteInstance(m_firstScript);
-		m_firstScript = NULL;
-	}
+	deleteInstance(m_firstGroup);
+	m_firstGroup = NULL;
+
+	deleteInstance(m_firstScript);
+	m_firstScript = NULL;
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -529,10 +526,8 @@ Bool ScriptList::ParseScriptsDataChunk(DataChunkInput &file, DataChunkInfo *info
 	file.registerParser( AsciiString("ScriptList"), info->label, ScriptList::ParseScriptListDataChunk );
 	DEBUG_ASSERTCRASH(s_numInReadList==0, ("Leftover scripts floating aroung."));
 	for (i=0; i<s_numInReadList; i++) {
-		if (s_readLists[i]) {
-			deleteInstance(s_readLists[i]);
-			s_readLists[i] = NULL;
-		}
+		deleteInstance(s_readLists[i]);
+		s_readLists[i] = NULL;
 	}
 	TScriptListReadInfo readInfo;
 	for (i=0; i<MAX_PLAYER_COUNT; i++) {
@@ -652,11 +647,10 @@ m_nextGroup(NULL)
 */
 ScriptGroup::~ScriptGroup(void)
 {
-	if (m_firstScript) {
-		// Delete the first script.  m_firstScript deletes the entire list.
-		deleteInstance(m_firstScript);
-		m_firstScript = NULL;
-	}
+	// Delete the first script.  m_firstScript deletes the entire list.
+	deleteInstance(m_firstScript);
+	m_firstScript = NULL;
+
 	if (m_nextGroup) {
 		// Delete all the subsequent groups in our list.
 		ScriptGroup *cur = m_nextGroup;
@@ -942,16 +936,10 @@ Script::~Script(void)
 			cur = next;
 		}
 	}
-	if (m_condition) {
-		deleteInstance(m_condition);
-	}
-	if (m_action) {
-		deleteInstance(m_action);
-	}
 
-	if (m_actionFalse) {
-		deleteInstance(m_actionFalse);
-	}
+	deleteInstance(m_condition);
+	deleteInstance(m_action);
+	deleteInstance(m_actionFalse);
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -998,12 +986,7 @@ void Script::loadPostProcess( void )
 Script *Script::duplicate(void) const
 {
 	Script *pNew = newInstance(Script);
-	if (pNew->m_condition) {
-		deleteInstance(pNew->m_condition);
-	}
-	if (pNew->m_action) {
-		deleteInstance(pNew->m_action);
-	}
+
 	pNew->m_scriptName = m_scriptName;
 	pNew->m_comment = m_comment;
 	pNew->m_conditionComment = m_conditionComment;
@@ -1015,6 +998,7 @@ Script *Script::duplicate(void) const
 	pNew->m_normal = m_normal;
 	pNew->m_hard = m_hard;
 	pNew->m_delayEvaluationSeconds = m_delayEvaluationSeconds;
+
 	if (m_condition) {
 		pNew->m_condition = m_condition->duplicate();
 	}
@@ -1037,12 +1021,7 @@ Script *Script::duplicateAndQualify(const AsciiString& qualifier,
 			const AsciiString& playerTemplateName, const AsciiString& newPlayerName) const
 {
 	Script *pNew = newInstance(Script);
-	if (pNew->m_condition) {
-		deleteInstance(pNew->m_condition);
-	}
-	if (pNew->m_action) {
-		deleteInstance(pNew->m_action);
-	}
+
 	pNew->m_scriptName = m_scriptName;
 	pNew->m_scriptName.concat(qualifier);
 	pNew->m_comment = m_comment;
@@ -1055,6 +1034,7 @@ Script *Script::duplicateAndQualify(const AsciiString& qualifier,
 	pNew->m_normal = m_normal;
 	pNew->m_hard = m_hard;
 	pNew->m_delayEvaluationSeconds = m_delayEvaluationSeconds;
+
 	if (m_condition) {
 		pNew->m_condition = m_condition->duplicateAndQualify(qualifier, playerTemplateName, newPlayerName);
 	}
@@ -1086,19 +1066,16 @@ void Script::updateFrom(Script *pSrc)
 	this->m_easy = pSrc->m_easy;
 	this->m_normal = pSrc->m_normal;
 	this->m_hard = pSrc->m_hard;
-	if (this->m_condition) {
-		deleteInstance(this->m_condition);
-	}
+
+	deleteInstance(this->m_condition);
 	this->m_condition = pSrc->m_condition;
 	pSrc->m_condition = NULL;
-	if (this->m_action) {
-		deleteInstance(this->m_action);
-	}
+
+	deleteInstance(this->m_action);
 	this->m_action = pSrc->m_action;
 	pSrc->m_action = NULL;
-	if (this->m_actionFalse) {
-		deleteInstance(this->m_actionFalse);
-	}
+
+	deleteInstance(this->m_actionFalse);
 	this->m_actionFalse = pSrc->m_actionFalse;
 	pSrc->m_actionFalse = NULL;
 }
@@ -1346,10 +1323,9 @@ OrCondition *Script::findPreviousOrCondition( OrCondition *curOr )
 //-------------------------------------------------------------------------------------------------
 OrCondition::~OrCondition(void)
 {
-	if (m_firstAnd) {
-		deleteInstance(m_firstAnd);
-		m_firstAnd = NULL;
-	}
+	deleteInstance(m_firstAnd);
+	m_firstAnd = NULL;
+
 	if (m_nextOr) {
 		OrCondition *cur = m_nextOr;
 		OrCondition *next;
@@ -1539,8 +1515,7 @@ void Condition::setConditionType(enum ConditionType type)
 {
 	Int i;
 	for (i=0; i<m_numParms; i++) {
-		if (m_parms[i])
-			deleteInstance(m_parms[i]);
+		deleteInstance(m_parms[i]);
 		m_parms[i] = NULL;
 	}
 	m_conditionType = type;
@@ -2292,8 +2267,7 @@ void ScriptAction::setActionType(enum ScriptActionType type)
 {
 	Int i;
 	for (i=0; i<m_numParms; i++) {
-		if (m_parms[i])
-			deleteInstance(m_parms[i]);
+		deleteInstance(m_parms[i]);
 		m_parms[i] = NULL;
 	}
 	m_actionType = type;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/CaveSystem.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/CaveSystem.cpp
@@ -52,11 +52,8 @@ void CaveSystem::reset()
 {
 	for( std::vector<TunnelTracker*>::iterator iter = m_tunnelTrackerVector.begin(); iter != m_tunnelTrackerVector.end(); iter++ )
 	{
-		TunnelTracker *currentTracker = *iter;
-		if( currentTracker )// could be NULL, since we don't slide back to fill deleted entries so offsets don't shift
-		{
-			deleteInstance(currentTracker);
-		}
+		TunnelTracker *currentTracker = *iter; // could be NULL, since we don't slide back to fill deleted entries so offsets don't shift
+		deleteInstance(currentTracker);
 	}
 	m_tunnelTrackerVector.clear();
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/CrateSystem.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/CrateSystem.cpp
@@ -47,10 +47,7 @@ CrateSystem::~CrateSystem()
 	for( Int templateIndex = 0; templateIndex < count; templateIndex ++ )
 	{
 		CrateTemplate *currentTemplate = m_crateTemplateVector[templateIndex];
-		if( currentTemplate )
-		{
-			deleteInstance(currentTemplate);
-		}
+		deleteInstance(currentTemplate);
 	}
 	m_crateTemplateVector.clear();
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/RankInfo.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/RankInfo.cpp
@@ -49,10 +49,7 @@ RankInfoStore::~RankInfoStore()
 	for (level =0; level < getRankLevelCount(); level++)
 	{
 		RankInfo* ri = m_rankInfos[level];
-		if (ri)
-		{
-			deleteInstance(ri);
-		}
+		deleteInstance(ri);
 	}
 	m_rankInfos.clear();
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/Connection.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/Connection.cpp
@@ -58,15 +58,11 @@ Connection::Connection() {
  * The destructor.
  */
 Connection::~Connection() {
-	if (m_user != NULL) {
-		deleteInstance(m_user);
-		m_user = NULL;
-	}
+	deleteInstance(m_user);
+	m_user = NULL;
 
-	if (m_netCommandList != NULL) {
-		deleteInstance(m_netCommandList);
-		m_netCommandList = NULL;
-	}
+	deleteInstance(m_netCommandList);
+	m_netCommandList = NULL;
 }
 
 /**
@@ -75,10 +71,8 @@ Connection::~Connection() {
 void Connection::init() {
 	m_transport = NULL;
 
-	if (m_user != NULL) {
-		deleteInstance(m_user);
-		m_user = NULL;
-	}
+	deleteInstance(m_user);
+	m_user = NULL;
 
 	if (m_netCommandList == NULL) {
 		m_netCommandList = newInstance(NetCommandList);
@@ -123,10 +117,7 @@ void Connection::attachTransport(Transport *transport) {
  * Assign this connection a user.  This is the user to whome we send all our packetized goodies.
  */
 void Connection::setUser(User *user) {
-	if (m_user != NULL) {
-		deleteInstance(m_user);
-	}
-
+	deleteInstance(m_user);
 	m_user = user;
 }
 
@@ -325,9 +316,8 @@ UnsignedInt Connection::doSend() {
 			couldQueue = m_transport->queueSend(packet->getAddr(), packet->getPort(), packet->getData(), packet->getLength());
 			m_lastTimeSent = curtime;
 		}
-		if (packet != NULL) {
-			deleteInstance(packet); // delete the packet now that we're done with it.
-		}
+
+		deleteInstance(packet); // delete the packet now that we're done with it.
 	}
 
 	return numpackets;

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/ConnectionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/ConnectionManager.cpp
@@ -59,57 +59,39 @@
  */
 ConnectionManager::~ConnectionManager(void)
 {
-	if (m_localUser != NULL) {
-		deleteInstance(m_localUser);
-		m_localUser = NULL;
-	}
+	deleteInstance(m_localUser);
+	m_localUser = NULL;
 
-//	m_transport = NULL; // Network will delete transports; we just forget them
-	if (m_transport != NULL) {
-		delete m_transport;
-		m_transport = NULL;
-	}
+	// Network will delete transports; we just forget them
+	delete m_transport;
+	m_transport = NULL;
 
 	Int i = 0;
 	for (; i < MAX_SLOTS; ++i) {
-		if (m_frameData[i] != NULL) {
-			deleteInstance(m_frameData[i]);
-			m_frameData[i] = NULL;
-		}
+		deleteInstance(m_frameData[i]);
+		m_frameData[i] = NULL;
 	}
 
 	for (i = 0; i < NUM_CONNECTIONS; ++i) {
-		if (m_connections[i] != NULL) {
-			deleteInstance(m_connections[i]);
-			m_connections[i] = NULL;
-		}
+		deleteInstance(m_connections[i]);
+		m_connections[i] = NULL;
 	}
 
-	if (TheDisconnectMenu != NULL) {
-		// This is done here since TheDisconnectMenu should only be there if we are in a network game.
-		delete TheDisconnectMenu;
-		TheDisconnectMenu = NULL;
-	}
+	// This is done here since TheDisconnectMenu should only be there if we are in a network game.
+	delete TheDisconnectMenu;
+	TheDisconnectMenu = NULL;
 
-	if (m_disconnectManager != NULL) {
-		delete m_disconnectManager;
-		m_disconnectManager = NULL;
-	}
+	delete m_disconnectManager;
+	m_disconnectManager = NULL;
 
-	if (m_pendingCommands != NULL) {
-		deleteInstance(m_pendingCommands);
-		m_pendingCommands = NULL;
-	}
+	deleteInstance(m_pendingCommands);
+	m_pendingCommands = NULL;
 
-	if (m_relayedCommands != NULL) {
-		deleteInstance(m_relayedCommands);
-		m_relayedCommands = NULL;
-	}
+	deleteInstance(m_relayedCommands);
+	m_relayedCommands = NULL;
 
-	if (m_netCommandWrapperList != NULL) {
-		deleteInstance(m_netCommandWrapperList);
-		m_netCommandWrapperList = NULL;
-	}
+	deleteInstance(m_netCommandWrapperList);
+	m_netCommandWrapperList = NULL;
 
 	s_fileCommandMap.clear();
 	s_fileRecipientMaskMap.clear();
@@ -174,10 +156,8 @@ void ConnectionManager::init()
 	}
 
 	for (i = 0; i < MAX_SLOTS; ++i) {
-		if (m_frameData[i] != NULL) {
-			deleteInstance(m_frameData[i]);
-			m_frameData[i] = NULL;
-		}
+		deleteInstance(m_frameData[i]);
+		m_frameData[i] = NULL;
 	}
 
 //	m_averageFps = 30;			// since 30 fps is the desired rate, we'll start off at that.
@@ -228,18 +208,14 @@ void ConnectionManager::reset()
 
 	UnsignedInt i = 0;
 	for (; i < (UnsignedInt)NUM_CONNECTIONS; ++i) {
-		if (m_connections[i] != NULL) {
-			deleteInstance(m_connections[i]);
-			m_connections[i] = NULL;
-		}
+		deleteInstance(m_connections[i]);
+		m_connections[i] = NULL;
 	}
 
 	for (i=0; i<(UnsignedInt)MAX_SLOTS; ++i)
 	{
-		if (m_frameData[i] != NULL) {
-			deleteInstance(m_frameData[i]);
-			m_frameData[i] = NULL;
-		}
+		deleteInstance(m_frameData[i]);
+		m_frameData[i] = NULL;
 	}
 
 	if (m_pendingCommands == NULL) {

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/FrameData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/FrameData.cpp
@@ -49,10 +49,8 @@ FrameData::FrameData()
  */
 FrameData::~FrameData()
 {
-	if (m_commandList != NULL) {
-		deleteInstance(m_commandList);
-		m_commandList = NULL;
-	}
+	deleteInstance(m_commandList);
+	m_commandList = NULL;
 }
 
 /**

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/NetPacket.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/NetPacket.cpp
@@ -1005,8 +1005,7 @@ void NetPacket::FillBufferWithGameCommand(UnsignedByte *buffer, NetCommandRef *m
 
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addGameMessage - added game message, frame %d, player %d, command ID %d", m_lastFrame, m_lastPlayerID, m_lastCommandID));
 
-	if (gmsg)
-		deleteInstance(gmsg);
+	deleteInstance(gmsg);
 	gmsg = NULL;
 }
 
@@ -2002,10 +2001,8 @@ NetPacket::NetPacket(TransportMessage *msg) {
  * Destructor
  */
 NetPacket::~NetPacket() {
-	if (m_lastCommand != NULL) {
-		deleteInstance(m_lastCommand);
-		m_lastCommand = NULL;
-	}
+	deleteInstance(m_lastCommand);
+	m_lastCommand = NULL;
 }
 
 /**
@@ -2028,10 +2025,9 @@ void NetPacket::init() {
 }
 
 void NetPacket::reset() {
-	if (m_lastCommand != NULL) {
-		deleteInstance(m_lastCommand);
-		m_lastCommand = NULL;
-	}
+	deleteInstance(m_lastCommand);
+	m_lastCommand = NULL;
+
 	init();
 }
 
@@ -2197,10 +2193,8 @@ Bool NetPacket::addFrameResendRequestCommand(NetCommandRef *msg) {
 		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addFrameResendRequest - added frame resend request command from player %d for frame %d, command id = %d", m_lastPlayerID, frameToResend, m_lastCommandID));
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 
@@ -2308,10 +2302,8 @@ Bool NetPacket::addDisconnectScreenOffCommand(NetCommandRef *msg) {
 		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addDisconnectScreenOff - added disconnect screen off command from player %d for frame %d, command id = %d", m_lastPlayerID, newFrame, m_lastCommandID));
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 
@@ -2417,10 +2409,8 @@ Bool NetPacket::addDisconnectFrameCommand(NetCommandRef *msg) {
 		m_packetLen += sizeof(disconnectFrame);
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 
@@ -2525,10 +2515,8 @@ Bool NetPacket::addFileCommand(NetCommandRef *msg) {
 		m_packetLen += fileLength;
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 		return TRUE;
@@ -2630,10 +2618,8 @@ Bool NetPacket::addFileAnnounceCommand(NetCommandRef *msg) {
 		m_packetLen += sizeof(playerMask);
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 
@@ -2735,10 +2721,8 @@ Bool NetPacket::addFileProgressCommand(NetCommandRef *msg) {
 		m_packetLen += sizeof(progress);
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 
@@ -2867,10 +2851,8 @@ Bool NetPacket::addWrapperCommand(NetCommandRef *msg) {
 		m_packetLen += dataLength;
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 
@@ -2966,10 +2948,8 @@ Bool NetPacket::addTimeOutGameStartMessage(NetCommandRef *msg) {
 		++m_packetLen;
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 
@@ -3060,10 +3040,8 @@ Bool NetPacket::addLoadCompleteMessage(NetCommandRef *msg) {
 		++m_packetLen;
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 
@@ -3146,10 +3124,8 @@ Bool NetPacket::addProgressMessage(NetCommandRef *msg) {
 		++m_packetLen;
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 
@@ -3257,10 +3233,8 @@ Bool NetPacket::addDisconnectVoteCommand(NetCommandRef *msg) {
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addDisconnectVoteCommand - added disconnect vote command, player id %d command id %d, voted slot %d", m_lastPlayerID, m_lastCommandID, slot));
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 		return TRUE;
@@ -3356,10 +3330,8 @@ Bool NetPacket::addDisconnectChatCommand(NetCommandRef *msg) {
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket - added disconnect chat command"));
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 		return TRUE;
@@ -3473,10 +3445,8 @@ Bool NetPacket::addChatCommand(NetCommandRef *msg) {
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket - added chat command"));
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 		return TRUE;
@@ -3564,10 +3534,8 @@ Bool NetPacket::addPacketRouterAckCommand(NetCommandRef *msg) {
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket - added packet router ack command, player id %d", m_lastPlayerID));
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 		return TRUE;
@@ -3646,10 +3614,8 @@ Bool NetPacket::addPacketRouterQueryCommand(NetCommandRef *msg) {
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket - added packet router query command, player id %d", m_lastPlayerID));
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 		return TRUE;
@@ -3751,10 +3717,8 @@ Bool NetPacket::addDisconnectPlayerCommand(NetCommandRef *msg) {
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addDisconnectPlayerCommand - added disconnect player command, player id %d command id %d, disconnecting slot %d", m_lastPlayerID, m_lastCommandID, slot));
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 		return TRUE;
@@ -3836,10 +3800,8 @@ Bool NetPacket::addDisconnectKeepAliveCommand(NetCommandRef *msg) {
 		++m_packetLen;
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 
@@ -3916,10 +3878,8 @@ Bool NetPacket::addKeepAliveCommand(NetCommandRef *msg) {
 		++m_packetLen;
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 
@@ -4035,10 +3995,8 @@ Bool NetPacket::addRunAheadCommand(NetCommandRef *msg) {
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket - added run ahead command, frame %d, player id %d command id %d", m_lastFrame, m_lastPlayerID, m_lastCommandID));
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 		return TRUE;
@@ -4156,10 +4114,8 @@ Bool NetPacket::addDestroyPlayerCommand(NetCommandRef *msg) {
 		//DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket - added CRC:0x%8.8X info command, frame %d, player id %d command id %d", newCRC, m_lastFrame, m_lastPlayerID, m_lastCommandID));
 
 		++m_numCommands;
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 		return TRUE;
@@ -4268,10 +4224,7 @@ Bool NetPacket::addRunAheadMetricsCommand(NetCommandRef *msg) {
 		memcpy(m_packet + m_packetLen, &averageFps, sizeof(averageFps));
 		m_packetLen += sizeof(averageFps);
 
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 
@@ -4387,10 +4340,7 @@ Bool NetPacket::addPlayerLeaveCommand(NetCommandRef *msg) {
 		memcpy(m_packet + m_packetLen, &leavingPlayerID, sizeof(UnsignedByte));
 		m_packetLen += sizeof(UnsignedByte);
 
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 
@@ -4526,10 +4476,7 @@ Bool NetPacket::addFrameCommand(NetCommandRef *msg) {
 		// frameinfodebug
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("outgoing - added frame %d, player %d, command count = %d, command id = %d", cmdMsg->getExecutionFrame(), cmdMsg->getPlayerID(), cmdMsg->getCommandCount(), cmdMsg->getID()));
 
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 
@@ -4632,9 +4579,8 @@ Bool NetPacket::addAckCommand(NetCommandRef *msg, UnsignedShort commandID, Unsig
 		m_packet[m_packetLen] = 'Z';
 		++m_packetLen;
 		++m_numCommands;
-		deleteInstance(m_lastCommand);
-		m_lastCommand = NULL;
 
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 		return TRUE;
@@ -4669,10 +4615,7 @@ Bool NetPacket::addAckCommand(NetCommandRef *msg, UnsignedShort commandID, Unsig
 		memcpy(m_packet + m_packetLen, &originalPlayerID, sizeof(UnsignedByte));
 		m_packetLen += sizeof(UnsignedByte);
 
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 
@@ -4882,20 +4825,15 @@ Bool NetPacket::addGameCommand(NetCommandRef *msg) {
 
 		++m_numCommands;
 
-		if (m_lastCommand != NULL) {
-			deleteInstance(m_lastCommand);
-			m_lastCommand = NULL;
-		}
+		deleteInstance(m_lastCommand);
 		m_lastCommand = NEW_NETCOMMANDREF(msg->getCommand());
 		m_lastCommand->setRelay(msg->getRelay());
 
 		retval = TRUE;
 	}
 
-	if (gmsg) {
-		deleteInstance(gmsg);
-		gmsg = NULL;
-	}
+	deleteInstance(gmsg);
+	gmsg = NULL;
 
 	return retval;
 }
@@ -5233,10 +5171,7 @@ NetCommandList * NetPacket::getCommandList() {
 				DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::getCommandList - failed to set relay for message %d", msg->getID()));
 			}
 
-			if (lastCommand != NULL) {
-				deleteInstance(lastCommand);
-				lastCommand = NULL;
-			}
+			deleteInstance(lastCommand);
 			lastCommand = newInstance(NetCommandRef)(msg);
 
 			msg->detach();  // Need to detach from new NetCommandMsg created by the "readXMessage" above.
@@ -5311,7 +5246,6 @@ NetCommandList * NetPacket::getCommandList() {
 			}
 
 			deleteInstance(lastCommand);
-			lastCommand = NULL;
 //			lastCommand = newInstance(NetCommandRef)(msg);
 			lastCommand = NEW_NETCOMMANDREF(msg);
 
@@ -5334,10 +5268,9 @@ NetCommandList * NetPacket::getCommandList() {
 
 	}
 
-	if (lastCommand != NULL) {
-		deleteInstance(lastCommand);
-		lastCommand = NULL;
-	}
+	deleteInstance(lastCommand);
+	lastCommand = NULL;
+
 	return retval;
 }
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/Common/System/W3DRadar.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/Common/System/W3DRadar.cpp
@@ -142,8 +142,8 @@ void W3DRadar::deleteResources( void )
 	if( m_terrainTexture )
 		m_terrainTexture->Release_Ref();
 	m_terrainTexture = NULL;
-	if( m_terrainImage )
-		deleteInstance(m_terrainImage);
+
+	deleteInstance(m_terrainImage);
 	m_terrainImage = NULL;
 
 	//
@@ -152,8 +152,8 @@ void W3DRadar::deleteResources( void )
 	if( m_overlayTexture )
 		m_overlayTexture->Release_Ref();
 	m_overlayTexture = NULL;
-	if( m_overlayImage )
-		deleteInstance(m_overlayImage);
+
+	deleteInstance(m_overlayImage);
 	m_overlayImage = NULL;
 
 	//
@@ -162,8 +162,8 @@ void W3DRadar::deleteResources( void )
 	if( m_shroudTexture )
 		m_shroudTexture->Release_Ref();
 	m_shroudTexture = NULL;
-	if( m_shroudImage )
-		deleteInstance(m_shroudImage);
+
+	deleteInstance(m_shroudImage);
 	m_shroudImage = NULL;
 
 }  // end deleteResources

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/WorldBuilder.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/WorldBuilder.h
@@ -141,8 +141,7 @@ protected:
 protected:
 	void deletePasteObjList(void)
 	{
-		if (m_pasteMapObjList)
-			deleteInstance(m_pasteMapObjList);
+		deleteInstance(m_pasteMapObjList);
 		m_pasteMapObjList = NULL;
 	};
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/CUndoable.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/CUndoable.cpp
@@ -207,7 +207,7 @@ void WBDocUndoable::Undo(void)
 AddObjectUndoable::~AddObjectUndoable(void)
 {
 	m_pDoc = NULL;  // not ref counted.
-	if (m_objectToAdd && !m_addedToList) {
+	if (!m_addedToList) {
 		deleteInstance(m_objectToAdd);
 		m_objectToAdd=NULL;
 	}
@@ -857,7 +857,7 @@ void DictItemUndoable::Undo(void)
 ***************************************************************************/
 DeleteInfo::~DeleteInfo(void)
 {
-	if (m_didDelete && m_objectToDelete) {
+	if (m_didDelete) {
 		deleteInstance(m_objectToDelete);
 	}
 	DeleteInfo *pCur = m_next;

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/FenceOptions.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/FenceOptions.cpp
@@ -68,9 +68,7 @@ FenceOptions::FenceOptions(CWnd* pParent /*=NULL*/)
 
 FenceOptions::~FenceOptions(void)
 {
-	if (m_objectsList) {
-		deleteInstance(m_objectsList);
-	}
+	deleteInstance(m_objectsList);
 	m_objectsList = NULL;
 }
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/FenceTool.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/FenceTool.cpp
@@ -49,9 +49,7 @@ FenceTool::FenceTool(void) :
 /// Destructor
 FenceTool::~FenceTool(void)
 {
-	if (m_mapObjectList) {
-		deleteInstance(m_mapObjectList);
-	}
+	deleteInstance(m_mapObjectList);
 	m_mapObjectList = NULL;
 }
 
@@ -154,10 +152,10 @@ void FenceTool::mouseDown(TTrackingMode m, CPoint viewPt, WbView* pView, CWorldB
 	pView->snapPoint(&cpt);
 	m_downPt2d = viewPt;
 	m_downPt3d = cpt;
-	if (m_mapObjectList) {
-		deleteInstance(m_mapObjectList);
-		m_mapObjectList = NULL;
-	}
+
+	deleteInstance(m_mapObjectList);
+	m_mapObjectList = NULL;
+
 	if (FenceOptions::hasSelectedObject()) {
 		FenceOptions::update();
 		m_curObjectWidth = FenceOptions::getFenceSpacing();

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/GroveTool.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/GroveTool.cpp
@@ -244,9 +244,7 @@ GroveTool::GroveTool(void) :
 /// Destructor
 GroveTool::~GroveTool(void)
 {
-	if (m_headMapObj) {
-		deleteInstance(m_headMapObj);
-	}
+	deleteInstance(m_headMapObj);
 }
 
 /** Execute the tool on mouse down - Place an object. */

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/ObjectOptions.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/ObjectOptions.cpp
@@ -64,9 +64,7 @@ ObjectOptions::ObjectOptions(CWnd* pParent /*=NULL*/)
 
 ObjectOptions::~ObjectOptions(void)
 {
-	if (m_objectsList) {
-		deleteInstance(m_objectsList);
-	}
+	deleteInstance(m_objectsList);
 	m_objectsList = NULL;
 }
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/PickUnitDialog.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/PickUnitDialog.cpp
@@ -94,9 +94,7 @@ PickUnitDialog::PickUnitDialog(UINT id, CWnd* pParent /*=NULL*/)
 
 PickUnitDialog::~PickUnitDialog()
 {
-	if (m_objectsList) {
-		deleteInstance(m_objectsList);
-	}
+	deleteInstance(m_objectsList);
 	m_objectsList = NULL;
 }
 


### PR DESCRIPTION
This change removes all superfluous null tests before calls to `deleteInstance`, because `deleteInstance` already tests null. This simplifies the code.

Most superfluous NULL assignments in destructors were not removed. Sometimes NULL assignments were added for consistency - until we decide to remove them.

## TODO

- [x] Replicate in Generals