### PR TITLE
bugfix(network): Prevent buffer overflow in NetPacket::readFileMessage() and NetPacket::readFileAnnounceMessage()

### DIFF
--- a/Core/GameEngine/Source/GameNetwork/NetPacket.cpp
+++ b/Core/GameEngine/Source/GameNetwork/NetPacket.cpp
@@ -5807,15 +5807,10 @@ NetCommandMsg * NetPacket::readWrapperMessage(UnsignedByte *data, Int &i) {
 NetCommandMsg * NetPacket::readFileMessage(UnsignedByte *data, Int &i) {
 	NetFileCommandMsg *msg = newInstance(NetFileCommandMsg);
 	char filename[_MAX_PATH];
-	char *c = filename;
 
-	while (data[i] != 0) {
-		*c = data[i];
-		++c;
-		++i;
-	}
-	*c = 0;
-	++i;
+	// TheSuperHackers @security Mauller/Jbremer/SkyAero 11/12/2025 Prevent buffer overflow when copying filepath string
+	i += strlcpy(filename, reinterpret_cast<const char*>(data), ARRAY_SIZE(filename));
+	++i; //Increment for null terminator
 	msg->setPortableFilename(AsciiString(filename));	// it's transferred as a portable filename
 
 	UnsignedInt dataLength = 0;
@@ -5834,15 +5829,10 @@ NetCommandMsg * NetPacket::readFileMessage(UnsignedByte *data, Int &i) {
 NetCommandMsg * NetPacket::readFileAnnounceMessage(UnsignedByte *data, Int &i) {
 	NetFileAnnounceCommandMsg *msg = newInstance(NetFileAnnounceCommandMsg);
 	char filename[_MAX_PATH];
-	char *c = filename;
 
-	while (data[i] != 0) {
-		*c = data[i];
-		++c;
-		++i;
-	}
-	*c = 0;
-	++i;
+	// TheSuperHackers @security Mauller/Jbremer/SkyAero 11/12/2025 Prevent buffer overflow when copying filepath string
+	i += strlcpy(filename, reinterpret_cast<const char*>(data), ARRAY_SIZE(filename));
+	++i; //Increment for null terminator
 	msg->setPortableFilename(AsciiString(filename));	// it's transferred as a portable filename
 
 	UnsignedShort fileID = 0;


### PR DESCRIPTION
This is a continuation of an earlier orphaned PR
Closes: #1668 

---

This PR fixes two possible buffer overflows in NetPacket file handling messages.

We are expecting the received message to be in a particular format and for strings received to be null terminated.
But the original code never checked if we had exceeded the size of the buffer in which the string will be stored.

The size of the buffer cannot be changed as it relates to the maximum path length supported within windows when long file paths are not in use.

Strlcpy will return the length of the orginal string beyond the size of the buffer but will only copy up to the buffer size-1, the rest of the code is safe from malicious behaviour but a malformed packet may cause unexpected behaviour still.