### PR TITLE
bugfix(ai): Units located above the terrain can no longer teleport into airborne transports

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -6157,6 +6157,8 @@ StateReturnType AIEnterState::update()
 #if RETAIL_COMPATIBLE_CRC
 	if (code == STATE_SUCCESS && goal->isAboveTerrain() && !obj->isAboveTerrain())
 #else
+	// TheSuperHackers @bugfix Stubbjax 05/11/2025 Check for vertical overlap when entering containers.
+	// This prevents levitating or airborne units from entering containers they are not actually touching.
 	if (code == STATE_SUCCESS && !hasVerticalOverlap(goal, obj))
 #endif
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -6369,6 +6369,8 @@ StateReturnType AIEnterState::update()
 #if RETAIL_COMPATIBLE_CRC
 	if (code == STATE_SUCCESS && goal->isAboveTerrain() && !obj->isAboveTerrain())
 #else
+	// TheSuperHackers @bugfix Stubbjax 05/11/2025 Check for vertical overlap when entering containers.
+	// This prevents levitating or airborne units from entering containers they are not actually touching.
 	if (code == STATE_SUCCESS && !hasVerticalOverlap(goal, obj))
 #endif
 	{


### PR DESCRIPTION
Fixes #245

This change fixes an issue where units that are located above the terrain can be immediately teleported into airborne transports.

When an airborne transport unloads units, the transport is often not exactly level with the terrain at the time of unloading as the landed condition is based on a distance threshold to the landing location. This can result in disembarked units floating slightly above the terrain, which bypasses the condition on the transport having landed before embarking.

This is also why disembarked units often remain clumped together in the one spot, as this floating state cancels out pathfinding. The floating issue can be seen below.

https://github.com/user-attachments/assets/546fd259-4020-47b4-b3a2-8614de64d19b

Fixing the floating issue would also solve this issue, however it is still proper to ensure the z-bounds of the respective objects overlap before boarding can occur.

### Before

Floating infantry can teleport back aboard the Chinook

https://github.com/user-attachments/assets/d974cae8-af4d-489f-aafc-8b4be5e0e83a

### After

Floating infantry can not teleport back aboard the Chinook

https://github.com/user-attachments/assets/2162d7fa-9ad3-42e1-b46c-0a8c270390ba