### PR TITLE
bugfix(worldbuilder): Initialize boolean in ScriptConditionsDlg::OnEditCondition to show logical condition

### DIFF
--- a/Generals/Code/Tools/WorldBuilder/src/ScriptConditions.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/ScriptConditions.cpp
@@ -130,7 +130,7 @@ void ScriptConditionsDlg::OnEditCondition()
 	ScriptDialog::updateScriptWarning(m_script);
 	pList->DeleteString(m_index);
 	AsciiString label;
-	Bool first;
+	Bool first = false;
 	if (m_orCondition && m_orCondition->getFirstAndCondition() == m_condition) {
 		first = true;
 	}

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/ScriptConditions.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/ScriptConditions.cpp
@@ -130,7 +130,7 @@ void ScriptConditionsDlg::OnEditCondition()
 	ScriptDialog::updateScriptWarning(m_script);
 	pList->DeleteString(m_index);
 	AsciiString label;
-	Bool first;
+	Bool first = false;
 	if (m_orCondition && m_orCondition->getFirstAndCondition() == m_condition) {
 		first = true;
 	}


### PR DESCRIPTION
Editing an existing script condition with the World Builder would show incorrect text, due to an uninitialized boolean.

## Before:
<img width="418" height="101" alt="image" src="https://github.com/user-attachments/assets/c39b2454-7f22-49fa-b1c8-1c13c3cded10" />

## After:
<img width="446" height="95" alt="image" src="https://github.com/user-attachments/assets/6b7b20dd-b4fe-47dc-8ef1-0399fd8fe1a7" />
