### PR TITLE
bugfix(object): Check whether a bike still has a rider before sniping the rider.

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/ActionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/ActionManager.cpp
@@ -1431,6 +1431,13 @@ Bool ActionManager::canSnipeVehicle( const Object *obj, const Object *objectToSn
 			return FALSE;
 		}
 
+		// TheSuperHackers @bugfix Caball009 04/09/2025 Disabled bikes may not have a rider to snipe.
+		ContainModuleInterface* contain = objectToSnipe->getContain();
+		if ( contain && contain->isRiderChangeContain() && contain->getContainedItemsList()->empty() )
+		{
+			return FALSE;
+		}
+
 		return TRUE;
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp
@@ -405,14 +405,19 @@ void ActiveBody::attemptDamage( DamageInfo *damageInfo )
 					}
 					else
 					{
-						//Removing the rider will scuttle the bike.
-						Object *rider = *(contain->getContainedItemsList()->begin());
-						ai->aiEvacuateInstantly( TRUE, CMD_FROM_AI );
+						// TheSuperHackers @bugfix Caball009 04/09/2025 Check whether a bike still has a rider.
+						// A rider may dismount or be sniped off a bike when it's disabled, resulting in a bike object with an empty contain list.
+						if ( !contain->getContainedItemsList()->empty() )
+						{
+							//Removing the rider will scuttle the bike.
+							Object* rider = *(contain->getContainedItemsList()->begin());
+							ai->aiEvacuateInstantly(TRUE, CMD_FROM_AI);
 
-						//Kill the rider.
-						if (damager)
-							damager->scoreTheKill( rider );
-						rider->kill();
+							//Kill the rider.
+							if (damager)
+								damager->scoreTheKill(rider);
+							rider->kill();
+						}
 					}
 				}
 				else


### PR DESCRIPTION
_Brought to my attention by @MrS-ibra_

This PR fixes a crash caused by accessing the first element of an empty list. This bug happens when you use Jarmen Kell to snipe an empty bike. Normally, empty (enemy) bikes are immediately destroyed, but disabled bikes can be empty for as long as they're disabled.

Bug reproduction:
1. Disable an enemy bike, for instance with Black Lotus. Keep the bike disabled for all steps.
2. Dismount the rider from the disabled bike (or use Jarmen Kell to snipe the rider from the bike).
3. Use Jarmen Kell to snipe the now empty bike.
4. The game crashes here:
https://github.com/TheSuperHackers/GeneralsGameCode/blob/87de0a0d41e793ebd7acdded5fc371582d36c8f4/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp#L408-L409

PS: It probably shouldn't be possible to dismount from a disabled bike, but that's outside the scope of this PR.