### PR TITLE
tweak(fps): Set min logic time scale to 5 with RTS_DEBUG

### DIFF
--- a/Core/GameEngine/Include/Common/FrameRateLimit.h
+++ b/Core/GameEngine/Include/Common/FrameRateLimit.h
@@ -18,6 +18,9 @@
 
 #pragma once
 
+#include "Common/GameCommon.h"
+
+
 class FrameRateLimit
 {
 public:
@@ -60,6 +63,11 @@ class LogicTimeScaleFpsPreset
 public:
 	enum CPP_11(: UnsignedInt)
 	{
+#if RTS_DEBUG
+		MinFpsValue = 5,
+#else
+		MinFpsValue = LOGICFRAMES_PER_SECOND,
+#endif
 		StepFpsValue = 5,
 	};
 

--- a/Core/GameEngine/Source/Common/FrameRateLimit.cpp
+++ b/Core/GameEngine/Source/Common/FrameRateLimit.cpp
@@ -105,9 +105,9 @@ UnsignedInt LogicTimeScaleFpsPreset::getNextFpsValue(UnsignedInt value)
 
 UnsignedInt LogicTimeScaleFpsPreset::getPrevFpsValue(UnsignedInt value)
 {
-	if (value - StepFpsValue < LOGICFRAMES_PER_SECOND)
+	if (value - StepFpsValue < MinFpsValue)
 	{
-		return LOGICFRAMES_PER_SECOND;
+		return MinFpsValue;
 	}
 	else
 	{


### PR DESCRIPTION
This changes the minimum logic time scale from 30 to 5 with RTS_DEBUG.

I found this to be very useful to test render/logic update discrepancies with slow motion game.
