### PR TITLE
bugfix(gui): Consistently show blue health bars for disabled objects

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -3388,8 +3388,9 @@ void Drawable::drawHealthBar(const IRegion2D* healthBarRegion)
 
 		Color color, outlineColor;
 		DisabledMaskType mask = obj->getDisabledFlags();
+		mask.clear(MAKE_DISABLED_MASK(DISABLED_HELD));
 
-		if (obj->getStatusBits().test(OBJECT_STATUS_UNDER_CONSTRUCTION) || (mask.clear(MAKE_DISABLED_MASK(DISABLED_HELD)), DISABLEDMASK_ANY_SET(mask)))
+		if (obj->getStatusBits().test(OBJECT_STATUS_UNDER_CONSTRUCTION) || DISABLEDMASK_ANY_SET(mask))
 		{
 			color = GameMakeColor( 0, healthRatio * 255.0f, 255, 255 );//blue to cyan
 			outlineColor = GameMakeColor( 0, healthRatio * 128.0f, 128, 255 );//dark blue to dark cyan

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -3886,8 +3886,9 @@ void Drawable::drawHealthBar(const IRegion2D* healthBarRegion)
 
 		Color color, outlineColor;
 		DisabledMaskType mask = obj->getDisabledFlags();
+		mask.clear(MAKE_DISABLED_MASK(DISABLED_HELD));
 
-		if (obj->getStatusBits().test(OBJECT_STATUS_UNDER_CONSTRUCTION) || (mask.clear(MAKE_DISABLED_MASK(DISABLED_HELD)), DISABLEDMASK_ANY_SET(mask)))
+		if (obj->getStatusBits().test(OBJECT_STATUS_UNDER_CONSTRUCTION) || DISABLEDMASK_ANY_SET(mask))
 		{
 			color = GameMakeColor( 0, healthRatio * 255.0f, 255, 255 );//blue to cyan
 			outlineColor = GameMakeColor( 0, healthRatio * 128.0f, 128, 255 );//dark blue to dark cyan


### PR DESCRIPTION
This change fixes a small visual inconsistency with the health bars of disabled units - when a unit has the `DISABLED_HELD` status (e.g. a Battle Bus in bunkered form), its 'disabled' blue health bar colouring is absent even if the object has other disabled statuses.

### Before
A bunkered Battle Bus shows a green health bar despite having the `DISABLED_EMP` status:

<img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/484bb752-f41f-4bce-975e-6e43bc1fe7e2" />

### After
A bunkered Battle Bus shows a blue health bar due to having the `DISABLED_EMP` status:

<img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/14c2fc7c-1695-4579-b28e-b53a8ac05413" />
