### PR TITLE
tweak(gui): Add configuration to GameData.ini to allow Money Per Minute for players

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/GlobalData.h
+++ b/Generals/Code/GameEngine/Include/Common/GlobalData.h
@@ -410,6 +410,7 @@ public:
 
 	// TheSuperHackers @feature L3-M 21/08/2025 toggle the money per minute display, false shows only the original current money
 	Bool m_showMoneyPerMinute;
+	Bool m_allowMoneyPerMinuteForPlayer;
 
 	Real m_shakeSubtleIntensity;			///< Intensity for shaking a camera with SHAKE_SUBTLE
 	Real m_shakeNormalIntensity;			///< Intensity for shaking a camera with SHAKE_NORMAL

--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -442,6 +442,11 @@ GlobalData* GlobalData::m_theOriginal = NULL;
 
 	{	"CameraAudibleRadius",				INI::parseReal,				NULL,			offsetof( GlobalData, m_cameraAudibleRadius ) },
 	{ "GroupMoveClickToGatherAreaFactor", INI::parseReal,	NULL,			offsetof( GlobalData, m_groupMoveClickToGatherFactor ) },
+
+#if !PRESERVE_RETAIL_BEHAVIOR
+	{ "AllowMoneyPerMinuteForPlayer",	INI::parseBool,			NULL,			offsetof( GlobalData, m_allowMoneyPerMinuteForPlayer ) },
+#endif
+
 	{ "ShakeSubtleIntensity",				INI::parseReal,				NULL,			offsetof( GlobalData, m_shakeSubtleIntensity ) },
 	{ "ShakeNormalIntensity",				INI::parseReal,				NULL,			offsetof( GlobalData, m_shakeNormalIntensity ) },
 	{ "ShakeStrongIntensity",				INI::parseReal,				NULL,			offsetof( GlobalData, m_shakeStrongIntensity ) },
@@ -943,6 +948,7 @@ GlobalData::GlobalData()
 	m_gameTimeFontSize = 8;
 
 	m_showMoneyPerMinute = FALSE;
+	m_allowMoneyPerMinuteForPlayer = FALSE;
 
 	m_debugShowGraphicalFramerate = FALSE;
 

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -1880,8 +1880,10 @@ void InGameUI::update( void )
 	if( moneyPlayer)
 	{
 		Money *money = moneyPlayer->getMoney();
-		Bool showIncome = TheGlobalData->m_showMoneyPerMinute;
-		if (!showIncome)
+		Bool wantShowIncome = TheGlobalData->m_showMoneyPerMinute;
+		Bool canShowIncome = TheGlobalData->m_allowMoneyPerMinuteForPlayer || TheControlBar->isObserverControlBarOn();
+		Bool doShowIncome = wantShowIncome && canShowIncome;
+		if (!doShowIncome)
 		{
 			UnsignedInt currentMoney = money->countMoney();
 			if( lastMoney != currentMoney )

--- a/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
@@ -417,6 +417,7 @@ public:
 
 	// TheSuperHackers @feature L3-M 21/08/2025 toggle the money per minute display, false shows only the original current money
 	Bool m_showMoneyPerMinute;
+	Bool m_allowMoneyPerMinuteForPlayer;
 
 	Real m_shakeSubtleIntensity;			///< Intensity for shaking a camera with SHAKE_SUBTLE
 	Real m_shakeNormalIntensity;			///< Intensity for shaking a camera with SHAKE_NORMAL

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -442,6 +442,11 @@ GlobalData* GlobalData::m_theOriginal = NULL;
 
 	{	"CameraAudibleRadius",				INI::parseReal,				NULL,			offsetof( GlobalData, m_cameraAudibleRadius ) },
 	{ "GroupMoveClickToGatherAreaFactor", INI::parseReal,	NULL,			offsetof( GlobalData, m_groupMoveClickToGatherFactor ) },
+
+#if !PRESERVE_RETAIL_BEHAVIOR
+	{ "AllowMoneyPerMinuteForPlayer",	INI::parseBool,			NULL,			offsetof( GlobalData, m_allowMoneyPerMinuteForPlayer ) },
+#endif
+
 	{ "ShakeSubtleIntensity",				INI::parseReal,				NULL,			offsetof( GlobalData, m_shakeSubtleIntensity ) },
 	{ "ShakeNormalIntensity",				INI::parseReal,				NULL,			offsetof( GlobalData, m_shakeNormalIntensity ) },
 	{ "ShakeStrongIntensity",				INI::parseReal,				NULL,			offsetof( GlobalData, m_shakeStrongIntensity ) },
@@ -952,6 +957,7 @@ GlobalData::GlobalData()
 	m_gameTimeFontSize = 8;
 
 	m_showMoneyPerMinute = FALSE;
+	m_allowMoneyPerMinuteForPlayer = FALSE;
 
 	m_debugShowGraphicalFramerate = FALSE;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -1936,8 +1936,10 @@ void InGameUI::update( void )
 	if( moneyPlayer)
 	{
 		Money *money = moneyPlayer->getMoney();
-		Bool showIncome = TheGlobalData->m_showMoneyPerMinute;
-		if (!showIncome)
+		Bool wantShowIncome = TheGlobalData->m_showMoneyPerMinute;
+		Bool canShowIncome = TheGlobalData->m_allowMoneyPerMinuteForPlayer || TheControlBar->isObserverControlBarOn();
+		Bool doShowIncome = wantShowIncome && canShowIncome;
+		if (!doShowIncome)
 		{
 			UnsignedInt currentMoney = money->countMoney();
 			if( lastMoney != currentMoney )


### PR DESCRIPTION
* Follow up for #1481

This change implements a GameData.ini option to enable or disable Money Per Minute for Players in Generals and Zero Hour. 

The new option is `AllowMoneyPerMinuteForPlayer`, which is disabled by default and can be set to yes/no in `GameData.ini` when `PRESERVE_RETAIL_BEHAVIOR` is set to (0).
