### PR TITLE
ci: Update Windows Version for Replay Checker

### DIFF
--- a/.github/workflows/check-replays.yml
+++ b/.github/workflows/check-replays.yml
@@ -1,4 +1,4 @@
-name: check-replays
+name: Check Replays
 
 permissions:
   contents: read
@@ -23,7 +23,7 @@ on:
 jobs:
   build:
     name: ${{ inputs.preset }}
-    runs-on: windows-latest
+    runs-on: windows-2022
     timeout-minutes: 15
     env:
       GAME_PATH: C:\GameData


### PR DESCRIPTION
Follow-up for #1366

Use same windows version for replay-checker as build-toolchain. (latest generates a warning) Also make name consistent with other ci jobs.
