### PR TITLE
tweak(gui): Track money per minute for every player

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -684,6 +684,8 @@ void Player::update()
 	if (tunnelSystem)
 		tunnelSystem->healObjects();
 #endif
+
+	m_money.updateIncomeBucket();
 }
 
 //=============================================================================

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -1898,7 +1898,6 @@ void InGameUI::update( void )
 		else
 		{
 			// TheSuperHackers @feature L3-M 21/08/2025 player money per minute
-			money->updateIncomeBucket();
 			UnsignedInt currentMoney = money->countMoney();
 			UnsignedInt cashPerMin = money->getCashPerMinute();
 			if ( lastMoney != currentMoney || lastIncome != cashPerMin )

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -724,6 +724,8 @@ void Player::update()
 	if (tunnelSystem)
 		tunnelSystem->healObjects();
 #endif
+
+	m_money.updateIncomeBucket();
 }
 
 //=============================================================================

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -1954,7 +1954,6 @@ void InGameUI::update( void )
 		else
 		{
 			// TheSuperHackers @feature L3-M 21/08/2025 player money per minute
-			money->updateIncomeBucket();
 			UnsignedInt currentMoney = money->countMoney();
 			UnsignedInt cashPerMin = money->getCashPerMinute();
 			if ( lastMoney != currentMoney || lastIncome != cashPerMin )


### PR DESCRIPTION
- Follow up for: #1481

This change updates money per minute for every player correctly in Generals and Zero Hour.
Previously it only started tracking after selecting a player.

For example:


https://github.com/user-attachments/assets/514e1105-9f20-4157-a503-b4d6eb014893

