### PR TITLE
refactor(dx8): Replace unsafe Matrix4x4/D3DMATRIX casts with proper transpose conversion

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/TerrainTex.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/TerrainTex.cpp
@@ -717,14 +717,15 @@ void LightMapTerrainTextureClass::Apply(unsigned int stage)
 
 	D3DXMATRIX inv;
 	float det;
-	D3DXMatrixInverse(&inv, &det, (D3DXMATRIX*)&curView);
+	D3DXMATRIX d3dCurView = Build_D3DXMATRIX(curView);
+	D3DXMatrixInverse(&inv, &det, &d3dCurView);
 	D3DXMATRIX scale;
 	D3DXMatrixScaling(&scale, STRETCH_FACTOR, STRETCH_FACTOR,1);
 	inv *=scale;
 	if (stage==0) {
-		DX8Wrapper::_Set_DX8_Transform(D3DTS_TEXTURE0, *((Matrix4x4*)&inv));
+		DX8Wrapper::_Set_DX8_Transform(D3DTS_TEXTURE0, inv);
 	}	if (stage==1) {
-		DX8Wrapper::_Set_DX8_Transform(D3DTS_TEXTURE1, *((Matrix4x4*)&inv));
+		DX8Wrapper::_Set_DX8_Transform(D3DTS_TEXTURE1, inv);
 	}
 
 
@@ -971,7 +972,8 @@ void CloudMapTerrainTextureClass::Apply(unsigned int stage)
 
 	D3DXMATRIX inv;
 	float det;
-	D3DXMatrixInverse(&inv, &det, (D3DXMATRIX*)&curView);
+	D3DXMATRIX d3dCurView = Build_D3DXMATRIX(curView);
+	D3DXMatrixInverse(&inv, &det, &d3dCurView);
 	D3DXMATRIX scale;
 	D3DXMatrixScaling(&scale, STRETCH_FACTOR, STRETCH_FACTOR,1);
 	inv *=scale;
@@ -999,7 +1001,7 @@ void CloudMapTerrainTextureClass::Apply(unsigned int stage)
 		DX8Wrapper::Set_DX8_Texture_Stage_State( 0, D3DTSS_COLOROP,   D3DTOP_SELECTARG1 );
 		DX8Wrapper::Set_DX8_Texture_Stage_State( 0, D3DTSS_ALPHAOP,   D3DTOP_DISABLE );
 
-		DX8Wrapper::_Set_DX8_Transform(D3DTS_TEXTURE0, *((Matrix4x4*)&inv));
+		DX8Wrapper::_Set_DX8_Transform(D3DTS_TEXTURE0, inv);
 
 		// Disable 3rd stage just in case.
 		DX8Wrapper::Set_DX8_Texture_Stage_State( 2, D3DTSS_COLOROP,   D3DTOP_DISABLE );
@@ -1018,7 +1020,7 @@ void CloudMapTerrainTextureClass::Apply(unsigned int stage)
 		DX8Wrapper::Set_DX8_Texture_Stage_State( 1, D3DTSS_ALPHAARG1, D3DTA_CURRENT );
 		DX8Wrapper::Set_DX8_Texture_Stage_State( 1, D3DTSS_ALPHAOP,   D3DTOP_SELECTARG1 );
 
-		DX8Wrapper::_Set_DX8_Transform(D3DTS_TEXTURE1, *((Matrix4x4*)&inv));
+		DX8Wrapper::_Set_DX8_Transform(D3DTS_TEXTURE1, inv);
 	}
 #endif
 }

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTreeBuffer.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTreeBuffer.cpp
@@ -1717,9 +1717,9 @@ void W3DTreeBuffer::drawTrees(CameraClass * camera, RefRenderObjListIterator *pD
 
 	if (m_dwTreeVertexShader) {
 		D3DXMATRIX matProj, matView, matWorld;
-		DX8Wrapper::_Get_DX8_Transform(D3DTS_WORLD, *(Matrix4x4*)&matWorld);
-		DX8Wrapper::_Get_DX8_Transform(D3DTS_VIEW, *(Matrix4x4*)&matView);
-		DX8Wrapper::_Get_DX8_Transform(D3DTS_PROJECTION, *(Matrix4x4*)&matProj);
+		DX8Wrapper::_Get_DX8_Transform(D3DTS_WORLD, matWorld);
+		DX8Wrapper::_Get_DX8_Transform(D3DTS_VIEW, matView);
+		DX8Wrapper::_Get_DX8_Transform(D3DTS_PROJECTION, matProj);
 		D3DXMATRIX mat;
 		D3DXMatrixMultiply( &mat, &matView, &matProj );
 		D3DXMatrixMultiply( &mat, &matWorld, &mat );

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
@@ -1622,7 +1622,7 @@ void WaterRenderObjClass::Render(RenderInfoClass & rinfo)
 				DX8Wrapper::Set_DX8_Texture_Stage_State(1, D3DTSS_TEXTURETRANSFORMFLAGS, D3DTTFF_COUNT2);
 
 				// Set texture generation matrix for stage 1
-				DX8Wrapper::_Set_DX8_Transform(D3DTS_TEXTURE1, *((Matrix4*)&inv));
+				DX8Wrapper::_Set_DX8_Transform(D3DTS_TEXTURE1, inv);
 
 				// Disable bilinear filtering
 				DX8Wrapper::Set_DX8_Texture_Stage_State(1, D3DTSS_MINFILTER, D3DTEXF_POINT);

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
@@ -240,9 +240,8 @@ void WaterRenderObjClass::setupJbaWaterShader(void)
 		D3DXMATRIX inv;
 		float det;
 
-		Matrix4x4 curView;
-		DX8Wrapper::_Get_DX8_Transform(D3DTS_VIEW, curView);
-		D3DXMATRIX d3dCurView = Build_D3DXMATRIX(curView);
+		D3DXMATRIX d3dCurView;
+		DX8Wrapper::_Get_DX8_Transform(D3DTS_VIEW, d3dCurView);
 		D3DXMatrixInverse(&inv, &det, &d3dCurView);
 		D3DXMATRIX scale;
 
@@ -1597,13 +1596,12 @@ void WaterRenderObjClass::Render(RenderInfoClass & rinfo)
 				D3DXMATRIX inv;
 				D3DXMATRIX clipMatrix;
 				Real det;
-				Matrix4x4 curView;
 
 				//get current view matrix
-				DX8Wrapper::_Get_DX8_Transform(D3DTS_VIEW, curView);
+				D3DXMATRIX d3dCurView;
+				DX8Wrapper::_Get_DX8_Transform(D3DTS_VIEW, d3dCurView);
 
 				//get inverse of view matrix(= view to world matrix)
-				D3DXMATRIX d3dCurView = Build_D3DXMATRIX(curView);
 				D3DXMatrixInverse(&inv, &det, &d3dCurView);
 
 				//create clipping matrix by inserting our plane equation into the 1st column
@@ -2998,9 +2996,8 @@ void WaterRenderObjClass::setupFlatWaterShader(void)
 		D3DXMATRIX inv;
 		float det;
 
-		Matrix4x4 curView;
-		DX8Wrapper::_Get_DX8_Transform(D3DTS_VIEW, curView);
-		D3DXMATRIX d3dCurView = Build_D3DXMATRIX(curView);
+		D3DXMATRIX d3dCurView;
+		DX8Wrapper::_Get_DX8_Transform(D3DTS_VIEW, d3dCurView);
 		D3DXMatrixInverse(&inv, &det, &d3dCurView);
 		D3DXMATRIX scale;
 

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
@@ -1800,8 +1800,8 @@ void WaterRenderObjClass::drawSea(RenderInfoClass & rinfo)
 
 	rinfo.Camera.Get_Transform().Get_Translation(&camTran);
 
-	DX8Wrapper::_Get_DX8_Transform(D3DTS_VIEW, *(Matrix4x4*)&matView);
-	DX8Wrapper::_Get_DX8_Transform(D3DTS_PROJECTION, *(Matrix4x4*)&matProj);
+	DX8Wrapper::_Get_DX8_Transform(D3DTS_VIEW, matView);
+	DX8Wrapper::_Get_DX8_Transform(D3DTS_PROJECTION, matProj);
 
 	//default setup from Kenny's demo
 	m_pDev->SetTextureStageState( 0, D3DTSS_COLORARG1, D3DTA_TEXTURE );
@@ -1941,8 +1941,8 @@ void WaterRenderObjClass::drawSea(RenderInfoClass & rinfo)
 	m_pDev->SetTextureStageState( 2, D3DTSS_ALPHAOP,   D3DTOP_DISABLE );
 
 	//Restore old transforms
-	DX8Wrapper::_Set_DX8_Transform(D3DTS_VIEW, *(Matrix4x4*)&matView);
-	DX8Wrapper::_Set_DX8_Transform(D3DTS_PROJECTION, *(Matrix4x4*)&matProj);
+	DX8Wrapper::_Set_DX8_Transform(D3DTS_VIEW, matView);
+	DX8Wrapper::_Set_DX8_Transform(D3DTS_PROJECTION, matProj);
 
 	m_pDev->SetPixelShader(0);	//turn off pixel shader
 	m_pDev->SetVertexShader(DX8_FVF_XYZDUV1);	//turn off custom vertex shader
@@ -1966,7 +1966,7 @@ void WaterRenderObjClass::drawSea(RenderInfoClass & rinfo)
 
 				D3DXMatrixMultiply(&matTemp, &patchMatrix, &matWW3D);
 
-				DX8Wrapper::_Set_DX8_Transform(D3DTS_WORLD, *(Matrix4x4*)&matTemp);
+				DX8Wrapper::_Set_DX8_Transform(D3DTS_WORLD, matTemp);
 
 				m_pDev->DrawIndexedPrimitive(D3DPT_TRIANGLESTRIP,0,m_numVertices,0,m_numIndices);
 			}

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
@@ -242,14 +242,15 @@ void WaterRenderObjClass::setupJbaWaterShader(void)
 
 		Matrix4x4 curView;
 		DX8Wrapper::_Get_DX8_Transform(D3DTS_VIEW, curView);
-		D3DXMatrixInverse(&inv, &det, (D3DXMATRIX*)&curView);
+		D3DXMATRIX d3dCurView = Build_D3DXMATRIX(curView);
+		D3DXMatrixInverse(&inv, &det, &d3dCurView);
 		D3DXMATRIX scale;
 
 		D3DXMatrixScaling(&scale, NOISE_REPEAT_FACTOR, NOISE_REPEAT_FACTOR,1);
 		D3DXMATRIX destMatrix = inv * scale;
 		D3DXMatrixTranslation(&scale, m_riverVOrigin, m_riverVOrigin,0);
 		destMatrix = destMatrix*scale;
-		DX8Wrapper::_Set_DX8_Transform(D3DTS_TEXTURE2, *(Matrix4x4*)&destMatrix);
+		DX8Wrapper::_Set_DX8_Transform(D3DTS_TEXTURE2, destMatrix);
 
 	}
 	m_pDev->SetTextureStageState( 0, D3DTSS_MINFILTER, D3DTEXF_LINEAR );
@@ -1602,7 +1603,8 @@ void WaterRenderObjClass::Render(RenderInfoClass & rinfo)
 				DX8Wrapper::_Get_DX8_Transform(D3DTS_VIEW, curView);
 
 				//get inverse of view matrix(= view to world matrix)
-				D3DXMatrixInverse(&inv, &det, (D3DXMATRIX*)&curView);
+				D3DXMATRIX d3dCurView = Build_D3DXMATRIX(curView);
+				D3DXMatrixInverse(&inv, &det, &d3dCurView);
 
 				//create clipping matrix by inserting our plane equation into the 1st column
 				D3DXMatrixIdentity(&clipMatrix);
@@ -2998,14 +3000,15 @@ void WaterRenderObjClass::setupFlatWaterShader(void)
 
 		Matrix4x4 curView;
 		DX8Wrapper::_Get_DX8_Transform(D3DTS_VIEW, curView);
-		D3DXMatrixInverse(&inv, &det, (D3DXMATRIX*)&curView);
+		D3DXMATRIX d3dCurView = Build_D3DXMATRIX(curView);
+		D3DXMatrixInverse(&inv, &det, &d3dCurView);
 		D3DXMATRIX scale;
 
 		D3DXMatrixScaling(&scale, NOISE_REPEAT_FACTOR, NOISE_REPEAT_FACTOR,1);
 		D3DXMATRIX destMatrix = inv * scale;
 		D3DXMatrixTranslation(&scale, m_riverVOrigin, m_riverVOrigin,0);
 		destMatrix = destMatrix*scale;
-		DX8Wrapper::_Set_DX8_Transform(D3DTS_TEXTURE2, *(Matrix4x4*)&destMatrix);
+		DX8Wrapper::_Set_DX8_Transform(D3DTS_TEXTURE2, destMatrix);
 
 	}
 	m_pDev->SetTextureStageState( 0, D3DTSS_MINFILTER, D3DTEXF_LINEAR );

--- a/Core/Libraries/Source/WWVegas/WWMath/matrix3d.cpp
+++ b/Core/Libraries/Source/WWVegas/WWMath/matrix3d.cpp
@@ -519,7 +519,10 @@ void Matrix3D::Get_Inverse(Matrix3D & inv) const
 	Matrix4x4	mat4Inv;
 
 	float det;
-	D3DXMatrixInverse((D3DXMATRIX *)&mat4Inv, &det, (D3DXMATRIX*)&mat4);
+	D3DXMATRIX d3dMat = Build_D3DXMATRIX(mat4);
+	D3DXMATRIX d3dMatInv;
+	D3DXMatrixInverse(&d3dMatInv, &det, &d3dMat);
+	Build_Matrix4(mat4Inv, d3dMatInv);
 
 	inv.Row[0][0]=mat4Inv[0][0];
 	inv.Row[0][1]=mat4Inv[0][1];

--- a/Core/Libraries/Source/WWVegas/WWMath/matrix4.cpp
+++ b/Core/Libraries/Source/WWVegas/WWMath/matrix4.cpp
@@ -266,5 +266,15 @@ Matrix4x4 Build_Matrix4(const D3DMATRIX& dxm)
 	Build_Matrix4(m, dxm);
 	return m;
 }
+
+void Build_Matrix4(Matrix4x4& m, const D3DXMATRIX& dxm)
+{
+	Build_Matrix4(m, (const D3DMATRIX&)dxm);
+}
+
+Matrix4x4 Build_Matrix4(const D3DXMATRIX& dxm)
+{
+	return Build_Matrix4((const D3DMATRIX&)dxm);
+}
 #endif
 

--- a/Core/Libraries/Source/WWVegas/WWMath/matrix4.cpp
+++ b/Core/Libraries/Source/WWVegas/WWMath/matrix4.cpp
@@ -195,3 +195,76 @@ int operator != (const Matrix4x4 & a, const Matrix4x4 & b)
 	return (!(a == b));
 }
 
+#ifdef BUILD_WITH_D3D8
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include "d3d8types.h"
+#include "d3dx8.h"
+
+void Build_D3DMATRIX(D3DMATRIX& dxm, const Matrix4x4& m)
+{
+	// Transpose: dxm.m[i][j] = m[j][i]
+	dxm.m[0][0] = m[0][0];
+	dxm.m[0][1] = m[1][0];
+	dxm.m[0][2] = m[2][0];
+	dxm.m[0][3] = m[3][0];
+
+	dxm.m[1][0] = m[0][1];
+	dxm.m[1][1] = m[1][1];
+	dxm.m[1][2] = m[2][1];
+	dxm.m[1][3] = m[3][1];
+
+	dxm.m[2][0] = m[0][2];
+	dxm.m[2][1] = m[1][2];
+	dxm.m[2][2] = m[2][2];
+	dxm.m[2][3] = m[3][2];
+
+	dxm.m[3][0] = m[0][3];
+	dxm.m[3][1] = m[1][3];
+	dxm.m[3][2] = m[2][3];
+	dxm.m[3][3] = m[3][3];
+}
+
+D3DXMATRIX Build_D3DXMATRIX(const Matrix4x4& m)
+{
+	// Transpose: result[i][j] = m[j][i]
+	return D3DXMATRIX(
+		m[0][0], m[1][0], m[2][0], m[3][0],
+		m[0][1], m[1][1], m[2][1], m[3][1],
+		m[0][2], m[1][2], m[2][2], m[3][2],
+		m[0][3], m[1][3], m[2][3], m[3][3]
+	);
+}
+
+void Build_Matrix4(Matrix4x4& m, const D3DMATRIX& dxm)
+{
+	// Transpose: m[i][j] = dxm.m[j][i]
+	m[0][0] = dxm.m[0][0];
+	m[0][1] = dxm.m[1][0];
+	m[0][2] = dxm.m[2][0];
+	m[0][3] = dxm.m[3][0];
+
+	m[1][0] = dxm.m[0][1];
+	m[1][1] = dxm.m[1][1];
+	m[1][2] = dxm.m[2][1];
+	m[1][3] = dxm.m[3][1];
+
+	m[2][0] = dxm.m[0][2];
+	m[2][1] = dxm.m[1][2];
+	m[2][2] = dxm.m[2][2];
+	m[2][3] = dxm.m[3][2];
+
+	m[3][0] = dxm.m[0][3];
+	m[3][1] = dxm.m[1][3];
+	m[3][2] = dxm.m[2][3];
+	m[3][3] = dxm.m[3][3];
+}
+
+Matrix4x4 Build_Matrix4(const D3DMATRIX& dxm)
+{
+	Matrix4x4 m;
+	Build_Matrix4(m, dxm);
+	return m;
+}
+#endif
+

--- a/Core/Libraries/Source/WWVegas/WWMath/matrix4.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/matrix4.h
@@ -199,6 +199,8 @@ D3DXMATRIX Build_D3DXMATRIX(const Matrix4x4& m);
 
 void Build_Matrix4(Matrix4x4& m, const D3DMATRIX& dxm);
 Matrix4x4 Build_Matrix4(const D3DMATRIX& dxm);
+void Build_Matrix4(Matrix4x4& m, const D3DXMATRIX& dxm);
+Matrix4x4 Build_Matrix4(const D3DXMATRIX& dxm);
 #endif
 
 
@@ -865,5 +867,7 @@ D3DXMATRIX Build_D3DXMATRIX(const Matrix4x4& m);
 
 void Build_Matrix4(Matrix4x4& m, const D3DMATRIX& dxm);
 Matrix4x4 Build_Matrix4(const D3DMATRIX& dxm);
+void Build_Matrix4(Matrix4x4& m, const D3DXMATRIX& dxm);
+Matrix4x4 Build_Matrix4(const D3DXMATRIX& dxm);
 #endif
 

--- a/Core/Libraries/Source/WWVegas/WWMath/matrix4.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/matrix4.h
@@ -181,6 +181,8 @@ public:
 	static WWINLINE void	Transform_Vector(const Matrix4x4 & tm,const Vector3 & in,Vector4 * out);
 	static WWINLINE void	Transform_Vector(const Matrix4x4 & tm,const Vector4 & in,Vector4 * out);
 
+protected:
+
 	Vector4 Row[4];
 
 };

--- a/Core/Libraries/Source/WWVegas/WWMath/matrix4.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/matrix4.h
@@ -185,24 +185,6 @@ public:
 
 };
 
-#ifdef BUILD_WITH_D3D8
-struct _D3DMATRIX;
-typedef struct _D3DMATRIX D3DMATRIX;
-struct D3DXMATRIX;
-
-// When converting Matrix4x4 to D3DMATRIX or vice versa always use conversion functions below.
-// Reason being, D3DMATRIX is row major matrix, and Matrix4x4 is column major matrix.
-// Thus copying from one to another will always require a transpose (or invert).
-
-void Build_D3DMATRIX(D3DMATRIX& dxm, const Matrix4x4& m);
-D3DXMATRIX Build_D3DXMATRIX(const Matrix4x4& m);
-
-void Build_Matrix4(Matrix4x4& m, const D3DMATRIX& dxm);
-Matrix4x4 Build_Matrix4(const D3DMATRIX& dxm);
-void Build_Matrix4(Matrix4x4& m, const D3DXMATRIX& dxm);
-Matrix4x4 Build_Matrix4(const D3DXMATRIX& dxm);
-#endif
-
 
 /***********************************************************************************************
  * Matrix4x4::Matrix4x4 -- Constructor, optionally initialize to Identitiy matrix                  *

--- a/Core/Libraries/Source/WWVegas/WWMath/matrix4.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/matrix4.h
@@ -181,11 +181,25 @@ public:
 	static WWINLINE void	Transform_Vector(const Matrix4x4 & tm,const Vector3 & in,Vector4 * out);
 	static WWINLINE void	Transform_Vector(const Matrix4x4 & tm,const Vector4 & in,Vector4 * out);
 
-protected:
-
 	Vector4 Row[4];
 
 };
+
+#ifdef BUILD_WITH_D3D8
+struct _D3DMATRIX;
+typedef struct _D3DMATRIX D3DMATRIX;
+struct D3DXMATRIX;
+
+// When converting Matrix4x4 to D3DMATRIX or vice versa always use conversion functions below.
+// Reason being, D3DMATRIX is row major matrix, and Matrix4x4 is column major matrix.
+// Thus copying from one to another will always require a transpose (or invert).
+
+void Build_D3DMATRIX(D3DMATRIX& dxm, const Matrix4x4& m);
+D3DXMATRIX Build_D3DXMATRIX(const Matrix4x4& m);
+
+void Build_Matrix4(Matrix4x4& m, const D3DMATRIX& dxm);
+Matrix4x4 Build_Matrix4(const D3DMATRIX& dxm);
+#endif
 
 
 /***********************************************************************************************
@@ -836,3 +850,20 @@ WWINLINE void	Matrix4x4::Transform_Vector(const Matrix4x4 & A,const Vector4 & in
 	out->Z = (A[2][0] * v->X + A[2][1] * v->Y + A[2][2] * v->Z + A[2][3] * v->W);
 	out->W = (A[3][0] * v->X + A[3][1] * v->Y + A[3][2] * v->Z + A[3][3] * v->W);
 }
+
+#ifdef BUILD_WITH_D3D8
+struct _D3DMATRIX;
+typedef struct _D3DMATRIX D3DMATRIX;
+struct D3DXMATRIX;
+
+// When converting Matrix4x4 to D3DMATRIX or vice versa always use conversion functions below.
+// Reason being, D3DMATRIX is row major matrix, and Matrix4x4 is column major matrix.
+// Thus copying from one to another will always require a transpose (or invert).
+
+void Build_D3DMATRIX(D3DMATRIX& dxm, const Matrix4x4& m);
+D3DXMATRIX Build_D3DXMATRIX(const Matrix4x4& m);
+
+void Build_Matrix4(Matrix4x4& m, const D3DMATRIX& dxm);
+Matrix4x4 Build_Matrix4(const D3DMATRIX& dxm);
+#endif
+

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp
@@ -1907,7 +1907,10 @@ void W3DVolumetricShadow::updateMeshVolume(Int meshIndex, Int lightIndex, const 
 		// system change, not the translations
 		//
 		Real det;
-		D3DXMatrixInverse((D3DXMATRIX*)&worldToObject, &det, (D3DXMATRIX*)&objectToWorld);
+		D3DXMATRIX d3dObjectToWorld = Build_D3DXMATRIX(objectToWorld);
+		D3DXMATRIX d3dWorldToObject;
+		D3DXMatrixInverse(&d3dWorldToObject, &det, &d3dObjectToWorld);
+		Build_Matrix4(worldToObject, (D3DMATRIX&)d3dWorldToObject);
 
 		// find out light position in object space
 		Matrix4x4::Transform_Vector(worldToObject,lightPosWorld,&lightPosObject);

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
@@ -304,6 +304,7 @@ public:
 	static void _Set_DX8_Transform(D3DTRANSFORMSTATETYPE transform,const Matrix3D& m);
 	static void _Set_DX8_Transform(D3DTRANSFORMSTATETYPE transform,const D3DXMATRIX& m);
 	static void _Get_DX8_Transform(D3DTRANSFORMSTATETYPE transform, Matrix4x4& m);
+	static void _Get_DX8_Transform(D3DTRANSFORMSTATETYPE transform, D3DXMATRIX& m);
 
 	static void Set_DX8_Light(int index,D3DLIGHT8* light);
 	static void Set_DX8_Render_State(D3DRENDERSTATETYPE state, unsigned value);
@@ -789,7 +790,12 @@ WWINLINE void DX8Wrapper::_Get_DX8_Transform(D3DTRANSFORMSTATETYPE transform, Ma
 {
 	D3DXMATRIX d3dMat;
 	DX8CALL(GetTransform(transform,&d3dMat));
-	Build_Matrix4(m, (D3DMATRIX&)d3dMat);
+	Build_Matrix4(m, d3dMat);
+}
+
+WWINLINE void DX8Wrapper::_Get_DX8_Transform(D3DTRANSFORMSTATETYPE transform, D3DXMATRIX& m)
+{
+	DX8CALL(GetTransform(transform, &m));
 }
 
 // ----------------------------------------------------------------------------

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
@@ -1298,8 +1298,7 @@ WWINLINE void DX8Wrapper::Get_Transform(D3DTRANSFORMSTATETYPE transform, Matrix4
 		break;
 	default:
 		DX8CALL(GetTransform(transform,&mat));
-		m=*(Matrix4x4*)&mat;
-		m=m.Transpose();
+		Build_Matrix4(m, mat);
 		break;
 	}
 }

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
@@ -174,8 +174,8 @@ struct RenderStateStruct
 	TextureBaseClass * Textures[MAX_TEXTURE_STAGES];
 	D3DLIGHT8 Lights[4];
 	bool LightEnable[4];
-	Matrix4x4 world;
-	Matrix4x4 view;
+	D3DXMATRIX world;
+	D3DXMATRIX view;
 	unsigned vertex_buffer_type;
 	unsigned index_buffer_type;
 	unsigned short vba_offset;
@@ -1212,12 +1212,12 @@ WWINLINE void DX8Wrapper::Set_Transform(D3DTRANSFORMSTATETYPE transform,const Ma
 {
 	switch ((int)transform) {
 	case D3DTS_WORLD:
-		render_state.world=m;
+		render_state.world=Build_D3DXMATRIX(m);
 		render_state_changed|=(unsigned)WORLD_CHANGED;
 		render_state_changed&=~(unsigned)WORLD_IDENTITY;
 		break;
 	case D3DTS_VIEW:
-		render_state.view=m;
+		render_state.view=Build_D3DXMATRIX(m);
 		render_state_changed|=(unsigned)VIEW_CHANGED;
 		render_state_changed&=~(unsigned)VIEW_IDENTITY;
 		break;
@@ -1242,12 +1242,12 @@ WWINLINE void DX8Wrapper::Set_Transform(D3DTRANSFORMSTATETYPE transform,const Ma
 	Matrix4x4 m2(m);
 	switch ((int)transform) {
 	case D3DTS_WORLD:
-		render_state.world=m2;
+		render_state.world=Build_D3DXMATRIX(m2);
 		render_state_changed|=(unsigned)WORLD_CHANGED;
 		render_state_changed&=~(unsigned)WORLD_IDENTITY;
 		break;
 	case D3DTS_VIEW:
-		render_state.view=m2;
+		render_state.view=Build_D3DXMATRIX(m2);
 		render_state_changed|=(unsigned)VIEW_CHANGED;
 		render_state_changed&=~(unsigned)VIEW_IDENTITY;
 		break;
@@ -1262,14 +1262,14 @@ WWINLINE void DX8Wrapper::Set_Transform(D3DTRANSFORMSTATETYPE transform,const Ma
 WWINLINE void DX8Wrapper::Set_World_Identity()
 {
 	if (render_state_changed&(unsigned)WORLD_IDENTITY) return;
-	render_state.world.Make_Identity();
+	D3DXMatrixIdentity(&render_state.world);
 	render_state_changed|=(unsigned)WORLD_CHANGED|(unsigned)WORLD_IDENTITY;
 }
 
 WWINLINE void DX8Wrapper::Set_View_Identity()
 {
 	if (render_state_changed&(unsigned)VIEW_IDENTITY) return;
-	render_state.view.Make_Identity();
+	D3DXMatrixIdentity(&render_state.view);
 	render_state_changed|=(unsigned)VIEW_CHANGED|(unsigned)VIEW_IDENTITY;
 }
 
@@ -1290,11 +1290,11 @@ WWINLINE void DX8Wrapper::Get_Transform(D3DTRANSFORMSTATETYPE transform, Matrix4
 	switch ((int)transform) {
 	case D3DTS_WORLD:
 		if (render_state_changed&WORLD_IDENTITY) m.Make_Identity();
-		else m=render_state.world;
+		else Build_Matrix4(m, render_state.world);
 		break;
 	case D3DTS_VIEW:
 		if (render_state_changed&VIEW_IDENTITY) m.Make_Identity();
-		else m=render_state.view;
+		else Build_Matrix4(m, render_state.view);
 		break;
 	default:
 		DX8CALL(GetTransform(transform,&mat));

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
@@ -1290,11 +1290,11 @@ WWINLINE void DX8Wrapper::Get_Transform(D3DTRANSFORMSTATETYPE transform, Matrix4
 	switch ((int)transform) {
 	case D3DTS_WORLD:
 		if (render_state_changed&WORLD_IDENTITY) m.Make_Identity();
-		else m=render_state.world.Transpose();
+		else m=render_state.world;
 		break;
 	case D3DTS_VIEW:
 		if (render_state_changed&VIEW_IDENTITY) m.Make_Identity();
-		else m=render_state.view.Transpose();
+		else m=render_state.view;
 		break;
 	default:
 		DX8CALL(GetTransform(transform,&mat));

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
@@ -41,6 +41,7 @@
 #include "always.h"
 #include "dllist.h"
 #include "d3d8.h"
+#include "d3dx8.h"
 #include "matrix4.h"
 #include "statistics.h"
 #include "wwstring.h"
@@ -301,6 +302,7 @@ public:
 
 	static void _Set_DX8_Transform(D3DTRANSFORMSTATETYPE transform,const Matrix4x4& m);
 	static void _Set_DX8_Transform(D3DTRANSFORMSTATETYPE transform,const Matrix3D& m);
+	static void _Set_DX8_Transform(D3DTRANSFORMSTATETYPE transform,const D3DXMATRIX& m);
 	static void _Get_DX8_Transform(D3DTRANSFORMSTATETYPE transform, Matrix4x4& m);
 
 	static void Set_DX8_Light(int index,D3DLIGHT8* light);
@@ -745,7 +747,6 @@ WWINLINE void DX8Wrapper::Set_Pixel_Shader_Constant(int reg, const void* data, i
 }
 // shader system updates KJM ^
 
-
 WWINLINE void DX8Wrapper::_Set_DX8_Transform(D3DTRANSFORMSTATETYPE transform,const Matrix4x4& m)
 {
 	WWASSERT(transform<=D3DTS_WORLD);
@@ -756,7 +757,8 @@ WWINLINE void DX8Wrapper::_Set_DX8_Transform(D3DTRANSFORMSTATETYPE transform,con
 		DX8Transforms[transform]=m;
 		SNAPSHOT_SAY(("DX8 - SetTransform %d [%f,%f,%f,%f][%f,%f,%f,%f][%f,%f,%f,%f][%f,%f,%f,%f]",transform,m[0][0],m[0][1],m[0][2],m[0][3],m[1][0],m[1][1],m[1][2],m[1][3],m[2][0],m[2][1],m[2][2],m[2][3],m[3][0],m[3][1],m[3][2],m[3][3]));
 		DX8_RECORD_MATRIX_CHANGE();
-		DX8CALL(SetTransform(transform,(D3DMATRIX*)&m));
+		D3DXMATRIX d3dMat = Build_D3DXMATRIX(m);
+		DX8CALL(SetTransform(transform, &d3dMat));
 	}
 }
 
@@ -772,13 +774,22 @@ WWINLINE void DX8Wrapper::_Set_DX8_Transform(D3DTRANSFORMSTATETYPE transform,con
 		DX8Transforms[transform]=mtx;
 		SNAPSHOT_SAY(("DX8 - SetTransform %d [%f,%f,%f,%f][%f,%f,%f,%f][%f,%f,%f,%f]",transform,m[0][0],m[0][1],m[0][2],m[0][3],m[1][0],m[1][1],m[1][2],m[1][3],m[2][0],m[2][1],m[2][2],m[2][3]));
 		DX8_RECORD_MATRIX_CHANGE();
-		DX8CALL(SetTransform(transform,(D3DMATRIX*)&m));
+		D3DXMATRIX d3dMat = Build_D3DXMATRIX(mtx);
+		DX8CALL(SetTransform(transform, &d3dMat));
 	}
+}
+
+WWINLINE void DX8Wrapper::_Set_DX8_Transform(D3DTRANSFORMSTATETYPE transform,const D3DXMATRIX& m)
+{
+	DX8_RECORD_MATRIX_CHANGE();
+	DX8CALL(SetTransform(transform, &m));
 }
 
 WWINLINE void DX8Wrapper::_Get_DX8_Transform(D3DTRANSFORMSTATETYPE transform, Matrix4x4& m)
 {
-	DX8CALL(GetTransform(transform,(D3DMATRIX*)&m));
+	D3DXMATRIX d3dMat;
+	DX8CALL(GetTransform(transform,&d3dMat));
+	Build_Matrix4(m, (D3DMATRIX&)d3dMat);
 }
 
 // ----------------------------------------------------------------------------
@@ -1195,27 +1206,27 @@ WWINLINE void DX8Wrapper::Set_Transform(D3DTRANSFORMSTATETYPE transform,const Ma
 {
 	switch ((int)transform) {
 	case D3DTS_WORLD:
-		render_state.world=m.Transpose();
+		render_state.world=m;
 		render_state_changed|=(unsigned)WORLD_CHANGED;
 		render_state_changed&=~(unsigned)WORLD_IDENTITY;
 		break;
 	case D3DTS_VIEW:
-		render_state.view=m.Transpose();
+		render_state.view=m;
 		render_state_changed|=(unsigned)VIEW_CHANGED;
 		render_state_changed&=~(unsigned)VIEW_IDENTITY;
 		break;
 	case D3DTS_PROJECTION:
 		{
-			Matrix4x4 ProjectionMatrix=m.Transpose();
 			ZFar=0.0f;
 			ZNear=0.0f;
-			DX8CALL(SetTransform(D3DTS_PROJECTION,(D3DMATRIX*)&ProjectionMatrix));
+			D3DXMATRIX d3dMat = Build_D3DXMATRIX(m);
+			DX8CALL(SetTransform(D3DTS_PROJECTION,&d3dMat));
 		}
 		break;
 	default:
 		DX8_RECORD_MATRIX_CHANGE();
-		Matrix4x4 m2=m.Transpose();
-		DX8CALL(SetTransform(transform,(D3DMATRIX*)&m2));
+		D3DXMATRIX d3dMat2 = Build_D3DXMATRIX(m);
+		DX8CALL(SetTransform(transform,&d3dMat2));
 		break;
 	}
 }
@@ -1225,19 +1236,19 @@ WWINLINE void DX8Wrapper::Set_Transform(D3DTRANSFORMSTATETYPE transform,const Ma
 	Matrix4x4 m2(m);
 	switch ((int)transform) {
 	case D3DTS_WORLD:
-		render_state.world=m2.Transpose();
+		render_state.world=m2;
 		render_state_changed|=(unsigned)WORLD_CHANGED;
 		render_state_changed&=~(unsigned)WORLD_IDENTITY;
 		break;
 	case D3DTS_VIEW:
-		render_state.view=m2.Transpose();
+		render_state.view=m2;
 		render_state_changed|=(unsigned)VIEW_CHANGED;
 		render_state_changed&=~(unsigned)VIEW_IDENTITY;
 		break;
 	default:
 		DX8_RECORD_MATRIX_CHANGE();
-		m2=m2.Transpose();
-		DX8CALL(SetTransform(transform,(D3DMATRIX*)&m2));
+		D3DXMATRIX d3dMat3 = Build_D3DXMATRIX(m2);
+		DX8CALL(SetTransform(transform,&d3dMat3));
 		break;
 	}
 }

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/sortingrenderer.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/sortingrenderer.cpp
@@ -351,9 +351,7 @@ void SortingRendererClass::Insert_Triangles(
 	WWASSERT(vertex_buffer);
 	WWASSERT(state->vertex_count<=vertex_buffer->Get_Vertex_Count());
 
-	D3DXMATRIX worldMat = Build_D3DXMATRIX(state->sorting_state.world);
-	D3DXMATRIX viewMat = Build_D3DXMATRIX(state->sorting_state.view);
-	D3DXMATRIX mtx=worldMat*viewMat;
+	D3DXMATRIX mtx=state->sorting_state.world*state->sorting_state.view;
 	D3DXVECTOR3 vec=(D3DXVECTOR3&)state->bounding_sphere.Center;
 	D3DXVECTOR4 transformed_vec;
 	D3DXVec3Transform(
@@ -554,9 +552,7 @@ void SortingRendererClass::Flush_Sorting_Pool()
 			src_verts+=state->sorting_state.index_base_offset;
 			src_verts+=state->min_vertex_index;
 
-			D3DXMATRIX worldMat2 = Build_D3DXMATRIX(state->sorting_state.world);
-			D3DXMATRIX viewMat2 = Build_D3DXMATRIX(state->sorting_state.view);
-			D3DXMATRIX d3d_mtx=worldMat2*viewMat2;
+			D3DXMATRIX d3d_mtx=state->sorting_state.world*state->sorting_state.view;
 			const Matrix4x4& mtx=(const Matrix4x4&)d3d_mtx;
 			unsigned i=0;
 			for (;i<state->vertex_count;++i,++src_verts) {
@@ -820,9 +816,7 @@ void SortingRendererClass::Insert_VolumeParticle(
 
 	// Transform the center point to view space for sorting
 
-	D3DXMATRIX worldMat3 = Build_D3DXMATRIX(state->sorting_state.world);
-	D3DXMATRIX viewMat3 = Build_D3DXMATRIX(state->sorting_state.view);
-	D3DXMATRIX mtx=worldMat3*viewMat3;
+	D3DXMATRIX mtx=state->sorting_state.world*state->sorting_state.view;
 	D3DXVECTOR3 vec=(D3DXVECTOR3&)state->bounding_sphere.Center;
 	D3DXVECTOR4 transformed_vec;
 	D3DXVec3Transform(

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/sortingrenderer.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/sortingrenderer.cpp
@@ -351,7 +351,9 @@ void SortingRendererClass::Insert_Triangles(
 	WWASSERT(vertex_buffer);
 	WWASSERT(state->vertex_count<=vertex_buffer->Get_Vertex_Count());
 
-	D3DXMATRIX mtx=(D3DXMATRIX&)state->sorting_state.world*(D3DXMATRIX&)state->sorting_state.view;
+	D3DXMATRIX worldMat = Build_D3DXMATRIX(state->sorting_state.world);
+	D3DXMATRIX viewMat = Build_D3DXMATRIX(state->sorting_state.view);
+	D3DXMATRIX mtx=worldMat*viewMat;
 	D3DXVECTOR3 vec=(D3DXVECTOR3&)state->bounding_sphere.Center;
 	D3DXVECTOR4 transformed_vec;
 	D3DXVec3Transform(
@@ -552,8 +554,9 @@ void SortingRendererClass::Flush_Sorting_Pool()
 			src_verts+=state->sorting_state.index_base_offset;
 			src_verts+=state->min_vertex_index;
 
-			D3DXMATRIX d3d_mtx=(D3DXMATRIX&)state->sorting_state.world*(D3DXMATRIX&)state->sorting_state.view;
-			D3DXMatrixTranspose(&d3d_mtx,&d3d_mtx);
+			D3DXMATRIX worldMat2 = Build_D3DXMATRIX(state->sorting_state.world);
+			D3DXMATRIX viewMat2 = Build_D3DXMATRIX(state->sorting_state.view);
+			D3DXMATRIX d3d_mtx=worldMat2*viewMat2;
 			const Matrix4x4& mtx=(const Matrix4x4&)d3d_mtx;
 			unsigned i=0;
 			for (;i<state->vertex_count;++i,++src_verts) {
@@ -817,7 +820,9 @@ void SortingRendererClass::Insert_VolumeParticle(
 
 	// Transform the center point to view space for sorting
 
-	D3DXMATRIX mtx=(D3DXMATRIX&)state->sorting_state.world*(D3DXMATRIX&)state->sorting_state.view;
+	D3DXMATRIX worldMat3 = Build_D3DXMATRIX(state->sorting_state.world);
+	D3DXMATRIX viewMat3 = Build_D3DXMATRIX(state->sorting_state.view);
+	D3DXMATRIX mtx=worldMat3*viewMat3;
 	D3DXVECTOR3 vec=(D3DXVECTOR3&)state->bounding_sphere.Center;
 	D3DXVECTOR4 transformed_vec;
 	D3DXVec3Transform(

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp
@@ -2053,7 +2053,10 @@ void W3DVolumetricShadow::updateMeshVolume(Int meshIndex, Int lightIndex, const 
 		// system change, not the translations
 		//
 		Real det;
-		D3DXMatrixInverse((D3DXMATRIX*)&worldToObject, &det, (D3DXMATRIX*)&objectToWorld);
+		D3DXMATRIX d3dObjectToWorld = Build_D3DXMATRIX(objectToWorld);
+		D3DXMATRIX d3dWorldToObject;
+		D3DXMatrixInverse(&d3dWorldToObject, &det, &d3dObjectToWorld);
+		Build_Matrix4(worldToObject, (D3DMATRIX&)d3dWorldToObject);
 
 		// find out light position in object space
 		Matrix4x4::Transform_Vector(worldToObject,lightPosWorld,&lightPosObject);

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
@@ -1346,11 +1346,11 @@ WWINLINE void DX8Wrapper::Get_Transform(D3DTRANSFORMSTATETYPE transform, Matrix4
 	switch ((int)transform) {
 	case D3DTS_WORLD:
 		if (render_state_changed&WORLD_IDENTITY) m.Make_Identity();
-		else m=render_state.world.Transpose();
+		else m=render_state.world;
 		break;
 	case D3DTS_VIEW:
 		if (render_state_changed&VIEW_IDENTITY) m.Make_Identity();
-		else m=render_state.view.Transpose();
+		else m=render_state.view;
 		break;
 	default:
 		DX8CALL(GetTransform(transform,&mat));

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
@@ -180,8 +180,8 @@ struct RenderStateStruct
 	D3DLIGHT8 Lights[4];
 	bool LightEnable[4];
   //unsigned lightsHash;
-	Matrix4x4 world;
-	Matrix4x4 view;
+	D3DXMATRIX world;
+	D3DXMATRIX view;
 	unsigned vertex_buffer_types[MAX_VERTEX_STREAMS];
 	unsigned index_buffer_type;
 	unsigned short vba_offset;
@@ -1268,12 +1268,12 @@ WWINLINE void DX8Wrapper::Set_Transform(D3DTRANSFORMSTATETYPE transform,const Ma
 {
 	switch ((int)transform) {
 	case D3DTS_WORLD:
-		render_state.world=m;
+		render_state.world=Build_D3DXMATRIX(m);
 		render_state_changed|=(unsigned)WORLD_CHANGED;
 		render_state_changed&=~(unsigned)WORLD_IDENTITY;
 		break;
 	case D3DTS_VIEW:
-		render_state.view=m;
+		render_state.view=Build_D3DXMATRIX(m);
 		render_state_changed|=(unsigned)VIEW_CHANGED;
 		render_state_changed&=~(unsigned)VIEW_IDENTITY;
 		break;
@@ -1298,12 +1298,12 @@ WWINLINE void DX8Wrapper::Set_Transform(D3DTRANSFORMSTATETYPE transform,const Ma
 	Matrix4x4 m2(m);
 	switch ((int)transform) {
 	case D3DTS_WORLD:
-		render_state.world=m2;
+		render_state.world=Build_D3DXMATRIX(m2);
 		render_state_changed|=(unsigned)WORLD_CHANGED;
 		render_state_changed&=~(unsigned)WORLD_IDENTITY;
 		break;
 	case D3DTS_VIEW:
-		render_state.view=m2;
+		render_state.view=Build_D3DXMATRIX(m2);
 		render_state_changed|=(unsigned)VIEW_CHANGED;
 		render_state_changed&=~(unsigned)VIEW_IDENTITY;
 		break;
@@ -1318,14 +1318,14 @@ WWINLINE void DX8Wrapper::Set_Transform(D3DTRANSFORMSTATETYPE transform,const Ma
 WWINLINE void DX8Wrapper::Set_World_Identity()
 {
 	if (render_state_changed&(unsigned)WORLD_IDENTITY) return;
-	render_state.world.Make_Identity();
+	D3DXMatrixIdentity(&render_state.world);
 	render_state_changed|=(unsigned)WORLD_CHANGED|(unsigned)WORLD_IDENTITY;
 }
 
 WWINLINE void DX8Wrapper::Set_View_Identity()
 {
 	if (render_state_changed&(unsigned)VIEW_IDENTITY) return;
-	render_state.view.Make_Identity();
+	D3DXMatrixIdentity(&render_state.view);
 	render_state_changed|=(unsigned)VIEW_CHANGED|(unsigned)VIEW_IDENTITY;
 }
 
@@ -1346,11 +1346,11 @@ WWINLINE void DX8Wrapper::Get_Transform(D3DTRANSFORMSTATETYPE transform, Matrix4
 	switch ((int)transform) {
 	case D3DTS_WORLD:
 		if (render_state_changed&WORLD_IDENTITY) m.Make_Identity();
-		else m=render_state.world;
+		else Build_Matrix4(m, render_state.world);
 		break;
 	case D3DTS_VIEW:
 		if (render_state_changed&VIEW_IDENTITY) m.Make_Identity();
-		else m=render_state.view;
+		else Build_Matrix4(m, render_state.view);
 		break;
 	default:
 		DX8CALL(GetTransform(transform,&mat));

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
@@ -313,6 +313,7 @@ public:
 	static void _Set_DX8_Transform(D3DTRANSFORMSTATETYPE transform,const Matrix3D& m);
 	static void _Set_DX8_Transform(D3DTRANSFORMSTATETYPE transform,const D3DXMATRIX& m);
 	static void _Get_DX8_Transform(D3DTRANSFORMSTATETYPE transform, Matrix4x4& m);
+	static void _Get_DX8_Transform(D3DTRANSFORMSTATETYPE transform, D3DXMATRIX& m);
 
 	static void Set_DX8_Light(int index,D3DLIGHT8* light);
 	static void Set_DX8_Render_State(D3DRENDERSTATETYPE state, unsigned value);
@@ -798,7 +799,12 @@ WWINLINE void DX8Wrapper::_Get_DX8_Transform(D3DTRANSFORMSTATETYPE transform, Ma
 {
 	D3DXMATRIX d3dMat;
 	DX8CALL(GetTransform(transform,&d3dMat));
-	Build_Matrix4(m, (D3DMATRIX&)d3dMat);
+	Build_Matrix4(m, d3dMat);
+}
+
+WWINLINE void DX8Wrapper::_Get_DX8_Transform(D3DTRANSFORMSTATETYPE transform, D3DXMATRIX& m)
+{
+	DX8CALL(GetTransform(transform, &m));
 }
 
 // ----------------------------------------------------------------------------

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
@@ -1354,8 +1354,7 @@ WWINLINE void DX8Wrapper::Get_Transform(D3DTRANSFORMSTATETYPE transform, Matrix4
 		break;
 	default:
 		DX8CALL(GetTransform(transform,&mat));
-		m=*(Matrix4x4*)&mat;
-		m=m.Transpose();
+		Build_Matrix4(m, mat);
 		break;
 	}
 }

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/sortingrenderer.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/sortingrenderer.cpp
@@ -246,7 +246,9 @@ void SortingRendererClass::Insert_Triangles(
 	WWASSERT(vertex_buffer);
 	WWASSERT(state->vertex_count<=vertex_buffer->Get_Vertex_Count());
 
-	D3DXMATRIX mtx=(D3DXMATRIX&)state->sorting_state.world*(D3DXMATRIX&)state->sorting_state.view;
+	D3DXMATRIX worldMat = Build_D3DXMATRIX(state->sorting_state.world);
+	D3DXMATRIX viewMat = Build_D3DXMATRIX(state->sorting_state.view);
+	D3DXMATRIX mtx=worldMat*viewMat;
 	D3DXVECTOR3 vec=(D3DXVECTOR3&)state->bounding_sphere.Center;
 	D3DXVECTOR4 transformed_vec;
 	D3DXVec3Transform(
@@ -441,7 +443,9 @@ void SortingRendererClass::Flush_Sorting_Pool()
 			memcpy(dest_verts, src_verts, sizeof(VertexFormatXYZNDUV2)*state->vertex_count);
 			dest_verts += state->vertex_count;
 
-			D3DXMATRIX d3d_mtx=(D3DXMATRIX&)state->sorting_state.world*(D3DXMATRIX&)state->sorting_state.view;
+			D3DXMATRIX worldMat2 = Build_D3DXMATRIX(state->sorting_state.world);
+			D3DXMATRIX viewMat2 = Build_D3DXMATRIX(state->sorting_state.view);
+			D3DXMATRIX d3d_mtx=worldMat2*viewMat2;
 			const Matrix4x4& mtx=(const Matrix4x4&)d3d_mtx;
 
 			unsigned short* indices=NULL;
@@ -709,7 +713,9 @@ void SortingRendererClass::Insert_VolumeParticle(
 
 	// Transform the center point to view space for sorting
 
-	D3DXMATRIX mtx=(D3DXMATRIX&)state->sorting_state.world*(D3DXMATRIX&)state->sorting_state.view;
+	D3DXMATRIX worldMat3 = Build_D3DXMATRIX(state->sorting_state.world);
+	D3DXMATRIX viewMat3 = Build_D3DXMATRIX(state->sorting_state.view);
+	D3DXMATRIX mtx=worldMat3*viewMat3;
 	D3DXVECTOR3 vec=(D3DXVECTOR3&)state->bounding_sphere.Center;
 	D3DXVECTOR4 transformed_vec;
 	D3DXVec3Transform(

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/sortingrenderer.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/sortingrenderer.cpp
@@ -246,9 +246,7 @@ void SortingRendererClass::Insert_Triangles(
 	WWASSERT(vertex_buffer);
 	WWASSERT(state->vertex_count<=vertex_buffer->Get_Vertex_Count());
 
-	D3DXMATRIX worldMat = Build_D3DXMATRIX(state->sorting_state.world);
-	D3DXMATRIX viewMat = Build_D3DXMATRIX(state->sorting_state.view);
-	D3DXMATRIX mtx=worldMat*viewMat;
+	D3DXMATRIX mtx=state->sorting_state.world*state->sorting_state.view;
 	D3DXVECTOR3 vec=(D3DXVECTOR3&)state->bounding_sphere.Center;
 	D3DXVECTOR4 transformed_vec;
 	D3DXVec3Transform(
@@ -443,9 +441,7 @@ void SortingRendererClass::Flush_Sorting_Pool()
 			memcpy(dest_verts, src_verts, sizeof(VertexFormatXYZNDUV2)*state->vertex_count);
 			dest_verts += state->vertex_count;
 
-			D3DXMATRIX worldMat2 = Build_D3DXMATRIX(state->sorting_state.world);
-			D3DXMATRIX viewMat2 = Build_D3DXMATRIX(state->sorting_state.view);
-			D3DXMATRIX d3d_mtx=worldMat2*viewMat2;
+			D3DXMATRIX d3d_mtx=state->sorting_state.world*state->sorting_state.view;
 			const Matrix4x4& mtx=(const Matrix4x4&)d3d_mtx;
 
 			unsigned short* indices=NULL;
@@ -713,9 +709,7 @@ void SortingRendererClass::Insert_VolumeParticle(
 
 	// Transform the center point to view space for sorting
 
-	D3DXMATRIX worldMat3 = Build_D3DXMATRIX(state->sorting_state.world);
-	D3DXMATRIX viewMat3 = Build_D3DXMATRIX(state->sorting_state.view);
-	D3DXMATRIX mtx=worldMat3*viewMat3;
+	D3DXMATRIX mtx=state->sorting_state.world*state->sorting_state.view;
 	D3DXVECTOR3 vec=(D3DXVECTOR3&)state->bounding_sphere.Center;
 	D3DXVECTOR4 transformed_vec;
 	D3DXVec3Transform(


### PR DESCRIPTION
- Closes #552

## Summary
Replaces all C-style casts between `Matrix4x4`/`Matrix3D` and `D3DXMATRIX`/`D3DMATRIX` with proper conversion functions that handle the row-major/column-major transpose.

Before:
```
DX8CALL(SetTransform(transform, (D3DMATRIX*)&m));
```

After:
```
D3DXMATRIX d3dMat = Build_D3DXMATRIX(m);
DX8CALL(SetTransform(transform, &d3dMat));
```
