### PR TITLE
bugfix(aiplayer): Preserve scaffold health when AI building completes

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -121,7 +121,10 @@ void AIPlayer::onStructureProduced( Object *factory, Object *bldg )
 		Dict d;
 		d.setAsciiString(TheKey_objectName, info->getBuildingName());
 		d.setAsciiString(TheKey_objectScriptAttachment, info->getScript());
+#if RETAIL_COMPATIBLE_CRC
 		d.setInt(TheKey_objectInitialHealth, info->getHealth());
+#endif
+		// TheSuperHackers @bugfix bobtista 31/10/2025 Preserve scaffold health when AI building construction completes instead of resetting to initial health. (#1343)
 		d.setBool(TheKey_objectUnsellable, info->getUnsellable());
 
 		info->setUnderConstruction(false);
@@ -458,7 +461,10 @@ Object *AIPlayer::buildStructureNow(const ThingTemplate *bldgPlan, BuildListInfo
 		Dict d;
 		d.setAsciiString(TheKey_objectName, info->getBuildingName());
 		d.setAsciiString(TheKey_objectScriptAttachment, info->getScript());
+#if RETAIL_COMPATIBLE_CRC
 		d.setInt(TheKey_objectInitialHealth, info->getHealth());
+#endif
+		// TheSuperHackers @bugfix bobtista 31/10/2025 Preserve scaffold health when AI building construction completes instead of resetting to initial health. (#1343)
 		d.setBool(TheKey_objectUnsellable, info->getUnsellable());
 
 		bldg->updateObjValuesFromMapProperties(&d);

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -121,10 +121,10 @@ void AIPlayer::onStructureProduced( Object *factory, Object *bldg )
 		Dict d;
 		d.setAsciiString(TheKey_objectName, info->getBuildingName());
 		d.setAsciiString(TheKey_objectScriptAttachment, info->getScript());
+		// TheSuperHackers @bugfix bobtista 31/10/2025 Preserve scaffold health when AI building construction completes instead of resetting to initial health.
 #if RETAIL_COMPATIBLE_CRC
 		d.setInt(TheKey_objectInitialHealth, info->getHealth());
 #endif
-		// TheSuperHackers @bugfix bobtista 31/10/2025 Preserve scaffold health when AI building construction completes instead of resetting to initial health. (#1343)
 		d.setBool(TheKey_objectUnsellable, info->getUnsellable());
 
 		info->setUnderConstruction(false);
@@ -461,10 +461,10 @@ Object *AIPlayer::buildStructureNow(const ThingTemplate *bldgPlan, BuildListInfo
 		Dict d;
 		d.setAsciiString(TheKey_objectName, info->getBuildingName());
 		d.setAsciiString(TheKey_objectScriptAttachment, info->getScript());
+		// TheSuperHackers @bugfix bobtista 31/10/2025 Preserve scaffold health when AI building construction completes instead of resetting to initial health.
 #if RETAIL_COMPATIBLE_CRC
 		d.setInt(TheKey_objectInitialHealth, info->getHealth());
 #endif
-		// TheSuperHackers @bugfix bobtista 31/10/2025 Preserve scaffold health when AI building construction completes instead of resetting to initial health. (#1343)
 		d.setBool(TheKey_objectUnsellable, info->getUnsellable());
 
 		bldg->updateObjValuesFromMapProperties(&d);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -122,10 +122,10 @@ void AIPlayer::onStructureProduced( Object *factory, Object *bldg )
 		Dict d;
 		d.setAsciiString(TheKey_objectName, info->getBuildingName());
 		d.setAsciiString(TheKey_objectScriptAttachment, info->getScript());
+		// TheSuperHackers @bugfix bobtista 31/10/2025 Preserve scaffold health when AI building construction completes instead of resetting to initial health.
 #if RETAIL_COMPATIBLE_CRC
 		d.setInt(TheKey_objectInitialHealth, info->getHealth());
 #endif
-		// TheSuperHackers @bugfix bobtista 31/10/2025 Preserve scaffold health when AI building construction completes instead of resetting to initial health. (#1343)
 		d.setBool(TheKey_objectUnsellable, info->getUnsellable());
 
 		info->setUnderConstruction(false);
@@ -465,10 +465,10 @@ Object *AIPlayer::buildStructureNow(const ThingTemplate *bldgPlan, BuildListInfo
 		Dict d;
 		d.setAsciiString(TheKey_objectName, info->getBuildingName());
 		d.setAsciiString(TheKey_objectScriptAttachment, info->getScript());
+		// TheSuperHackers @bugfix bobtista 31/10/2025 Preserve scaffold health when AI building construction completes instead of resetting to initial health.
 #if RETAIL_COMPATIBLE_CRC
 		d.setInt(TheKey_objectInitialHealth, info->getHealth());
 #endif
-		// TheSuperHackers @bugfix bobtista 31/10/2025 Preserve scaffold health when AI building construction completes instead of resetting to initial health. (#1343)
 		d.setBool(TheKey_objectUnsellable, info->getUnsellable());
 
 		bldg->updateObjValuesFromMapProperties(&d);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -122,7 +122,10 @@ void AIPlayer::onStructureProduced( Object *factory, Object *bldg )
 		Dict d;
 		d.setAsciiString(TheKey_objectName, info->getBuildingName());
 		d.setAsciiString(TheKey_objectScriptAttachment, info->getScript());
+#if RETAIL_COMPATIBLE_CRC
 		d.setInt(TheKey_objectInitialHealth, info->getHealth());
+#endif
+		// TheSuperHackers @bugfix bobtista 31/10/2025 Preserve scaffold health when AI building construction completes instead of resetting to initial health. (#1343)
 		d.setBool(TheKey_objectUnsellable, info->getUnsellable());
 
 		info->setUnderConstruction(false);
@@ -462,7 +465,10 @@ Object *AIPlayer::buildStructureNow(const ThingTemplate *bldgPlan, BuildListInfo
 		Dict d;
 		d.setAsciiString(TheKey_objectName, info->getBuildingName());
 		d.setAsciiString(TheKey_objectScriptAttachment, info->getScript());
+#if RETAIL_COMPATIBLE_CRC
 		d.setInt(TheKey_objectInitialHealth, info->getHealth());
+#endif
+		// TheSuperHackers @bugfix bobtista 31/10/2025 Preserve scaffold health when AI building construction completes instead of resetting to initial health. (#1343)
 		d.setBool(TheKey_objectUnsellable, info->getUnsellable());
 
 		bldg->updateObjValuesFromMapProperties(&d);


### PR DESCRIPTION
Addresses issue #1343

When AI buildings finished construction, they were incorrectly restored to their `BuildListInfo` initial health value (default 100%, can be set in WorldBuilder)

The `BuildListInfo::m_health` field is still used for its intended purpose: setting initial health on pre-placed buildings. It just no longer incorrectly applies to buildings under construction.

Note: This change causes mismatches with retail, so it's behind flags. 

Tested: The fix works (with RETAIL_COMPATIBILE_CRC and RETAIL_COMPATIBLE_BUG flags set)