### PR TITLE
build(memory): Add placement new for VC6 compat with GameMemoryNull

### DIFF
--- a/Core/GameEngine/Include/Common/GameMemoryNull.h
+++ b/Core/GameEngine/Include/Common/GameMemoryNull.h
@@ -163,3 +163,9 @@ extern void* __cdecl operator new[](size_t size, const char *, int);
 extern void __cdecl operator delete[](void *p, const char *, int);
 
 #endif
+
+#if defined(_MSC_VER) && _MSC_VER < 1300
+// additional overloads for 'placement new'
+inline void* __cdecl operator new[](size_t s, void* p) { return p; }
+inline void __cdecl operator delete[](void*, void* p) {}
+#endif


### PR DESCRIPTION
This change adds the 'placement new' overloads to GameMemoryNull if compiling with VC6.
Without these, when configured with `-DRTS_GAMEMEMORY_ENABLE=OFF` VC6 builds fail with errors like:

```
[48/688] Building CXX object GeneralsMD\Code\GameEngine\CMakeFiles\z_gameengine.dir\Source\Common\System\CriticalSection.cpp.obj

FAILED: GeneralsMD/Code/GameEngine/CMakeFiles/z_gameengine.dir/Source/Common/System/CriticalSection.cpp.obj

C:\MSVC600\VC98\Bin\CL.EXE  /nologo /TP -DBUILD_WITH_D3D8 -DDISABLE_GAMEMEMORY=1 -DDISABLE_MEMORYPOOL_CHECKPOINTING=1 -DDISABLE_MEMORYPOOL_DEBUG_CUSTOM_NEW=1 -DDISABLE_MEMORYPOOL_STACKTRACE=1 -DIG_DEBUG_STACKTRACE -DRTS_RELEASE -DRTS_ZEROHOUR=1 -DUSING_STLPORT=1 -DZ_PREFIX -D_CRT_NONSTDC_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS -IC:\source\repos\GeneralsGameCode\GeneralsMD\Code\GameEngine\Include -IC:\source\repos\GeneralsGameCode\GeneralsMD\Code\GameEngine\Include\Precompiled -IC:\source\repos\GeneralsGameCode\Dependencies\Utility\. -IC:\source\repos\GeneralsGameCode\Core\Libraries\Include -IC:\source\repos\GeneralsGameCode\resources\gitinfo -IC:\source\repos\GeneralsGameCode\GeneralsMD\Code\Libraries\Include -IC:\source\repos\GeneralsGameCode\Core\GameEngine\Include -IC:\source\repos\GeneralsGameCode\Core\Libraries\Source\Compression -IC:\source\repos\GeneralsGameCode\build_vc6\_deps\lzhl-src\CompLibHeader -IC:\source\repos\GeneralsGameCode\build_vc6\_deps\lzhl-src\CompLibHeader\.. -IC:\source\repos\GeneralsGameCode\build_vc6\Core\Libraries\Source\Compression\_deps\zlib-1.1.4-src\ZLib -IC:\source\repos\GeneralsGameCode\build_vc6\Core\Libraries\Source\EABrowserDispatch\.. -IC:\source\repos\GeneralsGameCode\build_vc6\_deps\dx8-src\extra -IC:\source\repos\GeneralsGameCode\build_vc6\_deps\dx8-src -IC:\source\repos\GeneralsGameCode\build_vc6\_deps\gamespy-src\include -IC:\source\repos\GeneralsGameCode\build_vc6\_deps\gamespy-src\include\gamespy -IC:\source\repos\GeneralsGameCode\build_vc6\_deps\stlport-src\. -IC:\source\repos\GeneralsGameCode\GeneralsMD\Code\Libraries\Source\WWVegas -IC:\source\repos\GeneralsGameCode\GeneralsMD\Code\Libraries\Source\WWVegas\WW3D2 -IC:\source\repos\GeneralsGameCode\Core\Libraries\Source\WWVegas -IC:\source\repos\GeneralsGameCode\Core\Libraries\Source\WWVegas\WW3D2 -IC:\source\repos\GeneralsGameCode\Core\Libraries\Source\WWVegas\WWAudio -IC:\source\repos\GeneralsGameCode\Core\Libraries\Source\WWVegas\WWDebug -IC:\source\repos\GeneralsGameCode\Core\Libraries\Source\WWVegas\WWLib -IC:\source\repos\GeneralsGameCode\Core\Libraries\Source\WWVegas\WWMath -IC:\source\repos\GeneralsGameCode\Core\Libraries\Source\WWVegas\WWSaveLoad /DWIN32 /D_WINDOWS /Zm1000 /GX /O2 /Ob2 /DNDEBUG -MD /W3 /YuC:/source/repos/GeneralsGameCode/build_vc6/GeneralsMD/Code/GameEngine/CMakeFiles/z_gameengine.dir/cmake_pch.hxx /FpC:/source/repos/GeneralsGameCode/build_vc6/GeneralsMD/Code/GameEngine/CMakeFiles/z_gameengine.dir/./cmake_pch.cxx.pch /FIC:/source/repos/GeneralsGameCode/build_vc6/GeneralsMD/Code/GameEngine/CMakeFiles/z_gameengine.dir/cmake_pch.hxx /FoGeneralsMD\Code\GameEngine\CMakeFiles\z_gameengine.dir\Source\Common\System\CriticalSection.cpp.obj /FdGeneralsMD\Code\GameEngine\CMakeFiles\z_gameengine.dir\z_gameengine.pdb -c C:\source\repos\GeneralsGameCode\GeneralsMD\Code\GameEngine\Source\Common\System\CriticalSection.cpp
CriticalSection.cpp

C:\source\repos\GeneralsGameCode\Core\Libraries\Source\WWVegas\WWLib\Vector.H(423) : error C2661: 'new[]' : no overloaded function takes 2 parameters
        C:\source\repos\GeneralsGameCode\build_vc6\_deps\stlport-src\.\stl/_alloc.h(375) : while compiling class-template member function 'bool __thiscall VectorClass<unsigned char>::Resize(int,const unsigned char *)'
```