### PR TITLE
bugfix(behavior): Fix hardcoded cash hack value for Black Lotus

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
@@ -1339,14 +1339,18 @@ void SpecialAbilityUpdate::triggerAbilityEffect()
 				return;
 			}
 
-			//Steal a thousand cash from the other team!
+			//Steal cash from the other team!
 			Money *targetMoney = target->getControllingPlayer()->getMoney();
 			Money *objectMoney = object->getControllingPlayer()->getMoney();
 			if( targetMoney && objectMoney )
 			{
 				UnsignedInt cash = targetMoney->countMoney();
+#if RETAIL_COMPATIBLE_CRC
 				UnsignedInt desiredAmount = 1000;
-				//Check to see if they have 1000 cash, otherwise, take the remainder!
+#else
+				UnsignedInt desiredAmount = data->m_effectValue;
+#endif
+				//Check to see if they have the cash, otherwise, take the remainder!
 				cash = min( desiredAmount, cash );
 				if( cash > 0 )
 				{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
@@ -1485,14 +1485,18 @@ void SpecialAbilityUpdate::triggerAbilityEffect()
         return;
       }
 
-      //Steal a thousand cash from the other team!
+      //Steal cash from the other team!
       Money *targetMoney = target->getControllingPlayer()->getMoney();
       Money *objectMoney = object->getControllingPlayer()->getMoney();
       if( targetMoney && objectMoney )
       {
         UnsignedInt cash = targetMoney->countMoney();
+#if RETAIL_COMPATIBLE_CRC
         UnsignedInt desiredAmount = 1000;
-        //Check to see if they have 1000 cash, otherwise, take the remainder!
+#else
+        UnsignedInt desiredAmount = data->m_effectValue;
+#endif
+        //Check to see if they have the cash, otherwise, take the remainder!
         cash = min( desiredAmount, cash );
         if( cash > 0 )
         {


### PR DESCRIPTION
This change allows the `EffectValue` defined in the `SpecialAbilityUpdate` module to control the amount of cash stolen by Black Lotus's Cash Hack ability as originally intended.

```
  Behavior = SpecialAbilityUpdate ModuleTag_13
    SpecialPowerTemplate  = SpecialAbilityBlackLotusStealCashHack
    StartAbilityRange     = 150.0
    UnpackTime            = 6730 ;animation time is 6730 (changing this will scale anim speed)
    PackTime              = 5800 ;animation time is 5800 (changing this will scale anim speed)
    PreparationTime       = 6000 ;time to complete hack once prepared (unpacked)
    EffectValue           = 1000 ;amount of cash stolen
    SpecialObject         = BinaryDataStream
    PackSound             = BlackLotusPack
    UnpackSound           = BlackLotusUnpack
    TriggerSound          = BlackLotusTrigger
    PrepSoundLoop         = BlackLotusPrepLoop
    AwardXPForTriggering  = 20
    ;SkillPointsForTriggering = ???  -- Dustin, fill me out if you want different balance values.
  End
```