### PR TITLE
unify(ww3d2): Equalize files between Zero Hour and Generals in WW3d2

### DIFF
--- a/Generals/Code/Libraries/Source/WWVegas/CMakeLists.txt
+++ b/Generals/Code/Libraries/Source/WWVegas/CMakeLists.txt
@@ -19,6 +19,10 @@ add_subdirectory(WWAudio)
 add_subdirectory(WW3D2)
 add_subdirectory(WWDownload)
 
+target_link_libraries(g_ww3d2 PRIVATE
+    gi_always
+)
+
 # Helpful interface to bundle the ww modules together.
 add_library(g_wwvegas INTERFACE)
 

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/animobj.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/animobj.cpp
@@ -1,5 +1,5 @@
 /*
-**	Command & Conquer Generals(tm)
+**	Command & Conquer Generals Zero Hour(tm)
 **	Copyright 2025 Electronic Arts Inc.
 **
 **	This program is free software: you can redistribute it and/or modify
@@ -26,9 +26,9 @@
  *                                                                                             *
  *                       Author:: Greg_h                                                       *
  *                                                                                             *
- *                     $Modtime:: 8/28/01 12:12p                                              $*
+ *                     $Modtime:: 12/13/01 6:56p                                              $*
  *                                                                                             *
- *                    $Revision:: 7                                                           $*
+ *                    $Revision:: 10                                                          $*
  *                                                                                             *
  *---------------------------------------------------------------------------------------------*
  * Functions:                                                                                  *
@@ -498,7 +498,6 @@ void Animatable3DObjClass::Set_Animation(HAnimClass * motion, float frame, int m
 	Set_Hierarchy_Valid(false);
 }
 
-
 /***********************************************************************************************
  * Animatable3DObjClass::Set_Animation -- set the animation state to a blend of two anims      *
  *                                                                                             *
@@ -869,8 +868,10 @@ bool Animatable3DObjClass::Simple_Evaluate_Bone(int boneindex, Matrix3D *tm) con
 	//
 	//	Only do this for simple animations
 	//
-	if (CurMotionMode == SINGLE_ANIM) {
-
+	if (	CurMotionMode == NONE ||
+			CurMotionMode == BASE_POSE ||
+			CurMotionMode == SINGLE_ANIM)
+	{
 		//
 		//	Determine which frame we should be on, then use this
 		// information to determine the bone's transform.
@@ -880,7 +881,8 @@ bool Animatable3DObjClass::Simple_Evaluate_Bone(int boneindex, Matrix3D *tm) con
 
 	} else {
 
-		*tm = Transform;
+		const_cast <Animatable3DObjClass *>(this)->Update_Sub_Object_Transforms();
+		*tm = HTree->Get_Transform(boneindex);
 
 	}
 
@@ -909,9 +911,15 @@ bool Animatable3DObjClass::Simple_Evaluate_Bone(int boneindex, float frame, Matr
 	//	Only do this for simple animations
 	//
 	if (HTree != NULL) {
+
 		if (CurMotionMode == SINGLE_ANIM) {
 			retval = HTree->Simple_Evaluate_Pivot (ModeAnim.Motion, boneindex, frame, Get_Transform (), tm);
+		} else if (CurMotionMode == NONE || CurMotionMode == BASE_POSE) {
+			retval = HTree->Simple_Evaluate_Pivot (boneindex, Get_Transform (), tm);
+		} else {
+			*tm = Transform;
 		}
+
 	} else {
 		*tm = Transform;
 	}

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/animobj.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/animobj.h
@@ -1,5 +1,5 @@
 /*
-**	Command & Conquer Generals(tm)
+**	Command & Conquer Generals Zero Hour(tm)
 **	Copyright 2025 Electronic Arts Inc.
 **
 **	This program is free software: you can redistribute it and/or modify

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/boxrobj.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/boxrobj.cpp
@@ -1,5 +1,5 @@
 /*
-**	Command & Conquer Generals(tm)
+**	Command & Conquer Generals Zero Hour(tm)
 **	Copyright 2025 Electronic Arts Inc.
 **
 **	This program is free software: you can redistribute it and/or modify
@@ -460,7 +460,7 @@ void BoxRenderObjClass::render_box(RenderInfoClass & rinfo,const Vector3 & cente
 		*/
 		DWORD color = DX8Wrapper::Convert_Color(Color,Opacity);
 
-		int buffer_type = BUFFER_TYPE_DYNAMIC_SORTING;
+		int buffer_type = BUFFER_TYPE_DYNAMIC_DX8;
 
 		DynamicVBAccessClass vbaccess(buffer_type,dynamic_fvf_type,NUM_BOX_VERTS);
 		{
@@ -805,6 +805,9 @@ void AABoxRenderObjClass::update_cached_box(void)
 bool AABoxRenderObjClass::Cast_Ray(RayCollisionTestClass & raytest)
 {
 	if ((Get_Collision_Type() & raytest.CollisionType) == 0) return false;
+	if (Is_Animation_Hidden()) return false;
+	if (raytest.Result->StartBad) return false;
+
 	if (CollisionMath::Collide(raytest.Ray,CachedBox,raytest.Result)) {
 		raytest.CollidedRenderObj = this;
 		return true;
@@ -828,6 +831,8 @@ bool AABoxRenderObjClass::Cast_Ray(RayCollisionTestClass & raytest)
 bool AABoxRenderObjClass::Cast_AABox(AABoxCollisionTestClass & boxtest)
 {
 	if ((Get_Collision_Type() & boxtest.CollisionType) == 0) return false;
+	if (boxtest.Result->StartBad) return false;
+
 	if (CollisionMath::Collide(boxtest.Box,boxtest.Move,CachedBox,boxtest.Result)) {
 		boxtest.CollidedRenderObj = this;
 		return true;
@@ -851,6 +856,8 @@ bool AABoxRenderObjClass::Cast_AABox(AABoxCollisionTestClass & boxtest)
 bool AABoxRenderObjClass::Cast_OBBox(OBBoxCollisionTestClass & boxtest)
 {
 	if ((Get_Collision_Type() & boxtest.CollisionType) == 0) return false;
+	if (boxtest.Result->StartBad) return false;
+
 	if (CollisionMath::Collide(boxtest.Box,boxtest.Move,CachedBox,Vector3(0,0,0),boxtest.Result)) {
 		boxtest.CollidedRenderObj = this;
 		return true;
@@ -1181,6 +1188,9 @@ void OBBoxRenderObjClass::update_cached_box(void)
 bool OBBoxRenderObjClass::Cast_Ray(RayCollisionTestClass & raytest)
 {
 	if ((Get_Collision_Type() & raytest.CollisionType) == 0) return false;
+	if (Is_Animation_Hidden()) return false;
+	if (raytest.Result->StartBad) return false;
+
 	if (CollisionMath::Collide(raytest.Ray,CachedBox,raytest.Result)) {
 		raytest.CollidedRenderObj = this;
 		return true;
@@ -1204,6 +1214,8 @@ bool OBBoxRenderObjClass::Cast_Ray(RayCollisionTestClass & raytest)
 bool OBBoxRenderObjClass::Cast_AABox(AABoxCollisionTestClass & boxtest)
 {
 	if ((Get_Collision_Type() & boxtest.CollisionType) == 0) return false;
+	if (boxtest.Result->StartBad) return false;
+
 	if (CollisionMath::Collide(boxtest.Box,boxtest.Move,CachedBox,Vector3(0,0,0),boxtest.Result)) {
 		boxtest.CollidedRenderObj = this;
 		return true;
@@ -1227,6 +1239,8 @@ bool OBBoxRenderObjClass::Cast_AABox(AABoxCollisionTestClass & boxtest)
 bool OBBoxRenderObjClass::Cast_OBBox(OBBoxCollisionTestClass & boxtest)
 {
 	if ((Get_Collision_Type() & boxtest.CollisionType) == 0) return false;
+	if (boxtest.Result->StartBad) return false;
+
 	if (CollisionMath::Collide(boxtest.Box,boxtest.Move,CachedBox,Vector3(0,0,0),boxtest.Result)) {
 		boxtest.CollidedRenderObj = this;
 		return true;

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/boxrobj.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/boxrobj.h
@@ -1,5 +1,5 @@
 /*
-**	Command & Conquer Generals(tm)
+**	Command & Conquer Generals Zero Hour(tm)
 **	Copyright 2025 Electronic Arts Inc.
 **
 **	This program is free software: you can redistribute it and/or modify

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/hanimmgr.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/hanimmgr.cpp
@@ -1,5 +1,5 @@
 /*
-**	Command & Conquer Generals(tm)
+**	Command & Conquer Generals Zero Hour(tm)
 **	Copyright 2025 Electronic Arts Inc.
 **
 **	This program is free software: you can redistribute it and/or modify
@@ -16,7 +16,7 @@
 **	along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/* $Header: /Commando/Code/ww3d2/hanimmgr.cpp 1     1/22/01 3:36p Greg_h $ */
+/* $Header: /Commando/Code/ww3d2/hanimmgr.cpp 3     1/16/02 9:51a Jani_p $ */
 /***********************************************************************************************
  ***                            Confidential - Westwood Studios                              ***
  ***********************************************************************************************
@@ -27,9 +27,9 @@
  *                                                                                             *
  *                       Author:: Greg_h                                                       *
  *                                                                                             *
- *                     $Modtime:: 1/08/01 10:04a                                              $*
+ *                     $Modtime:: 1/16/02 9:49a                                               $*
  *                                                                                             *
- *                    $Revision:: 1                                                           $*
+ *                    $Revision:: 3                                                           $*
  *                                                                                             *
  *---------------------------------------------------------------------------------------------*
  * Functions:                                                                                  *
@@ -92,6 +92,7 @@ HAnimManagerClass::HAnimManagerClass(void)
 HAnimManagerClass::~HAnimManagerClass(void)
 {
 	Free_All_Anims();
+	Reset_Missing();	// Jani: Deleting missing animations as well
 
 	delete AnimPtrTable;
 	AnimPtrTable = NULL;

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/hanimmgr.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/hanimmgr.h
@@ -1,5 +1,5 @@
 /*
-**	Command & Conquer Generals(tm)
+**	Command & Conquer Generals Zero Hour(tm)
 **	Copyright 2025 Electronic Arts Inc.
 **
 **	This program is free software: you can redistribute it and/or modify

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/hlod.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/hlod.cpp
@@ -1,5 +1,5 @@
 /*
-**	Command & Conquer Generals(tm)
+**	Command & Conquer Generals Zero Hour(tm)
 **	Copyright 2025 Electronic Arts Inc.
 **
 **	This program is free software: you can redistribute it and/or modify
@@ -3510,6 +3510,14 @@ void HLodClass::Update_Obj_Space_Bounding_Volumes(void)
 void HLodClass::Add_Lod_Model(int lod, RenderObjClass * robj, int boneindex)
 {
 	WWASSERT(robj != NULL);
+
+	// (gth) survive the case where the skeleton for this object no longer has
+	// the bone that we're trying to use.  This happens when a skeleton is re-exported
+	// but the models that depend on it aren't re-exported...
+	if (boneindex >= HTree->Num_Pivots()) {
+		WWDEBUG_SAY(("ERROR: Model %s tried to use bone %d in skeleton %s.  Please re-export!",Get_Name(),boneindex,HTree->Get_Name()));
+		boneindex = 0;
+	}
 
 	ModelNodeClass newnode;
 	newnode.Model = robj;

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/hlod.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/hlod.h
@@ -1,5 +1,5 @@
 /*
-**	Command & Conquer Generals(tm)
+**	Command & Conquer Generals Zero Hour(tm)
 **	Copyright 2025 Electronic Arts Inc.
 **
 **	This program is free software: you can redistribute it and/or modify

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/hmorphanim.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/hmorphanim.cpp
@@ -1,5 +1,5 @@
 /*
-**	Command & Conquer Generals(tm)
+**	Command & Conquer Generals Zero Hour(tm)
 **	Copyright 2025 Electronic Arts Inc.
 **
 **	This program is free software: you can redistribute it and/or modify
@@ -26,11 +26,11 @@
  *                                                                                             *
  *              Original Author:: Greg Hjelstrom                                               *
  *                                                                                             *
- *                      $Author:: Jani_p                                                      $*
+ *                      $Author:: Byon_g                                                      $*
  *                                                                                             *
- *                     $Modtime:: 6/27/01 7:50p                                               $*
+ *                     $Modtime:: 1/16/02 6:39p                                               $*
  *                                                                                             *
- *                    $Revision:: 5                                                           $*
+ *                    $Revision:: 7                                                           $*
  *                                                                                             *
  *---------------------------------------------------------------------------------------------*
  * Functions:                                                                                  *
@@ -343,7 +343,7 @@ bool HMorphAnimClass::Import(const char *hierarchy_name, TextFileClass &text_des
 	//
 	// Copy the hierarchy name into a class variable
 	//
-	::strlcpy(HierarchyName, hierarchy_name, W3D_NAME_LEN);
+	strlcpy (HierarchyName, hierarchy_name, W3D_NAME_LEN);
 
 	//
 	// Attempt to load the new base pose
@@ -516,9 +516,12 @@ int HMorphAnimClass::Create_New_Morph(const int channels, HAnimClass *anim[])
 
 	// set up info
 	//	FrameCount = anim[0]->Get_Num_Frames();
-	//	FrameRate = anim[0]->Get_Frame_Rate();
 	FrameCount = 0;
+#if RTS_GENERALS
 	FrameRate = 30.0f;
+#elif RTS_ZEROHOUR
+	FrameRate = anim[0]->Get_Frame_Rate();
+#endif
 	NumNodes = anim[0]->Get_Num_Pivots();
 
 	// Set up the anim data for all the channels

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/hmorphanim.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/hmorphanim.h
@@ -1,5 +1,5 @@
 /*
-**	Command & Conquer Generals(tm)
+**	Command & Conquer Generals Zero Hour(tm)
 **	Copyright 2025 Electronic Arts Inc.
 **
 **	This program is free software: you can redistribute it and/or modify

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/hrawanim.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/hrawanim.cpp
@@ -1,5 +1,5 @@
 /*
-**	Command & Conquer Generals(tm)
+**	Command & Conquer Generals Zero Hour(tm)
 **	Copyright 2025 Electronic Arts Inc.
 **
 **	This program is free software: you can redistribute it and/or modify
@@ -28,9 +28,9 @@
  *                                                                                             *
  *                      $Author:: Jani_p                                                      $*
  *                                                                                             *
- *                     $Modtime:: 6/27/01 7:52p                                               $*
+ *                     $Modtime:: 11/25/01 6:06p                                              $*
  *                                                                                             *
- *                    $Revision:: 4                                                           $*
+ *                    $Revision:: 5                                                           $*
  *                                                                                             *
  *---------------------------------------------------------------------------------------------*
  * Functions:                                                                                  *
@@ -310,7 +310,8 @@ bool HRawAnimClass::read_channel(ChunkLoadClass & cload,MotionChannelClass * * n
 	bool result = (*newchan)->Load_W3D(cload);
 
 	if (result && pre30) {
-		(*newchan)->PivotIdx += 1;
+//		(*newchan)->PivotIdx += 1;
+		(*newchan)->Set_Pivot((*newchan)->Get_Pivot()+1);
 	}
 
 	return result;

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/hrawanim.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/hrawanim.h
@@ -1,5 +1,5 @@
 /*
-**	Command & Conquer Generals(tm)
+**	Command & Conquer Generals Zero Hour(tm)
 **	Copyright 2025 Electronic Arts Inc.
 **
 **	This program is free software: you can redistribute it and/or modify

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/matpass.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/matpass.cpp
@@ -1,5 +1,5 @@
 /*
-**	Command & Conquer Generals(tm)
+**	Command & Conquer Generals Zero Hour(tm)
 **	Copyright 2025 Electronic Arts Inc.
 **
 **	This program is free software: you can redistribute it and/or modify

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/matpass.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/matpass.h
@@ -1,5 +1,5 @@
 /*
-**	Command & Conquer Generals(tm)
+**	Command & Conquer Generals Zero Hour(tm)
 **	Copyright 2025 Electronic Arts Inc.
 **
 **	This program is free software: you can redistribute it and/or modify
@@ -26,12 +26,13 @@
  *                                                                                             *
  *              Original Author:: Greg Hjelstrom                                               *
  *                                                                                             *
- *                      $Author:: Greg_h                                                      $*
+ *                       Author : Kenny Mitchell                                               *
  *                                                                                             *
- *                     $Modtime:: 5/13/01 11:25a                                              $*
+ *                     $Modtime:: 06/27/02 1:27p                                              $*
  *                                                                                             *
- *                    $Revision:: 5                                                           $*
+ *                    $Revision:: 6                                                           $*
  *                                                                                             *
+ * 06/27/02 KM Texture class abstraction																			*
  *---------------------------------------------------------------------------------------------*
  * Functions:                                                                                  *
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
@@ -41,7 +42,6 @@
 #include "refcount.h"
 #include "shader.h"
 #include "wwdebug.h"
-
 
 class TextureClass;
 class VertexMaterialClass;
@@ -94,7 +94,11 @@ public:
 
 protected:
 
+#if RTS_GENERALS
 	enum { MAX_TEX_STAGES = 2 };
+#elif RTS_ZEROHOUR
+	enum { MAX_TEX_STAGES = 8 };
+#endif
 
 	TextureClass *				Texture[MAX_TEX_STAGES];
 	ShaderClass					Shader;

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/motchan.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/motchan.h
@@ -1,5 +1,5 @@
 /*
-**	Command & Conquer Generals(tm)
+**	Command & Conquer Generals Zero Hour(tm)
 **	Copyright 2025 Electronic Arts Inc.
 **
 **	This program is free software: you can redistribute it and/or modify
@@ -16,7 +16,7 @@
 **	along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/* $Header: /Commando/Code/ww3d2/motchan.h 2     6/29/01 6:41p Jani_p $ */
+/* $Header: /Commando/Code/ww3d2/motchan.h 5     11/29/01 1:07p Jani_p $ */
 /***********************************************************************************************
  ***                            Confidential - Westwood Studios                              ***
  ***********************************************************************************************
@@ -27,9 +27,9 @@
  *                                                                                             *
  *                      $Author:: Jani_p                                                      $*
  *                                                                                             *
- *                     $Modtime:: 6/27/01 6:29p                                               $*
+ *                     $Modtime:: 11/28/01 5:43p                                              $*
  *                                                                                             *
- *                    $Revision:: 2                                                           $*
+ *                    $Revision:: 5                                                           $*
  *                                                                                             *
  *---------------------------------------------------------------------------------------------*
  * Functions:                                                                                  *
@@ -44,7 +44,6 @@
 
 class ChunkLoadClass;
 class Quaternion;
-
 
 /******************************************************************************
 
@@ -61,6 +60,8 @@ class MotionChannelClass : public W3DMPO
 	W3DMPO_GLUE(MotionChannelClass)
 
 public:
+	void Do_Data_Compression(int datasize);
+	void Get_Vector(int frame,float * setvec) const;
 
 	MotionChannelClass(void);
 	~MotionChannelClass(void);
@@ -68,7 +69,7 @@ public:
 	bool	Load_W3D(ChunkLoadClass & cload);
 	WWINLINE int Get_Type(void) const { return Type; }
 	WWINLINE int Get_Pivot(void) const { return PivotIdx; }
-	WWINLINE void Get_Vector(int frame,float * setvec) const;
+	WWINLINE void Set_Pivot(int idx) { PivotIdx=idx; }
 
 #define SPECIAL_GETVEC_AS_QUAT
 #ifdef SPECIAL_GETVEC_AS_QUAT
@@ -81,14 +82,18 @@ private:
 	uint32	Type;					// what type of channel is this
 	int		VectorLen;			// size of each individual vector
 
+	float		ValueOffset;
+	float		ValueScale;
+	unsigned short* CompressedData;
+
 	float	*	Data;					// pointer to the raw floating point data
 	int		FirstFrame;			// first frame which was non-identity
 	int		LastFrame;			// last frame which was non-identity
-
 	void Free(void);
 	WWINLINE void set_identity(float * setvec) const;
 
-	friend class HRawAnimClass;
+//	friend class HRawAnimClass;
+
 };
 
 WWINLINE void MotionChannelClass::set_identity(float * setvec) const

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/nullrobj.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/nullrobj.cpp
@@ -1,5 +1,5 @@
 /*
-**	Command & Conquer Generals(tm)
+**	Command & Conquer Generals Zero Hour(tm)
 **	Copyright 2025 Electronic Arts Inc.
 **
 **	This program is free software: you can redistribute it and/or modify
@@ -26,9 +26,9 @@
  *                                                                                             *
  *                       Author:: Greg Hjelstrom                                               *
  *                                                                                             *
- *                     $Modtime:: 1/08/01 10:04a                                              $*
+ *                     $Modtime:: 12/01/01 12:18p                                             $*
  *                                                                                             *
- *                    $Revision:: 1                                                           $*
+ *                    $Revision:: 2                                                           $*
  *                                                                                             *
  *---------------------------------------------------------------------------------------------*
  * Functions:                                                                                  *
@@ -77,13 +77,13 @@ void Null3DObjClass::Render(RenderInfoClass & rinfo)
 void Null3DObjClass::Get_Obj_Space_Bounding_Sphere(SphereClass & sphere) const
 {
    sphere.Center.Set(0,0,0);
-	sphere.Radius = 0.0f;
+	sphere.Radius = 0.1f;
 }
 
 void Null3DObjClass::Get_Obj_Space_Bounding_Box(AABoxClass & box) const
 {
 	box.Center.Set(0,0,0);
-	box.Extent.Set(0,0,0);
+	box.Extent.Set(0.1f,0.1f,0.1f);
 }
 
 /*

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/nullrobj.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/nullrobj.h
@@ -1,5 +1,5 @@
 /*
-**	Command & Conquer Generals(tm)
+**	Command & Conquer Generals Zero Hour(tm)
 **	Copyright 2025 Electronic Arts Inc.
 **
 **	This program is free software: you can redistribute it and/or modify

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/w3d_file.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/w3d_file.h
@@ -1,5 +1,5 @@
 /*
-**	Command & Conquer Generals(tm)
+**	Command & Conquer Generals Zero Hour(tm)
 **	Copyright 2025 Electronic Arts Inc.
 **
 **	This program is free software: you can redistribute it and/or modify
@@ -396,10 +396,10 @@ enum {
 				W3D_CHUNK_DEFORM_KEYFRAME				=0x0000005A,	// a keyframe of deform information in the set
 					W3D_CHUNK_DEFORM_DATA				=0x0000005B,	// deform information about a single vertex
 
-		W3D_CHUNK_PS2_SHADERS							=0x00000080,	// Shader info specific to the Playstation 2.
-
 		W3D_CHUNK_VERTEX_TANGENTS = 0x00000060,         // array of tangents (array of W3dVectorStruct's)
 		W3D_CHUNK_VERTEX_BINORMALS = 0x00000061,         // array of binormals (array of W3dVectorStruct's)
+
+		W3D_CHUNK_PS2_SHADERS							=0x00000080,	// Shader info specific to the Playstation 2.
 
 		W3D_CHUNK_AABTREE									=0x00000090,	// Axis-Aligned Box Tree for hierarchical polygon culling
 			W3D_CHUNK_AABTREE_HEADER,										// catalog of the contents of the AABTree
@@ -1225,9 +1225,9 @@ const char * const SURFACE_TYPE_STRINGS[SURFACE_TYPE_MAX] =
 // boundary values for W3dMeshHeaderStruct::SortLevel
 #define SORT_LEVEL_NONE						0
 #define MAX_SORT_LEVEL						32
-#define SORT_LEVEL_BIN1						10
+#define SORT_LEVEL_BIN1						20
 #define SORT_LEVEL_BIN2						15
-#define SORT_LEVEL_BIN3						20
+#define SORT_LEVEL_BIN3						10
 
 struct W3dMeshHeader3Struct
 {

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/CMakeLists.txt
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/CMakeLists.txt
@@ -19,6 +19,10 @@ add_subdirectory(WWAudio)
 add_subdirectory(WW3D2)
 add_subdirectory(WWDownload)
 
+target_link_libraries(z_ww3d2 PRIVATE
+    zi_always
+)
+
 # Helpful interface to bundle the ww modules together.
 add_library(z_wwvegas INTERFACE)
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/hlod.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/hlod.h
@@ -43,7 +43,6 @@
 #include "w3derr.h"
 #include "proxy.h"
 
-
 class DistLODClass;
 class HModelClass;
 class HLodDefClass;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/hmorphanim.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/hmorphanim.cpp
@@ -517,7 +517,11 @@ int HMorphAnimClass::Create_New_Morph(const int channels, HAnimClass *anim[])
 	// set up info
 	//	FrameCount = anim[0]->Get_Num_Frames();
 	FrameCount = 0;
+#if RTS_GENERALS
+	FrameRate = 30.0f;
+#elif RTS_ZEROHOUR
 	FrameRate = anim[0]->Get_Frame_Rate();
+#endif
 	NumNodes = anim[0]->Get_Num_Pivots();
 
 	// Set up the anim data for all the channels

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/matpass.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/matpass.h
@@ -94,7 +94,11 @@ public:
 
 protected:
 
+#if RTS_GENERALS
+	enum { MAX_TEX_STAGES = 2 };
+#elif RTS_ZEROHOUR
 	enum { MAX_TEX_STAGES = 8 };
+#endif
 
 	TextureClass *				Texture[MAX_TEX_STAGES];
 	ShaderClass					Shader;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/motchan.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/motchan.cpp
@@ -51,7 +51,7 @@
 #include "wwmath.h"
 #include "quat.h"
 #include "wwmath.h"
-//#include <Windows.h>
+
 // Static Table, for Adaptive Delta Decompressor
 #define FILTER_TABLE_SIZE (256)
 #define FILTER_TABLE_GEN_START (16)


### PR DESCRIPTION
Equalized files between ZH and Gen that had smaller changes. Particular large changes are a texture rewrite, shading rewrite and lighting rewrite in ZH, which will be tackeled in seperate PR's

The following files have changed in this PR:
 - matpass
     - Texture array size change merged using RTS_* guards. I don't full graps the texture rewrite yet and don't know if Generals could handle the larger array size as well. TODO: Figure that out
 - boxrobj
    - Changed buffer type from `BUFFER_TYPE_DYNAMIC_SORTING` (gen) to `BUFFER_TYPE_DYNAMIC_DX8` (zh)
    - Copy additional checks in zh to gen
 - hmorphanim
     - framerate set using RTS_* guards. In ZH the animation framerate is read from file (?) in Gen it is a constant of 30. TODO: can generals also read from file?
 - hanimgr
     - add additional cleanup logic from ZH to Gen
 - hlod
    - Add boneindex safeguard from ZH to Gen
 - nullobj
     - Change sphere and box extend default to nonzero
 - w3d_file
 
 - hrawanim
     - Use ZH logic to changed pivot index
  - animobj
      - Modified conditions and logic for simple animations


These changes have no (visual) impact on Generals as far as I've tested