### PR TITLE
bugfix(aiupdate): Chinooks and Helixes now correctly wait for their passengers to disembark

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
@@ -1156,6 +1156,14 @@ void ChinookAIUpdate::aiDoCommand(const AICommandParms* parms)
 		{
 			const Real THRESH = 3.0f;
 			const Real THRESH_SQR = THRESH*THRESH;
+#if RETAIL_COMPATIBLE_CRC
+			const bool allowExit = true;
+#else
+			// TheSuperHackers @bugfix Stubbjax 04/11/2025 Passengers are no longer all dumped in a single frame.
+			const ContainModuleInterface* contain = getObject()->getContain();
+			const bool allowExit = contain && contain->hasObjectsWantingToEnterOrExit();
+#endif
+
 			if (calcDistSqr(*getObject()->getPosition(), parms->m_pos) > THRESH_SQR &&
 					m_flightStatus == CHINOOK_LANDED)
 			{
@@ -1166,12 +1174,7 @@ void ChinookAIUpdate::aiDoCommand(const AICommandParms* parms)
 				setMyState(TAKING_OFF, NULL, NULL, CMD_FROM_AI);
 				passItThru = false;
 			}
-#if RETAIL_COMPATIBLE_CRC
-			else
-#else
-			// TheSuperHackers @bugfix Stubbjax 04/11/2025 Passengers are no longer all dumped in a single frame.
-			else if (getObject()->getContain() && getObject()->getContain()->hasObjectsWantingToEnterOrExit())
-#endif
+			else if (allowExit)
 			{
 				// do this INSTEAD of the standard stuff
 				setMyState(

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
@@ -1291,6 +1291,14 @@ void ChinookAIUpdate::aiDoCommand(const AICommandParms* parms)
 		{
 			const Real THRESH = 3.0f;
 			const Real THRESH_SQR = THRESH*THRESH;
+#if RETAIL_COMPATIBLE_CRC
+			const bool allowExit = true;
+#else
+			// TheSuperHackers @bugfix Stubbjax 04/11/2025 Passengers are no longer all dumped in a single frame.
+			const ContainModuleInterface* contain = getObject()->getContain();
+			const bool allowExit = contain && contain->hasObjectsWantingToEnterOrExit();
+#endif
+
 			if (calcDistSqr(*getObject()->getPosition(), parms->m_pos) > THRESH_SQR &&
 					m_flightStatus == CHINOOK_LANDED)
 			{
@@ -1301,12 +1309,7 @@ void ChinookAIUpdate::aiDoCommand(const AICommandParms* parms)
 				setMyState(TAKING_OFF, NULL, NULL, CMD_FROM_AI);
 				passItThru = false;
 			}
-#if RETAIL_COMPATIBLE_CRC
-			else
-#else
-			// TheSuperHackers @bugfix Stubbjax 04/11/2025 Passengers are no longer all dumped in a single frame.
-			else if (getObject()->getContain() && getObject()->getContain()->hasObjectsWantingToEnterOrExit())
-#endif
+			else if (allowExit)
 			{
 				// do this INSTEAD of the standard stuff
 				setMyState(


### PR DESCRIPTION
Fixes [#703](https://github.com/TheSuperHackers/GeneralsGamePatch/issues/703) from the patch repository

This change adjusts Chinook and Helix behaviour so that they evacuate their passengers with the correct timing. In the retail game, the `ExitDelay` field of the `TransportContain` module is ignored and all passengers are immediately evacuated - unless the aircraft is already landed (e.g. repairing at an airfield or waiting for passengers to board). With this change, the `ExitDelay` field is always respected and remains consistent across all evacuation pathways. If the immediate evacuation behaviour from the retail game is preferred, the `ExitDelay` can be simply tweaked to 0.

As a bonus, the double evacuation bug is also fixed as a result of this change.

### Before

The Chinook dumps all passengers in a single frame

https://github.com/user-attachments/assets/f8d4a2d6-f1c9-4735-8240-52da04c13df8

The Chinook lands twice if given two or more evacuation orders before all passengers have disembarked

https://github.com/user-attachments/assets/913696f0-6bf1-433a-82b2-43385dea3e5d

### After

The Chinook correctly unloads a passenger every 100ms as defined by the `ExitDelay` in the `TransportContain` module

https://github.com/user-attachments/assets/58b01b5f-b393-4f6f-bc33-d2c89f26ca1e