### PR TITLE
tweak(gamelod): Disable changing display settings when clicking the Default button in Options Menu

### DIFF
--- a/Core/GameEngine/Include/Common/GameDefines.h
+++ b/Core/GameEngine/Include/Common/GameDefines.h
@@ -81,6 +81,11 @@
 #endif
 #endif
 
+// Overwrite window settings until wnd data files are adapted or fixed.
+#ifndef ENABLE_GUI_HACKS
+#define ENABLE_GUI_HACKS (1)
+#endif
+
 #define MIN_DISPLAY_BIT_DEPTH       16
 #define DEFAULT_DISPLAY_BIT_DEPTH   32
 #define DEFAULT_DISPLAY_WIDTH      800 // The standard resolution this game was designed for

--- a/GeneralsMD/Code/GameEngine/Include/Common/GameLOD.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GameLOD.h
@@ -164,7 +164,7 @@ public:
 
 	const char *getStaticGameLODLevelName(StaticGameLODLevel level);
 	const char *getDynamicGameLODLevelName(DynamicGameLODLevel level);
-	StaticGameLODLevel findStaticLODLevel(void);	///< calculate the optimal static LOD level for this system.
+	StaticGameLODLevel getRecommendedStaticLODLevel(void);	///< calculate the optimal static LOD level for this system.
 	Bool setStaticLODLevel(StaticGameLODLevel level);	///< set the current static LOD level.
 	StaticGameLODLevel getStaticLODLevel(void) { return m_currentStaticLOD;}
 	DynamicGameLODLevel findDynamicLODLevel(Real averageFPS);	///<given an average fps, return the optimal dynamic LOD.

--- a/GeneralsMD/Code/GameEngine/Include/Common/GameLOD.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GameLOD.h
@@ -204,6 +204,7 @@ protected:
 	void applyStaticLODLevel(StaticGameLODLevel level);
 	void applyDynamicLODLevel(DynamicGameLODLevel level);
 	void refreshCustomStaticLODLevel(void);	///<grabs current globaldata values and makes them the custom detail setting.
+	StaticGameLODLevel getRecommendedTextureLODLevel();
 
 	static const FieldParse m_staticGameLODFieldParseTable[];
 	StaticGameLODLevel m_currentStaticLOD;		///< current value of static LOD.

--- a/GeneralsMD/Code/GameEngine/Include/Common/GameLOD.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GameLOD.h
@@ -38,18 +38,24 @@
 
 enum ParticlePriorityType CPP_11(: Int);
 
-#define MAX_LOD_PRESETS_PER_LEVEL	32	//number of hardware configs preset for each low,medium,high
+#define MAX_LOD_PRESETS_PER_LEVEL	32	//number of hardware configs preset for each low,medium,high,veryhigh
 #define MAX_BENCH_PROFILES	16
 
 //Make sure this enum stays in sync with GameLODNames[]
 enum StaticGameLODLevel CPP_11(: Int)
 {
 	STATIC_GAME_LOD_UNKNOWN=-1,
+
 	STATIC_GAME_LOD_LOW,
 	STATIC_GAME_LOD_MEDIUM,
 	STATIC_GAME_LOD_HIGH,
+	STATIC_GAME_LOD_VERY_HIGH,
+
 	STATIC_GAME_LOD_CUSTOM,	//make sure this remains last!
-	STATIC_GAME_LOD_COUNT
+
+	STATIC_GAME_LOD_COUNT,
+	STATIC_GAME_LOD_FIRST = 0,
+	STATIC_GAME_LOD_LAST = STATIC_GAME_LOD_CUSTOM - 1,
 };
 
 enum DynamicGameLODLevel CPP_11(: Int)
@@ -194,6 +200,7 @@ public:
 	BenchProfile m_benchProfiles[MAX_BENCH_PROFILES];
 
 protected:
+	void initStaticLODLevels();
 	void applyStaticLODLevel(StaticGameLODLevel level);
 	void applyDynamicLODLevel(DynamicGameLODLevel level);
 	void refreshCustomStaticLODLevel(void);	///<grabs current globaldata values and makes them the custom detail setting.

--- a/GeneralsMD/Code/GameEngine/Include/Common/GameLOD.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GameLOD.h
@@ -177,8 +177,6 @@ public:
 	Bool setDynamicLODLevel(DynamicGameLODLevel level);	///< set the current dynamic LOD level.
 	DynamicGameLODLevel getDynamicLODLevel(void) { return m_currentDynamicLOD;}
 	void init(void);	///<initialize tables of preset LOD's.
-	void setCurrentTextureReduction(Int val) {m_currentTextureReduction = val;}
-	Int getCurrentTextureReduction(void) {return m_currentTextureReduction;}
 	Int getStaticGameLODIndex(AsciiString name);
 	Int getDynamicGameLODIndex(AsciiString name);
 	inline Bool isParticleSkipped(void);
@@ -230,7 +228,6 @@ protected:
 	Real m_floatBenchIndex;
 	Real m_memBenchIndex;
 	Real m_compositeBenchIndex;
-	Int m_currentTextureReduction;
 	Int m_reallyLowMHz;
 };
 

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/GameClient.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/GameClient.h
@@ -143,7 +143,8 @@ public:
 
 	//---------------------------------------------------------------------------
 	virtual void setTeamColor( Int red, Int green, Int blue ) = 0;  ///< @todo superhack for demo, remove!!!
-	virtual void adjustLOD( Int adj ) = 0; ///< @todo hack for evaluation, remove.
+
+	virtual void setTextureLOD( Int level ) = 0;
 
 	virtual void releaseShadows(void);	///< frees all shadow resources used by this module - used by Options screen.
 	virtual void allocateShadows(void); ///< create shadow resources if not already present. Used by Options screen.

--- a/GeneralsMD/Code/GameEngine/Source/Common/GameLOD.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GameLOD.cpp
@@ -77,6 +77,7 @@ static const char *const StaticGameLODNames[]=
 	"Low",
 	"Medium",
 	"High",
+	"VeryHigh",
 	"Custom"
 };
 static_assert(ARRAY_SIZE(StaticGameLODNames) == STATIC_GAME_LOD_COUNT, "Incorrect array size");
@@ -233,11 +234,42 @@ GameLODManager::GameLODManager(void)
 
 	for (Int i=0; i<STATIC_GAME_LOD_CUSTOM; i++)
 		m_numLevelPresets[i]=0;
+
+	initStaticLODLevels();
 };
 
 GameLODManager::~GameLODManager()
 {
 
+}
+
+void GameLODManager::initStaticLODLevels()
+{
+	// TheSuperHackers @info Initialize new system specs in this function when we cannot rely on new edits to GameLOD.ini.
+
+	StaticGameLODInfo& veryhigh = m_staticGameLODInfo[STATIC_GAME_LOD_VERY_HIGH];
+	veryhigh.m_minFPS = 55;
+	veryhigh.m_minProcessorFPS = 59;
+	veryhigh.m_sampleCount2D = 6;
+	veryhigh.m_sampleCount3D = 24;
+	veryhigh.m_streamCount = 2;
+	veryhigh.m_maxParticleCount = 5000;
+	veryhigh.m_useShadowVolumes = TRUE;
+	veryhigh.m_useShadowDecals = TRUE;
+	veryhigh.m_useCloudMap = TRUE;
+	veryhigh.m_useLightMap = TRUE;
+	veryhigh.m_showSoftWaterEdge = TRUE;
+	veryhigh.m_maxTankTrackEdges = 100;
+	veryhigh.m_maxTankTrackOpaqueEdges = 25;
+	veryhigh.m_maxTankTrackFadeDelay = 60000;
+	veryhigh.m_useBuildupScaffolds = TRUE;
+	veryhigh.m_useTreeSway = TRUE;
+	veryhigh.m_useEmissiveNightMaterials = TRUE;
+	veryhigh.m_useHeatEffects = TRUE;
+	veryhigh.m_textureReduction = 0;
+	veryhigh.m_useFpsLimit = TRUE;
+	veryhigh.m_enableDynamicLOD = TRUE;
+	veryhigh.m_useTrees = TRUE;
 }
 
 BenchProfile *GameLODManager::newBenchProfile(void)
@@ -322,7 +354,7 @@ void GameLODManager::init(void)
 				//Check if we're within 5% of the performance of this cpu profile.
 				if (m_intBenchIndex/prof->m_intBenchIndex >= PROFILE_ERROR_LIMIT && m_floatBenchIndex/prof->m_floatBenchIndex >= PROFILE_ERROR_LIMIT && m_memBenchIndex/prof->m_memBenchIndex >= PROFILE_ERROR_LIMIT)
 				{
-					for (Int i=STATIC_GAME_LOD_HIGH; i >= STATIC_GAME_LOD_LOW; i--)
+					for (Int i=STATIC_GAME_LOD_LAST; i >= STATIC_GAME_LOD_FIRST; i--)
 					{
 						LODPresetInfo *preset=&m_lodPresets[i][0];	//pointer to first preset at this LOD level.
 						for (Int j=0; j<m_numLevelPresets[i]; j++)
@@ -460,7 +492,7 @@ StaticGameLODLevel GameLODManager::getRecommendedStaticLODLevel(void)
 
 		Int numMBRam=m_numRAM/(1024*1024);
 
-		for (Int i=STATIC_GAME_LOD_HIGH; i >= STATIC_GAME_LOD_LOW; i--)
+		for (Int i=STATIC_GAME_LOD_LAST; i >= STATIC_GAME_LOD_FIRST; i--)
 		{
 				LODPresetInfo *preset=&m_lodPresets[i][0];	//pointer to first preset at this LOD level.
 				for (Int j=0; j<m_numLevelPresets[i]; j++)

--- a/GeneralsMD/Code/GameEngine/Source/Common/GameLOD.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GameLOD.cpp
@@ -229,7 +229,6 @@ GameLODManager::GameLODManager(void)
 	m_memBenchIndex=0;
 	m_compositeBenchIndex=0;
 	m_numBenchProfiles=0;
-	m_currentTextureReduction=0;
 	m_reallyLowMHz = 400;
 
 	for (Int i=0; i<STATIC_GAME_LOD_CUSTOM; i++)
@@ -585,13 +584,7 @@ void GameLODManager::applyStaticLODLevel(StaticGameLODLevel level)
 		TheWritableGlobalData->m_useShadowVolumes=lodInfo->m_useShadowVolumes;
 		TheWritableGlobalData->m_useShadowDecals=lodInfo->m_useShadowDecals;
 
-		//Check if texture resolution changed.  No need to apply when current is unknown because display will do it
-		if (requestedTextureReduction != m_currentTextureReduction)
-		{
-				TheWritableGlobalData->m_textureReductionFactor = requestedTextureReduction;
-				if (TheGameClient)
-					TheGameClient->adjustLOD(0);	//apply the new setting stored in globaldata
-		}
+		TheWritableGlobalData->m_textureReductionFactor = requestedTextureReduction;
 
 		//Check if shadow state changed
 		if (m_currentStaticLOD == STATIC_GAME_LOD_UNKNOWN	||
@@ -629,9 +622,12 @@ void GameLODManager::applyStaticLODLevel(StaticGameLODLevel level)
 			TheWritableGlobalData->m_shellMapOn = false;
 		}
 	}
+
 	if (TheTerrainVisual)
 		TheTerrainVisual->setTerrainTracksDetail();
 
+	if (TheGameClient)
+		TheGameClient->setTextureLOD(requestedTextureReduction);
 }
 
 /**Parse a description of all the LOD settings for a given detail level*/

--- a/GeneralsMD/Code/GameEngine/Source/Common/GameLOD.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GameLOD.cpp
@@ -560,16 +560,23 @@ void GameLODManager::applyStaticLODLevel(StaticGameLODLevel level)
 	StaticGameLODInfo *lodInfo=&m_staticGameLODInfo[level];
 	StaticGameLODInfo *prevLodInfo=&prevLodBackup;
 
-	Int requestedTextureReduction = 0;
-	Bool requestedTrees = m_memPassed;	//only use trees if memory requirement passed.
+	Int requestedTextureReduction;
+	Bool requestedTrees;
 	if (level == STATIC_GAME_LOD_CUSTOM)
-	{	requestedTextureReduction = lodInfo->m_textureReduction;
+	{
+		requestedTextureReduction = lodInfo->m_textureReduction;
 		requestedTrees = lodInfo->m_useTrees;
 	}
 	else
-	if (level >= STATIC_GAME_LOD_LOW)
-	{	//normal non-custom level gets texture reduction based on recommendation
-		requestedTextureReduction = getRecommendedTextureReduction();
+	{
+		//normal non-custom level gets texture reduction based on recommendation
+		StaticGameLODLevel textureLevel = getRecommendedTextureLODLevel();
+		if (textureLevel == STATIC_GAME_LOD_UNKNOWN)
+			textureLevel = level;
+		requestedTextureReduction = getLevelTextureReduction(textureLevel);
+
+		//only use trees if memory requirement passed.
+		requestedTrees = m_memPassed;
 	}
 
 	if (TheGlobalData)
@@ -723,16 +730,36 @@ void GameLODManager::applyDynamicLODLevel(DynamicGameLODLevel level)
 
 Int GameLODManager::getRecommendedTextureReduction(void)
 {
-	if (m_idealDetailLevel == STATIC_GAME_LOD_UNKNOWN)
-		getRecommendedStaticLODLevel();	//it was never tested, so test now.
+	StaticGameLODLevel level = getRecommendedTextureLODLevel();
 
-	if (!m_memPassed)	//if they have < 256 MB, force them to low res textures.
-		return getLevelTextureReduction(STATIC_GAME_LOD_LOW);
+	if (level == STATIC_GAME_LOD_UNKNOWN)
+	{
+		level = getStaticLODLevel();
+	}
+	return getLevelTextureReduction(level);
+}
 
-	if (m_idealDetailLevel < 0 || m_idealDetailLevel >= STATIC_GAME_LOD_COUNT)
-		return getLevelTextureReduction(STATIC_GAME_LOD_LOW);
+StaticGameLODLevel GameLODManager::getRecommendedTextureLODLevel()
+{
+	// TheSuperHackers @bugfix xezon 24/09/2025 Disables the recommended static LOD level for texture reduction
+	// because the benchmark code always generates a low level for it. Can revisit if the benchmarking is changed.
+	constexpr const Bool UseRecommendedStaticLODLevel = FALSE;
 
-	return getLevelTextureReduction(m_idealDetailLevel);
+	StaticGameLODLevel level = STATIC_GAME_LOD_LOW;
+
+	// Force low res textures if user has less than 256 MB.
+	if (m_memPassed)
+	{
+		if constexpr (UseRecommendedStaticLODLevel)
+		{
+			level = getRecommendedStaticLODLevel();
+		}
+		else
+		{
+			level = STATIC_GAME_LOD_UNKNOWN;
+		}
+	}
+	return level;
 }
 
 Int GameLODManager::getLevelTextureReduction(StaticGameLODLevel level)

--- a/GeneralsMD/Code/GameEngine/Source/Common/GameLOD.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GameLOD.cpp
@@ -445,7 +445,7 @@ const char *GameLODManager::getStaticGameLODLevelName(StaticGameLODLevel level)
 
 /**Function which calculates the recommended LOD level for current hardware
 configuration.*/
-StaticGameLODLevel GameLODManager::findStaticLODLevel(void)
+StaticGameLODLevel GameLODManager::getRecommendedStaticLODLevel(void)
 {
 	//Check if we have never done the test on current system
 	if (m_idealDetailLevel == STATIC_GAME_LOD_UNKNOWN)
@@ -692,15 +692,15 @@ void GameLODManager::applyDynamicLODLevel(DynamicGameLODLevel level)
 Int GameLODManager::getRecommendedTextureReduction(void)
 {
 	if (m_idealDetailLevel == STATIC_GAME_LOD_UNKNOWN)
-		findStaticLODLevel();	//it was never tested, so test now.
+		getRecommendedStaticLODLevel();	//it was never tested, so test now.
 
 	if (!m_memPassed)	//if they have < 256 MB, force them to low res textures.
-		return m_staticGameLODInfo[STATIC_GAME_LOD_LOW].m_textureReduction;
+		return getLevelTextureReduction(STATIC_GAME_LOD_LOW);
 
 	if (m_idealDetailLevel < 0 || m_idealDetailLevel >= STATIC_GAME_LOD_COUNT)
-		return m_staticGameLODInfo[STATIC_GAME_LOD_LOW].m_textureReduction;
+		return getLevelTextureReduction(STATIC_GAME_LOD_LOW);
 
-	return m_staticGameLODInfo[m_idealDetailLevel].m_textureReduction;
+	return getLevelTextureReduction(m_idealDetailLevel);
 }
 
 Int GameLODManager::getLevelTextureReduction(StaticGameLODLevel level)

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -1810,12 +1810,18 @@ void OptionsMenuInit( WindowLayout *layout, void *userData )
 
 	// set the display detail
 	// TheSuperHackers @tweak xezon 24/09/2025 The Detail Combo Box now has the same value order as StaticGameLODLevel for simplicity.
+	// TheSuperHackers @feature xezon 24/09/2025 The Detail Combo Box now has a new options for "Very High".
 	GadgetComboBoxReset(comboBoxDetail);
+#if ENABLE_GUI_HACKS
+	// TheSuperHackers @tweak xezon 24/09/2025 Show max 4 rows because with the original layout it cannot possibly show 5.
+	GadgetComboBoxSetMaxDisplay(comboBoxDetail, 4);
+#endif
 	GadgetComboBoxAddEntry(comboBoxDetail, TheGameText->fetch("GUI:Low"), color);
 	GadgetComboBoxAddEntry(comboBoxDetail, TheGameText->fetch("GUI:Medium"), color);
 	GadgetComboBoxAddEntry(comboBoxDetail, TheGameText->fetch("GUI:High"), color);
+	GadgetComboBoxAddEntry(comboBoxDetail, TheGameText->FETCH_OR_SUBSTITUTE("GUI:VeryHigh", L"Very High"), color);
 	GadgetComboBoxAddEntry(comboBoxDetail, TheGameText->fetch("GUI:Custom"), color);
-	static_assert(STATIC_GAME_LOD_COUNT == 4, "Wrong combo box count");
+	static_assert(STATIC_GAME_LOD_COUNT == 5, "Wrong combo box count");
 
 	//Check if level was never set and default to setting most suitable for system.
 	if (TheGameLODManager->getStaticLODLevel() == STATIC_GAME_LOD_UNKNOWN)

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -217,14 +217,6 @@ extern void DoResolutionDialog();
 static Bool ignoreSelected = FALSE;
 WindowLayout *OptionsLayout = NULL;
 
-enum Detail CPP_11(: Int)
-{
-	HIGHDETAIL = 0,
-	MEDIUMDETAIL,
-	LOWDETAIL,
-	CUSTOMDETAIL,
-};
-
 
 OptionPreferences::OptionPreferences( void )
 {
@@ -922,25 +914,9 @@ static void setDefaults( void )
 
 	//-------------------------------------------------------------------------------------------------
 	// LOD
-	if ((TheGameLogic->isInGame() == FALSE) || (TheGameLogic->isInShellGame() == TRUE)) {
-		StaticGameLODLevel level=TheGameLODManager->findStaticLODLevel();
-		switch (level)
-		{
-		case STATIC_GAME_LOD_LOW:
-			GadgetComboBoxSetSelectedPos(comboBoxDetail, LOWDETAIL);
-			break;
-		case STATIC_GAME_LOD_MEDIUM:
-			GadgetComboBoxSetSelectedPos(comboBoxDetail, MEDIUMDETAIL);
-			break;
-		case STATIC_GAME_LOD_HIGH:
-			GadgetComboBoxSetSelectedPos(comboBoxDetail, HIGHDETAIL);
-			break;
-		case STATIC_GAME_LOD_CUSTOM:
-			GadgetComboBoxSetSelectedPos(comboBoxDetail, CUSTOMDETAIL);
-			break;
-		default:
-			DEBUG_ASSERTCRASH(FALSE,("Tried to set comboBoxDetail to a value of %d ", TheGameLODManager->getStaticLODLevel()) );
-		};
+	if ((TheGameLogic->isInGame() == FALSE) || (TheGameLogic->isInShellGame() == TRUE))
+	{
+		GadgetComboBoxSetSelectedPos(comboBoxDetail, (Int)TheGameLODManager->getRecommendedStaticLODLevel());
 	}
 
 	//-------------------------------------------------------------------------------------------------
@@ -1114,7 +1090,7 @@ static void saveOptions( void )
 	//-------------------------------------------------------------------------------------------------
 	// Custom game detail settings.
 	GadgetComboBoxGetSelectedPos( comboBoxDetail, &index );
-	if (index == CUSTOMDETAIL)
+	if (index == STATIC_GAME_LOD_CUSTOM)
 	{
  		//-------------------------------------------------------------------------------------------------
  		// Texture resolution slider
@@ -1186,27 +1162,8 @@ static void saveOptions( void )
 	// LOD
 	if (comboBoxDetail && comboBoxDetail->winGetEnabled())
 	{
-		Bool levelChanged=FALSE;
 		GadgetComboBoxGetSelectedPos( comboBoxDetail, &index );
-
-		//The levels stored by the LOD Manager are inverted compared to GUI so find correct one:
-		switch (index) {
-		case HIGHDETAIL:
-			levelChanged=TheGameLODManager->setStaticLODLevel(STATIC_GAME_LOD_HIGH);
-			break;
-		case MEDIUMDETAIL:
-			levelChanged=TheGameLODManager->setStaticLODLevel(STATIC_GAME_LOD_MEDIUM);
-			break;
-		case LOWDETAIL:
-			levelChanged=TheGameLODManager->setStaticLODLevel(STATIC_GAME_LOD_LOW);
-			break;
-		case CUSTOMDETAIL:
-			levelChanged=TheGameLODManager->setStaticLODLevel(STATIC_GAME_LOD_CUSTOM);
-			break;
-		default:
-			DEBUG_ASSERTCRASH(FALSE,("LOD passed in was %d, %d is not a supported LOD",index,index));
-			break;
-		}
+		const Bool levelChanged = TheGameLODManager->setStaticLODLevel((StaticGameLODLevel)index);
 
 		if (levelChanged)
 			(*pref)["StaticGameLOD"] = TheGameLODManager->getStaticGameLODLevelName(TheGameLODManager->getStaticLODLevel());
@@ -1534,23 +1491,7 @@ static void acceptAdvancedOptions()
 static void cancelAdvancedOptions()
 {
 	//restore the detail selection back to initial state
-	switch (TheGameLODManager->getStaticLODLevel())
-	{
-	case STATIC_GAME_LOD_LOW:
-		GadgetComboBoxSetSelectedPos(comboBoxDetail, LOWDETAIL);
-		break;
-	case STATIC_GAME_LOD_MEDIUM:
-		GadgetComboBoxSetSelectedPos(comboBoxDetail, MEDIUMDETAIL);
-		break;
-	case STATIC_GAME_LOD_HIGH:
-		GadgetComboBoxSetSelectedPos(comboBoxDetail, HIGHDETAIL);
-		break;
-	case STATIC_GAME_LOD_CUSTOM:
-		GadgetComboBoxSetSelectedPos(comboBoxDetail, CUSTOMDETAIL);
-		break;
-	default:
-		DEBUG_ASSERTCRASH(FALSE,("Tried to set comboBoxDetail to a value of %d ", TheGameLODManager->getStaticLODLevel()) );
-	};
+	GadgetComboBoxSetSelectedPos(comboBoxDetail, (Int)TheGameLODManager->getStaticLODLevel());
 
 	WinAdvancedDisplay->winHide(TRUE);
 }
@@ -1868,35 +1809,22 @@ void OptionsMenuInit( WindowLayout *layout, void *userData )
 	GadgetComboBoxSetSelectedPos( comboBoxResolution, selectedResIndex );
 
 	// set the display detail
+	// TheSuperHackers @tweak xezon 24/09/2025 The Detail Combo Box now has the same value order as StaticGameLODLevel for simplicity.
 	GadgetComboBoxReset(comboBoxDetail);
-	GadgetComboBoxAddEntry(comboBoxDetail, TheGameText->fetch("GUI:High"), color);
-	GadgetComboBoxAddEntry(comboBoxDetail, TheGameText->fetch("GUI:Medium"), color);
 	GadgetComboBoxAddEntry(comboBoxDetail, TheGameText->fetch("GUI:Low"), color);
+	GadgetComboBoxAddEntry(comboBoxDetail, TheGameText->fetch("GUI:Medium"), color);
+	GadgetComboBoxAddEntry(comboBoxDetail, TheGameText->fetch("GUI:High"), color);
 	GadgetComboBoxAddEntry(comboBoxDetail, TheGameText->fetch("GUI:Custom"), color);
+	static_assert(STATIC_GAME_LOD_COUNT == 4, "Wrong combo box count");
 
 	//Check if level was never set and default to setting most suitable for system.
 	if (TheGameLODManager->getStaticLODLevel() == STATIC_GAME_LOD_UNKNOWN)
-		TheGameLODManager->setStaticLODLevel(TheGameLODManager->findStaticLODLevel());
-
-	switch (TheGameLODManager->getStaticLODLevel())
 	{
-	case STATIC_GAME_LOD_LOW:
-		GadgetComboBoxSetSelectedPos(comboBoxDetail, LOWDETAIL);
-		break;
-	case STATIC_GAME_LOD_MEDIUM:
-		GadgetComboBoxSetSelectedPos(comboBoxDetail, MEDIUMDETAIL);
-		break;
-	case STATIC_GAME_LOD_HIGH:
-		GadgetComboBoxSetSelectedPos(comboBoxDetail, HIGHDETAIL);
-		break;
-	case STATIC_GAME_LOD_CUSTOM:
-		GadgetComboBoxSetSelectedPos(comboBoxDetail, CUSTOMDETAIL);
-		break;
-	default:
-		DEBUG_ASSERTCRASH(FALSE,("Tried to set comboBoxDetail to a value of %d ", TheGameLODManager->getStaticLODLevel()) );
-	};
+		TheGameLODManager->setStaticLODLevel(TheGameLODManager->getRecommendedStaticLODLevel());
+	}
 
 	Int txtFact=TheGameLODManager->getCurrentTextureReduction();
+	GadgetComboBoxSetSelectedPos(comboBoxDetail, (Int)TheGameLODManager->getStaticLODLevel());
 
 	GadgetSliderSetPosition( sliderTextureResolution, 2-txtFact);
 
@@ -2217,7 +2145,7 @@ WindowMsgHandledType OptionsMenuSystem( GameWindow *window, UnsignedInt msg,
 				{
 					Int index;
 					GadgetComboBoxGetSelectedPos( comboBoxDetail, &index );
-					if(index != CUSTOMDETAIL)
+					if(index != STATIC_GAME_LOD_CUSTOM)
 						break;
 
 					showAdvancedOptions();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -898,6 +898,8 @@ static OptionPreferences *pref = NULL;
 
 static void setDefaults( void )
 {
+	constexpr const Bool ModifyDisplaySettings = FALSE;
+
 	//-------------------------------------------------------------------------------------------------
 	// provider type
 //	GadgetCheckBoxSetChecked(checkAudioHardware, FALSE);
@@ -914,6 +916,8 @@ static void setDefaults( void )
 	// send Delay
 	GadgetCheckBoxSetChecked(checkSendDelay, FALSE);
 
+	if constexpr (ModifyDisplaySettings)
+	{
 	//-------------------------------------------------------------------------------------------------
 	// LOD
 	if ((TheGameLogic->isInGame() == FALSE) || (TheGameLogic->isInShellGame() == TRUE))
@@ -937,7 +941,7 @@ static void setDefaults( void )
 		}
 		GadgetComboBoxSetSelectedPos( comboBoxResolution, defaultResIndex );	//should be 800x600 (our lowest supported mode)
 	}
-
+	}
 
 	//-------------------------------------------------------------------------------------------------
 	// Mouse Mode
@@ -974,12 +978,13 @@ static void setDefaults( void )
  	GadgetSliderGetMinMax(sliderGamma,&valMin, &valMax);
  	GadgetSliderSetPosition(sliderGamma, ((valMax - valMin) / 2 + valMin));
 
-	//-------------------------------------------------------------------------------------------------
- 	// Texture resolution slider
-	//
-
+	if constexpr (ModifyDisplaySettings)
+	{
 	if ((TheGameLogic->isInGame() == FALSE) || (TheGameLogic->isInShellGame() == TRUE))
 	{
+		//-------------------------------------------------------------------------------------------------
+		// Texture resolution slider
+		//
 		Int	txtFact=TheGameLODManager->getRecommendedTextureReduction();
 
 		GadgetSliderSetPosition( sliderTextureResolution, 2-txtFact);
@@ -1043,6 +1048,7 @@ static void setDefaults( void )
  		// Trees and Shrubs
 		//
 		GadgetCheckBoxSetChecked( checkProps, TheGlobalData->m_useTrees);
+	}
 	}
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -75,6 +75,8 @@
 //used to access a messagebox that does "ok" and "cancel"
 #include "GameClient/MessageBox.h"
 
+#include "ww3d.h"
+
 // This is for non-RC builds only!!!
 #define VERBOSE_VERSION L"Release"
 
@@ -1095,18 +1097,14 @@ static void saveOptions( void )
  		//-------------------------------------------------------------------------------------------------
  		// Texture resolution slider
 		{
+		 		val = 2 - GadgetSliderGetPosition(sliderTextureResolution);
+
 				AsciiString prefString;
-
-		 		val = GadgetSliderGetPosition(sliderTextureResolution);
-				val = 2-val;
-
 				prefString.format("%d",val);
 				(*pref)["TextureReduction"] = prefString;
 
-				if (TheGlobalData->m_textureReductionFactor != val)
-				{
-					TheGameClient->adjustLOD(val-TheGlobalData->m_textureReductionFactor);	//apply the new setting
-				}
+				TheWritableGlobalData->m_textureReductionFactor = val;
+				TheGameClient->setTextureLOD(val);
 		}
 
 		TheWritableGlobalData->m_useShadowVolumes = GadgetCheckBoxIsChecked( check3DShadows );
@@ -1829,10 +1827,9 @@ void OptionsMenuInit( WindowLayout *layout, void *userData )
 		TheGameLODManager->setStaticLODLevel(TheGameLODManager->getRecommendedStaticLODLevel());
 	}
 
-	Int txtFact=TheGameLODManager->getCurrentTextureReduction();
 	GadgetComboBoxSetSelectedPos(comboBoxDetail, (Int)TheGameLODManager->getStaticLODLevel());
 
-	GadgetSliderSetPosition( sliderTextureResolution, 2-txtFact);
+	GadgetSliderSetPosition( sliderTextureResolution, 2-WW3D::Get_Texture_Reduction());
 
 	GadgetCheckBoxSetChecked( check3DShadows, TheGlobalData->m_useShadowVolumes);
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
@@ -900,7 +900,7 @@ void finishSinglePlayerInit( void )
 						if (!TheGameLODManager->didMemPass()) {
 							useLowRes = TRUE;
 						}
-						if (TheGameLODManager->findStaticLODLevel()==STATIC_GAME_LOD_LOW) {
+						if (TheGameLODManager->getRecommendedStaticLODLevel()==STATIC_GAME_LOD_LOW) {
 							useLowRes = TRUE;
 						}
 						if (TheGameLODManager->getStaticLODLevel()==STATIC_GAME_LOD_LOW) {
@@ -1980,7 +1980,7 @@ winName.format("ScoreScreen.wnd:StaticTextScore%d", pos);
 					stats.surrenders[ptIdx] += TheGameInfo->haveWeSurrendered()  || !TheVictoryConditions->getEndFrame();
 
 					AsciiString systemSpec;
-					systemSpec.format("LOD%d", TheGameLODManager->findStaticLODLevel());
+					systemSpec.format("LOD%d", TheGameLODManager->getRecommendedStaticLODLevel());
 					stats.systemSpec = systemSpec.str();
 
 					stats.techCaptured[ptIdx] += s->getTotalTechBuildingsCaptured();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -88,7 +88,7 @@
 #include "GameNetwork/GameSpyOverlay.h"
 #include "GameNetwork/GameSpy/BuddyThread.h"
 
-
+#include "ww3d.h"
 
 
 #define dont_ALLOW_ALT_F4
@@ -4179,7 +4179,8 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 		//-----------------------------------------------------------------------------------------
 		case GameMessage::MSG_META_DEMO_LOD_DECREASE:
 		{
-			TheGameClient->adjustLOD(-1);
+			const Int level = clamp(0, WW3D::Get_Texture_Reduction() - 1, 4);
+			TheGameClient->setTextureLOD(level);
 			TheInGameUI->messageNoFormat( TheGameText->FETCH_OR_SUBSTITUTE_FORMAT("GUI:DebugDecreaseLOD", L"Decrease LOD") );
 			disp = DESTROY_MESSAGE;
 			break;
@@ -4189,7 +4190,8 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 		//-----------------------------------------------------------------------------------------
 		case GameMessage::MSG_META_DEMO_LOD_INCREASE:
 		{
-			TheGameClient->adjustLOD(1);
+			const Int level = clamp(0, WW3D::Get_Texture_Reduction() + 1, 4);
+			TheGameClient->setTextureLOD(level);
 			TheInGameUI->messageNoFormat( TheGameText->FETCH_OR_SUBSTITUTE_FORMAT("GUI:DebugIncreaseLOD", L"Increase LOD") );
 			disp = DESTROY_MESSAGE;
 			break;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -1810,7 +1810,7 @@ void GameLogic::startNewGame( Bool loadingSaveGame )
 
 	// If forceFluffToProp == true, removable objects get created on client only. [7/14/2003]
 	// If static lod is HIGH, we don't do force fluff to client side only (create logic side props, more expensive. jba)
-	Bool forceFluffToProp = TheGameLODManager->getStaticLODLevel() != STATIC_GAME_LOD_HIGH;
+	Bool forceFluffToProp = TheGameLODManager->getStaticLODLevel() < STATIC_GAME_LOD_HIGH;
 	if (TheGameLODManager->getStaticLODLevel() == STATIC_GAME_LOD_CUSTOM &&
 			TheGlobalData->m_useShadowVolumes) {
 		// Custom LOD, and volumetric shadows turned on - very high detail.  So use logic props too. jba. [7/14/2003]

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DGameClient.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DGameClient.h
@@ -92,7 +92,7 @@ public:
 
 	//---------------------------------------------------------------------------
 	virtual void setTeamColor( Int red, Int green, Int blue );  ///< @todo superhack for demo, remove!!!
-	virtual void adjustLOD( Int adj ); ///< @todo hack for evaluation, remove.
+	virtual void setTextureLOD( Int level );
 	virtual void notifyTerrainObjectMoved(Object *obj);
 
 protected:

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/TerrainTex.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/TerrainTex.cpp
@@ -195,8 +195,8 @@ int TerrainTextureClass::update(WorldHeightMap *htMap)
 	surface_level->UnlockRect();
 	surface_level->Release();
 	DX8_ErrorCode(D3DXFilterTexture(Peek_D3D_Texture(), NULL, 0, D3DX_FILTER_BOX));
-	if (TheWritableGlobalData->m_textureReductionFactor) {
-		Peek_D3D_Texture()->SetLOD(TheWritableGlobalData->m_textureReductionFactor);
+	if (WW3D::Get_Texture_Reduction()) {
+		Peek_D3D_Texture()->SetLOD(WW3D::Get_Texture_Reduction());
 	}
 	return(surface_desc.Height);
 }

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -790,7 +790,9 @@ void W3DDisplay::init( void )
 
 		//Check if level was never set and default to setting most suitable for system.
 		if (TheGameLODManager->getStaticLODLevel() == STATIC_GAME_LOD_UNKNOWN)
-			TheGameLODManager->setStaticLODLevel(TheGameLODManager->findStaticLODLevel());
+		{
+			TheGameLODManager->setStaticLODLevel(TheGameLODManager->getRecommendedStaticLODLevel());
+		}
 		else
 		{	//Static LOD level was applied during GameLOD manager init except for texture reduction
 			//which needs to be applied here.

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -794,14 +794,10 @@ void W3DDisplay::init( void )
 			TheGameLODManager->setStaticLODLevel(TheGameLODManager->getRecommendedStaticLODLevel());
 		}
 		else
-		{	//Static LOD level was applied during GameLOD manager init except for texture reduction
+		{
+			//Static LOD level was applied during GameLOD manager init except for texture reduction
 			//which needs to be applied here.
-			Int txtReduction=TheWritableGlobalData->m_textureReductionFactor;
-			if (txtReduction > 0)
-			{		WW3D::Set_Texture_Reduction(txtReduction,32);
-					//Tell LOD manager that texture reduction was applied.
-					TheGameLODManager->setCurrentTextureReduction(txtReduction);
-			}
+			TheGameClient->setTextureLOD(TheWritableGlobalData->m_textureReductionFactor);
 		}
 
 		if (TheGlobalData->m_displayGamma != 1.0f)

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DGameClient.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DGameClient.cpp
@@ -196,27 +196,16 @@ void W3DGameClient::setTeamColor(Int red, Int green, Int blue)
 }
 
 //-------------------------------------------------------------------------------------------------
-/** temporary entry point for adjusting LOD for development testing. */
 //-------------------------------------------------------------------------------------------------
-void W3DGameClient::adjustLOD( Int adj )
+void W3DGameClient::setTextureLOD( Int level )
 {
-	if (TheGlobalData == NULL)
-		return;
+	if (WW3D::Get_Texture_Reduction() != level)
+	{
+		WW3D::Set_Texture_Reduction(level, 32);
 
-	TheWritableGlobalData->m_textureReductionFactor += adj;
-
-	if (TheWritableGlobalData->m_textureReductionFactor > 4)
-		TheWritableGlobalData->m_textureReductionFactor = 4;	//16x less resolution is probably enough.
-	if (TheWritableGlobalData->m_textureReductionFactor < 0)
-		TheWritableGlobalData->m_textureReductionFactor = 0;
-
-	if (WW3D::Get_Texture_Reduction() != TheWritableGlobalData->m_textureReductionFactor)
-	{	WW3D::Set_Texture_Reduction(TheWritableGlobalData->m_textureReductionFactor,32);
-		TheGameLODManager->setCurrentTextureReduction(TheWritableGlobalData->m_textureReductionFactor);
 		if( TheTerrainRenderObject )
-  			TheTerrainRenderObject->setTextureLOD( TheWritableGlobalData->m_textureReductionFactor );
+			TheTerrainRenderObject->setTextureLOD(level);
 	}
-
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DShaderManager.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DShaderManager.cpp
@@ -3128,7 +3128,7 @@ StaticGameLODLevel W3DShaderManager::getGPUPerformanceIndex(void)
 		if (chipType >=	DC_GEFORCE2)
 			detailSetting=STATIC_GAME_LOD_LOW;	//these cards need multiple terrain passes.
 		if (chipType >= DC_GENERIC_PIXEL_SHADER_1_1)	//these cards can do terrain in single pass.
-			detailSetting=STATIC_GAME_LOD_HIGH;
+			detailSetting=STATIC_GAME_LOD_VERY_HIGH;
 	}
 
 	return detailSetting;

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DTreeBuffer.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DTreeBuffer.cpp
@@ -189,8 +189,8 @@ int W3DTreeBuffer::W3DTreeTextureClass::update(W3DTreeBuffer *buffer)
 	DX8_ErrorCode(surface_level->UnlockRect());
 	surface_level->Release();
 	DX8_ErrorCode(D3DXFilterTexture(Peek_D3D_Texture(), NULL, (UINT)0, D3DX_FILTER_BOX));
-	if (TheWritableGlobalData->m_textureReductionFactor) {
-		DX8_ErrorCode(Peek_D3D_Texture()->SetLOD((DWORD)TheWritableGlobalData->m_textureReductionFactor));
+	if (WW3D::Get_Texture_Reduction()) {
+		DX8_ErrorCode(Peek_D3D_Texture()->SetLOD((DWORD)WW3D::Get_Texture_Reduction()));
 	}
 	return(surface_desc.Height);
 }

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/WorldHeightMap.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/WorldHeightMap.cpp
@@ -2214,8 +2214,8 @@ TextureClass *WorldHeightMap::getEdgeTerrainTexture(void)
 
 TerrainTextureClass *WorldHeightMap::getFlatTexture(Int xCell, Int yCell, Int cellWidth, Int pixelsPerCell)
 {
-	if (TheWritableGlobalData->m_textureReductionFactor) {
-		if (TheWritableGlobalData->m_textureReductionFactor>1) {
+	if (WW3D::Get_Texture_Reduction()) {
+		if (WW3D::Get_Texture_Reduction()>1) {
 			pixelsPerCell /= 4;
 		} else {
 			pixelsPerCell /= 2;


### PR DESCRIPTION
This change disables changing the display settings when clicking the Default button in the Options Menu.

There arguably is no good in changing the Resolution (to 800x600) or Detail level (to Low) when clicking Default.