### PR TITLE
bugfix(view): Prevent moving the camera with most user inputs during camera playback in Replay playback

### DIFF
--- a/Generals/Code/GameEngine/Include/GameClient/View.h
+++ b/Generals/Code/GameEngine/Include/GameClient/View.h
@@ -131,6 +131,7 @@ public:
 	virtual void setOrigin( Int x, Int y) { m_originX=x; m_originY=y;}				///< Sets location of top-left view corner on display
 	virtual void getOrigin( Int *x, Int *y) { *x=m_originX; *y=m_originY;}			///< Return location of top-left view corner on display
 
+	virtual void lockViewUntilFrame(UnsignedInt frame); ///< Locks the current view until the given frame is reached.
 	virtual void forceRedraw() = 0;
 
 	virtual void lookAt( const Coord3D *o );														///< Center the view on the given coordinate
@@ -254,6 +255,8 @@ protected:
 
 	UnsignedInt m_id;																						///< Rhe ID of this view
 	static UnsignedInt m_idNext;																///< Used for allocating view ID's for all views
+
+	UnsignedInt m_viewLockedUntilFrame;
 
 	Coord3D m_pos;																							///< Position of this view, in world coordinates
 	Int m_width, m_height;																			///< Dimensions of the view

--- a/Generals/Code/GameEngine/Source/GameClient/View.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/View.cpp
@@ -43,6 +43,7 @@ View::View( void )
 {
 	//Added By Sadullah Nader
 	//Initialization(s) inserted
+	m_viewLockedUntilFrame = 0u;
 	m_currentHeightAboveGround = 0.0f;
 	m_defaultAngle = 0.0f;
 	m_defaultPitchAngle = 0.0f;
@@ -110,6 +111,8 @@ void View::reset( void )
 {
 	// Only fixing the reported bug.  Who knows what side effects resetting the rest could have.
 	m_zoomLimited = TRUE;
+
+	m_viewLockedUntilFrame = 0u;
 }
 
 /**
@@ -124,6 +127,11 @@ View *View::prependViewToList( View *list )
 void View::zoom( Real height )
 {
 	setHeightAboveGround(getHeightAboveGround() + height);
+}
+
+void View::lockViewUntilFrame(UnsignedInt frame)
+{
+	m_viewLockedUntilFrame = frame;
 }
 
 /**

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -1873,6 +1873,9 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 					loc.init(pos.x, pos.y, pos.z, angle, pitch, zoom);
 					TheTacticalView->setLocation( &loc );
 
+					// TheSuperHackers @fix xezon 18/09/2025 Lock the new location to avoid user input from changing the camera in this frame.
+					TheTacticalView->lockViewUntilFrame( getFrame() + 1 );
+
 					if (!TheLookAtTranslator->hasMouseMovedRecently())
 					{
 						TheMouse->setCursor( (Mouse::MouseCursor)(msg->getArgument( 4 )->integer) );

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -413,6 +413,10 @@ void W3DView::setCameraTransform( void )
 {
 	if (TheGlobalData->m_headless)
 		return;
+
+	if (m_viewLockedUntilFrame > TheGameClient->getFrame())
+		return;
+
 	m_cameraHasMovedSinceRequest = true;
 	Matrix3D cameraTransform( 1 );
 

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/View.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/View.h
@@ -131,6 +131,7 @@ public:
 	virtual void setOrigin( Int x, Int y) { m_originX=x; m_originY=y;}				///< Sets location of top-left view corner on display
 	virtual void getOrigin( Int *x, Int *y) { *x=m_originX; *y=m_originY;}			///< Return location of top-left view corner on display
 
+	virtual void lockViewUntilFrame(UnsignedInt frame); ///< Locks the current view until the given frame is reached.
 	virtual void forceRedraw() = 0;
 
 	virtual void lookAt( const Coord3D *o );														///< Center the view on the given coordinate
@@ -258,6 +259,8 @@ protected:
 
 	UnsignedInt m_id;																						///< Rhe ID of this view
 	static UnsignedInt m_idNext;																///< Used for allocating view ID's for all views
+
+	UnsignedInt m_viewLockedUntilFrame;
 
 	Coord3D m_pos;																							///< Position of this view, in world coordinates
 	Int m_width, m_height;																			///< Dimensions of the view

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/View.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/View.cpp
@@ -43,6 +43,7 @@ View::View( void )
 {
 	//Added By Sadullah Nader
 	//Initialization(s) inserted
+	m_viewLockedUntilFrame = 0u;
 	m_currentHeightAboveGround = 0.0f;
 	m_defaultAngle = 0.0f;
 	m_defaultPitchAngle = 0.0f;
@@ -110,6 +111,8 @@ void View::reset( void )
 {
 	// Only fixing the reported bug.  Who knows what side effects resetting the rest could have.
 	m_zoomLimited = TRUE;
+
+	m_viewLockedUntilFrame = 0u;
 }
 
 /**
@@ -124,6 +127,11 @@ View *View::prependViewToList( View *list )
 void View::zoom( Real height )
 {
 	setHeightAboveGround(getHeightAboveGround() + height);
+}
+
+void View::lockViewUntilFrame(UnsignedInt frame)
+{
+	m_viewLockedUntilFrame = frame;
 }
 
 /**

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -1901,6 +1901,9 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 					loc.init(pos.x, pos.y, pos.z, angle, pitch, zoom);
 					TheTacticalView->setLocation( &loc );
 
+					// TheSuperHackers @fix xezon 18/09/2025 Lock the new location to avoid user input from changing the camera in this frame.
+					TheTacticalView->lockViewUntilFrame( getFrame() + 1 );
+
 					if (!TheLookAtTranslator->hasMouseMovedRecently())
 					{
 						TheMouse->setCursor( (Mouse::MouseCursor)(msg->getArgument( 4 )->integer) );

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -544,6 +544,10 @@ void W3DView::setCameraTransform( void )
 {
 	if (TheGlobalData->m_headless)
 		return;
+
+	if (m_viewLockedUntilFrame > TheGameClient->getFrame())
+		return;
+
 	m_cameraHasMovedSinceRequest = true;
 	Matrix3D cameraTransform( 1 );
 


### PR DESCRIPTION
* Follow up for #1451

This change prevents moving the camera with most user inputs during camera playback in Replay playback. The possibility of this behavior was introduced with the render and logic update decoupling. When the logic step is smaller than the render update, then there is room for user input to move the camera after a `MSG_SET_REPLAY_CAMERA` message.

Numpad 5 still causes issues but it is very minor and a different problem.

## Before this fix

https://github.com/user-attachments/assets/75e64678-f35f-41d6-aaef-a1f63a8e016e

## TODO

- [x] Replicate in Generals