### PR TITLE
Tweak(Gui): Hide the custom overlay during video playback and add the ability to correctly scale campaign videos

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -3567,6 +3567,12 @@ void InGameUI::postWindowDraw( void )
 	Int hudOffsetX = 0;
 	Int hudOffsetY = 0;
 
+	// TheSuperHackers @info During video playback we don't want custom overlay elements showing
+	if (TheDisplay->isMoviePlaying())
+	{
+		return;
+	}
+
 	if (m_networkLatencyPointSize > 0 && TheGameLogic->isInMultiplayerGame())
 	{
 		drawNetworkLatency(hudOffsetX, hudOffsetY);

--- a/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
@@ -264,6 +264,7 @@ public:
 	Bool m_sounds3DOn;
 	Bool m_speechOn;
 	Bool m_videoOn;
+	Bool m_maintainVideoAspect;
 	Bool m_disableCameraMovement;
 
 	Bool m_useFX;									///< If false, don't render effects

--- a/GeneralsMD/Code/GameEngine/Include/Common/UserPreferences.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/UserPreferences.h
@@ -150,6 +150,7 @@ public:
 	Real getResolutionFontAdjustment(void);
 
 	Bool getShowMoneyPerMinute(void) const;
+	Bool getMaintainVideoAspect(void) const;
 };
 
 //-----------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Display.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Display.h
@@ -143,14 +143,17 @@ public:
 
 	/// draw a video buffer fit within the screen coordinates
 	virtual void drawScaledVideoBuffer( VideoBuffer *buffer, VideoStreamInterface *stream ) = 0;
-	virtual void drawVideoBuffer( VideoBuffer *buffer, Int startX, Int startY,
-													Int endX, Int endY ) = 0;
+	virtual void drawScaledVideoBuffer() = 0;
+	virtual void drawVideoBuffer( VideoBuffer *buffer, Int startX, Int startY, Int endX, Int endY ) = 0;
+	virtual void drawVideoBuffer(Int startX, Int startY, Int endX, Int endY) = 0;
 
 	/// FullScreen video playback
 	virtual void playLogoMovie( AsciiString movieName, Int minMovieLength, Int minCopyrightLength );
 	virtual void playMovie( AsciiString movieName );
 	virtual void stopMovie( void );
 	virtual Bool isMoviePlaying(void);
+
+	virtual VideoBuffer* getVideoBuffer() { return m_videoBuffer; }
 
 	/// Register debug display callback
 	virtual void setDebugDisplayCallback( DebugDisplayCallback *callback, void *userData = NULL  );
@@ -172,6 +175,9 @@ public:
 	virtual void enableLetterBox(Bool enable) = 0;						///< forces letter-boxed display on/off
 	virtual Bool isLetterBoxFading( void ) { return FALSE; }	///< returns true while letterbox fades in/out
 	virtual Bool isLetterBoxed( void ) { return FALSE; }	//WST 10/2/2002. Added query interface
+
+	virtual void setMaintainVideoAspect(Bool maintainAspect) { m_maintainVideoAspect = maintainAspect; }
+	virtual Bool isVideoAspectMaintained() { return m_maintainVideoAspect;  }
 
 	virtual void setCinematicText( AsciiString string ) { m_cinematicText = string; }
 	virtual void setCinematicFont( GameFont *font ) { m_cinematicFont = font; }
@@ -205,6 +211,7 @@ protected:
 	void									*m_debugDisplayUserData;	///< Data for debug display update handler
 	Real	m_letterBoxFadeLevel;	///<tracks the current alpha level for fading letter-boxed mode in/out.
 	Bool	m_letterBoxEnabled;		///<current state of letterbox
+	Bool	m_maintainVideoAspect;
 	UnsignedInt	m_letterBoxFadeStartTime;		///< time of letterbox fade start
 	Int		m_movieHoldTime;									///< time that we hold on the last frame of the movie
 	Int		m_copyrightHoldTime;							///< time that the copyright must be on the screen

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -329,6 +329,7 @@ GlobalData* GlobalData::m_theOriginal = NULL;
 	{ "Sounds3DOn",									INI::parseBool,				NULL,			offsetof( GlobalData, m_sounds3DOn ) },
 	{ "SpeechOn",										INI::parseBool,				NULL,			offsetof( GlobalData, m_speechOn ) },
 	{ "VideoOn",										INI::parseBool,				NULL,			offsetof( GlobalData, m_videoOn ) },
+	{ "MaintainVideoAspect",				INI::parseBool,				NULL,			offsetof(GlobalData, m_maintainVideoAspect) },
 	{ "DisableCameraMovements",			INI::parseBool,				NULL,			offsetof( GlobalData, m_disableCameraMovement ) },
 
 /* These are internal use only, they do not need file definitons
@@ -784,6 +785,7 @@ GlobalData::GlobalData()
 	m_sounds3DOn = TRUE;
 	m_speechOn = TRUE;
 	m_videoOn = TRUE;
+	m_maintainVideoAspect = TRUE;
 	m_disableCameraMovement = FALSE;
 	m_maxVisibleTranslucentObjects = 512;
 	m_maxVisibleOccluderObjects = 512;
@@ -1226,6 +1228,7 @@ void GlobalData::parseGameDataDefinition( INI* ini )
 	TheWritableGlobalData->m_systemTimeFontSize = optionPref.getSystemTimeFontSize();
 	TheWritableGlobalData->m_gameTimeFontSize = optionPref.getGameTimeFontSize();
 	TheWritableGlobalData->m_showMoneyPerMinute = optionPref.getShowMoneyPerMinute();
+	TheWritableGlobalData->m_maintainVideoAspect = optionPref.getMaintainVideoAspect();
 
 	Int val=optionPref.getGammaValue();
 	//generate a value between 0.6 and 2.0.

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -995,6 +995,19 @@ Bool OptionPreferences::getShowMoneyPerMinute(void) const
 	return FALSE;
 }
 
+Bool OptionPreferences::getMaintainVideoAspect(void) const
+{
+	OptionPreferences::const_iterator it = find("MaintainVideoAspect");
+	if (it == end())
+		return TheGlobalData->m_maintainVideoAspect;
+
+	if (stricmp(it->second.str(), "yes") == 0)
+	{
+		return TRUE;
+	}
+	return FALSE;
+}
+
 static OptionPreferences *pref = NULL;
 
 static void setDefaults( void )
@@ -1572,6 +1585,16 @@ static void saveOptions( void )
 		prefString = show ? "yes" : "no";
 		(*pref)["ShowMoneyPerMinute"] = prefString;
 		TheWritableGlobalData->m_showMoneyPerMinute = show;
+	}
+
+	//-------------------------------------------------------------------------------------------------
+	// Set Video Scaling
+	{
+		Bool maintainAspect = pref->getMaintainVideoAspect();
+		AsciiString prefString;
+		prefString = maintainAspect ? "yes" : "no";
+		(*pref)["MaintainVideoAspect"] = prefString;
+		TheWritableGlobalData->m_maintainVideoAspect = maintainAspect;
 	}
 
 	//-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -326,6 +326,7 @@ void GameClient::init( void )
 	if( TheDisplay ) {
 		TheDisplay->init();
  		TheDisplay->setName("TheDisplay");
+		TheDisplay->setMaintainVideoAspect(TheGlobalData->m_maintainVideoAspect);
 	}
 
 	TheHeaderTemplateManager = MSGNEW("GameClientSubsystem") HeaderTemplateManager;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -3658,6 +3658,12 @@ void InGameUI::postWindowDraw( void )
 	Int hudOffsetX = 0;
 	Int hudOffsetY = 0;
 
+	// TheSuperHackers @info During video playback we don't want custom overlay elements showing
+	if (TheDisplay->isMoviePlaying())
+	{
+		return;
+	}
+
 	if (m_networkLatencyPointSize > 0 && TheGameLogic->isInMultiplayerGame())
 	{
 		drawNetworkLatency(hudOffsetX, hudOffsetY);

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -115,8 +115,9 @@ public:
 
 	/// draw a video buffer fit within the screen coordinates
 	virtual void drawScaledVideoBuffer( VideoBuffer *buffer, VideoStreamInterface *stream );
-	virtual void drawVideoBuffer( VideoBuffer *buffer, Int startX, Int startY,
-													Int endX, Int endY );
+	virtual void drawScaledVideoBuffer();
+	virtual void drawVideoBuffer( VideoBuffer *buffer, Int startX, Int startY, Int endX, Int endY );
+	virtual void drawVideoBuffer( Int startX, Int startY, Int endX, Int endY );
 
 	virtual VideoBuffer*	createVideoBuffer( void ) ;							///< Create a video buffer that can be used for this display
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/W3DGameWindow.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/W3DGameWindow.cpp
@@ -378,14 +378,21 @@ void W3DGameWinDefaultDraw( GameWindow *window, WinInstanceData *instData )
 
 	}
 
-	// if we have a video buffer, draw the video buffer
-	if ( instData->m_videoBuffer )
+	// if the display has a movie playing then we need to draw the video buffer
+	if( TheDisplay->isMoviePlaying() )
 	{
-		ICoord2D pos, size;
-		window->winGetScreenPosition( &pos.x, &pos.y );
-		window->winGetSize( &size.x, &size.y );
 
-		TheDisplay->drawVideoBuffer( instData->m_videoBuffer, pos.x, pos.y, pos.x + size.x, pos.y + size.y );
+		if (TheDisplay->isVideoAspectMaintained()) {
+			TheDisplay->drawScaledVideoBuffer();
+		}
+		else {
+			ICoord2D pos, size;
+			window->winGetScreenPosition( &pos.x, &pos.y );
+			window->winGetSize( &size.x, &size.y );
+
+			TheDisplay->drawVideoBuffer( pos.x, pos.y, pos.x + size.x, pos.y + size.y );
+		}
+
 	}
 
 }

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -2850,6 +2850,11 @@ void W3DDisplay::drawScaledVideoBuffer( VideoBuffer *buffer, VideoStreamInterfac
 	drawVideoBuffer( buffer, startX, startY, endX, endY );
 }
 
+void W3DDisplay::drawScaledVideoBuffer()
+{
+	drawScaledVideoBuffer(m_videoBuffer, m_videoStream);
+}
+
 //============================================================================
 // W3DDisplay::drawVideoBuffer
 //============================================================================
@@ -2865,6 +2870,11 @@ void W3DDisplay::drawVideoBuffer( VideoBuffer *buffer, Int startX, Int startY, I
 												vbuffer->Rect( 0, 0, 1, 1) );
 	m_2DRender->Render();
 
+}
+
+void W3DDisplay::drawVideoBuffer( Int startX, Int startY, Int endX, Int endY )
+{
+	TheDisplay->drawVideoBuffer(m_videoBuffer, startX, startY, endX, endY);
 }
 
 // W3DDisplay::setClipRegion ============================================

--- a/GeneralsMD/Code/Tools/GUIEdit/Include/GUIEditDisplay.h
+++ b/GeneralsMD/Code/Tools/GUIEdit/Include/GUIEditDisplay.h
@@ -98,9 +98,11 @@ public:
 	virtual VideoBuffer*	createVideoBuffer( void ) { return NULL; }
 
 	/// draw a video buffer fit within the screen coordinates
-	virtual void drawScaledVideoBuffer( VideoBuffer *buffer, VideoStreamInterface *stream ) { }
-	virtual void drawVideoBuffer( VideoBuffer *buffer, Int startX, Int startY,
-																Int endX, Int endY ) { }
+	virtual void drawScaledVideoBuffer(VideoBuffer* buffer, VideoStreamInterface* stream) { }
+	virtual void drawScaledVideoBuffer() { }
+	virtual void drawVideoBuffer(VideoBuffer* buffer, Int startX, Int startY, Int endX, Int endY) { }
+	virtual void drawVideoBuffer(Int startX, Int startY, Int endX, Int endY) { }
+
 	virtual void takeScreenShot(void){ }
 	virtual void toggleMovieCapture(void) {}
 


### PR DESCRIPTION
This PR implements the hiding of the custom SH overlay during video playback.
It also adds fixes to correctly scale the campaign videos instead of stretching them to fit the screen.

The campaign video playback was moved from within the window handler to the display object, this allows a central place to detect video playback, making the hiding of the video overlay during video playback simpler.

It also allowed reusing current video scaling code used for the opening videos for the campaign videos.

The Video scaling can be disabled but is enabled by default as this allows the true aspect of the videos to be seen by users.

The code for the load screen video playback was also simplified and removed the "Hacky" (EA words for it) code that tried to show and increment the loading bar as the video played.
Instead the loading bar is completely hidden during video playback and only used during asset loading.

---

**TODO**

- [ ] Replicate campaign video scaling in generals