### PR TITLE
Fix PoisonedBehavior damage over time to respect poison resistance

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/PoisonedBehavior.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/PoisonedBehavior.cpp
@@ -86,9 +86,16 @@ PoisonedBehavior::~PoisonedBehavior( void )
 //-------------------------------------------------------------------------------------------------
 void PoisonedBehavior::onDamage( DamageInfo *damageInfo )
 {
-	if( damageInfo->in.m_damageType == DAMAGE_POISON &&
-	    damageInfo->in.m_sourceID != INVALID_ID )
+	if( damageInfo->in.m_damageType == DAMAGE_POISON )
+	{
+#if !RETAIL_COMPATIBLE_CRC
+		// TheSuperHackers @bugfix bobtista 11/17/2025 Ignore damage with INVALID_ID source to prevent infinite loop from DoT
+		if( damageInfo->in.m_sourceID != INVALID_ID )
+			startPoisonedEffects( damageInfo );
+#else
 		startPoisonedEffects( damageInfo );
+#endif
+	}
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -119,9 +126,14 @@ UpdateSleepTime PoisonedBehavior::update()
 		// If it is time to do damage, then do it and reset the damage timer
 		DamageInfo damage;
 		damage.in.m_amount = m_poisonDamageAmount;
+#if !RETAIL_COMPATIBLE_CRC
 		// TheSuperHackers @bugfix bobtista 11/17/2025 Use INVALID_ID to prevent infinite loop while allowing poison resistance to work
 		damage.in.m_sourceID = INVALID_ID;
 		damage.in.m_damageType = DAMAGE_POISON;
+#else
+		damage.in.m_sourceID = m_poisonSource;
+		damage.in.m_damageType = DAMAGE_UNRESISTABLE; // Not poison, as that will infect us again
+#endif
 		damage.in.m_deathType = m_deathType;
 		getObject()->attemptDamage( &damage );
 


### PR DESCRIPTION
- Fixes #1616

The original code used `DAMAGE_UNRESISTABLE` to prevent an infinite loop where the DoT damage would retrigger `onDamage()`, which would restart the poison effect. The bug was that chem suits didn't work.

- Changed DoT damage type from `DAMAGE_UNRESISTABLE` to `DAMAGE_POISON` so resistance is properly applied
- Set `m_sourceID` to `INVALID_ID` for DoT damage
- Updated `onDamage()` to ignore damage with `INVALID_ID` source, preventing the infinite loop

## Testing
- Units with POISON resistance (Chemical Suits) now properly resist poison DoT damage
- Poison DoT no longer causes infinite loops
- External poison attacks still trigger poison effects correctly

Note - I don't think the DoT damage gives XP with this fix. 
 