### PR TITLE
bugfix(render2d): Fix possible greyscale image rendering issues on hardware without DOT3 support

### DIFF
--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/render2d.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/render2d.cpp
@@ -611,6 +611,9 @@ void Render2DClass::Render(void)
 			DX8Wrapper::Set_DX8_Texture_Stage_State( 0, D3DTSS_COLORARG1, D3DTA_TEXTURE);
 			DX8Wrapper::Set_DX8_Texture_Stage_State( 0, D3DTSS_COLORARG2, D3DTA_TFACTOR);
 			DX8Wrapper::Set_DX8_Texture_Stage_State( 0, D3DTSS_COLOROP, D3DTOP_MODULATE);
+
+			// TheSuperHackers @bugfix Stubbjax 08/01/2025 Fix possible greyscale rendering issues on hardware without DOT3 support.
+			DX8Wrapper::Set_DX8_Texture_Stage_State( 1, D3DTSS_COLOROP, D3DTOP_DISABLE);
 		}
 	}
 	else

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/render2d.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/render2d.cpp
@@ -685,6 +685,9 @@ void Render2DClass::Render(void)
 			DX8Wrapper::Set_DX8_Texture_Stage_State( 0, D3DTSS_COLORARG1, D3DTA_TEXTURE);
 			DX8Wrapper::Set_DX8_Texture_Stage_State( 0, D3DTSS_COLORARG2, D3DTA_TFACTOR);
 			DX8Wrapper::Set_DX8_Texture_Stage_State( 0, D3DTSS_COLOROP, D3DTOP_MODULATE);
+
+			// TheSuperHackers @bugfix Stubbjax 08/01/2025 Fix possible greyscale rendering issues on hardware without DOT3 support.
+			DX8Wrapper::Set_DX8_Texture_Stage_State( 1, D3DTSS_COLOROP, D3DTOP_DISABLE);
 		}
 	}
 	else


### PR DESCRIPTION
This change fixes a possible greyscale rendering issue on hardware without DOT3 support. The problem is that texture stage 1 is not explicitly disabled in the fallback logic block, which could result in undefined behavior depending on what state it was left in from previous rendering operations (such as the configuration applied via `_PresetOpaqueShader`). The issue is reproducible by inverting the DOT3 support condition and setting texture stage 1 to a bad state.

### Before
Hardware without DOT3 support may render greyscale textures as solid, opaque squares

<img width="920" height="242" alt="image" src="https://github.com/user-attachments/assets/e642e25d-fdd5-47e6-8c69-e137a6d6ab84" />


### After
Hardware without DOT3 support will render greyscale textures as darkened

<img width="920" height="242" alt="image" src="https://github.com/user-attachments/assets/cc9fc85a-88f9-4003-9714-c6865f8de85a" />
