### PR TITLE
refactor(language): Remove legacy code for loading Language9x.ini, HeaderTemplate9x.ini

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/HeaderTemplate.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/HeaderTemplate.cpp
@@ -136,22 +136,14 @@ HeaderTemplateManager::~HeaderTemplateManager( void )
 
 void HeaderTemplateManager::init( void )
 {
-	INI ini;
-	AsciiString fname;
-	fname.format("Data\\%s\\HeaderTemplate", GetRegistryLanguage().str());
-	OSVERSIONINFO	osvi;
-	osvi.dwOSVersionInfoSize=sizeof(OSVERSIONINFO);
-	if (GetVersionEx(&osvi))
-	{	//check if we're running Win9x variant since they may need different fonts
-		if (osvi.dwPlatformId == VER_PLATFORM_WIN32_WINDOWS)
-		{	AsciiString tempName;
+	{
+		AsciiString fname;
+		fname.format("Data\\%s\\HeaderTemplate", GetRegistryLanguage().str());
 
-			tempName.format("Data\\%s\\HeaderTemplate9x.ini", GetRegistryLanguage().str());
-			if (TheFileSystem->doesFileExist(tempName.str()))
-				fname = tempName;
-		}
+		INI ini;
+		ini.loadFileDirectory( fname, INI_LOAD_OVERWRITE, NULL );
 	}
-	ini.loadFileDirectory( fname, INI_LOAD_OVERWRITE, NULL );
+
 	populateGameFonts();
 }
 

--- a/Generals/Code/GameEngine/Source/GameClient/GlobalLanguage.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GlobalLanguage.cpp
@@ -133,23 +133,14 @@ GlobalLanguage::~GlobalLanguage()
 
 void GlobalLanguage::init( void )
 {
+	{
+		AsciiString fname;
+		fname.format("Data\\%s\\Language", GetRegistryLanguage().str());
 
-	INI ini;
-	AsciiString fname;
-	fname.format("Data\\%s\\Language", GetRegistryLanguage().str());
+		INI ini;
+		ini.loadFileDirectory( fname, INI_LOAD_OVERWRITE, NULL );
+ 	}
 
-	OSVERSIONINFO	osvi;
-	osvi.dwOSVersionInfoSize=sizeof(OSVERSIONINFO);
-	//GS NOTE: Must call doesFileExist in either case so that NameKeyGenerator will stay in sync
-	AsciiString tempName;
-	tempName.format("Data\\%s\\Language9x.ini", GetRegistryLanguage().str());
-	bool isExist = TheFileSystem->doesFileExist(tempName.str());
-	if (GetVersionEx(&osvi)  &&  osvi.dwPlatformId == VER_PLATFORM_WIN32_WINDOWS  && isExist)
-	{	//check if we're running Win9x variant since they may need different fonts
-		fname = tempName;
-	}
-
-	ini.loadFileDirectory( fname, INI_LOAD_OVERWRITE, NULL );
 	StringListIt it = m_localFonts.begin();
 	while( it != m_localFonts.end())
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/HeaderTemplate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/HeaderTemplate.cpp
@@ -136,22 +136,14 @@ HeaderTemplateManager::~HeaderTemplateManager( void )
 
 void HeaderTemplateManager::init( void )
 {
-	INI ini;
-	AsciiString fname;
-	fname.format("Data\\%s\\HeaderTemplate", GetRegistryLanguage().str());
-	OSVERSIONINFO	osvi;
-	osvi.dwOSVersionInfoSize=sizeof(OSVERSIONINFO);
-	if (GetVersionEx(&osvi))
-	{	//check if we're running Win9x variant since they may need different fonts
-		if (osvi.dwPlatformId == VER_PLATFORM_WIN32_WINDOWS)
-		{	AsciiString tempName;
+	{
+		AsciiString fname;
+		fname.format("Data\\%s\\HeaderTemplate", GetRegistryLanguage().str());
 
-			tempName.format("Data\\%s\\HeaderTemplate9x.ini", GetRegistryLanguage().str());
-			if (TheFileSystem->doesFileExist(tempName.str()))
-				fname = tempName;
-		}
+		INI ini;
+		ini.loadFileDirectory( fname, INI_LOAD_OVERWRITE, NULL );
 	}
-	ini.loadFileDirectory( fname, INI_LOAD_OVERWRITE, NULL );
+
 	populateGameFonts();
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GlobalLanguage.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GlobalLanguage.cpp
@@ -135,25 +135,14 @@ GlobalLanguage::~GlobalLanguage()
 
 void GlobalLanguage::init( void )
 {
+	{
+		AsciiString fname;
+		fname.format("Data\\%s\\Language", GetRegistryLanguage().str());
 
-	INI ini;
-	AsciiString fname;
-	fname.format("Data\\%s\\Language", GetRegistryLanguage().str());
-
-	OSVERSIONINFO	osvi;
-	osvi.dwOSVersionInfoSize=sizeof(OSVERSIONINFO);
-
-	//GS NOTE: Must call doesFileExist in either case so that NameKeyGenerator will stay in sync
-	AsciiString tempName;
-	tempName.format("Data\\%s\\Language9x.ini", GetRegistryLanguage().str());
-	bool isExist = TheFileSystem->doesFileExist(tempName.str());
-	if (GetVersionEx(&osvi)  &&  osvi.dwPlatformId == VER_PLATFORM_WIN32_WINDOWS  && isExist)
-	{	//check if we're running Win9x variant since they may need different fonts
-		fname = tempName;
+		INI ini;
+		ini.loadFileDirectory( fname, INI_LOAD_OVERWRITE, NULL );
 	}
 
-
-	ini.loadFileDirectory( fname, INI_LOAD_OVERWRITE, NULL );
 	StringListIt it = m_localFonts.begin();
 	while( it != m_localFonts.end())
 	{


### PR DESCRIPTION
* Replacement for #1496

This change removes the legacy code for loading Language9x.ini, HeaderTemplate9x.ini for Windows 95, 98, ME systems. It was used by Chinese and Korean localizations only.

## TODO

- [x] Replicate to Generals