### PR TITLE
fix(guiedit): Fix crash on GuiEdit launch by initializing GlobalLanguage after GlobalData

### DIFF
--- a/Generals/Code/Tools/GUIEdit/Source/GUIEdit.cpp
+++ b/Generals/Code/Tools/GUIEdit/Source/GUIEdit.cpp
@@ -486,8 +486,6 @@ void GUIEdit::init( void )
 	TheArchiveFileSystem = new Win32BIGFileSystem;
 	TheFileSystem->init();
 
-	TheGlobalLanguageData = new GlobalLanguage;
-	TheGlobalLanguageData->init();
 	//---------------------------------------------------------------------------
 	// GUI tool specific initializations ----------------------------------------
 	//---------------------------------------------------------------------------
@@ -510,9 +508,13 @@ void GUIEdit::init( void )
 	// Game engine specific initializations -------------------------------------
 	//---------------------------------------------------------------------------
 
-	// create the name key generator
+	// create the global data
 	TheWritableGlobalData = new GlobalData;
 	TheWritableGlobalData->init();
+
+	// TheSuperHackers @info global language relies on global data being initialized
+	TheGlobalLanguageData = new GlobalLanguage;
+	TheGlobalLanguageData->init();
 
 	// create the message stream
 	TheMessageStream = new MessageStream;

--- a/GeneralsMD/Code/Tools/GUIEdit/Source/GUIEdit.cpp
+++ b/GeneralsMD/Code/Tools/GUIEdit/Source/GUIEdit.cpp
@@ -486,8 +486,6 @@ void GUIEdit::init( void )
 	TheArchiveFileSystem = new Win32BIGFileSystem;
 	TheFileSystem->init();
 
-	TheGlobalLanguageData = new GlobalLanguage;
-	TheGlobalLanguageData->init();
 	//---------------------------------------------------------------------------
 	// GUI tool specific initializations ----------------------------------------
 	//---------------------------------------------------------------------------
@@ -510,9 +508,13 @@ void GUIEdit::init( void )
 	// Game engine specific initializations -------------------------------------
 	//---------------------------------------------------------------------------
 
-	// create the name key generator
+	// create the global data
 	TheWritableGlobalData = new GlobalData;
 	TheWritableGlobalData->init();
+
+	// TheSuperHackers @info global language relies on global data being initialized
+	TheGlobalLanguageData = new GlobalLanguage;
+	TheGlobalLanguageData->init();
 
 	// create the message stream
 	TheMessageStream = new MessageStream;


### PR DESCRIPTION
This PR fixes a startup crash within GuiEdit that was introduced by changed in Global Languge in PR #1457

This crash occured due to the global language object being initialised before global data in GuiEdit.
Global language is now dependent on being initialised after Global Data. This is due to the recent need for the user data directory string when retrieving options.ini settings within global language.

The user data directory string is initialised when the global data is initialised, resulting in a null string being handled within global languages, resulting in the crash.

For some reason the VS22 builds were immune to the issue. But the VC6 builds would always crash.