### PR TITLE
bugfix(input): Replace frame-based timings with real-time timings in input system

### DIFF
--- a/Generals/Code/GameEngine/Include/GameClient/Keyboard.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Keyboard.h
@@ -77,7 +77,7 @@ struct KeyboardIO
 	UnsignedByte	status;									// StatusType, above
 	UnsignedShort	state;									// KEY_STATE_* in KeyDefs.h
 	UnsignedInt		sequence;								// sequence info from DirectX used for order
-	UnsignedInt		keyDownTimeMS;					// real-time in milliseconds when key went down
+	UnsignedInt		keyDownTimeMsec;				// real-time in milliseconds when key went down
 
 };
 
@@ -87,7 +87,7 @@ struct KeyboardIO
 class Keyboard : public SubsystemInterface
 {
 
-	enum { KEY_REPEAT_DELAY_MS = 250 };
+	enum { KEY_REPEAT_DELAY_MSEC = 250 };
 
 public:
 

--- a/Generals/Code/GameEngine/Include/GameClient/Keyboard.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Keyboard.h
@@ -86,7 +86,7 @@ struct KeyboardIO
 class Keyboard : public SubsystemInterface
 {
 
-	enum { KEY_REPEAT_DELAY_MSEC = 333 };
+	enum { KEY_REPEAT_DELAY_MSEC = 333, KEY_REPEAT_INTERVAL_MSEC = 67 }; // ~2 frames at 30 FPS
 
 public:
 

--- a/Generals/Code/GameEngine/Include/GameClient/Keyboard.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Keyboard.h
@@ -87,7 +87,7 @@ struct KeyboardIO
 class Keyboard : public SubsystemInterface
 {
 
-	enum { KEY_REPEAT_DELAY_MS = 333 };
+	enum { KEY_REPEAT_DELAY_MS = 250 };
 
 public:
 

--- a/Generals/Code/GameEngine/Include/GameClient/Keyboard.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Keyboard.h
@@ -86,7 +86,11 @@ struct KeyboardIO
 class Keyboard : public SubsystemInterface
 {
 
-	enum { KEY_REPEAT_DELAY_MSEC = 333, KEY_REPEAT_INTERVAL_MSEC = 67 }; // ~2 frames at 30 FPS
+	enum
+	{
+		KEY_REPEAT_DELAY_MSEC = 333,
+		KEY_REPEAT_INTERVAL_MSEC = 67
+	}; // ~2 frames at 30 FPS
 
 public:
 

--- a/Generals/Code/GameEngine/Include/GameClient/Keyboard.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Keyboard.h
@@ -88,9 +88,9 @@ class Keyboard : public SubsystemInterface
 
 	enum
 	{
-		KEY_REPEAT_DELAY_MSEC = 333,
-		KEY_REPEAT_INTERVAL_MSEC = 67
-	}; // ~2 frames at 30 FPS
+		KEY_REPEAT_DELAY_MSEC = 333,	// 10 frames at 30 FPS
+		KEY_REPEAT_INTERVAL_MSEC = 67	// ~2 frames at 30 FPS
+	};
 
 public:
 

--- a/Generals/Code/GameEngine/Include/GameClient/Keyboard.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Keyboard.h
@@ -77,6 +77,7 @@ struct KeyboardIO
 	UnsignedByte	status;									// StatusType, above
 	UnsignedShort	state;									// KEY_STATE_* in KeyDefs.h
 	UnsignedInt		sequence;								// sequence info from DirectX used for order
+	UnsignedInt		keyDownTimeMS;					// real-time in milliseconds when key went down
 
 };
 
@@ -86,7 +87,7 @@ struct KeyboardIO
 class Keyboard : public SubsystemInterface
 {
 
-	enum { KEY_REPEAT_DELAY = 10 };
+	enum { KEY_REPEAT_DELAY_MS = 333 };
 
 public:
 

--- a/Generals/Code/GameEngine/Include/GameClient/Keyboard.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Keyboard.h
@@ -87,7 +87,7 @@ struct KeyboardIO
 class Keyboard : public SubsystemInterface
 {
 
-	enum { KEY_REPEAT_DELAY_MSEC = 250 };
+	enum { KEY_REPEAT_DELAY_MSEC = 333 };
 
 public:
 

--- a/Generals/Code/GameEngine/Include/GameClient/Keyboard.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Keyboard.h
@@ -160,7 +160,6 @@ protected:
 		WideChar shifted2;
 
 	} m_keyNames[ KEY_COUNT ];
-	UnsignedInt m_inputFrame;  ///< frame input was gathered on
 
 };
 

--- a/Generals/Code/GameEngine/Include/GameClient/Keyboard.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Keyboard.h
@@ -76,7 +76,6 @@ struct KeyboardIO
 	UnsignedByte	key;										// KeyDefType, key data
 	UnsignedByte	status;									// StatusType, above
 	UnsignedShort	state;									// KEY_STATE_* in KeyDefs.h
-	UnsignedInt		sequence;								// DirectInput sequence number; overwritten with frame number for ordering
 	UnsignedInt		keyDownTimeMsec;				// real-time in milliseconds when key went down
 
 };
@@ -134,7 +133,6 @@ protected:
 	Bool checkKeyRepeat( void );  ///< check for repeating keys
 	UnsignedByte getKeyStatusData( KeyDefType key );  ///< get key status
 	Bool getKeyStateBit( KeyDefType key, Int bit );  ///< get key state bit
-	UnsignedInt getKeySequenceData( KeyDefType key );  ///< get key sequence
 	void setKeyStateData( KeyDefType key, UnsignedByte data );  ///< get key state
 
 	UnsignedShort m_modifiers;

--- a/Generals/Code/GameEngine/Include/GameClient/Keyboard.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Keyboard.h
@@ -76,7 +76,7 @@ struct KeyboardIO
 	UnsignedByte	key;										// KeyDefType, key data
 	UnsignedByte	status;									// StatusType, above
 	UnsignedShort	state;									// KEY_STATE_* in KeyDefs.h
-	UnsignedInt		sequence;								// sequence info from DirectX used for order
+	UnsignedInt		sequence;								// DirectInput sequence number; overwritten with frame number for ordering
 	UnsignedInt		keyDownTimeMsec;				// real-time in milliseconds when key went down
 
 };

--- a/Generals/Code/GameEngine/Include/GameClient/LookAtXlat.h
+++ b/Generals/Code/GameEngine/Include/GameClient/LookAtXlat.h
@@ -76,7 +76,7 @@ private:
 	Bool m_isRotating;					// set to true if we are in the act of MMB rotating
 	Bool m_isPitching;					// set to true if we are in the act of ALT pitch rotation
 	Bool m_isChangingFOV;			// set to true if we are in the act of changing the field of view
-	UnsignedInt m_middleButtonDownTimeMS;				// real-time in milliseconds when middle button goes down
+	UnsignedInt m_middleButtonDownTimeMsec;				// real-time in milliseconds when middle button goes down
 	DrawableID m_lastPlaneID;
 	ViewLocation m_viewLocation[ MAX_VIEW_LOCS ];
 	ScrollType m_scrollType;

--- a/Generals/Code/GameEngine/Include/GameClient/LookAtXlat.h
+++ b/Generals/Code/GameEngine/Include/GameClient/LookAtXlat.h
@@ -81,7 +81,7 @@ private:
 	ViewLocation m_viewLocation[ MAX_VIEW_LOCS ];
 	ScrollType m_scrollType;
 	ScreenEdgeScrollMode m_screenEdgeScrollMode;
-	UnsignedInt m_lastMouseMoveFrame;
+	UnsignedInt m_lastMouseMoveTimeMsec;				// real-time in milliseconds when mouse last moved
 
 	void setScrolling( ScrollType scrollType );
 	void stopScrolling( void );

--- a/Generals/Code/GameEngine/Include/GameClient/LookAtXlat.h
+++ b/Generals/Code/GameEngine/Include/GameClient/LookAtXlat.h
@@ -76,7 +76,7 @@ private:
 	Bool m_isRotating;					// set to true if we are in the act of MMB rotating
 	Bool m_isPitching;					// set to true if we are in the act of ALT pitch rotation
 	Bool m_isChangingFOV;			// set to true if we are in the act of changing the field of view
-	UnsignedInt m_timestamp;				// set when button goes down
+	UnsignedInt m_middleButtonDownTimeMS;				// real-time in milliseconds when middle button goes down
 	DrawableID m_lastPlaneID;
 	ViewLocation m_viewLocation[ MAX_VIEW_LOCS ];
 	ScrollType m_scrollType;

--- a/Generals/Code/GameEngine/Include/GameClient/Mouse.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Mouse.h
@@ -107,15 +107,15 @@ struct MouseIO
 
 	MouseButtonState leftState;					// button state: Up, Down, DoubleClick (Which is also down)
 	Int leftEvent;											// Most important event this frame
-	Int leftFrame;											// last frame button state changed
+	Bool leftButtonStateChanged;					// TRUE if button state changed in this event
 
 	MouseButtonState rightState;
 	Int rightEvent;
-	Int rightFrame;
+	Bool rightButtonStateChanged;					// TRUE if button state changed in this event
 
 	MouseButtonState middleState;
 	Int middleEvent;
-	Int middleFrame;
+	Bool middleButtonStateChanged;					// TRUE if button state changed in this event
 };
 
 class CursorInfo
@@ -392,9 +392,6 @@ protected:
 	Int m_maxX;							///< mouse is locked to this region
 	Int m_minY;							///< mouse is locked to this region
 	Int m_maxY;							///< mouse is locked to this region
-
-	UnsignedInt m_inputFrame;				///< frame input was gathered on
-	UnsignedInt m_deadInputFrame;		///< Frame which last input occured
 
 	Bool m_inputMovesAbsolute;			/**< if TRUE, when processing mouse position
 																	chanages the movement will be done treating

--- a/Generals/Code/GameEngine/Include/GameClient/Mouse.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Mouse.h
@@ -107,15 +107,15 @@ struct MouseIO
 
 	MouseButtonState leftState;					// button state: Up, Down, DoubleClick (Which is also down)
 	Int leftEvent;											// Most important event this frame
-	Bool leftButtonStateChanged;					// TRUE if button state changed for a given mouse event
+	Bool leftStateChanged;					// TRUE if button state changed for a given mouse event
 
 	MouseButtonState rightState;
 	Int rightEvent;
-	Bool rightButtonStateChanged;					// TRUE if button state changed for a given mouse event
+	Bool rightStateChanged;					// TRUE if button state changed for a given mouse event
 
 	MouseButtonState middleState;
 	Int middleEvent;
-	Bool middleButtonStateChanged;					// TRUE if button state changed for a given mouse event
+	Bool middleStateChanged;					// TRUE if button state changed for a given mouse event
 };
 
 class CursorInfo

--- a/Generals/Code/GameEngine/Include/GameClient/Mouse.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Mouse.h
@@ -62,6 +62,7 @@ enum GameMode CPP_11(: Int);
 
 enum MouseButtonState CPP_11(: Int)
 {
+	MBS_None = -1,
 	MBS_Up = 0,
 	MBS_Down,
 	MBS_DoubleClick,
@@ -105,17 +106,14 @@ struct MouseIO
 								 user while - is down/toward user */
 	ICoord2D deltaPos;  ///< overall change in mouse pointer this frame
 
-	MouseButtonState leftState;					// button state: Up, Down, DoubleClick (Which is also down)
+	MouseButtonState leftState;					// button state: None (no event), Up, Down, DoubleClick
 	Int leftEvent;											// Most important event this frame
-	Bool leftStateChanged;					// TRUE if button state changed for a given mouse event
 
 	MouseButtonState rightState;
 	Int rightEvent;
-	Bool rightStateChanged;					// TRUE if button state changed for a given mouse event
 
 	MouseButtonState middleState;
 	Int middleEvent;
-	Bool middleStateChanged;					// TRUE if button state changed for a given mouse event
 };
 
 class CursorInfo

--- a/Generals/Code/GameEngine/Include/GameClient/Mouse.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Mouse.h
@@ -107,15 +107,15 @@ struct MouseIO
 
 	MouseButtonState leftState;					// button state: Up, Down, DoubleClick (Which is also down)
 	Int leftEvent;											// Most important event this frame
-	Bool leftButtonStateChanged;					// TRUE if button state changed in this event
+	Bool leftButtonStateChanged;					// TRUE if button state changed for a given mouse event
 
 	MouseButtonState rightState;
 	Int rightEvent;
-	Bool rightButtonStateChanged;					// TRUE if button state changed in this event
+	Bool rightButtonStateChanged;					// TRUE if button state changed for a given mouse event
 
 	MouseButtonState middleState;
 	Int middleEvent;
-	Bool middleButtonStateChanged;					// TRUE if button state changed in this event
+	Bool middleButtonStateChanged;					// TRUE if button state changed for a given mouse event
 };
 
 class CursorInfo

--- a/Generals/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
@@ -144,7 +144,7 @@ void Keyboard::updateKeys( void )
 		// Update key down time for new key presses
 		if( BitIsSet( m_keys[ index ].state, KEY_STATE_DOWN ) )
 		{
-			m_keyStatus[ m_keys[ index ].key ].keyDownTimeMsec = timeGetTime();
+			m_keyStatus[ m_keys[ index ].key ].keyDownTimeMsec = m_keys[ index ].keyDownTimeMsec;
 		}
 
 		// prevent ALT-TAB from causing a TAB event
@@ -200,7 +200,7 @@ void Keyboard::updateKeys( void )
 }
 
 //-------------------------------------------------------------------------------------------------
-/** check key repeat sequences, TRUE is returned if repeat is occurring */
+/** check key repeat timing, TRUE is returned if repeat is occurring */
 //-------------------------------------------------------------------------------------------------
 Bool Keyboard::checkKeyRepeat( void )
 {

--- a/Generals/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
@@ -130,6 +130,9 @@ void Keyboard::updateKeys( void )
 	}
 	while( m_keys[ index++ ].key != KEY_NONE );
 
+	// Get current time once for all key updates
+	UnsignedInt now = 0;
+
 	// update keyboard status array
 	index = 0;
 	while( m_keys[ index ].key != KEY_NONE )
@@ -145,7 +148,9 @@ void Keyboard::updateKeys( void )
 		// Update key down time for new key presses
 		if( BitIsSet( m_keys[ index ].state, KEY_STATE_DOWN ) )
 		{
-			m_keyStatus[ m_keys[ index ].key ].keyDownTimeMsec = timeGetTime();
+			if( !now )
+				now = timeGetTime();
+			m_keyStatus[ m_keys[ index ].key ].keyDownTimeMsec = now;
 		}
 
 		// prevent ALT-TAB from causing a TAB event

--- a/Generals/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
@@ -130,9 +130,6 @@ void Keyboard::updateKeys( void )
 	}
 	while( m_keys[ index++ ].key != KEY_NONE );
 
-	// Get current time once for all key updates
-	UnsignedInt now = 0;
-
 	// update keyboard status array
 	index = 0;
 	while( m_keys[ index ].key != KEY_NONE )
@@ -147,9 +144,7 @@ void Keyboard::updateKeys( void )
 		// Update key down time for new key presses
 		if( BitIsSet( m_keys[ index ].state, KEY_STATE_DOWN ) )
 		{
-			if( !now )
-				now = timeGetTime();
-			m_keyStatus[ m_keys[ index ].key ].keyDownTimeMsec = now;
+			m_keyStatus[ m_keys[ index ].key ].keyDownTimeMsec = timeGetTime();
 		}
 
 		// prevent ALT-TAB from causing a TAB event
@@ -225,14 +220,13 @@ Bool Keyboard::checkKeyRepeat( void )
 	// Scan Keyboard status array for first key down
 	// long enough to repeat
 	const UnsignedInt KEY_REPEAT_INTERVAL_MSEC = 67; // ~2 frames at 30 FPS
-	UnsignedInt now = timeGetTime();
 	for( key = 0; key < ARRAY_SIZE(m_keyStatus); key++ )
 	{
 
 		if( BitIsSet( m_keyStatus[ key ].state, KEY_STATE_DOWN ) )
 		{
 
-			if( now - m_keyStatus[ key ].keyDownTimeMsec > Keyboard::KEY_REPEAT_DELAY_MSEC )
+			if( timeGetTime() - m_keyStatus[ key ].keyDownTimeMsec > Keyboard::KEY_REPEAT_DELAY_MSEC )
 			{
 				// Add key to this frame
 				m_keys[ index ].key = (UnsignedByte)key;
@@ -243,7 +237,7 @@ Bool Keyboard::checkKeyRepeat( void )
 				m_keys[ ++index ].key = KEY_NONE;
 
 				// Set repeated key so it will repeat again after the interval
-				m_keyStatus[ key ].keyDownTimeMsec = now - (Keyboard::KEY_REPEAT_DELAY_MSEC + KEY_REPEAT_INTERVAL_MSEC);
+				m_keyStatus[ key ].keyDownTimeMsec = timeGetTime() - (Keyboard::KEY_REPEAT_DELAY_MSEC + KEY_REPEAT_INTERVAL_MSEC);
 
 				retVal = TRUE;
 				break;  // exit for key

--- a/Generals/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
@@ -225,6 +225,7 @@ Bool Keyboard::checkKeyRepeat( void )
 
 	// Scan Keyboard status array for first key down
 	// long enough to repeat
+	const UnsignedInt KEY_REPEAT_INTERVAL_MSEC = 67; // ~2 frames at 30 FPS
 	UnsignedInt now = timeGetTime();
 	for( key = 0; key < ARRAY_SIZE(m_keyStatus); key++ )
 	{
@@ -246,8 +247,7 @@ Bool Keyboard::checkKeyRepeat( void )
 				for( index = 0; index< NUM_KEYS; index++ )
 					m_keyStatus[ index ].sequence = m_inputFrame;
 
-				// Set repeated key so it will repeat again after a short interval
-				const UnsignedInt KEY_REPEAT_INTERVAL_MSEC = 67; // ~2 frames at 30 FPS
+				// Set repeated key so it will repeat again after the interval
 				m_keyStatus[ key ].keyDownTimeMsec = now - (Keyboard::KEY_REPEAT_DELAY_MSEC - KEY_REPEAT_INTERVAL_MSEC);
 
 				retVal = TRUE;

--- a/Generals/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
@@ -219,7 +219,6 @@ Bool Keyboard::checkKeyRepeat( void )
 
 	// Scan Keyboard status array for first key down
 	// long enough to repeat
-	const UnsignedInt KEY_REPEAT_INTERVAL_MSEC = 67; // ~2 frames at 30 FPS
 	for( key = 0; key < ARRAY_SIZE(m_keyStatus); key++ )
 	{
 
@@ -243,7 +242,7 @@ Bool Keyboard::checkKeyRepeat( void )
 					m_keyStatus[ index ].keyDownTimeMsec = now;
 
 				// Set repeated key so it will repeat again after the interval
-				m_keyStatus[ key ].keyDownTimeMsec = now - (Keyboard::KEY_REPEAT_DELAY_MSEC + KEY_REPEAT_INTERVAL_MSEC);
+				m_keyStatus[ key ].keyDownTimeMsec = now - (Keyboard::KEY_REPEAT_DELAY_MSEC + Keyboard::KEY_REPEAT_INTERVAL_MSEC);
 
 				retVal = TRUE;
 				break;  // exit for key

--- a/Generals/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
@@ -248,7 +248,7 @@ Bool Keyboard::checkKeyRepeat( void )
 					m_keyStatus[ index ].sequence = m_inputFrame;
 
 				// Set repeated key so it will repeat again after the interval
-				m_keyStatus[ key ].keyDownTimeMsec = now - (Keyboard::KEY_REPEAT_DELAY_MSEC - KEY_REPEAT_INTERVAL_MSEC);
+				m_keyStatus[ key ].keyDownTimeMsec = now - (Keyboard::KEY_REPEAT_DELAY_MSEC + KEY_REPEAT_INTERVAL_MSEC);
 
 				retVal = TRUE;
 				break;  // exit for key

--- a/Generals/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
@@ -143,7 +143,6 @@ void Keyboard::updateKeys( void )
 
 		m_keyStatus[ m_keys[ index ].key ].state = m_keys[ index ].state;
 		m_keyStatus[ m_keys[ index ].key ].status = m_keys[ index ].status;
-		m_keyStatus[ m_keys[ index ].key ].sequence = m_inputFrame;
 
 		// Update key down time for new key presses
 		if( BitIsSet( m_keys[ index ].state, KEY_STATE_DOWN ) )
@@ -242,10 +241,6 @@ Bool Keyboard::checkKeyRepeat( void )
 
 				// Set End Flag
 				m_keys[ ++index ].key = KEY_NONE;
-
-				// Set all keys as new to prevent multiple keys repeating
-				for( index = 0; index< NUM_KEYS; index++ )
-					m_keyStatus[ index ].sequence = m_inputFrame;
 
 				// Set repeated key so it will repeat again after the interval
 				m_keyStatus[ key ].keyDownTimeMsec = now - (Keyboard::KEY_REPEAT_DELAY_MSEC + KEY_REPEAT_INTERVAL_MSEC);
@@ -830,14 +825,6 @@ UnsignedByte Keyboard::getKeyStatusData( KeyDefType key )
 Bool Keyboard::getKeyStateBit( KeyDefType key, Int bit )
 {
 	return (m_keyStatus[ key ].state & bit) ? 1 : 0;
-}
-
-//-------------------------------------------------------------------------------------------------
-/** return the sequence data for the given key */
-//-------------------------------------------------------------------------------------------------
-UnsignedInt Keyboard::getKeySequenceData( KeyDefType key )
-{
-	return m_keyStatus[ key ].sequence;
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
@@ -701,7 +701,6 @@ Keyboard::Keyboard( void )
 	m_shift2Key = KEY_NONE;
 
 	memset( m_keyNames, 0, sizeof( m_keyNames ) );
-	m_inputFrame = 0;
 
 }
 
@@ -721,9 +720,6 @@ void Keyboard::init( void )
 	// initialize the key names
 	initKeyNames();
 
-	// first input frame
-	m_inputFrame = 0;
-
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -739,9 +735,6 @@ void Keyboard::reset( void )
 //-------------------------------------------------------------------------------------------------
 void Keyboard::update( void )
 {
-
-	// increment input frame
-	m_inputFrame++;
 
 	// update the key data
 	updateKeys();

--- a/Generals/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
@@ -145,7 +145,7 @@ void Keyboard::updateKeys( void )
 		// Update key down time for new key presses
 		if( BitIsSet( m_keys[ index ].state, KEY_STATE_DOWN ) )
 		{
-			m_keyStatus[ m_keys[ index ].key ].keyDownTimeMS = timeGetTime();
+			m_keyStatus[ m_keys[ index ].key ].keyDownTimeMsec = timeGetTime();
 		}
 
 		// prevent ALT-TAB from causing a TAB event
@@ -227,7 +227,7 @@ Bool Keyboard::checkKeyRepeat( void )
 		if( BitIsSet( m_keyStatus[ key ].state, KEY_STATE_DOWN ) )
 		{
 
-			if( now - m_keyStatus[ key ].keyDownTimeMS > Keyboard::KEY_REPEAT_DELAY_MS )
+			if( now - m_keyStatus[ key ].keyDownTimeMsec > Keyboard::KEY_REPEAT_DELAY_MSEC )
 			{
 				// Add key to this frame
 				m_keys[ index ].key = (UnsignedByte)key;
@@ -242,8 +242,8 @@ Bool Keyboard::checkKeyRepeat( void )
 					m_keyStatus[ index ].sequence = m_inputFrame;
 
 				// Set repeated key so it will repeat again after a short interval
-				const UnsignedInt KEY_REPEAT_INTERVAL_MS = 67; // ~2 frames at 30 FPS
-				m_keyStatus[ key ].keyDownTimeMS = now - (Keyboard::KEY_REPEAT_DELAY_MS - KEY_REPEAT_INTERVAL_MS);
+				const UnsignedInt KEY_REPEAT_INTERVAL_MSEC = 67; // ~2 frames at 30 FPS
+				m_keyStatus[ key ].keyDownTimeMsec = now - (Keyboard::KEY_REPEAT_DELAY_MSEC - KEY_REPEAT_INTERVAL_MSEC);
 
 				retVal = TRUE;
 				break;  // exit for key

--- a/Generals/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
@@ -225,9 +225,13 @@ Bool Keyboard::checkKeyRepeat( void )
 		if( BitIsSet( m_keyStatus[ key ].state, KEY_STATE_DOWN ) )
 		{
 
-			UnsignedInt now = timeGetTime();
+			const UnsignedInt now = timeGetTime();
+			const UnsignedInt keyDownTime = m_keyStatus[ key ].keyDownTimeMsec;
 
-			if( now - m_keyStatus[ key ].keyDownTimeMsec > Keyboard::KEY_REPEAT_DELAY_MSEC )
+			// Unsigned subtraction handles wraparound correctly
+			const UnsignedInt elapsedMsec = now - keyDownTime;
+
+			if( elapsedMsec > Keyboard::KEY_REPEAT_DELAY_MSEC )
 			{
 				// Add key to this frame
 				m_keys[ index ].key = (UnsignedByte)key;

--- a/Generals/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
@@ -220,12 +220,13 @@ Bool Keyboard::checkKeyRepeat( void )
 	// Scan Keyboard status array for first key down
 	// long enough to repeat
 	const UnsignedInt KEY_REPEAT_INTERVAL_MSEC = 67; // ~2 frames at 30 FPS
-	UnsignedInt now = timeGetTime();
 	for( key = 0; key < ARRAY_SIZE(m_keyStatus); key++ )
 	{
 
 		if( BitIsSet( m_keyStatus[ key ].state, KEY_STATE_DOWN ) )
 		{
+
+			UnsignedInt now = timeGetTime();
 
 			if( now - m_keyStatus[ key ].keyDownTimeMsec > Keyboard::KEY_REPEAT_DELAY_MSEC )
 			{

--- a/Generals/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
@@ -220,13 +220,14 @@ Bool Keyboard::checkKeyRepeat( void )
 	// Scan Keyboard status array for first key down
 	// long enough to repeat
 	const UnsignedInt KEY_REPEAT_INTERVAL_MSEC = 67; // ~2 frames at 30 FPS
+	UnsignedInt now = timeGetTime();
 	for( key = 0; key < ARRAY_SIZE(m_keyStatus); key++ )
 	{
 
 		if( BitIsSet( m_keyStatus[ key ].state, KEY_STATE_DOWN ) )
 		{
 
-			if( timeGetTime() - m_keyStatus[ key ].keyDownTimeMsec > Keyboard::KEY_REPEAT_DELAY_MSEC )
+			if( now - m_keyStatus[ key ].keyDownTimeMsec > Keyboard::KEY_REPEAT_DELAY_MSEC )
 			{
 				// Add key to this frame
 				m_keys[ index ].key = (UnsignedByte)key;
@@ -236,8 +237,12 @@ Bool Keyboard::checkKeyRepeat( void )
 				// Set End Flag
 				m_keys[ ++index ].key = KEY_NONE;
 
+				// Set all keys as new to prevent multiple keys repeating
+				for( index = 0; index< NUM_KEYS; index++ )
+					m_keyStatus[ index ].keyDownTimeMsec = now;
+
 				// Set repeated key so it will repeat again after the interval
-				m_keyStatus[ key ].keyDownTimeMsec = timeGetTime() - (Keyboard::KEY_REPEAT_DELAY_MSEC + KEY_REPEAT_INTERVAL_MSEC);
+				m_keyStatus[ key ].keyDownTimeMsec = now - (Keyboard::KEY_REPEAT_DELAY_MSEC + KEY_REPEAT_INTERVAL_MSEC);
 
 				retVal = TRUE;
 				break;  // exit for key

--- a/Generals/Code/GameEngine/Source/GameClient/Input/Mouse.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Input/Mouse.cpp
@@ -584,7 +584,6 @@ void Mouse::init( void )
 	m_minY = 0;
 	m_maxY = 599;
 
-
 	m_inputMovesAbsolute = FALSE;
 	m_eventsThisFrame = 0;
 

--- a/Generals/Code/GameEngine/Source/GameClient/Input/Mouse.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Input/Mouse.cpp
@@ -183,9 +183,6 @@ void Mouse::updateMouseData( )
 	else
 		m_eventsThisFrame = 0;
 
-	if( index != 0 )
-		m_deadInputFrame = m_inputFrame;
-
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -221,7 +218,7 @@ void Mouse::processMouseEvent( Int index )
 	m_currMouse.wheelPos += m_mouseEvents[ index ].wheelPos;
 
 	// Check Left Mouse State
-	if( m_mouseEvents[ index ].leftFrame )
+	if( m_mouseEvents[ index ].leftButtonStateChanged )
 	{
 		if( m_currMouse.leftState != m_mouseEvents[ index ].leftState )
 		{
@@ -231,21 +228,21 @@ void Mouse::processMouseEvent( Int index )
 				// Mouse Down
 				m_currMouse.leftEvent = GWM_LEFT_DOWN;
 				m_currMouse.leftState = MBS_Down;
-				m_currMouse.leftFrame = m_inputFrame;
+				m_currMouse.leftButtonStateChanged = TRUE;
 			}
 			else if ( m_mouseEvents[ index ].leftState == MBS_DoubleClick )
 			{
 				// Mouse Double Click
 				m_currMouse.leftEvent = GWM_LEFT_DOUBLE_CLICK;
 				m_currMouse.leftState = MBS_DoubleClick;
-				m_currMouse.leftFrame = m_inputFrame;
+				m_currMouse.leftButtonStateChanged = TRUE;
 			}
 			else
 			{
 				// Mouse Up
 				m_currMouse.leftEvent = GWM_LEFT_UP;
 				m_currMouse.leftState = MBS_Up;
-				m_currMouse.leftFrame = m_inputFrame;
+				m_currMouse.leftButtonStateChanged = TRUE;
 			}
 		}
 	}
@@ -257,7 +254,7 @@ void Mouse::processMouseEvent( Int index )
 	}
 
 	// Check Right Mouse State
-	if( m_mouseEvents[ index ].rightFrame )
+	if( m_mouseEvents[ index ].rightButtonStateChanged )
 	{
 		if( m_currMouse.rightState != m_mouseEvents[ index ].rightState )
 		{
@@ -267,21 +264,21 @@ void Mouse::processMouseEvent( Int index )
 				// Mouse Down
 				m_currMouse.rightEvent = GWM_RIGHT_DOWN;
 				m_currMouse.rightState = MBS_Down;
-				m_currMouse.rightFrame = m_inputFrame;
+				m_currMouse.rightButtonStateChanged = TRUE;
 			}
 			else if( m_mouseEvents[ index ].rightState == MBS_DoubleClick )
 			{
 				// Mouse Double Click
 				m_currMouse.rightEvent = GWM_RIGHT_DOUBLE_CLICK;
 				m_currMouse.rightState = MBS_DoubleClick;
-				m_currMouse.rightFrame = m_inputFrame;
+				m_currMouse.rightButtonStateChanged = TRUE;
 			}
 			else
 			{
 				// Mouse Up
 				m_currMouse.rightEvent = GWM_RIGHT_UP;
 				m_currMouse.rightState = MBS_Up;
-				m_currMouse.rightFrame = m_inputFrame;
+				m_currMouse.rightButtonStateChanged = TRUE;
 			}
 		}
 	}
@@ -293,7 +290,7 @@ void Mouse::processMouseEvent( Int index )
 	}
 
 	// Check Middle Mouse State
-	if( m_mouseEvents[ index ].middleFrame )
+	if( m_mouseEvents[ index ].middleButtonStateChanged )
 	{
 		if( m_currMouse.middleState != m_mouseEvents[index].middleState )
 		{
@@ -302,20 +299,20 @@ void Mouse::processMouseEvent( Int index )
 			{
 				m_currMouse.middleEvent = GWM_MIDDLE_DOWN;
 				m_currMouse.middleState = MBS_Down;
-				m_currMouse.middleFrame = m_inputFrame;
+				m_currMouse.middleButtonStateChanged = TRUE;
 			}
 			else if( m_mouseEvents[index].middleState == MBS_DoubleClick )
 			{
 				m_currMouse.middleEvent = GWM_MIDDLE_DOUBLE_CLICK;
 				m_currMouse.middleState = MBS_DoubleClick;
-				m_currMouse.middleFrame = m_inputFrame;
+				m_currMouse.middleButtonStateChanged = TRUE;
 			}
 			else
 			{
 				// Mouse Up
 				m_currMouse.middleEvent = GWM_MIDDLE_UP;
 				m_currMouse.middleState = MBS_Up;
-				m_currMouse.middleFrame = m_inputFrame;
+				m_currMouse.middleButtonStateChanged = TRUE;
 			}
 		}
 	}
@@ -328,7 +325,7 @@ void Mouse::processMouseEvent( Int index )
 
 	m_currMouse.deltaPos.x = m_currMouse.pos.x - m_prevMouse.pos.x;
 	m_currMouse.deltaPos.y = m_currMouse.pos.y - m_prevMouse.pos.y;
-//	DEBUG_LOG(("Mouse dx %d, dy %d, index %d, frame %d", m_currMouse.deltaPos.x, m_currMouse.deltaPos.y, index, m_inputFrame));
+//	DEBUG_LOG(("Mouse dx %d, dy %d, index %d", m_currMouse.deltaPos.x, m_currMouse.deltaPos.y, index));
 //	// check if mouse is still and flag tooltip
 //	if( ((dx*dx) + (dy*dy)) < CURSOR_MOVE_TOL_SQ )
 //	{
@@ -474,9 +471,6 @@ Mouse::Mouse( void )
 	m_maxY = 0;
 	m_eventsThisFrame = 0;
 
-	m_inputFrame = 0;
-	m_deadInputFrame =0;
-
 	m_inputMovesAbsolute = FALSE;
 
 	m_currentCursor = ARROW;
@@ -590,8 +584,6 @@ void Mouse::init( void )
 	m_minY = 0;
 	m_maxY = 599;
 
-	m_inputFrame = 0;
-	m_deadInputFrame =0;
 
 	m_inputMovesAbsolute = FALSE;
 	m_eventsThisFrame = 0;
@@ -675,9 +667,6 @@ void Mouse::reset( void )
 //-------------------------------------------------------------------------------------------------
 void Mouse::update( void )
 {
-
-	// increment input frame
-	m_inputFrame++;
 
 	// update the mouse data
 	updateMouseData( );

--- a/Generals/Code/GameEngine/Source/GameClient/Input/Mouse.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Input/Mouse.cpp
@@ -218,7 +218,7 @@ void Mouse::processMouseEvent( Int index )
 	m_currMouse.wheelPos += m_mouseEvents[ index ].wheelPos;
 
 	// Check Left Mouse State
-	if( m_mouseEvents[ index ].leftStateChanged )
+	if( m_mouseEvents[ index ].leftState != MBS_None )
 	{
 		if( m_currMouse.leftState != m_mouseEvents[ index ].leftState )
 		{
@@ -228,21 +228,18 @@ void Mouse::processMouseEvent( Int index )
 				// Mouse Down
 				m_currMouse.leftEvent = GWM_LEFT_DOWN;
 				m_currMouse.leftState = MBS_Down;
-				m_currMouse.leftStateChanged = TRUE;
 			}
 			else if ( m_mouseEvents[ index ].leftState == MBS_DoubleClick )
 			{
 				// Mouse Double Click
 				m_currMouse.leftEvent = GWM_LEFT_DOUBLE_CLICK;
 				m_currMouse.leftState = MBS_DoubleClick;
-				m_currMouse.leftStateChanged = TRUE;
 			}
 			else
 			{
 				// Mouse Up
 				m_currMouse.leftEvent = GWM_LEFT_UP;
 				m_currMouse.leftState = MBS_Up;
-				m_currMouse.leftStateChanged = TRUE;
 			}
 		}
 	}
@@ -254,7 +251,7 @@ void Mouse::processMouseEvent( Int index )
 	}
 
 	// Check Right Mouse State
-	if( m_mouseEvents[ index ].rightStateChanged )
+	if( m_mouseEvents[ index ].rightState != MBS_None )
 	{
 		if( m_currMouse.rightState != m_mouseEvents[ index ].rightState )
 		{
@@ -264,21 +261,18 @@ void Mouse::processMouseEvent( Int index )
 				// Mouse Down
 				m_currMouse.rightEvent = GWM_RIGHT_DOWN;
 				m_currMouse.rightState = MBS_Down;
-				m_currMouse.rightStateChanged = TRUE;
 			}
 			else if( m_mouseEvents[ index ].rightState == MBS_DoubleClick )
 			{
 				// Mouse Double Click
 				m_currMouse.rightEvent = GWM_RIGHT_DOUBLE_CLICK;
 				m_currMouse.rightState = MBS_DoubleClick;
-				m_currMouse.rightStateChanged = TRUE;
 			}
 			else
 			{
 				// Mouse Up
 				m_currMouse.rightEvent = GWM_RIGHT_UP;
 				m_currMouse.rightState = MBS_Up;
-				m_currMouse.rightStateChanged = TRUE;
 			}
 		}
 	}
@@ -290,7 +284,7 @@ void Mouse::processMouseEvent( Int index )
 	}
 
 	// Check Middle Mouse State
-	if( m_mouseEvents[ index ].middleStateChanged )
+	if( m_mouseEvents[ index ].middleState != MBS_None )
 	{
 		if( m_currMouse.middleState != m_mouseEvents[index].middleState )
 		{
@@ -299,20 +293,17 @@ void Mouse::processMouseEvent( Int index )
 			{
 				m_currMouse.middleEvent = GWM_MIDDLE_DOWN;
 				m_currMouse.middleState = MBS_Down;
-				m_currMouse.middleStateChanged = TRUE;
 			}
 			else if( m_mouseEvents[index].middleState == MBS_DoubleClick )
 			{
 				m_currMouse.middleEvent = GWM_MIDDLE_DOUBLE_CLICK;
 				m_currMouse.middleState = MBS_DoubleClick;
-				m_currMouse.middleStateChanged = TRUE;
 			}
 			else
 			{
 				// Mouse Up
 				m_currMouse.middleEvent = GWM_MIDDLE_UP;
 				m_currMouse.middleState = MBS_Up;
-				m_currMouse.middleStateChanged = TRUE;
 			}
 		}
 	}

--- a/Generals/Code/GameEngine/Source/GameClient/Input/Mouse.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Input/Mouse.cpp
@@ -218,7 +218,7 @@ void Mouse::processMouseEvent( Int index )
 	m_currMouse.wheelPos += m_mouseEvents[ index ].wheelPos;
 
 	// Check Left Mouse State
-	if( m_mouseEvents[ index ].leftButtonStateChanged )
+	if( m_mouseEvents[ index ].leftStateChanged )
 	{
 		if( m_currMouse.leftState != m_mouseEvents[ index ].leftState )
 		{
@@ -228,21 +228,21 @@ void Mouse::processMouseEvent( Int index )
 				// Mouse Down
 				m_currMouse.leftEvent = GWM_LEFT_DOWN;
 				m_currMouse.leftState = MBS_Down;
-				m_currMouse.leftButtonStateChanged = TRUE;
+				m_currMouse.leftStateChanged = TRUE;
 			}
 			else if ( m_mouseEvents[ index ].leftState == MBS_DoubleClick )
 			{
 				// Mouse Double Click
 				m_currMouse.leftEvent = GWM_LEFT_DOUBLE_CLICK;
 				m_currMouse.leftState = MBS_DoubleClick;
-				m_currMouse.leftButtonStateChanged = TRUE;
+				m_currMouse.leftStateChanged = TRUE;
 			}
 			else
 			{
 				// Mouse Up
 				m_currMouse.leftEvent = GWM_LEFT_UP;
 				m_currMouse.leftState = MBS_Up;
-				m_currMouse.leftButtonStateChanged = TRUE;
+				m_currMouse.leftStateChanged = TRUE;
 			}
 		}
 	}
@@ -254,7 +254,7 @@ void Mouse::processMouseEvent( Int index )
 	}
 
 	// Check Right Mouse State
-	if( m_mouseEvents[ index ].rightButtonStateChanged )
+	if( m_mouseEvents[ index ].rightStateChanged )
 	{
 		if( m_currMouse.rightState != m_mouseEvents[ index ].rightState )
 		{
@@ -264,21 +264,21 @@ void Mouse::processMouseEvent( Int index )
 				// Mouse Down
 				m_currMouse.rightEvent = GWM_RIGHT_DOWN;
 				m_currMouse.rightState = MBS_Down;
-				m_currMouse.rightButtonStateChanged = TRUE;
+				m_currMouse.rightStateChanged = TRUE;
 			}
 			else if( m_mouseEvents[ index ].rightState == MBS_DoubleClick )
 			{
 				// Mouse Double Click
 				m_currMouse.rightEvent = GWM_RIGHT_DOUBLE_CLICK;
 				m_currMouse.rightState = MBS_DoubleClick;
-				m_currMouse.rightButtonStateChanged = TRUE;
+				m_currMouse.rightStateChanged = TRUE;
 			}
 			else
 			{
 				// Mouse Up
 				m_currMouse.rightEvent = GWM_RIGHT_UP;
 				m_currMouse.rightState = MBS_Up;
-				m_currMouse.rightButtonStateChanged = TRUE;
+				m_currMouse.rightStateChanged = TRUE;
 			}
 		}
 	}
@@ -290,7 +290,7 @@ void Mouse::processMouseEvent( Int index )
 	}
 
 	// Check Middle Mouse State
-	if( m_mouseEvents[ index ].middleButtonStateChanged )
+	if( m_mouseEvents[ index ].middleStateChanged )
 	{
 		if( m_currMouse.middleState != m_mouseEvents[index].middleState )
 		{
@@ -299,20 +299,20 @@ void Mouse::processMouseEvent( Int index )
 			{
 				m_currMouse.middleEvent = GWM_MIDDLE_DOWN;
 				m_currMouse.middleState = MBS_Down;
-				m_currMouse.middleButtonStateChanged = TRUE;
+				m_currMouse.middleStateChanged = TRUE;
 			}
 			else if( m_mouseEvents[index].middleState == MBS_DoubleClick )
 			{
 				m_currMouse.middleEvent = GWM_MIDDLE_DOUBLE_CLICK;
 				m_currMouse.middleState = MBS_DoubleClick;
-				m_currMouse.middleButtonStateChanged = TRUE;
+				m_currMouse.middleStateChanged = TRUE;
 			}
 			else
 			{
 				// Mouse Up
 				m_currMouse.middleEvent = GWM_MIDDLE_UP;
 				m_currMouse.middleState = MBS_Up;
-				m_currMouse.middleButtonStateChanged = TRUE;
+				m_currMouse.middleStateChanged = TRUE;
 			}
 		}
 	}

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
@@ -137,7 +137,7 @@ LookAtTranslator::LookAtTranslator() :
 	m_isRotating(false),
 	m_isPitching(false),
 	m_isChangingFOV(false),
-	m_middleButtonDownTimeMS(0),
+	m_middleButtonDownTimeMsec(0),
 	m_lastPlaneID(INVALID_DRAWABLE_ID),
 	m_lastMouseMoveFrame(0),
 	m_scrollType(SCROLL_NONE)
@@ -291,7 +291,7 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 			m_anchorAngle = TheTacticalView->getAngle();
 			m_originalAnchor = msg->getArgument( 0 )->pixel;
 			m_currentPos = msg->getArgument( 0 )->pixel;
-			m_middleButtonDownTimeMS = timeGetTime();
+			m_middleButtonDownTimeMsec = timeGetTime();
 			break;
 		}
 
@@ -300,7 +300,7 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 		{
 			m_lastMouseMoveFrame = TheGameLogic->getFrame();
 
-			const UnsignedInt CLICK_DURATION_MS = 167;
+			const UnsignedInt CLICK_DURATION_MSEC = 167;
 			const UnsignedInt PIXEL_OFFSET = 5;
 
 			m_isRotating = false;
@@ -309,7 +309,7 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 			Int dy = m_currentPos.y-m_originalAnchor.y;
 			Bool didMove = dx>PIXEL_OFFSET || dy>PIXEL_OFFSET;
 			// if middle button is "clicked", reset to "home" orientation
-			if (!didMove && timeGetTime() - m_middleButtonDownTimeMS < CLICK_DURATION_MS)
+			if (!didMove && timeGetTime() - m_middleButtonDownTimeMsec < CLICK_DURATION_MSEC)
 			{
 				TheTacticalView->setAngleAndPitchToDefault();
 				TheTacticalView->setZoomToDefault();

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
@@ -288,21 +288,23 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 		//-----------------------------------------------------------------------------
 		case GameMessage::MSG_RAW_MOUSE_MIDDLE_BUTTON_DOWN:
 		{
-			m_lastMouseMoveTimeMsec = timeGetTime();
+			UnsignedInt now = timeGetTime();
+			m_lastMouseMoveTimeMsec = now;
 
 			m_isRotating = true;
 			m_anchor = msg->getArgument( 0 )->pixel;
 			m_anchorAngle = TheTacticalView->getAngle();
 			m_originalAnchor = msg->getArgument( 0 )->pixel;
 			m_currentPos = msg->getArgument( 0 )->pixel;
-			m_middleButtonDownTimeMsec = timeGetTime();
+			m_middleButtonDownTimeMsec = now;
 			break;
 		}
 
 		//-----------------------------------------------------------------------------
 		case GameMessage::MSG_RAW_MOUSE_MIDDLE_BUTTON_UP:
 		{
-			m_lastMouseMoveTimeMsec = timeGetTime();
+			UnsignedInt now = timeGetTime();
+			m_lastMouseMoveTimeMsec = now;
 
 			const UnsignedInt CLICK_DURATION_MSEC = 167;
 			const UnsignedInt PIXEL_OFFSET = 5;
@@ -313,7 +315,7 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 			Int dy = m_currentPos.y-m_originalAnchor.y;
 			Bool didMove = dx>PIXEL_OFFSET || dy>PIXEL_OFFSET;
 			// if middle button is "clicked", reset to "home" orientation
-			if (!didMove && timeGetTime() - m_middleButtonDownTimeMsec < CLICK_DURATION_MSEC)
+			if (!didMove && now - m_middleButtonDownTimeMsec < CLICK_DURATION_MSEC)
 			{
 				TheTacticalView->setAngleAndPitchToDefault();
 				TheTacticalView->setZoomToDefault();

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
@@ -171,14 +171,13 @@ const ICoord2D* LookAtTranslator::getRMBScrollAnchor(void)
 
 Bool LookAtTranslator::hasMouseMovedRecently( void )
 {
-	const UnsignedInt ONE_SECOND_MSEC = 1000;
 	UnsignedInt now = timeGetTime();
 
 	// Handle time wraparound
 	if (now < m_lastMouseMoveTimeMsec)
 		m_lastMouseMoveTimeMsec = now;
 
-	if (now - m_lastMouseMoveTimeMsec > ONE_SECOND_MSEC)
+	if (now - m_lastMouseMoveTimeMsec > MSEC_PER_SECOND)
 		return false;
 
 	return true;
@@ -288,22 +287,22 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 		//-----------------------------------------------------------------------------
 		case GameMessage::MSG_RAW_MOUSE_MIDDLE_BUTTON_DOWN:
 		{
-			UnsignedInt now = timeGetTime();
+			const UnsignedInt now = timeGetTime();
 			m_lastMouseMoveTimeMsec = now;
+			m_middleButtonDownTimeMsec = now;
 
 			m_isRotating = true;
 			m_anchor = msg->getArgument( 0 )->pixel;
 			m_anchorAngle = TheTacticalView->getAngle();
 			m_originalAnchor = msg->getArgument( 0 )->pixel;
 			m_currentPos = msg->getArgument( 0 )->pixel;
-			m_middleButtonDownTimeMsec = now;
 			break;
 		}
 
 		//-----------------------------------------------------------------------------
 		case GameMessage::MSG_RAW_MOUSE_MIDDLE_BUTTON_UP:
 		{
-			UnsignedInt now = timeGetTime();
+			const UnsignedInt now = timeGetTime();
 			m_lastMouseMoveTimeMsec = now;
 
 			const UnsignedInt CLICK_DURATION_MSEC = 167;

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
@@ -282,8 +282,8 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 			{
 				stopScrolling();
 			}
-		break;
-	}
+			break;
+		}
 
 		//-----------------------------------------------------------------------------
 		case GameMessage::MSG_RAW_MOUSE_MIDDLE_BUTTON_DOWN:

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
@@ -171,16 +171,12 @@ const ICoord2D* LookAtTranslator::getRMBScrollAnchor(void)
 
 Bool LookAtTranslator::hasMouseMovedRecently( void )
 {
-	UnsignedInt now = timeGetTime();
+	const UnsignedInt now = timeGetTime();
+	const UnsignedInt lastMove = m_lastMouseMoveTimeMsec;
 
-	// Handle time wraparound
-	if (now < m_lastMouseMoveTimeMsec)
-		m_lastMouseMoveTimeMsec = now;
+	const UnsignedInt elapsedMsec = now - lastMove;
 
-	if (now - m_lastMouseMoveTimeMsec > MSEC_PER_SECOND)
-		return false;
-
-	return true;
+	return elapsedMsec <= MSEC_PER_SECOND;
 }
 
 void LookAtTranslator::setCurrentPos( const ICoord2D& pos )
@@ -313,8 +309,11 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 			if (dx<0) dx = -dx;
 			Int dy = m_currentPos.y-m_originalAnchor.y;
 			Bool didMove = dx>PIXEL_OFFSET || dy>PIXEL_OFFSET;
+
+			const UnsignedInt elapsedMsec = now - m_middleButtonDownTimeMsec;
+
 			// if middle button is "clicked", reset to "home" orientation
-			if (!didMove && now - m_middleButtonDownTimeMsec < CLICK_DURATION_MSEC)
+			if (!didMove && elapsedMsec < CLICK_DURATION_MSEC)
 			{
 				TheTacticalView->setAngleAndPitchToDefault();
 				TheTacticalView->setZoomToDefault();

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
@@ -137,7 +137,7 @@ LookAtTranslator::LookAtTranslator() :
 	m_isRotating(false),
 	m_isPitching(false),
 	m_isChangingFOV(false),
-	m_timestamp(0),
+	m_middleButtonDownTimeMS(0),
 	m_lastPlaneID(INVALID_DRAWABLE_ID),
 	m_lastMouseMoveFrame(0),
 	m_scrollType(SCROLL_NONE)
@@ -278,8 +278,8 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 			{
 				stopScrolling();
 			}
-			break;
-		}
+		break;
+	}
 
 		//-----------------------------------------------------------------------------
 		case GameMessage::MSG_RAW_MOUSE_MIDDLE_BUTTON_DOWN:
@@ -291,7 +291,7 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 			m_anchorAngle = TheTacticalView->getAngle();
 			m_originalAnchor = msg->getArgument( 0 )->pixel;
 			m_currentPos = msg->getArgument( 0 )->pixel;
-			m_timestamp = TheGameClient->getFrame();
+			m_middleButtonDownTimeMS = timeGetTime();
 			break;
 		}
 
@@ -300,7 +300,7 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 		{
 			m_lastMouseMoveFrame = TheGameLogic->getFrame();
 
-			const UnsignedInt CLICK_DURATION = 5;
+			const UnsignedInt CLICK_DURATION_MS = 167;
 			const UnsignedInt PIXEL_OFFSET = 5;
 
 			m_isRotating = false;
@@ -309,7 +309,7 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 			Int dy = m_currentPos.y-m_originalAnchor.y;
 			Bool didMove = dx>PIXEL_OFFSET || dy>PIXEL_OFFSET;
 			// if middle button is "clicked", reset to "home" orientation
-			if (!didMove && TheGameClient->getFrame() - m_timestamp < CLICK_DURATION)
+			if (!didMove && timeGetTime() - m_middleButtonDownTimeMS < CLICK_DURATION_MS)
 			{
 				TheTacticalView->setAngleAndPitchToDefault();
 				TheTacticalView->setZoomToDefault();

--- a/Generals/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIKeyboard.cpp
+++ b/Generals/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIKeyboard.cpp
@@ -251,7 +251,6 @@ void DirectInputKeyboard::getKey( KeyboardIO *key )
 	HRESULT hr;
 
 	assert( key );
-	key->sequence = 0;
 	key->key = KEY_NONE;
 
 	if( m_pKeyboardDevice )
@@ -314,9 +313,6 @@ void DirectInputKeyboard::getKey( KeyboardIO *key )
 
 		// set the key
 		key->key = (UnsignedByte)(kbdat.dwOfs & 0xFF);
-
-		// sequence
-		key->sequence = kbdat.dwSequence;
 
 		//
 		// state of key, note we are setting the key state here with an assignment

--- a/Generals/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIKeyboard.cpp
+++ b/Generals/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIKeyboard.cpp
@@ -319,7 +319,15 @@ void DirectInputKeyboard::getKey( KeyboardIO *key )
 		// and not a bit set of the up/down state, this is the "start"
 		// of building this "key"
 		//
-		key->state = (( kbdat.dwData & 0x0080 ) ? KEY_STATE_DOWN : KEY_STATE_UP);
+		if( kbdat.dwData & 0x0080 )
+		{
+			key->state = KEY_STATE_DOWN;
+			key->keyDownTimeMsec = kbdat.dwTimeStamp;
+		}
+		else
+		{
+			key->state = KEY_STATE_UP;
+		}
 
 		// set status as unused (unprocessed)
 		key->status = KeyboardIO::STATUS_UNUSED;

--- a/Generals/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIMouse.cpp
+++ b/Generals/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIMouse.cpp
@@ -202,7 +202,7 @@ UnsignedByte DirectInputMouse::getMouseEvent( MouseIO *result, Bool flush )
 
 	/* set these to defaults */
 	result->leftState = result->middleState = result->rightState = FALSE;
-	result->leftFrame = result->middleFrame = result->rightFrame = 0;
+	result->leftButtonStateChanged = result->middleButtonStateChanged = result->rightButtonStateChanged = FALSE;
 	result->pos.x = result->pos.y = result->wheelPos = 0;
 
 	if( m_pMouseDevice )
@@ -283,17 +283,17 @@ void DirectInputMouse::mapDirectInputMouse( MouseIO *mouse,
 	{
 		case DIMOFS_BUTTON0:
 			mouse->leftState = (( mdat->dwData & 0x0080 ) ? TRUE : FALSE);
-			mouse->leftFrame = mdat->dwSequence;
+			mouse->leftButtonStateChanged = TRUE;
 			break;
 
 		case DIMOFS_BUTTON1:
 			mouse->rightState = (( mdat->dwData & 0x0080 ) ? TRUE : FALSE);
-			mouse->rightFrame = mdat->dwSequence;
+			mouse->rightButtonStateChanged = TRUE;
 			break;
 
 		case DIMOFS_BUTTON2:
 			mouse->middleState = (( mdat->dwData & 0x0080 ) ? TRUE : FALSE);
-			mouse->middleFrame = mdat->dwSequence;
+			mouse->middleButtonStateChanged = TRUE;
 			break;
 
 		case DIMOFS_BUTTON3:

--- a/Generals/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIMouse.cpp
+++ b/Generals/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIMouse.cpp
@@ -202,7 +202,7 @@ UnsignedByte DirectInputMouse::getMouseEvent( MouseIO *result, Bool flush )
 
 	/* set these to defaults */
 	result->leftState = result->middleState = result->rightState = FALSE;
-	result->leftStateChanged = result->middleStateChanged = result->rightStateChanged = FALSE;
+	result->leftState = result->middleState = result->rightState = MBS_None;
 	result->pos.x = result->pos.y = result->wheelPos = 0;
 
 	if( m_pMouseDevice )
@@ -282,18 +282,15 @@ void DirectInputMouse::mapDirectInputMouse( MouseIO *mouse,
 	switch( mdat->dwOfs )
 	{
 		case DIMOFS_BUTTON0:
-			mouse->leftState = (( mdat->dwData & 0x0080 ) ? TRUE : FALSE);
-			mouse->leftStateChanged = TRUE;
+			mouse->leftState = (( mdat->dwData & 0x0080 ) ? MBS_Down : MBS_Up);
 			break;
 
 		case DIMOFS_BUTTON1:
-			mouse->rightState = (( mdat->dwData & 0x0080 ) ? TRUE : FALSE);
-			mouse->rightStateChanged = TRUE;
+			mouse->rightState = (( mdat->dwData & 0x0080 ) ? MBS_Down : MBS_Up);
 			break;
 
 		case DIMOFS_BUTTON2:
-			mouse->middleState = (( mdat->dwData & 0x0080 ) ? TRUE : FALSE);
-			mouse->middleStateChanged = TRUE;
+			mouse->middleState = (( mdat->dwData & 0x0080 ) ? MBS_Down : MBS_Up);
 			break;
 
 		case DIMOFS_BUTTON3:

--- a/Generals/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIMouse.cpp
+++ b/Generals/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIMouse.cpp
@@ -202,7 +202,7 @@ UnsignedByte DirectInputMouse::getMouseEvent( MouseIO *result, Bool flush )
 
 	/* set these to defaults */
 	result->leftState = result->middleState = result->rightState = FALSE;
-	result->leftButtonStateChanged = result->middleButtonStateChanged = result->rightButtonStateChanged = FALSE;
+	result->leftStateChanged = result->middleStateChanged = result->rightStateChanged = FALSE;
 	result->pos.x = result->pos.y = result->wheelPos = 0;
 
 	if( m_pMouseDevice )
@@ -283,17 +283,17 @@ void DirectInputMouse::mapDirectInputMouse( MouseIO *mouse,
 	{
 		case DIMOFS_BUTTON0:
 			mouse->leftState = (( mdat->dwData & 0x0080 ) ? TRUE : FALSE);
-			mouse->leftButtonStateChanged = TRUE;
+			mouse->leftStateChanged = TRUE;
 			break;
 
 		case DIMOFS_BUTTON1:
 			mouse->rightState = (( mdat->dwData & 0x0080 ) ? TRUE : FALSE);
-			mouse->rightButtonStateChanged = TRUE;
+			mouse->rightStateChanged = TRUE;
 			break;
 
 		case DIMOFS_BUTTON2:
 			mouse->middleState = (( mdat->dwData & 0x0080 ) ? TRUE : FALSE);
-			mouse->middleButtonStateChanged = TRUE;
+			mouse->middleStateChanged = TRUE;
 			break;
 
 		case DIMOFS_BUTTON3:

--- a/Generals/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32Mouse.cpp
+++ b/Generals/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32Mouse.cpp
@@ -85,21 +85,10 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 	UINT msg = m_eventBuffer[ eventIndex ].msg;
 	WPARAM wParam = m_eventBuffer[ eventIndex ].wParam;
 	LPARAM lParam = m_eventBuffer[ eventIndex ].lParam;
-	UnsignedInt frame;
-
-	//
-	// get the current input frame from the client, if we don't have
-	// a client (like in the GUI editor) we just use frame 1 so it
-	// registers with the system
-	//
-	if( TheGameClient )
-		frame = TheGameClient->getFrame();
-	else
-		frame = 1;
 
 	// set these to defaults
 	result->leftState = result->middleState = result->rightState = MBS_Up;
-	result->leftFrame = result->middleFrame = result->rightFrame = 0;
+	result->leftButtonStateChanged = result->middleButtonStateChanged = result->rightButtonStateChanged = FALSE;
 	result->pos.x = result->pos.y = result->wheelPos = 0;
 
 	// Time is the same for all events
@@ -113,7 +102,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->leftState = MBS_Down;
-			result->leftFrame = frame;
+			result->leftButtonStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -125,7 +114,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->leftState = MBS_Up;
-			result->leftFrame = frame;
+			result->leftButtonStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -137,7 +126,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->leftState = MBS_DoubleClick;
-			result->leftFrame = frame;
+			result->leftButtonStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -149,7 +138,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->middleState = MBS_Down;
-			result->middleFrame = frame;
+			result->middleButtonStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -161,7 +150,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->middleState = MBS_Up;
-			result->middleFrame = frame;
+			result->middleButtonStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -173,7 +162,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->middleState = MBS_DoubleClick;
-			result->middleFrame = frame;
+			result->middleButtonStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -185,7 +174,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->rightState = MBS_Down;
-			result->rightFrame = frame;
+			result->rightButtonStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -197,7 +186,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->rightState = MBS_Up;
-			result->rightFrame = frame;
+			result->rightButtonStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -209,7 +198,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->rightState = MBS_DoubleClick;
-			result->rightFrame = frame;
+			result->rightButtonStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;

--- a/Generals/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32Mouse.cpp
+++ b/Generals/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32Mouse.cpp
@@ -87,8 +87,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 	LPARAM lParam = m_eventBuffer[ eventIndex ].lParam;
 
 	// set these to defaults
-	result->leftState = result->middleState = result->rightState = MBS_Up;
-	result->leftStateChanged = result->middleStateChanged = result->rightStateChanged = FALSE;
+	result->leftState = result->middleState = result->rightState = MBS_None;
 	result->pos.x = result->pos.y = result->wheelPos = 0;
 
 	// Time is the same for all events
@@ -102,7 +101,6 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->leftState = MBS_Down;
-			result->leftStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -114,7 +112,6 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->leftState = MBS_Up;
-			result->leftStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -126,7 +123,6 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->leftState = MBS_DoubleClick;
-			result->leftStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -138,7 +134,6 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->middleState = MBS_Down;
-			result->middleStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -150,7 +145,6 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->middleState = MBS_Up;
-			result->middleStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -162,7 +156,6 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->middleState = MBS_DoubleClick;
-			result->middleStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -174,7 +167,6 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->rightState = MBS_Down;
-			result->rightStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -186,7 +178,6 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->rightState = MBS_Up;
-			result->rightStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -198,7 +189,6 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->rightState = MBS_DoubleClick;
-			result->rightStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;

--- a/Generals/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32Mouse.cpp
+++ b/Generals/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32Mouse.cpp
@@ -88,7 +88,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 
 	// set these to defaults
 	result->leftState = result->middleState = result->rightState = MBS_Up;
-	result->leftButtonStateChanged = result->middleButtonStateChanged = result->rightButtonStateChanged = FALSE;
+	result->leftStateChanged = result->middleStateChanged = result->rightStateChanged = FALSE;
 	result->pos.x = result->pos.y = result->wheelPos = 0;
 
 	// Time is the same for all events
@@ -102,7 +102,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->leftState = MBS_Down;
-			result->leftButtonStateChanged = TRUE;
+			result->leftStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -114,7 +114,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->leftState = MBS_Up;
-			result->leftButtonStateChanged = TRUE;
+			result->leftStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -126,7 +126,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->leftState = MBS_DoubleClick;
-			result->leftButtonStateChanged = TRUE;
+			result->leftStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -138,7 +138,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->middleState = MBS_Down;
-			result->middleButtonStateChanged = TRUE;
+			result->middleStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -150,7 +150,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->middleState = MBS_Up;
-			result->middleButtonStateChanged = TRUE;
+			result->middleStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -162,7 +162,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->middleState = MBS_DoubleClick;
-			result->middleButtonStateChanged = TRUE;
+			result->middleStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -174,7 +174,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->rightState = MBS_Down;
-			result->rightButtonStateChanged = TRUE;
+			result->rightStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -186,7 +186,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->rightState = MBS_Up;
-			result->rightButtonStateChanged = TRUE;
+			result->rightStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -198,7 +198,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->rightState = MBS_DoubleClick;
-			result->rightButtonStateChanged = TRUE;
+			result->rightStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Keyboard.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Keyboard.h
@@ -77,7 +77,7 @@ struct KeyboardIO
 	UnsignedByte	status;									// StatusType, above
 	UnsignedShort	state;									// KEY_STATE_* in KeyDefs.h
 	UnsignedInt		sequence;								// sequence info from DirectX used for order
-	UnsignedInt		keyDownTimeMS;					// real-time in milliseconds when key went down
+	UnsignedInt		keyDownTimeMsec;				// real-time in milliseconds when key went down
 
 };
 
@@ -87,7 +87,7 @@ struct KeyboardIO
 class Keyboard : public SubsystemInterface
 {
 
-	enum { KEY_REPEAT_DELAY_MS = 250 };
+	enum { KEY_REPEAT_DELAY_MSEC = 250 };
 
 public:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Keyboard.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Keyboard.h
@@ -86,7 +86,7 @@ struct KeyboardIO
 class Keyboard : public SubsystemInterface
 {
 
-	enum { KEY_REPEAT_DELAY_MSEC = 333 };
+	enum { KEY_REPEAT_DELAY_MSEC = 333, KEY_REPEAT_INTERVAL_MSEC = 67 }; // ~2 frames at 30 FPS
 
 public:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Keyboard.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Keyboard.h
@@ -87,7 +87,7 @@ struct KeyboardIO
 class Keyboard : public SubsystemInterface
 {
 
-	enum { KEY_REPEAT_DELAY_MS = 333 };
+	enum { KEY_REPEAT_DELAY_MS = 250 };
 
 public:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Keyboard.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Keyboard.h
@@ -86,7 +86,11 @@ struct KeyboardIO
 class Keyboard : public SubsystemInterface
 {
 
-	enum { KEY_REPEAT_DELAY_MSEC = 333, KEY_REPEAT_INTERVAL_MSEC = 67 }; // ~2 frames at 30 FPS
+	enum
+	{
+		KEY_REPEAT_DELAY_MSEC = 333,
+		KEY_REPEAT_INTERVAL_MSEC = 67
+	}; // ~2 frames at 30 FPS
 
 public:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Keyboard.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Keyboard.h
@@ -88,9 +88,9 @@ class Keyboard : public SubsystemInterface
 
 	enum
 	{
-		KEY_REPEAT_DELAY_MSEC = 333,
-		KEY_REPEAT_INTERVAL_MSEC = 67
-	}; // ~2 frames at 30 FPS
+		KEY_REPEAT_DELAY_MSEC = 333,	// 10 frames at 30 FPS
+		KEY_REPEAT_INTERVAL_MSEC = 67	// ~2 frames at 30 FPS
+	};
 
 public:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Keyboard.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Keyboard.h
@@ -77,6 +77,7 @@ struct KeyboardIO
 	UnsignedByte	status;									// StatusType, above
 	UnsignedShort	state;									// KEY_STATE_* in KeyDefs.h
 	UnsignedInt		sequence;								// sequence info from DirectX used for order
+	UnsignedInt		keyDownTimeMS;					// real-time in milliseconds when key went down
 
 };
 
@@ -86,7 +87,7 @@ struct KeyboardIO
 class Keyboard : public SubsystemInterface
 {
 
-	enum { KEY_REPEAT_DELAY = 10 };
+	enum { KEY_REPEAT_DELAY_MS = 333 };
 
 public:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Keyboard.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Keyboard.h
@@ -87,7 +87,7 @@ struct KeyboardIO
 class Keyboard : public SubsystemInterface
 {
 
-	enum { KEY_REPEAT_DELAY_MSEC = 250 };
+	enum { KEY_REPEAT_DELAY_MSEC = 333 };
 
 public:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Keyboard.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Keyboard.h
@@ -160,7 +160,6 @@ protected:
 		WideChar shifted2;
 
 	} m_keyNames[ KEY_COUNT ];
-	UnsignedInt m_inputFrame;  ///< frame input was gathered on
 
 };
 

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Keyboard.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Keyboard.h
@@ -76,7 +76,6 @@ struct KeyboardIO
 	UnsignedByte	key;										// KeyDefType, key data
 	UnsignedByte	status;									// StatusType, above
 	UnsignedShort	state;									// KEY_STATE_* in KeyDefs.h
-	UnsignedInt		sequence;								// DirectInput sequence number; overwritten with frame number for ordering
 	UnsignedInt		keyDownTimeMsec;				// real-time in milliseconds when key went down
 
 };
@@ -134,7 +133,6 @@ protected:
 	Bool checkKeyRepeat( void );  ///< check for repeating keys
 	UnsignedByte getKeyStatusData( KeyDefType key );  ///< get key status
 	Bool getKeyStateBit( KeyDefType key, Int bit );  ///< get key state bit
-	UnsignedInt getKeySequenceData( KeyDefType key );  ///< get key sequence
 	void setKeyStateData( KeyDefType key, UnsignedByte data );  ///< get key state
 
 	UnsignedShort m_modifiers;

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Keyboard.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Keyboard.h
@@ -76,7 +76,7 @@ struct KeyboardIO
 	UnsignedByte	key;										// KeyDefType, key data
 	UnsignedByte	status;									// StatusType, above
 	UnsignedShort	state;									// KEY_STATE_* in KeyDefs.h
-	UnsignedInt		sequence;								// sequence info from DirectX used for order
+	UnsignedInt		sequence;								// DirectInput sequence number; overwritten with frame number for ordering
 	UnsignedInt		keyDownTimeMsec;				// real-time in milliseconds when key went down
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/LookAtXlat.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/LookAtXlat.h
@@ -76,7 +76,7 @@ private:
 	Bool m_isRotating;					// set to true if we are in the act of MMB rotating
 	Bool m_isPitching;					// set to true if we are in the act of ALT pitch rotation
 	Bool m_isChangingFOV;			// set to true if we are in the act of changing the field of view
-	UnsignedInt m_middleButtonDownTimeMS;				// real-time in milliseconds when middle button goes down
+	UnsignedInt m_middleButtonDownTimeMsec;				// real-time in milliseconds when middle button goes down
 	DrawableID m_lastPlaneID;
 	ViewLocation m_viewLocation[ MAX_VIEW_LOCS ];
 	ScrollType m_scrollType;

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/LookAtXlat.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/LookAtXlat.h
@@ -81,7 +81,7 @@ private:
 	ViewLocation m_viewLocation[ MAX_VIEW_LOCS ];
 	ScrollType m_scrollType;
 	ScreenEdgeScrollMode m_screenEdgeScrollMode;
-	UnsignedInt m_lastMouseMoveFrame;
+	UnsignedInt m_lastMouseMoveTimeMsec;				// real-time in milliseconds when mouse last moved
 
 	void setScrolling( ScrollType scrollType );
 	void stopScrolling( void );

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/LookAtXlat.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/LookAtXlat.h
@@ -76,7 +76,7 @@ private:
 	Bool m_isRotating;					// set to true if we are in the act of MMB rotating
 	Bool m_isPitching;					// set to true if we are in the act of ALT pitch rotation
 	Bool m_isChangingFOV;			// set to true if we are in the act of changing the field of view
-	UnsignedInt m_timestamp;				// set when button goes down
+	UnsignedInt m_middleButtonDownTimeMS;				// real-time in milliseconds when middle button goes down
 	DrawableID m_lastPlaneID;
 	ViewLocation m_viewLocation[ MAX_VIEW_LOCS ];
 	ScrollType m_scrollType;

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Mouse.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Mouse.h
@@ -107,15 +107,15 @@ struct MouseIO
 
 	MouseButtonState leftState;					// button state: Up, Down, DoubleClick (Which is also down)
 	Int leftEvent;											// Most important event this frame
-	Bool leftButtonStateChanged;					// TRUE if button state changed for a given mouse event
+	Bool leftStateChanged;					// TRUE if button state changed for a given mouse event
 
 	MouseButtonState rightState;
 	Int rightEvent;
-	Bool rightButtonStateChanged;					// TRUE if button state changed for a given mouse event
+	Bool rightStateChanged;					// TRUE if button state changed for a given mouse event
 
 	MouseButtonState middleState;
 	Int middleEvent;
-	Bool middleButtonStateChanged;					// TRUE if button state changed for a given mouse event
+	Bool middleStateChanged;					// TRUE if button state changed for a given mouse event
 };
 
 class CursorInfo

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Mouse.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Mouse.h
@@ -62,6 +62,7 @@ enum GameMode CPP_11(: Int);
 
 enum MouseButtonState CPP_11(: Int)
 {
+	MBS_None = -1,
 	MBS_Up = 0,
 	MBS_Down,
 	MBS_DoubleClick,
@@ -105,17 +106,14 @@ struct MouseIO
 								 user while - is down/toward user */
 	ICoord2D deltaPos;  ///< overall change in mouse pointer this frame
 
-	MouseButtonState leftState;					// button state: Up, Down, DoubleClick (Which is also down)
+	MouseButtonState leftState;					// button state: None (no event), Up, Down, DoubleClick
 	Int leftEvent;											// Most important event this frame
-	Bool leftStateChanged;					// TRUE if button state changed for a given mouse event
 
 	MouseButtonState rightState;
 	Int rightEvent;
-	Bool rightStateChanged;					// TRUE if button state changed for a given mouse event
 
 	MouseButtonState middleState;
 	Int middleEvent;
-	Bool middleStateChanged;					// TRUE if button state changed for a given mouse event
 };
 
 class CursorInfo

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Mouse.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Mouse.h
@@ -107,15 +107,15 @@ struct MouseIO
 
 	MouseButtonState leftState;					// button state: Up, Down, DoubleClick (Which is also down)
 	Int leftEvent;											// Most important event this frame
-	Bool leftButtonStateChanged;					// TRUE if button state changed in this event
+	Bool leftButtonStateChanged;					// TRUE if button state changed for a given mouse event
 
 	MouseButtonState rightState;
 	Int rightEvent;
-	Bool rightButtonStateChanged;					// TRUE if button state changed in this event
+	Bool rightButtonStateChanged;					// TRUE if button state changed for a given mouse event
 
 	MouseButtonState middleState;
 	Int middleEvent;
-	Bool middleButtonStateChanged;					// TRUE if button state changed in this event
+	Bool middleButtonStateChanged;					// TRUE if button state changed for a given mouse event
 };
 
 class CursorInfo

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Mouse.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Mouse.h
@@ -107,15 +107,15 @@ struct MouseIO
 
 	MouseButtonState leftState;					// button state: Up, Down, DoubleClick (Which is also down)
 	Int leftEvent;											// Most important event this frame
-	Int leftFrame;											// last frame button state changed
+	Bool leftButtonStateChanged;					// TRUE if button state changed in this event
 
 	MouseButtonState rightState;
 	Int rightEvent;
-	Int rightFrame;
+	Bool rightButtonStateChanged;					// TRUE if button state changed in this event
 
 	MouseButtonState middleState;
 	Int middleEvent;
-	Int middleFrame;
+	Bool middleButtonStateChanged;					// TRUE if button state changed in this event
 };
 
 class CursorInfo
@@ -393,9 +393,6 @@ protected:
 	Int m_maxX;							///< mouse is locked to this region
 	Int m_minY;							///< mouse is locked to this region
 	Int m_maxY;							///< mouse is locked to this region
-
-	UnsignedInt m_inputFrame;				///< frame input was gathered on
-	UnsignedInt m_deadInputFrame;		///< Frame which last input occured
 
 	Bool m_inputMovesAbsolute;			/**< if TRUE, when processing mouse position
 																	chanages the movement will be done treating

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
@@ -144,7 +144,7 @@ void Keyboard::updateKeys( void )
 		// Update key down time for new key presses
 		if( BitIsSet( m_keys[ index ].state, KEY_STATE_DOWN ) )
 		{
-			m_keyStatus[ m_keys[ index ].key ].keyDownTimeMsec = timeGetTime();
+			m_keyStatus[ m_keys[ index ].key ].keyDownTimeMsec = m_keys[ index ].keyDownTimeMsec;
 		}
 
 		// prevent ALT-TAB from causing a TAB event
@@ -200,7 +200,7 @@ void Keyboard::updateKeys( void )
 }
 
 //-------------------------------------------------------------------------------------------------
-/** check key repeat sequences, TRUE is returned if repeat is occurring */
+/** check key repeat timing, TRUE is returned if repeat is occurring */
 //-------------------------------------------------------------------------------------------------
 Bool Keyboard::checkKeyRepeat( void )
 {

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
@@ -130,9 +130,6 @@ void Keyboard::updateKeys( void )
 	}
 	while( m_keys[ index++ ].key != KEY_NONE );
 
-	// Get current time once for all key updates
-	UnsignedInt now = 0;
-
 	// update keyboard status array
 	index = 0;
 	while( m_keys[ index ].key != KEY_NONE )
@@ -147,9 +144,7 @@ void Keyboard::updateKeys( void )
 		// Update key down time for new key presses
 		if( BitIsSet( m_keys[ index ].state, KEY_STATE_DOWN ) )
 		{
-			if( !now )
-				now = timeGetTime();
-			m_keyStatus[ m_keys[ index ].key ].keyDownTimeMsec = now;
+			m_keyStatus[ m_keys[ index ].key ].keyDownTimeMsec = timeGetTime();
 		}
 
 		// prevent ALT-TAB from causing a TAB event
@@ -225,14 +220,13 @@ Bool Keyboard::checkKeyRepeat( void )
 	// Scan Keyboard status array for first key down
 	// long enough to repeat
 	const UnsignedInt KEY_REPEAT_INTERVAL_MSEC = 67; // ~2 frames at 30 FPS
-	UnsignedInt now = timeGetTime();
 	for( key = 0; key < ARRAY_SIZE(m_keyStatus); key++ )
 	{
 
 		if( BitIsSet( m_keyStatus[ key ].state, KEY_STATE_DOWN ) )
 		{
 
-			if( now - m_keyStatus[ key ].keyDownTimeMsec > Keyboard::KEY_REPEAT_DELAY_MSEC )
+			if( timeGetTime() - m_keyStatus[ key ].keyDownTimeMsec > Keyboard::KEY_REPEAT_DELAY_MSEC )
 			{
 				// Add key to this frame
 				m_keys[ index ].key = (UnsignedByte)key;
@@ -243,7 +237,7 @@ Bool Keyboard::checkKeyRepeat( void )
 				m_keys[ ++index ].key = KEY_NONE;
 
 				// Set repeated key so it will repeat again after the interval
-				m_keyStatus[ key ].keyDownTimeMsec = now - (Keyboard::KEY_REPEAT_DELAY_MSEC + KEY_REPEAT_INTERVAL_MSEC);
+				m_keyStatus[ key ].keyDownTimeMsec = timeGetTime() - (Keyboard::KEY_REPEAT_DELAY_MSEC + KEY_REPEAT_INTERVAL_MSEC);
 
 				retVal = TRUE;
 				break;  // exit for key

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
@@ -225,6 +225,7 @@ Bool Keyboard::checkKeyRepeat( void )
 
 	// Scan Keyboard status array for first key down
 	// long enough to repeat
+	const UnsignedInt KEY_REPEAT_INTERVAL_MSEC = 67; // ~2 frames at 30 FPS
 	UnsignedInt now = timeGetTime();
 	for( key = 0; key < ARRAY_SIZE(m_keyStatus); key++ )
 	{
@@ -246,8 +247,7 @@ Bool Keyboard::checkKeyRepeat( void )
 				for( index = 0; index< NUM_KEYS; index++ )
 					m_keyStatus[ index ].sequence = m_inputFrame;
 
-				// Set repeated key so it will repeat again after a short interval
-				const UnsignedInt KEY_REPEAT_INTERVAL_MSEC = 67; // ~2 frames at 30 FPS
+				// Set repeated key so it will repeat again after the interval
 				m_keyStatus[ key ].keyDownTimeMsec = now - (Keyboard::KEY_REPEAT_DELAY_MSEC - KEY_REPEAT_INTERVAL_MSEC);
 
 				retVal = TRUE;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
@@ -130,6 +130,9 @@ void Keyboard::updateKeys( void )
 	}
 	while( m_keys[ index++ ].key != KEY_NONE );
 
+	// Get current time once for all key updates
+	UnsignedInt now = 0;
+
 	// update keyboard status array
 	index = 0;
 	while( m_keys[ index ].key != KEY_NONE )
@@ -145,7 +148,9 @@ void Keyboard::updateKeys( void )
 		// Update key down time for new key presses
 		if( BitIsSet( m_keys[ index ].state, KEY_STATE_DOWN ) )
 		{
-			m_keyStatus[ m_keys[ index ].key ].keyDownTimeMS = timeGetTime();
+			if( !now )
+				now = timeGetTime();
+			m_keyStatus[ m_keys[ index ].key ].keyDownTimeMsec = now;
 		}
 
 		// prevent ALT-TAB from causing a TAB event
@@ -227,7 +232,7 @@ Bool Keyboard::checkKeyRepeat( void )
 		if( BitIsSet( m_keyStatus[ key ].state, KEY_STATE_DOWN ) )
 		{
 
-			if( now - m_keyStatus[ key ].keyDownTimeMS > Keyboard::KEY_REPEAT_DELAY_MS )
+			if( now - m_keyStatus[ key ].keyDownTimeMsec > Keyboard::KEY_REPEAT_DELAY_MSEC )
 			{
 				// Add key to this frame
 				m_keys[ index ].key = (UnsignedByte)key;
@@ -242,8 +247,8 @@ Bool Keyboard::checkKeyRepeat( void )
 					m_keyStatus[ index ].sequence = m_inputFrame;
 
 				// Set repeated key so it will repeat again after a short interval
-				const UnsignedInt KEY_REPEAT_INTERVAL_MS = 67; // ~2 frames at 30 FPS
-				m_keyStatus[ key ].keyDownTimeMS = now - (Keyboard::KEY_REPEAT_DELAY_MS - KEY_REPEAT_INTERVAL_MS);
+				const UnsignedInt KEY_REPEAT_INTERVAL_MSEC = 67; // ~2 frames at 30 FPS
+				m_keyStatus[ key ].keyDownTimeMsec = now - (Keyboard::KEY_REPEAT_DELAY_MSEC - KEY_REPEAT_INTERVAL_MSEC);
 
 				retVal = TRUE;
 				break;  // exit for key

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
@@ -219,7 +219,6 @@ Bool Keyboard::checkKeyRepeat( void )
 
 	// Scan Keyboard status array for first key down
 	// long enough to repeat
-	const UnsignedInt KEY_REPEAT_INTERVAL_MSEC = 67; // ~2 frames at 30 FPS
 	for( key = 0; key < ARRAY_SIZE(m_keyStatus); key++ )
 	{
 
@@ -243,7 +242,7 @@ Bool Keyboard::checkKeyRepeat( void )
 					m_keyStatus[ index ].keyDownTimeMsec = now;
 
 				// Set repeated key so it will repeat again after the interval
-				m_keyStatus[ key ].keyDownTimeMsec = now - (Keyboard::KEY_REPEAT_DELAY_MSEC + KEY_REPEAT_INTERVAL_MSEC);
+				m_keyStatus[ key ].keyDownTimeMsec = now - (Keyboard::KEY_REPEAT_DELAY_MSEC + Keyboard::KEY_REPEAT_INTERVAL_MSEC);
 
 				retVal = TRUE;
 				break;  // exit for key

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
@@ -225,9 +225,11 @@ Bool Keyboard::checkKeyRepeat( void )
 		if( BitIsSet( m_keyStatus[ key ].state, KEY_STATE_DOWN ) )
 		{
 
-			UnsignedInt now = timeGetTime();
+			const UnsignedInt now = timeGetTime();
+			const UnsignedInt keyDownTime = m_keyStatus[ key ].keyDownTimeMsec;
+			const UnsignedInt elapsedMsec = now - keyDownTime;
 
-			if( now - m_keyStatus[ key ].keyDownTimeMsec > Keyboard::KEY_REPEAT_DELAY_MSEC )
+			if( elapsedMsec > Keyboard::KEY_REPEAT_DELAY_MSEC )
 			{
 				// Add key to this frame
 				m_keys[ index ].key = (UnsignedByte)key;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
@@ -248,7 +248,7 @@ Bool Keyboard::checkKeyRepeat( void )
 					m_keyStatus[ index ].sequence = m_inputFrame;
 
 				// Set repeated key so it will repeat again after the interval
-				m_keyStatus[ key ].keyDownTimeMsec = now - (Keyboard::KEY_REPEAT_DELAY_MSEC - KEY_REPEAT_INTERVAL_MSEC);
+				m_keyStatus[ key ].keyDownTimeMsec = now - (Keyboard::KEY_REPEAT_DELAY_MSEC + KEY_REPEAT_INTERVAL_MSEC);
 
 				retVal = TRUE;
 				break;  // exit for key

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
@@ -143,7 +143,6 @@ void Keyboard::updateKeys( void )
 
 		m_keyStatus[ m_keys[ index ].key ].state = m_keys[ index ].state;
 		m_keyStatus[ m_keys[ index ].key ].status = m_keys[ index ].status;
-		m_keyStatus[ m_keys[ index ].key ].sequence = m_inputFrame;
 
 		// Update key down time for new key presses
 		if( BitIsSet( m_keys[ index ].state, KEY_STATE_DOWN ) )
@@ -242,10 +241,6 @@ Bool Keyboard::checkKeyRepeat( void )
 
 				// Set End Flag
 				m_keys[ ++index ].key = KEY_NONE;
-
-				// Set all keys as new to prevent multiple keys repeating
-				for( index = 0; index< NUM_KEYS; index++ )
-					m_keyStatus[ index ].sequence = m_inputFrame;
 
 				// Set repeated key so it will repeat again after the interval
 				m_keyStatus[ key ].keyDownTimeMsec = now - (Keyboard::KEY_REPEAT_DELAY_MSEC + KEY_REPEAT_INTERVAL_MSEC);
@@ -830,14 +825,6 @@ UnsignedByte Keyboard::getKeyStatusData( KeyDefType key )
 Bool Keyboard::getKeyStateBit( KeyDefType key, Int bit )
 {
 	return (m_keyStatus[ key ].state & bit) ? 1 : 0;
-}
-
-//-------------------------------------------------------------------------------------------------
-/** return the sequence data for the given key */
-//-------------------------------------------------------------------------------------------------
-UnsignedInt Keyboard::getKeySequenceData( KeyDefType key )
-{
-	return m_keyStatus[ key ].sequence;
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
@@ -701,7 +701,6 @@ Keyboard::Keyboard( void )
 	m_shift2Key = KEY_NONE;
 
 	memset( m_keyNames, 0, sizeof( m_keyNames ) );
-	m_inputFrame = 0;
 
 }
 
@@ -721,9 +720,6 @@ void Keyboard::init( void )
 	// initialize the key names
 	initKeyNames();
 
-	// first input frame
-	m_inputFrame = 0;
-
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -739,9 +735,6 @@ void Keyboard::reset( void )
 //-------------------------------------------------------------------------------------------------
 void Keyboard::update( void )
 {
-
-	// increment input frame
-	m_inputFrame++;
 
 	// update the key data
 	updateKeys();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
@@ -220,12 +220,13 @@ Bool Keyboard::checkKeyRepeat( void )
 	// Scan Keyboard status array for first key down
 	// long enough to repeat
 	const UnsignedInt KEY_REPEAT_INTERVAL_MSEC = 67; // ~2 frames at 30 FPS
-	UnsignedInt now = timeGetTime();
 	for( key = 0; key < ARRAY_SIZE(m_keyStatus); key++ )
 	{
 
 		if( BitIsSet( m_keyStatus[ key ].state, KEY_STATE_DOWN ) )
 		{
+
+			UnsignedInt now = timeGetTime();
 
 			if( now - m_keyStatus[ key ].keyDownTimeMsec > Keyboard::KEY_REPEAT_DELAY_MSEC )
 			{

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
@@ -220,13 +220,14 @@ Bool Keyboard::checkKeyRepeat( void )
 	// Scan Keyboard status array for first key down
 	// long enough to repeat
 	const UnsignedInt KEY_REPEAT_INTERVAL_MSEC = 67; // ~2 frames at 30 FPS
+	UnsignedInt now = timeGetTime();
 	for( key = 0; key < ARRAY_SIZE(m_keyStatus); key++ )
 	{
 
 		if( BitIsSet( m_keyStatus[ key ].state, KEY_STATE_DOWN ) )
 		{
 
-			if( timeGetTime() - m_keyStatus[ key ].keyDownTimeMsec > Keyboard::KEY_REPEAT_DELAY_MSEC )
+			if( now - m_keyStatus[ key ].keyDownTimeMsec > Keyboard::KEY_REPEAT_DELAY_MSEC )
 			{
 				// Add key to this frame
 				m_keys[ index ].key = (UnsignedByte)key;
@@ -236,8 +237,12 @@ Bool Keyboard::checkKeyRepeat( void )
 				// Set End Flag
 				m_keys[ ++index ].key = KEY_NONE;
 
+				// Set all keys as new to prevent multiple keys repeating
+				for( index = 0; index< NUM_KEYS; index++ )
+					m_keyStatus[ index ].keyDownTimeMsec = now;
+
 				// Set repeated key so it will repeat again after the interval
-				m_keyStatus[ key ].keyDownTimeMsec = timeGetTime() - (Keyboard::KEY_REPEAT_DELAY_MSEC + KEY_REPEAT_INTERVAL_MSEC);
+				m_keyStatus[ key ].keyDownTimeMsec = now - (Keyboard::KEY_REPEAT_DELAY_MSEC + KEY_REPEAT_INTERVAL_MSEC);
 
 				retVal = TRUE;
 				break;  // exit for key

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Mouse.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Mouse.cpp
@@ -218,7 +218,7 @@ void Mouse::processMouseEvent( Int index )
 	m_currMouse.wheelPos += m_mouseEvents[ index ].wheelPos;
 
 	// Check Left Mouse State
-	if( m_mouseEvents[ index ].leftStateChanged )
+	if( m_mouseEvents[ index ].leftState != MBS_None )
 	{
 		if( m_currMouse.leftState != m_mouseEvents[ index ].leftState )
 		{
@@ -228,21 +228,18 @@ void Mouse::processMouseEvent( Int index )
 				// Mouse Down
 				m_currMouse.leftEvent = GWM_LEFT_DOWN;
 				m_currMouse.leftState = MBS_Down;
-				m_currMouse.leftStateChanged = TRUE;
 			}
 			else if ( m_mouseEvents[ index ].leftState == MBS_DoubleClick )
 			{
 				// Mouse Double Click
 				m_currMouse.leftEvent = GWM_LEFT_DOUBLE_CLICK;
 				m_currMouse.leftState = MBS_DoubleClick;
-				m_currMouse.leftStateChanged = TRUE;
 			}
 			else
 			{
 				// Mouse Up
 				m_currMouse.leftEvent = GWM_LEFT_UP;
 				m_currMouse.leftState = MBS_Up;
-				m_currMouse.leftStateChanged = TRUE;
 			}
 		}
 	}
@@ -254,7 +251,7 @@ void Mouse::processMouseEvent( Int index )
 	}
 
 	// Check Right Mouse State
-	if( m_mouseEvents[ index ].rightStateChanged )
+	if( m_mouseEvents[ index ].rightState != MBS_None )
 	{
 		if( m_currMouse.rightState != m_mouseEvents[ index ].rightState )
 		{
@@ -264,21 +261,18 @@ void Mouse::processMouseEvent( Int index )
 				// Mouse Down
 				m_currMouse.rightEvent = GWM_RIGHT_DOWN;
 				m_currMouse.rightState = MBS_Down;
-				m_currMouse.rightStateChanged = TRUE;
 			}
 			else if( m_mouseEvents[ index ].rightState == MBS_DoubleClick )
 			{
 				// Mouse Double Click
 				m_currMouse.rightEvent = GWM_RIGHT_DOUBLE_CLICK;
 				m_currMouse.rightState = MBS_DoubleClick;
-				m_currMouse.rightStateChanged = TRUE;
 			}
 			else
 			{
 				// Mouse Up
 				m_currMouse.rightEvent = GWM_RIGHT_UP;
 				m_currMouse.rightState = MBS_Up;
-				m_currMouse.rightStateChanged = TRUE;
 			}
 		}
 	}
@@ -290,7 +284,7 @@ void Mouse::processMouseEvent( Int index )
 	}
 
 	// Check Middle Mouse State
-	if( m_mouseEvents[ index ].middleStateChanged )
+	if( m_mouseEvents[ index ].middleState != MBS_None )
 	{
 		if( m_currMouse.middleState != m_mouseEvents[index].middleState )
 		{
@@ -299,20 +293,17 @@ void Mouse::processMouseEvent( Int index )
 			{
 				m_currMouse.middleEvent = GWM_MIDDLE_DOWN;
 				m_currMouse.middleState = MBS_Down;
-				m_currMouse.middleStateChanged = TRUE;
 			}
 			else if( m_mouseEvents[index].middleState == MBS_DoubleClick )
 			{
 				m_currMouse.middleEvent = GWM_MIDDLE_DOUBLE_CLICK;
 				m_currMouse.middleState = MBS_DoubleClick;
-				m_currMouse.middleStateChanged = TRUE;
 			}
 			else
 			{
 				// Mouse Up
 				m_currMouse.middleEvent = GWM_MIDDLE_UP;
 				m_currMouse.middleState = MBS_Up;
-				m_currMouse.middleStateChanged = TRUE;
 			}
 		}
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Mouse.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Mouse.cpp
@@ -183,9 +183,6 @@ void Mouse::updateMouseData( )
 	else
 		m_eventsThisFrame = 0;
 
-	if( index != 0 )
-		m_deadInputFrame = m_inputFrame;
-
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -221,7 +218,7 @@ void Mouse::processMouseEvent( Int index )
 	m_currMouse.wheelPos += m_mouseEvents[ index ].wheelPos;
 
 	// Check Left Mouse State
-	if( m_mouseEvents[ index ].leftFrame )
+	if( m_mouseEvents[ index ].leftButtonStateChanged )
 	{
 		if( m_currMouse.leftState != m_mouseEvents[ index ].leftState )
 		{
@@ -231,21 +228,21 @@ void Mouse::processMouseEvent( Int index )
 				// Mouse Down
 				m_currMouse.leftEvent = GWM_LEFT_DOWN;
 				m_currMouse.leftState = MBS_Down;
-				m_currMouse.leftFrame = m_inputFrame;
+				m_currMouse.leftButtonStateChanged = TRUE;
 			}
 			else if ( m_mouseEvents[ index ].leftState == MBS_DoubleClick )
 			{
 				// Mouse Double Click
 				m_currMouse.leftEvent = GWM_LEFT_DOUBLE_CLICK;
 				m_currMouse.leftState = MBS_DoubleClick;
-				m_currMouse.leftFrame = m_inputFrame;
+				m_currMouse.leftButtonStateChanged = TRUE;
 			}
 			else
 			{
 				// Mouse Up
 				m_currMouse.leftEvent = GWM_LEFT_UP;
 				m_currMouse.leftState = MBS_Up;
-				m_currMouse.leftFrame = m_inputFrame;
+				m_currMouse.leftButtonStateChanged = TRUE;
 			}
 		}
 	}
@@ -257,7 +254,7 @@ void Mouse::processMouseEvent( Int index )
 	}
 
 	// Check Right Mouse State
-	if( m_mouseEvents[ index ].rightFrame )
+	if( m_mouseEvents[ index ].rightButtonStateChanged )
 	{
 		if( m_currMouse.rightState != m_mouseEvents[ index ].rightState )
 		{
@@ -267,21 +264,21 @@ void Mouse::processMouseEvent( Int index )
 				// Mouse Down
 				m_currMouse.rightEvent = GWM_RIGHT_DOWN;
 				m_currMouse.rightState = MBS_Down;
-				m_currMouse.rightFrame = m_inputFrame;
+				m_currMouse.rightButtonStateChanged = TRUE;
 			}
 			else if( m_mouseEvents[ index ].rightState == MBS_DoubleClick )
 			{
 				// Mouse Double Click
 				m_currMouse.rightEvent = GWM_RIGHT_DOUBLE_CLICK;
 				m_currMouse.rightState = MBS_DoubleClick;
-				m_currMouse.rightFrame = m_inputFrame;
+				m_currMouse.rightButtonStateChanged = TRUE;
 			}
 			else
 			{
 				// Mouse Up
 				m_currMouse.rightEvent = GWM_RIGHT_UP;
 				m_currMouse.rightState = MBS_Up;
-				m_currMouse.rightFrame = m_inputFrame;
+				m_currMouse.rightButtonStateChanged = TRUE;
 			}
 		}
 	}
@@ -293,7 +290,7 @@ void Mouse::processMouseEvent( Int index )
 	}
 
 	// Check Middle Mouse State
-	if( m_mouseEvents[ index ].middleFrame )
+	if( m_mouseEvents[ index ].middleButtonStateChanged )
 	{
 		if( m_currMouse.middleState != m_mouseEvents[index].middleState )
 		{
@@ -302,20 +299,20 @@ void Mouse::processMouseEvent( Int index )
 			{
 				m_currMouse.middleEvent = GWM_MIDDLE_DOWN;
 				m_currMouse.middleState = MBS_Down;
-				m_currMouse.middleFrame = m_inputFrame;
+				m_currMouse.middleButtonStateChanged = TRUE;
 			}
 			else if( m_mouseEvents[index].middleState == MBS_DoubleClick )
 			{
 				m_currMouse.middleEvent = GWM_MIDDLE_DOUBLE_CLICK;
 				m_currMouse.middleState = MBS_DoubleClick;
-				m_currMouse.middleFrame = m_inputFrame;
+				m_currMouse.middleButtonStateChanged = TRUE;
 			}
 			else
 			{
 				// Mouse Up
 				m_currMouse.middleEvent = GWM_MIDDLE_UP;
 				m_currMouse.middleState = MBS_Up;
-				m_currMouse.middleFrame = m_inputFrame;
+				m_currMouse.middleButtonStateChanged = TRUE;
 			}
 		}
 	}
@@ -328,7 +325,7 @@ void Mouse::processMouseEvent( Int index )
 
 	m_currMouse.deltaPos.x = m_currMouse.pos.x - m_prevMouse.pos.x;
 	m_currMouse.deltaPos.y = m_currMouse.pos.y - m_prevMouse.pos.y;
-//	DEBUG_LOG(("Mouse dx %d, dy %d, index %d, frame %d", m_currMouse.deltaPos.x, m_currMouse.deltaPos.y, index, m_inputFrame));
+//	DEBUG_LOG(("Mouse dx %d, dy %d, index %d", m_currMouse.deltaPos.x, m_currMouse.deltaPos.y, index));
 //	// check if mouse is still and flag tooltip
 //	if( ((dx*dx) + (dy*dy)) < CURSOR_MOVE_TOL_SQ )
 //	{
@@ -474,9 +471,6 @@ Mouse::Mouse( void )
 	m_maxY = 0;
 	m_eventsThisFrame = 0;
 
-	m_inputFrame = 0;
-	m_deadInputFrame =0;
-
 	m_inputMovesAbsolute = FALSE;
 
 	m_currentCursor = ARROW;
@@ -590,9 +584,6 @@ void Mouse::init( void )
 	m_minY = 0;
 	m_maxY = 599;
 
-	m_inputFrame = 0;
-	m_deadInputFrame =0;
-
 	m_inputMovesAbsolute = FALSE;
 	m_eventsThisFrame = 0;
 
@@ -675,9 +666,6 @@ void Mouse::reset( void )
 //-------------------------------------------------------------------------------------------------
 void Mouse::update( void )
 {
-
-	// increment input frame
-	m_inputFrame++;
 
 	// update the mouse data
 	updateMouseData( );

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Mouse.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Mouse.cpp
@@ -218,7 +218,7 @@ void Mouse::processMouseEvent( Int index )
 	m_currMouse.wheelPos += m_mouseEvents[ index ].wheelPos;
 
 	// Check Left Mouse State
-	if( m_mouseEvents[ index ].leftButtonStateChanged )
+	if( m_mouseEvents[ index ].leftStateChanged )
 	{
 		if( m_currMouse.leftState != m_mouseEvents[ index ].leftState )
 		{
@@ -228,21 +228,21 @@ void Mouse::processMouseEvent( Int index )
 				// Mouse Down
 				m_currMouse.leftEvent = GWM_LEFT_DOWN;
 				m_currMouse.leftState = MBS_Down;
-				m_currMouse.leftButtonStateChanged = TRUE;
+				m_currMouse.leftStateChanged = TRUE;
 			}
 			else if ( m_mouseEvents[ index ].leftState == MBS_DoubleClick )
 			{
 				// Mouse Double Click
 				m_currMouse.leftEvent = GWM_LEFT_DOUBLE_CLICK;
 				m_currMouse.leftState = MBS_DoubleClick;
-				m_currMouse.leftButtonStateChanged = TRUE;
+				m_currMouse.leftStateChanged = TRUE;
 			}
 			else
 			{
 				// Mouse Up
 				m_currMouse.leftEvent = GWM_LEFT_UP;
 				m_currMouse.leftState = MBS_Up;
-				m_currMouse.leftButtonStateChanged = TRUE;
+				m_currMouse.leftStateChanged = TRUE;
 			}
 		}
 	}
@@ -254,7 +254,7 @@ void Mouse::processMouseEvent( Int index )
 	}
 
 	// Check Right Mouse State
-	if( m_mouseEvents[ index ].rightButtonStateChanged )
+	if( m_mouseEvents[ index ].rightStateChanged )
 	{
 		if( m_currMouse.rightState != m_mouseEvents[ index ].rightState )
 		{
@@ -264,21 +264,21 @@ void Mouse::processMouseEvent( Int index )
 				// Mouse Down
 				m_currMouse.rightEvent = GWM_RIGHT_DOWN;
 				m_currMouse.rightState = MBS_Down;
-				m_currMouse.rightButtonStateChanged = TRUE;
+				m_currMouse.rightStateChanged = TRUE;
 			}
 			else if( m_mouseEvents[ index ].rightState == MBS_DoubleClick )
 			{
 				// Mouse Double Click
 				m_currMouse.rightEvent = GWM_RIGHT_DOUBLE_CLICK;
 				m_currMouse.rightState = MBS_DoubleClick;
-				m_currMouse.rightButtonStateChanged = TRUE;
+				m_currMouse.rightStateChanged = TRUE;
 			}
 			else
 			{
 				// Mouse Up
 				m_currMouse.rightEvent = GWM_RIGHT_UP;
 				m_currMouse.rightState = MBS_Up;
-				m_currMouse.rightButtonStateChanged = TRUE;
+				m_currMouse.rightStateChanged = TRUE;
 			}
 		}
 	}
@@ -290,7 +290,7 @@ void Mouse::processMouseEvent( Int index )
 	}
 
 	// Check Middle Mouse State
-	if( m_mouseEvents[ index ].middleButtonStateChanged )
+	if( m_mouseEvents[ index ].middleStateChanged )
 	{
 		if( m_currMouse.middleState != m_mouseEvents[index].middleState )
 		{
@@ -299,20 +299,20 @@ void Mouse::processMouseEvent( Int index )
 			{
 				m_currMouse.middleEvent = GWM_MIDDLE_DOWN;
 				m_currMouse.middleState = MBS_Down;
-				m_currMouse.middleButtonStateChanged = TRUE;
+				m_currMouse.middleStateChanged = TRUE;
 			}
 			else if( m_mouseEvents[index].middleState == MBS_DoubleClick )
 			{
 				m_currMouse.middleEvent = GWM_MIDDLE_DOUBLE_CLICK;
 				m_currMouse.middleState = MBS_DoubleClick;
-				m_currMouse.middleButtonStateChanged = TRUE;
+				m_currMouse.middleStateChanged = TRUE;
 			}
 			else
 			{
 				// Mouse Up
 				m_currMouse.middleEvent = GWM_MIDDLE_UP;
 				m_currMouse.middleState = MBS_Up;
-				m_currMouse.middleButtonStateChanged = TRUE;
+				m_currMouse.middleStateChanged = TRUE;
 			}
 		}
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
@@ -171,16 +171,12 @@ const ICoord2D* LookAtTranslator::getRMBScrollAnchor(void)
 
 Bool LookAtTranslator::hasMouseMovedRecently( void )
 {
-	UnsignedInt now = timeGetTime();
+	const UnsignedInt now = timeGetTime();
+	const UnsignedInt lastMove = m_lastMouseMoveTimeMsec;
 
-	// Handle time wraparound
-	if (now < m_lastMouseMoveTimeMsec)
-		m_lastMouseMoveTimeMsec = now;
+	const UnsignedInt elapsedMsec = now - lastMove;
 
-	if (now - m_lastMouseMoveTimeMsec > MSEC_PER_SECOND)
-		return false;
-
-	return true;
+	return elapsedMsec <= MSEC_PER_SECOND;
 }
 
 void LookAtTranslator::setCurrentPos( const ICoord2D& pos )
@@ -312,8 +308,11 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 			if (dx<0) dx = -dx;
 			Int dy = m_currentPos.y-m_originalAnchor.y;
 			Bool didMove = dx>PIXEL_OFFSET || dy>PIXEL_OFFSET;
+
+			const UnsignedInt elapsedMsec = now - m_middleButtonDownTimeMsec;
+
 			// if middle button is "clicked", reset to "home" orientation
-			if (!didMove && now - m_middleButtonDownTimeMsec < CLICK_DURATION_MSEC)
+			if (!didMove && elapsedMsec < CLICK_DURATION_MSEC)
 			{
 				TheTacticalView->setAngleAndPitchToDefault();
 				TheTacticalView->setZoomToDefault();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
@@ -137,7 +137,7 @@ LookAtTranslator::LookAtTranslator() :
 	m_isRotating(false),
 	m_isPitching(false),
 	m_isChangingFOV(false),
-	m_timestamp(0),
+	m_middleButtonDownTimeMS(0),
 	m_lastPlaneID(INVALID_DRAWABLE_ID),
 	m_lastMouseMoveFrame(0),
 	m_scrollType(SCROLL_NONE)
@@ -277,8 +277,8 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 			{
 				stopScrolling();
 			}
-			break;
-		}
+		break;
+	}
 
 		//-----------------------------------------------------------------------------
 		case GameMessage::MSG_RAW_MOUSE_MIDDLE_BUTTON_DOWN:
@@ -290,7 +290,7 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 			m_anchorAngle = TheTacticalView->getAngle();
 			m_originalAnchor = msg->getArgument( 0 )->pixel;
 			m_currentPos = msg->getArgument( 0 )->pixel;
-			m_timestamp = TheGameClient->getFrame();
+			m_middleButtonDownTimeMS = timeGetTime();
 			break;
 		}
 
@@ -299,7 +299,7 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 		{
 			m_lastMouseMoveFrame = TheGameLogic->getFrame();
 
-			const UnsignedInt CLICK_DURATION = 5;
+			const UnsignedInt CLICK_DURATION_MS = 167;
 			const UnsignedInt PIXEL_OFFSET = 5;
 
 			m_isRotating = false;
@@ -308,7 +308,7 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 			Int dy = m_currentPos.y-m_originalAnchor.y;
 			Bool didMove = dx>PIXEL_OFFSET || dy>PIXEL_OFFSET;
 			// if middle button is "clicked", reset to "home" orientation
-			if (!didMove && TheGameClient->getFrame() - m_timestamp < CLICK_DURATION)
+			if (!didMove && timeGetTime() - m_middleButtonDownTimeMS < CLICK_DURATION_MS)
 			{
 				TheTacticalView->setAngleAndPitchToDefault();
 				TheTacticalView->setZoomToDefault();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
@@ -281,8 +281,8 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 			{
 				stopScrolling();
 			}
-		break;
-	}
+			break;
+		}
 
 		//-----------------------------------------------------------------------------
 		case GameMessage::MSG_RAW_MOUSE_MIDDLE_BUTTON_DOWN:

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
@@ -287,21 +287,23 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 		//-----------------------------------------------------------------------------
 		case GameMessage::MSG_RAW_MOUSE_MIDDLE_BUTTON_DOWN:
 		{
-			m_lastMouseMoveTimeMsec = timeGetTime();
+			UnsignedInt now = timeGetTime();
+			m_lastMouseMoveTimeMsec = now;
 
 			m_isRotating = true;
 			m_anchor = msg->getArgument( 0 )->pixel;
 			m_anchorAngle = TheTacticalView->getAngle();
 			m_originalAnchor = msg->getArgument( 0 )->pixel;
 			m_currentPos = msg->getArgument( 0 )->pixel;
-			m_middleButtonDownTimeMsec = timeGetTime();
+			m_middleButtonDownTimeMsec = now;
 			break;
 		}
 
 		//-----------------------------------------------------------------------------
 		case GameMessage::MSG_RAW_MOUSE_MIDDLE_BUTTON_UP:
 		{
-			m_lastMouseMoveTimeMsec = timeGetTime();
+			UnsignedInt now = timeGetTime();
+			m_lastMouseMoveTimeMsec = now;
 
 			const UnsignedInt CLICK_DURATION_MSEC = 167;
 			const UnsignedInt PIXEL_OFFSET = 5;
@@ -312,7 +314,7 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 			Int dy = m_currentPos.y-m_originalAnchor.y;
 			Bool didMove = dx>PIXEL_OFFSET || dy>PIXEL_OFFSET;
 			// if middle button is "clicked", reset to "home" orientation
-			if (!didMove && timeGetTime() - m_middleButtonDownTimeMsec < CLICK_DURATION_MSEC)
+			if (!didMove && now - m_middleButtonDownTimeMsec < CLICK_DURATION_MSEC)
 			{
 				TheTacticalView->setAngleAndPitchToDefault();
 				TheTacticalView->setZoomToDefault();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
@@ -139,7 +139,7 @@ LookAtTranslator::LookAtTranslator() :
 	m_isChangingFOV(false),
 	m_middleButtonDownTimeMsec(0),
 	m_lastPlaneID(INVALID_DRAWABLE_ID),
-	m_lastMouseMoveFrame(0),
+	m_lastMouseMoveTimeMsec(0),
 	m_scrollType(SCROLL_NONE)
 {
 	m_anchor.x = m_anchor.y = 0;
@@ -171,10 +171,14 @@ const ICoord2D* LookAtTranslator::getRMBScrollAnchor(void)
 
 Bool LookAtTranslator::hasMouseMovedRecently( void )
 {
-	if (m_lastMouseMoveFrame > TheGameLogic->getFrame())
-		m_lastMouseMoveFrame = 0; // reset for new game
+	const UnsignedInt ONE_SECOND_MSEC = 1000;
+	UnsignedInt now = timeGetTime();
 
-	if (m_lastMouseMoveFrame + LOGICFRAMES_PER_SECOND < TheGameLogic->getFrame())
+	// Handle time wraparound
+	if (now < m_lastMouseMoveTimeMsec)
+		m_lastMouseMoveTimeMsec = now;
+
+	if (now - m_lastMouseMoveTimeMsec > ONE_SECOND_MSEC)
 		return false;
 
 	return true;
@@ -256,7 +260,7 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 		//-----------------------------------------------------------------------------
 		case GameMessage::MSG_RAW_MOUSE_RIGHT_BUTTON_DOWN:
 		{
-			m_lastMouseMoveFrame = TheGameLogic->getFrame();
+			m_lastMouseMoveTimeMsec = timeGetTime();
 
 			m_anchor = msg->getArgument( 0 )->pixel;
 			m_currentPos = msg->getArgument( 0 )->pixel;
@@ -271,7 +275,7 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 		//-----------------------------------------------------------------------------
 		case GameMessage::MSG_RAW_MOUSE_RIGHT_BUTTON_UP:
 		{
-			m_lastMouseMoveFrame = TheGameLogic->getFrame();
+			m_lastMouseMoveTimeMsec = timeGetTime();
 
 			if (m_scrollType == SCROLL_RMB)
 			{
@@ -283,7 +287,7 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 		//-----------------------------------------------------------------------------
 		case GameMessage::MSG_RAW_MOUSE_MIDDLE_BUTTON_DOWN:
 		{
-			m_lastMouseMoveFrame = TheGameLogic->getFrame();
+			m_lastMouseMoveTimeMsec = timeGetTime();
 
 			m_isRotating = true;
 			m_anchor = msg->getArgument( 0 )->pixel;
@@ -297,7 +301,7 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 		//-----------------------------------------------------------------------------
 		case GameMessage::MSG_RAW_MOUSE_MIDDLE_BUTTON_UP:
 		{
-			m_lastMouseMoveFrame = TheGameLogic->getFrame();
+			m_lastMouseMoveTimeMsec = timeGetTime();
 
 			const UnsignedInt CLICK_DURATION_MSEC = 167;
 			const UnsignedInt PIXEL_OFFSET = 5;
@@ -321,7 +325,7 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 		case GameMessage::MSG_RAW_MOUSE_POSITION:
 		{
 			if (m_currentPos.x != msg->getArgument( 0 )->pixel.x || m_currentPos.y != msg->getArgument( 0 )->pixel.y)
-				m_lastMouseMoveFrame = TheGameLogic->getFrame();
+				m_lastMouseMoveTimeMsec = timeGetTime();
 
 			m_currentPos = msg->getArgument( 0 )->pixel;
 
@@ -401,7 +405,7 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 		//-----------------------------------------------------------------------------
 		case GameMessage::MSG_RAW_MOUSE_WHEEL:
 		{
-			m_lastMouseMoveFrame = TheGameLogic->getFrame();
+			m_lastMouseMoveTimeMsec = timeGetTime();
 
 			Int spin = msg->getArgument( 1 )->integer;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
@@ -171,14 +171,13 @@ const ICoord2D* LookAtTranslator::getRMBScrollAnchor(void)
 
 Bool LookAtTranslator::hasMouseMovedRecently( void )
 {
-	const UnsignedInt ONE_SECOND_MSEC = 1000;
 	UnsignedInt now = timeGetTime();
 
 	// Handle time wraparound
 	if (now < m_lastMouseMoveTimeMsec)
 		m_lastMouseMoveTimeMsec = now;
 
-	if (now - m_lastMouseMoveTimeMsec > ONE_SECOND_MSEC)
+	if (now - m_lastMouseMoveTimeMsec > MSEC_PER_SECOND)
 		return false;
 
 	return true;
@@ -287,22 +286,22 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 		//-----------------------------------------------------------------------------
 		case GameMessage::MSG_RAW_MOUSE_MIDDLE_BUTTON_DOWN:
 		{
-			UnsignedInt now = timeGetTime();
+			const UnsignedInt now = timeGetTime();
 			m_lastMouseMoveTimeMsec = now;
+			m_middleButtonDownTimeMsec = now;
 
 			m_isRotating = true;
 			m_anchor = msg->getArgument( 0 )->pixel;
 			m_anchorAngle = TheTacticalView->getAngle();
 			m_originalAnchor = msg->getArgument( 0 )->pixel;
 			m_currentPos = msg->getArgument( 0 )->pixel;
-			m_middleButtonDownTimeMsec = now;
 			break;
 		}
 
 		//-----------------------------------------------------------------------------
 		case GameMessage::MSG_RAW_MOUSE_MIDDLE_BUTTON_UP:
 		{
-			UnsignedInt now = timeGetTime();
+			const UnsignedInt now = timeGetTime();
 			m_lastMouseMoveTimeMsec = now;
 
 			const UnsignedInt CLICK_DURATION_MSEC = 167;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
@@ -137,7 +137,7 @@ LookAtTranslator::LookAtTranslator() :
 	m_isRotating(false),
 	m_isPitching(false),
 	m_isChangingFOV(false),
-	m_middleButtonDownTimeMS(0),
+	m_middleButtonDownTimeMsec(0),
 	m_lastPlaneID(INVALID_DRAWABLE_ID),
 	m_lastMouseMoveFrame(0),
 	m_scrollType(SCROLL_NONE)
@@ -290,7 +290,7 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 			m_anchorAngle = TheTacticalView->getAngle();
 			m_originalAnchor = msg->getArgument( 0 )->pixel;
 			m_currentPos = msg->getArgument( 0 )->pixel;
-			m_middleButtonDownTimeMS = timeGetTime();
+			m_middleButtonDownTimeMsec = timeGetTime();
 			break;
 		}
 
@@ -299,7 +299,7 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 		{
 			m_lastMouseMoveFrame = TheGameLogic->getFrame();
 
-			const UnsignedInt CLICK_DURATION_MS = 167;
+			const UnsignedInt CLICK_DURATION_MSEC = 167;
 			const UnsignedInt PIXEL_OFFSET = 5;
 
 			m_isRotating = false;
@@ -308,7 +308,7 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 			Int dy = m_currentPos.y-m_originalAnchor.y;
 			Bool didMove = dx>PIXEL_OFFSET || dy>PIXEL_OFFSET;
 			// if middle button is "clicked", reset to "home" orientation
-			if (!didMove && timeGetTime() - m_middleButtonDownTimeMS < CLICK_DURATION_MS)
+			if (!didMove && timeGetTime() - m_middleButtonDownTimeMsec < CLICK_DURATION_MSEC)
 			{
 				TheTacticalView->setAngleAndPitchToDefault();
 				TheTacticalView->setZoomToDefault();

--- a/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIKeyboard.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIKeyboard.cpp
@@ -251,7 +251,6 @@ void DirectInputKeyboard::getKey( KeyboardIO *key )
 	HRESULT hr;
 
 	assert( key );
-	key->sequence = 0;
 	key->key = KEY_NONE;
 
 	if( m_pKeyboardDevice )
@@ -314,9 +313,6 @@ void DirectInputKeyboard::getKey( KeyboardIO *key )
 
 		// set the key
 		key->key = (UnsignedByte)(kbdat.dwOfs & 0xFF);
-
-		// sequence
-		key->sequence = kbdat.dwSequence;
 
 		//
 		// state of key, note we are setting the key state here with an assignment

--- a/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIKeyboard.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIKeyboard.cpp
@@ -319,7 +319,15 @@ void DirectInputKeyboard::getKey( KeyboardIO *key )
 		// and not a bit set of the up/down state, this is the "start"
 		// of building this "key"
 		//
-		key->state = (( kbdat.dwData & 0x0080 ) ? KEY_STATE_DOWN : KEY_STATE_UP);
+		if( kbdat.dwData & 0x0080 )
+		{
+			key->state = KEY_STATE_DOWN;
+			key->keyDownTimeMsec = kbdat.dwTimeStamp;
+		}
+		else
+		{
+			key->state = KEY_STATE_UP;
+		}
 
 		// set status as unused (unprocessed)
 		key->status = KeyboardIO::STATUS_UNUSED;

--- a/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIMouse.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIMouse.cpp
@@ -202,7 +202,7 @@ UnsignedByte DirectInputMouse::getMouseEvent( MouseIO *result, Bool flush )
 
 	/* set these to defaults */
 	result->leftState = result->middleState = result->rightState = FALSE;
-	result->leftFrame = result->middleFrame = result->rightFrame = 0;
+	result->leftButtonStateChanged = result->middleButtonStateChanged = result->rightButtonStateChanged = FALSE;
 	result->pos.x = result->pos.y = result->wheelPos = 0;
 
 	if( m_pMouseDevice )
@@ -283,17 +283,17 @@ void DirectInputMouse::mapDirectInputMouse( MouseIO *mouse,
 	{
 		case DIMOFS_BUTTON0:
 			mouse->leftState = (( mdat->dwData & 0x0080 ) ? TRUE : FALSE);
-			mouse->leftFrame = mdat->dwSequence;
+			mouse->leftButtonStateChanged = TRUE;
 			break;
 
 		case DIMOFS_BUTTON1:
 			mouse->rightState = (( mdat->dwData & 0x0080 ) ? TRUE : FALSE);
-			mouse->rightFrame = mdat->dwSequence;
+			mouse->rightButtonStateChanged = TRUE;
 			break;
 
 		case DIMOFS_BUTTON2:
 			mouse->middleState = (( mdat->dwData & 0x0080 ) ? TRUE : FALSE);
-			mouse->middleFrame = mdat->dwSequence;
+			mouse->middleButtonStateChanged = TRUE;
 			break;
 
 		case DIMOFS_BUTTON3:

--- a/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIMouse.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIMouse.cpp
@@ -202,7 +202,7 @@ UnsignedByte DirectInputMouse::getMouseEvent( MouseIO *result, Bool flush )
 
 	/* set these to defaults */
 	result->leftState = result->middleState = result->rightState = FALSE;
-	result->leftStateChanged = result->middleStateChanged = result->rightStateChanged = FALSE;
+	result->leftState = result->middleState = result->rightState = MBS_None;
 	result->pos.x = result->pos.y = result->wheelPos = 0;
 
 	if( m_pMouseDevice )
@@ -282,18 +282,15 @@ void DirectInputMouse::mapDirectInputMouse( MouseIO *mouse,
 	switch( mdat->dwOfs )
 	{
 		case DIMOFS_BUTTON0:
-			mouse->leftState = (( mdat->dwData & 0x0080 ) ? TRUE : FALSE);
-			mouse->leftStateChanged = TRUE;
+			mouse->leftState = (( mdat->dwData & 0x0080 ) ? MBS_Down : MBS_Up);
 			break;
 
 		case DIMOFS_BUTTON1:
-			mouse->rightState = (( mdat->dwData & 0x0080 ) ? TRUE : FALSE);
-			mouse->rightStateChanged = TRUE;
+			mouse->rightState = (( mdat->dwData & 0x0080 ) ? MBS_Down : MBS_Up);
 			break;
 
 		case DIMOFS_BUTTON2:
-			mouse->middleState = (( mdat->dwData & 0x0080 ) ? TRUE : FALSE);
-			mouse->middleStateChanged = TRUE;
+			mouse->middleState = (( mdat->dwData & 0x0080 ) ? MBS_Down : MBS_Up);
 			break;
 
 		case DIMOFS_BUTTON3:

--- a/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIMouse.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIMouse.cpp
@@ -202,7 +202,7 @@ UnsignedByte DirectInputMouse::getMouseEvent( MouseIO *result, Bool flush )
 
 	/* set these to defaults */
 	result->leftState = result->middleState = result->rightState = FALSE;
-	result->leftButtonStateChanged = result->middleButtonStateChanged = result->rightButtonStateChanged = FALSE;
+	result->leftStateChanged = result->middleStateChanged = result->rightStateChanged = FALSE;
 	result->pos.x = result->pos.y = result->wheelPos = 0;
 
 	if( m_pMouseDevice )
@@ -283,17 +283,17 @@ void DirectInputMouse::mapDirectInputMouse( MouseIO *mouse,
 	{
 		case DIMOFS_BUTTON0:
 			mouse->leftState = (( mdat->dwData & 0x0080 ) ? TRUE : FALSE);
-			mouse->leftButtonStateChanged = TRUE;
+			mouse->leftStateChanged = TRUE;
 			break;
 
 		case DIMOFS_BUTTON1:
 			mouse->rightState = (( mdat->dwData & 0x0080 ) ? TRUE : FALSE);
-			mouse->rightButtonStateChanged = TRUE;
+			mouse->rightStateChanged = TRUE;
 			break;
 
 		case DIMOFS_BUTTON2:
 			mouse->middleState = (( mdat->dwData & 0x0080 ) ? TRUE : FALSE);
-			mouse->middleButtonStateChanged = TRUE;
+			mouse->middleStateChanged = TRUE;
 			break;
 
 		case DIMOFS_BUTTON3:

--- a/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32Mouse.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32Mouse.cpp
@@ -85,21 +85,10 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 	UINT msg = m_eventBuffer[ eventIndex ].msg;
 	WPARAM wParam = m_eventBuffer[ eventIndex ].wParam;
 	LPARAM lParam = m_eventBuffer[ eventIndex ].lParam;
-	UnsignedInt frame;
-
-	//
-	// get the current input frame from the client, if we don't have
-	// a client (like in the GUI editor) we just use frame 1 so it
-	// registers with the system
-	//
-	if( TheGameClient )
-		frame = TheGameClient->getFrame();
-	else
-		frame = 1;
 
 	// set these to defaults
 	result->leftState = result->middleState = result->rightState = MBS_Up;
-	result->leftFrame = result->middleFrame = result->rightFrame = 0;
+	result->leftButtonStateChanged = result->middleButtonStateChanged = result->rightButtonStateChanged = FALSE;
 	result->pos.x = result->pos.y = result->wheelPos = 0;
 
 	// Time is the same for all events
@@ -113,7 +102,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->leftState = MBS_Down;
-			result->leftFrame = frame;
+			result->leftButtonStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -125,7 +114,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->leftState = MBS_Up;
-			result->leftFrame = frame;
+			result->leftButtonStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -137,7 +126,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->leftState = MBS_DoubleClick;
-			result->leftFrame = frame;
+			result->leftButtonStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -149,7 +138,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->middleState = MBS_Down;
-			result->middleFrame = frame;
+			result->middleButtonStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -161,7 +150,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->middleState = MBS_Up;
-			result->middleFrame = frame;
+			result->middleButtonStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -173,7 +162,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->middleState = MBS_DoubleClick;
-			result->middleFrame = frame;
+			result->middleButtonStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -185,7 +174,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->rightState = MBS_Down;
-			result->rightFrame = frame;
+			result->rightButtonStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -197,7 +186,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->rightState = MBS_Up;
-			result->rightFrame = frame;
+			result->rightButtonStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -209,7 +198,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->rightState = MBS_DoubleClick;
-			result->rightFrame = frame;
+			result->rightButtonStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;

--- a/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32Mouse.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32Mouse.cpp
@@ -87,8 +87,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 	LPARAM lParam = m_eventBuffer[ eventIndex ].lParam;
 
 	// set these to defaults
-	result->leftState = result->middleState = result->rightState = MBS_Up;
-	result->leftStateChanged = result->middleStateChanged = result->rightStateChanged = FALSE;
+	result->leftState = result->middleState = result->rightState = MBS_None;
 	result->pos.x = result->pos.y = result->wheelPos = 0;
 
 	// Time is the same for all events
@@ -102,7 +101,6 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->leftState = MBS_Down;
-			result->leftStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -114,7 +112,6 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->leftState = MBS_Up;
-			result->leftStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -126,7 +123,6 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->leftState = MBS_DoubleClick;
-			result->leftStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -138,7 +134,6 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->middleState = MBS_Down;
-			result->middleStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -150,7 +145,6 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->middleState = MBS_Up;
-			result->middleStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -162,7 +156,6 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->middleState = MBS_DoubleClick;
-			result->middleStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -174,7 +167,6 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->rightState = MBS_Down;
-			result->rightStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -186,7 +178,6 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->rightState = MBS_Up;
-			result->rightStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -198,7 +189,6 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->rightState = MBS_DoubleClick;
-			result->rightStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;

--- a/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32Mouse.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32Mouse.cpp
@@ -88,7 +88,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 
 	// set these to defaults
 	result->leftState = result->middleState = result->rightState = MBS_Up;
-	result->leftButtonStateChanged = result->middleButtonStateChanged = result->rightButtonStateChanged = FALSE;
+	result->leftStateChanged = result->middleStateChanged = result->rightStateChanged = FALSE;
 	result->pos.x = result->pos.y = result->wheelPos = 0;
 
 	// Time is the same for all events
@@ -102,7 +102,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->leftState = MBS_Down;
-			result->leftButtonStateChanged = TRUE;
+			result->leftStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -114,7 +114,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->leftState = MBS_Up;
-			result->leftButtonStateChanged = TRUE;
+			result->leftStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -126,7 +126,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->leftState = MBS_DoubleClick;
-			result->leftButtonStateChanged = TRUE;
+			result->leftStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -138,7 +138,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->middleState = MBS_Down;
-			result->middleButtonStateChanged = TRUE;
+			result->middleStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -150,7 +150,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->middleState = MBS_Up;
-			result->middleButtonStateChanged = TRUE;
+			result->middleStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -162,7 +162,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->middleState = MBS_DoubleClick;
-			result->middleButtonStateChanged = TRUE;
+			result->middleStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -174,7 +174,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->rightState = MBS_Down;
-			result->rightButtonStateChanged = TRUE;
+			result->rightStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -186,7 +186,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->rightState = MBS_Up;
-			result->rightButtonStateChanged = TRUE;
+			result->rightStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;
@@ -198,7 +198,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			result->rightState = MBS_DoubleClick;
-			result->rightButtonStateChanged = TRUE;
+			result->rightStateChanged = TRUE;
 			result->pos.x = LOWORD( lParam );
 			result->pos.y = HIWORD( lParam );
 			break;


### PR DESCRIPTION
- Fixes #1831 

## Summary

Fixes frame-rate dependent timing in mouse and keyboard input systems by replacing frame counts with real-time milliseconds.

### Middle Mouse Button Click
- Changed `m_timestamp` to track real-time in milliseconds instead of frame number
- Replaced `CLICK_DURATION = 5` frames with `CLICK_DURATION_MS = 167` milliseconds
- Uses `timeGetTime()` for timing comparisons

### Keyboard Repeat
- Added `keyDownTimeMS` field to `KeyboardIO` struct to track real-time key down events
- Replaced `KEY_REPEAT_DELAY = 10` frames with `KEY_REPEAT_DELAY_MS = 333` milliseconds
- Converted repeat interval to real-time (67ms)

## Testing

- Middle mouse click to reset camera now works consistently at any frame rate
- Keyboard repeat timing is uniform regardless of render FPS or logic time scale settings

## TODO:
Testing