### PR TITLE
bugfix(aiupdate): Chinooks and Helixes no longer take off after repair if passengers want to board or exit

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
@@ -1009,7 +1009,7 @@ UpdateSleepTime ChinookAIUpdate::update()
 	{
 		if (m_flightStatus == CHINOOK_LANDED &&
 #if !RETAIL_COMPATIBLE_CRC
-			!waitingToEnterOrExit &&
+				!waitingToEnterOrExit &&
 #endif
 				!m_hasPendingCommand &&
 				getObject()->getBodyModule()->getHealth() == getObject()->getBodyModule()->getMaxHealth())

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
@@ -1002,9 +1002,15 @@ Bool ChinookAIUpdate::chooseLocomotorSet(LocomotorSetType wst)
 UpdateSleepTime ChinookAIUpdate::update()
 {
 	ParkingPlaceBehaviorInterface* pp = getPP(m_airfieldForHealing);
+	ContainModuleInterface* contain = getObject()->getContain();
+	Bool waitingToEnterOrExit = contain && contain->hasObjectsWantingToEnterOrExit();
+
 	if (pp != NULL)
 	{
 		if (m_flightStatus == CHINOOK_LANDED &&
+#if !RETAIL_COMPATIBLE_CRC
+			!waitingToEnterOrExit &&
+#endif
 				!m_hasPendingCommand &&
 				getObject()->getBodyModule()->getHealth() == getObject()->getBodyModule()->getMaxHealth())
 		{
@@ -1026,10 +1032,8 @@ UpdateSleepTime ChinookAIUpdate::update()
 	// when we have a pending command...
 	if (SupplyTruckAIUpdate::isIdle())
 	{
-		ContainModuleInterface* contain = getObject()->getContain();
 		if( contain )
 		{
-			Bool waitingToEnterOrExit = contain->hasObjectsWantingToEnterOrExit();
 			if (m_hasPendingCommand)
 			{
 				AICommandParms parms(AICMD_MOVE_TO_POSITION, CMD_FROM_AI);	// values don't matter, will be wiped by next line

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
@@ -1009,6 +1009,7 @@ UpdateSleepTime ChinookAIUpdate::update()
 	{
 		if (m_flightStatus == CHINOOK_LANDED &&
 #if !RETAIL_COMPATIBLE_CRC
+				// TheSuperHackers @bugfix Stubbjax 03/11/2025 Prevent Chinooks from taking off while there are still units wanting to enter or exit.
 				!waitingToEnterOrExit &&
 #endif
 				!m_hasPendingCommand &&

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
@@ -1002,8 +1002,8 @@ Bool ChinookAIUpdate::chooseLocomotorSet(LocomotorSetType wst)
 UpdateSleepTime ChinookAIUpdate::update()
 {
 	ParkingPlaceBehaviorInterface* pp = getPP(m_airfieldForHealing);
-	ContainModuleInterface* contain = getObject()->getContain();
-	Bool waitingToEnterOrExit = contain && contain->hasObjectsWantingToEnterOrExit();
+	const ContainModuleInterface* contain = getObject()->getContain();
+	const Bool waitingToEnterOrExit = contain && contain->hasObjectsWantingToEnterOrExit();
 
 	if (pp != NULL)
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
@@ -1071,6 +1071,7 @@ UpdateSleepTime ChinookAIUpdate::update()
 	{
 		if (m_flightStatus == CHINOOK_LANDED &&
 #if !RETAIL_COMPATIBLE_CRC
+				// TheSuperHackers @bugfix Stubbjax 03/11/2025 Prevent Chinooks from taking off while there are still units wanting to enter or exit.
 				!waitingToEnterOrExit &&
 #endif
 				!m_hasPendingCommand &&

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
@@ -1064,8 +1064,8 @@ Bool ChinookAIUpdate::chooseLocomotorSet(LocomotorSetType wst)
 UpdateSleepTime ChinookAIUpdate::update()
 {
 	ParkingPlaceBehaviorInterface* pp = getPP(m_airfieldForHealing);
-	ContainModuleInterface* contain = getObject()->getContain();
-	Bool waitingToEnterOrExit = contain && contain->hasObjectsWantingToEnterOrExit();
+	const ContainModuleInterface* contain = getObject()->getContain();
+	const Bool waitingToEnterOrExit = contain && contain->hasObjectsWantingToEnterOrExit();
 
 	if (pp != NULL)
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
@@ -1071,7 +1071,7 @@ UpdateSleepTime ChinookAIUpdate::update()
 	{
 		if (m_flightStatus == CHINOOK_LANDED &&
 #if !RETAIL_COMPATIBLE_CRC
-			!waitingToEnterOrExit &&
+				!waitingToEnterOrExit &&
 #endif
 				!m_hasPendingCommand &&
 				getObject()->getBodyModule()->getHealth() == getObject()->getBodyModule()->getMaxHealth())

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
@@ -1064,9 +1064,15 @@ Bool ChinookAIUpdate::chooseLocomotorSet(LocomotorSetType wst)
 UpdateSleepTime ChinookAIUpdate::update()
 {
 	ParkingPlaceBehaviorInterface* pp = getPP(m_airfieldForHealing);
+	ContainModuleInterface* contain = getObject()->getContain();
+	Bool waitingToEnterOrExit = contain && contain->hasObjectsWantingToEnterOrExit();
+
 	if (pp != NULL)
 	{
 		if (m_flightStatus == CHINOOK_LANDED &&
+#if !RETAIL_COMPATIBLE_CRC
+			!waitingToEnterOrExit &&
+#endif
 				!m_hasPendingCommand &&
 				getObject()->getBodyModule()->getHealth() == getObject()->getBodyModule()->getMaxHealth())
 		{
@@ -1088,12 +1094,10 @@ UpdateSleepTime ChinookAIUpdate::update()
 
 	// have to call our parent's isIdle, because we override it to never return true
 	// when we have a pending command...
-	ContainModuleInterface* contain = getObject()->getContain();
 	if( contain )
 	{
 	  if (SupplyTruckAIUpdate::isIdle())
 		{
-			Bool waitingToEnterOrExit = contain->hasObjectsWantingToEnterOrExit();
 			if (m_hasPendingCommand)
 			{
 				AICommandParms parms(AICMD_MOVE_TO_POSITION, CMD_FROM_AI);	// values don't matter, will be wiped by next line


### PR DESCRIPTION
This change prevents repairing Chinooks and Helixes from taking off after repairing completes when there are passengers waiting to board or exit.

### Before

The Chinook takes off after healing completes even though passengers intend to board

https://github.com/user-attachments/assets/419e01d7-2fbf-4bd1-a2d0-482493cc77a0

### After

The Chinook stays landed after healing completes as passengers intend to board

https://github.com/user-attachments/assets/580be87a-fd7c-4dd2-b67f-b3c1e6e16ba4