### PR TITLE
bugfix(heightmap): Disable old uv adjument for cliffs

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/WorldHeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/WorldHeightMap.cpp
@@ -1742,7 +1742,11 @@ Bool WorldHeightMap::getUVForTileIndex(Int ndx, Short tileNdx, float U[4], float
 				return info.flip;
 			}
 		}
-#define DO_OLD_UV
+
+// TheSuperHackers @bugfix xezon 11/12/2025 Disables the old uv adjustment for cliffs,
+// because it produces bad uv tiles on steep terrain and is also not helping performance.
+// @todo Delete this code when we are certain we never need this again.
+//#define DO_OLD_UV
 #ifdef DO_OLD_UV
 // old uv adjustment for cliffs
 		static Real STRETCH_LIMIT = 1.5f;	 // If it is stretching less than this, don't adjust.


### PR DESCRIPTION
This change disables the old uv adjument for cliffs and fixes ugly UV mapping on cliffs. I suspect John A. forgot to disable it when placing the new code above it.

## Broken cliffs caused by old code

![shot_20251231_111139_1](https://github.com/user-attachments/assets/316a5269-aa35-4e21-9efa-8efe641f1217)
