### PR TITLE
bugfix(object): Preserve unit behaviour when transferring assets to allies

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -3996,7 +3996,8 @@ void Object::removeUpgrade( const UpgradeTemplate *upgradeT )
 //-------------------------------------------------------------------------------------------------
 void Object::onCapture( Player *oldOwner, Player *newOwner )
 {
-	// Everybody dhills when they captured so they don't keep doing something the new player might not want him to be doing
+	// Everybody chills when they captured so they don't keep doing something the new player might not want him to be doing
+	// TheSuperHackers @tweak Stubbjax 19/11/2025 Except when the new owner is an ally, so that Hackers keep on hacking, etc.
 	if( getAIUpdateInterface()  &&  (oldOwner != newOwner) )
 	{
 #if RETAIL_COMPATIBLE_CRC

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -4517,7 +4517,8 @@ void Object::removeUpgrade( const UpgradeTemplate *upgradeT )
 //-------------------------------------------------------------------------------------------------
 void Object::onCapture( Player *oldOwner, Player *newOwner )
 {
-	// Everybody dhills when they captured so they don't keep doing something the new player might not want him to be doing
+	// Everybody chills when they captured so they don't keep doing something the new player might not want him to be doing
+	// TheSuperHackers @tweak Stubbjax 19/11/2025 Except when the new owner is an ally, so that Hackers keep on hacking, etc.
 	if( getAIUpdateInterface()  &&  (oldOwner != newOwner) )
 	{
 #if RETAIL_COMPATIBLE_CRC


### PR DESCRIPTION
This change preserves unit behaviour when a player's assets are transferred to an ally player.

Transferred assets run through the `onCapture` logic, which tells them to idle in order to prevent undesirable circumstances like captured enemy objects continuing counterproductive tasks against the capturing player (e.g. we don't want a Dragon Tank to keep flaming our base when we hijack it). Some of these tasks are somehow preserved anyway, such as construction and capturing, while others are not, such as hacking, moving and attacking.

In the retail game, this idle-on-capture logic does not take ally asset transferal into consideration, in which case continued behaviour is always valid and desirable. A player will often want to give some of their units some final tasks before they surrender in order to give their ally a helping hand, such as moving workers to safety or attacking a target. Players especially always want their Hackers to keep on hacking. With this change, such tasks are now maintained as expected when transferred to an ally.

### Before

Hackers cease hacking when transferred to an ally

https://github.com/user-attachments/assets/6a2dbc2a-7ac7-4f39-abfa-5525dd9886c9

Units stop movement and attack orders when transferred to an ally

https://github.com/user-attachments/assets/1c9ed51d-38fc-4f99-bd90-d24608423203

### After

Hackers continue hacking when transferred to an ally

https://github.com/user-attachments/assets/28f555ca-a0c3-4999-820e-408e7cd3a209

Units continue movement and attack orders when transferred to an ally

https://github.com/user-attachments/assets/84ffa5f9-97a3-4a59-9537-c9bcb687a370