### PR TITLE
perf(audio): Optimize fail condition order in AudioManager::addAudioEvent

### DIFF
--- a/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
+++ b/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
@@ -72,7 +72,9 @@
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
+#if !RETAIL_COMPATIBLE_CRC
 static const AsciiString s_noSoundString("NoSound");
+#endif
 
 static const char* TheSpeakerTypes[] =
 {
@@ -409,7 +411,11 @@ void AudioManager::getInfoForAudioEvent( const AudioEventRTS *eventToFindAndFill
 //-------------------------------------------------------------------------------------------------
 AudioHandle AudioManager::addAudioEvent(const AudioEventRTS *eventToAdd)
 {
+#if RETAIL_COMPATIBLE_CRC
+	if (eventToAdd->getEventName().isEmpty() || eventToAdd->getEventName() == AsciiString("NoSound")) {
+#else
 	if (eventToAdd->getEventName().isEmpty() || eventToAdd->getEventName() == s_noSoundString) {
+#endif
 		return AHSV_NoSound;
 	}
 
@@ -445,11 +451,13 @@ AudioHandle AudioManager::addAudioEvent(const AudioEventRTS *eventToAdd)
 		return AHSV_NoSound;
 	}
 
+#if !RETAIL_COMPATIBLE_CRC
 	if (!eventToAdd->getUninterruptable()) {
 		if (!shouldPlayLocally(eventToAdd)) {
 			return AHSV_NotForLocal;
 		}
 	}
+#endif
 
 	AudioEventRTS *audioEvent = MSGNEW("AudioEventRTS") AudioEventRTS(*eventToAdd);		// poolify
 	audioEvent->setPlayingHandle( allocateNewHandle() );
@@ -464,6 +472,15 @@ AudioHandle AudioManager::addAudioEvent(const AudioEventRTS *eventToAdd)
 			break;
 		}
 	}
+
+#if RETAIL_COMPATIBLE_CRC
+	if (!audioEvent->getUninterruptable()) {
+		if (!shouldPlayLocally(audioEvent)) {
+			releaseAudioEventRTS(audioEvent);
+			return AHSV_NotForLocal;
+		}
+	}
+#endif
 
 	// cull muted audio
 	if (audioEvent->getVolume() < m_audioSettings->m_minVolume) {

--- a/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
+++ b/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
@@ -443,19 +443,17 @@ AudioHandle AudioManager::addAudioEvent(const AudioEventRTS *eventToAdd)
 		return AHSV_NoSound;
 	}
 
-	AudioEventRTS tempEvent = *eventToAdd;
-	tempEvent.generateFilename();
-	((AudioEventRTS*)eventToAdd)->setPlayingAudioIndex( tempEvent.getPlayingAudioIndex() );
-	tempEvent.generatePlayInfo();
-
-	if (!tempEvent.getUninterruptable()) {
-		if (!shouldPlayLocally(&tempEvent)) {
+	if (!eventToAdd->getUninterruptable()) {
+		if (!shouldPlayLocally(eventToAdd)) {
 			return AHSV_NotForLocal;
 		}
 	}
 
-	AudioEventRTS *audioEvent = MSGNEW("AudioEventRTS") AudioEventRTS(tempEvent);		// poolify
+	AudioEventRTS *audioEvent = MSGNEW("AudioEventRTS") AudioEventRTS(*eventToAdd);		// poolify
 	audioEvent->setPlayingHandle( allocateNewHandle() );
+	audioEvent->generateFilename();	// which file are we actually going to play?
+	((AudioEventRTS*)eventToAdd)->setPlayingAudioIndex( audioEvent->getPlayingAudioIndex() );
+	audioEvent->generatePlayInfo();	// generate pitch shift and volume shift now as well
 
 	std::list<std::pair<AsciiString, Real> >::iterator it;
 	for (it = m_adjustedVolumes.begin(); it != m_adjustedVolumes.end(); ++it) {

--- a/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
+++ b/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
@@ -451,18 +451,18 @@ AudioHandle AudioManager::addAudioEvent(const AudioEventRTS *eventToAdd)
 	((AudioEventRTS*)eventToAdd)->setPlayingAudioIndex( audioEvent->getPlayingAudioIndex() );
 	audioEvent->generatePlayInfo();	// generate pitch shift and volume shift now as well
 
-	if (!audioEvent->getUninterruptable()) {
-		if (!shouldPlayLocally(audioEvent)) {
-			releaseAudioEventRTS(audioEvent);
-			return AHSV_NotForLocal;
-		}
-	}
-
 	std::list<std::pair<AsciiString, Real> >::iterator it;
 	for (it = m_adjustedVolumes.begin(); it != m_adjustedVolumes.end(); ++it) {
 		if (it->first == audioEvent->getEventName()) {
 			audioEvent->setVolume(it->second);
 			break;
+		}
+	}
+
+	if (!audioEvent->getUninterruptable()) {
+		if (!shouldPlayLocally(audioEvent)) {
+			releaseAudioEventRTS(audioEvent);
+			return AHSV_NotForLocal;
 		}
 	}
 

--- a/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
+++ b/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
@@ -445,17 +445,18 @@ AudioHandle AudioManager::addAudioEvent(const AudioEventRTS *eventToAdd)
 		return AHSV_NoSound;
 	}
 
-	if (!eventToAdd->getUninterruptable()) {
-		if (!shouldPlayLocally(eventToAdd)) {
-			return AHSV_NotForLocal;
-		}
-	}
-
 	AudioEventRTS *audioEvent = MSGNEW("AudioEventRTS") AudioEventRTS(*eventToAdd);		// poolify
 	audioEvent->setPlayingHandle( allocateNewHandle() );
 	audioEvent->generateFilename();	// which file are we actually going to play?
 	((AudioEventRTS*)eventToAdd)->setPlayingAudioIndex( audioEvent->getPlayingAudioIndex() );
 	audioEvent->generatePlayInfo();	// generate pitch shift and volume shift now as well
+
+	if (!audioEvent->getUninterruptable()) {
+		if (!shouldPlayLocally(audioEvent)) {
+			releaseAudioEventRTS(audioEvent);
+			return AHSV_NotForLocal;
+		}
+	}
 
 	std::list<std::pair<AsciiString, Real> >::iterator it;
 	for (it = m_adjustedVolumes.begin(); it != m_adjustedVolumes.end(); ++it) {

--- a/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
+++ b/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
@@ -72,8 +72,6 @@
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-static const AsciiString s_noSoundString("NoSound");
-
 static const char* TheSpeakerTypes[] =
 {
 	"2 Speakers",
@@ -409,7 +407,7 @@ void AudioManager::getInfoForAudioEvent( const AudioEventRTS *eventToFindAndFill
 //-------------------------------------------------------------------------------------------------
 AudioHandle AudioManager::addAudioEvent(const AudioEventRTS *eventToAdd)
 {
-	if (eventToAdd->getEventName().isEmpty() || eventToAdd->getEventName() == s_noSoundString) {
+	if (eventToAdd->getEventName().isEmpty() || eventToAdd->getEventName() == AsciiString("NoSound")) {
 		return AHSV_NoSound;
 	}
 

--- a/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
+++ b/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
@@ -72,9 +72,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-#if !RETAIL_COMPATIBLE_CRC
 static const AsciiString s_noSoundString("NoSound");
-#endif
 
 static const char* TheSpeakerTypes[] =
 {
@@ -411,11 +409,7 @@ void AudioManager::getInfoForAudioEvent( const AudioEventRTS *eventToFindAndFill
 //-------------------------------------------------------------------------------------------------
 AudioHandle AudioManager::addAudioEvent(const AudioEventRTS *eventToAdd)
 {
-#if RETAIL_COMPATIBLE_CRC
-	if (eventToAdd->getEventName().isEmpty() || eventToAdd->getEventName() == AsciiString("NoSound")) {
-#else
 	if (eventToAdd->getEventName().isEmpty() || eventToAdd->getEventName() == s_noSoundString) {
-#endif
 		return AHSV_NoSound;
 	}
 
@@ -451,13 +445,11 @@ AudioHandle AudioManager::addAudioEvent(const AudioEventRTS *eventToAdd)
 		return AHSV_NoSound;
 	}
 
-#if !RETAIL_COMPATIBLE_CRC
 	if (!eventToAdd->getUninterruptable()) {
 		if (!shouldPlayLocally(eventToAdd)) {
 			return AHSV_NotForLocal;
 		}
 	}
-#endif
 
 	AudioEventRTS *audioEvent = MSGNEW("AudioEventRTS") AudioEventRTS(*eventToAdd);		// poolify
 	audioEvent->setPlayingHandle( allocateNewHandle() );
@@ -472,15 +464,6 @@ AudioHandle AudioManager::addAudioEvent(const AudioEventRTS *eventToAdd)
 			break;
 		}
 	}
-
-#if RETAIL_COMPATIBLE_CRC
-	if (!audioEvent->getUninterruptable()) {
-		if (!shouldPlayLocally(audioEvent)) {
-			releaseAudioEventRTS(audioEvent);
-			return AHSV_NotForLocal;
-		}
-	}
-#endif
 
 	// cull muted audio
 	if (audioEvent->getVolume() < m_audioSettings->m_minVolume) {

--- a/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
+++ b/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
@@ -72,6 +72,8 @@
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
+static const AsciiString s_noSoundString("NoSound");
+
 static const char* TheSpeakerTypes[] =
 {
 	"2 Speakers",
@@ -407,7 +409,7 @@ void AudioManager::getInfoForAudioEvent( const AudioEventRTS *eventToFindAndFill
 //-------------------------------------------------------------------------------------------------
 AudioHandle AudioManager::addAudioEvent(const AudioEventRTS *eventToAdd)
 {
-	if (eventToAdd->getEventName().isEmpty() || eventToAdd->getEventName() == AsciiString("NoSound")) {
+	if (eventToAdd->getEventName().isEmpty() || eventToAdd->getEventName() == s_noSoundString) {
 		return AHSV_NoSound;
 	}
 
@@ -443,6 +445,11 @@ AudioHandle AudioManager::addAudioEvent(const AudioEventRTS *eventToAdd)
 		return AHSV_NoSound;
 	}
 
+	if (!eventToAdd->getUninterruptable()) {
+		if (!shouldPlayLocally(eventToAdd)) {
+			return AHSV_NotForLocal;
+		}
+	}
 
 	AudioEventRTS *audioEvent = MSGNEW("AudioEventRTS") AudioEventRTS(*eventToAdd);		// poolify
 	audioEvent->setPlayingHandle( allocateNewHandle() );
@@ -455,13 +462,6 @@ AudioHandle AudioManager::addAudioEvent(const AudioEventRTS *eventToAdd)
 		if (it->first == audioEvent->getEventName()) {
 			audioEvent->setVolume(it->second);
 			break;
-		}
-	}
-
-	if (!audioEvent->getUninterruptable()) {
-		if (!shouldPlayLocally(audioEvent)) {
-			releaseAudioEventRTS(audioEvent);
-			return AHSV_NotForLocal;
 		}
 	}
 


### PR DESCRIPTION
- Closes #1352 

Optimizes AudioManager::addAudioEvent() to avoid wasted allocations and computations for sounds that won't play locally.

**Changes:**
- Check shouldPlayLocally() before expensive operations