### PR TITLE
refactor: improve code readability with clang-tidy fixes

### DIFF
--- a/Core/GameEngine/Source/Common/Audio/AudioEventRTS.cpp
+++ b/Core/GameEngine/Source/Common/Audio/AudioEventRTS.cpp
@@ -329,7 +329,7 @@ void AudioEventRTS::generateFilename( void )
 		adjustForLocalization(m_filenameToLoad);
 		return;
 	} else {
-		if (m_eventInfo->m_sounds.size() == 0) {
+		if (m_eventInfo->m_sounds.empty()) {
 			m_filenameToLoad = AsciiString::TheEmptyString;
 			return;
 		}

--- a/Core/GameEngine/Source/Common/System/GameMemory.cpp
+++ b/Core/GameEngine/Source/Common/System/GameMemory.cpp
@@ -2681,7 +2681,7 @@ MemoryPool *MemoryPoolFactory::findMemoryPool(const char *poolName)
 {
 	for (MemoryPool *pool = m_firstPoolInFactory; pool; pool = pool->getNextPoolInList())
 	{
-		if (!strcmp(poolName, pool->getPoolName()))
+		if (strcmp(poolName, pool->getPoolName()) == 0)
 		{
 			DEBUG_ASSERTCRASH(poolName == pool->getPoolName(), ("hmm, ptrs should probably match here"));
 			return pool;

--- a/Core/GameEngine/Source/Common/System/Xfer.cpp
+++ b/Core/GameEngine/Source/Common/System/Xfer.cpp
@@ -395,7 +395,7 @@ void Xfer::xferSTLObjectIDVector( std::vector<ObjectID> *objectIDVectorData )
 	{
 
 		// sanity, the list should be empty before we transfer more data into it
-		if( objectIDVectorData->size() != 0 )
+		if( !objectIDVectorData->empty() )
 		{
 
 			DEBUG_CRASH(( "Xfer::xferSTLObjectIDList - object vector should be empty before loading" ));
@@ -462,7 +462,7 @@ void Xfer::xferSTLObjectIDList( std::list< ObjectID > *objectIDListData )
 	{
 
 		// sanity, the list should be empty before we transfer more data into it
-		if( objectIDListData->size() != 0 )
+		if( !objectIDListData->empty() )
 		{
 
 			DEBUG_CRASH(( "Xfer::xferSTLObjectIDList - object list should be empty before loading" ));
@@ -528,7 +528,7 @@ void Xfer::xferSTLIntList( std::list< Int > *intListData )
 	{
 
 		// sanity, the list should be empty before we transfer more data into it
-		if( intListData->size() != 0 )
+		if( !intListData->empty() )
 		{
 
 			DEBUG_CRASH(( "Xfer::xferSTLIntList - int list should be empty before loading" ));

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/LadderDefs.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/LadderDefs.cpp
@@ -163,7 +163,7 @@ static LadderInfo *parseLadder(AsciiString raw)
 			// end of a ladder
 			if (lad->playersPerTeam >= 1 && lad->playersPerTeam <= MAX_SLOTS/2)
 			{
-				if (lad->validFactions.size() == 0)
+				if (lad->validFactions.empty())
 				{
 					DEBUG_LOG(("No factions specified.  Using all."));
 					lad->validFactions.clear();
@@ -190,7 +190,7 @@ static LadderInfo *parseLadder(AsciiString raw)
 					}
 				}
 
-				if (lad->validMaps.size() == 0)
+				if (lad->validMaps.empty())
 				{
 					DEBUG_LOG(("No maps specified.  Using all."));
 					std::list<AsciiString> qmMaps = TheGameSpyConfig->getQMMaps();
@@ -503,7 +503,7 @@ void LadderList::checkLadder( AsciiString fname, Int index )
 		return;
 	}
 
-	if (li->validMaps.size() == 0)
+	if (li->validMaps.empty())
 	{
 		DEBUG_LOG(("Bailing because of li->validMaps.size() == 0"));
 		delete li;

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/MainMenuUtils.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/MainMenuUtils.cpp
@@ -191,7 +191,7 @@ static void startOnline( void )
 			noPatchBeforeOnlineCallback);
 		return;
 	}
-	if (queuedDownloads.size())
+	if (!queuedDownloads.empty())
 	{
 		if (!hasWriteAccess())
 		{

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/PeerDefs.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/PeerDefs.cpp
@@ -340,7 +340,7 @@ void GameSpyInfo::addGroupRoom( GameSpyGroupRoom room )
 		groupLabel.format("GUI:%s", room.m_name.str());
 		room.m_translatedName = TheGameText->fetch(groupLabel);
 		m_groupRooms[room.m_groupID] = room;
-		if ( !stricmp("quickmatch", room.m_name.str()) )
+		if ( stricmp("quickmatch", room.m_name.str()) == 0 )
 		{
 			DEBUG_LOG(("Group room %d (%s) is the QuickMatch room", room.m_groupID, room.m_name.str()));
 			TheGameSpyConfig->setQMChannel(room.m_groupID);
@@ -378,7 +378,7 @@ void GameSpyInfo::joinBestGroupRoom( void )
 		return;
 	}
 
-	if (m_groupRooms.size())
+	if (!m_groupRooms.empty())
 	{
 		int minID = -1;
 		int minPlayers = 1000;

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
@@ -471,7 +471,7 @@ Int PeerThreadClass::findServer( SBServer server )
 			UnsignedInt oldPrivateIP = SBServerGetPrivateInetAddress(it->second);
 			UnsignedShort oldPrivatePort = SBServerGetPrivateQueryPort(it->second);
 			UnsignedInt oldPublicIP = SBServerGetPublicInetAddress(it->second);
-			if (!strcmp(oldName, newName) &&
+			if (strcmp(oldName, newName) == 0 &&
 				oldPrivateIP == newPrivateIP &&
 				oldPublicIP == newPublicIP &&
 				oldPrivatePort == newPrivatePort)
@@ -1663,7 +1663,7 @@ void PeerThreadClass::Thread_Function()
 							m_playerFactions[i] = 0;
 							m_playerColors[i] = 0;
 						}
-						if (incomingRequest.password.length() > 0)
+						if (!incomingRequest.password.empty())
 							m_hasPassword = true;
 						else
 							m_hasPassword = false;
@@ -1714,7 +1714,7 @@ void PeerThreadClass::Thread_Function()
 
 			case PeerRequest::PEERREQUEST_UTMPLAYER:
 				{
-					if (incomingRequest.nick.length() > 0)
+					if (!incomingRequest.nick.empty())
 					{
 						peerUTMPlayer( peer, incomingRequest.nick.c_str(), incomingRequest.id.c_str(), incomingRequest.options.c_str(), PEERFalse );
 					}
@@ -1842,7 +1842,7 @@ void PeerThreadClass::handleQMMatch(PEER peer, Int mapIndex, Int seed,
 		Int i=0;
 		for (; i<MAX_SLOTS; ++i)
 		{
-			if (playerName[i] && stricmp(playerName[i], m_loginName.c_str()))
+			if (playerName[i] && stricmp(playerName[i], m_loginName.c_str()) != 0)
 			{
 				peerMessagePlayer( peer, playerName[i], "We're matched!", NormalMessage );
 			}
@@ -2705,7 +2705,7 @@ void playerLeftCallback(PEER peer, RoomType roomType, const char * nick, const c
 
 	if (t->getQMStatus() != QM_IDLE && t->getQMStatus() != QM_STOPPED)
 	{
-		if (!stricmp(t->getQMBotName().c_str(), nick))
+		if (stricmp(t->getQMBotName().c_str(), nick) == 0)
 		{
 			// matchbot left - bail
 			PeerResponse resp;
@@ -2845,9 +2845,9 @@ static void listingGamesCallback(PEER peer, PEERBool success, const char * name,
 		DEBUG_LOG(("Game name is '%s'", name));
 		const char *newname = SBServerGetStringValue(server, "gamename", (char *)name);
 #if RTS_GENERALS
-		if (strcmp(newname, "ccgenerals"))
+		if (strcmp(newname, "ccgenerals") != 0)
 #elif RTS_ZEROHOUR
-		if (strcmp(newname, "ccgenzh"))
+		if (strcmp(newname, "ccgenzh") != 0)
 #endif
 			name = newname;
 		DEBUG_LOG(("Game name is now '%s'", name));

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PersistentStorageThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PersistentStorageThread.cpp
@@ -102,12 +102,12 @@ static void debugDumpPlayerStats( const PSPlayerStats& stats )
 		DEBUG_LOG(("gamesAsRandom: %d", stats.gamesAsRandom));
 	}
 
-	if (stats.options.length())
+	if (!stats.options.empty())
 	{
 		DEBUG_LOG(("Options: %s", stats.options.c_str()));
 	}
 
-	if (stats.systemSpec.length())
+	if (!stats.systemSpec.empty())
 	{
 		DEBUG_LOG(("systemSpec: %s", stats.systemSpec.c_str()));
 	}
@@ -184,7 +184,7 @@ static void debugDumpPlayerStats( const PSPlayerStats& stats )
 		DEBUG_LOG(("lastLadderPort: %d", stats.lastLadderPort));
 	}
 
-	if (stats.lastLadderHost.length())
+	if (!stats.lastLadderHost.empty())
 	{
 		DEBUG_LOG(("lastLadderHost: %s", stats.lastLadderHost.c_str()));
 	}
@@ -246,12 +246,12 @@ void PSPlayerStats::incorporate( const PSPlayerStats& other )
 		gamesAsRandom = other.gamesAsRandom;
 	}
 
-	if (other.options.length())
+	if (!other.options.empty())
 	{
 		options = other.options;
 	}
 
-	if (other.systemSpec.length())
+	if (!other.systemSpec.empty())
 	{
 		systemSpec = other.systemSpec;
 	}
@@ -325,7 +325,7 @@ void PSPlayerStats::incorporate( const PSPlayerStats& other )
 	{
 		lastLadderPort = other.lastLadderPort;
 	}
-	if (other.lastLadderHost.length())
+	if (!other.lastLadderHost.empty())
 	{
 		lastLadderHost = other.lastLadderHost;
 	}
@@ -971,7 +971,7 @@ void PSThreadClass::Thread_Function()
 								addedInDesyncs4 + req.addDesync, addedInDiscons4 + req.addDiscon));
 						}
 						pref.write();
-						if (req.password.size() == 0)
+						if (req.password.empty())
 							return;
 					}
 					if (!req.player.id)
@@ -1370,13 +1370,13 @@ std::string GameSpyPSMessageQueueInterface::formatPlayerKVPairs( PSPlayerStats s
 		s.append(kvbuf);
 	}
 
-	if (stats.options.length())
+	if (!stats.options.empty())
 	{
 		snprintf(kvbuf, 256, "\\options\\%s", stats.options.c_str());
 		s.append(kvbuf);
 	}
 
-	if (stats.systemSpec.length())
+	if (!stats.systemSpec.empty())
 	{
 		snprintf(kvbuf, 256, "\\systemSpec\\%s", stats.systemSpec.c_str());
 		s.append(kvbuf);
@@ -1472,7 +1472,7 @@ std::string GameSpyPSMessageQueueInterface::formatPlayerKVPairs( PSPlayerStats s
 		sprintf(kvbuf, "\\ladderPort\\%d", stats.lastLadderPort);
 		s.append(kvbuf);
 	}
-	if (stats.lastLadderHost.length())
+	if (!stats.lastLadderHost.empty())
 	{
 		snprintf(kvbuf, 256, "\\ladderHost\\%s", stats.lastLadderHost.c_str());
 		s.append(kvbuf);

--- a/Core/GameEngine/Source/GameNetwork/NAT.cpp
+++ b/Core/GameEngine/Source/GameNetwork/NAT.cpp
@@ -1169,7 +1169,7 @@ void NAT::processGlobalMessage(Int slotNum, const char *options) {
 		++ptr;
 	}
 	DEBUG_LOG(("NAT::processGlobalMessage - got message from slot %d, message is \"%s\"", slotNum, ptr));
-	if (!strncmp(ptr, "PROBED", strlen("PROBED"))) {
+	if (strncmp(ptr, "PROBED", strlen("PROBED")) == 0) {
 		// format: PROBED<node number>
 		// a probe has been sent at us, if we are waiting because of a netgear or something, we
 		// should start sending our own probes.
@@ -1180,7 +1180,7 @@ void NAT::processGlobalMessage(Int slotNum, const char *options) {
 		} else {
 			DEBUG_LOG(("NAT::processGlobalMessage - probed by node %d, not our target", node));
 		}
-	} else if (!strncmp(ptr, "CONNDONE", strlen("CONNDONE"))) {
+	} else if (strncmp(ptr, "CONNDONE", strlen("CONNDONE")) == 0) {
 		// format: CONNDONE<node number>
 		// we should get the node number of the player who's connection is done from the options
 		// and mark that down as part of the connectionStates.
@@ -1205,7 +1205,7 @@ void NAT::processGlobalMessage(Int slotNum, const char *options) {
 		} else {
 			DEBUG_LOG(("NAT::processGlobalMessage - got a connection done message that isn't from this round. node: %d sending node: %d", node, sendingNode));
 		}
-	} else if (!strncmp(ptr, "CONNFAILED", strlen("CONNFAILED"))) {
+	} else if (strncmp(ptr, "CONNFAILED", strlen("CONNFAILED")) == 0) {
 		// format: CONNFAILED<node number>
 		// we should get the node number of the player who's connection failed from the options
 		// and mark that down as part of the connectionStates.
@@ -1214,7 +1214,7 @@ void NAT::processGlobalMessage(Int slotNum, const char *options) {
 			DEBUG_LOG(("NAT::processGlobalMessage - node %d's connection failed, setting connection state to failed", node));
 			setConnectionState(node, NATCONNECTIONSTATE_FAILED);
 		}
-	} else if (!strncmp(ptr, "PORT", strlen("PORT"))) {
+	} else if (strncmp(ptr, "PORT", strlen("PORT")) == 0) {
 		// format: PORT<node number> <port number> <internal IP>
 		// we should get the node number and the mangled port number of the client we
 		// are supposed to be communicating with and start probing them. No, that was not

--- a/Core/GameEngineDevice/Source/StdDevice/Common/StdLocalFileSystem.cpp
+++ b/Core/GameEngineDevice/Source/StdDevice/Common/StdLocalFileSystem.cpp
@@ -241,7 +241,7 @@ void StdLocalFileSystem::getFileListInDirectory(const AsciiString& currentDirect
 	while (!done)	{
 		std::string filenameStr = iter->path().filename().string();
 		if (!iter->is_directory() && iter->path().extension() == searchExt &&
-			(strcmp(filenameStr.c_str(), ".") && strcmp(filenameStr.c_str(), ".."))) {
+			(strcmp(filenameStr.c_str(), ".") != 0 && strcmp(filenameStr.c_str(), ".."))) {
 			// if we haven't already, add this filename to the list.
 			// a stl set should only allow one copy of each filename
 			AsciiString newFilename = iter->path().string().c_str();
@@ -268,7 +268,7 @@ void StdLocalFileSystem::getFileListInDirectory(const AsciiString& currentDirect
 		while (!done) {
 			std::string filenameStr = iter->path().filename().string();
 			if(iter->is_directory() &&
-				(strcmp(filenameStr.c_str(), ".") && strcmp(filenameStr.c_str(), ".."))) {
+				(strcmp(filenameStr.c_str(), ".") != 0 && strcmp(filenameStr.c_str(), ".."))) {
 				AsciiString tempsearchstr(filenameStr.c_str());
 
 				// recursively add files in subdirectories if required.
@@ -323,7 +323,7 @@ Bool StdLocalFileSystem::createDirectory(AsciiString directory)
 	std::replace(fixedDirectory.begin(), fixedDirectory.end(), '\\', '/');
 #endif
 
-	if ((fixedDirectory.length() > 0) && (fixedDirectory.length() < _MAX_DIR)) {
+	if ((!fixedDirectory.empty()) && (fixedDirectory.length() < _MAX_DIR)) {
 		// Convert to host path
 		std::filesystem::path path(std::move(fixedDirectory));
 

--- a/Core/GameEngineDevice/Source/Win32Device/Common/Win32LocalFileSystem.cpp
+++ b/Core/GameEngineDevice/Source/Win32Device/Common/Win32LocalFileSystem.cpp
@@ -139,7 +139,7 @@ void Win32LocalFileSystem::getFileListInDirectory(const AsciiString& currentDire
 
 	while (!done)	{
 		if (!(findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) &&
-				(strcmp(findData.cFileName, ".") && strcmp(findData.cFileName, ".."))) {
+				(strcmp(findData.cFileName, ".") != 0 && strcmp(findData.cFileName, ".."))) {
 			// if we haven't already, add this filename to the list.
 				// a stl set should only allow one copy of each filename
 				AsciiString newFilename;
@@ -165,7 +165,7 @@ void Win32LocalFileSystem::getFileListInDirectory(const AsciiString& currentDire
 
 		while (!done) {
 			if ((findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) &&
-					(strcmp(findData.cFileName, ".") && strcmp(findData.cFileName, ".."))) {
+					(strcmp(findData.cFileName, ".") != 0 && strcmp(findData.cFileName, ".."))) {
 
 					AsciiString tempsearchstr;
 					tempsearchstr.concat(currentDirectory);

--- a/Core/Libraries/Source/WWVegas/WWDownload/Download.cpp
+++ b/Core/Libraries/Source/WWVegas/WWDownload/Download.cpp
@@ -47,7 +47,7 @@ HRESULT CDownload::DownloadFile(LPCSTR server, LPCSTR username, LPCSTR password,
 	// If we're still connected, make sure we're on the right server
 	if (m_Status == DOWNLOADSTATUS_FINDINGFILE)
 	{
-		if ((strcmp(m_Server, server)) || (strcmp(m_Login, username)))
+		if ((strcmp(m_Server, server) != 0) || (strcmp(m_Login, username)))
 		{
 			// Damn, a server switch.  Close conn & fix state
 			m_Ftp->DisconnectFromServer();

--- a/Core/Libraries/Source/WWVegas/WWLib/argv.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/argv.cpp
@@ -103,7 +103,7 @@ const char *ArgvClass::Find_Again(const char *arg)
 			if (Is_Exact_Size()) {
 				// Case Sensitive, Exact Size.
 				for (; CurrentPos < Argc; CurrentPos++) {
-					if (!strcmp(arg, Argv[CurrentPos])) {
+					if (strcmp(arg, Argv[CurrentPos]) == 0) {
 						return Argv[CurrentPos];
 					}
 				}
@@ -111,7 +111,7 @@ const char *ArgvClass::Find_Again(const char *arg)
 				// Case Sensitive, Match first strlen(arg).
 				int len = strlen(arg);
 				for (; CurrentPos < Argc; CurrentPos++) {
-					if (!strncmp(arg, Argv[CurrentPos], len)) {
+					if (strncmp(arg, Argv[CurrentPos], len) == 0) {
 						return Argv[CurrentPos];
 					}
 				}
@@ -120,7 +120,7 @@ const char *ArgvClass::Find_Again(const char *arg)
 			if (Is_Exact_Size()) {
 				// Note case sensitive, Exact Size.
 				for (; CurrentPos < Argc; CurrentPos++) {
-					if (!stricmp(arg, Argv[CurrentPos])) {
+					if (stricmp(arg, Argv[CurrentPos]) == 0) {
 						return Argv[CurrentPos];
 					}
 				}
@@ -128,7 +128,7 @@ const char *ArgvClass::Find_Again(const char *arg)
 				// Note case sensitive, Match first strlen(arg).
 				int len = strlen(arg);
 				for (; CurrentPos < Argc; CurrentPos++) {
-					if (!strnicmp(arg, Argv[CurrentPos], len)) {
+					if (strnicmp(arg, Argv[CurrentPos], len) == 0) {
 						return Argv[CurrentPos];
 					}
 				}
@@ -201,7 +201,7 @@ int ArgvClass::Init(char *lpCmdLine, const char *fileprefix)
 		bool was_file = false;
 
 		// See if we are to load a file with parameters in it.
-		if (fp_cmp_len && !strncmp(fileprefix, ptr, fp_cmp_len)) {
+		if (fp_cmp_len && strncmp(fileprefix, ptr, fp_cmp_len) == 0) {
 			ptr += fp_cmp_len;
 			if (*ptr) {
 				was_file = Load_File(ptr);

--- a/Core/Libraries/Source/WWVegas/WWLib/cpudetect.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/cpudetect.cpp
@@ -1113,7 +1113,7 @@ void CPUDetectClass::Init_Compact_Log()
 	Get_OS_Info(os_info,OSVersionPlatformId,OSVersionNumberMajor,OSVersionNumberMinor,OSVersionBuildNumber);
 	COMPACTLOG(("%s\t",os_info.Code));
 
-	if (!stricmp(os_info.SubCode,"UNKNOWN")) {
+	if (stricmp(os_info.SubCode,"UNKNOWN") == 0) {
 		COMPACTLOG(("%d\t",OSVersionBuildNumber&0xffff));
 	}
 	else {

--- a/Core/Libraries/Source/WWVegas/WWLib/ini.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/ini.cpp
@@ -1637,7 +1637,7 @@ bool INIClass::Put_String(char const * section, char const * entry, char const *
 	*/
 	INIEntry * entryptr = secptr->Find_Entry(entry);
 	if (entryptr != NULL) {
-      if (strcmp(entryptr->Entry, entry)) {
+      if (strcmp(entryptr->Entry, entry) != 0) {
          DuplicateCRCError("INIClass::Put_String", section, entry);
       } else {
 #if 0

--- a/Core/Libraries/Source/debug/debug_cmd.cpp
+++ b/Core/Libraries/Source/debug/debug_cmd.cpp
@@ -39,7 +39,7 @@ bool DebugCmdInterfaceDebug::Execute(class Debug& dbg, const char *cmd,
   // just for convenience...
   bool normalMode=cmdmode==CommandMode::Normal;
 
-  if (!strcmp(cmd,"help"))
+  if (strcmp(cmd,"help") == 0)
   {
     if (!normalMode)
       return true;
@@ -50,7 +50,7 @@ bool DebugCmdInterfaceDebug::Execute(class Debug& dbg, const char *cmd,
              "  list, io, alwaysflush, timestamp, exit, clear, add, view\n";
       return true;
     }
-    else if (!strcmp(argv[0],"list"))
+    else if (strcmp(argv[0],"list") == 0)
     {
       dbg << "list (g|l|d|a|c) [ <pattern> ]\n"
              "\n"
@@ -72,7 +72,7 @@ bool DebugCmdInterfaceDebug::Execute(class Debug& dbg, const char *cmd,
              "e.g. debug.cpp(13).\n";
       return true;
     }
-    else if (!strcmp(argv[0],"io"))
+    else if (strcmp(argv[0],"io") == 0)
     {
       dbg << "io <I/O Class> <cmd> { <param> }]\n"
              "\n"
@@ -91,33 +91,33 @@ bool DebugCmdInterfaceDebug::Execute(class Debug& dbg, const char *cmd,
              "a list of possible I/O classes.\n";
       return true;
     }
-    else if (!strcmp(argv[0],"alwaysflush"))
+    else if (strcmp(argv[0],"alwaysflush") == 0)
     {
       dbg << "alwaysflush [ (+|-) ]\n\n"
              "Enables/disables flushing after each new entry in\n"
              "the log file (default: off).\n";
       return true;
     }
-    else if (!strcmp(argv[0],"timestamp"))
+    else if (strcmp(argv[0],"timestamp") == 0)
     {
       dbg << "timestamp [ (+|-) ]\n\n"
              "Enables/disables timestamping each log entry\n"
              "(default: off).\n";
       return true;
     }
-    else if (!strcmp(argv[0],"exit"))
+    else if (strcmp(argv[0],"exit") == 0)
     {
       dbg << "exit\n\nExits program immediately.\n";
       return true;
     }
-    else if (!strcmp(argv[0],"clear"))
+    else if (strcmp(argv[0],"clear") == 0)
     {
       dbg << "clear (l|a|c)\n\n"
              "Clears the given inclusion/exclusion list\n"
              "(l=logs, a=asserts/crashes, c=checks).\n";
       return true;
     }
-    else if (!strcmp(argv[0],"add"))
+    else if (strcmp(argv[0],"add") == 0)
     {
       dbg << "add (l|a|c) (+|-) <pattern>\n"
              "\n"
@@ -132,7 +132,7 @@ bool DebugCmdInterfaceDebug::Execute(class Debug& dbg, const char *cmd,
              "the last match.";
       return true;
     }
-    else if (!strcmp(argv[0],"view"))
+    else if (strcmp(argv[0],"view") == 0)
     {
       dbg << "view [ (l|a|c) ]\n\n"
              "Shows the active pattern for the given list\n"
@@ -141,7 +141,7 @@ bool DebugCmdInterfaceDebug::Execute(class Debug& dbg, const char *cmd,
     }
     return false;
   }
-  if (!strcmp(cmd,"list"))
+  if (strcmp(cmd,"list") == 0)
   {
     const char *pattern=argn>=2?argv[1]:"*";
 
@@ -204,10 +204,10 @@ bool DebugCmdInterfaceDebug::Execute(class Debug& dbg, const char *cmd,
 
     return true;
   }
-  if (!strcmp(cmd,"io"))
+  if (strcmp(cmd,"io") == 0)
   {
     // cmd: io
-    if (!argn||!strcmp(argv[0],"?"))
+    if (!argn||strcmp(argv[0],"?") == 0)
     {
       // show active/all I/O classes
       if (normalMode)
@@ -232,7 +232,7 @@ bool DebugCmdInterfaceDebug::Execute(class Debug& dbg, const char *cmd,
       // find I/O class
       Debug::IOFactoryListEntry *cur=dbg.firstIOFactory;
       for (;cur;cur=cur->next)
-        if (!strcmp(argv[0],cur->ioID))
+        if (strcmp(argv[0],cur->ioID) == 0)
           break;
       if (!cur)
       {
@@ -243,7 +243,7 @@ bool DebugCmdInterfaceDebug::Execute(class Debug& dbg, const char *cmd,
       if (argn>1)
       {
         // 'add' command?
-        if (!strcmp(argv[1],"add"))
+        if (strcmp(argv[1],"add") == 0)
         {
           if (cur->io)
           {
@@ -258,7 +258,7 @@ bool DebugCmdInterfaceDebug::Execute(class Debug& dbg, const char *cmd,
           }
         }
         // 'remove' command?
-        if (!strcmp(argv[1],"remove"))
+        if (strcmp(argv[1],"remove") == 0)
         {
           if (cur->io)
           {
@@ -280,7 +280,7 @@ bool DebugCmdInterfaceDebug::Execute(class Debug& dbg, const char *cmd,
     }
     return true;
   }
-  if (!strcmp(cmd,"alwaysflush"))
+  if (strcmp(cmd,"alwaysflush") == 0)
   {
     if (argn)
     {
@@ -296,7 +296,7 @@ bool DebugCmdInterfaceDebug::Execute(class Debug& dbg, const char *cmd,
 
     return true;
   }
-  if (!strcmp(cmd,"timestamp"))
+  if (strcmp(cmd,"timestamp") == 0)
   {
     if (argn)
     {
@@ -312,14 +312,14 @@ bool DebugCmdInterfaceDebug::Execute(class Debug& dbg, const char *cmd,
 
     return true;
   }
-  if (!strcmp(cmd,"exit"))
+  if (strcmp(cmd,"exit") == 0)
   {
     exit(1);
     return true;
   }
-  if (!strcmp(cmd,"clear")||
-      !strcmp(cmd,"add")||
-      !strcmp(cmd,"view"))
+  if (strcmp(cmd,"clear") == 0||
+      strcmp(cmd,"add") == 0||
+      strcmp(cmd,"view") == 0)
   {
     unsigned mask=0;
     if (argn)
@@ -338,7 +338,7 @@ bool DebugCmdInterfaceDebug::Execute(class Debug& dbg, const char *cmd,
       mask=0xffffffff;
 
     bool modified=false;
-    if (!strcmp(cmd,"clear"))
+    if (strcmp(cmd,"clear") == 0)
     {
       // remove some (or all) pattern
       const char *pattern=argn<2?"*":argv[1];
@@ -368,7 +368,7 @@ bool DebugCmdInterfaceDebug::Execute(class Debug& dbg, const char *cmd,
       else
         dbg.lastPatternEntry=NULL;
     }
-    if (!strcmp(cmd,"add"))
+    if (strcmp(cmd,"add") == 0)
     {
       // add a pattern
       if (argn<3)
@@ -379,7 +379,7 @@ bool DebugCmdInterfaceDebug::Execute(class Debug& dbg, const char *cmd,
         modified=true;
       }
     }
-    if (!strcmp(cmd,"view"))
+    if (strcmp(cmd,"view") == 0)
     {
       // show list of defined patterns
       for (Debug::PatternListEntry *cur=dbg.firstPatternEntry;cur;cur=cur->next)

--- a/Core/Libraries/Source/debug/debug_debug.cpp
+++ b/Core/Libraries/Source/debug/debug_debug.cpp
@@ -526,7 +526,7 @@ Debug& Debug::LogBegin(const char *fileOrGroup)
     // we're doing all this extra work so that DLOGs can be spread across
     // multiple calls
     if (Instance.curType==DebugIOInterface::StringType::Log&&
-        strcmp(Instance.curSource,Instance.curFrameEntry->fileOrGroup))
+        strcmp(Instance.curSource,Instance.curFrameEntry->fileOrGroup) != 0)
       Instance.FlushOutput();
 
     if (Instance.curType!=DebugIOInterface::StringType::Log)
@@ -1227,7 +1227,7 @@ const char *Debug::AddLogGroup(const char *fileOrGroup, const char *descr)
   KnownLogGroupList *cur=firstLogGroup;
   for (;cur;cur=cur->next)
   {
-    if (!strcmp(cur->nameGroup,fileOrGroup))
+    if (strcmp(cur->nameGroup,fileOrGroup) == 0)
     {
       // yes, return translated name
       return cur->nameGroup;
@@ -1547,7 +1547,7 @@ void Debug::ExecCommand(const char *cmdstart, const char *cmdend)
 
     // command group known?
     for (CmdInterfaceListEntry *cur=firstCmdGroup;cur;cur=cur->next)
-      if (!strcmp(curCommandGroup,cur->group))
+      if (strcmp(curCommandGroup,cur->group) == 0)
         break;
     if (!cur)
     {
@@ -1563,18 +1563,18 @@ void Debug::ExecCommand(const char *cmdstart, const char *cmdend)
       // search for a matching command handler
       for (CmdInterfaceListEntry *cur=firstCmdGroup;cur;cur=cur->next)
       {
-        if (strcmp(curCommandGroup,cur->group))
+        if (strcmp(curCommandGroup,cur->group) != 0)
           continue;
 
         bool doneCommand=cur->cmdif->Execute(*this,p,mode,numParts-1,parts+1);
-        if (doneCommand&&(strcmp(p,"help")||numParts>1))
+        if (doneCommand&&(strcmp(p,"help") != 0||numParts>1))
           break;
       }
 
       // display error message if command not found, break away
       if (!cur&&mode==DebugCmdInterface::CommandMode::Normal)
       {
-        if (strcmp(p,"help"))
+        if (strcmp(p,"help") != 0)
           operator<<("Unknown command");
         else if (numParts>1)
           operator<<("Unknown command, help not available");

--- a/Core/Libraries/Source/debug/debug_io_con.cpp
+++ b/Core/Libraries/Source/debug/debug_io_con.cpp
@@ -194,13 +194,13 @@ void DebugIOCon::Write(StringType type, const char *src, const char *str)
 void DebugIOCon::Execute(class Debug& dbg, const char *cmd, bool structuredCmd,
                          unsigned argn, const char * const * argv)
 {
-  if (!cmd||!strcmp(cmd,"help"))
+  if (!cmd||strcmp(cmd,"help") == 0)
   {
     dbg << "con I/O help:\n"
            "  add [ <width> [ <height> ] ]\n"
            "    create con I/O (optionally specifying the window size)\n";
   }
-  else if (!strcmp(cmd,"add"))
+  else if (strcmp(cmd,"add") == 0)
   {
     if (argn>0&&m_allocatedConsole)
     {

--- a/Core/Libraries/Source/debug/debug_io_flat.cpp
+++ b/Core/Libraries/Source/debug/debug_io_flat.cpp
@@ -332,14 +332,14 @@ void DebugIOFlat::EmergencyFlush(void)
 void DebugIOFlat::Execute(class Debug& dbg, const char *cmd, bool structuredCmd,
                           unsigned argn, const char * const * argv)
 {
-  if (!cmd||!strcmp(cmd,"help"))
+  if (!cmd||strcmp(cmd,"help") == 0)
   {
     if (!argn)
       dbg << "flat I/O help:\n"
              "The following I/O commands are defined:\n"
              "  add, copy, splitadd, splitview, splitremove\n"
              "Type in debug.io flat help <cmd> for a detailed command help.\n";
-    else if (!strcmp(argv[0],"add"))
+    else if (strcmp(argv[0],"add") == 0)
       dbg <<
         "add [ <filename> [ <size in kb> ] ]\n\n"
         "Create flat file I/O (optionally specifying file name and file size).\n"
@@ -363,13 +363,13 @@ void DebugIOFlat::Execute(class Debug& dbg, const char *cmd, bool structuredCmd,
         "size memory based ring buffer. This data is flushed out once the \n"
         "program exits. If no size is given then the size of the log file is not \n"
         "limited and any log data is written out immediately.\n";
-    else if (!strcmp(argv[0],"copy"))
+    else if (strcmp(argv[0],"copy") == 0)
       dbg <<
         "copy <directory>\n\n"
         "Copies generated log file(s) into the given directory if the program\n"
         "exists or crashes. If there is already a log file with the same\n"
         "name a unique number is appended to the current log files' name.\n";
-    else if (!strcmp(argv[0],"splitadd"))
+    else if (strcmp(argv[0],"splitadd") == 0)
       dbg <<
         "splitadd <types> <filter> <name> [ <size in kb> ]\n\n"
         "Splits off part of the log data. Multiple splits can be defined. They \n"
@@ -402,16 +402,16 @@ void DebugIOFlat::Execute(class Debug& dbg, const char *cmd, bool structuredCmd,
         "\n"
         "If no size is given then the size of the log file is not limited and \n"
         "any log data is written out immediately.\n";
-    else if (!strcmp(argv[0],"splitview"))
+    else if (strcmp(argv[0],"splitview") == 0)
       dbg << "splitview\n\n"
              "Shows all existing splits in the order they are evaluated.";
-    else if (!strcmp(argv[0],"splitremove"))
+    else if (strcmp(argv[0],"splitremove") == 0)
       dbg << "splitremove <namepattern>\n\n"
              "Removes all active splits matching the given name pattern.";
     else
       dbg << "Unknown flat I/O command";
   }
-  else if (!strcmp(cmd,"add"))
+  else if (strcmp(cmd,"add") == 0)
   {
     // add [ <filename> [ <size in kb> ] ]
     __ASSERT(m_firstStream==NULL);
@@ -426,7 +426,7 @@ void DebugIOFlat::Execute(class Debug& dbg, const char *cmd, bool structuredCmd,
     m_firstStream->stream=OutputStream::Create(fn,argn>1?atoi(argv[1])*1024:0);
     m_lastStreamPtr=&m_firstStream->next;
   }
-  else if (!strcmp(cmd,"copy"))
+  else if (strcmp(cmd,"copy") == 0)
   {
     // copy <directory>
     if (argn)
@@ -434,7 +434,7 @@ void DebugIOFlat::Execute(class Debug& dbg, const char *cmd, bool structuredCmd,
       strlcpy(m_copyDir,argv[0],sizeof(m_copyDir));
     }
   }
-  else if (!strcmp(cmd,"splitadd"))
+  else if (strcmp(cmd,"splitadd") == 0)
   {
     // splitadd <types> <filter> <name> [ <size in kb> ]
     if (argn>=3)
@@ -470,7 +470,7 @@ void DebugIOFlat::Execute(class Debug& dbg, const char *cmd, bool structuredCmd,
       ExpandMagic(m_baseFilename,cur->name,fn);
       StreamListEntry *stream=m_firstStream;
       for (;stream;stream=stream->next)
-        if (!strcmp(stream->stream->GetFilename(),fn))
+        if (strcmp(stream->stream->GetFilename(),fn) == 0)
           break;
       if (!stream)
       {
@@ -484,7 +484,7 @@ void DebugIOFlat::Execute(class Debug& dbg, const char *cmd, bool structuredCmd,
       cur->stream=stream->stream;
     }
   }
-  else if (!strcmp(cmd,"splitview"))
+  else if (strcmp(cmd,"splitview") == 0)
   {
     // splitview
     for (SplitListEntry *cur=m_firstSplit;cur;cur=cur->next)
@@ -507,7 +507,7 @@ void DebugIOFlat::Execute(class Debug& dbg, const char *cmd, bool structuredCmd,
       dbg << " " << cur->items << " " << cur->name << "\n";
     }
   }
-  else if (!strcmp(cmd,"splitremove"))
+  else if (strcmp(cmd,"splitremove") == 0)
   {
     // splitremove <namepattern>
     const char *pattern=argn<1?"*":argv[0];

--- a/Core/Libraries/Source/debug/debug_io_net.cpp
+++ b/Core/Libraries/Source/debug/debug_io_net.cpp
@@ -86,13 +86,13 @@ void DebugIONet::EmergencyFlush(void)
 void DebugIONet::Execute(class Debug& dbg, const char *cmd, bool structuredCmd,
                          unsigned argn, const char * const * argv)
 {
-  if (!cmd||!strcmp(cmd,"help"))
+  if (!cmd||strcmp(cmd,"help") == 0)
   {
     dbg << "net I/O help:\n"
            "  add [ <machine> ]\n"
            "    create net I/O (optionally specifying the machine to connect to)\n";
   }
-  else if (!strcmp(cmd,"add"))
+  else if (strcmp(cmd,"add") == 0)
   {
     const char *machine=argn?argv[0]:".";
 

--- a/Core/Libraries/Source/profile/profile.cpp
+++ b/Core/Libraries/Source/profile/profile.cpp
@@ -166,7 +166,7 @@ void Profile::StartRange(const char *range)
   // known name?
   unsigned k=0;
   for (;k<m_names;++k)
-    if (!strcmp(range,m_frameNames[k].name))
+    if (strcmp(range,m_frameNames[k].name) == 0)
       break;
   if (k==m_names)
   {
@@ -221,7 +221,7 @@ void Profile::AppendRange(const char *range)
   // known name?
   unsigned k=0;
   for (;k<m_names;++k)
-    if (!strcmp(range,m_frameNames[k].name))
+    if (strcmp(range,m_frameNames[k].name) == 0)
       break;
   if (k==m_names)
   {
@@ -272,7 +272,7 @@ void Profile::StopRange(const char *range)
   // known name?
   unsigned k=0;
   for (;k<m_names;++k)
-    if (!strcmp(range,m_frameNames[k].name))
+    if (strcmp(range,m_frameNames[k].name) == 0)
       break;
   DFAIL_IF(k==m_names) return;
   DFAIL_IF(!m_frameNames[k].isRecording) return;

--- a/Core/Libraries/Source/profile/profile_cmd.cpp
+++ b/Core/Libraries/Source/profile/profile_cmd.cpp
@@ -38,7 +38,7 @@ void ProfileCmdInterface::AddResultFunction(ProfileResultInterface* (*func)(int,
   DFAIL_IF(!func) return;
   DFAIL_IF(!name) return;
   for (unsigned k=0;k<numResIf;k++)
-    if (!strcmp(resIf[k].name,name))
+    if (strcmp(resIf[k].name,name) == 0)
       return;
   ++numResIf;
   resIf=(Factory *)ProfileReAllocMemory(resIf,numResIf*sizeof(Factory));
@@ -67,7 +67,7 @@ bool ProfileCmdInterface::Execute(class Debug& dbg, const char *cmd, CommandMode
   // just for convenience...
   bool normalMode=cmdmode==CommandMode::Normal;
 
-  if (!strcmp(cmd,"help"))
+  if (strcmp(cmd,"help") == 0)
   {
     if (!normalMode)
       return true;
@@ -78,7 +78,7 @@ bool ProfileCmdInterface::Execute(class Debug& dbg, const char *cmd, CommandMode
              "  result, caller, clear, add, view\n";
       return true;
     }
-    else if (!strcmp(argv[0],"result"))
+    else if (strcmp(argv[0],"result") == 0)
     {
       dbg << "result\n\n"
              "Shows the list of available result functions and their\n"
@@ -88,20 +88,20 @@ bool ProfileCmdInterface::Execute(class Debug& dbg, const char *cmd, CommandMode
              "Adds the given result function to be executed on program\n"
              "exit.\n";
     }
-    else if (!strcmp(argv[0],"caller"))
+    else if (strcmp(argv[0],"caller") == 0)
     {
       dbg << "caller [ (+|-) ]\n\n"
              "Enables/disables recording of caller information while\n"
              "performing function level profiling. Turned off by default\n"
              "since CPU hit is non-zero.\n";
     }
-    else if (!strcmp(argv[0],"clear"))
+    else if (strcmp(argv[0],"clear") == 0)
     {
       dbg << "clear\n\n"
              "Clears the profile inclusion/exclusion list.\n";
       return true;
     }
-    else if (!strcmp(argv[0],"add"))
+    else if (strcmp(argv[0],"add") == 0)
     {
       dbg << "add (+|-) <pattern>\n"
              "\n"
@@ -112,7 +112,7 @@ bool ProfileCmdInterface::Execute(class Debug& dbg, const char *cmd, CommandMode
              "- for inactive). The final state is always the last match.";
       return true;
     }
-    else if (!strcmp(argv[0],"view"))
+    else if (strcmp(argv[0],"view") == 0)
     {
       dbg << "view\n\n"
              "Shows the active pattern list.\n";
@@ -122,7 +122,7 @@ bool ProfileCmdInterface::Execute(class Debug& dbg, const char *cmd, CommandMode
   }
 
   // command: result
-  if (!strcmp(cmd,"result"))
+  if (strcmp(cmd,"result") == 0)
   {
     if (!argn)
     {
@@ -139,7 +139,7 @@ bool ProfileCmdInterface::Execute(class Debug& dbg, const char *cmd, CommandMode
     {
       unsigned k=0;
       for (;k<numResIf;k++)
-        if (!strcmp(argv[0],resIf[k].name))
+        if (strcmp(argv[0],resIf[k].name) == 0)
           break;
       if (k==numResIf)
       {
@@ -165,7 +165,7 @@ bool ProfileCmdInterface::Execute(class Debug& dbg, const char *cmd, CommandMode
   }
 
   // command: caller
-  if (!strcmp(cmd,"caller"))
+  if (strcmp(cmd,"caller") == 0)
   {
 #ifdef HAS_PROFILE
     if (argn)
@@ -185,7 +185,7 @@ bool ProfileCmdInterface::Execute(class Debug& dbg, const char *cmd, CommandMode
   }
 
   // command: clear
-  if (!strcmp(cmd,"clear"))
+  if (strcmp(cmd,"clear") == 0)
   {
     // remove some (or all) pattern
     const char *pattern=argn<1?"*":argv[0];
@@ -216,7 +216,7 @@ bool ProfileCmdInterface::Execute(class Debug& dbg, const char *cmd, CommandMode
   }
 
   // command: add
-  if (!strcmp(cmd,"add"))
+  if (strcmp(cmd,"add") == 0)
   {
     // add a pattern
     if (argn<2)
@@ -244,7 +244,7 @@ bool ProfileCmdInterface::Execute(class Debug& dbg, const char *cmd, CommandMode
   }
 
   // command: view
-  if (!strcmp(cmd,"view"))
+  if (strcmp(cmd,"view") == 0)
   {
     // show list of defined patterns
     for (Profile::PatternListEntry *cur=Profile::firstPatternEntry;cur;cur=cur->next)

--- a/Core/Libraries/Source/profile/profile_highlevel.cpp
+++ b/Core/Libraries/Source/profile/profile_highlevel.cpp
@@ -324,7 +324,7 @@ bool ProfileHighLevel::FindProfile(const char *name, Id &id)
 
   ProfileFastCS::Lock lock(cs);
   for (ProfileId *cur=ProfileId::GetFirst();cur;cur=cur->GetNext())
-    if (!strcmp(name,cur->GetName()))
+    if (strcmp(name,cur->GetName()) == 0)
     {
       id.m_idPtr=cur;
       return true;

--- a/Core/Libraries/Source/profile/profile_result.cpp
+++ b/Core/Libraries/Source/profile/profile_result.cpp
@@ -196,7 +196,7 @@ void ProfileResultFileDOT::WriteResults(void)
   if (m_frameName)
   {
     for (unsigned k=0;k<Profile::GetFrameCount();k++)
-      if (!strcmp(Profile::GetFrameName(k),m_frameName))
+      if (strcmp(Profile::GetFrameName(k),m_frameName) == 0)
       {
         frame=k;
         break;
@@ -232,7 +232,7 @@ void ProfileResultFileDOT::WriteResults(void)
       const char *source=id.GetSource();
       FoldHelper *cur=fold;
       for (;cur;cur=cur->next)
-        if (!strcmp(source,cur->source))
+        if (strcmp(source,cur->source) == 0)
         {
           if (cur->numId<MAX_FUNCTIONS_PER_FILE)
             cur->id[cur->numId++]=id;
@@ -264,7 +264,7 @@ void ProfileResultFileDOT::WriteResults(void)
         {
           const char *s=caller.GetSource();
           for (FoldHelper *cur2=fold;cur2;cur2=cur2->next)
-            if (!strcmp(cur2->source,s))
+            if (strcmp(cur2->source,s) == 0)
               break;
           if (!cur2||cur2->mark)
             continue;

--- a/Core/Tools/ImagePacker/Source/ImagePacker.cpp
+++ b/Core/Tools/ImagePacker/Source/ImagePacker.cpp
@@ -385,8 +385,8 @@ void ImagePacker::addImagesInDirectory( char *dir )
 
 		// if this is a file count it
 		if( !(item.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) &&
-				strcmp( item.cFileName, "." ) &&
-				strcmp( item.cFileName, ".." ) )
+				strcmp( item.cFileName, "." ) != 0 &&
+				strcmp( item.cFileName, ".." ) != 0 )
 		{
 
 			len = strlen( item.cFileName );
@@ -410,8 +410,8 @@ void ImagePacker::addImagesInDirectory( char *dir )
 
 			// if this is a file count it
 			if( !(item.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) &&
-					strcmp( item.cFileName, "." ) &&
-					strcmp( item.cFileName, ".." ) )
+					strcmp( item.cFileName, "." ) != 0 &&
+					strcmp( item.cFileName, ".." ) != 0 )
 			{
 
 				len = strlen( item.cFileName );
@@ -473,8 +473,8 @@ Bool ImagePacker::checkOutputDirectory( void )
 
 		// if this is a file count it
 		if( !(item.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) &&
-				 strcmp( item.cFileName, "." ) &&
-				 strcmp( item.cFileName, ".." ) )
+				 strcmp( item.cFileName, "." ) != 0 &&
+				 strcmp( item.cFileName, ".." ) != 0 )
 			fileCount++;
 
 		// find the rest of the files
@@ -483,8 +483,8 @@ Bool ImagePacker::checkOutputDirectory( void )
 
 			// if this is a file count it
 			if( !(item.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) &&
-					 strcmp( item.cFileName, "." ) &&
-					 strcmp( item.cFileName, ".." ) )
+					 strcmp( item.cFileName, "." ) != 0 &&
+					 strcmp( item.cFileName, ".." ) != 0 )
 				fileCount++;
 
 		}
@@ -526,8 +526,8 @@ Bool ImagePacker::checkOutputDirectory( void )
 
 			// if this is a file count it
 			if( !(item.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) &&
-					 strcmp( item.cFileName, "." ) &&
-					 strcmp( item.cFileName, ".." ) )
+					 strcmp( item.cFileName, "." ) != 0 &&
+					 strcmp( item.cFileName, ".." ) != 0 )
 				DeleteFile( item.cFileName );
 
 			// find the rest of the files
@@ -536,8 +536,8 @@ Bool ImagePacker::checkOutputDirectory( void )
 
 				// if this is a file count it
 				if( !(item.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) &&
-						 strcmp( item.cFileName, "." ) &&
-						 strcmp( item.cFileName, ".." ) )
+						 strcmp( item.cFileName, "." ) != 0 &&
+						 strcmp( item.cFileName, ".." ) != 0 )
 					DeleteFile( item.cFileName );
 
 			}
@@ -687,8 +687,8 @@ void ImagePacker::addDirectory( char *path, Bool subDirs )
 
 		// if this is a file count it
 		if( !(item.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) &&
-				strcmp( item.cFileName, "." ) &&
-				strcmp( item.cFileName, ".." ) )
+				strcmp( item.cFileName, "." ) != 0 &&
+				strcmp( item.cFileName, ".." ) != 0 )
 		{
 
 			len = strlen( item.cFileName );
@@ -707,8 +707,8 @@ void ImagePacker::addDirectory( char *path, Bool subDirs )
 
 			// if this is a file count it
 			if( !(item.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) &&
-					strcmp( item.cFileName, "." ) &&
-					strcmp( item.cFileName, ".." ) )
+					strcmp( item.cFileName, "." ) != 0 &&
+					strcmp( item.cFileName, ".." ) != 0 )
 			{
 
 				len = strlen( item.cFileName );
@@ -743,8 +743,8 @@ void ImagePacker::addDirectory( char *path, Bool subDirs )
 
 			// if this is a file count it
 			if( (item.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) &&
-					strcmp( item.cFileName, "." ) &&
-					strcmp( item.cFileName, ".." ) )
+					strcmp( item.cFileName, "." ) != 0 &&
+					strcmp( item.cFileName, ".." ) != 0 )
 			{
 
 				sprintf( subDir, "%s%s\\", path, item.cFileName );
@@ -758,8 +758,8 @@ void ImagePacker::addDirectory( char *path, Bool subDirs )
 
 				// if this is a file count it
 				if( (item.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) &&
-						strcmp( item.cFileName, "." ) &&
-						strcmp( item.cFileName, ".." ) )
+						strcmp( item.cFileName, "." ) != 0 &&
+						strcmp( item.cFileName, ".." ) != 0 )
 				{
 
 					sprintf( subDir, "%s%s\\", path, item.cFileName );

--- a/Generals/Code/GameEngine/Include/GameClient/AnimateWindowManager.h
+++ b/Generals/Code/GameEngine/Include/GameClient/AnimateWindowManager.h
@@ -229,7 +229,7 @@ namespace wnd
 
 	inline Bool AnimateWindowManager::isFinished( void )					{ return !m_needsUpdate;	};
 	inline Bool AnimateWindowManager::isReversed( void )						{ return m_reverse;	};
-	inline Bool AnimateWindowManager::isEmpty( void ){return (m_winList.size() == 0 && m_winMustFinishList.size() == 0);	}
+	inline Bool AnimateWindowManager::isEmpty( void ){return (m_winList.empty() && m_winMustFinishList.empty());	}
 //-----------------------------------------------------------------------------
 // EXTERNALS //////////////////////////////////////////////////////////////////
 //-----------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -3913,7 +3913,7 @@ void Player::xfer( Xfer *xfer )
 	{
 
 		// sanity, list must be empty right now
-		if( m_kindOfPercentProductionChangeList.size() != 0 )
+		if( !m_kindOfPercentProductionChangeList.empty() )
 		{
 
 			DEBUG_CRASH(( "Player::xfer - m_kindOfPercentProductionChangeList should be empty but is not" ));
@@ -3966,7 +3966,7 @@ void Player::xfer( Xfer *xfer )
 		}
 		else
 		{
-			if( m_specialPowerReadyTimerList.size() != 0 ) // sanity, list must be empty right now
+			if( !m_specialPowerReadyTimerList.empty() ) // sanity, list must be empty right now
 			{
 				DEBUG_CRASH(( "Player::xfer - m_specialPowerReadyTimerList should be empty but is not" ));
 				throw SC_INVALID_DATA;

--- a/Generals/Code/GameEngine/Source/Common/RTS/ProductionPrerequisite.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/ProductionPrerequisite.cpp
@@ -128,7 +128,7 @@ Int ProductionPrerequisite::getAllPossibleBuildFacilityTemplates(const ThingTemp
 const ThingTemplate *ProductionPrerequisite::getExistingBuildFacilityTemplate( const Player *player ) const
 {
 	DEBUG_ASSERTCRASH(player, ("player may not be null"));
-	if (m_prereqUnits.size())
+	if (!m_prereqUnits.empty())
 	{
 		Int ownCount[MAX_PREREQ];
 		Int cnt = calcNumPrereqUnitsOwned(player, ownCount);

--- a/Generals/Code/GameEngine/Source/Common/RTS/TunnelTracker.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/TunnelTracker.cpp
@@ -414,7 +414,7 @@ void TunnelTracker::loadPostProcess( void )
 {
 
 	// sanity, the contain list should be empty until we post process the id list
-	if( m_containList.size() != 0 )
+	if( !m_containList.empty() )
 	{
 
 		DEBUG_CRASH(( "TunnelTracker::loadPostProcess - m_containList should be empty but is not" ));

--- a/Generals/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Recorder.cpp
@@ -892,7 +892,7 @@ Bool RecorderClass::readReplayHeader(ReplayHeader& header)
 	// Read the GENREP header.
 	char genrep[sizeof(s_genrep) - 1] = {0};
 	m_file->read( &genrep, sizeof(s_genrep) - 1 );
-	if ( strncmp(genrep, s_genrep, sizeof(s_genrep) - 1 ) ) {
+	if ( strncmp(genrep, s_genrep, sizeof(s_genrep) - 1 ) != 0 ) {
 		DEBUG_LOG(("RecorderClass::readReplayHeader - replay file did not have GENREP at the start."));
 		m_file->close();
 		m_file = NULL;

--- a/Generals/Code/GameEngine/Source/GameClient/Credits.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Credits.cpp
@@ -221,7 +221,7 @@ void CreditsManager::update( void )
 	if(!((m_scrollDown && (yTest >= start)) || (!m_scrollDown && (yTest  <= start))))
 		return;
 
-	if(m_displayedCreditLineList.size() == 0 && m_creditLineListIt == m_creditLineList.end())
+	if(m_displayedCreditLineList.empty() && m_creditLineListIt == m_creditLineList.end())
 		m_isFinished = TRUE;
 
 	if(m_creditLineListIt == m_creditLineList.end())

--- a/Generals/Code/GameEngine/Source/GameClient/Eva.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Eva.cpp
@@ -436,7 +436,7 @@ void Eva::processPlayingMessages(UnsignedInt currentFrame)
 	for (Int i = 0; i < numSides; ++i) {
 		if (side.compareNoCase(storedIt->m_evaInfo->m_evaSideSounds[i].m_side) == 0) {
 			// Its this one.
-			if (storedIt->m_evaInfo->m_evaSideSounds[i].m_soundNames.size() > 0) {
+			if (!storedIt->m_evaInfo->m_evaSideSounds[i].m_soundNames.empty()) {
 				Int soundToPlay = GameClientRandomValue(0, storedIt->m_evaInfo->m_evaSideSounds[i].m_soundNames.size() - 1);
 				m_evaSpeech.setEventName(storedIt->m_evaInfo->m_evaSideSounds[i].m_soundNames[soundToPlay]);
 			} else {

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarScheme.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarScheme.cpp
@@ -1009,7 +1009,7 @@ void ControlBarSchemeManager::init( void )
 //		if	(FindFirstFile(userDataPath.str(), &findData) !=INVALID_HANDLE_VALUE)
 //			ini.loadFileDirectory(userDataPath,  INI_LOAD_OVERWRITE, NULL );
 //	}
-	if( m_schemeList.size() <= 0 )
+	if( m_schemeList.empty() )
 	{
 		DEBUG_ASSERTCRASH(FALSE,("There's no ControlBarScheme in the ControlBarSchemeList:m_schemeList that was just read from the INI file"));
 		return;

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLBuddyOverlay.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLBuddyOverlay.cpp
@@ -508,7 +508,7 @@ void HandleBuddyResponses( void )
 				break;
 			case BuddyResponse::BUDDYRESPONSE_MESSAGE:
 				{
-					if ( !wcscmp(resp.arg.message.text, L"I have authorized your request to add me to your list") )
+					if ( wcscmp(resp.arg.message.text, L"I have authorized your request to add me to your list") == 0 )
 						break;
 
 					if (TheGameSpyInfo->isSavedIgnored(resp.profile))

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLGameSetupMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLGameSetupMenu.cpp
@@ -1779,7 +1779,7 @@ void WOLGameSetupMenuUpdate( WindowLayout * layout, void *userData)
 							resp.command.c_str(), resp.commandOptions.c_str()));
 					}
 #endif
-					if (!strcmp(resp.command.c_str(), "SL"))
+					if (strcmp(resp.command.c_str(), "SL") == 0)
 					{
 						// slotlist
 						GameSpyStagingRoom *game = TheGameSpyInfo->getCurrentStagingRoom();
@@ -1949,7 +1949,7 @@ void WOLGameSetupMenuUpdate( WindowLayout * layout, void *userData)
 							}
 						}
 					}
-					else if (!strcmp(resp.command.c_str(), "HWS"))
+					else if (strcmp(resp.command.c_str(), "HWS") == 0)
 					{
 						// host wants to start
 						GameInfo *game = TheGameSpyInfo->getCurrentStagingRoom();
@@ -1963,13 +1963,13 @@ void WOLGameSetupMenuUpdate( WindowLayout * layout, void *userData)
 							}
 						}
 					}
-					else if (!stricmp(resp.command.c_str(), "NAT"))
+					else if (stricmp(resp.command.c_str(), "NAT") == 0)
 					{
 						if (TheNAT != NULL) {
 							TheNAT->processGlobalMessage(-1, resp.commandOptions.c_str());
 						}
 					}
-					else if (!stricmp(resp.command.c_str(), "Pings"))
+					else if (stricmp(resp.command.c_str(), "Pings") == 0)
 					{
 						if (!TheGameSpyInfo->amIHost())
 						{
@@ -1996,7 +1996,7 @@ void WOLGameSetupMenuUpdate( WindowLayout * layout, void *userData)
 			case PeerResponse::PEERRESPONSE_PLAYERUTM:
 				{
 					sawImportantMessage = TRUE;
-					if (!strcmp(resp.command.c_str(), "STATS"))
+					if (strcmp(resp.command.c_str(), "STATS") == 0)
 					{
 						PSPlayerStats stats = TheGameSpyPSMessageQueue->parsePlayerKVPairs(resp.commandOptions.c_str());
 						if (stats.id && (TheGameSpyPSMessageQueue->findPlayerStatsByID(stats.id).id == 0))
@@ -2007,7 +2007,7 @@ void WOLGameSetupMenuUpdate( WindowLayout * layout, void *userData)
 					if (game)
 					{
 						Int slotNum = game->getSlotNum(resp.nick.c_str());
-						if ((slotNum >= 0) && (slotNum < MAX_SLOTS) && (!stricmp(resp.command.c_str(), "NAT"))) {
+						if ((slotNum >= 0) && (slotNum < MAX_SLOTS) && (stricmp(resp.command.c_str(), "NAT") == 0)) {
 							// this is a command for NAT negotiations, pass if off to TheNAT
 							if (TheNAT != NULL) {
 								TheNAT->processGlobalMessage(slotNum, resp.commandOptions.c_str());
@@ -2015,7 +2015,7 @@ void WOLGameSetupMenuUpdate( WindowLayout * layout, void *userData)
 						}
 						if (slotNum == 0 && !TheGameSpyInfo->amIHost())
 						{
-							if (!strcmp(resp.command.c_str(), "KICK"))
+							if (strcmp(resp.command.c_str(), "KICK") == 0)
 							{
 								// oops - we've been kicked.  bail.
 								buttonPushed = true;
@@ -2041,13 +2041,13 @@ void WOLGameSetupMenuUpdate( WindowLayout * layout, void *userData)
 						}
 						else if (slotNum > 0 && TheGameSpyInfo->amIHost())
 						{
-							if (!strcmp(resp.command.c_str(), "accept"))
+							if (strcmp(resp.command.c_str(), "accept") == 0)
 							{
 								game->getSlot(slotNum)->setAccept();
 								TheGameSpyInfo->setGameOptions();
 								WOLDisplaySlotList();
 							}
-							else if (!strcmp(resp.command.c_str(), "MAP"))
+							else if (strcmp(resp.command.c_str(), "MAP") == 0)
 							{
 								Bool hasMap = atoi(resp.commandOptions.c_str());
 								game->getSlot(slotNum)->setMapAvailability(hasMap);
@@ -2076,7 +2076,7 @@ void WOLGameSetupMenuUpdate( WindowLayout * layout, void *userData)
 								}
 								WOLDisplaySlotList();
 							}
-							else if (!strcmp(resp.command.c_str(), "REQ"))
+							else if (strcmp(resp.command.c_str(), "REQ") == 0)
 							{
 								AsciiString options = resp.commandOptions.c_str();
 								options.trim();

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLobbyMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLobbyMenu.cpp
@@ -563,7 +563,7 @@ void PopulateLobbyPlayerListbox(void)
 		}
 
 		// restore selection
-		if (indicesToSelect.size())
+		if (!indicesToSelect.empty())
 		{
 			std::set<Int>::const_iterator indexIt = indicesToSelect.begin();
 			const size_t count = indicesToSelect.size();
@@ -1067,7 +1067,7 @@ void WOLLobbyMenuUpdate( WindowLayout * layout, void *userData)
 								AsciiString hostName;
 								hostName.translate(room->getConstSlot(0)->getName());
 								const char *firstPlayer = resp.stagingRoomPlayerNames[i].c_str();
-								if (!strcmp(hostName.str(), firstPlayer))
+								if (strcmp(hostName.str(), firstPlayer) == 0)
 								{
 									DEBUG_LOG(("Saw host %s == %s in slot %d", hostName.str(), firstPlayer, i));
 									isHostPresent = TRUE;
@@ -1148,7 +1148,7 @@ void WOLLobbyMenuUpdate( WindowLayout * layout, void *userData)
 						//if (ParseAsciiStringToGameInfo(&room, resp.stagingRoomMapName.c_str()))
 						//if (ParseAsciiStringToGameInfo(&room, resp.stagingServerGameOptions.c_str()))
 						Bool serverOk = TRUE;
-						if (!resp.stagingRoomMapName.length())
+						if (resp.stagingRoomMapName.empty())
 						{
 							serverOk = FALSE;
 						}
@@ -1220,7 +1220,7 @@ void WOLLobbyMenuUpdate( WindowLayout * layout, void *userData)
 										slot->setState(SLOT_BRUTAL_AI);
 										++numPlayers;
 									}
-									else if (resp.stagingRoomPlayerNames[i].length())
+									else if (!resp.stagingRoomPlayerNames[i].empty())
 									{
 										UnicodeString nameUStr;
 										nameUStr.translate(resp.stagingRoomPlayerNames[i].c_str());

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLQuickMatchMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLQuickMatchMenu.cpp
@@ -786,9 +786,9 @@ void WOLQuickMatchMenuInit( WindowLayout *layout, void *userData )
 	comboBoxSide = TheWindowManager->winGetWindowFromId( parentWOLQuickMatch, comboBoxSideID );
 	comboBoxColor = TheWindowManager->winGetWindowFromId( parentWOLQuickMatch, comboBoxColorID );
 
-	if (TheLadderList->getStandardLadders()->size() == 0
-		&& TheLadderList->getSpecialLadders()->size() == 0
-		&& TheLadderList->getLocalLadders()->size() == 0)
+	if (TheLadderList->getStandardLadders()->empty()
+		&& TheLadderList->getSpecialLadders()->empty()
+		&& TheLadderList->getLocalLadders()->empty())
 	{
 		// no ladders, so just disable them
 		comboBoxDisabledLadder = comboBoxLadder;
@@ -1133,7 +1133,7 @@ void WOLQuickMatchMenuUpdate( WindowLayout * layout, void *userData)
 			{
 			case PeerResponse::PEERRESPONSE_PLAYERUTM:
 				{
-					if (!stricmp(resp.command.c_str(), "STATS"))
+					if (stricmp(resp.command.c_str(), "STATS") == 0)
 					{
 						DEBUG_LOG(("Saw STATS from %s, data was '%s'", resp.nick.c_str(), resp.commandOptions.c_str()));
 						AsciiString data = resp.commandOptions.c_str();
@@ -1162,7 +1162,7 @@ void WOLQuickMatchMenuUpdate( WindowLayout * layout, void *userData)
 						}
 					}
 					Int slotNum = TheGameSpyGame->getSlotNum(resp.nick.c_str());
-					if ((slotNum >= 0) && (slotNum < MAX_SLOTS) && (!stricmp(resp.command.c_str(), "NAT"))) {
+					if ((slotNum >= 0) && (slotNum < MAX_SLOTS) && (stricmp(resp.command.c_str(), "NAT") == 0)) {
 						// this is a command for NAT negotiations, pass if off to TheNAT
 						sawImportantMessage = TRUE;
 						if (TheNAT != NULL) {

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GameWindowManager.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GameWindowManager.cpp
@@ -3976,7 +3976,7 @@ Bool GameWindowManager::initTestGUI( void )
 
 void GameWindowManager::winNextTab( GameWindow *window )
 {
-	if(m_tabList.size() == 0|| m_modalHead)
+	if(m_tabList.empty()|| m_modalHead)
 		return;
 
 	GameWindowList::iterator it = m_tabList.begin();
@@ -4000,7 +4000,7 @@ void GameWindowManager::winNextTab( GameWindow *window )
 
 void GameWindowManager::winPrevTab( GameWindow *window )
 {
-	if(m_tabList.size() == 0 || m_modalHead)
+	if(m_tabList.empty() || m_modalHead)
 		return;
 
 	GameWindowList::reverse_iterator it = m_tabList.rbegin();

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GameWindowManagerScript.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GameWindowManagerScript.cpp
@@ -207,7 +207,7 @@ static Bool parseBitFlag( const char *flagString, UnsignedInt *bits,
 	for( i = 0, c = flagList; *c; i++, c++ )
 	{
 
-		if( !stricmp( *c, flagString ) )
+		if( stricmp( *c, flagString ) == 0 )
 		{
 			*bits |= (1 << i);
 			return TRUE;
@@ -233,7 +233,7 @@ static void parseBitString( const char *inBuffer, UnsignedInt *bits, ConstCharPt
 	// do not modify the inBuffer argument
 	strlcpy(buffer, inBuffer, ARRAY_SIZE(buffer));
 
-	if( strncmp( buffer, "NULL", 4 ) )
+	if( strncmp( buffer, "NULL", 4 ) != 0 )
 	{
 		for( tok = strtok( buffer, "+" ); tok; tok = strtok( NULL, "+" ) )
 		{
@@ -436,7 +436,7 @@ static Bool parseDefaultColor( Color *color, File *inFile, char *buffer )
   // Read the rest of the color definition
 	readUntilSemicolon( inFile, buffer, WIN_BUFFER_LENGTH );
 
-  if (!strcmp( buffer, "TRANSPARENT" ))
+  if (strcmp( buffer, "TRANSPARENT" ) == 0)
 	{
 
 		*color = WIN_COLOR_UNDEFINED;
@@ -838,7 +838,7 @@ static Bool parseListboxData( const char *token, WinInstanceData *instData,
 
 	// "SCROLLIFATEND" (optional)
 	c = strtok( NULL, seps );  // label
-	if ( !stricmp(c, "ScrollIfAtEnd") )
+	if ( stricmp(c, "ScrollIfAtEnd") == 0 )
 	{
 		c = strtok( NULL, seps );  // value
 		scanBool( c, listData->scrollIfAtEnd );
@@ -1314,7 +1314,7 @@ static Bool parseDrawData( const char *token, WinInstanceData *instData,
 		first = FALSE;
 
 		c = strtok( NULL, seps );  // value
-		if( strcmp( c, "NoImage" ) )
+		if( strcmp( c, "NoImage" ) != 0 )
 			drawData->image = TheMappedImageCollection->findImageByName( AsciiString( c ) );
 		else
 			drawData->image = NULL;
@@ -1364,46 +1364,46 @@ void *getDataTemplate( char *type )
 	static ComboBoxData	cData;
 	void *data;
 
-  if( !strcmp( type, "VERTSLIDER" ) || !strcmp( type, "HORZSLIDER" ) )
+  if( strcmp( type, "VERTSLIDER" ) == 0 || strcmp( type, "HORZSLIDER" ) == 0 )
 	{
 
     memset( &sData, 0, sizeof( SliderData ) );
     data = &sData;
 
   }
-	else if( !strcmp( type, "SCROLLLISTBOX" ) )
+	else if( strcmp( type, "SCROLLLISTBOX" ) == 0 )
 	{
 
     memset( &lData, 0, sizeof( ListboxData ) );
     data = &lData;
 
   }
-	else if( !strcmp( type, "TABCONTROL" ) )
+	else if( strcmp( type, "TABCONTROL" ) == 0 )
 	{
     memset( &tcData, 0, sizeof( TabControlData ) );
     data = &tcData;
   }
-	else if( !strcmp( type, "ENTRYFIELD" ) )
+	else if( strcmp( type, "ENTRYFIELD" ) == 0 )
 	{
 
     memset( &eData, 0, sizeof( EntryData ) );
     data = &eData;
 
   }
-	else if( !strcmp( type, "STATICTEXT" ) )
+	else if( strcmp( type, "STATICTEXT" ) == 0 )
 	{
 
 		memset( &tData, 0, sizeof( TextData ) );
 		data = &tData;
 
   }
-	else if( !strcmp( type, "RADIOBUTTON" ) )
+	else if( strcmp( type, "RADIOBUTTON" ) == 0 )
 	{
 
 		memset( &rData, 0, sizeof( RadioButtonData ) );
 		data = &rData;
 	}
-	else if( !strcmp( type, "COMBOBOX" ) )
+	else if( strcmp( type, "COMBOBOX" ) == 0 )
 	{
 
 		memset( &cData, 0, sizeof( ComboBoxData ) );
@@ -1446,7 +1446,7 @@ static Bool parseData( void **data, char *type, char *buffer )
 	static RadioButtonData rData;
 	static ComboBoxData cData;
 
-  if( !strcmp( type, "VERTSLIDER" ) || !strcmp( type, "HORZSLIDER" ) )
+  if( strcmp( type, "VERTSLIDER" ) == 0 || strcmp( type, "HORZSLIDER" ) == 0 )
 	{
 
     memset( &sData, 0, sizeof( SliderData ) );
@@ -1460,7 +1460,7 @@ static Bool parseData( void **data, char *type, char *buffer )
     *data = &sData;
 
   }
-	else if( !strcmp( type, "SCROLLLISTBOX" ) )
+	else if( strcmp( type, "SCROLLLISTBOX" ) == 0 )
 	{
 
     memset( &lData, 0, sizeof( ListboxData ) );
@@ -1489,7 +1489,7 @@ static Bool parseData( void **data, char *type, char *buffer )
     *data = &lData;
 
   }
-	else if( !strcmp( type, "ENTRYFIELD" ) )
+	else if( strcmp( type, "ENTRYFIELD" ) == 0 )
 	{
 
     memset( &eData, 0, sizeof( EntryData ) );
@@ -1530,7 +1530,7 @@ static Bool parseData( void **data, char *type, char *buffer )
     *data = &eData;
 
   }
-	else if( !strcmp( type, "STATICTEXT" ) )
+	else if( strcmp( type, "STATICTEXT" ) == 0 )
 	{
 
 	  c = strtok( buffer, " \t\n\r" );
@@ -1551,7 +1551,7 @@ static Bool parseData( void **data, char *type, char *buffer )
 		*data = &tData;
 
   }
-	else if( !strcmp( type, "RADIOBUTTON" ) )
+	else if( strcmp( type, "RADIOBUTTON" ) == 0 )
 	{
 
 		c = strtok( buffer, " \t\n\r" );
@@ -1617,7 +1617,7 @@ static GameWindow *createGadget( char *type,
 
   instData->m_owner = parent;
 
-  if( !strcmp( type, "PUSHBUTTON" ) )
+  if( strcmp( type, "PUSHBUTTON" ) == 0 )
 	{
 
     instData->m_style |= GWS_PUSH_BUTTON;
@@ -1627,7 +1627,7 @@ static GameWindow *createGadget( char *type,
 																										 instData->m_font, FALSE );
 
   }
-	else if( !strcmp( type, "RADIOBUTTON" ) )
+	else if( strcmp( type, "RADIOBUTTON" ) == 0 )
 	{
 		RadioButtonData *rData = (RadioButtonData *)data;
 		char filename[ MAX_WINDOW_NAME_LEN ];
@@ -1653,7 +1653,7 @@ static GameWindow *createGadget( char *type,
 																											instData->m_font, FALSE );
 
   }
-	else if( !strcmp( type, "CHECKBOX" ) )
+	else if( strcmp( type, "CHECKBOX" ) == 0 )
 	{
 
     instData->m_style |= GWS_CHECK_BOX;
@@ -1663,7 +1663,7 @@ static GameWindow *createGadget( char *type,
 																									 instData->m_font, FALSE );
 
   }
-	else if( !strcmp( type, "TABCONTROL" ) )
+	else if( strcmp( type, "TABCONTROL" ) == 0 )
 	{
 		TabControlData *tcData = (TabControlData *)data;
     instData->m_style |= GWS_TAB_CONTROL;
@@ -1672,7 +1672,7 @@ static GameWindow *createGadget( char *type,
 																										instData, tcData,
 																										instData->m_font, FALSE );
 	}
-	else if( !strcmp( type, "VERTSLIDER" ) )
+	else if( strcmp( type, "VERTSLIDER" ) == 0 )
 	{
     SliderData *sData = (SliderData *)data;
 
@@ -1704,7 +1704,7 @@ static GameWindow *createGadget( char *type,
 		}
 
   }
-	else if( !strcmp( type, "HORZSLIDER" ) )
+	else if( strcmp( type, "HORZSLIDER" ) == 0 )
 	{
     SliderData *sData = (SliderData *)data;
 
@@ -1736,7 +1736,7 @@ static GameWindow *createGadget( char *type,
 		}
 
   }
-	else if( !strcmp( type, "SCROLLLISTBOX" ) )
+	else if( strcmp( type, "SCROLLLISTBOX" ) == 0 )
 	{
 
     ListboxData *lData = (ListboxData *)data;
@@ -1818,7 +1818,7 @@ static GameWindow *createGadget( char *type,
 		}
 
   }
-	else if( !strcmp( type, "COMBOBOX" ) )
+	else if( strcmp( type, "COMBOBOX" ) == 0 )
 	{
 		ComboBoxData *cData = (ComboBoxData *)data;
 		cData->entryData = NEW EntryData;
@@ -1966,7 +1966,7 @@ static GameWindow *createGadget( char *type,
 			}
 		}
   }
-	else if( !strcmp( type, "ENTRYFIELD" ) )
+	else if( strcmp( type, "ENTRYFIELD" ) == 0 )
 	{
     EntryData *eData = (EntryData *)data;
 
@@ -1977,7 +1977,7 @@ static GameWindow *createGadget( char *type,
 																										instData->m_font, FALSE );
 
   }
-	else if( !strcmp( type, "STATICTEXT" ) )
+	else if( strcmp( type, "STATICTEXT" ) == 0 )
 	{
     TextData *tData = (TextData *)data;
 
@@ -1989,7 +1989,7 @@ static GameWindow *createGadget( char *type,
 
 
   }
-	else if( !strcmp( type, "PROGRESSBAR" ) )
+	else if( strcmp( type, "PROGRESSBAR" ) == 0 )
 	{
 
     instData->m_style |= GWS_PROGRESS_BAR;
@@ -2025,7 +2025,7 @@ static GameWindow *createWindow( char *type,
   parent = peekWindow();
 
   // If this is a regular window just create it
-  if( !strcmp( type, "USER" ) )
+  if( strcmp( type, "USER" ) == 0 )
 	{
 
     window = TheWindowManager->winCreate( parent,
@@ -2042,7 +2042,7 @@ static GameWindow *createWindow( char *type,
 		}
 
   }
-	else if( !strcmp( type, "TABPANE" ) )
+	else if( strcmp( type, "TABPANE" ) == 0 )
 	{
 
     window = TheWindowManager->winCreate( parent,

--- a/Generals/Code/GameEngine/Source/GameClient/GameText.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GameText.cpp
@@ -824,7 +824,7 @@ Bool GameTextManager::getStringCount( const char *filename, Int& textCount )
 				m_buffer[ len+1] = 0;
 			readToEndOfQuote( file, &m_buffer[1], m_buffer2, m_buffer3, MAX_UITEXT_LENGTH );
 		}
-		else if( !stricmp( m_buffer, "END") )
+		else if( stricmp( m_buffer, "END") == 0 )
 		{
 			textCount++;
 		}
@@ -1035,7 +1035,7 @@ Bool GameTextManager::parseStringFile( const char *filename )
 
 		for ( Int i = 0; i < listCount; i++ )
 		{
-			if ( !stricmp ( m_stringInfo[i].label.str(), m_buffer ))
+			if ( stricmp ( m_stringInfo[i].label.str(), m_buffer ) == 0)
 			{
 				DEBUG_ASSERTCRASH ( FALSE, ("String label '%s' multiply defined!", m_buffer ));
 			}
@@ -1086,7 +1086,7 @@ Bool GameTextManager::parseStringFile( const char *filename )
 					readString = TRUE;
 				}
 			}
-			else if ( !stricmp ( m_buffer, "END" ))
+			else if ( stricmp ( m_buffer, "END" ) == 0)
 			{
 				break;
 			}
@@ -1166,7 +1166,7 @@ Bool GameTextManager::parseMapStringFile( const char *filename )
 
 		for ( Int i = 0; i < listCount; i++ )
 		{
-			if ( !stricmp ( m_mapStringInfo[i].label.str(), m_buffer ))
+			if ( stricmp ( m_mapStringInfo[i].label.str(), m_buffer ) == 0)
 			{
 				DEBUG_ASSERTCRASH ( FALSE, ("String label '%s' multiply defined!", m_buffer ));
 			}
@@ -1221,7 +1221,7 @@ Bool GameTextManager::parseMapStringFile( const char *filename )
 					readString = TRUE;
 				}
 			}
-			else if ( !stricmp ( m_buffer, "END" ))
+			else if ( stricmp ( m_buffer, "END" ) == 0)
 			{
 				break;
 			}

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -623,7 +623,7 @@ Bool InGameUI::removeSuperweapon(Int playerIndex, const AsciiString& powerName, 
 				SuperweaponInfo *info = *listIt;
 				swList.erase(listIt);
 				deleteInstance(info);
-				if (swList.size() == 0)
+				if (swList.empty())
 				{
 					m_superweapons[playerIndex].erase(mapIt);
 				}
@@ -4522,7 +4522,7 @@ Bool InGameUI::canSelectedObjectsDoSpecialPower( const CommandButton *command, c
 	if (ignoreSelDraw)
 		tmpList.push_back(ignoreSelDraw);
 
-	const DrawableList* selected = (tmpList.size() > 0) ? &tmpList : TheInGameUI->getAllSelectedDrawables();
+	const DrawableList* selected = (!tmpList.empty()) ? &tmpList : TheInGameUI->getAllSelectedDrawables();
 
 	// set up counters for rule checking
 	Int count = 0;
@@ -4785,7 +4785,7 @@ Int InGameUI::selectMatchingAcrossRegion( IRegion2D *region )
 		}
 	}
 
-	if (drawableList.size() == 0)
+	if (drawableList.empty())
 		return -1; // nothing useful selected to begin with - don't bother iterating
 
 	std::set<const ThingTemplate*>::iterator iter;

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AI.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AI.cpp
@@ -324,7 +324,7 @@ void AI::reset( void )
 	}
 
 #if RETAIL_COMPATIBLE_AIGROUP
-	while (m_groupList.size())
+	while (!m_groupList.empty())
 	{
 		AIGroup *groupToRemove = m_groupList.front();
 		if (groupToRemove)

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
@@ -1042,7 +1042,7 @@ Bool AIGroup::friend_moveInfantryToPos( const Coord3D *pos, CommandSourceType cm
 		dest.y -= factor*offset*endVector.y;
 		dest.z = TheTerrainLogic->getLayerHeight( dest.x, dest.y, layer );
 
-		while (path.size()>0) {
+		while (!path.empty()) {
 			Coord2D curVector;
 			prevPos = path[path.size()-1];
 			curVector.x = dest.x-prevPos.x;
@@ -1520,7 +1520,7 @@ Bool AIGroup::friend_moveVehicleToPos( const Coord3D *pos, CommandSourceType cmd
 		dest.y -= factor*offset*endVector.y;
 		dest.z = TheTerrainLogic->getLayerHeight( dest.x, dest.y, layer );
 
-		while (path.size()>0) {
+		while (!path.empty()) {
 			Coord2D curVector;
 			prevPos = path[path.size()-1];
 			curVector.x = dest.x-prevPos.x;

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -966,7 +966,7 @@ StateReturnType AIStateMachine::setTemporaryState( StateID newStateID, Int frame
  */
 void AIStateMachine::addToGoalPath( const Coord3D *pathPoint)
 {
-	if (m_goalPath.size()==0) {
+	if (m_goalPath.empty()) {
 		m_goalPath.push_back(*pathPoint);
 	}	else {
 		Coord3D *finalPoint = &m_goalPath[ m_goalPath.size() - 1 ];
@@ -5793,7 +5793,7 @@ Object *AIAttackSquadState::chooseVictim(void)
 		{
 			// everyone picks the same unit
 			VecObjectPtr objects = victimSquad->getLiveObjects();
-			if (objects.size() > 0)
+			if (!objects.empty())
 			{
 				return objects[0];
 			}

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/Squad.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/Squad.cpp
@@ -233,7 +233,7 @@ void Squad::xfer( Xfer *xfer )
 	{
 
 		// the cached objects list should be empty
-		if( m_objectsCached.size() != 0 )
+		if( !m_objectsCached.empty() )
 		{
 
 			DEBUG_CRASH(( "Squad::xfer - m_objectsCached should be emtpy, but is not" ));

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
@@ -938,7 +938,7 @@ protected:
 				if (di)
 				{
 					di->setModelName(modelName, m_okToChangeModelColor ? obj->getIndicatorColor() : 0, m_shadowType);
-					if (m_animSets.size() > 0)
+					if (!m_animSets.empty())
 					{
 						Int which = GameLogicRandomValue(0, m_animSets.size()-1);
 						di->setAnimNames(m_animSets[which].m_animInitial, m_animSets[which].m_animFlying, m_animSets[which].m_animFinal, m_fxFinal);
@@ -1217,7 +1217,7 @@ protected:
 	{
 		static const ThingTemplate* debrisTemplate = TheThingFactory->findTemplate("GenericDebris");
 
-		if (m_names.size() <= 0)
+		if (m_names.empty())
 			return NULL;
 
 		if (m_requiresLivePlayer && (!sourceObj || !sourceObj->getControllingPlayer()->isPlayerActive()))

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -174,7 +174,7 @@ const LocomotorTemplateVector* AIUpdateModuleData::findLocomotorTemplateVector(L
 	self->m_locomotorTemplates[set].clear();
 	for (const char* locoName = ini->getNextToken(); locoName; locoName = ini->getNextTokenOrNull())
 	{
-		if (!*locoName || !stricmp(locoName, "None"))
+		if (!*locoName || stricmp(locoName, "None") == 0)
 			continue;
 
 		NameKeyType locoKey = NAMEKEY(locoName);
@@ -3254,7 +3254,7 @@ void AIUpdateInterface::privateFollowPath( const std::vector<Coord3D>* path, Obj
 	// clear current state machine
 	getStateMachine()->clear();
 
-	if (path->size()>0) {
+	if (!path->empty()) {
 		const Coord3D goal = (*path)[path->size()-1];
 		getStateMachine()->setGoalPosition(&goal);
 	}

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DeliverPayloadAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DeliverPayloadAIUpdate.cpp
@@ -681,7 +681,7 @@ StateReturnType DeliveringState::update() // Kick a dude out every so often
 		return STATE_FAILURE;
 
 	const ContainedItemsList* items = owner->getContain() ? owner->getContain()->getContainedItemsList() : NULL;
-	if( (!items || !items->size()) && ai->getVisibleItemsDelivered() == ai->getData()->m_visibleNumBones )
+	if( (!items || items->empty()) && ai->getVisibleItemsDelivered() == ai->getData()->m_visibleNumBones )
 	{
 		//We are out of payload to drop AND our visible payload is empty. It's possible for deliverers to
 		//have one or the other or even both.

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -1103,7 +1103,7 @@ UnsignedInt WeaponTemplate::fireWeaponTemplate
 void WeaponTemplate::trimOldHistoricDamage() const
 {
 	UnsignedInt expirationDate = TheGameLogic->getFrame() - TheGlobalData->m_historicDamageLimit;
-	while (m_historicDamage.size() > 0)
+	while (!m_historicDamage.empty())
 	{
 		HistoricWeaponDamageInfo& h = m_historicDamage.front();
 		if (h.frame <= expirationDate)
@@ -2461,7 +2461,7 @@ Bool Weapon::privateFireWeapon(
 			m_numShotsForCurBarrel = m_template->getShotsPerBarrel();
 		}
 
-		if( m_scatterTargetsUnused.size() )
+		if( !m_scatterTargetsUnused.empty() )
 		{
 			// If I have a set scatter pattern, I need to offset the target by a random pick from that pattern
 			if( victimObj )

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
@@ -8147,7 +8147,7 @@ void ScriptEngine::xfer( Xfer *xfer )
 	{
 
 		// this list should be empty on loading
-		if( m_sequentialScripts.size() != 0 )
+		if( !m_sequentialScripts.empty() )
 		{
 
 			DEBUG_CRASH(( "ScriptEngine::xfer - m_sequentialScripts should be empty but is not" ));

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
@@ -647,7 +647,7 @@ void ModelConditionInfo::validateCachedBones(RenderObjClass* robj, Real scale) c
 	// if we have any animations in this state, always choose the first, since the animations
 	// vary on a per-client basis.
 	HAnimClass* animToUse;
-	if (m_animations.size() > 0)
+	if (!m_animations.empty())
 	{
 		animToUse = m_animations.front().getAnimHandle();	// return an AddRef'ed handle
 	}
@@ -3748,8 +3748,8 @@ void W3DModelDraw::setAnimationLoopDuration(UnsignedInt numFrames)
 */
 void W3DModelDraw::setAnimationCompletionTime(UnsignedInt numFrames)
 {
-	if (m_curState != NULL && m_curState->m_transitionSig != NO_TRANSITION && m_curState->m_animations.size() > 0 &&
-			m_nextState != NULL && m_nextState->m_transitionSig == NO_TRANSITION && m_nextState->m_animations.size() > 0)
+	if (m_curState != NULL && m_curState->m_transitionSig != NO_TRANSITION && !m_curState->m_animations.empty() &&
+			m_nextState != NULL && m_nextState->m_transitionSig == NO_TRANSITION && !m_nextState->m_animations.empty())
 	{
 		// we have a transition; split up the time suitably.
 		// note that this is just a guess, and assumes that the states

--- a/Generals/Code/Tools/ParticleEditor/ParticleEditorDialog.cpp
+++ b/Generals/Code/Tools/ParticleEditor/ParticleEditorDialog.cpp
@@ -336,7 +336,7 @@ void DebugWindowDialog::getSelectedParticleAsciiStringParm( IN int parmNum, OUT 
 		return;
 	}
 
-	if (m_particleParmValues[parmNum].length()) {
+	if (!m_particleParmValues[parmNum].empty()) {
 		strcpy(bufferToCopyInto, m_particleParmValues[parmNum].c_str());
 	} else {
 		bufferToCopyInto[0] = 0;

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/AnimateWindowManager.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/AnimateWindowManager.h
@@ -229,7 +229,7 @@ namespace wnd
 
 	inline Bool AnimateWindowManager::isFinished( void )					{ return !m_needsUpdate;	};
 	inline Bool AnimateWindowManager::isReversed( void )						{ return m_reverse;	};
-	inline Bool AnimateWindowManager::isEmpty( void ){return (m_winList.size() == 0 && m_winMustFinishList.size() == 0);	}
+	inline Bool AnimateWindowManager::isEmpty( void ){return (m_winList.empty() && m_winMustFinishList.empty());	}
 //-----------------------------------------------------------------------------
 // EXTERNALS //////////////////////////////////////////////////////////////////
 //-----------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -4376,7 +4376,7 @@ void Player::xfer( Xfer *xfer )
 	{
 
 		// sanity, list must be empty right now
-		if( m_kindOfPercentProductionChangeList.size() != 0 )
+		if( !m_kindOfPercentProductionChangeList.empty() )
 		{
 
 			DEBUG_CRASH(( "Player::xfer - m_kindOfPercentProductionChangeList should be empty but is not" ));
@@ -4429,7 +4429,7 @@ void Player::xfer( Xfer *xfer )
 		}
 		else
 		{
-			if( m_specialPowerReadyTimerList.size() != 0 ) // sanity, list must be empty right now
+			if( !m_specialPowerReadyTimerList.empty() ) // sanity, list must be empty right now
 			{
 				DEBUG_CRASH(( "Player::xfer - m_specialPowerReadyTimerList should be empty but is not" ));
 				throw SC_INVALID_DATA;

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/ProductionPrerequisite.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/ProductionPrerequisite.cpp
@@ -131,7 +131,7 @@ Int ProductionPrerequisite::getAllPossibleBuildFacilityTemplates(const ThingTemp
 const ThingTemplate *ProductionPrerequisite::getExistingBuildFacilityTemplate( const Player *player ) const
 {
 	DEBUG_ASSERTCRASH(player, ("player may not be null"));
-	if (m_prereqUnits.size())
+	if (!m_prereqUnits.empty())
 	{
 		Int ownCount[MAX_PREREQ];
 		Int cnt = calcNumPrereqUnitsOwned(player, ownCount);

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/TunnelTracker.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/TunnelTracker.cpp
@@ -415,7 +415,7 @@ void TunnelTracker::loadPostProcess( void )
 {
 
 	// sanity, the contain list should be empty until we post process the id list
-	if( m_containList.size() != 0 )
+	if( !m_containList.empty() )
 	{
 
 		DEBUG_CRASH(( "TunnelTracker::loadPostProcess - m_containList should be empty but is not" ));

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -894,7 +894,7 @@ Bool RecorderClass::readReplayHeader(ReplayHeader& header)
 	// Read the GENREP header.
 	char genrep[sizeof(s_genrep) - 1] = {0};
 	m_file->read( &genrep, sizeof(s_genrep) - 1 );
-	if ( strncmp(genrep, s_genrep, sizeof(s_genrep) - 1 ) ) {
+	if ( strncmp(genrep, s_genrep, sizeof(s_genrep) - 1 ) != 0 ) {
 		DEBUG_LOG(("RecorderClass::readReplayHeader - replay file did not have GENREP at the start."));
 		m_file->close();
 		m_file = NULL;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Credits.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Credits.cpp
@@ -221,7 +221,7 @@ void CreditsManager::update( void )
 	if(!((m_scrollDown && (yTest >= start)) || (!m_scrollDown && (yTest  <= start))))
 		return;
 
-	if(m_displayedCreditLineList.size() == 0 && m_creditLineListIt == m_creditLineList.end())
+	if(m_displayedCreditLineList.empty() && m_creditLineListIt == m_creditLineList.end())
 		m_isFinished = TRUE;
 
 	if(m_creditLineListIt == m_creditLineList.end())

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Eva.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Eva.cpp
@@ -513,7 +513,7 @@ void Eva::processPlayingMessages(UnsignedInt currentFrame)
 	for (Int i = 0; i < numSides; ++i) {
 		if (side.compareNoCase(storedIt->m_evaInfo->m_evaSideSounds[i].m_side) == 0) {
 			// Its this one.
-			if (storedIt->m_evaInfo->m_evaSideSounds[i].m_soundNames.size() > 0) {
+			if (!storedIt->m_evaInfo->m_evaSideSounds[i].m_soundNames.empty()) {
 				Int soundToPlay = GameClientRandomValue(0, storedIt->m_evaInfo->m_evaSideSounds[i].m_soundNames.size() - 1);
 				m_evaSpeech.setEventName(storedIt->m_evaInfo->m_evaSideSounds[i].m_soundNames[soundToPlay]);
 			}

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarScheme.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarScheme.cpp
@@ -1022,7 +1022,7 @@ void ControlBarSchemeManager::init( void )
 //		if	(FindFirstFile(userDataPath.str(), &findData) !=INVALID_HANDLE_VALUE)
 //			ini.loadFileDirectory(userDataPath,  INI_LOAD_OVERWRITE, NULL );
 //	}
-	if( m_schemeList.size() <= 0 )
+	if( m_schemeList.empty() )
 	{
 		DEBUG_ASSERTCRASH(FALSE,("There's no ControlBarScheme in the ControlBarSchemeList:m_schemeList that was just read from the INI file"));
 		return;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLBuddyOverlay.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLBuddyOverlay.cpp
@@ -508,7 +508,7 @@ void HandleBuddyResponses( void )
 				break;
 			case BuddyResponse::BUDDYRESPONSE_MESSAGE:
 				{
-					if ( !wcscmp(resp.arg.message.text, L"I have authorized your request to add me to your list") )
+					if ( wcscmp(resp.arg.message.text, L"I have authorized your request to add me to your list") == 0 )
 						break;
 
 					if (TheGameSpyInfo->isSavedIgnored(resp.profile))

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLGameSetupMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLGameSetupMenu.cpp
@@ -1957,7 +1957,7 @@ void WOLGameSetupMenuUpdate( WindowLayout * layout, void *userData)
 							resp.command.c_str(), resp.commandOptions.c_str()));
 					}
 #endif
-					if (!strcmp(resp.command.c_str(), "SL"))
+					if (strcmp(resp.command.c_str(), "SL") == 0)
 					{
 						// slotlist
 						GameSpyStagingRoom *game = TheGameSpyInfo->getCurrentStagingRoom();
@@ -2127,7 +2127,7 @@ void WOLGameSetupMenuUpdate( WindowLayout * layout, void *userData)
 							}
 						}
 					}
-					else if (!strcmp(resp.command.c_str(), "HWS"))
+					else if (strcmp(resp.command.c_str(), "HWS") == 0)
 					{
 						// host wants to start
 						GameInfo *game = TheGameSpyInfo->getCurrentStagingRoom();
@@ -2141,13 +2141,13 @@ void WOLGameSetupMenuUpdate( WindowLayout * layout, void *userData)
 							}
 						}
 					}
-					else if (!stricmp(resp.command.c_str(), "NAT"))
+					else if (stricmp(resp.command.c_str(), "NAT") == 0)
 					{
 						if (TheNAT != NULL) {
 							TheNAT->processGlobalMessage(-1, resp.commandOptions.c_str());
 						}
 					}
-					else if (!stricmp(resp.command.c_str(), "Pings"))
+					else if (stricmp(resp.command.c_str(), "Pings") == 0)
 					{
 						if (!TheGameSpyInfo->amIHost())
 						{
@@ -2174,7 +2174,7 @@ void WOLGameSetupMenuUpdate( WindowLayout * layout, void *userData)
 			case PeerResponse::PEERRESPONSE_PLAYERUTM:
 				{
 					sawImportantMessage = TRUE;
-					if (!strcmp(resp.command.c_str(), "STATS"))
+					if (strcmp(resp.command.c_str(), "STATS") == 0)
 					{
 						PSPlayerStats stats = TheGameSpyPSMessageQueue->parsePlayerKVPairs(resp.commandOptions.c_str());
 						if (stats.id && (TheGameSpyPSMessageQueue->findPlayerStatsByID(stats.id).id == 0))
@@ -2185,7 +2185,7 @@ void WOLGameSetupMenuUpdate( WindowLayout * layout, void *userData)
 					if (game)
 					{
 						Int slotNum = game->getSlotNum(resp.nick.c_str());
-						if ((slotNum >= 0) && (slotNum < MAX_SLOTS) && (!stricmp(resp.command.c_str(), "NAT"))) {
+						if ((slotNum >= 0) && (slotNum < MAX_SLOTS) && (stricmp(resp.command.c_str(), "NAT") == 0)) {
 							// this is a command for NAT negotiations, pass if off to TheNAT
 							if (TheNAT != NULL) {
 								TheNAT->processGlobalMessage(slotNum, resp.commandOptions.c_str());
@@ -2193,7 +2193,7 @@ void WOLGameSetupMenuUpdate( WindowLayout * layout, void *userData)
 						}
 						if (slotNum == 0 && !TheGameSpyInfo->amIHost())
 						{
-							if (!strcmp(resp.command.c_str(), "KICK"))
+							if (strcmp(resp.command.c_str(), "KICK") == 0)
 							{
 								// oops - we've been kicked.  bail.
 								buttonPushed = true;
@@ -2219,13 +2219,13 @@ void WOLGameSetupMenuUpdate( WindowLayout * layout, void *userData)
 						}
 						else if (slotNum > 0 && TheGameSpyInfo->amIHost())
 						{
-							if (!strcmp(resp.command.c_str(), "accept"))
+							if (strcmp(resp.command.c_str(), "accept") == 0)
 							{
 								game->getSlot(slotNum)->setAccept();
 								TheGameSpyInfo->setGameOptions();
 								WOLDisplaySlotList();
 							}
-							else if (!strcmp(resp.command.c_str(), "MAP"))
+							else if (strcmp(resp.command.c_str(), "MAP") == 0)
 							{
 								Bool hasMap = atoi(resp.commandOptions.c_str());
 								game->getSlot(slotNum)->setMapAvailability(hasMap);
@@ -2254,7 +2254,7 @@ void WOLGameSetupMenuUpdate( WindowLayout * layout, void *userData)
 								}
 								WOLDisplaySlotList();
 							}
-							else if (!strcmp(resp.command.c_str(), "REQ"))
+							else if (strcmp(resp.command.c_str(), "REQ") == 0)
 							{
 								AsciiString options = resp.commandOptions.c_str();
 								options.trim();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLobbyMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLobbyMenu.cpp
@@ -580,7 +580,7 @@ void PopulateLobbyPlayerListbox(void)
 		}
 
 		// restore selection
-		if (indicesToSelect.size())
+		if (!indicesToSelect.empty())
 		{
 			std::set<Int>::const_iterator indexIt = indicesToSelect.begin();
 			const size_t count = indicesToSelect.size();
@@ -1085,7 +1085,7 @@ void WOLLobbyMenuUpdate( WindowLayout * layout, void *userData)
 								AsciiString hostName;
 								hostName.translate(room->getConstSlot(0)->getName());
 								const char *firstPlayer = resp.stagingRoomPlayerNames[i].c_str();
-								if (!strcmp(hostName.str(), firstPlayer))
+								if (strcmp(hostName.str(), firstPlayer) == 0)
 								{
 									DEBUG_LOG(("Saw host %s == %s in slot %d", hostName.str(), firstPlayer, i));
 									isHostPresent = TRUE;
@@ -1166,7 +1166,7 @@ void WOLLobbyMenuUpdate( WindowLayout * layout, void *userData)
 						//if (ParseAsciiStringToGameInfo(&room, resp.stagingRoomMapName.c_str()))
 						//if (ParseAsciiStringToGameInfo(&room, resp.stagingServerGameOptions.c_str()))
 						Bool serverOk = TRUE;
-						if (!resp.stagingRoomMapName.length())
+						if (resp.stagingRoomMapName.empty())
 						{
 							serverOk = FALSE;
 						}
@@ -1238,7 +1238,7 @@ void WOLLobbyMenuUpdate( WindowLayout * layout, void *userData)
 										slot->setState(SLOT_BRUTAL_AI);
 										++numPlayers;
 									}
-									else if (resp.stagingRoomPlayerNames[i].length())
+									else if (!resp.stagingRoomPlayerNames[i].empty())
 									{
 										UnicodeString nameUStr;
 										nameUStr.translate(resp.stagingRoomPlayerNames[i].c_str());

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLQuickMatchMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLQuickMatchMenu.cpp
@@ -765,9 +765,9 @@ void WOLQuickMatchMenuInit( WindowLayout *layout, void *userData )
 	comboBoxSide = TheWindowManager->winGetWindowFromId( parentWOLQuickMatch, comboBoxSideID );
 	comboBoxColor = TheWindowManager->winGetWindowFromId( parentWOLQuickMatch, comboBoxColorID );
 
-	if (TheLadderList->getStandardLadders()->size() == 0
-		&& TheLadderList->getSpecialLadders()->size() == 0
-		&& TheLadderList->getLocalLadders()->size() == 0)
+	if (TheLadderList->getStandardLadders()->empty()
+		&& TheLadderList->getSpecialLadders()->empty()
+		&& TheLadderList->getLocalLadders()->empty())
 	{
 		// no ladders, so just disable them
 		comboBoxDisabledLadder = comboBoxLadder;
@@ -1112,7 +1112,7 @@ void WOLQuickMatchMenuUpdate( WindowLayout * layout, void *userData)
 			{
 			case PeerResponse::PEERRESPONSE_PLAYERUTM:
 				{
-					if (!stricmp(resp.command.c_str(), "STATS"))
+					if (stricmp(resp.command.c_str(), "STATS") == 0)
 					{
 						DEBUG_LOG(("Saw STATS from %s, data was '%s'", resp.nick.c_str(), resp.commandOptions.c_str()));
 						AsciiString data = resp.commandOptions.c_str();
@@ -1141,7 +1141,7 @@ void WOLQuickMatchMenuUpdate( WindowLayout * layout, void *userData)
 						}
 					}
 					Int slotNum = TheGameSpyGame->getSlotNum(resp.nick.c_str());
-					if ((slotNum >= 0) && (slotNum < MAX_SLOTS) && (!stricmp(resp.command.c_str(), "NAT"))) {
+					if ((slotNum >= 0) && (slotNum < MAX_SLOTS) && (stricmp(resp.command.c_str(), "NAT") == 0)) {
 						// this is a command for NAT negotiations, pass if off to TheNAT
 						sawImportantMessage = TRUE;
 						if (TheNAT != NULL) {

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowManager.cpp
@@ -3976,7 +3976,7 @@ Bool GameWindowManager::initTestGUI( void )
 
 void GameWindowManager::winNextTab( GameWindow *window )
 {
-	if(m_tabList.size() == 0|| m_modalHead)
+	if(m_tabList.empty()|| m_modalHead)
 		return;
 
 	GameWindowList::iterator it = m_tabList.begin();
@@ -4000,7 +4000,7 @@ void GameWindowManager::winNextTab( GameWindow *window )
 
 void GameWindowManager::winPrevTab( GameWindow *window )
 {
-	if(m_tabList.size() == 0 || m_modalHead)
+	if(m_tabList.empty() || m_modalHead)
 		return;
 
 	GameWindowList::reverse_iterator it = m_tabList.rbegin();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowManagerScript.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowManagerScript.cpp
@@ -208,7 +208,7 @@ static Bool parseBitFlag( const char *flagString, UnsignedInt *bits,
 	for( i = 0, c = flagList; *c; i++, c++ )
 	{
 
-		if( !stricmp( *c, flagString ) )
+		if( stricmp( *c, flagString ) == 0 )
 		{
 			*bits |= (1 << i);
 			return TRUE;
@@ -234,7 +234,7 @@ static void parseBitString( const char *inBuffer, UnsignedInt *bits, ConstCharPt
 	// do not modify the inBuffer argument
 	strlcpy(buffer, inBuffer, ARRAY_SIZE(buffer));
 
-	if( strncmp( buffer, "NULL", 4 ) )
+	if( strncmp( buffer, "NULL", 4 ) != 0 )
 	{
 		for( tok = strtok( buffer, "+" ); tok; tok = strtok( NULL, "+" ) )
 		{
@@ -437,7 +437,7 @@ static Bool parseDefaultColor( Color *color, File *inFile, char *buffer )
   // Read the rest of the color definition
 	readUntilSemicolon( inFile, buffer, WIN_BUFFER_LENGTH );
 
-  if (!strcmp( buffer, "TRANSPARENT" ))
+  if (strcmp( buffer, "TRANSPARENT" ) == 0)
 	{
 
 		*color = WIN_COLOR_UNDEFINED;
@@ -839,7 +839,7 @@ static Bool parseListboxData( const char *token, WinInstanceData *instData,
 
 	// "SCROLLIFATEND" (optional)
 	c = strtok( NULL, seps );  // label
-	if ( !stricmp(c, "ScrollIfAtEnd") )
+	if ( stricmp(c, "ScrollIfAtEnd") == 0 )
 	{
 		c = strtok( NULL, seps );  // value
 		scanBool( c, listData->scrollIfAtEnd );
@@ -1322,7 +1322,7 @@ static Bool parseDrawData( const char *token, WinInstanceData *instData,
 		first = FALSE;
 
 		c = strtok( NULL, seps );  // value
-		if( strcmp( c, "NoImage" ) )
+		if( strcmp( c, "NoImage" ) != 0 )
 			drawData->image = TheMappedImageCollection->findImageByName( AsciiString( c ) );
 		else
 			drawData->image = NULL;
@@ -1372,46 +1372,46 @@ void *getDataTemplate( char *type )
 	static ComboBoxData	cData;
 	void *data;
 
-  if( !strcmp( type, "VERTSLIDER" ) || !strcmp( type, "HORZSLIDER" ) )
+  if( strcmp( type, "VERTSLIDER" ) == 0 || strcmp( type, "HORZSLIDER" ) == 0 )
 	{
 
     memset( &sData, 0, sizeof( SliderData ) );
     data = &sData;
 
   }
-	else if( !strcmp( type, "SCROLLLISTBOX" ) )
+	else if( strcmp( type, "SCROLLLISTBOX" ) == 0 )
 	{
 
     memset( &lData, 0, sizeof( ListboxData ) );
     data = &lData;
 
   }
-	else if( !strcmp( type, "TABCONTROL" ) )
+	else if( strcmp( type, "TABCONTROL" ) == 0 )
 	{
     memset( &tcData, 0, sizeof( TabControlData ) );
     data = &tcData;
   }
-	else if( !strcmp( type, "ENTRYFIELD" ) )
+	else if( strcmp( type, "ENTRYFIELD" ) == 0 )
 	{
 
     memset( &eData, 0, sizeof( EntryData ) );
     data = &eData;
 
   }
-	else if( !strcmp( type, "STATICTEXT" ) )
+	else if( strcmp( type, "STATICTEXT" ) == 0 )
 	{
 
 		memset( &tData, 0, sizeof( TextData ) );
 		data = &tData;
 
   }
-	else if( !strcmp( type, "RADIOBUTTON" ) )
+	else if( strcmp( type, "RADIOBUTTON" ) == 0 )
 	{
 
 		memset( &rData, 0, sizeof( RadioButtonData ) );
 		data = &rData;
 	}
-	else if( !strcmp( type, "COMBOBOX" ) )
+	else if( strcmp( type, "COMBOBOX" ) == 0 )
 	{
 
 		memset( &cData, 0, sizeof( ComboBoxData ) );
@@ -1454,7 +1454,7 @@ static Bool parseData( void **data, char *type, char *buffer )
 	static RadioButtonData rData;
 	static ComboBoxData cData;
 
-  if( !strcmp( type, "VERTSLIDER" ) || !strcmp( type, "HORZSLIDER" ) )
+  if( strcmp( type, "VERTSLIDER" ) == 0 || strcmp( type, "HORZSLIDER" ) == 0 )
 	{
 
     memset( &sData, 0, sizeof( SliderData ) );
@@ -1468,7 +1468,7 @@ static Bool parseData( void **data, char *type, char *buffer )
     *data = &sData;
 
   }
-	else if( !strcmp( type, "SCROLLLISTBOX" ) )
+	else if( strcmp( type, "SCROLLLISTBOX" ) == 0 )
 	{
 
     memset( &lData, 0, sizeof( ListboxData ) );
@@ -1497,7 +1497,7 @@ static Bool parseData( void **data, char *type, char *buffer )
     *data = &lData;
 
   }
-	else if( !strcmp( type, "ENTRYFIELD" ) )
+	else if( strcmp( type, "ENTRYFIELD" ) == 0 )
 	{
 
     memset( &eData, 0, sizeof( EntryData ) );
@@ -1538,7 +1538,7 @@ static Bool parseData( void **data, char *type, char *buffer )
     *data = &eData;
 
   }
-	else if( !strcmp( type, "STATICTEXT" ) )
+	else if( strcmp( type, "STATICTEXT" ) == 0 )
 	{
 
 	  c = strtok( buffer, " \t\n\r" );
@@ -1559,7 +1559,7 @@ static Bool parseData( void **data, char *type, char *buffer )
 		*data = &tData;
 
   }
-	else if( !strcmp( type, "RADIOBUTTON" ) )
+	else if( strcmp( type, "RADIOBUTTON" ) == 0 )
 	{
 
 		c = strtok( buffer, " \t\n\r" );
@@ -1625,7 +1625,7 @@ static GameWindow *createGadget( char *type,
 
   instData->m_owner = parent;
 
-  if( !strcmp( type, "PUSHBUTTON" ) )
+  if( strcmp( type, "PUSHBUTTON" ) == 0 )
 	{
 
     instData->m_style |= GWS_PUSH_BUTTON;
@@ -1635,7 +1635,7 @@ static GameWindow *createGadget( char *type,
 																										 instData->m_font, FALSE );
 
   }
-	else if( !strcmp( type, "RADIOBUTTON" ) )
+	else if( strcmp( type, "RADIOBUTTON" ) == 0 )
 	{
 		RadioButtonData *rData = (RadioButtonData *)data;
 		char filename[ MAX_WINDOW_NAME_LEN ];
@@ -1661,7 +1661,7 @@ static GameWindow *createGadget( char *type,
 																											instData->m_font, FALSE );
 
   }
-	else if( !strcmp( type, "CHECKBOX" ) )
+	else if( strcmp( type, "CHECKBOX" ) == 0 )
 	{
 
     instData->m_style |= GWS_CHECK_BOX;
@@ -1671,7 +1671,7 @@ static GameWindow *createGadget( char *type,
 																									 instData->m_font, FALSE );
 
   }
-	else if( !strcmp( type, "TABCONTROL" ) )
+	else if( strcmp( type, "TABCONTROL" ) == 0 )
 	{
 		TabControlData *tcData = (TabControlData *)data;
     instData->m_style |= GWS_TAB_CONTROL;
@@ -1680,7 +1680,7 @@ static GameWindow *createGadget( char *type,
 																										instData, tcData,
 																										instData->m_font, FALSE );
 	}
-	else if( !strcmp( type, "VERTSLIDER" ) )
+	else if( strcmp( type, "VERTSLIDER" ) == 0 )
 	{
     SliderData *sData = (SliderData *)data;
 
@@ -1712,7 +1712,7 @@ static GameWindow *createGadget( char *type,
 		}
 
   }
-	else if( !strcmp( type, "HORZSLIDER" ) )
+	else if( strcmp( type, "HORZSLIDER" ) == 0 )
 	{
     SliderData *sData = (SliderData *)data;
 
@@ -1744,7 +1744,7 @@ static GameWindow *createGadget( char *type,
 		}
 
   }
-	else if( !strcmp( type, "SCROLLLISTBOX" ) )
+	else if( strcmp( type, "SCROLLLISTBOX" ) == 0 )
 	{
 
     ListboxData *lData = (ListboxData *)data;
@@ -1826,7 +1826,7 @@ static GameWindow *createGadget( char *type,
 		}
 
   }
-	else if( !strcmp( type, "COMBOBOX" ) )
+	else if( strcmp( type, "COMBOBOX" ) == 0 )
 	{
 		ComboBoxData *cData = (ComboBoxData *)data;
 		cData->entryData = NEW EntryData;
@@ -1974,7 +1974,7 @@ static GameWindow *createGadget( char *type,
 			}
 		}
   }
-	else if( !strcmp( type, "ENTRYFIELD" ) )
+	else if( strcmp( type, "ENTRYFIELD" ) == 0 )
 	{
     EntryData *eData = (EntryData *)data;
 
@@ -1985,7 +1985,7 @@ static GameWindow *createGadget( char *type,
 																										instData->m_font, FALSE );
 
   }
-	else if( !strcmp( type, "STATICTEXT" ) )
+	else if( strcmp( type, "STATICTEXT" ) == 0 )
 	{
     TextData *tData = (TextData *)data;
 
@@ -1997,7 +1997,7 @@ static GameWindow *createGadget( char *type,
 
 
   }
-	else if( !strcmp( type, "PROGRESSBAR" ) )
+	else if( strcmp( type, "PROGRESSBAR" ) == 0 )
 	{
 
     instData->m_style |= GWS_PROGRESS_BAR;
@@ -2033,7 +2033,7 @@ static GameWindow *createWindow( char *type,
   parent = peekWindow();
 
   // If this is a regular window just create it
-  if( !strcmp( type, "USER" ) )
+  if( strcmp( type, "USER" ) == 0 )
 	{
 
     window = TheWindowManager->winCreate( parent,
@@ -2050,7 +2050,7 @@ static GameWindow *createWindow( char *type,
 		}
 
   }
-	else if( !strcmp( type, "TABPANE" ) )
+	else if( strcmp( type, "TABPANE" ) == 0 )
 	{
 
     window = TheWindowManager->winCreate( parent,

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GameText.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GameText.cpp
@@ -825,7 +825,7 @@ Bool GameTextManager::getStringCount( const char *filename, Int& textCount )
 				m_buffer[ len+1] = 0;
 			readToEndOfQuote( file, &m_buffer[1], m_buffer2, m_buffer3, MAX_UITEXT_LENGTH );
 		}
-		else if( !stricmp( m_buffer, "END") )
+		else if( stricmp( m_buffer, "END") == 0 )
 		{
 			textCount++;
 		}
@@ -1036,7 +1036,7 @@ Bool GameTextManager::parseStringFile( const char *filename )
 
 		for ( Int i = 0; i < listCount; i++ )
 		{
-			if ( !stricmp ( m_stringInfo[i].label.str(), m_buffer ))
+			if ( stricmp ( m_stringInfo[i].label.str(), m_buffer ) == 0)
 			{
 				DEBUG_ASSERTCRASH ( FALSE, ("String label '%s' multiply defined!", m_buffer ));
 			}
@@ -1087,7 +1087,7 @@ Bool GameTextManager::parseStringFile( const char *filename )
 					readString = TRUE;
 				}
 			}
-			else if ( !stricmp ( m_buffer, "END" ))
+			else if ( stricmp ( m_buffer, "END" ) == 0)
 			{
 				break;
 			}
@@ -1167,7 +1167,7 @@ Bool GameTextManager::parseMapStringFile( const char *filename )
 
 		for ( Int i = 0; i < listCount; i++ )
 		{
-			if ( !stricmp ( m_mapStringInfo[i].label.str(), m_buffer ))
+			if ( stricmp ( m_mapStringInfo[i].label.str(), m_buffer ) == 0)
 			{
 				DEBUG_ASSERTCRASH ( FALSE, ("String label '%s' multiply defined!", m_buffer ));
 			}
@@ -1222,7 +1222,7 @@ Bool GameTextManager::parseMapStringFile( const char *filename )
 					readString = TRUE;
 				}
 			}
-			else if ( !stricmp ( m_buffer, "END" ))
+			else if ( stricmp ( m_buffer, "END" ) == 0)
 			{
 				break;
 			}

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -647,7 +647,7 @@ Bool InGameUI::removeSuperweapon(Int playerIndex, const AsciiString& powerName, 
 				SuperweaponInfo *info = *listIt;
 				swList.erase(listIt);
 				deleteInstance(info);
-				if (swList.size() == 0)
+				if (swList.empty())
 				{
 					m_superweapons[playerIndex].erase(mapIt);
 				}
@@ -4695,7 +4695,7 @@ Bool InGameUI::canSelectedObjectsDoSpecialPower( const CommandButton *command, c
 	if (ignoreSelDraw)
 		tmpList.push_back(ignoreSelDraw);
 
-	const DrawableList* selected = (tmpList.size() > 0) ? &tmpList : TheInGameUI->getAllSelectedDrawables();
+	const DrawableList* selected = (!tmpList.empty()) ? &tmpList : TheInGameUI->getAllSelectedDrawables();
 
 	// set up counters for rule checking
 	Int count = 0;
@@ -4958,7 +4958,7 @@ Int InGameUI::selectMatchingAcrossRegion( IRegion2D *region )
 		}
 	}
 
-	if (drawableList.size() == 0)
+	if (drawableList.empty())
 		return -1; // nothing useful selected to begin with - don't bother iterating
 
 	std::set<const ThingTemplate*>::iterator iter;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AI.cpp
@@ -327,7 +327,7 @@ void AI::reset( void )
 	}
 
 #if RETAIL_COMPATIBLE_AIGROUP
-	while (m_groupList.size())
+	while (!m_groupList.empty())
 	{
 		AIGroup *groupToRemove = m_groupList.front();
 		if (groupToRemove)

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
@@ -1046,7 +1046,7 @@ Bool AIGroup::friend_moveInfantryToPos( const Coord3D *pos, CommandSourceType cm
 		dest.y -= factor*offset*endVector.y;
 		dest.z = TheTerrainLogic->getLayerHeight( dest.x, dest.y, layer );
 
-		while (path.size()>0) {
+		while (!path.empty()) {
 			Coord2D curVector;
 			prevPos = path[path.size()-1];
 			curVector.x = dest.x-prevPos.x;
@@ -1529,7 +1529,7 @@ Bool AIGroup::friend_moveVehicleToPos( const Coord3D *pos, CommandSourceType cmd
 		dest.y -= factor*offset*endVector.y;
 		dest.z = TheTerrainLogic->getLayerHeight( dest.x, dest.y, layer );
 
-		while (path.size()>0) {
+		while (!path.empty()) {
 			Coord2D curVector;
 			prevPos = path[path.size()-1];
 			curVector.x = dest.x-prevPos.x;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -971,7 +971,7 @@ StateReturnType AIStateMachine::setTemporaryState( StateID newStateID, Int frame
  */
 void AIStateMachine::addToGoalPath( const Coord3D *pathPoint)
 {
-	if (m_goalPath.size()==0) {
+	if (m_goalPath.empty()) {
 		m_goalPath.push_back(*pathPoint);
 	}	else {
 		Coord3D *finalPoint = &m_goalPath[ m_goalPath.size() - 1 ];
@@ -6005,7 +6005,7 @@ Object *AIAttackSquadState::chooseVictim(void)
 		{
 			// everyone picks the same unit
 			VecObjectPtr objects = victimSquad->getLiveObjects();
-			if (objects.size() > 0)
+			if (!objects.empty())
 			{
 				return objects[0];
 			}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/Squad.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/Squad.cpp
@@ -233,7 +233,7 @@ void Squad::xfer( Xfer *xfer )
 	{
 
 		// the cached objects list should be empty
-		if( m_objectsCached.size() != 0 )
+		if( !m_objectsCached.empty() )
 		{
 
 			DEBUG_CRASH(( "Squad::xfer - m_objectsCached should be emtpy, but is not" ));

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
@@ -953,7 +953,7 @@ protected:
 				if (di)
 				{
 					di->setModelName(modelName, m_okToChangeModelColor ? obj->getIndicatorColor() : 0, m_shadowType);
-					if (m_animSets.size() > 0)
+					if (!m_animSets.empty())
 					{
 						Int which = GameLogicRandomValue(0, m_animSets.size()-1);
 						di->setAnimNames(m_animSets[which].m_animInitial, m_animSets[which].m_animFlying, m_animSets[which].m_animFinal, m_fxFinal);
@@ -1304,7 +1304,7 @@ protected:
 	{
 		static const ThingTemplate* debrisTemplate = TheThingFactory->findTemplate("GenericDebris");
 
-		if (m_names.size() <= 0)
+		if (m_names.empty())
 			return NULL;
 
 		if (m_requiresLivePlayer && (!sourceObj || !sourceObj->getControllingPlayer() || !sourceObj->getControllingPlayer()->isPlayerActive()))

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -179,7 +179,7 @@ const LocomotorTemplateVector* AIUpdateModuleData::findLocomotorTemplateVector(L
 	self->m_locomotorTemplates[set].clear();
 	for (const char* locoName = ini->getNextToken(); locoName; locoName = ini->getNextTokenOrNull())
 	{
-		if (!*locoName || !stricmp(locoName, "None"))
+		if (!*locoName || stricmp(locoName, "None") == 0)
 			continue;
 
 		NameKeyType locoKey = NAMEKEY(locoName);
@@ -3391,7 +3391,7 @@ void AIUpdateInterface::privateFollowPath( const std::vector<Coord3D>* path, Obj
 	// clear current state machine
 	getStateMachine()->clear();
 
-	if (path->size()>0) {
+	if (!path->empty()) {
 		const Coord3D goal = (*path)[path->size()-1];
 		getStateMachine()->setGoalPosition(&goal);
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DeliverPayloadAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DeliverPayloadAIUpdate.cpp
@@ -697,7 +697,7 @@ StateReturnType DeliveringState::update() // Kick a dude out every so often
 		return STATE_FAILURE;
 
 	const ContainedItemsList* items = owner->getContain() ? owner->getContain()->getContainedItemsList() : NULL;
-	if( (!items || !items->size()) && ai->getVisibleItemsDelivered() == ai->getData()->m_visibleNumBones )
+	if( (!items || items->empty()) && ai->getVisibleItemsDelivered() == ai->getData()->m_visibleNumBones )
 	{
 		//We are out of payload to drop AND our visible payload is empty. It's possible for deliverers to
 		//have one or the other or even both.

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -1180,7 +1180,7 @@ UnsignedInt WeaponTemplate::fireWeaponTemplate
 void WeaponTemplate::trimOldHistoricDamage() const
 {
 	UnsignedInt expirationDate = TheGameLogic->getFrame() - TheGlobalData->m_historicDamageLimit;
-	while (m_historicDamage.size() > 0)
+	while (!m_historicDamage.empty())
 	{
 		HistoricWeaponDamageInfo& h = m_historicDamage.front();
 		if (h.frame <= expirationDate)
@@ -2672,7 +2672,7 @@ Bool Weapon::privateFireWeapon(
 			m_numShotsForCurBarrel = m_template->getShotsPerBarrel();
 		}
 
-		if( m_scatterTargetsUnused.size() )
+		if( !m_scatterTargetsUnused.empty() )
 		{
 			// If I have a set scatter pattern, I need to offset the target by a random pick from that pattern
 			if( victimObj )

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptEngine.cpp
@@ -8870,7 +8870,7 @@ void ScriptEngine::xfer( Xfer *xfer )
 	{
 
 		// this list should be empty on loading
-		if( m_sequentialScripts.size() != 0 )
+		if( !m_sequentialScripts.empty() )
 		{
 
 			DEBUG_CRASH(( "ScriptEngine::xfer - m_sequentialScripts should be empty but is not" ));

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
@@ -647,7 +647,7 @@ void ModelConditionInfo::validateCachedBones(RenderObjClass* robj, Real scale) c
 	// if we have any animations in this state, always choose the first, since the animations
 	// vary on a per-client basis.
 	HAnimClass* animToUse;
-	if (m_animations.size() > 0)
+	if (!m_animations.empty())
 	{
 		animToUse = m_animations.front().getAnimHandle();	// return an AddRef'ed handle
 	}
@@ -3803,8 +3803,8 @@ void W3DModelDraw::setAnimationLoopDuration(UnsignedInt numFrames)
 */
 void W3DModelDraw::setAnimationCompletionTime(UnsignedInt numFrames)
 {
-	if (m_curState != NULL && m_curState->m_transitionSig != NO_TRANSITION && m_curState->m_animations.size() > 0 &&
-			m_nextState != NULL && m_nextState->m_transitionSig == NO_TRANSITION && m_nextState->m_animations.size() > 0)
+	if (m_curState != NULL && m_curState->m_transitionSig != NO_TRANSITION && !m_curState->m_animations.empty() &&
+			m_nextState != NULL && m_nextState->m_transitionSig == NO_TRANSITION && !m_nextState->m_animations.empty())
 	{
 		// we have a transition; split up the time suitably.
 		// note that this is just a guess, and assumes that the states

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8caps.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8caps.cpp
@@ -833,14 +833,14 @@ void DX8Caps::Check_Driver_Version_Status()
 		DriverVersionStatus=DRIVER_STATUS_BAD;
 		break;
 	case VENDOR_NVIDIA:
-		if (!stricmp(DriverDLL,"nv4.dll")) {
+		if (stricmp(DriverDLL,"nv4.dll") == 0) {
 			switch (DriverBuildVersion) {
 			case 327:	// 5.00.2165.327
 				DriverVersionStatus=DRIVER_STATUS_BAD;
 			}
 		}
 
-		if (!stricmp(DriverDLL,"nv4_disp.dll") || !stricmp(DriverDLL,"nvdd32.dll")) {
+		if (stricmp(DriverDLL,"nv4_disp.dll") == 0 || stricmp(DriverDLL,"nvdd32.dll") == 0) {
 			switch (DriverBuildVersion) {
 			// 23.11 Is known to be very unstable
 			case 2311:
@@ -902,7 +902,7 @@ void DX8Caps::Check_Driver_Version_Status()
 			}
 		}
 		// Elsa OEM drivers?
-		if (!stricmp(DriverDLL,"egdad.dll")) {
+		if (stricmp(DriverDLL,"egdad.dll") == 0) {
 			// We know of version 5.9.0.312 (asked MShelling if he the drivers seem ok)
 			switch (DriverBuildVersion) {
 			default:
@@ -913,7 +913,7 @@ void DX8Caps::Check_Driver_Version_Status()
 		}
 
 		// Elsa GLoria
-		if (!stricmp(DriverDLL,"egliid.dll")) {
+		if (stricmp(DriverDLL,"egliid.dll") == 0) {
 			switch (DriverBuildVersion) {
 			default:
 				DriverVersionStatus=DRIVER_STATUS_UNKNOWN;
@@ -924,12 +924,12 @@ void DX8Caps::Check_Driver_Version_Status()
 		}
 
 		// ASUS OEM drivers?
-		if (!stricmp(DriverDLL,"v66_disp.dll")) {
+		if (stricmp(DriverDLL,"v66_disp.dll") == 0) {
 		// TOMSS1: 5.0.2195.379
 		}
 		break;
 	case VENDOR_ATI:
-		if (!stricmp(DriverDLL,"ati2dvag.dll")) {
+		if (stricmp(DriverDLL,"ati2dvag.dll") == 0) {
 			switch (DriverBuildVersion) {
 			case 3287:
 				DriverVersionStatus=DRIVER_STATUS_UNKNOWN;
@@ -948,13 +948,13 @@ void DX8Caps::Check_Driver_Version_Status()
 				break;
 			}
 		}
-		if (!stricmp(DriverDLL,"atid32ae.dll")) {
+		if (stricmp(DriverDLL,"atid32ae.dll") == 0) {
 			switch (DriverBuildVersion) {
 			case 1010:
 				DriverVersionStatus=DRIVER_STATUS_OK;
 			}
 		}
-		if (!stricmp(DriverDLL,"ati3drai.dll")) {
+		if (stricmp(DriverDLL,"ati3drai.dll") == 0) {
 			switch (DriverBuildVersion) {
 			case 1119:
 				DriverVersionStatus=DRIVER_STATUS_UNKNOWN;
@@ -962,7 +962,7 @@ void DX8Caps::Check_Driver_Version_Status()
 		}
 		break;
 	case VENDOR_POWERVR:
-		if (!stricmp(DriverDLL,"pmx2hal.dll")) {
+		if (stricmp(DriverDLL,"pmx2hal.dll") == 0) {
 			switch (DriverBuildVersion) {
 			case 3111:	// Michael Ruppert - TESTIBM104
 			default: DriverVersionStatus=DRIVER_STATUS_UNKNOWN;

--- a/GeneralsMD/Code/Tools/ParticleEditor/ParticleEditorDialog.cpp
+++ b/GeneralsMD/Code/Tools/ParticleEditor/ParticleEditorDialog.cpp
@@ -336,7 +336,7 @@ void DebugWindowDialog::getSelectedParticleAsciiStringParm( IN int parmNum, OUT 
 		return;
 	}
 
-	if (m_particleParmValues[parmNum].length()) {
+	if (!m_particleParmValues[parmNum].empty()) {
 		strcpy(bufferToCopyInto, m_particleParmValues[parmNum].c_str());
 	} else {
 		bufferToCopyInto[0] = 0;


### PR DESCRIPTION
### Container Empty Checks (`readability-container-size-empty`)
**Before:** `if (container.size() == 0)`  
**After:** `if (container.empty())`

### Explicit String Comparisons (`bugprone-suspicious-string-compare`)
**Before:** `if (strcmp(a, b))`  
**After:** `if (strcmp(a, b) == 0)`

Applied automatically using `clang-tidy` checks:
- `readability-container-size-empty`
- `bugprone-suspicious-string-compare`