### PR TITLE
tweak(gui): No longer disable the idle worker button when game input is disabled

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5557,10 +5557,10 @@ void InGameUI::updateIdleWorker( void )
 {
 	Int idleCount = getIdleWorkerCount();
 
-	if(idleCount > 0 && m_currentIdleWorkerDisplay != idleCount && getInputEnabled())
+	if(idleCount > 0 && m_currentIdleWorkerDisplay != idleCount)
 		showIdleWorkerLayout();
 
-	if((idleCount <= 0 && m_idleWorkerWin) || !getInputEnabled())
+	if(idleCount <= 0 && m_idleWorkerWin)
 		hideIdleWorkerLayout();
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5729,10 +5729,10 @@ void InGameUI::updateIdleWorker( void )
 {
 	Int idleCount = getIdleWorkerCount();
 
-	if(idleCount > 0 && m_currentIdleWorkerDisplay != idleCount && getInputEnabled())
+	if(idleCount > 0 && m_currentIdleWorkerDisplay != idleCount)
 		showIdleWorkerLayout();
 
-	if((idleCount <= 0 && m_idleWorkerWin) || !getInputEnabled())
+	if(idleCount <= 0 && m_idleWorkerWin)
 		hideIdleWorkerLayout();
 }
 


### PR DESCRIPTION
This change no longer disables the idle worker button when the game input is disabled.

This behaviour is consistent with the Menu and Diplomacy buttons of the Control Bar.

The Exit Menu closes when the button is pressed.