### PR TITLE
bugfix(weapon): Show weapon effects of stealthed objects for allies and observers

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -884,7 +884,7 @@ UnsignedInt WeaponTemplate::fireWeaponTemplate
 
 		Bool handled;
 
-		// TODO: Remove hardcoded KINDOF_MINE check and apply PlayFXWhenStealthed = Yes to the mine weapons instead.
+		// TheSuperHackers @todo: Remove hardcoded KINDOF_MINE check and apply PlayFXWhenStealthed = Yes to the mine weapons instead.
 
 		if(!sourceObj->getDrawable()->isVisible()							// if user watching cannot see us
 			&& !sourceObj->isKindOf(KINDOF_MINE)								// and not a mine (which always do the FX, even if hidden)...

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -915,7 +915,7 @@ UnsignedInt WeaponTemplate::fireWeaponTemplate
 
 		Bool handled;
 
-		// TODO: Remove hardcoded KINDOF_MINE check and apply PlayFXWhenStealthed = Yes to the mine weapons instead.
+		// TheSuperHackers @todo: Remove hardcoded KINDOF_MINE check and apply PlayFXWhenStealthed = Yes to the mine weapons instead.
 
 		if(!sourceObj->getDrawable()->isVisible()							// if user watching cannot see us
 			&& !sourceObj->isKindOf(KINDOF_MINE)								// and not a mine (which always do the FX, even if hidden)...


### PR DESCRIPTION
This change fixes the weapon effects of stealthed objects not being shown for allies and observers (essentially anyone who can see the object should see the effects, instead of just the owner). The logic is also cleaner and easier to understand as an added bonus.

### Before
Allies and observers do not see the muzzle flash, bullet casing or bullet trail of the shooting Pathfinder

https://github.com/user-attachments/assets/c99e2c2e-c193-422d-b75e-55a9bf75b8f1

### After
Allies and observers can see the muzzle flash, bullet casing and bullet trail of the shooting Pathfinder

https://github.com/user-attachments/assets/b32934e0-f356-4654-8400-37c638a3e63d