### PR TITLE
fix: Wrong usage of sizeof(this) in BitFlags::xfer(), W3DMPO::glueEnforcer()

### DIFF
--- a/Core/Libraries/Source/WWVegas/WWLib/always.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/always.h
@@ -144,7 +144,7 @@ private: \
 		return The##ARGCLASS##Pool; \
 	} \
 protected: \
-	virtual int glueEnforcer() const { return sizeof(*this); } \
+	virtual void glueEnforcer() const { } \
 public: \
 	inline void* operator new(size_t s) { return allocateFromW3DMemPool(getClassMemoryPool(), s); } \
 	inline void operator delete(void *p) { freeFromW3DMemPool(getClassMemoryPool(), p); } \
@@ -162,7 +162,7 @@ private:
 	}
 protected:
 	// we never call this; it is present to cause compile errors in descendent classes
-	virtual int glueEnforcer() const = 0;
+	virtual void glueEnforcer() const = 0;
 public:
 	virtual ~W3DMPO() { /* nothing */ }
 };

--- a/Core/Libraries/Source/WWVegas/WWLib/always.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/always.h
@@ -144,7 +144,7 @@ private: \
 		return The##ARGCLASS##Pool; \
 	} \
 protected: \
-	virtual int glueEnforcer() const { return sizeof(this); } \
+	virtual int glueEnforcer() const { return sizeof(*this); } \
 public: \
 	inline void* operator new(size_t s) { return allocateFromW3DMemPool(getClassMemoryPool(), s); } \
 	inline void operator delete(void *p) { freeFromW3DMemPool(getClassMemoryPool(), p); } \

--- a/Generals/Code/GameEngine/Include/Common/BitFlagsIO.h
+++ b/Generals/Code/GameEngine/Include/Common/BitFlagsIO.h
@@ -214,7 +214,7 @@ void BitFlags<NUMBITS>::xfer(Xfer* xfer)
 	{
 
 		// just call the xfer implementation on the data values
-		xfer->xferUser( this, sizeof( this ) );
+		xfer->xferUser( this, sizeof( *this ) );
 
 	}
 	else

--- a/Generals/Code/GameEngine/Include/Common/BitFlagsIO.h
+++ b/Generals/Code/GameEngine/Include/Common/BitFlagsIO.h
@@ -214,7 +214,13 @@ void BitFlags<NUMBITS>::xfer(Xfer* xfer)
 	{
 
 		// just call the xfer implementation on the data values
+		// TheSuperHackers @bugfix bobtista 05/12/2025 Fix sizeof(this) bug
+		// Original code used sizeof(this) which is pointer size
+#ifndef RETAIL_COMPATIBLE_CRC
 		xfer->xferUser( this, sizeof( *this ) );
+#else
+		xfer->xferUser( this, sizeof( this ) );
+#endif
 
 	}
 	else

--- a/Generals/Code/GameEngine/Include/Common/BitFlagsIO.h
+++ b/Generals/Code/GameEngine/Include/Common/BitFlagsIO.h
@@ -214,7 +214,7 @@ void BitFlags<NUMBITS>::xfer(Xfer* xfer)
 	{
 
 		// just call the xfer implementation on the data values
-#if RETAIL_COMPATIBLE_XFER_SAVE
+#if RETAIL_COMPATIBLE_CRC
 		xfer->xferUser( this, sizeof( this ) );
 #else
 		xfer->xferUser( this, sizeof( *this ) );

--- a/Generals/Code/GameEngine/Include/Common/BitFlagsIO.h
+++ b/Generals/Code/GameEngine/Include/Common/BitFlagsIO.h
@@ -214,12 +214,10 @@ void BitFlags<NUMBITS>::xfer(Xfer* xfer)
 	{
 
 		// just call the xfer implementation on the data values
-		// TheSuperHackers @bugfix bobtista 05/12/2025 Fix sizeof(this) bug
-		// Original code used sizeof(this) which is pointer size
-#ifndef RETAIL_COMPATIBLE_CRC
-		xfer->xferUser( this, sizeof( *this ) );
-#else
+#if RETAIL_COMPATIBLE_XFER_SAVE
 		xfer->xferUser( this, sizeof( this ) );
+#else
+		xfer->xferUser( this, sizeof( *this ) );
 #endif
 
 	}

--- a/GeneralsMD/Code/GameEngine/Include/Common/BitFlagsIO.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/BitFlagsIO.h
@@ -214,7 +214,7 @@ void BitFlags<NUMBITS>::xfer(Xfer* xfer)
 	{
 
 		// just call the xfer implementation on the data values
-		xfer->xferUser( this, sizeof( this ) );
+		xfer->xferUser( this, sizeof( *this ) );
 
 	}
 	else

--- a/GeneralsMD/Code/GameEngine/Include/Common/BitFlagsIO.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/BitFlagsIO.h
@@ -214,7 +214,13 @@ void BitFlags<NUMBITS>::xfer(Xfer* xfer)
 	{
 
 		// just call the xfer implementation on the data values
+		// TheSuperHackers @bugfix bobtista 05/12/2025 Fix sizeof(this) bug
+		// Original code used sizeof(this) which is pointer size
+#ifndef RETAIL_COMPATIBLE_CRC
 		xfer->xferUser( this, sizeof( *this ) );
+#else
+		xfer->xferUser( this, sizeof( this ) );
+#endif
 
 	}
 	else

--- a/GeneralsMD/Code/GameEngine/Include/Common/BitFlagsIO.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/BitFlagsIO.h
@@ -214,7 +214,7 @@ void BitFlags<NUMBITS>::xfer(Xfer* xfer)
 	{
 
 		// just call the xfer implementation on the data values
-#if RETAIL_COMPATIBLE_XFER_SAVE
+#if RETAIL_COMPATIBLE_CRC
 		xfer->xferUser( this, sizeof( this ) );
 #else
 		xfer->xferUser( this, sizeof( *this ) );

--- a/GeneralsMD/Code/GameEngine/Include/Common/BitFlagsIO.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/BitFlagsIO.h
@@ -214,12 +214,10 @@ void BitFlags<NUMBITS>::xfer(Xfer* xfer)
 	{
 
 		// just call the xfer implementation on the data values
-		// TheSuperHackers @bugfix bobtista 05/12/2025 Fix sizeof(this) bug
-		// Original code used sizeof(this) which is pointer size
-#ifndef RETAIL_COMPATIBLE_CRC
-		xfer->xferUser( this, sizeof( *this ) );
-#else
+#if RETAIL_COMPATIBLE_XFER_SAVE
 		xfer->xferUser( this, sizeof( this ) );
+#else
+		xfer->xferUser( this, sizeof( *this ) );
 #endif
 
 	}


### PR DESCRIPTION
### 1 `Core/Libraries/Source/WWVegas/WWLib/always.h:147`
- Affects ~500+ classes using this macro for memory pool allocation.
- Return value unused, and CI replays passed, so it seems safe.

### 2. BitFlags CRC Calculation (`BitFlagsIO.h`)
- CRC calculation used `sizeof(this)`, causing incomplete CRC hashing.
- Behind retail compat flag