### PR TITLE
refactor: Simplify path string formatting in World Builder

### DIFF
--- a/Core/Libraries/Source/WWVegas/WW3D2/hmdldef.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/hmdldef.cpp
@@ -148,9 +148,9 @@ int HModelDefClass::Load_W3D(ChunkLoadClass & cload)
 	/*
 	** process the header info
 	*/
-	strlcpy(ModelName,header.Name,W3D_NAME_LEN);
-	strlcpy(BasePoseName,header.HierarchyName,W3D_NAME_LEN);
-	strcpy(Name,ModelName);
+    strlcpy(ModelName,header.Name,W3D_NAME_LEN);
+    strlcpy(BasePoseName,header.HierarchyName,W3D_NAME_LEN);
+    strcpy(Name,ModelName);
 
 	/*
 	** Just allocate a node for the number of sub objects we're expecting

--- a/Core/Libraries/Source/WWVegas/WW3D2/hmdldef.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/hmdldef.cpp
@@ -148,9 +148,9 @@ int HModelDefClass::Load_W3D(ChunkLoadClass & cload)
 	/*
 	** process the header info
 	*/
-    strlcpy(ModelName,header.Name,W3D_NAME_LEN);
-    strlcpy(BasePoseName,header.HierarchyName,W3D_NAME_LEN);
-    strcpy(Name,ModelName);
+	strlcpy(ModelName,header.Name,W3D_NAME_LEN);
+	strlcpy(BasePoseName,header.HierarchyName,W3D_NAME_LEN);
+	strcpy(Name,ModelName);
 
 	/*
 	** Just allocate a node for the number of sub objects we're expecting

--- a/Generals/Code/Tools/WorldBuilder/src/OpenMap.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/OpenMap.cpp
@@ -136,7 +136,7 @@ void OpenMap::populateMapListbox( Bool systemMaps )
 				continue;
 			}
 
-		snprintf(fileBuf, ARRAY_SIZE(fileBuf), "%s%s\\%s.map", dirBuf, findData.cFileName, findData.cFileName);
+			snprintf(fileBuf, ARRAY_SIZE(fileBuf), "%s%s\\%s.map", dirBuf, findData.cFileName, findData.cFileName);
 			try {
 				CFileStatus status;
 				if (CFile::GetStatus(fileBuf, status)) {

--- a/Generals/Code/Tools/WorldBuilder/src/OpenMap.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/OpenMap.cpp
@@ -115,17 +115,10 @@ void OpenMap::populateMapListbox( Bool systemMaps )
 	char				fileBuf[_MAX_PATH];
 
 	if (systemMaps)
-		strlcpy(dirBuf, "Maps\\", ARRAY_SIZE(dirBuf));
+		strcpy(dirBuf, "Maps\\");
 	else
 	{
 		snprintf(dirBuf, ARRAY_SIZE(dirBuf), "%sMaps\\", TheGlobalData->getPath_UserData().str());
-	}
-
-	int len = strlen(dirBuf);
-
-	if (len > 0 && dirBuf[len - 1] != '\\') {
-		dirBuf[len++] = '\\';
-		dirBuf[len] = 0;
 	}
 	CListBox *pList = (CListBox *)this->GetDlgItem(IDC_OPEN_LIST);
 	if (pList == NULL) return;
@@ -139,9 +132,9 @@ void OpenMap::populateMapListbox( Bool systemMaps )
 		do {
 			if (strcmp(findData.cFileName, ".") == 0 || strcmp(findData.cFileName, "..") == 0)
 				continue;
-		if ((findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0) {
-			continue;
-		}
+			if ((findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0) {
+				continue;
+			}
 
 		snprintf(fileBuf, ARRAY_SIZE(fileBuf), "%s%s\\%s.map", dirBuf, findData.cFileName, findData.cFileName);
 			try {

--- a/Generals/Code/Tools/WorldBuilder/src/OpenMap.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/OpenMap.cpp
@@ -115,11 +115,10 @@ void OpenMap::populateMapListbox( Bool systemMaps )
 	char				fileBuf[_MAX_PATH];
 
 	if (systemMaps)
-		strcpy(dirBuf, "Maps\\");
+		strlcpy(dirBuf, "Maps\\", ARRAY_SIZE(dirBuf));
 	else
 	{
-		strcpy(dirBuf, TheGlobalData->getPath_UserData().str());
-		strlcat(dirBuf, "Maps\\", ARRAY_SIZE(dirBuf));
+		snprintf(dirBuf, ARRAY_SIZE(dirBuf), "%sMaps\\", TheGlobalData->getPath_UserData().str());
 	}
 
 	int len = strlen(dirBuf);
@@ -131,8 +130,7 @@ void OpenMap::populateMapListbox( Bool systemMaps )
 	CListBox *pList = (CListBox *)this->GetDlgItem(IDC_OPEN_LIST);
 	if (pList == NULL) return;
 	pList->ResetContent();
-	strcpy(findBuf, dirBuf);
-	strlcat(findBuf, "*.*", ARRAY_SIZE(findBuf));
+	snprintf(findBuf, ARRAY_SIZE(findBuf), "%s*.*", dirBuf);
 
 	Bool found = false;
 
@@ -141,15 +139,11 @@ void OpenMap::populateMapListbox( Bool systemMaps )
 		do {
 			if (strcmp(findData.cFileName, ".") == 0 || strcmp(findData.cFileName, "..") == 0)
 				continue;
-			if ((findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0) {
-				continue;
-			}
+		if ((findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0) {
+			continue;
+		}
 
-			strcpy(fileBuf, dirBuf);
-			strlcat(fileBuf, findData.cFileName, ARRAY_SIZE(findBuf));
-			strlcat(fileBuf, "\\", ARRAY_SIZE(findBuf));
-			strlcat(fileBuf, findData.cFileName, ARRAY_SIZE(findBuf));
-			strlcat(fileBuf, ".map", ARRAY_SIZE(findBuf));
+		snprintf(fileBuf, ARRAY_SIZE(fileBuf), "%s%s\\%s.map", dirBuf, findData.cFileName, findData.cFileName);
 			try {
 				CFileStatus status;
 				if (CFile::GetStatus(fileBuf, status)) {

--- a/Generals/Code/Tools/WorldBuilder/src/SaveMap.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/SaveMap.cpp
@@ -138,22 +138,17 @@ void SaveMap::populateMapListbox( Bool systemMaps )
 	CListBox *pList = (CListBox *)this->GetDlgItem(IDC_SAVE_LIST);
 	if (pList == NULL) return;
 	pList->ResetContent();
-	strcpy(findBuf, dirBuf);
-	strlcat(findBuf, "*.*", ARRAY_SIZE(findBuf));
+	snprintf(findBuf, ARRAY_SIZE(findBuf), "%s*.*", dirBuf);
 
 	hFindFile = FindFirstFile(findBuf, &findData);
 	if (hFindFile != INVALID_HANDLE_VALUE) {
 		do {
 			if (strcmp(findData.cFileName, ".") == 0 || strcmp(findData.cFileName, "..") == 0)
 				continue;
-			if ((findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0) {
-				continue;
-			}
-			strcpy(fileBuf, dirBuf);
-			strlcat(fileBuf, findData.cFileName, ARRAY_SIZE(fileBuf));
-			strlcat(fileBuf, "\\", ARRAY_SIZE(fileBuf));
-			strlcat(fileBuf, findData.cFileName, ARRAY_SIZE(fileBuf));
-			strlcat(fileBuf, ".map", ARRAY_SIZE(fileBuf));
+		if ((findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0) {
+			continue;
+		}
+		snprintf(fileBuf, ARRAY_SIZE(fileBuf), "%s%s\\%s.map", dirBuf, findData.cFileName, findData.cFileName);
 			try {
 				CFileStatus status;
 				if (CFile::GetStatus(fileBuf, status)) {
@@ -169,7 +164,7 @@ void SaveMap::populateMapListbox( Bool systemMaps )
  	}
 	CEdit *pEdit = (CEdit*)GetDlgItem(IDC_SAVE_MAP_EDIT);
 	if (pEdit != NULL) {
-		strcpy(fileBuf, m_pInfo->filename);
+		strlcpy(fileBuf, m_pInfo->filename, ARRAY_SIZE(fileBuf));
 		Int len = strlen(fileBuf);
 		if (len>4 && stricmp(".map", fileBuf+(len-4)) == 0) {
 			// strip of the .map

--- a/Generals/Code/Tools/WorldBuilder/src/SaveMap.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/SaveMap.cpp
@@ -145,10 +145,10 @@ void SaveMap::populateMapListbox( Bool systemMaps )
 		do {
 			if (strcmp(findData.cFileName, ".") == 0 || strcmp(findData.cFileName, "..") == 0)
 				continue;
-		if ((findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0) {
-			continue;
-		}
-		snprintf(fileBuf, ARRAY_SIZE(fileBuf), "%s%s\\%s.map", dirBuf, findData.cFileName, findData.cFileName);
+			if ((findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0) {
+				continue;
+			}
+			snprintf(fileBuf, ARRAY_SIZE(fileBuf), "%s%s\\%s.map", dirBuf, findData.cFileName, findData.cFileName);
 			try {
 				CFileStatus status;
 				if (CFile::GetStatus(fileBuf, status)) {

--- a/Generals/Code/Tools/WorldBuilder/src/WHeightMapEdit.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/WHeightMapEdit.cpp
@@ -433,7 +433,7 @@ void WorldHeightMapEdit::loadDirectoryOfImages(const char *pFilePath)
 	FilenameList::iterator it = filenameList.begin();
 	do {
 		AsciiString filename = *it;
-		strlcpy(fileBuf, filename.str(), ARRAY_SIZE(fileBuf));
+		snprintf(fileBuf, ARRAY_SIZE(fileBuf), "%s%s", dirBuf, filename.str());
 		loadBitmap(fileBuf, filename.str());
 
 		++it;

--- a/Generals/Code/Tools/WorldBuilder/src/WHeightMapEdit.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/WHeightMapEdit.cpp
@@ -414,20 +414,18 @@ void WorldHeightMapEdit::loadBaseImages(void)
 void WorldHeightMapEdit::loadDirectoryOfImages(const char *pFilePath)
 {
 	char				dirBuf[_MAX_PATH];
-	char				findBuf[_MAX_PATH];
 	char				fileBuf[_MAX_PATH];
 
-	strcpy(dirBuf, pFilePath);
+	strlcpy(dirBuf, pFilePath, ARRAY_SIZE(dirBuf));
 	int len = strlen(dirBuf);
 
 	if (len > 0 && dirBuf[len - 1] != '\\') {
 		dirBuf[len++] = '\\';
 		dirBuf[len] = 0;
 	}
-	strcpy(findBuf, dirBuf);
 
 	FilenameList filenameList;
-	TheFileSystem->getFileListInDirectory(AsciiString(findBuf), AsciiString("*.*"), filenameList, TRUE);
+	TheFileSystem->getFileListInDirectory(AsciiString(dirBuf), AsciiString("*.*"), filenameList, TRUE);
 
 	if (filenameList.size() == 0) {
 		return;
@@ -435,9 +433,7 @@ void WorldHeightMapEdit::loadDirectoryOfImages(const char *pFilePath)
 	FilenameList::iterator it = filenameList.begin();
 	do {
 		AsciiString filename = *it;
-
-		strcpy(fileBuf, dirBuf);
-		strcat(fileBuf, filename.str());
+		strlcpy(fileBuf, filename.str(), ARRAY_SIZE(fileBuf));
 		loadBitmap(fileBuf, filename.str());
 
 		++it;

--- a/Generals/Code/Tools/WorldBuilder/src/WHeightMapEdit.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/WHeightMapEdit.cpp
@@ -433,6 +433,7 @@ void WorldHeightMapEdit::loadDirectoryOfImages(const char *pFilePath)
 	FilenameList::iterator it = filenameList.begin();
 	do {
 		AsciiString filename = *it;
+
 		snprintf(fileBuf, ARRAY_SIZE(fileBuf), "%s%s", dirBuf, filename.str());
 		loadBitmap(fileBuf, filename.str());
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/OpenMap.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/OpenMap.cpp
@@ -132,11 +132,11 @@ void OpenMap::populateMapListbox( Bool systemMaps )
 		do {
 			if (strcmp(findData.cFileName, ".") == 0 || strcmp(findData.cFileName, "..") == 0)
 				continue;
-		if ((findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0) {
-			continue;
-		}
+			if ((findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0) {
+				continue;
+			}
 
-		snprintf(fileBuf, ARRAY_SIZE(fileBuf), "%s%s\\%s.map", dirBuf, findData.cFileName, findData.cFileName);
+			snprintf(fileBuf, ARRAY_SIZE(fileBuf), "%s%s\\%s.map", dirBuf, findData.cFileName, findData.cFileName);
 			try {
 				CFileStatus status;
 				if (CFile::GetStatus(fileBuf, status)) {

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/OpenMap.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/OpenMap.cpp
@@ -115,17 +115,10 @@ void OpenMap::populateMapListbox( Bool systemMaps )
 	char				fileBuf[_MAX_PATH];
 
 	if (systemMaps)
-		strlcpy(dirBuf, "Maps\\", ARRAY_SIZE(dirBuf));
+		strcpy(dirBuf, "Maps\\");
 	else
 	{
 		snprintf(dirBuf, ARRAY_SIZE(dirBuf), "%sMaps\\", TheGlobalData->getPath_UserData().str());
-	}
-
-	int len = strlen(dirBuf);
-
-	if (len > 0 && dirBuf[len - 1] != '\\') {
-		dirBuf[len++] = '\\';
-		dirBuf[len] = 0;
 	}
 	CListBox *pList = (CListBox *)this->GetDlgItem(IDC_OPEN_LIST);
 	if (pList == NULL) return;

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/OpenMap.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/OpenMap.cpp
@@ -115,11 +115,10 @@ void OpenMap::populateMapListbox( Bool systemMaps )
 	char				fileBuf[_MAX_PATH];
 
 	if (systemMaps)
-		strcpy(dirBuf, "Maps\\");
+		strlcpy(dirBuf, "Maps\\", ARRAY_SIZE(dirBuf));
 	else
 	{
-		strcpy(dirBuf, TheGlobalData->getPath_UserData().str());
-		strlcat(dirBuf, "Maps\\", ARRAY_SIZE(dirBuf));
+		snprintf(dirBuf, ARRAY_SIZE(dirBuf), "%sMaps\\", TheGlobalData->getPath_UserData().str());
 	}
 
 	int len = strlen(dirBuf);
@@ -131,8 +130,7 @@ void OpenMap::populateMapListbox( Bool systemMaps )
 	CListBox *pList = (CListBox *)this->GetDlgItem(IDC_OPEN_LIST);
 	if (pList == NULL) return;
 	pList->ResetContent();
-	strcpy(findBuf, dirBuf);
-	strlcat(findBuf, "*.*", ARRAY_SIZE(findBuf));
+	snprintf(findBuf, ARRAY_SIZE(findBuf), "%s*.*", dirBuf);
 
 	Bool found = false;
 
@@ -141,15 +139,11 @@ void OpenMap::populateMapListbox( Bool systemMaps )
 		do {
 			if (strcmp(findData.cFileName, ".") == 0 || strcmp(findData.cFileName, "..") == 0)
 				continue;
-			if ((findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0) {
-				continue;
-			}
+		if ((findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0) {
+			continue;
+		}
 
-			strcpy(fileBuf, dirBuf);
-			strlcat(fileBuf, findData.cFileName, ARRAY_SIZE(findBuf));
-			strlcat(fileBuf, "\\", ARRAY_SIZE(findBuf));
-			strlcat(fileBuf, findData.cFileName, ARRAY_SIZE(findBuf));
-			strlcat(fileBuf, ".map", ARRAY_SIZE(findBuf));
+		snprintf(fileBuf, ARRAY_SIZE(fileBuf), "%s%s\\%s.map", dirBuf, findData.cFileName, findData.cFileName);
 			try {
 				CFileStatus status;
 				if (CFile::GetStatus(fileBuf, status)) {

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/SaveMap.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/SaveMap.cpp
@@ -138,22 +138,17 @@ void SaveMap::populateMapListbox( Bool systemMaps )
 	CListBox *pList = (CListBox *)this->GetDlgItem(IDC_SAVE_LIST);
 	if (pList == NULL) return;
 	pList->ResetContent();
-	strcpy(findBuf, dirBuf);
-	strlcat(findBuf, "*.*", ARRAY_SIZE(findBuf));
+	snprintf(findBuf, ARRAY_SIZE(findBuf), "%s*.*", dirBuf);
 
 	hFindFile = FindFirstFile(findBuf, &findData);
 	if (hFindFile != INVALID_HANDLE_VALUE) {
 		do {
 			if (strcmp(findData.cFileName, ".") == 0 || strcmp(findData.cFileName, "..") == 0)
 				continue;
-			if ((findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0) {
-				continue;
-			}
-			strcpy(fileBuf, dirBuf);
-			strlcat(fileBuf, findData.cFileName, ARRAY_SIZE(fileBuf));
-			strlcat(fileBuf, "\\", ARRAY_SIZE(fileBuf));
-			strlcat(fileBuf, findData.cFileName, ARRAY_SIZE(fileBuf));
-			strlcat(fileBuf, ".map", ARRAY_SIZE(fileBuf));
+		if ((findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0) {
+			continue;
+		}
+		snprintf(fileBuf, ARRAY_SIZE(fileBuf), "%s%s\\%s.map", dirBuf, findData.cFileName, findData.cFileName);
 			try {
 				CFileStatus status;
 				if (CFile::GetStatus(fileBuf, status)) {
@@ -169,7 +164,7 @@ void SaveMap::populateMapListbox( Bool systemMaps )
  	}
 	CEdit *pEdit = (CEdit*)GetDlgItem(IDC_SAVE_MAP_EDIT);
 	if (pEdit != NULL) {
-		strcpy(fileBuf, m_pInfo->filename);
+		strlcpy(fileBuf, m_pInfo->filename, ARRAY_SIZE(fileBuf));
 		Int len = strlen(fileBuf);
 		if (len>4 && stricmp(".map", fileBuf+(len-4)) == 0) {
 			// strip of the .map

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/SaveMap.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/SaveMap.cpp
@@ -145,10 +145,10 @@ void SaveMap::populateMapListbox( Bool systemMaps )
 		do {
 			if (strcmp(findData.cFileName, ".") == 0 || strcmp(findData.cFileName, "..") == 0)
 				continue;
-		if ((findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0) {
-			continue;
-		}
-		snprintf(fileBuf, ARRAY_SIZE(fileBuf), "%s%s\\%s.map", dirBuf, findData.cFileName, findData.cFileName);
+			if ((findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0) {
+				continue;
+			}
+			snprintf(fileBuf, ARRAY_SIZE(fileBuf), "%s%s\\%s.map", dirBuf, findData.cFileName, findData.cFileName);
 			try {
 				CFileStatus status;
 				if (CFile::GetStatus(fileBuf, status)) {

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/WHeightMapEdit.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/WHeightMapEdit.cpp
@@ -434,7 +434,7 @@ void WorldHeightMapEdit::loadDirectoryOfImages(const char *pFilePath)
 	FilenameList::iterator it = filenameList.begin();
 	do {
 		AsciiString filename = *it;
-		strlcpy(fileBuf, filename.str(), ARRAY_SIZE(fileBuf));
+		snprintf(fileBuf, ARRAY_SIZE(fileBuf), "%s%s", dirBuf, filename.str());
 		loadBitmap(fileBuf, filename.str());
 
 		++it;

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/WHeightMapEdit.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/WHeightMapEdit.cpp
@@ -415,20 +415,18 @@ void WorldHeightMapEdit::loadBaseImages(void)
 void WorldHeightMapEdit::loadDirectoryOfImages(const char *pFilePath)
 {
 	char				dirBuf[_MAX_PATH];
-	char				findBuf[_MAX_PATH];
 	char				fileBuf[_MAX_PATH];
 
-	strcpy(dirBuf, pFilePath);
+	strlcpy(dirBuf, pFilePath, ARRAY_SIZE(dirBuf));
 	int len = strlen(dirBuf);
 
 	if (len > 0 && dirBuf[len - 1] != '\\') {
 		dirBuf[len++] = '\\';
 		dirBuf[len] = 0;
 	}
-	strcpy(findBuf, dirBuf);
 
 	FilenameList filenameList;
-	TheFileSystem->getFileListInDirectory(AsciiString(findBuf), AsciiString("*.*"), filenameList, TRUE);
+	TheFileSystem->getFileListInDirectory(AsciiString(dirBuf), AsciiString("*.*"), filenameList, TRUE);
 
 	if (filenameList.size() == 0) {
 		return;
@@ -436,8 +434,7 @@ void WorldHeightMapEdit::loadDirectoryOfImages(const char *pFilePath)
 	FilenameList::iterator it = filenameList.begin();
 	do {
 		AsciiString filename = *it;
-		//strcpy(fileBuf, dirBuf);
-		strcpy(fileBuf, filename.str());
+		strlcpy(fileBuf, filename.str(), ARRAY_SIZE(fileBuf));
 		loadBitmap(fileBuf, filename.str());
 
 		++it;

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/WHeightMapEdit.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/WHeightMapEdit.cpp
@@ -434,7 +434,8 @@ void WorldHeightMapEdit::loadDirectoryOfImages(const char *pFilePath)
 	FilenameList::iterator it = filenameList.begin();
 	do {
 		AsciiString filename = *it;
-		snprintf(fileBuf, ARRAY_SIZE(fileBuf), "%s%s", dirBuf, filename.str());
+		//strcpy(fileBuf, dirBuf);
+		strlcpy(fileBuf, filename.str(), ARRAY_SIZE(fileBuf));
 		loadBitmap(fileBuf, filename.str());
 
 		++it;


### PR DESCRIPTION
Addresses feedback on PR #1712 by removing unnecessary intermediate buffer copies before converting strcpy to strlcpy.
Merge before #1712

Changes:
- WorldBuilder files: Replace redundant strcpy+strlcat chains with single snprintf calls
- Eliminate temporary buffers (findBuf in WHeightMapEdit) where not needed
