### PR TITLE
bugfix(aiupdate): Chinooks no longer get stuck when performing Combat Drops into buildings above terrain height

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
@@ -360,7 +360,11 @@ private:
 			for (std::list<ObjectID>::iterator oit = it->rappellerIDs.begin(); oit != it->rappellerIDs.end(); )
 			{
 				Object* rappeller = TheGameLogic->findObjectByID(*oit);
+#if RETAIL_COMPATIBLE_CRC
 				if (rappeller == NULL || rappeller->isEffectivelyDead() || !rappeller->isAboveTerrain())
+#else
+				if (rappeller == NULL || rappeller->isEffectivelyDead() || !rappeller->isAboveTerrain() || rappeller->isContained())
+#endif
 				{
 					oit = it->rappellerIDs.erase(oit);
 				}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
@@ -361,7 +361,11 @@ private:
 			for (std::list<ObjectID>::iterator oit = it->rappellerIDs.begin(); oit != it->rappellerIDs.end(); )
 			{
 				Object* rappeller = TheGameLogic->findObjectByID(*oit);
+#if RETAIL_COMPATIBLE_CRC
 				if (rappeller == NULL || rappeller->isEffectivelyDead() || !rappeller->isAboveTerrain())
+#else
+				if (rappeller == NULL || rappeller->isEffectivelyDead() || !rappeller->isAboveTerrain() || rappeller->isContained())
+#endif
 				{
 					oit = it->rappellerIDs.erase(oit);
 				}


### PR DESCRIPTION
This change prevents Chinooks from getting stuck when performing Combat Drops into buildings above terrain height.

As can be seen in 1.04 in particular situations on some maps:

https://github.com/user-attachments/assets/e5b8d400-ca91-4a90-a3a2-4061bd46f296