### PR TITLE
tweak(gui): Decouple GUI transition and world animation time step from render update

### DIFF
--- a/Core/GameEngine/Include/GameClient/GameWindowTransitions.h
+++ b/Core/GameEngine/Include/GameClient/GameWindowTransitions.h
@@ -647,7 +647,7 @@ private:
 	typedef std::list<TransitionWindow *> TransitionWindowList;
 	TransitionWindowList m_transitionWindowList;
 	Int m_directionMultiplier;
-	Int m_currentFrame; ///< maintain how long we've spent on this transition;
+	Real m_currentFrame; ///< maintain how long we've spent on this transition (in 30fps-equivalent frames);
 	AsciiString m_name;
 };
 

--- a/Core/GameEngine/Source/GameClient/GUI/GameWindowTransitions.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/GameWindowTransitions.cpp
@@ -55,6 +55,7 @@
 #include "GameClient/GameWindowTransitions.h"
 #include "GameClient/GameWindow.h"
 #include "GameClient/GameWindowManager.h"
+#include "Common/FramePacer.h"
 //-----------------------------------------------------------------------------
 // DEFINES ////////////////////////////////////////////////////////////////////
 //-----------------------------------------------------------------------------
@@ -270,7 +271,9 @@ void TransitionGroup::init( void )
 
 void TransitionGroup::update( void )
 {
-	m_currentFrame += m_directionMultiplier; // we go forward or backwards depending.
+	// TheSuperHackers @tweak GUI transition timing is now decoupled from the render update.
+	const Real timeScale = TheFramePacer->getActualLogicTimeScaleOverFpsRatio();
+	m_currentFrame += m_directionMultiplier * timeScale; // we go forward or backwards depending.
 	TransitionWindowList::iterator it = m_transitionWindowList.begin();
 	while (it != m_transitionWindowList.end())
 	{

--- a/Core/GameEngine/Source/GameClient/GUI/GameWindowTransitions.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/GameWindowTransitions.cpp
@@ -271,8 +271,8 @@ void TransitionGroup::init( void )
 
 void TransitionGroup::update( void )
 {
-	// TheSuperHackers @tweak GUI transition timing is now decoupled from the render update.
-	const Real timeScale = TheFramePacer->getActualLogicTimeScaleOverFpsRatio();
+	// TheSuperHackers @tweak bobtista GUI transition timing is now decoupled from the render update.
+	const Real timeScale = TheFramePacer->getBaseOverUpdateFpsRatio();
 	m_currentFrame += m_directionMultiplier * timeScale; // we go forward or backwards depending.
 	TransitionWindowList::iterator it = m_transitionWindowList.begin();
 	while (it != m_transitionWindowList.end())

--- a/Core/GameEngine/Source/GameClient/GUI/GameWindowTransitions.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/GameWindowTransitions.cpp
@@ -287,15 +287,22 @@ void TransitionGroup::update( void )
 	const Int step = (newFrame > prevFrame) ? 1 : -1;
 	for( Int frame = prevFrame + step; frame != newFrame + step; frame += step )
 	{
+		Bool isFinished = TRUE;
 		TransitionWindowList::iterator it = m_transitionWindowList.begin();
 		while (it != m_transitionWindowList.end())
 		{
 			TransitionWindow *tWin = *it;
 			tWin->update(frame);
+
+			if( tWin->isFinished() == FALSE )
+			{
+				isFinished = FALSE;
+			}
+
 			it++;
 		}
 
-		if( isFinished() )
+		if( isFinished )
 		{
 			break;
 		}

--- a/Core/GameEngine/Source/GameClient/GUI/GameWindowTransitions.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/GameWindowTransitions.cpp
@@ -240,7 +240,7 @@ Int TransitionWindow::getTotalFrames( void )
 //-----------------------------------------------------------------------------
 TransitionGroup::TransitionGroup( void )
 {
-	m_currentFrame = 0;
+	m_currentFrame = 0.0f;
 	m_fireOnce = FALSE;
 }
 
@@ -257,7 +257,7 @@ TransitionGroup::~TransitionGroup( void )
 
 void TransitionGroup::init( void )
 {
-	m_currentFrame = 0;
+	m_currentFrame = 0.0f;
 	m_directionMultiplier = 1;
 	TransitionWindowList::iterator it = m_transitionWindowList.begin();
 	while (it != m_transitionWindowList.end())
@@ -318,7 +318,7 @@ void TransitionGroup::reverse( void )
 		tWin->reverse(totalFrames);
 		it++;
 	}
-	m_currentFrame = totalFrames;
+	m_currentFrame = (Real)totalFrames;
 //	m_currentFrame ++;
 }
 

--- a/Core/GameEngine/Source/GameClient/GUI/GameWindowTransitions.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/GameWindowTransitions.cpp
@@ -293,12 +293,7 @@ void TransitionGroup::update( void )
 		{
 			TransitionWindow *tWin = *it;
 			tWin->update(frame);
-
-			if( tWin->isFinished() == FALSE )
-			{
-				isFinished = FALSE;
-			}
-
+			isFinished &= tWin->isFinished();
 			it++;
 		}
 

--- a/Core/GameEngine/Source/GameClient/GUI/GameWindowTransitions.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/GameWindowTransitions.cpp
@@ -272,14 +272,33 @@ void TransitionGroup::init( void )
 void TransitionGroup::update( void )
 {
 	// TheSuperHackers @tweak bobtista GUI transition timing is now decoupled from the render update.
+	// Step every integer frame between the old and new accumulator value so discrete-state-machine
+	// transitions cannot skip a state when the render frame rate dips below the base rate.
 	const Real timeScale = TheFramePacer->getBaseOverUpdateFpsRatio();
-	m_currentFrame += m_directionMultiplier * timeScale; // we go forward or backwards depending.
-	TransitionWindowList::iterator it = m_transitionWindowList.begin();
-	while (it != m_transitionWindowList.end())
+	const Int prevFrame = (Int)m_currentFrame;
+	m_currentFrame += m_directionMultiplier * timeScale;
+	const Int newFrame = (Int)m_currentFrame;
+
+	if( newFrame == prevFrame )
 	{
-		TransitionWindow *tWin = *it;
-		tWin->update(m_currentFrame);
-		it++;
+		return;
+	}
+
+	const Int step = (newFrame > prevFrame) ? 1 : -1;
+	for( Int frame = prevFrame + step; frame != newFrame + step; frame += step )
+	{
+		TransitionWindowList::iterator it = m_transitionWindowList.begin();
+		while (it != m_transitionWindowList.end())
+		{
+			TransitionWindow *tWin = *it;
+			tWin->update(frame);
+			it++;
+		}
+
+		if( isFinished() )
+		{
+			break;
+		}
 	}
 }
 

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5534,8 +5534,12 @@ void InGameUI::updateAndDrawWorldAnimations( void )
 			}
 
 			// update the Z value
+			// TheSuperHackers @tweak World animation Z-rise is now decoupled from the render update.
 			if( wad->m_zRisePerSecond )
-				wad->m_worldPos.z += wad->m_zRisePerSecond / LOGICFRAMES_PER_SECOND;
+			{
+				const Real timeScale = TheFramePacer->getActualLogicTimeScaleOverFpsRatio();
+				wad->m_worldPos.z += wad->m_zRisePerSecond / LOGICFRAMES_PER_SECOND * timeScale;
+			}
 
 		}
 

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5534,10 +5534,10 @@ void InGameUI::updateAndDrawWorldAnimations( void )
 			}
 
 			// update the Z value
-			// TheSuperHackers @tweak World animation Z-rise is now decoupled from the render update.
+			// TheSuperHackers @tweak bobtista World animation Z-rise is now decoupled from the render update.
 			if( wad->m_zRisePerSecond )
 			{
-				const Real timeScale = TheFramePacer->getActualLogicTimeScaleOverFpsRatio();
+				const Real timeScale = TheFramePacer->getBaseOverUpdateFpsRatio();
 				wad->m_worldPos.z += wad->m_zRisePerSecond / LOGICFRAMES_PER_SECOND * timeScale;
 			}
 

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5537,7 +5537,7 @@ void InGameUI::updateAndDrawWorldAnimations( void )
 			// TheSuperHackers @tweak bobtista World animation Z-rise is now decoupled from the render update.
 			if( wad->m_zRisePerSecond )
 			{
-				const Real timeScale = TheFramePacer->getBaseOverUpdateFpsRatio();
+				const Real timeScale = TheFramePacer->getActualLogicTimeScaleOverFpsRatio();
 				wad->m_worldPos.z += wad->m_zRisePerSecond / LOGICFRAMES_PER_SECOND * timeScale;
 			}
 

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5504,6 +5504,9 @@ static const UnsignedInt FRAMES_BEFORE_EXPIRE_TO_FADE = LOGICFRAMES_PER_SECOND *
 // ------------------------------------------------------------------------------------------------
 void InGameUI::updateAndDrawWorldAnimations( void )
 {
+	// TheSuperHackers @tweak bobtista World animation Z-rise is now decoupled from the render update.
+	const Real zRiseTimeScale = TheFramePacer->getActualLogicTimeScaleOverFpsRatio();
+
 	// go through all animations
 	for( WorldAnimationListIterator it = m_worldAnimationList.begin();
 			 it != m_worldAnimationList.end(); /*empty*/ )
@@ -5534,11 +5537,9 @@ void InGameUI::updateAndDrawWorldAnimations( void )
 			}
 
 			// update the Z value
-			// TheSuperHackers @tweak bobtista World animation Z-rise is now decoupled from the render update.
 			if( wad->m_zRisePerSecond )
 			{
-				const Real timeScale = TheFramePacer->getActualLogicTimeScaleOverFpsRatio();
-				wad->m_worldPos.z += wad->m_zRisePerSecond / LOGICFRAMES_PER_SECOND * timeScale;
+				wad->m_worldPos.z += wad->m_zRisePerSecond / LOGICFRAMES_PER_SECOND * zRiseTimeScale;
 			}
 
 		}

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5515,33 +5515,27 @@ void InGameUI::updateAndDrawWorldAnimations( void )
 		// get data
 		WorldAnimationData *wad = *it;
 
-		// update portion ... only when the game is in motion
-		if( TheGameLogic->isGamePaused() == FALSE )
+		//
+		// see if it's time to expire this animation based on animation type and options or
+		// the expire frame
+		//
+		if( TheGameLogic->getFrame() >= wad->m_expireFrame ||
+				(BitIsSet( wad->m_options, WORLD_ANIM_PLAY_ONCE_AND_DESTROY ) &&
+				 BitIsSet( wad->m_anim->getStatus(), ANIM_2D_STATUS_COMPLETE )) )
 		{
 
-			//
-			// see if it's time to expire this animation based on animation type and options or
-			// the expire frame
-			//
-			if( TheGameLogic->getFrame() >= wad->m_expireFrame ||
-					(BitIsSet( wad->m_options, WORLD_ANIM_PLAY_ONCE_AND_DESTROY ) &&
-					 BitIsSet( wad->m_anim->getStatus(), ANIM_2D_STATUS_COMPLETE )) )
-			{
+			// delete this element and continue
+			deleteInstance(wad->m_anim);
+			delete wad;
+			it = m_worldAnimationList.erase( it );
+			continue;
 
-				// delete this element and continue
-				deleteInstance(wad->m_anim);
-				delete wad;
-				it = m_worldAnimationList.erase( it );
-				continue;
+		}
 
-			}
-
-			// update the Z value
-			if( wad->m_zRisePerSecond )
-			{
-				wad->m_worldPos.z += wad->m_zRisePerSecond / LOGICFRAMES_PER_SECOND * zRiseTimeScale;
-			}
-
+		// update the Z value
+		if( wad->m_zRisePerSecond )
+		{
+			wad->m_worldPos.z += wad->m_zRisePerSecond / LOGICFRAMES_PER_SECOND * zRiseTimeScale;
 		}
 
 		//

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5707,10 +5707,10 @@ void InGameUI::updateAndDrawWorldAnimations( void )
 			}
 
 			// update the Z value
-			// TheSuperHackers @tweak World animation Z-rise is now decoupled from the render update.
+			// TheSuperHackers @tweak bobtista World animation Z-rise is now decoupled from the render update.
 			if( wad->m_zRisePerSecond )
 			{
-				const Real timeScale = TheFramePacer->getActualLogicTimeScaleOverFpsRatio();
+				const Real timeScale = TheFramePacer->getBaseOverUpdateFpsRatio();
 				wad->m_worldPos.z += wad->m_zRisePerSecond / LOGICFRAMES_PER_SECOND * timeScale;
 			}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5707,8 +5707,12 @@ void InGameUI::updateAndDrawWorldAnimations( void )
 			}
 
 			// update the Z value
+			// TheSuperHackers @tweak World animation Z-rise is now decoupled from the render update.
 			if( wad->m_zRisePerSecond )
-				wad->m_worldPos.z += wad->m_zRisePerSecond / LOGICFRAMES_PER_SECOND;
+			{
+				const Real timeScale = TheFramePacer->getActualLogicTimeScaleOverFpsRatio();
+				wad->m_worldPos.z += wad->m_zRisePerSecond / LOGICFRAMES_PER_SECOND * timeScale;
+			}
 
 		}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5677,6 +5677,9 @@ static const UnsignedInt FRAMES_BEFORE_EXPIRE_TO_FADE = LOGICFRAMES_PER_SECOND *
 // ------------------------------------------------------------------------------------------------
 void InGameUI::updateAndDrawWorldAnimations( void )
 {
+	// TheSuperHackers @tweak bobtista World animation Z-rise is now decoupled from the render update.
+	const Real zRiseTimeScale = TheFramePacer->getActualLogicTimeScaleOverFpsRatio();
+
 	// go through all animations
 	for( WorldAnimationListIterator it = m_worldAnimationList.begin();
 			 it != m_worldAnimationList.end(); /*empty*/ )
@@ -5707,11 +5710,9 @@ void InGameUI::updateAndDrawWorldAnimations( void )
 			}
 
 			// update the Z value
-			// TheSuperHackers @tweak bobtista World animation Z-rise is now decoupled from the render update.
 			if( wad->m_zRisePerSecond )
 			{
-				const Real timeScale = TheFramePacer->getActualLogicTimeScaleOverFpsRatio();
-				wad->m_worldPos.z += wad->m_zRisePerSecond / LOGICFRAMES_PER_SECOND * timeScale;
+				wad->m_worldPos.z += wad->m_zRisePerSecond / LOGICFRAMES_PER_SECOND * zRiseTimeScale;
 			}
 
 		}

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5688,33 +5688,27 @@ void InGameUI::updateAndDrawWorldAnimations( void )
 		// get data
 		WorldAnimationData *wad = *it;
 
-		// update portion ... only when the game is in motion
-		if( TheGameLogic->isGamePaused() == FALSE )
+		//
+		// see if it's time to expire this animation based on animation type and options or
+		// the expire frame
+		//
+		if( TheGameLogic->getFrame() >= wad->m_expireFrame ||
+				(BitIsSet( wad->m_options, WORLD_ANIM_PLAY_ONCE_AND_DESTROY ) &&
+				 BitIsSet( wad->m_anim->getStatus(), ANIM_2D_STATUS_COMPLETE )) )
 		{
 
-			//
-			// see if it's time to expire this animation based on animation type and options or
-			// the expire frame
-			//
-			if( TheGameLogic->getFrame() >= wad->m_expireFrame ||
-					(BitIsSet( wad->m_options, WORLD_ANIM_PLAY_ONCE_AND_DESTROY ) &&
-					 BitIsSet( wad->m_anim->getStatus(), ANIM_2D_STATUS_COMPLETE )) )
-			{
+			// delete this element and continue
+			deleteInstance(wad->m_anim);
+			delete wad;
+			it = m_worldAnimationList.erase( it );
+			continue;
 
-				// delete this element and continue
-				deleteInstance(wad->m_anim);
-				delete wad;
-				it = m_worldAnimationList.erase( it );
-				continue;
+		}
 
-			}
-
-			// update the Z value
-			if( wad->m_zRisePerSecond )
-			{
-				wad->m_worldPos.z += wad->m_zRisePerSecond / LOGICFRAMES_PER_SECOND * zRiseTimeScale;
-			}
-
+		// update the Z value
+		if( wad->m_zRisePerSecond )
+		{
+			wad->m_worldPos.z += wad->m_zRisePerSecond / LOGICFRAMES_PER_SECOND * zRiseTimeScale;
 		}
 
 		//

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -5710,7 +5710,7 @@ void InGameUI::updateAndDrawWorldAnimations( void )
 			// TheSuperHackers @tweak bobtista World animation Z-rise is now decoupled from the render update.
 			if( wad->m_zRisePerSecond )
 			{
-				const Real timeScale = TheFramePacer->getBaseOverUpdateFpsRatio();
+				const Real timeScale = TheFramePacer->getActualLogicTimeScaleOverFpsRatio();
 				wad->m_worldPos.z += wad->m_zRisePerSecond / LOGICFRAMES_PER_SECOND * timeScale;
 			}
 


### PR DESCRIPTION
## Summary
- GUI window transitions now advance at a consistent rate regardless of frame rate
- 2D world animation icons (healing, promotion, crate collection effects) rise at consistent speed regardless of frame rate

### Changes
- `TransitionGroup::m_currentFrame` changed from `Int` to `Real` to support fractional frame accumulation
- `TransitionGroup::update()` scales frame advancement by `TheFramePacer->getActualLogicTimeScaleOverFpsRatio()`
- `InGameUI` world animation Z-rise calculation now scales by the same time factor

## Test plan
- [x] Verify GUI transitions (menu fades, button flashes) play at the same speed at 30fps and higher frame rates
- [x] Verify 2D world icons (healing icons, veteran stars, crate pickups) rise at consistent speed regardless of frame rate