### PR TITLE
tweak(fps): Simplify function W3DDisplay::updateAverageFPS() and remove its frame spike filter

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/GameEngine.h
+++ b/Generals/Code/GameEngine/Include/Common/GameEngine.h
@@ -78,7 +78,7 @@ public:
 
 	virtual void setFramesPerSecondLimit( Int fps ); ///< Set the max render and engine update fps.
 	virtual Int getFramesPerSecondLimit( void ); ///< Get the max render and engine update fps.
-	Real getUpdateTime(); ///< Get the last engine update delta time.
+	Real getUpdateTime(); ///< Get the last engine update delta time in seconds.
 	Real getUpdateFps(); ///< Get the last engine update fps.
 
 	static Bool isTimeFrozen(); ///< Returns true if a script has frozen time.
@@ -128,7 +128,7 @@ protected:
 	Int m_maxFPS; ///< Maximum frames per second for rendering
 	Int m_logicTimeScaleFPS; ///< Maximum frames per second for logic time scale
 
-	Real m_updateTime; ///< Last engine update delta time
+	Real m_updateTime; ///< Last engine update delta time in seconds
 	Real m_logicTimeAccumulator; ///< Frame time accumulated towards submitting a new logic frame
 
 	Bool m_quitting; ///< true when we need to quit the game

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -161,7 +161,7 @@ protected:
 	void drawCurrentDebugDisplay( void );			///< draws current debug display
 	void calculateTerrainLOD(void);						///< Calculate terrain LOD.
 	void renderLetterBox(UnsignedInt time);							///< draw letter box border
-	void updateAverageFPS(void);	///< figure out the average fps over the last 30 frames.
+	void updateAverageFPS(void);	///< calculate the average fps over the last 30 frames.
 
 	Byte m_initialized;												///< TRUE when system is initialized
 	LightClass *m_myLight[LightEnvironmentClass::MAX_LIGHTS];										///< light hack for now

--- a/GeneralsMD/Code/GameEngine/Include/Common/GameEngine.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GameEngine.h
@@ -78,7 +78,7 @@ public:
 
 	virtual void setFramesPerSecondLimit( Int fps ); ///< Set the max render and engine update fps.
 	virtual Int getFramesPerSecondLimit( void ); ///< Get the max render and engine update fps.
-	Real getUpdateTime(); ///< Get the last engine update delta time.
+	Real getUpdateTime(); ///< Get the last engine update delta time in seconds.
 	Real getUpdateFps(); ///< Get the last engine update fps.
 
 	static Bool isTimeFrozen(); ///< Returns true if a script has frozen time.
@@ -127,7 +127,7 @@ protected:
 	Int m_maxFPS; ///< Maximum frames per second for rendering
 	Int m_logicTimeScaleFPS; ///< Maximum frames per second for logic time scale
 
-	Real m_updateTime; ///< Last engine update delta time
+	Real m_updateTime; ///< Last engine update delta time in seconds
 	Real m_logicTimeAccumulator; ///< Frame time accumulated towards submitting a new logic frame
 
 	Bool m_quitting; ///< true when we need to quit the game

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -162,7 +162,7 @@ protected:
 	void drawCurrentDebugDisplay( void );			///< draws current debug display
 	void calculateTerrainLOD(void);						///< Calculate terrain LOD.
 	void renderLetterBox(UnsignedInt time);							///< draw letter box border
-	void updateAverageFPS(void);	///< figure out the average fps over the last 30 frames.
+	void updateAverageFPS(void);	///< calculate the average fps over the last 30 frames.
 
 	Byte m_initialized;												///< TRUE when system is initialized
 	LightClass *m_myLight[LightEnvironmentClass::MAX_LIGHTS];										///< light hack for now

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -34,6 +34,7 @@
 static void drawFramerateBar(void);
 
 // SYSTEM INCLUDES ////////////////////////////////////////////////////////////
+#include <numeric>
 #include <stdlib.h>
 #include <windows.h>
 #include <io.h>
@@ -885,21 +886,16 @@ void W3DDisplay::reset( void )
 
 const UnsignedInt START_CUMU_FRAME = LOGICFRAMES_PER_SECOND / 2;	// skip first half-sec
 
-/** Update a moving average of the last 30 fps measurements.  Also try to filter out temporary spikes.
-	This code is designed to be used by the GameLOD sytems to determine the correct dynamic LOD setting.
-*/
 void W3DDisplay::updateAverageFPS(void)
 {
-	const Real MaximumFrameTimeCutoff = 0.5f;	//largest frame interval (seconds) we accept before ignoring it as a momentary "spike"
-	const Int FPS_HISTORY_SIZE = 30;	//keep track of the last 30 frames
+	constexpr const Int FPS_HISTORY_SIZE = 30;
 
 	static Int64 lastUpdateTime64 = 0;
 	static Int historyOffset = 0;
-	static Int numSamples = 0;
-	static double fpsHistory[FPS_HISTORY_SIZE];
+	static Real fpsHistory[FPS_HISTORY_SIZE] = {0};
 
-	Int64 freq64 = getPerformanceCounterFrequency();
-	Int64 time64 = getPerformanceCounter();
+	const Int64 freq64 = getPerformanceCounterFrequency();
+	const Int64 time64 = getPerformanceCounter();
 
 #if defined(RTS_DEBUG)
 	if (TheGameLogic->getFrame() == START_CUMU_FRAME)
@@ -908,37 +904,21 @@ void W3DDisplay::updateAverageFPS(void)
 	}
 #endif
 
-	Int64 timeDiff = time64 - lastUpdateTime64;
+	const Int64 timeDiff = time64 - lastUpdateTime64;
 
 	// convert elapsed time to seconds
-	double elapsedSeconds = (double)timeDiff/(double)(freq64);
+	Real elapsedSeconds = (Real)timeDiff/(Real)freq64;
 
-	if (elapsedSeconds <= MaximumFrameTimeCutoff)	//make sure it's not a spike
-	{
-		// append new sameple to fps history.
-		if (historyOffset >= FPS_HISTORY_SIZE)
-			historyOffset = 0;
+	// append new sample to fps history.
+	if (historyOffset >= FPS_HISTORY_SIZE)
+		historyOffset = 0;
 
-		m_currentFPS = 1.0/elapsedSeconds;
-		fpsHistory[historyOffset++] = m_currentFPS;
-		numSamples++;
-		if (numSamples > FPS_HISTORY_SIZE)
-			numSamples = FPS_HISTORY_SIZE;
-	}
+	m_currentFPS = 1.0f/elapsedSeconds;
+	fpsHistory[historyOffset++] = m_currentFPS;
 
-	if (numSamples)
-	{
-		// determine average frame rate over our past history.
-		Real average=0;
-		for (Int i=0,j=historyOffset-1; i<numSamples; i++,j--)
-		{
-			if (j < 0)
-				j=FPS_HISTORY_SIZE-1;	// wrap around to front of buffer
-			average += fpsHistory[j];
-		}
-
-		m_averageFPS = average / (Real)numSamples;
-	}
+	// determine average frame rate over our past history.
+	const Real sum = std::accumulate(fpsHistory, fpsHistory + FPS_HISTORY_SIZE, 0.0f);
+	m_averageFPS = sum / FPS_HISTORY_SIZE;
 
 	lastUpdateTime64 = time64;
 }


### PR DESCRIPTION
This change removes the Munkee übercomplexity and the frame spike filter from W3DDisplay::updateAverageFPS().

The spike filter ignored any frames longer than 500 ms and that does not make sense to keep around.

## TODO

- [x] Replicate in Generals