### PR TITLE
bugfix(network): Assign disconnect frame when quitting the game via the disconnection menu

### DIFF
--- a/Core/GameEngine/Source/GameNetwork/ConnectionManager.cpp
+++ b/Core/GameEngine/Source/GameNetwork/ConnectionManager.cpp
@@ -1771,6 +1771,7 @@ void ConnectionManager::quitGame() {
 	// Need to do the NetDisconnectPlayerCommandMsg creation and sending here.
 	NetDisconnectPlayerCommandMsg *disconnectMsg = newInstance(NetDisconnectPlayerCommandMsg);
 	disconnectMsg->setDisconnectSlot(m_localSlot);
+	disconnectMsg->setDisconnectFrame(TheGameLogic->getFrame());
 	disconnectMsg->setPlayerID(m_localSlot);
 	if (DoesCommandRequireACommandID(disconnectMsg->getNetCommandType())) {
 		disconnectMsg->setID(GenerateNextCommandID());


### PR DESCRIPTION
Fixes #2013

This change fixes a network issue that manifested as a result of the asset transferal change introduced by #1523.

When a player exits the game via the disconnection menu, the disconnect frame is not assigned to the outgoing disconnection message / packet. Depending on the timing, this causes user-facing discrepancies in the retail game - sometimes the game will notify `Player X has left the game` and remove the player from the disconnection menu, and other times the player will just silently start counting down. The former case, albeit seemingly more correct, is symptomatic of an unassigned `disconnectFrame` in the received disconnection message from the exiting player, and is what leads to the player not being properly removed from the game.

This change now assures the disconnect frame is always correctly assigned to outgoing disconnection messages, and ensures consistent behaviour across all disconnection pathways. The assert crash in `DisconnectManager::processDisconnectPlayer` is also avoided as a result. The immediate notification of players exiting via the disconnection screen can be looked into separately.