### PR TITLE
feat(hotkey): Enable players to hold down hotkeys to queue multiple units

### DIFF
--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Keyboard.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Keyboard.h
@@ -77,6 +77,7 @@ struct KeyboardIO
 	UnsignedByte	status;									// StatusType, above
 	UnsignedShort	state;									// KEY_STATE_* in KeyDefs.h
 	UnsignedInt		keyDownTimeMsec;				// real-time in milliseconds when key went down
+	UnsignedInt		keyRepeatTimeMsecOffset;	// shorten key repeat delay by offset
 
 };
 
@@ -88,8 +89,12 @@ class Keyboard : public SubsystemInterface
 
 	enum
 	{
-		KEY_REPEAT_DELAY_MSEC = 333,	// 10 frames at 30 FPS
-		KEY_REPEAT_INTERVAL_MSEC = 67	// ~2 frames at 30 FPS
+		// TheSuperHackers @info Holding a button down requires 200 msec to register as a repeated key for the first time.
+		// After that the delay gets shorter and shorter, between 140 (200 - 60) and 15 (200 - 185) msec, with a decrease step of 15 msec.
+		KEY_REPEAT_DELAY_MSEC             = 200,
+		KEY_REPEAT_OFFSET_DELAY_MIN_MSEC  =  60,
+		KEY_REPEAT_OFFSET_DELAY_MAX_MSEC  = 185,
+		KEY_REPEAT_OFFSET_DELAY_STEP_MSEC =  15
 	};
 
 public:

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -289,8 +289,8 @@ void GameClient::init( void )
 
 		// since we only allocate one of each, don't bother pooling 'em
 		m_translators[ m_numTranslators++ ] =	TheMessageStream->attachTranslator( MSGNEW("GameClientSubsystem") WindowTranslator,     10 );
-		m_translators[ m_numTranslators++ ] =	TheMessageStream->attachTranslator( MSGNEW("GameClientSubsystem") MetaEventTranslator,	20 );
-		m_translators[ m_numTranslators++ ] =	TheMessageStream->attachTranslator( MSGNEW("GameClientSubsystem") HotKeyTranslator,	25 );
+		m_translators[ m_numTranslators++ ] =	TheMessageStream->attachTranslator( MSGNEW("GameClientSubsystem") HotKeyTranslator,	    20 );
+		m_translators[ m_numTranslators++ ] =	TheMessageStream->attachTranslator( MSGNEW("GameClientSubsystem") MetaEventTranslator,	25 );
 		m_translators[ m_numTranslators++ ] =	TheMessageStream->attachTranslator( MSGNEW("GameClientSubsystem") PlaceEventTranslator,	30 );
 		m_translators[ m_numTranslators++ ] = TheMessageStream->attachTranslator( MSGNEW("GameClientSubsystem") GUICommandTranslator, 40 );
 		m_translators[ m_numTranslators++ ] =	TheMessageStream->attachTranslator( MSGNEW("GameClientSubsystem") SelectionTranslator,	50 );

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
@@ -209,6 +209,7 @@ Bool Keyboard::checkKeyRepeat( void )
 	Bool retVal = FALSE;
 	size_t index = 0;
 
+	// Find end of real keys for this frame
 	for (size_t i = 0; i < ARRAY_SIZE(m_keys) - 1 && m_keys[i].key != KEY_NONE; ++i)
 	{
 		++index;
@@ -226,6 +227,7 @@ Bool Keyboard::checkKeyRepeat( void )
 				// Add key to this frame
 				if (index < ARRAY_SIZE(m_keys) - 2)
 				{
+					// Add key to this frame
 					m_keys[index].key = (UnsignedByte)key;
 					m_keys[index].state = KEY_STATE_DOWN | KEY_STATE_AUTOREPEAT; // note: not a bitset; this is an assignment
 					m_keys[index].status = KeyboardIO::STATUS_UNUSED;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
@@ -228,7 +228,7 @@ Bool Keyboard::checkKeyRepeat( void )
 				{
 					// Add key to this frame
 					m_keys[index].key = (UnsignedByte)key;
-					m_keys[index].state = KEY_STATE_DOWN | KEY_STATE_AUTOREPEAT; // note: not a bitset; this is an assignment
+					m_keys[index].state = KEY_STATE_DOWN | KEY_STATE_AUTOREPEAT;
 					m_keys[index].status = KeyboardIO::STATUS_UNUSED;
 					++index;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
@@ -231,9 +231,9 @@ Bool Keyboard::checkKeyRepeat( void )
 					m_keys[index].key = (UnsignedByte)key;
 					m_keys[index].state = KEY_STATE_DOWN | KEY_STATE_AUTOREPEAT; // note: not a bitset; this is an assignment
 					m_keys[index].status = KeyboardIO::STATUS_UNUSED;
+					++index;
 
 					// Set end flag
-					++index;
 					m_keys[index].key = KEY_NONE;
 				}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
@@ -210,7 +210,7 @@ Bool Keyboard::checkKeyRepeat( void )
 	size_t index = 0;
 
 	// Find end of real keys for this frame
-	for (size_t i = 0; i < ARRAY_SIZE(m_keys) - 1 && m_keys[i].key != KEY_NONE; ++i)
+	for (size_t i = 0; i < ARRAY_SIZE(m_keys) && m_keys[i].key != KEY_NONE; ++i)
 	{
 		++index;
 	}
@@ -225,7 +225,7 @@ Bool Keyboard::checkKeyRepeat( void )
 			if( m_keyStatus[ key ].keyDownTimeMsec > 0 && now - m_keyStatus[ key ].keyDownTimeMsec > Keyboard::KEY_REPEAT_DELAY_MSEC )
 			{
 				// Add key to this frame
-				if (index < ARRAY_SIZE(m_keys) - 2)
+				if (index < ARRAY_SIZE(m_keys) - 1)
 				{
 					// Add key to this frame
 					m_keys[index].key = (UnsignedByte)key;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
@@ -224,7 +224,6 @@ Bool Keyboard::checkKeyRepeat( void )
 
 			if( m_keyStatus[ key ].keyDownTimeMsec > 0 && now - m_keyStatus[ key ].keyDownTimeMsec > Keyboard::KEY_REPEAT_DELAY_MSEC )
 			{
-				// Add key to this frame
 				if (index < ARRAY_SIZE(m_keys) - 1)
 				{
 					// Add key to this frame


### PR DESCRIPTION
QoL improvement to make it more convenient to add units to build queues by holding down hotkeys.

Currently, a hotkey needs to be held down for longer than 200 milliseconds to start queuing multiple units. Next units will take less and less time to queue.

**Work in progress.**

## TODO:
- [ ] Revisit key event timings
- [ ] Maybe put this behind some sort of flag or macro for multiplayer
- [ ] Maybe add settings for options.ini
- [ ] Replicate in Generals