### PR TITLE
perf(heightmap): Reduce cost of min height loop in HeightMapRenderObjClass::updateCenter by 93%

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/HeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/HeightMap.cpp
@@ -1677,8 +1677,8 @@ void HeightMapRenderObjClass::updateCenter(CameraClass *camera , RefRenderObjLis
 
 	Real intersectionZ;
 	minHt = m_map->getMaxHeightValue();
-	for (i=0; i<m_x; i++) {
-		for (j=0; j<m_y; j++) {
+	for (j=0; j<m_y; j+=4) {
+		for (i=0; i<m_x; i+=4) {
 			Short cur = m_map->getDisplayHeight(i,j);
 			if (cur<minHt) minHt = cur;
 		}


### PR DESCRIPTION
This change reduces the cost of the min height loop in `HeightMapRenderObjClass::updateCenter` by 93%.

`HeightMapRenderObjClass::updateCenter` is called once a frame if the camera transform is changed.

The sample resolution is reduced by a factor of 16 which should be no problem in practice. `m_y` and `m_x` are flipped because the memory is laid out that way.

Tested on Defcon6 map without visual penalties.