### PR TITLE
refactor: Rename CONSTEXPR to constexpr

### DIFF
--- a/Core/GameEngineDevice/Source/StdDevice/Common/StdBIGFile.cpp
+++ b/Core/GameEngineDevice/Source/StdDevice/Common/StdBIGFile.cpp
@@ -86,7 +86,7 @@ File* StdBIGFile::openFile( const Char *filename, Int access )
 	// whoever is opening this file wants write access, so copy the file to the local disk
 	// and return that file pointer.
 
-	CONSTEXPR size_t bufferSize = 0;
+	constexpr size_t bufferSize = 0;
 	File *localFile = TheLocalFileSystem->openFile(filename, access, bufferSize);
 	if (localFile != NULL) {
 		ramFile->copyDataToFile(localFile);

--- a/Core/GameEngineDevice/Source/Win32Device/Common/Win32BIGFile.cpp
+++ b/Core/GameEngineDevice/Source/Win32Device/Common/Win32BIGFile.cpp
@@ -86,7 +86,7 @@ File* Win32BIGFile::openFile( const Char *filename, Int access )
 	// whoever is opening this file wants write access, so copy the file to the local disk
 	// and return that file pointer.
 
-	CONSTEXPR size_t bufferSize = 0;
+	constexpr size_t bufferSize = 0;
 	File *localFile = TheLocalFileSystem->openFile(filename, access, bufferSize);
 	if (localFile != NULL) {
 		ramFile->copyDataToFile(localFile);

--- a/Dependencies/Utility/Utility/CppMacros.h
+++ b/Dependencies/Utility/Utility/CppMacros.h
@@ -38,12 +38,8 @@
 
 #if __cplusplus >= 201103L
   #define CPP_11(code) code
-  #define CONSTEXPR constexpr
 #else
   #define CPP_11(code)
-  #define CONSTEXPR
-#endif
-
-#if __cplusplus < 201103L
-#define static_assert(expr, msg)
+  #define static_assert(expr, msg)
+  #define constexpr
 #endif

--- a/Generals/Code/GameEngine/Include/Common/GlobalData.h
+++ b/Generals/Code/GameEngine/Include/Common/GlobalData.h
@@ -52,8 +52,8 @@ enum AIDebugOptions CPP_11(: Int);
 
 // PUBLIC /////////////////////////////////////////////////////////////////////////////////////////
 
-CONSTEXPR const Int MAX_GLOBAL_LIGHTS = 3;
-CONSTEXPR const Int SIMULATE_REPLAYS_SEQUENTIAL = -1;
+constexpr const Int MAX_GLOBAL_LIGHTS = 3;
+constexpr const Int SIMULATE_REPLAYS_SEQUENTIAL = -1;
 
 //-------------------------------------------------------------------------------------------------
 class CommandLineData

--- a/Generals/Code/GameEngine/Include/Common/SparseMatchFinder.h
+++ b/Generals/Code/GameEngine/Include/Common/SparseMatchFinder.h
@@ -202,7 +202,7 @@ public:
 	//-------------------------------------------------------------------------------------------------
 	SparseMatchFinder& operator=(const SparseMatchFinder& other)
 	{
-		if CONSTEXPR ((FLAGS & SparseMatchFinderFlags_NoCopy) == 0)
+		if constexpr ((FLAGS & SparseMatchFinderFlags_NoCopy) == 0)
 		{
 			if (this != &other)
 			{

--- a/Generals/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Recorder.cpp
@@ -47,8 +47,8 @@
 #include "Common/CRCDebug.h"
 #include "Common/version.h"
 
-CONSTEXPR const char s_genrep[] = "GENREP";
-CONSTEXPR const UnsignedInt replayBufferBytes = 8192;
+constexpr const char s_genrep[] = "GENREP";
+constexpr const UnsignedInt replayBufferBytes = 8192;
 
 Int REPLAY_CRC_INTERVAL = 100;
 

--- a/Generals/Code/GameEngine/Source/GameClient/Input/Mouse.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Input/Mouse.cpp
@@ -1072,7 +1072,7 @@ void Mouse::initCapture()
 // ------------------------------------------------------------------------------------------------
 Bool Mouse::canCapture() const
 {
-	CONSTEXPR const CursorCaptureBlockReasonInt noGameBits = CursorCaptureBlockReason_NoGame | CursorCaptureBlockReason_Paused;
+	constexpr const CursorCaptureBlockReasonInt noGameBits = CursorCaptureBlockReason_NoGame | CursorCaptureBlockReason_Paused;
 
 	switch (m_cursorCaptureMode)
 	{

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
@@ -73,8 +73,8 @@ static Bool scrollDir[4] = { false, false, false, false };
 // The multiplier of 2 was logically chosen because originally the Scroll Factor did practically not affect the RMB scroll speed
 // and because the default Scroll Factor is/was 0.5, it needs to be doubled to get to a neutral 1x multiplier.
 
-CONSTEXPR const Real SCROLL_MULTIPLIER = 2.0f;
-CONSTEXPR const Real SCROLL_AMT = 100.0f * SCROLL_MULTIPLIER;
+constexpr const Real SCROLL_MULTIPLIER = 2.0f;
+constexpr const Real SCROLL_AMT = 100.0f * SCROLL_MULTIPLIER;
 
 static const Int edgeScrollSize = 3;
 

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -1656,7 +1656,7 @@ void W3DView::scrollBy( Coord2D *delta )
 	// if we haven't moved, ignore
 	if( delta && (delta->x != 0 || delta->y != 0) )
 	{
-		CONSTEXPR const Real SCROLL_RESOLUTION = 250.0f;
+		constexpr const Real SCROLL_RESOLUTION = 250.0f;
 
 		Vector3 world, worldStart, worldEnd;
 		Vector2 start, end;

--- a/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
@@ -53,8 +53,8 @@ enum AIDebugOptions CPP_11(: Int);
 
 // PUBLIC /////////////////////////////////////////////////////////////////////////////////////////
 
-CONSTEXPR const Int MAX_GLOBAL_LIGHTS = 3;
-CONSTEXPR const Int SIMULATE_REPLAYS_SEQUENTIAL = -1;
+constexpr const Int MAX_GLOBAL_LIGHTS = 3;
+constexpr const Int SIMULATE_REPLAYS_SEQUENTIAL = -1;
 
 //-------------------------------------------------------------------------------------------------
 class CommandLineData

--- a/GeneralsMD/Code/GameEngine/Include/Common/SparseMatchFinder.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/SparseMatchFinder.h
@@ -204,7 +204,7 @@ public:
 	//-------------------------------------------------------------------------------------------------
 	SparseMatchFinder& operator=(const SparseMatchFinder& other)
 	{
-		if CONSTEXPR ((FLAGS & SparseMatchFinderFlags_NoCopy) == 0)
+		if constexpr ((FLAGS & SparseMatchFinderFlags_NoCopy) == 0)
 		{
 			if (this != &other)
 			{

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -47,8 +47,8 @@
 #include "Common/CRCDebug.h"
 #include "Common/version.h"
 
-CONSTEXPR const char s_genrep[] = "GENREP";
-CONSTEXPR const UnsignedInt replayBufferBytes = 8192;
+constexpr const char s_genrep[] = "GENREP";
+constexpr const UnsignedInt replayBufferBytes = 8192;
 
 Int REPLAY_CRC_INTERVAL = 100;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Mouse.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Mouse.cpp
@@ -1072,7 +1072,7 @@ void Mouse::initCapture()
 // ------------------------------------------------------------------------------------------------
 Bool Mouse::canCapture() const
 {
-	CONSTEXPR const CursorCaptureBlockReasonInt noGameBits = CursorCaptureBlockReason_NoGame | CursorCaptureBlockReason_Paused;
+	constexpr const CursorCaptureBlockReasonInt noGameBits = CursorCaptureBlockReason_NoGame | CursorCaptureBlockReason_Paused;
 
 	switch (m_cursorCaptureMode)
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
@@ -73,8 +73,8 @@ static Bool scrollDir[4] = { false, false, false, false };
 // The multiplier of 2 was logically chosen because originally the Scroll Factor did practically not affect the RMB scroll speed
 // and because the default Scroll Factor is/was 0.5, it needs to be doubled to get to a neutral 1x multiplier.
 
-CONSTEXPR const Real SCROLL_MULTIPLIER = 2.0f;
-CONSTEXPR const Real SCROLL_AMT = 100.0f * SCROLL_MULTIPLIER;
+constexpr const Real SCROLL_MULTIPLIER = 2.0f;
+constexpr const Real SCROLL_AMT = 100.0f * SCROLL_MULTIPLIER;
 
 static const Int edgeScrollSize = 3;
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -1820,7 +1820,7 @@ void W3DView::scrollBy( Coord2D *delta )
 	// if we haven't moved, ignore
 	if( delta && (delta->x != 0 || delta->y != 0) )
 	{
-		CONSTEXPR const Real SCROLL_RESOLUTION = 250.0f;
+		constexpr const Real SCROLL_RESOLUTION = 250.0f;
 
 		Vector3 world, worldStart, worldEnd;
 		Vector2 start, end;


### PR DESCRIPTION
This change renames CONSTEXPR to constexpr.

Uncrustify complained about CONSTEXPR which prompted this action.