### PR TITLE
refactor(w3dview): Migrate raw pointers to RefCountPtr

### DIFF
--- a/Core/Tools/W3DView/AssetInfo.cpp
+++ b/Core/Tools/W3DView/AssetInfo.cpp
@@ -52,28 +52,23 @@ AssetInfoClass::Initialize ()
 	if (m_AssetType != TypeMaterial) {
 
 		// Assume we are wrapping an instance as apposed to an asset 'name'.
-		RenderObjClass *prender_obj = m_pRenderObj;
-		if (prender_obj)
-			prender_obj->Add_Ref();
+		RefCountPtr<RenderObjClass> render_obj = m_pRenderObj;
 
 		// If we are wrapping an asset name, then create an instance of it.
-		if (prender_obj == nullptr) {
-			prender_obj = WW3DAssetManager::Get_Instance()->Create_Render_Obj (m_Name);
+		if (render_obj == nullptr) {
+			render_obj.Assign_No_Add_Ref (WW3DAssetManager::Get_Instance()->Create_Render_Obj (m_Name));
 		}
 
-		if (prender_obj != nullptr) {
+		if (render_obj != nullptr) {
 
 			// Get the hierarchy tree for this object (if one exists)
-			const HTreeClass *phtree = prender_obj->Get_HTree ();
+			const HTreeClass *phtree = render_obj->Get_HTree ();
 			if (phtree) {
 
 				// Get the name of the hierarchy tree
 				m_HierarchyName = phtree->Get_Name ();
 			}
 		}
-
-		// Release our hold on the temporary object
-		REF_PTR_RELEASE (prender_obj);
 	}
 }
 

--- a/Core/Tools/W3DView/AssetInfo.h
+++ b/Core/Tools/W3DView/AssetInfo.h
@@ -37,7 +37,6 @@
 #pragma once
 
 #include "WW3D2/rendobj.h"
-#include "Utils.h"
 #include "AssetTypes.h"
 
 
@@ -58,16 +57,15 @@ class AssetInfoClass
 		//
 		AssetInfoClass ()
 			: m_AssetType (TypeUnknown),
-			  m_dwUserData (0L),
-			  m_pRenderObj (nullptr)			{ Initialize (); }
+			  m_dwUserData (0L)			{ Initialize (); }
 
 		AssetInfoClass (LPCTSTR passet_name, ASSET_TYPE type, RenderObjClass *prender_obj = nullptr, DWORD user_data = 0L)
 			: m_Name (passet_name),
 			  m_AssetType (type),
 			  m_dwUserData (user_data),
-			  m_pRenderObj (nullptr)			{ REF_PTR_SET (m_pRenderObj, prender_obj); Initialize (); }
+			  m_pRenderObj (Create_Add_Ref (prender_obj))			{ Initialize (); }
 
-		virtual ~AssetInfoClass ()	{ REF_PTR_RELEASE (m_pRenderObj); }
+		virtual ~AssetInfoClass ()	{}
 
 		//////////////////////////////////////////////////////////////
 		//
@@ -83,14 +81,14 @@ class AssetInfoClass
 		ASSET_TYPE			Get_Type () const						{ return m_AssetType; }
 		DWORD					Get_User_Number () const				{ return m_dwUserData; }
 		const CString &	Get_User_String () const				{ return m_UserString; }
-		RenderObjClass *	Get_Render_Obj () const				{ if (m_pRenderObj) m_pRenderObj->Add_Ref(); return m_pRenderObj; }
-		RenderObjClass *	Peek_Render_Obj () const				{ return m_pRenderObj; }
+		RenderObjClass *	Get_Render_Obj () const				{ RenderObjClass *ptr = m_pRenderObj.Peek(); if (ptr) ptr->Add_Ref(); return ptr; }
+		RenderObjClass *	Peek_Render_Obj () const				{ return m_pRenderObj.Peek(); }
 		void					Set_Name (LPCTSTR pname)					{ m_Name = pname; }
 		void					Set_Hierarchy_Name (LPCTSTR pname)		{ m_HierarchyName = pname; }
 		void					Set_Type (ASSET_TYPE type)					{ m_AssetType = type; }
 		void					Set_User_Number (DWORD user_data)		{ m_dwUserData = user_data; }
 		void					Set_User_String (LPCTSTR string)			{ m_UserString = string; }
-		void					Set_Render_Obj (RenderObjClass *pobj)	{ REF_PTR_SET (m_pRenderObj, pobj); }
+		void					Set_Render_Obj (RenderObjClass *pobj)	{ m_pRenderObj.Assign_Add_Ref (pobj); }
 
 		//
 		//	Information methods
@@ -118,5 +116,5 @@ class AssetInfoClass
 		CString				m_OriginalName;
 		ASSET_TYPE			m_AssetType;
 		DWORD					m_dwUserData;
-		RenderObjClass *	m_pRenderObj;
+		RefCountPtr<RenderObjClass>		m_pRenderObj;
 };

--- a/Core/Tools/W3DView/GraphicView.cpp
+++ b/Core/Tools/W3DView/GraphicView.cpp
@@ -71,7 +71,6 @@ IMPLEMENT_DYNCREATE(CGraphicView, CView)
 ////////////////////////////////////////////////////////////////////////////
 CGraphicView::CGraphicView ()
     : m_bInitialized (FALSE),
-      m_pCamera (nullptr),
       m_TimerID (0),
       m_bMouseDown (FALSE),
       m_bRMouseDown (FALSE),
@@ -83,7 +82,6 @@ CGraphicView::CGraphicView ()
       m_objectRotation (NoRotation),
 		m_LightRotation (NoRotation),
 		m_bLightMeshInScene (false),
-		m_pLightMesh (nullptr),
 		m_ParticleCountUpdate (0),
 		m_CameraBonePosX (false),
 		m_UpdateCounter (0),
@@ -212,7 +210,7 @@ CGraphicView::InitializeGraphicView ()
     if (bReturn && (m_pCamera == nullptr))
     {
         // Instantiate a new camera class
-	    m_pCamera = new CameraClass ();
+	    m_pCamera.Assign_No_Add_Ref (new CameraClass ());
         bReturn = (m_pCamera != nullptr);
 
         // Were we successful in creating a camera?
@@ -230,7 +228,7 @@ CGraphicView::InitializeGraphicView ()
 		  //
 		  //	Attach the 'listener' to the camera
 		  //
-		  WWAudioClass::Get_Instance ()->Get_Sound_Scene ()->Attach_Listener_To_Obj (m_pCamera);
+		  WWAudioClass::Get_Instance ()->Get_Sound_Scene ()->Attach_Listener_To_Obj (m_pCamera.Peek());
     }
 
 	Reset_FOV ();
@@ -240,7 +238,7 @@ CGraphicView::InitializeGraphicView ()
 		ResourceFileClass light_mesh_file (nullptr, "Light.w3d");
 		WW3DAssetManager::Get_Instance()->Load_3D_Assets (light_mesh_file);
 
-		m_pLightMesh = WW3DAssetManager::Get_Instance()->Create_Render_Obj ("LIGHT");
+		m_pLightMesh.Assign_No_Add_Ref (WW3DAssetManager::Get_Instance()->Create_Render_Obj ("LIGHT"));
 		ASSERT (m_pLightMesh != nullptr);
 		m_bLightMeshInScene = false;
 	 }
@@ -323,8 +321,8 @@ CGraphicView::OnDestroy ()
 	//
 	// Free the camera object
 	//
-	REF_PTR_RELEASE (m_pCamera);
-	REF_PTR_RELEASE (m_pLightMesh);
+	m_pCamera.Clear();
+	m_pLightMesh.Clear();
 
 	// Is there an update thread running?
 	if (m_TimerID == 0) {
@@ -520,7 +518,7 @@ CGraphicView::RepaintView
 		// Wait for all previous rendering to complete before starting benchmark.
 		DWORD profile_time = ::Get_CPU_Clock (pt_high);
 
-		WW3D::Render (doc->GetScene (), m_pCamera, FALSE, FALSE);
+		WW3D::Render (doc->GetScene (), m_pCamera.Peek(), FALSE, FALSE);
 
 		// Wait for all rendering to complete before stopping benchmark.
 		DWORD milliseconds = (::Get_CPU_Clock (pt_high) - profile_time) / 1000;
@@ -531,7 +529,7 @@ CGraphicView::RepaintView
 		WW3D::Render (doc->GetCursorScene (), doc->Get2DCamera (), FALSE, FALSE);
 
 		// Render the dazzles
-		doc->Render_Dazzles(m_pCamera);
+		doc->Render_Dazzles(m_pCamera.Peek());
 
 		// Finish out the rendering process
 		WW3D::End_Render ();
@@ -589,7 +587,7 @@ CGraphicView::UpdateDisplay ()
 
 		// Render the current view inside the frame
         WW3D::Begin_Render (TRUE, TRUE, Vector3 (0.2,0.4,0.6));
-		WW3D::Render (doc->GetScene (), m_pCamera, FALSE, FALSE);
+		WW3D::Render (doc->GetScene (), m_pCamera.Peek(), FALSE, FALSE);
 		WW3D::End_Render ();
     } */
 }

--- a/Core/Tools/W3DView/GraphicView.h
+++ b/Core/Tools/W3DView/GraphicView.h
@@ -170,7 +170,7 @@ protected:
         void					SetAllowedCameraRotation (CAMERA_ROTATION cameraRotation);
         CAMERA_ROTATION		GetAllowedCameraRotation () const			{ return m_allowedCameraRotation; }
         void					SetCameraPos (CAMERA_POS cameraPos);
-        class CameraClass *GetCamera () const							{ return m_pCamera; }
+        class CameraClass *GetCamera () const							{ return m_pCamera.Peek(); }
 
 		  float					Get_Camera_Distance () const				{ return m_CameraDistance; }
 		  void					Set_Camera_Distance (float dist);
@@ -200,7 +200,7 @@ protected:
 			//
 			//	Misc
 			//
-			RenderObjClass *	Get_Light_Mesh () const					{ return m_pLightMesh; }
+			RenderObjClass *	Get_Light_Mesh () const					{ return m_pLightMesh.Peek(); }
 			Vector3 &			Get_Object_Center ()						{ return m_ObjectCenter; }
 
 			//
@@ -227,8 +227,8 @@ protected:
         BOOL					m_bInitialized;
         BOOL					m_bActive;
         UINT					m_TimerID;
-        CameraClass	*		m_pCamera;
-		  RenderObjClass *	m_pLightMesh;
+        RefCountPtr<CameraClass>	m_pCamera;
+		  RefCountPtr<RenderObjClass>	m_pLightMesh;
 		  bool					m_bLightMeshInScene;
 		  Vector3				m_ObjectCenter;
 		  SphereClass			m_ViewedSphere;

--- a/Core/Tools/W3DView/PlaySoundDialog.cpp
+++ b/Core/Tools/W3DView/PlaySoundDialog.cpp
@@ -39,7 +39,6 @@ static char THIS_FILE[] = __FILE__;
 /////////////////////////////////////////////////////////////////////////////
 PlaySoundDialogClass::PlaySoundDialogClass(LPCTSTR filename, CWnd* pParent /*=nullptr*/)
 	:	Filename (filename),
-		SoundObj (nullptr),
 		CDialog(PlaySoundDialogClass::IDD, pParent)
 {
 	//{{AFX_DATA_INIT(PlaySoundDialogClass)
@@ -96,7 +95,7 @@ void
 PlaySoundDialogClass::OnCancel ()
 {
 	SoundObj->Stop ();
-	REF_PTR_RELEASE (SoundObj);
+	SoundObj.Clear();
 
 	CDialog::OnCancel ();
 }
@@ -120,7 +119,7 @@ PlaySoundDialogClass::OnInitDialog ()
 	//
 	//	Create the sound effect so we can play it
 	//
-	SoundObj = WWAudioClass::Get_Instance ()->Create_Sound_Effect (Filename);
+	SoundObj.Assign_No_Add_Ref (WWAudioClass::Get_Instance ()->Create_Sound_Effect (Filename));
 	if (SoundObj == nullptr) {
 		CString message;
 		message.Format ("Cannot find sound file: %s!", (LPCTSTR)Filename, MB_OK);

--- a/Core/Tools/W3DView/PlaySoundDialog.h
+++ b/Core/Tools/W3DView/PlaySoundDialog.h
@@ -61,7 +61,7 @@ protected:
 
 private:
 	CString					Filename;
-	AudibleSoundClass *	SoundObj;
+	RefCountPtr<AudibleSoundClass>	SoundObj;
 };
 
 //{{AFX_INSERT_LOCATION}}

--- a/Core/Tools/W3DView/RingPropertySheet.cpp
+++ b/Core/Tools/W3DView/RingPropertySheet.cpp
@@ -48,10 +48,9 @@ RingPropertySheetClass::RingPropertySheetClass
 	CWnd *					pParentWnd,
 	UINT						iSelectPage
 )
-	:	m_RenderObj (nullptr),
-		CPropertySheet(nIDCaption, pParentWnd, iSelectPage)
+	:	CPropertySheet(nIDCaption, pParentWnd, iSelectPage),
+		m_RenderObj (Create_Add_Ref (ring))
 {
-	REF_PTR_SET (m_RenderObj, ring);
 	Initialize ();
 }
 
@@ -68,10 +67,9 @@ RingPropertySheetClass::RingPropertySheetClass
 	CWnd *						pParentWnd,
 	UINT							iSelectPage
 )
-	:	m_RenderObj (nullptr),
-		CPropertySheet(pszCaption, pParentWnd, iSelectPage)
+	:	CPropertySheet(pszCaption, pParentWnd, iSelectPage),
+		m_RenderObj (Create_Add_Ref (ring))
 {
-	REF_PTR_SET (m_RenderObj, ring);
 	Initialize ();
 }
 
@@ -83,7 +81,6 @@ RingPropertySheetClass::RingPropertySheetClass
 /////////////////////////////////////////////////////////////////////////////
 RingPropertySheetClass::~RingPropertySheetClass ()
 {
-	REF_PTR_RELEASE (m_RenderObj);
 }
 
 
@@ -180,7 +177,7 @@ RingPropertySheetClass::Add_Object_To_Viewer ()
 		//
 		// Create a new prototype for this object
 		//
-		RingPrototypeClass *prototype	= new RingPrototypeClass (m_RenderObj);
+		RingPrototypeClass *prototype	= new RingPrototypeClass (m_RenderObj.Peek());
 
 		//
 		// Update the asset manager with the new prototype
@@ -201,14 +198,14 @@ RingPropertySheetClass::Add_Object_To_Viewer ()
 		//
 		doc->Reload_Displayed_Object ();
 		m_LastSavedName = m_RenderObj->Get_Name ();
-		REF_PTR_SET (m_RenderObj, (RingRenderObjClass *)doc->GetDisplayedObject ());
+		m_RenderObj.Assign_Add_Ref ((RingRenderObjClass *)doc->GetDisplayedObject ());
 
 		//
 		// Pass the object along to the pages
 		//
-		m_GeneralPage.Set_Ring (m_RenderObj);
-		m_ColorPage.Set_Ring (m_RenderObj);
-		m_ScalePage.Set_Ring (m_RenderObj);
+		m_GeneralPage.Set_Ring (m_RenderObj.Peek());
+		m_ColorPage.Set_Ring (m_RenderObj.Peek());
+		m_ScalePage.Set_Ring (m_RenderObj.Peek());
 	}
 }
 
@@ -242,9 +239,9 @@ RingPropertySheetClass::Initialize ()
 	//
 	// Pass the object along to the pages
 	//
-	m_GeneralPage.Set_Ring (m_RenderObj);
-	m_ColorPage.Set_Ring (m_RenderObj);
-	m_ScalePage.Set_Ring (m_RenderObj);
+	m_GeneralPage.Set_Ring (m_RenderObj.Peek());
+	m_ColorPage.Set_Ring (m_RenderObj.Peek());
+	m_ScalePage.Set_Ring (m_RenderObj.Peek());
 
 	//
 	// Add the pages to the sheet
@@ -270,12 +267,12 @@ RingPropertySheetClass::Initialize ()
 void
 RingPropertySheetClass::Create_New_Object ()
 {
-	m_RenderObj = new RingRenderObjClass;
+	m_RenderObj.Assign_No_Add_Ref (new RingRenderObjClass);
 	m_RenderObj->Set_Name ("Ring");
 
 	//
 	//	Display the new object
 	//
-	::GetCurrentDocument ()->DisplayObject (m_RenderObj);
+	::GetCurrentDocument ()->DisplayObject (m_RenderObj.Peek());
 }
 

--- a/Core/Tools/W3DView/RingPropertySheet.h
+++ b/Core/Tools/W3DView/RingPropertySheet.h
@@ -109,7 +109,7 @@ private:
 	RingGeneralPropPageClass	m_GeneralPage;
 	RingColorPropPageClass		m_ColorPage;
 	RingSizePropPageClass		m_ScalePage;
-	RingRenderObjClass *			m_RenderObj;
+	RefCountPtr<RingRenderObjClass>			m_RenderObj;
 	CString							m_LastSavedName;
 };
 

--- a/Core/Tools/W3DView/ScreenCursor.cpp
+++ b/Core/Tools/W3DView/ScreenCursor.cpp
@@ -53,8 +53,6 @@
 ///////////////////////////////////////////////////////////////////
 ScreenCursorClass::ScreenCursorClass ()
 	:	m_ScreenPos (0, 0),
-		m_pTexture (nullptr),
-		m_pVertMaterial (nullptr),
 		m_Width (0),
 		m_Height (0),
 		m_hWnd (nullptr)
@@ -70,9 +68,7 @@ ScreenCursorClass::ScreenCursorClass ()
 ///////////////////////////////////////////////////////////////////
 ScreenCursorClass::ScreenCursorClass (const ScreenCursorClass &src)
 	:	m_ScreenPos (0, 0),
-		m_pTexture (nullptr),
 		m_hWnd (nullptr),
-		m_pVertMaterial (nullptr),
 		m_Width (0),
 		m_Height (0),
 		RenderObjClass (src)
@@ -88,8 +84,6 @@ ScreenCursorClass::ScreenCursorClass (const ScreenCursorClass &src)
 ///////////////////////////////////////////////////////////////////
 ScreenCursorClass::~ScreenCursorClass ()
 {
-	REF_PTR_RELEASE (m_pTexture);
-	REF_PTR_RELEASE (m_pVertMaterial);
 }
 
 
@@ -101,10 +95,8 @@ ScreenCursorClass::~ScreenCursorClass ()
 void
 ScreenCursorClass::Initialize ()
 {
-	REF_PTR_RELEASE(m_pVertMaterial);
-
 	// Create default vertex material
-	m_pVertMaterial = NEW_REF( VertexMaterialClass, ());
+	m_pVertMaterial.Assign_No_Add_Ref (NEW_REF( VertexMaterialClass, ()));
 	m_pVertMaterial->Set_Diffuse (1.0F, 1.0F, 1.0F);
 	m_pVertMaterial->Set_Emissive (0.0F, 0.0F, 0.0F);
 	m_pVertMaterial->Set_Specular (1.0F, 1.0F, 1.0F);
@@ -149,7 +141,7 @@ ScreenCursorClass::Initialize ()
 void
 ScreenCursorClass::Set_Texture (TextureClass *texture)
 {
-	REF_PTR_SET (m_pTexture, texture);
+	m_pTexture.Assign_Add_Ref (texture);
 
 	// Find the dimensions of the texture:
 	if (m_pTexture != nullptr) {
@@ -296,9 +288,9 @@ ScreenCursorClass::Render (RenderInfoClass &rinfo)
 	/*
 	** Apply the shader and material
 	*/
-	DX8Wrapper::Set_Material(m_pVertMaterial);
+	DX8Wrapper::Set_Material(m_pVertMaterial.Peek());
 	DX8Wrapper::Set_Shader(ShaderClass::_PresetATestBlend2DShader);
-	DX8Wrapper::Set_Texture(0,m_pTexture);
+	DX8Wrapper::Set_Texture(0,m_pTexture.Peek());
 
 	DX8Wrapper::Set_Vertex_Buffer(vbaccess);
 	DX8Wrapper::Set_Index_Buffer(ibaccess,0);

--- a/Core/Tools/W3DView/ScreenCursor.h
+++ b/Core/Tools/W3DView/ScreenCursor.h
@@ -93,8 +93,8 @@ class ScreenCursorClass : public RenderObjClass
 		////////////////////////////////////////////////////////////////////////
 		HWND						m_hWnd;
 		Vector2					m_ScreenPos;
-		TextureClass *			m_pTexture;
-		VertexMaterialClass *m_pVertMaterial;
+		RefCountPtr<TextureClass>			m_pTexture;
+		RefCountPtr<VertexMaterialClass> m_pVertMaterial;
 
 		Vector3					m_Verticies[4];
 		Vector3					m_Normals[4];

--- a/Core/Tools/W3DView/SpherePropertySheet.cpp
+++ b/Core/Tools/W3DView/SpherePropertySheet.cpp
@@ -48,10 +48,9 @@ SpherePropertySheetClass::SpherePropertySheetClass
 	CWnd *						pParentWnd,
 	UINT							iSelectPage
 )
-	:	m_RenderObj (nullptr),
-		CPropertySheet(nIDCaption, pParentWnd, iSelectPage)
+	:	CPropertySheet(nIDCaption, pParentWnd, iSelectPage),
+		m_RenderObj (Create_Add_Ref (sphere))
 {
-	REF_PTR_SET (m_RenderObj, sphere);
 	Initialize ();
 }
 
@@ -68,10 +67,9 @@ SpherePropertySheetClass::SpherePropertySheetClass
 	CWnd *							pParentWnd,
 	UINT								iSelectPage
 )
-	:	m_RenderObj (nullptr),
-		CPropertySheet(pszCaption, pParentWnd, iSelectPage)
+	:	CPropertySheet(pszCaption, pParentWnd, iSelectPage),
+		m_RenderObj (Create_Add_Ref (sphere))
 {
-	REF_PTR_SET (m_RenderObj, sphere);
 	Initialize ();
 }
 
@@ -83,7 +81,6 @@ SpherePropertySheetClass::SpherePropertySheetClass
 /////////////////////////////////////////////////////////////////////////////
 SpherePropertySheetClass::~SpherePropertySheetClass ()
 {
-	REF_PTR_RELEASE (m_RenderObj);
 }
 
 
@@ -180,7 +177,7 @@ SpherePropertySheetClass::Add_Object_To_Viewer ()
 		//
 		// Create a new prototype for this object
 		//
-		SpherePrototypeClass *prototype	= new SpherePrototypeClass (m_RenderObj);
+		SpherePrototypeClass *prototype	= new SpherePrototypeClass (m_RenderObj.Peek());
 
 		//
 		// Update the asset manager with the new prototype
@@ -201,14 +198,14 @@ SpherePropertySheetClass::Add_Object_To_Viewer ()
 		//
 		doc->Reload_Displayed_Object ();
 		m_LastSavedName = m_RenderObj->Get_Name ();
-		REF_PTR_SET (m_RenderObj, (SphereRenderObjClass *)doc->GetDisplayedObject ());
+		m_RenderObj.Assign_Add_Ref ((SphereRenderObjClass *)doc->GetDisplayedObject ());
 
 		//
 		// Pass the object along to the pages
 		//
-		m_GeneralPage.Set_Sphere (m_RenderObj);
-		m_ColorPage.Set_Sphere (m_RenderObj);
-		m_ScalePage.Set_Sphere (m_RenderObj);
+		m_GeneralPage.Set_Sphere (m_RenderObj.Peek());
+		m_ColorPage.Set_Sphere (m_RenderObj.Peek());
+		m_ScalePage.Set_Sphere (m_RenderObj.Peek());
 	}
 }
 
@@ -242,9 +239,9 @@ SpherePropertySheetClass::Initialize ()
 	//
 	// Pass the object along to the pages
 	//
-	m_GeneralPage.Set_Sphere (m_RenderObj);
-	m_ColorPage.Set_Sphere (m_RenderObj);
-	m_ScalePage.Set_Sphere (m_RenderObj);
+	m_GeneralPage.Set_Sphere (m_RenderObj.Peek());
+	m_ColorPage.Set_Sphere (m_RenderObj.Peek());
+	m_ScalePage.Set_Sphere (m_RenderObj.Peek());
 
 	//
 	// Add the pages to the sheet
@@ -270,12 +267,12 @@ SpherePropertySheetClass::Initialize ()
 void
 SpherePropertySheetClass::Create_New_Object ()
 {
-	m_RenderObj = new SphereRenderObjClass;
+	m_RenderObj.Assign_No_Add_Ref (new SphereRenderObjClass);
 	m_RenderObj->Set_Name ("Sphere");
 
 	//
 	//	Display the new object
 	//
-	::GetCurrentDocument ()->DisplayObject (m_RenderObj);
+	::GetCurrentDocument ()->DisplayObject (m_RenderObj.Peek());
 }
 

--- a/Core/Tools/W3DView/SpherePropertySheet.h
+++ b/Core/Tools/W3DView/SpherePropertySheet.h
@@ -109,7 +109,7 @@ private:
 	SphereGeneralPropPageClass		m_GeneralPage;
 	SphereColorPropPageClass		m_ColorPage;
 	SphereSizePropPageClass			m_ScalePage;
-	SphereRenderObjClass *			m_RenderObj;
+	RefCountPtr<SphereRenderObjClass>			m_RenderObj;
 	CString								m_LastSavedName;
 };
 

--- a/Core/Tools/W3DView/W3DViewDoc.cpp
+++ b/Core/Tools/W3DView/W3DViewDoc.cpp
@@ -194,31 +194,13 @@ CW3DViewDoc::CleanupResources ()
 	 delete m_pDazzleLayer;
 	 m_pDazzleLayer = nullptr;
 
-    // Was there a valid 2D camera?
-    if (m_pC2DCamera)
-    {
-        // Free the camera object
-        m_pC2DCamera.Clear ();
-    }
+    // Free the camera objects
+    m_pC2DCamera.Clear ();
+    m_pCBackObjectCamera.Clear ();
 
-    // Was there a valid background camera?
-    if (m_pCBackObjectCamera)
-    {
-        // Free the camera object
-        m_pCBackObjectCamera.Clear ();
-    }
-
-    // Was there a valid background BMP?
-    if (m_pCBackgroundBMP)
-    {
-        m_pCBackgroundBMP.Clear ();
-    }
-
-    // Was there a valid scene light?
-    if (m_pCSceneLight)
-    {
-        m_pCSceneLight.Clear ();
-    }
+    // Free the background BMP and scene light
+    m_pCBackgroundBMP.Clear ();
+    m_pCSceneLight.Clear ();
 
     // Free the currently displayed object
     SAFE_DELETE (m_pCAnimCombo);

--- a/Core/Tools/W3DView/W3DViewDoc.cpp
+++ b/Core/Tools/W3DView/W3DViewDoc.cpp
@@ -140,29 +140,23 @@ CW3DViewDoc::~CW3DViewDoc ()
 void
 CW3DViewDoc::CleanupResources ()
 {
-    if (m_pC2DScene)
+    if (m_pCBackgroundBMP)
     {
-		  if (m_pCBackgroundBMP)
-        {
-            // Remove the background BMP from the scene
-				m_pCBackgroundBMP->Remove ();
-        }
-
-        // Release the 2D scene we allocated to display background BMPs
-        m_pC2DScene.Clear ();
+        // Remove the background BMP from the scene
+        m_pCBackgroundBMP->Remove ();
     }
 
-    if (m_pCBackObjectScene)
-    {
-        if (m_pCBackgroundObject)
-        {
-            // Remove the background BMP from the scene
-				m_pCBackgroundObject->Remove ();
-        }
+    // Release the 2D scene we allocated to display background BMPs
+    m_pC2DScene.Clear ();
 
-        // Release the scene we allocated to display background objects
-        m_pCBackObjectScene.Clear ();
+    if (m_pCBackgroundObject)
+    {
+        // Remove the background BMP from the scene
+        m_pCBackgroundObject->Remove ();
     }
+
+    // Release the scene we allocated to display background objects
+    m_pCBackObjectScene.Clear ();
 
 	if (m_pCursor != nullptr) {
 		m_pCursor->Remove ();

--- a/Core/Tools/W3DView/W3DViewDoc.cpp
+++ b/Core/Tools/W3DView/W3DViewDoc.cpp
@@ -149,8 +149,7 @@ CW3DViewDoc::CleanupResources ()
         }
 
         // Release the 2D scene we allocated to display background BMPs
-        m_pC2DScene->Release_Ref ();
-        m_pC2DScene = nullptr;
+        m_pC2DScene.Clear ();
     }
 
     if (m_pCBackObjectScene)
@@ -162,8 +161,7 @@ CW3DViewDoc::CleanupResources ()
         }
 
         // Release the scene we allocated to display background objects
-        m_pCBackObjectScene->Release_Ref ();
-        m_pCBackObjectScene = nullptr;
+        m_pCBackObjectScene.Clear ();
     }
 
 	if (m_pCursor != nullptr) {
@@ -182,15 +180,14 @@ CW3DViewDoc::CleanupResources ()
         if (m_pCSceneLight)
         {
             // Remove the light from the scene
-				Remove_Object_From_Scene (m_pCSceneLight);
+				Remove_Object_From_Scene (m_pCSceneLight.Peek());
         }
 
 		  // Get rid of the lined up objects.
 		  m_pCScene->Clear_Lineup();
 
         // Release the scene object we allocated earlier
-        m_pCScene->Release_Ref ();
-        m_pCScene = nullptr;
+        m_pCScene.Clear ();
     }
 
 	 // Was there a dazzle layer?
@@ -201,30 +198,26 @@ CW3DViewDoc::CleanupResources ()
     if (m_pC2DCamera)
     {
         // Free the camera object
-        m_pC2DCamera->Release_Ref ();
-        m_pC2DCamera = nullptr;
+        m_pC2DCamera.Clear ();
     }
 
     // Was there a valid background camera?
     if (m_pCBackObjectCamera)
     {
         // Free the camera object
-        m_pCBackObjectCamera->Release_Ref ();
-        m_pCBackObjectCamera = nullptr;
+        m_pCBackObjectCamera.Clear ();
     }
 
     // Was there a valid background BMP?
     if (m_pCBackgroundBMP)
     {
-        m_pCBackgroundBMP->Release_Ref ();
-        m_pCBackgroundBMP = nullptr;
+        m_pCBackgroundBMP.Clear ();
     }
 
     // Was there a valid scene light?
     if (m_pCSceneLight)
     {
-        m_pCSceneLight->Release_Ref ();
-        m_pCSceneLight = nullptr;
+        m_pCSceneLight.Clear ();
     }
 
     // Free the currently displayed object
@@ -338,7 +331,7 @@ CW3DViewDoc::InitScene ()
 		//
 		ParticleEmitterClass::Set_Default_Remove_On_Complete (false);
 
-		m_pCScene = new ViewerSceneClass;
+		m_pCScene.Assign_No_Add_Ref (new ViewerSceneClass);
 		ASSERT (m_pCScene);
 		if (m_pCScene != nullptr) {
 
@@ -349,7 +342,7 @@ CW3DViewDoc::InitScene ()
 			m_pCScene->Set_Fog_Color(GetBackgroundColor());
 
 			// Create a new scene light
-			m_pCSceneLight = new LightClass;
+			m_pCSceneLight.Assign_No_Add_Ref (new LightClass);
 			ASSERT (m_pCSceneLight);
 
 			if (m_pCSceneLight != nullptr) {
@@ -365,12 +358,12 @@ CW3DViewDoc::InitScene ()
 				m_pCSceneLight->Set_Specular (Vector3(1, 1, 1));
 
 				// Add this light to the scene
-				m_pCScene->Add_Render_Object (m_pCSceneLight);
+				m_pCScene->Add_Render_Object (m_pCSceneLight.Peek());
 			}
 		}
 
 		// Instantiate a new 2D scene
-		m_pC2DScene = new SimpleSceneClass;
+		m_pC2DScene.Assign_No_Add_Ref (new SimpleSceneClass);
 		ASSERT (m_pC2DScene);
 
 		// Instantiate a new 2D cursor scene
@@ -381,7 +374,7 @@ CW3DViewDoc::InitScene ()
 		m_pCursorScene->Add_Render_Object (m_pCursor.Peek());
 
 
-		m_pCBackObjectScene = new SimpleSceneClass;
+		m_pCBackObjectScene.Assign_No_Add_Ref (new SimpleSceneClass);
 
 		// Were we successful in instantiating the scene object?
 		ASSERT (m_pCBackObjectScene);
@@ -394,7 +387,7 @@ CW3DViewDoc::InitScene ()
 
 		// Create a new instance of the camera class to use
 		// when rendering the background object
-		m_pCBackObjectCamera = new CameraClass ();
+		m_pCBackObjectCamera.Assign_No_Add_Ref (new CameraClass ());
 
 		// Were we successful in creating the new instance?
 		ASSERT (m_pCBackObjectCamera);
@@ -408,7 +401,7 @@ CW3DViewDoc::InitScene ()
 
 		// Create a new instance of the camera class to use
 		// when rendering the background BMP
-		m_pC2DCamera = new CameraClass ();
+		m_pC2DCamera.Assign_No_Add_Ref (new CameraClass ());
 
 		// Were we successful in creating the new instance?
 		ASSERT (m_pC2DCamera);
@@ -1235,8 +1228,7 @@ CW3DViewDoc::SetBackgroundBMP (LPCTSTR pszBackgroundBMP)
             // Remove the background BMP from the scene
             // and release its pointer
 				m_pCBackgroundBMP->Remove ();
-            m_pCBackgroundBMP->Release_Ref ();
-            m_pCBackgroundBMP = nullptr;
+            m_pCBackgroundBMP.Clear ();
         }
 
         // Is this a new background BMP?
@@ -1244,14 +1236,14 @@ CW3DViewDoc::SetBackgroundBMP (LPCTSTR pszBackgroundBMP)
             (m_stringBackgroundBMP.CompareNoCase (pszBackgroundBMP) != 0))
         {
 				// Create a new instance of the BMP object to use
-            m_pCBackgroundBMP = new Bitmap2DObjClass (pszBackgroundBMP, 0.5F, 0.5F, TRUE, FALSE);
+            m_pCBackgroundBMP.Assign_No_Add_Ref (new Bitmap2DObjClass (pszBackgroundBMP, 0.5F, 0.5F, TRUE, FALSE));
 
             // Were we successful in creating the bitmap object?
             ASSERT (m_pCBackgroundBMP);
             if (m_pCBackgroundBMP)
             {
                 // Add the object to the scene
-					 m_pC2DScene->Add_Render_Object (m_pCBackgroundBMP);
+					 m_pC2DScene->Add_Render_Object (m_pCBackgroundBMP.Peek());
             }
         }
 
@@ -1775,14 +1767,13 @@ CW3DViewDoc::SetBackgroundObject (LPCTSTR pszBackgroundObjectName)
 				m_pCBackgroundObject->Remove ();
 
             // Free the object
-            m_pCBackgroundObject->Release_Ref ();
-            m_pCBackgroundObject = nullptr;
+            m_pCBackgroundObject.Clear ();
         }
 
         if (pszBackgroundObjectName)
         {
             // Create a new instance of the render object to use as the background
-            m_pCBackgroundObject = WW3DAssetManager::Get_Instance()->Create_Render_Obj (pszBackgroundObjectName);
+            m_pCBackgroundObject.Assign_No_Add_Ref (WW3DAssetManager::Get_Instance()->Create_Render_Obj (pszBackgroundObjectName));
 
             ASSERT (m_pCBackgroundObject);
             if (m_pCBackgroundObject)
@@ -1806,7 +1797,7 @@ CW3DViewDoc::SetBackgroundObject (LPCTSTR pszBackgroundObjectName)
                 m_pCBackObjectCamera->Set_Clip_Planes (1, cameraDepth);
 
                 // Add the background object to the scene
-					 m_pCBackObjectScene->Add_Render_Object (m_pCBackgroundObject);
+					 m_pCBackObjectScene->Add_Render_Object (m_pCBackgroundObject.Peek());
             }
         }
 

--- a/Core/Tools/W3DView/W3DViewDoc.cpp
+++ b/Core/Tools/W3DView/W3DViewDoc.cpp
@@ -129,7 +129,6 @@ CW3DViewDoc::CW3DViewDoc ()
 CW3DViewDoc::~CW3DViewDoc ()
 {
     CleanupResources ();
-	 REF_PTR_RELEASE (m_pCursor);
 }
 
 
@@ -170,14 +169,14 @@ CW3DViewDoc::CleanupResources ()
 	if (m_pCursor != nullptr) {
 		m_pCursor->Remove ();
 	}
-	REF_PTR_RELEASE (m_pCursorScene);
+	m_pCursorScene.Clear();
 
     if (m_pCScene)
     {
         if (m_pCRenderObj)
         {
             // Remove the currently displayed object from the scene
-				Remove_Object_From_Scene (m_pCRenderObj);
+				Remove_Object_From_Scene (m_pCRenderObj.Peek());
         }
 
         if (m_pCSceneLight)
@@ -197,14 +196,6 @@ CW3DViewDoc::CleanupResources ()
 	 // Was there a dazzle layer?
 	 delete m_pDazzleLayer;
 	 m_pDazzleLayer = nullptr;
-
-    // Was there a valid scene object?
-    if (m_pCBackObjectScene)
-    {
-        // Free the scene object
-        m_pCBackObjectScene->Release_Ref ();
-        m_pCBackObjectScene = nullptr;
-    }
 
     // Was there a valid 2D camera?
     if (m_pC2DCamera)
@@ -236,14 +227,10 @@ CW3DViewDoc::CleanupResources ()
         m_pCSceneLight = nullptr;
     }
 
-    // Was there a valid display object?
-    if (m_pCRenderObj)
-    {
-        // Free the currently displayed object
-			SAFE_DELETE (m_pCAnimCombo);
-			REF_PTR_RELEASE (m_pCAnimation);
-			REF_PTR_RELEASE (m_pCRenderObj);
-    }
+    // Free the currently displayed object
+    SAFE_DELETE (m_pCAnimCombo);
+    m_pCAnimation.Clear ();
+    m_pCRenderObj.Clear ();
 }
 
 ///////////////////////////////////////////////////////////////
@@ -264,7 +251,7 @@ CW3DViewDoc::OnNewDocument ()
     if (m_pCScene && m_pCRenderObj)
     {
         // Remove the currently displayed object from the scene
-		  Remove_Object_From_Scene (m_pCRenderObj);
+		  Remove_Object_From_Scene (m_pCRenderObj.Peek());
     }
 
 	 if (m_pCScene)
@@ -276,13 +263,10 @@ CW3DViewDoc::OnNewDocument ()
 		 m_pCScene->Set_Fog_Color(m_backgroundColor);
 	 }
 
-    if (m_pCRenderObj)
-    {
-			// Free the currently displayed object
-			SAFE_DELETE (m_pCAnimCombo);
-			REF_PTR_RELEASE (m_pCAnimation);
-			REF_PTR_RELEASE (m_pCRenderObj);
-    }
+	// Free the currently displayed object
+	SAFE_DELETE (m_pCAnimCombo);
+	m_pCAnimation.Clear();
+	m_pCRenderObj.Clear();
 
     CDataTreeView *pCDataTreeView = GetDataTreeView ();
     if (pCDataTreeView)
@@ -390,11 +374,11 @@ CW3DViewDoc::InitScene ()
 		ASSERT (m_pC2DScene);
 
 		// Instantiate a new 2D cursor scene
-		m_pCursorScene = new SimpleSceneClass;
-		ASSERT (m_pCursorScene);
+		m_pCursorScene.Assign_No_Add_Ref (new SimpleSceneClass);
+		ASSERT (m_pCursorScene != nullptr);
 
 		Create_Cursor ();
-		m_pCursorScene->Add_Render_Object (m_pCursor);
+		m_pCursorScene->Add_Render_Object (m_pCursor.Peek());
 
 
 		m_pCBackObjectScene = new SimpleSceneClass;
@@ -600,14 +584,13 @@ CW3DViewDoc::Display_Emitter
 
 		// Lose the animation
 		SAFE_DELETE (m_pCAnimCombo);
-		REF_PTR_RELEASE (m_pCAnimation);
+		m_pCAnimation.Clear();
 
 			if (m_pCRenderObj != nullptr) {
 
 				// Remove this object from the scene
-				Remove_Object_From_Scene (m_pCRenderObj);
-				m_pCRenderObj->Release_Ref ();
-				m_pCRenderObj = nullptr;
+				Remove_Object_From_Scene (m_pCRenderObj.Peek());
+				m_pCRenderObj.Clear();
 			}
 			m_pCScene->Clear_Lineup();
 
@@ -616,8 +599,8 @@ CW3DViewDoc::Display_Emitter
 
 			// Add the emitter to the scene
 			pemitter->Set_Transform (Matrix3D (1));
-			REF_PTR_SET (m_pCRenderObj, pemitter);
-			m_pCScene->Add_Render_Object (m_pCRenderObj);
+			m_pCRenderObj.Assign_Add_Ref (pemitter);
+			m_pCScene->Add_Render_Object (m_pCRenderObj.Peek());
 			pemitter->Start ();
 
 			CGraphicView *pCGraphicView = GetGraphicView ();
@@ -657,16 +640,15 @@ CW3DViewDoc::DisplayObject
     {
         // Lose the animation
 		  SAFE_DELETE (m_pCAnimCombo);
-		  REF_PTR_RELEASE (m_pCAnimation);
+		  m_pCAnimation.Clear();
 
         // Do we have an old object to remove from the scene?
 		  if (add_ghost == false) {
 			  if (m_pCRenderObj)
 			  {
 					// Remove this object from the scene
-					Remove_Object_From_Scene (m_pCRenderObj);
-					m_pCRenderObj->Release_Ref ();
-					m_pCRenderObj = nullptr;
+					Remove_Object_From_Scene (m_pCRenderObj.Peek());
+					m_pCRenderObj.Clear();
 			  }
 		  }
 		  m_pCScene->Clear_Lineup();
@@ -677,21 +659,20 @@ CW3DViewDoc::DisplayObject
             // Reset the animation for this object
             pCModel->Set_Animation ();
 
-            m_pCRenderObj = pCModel;
-            m_pCRenderObj->Add_Ref ();
+            m_pCRenderObj.Assign_Add_Ref (pCModel);
             m_pCRenderObj->Set_Transform (Matrix3D (1));
 
             // Add this object to the scene
 				if (m_pCRenderObj->Class_ID () == RenderObjClass::CLASSID_BITMAP2D) {
-					m_pC2DScene->Add_Render_Object (m_pCRenderObj);
+					m_pC2DScene->Add_Render_Object (m_pCRenderObj.Peek());
 				} else {
-					m_pCScene->Add_Render_Object (m_pCRenderObj);
+					m_pCScene->Add_Render_Object (m_pCRenderObj.Peek());
 				}
 
 				// Reset the current lod to be the lowest possible LOD...
 				if ((m_pCScene->Are_LODs_Switching ()) &&
 					 (m_pCRenderObj->Class_ID () == RenderObjClass::CLASSID_HLOD)) {
-					((HLodClass *)m_pCRenderObj)->Set_LOD_Level (0);
+					((HLodClass *)m_pCRenderObj.Peek())->Set_LOD_Level (0);
 				}
 
             CGraphicView *pCGraphicView = GetGraphicView ();
@@ -820,7 +801,7 @@ CW3DViewDoc::StepAnimation (int iFrameInc)
 
 			m_pCRenderObj->Set_Animation (m_pCAnimCombo);
 		} else {
-			m_pCRenderObj->Set_Animation (m_pCAnimation, m_CurrentFrame);
+			m_pCRenderObj->Set_Animation (m_pCAnimation.Peek(), m_CurrentFrame);
 		}
 
 		Update_Camera ();
@@ -856,9 +837,8 @@ CW3DViewDoc::PlayAnimation
 
         // Get an instance of the animation object
 		  SAFE_DELETE (m_pCAnimCombo);
-		  REF_PTR_RELEASE (m_pCAnimation);
-        m_pCAnimation = WW3DAssetManager::Get_Instance()->Get_HAnim (pszAnimationName);
-        ASSERT (m_pCAnimation);
+        m_pCAnimation.Assign_No_Add_Ref (WW3DAssetManager::Get_Instance()->Get_HAnim (pszAnimationName));
+        ASSERT (m_pCAnimation != nullptr);
 
         // Reset the frame counter
         m_CurrentFrame = 0;
@@ -867,7 +847,7 @@ CW3DViewDoc::PlayAnimation
         if (m_pCRenderObj)
         {
             // Update the animation frame
-            m_pCRenderObj->Set_Animation (m_pCAnimation, 0);
+            m_pCRenderObj->Set_Animation (m_pCAnimation.Peek(), 0);
 
             CGraphicView *pCGraphicView = GetGraphicView ();
             if (pCGraphicView)
@@ -944,10 +924,9 @@ CW3DViewDoc::PlayAnimation
 
         // Get an instance of the animation object
 		  SAFE_DELETE (m_pCAnimCombo);
-		  REF_PTR_RELEASE (m_pCAnimation);
 		  m_pCAnimCombo = pCAnimCombo;
-		  m_pCAnimation = m_pCAnimCombo->Get_Motion(0);	// ref added by get_motion
-        ASSERT (m_pCAnimation);
+		  m_pCAnimation.Assign_No_Add_Ref (m_pCAnimCombo->Get_Motion(0));	// ref added by get_motion
+        ASSERT (m_pCAnimation != nullptr);
 
 		  // It will be assumed that every animation in the m_pCAnimCombo
 		  // has the same number of frames and has the same framerate as
@@ -1030,7 +1009,7 @@ CW3DViewDoc::Update_Camera ()
 	if (m_bAnimateCamera && m_pCRenderObj != nullptr) {
 
 		Matrix3D transform (1);
-		if (Get_Camera_Transform (m_pCRenderObj, transform)) {
+		if (Get_Camera_Transform (m_pCRenderObj.Peek(), transform)) {
 
 			// Convert the bone's transform into a camera transform
 			//Matrix3D	transform = m_pCRenderObj->Get_Bone_Transform (index);
@@ -1092,9 +1071,9 @@ CW3DViewDoc::UpdateFrame (float relativeTimeSlice)
 
 			m_pCRenderObj->Set_Animation (m_pCAnimCombo);
 		} else if (m_bAnimBlend) {
-			m_pCRenderObj->Set_Animation (m_pCAnimation, m_CurrentFrame);
+			m_pCRenderObj->Set_Animation (m_pCAnimation.Peek(), m_CurrentFrame);
 		} else {
-			m_pCRenderObj->Set_Animation (m_pCAnimation, (int)m_CurrentFrame);
+			m_pCRenderObj->Set_Animation (m_pCAnimation.Peek(), (int)m_CurrentFrame);
 		}
 
 		Update_Camera ();
@@ -1847,7 +1826,7 @@ CW3DViewDoc::Remove_Object_From_Scene (RenderObjClass *prender_obj)
 {
 	// If the render object is null, then remove the current render object
 	if (prender_obj == nullptr) {
-		prender_obj = m_pCRenderObj;
+		prender_obj = m_pCRenderObj.Peek();
 	}
 
 	// Recursively remove objects from the scene (to make sure we get all particle buffers)
@@ -2403,7 +2382,7 @@ CW3DViewDoc::Make_Movie ()
 			m_pCRenderObj->Set_Animation (m_pCAnimCombo);
 		}
 		else
-			m_pCRenderObj->Set_Animation (m_pCAnimation, (int)0);
+			m_pCRenderObj->Set_Animation (m_pCAnimation.Peek(), (int)0);
 		graphic_view->RepaintView (FALSE);
 
 		// Begin our movie
@@ -2425,7 +2404,7 @@ CW3DViewDoc::Make_Movie ()
 				m_pCRenderObj->Set_Animation (m_pCAnimCombo);
 			}
 			else
-				m_pCRenderObj->Set_Animation (m_pCAnimation, frame);
+				m_pCRenderObj->Set_Animation (m_pCAnimation.Peek(), frame);
 
 			// Should we be updating the camera?
 			if (m_bAnimateCamera) {
@@ -2483,7 +2462,7 @@ CW3DViewDoc::Build_Emitter_List
 	// If the render object is null, then start from the current render object
 	//
 	if (render_obj == nullptr) {
-		render_obj = m_pCRenderObj;
+		render_obj = m_pCRenderObj.Peek();
 	}
 
 	//
@@ -2558,7 +2537,7 @@ void
 CW3DViewDoc::Create_Cursor ()
 {
 	if (m_pCursor == nullptr) {
-		m_pCursor = new ScreenCursorClass;
+		m_pCursor.Assign_No_Add_Ref (new ScreenCursorClass);
 		m_pCursor->Set_Window (GetGraphicView ()->m_hWnd);
 		m_pCursor->Set_Texture (::Load_RC_Texture ("cursor.tga"));
 	}
@@ -2579,7 +2558,7 @@ CW3DViewDoc::Count_Particles (RenderObjClass *render_obj)
 	// If the render object is null, then start from the current render object
 	//
 	if (render_obj == nullptr) {
-		render_obj = m_pCRenderObj;
+		render_obj = m_pCRenderObj.Peek();
 	}
 
 	//
@@ -2638,7 +2617,7 @@ CW3DViewDoc::Switch_LOD (int increment, RenderObjClass *render_obj)
 	// If the render object is null, then start from the current render object
 	//
 	if (render_obj == nullptr) {
-		render_obj = m_pCRenderObj;
+		render_obj = m_pCRenderObj.Peek();
 	}
 
 	//
@@ -2676,7 +2655,7 @@ CW3DViewDoc::Toggle_Alternate_Materials(RenderObjClass * render_obj)
 	// If the render object is null, start from the current render object
 	//
 	if (render_obj == nullptr) {
-		render_obj = m_pCRenderObj;
+		render_obj = m_pCRenderObj.Peek();
 	}
 
 	if (render_obj != nullptr) {

--- a/Core/Tools/W3DView/W3DViewDoc.h
+++ b/Core/Tools/W3DView/W3DViewDoc.h
@@ -112,12 +112,12 @@ public:
 	CameraClass *			Get2DCamera () const				{ return m_pC2DCamera; }
 	CameraClass *			GetBackObjectCamera () const		{ return m_pCBackObjectCamera; }
 	SceneClass *			Get2DScene () const					{ return m_pC2DScene; }
-	SceneClass *			GetCursorScene () const			{ return m_pCursorScene; }
+	SceneClass *			GetCursorScene () const			{ return m_pCursorScene.Peek(); }
 	ViewerSceneClass *	GetScene () const					{ return m_pCScene; }
 	SceneClass *			GetBackObjectScene () const		{ return m_pCBackObjectScene; }
 	LightClass *			GetSceneLight () const				{ return m_pCSceneLight; }
-	RenderObjClass *		GetDisplayedObject () const		{ return m_pCRenderObj; }
-	HAnimClass *			GetCurrentAnimation () const		{ return m_pCAnimation; }
+	RenderObjClass *		GetDisplayedObject () const		{ return m_pCRenderObj.Peek(); }
+	HAnimClass *			GetCurrentAnimation () const		{ return m_pCAnimation.Peek(); }
 	const HTreeClass *	Get_Current_HTree () const;
 
 	//
@@ -291,18 +291,18 @@ private:
 	//////////////////////////////////////////////////////////////////
 	ViewerSceneClass *	m_pCScene;
 	SceneClass *			m_pC2DScene;
-	SceneClass *			m_pCursorScene;
+	RefCountPtr<SceneClass>			m_pCursorScene;
 	SceneClass *			m_pCBackObjectScene;
 	DazzleLayerClass *	m_pDazzleLayer;
-	RenderObjClass *		m_pCRenderObj;
+	RefCountPtr<RenderObjClass>		m_pCRenderObj;
 	RenderObjClass *		m_pCBackgroundObject;
-	HAnimClass *			m_pCAnimation;
+	RefCountPtr<HAnimClass>			m_pCAnimation;
 	HAnimComboClass *		m_pCAnimCombo;
 	LightClass *			m_pCSceneLight;
 	Bitmap2DObjClass *	m_pCBackgroundBMP;
 	CameraClass *			m_pC2DCamera;
 	CameraClass *			m_pCBackObjectCamera;
-	ScreenCursorClass *	m_pCursor;
+	RefCountPtr<ScreenCursorClass>	m_pCursor;
 	Vector3					m_backgroundColor;
 	CString					m_stringBackgroundBMP;
 	CString					m_stringBackgroundObject;

--- a/Core/Tools/W3DView/W3DViewDoc.h
+++ b/Core/Tools/W3DView/W3DViewDoc.h
@@ -109,13 +109,13 @@ public:
 	//
 	//  Accessors
 	//
-	CameraClass *			Get2DCamera () const				{ return m_pC2DCamera; }
-	CameraClass *			GetBackObjectCamera () const		{ return m_pCBackObjectCamera; }
-	SceneClass *			Get2DScene () const					{ return m_pC2DScene; }
+	CameraClass *			Get2DCamera () const				{ return m_pC2DCamera.Peek(); }
+	CameraClass *			GetBackObjectCamera () const		{ return m_pCBackObjectCamera.Peek(); }
+	SceneClass *			Get2DScene () const					{ return m_pC2DScene.Peek(); }
 	SceneClass *			GetCursorScene () const			{ return m_pCursorScene.Peek(); }
-	ViewerSceneClass *	GetScene () const					{ return m_pCScene; }
-	SceneClass *			GetBackObjectScene () const		{ return m_pCBackObjectScene; }
-	LightClass *			GetSceneLight () const				{ return m_pCSceneLight; }
+	ViewerSceneClass *	GetScene () const					{ return m_pCScene.Peek(); }
+	SceneClass *			GetBackObjectScene () const		{ return m_pCBackObjectScene.Peek(); }
+	LightClass *			GetSceneLight () const				{ return m_pCSceneLight.Peek(); }
 	RenderObjClass *		GetDisplayedObject () const		{ return m_pCRenderObj.Peek(); }
 	HAnimClass *			GetCurrentAnimation () const		{ return m_pCAnimation.Peek(); }
 	const HTreeClass *	Get_Current_HTree () const;
@@ -289,19 +289,19 @@ private:
 	//////////////////////////////////////////////////////////////////
 	//  Private member data
 	//////////////////////////////////////////////////////////////////
-	ViewerSceneClass *	m_pCScene;
-	SceneClass *			m_pC2DScene;
+	RefCountPtr<ViewerSceneClass>	m_pCScene;
+	RefCountPtr<SceneClass>			m_pC2DScene;
 	RefCountPtr<SceneClass>			m_pCursorScene;
-	SceneClass *			m_pCBackObjectScene;
+	RefCountPtr<SceneClass>			m_pCBackObjectScene;
 	DazzleLayerClass *	m_pDazzleLayer;
 	RefCountPtr<RenderObjClass>		m_pCRenderObj;
-	RenderObjClass *		m_pCBackgroundObject;
+	RefCountPtr<RenderObjClass>		m_pCBackgroundObject;
 	RefCountPtr<HAnimClass>			m_pCAnimation;
 	HAnimComboClass *		m_pCAnimCombo;
-	LightClass *			m_pCSceneLight;
-	Bitmap2DObjClass *	m_pCBackgroundBMP;
-	CameraClass *			m_pC2DCamera;
-	CameraClass *			m_pCBackObjectCamera;
+	RefCountPtr<LightClass>			m_pCSceneLight;
+	RefCountPtr<Bitmap2DObjClass>	m_pCBackgroundBMP;
+	RefCountPtr<CameraClass>			m_pC2DCamera;
+	RefCountPtr<CameraClass>			m_pCBackObjectCamera;
 	RefCountPtr<ScreenCursorClass>	m_pCursor;
 	Vector3					m_backgroundColor;
 	CString					m_stringBackgroundBMP;


### PR DESCRIPTION
Replaces manual reference counting (REF_PTR_SET, REF_PTR_RELEASE, manual Add_Ref/Release_Ref) with the type-safe RefCountPtr<T> smart pointer for member variables in W3DView. Follow up to #1784.

Member variables migrated to RefCountPtr<T>:

- AssetInfoClass::m_pRenderObj
- ScreenCursorClass::m_pTexture, m_pVertMaterial
- PlaySoundDialogClass::SoundObj
- SpherePropertySheetClass::m_RenderObj
- RingPropertySheetClass::m_RenderObj
- CW3DViewDoc::m_pCScene, m_pC2DScene, m_pCursorScene, m_pCBackObjectScene, m_pCRenderObj, m_pCBackgroundObject, m_pCAnimation, m_pCSceneLight, m_pCBackgroundBMP, m_pC2DCamera, m_pCBackObjectCamera, m_pCursor
- CGraphicView::m_pCamera, m_pLightMesh

Notes:

- Used Assign_No_Add_Ref() when wrapping pointers returned with a reference already added (new, Create_Render_Obj, Create_Sound_Effect, Get_HAnim, Get_Motion)
- Used Assign_Add_Ref() when wrapping borrowed (peeked) pointers, and Create_Add_Ref() where the member is set in a constructor initializer list
- Added .Peek() when passing to functions expecting raw pointers; getters keep their raw pointer signatures
- Removed null-guards around cleanup that RefCountPtr makes redundant, and the duplicate m_pCBackObjectScene release in CleanupResources (already released earlier in the same function)