### PR TITLE
bugfix(string): Allow startsWith and endsWith to be called on empty strings

### DIFF
--- a/Core/GameEngine/Source/Common/System/AsciiString.cpp
+++ b/Core/GameEngine/Source/Common/System/AsciiString.cpp
@@ -477,25 +477,25 @@ void AsciiString::format_va(const char* format, va_list args)
 // -----------------------------------------------------
 Bool AsciiString::startsWith(const char* p) const
 {
-	return ::startsWith(peek(), p);
+	return m_data && ::startsWith(peek(), p);
 }
 
 // -----------------------------------------------------
 Bool AsciiString::startsWithNoCase(const char* p) const
 {
-	return ::startsWithNoCase(peek(), p);
+	return m_data && ::startsWithNoCase(peek(), p);
 }
 
 // -----------------------------------------------------
 Bool AsciiString::endsWith(const char* p) const
 {
-	return ::endsWith(peek(), p);
+	return m_data && ::endsWith(peek(), p);
 }
 
 // -----------------------------------------------------
 Bool AsciiString::endsWithNoCase(const char* p) const
 {
-	return ::endsWithNoCase(peek(), p);
+	return m_data && ::endsWithNoCase(peek(), p);
 }
 
 //-----------------------------------------------------------------------------

--- a/Core/GameEngine/Source/Common/System/UnicodeString.cpp
+++ b/Core/GameEngine/Source/Common/System/UnicodeString.cpp
@@ -409,25 +409,25 @@ void UnicodeString::format_va(const WideChar* format, va_list args)
 // -----------------------------------------------------
 Bool UnicodeString::startsWith(const WideChar* p) const
 {
-	return ::startsWith(peek(), p);
+	return m_data && ::startsWith(peek(), p);
 }
 
 // -----------------------------------------------------
 Bool UnicodeString::startsWithNoCase(const WideChar* p) const
 {
-	return ::startsWithNoCase(peek(), p);
+	return m_data && ::startsWithNoCase(peek(), p);
 }
 
 // -----------------------------------------------------
 Bool UnicodeString::endsWith(const WideChar* p) const
 {
-	return ::endsWith(peek(), p);
+	return m_data && ::endsWith(peek(), p);
 }
 
 // -----------------------------------------------------
 Bool UnicodeString::endsWithNoCase(const WideChar* p) const
 {
-	return ::endsWithNoCase(peek(), p);
+	return m_data && ::endsWithNoCase(peek(), p);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes a crash that would happen if `AsciiString::startsWith` or similar was called on an empty string:
e.g. `AsciiString().startsWith("test")`.