### PR TITLE
bugfix: All external network commands are now correctly cleared when leaving a game

### DIFF
--- a/Generals/Code/GameEngine/Source/GameNetwork/Connection.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/Connection.cpp
@@ -217,18 +217,19 @@ void Connection::clearCommandsExceptFrom( Int playerIndex )
 	NetCommandRef *tmp = m_netCommandList->getFirstMessage();
 	while (tmp)
 	{
+		NetCommandRef *next = tmp->getNext();
 		NetCommandMsg *msg = tmp->getCommand();
+
 		if (msg->getPlayerID() != playerIndex)
 		{
-			DEBUG_LOG(("Connection::clearCommandsExceptFrom(%d) - clearing a command from %d for frame %d",
+			DEBUG_LOG(("Connection::clearCommandsExceptFrom(%d) - clearing a command from player %d for frame %d",
 				playerIndex, tmp->getCommand()->getPlayerID(), tmp->getCommand()->getExecutionFrame()));
+
 			m_netCommandList->removeMessage(tmp);
-			NetCommandRef *toDelete = tmp;
-			tmp = tmp->getNext();
-			deleteInstance(toDelete);
-		} else {
-			tmp = tmp->getNext();
+			deleteInstance(tmp);
 		}
+
+		tmp = next;
 	}
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/Connection.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/Connection.cpp
@@ -217,18 +217,19 @@ void Connection::clearCommandsExceptFrom( Int playerIndex )
 	NetCommandRef *tmp = m_netCommandList->getFirstMessage();
 	while (tmp)
 	{
+		NetCommandRef *next = tmp->getNext();
 		NetCommandMsg *msg = tmp->getCommand();
+
 		if (msg->getPlayerID() != playerIndex)
 		{
-			DEBUG_LOG(("Connection::clearCommandsExceptFrom(%d) - clearing a command from %d for frame %d",
+			DEBUG_LOG(("Connection::clearCommandsExceptFrom(%d) - clearing a command from player %d for frame %d",
 				playerIndex, tmp->getCommand()->getPlayerID(), tmp->getCommand()->getExecutionFrame()));
+
 			m_netCommandList->removeMessage(tmp);
-			NetCommandRef *toDelete = tmp;
-			tmp = tmp->getNext();
-			deleteInstance(toDelete);
-		} else {
-			tmp = tmp->getNext();
+			deleteInstance(tmp);
 		}
+
+		tmp = next;
 	}
 }
 


### PR DESCRIPTION
This change fixes an issue where only a single network command is cleared per connection upon leaving a game, rather than the entire list as expected. This occurs due to the command list iterator being invalidated when removing the current node.

This resolves cases where players are not immediately sent to the score screen after leaving a game due to network commands being left in the buffer.