### PR TITLE
refactor(maputil): Remove unused variables in MapUtil

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/MapUtil.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MapUtil.cpp
@@ -216,25 +216,12 @@ static Bool ParseSizeOnlyInChunk(DataChunkInput &file, DataChunkInfo *info, void
 	return ParseSizeOnly(file, info, userData);
 }
 
+// TheSuperHackers @refactor bobtista 31/10/2025 Remove unused variables. Function only uses filename directly.
 static Bool loadMap( AsciiString filename )
 {
-	char	tempBuf[_MAX_PATH];
-	char	filenameBuf[_MAX_PATH];
-	AsciiString asciiFile;
-	int length = 0;
-
-	strcpy(tempBuf, filename.str());
-
-	length = strlen( tempBuf );
-	if( length >= 4 )
-	{
-		strlcpy( filenameBuf, tempBuf, length - 4 + 1);
-	}
-
 	CachedFileInputStream fileStrm;
 
-	asciiFile = filename;
-	if( !fileStrm.open(asciiFile) )
+	if( !fileStrm.open(filename) )
 	{
 		return FALSE;
 	}
@@ -579,18 +566,8 @@ Bool MapCache::loadUserMaps()
 				}
 				else
 				{
+					// TheSuperHackers @refactor bobtista 31/10/2025 Remove unused code block that parsed filename but never used result.
 					if (TheFileSystem->getFileInfo(tempfilename, &fileInfo)) {
-						char funk[_MAX_PATH];
-						strcpy(funk, tempfilename.str());
-						char *filenameptr = funk;
-						char *tempchar = funk;
-						while (*tempchar != 0) {
-							if ((*tempchar == '\\') || (*tempchar == '/')) {
-								filenameptr = tempchar+1;
-							}
-							++tempchar;
-						}
-
 						m_seen[tempfilename] = TRUE;
 						parsedAMap |= addMap(mapDir, *iter, &fileInfo, TheGlobalData->m_buildMapCache);
 					} else {

--- a/Generals/Code/GameEngine/Source/GameClient/MapUtil.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MapUtil.cpp
@@ -81,7 +81,6 @@ static Coord3DList	m_techPositions;
 static Int m_mapDX = 0;
 static Int m_mapDY = 0;
 
-// TheSuperHackers @refactor bobtista 31/10/2025 Remove unused variables and parameter. Function only uses fname directly.
 static UnsignedInt calcCRC( AsciiString fname )
 {
 	CRC theCRC;
@@ -216,7 +215,6 @@ static Bool ParseSizeOnlyInChunk(DataChunkInput &file, DataChunkInfo *info, void
 	return ParseSizeOnly(file, info, userData);
 }
 
-// TheSuperHackers @refactor bobtista 31/10/2025 Remove unused variables. Function only uses filename directly.
 static Bool loadMap( AsciiString filename )
 {
 	CachedFileInputStream fileStrm;
@@ -566,7 +564,6 @@ Bool MapCache::loadUserMaps()
 				}
 				else
 				{
-					// TheSuperHackers @refactor bobtista 31/10/2025 Remove unused code block that parsed filename but never used result.
 					if (TheFileSystem->getFileInfo(tempfilename, &fileInfo)) {
 						m_seen[tempfilename] = TRUE;
 						parsedAMap |= addMap(mapDir, *iter, &fileInfo, TheGlobalData->m_buildMapCache);
@@ -1017,12 +1014,8 @@ Image *getMapPreviewImage( AsciiString mapName )
 	AsciiString tgaName = mapName;
 	AsciiString name;
 	AsciiString tempName;
-	AsciiString filename;
 	tgaName.truncateBy(4); // ".map"
-	name = tgaName;//.reverseFind('\\') + 1;
-	filename = tgaName.reverseFind('\\') + 1;
-	//tgaName = name;
-	filename.concat(".tga");
+	name = tgaName;
 	tgaName.concat(".tga");
 
 	AsciiString portableName = TheGameState->realMapPathToPortableMapPath(name);

--- a/Generals/Code/GameEngine/Source/GameClient/MapUtil.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MapUtil.cpp
@@ -81,26 +81,13 @@ static Coord3DList	m_techPositions;
 static Int m_mapDX = 0;
 static Int m_mapDY = 0;
 
-static UnsignedInt calcCRC( AsciiString dirName, AsciiString fname )
+// TheSuperHackers @refactor bobtista 31/10/2025 Remove unused variables and parameter. Function only uses fname directly.
+static UnsignedInt calcCRC( AsciiString fname )
 {
 	CRC theCRC;
 	theCRC.clear();
 
-	// Try the official map dir
-	AsciiString asciiFile;
-	char	tempBuf[_MAX_PATH];
-	char	filenameBuf[_MAX_PATH];
-	int length = 0;
-	strcpy(tempBuf, fname.str());
-	length = strlen( tempBuf );
-	if( length >= 4 )
-	{
-		strlcpy( filenameBuf, tempBuf, length - 4 + 1);
-	}
-
-	File *fp;
-	asciiFile = fname;
-	fp = TheFileSystem->openFile(asciiFile.str(), File::READ);
+	File *fp = TheFileSystem->openFile(fname.str(), File::READ);
 	if( !fp )
 	{
 		DEBUG_CRASH(("Couldn't open '%s'", fname.str()));
@@ -672,7 +659,7 @@ Bool MapCache::addMap( AsciiString dirName, AsciiString fname, FileInfo *fileInf
 	md.m_timestamp.m_lowTimeStamp = fileInfo->timestampLow;
 	md.m_supplyPositions = m_supplyPositions;
 	md.m_techPositions = m_techPositions;
-	md.m_CRC = calcCRC(dirName, fname);
+	md.m_CRC = calcCRC(fname);
 
 	Bool exists = false;
 	AsciiString munkee = worldDict.getAsciiString(TheKey_mapName, &exists);

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MapUtil.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MapUtil.cpp
@@ -216,25 +216,12 @@ static Bool ParseSizeOnlyInChunk(DataChunkInput &file, DataChunkInfo *info, void
 	return ParseSizeOnly(file, info, userData);
 }
 
+// TheSuperHackers @refactor bobtista 31/10/2025 Remove unused variables. Function only uses filename directly.
 static Bool loadMap( AsciiString filename )
 {
-	char	tempBuf[_MAX_PATH];
-	char	filenameBuf[_MAX_PATH];
-	AsciiString asciiFile;
-	int length = 0;
-
-	strcpy(tempBuf, filename.str());
-
-	length = strlen( tempBuf );
-	if( length >= 4 )
-	{
-		strlcpy( filenameBuf, tempBuf, length - 4 + 1);
-	}
-
 	CachedFileInputStream fileStrm;
 
-	asciiFile = filename;
-	if( !fileStrm.open(asciiFile) )
+	if( !fileStrm.open(filename) )
 	{
 		return FALSE;
 	}
@@ -581,18 +568,8 @@ Bool MapCache::loadUserMaps()
 				}
 				else
 				{
+					// TheSuperHackers @refactor bobtista 31/10/2025 Remove unused code block that parsed filename but never used result.
 					if (TheFileSystem->getFileInfo(tempfilename, &fileInfo)) {
-						char funk[_MAX_PATH];
-						strcpy(funk, tempfilename.str());
-						char *filenameptr = funk;
-						char *tempchar = funk;
-						while (*tempchar != 0) {
-							if ((*tempchar == '\\') || (*tempchar == '/')) {
-								filenameptr = tempchar+1;
-							}
-							++tempchar;
-						}
-
 						m_seen[tempfilename] = TRUE;
 						parsedAMap |= addMap(mapDir, *iter, &fileInfo, TheGlobalData->m_buildMapCache);
 					} else {

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MapUtil.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MapUtil.cpp
@@ -81,26 +81,13 @@ static Coord3DList	m_techPositions;
 static Int m_mapDX = 0;
 static Int m_mapDY = 0;
 
-static UnsignedInt calcCRC( AsciiString dirName, AsciiString fname )
+// TheSuperHackers @refactor bobtista 31/10/2025 Remove unused variables and parameter. Function only uses fname directly.
+static UnsignedInt calcCRC( AsciiString fname )
 {
 	CRC theCRC;
 	theCRC.clear();
 
-	// Try the official map dir
-	AsciiString asciiFile;
-	char	tempBuf[_MAX_PATH];
-	char	filenameBuf[_MAX_PATH];
-	int length = 0;
-	strcpy(tempBuf, fname.str());
-	length = strlen( tempBuf );
-	if( length >= 4 )
-	{
-		strlcpy( filenameBuf, tempBuf, length - 4 + 1);
-	}
-
-	File *fp;
-	asciiFile = fname;
-	fp = TheFileSystem->openFile(asciiFile.str(), File::READ);
+	File *fp = TheFileSystem->openFile(fname.str(), File::READ);
 	if( !fp )
 	{
 		DEBUG_CRASH(("Couldn't open '%s'", fname.str()));
@@ -699,7 +686,7 @@ Bool MapCache::addMap( AsciiString dirName, AsciiString fname, FileInfo *fileInf
 	md.m_timestamp.m_lowTimeStamp = fileInfo->timestampLow;
 	md.m_supplyPositions = m_supplyPositions;
 	md.m_techPositions = m_techPositions;
-	md.m_CRC = calcCRC(dirName, fname);
+	md.m_CRC = calcCRC(fname);
 
 	Bool exists = false;
 	AsciiString munkee = worldDict.getAsciiString(TheKey_mapName, &exists);

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MapUtil.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MapUtil.cpp
@@ -81,7 +81,6 @@ static Coord3DList	m_techPositions;
 static Int m_mapDX = 0;
 static Int m_mapDY = 0;
 
-// TheSuperHackers @refactor bobtista 31/10/2025 Remove unused variables and parameter. Function only uses fname directly.
 static UnsignedInt calcCRC( AsciiString fname )
 {
 	CRC theCRC;
@@ -216,7 +215,6 @@ static Bool ParseSizeOnlyInChunk(DataChunkInput &file, DataChunkInfo *info, void
 	return ParseSizeOnly(file, info, userData);
 }
 
-// TheSuperHackers @refactor bobtista 31/10/2025 Remove unused variables. Function only uses filename directly.
 static Bool loadMap( AsciiString filename )
 {
 	CachedFileInputStream fileStrm;
@@ -568,7 +566,6 @@ Bool MapCache::loadUserMaps()
 				}
 				else
 				{
-					// TheSuperHackers @refactor bobtista 31/10/2025 Remove unused code block that parsed filename but never used result.
 					if (TheFileSystem->getFileInfo(tempfilename, &fileInfo)) {
 						m_seen[tempfilename] = TRUE;
 						parsedAMap |= addMap(mapDir, *iter, &fileInfo, TheGlobalData->m_buildMapCache);
@@ -1097,12 +1094,8 @@ Image *getMapPreviewImage( AsciiString mapName )
 	AsciiString tgaName = mapName;
 	AsciiString name;
 	AsciiString tempName;
-	AsciiString filename;
 	tgaName.truncateBy(4); // ".map"
-	name = tgaName;//.reverseFind('\\') + 1;
-	filename = tgaName.reverseFind('\\') + 1;
-	//tgaName = name;
-	filename.concat(".tga");
+	name = tgaName;
 	tgaName.concat(".tga");
 
 	AsciiString portableName = TheGameState->realMapPathToPortableMapPath(name);


### PR DESCRIPTION
* Relates to #1712

Removes dead code from the `calcCRC` static function in MapUtil.cpp 

The function declared several variables (`dirName` parameter, `asciiFile`, `tempBuf`, `filenameBuf`) that were never used. The function only needs the `fname` parameter to compute the CRC of a map file.

**Changes:**
- Removed unused `dirName` parameter from function signature
- Removed unused local variables: `asciiFile`, `tempBuf`, `filenameBuf`, `length`
- Removed misleading comment suggesting directory handling
- Updated call site to pass only `fname`
- Applied changes to both GeneralsMD and Generals versions
