### PR TITLE
build(vcpkg): Add lockfile and binary cache

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -31,9 +31,21 @@ jobs:
     name: ${{ inputs.preset }}${{ inputs.tools && '+t' || '' }}${{ inputs.extras && '+e' || '' }}
     runs-on: windows-2022
     timeout-minutes: 20
+    env:
+      VCPKG_FILE_CACHE: ${{ github.workspace }}\vcpkg-bincache
+      VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}\vcpkg-bincache,readwrite
+      VCPKG_FEATURE_FLAGS: manifests,versions,binarycaching
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+
+      - name: Cache vcpkg binary artifacts
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}\vcpkg-bincache
+          key: vcpkg-bincache-${{ runner.os }}-${{ hashFiles('vcpkg.json','vcpkg-lock.json') }}
+          restore-keys: |
+            vcpkg-bincache-${{ runner.os }}-
 
       - name: Cache VC6 Installation
         if: startsWith(inputs.preset, 'vc6')

--- a/README.md
+++ b/README.md
@@ -65,6 +65,15 @@ We provide support for building the project using Visual Studio 6 (VS6) and Visu
 instructions, check the [Wiki](https://github.com/TheSuperHackers/GeneralsGameCode/wiki/build_guides), which also
 includes guides for building with Docker, CLion, and links to forks supporting additional versions.
 
+### Dependency management
+
+The repository uses a vcpkg manifest (`vcpkg.json`) paired with a lockfile (`vcpkg-lock.json`). When you add or upgrade
+dependencies, run `vcpkg install --x-manifest-root . --triplet <triplet>` with `VCPKG_FEATURE_FLAGS=versions` so the
+lockfile picks up the new versions and include the updated lockfile in your change. GitHub Actions consumes these ports
+through `VCPKG_BINARY_SOURCES=clear;files,<workspace>/vcpkg-bincache,readwrite` (paired with an `actions/cache` entry for
+that folder), so the first CI build warms the cache and subsequent builds pull prebuilt binaries instead of
+re-compiling everything.
+
 ## Contributing
 
 We welcome contributions to the project! If you’re interested in contributing, you need to have knowledge of C++. Join

--- a/vcpkg-lock.json
+++ b/vcpkg-lock.json
@@ -1,0 +1,48 @@
+{
+    "version": 1,
+    "dependencies": [
+        {
+            "name": "ffmpeg",
+            "version-string": "7.1.1",
+            "port-version": 1,
+            "git-tree": "6ff75f1f596ada519241989f44077cda442480b2"
+        },
+        {
+            "name": "pkgconf",
+            "version-string": "2.3.0",
+            "port-version": 0,
+            "git-tree": "ae3886d8a627ec99dd18890389b6d5d331e29799"
+        },
+        {
+            "name": "vcpkg-cmake",
+            "version-string": "2024-04-23",
+            "port-version": 0,
+            "git-tree": "e74aa1e8f93278a8e71372f1fa08c3df420eb840"
+        },
+        {
+            "name": "vcpkg-cmake-get-vars",
+            "version-string": "2024-09-22",
+            "port-version": 0,
+            "git-tree": "f23148add155147f3d95ae622d3b0031beb25acf"
+        },
+        {
+            "name": "vcpkg-pkgconfig-get-modules",
+            "version-string": "2024-04-03",
+            "port-version": 0,
+            "git-tree": "6845369c8cb7d3c318e8e3ae92fd2b7570a756ca"
+        },
+        {
+            "name": "vcpkg-tool-meson",
+            "version-string": "1.6.1",
+            "port-version": 0,
+            "git-tree": "dc948c67d7f1359319f801078422e996b0a89fd0"
+        },
+        {
+            "name": "zlib",
+            "version-string": "1.3.1",
+            "port-version": 0,
+            "git-tree": "3f05e04b9aededb96786a911a16193cdb711f0c9"
+        }
+    ]
+}
+


### PR DESCRIPTION
* Add vcpkg-lock.json so ffmpeg/zlib/helper ports are pinned to explicit git trees.
* Set CI to a file-backed vcpkg binary cache (`clear;files,<workspace>/vcpkg-bincache,readwrite` + actions/cache) so the first run warms it and later runs reuse prebuilt packages.
* Document the manifest + cache workflow in README so contributors know to regenerate the lockfile and rely on the cache.

-Merge before #1863 