### PR TITLE
bugfix(weapon): fix patriot assist system extended range bug

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -3286,8 +3286,10 @@ void AIUpdateInterface::privateAttackObject( Object *victim, Int maxShotsToFire,
 
 	if (!victim)
 	{
+#if !RETAIL_COMPATIBLE_CRC
 		// TheSuperHackers @bugfix bobtista Reset weapons lock to fix patriot turret extended range bug
 		getObject()->releaseWeaponLock(LOCKED_TEMPORARILY);
+#endif
 		// Hard to kill em if they're already dead.  jba
 		return;
 	}
@@ -3307,8 +3309,10 @@ void AIUpdateInterface::privateAttackObject( Object *victim, Int maxShotsToFire,
 void AIUpdateInterface::privateForceAttackObject( Object *victim, Int maxShotsToFire, CommandSourceType cmdSource )
 {
 	if (!victim) {
+#if !RETAIL_COMPATIBLE_CRC
 		// TheSuperHackers @bugfix bobtista Reset weapons lock to fix patriot turret extended range bug
 		getObject()->releaseWeaponLock(LOCKED_TEMPORARILY);
+#endif
 		return;
 	}
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -2756,9 +2756,11 @@ static void makeAssistanceRequest( Object *requestOf, void *userData )
 	if( requestOf == requestData->m_requestingObject )
 		return;
 
+#if !RETAIL_COMPATIBLE_CRC
 	// TheSuperHackers @bugfix bobtista Prevent patriot from assisting when it is the target
 	if( requestOf == requestData->m_victimObject )
 		return;
+#endif
 
 	// Only request of our kind of people
 	if( !requestOf->getTemplate()->isEquivalentTo( requestData->m_requestingObject->getTemplate() ) )

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -3423,8 +3423,10 @@ void AIUpdateInterface::privateAttackObject( Object *victim, Int maxShotsToFire,
 
 	if (!victim)
 	{
+#if !RETAIL_COMPATIBLE_CRC
 		// TheSuperHackers @bugfix bobtista Reset weapons lock to fix patriot turret extended range bug
 		getObject()->releaseWeaponLock(LOCKED_TEMPORARILY);
+#endif
 		// Hard to kill em if they're already dead.  jba
 		return;
 	}
@@ -3444,8 +3446,10 @@ void AIUpdateInterface::privateAttackObject( Object *victim, Int maxShotsToFire,
 void AIUpdateInterface::privateForceAttackObject( Object *victim, Int maxShotsToFire, CommandSourceType cmdSource )
 {
 	if (!victim) {
+#if !RETAIL_COMPATIBLE_CRC
 		// TheSuperHackers @bugfix bobtista Reset weapons lock to fix patriot turret extended range bug
 		getObject()->releaseWeaponLock(LOCKED_TEMPORARILY);
+#endif
 		return;
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -2967,9 +2967,11 @@ static void makeAssistanceRequest( Object *requestOf, void *userData )
 	if( requestOf == requestData->m_requestingObject )
 		return;
 
+#if !RETAIL_COMPATIBLE_CRC
 	// TheSuperHackers @bugfix bobtista Prevent patriot from assisting when it is the target
 	if( requestOf == requestData->m_victimObject )
 		return;
+#endif
 
 	// Only request of our kind of people
 	if( !requestOf->getTemplate()->isEquivalentTo( requestData->m_requestingObject->getTemplate() ) )


### PR DESCRIPTION
- Fixes #370

Follows SkyAero's comments on the original issue. Fixes an issue where patriot systems (especially laser patriots) would shoot at units outside their normal range. This occurred due to two bugs in the assist targeting system:

**Fix 1: Prevent Self-Targeting**
When a patriot requests assistance, it could ask itself to assist if it was also the target, causing the patriot to switch to its extended-range secondary weapon and attempt to fire at itself. This fix adds a check to prevent a patriot from assisting when it is the target. "Stop hitting yourself, why are you hitting yourself?" - Patriot's older brother. 

**Fix 2: Release Weapon Lock on Target Destruction**
When a patriot enters assist mode, it temporarily locks its secondary weapon (extended range) until the clip is empty or the attack completes. If the target was destroyed before the clip finished, the weapon lock was not released, causing the patriot to continue using the extended-range weapon. This fix releases the temporary weapon lock when the victim is null or destroyed in both `privateAttackObject()` and `privateForceAttackObject()` functions.

Both fixes are behind `!RETAIL_COMPATIBLE_CRC` 

### Testing
Test Case 1: Extended Range After Target Destruction

1. Start a skirmish/match with USA faction
2. Build 2-3 Laser Patriot Missile Systems (or regular Patriots)
3. Position them so they can assist each other (within assist range)
4. Send an enemy unit toward the patriots
5. When the first patriot starts firing, observe:
6. The assisting patriots switch to extended-range secondary weapons
7. Destroy the target unit before all shots are fired
8. Observe fix: Assisting patriots range goes back to normal, it does not shoot at units beyond normal range

Test Case 2: Self targeting 
Follow steps from above, force fire one of the patriots at another one after step 4. 