### PR TITLE
bugfix(buildassistant): Prevent showing the invalid placement indicator for shrouded objects

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
@@ -674,6 +674,8 @@ Bool BuildAssistant::isLocationClearOfObjects( const Coord3D *worldPos,
 	MemoryPoolObjectHolder hold(iter);
 	for( them = iter->first(); them; them = iter->next() )
 	{
+		if (them->getDrawable() && them->getDrawable()->getFullyObscuredByShroud())
+			return false;
 
 		// ignore any kind of class of objects that we will "remove" for building
 		if( isRemovableForConstruction( them ) == TRUE )
@@ -803,22 +805,26 @@ Bool BuildAssistant::isLocationClearOfObjects( const Coord3D *worldPos,
 
 		// an immobile object will obstruct our building no matter what team it's on
 		if ( them->isKindOf( KINDOF_IMMOBILE ) )	{
+			Bool shrouded = them->getDrawable() && them->getDrawable()->getFullyObscuredByShroud();
 			/* Check for overlap of my exit rectangle to his geom info. */
 			if (checkMyExit && ThePartitionManager->geomCollidesWithGeom(them->getPosition(), hisBounds, them->getOrientation(),
 				&myExitPos, myGeom, angle)) {
-				TheTerrainVisual->addFactionBib(them, true);
+				if (!shrouded)
+					TheTerrainVisual->addFactionBib(them, true);
 				return false;
 			}
 			// Check for overlap of his exit rectangle with my geom info
 			if (checkHisExit && ThePartitionManager->geomCollidesWithGeom(&hisExitPos, hisGeom, them->getOrientation(),
 					worldPos, myBounds, angle)) {
-				TheTerrainVisual->addFactionBib(them, true);
+				if (!shrouded)
+					TheTerrainVisual->addFactionBib(them, true);
 				return false;
 			}
 			// Check both exit rectangles together.
 			if (checkMyExit&&checkHisExit&&ThePartitionManager->geomCollidesWithGeom(&hisExitPos, hisGeom, them->getOrientation(),
 					&myExitPos, myGeom, angle)) {
-				TheTerrainVisual->addFactionBib(them, true);
+				if (!shrouded)
+					TheTerrainVisual->addFactionBib(them, true);
 				return false;
 			}
 		}

--- a/Generals/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
@@ -657,7 +657,8 @@ void BuildAssistant::iterateFootprint( const ThingTemplate *build,
 
 //-------------------------------------------------------------------------------------------------
 /** Check for objects preventing building at this location.
-	* TheSuperHackers @tweak Stubbjax 05/09/2025 Return LBC_SHROUD for shrouded objects. */
+	* TheSuperHackers @tweak Stubbjax 05/09/2025 Return LBC_SHROUD for shrouded objects near the
+	* edge of the shroud so that players cannot use this info to determine whether they exist. */
 //-------------------------------------------------------------------------------------------------
 Bool BuildAssistant::isLocationClearOfObjects( const Coord3D *worldPos,
 																											 const ThingTemplate *build,

--- a/Generals/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
@@ -656,7 +656,8 @@ void BuildAssistant::iterateFootprint( const ThingTemplate *build,
 
 
 //-------------------------------------------------------------------------------------------------
-/** Check for objects preventing building at this location.  */
+/** Check for objects preventing building at this location.
+	* TheSuperHackers @tweak Stubbjax 05/09/2025 Return LBC_SHROUD for shrouded objects. */
 //-------------------------------------------------------------------------------------------------
 Bool BuildAssistant::isLocationClearOfObjects( const Coord3D *worldPos,
 																											 const ThingTemplate *build,

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
@@ -657,7 +657,8 @@ void BuildAssistant::iterateFootprint( const ThingTemplate *build,
 
 //-------------------------------------------------------------------------------------------------
 /** Check for objects preventing building at this location.
-  * TheSuperHackers @tweak Stubbjax 05/09/2025 Return LBC_SHROUD for shrouded objects. */
+  * TheSuperHackers @tweak Stubbjax 05/09/2025 Return LBC_SHROUD for shrouded objects near the
+	* edge of the shroud so that players cannot use this info to determine whether they exist. */
 //-------------------------------------------------------------------------------------------------
 LegalBuildCode BuildAssistant::isLocationClearOfObjects( const Coord3D *worldPos,
 																											 const ThingTemplate *build,

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
@@ -674,11 +674,10 @@ LegalBuildCode BuildAssistant::isLocationClearOfObjects( const Coord3D *worldPos
 	MemoryPoolObjectHolder hold(iter);
 	for( them = iter->first(); them; them = iter->next() )
 	{
-		Bool feedbackWithFailure = TRUE;
-
 		if (them->getDrawable() && them->getDrawable()->getFullyObscuredByShroud())
 			return LBC_SHROUD;
 
+		Bool feedbackWithFailure = TRUE;
 		Relationship rel = builderObject ? builderObject->getRelationship( them ) : NEUTRAL;
 
 		//Kris: If the object is stealthed and we can't see it, pretend we can build there.

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
@@ -656,7 +656,8 @@ void BuildAssistant::iterateFootprint( const ThingTemplate *build,
 
 
 //-------------------------------------------------------------------------------------------------
-/** Check for objects preventing building at this location.  */
+/** Check for objects preventing building at this location.
+  * TheSuperHackers @tweak Stubbjax 05/09/2025 Return LBC_SHROUD for shrouded objects. */
 //-------------------------------------------------------------------------------------------------
 LegalBuildCode BuildAssistant::isLocationClearOfObjects( const Coord3D *worldPos,
 																											 const ThingTemplate *build,

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
@@ -676,6 +676,9 @@ LegalBuildCode BuildAssistant::isLocationClearOfObjects( const Coord3D *worldPos
 	{
 		Bool feedbackWithFailure = TRUE;
 
+		if (them->getDrawable() && them->getDrawable()->getFullyObscuredByShroud())
+			return LBC_SHROUD;
+
 		Relationship rel = builderObject ? builderObject->getRelationship( them ) : NEUTRAL;
 
 		//Kris: If the object is stealthed and we can't see it, pretend we can build there.
@@ -871,22 +874,26 @@ LegalBuildCode BuildAssistant::isLocationClearOfObjects( const Coord3D *worldPos
 
 		// an immobile object will obstruct our building no matter what team it's on
 		if ( them->isKindOf( KINDOF_IMMOBILE ) )	{
+			Bool shrouded = them->getDrawable() && them->getDrawable()->getFullyObscuredByShroud();
 			/* Check for overlap of my exit rectangle to his geom info. */
 			if (checkMyExit && ThePartitionManager->geomCollidesWithGeom(them->getPosition(), hisBounds, them->getOrientation(),
 				&myExitPos, myGeom, angle)) {
-				TheTerrainVisual->addFactionBib(them, true);
+				if (!shrouded)
+					TheTerrainVisual->addFactionBib(them, true);
 				return LBC_OBJECTS_IN_THE_WAY;
 			}
 			// Check for overlap of his exit rectangle with my geom info
 			if (checkHisExit && ThePartitionManager->geomCollidesWithGeom(&hisExitPos, hisGeom, them->getOrientation(),
 					worldPos, myBounds, angle)) {
-				TheTerrainVisual->addFactionBib(them, true);
+				if (!shrouded)
+					TheTerrainVisual->addFactionBib(them, true);
 				return LBC_OBJECTS_IN_THE_WAY;
 			}
 			// Check both exit rectangles together.
 			if (checkMyExit&&checkHisExit&&ThePartitionManager->geomCollidesWithGeom(&hisExitPos, hisGeom, them->getOrientation(),
 					&myExitPos, myGeom, angle)) {
-				TheTerrainVisual->addFactionBib(them, true);
+				if (!shrouded)
+					TheTerrainVisual->addFactionBib(them, true);
 				return LBC_OBJECTS_IN_THE_WAY;
 			}
 		}

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
@@ -873,26 +873,31 @@ LegalBuildCode BuildAssistant::isLocationClearOfObjects( const Coord3D *worldPos
 
 		// an immobile object will obstruct our building no matter what team it's on
 		if ( them->isKindOf( KINDOF_IMMOBILE ) )	{
-			Bool shrouded = them->getDrawable() && them->getDrawable()->getFullyObscuredByShroud();
 			/* Check for overlap of my exit rectangle to his geom info. */
 			if (checkMyExit && ThePartitionManager->geomCollidesWithGeom(them->getPosition(), hisBounds, them->getOrientation(),
 				&myExitPos, myGeom, angle)) {
-				if (!shrouded)
-					TheTerrainVisual->addFactionBib(them, true);
+				if (them->getDrawable() && them->getDrawable()->getFullyObscuredByShroud())
+					return LBC_SHROUD;
+				
+				TheTerrainVisual->addFactionBib(them, true);
 				return LBC_OBJECTS_IN_THE_WAY;
 			}
 			// Check for overlap of his exit rectangle with my geom info
 			if (checkHisExit && ThePartitionManager->geomCollidesWithGeom(&hisExitPos, hisGeom, them->getOrientation(),
 					worldPos, myBounds, angle)) {
-				if (!shrouded)
-					TheTerrainVisual->addFactionBib(them, true);
+				if (them->getDrawable() && them->getDrawable()->getFullyObscuredByShroud())
+					return LBC_SHROUD;
+				
+				TheTerrainVisual->addFactionBib(them, true);
 				return LBC_OBJECTS_IN_THE_WAY;
 			}
 			// Check both exit rectangles together.
 			if (checkMyExit&&checkHisExit&&ThePartitionManager->geomCollidesWithGeom(&hisExitPos, hisGeom, them->getOrientation(),
 					&myExitPos, myGeom, angle)) {
-				if (!shrouded)
-					TheTerrainVisual->addFactionBib(them, true);
+				if (them->getDrawable() && them->getDrawable()->getFullyObscuredByShroud())
+					return LBC_SHROUD;
+				
+				TheTerrainVisual->addFactionBib(them, true);
 				return LBC_OBJECTS_IN_THE_WAY;
 			}
 		}

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
@@ -875,10 +875,11 @@ LegalBuildCode BuildAssistant::isLocationClearOfObjects( const Coord3D *worldPos
 
 		// an immobile object will obstruct our building no matter what team it's on
 		if ( them->isKindOf( KINDOF_IMMOBILE ) )	{
+			Bool shrouded = them->getDrawable() && them->getDrawable()->getFullyObscuredByShroud();
 			/* Check for overlap of my exit rectangle to his geom info. */
 			if (checkMyExit && ThePartitionManager->geomCollidesWithGeom(them->getPosition(), hisBounds, them->getOrientation(),
 				&myExitPos, myGeom, angle)) {
-				if (them->getDrawable() && them->getDrawable()->getFullyObscuredByShroud())
+				if (shrouded)
 					return LBC_SHROUD;
 				
 				TheTerrainVisual->addFactionBib(them, true);
@@ -887,7 +888,7 @@ LegalBuildCode BuildAssistant::isLocationClearOfObjects( const Coord3D *worldPos
 			// Check for overlap of his exit rectangle with my geom info
 			if (checkHisExit && ThePartitionManager->geomCollidesWithGeom(&hisExitPos, hisGeom, them->getOrientation(),
 					worldPos, myBounds, angle)) {
-				if (them->getDrawable() && them->getDrawable()->getFullyObscuredByShroud())
+				if (shrouded)
 					return LBC_SHROUD;
 				
 				TheTerrainVisual->addFactionBib(them, true);
@@ -896,7 +897,7 @@ LegalBuildCode BuildAssistant::isLocationClearOfObjects( const Coord3D *worldPos
 			// Check both exit rectangles together.
 			if (checkMyExit&&checkHisExit&&ThePartitionManager->geomCollidesWithGeom(&hisExitPos, hisGeom, them->getOrientation(),
 					&myExitPos, myGeom, angle)) {
-				if (them->getDrawable() && them->getDrawable()->getFullyObscuredByShroud())
+				if (shrouded)
 					return LBC_SHROUD;
 				
 				TheTerrainVisual->addFactionBib(them, true);


### PR DESCRIPTION
This change prevents the invalid building placement indicator from showing for shrouded objects (an example of which can be seen below).

<img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/4088ba81-050c-4096-bba0-80e458de7422" />