### PR TITLE
bugfix(aiupdate): Prevent manually ejecting rappelling Rangers during Chinook Combat Drop

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
@@ -587,11 +587,7 @@ public:
 				Object* rappeller = getPotentialRappeller(obj);
 				if (rappeller != NULL)
 				{
-#if !RETAIL_COMPATIBLE_CRC
-					// ChinookAIUpdate::getAiFreeToExit is dependent on this status.
-					rappeller->setStatus(MAKE_OBJECT_STATUS_MASK(OBJECT_STATUS_IS_USING_ABILITY));
-#endif
-
+#if RETAIL_COMPATIBLE_CRC
 					ExitInterface *exitInterface = obj->getObjectExitInterface();
 					ExitDoorType exitDoor = exitInterface ? exitInterface->reserveDoorForExit(rappeller->getTemplate(), rappeller) : DOOR_NONE_AVAILABLE;
 					if(exitDoor != DOOR_NONE_AVAILABLE)
@@ -602,10 +598,16 @@ public:
 					{
 						DEBUG_CRASH(("rappeller is not free to exit... what?"));
 					}
-
-#if !RETAIL_COMPATIBLE_CRC
-					rappeller->clearStatus(MAKE_OBJECT_STATUS_MASK(OBJECT_STATUS_IS_USING_ABILITY));
+#else
+					// TheSuperHackers @bugfix 03/01/2026 Bypass door reservation as rappellers are always
+					// expected to be free to exit. This avoids prior rappel conditions in getAiFreeToExit
+					// from allowing rappellers to be freely 'dropped' from the Chinook during this state.
+					if (ExitInterface* exitInterface = obj->getObjectExitInterface())
+					{
+						exitInterface->exitObjectViaDoor(rappeller, DOOR_1);
+					}
 #endif
+
 					rappeller->setTransformMatrix(&it->dropStartMtx);
 
 					AIUpdateInterface* rappellerAI = rappeller ? rappeller->getAIUpdateInterface() : NULL;
@@ -991,17 +993,12 @@ ObjectID ChinookAIUpdate::getBuildingToNotPathAround() const
 //-------------------------------------------------------------------------------------------------
 AIFreeToExitType ChinookAIUpdate::getAiFreeToExit(const Object* exiter) const
 {
-	if (m_flightStatus == CHINOOK_DOING_COMBAT_DROP && exiter->isKindOf(KINDOF_CAN_RAPPEL))
-	{
-#if !RETAIL_COMPATIBLE_CRC
-		if (!exiter->testStatus(OBJECT_STATUS_IS_USING_ABILITY))
-			return WAIT_TO_EXIT;
-#endif
-
-		return FREE_TO_EXIT;
-	}
-
+#if RETAIL_COMPATIBLE_CRC
+	 if (m_flightStatus == CHINOOK_LANDED
+				|| (m_flightStatus == CHINOOK_DOING_COMBAT_DROP && exiter->isKindOf(KINDOF_CAN_RAPPEL)))
+#else
 	if (m_flightStatus == CHINOOK_LANDED)
+#endif
 		return FREE_TO_EXIT;
 
 	return WAIT_TO_EXIT;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
@@ -588,11 +588,7 @@ public:
 				Object* rappeller = getPotentialRappeller(obj);
 				if (rappeller != NULL)
 				{
-#if !RETAIL_COMPATIBLE_CRC
-					// ChinookAIUpdate::getAiFreeToExit is dependent on this status.
-					rappeller->setStatus(MAKE_OBJECT_STATUS_MASK(OBJECT_STATUS_IS_USING_ABILITY));
-#endif
-
+#if RETAIL_COMPATIBLE_CRC
 					ExitInterface *exitInterface = obj->getObjectExitInterface();
 					ExitDoorType exitDoor = exitInterface ? exitInterface->reserveDoorForExit(rappeller->getTemplate(), rappeller) : DOOR_NONE_AVAILABLE;
 					if(exitDoor != DOOR_NONE_AVAILABLE)
@@ -603,10 +599,16 @@ public:
 					{
 						DEBUG_CRASH(("rappeller is not free to exit... what?"));
 					}
-
-#if !RETAIL_COMPATIBLE_CRC
-					rappeller->clearStatus(MAKE_OBJECT_STATUS_MASK(OBJECT_STATUS_IS_USING_ABILITY));
+#else
+					// TheSuperHackers @bugfix 03/01/2026 Bypass door reservation as rappellers are always
+					// expected to be free to exit. This avoids prior rappel conditions in getAiFreeToExit
+					// from allowing rappellers to be freely 'dropped' from the Chinook during this state.
+					if (ExitInterface* exitInterface = obj->getObjectExitInterface())
+					{
+						exitInterface->exitObjectViaDoor(rappeller, DOOR_1);
+					}
 #endif
+
 					rappeller->setTransformMatrix(&it->dropStartMtx);
 
 					AIUpdateInterface* rappellerAI = rappeller ? rappeller->getAIUpdateInterface() : NULL;
@@ -1053,17 +1055,12 @@ ObjectID ChinookAIUpdate::getBuildingToNotPathAround() const
 //-------------------------------------------------------------------------------------------------
 AIFreeToExitType ChinookAIUpdate::getAiFreeToExit(const Object* exiter) const
 {
-	if (m_flightStatus == CHINOOK_DOING_COMBAT_DROP && exiter->isKindOf(KINDOF_CAN_RAPPEL))
-	{
-#if !RETAIL_COMPATIBLE_CRC
-		if (!exiter->testStatus(OBJECT_STATUS_IS_USING_ABILITY))
-			return WAIT_TO_EXIT;
-#endif
-
-		return FREE_TO_EXIT;
-	}
-
+#if RETAIL_COMPATIBLE_CRC
+	 if (m_flightStatus == CHINOOK_LANDED
+				|| (m_flightStatus == CHINOOK_DOING_COMBAT_DROP && exiter->isKindOf(KINDOF_CAN_RAPPEL)))
+#else
 	if (m_flightStatus == CHINOOK_LANDED)
+#endif
 		return FREE_TO_EXIT;
 
 	return WAIT_TO_EXIT;


### PR DESCRIPTION
- Fixes #39

This change prevents rappelling units from being manually ejected during combat drops.

### Before

Clicking a passenger's icon in the command bar during a combat drop will eject that unit in the air

https://github.com/user-attachments/assets/4bd78bd3-871c-432d-962c-bb318acf7bd0

### After

Clicking a passenger's icon in the command bar during a combat drop will do nothing

https://github.com/user-attachments/assets/31072e53-2cf2-49ee-9ccc-4ea0423a1655