### PR TITLE
bugfix(network): Fix data offset for string reads in NetPacket::readFileMessage() and NetPacket::readFileAnnounceMessage()

### DIFF
--- a/Core/GameEngine/Source/GameNetwork/NetPacket.cpp
+++ b/Core/GameEngine/Source/GameNetwork/NetPacket.cpp
@@ -5809,7 +5809,7 @@ NetCommandMsg * NetPacket::readFileMessage(UnsignedByte *data, Int &i) {
 	char filename[_MAX_PATH];
 
 	// TheSuperHackers @security Mauller/Jbremer/SkyAero 11/12/2025 Prevent buffer overflow when copying filepath string
-	i += strlcpy(filename, reinterpret_cast<const char*>(data), ARRAY_SIZE(filename));
+	i += strlcpy(filename, reinterpret_cast<const char*>(data + i), ARRAY_SIZE(filename));
 	++i; //Increment for null terminator
 	msg->setPortableFilename(AsciiString(filename));	// it's transferred as a portable filename
 
@@ -5831,7 +5831,7 @@ NetCommandMsg * NetPacket::readFileAnnounceMessage(UnsignedByte *data, Int &i) {
 	char filename[_MAX_PATH];
 
 	// TheSuperHackers @security Mauller/Jbremer/SkyAero 11/12/2025 Prevent buffer overflow when copying filepath string
-	i += strlcpy(filename, reinterpret_cast<const char*>(data), ARRAY_SIZE(filename));
+	i += strlcpy(filename, reinterpret_cast<const char*>(data + i), ARRAY_SIZE(filename));
 	++i; //Increment for null terminator
 	msg->setPortableFilename(AsciiString(filename));	// it's transferred as a portable filename
 


### PR DESCRIPTION
* Follow up for #1981

#1981 introduced the game to crash on file transfer.

This PR fixes an oversight that caused file transfers to be invalid in the code of the related commit.
( Should have tested it instead of just eyeing the correctness of the code. )

The data pointer being passed into the function is a pointer to the current message being processed, the index is used to tell where the processing currently, as external code to these functions have decoded fields from the message before the file announce sections are handled.

The index needed to be used to offset the data pointer when reading the string which was overlooked from the original code.

File transfers are now fixed with this.