### PR TITLE
tweak(text): Add English substitute text for Fast Forward messages

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -3290,7 +3290,10 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 #endif
 				{
 					TheWritableGlobalData->m_TiVOFastMode = 1 - TheGlobalData->m_TiVOFastMode;
-					TheInGameUI->messageNoFormat( TheGlobalData->m_TiVOFastMode ? TheGameText->fetch("GUI:FF_ON") : TheGameText->fetch("GUI:FF_OFF") );
+					TheInGameUI->messageNoFormat( TheGlobalData->m_TiVOFastMode
+						? TheGameText->FETCH_OR_SUBSTITUTE("GUI:FF_ON", L"Fast Forward is on")
+						: TheGameText->FETCH_OR_SUBSTITUTE("GUI:FF_OFF", L"Fast Forward is off")
+					);
 				}
 			}  // end if
 

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/MetaEvent.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/MetaEvent.cpp
@@ -466,7 +466,10 @@ GameMessageDisposition MetaEventTranslator::translateGameMessage(const GameMessa
                 TheWritableGlobalData->m_TiVOFastMode = 1 - TheGlobalData->m_TiVOFastMode;
 
               if ( TheInGameUI )
-  				      TheInGameUI->message( TheGlobalData->m_TiVOFastMode ? TheGameText->fetch("GUI:FF_ON") : TheGameText->fetch("GUI:FF_OFF") );
+								TheInGameUI->messageNoFormat( TheGlobalData->m_TiVOFastMode
+									? TheGameText->FETCH_OR_SUBSTITUTE("GUI:FF_ON", L"Fast Forward is on")
+									: TheGameText->FETCH_OR_SUBSTITUTE("GUI:FF_OFF", L"Fast Forward is off")
+								);
 			      }
 			      disp = KEEP_MESSAGE; // cause for goodness sake, this key gets used a lot by non-replay hotkeys
 			      break;

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -2095,6 +2095,13 @@ void GameLogic::startNewGame( Bool saveGame )
 	if (TheGameSpyInfo)
 		TheGameSpyInfo->updateAdditionalGameSpyDisconnections(1);
 
+
+  if ( isInReplayGame() && TheInGameUI && TheGameText )
+  {
+		TheInGameUI->message( TheGameText->fetch( "GUI:FastForwardInstructions" ) );
+  }
+
+
 }  // end startNewGame
 
 //-----------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -2098,7 +2098,7 @@ void GameLogic::startNewGame( Bool saveGame )
 
   if ( isInReplayGame() && TheInGameUI && TheGameText )
   {
-		TheInGameUI->message( TheGameText->fetch( "GUI:FastForwardInstructions" ) );
+		TheInGameUI->messageNoFormat( TheGameText->FETCH_OR_SUBSTITUTE( "GUI:FastForwardInstructions", L"Press F to toggle Fast Forward" ) );
   }
 
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -3440,7 +3440,10 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 #endif
 				{
 					TheWritableGlobalData->m_TiVOFastMode = 1 - TheGlobalData->m_TiVOFastMode;
-					TheInGameUI->messageNoFormat( TheGlobalData->m_TiVOFastMode ? TheGameText->fetch("GUI:FF_ON") : TheGameText->fetch("GUI:FF_OFF") );
+					TheInGameUI->messageNoFormat( TheGlobalData->m_TiVOFastMode
+						? TheGameText->FETCH_OR_SUBSTITUTE("GUI:FF_ON", L"Fast Forward is on")
+						: TheGameText->FETCH_OR_SUBSTITUTE("GUI:FF_OFF", L"Fast Forward is off")
+					);
 				}
 			}  // end if
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/MetaEvent.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/MetaEvent.cpp
@@ -509,7 +509,10 @@ GameMessageDisposition MetaEventTranslator::translateGameMessage(const GameMessa
                 TheWritableGlobalData->m_TiVOFastMode = 1 - TheGlobalData->m_TiVOFastMode;
 
               if ( TheInGameUI )
-  				      TheInGameUI->message( TheGlobalData->m_TiVOFastMode ? TheGameText->fetch("GUI:FF_ON") : TheGameText->fetch("GUI:FF_OFF") );
+								TheInGameUI->messageNoFormat( TheGlobalData->m_TiVOFastMode
+									? TheGameText->FETCH_OR_SUBSTITUTE("GUI:FF_ON", L"Fast Forward is on")
+									: TheGameText->FETCH_OR_SUBSTITUTE("GUI:FF_OFF", L"Fast Forward is off")
+								);
 			      }
 			      disp = KEEP_MESSAGE; // cause for goodness sake, this key gets used a lot by non-replay hotkeys
 			      break;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -2415,7 +2415,7 @@ void GameLogic::startNewGame( Bool loadingSaveGame )
 
   if ( isInReplayGame() && TheInGameUI && TheGameText )
   {
-		TheInGameUI->message( TheGameText->fetch( "GUI:FastForwardInstructions" ) );
+		TheInGameUI->messageNoFormat( TheGameText->FETCH_OR_SUBSTITUTE( "GUI:FastForwardInstructions", L"Press F to toggle Fast Forward" ) );
   }
 
 


### PR DESCRIPTION
**Merge with Rebase**

* Follow up for #827

This change backports the fast forward instructions text from Zero Hour and adds English substitute text for Fast Forward messages.

The substitute texts are relevant for Generals, because its loca strings do not contain texts for it.