### PR TITLE
refactor(audio): Simplify volume related code in AudioManager and MilesAudioManager

### DIFF
--- a/Core/GameEngine/Include/Common/GameAudio.h
+++ b/Core/GameEngine/Include/Common/GameAudio.h
@@ -105,7 +105,7 @@ enum
 	local player affiliation, etc. (The entire list of checks is contained in shouldPlayLocally()).
 
 	In addition, the world and unit audio are never allowed to exceed their footprint, as specified
-	in the audio settings INI file. In order to accomodate this, the audio uses an audio cache. The
+	in the audio settings INI file. In order to accommodate this, the audio uses an audio cache. The
 	audio cache will attempt to load a sample, assuming there is enough room. If there is not enough
 	room, then it goes through and finds any samples that are lower priority, and kills them until
 	enough room is present for the sample. If it cannot free enough room, nothing happens to the
@@ -190,7 +190,7 @@ class AudioManager : public SubsystemInterface
 		virtual void closeDevice( void ) = 0;
 		virtual void *getDevice( void ) = 0;
 
-		// Debice Dependent notification functions
+		// Device Dependent notification functions
 		virtual void notifyOfAudioCompletion( UnsignedInt audioCompleted, UnsignedInt flags ) = 0;
 
 		// Device Dependent enumerate providers functions. It is okay for there to be only 1 provider (Miles provides a maximum of 64.

--- a/Core/GameEngine/Source/Common/Audio/AudioEventRTS.cpp
+++ b/Core/GameEngine/Source/Common/Audio/AudioEventRTS.cpp
@@ -724,14 +724,13 @@ void AudioEventRTS::setVolume( Real vol )
 //-------------------------------------------------------------------------------------------------
 const Coord3D *AudioEventRTS::getCurrentPosition( void )
 {
-	if (m_ownerType == OT_Positional)
+	switch (m_ownerType)
 	{
+	case OT_Positional:
 		return &m_positionOfAudio;
-	}
-	else if (m_ownerType == OT_Object)
-	{
-		Object *obj = TheGameLogic->findObjectByID(m_objectID);
-		if (obj)
+
+	case OT_Object:
+		if (Object *obj = TheGameLogic->findObjectByID(m_objectID))
 		{
 			m_positionOfAudio.set( obj->getPosition() );
 		}
@@ -740,11 +739,9 @@ const Coord3D *AudioEventRTS::getCurrentPosition( void )
 			m_ownerType = OT_Dead;
 		}
 		return &m_positionOfAudio;
-	}
-	else if (m_ownerType == OT_Drawable)
-	{
-		Drawable *draw = TheGameClient->findDrawableByID(m_drawableID);
-		if( draw )
+
+	case OT_Drawable:
+		if (Drawable *draw = TheGameClient->findDrawableByID(m_drawableID))
 		{
 			m_positionOfAudio.set( draw->getPosition() );
 		}
@@ -753,9 +750,8 @@ const Coord3D *AudioEventRTS::getCurrentPosition( void )
 			m_ownerType = OT_Dead;
 		}
 		return &m_positionOfAudio;
-	}
-	else if( m_ownerType == OT_Dead )
-	{
+
+	case OT_Dead:
 		return &m_positionOfAudio;
 	}
 

--- a/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
+++ b/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
@@ -2677,25 +2677,29 @@ Bool MilesAudioManager::isOnScreen( const Coord3D *pos ) const
 //-------------------------------------------------------------------------------------------------
 Real MilesAudioManager::getEffectiveVolume(AudioEventRTS *event) const
 {
-	Real volume = 1.0f;
-	volume *= (event->getVolume() * event->getVolumeShift());
-	if (event->getAudioEventInfo()->m_soundType == AT_Music)
+	Real volume = event->getVolume() * event->getVolumeShift();
+
+	switch (event->getAudioEventInfo()->m_soundType)
+	{
+	case AT_Music:
 	{
 		volume *= m_musicVolume;
+		break;
 	}
-	else if (event->getAudioEventInfo()->m_soundType == AT_Streaming)
+	case AT_Streaming:
 	{
 		volume *= m_speechVolume;
+		break;
 	}
-	else
+	case AT_SoundEffect:
 	{
 		if (event->isPositionalAudio())
 		{
 			volume *= m_sound3DVolume;
-			Coord3D distance = m_listenerPosition;
 			const Coord3D *pos = event->getCurrentPosition();
 			if (pos)
 			{
+				Coord3D distance = m_listenerPosition;
 				distance.sub(pos);
 				Real objMinDistance;
 				Real objMaxDistance;
@@ -2730,6 +2734,8 @@ Real MilesAudioManager::getEffectiveVolume(AudioEventRTS *event) const
 		{
 			volume *= m_soundVolume;
 		}
+		break;
+	}
 	}
 
 	return volume;


### PR DESCRIPTION
This change simplifies volume related code in AudioManager and MilesAudioManager. It is mostly a refactor and performance gains will be immeasurable. I replaced a few if-else with switches.

Functionality wise nothing changes.

The initial motivation for this change was to explore not triggering sounds when the volume was set to 0, but in the end I decided against changing this because it would change behavior in regards to muted audio in flight. I added an info comment in the code to document the desired behavior.
