### PR TITLE
bugfix(registry): Prioritize HKEY_CURRENT_USER registry reads and writes over HKEY_LOCAL_MACHINE to prevent inaccessible data

### DIFF
--- a/Core/Libraries/Source/WWVegas/WWDownload/registry.cpp
+++ b/Core/Libraries/Source/WWVegas/WWDownload/registry.cpp
@@ -154,10 +154,11 @@ bool SetStringInRegistry( std::string path, std::string key, std::string val)
 #endif
 	fullPath.append(path);
 
-	if (setStringInRegistry( HKEY_LOCAL_MACHINE, fullPath, key, val))
+	// TheSuperHackers @fix bobtista 12/02/2026 Prefer HKCU for writes to match read priority
+	if (setStringInRegistry( HKEY_CURRENT_USER, fullPath, key, val))
 		return true;
 
-	return setStringInRegistry( HKEY_CURRENT_USER, fullPath, key, val );
+	return setStringInRegistry( HKEY_LOCAL_MACHINE, fullPath, key, val );
 }
 
 bool SetUnsignedIntInRegistry( std::string path, std::string key, unsigned int val)
@@ -169,9 +170,10 @@ bool SetUnsignedIntInRegistry( std::string path, std::string key, unsigned int v
 #endif
 	fullPath.append(path);
 
-	if (setUnsignedIntInRegistry( HKEY_LOCAL_MACHINE, fullPath, key, val))
+	// TheSuperHackers @fix bobtista 12/02/2026 Prefer HKCU for writes to match read priority
+	if (setUnsignedIntInRegistry( HKEY_CURRENT_USER, fullPath, key, val))
 		return true;
 
-	return setUnsignedIntInRegistry( HKEY_CURRENT_USER, fullPath, key, val );
+	return setUnsignedIntInRegistry( HKEY_LOCAL_MACHINE, fullPath, key, val );
 }
 

--- a/Core/Libraries/Source/WWVegas/WWDownload/registry.cpp
+++ b/Core/Libraries/Source/WWVegas/WWDownload/registry.cpp
@@ -120,12 +120,12 @@ bool GetStringFromRegistry(std::string path, std::string key, std::string& val)
 #endif
 
 	fullPath.append(path);
-	if (getStringFromRegistry(HKEY_LOCAL_MACHINE, fullPath.c_str(), key.c_str(), val))
+	if (getStringFromRegistry(HKEY_CURRENT_USER, fullPath.c_str(), key.c_str(), val))
 	{
 		return true;
 	}
 
-	return getStringFromRegistry(HKEY_CURRENT_USER, fullPath.c_str(), key.c_str(), val);
+	return getStringFromRegistry(HKEY_LOCAL_MACHINE, fullPath.c_str(), key.c_str(), val);
 }
 
 bool GetUnsignedIntFromRegistry(std::string path, std::string key, unsigned int& val)
@@ -137,12 +137,12 @@ bool GetUnsignedIntFromRegistry(std::string path, std::string key, unsigned int&
 #endif
 
 	fullPath.append(path);
-	if (getUnsignedIntFromRegistry(HKEY_LOCAL_MACHINE, fullPath.c_str(), key.c_str(), val))
+	if (getUnsignedIntFromRegistry(HKEY_CURRENT_USER, fullPath.c_str(), key.c_str(), val))
 	{
 		return true;
 	}
 
-	return getUnsignedIntFromRegistry(HKEY_CURRENT_USER, fullPath.c_str(), key.c_str(), val);
+	return getUnsignedIntFromRegistry(HKEY_LOCAL_MACHINE, fullPath.c_str(), key.c_str(), val);
 }
 
 bool SetStringInRegistry( std::string path, std::string key, std::string val)
@@ -153,9 +153,6 @@ bool SetStringInRegistry( std::string path, std::string key, std::string val)
 	std::string fullPath = "SOFTWARE\\Electronic Arts\\EA Games\\Command and Conquer Generals Zero Hour";
 #endif
 	fullPath.append(path);
-
-	if (setStringInRegistry( HKEY_LOCAL_MACHINE, fullPath, key, val))
-		return true;
 
 	return setStringInRegistry( HKEY_CURRENT_USER, fullPath, key, val );
 }
@@ -168,9 +165,6 @@ bool SetUnsignedIntInRegistry( std::string path, std::string key, unsigned int v
 	std::string fullPath = "SOFTWARE\\Electronic Arts\\EA Games\\Command and Conquer Generals Zero Hour";
 #endif
 	fullPath.append(path);
-
-	if (setUnsignedIntInRegistry( HKEY_LOCAL_MACHINE, fullPath, key, val))
-		return true;
 
 	return setUnsignedIntInRegistry( HKEY_CURRENT_USER, fullPath, key, val );
 }

--- a/Core/Libraries/Source/WWVegas/WWDownload/registry.cpp
+++ b/Core/Libraries/Source/WWVegas/WWDownload/registry.cpp
@@ -154,6 +154,9 @@ bool SetStringInRegistry( std::string path, std::string key, std::string val)
 #endif
 	fullPath.append(path);
 
+	if (setStringInRegistry( HKEY_LOCAL_MACHINE, fullPath, key, val))
+		return true;
+
 	return setStringInRegistry( HKEY_CURRENT_USER, fullPath, key, val );
 }
 
@@ -165,6 +168,9 @@ bool SetUnsignedIntInRegistry( std::string path, std::string key, unsigned int v
 	std::string fullPath = "SOFTWARE\\Electronic Arts\\EA Games\\Command and Conquer Generals Zero Hour";
 #endif
 	fullPath.append(path);
+
+	if (setUnsignedIntInRegistry( HKEY_LOCAL_MACHINE, fullPath, key, val))
+		return true;
 
 	return setUnsignedIntInRegistry( HKEY_CURRENT_USER, fullPath, key, val );
 }

--- a/Core/Libraries/Source/WWVegas/WWDownload/registry.cpp
+++ b/Core/Libraries/Source/WWVegas/WWDownload/registry.cpp
@@ -154,11 +154,9 @@ bool SetStringInRegistry( std::string path, std::string key, std::string val)
 #endif
 	fullPath.append(path);
 
-	// TheSuperHackers @fix bobtista 12/02/2026 Prefer HKCU for writes to match read priority
-	if (setStringInRegistry( HKEY_CURRENT_USER, fullPath, key, val))
-		return true;
-
-	return setStringInRegistry( HKEY_LOCAL_MACHINE, fullPath, key, val );
+	// TheSuperHackers @fix bobtista 12/02/2026 Always write to HKCU. Per-user settings belong
+	// in HKEY_CURRENT_USER and writes there should always succeed without admin privileges.
+	return setStringInRegistry( HKEY_CURRENT_USER, fullPath, key, val );
 }
 
 bool SetUnsignedIntInRegistry( std::string path, std::string key, unsigned int val)
@@ -170,10 +168,8 @@ bool SetUnsignedIntInRegistry( std::string path, std::string key, unsigned int v
 #endif
 	fullPath.append(path);
 
-	// TheSuperHackers @fix bobtista 12/02/2026 Prefer HKCU for writes to match read priority
-	if (setUnsignedIntInRegistry( HKEY_CURRENT_USER, fullPath, key, val))
-		return true;
-
-	return setUnsignedIntInRegistry( HKEY_LOCAL_MACHINE, fullPath, key, val );
+	// TheSuperHackers @fix bobtista 12/02/2026 Always write to HKCU. Per-user settings belong
+	// in HKEY_CURRENT_USER and writes there should always succeed without admin privileges.
+	return setUnsignedIntInRegistry( HKEY_CURRENT_USER, fullPath, key, val );
 }
 

--- a/Generals/Code/GameEngine/Source/Common/System/registry.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/registry.cpp
@@ -121,12 +121,12 @@ Bool GetStringFromRegistry(AsciiString path, AsciiString key, AsciiString& val)
 
 	fullPath.concat(path);
 	DEBUG_LOG(("GetStringFromRegistry - looking in %s for key %s", fullPath.str(), key.str()));
-	if (getStringFromRegistry(HKEY_LOCAL_MACHINE, fullPath.str(), key.str(), val))
+	if (getStringFromRegistry(HKEY_CURRENT_USER, fullPath.str(), key.str(), val))
 	{
 		return TRUE;
 	}
 
-	return getStringFromRegistry(HKEY_CURRENT_USER, fullPath.str(), key.str(), val);
+	return getStringFromRegistry(HKEY_LOCAL_MACHINE, fullPath.str(), key.str(), val);
 }
 
 Bool GetUnsignedIntFromRegistry(AsciiString path, AsciiString key, UnsignedInt& val)
@@ -135,12 +135,12 @@ Bool GetUnsignedIntFromRegistry(AsciiString path, AsciiString key, UnsignedInt& 
 
 	fullPath.concat(path);
 	DEBUG_LOG(("GetUnsignedIntFromRegistry - looking in %s for key %s", fullPath.str(), key.str()));
-	if (getUnsignedIntFromRegistry(HKEY_LOCAL_MACHINE, fullPath.str(), key.str(), val))
+	if (getUnsignedIntFromRegistry(HKEY_CURRENT_USER, fullPath.str(), key.str(), val))
 	{
 		return TRUE;
 	}
 
-	return getUnsignedIntFromRegistry(HKEY_CURRENT_USER, fullPath.str(), key.str(), val);
+	return getUnsignedIntFromRegistry(HKEY_LOCAL_MACHINE, fullPath.str(), key.str(), val);
 }
 
 AsciiString GetRegistryLanguage(void)

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/registry.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/registry.cpp
@@ -121,12 +121,12 @@ Bool GetStringFromGeneralsRegistry(AsciiString path, AsciiString key, AsciiStrin
 
 	fullPath.concat(path);
 	DEBUG_LOG(("GetStringFromRegistry - looking in %s for key %s", fullPath.str(), key.str()));
-	if (getStringFromRegistry(HKEY_LOCAL_MACHINE, fullPath.str(), key.str(), val))
+	if (getStringFromRegistry(HKEY_CURRENT_USER, fullPath.str(), key.str(), val))
 	{
 		return TRUE;
 	}
 
-	return getStringFromRegistry(HKEY_CURRENT_USER, fullPath.str(), key.str(), val);
+	return getStringFromRegistry(HKEY_LOCAL_MACHINE, fullPath.str(), key.str(), val);
 }
 
 Bool GetStringFromRegistry(AsciiString path, AsciiString key, AsciiString& val)
@@ -135,12 +135,12 @@ Bool GetStringFromRegistry(AsciiString path, AsciiString key, AsciiString& val)
 
 	fullPath.concat(path);
 	DEBUG_LOG(("GetStringFromRegistry - looking in %s for key %s", fullPath.str(), key.str()));
-	if (getStringFromRegistry(HKEY_LOCAL_MACHINE, fullPath.str(), key.str(), val))
+	if (getStringFromRegistry(HKEY_CURRENT_USER, fullPath.str(), key.str(), val))
 	{
 		return TRUE;
 	}
 
-	return getStringFromRegistry(HKEY_CURRENT_USER, fullPath.str(), key.str(), val);
+	return getStringFromRegistry(HKEY_LOCAL_MACHINE, fullPath.str(), key.str(), val);
 }
 
 Bool GetUnsignedIntFromRegistry(AsciiString path, AsciiString key, UnsignedInt& val)
@@ -149,12 +149,12 @@ Bool GetUnsignedIntFromRegistry(AsciiString path, AsciiString key, UnsignedInt& 
 
 	fullPath.concat(path);
 	DEBUG_LOG(("GetUnsignedIntFromRegistry - looking in %s for key %s", fullPath.str(), key.str()));
-	if (getUnsignedIntFromRegistry(HKEY_LOCAL_MACHINE, fullPath.str(), key.str(), val))
+	if (getUnsignedIntFromRegistry(HKEY_CURRENT_USER, fullPath.str(), key.str(), val))
 	{
 		return TRUE;
 	}
 
-	return getUnsignedIntFromRegistry(HKEY_CURRENT_USER, fullPath.str(), key.str(), val);
+	return getUnsignedIntFromRegistry(HKEY_LOCAL_MACHINE, fullPath.str(), key.str(), val);
 }
 
 AsciiString GetRegistryLanguage(void)


### PR DESCRIPTION
- Closes #1059

Per-user settings (e.g. HTTP Proxy) should always go in HKEY_CURRENT_USER.

Flips both read and write priority to prefer HKCU over HKLM across all registry helpers, with HKLM as fallback. This prevents stale HKCU values when the game is run with admin privileges.