### PR TITLE
build(memory): Add missing REF macros to always.h for null memory manager

### DIFF
--- a/Core/Libraries/Source/WWVegas/WWLib/always.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/always.h
@@ -175,6 +175,9 @@ public:
 	#define W3DNEW									new
 	#define W3DNEWARRAY							new
 
+	#define NEW_REF( C, P )					( W3DNEW C P )
+	#define SET_REF_OWNER( P )			P
+
 	#define W3DMPO_GLUE(ARGCLASS)
 
 	class W3DMPO { };


### PR DESCRIPTION
Relates to: #1798 

This PR adds the missing reference class macros for when the null memory manager is being used.