### PR TITLE
bugfix(armorstore): Create overrides for ArmorTemplate data from custom maps to avoid CRC mismatch in the next multiplayer game session

### DIFF
--- a/Core/GameEngine/Source/Common/System/GameMemoryInitPools_GeneralsMD.inl
+++ b/Core/GameEngine/Source/Common/System/GameMemoryInitPools_GeneralsMD.inl
@@ -21,7 +21,6 @@
 static PoolSizeRec PoolSizes[] =
 {
 	{ "ArmorTemplatePool", 64, 8 },
-
 	{ "PartitionContactListNode", 2048, 512 },
 	{ "BattleshipUpdate", 32, 32 },
 	{ "FlyToDestAndDestroyUpdate", 32, 32 },

--- a/Core/GameEngine/Source/Common/System/GameMemoryInitPools_GeneralsMD.inl
+++ b/Core/GameEngine/Source/Common/System/GameMemoryInitPools_GeneralsMD.inl
@@ -20,6 +20,8 @@
 // not const -- we might override from INI
 static PoolSizeRec PoolSizes[] =
 {
+	{ "ArmorTemplatePool", 64, 8 },
+
 	{ "PartitionContactListNode", 2048, 512 },
 	{ "BattleshipUpdate", 32, 32 },
 	{ "FlyToDestAndDestroyUpdate", 32, 32 },

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Armor.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Armor.h
@@ -133,7 +133,7 @@ public:
 
 private:
 
-	ArmorTemplate* newOverride(ArmorTemplate *armorTemplate);
+	ArmorTemplate* newOverride(ArmorTemplate *armorTemplate, const char* name);
 
 	typedef std::hash_map< NameKeyType, ArmorTemplate*, rts::hash<NameKeyType>, rts::equal_to<NameKeyType> > ArmorTemplateMap;
 	ArmorTemplateMap m_armorTemplates;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Armor.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Armor.h
@@ -111,7 +111,7 @@ class ArmorStore : public SubsystemInterface
 public:
 
 	ArmorStore();
-	~ArmorStore();
+	virtual ~ArmorStore();
 
 	void init() { }
 	void reset();

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Armor.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Armor.h
@@ -32,6 +32,7 @@
 // INCLUDES ///////////////////////////////////////////////////////////////////////////////////////
 #include "Common/NameKeyGenerator.h"
 #include "Common/STLTypedefs.h"
+#include "Common/Overridable.h"
 #include "GameLogic/Damage.h"
 
 // FORWARD REFERENCES /////////////////////////////////////////////////////////////////////////////
@@ -43,8 +44,19 @@ class ArmorStore;
 	to simulate different materials, and to help make game balance easier to adjust.
 */
 //-------------------------------------------------------------------------------------------------
-class ArmorTemplate
+class ArmorTemplate : public Overridable
 {
+	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(ArmorTemplate, "ArmorTemplatePool")
+
+#if defined(_MSC_VER) && _MSC_VER < 1300
+		ArmorTemplate(const ArmorTemplate&)
+	{
+		DEBUG_CRASH(("This should never be called"));
+	}
+#else
+		ArmorTemplate(const ArmorTemplate& that) = delete;
+#endif
+
 public:
 
 	ArmorTemplate();
@@ -102,7 +114,7 @@ public:
 	~ArmorStore();
 
 	void init() { }
-	void reset() { }
+	void reset();
 	void update() { }
 
 	const ArmorTemplate* findArmorTemplate(NameKeyType namekey) const;
@@ -121,7 +133,9 @@ public:
 
 private:
 
-	typedef std::hash_map< NameKeyType, ArmorTemplate, rts::hash<NameKeyType>, rts::equal_to<NameKeyType> > ArmorTemplateMap;
+	ArmorTemplate* newOverride(ArmorTemplate *armorTemplate);
+
+	typedef std::hash_map< NameKeyType, ArmorTemplate*, rts::hash<NameKeyType>, rts::equal_to<NameKeyType> > ArmorTemplateMap;
 	ArmorTemplateMap m_armorTemplates;
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Armor.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Armor.h
@@ -54,7 +54,7 @@ class ArmorTemplate : public Overridable
 		DEBUG_CRASH(("This should never be called"));
 	}
 #else
-		ArmorTemplate(const ArmorTemplate& that) = delete;
+	ArmorTemplate(const ArmorTemplate& that) = delete;
 #endif
 
 public:

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Armor.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Armor.h
@@ -49,7 +49,7 @@ class ArmorTemplate : public Overridable
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(ArmorTemplate, "ArmorTemplatePool")
 
 #if defined(_MSC_VER) && _MSC_VER < 1300
-		ArmorTemplate(const ArmorTemplate&)
+	ArmorTemplate(const ArmorTemplate&)
 	{
 		DEBUG_CRASH(("This should never be called"));
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Armor.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Armor.cpp
@@ -118,9 +118,9 @@ ArmorStore::ArmorStore()
 //-------------------------------------------------------------------------------------------------
 ArmorStore::~ArmorStore()
 {
-	for (ArmorTemplateMap::iterator itr = m_armorTemplates.begin(); itr != m_armorTemplates.end(); ++itr)
+	for (ArmorTemplateMap::iterator it = m_armorTemplates.begin(); it != m_armorTemplates.end(); ++it)
 	{
-		deleteInstance(itr->second);
+		deleteInstance(it->second);
 	}
 
 	m_armorTemplates.clear();
@@ -222,22 +222,22 @@ ArmorTemplate* ArmorStore::newOverride(ArmorTemplate *armorTemplate, const char 
 //-------------------------------------------------------------------------------------------------
 void ArmorStore::reset()
 {
-	ArmorTemplateMap::iterator itr = m_armorTemplates.begin();
+	ArmorTemplateMap::iterator it = m_armorTemplates.begin();
 
-	while (itr != m_armorTemplates.end())
+	while (it != m_armorTemplates.end())
 	{
-		ArmorTemplateMap::iterator next = itr;
+		ArmorTemplateMap::iterator next = it;
 		++next;
 
-		const Overridable *stillValid = itr->second->deleteOverrides();
+		const Overridable *stillValid = it->second->deleteOverrides();
 
 		if (stillValid == NULL)
 		{
 			// Also needs to be removed from the Hash map.
-			m_armorTemplates.erase(itr);
+			m_armorTemplates.erase(it);
 		}
 
-		itr = next;
+		it = next;
 	}
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Armor.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Armor.cpp
@@ -118,6 +118,11 @@ ArmorStore::ArmorStore()
 //-------------------------------------------------------------------------------------------------
 ArmorStore::~ArmorStore()
 {
+	for (ArmorTemplateMap::iterator itr = m_armorTemplates.begin(); itr != m_armorTemplates.end(); ++itr)
+	{
+		deleteInstance(itr->second);
+	}
+
 	m_armorTemplates.clear();
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Armor.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Armor.cpp
@@ -176,22 +176,21 @@ const ArmorTemplate* ArmorStore::findArmorTemplate(const char* name) const
 	}
 	else
 	{
-		armorTmpl = TheArmorStore->newOverride(armorTmpl);
+		armorTmpl = TheArmorStore->newOverride(armorTmpl, name);
 	}
 
 	ini->initFromINI(armorTmpl, myFieldParse);
 }
 
 //-------------------------------------------------------------------------------------------------
-ArmorTemplate* ArmorStore::newOverride( ArmorTemplate *armorTemplate )
+ArmorTemplate* ArmorStore::newOverride(ArmorTemplate *armorTemplate, const char *name)
 {
 	// sanity
 	DEBUG_ASSERTCRASH( armorTemplate, ("newOverride(): NULL 'parent' armor template") );
 
 	// sanity just for debuging, the armor must be in the master list to do overrides
-	DEBUG_ASSERTCRASH( findArmorTemplate( armorTemplate->getName() ) != NULL,
-										 ("newOverride(): Armor template '%s' not in master list",
-										 armorTemplate->getName().str()) );
+	DEBUG_ASSERTCRASH( findArmorTemplate( name ) != NULL,
+										 ("newOverride(): Armor template '%s' not in master list", name) );
 
 	// find final override of the 'parent' template
 	ArmorTemplate *child = static_cast<ArmorTemplate*>(armorTemplate->friend_getFinalOverride());

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Armor.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Armor.cpp
@@ -217,14 +217,20 @@ ArmorTemplate* ArmorStore::newOverride(ArmorTemplate *armorTemplate, const char 
 //-------------------------------------------------------------------------------------------------
 void ArmorStore::reset()
 {
-	for (ArmorTemplateMap::iterator itr = m_armorTemplates.begin(); itr != m_armorTemplates.end(); ++itr)
+	ArmorTemplateMap::iterator itr = m_armorTemplates.begin();
+
+	while (itr != m_armorTemplates.end())
 	{
 		const Overridable *stillValid = itr->second->deleteOverrides();
 
 		if (stillValid == NULL)
 		{
 			// Also needs to be removed from the Hash map.
-			m_armorTemplates.erase(itr->first);
+			itr = m_armorTemplates.erase(itr);
+		}
+		else
+		{
+			++itr;
 		}
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Armor.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Armor.cpp
@@ -226,17 +226,18 @@ void ArmorStore::reset()
 
 	while (itr != m_armorTemplates.end())
 	{
+		ArmorTemplateMap::iterator next = itr;
+		++next;
+
 		const Overridable *stillValid = itr->second->deleteOverrides();
 
 		if (stillValid == NULL)
 		{
 			// Also needs to be removed from the Hash map.
-			itr = m_armorTemplates.erase(itr);
+			m_armorTemplates.erase(itr);
 		}
-		else
-		{
-			++itr;
-		}
+
+		itr = next;
 	}
 }
 


### PR DESCRIPTION
* Closes https://github.com/TheSuperHackers/GeneralsGameCode/issues/1976

Implemented an override system for the `ArmorStore` like the `ThingFactory` to avoid potential mismatches because the original `ArmorTemplate` data is overwritten and not restored.

## TODO:
- [x] Make implementation / code resemble that of the `ThingFactory` as much as possible.
- [ ] Replicate in Generals.