### PR TITLE
refactor: Remove redundant CppMacros.h includes

### DIFF
--- a/Core/Libraries/Source/WWVegas/WW3D2/intersec.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/intersec.cpp
@@ -40,7 +40,6 @@
 #include "camera.h"
 #include "scene.h"
 #include "intersec.inl"
-#include "Utility/CppMacros.h"
 
 
 //////////////////////////////////////////////////////////////////////

--- a/Core/Libraries/Source/WWVegas/WWLib/always.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/always.h
@@ -49,7 +49,6 @@
 // TheSuperHackers @build feliwir 17/04/2025 include utility macros for cross-platform compatibility
 #include <Utility/compat.h>
 #include <Utility/stdint_adapter.h>
-#include <Utility/CppMacros.h>
 
 // Disable warning about exception handling not being enabled. It's used as part of STL - in a part of STL we don't use.
 #pragma warning(disable : 4530)

--- a/Dependencies/Utility/Utility/endian_compat.h
+++ b/Dependencies/Utility/Utility/endian_compat.h
@@ -19,7 +19,6 @@
 // This file contains macros to help with endian conversions between different endian systems.
 #pragma once
 
-// VC6 does not support pragma once
 #ifndef ENDIAN_COMPAT_H
 #define ENDIAN_COMPAT_H
 

--- a/Generals/Code/GameEngine/Source/GameNetwork/NetPacket.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/NetPacket.cpp
@@ -31,7 +31,6 @@
 #include "GameNetwork/NetworkDefs.h"
 #include "GameNetwork/networkutil.h"
 #include "GameNetwork/GameMessageParser.h"
-#include <Utility/CppMacros.h>
 
 // TheSuperHackers @refactor BobTista 10/06/2025 Extract magic character literals into named constants for improved readability
 typedef UnsignedByte NetPacketFieldType;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -52,8 +52,6 @@
 
 #include "Common/UnitTimings.h" //Contains the DO_UNIT_TIMINGS define jba.
 
-#include "Utility/CppMacros.h"
-
 #define no_INTENSE_DEBUG
 
 #define DEBUG_QPF

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/NetPacket.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/NetPacket.cpp
@@ -31,7 +31,6 @@
 #include "GameNetwork/NetworkDefs.h"
 #include "GameNetwork/networkutil.h"
 #include "GameNetwork/GameMessageParser.h"
-#include <Utility/CppMacros.h>
 
 // TheSuperHackers @refactor BobTista 10/06/2025 Extract magic character literals into named constants for improved readability
 typedef UnsignedByte NetPacketFieldType;


### PR DESCRIPTION
This changes removes redundant CppMacros.h includes.