### PR TITLE
bugfix(module): Fix damage calculation for determining the initial death of GLA Battle Bus

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Body/UndeadBody.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Body/UndeadBody.cpp
@@ -84,6 +84,7 @@ void UndeadBody::attemptDamage( DamageInfo *damageInfo )
 #if RETAIL_COMPATIBLE_CRC
 			&& damageInfo->in.m_amount >= getHealth()
 #else
+			// TheSuperHackers @bugfix Stubbjax 20/09/2025 Battle Buses now correctly apply damage modifiers when calculating lethal damage
 			&& estimateDamage(damageInfo->in) >= getHealth()
 #endif
 			&& IsHealthDamagingDamage(damageInfo->in.m_damageType)

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Body/UndeadBody.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Body/UndeadBody.cpp
@@ -81,7 +81,11 @@ void UndeadBody::attemptDamage( DamageInfo *damageInfo )
 
 	if( damageInfo->in.m_damageType != DAMAGE_UNRESISTABLE
 			&& !m_isSecondLife
+#if RETAIL_COMPATIBLE_CRC
 			&& damageInfo->in.m_amount >= getHealth()
+#else
+			&& estimateDamage(damageInfo->in) >= getHealth()
+#endif
 			&& IsHealthDamagingDamage(damageInfo->in.m_damageType)
 			)
 	{


### PR DESCRIPTION
Fixes #135

This change fixes the damage calculation for determining the Battle Bus's initial death, meaning it no longer prematurely dies when receiving damage via radiation or poison fields.

The issue is most notable when receiving damage via radiation or poison fields due to `HazardFieldCoreWeapon` - an invisible 200-damage hazard cleanup weapon that typically accompanies poison and radiation fields to stop them from stacking. As no armour damage modifiers are applied to ignore the hazard cleanup damage, the Battle Bus dies when receiving damage from this source if health is <= 200. Even [an Ambulance can kill a Battle Bus](https://github.com/user-attachments/assets/964a7854-4bbe-414b-ac9b-0b32fe8c6efe) by exploiting this logic.

https://github.com/user-attachments/assets/f5923571-ca3c-45c4-805e-31093d3af092