### PR TITLE
bugfix: Jets now defer attack, force attack, attack move and guard commands while reloading

### DIFF
--- a/Generals/Code/GameEngine/Include/GameLogic/Module/JetAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/JetAIUpdate.h
@@ -133,6 +133,7 @@ protected:
 	virtual Bool getTreatAsAircraftForLocoDistToGoal() const;
 	virtual Bool shouldDeferCommand(const AICommandType commandType) const; ///< returns whether the specified command type should be deferred
 	virtual Bool commandRequiresTakeoff(const AICommandParms* parms) const; ///< returns whether the specified command requires takeoff
+	virtual Bool commandRequiresAmmo(const AICommandType commandType) const; ///< returns whether the specified command type requires ammo
 	virtual Bool isGuardCommand(const AICommandType commandType) const; ///< returns whether the specified command type is a guard command
 	Bool isParkedAt(const Object* obj) const;
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/JetAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/JetAIUpdate.h
@@ -131,6 +131,7 @@ protected:
 	void positionLockon();
 
 	virtual Bool getTreatAsAircraftForLocoDistToGoal() const;
+	virtual Bool shouldDeferCommand(const AICommandType commandType) const; ///< returns whether the specified command type should be deferred
 	Bool isParkedAt(const Object* obj) const;
 
 private:

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/JetAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/JetAIUpdate.h
@@ -132,6 +132,7 @@ protected:
 
 	virtual Bool getTreatAsAircraftForLocoDistToGoal() const;
 	virtual Bool shouldDeferCommand(const AICommandType commandType) const; ///< returns whether the specified command type should be deferred
+	virtual Bool commandRequiresTakeoff(const AICommandParms* parms) const; ///< returns whether the specified command requires takeoff
 	Bool isParkedAt(const Object* obj) const;
 
 private:

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/JetAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/JetAIUpdate.h
@@ -133,6 +133,7 @@ protected:
 	virtual Bool getTreatAsAircraftForLocoDistToGoal() const;
 	virtual Bool shouldDeferCommand(const AICommandType commandType) const; ///< returns whether the specified command type should be deferred
 	virtual Bool commandRequiresTakeoff(const AICommandParms* parms) const; ///< returns whether the specified command requires takeoff
+	virtual Bool isGuardCommand(const AICommandType commandType) const; ///< returns whether the specified command type is a guard command
 	Bool isParkedAt(const Object* obj) const;
 
 private:

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -2322,7 +2322,8 @@ void JetAIUpdate::aiDoCommand(const AICommandParms* parms)
 		setFlag(HAS_PENDING_COMMAND, true);
 		return;
 	}
-	else if (parms->m_cmd == AICMD_IDLE && getStateMachine()->getCurrentStateID() == RELOAD_AMMO)
+
+	if (parms->m_cmd == AICMD_IDLE && getStateMachine()->getCurrentStateID() == RELOAD_AMMO)
 	{
 		// uber-special-case... if we are told to idle, but are reloading ammo, ignore it for now,
 		// since we're already doing "nothing" and responding to this will cease our reload...
@@ -2330,7 +2331,8 @@ void JetAIUpdate::aiDoCommand(const AICommandParms* parms)
 		setFlag(HAS_PENDING_COMMAND, true);
 		return;
 	}
-	else if (!getFlag(ALLOW_AIR_LOCO))
+
+	if (!getFlag(ALLOW_AIR_LOCO))
 	{
 		switch (parms->m_cmd)
 		{

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -2354,6 +2354,11 @@ Bool JetAIUpdate::shouldDeferCommand(const AICommandType commandType) const
 	if (commandType == AICMD_IDLE && currentState == RELOAD_AMMO)
 		return true;
 
+#if !RETAIL_COMPATIBLE_CRC
+	if (isGuardCommand(commandType) && currentState == RELOAD_AMMO)
+		return true;
+#endif
+
 	return false;
 }
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -2316,18 +2316,8 @@ void JetAIUpdate::aiDoCommand(const AICommandParms* parms)
 	// note that we always store this, even if nothing will be "pending".
 	m_mostRecentCommand.store(*parms);
 
-	if (getFlag(TAKEOFF_IN_PROGRESS) || getFlag(LANDING_IN_PROGRESS))
+	if (shouldDeferCommand(parms->m_cmd))
 	{
-		// have to wait for takeoff or landing to complete, just store the sucker
-		setFlag(HAS_PENDING_COMMAND, true);
-		return;
-	}
-
-	if (parms->m_cmd == AICMD_IDLE && getStateMachine()->getCurrentStateID() == RELOAD_AMMO)
-	{
-		// uber-special-case... if we are told to idle, but are reloading ammo, ignore it for now,
-		// since we're already doing "nothing" and responding to this will cease our reload...
-		// don't just return, tho, in case we were (say) reloading during a guard stint.
 		setFlag(HAS_PENDING_COMMAND, true);
 		return;
 	}
@@ -2381,6 +2371,24 @@ void JetAIUpdate::aiDoCommand(const AICommandParms* parms)
 
 	setFlag(HAS_PENDING_COMMAND, false);
 	AIUpdateInterface::aiDoCommand(parms);
+}
+
+//-------------------------------------------------------------------------------------------------
+Bool JetAIUpdate::shouldDeferCommand(const AICommandType commandType) const
+{
+	// Always defer commands received during takeoff or landing
+	if (getFlag(TAKEOFF_IN_PROGRESS) || getFlag(LANDING_IN_PROGRESS))
+		return true;
+
+	const StateID currentState = getStateMachine()->getCurrentStateID();
+
+	// uber-special-case... if we are told to idle, but are reloading ammo, ignore it for now,
+	// since we're already doing "nothing" and responding to this will cease our reload...
+	// don't just return, tho, in case we were (say) reloading during a guard stint.
+	if (commandType == AICMD_IDLE && currentState == RELOAD_AMMO)
+		return true;
+
+	return false;
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -2334,19 +2334,7 @@ void JetAIUpdate::aiDoCommand(const AICommandParms* parms)
 		return;
 	}
 
-	switch (parms->m_cmd)
-	{
-		case AICMD_GUARD_POSITION:
-		case AICMD_GUARD_OBJECT:
-		case AICMD_GUARD_AREA:
-		case AICMD_HUNT:
-			setFlag(ALLOW_INTERRUPT_AND_RESUME_OF_CUR_STATE_FOR_RELOAD, true);
-			break;
-		default:
-			setFlag(ALLOW_INTERRUPT_AND_RESUME_OF_CUR_STATE_FOR_RELOAD, false);
-			break;
-	}
-
+	setFlag(ALLOW_INTERRUPT_AND_RESUME_OF_CUR_STATE_FOR_RELOAD, isGuardCommand(parms->m_cmd));
 	setFlag(HAS_PENDING_COMMAND, false);
 	AIUpdateInterface::aiDoCommand(parms);
 }
@@ -2386,6 +2374,20 @@ Bool JetAIUpdate::commandRequiresTakeoff(const AICommandParms* parms) const
 
 		default:
 			return true;
+	}
+}
+
+Bool JetAIUpdate::isGuardCommand(const AICommandType commandType) const
+{
+	switch (commandType)
+	{
+		case AICMD_GUARD_AREA:
+		case AICMD_GUARD_OBJECT:
+		case AICMD_GUARD_POSITION:
+		case AICMD_HUNT:
+			return true;
+		default:
+			return false;
 	}
 }
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -2355,7 +2355,7 @@ Bool JetAIUpdate::shouldDeferCommand(const AICommandType commandType) const
 		return true;
 
 #if !RETAIL_COMPATIBLE_CRC
-	if (isGuardCommand(commandType) && currentState == RELOAD_AMMO)
+	if (commandRequiresAmmo(commandType) && currentState == RELOAD_AMMO)
 		return true;
 #endif
 
@@ -2379,6 +2379,22 @@ Bool JetAIUpdate::commandRequiresTakeoff(const AICommandParms* parms) const
 
 		default:
 			return true;
+	}
+}
+
+Bool JetAIUpdate::commandRequiresAmmo(const AICommandType commandType) const
+{
+	switch (commandType)
+	{
+		case AICMD_ATTACKMOVE_TO_POSITION:
+		case AICMD_ATTACK_AREA:
+		case AICMD_ATTACK_OBJECT:
+		case AICMD_ATTACK_POSITION:
+		case AICMD_ATTACK_TEAM:
+		case AICMD_FORCE_ATTACK_OBJECT:
+			return true;
+		default:
+			return isGuardCommand(commandType);
 	}
 }
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -2322,38 +2322,16 @@ void JetAIUpdate::aiDoCommand(const AICommandParms* parms)
 		return;
 	}
 
-	if (!getFlag(ALLOW_AIR_LOCO))
+	if (!getFlag(ALLOW_AIR_LOCO) && commandRequiresTakeoff(parms))
 	{
-		switch (parms->m_cmd)
-		{
-			case AICMD_IDLE:
-			case AICMD_BUSY:
-			case AICMD_FOLLOW_EXITPRODUCTION_PATH:
-				// don't need (or want) to take off for these
-				break;
+		// nuke any existing pending cmd
+		m_mostRecentCommand.store(*parms);
+		setFlag(HAS_PENDING_COMMAND, true);
 
-			case AICMD_ENTER:
-			case AICMD_GET_REPAIRED:
-
-				// if we're already parked at the airfield in question, just ignore.
-				if (isParkedAt(parms->m_obj))
-					return;
-
-				FALLTHROUGH; // else fall thru to the default case!
-
-			default:
-			{
-				// nuke any existing pending cmd
-				m_mostRecentCommand.store(*parms);
-				setFlag(HAS_PENDING_COMMAND, true);
-
-				getStateMachine()->clear();
-				setLastCommandSource( CMD_FROM_AI );
-				getStateMachine()->setState( TAKING_OFF_AWAIT_CLEARANCE );
-
-				return;
-			}
-		}
+		getStateMachine()->clear();
+		setLastCommandSource(CMD_FROM_AI);
+		getStateMachine()->setState(TAKING_OFF_AWAIT_CLEARANCE);
+		return;
 	}
 
 	switch (parms->m_cmd)
@@ -2389,6 +2367,26 @@ Bool JetAIUpdate::shouldDeferCommand(const AICommandType commandType) const
 		return true;
 
 	return false;
+}
+
+//-------------------------------------------------------------------------------------------------
+Bool JetAIUpdate::commandRequiresTakeoff(const AICommandParms* parms) const
+{
+	switch (parms->m_cmd)
+	{
+		case AICMD_IDLE:
+		case AICMD_BUSY:
+		case AICMD_FOLLOW_EXITPRODUCTION_PATH:
+			return false;
+
+		case AICMD_ENTER:
+		case AICMD_GET_REPAIRED:
+			// if we're already parked at the airfield in question, just ignore.
+			return !isParkedAt(parms->m_obj);
+
+		default:
+			return true;
+	}
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/JetAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/JetAIUpdate.h
@@ -140,6 +140,7 @@ protected:
 	void positionLockon();
 
 	virtual Bool getTreatAsAircraftForLocoDistToGoal() const;
+	virtual Bool shouldDeferCommand(const AICommandType commandType) const; ///< returns whether the specified command type should be deferred
 	Bool isParkedAt(const Object* obj) const;
 
 private:

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/JetAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/JetAIUpdate.h
@@ -142,6 +142,7 @@ protected:
 	virtual Bool getTreatAsAircraftForLocoDistToGoal() const;
 	virtual Bool shouldDeferCommand(const AICommandType commandType) const; ///< returns whether the specified command type should be deferred
 	virtual Bool commandRequiresTakeoff(const AICommandParms* parms) const; ///< returns whether the specified command requires takeoff
+	virtual Bool isGuardCommand(const AICommandType commandType) const; ///< returns whether the specified command type is a guard command
 	Bool isParkedAt(const Object* obj) const;
 
 private:

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/JetAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/JetAIUpdate.h
@@ -141,6 +141,7 @@ protected:
 
 	virtual Bool getTreatAsAircraftForLocoDistToGoal() const;
 	virtual Bool shouldDeferCommand(const AICommandType commandType) const; ///< returns whether the specified command type should be deferred
+	virtual Bool commandRequiresTakeoff(const AICommandParms* parms) const; ///< returns whether the specified command requires takeoff
 	Bool isParkedAt(const Object* obj) const;
 
 private:

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/JetAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/JetAIUpdate.h
@@ -142,6 +142,7 @@ protected:
 	virtual Bool getTreatAsAircraftForLocoDistToGoal() const;
 	virtual Bool shouldDeferCommand(const AICommandType commandType) const; ///< returns whether the specified command type should be deferred
 	virtual Bool commandRequiresTakeoff(const AICommandParms* parms) const; ///< returns whether the specified command requires takeoff
+	virtual Bool commandRequiresAmmo(const AICommandType commandType) const; ///< returns whether the specified command type requires ammo
 	virtual Bool isGuardCommand(const AICommandType commandType) const; ///< returns whether the specified command type is a guard command
 	Bool isParkedAt(const Object* obj) const;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -2549,7 +2549,8 @@ void JetAIUpdate::aiDoCommand(const AICommandParms* parms)
 		setFlag(HAS_PENDING_COMMAND, true);
 		return;
 	}
-	else if (parms->m_cmd == AICMD_IDLE && getStateMachine()->getCurrentStateID() == RELOAD_AMMO)
+
+	if (parms->m_cmd == AICMD_IDLE && getStateMachine()->getCurrentStateID() == RELOAD_AMMO)
 	{
 		// uber-special-case... if we are told to idle, but are reloading ammo, ignore it for now,
 		// since we're already doing "nothing" and responding to this will cease our reload...
@@ -2557,14 +2558,16 @@ void JetAIUpdate::aiDoCommand(const AICommandParms* parms)
 		setFlag(HAS_PENDING_COMMAND, true);
 		return;
 	}
-	else if( parms->m_cmd == AICMD_IDLE && getObject()->isAirborneTarget() && !getObject()->isKindOf( KINDOF_PRODUCED_AT_HELIPAD ) )
+
+	if( parms->m_cmd == AICMD_IDLE && getObject()->isAirborneTarget() && !getObject()->isKindOf( KINDOF_PRODUCED_AT_HELIPAD ) )
 	{
 		getStateMachine()->clear();
 		setLastCommandSource( CMD_FROM_AI );
 		getStateMachine()->setState( RETURNING_FOR_LANDING );
 		return;
 	}
-	else if (!getFlag(ALLOW_AIR_LOCO))
+
+	if (!getFlag(ALLOW_AIR_LOCO))
 	{
 		switch (parms->m_cmd)
 		{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -2569,20 +2569,7 @@ void JetAIUpdate::aiDoCommand(const AICommandParms* parms)
 		return;
 	}
 
-	switch (parms->m_cmd)
-	{
-		case AICMD_GUARD_POSITION:
-		case AICMD_GUARD_OBJECT:
-		case AICMD_GUARD_AREA:
-		case AICMD_HUNT:
-		case AICMD_GUARD_RETALIATE:
-			setFlag(ALLOW_INTERRUPT_AND_RESUME_OF_CUR_STATE_FOR_RELOAD, true);
-			break;
-		default:
-			setFlag(ALLOW_INTERRUPT_AND_RESUME_OF_CUR_STATE_FOR_RELOAD, false);
-			break;
-	}
-
+	setFlag(ALLOW_INTERRUPT_AND_RESUME_OF_CUR_STATE_FOR_RELOAD, isGuardCommand(parms->m_cmd));
 	setFlag(HAS_PENDING_COMMAND, false);
 	AIUpdateInterface::aiDoCommand(parms);
 }
@@ -2622,6 +2609,21 @@ Bool JetAIUpdate::commandRequiresTakeoff(const AICommandParms* parms) const
 
 		default:
 			return true;
+	}
+}
+
+Bool JetAIUpdate::isGuardCommand(const AICommandType commandType) const
+{
+	switch (commandType)
+	{
+		case AICMD_GUARD_AREA:
+		case AICMD_GUARD_OBJECT:
+		case AICMD_GUARD_POSITION:
+		case AICMD_GUARD_RETALIATE:
+		case AICMD_HUNT:
+			return true;
+		default:
+			return false;
 	}
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -2589,6 +2589,11 @@ Bool JetAIUpdate::shouldDeferCommand(const AICommandType commandType) const
 	if (commandType == AICMD_IDLE && currentState == RELOAD_AMMO)
 		return true;
 
+#if !RETAIL_COMPATIBLE_CRC
+	if (isGuardCommand(commandType) && currentState == RELOAD_AMMO)
+		return true;
+#endif
+
 	return false;
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -2590,7 +2590,7 @@ Bool JetAIUpdate::shouldDeferCommand(const AICommandType commandType) const
 		return true;
 
 #if !RETAIL_COMPATIBLE_CRC
-	if (isGuardCommand(commandType) && currentState == RELOAD_AMMO)
+	if (commandRequiresAmmo(commandType) && currentState == RELOAD_AMMO)
 		return true;
 #endif
 
@@ -2614,6 +2614,22 @@ Bool JetAIUpdate::commandRequiresTakeoff(const AICommandParms* parms) const
 
 		default:
 			return true;
+	}
+}
+
+Bool JetAIUpdate::commandRequiresAmmo(const AICommandType commandType) const
+{
+	switch (commandType)
+	{
+		case AICMD_ATTACKMOVE_TO_POSITION:
+		case AICMD_ATTACK_AREA:
+		case AICMD_ATTACK_OBJECT:
+		case AICMD_ATTACK_POSITION:
+		case AICMD_ATTACK_TEAM:
+		case AICMD_FORCE_ATTACK_OBJECT:
+			return true;
+		default:
+			return isGuardCommand(commandType);
 	}
 }
 


### PR DESCRIPTION
Fixes #197

This change adjusts jet aircraft behaviour so that attack, force attack, attack move and guard commands given while the aircraft is reloading are deferred until reloading is complete.

### Demonstration

https://github.com/user-attachments/assets/fcb79d64-2883-4eb9-8c9b-dc9b28eb2dd9