### PR TITLE
bugfix(weapon): Fix unreliability of historic bonus weapons

### DIFF
--- a/Generals/Code/GameEngine/Include/GameLogic/Weapon.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Weapon.h
@@ -320,10 +320,10 @@ struct HistoricWeaponDamageInfo
 	// The time and location this weapon was fired
 	UnsignedInt						frame;
 	Coord3D								location;
-	Bool									triggered;
+	Int										triggerIndex;
 
 	HistoricWeaponDamageInfo(UnsignedInt f, const Coord3D& l) :
-		frame(f), location(l), triggered(false)
+		frame(f), location(l), triggerIndex(0)
 	{
 	}
 };
@@ -539,6 +539,7 @@ private:
 	Real m_infantryInaccuracyDist;					///< When this weapon is used against infantry, it can randomly miss by as much as this distance.
 	UnsignedInt m_suspendFXDelay;						///< The fx can be suspended for any delay, in frames, then they will execute as normal
 	mutable HistoricWeaponDamageList m_historicDamage;
+	mutable UnsignedInt m_historicDamageInstanceCount;
 };
 
 // ---------------------------------------------------------

--- a/Generals/Code/GameEngine/Include/GameLogic/Weapon.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Weapon.h
@@ -320,7 +320,7 @@ struct HistoricWeaponDamageInfo
 	// The time and location this weapon was fired
 	UnsignedInt						frame;
 	Coord3D								location;
-	Int										triggerId;
+	UnsignedInt						triggerId;
 
 	HistoricWeaponDamageInfo(UnsignedInt f, const Coord3D& l) :
 		frame(f), location(l), triggerId(0)

--- a/Generals/Code/GameEngine/Include/GameLogic/Weapon.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Weapon.h
@@ -320,10 +320,10 @@ struct HistoricWeaponDamageInfo
 	// The time and location this weapon was fired
 	UnsignedInt						frame;
 	Coord3D								location;
-	Int										triggerIndex;
+	Int										triggerId;
 
 	HistoricWeaponDamageInfo(UnsignedInt f, const Coord3D& l) :
-		frame(f), location(l), triggerIndex(0)
+		frame(f), location(l), triggerId(0)
 	{
 	}
 };
@@ -539,7 +539,7 @@ private:
 	Real m_infantryInaccuracyDist;					///< When this weapon is used against infantry, it can randomly miss by as much as this distance.
 	UnsignedInt m_suspendFXDelay;						///< The fx can be suspended for any delay, in frames, then they will execute as normal
 	mutable HistoricWeaponDamageList m_historicDamage;
-	mutable UnsignedInt m_historicDamageInstanceCount;
+	mutable UnsignedInt m_historicDamageTriggerId;
 };
 
 // ---------------------------------------------------------

--- a/Generals/Code/GameEngine/Include/GameLogic/Weapon.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Weapon.h
@@ -320,10 +320,12 @@ struct HistoricWeaponDamageInfo
 	// The time and location this weapon was fired
 	UnsignedInt						frame;
 	Coord3D								location;
+	Bool									triggered;
 
 	HistoricWeaponDamageInfo(UnsignedInt f, const Coord3D& l) :
 		frame(f), location(l)
 	{
+		triggered = false;
 	}
 };
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Weapon.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Weapon.h
@@ -323,9 +323,8 @@ struct HistoricWeaponDamageInfo
 	Bool									triggered;
 
 	HistoricWeaponDamageInfo(UnsignedInt f, const Coord3D& l) :
-		frame(f), location(l)
+		frame(f), location(l), triggered(false)
 	{
-		triggered = false;
 	}
 };
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Weapon.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Weapon.h
@@ -460,6 +460,7 @@ protected:
 	// actually deal out the damage.
 	void dealDamageInternal(ObjectID sourceID, ObjectID victimID, const Coord3D *pos, const WeaponBonus& bonus, Bool isProjectileDetonation) const;
 	void trimOldHistoricDamage() const;
+	void processHistoricDamage(const Object* source, const Coord3D* pos) const;
 
 private:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Weapon.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Weapon.h
@@ -461,6 +461,7 @@ protected:
 	// actually deal out the damage.
 	void dealDamageInternal(ObjectID sourceID, ObjectID victimID, const Coord3D *pos, const WeaponBonus& bonus, Bool isProjectileDetonation) const;
 	void trimOldHistoricDamage() const;
+	void trimTriggeredHistoricDamage() const;
 	void processHistoricDamage(const Object* source, const Coord3D* pos) const;
 
 private:

--- a/Generals/Code/GameEngine/Include/GameLogic/Weapon.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Weapon.h
@@ -320,7 +320,7 @@ struct HistoricWeaponDamageInfo
 	// The time and location this weapon was fired
 	UnsignedInt						frame;
 	Coord3D								location;
-	UnsignedInt						triggerId;
+	UnsignedInt						triggerId; ///< Unique Id assigned to any grouped damage instances
 
 	HistoricWeaponDamageInfo(UnsignedInt f, const Coord3D& l) :
 		frame(f), location(l), triggerId(0)

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -1126,13 +1126,27 @@ void WeaponTemplate::trimOldHistoricDamage() const
 
 	while (it != m_historicDamage.end())
 	{
-		if (it->frame <= expirationFrame || it->triggered)
+		if (it->frame <= expirationFrame)
+			it = m_historicDamage.erase(it);
+		else
+			break;
+	}
+}
+#endif
+
+//-------------------------------------------------------------------------------------------------
+void WeaponTemplate::trimTriggeredHistoricDamage() const
+{
+	HistoricWeaponDamageList::iterator it = m_historicDamage.begin();
+
+	while (it != m_historicDamage.end())
+	{
+		if (it->triggered)
 			it = m_historicDamage.erase(it);
 		else
 			++it;
 	}
 }
-#endif
 
 //-------------------------------------------------------------------------------------------------
 static Bool is2DDistSquaredLessThan(const Coord3D& a, const Coord3D& b, Real distSqr)
@@ -1216,6 +1230,7 @@ void WeaponTemplate::processHistoricDamage(const Object* source, const Coord3D* 
 					if (count >= requiredCount)
 					{
 						TheWeaponStore->createAndFireTempWeapon(m_historicBonusWeapon, source, pos);
+						trimTriggeredHistoricDamage();
 						return;
 					}
 				}

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -1130,10 +1130,10 @@ void WeaponTemplate::processHistoricDamage(const Object* source, const Coord3D* 
 	// firestorms (CBD) */
 	//
 
-	trimOldHistoricDamage();
-
 	if( m_historicBonusCount > 0 && m_historicBonusWeapon != this )
 	{
+		trimOldHistoricDamage();
+
 		Real radSqr = m_historicBonusRadius * m_historicBonusRadius;
 		Int count = 0;
 		UnsignedInt frameNow = TheGameLogic->getFrame();

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -310,7 +310,7 @@ WeaponTemplate::WeaponTemplate() : m_nextTemplate(NULL)
 	m_infantryInaccuracyDist				= 0.0f;
 	m_suspendFXDelay								= 0;
 
-	m_historicDamageInstanceCount = 0;
+	m_historicDamageTriggerId = 0;
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1143,7 +1143,7 @@ void WeaponTemplate::trimTriggeredHistoricDamage() const
 
 	while (it != m_historicDamage.end())
 	{
-		if (it->triggerIndex == m_historicDamageInstanceCount)
+		if (it->triggerId == m_historicDamageTriggerId)
 			it = m_historicDamage.erase(it);
 		else
 			++it;
@@ -1214,7 +1214,7 @@ void WeaponTemplate::processHistoricDamage(const Object* source, const Coord3D* 
 	{
 		trimOldHistoricDamage();
 
-		++m_historicDamageInstanceCount;
+		++m_historicDamageTriggerId;
 
 		const Int requiredCount = m_historicBonusCount - 1; // minus 1 since we include ourselves implicitly
 		if (m_historicDamage.size() >= requiredCount)
@@ -1228,7 +1228,7 @@ void WeaponTemplate::processHistoricDamage(const Object* source, const Coord3D* 
 				{
 					// This one is close enough in time and distance, so count it. This is tracked by template since it applies
 					// across units, so don't try to clear historicDamage on success in here.
-					it->triggerIndex = m_historicDamageInstanceCount;
+					it->triggerId = m_historicDamageTriggerId;
 
 					if (++count == requiredCount)
 					{

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -1231,7 +1231,7 @@ void WeaponTemplate::processHistoricDamage(const Object* source, const Coord3D* 
 				{
 					// This one is close enough in time and distance, so count it. This is tracked by template since it applies
 					// across units, so don't try to clear historicDamage on success in here.
-					(*it).triggerIndex = m_historicDamageInstanceCount;
+					it->triggerIndex = m_historicDamageInstanceCount;
 
 					if (++count == requiredCount)
 					{

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -1116,12 +1116,17 @@ void WeaponTemplate::trimOldHistoricDamage() const
 #else
 void WeaponTemplate::trimOldHistoricDamage() const
 {
+	if (m_historicDamage.empty())
+		return;
+
+	const UnsignedInt currentFrame = TheGameLogic->getFrame();
+	const UnsignedInt expirationFrame = currentFrame - m_historicBonusTime;
+
 	HistoricWeaponDamageList::iterator it = m_historicDamage.begin();
 
 	while (it != m_historicDamage.end())
 	{
-		UnsignedInt expirationFrame = it->frame + m_historicBonusTime;
-		if (TheGameLogic->getFrame() > expirationFrame || it->triggered)
+		if (it->frame <= expirationFrame || it->triggered)
 			it = m_historicDamage.erase(it);
 		else
 			++it;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -1198,27 +1198,32 @@ void WeaponTemplate::processHistoricDamage(const Object* source, const Coord3D* 
 	{
 		trimOldHistoricDamage();
 
-		Real radSqr = m_historicBonusRadius * m_historicBonusRadius;
-		Int count = 0;
-		for (HistoricWeaponDamageList::iterator it = m_historicDamage.begin(); it != m_historicDamage.end(); ++it)
+		const Int requiredCount = m_historicBonusCount - 1; // minus 1 since we include ourselves implicitly
+		if (m_historicDamage.size() >= requiredCount)
 		{
-			if (is2DDistSquaredLessThan(*pos, it->location, radSqr))
-			{
-				// This one is close enough in time and distance, so count it. This is tracked by template since it applies
-				// across units, so don't try to clear historicDamage on success in here.
-				(*it).triggered = true;
-				++count;
+			const Real radSqr = m_historicBonusRadius * m_historicBonusRadius;
+			Int count = 0;
 
-				if (count >= m_historicBonusCount - 1)	// minus 1 since we include ourselves implicitly
+			for (HistoricWeaponDamageList::iterator it = m_historicDamage.begin(); it != m_historicDamage.end(); ++it)
+			{
+				if (is2DDistSquaredLessThan(*pos, it->location, radSqr))
 				{
-					TheWeaponStore->createAndFireTempWeapon(m_historicBonusWeapon, source, pos);
-					return;
+					// This one is close enough in time and distance, so count it. This is tracked by template since it applies
+					// across units, so don't try to clear historicDamage on success in here.
+					(*it).triggered = true;
+					++count;
+
+					if (count >= requiredCount)
+					{
+						TheWeaponStore->createAndFireTempWeapon(m_historicBonusWeapon, source, pos);
+						return;
+					}
 				}
 			}
-		}
 
-		for (HistoricWeaponDamageList::iterator it = m_historicDamage.begin(); it != m_historicDamage.end(); ++it)
-			(*it).triggered = false;
+			for (HistoricWeaponDamageList::iterator it = m_historicDamage.begin(); it != m_historicDamage.end(); ++it)
+				(*it).triggered = false;
+		}
 
 		// add AFTER checking for historic stuff
 		m_historicDamage.push_back(HistoricWeaponDamageInfo(TheGameLogic->getFrame(), *pos));

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -1093,6 +1093,7 @@ UnsignedInt WeaponTemplate::fireWeaponTemplate
 }
 
 //-------------------------------------------------------------------------------------------------
+#if RETAIL_COMPATIBLE_CRC
 void WeaponTemplate::trimOldHistoricDamage() const
 {
 	UnsignedInt expirationDate = TheGameLogic->getFrame() - TheGlobalData->m_historicDamageLimit;
@@ -1112,6 +1113,21 @@ void WeaponTemplate::trimOldHistoricDamage() const
 		}
 	}
 }
+#else
+void WeaponTemplate::trimOldHistoricDamage() const
+{
+	HistoricWeaponDamageList::iterator it = m_historicDamage.begin();
+
+	while (it != m_historicDamage.end())
+	{
+		UnsignedInt expirationDate = it->frame + m_historicBonusTime;
+		if (TheGameLogic->getFrame() > expirationDate || it->triggered)
+			it = m_historicDamage.erase(it);
+		else
+			++it;
+	}
+}
+#endif
 
 //-------------------------------------------------------------------------------------------------
 static Bool is2DDistSquaredLessThan(const Coord3D& a, const Coord3D& b, Real distSqr)
@@ -1121,6 +1137,7 @@ static Bool is2DDistSquaredLessThan(const Coord3D& a, const Coord3D& b, Real dis
 }
 
 //-------------------------------------------------------------------------------------------------
+#if RETAIL_COMPATIBLE_CRC
 void WeaponTemplate::processHistoricDamage(const Object* source, const Coord3D* pos) const
 {
 	//
@@ -1169,6 +1186,39 @@ void WeaponTemplate::processHistoricDamage(const Object* source, const Coord3D* 
 
 	}
 }
+#else
+void WeaponTemplate::processHistoricDamage(const Object* source, const Coord3D* pos) const
+{
+	if (m_historicBonusCount > 0 && m_historicBonusWeapon != this)
+	{
+		trimOldHistoricDamage();
+
+		Real radSqr = m_historicBonusRadius * m_historicBonusRadius;
+		Int count = 0;
+		for (HistoricWeaponDamageList::iterator it = m_historicDamage.begin(); it != m_historicDamage.end(); ++it)
+		{
+			if (is2DDistSquaredLessThan(*pos, it->location, radSqr))
+			{
+				// This one is close enough in time and distance, so count it. This is tracked by template since it applies
+				// across units, so don't try to clear historicDamage on success in here.
+				(*it).triggered = true;
+				++count;
+			}
+		}
+
+		if (count >= m_historicBonusCount - 1)	// minus 1 since we include ourselves implicitly
+			TheWeaponStore->createAndFireTempWeapon(m_historicBonusWeapon, source, pos);
+		else
+		{
+			for (HistoricWeaponDamageList::iterator it = m_historicDamage.begin(); it != m_historicDamage.end(); ++it)
+				(*it).triggered = false;
+
+			// add AFTER checking for historic stuff
+			m_historicDamage.push_back(HistoricWeaponDamageInfo(TheGameLogic->getFrame(), *pos));
+		}
+	}
+}
+#endif
 
 //-------------------------------------------------------------------------------------------------
 void WeaponTemplate::dealDamageInternal(ObjectID sourceID, ObjectID victimID, const Coord3D *pos, const WeaponBonus& bonus, Bool isProjectileDetonation) const

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -1232,9 +1232,8 @@ void WeaponTemplate::processHistoricDamage(const Object* source, const Coord3D* 
 					// This one is close enough in time and distance, so count it. This is tracked by template since it applies
 					// across units, so don't try to clear historicDamage on success in here.
 					(*it).triggerIndex = m_historicDamageInstanceCount;
-					++count;
 
-					if (count >= requiredCount)
+					if (++count == requiredCount)
 					{
 						TheWeaponStore->createAndFireTempWeapon(m_historicBonusWeapon, source, pos);
 						trimTriggeredHistoricDamage();

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -1119,10 +1119,7 @@ void WeaponTemplate::trimOldHistoricDamage() const
 void WeaponTemplate::trimOldHistoricDamage() const
 {
 	if (m_historicDamage.empty())
-	{
-		m_historicDamageInstanceCount = 0;
 		return;
-	}
 
 	const UnsignedInt currentFrame = TheGameLogic->getFrame();
 	const UnsignedInt expirationFrame = currentFrame - m_historicBonusTime;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -1120,8 +1120,8 @@ void WeaponTemplate::trimOldHistoricDamage() const
 
 	while (it != m_historicDamage.end())
 	{
-		UnsignedInt expirationDate = it->frame + m_historicBonusTime;
-		if (TheGameLogic->getFrame() > expirationDate || it->triggered)
+		UnsignedInt expirationFrame = it->frame + m_historicBonusTime;
+		if (TheGameLogic->getFrame() > expirationFrame || it->triggered)
 			it = m_historicDamage.erase(it);
 		else
 			++it;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -1121,16 +1121,8 @@ static Bool is2DDistSquaredLessThan(const Coord3D& a, const Coord3D& b, Real dis
 }
 
 //-------------------------------------------------------------------------------------------------
-void WeaponTemplate::dealDamageInternal(ObjectID sourceID, ObjectID victimID, const Coord3D *pos, const WeaponBonus& bonus, Bool isProjectileDetonation) const
+void WeaponTemplate::processHistoricDamage(const Object* source, const Coord3D* pos) const
 {
-	if (sourceID == 0)	// must have a source
-		return;
-
-	if (victimID == 0 && pos == NULL)	// must have some sort of destination
-		return;
-
-	Object *source = TheGameLogic->findObjectByID(sourceID);	// might be null...
-
 	//
 	/** @todo We need to rewrite the historic stuff ... if you fire 5 missiles, and the 5th,
 	// one creates a firestorm ... and then half a second later another volley of 5 missiles
@@ -1176,6 +1168,20 @@ void WeaponTemplate::dealDamageInternal(ObjectID sourceID, ObjectID victimID, co
 		}
 
 	}
+}
+
+//-------------------------------------------------------------------------------------------------
+void WeaponTemplate::dealDamageInternal(ObjectID sourceID, ObjectID victimID, const Coord3D *pos, const WeaponBonus& bonus, Bool isProjectileDetonation) const
+{
+	if (sourceID == 0)	// must have a source
+		return;
+
+	if (victimID == 0 && pos == NULL)	// must have some sort of destination
+		return;
+
+	Object *source = TheGameLogic->findObjectByID(sourceID);	// might be null...
+
+	processHistoricDamage(source, pos);
 
 //DEBUG_LOG(("WeaponTemplate::dealDamageInternal: dealing damage %s at frame %d",m_name.str(),TheGameLogic->getFrame()));
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -1203,19 +1203,20 @@ void WeaponTemplate::processHistoricDamage(const Object* source, const Coord3D* 
 				// across units, so don't try to clear historicDamage on success in here.
 				(*it).triggered = true;
 				++count;
+
+				if (count >= m_historicBonusCount - 1)	// minus 1 since we include ourselves implicitly
+				{
+					TheWeaponStore->createAndFireTempWeapon(m_historicBonusWeapon, source, pos);
+					return;
+				}
 			}
 		}
 
-		if (count >= m_historicBonusCount - 1)	// minus 1 since we include ourselves implicitly
-			TheWeaponStore->createAndFireTempWeapon(m_historicBonusWeapon, source, pos);
-		else
-		{
-			for (HistoricWeaponDamageList::iterator it = m_historicDamage.begin(); it != m_historicDamage.end(); ++it)
-				(*it).triggered = false;
+		for (HistoricWeaponDamageList::iterator it = m_historicDamage.begin(); it != m_historicDamage.end(); ++it)
+			(*it).triggered = false;
 
-			// add AFTER checking for historic stuff
-			m_historicDamage.push_back(HistoricWeaponDamageInfo(TheGameLogic->getFrame(), *pos));
-		}
+		// add AFTER checking for historic stuff
+		m_historicDamage.push_back(HistoricWeaponDamageInfo(TheGameLogic->getFrame(), *pos));
 	}
 }
 #endif

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -309,6 +309,8 @@ WeaponTemplate::WeaponTemplate() : m_nextTemplate(NULL)
 	m_continueAttackRange						= 0.0f;
 	m_infantryInaccuracyDist				= 0.0f;
 	m_suspendFXDelay								= 0;
+
+	m_historicDamageInstanceCount = 0;
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1117,7 +1119,10 @@ void WeaponTemplate::trimOldHistoricDamage() const
 void WeaponTemplate::trimOldHistoricDamage() const
 {
 	if (m_historicDamage.empty())
+	{
+		m_historicDamageInstanceCount = 0;
 		return;
+	}
 
 	const UnsignedInt currentFrame = TheGameLogic->getFrame();
 	const UnsignedInt expirationFrame = currentFrame - m_historicBonusTime;
@@ -1141,7 +1146,7 @@ void WeaponTemplate::trimTriggeredHistoricDamage() const
 
 	while (it != m_historicDamage.end())
 	{
-		if (it->triggered)
+		if (it->triggerIndex == m_historicDamageInstanceCount)
 			it = m_historicDamage.erase(it);
 		else
 			++it;
@@ -1212,6 +1217,8 @@ void WeaponTemplate::processHistoricDamage(const Object* source, const Coord3D* 
 	{
 		trimOldHistoricDamage();
 
+		++m_historicDamageInstanceCount;
+
 		const Int requiredCount = m_historicBonusCount - 1; // minus 1 since we include ourselves implicitly
 		if (m_historicDamage.size() >= requiredCount)
 		{
@@ -1224,7 +1231,7 @@ void WeaponTemplate::processHistoricDamage(const Object* source, const Coord3D* 
 				{
 					// This one is close enough in time and distance, so count it. This is tracked by template since it applies
 					// across units, so don't try to clear historicDamage on success in here.
-					(*it).triggered = true;
+					(*it).triggerIndex = m_historicDamageInstanceCount;
 					++count;
 
 					if (count >= requiredCount)
@@ -1235,9 +1242,6 @@ void WeaponTemplate::processHistoricDamage(const Object* source, const Coord3D* 
 					}
 				}
 			}
-
-			for (HistoricWeaponDamageList::iterator it = m_historicDamage.begin(); it != m_historicDamage.end(); ++it)
-				(*it).triggered = false;
 		}
 
 		// add AFTER checking for historic stuff

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Weapon.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Weapon.h
@@ -331,10 +331,12 @@ struct HistoricWeaponDamageInfo
 	// The time and location this weapon was fired
 	UnsignedInt						frame;
 	Coord3D								location;
+	Bool									triggered;
 
 	HistoricWeaponDamageInfo(UnsignedInt f, const Coord3D& l) :
 		frame(f), location(l)
 	{
+		triggered = false;
 	}
 };
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Weapon.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Weapon.h
@@ -481,6 +481,7 @@ protected:
 	// actually deal out the damage.
 	void dealDamageInternal(ObjectID sourceID, ObjectID victimID, const Coord3D *pos, const WeaponBonus& bonus, Bool isProjectileDetonation) const;
 	void trimOldHistoricDamage() const;
+	void trimTriggeredHistoricDamage() const;
 	void processHistoricDamage(const Object* source, const Coord3D* pos) const;
 
 private:

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Weapon.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Weapon.h
@@ -331,7 +331,7 @@ struct HistoricWeaponDamageInfo
 	// The time and location this weapon was fired
 	UnsignedInt						frame;
 	Coord3D								location;
-	UnsignedInt						triggerId;
+	UnsignedInt						triggerId; ///< Unique Id assigned to any grouped damage instances
 
 	HistoricWeaponDamageInfo(UnsignedInt f, const Coord3D& l) :
 		frame(f), location(l), triggerId(0)

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Weapon.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Weapon.h
@@ -331,7 +331,7 @@ struct HistoricWeaponDamageInfo
 	// The time and location this weapon was fired
 	UnsignedInt						frame;
 	Coord3D								location;
-	Int										triggerId;
+	UnsignedInt						triggerId;
 
 	HistoricWeaponDamageInfo(UnsignedInt f, const Coord3D& l) :
 		frame(f), location(l), triggerId(0)

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Weapon.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Weapon.h
@@ -331,10 +331,10 @@ struct HistoricWeaponDamageInfo
 	// The time and location this weapon was fired
 	UnsignedInt						frame;
 	Coord3D								location;
-	Int										triggerIndex;
+	Int										triggerId;
 
 	HistoricWeaponDamageInfo(UnsignedInt f, const Coord3D& l) :
-		frame(f), location(l), triggerIndex(0)
+		frame(f), location(l), triggerId(0)
 	{
 	}
 };
@@ -567,7 +567,7 @@ private:
 	Bool m_dieOnDetonate;
 
 	mutable HistoricWeaponDamageList m_historicDamage;
-	mutable UnsignedInt m_historicDamageInstanceCount;
+	mutable UnsignedInt m_historicDamageTriggerId;
 };
 
 // ---------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Weapon.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Weapon.h
@@ -331,10 +331,10 @@ struct HistoricWeaponDamageInfo
 	// The time and location this weapon was fired
 	UnsignedInt						frame;
 	Coord3D								location;
-	Bool									triggered;
+	Int										triggerIndex;
 
 	HistoricWeaponDamageInfo(UnsignedInt f, const Coord3D& l) :
-		frame(f), location(l), triggered(false)
+		frame(f), location(l), triggerIndex(0)
 	{
 	}
 };
@@ -567,6 +567,7 @@ private:
 	Bool m_dieOnDetonate;
 
 	mutable HistoricWeaponDamageList m_historicDamage;
+	mutable UnsignedInt m_historicDamageInstanceCount;
 };
 
 // ---------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Weapon.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Weapon.h
@@ -480,6 +480,7 @@ protected:
 	// actually deal out the damage.
 	void dealDamageInternal(ObjectID sourceID, ObjectID victimID, const Coord3D *pos, const WeaponBonus& bonus, Bool isProjectileDetonation) const;
 	void trimOldHistoricDamage() const;
+	void processHistoricDamage(const Object* source, const Coord3D* pos) const;
 
 private:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Weapon.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Weapon.h
@@ -334,9 +334,8 @@ struct HistoricWeaponDamageInfo
 	Bool									triggered;
 
 	HistoricWeaponDamageInfo(UnsignedInt f, const Coord3D& l) :
-		frame(f), location(l)
+		frame(f), location(l), triggered(false)
 	{
-		triggered = false;
 	}
 };
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -1310,9 +1310,8 @@ void WeaponTemplate::processHistoricDamage(const Object* source, const Coord3D* 
 					// This one is close enough in time and distance, so count it. This is tracked by template since it applies
 					// across units, so don't try to clear historicDamage on success in here.
 					(*it).triggerIndex = m_historicDamageInstanceCount;
-					++count;
 
-					if (count >= requiredCount)
+					if (++count == requiredCount)
 					{
 						TheWeaponStore->createAndFireTempWeapon(m_historicBonusWeapon, source, pos);
 						trimTriggeredHistoricDamage();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -1309,7 +1309,7 @@ void WeaponTemplate::processHistoricDamage(const Object* source, const Coord3D* 
 				{
 					// This one is close enough in time and distance, so count it. This is tracked by template since it applies
 					// across units, so don't try to clear historicDamage on success in here.
-					(*it).triggerIndex = m_historicDamageInstanceCount;
+					it->triggerIndex = m_historicDamageInstanceCount;
 
 					if (++count == requiredCount)
 					{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -1281,19 +1281,20 @@ void WeaponTemplate::processHistoricDamage(const Object* source, const Coord3D* 
 				// across units, so don't try to clear historicDamage on success in here.
 				(*it).triggered = true;
 				++count;
+
+				if (count >= m_historicBonusCount - 1)	// minus 1 since we include ourselves implicitly
+				{
+					TheWeaponStore->createAndFireTempWeapon(m_historicBonusWeapon, source, pos);
+					return;
+				}
 			}
 		}
 
-		if (count >= m_historicBonusCount - 1)	// minus 1 since we include ourselves implicitly
-			TheWeaponStore->createAndFireTempWeapon(m_historicBonusWeapon, source, pos);
-		else
-		{
-			for (HistoricWeaponDamageList::iterator it = m_historicDamage.begin(); it != m_historicDamage.end(); ++it)
-				(*it).triggered = false;
+		for (HistoricWeaponDamageList::iterator it = m_historicDamage.begin(); it != m_historicDamage.end(); ++it)
+			(*it).triggered = false;
 
-			// add AFTER checking for historic stuff
-			m_historicDamage.push_back(HistoricWeaponDamageInfo(TheGameLogic->getFrame(), *pos));
-		}
+		// add AFTER checking for historic stuff
+		m_historicDamage.push_back(HistoricWeaponDamageInfo(TheGameLogic->getFrame(), *pos));
 	}
 }
 #endif

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -1194,12 +1194,17 @@ void WeaponTemplate::trimOldHistoricDamage() const
 #else
 void WeaponTemplate::trimOldHistoricDamage() const
 {
+	if (m_historicDamage.empty())
+		return;
+
+	const UnsignedInt currentFrame = TheGameLogic->getFrame();
+	const UnsignedInt expirationFrame = currentFrame - m_historicBonusTime;
+
 	HistoricWeaponDamageList::iterator it = m_historicDamage.begin();
 
 	while (it != m_historicDamage.end())
 	{
-		UnsignedInt expirationFrame = it->frame + m_historicBonusTime;
-		if (TheGameLogic->getFrame() > expirationFrame || it->triggered)
+		if (it->frame <= expirationFrame || it->triggered)
 			it = m_historicDamage.erase(it);
 		else
 			++it;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -1204,13 +1204,27 @@ void WeaponTemplate::trimOldHistoricDamage() const
 
 	while (it != m_historicDamage.end())
 	{
-		if (it->frame <= expirationFrame || it->triggered)
+		if (it->frame <= expirationFrame)
+			it = m_historicDamage.erase(it);
+		else
+			break;
+	}
+}
+#endif
+
+//-------------------------------------------------------------------------------------------------
+void WeaponTemplate::trimTriggeredHistoricDamage() const
+{
+	HistoricWeaponDamageList::iterator it = m_historicDamage.begin();
+
+	while (it != m_historicDamage.end())
+	{
+		if (it->triggered)
 			it = m_historicDamage.erase(it);
 		else
 			++it;
 	}
 }
-#endif
 
 //-------------------------------------------------------------------------------------------------
 static Bool is2DDistSquaredLessThan(const Coord3D& a, const Coord3D& b, Real distSqr)
@@ -1294,6 +1308,7 @@ void WeaponTemplate::processHistoricDamage(const Object* source, const Coord3D* 
 					if (count >= requiredCount)
 					{
 						TheWeaponStore->createAndFireTempWeapon(m_historicBonusWeapon, source, pos);
+						trimTriggeredHistoricDamage();
 						return;
 					}
 				}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -323,7 +323,7 @@ WeaponTemplate::WeaponTemplate() : m_nextTemplate(NULL)
 	m_suspendFXDelay								= 0;
 	m_dieOnDetonate						= FALSE;
 
-	m_historicDamageInstanceCount = 0;
+	m_historicDamageTriggerId = 0;
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1221,7 +1221,7 @@ void WeaponTemplate::trimTriggeredHistoricDamage() const
 
 	while (it != m_historicDamage.end())
 	{
-		if (it->triggerIndex == m_historicDamageInstanceCount)
+		if (it->triggerId == m_historicDamageTriggerId)
 			it = m_historicDamage.erase(it);
 		else
 			++it;
@@ -1292,7 +1292,7 @@ void WeaponTemplate::processHistoricDamage(const Object* source, const Coord3D* 
 	{
 		trimOldHistoricDamage();
 
-		++m_historicDamageInstanceCount;
+		++m_historicDamageTriggerId;
 
 		const Int requiredCount = m_historicBonusCount - 1; // minus 1 since we include ourselves implicitly
 		if (m_historicDamage.size() >= requiredCount)
@@ -1306,7 +1306,7 @@ void WeaponTemplate::processHistoricDamage(const Object* source, const Coord3D* 
 				{
 					// This one is close enough in time and distance, so count it. This is tracked by template since it applies
 					// across units, so don't try to clear historicDamage on success in here.
-					it->triggerIndex = m_historicDamageInstanceCount;
+					it->triggerId = m_historicDamageTriggerId;
 
 					if (++count == requiredCount)
 					{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -1197,10 +1197,7 @@ void WeaponTemplate::trimOldHistoricDamage() const
 void WeaponTemplate::trimOldHistoricDamage() const
 {
 	if (m_historicDamage.empty())
-	{
-		m_historicDamageInstanceCount = 0;
 		return;
-	}
 
 	const UnsignedInt currentFrame = TheGameLogic->getFrame();
 	const UnsignedInt expirationFrame = currentFrame - m_historicBonusTime;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -1208,10 +1208,10 @@ void WeaponTemplate::processHistoricDamage(const Object* source, const Coord3D* 
 	// firestorms (CBD) */
 	//
 
-	trimOldHistoricDamage();
-
 	if( m_historicBonusCount > 0 && m_historicBonusWeapon != this )
 	{
+		trimOldHistoricDamage();
+
 		Real radSqr = m_historicBonusRadius * m_historicBonusRadius;
 		Int count = 0;
 		UnsignedInt frameNow = TheGameLogic->getFrame();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -1199,16 +1199,8 @@ static Bool is2DDistSquaredLessThan(const Coord3D& a, const Coord3D& b, Real dis
 }
 
 //-------------------------------------------------------------------------------------------------
-void WeaponTemplate::dealDamageInternal(ObjectID sourceID, ObjectID victimID, const Coord3D *pos, const WeaponBonus& bonus, Bool isProjectileDetonation) const
+void WeaponTemplate::processHistoricDamage(const Object* source, const Coord3D* pos) const
 {
-	if (sourceID == 0)	// must have a source
-		return;
-
-	if (victimID == 0 && pos == NULL)	// must have some sort of destination
-		return;
-
-	Object *source = TheGameLogic->findObjectByID(sourceID);	// might be null...
-
 	//
 	/** @todo We need to rewrite the historic stuff ... if you fire 5 missiles, and the 5th,
 	// one creates a firestorm ... and then half a second later another volley of 5 missiles
@@ -1254,6 +1246,20 @@ void WeaponTemplate::dealDamageInternal(ObjectID sourceID, ObjectID victimID, co
 		}
 
 	}
+}
+
+//-------------------------------------------------------------------------------------------------
+void WeaponTemplate::dealDamageInternal(ObjectID sourceID, ObjectID victimID, const Coord3D *pos, const WeaponBonus& bonus, Bool isProjectileDetonation) const
+{
+	if (sourceID == 0)	// must have a source
+		return;
+
+	if (victimID == 0 && pos == NULL)	// must have some sort of destination
+		return;
+
+	Object *source = TheGameLogic->findObjectByID(sourceID);	// might be null...
+
+	processHistoricDamage(source, pos);
 
 //DEBUG_LOG(("WeaponTemplate::dealDamageInternal: dealing damage %s at frame %d",m_name.str(),TheGameLogic->getFrame()));
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -1198,8 +1198,8 @@ void WeaponTemplate::trimOldHistoricDamage() const
 
 	while (it != m_historicDamage.end())
 	{
-		UnsignedInt expirationDate = it->frame + m_historicBonusTime;
-		if (TheGameLogic->getFrame() > expirationDate || it->triggered)
+		UnsignedInt expirationFrame = it->frame + m_historicBonusTime;
+		if (TheGameLogic->getFrame() > expirationFrame || it->triggered)
 			it = m_historicDamage.erase(it);
 		else
 			++it;


### PR DESCRIPTION
* Fixes #1760

This change fixes historic bonus weapons not triggering reliably. The issue is that whenever a historic bonus weapon is triggered (e.g. a firestorm) it resets the historic bonus count for _all_ weapons using the same template. This means that if a firestorm is triggered while another firestorm is half way to triggering, that other firestorm's progress will be reset.

In addition, historic damage instances now more accurately expire based on the weapon template's `HistoricBonusTime` rather than the global `HistoricDamageLimit`. Historic damage involved in triggering a historic weapon cannot be used in subsequent attempts.

### Example

Four MiGs must strike a target within a certain radius to trigger a firestorm. Each missile contributes +1 to the historic bonus count of `NapalmMissileWeapon`, which must reach 8 to create the firestorm.

Now imagine a scenario where there are two squadrons of four MiGs each, Squad A and Squad B. Both squads strike different targets at the roughly same time.

Squad A MiG 1 increases the historic bonus count to 2.
Squad A MiG 2 increases the historic bonus count to 4.
Squad B MiG 1 increases the historic bonus count to 6.
Squad B MiG 2 increases the historic bonus count to 8.
Squad A MiG 3 increases the historic bonus count to 10.
Squad A MiG 4 increases the historic bonus count to 12.
Of the 12 historic bonus instances, 8 are determined to be in the same location, and thus a firestorm is triggered for Squad A.
The triggering of Squad A's firestorm resets the historic bonus count to 0.
Squad B MiG 3 increases the historic bonus count to 2.
Squad B MiG 4 increases the historic bonus count to 4.
No firestorm is triggered for Squad B.

### Demonstration of the bug

https://github.com/user-attachments/assets/7e3a4c19-8aff-4dba-afdd-3a2ff8daeae5

Note: When testing with Inferno Cannons, it is preferable to test without the `HeightDieUpdate` modules in the `InfernoTankShell` and `InfernoTankShellUpgraded` weapon objects for 100% accuracy. See [#1564](https://github.com/TheSuperHackers/GeneralsGamePatch/pull/1564) from the patch repository for more info.