### PR TITLE
bugfix(ocl): Fix GLA Rebel Ambush units spawning in water/cliffs and dying immediately

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
@@ -1398,7 +1398,7 @@ protected:
 				// TheSuperHackers @bugfix bobtista 18/11/2025 Use FPF_CLEAR_CELLS_ONLY when DiesOnBadLand to prevent spawning in water/cliffs
 				if (m_diesOnBadLand)
 				{
-					fpOptions.flags = FPF_USE_HIGHEST_LAYER | FPF_CLEAR_CELLS_ONLY;
+					fpOptions.flags = static_cast<FindPositionFlags>(FPF_USE_HIGHEST_LAYER | FPF_CLEAR_CELLS_ONLY);
 				}
 				else
 				{


### PR DESCRIPTION
* Fixes #959

Spread formation uses FPF_USE_HIGHEST_LAYER which allows spawning on bridges/elevated terrain but doesn't guarantee passable ground.

Now spread formation uses FPF_CLEAR_CELLS_ONLY to only spawn units on passable terrain. If no passable position is found within the spread radius, units fall back to the center position which is guaranteed passable due to OCLAdjustPositionToPassable. It still uses FPF_USE_HIGHEST_LAYER, so they'll still spawn on a bridge.

Generals does not work the same way as Zero Hour, so this fix does not apply there. 

### Testing

1. Place a rebelambush in the water or on impassable terrain
2. Rebels should spawn without dying on nearby passable terrain

