### PR TITLE
bugfix(heightmap): Fix dynamic lights on terrain

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/HeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/HeightMap.cpp
@@ -1389,8 +1389,8 @@ Int HeightMapRenderObjClass::initHeightData(Int x, Int y, WorldHeightMap *pMap, 
 //=============================================================================
 // Updates the diffuse color values in the vertices as affected by the dynamic
 // lights.
-// TheSuperHackers @bugfix xezon 15/12/2025 The dynamic lights are now properly
-// drawn on the entirety of the drawable map region.
+// TheSuperHackers @bugfix xezon 15/12/2025 Now draws the dynamic lights
+// properly on the entirety of the drawable map region.
 //=============================================================================
 void HeightMapRenderObjClass::On_Frame_Update(void)
 {


### PR DESCRIPTION
* Fixes #182

This changes fixes the dynamic lights on terrain. The coordinate bounds were incorrectly calculated, which caused dynamic lights to not draw at all within a viewed area or become stuck under some conditions.

Some vehicle types do not emit dynamic lights.

## Fixed Dynamic Lights on Terrain

![shot_20251215_201428_1](https://github.com/user-attachments/assets/6af5c908-b2b0-47b8-bd19-b94411b0dafe)

![shot_20251215_202305_4](https://github.com/user-attachments/assets/b582365f-4db9-431e-9dfa-089be6c297b0)
