### PR TITLE
refactor(pathfinding): remove extra whitespace and commented out code

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -1975,7 +1975,6 @@ inline void applyZone(PathfindCell &targetCell, const PathfindCell &sourceCell, 
 {
 	DEBUG_ASSERTCRASH(sourceCell.getZone()!=0, ("Unset source zone."));
 	Int srcZone = zoneEquivalency[sourceCell.getZone()];
-	//DEBUG_ASSERTCRASH(srcZone!=0, ("Bad zone equivalency zone."));
 	Int targetZone = zoneEquivalency[targetCell.getZone()];
 
 	if (targetZone == 0) {
@@ -2015,11 +2014,8 @@ m_interactsWithBridge(FALSE)
 {
 	m_cellOrigin.x = 0;
 	m_cellOrigin.y = 0;
-	//Added By Sadullah Nader
-	//Initialization(s) inserted
 	m_firstZone = 0;
 	m_markedPassable = TRUE;
-	//
 }
 
 ZoneBlock::~ZoneBlock()
@@ -2329,7 +2325,6 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
 #endif
 #endif
 
-
 	m_maxZone = 1;	// we start using zone 0 as a flag.
 	const Int maxZones=24000;
 	zoneStorageType zoneEquivalency[maxZones];
@@ -2392,7 +2387,6 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
 
 				}
 			}
-			//DEBUG_LOG(("Collapsed zones %d", m_maxZone));
  		}
 	}
 
@@ -2547,19 +2541,6 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
 				if (crusherGround(map[i][j], map[i][j-1])) {
 					applyZone(map[i][j], map[i][j-1], m_crusherZones, m_maxZone);
 				}
-/* No diagonals.  jba.
-				if (i>globalBounds.lo.x) {
-					if (waterGround(map[i][j],map[i-1][j-1])) {
-						applyZone(map[i][j], map[i-1][j-1], m_groundWaterZones, m_maxZone);
-					}
-					if (groundCliff(map[i][j],map[i-1][j-1])) {
-						applyZone(map[i][j], map[i-1][j-1], m_groundCliffZones, m_maxZone);
-					}
-					if (terrain(map[i][j],map[i-1][j-1])) {
-						applyZone(map[i][j], map[i-1][j-1], m_terrainZones, m_maxZone);
-					}
-				}
-*/
 			}
 			DEBUG_ASSERTCRASH(map[i][j].getZone() != 0, ("Cleared the zone."));
 		}
@@ -3289,7 +3270,6 @@ PathfindCell *PathfindLayer::getCell(Int x, Int y)
 }
 
 
-
 /**
  * Classify the given map cell as clear, or not, etc.
  */
@@ -3675,48 +3655,8 @@ void Pathfinder::classifyFence( Object *obj, Bool insert )
  				else
  					m_map[cx][cy].removeObstacle(obj);
  			}
-
  		}
  	}
-
-#if 0
-	// Perhaps it would make more sense to use the iteratecellsalongpath() provided in this class,
-	// but this way works well and is very traceable
-	// neither one is true Bresenham
-	// this one assumes zero fence thickness
-
-	const Coord3D *fencePos = obj->getPosition();
-	Coord3D fenceNorm;
-	obj->getUnitDirectionVector2D( fenceNorm );
-	Coord3D halfLength = fenceNorm;
-	halfLength.scale( obj->getGeometryInfo().getMajorRadius() );
-
-	Coord3D head = *fencePos;
-	head.add( &halfLength );
-	Coord3D tail = *fencePos;
-	tail.sub( &halfLength );
-
-	Real stepLength = 1.0f / ((halfLength.length()*2.0f) / PATHFIND_CELL_SIZE_F);
-
-	for ( Real t = 0.0f; t <= 1.0f; t += stepLength )
-	{
-		Real lengthWalk_x = (head.x * t) + (tail.x * (1.0f-t));
-		Real lengthWalk_y = (head.y * t) + (tail.y * (1.0f-t));
-
-		Int cx = REAL_TO_INT_FLOOR( lengthWalk_x / PATHFIND_CELL_SIZE_F );
-		Int cy = REAL_TO_INT_FLOOR( lengthWalk_y / PATHFIND_CELL_SIZE_F );
-		if (cx >= 0 && cy >= 0 && cx < m_extent.hi.x && cy < m_extent.hi.y)
-		{
-			if (insert) {
-				ICoord2D pos = { cx, cy };
-				m_map[cx][cy].setTypeAsObstacle( obj, true, pos );
-			}
-			else
-				m_map[cx][cy].removeObstacle(obj);
-		}
-	}
-#endif
-
 }
 
 /**
@@ -3983,8 +3923,6 @@ void Pathfinder::internal_classifyObjectFootprint( Object *obj, Bool insert )
 	}
 
 	// Expand building bounds 1 cell.
-#define MARK_BORDER_PINCHED
-#ifdef MARK_BORDER_PINCHED
 	for( j=cellBounds.lo.y; j<=cellBounds.hi.y; j++ )
 	{
 		for( i=cellBounds.lo.x; i<=cellBounds.hi.x; i++ )
@@ -4011,10 +3949,6 @@ void Pathfinder::internal_classifyObjectFootprint( Object *obj, Bool insert )
 			}
 		}
 	}
-#endif
-
-
-
 }
 
 /**
@@ -4216,8 +4150,6 @@ void Pathfinder::debugShowSearch(  Bool pathFound  )
 
 	// show all explored cells for debugging
 	PathfindCell *s;
-
-
 	RGBColor color;
 	color.red = color.blue = color.green = 1;
 	if (!pathFound) {
@@ -4240,7 +4172,6 @@ void Pathfinder::debugShowSearch(  Bool pathFound  )
 
 	for( s = m_closedList; s; s=s->getNextOpen() )
 	{
-		// create objects to show path - they decay
 		// create objects to show path - they decay
 		RGBColor color;
 		color.red = color.blue = 1;
@@ -4308,7 +4239,6 @@ Bool Pathfinder::validMovementTerrain( PathfindLayerEnum layer, const Locomotor*
 
 	if (toCell == NULL)
 		return false;
-	// Only do terrain, not obstacle cells.  jba.
 	if (toCell->getType()==PathfindCell::CELL_OBSTACLE) return true;
 	if (toCell->getType()==PathfindCell::CELL_IMPASSABLE) return true;
 	if (toCell->getLayer()!=LAYER_GROUND && toCell->getLayer() == PathfindCell::CELL_CLEAR) {
@@ -4356,30 +4286,6 @@ void Pathfinder::cleanOpenAndClosedLists(void) {
 #endif
 
 	m_cumulativeCellsAllocated += count;
-//#ifdef RTS_DEBUG
-#if 0
-	// Check for dangling cells.
-	for( int j=0; j<=m_extent.hi.y; j++ )
-		for( int i=0; i<=m_extent.hi.x; i++ )
-			if (m_map[ i ][ j ].hasInfo()) {
-				DEBUG_ASSERTCRASH((m_map[i][j].getXIndex()==i && m_map[i][j].getYIndex()==j), ("Wrong cell coordinates"));
-				Bool needInfo = (m_map[ i ][ j ].getType() == PathfindCell::CELL_OBSTACLE);
-				if (m_map[i][j].isAircraftGoal()) {
-					needInfo = true;
-				}
-				if (m_map[i][j].getFlags() != PathfindCell::NO_UNITS)  {
-					needInfo = true;
-				}
-				if (!needInfo) {
-					DEBUG_LOG(("leaked cell %d, %d", m_map[i][j].getXIndex(), m_map[i][j].getYIndex()));
-					m_map[i][j].releaseInfo();
-				}
-				DEBUG_ASSERTCRASH((needInfo), ("Minor temporary memory leak - Extra cell allocated.  Tell JBA steps if repeatable."));
-			};
-	//DEBUG_LOG(("Pathfind used %d cells.", count));
-#endif
-//#endif
-
 }
 
 
@@ -4405,49 +4311,6 @@ Bool Pathfinder::validMovementPosition( Bool isCrusher, LocomotorSurfaceTypeMask
 	LocomotorSurfaceTypeMask cellSurfaces = validLocomotorSurfacesForCellType(toCell->getType());
 	if ((cellSurfaces & acceptableSurfaces) == 0)
 		return false;
-
-#if 0
-	//
-	// For diagonal moves, check neighboring vertical and horizontal
-	// steps as well to avoid "squeezing through a crack".
-	//
-	if (fromCell)
-	{
-		ICoord2D delta;
-
-		delta.x = toCell->getXIndex() - fromCell->getXIndex();
-		delta.y = toCell->getYIndex() - fromCell->getYIndex();
-
-		if (delta.x != 0 && delta.y != 0)
-		{
-			// test vertical movement
-			PathfindCell *otherCell = getCell( toCell->getXIndex(), fromCell->getYIndex() );
-			Bool open = true;
-
-			// check if cell is on the map
-			if (otherCell == NULL)
-				open = false;
-
-			// check if we can move onto this new cell
-			if (validMovementPosition( locomotorSet, otherCell, fromCell ) == false)
-				open = false;
-
-			// test horizontal movement
-			if (open == false)
-			{
-				otherCell = getCell( fromCell->getXIndex(), toCell->getYIndex() );
-
-				// check if cell is on the map
-				if (otherCell == NULL)
-					return false;
-
-				// check if we can move onto this new cell
-				if (validMovementPosition( locomotorSet, otherCell, fromCell ) == false)
-					return false;
-			}
-		}
-	}
-#endif
 
 	return true;
 }
@@ -4707,7 +4570,6 @@ void Pathfinder::snapClosestGoalPosition(Object *obj, Coord3D *pos)
 			}
 		}
 	}
-	//DEBUG_LOG(("Couldn't find goal."));
 }
 
 /**
@@ -4877,8 +4739,6 @@ Bool Pathfinder::adjustToLandingDestination(Object *obj, Coord3D *dest)
 }
 
 
-
-
 /**
  * Find an unoccupied spot for a unit to move to.
  * Returns false if there are no spots available within a reasonable radius.
@@ -4956,8 +4816,6 @@ Bool Pathfinder::adjustDestination(Object *obj, const LocomotorSet& locomotorSet
 		// Didn't work, so just do simple adjust.
 		return(adjustDestination(obj, locomotorSet, dest, NULL));
 	}
-	//DEBUG_LOG(("adjustDestination failed, dest (%f, %f), adj dest (%f,%f), %x %s", dest->x, dest->y, adjustDest.x, adjustDest.y,
-		//obj, obj->getTemplate()->getName().str()));
 	return false;
 }
 
@@ -5333,8 +5191,6 @@ Path *Pathfinder::getAircraftPath( const Object *obj, const Coord3D *to )
 {
 	// for now, quick path objects don't pathfind, generally airborne units
 	// build a trivial one-node path containing destination, then avoid buildings.
-
-
 	Path *thePath = newInstance(Path);
 	const AIUpdateInterface *ai = obj->getAI();
 	ObjectID avoidObject = INVALID_ID;
@@ -5607,10 +5463,6 @@ struct ExamineCellsStruct
 			to->setParentCell(from) ;
 			to->setTotalCost(to->getCostSoFar() + costRemaining) ;
 
-			//DEBUG_LOG(("Cell (%d,%d), Parent cost %d, newCostSoFar %d, cost rem %d, tot %d",
-			//	to->getXIndex(), to->getYIndex(),
-			//	to->costSoFar(from), newCostSoFar, costRemaining, to->getCostSoFar() + costRemaining));
-
 			// if to was on closed list, remove it from the list
 			if (to->getClosed())
 				d->thePathfinder->m_closedList = to->removeFromClosedList( d->thePathfinder->m_closedList );
@@ -5625,8 +5477,6 @@ struct ExamineCellsStruct
 
 	return 0;	// keep going
 }
-
-
 
 
 Int Pathfinder::examineNeighboringCells(PathfindCell *parentCell, PathfindCell *goalCell, const LocomotorSet& locomotorSet,
@@ -5670,8 +5520,6 @@ Int Pathfinder::examineNeighboringCells(PathfindCell *parentCell, PathfindCell *
 		Bool neighborFlags[8] = { 0 };
 
 		UnsignedInt newCostSoFar = 0;
-
-
 
 		for( int i=0; i<numNeighbors; i++ )
 		{
@@ -5736,8 +5584,6 @@ Int Pathfinder::examineNeighboringCells(PathfindCell *parentCell, PathfindCell *
 				if ( fromPos.z < toPos.z )
 					continue;
 			}
-
-
 
 			Bool movementValid = true;
 			Bool dozerHack = false;
@@ -5869,10 +5715,6 @@ Int Pathfinder::examineNeighboringCells(PathfindCell *parentCell, PathfindCell *
 			}
 			newCell->setTotalCost(newCell->getCostSoFar() + costRemaining) ;
 
-			//DEBUG_LOG(("Cell (%d,%d), Parent cost %d, newCostSoFar %d, cost rem %d, tot %d",
-			//	newCell->getXIndex(), newCell->getYIndex(),
-			//	newCell->costSoFar(parentCell), newCostSoFar, costRemaining, newCell->getCostSoFar() + costRemaining));
-
 			// if newCell was on closed list, remove it from the list
 			if (newCell->getClosed())
 				m_closedList = newCell->removeFromClosedList( m_closedList );
@@ -5916,50 +5758,6 @@ Path *Pathfinder::findPath( Object *obj, const LocomotorSet& locomotorSet, const
 		return pat;
 	}
 
-/* hierarchical build path code.
-	if (pat) {
-
-		Path *path = newInstance(Path);
-		PathNode *prior = NULL;
-		for (PathNode *node = pat->getLastNode(); node; node=node->getPrevious()) {
-			Bool unobstructed = true;
-			if (prior!=NULL) {
-				unobstructed = isLinePassable( obj, locomotorSet.getValidSurfaces(),
-				prior->getLayer(), *prior->getPosition(), *node->getPosition(), false, true);
-			}
-			if (unobstructed) {
-				path->prependNode( node->getPosition(), node->getLayer() );
-				path->getFirstNode()->setCanOptimize(node->getCanOptimize());
-				path->getFirstNode()->setNextOptimized(path->getFirstNode()->getNext());
-			} else {
-				Path *linkPath = findClosestPath(obj, locomotorSet, node->getPosition(),
-					prior->getPosition(), false, 0, true);
-				if (linkPath==NULL) {
-					DEBUG_LOG(("Couldn't find path - unexpected. jba."));
-					continue;
-				}
-				PathNode *linkNode = linkPath->getLastNode();
-				if (linkNode==NULL) {
-					DEBUG_LOG(("Empty path - unexpected. jba."));
-					continue;
-				}
-				for (linkNode=linkNode->getPrevious(); linkNode; linkNode=linkNode->getPrevious()) {
-					path->prependNode( linkNode->getPosition(), linkNode->getLayer() );
-					path->getFirstNode()->setCanOptimize(linkNode->getCanOptimize());
-					path->getFirstNode()->setNextOptimized(path->getFirstNode()->getNext());
-				}
-				deleteInstance(linkPath);
-			}
-			prior = node;
-		}
-		deleteInstance(pat);
-		path->optimize(obj, locomotorSet.getValidSurfaces(), false);
-		if (TheGlobalData->m_debugAI) {
-			setDebugPath(path);
-		}
-		return path;
-	}
-*/
 	return NULL;
 }
 /**
@@ -6823,17 +6621,10 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 				if (newCell->getCostSoFar() <= newCostSoFar)
 					continue;
 			}
-			//DEBUG_LOG(("CELL(%d,%d)L%d CD%d CSF %d, CR%d // ",newCell->getXIndex(), newCell->getYIndex(),
-			//	newCell->getLayer(), clearDiameter, newCostSoFar, costRemaining));
-			//if ((cellCount&7)==0) DEBUG_LOG_RAW(("\n"));
 			newCell->setCostSoFar(newCostSoFar);
 			// keep track of path we're building - point back to cell we moved here from
 			newCell->setParentCell(parentCell) ;
 			newCell->setTotalCost(newCell->getCostSoFar() + costRemaining) ;
-
-			//DEBUG_LOG(("Cell (%d,%d), Parent cost %d, newCostSoFar %d, cost rem %d, tot %d",
-			//	newCell->getXIndex(), newCell->getYIndex(),
-			//	newCell->costSoFar(parentCell), newCostSoFar, costRemaining, newCell->getCostSoFar() + costRemaining));
 
 			// if newCell was on closed list, remove it from the list
 			if (newCell->getClosed())
@@ -6846,8 +6637,6 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 			// insert newCell in open list such that open list is sorted, smallest total path cost first
 			m_openList = newCell->putOnSortedOpenList( m_openList );
 		}
-
-
 	}
 	// failure - goal cannot be reached
 #ifdef INTENSE_DEBUG
@@ -7319,26 +7108,6 @@ Path *Pathfinder::internal_findHierarchicalPath( Bool isHuman, const LocomotorSu
 			show |= (TheGlobalData->m_debugAI==AI_DEBUG_GROUND_PATHS);
 			if (show)	{
 				debugShowSearch(true);
-#if 0 // Show hierarchical blocks (big blue ones.)
-				Int i, j;
-				ICoord2D extent;
-				m_zoneManager.getExtent(extent);
-				for (i=0; i<extent.x; i++) {
-					for (j=0; j<extent.y; j++) {
-						extern void addIcon(const Coord3D *pos, Real width, Int numFramesDuration, RGBColor color);
- 						RGBColor color;
-						color.blue = 1;
-						color.red = color.green = 0;
-						Coord3D pos;
-						pos.x = ((i+0.5f)*PathfindZoneManager::ZONE_BLOCK_SIZE)*PATHFIND_CELL_SIZE_F ;
-						pos.y = ((j+0.5f)*PathfindZoneManager::ZONE_BLOCK_SIZE)*PATHFIND_CELL_SIZE_F ;
-						pos.z = TheTerrainLogic->getGroundHeight( pos.x, pos.y ) + 0.5f;
-						if (m_zoneManager.isPassable(i*PathfindZoneManager::ZONE_BLOCK_SIZE, j*PathfindZoneManager::ZONE_BLOCK_SIZE)) {
-							addIcon(&pos, 5*PATHFIND_CELL_SIZE_F, 300, color);
-						}
-					}
-				}
-#endif
 			}
 #endif
 #if RETAIL_COMPATIBLE_PATHFINDING
@@ -7527,32 +7296,7 @@ Path *Pathfinder::internal_findHierarchicalPath( Bool isHuman, const LocomotorSu
 		m_isTunneling = false;
 		// construct and return path
 		Path *path =  buildHierachicalPath( from, closestCell );
-#if defined(RTS_DEBUG)
-#if 0
-		if (TheGlobalData->m_debugAI)
-		{
-			debugShowSearch(true);
-			Int i, j;
-			ICoord2D extent;
-			m_zoneManager.getExtent(extent);
-			for (i=0; i<extent.x; i++) {
-				for (j=0; j<extent.y; j++) {
-					extern void addIcon(const Coord3D *pos, Real width, Int numFramesDuration, RGBColor color);
- 					RGBColor color;
-					color.blue = 1;
-					color.red = color.green = 0;
-					Coord3D pos;
-					pos.x = ((i+0.5f)*PathfindZoneManager::ZONE_BLOCK_SIZE)*PATHFIND_CELL_SIZE_F ;
-					pos.y = ((j+0.5f)*PathfindZoneManager::ZONE_BLOCK_SIZE)*PATHFIND_CELL_SIZE_F ;
-					pos.z = TheTerrainLogic->getGroundHeight( pos.x, pos.y ) + 0.5f;
-					if (m_zoneManager.isPassable(i*PathfindZoneManager::ZONE_BLOCK_SIZE, j*PathfindZoneManager::ZONE_BLOCK_SIZE)) {
-						addIcon(&pos, 5*PATHFIND_CELL_SIZE_F, 300, color);
-					}
-				}
-			}
-		}
-#endif
-#endif
+
 #if RETAIL_COMPATIBLE_PATHFINDING
 		if (!s_useFixedPathfinding)
 		{
@@ -7874,8 +7618,7 @@ Bool Pathfinder::pathDestination( 	Object *obj, const LocomotorSet& locomotorSet
 			Int dx = IABS(goalCell->getXIndex()-parentCell->getXIndex());
 			Int dy = IABS(goalCell->getYIndex()-parentCell->getYIndex());
 			Real distSqr = dx*dx+dy*dy;
-			//Real cost = (parentCell->getCostSoFar()*(parentCell->getCostSoFar()*COST_TO_DISTANCE_FACTOR))*0.5f;
-			//distSqr += sqr(cost);
+
 			if (distSqr < closestDistanceSqr) {
 				closestCell = parentCell;
 				closestDistanceSqr = distSqr;
@@ -7983,10 +7726,6 @@ Bool Pathfinder::pathDestination( 	Object *obj, const LocomotorSet& locomotorSet
 			}
 
 			newCell->setTotalCost(newCell->getCostSoFar() + costRemaining) ;
-
-			//DEBUG_LOG(("Cell (%d,%d), Parent cost %d, newCostSoFar %d, cost rem %d, tot %d",
-			//	newCell->getXIndex(), newCell->getYIndex(),
-			//	newCell->costSoFar(parentCell), newCostSoFar, costRemaining, newCell->getCostSoFar() + costRemaining));
 
 			// if newCell was on closed list, remove it from the list
 			if (newCell->getClosed())
@@ -8274,10 +8013,6 @@ Int Pathfinder::checkPathCost(Object *obj, const LocomotorSet& locomotorSet, con
 
 			newCell->setTotalCost(newCell->getCostSoFar() + costRemaining) ;
 
-			//DEBUG_LOG(("Cell (%d,%d), Parent cost %d, newCostSoFar %d, cost rem %d, tot %d",
-			//	newCell->getXIndex(), newCell->getYIndex(),
-			//	newCell->costSoFar(parentCell), newCostSoFar, costRemaining, newCell->getCostSoFar() + costRemaining));
-
 			// if newCell was on closed list, remove it from the list
 			if (newCell->getClosed())
 				m_closedList = newCell->removeFromClosedList( m_closedList );
@@ -8318,8 +8053,6 @@ Int Pathfinder::checkPathCost(Object *obj, const LocomotorSet& locomotorSet, con
 	}
 	return MAX_COST;
 }
-
-
 
 
 /**
@@ -8670,8 +8403,6 @@ void Pathfinder::adjustCoordToCell(Int cellX, Int cellY, Bool centerInCell, Coor
 	}
 	pos.z = TheTerrainLogic->getLayerHeight( pos.x, pos.y, layer );
 }
-
-
 
 
 /**
@@ -9514,8 +9245,6 @@ void Pathfinder::updateGoal( Object *obj, const Coord3D *newGoalPos, PathfindLay
 				if (cell) {
 					if (warn && cell->getGoalUnit()!=INVALID_ID && cell->getGoalUnit() != obj->getID()) {
 						warn = false;
-						// jba intense debug
-						//DEBUG_LOG(, ("Units got stuck close to each other.  jba"));
 					}
 					cellNdx.x = i;
 					cellNdx.y = j;
@@ -9527,8 +9256,6 @@ void Pathfinder::updateGoal( Object *obj, const Coord3D *newGoalPos, PathfindLay
 				if (cell) {
 					if (warn && cell->getGoalUnit()!=INVALID_ID && cell->getGoalUnit() != obj->getID()) {
 						warn = false;
-						// jba intense debug
-						//DEBUG_LOG(, ("Units got stuck close to each other.  jba"));
 					}
 					cellNdx.x = i;
 					cellNdx.y = j;
@@ -10087,7 +9814,6 @@ Path *Pathfinder::getMoveAwayFromPath(Object* obj, Object *otherObj,
 }
 
 
-
 /** Patch to the exiting path from the current position, either because we became blocked,
   or because we had to move off the path to avoid other units. */
 Path *Pathfinder::patchPath( const Object *obj, const LocomotorSet& locomotorSet,
@@ -10313,39 +10039,7 @@ Path *Pathfinder::patchPath( const Object *obj, const LocomotorSet& locomotorSet
 Path *Pathfinder::findAttackPath( const Object *obj, const LocomotorSet& locomotorSet, const Coord3D *from,
 		const Object *victim, const Coord3D* victimPos, const Weapon *weapon )
 {
-	/*
-	CRCDEBUG_LOG(("Pathfinder::findAttackPath() for object %d (%s)", obj->getID(), obj->getTemplate()->getName().str()));
-	XferCRC xferCRC;
-	xferCRC.open("lightCRC");
-	xferCRC.xferSnapshot((Object *)obj);
-	xferCRC.close();
-	CRCDEBUG_LOG(("obj CRC is %X", xferCRC.getCRC()));
-	if (from)
-	{
-		CRCDEBUG_LOG(("from: (%g,%g,%g) (%X,%X,%X)",
-			from->x, from->y, from->z,
-			AS_INT(from->x), AS_INT(from->y), AS_INT(from->z)));
-	}
-	if (victim)
-	{
-		CRCDEBUG_LOG(("victim is %d (%s)", victim->getID(), victim->getTemplate()->getName().str()));
-		XferCRC xferCRC;
-		xferCRC.open("lightCRC");
-		xferCRC.xferSnapshot((Object *)victim);
-		xferCRC.close();
-		CRCDEBUG_LOG(("victim CRC is %X", xferCRC.getCRC()));
-	}
-	if (victimPos)
-	{
-		CRCDEBUG_LOG(("from: (%g,%g,%g) (%X,%X,%X)",
-			victimPos->x, victimPos->y, victimPos->z,
-			AS_INT(victimPos->x), AS_INT(victimPos->y), AS_INT(victimPos->z)));
-	}
-	*/
 	if (m_isMapReady == false) return NULL; // Should always be ok.
-#if defined(RTS_DEBUG)
-//	Int startTimeMS = ::GetTickCount();
-#endif
 
 	Bool isCrusher = obj ? obj->getCrusherLevel() > 0 : false;
 	Int radius;
@@ -10392,8 +10086,6 @@ Path *Pathfinder::findAttackPath( const Object *obj, const LocomotorSet& locomot
 			}
 		}
 	}
-
-
 
 	const Int ATTACK_CELL_LIMIT = 2500; // this is a rather expensive operation, so limit the search.
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -1999,7 +1999,6 @@ inline void applyZone(PathfindCell &targetCell, const PathfindCell &sourceCell, 
 {
 	DEBUG_ASSERTCRASH(sourceCell.getZone()!=0, ("Unset source zone."));
 	Int srcZone = zoneEquivalency[sourceCell.getZone()];
-	//DEBUG_ASSERTCRASH(srcZone!=0, ("Bad zone equivalency zone."));
 	Int targetZone = zoneEquivalency[targetCell.getZone()];
 
 	if (targetZone == 0) {
@@ -2039,11 +2038,8 @@ m_interactsWithBridge(FALSE)
 {
 	m_cellOrigin.x = 0;
 	m_cellOrigin.y = 0;
-	//Added By Sadullah Nader
-	//Initialization(s) inserted
 	m_firstZone = 0;
 	m_markedPassable = TRUE;
-	//
 }
 
 ZoneBlock::~ZoneBlock()
@@ -2340,9 +2336,6 @@ void PathfindZoneManager::markZonesDirty( Bool insert )  ///< Called when the zo
 		m_nextFrameToCalculateZones = 2;
 		return;
 	}
-//  if ( insert )
-//  	m_nextFrameToCalculateZones = TheGameLogic->getFrame();
-//  else
     m_nextFrameToCalculateZones = MIN( m_nextFrameToCalculateZones, TheGameLogic->getFrame() + ZONE_UPDATE_FREQUENCY );
 }
 
@@ -2354,13 +2347,10 @@ void PathfindZoneManager::markZonesDirty( Bool insert )  ///< Called when the zo
  * complicated.
  */
 
-
-
 #define dont_forceRefreshCalling
 #ifdef forceRefreshCalling
 static  Bool  s_stopForceCalling = FALSE;
 #endif
-
 
 void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer layers[], const IRegion2D &globalBounds )
 {
@@ -2376,7 +2366,6 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
 	QueryPerformanceCounter((LARGE_INTEGER *)&startTime64);
 #endif
 #endif
-
 
 	m_maxZone = 1;	// we start using zone 0 as a flag.
 	const Int maxZones=24000;
@@ -2406,10 +2395,6 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
 			if (bounds.hi.y > globalBounds.hi.y) {
 				bounds.hi.y = globalBounds.hi.y;
 			}
-//			if (bounds.lo.x>bounds.hi.x || bounds.lo.y>bounds.hi.y) {
-//				DEBUG_CRASH(("Incorrect bounds calculation. Logic error, fix me. jba."));
-//				continue;
-//			}
 			m_zoneBlocks[xBlock][yBlock].setInteractsWithBridge(false);
 			for( j=bounds.lo.y; j<=bounds.hi.y; j++ )	{
 				for( i=bounds.lo.x; i<=bounds.hi.x; i++ )	{
@@ -2429,10 +2414,6 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
 					if (cell->getZone()==0) {
 						cell->setZone(m_maxZone);
 						m_maxZone++;
-//						if (m_maxZone>= maxZones) {
-//							DEBUG_CRASH(("Ran out of pathfind zones.  SERIOUS ERROR! jba."));
-//							break;
-//						}
 					}
 					if (cell->getConnectLayer() > LAYER_GROUND) {
  						m_zoneBlocks[xBlock][yBlock].setInteractsWithBridge(true);
@@ -2440,14 +2421,10 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
 
 				}
 			}
-			//DEBUG_LOG(("Collapsed zones %d", m_maxZone));
  		}
 	}
 
 	Int totalZones = m_maxZone;
-//	if (totalZones>maxZones/2) {
-//		DEBUG_LOG(("Max zones %d", m_maxZone));
-//	}
 
 	// Collapse the zones into a 1,2,3... sequence, removing collapsed zones.
 	m_maxZone = 1;
@@ -2469,34 +2446,6 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
     ++i;
   }
 
-//	for (i=1; i<totalZones; i++) {
-//		Int zone = zoneEquivalency[i];
-//		if (zone == i) {
-//			collapsedZones[i] = m_maxZone;
-//			++m_maxZone;
-//		}	else {
-//			collapsedZones[i] = collapsedZones[zone];
-//		}
-//	}
-
-
-
-
-
-
-//#ifdef DEBUG_QPF
-//#if defined(DEBUG_LOGGING)
-//	QueryPerformanceCounter((LARGE_INTEGER *)&endTime64);
-//	timeToUpdate = ((double)(endTime64-startTime64) / (double)(freq64));
-//	DEBUG_LOG(("Time to calculate first %f", timeToUpdate));
-//#endif
-//#endif
-
-
-
-
-
-
 	// Now map the zones in the map back into the collapsed zones.
 	j=globalBounds.lo.y;
   while( j<=globalBounds.hi.y )
@@ -2506,29 +2455,10 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
     {
       PathfindCell &cell = map[i][j];
 			cell.setZone(collapsedZones[cell.getZone()]);
-
-      //if (cell.getZone()==0)
-      //{
-			//	DEBUG_CRASH(("Zone not set cell %d, %d", i, j));
-			//}
       ++i;
 		}
     ++j;
 	}
-
-//	for( j=globalBounds.lo.y; j<=globalBounds.hi.y; j++ )	{
-//		for( i=globalBounds.lo.x; i<=globalBounds.hi.x; i++ )	{
-//			map[i][j].setZone(collapsedZones[map[i][j].getZone()]);
-////			if (map[i][j].getZone()==0) {
-////				DEBUG_CRASH(("Zone not set cell %d, %d", i, j));
-////			}
-//		}
-//	}
-
-
-
-
-
 
   i = 0;
 	while ( i <= LAYER_LAST )
@@ -2557,36 +2487,8 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
     ++i;
 	}
 
-//	for (i=0; i<=LAYER_LAST; i++) {
-//		Int zone = collapsedZones[layers[i].getZone()];
-//		if (zone == 0) {
-//			zone = m_maxZone;
-//			m_maxZone++;
-//		}
-//		layers[i].setZone( zone );
-////		if (!layers[i].isUnused() && !layers[i].isDestroyed() && layers[i].getZone()==0) {
-////			DEBUG_CRASH(("Zone not set Layer %d", i));
-////		}
-//		layers[i].applyZone();
-//		if (!layers[i].isUnused() && !layers[i].isDestroyed()) {
-//			ICoord2D ndx;
-//			layers[i].getStartCellIndex(&ndx);
-//			setBridge(ndx.x, ndx.y, true);
-//			layers[i].getEndCellIndex(&ndx);
-//			setBridge(ndx.x, ndx.y, true);
-//		}
-//	}
-
-
-
-
-
-
 	allocateZones();
 
-
-
-//	DEBUG_ASSERTCRASH(xBlock==m_zoneBlockExtent.x && yBlock==m_zoneBlockExtent.y, ("Inconsistent allocation - SERIOUS ERROR. jba"));
 	for (xBlock=0; xBlock<xCount; xBlock++)
   {
 		for (yBlock=0; yBlock<yCount; yBlock++)
@@ -2603,39 +2505,10 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
       if (bounds.hi.y > globalBounds.hi.y)
 				bounds.hi.y = globalBounds.hi.y;
 
-// Although a good safeguard, the logic is already proven, thus skip the check
-//			if (bounds.lo.x>bounds.hi.x || bounds.lo.y>bounds.hi.y) {
-//				DEBUG_CRASH(("Incorrect bounds calculation. Logic error, fix me. jba."));
-//				continue;
-//			}
 			m_zoneBlocks[xBlock][yBlock].blockCalculateZones(map, layers, bounds);
 		}
 	}
 
-
-
-
-//#ifdef DEBUG_QPF
-//#if defined(DEBUG_LOGGING)
-//	QueryPerformanceCounter((LARGE_INTEGER *)&endTime64);
-//	timeToUpdate = ((double)(endTime64-startTime64) / (double)(freq64));
-//	DEBUG_LOG(("Time to calculate second %f", timeToUpdate));
-//#endif
-//#endif
-
-
-
-
-
-	// Determine water/ground equivalent zones, and ground/cliff equivalent zones.
-//	for (i=0; i<m_zonesAllocated; i++) {
-//		m_groundCliffZones[i] = i;
-//		m_groundWaterZones[i] = i;
-//		m_groundRubbleZones[i] = i;
-//		m_terrainZones[i] = i;
-//		m_crusherZones[i] = i;
-//		m_hierarchicalZones[i] = i;
-//	}
 	i = 0;
   while ( i < m_zonesAllocated )
 	{
@@ -2643,71 +2516,6 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
     i++;
   }
 
-
-
-
-
-
-//	for( j=globalBounds.lo.y; j<=globalBounds.hi.y; j++ )	{
-//		for( i=globalBounds.lo.x; i<=globalBounds.hi.x; i++ )	{
-//			if ( (map[i][j].getConnectLayer() > LAYER_GROUND) &&
-//				(map[i][j].getType() == PathfindCell::CELL_CLEAR) ) {
-//				PathfindLayer *layer = layers + map[i][j].getConnectLayer();
-//				resolveZones(map[i][j].getZone(), layer->getZone(), m_hierarchicalZones, m_maxZone);
-//			}
-//			if (i>globalBounds.lo.x && map[i][j].getZone()!=map[i-1][j].getZone()) {
-//				if (map[i][j].getType() == map[i-1][j].getType()) {
-//					applyZone(map[i][j], map[i-1][j], m_hierarchicalZones, m_maxZone);
-//				}
-//				if (waterGround(map[i][j], map[i-1][j])) {
-//					applyZone(map[i][j], map[i-1][j], m_groundWaterZones, m_maxZone);
-//				}
-//				if (groundRubble(map[i][j], map[i-1][j])) {
-////					Int zone1 = map[i][j].getZone();
-////					Int zone2 = map[i-1][j].getZone();
-////					if (m_terrainZones[zone1] != m_terrainZones[zone2]) {
-////						//DEBUG_LOG(("Matching terrain zone %d to %d.", zone1, zone2));
-////					}
-//					applyZone(map[i][j], map[i-1][j], m_groundRubbleZones, m_maxZone);
-//				}
-//				if (groundCliff(map[i][j], map[i-1][j])) {
-//					applyZone(map[i][j], map[i-1][j], m_groundCliffZones, m_maxZone);
-//				}
-//				if (terrain(map[i][j], map[i-1][j])) {
-//					applyZone(map[i][j], map[i-1][j], m_terrainZones, m_maxZone);
-//				}
-//				if (crusherGround(map[i][j], map[i-1][j])) {
-//					applyZone(map[i][j], map[i-1][j], m_crusherZones, m_maxZone);
-//				}
-//			}
-//			if (j>globalBounds.lo.y && map[i][j].getZone()!=map[i][j-1].getZone()) {
-//				if (map[i][j].getType() == map[i][j-1].getType()) {
-//					applyZone(map[i][j], map[i][j-1], m_hierarchicalZones, m_maxZone);
-//				}
-//				if (waterGround(map[i][j],map[i][j-1])) {
-//					applyZone(map[i][j], map[i][j-1], m_groundWaterZones, m_maxZone);
-//				}
-//				if (groundRubble(map[i][j], map[i][j-1])) {
-////					Int zone1 = map[i][j].getZone();
-////					Int zone2 = map[i][j-1].getZone();
-////					if (m_terrainZones[zone1] != m_terrainZones[zone2]) {
-////						//DEBUG_LOG(("Matching terrain zone %d to %d.", zone1, zone2));
-////					}
-//					applyZone(map[i][j], map[i][j-1], m_groundRubbleZones, m_maxZone);
-//				}
-//				if (groundCliff(map[i][j],map[i][j-1])) {
-//					applyZone(map[i][j], map[i][j-1], m_groundCliffZones, m_maxZone);
-//				}
-//				if (terrain(map[i][j], map[i][j-1])) {
-//					applyZone(map[i][j], map[i][j-1], m_terrainZones, m_maxZone);
-//				}
-//				if (crusherGround(map[i][j], map[i][j-1])) {
-//					applyZone(map[i][j], map[i][j-1], m_crusherZones, m_maxZone);
-//				}
-//			}
-//		//	DEBUG_ASSERTCRASH(map[i][j].getZone() != 0, ("Cleared the zone."));
-//		}
-//	}
   REGISTER UnsignedInt maxZone = m_maxZone;
 	j=globalBounds.lo.y;
   while( j <= globalBounds.hi.y )
@@ -2793,31 +2601,12 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
 
       }
 
-//			DEBUG_ASSERTCRASH(r_thisCell.getZone() != 0, ("Cleared the zone."));
-
       ++i;
 		}
 
     ++j;
 	}
 
-
-
-
-
-
-
-
-
-//	if (m_maxZone >= m_zonesAllocated) {
-//		RELEASE_CRASH("Pathfind allocation error - fatal. see jba.");
-//	}
-
-//	for (i=1; i<m_maxZone; i++) {
-//		// Flatten hierarchical zones.
-//		Int zone = m_hierarchicalZones[i];
-//		m_hierarchicalZones[i] = m_hierarchicalZones[zone];
-//	}
   //FLATTEN HIERARCHICAL ZONES
   {
 	  i = 1;
@@ -2830,8 +2619,6 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
 	  }
   }
 
-
-
   //THIS BLOCK IS 20%
 	flattenZones(m_groundCliffZones, m_hierarchicalZones, m_maxZone);
 	flattenZones(m_groundWaterZones, m_hierarchicalZones, m_maxZone);
@@ -2839,13 +2626,11 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
 	flattenZones(m_terrainZones, m_hierarchicalZones, m_maxZone);
 	flattenZones(m_crusherZones, m_hierarchicalZones, m_maxZone);
 
-
 #ifdef DEBUG_QPF
 #if defined(DEBUG_LOGGING)
 	QueryPerformanceCounter((LARGE_INTEGER *)&endTime64);
 	timeToUpdate = ((double)(endTime64-startTime64) / (double)(freq64));
 
-//	DEBUG_LOG(("Time to calculate zones %f, cells %d", timeToUpdate, (globalBounds.hi.x-globalBounds.lo.x)*(globalBounds.hi.y-globalBounds.lo.y)));
   if ( updateSamples < 400 )
   {
     averageTimeToUpdate = ((averageTimeToUpdate * updateSamples) + timeToUpdate) / (updateSamples + 1.0f);
@@ -2874,8 +2659,6 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
 		for( j=0; j<globalBounds.hi.y; j++ )	{
 			for( i=0; i<globalBounds.hi.x; i++ )	{
 				Int zone = map[i][j].getZone();
-				//zone = m_terrainZones[zone];
-				//zone = m_groundCliffZones[zone];
 				zone = m_hierarchicalZones[zone];
 
 				color.blue = (zone%3) * 0.5f;
@@ -2894,8 +2677,6 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
 #endif
 	m_nextFrameToCalculateZones = 0xffffffff;
 }
-
-
 
 /**
  * Update zones where a structure has been added or removed.
@@ -2999,14 +2780,12 @@ void PathfindZoneManager::updateZonesForModify(PathfindCell **map, PathfindLayer
 					}
 				}
 			}
-			//DEBUG_LOG(("Collapsed zones %d", m_maxZone));
  		}
 	}
 #ifdef DEBUG_QPF
 #if defined(DEBUG_LOGGING)
 	QueryPerformanceCounter((LARGE_INTEGER *)&endTime64);
 	timeToUpdate = ((double)(endTime64-startTime64) / (double)(freq64));
-	//DEBUG_LOG(("Time to update zones %f, cells %d", timeToUpdate, (globalBounds.hi.x-globalBounds.lo.x)*(globalBounds.hi.y-globalBounds.lo.y)));
 #endif
 #endif
 #if defined(RTS_DEBUG)
@@ -3039,15 +2818,6 @@ void PathfindZoneManager::updateZonesForModify(PathfindCell **map, PathfindLayer
 #endif
 
 }
-
-
-
-
-
-
-
-
-
 
 //
 // Clear the passable flags.
@@ -3731,7 +3501,6 @@ PathfindCell *PathfindLayer::getCell(Int x, Int y)
 }
 
 
-
 /**
  * Classify the given map cell as clear, or not, etc.
  */
@@ -4143,44 +3912,6 @@ void Pathfinder::classifyFence( Object *obj, Bool insert )
 		m_zoneManager.markZonesDirty( insert );
 		m_zoneManager.updateZonesForModify(m_map, m_layers, cellBounds, m_extent);
 	}
-#if 0
-	// Perhaps it would make more sense to use the iteratecellsalongpath() provided in this class,
-	// but this way works well and is very traceable
-	// neither one is true Bresenham
-	// this one assumes zero fence thickness
-
-	const Coord3D *fencePos = obj->getPosition();
-	Coord3D fenceNorm;
-	obj->getUnitDirectionVector2D( fenceNorm );
-	Coord3D halfLength = fenceNorm;
-	halfLength.scale( obj->getGeometryInfo().getMajorRadius() );
-
-	Coord3D head = *fencePos;
-	head.add( &halfLength );
-	Coord3D tail = *fencePos;
-	tail.sub( &halfLength );
-
-	Real stepLength = 1.0f / ((halfLength.length()*2.0f) / PATHFIND_CELL_SIZE_F);
-
-	for ( Real t = 0.0f; t <= 1.0f; t += stepLength )
-	{
-		Real lengthWalk_x = (head.x * t) + (tail.x * (1.0f-t));
-		Real lengthWalk_y = (head.y * t) + (tail.y * (1.0f-t));
-
-		Int cx = REAL_TO_INT_FLOOR( lengthWalk_x / PATHFIND_CELL_SIZE_F );
-		Int cy = REAL_TO_INT_FLOOR( lengthWalk_y / PATHFIND_CELL_SIZE_F );
-		if (cx >= 0 && cy >= 0 && cx < m_extent.hi.x && cy < m_extent.hi.y)
-		{
-			if (insert) {
-				ICoord2D pos = { cx, cy };
-				m_map[cx][cy].setTypeAsObstacle( obj, true, pos );
-			}
-			else
-				m_map[cx][cy].removeObstacle(obj);
-		}
-	}
-#endif
-
 }
 
 /**
@@ -4475,8 +4206,6 @@ void Pathfinder::internal_classifyObjectFootprint( Object *obj, Bool insert )
 	}
 
 	// Expand building bounds 1 cell.
-#define MARK_BORDER_PINCHED
-#ifdef MARK_BORDER_PINCHED
 	for( j=cellBounds.lo.y; j<=cellBounds.hi.y; j++ )
 	{
 		for( i=cellBounds.lo.x; i<=cellBounds.hi.x; i++ )
@@ -4503,10 +4232,6 @@ void Pathfinder::internal_classifyObjectFootprint( Object *obj, Bool insert )
 			}
 		}
 	}
-#endif
-
-
-
 }
 
 /**
@@ -4708,8 +4433,6 @@ void Pathfinder::debugShowSearch(  Bool pathFound  )
 
 	// show all explored cells for debugging
 	PathfindCell *s;
-
-
 	RGBColor color;
 	color.red = color.blue = color.green = 1;
 	if (!pathFound) {
@@ -4732,7 +4455,6 @@ void Pathfinder::debugShowSearch(  Bool pathFound  )
 
 	for( s = m_closedList; s; s=s->getNextOpen() )
 	{
-		// create objects to show path - they decay
 		// create objects to show path - they decay
 		RGBColor color;
 		color.red = color.blue = 1;
@@ -4850,30 +4572,6 @@ void Pathfinder::cleanOpenAndClosedLists(void) {
 #endif
 
 	m_cumulativeCellsAllocated += count;
-//#ifdef RTS_DEBUG
-#if 0
-	// Check for dangling cells.
-	for( int j=0; j<=m_extent.hi.y; j++ )
-		for( int i=0; i<=m_extent.hi.x; i++ )
-			if (m_map[ i ][ j ].hasInfo()) {
-				DEBUG_ASSERTCRASH((m_map[i][j].getXIndex()==i && m_map[i][j].getYIndex()==j), ("Wrong cell coordinates"));
-				Bool needInfo = (m_map[ i ][ j ].getType() == PathfindCell::CELL_OBSTACLE);
-				if (m_map[i][j].isAircraftGoal()) {
-					needInfo = true;
-				}
-				if (m_map[i][j].getFlags() != PathfindCell::NO_UNITS)  {
-					needInfo = true;
-				}
-				if (!needInfo) {
-					DEBUG_LOG(("leaked cell %d, %d", m_map[i][j].getXIndex(), m_map[i][j].getYIndex()));
-					m_map[i][j].releaseInfo();
-				}
-				DEBUG_ASSERTCRASH((needInfo), ("Minor temporary memory leak - Extra cell allocated.  Tell JBA steps if repeatable."));
-			};
-	//DEBUG_LOG(("Pathfind used %d cells.", count));
-#endif
-//#endif
-
 }
 
 
@@ -4899,49 +4597,6 @@ Bool Pathfinder::validMovementPosition( Bool isCrusher, LocomotorSurfaceTypeMask
 	LocomotorSurfaceTypeMask cellSurfaces = validLocomotorSurfacesForCellType(toCell->getType());
 	if ((cellSurfaces & acceptableSurfaces) == 0)
 		return false;
-
-#if 0
-	//
-	// For diagonal moves, check neighboring vertical and horizontal
-	// steps as well to avoid "squeezing through a crack".
-	//
-	if (fromCell)
-	{
-		ICoord2D delta;
-
-		delta.x = toCell->getXIndex() - fromCell->getXIndex();
-		delta.y = toCell->getYIndex() - fromCell->getYIndex();
-
-		if (delta.x != 0 && delta.y != 0)
-		{
-			// test vertical movement
-			PathfindCell *otherCell = getCell( toCell->getXIndex(), fromCell->getYIndex() );
-			Bool open = true;
-
-			// check if cell is on the map
-			if (otherCell == NULL)
-				open = false;
-
-			// check if we can move onto this new cell
-			if (validMovementPosition( locomotorSet, otherCell, fromCell ) == false)
-				open = false;
-
-			// test horizontal movement
-			if (open == false)
-			{
-				otherCell = getCell( fromCell->getXIndex(), toCell->getYIndex() );
-
-				// check if cell is on the map
-				if (otherCell == NULL)
-					return false;
-
-				// check if we can move onto this new cell
-				if (validMovementPosition( locomotorSet, otherCell, fromCell ) == false)
-					return false;
-			}
-		}
-	}
-#endif
 
 	return true;
 }
@@ -5094,11 +4749,6 @@ Bool Pathfinder::checkForMovement(const Object *obj, TCheckMovementInfo &info)
 							if (!unit->getAIUpdateInterface()) {
 								return false; // can't path through not-idle units.
 							}
-#if 0
-							if (!unit->getAIUpdateInterface()->isIdle()) {
-								return false; // can't path through not-idle units.
-							}
-#endif
 							Bool found = false;
 							Int k;
 							for (k=0; k<numAlly; k++) {
@@ -5206,7 +4856,6 @@ void Pathfinder::snapClosestGoalPosition(Object *obj, Coord3D *pos)
 			}
 		}
 	}
-	//DEBUG_LOG(("Couldn't find goal."));
 }
 
 /**
@@ -5376,8 +5025,6 @@ Bool Pathfinder::adjustToLandingDestination(Object *obj, Coord3D *dest)
 }
 
 
-
-
 /**
  * Find an unoccupied spot for a unit to move to.
  * Returns false if there are no spots available within a reasonable radius.
@@ -5455,8 +5102,6 @@ Bool Pathfinder::adjustDestination(Object *obj, const LocomotorSet& locomotorSet
 		// Didn't work, so just do simple adjust.
 		return(adjustDestination(obj, locomotorSet, dest, NULL));
 	}
-	//DEBUG_LOG(("adjustDestination failed, dest (%f, %f), adj dest (%f,%f), %x %s", dest->x, dest->y, adjustDest.x, adjustDest.y,
-		//obj, obj->getTemplate()->getName().str()));
 	return false;
 }
 
@@ -5836,8 +5481,6 @@ Path *Pathfinder::getAircraftPath( const Object *obj, const Coord3D *to )
 {
 	// for now, quick path objects don't pathfind, generally airborne units
 	// build a trivial one-node path containing destination, then avoid buildings.
-
-
 	Path *thePath = newInstance(Path);
 	const AIUpdateInterface *ai = obj->getAI();
 	ObjectID avoidObject = INVALID_ID;
@@ -5901,9 +5544,6 @@ Path *Pathfinder::getAircraftPath( const Object *obj, const Coord3D *to )
 }
 
 
-
-
-
 /**
  * Process some path requests in the pathfind queue.
  */
@@ -5924,8 +5564,6 @@ void Pathfinder::processPathfindQueue(void)
 	QueryPerformanceCounter((LARGE_INTEGER *)&startTime64);
 #endif
 #endif
-
-
 
 	if (
 #ifdef forceRefreshCalling
@@ -6125,10 +5763,6 @@ struct ExamineCellsStruct
 			to->setParentCell(from) ;
 			to->setTotalCost(to->getCostSoFar() + costRemaining) ;
 
-			//DEBUG_LOG(("Cell (%d,%d), Parent cost %d, newCostSoFar %d, cost rem %d, tot %d",
-			//	to->getXIndex(), to->getYIndex(),
-			//	to->costSoFar(from), newCostSoFar, costRemaining, to->getCostSoFar() + costRemaining));
-
 			// if to was on closed list, remove it from the list
 			if (to->getClosed())
 				d->thePathfinder->m_closedList = to->removeFromClosedList( d->thePathfinder->m_closedList );
@@ -6143,8 +5777,6 @@ struct ExamineCellsStruct
 
 	return 0;	// keep going
 }
-
-
 
 
 Int Pathfinder::examineNeighboringCells(PathfindCell *parentCell, PathfindCell *goalCell, const LocomotorSet& locomotorSet,
@@ -6188,8 +5820,6 @@ Int Pathfinder::examineNeighboringCells(PathfindCell *parentCell, PathfindCell *
 		Bool neighborFlags[8] = { 0 };
 
 		UnsignedInt newCostSoFar = 0;
-
-
 
 		for( int i=0; i<numNeighbors; i++ )
 		{
@@ -6254,8 +5884,6 @@ Int Pathfinder::examineNeighboringCells(PathfindCell *parentCell, PathfindCell *
 				if ( fromPos.z < toPos.z )
 					continue;
 			}
-
-
 
 			Bool movementValid = true;
 			Bool dozerHack = false;
@@ -6391,10 +6019,6 @@ Int Pathfinder::examineNeighboringCells(PathfindCell *parentCell, PathfindCell *
 			}
 			newCell->setTotalCost(newCell->getCostSoFar() + costRemaining) ;
 
-			//DEBUG_LOG(("Cell (%d,%d), Parent cost %d, newCostSoFar %d, cost rem %d, tot %d",
-			//	newCell->getXIndex(), newCell->getYIndex(),
-			//	newCell->costSoFar(parentCell), newCostSoFar, costRemaining, newCell->getCostSoFar() + costRemaining));
-
 			// if newCell was on closed list, remove it from the list
 			if (newCell->getClosed())
 				m_closedList = newCell->removeFromClosedList( m_closedList );
@@ -6438,50 +6062,6 @@ Path *Pathfinder::findPath( Object *obj, const LocomotorSet& locomotorSet, const
 		return pat;
 	}
 
-/* hierarchical build path code.
-	if (pat) {
-
-		Path *path = newInstance(Path);
-		PathNode *prior = NULL;
-		for (PathNode *node = pat->getLastNode(); node; node=node->getPrevious()) {
-			Bool unobstructed = true;
-			if (prior!=NULL) {
-				unobstructed = isLinePassable( obj, locomotorSet.getValidSurfaces(),
-				prior->getLayer(), *prior->getPosition(), *node->getPosition(), false, true);
-			}
-			if (unobstructed) {
-				path->prependNode( node->getPosition(), node->getLayer() );
-				path->getFirstNode()->setCanOptimize(node->getCanOptimize());
-				path->getFirstNode()->setNextOptimized(path->getFirstNode()->getNext());
-			} else {
-				Path *linkPath = findClosestPath(obj, locomotorSet, node->getPosition(),
-					prior->getPosition(), false, 0, true);
-				if (linkPath==NULL) {
-					DEBUG_LOG(("Couldn't find path - unexpected. jba."));
-					continue;
-				}
-				PathNode *linkNode = linkPath->getLastNode();
-				if (linkNode==NULL) {
-					DEBUG_LOG(("Empty path - unexpected. jba."));
-					continue;
-				}
-				for (linkNode=linkNode->getPrevious(); linkNode; linkNode=linkNode->getPrevious()) {
-					path->prependNode( linkNode->getPosition(), linkNode->getLayer() );
-					path->getFirstNode()->setCanOptimize(linkNode->getCanOptimize());
-					path->getFirstNode()->setNextOptimized(path->getFirstNode()->getNext());
-				}
-				deleteInstance(linkPath);
-			}
-			prior = node;
-		}
-		deleteInstance(pat);
-		path->optimize(obj, locomotorSet.getValidSurfaces(), false);
-		if (TheGlobalData->m_debugAI) {
-			setDebugPath(path);
-		}
-		return path;
-	}
-*/
 	return NULL;
 }
 /**
@@ -7371,17 +6951,10 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 				if (newCell->getCostSoFar() <= newCostSoFar)
 					continue;
 			}
-			//DEBUG_LOG(("CELL(%d,%d)L%d CD%d CSF %d, CR%d // ",newCell->getXIndex(), newCell->getYIndex(),
-			//	newCell->getLayer(), clearDiameter, newCostSoFar, costRemaining));
-			//if ((cellCount&7)==0) DEBUG_LOG_RAW(("\n"));
 			newCell->setCostSoFar(newCostSoFar);
 			// keep track of path we're building - point back to cell we moved here from
 			newCell->setParentCell(parentCell) ;
 			newCell->setTotalCost(newCell->getCostSoFar() + costRemaining) ;
-
-			//DEBUG_LOG(("Cell (%d,%d), Parent cost %d, newCostSoFar %d, cost rem %d, tot %d",
-			//	newCell->getXIndex(), newCell->getYIndex(),
-			//	newCell->costSoFar(parentCell), newCostSoFar, costRemaining, newCell->getCostSoFar() + costRemaining));
 
 			// if newCell was on closed list, remove it from the list
 			if (newCell->getClosed())
@@ -7394,8 +6967,6 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 			// insert newCell in open list such that open list is sorted, smallest total path cost first
 			m_openList = newCell->putOnSortedOpenList( m_openList );
 		}
-
-
 	}
 	// failure - goal cannot be reached
 #ifdef INTENSE_DEBUG
@@ -7881,26 +7452,6 @@ Path *Pathfinder::internal_findHierarchicalPath( Bool isHuman, const LocomotorSu
 			show |= (TheGlobalData->m_debugAI==AI_DEBUG_GROUND_PATHS);
 			if (show)	{
 				debugShowSearch(true);
-#if 0 // Show hierarchical blocks (big blue ones.)
-				Int i, j;
-				ICoord2D extent;
-				m_zoneManager.getExtent(extent);
-				for (i=0; i<extent.x; i++) {
-					for (j=0; j<extent.y; j++) {
-						extern void addIcon(const Coord3D *pos, Real width, Int numFramesDuration, RGBColor color);
- 						RGBColor color;
-						color.blue = 1;
-						color.red = color.green = 0;
-						Coord3D pos;
-						pos.x = ((i+0.5f)*PathfindZoneManager::ZONE_BLOCK_SIZE)*PATHFIND_CELL_SIZE_F ;
-						pos.y = ((j+0.5f)*PathfindZoneManager::ZONE_BLOCK_SIZE)*PATHFIND_CELL_SIZE_F ;
-						pos.z = TheTerrainLogic->getGroundHeight( pos.x, pos.y ) + 0.5f;
-						if (m_zoneManager.isPassable(i*PathfindZoneManager::ZONE_BLOCK_SIZE, j*PathfindZoneManager::ZONE_BLOCK_SIZE)) {
-							addIcon(&pos, 5*PATHFIND_CELL_SIZE_F, 300, color);
-						}
-					}
-				}
-#endif
 			}
 #endif
 #if RETAIL_COMPATIBLE_PATHFINDING
@@ -8089,32 +7640,7 @@ Path *Pathfinder::internal_findHierarchicalPath( Bool isHuman, const LocomotorSu
 		m_isTunneling = false;
 		// construct and return path
 		Path *path =  buildHierachicalPath( from, closestCell );
-#if defined(RTS_DEBUG)
-#if 0
-		if (TheGlobalData->m_debugAI)
-		{
-			debugShowSearch(true);
-			Int i, j;
-			ICoord2D extent;
-			m_zoneManager.getExtent(extent);
-			for (i=0; i<extent.x; i++) {
-				for (j=0; j<extent.y; j++) {
-					extern void addIcon(const Coord3D *pos, Real width, Int numFramesDuration, RGBColor color);
- 					RGBColor color;
-					color.blue = 1;
-					color.red = color.green = 0;
-					Coord3D pos;
-					pos.x = ((i+0.5f)*PathfindZoneManager::ZONE_BLOCK_SIZE)*PATHFIND_CELL_SIZE_F ;
-					pos.y = ((j+0.5f)*PathfindZoneManager::ZONE_BLOCK_SIZE)*PATHFIND_CELL_SIZE_F ;
-					pos.z = TheTerrainLogic->getGroundHeight( pos.x, pos.y ) + 0.5f;
-					if (m_zoneManager.isPassable(i*PathfindZoneManager::ZONE_BLOCK_SIZE, j*PathfindZoneManager::ZONE_BLOCK_SIZE)) {
-						addIcon(&pos, 5*PATHFIND_CELL_SIZE_F, 300, color);
-					}
-				}
-			}
-		}
-#endif
-#endif
+
 #if RETAIL_COMPATIBLE_PATHFINDING
 		if (!s_useFixedPathfinding)
 		{
@@ -8498,8 +8024,7 @@ Bool Pathfinder::pathDestination( 	Object *obj, const LocomotorSet& locomotorSet
 			Int dx = IABS(goalCell->getXIndex()-parentCell->getXIndex());
 			Int dy = IABS(goalCell->getYIndex()-parentCell->getYIndex());
 			Real distSqr = dx*dx+dy*dy;
-			//Real cost = (parentCell->getCostSoFar()*(parentCell->getCostSoFar()*COST_TO_DISTANCE_FACTOR))*0.5f;
-			//distSqr += sqr(cost);
+
 			if (distSqr < closestDistanceSqr) {
 				closestCell = parentCell;
 				closestDistanceSqr = distSqr;
@@ -8607,10 +8132,6 @@ Bool Pathfinder::pathDestination( 	Object *obj, const LocomotorSet& locomotorSet
 			}
 
 			newCell->setTotalCost(newCell->getCostSoFar() + costRemaining) ;
-
-			//DEBUG_LOG(("Cell (%d,%d), Parent cost %d, newCostSoFar %d, cost rem %d, tot %d",
-			//	newCell->getXIndex(), newCell->getYIndex(),
-			//	newCell->costSoFar(parentCell), newCostSoFar, costRemaining, newCell->getCostSoFar() + costRemaining));
 
 			// if newCell was on closed list, remove it from the list
 			if (newCell->getClosed())
@@ -8898,10 +8419,6 @@ Int Pathfinder::checkPathCost(Object *obj, const LocomotorSet& locomotorSet, con
 
 			newCell->setTotalCost(newCell->getCostSoFar() + costRemaining) ;
 
-			//DEBUG_LOG(("Cell (%d,%d), Parent cost %d, newCostSoFar %d, cost rem %d, tot %d",
-			//	newCell->getXIndex(), newCell->getYIndex(),
-			//	newCell->costSoFar(parentCell), newCostSoFar, costRemaining, newCell->getCostSoFar() + costRemaining));
-
 			// if newCell was on closed list, remove it from the list
 			if (newCell->getClosed())
 				m_closedList = newCell->removeFromClosedList( m_closedList );
@@ -8942,8 +8459,6 @@ Int Pathfinder::checkPathCost(Object *obj, const LocomotorSet& locomotorSet, con
 	}
 	return MAX_COST;
 }
-
-
 
 
 /**
@@ -9297,8 +8812,6 @@ void Pathfinder::adjustCoordToCell(Int cellX, Int cellY, Bool centerInCell, Coor
 	}
 	pos.z = TheTerrainLogic->getLayerHeight( pos.x, pos.y, layer );
 }
-
-
 
 
 /**
@@ -10102,7 +9615,6 @@ void Pathfinder::updateGoal( Object *obj, const Coord3D *newGoalPos, PathfindLay
 
 	PathfindLayerEnum originalLayer = obj->getDestinationLayer();
 
-	//DEBUG_LOG(("Object Goal layer is %d", layer));
 	Bool layerChanged = originalLayer != layer;
 
 	Bool doGround=false;
@@ -10150,8 +9662,6 @@ void Pathfinder::updateGoal( Object *obj, const Coord3D *newGoalPos, PathfindLay
 				if (cell) {
 					if (warn && cell->getGoalUnit()!=INVALID_ID && cell->getGoalUnit() != obj->getID()) {
 						warn = false;
-						// jba intense debug
-						//DEBUG_LOG(, ("Units got stuck close to each other.  jba"));
 					}
 					cellNdx.x = i;
 					cellNdx.y = j;
@@ -10163,8 +9673,6 @@ void Pathfinder::updateGoal( Object *obj, const Coord3D *newGoalPos, PathfindLay
 				if (cell) {
 					if (warn && cell->getGoalUnit()!=INVALID_ID && cell->getGoalUnit() != obj->getID()) {
 						warn = false;
-						// jba intense debug
-						//DEBUG_LOG(, ("Units got stuck close to each other.  jba"));
 					}
 					cellNdx.x = i;
 					cellNdx.y = j;
@@ -10736,7 +10244,6 @@ Path *Pathfinder::getMoveAwayFromPath(Object* obj, Object *otherObj,
 }
 
 
-
 /** Patch to the exiting path from the current position, either because we became blocked,
   or because we had to move off the path to avoid other units. */
 Path *Pathfinder::patchPath( const Object *obj, const LocomotorSet& locomotorSet,
@@ -10962,39 +10469,7 @@ Path *Pathfinder::patchPath( const Object *obj, const LocomotorSet& locomotorSet
 Path *Pathfinder::findAttackPath( const Object *obj, const LocomotorSet& locomotorSet, const Coord3D *from,
 		const Object *victim, const Coord3D* victimPos, const Weapon *weapon )
 {
-	/*
-	CRCDEBUG_LOG(("Pathfinder::findAttackPath() for object %d (%s)", obj->getID(), obj->getTemplate()->getName().str()));
-	XferCRC xferCRC;
-	xferCRC.open("lightCRC");
-	xferCRC.xferSnapshot((Object *)obj);
-	xferCRC.close();
-	CRCDEBUG_LOG(("obj CRC is %X", xferCRC.getCRC()));
-	if (from)
-	{
-		CRCDEBUG_LOG(("from: (%g,%g,%g) (%X,%X,%X)",
-			from->x, from->y, from->z,
-			AS_INT(from->x), AS_INT(from->y), AS_INT(from->z)));
-	}
-	if (victim)
-	{
-		CRCDEBUG_LOG(("victim is %d (%s)", victim->getID(), victim->getTemplate()->getName().str()));
-		XferCRC xferCRC;
-		xferCRC.open("lightCRC");
-		xferCRC.xferSnapshot((Object *)victim);
-		xferCRC.close();
-		CRCDEBUG_LOG(("victim CRC is %X", xferCRC.getCRC()));
-	}
-	if (victimPos)
-	{
-		CRCDEBUG_LOG(("from: (%g,%g,%g) (%X,%X,%X)",
-			victimPos->x, victimPos->y, victimPos->z,
-			AS_INT(victimPos->x), AS_INT(victimPos->y), AS_INT(victimPos->z)));
-	}
-	*/
 	if (m_isMapReady == false) return NULL; // Should always be ok.
-#if defined(RTS_DEBUG)
-//	Int startTimeMS = ::GetTickCount();
-#endif
 
 	Bool isCrusher = obj ? obj->getCrusherLevel() > 0 : false;
 	Int radius;
@@ -11041,8 +10516,6 @@ Path *Pathfinder::findAttackPath( const Object *obj, const LocomotorSet& locomot
 			}
 		}
 	}
-
-
 
 	const Int ATTACK_CELL_LIMIT = 2500; // this is a rather expensive operation, so limit the search.
 
@@ -11182,9 +10655,7 @@ Path *Pathfinder::findAttackPath( const Object *obj, const LocomotorSet& locomot
 	#endif
 				if (show)
 					debugShowSearch(true);
-	#if defined(RTS_DEBUG)
-				//DEBUG_LOG(("Attack path took %d cells, %f sec", cellCount, (::GetTickCount()-startTimeMS)/1000.0f));
-	#endif
+
 				// put parent cell onto closed list - its evaluation is finished
 				m_closedList = parentCell->putOnClosedList( m_closedList );
 				// construct and return path


### PR DESCRIPTION
This PR is a cleanup of the pathfinding code, it removes a lot of commented out code and whitespace.
It also removes the defines wrapping some blocks and integrates them directly, as the define was local to that block only.

Rubbish getting taken out, a followup PR will perform some refactoring to make code clearer to understand and more performant.