### PR TITLE
bugfix(actionmanager): Allow immediate resumed construction of buildings if the existing builder dies

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/RTS/ActionManager.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/ActionManager.cpp
@@ -479,6 +479,7 @@ Bool ActionManager::canResumeConstructionOf( const Object *obj,
 #if RETAIL_COMPATIBLE_CRC
 	if( builder )
 #else
+	// TheSuperHackers @bugfix Stubbjax 18/11/2025 Allow scaffold to be immediately resumed after builder death.
 	if (builder && !builder->isEffectivelyDead())
 #endif
 	{

--- a/Generals/Code/GameEngine/Source/Common/RTS/ActionManager.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/ActionManager.cpp
@@ -476,7 +476,11 @@ Bool ActionManager::canResumeConstructionOf( const Object *obj,
 	// in the future)
 	//
 	Object *builder = TheGameLogic->findObjectByID( objectBeingConstructed->getBuilderID() );
+#if RETAIL_COMPATIBLE_CRC
 	if( builder )
+#else
+	if (builder && !builder->isEffectivelyDead())
+#endif
 	{
 		AIUpdateInterface *ai = builder->getAI();
 		DEBUG_ASSERTCRASH( ai, ("Builder object does not have an AI interface!") );

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/ActionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/ActionManager.cpp
@@ -483,6 +483,7 @@ Bool ActionManager::canResumeConstructionOf( const Object *obj,
 #if RETAIL_COMPATIBLE_CRC
 	if( builder )
 #else
+	// TheSuperHackers @bugfix Stubbjax 18/11/2025 Allow scaffold to be immediately resumed after builder death.
 	if (builder && !builder->isEffectivelyDead())
 #endif
 	{

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/ActionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/ActionManager.cpp
@@ -480,7 +480,11 @@ Bool ActionManager::canResumeConstructionOf( const Object *obj,
 	// in the future)
 	//
 	Object *builder = TheGameLogic->findObjectByID( objectBeingConstructed->getBuilderID() );
+#if RETAIL_COMPATIBLE_CRC
 	if( builder )
+#else
+	if (builder && !builder->isEffectivelyDead())
+#endif
 	{
 		AIUpdateInterface *ai = builder->getAI();
 		DEBUG_ASSERTCRASH( ai, ("Builder object does not have an AI interface!") );


### PR DESCRIPTION
This change allows immediate resumed construction of buildings if the existing builder dies. In the retail game, the player must await the `SlowDeathBehavior` module's `DestructionDelay` / `SinkDelay` before construction can resume. This delay is up to 2100ms for USA and China Dozers with a fixed 3000ms delay for GLA Workers.

### Before
The player must wait for the original builder's `SlowDeathBehavior` delay before construction can resume with another builder

https://github.com/user-attachments/assets/fec86fe2-44b2-45b8-98ae-f560d056bc39

### After
The player is free to resume construction the instant the existing builder dies

https://github.com/user-attachments/assets/75fcdaa9-d6ae-4878-8548-d72a52373814