### PR TITLE
build(ai): Resolve compile errors when the USE_DOZER preprocessor directive is false

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -801,6 +801,7 @@ void AIPlayer::processBaseBuilding( void )
 
 #else
 					// force delay between rebuilds
+					Int framesToBuild = bldgPlan->calcTimeToBuild(m_player);
 					if (TheGameLogic->getFrame() - m_frameLastBuildingBuilt < framesToBuild)
 					{
 						m_buildDelay = framesToBuild - (TheGameLogic->getFrame() - m_frameLastBuildingBuilt);
@@ -815,7 +816,7 @@ void AIPlayer::processBaseBuilding( void )
 							m_player->getMoney()->withdraw( cost );
 
 							// inst-construct the building
-							bldg = buildStructureNow(bldgPlan, info, NULL);
+							bldg = buildStructureNow(bldgPlan, info);
 							// store the object with the build order
 							if (bldg)
 							{

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AISkirmishPlayer.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AISkirmishPlayer.cpp
@@ -262,6 +262,7 @@ void AISkirmishPlayer::processBaseBuilding( void )
 
 #else
 			// force delay between rebuilds
+			Int framesToBuild = bldgPlan->calcTimeToBuild(m_player);
 			if (TheGameLogic->getFrame() - m_frameLastBuildingBuilt < framesToBuild)
 			{
 				m_buildDelay = framesToBuild - (TheGameLogic->getFrame() - m_frameLastBuildingBuilt);
@@ -276,12 +277,12 @@ void AISkirmishPlayer::processBaseBuilding( void )
 					m_player->getMoney()->withdraw( cost );
 
 					// inst-construct the building
-					bldg = buildStructureNow(bldgPlan, info, NULL);
+					bldg = buildStructureNow(bldgPlan, bldgInfo);
 					// store the object with the build order
 					if (bldg)
 					{
-						info->setObjectID( bldg->getID() );
-						info->decrementNumRebuilds();
+						bldgInfo->setObjectID( bldg->getID() );
+						bldgInfo->decrementNumRebuilds();
 
 						m_readyToBuildStructure = false;
 						m_structureTimer = TheAI->getAiData()->m_structureSeconds*LOGICFRAMES_PER_SECOND;
@@ -291,8 +292,6 @@ void AISkirmishPlayer::processBaseBuilding( void )
 							m_structureTimer = m_structureTimer/TheAI->getAiData()->m_structuresWealthyMod;
 						}
 						m_frameLastBuildingBuilt = TheGameLogic->getFrame();
-						// only build one building per delay loop
-						break;
 					}
 				}
 			}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPlayer.cpp
@@ -808,6 +808,7 @@ void AIPlayer::processBaseBuilding( void )
 
 #else
 					// force delay between rebuilds
+					Int framesToBuild = bldgPlan->calcTimeToBuild(m_player);
 					if (TheGameLogic->getFrame() - m_frameLastBuildingBuilt < framesToBuild)
 					{
 						m_buildDelay = framesToBuild - (TheGameLogic->getFrame() - m_frameLastBuildingBuilt);
@@ -822,7 +823,7 @@ void AIPlayer::processBaseBuilding( void )
 							m_player->getMoney()->withdraw( cost );
 
 							// inst-construct the building
-							bldg = buildStructureNow(bldgPlan, info, NULL);
+							bldg = buildStructureNow(bldgPlan, info);
 							// store the object with the build order
 							if (bldg)
 							{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AISkirmishPlayer.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AISkirmishPlayer.cpp
@@ -269,6 +269,7 @@ void AISkirmishPlayer::processBaseBuilding( void )
 
 #else
 			// force delay between rebuilds
+			Int framesToBuild = bldgPlan->calcTimeToBuild(m_player);
 			if (TheGameLogic->getFrame() - m_frameLastBuildingBuilt < framesToBuild)
 			{
 				m_buildDelay = framesToBuild - (TheGameLogic->getFrame() - m_frameLastBuildingBuilt);
@@ -283,12 +284,12 @@ void AISkirmishPlayer::processBaseBuilding( void )
 					m_player->getMoney()->withdraw( cost );
 
 					// inst-construct the building
-					bldg = buildStructureNow(bldgPlan, info, NULL);
+					bldg = buildStructureNow(bldgPlan, bldgInfo);
 					// store the object with the build order
 					if (bldg)
 					{
-						info->setObjectID( bldg->getID() );
-						info->decrementNumRebuilds();
+						bldgInfo->setObjectID( bldg->getID() );
+						bldgInfo->decrementNumRebuilds();
 
 						m_readyToBuildStructure = false;
 						m_structureTimer = TheAI->getAiData()->m_structureSeconds*LOGICFRAMES_PER_SECOND;
@@ -298,8 +299,6 @@ void AISkirmishPlayer::processBaseBuilding( void )
 							m_structureTimer = m_structureTimer/TheAI->getAiData()->m_structuresWealthyMod;
 						}
 						m_frameLastBuildingBuilt = TheGameLogic->getFrame();
-						// only build one building per delay loop
-						break;
 					}
 				}
 			}


### PR DESCRIPTION
This change fixes some compile errors when the `USE_DOZER` preprocessor directive is set to false in the `AIPlayer` and `AISkirmishPlayer` classes.