### PR TITLE
bugfix(module): Consistently yield experience for direct flame kills

### DIFF
--- a/Generals/Code/GameEngine/Include/GameLogic/Module/FlammableUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/FlammableUpdate.h
@@ -111,6 +111,7 @@ protected:
 	UnsignedInt							m_damageEndFrame;
 	AudioHandle							m_audioHandle;
 	Real										m_flameDamageLimit;
+	ObjectID								m_flameSource;
 	UnsignedInt							m_lastFlameDamageDealt;
 };
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/FlammableUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/FlammableUpdate.cpp
@@ -84,6 +84,7 @@ FlammableUpdate::FlammableUpdate( Thing *thing, const ModuleData* moduleData ) :
 	m_damageEndFrame = 0;
 	m_audioHandle = NULL;
 	m_flameDamageLimit = getFlammableUpdateModuleData()->m_flameDamageLimitData;
+	m_flameSource = INVALID_ID;
 	m_lastFlameDamageDealt = 0;
 
 	setWakeFrame(getObject(), UPDATE_SLEEP_FOREVER);
@@ -110,6 +111,11 @@ void FlammableUpdate::onDamage( DamageInfo *damageInfo )
 			m_flameDamageLimit = getFlammableUpdateModuleData()->m_flameDamageLimitData;
 		}
 		m_lastFlameDamageDealt = now;
+#if RETAIL_COMPATIBLE_CRC
+		m_flameSource = getObject()->getID();
+#else
+		m_flameSource = damageInfo->in.m_sourceID;
+#endif
 
 		Object *me = getObject();
 		if( !me->getStatusBits().test( OBJECT_STATUS_AFLAME ) && !me->getStatusBits().test( OBJECT_STATUS_BURNED ) )
@@ -229,7 +235,7 @@ void FlammableUpdate::doAflameDamage()
 
 	DamageInfo info;
 	info.in.m_amount = data->m_aflameDamageAmount;
-	info.in.m_sourceID = getObject()->getID();
+	info.in.m_sourceID = m_flameSource;
 	info.in.m_damageType = DAMAGE_FLAME;
 	info.in.m_deathType = DEATH_BURNED;
 
@@ -287,7 +293,11 @@ void FlammableUpdate::xfer( Xfer *xfer )
 {
 
 	// version
+#if RETAIL_COMPATIBLE_XFER_SAVE
 	XferVersion currentVersion = 1;
+#else
+	XferVersion currentVersion = 2;
+#endif
 	XferVersion version = currentVersion;
 	xfer->xferVersion( &version, currentVersion );
 
@@ -312,6 +322,12 @@ void FlammableUpdate::xfer( Xfer *xfer )
 	// last flame damage dealt
 	xfer->xferUnsignedInt( &m_lastFlameDamageDealt );
 
+#if !RETAIL_COMPATIBLE_XFER_SAVE
+	if (version >= 2)
+	{
+		xfer->xferObjectID(&m_flameSource);
+	}
+#endif
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/FlammableUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/FlammableUpdate.cpp
@@ -114,6 +114,7 @@ void FlammableUpdate::onDamage( DamageInfo *damageInfo )
 #if RETAIL_COMPATIBLE_CRC
 		m_flameSource = getObject()->getID();
 #else
+		// TheSuperHackers @bugfix Stubbjax 03/09/2025 Allow flame damage to award xp to the flame source.
 		m_flameSource = damageInfo->in.m_sourceID;
 #endif
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/FlammableUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/FlammableUpdate.h
@@ -111,6 +111,7 @@ protected:
 	UnsignedInt							m_damageEndFrame;
 	AudioHandle							m_audioHandle;
 	Real										m_flameDamageLimit;
+	ObjectID								m_flameSource;
 	UnsignedInt							m_lastFlameDamageDealt;
 };
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/FlammableUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/FlammableUpdate.cpp
@@ -84,6 +84,7 @@ FlammableUpdate::FlammableUpdate( Thing *thing, const ModuleData* moduleData ) :
 	m_damageEndFrame = 0;
 	m_audioHandle = NULL;
 	m_flameDamageLimit = getFlammableUpdateModuleData()->m_flameDamageLimitData;
+	m_flameSource = INVALID_ID;
 	m_lastFlameDamageDealt = 0;
 
 	setWakeFrame(getObject(), UPDATE_SLEEP_FOREVER);
@@ -110,6 +111,11 @@ void FlammableUpdate::onDamage( DamageInfo *damageInfo )
 			m_flameDamageLimit = getFlammableUpdateModuleData()->m_flameDamageLimitData;
 		}
 		m_lastFlameDamageDealt = now;
+#if RETAIL_COMPATIBLE_CRC
+		m_flameSource = getObject()->getID();
+#else
+		m_flameSource = damageInfo->in.m_sourceID;
+#endif
 
 		Object *me = getObject();
 		if( !me->getStatusBits().test( OBJECT_STATUS_AFLAME ) && !me->getStatusBits().test( OBJECT_STATUS_BURNED ) )
@@ -229,7 +235,7 @@ void FlammableUpdate::doAflameDamage()
 
 	DamageInfo info;
 	info.in.m_amount = data->m_aflameDamageAmount;
-	info.in.m_sourceID = getObject()->getID();
+	info.in.m_sourceID = m_flameSource;
 	info.in.m_damageType = DAMAGE_FLAME;
 	info.in.m_deathType = DEATH_BURNED;
 
@@ -287,7 +293,11 @@ void FlammableUpdate::xfer( Xfer *xfer )
 {
 
 	// version
+#if RETAIL_COMPATIBLE_XFER_SAVE
 	XferVersion currentVersion = 1;
+#else
+	XferVersion currentVersion = 2;
+#endif
 	XferVersion version = currentVersion;
 	xfer->xferVersion( &version, currentVersion );
 
@@ -312,6 +322,12 @@ void FlammableUpdate::xfer( Xfer *xfer )
 	// last flame damage dealt
 	xfer->xferUnsignedInt( &m_lastFlameDamageDealt );
 
+#if !RETAIL_COMPATIBLE_XFER_SAVE
+	if (version >= 2)
+	{
+		xfer->xferObjectID(&m_flameSource);
+	}
+#endif
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/FlammableUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/FlammableUpdate.cpp
@@ -114,6 +114,7 @@ void FlammableUpdate::onDamage( DamageInfo *damageInfo )
 #if RETAIL_COMPATIBLE_CRC
 		m_flameSource = getObject()->getID();
 #else
+		// TheSuperHackers @bugfix Stubbjax 03/09/2025 Allow flame damage to award xp to the flame source.
 		m_flameSource = damageInfo->in.m_sourceID;
 #endif
 


### PR DESCRIPTION
This change causes units and buildings that die via flammable status to consistently yield experience to the flammable status source.

In 1.04, the flammable update damage tick can score the kill on a unit or building and negate any experience that should otherwise have been given to the killer (though this is a lot rarer for flammables as the damage tick is fairly low (usually 5)). This can be seen in the demonstration below, where a Dragon does not gain any experience from destroying a Black Market:

https://github.com/user-attachments/assets/0a2b9fbc-927a-446b-b716-19a1792fdcd9

This is a counterpart to #1527 and fixes the same issue but for flame weapons; essentially making experience yields consistent for units directly killed by flame damage weapons. It pretty much exclusively affects the Dragon Tank's primary weapon and does not affect experience yields for flame damage dealt via projectile detonation OCLs such as firewalls or firestorms.