### PR TITLE
Add issue search links to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ and features will be possible to implement.
 Here's an overview of our current focus and future plans
 
 - **Modernizing the Codebase**: Transitioning to modern C++ standards and refactoring old code.
-- **Critical Bug Fixes**: Fixing game-breaking issues (e.g., fullscreen crash).
-- **Minor Bug Fixes**: Addressing minor bugs (e.g., UI issues, graphical glitches).
-- **Cross-Platform Support**: Adding support for more platforms (e.g., Linux, macOS).
+- [**Critical Bug Fixes**](https://github.com/TheSuperHackers/GeneralsGameCode/issues?q=state%3Aopen%20label%3ACritical): Fixing game-breaking issues (e.g., fullscreen crash).
+- [**Minor Bug Fixes**](https://github.com/TheSuperHackers/GeneralsGameCode/issues?q=state%3Aopen%20label%3AMinor): Addressing minor bugs (e.g., UI issues, graphical glitches).
+- [**Cross-Platform Support**](https://github.com/TheSuperHackers/GeneralsGameCode/issues?q=label%3APlatform%20state%3Aopen): Adding support for more platforms (e.g., Linux, macOS).
 - **Engine Improvements**: Enhancing the game engine to improve performance and stability.
 - **Client-Side Features**: Enhancing the game's client with features such as an improved replay viewer and UI updates.
-- **Multiplayer Improvements**: Implementing a new game server and an upgraded matchmaking lobby.
-- **Tooling Improvements**: Developing new or improving existing tools for modding and game development.
+- [**Multiplayer Improvements**](https://github.com/TheSuperHackers/GeneralsGameCode/issues?q=state%3Aopen%20label%3ANetwork): Implementing a new game server and an upgraded matchmaking lobby.
+- [**Tooling Improvements**](https://github.com/TheSuperHackers/GeneralsGameCode/issues?q=label%3ATools%20state%3Aopen): Developing new or improving existing tools for modding and game development.
 - **Community-Driven Improvements**: Once the community grows, we plan to incorporate more features, updates, and
   changes based on player feedback.
 


### PR DESCRIPTION
This PR just adds some Github issue/PR search links to some of the focus and future plans bulletpoints.

I was wondering how platform support was going, and the Readme mentions it is a plan, but then I had to go and hunt through the list of Github issue labels to try and find the relevant label for platform tickets and find the right ticket.

I've not linked all of them, as it seems there's not a 1:1 mapping of labels to bulletpoints here, as one would expect, there are more labels than bulletpoints in this readme, and some of these other bulletpoints don't clearly map to any specific label.
I wasn't sure quite what to do with regards to major issues, as there's bulletpoints only for critical and minor, but yeah. Hopefully this is a bit helpful, at least?