### PR TITLE
bugfix(movie): Fix Campaign, Challenge, Score movie cancellation or decompression artifacts when tabbing out of the game

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
@@ -634,6 +634,9 @@ void PlayMovieAndBlock(AsciiString movieTitle)
 		return;
 	}
 
+	// TheSuperHackers @bugfix Originally this movie render loop stopped rendering when the game window was inactive.
+	// This either skipped the movie or caused decompression artifacts. Now the video just keeps playing until it done.
+
 	GameWindow *movieWindow = s_blankLayout->getFirstWindow();
 	TheWritableGlobalData->m_loadScreenRender = TRUE;
 	while (videoStream->frameIndex() < videoStream->frameCount() - 1)
@@ -643,13 +646,6 @@ void PlayMovieAndBlock(AsciiString movieTitle)
 		if(!videoStream->isFrameReady())
 		{
 			Sleep(1);
-			continue;
-		}
-
-		if (!TheGameEngine->isActive())
-		{	//we are alt-tabbed out, so just increment the frame
-			videoStream->frameNext();
-			videoStream->frameDecompress();
 			continue;
 		}
 

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/LoadScreen.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/LoadScreen.cpp
@@ -486,6 +486,9 @@ void SinglePlayerLoadScreen::init( GameInfo *game )
 
 	if(TheGameLODManager && TheGameLODManager->didMemPass())
 	{
+		// TheSuperHackers @bugfix Originally this movie render loop stopped rendering when the game window was inactive.
+		// This either skipped the movie or caused decompression artifacts. Now the video just keeps playing until it done.
+
 		Int progressUpdateCount = m_videoStream->frameCount() / FRAME_FUDGE_ADD;
 		Int shiftedPercent = -FRAME_FUDGE_ADD + 1;
 		while (m_videoStream->frameIndex() < m_videoStream->frameCount() - 1 )
@@ -495,13 +498,6 @@ void SinglePlayerLoadScreen::init( GameInfo *game )
 			if(!m_videoStream->isFrameReady())
 			{
 				Sleep(1);
-				continue;
-			}
-
-			if (!TheGameEngine->isActive())
-			{	//we are alt-tabbed out, so just increment the frame
-				m_videoStream->frameNext();
-				m_videoStream->frameDecompress();
 				continue;
 			}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
@@ -727,6 +727,9 @@ void PlayMovieAndBlock(AsciiString movieTitle)
 		return;
 	}
 
+	// TheSuperHackers @bugfix Originally this movie render loop stopped rendering when the game window was inactive.
+	// This either skipped the movie or caused decompression artifacts. Now the video just keeps playing until it done.
+
 	GameWindow *movieWindow = s_blankLayout->getFirstWindow();
 	TheWritableGlobalData->m_loadScreenRender = TRUE;
 	while (videoStream->frameIndex() < videoStream->frameCount() - 1)
@@ -736,13 +739,6 @@ void PlayMovieAndBlock(AsciiString movieTitle)
 		if(!videoStream->isFrameReady())
 		{
 			Sleep(1);
-			continue;
-		}
-
-		if (!TheGameEngine->isActive())
-		{	//we are alt-tabbed out, so just increment the frame
-			videoStream->frameNext();
-			videoStream->frameDecompress();
 			continue;
 		}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/LoadScreen.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/LoadScreen.cpp
@@ -529,6 +529,9 @@ void SinglePlayerLoadScreen::init( GameInfo *game )
 
 	if(TheGameLODManager && TheGameLODManager->didMemPass())
 	{
+		// TheSuperHackers @bugfix Originally this movie render loop stopped rendering when the game window was inactive.
+		// This either skipped the movie or caused decompression artifacts. Now the video just keeps playing until it done.
+
 		Int progressUpdateCount = m_videoStream->frameCount() / FRAME_FUDGE_ADD;
 		Int shiftedPercent = -FRAME_FUDGE_ADD + 1;
 		while (m_videoStream->frameIndex() < m_videoStream->frameCount() - 1 )
@@ -539,15 +542,6 @@ void SinglePlayerLoadScreen::init( GameInfo *game )
 			{
 				Sleep(1);
 				continue;
-			}
-
-			if (!TheGameEngine->isActive())
-			{/*	//we are alt-tabbed out, so just increment the frame
-				m_videoStream->frameNext();
-				m_videoStream->frameDecompress();*/
-
-				//Changing for MissionDisk, just skip to end.
-				break;
 			}
 
 			m_videoStream->frameDecompress();
@@ -1049,6 +1043,9 @@ void ChallengeLoadScreen::init( GameInfo *game )
 
 	if(TheGameLODManager && TheGameLODManager->didMemPass())
 	{
+		// TheSuperHackers @bugfix Originally this movie render loop stopped rendering when the game window was inactive.
+		// This either skipped the movie or caused decompression artifacts. Now the video just keeps playing until it done.
+
 		Int progressUpdateCount = m_videoStream->frameCount() / FRAME_FUDGE_ADD;
 		Int shiftedPercent = -FRAME_FUDGE_ADD + 1;
 		while (m_videoStream->frameIndex() < m_videoStream->frameCount() - 1 )
@@ -1058,13 +1055,6 @@ void ChallengeLoadScreen::init( GameInfo *game )
 			if(!m_videoStream->isFrameReady())
 			{
 				Sleep(1);
-				continue;
-			}
-
-			if (!TheGameEngine->isActive())
-			{	//we are alt-tabbed out, so just increment the frame
-				m_videoStream->frameNext();
-				m_videoStream->frameDecompress();
 				continue;
 			}
 


### PR DESCRIPTION
* Fixes #1639

This change fixes Campaign, Challenge, Score movie stopping or showing decompression artifacts when tabbing out of the game.

I was unable to observe issues with the code removed. Movies look good.