### PR TITLE
tweak(options): Simplify the user options for the cursor capture mode

### DIFF
--- a/GeneralsMD/Code/GameEngine/Include/Common/UserPreferences.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/UserPreferences.h
@@ -39,7 +39,7 @@
 #include "Common/STLTypedefs.h"
 
 class Money;
-enum CursorCaptureMode CPP_11(: Int);
+typedef UnsignedInt CursorCaptureMode;
 
 //-----------------------------------------------------------------------------
 // PUBLIC TYPES ///////////////////////////////////////////////////////////////
@@ -97,6 +97,10 @@ public:
 	Real getScrollFactor(void);								// convenience function
 	Bool getDrawScrollAnchor(void);
 	Bool getMoveScrollAnchor(void);
+	Bool getCursorCaptureEnabledInWindowedGame() const;
+	Bool getCursorCaptureEnabledInWindowedMenu() const;
+	Bool getCursorCaptureEnabledInFullscreenGame() const;
+	Bool getCursorCaptureEnabledInFullscreenMenu() const;
 	CursorCaptureMode getCursorCaptureMode() const;
 	Bool getSendDelay(void);									// convenience function
 	Int getFirewallBehavior(void);						// convenience function

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Mouse.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Mouse.h
@@ -141,18 +141,19 @@ public:
 	Int						numDirections;	//number of directions for cursors like scrolling/panning.
 };
 
-enum CursorCaptureMode CPP_11(: Int)
+typedef UnsignedInt CursorCaptureMode;
+enum CursorCaptureMode_ CPP_11(: CursorCaptureMode)
 {
-	CursorCaptureMode_None, // Does not capture the cursor
-	CursorCaptureMode_InGame, // Captures the cursor when playing and observing
-	CursorCaptureMode_Always, // Captures the cursor always in menus and game
-	CursorCaptureMode_Auto, // Applies mode "InGame" when Windowed, "Always" when Fullscreen
+	CursorCaptureMode_EnabledInWindowedGame = 1<<0, // Captures the cursor when in game while the app is windowed
+	CursorCaptureMode_EnabledInWindowedMenu = 1<<1, // Captures the cursor when in menu while the app is windowed
+	CursorCaptureMode_EnabledInFullscreenGame = 1<<2, // Captures the cursor when in game while the app is fullscreen
+	CursorCaptureMode_EnabledInFullscreenMenu = 1<<3, // Captures the cursor when in menu while the app is fullscreen
 
-	CursorCaptureMode_Count,
-	CursorCaptureMode_Default = CursorCaptureMode_Auto,
+	CursorCaptureMode_Default =
+		CursorCaptureMode_EnabledInWindowedGame |
+		CursorCaptureMode_EnabledInFullscreenGame |
+		CursorCaptureMode_EnabledInFullscreenMenu,
 };
-
-extern const char* const TheCursorCaptureModeNames[];
 
 // Mouse ----------------------------------------------------------------------
 // Class interface for working with a mouse pointing device
@@ -170,7 +171,6 @@ class Mouse : public SubsystemInterface
 	enum CursorCaptureBlockReason
 	{
 		CursorCaptureBlockReason_NoInit,
-		CursorCaptureBlockReason_NoGame,
 		CursorCaptureBlockReason_Paused,
 		CursorCaptureBlockReason_Unfocused,
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/GameLogic.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/GameLogic.h
@@ -183,6 +183,7 @@ public:
 	Bool isInInternetGame( void );
 	Bool isInShellGame( void );
 	Bool isInMultiplayerGame( void );
+	Bool isInInteractiveGame() const;
 
 	static Bool isInInteractiveGame(GameMode mode) { return mode != GAME_NONE && mode != GAME_SHELL; }
 
@@ -418,6 +419,7 @@ inline GameMode GameLogic::getGameMode( void ) { return m_gameMode; }
 inline Bool GameLogic::isInLanGame( void ) { return (m_gameMode == GAME_LAN); }
 inline Bool GameLogic::isInSkirmishGame( void ) { return (m_gameMode == GAME_SKIRMISH); }
 inline Bool GameLogic::isInMultiplayerGame( void ) { return (m_gameMode == GAME_LAN) || (m_gameMode == GAME_INTERNET) ; }
+inline Bool GameLogic::isInInteractiveGame() const { return isInInteractiveGame(m_gameMode); }
 inline Bool GameLogic::isInReplayGame( void ) { return (m_gameMode == GAME_REPLAY); }
 inline Bool GameLogic::isInInternetGame( void ) { return (m_gameMode == GAME_INTERNET); }
 inline Bool GameLogic::isInShellGame( void ) { return (m_gameMode == GAME_SHELL); }

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -404,21 +404,61 @@ Bool OptionPreferences::getMoveScrollAnchor(void)
 	return FALSE;
 }
 
+Bool OptionPreferences::getCursorCaptureEnabledInWindowedGame() const
+{
+	OptionPreferences::const_iterator it = find("CursorCaptureEnabledInWindowedGame");
+	if (it == end())
+		return (CursorCaptureMode_Default & CursorCaptureMode_EnabledInWindowedGame);
+
+	if (stricmp(it->second.str(), "yes") == 0)
+		return TRUE;
+
+	return FALSE;
+}
+
+Bool OptionPreferences::getCursorCaptureEnabledInWindowedMenu() const
+{
+	OptionPreferences::const_iterator it = find("CursorCaptureEnabledInWindowedMenu");
+	if (it == end())
+		return (CursorCaptureMode_Default & CursorCaptureMode_EnabledInWindowedMenu);
+
+	if (stricmp(it->second.str(), "yes") == 0)
+		return TRUE;
+
+	return FALSE;
+}
+
+Bool OptionPreferences::getCursorCaptureEnabledInFullscreenGame() const
+{
+	OptionPreferences::const_iterator it = find("CursorCaptureEnabledInFullscreenGame");
+	if (it == end())
+		return (CursorCaptureMode_Default & CursorCaptureMode_EnabledInFullscreenGame);
+
+	if (stricmp(it->second.str(), "yes") == 0)
+		return TRUE;
+
+	return FALSE;
+}
+
+Bool OptionPreferences::getCursorCaptureEnabledInFullscreenMenu() const
+{
+	OptionPreferences::const_iterator it = find("CursorCaptureEnabledInFullscreenMenu");
+	if (it == end())
+		return (CursorCaptureMode_Default & CursorCaptureMode_EnabledInFullscreenMenu);
+
+	if (stricmp(it->second.str(), "yes") == 0)
+		return TRUE;
+
+	return FALSE;
+}
+
 CursorCaptureMode OptionPreferences::getCursorCaptureMode() const
 {
-	CursorCaptureMode mode = CursorCaptureMode_Default;
-	OptionPreferences::const_iterator it = find("CursorCaptureMode");
-	if (it != end())
-	{
-		for (Int i = 0; i < CursorCaptureMode_Count; ++i)
-		{
-			if (stricmp(it->second.str(), TheCursorCaptureModeNames[i]) == 0)
-			{
-				mode = static_cast<CursorCaptureMode>(i);
-				break;
-			}
-		}
-	}
+	CursorCaptureMode mode = 0;
+	mode |= getCursorCaptureEnabledInWindowedGame() ? CursorCaptureMode_EnabledInWindowedGame : 0;
+	mode |= getCursorCaptureEnabledInWindowedMenu() ? CursorCaptureMode_EnabledInWindowedMenu : 0;
+	mode |= getCursorCaptureEnabledInFullscreenGame() ? CursorCaptureMode_EnabledInFullscreenGame : 0;
+	mode |= getCursorCaptureEnabledInFullscreenMenu() ? CursorCaptureMode_EnabledInFullscreenMenu : 0;
 	return mode;
 }
 
@@ -1247,7 +1287,10 @@ static void saveOptions( void )
 	// TheSuperHackers @todo Add combo box ?
 	{
 		CursorCaptureMode mode = pref->getCursorCaptureMode();
-		(*pref)["CursorCaptureMode"] = TheCursorCaptureModeNames[mode];
+		(*pref)["CursorCaptureEnabledInWindowedGame"] = (mode & CursorCaptureMode_EnabledInWindowedGame) ? "yes" : "no";
+		(*pref)["CursorCaptureEnabledInWindowedMenu"] = (mode & CursorCaptureMode_EnabledInWindowedMenu) ? "yes" : "no";
+		(*pref)["CursorCaptureEnabledInFullscreenGame"] = (mode & CursorCaptureMode_EnabledInFullscreenGame) ? "yes" : "no";
+		(*pref)["CursorCaptureEnabledInFullscreenMenu"] = (mode & CursorCaptureMode_EnabledInFullscreenMenu) ? "yes" : "no";
 		TheMouse->setCursorCaptureMode(mode);
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Mouse.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Mouse.cpp
@@ -53,14 +53,6 @@
 // PUBLIC DATA ////////////////////////////////////////////////////////////////////////////////////
 Mouse *TheMouse = NULL;
 
-const char* const TheCursorCaptureModeNames[] = {
-	"None",
-	"InGame",
-	"Always",
-	"Auto",
-};
-static_assert(ARRAY_SIZE(TheCursorCaptureModeNames) == CursorCaptureMode_Count, "Incorrect array size");
-
 const char *const Mouse::RedrawModeName[] = {
 	"Mouse:Windows",
 	"Mouse:W3D",
@@ -70,7 +62,6 @@ const char *const Mouse::RedrawModeName[] = {
 
 const char *const Mouse::CursorCaptureBlockReasonNames[] = {
 	"CursorCaptureBlockReason_NoInit",
-	"CursorCaptureBlockReason_NoGame",
 	"CursorCaptureBlockReason_Paused",
 	"CursorCaptureBlockReason_Unfocused",
 };
@@ -552,8 +543,8 @@ Mouse::Mouse( void )
 
 	m_cursorCaptureMode = CursorCaptureMode_Default;
 
-	m_captureBlockReasonBits = (1 << CursorCaptureBlockReason_NoInit) | (1 << CursorCaptureBlockReason_NoGame);
-	DEBUG_LOG(("Mouse::Mouse: m_blockCaptureReason=CursorCaptureBlockReason_NoInit|CursorCaptureBlockReason_NoGame"));
+	m_captureBlockReasonBits = (1 << CursorCaptureBlockReason_NoInit);
+	DEBUG_LOG(("Mouse::Mouse: m_blockCaptureReason=CursorCaptureBlockReason_NoInit"));
 
 }  // end Mouse
 
@@ -653,17 +644,7 @@ void Mouse::mouseNotifyResolutionChange( void )
 //-------------------------------------------------------------------------------------------------
 void Mouse::onGameModeChanged(GameMode prev, GameMode next)
 {
-	const Bool wasInteractiveGame = GameLogic::isInInteractiveGame(prev);
-	const Bool isInteractiveGame = GameLogic::isInInteractiveGame(next);
-
-	if (wasInteractiveGame && !isInteractiveGame)
-	{
-		blockCapture(CursorCaptureBlockReason_NoGame);
-	}
-	else if (!wasInteractiveGame && isInteractiveGame)
-	{
-		unblockCapture(CursorCaptureBlockReason_NoGame);
-	}
+	refreshCursorCapture();
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1072,23 +1053,40 @@ void Mouse::initCapture()
 // ------------------------------------------------------------------------------------------------
 Bool Mouse::canCapture() const
 {
-	CONSTEXPR const CursorCaptureBlockReasonInt noGameBits = CursorCaptureBlockReason_NoGame | CursorCaptureBlockReason_Paused;
-
-	switch (m_cursorCaptureMode)
-	{
-	case CursorCaptureMode_None:
+	if (m_captureBlockReasonBits != 0)
 		return false;
-	case CursorCaptureMode_InGame:
-		return (m_captureBlockReasonBits == 0);
-	case CursorCaptureMode_Always:
-		return (m_captureBlockReasonBits & ~noGameBits) == 0;
-	case CursorCaptureMode_Auto:
-	default:
-		if (TheDisplay == NULL || TheDisplay->getWindowed())
-			return (m_captureBlockReasonBits == 0);
+
+	DEBUG_ASSERTCRASH(TheDisplay != NULL, ("The Display is NULL"));
+	const Bool inInteractiveGame = TheGameLogic && TheGameLogic->isInInteractiveGame();
+
+	if (TheDisplay->getWindowed())
+	{
+		if (inInteractiveGame)
+		{
+			if ((m_cursorCaptureMode & CursorCaptureMode_EnabledInWindowedGame) == 0)
+				return false;
+		}
 		else
-			return (m_captureBlockReasonBits & ~noGameBits) == 0;
+		{
+			if ((m_cursorCaptureMode & CursorCaptureMode_EnabledInWindowedMenu) == 0)
+				return false;
+		}
 	}
+	else
+	{
+		if (inInteractiveGame)
+		{
+			if ((m_cursorCaptureMode & CursorCaptureMode_EnabledInFullscreenGame) == 0)
+				return false;
+		}
+		else
+		{
+			if ((m_cursorCaptureMode & CursorCaptureMode_EnabledInFullscreenMenu) == 0)
+				return false;
+		}
+	}
+
+	return true;
 }
 
 // ------------------------------------------------------------------------------------------------


### PR DESCRIPTION
* Follow up for #1369

This change simplifies the user options for the cursor capture mode.

## Options.ini before
```
CursorCaptureMode = Auto
```
The values are: `None`, `InGame`, `Always`, `Auto`. Albeit the option is a simple one liner, the user would not intuitively understand what options are available for this enum and what these options really mean.

## Options.ini after

```
CursorCaptureEnabledInFullscreenGame = yes
CursorCaptureEnabledInFullscreenMenu = yes
CursorCaptureEnabledInWindowedGame = yes
CursorCaptureEnabledInWindowedMenu = no
```
The user can intuitively understand what the options are and how to tweak them.

## TODO

- [ ] Replicate in Generals