### PR TITLE
bugfix(view): Fix camera terrain height adjustment during camera playback in Replay playback

### DIFF
--- a/Generals/Code/GameEngine/Include/GameClient/View.h
+++ b/Generals/Code/GameEngine/Include/GameClient/View.h
@@ -180,12 +180,11 @@ public:
 	virtual const Coord3D& get3DCameraPosition() const = 0;							///< Returns the actual camera position
 
 	virtual Real getZoom() { return m_zoom; }
-	virtual void setZoom(Real z) { }
+	virtual void setZoom(Real z) { m_zoom = z; }
 	virtual Real getHeightAboveGround() { return m_heightAboveGround; }
 	virtual void setHeightAboveGround(Real z);
 	virtual void zoom( Real height ); ///< Zoom in/out, closer to the ground, limit to min, or farther away from the ground, limit to max
 	virtual void setZoomToDefault( void ) { m_zoom  = 1.0f; } ///< Set zoom to default value
-	virtual Real getMaxZoom( void ) { return m_maxZoom; }								///< return max zoom value
 	virtual void setOkToAdjustHeight( Bool val ) { m_okToAdjustHeight = val; }	///< Set this to adjust camera height
 
 	// for debugging
@@ -263,8 +262,6 @@ protected:
 	Real m_angle;																								///< Angle at which view has been rotated about the Z axis
 	Real m_pitchAngle;																					///< Rotation of view direction around horizontal (X) axis
 
-	Real m_maxZoom;																							///< Largest zoom value (minimum actual zoom)
-	Real m_minZoom;																							///< Smallest zoom value (maximum actual zoom)
 	Real m_maxHeightAboveGround;																///< Highest camera above ground value
 	Real m_minHeightAboveGround;																///< Lowest camera above ground value
 	Real m_zoom;																								///< Current zoom value

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5345,7 +5345,9 @@ void InGameUI::updateAndDrawWorldAnimations( void )
 			UnsignedInt height = wad->m_anim->getCurrentFrameHeight();
 
 			// scale the width and height given the camera zoom level
-			Real zoomScale = TheTacticalView->getMaxZoom() / TheTacticalView->getZoom();
+			// TheSuperHackers @todo Rework this with sane values. scaler=1.3 originally came from TheTacticalView::getMaxZoom()
+			constexpr Real scaler = 1.3f;
+			Real zoomScale = scaler / TheTacticalView->getZoom();
 			width *= zoomScale;
 			height *= zoomScale;
 

--- a/Generals/Code/GameEngine/Source/GameClient/View.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/View.cpp
@@ -49,9 +49,7 @@ View::View( void )
 	m_heightAboveGround = 0.0f;
 	m_lockDist = 0.0f;
 	m_maxHeightAboveGround = 0.0f;
-	m_maxZoom = 0.0f;
 	m_minHeightAboveGround = 0.0f;
-	m_minZoom = 0.0f;
 	m_next = NULL;
 	m_okToAdjustHeight = TRUE;
 	m_originX = 0;
@@ -99,9 +97,7 @@ void View::init( void )
 	m_cameraLockDrawable = NULL;
 	m_zoomLimited = TRUE;
 
-	m_maxZoom = 1.3f;
-	m_minZoom = 0.2f;
-	m_zoom = m_maxZoom;
+	m_zoom = 1.0f;
 	m_maxHeightAboveGround = TheGlobalData->m_maxCameraHeight;
 	m_minHeightAboveGround = TheGlobalData->m_minCameraHeight;
 	m_okToAdjustHeight = FALSE;

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -1777,15 +1777,13 @@ void W3DView::setHeightAboveGround(Real z)
 
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
+// TheSuperHackers @bugfix xezon 18/09/2025 setZoom is no longer clamped by a min and max zoom.
+// Instead the min and max camera height will be clamped elsewhere. Clamping the zoom would cause
+// issues with camera playback in replay playback where changes in terrain elevation would not raise
+// the camera height.
 void W3DView::setZoom(Real z)
 {
-	m_zoom = z;
-
-	if (m_zoom < m_minZoom)
-		m_zoom = m_minZoom;
-
-	if (m_zoom > m_maxZoom)
-		m_zoom = m_maxZoom;
+	View::setZoom(z);
 
 	m_doingMoveCameraOnWaypointPath = false;
 	m_doingRotateCamera = false;

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/View.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/View.h
@@ -184,12 +184,11 @@ public:
 	virtual const Coord3D& get3DCameraPosition() const = 0;							///< Returns the actual camera position
 
 	virtual Real getZoom() { return m_zoom; }
-	virtual void setZoom(Real z) { }
+	virtual void setZoom(Real z) { m_zoom = z; }
 	virtual Real getHeightAboveGround() { return m_heightAboveGround; }
 	virtual void setHeightAboveGround(Real z);
 	virtual void zoom( Real height ); ///< Zoom in/out, closer to the ground, limit to min, or farther away from the ground, limit to max
 	virtual void setZoomToDefault( void ) { m_zoom  = 1.0f; } ///< Set zoom to default value
-	virtual Real getMaxZoom( void ) { return m_maxZoom; }								///< return max zoom value
 	virtual void setOkToAdjustHeight( Bool val ) { m_okToAdjustHeight = val; }	///< Set this to adjust camera height
 
 	// for debugging
@@ -267,8 +266,6 @@ protected:
 	Real m_angle;																								///< Angle at which view has been rotated about the Z axis
 	Real m_pitchAngle;																					///< Rotation of view direction around horizontal (X) axis
 
-	Real m_maxZoom;																							///< Largest zoom value (minimum actual zoom)
-	Real m_minZoom;																							///< Smallest zoom value (maximum actual zoom)
 	Real m_maxHeightAboveGround;																///< Highest camera above ground value
 	Real m_minHeightAboveGround;																///< Lowest camera above ground value
 	Real m_zoom;																								///< Current zoom value

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5517,6 +5517,7 @@ void InGameUI::updateAndDrawWorldAnimations( void )
 			UnsignedInt height = wad->m_anim->getCurrentFrameHeight();
 
 			// scale the width and height given the camera zoom level
+			// TheSuperHackers @todo Reword this with sane values. scaler=1.3 originally came from TheTacticalView::getMaxZoom()
 			constexpr Real scaler = 1.3f;
 			Real zoomScale = scaler / TheTacticalView->getZoom();
 			width *= zoomScale;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5517,7 +5517,8 @@ void InGameUI::updateAndDrawWorldAnimations( void )
 			UnsignedInt height = wad->m_anim->getCurrentFrameHeight();
 
 			// scale the width and height given the camera zoom level
-			Real zoomScale = TheTacticalView->getMaxZoom() / TheTacticalView->getZoom();
+			constexpr Real scaler = 1.3f;
+			Real zoomScale = scaler / TheTacticalView->getZoom();
 			width *= zoomScale;
 			height *= zoomScale;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5517,7 +5517,7 @@ void InGameUI::updateAndDrawWorldAnimations( void )
 			UnsignedInt height = wad->m_anim->getCurrentFrameHeight();
 
 			// scale the width and height given the camera zoom level
-			// TheSuperHackers @todo Reword this with sane values. scaler=1.3 originally came from TheTacticalView::getMaxZoom()
+			// TheSuperHackers @todo Rework this with sane values. scaler=1.3 originally came from TheTacticalView::getMaxZoom()
 			constexpr Real scaler = 1.3f;
 			Real zoomScale = scaler / TheTacticalView->getZoom();
 			width *= zoomScale;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/View.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/View.cpp
@@ -49,9 +49,7 @@ View::View( void )
 	m_heightAboveGround = 0.0f;
 	m_lockDist = 0.0f;
 	m_maxHeightAboveGround = 0.0f;
-	m_maxZoom = 0.0f;
 	m_minHeightAboveGround = 0.0f;
-	m_minZoom = 0.0f;
 	m_next = NULL;
 	m_okToAdjustHeight = TRUE;
 	m_originX = 0;
@@ -99,9 +97,7 @@ void View::init( void )
 	m_cameraLockDrawable = NULL;
 	m_zoomLimited = TRUE;
 
-	m_maxZoom = 1.3f;
-	m_minZoom = 0.2f;
-	m_zoom = m_maxZoom;
+	m_zoom = 1.0f;
 	m_maxHeightAboveGround = TheGlobalData->m_maxCameraHeight;
 	m_minHeightAboveGround = TheGlobalData->m_minCameraHeight;
 	m_okToAdjustHeight = FALSE;

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -1940,15 +1940,13 @@ void W3DView::setHeightAboveGround(Real z)
 
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
+// TheSuperHackers @bugfix xezon 18/09/2025 setZoom is no longer clamped by a min and max zoom.
+// Instead the min and max camera height will be clamped elsewhere. Clamping the zoom would cause
+// issues with camera playback in replay playback where changes in terrain elevation would not raise
+// the camera height.
 void W3DView::setZoom(Real z)
 {
-	m_zoom = z;
-
-	if (m_zoom < m_minZoom)
-		m_zoom = m_minZoom;
-
-	if (m_zoom > m_maxZoom)
-		m_zoom = m_maxZoom;
+	View::setZoom(z);
 
 	m_doingMoveCameraOnWaypointPath = false;
 	m_CameraArrivedAtWaypointOnPathFlag = false;


### PR DESCRIPTION
This change fixes camera terrain height adjustment during camera playback in Replay playback. Originally the saved camera would not raise or lower when scrolling over a mountain or valley. This happened because of the (min) and max zoom clamping. Removing the clamping solves this.

## TODO

- [x] Replicate in Generals