### PR TITLE
bugfix(Geometry): Checks Hitboxes for buildings with BOX Geometry, preventing the building to take damage without being hit 

### DIFF
--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/PartitionManager.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/PartitionManager.h
@@ -1442,7 +1442,8 @@ public:
 							Real angle1,
 							const Coord3D* pos2,
 							const GeometryInfo& geom2,
-							Real angle2
+							Real angle2,
+							Bool passHeightCheck = FALSE
   ) const;
 
 	/// finding legal positions in the world


### PR DESCRIPTION
This resolves issue #2036