### PR TITLE
feat(client): Make opacity and shadows of build placement preview objects customizable

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/GlobalData.h
+++ b/Generals/Code/GameEngine/Include/Common/GlobalData.h
@@ -425,6 +425,9 @@ public:
 
 	AsciiString m_specialPowerViewObjectName;	///< Created when certain special powers are fired so players can watch.
 
+	Real m_objectPlacementOpacity; ///< Sets the opacity of build preview objects.
+	Bool m_objectPlacementShadows; ///< Enables or disables shadows of build preview objects.
+
 	std::vector<AsciiString> m_standardPublicBones;
 
 	Real m_standardMinefieldDensity;

--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -398,6 +398,7 @@ GlobalData* GlobalData::m_theOriginal = NULL;
 	{ "EnforceMaxCameraHeight",			INI::parseBool,				NULL,			offsetof( GlobalData, m_enforceMaxCameraHeight ) },
 	{ "KeyboardScrollSpeedFactor",	INI::parseReal,				NULL,			offsetof( GlobalData, m_keyboardScrollFactor ) },
 	{ "KeyboardDefaultScrollSpeedFactor",	INI::parseReal,				NULL,			offsetof( GlobalData, m_keyboardDefaultScrollFactor ) },
+	{ "KeyboardCameraRotateSpeed", INI::parseReal, NULL, offsetof( GlobalData, m_keyboardCameraRotateSpeed ) },
 	{ "MovementPenaltyDamageState",	INI::parseIndexList,	TheBodyDamageTypeNames,	 offsetof( GlobalData, m_movementPenaltyDamageState ) },
 
 // you cannot set this; it always has a value of 100%.
@@ -457,6 +458,11 @@ GlobalData* GlobalData::m_theOriginal = NULL;
 
 	{ "SpecialPowerViewObject",			INI::parseAsciiString,	NULL,			offsetof( GlobalData, m_specialPowerViewObjectName ) },
 
+	// TheSuperHackers @feature Customize the opacity (0..1) and shadows of build preview objects. Shadows are enabled by default.
+	// Note that disabling shadows loses a fair bit of contrast visually and warrants raising the opacity.
+	{ "ObjectPlacementOpacity", INI::parseReal, NULL, offsetof( GlobalData, m_objectPlacementOpacity ) },
+	{ "ObjectPlacementShadows", INI::parseBool, NULL, offsetof( GlobalData, m_objectPlacementShadows ) },
+
 	{ "StandardPublicBone", INI::parseAsciiStringVectorAppend, NULL, offsetof(GlobalData, m_standardPublicBones) },
 	{ "ShowMetrics",								INI::parseBool,				NULL,			offsetof( GlobalData, m_showMetrics ) },
 	{ "DefaultStartingCash",				INI::parseUnsignedInt, NULL,		offsetof( GlobalData, m_defaultStartingCash ) },
@@ -486,7 +492,6 @@ GlobalData* GlobalData::m_theOriginal = NULL;
 	{ "NetworkPlayerTimeoutTime", INI::parseInt, NULL, offsetof(GlobalData, m_networkPlayerTimeoutTime) },
 	{ "NetworkDisconnectScreenNotifyTime", INI::parseInt, NULL, offsetof(GlobalData, m_networkDisconnectScreenNotifyTime) },
 
-	{ "KeyboardCameraRotateSpeed", INI::parseReal, NULL, offsetof( GlobalData, m_keyboardCameraRotateSpeed ) },
 	{ "PlayStats",									INI::parseInt,				NULL,			offsetof( GlobalData, m_playStats ) },
 
 #if defined(RTS_DEBUG)
@@ -867,6 +872,9 @@ GlobalData::GlobalData()
 
 	m_standardMinefieldDensity = 0.01f;
 	m_standardMinefieldDistance = 40.0f;
+
+	m_objectPlacementOpacity = 0.45f;
+	m_objectPlacementShadows = TRUE;
 
 	m_groupSelectMinSelectSize = 5;
 	m_groupSelectVolumeBase = 0.5f;

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -87,8 +87,7 @@
 
 
 // ------------------------------------------------------------------------------------------------
-static const Real placementOpacity = 0.45f;
-static const RGBColor illegalBuildColor = { 1.0, 0.0, 0.0 };
+static const RGBColor IllegalBuildColor = { 1.0, 0.0, 0.0 };
 
 //-------------------------------------------------------------------------------------------------
 /// The InGameUI singleton instance.
@@ -1467,8 +1466,9 @@ void InGameUI::handleBuildPlacements( void )
 																											 BuildAssistant::SHROUD_REVEALED,
 																											 builderObject,
 																											 NULL );
+
 			if( lbc != LBC_OK )
-				m_placeIcon[ 0 ]->colorTint( &illegalBuildColor );
+				m_placeIcon[ 0 ]->colorTint( &IllegalBuildColor );
 			else
 				m_placeIcon[ 0 ]->colorTint( NULL );
 
@@ -1528,8 +1528,11 @@ void InGameUI::handleBuildPlacements( void )
 			{
 
 				if( m_placeIcon[ i ] == NULL )
-					m_placeIcon[ i ] = TheThingFactory->newDrawable( m_pendingPlaceType,
-						DRAWABLE_STATUS_SHADOWS | DRAWABLE_STATUS_NO_STATE_PARTICLES );
+				{
+					UnsignedInt drawableStatus = DRAWABLE_STATUS_NO_STATE_PARTICLES;
+					drawableStatus |= TheGlobalData->m_objectPlacementShadows ? DRAWABLE_STATUS_SHADOWS : 0;
+					m_placeIcon[ i ] = TheThingFactory->newDrawable( m_pendingPlaceType, drawableStatus );
+				}
 
 			}
 
@@ -1553,11 +1556,11 @@ void InGameUI::handleBuildPlacements( void )
 			for( i = 0; i < tileBuildInfo->tilesUsed; i++ )
 			{
 
-				// set the drawble position
+				// set the drawable position
 				m_placeIcon[ i ]->setPosition( &tileBuildInfo->positions[ i ] );
 
-				// set opacity for the drawble
-				m_placeIcon[ i ]->setDrawableOpacity( placementOpacity );
+				// set opacity for the drawable
+				m_placeIcon[ i ]->setDrawableOpacity( TheGlobalData->m_objectPlacementOpacity );
 
 				// set the drawable angle
 				m_placeIcon[ i ]->setOrientation( angle );
@@ -3039,8 +3042,12 @@ void InGameUI::placeBuildAvailable( const ThingTemplate *build, Drawable *buildD
 			///@ todo when message stream order more formalized eliminate this
 //			TheInGameUI->deselectAllDrawables();
 
-			// create a drawble of what we are building to be "attached" at the cursor
-			draw = TheThingFactory->newDrawable( build, DRAWABLE_STATUS_SHADOWS | DRAWABLE_STATUS_NO_STATE_PARTICLES );
+			{
+				// create a drawable of what we are building to be "attached" at the cursor
+				UnsignedInt drawableStatus = DRAWABLE_STATUS_NO_STATE_PARTICLES;
+				drawableStatus |= TheGlobalData->m_objectPlacementShadows ? DRAWABLE_STATUS_SHADOWS : 0;
+				draw = TheThingFactory->newDrawable( build, drawableStatus );
+			}
 			if (sourceObject)
 			{
 				if (TheGlobalData->m_timeOfDay == TIME_OF_DAY_NIGHT)
@@ -3058,14 +3065,11 @@ void InGameUI::placeBuildAvailable( const ThingTemplate *build, Drawable *buildD
 			//
 			Real angle = build->getPlacementViewAngle();
 
-			// don't forget to take into account the current view angle
-			// angle += TheTacticalView->getAngle();	Don't do this - makes odd angled building placements.  jba.
-
 			// set the angle in the icon we just created
 			draw->setOrientation( angle );
 
 			// set the build icon attached to the cursor to be "see-thru"
-			draw->setDrawableOpacity( placementOpacity );
+			draw->setDrawableOpacity( TheGlobalData->m_objectPlacementOpacity );
 
 			// set the "icon" in the icon array at the first index
 			DEBUG_ASSERTCRASH( m_placeIcon[ 0 ] == NULL, ("placeBuildAvailable, build icon array is not empty!") );

--- a/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
@@ -436,6 +436,9 @@ public:
 
 	AsciiString m_specialPowerViewObjectName;	///< Created when certain special powers are fired so players can watch.
 
+	Real m_objectPlacementOpacity; ///< Sets the opacity of build preview objects.
+	Bool m_objectPlacementShadows; ///< Enables or disables shadows of build preview objects.
+
 	std::vector<AsciiString> m_standardPublicBones;
 
 	Real m_standardMinefieldDensity;

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -398,6 +398,7 @@ GlobalData* GlobalData::m_theOriginal = NULL;
 	{ "EnforceMaxCameraHeight",			INI::parseBool,				NULL,			offsetof( GlobalData, m_enforceMaxCameraHeight ) },
 	{ "KeyboardScrollSpeedFactor",	INI::parseReal,				NULL,			offsetof( GlobalData, m_keyboardScrollFactor ) },
 	{ "KeyboardDefaultScrollSpeedFactor",	INI::parseReal,				NULL,			offsetof( GlobalData, m_keyboardDefaultScrollFactor ) },
+	{ "KeyboardCameraRotateSpeed", INI::parseReal, NULL, offsetof( GlobalData, m_keyboardCameraRotateSpeed ) },
 	{ "MovementPenaltyDamageState",	INI::parseIndexList,	TheBodyDamageTypeNames,	 offsetof( GlobalData, m_movementPenaltyDamageState ) },
 
 // you cannot set this; it always has a value of 100%.
@@ -457,6 +458,11 @@ GlobalData* GlobalData::m_theOriginal = NULL;
 
 	{ "SpecialPowerViewObject",			INI::parseAsciiString,	NULL,			offsetof( GlobalData, m_specialPowerViewObjectName ) },
 
+	// TheSuperHackers @feature Customize the opacity (0..1) and shadows of build preview objects. Shadows are enabled by default.
+	// Note that disabling shadows loses a fair bit of contrast visually and warrants raising the opacity.
+	{ "ObjectPlacementOpacity", INI::parseReal, NULL, offsetof( GlobalData, m_objectPlacementOpacity ) },
+	{ "ObjectPlacementShadows", INI::parseBool, NULL, offsetof( GlobalData, m_objectPlacementShadows ) },
+
 	{ "StandardPublicBone", INI::parseAsciiStringVectorAppend, NULL, offsetof(GlobalData, m_standardPublicBones) },
 	{ "ShowMetrics",								INI::parseBool,				   NULL,		offsetof( GlobalData, m_showMetrics ) },
   { "DefaultStartingCash",				Money::parseMoneyAmount, NULL,		offsetof( GlobalData, m_defaultStartingCash ) },
@@ -486,7 +492,6 @@ GlobalData* GlobalData::m_theOriginal = NULL;
 	{ "NetworkPlayerTimeoutTime", INI::parseInt, NULL, offsetof(GlobalData, m_networkPlayerTimeoutTime) },
 	{ "NetworkDisconnectScreenNotifyTime", INI::parseInt, NULL, offsetof(GlobalData, m_networkDisconnectScreenNotifyTime) },
 
-	{ "KeyboardCameraRotateSpeed", INI::parseReal, NULL, offsetof( GlobalData, m_keyboardCameraRotateSpeed ) },
 	{ "PlayStats",									INI::parseInt,				NULL,			offsetof( GlobalData, m_playStats ) },
 
 #if defined(RTS_DEBUG)
@@ -873,6 +878,9 @@ GlobalData::GlobalData()
 
 	m_standardMinefieldDensity = 0.01f;
 	m_standardMinefieldDistance = 40.0f;
+
+	m_objectPlacementOpacity = 0.45f;
+	m_objectPlacementShadows = TRUE;
 
 	m_groupSelectMinSelectSize = 5;
 	m_groupSelectVolumeBase = 0.5f;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -91,8 +91,7 @@
 
 
 // ------------------------------------------------------------------------------------------------
-static const Real placementOpacity = 0.45f;
-static const RGBColor illegalBuildColor = { 1.0, 0.0, 0.0 };
+static const RGBColor IllegalBuildColor = { 1.0, 0.0, 0.0 };
 
 //-------------------------------------------------------------------------------------------------
 /// The InGameUI singleton instance.
@@ -1523,8 +1522,9 @@ void InGameUI::handleBuildPlacements( void )
 																											 BuildAssistant::IGNORE_STEALTHED,
 																											 builderObject,
 																											 NULL );
+
 			if( lbc != LBC_OK )
-				m_placeIcon[ 0 ]->colorTint( &illegalBuildColor );
+				m_placeIcon[ 0 ]->colorTint( &IllegalBuildColor );
 			else
 				m_placeIcon[ 0 ]->colorTint( NULL );
 
@@ -1584,8 +1584,11 @@ void InGameUI::handleBuildPlacements( void )
 			{
 
 				if( m_placeIcon[ i ] == NULL )
-					m_placeIcon[ i ] = TheThingFactory->newDrawable( m_pendingPlaceType,
-						DRAWABLE_STATUS_SHADOWS | DRAWABLE_STATUS_NO_STATE_PARTICLES );
+				{
+					UnsignedInt drawableStatus = DRAWABLE_STATUS_NO_STATE_PARTICLES;
+					drawableStatus |= TheGlobalData->m_objectPlacementShadows ? DRAWABLE_STATUS_SHADOWS : 0;
+					m_placeIcon[ i ] = TheThingFactory->newDrawable( m_pendingPlaceType, drawableStatus );
+				}
 
 			}
 
@@ -1609,11 +1612,11 @@ void InGameUI::handleBuildPlacements( void )
 			for( i = 0; i < tileBuildInfo->tilesUsed; i++ )
 			{
 
-				// set the drawble position
+				// set the drawable position
 				m_placeIcon[ i ]->setPosition( &tileBuildInfo->positions[ i ] );
 
-				// set opacity for the drawble
-				m_placeIcon[ i ]->setDrawableOpacity( placementOpacity );
+				// set opacity for the drawable
+				m_placeIcon[ i ]->setDrawableOpacity( TheGlobalData->m_objectPlacementOpacity );
 
 				// set the drawable angle
 				m_placeIcon[ i ]->setOrientation( angle );
@@ -3119,8 +3122,12 @@ void InGameUI::placeBuildAvailable( const ThingTemplate *build, Drawable *buildD
 			///@ todo when message stream order more formalized eliminate this
 //			TheInGameUI->deselectAllDrawables();
 
-			// create a drawble of what we are building to be "attached" at the cursor
-			draw = TheThingFactory->newDrawable( build, DRAWABLE_STATUS_SHADOWS | DRAWABLE_STATUS_NO_STATE_PARTICLES );
+			{
+				// create a drawable of what we are building to be "attached" at the cursor
+				UnsignedInt drawableStatus = DRAWABLE_STATUS_NO_STATE_PARTICLES;
+				drawableStatus |= TheGlobalData->m_objectPlacementShadows ? DRAWABLE_STATUS_SHADOWS : 0;
+				draw = TheThingFactory->newDrawable( build, drawableStatus );
+			}
 			if (sourceObject)
 			{
 				if (TheGlobalData->m_timeOfDay == TIME_OF_DAY_NIGHT)
@@ -3138,14 +3145,11 @@ void InGameUI::placeBuildAvailable( const ThingTemplate *build, Drawable *buildD
 			//
 			Real angle = build->getPlacementViewAngle();
 
-			// don't forget to take into account the current view angle
-			// angle += TheTacticalView->getAngle();	Don't do this - makes odd angled building placements.  jba.
-
 			// set the angle in the icon we just created
 			draw->setOrientation( angle );
 
 			// set the build icon attached to the cursor to be "see-thru"
-			draw->setDrawableOpacity( placementOpacity );
+			draw->setDrawableOpacity( TheGlobalData->m_objectPlacementOpacity );
 
 			// set the "icon" in the icon array at the first index
 			DEBUG_ASSERTCRASH( m_placeIcon[ 0 ] == NULL, ("placeBuildAvailable, build icon array is not empty!") );


### PR DESCRIPTION
* Merge after #1591

This change makes the opacity and shadows of build placement preview objects customizable. It adds new fields `ObjectPlacementOpacity=0..1` and `ObjectPlacementShadows=Yes/No` to GameData.ini.

By default, user facing nothing changes.

I put the mod fields into GameData.ini instead of InGameUI.ini because thematically it does not fit in InGameUI, despite being referenced there.

I have chosen the new fields names because there is precedent in `Object: PlacementViewAngle`.

## Example Modification

```
ObjectPlacementOpacity = 0.60
ObjectPlacementShadows = No
```

![shot_20250914_191345_1](https://github.com/user-attachments/assets/8c4fde24-4c00-41c4-9279-1a565a0ad637)

## TODO

- [x] Replicate in Generals