### PR TITLE
tweak(module): Add 'TransferSelection' field to CreateObjectDie INI module to allow transfer selection on object creation

### DIFF
--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CreateObjectDie.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CreateObjectDie.h
@@ -48,6 +48,7 @@ public:
 
 	const ObjectCreationList* m_ocl;			///< object creaton list to make
 	Bool m_transferPreviousHealth; ///< Transfers previous health before death to the new object created.
+	Bool m_transferSelection;      ///< Transfers selection state before death to the new object created.
 
 	CreateObjectDieModuleData();
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Die/CreateObjectDie.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Die/CreateObjectDie.cpp
@@ -38,7 +38,7 @@
 #include "GameLogic/Object.h"
 #include "GameLogic/ObjectCreationList.h"
 #include "GameLogic/Module/BodyModule.h"
-
+#include "GameClient/InGameUI.h"
 
 // ------------------------------------------------------------------------------------------------
 // ------------------------------------------------------------------------------------------------
@@ -47,7 +47,7 @@ CreateObjectDieModuleData::CreateObjectDieModuleData()
 
 	m_ocl = NULL;
 	m_transferPreviousHealth = FALSE;
-
+	m_transferSelection = FALSE;
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -60,6 +60,7 @@ CreateObjectDieModuleData::CreateObjectDieModuleData()
 	{
 		{ "CreationList",	INI::parseObjectCreationList,		NULL,											offsetof( CreateObjectDieModuleData, m_ocl ) },
 		{ "TransferPreviousHealth", INI::parseBool, NULL	,offsetof( CreateObjectDieModuleData, m_transferPreviousHealth ) },
+		{ "TransferSelection", INI::parseBool, NULL	,offsetof( CreateObjectDieModuleData, m_transferSelection ) },
 		{ 0, 0, 0, 0 }
 	};
 	p.add(dataFieldParse);
@@ -95,11 +96,13 @@ void CreateObjectDie::onDie( const DamageInfo * damageInfo )
 	Object *damageDealer = TheGameLogic->findObjectByID( damageInfo->in.m_sourceID );
 
 	Object *newObject = ObjectCreationList::create( data->m_ocl, getObject(), damageDealer );
+	if (!newObject)
+		return;
 
 	//If we're transferring previous health, we're transfering the last known
 	//health before we died. In the case of the sneak attack tunnel network, it
 	//is killed after the lifetime update expires.
-	if( newObject && data->m_transferPreviousHealth )
+	if( data->m_transferPreviousHealth )
 	{
 		//Convert old health to new health.
 		Object *oldObject = getObject();
@@ -140,7 +143,20 @@ void CreateObjectDie::onDie( const DamageInfo * damageInfo )
 		}
 	}
 
+	if (data->m_transferSelection)
+	{
+		Object* oldObject = getObject();
+		Drawable* selectedDrawable = TheInGameUI->getFirstSelectedDrawable();
+		Bool oldObjectSelected = selectedDrawable && selectedDrawable->getID() == oldObject->getDrawable()->getID();
 
+		if (oldObjectSelected)
+		{
+			GameMessage* msg = TheMessageStream->appendMessage(GameMessage::MSG_CREATE_SELECTED_GROUP_NO_SOUND);
+			msg->appendBooleanArgument(TRUE);
+			msg->appendObjectIDArgument(newObject->getID());
+			TheInGameUI->selectDrawable(newObject->getDrawable());
+		}
+	}
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Die/CreateObjectDie.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Die/CreateObjectDie.cpp
@@ -60,7 +60,7 @@ CreateObjectDieModuleData::CreateObjectDieModuleData()
 	{
 		{ "CreationList",	INI::parseObjectCreationList,		NULL,											offsetof( CreateObjectDieModuleData, m_ocl ) },
 		{ "TransferPreviousHealth", INI::parseBool, NULL	,offsetof( CreateObjectDieModuleData, m_transferPreviousHealth ) },
-		{ "TransferSelection", INI::parseBool, NULL	,offsetof( CreateObjectDieModuleData, m_transferSelection ) },
+		{ "TransferSelection", INI::parseBool, NULL, offsetof( CreateObjectDieModuleData, m_transferSelection ) },
 		{ 0, 0, 0, 0 }
 	};
 	p.add(dataFieldParse);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Die/CreateObjectDie.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Die/CreateObjectDie.cpp
@@ -143,6 +143,8 @@ void CreateObjectDie::onDie( const DamageInfo * damageInfo )
 		}
 	}
 
+	// TheSuperHackers @bugfix Stubbjax 02/10/2025 If the old object was selected, select the new one.
+	// This is important for the Sneak Attack, which is spawned via a CreateObjectDie module.
 	if (data->m_transferSelection)
 	{
 		Object* oldObject = getObject();


### PR DESCRIPTION
This change allows the Sneak Attack to remain selected when it transitions from its spawning object.

A new `TransferSelection` field can now be added to the `CreateObjectDie` module to enable this behaviour.

Note: No other object uses the `TransferPreviousHealth` field, so this field could technically be used to control the reselection behaviour (initially?) and thus be retail compatible. However, it would not make logical sense and would confound the behaviour.

```diff
Object GLASneakAttackTunnelNetworkStart
  Behavior             = CreateObjectDie ModuleTag_11
    CreationList  = OCL_CreateSneakAttackTunnel
    TransferPreviousHealth = Yes
+   TransferSelection = Yes
  End
End
```

Feature or bugfix?