### PR TITLE
bugfix(replay): Handle replay deletion during version mismatch prompt

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Recorder.cpp
@@ -1145,8 +1145,6 @@ Bool RecorderClass::playbackFile(AsciiString filename)
 	DEBUG_ASSERTCRASH(!exeDifferent && !iniDifferent, (debugString.str()));
 #endif
 
-	TheWritableGlobalData->m_pendingFile = m_gameInfo.getMap();
-
 #ifdef DEBUG_LOGGING
 	if (header.localPlayerIndex >= 0)
 	{
@@ -1179,6 +1177,13 @@ Bool RecorderClass::playbackFile(AsciiString filename)
 	TheCommandList->reset();
 
 	readNextFrame();
+	// readNextFrame() closes m_file via stopPlayback() if the first frame cannot be read.
+	if(m_file == nullptr)
+	{
+		return FALSE;
+	}
+
+	TheWritableGlobalData->m_pendingFile = m_gameInfo.getMap();
 
 	// send a message to the logic for a new game
 	if (!m_doingAnalysis)

--- a/Generals/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Recorder.cpp
@@ -1088,8 +1088,6 @@ Bool RecorderClass::playbackFile(AsciiString filename)
 		}
 	}
 
-	m_mode = RECORDERMODETYPE_PLAYBACK;
-
 	ReplayHeader header;
 	header.forPlayback = TRUE;
 	header.filename = filename;
@@ -1198,6 +1196,11 @@ Bool RecorderClass::playbackFile(AsciiString filename)
 		TheCommandList->appendMessage( msg );
 		InitRandom( m_gameInfo.getSeed() );
 	}
+
+	// TheSuperHackers @bugfix bobtista 25/07/2026 Enter playback mode only once the playback is ready.
+	// Previously a failed open left the recorder in playback mode with a NULL m_file, and the next
+	// update dereferenced it, for example when the replay is deleted during the version mismatch prompt.
+	m_mode = RECORDERMODETYPE_PLAYBACK;
 
 	m_currentReplayFilename = filename;
 	m_playbackFrameCount = header.frameCount;

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
@@ -559,6 +559,14 @@ static void showReplayLoadFailedAndRefreshList()
 	PopulateReplayFileListbox(listboxReplayFiles);
 }
 
+static void showReplayMapNotFound()
+{
+	UnicodeString title = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayMapNotFoundTitle", L"MAP NOT FOUND");
+	UnicodeString body = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayMapNotFound", L"This replay cannot be loaded because the map was not found on this device.");
+
+	MessageBoxOk(title, body, nullptr);
+}
+
 //-------------------------------------------------------------------------------------------------
 
 void reallyLoadReplay()
@@ -587,6 +595,12 @@ void reallyLoadReplay()
 	if(!readReplayMapInfo(asciiFilename, header, info, mapData))
 	{
 		showReplayLoadFailedAndRefreshList();
+		return;
+	}
+
+	if(mapData == nullptr)
+	{
+		showReplayMapNotFound();
 		return;
 	}
 
@@ -622,10 +636,7 @@ static void loadReplay(UnicodeString filename)
 	{
 		// TheSuperHackers @bugfix Prompts a message box when the map used by the replay was not found.
 
-		UnicodeString title = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayMapNotFoundTitle", L"MAP NOT FOUND");
-		UnicodeString body = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayMapNotFound", L"This replay cannot be loaded because the map was not found on this device.");
-
-		MessageBoxOk(title, body, nullptr);
+		showReplayMapNotFound();
 	}
 	else if(!TheRecorder->replayMatchesGameVersion(header))
 	{

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
@@ -548,7 +548,7 @@ WindowMsgHandledType ReplayMenuInput( GameWindow *window, UnsignedInt msg,
 
 }
 
-static void showReplayLoadFailedAndRefreshList()
+static void handleReplayLoadFailure()
 {
 	UnicodeString title = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayLoadFailedTitle", L"REPLAY CANNOT BE LOADED");
 	UnicodeString body = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayLoadFailed", L"The replay file could not be opened or is invalid.");
@@ -594,7 +594,7 @@ void reallyLoadReplay()
 
 	if(!readReplayMapInfo(asciiFilename, header, info, mapData))
 	{
-		showReplayLoadFailedAndRefreshList();
+		handleReplayLoadFailure();
 		return;
 	}
 
@@ -613,7 +613,7 @@ void reallyLoadReplay()
 	}
 	else
 	{
-		showReplayLoadFailedAndRefreshList();
+		handleReplayLoadFailure();
 	}
 }
 
@@ -630,7 +630,7 @@ static void loadReplay(UnicodeString filename)
 	{
 		// TheSuperHackers @bugfix Prompts a message box when the replay was deleted by the user while the Replay Menu was opened.
 
-		showReplayLoadFailedAndRefreshList();
+		handleReplayLoadFailure();
 	}
 	else if(mapData == nullptr)
 	{
@@ -657,7 +657,7 @@ static void loadReplay(UnicodeString filename)
 		}
 		else
 		{
-			showReplayLoadFailedAndRefreshList();
+			handleReplayLoadFailure();
 		}
 	}
 }

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
@@ -564,11 +564,31 @@ void reallyLoadReplay()
 	AsciiString asciiFilename;
 	asciiFilename.translate(filename);
 
-	TheRecorder->playbackFile(asciiFilename);
+	// TheSuperHackers @bugfix bobtista 25/07/2026 Re-validate the replay before starting playback.
+	// The user can delete the file while the version mismatch prompt is open, in which case the
+	// listbox entry is stale. Prompts the same message box as loadReplay and refreshes the list.
+	RecorderClass::ReplayHeader header;
+	ReplayGameInfo info;
+	const MapMetaData *mapData;
 
-	if(parentReplayMenu != nullptr)
+	if(!readReplayMapInfo(asciiFilename, header, info, mapData))
 	{
-		parentReplayMenu->winHide(TRUE);
+		UnicodeString title = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayFileNotFoundTitle", L"REPLAY NOT FOUND");
+		UnicodeString body = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayFileNotFound", L"This replay cannot be loaded because the file no longer exists on this device.");
+
+		MessageBoxOk(title, body, nullptr);
+
+		GadgetListBoxReset(listboxReplayFiles);
+		PopulateReplayFileListbox(listboxReplayFiles);
+		return;
+	}
+
+	if(TheRecorder->playbackFile(asciiFilename))
+	{
+		if(parentReplayMenu != nullptr)
+		{
+			parentReplayMenu->winHide(TRUE);
+		}
 	}
 }
 

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
@@ -548,10 +548,10 @@ WindowMsgHandledType ReplayMenuInput( GameWindow *window, UnsignedInt msg,
 
 }
 
-static void showReplayNotFoundAndRefreshList()
+static void showReplayLoadFailedAndRefreshList()
 {
-	UnicodeString title = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayFileNotFoundTitle", L"REPLAY NOT FOUND");
-	UnicodeString body = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayFileNotFound", L"This replay cannot be loaded because the file no longer exists on this device.");
+	UnicodeString title = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayLoadFailedTitle", L"REPLAY CANNOT BE LOADED");
+	UnicodeString body = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayLoadFailed", L"The replay file could not be opened or is invalid.");
 
 	MessageBoxOk(title, body, nullptr);
 
@@ -586,7 +586,7 @@ void reallyLoadReplay()
 
 	if(!readReplayMapInfo(asciiFilename, header, info, mapData))
 	{
-		showReplayNotFoundAndRefreshList();
+		showReplayLoadFailedAndRefreshList();
 		return;
 	}
 
@@ -599,7 +599,7 @@ void reallyLoadReplay()
 	}
 	else
 	{
-		showReplayNotFoundAndRefreshList();
+		showReplayLoadFailedAndRefreshList();
 	}
 }
 
@@ -616,7 +616,7 @@ static void loadReplay(UnicodeString filename)
 	{
 		// TheSuperHackers @bugfix Prompts a message box when the replay was deleted by the user while the Replay Menu was opened.
 
-		showReplayNotFoundAndRefreshList();
+		showReplayLoadFailedAndRefreshList();
 	}
 	else if(mapData == nullptr)
 	{
@@ -646,7 +646,7 @@ static void loadReplay(UnicodeString filename)
 		}
 		else
 		{
-			showReplayNotFoundAndRefreshList();
+			showReplayLoadFailedAndRefreshList();
 		}
 	}
 }
@@ -861,4 +861,3 @@ void copyReplay()
 	}
 
 }
-

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
@@ -548,6 +548,19 @@ WindowMsgHandledType ReplayMenuInput( GameWindow *window, UnsignedInt msg,
 
 }
 
+static void showReplayNotFoundAndRefreshList()
+{
+	UnicodeString title = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayFileNotFoundTitle", L"REPLAY NOT FOUND");
+	UnicodeString body = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayFileNotFound", L"This replay cannot be loaded because the file no longer exists on this device.");
+
+	MessageBoxOk(title, body, nullptr);
+
+	GadgetListBoxReset(listboxReplayFiles);
+	PopulateReplayFileListbox(listboxReplayFiles);
+}
+
+//-------------------------------------------------------------------------------------------------
+
 void reallyLoadReplay()
 {
 	UnicodeString filename;
@@ -573,13 +586,7 @@ void reallyLoadReplay()
 
 	if(!readReplayMapInfo(asciiFilename, header, info, mapData))
 	{
-		UnicodeString title = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayFileNotFoundTitle", L"REPLAY NOT FOUND");
-		UnicodeString body = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayFileNotFound", L"This replay cannot be loaded because the file no longer exists on this device.");
-
-		MessageBoxOk(title, body, nullptr);
-
-		GadgetListBoxReset(listboxReplayFiles);
-		PopulateReplayFileListbox(listboxReplayFiles);
+		showReplayNotFoundAndRefreshList();
 		return;
 	}
 
@@ -589,6 +596,10 @@ void reallyLoadReplay()
 		{
 			parentReplayMenu->winHide(TRUE);
 		}
+	}
+	else
+	{
+		showReplayNotFoundAndRefreshList();
 	}
 }
 
@@ -605,10 +616,7 @@ static void loadReplay(UnicodeString filename)
 	{
 		// TheSuperHackers @bugfix Prompts a message box when the replay was deleted by the user while the Replay Menu was opened.
 
-		UnicodeString title = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayFileNotFoundTitle", L"REPLAY NOT FOUND");
-		UnicodeString body = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayFileNotFound", L"This replay cannot be loaded because the file no longer exists on this device.");
-
-		MessageBoxOk(title, body, nullptr);
+		showReplayNotFoundAndRefreshList();
 	}
 	else if(mapData == nullptr)
 	{
@@ -627,11 +635,18 @@ static void loadReplay(UnicodeString filename)
 	}
 	else
 	{
-		TheRecorder->playbackFile(asciiFilename);
-
-		if(parentReplayMenu != nullptr)
+		// TheSuperHackers @bugfix bobtista 25/07/2026 Keep the Replay Menu open when the playback
+		// could not be started, for example when the replay was deleted after it was validated above.
+		if(TheRecorder->playbackFile(asciiFilename))
 		{
-			parentReplayMenu->winHide(TRUE);
+			if(parentReplayMenu != nullptr)
+			{
+				parentReplayMenu->winHide(TRUE);
+			}
+		}
+		else
+		{
+			showReplayNotFoundAndRefreshList();
 		}
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -1091,8 +1091,6 @@ Bool RecorderClass::playbackFile(AsciiString filename)
 		}
 	}
 
-	m_mode = RECORDERMODETYPE_PLAYBACK;
-
 	ReplayHeader header;
 	header.forPlayback = TRUE;
 	header.filename = filename;
@@ -1201,6 +1199,11 @@ Bool RecorderClass::playbackFile(AsciiString filename)
 		TheCommandList->appendMessage( msg );
 		InitRandom( m_gameInfo.getSeed() );
 	}
+
+	// TheSuperHackers @bugfix bobtista 25/07/2026 Enter playback mode only once the playback is ready.
+	// Previously a failed open left the recorder in playback mode with a NULL m_file, and the next
+	// update dereferenced it, for example when the replay is deleted during the version mismatch prompt.
+	m_mode = RECORDERMODETYPE_PLAYBACK;
 
 	m_currentReplayFilename = filename;
 	m_playbackFrameCount = header.frameCount;

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -1148,8 +1148,6 @@ Bool RecorderClass::playbackFile(AsciiString filename)
 	DEBUG_ASSERTCRASH(!exeDifferent && !iniDifferent, (debugString.str()));
 #endif
 
-	TheWritableGlobalData->m_pendingFile = m_gameInfo.getMap();
-
 #ifdef DEBUG_LOGGING
 	if (header.localPlayerIndex >= 0)
 	{
@@ -1182,6 +1180,13 @@ Bool RecorderClass::playbackFile(AsciiString filename)
 	TheCommandList->reset();
 
 	readNextFrame();
+	// readNextFrame() closes m_file via stopPlayback() if the first frame cannot be read.
+	if(m_file == nullptr)
+	{
+		return FALSE;
+	}
+
+	TheWritableGlobalData->m_pendingFile = m_gameInfo.getMap();
 
 	// send a message to the logic for a new game
 	if (!m_doingAnalysis)

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
@@ -559,6 +559,14 @@ static void showReplayLoadFailedAndRefreshList()
 	PopulateReplayFileListbox(listboxReplayFiles);
 }
 
+static void showReplayMapNotFound()
+{
+	UnicodeString title = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayMapNotFoundTitle", L"MAP NOT FOUND");
+	UnicodeString body = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayMapNotFound", L"This replay cannot be loaded because the map was not found on this device.");
+
+	MessageBoxOk(title, body, nullptr);
+}
+
 //-------------------------------------------------------------------------------------------------
 
 void reallyLoadReplay()
@@ -587,6 +595,12 @@ void reallyLoadReplay()
 	if(!readReplayMapInfo(asciiFilename, header, info, mapData))
 	{
 		showReplayLoadFailedAndRefreshList();
+		return;
+	}
+
+	if(mapData == nullptr)
+	{
+		showReplayMapNotFound();
 		return;
 	}
 
@@ -622,10 +636,7 @@ static void loadReplay(UnicodeString filename)
 	{
 		// TheSuperHackers @bugfix Prompts a message box when the map used by the replay was not found.
 
-		UnicodeString title = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayMapNotFoundTitle", L"MAP NOT FOUND");
-		UnicodeString body = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayMapNotFound", L"This replay cannot be loaded because the map was not found on this device.");
-
-		MessageBoxOk(title, body, nullptr);
+		showReplayMapNotFound();
 	}
 	else if(!TheRecorder->replayMatchesGameVersion(header))
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
@@ -548,7 +548,7 @@ WindowMsgHandledType ReplayMenuInput( GameWindow *window, UnsignedInt msg,
 
 }
 
-static void showReplayLoadFailedAndRefreshList()
+static void handleReplayLoadFailure()
 {
 	UnicodeString title = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayLoadFailedTitle", L"REPLAY CANNOT BE LOADED");
 	UnicodeString body = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayLoadFailed", L"The replay file could not be opened or is invalid.");
@@ -594,7 +594,7 @@ void reallyLoadReplay()
 
 	if(!readReplayMapInfo(asciiFilename, header, info, mapData))
 	{
-		showReplayLoadFailedAndRefreshList();
+		handleReplayLoadFailure();
 		return;
 	}
 
@@ -613,7 +613,7 @@ void reallyLoadReplay()
 	}
 	else
 	{
-		showReplayLoadFailedAndRefreshList();
+		handleReplayLoadFailure();
 	}
 }
 
@@ -630,7 +630,7 @@ static void loadReplay(UnicodeString filename)
 	{
 		// TheSuperHackers @bugfix Prompts a message box when the replay was deleted by the user while the Replay Menu was opened.
 
-		showReplayLoadFailedAndRefreshList();
+		handleReplayLoadFailure();
 	}
 	else if(mapData == nullptr)
 	{
@@ -657,7 +657,7 @@ static void loadReplay(UnicodeString filename)
 		}
 		else
 		{
-			showReplayLoadFailedAndRefreshList();
+			handleReplayLoadFailure();
 		}
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
@@ -564,11 +564,31 @@ void reallyLoadReplay()
 	AsciiString asciiFilename;
 	asciiFilename.translate(filename);
 
-	TheRecorder->playbackFile(asciiFilename);
+	// TheSuperHackers @bugfix bobtista 25/07/2026 Re-validate the replay before starting playback.
+	// The user can delete the file while the version mismatch prompt is open, in which case the
+	// listbox entry is stale. Prompts the same message box as loadReplay and refreshes the list.
+	RecorderClass::ReplayHeader header;
+	ReplayGameInfo info;
+	const MapMetaData *mapData;
 
-	if(parentReplayMenu != nullptr)
+	if(!readReplayMapInfo(asciiFilename, header, info, mapData))
 	{
-		parentReplayMenu->winHide(TRUE);
+		UnicodeString title = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayFileNotFoundTitle", L"REPLAY NOT FOUND");
+		UnicodeString body = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayFileNotFound", L"This replay cannot be loaded because the file no longer exists on this device.");
+
+		MessageBoxOk(title, body, nullptr);
+
+		GadgetListBoxReset(listboxReplayFiles);
+		PopulateReplayFileListbox(listboxReplayFiles);
+		return;
+	}
+
+	if(TheRecorder->playbackFile(asciiFilename))
+	{
+		if(parentReplayMenu != nullptr)
+		{
+			parentReplayMenu->winHide(TRUE);
+		}
 	}
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
@@ -548,10 +548,10 @@ WindowMsgHandledType ReplayMenuInput( GameWindow *window, UnsignedInt msg,
 
 }
 
-static void showReplayNotFoundAndRefreshList()
+static void showReplayLoadFailedAndRefreshList()
 {
-	UnicodeString title = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayFileNotFoundTitle", L"REPLAY NOT FOUND");
-	UnicodeString body = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayFileNotFound", L"This replay cannot be loaded because the file no longer exists on this device.");
+	UnicodeString title = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayLoadFailedTitle", L"REPLAY CANNOT BE LOADED");
+	UnicodeString body = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayLoadFailed", L"The replay file could not be opened or is invalid.");
 
 	MessageBoxOk(title, body, nullptr);
 
@@ -586,7 +586,7 @@ void reallyLoadReplay()
 
 	if(!readReplayMapInfo(asciiFilename, header, info, mapData))
 	{
-		showReplayNotFoundAndRefreshList();
+		showReplayLoadFailedAndRefreshList();
 		return;
 	}
 
@@ -599,7 +599,7 @@ void reallyLoadReplay()
 	}
 	else
 	{
-		showReplayNotFoundAndRefreshList();
+		showReplayLoadFailedAndRefreshList();
 	}
 }
 
@@ -616,7 +616,7 @@ static void loadReplay(UnicodeString filename)
 	{
 		// TheSuperHackers @bugfix Prompts a message box when the replay was deleted by the user while the Replay Menu was opened.
 
-		showReplayNotFoundAndRefreshList();
+		showReplayLoadFailedAndRefreshList();
 	}
 	else if(mapData == nullptr)
 	{
@@ -646,7 +646,7 @@ static void loadReplay(UnicodeString filename)
 		}
 		else
 		{
-			showReplayNotFoundAndRefreshList();
+			showReplayLoadFailedAndRefreshList();
 		}
 	}
 }
@@ -861,4 +861,3 @@ void copyReplay()
 	}
 
 }
-

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
@@ -548,6 +548,19 @@ WindowMsgHandledType ReplayMenuInput( GameWindow *window, UnsignedInt msg,
 
 }
 
+static void showReplayNotFoundAndRefreshList()
+{
+	UnicodeString title = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayFileNotFoundTitle", L"REPLAY NOT FOUND");
+	UnicodeString body = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayFileNotFound", L"This replay cannot be loaded because the file no longer exists on this device.");
+
+	MessageBoxOk(title, body, nullptr);
+
+	GadgetListBoxReset(listboxReplayFiles);
+	PopulateReplayFileListbox(listboxReplayFiles);
+}
+
+//-------------------------------------------------------------------------------------------------
+
 void reallyLoadReplay()
 {
 	UnicodeString filename;
@@ -573,13 +586,7 @@ void reallyLoadReplay()
 
 	if(!readReplayMapInfo(asciiFilename, header, info, mapData))
 	{
-		UnicodeString title = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayFileNotFoundTitle", L"REPLAY NOT FOUND");
-		UnicodeString body = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayFileNotFound", L"This replay cannot be loaded because the file no longer exists on this device.");
-
-		MessageBoxOk(title, body, nullptr);
-
-		GadgetListBoxReset(listboxReplayFiles);
-		PopulateReplayFileListbox(listboxReplayFiles);
+		showReplayNotFoundAndRefreshList();
 		return;
 	}
 
@@ -589,6 +596,10 @@ void reallyLoadReplay()
 		{
 			parentReplayMenu->winHide(TRUE);
 		}
+	}
+	else
+	{
+		showReplayNotFoundAndRefreshList();
 	}
 }
 
@@ -605,10 +616,7 @@ static void loadReplay(UnicodeString filename)
 	{
 		// TheSuperHackers @bugfix Prompts a message box when the replay was deleted by the user while the Replay Menu was opened.
 
-		UnicodeString title = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayFileNotFoundTitle", L"REPLAY NOT FOUND");
-		UnicodeString body = TheGameText->FETCH_OR_SUBSTITUTE("GUI:ReplayFileNotFound", L"This replay cannot be loaded because the file no longer exists on this device.");
-
-		MessageBoxOk(title, body, nullptr);
+		showReplayNotFoundAndRefreshList();
 	}
 	else if(mapData == nullptr)
 	{
@@ -627,11 +635,18 @@ static void loadReplay(UnicodeString filename)
 	}
 	else
 	{
-		TheRecorder->playbackFile(asciiFilename);
-
-		if(parentReplayMenu != nullptr)
+		// TheSuperHackers @bugfix bobtista 25/07/2026 Keep the Replay Menu open when the playback
+		// could not be started, for example when the replay was deleted after it was validated above.
+		if(TheRecorder->playbackFile(asciiFilename))
 		{
-			parentReplayMenu->winHide(TRUE);
+			if(parentReplayMenu != nullptr)
+			{
+				parentReplayMenu->winHide(TRUE);
+			}
+		}
+		else
+		{
+			showReplayNotFoundAndRefreshList();
 		}
 	}
 }


### PR DESCRIPTION
Fixes #1732

### Summary

- Revalidates the replay after the version-mismatch prompt.
- Keeps the Replay Menu open, shows “REPLAY NOT FOUND,” and refreshes the list if validation or final playback fails.
- Enters recorder playback mode only after initialization succeeds, preventing a failed open from leaving a null replay file.
- Applies the fix to both Generals and Zero Hour.

### Notes
- Both `reallyLoadReplay()` and `loadReplay()` now handle `playbackFile()` failure by keeping the menu open, showing the replay-not-found message, and refreshing the list.
- Recorder playback mode is only entered after initialization succeeds.
- The changes are mirrored across Generals and Zero Hour.
- Side benefit now ReplayMenu.cpp can be unified to core

### Testing

1. Select a replay with a different executable hash/version.
2. Double-click it or press Load.
3. Delete the replay externally while the version-mismatch prompt is open.
4. Confirm the prompt.
5. Verify that the game does not crash, displays “REPLAY CANNOT BE LOADED,” and refreshes the replay list.