### PR TITLE
bugfix(network): Fix packet size setup mistakes

### DIFF
--- a/Core/GameEngine/Include/GameNetwork/NetPacketStructs.h
+++ b/Core/GameEngine/Include/GameNetwork/NetPacketStructs.h
@@ -137,8 +137,6 @@ struct NetPacketPlayerLeaveCommand {
 
 // Run ahead metrics command packet structure
 // Fields: T + type, R + relay, P + playerID, C + commandID, D + averageLatency + averageFps
-// TODO: averageFps should be UnsignedShort to match FillBufferWithRunAheadMetricsCommand, but
-// original GetRunAheadMetricsCommandSize incorrectly counted it as UnsignedByte
 struct NetPacketRunAheadMetricsCommand {
 	NetPacketCommandTypeField commandType;
 	NetPacketRelayField relay;
@@ -146,7 +144,7 @@ struct NetPacketRunAheadMetricsCommand {
 	NetPacketCommandIdField commandId;
 	NetPacketDataFieldHeader dataHeader;
 	Real averageLatency;
-	UnsignedByte averageFps;
+	UnsignedShort averageFps;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -362,24 +360,22 @@ struct NetPacketProgressMessage {
 };
 
 // Load complete message packet
-// Fields: T + type, R + relay, P + playerID, D
-// TODO: commandId field is missing. FillBufferWithLoadCompleteMessage writes it, but
-// original GetLoadCompleteMessageSize did not count it
+// Fields: T + type, R + relay, P + playerID, C + commandID, D
 struct NetPacketLoadCompleteMessage {
 	NetPacketCommandTypeField commandType;
 	NetPacketRelayField relay;
 	NetPacketPlayerIdField playerId;
+	NetPacketCommandIdField commandId;
 	NetPacketDataFieldHeader dataHeader;
 };
 
 // Timeout game start message packet
-// Fields: T + type, R + relay, P + playerID, D
-// TODO: commandId field is missing. FillBufferWithTimeOutGameStartMessage writes it, but
-// original GetTimeOutGameStartMessageSize did not count it
+// Fields: T + type, R + relay, P + playerID, C + commandID, D
 struct NetPacketTimeOutGameStartMessage {
 	NetPacketCommandTypeField commandType;
 	NetPacketRelayField relay;
 	NetPacketPlayerIdField playerId;
+	NetPacketCommandIdField commandId;
 	NetPacketDataFieldHeader dataHeader;
 };
 

--- a/Core/GameEngine/Source/GameNetwork/NetPacket.cpp
+++ b/Core/GameEngine/Source/GameNetwork/NetPacket.cpp
@@ -2392,7 +2392,7 @@ Bool NetPacket::isRoomForWrapperMessage(NetCommandRef *msg) {
  */
 Bool NetPacket::addTimeOutGameStartMessage(NetCommandRef *msg) {
 	Bool needNewCommandID = FALSE;
-	if (isRoomForLoadCompleteMessage(msg)) {
+	if (isRoomForTimeOutGameStartMessage(msg)) {
 		NetCommandMsg *cmdMsg = static_cast<NetCommandMsg *>(msg->getCommand());
 
 		// If necessary, put the NetCommandType into the packet.

--- a/Core/GameEngine/Source/GameNetwork/NetPacket.cpp
+++ b/Core/GameEngine/Source/GameNetwork/NetPacket.cpp
@@ -2457,6 +2457,7 @@ Bool NetPacket::addTimeOutGameStartMessage(NetCommandRef *msg) {
  */
 Bool NetPacket::isRoomForTimeOutGameStartMessage(NetCommandRef *msg) {
 	Int len = 0;
+	Bool needNewCommandID = FALSE;
 	NetCommandMsg *cmdMsg = static_cast<NetCommandMsg *>(msg->getCommand());
 	if (m_lastCommandType != cmdMsg->getNetCommandType()) {
 		++len;
@@ -2468,6 +2469,10 @@ Bool NetPacket::isRoomForTimeOutGameStartMessage(NetCommandRef *msg) {
 	if (m_lastPlayerID != cmdMsg->getPlayerID()) {
 		++len;
 		len += sizeof(UnsignedByte);
+		needNewCommandID = TRUE;
+	}
+	if (((m_lastCommandID + 1) != (UnsignedShort)(cmdMsg->getID())) || (needNewCommandID == TRUE)) {
+		len += sizeof(UnsignedByte) + sizeof(UnsignedShort);
 	}
 
 	++len; // for NetPacketFieldTypes::Data
@@ -2549,6 +2554,7 @@ Bool NetPacket::addLoadCompleteMessage(NetCommandRef *msg) {
  */
 Bool NetPacket::isRoomForLoadCompleteMessage(NetCommandRef *msg) {
 	Int len = 0;
+	Bool needNewCommandID = FALSE;
 	NetCommandMsg *cmdMsg = static_cast<NetCommandMsg *>(msg->getCommand());
 	if (m_lastCommandType != cmdMsg->getNetCommandType()) {
 		++len;
@@ -2560,6 +2566,10 @@ Bool NetPacket::isRoomForLoadCompleteMessage(NetCommandRef *msg) {
 	if (m_lastPlayerID != cmdMsg->getPlayerID()) {
 		++len;
 		len += sizeof(UnsignedByte);
+		needNewCommandID = TRUE;
+	}
+	if (((m_lastCommandID + 1) != (UnsignedShort)(cmdMsg->getID())) || (needNewCommandID == TRUE)) {
+		len += sizeof(UnsignedByte) + sizeof(UnsignedShort);
 	}
 
 	++len; // for NetPacketFieldTypes::Data


### PR DESCRIPTION
Fixes latent bugs in network packet size calculations

### Changes

  1. **Fix struct sizes** (`NetPacketStructs.h`)
     - Add missing `commandId` field to `NetPacketLoadCompleteMessage` and `NetPacketTimeOutGameStartMessage`
     - Change `averageFps` from `UnsignedByte` to `UnsignedShort` in `NetPacketRunAheadMetricsCommand`

  2. **Fix `isRoomFor*` functions** (`NetPacket.cpp`)
     - Add missing CommandId size calculation to `isRoomForLoadCompleteMessage` and `isRoomForTimeOutGameStartMessage`

  3. **Fix wrong function call** (`NetPacket.cpp`)
     - `addTimeOutGameStartMessage` now calls `isRoomForTimeOutGameStartMessage` instead of `isRoomForLoadCompleteMessage` (These are accidentally/coincidentally identical, but it's now using the right one)