### PR TITLE
bugfix(ai): fix crash when AI fires China Nuclear Missile while another is under construction

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
@@ -2620,6 +2620,12 @@ void AIGroup::groupDoSpecialPower( UnsignedInt specialPowerID, UnsignedInt comma
 		//Special powers do a lot of different things, but the top level stuff doesn't use
 		//ai interface code. It finds the special power module and calls it directly for each object.
 		Object *object = (*i);
+#if !RETAIL_COMPATIBLE_AIGROUP
+		// TheSuperHackers @bugfix bobtista 01/11/2025 Prevents AI from trying to fire special powers from buildings under construction.
+		if (object->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION)) {
+			continue;
+		}
+#endif
 		const SpecialPowerTemplate *spTemplate = TheSpecialPowerStore->findSpecialPowerTemplateByID( specialPowerID );
 		if( spTemplate )
 		{
@@ -2659,6 +2665,12 @@ void AIGroup::groupDoSpecialPowerAtLocation( UnsignedInt specialPowerID, const C
 		//ai interface code. It finds the special power module and calls it directly for each object.
 
 		Object *object = (*i);
+#if !RETAIL_COMPATIBLE_AIGROUP
+		// TheSuperHackers @bugfix bobtista 01/11/2025 Prevents AI from trying to fire special powers from buildings under construction.
+		if (object->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION)) {
+			continue;
+		}
+#endif
 		const SpecialPowerTemplate *spTemplate = TheSpecialPowerStore->findSpecialPowerTemplateByID( specialPowerID );
 		if( spTemplate )
 		{
@@ -2698,6 +2710,12 @@ void AIGroup::groupDoSpecialPowerAtObject( UnsignedInt specialPowerID, Object *t
 		//ai interface code. It finds the special power module and calls it directly for each object.
 
 		Object *object = (*i);
+#if !RETAIL_COMPATIBLE_AIGROUP
+		// TheSuperHackers @bugfix bobtista 01/11/2025 Prevents AI from trying to fire special powers from buildings under construction.
+		if (object->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION)) {
+			continue;
+		}
+#endif
 		const SpecialPowerTemplate *spTemplate = TheSpecialPowerStore->findSpecialPowerTemplateByID( specialPowerID );
 		if( spTemplate )
 		{

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/SpecialPower/SpecialPowerModule.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/SpecialPower/SpecialPowerModule.cpp
@@ -406,6 +406,16 @@ Bool SpecialPowerModule::initiateIntentToDoSpecialPower( const Object *targetObj
 		}
 	}
 
+	// TheSuperHackers @bugfix bobtista 01/11/2025 Prevents AI from consuming special power timer when MissileLauncherBuildingUpdate is not ready.
+#if RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @info we need to leave early if we are in the MissileLauncherBuildingUpdate crash fix codepath
+	if (m_availableOnFrame == 0xFFFFFFFF)
+	{
+		DEBUG_ASSERTCRASH(!valid, ("Using MissileLauncherBuildingUpdate escape path when valid is set to true"));
+		return false;
+	}
+#endif
+
 	//If we depend on our update module to trigger the special power, make sure we have the
 	//appropriate update module!
 	if( !valid && getSpecialPowerModuleData()->m_updateModuleStartsAttack )

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/MissileLauncherBuildingUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/MissileLauncherBuildingUpdate.cpp
@@ -200,6 +200,20 @@ void MissileLauncherBuildingUpdate::switchToState(DoorStateType dst)
 //-------------------------------------------------------------------------------------------------
 Bool MissileLauncherBuildingUpdate::initiateIntentToDoSpecialPower( const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions )
 {
+	// TheSuperHackers @bugfix bobtista 01/11/2025 Prevents crash when AI fires China Nuclear Missile while another is under construction.
+	if (!m_specialPowerModule) {
+#if RETAIL_COMPATIBLE_CRC
+		Object* us = getObject();
+		us->getSpecialPowerModule(specialPowerTemplate)->setReadyFrame(0xFFFFFFFF);
+#endif
+		return FALSE;
+	}
+
+	if( m_specialPowerModule->getSpecialPowerTemplate() != specialPowerTemplate )
+	{
+		return FALSE;
+	}
+
 #if defined(RTS_DEBUG)
 	DEBUG_ASSERTCRASH(!TheGlobalData->m_specialPowerUsesDelay || m_doorState == DOOR_OPEN, ("door is not fully open when specialpower is fired!"));
 #endif

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
@@ -2683,6 +2683,12 @@ void AIGroup::groupDoSpecialPower( UnsignedInt specialPowerID, UnsignedInt comma
 		//Special powers do a lot of different things, but the top level stuff doesn't use
 		//ai interface code. It finds the special power module and calls it directly for each object.
 		Object *object = (*i);
+#if !RETAIL_COMPATIBLE_AIGROUP
+		// TheSuperHackers @bugfix bobtista 01/11/2025 Prevents AI from trying to fire special powers from buildings under construction.
+		if (object->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION)) {
+			continue;
+		}
+#endif
 		const SpecialPowerTemplate *spTemplate = TheSpecialPowerStore->findSpecialPowerTemplateByID( specialPowerID );
 		if( spTemplate )
 		{
@@ -2731,6 +2737,13 @@ void AIGroup::groupDoSpecialPowerAtLocation( UnsignedInt specialPowerID, const C
          // destroys the AIGroup list, in order to keep the selection sync'ed with the group.
          // M Lorenzen... 8/23/03
 
+#if !RETAIL_COMPATIBLE_AIGROUP
+		// TheSuperHackers @bugfix bobtista 01/11/2025 Prevents AI from trying to fire special powers from buildings under construction.
+		if (object->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION)) {
+			continue;
+		}
+#endif
+
     const SpecialPowerTemplate *spTemplate = TheSpecialPowerStore->findSpecialPowerTemplateByID( specialPowerID );
 		if( spTemplate )
 		{
@@ -2771,6 +2784,12 @@ void AIGroup::groupDoSpecialPowerAtObject( UnsignedInt specialPowerID, Object *t
 		//ai interface code. It finds the special power module and calls it directly for each object.
 
 		Object *object = (*i);
+#if !RETAIL_COMPATIBLE_AIGROUP
+		// TheSuperHackers @bugfix bobtista 01/11/2025 Prevents AI from trying to fire special powers from buildings under construction.
+		if (object->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION)) {
+			continue;
+		}
+#endif
 		const SpecialPowerTemplate *spTemplate = TheSpecialPowerStore->findSpecialPowerTemplateByID( specialPowerID );
 		if( spTemplate )
 		{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/MissileLauncherBuildingUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/MissileLauncherBuildingUpdate.cpp
@@ -201,14 +201,15 @@ void MissileLauncherBuildingUpdate::switchToState(DoorStateType dst)
 //-------------------------------------------------------------------------------------------------
 Bool MissileLauncherBuildingUpdate::initiateIntentToDoSpecialPower( const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions )
 {
-#if RETAIL_COMPATIBLE_CRC
 	// TheSuperHackers @bugfix Mauller 29/06/2025 prevent a game crash when told to launch before ready to do so
+	// TheSuperHackers @bugfix bobtista 01/11/2025 Prevents crash when AI fires China Nuclear Missile while another is under construction.
 	if (!m_specialPowerModule) {
+#if RETAIL_COMPATIBLE_CRC
 		Object* us = getObject();
 		us->getSpecialPowerModule(specialPowerTemplate)->setReadyFrame(0xFFFFFFFF);
+#endif
 		return FALSE;
 	}
-#endif
 
 	if( m_specialPowerModule->getSpecialPowerTemplate() != specialPowerTemplate )
 	{


### PR DESCRIPTION
Addresses Issue #1664 

The behavior differs between versions:
Generals: Causes visual bugs (missile launches from scaffold) but does not crash
Zero Hour (GeneralsMD): Crashes with a NULL pointer dereference

Root Cause Theory:
For Nuclear Missiles with `MissileLauncherBuildingUpdate`, this causes issues because:
1. Buildings under construction never initialize their `m_specialPowerModule` pointer
2. The pointer is only initialized in `update()`, which exits early for `OBJECT_STATUS_UNDER_CONSTRUCTION`
3. When the AI tries to fire from the under-construction building, it accesses the NULL pointer → crash (Zero Hour) or visual bugs (Generals)

**Mauller's fix (#1218):** Prevents exploit where special power timers initialize to 0  
**This fix (#1664):** Prevents AI from firing special powers from buildings under construction

Proposed Fix:
Prevention (AIGroup): Skip buildings under construction when firing special powers. Guarded by !RETAIL_COMPATIBLE_AIGROUP flag

Protection (MissileLauncherBuildingUpdate): Add NULL check to return early if the module isn't initialized. Always active in all builds.


Note: Not yet tested. Also, added Mauller's fix to Generals
