### PR TITLE
tweak(behavior): Add RETAIL_COMPATIBLE_BUG to Black Lotus cash value fix

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
@@ -1341,7 +1341,7 @@ void SpecialAbilityUpdate::triggerAbilityEffect()
 			if( targetMoney && objectMoney )
 			{
 				UnsignedInt cash = targetMoney->countMoney();
-#if RETAIL_COMPATIBLE_CRC
+#if RETAIL_COMPATIBLE_CRC || RETAIL_COMPATIBLE_BUG
 				UnsignedInt desiredAmount = 1000;
 #else
 				UnsignedInt desiredAmount = data->m_effectValue;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
@@ -1487,7 +1487,7 @@ void SpecialAbilityUpdate::triggerAbilityEffect()
       if( targetMoney && objectMoney )
       {
         UnsignedInt cash = targetMoney->countMoney();
-#if RETAIL_COMPATIBLE_CRC
+#if RETAIL_COMPATIBLE_CRC || RETAIL_COMPATIBLE_BUG
         UnsignedInt desiredAmount = 1000;
 #else
         UnsignedInt desiredAmount = data->m_effectValue;


### PR DESCRIPTION
- Follow up on #1601

With  #1601 removing the hardcoded cash gain when Black Lotus performs a successfull cash hack, the Super Lotus now gains 1.500 instead of 1.000 credits per INI configuration.

To keep in line with expectations, this fix also needs to be behind RETAIL_COMPATIBLE_BUG guards.