### PR TITLE
fix: replace wcscat with wcslcat for robustness

### DIFF
--- a/Core/GameEngine/Source/Common/System/UnicodeString.cpp
+++ b/Core/GameEngine/Source/Common/System/UnicodeString.cpp
@@ -91,7 +91,7 @@ void UnicodeString::ensureUniqueBufferOfSize(int numCharsNeeded, Bool preserveDa
 			m_data->peek()[usableNumChars] = 0;
 		}
 		if (strToCat)
-			wcscat(m_data->peek(), strToCat);
+			wcslcat(m_data->peek(), strToCat, usableNumChars + 1);
 		return;
 	}
 
@@ -120,7 +120,7 @@ void UnicodeString::ensureUniqueBufferOfSize(int numCharsNeeded, Bool preserveDa
 		newData->peek()[usableNumChars] = 0;
 	}
 	if (strToCat)
-		wcscat(newData->peek(), strToCat);
+		wcslcat(newData->peek(), strToCat, usableNumChars + 1);
 
 	releaseBuffer();
 	m_data = newData;

--- a/Generals/Code/GameEngine/Include/Common/Language.h
+++ b/Generals/Code/GameEngine/Include/Common/Language.h
@@ -78,7 +78,6 @@ typedef enum
 #define GameStrcpy wcscpy
 #define GameStrncpy wcsncpy
 #define GameStrlen wcslen
-#define GameStrcat wcscat
 #define GameStrcmp wcscmp
 #define GameStrncmp wcsncmp
 #define GameStricmp wcsicmp

--- a/GeneralsMD/Code/GameEngine/Include/Common/Language.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Language.h
@@ -78,7 +78,6 @@ typedef enum
 #define GameStrcpy wcscpy
 #define GameStrncpy wcsncpy
 #define GameStrlen wcslen
-#define GameStrcat wcscat
 #define GameStrcmp wcscmp
 #define GameStrncmp wcsncmp
 #define GameStricmp wcsicmp


### PR DESCRIPTION
- Part of #1518

This change replaces `wcscat ` with `wcslcat ` for robustness