### PR TITLE
bugfix: Prevent tunnel healing from stacking

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/TunnelTracker.h
+++ b/Generals/Code/GameEngine/Include/Common/TunnelTracker.h
@@ -84,6 +84,7 @@ private:
 	std::list< ObjectID > m_xferContainList;///< for loading of m_containList during post processing
 	Int m_containListSize;									///< size of the contain list
 	UnsignedInt m_tunnelCount;							///< How many tunnels have registered so we know when we should kill our contain list
+	UnsignedInt m_lastHealFrame;						///< Ensure we don't heal more than once per frame
 
 	ObjectID		m_curNemesisID;							///< If we have team(s) guarding a tunnel network system, this is one of the current targets.
 	UnsignedInt m_nemesisTimestamp;					///< We only keep nemesis for a couple of seconds.

--- a/Generals/Code/GameEngine/Source/Common/RTS/TunnelTracker.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/TunnelTracker.cpp
@@ -254,7 +254,13 @@ void TunnelTracker::destroyObject( Object *obj, void * )
 	// heal all the objects within the tunnel system using the iterateContained function
 void TunnelTracker::healObjects(Real frames)
 {
+#if !RETAIL_COMPATIBLE_CRC
+	if (m_lastHealFrame == TheGameLogic->getFrame())
+		return; // Only heal objects once per frame.
+#endif
+
 	iterateContained(healObject, &frames, FALSE);
+	m_lastHealFrame = TheGameLogic->getFrame();
 }
 
 // ------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Include/Common/TunnelTracker.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/TunnelTracker.h
@@ -84,6 +84,7 @@ private:
 	std::list< ObjectID > m_xferContainList;///< for loading of m_containList during post processing
 	Int m_containListSize;									///< size of the contain list
 	UnsignedInt m_tunnelCount;							///< How many tunnels have registered so we know when we should kill our contain list
+	UnsignedInt m_lastHealFrame;						///< Ensure we don't heal more than once per frame
 
 	ObjectID		m_curNemesisID;							///< If we have team(s) guarding a tunnel network system, this is one of the current targets.
 	UnsignedInt m_nemesisTimestamp;					///< We only keep nemesis for a couple of seconds.

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/TunnelTracker.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/TunnelTracker.cpp
@@ -255,7 +255,13 @@ void TunnelTracker::destroyObject( Object *obj, void * )
 	// heal all the objects within the tunnel system using the iterateContained function
 void TunnelTracker::healObjects(Real frames)
 {
+#if !RETAIL_COMPATIBLE_CRC
+	if (m_lastHealFrame == TheGameLogic->getFrame())
+		return; // Only heal objects once per frame.
+#endif
+
 	iterateContained(healObject, &frames, FALSE);
+	m_lastHealFrame = TheGameLogic->getFrame();
 }
 
 // ------------------------------------------------------------------------


### PR DESCRIPTION
Fixes [#838](https://github.com/TheSuperHackers/GeneralsGamePatch/issues/838) from the patch repository

This change fixes tunnels stacking their healing behaviour for each existing tunnel.

The `TunnelContain` module specifies a healing time of 5000 milliseconds (5 seconds) for its occupants.
```
Behavior = TunnelContain ModuleTag_05
  TimeForFullHeal = 5000 ; (in milliseconds)
End
```
This works as expected when there is a single tunnel. However, when there are two tunnels, this time drops to 2500 milliseconds as both tunnels are applying the healing, and is halved again for every additional tunnel.

This behaviour is undesirable as it nullifies the purpose of the `TimeForFullHeal` field and makes healing time feel random. Players typically end up with enough tunnels for their units to effectively heal instantly. If the instantaneous heal speeds from retail remain desirable, the `TimeForFullHeal` field can be adjusted accordingly.

Below is a summary of the heal times based on the number of tunnels in retail:

| Tunnels | Heal time | Heal frames |
|-|-|-|
| 1 | 5000 ms | 150 |
| 2 | 2500 ms | 75 |
| 3 | 1250 ms | 38 |
| 4 | 625 ms | 19 |
| 5 | 313 ms | 10 |
| 6 | 156 ms | 5 |
| 7 | 78 ms | 3 |
| 8 | 39 ms | 2 |
| 9 | 20 ms | 1 |

Note: These are times for a full heal; e.g. if a unit has 50% health, the heal time is halved.