### PR TITLE
bugfix(aiupdate): Repairing Chinooks and Helixes no longer take off after evacuating all passengers

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
@@ -1127,7 +1127,7 @@ void ChinookAIUpdate::aiDoCommand(const AICommandParms* parms)
 	// this gets reset every time a command is issued.
 	setAirfieldForHealing(INVALID_ID);
 #else
-	// Don't leave healing state for evacuation commands
+	// TheSuperHackers @bugfix Stubbjax 31/10/2025 Don't leave healing state for evacuation commands.
 	if (parms->m_cmd != AICMD_EVACUATE && parms->m_cmd != AICMD_EXIT)
 		setAirfieldForHealing(INVALID_ID);
 #endif

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
@@ -1262,7 +1262,7 @@ void ChinookAIUpdate::aiDoCommand(const AICommandParms* parms)
 	// this gets reset every time a command is issued.
 	setAirfieldForHealing(INVALID_ID);
 #else
-	// Don't leave healing state for evacuation commands
+	// TheSuperHackers @bugfix Stubbjax 31/10/2025 Don't leave healing state for evacuation commands.
 	if (parms->m_cmd != AICMD_EVACUATE && parms->m_cmd != AICMD_EXIT)
 		setAirfieldForHealing(INVALID_ID);
 #endif


### PR DESCRIPTION
This change prevents repairing Chinooks and Helixes from taking off after evacuating **all** passengers.

### Before
The Chinook stays landed when evacuating individual passengers, but takes off when evacuating all passengers

https://github.com/user-attachments/assets/7cac7fe2-8615-4cc7-b424-a77ba56895e9

### After
The Chinook stays landed when evacuating individual or all passengers

https://github.com/user-attachments/assets/6cc05d8d-4aad-4e0a-94b9-3ed01981b4bb