### PR TITLE
bugfix(gui): fix resolution and zoom scaling of unit information

### DIFF
--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Display.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Display.h
@@ -97,6 +97,12 @@ public:
 #endif
 
 	//---------------------------------------------------------------------------------------
+	// Display scaling methods
+	virtual Real getWidthScale( void );
+	virtual Real getHeightScale( void );
+	virtual Real getAspectRatioScale( void );
+
+	//---------------------------------------------------------------------------------------
 	// View management
 	virtual void attachView( View *view );												///< Attach the given view to the world
 	virtual View *getFirstView( void ) { return m_viewList; }				///< Return the first view of the world

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/View.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/View.h
@@ -43,6 +43,9 @@
 #define DEFAULT_VIEW_ORIGIN_X 0
 #define DEFAULT_VIEW_ORIGIN_Y 0
 
+#define DEFAULT_VIEW_MAX_ZOOM 1.3f
+#define DEFAULT_VIEW_MIN_ZOOM 0.2f
+
 // FORWARD DECLARATIONS ///////////////////////////////////////////////////////////////////////////
 class Drawable;
 class ViewLocation;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Display.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Display.cpp
@@ -202,6 +202,32 @@ void Display::setHeight( UnsignedInt height )
 
 }
 
+// Display::getWidthScale =========================================================
+/** Return the ratio of the current display width relative to the default resolution */
+//=============================================================================
+Real Display::getWidthScale(void)
+{
+	return INT_TO_REAL(m_width) / DEFAULT_DISPLAY_WIDTH;
+}
+
+// Display::getHeightScale =========================================================
+/** Return the ratio of the current display height relative to the default resolution */
+//=============================================================================
+Real Display::getHeightScale(void)
+{
+	return INT_TO_REAL(m_height) / DEFAULT_DISPLAY_HEIGHT;
+}
+
+// Display::getAspectRatioScale =========================================================
+/** Return the ratio of the current display aspect ratio relative to the default aspect ratio */
+//=============================================================================
+Real Display::getAspectRatioScale(void)
+{
+	Real baseAspectRatio = INT_TO_REAL(DEFAULT_DISPLAY_WIDTH) / DEFAULT_DISPLAY_HEIGHT;
+	Real currentAspectRatio = INT_TO_REAL(m_width) / m_height;
+	return currentAspectRatio / baseAspectRatio;
+}
+
 //============================================================================
 // Display::playLogoMovie
 // minMovieLength is in milliseconds

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/View.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/View.cpp
@@ -99,8 +99,8 @@ void View::init( void )
 	m_cameraLockDrawable = NULL;
 	m_zoomLimited = TRUE;
 
-	m_maxZoom = 1.3f;
-	m_minZoom = 0.2f;
+	m_maxZoom = DEFAULT_VIEW_MAX_ZOOM;
+	m_minZoom = DEFAULT_VIEW_MIN_ZOOM;
 	m_zoom = m_maxZoom;
 	m_maxHeightAboveGround = TheGlobalData->m_maxCameraHeight;
 	m_minHeightAboveGround = TheGlobalData->m_minCameraHeight;

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -119,18 +119,7 @@ inline Real maxf(Real a, Real b) { if (a > b) return a; else return b; }
 //-------------------------------------------------------------------------------------------------
 static void normAngle(Real &angle)
 {
-	if (angle < -10*PI) {
-		angle = 0;
-	}
-	if (angle > 10*PI) {
-		angle = 0;
-	}
-	while (angle < -PI) {
-		angle += 2*PI;
-	}
-	while (angle > PI) {
-		angle -= 2*PI;
-	}
+	angle = angle - (TWO_PI * floorf((angle + PI) / TWO_PI));
 }
 
 #define TERRAIN_SAMPLE_SIZE 40.0f
@@ -1945,15 +1934,7 @@ void W3DView::setHeightAboveGround(Real z)
 
   // if our zoom is limited, we will stay within a predefined distance from the terrain
 	if( m_zoomLimited )
-	{
-
-		if (m_heightAboveGround < m_minHeightAboveGround)
-			m_heightAboveGround = m_minHeightAboveGround;
-
-		if (m_heightAboveGround > m_maxHeightAboveGround)
-			m_heightAboveGround = m_maxHeightAboveGround;
-
-	}
+		m_heightAboveGround = clamp<Real>(m_minHeightAboveGround, m_heightAboveGround, m_maxHeightAboveGround);
 
 	m_doingMoveCameraOnWaypointPath = false;
 	m_CameraArrivedAtWaypointOnPathFlag = false;
@@ -1969,13 +1950,7 @@ void W3DView::setHeightAboveGround(Real z)
 //-------------------------------------------------------------------------------------------------
 void W3DView::setZoom(Real z)
 {
-	m_zoom = z;
-
-	if (m_zoom < m_minZoom)
-		m_zoom = m_minZoom;
-
-	if (m_zoom > m_maxZoom)
-		m_zoom = m_maxZoom;
+	m_zoom = clamp<Real>(m_minZoom, z, m_maxZoom);
 
 	m_doingMoveCameraOnWaypointPath = false;
 	m_CameraArrivedAtWaypointOnPathFlag = false;


### PR DESCRIPTION
- fixes: #867 
- fixes: #868 
- fixes: #869 
- fixes: #871 

This PR fixes the unit information scaling within the game.
It fixes the scaling and placement of the following:

1. health bar
2. veterancy icon
3. contained pips
4. ammo pips
5. enthusiastic and emoticon
6. healing icon
7. Bomb icons on structures
8. disabled icon
9. battleplan icons (These are currently disabled and have no data related to them so crash the game, but i tweaked the code to fix it)

The majority of the scaling now takes the zoom and difference in resolution, relative to the default resolution that the items were scaled for, into account.

Some of the scaling and placement of info is slightly altered relative to the original 800x600 implementation.
This was done as the original sizes of the information was considered excessive.

I have currently kept the bombed icon set to scale to half the size of a health bar, it makes it more obvious which buildings have been rigged. Prior to this the bombed icon was using the infantries health bar to scale itself and it was then placed at the feet of where the infantry unit used the ability instead of on the building.