### PR TITLE
docs(build): Add Linux build support and comprehensive documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ thumbs.db
 .clang-format
 /.vscode
 /Dependencies/MaxSDK/maxsdk
+/tmp/
 
 ## IntelliJ, CLion, etc.
 /.idea

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,335 @@
+# Building Generals Game Code
+
+This document provides comprehensive instructions for building Command & Conquer: Generals and Zero Hour from source on Windows and Linux.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Prerequisites](#prerequisites)
+- [Building on Windows](#building-on-windows)
+  - [Visual Studio 2022 Build](#visual-studio-2022-build)
+  - [VC6 Build (Retail Compatible)](#vc6-build-retail-compatible)
+- [Building on Linux](#building-on-linux)
+  - [Docker Build (Recommended)](#docker-build-recommended)
+  - [Running the Game on Linux](#running-the-game-on-linux)
+- [Build Presets](#build-presets)
+- [Build Targets](#build-targets)
+- [Troubleshooting](#troubleshooting)
+
+## Overview
+
+The Generals Game Code can be built using different compilers and configurations:
+
+| Build Type | Platform | Compiler | Notes |
+|------------|----------|----------|-------|
+| VC6 | Windows | Visual Studio 6 | Retail-compatible binaries |
+| Win32 | Windows | Visual Studio 2022 | Modern build with C++20 |
+| Docker | Linux | Wine + VC6 | Cross-compiles Windows binaries |
+
+**Important**: The game engine uses DirectX 8, Miles Sound System, and Bink Video, which are Windows-only technologies. All builds produce Windows executables (.exe files). Linux users run these via Wine.
+
+## Prerequisites
+
+### Windows
+
+- **CMake 3.25+**: Download from [cmake.org](https://cmake.org/download/)
+- **Ninja**: Download from [ninja-build.org](https://ninja-build.org/) or install via package manager
+- **Git**: For cloning the repository and fetching dependencies
+
+For **Visual Studio 2022** builds:
+- Visual Studio 2022 with "Desktop development with C++" workload
+- Windows SDK
+
+For **VC6** builds (retail-compatible):
+- Visual Studio 6.0 (MSVC 6) - see CI configuration for setup
+
+### Linux
+
+- **Docker**: Install from [docker.com](https://docs.docker.com/engine/install/)
+- **Wine** (optional): For running the built executables
+
+```bash
+# Debian/Ubuntu
+sudo apt-get install docker.io wine
+
+# Fedora
+sudo dnf install docker wine
+
+# Arch Linux
+sudo pacman -S docker wine
+```
+
+## Building on Windows
+
+### Visual Studio 2022 Build
+
+This is the recommended build for development on Windows.
+
+```powershell
+# Configure
+cmake --preset win32
+
+# Build (Release)
+cmake --build build/win32 --config Release
+
+# Build (Debug)
+cmake --build build/win32 --config Debug
+```
+
+Executables are placed in `build/win32/GeneralsMD/` and `build/win32/Generals/`.
+
+### VC6 Build (Retail Compatible)
+
+The VC6 build produces binaries compatible with the retail game, allowing replay compatibility testing.
+
+```powershell
+# Configure
+cmake --preset vc6
+
+# Build
+cmake --build build/vc6
+```
+
+**Note**: VC6 builds require the Visual Studio 6 toolchain. The CI uses [itsmattkc/MSVC600](https://github.com/itsmattkc/MSVC600) portable installation.
+
+## Building on Linux
+
+### Docker Build (Recommended)
+
+The Docker build compiles Windows executables using Wine and VC6 inside a container. This is the recommended way to build on Linux.
+
+#### Quick Start
+
+```bash
+# Full build (both games)
+./scripts/build-linux.sh
+
+# Build Zero Hour only
+./scripts/build-linux.sh --game zh
+
+# Build Generals only
+./scripts/build-linux.sh --game generals
+```
+
+#### Using the Docker Script Directly
+
+```bash
+# Build with the original script
+./scripts/dockerbuild.sh
+
+# Force CMake reconfiguration
+./scripts/dockerbuild.sh --cmake
+
+# Enter interactive shell in container
+./scripts/dockerbuild.sh --bash
+```
+
+#### Build Output
+
+After a successful build, executables are located in:
+
+```
+build/docker/
+    GeneralsMD/             # Zero Hour
+        generalszh.exe          # Main game
+        WorldBuilderZH.exe      # Map editor
+        W3DViewZH.exe           # 3D model viewer
+        guiedit.exe             # GUI editor
+        ParticleEditor.dll      # Particle editor
+        ...
+    Generals/               # Original Generals
+        generalsv.exe           # Main game
+        WorldBuilderV.exe       # Map editor
+        W3DViewV.exe            # 3D model viewer
+        ...
+```
+
+### Installing to Existing Game
+
+The build produces Windows executables that need the original game data files (textures, sounds, maps, etc.) to run. You must have a legal copy of Command & Conquer: Generals Zero Hour installed.
+
+#### Using the Installation Script
+
+```bash
+# Auto-detect game installation and install built files
+./scripts/install-to-game.sh --detect
+
+# Or specify the game directory manually
+./scripts/install-to-game.sh "/path/to/Generals Zero Hour"
+
+# Restore original files
+./scripts/install-to-game.sh --restore "/path/to/Generals Zero Hour"
+
+# Dry run (show what would be installed)
+./scripts/install-to-game.sh --dry-run "/path/to/Generals Zero Hour"
+```
+
+#### Manual Installation
+
+If you prefer manual installation:
+
+1. Locate your game installation directory (e.g., `C:\Program Files\EA Games\Command and Conquer Generals Zero Hour\Data\`)
+2. Backup the original executables (e.g., `generalszh.exe` → `generalszh.exe.backup`)
+3. Copy the built executables from `build/docker/GeneralsMD/` to the game's `Data/` directory:
+   - `generalszh.exe` - Main game
+   - `WorldBuilderZH.exe` - Map editor
+   - `W3DViewZH.exe` - Model viewer
+   - `DebugWindow.dll` - Debug tools
+   - `ParticleEditor.dll` - Particle editor
+
+**Important**: Do NOT copy `mss32.dll` or `binkw32.dll` from the build directory - these are stub libraries for compilation only. Keep the original DLLs from your game installation.
+
+### Running the Game on Linux
+
+After installing the built executables to your game directory:
+
+```bash
+# Set up Wine prefix (first time only)
+export WINEPREFIX=~/.wine-generals
+export WINEARCH=win32
+wineboot
+
+# Run the game
+cd "/path/to/Generals Zero Hour/Data"
+wine generalszh.exe
+
+# With quickstart (skip intro videos)
+wine generalszh.exe -quickstart
+```
+
+**Requirements**:
+- Original game data files installed (from retail, Origin, or other legal source)
+- Wine 5.0+ recommended (Wine 10.0+ for best compatibility)
+- DirectX 8 compatible graphics (Wine handles translation)
+
+#### Wine Configuration Tips
+
+```bash
+# Use winetricks for better DirectX support
+winetricks d3dx9 vcrun6
+
+# Use 32-bit Wine prefix (required for this game)
+WINEPREFIX=~/.wine32 WINEARCH=win32 wine generalszh.exe
+
+# Enable DXVK for better performance (optional)
+# Install DXVK to your Wine prefix for DirectX to Vulkan translation
+```
+
+## Build Presets
+
+Available CMake presets:
+
+| Preset | Description |
+|--------|-------------|
+| `vc6` | VC6 release build (retail compatible) |
+| `vc6-debug` | VC6 debug build |
+| `vc6-profile` | VC6 with profiling enabled |
+| `win32` | VS2022 release build |
+| `win32-debug` | VS2022 debug build |
+| `win32-vcpkg` | VS2022 with vcpkg dependencies |
+| `unix` | Unix experimental build (limited) |
+
+List all presets:
+```bash
+cmake --list-presets
+```
+
+## Build Targets
+
+### Game Executables
+
+| Target | Game | Description |
+|--------|------|-------------|
+| `generalszh` | Zero Hour | Main game executable |
+| `generalsv` | Generals | Main game executable |
+
+### Tools
+
+| Target | Description |
+|--------|-------------|
+| `generalszh_tools` | All Zero Hour tools |
+| `generalsv_tools` | All Generals tools |
+| `WorldBuilderZH` | Zero Hour map editor |
+| `WorldBuilderV` | Generals map editor |
+| `W3DViewZH` | Zero Hour 3D model viewer |
+| `W3DViewV` | Generals 3D model viewer |
+
+Build specific target:
+```bash
+cmake --build build/vc6 --target generalszh
+```
+
+## Build Options
+
+CMake options that can be set during configuration:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `RTS_BUILD_ZEROHOUR` | ON | Build Zero Hour code |
+| `RTS_BUILD_GENERALS` | ON | Build Generals code |
+| `RTS_BUILD_OPTION_DEBUG` | OFF | Debug build (breaks retail compatibility) |
+| `RTS_BUILD_OPTION_PROFILE` | OFF | Enable profiling |
+| `RTS_BUILD_OPTION_FFMPEG` | OFF | Enable FFmpeg support |
+
+Example:
+```bash
+cmake --preset vc6 -DRTS_BUILD_GENERALS=OFF  # Zero Hour only
+```
+
+## Troubleshooting
+
+### Docker Build Issues
+
+**"Permission denied" when running Docker**
+```bash
+# Add user to docker group
+sudo usermod -aG docker $USER
+# Log out and back in, or run:
+newgrp docker
+```
+
+**Build fails with "out of memory"**
+- Increase Docker memory limit in Docker Desktop settings
+- Or build specific targets instead of all:
+  ```bash
+  ./scripts/build-linux.sh --target generalszh
+  ```
+
+### Wine Runtime Issues
+
+**"d3d8.dll not found"**
+- Install Wine's DirectX components:
+  ```bash
+  winetricks d3dx9
+  ```
+
+**Game crashes on startup**
+- Try using a 32-bit Wine prefix
+- Check game data files are properly installed
+- Verify registry paths point to correct game directory
+
+### Windows Build Issues
+
+**"CMake Error: CMake was unable to find a build program"**
+- Ensure Ninja is installed and in PATH
+- Or use Visual Studio generator: `cmake -G "Visual Studio 17 2022" -A Win32 ..`
+
+**"Cannot find compiler"**
+- Open "Developer Command Prompt for VS 2022" before running CMake
+- Or ensure Visual Studio C++ tools are installed
+
+### General Issues
+
+**Replay compatibility test failures**
+- Use VC6 optimized build with `RTS_BUILD_OPTION_DEBUG=OFF`
+- Don't mix debug and release builds
+
+**Missing dependencies**
+- Dependencies are fetched automatically via CMake FetchContent
+- Ensure internet connection during first build
+
+## Additional Resources
+
+- [CLAUDE.md](CLAUDE.md) - AI assistant instructions for this codebase
+- [.github/workflows/](.github/workflows/) - CI build configurations
+- [cmake/](cmake/) - CMake configuration modules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,144 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+GeneralsGameCode is a community project to fix and improve *Command & Conquer: Generals* and *Zero Hour*. The codebase was modernized from Visual Studio 6/C++98 to Visual Studio 2022/C++20 while maintaining retail compatibility.
+
+## Build Commands
+
+### Windows
+```bash
+# Configure (choose a preset)
+cmake --preset vc6          # VC6 release build (retail compatible)
+cmake --preset win32        # Modern VS2022 build
+cmake --preset vc6-debug    # Debug build (breaks retail compatibility)
+
+# Build
+cmake --build build/vc6
+cmake --build build/win32 --config Release
+
+# Build with tools
+cmake --build build/vc6 --target generalszh_tools generalszh_extras
+```
+
+### Linux (via Docker)
+```bash
+# Build using Docker (produces Windows executables)
+./scripts/build-linux.sh              # Full build
+./scripts/build-linux.sh --game zh    # Zero Hour only
+
+# Install to existing game
+./scripts/install-to-game.sh --detect
+
+# See BUILDING.md for detailed instructions
+```
+
+Key presets: `vc6`, `vc6-debug`, `vc6-profile`, `win32`, `win32-debug`, `win32-vcpkg`
+
+## Replay Compatibility Testing
+
+```bash
+# Run replay tests (requires VC6 optimized build with RTS_BUILD_OPTION_DEBUG=OFF)
+generalszh.exe -jobs 4 -headless -replay subfolder/*.rep
+```
+
+Replays in `GeneralsReplays/` are used for CI compatibility testing.
+
+## Clang-Tidy
+
+```bash
+# Generate compile commands database
+cmake -B build/clang-tidy -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON -G Ninja
+
+# Run custom checks
+clang-tidy -p build/clang-tidy --checks='-*,generals-use-is-empty,generals-use-this-instead-of-singleton' file.cpp
+```
+
+## Architecture
+
+### Dual Game Structure
+- **GeneralsMD/**: Zero Hour (v1.04) - **primary development focus**
+- **Generals/**: Original Generals (v1.08)
+- **Core/**: Shared engine and libraries used by both
+
+Changes to Zero Hour take precedence. When code is not shared, implement for Zero Hour first, then replicate to Generals with identical implementation.
+
+### Engine Separation (Core/GameEngine/)
+- **GameLogic** (`Include/GameLogic/`): Game state, rules, simulation - deterministic for multiplayer/replays
+- **GameClient** (`Include/GameClient/`): Rendering, UI, platform-specific code
+- **Common** (`Include/Common/`): Shared utilities (AsciiString, UnicodeString, file systems, audio)
+
+### Library Stack (Core/Libraries/)
+- **WWVegas**: Graphics framework (WW3D2, WWAudio, WWLib, WWMath)
+- **rts/**: RTS-specific utilities
+
+### Key Singletons
+Global singletons like `TheGameLogic`, `TheGlobalData` are used throughout. Inside member functions of the same class, use member access directly instead of the singleton reference.
+
+## Code Change Requirements
+
+### Comment Format (Mandatory for User-Facing Changes)
+```cpp
+// TheSuperHackers @keyword author DD/MM/YYYY Description
+```
+
+Keywords: `@bugfix`, `@feature`, `@performance`, `@refactor`, `@tweak`, `@build`, `@fix`, `@info`, `@todo`
+
+### Pull Request Titles
+Use conventional commits format:
+```
+bugfix(scope): Fix description starting with action verb
+feat(scope): Add new feature
+refactor(scope): Improve code structure
+perf(scope): Optimize performance
+```
+
+### Code Style
+- Match surrounding legacy code style
+- Prefer C++98 patterns unless modern features add significant value
+- Separate refactors from logical changes into different commits
+- Use present tense in documentation ("Fixes" not "Fixed")
+- Prefix unit names with faction (e.g., "USA Missile Defender" not "MD")
+
+## Code Quality Principles
+
+### SOLID Principles
+When adding new code, follow SOLID principles where practical:
+
+- **Single Responsibility (SRP)**: Each class/function should have one reason to change. Split large classes into focused components.
+- **Open/Closed (OCP)**: Design for extension over modification. Use virtual functions and inheritance for varying behavior.
+- **Liskov Substitution (LSP)**: Derived classes must be substitutable for their base classes without breaking behavior.
+- **Interface Segregation (ISP)**: Prefer focused interfaces. Don't force classes to implement methods they don't need.
+- **Dependency Inversion (DIP)**: High-level modules shouldn't depend on low-level modules. Both should depend on abstractions.
+
+### Clean Code Practices
+- **Meaningful names**: Use descriptive variable and function names that reveal intent
+- **Small functions**: Functions should do one thing and do it well (aim for <20 lines)
+- **DRY (Don't Repeat Yourself)**: Extract common code into reusable functions
+- **Fail fast**: Validate inputs early and return/throw on invalid state
+- **Minimize nesting**: Use early returns to reduce indentation depth
+- **Comments**: Code should be self-documenting; comments explain *why*, not *what*
+
+### Legacy Code Considerations
+This is a legacy codebase (C++98 era). When modifying existing code:
+- Maintain consistency with surrounding code style
+- Avoid introducing modern patterns that clash with existing architecture
+- Make incremental improvements rather than large refactors
+- Keep retail binary compatibility in mind for VC6 builds
+
+## Build Options
+
+Key CMake options in `cmake/config-build.cmake`:
+- `RTS_BUILD_ZEROHOUR` / `RTS_BUILD_GENERALS`: Select which game to build
+- `RTS_BUILD_OPTION_DEBUG`: Debug build (breaks retail compatibility)
+- `RTS_BUILD_OPTION_PROFILE`: Profiling build
+- `RTS_BUILD_ZEROHOUR_TOOLS`: Build mod tools
+
+## Dependencies
+
+- **VC6 builds**: Require MSVC 6.0 toolchain (CI uses itsmattkc/MSVC600)
+- **Modern builds**: Visual Studio 2022, Ninja
+- **vcpkg**: Optional (zlib, ffmpeg for enhanced builds)
+- **Platform libs**: DirectX 8, Miles Sound System, Bink Video (Windows 32-bit only)

--- a/README.md
+++ b/README.md
@@ -61,9 +61,23 @@ report bugs, and contribute to the project!
 
 ## Building the Game Yourself
 
-We provide support for building the project using Visual Studio 6 (VS6) and Visual Studio 2022. For detailed build
-instructions, check the [Wiki](https://github.com/TheSuperHackers/GeneralsGameCode/wiki/build_guides), which also
-includes guides for building with Docker, CLion, and links to forks supporting additional versions.
+We provide support for building the project on Windows and Linux. See [BUILDING.md](BUILDING.md) for comprehensive build instructions.
+
+### Quick Start
+
+**Windows (Visual Studio 2022)**
+```bash
+cmake --preset win32
+cmake --build build/win32 --config Release
+```
+
+**Linux (via Docker)**
+```bash
+./scripts/build-linux.sh              # Build using Docker
+./scripts/install-to-game.sh --detect  # Install to your game
+```
+
+For more details including VC6 retail-compatible builds, see [BUILDING.md](BUILDING.md) or the [Wiki](https://github.com/TheSuperHackers/GeneralsGameCode/wiki/build_guides).
 
 ### Dependency management
 

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+#
+# TheSuperHackers @build Claude 29/12/2025
+# Build script for compiling Generals/Zero Hour on Linux using Docker
+#
+# This script builds Windows executables using a Docker container with Wine and VC6.
+# The resulting binaries can be run on Linux using Wine or on Windows natively.
+#
+# Usage:
+#   ./scripts/build-linux.sh                  # Full build (both games)
+#   ./scripts/build-linux.sh --game zh        # Build Zero Hour only
+#   ./scripts/build-linux.sh --game generals  # Build Generals only
+#   ./scripts/build-linux.sh --target generalszh  # Build specific target
+#   ./scripts/build-linux.sh --clean          # Clean build directory
+#   ./scripts/build-linux.sh --interactive    # Enter container shell
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+BUILD_DIR="$PROJECT_DIR/build/docker"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+print_header() {
+    echo -e "${BLUE}======================================${NC}"
+    echo -e "${BLUE}  Generals Game Code - Linux Builder${NC}"
+    echo -e "${BLUE}======================================${NC}"
+    echo ""
+}
+
+print_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+print_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS] [TARGET...]
+
+Build Generals/Zero Hour on Linux using Docker (produces Windows executables).
+
+Options:
+    -h, --help          Show this help message
+    -g, --game GAME     Build specific game: 'zh' (Zero Hour), 'generals', or 'all' (default: all)
+    -t, --target TARGET Build specific CMake target (e.g., generalszh, WorldBuilderZH)
+    -c, --clean         Clean build directory before building
+    -i, --interactive   Enter container shell for debugging
+    --cmake             Force CMake reconfiguration
+    -j, --jobs N        Number of parallel jobs (passed to ninja)
+
+Examples:
+    $(basename "$0")                      # Build everything
+    $(basename "$0") --game zh            # Build Zero Hour only
+    $(basename "$0") --target generalszh  # Build Zero Hour executable only
+    $(basename "$0") --clean --game all   # Clean and rebuild everything
+    $(basename "$0") --interactive        # Enter container for debugging
+
+Output:
+    Build artifacts are placed in: $BUILD_DIR/
+
+    Zero Hour executables:
+        - generalszh.exe       (Main game)
+        - WorldBuilderZH.exe   (Map editor)
+        - W3DViewZH.exe        (3D model viewer)
+
+    Generals executables:
+        - generalsv.exe        (Main game)
+        - WorldBuilderV.exe    (Map editor)
+        - W3DViewV.exe         (3D model viewer)
+
+Running the game:
+    After building, you can run the game with Wine:
+        wine $BUILD_DIR/GeneralsMD/generalszh.exe
+
+    Note: You need the original game data files installed.
+EOF
+}
+
+check_dependencies() {
+    print_info "Checking dependencies..."
+
+    if ! command -v docker &>/dev/null; then
+        print_error "Docker is not installed. Please install Docker first."
+        echo "  See: https://docs.docker.com/engine/install/"
+        exit 1
+    fi
+
+    if ! docker info &>/dev/null; then
+        print_error "Docker daemon is not running or you don't have permission."
+        echo "  Try: sudo systemctl start docker"
+        echo "  Or add your user to the docker group: sudo usermod -aG docker \$USER"
+        exit 1
+    fi
+
+    print_success "All dependencies satisfied"
+}
+
+build_docker_image() {
+    print_info "Building Docker image (this may take a while on first run)..."
+
+    docker build \
+        --build-arg UID="$(id -u)" \
+        --build-arg GID="$(id -g)" \
+        "$PROJECT_DIR/resources/dockerbuild" \
+        -t zerohour-build \
+        || {
+            print_error "Failed to build Docker image"
+            exit 1
+        }
+
+    print_success "Docker image ready"
+}
+
+run_build() {
+    local force_cmake="$1"
+    local target="$2"
+    local interactive="$3"
+
+    local docker_flags=""
+    if [[ "$interactive" == "true" ]]; then
+        docker_flags="-it --entrypoint bash"
+    fi
+
+    print_info "Starting build..."
+    if [[ -n "$target" ]]; then
+        print_info "Target: $target"
+    fi
+
+    # shellcheck disable=SC2086
+    docker run \
+        -u "$(id -u):$(id -g)" \
+        -e MAKE_TARGET="$target" \
+        -e FORCE_CMAKE="$force_cmake" \
+        -v "$PROJECT_DIR:/build/cnc" \
+        --rm \
+        $docker_flags \
+        zerohour-build \
+        || {
+            print_error "Build failed"
+            exit 1
+        }
+
+    if [[ "$interactive" != "true" ]]; then
+        print_success "Build completed"
+    fi
+}
+
+clean_build() {
+    print_info "Cleaning build directory..."
+    rm -rf "$BUILD_DIR"
+    print_success "Build directory cleaned"
+}
+
+list_outputs() {
+    echo ""
+    print_info "Build outputs:"
+    echo ""
+
+    if [[ -d "$BUILD_DIR/GeneralsMD" ]]; then
+        echo "Zero Hour (GeneralsMD):"
+        find "$BUILD_DIR/GeneralsMD" -maxdepth 1 -name "*.exe" -printf "    %f (%s bytes)\n" 2>/dev/null || true
+    fi
+
+    if [[ -d "$BUILD_DIR/Generals" ]]; then
+        echo ""
+        echo "Generals:"
+        find "$BUILD_DIR/Generals" -maxdepth 1 -name "*.exe" -printf "    %f (%s bytes)\n" 2>/dev/null || true
+    fi
+}
+
+# Parse arguments
+GAME="all"
+TARGET=""
+CLEAN=false
+INTERACTIVE=false
+FORCE_CMAKE=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        -g|--game)
+            GAME="$2"
+            shift 2
+            ;;
+        -t|--target)
+            TARGET="$2"
+            shift 2
+            ;;
+        -c|--clean)
+            CLEAN=true
+            shift
+            ;;
+        -i|--interactive)
+            INTERACTIVE=true
+            shift
+            ;;
+        --cmake)
+            FORCE_CMAKE=true
+            shift
+            ;;
+        -j|--jobs)
+            # Jobs are handled by ninja in the container
+            shift 2
+            ;;
+        -*)
+            print_error "Unknown option: $1"
+            usage
+            exit 1
+            ;;
+        *)
+            # Positional argument treated as target
+            TARGET="$TARGET $1"
+            shift
+            ;;
+    esac
+done
+
+# Set target based on game selection
+if [[ -z "$TARGET" ]]; then
+    case "$GAME" in
+        zh|zerohour)
+            TARGET="generalszh generalszh_tools"
+            ;;
+        generals)
+            TARGET="generalsv generalsv_tools"
+            ;;
+        all)
+            TARGET=""  # Build all
+            ;;
+        *)
+            print_error "Unknown game: $GAME (use 'zh', 'generals', or 'all')"
+            exit 1
+            ;;
+    esac
+fi
+
+# Main execution
+print_header
+check_dependencies
+
+if [[ "$CLEAN" == "true" ]]; then
+    clean_build
+fi
+
+build_docker_image
+run_build "$FORCE_CMAKE" "$TARGET" "$INTERACTIVE"
+
+if [[ "$INTERACTIVE" != "true" ]]; then
+    list_outputs
+
+    echo ""
+    print_info "To run the game with Wine:"
+    echo "    wine $BUILD_DIR/GeneralsMD/generalszh.exe"
+fi

--- a/scripts/install-to-game.sh
+++ b/scripts/install-to-game.sh
@@ -1,0 +1,379 @@
+#!/usr/bin/env bash
+#
+# TheSuperHackers @build Claude 29/12/2025
+# Install built executables to an existing Generals/Zero Hour installation
+#
+# This script copies the built executables and tools to a game installation,
+# allowing you to test your compiled version with the full game data.
+#
+# Usage:
+#   ./scripts/install-to-game.sh /path/to/game/installation
+#   ./scripts/install-to-game.sh --detect        # Auto-detect game location
+#   ./scripts/install-to-game.sh --restore       # Restore original files
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+BUILD_DIR="$PROJECT_DIR/build/docker"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+print_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
+print_warning() { echo -e "${YELLOW}[WARNING]${NC} $1"; }
+print_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+print_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS] [GAME_DIR]
+
+Install built executables to an existing Generals/Zero Hour installation.
+
+Arguments:
+    GAME_DIR        Path to game installation (containing Data/ subdirectory)
+
+Options:
+    -h, --help      Show this help message
+    -d, --detect    Auto-detect game installation location
+    -r, --restore   Restore original game files from backups
+    -g, --game      Which game to install: 'zh' (Zero Hour), 'generals', or 'both'
+    --dry-run       Show what would be installed without actually copying
+
+Requirements:
+    - Build the project first using: ./scripts/build-linux.sh
+    - Have an existing Generals/Zero Hour installation with game data files
+
+The script will:
+    1. Backup your original executables (*.exe.backup)
+    2. Copy the newly built executables
+    3. Copy any new DLLs (DebugWindow.dll, ParticleEditor.dll)
+    4. Preserve your original mss32.dll and binkw32.dll (audio/video libraries)
+
+Example:
+    # Linux with Wine
+    ./scripts/install-to-game.sh ~/.wine/drive_c/Program\ Files/EA\ Games/Command\ and\ Conquer\ Generals\ Zero\ Hour
+
+    # Windows (from Git Bash or WSL)
+    ./scripts/install-to-game.sh "C:/Program Files/EA Games/Command and Conquer Generals Zero Hour"
+
+To restore original files:
+    ./scripts/install-to-game.sh --restore /path/to/game
+EOF
+}
+
+detect_game() {
+    local candidates=()
+
+    # TheSuperHackers @feature Claude 02/01/2026 Use Windows registry to detect game installation
+    # Check Windows registry (for Git Bash/WSL)
+    if command -v reg.exe &>/dev/null; then
+        for key in \
+            "HKLM\\SOFTWARE\\Electronic Arts\\EA Games\\Command and Conquer Generals Zero Hour" \
+            "HKLM\\SOFTWARE\\WOW6432Node\\Electronic Arts\\EA Games\\Command and Conquer Generals Zero Hour"; do
+            local install_path
+            install_path=$(reg.exe query "$key" //v "InstallPath" 2>/dev/null | grep -oP 'REG_SZ\s+\K.*' | tr -d '\r')
+            if [ -n "$install_path" ] && [ -d "$install_path/Data" ]; then
+                candidates+=("$install_path")
+            fi
+        done
+    fi
+
+    # Check Wine registry (for Linux with Wine)
+    for reg_file in ~/.wine/system.reg ~/.wine32/system.reg; do
+        if [ -f "$reg_file" ]; then
+            local install_path
+            install_path=$(grep -A1 '\[Software\\\\Electronic Arts\\\\EA Games\\\\Command and Conquer Generals Zero Hour\]' "$reg_file" 2>/dev/null | grep -oP '"InstallPath"="\K[^"]+' | sed 's/\\\\x0//g; s/\\\\/\//g; s/^C:/~\/.wine\/drive_c/')
+            if [ -n "$install_path" ] && [ -d "$install_path/Data" ]; then
+                candidates+=("$install_path")
+            fi
+        fi
+    done
+
+    # Fallback: Common Linux Wine locations
+    for prefix in ~/.wine ~/.wine32 ~/.wine-* ~/.local/share/Steam/steamapps/compatdata/*/pfx; do
+        if [ -d "$prefix" ]; then
+            for path in \
+                "$prefix/drive_c/Program Files/EA Games/Command and Conquer Generals Zero Hour" \
+                "$prefix/drive_c/Program Files (x86)/EA Games/Command and Conquer Generals Zero Hour" \
+                "$prefix/drive_c/Program Files/DODI-Repacks/Generals Zero Hour" \
+                "$prefix/drive_c/GOG Games/Command Conquer Generals Zero Hour"; do
+                if [ -d "$path/Data" ]; then
+                    candidates+=("$path")
+                fi
+            done
+        fi
+    done
+
+    # Fallback: Windows paths (for Git Bash/WSL)
+    for path in \
+        "/c/Program Files/EA Games/Command and Conquer Generals Zero Hour" \
+        "/c/Program Files (x86)/EA Games/Command and Conquer Generals Zero Hour" \
+        "C:/Program Files/EA Games/Command and Conquer Generals Zero Hour" \
+        "C:/Program Files (x86)/EA Games/Command and Conquer Generals Zero Hour"; do
+        if [ -d "$path/Data" ]; then
+            candidates+=("$path")
+        fi
+    done
+
+    if [ ${#candidates[@]} -eq 0 ]; then
+        print_error "No game installation found" >&2
+        echo "" >&2
+        echo "Please specify the game directory manually:" >&2
+        echo "  $(basename "$0") /path/to/game/installation" >&2
+        exit 1
+    fi
+
+    if [ ${#candidates[@]} -eq 1 ]; then
+        echo "${candidates[0]}"
+        return
+    fi
+
+    echo "Found multiple installations:" >&2
+    for i in "${!candidates[@]}"; do
+        echo "  $((i+1)). ${candidates[$i]}" >&2
+    done
+    echo "" >&2
+    read -p "Select installation (1-${#candidates[@]}): " selection >&2
+    echo "${candidates[$((selection-1))]}"
+}
+
+check_build() {
+    if [ ! -d "$BUILD_DIR" ]; then
+        print_error "Build directory not found: $BUILD_DIR"
+        echo ""
+        echo "Please build the project first:"
+        echo "  ./scripts/build-linux.sh"
+        exit 1
+    fi
+
+    if [ ! -f "$BUILD_DIR/GeneralsMD/generalszh.exe" ]; then
+        print_error "Built executables not found"
+        echo ""
+        echo "Please build the project first:"
+        echo "  ./scripts/build-linux.sh"
+        exit 1
+    fi
+
+    print_success "Build directory found"
+}
+
+backup_file() {
+    local file="$1"
+    local backup="${file}.backup"
+
+    if [ -f "$file" ] && [ ! -f "$backup" ]; then
+        cp "$file" "$backup"
+        print_info "Backed up: $(basename "$file")"
+    fi
+}
+
+install_file() {
+    local src="$1"
+    local dest="$2"
+    local dry_run="${3:-false}"
+
+    if [ "$dry_run" == "true" ]; then
+        echo "  Would copy: $(basename "$src") -> $dest"
+    else
+        backup_file "$dest"
+        cp "$src" "$dest"
+        print_success "Installed: $(basename "$src")"
+    fi
+}
+
+install_game() {
+    local game_dir="$1"
+    local game_type="$2"  # "zh" or "generals"
+    local dry_run="${3:-false}"
+
+    local data_dir="$game_dir/Data"
+    local build_game_dir
+    local exe_name
+    local tools_prefix
+
+    if [ "$game_type" == "zh" ]; then
+        build_game_dir="$BUILD_DIR/GeneralsMD"
+        exe_name="generalszh.exe"
+        tools_prefix="ZH"
+    else
+        build_game_dir="$BUILD_DIR/Generals"
+        exe_name="generalsv.exe"
+        tools_prefix="V"
+    fi
+
+    if [ ! -d "$build_game_dir" ]; then
+        print_warning "Build for $game_type not found, skipping"
+        return
+    fi
+
+    print_info "Installing $game_type executables..."
+
+    # Main game executable
+    if [ -f "$build_game_dir/$exe_name" ]; then
+        install_file "$build_game_dir/$exe_name" "$data_dir/$exe_name" "$dry_run"
+    fi
+
+    # Tools
+    for tool in WorldBuilder$tools_prefix W3DView$tools_prefix guiedit imagepacker mapcachebuilder wdump; do
+        local tool_exe="${tool}.exe"
+        if [ -f "$build_game_dir/$tool_exe" ]; then
+            install_file "$build_game_dir/$tool_exe" "$data_dir/$tool_exe" "$dry_run"
+        fi
+    done
+
+    # DLLs (but NOT mss32.dll or binkw32.dll - keep originals)
+    for dll in DebugWindow.dll ParticleEditor.dll; do
+        if [ -f "$build_game_dir/$dll" ]; then
+            install_file "$build_game_dir/$dll" "$data_dir/$dll" "$dry_run"
+        fi
+    done
+
+    # Also check Core directory for DLLs
+    if [ -f "$BUILD_DIR/Core/DebugWindow.dll" ]; then
+        install_file "$BUILD_DIR/Core/DebugWindow.dll" "$data_dir/DebugWindow.dll" "$dry_run"
+    fi
+}
+
+restore_files() {
+    local game_dir="$1"
+    local data_dir="$game_dir/Data"
+
+    print_info "Restoring original files..."
+
+    local restored=0
+    for backup in "$data_dir"/*.backup; do
+        if [ -f "$backup" ]; then
+            local original="${backup%.backup}"
+            cp "$backup" "$original"
+            print_success "Restored: $(basename "$original")"
+            ((restored++))
+        fi
+    done
+
+    if [ $restored -eq 0 ]; then
+        print_warning "No backup files found to restore"
+    else
+        print_success "Restored $restored files"
+    fi
+}
+
+# Parse arguments
+GAME_DIR=""
+DETECT=false
+RESTORE=false
+GAME_TYPE="zh"
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        -d|--detect)
+            DETECT=true
+            shift
+            ;;
+        -r|--restore)
+            RESTORE=true
+            shift
+            ;;
+        -g|--game)
+            GAME_TYPE="$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        -*)
+            print_error "Unknown option: $1"
+            usage
+            exit 1
+            ;;
+        *)
+            GAME_DIR="$1"
+            shift
+            ;;
+    esac
+done
+
+# Main execution
+echo ""
+echo "==================================="
+echo "  Generals Game Code - Installer"
+echo "==================================="
+echo ""
+
+# Detect or validate game directory
+if [ "$DETECT" == "true" ] || [ -z "$GAME_DIR" ]; then
+    print_info "Searching for game installations..."
+    GAME_DIR=$(detect_game)
+fi
+
+print_info "Game directory: $GAME_DIR"
+
+# Validate game directory
+if [ ! -d "$GAME_DIR/Data" ]; then
+    print_error "Invalid game directory (Data/ subdirectory not found)"
+    echo ""
+    echo "Expected directory structure:"
+    echo "  $GAME_DIR/"
+    echo "    Data/"
+    echo "      generalszh.exe"
+    echo "      *.big files"
+    exit 1
+fi
+
+# Restore mode
+if [ "$RESTORE" == "true" ]; then
+    restore_files "$GAME_DIR"
+    exit 0
+fi
+
+# Check build exists
+check_build
+
+# Install
+if [ "$DRY_RUN" == "true" ]; then
+    print_info "Dry run - showing what would be installed:"
+fi
+
+case "$GAME_TYPE" in
+    zh|zerohour)
+        install_game "$GAME_DIR" "zh" "$DRY_RUN"
+        ;;
+    generals)
+        install_game "$GAME_DIR" "generals" "$DRY_RUN"
+        ;;
+    both|all)
+        install_game "$GAME_DIR" "zh" "$DRY_RUN"
+        install_game "$GAME_DIR" "generals" "$DRY_RUN"
+        ;;
+    *)
+        print_error "Unknown game type: $GAME_TYPE"
+        exit 1
+        ;;
+esac
+
+if [ "$DRY_RUN" != "true" ]; then
+    echo ""
+    print_success "Installation complete!"
+    echo ""
+    echo "To run the game:"
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        echo "  wine \"$GAME_DIR/Data/generalszh.exe\""
+    else
+        echo "  cd \"$GAME_DIR/Data\" && generalszh.exe"
+    fi
+    echo ""
+    echo "To restore original files:"
+    echo "  $(basename "$0") --restore \"$GAME_DIR\""
+fi


### PR DESCRIPTION
## Summary
- Add comprehensive build documentation (BUILDING.md) for Windows and Linux
- Add convenience scripts for Linux users to build via Docker
- Add installation script to deploy built executables to existing game
- Add CLAUDE.md with AI assistant guidelines and SOLID principles
- Update README.md with quick start build instructions

## Changes
1. **BUILDING.md** - Detailed build instructions for all platforms
2. **scripts/build-linux.sh** - Docker-based build script for Linux
3. **scripts/install-to-game.sh** - Script to install built files to existing game installation
4. **CLAUDE.md** - Guidelines for AI code assistants with SOLID principles
5. **README.md** - Added quick start build section
6. **.gitignore** - Added /tmp/ to ignored paths

## Test plan
- [x] Docker build completed successfully on Linux (Debian)
- [x] Built executables installed to existing game
- [x] Game launched successfully with built executable
- [x] Scripts work with --help and --dry-run options

## Notes
The Linux build uses the existing Docker infrastructure with Wine and VC6 to produce Windows-compatible executables. The game was tested and runs successfully under Wine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)