### PR TITLE
tweak: Allow exit during match outcome

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/QuitMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/QuitMenu.cpp
@@ -279,7 +279,7 @@ void HideQuitMenu( void )
 //-------------------------------------------------------------------------------------------------
 void ToggleQuitMenu()
 {
-	if (TheGameLogic->isIntroMoviePlaying() || TheGameLogic->isLoadingGame() ||TheScriptEngine->isGameEnding())
+	if (TheGameLogic->isIntroMoviePlaying() || TheGameLogic->isLoadingGame())
 		return;
 
 	// BGC- If we are currently in the disconnect screen, don't let the quit menu come up.
@@ -346,6 +346,7 @@ void ToggleQuitMenu()
 	{
 
 		TheMouse->setCursor( Mouse::ARROW );
+		TheMouse->setVisibility(true);
 
 		TheControlBar->hidePurchaseScience();
 		if ( TheGameLogic->isInMultiplayerGame()  || TheGameLogic->isInReplayGame() )
@@ -431,6 +432,7 @@ void ToggleQuitMenu()
 		HideDiplomacy();
 		HideInGameChat();
 		TheControlBar->hidePurchaseScience();
+		quitMenuLayout->bringForward();
 		isVisible = TRUE;
 	}
 

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/QuitMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/QuitMenu.cpp
@@ -341,12 +341,14 @@ void ToggleQuitMenu()
 			//}
 			//end KRISMORNESS
 		}
+
+		if (TheScriptEngine->isGameEnding())
+			TheMouse->setVisibility(false);
 	}
 	else
 	{
 
 		TheMouse->setCursor( Mouse::ARROW );
-		TheMouse->setVisibility(true);
 
 		TheControlBar->hidePurchaseScience();
 		if ( TheGameLogic->isInMultiplayerGame()  || TheGameLogic->isInReplayGame() )
@@ -433,6 +435,7 @@ void ToggleQuitMenu()
 		HideInGameChat();
 		TheControlBar->hidePurchaseScience();
 		quitMenuLayout->bringForward();
+		TheMouse->setVisibility(true);
 		isVisible = TRUE;
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/QuitMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/QuitMenu.cpp
@@ -279,7 +279,7 @@ void HideQuitMenu( void )
 //-------------------------------------------------------------------------------------------------
 void ToggleQuitMenu()
 {
-	if (TheGameLogic->isIntroMoviePlaying() || TheGameLogic->isLoadingMap() ||TheScriptEngine->isGameEnding())
+	if (TheGameLogic->isIntroMoviePlaying() || TheGameLogic->isLoadingMap())
 		return;
 
 	// BGC- If we are currently in the disconnect screen, don't let the quit menu come up.
@@ -346,6 +346,7 @@ void ToggleQuitMenu()
 	{
 
 		TheMouse->setCursor( Mouse::ARROW );
+		TheMouse->setVisibility(true);
 
 		TheControlBar->hidePurchaseScience();
 		if ( TheGameLogic->isInMultiplayerGame()  || TheGameLogic->isInReplayGame() )
@@ -431,6 +432,7 @@ void ToggleQuitMenu()
 		HideDiplomacy();
 		HideInGameChat();
 		TheControlBar->hidePurchaseScience();
+		quitMenuLayout->bringForward();
 		isVisible = TRUE;
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/QuitMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/QuitMenu.cpp
@@ -341,12 +341,14 @@ void ToggleQuitMenu()
 			//}
 			//end KRISMORNESS
 		}
+
+		if (TheScriptEngine->isGameEnding())
+			TheMouse->setVisibility(false);
 	}
 	else
 	{
 
 		TheMouse->setCursor( Mouse::ARROW );
-		TheMouse->setVisibility(true);
 
 		TheControlBar->hidePurchaseScience();
 		if ( TheGameLogic->isInMultiplayerGame()  || TheGameLogic->isInReplayGame() )
@@ -433,6 +435,7 @@ void ToggleQuitMenu()
 		HideInGameChat();
 		TheControlBar->hidePurchaseScience();
 		quitMenuLayout->bringForward();
+		TheMouse->setVisibility(true);
 		isVisible = TRUE;
 	}
 


### PR DESCRIPTION
This change allows players to bring up the quit menu and exit the game during the match outcome screen via the ESC key. Players are no longer forced to wait for the duration of the match outcome before they can exit the game.

https://github.com/user-attachments/assets/28c5d13b-da73-4534-bbb8-c49c0c5c0108