### PR TITLE
build(cmake): Add status message for missing game install path

### DIFF
--- a/Generals/CMakeLists.txt
+++ b/Generals/CMakeLists.txt
@@ -69,4 +69,8 @@ if(RTS_INSTALL_PREFIX_GENERALS AND NOT "${RTS_INSTALL_PREFIX_GENERALS}" STREQUAL
         install(TARGETS g_w3dview RUNTIME DESTINATION "${RTS_INSTALL_PREFIX_GENERALS}")
         install(FILES $<TARGET_PDB_FILE:g_w3dview> DESTINATION "${RTS_INSTALL_PREFIX_GENERALS}" OPTIONAL)
     endif()
+else()
+    message(STATUS "Generals install path not found. Registry keys for 'Generals' not found. "
+                   "Generals targets will be built, but not installed. "
+                   "You can specify the path manually by setting RTS_INSTALL_PREFIX_GENERALS.")
 endif()

--- a/GeneralsMD/CMakeLists.txt
+++ b/GeneralsMD/CMakeLists.txt
@@ -63,7 +63,7 @@ if(RTS_INSTALL_PREFIX_ZEROHOUR AND NOT "${RTS_INSTALL_PREFIX_ZEROHOUR}" STREQUAL
         install(TARGETS z_mapcachebuilder RUNTIME DESTINATION "${RTS_INSTALL_PREFIX_ZEROHOUR}")
         install(FILES $<TARGET_PDB_FILE:z_mapcachebuilder> DESTINATION "${RTS_INSTALL_PREFIX_ZEROHOUR}" OPTIONAL)
     endif()
-    
+
     if(TARGET z_w3dview)
         install(TARGETS z_w3dview RUNTIME DESTINATION "${RTS_INSTALL_PREFIX_ZEROHOUR}")
         install(FILES $<TARGET_PDB_FILE:z_w3dview> DESTINATION "${RTS_INSTALL_PREFIX_ZEROHOUR}" OPTIONAL)
@@ -73,4 +73,8 @@ if(RTS_INSTALL_PREFIX_ZEROHOUR AND NOT "${RTS_INSTALL_PREFIX_ZEROHOUR}" STREQUAL
         install(TARGETS z_wdump RUNTIME DESTINATION "${RTS_INSTALL_PREFIX_ZEROHOUR}")
         install(FILES $<TARGET_PDB_FILE:z_wdump> DESTINATION "${RTS_INSTALL_PREFIX_ZEROHOUR}" OPTIONAL)
     endif()
+else()
+    message(STATUS "Zero Hour install path not found. Registry keys for 'Command and Conquer Generals Zero Hour' not found. "
+                   "Zero Hour targets will be built, but not installed. "
+                   "You can specify the path manually by setting RTS_INSTALL_PREFIX_ZEROHOUR.")
 endif()


### PR DESCRIPTION
If install path is not found in the registry, prints a message to notify you of that.

Else install target may not do what you expected.