### PR TITLE
bugfix(module): A projectile can no longer be jammed multiple times

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp
@@ -1323,6 +1323,8 @@ Bool ActiveBody::isSubdued() const
 #if RETAIL_COMPATIBLE_CRC
 	return m_maxHealth <= m_currentSubdualDamage;
 #else
+  // TheSuperHackers @info Projectiles don't receive the DISABLED_SUBDUED flag (or any flag for
+	// that matter) when jammed, so we have to check their subdual damage directly.
 	if (getObject()->isKindOf(KINDOF_PROJECTILE))
 		return m_maxHealth <= m_currentSubdualDamage;
 


### PR DESCRIPTION
Fixes #1793

This change fixes a bug introduced by 5ba1741dd3335b085e8a36507ab3398687165fe8, which caused `isSubdued` to never return true for projectiles, resulting in continuous and repeated jamming by the ECM Tank's missile jammer.