### PR TITLE
bugfix: Double-clicking to place a building no longer performs double-click selection logic

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/PlaceEventTranslator.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/PlaceEventTranslator.cpp
@@ -62,6 +62,7 @@ GameMessageDisposition PlaceEventTranslator::translateGameMessage(const GameMess
 	{
 
 		//---------------------------------------------------------------------------------------------
+		case GameMessage::MSG_RAW_MOUSE_LEFT_DOUBLE_CLICK:
 		case GameMessage::MSG_RAW_MOUSE_LEFT_BUTTON_DOWN:
 		{
 			// if we're in a building placement mode, do the place and send to all players

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/PlaceEventTranslator.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/PlaceEventTranslator.cpp
@@ -68,6 +68,7 @@ GameMessageDisposition PlaceEventTranslator::translateGameMessage(const GameMess
 	{
 
 		//---------------------------------------------------------------------------------------------
+		case GameMessage::MSG_RAW_MOUSE_LEFT_DOUBLE_CLICK:
 		case GameMessage::MSG_RAW_MOUSE_LEFT_BUTTON_DOWN:
 		{
 			// if we're in a building placement mode, do the place and send to all players


### PR DESCRIPTION
This change fixes an issue where double-clicking to place a building in an invalid location can end up performing double-click selection logic if a unit is beneath the build location.

### Before

https://github.com/user-attachments/assets/4a7dbaee-c8f0-4e6c-81e7-0e3d9c060634

### After

https://github.com/user-attachments/assets/6ac52a66-806c-433a-b3dd-fad92bf80d92