### PR TITLE
bugfix(behavior): Fix unexpected propaganda influence from contained units with direct Propaganda Tower behavior modules

### DIFF
--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
@@ -440,6 +440,8 @@ public:
 	// contained-by
 	inline Object *getContainedBy() { return m_containedBy; }
 	inline const Object *getContainedBy() const { return m_containedBy; }
+	Object *getContainedBySpecialOverlordStyle(); ///< Get parent container object if its contain module is Overlord style.
+	const Object *getContainedBySpecialOverlordStyle() const; ///< Get parent container object if its contain module is Overlord style.
 	inline UnsignedInt getContainedByFrame() const { return m_containedByFrame; }
 	inline Bool isContained() const { return m_containedBy != NULL; }
 	void onContainedBy( Object *containedBy );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/PropagandaTowerBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/PropagandaTowerBehavior.cpp
@@ -207,14 +207,25 @@ UpdateSleepTime PropagandaTowerBehavior::update( void )
 		}
 	}
 
-	if( self->getContainedBy()  &&  self->getContainedBy()->getContainedBy() )
+	if (const Object *container = self->getContainedBySpecialOverlordStyle())
 	{
-		// If our container is contained, we turn the heck off.  Seems like a weird specific check, but all of
-		// attacking is guarded by the same check in isPassengersAllowedToFire.  We similarly work in a container,
-		// but not in a double container.
+		if (container->getContainedBy() != NULL)
+		{
+			// If our container is contained, we turn the heck off.  Seems like a weird specific check, but all of
+			// attacking is guarded by the same check in isPassengerAllowedToFire.  We similarly work in a container,
+			// but not in a double container.
+			removeAllInfluence();
+			return UPDATE_SLEEP_NONE;
+		}
+	}
+#if !RETAIL_COMPATIBLE_CRC
+	else if (self->getContainedBy() != NULL)
+	{
+		// TheSuperHackers @bugfix Also turn off when a non overlord styled Propaganda Tower is contained.
 		removeAllInfluence();
 		return UPDATE_SLEEP_NONE;
 	}
+#endif
 
 	// if it's not time to scan, nothing to do
 	UnsignedInt currentFrame = TheGameLogic->getFrame();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
@@ -598,16 +598,8 @@ Bool TransportContain::isPassengerAllowedToFire( ObjectID id ) const
   // but wait! I may be riding on an Overlord
   // This code detects the case of whether the contained passenger is in a bunker riding on an overlord, inside a helix!
   // Oh  my  God.
-  const Object *heWhoContainsMe = getObject()->getContainedBy();
-  if ( heWhoContainsMe)
-  {
-    ContainModuleInterface *hisContain = heWhoContainsMe->getContain();
-    DEBUG_ASSERTCRASH( hisContain,("TransportContain::isPassengerAllowedToFire()... CONTAINER WITHOUT A CONTAIN! AARRGH!") );
-    if ( hisContain && hisContain->isSpecialOverlordStyleContainer() )
-      return hisContain->isPassengerAllowedToFire( id );
-  }
-
-
+	if (const Object *heWhoContainsMe = getObject()->getContainedBySpecialOverlordStyle())
+		return heWhoContainsMe->getContain()->isPassengerAllowedToFire( id );
 
 	return OpenContain::isPassengerAllowedToFire();
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -681,6 +681,29 @@ Object::~Object()
 }
 
 //-------------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------------------
+Object *Object::getContainedBySpecialOverlordStyle()
+{
+	if (Object *containedBy = getContainedBy())
+	{
+		ContainModuleInterface *contain = containedBy->getContain();
+		DEBUG_ASSERTCRASH(contain, ("Object::getContainedBySpecialOverlordStyle()... CONTAINER WITHOUT A CONTAIN! AARRGH!"));
+		if (contain->isSpecialOverlordStyleContainer())
+		{
+			return containedBy;
+		}
+	}
+	return NULL;
+}
+
+//-------------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------------------
+const Object *Object::getContainedBySpecialOverlordStyle() const
+{
+	return const_cast<Object*>(this)->getContainedBySpecialOverlordStyle();
+}
+
+//-------------------------------------------------------------------------------------------------
 /// this object now contained in "containedBy"
 //-------------------------------------------------------------------------------------------------
 void Object::onContainedBy( Object *containedBy )


### PR DESCRIPTION
* Closes #1545

This fix is an alternative to #1545 and fixes the unexpected propaganda influence from contained units with direct Propaganda Tower behavior modules.