### PR TITLE
fix(network): Prevent buffer overflows for incoming messages in NetPacket

### DIFF
--- a/Generals/Code/GameEngine/Source/GameNetwork/NetPacket.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/NetPacket.cpp
@@ -5798,7 +5798,7 @@ NetCommandMsg * NetPacket::readFileMessage(UnsignedByte *data, Int &i) {
 	char filename[_MAX_PATH];
 	char *c = filename;
 
-	while (data[i] != 0) {
+	for (Int l = 0; l < _MAX_PATH-1 && data[i] != 0; l++) {
 		*c = data[i];
 		++c;
 		++i;
@@ -5825,7 +5825,7 @@ NetCommandMsg * NetPacket::readFileAnnounceMessage(UnsignedByte *data, Int &i) {
 	char filename[_MAX_PATH];
 	char *c = filename;
 
-	while (data[i] != 0) {
+	for (Int l = 0; l < _MAX_PATH-1 && data[i] != 0; l++) {
 		*c = data[i];
 		++c;
 		++i;

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/NetPacket.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/NetPacket.cpp
@@ -5798,7 +5798,7 @@ NetCommandMsg * NetPacket::readFileMessage(UnsignedByte *data, Int &i) {
 	char filename[_MAX_PATH];
 	char *c = filename;
 
-	while (data[i] != 0) {
+	for (Int l = 0; l < _MAX_PATH-1 && data[i] != 0; l++) {
 		*c = data[i];
 		++c;
 		++i;
@@ -5825,7 +5825,7 @@ NetCommandMsg * NetPacket::readFileAnnounceMessage(UnsignedByte *data, Int &i) {
 	char filename[_MAX_PATH];
 	char *c = filename;
 
-	while (data[i] != 0) {
+	for (Int l = 0; l < _MAX_PATH-1 && data[i] != 0; l++) {
 		*c = data[i];
 		++c;
 		++i;


### PR DESCRIPTION
TODO Fix numerous out of bound reads which may lead to crashes.