### PR TITLE
tweak(camera): Decouple camera zoom update from logic time

### DIFF
--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -1355,7 +1355,8 @@ void W3DView::update(void)
 			// if scrolling, only adjust if we're too close or too far
 			if (m_scrollAmount.length() < m_scrollAmountCutoff || (m_currentHeightAboveGround < m_minHeightAboveGround) || (TheGlobalData->m_enforceMaxCameraHeight && m_currentHeightAboveGround > m_maxHeightAboveGround))
 			{
-				Real zoomAdj = (desiredZoom - m_zoom) * TheGlobalData->m_cameraAdjustSpeed * TheGameEngine->getActualLogicTimeScaleOverFpsRatio();
+				const Real fpsRatio = (Real)BaseFps / TheGameEngine->getUpdateFps();
+				const Real zoomAdj = (desiredZoom - m_zoom) * TheGlobalData->m_cameraAdjustSpeed * fpsRatio;
 				if (fabs(zoomAdj) >= 0.0001f)	// only do positive
 				{
 					m_zoom += zoomAdj;
@@ -1366,7 +1367,8 @@ void W3DView::update(void)
 		else if (!didScriptedMovement)
 		{
 			// we're not scrolling; settle toward desired height above ground
-			Real zoomAdj = (m_zoom - desiredZoom) * TheGlobalData->m_cameraAdjustSpeed * TheGameEngine->getActualLogicTimeScaleOverFpsRatio();
+			const Real fpsRatio = (Real)BaseFps / TheGameEngine->getUpdateFps();
+			const Real zoomAdj = (m_zoom - desiredZoom) * TheGlobalData->m_cameraAdjustSpeed * fpsRatio;
 			if (fabs(zoomAdj) >= 0.0001f)
 			{
 				m_zoom -= zoomAdj;


### PR DESCRIPTION
* Follow up for #1587

This change is a follow up for #1587 and now correctly decouples the camera zoom update from the logic time.

Previously I coupled it with the logic update, but that is bogus. Camera zoom should not become slower on slow motion logic. It is independent of both logic and render update and instead is based on Base Fps (30) and therefore always has the same speed.