### PR TITLE
performance(weapon): Optimized ProjectileStreamUpdate Behaviors + Added Variables to Optimize Weapon FX Rendering

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DProjectileStreamDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DProjectileStreamDraw.cpp
@@ -132,6 +132,10 @@ void W3DProjectileStreamDraw::doDrawModule(const Matrix3D* )
 	static NameKeyType key_ProjectileStreamUpdate = NAMEKEY("ProjectileStreamUpdate");
 	ProjectileStreamUpdate* update = (ProjectileStreamUpdate*)me->findUpdateModule(key_ProjectileStreamUpdate);
 
+	// Requires ProjectileStreamUpdate for getting Vector Points
+	if(!update)
+		return;
+
 	const W3DProjectileStreamDrawModuleData *data = getW3DProjectileStreamDrawModuleData();
 
 	Vector3 allPoints[MAX_PROJECTILE_STREAM];
@@ -140,7 +144,6 @@ void W3DProjectileStreamDraw::doDrawModule(const Matrix3D* )
 	update->getAllPoints( allPoints, &pointsUsed );
 
 	Vector3 stagingPoints[MAX_PROJECTILE_STREAM];
-	Vector3 zeroVector(0, 0, 0);
 
 	Int linesMade = 0;
 	Int currentMasterPoint = 0;
@@ -159,7 +162,10 @@ void W3DProjectileStreamDraw::doDrawModule(const Matrix3D* )
 	// I'll keep doing this until I run out of valid points.
 	while( currentMasterPoint < pointsUsed )
 	{
-		while( currentMasterPoint < pointsUsed  &&  allPoints[currentMasterPoint] != zeroVector )
+		// TheSuperHackers @ performance IamInnocent 03/01/26 - Changes ProjectileStreamDraw Update Requirement Vector from being equal zero Vector to any Vector above near zero.
+		while( currentMasterPoint < pointsUsed  &&
+			   (fabs(allPoints[currentMasterPoint].X) > WWMATH_EPSILON || fabs(allPoints[currentMasterPoint].Y) > WWMATH_EPSILON || fabs(allPoints[currentMasterPoint].Z) > WWMATH_EPSILON)
+			 )
 		{
 			// While I am not looking at a bad point (off edge or zero)
 			stagingPoints[currentStagingPoint] = allPoints[currentMasterPoint];// copy to the staging

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BoneFXUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BoneFXUpdate.h
@@ -243,6 +243,10 @@ public:
 
 	virtual UpdateSleepTime update();
 
+#if !PRESERVE_RETAIL_BEHAVIOR
+	void setInactive() { m_inactive = TRUE; }
+#endif
+
 protected:
 
 	virtual void onObjectCreated();
@@ -273,4 +277,8 @@ protected:
 	BodyDamageType m_curBodyState;
 	Bool m_bonesResolved[BODYDAMAGETYPE_COUNT];
 	Bool m_active;
+
+#if !PRESERVE_RETAIL_BEHAVIOR
+	Bool m_inactive;
+#endif
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BoneFXUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BoneFXUpdate.h
@@ -243,6 +243,10 @@ public:
 
 	virtual UpdateSleepTime update() override;
 
+#if !PRESERVE_RETAIL_BEHAVIOR
+	void setInactive() { m_inactive = TRUE; }
+#endif
+
 protected:
 
 	virtual void onObjectCreated() override;
@@ -273,4 +277,8 @@ protected:
 	BodyDamageType m_curBodyState;
 	Bool m_bonesResolved[BODYDAMAGETYPE_COUNT];
 	Bool m_active;
+
+#if !PRESERVE_RETAIL_BEHAVIOR
+	Bool m_inactive;
+#endif
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/PartitionManager.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/PartitionManager.h
@@ -368,8 +368,7 @@ public:
 	void friend_removeFromCellList(CellAndObjectIntersection *coi);
 
 #if !PRESERVE_RETAIL_BEHAVIOR
-	Int getWeaponNameStack(const AsciiString& weaponName) const;
-	void registerWeaponNameStack(const AsciiString& weaponName, UnsignedInt duration);
+	Bool checkWeaponNameStack(const AsciiString& weaponName, Int maxCount, UnsignedInt duration);
 #endif
 };
 
@@ -1542,8 +1541,7 @@ public:
 	void restoreFoggedCells(const ShroudStatusStoreRestore &inPartitionStore, Bool restoreToFog);
 
 #if !PRESERVE_RETAIL_BEHAVIOR
-	Int getWeaponNameStackAtCell(const Coord3D *pos, const AsciiString& weaponName) const;
-	void registerWeaponNameAtCell(const Coord3D *pos, const AsciiString& weaponName, UnsignedInt duration);
+	Bool checkWeaponNameStackAtCell(const Coord3D *pos, const AsciiString& weaponName, Int maxCount, UnsignedInt duration);
 #endif
 };
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/PartitionManager.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/PartitionManager.h
@@ -304,6 +304,13 @@ private:
 	Short													m_cellX;						///< x-coord of this cell within the Partition Mgr coords (NOT in world coords)
 	Short													m_cellY;						///< y-coord of this cell within the Partition Mgr coords (NOT in world coords)
 
+#if !PRESERVE_RETAIL_BEHAVIOR
+	typedef std::pair<AsciiString,Int> WeaponNameDurationPair;
+	typedef std::vector<WeaponNameDurationPair> WeaponNameDurationVec;
+
+	WeaponNameDurationVec m_weaponNameDurationVec;
+#endif
+
 public:
 
 	// Note, we allocate these in arrays, thus we must have a default ctor (and NOT descend from MPO)
@@ -359,6 +366,11 @@ public:
 
 	// intended only for CellAndObjectIntersection.
 	void friend_removeFromCellList(CellAndObjectIntersection *coi);
+
+#if !PRESERVE_RETAIL_BEHAVIOR
+	Int getWeaponNameStack(const AsciiString& weaponName) const;
+	void registerWeaponNameStack(const AsciiString& weaponName, UnsignedInt duration);
+#endif
 };
 
 //=====================================
@@ -1528,6 +1540,11 @@ public:
 	// If saveToFog is false, then we are writing STORE_PERMENANT_REVEAL
 	void storeFoggedCells(ShroudStatusStoreRestore &outPartitionStore, Bool storeToFog) const;
 	void restoreFoggedCells(const ShroudStatusStoreRestore &inPartitionStore, Bool restoreToFog);
+
+#if !PRESERVE_RETAIL_BEHAVIOR
+	Int getWeaponNameStackAtCell(const Coord3D *pos, const AsciiString& weaponName) const;
+	void registerWeaponNameAtCell(const Coord3D *pos, const AsciiString& weaponName, UnsignedInt duration);
+#endif
 };
 
 // -----------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/PartitionManager.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/PartitionManager.h
@@ -304,6 +304,13 @@ private:
 	Short													m_cellX;						///< x-coord of this cell within the Partition Mgr coords (NOT in world coords)
 	Short													m_cellY;						///< y-coord of this cell within the Partition Mgr coords (NOT in world coords)
 
+#if !PRESERVE_RETAIL_BEHAVIOR
+	typedef std::pair<AsciiString,Int> WeaponNameDurationPair;
+	typedef std::vector<WeaponNameDurationPair> WeaponNameDurationVec;
+
+	WeaponNameDurationVec m_weaponNameDurationVec;
+#endif
+
 public:
 
 	// Note, we allocate these in arrays, thus we must have a default ctor (and NOT descend from MPO)
@@ -359,6 +366,11 @@ public:
 
 	// intended only for CellAndObjectIntersection.
 	void friend_removeFromCellList(CellAndObjectIntersection *coi);
+
+#if !PRESERVE_RETAIL_BEHAVIOR
+	Int getWeaponNameStack(const AsciiString& weaponName) const;
+	void registerWeaponNameStack(const AsciiString& weaponName, UnsignedInt duration);
+#endif
 };
 
 //=====================================
@@ -1533,6 +1545,11 @@ public:
 	// If saveToFog is false, then we are writing STORE_PERMENANT_REVEAL
 	void storeFoggedCells(ShroudStatusStoreRestore &outPartitionStore, Bool storeToFog) const;
 	void restoreFoggedCells(const ShroudStatusStoreRestore &inPartitionStore, Bool restoreToFog);
+
+#if !PRESERVE_RETAIL_BEHAVIOR
+	Int getWeaponNameStackAtCell(const Coord3D *pos, const AsciiString& weaponName) const;
+	void registerWeaponNameAtCell(const Coord3D *pos, const AsciiString& weaponName, UnsignedInt duration);
+#endif
 };
 
 // -----------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/PartitionManager.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/PartitionManager.h
@@ -368,8 +368,7 @@ public:
 	void friend_removeFromCellList(CellAndObjectIntersection *coi);
 
 #if !PRESERVE_RETAIL_BEHAVIOR
-	Int getWeaponNameStack(const AsciiString& weaponName) const;
-	void registerWeaponNameStack(const AsciiString& weaponName, UnsignedInt duration);
+	Bool checkWeaponNameStack(const AsciiString& weaponName, Int maxCount, UnsignedInt duration);
 #endif
 };
 
@@ -1547,8 +1546,7 @@ public:
 	void restoreFoggedCells(const ShroudStatusStoreRestore &inPartitionStore, Bool restoreToFog);
 
 #if !PRESERVE_RETAIL_BEHAVIOR
-	Int getWeaponNameStackAtCell(const Coord3D *pos, const AsciiString& weaponName) const;
-	void registerWeaponNameAtCell(const Coord3D *pos, const AsciiString& weaponName, UnsignedInt duration);
+	Bool checkWeaponNameStackAtCell(const Coord3D *pos, const AsciiString& weaponName, Int maxCount, UnsignedInt duration);
 #endif
 };
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Weapon.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Weapon.h
@@ -464,6 +464,13 @@ public:
 	Bool isPlayFXWhenStealthed() const { return m_playFXWhenStealthed; }
 	Bool getDieOnDetonate() const { return m_dieOnDetonate; }
 
+#if !PRESERVE_RETAIL_BEHAVIOR
+	UnsignedInt getFXRenderingInterval() const { return m_fxRenderingInterval; }
+	UnsignedInt getFXMaxStackInterval() const { return m_fxMaxStackInterval; }
+	Int getFXMaxStackPerLoc() const { return m_fxMaxStackPerLoc; }
+	Bool getCheckFireFXForFXMaxStack() const { return m_checkFireFXForFXMaxStack; }
+#endif
+
 	Bool shouldProjectileCollideWith(
 		const Object* projectileLauncher,
 		const Object* projectile,
@@ -562,6 +569,13 @@ private:
 	ObjectStatusTypes m_damageStatusType;		///< If our damage is Status damage, the status we apply
 	UnsignedInt m_suspendFXDelay;						///< The fx can be suspended for any delay, in frames, then they will execute as normal
 	Bool m_dieOnDetonate;
+
+#if !PRESERVE_RETAIL_BEHAVIOR
+	UnsignedInt m_fxRenderingInterval;
+	UnsignedInt m_fxMaxStackInterval;
+	Int m_fxMaxStackPerLoc;
+	Bool m_checkFireFXForFXMaxStack;
+#endif
 
 	mutable HistoricWeaponDamageList m_historicDamage;
 	mutable UnsignedInt m_historicDamageTriggerId;
@@ -766,6 +780,11 @@ public:
 	void setClipPercentFull(Real percent, Bool allowReduction);
 	UnsignedInt getSuspendFXFrame( void ) const { return m_suspendFXFrame; }
 
+#if !PRESERVE_RETAIL_BEHAVIOR
+	UnsignedInt getLastFXShotFrame( void ) const { return m_lastFXFireFrame; }
+	void setLastFXShotFrame(UnsignedInt frame) { m_lastFXFireFrame = frame; }
+#endif
+
 protected:
 
 	Weapon(const WeaponTemplate* tmpl, WeaponSlotType wslot);
@@ -810,6 +829,10 @@ private:
 	std::vector<Int>					m_scatterTargetsUnused;			///< A running memory of which targets I've used, so I can shoot them all at random
 	Bool											m_pitchLimited;
 	Bool											m_leechWeaponRangeActive;		///< This weapon has unlimited range until attack state is aborted!
+
+#if !PRESERVE_RETAIL_BEHAVIOR
+	UnsignedInt								m_lastFXFireFrame;						///< frame a shot was last fired on with FX Rendered
+#endif
 
 	// setter function for status that should not be used outside this class
 	void setStatus( WeaponStatus status) { m_status = status; }

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Weapon.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Weapon.h
@@ -464,6 +464,13 @@ public:
 	Bool isPlayFXWhenStealthed() const { return m_playFXWhenStealthed; }
 	Bool getDieOnDetonate() const { return m_dieOnDetonate; }
 
+#if !PRESERVE_RETAIL_BEHAVIOR
+	UnsignedInt getFXRenderingInterval() const { return m_fxRenderingInterval; }
+	UnsignedInt getFXMaxStackInterval() const { return m_fxMaxStackInterval; }
+	Int getFXMaxStackPerLoc() const { return m_fxMaxStackPerLoc; }
+	Bool getCheckFireFXForFXMaxStack() const { return m_checkFireFXForFXMaxStack; }
+#endif
+
 	Bool shouldProjectileCollideWith(
 		const Object* projectileLauncher,
 		const Object* projectile,
@@ -562,6 +569,13 @@ private:
 	ObjectStatusTypes m_damageStatusType;		///< If our damage is Status damage, the status we apply
 	UnsignedInt m_suspendFXDelay;						///< The fx can be suspended for any delay, in frames, then they will execute as normal
 	Bool m_dieOnDetonate;
+
+#if !PRESERVE_RETAIL_BEHAVIOR
+	UnsignedInt m_fxRenderingInterval;
+	UnsignedInt m_fxMaxStackInterval;
+	Int m_fxMaxStackPerLoc;
+	Bool m_checkFireFXForFXMaxStack;
+#endif
 
 	mutable HistoricWeaponDamageList m_historicDamage;
 	mutable UnsignedInt m_historicDamageTriggerId;
@@ -766,6 +780,11 @@ public:
 	void setClipPercentFull(Real percent, Bool allowReduction);
 	UnsignedInt getSuspendFXFrame() const { return m_suspendFXFrame; }
 
+#if !PRESERVE_RETAIL_BEHAVIOR
+	UnsignedInt getLastFXShotFrame( void ) const { return m_lastFXFireFrame; }
+	void setLastFXShotFrame(UnsignedInt frame) { m_lastFXFireFrame = frame; }
+#endif
+
 protected:
 
 	Weapon(const WeaponTemplate* tmpl, WeaponSlotType wslot);
@@ -810,6 +829,10 @@ private:
 	std::vector<Int>					m_scatterTargetsUnused;			///< A running memory of which targets I've used, so I can shoot them all at random
 	Bool											m_pitchLimited;
 	Bool											m_leechWeaponRangeActive;		///< This weapon has unlimited range until attack state is aborted!
+
+#if !PRESERVE_RETAIL_BEHAVIOR
+	UnsignedInt								m_lastFXFireFrame;						///< frame a shot was last fired on with FX Rendered
+#endif
 
 	// setter function for status that should not be used outside this class
 	void setStatus( WeaponStatus status) { m_status = status; }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
@@ -1250,6 +1250,10 @@ PartitionCell::PartitionCell()
 		// default threat value is 0
 		m_threatValue[i] = 0;
 	}
+
+#if !PRESERVE_RETAIL_BEHAVIOR
+	m_weaponNameDurationVec.clear();
+#endif
 }
 
 //-----------------------------------------------------------------------------
@@ -1496,6 +1500,46 @@ void PartitionCell::validateCoiList()
 		DEBUG_ASSERTCRASH((coi == getFirstCoiInCell()) == (prevCoi == NULL) , ("coi link mismatch"));
 		DEBUG_ASSERTCRASH(nextCoi == NULL || nextCoi->getPrevCoi() == coi, ("coi link mismatch"));
 	}
+}
+#endif
+
+#if !PRESERVE_RETAIL_BEHAVIOR
+//-----------------------------------------------------------------------------
+Int PartitionCell::getWeaponNameStack(const AsciiString& weaponName) const
+{
+	Int count = 0;
+	UnsignedInt now = TheGameLogic->getFrame();
+	for(WeaponNameDurationVec::const_iterator it = m_weaponNameDurationVec.begin(); it != m_weaponNameDurationVec.end(); ++it)
+	{
+		if(it->first == weaponName && it->second > now)
+			count++;
+	}
+	return count;
+}
+
+//-----------------------------------------------------------------------------
+void PartitionCell::registerWeaponNameStack(const AsciiString& weaponName, UnsignedInt duration)
+{
+	UnsignedInt now = TheGameLogic->getFrame();
+
+	// Clean the vector everytime we register a new stack
+	for (WeaponNameDurationVec::iterator it = m_weaponNameDurationVec.begin(); it != m_weaponNameDurationVec.end(); /* empty */ )
+	{
+		if (it->second <= now)
+		{
+			it = m_weaponNameDurationVec.erase(it);
+		}
+		else
+		{
+			++it;
+		}
+	}
+
+	WeaponNameDurationPair stack;
+	stack.first = weaponName;
+	stack.second = now + duration;
+
+	m_weaponNameDurationVec.push_back(stack);
 }
 #endif
 
@@ -4592,6 +4636,32 @@ Bool PartitionManager::isClearLineOfSightTerrain(const Object* obj, const Coord3
 	return TheTerrainLogic->isClearLineOfSight(pos, posOther);
 #endif
 }
+
+#if !PRESERVE_RETAIL_BEHAVIOR
+//-----------------------------------------------------------------------------
+Int PartitionManager::getWeaponNameStackAtCell(const Coord3D *pos, const AsciiString& weaponName) const
+{
+	Int cellX, cellY;
+	worldToCell(pos->x, pos->y, &cellX, &cellY);
+	const PartitionCell* cell = getCellAt(cellX, cellY);	// might be null if off the edge
+	DEBUG_ASSERTCRASH(cell != NULL, ("off the map"));
+	if (cell)
+		return cell->getWeaponNameStack(weaponName);
+	else
+		return 0;
+}
+
+//-----------------------------------------------------------------------------
+void PartitionManager::registerWeaponNameAtCell(const Coord3D *pos, const AsciiString& weaponName, UnsignedInt duration)
+{
+	Int cellX, cellY;
+	worldToCell(pos->x, pos->y, &cellX, &cellY);
+	PartitionCell* cell = getCellAt(cellX, cellY);	// might be null if off the edge
+	DEBUG_ASSERTCRASH(cell != NULL, ("off the map"));
+	if (cell)
+		cell->registerWeaponNameStack(weaponName, duration);
+}
+#endif
 
 // ------------------------------------------------------------------------------------------------
 /** CRC */

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
@@ -1252,6 +1252,10 @@ PartitionCell::PartitionCell()
 		// default threat value is 0
 		m_threatValue[i] = 0;
 	}
+
+#if !PRESERVE_RETAIL_BEHAVIOR
+	m_weaponNameDurationVec.clear();
+#endif
 }
 
 //-----------------------------------------------------------------------------
@@ -1498,6 +1502,46 @@ void PartitionCell::validateCoiList()
 		DEBUG_ASSERTCRASH((coi == getFirstCoiInCell()) == (prevCoi == nullptr) , ("coi link mismatch"));
 		DEBUG_ASSERTCRASH(nextCoi == nullptr || nextCoi->getPrevCoi() == coi, ("coi link mismatch"));
 	}
+}
+#endif
+
+#if !PRESERVE_RETAIL_BEHAVIOR
+//-----------------------------------------------------------------------------
+Int PartitionCell::getWeaponNameStack(const AsciiString& weaponName) const
+{
+	Int count = 0;
+	UnsignedInt now = TheGameLogic->getFrame();
+	for(WeaponNameDurationVec::const_iterator it = m_weaponNameDurationVec.begin(); it != m_weaponNameDurationVec.end(); ++it)
+	{
+		if(it->first == weaponName && it->second > now)
+			count++;
+	}
+	return count;
+}
+
+//-----------------------------------------------------------------------------
+void PartitionCell::registerWeaponNameStack(const AsciiString& weaponName, UnsignedInt duration)
+{
+	UnsignedInt now = TheGameLogic->getFrame();
+
+	// Clean the vector everytime we register a new stack
+	for (WeaponNameDurationVec::iterator it = m_weaponNameDurationVec.begin(); it != m_weaponNameDurationVec.end(); /* empty */ )
+	{
+		if (it->second <= now)
+		{
+			it = m_weaponNameDurationVec.erase(it);
+		}
+		else
+		{
+			++it;
+		}
+	}
+
+	WeaponNameDurationPair stack;
+	stack.first = weaponName;
+	stack.second = now + duration;
+
+	m_weaponNameDurationVec.push_back(stack);
 }
 #endif
 
@@ -4643,6 +4687,32 @@ Bool PartitionManager::isClearLineOfSightTerrain(const Object* obj, const Coord3
 	return TheTerrainLogic->isClearLineOfSight(pos, posOther);
 #endif
 }
+
+#if !PRESERVE_RETAIL_BEHAVIOR
+//-----------------------------------------------------------------------------
+Int PartitionManager::getWeaponNameStackAtCell(const Coord3D *pos, const AsciiString& weaponName) const
+{
+	Int cellX, cellY;
+	worldToCell(pos->x, pos->y, &cellX, &cellY);
+	const PartitionCell* cell = getCellAt(cellX, cellY);	// might be null if off the edge
+	DEBUG_ASSERTCRASH(cell != NULL, ("off the map"));
+	if (cell)
+		return cell->getWeaponNameStack(weaponName);
+	else
+		return 0;
+}
+
+//-----------------------------------------------------------------------------
+void PartitionManager::registerWeaponNameAtCell(const Coord3D *pos, const AsciiString& weaponName, UnsignedInt duration)
+{
+	Int cellX, cellY;
+	worldToCell(pos->x, pos->y, &cellX, &cellY);
+	PartitionCell* cell = getCellAt(cellX, cellY);	// might be null if off the edge
+	DEBUG_ASSERTCRASH(cell != NULL, ("off the map"));
+	if (cell)
+		cell->registerWeaponNameStack(weaponName, duration);
+}
+#endif
 
 // ------------------------------------------------------------------------------------------------
 /** CRC */

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
@@ -4697,7 +4697,7 @@ Bool PartitionManager::checkWeaponNameStackAtCell(const Coord3D *pos, const Asci
 	Int cellX, cellY;
 	worldToCell(pos->x, pos->y, &cellX, &cellY);
 	PartitionCell* cell = getCellAt(cellX, cellY);	// might be null if off the edge
-	DEBUG_ASSERTCRASH(cell != NULL, ("off the map"));
+	DEBUG_ASSERTCRASH(cell != nullptr, ("off the map"));
 	if (cell)
 		return cell->checkWeaponNameStack(weaponName, maxCount, duration);
 	else

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/PartitionManager.cpp
@@ -1507,41 +1507,43 @@ void PartitionCell::validateCoiList()
 
 #if !PRESERVE_RETAIL_BEHAVIOR
 //-----------------------------------------------------------------------------
-Int PartitionCell::getWeaponNameStack(const AsciiString& weaponName) const
+Bool PartitionCell::checkWeaponNameStack(const AsciiString& weaponName, Int maxCount, UnsignedInt duration)
 {
 	Int count = 0;
 	UnsignedInt now = TheGameLogic->getFrame();
-	for(WeaponNameDurationVec::const_iterator it = m_weaponNameDurationVec.begin(); it != m_weaponNameDurationVec.end(); ++it)
+	for(WeaponNameDurationVec::iterator it = m_weaponNameDurationVec.begin(); it != m_weaponNameDurationVec.end(); /* empty */)
 	{
-		if(it->first == weaponName && it->second > now)
-			count++;
-	}
-	return count;
-}
-
-//-----------------------------------------------------------------------------
-void PartitionCell::registerWeaponNameStack(const AsciiString& weaponName, UnsignedInt duration)
-{
-	UnsignedInt now = TheGameLogic->getFrame();
-
-	// Clean the vector everytime we register a new stack
-	for (WeaponNameDurationVec::iterator it = m_weaponNameDurationVec.begin(); it != m_weaponNameDurationVec.end(); /* empty */ )
-	{
+		// Delete the element if it has exceeded the current frame
 		if (it->second <= now)
 		{
 			it = m_weaponNameDurationVec.erase(it);
+			continue;
 		}
-		else
-		{
-			++it;
-		}
+
+		// Add it to count if it matches the name
+		if(it->first == weaponName)
+			count++;
+
+		++it;
 	}
 
-	WeaponNameDurationPair stack;
-	stack.first = weaponName;
-	stack.second = now + duration;
+	if(count < maxCount)
+	{
+		// Add it to vector if it has not reached maxCount
+		WeaponNameDurationPair stack;
+		stack.first = weaponName;
+		stack.second = now + duration;
 
-	m_weaponNameDurationVec.push_back(stack);
+		m_weaponNameDurationVec.push_back(stack);
+
+		// return FALSE if not yet reached Max Count
+		return FALSE;
+	}
+	else
+	{
+		// return TRUE if reached Max Count
+		return TRUE;
+	}
 }
 #endif
 
@@ -4690,27 +4692,16 @@ Bool PartitionManager::isClearLineOfSightTerrain(const Object* obj, const Coord3
 
 #if !PRESERVE_RETAIL_BEHAVIOR
 //-----------------------------------------------------------------------------
-Int PartitionManager::getWeaponNameStackAtCell(const Coord3D *pos, const AsciiString& weaponName) const
-{
-	Int cellX, cellY;
-	worldToCell(pos->x, pos->y, &cellX, &cellY);
-	const PartitionCell* cell = getCellAt(cellX, cellY);	// might be null if off the edge
-	DEBUG_ASSERTCRASH(cell != NULL, ("off the map"));
-	if (cell)
-		return cell->getWeaponNameStack(weaponName);
-	else
-		return 0;
-}
-
-//-----------------------------------------------------------------------------
-void PartitionManager::registerWeaponNameAtCell(const Coord3D *pos, const AsciiString& weaponName, UnsignedInt duration)
+Bool PartitionManager::checkWeaponNameStackAtCell(const Coord3D *pos, const AsciiString& weaponName, Int maxCount, UnsignedInt duration)
 {
 	Int cellX, cellY;
 	worldToCell(pos->x, pos->y, &cellX, &cellY);
 	PartitionCell* cell = getCellAt(cellX, cellY);	// might be null if off the edge
 	DEBUG_ASSERTCRASH(cell != NULL, ("off the map"));
 	if (cell)
-		cell->registerWeaponNameStack(weaponName, duration);
+		return cell->checkWeaponNameStack(weaponName, maxCount, duration);
+	else
+		return FALSE;
 }
 #endif
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/BoneFXUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/BoneFXUpdate.cpp
@@ -90,6 +90,9 @@ BoneFXUpdate::BoneFXUpdate( Thing *thing, const ModuleData* moduleData ) : Updat
 	}
 	m_particleSystemIDs.clear();
 	m_active = FALSE;
+#if !PRESERVE_RETAIL_BEHAVIOR
+	m_inactive = FALSE;
+#endif
 
 	m_curBodyState = BODY_PRISTINE;
 }
@@ -291,6 +294,11 @@ UpdateSleepTime BoneFXUpdate::update( void )
 /// @todo srj use SLEEPY_UPDATE here
 	const BoneFXUpdateModuleData *d = getBoneFXUpdateModuleData();
 	Int now = TheGameLogic->getFrame();
+
+#if !PRESERVE_RETAIL_BEHAVIOR
+	if(m_inactive == TRUE)
+		return UPDATE_SLEEP_NONE;
+#endif
 
 	if (m_active == FALSE) {
 		initTimes();
@@ -569,7 +577,11 @@ void BoneFXUpdate::xfer( Xfer *xfer )
 {
 
 	// version
+#if !RETAIL_COMPATIBLE_XFER_SAVE && !PRESERVE_RETAIL_BEHAVIOR
+	XferVersion currentVersion = 2;
+#else
 	XferVersion currentVersion = 1;
+#endif
 	XferVersion version = currentVersion;
 	xfer->xferVersion( &version, currentVersion );
 
@@ -645,6 +657,11 @@ void BoneFXUpdate::xfer( Xfer *xfer )
 
 	// active
 	xfer->xferBool( &m_active );
+
+#if !PRESERVE_RETAIL_BEHAVIOR
+	if( version >= 2)
+		xfer->xferBool( &m_inactive );
+#endif
 
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/BoneFXUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/BoneFXUpdate.cpp
@@ -87,6 +87,9 @@ BoneFXUpdate::BoneFXUpdate( Thing *thing, const ModuleData* moduleData ) : Updat
 	}
 	m_particleSystemIDs.clear();
 	m_active = FALSE;
+#if !PRESERVE_RETAIL_BEHAVIOR
+	m_inactive = FALSE;
+#endif
 
 	m_curBodyState = BODY_PRISTINE;
 }
@@ -288,6 +291,11 @@ UpdateSleepTime BoneFXUpdate::update()
 /// @todo srj use SLEEPY_UPDATE here
 	const BoneFXUpdateModuleData *d = getBoneFXUpdateModuleData();
 	Int now = TheGameLogic->getFrame();
+
+#if !PRESERVE_RETAIL_BEHAVIOR
+	if(m_inactive == TRUE)
+		return UPDATE_SLEEP_NONE;
+#endif
 
 	if (m_active == FALSE) {
 		initTimes();
@@ -566,7 +574,11 @@ void BoneFXUpdate::xfer( Xfer *xfer )
 {
 
 	// version
+#if !RETAIL_COMPATIBLE_XFER_SAVE && !PRESERVE_RETAIL_BEHAVIOR
+	XferVersion currentVersion = 2;
+#else
 	XferVersion currentVersion = 1;
+#endif
 	XferVersion version = currentVersion;
 	xfer->xferVersion( &version, currentVersion );
 
@@ -642,6 +654,11 @@ void BoneFXUpdate::xfer( Xfer *xfer )
 
 	// active
 	xfer->xferBool( &m_active );
+
+#if !PRESERVE_RETAIL_BEHAVIOR
+	if( version >= 2)
+		xfer->xferBool( &m_inactive );
+#endif
 
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ProjectileStreamUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ProjectileStreamUpdate.cpp
@@ -91,7 +91,10 @@ void ProjectileStreamUpdate::addProjectile( ObjectID sourceID, ObjectID newID, O
 		{
 			// Changed targets, insert a hole to break the stream
 			m_projectileIDs[ m_nextFreeIndex ] = INVALID_ID;
-			m_nextFreeIndex = (m_nextFreeIndex + 1) % MAX_PROJECTILE_STREAM;
+
+			// TheSuperHackers @ performance IamInnocent 03/01/26 - Refractor the usage of Modulo to Comparison
+			if(++m_nextFreeIndex >= MAX_PROJECTILE_STREAM)
+				m_nextFreeIndex -= MAX_PROJECTILE_STREAM;
 
 			// And mark this as our new target
 			m_targetObject = victimID;
@@ -106,7 +109,8 @@ void ProjectileStreamUpdate::addProjectile( ObjectID sourceID, ObjectID newID, O
 		{
 			// New position, so insert hole
 			m_projectileIDs[ m_nextFreeIndex ] = INVALID_ID;
-			m_nextFreeIndex = (m_nextFreeIndex + 1) % MAX_PROJECTILE_STREAM;
+			if(++m_nextFreeIndex >= MAX_PROJECTILE_STREAM)
+				m_nextFreeIndex -= MAX_PROJECTILE_STREAM;
 
 			// And mark this as our new target
 			m_targetPosition = (*victimPos);
@@ -122,7 +126,8 @@ void ProjectileStreamUpdate::addProjectile( ObjectID sourceID, ObjectID newID, O
 
 	// Keep track of the id in a circular array
 	m_projectileIDs[ m_nextFreeIndex ] = newID;
-	m_nextFreeIndex = (m_nextFreeIndex + 1) % MAX_PROJECTILE_STREAM;
+	if(++m_nextFreeIndex >= MAX_PROJECTILE_STREAM)
+		m_nextFreeIndex -= MAX_PROJECTILE_STREAM;
 	DEBUG_ASSERTCRASH( m_nextFreeIndex != m_firstValidIndex, ("Need to increase the allowed number of simultaneous particles in ProjectileStreamUpdate.") );
 }
 
@@ -131,7 +136,8 @@ void ProjectileStreamUpdate::cullFrontOfList()
 	while( (m_firstValidIndex != m_nextFreeIndex)  &&  (TheGameLogic->findObjectByID( m_projectileIDs[m_firstValidIndex] ) == NULL) )
 	{
 		// Chew off the front if they are gone.  Don't chew on the middle, as bad ones there are just a break in the chain
-		m_firstValidIndex = (m_firstValidIndex + 1) % MAX_PROJECTILE_STREAM;
+		if(++m_nextFreeIndex >= MAX_PROJECTILE_STREAM)
+			m_nextFreeIndex -= MAX_PROJECTILE_STREAM;
 	}
 }
 
@@ -194,7 +200,8 @@ void ProjectileStreamUpdate::getAllPoints( Vector3 *points, Int *count )
 			points[pointCount].Z = 0;
 		}
 
-		pointIndex = (pointIndex + 1) % MAX_PROJECTILE_STREAM;
+		if(++pointIndex >= MAX_PROJECTILE_STREAM)
+			pointIndex -= MAX_PROJECTILE_STREAM;
 		pointCount++;
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ProjectileStreamUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ProjectileStreamUpdate.cpp
@@ -86,7 +86,10 @@ void ProjectileStreamUpdate::addProjectile( ObjectID sourceID, ObjectID newID, O
 		{
 			// Changed targets, insert a hole to break the stream
 			m_projectileIDs[ m_nextFreeIndex ] = INVALID_ID;
-			m_nextFreeIndex = (m_nextFreeIndex + 1) % MAX_PROJECTILE_STREAM;
+
+			// TheSuperHackers @ performance IamInnocent 03/01/26 - Refractor the usage of Modulo to Comparison
+			if(++m_nextFreeIndex >= MAX_PROJECTILE_STREAM)
+				m_nextFreeIndex -= MAX_PROJECTILE_STREAM;
 
 			// And mark this as our new target
 			m_targetObject = victimID;
@@ -101,7 +104,8 @@ void ProjectileStreamUpdate::addProjectile( ObjectID sourceID, ObjectID newID, O
 		{
 			// New position, so insert hole
 			m_projectileIDs[ m_nextFreeIndex ] = INVALID_ID;
-			m_nextFreeIndex = (m_nextFreeIndex + 1) % MAX_PROJECTILE_STREAM;
+			if(++m_nextFreeIndex >= MAX_PROJECTILE_STREAM)
+				m_nextFreeIndex -= MAX_PROJECTILE_STREAM;
 
 			// And mark this as our new target
 			m_targetPosition = (*victimPos);
@@ -117,7 +121,8 @@ void ProjectileStreamUpdate::addProjectile( ObjectID sourceID, ObjectID newID, O
 
 	// Keep track of the id in a circular array
 	m_projectileIDs[ m_nextFreeIndex ] = newID;
-	m_nextFreeIndex = (m_nextFreeIndex + 1) % MAX_PROJECTILE_STREAM;
+	if(++m_nextFreeIndex >= MAX_PROJECTILE_STREAM)
+		m_nextFreeIndex -= MAX_PROJECTILE_STREAM;
 	DEBUG_ASSERTCRASH( m_nextFreeIndex != m_firstValidIndex, ("Need to increase the allowed number of simultaneous particles in ProjectileStreamUpdate.") );
 }
 
@@ -126,7 +131,8 @@ void ProjectileStreamUpdate::cullFrontOfList()
 	while( (m_firstValidIndex != m_nextFreeIndex)  &&  (TheGameLogic->findObjectByID( m_projectileIDs[m_firstValidIndex] ) == nullptr) )
 	{
 		// Chew off the front if they are gone.  Don't chew on the middle, as bad ones there are just a break in the chain
-		m_firstValidIndex = (m_firstValidIndex + 1) % MAX_PROJECTILE_STREAM;
+		if(++m_nextFreeIndex >= MAX_PROJECTILE_STREAM)
+			m_nextFreeIndex -= MAX_PROJECTILE_STREAM;
 	}
 }
 
@@ -189,7 +195,8 @@ void ProjectileStreamUpdate::getAllPoints( Vector3 *points, Int *count )
 			points[pointCount].Z = 0;
 		}
 
-		pointIndex = (pointIndex + 1) % MAX_PROJECTILE_STREAM;
+		if(++pointIndex >= MAX_PROJECTILE_STREAM)
+			pointIndex -= MAX_PROJECTILE_STREAM;
 		pointCount++;
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ProjectileStreamUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ProjectileStreamUpdate.cpp
@@ -131,8 +131,8 @@ void ProjectileStreamUpdate::cullFrontOfList()
 	while( (m_firstValidIndex != m_nextFreeIndex)  &&  (TheGameLogic->findObjectByID( m_projectileIDs[m_firstValidIndex] ) == nullptr) )
 	{
 		// Chew off the front if they are gone.  Don't chew on the middle, as bad ones there are just a break in the chain
-		if(++m_nextFreeIndex >= MAX_PROJECTILE_STREAM)
-			m_nextFreeIndex -= MAX_PROJECTILE_STREAM;
+		if(++m_firstValidIndex >= MAX_PROJECTILE_STREAM)
+			m_firstValidIndex -= MAX_PROJECTILE_STREAM;
 	}
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -946,11 +946,11 @@ UnsignedInt WeaponTemplate::fireWeaponTemplate
 		VeterancyLevel v = sourceObj->getVeterancyLevel();
 		const FXList* fx = isProjectileDetonation ? getProjectileDetonateFX(v) : getFireFX(v);
 
-		if ( TheGameLogic->getFrame() < firingWeapon->getSuspendFXFrame()
-#if !PRESERVE_RETAIL_BEHAVIOR
-			 || !renderWeaponFX
+#if PRESERVE_RETAIL_BEHAVIOR
+		if ( TheGameLogic->getFrame() < firingWeapon->getSuspendFXFrame() )
+#else
+		if ( TheGameLogic->getFrame() < firingWeapon->getSuspendFXFrame() || !renderWeaponFX )
 #endif
-		   )
 			fx = NULL;
 
 		Bool handled;
@@ -958,10 +958,8 @@ UnsignedInt WeaponTemplate::fireWeaponTemplate
 #if !PRESERVE_RETAIL_BEHAVIOR
 		if( getFXMaxStackPerLoc() > 0 && fx && (isProjectileDetonation || getCheckFireFXForFXMaxStack()) )
 		{
-			// Check if there is any FX Stack to apply for the Weapon at Loc. Purely in data form, so shouldn't have much performance issue
-			if(ThePartitionManager->getWeaponNameStackAtCell(&targetPos, getName()) <= getFXMaxStackPerLoc())
-				ThePartitionManager->registerWeaponNameAtCell(&targetPos, getName(), getFXMaxStackInterval() ? getFXMaxStackInterval() : getDelayBetweenShots(bonus));
-			else
+			// Check if there is any FX Stack to apply for the Weapon at Loc. Returns TRUE if stack reaches MaxStackCount
+			if(ThePartitionManager->checkWeaponNameStackAtCell(&targetPos, getName(), getFXMaxStackPerLoc(), getFXMaxStackInterval() ? getFXMaxStackInterval() : getDelayBetweenShots(bonus)))
 				fx = NULL;
 		}
 #endif

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -76,6 +76,10 @@
 #include "GameLogic/Module/PhysicsUpdate.h"
 #include "GameLogic/TerrainLogic.h"
 
+#if !PRESERVE_RETAIL_BEHAVIOR
+#include "GameLogic/Module/BoneFXUpdate.h"
+#endif
+
 #define RATIONALIZE_ATTACK_RANGE
 #define ATTACK_RANGE_IS_2D
 
@@ -238,6 +242,15 @@ const FieldParse WeaponTemplate::TheWeaponTemplateFieldParseTable[] =
 	{ "ContinueAttackRange",			INI::parseReal,													NULL,							offsetof(WeaponTemplate, m_continueAttackRange) },
 	{ "SuspendFXDelay",						INI::parseDurationUnsignedInt,					NULL,							offsetof(WeaponTemplate, m_suspendFXDelay) },
 	{ "MissileCallsOnDie",			INI::parseBool,													NULL,							offsetof(WeaponTemplate, m_dieOnDetonate) },
+
+#if !PRESERVE_RETAIL_BEHAVIOR
+	// TheSuperHackers @performance IamInnocent 03/01/2026 - Tweaks to Limit FX Rendering for Performance Improvisation
+	{ "FXRenderingInterval",		INI::parseDurationUnsignedInt,			NULL,			offsetof( WeaponTemplate, m_fxRenderingInterval ) },
+	{ "FXMaxStackInterval",			INI::parseDurationUnsignedInt,			NULL,			offsetof( WeaponTemplate, m_fxMaxStackInterval ) },
+	{ "FXMaxStackPerLoc",			INI::parseInt,							NULL,			offsetof( WeaponTemplate, m_fxMaxStackPerLoc ) },
+	{ "CheckFireFXForFXMaxStack",	INI::parseBool,							NULL,			offsetof( WeaponTemplate, m_checkFireFXForFXMaxStack ) },
+#endif
+
 	{ NULL,												NULL,																		NULL,							0 }
 
 };
@@ -322,6 +335,13 @@ WeaponTemplate::WeaponTemplate() : m_nextTemplate(NULL)
 	m_damageStatusType							= OBJECT_STATUS_NONE;
 	m_suspendFXDelay								= 0;
 	m_dieOnDetonate						= FALSE;
+
+#if !PRESERVE_RETAIL_BEHAVIOR
+	m_fxRenderingInterval = 0;
+	m_fxMaxStackInterval = 0;
+	m_fxMaxStackPerLoc = 0;
+	m_checkFireFXForFXMaxStack = FALSE;
+#endif
 
 	m_historicDamageTriggerId = 0;
 }
@@ -893,6 +913,22 @@ UnsignedInt WeaponTemplate::fireWeaponTemplate
 		}
 	}
 
+#if !PRESERVE_RETAIL_BEHAVIOR
+	Bool renderWeaponFX = TRUE;
+	if( getFXRenderingInterval() > 0 && !isProjectileDetonation )
+	{
+		if(TheGameLogic->getFrame() >= firingWeapon->getLastFXShotFrame() + getFXRenderingInterval())
+		{
+			firingWeapon->setLastFXShotFrame(TheGameLogic->getFrame());
+			renderWeaponFX = TRUE;
+		}
+		else
+		{
+			renderWeaponFX = FALSE;
+		}
+	}
+#endif
+
 	// call this even if FXList is null, because this also handles stuff like Gun Barrel Recoil
 	if (sourceObj && sourceObj->getDrawable())
 	{
@@ -910,10 +946,25 @@ UnsignedInt WeaponTemplate::fireWeaponTemplate
 		VeterancyLevel v = sourceObj->getVeterancyLevel();
 		const FXList* fx = isProjectileDetonation ? getProjectileDetonateFX(v) : getFireFX(v);
 
-		if ( TheGameLogic->getFrame() < firingWeapon->getSuspendFXFrame() )
+		if ( TheGameLogic->getFrame() < firingWeapon->getSuspendFXFrame()
+#if !PRESERVE_RETAIL_BEHAVIOR
+			 || !renderWeaponFX
+#endif
+		   )
 			fx = NULL;
 
 		Bool handled;
+
+#if !PRESERVE_RETAIL_BEHAVIOR
+		if( getFXMaxStackPerLoc() > 0 && fx && (isProjectileDetonation || getCheckFireFXForFXMaxStack()) )
+		{
+			// Check if there is any FX Stack to apply for the Weapon at Loc. Purely in data form, so shouldn't have much performance issue
+			if(ThePartitionManager->getWeaponNameStackAtCell(&targetPos, getName()) <= getFXMaxStackPerLoc())
+				ThePartitionManager->registerWeaponNameAtCell(&targetPos, getName(), getFXMaxStackInterval() ? getFXMaxStackInterval() : getDelayBetweenShots(bonus));
+			else
+				fx = NULL;
+		}
+#endif
 
 		// TheSuperHackers @todo: Remove hardcoded KINDOF_MINE check and apply PlayFXWhenStealthed = Yes to the mine weapons instead.
 
@@ -1139,6 +1190,18 @@ UnsignedInt WeaponTemplate::fireWeaponTemplate
 			{
 				pui->projectileLaunchAtObjectOrPosition(victimObj, &projectileDestination, sourceObj, wslot, specificBarrelToUse, this, m_projectileExhausts[v]);
 			}
+
+#if !PRESERVE_RETAIL_BEHAVIOR
+			if( !renderWeaponFX )
+			{
+				static NameKeyType key_BoneFXUpdate = NAMEKEY("BoneFXUpdate");
+				BoneFXUpdate *bfxu = (BoneFXUpdate *)projectile->findUpdateModule(key_BoneFXUpdate);
+				if (bfxu != NULL)
+				{
+					bfxu->setInactive();
+				}
+			}
+#endif
 		}
 		else
 		{
@@ -1837,6 +1900,10 @@ Weapon::Weapon(const WeaponTemplate* tmpl, WeaponSlotType wslot)
 	m_numShotsForCurBarrel = 	m_template->getShotsPerBarrel();
 	m_lastFireFrame = 0;
 	m_suspendFXFrame = TheGameLogic->getFrame() + m_template->getSuspendFXDelay();
+
+#if !PRESERVE_RETAIL_BEHAVIOR
+	m_lastFXFireFrame = 0;
+#endif
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1858,6 +1925,10 @@ Weapon::Weapon(const Weapon& that)
 	this->m_numShotsForCurBarrel = m_template->getShotsPerBarrel();
 	this->m_lastFireFrame = 0;
 	this->m_suspendFXFrame = that.getSuspendFXFrame();
+
+#if !PRESERVE_RETAIL_BEHAVIOR
+	this->m_lastFXFireFrame = 0;
+#endif
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1881,6 +1952,10 @@ Weapon& Weapon::operator=(const Weapon& that)
 		this->m_suspendFXFrame = that.getSuspendFXFrame();
 		this->m_numShotsForCurBarrel = m_template->getShotsPerBarrel();
 		this->m_projectileStreamID = INVALID_ID;
+
+#if !PRESERVE_RETAIL_BEHAVIOR
+		this->m_lastFXFireFrame = 0;
+#endif
 	}
 	return *this;
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -956,11 +956,11 @@ UnsignedInt WeaponTemplate::fireWeaponTemplate
 		VeterancyLevel v = sourceObj->getVeterancyLevel();
 		const FXList* fx = isProjectileDetonation ? getProjectileDetonateFX(v) : getFireFX(v);
 
-		if ( TheGameLogic->getFrame() < firingWeapon->getSuspendFXFrame()
-#if !PRESERVE_RETAIL_BEHAVIOR
-			 || !renderWeaponFX
+#if PRESERVE_RETAIL_BEHAVIOR
+		if ( TheGameLogic->getFrame() < firingWeapon->getSuspendFXFrame() )
+#else
+		if ( TheGameLogic->getFrame() < firingWeapon->getSuspendFXFrame() || !renderWeaponFX )
 #endif
-		   )
 			fx = nullptr;
 
 		Bool handled;
@@ -968,10 +968,8 @@ UnsignedInt WeaponTemplate::fireWeaponTemplate
 #if !PRESERVE_RETAIL_BEHAVIOR
 		if( getFXMaxStackPerLoc() > 0 && fx && (isProjectileDetonation || getCheckFireFXForFXMaxStack()) )
 		{
-			// Check if there is any FX Stack to apply for the Weapon at Loc. Purely in data form, so shouldn't have much performance issue
-			if(ThePartitionManager->getWeaponNameStackAtCell(&targetPos, getName()) <= getFXMaxStackPerLoc())
-				ThePartitionManager->registerWeaponNameAtCell(&targetPos, getName(), getFXMaxStackInterval() ? getFXMaxStackInterval() : getDelayBetweenShots(bonus));
-			else
+			// Check if there is any FX Stack to apply for the Weapon at Loc. Returns TRUE if stack reaches MaxStackCount
+			if(ThePartitionManager->checkWeaponNameStackAtCell(&targetPos, getName(), getFXMaxStackPerLoc(), getFXMaxStackInterval() ? getFXMaxStackInterval() : getDelayBetweenShots(bonus)))
 				fx = NULL;
 		}
 #endif

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -970,7 +970,7 @@ UnsignedInt WeaponTemplate::fireWeaponTemplate
 		{
 			// Check if there is any FX Stack to apply for the Weapon at Loc. Returns TRUE if stack reaches MaxStackCount
 			if(ThePartitionManager->checkWeaponNameStackAtCell(&targetPos, getName(), getFXMaxStackPerLoc(), getFXMaxStackInterval() ? getFXMaxStackInterval() : getDelayBetweenShots(bonus)))
-				fx = NULL;
+				fx = nullptr;
 		}
 #endif
 
@@ -1204,7 +1204,7 @@ UnsignedInt WeaponTemplate::fireWeaponTemplate
 			{
 				static NameKeyType key_BoneFXUpdate = NAMEKEY("BoneFXUpdate");
 				BoneFXUpdate *bfxu = (BoneFXUpdate *)projectile->findUpdateModule(key_BoneFXUpdate);
-				if (bfxu != NULL)
+				if (bfxu != nullptr)
 				{
 					bfxu->setInactive();
 				}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -77,6 +77,10 @@
 #include "GameLogic/Module/SpawnBehavior.h"
 #include "GameLogic/TerrainLogic.h"
 
+#if !PRESERVE_RETAIL_BEHAVIOR
+#include "GameLogic/Module/BoneFXUpdate.h"
+#endif
+
 #define RATIONALIZE_ATTACK_RANGE
 #define ATTACK_RANGE_IS_2D
 
@@ -239,6 +243,15 @@ const FieldParse WeaponTemplate::TheWeaponTemplateFieldParseTable[] =
 	{ "ContinueAttackRange",			INI::parseReal,													nullptr,							offsetof(WeaponTemplate, m_continueAttackRange) },
 	{ "SuspendFXDelay",						INI::parseDurationUnsignedInt,					nullptr,							offsetof(WeaponTemplate, m_suspendFXDelay) },
 	{ "MissileCallsOnDie",			INI::parseBool,													nullptr,							offsetof(WeaponTemplate, m_dieOnDetonate) },
+
+#if !PRESERVE_RETAIL_BEHAVIOR
+	// TheSuperHackers @performance IamInnocent 03/01/2026 - Tweaks to Limit FX Rendering for Performance Improvisation
+	{ "FXRenderingInterval",		INI::parseDurationUnsignedInt,			nullptr,			offsetof( WeaponTemplate, m_fxRenderingInterval ) },
+	{ "FXMaxStackInterval",			INI::parseDurationUnsignedInt,			nullptr,			offsetof( WeaponTemplate, m_fxMaxStackInterval ) },
+	{ "FXMaxStackPerLoc",			INI::parseInt,							nullptr,			offsetof( WeaponTemplate, m_fxMaxStackPerLoc ) },
+	{ "CheckFireFXForFXMaxStack",	INI::parseBool,							nullptr,			offsetof( WeaponTemplate, m_checkFireFXForFXMaxStack ) },
+#endif
+
 	{ nullptr,												nullptr,																		nullptr,							0 }
 
 };
@@ -323,6 +336,13 @@ WeaponTemplate::WeaponTemplate() : m_nextTemplate(nullptr)
 	m_damageStatusType							= OBJECT_STATUS_NONE;
 	m_suspendFXDelay								= 0;
 	m_dieOnDetonate						= FALSE;
+
+#if !PRESERVE_RETAIL_BEHAVIOR
+	m_fxRenderingInterval = 0;
+	m_fxMaxStackInterval = 0;
+	m_fxMaxStackPerLoc = 0;
+	m_checkFireFXForFXMaxStack = FALSE;
+#endif
 
 	m_historicDamageTriggerId = 0;
 }
@@ -903,6 +923,22 @@ UnsignedInt WeaponTemplate::fireWeaponTemplate
 		}
 	}
 
+#if !PRESERVE_RETAIL_BEHAVIOR
+	Bool renderWeaponFX = TRUE;
+	if( getFXRenderingInterval() > 0 && !isProjectileDetonation )
+	{
+		if(TheGameLogic->getFrame() >= firingWeapon->getLastFXShotFrame() + getFXRenderingInterval())
+		{
+			firingWeapon->setLastFXShotFrame(TheGameLogic->getFrame());
+			renderWeaponFX = TRUE;
+		}
+		else
+		{
+			renderWeaponFX = FALSE;
+		}
+	}
+#endif
+
 	// call this even if FXList is null, because this also handles stuff like Gun Barrel Recoil
 	if (sourceObj && sourceObj->getDrawable())
 	{
@@ -920,10 +956,25 @@ UnsignedInt WeaponTemplate::fireWeaponTemplate
 		VeterancyLevel v = sourceObj->getVeterancyLevel();
 		const FXList* fx = isProjectileDetonation ? getProjectileDetonateFX(v) : getFireFX(v);
 
-		if ( TheGameLogic->getFrame() < firingWeapon->getSuspendFXFrame() )
+		if ( TheGameLogic->getFrame() < firingWeapon->getSuspendFXFrame()
+#if !PRESERVE_RETAIL_BEHAVIOR
+			 || !renderWeaponFX
+#endif
+		   )
 			fx = nullptr;
 
 		Bool handled;
+
+#if !PRESERVE_RETAIL_BEHAVIOR
+		if( getFXMaxStackPerLoc() > 0 && fx && (isProjectileDetonation || getCheckFireFXForFXMaxStack()) )
+		{
+			// Check if there is any FX Stack to apply for the Weapon at Loc. Purely in data form, so shouldn't have much performance issue
+			if(ThePartitionManager->getWeaponNameStackAtCell(&targetPos, getName()) <= getFXMaxStackPerLoc())
+				ThePartitionManager->registerWeaponNameAtCell(&targetPos, getName(), getFXMaxStackInterval() ? getFXMaxStackInterval() : getDelayBetweenShots(bonus));
+			else
+				fx = NULL;
+		}
+#endif
 
 		// TheSuperHackers @todo: Remove hardcoded KINDOF_MINE check and apply PlayFXWhenStealthed = Yes to the mine weapons instead.
 
@@ -1149,6 +1200,18 @@ UnsignedInt WeaponTemplate::fireWeaponTemplate
 			{
 				pui->projectileLaunchAtObjectOrPosition(victimObj, &projectileDestination, sourceObj, wslot, specificBarrelToUse, this, m_projectileExhausts[v]);
 			}
+
+#if !PRESERVE_RETAIL_BEHAVIOR
+			if( !renderWeaponFX )
+			{
+				static NameKeyType key_BoneFXUpdate = NAMEKEY("BoneFXUpdate");
+				BoneFXUpdate *bfxu = (BoneFXUpdate *)projectile->findUpdateModule(key_BoneFXUpdate);
+				if (bfxu != NULL)
+				{
+					bfxu->setInactive();
+				}
+			}
+#endif
 		}
 		else
 		{
@@ -1847,6 +1910,10 @@ Weapon::Weapon(const WeaponTemplate* tmpl, WeaponSlotType wslot)
 	m_numShotsForCurBarrel = 	m_template->getShotsPerBarrel();
 	m_lastFireFrame = 0;
 	m_suspendFXFrame = TheGameLogic->getFrame() + m_template->getSuspendFXDelay();
+
+#if !PRESERVE_RETAIL_BEHAVIOR
+	m_lastFXFireFrame = 0;
+#endif
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1868,6 +1935,10 @@ Weapon::Weapon(const Weapon& that)
 	this->m_numShotsForCurBarrel = m_template->getShotsPerBarrel();
 	this->m_lastFireFrame = 0;
 	this->m_suspendFXFrame = that.getSuspendFXFrame();
+
+#if !PRESERVE_RETAIL_BEHAVIOR
+	this->m_lastFXFireFrame = 0;
+#endif
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1891,6 +1962,10 @@ Weapon& Weapon::operator=(const Weapon& that)
 		this->m_suspendFXFrame = that.getSuspendFXFrame();
 		this->m_numShotsForCurBarrel = m_template->getShotsPerBarrel();
 		this->m_projectileStreamID = INVALID_ID;
+
+#if !PRESERVE_RETAIL_BEHAVIOR
+		this->m_lastFXFireFrame = 0;
+#endif
 	}
 	return *this;
 }

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DProjectileStreamDraw.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DProjectileStreamDraw.cpp
@@ -132,6 +132,10 @@ void W3DProjectileStreamDraw::doDrawModule(const Matrix3D* )
 	static NameKeyType key_ProjectileStreamUpdate = NAMEKEY("ProjectileStreamUpdate");
 	ProjectileStreamUpdate* update = (ProjectileStreamUpdate*)me->findUpdateModule(key_ProjectileStreamUpdate);
 
+	// Requires ProjectileStreamUpdate for getting Vector Points
+	if(!update)
+		return;
+
 	const W3DProjectileStreamDrawModuleData *data = getW3DProjectileStreamDrawModuleData();
 
 	Vector3 allPoints[MAX_PROJECTILE_STREAM];
@@ -140,7 +144,6 @@ void W3DProjectileStreamDraw::doDrawModule(const Matrix3D* )
 	update->getAllPoints( allPoints, &pointsUsed );
 
 	Vector3 stagingPoints[MAX_PROJECTILE_STREAM];
-	Vector3 zeroVector(0, 0, 0);
 
 	Int linesMade = 0;
 	Int currentMasterPoint = 0;
@@ -159,7 +162,10 @@ void W3DProjectileStreamDraw::doDrawModule(const Matrix3D* )
 	// I'll keep doing this until I run out of valid points.
 	while( currentMasterPoint < pointsUsed )
 	{
-		while( currentMasterPoint < pointsUsed  &&  allPoints[currentMasterPoint] != zeroVector )
+		// TheSuperHackers @ performance IamInnocent 03/01/26 - Changes ProjectileStreamDraw Update Requirement Vector from being equal zero Vector to any Vector above near zero.
+		while( currentMasterPoint < pointsUsed  &&
+			   (fabs(allPoints[currentMasterPoint].X) > WWMATH_EPSILON || fabs(allPoints[currentMasterPoint].Y) > WWMATH_EPSILON || fabs(allPoints[currentMasterPoint].Z) > WWMATH_EPSILON)
+			 )
 		{
 			// While I am not looking at a bad point (off edge or zero)
 			stagingPoints[currentStagingPoint] = allPoints[currentMasterPoint];// copy to the staging


### PR DESCRIPTION
Adresses issues: https://github.com/TheSuperHackers/GeneralsGameCode/issues/57 and https://github.com/TheSuperHackers/GeneralsGameCode/issues/124

ProjectileStreamUpdate - Minor changes of refractoring Modulo to use Comparison and Increment.
W3DProjectileStreamDraw - Minor change of updating Requirement Vector from being not equal zero Vector to any Vector above near zero.

### Weapons
Added 4 FX Tweaking Variables:
- FXRenderingInterval
- FXMaxStackPerLoc
- FXMaxStackInterval
- CheckFireFXForFXMaxStack

The performance of Toxin Tractor and Dragon Tank can simply be improved by Increasing their Weapon's DelayBetweenShots from 40 to 80. This however, affects the Gameplay. Therefore, I propose a makeshift design to be able to Tweak Weapon's FX spawning Rate without affecting the Gameplay.

Each of these Variables enables the customization of _Rendering_ WeaponFX and BoneFXUpdate without affecting Gameplay in any way.

> FXRenderingInterval - Adds an _interval_ for Weapons required to be able to _Render_ the next _FireFX_ and _BoneFXUpdate_. 
> - BoneFXUpdate is one of the main features that reduces _Performance_ for ProjectileStreamUpdate. Reducing the _Generation_ of Particle from BoneFXUpdate will _Increase_ the overall performance.
> 
> FXMaxStackPerLoc - If the FX used is from ProjectileDetonationFX, then the system will register the _Name_ of the FiringWeapon with one _Count_ onto the PartitionCell with PartitionManager. If the _Count_ exceeds the configured variable, Weapons with the same name cannot _Spawn_ ProjectileDetonationFX on the _Same_ Cell with the registered name.
>  
> FXMaxStackInterval - Adds an _Interval_ for the Registered _Count_ of the previous Variable to be _Obsolete_. If not configured, the Weapon will use its _'DelayBetweenShots'_ variable to account for the delay.
> 
> CheckFireFXForFXMaxStack: Bypasses 'FXMaxStackPerLoc' original intent and _Use_ FireFX for FXMaxStack. This is useful for _Modules_ like FireWeaponWhenDeadBehavior or FireWeaponCollide that does not use ProjectileObject.

The performance improvements from using the above tweaks without changing the DelayBetweenShots is noticeable. ToxinTruckGun is configured with [these parameters ](https://docs.google.com/document/d/1iam3SAICinw_G_ZBpb_bY3qcEwrK7ZjmDMSC_Oplyeo/edit?usp=sharing) and able to achieve 50-60% performance boost.

<img width="2210" height="638" alt="image" src="https://github.com/user-attachments/assets/3844b4b0-4756-4536-bd5f-9e6be63b746e" />

