### PR TITLE
fix(mismatch): Fix mismatch due to custom upgrades in custom maps not properly resetting after match

### DIFF
--- a/GeneralsMD/Code/GameEngine/Include/Common/Upgrade.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Upgrade.h
@@ -235,6 +235,7 @@ public:
 	void reset( void );												///< subsystem interface
 	void update( void ) { }										///< subsystem interface
 
+	void deleteAllUpgrades();
 	UpgradeTemplate *firstUpgradeTemplate( void );	///< return the first upgrade template
 	const UpgradeTemplate *findUpgradeByKey( NameKeyType key ) const;		///< find upgrade by name key
 	const UpgradeTemplate *findUpgrade( const AsciiString& name ) const;				///< find and return upgrade by name


### PR DESCRIPTION
Fixes: #1436

The UpgradeCenter class doesn't reset itself properly and as such can cause mismatches in a second match when the upgrades were modified due to custom scripts in a first match.

This PR fixes it by reloading the corresponding INI files during reset. Not exactly elegant, but it works!