### PR TITLE
fix(network): Fix missing value initialization of LANGameInfo::m_isDirectConnect

### DIFF
--- a/Core/GameEngine/Source/GameNetwork/LANAPIhandlers.cpp
+++ b/Core/GameEngine/Source/GameNetwork/LANAPIhandlers.cpp
@@ -65,6 +65,7 @@ void LANAPI::handleRequestLocations( LANMessage *msg, UnsignedInt senderIP )
 				strlcpy(reply.GameInfo.options, gameOpts.str(), ARRAY_SIZE(reply.GameInfo.options));
 				wcslcpy(reply.GameInfo.gameName, m_currentGame->getName().str(), ARRAY_SIZE(reply.GameInfo.gameName));
 				reply.GameInfo.inProgress = m_currentGame->isGameInProgress();
+				reply.GameInfo.isDirectConnect = m_currentGame->getIsDirectConnect();
 
 				sendMessage(&reply);
 			}

--- a/Core/GameEngine/Source/GameNetwork/LANGameInfo.cpp
+++ b/Core/GameEngine/Source/GameNetwork/LANGameInfo.cpp
@@ -90,6 +90,8 @@ LANGameInfo::LANGameInfo()
 {
 	m_lastHeard = 0;
 	m_next = NULL;
+	m_isDirectConnect = false;
+	//
 	for (Int i = 0; i< MAX_SLOTS; ++i)
 		setSlotPointer(i, &m_LANSlot[i]);
 


### PR DESCRIPTION
- Fixes #1802 

## Summary
Fixes uninitialized memory bug in LAN game announcement messages when announcing games to the lobby.

## TODO
Testing