### PR TITLE
perf(contain): Optimize Object::isHero with cached hero counter

### DIFF
--- a/Generals/Code/GameEngine/Include/GameLogic/Module/ContainModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/ContainModule.h
@@ -155,6 +155,7 @@ public:
 	virtual const Object *friend_getRider() const = 0; ///< Damn.  The draw order dependency bug for riders means that our draw module needs to cheat to get around it.
 	virtual Real getContainedItemsMass() const = 0;
 	virtual UnsignedInt getStealthUnitsContained() const = 0;
+	virtual UnsignedInt getHeroUnitsContained() const = 0;
 
 	virtual Bool calcBestGarrisonPosition( Coord3D *sourcePos, const Coord3D *targetPos ) = 0;
 	virtual Bool attemptBestFirePointPosition( Object *source, Weapon *weapon, Object *victim ) = 0;

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/ContainModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/ContainModule.h
@@ -155,7 +155,9 @@ public:
 	virtual const Object *friend_getRider() const = 0; ///< Damn.  The draw order dependency bug for riders means that our draw module needs to cheat to get around it.
 	virtual Real getContainedItemsMass() const = 0;
 	virtual UnsignedInt getStealthUnitsContained() const = 0;
+#if !RETAIL_COMPATIBLE_CRC
 	virtual UnsignedInt getHeroUnitsContained() const = 0;
+#endif
 
 	virtual Bool calcBestGarrisonPosition( Coord3D *sourcePos, const Coord3D *targetPos ) = 0;
 	virtual Bool attemptBestFirePointPosition( Object *source, Weapon *weapon, Object *victim ) = 0;

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/ContainModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/ContainModule.h
@@ -155,9 +155,7 @@ public:
 	virtual const Object *friend_getRider() const = 0; ///< Damn.  The draw order dependency bug for riders means that our draw module needs to cheat to get around it.
 	virtual Real getContainedItemsMass() const = 0;
 	virtual UnsignedInt getStealthUnitsContained() const = 0;
-#if !RETAIL_COMPATIBLE_CRC
 	virtual UnsignedInt getHeroUnitsContained() const = 0;
-#endif
 
 	virtual Bool calcBestGarrisonPosition( Coord3D *sourcePos, const Coord3D *targetPos ) = 0;
 	virtual Bool attemptBestFirePointPosition( Object *source, Weapon *weapon, Object *victim ) = 0;

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/OpenContain.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/OpenContain.h
@@ -164,6 +164,7 @@ public:
 	virtual const Object *friend_getRider() const{return NULL;} ///< Damn.  The draw order dependency bug for riders means that our draw module needs to cheat to get around it.
 	virtual Real getContainedItemsMass() const;
 	virtual UnsignedInt getStealthUnitsContained() const { return m_stealthUnitsContained; }
+	virtual UnsignedInt getHeroUnitsContained() const { return m_heroUnitsContained; }
 
 	virtual PlayerMaskType getPlayerWhoEntered(void) const { return m_playerEnteredMask; }
 
@@ -238,6 +239,7 @@ private:
 
 	ObjectEnterExitMap	m_objectEnterExitInfo;
 	UnsignedInt					m_stealthUnitsContained;				///< number of stealth units that can't be seen by enemy players.
+	UnsignedInt					m_heroUnitsContained;						///< cached hero count
 	Int									m_whichExitPath; ///< Cycles from 1 to n and is used only in modules whose data has numberOfExitPaths > 1.
 	UnsignedInt					m_doorCloseCountdown;						///< When should I shut my door.
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/OpenContain.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/OpenContain.h
@@ -164,11 +164,7 @@ public:
 	virtual const Object *friend_getRider() const{return NULL;} ///< Damn.  The draw order dependency bug for riders means that our draw module needs to cheat to get around it.
 	virtual Real getContainedItemsMass() const;
 	virtual UnsignedInt getStealthUnitsContained() const { return m_stealthUnitsContained; }
-#if !RETAIL_COMPATIBLE_CRC
 	virtual UnsignedInt getHeroUnitsContained() const { return m_heroUnitsContained; }
-#else
-	virtual UnsignedInt getHeroUnitsContained() const { return 0; }
-#endif
 
 	virtual PlayerMaskType getPlayerWhoEntered(void) const { return m_playerEnteredMask; }
 
@@ -243,9 +239,7 @@ private:
 
 	ObjectEnterExitMap	m_objectEnterExitInfo;
 	UnsignedInt					m_stealthUnitsContained;				///< number of stealth units that can't be seen by enemy players.
-#if !RETAIL_COMPATIBLE_CRC
 	UnsignedInt					m_heroUnitsContained;						///< cached hero count
-#endif
 	Int									m_whichExitPath; ///< Cycles from 1 to n and is used only in modules whose data has numberOfExitPaths > 1.
 	UnsignedInt					m_doorCloseCountdown;						///< When should I shut my door.
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/OpenContain.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/OpenContain.h
@@ -240,6 +240,7 @@ private:
 	ObjectEnterExitMap	m_objectEnterExitInfo;
 	UnsignedInt					m_stealthUnitsContained;				///< number of stealth units that can't be seen by enemy players.
 	UnsignedInt					m_heroUnitsContained;						///< cached hero count
+	XferVersion					m_xferVersion;									///< version of loaded save file for loadPostProcess
 	Int									m_whichExitPath; ///< Cycles from 1 to n and is used only in modules whose data has numberOfExitPaths > 1.
 	UnsignedInt					m_doorCloseCountdown;						///< When should I shut my door.
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/OpenContain.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/OpenContain.h
@@ -164,7 +164,11 @@ public:
 	virtual const Object *friend_getRider() const{return NULL;} ///< Damn.  The draw order dependency bug for riders means that our draw module needs to cheat to get around it.
 	virtual Real getContainedItemsMass() const;
 	virtual UnsignedInt getStealthUnitsContained() const { return m_stealthUnitsContained; }
+#if !RETAIL_COMPATIBLE_CRC
 	virtual UnsignedInt getHeroUnitsContained() const { return m_heroUnitsContained; }
+#else
+	virtual UnsignedInt getHeroUnitsContained() const { return 0; }
+#endif
 
 	virtual PlayerMaskType getPlayerWhoEntered(void) const { return m_playerEnteredMask; }
 
@@ -239,7 +243,9 @@ private:
 
 	ObjectEnterExitMap	m_objectEnterExitInfo;
 	UnsignedInt					m_stealthUnitsContained;				///< number of stealth units that can't be seen by enemy players.
+#if !RETAIL_COMPATIBLE_CRC
 	UnsignedInt					m_heroUnitsContained;						///< cached hero count
+#endif
 	Int									m_whichExitPath; ///< Cycles from 1 to n and is used only in modules whose data has numberOfExitPaths > 1.
 	UnsignedInt					m_doorCloseCountdown;						///< When should I shut my door.
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -126,6 +126,7 @@ OpenContain::OpenContain( Thing *thing, const ModuleData* moduleData ) : UpdateM
 	m_containListSize = 0;
 	m_stealthUnitsContained = 0;
 	m_heroUnitsContained = 0;
+	m_xferVersion = 1;
 	m_doorCloseCountdown = 0;
 
 	m_rallyPoint.zero();
@@ -1467,6 +1468,7 @@ void OpenContain::xfer( Xfer *xfer )
 #endif
 	XferVersion version = currentVersion;
 	xfer->xferVersion( &version, currentVersion );
+	m_xferVersion = version;
 
 	// extend base class
 	UpdateModule::xfer( xfer );
@@ -1680,17 +1682,18 @@ void OpenContain::loadPostProcess( void )
 
 	}
 
-#if RETAIL_COMPATIBLE_XFER_SAVE
-	// In retail compatibility mode, restore hero count by iterating hero objects
-	m_heroUnitsContained = 0;
-	for( ContainedItemsList::const_iterator it = m_containList.begin(); it != m_containList.end(); ++it )
+	if (m_xferVersion < 2)
 	{
-		if( (*it)->isKindOf( KINDOF_HERO ) )
+		// Restore hero count by iterating hero objects for old save versions
+		m_heroUnitsContained = 0;
+		for( ContainedItemsList::const_iterator it = m_containList.begin(); it != m_containList.end(); ++it )
 		{
-			m_heroUnitsContained++;
+			if( (*it)->isKindOf( KINDOF_HERO ) )
+			{
+				m_heroUnitsContained++;
+			}
 		}
 	}
-#endif
 
 	// sanity
 	DEBUG_ASSERTCRASH( m_containListSize == m_containList.size(),

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -549,7 +549,7 @@ void OpenContain::removeFromContainViaIterator( ContainedItemsList::iterator it,
 	}
 	if( rider->isKindOf( KINDOF_HERO ) )
 	{
-		DEBUG_ASSERTCRASH( m_heroUnitsContained > 0, ("Removing hero but hero count is 0") );
+		DEBUG_ASSERTCRASH( m_heroUnitsContained > 0, ("OpenContain::removeFromContainViaIterator - Removing hero but hero count is %d", m_heroUnitsContained) );
 		m_heroUnitsContained--;
 	}
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -125,9 +125,7 @@ OpenContain::OpenContain( Thing *thing, const ModuleData* moduleData ) : UpdateM
 	m_lastLoadSoundFrame = 0;
 	m_containListSize = 0;
 	m_stealthUnitsContained = 0;
-#if !RETAIL_COMPATIBLE_CRC
 	m_heroUnitsContained = 0;
-#endif
 	m_doorCloseCountdown = 0;
 
 	m_rallyPoint.zero();
@@ -633,13 +631,10 @@ void OpenContain::onContaining( Object *rider )
 		TheAudio->addAudioEvent(&enterSound);
 	}
 
-	// TheSuperHackers @performance bobtista 13/11/2025 Cache hero count to avoid O(n) iteration in Object::isHero().
-#if !RETAIL_COMPATIBLE_CRC
 	if( rider && rider->isKindOf( KINDOF_HERO ) )
 	{
 		m_heroUnitsContained++;
 	}
-#endif
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -656,12 +651,10 @@ void OpenContain::onRemoving( Object *rider)
 		fallingSound.setObjectID(rider->getID());
 		TheAudio->addAudioEvent(&fallingSound);
 
-#if !RETAIL_COMPATIBLE_CRC
 		if( rider->isKindOf( KINDOF_HERO ) && m_heroUnitsContained > 0 )
 		{
 			m_heroUnitsContained--;
 		}
-#endif
 	}
 }
 
@@ -1543,6 +1536,9 @@ void OpenContain::xfer( Xfer *xfer )
 
 	// stealth units contained
 	xfer->xferUnsignedInt( &m_stealthUnitsContained );
+
+	// hero units contained
+	xfer->xferUnsignedInt( &m_heroUnitsContained );
 
 	// door close countdown
 	xfer->xferUnsignedInt( &m_doorCloseCountdown );

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -125,7 +125,9 @@ OpenContain::OpenContain( Thing *thing, const ModuleData* moduleData ) : UpdateM
 	m_lastLoadSoundFrame = 0;
 	m_containListSize = 0;
 	m_stealthUnitsContained = 0;
+#if !RETAIL_COMPATIBLE_CRC
 	m_heroUnitsContained = 0;
+#endif
 	m_doorCloseCountdown = 0;
 
 	m_rallyPoint.zero();
@@ -632,10 +634,12 @@ void OpenContain::onContaining( Object *rider )
 	}
 
 	// TheSuperHackers @performance bobtista 13/11/2025 Cache hero count to avoid O(n) iteration in Object::isHero().
+#if !RETAIL_COMPATIBLE_CRC
 	if( rider && rider->isKindOf( KINDOF_HERO ) )
 	{
 		m_heroUnitsContained++;
 	}
+#endif
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -652,10 +656,12 @@ void OpenContain::onRemoving( Object *rider)
 		fallingSound.setObjectID(rider->getID());
 		TheAudio->addAudioEvent(&fallingSound);
 
+#if !RETAIL_COMPATIBLE_CRC
 		if( rider->isKindOf( KINDOF_HERO ) && m_heroUnitsContained > 0 )
 		{
 			m_heroUnitsContained--;
 		}
+#endif
 	}
 }
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -353,6 +353,10 @@ void OpenContain::addToContainList( Object *rider )
 	{
 		m_stealthUnitsContained++;
 	}
+	if( rider->isKindOf( KINDOF_HERO ) )
+	{
+		m_heroUnitsContained++;
+	}
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -543,6 +547,10 @@ void OpenContain::removeFromContainViaIterator( ContainedItemsList::iterator it,
 			}
 		}
 	}
+	if( rider->isKindOf( KINDOF_HERO ) && m_heroUnitsContained > 0 )
+	{
+		m_heroUnitsContained--;
+	}
 
 
 	if (isEnclosingContainerFor( rider ))
@@ -630,11 +638,6 @@ void OpenContain::onContaining( Object *rider )
 		enterSound.setObjectID(getObject()->getID());
 		TheAudio->addAudioEvent(&enterSound);
 	}
-
-	if( rider && rider->isKindOf( KINDOF_HERO ) )
-	{
-		m_heroUnitsContained++;
-	}
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -650,11 +653,6 @@ void OpenContain::onRemoving( Object *rider)
 		AudioEventRTS fallingSound = *rider->getTemplate()->getSoundFalling();
 		fallingSound.setObjectID(rider->getID());
 		TheAudio->addAudioEvent(&fallingSound);
-
-		if( rider->isKindOf( KINDOF_HERO ) && m_heroUnitsContained > 0 )
-		{
-			m_heroUnitsContained--;
-		}
 	}
 }
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -1453,7 +1453,8 @@ void OpenContain::crc( Xfer *xfer )
 /** Xfer method
 	* Version Info:
 	* 1: Initial version
-	* 2: Added m_heroUnitsContained cached hero count (bobtista) */
+	* 2: TheSuperHackers @tweak Serialize hero units contained count
+	*/
 // ------------------------------------------------------------------------------------------------
 void OpenContain::xfer( Xfer *xfer )
 {

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -1452,13 +1452,18 @@ void OpenContain::crc( Xfer *xfer )
 // ------------------------------------------------------------------------------------------------
 /** Xfer method
 	* Version Info:
-	* 1: Initial version */
+	* 1: Initial version
+	* 2: Added m_heroUnitsContained cached hero count (bobtista) */
 // ------------------------------------------------------------------------------------------------
 void OpenContain::xfer( Xfer *xfer )
 {
 
 	// version
-	const XferVersion currentVersion = 1;
+#if RETAIL_COMPATIBLE_XFER_SAVE
+	XferVersion currentVersion = 1;
+#else
+	XferVersion currentVersion = 2;
+#endif
 	XferVersion version = currentVersion;
 	xfer->xferVersion( &version, currentVersion );
 
@@ -1685,6 +1690,18 @@ void OpenContain::loadPostProcess( void )
 		obj->friend_setContainedBy( us );
 
 	}
+
+#if RETAIL_COMPATIBLE_XFER_SAVE
+	// In retail compatibility mode, restore hero count by iterating hero objects
+	m_heroUnitsContained = 0;
+	for( ContainedItemsList::const_iterator it = m_containList.begin(); it != m_containList.end(); ++it )
+	{
+		if( (*it)->isKindOf( KINDOF_HERO ) )
+		{
+			m_heroUnitsContained++;
+		}
+	}
+#endif
 
 	// sanity
 	DEBUG_ASSERTCRASH( m_containListSize == m_containList.size(),

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -1537,7 +1537,22 @@ void OpenContain::xfer( Xfer *xfer )
 	xfer->xferUnsignedInt( &m_stealthUnitsContained );
 
 	// hero units contained
-	xfer->xferUnsignedInt( &m_heroUnitsContained );
+#if !RETAIL_COMPATIBLE_XFER_SAVE
+	if (version >= 2)
+	{
+		xfer->xferUnsignedInt( &m_heroUnitsContained );
+	}
+	else if (xfer->getXferMode() == XFER_LOAD)
+	{
+		m_heroUnitsContained = 0;
+	}
+#else
+	// In retail compatibility mode, hero count is restored by iterating hero objects in loadPostProcess
+	if (xfer->getXferMode() == XFER_LOAD)
+	{
+		m_heroUnitsContained = 0;
+	}
+#endif
 
 	// door close countdown
 	xfer->xferUnsignedInt( &m_doorCloseCountdown );

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -1542,22 +1542,10 @@ void OpenContain::xfer( Xfer *xfer )
 	xfer->xferUnsignedInt( &m_stealthUnitsContained );
 
 	// hero units contained
-#if !RETAIL_COMPATIBLE_XFER_SAVE
 	if (version >= 2)
 	{
 		xfer->xferUnsignedInt( &m_heroUnitsContained );
 	}
-	else if (xfer->getXferMode() == XFER_LOAD)
-	{
-		m_heroUnitsContained = 0;
-	}
-#else
-	// In retail compatibility mode, hero count is restored by iterating hero objects in loadPostProcess
-	if (xfer->getXferMode() == XFER_LOAD)
-	{
-		m_heroUnitsContained = 0;
-	}
-#endif
 
 	// door close countdown
 	xfer->xferUnsignedInt( &m_doorCloseCountdown );

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -547,8 +547,9 @@ void OpenContain::removeFromContainViaIterator( ContainedItemsList::iterator it,
 			}
 		}
 	}
-	if( rider->isKindOf( KINDOF_HERO ) && m_heroUnitsContained > 0 )
+	if( rider->isKindOf( KINDOF_HERO ) )
 	{
+		DEBUG_ASSERTCRASH( m_heroUnitsContained > 0, ("Removing hero but hero count is 0") );
 		m_heroUnitsContained--;
 	}
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -538,6 +538,7 @@ void OpenContain::removeFromContainViaIterator( ContainedItemsList::iterator it,
 	m_containListSize--;
 	if( rider->isKindOf( KINDOF_STEALTH_GARRISON ) )
 	{
+		DEBUG_ASSERTCRASH( m_stealthUnitsContained > 0, ("OpenContain::removeFromContainViaIterator - Removing stealth unit but stealth count is %d", m_stealthUnitsContained) );
 		m_stealthUnitsContained--;
 		if( exposeStealthUnits )
 		{

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -125,6 +125,7 @@ OpenContain::OpenContain( Thing *thing, const ModuleData* moduleData ) : UpdateM
 	m_lastLoadSoundFrame = 0;
 	m_containListSize = 0;
 	m_stealthUnitsContained = 0;
+	m_heroUnitsContained = 0;
 	m_doorCloseCountdown = 0;
 
 	m_rallyPoint.zero();
@@ -620,7 +621,7 @@ void OpenContain::scatterToNearbyPosition(Object* rider)
 }
 
 //-------------------------------------------------------------------------------------------------
-void OpenContain::onContaining( Object * /*rider*/ )
+void OpenContain::onContaining( Object *rider )
 {
 	// Play audio
 	if( m_loadSoundsEnabled )
@@ -628,6 +629,12 @@ void OpenContain::onContaining( Object * /*rider*/ )
 		AudioEventRTS enterSound = *getObject()->getTemplate()->getSoundEnter();
 		enterSound.setObjectID(getObject()->getID());
 		TheAudio->addAudioEvent(&enterSound);
+	}
+
+	// TheSuperHackers @performance bobtista 13/11/2025 Cache hero count to avoid O(n) iteration in Object::isHero().
+	if( rider && rider->isKindOf( KINDOF_HERO ) )
+	{
+		m_heroUnitsContained++;
 	}
 }
 
@@ -644,6 +651,11 @@ void OpenContain::onRemoving( Object *rider)
 		AudioEventRTS fallingSound = *rider->getTemplate()->getSoundFalling();
 		fallingSound.setObjectID(rider->getID());
 		TheAudio->addAudioEvent(&fallingSound);
+
+		if( rider->isKindOf( KINDOF_HERO ) && m_heroUnitsContained > 0 )
+		{
+			m_heroUnitsContained--;
+		}
 	}
 }
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -594,16 +594,38 @@ Object::~Object()
 
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
+#if RETAIL_COMPATIBLE_CRC
+void localIsHero( Object *obj, void* userData )
+{
+	Bool *hero = (Bool*)userData;
+
+	if( obj && obj->isKindOf( KINDOF_HERO ) )
+	{
+		*hero = TRUE;
+	}
+}
+#endif
+
+//-------------------------------------------------------------------------------------------------
 // TheSuperHackers @performance bobtista 13/11/2025 Use cached hero count for O(1) lookup instead of O(n) iteration.
 Bool Object::isHero() const
 {
 	ContainModuleInterface *contain = getContain();
 	if( contain )
 	{
+#if !RETAIL_COMPATIBLE_CRC
 		if( contain->getHeroUnitsContained() > 0 )
 		{
 			return TRUE;
 		}
+#else
+		Bool heroInside = FALSE;
+		contain->iterateContained( localIsHero, (void*)(&heroInside), FALSE );
+		if( heroInside )
+		{
+			return TRUE;
+		}
+#endif
 	}
 	return isKindOf( KINDOF_HERO );
 }

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -593,39 +593,16 @@ Object::~Object()
 }
 
 //-------------------------------------------------------------------------------------------------
-//-------------------------------------------------------------------------------------------------
-#if RETAIL_COMPATIBLE_CRC
-void localIsHero( Object *obj, void* userData )
-{
-	Bool *hero = (Bool*)userData;
-
-	if( obj && obj->isKindOf( KINDOF_HERO ) )
-	{
-		*hero = TRUE;
-	}
-}
-#endif
-
-//-------------------------------------------------------------------------------------------------
 // TheSuperHackers @performance bobtista 13/11/2025 Use cached hero count for O(1) lookup instead of O(n) iteration.
 Bool Object::isHero() const
 {
 	ContainModuleInterface *contain = getContain();
 	if( contain )
 	{
-#if !RETAIL_COMPATIBLE_CRC
 		if( contain->getHeroUnitsContained() > 0 )
 		{
 			return TRUE;
 		}
-#else
-		Bool heroInside = FALSE;
-		contain->iterateContained( localIsHero, (void*)(&heroInside), FALSE );
-		if( heroInside )
-		{
-			return TRUE;
-		}
-#endif
 	}
 	return isKindOf( KINDOF_HERO );
 }

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -593,25 +593,14 @@ Object::~Object()
 }
 
 //-------------------------------------------------------------------------------------------------
-void localIsHero( Object *obj, void* userData )
-{
-	Bool *hero = (Bool*)userData;
-
-	if( obj && obj->isKindOf( KINDOF_HERO ) )
-	{
-		*hero = TRUE;
-	}
-}
-
 //-------------------------------------------------------------------------------------------------
+// TheSuperHackers @performance bobtista 13/11/2025 Use cached hero count for O(1) lookup instead of O(n) iteration.
 Bool Object::isHero() const
 {
 	ContainModuleInterface *contain = getContain();
 	if( contain )
 	{
-		Bool heroInside = FALSE;
-		contain->iterateContained( localIsHero, (void*)(&heroInside), FALSE );
-		if( heroInside )
+		if( contain->getHeroUnitsContained() > 0 )
 		{
 			return TRUE;
 		}

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ContainModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ContainModule.h
@@ -175,6 +175,7 @@ public:
 	virtual const Object *friend_getRider() const = 0; ///< Damn.  The draw order dependency bug for riders means that our draw module needs to cheat to get around it.
 	virtual Real getContainedItemsMass() const = 0;
 	virtual UnsignedInt getStealthUnitsContained() const = 0;
+	virtual UnsignedInt getHeroUnitsContained() const = 0;
 
 	virtual Bool calcBestGarrisonPosition( Coord3D *sourcePos, const Coord3D *targetPos ) = 0;
 	virtual Bool attemptBestFirePointPosition( Object *source, Weapon *weapon, Object *victim ) = 0;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ContainModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ContainModule.h
@@ -175,9 +175,7 @@ public:
 	virtual const Object *friend_getRider() const = 0; ///< Damn.  The draw order dependency bug for riders means that our draw module needs to cheat to get around it.
 	virtual Real getContainedItemsMass() const = 0;
 	virtual UnsignedInt getStealthUnitsContained() const = 0;
-#if !RETAIL_COMPATIBLE_CRC
 	virtual UnsignedInt getHeroUnitsContained() const = 0;
-#endif
 
 	virtual Bool calcBestGarrisonPosition( Coord3D *sourcePos, const Coord3D *targetPos ) = 0;
 	virtual Bool attemptBestFirePointPosition( Object *source, Weapon *weapon, Object *victim ) = 0;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ContainModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ContainModule.h
@@ -175,7 +175,9 @@ public:
 	virtual const Object *friend_getRider() const = 0; ///< Damn.  The draw order dependency bug for riders means that our draw module needs to cheat to get around it.
 	virtual Real getContainedItemsMass() const = 0;
 	virtual UnsignedInt getStealthUnitsContained() const = 0;
+#if !RETAIL_COMPATIBLE_CRC
 	virtual UnsignedInt getHeroUnitsContained() const = 0;
+#endif
 
 	virtual Bool calcBestGarrisonPosition( Coord3D *sourcePos, const Coord3D *targetPos ) = 0;
 	virtual Bool attemptBestFirePointPosition( Object *source, Weapon *weapon, Object *victim ) = 0;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OpenContain.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OpenContain.h
@@ -174,11 +174,7 @@ public:
 	virtual const Object *friend_getRider() const{return NULL;} ///< Damn.  The draw order dependency bug for riders means that our draw module needs to cheat to get around it.
 	virtual Real getContainedItemsMass() const;
 	virtual UnsignedInt getStealthUnitsContained() const { return m_stealthUnitsContained; }
-#if !RETAIL_COMPATIBLE_CRC
 	virtual UnsignedInt getHeroUnitsContained() const { return m_heroUnitsContained; }
-#else
-	virtual UnsignedInt getHeroUnitsContained() const { return 0; }
-#endif
 
 	virtual PlayerMaskType getPlayerWhoEntered(void) const { return m_playerEnteredMask; }
 
@@ -264,9 +260,7 @@ private:
 
 	ObjectEnterExitMap	m_objectEnterExitInfo;
 	UnsignedInt					m_stealthUnitsContained;				///< number of stealth units that can't be seen by enemy players.
-#if !RETAIL_COMPATIBLE_CRC
 	UnsignedInt					m_heroUnitsContained;						///< cached hero count
-#endif
 	Int									m_whichExitPath; ///< Cycles from 1 to n and is used only in modules whose data has numberOfExitPaths > 1.
 	UnsignedInt					m_doorCloseCountdown;						///< When should I shut my door.
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OpenContain.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OpenContain.h
@@ -174,6 +174,7 @@ public:
 	virtual const Object *friend_getRider() const{return NULL;} ///< Damn.  The draw order dependency bug for riders means that our draw module needs to cheat to get around it.
 	virtual Real getContainedItemsMass() const;
 	virtual UnsignedInt getStealthUnitsContained() const { return m_stealthUnitsContained; }
+	virtual UnsignedInt getHeroUnitsContained() const { return m_heroUnitsContained; }
 
 	virtual PlayerMaskType getPlayerWhoEntered(void) const { return m_playerEnteredMask; }
 
@@ -259,6 +260,7 @@ private:
 
 	ObjectEnterExitMap	m_objectEnterExitInfo;
 	UnsignedInt					m_stealthUnitsContained;				///< number of stealth units that can't be seen by enemy players.
+	UnsignedInt					m_heroUnitsContained;						///< cached hero count
 	Int									m_whichExitPath; ///< Cycles from 1 to n and is used only in modules whose data has numberOfExitPaths > 1.
 	UnsignedInt					m_doorCloseCountdown;						///< When should I shut my door.
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OpenContain.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OpenContain.h
@@ -174,7 +174,11 @@ public:
 	virtual const Object *friend_getRider() const{return NULL;} ///< Damn.  The draw order dependency bug for riders means that our draw module needs to cheat to get around it.
 	virtual Real getContainedItemsMass() const;
 	virtual UnsignedInt getStealthUnitsContained() const { return m_stealthUnitsContained; }
+#if !RETAIL_COMPATIBLE_CRC
 	virtual UnsignedInt getHeroUnitsContained() const { return m_heroUnitsContained; }
+#else
+	virtual UnsignedInt getHeroUnitsContained() const { return 0; }
+#endif
 
 	virtual PlayerMaskType getPlayerWhoEntered(void) const { return m_playerEnteredMask; }
 
@@ -260,7 +264,9 @@ private:
 
 	ObjectEnterExitMap	m_objectEnterExitInfo;
 	UnsignedInt					m_stealthUnitsContained;				///< number of stealth units that can't be seen by enemy players.
+#if !RETAIL_COMPATIBLE_CRC
 	UnsignedInt					m_heroUnitsContained;						///< cached hero count
+#endif
 	Int									m_whichExitPath; ///< Cycles from 1 to n and is used only in modules whose data has numberOfExitPaths > 1.
 	UnsignedInt					m_doorCloseCountdown;						///< When should I shut my door.
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OpenContain.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OpenContain.h
@@ -261,6 +261,7 @@ private:
 	ObjectEnterExitMap	m_objectEnterExitInfo;
 	UnsignedInt					m_stealthUnitsContained;				///< number of stealth units that can't be seen by enemy players.
 	UnsignedInt					m_heroUnitsContained;						///< cached hero count
+	XferVersion					m_xferVersion;									///< version of loaded save file for loadPostProcess
 	Int									m_whichExitPath; ///< Cycles from 1 to n and is used only in modules whose data has numberOfExitPaths > 1.
 	UnsignedInt					m_doorCloseCountdown;						///< When should I shut my door.
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -665,8 +665,9 @@ void OpenContain::removeFromContainViaIterator( ContainedItemsList::iterator it,
 			}
 		}
 	}
-	if( rider->isKindOf( KINDOF_HERO ) && m_heroUnitsContained > 0 )
+	if( rider->isKindOf( KINDOF_HERO ) )
 	{
+		DEBUG_ASSERTCRASH( m_heroUnitsContained > 0, ("Removing hero but hero count is 0") );
 		m_heroUnitsContained--;
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -129,6 +129,7 @@ OpenContain::OpenContain( Thing *thing, const ModuleData* moduleData ) : UpdateM
 	m_lastLoadSoundFrame = 0;
 	m_containListSize = 0;
 	m_stealthUnitsContained = 0;
+	m_heroUnitsContained = 0;
 	m_doorCloseCountdown = 0;
 
 	m_rallyPoint.zero();
@@ -749,6 +750,12 @@ void OpenContain::onContaining( Object *rider, Bool wasSelected )
 		enterSound.setObjectID(getObject()->getID());
 		TheAudio->addAudioEvent(&enterSound);
 	}
+
+	// TheSuperHackers @performance bobtista 13/11/2025 Cache hero count to avoid O(n) iteration in Object::isHero().
+	if( rider && rider->isKindOf( KINDOF_HERO ) )
+	{
+		m_heroUnitsContained++;
+	}
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -764,6 +771,11 @@ void OpenContain::onRemoving( Object *rider)
 		AudioEventRTS fallingSound = *rider->getTemplate()->getSoundFalling();
 		fallingSound.setObjectID(rider->getID());
 		TheAudio->addAudioEvent(&fallingSound);
+
+		if( rider->isKindOf( KINDOF_HERO ) && m_heroUnitsContained > 0 )
+		{
+			m_heroUnitsContained--;
+		}
 	}
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -1677,13 +1677,19 @@ void OpenContain::crc( Xfer *xfer )
 // ------------------------------------------------------------------------------------------------
 /** Xfer method
 	* Version Info:
-	* 1: Initial version */
+	* 1: Initial version
+	* 2: Added m_passengerAllowedToFire
+	* 3: Added m_heroUnitsContained cached hero count (bobtista) */
 // ------------------------------------------------------------------------------------------------
 void OpenContain::xfer( Xfer *xfer )
 {
 
 	// version
-	const XferVersion currentVersion = 2;
+#if RETAIL_COMPATIBLE_XFER_SAVE
+	XferVersion currentVersion = 2;
+#else
+	XferVersion currentVersion = 3;
+#endif
 	XferVersion version = currentVersion;
 	xfer->xferVersion( &version, currentVersion );
 
@@ -1762,7 +1768,22 @@ void OpenContain::xfer( Xfer *xfer )
 	xfer->xferUnsignedInt( &m_stealthUnitsContained );
 
 	// hero units contained
-	xfer->xferUnsignedInt( &m_heroUnitsContained );
+#if !RETAIL_COMPATIBLE_XFER_SAVE
+	if (version >= 3)
+	{
+		xfer->xferUnsignedInt( &m_heroUnitsContained );
+	}
+	else if (xfer->getXferMode() == XFER_LOAD)
+	{
+		m_heroUnitsContained = 0;
+	}
+#else
+	// In retail compatibility mode, hero count is restored by iterating hero objects in loadPostProcess
+	if (xfer->getXferMode() == XFER_LOAD)
+	{
+		m_heroUnitsContained = 0;
+	}
+#endif
 
 	// door close countdown
 	xfer->xferUnsignedInt( &m_doorCloseCountdown );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -667,7 +667,7 @@ void OpenContain::removeFromContainViaIterator( ContainedItemsList::iterator it,
 	}
 	if( rider->isKindOf( KINDOF_HERO ) )
 	{
-		DEBUG_ASSERTCRASH( m_heroUnitsContained > 0, ("Removing hero but hero count is 0") );
+		DEBUG_ASSERTCRASH( m_heroUnitsContained > 0, ("OpenContain::removeFromContainViaIterator - Removing hero but hero count is %d", m_heroUnitsContained) );
 		m_heroUnitsContained--;
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -130,6 +130,7 @@ OpenContain::OpenContain( Thing *thing, const ModuleData* moduleData ) : UpdateM
 	m_containListSize = 0;
 	m_stealthUnitsContained = 0;
 	m_heroUnitsContained = 0;
+	m_xferVersion = 1;
 	m_doorCloseCountdown = 0;
 
 	m_rallyPoint.zero();
@@ -1693,6 +1694,7 @@ void OpenContain::xfer( Xfer *xfer )
 #endif
 	XferVersion version = currentVersion;
 	xfer->xferVersion( &version, currentVersion );
+	m_xferVersion = version;
 
 	// extend base class
 	UpdateModule::xfer( xfer );
@@ -1913,17 +1915,18 @@ void OpenContain::loadPostProcess( void )
 
 	}
 
-#if RETAIL_COMPATIBLE_XFER_SAVE
-	// In retail compatibility mode, restore hero count by iterating hero objects
-	m_heroUnitsContained = 0;
-	for( ContainedItemsList::const_iterator it = m_containList.begin(); it != m_containList.end(); ++it )
+	if (m_xferVersion < 3)
 	{
-		if( (*it)->isKindOf( KINDOF_HERO ) )
+		// Restore hero count by iterating hero objects for old save versions
+		m_heroUnitsContained = 0;
+		for( ContainedItemsList::const_iterator it = m_containList.begin(); it != m_containList.end(); ++it )
 		{
-			m_heroUnitsContained++;
+			if( (*it)->isKindOf( KINDOF_HERO ) )
+			{
+				m_heroUnitsContained++;
+			}
 		}
 	}
-#endif
 
 	// sanity
 	DEBUG_ASSERTCRASH( m_containListSize == m_containList.size(),

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -129,9 +129,7 @@ OpenContain::OpenContain( Thing *thing, const ModuleData* moduleData ) : UpdateM
 	m_lastLoadSoundFrame = 0;
 	m_containListSize = 0;
 	m_stealthUnitsContained = 0;
-#if !RETAIL_COMPATIBLE_CRC
 	m_heroUnitsContained = 0;
-#endif
 	m_doorCloseCountdown = 0;
 
 	m_rallyPoint.zero();
@@ -753,13 +751,10 @@ void OpenContain::onContaining( Object *rider, Bool wasSelected )
 		TheAudio->addAudioEvent(&enterSound);
 	}
 
-	// TheSuperHackers @performance bobtista 13/11/2025 Cache hero count to avoid O(n) iteration in Object::isHero().
-#if !RETAIL_COMPATIBLE_CRC
 	if( rider && rider->isKindOf( KINDOF_HERO ) )
 	{
 		m_heroUnitsContained++;
 	}
-#endif
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -776,12 +771,10 @@ void OpenContain::onRemoving( Object *rider)
 		fallingSound.setObjectID(rider->getID());
 		TheAudio->addAudioEvent(&fallingSound);
 
-#if !RETAIL_COMPATIBLE_CRC
 		if( rider->isKindOf( KINDOF_HERO ) && m_heroUnitsContained > 0 )
 		{
 			m_heroUnitsContained--;
 		}
-#endif
 	}
 }
 
@@ -1768,6 +1761,9 @@ void OpenContain::xfer( Xfer *xfer )
 
 	// stealth units contained
 	xfer->xferUnsignedInt( &m_stealthUnitsContained );
+
+	// hero units contained
+	xfer->xferUnsignedInt( &m_heroUnitsContained );
 
 	// door close countdown
 	xfer->xferUnsignedInt( &m_doorCloseCountdown );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -129,7 +129,9 @@ OpenContain::OpenContain( Thing *thing, const ModuleData* moduleData ) : UpdateM
 	m_lastLoadSoundFrame = 0;
 	m_containListSize = 0;
 	m_stealthUnitsContained = 0;
+#if !RETAIL_COMPATIBLE_CRC
 	m_heroUnitsContained = 0;
+#endif
 	m_doorCloseCountdown = 0;
 
 	m_rallyPoint.zero();
@@ -752,10 +754,12 @@ void OpenContain::onContaining( Object *rider, Bool wasSelected )
 	}
 
 	// TheSuperHackers @performance bobtista 13/11/2025 Cache hero count to avoid O(n) iteration in Object::isHero().
+#if !RETAIL_COMPATIBLE_CRC
 	if( rider && rider->isKindOf( KINDOF_HERO ) )
 	{
 		m_heroUnitsContained++;
 	}
+#endif
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -772,10 +776,12 @@ void OpenContain::onRemoving( Object *rider)
 		fallingSound.setObjectID(rider->getID());
 		TheAudio->addAudioEvent(&fallingSound);
 
+#if !RETAIL_COMPATIBLE_CRC
 		if( rider->isKindOf( KINDOF_HERO ) && m_heroUnitsContained > 0 )
 		{
 			m_heroUnitsContained--;
 		}
+#endif
 	}
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -1768,22 +1768,10 @@ void OpenContain::xfer( Xfer *xfer )
 	xfer->xferUnsignedInt( &m_stealthUnitsContained );
 
 	// hero units contained
-#if !RETAIL_COMPATIBLE_XFER_SAVE
 	if (version >= 3)
 	{
 		xfer->xferUnsignedInt( &m_heroUnitsContained );
 	}
-	else if (xfer->getXferMode() == XFER_LOAD)
-	{
-		m_heroUnitsContained = 0;
-	}
-#else
-	// In retail compatibility mode, hero count is restored by iterating hero objects in loadPostProcess
-	if (xfer->getXferMode() == XFER_LOAD)
-	{
-		m_heroUnitsContained = 0;
-	}
-#endif
 
 	// door close countdown
 	xfer->xferUnsignedInt( &m_doorCloseCountdown );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -1679,7 +1679,8 @@ void OpenContain::crc( Xfer *xfer )
 	* Version Info:
 	* 1: Initial version
 	* 2: Added m_passengerAllowedToFire
-	* 3: Added m_heroUnitsContained cached hero count (bobtista) */
+	* 3: TheSuperHackers @tweak Serialize hero units contained count
+	*/
 // ------------------------------------------------------------------------------------------------
 void OpenContain::xfer( Xfer *xfer )
 {

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -1924,6 +1924,18 @@ void OpenContain::loadPostProcess( void )
 
 	}
 
+#if RETAIL_COMPATIBLE_XFER_SAVE
+	// In retail compatibility mode, restore hero count by iterating hero objects
+	m_heroUnitsContained = 0;
+	for( ContainedItemsList::const_iterator it = m_containList.begin(); it != m_containList.end(); ++it )
+	{
+		if( (*it)->isKindOf( KINDOF_HERO ) )
+		{
+			m_heroUnitsContained++;
+		}
+	}
+#endif
+
 	// sanity
 	DEBUG_ASSERTCRASH( m_containListSize == m_containList.size(),
 										 ("OpenContain::loadPostProcess - contain list count mismatch") );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -656,6 +656,7 @@ void OpenContain::removeFromContainViaIterator( ContainedItemsList::iterator it,
 	m_containListSize--;
 	if( rider->isKindOf( KINDOF_STEALTH_GARRISON ) )
 	{
+		DEBUG_ASSERTCRASH( m_stealthUnitsContained > 0, ("OpenContain::removeFromContainViaIterator - Removing stealth unit but stealth count is %d", m_stealthUnitsContained) );
 		m_stealthUnitsContained--;
 		if( exposeStealthUnits )
 		{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -375,6 +375,10 @@ void OpenContain::addToContainList( Object *rider )
 	{
 		m_stealthUnitsContained++;
 	}
+	if( rider->isKindOf( KINDOF_HERO ) )
+	{
+		m_heroUnitsContained++;
+	}
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -661,6 +665,10 @@ void OpenContain::removeFromContainViaIterator( ContainedItemsList::iterator it,
 			}
 		}
 	}
+	if( rider->isKindOf( KINDOF_HERO ) && m_heroUnitsContained > 0 )
+	{
+		m_heroUnitsContained--;
+	}
 
 
 	if (isEnclosingContainerFor( rider ))
@@ -750,11 +758,6 @@ void OpenContain::onContaining( Object *rider, Bool wasSelected )
 		enterSound.setObjectID(getObject()->getID());
 		TheAudio->addAudioEvent(&enterSound);
 	}
-
-	if( rider && rider->isKindOf( KINDOF_HERO ) )
-	{
-		m_heroUnitsContained++;
-	}
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -770,11 +773,6 @@ void OpenContain::onRemoving( Object *rider)
 		AudioEventRTS fallingSound = *rider->getTemplate()->getSoundFalling();
 		fallingSound.setObjectID(rider->getID());
 		TheAudio->addAudioEvent(&fallingSound);
-
-		if( rider->isKindOf( KINDOF_HERO ) && m_heroUnitsContained > 0 )
-		{
-			m_heroUnitsContained--;
-		}
 	}
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/RiderChangeContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/RiderChangeContain.cpp
@@ -184,7 +184,9 @@ Bool RiderChangeContain::isValidContainerFor(const Object* rider, Bool checkCapa
 //-------------------------------------------------------------------------------------------------
 void RiderChangeContain::onContaining( Object *rider, Bool wasSelected )
 {
+#if !RETAIL_COMPATIBLE_CRC
 	TransportContain::onContaining( rider, wasSelected );
+#endif
 
 	Object *obj = getObject();
 	m_containing = TRUE;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/RiderChangeContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/RiderChangeContain.cpp
@@ -184,6 +184,8 @@ Bool RiderChangeContain::isValidContainerFor(const Object* rider, Bool checkCapa
 //-------------------------------------------------------------------------------------------------
 void RiderChangeContain::onContaining( Object *rider, Bool wasSelected )
 {
+	TransportContain::onContaining( rider, wasSelected );
+
 	Object *obj = getObject();
 	m_containing = TRUE;
 	//Remove our existing rider

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/RiderChangeContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/RiderChangeContain.cpp
@@ -184,10 +184,6 @@ Bool RiderChangeContain::isValidContainerFor(const Object* rider, Bool checkCapa
 //-------------------------------------------------------------------------------------------------
 void RiderChangeContain::onContaining( Object *rider, Bool wasSelected )
 {
-#if !RETAIL_COMPATIBLE_CRC
-	TransportContain::onContaining( rider, wasSelected );
-#endif
-
 	Object *obj = getObject();
 	m_containing = TRUE;
 	//Remove our existing rider

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -2043,16 +2043,38 @@ Bool Object::isNonFactionStructure(void) const
 }
 
 //-------------------------------------------------------------------------------------------------
+#if RETAIL_COMPATIBLE_CRC
+void localIsHero( Object *obj, void* userData )
+{
+	Bool *hero = (Bool*)userData;
+
+	if( obj && obj->isKindOf( KINDOF_HERO ) )
+	{
+		*hero = TRUE;
+	}
+}
+#endif
+
+//-------------------------------------------------------------------------------------------------
 // TheSuperHackers @performance bobtista 13/11/2025 Use cached hero count for O(1) lookup instead of O(n) iteration.
 Bool Object::isHero(void) const
 {
 	ContainModuleInterface *contain = getContain();
 	if( contain )
 	{
+#if !RETAIL_COMPATIBLE_CRC
 		if( contain->getHeroUnitsContained() > 0 )
 		{
 			return TRUE;
 		}
+#else
+		Bool heroInside = FALSE;
+		contain->iterateContained( localIsHero, (void*)(&heroInside), FALSE );
+		if( heroInside )
+		{
+			return TRUE;
+		}
+#endif
 	}
 	return isKindOf( KINDOF_HERO );
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -2042,25 +2042,14 @@ Bool Object::isNonFactionStructure(void) const
 	return isStructure() && !isFactionStructure();
 }
 
-void localIsHero( Object *obj, void* userData )
-{
-	Bool *hero = (Bool*)userData;
-
-	if( obj && obj->isKindOf( KINDOF_HERO ) )
-	{
-		*hero = TRUE;
-	}
-}
-
 //-------------------------------------------------------------------------------------------------
+// TheSuperHackers @performance bobtista 13/11/2025 Use cached hero count for O(1) lookup instead of O(n) iteration.
 Bool Object::isHero(void) const
 {
 	ContainModuleInterface *contain = getContain();
 	if( contain )
 	{
-		Bool heroInside = FALSE;
-		contain->iterateContained( localIsHero, (void*)(&heroInside), FALSE );
-		if( heroInside )
+		if( contain->getHeroUnitsContained() > 0 )
 		{
 			return TRUE;
 		}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -2043,38 +2043,16 @@ Bool Object::isNonFactionStructure(void) const
 }
 
 //-------------------------------------------------------------------------------------------------
-#if RETAIL_COMPATIBLE_CRC
-void localIsHero( Object *obj, void* userData )
-{
-	Bool *hero = (Bool*)userData;
-
-	if( obj && obj->isKindOf( KINDOF_HERO ) )
-	{
-		*hero = TRUE;
-	}
-}
-#endif
-
-//-------------------------------------------------------------------------------------------------
 // TheSuperHackers @performance bobtista 13/11/2025 Use cached hero count for O(1) lookup instead of O(n) iteration.
 Bool Object::isHero(void) const
 {
 	ContainModuleInterface *contain = getContain();
 	if( contain )
 	{
-#if !RETAIL_COMPATIBLE_CRC
 		if( contain->getHeroUnitsContained() > 0 )
 		{
 			return TRUE;
 		}
-#else
-		Bool heroInside = FALSE;
-		contain->iterateContained( localIsHero, (void*)(&heroInside), FALSE );
-		if( heroInside )
-		{
-			return TRUE;
-		}
-#endif
 	}
 	return isKindOf( KINDOF_HERO );
 }


### PR DESCRIPTION
- Fixes #1265

### Summary

Optimizes `Object::isHero()` by caching hero count in containers instead of iterating through all contained objects on every call.