### PR TITLE
perf(ai): Avoid a few std::vector copies when passing ai paths to functions

### DIFF
--- a/Dependencies/Utility/Utility/CppMacros.h
+++ b/Dependencies/Utility/Utility/CppMacros.h
@@ -19,6 +19,10 @@
 // This file contains macros to help upgrade the code for newer cpp standards.
 #pragma once
 
+#if __cplusplus >= 201103L
+#include <utility>
+#endif
+
 #if __cplusplus >= 201703L
 #define NOEXCEPT_17 noexcept
 #define REGISTER
@@ -44,3 +48,15 @@
 #define constexpr
 #define nullptr 0
 #endif
+
+// TheSuperHackers @performance bobtista 25/11/2025 Helper to move-assign from pointer: uses std::move in C++11, swap in C++98
+template<typename T>
+inline void move_assign_from_pointer(T& dest, T* src)
+{
+#if __cplusplus >= 201103L
+	dest = std::move(*src);
+#else
+	// Use swap to emulate move semantics for VC6 compatibility
+	dest.swap(*src);
+#endif
+}

--- a/Dependencies/Utility/Utility/CppMacros.h
+++ b/Dependencies/Utility/Utility/CppMacros.h
@@ -49,6 +49,9 @@
 #define nullptr 0
 #endif
 
+namespace stl
+{
+
 // Helper to move-assign from reference: uses std::move in C++11, swap in C++98
 template<typename T>
 inline void move_or_swap(T& dest, T& src)
@@ -63,3 +66,5 @@ inline void move_or_swap(T& dest, T& src)
 	src.swap(empty);
 #endif
 }
+
+} // namespace stl

--- a/Dependencies/Utility/Utility/CppMacros.h
+++ b/Dependencies/Utility/Utility/CppMacros.h
@@ -49,14 +49,17 @@
 #define nullptr 0
 #endif
 
-// TheSuperHackers @performance bobtista 25/11/2025 Helper to move-assign from reference: uses std::move in C++11, swap in C++98
+// Helper to move-assign from reference: uses std::move in C++11, swap in C++98
 template<typename T>
 inline void move_or_swap(T& dest, T& src)
 {
 #if __cplusplus >= 201103L
 	dest = std::move(src);
 #else
-	// Use swap to emulate move semantics for VC6 compatibility
+	// C++03 fallback: mimic move semantics
+	// dest gets src's value, src becomes empty
+	T empty;
 	dest.swap(src);
+	src.swap(empty);
 #endif
 }

--- a/Dependencies/Utility/Utility/CppMacros.h
+++ b/Dependencies/Utility/Utility/CppMacros.h
@@ -49,14 +49,14 @@
 #define nullptr 0
 #endif
 
-// TheSuperHackers @performance bobtista 25/11/2025 Helper to move-assign from pointer: uses std::move in C++11, swap in C++98
+// TheSuperHackers @performance bobtista 25/11/2025 Helper to move-assign from reference: uses std::move in C++11, swap in C++98
 template<typename T>
-inline void move_assign_from_pointer(T& dest, T* src)
+inline void move_or_swap(T& dest, T& src)
 {
 #if __cplusplus >= 201103L
-	dest = std::move(*src);
+	dest = std::move(src);
 #else
 	// Use swap to emulate move semantics for VC6 compatibility
-	dest.swap(*src);
+	dest.swap(src);
 #endif
 }

--- a/Generals/Code/GameEngine/Include/GameLogic/AI.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AI.h
@@ -539,7 +539,13 @@ public:
 	inline void aiFollowExitProductionPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource )
 	{
 		AICommandParms parms(AICMD_FOLLOW_EXITPRODUCTION_PATH, cmdSource);
+#if __cplusplus >= 201103L
+		parms.m_coords = std::move(*path);
+#else
+		// TheSuperHackers @performance bobtista 23/11/2025 Use swap to emulate move semantics for VC6 compatibility
 		parms.m_coords.swap(*path);
+		path->clear();
+#endif
 		parms.m_obj = ignoreObject;
 		aiDoCommand(&parms);
 	}
@@ -547,7 +553,13 @@ public:
 	inline void aiFollowPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource )
 	{
 		AICommandParms parms(AICMD_FOLLOW_PATH, cmdSource);
+#if __cplusplus >= 201103L
+		parms.m_coords = std::move(*path);
+#else
+		// TheSuperHackers @performance bobtista 23/11/2025 Use swap to emulate move semantics for VC6 compatibility
 		parms.m_coords.swap(*path);
+		path->clear();
+#endif
 		parms.m_obj = ignoreObject;
 		aiDoCommand(&parms);
 	}

--- a/Generals/Code/GameEngine/Include/GameLogic/AI.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AI.h
@@ -35,6 +35,7 @@
 #include "GameLogic/Damage.h"
 #include "Common/STLTypedefs.h"
 #include "ref_ptr.h"
+#include "Utility/CppMacros.h"
 
 class AIGroup;
 class AttackPriorityInfo;
@@ -539,13 +540,7 @@ public:
 	inline void aiFollowExitProductionPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource )
 	{
 		AICommandParms parms(AICMD_FOLLOW_EXITPRODUCTION_PATH, cmdSource);
-#if __cplusplus >= 201103L
-		parms.m_coords = std::move(*path);
-#else
-		// TheSuperHackers @performance bobtista 23/11/2025 Use swap to emulate move semantics for VC6 compatibility
-		parms.m_coords.swap(*path);
-		path->clear();
-#endif
+		move_assign_from_pointer(parms.m_coords, path);
 		parms.m_obj = ignoreObject;
 		aiDoCommand(&parms);
 	}
@@ -553,13 +548,7 @@ public:
 	inline void aiFollowPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource )
 	{
 		AICommandParms parms(AICMD_FOLLOW_PATH, cmdSource);
-#if __cplusplus >= 201103L
-		parms.m_coords = std::move(*path);
-#else
-		// TheSuperHackers @performance bobtista 23/11/2025 Use swap to emulate move semantics for VC6 compatibility
-		parms.m_coords.swap(*path);
-		path->clear();
-#endif
+		move_assign_from_pointer(parms.m_coords, path);
 		parms.m_obj = ignoreObject;
 		aiDoCommand(&parms);
 	}

--- a/Generals/Code/GameEngine/Include/GameLogic/AI.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AI.h
@@ -536,18 +536,18 @@ public:
 		aiDoCommand(&parms);
 	}
 
-	void aiFollowExitProductionPath( const std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource )
+	inline void aiFollowExitProductionPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource )
 	{
 		AICommandParms parms(AICMD_FOLLOW_EXITPRODUCTION_PATH, cmdSource);
-		parms.m_coords = *path;
+		parms.m_coords = std::move(*path);
 		parms.m_obj = ignoreObject;
 		aiDoCommand(&parms);
 	}
 
-	void aiFollowPath( const std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource )
+	inline void aiFollowPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource )
 	{
 		AICommandParms parms(AICMD_FOLLOW_PATH, cmdSource);
-		parms.m_coords = *path;
+		parms.m_coords = std::move(*path);
 		parms.m_obj = ignoreObject;
 		aiDoCommand(&parms);
 	}

--- a/Generals/Code/GameEngine/Include/GameLogic/AI.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AI.h
@@ -539,7 +539,7 @@ public:
 	inline void aiFollowExitProductionPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource )
 	{
 		AICommandParms parms(AICMD_FOLLOW_EXITPRODUCTION_PATH, cmdSource);
-		parms.m_coords = std::move(*path);
+		parms.m_coords.swap(*path);
 		parms.m_obj = ignoreObject;
 		aiDoCommand(&parms);
 	}
@@ -547,7 +547,7 @@ public:
 	inline void aiFollowPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource )
 	{
 		AICommandParms parms(AICMD_FOLLOW_PATH, cmdSource);
-		parms.m_coords = std::move(*path);
+		parms.m_coords.swap(*path);
 		parms.m_obj = ignoreObject;
 		aiDoCommand(&parms);
 	}

--- a/Generals/Code/GameEngine/Include/GameLogic/AI.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AI.h
@@ -539,7 +539,7 @@ public:
 	inline void aiFollowExitProductionPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource )
 	{
 		AICommandParms parms(AICMD_FOLLOW_EXITPRODUCTION_PATH, cmdSource);
-		move_assign_from_pointer(parms.m_coords, path);
+		move_or_swap(parms.m_coords, *path);
 		parms.m_obj = ignoreObject;
 		aiDoCommand(&parms);
 	}
@@ -547,7 +547,7 @@ public:
 	inline void aiFollowPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource )
 	{
 		AICommandParms parms(AICMD_FOLLOW_PATH, cmdSource);
-		move_assign_from_pointer(parms.m_coords, path);
+		move_or_swap(parms.m_coords, *path);
 		parms.m_obj = ignoreObject;
 		aiDoCommand(&parms);
 	}

--- a/Generals/Code/GameEngine/Include/GameLogic/AI.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AI.h
@@ -35,7 +35,6 @@
 #include "GameLogic/Damage.h"
 #include "Common/STLTypedefs.h"
 #include "ref_ptr.h"
-#include "Utility/CppMacros.h"
 
 class AIGroup;
 class AttackPriorityInfo;

--- a/Generals/Code/GameEngine/Include/GameLogic/AI.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AI.h
@@ -539,7 +539,7 @@ public:
 	void aiFollowExitProductionPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource )
 	{
 		AICommandParms parms(AICMD_FOLLOW_EXITPRODUCTION_PATH, cmdSource);
-		move_or_swap(parms.m_coords, *path);
+		stl::move_or_swap(parms.m_coords, *path);
 		parms.m_obj = ignoreObject;
 		aiDoCommand(&parms);
 	}
@@ -547,7 +547,7 @@ public:
 	void aiFollowPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource )
 	{
 		AICommandParms parms(AICMD_FOLLOW_PATH, cmdSource);
-		move_or_swap(parms.m_coords, *path);
+		stl::move_or_swap(parms.m_coords, *path);
 		parms.m_obj = ignoreObject;
 		aiDoCommand(&parms);
 	}

--- a/Generals/Code/GameEngine/Include/GameLogic/AI.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AI.h
@@ -536,7 +536,7 @@ public:
 		aiDoCommand(&parms);
 	}
 
-	inline void aiFollowExitProductionPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource )
+	void aiFollowExitProductionPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource )
 	{
 		AICommandParms parms(AICMD_FOLLOW_EXITPRODUCTION_PATH, cmdSource);
 		move_or_swap(parms.m_coords, *path);
@@ -544,7 +544,7 @@ public:
 		aiDoCommand(&parms);
 	}
 
-	inline void aiFollowPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource )
+	void aiFollowPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource )
 	{
 		AICommandParms parms(AICMD_FOLLOW_PATH, cmdSource);
 		move_or_swap(parms.m_coords, *path);

--- a/Generals/Code/GameEngine/Include/GameLogic/AI.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AI.h
@@ -407,7 +407,7 @@ struct AICommandParms
   Object*									m_obj;
   Object*									m_otherObj;
   const Team*							m_team;
-	mutable std::vector<Coord3D>		m_coords;
+	std::vector<Coord3D>		m_coords;
   const Waypoint*         m_waypoint;
   const PolygonTrigger*   m_polygon;
   Int											m_intValue;       /// misc usage

--- a/Generals/Code/GameEngine/Include/GameLogic/AI.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AI.h
@@ -407,7 +407,7 @@ struct AICommandParms
   Object*									m_obj;
   Object*									m_otherObj;
   const Team*							m_team;
-	std::vector<Coord3D>		m_coords;
+	mutable std::vector<Coord3D>		m_coords;
   const Waypoint*         m_waypoint;
   const PolygonTrigger*   m_polygon;
   Int											m_intValue;       /// misc usage

--- a/Generals/Code/GameEngine/Include/GameLogic/AIStateMachine.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AIStateMachine.h
@@ -138,7 +138,7 @@ public:
 	virtual StateReturnType setState( StateID newStateID );
 
 	/// @todo Rethink state parameter passing. Continuing in this fashion will have a pile of params in the machine (MSB)
-	void setGoalPath( const std::vector<Coord3D>* path );
+	void setGoalPath( std::vector<Coord3D>* path );
 	void addToGoalPath( const Coord3D *pathPoint );
 	const Coord3D *getGoalPathPosition( Int i ) const;		///< return path position at index "i"
 	Int getGoalPathSize() const { return m_goalPath.size(); }

--- a/Generals/Code/GameEngine/Include/GameLogic/AIStateMachine.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AIStateMachine.h
@@ -108,8 +108,6 @@ extern Bool outOfWeaponRangeObject( State *thisState, void* userData );
 extern Bool outOfWeaponRangePosition( State *thisState, void* userData );
 extern Bool wantToSquishTarget( State *thisState, void* userData );
 
-#include "Utility/CppMacros.h"
-
 //-----------------------------------------------------------------------------------------------------------
 /**
   The AI state machine.  This is used by AIUpdate to implement all of the

--- a/Generals/Code/GameEngine/Include/GameLogic/AIStateMachine.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AIStateMachine.h
@@ -108,6 +108,8 @@ extern Bool outOfWeaponRangeObject( State *thisState, void* userData );
 extern Bool outOfWeaponRangePosition( State *thisState, void* userData );
 extern Bool wantToSquishTarget( State *thisState, void* userData );
 
+#include "Utility/CppMacros.h"
+
 //-----------------------------------------------------------------------------------------------------------
 /**
   The AI state machine.  This is used by AIUpdate to implement all of the

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/AIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/AIUpdate.h
@@ -244,7 +244,7 @@ protected:
 	virtual void privateFollowWaypointPathAsTeam( const Waypoint *way, CommandSourceType cmdSource );///< start following the path from the given point
 	virtual void privateFollowWaypointPathExact( const Waypoint *way, CommandSourceType cmdSource );///< start following the path from the given point
 	virtual void privateFollowWaypointPathAsTeamExact( const Waypoint *way, CommandSourceType cmdSource );///< start following the path from the given point
-	virtual void privateFollowPath( const std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource, Bool exitProduction );///< follow the path defined by the given array of points
+	virtual void privateFollowPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource, Bool exitProduction );///< follow the path defined by the given array of points
 	virtual void privateFollowPathAppend( const Coord3D *pos, CommandSourceType cmdSource );
 	virtual void privateAttackObject( Object *victim, Int maxShotsToFire, CommandSourceType cmdSource );					///< attack given object
 	virtual void privateForceAttackObject( Object *victim, Int maxShotsToFire, CommandSourceType cmdSource );					///< attack given object
@@ -338,7 +338,7 @@ public:
 	virtual Bool isBusy() const;
 
 	virtual void onObjectCreated();
-	virtual void doQuickExit( const std::vector<Coord3D>* path );			///< get out of this Object
+	virtual void doQuickExit( std::vector<Coord3D>* path );			///< get out of this Object
 
 	virtual void aiDoCommand(const AICommandParms* parms);
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/JetAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/JetAIUpdate.h
@@ -104,7 +104,7 @@ public:
 	Real friend_getMinHeight() const { return getJetAIUpdateModuleData()->m_minHeight; }
 	Real friend_getParkingOffset() const { return getJetAIUpdateModuleData()->m_parkingOffset; }
 	UnsignedInt friend_getTakeoffPause() const { return getJetAIUpdateModuleData()->m_takeoffPause; }
-	void friend_setGoalPath( const std::vector<Coord3D>* path ) { getStateMachine()->setGoalPath(path); }
+	void friend_setGoalPath( std::vector<Coord3D>* path ) { getStateMachine()->setGoalPath(path); }
 	void friend_setTakeoffInProgress(Bool v) { setFlag(TAKEOFF_IN_PROGRESS, v); }
 	void friend_setLandingInProgress(Bool v) { setFlag(LANDING_IN_PROGRESS, v); }
 	void friend_setTaxiInProgress(Bool v) { setFlag(TAXI_IN_PROGRESS, v); }
@@ -122,7 +122,7 @@ protected:
 
 	virtual AIStateMachine* makeStateMachine();
 
-	virtual void privateFollowPath( const std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource, Bool exitProduction );///< follow the path defined by the given array of points
+	virtual void privateFollowPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource, Bool exitProduction );///< follow the path defined by the given array of points
 	virtual void privateFollowPathAppend( const Coord3D *pos, CommandSourceType cmdSource );
 	virtual void privateEnter( Object *obj, CommandSourceType cmdSource );							///< enter the given object
 	virtual void privateGetRepaired( Object *repairDepot, CommandSourceType cmdSource );///< get repaired at repair depot

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -818,7 +818,7 @@ void AIStateMachine::loadPostProcess( void )
  */
 void AIStateMachine::setGoalPath( std::vector<Coord3D>* path )
 {
-	m_goalPath = std::move(*path);
+	m_goalPath.swap(*path);
 }
 
 #ifdef STATE_MACHINE_DEBUG

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -95,10 +95,7 @@ void AICommandParmsStorage::store(const AICommandParms& parms)
   m_obj = parms.m_obj ? parms.m_obj->getID() : INVALID_ID;
   m_otherObj = parms.m_otherObj ? parms.m_otherObj->getID() : INVALID_ID;
   m_teamName = parms.m_team ? parms.m_team->getName() : AsciiString::TheEmptyString;
-	// We intentionally const_cast here so we can move the path coordinates into storage.
-	// AICommandParms is treated as a transient command container that is not reused after dispatch.
-	std::vector<Coord3D>& coords = const_cast<std::vector<Coord3D>&>(parms.m_coords);
-	move_or_swap(m_coords, coords);
+	m_coords = parms.m_coords;
   m_waypoint = parms.m_waypoint;
   m_polygon = parms.m_polygon;
   m_intValue = parms.m_intValue;       /// misc usage

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -818,7 +818,14 @@ void AIStateMachine::loadPostProcess( void )
  */
 void AIStateMachine::setGoalPath( std::vector<Coord3D>* path )
 {
+#if __cplusplus >= 201103L
+	m_goalPath = std::move(*path);
+#else
+	// TheSuperHackers @performance bobtista 23/11/2025 Use swap to emulate move semantics for VC6 compatibility
+	// Swap transfers ownership without copying. Clear source to make intent explicit.
 	m_goalPath.swap(*path);
+	path->clear();
+#endif
 }
 
 #ifdef STATE_MACHINE_DEBUG

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -95,7 +95,10 @@ void AICommandParmsStorage::store(const AICommandParms& parms)
   m_obj = parms.m_obj ? parms.m_obj->getID() : INVALID_ID;
   m_otherObj = parms.m_otherObj ? parms.m_otherObj->getID() : INVALID_ID;
   m_teamName = parms.m_team ? parms.m_team->getName() : AsciiString::TheEmptyString;
-	m_coords = parms.m_coords;
+	// We intentionally const_cast here so we can move the path coordinates into storage.
+	// AICommandParms is treated as a transient command container that is not reused after dispatch.
+	std::vector<Coord3D>& coords = const_cast<std::vector<Coord3D>&>(parms.m_coords);
+	move_or_swap(m_coords, coords);
   m_waypoint = parms.m_waypoint;
   m_polygon = parms.m_polygon;
   m_intValue = parms.m_intValue;       /// misc usage

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -816,9 +816,9 @@ void AIStateMachine::loadPostProcess( void )
 /**
  * Define a simple path
  */
-void AIStateMachine::setGoalPath( const std::vector<Coord3D>* path )
+void AIStateMachine::setGoalPath( std::vector<Coord3D>* path )
 {
-	m_goalPath = *path;
+	m_goalPath = std::move(*path);
 }
 
 #ifdef STATE_MACHINE_DEBUG

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -818,13 +818,7 @@ void AIStateMachine::loadPostProcess( void )
  */
 void AIStateMachine::setGoalPath( std::vector<Coord3D>* path )
 {
-#if __cplusplus >= 201103L
-	m_goalPath = std::move(*path);
-#else
-	// TheSuperHackers @performance bobtista 23/11/2025 Use swap to emulate move semantics for VC6 compatibility
-	m_goalPath.swap(*path);
-	path->clear();
-#endif
+	move_assign_from_pointer(m_goalPath, path);
 }
 
 #ifdef STATE_MACHINE_DEBUG

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -818,7 +818,7 @@ void AIStateMachine::loadPostProcess( void )
  */
 void AIStateMachine::setGoalPath( std::vector<Coord3D>* path )
 {
-	move_or_swap(m_goalPath, *path);
+	stl::move_or_swap(m_goalPath, *path);
 }
 
 #ifdef STATE_MACHINE_DEBUG

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -822,7 +822,6 @@ void AIStateMachine::setGoalPath( std::vector<Coord3D>* path )
 	m_goalPath = std::move(*path);
 #else
 	// TheSuperHackers @performance bobtista 23/11/2025 Use swap to emulate move semantics for VC6 compatibility
-	// Swap transfers ownership without copying. Clear source to make intent explicit.
 	m_goalPath.swap(*path);
 	path->clear();
 #endif

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -818,7 +818,7 @@ void AIStateMachine::loadPostProcess( void )
  */
 void AIStateMachine::setGoalPath( std::vector<Coord3D>* path )
 {
-	move_assign_from_pointer(m_goalPath, path);
+	move_or_swap(m_goalPath, *path);
 }
 
 #ifdef STATE_MACHINE_DEBUG

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -2619,13 +2619,13 @@ void AIUpdateInterface::aiDoCommand(const AICommandParms* parms)
 			privateFollowWaypointPathAsTeamExact(parms->m_waypoint, parms->m_cmdSource);
 			break;
 		case AICMD_FOLLOW_PATH:
-			privateFollowPath(&const_cast<AICommandParms*>(parms)->m_coords, parms->m_obj, parms->m_cmdSource, FALSE);
+			privateFollowPath(&parms->m_coords, parms->m_obj, parms->m_cmdSource, FALSE);
 			break;
 		case AICMD_FOLLOW_PATH_APPEND:
 			privateFollowPathAppend(&parms->m_pos, parms->m_cmdSource);
 			break;
 		case AICMD_FOLLOW_EXITPRODUCTION_PATH:
-			privateFollowPath(&const_cast<AICommandParms*>(parms)->m_coords, parms->m_obj, parms->m_cmdSource, TRUE);
+			privateFollowPath(&parms->m_coords, parms->m_obj, parms->m_cmdSource, TRUE);
 			break;
 		case AICMD_ATTACK_OBJECT:
 			privateAttackObject(parms->m_obj, parms->m_intValue, parms->m_cmdSource);

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -2620,7 +2620,6 @@ void AIUpdateInterface::aiDoCommand(const AICommandParms* parms)
 			break;
 		case AICMD_FOLLOW_PATH:
 		{
-			// Copy coordinates to a local vector since privateFollowPath requires a non-const pointer.
 			std::vector<Coord3D> coords = parms->m_coords;
 			privateFollowPath(&coords, parms->m_obj, parms->m_cmdSource, FALSE);
 			break;
@@ -2630,7 +2629,6 @@ void AIUpdateInterface::aiDoCommand(const AICommandParms* parms)
 			break;
 		case AICMD_FOLLOW_EXITPRODUCTION_PATH:
 		{
-			// Copy coordinates to a local vector since privateFollowPath requires a non-const pointer.
 			std::vector<Coord3D> coords = parms->m_coords;
 			privateFollowPath(&coords, parms->m_obj, parms->m_cmdSource, TRUE);
 			break;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -2619,14 +2619,22 @@ void AIUpdateInterface::aiDoCommand(const AICommandParms* parms)
 			privateFollowWaypointPathAsTeamExact(parms->m_waypoint, parms->m_cmdSource);
 			break;
 		case AICMD_FOLLOW_PATH:
-			privateFollowPath(&parms->m_coords, parms->m_obj, parms->m_cmdSource, FALSE);
+		{
+			// Keep AICommandParms const; use a local copy of the coordinates when following the path.
+			std::vector<Coord3D> coords = parms->m_coords;
+			privateFollowPath(&coords, parms->m_obj, parms->m_cmdSource, FALSE);
 			break;
+		}
 		case AICMD_FOLLOW_PATH_APPEND:
 			privateFollowPathAppend(&parms->m_pos, parms->m_cmdSource);
 			break;
 		case AICMD_FOLLOW_EXITPRODUCTION_PATH:
-			privateFollowPath(&parms->m_coords, parms->m_obj, parms->m_cmdSource, TRUE);
+		{
+			// Keep AICommandParms const; use a local copy of the coordinates when following the exit path.
+			std::vector<Coord3D> coords = parms->m_coords;
+			privateFollowPath(&coords, parms->m_obj, parms->m_cmdSource, TRUE);
 			break;
+		}
 		case AICMD_ATTACK_OBJECT:
 			privateAttackObject(parms->m_obj, parms->m_intValue, parms->m_cmdSource);
 			break;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -3240,7 +3240,7 @@ void AIUpdateInterface::privateFollowPathAppend( const Coord3D *pos, CommandSour
 /**
  * Follow the path defined by the given array of points
  */
-void AIUpdateInterface::privateFollowPath( const std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource, Bool exitProduction )
+void AIUpdateInterface::privateFollowPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource, Bool exitProduction )
 {
 	if (getObject()->isMobile() == FALSE)
 		return;
@@ -3681,7 +3681,7 @@ void AIUpdateInterface::privateExit( Object *objectToExit, CommandSourceType cmd
 /**
  * Get out of whatever it is inside of
  */
-void AIUpdateInterface::doQuickExit( const std::vector<Coord3D>* path )
+void AIUpdateInterface::doQuickExit( std::vector<Coord3D>* path )
 {
 
 	Bool locked = getStateMachine()->isLocked();

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -2620,7 +2620,7 @@ void AIUpdateInterface::aiDoCommand(const AICommandParms* parms)
 			break;
 		case AICMD_FOLLOW_PATH:
 		{
-			// Keep AICommandParms const; use a local copy of the coordinates when following the path.
+			// Copy coordinates to a local vector since privateFollowPath requires a non-const pointer.
 			std::vector<Coord3D> coords = parms->m_coords;
 			privateFollowPath(&coords, parms->m_obj, parms->m_cmdSource, FALSE);
 			break;
@@ -2630,7 +2630,7 @@ void AIUpdateInterface::aiDoCommand(const AICommandParms* parms)
 			break;
 		case AICMD_FOLLOW_EXITPRODUCTION_PATH:
 		{
-			// Keep AICommandParms const; use a local copy of the coordinates when following the exit path.
+			// Copy coordinates to a local vector since privateFollowPath requires a non-const pointer.
 			std::vector<Coord3D> coords = parms->m_coords;
 			privateFollowPath(&coords, parms->m_obj, parms->m_cmdSource, TRUE);
 			break;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -2619,13 +2619,13 @@ void AIUpdateInterface::aiDoCommand(const AICommandParms* parms)
 			privateFollowWaypointPathAsTeamExact(parms->m_waypoint, parms->m_cmdSource);
 			break;
 		case AICMD_FOLLOW_PATH:
-			privateFollowPath(&parms->m_coords, parms->m_obj, parms->m_cmdSource, FALSE);
+			privateFollowPath(&const_cast<AICommandParms*>(parms)->m_coords, parms->m_obj, parms->m_cmdSource, FALSE);
 			break;
 		case AICMD_FOLLOW_PATH_APPEND:
 			privateFollowPathAppend(&parms->m_pos, parms->m_cmdSource);
 			break;
 		case AICMD_FOLLOW_EXITPRODUCTION_PATH:
-			privateFollowPath(&parms->m_coords, parms->m_obj, parms->m_cmdSource, TRUE);
+			privateFollowPath(&const_cast<AICommandParms*>(parms)->m_coords, parms->m_obj, parms->m_cmdSource, TRUE);
 			break;
 		case AICMD_ATTACK_OBJECT:
 			privateAttackObject(parms->m_obj, parms->m_intValue, parms->m_cmdSource);

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -2172,7 +2172,7 @@ Bool JetAIUpdate::getTreatAsAircraftForLocoDistToGoal() const
 /**
  * Follow the path defined by the given array of points
  */
-void JetAIUpdate::privateFollowPath( const std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource, Bool exitProduction )
+void JetAIUpdate::privateFollowPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource, Bool exitProduction )
 {
 	if (exitProduction)
 	{

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
@@ -550,18 +550,18 @@ public:
 		aiDoCommand(&parms);
 	}
 
-	void aiFollowExitProductionPath( const std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource )
+	inline void aiFollowExitProductionPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource )
 	{
 		AICommandParms parms(AICMD_FOLLOW_EXITPRODUCTION_PATH, cmdSource);
-		parms.m_coords = *path;
+		parms.m_coords = std::move(*path);
 		parms.m_obj = ignoreObject;
 		aiDoCommand(&parms);
 	}
 
-	void aiFollowPath( const std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource )
+	inline void aiFollowPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource )
 	{
 		AICommandParms parms(AICMD_FOLLOW_PATH, cmdSource);
-		parms.m_coords = *path;
+		parms.m_coords = std::move(*path);
 		parms.m_obj = ignoreObject;
 		aiDoCommand(&parms);
 	}

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
@@ -420,7 +420,7 @@ struct AICommandParms
   Object*									m_obj;
   Object*									m_otherObj;
   const Team*							m_team;
-	mutable std::vector<Coord3D>		m_coords;
+	std::vector<Coord3D>		m_coords;
   const Waypoint*         m_waypoint;
   const PolygonTrigger*   m_polygon;
   Int											m_intValue;       /// misc usage

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
@@ -35,6 +35,7 @@
 #include "GameLogic/Damage.h"
 #include "Common/STLTypedefs.h"
 #include "ref_ptr.h"
+#include "Utility/CppMacros.h"
 
 class AIGroup;
 class AttackPriorityInfo;
@@ -553,13 +554,7 @@ public:
 	inline void aiFollowExitProductionPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource )
 	{
 		AICommandParms parms(AICMD_FOLLOW_EXITPRODUCTION_PATH, cmdSource);
-#if __cplusplus >= 201103L
-		parms.m_coords = std::move(*path);
-#else
-		// TheSuperHackers @performance bobtista 23/11/2025 Use swap to emulate move semantics for VC6 compatibility
-		parms.m_coords.swap(*path);
-		path->clear();
-#endif
+		move_assign_from_pointer(parms.m_coords, path);
 		parms.m_obj = ignoreObject;
 		aiDoCommand(&parms);
 	}
@@ -567,13 +562,7 @@ public:
 	inline void aiFollowPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource )
 	{
 		AICommandParms parms(AICMD_FOLLOW_PATH, cmdSource);
-#if __cplusplus >= 201103L
-		parms.m_coords = std::move(*path);
-#else
-		// TheSuperHackers @performance bobtista 23/11/2025 Use swap to emulate move semantics for VC6 compatibility
-		parms.m_coords.swap(*path);
-		path->clear();
-#endif
+		move_assign_from_pointer(parms.m_coords, path);
 		parms.m_obj = ignoreObject;
 		aiDoCommand(&parms);
 	}

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
@@ -553,7 +553,7 @@ public:
 	inline void aiFollowExitProductionPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource )
 	{
 		AICommandParms parms(AICMD_FOLLOW_EXITPRODUCTION_PATH, cmdSource);
-		parms.m_coords = std::move(*path);
+		parms.m_coords.swap(*path);
 		parms.m_obj = ignoreObject;
 		aiDoCommand(&parms);
 	}
@@ -561,7 +561,7 @@ public:
 	inline void aiFollowPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource )
 	{
 		AICommandParms parms(AICMD_FOLLOW_PATH, cmdSource);
-		parms.m_coords = std::move(*path);
+		parms.m_coords.swap(*path);
 		parms.m_obj = ignoreObject;
 		aiDoCommand(&parms);
 	}

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
@@ -550,7 +550,7 @@ public:
 		aiDoCommand(&parms);
 	}
 
-	inline void aiFollowExitProductionPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource )
+	void aiFollowExitProductionPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource )
 	{
 		AICommandParms parms(AICMD_FOLLOW_EXITPRODUCTION_PATH, cmdSource);
 		move_or_swap(parms.m_coords, *path);
@@ -558,7 +558,7 @@ public:
 		aiDoCommand(&parms);
 	}
 
-	inline void aiFollowPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource )
+	void aiFollowPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource )
 	{
 		AICommandParms parms(AICMD_FOLLOW_PATH, cmdSource);
 		move_or_swap(parms.m_coords, *path);

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
@@ -553,7 +553,7 @@ public:
 	inline void aiFollowExitProductionPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource )
 	{
 		AICommandParms parms(AICMD_FOLLOW_EXITPRODUCTION_PATH, cmdSource);
-		move_assign_from_pointer(parms.m_coords, path);
+		move_or_swap(parms.m_coords, *path);
 		parms.m_obj = ignoreObject;
 		aiDoCommand(&parms);
 	}
@@ -561,7 +561,7 @@ public:
 	inline void aiFollowPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource )
 	{
 		AICommandParms parms(AICMD_FOLLOW_PATH, cmdSource);
-		move_assign_from_pointer(parms.m_coords, path);
+		move_or_swap(parms.m_coords, *path);
 		parms.m_obj = ignoreObject;
 		aiDoCommand(&parms);
 	}

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
@@ -420,7 +420,7 @@ struct AICommandParms
   Object*									m_obj;
   Object*									m_otherObj;
   const Team*							m_team;
-	std::vector<Coord3D>		m_coords;
+	mutable std::vector<Coord3D>		m_coords;
   const Waypoint*         m_waypoint;
   const PolygonTrigger*   m_polygon;
   Int											m_intValue;       /// misc usage

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
@@ -35,7 +35,6 @@
 #include "GameLogic/Damage.h"
 #include "Common/STLTypedefs.h"
 #include "ref_ptr.h"
-#include "Utility/CppMacros.h"
 
 class AIGroup;
 class AttackPriorityInfo;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
@@ -553,7 +553,13 @@ public:
 	inline void aiFollowExitProductionPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource )
 	{
 		AICommandParms parms(AICMD_FOLLOW_EXITPRODUCTION_PATH, cmdSource);
+#if __cplusplus >= 201103L
+		parms.m_coords = std::move(*path);
+#else
+		// TheSuperHackers @performance bobtista 23/11/2025 Use swap to emulate move semantics for VC6 compatibility
 		parms.m_coords.swap(*path);
+		path->clear();
+#endif
 		parms.m_obj = ignoreObject;
 		aiDoCommand(&parms);
 	}
@@ -561,7 +567,13 @@ public:
 	inline void aiFollowPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource )
 	{
 		AICommandParms parms(AICMD_FOLLOW_PATH, cmdSource);
+#if __cplusplus >= 201103L
+		parms.m_coords = std::move(*path);
+#else
+		// TheSuperHackers @performance bobtista 23/11/2025 Use swap to emulate move semantics for VC6 compatibility
 		parms.m_coords.swap(*path);
+		path->clear();
+#endif
 		parms.m_obj = ignoreObject;
 		aiDoCommand(&parms);
 	}

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
@@ -553,7 +553,7 @@ public:
 	void aiFollowExitProductionPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource )
 	{
 		AICommandParms parms(AICMD_FOLLOW_EXITPRODUCTION_PATH, cmdSource);
-		move_or_swap(parms.m_coords, *path);
+		stl::move_or_swap(parms.m_coords, *path);
 		parms.m_obj = ignoreObject;
 		aiDoCommand(&parms);
 	}
@@ -561,7 +561,7 @@ public:
 	void aiFollowPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource )
 	{
 		AICommandParms parms(AICMD_FOLLOW_PATH, cmdSource);
-		move_or_swap(parms.m_coords, *path);
+		stl::move_or_swap(parms.m_coords, *path);
 		parms.m_obj = ignoreObject;
 		aiDoCommand(&parms);
 	}

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AIStateMachine.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AIStateMachine.h
@@ -141,7 +141,7 @@ public:
 	virtual StateReturnType setState( StateID newStateID );
 
 	/// @todo Rethink state parameter passing. Continuing in this fashion will have a pile of params in the machine (MSB)
-	void setGoalPath( const std::vector<Coord3D>* path );
+	void setGoalPath( std::vector<Coord3D>* path );
 	void addToGoalPath( const Coord3D *pathPoint );
 	const Coord3D *getGoalPathPosition( Int i ) const;		///< return path position at index "i"
 	Int getGoalPathSize() const { return m_goalPath.size(); }

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AIStateMachine.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AIStateMachine.h
@@ -111,8 +111,6 @@ extern Bool outOfWeaponRangeObject( State *thisState, void* userData );
 extern Bool outOfWeaponRangePosition( State *thisState, void* userData );
 extern Bool wantToSquishTarget( State *thisState, void* userData );
 
-#include "Utility/CppMacros.h"
-
 //-----------------------------------------------------------------------------------------------------------
 /**
   The AI state machine.  This is used by AIUpdate to implement all of the

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AIStateMachine.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AIStateMachine.h
@@ -111,6 +111,8 @@ extern Bool outOfWeaponRangeObject( State *thisState, void* userData );
 extern Bool outOfWeaponRangePosition( State *thisState, void* userData );
 extern Bool wantToSquishTarget( State *thisState, void* userData );
 
+#include "Utility/CppMacros.h"
+
 //-----------------------------------------------------------------------------------------------------------
 /**
   The AI state machine.  This is used by AIUpdate to implement all of the

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/AIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/AIUpdate.h
@@ -249,7 +249,7 @@ protected:
 	virtual void privateFollowWaypointPathAsTeam( const Waypoint *way, CommandSourceType cmdSource );///< start following the path from the given point
 	virtual void privateFollowWaypointPathExact( const Waypoint *way, CommandSourceType cmdSource );///< start following the path from the given point
 	virtual void privateFollowWaypointPathAsTeamExact( const Waypoint *way, CommandSourceType cmdSource );///< start following the path from the given point
-	virtual void privateFollowPath( const std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource, Bool exitProduction );///< follow the path defined by the given array of points
+	virtual void privateFollowPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource, Bool exitProduction );///< follow the path defined by the given array of points
 	virtual void privateFollowPathAppend( const Coord3D *pos, CommandSourceType cmdSource );
 	virtual void privateAttackObject( Object *victim, Int maxShotsToFire, CommandSourceType cmdSource );					///< attack given object
 	virtual void privateForceAttackObject( Object *victim, Int maxShotsToFire, CommandSourceType cmdSource );					///< attack given object
@@ -351,7 +351,7 @@ public:
 	virtual Bool isBusy() const;
 
 	virtual void onObjectCreated();
-	virtual void doQuickExit( const std::vector<Coord3D>* path );			///< get out of this Object
+	virtual void doQuickExit( std::vector<Coord3D>* path );			///< get out of this Object
 
 	virtual void aiDoCommand(const AICommandParms* parms);
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/JetAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/JetAIUpdate.h
@@ -110,7 +110,7 @@ public:
 	Real friend_getMinHeight() const { return getJetAIUpdateModuleData()->m_minHeight; }
 	Real friend_getParkingOffset() const { return getJetAIUpdateModuleData()->m_parkingOffset; }
 	UnsignedInt friend_getTakeoffPause() const { return getJetAIUpdateModuleData()->m_takeoffPause; }
-	void friend_setGoalPath( const std::vector<Coord3D>* path ) { getStateMachine()->setGoalPath(path); }
+	void friend_setGoalPath( std::vector<Coord3D>* path ) { getStateMachine()->setGoalPath(path); }
 	void friend_setTakeoffInProgress(Bool v) { setFlag(TAKEOFF_IN_PROGRESS, v); }
 	void friend_setLandingInProgress(Bool v) { setFlag(LANDING_IN_PROGRESS, v); }
 	void friend_setTaxiInProgress(Bool v) { setFlag(TAXI_IN_PROGRESS, v); }
@@ -131,7 +131,7 @@ protected:
 
 	virtual AIStateMachine* makeStateMachine();
 
-	virtual void privateFollowPath( const std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource, Bool exitProduction );///< follow the path defined by the given array of points
+	virtual void privateFollowPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource, Bool exitProduction );///< follow the path defined by the given array of points
 	virtual void privateFollowPathAppend( const Coord3D *pos, CommandSourceType cmdSource );
 	virtual void privateEnter( Object *obj, CommandSourceType cmdSource );							///< enter the given object
 	virtual void privateGetRepaired( Object *repairDepot, CommandSourceType cmdSource );///< get repaired at repair depot

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -98,7 +98,10 @@ void AICommandParmsStorage::store(const AICommandParms& parms)
   m_obj = parms.m_obj ? parms.m_obj->getID() : INVALID_ID;
   m_otherObj = parms.m_otherObj ? parms.m_otherObj->getID() : INVALID_ID;
   m_teamName = parms.m_team ? parms.m_team->getName() : AsciiString::TheEmptyString;
-	m_coords = parms.m_coords;
+	// We intentionally const_cast here so we can move the path coordinates into storage.
+	// AICommandParms is treated as a transient command container that is not reused after dispatch.
+	std::vector<Coord3D>& coords = const_cast<std::vector<Coord3D>&>(parms.m_coords);
+	move_or_swap(m_coords, coords);
   m_waypoint = parms.m_waypoint;
   m_polygon = parms.m_polygon;
   m_intValue = parms.m_intValue;       /// misc usage

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -823,13 +823,7 @@ void AIStateMachine::loadPostProcess( void )
  */
 void AIStateMachine::setGoalPath( std::vector<Coord3D>* path )
 {
-#if __cplusplus >= 201103L
-	m_goalPath = std::move(*path);
-#else
-	// TheSuperHackers @performance bobtista 23/11/2025 Use swap to emulate move semantics for VC6 compatibility
-	m_goalPath.swap(*path);
-	path->clear();
-#endif
+	move_assign_from_pointer(m_goalPath, path);
 }
 
 #ifdef STATE_MACHINE_DEBUG

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -827,7 +827,6 @@ void AIStateMachine::setGoalPath( std::vector<Coord3D>* path )
 	m_goalPath = std::move(*path);
 #else
 	// TheSuperHackers @performance bobtista 23/11/2025 Use swap to emulate move semantics for VC6 compatibility
-	// Swap transfers ownership without copying. Clear source to make intent explicit.
 	m_goalPath.swap(*path);
 	path->clear();
 #endif

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -823,7 +823,7 @@ void AIStateMachine::loadPostProcess( void )
  */
 void AIStateMachine::setGoalPath( std::vector<Coord3D>* path )
 {
-	move_assign_from_pointer(m_goalPath, path);
+	move_or_swap(m_goalPath, *path);
 }
 
 #ifdef STATE_MACHINE_DEBUG

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -823,7 +823,7 @@ void AIStateMachine::loadPostProcess( void )
  */
 void AIStateMachine::setGoalPath( std::vector<Coord3D>* path )
 {
-	move_or_swap(m_goalPath, *path);
+	stl::move_or_swap(m_goalPath, *path);
 }
 
 #ifdef STATE_MACHINE_DEBUG

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -823,7 +823,14 @@ void AIStateMachine::loadPostProcess( void )
  */
 void AIStateMachine::setGoalPath( std::vector<Coord3D>* path )
 {
+#if __cplusplus >= 201103L
+	m_goalPath = std::move(*path);
+#else
+	// TheSuperHackers @performance bobtista 23/11/2025 Use swap to emulate move semantics for VC6 compatibility
+	// Swap transfers ownership without copying. Clear source to make intent explicit.
 	m_goalPath.swap(*path);
+	path->clear();
+#endif
 }
 
 #ifdef STATE_MACHINE_DEBUG

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -823,7 +823,7 @@ void AIStateMachine::loadPostProcess( void )
  */
 void AIStateMachine::setGoalPath( std::vector<Coord3D>* path )
 {
-	m_goalPath = std::move(*path);
+	m_goalPath.swap(*path);
 }
 
 #ifdef STATE_MACHINE_DEBUG

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -98,10 +98,7 @@ void AICommandParmsStorage::store(const AICommandParms& parms)
   m_obj = parms.m_obj ? parms.m_obj->getID() : INVALID_ID;
   m_otherObj = parms.m_otherObj ? parms.m_otherObj->getID() : INVALID_ID;
   m_teamName = parms.m_team ? parms.m_team->getName() : AsciiString::TheEmptyString;
-	// We intentionally const_cast here so we can move the path coordinates into storage.
-	// AICommandParms is treated as a transient command container that is not reused after dispatch.
-	std::vector<Coord3D>& coords = const_cast<std::vector<Coord3D>&>(parms.m_coords);
-	move_or_swap(m_coords, coords);
+	m_coords = parms.m_coords;
   m_waypoint = parms.m_waypoint;
   m_polygon = parms.m_polygon;
   m_intValue = parms.m_intValue;       /// misc usage

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -821,9 +821,9 @@ void AIStateMachine::loadPostProcess( void )
 /**
  * Define a simple path
  */
-void AIStateMachine::setGoalPath( const std::vector<Coord3D>* path )
+void AIStateMachine::setGoalPath( std::vector<Coord3D>* path )
 {
-	m_goalPath = *path;
+	m_goalPath = std::move(*path);
 }
 
 #ifdef STATE_MACHINE_DEBUG

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -2681,14 +2681,22 @@ void AIUpdateInterface::aiDoCommand(const AICommandParms* parms)
 			privateFollowWaypointPathAsTeamExact(parms->m_waypoint, parms->m_cmdSource);
 			break;
 		case AICMD_FOLLOW_PATH:
-			privateFollowPath(&parms->m_coords, parms->m_obj, parms->m_cmdSource, FALSE);
+		{
+			// Keep AICommandParms const; use a local copy of the coordinates when following the path.
+			std::vector<Coord3D> coords = parms->m_coords;
+			privateFollowPath(&coords, parms->m_obj, parms->m_cmdSource, FALSE);
 			break;
+		}
 		case AICMD_FOLLOW_PATH_APPEND:
 			privateFollowPathAppend(&parms->m_pos, parms->m_cmdSource);
 			break;
 		case AICMD_FOLLOW_EXITPRODUCTION_PATH:
-			privateFollowPath(&parms->m_coords, parms->m_obj, parms->m_cmdSource, TRUE);
+		{
+			// Keep AICommandParms const; use a local copy of the coordinates when following the exit path.
+			std::vector<Coord3D> coords = parms->m_coords;
+			privateFollowPath(&coords, parms->m_obj, parms->m_cmdSource, TRUE);
 			break;
+		}
 		case AICMD_ATTACK_OBJECT:
 			privateAttackObject(parms->m_obj, parms->m_intValue, parms->m_cmdSource);
 			break;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -2681,13 +2681,13 @@ void AIUpdateInterface::aiDoCommand(const AICommandParms* parms)
 			privateFollowWaypointPathAsTeamExact(parms->m_waypoint, parms->m_cmdSource);
 			break;
 		case AICMD_FOLLOW_PATH:
-			privateFollowPath(&const_cast<AICommandParms*>(parms)->m_coords, parms->m_obj, parms->m_cmdSource, FALSE);
+			privateFollowPath(&parms->m_coords, parms->m_obj, parms->m_cmdSource, FALSE);
 			break;
 		case AICMD_FOLLOW_PATH_APPEND:
 			privateFollowPathAppend(&parms->m_pos, parms->m_cmdSource);
 			break;
 		case AICMD_FOLLOW_EXITPRODUCTION_PATH:
-			privateFollowPath(&const_cast<AICommandParms*>(parms)->m_coords, parms->m_obj, parms->m_cmdSource, TRUE);
+			privateFollowPath(&parms->m_coords, parms->m_obj, parms->m_cmdSource, TRUE);
 			break;
 		case AICMD_ATTACK_OBJECT:
 			privateAttackObject(parms->m_obj, parms->m_intValue, parms->m_cmdSource);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -2682,7 +2682,7 @@ void AIUpdateInterface::aiDoCommand(const AICommandParms* parms)
 			break;
 		case AICMD_FOLLOW_PATH:
 		{
-			// Keep AICommandParms const; use a local copy of the coordinates when following the path.
+			// Copy coordinates to a local vector since privateFollowPath requires a non-const pointer.
 			std::vector<Coord3D> coords = parms->m_coords;
 			privateFollowPath(&coords, parms->m_obj, parms->m_cmdSource, FALSE);
 			break;
@@ -2692,7 +2692,7 @@ void AIUpdateInterface::aiDoCommand(const AICommandParms* parms)
 			break;
 		case AICMD_FOLLOW_EXITPRODUCTION_PATH:
 		{
-			// Keep AICommandParms const; use a local copy of the coordinates when following the exit path.
+			// Copy coordinates to a local vector since privateFollowPath requires a non-const pointer.
 			std::vector<Coord3D> coords = parms->m_coords;
 			privateFollowPath(&coords, parms->m_obj, parms->m_cmdSource, TRUE);
 			break;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -2682,7 +2682,6 @@ void AIUpdateInterface::aiDoCommand(const AICommandParms* parms)
 			break;
 		case AICMD_FOLLOW_PATH:
 		{
-			// Copy coordinates to a local vector since privateFollowPath requires a non-const pointer.
 			std::vector<Coord3D> coords = parms->m_coords;
 			privateFollowPath(&coords, parms->m_obj, parms->m_cmdSource, FALSE);
 			break;
@@ -2692,7 +2691,6 @@ void AIUpdateInterface::aiDoCommand(const AICommandParms* parms)
 			break;
 		case AICMD_FOLLOW_EXITPRODUCTION_PATH:
 		{
-			// Copy coordinates to a local vector since privateFollowPath requires a non-const pointer.
 			std::vector<Coord3D> coords = parms->m_coords;
 			privateFollowPath(&coords, parms->m_obj, parms->m_cmdSource, TRUE);
 			break;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -2681,13 +2681,13 @@ void AIUpdateInterface::aiDoCommand(const AICommandParms* parms)
 			privateFollowWaypointPathAsTeamExact(parms->m_waypoint, parms->m_cmdSource);
 			break;
 		case AICMD_FOLLOW_PATH:
-			privateFollowPath(&parms->m_coords, parms->m_obj, parms->m_cmdSource, FALSE);
+			privateFollowPath(&const_cast<AICommandParms*>(parms)->m_coords, parms->m_obj, parms->m_cmdSource, FALSE);
 			break;
 		case AICMD_FOLLOW_PATH_APPEND:
 			privateFollowPathAppend(&parms->m_pos, parms->m_cmdSource);
 			break;
 		case AICMD_FOLLOW_EXITPRODUCTION_PATH:
-			privateFollowPath(&parms->m_coords, parms->m_obj, parms->m_cmdSource, TRUE);
+			privateFollowPath(&const_cast<AICommandParms*>(parms)->m_coords, parms->m_obj, parms->m_cmdSource, TRUE);
 			break;
 		case AICMD_ATTACK_OBJECT:
 			privateAttackObject(parms->m_obj, parms->m_intValue, parms->m_cmdSource);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -3377,7 +3377,7 @@ void AIUpdateInterface::privateFollowPathAppend( const Coord3D *pos, CommandSour
 /**
  * Follow the path defined by the given array of points
  */
-void AIUpdateInterface::privateFollowPath( const std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource, Bool exitProduction )
+void AIUpdateInterface::privateFollowPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource, Bool exitProduction )
 {
 	if (getObject()->isMobile() == FALSE)
 		return;
@@ -3869,7 +3869,7 @@ void AIUpdateInterface::privateExitInstantly( Object *objectToExit, CommandSourc
 /**
  * Get out of whatever it is inside of
  */
-void AIUpdateInterface::doQuickExit( const std::vector<Coord3D>* path )
+void AIUpdateInterface::doQuickExit( std::vector<Coord3D>* path )
 {
 
 	Bool locked = getStateMachine()->isLocked();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -2399,7 +2399,7 @@ Bool JetAIUpdate::getTreatAsAircraftForLocoDistToGoal() const
 /**
  * Follow the path defined by the given array of points
  */
-void JetAIUpdate::privateFollowPath( const std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource, Bool exitProduction )
+void JetAIUpdate::privateFollowPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource, Bool exitProduction )
 {
 	if (exitProduction)
 	{


### PR DESCRIPTION
- Closes #1891

Refactors path-following functions to use move when transferring `std::vector<Coord3D>` ownership

### Changes:
- Updated `aiFollowExitProductionPath` and `aiFollowPath` inline functions to accept non-const vector pointers and use `std::move`
- Modified `AIStateMachine::setGoalPath` to move the vector instead of copying
- Updated `privateFollowPath` and `doQuickExit` signatures to support move semantics


