### PR TITLE
perf(namekey): Remove superfluous AsciiString allocations for name key lookups

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/DamageFX.h
+++ b/Generals/Code/GameEngine/Include/Common/DamageFX.h
@@ -147,7 +147,9 @@ public:
 	/**
 		Find the DamageFX with the given name. If no such DamageFX exists, return null.
 	*/
-	const DamageFX *findDamageFX( AsciiString name ) const;
+	const DamageFX *findDamageFX( NameKeyType namekey ) const;
+	const DamageFX *findDamageFX( const AsciiString& name ) const;
+	const DamageFX *findDamageFX( const char* name ) const;
 
 	static void parseDamageFXDefinition(INI* ini);
 

--- a/Generals/Code/GameEngine/Include/Common/NameKeyGenerator.h
+++ b/Generals/Code/GameEngine/Include/Common/NameKeyGenerator.h
@@ -90,8 +90,8 @@ public:
 	virtual void update() { }
 
 	/// Given a string, convert into a unique integer key.
-	NameKeyType nameToKey(const AsciiString& name) { return nameToKey(name.str()); }
-	NameKeyType nameToLowercaseKey(const AsciiString& name) { return nameToLowercaseKey(name.str()); }
+	NameKeyType nameToKey(const AsciiString& name);
+	NameKeyType nameToLowercaseKey(const AsciiString& name);
 
 	/// Given a string, convert into a unique integer key.
 	NameKeyType nameToKey(const char* name);
@@ -120,6 +120,8 @@ private:
 	Bool addReservedKey();
 #endif
 
+	NameKeyType nameToKeyImpl(const AsciiString& name);
+	NameKeyType nameToLowercaseKeyImpl(const AsciiString& name);
 	NameKeyType nameToKeyImpl(const char* name);
 	NameKeyType nameToLowercaseKeyImpl(const char *name);
 	NameKeyType createNameKey(UnsignedInt hash, const AsciiString& name);

--- a/Generals/Code/GameEngine/Include/Common/Upgrade.h
+++ b/Generals/Code/GameEngine/Include/Common/Upgrade.h
@@ -235,6 +235,7 @@ public:
 	UpgradeTemplate *firstUpgradeTemplate( void ); ///< return the first upgrade template
 	const UpgradeTemplate *findUpgradeByKey( NameKeyType key ) const; ///< find upgrade by name key
 	const UpgradeTemplate *findUpgrade( const AsciiString& name ) const; ///< find and return upgrade by name
+	const UpgradeTemplate *findUpgrade( const char* name ) const; ///< find and return upgrade by name
 	const UpgradeTemplate *findVeterancyUpgrade(VeterancyLevel level) const; ///< find and return upgrade by veterancy level
 
 	UpgradeTemplate *newUpgrade( const AsciiString& name );				///< allocate, link, and return new upgrade

--- a/Generals/Code/GameEngine/Include/GameClient/Image.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Image.h
@@ -116,6 +116,7 @@ friend class ImageCollection;
 //-------------------------------------------------------------------------------------------------
 class ImageCollection : public SubsystemInterface
 {
+	typedef std::map<NameKeyType, Image *> ImageMap;
 
 public:
 
@@ -128,7 +129,9 @@ public:
 
 	void load( Int textureSize );												 ///< load images
 
+	const Image *findImage( NameKeyType namekey ) const; ///< find image based on name key
 	const Image *findImageByName( const AsciiString& name ) const; ///< find image based on name
+	const Image *findImageByName( const char* name ) const; ///< find image based on name
 
   /// adds the given image to the collection, transfers ownership to this object
   void addImage(Image *image);
@@ -136,14 +139,14 @@ public:
   /// enumerates the list of existing images
   Image *Enum(unsigned index)
   {
-    for (std::map<unsigned,Image *>::iterator i=m_imageMap.begin();i!=m_imageMap.end();++i)
+    for (ImageMap::iterator i=m_imageMap.begin();i!=m_imageMap.end();++i)
       if (!index--)
         return i->second;
     return NULL;
   }
 
 protected:
-  std::map<unsigned,Image *> m_imageMap;  ///< maps named keys to images
+  ImageMap m_imageMap;  ///< maps named keys to images
 };
 
 // INLINING ///////////////////////////////////////////////////////////////////////////////////////

--- a/Generals/Code/GameEngine/Include/GameLogic/Armor.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Armor.h
@@ -105,10 +105,12 @@ public:
 	void reset() { }
 	void update() { }
 
+	const ArmorTemplate* findArmorTemplate(NameKeyType namekey) const;
 	/**
 		Find the Armor with the given name. If no such Armor exists, return null.
 	*/
-	const ArmorTemplate* findArmorTemplate(AsciiString name) const;
+	const ArmorTemplate* findArmorTemplate(const AsciiString& name) const;
+	const ArmorTemplate* findArmorTemplate(const char* name) const;
 
 	inline Armor makeArmor(const ArmorTemplate *tmpl) const
 	{

--- a/Generals/Code/GameEngine/Include/GameLogic/Weapon.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Weapon.h
@@ -814,7 +814,8 @@ public:
 	/**
 		Find the WeaponTemplate with the given name. If no such WeaponTemplate exists, return null.
 	*/
-	const WeaponTemplate *findWeaponTemplate(AsciiString name) const;
+	const WeaponTemplate *findWeaponTemplate(const AsciiString& name) const;
+	const WeaponTemplate *findWeaponTemplate(const char* name) const;
 	const WeaponTemplate *findWeaponTemplateByNameKey( NameKeyType key ) const { return findWeaponTemplatePrivate( key ); }
 
 	// this dynamically allocates a new Weapon, which is owned (and must be freed!) by the caller.

--- a/Generals/Code/GameEngine/Source/Common/DamageFX.cpp
+++ b/Generals/Code/GameEngine/Source/Common/DamageFX.cpp
@@ -274,11 +274,10 @@ DamageFXStore::~DamageFXStore()
 }
 
 //-------------------------------------------------------------------------------------------------
-const DamageFX *DamageFXStore::findDamageFX(AsciiString name) const
+const DamageFX *DamageFXStore::findDamageFX(NameKeyType namekey) const
 {
-	NameKeyType namekey = TheNameKeyGenerator->nameToKey(name);
-  DamageFXMap::const_iterator it = m_dfxmap.find(namekey);
-  if (it == m_dfxmap.end())
+	DamageFXMap::const_iterator it = m_dfxmap.find(namekey);
+	if (it == m_dfxmap.end())
 	{
 		return NULL;
 	}
@@ -286,6 +285,18 @@ const DamageFX *DamageFXStore::findDamageFX(AsciiString name) const
 	{
 		return &(*it).second;
 	}
+}
+
+//-------------------------------------------------------------------------------------------------
+const DamageFX *DamageFXStore::findDamageFX(const AsciiString& name) const
+{
+	return findDamageFX(TheNameKeyGenerator->nameToKey(name));
+}
+
+//-------------------------------------------------------------------------------------------------
+const DamageFX *DamageFXStore::findDamageFX(const char* name) const
+{
+	return findDamageFX(TheNameKeyGenerator->nameToKey(name));
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/Common/INI/INI.cpp
+++ b/Generals/Code/GameEngine/Source/Common/INI/INI.cpp
@@ -872,7 +872,7 @@ void INI::parseMappedImage( INI *ini, void * /*instance*/, void *store, const vo
 	if( TheMappedImageCollection )
 	{
 		typedef const Image* ConstImagePtr;
-		*(ConstImagePtr*)store = TheMappedImageCollection->findImageByName( AsciiString( token ) );
+		*(ConstImagePtr*)store = TheMappedImageCollection->findImageByName( token );
 	}
 
 	//KM: If we are in the worldbuilder, we want to parse commandbuttons for informational purposes,
@@ -1377,7 +1377,7 @@ void INI::parseUpgradeTemplate( INI* ini, void * /*instance*/, void *store, cons
 		throw ERROR_BUG;
 	}
 
-	const UpgradeTemplate *uu = TheUpgradeCenter->findUpgrade( AsciiString( token ) );
+	const UpgradeTemplate *uu = TheUpgradeCenter->findUpgrade( token );
 	DEBUG_ASSERTCRASH( uu || stricmp( token, "None" ) == 0, ("Upgrade %s not found!",token) );
 
 	typedef const UpgradeTemplate* ConstUpgradeTemplatePtr;

--- a/Generals/Code/GameEngine/Source/Common/INI/INIMappedImage.cpp
+++ b/Generals/Code/GameEngine/Source/Common/INI/INIMappedImage.cpp
@@ -42,11 +42,8 @@
 //-------------------------------------------------------------------------------------------------
 void INI::parseMappedImageDefinition( INI* ini )
 {
-	AsciiString name;
-
 	// read the name
-	const char* c = ini->getNextToken();
-	name.set( c );
+	const char* name = ini->getNextToken();
 
 	//
 	// find existing item if present, note that we do not support overrides
@@ -66,11 +63,10 @@ void INI::parseMappedImageDefinition( INI* ini )
 	{
 
 		// image not found, create a new one
-  	image = newInstance(Image);
+		image = newInstance(Image);
 		image->setName( name );
 		TheMappedImageCollection->addImage(image);
-		DEBUG_ASSERTCRASH( image, ("parseMappedImage: unable to allocate image for '%s'",
-															name.str()) );
+		DEBUG_ASSERTCRASH( image, ("parseMappedImage: unable to allocate image for '%s'", name) );
 
 	}
 

--- a/Generals/Code/GameEngine/Source/Common/System/FunctionLexicon.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/FunctionLexicon.cpp
@@ -389,7 +389,7 @@ void FunctionLexicon::loadTable( TableEntry *table,
 	{
 
 		// assign key from name key based on name provided in table
-		entry->key = TheNameKeyGenerator->nameToKey( AsciiString(entry->name) );
+		entry->key = TheNameKeyGenerator->nameToKey( entry->name );
 
 		// next table entry please
 		entry++;

--- a/Generals/Code/GameEngine/Source/Common/System/Upgrade.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/Upgrade.cpp
@@ -352,6 +352,14 @@ const UpgradeTemplate *UpgradeCenter::findUpgrade( const AsciiString& name ) con
 }
 
 //-------------------------------------------------------------------------------------------------
+/** Find upgrade by name */
+//-------------------------------------------------------------------------------------------------
+const UpgradeTemplate *UpgradeCenter::findUpgrade( const char* name ) const
+{
+	return findUpgradeByKey( TheNameKeyGenerator->nameToKey( name ) );
+}
+
+//-------------------------------------------------------------------------------------------------
 /** Allocate a new upgrade template */
 //-------------------------------------------------------------------------------------------------
 UpgradeTemplate *UpgradeCenter::newUpgrade( const AsciiString& name )
@@ -470,8 +478,7 @@ std::vector<AsciiString> UpgradeCenter::getUpgradeNames( void ) const
 void UpgradeCenter::parseUpgradeDefinition( INI *ini )
 {
 	// read the name
-	const char* c = ini->getNextToken();
-	AsciiString name = c;
+	const char* name = ini->getNextToken();
 
 	// find existing item if present
 	UpgradeTemplate* upgrade = TheUpgradeCenter->findNonConstUpgradeByKey( NAMEKEY(name) );
@@ -484,7 +491,7 @@ void UpgradeCenter::parseUpgradeDefinition( INI *ini )
 	}
 
 	// sanity
-	DEBUG_ASSERTCRASH( upgrade, ("parseUpgradeDefinition: Unable to allocate upgrade '%s'", name.str()) );
+	DEBUG_ASSERTCRASH( upgrade, ("parseUpgradeDefinition: Unable to allocate upgrade '%s'", name) );
 
 	// parse the ini definition
 	ini->initFromINI( upgrade, upgrade->getFieldParse() );

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/DifficultySelect.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/DifficultySelect.cpp
@@ -125,8 +125,7 @@ static void SetDifficultyRadioButton( void )
 
 void DifficultySelectInit( WindowLayout *layout, void *userData )
 {
-	AsciiString parentName( "DifficultySelect.wnd:DifficultySelectParent" );
-	NameKeyType parentID = TheNameKeyGenerator->nameToKey( parentName );
+	NameKeyType parentID = TheNameKeyGenerator->nameToKey( "DifficultySelect.wnd:DifficultySelectParent" );
 	GameWindow *parent = TheWindowManager->winGetWindowFromId( NULL, parentID );
 
 	buttonOkID = TheNameKeyGenerator->nameToKey( "DifficultySelect.wnd:ButtonOk" );

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/DownloadMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/DownloadMenu.cpp
@@ -349,8 +349,7 @@ WindowMsgHandledType DownloadMenuInput( GameWindow *window, UnsignedInt msg,
 					//
 					if( BitIsSet( state, KEY_STATE_UP ) )
 					{
-						AsciiString buttonName( "DownloadMenu.wnd:ButtonCancel" );
-						NameKeyType buttonID = TheNameKeyGenerator->nameToKey( buttonName );
+						NameKeyType buttonID = TheNameKeyGenerator->nameToKey( "DownloadMenu.wnd:ButtonCancel" );
 						GameWindow *button = TheWindowManager->winGetWindowFromId( window, buttonID );
 
 						TheWindowManager->winSendSystemMsg( window, GBM_SELECTED,

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/KeyboardOptionsMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/KeyboardOptionsMenu.cpp
@@ -499,8 +499,7 @@ WindowMsgHandledType KeyboardOptionsMenuInput( GameWindow *window, UnsignedInt m
 					//
 					if( BitIsSet( state, KEY_STATE_UP ) )
 					{
-						AsciiString buttonName( "KeyboardOptionsMenu.wnd:ButtonBack" );
-						NameKeyType buttonID = TheNameKeyGenerator->nameToKey( buttonName );
+						NameKeyType buttonID = TheNameKeyGenerator->nameToKey( "KeyboardOptionsMenu.wnd:ButtonBack" );
 						GameWindow *button = TheWindowManager->winGetWindowFromId( window, buttonID );
 
 						TheWindowManager->winSendSystemMsg( window, GBM_SELECTED,

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanMapSelectMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanMapSelectMenu.cpp
@@ -122,8 +122,7 @@ void LanMapSelectMenuInit( WindowLayout *layout, void *userData )
 	showLANGameOptionsUnderlyingGUIElements(FALSE);
 
 	// set keyboard focus to main parent
-	AsciiString parentName( "LanMapSelectMenu.wnd:LanMapSelectMenuParent" );
-	NameKeyType parentID = TheNameKeyGenerator->nameToKey( parentName );
+	NameKeyType parentID = TheNameKeyGenerator->nameToKey( "LanMapSelectMenu.wnd:LanMapSelectMenuParent" );
 	parent = TheWindowManager->winGetWindowFromId( NULL, parentID );
 
 	TheWindowManager->winSetFocus( parent );
@@ -165,8 +164,7 @@ void LanMapSelectMenuInit( WindowLayout *layout, void *userData )
 	}
 
 	// get the listbox window
-	AsciiString listString( "LanMapSelectMenu.wnd:ListboxMap" );
-	NameKeyType mapListID = TheNameKeyGenerator->nameToKey( listString );
+	NameKeyType mapListID = TheNameKeyGenerator->nameToKey( "LanMapSelectMenu.wnd:ListboxMap" );
 	mapList = TheWindowManager->winGetWindowFromId( parent, mapListID );
 	if( mapList )
 	{
@@ -228,8 +226,7 @@ WindowMsgHandledType LanMapSelectMenuInput( GameWindow *window, UnsignedInt msg,
 					//
 					if( BitIsSet( state, KEY_STATE_UP ) )
 					{
-						AsciiString buttonName( "LanMapSelectMenu.wnd:ButtonBack" );
-						NameKeyType buttonID = TheNameKeyGenerator->nameToKey( buttonName );
+						NameKeyType buttonID = TheNameKeyGenerator->nameToKey( "LanMapSelectMenu.wnd:ButtonBack" );
 						GameWindow *button = TheWindowManager->winGetWindowFromId( window, buttonID );
 
 						TheWindowManager->winSendSystemMsg( window, GBM_SELECTED,

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/MapSelectMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/MapSelectMenu.cpp
@@ -108,8 +108,7 @@ static void shutdownComplete( WindowLayout *layout )
 
 void SetDifficultyRadioButton( void )
 {
-	AsciiString parentName( "MapSelectMenu.wnd:MapSelectMenuParent" );
-	NameKeyType parentID = TheNameKeyGenerator->nameToKey( parentName );
+	NameKeyType parentID = TheNameKeyGenerator->nameToKey( "MapSelectMenu.wnd:MapSelectMenuParent" );
 	GameWindow *parent = TheWindowManager->winGetWindowFromId( NULL, parentID );
 
 	if (!TheScriptEngine)
@@ -171,8 +170,7 @@ void MapSelectMenuInit( WindowLayout *layout, void *userData )
 	Bool usesSystemMapDir = pref.usesSystemMapDir();
 
 	// get the listbox window
-	AsciiString listString( "MapSelectMenu.wnd:ListboxMap" );
-	NameKeyType mapListID = TheNameKeyGenerator->nameToKey( listString );
+	NameKeyType mapListID = TheNameKeyGenerator->nameToKey( "MapSelectMenu.wnd:ListboxMap" );
 	mapList = TheWindowManager->winGetWindowFromId( NULL, mapListID );
 	if( mapList )
 	{
@@ -183,8 +181,7 @@ void MapSelectMenuInit( WindowLayout *layout, void *userData )
 
 
 	// set keyboard focus to main parent
-	AsciiString parentName( "MapSelectMenu.wnd:MapSelectMenuParent" );
-	NameKeyType parentID = TheNameKeyGenerator->nameToKey( parentName );
+	NameKeyType parentID = TheNameKeyGenerator->nameToKey( "MapSelectMenu.wnd:MapSelectMenuParent" );
 	GameWindow *parent = TheWindowManager->winGetWindowFromId( NULL, parentID );
 	TheWindowManager->winSetFocus( parent );
 
@@ -280,8 +277,7 @@ WindowMsgHandledType MapSelectMenuInput( GameWindow *window, UnsignedInt msg,
 					//
 					if( BitIsSet( state, KEY_STATE_UP ) )
 					{
-						AsciiString buttonName( "MapSelectMenu.wnd:ButtonBack" );
-						NameKeyType buttonID = TheNameKeyGenerator->nameToKey( buttonName );
+						NameKeyType buttonID = TheNameKeyGenerator->nameToKey( "MapSelectMenu.wnd:ButtonBack" );
 						GameWindow *button = TheWindowManager->winGetWindowFromId( window, buttonID );
 
 						TheWindowManager->winSendSystemMsg( window, GBM_SELECTED,

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -2046,8 +2046,7 @@ void OptionsMenuInit( WindowLayout *layout, void *userData )
 	layout->hide( FALSE );
 
 	// set keyboard focus to main parent
-	AsciiString parentName( "OptionsMenu.wnd:OptionsMenuParent" );
-	NameKeyType parentID = TheNameKeyGenerator->nameToKey( parentName );
+	NameKeyType parentID = TheNameKeyGenerator->nameToKey( "OptionsMenu.wnd:OptionsMenuParent" );
 	GameWindow *parent = TheWindowManager->winGetWindowFromId( NULL, parentID );
 	TheWindowManager->winSetFocus( parent );
 
@@ -2148,8 +2147,7 @@ WindowMsgHandledType OptionsMenuInput( GameWindow *window, UnsignedInt msg,
 					//
 					if( BitIsSet( state, KEY_STATE_UP ) )
 					{
-						AsciiString buttonName( "OptionsMenu.wnd:ButtonBack" );
-						NameKeyType buttonID = TheNameKeyGenerator->nameToKey( buttonName );
+						NameKeyType buttonID = TheNameKeyGenerator->nameToKey( "OptionsMenu.wnd:ButtonBack" );
 						GameWindow *button = TheWindowManager->winGetWindowFromId( window, buttonID );
 
 						TheWindowManager->winSendSystemMsg( window, GBM_SELECTED,

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SinglePlayerMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SinglePlayerMenu.cpp
@@ -69,8 +69,7 @@ void SinglePlayerMenuInit( WindowLayout *layout, void *userData )
 	layout->hide( FALSE );
 
 	// set keyboard focus to main parent
-	AsciiString parentName( "SinglePlayerMenu.wnd:SinglePlayerMenuParent" );
-	NameKeyType parentID = TheNameKeyGenerator->nameToKey( parentName );
+	NameKeyType parentID = TheNameKeyGenerator->nameToKey( "SinglePlayerMenu.wnd:SinglePlayerMenuParent" );
 	GameWindow *parent = TheWindowManager->winGetWindowFromId( NULL, parentID );
 	TheWindowManager->winSetFocus( parent );
 
@@ -155,8 +154,7 @@ WindowMsgHandledType SinglePlayerMenuInput( GameWindow *window, UnsignedInt msg,
 					//
 					if( BitIsSet( state, KEY_STATE_UP ) )
 					{
-						AsciiString buttonName( "SinglePlayerMenu.wnd:ButtonBack" );
-						NameKeyType buttonID = TheNameKeyGenerator->nameToKey( buttonName );
+						NameKeyType buttonID = TheNameKeyGenerator->nameToKey( "SinglePlayerMenu.wnd:ButtonBack" );
 						GameWindow *button = TheWindowManager->winGetWindowFromId( window, buttonID );
 
 						TheWindowManager->winSendSystemMsg( window, GBM_SELECTED,

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishMapSelectMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishMapSelectMenu.cpp
@@ -127,8 +127,7 @@ void skirmishPositionStartSpots( void );
 void skirmishUpdateSlotList( void );
 void showSkirmishGameOptionsUnderlyingGUIElements( Bool show )
 {
-	AsciiString parentName( "SkirmishGameOptionsMenu.wnd:SkirmishGameOptionsMenuParent" );
-	NameKeyType parentID = TheNameKeyGenerator->nameToKey( parentName );
+	NameKeyType parentID = TheNameKeyGenerator->nameToKey( "SkirmishGameOptionsMenu.wnd:SkirmishGameOptionsMenuParent" );
 	GameWindow *parent = TheWindowManager->winGetWindowFromId( NULL, parentID );
 	if (!parent)
 		return;
@@ -249,8 +248,7 @@ void SkirmishMapSelectMenuInit( WindowLayout *layout, void *userData )
 {
 
 	// set keyboard focus to main parent
-	AsciiString parentName( "SkirmishMapSelectMenu.wnd:SkrimishMapSelectMenuParent" );
-	NameKeyType parentID = TheNameKeyGenerator->nameToKey( parentName );
+	NameKeyType parentID = TheNameKeyGenerator->nameToKey( "SkirmishMapSelectMenu.wnd:SkrimishMapSelectMenuParent" );
 	parent = TheWindowManager->winGetWindowFromId( NULL, parentID );
 
 	TheWindowManager->winSetFocus( parent );
@@ -295,8 +293,7 @@ void SkirmishMapSelectMenuInit( WindowLayout *layout, void *userData )
 	showSkirmishGameOptionsUnderlyingGUIElements(FALSE);
 
 	// get the listbox window
-	AsciiString listString( "SkirmishMapSelectMenu.wnd:ListboxMap" );
-	NameKeyType mapListID = TheNameKeyGenerator->nameToKey( listString );
+	NameKeyType mapListID = TheNameKeyGenerator->nameToKey( "SkirmishMapSelectMenu.wnd:ListboxMap" );
 	mapList = TheWindowManager->winGetWindowFromId( parent, mapListID );
 	if( mapList )
 	{
@@ -369,8 +366,7 @@ WindowMsgHandledType SkirmishMapSelectMenuInput( GameWindow *window, UnsignedInt
 					//
 					if( BitIsSet( state, KEY_STATE_UP ) )
 					{
-						AsciiString buttonName( "SkirmishMapSelectMenu.wnd:ButtonBack" );
-						NameKeyType buttonID = TheNameKeyGenerator->nameToKey( buttonName );
+						NameKeyType buttonID = TheNameKeyGenerator->nameToKey( "SkirmishMapSelectMenu.wnd:ButtonBack" );
 						GameWindow *button = TheWindowManager->winGetWindowFromId( window, buttonID );
 
 						TheWindowManager->winSendSystemMsg( window, GBM_SELECTED,

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLMapSelectMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLMapSelectMenu.cpp
@@ -127,8 +127,7 @@ void WOLMapSelectMenuInit( WindowLayout *layout, void *userData )
 {
 
 	// set keyboard focus to main parent
-	AsciiString parentName( "WOLMapSelectMenu.wnd:WOLMapSelectMenuParent" );
-	NameKeyType parentID = TheNameKeyGenerator->nameToKey( parentName );
+	NameKeyType parentID = TheNameKeyGenerator->nameToKey( "WOLMapSelectMenu.wnd:WOLMapSelectMenuParent" );
 	parent = TheWindowManager->winGetWindowFromId( NULL, parentID );
 
 	TheWindowManager->winSetFocus( parent );
@@ -173,8 +172,7 @@ void WOLMapSelectMenuInit( WindowLayout *layout, void *userData )
 	showGameSpyGameOptionsUnderlyingGUIElements( FALSE );
 
 	// get the listbox window
-	AsciiString listString( "WOLMapSelectMenu.wnd:ListboxMap" );
-	NameKeyType mapListID = TheNameKeyGenerator->nameToKey( listString );
+	NameKeyType mapListID = TheNameKeyGenerator->nameToKey( "WOLMapSelectMenu.wnd:ListboxMap" );
 	mapList = TheWindowManager->winGetWindowFromId( parent, mapListID );
 	if( mapList )
 	{
@@ -245,8 +243,7 @@ WindowMsgHandledType WOLMapSelectMenuInput( GameWindow *window, UnsignedInt msg,
 					//
 					if( BitIsSet( state, KEY_STATE_UP ) )
 					{
-						AsciiString buttonName( "WOLMapSelectMenu.wnd:ButtonBack" );
-						NameKeyType buttonID = TheNameKeyGenerator->nameToKey( buttonName );
+						NameKeyType buttonID = TheNameKeyGenerator->nameToKey( "WOLMapSelectMenu.wnd:ButtonBack" );
 						GameWindow *button = TheWindowManager->winGetWindowFromId( window, buttonID );
 
 						TheWindowManager->winSendSystemMsg( window, GBM_SELECTED,

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GameWindowGlobal.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GameWindowGlobal.cpp
@@ -131,7 +131,7 @@ const Image *GameWindowManager::winFindImage( const char *name )
 
 	assert( TheMappedImageCollection );
 	if( TheMappedImageCollection )
-		return TheMappedImageCollection->findImageByName( AsciiString( name ) );
+		return TheMappedImageCollection->findImageByName( name );
 
 	return NULL;
 

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GameWindowManagerScript.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GameWindowManagerScript.cpp
@@ -1315,7 +1315,7 @@ static Bool parseDrawData( const char *token, WinInstanceData *instData,
 
 		c = strtok( NULL, seps );  // value
 		if( strcmp( c, "NoImage" ) )
-			drawData->image = TheMappedImageCollection->findImageByName( AsciiString( c ) );
+			drawData->image = TheMappedImageCollection->findImageByName( c );
 		else
 			drawData->image = NULL;
 		// COLOR: R G B A
@@ -1644,7 +1644,7 @@ static GameWindow *createGadget( char *type,
 			*c = 0;  // terminate after filename (format is filename:gadgetname)
 		assert( TheNameKeyGenerator );
 		if( TheNameKeyGenerator )
-			rData->screen = (Int)(TheNameKeyGenerator->nameToKey( AsciiString(filename) ));
+			rData->screen = (Int)(TheNameKeyGenerator->nameToKey( filename ));
 
     instData->m_style |= GWS_RADIO_BUTTON;
     window = TheWindowManager->gogoGadgetRadioButton( parent, status, x, y,

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/LoadScreen.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/LoadScreen.cpp
@@ -1258,13 +1258,11 @@ void MapTransferLoadScreen::init( GameInfo *game )
 	Int i;
 
 	// Load the Filename Text
-	winName.format( "MapTransferScreen.wnd:StaticTextCurrentFile");
-	m_fileNameText = TheWindowManager->winGetWindowFromId( m_loadScreen,TheNameKeyGenerator->nameToKey( winName ));
+	m_fileNameText = TheWindowManager->winGetWindowFromId( m_loadScreen,TheNameKeyGenerator->nameToKey( "MapTransferScreen.wnd:StaticTextCurrentFile" ));
 	DEBUG_ASSERTCRASH(m_fileNameText, ("Can't initialize the filename for the map transfer loadscreen"));
 
 	// Load the Timeout Text
-	winName.format( "MapTransferScreen.wnd:StaticTextTimeout");
-	m_timeoutText = TheWindowManager->winGetWindowFromId( m_loadScreen,TheNameKeyGenerator->nameToKey( winName ));
+	m_timeoutText = TheWindowManager->winGetWindowFromId( m_loadScreen,TheNameKeyGenerator->nameToKey( "MapTransferScreen.wnd:StaticTextTimeout" ));
 	DEBUG_ASSERTCRASH(m_timeoutText, ("Can't initialize the timeout for the map transfer loadscreen"));
 
 	Int netSlot = 0;

--- a/Generals/Code/GameEngine/Source/GameClient/System/Image.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/System/Image.cpp
@@ -204,7 +204,7 @@ ImageCollection::ImageCollection( void )
 //-------------------------------------------------------------------------------------------------
 ImageCollection::~ImageCollection( void )
 {
-  for (std::map<unsigned,Image *>::iterator i=m_imageMap.begin();i!=m_imageMap.end();++i)
+  for (ImageMap::iterator i=m_imageMap.begin();i!=m_imageMap.end();++i)
     deleteInstance(i->second);
 }
 
@@ -217,12 +217,26 @@ void ImageCollection::addImage( Image *image )
 }
 
 //-------------------------------------------------------------------------------------------------
+const Image *ImageCollection::findImage( NameKeyType namekey ) const
+{
+	ImageMap::const_iterator i = m_imageMap.find(namekey);
+	return i == m_imageMap.end() ? NULL : i->second;
+}
+
+//-------------------------------------------------------------------------------------------------
 /** Find an image given the image name */
 //-------------------------------------------------------------------------------------------------
 const Image *ImageCollection::findImageByName( const AsciiString& name ) const
 {
-  std::map<unsigned,Image *>::const_iterator i=m_imageMap.find(TheNameKeyGenerator->nameToLowercaseKey(name));
-  return i==m_imageMap.end()?NULL:i->second;
+	return findImage(TheNameKeyGenerator->nameToLowercaseKey(name));
+}
+
+//-------------------------------------------------------------------------------------------------
+/** Find an image given the image name */
+//-------------------------------------------------------------------------------------------------
+const Image *ImageCollection::findImageByName( const char* name ) const
+{
+	return findImage(TheNameKeyGenerator->nameToLowercaseKey(name));
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Armor.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Armor.cpp
@@ -115,11 +115,10 @@ ArmorStore::~ArmorStore()
 }
 
 //-------------------------------------------------------------------------------------------------
-const ArmorTemplate* ArmorStore::findArmorTemplate(AsciiString name) const
+const ArmorTemplate* ArmorStore::findArmorTemplate(NameKeyType namekey) const
 {
-	NameKeyType namekey = TheNameKeyGenerator->nameToKey(name);
-  ArmorTemplateMap::const_iterator it = m_armorTemplates.find(namekey);
-  if (it == m_armorTemplates.end())
+	ArmorTemplateMap::const_iterator it = m_armorTemplates.find(namekey);
+	if (it == m_armorTemplates.end())
 	{
 		return NULL;
 	}
@@ -127,6 +126,18 @@ const ArmorTemplate* ArmorStore::findArmorTemplate(AsciiString name) const
 	{
 		return &(*it).second;
 	}
+}
+
+//-------------------------------------------------------------------------------------------------
+const ArmorTemplate* ArmorStore::findArmorTemplate(const AsciiString& name) const
+{
+	return findArmorTemplate(TheNameKeyGenerator->nameToKey(name));
+}
+
+//-------------------------------------------------------------------------------------------------
+const ArmorTemplate* ArmorStore::findArmorTemplate(const char* name) const
+{
+	return findArmorTemplate(TheNameKeyGenerator->nameToKey(name));
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -1477,12 +1477,22 @@ void WeaponStore::createAndFireTempWeapon(const WeaponTemplate* wt, const Object
 }
 
 //-------------------------------------------------------------------------------------------------
-const WeaponTemplate *WeaponStore::findWeaponTemplate( AsciiString name ) const
+const WeaponTemplate *WeaponStore::findWeaponTemplate( const AsciiString& name ) const
 {
-	if (stricmp(name.str(), "None") == 0)
+	if (name.compareNoCase("None") == 0)
 		return NULL;
 	const WeaponTemplate * wt = findWeaponTemplatePrivate( TheNameKeyGenerator->nameToKey( name ) );
-	DEBUG_ASSERTCRASH(wt != NULL, ("Weapon %s not found!",name.str()));
+	DEBUG_ASSERTCRASH(wt != NULL, ("Weapon %s not found!",name));
+	return wt;
+}
+
+//-------------------------------------------------------------------------------------------------
+const WeaponTemplate *WeaponStore::findWeaponTemplate( const char* name ) const
+{
+	if (stricmp(name, "None") == 0)
+		return NULL;
+	const WeaponTemplate * wt = findWeaponTemplatePrivate( TheNameKeyGenerator->nameToKey( name ) );
+	DEBUG_ASSERTCRASH(wt != NULL, ("Weapon %s not found!",name));
 	return wt;
 }
 

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
@@ -1466,8 +1466,10 @@ void W3DModelDrawModuleData::parseConditionState(INI* ini, void *instance, void 
 
 		case PARSE_TRANSITION:
 		{
-		  AsciiString firstNm = ini->getNextToken(); firstNm.toLower();
-		  AsciiString secondNm = ini->getNextToken(); secondNm.toLower();
+			AsciiString firstNm = ini->getNextToken();
+			AsciiString secondNm = ini->getNextToken();
+			firstNm.toLower();
+			secondNm.toLower();
 			NameKeyType firstKey = NAMEKEY(firstNm);
 			NameKeyType secondKey = NAMEKEY(secondNm);
 

--- a/Generals/Code/Tools/GUIEdit/Source/Dialog Procedures/RadioButtonProperties.cpp
+++ b/Generals/Code/Tools/GUIEdit/Source/Dialog Procedures/RadioButtonProperties.cpp
@@ -177,7 +177,7 @@ static LRESULT CALLBACK radioButtonPropertiesCallback( HWND hWndDialog,
 
 						// save group
 						Int group = GetDlgItemInt( hWndDialog, COMBO_GROUP, NULL, FALSE );
-						Int screen = TheNameKeyGenerator->nameToKey( AsciiString(TheEditor->getSaveFilename()) );
+						Int screen = TheNameKeyGenerator->nameToKey( TheEditor->getSaveFilename() );
 						GadgetRadioSetGroup( window, group, screen );
 
 					}

--- a/Generals/Code/Tools/GUIEdit/Source/LayoutScheme.cpp
+++ b/Generals/Code/Tools/GUIEdit/Source/LayoutScheme.cpp
@@ -2433,7 +2433,7 @@ Bool LayoutScheme::loadScheme( char *filename )
 
 				// store the info
 				storeImageAndColor( (StateIdentifier)state,
-														TheMappedImageCollection->findImageByName( AsciiString(  imageBuffer ) ),
+														TheMappedImageCollection->findImageByName( imageBuffer ),
 														GameMakeColor( colorR, colorG, colorB, colorA ),
 														GameMakeColor( bColorR, bColorG, bColorB, bColorA ) );
 			}

--- a/Generals/Code/Tools/GUIEdit/Source/Properties.cpp
+++ b/Generals/Code/Tools/GUIEdit/Source/Properties.cpp
@@ -1258,7 +1258,7 @@ const Image *ComboBoxSelectionToImage( HWND comboBox )
 	SendMessage( comboBox, CB_GETLBTEXT, selected, (LPARAM)buffer );
 
 	// return the image loc that matches the string
-	return TheMappedImageCollection->findImageByName( AsciiString( buffer ) );
+	return TheMappedImageCollection->findImageByName( buffer );
 
 }
 

--- a/Generals/Code/Tools/GUIEdit/Source/Save.cpp
+++ b/Generals/Code/Tools/GUIEdit/Source/Save.cpp
@@ -1235,7 +1235,7 @@ Bool GUIEdit::saveData( char *filePathAndFilename, char *filename )
 
 	// update all radio button screen identifiers with the filename
 	updateRadioScreenIdentifiers( TheWindowManager->winGetWindowList(),
-																TheNameKeyGenerator->nameToKey( AsciiString(m_saveFilename) ) );
+																TheNameKeyGenerator->nameToKey( m_saveFilename ) );
 
 	// open the file
 	fp = fopen( filePathAndFilename, "w" );

--- a/Generals/Code/Tools/WorldBuilder/src/addplayerdialog.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/addplayerdialog.cpp
@@ -76,9 +76,8 @@ void AddPlayerDialog::OnOK()
 		} else {
 			faction->GetWindowText(theText);
 		}
-		AsciiString name((LPCTSTR)theText);
 
-		const PlayerTemplate* pt = ThePlayerTemplateStore->findPlayerTemplate(NAMEKEY(name));
+		const PlayerTemplate* pt = ThePlayerTemplateStore->findPlayerTemplate(NAMEKEY((LPCTSTR)theText));
 		if (pt)
 		{
 			m_addedSide = pt ? pt->getName() : AsciiString::TheEmptyString;

--- a/GeneralsMD/Code/GameEngine/Include/Common/DamageFX.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/DamageFX.h
@@ -147,7 +147,9 @@ public:
 	/**
 		Find the DamageFX with the given name. If no such DamageFX exists, return null.
 	*/
-	const DamageFX *findDamageFX( AsciiString name ) const;
+	const DamageFX *findDamageFX( NameKeyType namekey ) const;
+	const DamageFX *findDamageFX( const AsciiString& name ) const;
+	const DamageFX *findDamageFX( const char* name ) const;
 
 	static void parseDamageFXDefinition(INI* ini);
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/NameKeyGenerator.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/NameKeyGenerator.h
@@ -90,8 +90,8 @@ public:
 	virtual void update() { }
 
 	/// Given a string, convert into a unique integer key.
-	NameKeyType nameToKey(const AsciiString& name) { return nameToKey(name.str()); }
-	NameKeyType nameToLowercaseKey(const AsciiString& name) { return nameToLowercaseKey(name.str()); }
+	NameKeyType nameToKey(const AsciiString& name);
+	NameKeyType nameToLowercaseKey(const AsciiString& name);
 
 	/// Given a string, convert into a unique integer key.
 	NameKeyType nameToKey(const char* name);
@@ -118,6 +118,8 @@ private:
 	Bool addReservedKey();
 #endif
 
+	NameKeyType nameToKeyImpl(const AsciiString& name);
+	NameKeyType nameToLowercaseKeyImpl(const AsciiString& name);
 	NameKeyType nameToKeyImpl(const char* name);
 	NameKeyType nameToLowercaseKeyImpl(const char *name);
 	NameKeyType createNameKey(UnsignedInt hash, const AsciiString& name);

--- a/GeneralsMD/Code/GameEngine/Include/Common/Upgrade.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Upgrade.h
@@ -238,6 +238,7 @@ public:
 	UpgradeTemplate *firstUpgradeTemplate( void ); ///< return the first upgrade template
 	const UpgradeTemplate *findUpgradeByKey( NameKeyType key ) const; ///< find upgrade by name key
 	const UpgradeTemplate *findUpgrade( const AsciiString& name ) const; ///< find and return upgrade by name
+	const UpgradeTemplate *findUpgrade( const char* name ) const; ///< find and return upgrade by name
 	const UpgradeTemplate *findVeterancyUpgrade(VeterancyLevel level) const; ///< find and return upgrade by veterancy level
 
 	UpgradeTemplate *newUpgrade( const AsciiString& name );				///< allocate, link, and return new upgrade

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Image.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Image.h
@@ -116,6 +116,7 @@ friend class ImageCollection;
 //-------------------------------------------------------------------------------------------------
 class ImageCollection : public SubsystemInterface
 {
+	typedef std::map<NameKeyType, Image *> ImageMap;
 
 public:
 
@@ -128,7 +129,9 @@ public:
 
 	void load( Int textureSize );												 ///< load images
 
+	const Image *findImage( NameKeyType namekey ) const; ///< find image based on name key
 	const Image *findImageByName( const AsciiString& name ) const; ///< find image based on name
+	const Image *findImageByName( const char* name ) const; ///< find image based on name
 
   /// adds the given image to the collection, transfers ownership to this object
   void addImage(Image *image);
@@ -136,14 +139,14 @@ public:
   /// enumerates the list of existing images
   Image *Enum(unsigned index)
   {
-    for (std::map<unsigned,Image *>::iterator i=m_imageMap.begin();i!=m_imageMap.end();++i)
+    for (ImageMap::iterator i=m_imageMap.begin();i!=m_imageMap.end();++i)
       if (!index--)
         return i->second;
     return NULL;
   }
 
 protected:
-  std::map<unsigned,Image *> m_imageMap;  ///< maps named keys to images
+  ImageMap m_imageMap;  ///< maps named keys to images
 };
 
 // INLINING ///////////////////////////////////////////////////////////////////////////////////////

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Armor.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Armor.h
@@ -105,10 +105,12 @@ public:
 	void reset() { }
 	void update() { }
 
+	const ArmorTemplate* findArmorTemplate(NameKeyType namekey) const;
 	/**
 		Find the Armor with the given name. If no such Armor exists, return null.
 	*/
-	const ArmorTemplate* findArmorTemplate(AsciiString name) const;
+	const ArmorTemplate* findArmorTemplate(const AsciiString& name) const;
+	const ArmorTemplate* findArmorTemplate(const char* name) const;
 
 	inline Armor makeArmor(const ArmorTemplate *tmpl) const
 	{

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Weapon.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Weapon.h
@@ -839,7 +839,8 @@ public:
 	/**
 		Find the WeaponTemplate with the given name. If no such WeaponTemplate exists, return null.
 	*/
-	const WeaponTemplate *findWeaponTemplate(AsciiString name) const;
+	const WeaponTemplate *findWeaponTemplate(const AsciiString& name) const;
+	const WeaponTemplate *findWeaponTemplate(const char* name) const;
 	const WeaponTemplate *findWeaponTemplateByNameKey( NameKeyType key ) const { return findWeaponTemplatePrivate( key ); }
 
 	// this dynamically allocates a new Weapon, which is owned (and must be freed!) by the caller.

--- a/GeneralsMD/Code/GameEngine/Source/Common/DamageFX.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/DamageFX.cpp
@@ -272,11 +272,10 @@ DamageFXStore::~DamageFXStore()
 }
 
 //-------------------------------------------------------------------------------------------------
-const DamageFX *DamageFXStore::findDamageFX(AsciiString name) const
+const DamageFX *DamageFXStore::findDamageFX(NameKeyType namekey) const
 {
-	NameKeyType namekey = TheNameKeyGenerator->nameToKey(name);
-  DamageFXMap::const_iterator it = m_dfxmap.find(namekey);
-  if (it == m_dfxmap.end())
+	DamageFXMap::const_iterator it = m_dfxmap.find(namekey);
+	if (it == m_dfxmap.end())
 	{
 		return NULL;
 	}
@@ -284,6 +283,18 @@ const DamageFX *DamageFXStore::findDamageFX(AsciiString name) const
 	{
 		return &(*it).second;
 	}
+}
+
+//-------------------------------------------------------------------------------------------------
+const DamageFX *DamageFXStore::findDamageFX(const AsciiString& name) const
+{
+	return findDamageFX(TheNameKeyGenerator->nameToKey(name));
+}
+
+//-------------------------------------------------------------------------------------------------
+const DamageFX *DamageFXStore::findDamageFX(const char* name) const
+{
+	return findDamageFX(TheNameKeyGenerator->nameToKey(name));
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/Common/INI/INI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/INI/INI.cpp
@@ -871,7 +871,7 @@ void INI::parseMappedImage( INI *ini, void * /*instance*/, void *store, const vo
 	if( TheMappedImageCollection )
 	{
 		typedef const Image* ConstImagePtr;
-		*(ConstImagePtr*)store = TheMappedImageCollection->findImageByName( AsciiString( token ) );
+		*(ConstImagePtr*)store = TheMappedImageCollection->findImageByName( token );
 	}
 
 	//KM: If we are in the worldbuilder, we want to parse commandbuttons for informational purposes,
@@ -1376,7 +1376,7 @@ void INI::parseUpgradeTemplate( INI* ini, void * /*instance*/, void *store, cons
 		throw ERROR_BUG;
 	}
 
-	const UpgradeTemplate *uu = TheUpgradeCenter->findUpgrade( AsciiString( token ) );
+	const UpgradeTemplate *uu = TheUpgradeCenter->findUpgrade( token );
 	DEBUG_ASSERTCRASH( uu || stricmp( token, "None" ) == 0, ("Upgrade %s not found!",token) );
 
 	typedef const UpgradeTemplate* ConstUpgradeTemplatePtr;

--- a/GeneralsMD/Code/GameEngine/Source/Common/INI/INIMappedImage.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/INI/INIMappedImage.cpp
@@ -42,11 +42,8 @@
 //-------------------------------------------------------------------------------------------------
 void INI::parseMappedImageDefinition( INI* ini )
 {
-	AsciiString name;
-
 	// read the name
-	const char* c = ini->getNextToken();
-	name.set( c );
+	const char* name = ini->getNextToken();
 
 	//
 	// find existing item if present, note that we do not support overrides
@@ -66,11 +63,10 @@ void INI::parseMappedImageDefinition( INI* ini )
 	{
 
 		// image not found, create a new one
-  	image = newInstance(Image);
+		image = newInstance(Image);
 		image->setName( name );
 		TheMappedImageCollection->addImage(image);
-		DEBUG_ASSERTCRASH( image, ("parseMappedImage: unable to allocate image for '%s'",
-															name.str()) );
+		DEBUG_ASSERTCRASH( image, ("parseMappedImage: unable to allocate image for '%s'", name) );
 
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/FunctionLexicon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/FunctionLexicon.cpp
@@ -395,7 +395,7 @@ void FunctionLexicon::loadTable( TableEntry *table,
 	{
 
 		// assign key from name key based on name provided in table
-		entry->key = TheNameKeyGenerator->nameToKey( AsciiString(entry->name) );
+		entry->key = TheNameKeyGenerator->nameToKey( entry->name );
 
 		// next table entry please
 		entry++;

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/Upgrade.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/Upgrade.cpp
@@ -353,6 +353,14 @@ const UpgradeTemplate *UpgradeCenter::findUpgrade( const AsciiString& name ) con
 }
 
 //-------------------------------------------------------------------------------------------------
+/** Find upgrade by name */
+//-------------------------------------------------------------------------------------------------
+const UpgradeTemplate *UpgradeCenter::findUpgrade( const char* name ) const
+{
+	return findUpgradeByKey( TheNameKeyGenerator->nameToKey( name ) );
+}
+
+//-------------------------------------------------------------------------------------------------
 /** Allocate a new upgrade template */
 //-------------------------------------------------------------------------------------------------
 UpgradeTemplate *UpgradeCenter::newUpgrade( const AsciiString& name )
@@ -471,8 +479,7 @@ std::vector<AsciiString> UpgradeCenter::getUpgradeNames( void ) const
 void UpgradeCenter::parseUpgradeDefinition( INI *ini )
 {
 	// read the name
-	const char* c = ini->getNextToken();
-	AsciiString name = c;
+	const char* name = ini->getNextToken();
 
 	// find existing item if present
 	UpgradeTemplate* upgrade = TheUpgradeCenter->findNonConstUpgradeByKey( NAMEKEY(name) );
@@ -485,7 +492,7 @@ void UpgradeCenter::parseUpgradeDefinition( INI *ini )
 	}
 
 	// sanity
-	DEBUG_ASSERTCRASH( upgrade, ("parseUpgradeDefinition: Unable to allocate upgrade '%s'", name.str()) );
+	DEBUG_ASSERTCRASH( upgrade, ("parseUpgradeDefinition: Unable to allocate upgrade '%s'", name) );
 
 	// parse the ini definition
 	ini->initFromINI( upgrade, upgrade->getFieldParse() );

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/DifficultySelect.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/DifficultySelect.cpp
@@ -125,8 +125,7 @@ static void SetDifficultyRadioButton( void )
 
 void DifficultySelectInit( WindowLayout *layout, void *userData )
 {
-	AsciiString parentName( "DifficultySelect.wnd:DifficultySelectParent" );
-	NameKeyType parentID = TheNameKeyGenerator->nameToKey( parentName );
+	NameKeyType parentID = TheNameKeyGenerator->nameToKey( "DifficultySelect.wnd:DifficultySelectParent" );
 	GameWindow *parent = TheWindowManager->winGetWindowFromId( NULL, parentID );
 
 	buttonOkID = TheNameKeyGenerator->nameToKey( "DifficultySelect.wnd:ButtonOk" );

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/DownloadMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/DownloadMenu.cpp
@@ -349,8 +349,7 @@ WindowMsgHandledType DownloadMenuInput( GameWindow *window, UnsignedInt msg,
 					//
 					if( BitIsSet( state, KEY_STATE_UP ) )
 					{
-						AsciiString buttonName( "DownloadMenu.wnd:ButtonCancel" );
-						NameKeyType buttonID = TheNameKeyGenerator->nameToKey( buttonName );
+						NameKeyType buttonID = TheNameKeyGenerator->nameToKey( "DownloadMenu.wnd:ButtonCancel" );
 						GameWindow *button = TheWindowManager->winGetWindowFromId( window, buttonID );
 
 						TheWindowManager->winSendSystemMsg( window, GBM_SELECTED,

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/KeyboardOptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/KeyboardOptionsMenu.cpp
@@ -499,8 +499,7 @@ WindowMsgHandledType KeyboardOptionsMenuInput( GameWindow *window, UnsignedInt m
 					//
 					if( BitIsSet( state, KEY_STATE_UP ) )
 					{
-						AsciiString buttonName( "KeyboardOptionsMenu.wnd:ButtonBack" );
-						NameKeyType buttonID = TheNameKeyGenerator->nameToKey( buttonName );
+						NameKeyType buttonID = TheNameKeyGenerator->nameToKey( "KeyboardOptionsMenu.wnd:ButtonBack" );
 						GameWindow *button = TheWindowManager->winGetWindowFromId( window, buttonID );
 
 						TheWindowManager->winSendSystemMsg( window, GBM_SELECTED,

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanMapSelectMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanMapSelectMenu.cpp
@@ -122,8 +122,7 @@ void LanMapSelectMenuInit( WindowLayout *layout, void *userData )
 	showLANGameOptionsUnderlyingGUIElements(FALSE);
 
 	// set keyboard focus to main parent
-	AsciiString parentName( "LanMapSelectMenu.wnd:LanMapSelectMenuParent" );
-	NameKeyType parentID = TheNameKeyGenerator->nameToKey( parentName );
+	NameKeyType parentID = TheNameKeyGenerator->nameToKey( "LanMapSelectMenu.wnd:LanMapSelectMenuParent" );
 	parent = TheWindowManager->winGetWindowFromId( NULL, parentID );
 
 	TheWindowManager->winSetFocus( parent );
@@ -165,8 +164,7 @@ void LanMapSelectMenuInit( WindowLayout *layout, void *userData )
 	}
 
 	// get the listbox window
-	AsciiString listString( "LanMapSelectMenu.wnd:ListboxMap" );
-	NameKeyType mapListID = TheNameKeyGenerator->nameToKey( listString );
+	NameKeyType mapListID = TheNameKeyGenerator->nameToKey( "LanMapSelectMenu.wnd:ListboxMap" );
 	mapList = TheWindowManager->winGetWindowFromId( parent, mapListID );
 	if( mapList )
 	{
@@ -228,8 +226,7 @@ WindowMsgHandledType LanMapSelectMenuInput( GameWindow *window, UnsignedInt msg,
 					//
 					if( BitIsSet( state, KEY_STATE_UP ) )
 					{
-						AsciiString buttonName( "LanMapSelectMenu.wnd:ButtonBack" );
-						NameKeyType buttonID = TheNameKeyGenerator->nameToKey( buttonName );
+						NameKeyType buttonID = TheNameKeyGenerator->nameToKey( "LanMapSelectMenu.wnd:ButtonBack" );
 						GameWindow *button = TheWindowManager->winGetWindowFromId( window, buttonID );
 
 						TheWindowManager->winSendSystemMsg( window, GBM_SELECTED,

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/MapSelectMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/MapSelectMenu.cpp
@@ -108,8 +108,7 @@ static void shutdownComplete( WindowLayout *layout )
 
 void SetDifficultyRadioButton( void )
 {
-	AsciiString parentName( "MapSelectMenu.wnd:MapSelectMenuParent" );
-	NameKeyType parentID = TheNameKeyGenerator->nameToKey( parentName );
+	NameKeyType parentID = TheNameKeyGenerator->nameToKey( "MapSelectMenu.wnd:MapSelectMenuParent" );
 	GameWindow *parent = TheWindowManager->winGetWindowFromId( NULL, parentID );
 
 	if (!TheScriptEngine)
@@ -171,8 +170,7 @@ void MapSelectMenuInit( WindowLayout *layout, void *userData )
 	Bool usesSystemMapDir = pref.usesSystemMapDir();
 
 	// get the listbox window
-	AsciiString listString( "MapSelectMenu.wnd:ListboxMap" );
-	NameKeyType mapListID = TheNameKeyGenerator->nameToKey( listString );
+	NameKeyType mapListID = TheNameKeyGenerator->nameToKey( "MapSelectMenu.wnd:ListboxMap" );
 	mapList = TheWindowManager->winGetWindowFromId( NULL, mapListID );
 	if( mapList )
 	{
@@ -183,8 +181,7 @@ void MapSelectMenuInit( WindowLayout *layout, void *userData )
 
 
 	// set keyboard focus to main parent
-	AsciiString parentName( "MapSelectMenu.wnd:MapSelectMenuParent" );
-	NameKeyType parentID = TheNameKeyGenerator->nameToKey( parentName );
+	NameKeyType parentID = TheNameKeyGenerator->nameToKey( "MapSelectMenu.wnd:MapSelectMenuParent" );
 	GameWindow *parent = TheWindowManager->winGetWindowFromId( NULL, parentID );
 	TheWindowManager->winSetFocus( parent );
 
@@ -280,8 +277,7 @@ WindowMsgHandledType MapSelectMenuInput( GameWindow *window, UnsignedInt msg,
 					//
 					if( BitIsSet( state, KEY_STATE_UP ) )
 					{
-						AsciiString buttonName( "MapSelectMenu.wnd:ButtonBack" );
-						NameKeyType buttonID = TheNameKeyGenerator->nameToKey( buttonName );
+						NameKeyType buttonID = TheNameKeyGenerator->nameToKey( "MapSelectMenu.wnd:ButtonBack" );
 						GameWindow *button = TheWindowManager->winGetWindowFromId( window, buttonID );
 
 						TheWindowManager->winSendSystemMsg( window, GBM_SELECTED,

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -2117,8 +2117,7 @@ void OptionsMenuInit( WindowLayout *layout, void *userData )
 	layout->hide( FALSE );
 
 	// set keyboard focus to main parent
-	AsciiString parentName( "OptionsMenu.wnd:OptionsMenuParent" );
-	NameKeyType parentID = TheNameKeyGenerator->nameToKey( parentName );
+	NameKeyType parentID = TheNameKeyGenerator->nameToKey( "OptionsMenu.wnd:OptionsMenuParent" );
 	GameWindow *parent = TheWindowManager->winGetWindowFromId( NULL, parentID );
 	TheWindowManager->winSetFocus( parent );
 
@@ -2219,8 +2218,7 @@ WindowMsgHandledType OptionsMenuInput( GameWindow *window, UnsignedInt msg,
 					//
 					if( BitIsSet( state, KEY_STATE_UP ) )
 					{
-						AsciiString buttonName( "OptionsMenu.wnd:ButtonBack" );
-						NameKeyType buttonID = TheNameKeyGenerator->nameToKey( buttonName );
+						NameKeyType buttonID = TheNameKeyGenerator->nameToKey( "OptionsMenu.wnd:ButtonBack" );
 						GameWindow *button = TheWindowManager->winGetWindowFromId( window, buttonID );
 
 						TheWindowManager->winSendSystemMsg( window, GBM_SELECTED,

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SinglePlayerMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SinglePlayerMenu.cpp
@@ -69,8 +69,7 @@ void SinglePlayerMenuInit( WindowLayout *layout, void *userData )
 	layout->hide( FALSE );
 
 	// set keyboard focus to main parent
-	AsciiString parentName( "SinglePlayerMenu.wnd:SinglePlayerMenuParent" );
-	NameKeyType parentID = TheNameKeyGenerator->nameToKey( parentName );
+	NameKeyType parentID = TheNameKeyGenerator->nameToKey( "SinglePlayerMenu.wnd:SinglePlayerMenuParent" );
 	GameWindow *parent = TheWindowManager->winGetWindowFromId( NULL, parentID );
 	TheWindowManager->winSetFocus( parent );
 
@@ -155,8 +154,7 @@ WindowMsgHandledType SinglePlayerMenuInput( GameWindow *window, UnsignedInt msg,
 					//
 					if( BitIsSet( state, KEY_STATE_UP ) )
 					{
-						AsciiString buttonName( "SinglePlayerMenu.wnd:ButtonBack" );
-						NameKeyType buttonID = TheNameKeyGenerator->nameToKey( buttonName );
+						NameKeyType buttonID = TheNameKeyGenerator->nameToKey( "SinglePlayerMenu.wnd:ButtonBack" );
 						GameWindow *button = TheWindowManager->winGetWindowFromId( window, buttonID );
 
 						TheWindowManager->winSendSystemMsg( window, GBM_SELECTED,

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishMapSelectMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishMapSelectMenu.cpp
@@ -130,8 +130,7 @@ void skirmishPositionStartSpots( void );
 void skirmishUpdateSlotList( void );
 void showSkirmishGameOptionsUnderlyingGUIElements( Bool show )
 {
-	AsciiString parentName( "SkirmishGameOptionsMenu.wnd:SkirmishGameOptionsMenuParent" );
-	NameKeyType parentID = TheNameKeyGenerator->nameToKey( parentName );
+	NameKeyType parentID = TheNameKeyGenerator->nameToKey( "SkirmishGameOptionsMenu.wnd:SkirmishGameOptionsMenuParent" );
 	GameWindow *parent = TheWindowManager->winGetWindowFromId( NULL, parentID );
 	if (!parent)
 		return;
@@ -252,8 +251,7 @@ void SkirmishMapSelectMenuInit( WindowLayout *layout, void *userData )
 {
 
 	// set keyboard focus to main parent
-	AsciiString parentName( "SkirmishMapSelectMenu.wnd:SkrimishMapSelectMenuParent" );
-	NameKeyType parentID = TheNameKeyGenerator->nameToKey( parentName );
+	NameKeyType parentID = TheNameKeyGenerator->nameToKey( "SkirmishMapSelectMenu.wnd:SkrimishMapSelectMenuParent" );
 	parent = TheWindowManager->winGetWindowFromId( NULL, parentID );
 
 	TheWindowManager->winSetFocus( parent );
@@ -298,8 +296,7 @@ void SkirmishMapSelectMenuInit( WindowLayout *layout, void *userData )
 	showSkirmishGameOptionsUnderlyingGUIElements(FALSE);
 
 	// get the listbox window
-	AsciiString listString( "SkirmishMapSelectMenu.wnd:ListboxMap" );
-	NameKeyType mapListID = TheNameKeyGenerator->nameToKey( listString );
+	NameKeyType mapListID = TheNameKeyGenerator->nameToKey( "SkirmishMapSelectMenu.wnd:ListboxMap" );
 	mapList = TheWindowManager->winGetWindowFromId( parent, mapListID );
 	if( mapList )
 	{
@@ -372,8 +369,7 @@ WindowMsgHandledType SkirmishMapSelectMenuInput( GameWindow *window, UnsignedInt
 					//
 					if( BitIsSet( state, KEY_STATE_UP ) )
 					{
-						AsciiString buttonName( "SkirmishMapSelectMenu.wnd:ButtonBack" );
-						NameKeyType buttonID = TheNameKeyGenerator->nameToKey( buttonName );
+						NameKeyType buttonID = TheNameKeyGenerator->nameToKey( "SkirmishMapSelectMenu.wnd:ButtonBack" );
 						GameWindow *button = TheWindowManager->winGetWindowFromId( window, buttonID );
 
 						TheWindowManager->winSendSystemMsg( window, GBM_SELECTED,

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLMapSelectMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLMapSelectMenu.cpp
@@ -127,8 +127,7 @@ void WOLMapSelectMenuInit( WindowLayout *layout, void *userData )
 {
 
 	// set keyboard focus to main parent
-	AsciiString parentName( "WOLMapSelectMenu.wnd:WOLMapSelectMenuParent" );
-	NameKeyType parentID = TheNameKeyGenerator->nameToKey( parentName );
+	NameKeyType parentID = TheNameKeyGenerator->nameToKey( "WOLMapSelectMenu.wnd:WOLMapSelectMenuParent" );
 	parent = TheWindowManager->winGetWindowFromId( NULL, parentID );
 
 	TheWindowManager->winSetFocus( parent );
@@ -182,8 +181,7 @@ void WOLMapSelectMenuInit( WindowLayout *layout, void *userData )
 	showGameSpyGameOptionsUnderlyingGUIElements( FALSE );
 
 	// get the listbox window
-	AsciiString listString( "WOLMapSelectMenu.wnd:ListboxMap" );
-	NameKeyType mapListID = TheNameKeyGenerator->nameToKey( listString );
+	NameKeyType mapListID = TheNameKeyGenerator->nameToKey( "WOLMapSelectMenu.wnd:ListboxMap" );
 	mapList = TheWindowManager->winGetWindowFromId( parent, mapListID );
 	if( mapList )
 	{
@@ -254,8 +252,7 @@ WindowMsgHandledType WOLMapSelectMenuInput( GameWindow *window, UnsignedInt msg,
 					//
 					if( BitIsSet( state, KEY_STATE_UP ) )
 					{
-						AsciiString buttonName( "WOLMapSelectMenu.wnd:ButtonBack" );
-						NameKeyType buttonID = TheNameKeyGenerator->nameToKey( buttonName );
+						NameKeyType buttonID = TheNameKeyGenerator->nameToKey( "WOLMapSelectMenu.wnd:ButtonBack" );
 						GameWindow *button = TheWindowManager->winGetWindowFromId( window, buttonID );
 
 						TheWindowManager->winSendSystemMsg( window, GBM_SELECTED,

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowGlobal.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowGlobal.cpp
@@ -131,7 +131,7 @@ const Image *GameWindowManager::winFindImage( const char *name )
 
 	assert( TheMappedImageCollection );
 	if( TheMappedImageCollection )
-		return TheMappedImageCollection->findImageByName( AsciiString( name ) );
+		return TheMappedImageCollection->findImageByName( name );
 
 	return NULL;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowManagerScript.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowManagerScript.cpp
@@ -1323,7 +1323,7 @@ static Bool parseDrawData( const char *token, WinInstanceData *instData,
 
 		c = strtok( NULL, seps );  // value
 		if( strcmp( c, "NoImage" ) )
-			drawData->image = TheMappedImageCollection->findImageByName( AsciiString( c ) );
+			drawData->image = TheMappedImageCollection->findImageByName( c );
 		else
 			drawData->image = NULL;
 		// COLOR: R G B A
@@ -1652,7 +1652,7 @@ static GameWindow *createGadget( char *type,
 			*c = 0;  // terminate after filename (format is filename:gadgetname)
 		assert( TheNameKeyGenerator );
 		if( TheNameKeyGenerator )
-			rData->screen = (Int)(TheNameKeyGenerator->nameToKey( AsciiString(filename) ));
+			rData->screen = (Int)(TheNameKeyGenerator->nameToKey( filename ));
 
     instData->m_style |= GWS_RADIO_BUTTON;
     window = TheWindowManager->gogoGadgetRadioButton( parent, status, x, y,

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/LoadScreen.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/LoadScreen.cpp
@@ -1903,13 +1903,11 @@ void MapTransferLoadScreen::init( GameInfo *game )
 	Int i;
 
 	// Load the Filename Text
-	winName.format( "MapTransferScreen.wnd:StaticTextCurrentFile");
-	m_fileNameText = TheWindowManager->winGetWindowFromId( m_loadScreen,TheNameKeyGenerator->nameToKey( winName ));
+	m_fileNameText = TheWindowManager->winGetWindowFromId( m_loadScreen,TheNameKeyGenerator->nameToKey( "MapTransferScreen.wnd:StaticTextCurrentFile" ));
 	DEBUG_ASSERTCRASH(m_fileNameText, ("Can't initialize the filename for the map transfer loadscreen"));
 
 	// Load the Timeout Text
-	winName.format( "MapTransferScreen.wnd:StaticTextTimeout");
-	m_timeoutText = TheWindowManager->winGetWindowFromId( m_loadScreen,TheNameKeyGenerator->nameToKey( winName ));
+	m_timeoutText = TheWindowManager->winGetWindowFromId( m_loadScreen,TheNameKeyGenerator->nameToKey( "MapTransferScreen.wnd:StaticTextTimeout" ));
 	DEBUG_ASSERTCRASH(m_timeoutText, ("Can't initialize the timeout for the map transfer loadscreen"));
 
 	Int netSlot = 0;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/System/Image.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/System/Image.cpp
@@ -204,7 +204,7 @@ ImageCollection::ImageCollection( void )
 //-------------------------------------------------------------------------------------------------
 ImageCollection::~ImageCollection( void )
 {
-  for (std::map<unsigned,Image *>::iterator i=m_imageMap.begin();i!=m_imageMap.end();++i)
+  for (ImageMap::iterator i=m_imageMap.begin();i!=m_imageMap.end();++i)
     deleteInstance(i->second);
 }
 
@@ -217,12 +217,26 @@ void ImageCollection::addImage( Image *image )
 }
 
 //-------------------------------------------------------------------------------------------------
+const Image *ImageCollection::findImage( NameKeyType namekey ) const
+{
+	ImageMap::const_iterator i = m_imageMap.find(namekey);
+	return i == m_imageMap.end() ? NULL : i->second;
+}
+
+//-------------------------------------------------------------------------------------------------
 /** Find an image given the image name */
 //-------------------------------------------------------------------------------------------------
 const Image *ImageCollection::findImageByName( const AsciiString& name ) const
 {
-  std::map<unsigned,Image *>::const_iterator i=m_imageMap.find(TheNameKeyGenerator->nameToLowercaseKey(name));
-  return i==m_imageMap.end()?NULL:i->second;
+	return findImage(TheNameKeyGenerator->nameToLowercaseKey(name));
+}
+
+//-------------------------------------------------------------------------------------------------
+/** Find an image given the image name */
+//-------------------------------------------------------------------------------------------------
+const Image *ImageCollection::findImageByName( const char* name ) const
+{
+	return findImage(TheNameKeyGenerator->nameToLowercaseKey(name));
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Armor.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Armor.cpp
@@ -116,11 +116,10 @@ ArmorStore::~ArmorStore()
 }
 
 //-------------------------------------------------------------------------------------------------
-const ArmorTemplate* ArmorStore::findArmorTemplate(AsciiString name) const
+const ArmorTemplate* ArmorStore::findArmorTemplate(NameKeyType namekey) const
 {
-	NameKeyType namekey = TheNameKeyGenerator->nameToKey(name);
-  ArmorTemplateMap::const_iterator it = m_armorTemplates.find(namekey);
-  if (it == m_armorTemplates.end())
+	ArmorTemplateMap::const_iterator it = m_armorTemplates.find(namekey);
+	if (it == m_armorTemplates.end())
 	{
 		return NULL;
 	}
@@ -128,6 +127,18 @@ const ArmorTemplate* ArmorStore::findArmorTemplate(AsciiString name) const
 	{
 		return &(*it).second;
 	}
+}
+
+//-------------------------------------------------------------------------------------------------
+const ArmorTemplate* ArmorStore::findArmorTemplate(const AsciiString& name) const
+{
+	return findArmorTemplate(TheNameKeyGenerator->nameToKey(name));
+}
+
+//-------------------------------------------------------------------------------------------------
+const ArmorTemplate* ArmorStore::findArmorTemplate(const char* name) const
+{
+	return findArmorTemplate(TheNameKeyGenerator->nameToKey(name));
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Upgrade/CommandSetUpgrade.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Upgrade/CommandSetUpgrade.cpp
@@ -68,7 +68,7 @@ void CommandSetUpgrade::upgradeImplementation( )
 {
 	Object *obj = getObject();
 
-	const char * upgradeAlt = getCommandSetUpgradeModuleData()->m_triggerAlt.str();
+	const AsciiString& upgradeAlt = getCommandSetUpgradeModuleData()->m_triggerAlt;
 	const UpgradeTemplate *upgradeTemplate = TheUpgradeCenter->findUpgrade( upgradeAlt );
 
 	if (upgradeTemplate)

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -1622,12 +1622,22 @@ void WeaponStore::createAndFireTempWeapon(const WeaponTemplate* wt, const Object
 }
 
 //-------------------------------------------------------------------------------------------------
-const WeaponTemplate *WeaponStore::findWeaponTemplate( AsciiString name ) const
+const WeaponTemplate *WeaponStore::findWeaponTemplate( const AsciiString& name ) const
 {
-	if (stricmp(name.str(), "None") == 0)
+	if (name.compareNoCase("None") == 0)
 		return NULL;
 	const WeaponTemplate * wt = findWeaponTemplatePrivate( TheNameKeyGenerator->nameToKey( name ) );
-	DEBUG_ASSERTCRASH(wt != NULL, ("Weapon %s not found!",name.str()));
+	DEBUG_ASSERTCRASH(wt != NULL, ("Weapon %s not found!",name));
+	return wt;
+}
+
+//-------------------------------------------------------------------------------------------------
+const WeaponTemplate *WeaponStore::findWeaponTemplate( const char* name ) const
+{
+	if (stricmp(name, "None") == 0)
+		return NULL;
+	const WeaponTemplate * wt = findWeaponTemplatePrivate( TheNameKeyGenerator->nameToKey( name ) );
+	DEBUG_ASSERTCRASH(wt != NULL, ("Weapon %s not found!",name));
 	return wt;
 }
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
@@ -1490,8 +1490,10 @@ void W3DModelDrawModuleData::parseConditionState(INI* ini, void *instance, void 
 
 		case PARSE_TRANSITION:
 		{
-		  AsciiString firstNm = ini->getNextToken(); firstNm.toLower();
-		  AsciiString secondNm = ini->getNextToken(); secondNm.toLower();
+			AsciiString firstNm = ini->getNextToken();
+			AsciiString secondNm = ini->getNextToken();
+			firstNm.toLower();
+			secondNm.toLower();
 			NameKeyType firstKey = NAMEKEY(firstNm);
 			NameKeyType secondKey = NAMEKEY(secondNm);
 

--- a/GeneralsMD/Code/Tools/GUIEdit/Source/Dialog Procedures/RadioButtonProperties.cpp
+++ b/GeneralsMD/Code/Tools/GUIEdit/Source/Dialog Procedures/RadioButtonProperties.cpp
@@ -177,7 +177,7 @@ static LRESULT CALLBACK radioButtonPropertiesCallback( HWND hWndDialog,
 
 						// save group
 						Int group = GetDlgItemInt( hWndDialog, COMBO_GROUP, NULL, FALSE );
-						Int screen = TheNameKeyGenerator->nameToKey( AsciiString(TheEditor->getSaveFilename()) );
+						Int screen = TheNameKeyGenerator->nameToKey( TheEditor->getSaveFilename() );
 						GadgetRadioSetGroup( window, group, screen );
 
 					}

--- a/GeneralsMD/Code/Tools/GUIEdit/Source/LayoutScheme.cpp
+++ b/GeneralsMD/Code/Tools/GUIEdit/Source/LayoutScheme.cpp
@@ -2433,7 +2433,7 @@ Bool LayoutScheme::loadScheme( char *filename )
 
 				// store the info
 				storeImageAndColor( (StateIdentifier)state,
-														TheMappedImageCollection->findImageByName( AsciiString(  imageBuffer ) ),
+														TheMappedImageCollection->findImageByName( imageBuffer ),
 														GameMakeColor( colorR, colorG, colorB, colorA ),
 														GameMakeColor( bColorR, bColorG, bColorB, bColorA ) );
 			}

--- a/GeneralsMD/Code/Tools/GUIEdit/Source/Properties.cpp
+++ b/GeneralsMD/Code/Tools/GUIEdit/Source/Properties.cpp
@@ -1258,7 +1258,7 @@ const Image *ComboBoxSelectionToImage( HWND comboBox )
 	SendMessage( comboBox, CB_GETLBTEXT, selected, (LPARAM)buffer );
 
 	// return the image loc that matches the string
-	return TheMappedImageCollection->findImageByName( AsciiString( buffer ) );
+	return TheMappedImageCollection->findImageByName( buffer );
 
 }
 

--- a/GeneralsMD/Code/Tools/GUIEdit/Source/Save.cpp
+++ b/GeneralsMD/Code/Tools/GUIEdit/Source/Save.cpp
@@ -1235,7 +1235,7 @@ Bool GUIEdit::saveData( char *filePathAndFilename, char *filename )
 
 	// update all radio button screen identifiers with the filename
 	updateRadioScreenIdentifiers( TheWindowManager->winGetWindowList(),
-																TheNameKeyGenerator->nameToKey( AsciiString(m_saveFilename) ) );
+																TheNameKeyGenerator->nameToKey( m_saveFilename ) );
 
 	// open the file
 	fp = fopen( filePathAndFilename, "w" );

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/addplayerdialog.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/addplayerdialog.cpp
@@ -76,9 +76,8 @@ void AddPlayerDialog::OnOK()
 		} else {
 			faction->GetWindowText(theText);
 		}
-		AsciiString name((LPCTSTR)theText);
 
-		const PlayerTemplate* pt = ThePlayerTemplateStore->findPlayerTemplate(NAMEKEY(name));
+		const PlayerTemplate* pt = ThePlayerTemplateStore->findPlayerTemplate(NAMEKEY((LPCTSTR)theText));
 		if (pt)
 		{
 			m_addedSide = pt ? pt->getName() : AsciiString::TheEmptyString;


### PR DESCRIPTION
**Merge with Rebase**

* Alternative to #1917

This change removes superfluous `AsciiString` allocations for name key lookups. It was applied by hand. It is split into 2 commits for a cleaner file diff.

It cuts many allocations and can help loading and runtime performance a bit.

Adjacent to Name Key, some functions that did Name Key lookups and do not necessarily need to be given an `AsciiString` have been given a new function overload taking `const char*`.

The identified and affected functions are:

* DamageFXStore::findDamageFX
* UpgradeCenter::findUpgrade
* ImageCollection::findImageByName
* ArmorStore::findArmorTemplate
* WeaponStore::findWeaponTemplate

There are probably plenty more functions of this kind but this change is already large enough as is and this seemed to be all directly related to Name Key things.

## TODO

- [x] Replicate in Generals
- [x] Add pull id to commits