### PR TITLE
bugfix(radar): Preserve hero icon during hidden exit frames

### DIFF
--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/Common/System/W3DRadar.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/Common/System/W3DRadar.cpp
@@ -654,12 +654,15 @@ void W3DRadar::renderObjectList( const RadarObject *listHead, TextureClass *text
 
 	for( const RadarObject *rObj = listHead; rObj; rObj = rObj->friend_getNext() )
 	{
+		// get object
+		const Object *obj = rObj->friend_getObject();
+
+		// TheSuperHackers @bugfix arcticdolphin 07/11/2025 Keep hero icon during hidden exit frames
+		if (calcHero && rObj->isTemporarilyHidden() && obj->isHero())
+			m_cachedHeroObjectList.push_back(obj);
 
 		if (rObj->isTemporarilyHidden())
 			continue;
-
-		// get object
-		const Object *obj = rObj->friend_getObject();
 
 		// check for shrouded status
 		if (obj->getShroudedStatus(playerIndex) > OBJECTSHROUD_PARTIAL_CLEAR)

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/Common/System/W3DRadar.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/Common/System/W3DRadar.cpp
@@ -652,12 +652,15 @@ void W3DRadar::renderObjectList( const RadarObject *listHead, TextureClass *text
 
 	for( const RadarObject *rObj = listHead; rObj; rObj = rObj->friend_getNext() )
 	{
+		// get object
+		const Object *obj = rObj->friend_getObject();
+
+		// TheSuperHackers @bugfix arcticdolphin 07/11/2025 Keep hero icon during hidden exit frames
+		if (calcHero && rObj->isTemporarilyHidden() && obj->isHero())
+			m_cachedHeroObjectList.push_back(obj);
 
 		if (rObj->isTemporarilyHidden())
 			continue;
-
-		// get object
-		const Object *obj = rObj->friend_getObject();
 
 		// check for shrouded status
 		if (obj->getShroudedStatus(playerIndex) > OBJECTSHROUD_PARTIAL_CLEAR)


### PR DESCRIPTION
Preserve hero icon during hidden exit frames.

Closes #1266