### PR TITLE
feat(crashdump): Add crash dump functionality for fatal errors

### DIFF
--- a/Core/GameEngine/CMakeLists.txt
+++ b/Core/GameEngine/CMakeLists.txt
@@ -70,6 +70,8 @@ set(GAMEENGINE_SRC
 #    Include/Common/MapObject.h
 #    Include/Common/MapReaderWriterInfo.h
 #    Include/Common/MessageStream.h
+    Include/Common/MiniDumper.h
+    Include/Common/MiniDumper_compat.h
 #    Include/Common/MiniLog.h
     Include/Common/MiscAudio.h
 #    Include/Common/MissionStats.h
@@ -657,6 +659,7 @@ set(GAMEENGINE_SRC
 #    Source/Common/System/List.cpp
     Source/Common/System/LocalFile.cpp
     Source/Common/System/LocalFileSystem.cpp
+    Source/Common/System/MiniDumper.cpp
 #    Source/Common/System/ObjectStatusTypes.cpp
 #    Source/Common/System/QuotedPrintable.cpp
 #    Source/Common/System/Radar.cpp

--- a/Core/GameEngine/Include/Common/GameMemory.h
+++ b/Core/GameEngine/Include/Common/GameMemory.h
@@ -226,6 +226,9 @@ class MemoryPool;
 class MemoryPoolFactory;
 class DynamicMemoryAllocator;
 class BlockCheckpointInfo;
+#ifdef RTS_ENABLE_CRASHDUMP
+class AllocationRangeIterator;
+#endif
 
 // TYPE DEFINES ///////////////////////////////////////////////////////////////
 
@@ -279,6 +282,14 @@ public:
 	void debugCheckpointReport(Int flags, Int startCheckpoint, Int endCheckpoint, const char *poolName);
 	/// reset all the checkpoints for this pool/dma
 	void debugResetCheckpoints();
+};
+#endif
+
+#ifdef RTS_ENABLE_CRASHDUMP
+struct MemoryPoolAllocatedRange
+{
+	char* allocationAddr;
+	size_t allocationSize;
 };
 #endif
 
@@ -387,6 +398,9 @@ public:
 		/// return true iff this block was allocated by this pool.
 		Bool debugIsBlockInPool(void *pBlock);
 	#endif
+#ifdef RTS_ENABLE_CRASHDUMP
+		friend class AllocationRangeIterator;
+#endif
 };
 
 // ----------------------------------------------------------------------------
@@ -477,11 +491,68 @@ public:
 		Bool debugIsPoolInDma(MemoryPool *pool);
 
 	#endif	// MEMORYPOOL_DEBUG
+#ifdef RTS_ENABLE_CRASHDUMP
+		Int getRawBlockCount() const;
+		void fillAllocationRangeForRawBlockN(const Int n, MemoryPoolAllocatedRange& allocationRange) const;
+#endif
 };
 
 // ----------------------------------------------------------------------------
 #ifdef MEMORYPOOL_DEBUG
 enum { MAX_SPECIAL_USED = 256 };
+#endif
+
+#ifdef RTS_ENABLE_CRASHDUMP
+class AllocationRangeIterator {
+	typedef const MemoryPoolAllocatedRange value_type;
+	typedef const MemoryPoolAllocatedRange* pointer;
+	typedef const MemoryPoolAllocatedRange& reference;
+public:
+
+	AllocationRangeIterator(const MemoryPoolFactory* factory);
+	AllocationRangeIterator(MemoryPool& pool, MemoryPoolBlob& blob) {
+		m_currentPool = &pool;
+		m_currentBlobInPool = &blob;
+		m_factory = NULL;
+		m_range = MemoryPoolAllocatedRange();
+	};
+
+	AllocationRangeIterator(MemoryPool* pool, MemoryPoolBlob* blob)
+	{
+		m_currentPool = pool;
+		m_currentBlobInPool = blob;
+		m_factory = NULL;
+		m_range = MemoryPoolAllocatedRange();
+	};
+
+	AllocationRangeIterator()
+	{
+		m_currentPool = NULL;
+		m_currentBlobInPool = NULL;
+		m_factory = NULL;
+		m_range = MemoryPoolAllocatedRange();
+	};
+
+	reference operator*() { UpdateRange(); return m_range; }
+	pointer operator->() { UpdateRange(); return &m_range; }
+
+	// Prefix increment
+	AllocationRangeIterator& operator++() { MoveToNextBlob(); return *this; }
+
+	// Postfix increment
+	AllocationRangeIterator operator++(int) { AllocationRangeIterator tmp = *this; ++(*this); return tmp; }
+
+	friend bool operator== (const AllocationRangeIterator& a, const AllocationRangeIterator& b) { return a.m_currentBlobInPool == b.m_currentBlobInPool; };
+	friend bool operator!= (const AllocationRangeIterator& a, const AllocationRangeIterator& b) { return a.m_currentBlobInPool != b.m_currentBlobInPool; };
+
+private:
+	const MemoryPoolFactory* m_factory;
+	MemoryPool* m_currentPool;
+	MemoryPoolBlob* m_currentBlobInPool;
+	MemoryPoolAllocatedRange m_range;
+	void UpdateRange();
+	void MoveToNextBlob();
+};
 #endif
 
 // ----------------------------------------------------------------------------
@@ -576,6 +647,19 @@ public:
 		void debugResetCheckpoints();
 
 	#endif
+#ifdef RTS_ENABLE_CRASHDUMP
+		AllocationRangeIterator cbegin() const {
+			return AllocationRangeIterator(this);
+		}
+
+		AllocationRangeIterator cend() const {
+			return AllocationRangeIterator(NULL, NULL);
+		}
+
+		Int getMemoryPoolCount() const;
+		MemoryPool* getMemoryPoolN(const Int n) const;
+		friend class AllocationRangeIterator;
+#endif
 };
 
 // how many bytes are we allowed to 'waste' per pool allocation before the debug code starts yelling at us...

--- a/Core/GameEngine/Include/Common/MiniDumper.h
+++ b/Core/GameEngine/Include/Common/MiniDumper.h
@@ -1,0 +1,120 @@
+/*
+**	Command & Conquer Generals Zero Hour(tm)
+**	Copyright 2025 TheSuperHackers
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#ifdef RTS_ENABLE_CRASHDUMP
+#include <imagehlp.h>
+#include "Common/MiniDumper_compat.h"
+
+class MiniDumper
+{
+public:
+	MiniDumper()
+	{
+		m_miniDumpInitialized = false;
+		m_extendedInfoRequested = false;
+		m_dbgHlp = NULL;
+		m_pMiniDumpWriteDump = NULL;
+		m_dumpRequested = NULL;
+		m_dumpComplete = NULL;
+		m_quitting = NULL;
+		m_dumpThread = NULL;
+		m_dumpThreadId = 0;
+		m_dumpObjectsState = 0;
+		m_dumpObjectsSubState = 0;
+		m_dmaRawBlockIndex = 0;
+		memset(m_dumpDir, 0, ARRAY_SIZE(m_dumpDir));
+		memset(m_dumpFile, 0, ARRAY_SIZE(m_dumpFile));
+		memset(m_sysDbgHelpPath, 0, ARRAY_SIZE(m_sysDbgHelpPath));
+	};
+
+	void Initialize(const AsciiString& userDirPath);
+	Bool IsInitialized() const;
+	void TriggerMiniDump(Bool extendedInfo = false);
+	void TriggerMiniDumpForException(struct _EXCEPTION_POINTERS* e_info, Bool extendedInfo = false);
+	void ShutDown();
+	static LONG WINAPI DumpingExceptionFilter(struct _EXCEPTION_POINTERS* e_info);
+private:
+	void CreateMiniDump(Bool extendedInfo);
+	BOOL DumpMemoryObjects(ULONG64& memoryBase, ULONG& memorySize);
+	void CleanupResources();
+
+	// Callbacks from dbghelp
+	static BOOL CALLBACK MiniDumpCallback(PVOID CallbackParam, PMINIDUMP_CALLBACK_INPUT CallbackInput, PMINIDUMP_CALLBACK_OUTPUT CallbackOutput);
+	BOOL CallbackInternal(const MINIDUMP_CALLBACK_INPUT& input, MINIDUMP_CALLBACK_OUTPUT& output);
+
+	// Thread procs
+	static DWORD WINAPI MiniDumpThreadProc(LPVOID lpParam);
+	DWORD ThreadProcInternal();
+
+	// Dump file directory bookkeeping
+	Bool InitializeDumpDirectory(const AsciiString& userDirPath);
+	static void KeepNewestFiles(const std::string& directory, const std::string& fileWildcard, const Int keepCount);
+
+	// Struct to hold file information
+	struct FileInfo {
+		std::string name;
+		FILETIME lastWriteTime;
+	};
+
+	static bool CompareByLastWriteTime(const FileInfo& a, const FileInfo& b);
+
+private:
+	Bool m_miniDumpInitialized;
+	Bool m_extendedInfoRequested;
+
+	// Path buffers
+	Char m_dumpDir[MAX_PATH];
+	Char m_dumpFile[MAX_PATH];
+	Char m_sysDbgHelpPath[MAX_PATH];
+
+	// Module handles
+	HMODULE m_dbgHlp;
+
+	// Event handles
+	HANDLE m_dumpRequested;
+	HANDLE m_dumpComplete;
+	HANDLE m_quitting;
+
+	// Thread handles
+	HANDLE m_dumpThread;
+	DWORD m_dumpThreadId;
+
+	// Internal memory dumping progress state
+	int m_dumpObjectsState;
+	int m_dumpObjectsSubState;
+	int m_dmaRawBlockIndex;
+
+	AllocationRangeIterator m_RangeIter;
+	AllocationRangeIterator m_endRangeIter;
+
+	// Function pointer to MiniDumpWriteDump in dbghelp.dll
+	typedef BOOL(WINAPI* MiniDumpWriteDump_t)(
+		HANDLE hProcess,
+		DWORD ProcessId,
+		HANDLE hFile,
+		MINIDUMP_TYPE DumpType,
+		PMINIDUMP_EXCEPTION_INFORMATION ExceptionParam,
+		PMINIDUMP_USER_STREAM_INFORMATION UserStreamParam,
+		PMINIDUMP_CALLBACK_INFORMATION CallbackParam
+		);
+
+	MiniDumpWriteDump_t m_pMiniDumpWriteDump;
+};
+#endif

--- a/Core/GameEngine/Include/Common/MiniDumper_compat.h
+++ b/Core/GameEngine/Include/Common/MiniDumper_compat.h
@@ -1,0 +1,254 @@
+#pragma once
+
+#ifdef RTS_ENABLE_CRASHDUMP
+
+// Backported defines from minidumpapiset.h for VC6.
+// minidumpapiset.h is Copyright (C) Microsoft Corporation. All rights reserved.
+#if defined(_MSC_VER) && _MSC_VER < 1300
+#pragma pack(push, 4)
+
+typedef enum _MINIDUMP_CALLBACK_TYPE {
+	ModuleCallback,
+	ThreadCallback,
+	ThreadExCallback,
+	IncludeThreadCallback,
+	IncludeModuleCallback,
+	MemoryCallback,
+	CancelCallback,
+	WriteKernelMinidumpCallback,
+	KernelMinidumpStatusCallback,
+	RemoveMemoryCallback,
+	IncludeVmRegionCallback,
+	IoStartCallback,
+	IoWriteAllCallback,
+	IoFinishCallback,
+	ReadMemoryFailureCallback,
+	SecondaryFlagsCallback,
+	IsProcessSnapshotCallback,
+	VmStartCallback,
+	VmQueryCallback,
+	VmPreReadCallback,
+	VmPostReadCallback
+} MINIDUMP_CALLBACK_TYPE;
+
+typedef struct _MINIDUMP_THREAD_CALLBACK {
+	ULONG ThreadId;
+	HANDLE ThreadHandle;
+#if defined(_ARM64_)
+	ULONG Pad;
+#endif
+	CONTEXT Context;
+	ULONG SizeOfContext;
+	ULONG64 StackBase;
+	ULONG64 StackEnd;
+} MINIDUMP_THREAD_CALLBACK, * PMINIDUMP_THREAD_CALLBACK;
+
+typedef struct _MINIDUMP_THREAD_EX_CALLBACK {
+	ULONG ThreadId;
+	HANDLE ThreadHandle;
+#if defined(_ARM64_)
+	ULONG Pad;
+#endif
+	CONTEXT Context;
+	ULONG SizeOfContext;
+	ULONG64 StackBase;
+	ULONG64 StackEnd;
+	ULONG64 BackingStoreBase;
+	ULONG64 BackingStoreEnd;
+} MINIDUMP_THREAD_EX_CALLBACK, * PMINIDUMP_THREAD_EX_CALLBACK;
+
+typedef struct _MINIDUMP_MODULE_CALLBACK {
+	PWCHAR FullPath;
+	ULONG64 BaseOfImage;
+	ULONG SizeOfImage;
+	ULONG CheckSum;
+	ULONG TimeDateStamp;
+	VS_FIXEDFILEINFO VersionInfo;
+	PVOID CvRecord;
+	ULONG SizeOfCvRecord;
+	PVOID MiscRecord;
+	ULONG SizeOfMiscRecord;
+} MINIDUMP_MODULE_CALLBACK, * PMINIDUMP_MODULE_CALLBACK;
+
+typedef struct _MINIDUMP_INCLUDE_THREAD_CALLBACK {
+	ULONG ThreadId;
+} MINIDUMP_INCLUDE_THREAD_CALLBACK, * PMINIDUMP_INCLUDE_THREAD_CALLBACK;
+
+typedef struct _MINIDUMP_INCLUDE_MODULE_CALLBACK {
+	ULONG64 BaseOfImage;
+} MINIDUMP_INCLUDE_MODULE_CALLBACK, * PMINIDUMP_INCLUDE_MODULE_CALLBACK;
+
+typedef struct _MINIDUMP_IO_CALLBACK {
+	HANDLE Handle;
+	ULONG64 Offset;
+	PVOID Buffer;
+	ULONG BufferBytes;
+} MINIDUMP_IO_CALLBACK, * PMINIDUMP_IO_CALLBACK;
+
+typedef struct _MINIDUMP_READ_MEMORY_FAILURE_CALLBACK
+{
+	ULONG64 Offset;
+	ULONG Bytes;
+	HRESULT FailureStatus;
+} MINIDUMP_READ_MEMORY_FAILURE_CALLBACK,
+* PMINIDUMP_READ_MEMORY_FAILURE_CALLBACK;
+
+typedef struct _MINIDUMP_VM_QUERY_CALLBACK
+{
+	ULONG64 Offset;
+} MINIDUMP_VM_QUERY_CALLBACK, * PMINIDUMP_VM_QUERY_CALLBACK;
+
+typedef struct _MINIDUMP_VM_PRE_READ_CALLBACK
+{
+	ULONG64 Offset;
+	PVOID Buffer;
+	ULONG Size;
+} MINIDUMP_VM_PRE_READ_CALLBACK, * PMINIDUMP_VM_PRE_READ_CALLBACK;
+
+typedef struct _MINIDUMP_VM_POST_READ_CALLBACK
+{
+	ULONG64 Offset;
+	PVOID Buffer;
+	ULONG Size;
+	ULONG Completed;
+	HRESULT Status;
+} MINIDUMP_VM_POST_READ_CALLBACK, * PMINIDUMP_VM_POST_READ_CALLBACK;
+
+typedef struct _MINIDUMP_MEMORY_INFO {
+	ULONG64 BaseAddress;
+	ULONG64 AllocationBase;
+	ULONG32 AllocationProtect;
+	ULONG32 __alignment1;
+	ULONG64 RegionSize;
+	ULONG32 State;
+	ULONG32 Protect;
+	ULONG32 Type;
+	ULONG32 __alignment2;
+} MINIDUMP_MEMORY_INFO, * PMINIDUMP_MEMORY_INFO;
+
+typedef struct _MINIDUMP_CALLBACK_INPUT {
+	ULONG ProcessId;
+	HANDLE ProcessHandle;
+	ULONG CallbackType;
+	union {
+		HRESULT Status;
+		MINIDUMP_THREAD_CALLBACK Thread;
+		MINIDUMP_THREAD_EX_CALLBACK ThreadEx;
+		MINIDUMP_MODULE_CALLBACK Module;
+		MINIDUMP_INCLUDE_THREAD_CALLBACK IncludeThread;
+		MINIDUMP_INCLUDE_MODULE_CALLBACK IncludeModule;
+		MINIDUMP_IO_CALLBACK Io;
+		MINIDUMP_READ_MEMORY_FAILURE_CALLBACK ReadMemoryFailure;
+		ULONG SecondaryFlags;
+		MINIDUMP_VM_QUERY_CALLBACK VmQuery;
+		MINIDUMP_VM_PRE_READ_CALLBACK VmPreRead;
+		MINIDUMP_VM_POST_READ_CALLBACK VmPostRead;
+	};
+} MINIDUMP_CALLBACK_INPUT, * PMINIDUMP_CALLBACK_INPUT;
+
+typedef struct _MINIDUMP_CALLBACK_OUTPUT {
+	union {
+		ULONG ModuleWriteFlags;
+		ULONG ThreadWriteFlags;
+		ULONG SecondaryFlags;
+		struct {
+			ULONG64 MemoryBase;
+			ULONG MemorySize;
+		};
+		struct {
+			BOOL CheckCancel;
+			BOOL Cancel;
+		};
+		HANDLE Handle;
+		struct {
+			MINIDUMP_MEMORY_INFO VmRegion;
+			BOOL Continue;
+		};
+		struct {
+			HRESULT VmQueryStatus;
+			MINIDUMP_MEMORY_INFO VmQueryResult;
+		};
+		struct {
+			HRESULT VmReadStatus;
+			ULONG VmReadBytesCompleted;
+		};
+		HRESULT Status;
+	};
+} MINIDUMP_CALLBACK_OUTPUT, * PMINIDUMP_CALLBACK_OUTPUT;
+
+typedef struct _MINIDUMP_EXCEPTION_INFORMATION {
+	DWORD ThreadId;
+	PEXCEPTION_POINTERS ExceptionPointers;
+	BOOL ClientPointers;
+} MINIDUMP_EXCEPTION_INFORMATION, * PMINIDUMP_EXCEPTION_INFORMATION;
+
+typedef struct _MINIDUMP_USER_STREAM {
+	ULONG32 Type;
+	ULONG BufferSize;
+	PVOID Buffer;
+
+} MINIDUMP_USER_STREAM, * PMINIDUMP_USER_STREAM;
+
+typedef struct _MINIDUMP_USER_STREAM_INFORMATION {
+	ULONG UserStreamCount;
+	PMINIDUMP_USER_STREAM UserStreamArray;
+} MINIDUMP_USER_STREAM_INFORMATION, * PMINIDUMP_USER_STREAM_INFORMATION;
+
+typedef
+BOOL
+(WINAPI* MINIDUMP_CALLBACK_ROUTINE) (
+	PVOID CallbackParam,
+	PMINIDUMP_CALLBACK_INPUT CallbackInput,
+	PMINIDUMP_CALLBACK_OUTPUT CallbackOutput
+	);
+
+typedef struct _MINIDUMP_CALLBACK_INFORMATION {
+	MINIDUMP_CALLBACK_ROUTINE CallbackRoutine;
+	PVOID CallbackParam;
+} MINIDUMP_CALLBACK_INFORMATION, * PMINIDUMP_CALLBACK_INFORMATION;
+
+typedef enum _MINIDUMP_TYPE {
+	MiniDumpNormal = 0x00000000,
+	MiniDumpWithDataSegs = 0x00000001,
+	MiniDumpWithFullMemory = 0x00000002,
+	MiniDumpWithHandleData = 0x00000004,
+	MiniDumpFilterMemory = 0x00000008,
+	MiniDumpScanMemory = 0x00000010,
+	MiniDumpWithUnloadedModules = 0x00000020,
+	MiniDumpWithIndirectlyReferencedMemory = 0x00000040,
+	MiniDumpFilterModulePaths = 0x00000080,
+	MiniDumpWithProcessThreadData = 0x00000100,
+	MiniDumpWithPrivateReadWriteMemory = 0x00000200,
+	MiniDumpWithoutOptionalData = 0x00000400,
+	MiniDumpWithFullMemoryInfo = 0x00000800,
+	MiniDumpWithThreadInfo = 0x00001000,
+	MiniDumpWithCodeSegs = 0x00002000,
+	MiniDumpWithoutAuxiliaryState = 0x00004000,
+	MiniDumpWithFullAuxiliaryState = 0x00008000,
+	MiniDumpWithPrivateWriteCopyMemory = 0x00010000,
+	MiniDumpIgnoreInaccessibleMemory = 0x00020000,
+	MiniDumpWithTokenInformation = 0x00040000,
+	MiniDumpWithModuleHeaders = 0x00080000,
+	MiniDumpFilterTriage = 0x00100000,
+	MiniDumpWithAvxXStateContext = 0x00200000,
+	MiniDumpWithIptTrace = 0x00400000,
+	MiniDumpScanInaccessiblePartialPages = 0x00800000,
+	MiniDumpFilterWriteCombinedMemory = 0x01000000,
+	MiniDumpValidTypeFlags = 0x01ffffff,
+	MiniDumpNoIgnoreInaccessibleMemory = 0x02000000,
+	MiniDumpValidTypeFlagsEx = 0x03ffffff,
+} MINIDUMP_TYPE;
+
+typedef enum _MODULE_WRITE_FLAGS {
+	ModuleWriteModule = 0x0001,
+	ModuleWriteDataSeg = 0x0002,
+	ModuleWriteMiscRecord = 0x0004,
+	ModuleWriteCvRecord = 0x0008,
+	ModuleReferencedByMemory = 0x0010,
+	ModuleWriteTlsData = 0x0020,
+	ModuleWriteCodeSegs = 0x0040,
+} MODULE_WRITE_FLAGS;
+
+#pragma pack(pop)
+#endif
+#endif

--- a/Core/GameEngine/Source/Common/System/Debug.cpp
+++ b/Core/GameEngine/Source/Common/System/Debug.cpp
@@ -70,6 +70,11 @@
 #if defined(DEBUG_STACKTRACE) || defined(IG_DEBUG_STACKTRACE)
 	#include "Common/StackDump.h"
 #endif
+#ifdef RTS_ENABLE_CRASHDUMP
+#include "Common/MiniDumper.h"
+
+MiniDumper TheMiniDumper = MiniDumper();
+#endif
 
 // Horrible reference, but we really, really need to know if we are windowed.
 extern bool DX8Wrapper_IsWindowed;
@@ -729,6 +734,16 @@ void ReleaseCrash(const char *reason)
 		}
 	}
 
+#ifdef RTS_ENABLE_CRASHDUMP
+	if (TheMiniDumper.IsInitialized())
+	{
+		// Do dumps both with and without extended info
+		TheMiniDumper.TriggerMiniDump(false);
+		TheMiniDumper.TriggerMiniDump(true);
+		TheMiniDumper.ShutDown();
+	}
+#endif
+
 	char prevbuf[ _MAX_PATH ];
 	char curbuf[ _MAX_PATH ];
 
@@ -793,6 +808,16 @@ void ReleaseCrashLocalized(const AsciiString& p, const AsciiString& m)
 		// This won't ever return
 		return;
 	}
+
+#ifdef RTS_ENABLE_CRASHDUMP
+	if (TheMiniDumper.IsInitialized())
+	{
+		// Do dumps both with and without extended info
+		TheMiniDumper.TriggerMiniDump(false);
+		TheMiniDumper.TriggerMiniDump(true);
+		TheMiniDumper.ShutDown();
+	}
+#endif
 
 	UnicodeString prompt = TheGameText->fetch(p);
 	UnicodeString mesg = TheGameText->fetch(m);

--- a/Core/GameEngine/Source/Common/System/MiniDumper.cpp
+++ b/Core/GameEngine/Source/Common/System/MiniDumper.cpp
@@ -1,0 +1,635 @@
+/*
+**	Command & Conquer Generals Zero Hour(tm)
+**	Copyright 2025 TheSuperHackers
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "PreRTS.h"	// This must go first in EVERY cpp file in the GameEngine
+
+#ifdef RTS_ENABLE_CRASHDUMP
+#include "Common/MiniDumper.h"
+#include "Common/GameMemory.h"
+#include "gitinfo.h"
+
+// Globals for storing the pointer to the exception
+_EXCEPTION_POINTERS* g_dumpException = NULL;
+DWORD g_dumpExceptionThreadId = 0;
+
+// Globals containing state about the current exception that's used for context in the mini dump.
+// These are populated by MiniDumper::DumpingExceptionFilter to store a copy of the exception in case it goes out of scope
+_EXCEPTION_POINTERS g_exceptionPointers = { 0 };
+EXCEPTION_RECORD g_exceptionRecord = { 0 };
+CONTEXT g_exceptionContext = { 0 };
+
+
+LONG WINAPI MiniDumper::DumpingExceptionFilter(struct _EXCEPTION_POINTERS* e_info)
+{
+	// Store the exception info in the global variables for later use by the dumping thread
+	g_exceptionRecord = *(e_info->ExceptionRecord);
+	g_exceptionContext = *(e_info->ContextRecord);
+	g_exceptionPointers.ContextRecord = &g_exceptionContext;
+	g_exceptionPointers.ExceptionRecord = &g_exceptionRecord;
+	g_dumpException = &g_exceptionPointers;
+
+	return EXCEPTION_EXECUTE_HANDLER;
+}
+
+void MiniDumper::TriggerMiniDump(Bool extendedInfo)
+{
+	if (!m_miniDumpInitialized)
+	{
+		DEBUG_LOG(("MiniDumper::TriggerMiniDump: Attempted to use an uninitialized instance."));
+		return;
+	}
+
+	__try
+	{
+		// Use DebugBreak to raise an exception that can be caught in the __except block
+		DebugBreak();
+	}
+	__except (DumpingExceptionFilter(GetExceptionInformation()))
+	{
+		TriggerMiniDumpForException(g_dumpException, extendedInfo);
+	}
+}
+
+void MiniDumper::TriggerMiniDumpForException(struct _EXCEPTION_POINTERS* e_info, Bool extendedInfo)
+{
+	if (!m_miniDumpInitialized)
+	{
+		DEBUG_LOG(("MiniDumper::TriggerMiniDumpForException: Attempted to use an uninitialized instance."));
+		return;
+	}
+
+	g_dumpException = e_info;
+	g_dumpExceptionThreadId = GetCurrentThreadId();
+	m_extendedInfoRequested = extendedInfo;
+
+	SetEvent(m_dumpRequested);
+	DWORD wait = WaitForSingleObject(m_dumpComplete, INFINITE);
+	if (wait != WAIT_OBJECT_0)
+	{
+		if (wait == WAIT_FAILED)
+		{
+			DEBUG_LOG(("MiniDumper::TriggerMiniDumpForException: Waiting for minidump triggering failed, status=%u, error=%u", wait, GetLastError()));
+		}
+		else
+		{
+			DEBUG_LOG(("MiniDumper::TriggerMiniDumpForException: Waiting for minidump triggering failed, status=%u", wait));
+		}
+	}
+
+	ResetEvent(m_dumpComplete);
+}
+
+void MiniDumper::Initialize(const AsciiString& userDirPath)
+{
+	// Find the full path to the dbghelp.dll file in the system32 dir
+	GetSystemDirectory(m_sysDbgHelpPath, MAX_PATH);
+	strlcat(m_sysDbgHelpPath, "\\dbghelp.dll", MAX_PATH);
+
+	// We want to only use the dbghelp.dll from the OS installation, as the one bundled with the game does not support MiniDump functionality
+	Bool loadedDbgHelp = false;
+	HMODULE m_dbgHlp = GetModuleHandle(m_sysDbgHelpPath);
+	if (m_dbgHlp == NULL)
+	{
+		// Load the dbghelp library from the system folder
+		m_dbgHlp = LoadLibrary(m_sysDbgHelpPath);
+		if (m_dbgHlp == NULL)
+		{
+			DEBUG_LOG(("MiniDumper::Initialize: Unable to load system-provided dbghelp.dll from '%s', error code=%u", m_sysDbgHelpPath, GetLastError()));
+			return;
+		}
+
+		loadedDbgHelp = true;
+	}
+
+	m_pMiniDumpWriteDump = (MiniDumpWriteDump_t)GetProcAddress(m_dbgHlp, "MiniDumpWriteDump");
+	if (m_pMiniDumpWriteDump == NULL)
+	{
+		if (loadedDbgHelp)
+		{
+			FreeLibrary(m_dbgHlp);
+			m_dbgHlp = NULL;
+		}
+
+		DEBUG_LOG(("MiniDumper::Initialize: Could not get address of proc MiniDumpWriteDump from '%s'!", m_sysDbgHelpPath));
+		return;
+	}
+
+	// Create & store dump folder
+	if (!InitializeDumpDirectory(userDirPath))
+	{
+		return;
+	}
+
+	m_dumpRequested = CreateEvent(NULL, TRUE, FALSE, NULL);
+	m_dumpComplete = CreateEvent(NULL, TRUE, FALSE, NULL);
+	m_quitting = CreateEvent(NULL, TRUE, FALSE, NULL);
+
+	if (m_dumpRequested == NULL || m_dumpComplete == NULL || m_quitting == NULL)
+	{
+		// Something went wrong with the creation of the events..
+		DEBUG_LOG(("MiniDumper::Initialize: Unable to create events: error=%u", GetLastError()));
+		CleanupResources();
+		return;
+	}
+
+	m_dumpThread = CreateThread(NULL, 0, MiniDumpThreadProc, this, CREATE_SUSPENDED, &m_dumpThreadId);
+	if (!m_dumpThread)
+	{
+		DEBUG_LOG(("MiniDumper::Initialize: Unable to create thread: error=%u", GetLastError()));
+		CleanupResources();
+		return;
+	}
+
+	if (!ResumeThread(m_dumpThread))
+	{
+		DEBUG_LOG(("MiniDumper::Initialize: Unable to resume thread: error=%u", GetLastError()));
+		CleanupResources();
+		return;
+	}
+
+	DEBUG_LOG(("MiniDumper::Initialize: Configured to store crash dumps in '%s'", m_dumpDir));
+	m_miniDumpInitialized = true;
+}
+
+Bool MiniDumper::IsInitialized() const
+{
+	return m_miniDumpInitialized;
+}
+
+Bool MiniDumper::InitializeDumpDirectory(const AsciiString& userDirPath)
+{
+	constexpr Int MaxExtendedFileCount = 2;
+	constexpr Int MaxMiniFileCount = 10;
+
+	strlcpy(m_dumpDir, userDirPath.str(), ARRAY_SIZE(m_dumpDir));
+	strlcat(m_dumpDir, "CrashDumps\\", ARRAY_SIZE(m_dumpDir));
+	if (_access(m_dumpDir, 0) != 0)
+	{
+		if (!CreateDirectory(m_dumpDir, NULL))
+		{
+			DEBUG_LOG(("MiniDumper::Initialize: Unable to create path for crash dumps at '%s': %u", m_dumpDir, GetLastError()));
+			return false;
+		}
+	}
+
+	// Clean up old files (we keep a maximum of 10 small and 2 extended)
+	KeepNewestFiles(m_dumpDir, "CrashX*", MaxExtendedFileCount);
+	KeepNewestFiles(m_dumpDir, "CrashM*", MaxMiniFileCount);
+
+	return true;
+}
+
+void MiniDumper::CleanupResources()
+{
+	// NOTE: This method should not be called unless the dump thread is confirmed to not be running anymore.
+	if (m_dumpThread != NULL)
+	{
+		CloseHandle(m_dumpThread);
+		m_dumpThread = NULL;
+	}
+
+	if (m_dumpComplete != NULL)
+	{
+		CloseHandle(m_dumpComplete);
+		m_dumpComplete = NULL;
+	}
+
+	if (m_dumpRequested != NULL)
+	{
+		CloseHandle(m_dumpRequested);
+		m_dumpRequested = NULL;
+	}
+
+	if (m_quitting != NULL)
+	{
+		CloseHandle(m_quitting);
+		m_quitting = NULL;
+	}
+
+	if (m_dbgHlp != NULL)
+	{
+		FreeModule(m_dbgHlp);
+		m_dbgHlp = NULL;
+	}
+}
+
+void MiniDumper::ShutDown()
+{
+	if (!m_miniDumpInitialized)
+	{
+		return;
+	}
+
+	SetEvent(m_quitting);
+	DWORD waitRet = WaitForSingleObject(m_dumpThread, 3000);
+	if (waitRet != WAIT_OBJECT_0)
+	{
+		if (waitRet == WAIT_TIMEOUT)
+		{
+			DEBUG_LOG(("MiniDumper::ShutDown: Waiting for dumping thread to exit timed out, killing thread", waitRet));
+			TerminateThread(m_dumpThread, 2);
+		}
+		else if (waitRet == WAIT_FAILED)
+		{
+			DEBUG_LOG(("MiniDumper::ShutDown: Waiting for minidump triggering failed, status=%u, error=%u", waitRet, GetLastError()));
+		}
+		else
+		{
+			DEBUG_LOG(("MiniDumper::ShutDown: Waiting for minidump triggering failed, status=%u", waitRet));
+		}
+		return;
+	}
+
+	CleanupResources();
+	m_miniDumpInitialized = false;
+}
+
+DWORD MiniDumper::ThreadProcInternal()
+{
+	while (true)
+	{
+		HANDLE waitEvents[2] = { m_dumpRequested, m_quitting };
+		DWORD event = WaitForMultipleObjects(ARRAY_SIZE(waitEvents), waitEvents, FALSE, INFINITE);
+		if (event == WAIT_OBJECT_0 + 0)
+		{
+			// A dump is requested (m_dumpRequested)
+			ResetEvent(m_dumpComplete);
+			CreateMiniDump(m_extendedInfoRequested);
+			ResetEvent(m_dumpRequested);
+			SetEvent(m_dumpComplete);
+		}
+		else if (event == WAIT_OBJECT_0 + 1)
+		{
+			// Quit (m_quitting)
+			return 0;
+		}
+		else
+		{
+			if (event == WAIT_FAILED)
+			{
+				DEBUG_LOG(("MiniDumper::ThreadProcInternal: Waiting for events failed, status=%u, error=%u", event, GetLastError()));
+			}
+			else
+			{
+				DEBUG_LOG(("MiniDumper::ThreadProcInternal: Waiting for events failed, status=%u", event));
+			}
+			return 1;
+		}
+	}
+}
+
+DWORD WINAPI MiniDumper::MiniDumpThreadProc(LPVOID lpParam)
+{
+	if (lpParam == NULL)
+	{
+		DEBUG_LOG(("MiniDumper::MiniDumpThreadProc: The provided parameter was NULL, exiting thread."));
+		return -1;
+	}
+
+	MiniDumper* dumper = static_cast<MiniDumper *>(lpParam);
+	return dumper->ThreadProcInternal();
+}
+
+
+void MiniDumper::CreateMiniDump(Bool extendedInfo)
+{
+	// Create a unique dump file name, using the path from m_dumpDir, in m_dumpFile
+	SYSTEMTIME sysTime;
+	GetLocalTime(&sysTime);
+#if RTS_ZEROHOUR
+	Char product = 'Z';
+#else
+	Char product = 'G';
+#endif
+	Char dumpTypeSpecifier = extendedInfo ? 'X' : 'M';
+	DWORD currentProcessId = GetCurrentProcessId();
+	DWORD currentThreadId = GetCurrentThreadId();
+
+	// m_dumpDir is stored with trailing backslash in Initialize
+	snprintf(m_dumpFile, ARRAY_SIZE(m_dumpFile), "%sCrash%c%c-%04d%02d%02d-%02d%02d%02d-%s-%ld-%ld.dmp",
+		m_dumpDir, dumpTypeSpecifier, product, sysTime.wYear, sysTime.wMonth,
+		sysTime.wDay, sysTime.wHour, sysTime.wMinute, sysTime.wSecond,
+		GitShortSHA1, currentProcessId, currentThreadId);
+
+	HANDLE dumpFile = CreateFile(m_dumpFile, GENERIC_READ | GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+	if (dumpFile == NULL || dumpFile == INVALID_HANDLE_VALUE)
+	{
+		DEBUG_LOG(("MiniDumper::CreateMiniDump: Unable to create dump file '%s', error=%u", m_dumpFile, GetLastError()));
+		return;
+	}
+
+	PMINIDUMP_EXCEPTION_INFORMATION exceptionInfoPtr = NULL;
+	MINIDUMP_EXCEPTION_INFORMATION exceptionInfo = { 0 };
+	if (g_dumpException != NULL)
+	{
+		exceptionInfo.ExceptionPointers = g_dumpException;
+		exceptionInfo.ThreadId = g_dumpExceptionThreadId;
+		exceptionInfo.ClientPointers = FALSE;
+		exceptionInfoPtr = &exceptionInfo;
+	}
+
+	PMINIDUMP_CALLBACK_INFORMATION callbackInfoPtr = NULL;
+	MINIDUMP_CALLBACK_INFORMATION callBackInfo = { 0 };
+	if (extendedInfo)
+	{
+		callBackInfo.CallbackRoutine = MiniDumpCallback;
+		callBackInfo.CallbackParam = this;
+		callbackInfoPtr = &callBackInfo;
+	}
+
+	MINIDUMP_TYPE dumpType = static_cast<MINIDUMP_TYPE>(MiniDumpWithIndirectlyReferencedMemory | MiniDumpScanMemory);
+	if (extendedInfo)
+	{
+		dumpType = static_cast<MINIDUMP_TYPE>(MiniDumpWithDataSegs | MiniDumpWithHandleData | MiniDumpWithThreadInfo | MiniDumpScanMemory | MiniDumpWithIndirectlyReferencedMemory | MiniDumpWithFullMemoryInfo);
+	}
+
+	BOOL success = m_pMiniDumpWriteDump(
+		GetCurrentProcess(),
+		currentProcessId,
+		dumpFile,
+		dumpType,
+		exceptionInfoPtr,
+		NULL,
+		callbackInfoPtr);
+
+	if (!success)
+	{
+		DEBUG_LOG(("MiniDumper::CreateMiniDump: Unable to write minidump file '%s', error=%u", m_dumpFile, GetLastError()));
+	}
+	else
+	{
+		DEBUG_LOG(("MiniDumper::CreateMiniDump: Successfully wrote minidump file to '%s'", m_dumpFile));
+	}
+
+	CloseHandle(dumpFile);
+}
+
+BOOL CALLBACK MiniDumper::MiniDumpCallback(PVOID CallbackParam, PMINIDUMP_CALLBACK_INPUT CallbackInput, PMINIDUMP_CALLBACK_OUTPUT CallbackOutput)
+{
+	if (CallbackParam == NULL || CallbackInput == NULL || CallbackOutput == NULL)
+	{
+		DEBUG_LOG(("MiniDumper::MiniDumpCallback: Required parameters were null; CallbackParam=%p, CallbackInput=%p, CallbackOutput=%p.", CallbackParam, CallbackInput, CallbackOutput));
+		return false;
+	}
+
+	MiniDumper* dumper = static_cast<MiniDumper*>(CallbackParam);
+	return dumper->CallbackInternal(*CallbackInput, *CallbackOutput);
+}
+
+// This is where the memory regions and things are being filtered
+BOOL MiniDumper::CallbackInternal(const MINIDUMP_CALLBACK_INPUT& input, MINIDUMP_CALLBACK_OUTPUT& output)
+{
+	BOOL retVal = TRUE;
+	switch (input.CallbackType)
+	{
+	case IncludeModuleCallback:
+		retVal = TRUE;
+		break;
+	case ModuleCallback:
+	{
+		// Only include data segments for the game and ntdll modules to keep dump size low
+		if (output.ModuleWriteFlags & ModuleWriteDataSeg)
+		{
+			if (!StrStrIW(input.Module.FullPath, L"generalszh.exe") && !StrStrIW(input.Module.FullPath, L"generalsv.exe") && !StrStrIW(input.Module.FullPath, L"ntdll.dll"))
+			{
+				// Exclude data segments for the module
+				output.ModuleWriteFlags &= (~ModuleWriteDataSeg);
+			}
+		}
+
+		retVal = TRUE;
+		break;
+	}
+	case IncludeThreadCallback:
+		// We want all threads except the dumping thread
+		if (input.IncludeThread.ThreadId == m_dumpThreadId)
+		{
+			retVal = FALSE;
+		}
+		break;
+	case ThreadCallback:
+		retVal = TRUE;
+		break;
+	case ThreadExCallback:
+		retVal = TRUE;
+		break;
+	case MemoryCallback:
+	{
+		do
+		{
+			// DumpMemoryObjects will return false once it's completed, signalling the end of memory callbacks
+			retVal = DumpMemoryObjects(output.MemoryBase, output.MemorySize);
+		} while ((output.MemoryBase == NULL || output.MemorySize == NULL) && retVal == TRUE);
+		break;
+	}
+	case ReadMemoryFailureCallback:
+	{
+		DEBUG_LOG(("MiniDumper::CallbackInternal: ReadMemoryFailure with MemoryBase=%llu, MemorySize=%lu, error=%u", input.ReadMemoryFailure.Offset, input.ReadMemoryFailure.Bytes, input.ReadMemoryFailure.FailureStatus));
+		retVal = TRUE;
+		break;
+	}
+	case CancelCallback:
+		output.Cancel = FALSE;
+		output.CheckCancel = FALSE;
+		retVal = TRUE;
+		break;
+	}
+
+	return retVal;
+}
+
+BOOL MiniDumper::DumpMemoryObjects(ULONG64& memoryBase, ULONG& memorySize)
+{
+	BOOL moreToDo = TRUE;
+	// m_dumpObjectsState is used to keep track of the current "phase" of the memory dumping process
+	// m_dumpObjectsSubState is used to keep track of the progress within each phase, and is reset when advancing on to the next phase
+	switch (m_dumpObjectsState)
+	{
+	case 0:
+	{
+		// Dump all the MemoryPool instances in TheMemoryPoolFactory
+		// This only dumps the metadata, not the actual MemoryPool contents (done in the next phase).
+		if (TheMemoryPoolFactory == NULL)
+		{
+			++m_dumpObjectsState;
+			break;
+		}
+
+		Int poolCount = TheMemoryPoolFactory->getMemoryPoolCount();
+		//m_dumpObjectsSubState contains the index in TheMemoryPoolFactory of the MemoryPool that is being processed
+		if (m_dumpObjectsSubState < poolCount)
+		{
+			MemoryPool* pool = TheMemoryPoolFactory->getMemoryPoolN(m_dumpObjectsSubState);
+			if (pool != NULL)
+			{
+				memoryBase = reinterpret_cast<ULONG64>(pool);
+				memorySize = sizeof(MemoryPool);
+				++m_dumpObjectsSubState;
+			}
+			else
+			{
+				m_dumpObjectsSubState = poolCount;
+			}
+		}
+
+		if (m_dumpObjectsSubState == poolCount)
+		{
+			m_dumpObjectsSubState = 0;
+			++m_dumpObjectsState;
+		}
+		break;
+	}
+	case 1:
+	{
+		// Iterate through all the allocations of memory pools and containing blobs that has been done via the memory pool factory
+		// and include all of the storage space allocated for objects
+		if (TheMemoryPoolFactory == NULL)
+		{
+			++m_dumpObjectsState;
+			break;
+		}
+
+		//m_dumpObjectsSubState is used to track if the iterator needs to be initialized, otherwise just a counter of the number of items dumped
+		if (m_dumpObjectsSubState == 0)
+		{
+			m_RangeIter = TheMemoryPoolFactory->cbegin();
+			m_endRangeIter = TheMemoryPoolFactory->cend();
+			++m_dumpObjectsSubState;
+		}
+
+		// m_RangeIter should != m_endRangeIter, unless the memory pool factory is corrupted (or has 0 entries)
+		memoryBase = reinterpret_cast<ULONG64>(m_RangeIter->allocationAddr);
+		memorySize = m_RangeIter->allocationSize;
+		++m_dumpObjectsSubState;
+		++m_RangeIter;
+
+		if (m_RangeIter == m_endRangeIter)
+		{
+			++m_dumpObjectsState;
+			m_dumpObjectsSubState = 0;
+		}
+		break;
+	}
+	case 2:
+	{
+		// Iterate through all the direct allocations ("raw blocks") done by DMAs, as these are done outside of the
+		// memory pool factory allocations dumped in the previous phase.
+		if (TheDynamicMemoryAllocator == NULL)
+		{
+			++m_dumpObjectsState;
+			break;
+		}
+
+		DynamicMemoryAllocator* allocator = TheDynamicMemoryAllocator;
+
+		//m_dumpObjectsSubState is used to track the index of the allocator we are currently traversing
+		for (int i = 0; i < m_dumpObjectsSubState; ++i)
+		{
+			allocator = allocator->getNextDmaInList();
+		}
+
+		MemoryPoolAllocatedRange rawBlockRange = {0};
+		int rawBlocksInDma = allocator->getRawBlockCount();
+		if (m_dmaRawBlockIndex < rawBlocksInDma)
+		{
+			// Dump this block
+			allocator->fillAllocationRangeForRawBlockN(m_dmaRawBlockIndex, rawBlockRange);
+			memoryBase = reinterpret_cast<ULONG64>(rawBlockRange.allocationAddr);
+			memorySize = rawBlockRange.allocationSize;
+			++m_dmaRawBlockIndex;
+		}
+
+		if (rawBlocksInDma == m_dmaRawBlockIndex)
+		{
+			// Advance to the next DMA
+			++m_dumpObjectsSubState;
+			m_dmaRawBlockIndex = 0;
+			if (allocator->getNextDmaInList() == NULL)
+			{
+				// Done iterating through all the DMAs
+				m_dumpObjectsSubState = 0;
+				++m_dumpObjectsState;
+			}
+		}
+		break;
+	}
+	default:
+		// Done, set "no more stuff" values
+		m_dumpObjectsState = 0;
+		m_dumpObjectsSubState = 0;
+		m_dmaRawBlockIndex = 0;
+		memoryBase = 0;
+		memorySize = 0;
+		moreToDo = FALSE;
+		break;
+	}
+
+	return moreToDo;
+}
+
+// Comparator for sorting files by last modified time (newest first)
+bool MiniDumper::CompareByLastWriteTime(const FileInfo& a, const FileInfo& b) {
+	return CompareFileTime(&a.lastWriteTime, &b.lastWriteTime) > 0;
+}
+
+void MiniDumper::KeepNewestFiles(const std::string& directory, const std::string& fileWildcard, const Int keepCount)
+{
+	// directory already contains trailing backslash
+	std::string searchPath = directory + fileWildcard;
+	WIN32_FIND_DATA findData;
+	HANDLE hFind = FindFirstFile(searchPath.c_str(), &findData);
+
+	if (hFind == INVALID_HANDLE_VALUE) {
+		if (GetLastError() != ERROR_FILE_NOT_FOUND)
+		{
+			DEBUG_LOG(("MiniDumper::KeepNewestFiles: Unable to find files in directory '%s': %u", searchPath.c_str(), GetLastError()));
+		}
+
+		return;
+	}
+
+	std::vector<FileInfo> files;
+	do {
+		if (findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+			continue;
+		}
+
+		// Store file info
+		FileInfo fileInfo;
+		fileInfo.name = directory + findData.cFileName;
+		fileInfo.lastWriteTime = findData.ftLastWriteTime;
+		files.push_back(fileInfo);
+
+	} while (FindNextFile(hFind, &findData));
+
+	FindClose(hFind);
+
+	// Sort files by last modified time in descending order
+	std::sort(files.begin(), files.end(), CompareByLastWriteTime);
+
+	// Delete files beyond the newest keepCount
+	for (size_t i = keepCount; i < files.size(); ++i) {
+		if (DeleteFile(files[i].name.c_str())) {
+			DEBUG_LOG(("MiniDumper::KeepNewestFiles: Deleted old dump file '%s'.", files[i].name.c_str()));
+		}
+		else {
+			DEBUG_LOG(("MiniDumper::KeepNewestFiles: Failed to delete file '%s', error=%u", files[i].name.c_str(), GetLastError()));
+		}
+	}
+}
+#endif

--- a/Generals/Code/Main/WinMain.cpp
+++ b/Generals/Code/Main/WinMain.cpp
@@ -64,6 +64,9 @@
 #include "BuildVersion.h"
 #include "GeneratedVersion.h"
 #include "resource.h"
+#ifdef RTS_ENABLE_CRASHDUMP
+#include "Common/MiniDumper.h"
+#endif
 
 
 // GLOBALS ////////////////////////////////////////////////////////////////////
@@ -71,6 +74,9 @@ HINSTANCE ApplicationHInstance = NULL;  ///< our application instance
 HWND ApplicationHWnd = NULL;  ///< our application window handle
 Win32Mouse *TheWin32Mouse= NULL;  ///< for the WndProc() only
 DWORD TheMessageTime = 0;	///< For getting the time that a message was posted from Windows.
+#ifdef RTS_ENABLE_CRASHDUMP
+extern MiniDumper TheMiniDumper;
+#endif
 
 const Char *g_strFile = "data\\Generals.str";
 const Char *g_csfFile = "data\\%s\\Generals.csf";
@@ -741,6 +747,15 @@ static CriticalSection critSec1, critSec2, critSec3, critSec4, critSec5;
 static LONG WINAPI UnHandledExceptionFilter( struct _EXCEPTION_POINTERS* e_info )
 {
 	DumpExceptionInfo( e_info->ExceptionRecord->ExceptionCode, e_info );
+#ifdef RTS_ENABLE_CRASHDUMP
+	if (TheMiniDumper.IsInitialized())
+	{
+		// Do dumps both with and without extended info
+		TheMiniDumper.TriggerMiniDumpForException(e_info, false);
+		TheMiniDumper.TriggerMiniDumpForException(e_info, true);
+		TheMiniDumper.ShutDown();
+	}
+#endif
 	return EXCEPTION_EXECUTE_HANDLER;
 }
 
@@ -807,6 +822,10 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 
 		CommandLine::parseCommandLineForStartup();
 
+#ifdef RTS_ENABLE_CRASHDUMP
+		// Initialize minidump facilities - requires TheGlobalData so performed after parseCommandLineForStartup
+		TheMiniDumper.Initialize(TheGlobalData->getPath_UserData());
+#endif
 		// register windows class and create application window
 		if(!TheGlobalData->m_headless && initializeAppWindows(hInstance, nCmdShow, TheGlobalData->m_windowed) == false)
 			return exitcode;
@@ -874,6 +893,9 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 
 	}
 
+#ifdef RTS_ENABLE_CRASHDUMP
+	TheMiniDumper.ShutDown();
+#endif
 	TheAsciiStringCriticalSection = NULL;
 	TheUnicodeStringCriticalSection = NULL;
 	TheDmaCriticalSection = NULL;

--- a/GeneralsMD/Code/Main/WinMain.cpp
+++ b/GeneralsMD/Code/Main/WinMain.cpp
@@ -67,6 +67,9 @@
 #include "resource.h"
 
 #include <rts/profile.h>
+#ifdef RTS_ENABLE_CRASHDUMP
+#include "Common/MiniDumper.h"
+#endif
 
 
 // GLOBALS ////////////////////////////////////////////////////////////////////
@@ -74,6 +77,9 @@ HINSTANCE ApplicationHInstance = NULL;  ///< our application instance
 HWND ApplicationHWnd = NULL;  ///< our application window handle
 Win32Mouse *TheWin32Mouse= NULL;  ///< for the WndProc() only
 DWORD TheMessageTime = 0;	///< For getting the time that a message was posted from Windows.
+#ifdef RTS_ENABLE_CRASHDUMP
+extern MiniDumper TheMiniDumper;
+#endif
 
 const Char *g_strFile = "data\\Generals.str";
 const Char *g_csfFile = "data\\%s\\Generals.csf";
@@ -763,6 +769,15 @@ static CriticalSection critSec1, critSec2, critSec3, critSec4, critSec5;
 static LONG WINAPI UnHandledExceptionFilter( struct _EXCEPTION_POINTERS* e_info )
 {
 	DumpExceptionInfo( e_info->ExceptionRecord->ExceptionCode, e_info );
+#ifdef RTS_ENABLE_CRASHDUMP
+	if (TheMiniDumper.IsInitialized())
+	{
+		// Do dumps both with and without extended info
+		TheMiniDumper.TriggerMiniDumpForException(e_info, false);
+		TheMiniDumper.TriggerMiniDumpForException(e_info, true);
+		TheMiniDumper.ShutDown();
+	}
+#endif
 	return EXCEPTION_EXECUTE_HANDLER;
 }
 
@@ -853,6 +868,10 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 #endif
 
 		CommandLine::parseCommandLineForStartup();
+#ifdef RTS_ENABLE_CRASHDUMP
+		// Initialize minidump facilities - requires TheGlobalData so performed after parseCommandLineForStartup
+		TheMiniDumper.Initialize(TheGlobalData->getPath_UserData());
+#endif
 
 		// register windows class and create application window
 		if(!TheGlobalData->m_headless && initializeAppWindows(hInstance, nCmdShow, TheGlobalData->m_windowed) == false)
@@ -922,6 +941,9 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 
 	}
 
+#ifdef RTS_ENABLE_CRASHDUMP
+	TheMiniDumper.ShutDown();
+#endif
 	TheUnicodeStringCriticalSection = NULL;
 	TheDmaCriticalSection = NULL;
 	TheMemoryPoolCriticalSection = NULL;

--- a/cmake/config-memory.cmake
+++ b/cmake/config-memory.cmake
@@ -20,6 +20,9 @@ option(RTS_MEMORYPOOL_DEBUG_INTENSE_VERIFY "Enables intensive verifications afte
 option(RTS_MEMORYPOOL_DEBUG_CHECK_BLOCK_OWNERSHIP "Enables debug to verify that a block actually belongs to the pool it is called with. This is great for debugging, but can be realllly slow, so is OFF by default." OFF)
 option(RTS_MEMORYPOOL_DEBUG_INTENSE_DMA_BOOKKEEPING "Prints statistics for memory usage of Memory Pools." OFF)
 
+# Memory dump options (depends on original game memory implementation)
+cmake_dependent_option(RTS_CRASHDUMP_ENABLE "Enables writing crash dumps on unhandled exceptions or release crash failures." ON RTS_GAMEMEMORY_ENABLE OFF)
+
 # Game Memory features
 add_feature_info(GameMemoryEnable RTS_GAMEMEMORY_ENABLE "Build with the original game memory implementation")
 
@@ -37,6 +40,8 @@ add_feature_info(MemoryPoolDebugIntenseVerify RTS_MEMORYPOOL_DEBUG_INTENSE_VERIF
 add_feature_info(MemoryPoolDebugCheckBlockOwnership RTS_MEMORYPOOL_DEBUG_CHECK_BLOCK_OWNERSHIP "Build with Memory Pool block ownership checks")
 add_feature_info(MemoryPoolDebugIntenseDmaBookkeeping RTS_MEMORYPOOL_DEBUG_INTENSE_DMA_BOOKKEEPING "Build with Memory Pool intense DMA bookkeeping")
 
+# Memory dump features
+add_feature_info(CrashDumpEnable "RTS_CRASHDUMP_ENABLE" "Build with Crash Dumps")
 
 # Game Memory features
 if(NOT RTS_GAMEMEMORY_ENABLE)
@@ -85,5 +90,12 @@ else()
     
     if(RTS_MEMORYPOOL_DEBUG_INTENSE_DMA_BOOKKEEPING)
         target_compile_definitions(core_config INTERFACE INTENSE_DMA_BOOKKEEPING=1)
+    endif()
+endif()
+
+if(RTS_CRASHDUMP_ENABLE)
+    target_compile_definitions(core_config INTERFACE RTS_ENABLE_CRASHDUMP=1)
+    if (IS_VS6_BUILD AND NOT RTS_BUILD_OPTION_VC6_FULL_DEBUG)
+        message(WARNING "Crash Dumps will be significantly less useful in VC6 builds without full debug info enabled")
     endif()
 endif()


### PR DESCRIPTION
This change introduces the option to generate crash dumps, aka. mini dumps, on fatal errors.
The main minidump functionality is done by explicitly loading the `dbghelp.dll` from the system directory, as the dbghelp.dll that is bundled with the game is an older version that does not include this functionality. There is an option to create small dumps or extended info dumps, currently both are created.


### Small dumps
These mostly contain stacks for the process threads and some stack variables, or to create dumps with extended info. The use case for these is to quickly determine where a crash occured, the type of crash, if it was already fixed etc. In addition, if the memory allocation structures are corrupted enough, an extended info dump might not succeed while the small dump should. The size of these dumps are typically on the order of 250kB.

### Extended info
These contain global values, along with the memory regions allocated via the memory pool factory and the dynamic memory allocator. This makes all in-game objects available to the person debugging the crash dump, so for example `dt generalszh!TheWritableGlobalData` in WinDbg will show the state at the time the dump was created.

An alternative option could be to not traverse the memory structures "manually" to get to the allocations and instead just specify the `MiniDumpWithFullMemory` flag to `MiniDumpWriteDump`, but that increases the file size considerably.

As an example, dump of the generalszh process in the main menu with the shell map in the background yields a ~140MB dump when traversing and ~420MB with `MiniDumpWithFullMemory`. Beyond that, the ~140MB file compresses to ~20MB with 7Z, so should be relatively easily transferable.

### Storage Location
Crash dumps are stored in a new folder called 'CrashDumps' under the userDir ("Documents\Command and Conquer Generals Zero Hour Data\"), and on startup it will create this directory if it doesn't exist and delete any older dumps so only the 10 newest small and 2 newest extended info dumps are left. This is to preserve disk space, as the extended info files can be several hundred MB.

### Integration points
For VS2022 builds, unhandled exceptions end up in the `UnhandledExceptionFilter` in WinMain, which then get a reference to the actual exception that occurred and includes that in the dump.
For VC6 builds, unhandled exceptions are caught in the `catch(...)` blocks of `GameEngine::execute` which then calls RELEASE_CRASH. As there is no exception data available in this case to populate _EXCEPTION_POINTERS from, an intentional exception is triggered to get the trace of the current thread. This makes the stack traces for VC6 a bit more cryptic than VS2022 builds as the C++ exception handling gets included in the trace.

### Limitations

In the longer run we'll probably want to replace this code with a more mature solution, like CrashPad, but that currently depends on a newer compiler than VC6.
As the code is intended to be temporary, it's kept behind a new CMake feature so it can be easily removed. There are also some other decisions made with this in mind:

* Minidump is created in-process. Ideally, the dump should be performed by a process external to the crashing/failing process, but to avoid having to ship an extra binary, in-process was chosen instead. It's being performed in a separate thread to hopefully have a clean stack to work with. 
* Depends on RTS_BUILD_OPTION_VC6_FULL_DEBUG for VC6 builds. The PDBs generated with the default VC6 compile options are lacking in information, making the mini dumps less useful. The option RTS_BUILD_OPTION_VC6_FULL_DEBUG should be enabled for VC6 builds to ensure maximum usability. VS2022 builds produce better PDBs and require no extra options.
* Directory management code is contained within the MiniDumper class, not re-usable by other components.
* Many Win32-specific types and functions are used directly without regards for portability.
* As the MiniDump feature is not available for VC6, a lot of headers have been borrowed from minidumpapiset.h and included in the MiniDumper_compat.h file.
* Globals are used for storing the current exception info.
* Only enabled for the games, tools are currently not included.