### PR TITLE
bugfix(jetaiupdate): Fix pairs of Jets not always waiting for each other before takeoff

### DIFF
--- a/Generals/Code/GameEngine/Include/GameLogic/Module/BehaviorModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/BehaviorModule.h
@@ -202,6 +202,11 @@ protected:
 inline BehaviorModule::BehaviorModule( Thing *thing, const ModuleData* moduleData ) : ObjectModule( thing, moduleData ) { }
 inline BehaviorModule::~BehaviorModule() { }
 
+enum
+{
+	InvalidRunway = -1,
+};
+
 //-------------------------------------------------------------------------------------------------
 class ParkingPlaceBehaviorInterface
 {
@@ -224,6 +229,7 @@ public:
 	virtual void releaseSpace(ObjectID id) = 0;
 	virtual Bool reserveRunway(ObjectID id, Bool forLanding) = 0;
 	virtual void releaseRunway(ObjectID id) = 0;
+	virtual Int getRunwayIndex(ObjectID id) = 0;
 	virtual Int getRunwayCount() const = 0;
 	virtual ObjectID getRunwayReservation(Int r) = 0;
 	virtual void transferRunwayReservationToNextInLineForTakeoff(ObjectID id) = 0;

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/ParkingPlaceBehavior.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/ParkingPlaceBehavior.h
@@ -130,8 +130,8 @@ public:
 	Bool reserveSpace(ObjectID id, Real parkingOffset, PPInfo* info);
 	void releaseSpace(ObjectID id);
 	Bool reserveRunway(ObjectID id, Bool forLanding);
-	Bool postponeRunwayReservation(UnsignedInt spaceIndex, Bool forLanding);
 	void releaseRunway(ObjectID id);
+	virtual Int getRunwayIndex(ObjectID id);
 	Int getRunwayCount() const { return m_runways.size(); }
 	ObjectID getRunwayReservation(Int r);
 	void transferRunwayReservationToNextInLineForTakeoff(ObjectID id);
@@ -191,6 +191,7 @@ private:
 	UnsignedInt										m_nextHealFrame;
 	Bool													m_gotInfo;
 
+	Bool postponeRunwayReservation(UnsignedInt spaceIndex, Bool forLanding);
 	void buildInfo();
 	void purgeDead();
 	void resetWakeFrame();

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/ParkingPlaceBehavior.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/ParkingPlaceBehavior.cpp
@@ -393,6 +393,21 @@ void ParkingPlaceBehavior::releaseSpace(ObjectID id)
 }
 
 //-------------------------------------------------------------------------------------------------
+Int ParkingPlaceBehavior::getRunwayIndex(ObjectID id)
+{
+	purgeDead();
+
+	for (std::vector<ParkingPlaceInfo>::iterator it = m_spaces.begin(); it != m_spaces.end(); ++it)
+	{
+		if (it->m_objectInSpace == id)
+		{
+			return it->m_runway;
+		}
+	}
+	return InvalidRunway;
+}
+
+//-------------------------------------------------------------------------------------------------
 ObjectID ParkingPlaceBehavior::getRunwayReservation(Int runway)
 {
 	buildInfo();

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -1059,7 +1059,7 @@ protected:
 		xfer->xferVersion( &version, currentVersion );
 
 		// set on create. xfer->xferBool(&m_landing);
-		xfer->xferUnsignedInt(&m_when);
+		xfer->xferUnsignedInt(&m_whenTakeoff);
 		xfer->xferUnsignedInt(&m_whenTransfer);
 		xfer->xferBool(&m_afterburners);
 		xfer->xferBool(&m_resetTimer);
@@ -1071,7 +1071,7 @@ protected:
 	}
 
 private:
-	UnsignedInt		m_when;
+	UnsignedInt		m_whenTakeoff;
 	UnsignedInt		m_whenTransfer;
 	ObjectID			m_waitedForTaxiID;
 	Bool					m_resetTimer;
@@ -1110,7 +1110,7 @@ private:
 public:
 	JetPauseBeforeTakeoffState( StateMachine *machine ) :
 		AIFaceState(machine, false),
-		m_when(0),
+		m_whenTakeoff(0),
 		m_whenTransfer(0),
 		m_waitedForTaxiID(INVALID_ID),
 		m_resetTimer(false),
@@ -1129,7 +1129,7 @@ public:
 		jetAI->friend_setTakeoffInProgress(true);
 		jetAI->friend_setLandingInProgress(false);
 
-		m_when = 0;
+		m_whenTakeoff = 0;
 		m_whenTransfer = 0;
 		m_waitedForTaxiID = INVALID_ID;
 		m_resetTimer = false;
@@ -1165,7 +1165,7 @@ public:
 		if (!m_resetTimer)
 		{
 			// we had to wait, but now everyone else is ready, so restart our countdown.
-			m_when = now + jetAI->friend_getTakeoffPause();
+			m_whenTakeoff = now + jetAI->friend_getTakeoffPause();
 			if (m_waitedForTaxiID == INVALID_ID)
 			{
 				m_waitedForTaxiID = jet->getID();	// just so we don't pick up anyone else
@@ -1184,7 +1184,7 @@ public:
 			m_afterburners = true;
 		}
 
-		DEBUG_ASSERTCRASH(m_when != 0, ("hmm"));
+		DEBUG_ASSERTCRASH(m_whenTakeoff != 0, ("hmm"));
 		DEBUG_ASSERTCRASH(m_whenTransfer != 0, ("hmm"));
 
 			// once we start the final wait, release the runways for guys behind us, so they can start taxiing
@@ -1194,7 +1194,7 @@ public:
 			pp->transferRunwayReservationToNextInLineForTakeoff(jet->getID());
 		}
 
-		if (now >= m_when)
+		if (now >= m_whenTakeoff)
 			return superStatus;
 
 		return STATE_CONTINUE;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BehaviorModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BehaviorModule.h
@@ -213,6 +213,11 @@ enum RunwayReservationType CPP_11(: Int)
 	RESERVATION_LANDING,
 };
 
+enum
+{
+	InvalidRunway = -1,
+};
+
 //-------------------------------------------------------------------------------------------------
 class ParkingPlaceBehaviorInterface
 {
@@ -241,6 +246,7 @@ public:
 	virtual Bool reserveRunway(ObjectID id, Bool forLanding) = 0;
 	virtual void calcPPInfo( ObjectID id, PPInfo *info ) = 0;
 	virtual void releaseRunway(ObjectID id) = 0;
+	virtual Int getRunwayIndex(ObjectID id) = 0;
 	virtual Int getRunwayCount() const = 0;
 	virtual ObjectID getRunwayReservation( Int r, RunwayReservationType type = RESERVATION_TAKEOFF ) = 0;
 	virtual void transferRunwayReservationToNextInLineForTakeoff(ObjectID id) = 0;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/FlightDeckBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/FlightDeckBehavior.h
@@ -139,6 +139,7 @@ public:
 	virtual Bool reserveRunway(ObjectID id, Bool forLanding);
 	virtual void releaseRunway(ObjectID id);
 	virtual void calcPPInfo( ObjectID id, PPInfo *info );
+	virtual Int getRunwayIndex(ObjectID id);
 	virtual Int getRunwayCount() const { return m_runways.size(); }
 	virtual ObjectID getRunwayReservation( Int r, RunwayReservationType type );
 	virtual void transferRunwayReservationToNextInLineForTakeoff(ObjectID id);

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ParkingPlaceBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ParkingPlaceBehavior.h
@@ -140,9 +140,9 @@ public:
 	virtual Bool reserveSpace(ObjectID id, Real parkingOffset, PPInfo* info);
 	virtual void releaseSpace(ObjectID id);
 	virtual Bool reserveRunway(ObjectID id, Bool forLanding);
-	Bool postponeRunwayReservation(UnsignedInt spaceIndex, Bool forLanding);
 	virtual void releaseRunway(ObjectID id);
 	virtual void calcPPInfo( ObjectID id, PPInfo *info );
+	virtual Int getRunwayIndex(ObjectID id);
 	virtual Int getRunwayCount() const { return m_runways.size(); }
 	virtual ObjectID getRunwayReservation( Int r, RunwayReservationType type );
 	virtual void transferRunwayReservationToNextInLineForTakeoff(ObjectID id);
@@ -206,6 +206,7 @@ private:
 	UnsignedInt										m_nextHealFrame;
 	Bool													m_gotInfo;
 
+	Bool postponeRunwayReservation(UnsignedInt spaceIndex, Bool forLanding);
 	void buildInfo();
 	void purgeDead();
 	void resetWakeFrame();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/FlightDeckBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/FlightDeckBehavior.cpp
@@ -600,6 +600,21 @@ void FlightDeckBehavior::releaseSpace(ObjectID id)
 }
 
 //-------------------------------------------------------------------------------------------------
+Int FlightDeckBehavior::getRunwayIndex(ObjectID id)
+{
+	purgeDead();
+
+	for (std::vector<FlightDeckInfo>::iterator it = m_spaces.begin(); it != m_spaces.end(); ++it)
+	{
+		if (it->m_objectInSpace == id)
+		{
+			return it->m_runway;
+		}
+	}
+	return InvalidRunway;
+}
+
+//-------------------------------------------------------------------------------------------------
 ObjectID FlightDeckBehavior::getRunwayReservation( Int runway, RunwayReservationType type )
 {
 	buildInfo();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/ParkingPlaceBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/ParkingPlaceBehavior.cpp
@@ -451,6 +451,21 @@ void ParkingPlaceBehavior::releaseSpace(ObjectID id)
 }
 
 //-------------------------------------------------------------------------------------------------
+Int ParkingPlaceBehavior::getRunwayIndex(ObjectID id)
+{
+	purgeDead();
+
+	for (std::vector<ParkingPlaceInfo>::iterator it = m_spaces.begin(); it != m_spaces.end(); ++it)
+	{
+		if (it->m_objectInSpace == id)
+		{
+			return it->m_runway;
+		}
+	}
+	return InvalidRunway;
+}
+
+//-------------------------------------------------------------------------------------------------
 ObjectID ParkingPlaceBehavior::getRunwayReservation( Int runway, RunwayReservationType type )
 {
 	//Note: We don't care about type because these runways share the runway for taking off and landing.

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -1251,7 +1251,7 @@ protected:
 		xfer->xferVersion( &version, currentVersion );
 
 		// set on create. xfer->xferBool(&m_landing);
-		xfer->xferUnsignedInt(&m_when);
+		xfer->xferUnsignedInt(&m_whenTakeoff);
 		xfer->xferUnsignedInt(&m_whenTransfer);
 		xfer->xferBool(&m_afterburners);
 		xfer->xferBool(&m_resetTimer);
@@ -1263,7 +1263,7 @@ protected:
 	}
 
 private:
-	UnsignedInt		m_when;
+	UnsignedInt		m_whenTakeoff;
 	UnsignedInt		m_whenTransfer;
 	ObjectID			m_waitedForTaxiID;
 	Bool					m_resetTimer;
@@ -1302,7 +1302,7 @@ private:
 public:
 	JetPauseBeforeTakeoffState( StateMachine *machine ) :
 		AIFaceState(machine, false),
-		m_when(0),
+		m_whenTakeoff(0),
 		m_whenTransfer(0),
 		m_waitedForTaxiID(INVALID_ID),
 		m_resetTimer(false),
@@ -1321,7 +1321,7 @@ public:
 		jetAI->friend_setTakeoffInProgress(true);
 		jetAI->friend_setLandingInProgress(false);
 
-		m_when = 0;
+		m_whenTakeoff = 0;
 		m_whenTransfer = 0;
 		m_waitedForTaxiID = INVALID_ID;
 		m_resetTimer = false;
@@ -1357,7 +1357,7 @@ public:
 		if (!m_resetTimer)
 		{
 			// we had to wait, but now everyone else is ready, so restart our countdown.
-			m_when = now + jetAI->friend_getTakeoffPause();
+			m_whenTakeoff = now + jetAI->friend_getTakeoffPause();
 			if (m_waitedForTaxiID == INVALID_ID)
 			{
 				m_waitedForTaxiID = jet->getID();	// just so we don't pick up anyone else
@@ -1376,7 +1376,7 @@ public:
 			m_afterburners = true;
 		}
 
-		DEBUG_ASSERTCRASH(m_when != 0, ("hmm"));
+		DEBUG_ASSERTCRASH(m_whenTakeoff != 0, ("hmm"));
 		DEBUG_ASSERTCRASH(m_whenTransfer != 0, ("hmm"));
 
 			// once we start the final wait, release the runways for guys behind us, so they can start taxiing
@@ -1386,7 +1386,7 @@ public:
 			pp->transferRunwayReservationToNextInLineForTakeoff(jet->getID());
 		}
 
-		if (now >= m_when)
+		if (now >= m_whenTakeoff)
 			return superStatus;
 
 		return STATE_CONTINUE;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -1246,17 +1246,37 @@ protected:
 	virtual void xfer( Xfer *xfer )
 	{
 		// version
+#if RETAIL_COMPATIBLE_CRC || RETAIL_COMPATIBLE_XFER_SAVE
 		XferVersion currentVersion = 1;
+#else
+		XferVersion currentVersion = 2;
+#endif
 		XferVersion version = currentVersion;
 		xfer->xferVersion( &version, currentVersion );
 
 		// set on create. xfer->xferBool(&m_landing);
 		xfer->xferUnsignedInt(&m_whenTakeoff);
 		xfer->xferUnsignedInt(&m_whenTransfer);
-		xfer->xferBool(&m_afterburners);
-		xfer->xferBool(&m_resetTimer);
+
+#if RETAIL_COMPATIBLE_CRC || RETAIL_COMPATIBLE_XFER_SAVE
+		if (version <= 1)
+		{
+			xfer->xferBool(&m_afterburners);
+			xfer->xferBool(&m_resetTimer);
+		}
+#else
+		if (version <= 1)
+		{
+			Bool afterburners = false;
+			Bool resetTimer = false;
+			xfer->xferBool(&afterburners);
+			xfer->xferBool(&resetTimer);
+		}
+#endif
+
 		xfer->xferObjectID(&m_waitedForTaxiID);
 	}
+
 	virtual void loadPostProcess()
 	{
 		// empty. jba.
@@ -1266,9 +1286,12 @@ private:
 	UnsignedInt		m_whenTakeoff;
 	UnsignedInt		m_whenTransfer;
 	ObjectID			m_waitedForTaxiID;
+#if RETAIL_COMPATIBLE_CRC || RETAIL_COMPATIBLE_XFER_SAVE
 	Bool					m_resetTimer;
 	Bool					m_afterburners;
+#endif
 
+#if RETAIL_COMPATIBLE_CRC || RETAIL_COMPATIBLE_XFER_SAVE
 	Bool findWaiter()
 	{
 		Object* jet = getMachineOwner();
@@ -1298,15 +1321,50 @@ private:
 		}
 		return false;
 	}
+#else
+	Object* findJetToWaitFor() const
+	{
+		const Object* thisJet = getMachineOwner();
+		ParkingPlaceBehaviorInterface* pp = getPP(getMachineOwner()->getProducerID());
+
+		if (pp != NULL)
+		{
+			const Int thisJetRunway = pp->getRunwayIndex(thisJet->getID());
+			const Int runwayCount = pp->getRunwayCount();
+
+			for (Int runway = 0; runway < runwayCount; ++runway)
+			{
+				if (runway == thisJetRunway)
+					continue;
+
+				Object* otherJet = TheGameLogic->findObjectByID(pp->getRunwayReservation(runway, RESERVATION_TAKEOFF));
+				if (otherJet == NULL)
+					continue;
+
+				AIUpdateInterface* ai = otherJet->getAIUpdateInterface();
+				if (ai == NULL)
+					continue;
+
+				if (ai->getCurrentStateID() != TAXI_TO_TAKEOFF)
+					continue;
+				
+				return otherJet;
+			}
+		}
+		return NULL;
+	}
+#endif
 
 public:
-	JetPauseBeforeTakeoffState( StateMachine *machine ) :
-		AIFaceState(machine, false),
-		m_whenTakeoff(0),
-		m_whenTransfer(0),
-		m_waitedForTaxiID(INVALID_ID),
-		m_resetTimer(false),
-		m_afterburners(false)
+	JetPauseBeforeTakeoffState( StateMachine *machine )
+		: AIFaceState(machine, false)
+		, m_whenTakeoff(0)
+		, m_whenTransfer(0)
+		, m_waitedForTaxiID(INVALID_ID)
+#if RETAIL_COMPATIBLE_CRC || RETAIL_COMPATIBLE_XFER_SAVE
+		, m_resetTimer(false)
+		, m_afterburners(false)
+#endif
 	{
 		// nothing
 	}
@@ -1324,8 +1382,10 @@ public:
 		m_whenTakeoff = 0;
 		m_whenTransfer = 0;
 		m_waitedForTaxiID = INVALID_ID;
+#if RETAIL_COMPATIBLE_CRC || RETAIL_COMPATIBLE_XFER_SAVE
 		m_resetTimer = false;
 		m_afterburners = false;
+#endif
 
 		ParkingPlaceBehaviorInterface* pp = getPP(jet->getProducerID());
 		if (pp == NULL)
@@ -1340,6 +1400,7 @@ public:
 		return AIFaceState::onEnter();
 	}
 
+#if RETAIL_COMPATIBLE_CRC || RETAIL_COMPATIBLE_XFER_SAVE
 	virtual StateReturnType update()
 	{
 		Object* jet = getMachineOwner();
@@ -1391,6 +1452,81 @@ public:
 
 		return STATE_CONTINUE;
 	}
+#else
+	// TheSuperHackers @bugfix Reimplements the update to wait for another Jet on another runway.
+	// If this must work with more than 2 runways, then this logic needs another look.
+	virtual StateReturnType update()
+	{
+		Object* jet = getMachineOwner();
+		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();
+
+		if (jet->isEffectivelyDead())
+			return STATE_FAILURE;
+
+		// always call this.
+		StateReturnType superStatus = AIFaceState::update();
+
+		if (Object* otherJet = findJetToWaitFor())
+		{
+			// Found a jet on another runway to wait for.
+			if (m_waitedForTaxiID == INVALID_ID)
+			{
+				// Save the other Jet to wait for.
+				m_waitedForTaxiID = otherJet->getID();
+			}
+
+			if (m_waitedForTaxiID == otherJet->getID())
+			{
+				// Wait for the other Jet to get ready.
+				return STATE_CONTINUE;
+			}
+		}
+
+		const UnsignedInt now = TheGameLogic->getFrame();
+
+		if (m_whenTakeoff == 0)
+		{
+			// The other Jet (if any) is ready. Prepare runway transfer and takeoff.
+			// Transfer the runway after one or two frames earliest to give the other
+			// Jet a chance to update as well before the runway is transfered.
+			if (m_waitedForTaxiID == INVALID_ID)
+			{
+				// Do not wait for any other Jet from now on.
+				m_waitedForTaxiID = jet->getID();
+				m_whenTransfer = now + 1;
+			}
+			else
+			{
+				m_whenTransfer = now + 2; // 2 seems odd, but is correct
+			}
+
+			// Take off soon, but not before the runway transfer.
+			m_whenTakeoff = std::max(m_whenTransfer, now + jetAI->friend_getTakeoffPause());
+			jetAI->friend_enableAfterburners(true);
+		}
+		else
+		{
+			// once we start the final wait, release the runways for guys behind us, so they can start taxiing
+			if (now >= m_whenTransfer)
+			{
+				if (ParkingPlaceBehaviorInterface* pp = getPP(jet->getProducerID()))
+				{
+					pp->transferRunwayReservationToNextInLineForTakeoff(jet->getID());
+				}
+				// Do not transfer the runway again in the next update.
+				m_whenTransfer = ~0u;
+			}
+
+			if (now >= m_whenTakeoff)
+			{
+				// Ready to take off!
+				return superStatus;
+			}
+		}
+
+		return STATE_CONTINUE;
+	}
+#endif
 
 	virtual void onExit(StateExitType status)
 	{


### PR DESCRIPTION
**Merge with Rebase**

* Closes #1298

This change is a (more complex) alternative to #1298 and fixes pairs of Jets not waiting for each other before takeoff.

The first commit just renames `m_when` to `m_whenTakeoff` because it was not a conclusive variable name.

The second commit reimplements functions `JetPauseBeforeTakeoffState::findWaiter` and `JetPauseBeforeTakeoffState::update` to simplify and correct the logic.

The randomness of takeoff discrepancies originates from random object order in AIGroup, via 

https://github.com/TheSuperHackers/GeneralsGameCode/blob/1875dbfa296ede28400fdc7273bad5f7d5544017/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp#L1737-L1742

It never has the same order. And when the State Machine updates are in different orders, then different things can happen.

## TODO

- [x] Replicate in Generals