### PR TITLE
fix(quotedprintable): Fix assert in AsciiStringToQuotedPrintable during map cache generation

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/Common/System/QuotedPrintable.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/QuotedPrintable.cpp
@@ -65,7 +65,8 @@ AsciiString UnicodeStringToQuotedPrintable(UnicodeString original)
 			dest[i++] = MAGIC_CHAR;
 			dest[i++] = intToHexDigit((*src)>>4);
 			dest[i++] = intToHexDigit((*src)&0xf);
-		} else
+		}
+		else
 		{
 			dest[i++] = *src;
 		}
@@ -100,7 +101,8 @@ AsciiString AsciiStringToQuotedPrintable(AsciiString original)
 			dest[i++] = MAGIC_CHAR;
 			dest[i++] = intToHexDigit((*src)>>4);
 			dest[i++] = intToHexDigit((*src)&0xf);
-		} else
+		}
+		else
 		{
 			dest[i++] = *src;
 		}
@@ -117,8 +119,8 @@ UnicodeString QuotedPrintableToUnicodeString(AsciiString original)
 	static WideChar dest[1024];
 	int i=0;
 
-	unsigned char *c = (unsigned char *)dest;
-	const unsigned char *src = (const unsigned char *)original.str();
+	unsigned char *c = reinterpret_cast<unsigned char *>(dest);
+	const unsigned char *src = reinterpret_cast<const unsigned char *>(original.str());
 
 	while (*src && i<1023)
 	{
@@ -159,18 +161,17 @@ UnicodeString QuotedPrintableToUnicodeString(AsciiString original)
 
 	*c = 0;
 
-	UnicodeString out(dest);
-	return out;
+	return dest;
 }
 
 // Convert ascii quoted-printable strings into ascii strings
 AsciiString QuotedPrintableToAsciiString(AsciiString original)
 {
-	static unsigned char dest[1024];
+	static char dest[1024];
 	int i=0;
 
-	unsigned char *c = (unsigned char *)dest;
-	const unsigned char *src = (const unsigned char *)original.str();
+	unsigned char *c = reinterpret_cast<unsigned char *>(dest);
+	const unsigned char *src = reinterpret_cast<const unsigned char *>(original.str());
 
 	while (*src && i<1023)
 	{
@@ -200,6 +201,6 @@ AsciiString QuotedPrintableToAsciiString(AsciiString original)
 
 	*c = 0;
 
-	return AsciiString((const char *)dest);
+	return dest;
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/QuotedPrintable.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/QuotedPrintable.cpp
@@ -56,7 +56,7 @@ static int hexDigitToInt(char c)
 AsciiString UnicodeStringToQuotedPrintable(UnicodeString original)
 {
 	static char dest[1024];
-	const char *src = (const char *)original.str();
+	const unsigned char *src = reinterpret_cast<const unsigned char *>(original.str());
 	int i=0;
 	while ( !(src[0]=='\0' && src[1]=='\0') && i<1021 )
 	{
@@ -91,7 +91,7 @@ AsciiString UnicodeStringToQuotedPrintable(UnicodeString original)
 AsciiString AsciiStringToQuotedPrintable(AsciiString original)
 {
 	static char dest[1024];
-	const char *src = (const char *)original.str();
+	const unsigned char *src = reinterpret_cast<const unsigned char *>(original.str());
 	int i=0;
 	while ( src[0]!='\0' && i<1021 )
 	{


### PR DESCRIPTION
**Merge with Rebase**

This change fixes asserts in AsciiStringToQuotedPrintable (and UnicodeStringToQuotedPrintable). Seen during map cache generation. I think user facing this did not cause bugs.

```
 	ucrtbased.dll!548c4586()	Unknown
 	[Frames below may be incorrect and/or missing, no symbols loaded for ucrtbased.dll]	
 	ucrtbased.dll!548cb672()	Unknown
 	ucrtbased.dll!548cb581()	Unknown
 	ucrtbased.dll!548cb933()	Unknown
>	generalszh.exe!AsciiStringToQuotedPrintable(AsciiString original) Line 98	C++
 	generalszh.exe!MapCache::writeCacheINI(bool userDir) Line 397	C++
 	generalszh.exe!MapCache::updateCache() Line 457	C++
 	generalszh.exe!isValidMap(AsciiString mapName, bool isMultiplayer) Line 1001	C++
 	generalszh.exe!SkirmishPreferences::getPreferredMap() Line 296	C++
 	generalszh.exe!SkirmishGameOptionsMenuInit(WindowLayout * layout, void * userData) Line 1374	C++
 	generalszh.exe!WindowLayout::runInit(void * userData) Line 117	C++
 	generalszh.exe!Shell::doPop(bool impendingPush) Line 717	C++
 	generalszh.exe!Shell::shutdownComplete(WindowLayout * screen, bool impendingPush) Line 765	C++
 	generalszh.exe!ScoreScreenShutdown(WindowLayout * layout, void * userData) Line 404	C++
 	generalszh.exe!WindowLayout::runShutdown(void * userData) Line 119	C++
 	generalszh.exe!Shell::pop() Line 419	C++
 	generalszh.exe!ScoreScreenSystem(GameWindow * window, unsigned int msg, unsigned int mData1, unsigned int mData2) Line 546	C++
 	generalszh.exe!GameWindowManager::winSendSystemMsg(GameWindow * window, unsigned int msg, unsigned int mData1, unsigned int mData2) Line 705	C++
 	generalszh.exe!GadgetPushButtonInput(GameWindow * window, unsigned int msg, unsigned int mData1, unsigned int mData2) Line 218	C++
 	generalszh.exe!GameWindowManager::winSendInputMsg(GameWindow * window, unsigned int msg, unsigned int mData1, unsigned int mData2) Line 724	C++
 	generalszh.exe!GameWindowManager::winProcessMouseEvent(GameWindowMessage msg, ICoord2D * mousePos, void * data) Line 919	C++
 	generalszh.exe!WindowTranslator::translateGameMessage(const GameMessage * msg) Line 242	C++
 	generalszh.exe!MessageStream::propagateMessages() Line 1112	C++
 	generalszh.exe!GameEngine::update() Line 1014	C++
 	generalszh.exe!Win32GameEngine::update() Line 90	C++
 	generalszh.exe!GameEngine::execute() Line 1096	C++
 	generalszh.exe!GameMain() Line 52	C++
 	generalszh.exe!WinMain(HINSTANCE__ * hInstance, HINSTANCE__ * hPrevInstance, char * lpCmdLine, int nCmdShow) Line 903	C++
 	generalszh.exe!invoke_main() Line 107	C++
 	generalszh.exe!__scrt_common_main_seh() Line 288	C++
 	generalszh.exe!__scrt_common_main() Line 331	C++
 	generalszh.exe!WinMainCRTStartup(void * __formal) Line 17	C++
 	kernel32.dll!7781fcc9()	Unknown
 	ntdll.dll!77bb82ae()	Unknown
 	ntdll.dll!77bb827e()	Unknown
```

The second commit refactors the code a bit.

## TODO

- [ ] Add pull id to commits
- [ ] Replicate in Generals