### PR TITLE
fix(parabolicease): Fix asserting on float imprecision in ParabolicEase::setEaseTimes()

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameClient/ParabolicEase.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/ParabolicEase.cpp
@@ -59,8 +59,8 @@ ParabolicEase::setEaseTimes(Real easeInTime, Real easeOutTime)
 		m_out = clamp(m_out);
 	}
 
-	if (m_in > m_out + FLT_EPSILON) {
-		DEBUG_CRASH(("Ease-in and ease-out overlap (in = %g, out = %g)", m_in, m_out));
+	if (m_in > m_out) {
+		DEBUG_ASSERTCRASH(m_in <= m_out + FLT_EPSILON, ("Ease-in and ease-out overlap (in = %g, out = %g)", m_in, m_out));
 		m_in = m_out;
 	}
 }


### PR DESCRIPTION
This change enables the `ParabolicEase::setEaseTimes` method to better handle floating point imprecision, such as cases where `m_in = 0.200000003` and `m_out = 0.199999988`, without calling a `DEBUG_CRASH`.