### PR TITLE
bugfix(view): Fix camera terrain height adjustment in Replay playback

### DIFF
--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -1178,6 +1178,7 @@ void W3DView::update(void)
 	 * scrolling), the zoom will move toward matching the desired height.
 	 */
 	// TheSuperHackers @tweak Can now also zoom when the game is paused.
+	// TheSuperHackers @tweak The camera zoom speed is now decoupled from the render update.
 	// TheSuperHackers @bugfix The camera terrain height adjustment now also works in replay playback.
 
 	m_terrainHeightUnderCamera = getHeightAroundPos(m_pos.x, m_pos.y);

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -1178,14 +1178,17 @@ void W3DView::update(void)
 	 * scrolling), the zoom will move toward matching the desired height.
 	 */
 	// TheSuperHackers @tweak Can now also zoom when the game is paused.
+	// TheSuperHackers @bugfix The camera terrain height adjustment now also works in replay playback.
+
 	m_terrainHeightUnderCamera = getHeightAroundPos(m_pos.x, m_pos.y);
 	m_currentHeightAboveGround = m_cameraOffset.z * m_zoom - m_terrainHeightUnderCamera;
+
 	if (TheTerrainLogic && TheGlobalData && TheInGameUI && m_okToAdjustHeight)
 	{
 		Real desiredHeight = (m_terrainHeightUnderCamera + m_heightAboveGround);
 		Real desiredZoom = desiredHeight / m_cameraOffset.z;
 
-  	if (didScriptedMovement || (TheGameLogic->isInReplayGame() && TheGlobalData->m_useCameraInReplay))
+	if (didScriptedMovement)
   	{
   		// if we are in a scripted camera movement, take its height above ground as our desired height.
   		m_heightAboveGround = m_currentHeightAboveGround;

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -1327,6 +1327,7 @@ void W3DView::update(void)
 	 * scrolling), the zoom will move toward matching the desired height.
 	 */
 	// TheSuperHackers @tweak Can now also zoom when the game is paused.
+	// TheSuperHackers @tweak The camera zoom speed is now decoupled from the render update.
 	// TheSuperHackers @bugfix The camera terrain height adjustment now also works in replay playback.
 
 	m_terrainHeightUnderCamera = getHeightAroundPos(m_pos.x, m_pos.y);

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -1327,14 +1327,17 @@ void W3DView::update(void)
 	 * scrolling), the zoom will move toward matching the desired height.
 	 */
 	// TheSuperHackers @tweak Can now also zoom when the game is paused.
+	// TheSuperHackers @bugfix The camera terrain height adjustment now also works in replay playback.
+
 	m_terrainHeightUnderCamera = getHeightAroundPos(m_pos.x, m_pos.y);
 	m_currentHeightAboveGround = m_cameraOffset.z * m_zoom - m_terrainHeightUnderCamera;
+
 	if (TheTerrainLogic && TheGlobalData && TheInGameUI && m_okToAdjustHeight)
 	{
 		Real desiredHeight = (m_terrainHeightUnderCamera + m_heightAboveGround);
 		Real desiredZoom = desiredHeight / m_cameraOffset.z;
 
-  	if (didScriptedMovement || (TheGameLogic->isInReplayGame() && TheGlobalData->m_useCameraInReplay))
+  	if (didScriptedMovement)
   	{
   		// if we are in a scripted camera movement, take its height above ground as our desired height.
   		m_heightAboveGround = m_currentHeightAboveGround;


### PR DESCRIPTION
* Relates to #850

This change fixes the camera terrain height adjustment in Replay playback. Originally the camera would not raise or lower when scrolling over a mountain or valley.

## TODO

- [x] Replicate in Generals