### PR TITLE
fix(shadow): Fix counting of W3DProjectedShadowManager::m_numDecalShadows

### DIFF
--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DProjectedShadow.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DProjectedShadow.h
@@ -78,7 +78,9 @@ class W3DProjectedShadowManager	: public ProjectedShadowManager
 
 	private:
 		Int renderProjectedTerrainShadow(W3DProjectedShadow *shadow, AABoxClass &box);	///<render shadow on map terrain.
+		void updateShadowNumbers(ShadowType shadowType, Int addNum);
 
+	private:
 		W3DProjectedShadow *m_shadowList;
 		W3DProjectedShadow *m_decalList;
 		TextureClass	*m_dynamicRenderTarget;	///<offscreen video memory texture used to render all shadow textures.

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DProjectedShadow.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DProjectedShadow.cpp
@@ -1566,20 +1566,7 @@ Shadow* W3DProjectedShadowManager::addDecal(Shadow::ShadowTypeInfo *shadowInfo)
 		m_decalList = shadow;
 	}
 
-	switch (shadow->m_type)
-	{
-		case SHADOW_DECAL:
-		case SHADOW_ALPHA_DECAL:
-		case SHADOW_ADDITIVE_DECAL:
-			m_numDecalShadows++;
-			break;
-		case SHADOW_PROJECTION:
-			m_numProjectionShadows++;
-			break;
-		default:
-			break;
-	}
-
+	updateShadowNumbers(shadow->m_type, +1);
 	return shadow;
 }
 
@@ -1703,20 +1690,7 @@ Shadow* W3DProjectedShadowManager::addDecal(RenderObjClass *robj, Shadow::Shadow
 		m_decalList = shadow;
 	}
 
-	switch (shadow->m_type)
-	{
-		case SHADOW_DECAL:
-		case SHADOW_ALPHA_DECAL:
-		case SHADOW_ADDITIVE_DECAL:
-			m_numDecalShadows++;
-			break;
-		case SHADOW_PROJECTION:
-			m_numProjectionShadows++;
-			break;
-		default:
-			break;
-	}
-
+	updateShadowNumbers(shadow->m_type, +1);
 	return shadow;
 }
 
@@ -1902,18 +1876,7 @@ W3DProjectedShadow* W3DProjectedShadowManager::addShadow(RenderObjClass *robj, S
 		m_shadowList = shadow;
 	}
 
-	switch (shadow->m_type)
-	{
-		case SHADOW_DECAL:
-			m_numDecalShadows++;
-			break;
-		case SHADOW_PROJECTION:
-			m_numProjectionShadows++;
-			break;
-		default:
-			break;
-	}
-
+	updateShadowNumbers(shadow->m_type, +1);
 	return shadow;
 }
 
@@ -2033,17 +1996,8 @@ void W3DProjectedShadowManager::removeShadow (W3DProjectedShadow *shadow)
 					prev_shadow->m_next=shadow->m_next;
 				else
 					m_decalList=shadow->m_next;
-				switch (shadow->m_type)
-				{
-					case SHADOW_DECAL:
-						m_numDecalShadows--;
-						break;
-					case SHADOW_PROJECTION:
-						m_numProjectionShadows--;
-						break;
-					default:
-						break;
-				}
+
+				updateShadowNumbers(shadow->m_type, -1);
 				delete shadow;
 				return;
 			}
@@ -2059,17 +2013,8 @@ void W3DProjectedShadowManager::removeShadow (W3DProjectedShadow *shadow)
 				prev_shadow->m_next=shadow->m_next;
 			else
 				m_shadowList=shadow->m_next;
-			switch (shadow->m_type)
-			{
-				case SHADOW_DECAL:
-					m_numDecalShadows--;
-					break;
-				case SHADOW_PROJECTION:
-					m_numProjectionShadows--;
-					break;
-				default:
-					break;
-			}
+
+			updateShadowNumbers(shadow->m_type, -1);
 			delete shadow;
 			return;
 		}
@@ -2101,6 +2046,23 @@ void W3DProjectedShadowManager::removeAllShadows(void)
 		next_shadow = cur_shadow->m_next;
 		cur_shadow->m_next = NULL;
 		delete cur_shadow;
+	}
+}
+
+void W3DProjectedShadowManager::updateShadowNumbers(ShadowType shadowType, Int addNum)
+{
+	switch (shadowType)
+	{
+		case SHADOW_DECAL:
+		case SHADOW_ALPHA_DECAL:
+		case SHADOW_ADDITIVE_DECAL:
+			m_numDecalShadows += addNum;
+			break;
+		case SHADOW_PROJECTION:
+			m_numProjectionShadows += addNum;
+			break;
+		default:
+			break;
 	}
 }
 

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DProjectedShadow.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DProjectedShadow.h
@@ -78,7 +78,9 @@ class W3DProjectedShadowManager	: public ProjectedShadowManager
 
 	private:
 		Int renderProjectedTerrainShadow(W3DProjectedShadow *shadow, AABoxClass &box);	///<render shadow on map terrain.
+		void updateShadowNumbers(ShadowType shadowType, Int addNum);
 
+	private:
 		W3DProjectedShadow *m_shadowList;
 		W3DProjectedShadow *m_decalList;
 		TextureClass	*m_dynamicRenderTarget;	///<offscreen video memory texture used to render all shadow textures.

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DProjectedShadow.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DProjectedShadow.cpp
@@ -1566,20 +1566,7 @@ Shadow* W3DProjectedShadowManager::addDecal(Shadow::ShadowTypeInfo *shadowInfo)
 		m_decalList = shadow;
 	}
 
-	switch (shadow->m_type)
-	{
-		case SHADOW_DECAL:
-		case SHADOW_ALPHA_DECAL:
-		case SHADOW_ADDITIVE_DECAL:
-			m_numDecalShadows++;
-			break;
-		case SHADOW_PROJECTION:
-			m_numProjectionShadows++;
-			break;
-		default:
-			break;
-	}
-
+	updateShadowNumbers(shadow->m_type, +1);
 	return shadow;
 }
 
@@ -1703,20 +1690,7 @@ Shadow* W3DProjectedShadowManager::addDecal(RenderObjClass *robj, Shadow::Shadow
 		m_decalList = shadow;
 	}
 
-	switch (shadow->m_type)
-	{
-		case SHADOW_DECAL:
-		case SHADOW_ALPHA_DECAL:
-		case SHADOW_ADDITIVE_DECAL:
-			m_numDecalShadows++;
-			break;
-		case SHADOW_PROJECTION:
-			m_numProjectionShadows++;
-			break;
-		default:
-			break;
-	}
-
+	updateShadowNumbers(shadow->m_type, +1);
 	return shadow;
 }
 
@@ -1902,18 +1876,7 @@ W3DProjectedShadow* W3DProjectedShadowManager::addShadow(RenderObjClass *robj, S
 		m_shadowList = shadow;
 	}
 
-	switch (shadow->m_type)
-	{
-		case SHADOW_DECAL:
-			m_numDecalShadows++;
-			break;
-		case SHADOW_PROJECTION:
-			m_numProjectionShadows++;
-			break;
-		default:
-			break;
-	}
-
+	updateShadowNumbers(shadow->m_type, +1);
 	return shadow;
 }
 
@@ -2033,17 +1996,8 @@ void W3DProjectedShadowManager::removeShadow (W3DProjectedShadow *shadow)
 					prev_shadow->m_next=shadow->m_next;
 				else
 					m_decalList=shadow->m_next;
-				switch (shadow->m_type)
-				{
-					case SHADOW_DECAL:
-						m_numDecalShadows--;
-						break;
-					case SHADOW_PROJECTION:
-						m_numProjectionShadows--;
-						break;
-					default:
-						break;
-				}
+
+				updateShadowNumbers(shadow->m_type, -1);
 				delete shadow;
 				return;
 			}
@@ -2059,17 +2013,8 @@ void W3DProjectedShadowManager::removeShadow (W3DProjectedShadow *shadow)
 				prev_shadow->m_next=shadow->m_next;
 			else
 				m_shadowList=shadow->m_next;
-			switch (shadow->m_type)
-			{
-				case SHADOW_DECAL:
-					m_numDecalShadows--;
-					break;
-				case SHADOW_PROJECTION:
-					m_numProjectionShadows--;
-					break;
-				default:
-					break;
-			}
+
+			updateShadowNumbers(shadow->m_type, -1);
 			delete shadow;
 			return;
 		}
@@ -2101,6 +2046,23 @@ void W3DProjectedShadowManager::removeAllShadows(void)
 		next_shadow = cur_shadow->m_next;
 		cur_shadow->m_next = NULL;
 		delete cur_shadow;
+	}
+}
+
+void W3DProjectedShadowManager::updateShadowNumbers(ShadowType shadowType, Int addNum)
+{
+	switch (shadowType)
+	{
+		case SHADOW_DECAL:
+		case SHADOW_ALPHA_DECAL:
+		case SHADOW_ADDITIVE_DECAL:
+			m_numDecalShadows += addNum;
+			break;
+		case SHADOW_PROJECTION:
+			m_numProjectionShadows += addNum;
+			break;
+		default:
+			break;
 	}
 }
 


### PR DESCRIPTION
This change fixes counting of `W3DProjectedShadowManager::m_numDecalShadows`. This value appears to be not used for anything, so it is inconsequential. I think it was mainly intended for diagnostics.

Interestingly, the count appears to be still not right after the fix. I do see value of 1 even when there are 0 decals in the list, which implies that there is another bug somewhere. I was not able to locate it.

## TODO

- [x] Replicate in Generals