### PR TITLE
bugfix(weapon): Weapon effects now show again for hidden objects that are not explicitly stealthed

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -890,6 +890,7 @@ UnsignedInt WeaponTemplate::fireWeaponTemplate
 		const Bool isVisible = outerDrawable && outerDrawable->isVisible();
 
 		if (!isVisible																				// if user watching cannot see us
+			&& sourceObj->testStatus(OBJECT_STATUS_STEALTHED)		// if unit is stealthed (like a Pathfinder)
 			&& !sourceObj->isKindOf(KINDOF_MINE)								// and not a mine (which always do the FX, even if hidden)...
 			&& !isPlayFXWhenStealthed()													// and not a weapon marked to playwhenstealthed
 			)

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -921,6 +921,7 @@ UnsignedInt WeaponTemplate::fireWeaponTemplate
 		const Bool isVisible = outerDrawable && outerDrawable->isVisible();
 
 		if (!isVisible																				// if user watching cannot see us
+			&& sourceObj->testStatus(OBJECT_STATUS_STEALTHED)		// if unit is stealthed (like a Pathfinder)
 			&& !sourceObj->isKindOf(KINDOF_MINE)								// and not a mine (which always do the FX, even if hidden)...
 			&& !isPlayFXWhenStealthed()													// and not a weapon marked to playwhenstealthed
 			)


### PR DESCRIPTION
* Follow up for #1865
* Fixes #1908
* Fixes #1905

This change fixes weapon effects not showing when spawned by hidden objects such as toxin and radiation fields.

If the object is invisible, the `OBJECT_STATUS_STEALTHED` status is explicitly checked. This ensures objects that are invisible as a result of being stealthed do not play their effects; while still allowing detected, allied or observed stealthed objects to play their effects as they are considered visible.