### PR TITLE
bugfix(filesystem): Prevent loading wrong INIZH.big from Data/INI directory to prevent INI CRC mismatch

### DIFF
--- a/Core/GameEngineDevice/Source/StdDevice/Common/StdBIGFileSystem.cpp
+++ b/Core/GameEngineDevice/Source/StdDevice/Common/StdBIGFileSystem.cpp
@@ -219,7 +219,7 @@ Bool StdBIGFileSystem::loadBigFilesFromDirectory(AsciiString dir, AsciiString fi
 		// TheSuperHackers @bugfix bobtista 18/11/2025 Skip duplicate INIZH.big in Data\INI to prevent CRC mismatches.
 		// English, Chinese, and Korean SKUs shipped with two INIZH.big files (one in Run directory, one in Run\Data\INI).
 		// The DeleteFile cleanup doesn't work on EA App/Origin installs because the folder is not writable, so we skip loading it instead.
-		if (it->endsWithNoCase("data\\ini\\inizh.big") || it->endsWithNoCase("data/ini/inizh.big")) {
+		if (it->endsWithNoCase("Data\\INI\\INIZH.big") || it->endsWithNoCase("Data/INI/INIZH.big")) {
 			it++;
 			continue;
 		}

--- a/Core/GameEngineDevice/Source/StdDevice/Common/StdBIGFileSystem.cpp
+++ b/Core/GameEngineDevice/Source/StdDevice/Common/StdBIGFileSystem.cpp
@@ -215,6 +215,7 @@ Bool StdBIGFileSystem::loadBigFilesFromDirectory(AsciiString dir, AsciiString fi
 	Bool actuallyAdded = FALSE;
 	FilenameListIter it = filenameList.begin();
 	while (it != filenameList.end()) {
+#if RTS_ZEROHOUR
 		AsciiString filePath = (*it);
 		filePath.toLower();
 		// TheSuperHackers @fix bobtista 18/11/2025 Skip duplicate INIZH.big in Data\INI to prevent CRC mismatches on EA App/Origin installs
@@ -222,6 +223,7 @@ Bool StdBIGFileSystem::loadBigFilesFromDirectory(AsciiString dir, AsciiString fi
 			it++;
 			continue;
 		}
+#endif
 
 		ArchiveFile *archiveFile = openArchiveFile((*it).str());
 

--- a/Core/GameEngineDevice/Source/StdDevice/Common/StdBIGFileSystem.cpp
+++ b/Core/GameEngineDevice/Source/StdDevice/Common/StdBIGFileSystem.cpp
@@ -215,6 +215,14 @@ Bool StdBIGFileSystem::loadBigFilesFromDirectory(AsciiString dir, AsciiString fi
 	Bool actuallyAdded = FALSE;
 	FilenameListIter it = filenameList.begin();
 	while (it != filenameList.end()) {
+		AsciiString filePath = (*it);
+		filePath.toLower();
+		// TheSuperHackers @fix bobtista 18/11/2025 Skip duplicate INIZH.big in Data\INI to prevent CRC mismatches on EA App/Origin installs
+		if (strstr(filePath.str(), "data\\ini\\inizh.big") != NULL || strstr(filePath.str(), "data/ini/inizh.big") != NULL) {
+			it++;
+			continue;
+		}
+
 		ArchiveFile *archiveFile = openArchiveFile((*it).str());
 
 		if (archiveFile != NULL) {

--- a/Core/GameEngineDevice/Source/StdDevice/Common/StdBIGFileSystem.cpp
+++ b/Core/GameEngineDevice/Source/StdDevice/Common/StdBIGFileSystem.cpp
@@ -216,10 +216,8 @@ Bool StdBIGFileSystem::loadBigFilesFromDirectory(AsciiString dir, AsciiString fi
 	FilenameListIter it = filenameList.begin();
 	while (it != filenameList.end()) {
 #if RTS_ZEROHOUR
-		AsciiString filePath = (*it);
-		filePath.toLower();
 		// TheSuperHackers @fix bobtista 18/11/2025 Skip duplicate INIZH.big in Data\INI to prevent CRC mismatches on EA App/Origin installs
-		if (strstr(filePath.str(), "data\\ini\\inizh.big") != NULL || strstr(filePath.str(), "data/ini/inizh.big") != NULL) {
+		if ((*it).endsWithNoCase("data\\ini\\inizh.big") || (*it).endsWithNoCase("data/ini/inizh.big")) {
 			it++;
 			continue;
 		}

--- a/Core/GameEngineDevice/Source/StdDevice/Common/StdBIGFileSystem.cpp
+++ b/Core/GameEngineDevice/Source/StdDevice/Common/StdBIGFileSystem.cpp
@@ -216,7 +216,9 @@ Bool StdBIGFileSystem::loadBigFilesFromDirectory(AsciiString dir, AsciiString fi
 	FilenameListIter it = filenameList.begin();
 	while (it != filenameList.end()) {
 #if RTS_ZEROHOUR
-		// TheSuperHackers @bugfix bobtista 18/11/2025 Skip duplicate INIZH.big in Data\INI to prevent CRC mismatches on EA App/Origin installs
+		// TheSuperHackers @bugfix bobtista 18/11/2025 Skip duplicate INIZH.big in Data\INI to prevent CRC mismatches.
+		// English, Chinese, and Korean SKUs shipped with two INIZH.big files (one in Run directory, one in Run\Data\INI).
+		// The DeleteFile cleanup doesn't work on EA App/Origin installs because the folder is not writable, so we skip loading it instead.
 		if (it->endsWithNoCase("data\\ini\\inizh.big") || it->endsWithNoCase("data/ini/inizh.big")) {
 			it++;
 			continue;

--- a/Core/GameEngineDevice/Source/StdDevice/Common/StdBIGFileSystem.cpp
+++ b/Core/GameEngineDevice/Source/StdDevice/Common/StdBIGFileSystem.cpp
@@ -216,8 +216,8 @@ Bool StdBIGFileSystem::loadBigFilesFromDirectory(AsciiString dir, AsciiString fi
 	FilenameListIter it = filenameList.begin();
 	while (it != filenameList.end()) {
 #if RTS_ZEROHOUR
-		// TheSuperHackers @fix bobtista 18/11/2025 Skip duplicate INIZH.big in Data\INI to prevent CRC mismatches on EA App/Origin installs
-		if ((*it).endsWithNoCase("data\\ini\\inizh.big") || (*it).endsWithNoCase("data/ini/inizh.big")) {
+		// TheSuperHackers @bugfix bobtista 18/11/2025 Skip duplicate INIZH.big in Data\INI to prevent CRC mismatches on EA App/Origin installs
+		if (it->endsWithNoCase("data\\ini\\inizh.big") || it->endsWithNoCase("data/ini/inizh.big")) {
 			it++;
 			continue;
 		}

--- a/Core/GameEngineDevice/Source/Win32Device/Common/Win32BIGFileSystem.cpp
+++ b/Core/GameEngineDevice/Source/Win32Device/Common/Win32BIGFileSystem.cpp
@@ -217,10 +217,8 @@ Bool Win32BIGFileSystem::loadBigFilesFromDirectory(AsciiString dir, AsciiString 
 	FilenameListIter it = filenameList.begin();
 	while (it != filenameList.end()) {
 #if RTS_ZEROHOUR
-		AsciiString filePath = (*it);
-		filePath.toLower();
 		// TheSuperHackers @fix bobtista 18/11/2025 Skip duplicate INIZH.big in Data\INI to prevent CRC mismatches on EA App/Origin installs
-		if (strstr(filePath.str(), "data\\ini\\inizh.big") != NULL || strstr(filePath.str(), "data/ini/inizh.big") != NULL) {
+		if ((*it).endsWithNoCase("data\\ini\\inizh.big") || (*it).endsWithNoCase("data/ini/inizh.big")) {
 			it++;
 			continue;
 		}

--- a/Core/GameEngineDevice/Source/Win32Device/Common/Win32BIGFileSystem.cpp
+++ b/Core/GameEngineDevice/Source/Win32Device/Common/Win32BIGFileSystem.cpp
@@ -220,7 +220,7 @@ Bool Win32BIGFileSystem::loadBigFilesFromDirectory(AsciiString dir, AsciiString 
 		// TheSuperHackers @bugfix bobtista 18/11/2025 Skip duplicate INIZH.big in Data\INI to prevent CRC mismatches.
 		// English, Chinese, and Korean SKUs shipped with two INIZH.big files (one in Run directory, one in Run\Data\INI).
 		// The DeleteFile cleanup doesn't work on EA App/Origin installs because the folder is not writable, so we skip loading it instead.
-		if (it->endsWithNoCase("data\\ini\\inizh.big") || it->endsWithNoCase("data/ini/inizh.big")) {
+		if (it->endsWithNoCase("Data\\INI\\INIZH.big") || it->endsWithNoCase("Data/INI/INIZH.big")) {
 			it++;
 			continue;
 		}

--- a/Core/GameEngineDevice/Source/Win32Device/Common/Win32BIGFileSystem.cpp
+++ b/Core/GameEngineDevice/Source/Win32Device/Common/Win32BIGFileSystem.cpp
@@ -216,6 +216,7 @@ Bool Win32BIGFileSystem::loadBigFilesFromDirectory(AsciiString dir, AsciiString 
 	Bool actuallyAdded = FALSE;
 	FilenameListIter it = filenameList.begin();
 	while (it != filenameList.end()) {
+#if RTS_ZEROHOUR
 		AsciiString filePath = (*it);
 		filePath.toLower();
 		// TheSuperHackers @fix bobtista 18/11/2025 Skip duplicate INIZH.big in Data\INI to prevent CRC mismatches on EA App/Origin installs
@@ -223,6 +224,7 @@ Bool Win32BIGFileSystem::loadBigFilesFromDirectory(AsciiString dir, AsciiString 
 			it++;
 			continue;
 		}
+#endif
 
 		ArchiveFile *archiveFile = openArchiveFile((*it).str());
 

--- a/Core/GameEngineDevice/Source/Win32Device/Common/Win32BIGFileSystem.cpp
+++ b/Core/GameEngineDevice/Source/Win32Device/Common/Win32BIGFileSystem.cpp
@@ -217,8 +217,8 @@ Bool Win32BIGFileSystem::loadBigFilesFromDirectory(AsciiString dir, AsciiString 
 	FilenameListIter it = filenameList.begin();
 	while (it != filenameList.end()) {
 #if RTS_ZEROHOUR
-		// TheSuperHackers @fix bobtista 18/11/2025 Skip duplicate INIZH.big in Data\INI to prevent CRC mismatches on EA App/Origin installs
-		if ((*it).endsWithNoCase("data\\ini\\inizh.big") || (*it).endsWithNoCase("data/ini/inizh.big")) {
+		// TheSuperHackers @bugfix bobtista 18/11/2025 Skip duplicate INIZH.big in Data\INI to prevent CRC mismatches on EA App/Origin installs
+		if (it->endsWithNoCase("data\\ini\\inizh.big") || it->endsWithNoCase("data/ini/inizh.big")) {
 			it++;
 			continue;
 		}

--- a/Core/GameEngineDevice/Source/Win32Device/Common/Win32BIGFileSystem.cpp
+++ b/Core/GameEngineDevice/Source/Win32Device/Common/Win32BIGFileSystem.cpp
@@ -216,6 +216,14 @@ Bool Win32BIGFileSystem::loadBigFilesFromDirectory(AsciiString dir, AsciiString 
 	Bool actuallyAdded = FALSE;
 	FilenameListIter it = filenameList.begin();
 	while (it != filenameList.end()) {
+		AsciiString filePath = (*it);
+		filePath.toLower();
+		// TheSuperHackers @fix bobtista 18/11/2025 Skip duplicate INIZH.big in Data\INI to prevent CRC mismatches on EA App/Origin installs
+		if (strstr(filePath.str(), "data\\ini\\inizh.big") != NULL || strstr(filePath.str(), "data/ini/inizh.big") != NULL) {
+			it++;
+			continue;
+		}
+
 		ArchiveFile *archiveFile = openArchiveFile((*it).str());
 
 		if (archiveFile != NULL) {

--- a/Core/GameEngineDevice/Source/Win32Device/Common/Win32BIGFileSystem.cpp
+++ b/Core/GameEngineDevice/Source/Win32Device/Common/Win32BIGFileSystem.cpp
@@ -217,7 +217,9 @@ Bool Win32BIGFileSystem::loadBigFilesFromDirectory(AsciiString dir, AsciiString 
 	FilenameListIter it = filenameList.begin();
 	while (it != filenameList.end()) {
 #if RTS_ZEROHOUR
-		// TheSuperHackers @bugfix bobtista 18/11/2025 Skip duplicate INIZH.big in Data\INI to prevent CRC mismatches on EA App/Origin installs
+		// TheSuperHackers @bugfix bobtista 18/11/2025 Skip duplicate INIZH.big in Data\INI to prevent CRC mismatches.
+		// English, Chinese, and Korean SKUs shipped with two INIZH.big files (one in Run directory, one in Run\Data\INI).
+		// The DeleteFile cleanup doesn't work on EA App/Origin installs because the folder is not writable, so we skip loading it instead.
 		if (it->endsWithNoCase("data\\ini\\inizh.big") || it->endsWithNoCase("data/ini/inizh.big")) {
 			it++;
 			continue;

--- a/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -395,12 +395,6 @@ void GameEngine::init()
 		// Create the low-level file system interface
 		TheFileSystem = createFileSystem();
 
-		//Kris: Patch 1.01 - November 17, 2003
-		//I was unable to resolve the RTPatch method of deleting a shipped file. English, Chinese, and Korean
-		//SKU's shipped with two INIZH.big files. One properly in the Run directory and the other in Run\INI\Data.
-		//We need to toast the latter in order for the game to patch properly.
-		DeleteFile( "Data\\INI\\INIZH.big" );
-
 		// not part of the subsystem list, because it should normally never be reset!
 		TheNameKeyGenerator = MSGNEW("GameEngineSubsystem") NameKeyGenerator;
 		TheNameKeyGenerator->init();


### PR DESCRIPTION
- Fixes #1179

This change skips loading any BIG file matching `Data\INI\INIZH.big` during archive initialization.

### Testing

1. Install the game from EA App/Origin
2. Observe two INIZH.big files, one in the root folder and one in Data/INI
3. Run the game; notice that DeleteFile/cleanup code does not successfully delete it (this is expected and acceptable now)
4. Try to join a multiplayer game which performs CRC checks — CRC should now match
5. Play the multiplayer game — no mismatches should occur (From this issue)