### PR TITLE
fix(logic): Fix unexpected return in GameLogic::logicMessageDispatcher's switch case MSG_CANCEL_UNIT_CREATE

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -1390,11 +1390,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			// get the unit production interface
 			ProductionUpdateInterface *pu = producer->getProductionUpdateInterface();
 			if( pu == NULL )
-#if RETAIL_COMPATIBLE_CRC
-				return;
-#else
 				break;
-#endif
 
 			// cancel the production
 			pu->cancelUnitCreate( productionID );

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -1390,7 +1390,11 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			// get the unit production interface
 			ProductionUpdateInterface *pu = producer->getProductionUpdateInterface();
 			if( pu == NULL )
+#if RETAIL_COMPATIBLE_CRC
+				return;
+#else
 				break;
+#endif
 
 			// cancel the production
 			pu->cancelUnitCreate( productionID );

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -1390,7 +1390,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			// get the unit production interface
 			ProductionUpdateInterface *pu = producer->getProductionUpdateInterface();
 			if( pu == NULL )
-				return;
+				break;
 
 			// cancel the production
 			pu->cancelUnitCreate( productionID );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -1418,11 +1418,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			// get the unit production interface
 			ProductionUpdateInterface *pu = producer->getProductionUpdateInterface();
 			if( pu == NULL )
-#if RETAIL_COMPATIBLE_CRC
-				return;
-#else
 				break;
-#endif
 
 			// cancel the production
 			pu->cancelUnitCreate( productionID );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -1418,7 +1418,11 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			// get the unit production interface
 			ProductionUpdateInterface *pu = producer->getProductionUpdateInterface();
 			if( pu == NULL )
+#if RETAIL_COMPATIBLE_CRC
+				return;
+#else
 				break;
+#endif
 
 			// cancel the production
 			pu->cancelUnitCreate( productionID );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -1418,7 +1418,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			// get the unit production interface
 			ProductionUpdateInterface *pu = producer->getProductionUpdateInterface();
 			if( pu == NULL )
-				return;
+				break;
 
 			// cancel the production
 			pu->cancelUnitCreate( productionID );


### PR DESCRIPTION
* Fixes #1211

The change is wrapped behind the RETAIL_COMPATIBLE_CRC flag to be safe, though I haven't tested for mismatches without it.