### PR TITLE
refactor: Remove superfluous global references in singleton classes

### DIFF
--- a/Core/GameEngine/Source/Common/System/FileSystem.cpp
+++ b/Core/GameEngine/Source/Common/System/FileSystem.cpp
@@ -421,8 +421,8 @@ AsciiString FileSystem::normalizePath(const AsciiString& path)
 //============================================================================
 Bool FileSystem::isPathInDirectory(const AsciiString& testPath, const AsciiString& basePath)
 {
-	AsciiString testPathNormalized = TheFileSystem->normalizePath(testPath);
-	AsciiString basePathNormalized = TheFileSystem->normalizePath(basePath);
+	AsciiString testPathNormalized = normalizePath(testPath);
+	AsciiString basePathNormalized = normalizePath(basePath);
 
 	if (basePathNormalized.isEmpty())
 	{

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
@@ -636,7 +636,7 @@ SaveCode GameState::missionSave( void )
 	desc.format( format, TheGameText->fetch( campaign->m_campaignNameLabel ).str(), missionNumber );
 
 	// do an automatic mission save
-	return TheGameState->saveGame( "", desc, SAVE_FILE_TYPE_MISSION );
+	return saveGame( "", desc, SAVE_FILE_TYPE_MISSION );
 
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -1110,7 +1110,7 @@ void GameClient::preloadAssets( TimeOfDay timeOfDay )
 			draw->preloadAssets( timeOfDay );
 
 			// destroy the drawable
-			TheGameClient->destroyDrawable( draw );
+			destroyDrawable( draw );
 
 		}
 
@@ -1534,7 +1534,7 @@ void GameClient::xfer( Xfer *xfer )
 				const ThingTemplate* drawTemplate = draw->getTemplate();
 				if (drawTemplate->getFinalOverride() != thingTemplate->getFinalOverride())
 				{
-					TheGameClient->destroyDrawable( draw );
+					destroyDrawable( draw );
 					draw = TheThingFactory->newDrawable( thingTemplate );
 					TheGameLogic->bindObjectAndDrawable(object, draw);
 				}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AI.cpp
@@ -710,7 +710,7 @@ Object *AI::findClosestEnemy( const Object *me, Real range, UnsignedInt qualifie
 
 		Real distSqr = ThePartitionManager->getDistanceSquared(me, theEnemy, FROM_BOUNDINGSPHERE_2D);
 		Real dist = sqrt(distSqr);
-		Int modifier = dist/TheAI->getAiData()->m_attackPriorityDistanceModifier;
+		Int modifier = dist/getAiData()->m_attackPriorityDistanceModifier;
 		Int modPriority = curPriority-modifier;
 		if (modPriority < 1)
 			modPriority = 1;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -1592,7 +1592,7 @@ WeaponStore::~WeaponStore()
 //-------------------------------------------------------------------------------------------------
 void WeaponStore::handleProjectileDetonation(const WeaponTemplate* wt, const Object *source, const Coord3D* pos, WeaponBonusConditionFlags extraBonusFlags, Bool inflictDamage )
 {
-	Weapon* w = TheWeaponStore->allocateNewWeapon(wt, PRIMARY_WEAPON);
+	Weapon* w = allocateNewWeapon(wt, PRIMARY_WEAPON);
 	w->loadAmmoNow(source);
 	w->fireProjectileDetonationWeapon( source, pos, extraBonusFlags, inflictDamage );
 	deleteInstance(w);
@@ -1603,7 +1603,7 @@ void WeaponStore::createAndFireTempWeapon(const WeaponTemplate* wt, const Object
 {
 	if (wt == NULL)
 		return;
-	Weapon* w = TheWeaponStore->allocateNewWeapon(wt, PRIMARY_WEAPON);
+	Weapon* w = allocateNewWeapon(wt, PRIMARY_WEAPON);
 	w->loadAmmoNow(source);
 	w->fireWeapon(source, pos);
 	deleteInstance(w);
@@ -1615,7 +1615,7 @@ void WeaponStore::createAndFireTempWeapon(const WeaponTemplate* wt, const Object
 	//CRCDEBUG_LOG(("WeaponStore::createAndFireTempWeapon() for %s", DescribeObject(source)));
 	if (wt == NULL)
 		return;
-	Weapon* w = TheWeaponStore->allocateNewWeapon(wt, PRIMARY_WEAPON);
+	Weapon* w = allocateNewWeapon(wt, PRIMARY_WEAPON);
 	w->loadAmmoNow(source);
 	w->fireWeapon(source, target);
 	deleteInstance(w);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -1702,8 +1702,8 @@ void GameLogic::startNewGame( Bool loadingSaveGame )
 	Region3D extent;
 	TheTerrainLogic->getExtent( &extent );
 
-	TheGameLogic->setWidth( extent.hi.x - extent.lo.x );
-	TheGameLogic->setHeight( extent.hi.y - extent.lo.y );
+	setWidth( extent.hi.x - extent.lo.x );
+	setHeight( extent.hi.y - extent.lo.y );
 
 	// anytime the world's size changes, must reset the partition mgr
 	ThePartitionManager->init();
@@ -3060,7 +3060,7 @@ void GameLogic::popSleepyUpdate()
 void GameLogic::friend_awakenUpdateModule(Object* obj, UpdateModulePtr u, UnsignedInt whenToWakeUp)
 {
 	//USE_PERF_TIMER(friend_awakenUpdateModule)
-	UnsignedInt now = TheGameLogic->getFrame();
+	UnsignedInt now = getFrame();
 	DEBUG_ASSERTCRASH(whenToWakeUp >= now, ("setWakeFrame frame is in the past... are you sure this is what you want?"));
 
 	if (u == m_curUpdateModule)
@@ -3692,7 +3692,7 @@ void GameLogic::update( void )
 	}
 
 	// send the current time to the GameClient
-	UnsignedInt now = TheGameLogic->getFrame();
+	UnsignedInt now = getFrame();
 	TheGameClient->setFrame(now);
 
 	// update (execute) scripts
@@ -3888,7 +3888,7 @@ void GameLogic::preUpdate()
 		Bool pause = TRUE;
 		Bool pauseMusic = FALSE;
 		Bool pauseInput = FALSE;
-		TheGameLogic->setGamePaused(pause, pauseMusic, pauseInput);
+		setGamePaused(pause, pauseMusic, pauseInput);
 	}
 }
 
@@ -3960,7 +3960,7 @@ void GameLogic::registerObject( Object *obj )
 	// add object to lookup table
 	addObjectToLookupTable( obj );
 
-	UnsignedInt now = TheGameLogic->getFrame();
+	UnsignedInt now = getFrame();
 	if (now == 0)
 		now = 1;
 	for (BehaviorModule** b = obj->getBehaviorModules(); *b; ++b)
@@ -5206,7 +5206,7 @@ void GameLogic::loadPostProcess( void )
 #ifdef ALLOW_NONSLEEPY_UPDATES
 	m_normalUpdates.clear();
 #else
-	UnsignedInt now = TheGameLogic->getFrame();
+	UnsignedInt now = getFrame();
 	if (now == 0)
 		now = 1;
 #endif


### PR DESCRIPTION
This change removes superfluous global references in singleton classes.

I did a pass on all singleton classes (as seen in GameEngine::init) and these are all I found.

## TODO

- [ ] Replicate in Generals