### PR TITLE
refactor(netpacket): Simplify packet serialization code by using packed structs

### DIFF
--- a/Core/GameEngine/Include/GameNetwork/NetPacketStructs.h
+++ b/Core/GameEngine/Include/GameNetwork/NetPacketStructs.h
@@ -299,6 +299,47 @@ struct NetPacketGameCommand {
 	// Variable fields: game message arguments
 };
 
+////////////////////////////////////////////////////////////////////////////////
+// Variable-Length Packet Headers for FillBufferWithXXX serialization
+// These structs include the textLength field for direct buffer overlay
+////////////////////////////////////////////////////////////////////////////////
+
+// Chat command header (includes textLength for serialization)
+// Fixed fields: T + type, F + frame, R + relay, P + playerID, C + commandID, D + textLength
+struct NetPacketChatCommandHeader {
+	NetPacketCommandTypeField commandType;
+	NetPacketFrameField frame;
+	NetPacketRelayField relay;
+	NetPacketPlayerIdField playerId;
+	NetPacketCommandIdField commandId;
+	NetPacketDataFieldHeader dataHeader;
+	UnsignedByte textLength;
+	// Variable fields: WideChar text[textLength] + Int playerMask
+};
+
+// Disconnect chat command header (includes textLength for serialization)
+// Fixed fields: T + type, R + relay, P + playerID, D + textLength
+struct NetPacketDisconnectChatCommandHeader {
+	NetPacketCommandTypeField commandType;
+	NetPacketRelayField relay;
+	NetPacketPlayerIdField playerId;
+	NetPacketDataFieldHeader dataHeader;
+	UnsignedByte textLength;
+	// Variable fields: WideChar text[textLength]
+};
+
+// Game command header (for serialization)
+// Fixed fields: T + type, F + frame, R + relay, P + playerID, C + commandID, D
+struct NetPacketGameCommandHeader {
+	NetPacketCommandTypeField commandType;
+	NetPacketFrameField frame;
+	NetPacketRelayField relay;
+	NetPacketPlayerIdField playerId;
+	NetPacketCommandIdField commandId;
+	NetPacketDataFieldHeader dataHeader;
+	// Variable fields: GameMessage type + argument types + argument data
+};
+
 // Wrapper command packet (fixed size - contains metadata about wrapped command)
 // Fields: T + type, R + relay, P + playerID, C + commandID, D + metadata
 struct NetPacketWrapperCommand {
@@ -380,34 +421,34 @@ struct NetPacketTimeOutGameStartMessage {
 };
 
 // Disconnect frame command packet
-// Fields: T + type, P + playerID, C + commandID, R + relay, D + disconnectFrame
+// Fields: T + type, R + relay, P + playerID, C + commandID, D + disconnectFrame
 struct NetPacketDisconnectFrameCommand {
 	NetPacketCommandTypeField commandType;
+	NetPacketRelayField relay;
 	NetPacketPlayerIdField playerId;
 	NetPacketCommandIdField commandId;
-	NetPacketRelayField relay;
 	NetPacketDataFieldHeader dataHeader;
 	UnsignedInt disconnectFrame;
 };
 
 // Disconnect screen off command packet
-// Fields: T + type, P + playerID, C + commandID, R + relay, D + newFrame
+// Fields: T + type, R + relay, P + playerID, C + commandID, D + newFrame
 struct NetPacketDisconnectScreenOffCommand {
 	NetPacketCommandTypeField commandType;
+	NetPacketRelayField relay;
 	NetPacketPlayerIdField playerId;
 	NetPacketCommandIdField commandId;
-	NetPacketRelayField relay;
 	NetPacketDataFieldHeader dataHeader;
 	UnsignedInt newFrame;
 };
 
 // Frame resend request command packet
-// Fields: T + type, P + playerID, C + commandID, R + relay, D + frameToResend
+// Fields: T + type, R + relay, P + playerID, C + commandID, D + frameToResend
 struct NetPacketFrameResendRequestCommand {
 	NetPacketCommandTypeField commandType;
+	NetPacketRelayField relay;
 	NetPacketPlayerIdField playerId;
 	NetPacketCommandIdField commandId;
-	NetPacketRelayField relay;
 	NetPacketDataFieldHeader dataHeader;
 	UnsignedInt frameToResend;
 };

--- a/Core/GameEngine/Source/GameNetwork/NetPacket.cpp
+++ b/Core/GameEngine/Source/GameNetwork/NetPacket.cpp
@@ -371,47 +371,27 @@ void NetPacket::FillBufferWithCommand(UnsignedByte *buffer, NetCommandRef *ref) 
 
 void NetPacket::FillBufferWithGameCommand(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetGameCommandMsg *cmdMsg = static_cast<NetGameCommandMsg *>(msg->getCommand());
-	UnsignedShort offset = 0;
 	// get the game message from the NetCommandMsg
 	GameMessage *gmsg = cmdMsg->constructGameMessage();
 
 	//DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::FillBufferWithGameCommand for command ID %d", cmdMsg->getID()));
 
-	// If necessary, put the NetCommandType into the packet.
-	buffer[offset] = NetPacketFieldTypes::CommandType;
-	++offset;
-	buffer[offset] = cmdMsg->getNetCommandType();
-	offset += sizeof(UnsignedByte);
+	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for fixed header portion
+	NetPacketGameCommandHeader* packet = reinterpret_cast<NetPacketGameCommandHeader*>(buffer);
+	packet->commandType.header = NetPacketFieldTypes::CommandType;
+	packet->commandType.commandType = cmdMsg->getNetCommandType();
+	packet->frame.header = NetPacketFieldTypes::Frame;
+	packet->frame.frame = cmdMsg->getExecutionFrame();
+	packet->relay.header = NetPacketFieldTypes::Relay;
+	packet->relay.relay = msg->getRelay();
+	packet->playerId.header = NetPacketFieldTypes::PlayerId;
+	packet->playerId.playerId = cmdMsg->getPlayerID();
+	packet->commandId.header = NetPacketFieldTypes::CommandId;
+	packet->commandId.commandId = cmdMsg->getID();
+	packet->dataHeader.header = NetPacketFieldTypes::Data;
 
-	// If necessary, put the execution frame into the packet.
-	buffer[offset] = NetPacketFieldTypes::Frame;
-	++offset;
-	UnsignedInt newframe = cmdMsg->getExecutionFrame();
-	memcpy(buffer+offset, &newframe, sizeof(UnsignedInt));
-	offset += sizeof(UnsignedInt);
-
-	// If necessary, put the relay into the packet.
-	buffer[offset] = NetPacketFieldTypes::Relay;
-	++offset;
-	UnsignedByte newRelay = msg->getRelay();
-	memcpy(buffer+offset, &newRelay, sizeof(UnsignedByte));
-	offset += sizeof(UnsignedByte);
-
-	// If necessary, put the playerID into the packet.
-	buffer[offset] = NetPacketFieldTypes::PlayerId;
-	++offset;
-	buffer[offset] = cmdMsg->getPlayerID();
-	offset += sizeof(UnsignedByte);
-
-	// If necessary, specify the command ID of this command.
-	buffer[offset] = NetPacketFieldTypes::CommandId;
-	++offset;
-	UnsignedShort newID = cmdMsg->getID();
-	memcpy(buffer + offset, &newID, sizeof(UnsignedShort));
-	offset += sizeof(UnsignedShort);
-
-	buffer[offset] = NetPacketFieldTypes::Data;
-	++offset;
+	// Variable data portion
+	UnsignedShort offset = sizeof(NetPacketGameCommandHeader);
 
 	// Now copy the GameMessage type into the packet.
 	GameMessage::Type newType = gmsg->getType();
@@ -505,7 +485,6 @@ void NetPacket::FillBufferWithAckCommand(UnsignedByte *buffer, NetCommandRef *ms
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::FillBufferWithAckCommand - adding ack for command %d for player %d", cmdMsg->getCommandID(), msg->getCommand()->getPlayerID()));
 
 	NetCommandMsg *cmdMsg = msg->getCommand();
-	UnsignedShort offset = 0;
 
 	UnsignedShort commandID = 0;
 	UnsignedByte originalPlayerID = 0;
@@ -537,75 +516,37 @@ void NetPacket::FillBufferWithAckCommand(UnsignedByte *buffer, NetCommandRef *ms
 
 	}
 
-	buffer[offset] = NetPacketFieldTypes::CommandType;
-	++offset;
-	buffer[offset] = type;
-	offset += sizeof(UnsignedByte);
-
-	buffer[offset] = NetPacketFieldTypes::PlayerId;
-	++offset;
-	buffer[offset] = cmdMsg->getPlayerID();
-	offset += sizeof(UnsignedByte);
-
-	// Put in the command id of the command we are acking.
-	buffer[offset] = NetPacketFieldTypes::Data;
-	++offset;
-	memcpy(buffer + offset, &commandID, sizeof(UnsignedShort));
-	offset += sizeof(UnsignedShort);
-	memcpy(buffer + offset, &originalPlayerID, sizeof(UnsignedByte));
-	offset += sizeof(UnsignedByte);
+	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
+	NetPacketAckCommand* packet = reinterpret_cast<NetPacketAckCommand*>(buffer);
+	packet->commandType.header = NetPacketFieldTypes::CommandType;
+	packet->commandType.commandType = type;
+	packet->playerId.header = NetPacketFieldTypes::PlayerId;
+	packet->playerId.playerId = cmdMsg->getPlayerID();
+	packet->dataHeader.header = NetPacketFieldTypes::Data;
+	packet->commandId = commandID;
+	packet->originalPlayerId = originalPlayerID;
 
 	//		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("outgoing - added ACK, original player %d, command id %d", origPlayerID, cmdID));
 }
 
 void NetPacket::FillBufferWithFrameCommand(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetFrameCommandMsg *cmdMsg = static_cast<NetFrameCommandMsg *>(msg->getCommand());
-	UnsignedShort offset = 0;
 	//		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addFrameCommand - adding frame command for frame %d, command count = %d, command id = %d", cmdMsg->getExecutionFrame(), cmdMsg->getCommandCount(), cmdMsg->getID()));
 
-// If necessary, put the NetCommandType into the packet.
-	buffer[offset] = NetPacketFieldTypes::CommandType;
-	++offset;
-	buffer[offset] = cmdMsg->getNetCommandType();
-	offset += sizeof(UnsignedByte);
-
-// If necessary, put the execution frame into the packet.
-	buffer[offset] = NetPacketFieldTypes::Frame;
-	++offset;
-	UnsignedInt newframe = cmdMsg->getExecutionFrame();
-	memcpy(buffer+offset, &newframe, sizeof(UnsignedInt));
-	offset += sizeof(UnsignedInt);
-
-// If necessary, put the relay into the packet.
-	buffer[offset] = NetPacketFieldTypes::Relay;
-	++offset;
-	UnsignedByte newRelay = msg->getRelay();
-	memcpy(buffer+offset, &newRelay, sizeof(UnsignedByte));
-	offset += sizeof(UnsignedByte);
-
-//		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("relay = %d, ", m_lastRelay));
-
-	buffer[offset] = NetPacketFieldTypes::PlayerId;
-	++offset;
-	buffer[offset] = cmdMsg->getPlayerID();
-	offset += sizeof(UnsignedByte);
-
-//		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("player = %d", m_lastPlayerID));
-
-// If necessary, specify the command ID of this command.
-	buffer[offset] = NetPacketFieldTypes::CommandId;
-	++offset;
-	UnsignedShort newID = cmdMsg->getID();
-	memcpy(buffer + offset, &newID, sizeof(UnsignedShort));
-	offset += sizeof(UnsignedShort);
-
-//		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("command id = %d", m_lastCommandID));
-
-	buffer[offset] = NetPacketFieldTypes::Data;
-	++offset;
-	UnsignedShort cmdCount = cmdMsg->getCommandCount();
-	memcpy(buffer + offset, &cmdCount, sizeof(UnsignedShort));
-	offset += sizeof(UnsignedShort);
+	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
+	NetPacketFrameCommand* packet = reinterpret_cast<NetPacketFrameCommand*>(buffer);
+	packet->commandType.header = NetPacketFieldTypes::CommandType;
+	packet->commandType.commandType = cmdMsg->getNetCommandType();
+	packet->frame.header = NetPacketFieldTypes::Frame;
+	packet->frame.frame = cmdMsg->getExecutionFrame();
+	packet->relay.header = NetPacketFieldTypes::Relay;
+	packet->relay.relay = msg->getRelay();
+	packet->playerId.header = NetPacketFieldTypes::PlayerId;
+	packet->playerId.playerId = cmdMsg->getPlayerID();
+	packet->commandId.header = NetPacketFieldTypes::CommandId;
+	packet->commandId.commandId = cmdMsg->getID();
+	packet->dataHeader.header = NetPacketFieldTypes::Data;
+	packet->commandCount = cmdMsg->getCommandCount();
 
 	// frameinfodebug
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("outgoing - added frame %d, player %d, command count = %d, command id = %d", cmdMsg->getExecutionFrame(), cmdMsg->getPlayerID(), cmdMsg->getCommandCount(), cmdMsg->getID()));
@@ -613,639 +554,300 @@ void NetPacket::FillBufferWithFrameCommand(UnsignedByte *buffer, NetCommandRef *
 
 void NetPacket::FillBufferWithPlayerLeaveCommand(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetPlayerLeaveCommandMsg *cmdMsg = static_cast<NetPlayerLeaveCommandMsg *>(msg->getCommand());
-	UnsignedShort offset = 0;
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addPlayerLeaveCommand - adding player leave command for player %d", cmdMsg->getLeavingPlayerID()));
 
-	// If necessary, put the NetCommandType into the packet.
-	buffer[offset] = NetPacketFieldTypes::CommandType;
-	++offset;
-	buffer[offset] = cmdMsg->getNetCommandType();
-	offset += sizeof(UnsignedByte);
-
-// If necessary, put the relay into the packet.
-	buffer[offset] = NetPacketFieldTypes::Relay;
-	++offset;
-	UnsignedByte newRelay = msg->getRelay();
-	memcpy(buffer+offset, &newRelay, sizeof(UnsignedByte));
-	offset += sizeof(UnsignedByte);
-
-// If necessary, put the execution frame into the packet.
-	buffer[offset] = NetPacketFieldTypes::Frame;
-	++offset;
-	UnsignedInt newframe = cmdMsg->getExecutionFrame();
-	memcpy(buffer+offset, &newframe, sizeof(UnsignedInt));
-	offset += sizeof(UnsignedInt);
-
-//		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("relay = %d, ", m_lastRelay));
-
-	buffer[offset] = NetPacketFieldTypes::PlayerId;
-	++offset;
-	buffer[offset] = cmdMsg->getPlayerID();
-	offset += sizeof(UnsignedByte);
-
-//		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("player = %d", m_lastPlayerID));
-
-// If necessary, specify the command ID of this command.
-	buffer[offset] = NetPacketFieldTypes::CommandId;
-	++offset;
-	UnsignedShort newID = cmdMsg->getID();
-	memcpy(buffer + offset, &newID, sizeof(UnsignedShort));
-	offset += sizeof(UnsignedShort);
-
-//		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("command id = %d", m_lastCommandID));
-
-	buffer[offset] = NetPacketFieldTypes::Data;
-	++offset;
-	UnsignedByte leavingPlayerID = cmdMsg->getLeavingPlayerID();
-	memcpy(buffer + offset, &leavingPlayerID, sizeof(UnsignedByte));
-	offset += sizeof(UnsignedByte);
+	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
+	NetPacketPlayerLeaveCommand* packet = reinterpret_cast<NetPacketPlayerLeaveCommand*>(buffer);
+	packet->commandType.header = NetPacketFieldTypes::CommandType;
+	packet->commandType.commandType = cmdMsg->getNetCommandType();
+	packet->relay.header = NetPacketFieldTypes::Relay;
+	packet->relay.relay = msg->getRelay();
+	packet->frame.header = NetPacketFieldTypes::Frame;
+	packet->frame.frame = cmdMsg->getExecutionFrame();
+	packet->playerId.header = NetPacketFieldTypes::PlayerId;
+	packet->playerId.playerId = cmdMsg->getPlayerID();
+	packet->commandId.header = NetPacketFieldTypes::CommandId;
+	packet->commandId.commandId = cmdMsg->getID();
+	packet->dataHeader.header = NetPacketFieldTypes::Data;
+	packet->leavingPlayerId = cmdMsg->getLeavingPlayerID();
 }
 
 void NetPacket::FillBufferWithRunAheadMetricsCommand(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetRunAheadMetricsCommandMsg *cmdMsg = static_cast<NetRunAheadMetricsCommandMsg *>(msg->getCommand());
-	UnsignedShort offset = 0;
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addRunAheadMetricsCommand - adding run ahead metrics for player %d, fps = %d, latency = %f", cmdMsg->getPlayerID(), cmdMsg->getAverageFps(), cmdMsg->getAverageLatency()));
 
-	// If necessary, put the NetCommandType into the packet.
-	buffer[offset] = NetPacketFieldTypes::CommandType;
-	++offset;
-	buffer[offset] = cmdMsg->getNetCommandType();
-	offset += sizeof(UnsignedByte);
-
-// If necessary, put the relay into the packet.
-	buffer[offset] = NetPacketFieldTypes::Relay;
-	++offset;
-	UnsignedByte newRelay = msg->getRelay();
-	memcpy(buffer+offset, &newRelay, sizeof(UnsignedByte));
-	offset += sizeof(UnsignedByte);
-
-//		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("relay = %d, ", m_lastRelay));
-
-	buffer[offset] = NetPacketFieldTypes::PlayerId;
-	++offset;
-	buffer[offset] = cmdMsg->getPlayerID();
-	offset += sizeof(UnsignedByte);
-
-//		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("player = %d", m_lastPlayerID));
-
-// If necessary, specify the command ID of this command.
-	buffer[offset] = NetPacketFieldTypes::CommandId;
-	++offset;
-	UnsignedShort newID = cmdMsg->getID();
-	memcpy(buffer + offset, &newID, sizeof(UnsignedShort));
-	offset += sizeof(UnsignedShort);
-
-//		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("command id = %d", m_lastCommandID));
-
-	buffer[offset] = NetPacketFieldTypes::Data;
-	++offset;
-	// write the average latency
-	Real averageLatency = cmdMsg->getAverageLatency();
-	memcpy(buffer + offset, &averageLatency, sizeof(averageLatency));
-	offset += sizeof(averageLatency);
-	// write the average fps
-	UnsignedShort averageFps = (UnsignedShort)(cmdMsg->getAverageFps());
-	memcpy(buffer + offset, &averageFps, sizeof(averageFps));
-	offset += sizeof(averageFps);
+	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
+	NetPacketRunAheadMetricsCommand* packet = reinterpret_cast<NetPacketRunAheadMetricsCommand*>(buffer);
+	packet->commandType.header = NetPacketFieldTypes::CommandType;
+	packet->commandType.commandType = cmdMsg->getNetCommandType();
+	packet->relay.header = NetPacketFieldTypes::Relay;
+	packet->relay.relay = msg->getRelay();
+	packet->playerId.header = NetPacketFieldTypes::PlayerId;
+	packet->playerId.playerId = cmdMsg->getPlayerID();
+	packet->commandId.header = NetPacketFieldTypes::CommandId;
+	packet->commandId.commandId = cmdMsg->getID();
+	packet->dataHeader.header = NetPacketFieldTypes::Data;
+	packet->averageLatency = cmdMsg->getAverageLatency();
+	packet->averageFps = static_cast<UnsignedByte>(cmdMsg->getAverageFps());
 }
 
 void NetPacket::FillBufferWithRunAheadCommand(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetRunAheadCommandMsg *cmdMsg = static_cast<NetRunAheadCommandMsg *>(msg->getCommand());
-	UnsignedShort offset = 0;
 	//DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::FillBufferWithRunAheadCommand - adding run ahead command"));
 
-	// If necessary, put the NetCommandType into the packet.
-	buffer[offset] = NetPacketFieldTypes::CommandType;
-	++offset;
-	buffer[offset] = cmdMsg->getNetCommandType();
-	offset += sizeof(UnsignedByte);
-
-	// If necessary, put the relay into the packet.
-	buffer[offset] = NetPacketFieldTypes::Relay;
-	++offset;
-	UnsignedByte newRelay = msg->getRelay();
-	memcpy(buffer+offset, &newRelay, sizeof(UnsignedByte));
-	offset += sizeof(UnsignedByte);
-
-	// If necessary, put the execution frame into the packet.
-	buffer[offset] = NetPacketFieldTypes::Frame;
-	++offset;
-	UnsignedInt newframe = cmdMsg->getExecutionFrame();
-	memcpy(buffer+offset, &newframe, sizeof(UnsignedInt));
-	offset += sizeof(UnsignedInt);
-
-//		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("relay = %d, ", m_lastRelay));
-
-	buffer[offset] = NetPacketFieldTypes::PlayerId;
-	++offset;
-	buffer[offset] = cmdMsg->getPlayerID();
-	offset += sizeof(UnsignedByte);
-
-//		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("player = %d", m_lastPlayerID));
-
-	// If necessary, specify the command ID of this command.
-	buffer[offset] = NetPacketFieldTypes::CommandId;
-	++offset;
-	UnsignedShort newID = cmdMsg->getID();
-	memcpy(buffer + offset, &newID, sizeof(UnsignedShort));
-	offset += sizeof(UnsignedShort);
-
-//		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("command id = %d", m_lastCommandID));
-
-	buffer[offset] = NetPacketFieldTypes::Data;
-	++offset;
-	UnsignedShort newRunAhead = cmdMsg->getRunAhead();
-	memcpy(buffer + offset, &newRunAhead, sizeof(UnsignedShort));
-	offset += sizeof(UnsignedShort);
-
-	UnsignedByte newFrameRate = cmdMsg->getFrameRate();
-	memcpy(buffer + offset, &newFrameRate, sizeof(UnsignedByte));
-	offset += sizeof(UnsignedByte);
+	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
+	NetPacketRunAheadCommand* packet = reinterpret_cast<NetPacketRunAheadCommand*>(buffer);
+	packet->commandType.header = NetPacketFieldTypes::CommandType;
+	packet->commandType.commandType = cmdMsg->getNetCommandType();
+	packet->relay.header = NetPacketFieldTypes::Relay;
+	packet->relay.relay = msg->getRelay();
+	packet->frame.header = NetPacketFieldTypes::Frame;
+	packet->frame.frame = cmdMsg->getExecutionFrame();
+	packet->playerId.header = NetPacketFieldTypes::PlayerId;
+	packet->playerId.playerId = cmdMsg->getPlayerID();
+	packet->commandId.header = NetPacketFieldTypes::CommandId;
+	packet->commandId.commandId = cmdMsg->getID();
+	packet->dataHeader.header = NetPacketFieldTypes::Data;
+	packet->runAhead = cmdMsg->getRunAhead();
+	packet->frameRate = cmdMsg->getFrameRate();
 
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket - added run ahead command, frame %d, player id %d command id %d", m_lastFrame, m_lastPlayerID, m_lastCommandID));
 }
 
 void NetPacket::FillBufferWithDestroyPlayerCommand(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetDestroyPlayerCommandMsg *cmdMsg = static_cast<NetDestroyPlayerCommandMsg *>(msg->getCommand());
-	UnsignedShort offset = 0;
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addRunAheadCommand - adding run ahead command"));
 
-// If necessary, put the NetCommandType into the packet.
-	buffer[offset] = NetPacketFieldTypes::CommandType;
-	++offset;
-	buffer[offset] = cmdMsg->getNetCommandType();
-	offset += sizeof(UnsignedByte);
-
-// If necessary, put the relay into the packet.
-	buffer[offset] = NetPacketFieldTypes::Relay;
-	++offset;
-	UnsignedByte newRelay = msg->getRelay();
-	memcpy(buffer+offset, &newRelay, sizeof(UnsignedByte));
-	offset += sizeof(UnsignedByte);
-
-// If necessary, put the execution frame into the packet.
-	buffer[offset] = NetPacketFieldTypes::Frame;
-	++offset;
-	UnsignedInt newframe = cmdMsg->getExecutionFrame();
-	memcpy(buffer+offset, &newframe, sizeof(UnsignedInt));
-	offset += sizeof(UnsignedInt);
-
-//		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("relay = %d, ", m_lastRelay));
-
-	buffer[offset] = NetPacketFieldTypes::PlayerId;
-	++offset;
-	buffer[offset] = cmdMsg->getPlayerID();
-	offset += sizeof(UnsignedByte);
-
-//		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("player = %d", m_lastPlayerID));
-
-// If necessary, specify the command ID of this command.
-	buffer[offset] = NetPacketFieldTypes::CommandId;
-	++offset;
-	UnsignedShort newID = cmdMsg->getID();
-	memcpy(buffer + offset, &newID, sizeof(UnsignedShort));
-	offset += sizeof(UnsignedShort);
-
-//		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("command id = %d", m_lastCommandID));
-
-	buffer[offset] = NetPacketFieldTypes::Data;
-	++offset;
-	UnsignedInt newVal = cmdMsg->getPlayerIndex();
-	memcpy(buffer + offset, &newVal, sizeof(UnsignedInt));
-	offset += sizeof(UnsignedInt);
+	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
+	NetPacketDestroyPlayerCommand* packet = reinterpret_cast<NetPacketDestroyPlayerCommand*>(buffer);
+	packet->commandType.header = NetPacketFieldTypes::CommandType;
+	packet->commandType.commandType = cmdMsg->getNetCommandType();
+	packet->relay.header = NetPacketFieldTypes::Relay;
+	packet->relay.relay = msg->getRelay();
+	packet->frame.header = NetPacketFieldTypes::Frame;
+	packet->frame.frame = cmdMsg->getExecutionFrame();
+	packet->playerId.header = NetPacketFieldTypes::PlayerId;
+	packet->playerId.playerId = cmdMsg->getPlayerID();
+	packet->commandId.header = NetPacketFieldTypes::CommandId;
+	packet->commandId.commandId = cmdMsg->getID();
+	packet->dataHeader.header = NetPacketFieldTypes::Data;
+	packet->playerIndex = cmdMsg->getPlayerIndex();
 }
 
 void NetPacket::FillBufferWithKeepAliveCommand(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetKeepAliveCommandMsg *cmdMsg = static_cast<NetKeepAliveCommandMsg *>(msg->getCommand());
-	UnsignedShort offset = 0;
 
-	// If necessary, put the NetCommandType into the packet.
-	buffer[offset] = NetPacketFieldTypes::CommandType;
-	++offset;
-	buffer[offset] = cmdMsg->getNetCommandType();
-	offset += sizeof(UnsignedByte);
-
-// If necessary, put the relay into the packet.
-	buffer[offset] = NetPacketFieldTypes::Relay;
-	++offset;
-	UnsignedByte newRelay = msg->getRelay();
-	memcpy(buffer+offset, &newRelay, sizeof(UnsignedByte));
-	offset += sizeof(UnsignedByte);
-
-	buffer[offset] = NetPacketFieldTypes::PlayerId;
-	++offset;
-	buffer[offset] = cmdMsg->getPlayerID();
-	offset += sizeof(UnsignedByte);
-
-	buffer[offset] = NetPacketFieldTypes::Data;
-	++offset;
+	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
+	NetPacketKeepAliveCommand* packet = reinterpret_cast<NetPacketKeepAliveCommand*>(buffer);
+	packet->commandType.header = NetPacketFieldTypes::CommandType;
+	packet->commandType.commandType = cmdMsg->getNetCommandType();
+	packet->relay.header = NetPacketFieldTypes::Relay;
+	packet->relay.relay = msg->getRelay();
+	packet->playerId.header = NetPacketFieldTypes::PlayerId;
+	packet->playerId.playerId = cmdMsg->getPlayerID();
+	packet->dataHeader.header = NetPacketFieldTypes::Data;
 }
 
 void NetPacket::FillBufferWithDisconnectKeepAliveCommand(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetDisconnectKeepAliveCommandMsg *cmdMsg = static_cast<NetDisconnectKeepAliveCommandMsg *>(msg->getCommand());
-	UnsignedShort offset = 0;
 
-	// Put the NetCommandType into the packet.
-	buffer[offset] = NetPacketFieldTypes::CommandType;
-	++offset;
-	buffer[offset] = cmdMsg->getNetCommandType();
-	offset += sizeof(UnsignedByte);
-
-	// Put the relay into the packet.
-	buffer[offset] = NetPacketFieldTypes::Relay;
-	++offset;
-	UnsignedByte newRelay = msg->getRelay();
-	memcpy(buffer+offset, &newRelay, sizeof(UnsignedByte));
-	offset += sizeof(UnsignedByte);
-
-	// Put the player ID into the packet.
-	buffer[offset] = NetPacketFieldTypes::PlayerId;
-	++offset;
-	buffer[offset] = cmdMsg->getPlayerID();
-	offset += sizeof(UnsignedByte);
-
-	buffer[offset] = NetPacketFieldTypes::Data;
-	++offset;
+	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
+	NetPacketDisconnectKeepAliveCommand* packet = reinterpret_cast<NetPacketDisconnectKeepAliveCommand*>(buffer);
+	packet->commandType.header = NetPacketFieldTypes::CommandType;
+	packet->commandType.commandType = cmdMsg->getNetCommandType();
+	packet->relay.header = NetPacketFieldTypes::Relay;
+	packet->relay.relay = msg->getRelay();
+	packet->playerId.header = NetPacketFieldTypes::PlayerId;
+	packet->playerId.playerId = cmdMsg->getPlayerID();
+	packet->dataHeader.header = NetPacketFieldTypes::Data;
 }
 
 void NetPacket::FillBufferWithDisconnectPlayerCommand(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetDisconnectPlayerCommandMsg *cmdMsg = static_cast<NetDisconnectPlayerCommandMsg *>(msg->getCommand());
-	UnsignedShort offset = 0;
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addDisconnectPlayerCommand - adding run ahead command"));
 
-	// If necessary, put the NetCommandType into the packet.
-	buffer[offset] = NetPacketFieldTypes::CommandType;
-	++offset;
-	buffer[offset] = cmdMsg->getNetCommandType();
-	offset += sizeof(UnsignedByte);
-
-// If necessary, put the relay into the packet.
-	buffer[offset] = NetPacketFieldTypes::Relay;
-	++offset;
-	UnsignedByte newRelay = msg->getRelay();
-	memcpy(buffer+offset, &newRelay, sizeof(UnsignedByte));
-	offset += sizeof(UnsignedByte);
-
-//		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("relay = %d, ", m_lastRelay));
-
-	buffer[offset] = NetPacketFieldTypes::PlayerId;
-	++offset;
-	buffer[offset] = cmdMsg->getPlayerID();
-	offset += sizeof(UnsignedByte);
-
-//		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("player = %d", m_lastPlayerID));
-
-// If necessary, specify the command ID of this command.
-	buffer[offset] = NetPacketFieldTypes::CommandId;
-	++offset;
-	UnsignedShort newID = cmdMsg->getID();
-	memcpy(buffer + offset, &newID, sizeof(UnsignedShort));
-	offset += sizeof(UnsignedShort);
-
-	//		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("command id = %d", m_lastCommandID));
-
-	buffer[offset] = NetPacketFieldTypes::Data;
-	++offset;
-	UnsignedByte slot = cmdMsg->getDisconnectSlot();
-	memcpy(buffer + offset, &slot, sizeof(slot));
-	offset += sizeof(slot);
-
-	UnsignedInt disconnectFrame = cmdMsg->getDisconnectFrame();
-	memcpy(buffer + offset, &disconnectFrame, sizeof(disconnectFrame));
-	offset += sizeof(disconnectFrame);
+	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
+	NetPacketDisconnectPlayerCommand* packet = reinterpret_cast<NetPacketDisconnectPlayerCommand*>(buffer);
+	packet->commandType.header = NetPacketFieldTypes::CommandType;
+	packet->commandType.commandType = cmdMsg->getNetCommandType();
+	packet->relay.header = NetPacketFieldTypes::Relay;
+	packet->relay.relay = msg->getRelay();
+	packet->playerId.header = NetPacketFieldTypes::PlayerId;
+	packet->playerId.playerId = cmdMsg->getPlayerID();
+	packet->commandId.header = NetPacketFieldTypes::CommandId;
+	packet->commandId.commandId = cmdMsg->getID();
+	packet->dataHeader.header = NetPacketFieldTypes::Data;
+	packet->slot = cmdMsg->getDisconnectSlot();
+	packet->disconnectFrame = cmdMsg->getDisconnectFrame();
 }
 
 void NetPacket::FillBufferWithPacketRouterQueryCommand(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetPacketRouterQueryCommandMsg *cmdMsg = static_cast<NetPacketRouterQueryCommandMsg *>(msg->getCommand());
-	UnsignedShort offset = 0;
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addPacketRouterQueryCommand - adding packet router query command"));
 
-	// If necessary, put the NetCommandType into the packet.
-	buffer[offset] = NetPacketFieldTypes::CommandType;
-	++offset;
-	buffer[offset] = cmdMsg->getNetCommandType();
-	offset += sizeof(UnsignedByte);
-
-	// If necessary, put the relay into the packet.
-	buffer[offset] = NetPacketFieldTypes::Relay;
-	++offset;
-	UnsignedByte newRelay = msg->getRelay();
-	memcpy(buffer+offset, &newRelay, sizeof(UnsignedByte));
-	offset += sizeof(UnsignedByte);
-
-//		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("relay = %d, ", m_lastRelay));
-	buffer[offset] = NetPacketFieldTypes::PlayerId;
-	++offset;
-	buffer[offset] = cmdMsg->getPlayerID();
-	offset += sizeof(UnsignedByte);
-
-//		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("player = %d", m_lastPlayerID));
-
-	buffer[offset] = NetPacketFieldTypes::Data;
-	++offset;
+	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
+	NetPacketRouterQueryCommand* packet = reinterpret_cast<NetPacketRouterQueryCommand*>(buffer);
+	packet->commandType.header = NetPacketFieldTypes::CommandType;
+	packet->commandType.commandType = cmdMsg->getNetCommandType();
+	packet->relay.header = NetPacketFieldTypes::Relay;
+	packet->relay.relay = msg->getRelay();
+	packet->playerId.header = NetPacketFieldTypes::PlayerId;
+	packet->playerId.playerId = cmdMsg->getPlayerID();
+	packet->dataHeader.header = NetPacketFieldTypes::Data;
 }
 
 void NetPacket::FillBufferWithPacketRouterAckCommand(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetPacketRouterAckCommandMsg *cmdMsg = (NetPacketRouterAckCommandMsg *)(msg->getCommand());
-	UnsignedShort offset = 0;
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addPacketRouterAckCommand - adding packet router query command"));
 
-	// If necessary, put the NetCommandType into the packet.
-	buffer[offset] = NetPacketFieldTypes::CommandType;
-	++offset;
-	buffer[offset] = cmdMsg->getNetCommandType();
-	offset += sizeof(UnsignedByte);
-
-	// If necessary, put the relay into the packet.
-	buffer[offset] = NetPacketFieldTypes::Relay;
-	++offset;
-	UnsignedByte newRelay = msg->getRelay();
-	memcpy(buffer+offset, &newRelay, sizeof(UnsignedByte));
-	offset += sizeof(UnsignedByte);
-
-//		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("relay = %d, ", m_lastRelay));
-
-	buffer[offset] = NetPacketFieldTypes::PlayerId;
-	++offset;
-	buffer[offset] = cmdMsg->getPlayerID();
-	offset += sizeof(UnsignedByte);
-
-//		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("player = %d", m_lastPlayerID));
-
-	buffer[offset] = NetPacketFieldTypes::Data;
-	++offset;
+	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
+	NetPacketRouterAckCommand* packet = reinterpret_cast<NetPacketRouterAckCommand*>(buffer);
+	packet->commandType.header = NetPacketFieldTypes::CommandType;
+	packet->commandType.commandType = cmdMsg->getNetCommandType();
+	packet->relay.header = NetPacketFieldTypes::Relay;
+	packet->relay.relay = msg->getRelay();
+	packet->playerId.header = NetPacketFieldTypes::PlayerId;
+	packet->playerId.playerId = cmdMsg->getPlayerID();
+	packet->dataHeader.header = NetPacketFieldTypes::Data;
 }
 
 void NetPacket::FillBufferWithDisconnectChatCommand(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetDisconnectChatCommandMsg *cmdMsg = (NetDisconnectChatCommandMsg *)(msg->getCommand());
-	UnsignedShort offset = 0;
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addDisconnectChatCommand - adding run ahead command"));
 
-// If necessary, put the NetCommandType into the packet.
-	buffer[offset] = NetPacketFieldTypes::CommandType;
-	++offset;
-	buffer[offset] = cmdMsg->getNetCommandType();
-	offset += sizeof(UnsignedByte);
+	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
+	NetPacketDisconnectChatCommandHeader* packet = reinterpret_cast<NetPacketDisconnectChatCommandHeader*>(buffer);
+	packet->commandType.header = NetPacketFieldTypes::CommandType;
+	packet->commandType.commandType = cmdMsg->getNetCommandType();
+	packet->relay.header = NetPacketFieldTypes::Relay;
+	packet->relay.relay = msg->getRelay();
+	packet->playerId.header = NetPacketFieldTypes::PlayerId;
+	packet->playerId.playerId = cmdMsg->getPlayerID();
+	packet->dataHeader.header = NetPacketFieldTypes::Data;
 
-// If necessary, put the relay into the packet.
-	buffer[offset] = NetPacketFieldTypes::Relay;
-	++offset;
-	UnsignedByte newRelay = msg->getRelay();
-	memcpy(buffer+offset, &newRelay, sizeof(UnsignedByte));
-	offset += sizeof(UnsignedByte);
-
-//		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("relay = %d, ", m_lastRelay));
-
-	buffer[offset] = NetPacketFieldTypes::PlayerId;
-	++offset;
-	buffer[offset] = cmdMsg->getPlayerID();
-	offset += sizeof(UnsignedByte);
-
-//		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("player = %d", m_lastPlayerID));
-
-	buffer[offset] = NetPacketFieldTypes::Data;
-	++offset;
 	UnicodeString unitext = cmdMsg->getText();
-	UnsignedByte length = unitext.getLength();
-	memcpy(buffer + offset, &length, sizeof(UnsignedByte));
-	offset += sizeof(UnsignedByte);
+	packet->textLength = unitext.getLength();
 
-	memcpy(buffer + offset, unitext.str(), length * sizeof(UnsignedShort));
-	offset += length * sizeof(UnsignedShort);
+	// Variable data portion
+	UnsignedShort offset = sizeof(NetPacketDisconnectChatCommandHeader);
+	memcpy(buffer + offset, unitext.str(), packet->textLength * sizeof(UnsignedShort));
+	offset += packet->textLength * sizeof(UnsignedShort);
 }
 
 void NetPacket::FillBufferWithDisconnectVoteCommand(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetDisconnectVoteCommandMsg *cmdMsg = (NetDisconnectVoteCommandMsg *)(msg->getCommand());
-	UnsignedShort offset = 0;
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addDisconnectVoteCommand - adding run ahead command"));
 
-// If necessary, put the NetCommandType into the packet.
-	buffer[offset] = NetPacketFieldTypes::CommandType;
-	++offset;
-	buffer[offset] = cmdMsg->getNetCommandType();
-	offset += sizeof(UnsignedByte);
-
-// If necessary, put the relay into the packet.
-	buffer[offset] = NetPacketFieldTypes::Relay;
-	++offset;
-	UnsignedByte newRelay = msg->getRelay();
-	memcpy(buffer+offset, &newRelay, sizeof(UnsignedByte));
-	offset += sizeof(UnsignedByte);
-
-//		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("relay = %d, ", m_lastRelay));
-
-	buffer[offset] = NetPacketFieldTypes::PlayerId;
-	++offset;
-	buffer[offset] = cmdMsg->getPlayerID();
-	offset += sizeof(UnsignedByte);
-
-//		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("player = %d", m_lastPlayerID));
-
-// If necessary, specify the command ID of this command.
-	buffer[offset] = NetPacketFieldTypes::CommandId;
-	++offset;
-	UnsignedShort newID = cmdMsg->getID();
-	memcpy(buffer + offset, &newID, sizeof(UnsignedShort));
-	offset += sizeof(UnsignedShort);
-
-//		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("command id = %d", m_lastCommandID));
-
-	buffer[offset] = NetPacketFieldTypes::Data;
-	++offset;
-	UnsignedByte slot = cmdMsg->getSlot();
-	memcpy(buffer + offset, &slot, sizeof(slot));
-	offset += sizeof(slot);
-
-	UnsignedInt voteFrame = cmdMsg->getVoteFrame();
-	memcpy(buffer + offset, &voteFrame, sizeof(voteFrame));
-	offset += sizeof(voteFrame);
+	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
+	NetPacketDisconnectVoteCommand* packet = reinterpret_cast<NetPacketDisconnectVoteCommand*>(buffer);
+	packet->commandType.header = NetPacketFieldTypes::CommandType;
+	packet->commandType.commandType = cmdMsg->getNetCommandType();
+	packet->relay.header = NetPacketFieldTypes::Relay;
+	packet->relay.relay = msg->getRelay();
+	packet->playerId.header = NetPacketFieldTypes::PlayerId;
+	packet->playerId.playerId = cmdMsg->getPlayerID();
+	packet->commandId.header = NetPacketFieldTypes::CommandId;
+	packet->commandId.commandId = cmdMsg->getID();
+	packet->dataHeader.header = NetPacketFieldTypes::Data;
+	packet->slot = cmdMsg->getSlot();
+	packet->voteFrame = cmdMsg->getVoteFrame();
 }
 
 void NetPacket::FillBufferWithChatCommand(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetChatCommandMsg *cmdMsg = static_cast<NetChatCommandMsg *>(msg->getCommand());
-	UnsignedShort offset = 0;
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addDisconnectChatCommand - adding run ahead command"));
 
-// If necessary, put the NetCommandType into the packet.
-	buffer[offset] = NetPacketFieldTypes::CommandType;
-	++offset;
-	buffer[offset] = cmdMsg->getNetCommandType();
-	offset += sizeof(UnsignedByte);
+	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
+	NetPacketChatCommandHeader* packet = reinterpret_cast<NetPacketChatCommandHeader*>(buffer);
+	packet->commandType.header = NetPacketFieldTypes::CommandType;
+	packet->commandType.commandType = cmdMsg->getNetCommandType();
+	packet->frame.header = NetPacketFieldTypes::Frame;
+	packet->frame.frame = cmdMsg->getExecutionFrame();
+	packet->relay.header = NetPacketFieldTypes::Relay;
+	packet->relay.relay = msg->getRelay();
+	packet->playerId.header = NetPacketFieldTypes::PlayerId;
+	packet->playerId.playerId = cmdMsg->getPlayerID();
+	packet->commandId.header = NetPacketFieldTypes::CommandId;
+	packet->commandId.commandId = cmdMsg->getID();
+	packet->dataHeader.header = NetPacketFieldTypes::Data;
 
-// If necessary, put the execution frame into the packet.
-	buffer[offset] = NetPacketFieldTypes::Frame;
-	++offset;
-	UnsignedInt newframe = cmdMsg->getExecutionFrame();
-	memcpy(buffer+offset, &newframe, sizeof(UnsignedInt));
-	offset += sizeof(UnsignedInt);
-
-// If necessary, put the relay into the packet.
-	buffer[offset] = NetPacketFieldTypes::Relay;
-	++offset;
-	UnsignedByte newRelay = msg->getRelay();
-	memcpy(buffer+offset, &newRelay, sizeof(UnsignedByte));
-	offset += sizeof(UnsignedByte);
-
-//		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("relay = %d, ", m_lastRelay));
-
-	buffer[offset] = NetPacketFieldTypes::PlayerId;
-	++offset;
-	buffer[offset] = cmdMsg->getPlayerID();
-	offset += sizeof(UnsignedByte);
-
-//		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("player = %d", m_lastPlayerID));
-
-// If necessary, specify the command ID of this command.
-	buffer[offset] = NetPacketFieldTypes::CommandId;
-	++offset;
-	UnsignedShort newID = cmdMsg->getID();
-	memcpy(buffer + offset, &newID, sizeof(UnsignedShort));
-	offset += sizeof(UnsignedShort);
-
-//		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("command id = %d", m_lastCommandID));
-
-	buffer[offset] = NetPacketFieldTypes::Data;
-	++offset;
 	UnicodeString unitext = cmdMsg->getText();
-	UnsignedByte length = unitext.getLength();
+	packet->textLength = unitext.getLength();
+
+	// Variable data portion
+	UnsignedShort offset = sizeof(NetPacketChatCommandHeader);
+	memcpy(buffer + offset, unitext.str(), packet->textLength * sizeof(UnsignedShort));
+	offset += packet->textLength * sizeof(UnsignedShort);
+
 	Int playerMask = cmdMsg->getPlayerMask();
-	memcpy(buffer + offset, &length, sizeof(UnsignedByte));
-	offset += sizeof(UnsignedByte);
-
-	memcpy(buffer + offset, unitext.str(), length * sizeof(UnsignedShort));
-	offset += length * sizeof(UnsignedShort);
-
 	memcpy(buffer + offset, &playerMask, sizeof(Int));
 	offset += sizeof(Int);
 }
 
 void NetPacket::FillBufferWithProgressMessage(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetProgressCommandMsg *cmdMsg = (NetProgressCommandMsg *)(msg->getCommand());
-	UnsignedShort offset = 0;
 
-// If necessary, put the NetCommandType into the packet.
-	buffer[offset] = NetPacketFieldTypes::CommandType;
-	++offset;
-	buffer[offset] = cmdMsg->getNetCommandType();
-	offset += sizeof(UnsignedByte);
-
-// If necessary, put the relay into the packet.
-	buffer[offset] = NetPacketFieldTypes::Relay;
-	++offset;
-	UnsignedByte newRelay = msg->getRelay();
-	memcpy(buffer+offset, &newRelay, sizeof(UnsignedByte));
-	offset += sizeof(UnsignedByte);
-
-// Put the player ID into the packet.
-	buffer[offset] = NetPacketFieldTypes::PlayerId;
-	++offset;
-	buffer[offset] = cmdMsg->getPlayerID();
-	offset += sizeof(UnsignedByte);
-
-	buffer[offset] = NetPacketFieldTypes::Data;
-	++offset;
-
-	buffer[offset] = cmdMsg->getPercentage();
-	++offset;
+	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
+	NetPacketProgressMessage* packet = reinterpret_cast<NetPacketProgressMessage*>(buffer);
+	packet->commandType.header = NetPacketFieldTypes::CommandType;
+	packet->commandType.commandType = cmdMsg->getNetCommandType();
+	packet->relay.header = NetPacketFieldTypes::Relay;
+	packet->relay.relay = msg->getRelay();
+	packet->playerId.header = NetPacketFieldTypes::PlayerId;
+	packet->playerId.playerId = cmdMsg->getPlayerID();
+	packet->dataHeader.header = NetPacketFieldTypes::Data;
+	packet->percentage = cmdMsg->getPercentage();
 }
 
 void NetPacket::FillBufferWithLoadCompleteMessage(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetCommandMsg *cmdMsg = static_cast<NetCommandMsg *>(msg->getCommand());
-	UnsignedShort offset = 0;
 
-// If necessary, put the NetCommandType into the packet.
-	buffer[offset] = NetPacketFieldTypes::CommandType;
-	++offset;
-	buffer[offset] = cmdMsg->getNetCommandType();
-	offset += sizeof(UnsignedByte);
-
-// If necessary, put the relay into the packet.
-	buffer[offset] = NetPacketFieldTypes::Relay;
-	++offset;
-	UnsignedByte newRelay = msg->getRelay();
-	memcpy(buffer+offset, &newRelay, sizeof(UnsignedByte));
-	offset += sizeof(UnsignedByte);
-
-	buffer[offset] = NetPacketFieldTypes::PlayerId;
-	++offset;
-	buffer[offset] = cmdMsg->getPlayerID();
-	offset += sizeof(UnsignedByte);
-
-// If necessary, specify the command ID of this command.
-	buffer[offset] = NetPacketFieldTypes::CommandId;
-	++offset;
-	UnsignedShort newID = cmdMsg->getID();
-	memcpy(buffer + offset, &newID, sizeof(UnsignedShort));
-	offset += sizeof(UnsignedShort);
-
-	buffer[offset] = NetPacketFieldTypes::Data;
-	++offset;
+	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
+	NetPacketLoadCompleteMessage* packet = reinterpret_cast<NetPacketLoadCompleteMessage*>(buffer);
+	packet->commandType.header = NetPacketFieldTypes::CommandType;
+	packet->commandType.commandType = cmdMsg->getNetCommandType();
+	packet->relay.header = NetPacketFieldTypes::Relay;
+	packet->relay.relay = msg->getRelay();
+	packet->playerId.header = NetPacketFieldTypes::PlayerId;
+	packet->playerId.playerId = cmdMsg->getPlayerID();
+	packet->commandId.header = NetPacketFieldTypes::CommandId;
+	packet->commandId.commandId = cmdMsg->getID();
+	packet->dataHeader.header = NetPacketFieldTypes::Data;
 }
 
 void NetPacket::FillBufferWithTimeOutGameStartMessage(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetCommandMsg *cmdMsg = static_cast<NetCommandMsg *>(msg->getCommand());
-	UnsignedShort offset = 0;
 
-// If necessary, put the NetCommandType into the packet.
-	buffer[offset] = NetPacketFieldTypes::CommandType;
-	++offset;
-	buffer[offset] = cmdMsg->getNetCommandType();
-	offset += sizeof(UnsignedByte);
-
-// If necessary, put the relay into the packet.
-	buffer[offset] = NetPacketFieldTypes::Relay;
-	++offset;
-	UnsignedByte newRelay = msg->getRelay();
-	memcpy(buffer+offset, &newRelay, sizeof(UnsignedByte));
-	offset += sizeof(UnsignedByte);
-	buffer[offset] = NetPacketFieldTypes::PlayerId;
-	++offset;
-	buffer[offset] = cmdMsg->getPlayerID();
-	offset += sizeof(UnsignedByte);
-
-// If necessary, specify the command ID of this command.
-	buffer[offset] = NetPacketFieldTypes::CommandId;
-	++offset;
-	UnsignedShort newID = cmdMsg->getID();
-	memcpy(buffer + offset, &newID, sizeof(UnsignedShort));
-	offset += sizeof(UnsignedShort);
-
-	buffer[offset] = NetPacketFieldTypes::Data;
-	++offset;
+	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
+	NetPacketTimeOutGameStartMessage* packet = reinterpret_cast<NetPacketTimeOutGameStartMessage*>(buffer);
+	packet->commandType.header = NetPacketFieldTypes::CommandType;
+	packet->commandType.commandType = cmdMsg->getNetCommandType();
+	packet->relay.header = NetPacketFieldTypes::Relay;
+	packet->relay.relay = msg->getRelay();
+	packet->playerId.header = NetPacketFieldTypes::PlayerId;
+	packet->playerId.playerId = cmdMsg->getPlayerID();
+	packet->commandId.header = NetPacketFieldTypes::CommandId;
+	packet->commandId.commandId = cmdMsg->getID();
+	packet->dataHeader.header = NetPacketFieldTypes::Data;
 }
 
 void NetPacket::FillBufferWithFileMessage(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetFileCommandMsg *cmdMsg = static_cast<NetFileCommandMsg *>(msg->getCommand());
-	UnsignedInt offset = 0;
 
-	// command type
-	buffer[offset] = NetPacketFieldTypes::CommandType;
-	++offset;
-	buffer[offset] = cmdMsg->getNetCommandType();
-	offset += sizeof(UnsignedByte);
+	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
+	NetPacketFileCommand* packet = reinterpret_cast<NetPacketFileCommand*>(buffer);
+	packet->commandType.header = NetPacketFieldTypes::CommandType;
+	packet->commandType.commandType = cmdMsg->getNetCommandType();
+	packet->relay.header = NetPacketFieldTypes::Relay;
+	packet->relay.relay = msg->getRelay();
+	packet->playerId.header = NetPacketFieldTypes::PlayerId;
+	packet->playerId.playerId = cmdMsg->getPlayerID();
+	packet->commandId.header = NetPacketFieldTypes::CommandId;
+	packet->commandId.commandId = cmdMsg->getID();
+	packet->dataHeader.header = NetPacketFieldTypes::Data;
 
-	// relay
-	buffer[offset] = NetPacketFieldTypes::Relay;
-	++offset;
-	buffer[offset] = msg->getRelay();
-	offset += sizeof(UnsignedByte);
-
-	// player ID
-	buffer[offset] = NetPacketFieldTypes::PlayerId;
-	++offset;
-	buffer[offset] = cmdMsg->getPlayerID();
-	offset += sizeof(UnsignedByte);
-
-	// command ID
-	buffer[offset] = NetPacketFieldTypes::CommandId;
-	++offset;
-	UnsignedShort newID = cmdMsg->getID();
-	memcpy(buffer + offset, &newID, sizeof(newID));
-	offset += sizeof(newID);
-
-	// data
-	buffer[offset] = NetPacketFieldTypes::Data;
-	++offset;
+	// Variable data portion
+	UnsignedInt offset = sizeof(NetPacketFileCommand);
 
 	AsciiString filename = cmdMsg->getPortableFilename();	// PORTABLE
 	for (Int i = 0; i < filename.getLength(); ++i) {
@@ -1265,36 +867,21 @@ void NetPacket::FillBufferWithFileMessage(UnsignedByte *buffer, NetCommandRef *m
 
 void NetPacket::FillBufferWithFileAnnounceMessage(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetFileAnnounceCommandMsg *cmdMsg = static_cast<NetFileAnnounceCommandMsg *>(msg->getCommand());
-	UnsignedInt offset = 0;
 
-	// command type
-	buffer[offset] = NetPacketFieldTypes::CommandType;
-	++offset;
-	buffer[offset] = cmdMsg->getNetCommandType();
-	offset += sizeof(UnsignedByte);
+	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
+	NetPacketFileAnnounceCommand* packet = reinterpret_cast<NetPacketFileAnnounceCommand*>(buffer);
+	packet->commandType.header = NetPacketFieldTypes::CommandType;
+	packet->commandType.commandType = cmdMsg->getNetCommandType();
+	packet->relay.header = NetPacketFieldTypes::Relay;
+	packet->relay.relay = msg->getRelay();
+	packet->playerId.header = NetPacketFieldTypes::PlayerId;
+	packet->playerId.playerId = cmdMsg->getPlayerID();
+	packet->commandId.header = NetPacketFieldTypes::CommandId;
+	packet->commandId.commandId = cmdMsg->getID();
+	packet->dataHeader.header = NetPacketFieldTypes::Data;
 
-	// relay
-	buffer[offset] = NetPacketFieldTypes::Relay;
-	++offset;
-	buffer[offset] = msg->getRelay();
-	offset += sizeof(UnsignedByte);
-
-	// player ID
-	buffer[offset] = NetPacketFieldTypes::PlayerId;
-	++offset;
-	buffer[offset] = cmdMsg->getPlayerID();
-	offset += sizeof(UnsignedByte);
-
-	// command ID
-	buffer[offset] = NetPacketFieldTypes::CommandId;
-	++offset;
-	UnsignedShort newID = cmdMsg->getID();
-	memcpy(buffer + offset, &newID, sizeof(newID));
-	offset += sizeof(newID);
-
-	// data
-	buffer[offset] = NetPacketFieldTypes::Data;
-	++offset;
+	// Variable data portion
+	UnsignedInt offset = sizeof(NetPacketFileAnnounceCommand);
 
 	AsciiString filename = cmdMsg->getPortableFilename();	// PORTABLE
 	for (Int i = 0; i < filename.getLength(); ++i) {
@@ -1315,158 +902,71 @@ void NetPacket::FillBufferWithFileAnnounceMessage(UnsignedByte *buffer, NetComma
 
 void NetPacket::FillBufferWithFileProgressMessage(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetFileProgressCommandMsg *cmdMsg = (NetFileProgressCommandMsg *)(msg->getCommand());
-	UnsignedInt offset = 0;
 
-	// command type
-	buffer[offset] = NetPacketFieldTypes::CommandType;
-	++offset;
-	buffer[offset] = cmdMsg->getNetCommandType();
-	offset += sizeof(UnsignedByte);
-
-	// relay
-	buffer[offset] = NetPacketFieldTypes::Relay;
-	++offset;
-	buffer[offset] = msg->getRelay();
-	offset += sizeof(UnsignedByte);
-
-	// player ID
-	buffer[offset] = NetPacketFieldTypes::PlayerId;
-	++offset;
-	buffer[offset] = cmdMsg->getPlayerID();
-	offset += sizeof(UnsignedByte);
-
-	// command ID
-	buffer[offset] = NetPacketFieldTypes::CommandId;
-	++offset;
-	UnsignedShort newID = cmdMsg->getID();
-	memcpy(buffer + offset, &newID, sizeof(newID));
-	offset += sizeof(newID);
-
-	// data
-	buffer[offset] = NetPacketFieldTypes::Data;
-	++offset;
-
-	UnsignedShort fileID = cmdMsg->getFileID();
-	memcpy(buffer + offset, &fileID, sizeof(fileID));
-	offset += sizeof(fileID);
-
-	Int progress = cmdMsg->getProgress();
-	memcpy(buffer + offset, &progress, sizeof(progress));
-	offset += sizeof(progress);
+	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
+	NetPacketFileProgressCommand* packet = reinterpret_cast<NetPacketFileProgressCommand*>(buffer);
+	packet->commandType.header = NetPacketFieldTypes::CommandType;
+	packet->commandType.commandType = cmdMsg->getNetCommandType();
+	packet->relay.header = NetPacketFieldTypes::Relay;
+	packet->relay.relay = msg->getRelay();
+	packet->playerId.header = NetPacketFieldTypes::PlayerId;
+	packet->playerId.playerId = cmdMsg->getPlayerID();
+	packet->commandId.header = NetPacketFieldTypes::CommandId;
+	packet->commandId.commandId = cmdMsg->getID();
+	packet->dataHeader.header = NetPacketFieldTypes::Data;
+	packet->fileId = cmdMsg->getFileID();
+	packet->progress = cmdMsg->getProgress();
 }
 
 void NetPacket::FillBufferWithDisconnectFrameMessage(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetDisconnectFrameCommandMsg *cmdMsg = (NetDisconnectFrameCommandMsg *)(msg->getCommand());
-	UnsignedInt offset = 0;
 
-	// command type
-	buffer[offset] = NetPacketFieldTypes::CommandType;
-	++offset;
-	buffer[offset] = cmdMsg->getNetCommandType();
-	offset += sizeof(UnsignedByte);
-
-	// relay
-	buffer[offset] = NetPacketFieldTypes::Relay;
-	++offset;
-	buffer[offset] = msg->getRelay();
-	offset += sizeof(UnsignedByte);
-
-	// player ID
-	buffer[offset] = NetPacketFieldTypes::PlayerId;
-	++offset;
-	buffer[offset] = cmdMsg->getPlayerID();
-	offset += sizeof(UnsignedByte);
-
-	// command ID
-	buffer[offset] = NetPacketFieldTypes::CommandId;
-	++offset;
-	UnsignedShort newID = cmdMsg->getID();
-	memcpy(buffer + offset, &newID, sizeof(newID));
-	offset += sizeof(newID);
-
-	// data
-	buffer[offset] = NetPacketFieldTypes::Data;
-	++offset;
-
-	UnsignedInt disconnectFrame = cmdMsg->getDisconnectFrame();
-	memcpy(buffer + offset, &disconnectFrame, sizeof(disconnectFrame));
-	offset += sizeof(disconnectFrame);
+	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
+	NetPacketDisconnectFrameCommand* packet = reinterpret_cast<NetPacketDisconnectFrameCommand*>(buffer);
+	packet->commandType.header = NetPacketFieldTypes::CommandType;
+	packet->commandType.commandType = cmdMsg->getNetCommandType();
+	packet->relay.header = NetPacketFieldTypes::Relay;
+	packet->relay.relay = msg->getRelay();
+	packet->playerId.header = NetPacketFieldTypes::PlayerId;
+	packet->playerId.playerId = cmdMsg->getPlayerID();
+	packet->commandId.header = NetPacketFieldTypes::CommandId;
+	packet->commandId.commandId = cmdMsg->getID();
+	packet->dataHeader.header = NetPacketFieldTypes::Data;
+	packet->disconnectFrame = cmdMsg->getDisconnectFrame();
 }
 
 void NetPacket::FillBufferWithDisconnectScreenOffMessage(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetDisconnectScreenOffCommandMsg *cmdMsg = (NetDisconnectScreenOffCommandMsg *)(msg->getCommand());
-	UnsignedInt offset = 0;
 
-	// command type
-	buffer[offset] = NetPacketFieldTypes::CommandType;
-	++offset;
-	buffer[offset] = cmdMsg->getNetCommandType();
-	offset += sizeof(UnsignedByte);
-
-	// relay
-	buffer[offset] = NetPacketFieldTypes::Relay;
-	++offset;
-	buffer[offset] = msg->getRelay();
-	offset += sizeof(UnsignedByte);
-
-	// player ID
-	buffer[offset] = NetPacketFieldTypes::PlayerId;
-	++offset;
-	buffer[offset] = cmdMsg->getPlayerID();
-	offset += sizeof(UnsignedByte);
-
-	// command ID
-	buffer[offset] = NetPacketFieldTypes::CommandId;
-	++offset;
-	UnsignedShort newID = cmdMsg->getID();
-	memcpy(buffer + offset, &newID, sizeof(newID));
-	offset += sizeof(newID);
-
-	// data
-	buffer[offset] = NetPacketFieldTypes::Data;
-	++offset;
-
-	UnsignedInt newFrame = cmdMsg->getNewFrame();
-	memcpy(buffer + offset, &newFrame, sizeof(newFrame));
-	offset += sizeof(newFrame);
+	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
+	NetPacketDisconnectScreenOffCommand* packet = reinterpret_cast<NetPacketDisconnectScreenOffCommand*>(buffer);
+	packet->commandType.header = NetPacketFieldTypes::CommandType;
+	packet->commandType.commandType = cmdMsg->getNetCommandType();
+	packet->relay.header = NetPacketFieldTypes::Relay;
+	packet->relay.relay = msg->getRelay();
+	packet->playerId.header = NetPacketFieldTypes::PlayerId;
+	packet->playerId.playerId = cmdMsg->getPlayerID();
+	packet->commandId.header = NetPacketFieldTypes::CommandId;
+	packet->commandId.commandId = cmdMsg->getID();
+	packet->dataHeader.header = NetPacketFieldTypes::Data;
+	packet->newFrame = cmdMsg->getNewFrame();
 }
 
 void NetPacket::FillBufferWithFrameResendRequestMessage(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetFrameResendRequestCommandMsg *cmdMsg = (NetFrameResendRequestCommandMsg *)(msg->getCommand());
-	UnsignedInt offset = 0;
 
-	// command type
-	buffer[offset] = NetPacketFieldTypes::CommandType;
-	++offset;
-	buffer[offset] = cmdMsg->getNetCommandType();
-	offset += sizeof(UnsignedByte);
-
-	// relay
-	buffer[offset] = NetPacketFieldTypes::Relay;
-	++offset;
-	buffer[offset] = msg->getRelay();
-	offset += sizeof(UnsignedByte);
-
-	// player ID
-	buffer[offset] = NetPacketFieldTypes::PlayerId;
-	++offset;
-	buffer[offset] = cmdMsg->getPlayerID();
-	offset += sizeof(UnsignedByte);
-
-	// command ID
-	buffer[offset] = NetPacketFieldTypes::CommandId;
-	++offset;
-	UnsignedShort newID = cmdMsg->getID();
-	memcpy(buffer + offset, &newID, sizeof(newID));
-	offset += sizeof(newID);
-
-	// data
-	buffer[offset] = NetPacketFieldTypes::Data;
-	++offset;
-
-	UnsignedInt frameToResend = cmdMsg->getFrameToResend();
-	memcpy(buffer + offset, &frameToResend, sizeof(frameToResend));
-	offset += sizeof(frameToResend);
+	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
+	NetPacketFrameResendRequestCommand* packet = reinterpret_cast<NetPacketFrameResendRequestCommand*>(buffer);
+	packet->commandType.header = NetPacketFieldTypes::CommandType;
+	packet->commandType.commandType = cmdMsg->getNetCommandType();
+	packet->relay.header = NetPacketFieldTypes::Relay;
+	packet->relay.relay = msg->getRelay();
+	packet->playerId.header = NetPacketFieldTypes::PlayerId;
+	packet->playerId.playerId = cmdMsg->getPlayerID();
+	packet->commandId.header = NetPacketFieldTypes::CommandId;
+	packet->commandId.commandId = cmdMsg->getID();
+	packet->dataHeader.header = NetPacketFieldTypes::Data;
+	packet->frameToResend = cmdMsg->getFrameToResend();
 }
 
 

--- a/Core/GameEngine/Source/GameNetwork/NetPacket.cpp
+++ b/Core/GameEngine/Source/GameNetwork/NetPacket.cpp
@@ -33,6 +33,7 @@
 #include "GameNetwork/GameMessageParser.h"
 #include "GameNetwork/NetPacketStructs.h"
 
+// TheSuperHackers @refactor BobTista 31/12/2025 Use packed structs for FillBufferWithXXX serialization
 
 // This function assumes that all of the fields are either of default value or are
 // present in the raw data.
@@ -376,7 +377,6 @@ void NetPacket::FillBufferWithGameCommand(UnsignedByte *buffer, NetCommandRef *m
 
 	//DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::FillBufferWithGameCommand for command ID %d", cmdMsg->getID()));
 
-	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for fixed header portion
 	NetPacketGameCommandHeader* packet = reinterpret_cast<NetPacketGameCommandHeader*>(buffer);
 	packet->commandType.header = NetPacketFieldTypes::CommandType;
 	packet->commandType.commandType = cmdMsg->getNetCommandType();
@@ -516,7 +516,6 @@ void NetPacket::FillBufferWithAckCommand(UnsignedByte *buffer, NetCommandRef *ms
 
 	}
 
-	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
 	NetPacketAckCommand* packet = reinterpret_cast<NetPacketAckCommand*>(buffer);
 	packet->commandType.header = NetPacketFieldTypes::CommandType;
 	packet->commandType.commandType = type;
@@ -533,7 +532,6 @@ void NetPacket::FillBufferWithFrameCommand(UnsignedByte *buffer, NetCommandRef *
 	NetFrameCommandMsg *cmdMsg = static_cast<NetFrameCommandMsg *>(msg->getCommand());
 	//		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addFrameCommand - adding frame command for frame %d, command count = %d, command id = %d", cmdMsg->getExecutionFrame(), cmdMsg->getCommandCount(), cmdMsg->getID()));
 
-	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
 	NetPacketFrameCommand* packet = reinterpret_cast<NetPacketFrameCommand*>(buffer);
 	packet->commandType.header = NetPacketFieldTypes::CommandType;
 	packet->commandType.commandType = cmdMsg->getNetCommandType();
@@ -556,7 +554,6 @@ void NetPacket::FillBufferWithPlayerLeaveCommand(UnsignedByte *buffer, NetComman
 	NetPlayerLeaveCommandMsg *cmdMsg = static_cast<NetPlayerLeaveCommandMsg *>(msg->getCommand());
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addPlayerLeaveCommand - adding player leave command for player %d", cmdMsg->getLeavingPlayerID()));
 
-	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
 	NetPacketPlayerLeaveCommand* packet = reinterpret_cast<NetPacketPlayerLeaveCommand*>(buffer);
 	packet->commandType.header = NetPacketFieldTypes::CommandType;
 	packet->commandType.commandType = cmdMsg->getNetCommandType();
@@ -576,7 +573,6 @@ void NetPacket::FillBufferWithRunAheadMetricsCommand(UnsignedByte *buffer, NetCo
 	NetRunAheadMetricsCommandMsg *cmdMsg = static_cast<NetRunAheadMetricsCommandMsg *>(msg->getCommand());
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addRunAheadMetricsCommand - adding run ahead metrics for player %d, fps = %d, latency = %f", cmdMsg->getPlayerID(), cmdMsg->getAverageFps(), cmdMsg->getAverageLatency()));
 
-	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
 	NetPacketRunAheadMetricsCommand* packet = reinterpret_cast<NetPacketRunAheadMetricsCommand*>(buffer);
 	packet->commandType.header = NetPacketFieldTypes::CommandType;
 	packet->commandType.commandType = cmdMsg->getNetCommandType();
@@ -595,7 +591,6 @@ void NetPacket::FillBufferWithRunAheadCommand(UnsignedByte *buffer, NetCommandRe
 	NetRunAheadCommandMsg *cmdMsg = static_cast<NetRunAheadCommandMsg *>(msg->getCommand());
 	//DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::FillBufferWithRunAheadCommand - adding run ahead command"));
 
-	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
 	NetPacketRunAheadCommand* packet = reinterpret_cast<NetPacketRunAheadCommand*>(buffer);
 	packet->commandType.header = NetPacketFieldTypes::CommandType;
 	packet->commandType.commandType = cmdMsg->getNetCommandType();
@@ -618,7 +613,6 @@ void NetPacket::FillBufferWithDestroyPlayerCommand(UnsignedByte *buffer, NetComm
 	NetDestroyPlayerCommandMsg *cmdMsg = static_cast<NetDestroyPlayerCommandMsg *>(msg->getCommand());
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addRunAheadCommand - adding run ahead command"));
 
-	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
 	NetPacketDestroyPlayerCommand* packet = reinterpret_cast<NetPacketDestroyPlayerCommand*>(buffer);
 	packet->commandType.header = NetPacketFieldTypes::CommandType;
 	packet->commandType.commandType = cmdMsg->getNetCommandType();
@@ -637,7 +631,6 @@ void NetPacket::FillBufferWithDestroyPlayerCommand(UnsignedByte *buffer, NetComm
 void NetPacket::FillBufferWithKeepAliveCommand(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetKeepAliveCommandMsg *cmdMsg = static_cast<NetKeepAliveCommandMsg *>(msg->getCommand());
 
-	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
 	NetPacketKeepAliveCommand* packet = reinterpret_cast<NetPacketKeepAliveCommand*>(buffer);
 	packet->commandType.header = NetPacketFieldTypes::CommandType;
 	packet->commandType.commandType = cmdMsg->getNetCommandType();
@@ -651,7 +644,6 @@ void NetPacket::FillBufferWithKeepAliveCommand(UnsignedByte *buffer, NetCommandR
 void NetPacket::FillBufferWithDisconnectKeepAliveCommand(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetDisconnectKeepAliveCommandMsg *cmdMsg = static_cast<NetDisconnectKeepAliveCommandMsg *>(msg->getCommand());
 
-	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
 	NetPacketDisconnectKeepAliveCommand* packet = reinterpret_cast<NetPacketDisconnectKeepAliveCommand*>(buffer);
 	packet->commandType.header = NetPacketFieldTypes::CommandType;
 	packet->commandType.commandType = cmdMsg->getNetCommandType();
@@ -666,7 +658,6 @@ void NetPacket::FillBufferWithDisconnectPlayerCommand(UnsignedByte *buffer, NetC
 	NetDisconnectPlayerCommandMsg *cmdMsg = static_cast<NetDisconnectPlayerCommandMsg *>(msg->getCommand());
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addDisconnectPlayerCommand - adding run ahead command"));
 
-	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
 	NetPacketDisconnectPlayerCommand* packet = reinterpret_cast<NetPacketDisconnectPlayerCommand*>(buffer);
 	packet->commandType.header = NetPacketFieldTypes::CommandType;
 	packet->commandType.commandType = cmdMsg->getNetCommandType();
@@ -685,7 +676,6 @@ void NetPacket::FillBufferWithPacketRouterQueryCommand(UnsignedByte *buffer, Net
 	NetPacketRouterQueryCommandMsg *cmdMsg = static_cast<NetPacketRouterQueryCommandMsg *>(msg->getCommand());
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addPacketRouterQueryCommand - adding packet router query command"));
 
-	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
 	NetPacketRouterQueryCommand* packet = reinterpret_cast<NetPacketRouterQueryCommand*>(buffer);
 	packet->commandType.header = NetPacketFieldTypes::CommandType;
 	packet->commandType.commandType = cmdMsg->getNetCommandType();
@@ -700,7 +690,6 @@ void NetPacket::FillBufferWithPacketRouterAckCommand(UnsignedByte *buffer, NetCo
 	NetPacketRouterAckCommandMsg *cmdMsg = (NetPacketRouterAckCommandMsg *)(msg->getCommand());
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addPacketRouterAckCommand - adding packet router query command"));
 
-	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
 	NetPacketRouterAckCommand* packet = reinterpret_cast<NetPacketRouterAckCommand*>(buffer);
 	packet->commandType.header = NetPacketFieldTypes::CommandType;
 	packet->commandType.commandType = cmdMsg->getNetCommandType();
@@ -715,7 +704,6 @@ void NetPacket::FillBufferWithDisconnectChatCommand(UnsignedByte *buffer, NetCom
 	NetDisconnectChatCommandMsg *cmdMsg = (NetDisconnectChatCommandMsg *)(msg->getCommand());
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addDisconnectChatCommand - adding run ahead command"));
 
-	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
 	NetPacketDisconnectChatCommandHeader* packet = reinterpret_cast<NetPacketDisconnectChatCommandHeader*>(buffer);
 	packet->commandType.header = NetPacketFieldTypes::CommandType;
 	packet->commandType.commandType = cmdMsg->getNetCommandType();
@@ -738,7 +726,6 @@ void NetPacket::FillBufferWithDisconnectVoteCommand(UnsignedByte *buffer, NetCom
 	NetDisconnectVoteCommandMsg *cmdMsg = (NetDisconnectVoteCommandMsg *)(msg->getCommand());
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addDisconnectVoteCommand - adding run ahead command"));
 
-	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
 	NetPacketDisconnectVoteCommand* packet = reinterpret_cast<NetPacketDisconnectVoteCommand*>(buffer);
 	packet->commandType.header = NetPacketFieldTypes::CommandType;
 	packet->commandType.commandType = cmdMsg->getNetCommandType();
@@ -757,7 +744,6 @@ void NetPacket::FillBufferWithChatCommand(UnsignedByte *buffer, NetCommandRef *m
 	NetChatCommandMsg *cmdMsg = static_cast<NetChatCommandMsg *>(msg->getCommand());
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addDisconnectChatCommand - adding run ahead command"));
 
-	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
 	NetPacketChatCommandHeader* packet = reinterpret_cast<NetPacketChatCommandHeader*>(buffer);
 	packet->commandType.header = NetPacketFieldTypes::CommandType;
 	packet->commandType.commandType = cmdMsg->getNetCommandType();
@@ -787,7 +773,6 @@ void NetPacket::FillBufferWithChatCommand(UnsignedByte *buffer, NetCommandRef *m
 void NetPacket::FillBufferWithProgressMessage(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetProgressCommandMsg *cmdMsg = (NetProgressCommandMsg *)(msg->getCommand());
 
-	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
 	NetPacketProgressMessage* packet = reinterpret_cast<NetPacketProgressMessage*>(buffer);
 	packet->commandType.header = NetPacketFieldTypes::CommandType;
 	packet->commandType.commandType = cmdMsg->getNetCommandType();
@@ -802,7 +787,6 @@ void NetPacket::FillBufferWithProgressMessage(UnsignedByte *buffer, NetCommandRe
 void NetPacket::FillBufferWithLoadCompleteMessage(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetCommandMsg *cmdMsg = static_cast<NetCommandMsg *>(msg->getCommand());
 
-	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
 	NetPacketLoadCompleteMessage* packet = reinterpret_cast<NetPacketLoadCompleteMessage*>(buffer);
 	packet->commandType.header = NetPacketFieldTypes::CommandType;
 	packet->commandType.commandType = cmdMsg->getNetCommandType();
@@ -818,7 +802,6 @@ void NetPacket::FillBufferWithLoadCompleteMessage(UnsignedByte *buffer, NetComma
 void NetPacket::FillBufferWithTimeOutGameStartMessage(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetCommandMsg *cmdMsg = static_cast<NetCommandMsg *>(msg->getCommand());
 
-	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
 	NetPacketTimeOutGameStartMessage* packet = reinterpret_cast<NetPacketTimeOutGameStartMessage*>(buffer);
 	packet->commandType.header = NetPacketFieldTypes::CommandType;
 	packet->commandType.commandType = cmdMsg->getNetCommandType();
@@ -834,7 +817,6 @@ void NetPacket::FillBufferWithTimeOutGameStartMessage(UnsignedByte *buffer, NetC
 void NetPacket::FillBufferWithFileMessage(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetFileCommandMsg *cmdMsg = static_cast<NetFileCommandMsg *>(msg->getCommand());
 
-	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
 	NetPacketFileCommand* packet = reinterpret_cast<NetPacketFileCommand*>(buffer);
 	packet->commandType.header = NetPacketFieldTypes::CommandType;
 	packet->commandType.commandType = cmdMsg->getNetCommandType();
@@ -868,7 +850,6 @@ void NetPacket::FillBufferWithFileMessage(UnsignedByte *buffer, NetCommandRef *m
 void NetPacket::FillBufferWithFileAnnounceMessage(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetFileAnnounceCommandMsg *cmdMsg = static_cast<NetFileAnnounceCommandMsg *>(msg->getCommand());
 
-	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
 	NetPacketFileAnnounceCommand* packet = reinterpret_cast<NetPacketFileAnnounceCommand*>(buffer);
 	packet->commandType.header = NetPacketFieldTypes::CommandType;
 	packet->commandType.commandType = cmdMsg->getNetCommandType();
@@ -903,7 +884,6 @@ void NetPacket::FillBufferWithFileAnnounceMessage(UnsignedByte *buffer, NetComma
 void NetPacket::FillBufferWithFileProgressMessage(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetFileProgressCommandMsg *cmdMsg = (NetFileProgressCommandMsg *)(msg->getCommand());
 
-	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
 	NetPacketFileProgressCommand* packet = reinterpret_cast<NetPacketFileProgressCommand*>(buffer);
 	packet->commandType.header = NetPacketFieldTypes::CommandType;
 	packet->commandType.commandType = cmdMsg->getNetCommandType();
@@ -921,7 +901,6 @@ void NetPacket::FillBufferWithFileProgressMessage(UnsignedByte *buffer, NetComma
 void NetPacket::FillBufferWithDisconnectFrameMessage(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetDisconnectFrameCommandMsg *cmdMsg = (NetDisconnectFrameCommandMsg *)(msg->getCommand());
 
-	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
 	NetPacketDisconnectFrameCommand* packet = reinterpret_cast<NetPacketDisconnectFrameCommand*>(buffer);
 	packet->commandType.header = NetPacketFieldTypes::CommandType;
 	packet->commandType.commandType = cmdMsg->getNetCommandType();
@@ -938,7 +917,6 @@ void NetPacket::FillBufferWithDisconnectFrameMessage(UnsignedByte *buffer, NetCo
 void NetPacket::FillBufferWithDisconnectScreenOffMessage(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetDisconnectScreenOffCommandMsg *cmdMsg = (NetDisconnectScreenOffCommandMsg *)(msg->getCommand());
 
-	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
 	NetPacketDisconnectScreenOffCommand* packet = reinterpret_cast<NetPacketDisconnectScreenOffCommand*>(buffer);
 	packet->commandType.header = NetPacketFieldTypes::CommandType;
 	packet->commandType.commandType = cmdMsg->getNetCommandType();
@@ -955,7 +933,6 @@ void NetPacket::FillBufferWithDisconnectScreenOffMessage(UnsignedByte *buffer, N
 void NetPacket::FillBufferWithFrameResendRequestMessage(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetFrameResendRequestCommandMsg *cmdMsg = (NetFrameResendRequestCommandMsg *)(msg->getCommand());
 
-	// TheSuperHackers @refactor BobTista 12/31/2025 Use packed struct for serialization
 	NetPacketFrameResendRequestCommand* packet = reinterpret_cast<NetPacketFrameResendRequestCommand*>(buffer);
 	packet->commandType.header = NetPacketFieldTypes::CommandType;
 	packet->commandType.commandType = cmdMsg->getNetCommandType();

--- a/Core/GameEngine/Source/GameNetwork/NetPacket.cpp
+++ b/Core/GameEngine/Source/GameNetwork/NetPacket.cpp
@@ -584,7 +584,7 @@ void NetPacket::FillBufferWithRunAheadMetricsCommand(UnsignedByte *buffer, NetCo
 	packet->commandId.commandId = cmdMsg->getID();
 	packet->dataHeader.header = NetPacketFieldTypes::Data;
 	packet->averageLatency = cmdMsg->getAverageLatency();
-	packet->averageFps = static_cast<UnsignedByte>(cmdMsg->getAverageFps());
+	packet->averageFps = static_cast<UnsignedShort>(cmdMsg->getAverageFps());
 }
 
 void NetPacket::FillBufferWithRunAheadCommand(UnsignedByte *buffer, NetCommandRef *msg) {


### PR DESCRIPTION
- Merge after #1675, this PR uses the packed struct definitions for packet serialization

## Changes

 Refactors all 24 FillBufferWithXXX functions in NetPacket.cpp to use packed struct overlay instead of manual byte-by-byte serialization with offset tracking.

  - Replaces manual buffer[offset] / memcpy patterns with reinterpret_cast<StructType*>(buffer) and direct field assignment
  - Adds three new header struct variants to NetPacketStructs.h for variable-length packets:
    - NetPacketChatCommandHeader (includes textLength field)
    - NetPacketDisconnectChatCommandHeader (includes textLength field)
    - NetPacketGameCommandHeader
  
**Before (manual byte manipulation):**
```cpp
UnsignedShort offset = 0;
buffer[offset] = NetPacketFieldTypes::CommandType;
++offset;
buffer[offset] = cmdMsg->getNetCommandType();
offset += sizeof(UnsignedByte);
// ... 20+ lines of manual offset tracking and memcpy calls
```

**After (clean struct assignment):**
```cpp
NetPacketFrameCommand* packet = (NetPacketFrameCommand*)buffer;
packet->commandType.header = NetPacketFieldTypes::CommandType;
packet->commandType.commandType = cmdMsg->getNetCommandType();
packet->frame.header = NetPacketFieldTypes::Frame;
packet->frame.frame = cmdMsg->getExecutionFrame();
// ... readable struct field assignments
```
