### PR TITLE
bugfix(network): Deny players with invalid names from joining game

### DIFF
--- a/Generals/Code/GameEngine/Source/GameNetwork/LANAPIhandlers.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/LANAPIhandlers.cpp
@@ -289,7 +289,21 @@ void LANAPI::handleRequestJoin( LANMessage *msg, UnsignedInt senderIP )
 			}
 #endif
 
-			// We're the host, so see if he has a duplicate name
+			// We're the host, so first validate the name
+			if (wcschr(msg->name, L',') || wcschr(msg->name, L';') || wcschr(msg->name, L':'))
+			{
+				// Commas, colons or semicolons should not be in a player name.
+				// If so, just deny with a duplicate name error (for backwards compatibility with retail)
+				reply.LANMessageType = LANMessage::MSG_JOIN_DENY;
+				reply.GameNotJoined.reason = LANAPIInterface::RET_DUPLICATE_NAME;
+				reply.GameNotJoined.gameIP = m_localIP;
+				reply.GameNotJoined.playerIP = senderIP;
+				canJoin = false;
+
+				DEBUG_LOG(("LANAPI::handleRequestJoin - join denied because of illegal characters in the player name."));
+			}
+
+			// Then see if the player has a duplicate name
 			for (player = 0; canJoin && player<MAX_SLOTS; ++player)
 			{
 				LANGameSlot *slot = m_currentGame->getLANSlot(player);

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/LANAPIhandlers.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/LANAPIhandlers.cpp
@@ -290,7 +290,21 @@ void LANAPI::handleRequestJoin( LANMessage *msg, UnsignedInt senderIP )
 			}
 #endif
 
-			// We're the host, so see if he has a duplicate name
+			// We're the host, so first validate the name
+			if (wcschr(msg->name, L',') || wcschr(msg->name, L';') || wcschr(msg->name, L':'))
+			{
+				// Commas, colons or semicolons should not be in a player name.
+				// If so, just deny with a duplicate name error (for backwards compatibility with retail)
+				reply.LANMessageType = LANMessage::MSG_JOIN_DENY;
+				reply.GameNotJoined.reason = LANAPIInterface::RET_DUPLICATE_NAME;
+				reply.GameNotJoined.gameIP = m_localIP;
+				reply.GameNotJoined.playerIP = senderIP;
+				canJoin = false;
+
+				DEBUG_LOG(("LANAPI::handleRequestJoin - join denied because of illegal characters in the player name."));
+			}
+
+			// Then see if the player has a duplicate name
 			for (player = 0; canJoin && player<MAX_SLOTS; ++player)
 			{
 				LANGameSlot *slot = m_currentGame->getLANSlot(player);


### PR DESCRIPTION
This change introduces an extra validation of player names before they are allowed to join a network game.
Specifically, player names containing `,` `;` or `:` are denied, as they will cause trouble with the parsing of the string representation of the GameInfo. This set of characters mirrors the set of disallowed characters in https://github.com/TheSuperHackers/GeneralsGameCode/blob/dd2bb780a9226186e1d1ffe0dc60fc8000134117/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanLobbyMenu.cpp#L861C1-L869C1

The player attempting to join will be presented with a "duplicate name" error, hinting that the name needs to be changed, as we can't introduce a new error type and retain retail compatibility.