### PR TITLE
bugfix(anim): Fix elapsed time of object animations

### DIFF
--- a/Core/Libraries/Source/WWVegas/WW3D2/seglinerenderer.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/seglinerenderer.cpp
@@ -78,6 +78,7 @@ SegLineRendererClass::SegLineRendererClass(void) :
 		NoiseAmplitude(0.0f),
 		MergeAbortFactor(1.5f),
 		TextureTileFactor(1.0f),
+		LastUsedSyncTime(WW3D::Get_Logic_Time_Milliseconds()),
 		CurrentUVOffset(0.0f,0.0f),
 		UVOffsetDeltaPerMS(0.0f, 0.0f),
 		Bits(DEFAULT_BITS),
@@ -97,6 +98,7 @@ SegLineRendererClass::SegLineRendererClass(const SegLineRendererClass & that) :
 		NoiseAmplitude(0.0f),
 		MergeAbortFactor(1.5f),
 		TextureTileFactor(1.0f),
+		LastUsedSyncTime(that.LastUsedSyncTime),
 		CurrentUVOffset(0.0f,0.0f),
 		UVOffsetDeltaPerMS(0.0f, 0.0f),
 		Bits(DEFAULT_BITS),
@@ -118,6 +120,7 @@ SegLineRendererClass & SegLineRendererClass::operator = (const SegLineRendererCl
 		NoiseAmplitude = that.NoiseAmplitude;
 		MergeAbortFactor = that.MergeAbortFactor;
 		TextureTileFactor = that.TextureTileFactor;
+		LastUsedSyncTime = that.LastUsedSyncTime;
 		CurrentUVOffset = that.CurrentUVOffset;
 		UVOffsetDeltaPerMS = that.UVOffsetDeltaPerMS;
 		Bits = that.Bits;
@@ -198,6 +201,7 @@ void SegLineRendererClass::Set_Texture_Tile_Factor(float factor)
 
 void SegLineRendererClass::Reset_Line(void)
 {
+	LastUsedSyncTime = WW3D::Get_Logic_Time_Milliseconds();
 	CurrentUVOffset.Set(0.0f,0.0f);
 }
 
@@ -224,7 +228,8 @@ void SegLineRendererClass::Render
 	** Handle texture UV offset animation (done once for entire line).
 	*/
 	// TheSuperHackers @tweak The render update is now decoupled from the logic step.
-	Vector2 uv_offset = CurrentUVOffset + UVOffsetDeltaPerMS * WW3D::Get_Logic_Frame_Time_Milliseconds();
+	const unsigned int delta = WW3D::Get_Logic_Time_Milliseconds() - LastUsedSyncTime;
+	Vector2 uv_offset = CurrentUVOffset + UVOffsetDeltaPerMS * (float)delta;
 
 	// ensure offsets are in [0, 1] range:
 	uv_offset.X = uv_offset.X - floorf(uv_offset.X);
@@ -232,6 +237,7 @@ void SegLineRendererClass::Render
 
 	// Update state
 	CurrentUVOffset = uv_offset;
+	LastUsedSyncTime = WW3D::Get_Logic_Time_Milliseconds();
 
 	// Used later
 	TextureMapMode map_mode = Get_Texture_Mapping_Mode();

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/animobj.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/animobj.cpp
@@ -89,6 +89,7 @@ Animatable3DObjClass::Animatable3DObjClass(const char * htree_name) :
   ModeAnim.Motion=NULL;
 	ModeAnim.Frame=0.0f;
 	ModeAnim.PrevFrame=0.0f;
+	ModeAnim.LastSyncTime=WW3D::Get_Logic_Time_Milliseconds();
 	ModeAnim.frameRateMultiplier=1.0;	// 020607 srj -- added
 	ModeAnim.animDirection=1.0;	// 020607 srj -- added
 	ModeInterp.Motion0=NULL;
@@ -144,6 +145,7 @@ Animatable3DObjClass::Animatable3DObjClass(const Animatable3DObjClass & src) :
 	ModeAnim.Motion=NULL;
 	ModeAnim.Frame=0.0f;
 	ModeAnim.PrevFrame=0.0f;
+	ModeAnim.LastSyncTime=WW3D::Get_Logic_Time_Milliseconds();
 	ModeAnim.frameRateMultiplier=1.0;	// 020607 srj -- added
 	ModeAnim.animDirection=1.0;	// 020607 srj -- added
 	ModeInterp.Motion0=NULL;
@@ -203,6 +205,7 @@ Animatable3DObjClass & Animatable3DObjClass::operator = (const Animatable3DObjCl
 		ModeAnim.Motion = NULL;
 		ModeAnim.Frame = 0.0f;
 		ModeAnim.PrevFrame = 0.0f;
+		ModeAnim.LastSyncTime = WW3D::Get_Logic_Time_Milliseconds();
 		ModeAnim.frameRateMultiplier=1.0;	// 020607 srj -- added
 		ModeAnim.animDirection=1.0;	// 020607 srj -- added
 		ModeInterp.Motion0 = NULL;
@@ -461,6 +464,7 @@ void Animatable3DObjClass::Set_Animation(HAnimClass * motion, float frame, int m
 		ModeAnim.Motion = motion;
 		ModeAnim.PrevFrame = ModeAnim.Frame;
 		ModeAnim.Frame = frame;
+		ModeAnim.LastSyncTime = WW3D::Get_Logic_Time_Milliseconds();
 		ModeAnim.frameRateMultiplier=1.0;	// 020607 srj -- added
 		ModeAnim.animDirection=1.0;	// 020607 srj -- added
 
@@ -937,13 +941,14 @@ float Animatable3DObjClass::Compute_Current_Frame(float *newDirection) const
 		{
 			frame = ModeAnim.Frame;
 
-			//
-			//	Compute the current frame based on elapsed time.
-			//
 			if (ModeAnim.AnimMode != ANIM_MODE_MANUAL) {
+				//
+				//	Compute the current frame based on elapsed time.
+				//	TheSuperHackers @info Is using elapsed time because frame computation is not guaranteed to be called every render frame!
+				//
 				// TheSuperHackers @tweak The animation render update is now decoupled from the logic step.
-				const float frametime = WW3D::Get_Logic_Frame_Time_Seconds();
-				const float delta = ModeAnim.Motion->Get_Frame_Rate() * ModeAnim.frameRateMultiplier * ModeAnim.animDirection * frametime;
+				const float timeDiff = WW3D::Get_Logic_Time_Milliseconds() - ModeAnim.LastSyncTime;
+				const float delta = ModeAnim.Motion->Get_Frame_Rate() * ModeAnim.frameRateMultiplier * ModeAnim.animDirection * timeDiff * 0.001f;
 				frame += delta;
 
 				//
@@ -1040,6 +1045,7 @@ void Animatable3DObjClass::Single_Anim_Progress (void)
 		//
 		ModeAnim.PrevFrame		= ModeAnim.Frame;
 		ModeAnim.Frame				= Compute_Current_Frame(&ModeAnim.animDirection);
+		ModeAnim.LastSyncTime	= WW3D::Get_Logic_Time_Milliseconds();
 
 		//
 		// Force the hierarchy to be recalculated

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/animobj.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/animobj.h
@@ -190,6 +190,7 @@ protected:
 			float		  				Frame;
 			float						PrevFrame;
 			int						AnimMode;
+			int								LastSyncTime;
 			float							animDirection;
 			float							frameRateMultiplier;	// 020607 srj -- added
 		} ModeAnim;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/ww3d.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/ww3d.h
@@ -171,11 +171,25 @@ public:
 	** will control things like animated uv-offset mappers and render object animations.
 	*/
 	static void						Sync(bool step);
+
+	// Total sync time in milliseconds. Advances in full logic time steps only.
 	static unsigned int		Get_Sync_Time(void) { return SyncTime; }
+
+	// Current sync frame time in milliseconds. Can be zero when the logic has not stepped forward in the current render update.
 	static unsigned int		Get_Sync_Frame_Time(void) { return SyncTime - PreviousSyncTime; }
+
+	// Total logic time in milliseconds. Can include fractions of a logic step. Is rounded to integer.
+	static unsigned int		Get_Logic_Time_Milliseconds() { return SyncTime + (unsigned int)WWMath::Round(FractionalSyncMs); }
+
+	// Logic time step in milliseconds. Can be a fraction of a logic step.
 	static float					Get_Logic_Frame_Time_Milliseconds() { return LogicFrameTimeMs; }
+
+	// Logic time step in seconds. Can be a fraction of a logic step.
 	static float					Get_Logic_Frame_Time_Seconds() { return LogicFrameTimeMs * 0.001f; }
+
+	// Returns the render frame count.
 	static unsigned int		Get_Frame_Count(void) { return FrameCount; }
+
 	static unsigned int		Get_Last_Frame_Poly_Count(void);
 	static unsigned int		Get_Last_Frame_Vertex_Count(void);
 


### PR DESCRIPTION
* Follow up for #1579
* Fixes #1641

This change is a follow up for #1579 and fixes the elapsed time of object animations. It also adds the elapsed time for seg line again.

The deal with these updates is that they are not guaranteed to update always, but are only updated when inside world view. That is why we need to keep track of the absolute time of the last update instead of accumulating the frame time every render update.

## TODO

- [ ] Replicate in Generals