### PR TITLE
bugfix(gui): Fix crash when RenderFpsFontSize is set to 0

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5759,7 +5759,6 @@ void InGameUI::refreshRenderFpsResources(void)
 		m_renderFpsString = TheDisplayStringManager->newDisplayString();
 		m_lastRenderFps = ~0u;
 		m_lastRenderFpsUpdateMs = 0u;
-		updateRenderFpsString();
 	}
 
 	if (!m_renderFpsLimitString)
@@ -5773,6 +5772,11 @@ void InGameUI::refreshRenderFpsResources(void)
 	GameFont *fpsFont = TheWindowManager->winFindFont(m_renderFpsFont, adjustedRenderFpsFontSize, m_renderFpsBold);
 	m_renderFpsString->setFont(fpsFont);
 	m_renderFpsLimitString->setFont(fpsFont);
+
+	if (m_renderFpsPointSize > 0)
+	{
+		updateRenderFpsString();
+	}
 }
 
 void InGameUI::refreshSystemTimeResources(void)

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5932,7 +5932,6 @@ void InGameUI::refreshRenderFpsResources(void)
 		m_renderFpsString = TheDisplayStringManager->newDisplayString();
 		m_lastRenderFps = ~0u;
 		m_lastRenderFpsUpdateMs = 0u;
-		updateRenderFpsString();
 	}
 
 	if (!m_renderFpsLimitString)
@@ -5946,6 +5945,11 @@ void InGameUI::refreshRenderFpsResources(void)
 	GameFont *fpsFont = TheWindowManager->winFindFont(m_renderFpsFont, adjustedRenderFpsFontSize, m_renderFpsBold);
 	m_renderFpsString->setFont(fpsFont);
 	m_renderFpsLimitString->setFont(fpsFont);
+
+	if (m_renderFpsPointSize > 0)
+	{
+		updateRenderFpsString();
+	}
 }
 
 void InGameUI::refreshSystemTimeResources(void)


### PR DESCRIPTION
* Follow up for #1546 

This change fixes a crash when `RenderFpsFontSize = 0` in Generals and Zero Hour. 
