### PR TITLE
bugfix(network): Prevent out of bounds memory access in NetCommandWrapperListNode::copyChunkData()

### DIFF
--- a/Core/GameEngine/Include/GameNetwork/NetCommandWrapperList.h
+++ b/Core/GameEngine/Include/GameNetwork/NetCommandWrapperList.h
@@ -49,7 +49,7 @@ public:
 protected:
 	UnsignedShort m_commandID;
 	UnsignedByte *m_data;
-	UnsignedInt m_dataLength;
+	UnsignedInt m_totalDataLength;
 	Bool *m_chunksPresent;
 	UnsignedInt m_numChunks;
 	UnsignedInt m_numChunksPresent;


### PR DESCRIPTION
This PR prevents the ability to perform an out of bounds memory access using a well crafted wrapped command.

The Wrapped commands are designed to chunk up a larger data packet, so files can be transfered to another machine such as a map.

This PR adds checks to make sure the chunked data makes sense and fits within the bounds of the allocated memory.