### PR TITLE
feat(gui): Implement replay info tooltips in Replay Menu

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
@@ -299,12 +299,12 @@ void PopulateReplayFileListbox(GameWindow *listbox)
 			// map
 			UnicodeString mapStr = createMapName(asciistr, info, mapData);
 
-			// extra
-			UnicodeString extraStr = buildReplayTooltip(header, info);
+			// tooltip
+			UnicodeString tooltipStr = buildReplayTooltip(header, info);
 
 			UnicodeString key;
 			key.translate(asciistr);
-			replayTooltipCache[key] = extraStr;
+			replayTooltipCache[key] = tooltipStr;
 
 			// pick a color
 			Color color;
@@ -359,7 +359,6 @@ void PopulateReplayFileListbox(GameWindow *listbox)
 			GadgetListBoxAddEntryText(listbox, displayTimeBuffer, color, insertionIndex, 1);
 			GadgetListBoxAddEntryText(listbox, header.versionString, color, insertionIndex, 2);
 			GadgetListBoxAddEntryText(listbox, mapStr, mapColor, insertionIndex, 3);
-			//GadgetListBoxAddEntryText(listbox, extraStr, color, insertionIndex, 4);
 		}
 	}
 	GadgetListBoxSetSelected(listbox, 0);

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
@@ -299,12 +299,12 @@ void PopulateReplayFileListbox(GameWindow *listbox)
 			// map
 			UnicodeString mapStr = createMapName(asciistr, info, mapData);
 
-			// extra
-			UnicodeString extraStr = buildReplayTooltip(header, info);
+			// tooltip
+			UnicodeString tooltipStr = buildReplayTooltip(header, info);
 
 			UnicodeString key;
 			key.translate(asciistr);
-			replayTooltipCache[key] = extraStr;
+			replayTooltipCache[key] = tooltipStr;
 
 			// pick a color
 			Color color;
@@ -359,7 +359,6 @@ void PopulateReplayFileListbox(GameWindow *listbox)
 			GadgetListBoxAddEntryText(listbox, displayTimeBuffer, color, insertionIndex, 1);
 			GadgetListBoxAddEntryText(listbox, header.versionString, color, insertionIndex, 2);
 			GadgetListBoxAddEntryText(listbox, mapStr, mapColor, insertionIndex, 3);
-			//GadgetListBoxAddEntryText(listbox, extraStr, color, insertionIndex, 4);
 		}
 	}
 	GadgetListBoxSetSelected(listbox, 0);


### PR DESCRIPTION
This change introduces the ability to hover replays in the replays menu to observe additional data in the tooltip, including the duration and the players involved. This mostly leverages existing (previously disabled) logic with a few minor tweaks to make it a bit more tooltip-friendly.

https://github.com/user-attachments/assets/ecb45782-606f-44e9-b79b-31681f83efc8