### PR TITLE
fix(view): Adjust default camera height to compensate for screen aspect ratio

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -674,7 +674,7 @@ Real W3DView::getCameraOffsetZ() const
 	}
 #endif
 
-	return m_pos.z + TheGlobalData->m_maxCameraHeight;
+	return m_pos.z + m_maxHeightAboveGround;
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -2233,10 +2233,24 @@ void W3DView::setPitchToDefault()
 //-------------------------------------------------------------------------------------------------
 void W3DView::setDefaultView(Real pitch, Real angle, Real maxHeight)
 {
+	// TheSuperHackers @fix Mauller 08/05/2026 Adjust the maximum camera height to compensate for screen aspect ratio
+	Real baseAspectRatio = (Real)DEFAULT_DISPLAY_WIDTH / (Real)DEFAULT_DISPLAY_HEIGHT;
+	Real currentAspectRatio = (Real)TheTacticalView->getWidth() / (Real)TheTacticalView->getHeight();
+	Real aspectRatioScale = 1.0f;
+
+	if (currentAspectRatio > baseAspectRatio)
+	{
+		aspectRatioScale = fabs((1.0f + (currentAspectRatio - baseAspectRatio)));
+		const float nerf = 1.0f - (currentAspectRatio - baseAspectRatio) / 12.0f;
+
+		aspectRatioScale *= nerf;
+	}
+
 	// MDC - we no longer want to rotate maps (design made all of them right to begin with)
 	//	m_defaultAngle = angle * M_PI/180.0f;
 	setDefaultPitch(pitch);
-	m_maxHeightAboveGround = TheGlobalData->m_maxCameraHeight*maxHeight;
+	m_maxHeightAboveGround = TheGlobalData->m_maxCameraHeight * aspectRatioScale * maxHeight;
+	m_minHeightAboveGround = TheGlobalData->m_minCameraHeight * aspectRatioScale;
 	if (m_minHeightAboveGround > m_maxHeightAboveGround)
 		m_maxHeightAboveGround = m_minHeightAboveGround;
 }
@@ -2278,7 +2292,6 @@ void W3DView::setZoomToDefault()
 	m_heightAboveGround = m_maxHeightAboveGround;
 	m_zoom = getMaxZoom(m_pos.x, m_pos.y);
 
-	stopDoingScriptedCamera();
 	m_CameraArrivedAtWaypointOnPathFlag = false;
 	m_cameraAreaConstraintsValid = false;
 	m_recalcCamera = true;

--- a/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
@@ -193,8 +193,11 @@ public:
 #if PRESERVE_RETAIL_SCRIPTED_CAMERA
 	Real m_cameraHeight;
 #endif
+
+	 // TheSuperHackers @info Max and Min camera height for the original 4:3 view, these are then scaled for other aspect ratios.
 	Real m_maxCameraHeight;
 	Real m_minCameraHeight;
+
 	Real m_terrainHeightAtEdgeOfMap;
 	Real m_unitDamagedThresh;
 	Real m_unitReallyDamagedThresh;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -877,6 +877,13 @@ static void saveOptions()
 
 				TheInGameUI->recreateControlBar();
 				TheInGameUI->refreshCustomUiResources();
+
+				// TheSuperHackers @info Update the view so the shellmap looks correct when changing resolution
+				TheTacticalView->setDefaultView(
+					DEG_TO_RADF(TheGlobalData->m_cameraPitch),
+					DEG_TO_RADF(TheGlobalData->m_cameraYaw),
+					1.0f);
+				TheTacticalView->setZoomToDefault();
 			}
 		}
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -2081,6 +2081,10 @@ void GameLogic::tryStartNewGame( Bool loadingSaveGame )
 	// update the loadscreen
 	updateLoadProgress(LOAD_PROGRESS_POST_PRELOAD_ASSETS);
 
+	TheTacticalView->setDefaultView(
+		DEG_TO_RADF(TheGlobalData->m_cameraPitch),
+		DEG_TO_RADF(TheGlobalData->m_cameraYaw),
+		1.0f);
 	TheTacticalView->setAngleToDefault();
 	TheTacticalView->setPitchToDefault();
 	TheTacticalView->setZoomToDefault();


### PR DESCRIPTION
**Merge with Rebase**

- Fixes: #78 

This PR adjusts the default max camera height to compensate for different screen aspect ratios.

Previous work fixed the vertical field of view to match retail and adjusted the horizontal fields of view.
But this resulted in significant distortion being observed in the periphery of the view and lower corners.
This distortion was also observed at the 16:9 aspect ratio and became significantly worse as the aspect ratio increased.

By maintaining the original 60 degrees horizontal field of view, while allowing the game to narrow the vertical field of view, increasing the camera height results in minimal to no distortion being observed.

~~This PR does not fix any other known camera issues and focuses on giving a playable default view.~~

---
**TODO**

- [ ] Implement in generals