### PR TITLE
bugfix(gui): Always show correct teams for players in the observer control bar

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarObserver.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarObserver.cpp
@@ -274,7 +274,7 @@ void ControlBar::populateObserverList( void )
 				buttonPlayer[currentButton]->winHide(FALSE);
 				buttonPlayer[currentButton]->winSetStatus( WIN_STATUS_USE_OVERLAY_STATES );
 
-				const GameSlot *slot = TheGameInfo->getConstSlot(currentButton);
+				const GameSlot *slot = TheGameInfo->getConstSlot(i);
 				Color playerColor = p->getPlayerColor();
 				Color backColor = GameMakeColor(0, 0, 0, 255);
 				staticTextPlayer[currentButton]->winSetEnabledTextColors( playerColor, backColor );

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarObserver.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarObserver.cpp
@@ -274,7 +274,7 @@ void ControlBar::populateObserverList( void )
 				buttonPlayer[currentButton]->winHide(FALSE);
 				buttonPlayer[currentButton]->winSetStatus( WIN_STATUS_USE_OVERLAY_STATES );
 
-				const GameSlot *slot = TheGameInfo->getConstSlot(currentButton);
+				const GameSlot *slot = TheGameInfo->getConstSlot(i);
 				Color playerColor = p->getPlayerColor();
 				Color backColor = GameMakeColor(0, 0, 0, 255);
 				staticTextPlayer[currentButton]->winSetEnabledTextColors( playerColor, backColor );


### PR DESCRIPTION
This change fixes the team information displayed on the observer control bar for players that are not in the expected slot.

### Before
Player `--o.O--{0}` is in slot 7 while the control bar attempts to read slot 6 (which is empty) and incorrectly shows `Team None`

<img width="1080" height="320" alt="image" src="https://github.com/user-attachments/assets/5db0da96-6bba-4627-92f2-c5d577051330" />

### After
Player `--o.O--{0}` is in slot 7 and the control bar correctly reads slot 7 and correctly shows `Team 4`

<img width="1080" height="320" alt="image" src="https://github.com/user-attachments/assets/5c23710b-505a-467f-8cec-33180e2aaad0" />