### PR TITLE
fix building in docker.

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -9,7 +9,7 @@
         {
             "name": "vc6",
             "displayName": "Windows 32bit VC6 Release",
-            "generator": "Ninja",
+            "generator": "NMake Makefiles",
             "hidden": false,
             "binaryDir": "${sourceDir}/build/${presetName}",
             "cacheVariables": {


### PR DESCRIPTION
nmake without being set as generator will try to run --version, which the old version doesn't support