### PR TITLE
fix(mfc): add class qualifier to ON_MESSAGE_VOID macro

### DIFF
--- a/Core/Tools/W3DView/DialogToolbar.cpp
+++ b/Core/Tools/W3DView/DialogToolbar.cpp
@@ -42,7 +42,7 @@
 BEGIN_MESSAGE_MAP(DialogToolbarClass, CToolBar)
 	//{{AFX_MSG_MAP(DialogToolbarClass)
 	ON_MESSAGE(WM_IDLEUPDATECMDUI, OnIdleUpdateCmdUI)
-	ON_MESSAGE_VOID(WM_INITIALUPDATE, OnInitialUpdate)
+	ON_MESSAGE_VOID(WM_INITIALUPDATE, DialogToolbarClass::OnInitialUpdate)
 	ON_NOTIFY_EX( TTN_NEEDTEXT, 0, OnNeedToolTipText)
 	//}}AFX_MSG_MAP
 END_MESSAGE_MAP()


### PR DESCRIPTION
Fixes compiler error in DialogToolbar.cpp by adding class qualifier to ON_MESSAGE_VOID macro.

The MFC ON_MESSAGE_VOID macro requires a fully qualified member function name to resolve the function pointer correctly.