### PR TITLE
bugfix(debug): Fix missing toggle for DEMO_TOGGLE_NO_DRAW

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -4672,7 +4672,8 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 		//-----------------------------------------------------------------------------------------
 		case GameMessage::MSG_NO_DRAW:
 		{
-			TheWritableGlobalData->m_noDraw = REAL_TO_INT(pow(2, 32) - 1);
+			const Bool isZero = TheGlobalData->m_noDraw == 0;
+			TheWritableGlobalData->m_noDraw = isZero ? 0x80000000 : 0;
 			disp = DESTROY_MESSAGE;
 			break;
 		}

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -4672,8 +4672,8 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 		//-----------------------------------------------------------------------------------------
 		case GameMessage::MSG_NO_DRAW:
 		{
-			const Bool isZero = TheGlobalData->m_noDraw == 0;
-			TheWritableGlobalData->m_noDraw = isZero ? 0x80000000 : 0;
+			const Bool isZero = TheGlobalData->m_noDraw == 0u;
+			TheWritableGlobalData->m_noDraw = isZero ? ~0u : 0u;
 			disp = DESTROY_MESSAGE;
 			break;
 		}

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -5088,7 +5088,8 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 		//-----------------------------------------------------------------------------------------
 		case GameMessage::MSG_NO_DRAW:
 		{
-			TheWritableGlobalData->m_noDraw = REAL_TO_INT(pow(2, 32) - 1);
+			const Bool isZero = TheGlobalData->m_noDraw == 0;
+			TheWritableGlobalData->m_noDraw = isZero ? 0x80000000 : 0;
 			disp = DESTROY_MESSAGE;
 			break;
 		}

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -5088,8 +5088,8 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 		//-----------------------------------------------------------------------------------------
 		case GameMessage::MSG_NO_DRAW:
 		{
-			const Bool isZero = TheGlobalData->m_noDraw == 0;
-			TheWritableGlobalData->m_noDraw = isZero ? 0x80000000 : 0;
+			const Bool isZero = TheGlobalData->m_noDraw == 0u;
+			TheWritableGlobalData->m_noDraw = isZero ? ~0u : 0u;
 			disp = DESTROY_MESSAGE;
 			break;
 		}


### PR DESCRIPTION
This change fixes the missing toggle for DEMO_TOGGLE_NO_DRAW.

Previously, hitting the forward slash button (US keyboard) in game (with RTS_DEBUG) would disable draw for practically ever. This also happened during debug sessions. Annoying.