### PR TITLE
refactor(logic): Simplify code in GameLogic's init, reset, startNewGame

### DIFF
--- a/Generals/Code/GameEngine/Include/GameLogic/GameLogic.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/GameLogic.h
@@ -329,7 +329,6 @@ private:
 
 	ObjectID m_nextObjID;																		///< For allocating object id's
 
-	void setDefaults( Bool saveGame );											///< Set default values of class object
 	void processDestroyList( void );												///< Destroy all pending objects on the destroy list
 
 	void destroyAllObjectsImmediate();											///< destroy, and process destroy list immediately

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -1081,7 +1081,6 @@ void GameLogic::startNewGame( Bool saveGame )
 	TheWritableGlobalData->m_TiVOFastMode = FALSE;	//always disable the TIVO fast-forward mode at the start of a new game.
 
 	// Fill in the game color and Factions before we do the Load Screen
-	GameInfo *game = NULL;
 	TheGameInfo = NULL;
 	Int localSlot = 0;
 	if (TheNetwork)
@@ -1089,34 +1088,34 @@ void GameLogic::startNewGame( Bool saveGame )
 		if (TheLAN)
 		{
 			DEBUG_LOG(("Starting network game"));
-			TheGameInfo = game = TheLAN->GetMyGame();
+			TheGameInfo = TheLAN->GetMyGame();
 		}
 		else
 		{
 			DEBUG_LOG(("Starting gamespy game"));
-			TheGameInfo = game = TheGameSpyGame;	/// @todo: MDC add back in after demo
+			TheGameInfo = TheGameSpyGame;	/// @todo: MDC add back in after demo
 		}
 	}
 	else
 	{
 		if (TheRecorder && TheRecorder->isPlaybackMode())
 		{
-			TheGameInfo = game = TheRecorder->getGameInfo();
+			TheGameInfo = TheRecorder->getGameInfo();
 		}
 		else if(m_gameMode == GAME_SKIRMISH)
 		{
-		  TheGameInfo = game = TheSkirmishGameInfo;
+		  TheGameInfo = TheSkirmishGameInfo;
 		}
 	}
 
-	checkForDuplicateColors( game );
+	checkForDuplicateColors( TheGameInfo );
 
 	Bool isSkirmishOrSkirmishReplay = FALSE;
-	if (game)
+	if (TheGameInfo)
 	{
 		for (Int i=0; i<MAX_SLOTS; ++i)
 		{
-			GameSlot *slot = game->getSlot(i);
+			GameSlot *slot = TheGameInfo->getSlot(i);
 			if (!saveGame) {
 				slot->saveOffOriginalInfo();
 			}
@@ -1132,8 +1131,8 @@ void GameLogic::startNewGame( Bool saveGame )
 		}
 	}
 
-	populateRandomSideAndColor( game );
-	populateRandomStartPosition( game );
+	populateRandomSideAndColor( TheGameInfo );
+	populateRandomStartPosition( TheGameInfo );
 
 	//****************************//
 	// Start the LoadScreen Now!	//
@@ -1146,7 +1145,7 @@ void GameLogic::startNewGame( Bool saveGame )
 		if(m_loadScreen && !TheGlobalData->m_headless)
 		{
 			TheMouse->setVisibility(FALSE);
-			m_loadScreen->init(game);
+			m_loadScreen->init(TheGameInfo);
 
 			updateLoadProgress( LOAD_PROGRESS_START );
 		}
@@ -1188,7 +1187,7 @@ void GameLogic::startNewGame( Bool saveGame )
 	#endif
 
 	Int progressCount = LOAD_PROGRESS_SIDE_POPULATION;
-	if (game)
+	if (TheGameInfo)
 	{
 
 		if (TheGameEngine->isMultiplayerSession() || isSkirmishOrSkirmishReplay)
@@ -1197,12 +1196,12 @@ void GameLogic::startNewGame( Bool saveGame )
 			TheSidesList->prepareForMP_or_Skirmish();
 		}
 
-		//DEBUG_LOG(("Starting LAN game with %d players", game->getNumPlayers()));
+		//DEBUG_LOG(("Starting LAN game with %d players", TheGameInfo->getNumPlayers()));
 		Dict d;
 		for (int i=0; i<MAX_SLOTS; ++i)
 		{
 			// Add a Side to TheSidesList
-			GameSlot *slot = game->getSlot(i);
+			GameSlot *slot = TheGameInfo->getSlot(i);
 
 			if (!slot || !slot->isHuman())
 			{
@@ -1229,7 +1228,7 @@ void GameLogic::startNewGame( Bool saveGame )
 				d.setAsciiString(TheKey_playerFaction, KEYNAME(pt->getNameKey()));
 			}
 
-			if (game->isPlayerPreorder(i))
+			if (TheGameInfo->isPlayerPreorder(i))
 			{
 				d.setBool(TheKey_playerIsPreorder, TRUE);
 			}
@@ -1239,7 +1238,7 @@ void GameLogic::startNewGame( Bool saveGame )
 			DEBUG_LOG(("Looking for allies of player %d, team %d", i, team));
 			for(int j=0; j < MAX_SLOTS; ++j)
 			{
-				GameSlot *teamSlot = game->getSlot(j);
+				GameSlot *teamSlot = TheGameInfo->getSlot(j);
 				// for check to see if we're trying to add ourselves
 				if(i == j || !teamSlot->isOccupied())
 					continue;
@@ -1293,7 +1292,7 @@ void GameLogic::startNewGame( Bool saveGame )
 			d.setInt(TheKey_multiplayerStartIndex, slot->getStartPos());
 //			d.setBool(TheKey_multiplayerIsLocal, slot->isLocalPlayer());
 //			d.setBool(TheKey_multiplayerIsLocal, slot->getIP() == game->getLocalIP());
-			d.setBool(TheKey_multiplayerIsLocal, slot->isHuman() && (slot->getName().compare(game->getSlot(game->getLocalSlotNum())->getName().str()) == 0));
+			d.setBool(TheKey_multiplayerIsLocal, slot->isHuman() && (slot->getName().compare(TheGameInfo->getSlot(TheGameInfo->getLocalSlotNum())->getName().str()) == 0));
 
 /*
 			if (slot->getIP() == game->getLocalIP())
@@ -1316,7 +1315,7 @@ void GameLogic::startNewGame( Bool saveGame )
 
 			AsciiString slotNameAscii;
 			slotNameAscii.translate(slot->getName());
-			if (slot->isHuman() && game->getSlotNum(slotNameAscii) == game->getLocalSlotNum()) {
+			if (slot->isHuman() && TheGameInfo->getSlotNum(slotNameAscii) == TheGameInfo->getLocalSlotNum()) {
 				localSlot = i;
 			}
 			TheSidesList->addSide(&d);
@@ -1386,11 +1385,11 @@ void GameLogic::startNewGame( Bool saveGame )
 		// if there are no other teams (happens for debugging) don't end the game immediately
 		Int numTeams = 0; // this can be higher than expected, but is accurate for determining 0, 1, 2+
 		Int lastTeam = -1;
-		if (game)
+		if (TheGameInfo)
 		{
 			for (int i=0; i<MAX_SLOTS; ++i)
 			{
-				const GameSlot *slot = game->getConstSlot(i);
+				const GameSlot *slot = TheGameInfo->getConstSlot(i);
 				if (slot->isOccupied() && slot->getPlayerTemplate() != PLAYERTEMPLATE_OBSERVER)
 				{
 					if (slot->getTeamNumber() == -1 || slot->getTeamNumber() != lastTeam)
@@ -1619,11 +1618,11 @@ void GameLogic::startNewGame( Bool saveGame )
 	ThePartitionManager->revealMapForPlayerPermanently( observerPlayer->getPlayerIndex() );
 	DEBUG_LOG(("Reveal shroud for %ls whose index is %d", observerPlayer->getPlayerDisplayName().str(), observerPlayer->getPlayerIndex()));
 
-	if (game)
+	if (TheGameInfo)
 	{
 		for (int i=0; i<MAX_SLOTS; ++i)
 		{
-			GameSlot *slot = game->getSlot(i);
+			GameSlot *slot = TheGameInfo->getSlot(i);
 
 			if (!slot || !slot->isOccupied())
 				continue;
@@ -1757,11 +1756,11 @@ void GameLogic::startNewGame( Bool saveGame )
 
 	progressCount = LOAD_PROGRESS_LOOP_INITIAL_NETWORK_BUILDINGS;
 	// place initial network buildings/units
-	if (game && !saveGame)
+	if (TheGameInfo && !saveGame)
 	{
 		for (int i=0; i<MAX_SLOTS; ++i)
 		{
-			GameSlot *slot = game->getSlot(i);
+			GameSlot *slot = TheGameInfo->getSlot(i);
 
 			if (!slot || !slot->isOccupied())
 				continue;
@@ -1836,9 +1835,9 @@ void GameLogic::startNewGame( Bool saveGame )
 	// Note - We construct the multiplayer start spot name manually here, so change this if you
 	//        change TheKey_Player_1_Start etc.  mdc
 	AsciiString startingCamName = TheNameKeyGenerator->keyToName(TheKey_InitialCameraPosition);
-	if (game)
+	if (TheGameInfo)
 	{
-		GameSlot *slot = game->getSlot(localSlot);
+		GameSlot *slot = TheGameInfo->getSlot(localSlot);
 		DEBUG_ASSERTCRASH(slot, ("Starting a LAN game without ourselves!"));
 
 		if (slot->isHuman())

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -1123,7 +1123,6 @@ void GameLogic::startNewGame( Bool saveGame )
 			if (slot->isAI())
 			{
 				isSkirmishOrSkirmishReplay = TRUE;
-				continue;
 			}
 		}
 	} else {

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -370,9 +370,6 @@ void GameLogic::init( void )
 
 	setFPMode();
 
-	/// @todo Clear object and destroy lists
-	setDefaults( FALSE );
-
 	// create the partition manager
 	ThePartitionManager = NEW PartitionManager;
 	ThePartitionManager->init();
@@ -400,32 +397,8 @@ void GameLogic::init( void )
 	//DEBUG_ASSERTCRASH(ThePlayerList, ("null ThePlayerList"));
 	//ThePlayerList->setLocalPlayer(0);
 
-	m_CRC = 0;
-	m_pauseFrame = 0;
-	m_gamePaused = FALSE;
-	m_pauseSound = FALSE;
-	m_pauseMusic = FALSE;
-	m_pauseInput = FALSE;
-	m_inputEnabledMemory = TRUE;
-	m_mouseVisibleMemory = TRUE;
-	m_logicTimeScaleEnabledMemory = FALSE;
-
-	for(Int i = 0; i < MAX_SLOTS; ++i)
-	{
-		m_progressComplete[i] = FALSE;
-		m_progressCompleteTimeout[i] = 0;
-	}
-	m_forceGameStartByTimeOut = FALSE;
-
-	m_isScoringEnabled = TRUE;
-	m_showBehindBuildingMarkers = TRUE;
-	m_drawIconUI = TRUE;
-	m_showDynamicLOD = TRUE;
-	m_scriptHulkMaxLifetimeOverride = -1;
-
+	reset();
 	m_isInUpdate = FALSE;
-
-	m_rankPointsToAddAtGameStart = 0;
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -249,36 +249,6 @@ GameLogic::GameLogic( void )
 #endif
 }
 
-// ------------------------------------------------------------------------------------------------
-/** Utility function to set class variables to default values. */
-// ------------------------------------------------------------------------------------------------
-void GameLogic::setDefaults( Bool saveGame )
-{
-	m_frame = 0;
-	m_hasUpdated = FALSE;
-	m_width = DEFAULT_WORLD_WIDTH;
-	m_height = DEFAULT_WORLD_HEIGHT;
-	m_objList = NULL;
-#ifdef ALLOW_NONSLEEPY_UPDATES
-	m_normalUpdates.clear();
-#endif
-	for (std::vector<UpdateModulePtr>::iterator it = m_sleepyUpdates.begin(); it != m_sleepyUpdates.end(); ++it)
-	{
-		(*it)->friend_setIndexInLogic(-1);
-	}
-	m_sleepyUpdates.clear();
-	m_curUpdateModule = NULL;
-
-	//
-	// only reset the next object ID allocater counter when we're not loading a save game.
-	// for save games, we read this value out of the save game file and it is important
-	// that we preserve it as we load and execute the game
-	//
-	if( saveGame == FALSE )
-		m_nextObjID = (ObjectID)1;
-
-}
-
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
 Bool GameLogic::isInSinglePlayerGame( void )
@@ -455,7 +425,20 @@ void GameLogic::reset( void )
 	// clear any table of contents we have
 	m_objectTOC.clear();
 
-	setDefaults( FALSE );
+	m_frame = 0;
+	m_hasUpdated = FALSE;
+	m_width = DEFAULT_WORLD_WIDTH;
+	m_height = DEFAULT_WORLD_HEIGHT;
+	m_objList = NULL;
+#ifdef ALLOW_NONSLEEPY_UPDATES
+	m_normalUpdates.clear();
+#endif
+	for (std::vector<UpdateModulePtr>::iterator it = m_sleepyUpdates.begin(); it != m_sleepyUpdates.end(); ++it)
+	{
+		(*it)->friend_setIndexInLogic(-1);
+	}
+	m_sleepyUpdates.clear();
+	m_curUpdateModule = NULL;
 
 	m_isScoringEnabled = TRUE;
 	m_showBehindBuildingMarkers = TRUE;
@@ -1049,7 +1032,15 @@ void GameLogic::startNewGame( Bool saveGame )
 	}
 
 	m_rankLevelLimit = 1000;	// this is reset every game.
-	setDefaults( saveGame );
+
+	//
+	// only reset the next object ID allocater counter when we're not loading a save game.
+	// for save games, we read this value out of the save game file and it is important
+	// that we preserve it as we load and execute the game
+	//
+	if( saveGame == FALSE )
+		m_nextObjID = (ObjectID)1;
+
 	TheWritableGlobalData->m_loadScreenRender = TRUE;	///< mark it so only a few select things are rendered during load
 	TheWritableGlobalData->m_TiVOFastMode = FALSE;	//always disable the TIVO fast-forward mode at the start of a new game.
 

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -1080,11 +1080,6 @@ void GameLogic::startNewGame( Bool saveGame )
 	TheWritableGlobalData->m_loadScreenRender = TRUE;	///< mark it so only a few select things are rendered during load
 	TheWritableGlobalData->m_TiVOFastMode = FALSE;	//always disable the TIVO fast-forward mode at the start of a new game.
 
-	m_showBehindBuildingMarkers = TRUE;
-	m_drawIconUI = TRUE;
-	m_showDynamicLOD = TRUE;
-	m_scriptHulkMaxLifetimeOverride = -1;
-
 	// Fill in the game color and Factions before we do the Load Screen
 	GameInfo *game = NULL;
 	TheGameInfo = NULL;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/GameLogic.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/GameLogic.h
@@ -353,7 +353,6 @@ private:
 
 	ObjectID m_nextObjID;																		///< For allocating object id's
 
-	void setDefaults( Bool loadSaveGame );									///< Set default values of class object
 	void processDestroyList( void );												///< Destroy all pending objects on the destroy list
 
 	void destroyAllObjectsImmediate();											///< destroy, and process destroy list immediately

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -1285,7 +1285,6 @@ void GameLogic::startNewGame( Bool loadingSaveGame )
 			if (slot->isAI())
 			{
 				isSkirmishOrSkirmishReplay = TRUE;
-				continue;
 			}
 		}
 	} else {

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -264,36 +264,6 @@ GameLogic::GameLogic( void )
 	m_clearingGameData = FALSE;
 }
 
-// ------------------------------------------------------------------------------------------------
-/** Utility function to set class variables to default values. */
-// ------------------------------------------------------------------------------------------------
-void GameLogic::setDefaults( Bool loadingSaveGame )
-{
-	m_frame = 0;
-	m_hasUpdated = FALSE;
-	m_width = DEFAULT_WORLD_WIDTH;
-	m_height = DEFAULT_WORLD_HEIGHT;
-	m_objList = NULL;
-#ifdef ALLOW_NONSLEEPY_UPDATES
-	m_normalUpdates.clear();
-#endif
-	for (std::vector<UpdateModulePtr>::iterator it = m_sleepyUpdates.begin(); it != m_sleepyUpdates.end(); ++it)
-	{
-		(*it)->friend_setIndexInLogic(-1);
-	}
-	m_sleepyUpdates.clear();
-	m_curUpdateModule = NULL;
-
-	//
-	// only reset the next object ID allocater counter when we're not loading a save game.
-	// for save games, we read this value out of the save game file and it is important
-	// that we preserve it as we load and execute the game
-	//
-	if( loadingSaveGame == FALSE )
-		m_nextObjID = (ObjectID)1;
-
-}
-
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
 Bool GameLogic::isInSinglePlayerGame( void )
@@ -467,7 +437,20 @@ void GameLogic::reset( void )
 	// clear any table of contents we have
 	m_objectTOC.clear();
 
-	setDefaults( FALSE );
+	m_frame = 0;
+	m_hasUpdated = FALSE;
+	m_width = DEFAULT_WORLD_WIDTH;
+	m_height = DEFAULT_WORLD_HEIGHT;
+	m_objList = NULL;
+#ifdef ALLOW_NONSLEEPY_UPDATES
+	m_normalUpdates.clear();
+#endif
+	for (std::vector<UpdateModulePtr>::iterator it = m_sleepyUpdates.begin(); it != m_sleepyUpdates.end(); ++it)
+	{
+		(*it)->friend_setIndexInLogic(-1);
+	}
+	m_sleepyUpdates.clear();
+	m_curUpdateModule = NULL;
 
 	m_isScoringEnabled = TRUE;
 	m_showBehindBuildingMarkers = TRUE;
@@ -1187,7 +1170,15 @@ void GameLogic::startNewGame( Bool loadingSaveGame )
 	}
 
 	m_rankLevelLimit = 1000;	// this is reset every game.
-	setDefaults( loadingSaveGame );
+
+	//
+	// only reset the next object ID allocater counter when we're not loading a save game.
+	// for save games, we read this value out of the save game file and it is important
+	// that we preserve it as we load and execute the game
+	//
+	if( loadingSaveGame == FALSE )
+		m_nextObjID = (ObjectID)1;
+
 	TheWritableGlobalData->m_loadScreenRender = TRUE;	///< mark it so only a few select things are rendered during load
 	TheWritableGlobalData->m_TiVOFastMode = FALSE;	//always disable the TIVO fast-forward mode at the start of a new game.
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -1219,11 +1219,6 @@ void GameLogic::startNewGame( Bool loadingSaveGame )
 	TheWritableGlobalData->m_loadScreenRender = TRUE;	///< mark it so only a few select things are rendered during load
 	TheWritableGlobalData->m_TiVOFastMode = FALSE;	//always disable the TIVO fast-forward mode at the start of a new game.
 
-	m_showBehindBuildingMarkers = TRUE;
-	m_drawIconUI = TRUE;
-	m_showDynamicLOD = TRUE;
-	m_scriptHulkMaxLifetimeOverride = -1;
-
 	Campaign* currentCampaign = TheCampaignManager->getCurrentCampaign();
 	Bool isChallengeCampaign = m_gameMode == GAME_SINGLE_PLAYER && currentCampaign && currentCampaign->m_isChallengeCampaign;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -385,9 +385,6 @@ void GameLogic::init( void )
 
 	setFPMode();
 
-	/// @todo Clear object and destroy lists
-	setDefaults( FALSE );
-
 	// create the partition manager
 	ThePartitionManager = NEW PartitionManager;
 	ThePartitionManager->init();
@@ -414,33 +411,8 @@ void GameLogic::init( void )
 	// create a team for the player
 	//DEBUG_ASSERTCRASH(ThePlayerList, ("null ThePlayerList"));
 	//ThePlayerList->setLocalPlayer(0);
-
-	m_CRC = 0;
-	m_pauseFrame = 0;
-	m_gamePaused = FALSE;
-	m_pauseSound = FALSE;
-	m_pauseMusic = FALSE;
-	m_pauseInput = FALSE;
-	m_inputEnabledMemory = TRUE;
-	m_mouseVisibleMemory = TRUE;
-	m_logicTimeScaleEnabledMemory = FALSE;
-
-	for(Int i = 0; i < MAX_SLOTS; ++i)
-	{
-		m_progressComplete[i] = FALSE;
-		m_progressCompleteTimeout[i] = 0;
-	}
-	m_forceGameStartByTimeOut = FALSE;
-
-	m_isScoringEnabled = TRUE;
-	m_showBehindBuildingMarkers = TRUE;
-	m_drawIconUI = TRUE;
-	m_showDynamicLOD = TRUE;
-	m_scriptHulkMaxLifetimeOverride = -1;
-
+	reset();
 	m_isInUpdate = FALSE;
-
-	m_rankPointsToAddAtGameStart = 0;
 }
 
 //-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Goal of this refactor PR

These functions all refer to `GameLogic`

1. Check that `reset` is always called before `startNewGame`
2. Remove the code in `startNewGame` that is already handled in `reset`
3. `GameInfo` appears to have an unnecessary local variable, use `TheGameInfo` everywhere
4. Call `reset` and the end of `init` as this code was duplicated

## Overview of startNewGame

1. in SP, set up the load screen and return on the first call so the real start happens from the update loop (in case of a new game)
2. Initialize defaults and globals; resolve the active `GameInfo` (network/skirmish/challenge/replay) and copy per-game restrictions (e.g., superweapon limits).
3. Fill in random sides/colors/start positions, bring up the load screen, and tear down any background UI.
4. Load `map.ini`, load the terrain map, and prepare the side list for MP/skirmish.
5. Build player sides/teams from slots (plus a replay observer), reset team/player lists, and notify the script engine of the new map.
7. Configure victory conditions, radar, world extents, partition manager, ghost objects, and terrain `newMap`.
8. Spawn bridge landmarks, refresh radar/pathfinding, and reveal shroud per observer/MP rules.
9. Instantiate map objects (trees/props/logic objects), assign teams/positions, update behaviors, and register with pathfinding.
10. Place initial network buildings/units, preload assets, set up the tactical view and initial camera position.
11. Finalize relationships/skill points, drive load progress and fade-out, switch UI/control bar to the target mode, and clear loading state.