### PR TITLE
bugfix(fps): Fix and improve logic time step and render update decoupling 2

### DIFF
--- a/Core/Libraries/Source/WWVegas/WW3D2/hanim.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/hanim.h
@@ -95,11 +95,7 @@ public:
 	virtual float				Get_Frame_Rate() = 0;
 	virtual float				Get_Total_Time() = 0;
 
-//	virtual Vector3			Get_Translation(int pividx,float frame) = 0;
-//	virtual Quaternion		Get_Orientation(int pividx,float frame) = 0;
 	// Jani: Changed to pass in reference of destination to avoid copying
-	virtual void				Get_Translation(int pividx,float frame) {}	// todo: remove
-	virtual void				Get_Orientation(int pividx,float frame) {}	// todo: remove
 	virtual void				Get_Translation(Vector3& translation, int pividx,float frame) const = 0;
 	virtual void				Get_Orientation(Quaternion& orientation, int pividx,float frame) const = 0;
 	virtual void				Get_Transform(Matrix3D&, int pividx, float frame) const = 0;

--- a/Core/Libraries/Source/WWVegas/WW3D2/hcanim.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/hcanim.h
@@ -93,8 +93,6 @@ public:
 	float							Get_Total_Time() { return (float)NumFrames / FrameRate; }
 	int							Get_Flavor() { return Flavor; }
 
-//	Vector3						Get_Translation(int pividx,float frame);
-//	Quaternion					Get_Orientation(int pividx,float frame);
 	void							Get_Translation(Vector3& translation, int pividx,float frame) const;
 	void							Get_Orientation(Quaternion& orientation, int pividx,float frame) const;
 	void							Get_Transform(Matrix3D& transform, int pividx,float frame) const;

--- a/Core/Libraries/Source/WWVegas/WW3D2/htree.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/htree.cpp
@@ -62,6 +62,7 @@
 #include "wwmemlog.h"
 #include "hrawanim.h"
 #include "motchan.h"
+#include "ww3d.h"
 
 /***********************************************************************************************
  * HTreeClass::HTreeClass -- constructor                                                       *
@@ -606,8 +607,16 @@ void HTreeClass::Anim_Update(const Matrix3D & root,HAnimClass * motion,float fra
 
 /*Customized version of the above which excludes interpolation and assumes HRawAnimClass
 For use by 'Generals' -MW*/
-void HTreeClass::Anim_Update(const Matrix3D & root,HRawAnimClass * motion,float frame)
+void HTreeClass::Anim_Update_Without_Interpolation(const Matrix3D & root,HRawAnimClass * motion,float frame)
 {
+	if (WW3D::Get_Sync_Frame_Time() == 0 && (int)motion->Get_Frame_Rate() == WWSyncPerSecond)
+	{
+		// TheSuperHackers @tweak Keep the animation frame step in sync with the ww3d frame step if they can align.
+		// @todo This needs improving if the WWSyncPerSecond is changed or the animation frame rates can be larger.
+		static_assert(WWSyncPerSecond == 30, "This is currently catered to a 30 fps sync");
+		return;
+	}
+
 	PivotClass *pivot,*endpivot,*lastAnimPivot;
 
 	Pivot[0].Transform = root;

--- a/Core/Libraries/Source/WWVegas/WW3D2/htree.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/htree.h
@@ -100,7 +100,7 @@ public:
 	void					Anim_Update(		const Matrix3D &		root,
 													HAnimClass *			motion,
 													float						frame);
-	void					Anim_Update(const Matrix3D & root,HRawAnimClass * motion,float frame);
+	void					Anim_Update_Without_Interpolation(const Matrix3D & root,HRawAnimClass * motion,float frame);
 
 	void					Blend_Update(		const Matrix3D &		root,
 													HAnimClass *			motion0,

--- a/Core/Libraries/Source/WWVegas/WW3D2/ringobj.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/ringobj.cpp
@@ -1150,7 +1150,7 @@ void RingRenderObjClass::animate()
 			// Convert from milliseconds to seconds and normalize the time
 			//
 			if (AnimDuration > 0) {
-				float	frametime = WW3D::Get_Frame_Time();
+				float	frametime = WW3D::Get_Sync_Frame_Time();
 				frametime = (frametime * 0.001F) / AnimDuration;
 				anim_time += frametime;
 			} else {

--- a/Core/Libraries/Source/WWVegas/WW3D2/ringobj.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/ringobj.cpp
@@ -1146,13 +1146,9 @@ void RingRenderObjClass::animate()
 				InnerScaleChannel.Get_Key_Count () > 0 ||
 				OuterScaleChannel.Get_Key_Count () > 0)
 		{
-			//
-			// Convert from milliseconds to seconds and normalize the time
-			//
 			if (AnimDuration > 0) {
-				float	frametime = WW3D::Get_Sync_Frame_Time();
-				frametime = (frametime * 0.001F) / AnimDuration;
-				anim_time += frametime;
+				float frametime = WW3D::Get_Logic_Frame_Time_Seconds();
+				anim_time += frametime / AnimDuration;
 			} else {
 				anim_time = 1.0F;
 			}

--- a/Core/Libraries/Source/WWVegas/WW3D2/seglinerenderer.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/seglinerenderer.cpp
@@ -78,7 +78,6 @@ SegLineRendererClass::SegLineRendererClass(void) :
 		NoiseAmplitude(0.0f),
 		MergeAbortFactor(1.5f),
 		TextureTileFactor(1.0f),
-		LastUsedSyncTime(WW3D::Get_Sync_Time()),
 		CurrentUVOffset(0.0f,0.0f),
 		UVOffsetDeltaPerMS(0.0f, 0.0f),
 		Bits(DEFAULT_BITS),
@@ -98,7 +97,6 @@ SegLineRendererClass::SegLineRendererClass(const SegLineRendererClass & that) :
 		NoiseAmplitude(0.0f),
 		MergeAbortFactor(1.5f),
 		TextureTileFactor(1.0f),
-		LastUsedSyncTime(that.LastUsedSyncTime),
 		CurrentUVOffset(0.0f,0.0f),
 		UVOffsetDeltaPerMS(0.0f, 0.0f),
 		Bits(DEFAULT_BITS),
@@ -120,7 +118,6 @@ SegLineRendererClass & SegLineRendererClass::operator = (const SegLineRendererCl
 		NoiseAmplitude = that.NoiseAmplitude;
 		MergeAbortFactor = that.MergeAbortFactor;
 		TextureTileFactor = that.TextureTileFactor;
-		LastUsedSyncTime = that.LastUsedSyncTime;
 		CurrentUVOffset = that.CurrentUVOffset;
 		UVOffsetDeltaPerMS = that.UVOffsetDeltaPerMS;
 		Bits = that.Bits;
@@ -201,7 +198,6 @@ void SegLineRendererClass::Set_Texture_Tile_Factor(float factor)
 
 void SegLineRendererClass::Reset_Line(void)
 {
-	LastUsedSyncTime = WW3D::Get_Sync_Time();
 	CurrentUVOffset.Set(0.0f,0.0f);
 }
 
@@ -227,9 +223,8 @@ void SegLineRendererClass::Render
 	/*
 	** Handle texture UV offset animation (done once for entire line).
 	*/
-	unsigned int delta = WW3D::Get_Sync_Time() - LastUsedSyncTime;
-	float del = (float)delta;
-	Vector2 uv_offset = CurrentUVOffset + UVOffsetDeltaPerMS * del;
+	// TheSuperHackers @tweak The render update is now decoupled from the logic step.
+	Vector2 uv_offset = CurrentUVOffset + UVOffsetDeltaPerMS * WW3D::Get_Logic_Frame_Time_Milliseconds();
 
 	// ensure offsets are in [0, 1] range:
 	uv_offset.X = uv_offset.X - floorf(uv_offset.X);
@@ -237,7 +232,6 @@ void SegLineRendererClass::Render
 
 	// Update state
 	CurrentUVOffset = uv_offset;
-	LastUsedSyncTime = WW3D::Get_Sync_Time();
 
 	// Used later
 	TextureMapMode map_mode = Get_Texture_Mapping_Mode();

--- a/Core/Libraries/Source/WWVegas/WW3D2/sphereobj.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/sphereobj.cpp
@@ -1104,13 +1104,9 @@ void SphereRenderObjClass::animate (void)
 				ScaleChannel.Get_Key_Count () > 0 ||
 				VectorChannel.Get_Key_Count () > 0)
 		{
-			//
-			// Convert from milliseconds to seconds and normalize the time
-			//
 			if (AnimDuration > 0) {
-				float	frametime = WW3D::Get_Sync_Frame_Time();
-				frametime = (frametime * 0.001F) / AnimDuration;
-				anim_time += frametime;
+				float frametime = WW3D::Get_Logic_Frame_Time_Seconds();
+				anim_time += frametime / AnimDuration;
 			} else {
 				anim_time = 1.0F;
 			}

--- a/Core/Libraries/Source/WWVegas/WW3D2/sphereobj.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/sphereobj.cpp
@@ -1108,7 +1108,7 @@ void SphereRenderObjClass::animate (void)
 			// Convert from milliseconds to seconds and normalize the time
 			//
 			if (AnimDuration > 0) {
-				float	frametime = WW3D::Get_Frame_Time();
+				float	frametime = WW3D::Get_Sync_Frame_Time();
 				frametime = (frametime * 0.001F) / AnimDuration;
 				anim_time += frametime;
 			} else {

--- a/Core/Libraries/Source/WWVegas/WWLib/WWCommon.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/WWCommon.h
@@ -26,6 +26,12 @@
 #define ARRAY_SIZE(x) int(sizeof(x)/sizeof(x[0]))
 #endif
 
+enum
+{
+	// TheSuperHackers @info The original WWSync was 33 ms, ~30 fps, integer.
+	// Changing this will require tweaking all Drawable code that concerns the ww3d time step, including locomotion physics.
+	WWSyncPerSecond = 30
+};
 
 #if defined(_MSC_VER) && _MSC_VER < 1300
 typedef unsigned MemValueType;

--- a/Core/Libraries/Source/WWVegas/WWLib/WWDefines.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/WWDefines.h
@@ -17,3 +17,12 @@
 */
 
 #pragma once
+
+// Enable translation and rotation interpolation for raw animation (HRawAnimClass) updates.
+// This was intentionally disabled in the retail version, but likely not fully thought through.
+// Interpolation is certainly desired for animations that move and rotate meshes, but may not be
+// desired for animations that teleport meshes from one location to another, such as blinking lights.
+// @todo Implement a new flag per animation file to opt-out of interpolation.
+#ifndef WW3D_ENABLE_RAW_ANIM_INTERPOLATION
+#define WW3D_ENABLE_RAW_ANIM_INTERPOLATION (1)
+#endif

--- a/Core/Libraries/Source/WWVegas/WWLib/WWDefines.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/WWDefines.h
@@ -17,9 +17,3 @@
 */
 
 #pragma once
-
-// The WW3D Sync time. This was originally 33 ms, ~30 fps, integer.
-// Changing or removing this will require tweaking all Drawable code that concerns logic time step, including locomotion physics.
-#ifndef MSEC_PER_WWSYNC_FRAME
-#define MSEC_PER_WWSYNC_FRAME (33)
-#endif

--- a/Core/Tools/W3DView/GraphicView.cpp
+++ b/Core/Tools/W3DView/GraphicView.cpp
@@ -546,7 +546,7 @@ CGraphicView::RepaintView
 		//
 		//	Let the audio class think
 		//
-		WWAudioClass::Get_Instance ()->On_Frame_Update (WW3D::Get_Sync_Frame_Time());
+		WWAudioClass::Get_Instance ()->On_Frame_Update (WW3D::Get_Logic_Frame_Time_Milliseconds());
 
 		//
 		//	Update the count of particles and polys in the status bar

--- a/Core/Tools/W3DView/GraphicView.cpp
+++ b/Core/Tools/W3DView/GraphicView.cpp
@@ -546,7 +546,7 @@ CGraphicView::RepaintView
 		//
 		//	Let the audio class think
 		//
-		WWAudioClass::Get_Instance ()->On_Frame_Update (WW3D::Get_Frame_Time());
+		WWAudioClass::Get_Instance ()->On_Frame_Update (WW3D::Get_Sync_Frame_Time());
 
 		//
 		//	Update the count of particles and polys in the status bar

--- a/Generals/Code/GameEngine/Include/Common/GameCommon.h
+++ b/Generals/Code/GameEngine/Include/Common/GameCommon.h
@@ -66,7 +66,7 @@
 enum
 {
 	BaseFps = 30, // The historic base frame rate for this game. This value must never change.
-	LOGICFRAMES_PER_SECOND = 30,
+	LOGICFRAMES_PER_SECOND = WWSyncPerSecond,
 	MSEC_PER_SECOND = 1000
 };
 const Real LOGICFRAMES_PER_MSEC_REAL = (((Real)LOGICFRAMES_PER_SECOND) / ((Real)MSEC_PER_SECOND));

--- a/Generals/Code/GameEngine/Include/GameClient/Drawable.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Drawable.h
@@ -168,7 +168,7 @@ public:
 	TintEnvelope(void);
 	void update(void);  ///< does all the work
 	void play(const RGBColor *peak,
-						UnsignedInt atackFrames = DEF_ATTACK_FRAMES,
+						UnsignedInt attackFrames = DEF_ATTACK_FRAMES,
 						UnsignedInt decayFrames = DEF_DECAY_FRAMES,
 						UnsignedInt sustainAtPeak = DEF_SUSTAIN_FRAMES ); // ask MLorenzen
 	void sustain(void) { m_envState = ENVELOPE_STATE_SUSTAIN; }
@@ -231,7 +231,6 @@ enum DrawableStatus CPP_11(: DrawableStatusBits)
 	DRAWABLE_STATUS_NONE									= 0x00000000,		///< no status
 	DRAWABLE_STATUS_DRAWS_IN_MIRROR				=	0x00000001,		///< drawable can reflect
 	DRAWABLE_STATUS_SHADOWS								=	0x00000002,		///< use setShadowsEnabled() access method
-	DRAWABLE_STATUS_TINT_COLOR_LOCKED			=	0x00000004,		///< drawable tint color is "locked" and won't fade to normal
 	DRAWABLE_STATUS_NO_STATE_PARTICLES		= 0x00000008,		///< do *not* auto-create particle systems based on model condition
 	DRAWABLE_STATUS_NO_SAVE								= 0x00000010,		///< do *not* save this drawable (UI fluff only). ignored (error, actually) if attached to an object
 
@@ -372,7 +371,7 @@ public:
 
 	Bool getDrawsInMirror() const { return BitIsSet(m_status, DRAWABLE_STATUS_DRAWS_IN_MIRROR) || isKindOf(KINDOF_CAN_CAST_REFLECTIONS); }
 
-	void colorFlash( const RGBColor *color, UnsignedInt decayFrames = DEF_DECAY_FRAMES, UnsignedInt attackFrames = 0, UnsignedInt sustainAtPeak = FALSE );  ///< flash a drawable in the color specified for a short time
+	void colorFlash( const RGBColor *color, UnsignedInt decayFrames = DEF_DECAY_FRAMES, UnsignedInt attackFrames = 0, UnsignedInt sustainAtPeak = 0 );  ///< flash a drawable in the color specified for a short time
 	void colorTint( const RGBColor *color );	 ///< tint this drawable the color specified
 	void setTintEnvelope( const RGBColor *color, Real attack, Real decay );	 ///< how to transition color
 	void flashAsSelected( const RGBColor *color = NULL ); ///< drawable takes care of the details if you spec no color

--- a/Generals/Code/GameEngine/Include/GameLogic/GameLogic.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/GameLogic.h
@@ -133,6 +133,7 @@ public:
 	Real getHeight( void );													///< Returns the height of the world
 
 	Bool isInGameLogicUpdate( void ) const { return m_isInUpdate; }
+	Bool hasUpdated() const { return m_hasUpdated; } ///< Returns true if the logic frame has advanced in the current client/render update
 	UnsignedInt getFrame( void );										///< Returns the current simulation frame number
 	UnsignedInt getCRC( Int mode = CRC_CACHED, AsciiString deepCRCFileName = AsciiString::TheEmptyString );		///< Returns the CRC
 
@@ -301,6 +302,7 @@ private:
 	Bool m_loadingScene;
 
 	Bool m_isInUpdate;
+	Bool m_hasUpdated;
 
 	Int m_rankPointsToAddAtGameStart;
 

--- a/Generals/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -255,7 +255,7 @@ GameEngine::GameEngine( void )
 	// initialize to non garbage values
 	m_maxFPS = BaseFps;
 	m_logicTimeScaleFPS = LOGICFRAMES_PER_SECOND;
-	m_updateTime = 0.0f;
+	m_updateTime = 1.0f / BaseFps; // initialized to something to avoid division by zero on first use
 	m_logicTimeAccumulator = 0.0f;
 	m_quitting = FALSE;
 	m_isActive = FALSE;

--- a/Generals/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -1264,7 +1264,7 @@ void Drawable::applyPhysicsXform(Matrix3D* mtx)
 	{
 		// TheSuperHackers @tweak Update the physics transform on every WW Sync only.
 		// All calculations are originally catered to a 30 fps logic step.
-		if (WW3D::Get_Frame_Time() != 0)
+		if (WW3D::Get_Sync_Frame_Time() != 0)
 		{
 			calcPhysicsXform(*m_physicsXform);
 		}

--- a/Generals/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -922,9 +922,6 @@ void Drawable::colorFlash( const RGBColor* color, UnsignedInt decayFrames, Unsig
 		white.setFromInt(0xffffffff);
 		m_colorTintEnvelope->play( &white );
 	}
-
-	// make sure the tint color is unlocked so we "fade back down" to normal
-	clearDrawableStatus( DRAWABLE_STATUS_TINT_COLOR_LOCKED );
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -935,11 +932,7 @@ void Drawable::colorTint( const RGBColor* color )
 	if( color )
 	{
 		// set the color via color flash
-		colorFlash( color, 0, 0, TRUE );
-
-		// lock the tint color so the flash never "fades back down"
-		setDrawableStatus( DRAWABLE_STATUS_TINT_COLOR_LOCKED );
-
+		colorFlash( color, 0, 0, ~0u );
 	}
 	else
 	{
@@ -948,10 +941,6 @@ void Drawable::colorTint( const RGBColor* color )
 
 		// remove the tint applied to the object
 		m_colorTintEnvelope->rest();
-
-		// set the tint as unlocked so we can flash and stuff again
-		clearDrawableStatus( DRAWABLE_STATUS_TINT_COLOR_LOCKED );
-
 	}
 
 }
@@ -4756,11 +4745,11 @@ TintEnvelope::TintEnvelope(void)
 const Real FADE_RATE_EPSILON = (0.001f);
 
 //-------------------------------------------------------------------------------------------------
-void TintEnvelope::play(const RGBColor *peak, UnsignedInt atackFrames, UnsignedInt decayFrames, UnsignedInt sustainAtPeak )
+void TintEnvelope::play(const RGBColor *peak, UnsignedInt attackFrames, UnsignedInt decayFrames, UnsignedInt sustainAtPeak )
 {
 	setPeakColor( peak );
 
-	setAttackFrames( atackFrames );
+	setAttackFrames( attackFrames );
 	setDecayFrames( decayFrames );
 
 	m_envState = ENVELOPE_STATE_ATTACK;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/EMPUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/EMPUpdate.cpp
@@ -147,7 +147,7 @@ UpdateSleepTime EMPUpdate::update( void )
 	{
 		RGBColor end = data->m_endColor;
 		saturateRGB( end, 5 );
-		dr->colorFlash( &end, 9999, m_tintEnvFadeFrames, TRUE );
+		dr->colorFlash( &end, 0, m_tintEnvFadeFrames, ~0u );
 		doDisableAttack();
 	}
 

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -226,6 +226,7 @@ GameLogic::GameLogic( void )
 	//
 
 	m_frame = 0;
+	m_hasUpdated = FALSE;
 	m_frameObjectsChangedTriggerAreas = 0;
 	m_width = 0;
 	m_height = 0;
@@ -256,6 +257,7 @@ GameLogic::GameLogic( void )
 void GameLogic::setDefaults( Bool saveGame )
 {
 	m_frame = 0;
+	m_hasUpdated = FALSE;
 	m_width = DEFAULT_WORLD_WIDTH;
 	m_height = DEFAULT_WORLD_HEIGHT;
 	m_objList = NULL;
@@ -1020,6 +1022,7 @@ void GameLogic::startNewGame( Bool saveGame )
 
 	// reset the frame counter
 	m_frame = 0;
+	m_hasUpdated = FALSE;
 
 #ifdef DEBUG_CRC
 	// TheSuperHackers @info helmutbuhler 04/09/2025
@@ -3327,6 +3330,7 @@ void GameLogic::update( void )
 	if (!m_startNewGame)
 	{
 		m_frame++;
+		m_hasUpdated = TRUE;
 	}
 }
 
@@ -3334,6 +3338,8 @@ void GameLogic::update( void )
 // ------------------------------------------------------------------------------------------------
 void GameLogic::preUpdate()
 {
+	m_hasUpdated = FALSE;
+
 	if (m_pauseFrame == m_frame && m_pauseFrame != 0)
 	{
 		m_pauseFrame = 0;

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/HeightMap.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/HeightMap.h
@@ -180,7 +180,6 @@ public:
 
 	void renderTerrainPass(CameraClass *pCamera);	///< renders additional terrain pass.
 	W3DShroud *getShroud()	{return m_shroud;}
-	void renderExtraBlendTiles(void);			///< render 3-way blend tiles that have blend of 3 textures.
 	void updateShorelineTiles(Int minX, Int minY, Int maxX, Int maxY, WorldHeightMap *pMap);	///<figure out which tiles on this map cross water plane
 	void updateViewImpassableAreas(Bool partial = FALSE, Int minX = 0, Int maxX = 0, Int minY = 0, Int maxY = 0);
 	void clearAllScorches(void);
@@ -320,6 +319,9 @@ protected:
 	AABoxClass & getTileBoundingBox(AABoxClass *aabox, Int x, Int y);	///<Vertex buffer bounding box
 	void initDestAlphaLUT(void);	///<initialize water depth LUT stored in m_destAlphaTexture
 	void renderShoreLines(CameraClass *pCamera);	///<re-render parts of terrain that need custom blending into water edge
+	void renderExtraBlendTiles(void);	///< render 3-way blend tiles that have blend of 3 textures.
+
+	static Bool useCloud();
 };
 
 extern HeightMapRenderObjClass *TheTerrainRenderObject;

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DShaderManager.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DShaderManager.h
@@ -75,6 +75,8 @@ public:
 	W3DShaderManager(void);	///<constructor
 	static void init( void );	///<determine optimal shaders for current device.
 	static void shutdown(void);	///<release resources used by shaders
+	static void updateCloud();	///<update the cloud position once every render frame.
+
 	static ChipsetType getChipset(void);	///<return current device chipset.
 	static Int getShaderPasses(ShaderTypes shader);	///<rendering passes required for shader
 	static Int setShader(ShaderTypes shader, Int pass);	///<enable specific shader pass.

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankDraw.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankDraw.cpp
@@ -312,7 +312,7 @@ void W3DTankDraw::doDrawModule(const Matrix3D* transformMtx)
 {
 	// TheSuperHackers @tweak Update the draw on every WW Sync only.
 	// All calculations are originally catered to a 30 fps logic step.
-	if (WW3D::Get_Frame_Time() == 0)
+	if (WW3D::Get_Sync_Frame_Time() == 0)
 		return;
 
 	const Real DEBRIS_THRESHOLD = 0.00001f;

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankDraw.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankDraw.cpp
@@ -310,6 +310,8 @@ void W3DTankDraw::onRenderObjRecreated(void)
 //-------------------------------------------------------------------------------------------------
 void W3DTankDraw::doDrawModule(const Matrix3D* transformMtx)
 {
+	W3DModelDraw::doDrawModule(transformMtx);
+
 	// TheSuperHackers @tweak Update the draw on every WW Sync only.
 	// All calculations are originally catered to a 30 fps logic step.
 	if (WW3D::Get_Sync_Frame_Time() == 0)
@@ -405,8 +407,6 @@ void W3DTankDraw::doDrawModule(const Matrix3D* transformMtx)
 			}
 		}
 	}
-
-	W3DModelDraw::doDrawModule(transformMtx);
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankTruckDraw.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankTruckDraw.cpp
@@ -517,7 +517,7 @@ void W3DTankTruckDraw::doDrawModule(const Matrix3D* transformMtx)
 
 	// TheSuperHackers @tweak Update the draw on every WW Sync only.
 	// All calculations are originally catered to a 30 fps logic step.
-	if (WW3D::Get_Frame_Time() == 0)
+	if (WW3D::Get_Sync_Frame_Time() == 0)
 		return;
 
 	const Real ACCEL_THRESHOLD = 0.01f;

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTruckDraw.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTruckDraw.cpp
@@ -395,7 +395,7 @@ void W3DTruckDraw::doDrawModule(const Matrix3D* transformMtx)
 
 	// TheSuperHackers @tweak Update the draw on every WW Sync only.
 	// All calculations are originally catered to a 30 fps logic step.
-	if (WW3D::Get_Frame_Time() == 0)
+	if (WW3D::Get_Sync_Frame_Time() == 0)
 		return;
 
 	const Real ACCEL_THRESHOLD = 0.01f;

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/HeightMap.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/HeightMap.cpp
@@ -3815,7 +3815,14 @@ void HeightMapRenderObjClass::Render(RenderInfoClass & rinfo)
 
 	Int i,j,devicePasses;
 	W3DShaderManager::ShaderTypes st;
-	Bool doCloud = TheGlobalData->m_useCloudMap;
+	const Bool doCloud = useCloud();
+
+	if (doCloud)
+	{
+		// TheSuperHackers @tweak Updates the cloud movement before applying it to the world.
+		// Is now decoupled from logic step.
+		W3DShaderManager::updateCloud();
+	}
 
 	Matrix3D tm(Transform);
 #if 0 // There is some weirdness sometimes with the dx8 static buffers.
@@ -3905,10 +3912,6 @@ void HeightMapRenderObjClass::Render(RenderInfoClass & rinfo)
 	{
 		DX8Wrapper::Set_Material(m_vertexMaterialClass);
 		DX8Wrapper::Set_Shader(m_shaderClass);
-
-		if (TheGlobalData->m_timeOfDay == TIME_OF_DAY_NIGHT) {
-			doCloud = false;
-		}
 
  		st=W3DShaderManager::ST_TERRAIN_BASE; //set default shader
 
@@ -4454,10 +4457,7 @@ void HeightMapRenderObjClass::renderExtraBlendTiles(void)
 
 			W3DShaderManager::ShaderTypes st = W3DShaderManager::ST_ROAD_BASE;
 
-			Bool doCloud = TheGlobalData->m_useCloudMap;
-			if (TheGlobalData->m_timeOfDay == TIME_OF_DAY_NIGHT) {
-				doCloud = false;
-			}
+			const Bool doCloud = useCloud();
 
 			if (TheGlobalData->m_useLightMap && doCloud)
  			{
@@ -4485,4 +4485,10 @@ void HeightMapRenderObjClass::renderExtraBlendTiles(void)
 			W3DShaderManager::resetShader(st);
 		}
   }
+}
+
+//=============================================================================
+Bool HeightMapRenderObjClass::useCloud()
+{
+	return TheGlobalData->m_useCloudMap && TheGlobalData->m_timeOfDay != TIME_OF_DAY_NIGHT;
 }

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -1733,6 +1733,10 @@ AGAIN:
 
 	WW3D::Update_Logic_Frame_Time(TheGameEngine->getLogicTimeStepMilliseconds());
 
+	// TheSuperHackers @info This binds the WW3D update to the logic update. This was originally 33 ms, ~30 fps, integer.
+	// Changing this will require tweaking all Drawable code that concerns the ww3d time step, including locomotion physics.
+	WW3D::Sync(TheGameLogic->hasUpdated());
+
 	static Int now;
 	now=timeGetTime();
 

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -1731,7 +1731,7 @@ AGAIN:
 		}
 	}
 
-	WW3D::Add_Frame_Time(TheGameEngine->getLogicTimeStepMilliseconds());
+	WW3D::Update_Logic_Frame_Time(TheGameEngine->getLogicTimeStepMilliseconds());
 
 	static Int now;
 	now=timeGetTime();

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -1733,8 +1733,7 @@ AGAIN:
 
 	WW3D::Update_Logic_Frame_Time(TheGameEngine->getLogicTimeStepMilliseconds());
 
-	// TheSuperHackers @info This binds the WW3D update to the logic update. This was originally 33 ms, ~30 fps, integer.
-	// Changing this will require tweaking all Drawable code that concerns the ww3d time step, including locomotion physics.
+	// TheSuperHackers @info This binds the WW3D update to the logic update.
 	WW3D::Sync(TheGameLogic->hasUpdated());
 
 	static Int now;

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/animobj.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/animobj.cpp
@@ -941,18 +941,20 @@ float Animatable3DObjClass::Compute_Current_Frame(float *newDirection) const
 				//
 				//	Wrap the frame
 				//
+				const int numFrames = ModeAnim.Motion->Get_Num_Frames() - 1;
+
 				switch (ModeAnim.AnimMode)
 				{
 					case ANIM_MODE_ONCE:
-						if (frame >= ModeAnim.Motion->Get_Num_Frames() - 1) {
-							frame = ModeAnim.Motion->Get_Num_Frames() - 1;
+						if (frame >= numFrames) {
+							frame = numFrames;
 						}
 						break;
 					case ANIM_MODE_LOOP:
-						if ( frame >= ModeAnim.Motion->Get_Num_Frames() - 1 ) {
-							frame -= ModeAnim.Motion->Get_Num_Frames() - 1;
+						if ( frame >= numFrames ) {
+							frame -= numFrames;
 							// If it is still too far out, reset
-							if ( frame >= ModeAnim.Motion->Get_Num_Frames() - 1 ) {
+							if ( frame >= numFrames ) {
 								frame = 0;
 							}
 						}
@@ -964,22 +966,22 @@ float Animatable3DObjClass::Compute_Current_Frame(float *newDirection) const
 						break;
 					case ANIM_MODE_LOOP_BACKWARDS:	//play animation backwards in a loop
 						if ( frame < 0 ) {
-							frame += ModeAnim.Motion->Get_Num_Frames() - 1;
+							frame += numFrames;
 							// If it is still too far out, reset
 							if ( frame < 0 ) {
-								frame = ModeAnim.Motion->Get_Num_Frames() - 1;
+								frame = numFrames;
 							}
 						}
 						break;
 					case ANIM_MODE_LOOP_PINGPONG:
 						if (ModeAnim.animDirection >= 1.0f)
 						{	//playing forwards, reverse direction
-							if (frame >= (ModeAnim.Motion->Get_Num_Frames() - 1))
+							if (frame >= numFrames)
 							{	//step backwards in animation by excess time
-								frame = (ModeAnim.Motion->Get_Num_Frames() - 1)*2 - frame;
+								frame = numFrames * 2 - frame;
 								// If it is still too far out, reset
-								if ( frame >= ModeAnim.Motion->Get_Num_Frames() - 1 )
-									frame = (ModeAnim.Motion->Get_Num_Frames() - 1);
+								if ( frame >= numFrames - 1 )
+									frame = numFrames;
 								direction = ModeAnim.animDirection * -1.0f;
 							}
 						}
@@ -989,7 +991,7 @@ float Animatable3DObjClass::Compute_Current_Frame(float *newDirection) const
 							{	//step forwards in animation by excess time
 								frame = -frame;
 								// If it is still too far out, reset
-								if ( frame >= ModeAnim.Motion->Get_Num_Frames() - 1 )
+								if ( frame >= numFrames )
 										frame = 0;
 								direction = ModeAnim.animDirection * -1.0f;
 							}

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/animobj.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/animobj.cpp
@@ -289,12 +289,6 @@ void Animatable3DObjClass::Render(RenderInfoClass & rinfo)
 		return;
 	}
 
-	if ( CurMotionMode == SINGLE_ANIM ) {
-		if ( ModeAnim.AnimMode != ANIM_MODE_MANUAL ) {
-			Single_Anim_Progress();
-		}
-	}
-
 	if (!Is_Hierarchy_Valid() || Are_Sub_Object_Transforms_Dirty()) {
 		Update_Sub_Object_Transforms();
 	}
@@ -315,12 +309,6 @@ void Animatable3DObjClass::Render(RenderInfoClass & rinfo)
 void Animatable3DObjClass::Special_Render(SpecialRenderInfoClass & rinfo)
 {
 	if (HTree == NULL) return;
-
-	if ( CurMotionMode == SINGLE_ANIM ) {
-		if ( ModeAnim.AnimMode != ANIM_MODE_MANUAL ) {
-			Single_Anim_Progress();
-		}
-	}
 
 	if (!Is_Hierarchy_Valid()) {
 		Update_Sub_Object_Transforms();
@@ -1043,19 +1031,12 @@ void Animatable3DObjClass::Single_Anim_Progress (void)
 		//
 		// Update the frame number and sync time
 		//
-		float oldprev = ModeAnim.PrevFrame;
 		ModeAnim.PrevFrame		= ModeAnim.Frame;
 		ModeAnim.Frame				= Compute_Current_Frame(&ModeAnim.animDirection);
 		ModeAnim.LastSyncTime	= WW3D::Get_Sync_Time();
 
-		if (ModeAnim.Frame == ModeAnim.PrevFrame) {
-			// This function was somehow called twice per frame.
-			// Since ModeAnim.Frame hasn't changed, reset the ModeAnim.PrevFrame.
-			// If you don't do this sounds won't be triggered properly because Frame and PrevFrame will be the same.
-			ModeAnim.PrevFrame = oldprev;
-		}
 		//
-		// Force the heirarchy to be recalculated
+		// Force the hierarchy to be recalculated
 		//
 		Set_Hierarchy_Valid (false);
 	}

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/animobj.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/animobj.h
@@ -190,7 +190,6 @@ protected:
 			float		  				Frame;
 			float						PrevFrame;
 			int						AnimMode;
-			mutable int				LastSyncTime;
 			float							animDirection;
 			float							frameRateMultiplier;	// 020607 srj -- added
 		} ModeAnim;

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/animobj.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/animobj.h
@@ -261,8 +261,8 @@ inline void Animatable3DObjClass::Anim_Update(const Matrix3D & root,HAnimClass *
 	** Apply motion to the base pose
 	*/
 	if ((motion) && (HTree)) {
-		if (ModeAnim.Motion->Class_ID() == HAnimClass::CLASSID_HRAWANIM)
-			HTree->Anim_Update(Transform,(HRawAnimClass*)ModeAnim.Motion,ModeAnim.Frame);
+		if (motion->Class_ID() == HAnimClass::CLASSID_HRAWANIM)
+			HTree->Anim_Update(root,(HRawAnimClass*)motion,frame);
 		else
 			HTree->Anim_Update(root,motion,frame);
 	}

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/animobj.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/animobj.h
@@ -261,9 +261,11 @@ inline void Animatable3DObjClass::Anim_Update(const Matrix3D & root,HAnimClass *
 	** Apply motion to the base pose
 	*/
 	if ((motion) && (HTree)) {
+#if !WW3D_ENABLE_RAW_ANIM_INTERPOLATION
 		if (motion->Class_ID() == HAnimClass::CLASSID_HRAWANIM)
-			HTree->Anim_Update(root,(HRawAnimClass*)motion,frame);
+			HTree->Anim_Update_Without_Interpolation(root,(HRawAnimClass*)motion,frame);
 		else
+#endif
 			HTree->Anim_Update(root,motion,frame);
 	}
 	Set_Hierarchy_Valid(true);

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dazzle.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dazzle.cpp
@@ -940,7 +940,7 @@ void DazzleRenderObjClass::Render(RenderInfoClass & rinfo)
 			const DazzleTypeClass* params=types[type];
 			params->Calculate_Intensities(dazzle_intensity,dazzle_size,current_halo_intensity,camera_dir,current_dir,current_distance);
 
-			unsigned time_ms=WW3D::Get_Frame_Time();
+			unsigned time_ms=WW3D::Get_Sync_Frame_Time();
 			if (time_ms==0) time_ms=1;
 			float weight=pow(params->ic.history_weight,time_ms);
 
@@ -1011,9 +1011,6 @@ void DazzleRenderObjClass::Render_Dazzle(CameraClass* camera)
 	else {
 		screen_x_scale=h/w;
 	}
-
-//	unsigned time_ms=WW3D::Get_Frame_Time();
-//	if (time_ms==0) time_ms=1;
 
 	float halo_scale_x=types[type]->ic.halo_scale_x;
 	float halo_scale_y=types[type]->ic.halo_scale_y;
@@ -1481,7 +1478,7 @@ void DazzleLayerClass::Render(CameraClass* camera)
 
 	camera->Apply();
 
-	unsigned time_ms=WW3D::Get_Frame_Time();
+	unsigned time_ms=WW3D::Get_Sync_Frame_Time();
 	if (time_ms==0) time_ms=1;
 
 	DX8Wrapper::Set_Material(NULL);

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dazzle.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dazzle.cpp
@@ -940,8 +940,7 @@ void DazzleRenderObjClass::Render(RenderInfoClass & rinfo)
 			const DazzleTypeClass* params=types[type];
 			params->Calculate_Intensities(dazzle_intensity,dazzle_size,current_halo_intensity,camera_dir,current_dir,current_distance);
 
-			unsigned time_ms=WW3D::Get_Sync_Frame_Time();
-			if (time_ms==0) time_ms=1;
+			float time_ms=WW3D::Get_Logic_Frame_Time_Milliseconds();
 			float weight=pow(params->ic.history_weight,time_ms);
 
 			if (dazzle_intensity>0.0f) {
@@ -1477,9 +1476,6 @@ void DazzleLayerClass::Render(CameraClass* camera)
 	if (!camera) return;
 
 	camera->Apply();
-
-	unsigned time_ms=WW3D::Get_Sync_Frame_Time();
-	if (time_ms==0) time_ms=1;
 
 	DX8Wrapper::Set_Material(NULL);
 

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/hmorphanim.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/hmorphanim.h
@@ -94,8 +94,6 @@ public:
 	float							Get_Frame_Rate()									{ return FrameRate; }
 	float							Get_Total_Time()									{ return (float)FrameCount / FrameRate; }
 
-//	Vector3						Get_Translation(int pividx,float frame);
-//	Quaternion					Get_Orientation(int pividx,float frame);
 	void							Get_Translation(Vector3& translation, int pividx,float frame) const;
 	void							Get_Orientation(Quaternion& orientation, int pividx,float frame) const;
 	void							Get_Transform(Matrix3D& transform, int pividx,float frame) const;

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/hrawanim.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/hrawanim.h
@@ -97,8 +97,6 @@ public:
 	float							Get_Frame_Rate() { return FrameRate; }
 	float							Get_Total_Time() { return (float)NumFrames / FrameRate; }
 
-//	Vector3						Get_Translation(int pividx,float frame);
-//	Quaternion					Get_Orientation(int pividx,float frame);
 	void							Get_Translation(Vector3& translation, int pividx,float frame) const;
 	void							Get_Orientation(Quaternion& orientation, int pividx,float frame) const;
 	void							Get_Transform(Matrix3D& transform, int pividx,float frame) const;

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/part_emt.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/part_emt.cpp
@@ -549,7 +549,7 @@ void ParticleEmitterClass::Create_New_Particles(const Quaternion & curr_quat, co
 	// the previous interval when the last particle was emitted) is added to
 	// the size of the current frame to yield the time currently available
 	// for emitting particles.
-	unsigned int frametime = WW3D::Get_Frame_Time();
+	unsigned int frametime = WW3D::Get_Sync_Frame_Time();
 	// Since the particles are written into a wraparound buffer, we can take the time modulo a time
 	// constant which represents the time it takes to fill up the entire buffer with new particles.
 	// We will do this so we don't run into performance problems with very large frame times.

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp
@@ -1283,9 +1283,8 @@ void TexProjectClass::Pre_Render_Update(const Matrix3D & camera)
 	/*
 	** update the current intensity by iterating it towards the desired intensity
 	*/
-	float frame_time = (float)WW3D::Get_Sync_Frame_Time() / 1000.0f;
 	float intensity_delta = DesiredIntensity - Intensity;
-	float max_intensity_delta = INTENSITY_RATE_OF_CHANGE * frame_time;
+	float max_intensity_delta = INTENSITY_RATE_OF_CHANGE * WW3D::Get_Logic_Frame_Time_Seconds();
 
 	if (intensity_delta > max_intensity_delta) {
 		Intensity += max_intensity_delta;

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp
@@ -1283,7 +1283,7 @@ void TexProjectClass::Pre_Render_Update(const Matrix3D & camera)
 	/*
 	** update the current intensity by iterating it towards the desired intensity
 	*/
-	float frame_time = (float)WW3D::Get_Frame_Time() / 1000.0f;
+	float frame_time = (float)WW3D::Get_Sync_Frame_Time() / 1000.0f;
 	float intensity_delta = DesiredIntensity - Intensity;
 	float max_intensity_delta = INTENSITY_RATE_OF_CHANGE * frame_time;
 

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
@@ -165,7 +165,7 @@ const char* DAZZLE_INI_FILENAME="DAZZLE.INI";
 **
 ***********************************************************************************/
 
-float														WW3D::LogicFrameTimeMs = 33.33f;
+float														WW3D::LogicFrameTimeMs = 1000.0f / WWSyncPerSecond; // initialized to something to avoid division by zero on first use
 float															WW3D::FractionalSyncMs = 0.0f;
 unsigned int											WW3D::SyncTime = 0;
 unsigned int											WW3D::PreviousSyncTime = 0;

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
@@ -1173,18 +1173,6 @@ void WW3D::Update_Logic_Frame_Time(float milliseconds)
 {
 	LogicFrameTimeMs = milliseconds;
 	FractionalSyncMs += milliseconds;
-	unsigned int integralSyncMs = (unsigned int)FractionalSyncMs;
-
-#if MSEC_PER_WWSYNC_FRAME
-	if (integralSyncMs < MSEC_PER_WWSYNC_FRAME)
-	{
-		Sync(SyncTime);
-		return;
-	}
-#endif
-
-	FractionalSyncMs -= integralSyncMs;
-	Sync(SyncTime + integralSyncMs);
 }
 
 
@@ -1200,12 +1188,17 @@ void WW3D::Update_Logic_Frame_Time(float milliseconds)
  * HISTORY:                                                                                    *
  *   3/24/98    GTH : Created.                                                                 *
  *=============================================================================================*/
-void WW3D::Sync(unsigned int sync_time)
+void WW3D::Sync(bool step)
 {
 	PreviousSyncTime = SyncTime;
-   SyncTime = sync_time;
-}
 
+	if (step)
+	{
+		unsigned int integralSyncMs = (unsigned int)FractionalSyncMs;
+		FractionalSyncMs -= integralSyncMs;
+		SyncTime += integralSyncMs;
+	}
+}
 
 /***********************************************************************************************
  * WW3D::Set_Ext_Swap_Interval -- Sets the swap interval the device should aim sync for.       *

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
@@ -165,6 +165,7 @@ const char* DAZZLE_INI_FILENAME="DAZZLE.INI";
 **
 ***********************************************************************************/
 
+float														WW3D::LogicFrameTimeMs = 33.33f;
 float															WW3D::FractionalSyncMs = 0.0f;
 unsigned int											WW3D::SyncTime = 0;
 unsigned int											WW3D::PreviousSyncTime = 0;
@@ -1168,8 +1169,9 @@ unsigned int WW3D::Get_Last_Frame_Vertex_Count(void)
 	return Debug_Statistics::Get_DX8_Vertices();
 }
 
-void WW3D::Add_Frame_Time(float milliseconds)
+void WW3D::Update_Logic_Frame_Time(float milliseconds)
 {
+	LogicFrameTimeMs = milliseconds;
 	FractionalSyncMs += milliseconds;
 	unsigned int integralSyncMs = (unsigned int)FractionalSyncMs;
 

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/ww3d.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/ww3d.h
@@ -162,9 +162,9 @@ public:
 
 	static void Flip_To_Primary(void);
 
-	// TheSuperHackers @info Call this function to accumulate fractional render time.
-	// It will then call Sync with a new time on its own once an appropriate amount of time has passed.
-	static void Add_Frame_Time(float milliseconds);
+	// TheSuperHackers @info Add amount of milliseconds that the simulation has advanced in this render frame.
+	// This can be a fraction of a logic step. It will call Sync on its own once an appropriate amount of time has passed.
+	static void Update_Logic_Frame_Time(float milliseconds);
 	/*
 	** Timing
 	** By calling the Sync function, the application can move the ww3d library time forward.  This
@@ -173,6 +173,8 @@ public:
 	static void						Sync( unsigned int sync_time );
 	static unsigned int		Get_Sync_Time(void) { return SyncTime; }
 	static unsigned int		Get_Sync_Frame_Time(void) { return SyncTime - PreviousSyncTime; }
+	static float					Get_Logic_Frame_Time_Milliseconds() { return LogicFrameTimeMs; }
+	static float					Get_Logic_Frame_Time_Seconds() { return LogicFrameTimeMs * 0.001f; }
 	static unsigned int		Get_Frame_Count(void) { return FrameCount; }
 	static unsigned int		Get_Last_Frame_Poly_Count(void);
 	static unsigned int		Get_Last_Frame_Vertex_Count(void);
@@ -323,6 +325,10 @@ private:
 	static void					Allocate_Debug_Resources(void);
 	static void					Release_Debug_Resources(void);
 
+	// Logic frame time, in milliseconds
+	static float LogicFrameTimeMs;
+
+	// Accumulated synchronized frame time in milliseconds
 	static float FractionalSyncMs;
 
 	// Timing info:

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/ww3d.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/ww3d.h
@@ -163,14 +163,14 @@ public:
 	static void Flip_To_Primary(void);
 
 	// TheSuperHackers @info Add amount of milliseconds that the simulation has advanced in this render frame.
-	// This can be a fraction of a logic step. It will call Sync on its own once an appropriate amount of time has passed.
+	// This can be a fraction of a logic step.
 	static void Update_Logic_Frame_Time(float milliseconds);
 	/*
 	** Timing
 	** By calling the Sync function, the application can move the ww3d library time forward.  This
 	** will control things like animated uv-offset mappers and render object animations.
 	*/
-	static void						Sync( unsigned int sync_time );
+	static void						Sync(bool step);
 	static unsigned int		Get_Sync_Time(void) { return SyncTime; }
 	static unsigned int		Get_Sync_Frame_Time(void) { return SyncTime - PreviousSyncTime; }
 	static float					Get_Logic_Frame_Time_Milliseconds() { return LogicFrameTimeMs; }

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/ww3d.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/ww3d.h
@@ -170,10 +170,10 @@ public:
 	** By calling the Sync function, the application can move the ww3d library time forward.  This
 	** will control things like animated uv-offset mappers and render object animations.
 	*/
-	static void					Sync( unsigned int sync_time );
+	static void						Sync( unsigned int sync_time );
 	static unsigned int		Get_Sync_Time(void) { return SyncTime; }
-   static unsigned int     Get_Frame_Time(void) { return SyncTime - PreviousSyncTime; }
-   static unsigned int     Get_Frame_Count(void) { return FrameCount; }
+	static unsigned int		Get_Sync_Frame_Time(void) { return SyncTime - PreviousSyncTime; }
+	static unsigned int		Get_Frame_Count(void) { return FrameCount; }
 	static unsigned int		Get_Last_Frame_Poly_Count(void);
 	static unsigned int		Get_Last_Frame_Vertex_Count(void);
 
@@ -326,16 +326,16 @@ private:
 	static float FractionalSyncMs;
 
 	// Timing info:
-   // The absolute synchronized frame time (in milliseconds) supplied by the
-   // application at the start of every frame. Note that wraparound cases
-   // etc. need to be considered.
-	static unsigned int				SyncTime;
+	// The absolute synchronized frame time (in milliseconds) supplied by the
+	// application at the start of every frame. Note that wraparound cases
+	// etc. need to be considered.
+	static unsigned int SyncTime;
 
-   // The previously set absolute sync time - this is used to get the interval between
-   // the most recently set sync time and the previous one. Assuming the
-   // application sets sync time at the start of every frame, this represents
-   // the frame interval.
-   static unsigned int           PreviousSyncTime;
+	// The previously set absolute sync time - this is used to get the interval between
+	// the most recently set sync time and the previous one. Assuming the
+	// application sets sync time at the start of every frame, this represents
+	// the frame interval.
+	static unsigned int PreviousSyncTime;
 
 	static float						PixelCenterX;
 	static float						PixelCenterY;

--- a/Generals/Libraries/Source/WWVegas/WWLib/WWDefines.h
+++ b/Generals/Libraries/Source/WWVegas/WWLib/WWDefines.h
@@ -17,3 +17,12 @@
 */
 
 #pragma once
+
+// Enable translation and rotation interpolation for raw animation (HRawAnimClass) updates.
+// This was intentionally disabled in the retail version, but likely not fully thought through.
+// Interpolation is certainly desired for animations that move and rotate meshes, but may not be
+// desired for animations that teleport meshes from one location to another, such as blinking lights.
+// @todo Implement a new flag per animation file to opt-out of interpolation.
+#ifndef WW3D_ENABLE_RAW_ANIM_INTERPOLATION
+#define WW3D_ENABLE_RAW_ANIM_INTERPOLATION (1)
+#endif

--- a/Generals/Libraries/Source/WWVegas/WWLib/WWDefines.h
+++ b/Generals/Libraries/Source/WWVegas/WWLib/WWDefines.h
@@ -17,9 +17,3 @@
 */
 
 #pragma once
-
-// The WW3D Sync time. This was originally 33 ms, ~30 fps, integer.
-// Changing or removing this will require tweaking all Drawable code that concerns logic time step, including locomotion physics.
-#ifndef MSEC_PER_WWSYNC_FRAME
-#define MSEC_PER_WWSYNC_FRAME (33)
-#endif

--- a/GeneralsMD/Code/GameEngine/Include/Common/GameCommon.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GameCommon.h
@@ -72,7 +72,7 @@
 enum
 {
 	BaseFps = 30, // The historic base frame rate for this game. This value must never change.
-	LOGICFRAMES_PER_SECOND = 30,
+	LOGICFRAMES_PER_SECOND = WWSyncPerSecond,
 	MSEC_PER_SECOND = 1000
 };
 const Real LOGICFRAMES_PER_MSEC_REAL = (((Real)LOGICFRAMES_PER_SECOND) / ((Real)MSEC_PER_SECOND));

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Drawable.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Drawable.h
@@ -171,7 +171,7 @@ public:
 	TintEnvelope(void);
 	void update(void);  ///< does all the work
 	void play(const RGBColor *peak,
-						UnsignedInt atackFrames = DEF_ATTACK_FRAMES,
+						UnsignedInt attackFrames = DEF_ATTACK_FRAMES,
 						UnsignedInt decayFrames = DEF_DECAY_FRAMES,
 						UnsignedInt sustainAtPeak = DEF_SUSTAIN_FRAMES ); // ask MLorenzen
 	void sustain(void) { m_envState = ENVELOPE_STATE_SUSTAIN; }
@@ -234,7 +234,6 @@ enum DrawableStatus CPP_11(: DrawableStatusBits)
 	DRAWABLE_STATUS_NONE									= 0x00000000,		///< no status
 	DRAWABLE_STATUS_DRAWS_IN_MIRROR				=	0x00000001,		///< drawable can reflect
 	DRAWABLE_STATUS_SHADOWS								=	0x00000002,		///< use setShadowsEnabled() access method
-	DRAWABLE_STATUS_TINT_COLOR_LOCKED			=	0x00000004,		///< drawable tint color is "locked" and won't fade to normal
 	DRAWABLE_STATUS_NO_STATE_PARTICLES		= 0x00000008,		///< do *not* auto-create particle systems based on model condition
 	DRAWABLE_STATUS_NO_SAVE								= 0x00000010,		///< do *not* save this drawable (UI fluff only). ignored (error, actually) if attached to an object
 
@@ -388,7 +387,7 @@ public:
 
 	Bool getDrawsInMirror() const { return BitIsSet(m_status, DRAWABLE_STATUS_DRAWS_IN_MIRROR) || isKindOf(KINDOF_CAN_CAST_REFLECTIONS); }
 
-	void colorFlash( const RGBColor *color, UnsignedInt decayFrames = DEF_DECAY_FRAMES, UnsignedInt attackFrames = 0, UnsignedInt sustainAtPeak = FALSE );  ///< flash a drawable in the color specified for a short time
+	void colorFlash( const RGBColor *color, UnsignedInt decayFrames = DEF_DECAY_FRAMES, UnsignedInt attackFrames = 0, UnsignedInt sustainAtPeak = 0 );  ///< flash a drawable in the color specified for a short time
 	void colorTint( const RGBColor *color );	 ///< tint this drawable the color specified
 	void setTintEnvelope( const RGBColor *color, Real attack, Real decay );	 ///< how to transition color
 	void flashAsSelected( const RGBColor *color = NULL ); ///< drawable takes care of the details if you spec no color

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/GameLogic.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/GameLogic.h
@@ -138,6 +138,7 @@ public:
 	Real getHeight( void );													///< Returns the height of the world
 
 	Bool isInGameLogicUpdate( void ) const { return m_isInUpdate; }
+	Bool hasUpdated() const { return m_hasUpdated; } ///< Returns true if the logic frame has advanced in the current client/render update
 	UnsignedInt getFrame( void );										///< Returns the current simulation frame number
 	UnsignedInt getCRC( Int mode = CRC_CACHED, AsciiString deepCRCFileName = AsciiString::TheEmptyString );		///< Returns the CRC
 
@@ -324,6 +325,7 @@ private:
 	Bool m_clearingGameData;
 
 	Bool m_isInUpdate;
+	Bool m_hasUpdated;
 
 	Int m_rankPointsToAddAtGameStart;
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -253,7 +253,7 @@ GameEngine::GameEngine( void )
 	// initialize to non garbage values
 	m_maxFPS = BaseFps;
 	m_logicTimeScaleFPS = LOGICFRAMES_PER_SECOND;
-	m_updateTime = 0.0f;
+	m_updateTime = 1.0f / BaseFps; // initialized to something to avoid division by zero on first use
 	m_logicTimeAccumulator = 0.0f;
 	m_quitting = FALSE;
 	m_isActive = FALSE;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -971,9 +971,6 @@ void Drawable::colorFlash( const RGBColor* color, UnsignedInt decayFrames, Unsig
 		white.setFromInt(0xffffffff);
 		m_colorTintEnvelope->play( &white );
 	}
-
-	// make sure the tint color is unlocked so we "fade back down" to normal
-	clearDrawableStatus( DRAWABLE_STATUS_TINT_COLOR_LOCKED );
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -984,11 +981,7 @@ void Drawable::colorTint( const RGBColor* color )
 	if( color )
 	{
 		// set the color via color flash
-		colorFlash( color, 0, 0, TRUE );
-
-		// lock the tint color so the flash never "fades back down"
-		setDrawableStatus( DRAWABLE_STATUS_TINT_COLOR_LOCKED );
-
+		colorFlash( color, 0, 0, ~0u );
 	}
 	else
 	{
@@ -997,10 +990,6 @@ void Drawable::colorTint( const RGBColor* color )
 
 		// remove the tint applied to the object
 		m_colorTintEnvelope->rest();
-
-		// set the tint as unlocked so we can flash and stuff again
-		clearDrawableStatus( DRAWABLE_STATUS_TINT_COLOR_LOCKED );
-
 	}
 
 }
@@ -5513,11 +5502,11 @@ TintEnvelope::TintEnvelope(void)
 const Real FADE_RATE_EPSILON = (0.001f);
 
 //-------------------------------------------------------------------------------------------------
-void TintEnvelope::play(const RGBColor *peak, UnsignedInt atackFrames, UnsignedInt decayFrames, UnsignedInt sustainAtPeak )
+void TintEnvelope::play(const RGBColor *peak, UnsignedInt attackFrames, UnsignedInt decayFrames, UnsignedInt sustainAtPeak )
 {
 	setPeakColor( peak );
 
-	setAttackFrames( atackFrames );
+	setAttackFrames( attackFrames );
 	setDecayFrames( decayFrames );
 
 	m_envState = ENVELOPE_STATE_ATTACK;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -1392,7 +1392,7 @@ void Drawable::applyPhysicsXform(Matrix3D* mtx)
 	{
 		// TheSuperHackers @tweak Update the physics transform on every WW Sync only.
 		// All calculations are originally catered to a 30 fps logic step.
-		if (WW3D::Get_Frame_Time() != 0)
+		if (WW3D::Get_Sync_Frame_Time() != 0)
 		{
 			calcPhysicsXform(*m_physicsXform);
 		}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/EMPUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/EMPUpdate.cpp
@@ -149,7 +149,7 @@ UpdateSleepTime EMPUpdate::update( void )
 	{
 		RGBColor end = data->m_endColor;
 		saturateRGB( end, 5 );
-		dr->colorFlash( &end, 9999, m_tintEnvFadeFrames, TRUE );
+		dr->colorFlash( &end, 0, m_tintEnvFadeFrames, ~0u );
 		doDisableAttack();
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -237,6 +237,7 @@ GameLogic::GameLogic( void )
 	//
 
 	m_frame = 0;
+	m_hasUpdated = FALSE;
 	m_frameObjectsChangedTriggerAreas = 0;
 	m_width = 0;
 	m_height = 0;
@@ -271,6 +272,7 @@ GameLogic::GameLogic( void )
 void GameLogic::setDefaults( Bool loadingSaveGame )
 {
 	m_frame = 0;
+	m_hasUpdated = FALSE;
 	m_width = DEFAULT_WORLD_WIDTH;
 	m_height = DEFAULT_WORLD_HEIGHT;
 	m_objList = NULL;
@@ -1157,6 +1159,7 @@ void GameLogic::startNewGame( Bool loadingSaveGame )
 
 	// reset the frame counter
 	m_frame = 0;
+	m_hasUpdated = FALSE;
 
 #ifdef DEBUG_CRC
 	// TheSuperHackers @info helmutbuhler 04/09/2025
@@ -3863,6 +3866,7 @@ void GameLogic::update( void )
 	if (!m_startNewGame)
 	{
 		m_frame++;
+		m_hasUpdated = TRUE;
 	}
 }
 
@@ -3870,6 +3874,8 @@ void GameLogic::update( void )
 // ------------------------------------------------------------------------------------------------
 void GameLogic::preUpdate()
 {
+	m_hasUpdated = FALSE;
+
 	if (m_pauseFrame == m_frame && m_pauseFrame != 0)
 	{
 		m_pauseFrame = 0;

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/BaseHeightMap.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/BaseHeightMap.h
@@ -328,6 +328,8 @@ protected:
 	void initDestAlphaLUT(void);	///<initialize water depth LUT stored in m_destAlphaTexture
 	void renderShoreLines(CameraClass *pCamera);	///<re-render parts of terrain that need custom blending into water edge
 	void renderShoreLinesSorted(CameraClass *pCamera);	///<optimized version for game usage.
+
+	static Bool useCloud();
 };
 
 extern BaseHeightMapRenderObjClass *TheTerrainRenderObject;

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/HeightMap.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/HeightMap.h
@@ -81,9 +81,6 @@ public:
 	virtual Int freeMapResources(void);	///< free resources used to render heightmap
 	virtual void updateCenter(CameraClass *camera, RefRenderObjListIterator *pLightsIterator);
 
-	void renderExtraBlendTiles(void);			///< render 3-way blend tiles that have blend of 3 textures.
-
-
 	virtual void staticLightingChanged(void);
 	virtual	void adjustTerrainLOD(Int adj);
 	virtual void reset(void);
@@ -123,9 +120,7 @@ protected:
 	void renderTerrainPass(CameraClass *pCamera);	///< renders additional terrain pass.
 	Int	getNumExtraBlendTiles(Bool visible) { return visible?m_numVisibleExtraBlendTiles:m_numExtraBlendTiles;}
 	void freeIndexVertexBuffers(void);
-
-
-
+	void renderExtraBlendTiles(void);	///< render 3-way blend tiles that have blend of 3 textures.
 };
 
 #endif  // end __HEIGHTMAP_H_

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DShaderManager.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DShaderManager.h
@@ -81,6 +81,8 @@ public:
 	W3DShaderManager(void);	///<constructor
 	static void init( void );	///<determine optimal shaders for current device.
 	static void shutdown(void);	///<release resources used by shaders
+	static void updateCloud();	///<update the cloud position once every render frame.
+
 	static ChipsetType getChipset(void);	///<return current device chipset.
 	static GraphicsVenderID getCurrentVendor(void) {return m_currentVendor;}	///<return current card vendor.
 	static __int64 getCurrentDriverVersion(void) {return m_driverVersion; }	///<return current driver version.

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/BaseHeightMap.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/BaseHeightMap.cpp
@@ -3009,3 +3009,8 @@ void BaseHeightMapRenderObjClass::loadPostProcess( void )
 	// empty. jba [8/11/2003]
 }
 
+//=============================================================================
+Bool BaseHeightMapRenderObjClass::useCloud()
+{
+	return TheGlobalData->m_useCloudMap && TheGlobalData->m_timeOfDay != TIME_OF_DAY_NIGHT;
+}

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankDraw.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankDraw.cpp
@@ -312,7 +312,7 @@ void W3DTankDraw::doDrawModule(const Matrix3D* transformMtx)
 {
 	// TheSuperHackers @tweak Update the draw on every WW Sync only.
 	// All calculations are originally catered to a 30 fps logic step.
-	if (WW3D::Get_Frame_Time() == 0)
+	if (WW3D::Get_Sync_Frame_Time() == 0)
 		return;
 
 	const Real DEBRIS_THRESHOLD = 0.00001f;

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankDraw.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankDraw.cpp
@@ -310,6 +310,8 @@ void W3DTankDraw::onRenderObjRecreated(void)
 //-------------------------------------------------------------------------------------------------
 void W3DTankDraw::doDrawModule(const Matrix3D* transformMtx)
 {
+	W3DModelDraw::doDrawModule(transformMtx);
+
 	// TheSuperHackers @tweak Update the draw on every WW Sync only.
 	// All calculations are originally catered to a 30 fps logic step.
 	if (WW3D::Get_Sync_Frame_Time() == 0)
@@ -405,8 +407,6 @@ void W3DTankDraw::doDrawModule(const Matrix3D* transformMtx)
 			}
 		}
 	}
-
-	W3DModelDraw::doDrawModule(transformMtx);
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankTruckDraw.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankTruckDraw.cpp
@@ -517,7 +517,7 @@ void W3DTankTruckDraw::doDrawModule(const Matrix3D* transformMtx)
 
 	// TheSuperHackers @tweak Update the draw on every WW Sync only.
 	// All calculations are originally catered to a 30 fps logic step.
-	if (WW3D::Get_Frame_Time() == 0)
+	if (WW3D::Get_Sync_Frame_Time() == 0)
 		return;
 
 	const Real ACCEL_THRESHOLD = 0.01f;

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTruckDraw.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTruckDraw.cpp
@@ -395,7 +395,7 @@ void W3DTruckDraw::doDrawModule(const Matrix3D* transformMtx)
 
 	// TheSuperHackers @tweak Update the draw on every WW Sync only.
 	// All calculations are originally catered to a 30 fps logic step.
-	if (WW3D::Get_Frame_Time() == 0)
+	if (WW3D::Get_Sync_Frame_Time() == 0)
 		return;
 
 	const Real ACCEL_THRESHOLD = 0.01f;

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/FlatHeightMap.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/FlatHeightMap.cpp
@@ -459,7 +459,14 @@ void FlatHeightMapRenderObjClass::Render(RenderInfoClass & rinfo)
 
 	Int devicePasses;
 	W3DShaderManager::ShaderTypes st;
-	Bool doCloud = TheGlobalData->m_useCloudMap;
+	const Bool doCloud = useCloud();
+
+	if (doCloud)
+	{
+		// TheSuperHackers @tweak Updates the cloud movement before applying it to the world.
+		// Is now decoupled from logic step.
+		W3DShaderManager::updateCloud();
+	}
 
 	Matrix3D tm(Transform);
 	// If there are trees, tell them to draw at the transparent time to draw.
@@ -493,10 +500,6 @@ void FlatHeightMapRenderObjClass::Render(RenderInfoClass & rinfo)
 
 	DX8Wrapper::Set_Material(m_vertexMaterialClass);
 	DX8Wrapper::Set_Shader(m_shaderClass);
-
-	if (TheGlobalData->m_timeOfDay == TIME_OF_DAY_NIGHT) {
-		doCloud = false;
-	}
 
  	st=W3DShaderManager::ST_FLAT_TERRAIN_BASE; //set default shader
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/HeightMap.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/HeightMap.cpp
@@ -1912,7 +1912,14 @@ void HeightMapRenderObjClass::Render(RenderInfoClass & rinfo)
 
 	Int i,j,devicePasses;
 	W3DShaderManager::ShaderTypes st;
-	Bool doCloud = TheGlobalData->m_useCloudMap;
+	const Bool doCloud = useCloud();
+
+	if (doCloud)
+	{
+		// TheSuperHackers @tweak Updates the cloud movement before applying it to the world.
+		// Is now decoupled from logic step.
+		W3DShaderManager::updateCloud();
+	}
 
 	Matrix3D tm(Transform);
 #if 0 // There is some weirdness sometimes with the dx8 static buffers.
@@ -2002,10 +2009,6 @@ void HeightMapRenderObjClass::Render(RenderInfoClass & rinfo)
 	{
 		DX8Wrapper::Set_Material(m_vertexMaterialClass);
 		DX8Wrapper::Set_Shader(m_shaderClass);
-
-		if (TheGlobalData->m_timeOfDay == TIME_OF_DAY_NIGHT) {
-			doCloud = false;
-		}
 
  		st=W3DShaderManager::ST_TERRAIN_BASE; //set default shader
 
@@ -2415,10 +2418,7 @@ void HeightMapRenderObjClass::renderExtraBlendTiles(void)
 
 			W3DShaderManager::ShaderTypes st = W3DShaderManager::ST_ROAD_BASE;
 
-			Bool doCloud = TheGlobalData->m_useCloudMap;
-			if (TheGlobalData->m_timeOfDay == TIME_OF_DAY_NIGHT) {
-				doCloud = false;
-			}
+			const Bool doCloud = useCloud();
 
 			if (TheGlobalData->m_useLightMap && doCloud)
  			{

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -1812,7 +1812,7 @@ AGAIN:
 		}
 	}
 
-	WW3D::Add_Frame_Time(TheGameEngine->getLogicTimeStepMilliseconds());
+	WW3D::Update_Logic_Frame_Time(TheGameEngine->getLogicTimeStepMilliseconds());
 
 	static Int now;
 	now=timeGetTime();

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -1814,6 +1814,10 @@ AGAIN:
 
 	WW3D::Update_Logic_Frame_Time(TheGameEngine->getLogicTimeStepMilliseconds());
 
+	// TheSuperHackers @info This binds the WW3D update to the logic update. This was originally 33 ms, ~30 fps, integer.
+	// Changing this will require tweaking all Drawable code that concerns the ww3d time step, including locomotion physics.
+	WW3D::Sync(TheGameLogic->hasUpdated());
+
 	static Int now;
 	now=timeGetTime();
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -1814,8 +1814,7 @@ AGAIN:
 
 	WW3D::Update_Logic_Frame_Time(TheGameEngine->getLogicTimeStepMilliseconds());
 
-	// TheSuperHackers @info This binds the WW3D update to the logic update. This was originally 33 ms, ~30 fps, integer.
-	// Changing this will require tweaking all Drawable code that concerns the ww3d time step, including locomotion physics.
+	// TheSuperHackers @info This binds the WW3D update to the logic update.
 	WW3D::Sync(TheGameLogic->hasUpdated());
 
 	static Int now;

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DShaderManager.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DShaderManager.cpp
@@ -1482,12 +1482,14 @@ class TerrainShader2Stage : public W3DShaderInterface
 public:
 	float m_xSlidePerSecond ;	 ///< How far the clouds move per second.
 	float m_ySlidePerSecond ;	 ///< How far the clouds move per second.
-	int	  m_curTick;
 	float m_xOffset;
 	float m_yOffset;
+
 	virtual Int set(Int pass);		///<setup shader for the specified rendering pass.
 	virtual Int init(void);			///<perform any one time initialization and validation
 	virtual void reset(void);		///<do any custom resetting necessary to bring W3D in sync.
+
+	void updateCloud();
 	void updateNoise1 (D3DXMATRIX *destMatrix,D3DXMATRIX *curViewInverse, Bool doUpdate=true);	///<generate the uv coordinates for Noise1 (i.e clouds)
 	void updateNoise2 (D3DXMATRIX *destMatrix,D3DXMATRIX *curViewInverse, Bool doUpdate=true);	///<generate the uv coordinates for Noise2 (i.e lightmap)
 } terrainShader2Stage;
@@ -1561,8 +1563,6 @@ Int TerrainShader2Stage::init( void )
 	//initialize settings for uv animated clouds
 	m_xSlidePerSecond = -0.02f;
 	m_ySlidePerSecond =  1.50f * m_xSlidePerSecond;
-	m_curTick = 0;
-	m_curTick = WW3D::Get_Sync_Time();//::GetTickCount();
 	m_xOffset = 0;
 	m_yOffset = 0;
 
@@ -1595,6 +1595,18 @@ void TerrainShader2Stage::reset(void)
 	DX8Wrapper::Set_DX8_Texture_Stage_State( 1, D3DTSS_TEXCOORDINDEX, D3DTSS_TCI_PASSTHRU|1);
 }
 
+void TerrainShader2Stage::updateCloud()
+{
+	const float frame_time = WW3D::Get_Logic_Frame_Time_Seconds();
+	m_xOffset += m_xSlidePerSecond * frame_time;
+	m_yOffset += m_ySlidePerSecond * frame_time;
+
+	while (m_xOffset > 1) m_xOffset -= 1;
+	while (m_yOffset > 1) m_yOffset -= 1;
+	while (m_xOffset < -1) m_xOffset += 1;
+	while (m_yOffset < -1) m_yOffset += 1;
+}
+
 void TerrainShader2Stage::updateNoise1(D3DXMATRIX *destMatrix,D3DXMATRIX *curViewInverse, Bool doUpdate)
 {
 	#define STRETCH_FACTOR ((float)(1/(63.0*MAP_XY_FACTOR/2))) /* covers 63/2 tiles */
@@ -1605,26 +1617,6 @@ void TerrainShader2Stage::updateNoise1(D3DXMATRIX *destMatrix,D3DXMATRIX *curVie
 	*destMatrix = *curViewInverse * scale;
 
 	D3DXMATRIX offset;
-
-	Int delta = m_curTick;
-	m_curTick = WW3D::Get_Sync_Time();//::GetTickCount();
-	delta = m_curTick-delta;
-	m_xOffset += m_xSlidePerSecond*delta/1000;
-	m_yOffset += m_ySlidePerSecond*delta/1000;
-
-
-	//m_xOffset += m_xSlidePerSecond*delta/500;
-	//m_yOffset += m_ySlidePerSecond*delta/500;
-
-
-	//m_yOffset = sinf( (float)m_curTick * 0.0001f );
-	//m_xOffset = cosf( (float)m_curTick * 0.0001f );
-
-	while (m_xOffset > 1) m_xOffset -= 1;
-	while (m_yOffset > 1) m_yOffset -= 1;
-	while (m_xOffset < -1) m_xOffset += 1;
-	while (m_yOffset < -1) m_yOffset += 1;
-
 	D3DXMatrixTranslation(&offset, m_xOffset, m_yOffset,0);
 	*destMatrix *= offset;
 }
@@ -2702,6 +2694,12 @@ void W3DShaderManager::shutdown(void)
 		}
 	}
 
+}
+
+//=============================================================================
+void W3DShaderManager::updateCloud()
+{
+	terrainShader2Stage.updateCloud();
 }
 
 // W3DShaderManager::getShaderPasses =======================================================

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DSnow.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DSnow.cpp
@@ -156,8 +156,8 @@ void W3DSnowManager::reset( void )
 
 void W3DSnowManager::update(void)
 {
-
-	m_time += WW3D::Get_Sync_Frame_Time() / 1000.0f;
+	// TheSuperHackers @tweak The snow render update is now decoupled from the logic step.
+	m_time += WW3D::Get_Logic_Frame_Time_Seconds();
 
 	//find current time offset, adjusting for overflow
 	m_time=fmod(m_time,m_fullTimePeriod);

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DSnow.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DSnow.cpp
@@ -157,7 +157,7 @@ void W3DSnowManager::reset( void )
 void W3DSnowManager::update(void)
 {
 
-	m_time += WW3D::Get_Frame_Time() / 1000.0f;
+	m_time += WW3D::Get_Sync_Frame_Time() / 1000.0f;
 
 	//find current time offset, adjusting for overflow
 	m_time=fmod(m_time,m_fullTimePeriod);

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/animobj.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/animobj.cpp
@@ -289,12 +289,6 @@ void Animatable3DObjClass::Render(RenderInfoClass & rinfo)
 		return;
 	}
 
-	if ( CurMotionMode == SINGLE_ANIM ) {
-		if ( ModeAnim.AnimMode != ANIM_MODE_MANUAL ) {
-			Single_Anim_Progress();
-		}
-	}
-
 	if (!Is_Hierarchy_Valid() || Are_Sub_Object_Transforms_Dirty()) {
 		Update_Sub_Object_Transforms();
 	}
@@ -315,12 +309,6 @@ void Animatable3DObjClass::Render(RenderInfoClass & rinfo)
 void Animatable3DObjClass::Special_Render(SpecialRenderInfoClass & rinfo)
 {
 	if (HTree == NULL) return;
-
-	if ( CurMotionMode == SINGLE_ANIM ) {
-		if ( ModeAnim.AnimMode != ANIM_MODE_MANUAL ) {
-			Single_Anim_Progress();
-		}
-	}
 
 	if (!Is_Hierarchy_Valid()) {
 		Update_Sub_Object_Transforms();
@@ -1051,19 +1039,12 @@ void Animatable3DObjClass::Single_Anim_Progress (void)
 		//
 		// Update the frame number and sync time
 		//
-		float oldprev = ModeAnim.PrevFrame;
 		ModeAnim.PrevFrame		= ModeAnim.Frame;
 		ModeAnim.Frame				= Compute_Current_Frame(&ModeAnim.animDirection);
 		ModeAnim.LastSyncTime	= WW3D::Get_Sync_Time();
 
-		if (ModeAnim.Frame == ModeAnim.PrevFrame) {
-			// This function was somehow called twice per frame.
-			// Since ModeAnim.Frame hasn't changed, reset the ModeAnim.PrevFrame.
-			// If you don't do this sounds won't be triggered properly because Frame and PrevFrame will be the same.
-			ModeAnim.PrevFrame = oldprev;
-		}
 		//
-		// Force the heirarchy to be recalculated
+		// Force the hierarchy to be recalculated
 		//
 		Set_Hierarchy_Valid (false);
 	}

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/animobj.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/animobj.cpp
@@ -89,7 +89,6 @@ Animatable3DObjClass::Animatable3DObjClass(const char * htree_name) :
   ModeAnim.Motion=NULL;
 	ModeAnim.Frame=0.0f;
 	ModeAnim.PrevFrame=0.0f;
-	ModeAnim.LastSyncTime=WW3D::Get_Sync_Time();
 	ModeAnim.frameRateMultiplier=1.0;	// 020607 srj -- added
 	ModeAnim.animDirection=1.0;	// 020607 srj -- added
 	ModeInterp.Motion0=NULL;
@@ -145,7 +144,6 @@ Animatable3DObjClass::Animatable3DObjClass(const Animatable3DObjClass & src) :
 	ModeAnim.Motion=NULL;
 	ModeAnim.Frame=0.0f;
 	ModeAnim.PrevFrame=0.0f;
-	ModeAnim.LastSyncTime=WW3D::Get_Sync_Time();
 	ModeAnim.frameRateMultiplier=1.0;	// 020607 srj -- added
 	ModeAnim.animDirection=1.0;	// 020607 srj -- added
 	ModeInterp.Motion0=NULL;
@@ -205,7 +203,6 @@ Animatable3DObjClass & Animatable3DObjClass::operator = (const Animatable3DObjCl
 		ModeAnim.Motion = NULL;
 		ModeAnim.Frame = 0.0f;
 		ModeAnim.PrevFrame = 0.0f;
-		ModeAnim.LastSyncTime = WW3D::Get_Sync_Time();
 		ModeAnim.frameRateMultiplier=1.0;	// 020607 srj -- added
 		ModeAnim.animDirection=1.0;	// 020607 srj -- added
 		ModeInterp.Motion0 = NULL;
@@ -464,7 +461,6 @@ void Animatable3DObjClass::Set_Animation(HAnimClass * motion, float frame, int m
 		ModeAnim.Motion = motion;
 		ModeAnim.PrevFrame = ModeAnim.Frame;
 		ModeAnim.Frame = frame;
-		ModeAnim.LastSyncTime = WW3D::Get_Sync_Time();
 		ModeAnim.frameRateMultiplier=1.0;	// 020607 srj -- added
 		ModeAnim.animDirection=1.0;	// 020607 srj -- added
 
@@ -764,7 +760,7 @@ void Animatable3DObjClass::Control_Bone(int bindex,const Matrix3D & objtm,bool w
 void Animatable3DObjClass::Update_Sub_Object_Transforms(void)
 {
 	/*
-	** The RenderObj impementation will cause our 'container'
+	** The RenderObj implementation will cause our 'container'
 	** to update if we are not valid yet
 	*/
 	CompositeRenderObjClass::Update_Sub_Object_Transforms();
@@ -945,8 +941,9 @@ float Animatable3DObjClass::Compute_Current_Frame(float *newDirection) const
 			//	Compute the current frame based on elapsed time.
 			//
 			if (ModeAnim.AnimMode != ANIM_MODE_MANUAL) {
-				float sync_time_diff = WW3D::Get_Sync_Time() - ModeAnim.LastSyncTime;
-				float delta = ModeAnim.Motion->Get_Frame_Rate() * ModeAnim.frameRateMultiplier * ModeAnim.animDirection * sync_time_diff * 0.001f;
+				// TheSuperHackers @tweak The animation render update is now decoupled from the logic step.
+				const float frametime = WW3D::Get_Logic_Frame_Time_Seconds();
+				const float delta = ModeAnim.Motion->Get_Frame_Rate() * ModeAnim.frameRateMultiplier * ModeAnim.animDirection * frametime;
 				frame += delta;
 
 				//
@@ -962,10 +959,10 @@ float Animatable3DObjClass::Compute_Current_Frame(float *newDirection) const
 					case ANIM_MODE_LOOP:
 						if ( frame >= ModeAnim.Motion->Get_Num_Frames() - 1 ) {
 							frame -= ModeAnim.Motion->Get_Num_Frames() - 1;
-						}
-						// If it is still too far out, reset
-						if ( frame >= ModeAnim.Motion->Get_Num_Frames() - 1 ) {
-							frame = 0;
+							// If it is still too far out, reset
+							if ( frame >= ModeAnim.Motion->Get_Num_Frames() - 1 ) {
+								frame = 0;
+							}
 						}
 						break;
 					case ANIM_MODE_ONCE_BACKWARDS:	//play animation one time but backwards
@@ -976,10 +973,10 @@ float Animatable3DObjClass::Compute_Current_Frame(float *newDirection) const
 					case ANIM_MODE_LOOP_BACKWARDS:	//play animation backwards in a loop
 						if ( frame < 0 ) {
 							frame += ModeAnim.Motion->Get_Num_Frames() - 1;
-						}
-						// If it is still too far out, reset
-						if ( frame < 0 ) {
-							frame = ModeAnim.Motion->Get_Num_Frames() - 1;
+							// If it is still too far out, reset
+							if ( frame < 0 ) {
+								frame = ModeAnim.Motion->Get_Num_Frames() - 1;
+							}
 						}
 						break;
 					case ANIM_MODE_LOOP_PINGPONG:
@@ -1041,7 +1038,6 @@ void Animatable3DObjClass::Single_Anim_Progress (void)
 		//
 		ModeAnim.PrevFrame		= ModeAnim.Frame;
 		ModeAnim.Frame				= Compute_Current_Frame(&ModeAnim.animDirection);
-		ModeAnim.LastSyncTime	= WW3D::Get_Sync_Time();
 
 		//
 		// Force the hierarchy to be recalculated

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/animobj.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/animobj.cpp
@@ -949,18 +949,20 @@ float Animatable3DObjClass::Compute_Current_Frame(float *newDirection) const
 				//
 				//	Wrap the frame
 				//
+				const int numFrames = ModeAnim.Motion->Get_Num_Frames() - 1;
+
 				switch (ModeAnim.AnimMode)
 				{
 					case ANIM_MODE_ONCE:
-						if (frame >= ModeAnim.Motion->Get_Num_Frames() - 1) {
-							frame = ModeAnim.Motion->Get_Num_Frames() - 1;
+						if (frame >= numFrames) {
+							frame = numFrames;
 						}
 						break;
 					case ANIM_MODE_LOOP:
-						if ( frame >= ModeAnim.Motion->Get_Num_Frames() - 1 ) {
-							frame -= ModeAnim.Motion->Get_Num_Frames() - 1;
+						if ( frame >= numFrames ) {
+							frame -= numFrames;
 							// If it is still too far out, reset
-							if ( frame >= ModeAnim.Motion->Get_Num_Frames() - 1 ) {
+							if ( frame >= numFrames ) {
 								frame = 0;
 							}
 						}
@@ -972,22 +974,22 @@ float Animatable3DObjClass::Compute_Current_Frame(float *newDirection) const
 						break;
 					case ANIM_MODE_LOOP_BACKWARDS:	//play animation backwards in a loop
 						if ( frame < 0 ) {
-							frame += ModeAnim.Motion->Get_Num_Frames() - 1;
+							frame += numFrames;
 							// If it is still too far out, reset
 							if ( frame < 0 ) {
-								frame = ModeAnim.Motion->Get_Num_Frames() - 1;
+								frame = numFrames;
 							}
 						}
 						break;
 					case ANIM_MODE_LOOP_PINGPONG:
 						if (ModeAnim.animDirection >= 1.0f)
 						{	//playing forwards, reverse direction
-							if (frame >= (ModeAnim.Motion->Get_Num_Frames() - 1))
+							if (frame >= numFrames)
 							{	//step backwards in animation by excess time
-								frame = (ModeAnim.Motion->Get_Num_Frames() - 1)*2 - frame;
+								frame = numFrames * 2 - frame;
 								// If it is still too far out, reset
-								if ( frame >= ModeAnim.Motion->Get_Num_Frames() - 1 )
-									frame = (ModeAnim.Motion->Get_Num_Frames() - 1);
+								if ( frame >= numFrames - 1 )
+									frame = numFrames;
 								direction = ModeAnim.animDirection * -1.0f;
 							}
 						}
@@ -997,7 +999,7 @@ float Animatable3DObjClass::Compute_Current_Frame(float *newDirection) const
 							{	//step forwards in animation by excess time
 								frame = -frame;
 								// If it is still too far out, reset
-								if ( frame >= ModeAnim.Motion->Get_Num_Frames() - 1 )
+								if ( frame >= numFrames )
 										frame = 0;
 								direction = ModeAnim.animDirection * -1.0f;
 							}

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/animobj.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/animobj.h
@@ -190,7 +190,6 @@ protected:
 			float		  				Frame;
 			float						PrevFrame;
 			int						AnimMode;
-			mutable int				LastSyncTime;
 			float							animDirection;
 			float							frameRateMultiplier;	// 020607 srj -- added
 		} ModeAnim;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/animobj.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/animobj.h
@@ -261,8 +261,8 @@ inline void Animatable3DObjClass::Anim_Update(const Matrix3D & root,HAnimClass *
 	** Apply motion to the base pose
 	*/
 	if ((motion) && (HTree)) {
-		if (ModeAnim.Motion->Class_ID() == HAnimClass::CLASSID_HRAWANIM)
-			HTree->Anim_Update(Transform,(HRawAnimClass*)ModeAnim.Motion,ModeAnim.Frame);
+		if (motion->Class_ID() == HAnimClass::CLASSID_HRAWANIM)
+			HTree->Anim_Update(root,(HRawAnimClass*)motion,frame);
 		else
 			HTree->Anim_Update(root,motion,frame);
 	}

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/animobj.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/animobj.h
@@ -261,9 +261,11 @@ inline void Animatable3DObjClass::Anim_Update(const Matrix3D & root,HAnimClass *
 	** Apply motion to the base pose
 	*/
 	if ((motion) && (HTree)) {
+#if !WW3D_ENABLE_RAW_ANIM_INTERPOLATION
 		if (motion->Class_ID() == HAnimClass::CLASSID_HRAWANIM)
-			HTree->Anim_Update(root,(HRawAnimClass*)motion,frame);
+			HTree->Anim_Update_Without_Interpolation(root,(HRawAnimClass*)motion,frame);
 		else
+#endif
 			HTree->Anim_Update(root,motion,frame);
 	}
 	Set_Hierarchy_Valid(true);

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dazzle.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dazzle.cpp
@@ -975,7 +975,7 @@ void DazzleRenderObjClass::Render(RenderInfoClass & rinfo)
 			const DazzleTypeClass* params=types[type];
 			params->Calculate_Intensities(dazzle_intensity,dazzle_size,current_halo_intensity,camera_dir,current_dir,dir,current_distance);
 
-			unsigned time_ms=WW3D::Get_Frame_Time();
+			unsigned time_ms=WW3D::Get_Sync_Frame_Time();
 			if (time_ms==0) time_ms=1;
 			float weight=pow(params->ic.history_weight,time_ms);
 
@@ -1047,9 +1047,6 @@ void DazzleRenderObjClass::Render_Dazzle(CameraClass* camera)
 	else {
 		screen_x_scale=h/w;
 	}
-
-//	unsigned time_ms=WW3D::Get_Frame_Time();
-//	if (time_ms==0) time_ms=1;
 
 	// Do NOT scale halo by current scale
 	// because it uses screen parallel primitives
@@ -1587,7 +1584,7 @@ void DazzleLayerClass::Render(CameraClass* camera)
 
 	camera->Apply();
 
-	unsigned time_ms=WW3D::Get_Frame_Time();
+	unsigned time_ms=WW3D::Get_Sync_Frame_Time();
 	if (time_ms==0) time_ms=1;
 
 	DX8Wrapper::Set_Material(NULL);

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dazzle.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dazzle.cpp
@@ -975,8 +975,7 @@ void DazzleRenderObjClass::Render(RenderInfoClass & rinfo)
 			const DazzleTypeClass* params=types[type];
 			params->Calculate_Intensities(dazzle_intensity,dazzle_size,current_halo_intensity,camera_dir,current_dir,dir,current_distance);
 
-			unsigned time_ms=WW3D::Get_Sync_Frame_Time();
-			if (time_ms==0) time_ms=1;
+			float time_ms=WW3D::Get_Logic_Frame_Time_Milliseconds();
 			float weight=pow(params->ic.history_weight,time_ms);
 
 			if (dazzle_intensity>0.0f) {
@@ -1583,9 +1582,6 @@ void DazzleLayerClass::Render(CameraClass* camera)
 	if (!camera) return;
 
 	camera->Apply();
-
-	unsigned time_ms=WW3D::Get_Sync_Frame_Time();
-	if (time_ms==0) time_ms=1;
 
 	DX8Wrapper::Set_Material(NULL);
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/hmorphanim.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/hmorphanim.h
@@ -94,8 +94,6 @@ public:
 	float							Get_Frame_Rate()									{ return FrameRate; }
 	float							Get_Total_Time()									{ return (float)FrameCount / FrameRate; }
 
-//	Vector3						Get_Translation(int pividx,float frame);
-//	Quaternion					Get_Orientation(int pividx,float frame);
 	void							Get_Translation(Vector3& translation, int pividx,float frame) const;
 	void							Get_Orientation(Quaternion& orientation, int pividx,float frame) const;
 	void							Get_Transform(Matrix3D& transform, int pividx,float frame) const;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/hrawanim.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/hrawanim.h
@@ -97,8 +97,6 @@ public:
 	float							Get_Frame_Rate() { return FrameRate; }
 	float							Get_Total_Time() { return (float)NumFrames / FrameRate; }
 
-//	Vector3						Get_Translation(int pividx,float frame);
-//	Quaternion					Get_Orientation(int pividx,float frame);
 	void							Get_Translation(Vector3& translation, int pividx,float frame) const;
 	void							Get_Orientation(Quaternion& orientation, int pividx,float frame) const;
 	void							Get_Transform(Matrix3D& transform, int pividx,float frame) const;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/part_emt.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/part_emt.cpp
@@ -558,7 +558,7 @@ void ParticleEmitterClass::Create_New_Particles(const Quaternion & curr_quat, co
 	// the previous interval when the last particle was emitted) is added to
 	// the size of the current frame to yield the time currently available
 	// for emitting particles.
-	unsigned int frametime = WW3D::Get_Frame_Time();
+	unsigned int frametime = WW3D::Get_Sync_Frame_Time();
 	// Since the particles are written into a wraparound buffer, we can take the time modulo a time
 	// constant which represents the time it takes to fill up the entire buffer with new particles.
 	// We will do this so we don't run into performance problems with very large frame times.

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp
@@ -1317,9 +1317,8 @@ void TexProjectClass::Pre_Render_Update(const Matrix3D & camera)
 	/*
 	** update the current intensity by iterating it towards the desired intensity
 	*/
-	float frame_time = (float)WW3D::Get_Sync_Frame_Time() / 1000.0f;
 	float intensity_delta = DesiredIntensity - Intensity;
-	float max_intensity_delta = INTENSITY_RATE_OF_CHANGE * frame_time;
+	float max_intensity_delta = INTENSITY_RATE_OF_CHANGE * WW3D::Get_Logic_Frame_Time_Seconds();
 
 	if (intensity_delta > max_intensity_delta) {
 		Intensity += max_intensity_delta;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/texproject.cpp
@@ -1317,7 +1317,7 @@ void TexProjectClass::Pre_Render_Update(const Matrix3D & camera)
 	/*
 	** update the current intensity by iterating it towards the desired intensity
 	*/
-	float frame_time = (float)WW3D::Get_Frame_Time() / 1000.0f;
+	float frame_time = (float)WW3D::Get_Sync_Frame_Time() / 1000.0f;
 	float intensity_delta = DesiredIntensity - Intensity;
 	float max_intensity_delta = INTENSITY_RATE_OF_CHANGE * frame_time;
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
@@ -166,6 +166,7 @@ const char* DAZZLE_INI_FILENAME="DAZZLE.INI";
 **
 ***********************************************************************************/
 
+float														WW3D::LogicFrameTimeMs = 33.33f;
 float															WW3D::FractionalSyncMs = 0.0f;
 unsigned int											WW3D::SyncTime = 0;
 unsigned int											WW3D::PreviousSyncTime = 0;
@@ -1163,8 +1164,9 @@ unsigned int WW3D::Get_Last_Frame_Vertex_Count(void)
 	return Debug_Statistics::Get_DX8_Vertices();
 }
 
-void WW3D::Add_Frame_Time(float milliseconds)
+void WW3D::Update_Logic_Frame_Time(float milliseconds)
 {
+	LogicFrameTimeMs = milliseconds;
 	FractionalSyncMs += milliseconds;
 	unsigned int integralSyncMs = (unsigned int)FractionalSyncMs;
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
@@ -166,7 +166,7 @@ const char* DAZZLE_INI_FILENAME="DAZZLE.INI";
 **
 ***********************************************************************************/
 
-float														WW3D::LogicFrameTimeMs = 33.33f;
+float														WW3D::LogicFrameTimeMs = 1000.0f / WWSyncPerSecond; // initialized to something to avoid division by zero on first use
 float															WW3D::FractionalSyncMs = 0.0f;
 unsigned int											WW3D::SyncTime = 0;
 unsigned int											WW3D::PreviousSyncTime = 0;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
@@ -1168,18 +1168,6 @@ void WW3D::Update_Logic_Frame_Time(float milliseconds)
 {
 	LogicFrameTimeMs = milliseconds;
 	FractionalSyncMs += milliseconds;
-	unsigned int integralSyncMs = (unsigned int)FractionalSyncMs;
-
-#if MSEC_PER_WWSYNC_FRAME
-	if (integralSyncMs < MSEC_PER_WWSYNC_FRAME)
-	{
-		Sync(SyncTime);
-		return;
-	}
-#endif
-
-	FractionalSyncMs -= integralSyncMs;
-	Sync(SyncTime + integralSyncMs);
 }
 
 
@@ -1195,12 +1183,17 @@ void WW3D::Update_Logic_Frame_Time(float milliseconds)
  * HISTORY:                                                                                    *
  *   3/24/98    GTH : Created.                                                                 *
  *=============================================================================================*/
-void WW3D::Sync(unsigned int sync_time)
+void WW3D::Sync(bool step)
 {
 	PreviousSyncTime = SyncTime;
-   SyncTime = sync_time;
-}
 
+	if (step)
+	{
+		unsigned int integralSyncMs = (unsigned int)FractionalSyncMs;
+		FractionalSyncMs -= integralSyncMs;
+		SyncTime += integralSyncMs;
+	}
+}
 
 /***********************************************************************************************
  * WW3D::Set_Ext_Swap_Interval -- Sets the swap interval the device should aim sync for.       *

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/ww3d.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/ww3d.h
@@ -162,9 +162,9 @@ public:
 
 	static void Flip_To_Primary(void);
 
-	// TheSuperHackers @info Call this function to accumulate fractional render time.
-	// It will then call Sync with a new time on its own once an appropriate amount of time has passed.
-	static void Add_Frame_Time(float milliseconds);
+	// TheSuperHackers @info Add amount of milliseconds that the simulation has advanced in this render frame.
+	// This can be a fraction of a logic step. It will call Sync on its own once an appropriate amount of time has passed.
+	static void Update_Logic_Frame_Time(float milliseconds);
 	/*
 	** Timing
 	** By calling the Sync function, the application can move the ww3d library time forward.  This
@@ -173,6 +173,8 @@ public:
 	static void						Sync( unsigned int sync_time );
 	static unsigned int		Get_Sync_Time(void) { return SyncTime; }
 	static unsigned int		Get_Sync_Frame_Time(void) { return SyncTime - PreviousSyncTime; }
+	static float					Get_Logic_Frame_Time_Milliseconds() { return LogicFrameTimeMs; }
+	static float					Get_Logic_Frame_Time_Seconds() { return LogicFrameTimeMs * 0.001f; }
 	static unsigned int		Get_Frame_Count(void) { return FrameCount; }
 	static unsigned int		Get_Last_Frame_Poly_Count(void);
 	static unsigned int		Get_Last_Frame_Vertex_Count(void);
@@ -323,6 +325,10 @@ private:
 	static void					Allocate_Debug_Resources(void);
 	static void					Release_Debug_Resources(void);
 
+	// Logic frame time, in milliseconds
+	static float LogicFrameTimeMs;
+
+	// Accumulated synchronized frame time in milliseconds
 	static float FractionalSyncMs;
 
 	// Timing info:

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/ww3d.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/ww3d.h
@@ -163,14 +163,14 @@ public:
 	static void Flip_To_Primary(void);
 
 	// TheSuperHackers @info Add amount of milliseconds that the simulation has advanced in this render frame.
-	// This can be a fraction of a logic step. It will call Sync on its own once an appropriate amount of time has passed.
+	// This can be a fraction of a logic step.
 	static void Update_Logic_Frame_Time(float milliseconds);
 	/*
 	** Timing
 	** By calling the Sync function, the application can move the ww3d library time forward.  This
 	** will control things like animated uv-offset mappers and render object animations.
 	*/
-	static void						Sync( unsigned int sync_time );
+	static void						Sync(bool step);
 	static unsigned int		Get_Sync_Time(void) { return SyncTime; }
 	static unsigned int		Get_Sync_Frame_Time(void) { return SyncTime - PreviousSyncTime; }
 	static float					Get_Logic_Frame_Time_Milliseconds() { return LogicFrameTimeMs; }

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/ww3d.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/ww3d.h
@@ -170,10 +170,10 @@ public:
 	** By calling the Sync function, the application can move the ww3d library time forward.  This
 	** will control things like animated uv-offset mappers and render object animations.
 	*/
-	static void					Sync( unsigned int sync_time );
+	static void						Sync( unsigned int sync_time );
 	static unsigned int		Get_Sync_Time(void) { return SyncTime; }
-   static unsigned int     Get_Frame_Time(void) { return SyncTime - PreviousSyncTime; }
-   static unsigned int     Get_Frame_Count(void) { return FrameCount; }
+	static unsigned int		Get_Sync_Frame_Time(void) { return SyncTime - PreviousSyncTime; }
+	static unsigned int		Get_Frame_Count(void) { return FrameCount; }
 	static unsigned int		Get_Last_Frame_Poly_Count(void);
 	static unsigned int		Get_Last_Frame_Vertex_Count(void);
 
@@ -326,16 +326,16 @@ private:
 	static float FractionalSyncMs;
 
 	// Timing info:
-   // The absolute synchronized frame time (in milliseconds) supplied by the
-   // application at the start of every frame. Note that wraparound cases
-   // etc. need to be considered.
-	static unsigned int				SyncTime;
+	// The absolute synchronized frame time (in milliseconds) supplied by the
+	// application at the start of every frame. Note that wraparound cases
+	// etc. need to be considered.
+	static unsigned int SyncTime;
 
-   // The previously set absolute sync time - this is used to get the interval between
-   // the most recently set sync time and the previous one. Assuming the
-   // application sets sync time at the start of every frame, this represents
-   // the frame interval.
-   static unsigned int           PreviousSyncTime;
+	// The previously set absolute sync time - this is used to get the interval between
+	// the most recently set sync time and the previous one. Assuming the
+	// application sets sync time at the start of every frame, this represents
+	// the frame interval.
+	static unsigned int PreviousSyncTime;
 
 	static float						PixelCenterX;
 	static float						PixelCenterY;


### PR DESCRIPTION
**Merge with Rebase**

* Follow up for #1528
* Fixes #1636

This change is a follow up for #1528 and applies more fixes to properly decouple the render update from the logic step. This change has a lot of tiny commits to make it easy to review and find any issues that may arise from it.

The following issues were identified and fixed:

## W3DTankDraw update

Unlike `W3DTruckDraw` and `W3DTankTruckDraw`, the `W3DTankDraw::doDrawModule` did not call `W3DModelDraw::doDrawModule` on every render frame. This caused missing object transform on every non-logic frame. Simple fix.

## Snow update

Snow movement was updated once every logic frame. It is now smoothly updated every render frame.

## Segline update

Segmented line update (used by Lotus Hack, Patriot Assist beam) was updated once every logic frame. It is now smoothly updated every render frame.

## W3D Object Animation update

Decoupling the object animations for logic step was a bit more tricky because there was a bug that would not cause issues in the original implementation, but was a problem for the decoupling.

`Animatable3DObjClass::Single_Anim_Progress` was called twice every update, so trying to advance an animation with the render frame time would advance it twice as fast. This is now fixed.

`Animatable3DObjClass::Compute_Current_Frame` is now smoothly updated every render frame.

## WW Sync not in sync with Logic Step

The WW Sync was not perfectly in frame sync with the logic step. It was interleaved. This was introduced by previous changes. The result of this was that objects would move in one render frame, but object animations and physic movements would apply 1 render frame or so later. They would still have the same tick, but not on the exact frame. This is bad, because it gives the illusion of jittery movement.

The WW Sync and Logic Step are not back in sync.

## W3D Object Animation interpolation

All AnimClass animation have interpolation support for transforms and rotations. But `HRawAnimClass` had it intentionally disabled. This affects many (or all?) animations. Interpolations are now enabled, which makes all animations perfectly smooth. This is desirable on almost all animations, except for those that want to teleport meshes, such as blinking lights.

## Cloud update

The terrain cloud was updated once every logic frame. It is now smoothly updated every render frame. To do that, the cloud movement had to be moved out of its prior function into a new one that is only called once, instead of many times over.

## Drawable Tint Envelope update

The build placement preview object started flickering when it was colliding with objects. The reason for this was a bit more complicated to figure out: 

The calls to `colorTint` for the drawable in `InGameUI::handleBuildPlacements` on drawable collision are not called every logic frame, but every second logic frame. Furthermore, the tint envelope was not actually tinting with a stable color as was intended, but did attempt to fade the tint on the next frame. This caused the flickering on the alternating logic frames. This issue was fixed by correcting the tint logic mistakes.

## RingRenderObjClass::animate, SphereRenderObjClass::animate, DazzleRenderObjClass::Render, TexProjectClass::Pre_Render_Update

Courtesy. I adjusted these 4 to logically update correctly every render frame, but they appear to be unused and I have not found a way to test them.

## TODO

- [x] Replicate in Generals
- [x] Add pull id to commits