### PR TITLE
bugfix(module): GLA Battle Bus can no longer be subdued indefinitely

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp
@@ -492,6 +492,8 @@ void ActiveBody::attemptDamage( DamageInfo *damageInfo )
 		if( !canBeSubdued() )
 			return;
 
+		// TheSuperHackers @bugfix Stubbjax 20/09/2025 The isSubdued() function now directly checks status instead
+		// of health to prevent indefinite subdue status when internally shifting health across the threshold.
 		Bool wasSubdued = isSubdued();
 		internalAddSubdualDamage(amount);
 		Bool nowSubdued = m_maxHealth <= m_currentSubdualDamage;
@@ -1316,7 +1318,6 @@ Bool ActiveBody::isSubdued() const
 #if RETAIL_COMPATIBLE_CRC
 	return m_maxHealth <= m_currentSubdualDamage;
 #else
-	// TheSuperHackers @bugfix Stubbjax 20/09/2025 Prevent indefinite subdue status when internally shifting health across the threshold.
 	return getObject()->isDisabledByType(DISABLED_SUBDUED);
 #endif
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp
@@ -929,6 +929,12 @@ void ActiveBody::setMaxHealth( Real maxHealth, MaxHealthChangeType healthChangeT
 			internalChangeHealth(m_maxHealth - m_currentHealth);
 			break;
 		}
+
+#if !RETAIL_COMPATIBLE_CRC
+		// TheSuperHackers @bugfix Stubbjax 20/09/2025 Prevent indefinite subdue status when internally shifting health across the threshold.
+		if (isSubdued())
+			internalAddSubdualDamage(m_maxHealth - getCurrentSubdualDamageAmount());
+#endif
 	}
 
 	//

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp
@@ -494,7 +494,7 @@ void ActiveBody::attemptDamage( DamageInfo *damageInfo )
 
 		Bool wasSubdued = isSubdued();
 		internalAddSubdualDamage(amount);
-		Bool nowSubdued = isSubdued();
+		Bool nowSubdued = m_maxHealth <= m_currentSubdualDamage;
 		alreadyHandled = TRUE;
 		allowModifier = FALSE;
 
@@ -929,12 +929,6 @@ void ActiveBody::setMaxHealth( Real maxHealth, MaxHealthChangeType healthChangeT
 			internalChangeHealth(m_maxHealth - m_currentHealth);
 			break;
 		}
-
-#if !RETAIL_COMPATIBLE_CRC
-		// TheSuperHackers @bugfix Stubbjax 20/09/2025 Prevent indefinite subdue status when internally shifting health across the threshold.
-		if (isSubdued())
-			internalAddSubdualDamage(m_maxHealth - getCurrentSubdualDamageAmount());
-#endif
 	}
 
 	//
@@ -1319,7 +1313,12 @@ void ActiveBody::onSubdualChange( Bool isNowSubdued )
 //-------------------------------------------------------------------------------------------------
 Bool ActiveBody::isSubdued() const
 {
+#if RETAIL_COMPATIBLE_CRC
 	return m_maxHealth <= m_currentSubdualDamage;
+#else
+	// TheSuperHackers @bugfix Stubbjax 20/09/2025 Prevent indefinite subdue status when internally shifting health across the threshold.
+	return getObject()->isDisabledByType(DISABLED_SUBDUED);
+#endif
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Body/UndeadBody.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Body/UndeadBody.cpp
@@ -87,14 +87,6 @@ void UndeadBody::attemptDamage( DamageInfo *damageInfo )
 	{
 		damageInfo->in.m_amount = min( damageInfo->in.m_amount, getHealth() - 1 );
 		shouldStartSecondLife = TRUE;
-
-#if !RETAIL_COMPATIBLE_CRC
-		if (isSubdued())
-		{
-			const UndeadBodyModuleData* data = getUndeadBodyModuleData();
-			internalAddSubdualDamage(data->m_secondLifeMaxHealth - getCurrentSubdualDamageAmount());
-		}
-#endif
 	}
 
 	ActiveBody::attemptDamage(damageInfo);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Body/UndeadBody.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Body/UndeadBody.cpp
@@ -87,6 +87,14 @@ void UndeadBody::attemptDamage( DamageInfo *damageInfo )
 	{
 		damageInfo->in.m_amount = min( damageInfo->in.m_amount, getHealth() - 1 );
 		shouldStartSecondLife = TRUE;
+
+#if !RETAIL_COMPATIBLE_CRC
+		if (isSubdued())
+		{
+			const UndeadBodyModuleData* data = getUndeadBodyModuleData();
+			internalAddSubdualDamage(data->m_secondLifeMaxHealth - getCurrentSubdualDamageAmount());
+		}
+#endif
 	}
 
 	ActiveBody::attemptDamage(damageInfo);


### PR DESCRIPTION
This change prevents bunkered Battle Buses from being subdued indefinitely (demonstrated below).

https://github.com/user-attachments/assets/980cde0e-2d75-4c6d-a386-5d766c478931

As a Battle Bus gains 250 health when entering bunkered mode (400 health → 650 health), the subdual damage threshold can be shifted above the current subdual damage and thus cause the Battle Bus to remain subdued forever. To rectify this, the subdual damage is set to the threshold (max health) on transitioning to the bunkered state to ensure the subdued state is removed when healed.