### PR TITLE
bugfix(shadow): Fix initial shadow states of draw modules and implicitly remove shadows from build preview objects

### DIFF
--- a/GeneralsMD/Code/GameEngine/Include/Common/ThingFactory.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/ThingFactory.h
@@ -92,7 +92,7 @@ public:
 	/** request a new drawable using the given template.
 		this will throw an exception on failure; it will never return null.
 	*/
-	Drawable *newDrawable(const ThingTemplate *tmplate, DrawableStatus statusBits = DRAWABLE_STATUS_NONE );
+	Drawable *newDrawable(const ThingTemplate *tmplate, DrawableStatusInt statusBits = DRAWABLE_STATUS_DEFAULT );
 
 	static void parseObjectDefinition( INI* ini, const AsciiString& name, const AsciiString& reskinFrom );
 

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Drawable.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Drawable.h
@@ -228,7 +228,8 @@ enum StealthLookType CPP_11(: Int)
 // ------------------------------------------------------------------------------------------------
 /** Drawable status bits */
 // ------------------------------------------------------------------------------------------------
-enum DrawableStatus CPP_11(: Int)
+typedef UnsignedInt DrawableStatusInt;
+enum DrawableStatus CPP_11(: DrawableStatusInt)
 {
 	DRAWABLE_STATUS_NONE									= 0x00000000,		///< no status
 	DRAWABLE_STATUS_DRAWS_IN_MIRROR				=	0x00000001,		///< drawable can reflect
@@ -236,6 +237,8 @@ enum DrawableStatus CPP_11(: Int)
 	DRAWABLE_STATUS_TINT_COLOR_LOCKED			=	0x00000004,		///< drawable tint color is "locked" and won't fade to normal
 	DRAWABLE_STATUS_NO_STATE_PARTICLES		= 0x00000008,		///< do *not* auto-create particle systems based on model condition
 	DRAWABLE_STATUS_NO_SAVE								= 0x00000010,		///< do *not* save this drawable (UI fluff only). ignored (error, actually) if attached to an object
+
+	DRAWABLE_STATUS_DEFAULT = DRAWABLE_STATUS_SHADOWS,
 };
 
 enum TintStatus CPP_11(: Int)
@@ -291,7 +294,7 @@ class Drawable : public Thing,
 
 public:
 
-	Drawable( const ThingTemplate *thing, DrawableStatus statusBits = DRAWABLE_STATUS_NONE );
+	Drawable( const ThingTemplate *thing, DrawableStatusInt statusBits = DRAWABLE_STATUS_DEFAULT );
 
 	void onDestroy( void );																							///< run from GameClient::destroyDrawable
   void onLevelStart();                                                ///< run from GameLogic::startNewGame
@@ -669,7 +672,7 @@ private:
 
   DynamicAudioEventInfo *m_customSoundAmbientInfo; ///< If not NULL, info about the ambient sound to attach to this object
 
-	UnsignedInt m_status;				///< status bits (see DrawableStatus enum)
+	DrawableStatusInt m_status;			///< status bits (see DrawableStatus enum)
 	UnsignedInt m_tintStatus;				///< tint color status bits (see TintStatus enum)
 	UnsignedInt m_prevTintStatus;///< for edge testing with m_tintStatus
 

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/GameClient.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/GameClient.h
@@ -131,7 +131,7 @@ public:
 
 	virtual void iterateDrawablesInRegion( Region3D *region, GameClientFuncPtr userFunc, void *userData );		///< Calls userFunc for each drawable contained within the region
 
-	virtual Drawable *friend_createDrawable( const ThingTemplate *thing, DrawableStatus statusBits = DRAWABLE_STATUS_NONE ) = 0;
+	virtual Drawable *friend_createDrawable( const ThingTemplate *thing, DrawableStatusInt statusBits = DRAWABLE_STATUS_DEFAULT ) = 0;
 	virtual void destroyDrawable( Drawable *draw );											///< Destroy the given drawable
 
 	virtual void setTimeOfDay( TimeOfDay tod );													///< Tell all the drawables what time of day it is now

--- a/GeneralsMD/Code/GameEngine/Source/Common/Thing/ThingFactory.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Thing/ThingFactory.cpp
@@ -346,7 +346,7 @@ Object *ThingFactory::newObject( const ThingTemplate *tmplate, Team *team, Objec
 }
 
 //=============================================================================
-Drawable *ThingFactory::newDrawable(const ThingTemplate *tmplate, DrawableStatus statusBits)
+Drawable *ThingFactory::newDrawable(const ThingTemplate *tmplate, DrawableStatusInt statusBits)
 {
 	if (tmplate == NULL)
 		throw ERROR_BAD_ARG;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -340,7 +340,7 @@ void Drawable::saturateRGB(RGBColor& color, Real factor)
  * graphical side of a logical object, whereas GameLogic objects encapsulate
  * behaviors and physics.  */
 //-------------------------------------------------------------------------------------------------
-Drawable::Drawable( const ThingTemplate *thingTemplate, DrawableStatus statusBits )
+Drawable::Drawable( const ThingTemplate *thingTemplate, DrawableStatusInt statusBits )
 				: Thing( thingTemplate )
 {
 
@@ -491,6 +491,13 @@ Drawable::Drawable( const ThingTemplate *thingTemplate, DrawableStatus statusBit
 	{
 		for (Module** m = m_modules[i]; m && *m; ++m)
 			(*m)->onObjectCreated();
+	}
+
+	// TheSuperHackers @bugfix Match the shadow states of all draw modules with this drawable.
+	const Bool shadowsEnabled = getShadowsEnabled();
+	for (DrawModule** dm = getDrawModules(); *dm; ++dm)
+	{
+		(*dm)->setShadowsEnabled(shadowsEnabled);
 	}
 
 	m_groupNumber = NULL;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -91,8 +91,17 @@
 
 
 // ------------------------------------------------------------------------------------------------
-static const Real placementOpacity = 0.45f;
-static const RGBColor illegalBuildColor = { 1.0, 0.0, 0.0 };
+
+// TheSuperHackers @info Note that the placement objects no longer draw shadows after a bug was
+// fixed in the drawable. If you want shadows, add it here, but beware that shadows on translucent
+// models may look a bit odd.
+static const UnsignedInt PlacementDrawableStatus = DRAWABLE_STATUS_NO_STATE_PARTICLES;
+
+// TheSuperHackers @tweak Changes the placement object opacity from 0.45 to increase its visibility
+// because they no longer cast dark shadows and are less visible that way.
+static const Real PlacementOpacity = 0.60f;
+
+static const RGBColor IllegalBuildColor = { 1.0, 0.0, 0.0 };
 
 //-------------------------------------------------------------------------------------------------
 /// The InGameUI singleton instance.
@@ -1523,8 +1532,9 @@ void InGameUI::handleBuildPlacements( void )
 																											 BuildAssistant::IGNORE_STEALTHED,
 																											 builderObject,
 																											 NULL );
+
 			if( lbc != LBC_OK )
-				m_placeIcon[ 0 ]->colorTint( &illegalBuildColor );
+				m_placeIcon[ 0 ]->colorTint( &IllegalBuildColor );
 			else
 				m_placeIcon[ 0 ]->colorTint( NULL );
 
@@ -1585,7 +1595,7 @@ void InGameUI::handleBuildPlacements( void )
 
 				if( m_placeIcon[ i ] == NULL )
 					m_placeIcon[ i ] = TheThingFactory->newDrawable( m_pendingPlaceType,
-																													 DRAWABLE_STATUS_NO_STATE_PARTICLES );
+																													 PlacementDrawableStatus );
 
 			}
 
@@ -1613,7 +1623,7 @@ void InGameUI::handleBuildPlacements( void )
 				m_placeIcon[ i ]->setPosition( &tileBuildInfo->positions[ i ] );
 
 				// set opacity for the drawble
-				m_placeIcon[ i ]->setDrawableOpacity( placementOpacity );
+				m_placeIcon[ i ]->setDrawableOpacity( PlacementOpacity );
 
 				// set the drawable angle
 				m_placeIcon[ i ]->setOrientation( angle );
@@ -3111,7 +3121,7 @@ void InGameUI::placeBuildAvailable( const ThingTemplate *build, Drawable *buildD
 //			TheInGameUI->deselectAllDrawables();
 
 			// create a drawble of what we are building to be "attached" at the cursor
-			draw = TheThingFactory->newDrawable( build, DRAWABLE_STATUS_NO_STATE_PARTICLES );
+			draw = TheThingFactory->newDrawable( build, PlacementDrawableStatus );
 			if (sourceObject)
 			{
 				if (TheGlobalData->m_timeOfDay == TIME_OF_DAY_NIGHT)
@@ -3136,7 +3146,7 @@ void InGameUI::placeBuildAvailable( const ThingTemplate *build, Drawable *buildD
 			draw->setOrientation( angle );
 
 			// set the build icon attached to the cursor to be "see-thru"
-			draw->setDrawableOpacity( placementOpacity );
+			draw->setDrawableOpacity( PlacementOpacity );
 
 			// set the "icon" in the icon array at the first index
 			DEBUG_ASSERTCRASH( m_placeIcon[ 0 ] == NULL, ("placeBuildAvailable, build icon array is not empty!") );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -1836,7 +1836,7 @@ void GameLogic::startNewGame( Bool loadingSaveGame )
 			if (thingTemplate->isKindOf(KINDOF_OPTIMIZED_TREE)) {
 				// Opt trees and props just get drawables to tell the client about it, then deleted. jba [6/5/2003]
 				// This way there is no logic object to slow down partition manager and core logic stuff.
-				Drawable *draw = TheThingFactory->newDrawable(thingTemplate, DRAWABLE_STATUS_NONE);
+				Drawable *draw = TheThingFactory->newDrawable(thingTemplate);
 				if (draw) {
 					draw->setOrientation(angle);
 					draw->setPosition( &pos );
@@ -1887,8 +1887,7 @@ void GameLogic::startNewGame( Bool loadingSaveGame )
 			if (thingTemplate->isKindOf(KINDOF_OPTIMIZED_TREE)) {
 				// Opt trees and props just get drawables to tell the client about it, then deleted. jba [6/5/2003]
 				// This way there is no logic object to slow down partition manager and core logic stuff.
-
-				Drawable *draw = TheThingFactory->newDrawable(thingTemplate, DRAWABLE_STATUS_NONE);
+				Drawable *draw = TheThingFactory->newDrawable(thingTemplate);
 				if (draw) {
 					draw->setOrientation(angle);
 					draw->setPosition( &pos );

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DGameClient.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DGameClient.h
@@ -78,7 +78,7 @@ public:
 	virtual ~W3DGameClient();
 
 	/// given a type, create a drawable
-	virtual Drawable *friend_createDrawable( const ThingTemplate *thing, DrawableStatus statusBits = DRAWABLE_STATUS_NONE );
+	virtual Drawable *friend_createDrawable( const ThingTemplate *thing, DrawableStatusInt statusBits = DRAWABLE_STATUS_DEFAULT );
 
 	virtual void init( void );		///< initialize resources
 	virtual void update( void );  ///< per frame update

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DGameClient.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DGameClient.cpp
@@ -115,7 +115,7 @@ void W3DGameClient::reset( void )
 	* in the GameLogic and GameClient themselves */
 //-------------------------------------------------------------------------------------------------
 Drawable *W3DGameClient::friend_createDrawable( const ThingTemplate *tmplate,
-																								DrawableStatus statusBits )
+																								DrawableStatusInt statusBits )
 {
 	Drawable *draw = NULL;
 


### PR DESCRIPTION
**Merge with Rebase**

This change fixes the initial shadow states of draw modules and implicitly removes shadows from build preview objects.

While inspecting rendering issues I noticed that the shadows on build placement preview objects look a bit bad.

## Shadows on build placement preview objects

![shot_20250914_123146_1](https://github.com/user-attachments/assets/32e36ace-9460-4f1a-9e2f-1b419674f0ec)

![shot_20250914_123158_2](https://github.com/user-attachments/assets/b7c321ff-b61f-4098-b6fc-1647377f0702)

After investigating model shadow settings, I noticed that the model shadows in drawables are not correctly initialized: Even if a Drawable, such as the build placement preview object, is created without shadows, it will draw shadows.

The constructor of `W3DModelDraw` sets `m_shadowEnabled = TRUE` and ignores the `DRAWABLE_STATUS_SHADOWS` of the owning Drawable object. Pretty much all objects got initialized without shadows, but have shadows enabled on the first update during game start.

Accordingly, I streamlined the implementation and made the shadow initialization consistent. As a result, the build placement preview object no longer casts shadow.

## With Shadow

![shot_20250914_190933_1](https://github.com/user-attachments/assets/b23f4c35-6237-42b8-b816-f70292239967)

## Without Shadow

![shot_20250914_185404_2](https://github.com/user-attachments/assets/b78a1af7-3c4b-4b1c-9d9c-2240a15e6b2a)

Without shadow, the object is far less visible than before, because the shadow does give it additional contrast.

To compensate, I adjusted the opacity value from 0.45 to 0.60.

## Without Shadow and 0.60 opacity

![shot_20250914_191345_1](https://github.com/user-attachments/assets/8c4fde24-4c00-41c4-9279-1a565a0ad637)

![shot_20250914_192209_2](https://github.com/user-attachments/assets/78d2341c-19ad-4731-b691-f0c8f6d426d9)

If we want the shadow to remain, then we can adjust the flag and revert the opacity change.

## TODO

- [ ] Replicate in Generals
- [ ] Add pull id to commits