### PR TITLE
performance(Drawable): Rework for IterateDrawablesInRegion Functions for both GameClient and W3DView to be more Efficient

### DIFF
--- a/Core/GameEngine/Include/Common/GameDefines.h
+++ b/Core/GameEngine/Include/Common/GameDefines.h
@@ -50,6 +50,11 @@
 #define RETAIL_COMPATIBLE_AIGROUP (1) // AIGroup logic is expected to be CRC compatible with retail Generals 1.08, Zero Hour 1.04
 #endif
 
+// IamInnocent - DRAWUPDATE is Retail CRC Compatible, but might need more checking. Remove this comment once this check is done.
+#ifndef RETAIL_COMPATIBLE_DRAWUPDATE
+#define RETAIL_COMPATIBLE_DRAWUPDATE (1) // Drawable Update logic is expected to be CRC compatible with retail Generals 1.08, Zero Hour 1.04
+#endif
+
 #ifndef ENABLE_GAMETEXT_SUBSTITUTES
 #define ENABLE_GAMETEXT_SUBSTITUTES (1) // The code can provide substitute texts when labels and strings are missing in the STR or CSF translation file
 #endif

--- a/Core/GameEngine/Include/GameClient/View.h
+++ b/Core/GameEngine/Include/GameClient/View.h
@@ -234,6 +234,10 @@ public:
 	virtual void forceCameraConstraintRecalc(void) {}
 	virtual void setGuardBandBias( const Coord2D *gb ) = 0;
 
+#if !RETAIL_COMPATIBLE_DRAWUPDATE
+	virtual void setUpdateEfficient(void) {}
+#endif
+
 protected:
 
 	friend class Display;

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DView.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DView.h
@@ -230,6 +230,10 @@ public:
 
 	virtual void setGuardBandBias( const Coord2D *gb ) { m_guardBandBias.x = gb->x; m_guardBandBias.y = gb->y; }
 
+#if !RETAIL_COMPATIBLE_DRAWUPDATE
+	virtual void setUpdateEfficient(void) { m_updateEfficient = TRUE; }
+#endif
+
 
 private:
 
@@ -296,6 +300,11 @@ private:
 	Bool				m_useRealZoomCam;
 	AsciiString		m_cameraSlaveObjectName;
 	AsciiString		m_cameraSlaveObjectBoneName;
+
+#if !RETAIL_COMPATIBLE_DRAWUPDATE
+	// Efficient Draw Update
+	Bool				m_updateEfficient;
+#endif
 };
 
 // EXTERNALS //////////////////////////////////////////////////////////////////////////////////////

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/GameClient.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/GameClient.h
@@ -155,6 +155,13 @@ public:
 	void incrementRenderedObjectCount() { m_renderedObjectCount++; }
 	virtual void notifyTerrainObjectMoved(Object *obj) = 0;
 
+#if !RETAIL_COMPATIBLE_DRAWUPDATE
+	void informClientNewDrawable(Drawable *draw);
+	void addDrawableToEfficientList(Drawable *draw);
+	void clearEfficientDrawablesList() { m_drawablesIterateListMarkedForClear = TRUE; }
+	void setEfficientDrawableRegion(Region3D *region) { m_axisAlignedRegion.lo = region->lo; m_axisAlignedRegion.hi = region->hi; }
+	Region3D *getEfficientDrawableRegion() { return &m_axisAlignedRegion; }
+#endif
 
 protected:
 
@@ -213,6 +220,13 @@ private:
 	typedef std::list< Drawable* > TextBearingDrawableList;
 	typedef TextBearingDrawableList::iterator TextBearingDrawableListIterator;
 	TextBearingDrawableList m_textBearingDrawableList;	///< the drawables that have registered here during drawablepostdraw
+
+#if !RETAIL_COMPATIBLE_DRAWUPDATE
+	std::list< Drawable* > m_drawablesIterateList;
+	Bool m_drawablesIterateListMarkedForClear;
+
+	Region3D m_axisAlignedRegion;
+#endif
 };
 
 //Kris: Try not to use this if possible. In every case I found in the code base, the status was always Drawable::SELECTED.

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/PartitionManager.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/PartitionManager.h
@@ -92,6 +92,7 @@ class Team;
 class ThingTemplate;
 class GhostObject;
 class CommandButton;
+class Drawable;
 
 enum CommandSourceType CPP_11(: Int);
 
@@ -1528,6 +1529,9 @@ public:
 	// If saveToFog is false, then we are writing STORE_PERMENANT_REVEAL
 	void storeFoggedCells(ShroudStatusStoreRestore &outPartitionStore, Bool storeToFog) const;
 	void restoreFoggedCells(const ShroudStatusStoreRestore &inPartitionStore, Bool restoreToFog);
+
+	std::list<Drawable*> getDrawablesInRegion( IRegion2D *region2D );
+	Bool hasNoOffset() const { return m_radiusVec.empty(); }
 };
 
 // -----------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/Common/Thing/Thing.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Thing/Thing.cpp
@@ -46,6 +46,9 @@
 #include "Lib/trig.h"
 #include "GameLogic/TerrainLogic.h"
 
+#if !RETAIL_COMPATIBLE_DRAWUPDATE
+#include "GameClient/GameClient.h"
+#endif
 
 static constexpr const Real InitialThingPosX = 0.0f;
 static constexpr const Real InitialThingPosY = 0.0f;
@@ -169,6 +172,15 @@ void Thing::setPositionZ( Real z )
 		setTransformMatrix(&mtx);
 	}
 	DEBUG_ASSERTCRASH(!(_isnan(getPosition()->x) || _isnan(getPosition()->y) || _isnan(getPosition()->z)), ("Drawable/Object position NAN! '%s'", m_template->getName().str() ));
+#if !RETAIL_COMPATIBLE_DRAWUPDATE
+	if(TheGameClient)
+	{
+		if(AsObject(this) && AsObject(this)->getDrawable())
+			TheGameClient->informClientNewDrawable(AsObject(this)->getDrawable());
+		else if(AsDrawable(this))
+			TheGameClient->informClientNewDrawable(AsDrawable(this));
+	}
+#endif
 }
 
 //=============================================================================
@@ -198,6 +210,15 @@ void Thing::setPosition( const Coord3D *pos )
 		setTransformMatrix(&mtx);
 	}
 	DEBUG_ASSERTCRASH(!(_isnan(getPosition()->x) || _isnan(getPosition()->y) || _isnan(getPosition()->z)), ("Drawable/Object position NAN! '%s'", m_template->getName().str() ));
+#if !RETAIL_COMPATIBLE_DRAWUPDATE
+	if(TheGameClient)
+	{
+		if(AsObject(this) && AsObject(this)->getDrawable())
+			TheGameClient->informClientNewDrawable(AsObject(this)->getDrawable());
+		else if(AsDrawable(this))
+			TheGameClient->informClientNewDrawable(AsDrawable(this));
+	}
+#endif
 }
 
 //=============================================================================

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -2646,7 +2646,11 @@ void Drawable::draw()
 		applyPhysicsXform(&transformMtx);
 	}
 
+#if RETAIL_COMPATIBLE_DRAWUPDATE
 	for (DrawModule** dm = getDrawModules(); *dm; ++dm)
+#else
+	for (DrawModule** dm = getDrawModules(); dm != nullptr && *dm; ++dm)
+#endif
 	{
 		(*dm)->doDrawModule(&transformMtx);
 	}
@@ -4070,7 +4074,11 @@ void Drawable::replaceModelConditionStateInDrawable()
 	const TerrainDecalType terrainDecalType = getTerrainDecalType();
 	setTerrainDecal(TERRAIN_DECAL_NONE);
 
+#if RETAIL_COMPATIBLE_DRAWUPDATE
 	for (DrawModule** dm = getDrawModules(); *dm; ++dm)
+#else
+	for (DrawModule** dm = getDrawModules(); dm != nullptr && *dm; ++dm)
+#endif
 	{
 		ObjectDrawInterface* di = (*dm)->getObjectDrawInterface();
 		if (di)
@@ -4650,6 +4658,9 @@ void Drawable::updateHiddenStatus()
 			di->setHidden(hidden != 0);
 	}
 
+#if !RETAIL_COMPATIBLE_DRAWUPDATE
+	TheGameClient->informClientNewDrawable(this);
+#endif
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -4810,6 +4810,10 @@ void Object::handlePartitionCellMaintenance()
 	handleShroud();
 	handleValueMap();
 	handleThreatMap();
+
+#if !RETAIL_COMPATIBLE_DRAWUPDATE
+	TheGameClient->informClientNewDrawable(getDrawable());
+#endif
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
@@ -46,6 +46,10 @@
 #include "GameLogic/Weapon.h"
 #include "GameLogic/LogicRandomValue.h"
 
+#if !RETAIL_COMPATIBLE_DRAWUPDATE
+#include "GameClient/GameClient.h"
+#endif
+
 const Real DEFAULT_MASS = 1.0f;
 
 const Real DEFAULT_SHOCK_YAW = 0.05f;
@@ -907,6 +911,12 @@ UpdateSleepTime PhysicsBehavior::update()
 			obj->kill();
 		}
 	}
+
+#if !RETAIL_COMPATIBLE_DRAWUPDATE
+	// Always inform the Drawable for Physics, since the Object may end up within the Screen Region and it will need to be Registered.
+	if(obj->getDrawable())
+		TheGameClient->informClientNewDrawable(obj->getDrawable());
+#endif
 
 	setFlag(UPDATE_EVER_RUN, true);
 	setFlag(WAS_AIRBORNE_LAST_FRAME, airborneAtEnd);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/StealthUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/StealthUpdate.cpp
@@ -784,6 +784,14 @@ UpdateSleepTime StealthUpdate::update( void )
 		}
 
 		self->setStatus( MAKE_OBJECT_STATUS_MASK( OBJECT_STATUS_DETECTED ) );
+
+#if !RETAIL_COMPATIBLE_DRAWUPDATE
+		if(draw && ThePlayerList->getLocalPlayer()->getRelationship(self->getTeam()) == ENEMIES)
+		{
+			// Redraw everything as Stealth Detection bugs out how existing Drawables work
+			TheGameClient->clearEfficientDrawablesList();
+		}
+#endif
 	}
 	else
 	{
@@ -1108,6 +1116,14 @@ void StealthUpdate::changeVisualDisguise()
 		self->clearStatus( MAKE_OBJECT_STATUS_MASK( OBJECT_STATUS_DISGUISED ) );
 		self->clearModelConditionState( MODELCONDITION_DISGUISED );
 	}
+
+#if !RETAIL_COMPATIBLE_DRAWUPDATE
+	if(ThePlayerList->getLocalPlayer()->getRelationship(self->getTeam()) == ENEMIES)
+	{
+		// Redraw everything as Stealth Detection bugs out how existing Drawables work
+		TheGameClient->clearEfficientDrawablesList();
+	}
+#endif
 
 	//Reset the radar (determines color on add)
 	TheRadar->removeObject( self );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -4234,6 +4234,10 @@ void GameLogic::bindObjectAndDrawable(Object* obj, Drawable* draw)
 {
 	draw->friend_bindToObject( obj );
 	obj->friend_bindToDrawable( draw );
+
+#if !RETAIL_COMPATIBLE_DRAWUPDATE
+	TheGameClient->informClientNewDrawable(draw);
+#endif
 }
 
 // ------------------------------------------------------------------------------------------------


### PR DESCRIPTION
To use the features, RETAIL_COMPATIBLE_DRAWUPDATE must be set to 0. The feature is Retail Xfer Compatible, but might require checking. RETAIL_COMPATIBLE_DRAWUPDATE can be removed once the check is done.

- GameClient: Informs whenever a New Drawable has been registered or a Drawable has Moved. If the Drawable is within the Screen Region, it will be registered onto a Drawable List. The List is reset everytime the Camera Moves or a Stealthed Object has been Detected, or a Unit has Transitioned a Disguise. Resetting means it will reiterate the Drawable List from the first and registers Drawables that fits within the Screen onto the List. 

Above directly addresses the Issue - https://github.com/TheSuperHackers/GeneralsGameCode/issues/1502

- W3DView: Used for Selecting. Edited Function converts the Selection Region onto a Radius and gets its Center, then uses Partition Manager to find List of Drawables within the Region. Has a configured minimum Iterate Radius of 200.0f units as a Requirement to Select Airborne Units when selecting with a small region.