### PR TITLE
bugfix(actionmanager): Do not show false resume construction cursor for allied scaffolds

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/RTS/ActionManager.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/ActionManager.cpp
@@ -454,10 +454,8 @@ Bool ActionManager::canResumeConstructionOf( const Object *obj,
 	if( obj->isKindOf( KINDOF_DOZER ) == FALSE )
 		return FALSE;
 
-	Relationship r = obj->getRelationship(objectBeingConstructed);
-
-	// only available to our allies
-	if( r != ALLIES )
+	// TheSuperHackers @bugfix Stubbjax 06/01/2025 Ensure only the owner of the construction can resume it.
+	if (obj->getControllingPlayer() != objectBeingConstructed->getControllingPlayer())
 		return FALSE;
 
 	// if the objectBeingConstructed is not actually under construction we can't resume that!

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/ActionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/ActionManager.cpp
@@ -458,10 +458,8 @@ Bool ActionManager::canResumeConstructionOf( const Object *obj,
 	if( obj->isKindOf( KINDOF_DOZER ) == FALSE )
 		return FALSE;
 
-	Relationship r = obj->getRelationship(objectBeingConstructed);
-
-	// only available to our allies
-	if( r != ALLIES )
+	// TheSuperHackers @bugfix Stubbjax 06/01/2025 Ensure only the owner of the construction can resume it.
+	if (obj->getControllingPlayer() != objectBeingConstructed->getControllingPlayer())
 		return FALSE;
 
 	// if the objectBeingConstructed is not actually under construction we can't resume that!


### PR DESCRIPTION
Fixes #250

This change prevents the resume construction mouse cursor (and the command by extension) from being shown for stale scaffolds of allied players.