### PR TITLE
bugfix(ai): Undetected mines can now be approached when using a disarm weapon

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -2596,14 +2596,16 @@ StateReturnType AIAttackApproachTargetState::updateInternal()
 	{
 		if( victim->testStatus( OBJECT_STATUS_STEALTHED ) && !victim->testStatus( OBJECT_STATUS_DETECTED ) )
 		{
+			// If obj is stealthed, can no longer approach.
+			// TheSuperHackers @bugfix Stubbjax 19/11/2025 Except when disarming stealthed mines.
 #if RETAIL_COMPATIBLE_CRC
-			return STATE_FAILURE;	// If obj is stealthed, can no longer approach.
+			return STATE_FAILURE;
 #else
 			const Bool isTargetingMine = weapon && weapon->getDamageType() == DAMAGE_DISARM &&
 				(victim->isKindOf(KINDOF_MINE));
 
 			if (!isTargetingMine)
-				return STATE_FAILURE;	// If obj is stealthed, can no longer approach - unless we're targeting a mine!
+				return STATE_FAILURE;
 #endif
 		}
 		ai->setCurrentVictim(victim);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -2682,14 +2682,16 @@ StateReturnType AIAttackApproachTargetState::updateInternal()
 		}
 		if( victim->testStatus( OBJECT_STATUS_STEALTHED ) && !victim->testStatus( OBJECT_STATUS_DETECTED ) && !victim->testStatus( OBJECT_STATUS_DISGUISED ) )
 		{
+			// If obj is stealthed, can no longer approach.
+			// TheSuperHackers @bugfix Stubbjax 19/11/2025 Except when disarming stealthed mines or traps.
 #if RETAIL_COMPATIBLE_CRC
-			return STATE_FAILURE;	// If obj is stealthed, can no longer approach.
+			return STATE_FAILURE;
 #else
 			const Bool isTargetingMine = weapon && weapon->getDamageType() == DAMAGE_DISARM &&
 				(victim->isKindOf(KINDOF_MINE) || victim->isKindOf(KINDOF_BOOBY_TRAP) || victim->isKindOf(KINDOF_DEMOTRAP));
 
 			if (!isTargetingMine)
-				return STATE_FAILURE;	// If obj is stealthed, can no longer approach - unless we're targeting a mine!
+				return STATE_FAILURE;
 #endif
 		}
 		ai->setCurrentVictim(victim);


### PR DESCRIPTION
Fixes #1874

This change allows undetected mines to be approached when using a disarm weapon.

In the retail game, a worker or dozer refuses to perform a mine disarming command if there are undetected mines at the targeted location. This is because there is no logic in the `AIAttackApproachTargetState` (entered when a weapon is out of range) to accommodate the special-case mine disarming behaviour, and the state returns a fail if the target is stealthed and undetected irrespective of the initial command's success.

### Before
The worker does not proceed to disarm mines

https://github.com/user-attachments/assets/567881f3-b0ae-47ee-8f18-498afbd423e3

### After
The worker proceeds to disarm mines

https://github.com/user-attachments/assets/654b88ba-a794-40fc-87c9-a4bf1ed7484a