### PR TITLE
fix: Revert strlcat on pointer arguments

### DIFF
--- a/Core/Libraries/Source/debug/debug_debug.cpp
+++ b/Core/Libraries/Source/debug/debug_debug.cpp
@@ -348,7 +348,7 @@ bool Debug::AssertDone(void)
                         "time being (stops logging this assertion as well).";
     char *help=(char *)DebugAllocMemory(ioBuffer[curType].used+strlen(addInfo)+1);
     strcpy(help,ioBuffer[curType].buffer+82);
-    strlcat(help, addInfo, ARRAY_SIZE(help));
+    strcat(help, addInfo);
 
     // First hit? Then do a stack trace
     if (curFrameEntry->hits==1)
@@ -612,7 +612,7 @@ bool Debug::CrashDone(bool die)
 #endif
     char *help=(char *)DebugAllocMemory(ioBuffer[curType].used+strlen(addInfo)+1);
     strcpy(help,ioBuffer[curType].buffer+82);
-    strlcat(help, addInfo, ARRAY_SIZE(help));
+    strcat(help, addInfo);
 
     // First hit? Then do a stack trace
     if (curFrameEntry->hits==1)


### PR DESCRIPTION
- Follow up on #1685 

In two cases, `strlcat` has a pointer as target string, causing `ARRAY_SIZE` not returning the correct size.
This PR reverts the refactor back to `strcat`