### PR TITLE
bugfix: Fix Gatling Cannon barrels rotating despite insufficient energy

### DIFF
--- a/Generals/Code/GameEngine/Include/GameLogic/FiringTracker.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/FiringTracker.h
@@ -55,6 +55,7 @@ public:
 	void shotFired(const Weapon* weaponFired, ObjectID victimID );			///< Owner just fired this weapon at this Object
 	ObjectID getLastShotVictim() const { return m_victimID; }						///< get the last victim ID that was shot at
 	Int getNumConsecutiveShotsAtVictim( const Object *victim ) const;
+	void forceCoolDown();																						///< Force immediate cooldown, stopping all continuous fire states
 
 	/// this is never disabled, since we want disabled things to continue to slowly "spin down"... (srj)
 	virtual DisabledMaskType getDisabledTypesToProcess() const override { return DISABLEDMASK_ALL; }

--- a/Generals/Code/GameEngine/Include/GameLogic/FiringTracker.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/FiringTracker.h
@@ -57,6 +57,7 @@ public:
 	Int getNumConsecutiveShotsAtVictim( const Object *victim ) const;
 	void forceCoolDown();																						///< Force immediate cooldown, stopping all continuous fire states
 
+#if !RETAIL_COMPATIBLE_CRC
 	/// Exclude power-related disable types so update() doesn't restart barrel animations.
 	/// forceCoolDown() in setDisabledUntil() handles immediate cooldown.
 	virtual DisabledMaskType getDisabledTypesToProcess() const override
@@ -65,6 +66,10 @@ public:
 		mask.clear(MAKE_DISABLED_MASK3(DISABLED_HACKED, DISABLED_EMP, DISABLED_UNDERPOWERED));
 		return mask;
 	}
+#else
+	/// this is never disabled, since we want disabled things to continue to slowly "spin down"... (srj)
+	virtual DisabledMaskType getDisabledTypesToProcess() const { return DISABLEDMASK_ALL; }
+#endif
 
 	virtual UpdateSleepTime update() override;	///< See if spin down is needed because we haven't shot in a while
 

--- a/Generals/Code/GameEngine/Include/GameLogic/FiringTracker.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/FiringTracker.h
@@ -57,8 +57,8 @@ public:
 	Int getNumConsecutiveShotsAtVictim( const Object *victim ) const;
 	void forceCoolDown();																						///< Force immediate cooldown, stopping all continuous fire states
 
-	/// Exclude power-related disable types (UNDERPOWERED, EMP, HACKED) so update() isn't called when disabled.
-	/// This prevents delayed barrel animation restart. forceCoolDown() in Object::setDisabledUntil() handles immediate cooldown.
+	/// Exclude power-related disable types so update() doesn't restart barrel animations.
+	/// forceCoolDown() in setDisabledUntil() handles immediate cooldown.
 	virtual DisabledMaskType getDisabledTypesToProcess() const override
 	{
 		DisabledMaskType mask = DISABLEDMASK_ALL;

--- a/Generals/Code/GameEngine/Include/GameLogic/FiringTracker.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/FiringTracker.h
@@ -57,8 +57,14 @@ public:
 	Int getNumConsecutiveShotsAtVictim( const Object *victim ) const;
 	void forceCoolDown();																						///< Force immediate cooldown, stopping all continuous fire states
 
-	/// this is never disabled, since we want disabled things to continue to slowly "spin down"... (srj)
-	virtual DisabledMaskType getDisabledTypesToProcess() const override { return DISABLEDMASK_ALL; }
+	/// Exclude power-related disable types (UNDERPOWERED, EMP, HACKED) so update() isn't called when disabled.
+	/// This prevents delayed barrel animation restart. forceCoolDown() in Object::setDisabledUntil() handles immediate cooldown.
+	virtual DisabledMaskType getDisabledTypesToProcess() const override
+	{
+		DisabledMaskType mask = DISABLEDMASK_ALL;
+		mask.clear(MAKE_DISABLED_MASK3(DISABLED_HACKED, DISABLED_EMP, DISABLED_UNDERPOWERED));
+		return mask;
+	}
 
 	virtual UpdateSleepTime update() override;	///< See if spin down is needed because we haven't shot in a while
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Object.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Object.h
@@ -554,6 +554,7 @@ public:
 	void setDisabled( DisabledType type );
 	void setDisabledUntil( DisabledType type, UnsignedInt frame );
 	Bool isDisabledByType( DisabledType type ) const { return TEST_DISABLEDMASK( m_disabledMask, type ); }
+	Bool isUnderpoweredForAttack() const; ///< Returns true if powered-type and underpowered
 
 	void pauseAllSpecialPowers( const Bool disabling ) const;
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/FiringTracker.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/FiringTracker.cpp
@@ -283,6 +283,13 @@ void FiringTracker::speedUp()
 }
 
 //-------------------------------------------------------------------------------------------------
+void FiringTracker::forceCoolDown()
+{
+	m_frameToStartCooldown = 0;
+	coolDown();
+}
+
+//-------------------------------------------------------------------------------------------------
 void FiringTracker::coolDown()
 {
 	ModelConditionFlags clr, set;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -4252,7 +4252,15 @@ void Object::adjustModelConditionForWeaponStatus()
 			if (newStatus == READY_TO_FIRE && conditionToSet == WSF_NONE && testStatus( OBJECT_STATUS_IS_ATTACKING ) &&
 					(testStatus( OBJECT_STATUS_IS_AIMING_WEAPON ) || testStatus( OBJECT_STATUS_IS_FIRING_WEAPON )))
 			{
+				// TheSuperHackers @bugfix bobtista 11/11/2025 Don't resume firing animation if underpowered.
+#if !RETAIL_COMPATIBLE_CRC
+				if ( !( isKindOf( KINDOF_POWERED ) && isDisabledByType( DISABLED_UNDERPOWERED ) ) )
+				{
+					conditionToSet = WSF_BETWEEN;
+				}
+#else
 				conditionToSet = WSF_BETWEEN;
+#endif
 			}
 
 		}

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -2014,6 +2014,7 @@ void Object::setDisabledUntil( DisabledType type, UnsignedInt frame )
 
 	}
 
+#if !RETAIL_COMPATIBLE_CRC
 	// TheSuperHackers @bugfix bobtista 21/12/2025 Fix Gatling Cannon barrels rotating despite insufficient energy.
 	// When power is lost (UNDERPOWERED, EMP, HACKED), immediately force FiringTracker cooldown to stop barrel animations.
 	// getDisabledTypesToProcess() prevents update() from restarting animations, and isUnderpoweredForAttack() prevents cursor/attack logic.
@@ -2025,6 +2026,7 @@ void Object::setDisabledUntil( DisabledType type, UnsignedInt frame )
 			m_firingTracker->forceCoolDown();
 		}
 	}
+#endif
 
 	// This will only be called if we were NOT disabled before coming into this function.
 	if (edgeCase) {

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -2004,6 +2004,17 @@ void Object::setDisabledUntil( DisabledType type, UnsignedInt frame )
 
 	}
 
+	// TheSuperHackers @bugfix bobtista 21/12/2025 Force FiringTracker to cool down immediately when power is lost to prevent delayed barrel animations.
+	if (m_firingTracker && (type == DISABLED_UNDERPOWERED || type == DISABLED_EMP || type == DISABLED_HACKED))
+	{
+		if (testWeaponBonusCondition(WEAPONBONUSCONDITION_CONTINUOUS_FIRE_MEAN) || testWeaponBonusCondition(WEAPONBONUSCONDITION_CONTINUOUS_FIRE_FAST))
+		{
+			clearWeaponBonusCondition(WEAPONBONUSCONDITION_CONTINUOUS_FIRE_MEAN);
+			clearWeaponBonusCondition(WEAPONBONUSCONDITION_CONTINUOUS_FIRE_FAST);
+		}
+		m_firingTracker->forceCoolDown();
+	}
+
 	// This will only be called if we were NOT disabled before coming into this function.
 	if (edgeCase) {
 		onDisabledEdge(true);

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -2007,11 +2007,6 @@ void Object::setDisabledUntil( DisabledType type, UnsignedInt frame )
 	// TheSuperHackers @bugfix bobtista 21/12/2025 Force FiringTracker to cool down immediately when power is lost to prevent delayed barrel animations.
 	if (m_firingTracker && (type == DISABLED_UNDERPOWERED || type == DISABLED_EMP || type == DISABLED_HACKED))
 	{
-		if (testWeaponBonusCondition(WEAPONBONUSCONDITION_CONTINUOUS_FIRE_MEAN) || testWeaponBonusCondition(WEAPONBONUSCONDITION_CONTINUOUS_FIRE_FAST))
-		{
-			clearWeaponBonusCondition(WEAPONBONUSCONDITION_CONTINUOUS_FIRE_MEAN);
-			clearWeaponBonusCondition(WEAPONBONUSCONDITION_CONTINUOUS_FIRE_FAST);
-		}
 		m_firingTracker->forceCoolDown();
 	}
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -2923,6 +2923,10 @@ Bool Object::isAbleToAttack() const
 	if( testStatus(OBJECT_STATUS_SOLD) )
 		return false;
 
+	// TheSuperHackers @bugfix bobtista 31/10/2025 Fixes Gatling Cannon barrels rotating despite insufficient energy.
+	if ( isKindOf( KINDOF_POWERED ) && isDisabledByType( DISABLED_UNDERPOWERED ) )
+		return false;
+
 	//We can't fire if we, as a portable structure, are aptly disabled
 	if ( isKindOf( KINDOF_PORTABLE_STRUCTURE ) || isKindOf( KINDOF_SPAWNS_ARE_THE_WEAPONS ))
 	{
@@ -4214,6 +4218,11 @@ void Object::adjustModelConditionForWeaponStatus()
 			// then issue a move command. if we didn't do this here, we might still have a 'firing'
 			// pose, because his weapon might be in 'reloading' mode. since we're not attacking, however,
 			// we really don't care, so we just force the issue here. (This might still need tweaking for the pursue state.)
+			conditionToSet = WSF_NONE;
+		}
+		// TheSuperHackers @bugfix bobtista 11/11/2025 Prevent barrel animation when powered structures are underpowered.
+		else if ( isKindOf( KINDOF_POWERED ) && isDisabledByType( DISABLED_UNDERPOWERED ) )
+		{
 			conditionToSet = WSF_NONE;
 		}
 		else

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -2924,8 +2924,10 @@ Bool Object::isAbleToAttack() const
 		return false;
 
 	// TheSuperHackers @bugfix bobtista 31/10/2025 Fixes Gatling Cannon barrels rotating despite insufficient energy.
+#if !RETAIL_COMPATIBLE_CRC
 	if ( isKindOf( KINDOF_POWERED ) && isDisabledByType( DISABLED_UNDERPOWERED ) )
 		return false;
+#endif
 
 	//We can't fire if we, as a portable structure, are aptly disabled
 	if ( isKindOf( KINDOF_PORTABLE_STRUCTURE ) || isKindOf( KINDOF_SPAWNS_ARE_THE_WEAPONS ))
@@ -4221,10 +4223,12 @@ void Object::adjustModelConditionForWeaponStatus()
 			conditionToSet = WSF_NONE;
 		}
 		// TheSuperHackers @bugfix bobtista 11/11/2025 Prevent barrel animation when powered structures are underpowered.
+#if !RETAIL_COMPATIBLE_CRC
 		else if ( isKindOf( KINDOF_POWERED ) && isDisabledByType( DISABLED_UNDERPOWERED ) )
 		{
 			conditionToSet = WSF_NONE;
 		}
+#endif
 		else
 		{
 			WeaponStatus newStatus = w->getStatus();

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -1558,6 +1558,16 @@ Bool Object::isLogicallyVisible() const
 //=============================================================================
 // Object::isLocallyControlled
 //=============================================================================
+Bool Object::isUnderpoweredForAttack() const
+{
+#if !RETAIL_COMPATIBLE_CRC
+	return isKindOf( KINDOF_POWERED ) && isDisabledByType( DISABLED_UNDERPOWERED );
+#else
+	return false;
+#endif
+}
+
+//-------------------------------------------------------------------------------------------------
 Bool Object::isLocallyControlled() const
 {
 	return getControllingPlayer() == ThePlayerList->getLocalPlayer();
@@ -2004,10 +2014,16 @@ void Object::setDisabledUntil( DisabledType type, UnsignedInt frame )
 
 	}
 
-	// TheSuperHackers @bugfix bobtista 21/12/2025 Force FiringTracker to cool down immediately when power is lost to prevent delayed barrel animations.
-	if (m_firingTracker && (type == DISABLED_UNDERPOWERED || type == DISABLED_EMP || type == DISABLED_HACKED))
+	// TheSuperHackers @bugfix bobtista 21/12/2025 Fix Gatling Cannon barrels rotating despite insufficient energy.
+	// When power is lost (UNDERPOWERED, EMP, HACKED), immediately force FiringTracker cooldown to stop barrel animations.
+	// getDisabledTypesToProcess() prevents update() from restarting animations, and isUnderpoweredForAttack() prevents cursor/attack logic.
+	if (m_firingTracker)
 	{
-		m_firingTracker->forceCoolDown();
+		Bool isPowerDisableType = (type == DISABLED_UNDERPOWERED || type == DISABLED_EMP || type == DISABLED_HACKED);
+		if (isPowerDisableType)
+		{
+			m_firingTracker->forceCoolDown();
+		}
 	}
 
 	// This will only be called if we were NOT disabled before coming into this function.
@@ -2929,9 +2945,8 @@ Bool Object::isAbleToAttack() const
 	if( testStatus(OBJECT_STATUS_SOLD) )
 		return false;
 
-	// TheSuperHackers @bugfix bobtista 31/10/2025 Fixes Gatling Cannon barrels rotating despite insufficient energy.
 #if !RETAIL_COMPATIBLE_CRC
-	if ( isKindOf( KINDOF_POWERED ) && isDisabledByType( DISABLED_UNDERPOWERED ) )
+	if (isUnderpoweredForAttack())
 		return false;
 #endif
 
@@ -4228,9 +4243,8 @@ void Object::adjustModelConditionForWeaponStatus()
 			// we really don't care, so we just force the issue here. (This might still need tweaking for the pursue state.)
 			conditionToSet = WSF_NONE;
 		}
-		// TheSuperHackers @bugfix bobtista 11/11/2025 Prevent barrel animation when powered structures are underpowered.
 #if !RETAIL_COMPATIBLE_CRC
-		else if ( isKindOf( KINDOF_POWERED ) && isDisabledByType( DISABLED_UNDERPOWERED ) )
+		else if (isUnderpoweredForAttack())
 		{
 			conditionToSet = WSF_NONE;
 		}
@@ -4258,9 +4272,8 @@ void Object::adjustModelConditionForWeaponStatus()
 			if (newStatus == READY_TO_FIRE && conditionToSet == WSF_NONE && testStatus( OBJECT_STATUS_IS_ATTACKING ) &&
 					(testStatus( OBJECT_STATUS_IS_AIMING_WEAPON ) || testStatus( OBJECT_STATUS_IS_FIRING_WEAPON )))
 			{
-				// TheSuperHackers @bugfix bobtista 11/11/2025 Don't resume firing animation if underpowered.
 #if !RETAIL_COMPATIBLE_CRC
-				if ( !( isKindOf( KINDOF_POWERED ) && isDisabledByType( DISABLED_UNDERPOWERED ) ) )
+				if (!isUnderpoweredForAttack())
 				{
 					conditionToSet = WSF_BETWEEN;
 				}

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/FiringTracker.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/FiringTracker.h
@@ -55,6 +55,7 @@ public:
 	void shotFired(const Weapon* weaponFired, ObjectID victimID );			///< Owner just fired this weapon at this Object
 	ObjectID getLastShotVictim() const { return m_victimID; }						///< get the last victim ID that was shot at
 	Int getNumConsecutiveShotsAtVictim( const Object *victim ) const;
+	void forceCoolDown();																						///< Force immediate cooldown, stopping all continuous fire states
 
 	/// this is never disabled, since we want disabled things to continue to slowly "spin down"... (srj)
 	virtual DisabledMaskType getDisabledTypesToProcess() const override { return DISABLEDMASK_ALL; }

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/FiringTracker.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/FiringTracker.h
@@ -57,8 +57,8 @@ public:
 	Int getNumConsecutiveShotsAtVictim( const Object *victim ) const;
 	void forceCoolDown();																						///< Force immediate cooldown, stopping all continuous fire states
 
-	/// Exclude power-related disable types (UNDERPOWERED, EMP, HACKED, SUBDUED) so update() isn't called when disabled.
-	/// This prevents delayed barrel animation restart. forceCoolDown() in Object::setDisabledUntil() handles immediate cooldown.
+	/// Exclude power-related disable types so update() doesn't restart barrel animations.
+	/// forceCoolDown() in setDisabledUntil() handles immediate cooldown.
 	virtual DisabledMaskType getDisabledTypesToProcess() const override
 	{
 		DisabledMaskType mask = DISABLEDMASK_ALL;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/FiringTracker.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/FiringTracker.h
@@ -57,8 +57,14 @@ public:
 	Int getNumConsecutiveShotsAtVictim( const Object *victim ) const;
 	void forceCoolDown();																						///< Force immediate cooldown, stopping all continuous fire states
 
-	/// this is never disabled, since we want disabled things to continue to slowly "spin down"... (srj)
-	virtual DisabledMaskType getDisabledTypesToProcess() const override { return DISABLEDMASK_ALL; }
+	/// Exclude power-related disable types (UNDERPOWERED, EMP, HACKED, SUBDUED) so update() isn't called when disabled.
+	/// forceCoolDown() in Object::setDisabledUntil() handles immediate cooldown. Other types allow "spin down".
+	virtual DisabledMaskType getDisabledTypesToProcess() const override
+	{
+		DisabledMaskType mask = DISABLEDMASK_ALL;
+		mask.clear(MAKE_DISABLED_MASK4(DISABLED_HACKED, DISABLED_EMP, DISABLED_UNDERPOWERED, DISABLED_SUBDUED));
+		return mask;
+	}
 
 	virtual UpdateSleepTime update() override;	///< See if spin down is needed because we haven't shot in a while
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/FiringTracker.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/FiringTracker.h
@@ -58,7 +58,7 @@ public:
 	void forceCoolDown();																						///< Force immediate cooldown, stopping all continuous fire states
 
 	/// Exclude power-related disable types (UNDERPOWERED, EMP, HACKED, SUBDUED) so update() isn't called when disabled.
-	/// forceCoolDown() in Object::setDisabledUntil() handles immediate cooldown. Other types allow "spin down".
+	/// This prevents delayed barrel animation restart. forceCoolDown() in Object::setDisabledUntil() handles immediate cooldown.
 	virtual DisabledMaskType getDisabledTypesToProcess() const override
 	{
 		DisabledMaskType mask = DISABLEDMASK_ALL;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/FiringTracker.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/FiringTracker.h
@@ -57,6 +57,7 @@ public:
 	Int getNumConsecutiveShotsAtVictim( const Object *victim ) const;
 	void forceCoolDown();																						///< Force immediate cooldown, stopping all continuous fire states
 
+#if !RETAIL_COMPATIBLE_CRC
 	/// Exclude power-related disable types so update() doesn't restart barrel animations.
 	/// forceCoolDown() in setDisabledUntil() handles immediate cooldown.
 	virtual DisabledMaskType getDisabledTypesToProcess() const override
@@ -65,6 +66,10 @@ public:
 		mask.clear(MAKE_DISABLED_MASK4(DISABLED_HACKED, DISABLED_EMP, DISABLED_UNDERPOWERED, DISABLED_SUBDUED));
 		return mask;
 	}
+#else
+	/// this is never disabled, since we want disabled things to continue to slowly "spin down"... (srj)
+	virtual DisabledMaskType getDisabledTypesToProcess() const { return DISABLEDMASK_ALL; }
+#endif
 
 	virtual UpdateSleepTime update() override;	///< See if spin down is needed because we haven't shot in a while
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
@@ -591,6 +591,7 @@ public:
 	void setDisabled( DisabledType type );
 	void setDisabledUntil( DisabledType type, UnsignedInt frame );
 	Bool isDisabledByType( DisabledType type ) const { return TEST_DISABLEDMASK( m_disabledMask, type ); }
+	Bool isUnderpoweredForAttack() const; ///< Returns true if powered-type and underpowered
 
 	UnsignedInt getDisabledUntil( DisabledType type = DISABLED_ANY ) const;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/FiringTracker.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/FiringTracker.cpp
@@ -302,6 +302,13 @@ void FiringTracker::speedUp()
 }
 
 //-------------------------------------------------------------------------------------------------
+void FiringTracker::forceCoolDown()
+{
+	m_frameToStartCooldown = 0;
+	coolDown();
+}
+
+//-------------------------------------------------------------------------------------------------
 void FiringTracker::coolDown()
 {
 	ModelConditionFlags clr, set;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -3241,6 +3241,10 @@ Bool Object::isAbleToAttack() const
   if ( isDisabledByType( DISABLED_SUBDUED ) )
     return FALSE; // A Microwave Tank is cooking me
 
+	// TheSuperHackers @bugfix bobtista 31/10/2025 Fixes Gatling Cannon barrels rotating despite insufficient energy. (#1700)
+	if ( isKindOf( KINDOF_POWERED ) && isDisabledByType( DISABLED_UNDERPOWERED ) )
+		return false;
+
 	//We can't fire if we, as a portable structure, are aptly disabled
 	if ( isKindOf( KINDOF_PORTABLE_STRUCTURE ) || isKindOf( KINDOF_SPAWNS_ARE_THE_WEAPONS ))
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -2237,7 +2237,6 @@ void Object::setDisabledUntil( DisabledType type, UnsignedInt frame )
 	}
 
 	// TheSuperHackers @bugfix bobtista 21/12/2025 Force FiringTracker to cool down immediately when power is lost to prevent delayed barrel animations.
-	// FiringTracker::getDisabledTypesToProcess() excludes these types, but we still need forceCoolDown() for immediate cooldown.
 	if (m_firingTracker && (type == DISABLED_UNDERPOWERED || type == DISABLED_EMP || type == DISABLED_SUBDUED || type == DISABLED_HACKED))
 	{
 		m_firingTracker->forceCoolDown();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -2236,6 +2236,17 @@ void Object::setDisabledUntil( DisabledType type, UnsignedInt frame )
 
 	}
 
+	// TheSuperHackers @bugfix bobtista 21/12/2025 Force FiringTracker to cool down immediately when power is lost to prevent delayed barrel animations.
+	if (m_firingTracker && (type == DISABLED_UNDERPOWERED || type == DISABLED_EMP || type == DISABLED_SUBDUED || type == DISABLED_HACKED))
+	{
+		if (testWeaponBonusCondition(WEAPONBONUSCONDITION_CONTINUOUS_FIRE_MEAN) || testWeaponBonusCondition(WEAPONBONUSCONDITION_CONTINUOUS_FIRE_FAST))
+		{
+			clearWeaponBonusCondition(WEAPONBONUSCONDITION_CONTINUOUS_FIRE_MEAN);
+			clearWeaponBonusCondition(WEAPONBONUSCONDITION_CONTINUOUS_FIRE_FAST);
+		}
+		m_firingTracker->forceCoolDown();
+	}
+
 	// This will only be called if we were NOT disabled before coming into this function.
 	if (edgeCase) {
 		onDisabledEdge(true);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -2237,6 +2237,7 @@ void Object::setDisabledUntil( DisabledType type, UnsignedInt frame )
 	}
 
 	// TheSuperHackers @bugfix bobtista 21/12/2025 Force FiringTracker to cool down immediately when power is lost to prevent delayed barrel animations.
+	// FiringTracker::getDisabledTypesToProcess() excludes these types, but we still need forceCoolDown() for immediate cooldown.
 	if (m_firingTracker && (type == DISABLED_UNDERPOWERED || type == DISABLED_EMP || type == DISABLED_SUBDUED || type == DISABLED_HACKED))
 	{
 		m_firingTracker->forceCoolDown();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -1724,6 +1724,16 @@ Bool Object::isLogicallyVisible() const
 //=============================================================================
 // Object::isLocallyControlled
 //=============================================================================
+Bool Object::isUnderpoweredForAttack() const
+{
+#if !RETAIL_COMPATIBLE_CRC
+	return isKindOf( KINDOF_POWERED ) && isDisabledByType( DISABLED_UNDERPOWERED );
+#else
+	return false;
+#endif
+}
+
+//-------------------------------------------------------------------------------------------------
 Bool Object::isLocallyControlled() const
 {
 	return getControllingPlayer() == ThePlayerList->getLocalPlayer();
@@ -2236,10 +2246,16 @@ void Object::setDisabledUntil( DisabledType type, UnsignedInt frame )
 
 	}
 
-	// TheSuperHackers @bugfix bobtista 21/12/2025 Force FiringTracker to cool down immediately when power is lost to prevent delayed barrel animations.
-	if (m_firingTracker && (type == DISABLED_UNDERPOWERED || type == DISABLED_EMP || type == DISABLED_SUBDUED || type == DISABLED_HACKED))
+	// TheSuperHackers @bugfix bobtista 21/12/2025 Fix Gatling Cannon barrels rotating despite insufficient energy.
+	// When power is lost (UNDERPOWERED, EMP, SUBDUED, HACKED), immediately force FiringTracker cooldown to stop barrel animations.
+	// getDisabledTypesToProcess() prevents update() from restarting animations, and isUnderpoweredForAttack() prevents cursor/attack logic.
+	if (m_firingTracker)
 	{
-		m_firingTracker->forceCoolDown();
+		Bool isPowerDisableType = (type == DISABLED_UNDERPOWERED || type == DISABLED_EMP || type == DISABLED_SUBDUED || type == DISABLED_HACKED);
+		if (isPowerDisableType)
+		{
+			m_firingTracker->forceCoolDown();
+		}
 	}
 
 	// This will only be called if we were NOT disabled before coming into this function.
@@ -3247,9 +3263,8 @@ Bool Object::isAbleToAttack() const
   if ( isDisabledByType( DISABLED_SUBDUED ) )
     return FALSE; // A Microwave Tank is cooking me
 
-	// TheSuperHackers @bugfix bobtista 31/10/2025 Fixes Gatling Cannon barrels rotating despite insufficient energy.
 #if !RETAIL_COMPATIBLE_CRC
-	if ( isKindOf( KINDOF_POWERED ) && isDisabledByType( DISABLED_UNDERPOWERED ) )
+	if (isUnderpoweredForAttack())
 		return false;
 #endif
 
@@ -4802,9 +4817,8 @@ void Object::adjustModelConditionForWeaponStatus()
 			// we really don't care, so we just force the issue here. (This might still need tweaking for the pursue state.)
 			conditionToSet = WSF_NONE;
 		}
-		// TheSuperHackers @bugfix bobtista 11/11/2025 Prevent barrel animation when powered structures are underpowered.
 #if !RETAIL_COMPATIBLE_CRC
-		else if ( isKindOf( KINDOF_POWERED ) && isDisabledByType( DISABLED_UNDERPOWERED ) )
+		else if (isUnderpoweredForAttack())
 		{
 			conditionToSet = WSF_NONE;
 		}
@@ -4832,9 +4846,8 @@ void Object::adjustModelConditionForWeaponStatus()
 			if (newStatus == READY_TO_FIRE && conditionToSet == WSF_NONE && testStatus( OBJECT_STATUS_IS_ATTACKING ) &&
 					(testStatus( OBJECT_STATUS_IS_AIMING_WEAPON ) || testStatus( OBJECT_STATUS_IS_FIRING_WEAPON )))
 			{
-				// TheSuperHackers @bugfix bobtista 11/11/2025 Don't resume firing animation if underpowered.
 #if !RETAIL_COMPATIBLE_CRC
-				if ( !( isKindOf( KINDOF_POWERED ) && isDisabledByType( DISABLED_UNDERPOWERED ) ) )
+				if (!isUnderpoweredForAttack())
 				{
 					conditionToSet = WSF_BETWEEN;
 				}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -2246,6 +2246,7 @@ void Object::setDisabledUntil( DisabledType type, UnsignedInt frame )
 
 	}
 
+#if !RETAIL_COMPATIBLE_CRC
 	// TheSuperHackers @bugfix bobtista 21/12/2025 Fix Gatling Cannon barrels rotating despite insufficient energy.
 	// When power is lost (UNDERPOWERED, EMP, SUBDUED, HACKED), immediately force FiringTracker cooldown to stop barrel animations.
 	// getDisabledTypesToProcess() prevents update() from restarting animations, and isUnderpoweredForAttack() prevents cursor/attack logic.
@@ -2257,6 +2258,7 @@ void Object::setDisabledUntil( DisabledType type, UnsignedInt frame )
 			m_firingTracker->forceCoolDown();
 		}
 	}
+#endif
 
 	// This will only be called if we were NOT disabled before coming into this function.
 	if (edgeCase) {

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -3241,9 +3241,11 @@ Bool Object::isAbleToAttack() const
   if ( isDisabledByType( DISABLED_SUBDUED ) )
     return FALSE; // A Microwave Tank is cooking me
 
-	// TheSuperHackers @bugfix bobtista 31/10/2025 Fixes Gatling Cannon barrels rotating despite insufficient energy. (#1700)
+	// TheSuperHackers @bugfix bobtista 31/10/2025 Fixes Gatling Cannon barrels rotating despite insufficient energy.
+#if !RETAIL_COMPATIBLE_CRC
 	if ( isKindOf( KINDOF_POWERED ) && isDisabledByType( DISABLED_UNDERPOWERED ) )
 		return false;
+#endif
 
 	//We can't fire if we, as a portable structure, are aptly disabled
 	if ( isKindOf( KINDOF_PORTABLE_STRUCTURE ) || isKindOf( KINDOF_SPAWNS_ARE_THE_WEAPONS ))
@@ -4794,6 +4796,13 @@ void Object::adjustModelConditionForWeaponStatus()
 			// we really don't care, so we just force the issue here. (This might still need tweaking for the pursue state.)
 			conditionToSet = WSF_NONE;
 		}
+		// TheSuperHackers @bugfix bobtista 11/11/2025 Prevent barrel animation when powered structures are underpowered.
+#if !RETAIL_COMPATIBLE_CRC
+		else if ( isKindOf( KINDOF_POWERED ) && isDisabledByType( DISABLED_UNDERPOWERED ) )
+		{
+			conditionToSet = WSF_NONE;
+		}
+#endif
 		else
 		{
 			WeaponStatus newStatus = w->getStatus();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -2239,11 +2239,6 @@ void Object::setDisabledUntil( DisabledType type, UnsignedInt frame )
 	// TheSuperHackers @bugfix bobtista 21/12/2025 Force FiringTracker to cool down immediately when power is lost to prevent delayed barrel animations.
 	if (m_firingTracker && (type == DISABLED_UNDERPOWERED || type == DISABLED_EMP || type == DISABLED_SUBDUED || type == DISABLED_HACKED))
 	{
-		if (testWeaponBonusCondition(WEAPONBONUSCONDITION_CONTINUOUS_FIRE_MEAN) || testWeaponBonusCondition(WEAPONBONUSCONDITION_CONTINUOUS_FIRE_FAST))
-		{
-			clearWeaponBonusCondition(WEAPONBONUSCONDITION_CONTINUOUS_FIRE_MEAN);
-			clearWeaponBonusCondition(WEAPONBONUSCONDITION_CONTINUOUS_FIRE_FAST);
-		}
 		m_firingTracker->forceCoolDown();
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -4826,7 +4826,15 @@ void Object::adjustModelConditionForWeaponStatus()
 			if (newStatus == READY_TO_FIRE && conditionToSet == WSF_NONE && testStatus( OBJECT_STATUS_IS_ATTACKING ) &&
 					(testStatus( OBJECT_STATUS_IS_AIMING_WEAPON ) || testStatus( OBJECT_STATUS_IS_FIRING_WEAPON )))
 			{
+				// TheSuperHackers @bugfix bobtista 11/11/2025 Don't resume firing animation if underpowered.
+#if !RETAIL_COMPATIBLE_CRC
+				if ( !( isKindOf( KINDOF_POWERED ) && isDisabledByType( DISABLED_UNDERPOWERED ) ) )
+				{
+					conditionToSet = WSF_BETWEEN;
+				}
+#else
 				conditionToSet = WSF_BETWEEN;
+#endif
 			}
 
 		}


### PR DESCRIPTION
Addresses issue #1700  

Tested by building a power plant, then a gatling cannon, force firing it, then selling the power plant and trying to force fire.

Result: The gatling cannon can no longer force fire while powered down, the "can't" mouse cursor is displayed, and there is no spinning animation. 