### PR TITLE
refactor: Remove superfluous defines from Language.h

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/Language.h
+++ b/Generals/Code/GameEngine/Include/Common/Language.h
@@ -75,27 +75,6 @@ typedef enum
 
 } LanguageID;
 
-#define GameStrcpy wcscpy
-#define GameStrlen wcslen
-#define GameStrcat wcscat
-#define GameStrcmp wcscmp
-#define GameStrncmp wcsncmp
-#define GameStricmp wcsicmp
-#define GameStrnicmp wcsnicmp
-#define GameStrtok wcstok
-#define GameSprintf swprintf
-#define GameVsprintf vswprintf
-/// @todo -- add a non-malloc-based string dup func #define GameStrdup wcsdup
-#define GameAtoi(S) wcstol( (S), NULL, 10)
-#define GameAtod(S) wcstod( (S), NULL )
-#define GameItoa _itow
-#define GameSscanf swscanf
-#define GameStrstr wcsstr
-#define GameStrchr wcschr
-#define GameIsDigit iswdigit
-#define GameIsAscii iswascii
-#define GameIsAlNum iswalnum
-#define GameIsAlpha iswalpha
 #define GameArrayEnd(array) (array)[(sizeof(array)/sizeof((array)[0]))-1] = 0
 
 // INLINING ///////////////////////////////////////////////////////////////////

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GameWindowGlobal.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GameWindowGlobal.cpp
@@ -48,7 +48,6 @@
 #include "PreRTS.h"	// This must go first in EVERY cpp file int the GameEngine
 
 // USER INCLUDES //////////////////////////////////////////////////////////////
-#include "Common/Language.h"
 #include "GameClient/Image.h"
 #include "GameClient/Display.h"
 #include "GameClient/GameWindowManager.h"
@@ -196,7 +195,7 @@ Int GameWindowManager::winFontHeight( GameFont *font )
 Int GameWindowManager::winIsDigit( Int c )
 {
 
-	return GameIsDigit( c );
+	return iswdigit( c );
 
 }
 
@@ -206,7 +205,7 @@ Int GameWindowManager::winIsDigit( Int c )
 Int GameWindowManager::winIsAscii( Int c )
 {
 
-	return GameIsAscii( c );
+	return iswascii( c );
 
 }
 
@@ -216,7 +215,7 @@ Int GameWindowManager::winIsAscii( Int c )
 Int GameWindowManager::winIsAlNum( Int c )
 {
 
-	return GameIsAlNum( c );
+	return iswalnum( c );
 
 }
 

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/IMEManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/IMEManager.cpp
@@ -1130,7 +1130,7 @@ void IMEManager::updateCompositionString( void )
 				else
 				{
 					m_compositionCursorPos = (ImmGetCompositionString( m_context, GCS_CURSORPOS, NULL, 0) & 0xffff );
-					convRes = GameStrlen ( m_compositionString );
+					convRes = wcslen( m_compositionString );
 				}
 
 				// m_compositionCursorPos is in DBCS characters, need to convert it to Wide characters

--- a/Generals/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
@@ -927,7 +927,7 @@ WideChar Keyboard::translateKey( WideChar keyCode )
 				return( m_keyNames[ ubKeyCode ].shifted2 );
 			}
 
-			if( isShift() || getCapsState() && GameIsAlpha( m_keyNames[ ubKeyCode ].stdKey ) )
+			if( isShift() || getCapsState() && iswalpha( m_keyNames[ ubKeyCode ].stdKey ) )
 			{
 				return( m_keyNames[ ubKeyCode ].shifted );
 			}

--- a/GeneralsMD/Code/GameEngine/Include/Common/Language.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Language.h
@@ -75,27 +75,6 @@ typedef enum
 
 } LanguageID;
 
-#define GameStrcpy wcscpy
-#define GameStrlen wcslen
-#define GameStrcat wcscat
-#define GameStrcmp wcscmp
-#define GameStrncmp wcsncmp
-#define GameStricmp wcsicmp
-#define GameStrnicmp wcsnicmp
-#define GameStrtok wcstok
-#define GameSprintf swprintf
-#define GameVsprintf vswprintf
-/// @todo -- add a non-malloc-based string dup func #define GameStrdup wcsdup
-#define GameAtoi(S) wcstol( (S), NULL, 10)
-#define GameAtod(S) wcstod( (S), NULL )
-#define GameItoa _itow
-#define GameSscanf swscanf
-#define GameStrstr wcsstr
-#define GameStrchr wcschr
-#define GameIsDigit iswdigit
-#define GameIsAscii iswascii
-#define GameIsAlNum iswalnum
-#define GameIsAlpha iswalpha
 #define GameArrayEnd(array) (array)[(sizeof(array)/sizeof((array)[0]))-1] = 0
 
 // INLINING ///////////////////////////////////////////////////////////////////

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowGlobal.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowGlobal.cpp
@@ -48,7 +48,6 @@
 #include "PreRTS.h"	// This must go first in EVERY cpp file int the GameEngine
 
 // USER INCLUDES //////////////////////////////////////////////////////////////
-#include "Common/Language.h"
 #include "GameClient/Image.h"
 #include "GameClient/Display.h"
 #include "GameClient/GameWindowManager.h"
@@ -196,7 +195,7 @@ Int GameWindowManager::winFontHeight( GameFont *font )
 Int GameWindowManager::winIsDigit( Int c )
 {
 
-	return GameIsDigit( c );
+	return iswdigit( c );
 
 }
 
@@ -206,7 +205,7 @@ Int GameWindowManager::winIsDigit( Int c )
 Int GameWindowManager::winIsAscii( Int c )
 {
 
-	return GameIsAscii( c );
+	return iswascii( c );
 
 }
 
@@ -216,7 +215,7 @@ Int GameWindowManager::winIsAscii( Int c )
 Int GameWindowManager::winIsAlNum( Int c )
 {
 
-	return GameIsAlNum( c );
+	return iswalnum( c );
 
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/IMEManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/IMEManager.cpp
@@ -1130,7 +1130,7 @@ void IMEManager::updateCompositionString( void )
 				else
 				{
 					m_compositionCursorPos = (ImmGetCompositionString( m_context, GCS_CURSORPOS, NULL, 0) & 0xffff );
-					convRes = GameStrlen ( m_compositionString );
+					convRes = wcslen( m_compositionString );
 				}
 
 				// m_compositionCursorPos is in DBCS characters, need to convert it to Wide characters

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
@@ -927,7 +927,7 @@ WideChar Keyboard::translateKey( WideChar keyCode )
 				return( m_keyNames[ ubKeyCode ].shifted2 );
 			}
 
-			if( isShift() || getCapsState() && GameIsAlpha( m_keyNames[ ubKeyCode ].stdKey ) )
+			if( isShift() || getCapsState() && iswalpha( m_keyNames[ ubKeyCode ].stdKey ) )
 			{
 				return( m_keyNames[ ubKeyCode ].shifted );
 			}


### PR DESCRIPTION
Cleaned up unnecessary defines in `language.h`:

- Removed multiple unused defines.
- Inlined defines that were only referenced once. Eliminated unnecessary dependencies on `language.h` where possible.
- Retained the `GameArrayEnd` define, as it’s used in multiple places and is relatively complex.

Already replicated in Generals.