### PR TITLE
bugfix(object): Show veterancy effects of stealthed objects for allies and observers

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -2824,9 +2824,7 @@ void Object::onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel ne
 	Bool doAnimation = provideFeedback
 		&& newLevel > oldLevel
 		&& !isKindOf(KINDOF_IGNORED_IN_GUI)
-		&& (isLocallyControlled()
-			|| !testStatus(OBJECT_STATUS_STEALTHED)
-			|| testStatus(OBJECT_STATUS_DETECTED));
+		&& getDrawable()->isVisible();
 
 	if( doAnimation && TheGameLogic->getDrawIconUI() )
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -3139,10 +3139,7 @@ void Object::onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel ne
 	Bool doAnimation = provideFeedback
 		&& newLevel > oldLevel
 		&& !isKindOf(KINDOF_IGNORED_IN_GUI)
-		&& (isLocallyControlled()
-			|| !testStatus(OBJECT_STATUS_STEALTHED)
-			|| testStatus(OBJECT_STATUS_DETECTED)
-			|| testStatus(OBJECT_STATUS_DISGUISED));
+		&& getDrawable()->isVisible();
 
 	if( doAnimation && TheGameLogic->getDrawIconUI() )
 	{


### PR DESCRIPTION
This change fixes the veterancy effects of stealthed objects not being shown for allies and observers.

### Before

Allies and observers cannot see the veterancy effect when a stealthed unit ranks up

https://github.com/user-attachments/assets/9653c61c-8411-409c-97df-9925185545f6

### After

Allies and observers can see the veterancy effect when a stealthed unit ranks up

https://github.com/user-attachments/assets/ef179c66-ab09-4baa-ab7d-e205b92a717a