### PR TITLE
ci: Re-enable win32 vcpkg presets

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -30,7 +30,7 @@ jobs:
   build:
     name: ${{ inputs.preset }}${{ inputs.tools && '+t' || '' }}${{ inputs.extras && '+e' || '' }}
     runs-on: windows-2022
-    timeout-minutes: 20
+    timeout-minutes: 30
     env:
       VCPKG_FILE_CACHE: ${{ github.workspace }}\vcpkg-bincache
       VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}\vcpkg-bincache,readwrite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,16 +80,15 @@ jobs:
           - preset: "win32-debug"
             tools: true
             extras: true
-          # vcpkg builds have been disabled for now due to excessive build times of 30 minutes per preset
-          # - preset: "win32-vcpkg"
-          #   tools: true
-          #   extras: true
-          # - preset: "win32-vcpkg-profile"
-          #   tools: true
-          #   extras: true
-          # - preset: "win32-vcpkg-debug"
-          #   tools: true
-          #   extras: true
+          - preset: "win32-vcpkg"
+            tools: true
+            extras: true
+          - preset: "win32-vcpkg-profile"
+            tools: true
+            extras: true
+          - preset: "win32-vcpkg-debug"
+            tools: true
+            extras: true
       fail-fast: false
     uses: ./.github/workflows/build-toolchain.yml
     with:
@@ -145,16 +144,15 @@ jobs:
           - preset: "win32-debug"
             tools: true
             extras: true
-          # vcpkg builds have been disabled for now due to excessive build times of 30 minutes per preset
-          # - preset: "win32-vcpkg"
-          #   tools: true
-          #   extras: true
-          # - preset: "win32-vcpkg-profile"
-          #   tools: true
-          #   extras: true
-          # - preset: "win32-vcpkg-debug"
-          #   tools: true
-          #   extras: true
+          - preset: "win32-vcpkg"
+            tools: true
+            extras: true
+          - preset: "win32-vcpkg-profile"
+            tools: true
+            extras: true
+          - preset: "win32-vcpkg-debug"
+            tools: true
+            extras: true
       fail-fast: false
     uses: ./.github/workflows/build-toolchain.yml
     with:


### PR DESCRIPTION
- merge after #1862

* Re-enables the win32 vcpkg preset matrix for Generals and Zero Hour.
* 20+ minute builds now reduced to 5-6min
* ffmpeg build reduced from 15+min to seconds