### PR TITLE
bugfix(audio): UI audio no longer plays at maximum volume for a single frame when navigating between shell map menus

### DIFF
--- a/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
+++ b/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
@@ -2107,9 +2107,8 @@ void MilesAudioManager::adjustVolumeOfPlayingAudio(AsciiString eventName, Real n
 		if (playing && playing->m_audioEventRTS->getEventName() == eventName) {
 			// Adjust it
 			playing->m_audioEventRTS->setVolume(newVolume);
-			Real desiredVolume = playing->m_audioEventRTS->getVolume() * playing->m_audioEventRTS->getVolumeShift();
 			AIL_sample_volume_pan(playing->m_sample, NULL, &pan);
-			AIL_set_sample_volume_pan(playing->m_sample, m_soundVolume * desiredVolume, pan);
+			AIL_set_sample_volume_pan(playing->m_sample, getEffectiveVolume(playing->m_audioEventRTS), pan);
 		}
 	}
 
@@ -2118,8 +2117,7 @@ void MilesAudioManager::adjustVolumeOfPlayingAudio(AsciiString eventName, Real n
 		if (playing && playing->m_audioEventRTS->getEventName() == eventName) {
 			// Adjust it
 			playing->m_audioEventRTS->setVolume(newVolume);
-			Real desiredVolume = playing->m_audioEventRTS->getVolume() * playing->m_audioEventRTS->getVolumeShift();
-			AIL_set_3D_sample_volume(playing->m_3DSample, m_sound3DVolume * desiredVolume);
+			AIL_set_3D_sample_volume(playing->m_3DSample, getEffectiveVolume(playing->m_audioEventRTS));
 		}
 	}
 
@@ -2128,13 +2126,8 @@ void MilesAudioManager::adjustVolumeOfPlayingAudio(AsciiString eventName, Real n
 		if (playing && playing->m_audioEventRTS->getEventName() == eventName) {
 			// Adjust it
 			playing->m_audioEventRTS->setVolume(newVolume);
-			Real desiredVolume = playing->m_audioEventRTS->getVolume() * playing->m_audioEventRTS->getVolumeShift();
-			Real streamVolume = (playing->m_audioEventRTS->getAudioEventInfo()->m_soundType == AT_Music)
-				? m_musicVolume
-				: m_speechVolume;
-
 			AIL_stream_volume_pan(playing->m_stream, NULL, &pan);
-			AIL_set_stream_volume_pan(playing->m_stream, streamVolume * desiredVolume, pan);
+			AIL_set_stream_volume_pan(playing->m_stream, getEffectiveVolume(playing->m_audioEventRTS), pan);
 		}
 	}
 }


### PR DESCRIPTION
Fixes #1941

This change fixes an issue where currently playing UI audio can be heard at maximum volume for a single frame when navigating between the shell map and other menus.

The issue is caused by a script being run via the shell map. The script reduces the sound volume to 5% when opening the options or entering other menu screens in order to silence the explosions and other noise coming from the shell map. As this also reduces the UI sound effect volume, another script is run to offset the reduced volume by adjusting a manually defined list of UI sound effect volumes to 600%. See the script reference images further below.

When the game processes a volume override command for a particular sound, the override is also immediately applied to any currently playing instances of that sound. However, when the game processes a global volume command, that volume adjustment is not applied until the next frame.

The issue is that `adjustVolumeOfPlayingAudio` applies the override without multiplying the global volume (`m_soundVolume`), so the sound immediately plays at 600% volume instead of 30% (6 × 0.05). Then, on the next frame, `processPlayingList()` sees `m_volumeHasChanged = TRUE` and calls `adjustPlayingVolume()`, which correctly applies the global volume. So for one frame, the sound plays at 600% volume before being corrected to 30%.

The solution is to make `adjustVolumeOfPlayingAudio` apply the same global volume modifiers as `adjustPlayingVolume`.

### Script Reference

<img width="692" height="563" alt="Image" src="https://github.com/user-attachments/assets/9d46d15b-b2d5-46f2-b8fb-9cff7f4bee27" />

<img width="692" height="563" alt="Image" src="https://github.com/user-attachments/assets/aa0bf016-d90f-4582-9f7e-b56507bd7a05" />