### PR TITLE
unify(matpass): Merge WW3D2 matpass code

### DIFF
--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/matpass.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/matpass.h
@@ -26,12 +26,13 @@
  *                                                                                             *
  *              Original Author:: Greg Hjelstrom                                               *
  *                                                                                             *
- *                      $Author:: Greg_h                                                      $*
+ *                       Author : Kenny Mitchell                                               *
  *                                                                                             *
- *                     $Modtime:: 5/13/01 11:25a                                              $*
+ *                     $Modtime:: 06/27/02 1:27p                                              $*
  *                                                                                             *
- *                    $Revision:: 5                                                           $*
+ *                    $Revision:: 6                                                           $*
  *                                                                                             *
+ * 06/27/02 KM Texture class abstraction																			*
  *---------------------------------------------------------------------------------------------*
  * Functions:                                                                                  *
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
@@ -40,7 +41,6 @@
 
 #include "always.h"
 #include "shader.h"
-
 
 class TextureClass;
 class VertexMaterialClass;
@@ -93,7 +93,7 @@ public:
 
 protected:
 
-	enum { MAX_TEX_STAGES = 2 };
+	enum { MAX_TEX_STAGES = 8 };
 
 	TextureClass *				Texture[MAX_TEX_STAGES];
 	ShaderClass					Shader;


### PR DESCRIPTION
* Follow up for #1920

This change is a follow up for #1920 and merges matpass.h to prevent Generals from crashing.