### PR TITLE
feat: Enable special power EVA events for observed players

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/SpecialPower/SpecialPowerModule.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/SpecialPower/SpecialPowerModule.cpp
@@ -550,7 +550,7 @@ void SpecialPowerModule::aboutToDoSpecialPower( const Coord3D *location )
 	// Let EVA do her thing
 	SpecialPowerType type = getSpecialPowerModuleData()->m_specialPowerTemplate->getSpecialPowerType();
 
-  Player *localPlayer = ThePlayerList->getLocalPlayer();
+	Player *localPlayer = TheControlBar->getCurrentlyViewedPlayer();
 
   // Only play the EVA sounds if this is not the local player, and the local player doesn't consider the
 	// person an enemy.
@@ -564,7 +564,7 @@ void SpecialPowerModule::aboutToDoSpecialPower( const Coord3D *location )
       {
         TheEva->setShouldPlay(EVA_SuperweaponLaunched_Own_ParticleCannon);
       }
-      else if ( localPlayer->getRelationship(getObject()->getTeam()) != ENEMIES )
+      else if ( TheControlBar->getCurrentlyViewedPlayerRelationship(getObject()->getTeam()) != ENEMIES )
       {
         // Note: counting relationship NEUTRAL as ally. Not sure if this makes a difference???
         TheEva->setShouldPlay(EVA_SuperweaponLaunched_Ally_ParticleCannon);
@@ -580,7 +580,7 @@ void SpecialPowerModule::aboutToDoSpecialPower( const Coord3D *location )
       {
         TheEva->setShouldPlay(EVA_SuperweaponLaunched_Own_Nuke);
       }
-      else if ( localPlayer->getRelationship(getObject()->getTeam()) != ENEMIES )
+      else if ( TheControlBar->getCurrentlyViewedPlayerRelationship(getObject()->getTeam()) != ENEMIES )
       {
         // Note: counting relationship NEUTRAL as ally. Not sure if this makes a difference???
         TheEva->setShouldPlay(EVA_SuperweaponLaunched_Ally_Nuke);
@@ -596,7 +596,7 @@ void SpecialPowerModule::aboutToDoSpecialPower( const Coord3D *location )
       {
         TheEva->setShouldPlay(EVA_SuperweaponLaunched_Own_ScudStorm);
       }
-      else if ( localPlayer->getRelationship(getObject()->getTeam()) != ENEMIES )
+      else if ( TheControlBar->getCurrentlyViewedPlayerRelationship(getObject()->getTeam()) != ENEMIES )
       {
         // Note: counting relationship NEUTRAL as ally. Not sure if this makes a difference???
         TheEva->setShouldPlay(EVA_SuperweaponLaunched_Ally_ScudStorm);
@@ -614,7 +614,7 @@ void SpecialPowerModule::aboutToDoSpecialPower( const Coord3D *location )
       {
         TheEva->setShouldPlay(EVA_SuperweaponLaunched_Own_GPS_Scrambler);
       }
-      else if ( localPlayer->getRelationship(getObject()->getTeam()) != ENEMIES )
+      else if ( TheControlBar->getCurrentlyViewedPlayerRelationship(getObject()->getTeam()) != ENEMIES )
       {
         // Note: counting relationship NEUTRAL as ally. Not sure if this makes a difference???
         TheEva->setShouldPlay(EVA_SuperweaponLaunched_Ally_GPS_Scrambler);
@@ -630,7 +630,7 @@ void SpecialPowerModule::aboutToDoSpecialPower( const Coord3D *location )
       {
         TheEva->setShouldPlay(EVA_SuperweaponLaunched_Own_Sneak_Attack);
       }
-      else if ( localPlayer->getRelationship(getObject()->getTeam()) != ENEMIES )
+      else if ( TheControlBar->getCurrentlyViewedPlayerRelationship(getObject()->getTeam()) != ENEMIES )
       {
         // Note: counting relationship NEUTRAL as ally. Not sure if this makes a difference???
         TheEva->setShouldPlay(EVA_SuperweaponLaunched_Ally_Sneak_Attack);


### PR DESCRIPTION
This change allows special power EVA events to be played for the currently observed player. This includes the following events:

- `EVA_SuperweaponLaunched_Own_ParticleCannon`
- `EVA_SuperweaponLaunched_Ally_ParticleCannon`
- `EVA_SuperweaponLaunched_Enemy_ParticleCannon`
- `EVA_SuperweaponLaunched_Own_Nuke`
- `EVA_SuperweaponLaunched_Ally_Nuke`
- `EVA_SuperweaponLaunched_Enemy_Nuke`
- `EVA_SuperweaponLaunched_Own_ScudStorm`
- `EVA_SuperweaponLaunched_Ally_ScudStorm`
- `EVA_SuperweaponLaunched_Enemy_ScudStorm`
- `EVA_SuperweaponLaunched_Own_GPS_Scrambler`
- `EVA_SuperweaponLaunched_Ally_GPS_Scrambler`
- `EVA_SuperweaponLaunched_Enemy_GPS_Scrambler`
- `EVA_SuperweaponLaunched_Own_Sneak_Attack`
- `EVA_SuperweaponLaunched_Ally_Sneak_Attack`
- `EVA_SuperweaponLaunched_Enemy_Sneak_Attack`

This does not apply to Generals as the respective events there are not conditional on player relationships.