### PR TITLE
bugfix(lobby): Properly sort CRC mismatched game rooms to the bottom of the lobby

### DIFF
--- a/Core/GameEngine/Source/GameNetwork/GameSpy/LobbyUtils.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/LobbyUtils.cpp
@@ -474,11 +474,11 @@ struct GameSortStruct
 	bool operator()(GameSpyStagingRoom *g1, GameSpyStagingRoom *g2) const
 	{
 		// sort CRC mismatches to the bottom
-		Bool g1Mismatch = (g1->getExeCRC() != TheGlobalData->m_exeCRC || g1->getIniCRC() != TheGlobalData->m_iniCRC);
-		Bool g2Mismatch = (g2->getExeCRC() != TheGlobalData->m_exeCRC || g2->getIniCRC() != TheGlobalData->m_iniCRC);
-		if (g1Mismatch != g2Mismatch)
+		Bool isMismatch1 = (g1->getExeCRC() != TheGlobalData->m_exeCRC || g1->getIniCRC() != TheGlobalData->m_iniCRC);
+		Bool isMismatch2 = (g2->getExeCRC() != TheGlobalData->m_exeCRC || g2->getIniCRC() != TheGlobalData->m_iniCRC);
+		if (isMismatch1 != isMismatch2)
 		{
-			return !g1Mismatch;
+			return !isMismatch1;
 		}
 
 		// sort games with private ladders to the bottom

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/LobbyUtils.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/LobbyUtils.cpp
@@ -474,11 +474,11 @@ struct GameSortStruct
 	bool operator()(GameSpyStagingRoom *g1, GameSpyStagingRoom *g2) const
 	{
 		// sort CRC mismatches to the bottom
-		Bool isMismatch1 = (g1->getExeCRC() != TheGlobalData->m_exeCRC || g1->getIniCRC() != TheGlobalData->m_iniCRC);
-		Bool isMismatch2 = (g2->getExeCRC() != TheGlobalData->m_exeCRC || g2->getIniCRC() != TheGlobalData->m_iniCRC);
-		if (isMismatch1 != isMismatch2)
+		Bool g1Good = (g1->getExeCRC() == TheGlobalData->m_exeCRC && g1->getIniCRC() == TheGlobalData->m_iniCRC);
+		Bool g2Good = (g2->getExeCRC() == TheGlobalData->m_exeCRC && g2->getIniCRC() == TheGlobalData->m_iniCRC);
+		if ( g1Good ^ g2Good )
 		{
-			return !isMismatch1;
+			return g1Good;
 		}
 
 		// sort games with private ladders to the bottom

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/LobbyUtils.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/LobbyUtils.cpp
@@ -476,9 +476,9 @@ struct GameSortStruct
 		// sort CRC mismatches to the bottom
 		Bool g1Mismatch = (g1->getExeCRC() != TheGlobalData->m_exeCRC || g1->getIniCRC() != TheGlobalData->m_iniCRC);
 		Bool g2Mismatch = (g2->getExeCRC() != TheGlobalData->m_exeCRC || g2->getIniCRC() != TheGlobalData->m_iniCRC);
-		if ( g1Mismatch ^ g2Mismatch )
+		if (g1Mismatch != g2Mismatch)
 		{
-			return g2Mismatch;
+			return !g1Mismatch;
 		}
 
 		// sort games with private ladders to the bottom

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/LobbyUtils.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/LobbyUtils.cpp
@@ -474,11 +474,11 @@ struct GameSortStruct
 	bool operator()(GameSpyStagingRoom *g1, GameSpyStagingRoom *g2) const
 	{
 		// sort CRC mismatches to the bottom
-		Bool g1Good = (g1->getExeCRC() != TheGlobalData->m_exeCRC || g1->getIniCRC() != TheGlobalData->m_iniCRC);
-		Bool g2Good = (g1->getExeCRC() != TheGlobalData->m_exeCRC || g1->getIniCRC() != TheGlobalData->m_iniCRC);
-		if ( g1Good ^ g2Good )
+		Bool g1Mismatch = (g1->getExeCRC() != TheGlobalData->m_exeCRC || g1->getIniCRC() != TheGlobalData->m_iniCRC);
+		Bool g2Mismatch = (g2->getExeCRC() != TheGlobalData->m_exeCRC || g2->getIniCRC() != TheGlobalData->m_iniCRC);
+		if ( g1Mismatch ^ g2Mismatch )
 		{
-			return g1Good;
+			return g2Mismatch;
 		}
 
 		// sort games with private ladders to the bottom


### PR DESCRIPTION
- Fixes #967 Bugged sorting in GameSortStruct::operator()

Addressed had three issues:

1. Copy-paste error: g2Good was checking g1 instead of g2
2. Confusing variable names: g1Good/g2Good were true when CRCs were bad, not good
3. Wrong return value: returned g1Good instead of g2Good, sorting mismatches to top instead of bottom
