### PR TITLE
refactor(network): Replace implicit conversion from NULL to AsciiString in IPEnumeration::getMachineName

### DIFF
--- a/Core/GameEngine/Source/GameNetwork/IPEnumeration.cpp
+++ b/Core/GameEngine/Source/GameNetwork/IPEnumeration.cpp
@@ -172,12 +172,12 @@ AsciiString IPEnumeration::getMachineName( void )
 
 		int err = WSAStartup(verReq, &wsadata);
 		if (err != 0) {
-			return AsciiString();
+			return "";
 		}
 
 		if ((LOBYTE(wsadata.wVersion) != 2) || (HIBYTE(wsadata.wVersion) !=2)) {
 			WSACleanup();
-			return AsciiString();
+			return "";
 		}
 		m_isWinsockInitialized = true;
 	}
@@ -187,7 +187,7 @@ AsciiString IPEnumeration::getMachineName( void )
 	if (gethostname(hostname, sizeof(hostname)))
 	{
 		DEBUG_LOG(("Failed call to gethostname; WSAGetLastError returned %d", WSAGetLastError()));
-		return AsciiString();
+		return "";
 	}
 
 	return AsciiString(hostname);


### PR DESCRIPTION
Implicit conversion from `NULL` can be ambiguous; it can be either a pointer or an integer. 

It's also potentially less optimal - depending on whether the compiler can optimize this away - because the [current constructor](https://github.com/TheSuperHackers/GeneralsGameCode/blob/94354fdf503fee7c6934d9f723dbf1c1f5cd1181/Core/GameEngine/Source/Common/System/AsciiString.cpp#L199) needs to check whether the input is a `nullptr`.

We could do `return "";` but that's also potentially less optimal for the same reason.