### PR TITLE
refactor(network): replace manual size calculations with packed structs

### DIFF
--- a/Core/GameEngine/CMakeLists.txt
+++ b/Core/GameEngine/CMakeLists.txt
@@ -545,6 +545,7 @@ set(GAMEENGINE_SRC
     Include/GameNetwork/NetCommandRef.h
     Include/GameNetwork/NetCommandWrapperList.h
     Include/GameNetwork/NetPacket.h
+    Include/GameNetwork/NetPacketStructs.h
     Include/GameNetwork/NetworkDefs.h
     Include/GameNetwork/NetworkInterface.h
     Include/GameNetwork/networkutil.h

--- a/Core/GameEngine/Include/GameNetwork/NetCommandMsg.h
+++ b/Core/GameEngine/Include/GameNetwork/NetCommandMsg.h
@@ -50,6 +50,7 @@ public:
 	inline void setNetCommandType(NetCommandType type) { m_commandType = type; }
 	inline NetCommandType getNetCommandType() { return m_commandType; }
 	virtual Int getSortNumber();
+	virtual size_t getPackedByteCount() const = 0;
 	void attach();
 	void detach();
 
@@ -80,6 +81,8 @@ public:
 	void addArgument(const GameMessageArgumentDataType type, GameMessageArgumentType arg);
 	void setGameMessageType(GameMessage::Type type);
 
+	virtual size_t getPackedByteCount() const;
+
 protected:
 	Int m_numArgs;
 	Int m_argSize;
@@ -106,6 +109,8 @@ public:
 	void setOriginalPlayerID(UnsignedByte originalPlayerID);
 	virtual Int getSortNumber();
 
+	virtual size_t getPackedByteCount() const;
+
 protected:
 	UnsignedShort m_commandID;
 	UnsignedByte m_originalPlayerID;
@@ -129,6 +134,8 @@ public:
 	UnsignedByte getOriginalPlayerID();
 	void setOriginalPlayerID(UnsignedByte originalPlayerID);
 	virtual Int getSortNumber();
+
+	virtual size_t getPackedByteCount() const;
 
 protected:
 	UnsignedShort m_commandID;
@@ -154,6 +161,8 @@ public:
 	void setOriginalPlayerID(UnsignedByte originalPlayerID);
 	virtual Int getSortNumber();
 
+	virtual size_t getPackedByteCount() const;
+
 protected:
 	UnsignedShort m_commandID;
 	UnsignedByte m_originalPlayerID;
@@ -170,6 +179,8 @@ public:
 	void setCommandCount(UnsignedShort commandCount);
 	UnsignedShort getCommandCount();
 
+	virtual size_t getPackedByteCount() const;
+
 protected:
 	UnsignedShort m_commandCount;
 };
@@ -184,6 +195,8 @@ public:
 
 	UnsignedByte getLeavingPlayerID();
 	void setLeavingPlayerID(UnsignedByte id);
+
+	virtual size_t getPackedByteCount() const;
 
 protected:
 	UnsignedByte m_leavingPlayerID;
@@ -201,6 +214,8 @@ public:
 	void setAverageLatency(Real avgLat);
 	Int  getAverageFps();
 	void setAverageFps(Int fps);
+
+	virtual size_t getPackedByteCount() const;
 
 protected:
 	Real m_averageLatency;
@@ -221,6 +236,8 @@ public:
 	UnsignedByte getFrameRate();
 	void setFrameRate(UnsignedByte frameRate);
 
+	virtual size_t getPackedByteCount() const;
+
 protected:
 	UnsignedShort m_runAhead;
 	UnsignedByte m_frameRate;
@@ -237,6 +254,8 @@ public:
 	UnsignedInt getPlayerIndex();
 	void setPlayerIndex(UnsignedInt playerIndex);
 
+	virtual size_t getPackedByteCount() const;
+
 protected:
 	UnsignedInt m_playerIndex;
 };
@@ -248,6 +267,8 @@ class NetKeepAliveCommandMsg : public NetCommandMsg
 public:
 	NetKeepAliveCommandMsg();
 	//virtual ~NetKeepAliveCommandMsg();
+
+	virtual size_t getPackedByteCount() const;
 };
 
 //-----------------------------------------------------------------------------
@@ -257,6 +278,8 @@ class NetDisconnectKeepAliveCommandMsg : public NetCommandMsg
 public:
 	NetDisconnectKeepAliveCommandMsg();
 	//virtual ~NetDisconnectKeepAliveCommandMsg();
+
+	virtual size_t getPackedByteCount() const;
 };
 
 //-----------------------------------------------------------------------------
@@ -273,6 +296,8 @@ public:
 	UnsignedInt getDisconnectFrame();
 	void setDisconnectFrame(UnsignedInt frame);
 
+	virtual size_t getPackedByteCount() const;
+
 protected:
 	UnsignedByte m_disconnectSlot;
 	UnsignedInt m_disconnectFrame;
@@ -285,6 +310,8 @@ class NetPacketRouterQueryCommandMsg : public NetCommandMsg
 public:
 	NetPacketRouterQueryCommandMsg();
 	//virtual ~NetPacketRouterQueryCommandMsg();
+
+	virtual size_t getPackedByteCount() const;
 };
 
 //-----------------------------------------------------------------------------
@@ -294,6 +321,8 @@ class NetPacketRouterAckCommandMsg : public NetCommandMsg
 public:
 	NetPacketRouterAckCommandMsg();
 	//virtual ~NetPacketRouterAckCommandMsg();
+
+	virtual size_t getPackedByteCount() const;
 };
 
 //-----------------------------------------------------------------------------
@@ -306,6 +335,8 @@ public:
 
 	UnicodeString getText();
 	void setText(UnicodeString text);
+
+	virtual size_t getPackedByteCount() const;
 
 protected:
 	UnicodeString m_text;
@@ -324,6 +355,8 @@ public:
 
 	Int getPlayerMask( void );
 	void setPlayerMask( Int playerMask );
+
+	virtual size_t getPackedByteCount() const;
 
 protected:
 	UnicodeString m_text;
@@ -344,6 +377,8 @@ public:
 	UnsignedInt getVoteFrame();
 	void setVoteFrame(UnsignedInt voteFrame);
 
+	virtual size_t getPackedByteCount() const;
+
 protected:
 	UnsignedByte m_slot;
 	UnsignedInt m_voteFrame;
@@ -359,6 +394,8 @@ public:
 
 	UnsignedByte getPercentage();
 	void setPercentage( UnsignedByte percent );
+
+	virtual size_t getPackedByteCount() const;
 protected:
 	UnsignedByte m_percent;
 };
@@ -373,6 +410,8 @@ public:
 
 	UnsignedByte * getData();
 	void setData(UnsignedByte *data, UnsignedInt dataLength);
+
+	virtual size_t getPackedByteCount() const;
 
 	UnsignedInt getChunkNumber();
 	void setChunkNumber(UnsignedInt chunkNumber);
@@ -421,6 +460,8 @@ public:
 	UnsignedByte * getFileData();
 	void setFileData(UnsignedByte *data, UnsignedInt dataLength);
 
+	virtual size_t getPackedByteCount() const;
+
 protected:
 	AsciiString m_portableFilename;
 
@@ -448,6 +489,8 @@ public:
 	UnsignedByte getPlayerMask(void);
 	void setPlayerMask(UnsignedByte playerMask);
 
+	virtual size_t getPackedByteCount() const;
+
 protected:
 	AsciiString m_portableFilename;
 	UnsignedShort m_fileID;
@@ -468,6 +511,8 @@ public:
 	Int getProgress();
 	void setProgress(Int val);
 
+	virtual size_t getPackedByteCount() const;
+
 protected:
 	UnsignedShort m_fileID;
 	Int m_progress;
@@ -483,6 +528,8 @@ public:
 	UnsignedInt getDisconnectFrame();
 	void setDisconnectFrame(UnsignedInt disconnectFrame);
 
+	virtual size_t getPackedByteCount() const;
+
 protected:
 	UnsignedInt m_disconnectFrame;
 };
@@ -496,6 +543,8 @@ public:
 
 	UnsignedInt getNewFrame();
 	void setNewFrame(UnsignedInt newFrame);
+
+	virtual size_t getPackedByteCount() const;
 
 protected:
 	UnsignedInt m_newFrame;
@@ -511,6 +560,28 @@ public:
 	UnsignedInt getFrameToResend();
 	void setFrameToResend(UnsignedInt frame);
 
+	virtual size_t getPackedByteCount() const;
+
 protected:
 	UnsignedInt m_frameToResend;
+};
+
+class NetLoadCompleteCommandMsg : public NetCommandMsg
+{
+	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(NetLoadCompleteCommandMsg, "NetLoadCompleteCommandMsg")
+public:
+	NetLoadCompleteCommandMsg();
+	//virtual ~NetLoadCompleteCommandMsg();
+
+	virtual size_t getPackedByteCount() const;
+};
+
+class NetTimeOutGameStartCommandMsg : public NetCommandMsg
+{
+	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(NetTimeOutGameStartCommandMsg, "NetTimeOutGameStartCommandMsg")
+public:
+	NetTimeOutGameStartCommandMsg();
+	//virtual ~NetTimeOutGameStartCommandMsg();
+
+	virtual size_t getPackedByteCount() const;
 };

--- a/Core/GameEngine/Include/GameNetwork/NetPacketStructs.h
+++ b/Core/GameEngine/Include/GameNetwork/NetPacketStructs.h
@@ -1,0 +1,422 @@
+/*
+**	Command & Conquer Generals Zero Hour(tm)
+**	Copyright 2025 TheSuperHackers.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// TheSuperHackers @refactor BobTista 10/07/2025
+// Packed struct definitions for network packet serialization/deserialization.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "GameNetwork/NetworkDefs.h"
+
+// Ensure structs are packed to 1-byte alignment for network protocol compatibility
+#pragma pack(push, 1)
+
+// Network packet field type definitions
+typedef UnsignedByte NetPacketFieldType;
+
+namespace NetPacketFieldTypes {
+	constexpr const NetPacketFieldType CommandType = 'T';		// NetCommandType field
+	constexpr const NetPacketFieldType Relay = 'R';				// Relay field
+	constexpr const NetPacketFieldType PlayerId = 'P';			// Player ID field
+	constexpr const NetPacketFieldType CommandId = 'C';			// Command ID field
+	constexpr const NetPacketFieldType Frame = 'F';				// Frame field
+	constexpr const NetPacketFieldType Data = 'D';				// Data payload field
+}
+
+struct NetPacketCommandTypeField {
+	const NetPacketFieldType type;
+	UnsignedByte commandType;
+
+	NetPacketCommandTypeField() : type(NetPacketFieldTypes::CommandType) {}
+};
+
+struct NetPacketRelayField {
+	const NetPacketFieldType type;
+	UnsignedByte relay;
+
+	NetPacketRelayField() : type(NetPacketFieldTypes::Relay) {}
+};
+
+struct NetPacketPlayerIdField {
+	const NetPacketFieldType type;
+	UnsignedByte playerId;
+
+	NetPacketPlayerIdField() : type(NetPacketFieldTypes::PlayerId) {}
+};
+
+struct NetPacketFrameField {
+	const NetPacketFieldType type;
+	UnsignedInt frame;
+
+	NetPacketFrameField() : type(NetPacketFieldTypes::Frame) {}
+};
+
+struct NetPacketCommandIdField {
+	const NetPacketFieldType type;
+	UnsignedShort commandId;
+
+	NetPacketCommandIdField() : type(NetPacketFieldTypes::CommandId) {}
+};
+
+struct NetPacketDataFieldHeader {
+	const NetPacketFieldType type;
+
+	NetPacketDataFieldHeader() : type(NetPacketFieldTypes::Data) {}
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Acknowledgment Command Packets
+////////////////////////////////////////////////////////////////////////////////
+
+struct NetPacketAckCommand {
+	NetPacketCommandTypeField commandType;
+	NetPacketPlayerIdField playerId;
+	NetPacketDataFieldHeader dataHeader;
+	UnsignedShort commandId;
+	UnsignedByte originalPlayerId;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Frame Info Command Packet
+////////////////////////////////////////////////////////////////////////////////
+
+struct NetPacketFrameCommand {
+	NetPacketCommandTypeField commandType;
+	NetPacketRelayField relay;
+	NetPacketFrameField frame;
+	NetPacketPlayerIdField playerId;
+	NetPacketCommandIdField commandId;
+	NetPacketDataFieldHeader dataHeader;
+	UnsignedShort commandCount;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Player Leave Command Packet
+////////////////////////////////////////////////////////////////////////////////
+
+struct NetPacketPlayerLeaveCommand {
+	NetPacketCommandTypeField commandType;
+	NetPacketRelayField relay;
+	NetPacketFrameField frame;
+	NetPacketPlayerIdField playerId;
+	NetPacketCommandIdField commandId;
+	NetPacketDataFieldHeader dataHeader;
+	UnsignedByte leavingPlayerId;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Run Ahead Metrics Command Packet
+////////////////////////////////////////////////////////////////////////////////
+
+struct NetPacketRunAheadMetricsCommand {
+	NetPacketCommandTypeField commandType;
+	NetPacketRelayField relay;
+	NetPacketPlayerIdField playerId;
+	NetPacketCommandIdField commandId;
+	NetPacketDataFieldHeader dataHeader;
+	Real averageLatency;
+	UnsignedShort averageFps;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Run Ahead Command Packet
+////////////////////////////////////////////////////////////////////////////////
+
+struct NetPacketRunAheadCommand {
+	NetPacketCommandTypeField commandType;
+	NetPacketRelayField relay;
+	NetPacketFrameField frame;
+	NetPacketPlayerIdField playerId;
+	NetPacketCommandIdField commandId;
+	NetPacketDataFieldHeader dataHeader;
+	UnsignedShort runAhead;
+	UnsignedByte frameRate;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Destroy Player Command Packet
+////////////////////////////////////////////////////////////////////////////////
+
+struct NetPacketDestroyPlayerCommand {
+	NetPacketCommandTypeField commandType;
+	NetPacketRelayField relay;
+	NetPacketFrameField frame;
+	NetPacketPlayerIdField playerId;
+	NetPacketCommandIdField commandId;
+	NetPacketDataFieldHeader dataHeader;
+	UnsignedInt playerIndex;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Keep Alive Command Packet
+////////////////////////////////////////////////////////////////////////////////
+
+struct NetPacketKeepAliveCommand {
+	NetPacketCommandTypeField commandType;
+	NetPacketRelayField relay;
+	NetPacketPlayerIdField playerId;
+	NetPacketDataFieldHeader dataHeader;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Disconnect Keep Alive Command Packet
+////////////////////////////////////////////////////////////////////////////////
+
+struct NetPacketDisconnectKeepAliveCommand {
+	NetPacketCommandTypeField commandType;
+	NetPacketRelayField relay;
+	NetPacketPlayerIdField playerId;
+	NetPacketDataFieldHeader dataHeader;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Disconnect Player Command Packet
+////////////////////////////////////////////////////////////////////////////////
+
+struct NetPacketDisconnectPlayerCommand {
+	NetPacketCommandTypeField commandType;
+	NetPacketRelayField relay;
+	NetPacketPlayerIdField playerId;
+	NetPacketCommandIdField commandId;
+	NetPacketDataFieldHeader dataHeader;
+	UnsignedByte slot;
+	UnsignedInt disconnectFrame;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Packet Router Command Packets
+////////////////////////////////////////////////////////////////////////////////
+
+// Packet router query command packet
+struct NetPacketRouterQueryCommand {
+	NetPacketCommandTypeField commandType;
+	NetPacketRelayField relay;
+	NetPacketPlayerIdField playerId;
+	NetPacketDataFieldHeader dataHeader;
+};
+
+// Packet router ack command packet
+struct NetPacketRouterAckCommand {
+	NetPacketCommandTypeField commandType;
+	NetPacketRelayField relay;
+	NetPacketPlayerIdField playerId;
+	NetPacketDataFieldHeader dataHeader;
+};
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Variable-Length Packet Headers
+// These structs represent the fixed portion of packets with variable data
+////////////////////////////////////////////////////////////////////////////////
+
+// Chat command header (variable: text follows)
+struct NetPacketChatCommandHeader {
+	NetPacketCommandTypeField commandType;
+	NetPacketFrameField frame;
+	NetPacketRelayField relay;
+	NetPacketPlayerIdField playerId;
+	NetPacketCommandIdField commandId;
+	NetPacketDataFieldHeader dataHeader;
+};
+
+struct NetPacketDisconnectChatCommandHeader {
+	NetPacketCommandTypeField commandType;
+	NetPacketRelayField relay;
+	NetPacketPlayerIdField playerId;
+	NetPacketDataFieldHeader dataHeader;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Packed Structs for getPackedByteCount() calculations
+// These structs represent the fixed portion of variable-length command messages
+////////////////////////////////////////////////////////////////////////////////
+
+struct NetPacketChatCommand {
+	NetPacketCommandTypeField commandType;
+	NetPacketRelayField relay;
+	NetPacketPlayerIdField playerId;
+	NetPacketDataFieldHeader dataHeader;
+	NetPacketFrameField frame;
+	NetPacketCommandIdField commandId;
+};
+
+struct NetPacketDisconnectChatCommand {
+	NetPacketCommandTypeField commandType;
+	NetPacketRelayField relay;
+	NetPacketPlayerIdField playerId;
+	NetPacketDataFieldHeader dataHeader;
+};
+
+// Game command packed struct (variable: game message data follows)
+struct NetPacketGameCommand {
+	NetPacketCommandTypeField commandType;
+	NetPacketRelayField relay;
+	NetPacketPlayerIdField playerId;
+	NetPacketDataFieldHeader dataHeader;
+	NetPacketFrameField frame;
+	NetPacketCommandIdField commandId;
+};
+
+// File command packed struct (variable: filename and file data follow)
+struct NetPacketFileCommand {
+	NetPacketCommandTypeField commandType;
+	NetPacketRelayField relay;
+	NetPacketPlayerIdField playerId;
+	NetPacketDataFieldHeader dataHeader;
+	NetPacketCommandIdField commandId;
+};
+
+// File announce command packed struct (variable: filename and metadata follow)
+struct NetPacketFileAnnounceCommand {
+	NetPacketCommandTypeField commandType;
+	NetPacketRelayField relay;
+	NetPacketPlayerIdField playerId;
+	NetPacketDataFieldHeader dataHeader;
+	NetPacketCommandIdField commandId;
+};
+
+struct NetPacketDisconnectVoteCommand {
+	NetPacketCommandTypeField commandType;
+	NetPacketRelayField relay;
+	NetPacketPlayerIdField playerId;
+	NetPacketCommandIdField commandId;
+	NetPacketDataFieldHeader dataHeader;
+	UnsignedByte slot;
+	UnsignedInt voteFrame;
+};
+
+struct NetPacketWrapperCommand {
+	NetPacketCommandTypeField commandType;
+	NetPacketPlayerIdField playerId;
+	NetPacketCommandIdField commandId;
+	NetPacketRelayField relay;
+	NetPacketDataFieldHeader dataHeader;
+	UnsignedShort wrappedCommandId;
+	UnsignedInt chunkNumber;
+	UnsignedInt numChunks;
+	UnsignedInt totalDataLength;
+	UnsignedInt dataLength;
+	UnsignedInt dataOffset;
+};
+
+// File command header (variable: filename and file data follow)
+// Variable: null-terminated filename + UnsignedInt fileDataLength + file data
+struct NetPacketFileCommandHeader {
+	NetPacketCommandTypeField commandType;
+	NetPacketRelayField relay;
+	NetPacketPlayerIdField playerId;
+	NetPacketCommandIdField commandId;
+	NetPacketDataFieldHeader dataHeader;
+};
+
+// File announce command header (variable: filename and metadata follow)
+// Variable: null-terminated filename + UnsignedShort fileID + UnsignedByte playerMask
+struct NetPacketFileAnnounceCommandHeader {
+	NetPacketCommandTypeField commandType;
+	NetPacketRelayField relay;
+	NetPacketPlayerIdField playerId;
+	NetPacketCommandIdField commandId;
+	NetPacketDataFieldHeader dataHeader;
+};
+
+// File progress command packet
+struct NetPacketFileProgressCommand {
+	NetPacketCommandTypeField commandType;
+	NetPacketRelayField relay;
+	NetPacketPlayerIdField playerId;
+	NetPacketCommandIdField commandId;
+	NetPacketDataFieldHeader dataHeader;
+	UnsignedShort fileId;
+	Int progress;
+};
+
+// Game command header (variable: game message data follows)
+// Variable: GameMessage type + argument types + argument data
+struct NetPacketGameCommandHeader {
+	NetPacketCommandTypeField commandType;
+	NetPacketFrameField frame;
+	NetPacketRelayField relay;
+	NetPacketPlayerIdField playerId;
+	NetPacketCommandIdField commandId;
+	NetPacketDataFieldHeader dataHeader;
+};
+
+// Progress message packet
+struct NetPacketProgressMessage {
+	NetPacketCommandTypeField commandType;
+	NetPacketRelayField relay;
+	NetPacketPlayerIdField playerId;
+	NetPacketCommandIdField commandId;
+	NetPacketDataFieldHeader dataHeader;
+	UnsignedByte percentage;
+};
+
+// Load complete message packet
+struct NetPacketLoadCompleteMessage {
+	NetPacketCommandTypeField commandType;
+	NetPacketRelayField relay;
+	NetPacketPlayerIdField playerId;
+	NetPacketCommandIdField commandId;
+	NetPacketDataFieldHeader dataHeader;
+};
+
+// Timeout game start message packet
+struct NetPacketTimeOutGameStartMessage {
+	NetPacketCommandTypeField commandType;
+	NetPacketRelayField relay;
+	NetPacketPlayerIdField playerId;
+	NetPacketCommandIdField commandId;
+	NetPacketDataFieldHeader dataHeader;
+};
+
+// Disconnect frame command packet
+struct NetPacketDisconnectFrameCommand {
+	NetPacketCommandTypeField commandType;
+	NetPacketRelayField relay;
+	NetPacketPlayerIdField playerId;
+	NetPacketCommandIdField commandId;
+	NetPacketDataFieldHeader dataHeader;
+	UnsignedInt disconnectFrame;
+};
+
+// Disconnect screen off command packet
+struct NetPacketDisconnectScreenOffCommand {
+	NetPacketCommandTypeField commandType;
+	NetPacketRelayField relay;
+	NetPacketPlayerIdField playerId;
+	NetPacketCommandIdField commandId;
+	NetPacketDataFieldHeader dataHeader;
+	UnsignedInt newFrame;
+};
+
+// Frame resend request command packet
+struct NetPacketFrameResendRequestCommand {
+	NetPacketCommandTypeField commandType;
+	NetPacketRelayField relay;
+	NetPacketPlayerIdField playerId;
+	NetPacketCommandIdField commandId;
+	NetPacketDataFieldHeader dataHeader;
+	UnsignedInt frameToResend;
+};
+
+// Restore normal struct packing
+#pragma pack(pop)

--- a/Core/GameEngine/Source/GameNetwork/ConnectionManager.cpp
+++ b/Core/GameEngine/Source/GameNetwork/ConnectionManager.cpp
@@ -2275,12 +2275,11 @@ void ConnectionManager::updateLoadProgress( Int progress )
 
 void ConnectionManager::loadProgressComplete()
 {
-	NetCommandMsg *msg = newInstance(NetCommandMsg);
+	NetLoadCompleteCommandMsg *msg = newInstance(NetLoadCompleteCommandMsg);
 	msg->setPlayerID( m_localSlot );
 	if (DoesCommandRequireACommandID(msg->getNetCommandType()) == TRUE) {
 		msg->setID(GenerateNextCommandID());
 	}
-	msg->setNetCommandType(NETCOMMANDTYPE_LOADCOMPLETE);
 	processLoadComplete(msg);
 	sendLocalCommand(msg, 0xff ^ (1 << m_localSlot));
 
@@ -2289,9 +2288,8 @@ void ConnectionManager::loadProgressComplete()
 
 void ConnectionManager::sendTimeOutGameStart()
 {
-	NetCommandMsg *msg = newInstance(NetCommandMsg);
+	NetTimeOutGameStartCommandMsg *msg = newInstance(NetTimeOutGameStartCommandMsg);
 	msg->setPlayerID( m_localSlot );
-	msg->setNetCommandType(NETCOMMANDTYPE_TIMEOUTSTART);
 	if (DoesCommandRequireACommandID(msg->getNetCommandType()) == TRUE) {
 		msg->setID(GenerateNextCommandID());
 	}


### PR DESCRIPTION
* Merge after #1733

- Added NetPacketStructs.h, which introduces packed struct definitions for all 25 network command message types
- Implemented getPackedByteCount() Interface
- Eliminated manual size calculations in NetPacket.cpp
- Updated ConnectionManager to use specific command message classes directly instead of generic NetCommandMsg