### PR TITLE
ci(vcpkg): Include preset in binary cache key to avoid ABI mismatches and slow CI builds

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -43,8 +43,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}\vcpkg-bincache
-          key: vcpkg-bincache-${{ runner.os }}-${{ hashFiles('vcpkg.json','vcpkg-lock.json') }}
+          key: vcpkg-bincache-${{ runner.os }}-${{ hashFiles('vcpkg.json','vcpkg-lock.json') }}-${{ inputs.preset }}
           restore-keys: |
+            vcpkg-bincache-${{ runner.os }}-${{ hashFiles('vcpkg.json','vcpkg-lock.json') }}-
             vcpkg-bincache-${{ runner.os }}-
 
       - name: Cache VC6 Installation


### PR DESCRIPTION
VCPKG build time reduced from 24m to 6m.