### PR TITLE
fix(debug): Replace NDEBUG preprocessor with RTS_DEBUG or RTS_RELEASE

### DIFF
--- a/Core/Libraries/Source/WWVegas/WW3D2/coltest.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/coltest.cpp
@@ -99,7 +99,7 @@ bool AABoxCollisionTestClass::Cull(const AABoxClass & box)
 void AABoxCollisionTestClass::Rotate(ROTATION_TYPE rotation)
 {
 
-#ifndef NDEBUG
+#ifdef RTS_DEBUG
 
 	int i;
 	Matrix3D tm(1);
@@ -156,9 +156,7 @@ void AABoxCollisionTestClass::Rotate(ROTATION_TYPE rotation)
 		if (realmax.Z <= pts[i].Z) realmax.Z = pts[i].Z;
 	}
 
-
-#endif
-
+#endif // RTS_DEBUG
 
 	// rotate the test by the desired rotation about the Z axis, special cased for
 	// 90 degree rotations about Z.  arbitrary rotations cause the axis aligned
@@ -216,13 +214,13 @@ void AABoxCollisionTestClass::Rotate(ROTATION_TYPE rotation)
 			break;
 	}
 
-#ifndef NDEBUG
+#ifdef RTS_DEBUG
 
 	assert((Box.Center - realcenter).Length() < 0.001f);
 	assert((SweepMin - realmin).Length() < 0.001f);
 	assert((SweepMax - realmax).Length() < 0.001f);
 
-#endif
+#endif // RTS_DEBUG
 }
 
 

--- a/Core/Libraries/Source/WWVegas/WWLib/ini.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/ini.cpp
@@ -2284,7 +2284,7 @@ void INIClass::DuplicateCRCError(const char *message, const char *section, const
 	OutputDebugString(buffer);
 	assert(0);
 
-#ifdef NDEBUG
+#ifdef RTS_RELEASE
 #ifdef _WINDOWS
 	MessageBox(0, buffer, "Duplicate CRC in INI file.", MB_ICONSTOP | MB_OK);
 #endif

--- a/Core/Libraries/Source/WWVegas/WWLib/lzo_conf.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/lzo_conf.h
@@ -200,7 +200,7 @@
 /* Help the optimizer with register allocation.
  * Don't activate this macro for a fair comparision with other algorithms.
  */
-#if 1 && defined(NDEBUG) && !defined(__BOUNDS_CHECKING_ON)
+#if 1 && defined(RTS_RELEASE) && !defined(__BOUNDS_CHECKING_ON)
 #  if defined(__GNUC__) && defined(__i386__)
 #    if !defined(LZO_OPTIMIZE_GNUC_i386_IS_BUGGY)
 #      define LZO_OPTIMIZE_GNUC_i386

--- a/Core/Libraries/Source/WWVegas/WWLib/refcount.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/refcount.cpp
@@ -44,7 +44,7 @@
 // TheSuperHackers @build feliwir 17/04/2025 include __debugbreak macros
 #include <Utility/intrin_compat.h>
 
-#ifndef NDEBUG
+#ifdef RTS_DEBUG
 
 // #define PARANOID_REFCOUNTS
 
@@ -161,14 +161,12 @@ void	RefCountClass::Inc_Total_Refs(const RefCountClass * obj)
 	assert(Validate_Active_Ref(obj));
 #endif
 	TotalRefs++;
-
 }
 
 // SKB 7/21/99 Set BreakOnRefernce to a pointer and it will break when called.
 //					This is used for debugging, please do not deleted.
 RefCountClass* BreakOnReference = 0;
 
-#ifndef NDEBUG
 void RefCountClass::Add_Ref(void) const
 {
 	NumRefs++;
@@ -179,7 +177,6 @@ void RefCountClass::Add_Ref(void) const
 	}
 	Inc_Total_Refs(this);
 }
-#endif
 
 /***********************************************************************************************
  * RefCountClass::Validate_Active_Ref -- decrements the total reference count                   *
@@ -206,8 +203,4 @@ void	RefCountClass::Dec_Total_Refs(const RefCountClass * obj)
 	}
 }
 
-
-
-#endif
-
-
+#endif // RTS_DEBUG

--- a/Core/Libraries/Source/WWVegas/WWLib/refcount.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/refcount.h
@@ -43,7 +43,7 @@
 class RefCountClass;
 
 
-#ifndef NDEBUG
+#ifdef RTS_DEBUG
 
 struct ActiveRefStruct
 {
@@ -59,7 +59,7 @@ struct ActiveRefStruct
 #define	NEW_REF( C, P )					( W3DNEW C P )
 #define	SET_REF_OWNER( P )			P
 
-#endif
+#endif // RTS_DEBUG
 
 
 /*
@@ -101,31 +101,31 @@ class RefCountClass
 {
 public:
 
-	RefCountClass(void) :
-		NumRefs(1)
-		#ifndef NDEBUG
-		,ActiveRefNode(this)
-		#endif
+	RefCountClass(void)
+		: NumRefs(1)
+#ifdef RTS_DEBUG
+		, ActiveRefNode(this)
+#endif
 	{
-		#ifndef NDEBUG
+#ifdef RTS_DEBUG
 		Add_Active_Ref(this);
 		Inc_Total_Refs(this);
-		#endif
+#endif
 	}
 
 	/*
 	** The reference counter value cannot be copied.
 	*/
-	RefCountClass(const RefCountClass & ) :
-		NumRefs(1)
-		#ifndef NDEBUG
-		,ActiveRefNode(this)
-		#endif
+	RefCountClass(const RefCountClass & )
+		: NumRefs(1)
+#ifdef RTS_DEBUG
+		, ActiveRefNode(this)
+#endif
 	{
-		#ifndef NDEBUG
+#ifdef RTS_DEBUG
 		Add_Active_Ref(this);
 		Inc_Total_Refs(this);
-		#endif
+#endif
 	}
 
 	RefCountClass& operator=(const RefCountClass&) { return *this; }
@@ -134,24 +134,26 @@ public:
 	** Add_Ref, call this function if you are going to keep a pointer
 	** to this object.
 	*/
-#ifdef NDEBUG
-	WWINLINE void Add_Ref(void) const							{ NumRefs++; }
-#else
+#ifdef RTS_DEBUG
 	void Add_Ref(void) const;
+#else
+	WWINLINE void Add_Ref(void) const							{ NumRefs++; }
 #endif
 
 	/*
 	** Release_Ref, call this function when you no longer need the pointer
 	** to this object.
 	*/
-	WWINLINE void		Release_Ref(void) const					{
-																				#ifndef NDEBUG
-																				Dec_Total_Refs(this);
-																				#endif
-																				NumRefs--;
-																				WWASSERT(NumRefs >= 0);
-																				if (NumRefs == 0) const_cast<RefCountClass*>(this)->Delete_This();
-																			}
+	WWINLINE void		Release_Ref(void) const
+	{
+#ifdef RTS_DEBUG
+		Dec_Total_Refs(this);
+#endif
+		NumRefs--;
+		WWASSERT(NumRefs >= 0);
+		if (NumRefs == 0)
+			const_cast<RefCountClass*>(this)->Delete_This();
+	}
 
 
 	/*
@@ -180,9 +182,9 @@ protected:
 	*/
 	virtual ~RefCountClass(void)
 	{
-		#ifndef NDEBUG
+#ifdef RTS_DEBUG
 		Remove_Active_Ref(this);
-		#endif
+#endif
 		WWASSERT(NumRefs == 0);
 	}
 
@@ -211,7 +213,7 @@ private:
 
 public:
 
-#ifndef NDEBUG // Debugging stuff
+#ifdef RTS_DEBUG // Debugging stuff
 
 	/*
 	** Node in the Active Refs List
@@ -248,7 +250,7 @@ public:
 	*/
 	static bool							Validate_Active_Ref(RefCountClass * obj);
 
-#endif // NDEBUG
+#endif // RTS_DEBUG
 
 };
 

--- a/Core/Libraries/Source/debug/test3/test3.cpp
+++ b/Core/Libraries/Source/debug/test3/test3.cpp
@@ -26,7 +26,7 @@
 //
 // Debug module - Test 3 (Checking FLAT I/O, logging)
 //////////////////////////////////////////////////////////////////////////////
-#ifdef NDEBUG
+
 #include "../debug.h"
 
 unsigned divByNull;

--- a/Core/Tools/Autorun/TTFont.cpp
+++ b/Core/Tools/Autorun/TTFont.cpp
@@ -662,7 +662,7 @@ int TTFontClass::Set_YSpacing( int y )
  *	  06/20/1887 BNA : Modified to handle new fonts.														  *
  *=============================================================================================*/
 
-#if(NDEBUG)
+#ifdef RTS_RELEASE
 
 Point2D TTFontClass::Print(
 	HDC hdc,
@@ -772,7 +772,7 @@ Point2D TTFontClass::Print(
 	return( point );
 }
 
-#endif
+#endif // RTS_RELEASE
 
 /***********************************************************************************************
  * TTFontClass::Print -- Print text to the surface specified.  CHAR version.                   *

--- a/Core/Tools/W3DView/W3DView.cpp
+++ b/Core/Tools/W3DView/W3DView.cpp
@@ -318,7 +318,7 @@ void CW3DViewApp::OnAppAbout()
 */
 void Debug_Refs(void)
 {
-#ifndef NDEBUG
+#ifdef RTS_DEBUG
 	TRACE("Detecting Active Refs...\r\n");
    //ODS("At time %s", cMiscUtil::Get_Text_Time());
 	RefCountNodeClass * first = RefCountClass::ActiveRefList.First();
@@ -368,7 +368,7 @@ void Debug_Refs(void)
 	}
 	TRACE("Done.\r\n");
    //ODS("At time %s", cMiscUtil::Get_Text_Time());
-#endif
+#endif // RTS_DEBUG
 }
 
 

--- a/Core/Tools/textureCompress/textureCompress.cpp
+++ b/Core/Tools/textureCompress/textureCompress.cpp
@@ -64,7 +64,7 @@ static void logStuff(const char *fmt, ...)
 	::MessageBox(NULL, buffer, "textureCompress", MB_OK);
 }
 
-#ifndef NDEBUG
+#ifdef RTS_DEBUG
 
 class DebugMunkee
 {
@@ -96,7 +96,7 @@ static void debugLog(const char *fmt, ...)
 
 #define DEBUG_LOG(x) {}
 
-#endif // NDEBUG
+#endif // RTS_DEBUG
 
 
 static void usage(const char *progname)
@@ -619,7 +619,7 @@ int main(int argc, const char **argv)
 		const char *targetDir = argv[2];
 		const char *cacheDir  = argv[3];
 
-#ifndef NDEBUG
+#ifdef RTS_DEBUG
 		theDebugMunkee = new DebugMunkee(argv[4]);
 #endif
 
@@ -631,7 +631,7 @@ int main(int argc, const char **argv)
 		//printSet( hasAlpha, "Using Alpha Channel" );
 		//tearDownLoadWindow();
 
-#ifndef NDEBUG
+#ifdef RTS_DEBUG
 		delete theDebugMunkee;
 		theDebugMunkee = NULL;
 #endif

--- a/cmake/config-build.cmake
+++ b/cmake/config-build.cmake
@@ -67,7 +67,7 @@ endif()
 if(RTS_BUILD_OPTION_DEBUG)
     target_compile_definitions(core_config INTERFACE RTS_DEBUG WWDEBUG DEBUG)
 else()
-    target_compile_definitions(core_config INTERFACE RTS_RELEASE)
+    target_compile_definitions(core_config INTERFACE RTS_RELEASE NDEBUG)
 endif()
 
 if(RTS_BUILD_OPTION_PROFILE)


### PR DESCRIPTION
This change replaces NDEBUG preprocessor with RTS_DEBUG or RTS_RELEASE.

Most notably, debug code in `AABoxCollisionTestClass::Rotate()` and `RefCountClass` is now properly compiled out in Release builds.