### PR TITLE
refactor(logic): Remove double initialization of camera zoom and angles

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -2082,9 +2082,6 @@ void GameLogic::startNewGame( Bool loadingSaveGame )
 	// update the loadscreen
 	updateLoadProgress(LOAD_PROGRESS_POST_PRELOAD_ASSETS);
 
-	TheTacticalView->setAngleAndPitchToDefault();
-	TheTacticalView->setZoomToDefault();
-
 	if( TheRecorder )
 		TheRecorder->initControls();
 
@@ -2108,6 +2105,11 @@ void GameLogic::startNewGame( Bool loadingSaveGame )
 	// update the loadscreen
 	updateLoadProgress(LOAD_PROGRESS_POST_STARTING_CAMERA);
 
+	// Set up the camera height based on the map height & globalData.
+	TheTacticalView->initHeightForMap();
+	TheTacticalView->setAngleAndPitchToDefault();
+	TheTacticalView->setZoomToDefault();
+
 	Waypoint *way = findNamedWaypoint(startingCamName);
 	if (way)
 	{
@@ -2125,11 +2127,6 @@ void GameLogic::startNewGame( Bool loadingSaveGame )
 		TheTacticalView->lookAt( &pos );
 		DEBUG_LOG(("Failed to find initial camera position waypoint %s", startingCamName.str()));
 	}
-
-	// Set up the camera height based on the map height & globalData.
-	TheTacticalView->initHeightForMap();
-	TheTacticalView->setAngleAndPitchToDefault();
-	TheTacticalView->setZoomToDefault();
 
 	// update the loadscreen
 	updateLoadProgress(LOAD_PROGRESS_POST_STARTING_CAMERA_2);


### PR DESCRIPTION
This change removes the double initialization of camera zoom and angles in `GameLogic::startNewGame`. User facing nothing changes.

## TODO

- [ ] Replicate in Generals