### PR TITLE
bugfix: GLA Bomb Truck now consistently plays detonation weapon effects

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -891,6 +891,7 @@ UnsignedInt WeaponTemplate::fireWeaponTemplate
 
 		if (!isVisible																				// if user watching cannot see us
 			&& sourceObj->testStatus(OBJECT_STATUS_STEALTHED)		// if unit is stealthed (like a Pathfinder)
+			&& !sourceObj->isKindOf(KINDOF_DISGUISER)						// and not a disguiser (which should show FX while stealthed)...
 			&& !sourceObj->isKindOf(KINDOF_MINE)								// and not a mine (which always do the FX, even if hidden)...
 			&& !isPlayFXWhenStealthed()													// and not a weapon marked to playwhenstealthed
 			)

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -922,6 +922,7 @@ UnsignedInt WeaponTemplate::fireWeaponTemplate
 
 		if (!isVisible																				// if user watching cannot see us
 			&& sourceObj->testStatus(OBJECT_STATUS_STEALTHED)		// if unit is stealthed (like a Pathfinder)
+			&& !sourceObj->isKindOf(KINDOF_DISGUISER)						// and not a disguiser (which should show FX while stealthed)...
 			&& !sourceObj->isKindOf(KINDOF_MINE)								// and not a mine (which always do the FX, even if hidden)...
 			&& !isPlayFXWhenStealthed()													// and not a weapon marked to playwhenstealthed
 			)


### PR DESCRIPTION
This change fixes an inconsistency with the Bomb Truck detonation effect, which does not often play for opponents / allies / observers.

This inconsistency occurs because the Bomb Truck loses its `OBJECT_STATUS_DISGUISED` status as soon as it begins revealing itself as a result of the `RevealDistanceFromTarget` property on the `StealthUpdate` module, however it does not lose its `OBJECT_STATUS_STEALTHED` status until the `DisguiseRevealTransitionTime` has elapsed. (This is necessary or the stealth update will not run and update the transitions.)

This means there is a brief transitional period where the Bomb Truck has a status combination of `OBJECT_STATUS_STEALTHED (1)`, `OBJECT_STATUS_DETECTED (0)` and `OBJECT_STATUS_DISGUISED (0)`, which bypasses the retail weapon effect conditions as the object is considered invisible.

https://github.com/TheSuperHackers/GeneralsGameCode/blob/0a05454d8574207440a5fb15241b98ad0b435590/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp#L935-L944

There seems to be an assumption with most conditions throughout the codebase that `OBJECT_STATUS_STEALTHED` is always kept in alignment with `OBJECT_STATUS_DISGUISED`, i.e. if a `KINDOF_DISGUISER` object is disguised, it is also stealthed, and vice versa. This is evident when viewing references to `OBJECT_STATUS_DISGUISED`, where almost every usage follows an `if stealthed + not detected + not disguised` pattern (which returns a different result during the Bomb Truck's reveal transition). Several behaviours break during this transition, though it's only for a second so it's relatively inconspicuous.

A viable (and somewhat temporary) solution is to alter the `OBJECT_STATUS_DISGUISED` condition to `KINDOF_DISGUISER` as it then also extends the coverage to the disguise and reveal transitions on either side of the disguised state while otherwise behaving the same.

The ultimate long-term solution would likely involve decoupling the disguise behaviour from the stealth update and introducing a `DisguiseUpdate` module. This would simplify the logic and resolve the need to check the disguise status in tandem with the stealth status condition in almost all cases. It would also allow the stealth condition to be properly applied to `KINDOF_DISGUISER` units as a standalone status, such as via the GPS Scrambler. The `KINDOF_DISGUISER` type wouldn't be needed either.

Another safe and easy solution to fix the detonation effects is with a data change to the Bomb Truck weapons by applying `PlayFXWhenStealthed = Yes`.

### Before
The Bomb Truck explodes during its reveal transition, resulting in no detonation effect for other players

https://github.com/user-attachments/assets/4060f10e-d425-42e9-aa1f-924b4fb11e6d

### After
Other players can always see the detonation effect when the Bomb Truck explodes during its reveal transition

https://github.com/user-attachments/assets/2ccb4e76-020e-4540-8589-6582a288da4e

Note: The fix is also applied to Generals for posterity / consistency (disguised units do not exist there).