### PR TITLE
bugfix(energy): Destruction of disabled Power Plant no longer lowers energy production twice

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/RTS/Energy.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/Energy.cpp
@@ -189,12 +189,12 @@ void Energy::removePowerBonus( Object *obj )
 		return;
 
 	// TheSuperHackers @bugfix Caball009 14/11/2025 Don't remove power bonus for disabled power plants.
-#if RETAIL_COMPATIBLE_CRC
-	addProduction( -obj->getTemplate()->getEnergyBonus() );
-#else
-	if ( !obj->isDisabled() )
-		addProduction( -obj->getTemplate()->getEnergyBonus() );
+#if !RETAIL_COMPATIBLE_CRC
+	if ( obj->isDisabled() )
+		return;
 #endif
+
+	addProduction( -obj->getTemplate()->getEnergyBonus() );
 
 	// sanity
 	DEBUG_ASSERTCRASH( m_energyProduction >= 0 && m_energyConsumption >= 0,

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Energy.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Energy.cpp
@@ -208,12 +208,12 @@ void Energy::removePowerBonus( Object *obj )
 		return;
 
 	// TheSuperHackers @bugfix Caball009 14/11/2025 Don't remove power bonus for disabled power plants.
-#if RETAIL_COMPATIBLE_CRC
-	addProduction( -obj->getTemplate()->getEnergyBonus() );
-#else
-	if ( !obj->isDisabled() )
-		addProduction( -obj->getTemplate()->getEnergyBonus() );
+#if !RETAIL_COMPATIBLE_CRC
+	if ( obj->isDisabled() )
+		return;
 #endif
+
+	addProduction( -obj->getTemplate()->getEnergyBonus() );
 
 	// sanity
 	DEBUG_ASSERTCRASH( m_energyProduction >= 0 && m_energyConsumption >= 0,


### PR DESCRIPTION
* Fixes issue: https://github.com/TheSuperHackers/GeneralsGameCode/issues/1839

This change fixes a bug where destroying disabled power plants would trigger a second reduction in energy production. This affects reactors from USA and China if they're upgraded / overcharged.