### PR TITLE
build(cmake): Move all CppMacros.h includes into precompiled headers

### DIFF
--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -17,6 +17,9 @@ target_link_libraries(corei_always INTERFACE
     corei_libraries_include
     resources
 )
+target_precompile_headers(corei_always INTERFACE
+    [["Utility/CppMacros.h"]] # Must be first, to be removed when abandoning VC6
+)
 
 # Set where the build results will end up
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/Core/GameEngine/Include/Common/Debug.h
+++ b/Core/GameEngine/Include/Common/Debug.h
@@ -45,8 +45,6 @@
 
 #pragma once
 
-#include <Utility/CppMacros.h>
-
 class AsciiString;
 
 #define NO_RELEASE_DEBUG_LOGGING

--- a/Core/Libraries/Include/Lib/BaseTypeCore.h
+++ b/Core/Libraries/Include/Lib/BaseTypeCore.h
@@ -33,7 +33,6 @@
 #include <string.h>
 // TheSuperHackers @build feliwir 07/04/2025 Adds utility macros for cross-platform compatibility
 #include <Utility/compat.h>
-#include <Utility/CppMacros.h>
 #include <Utility/stdint_adapter.h>
 
 /*

--- a/Core/Libraries/Source/WWVegas/CMakeLists.txt
+++ b/Core/Libraries/Source/WWVegas/CMakeLists.txt
@@ -8,7 +8,7 @@ target_compile_definitions(core_wwcommon INTERFACE
 
 target_link_libraries(core_wwcommon INTERFACE
     core_config
-    core_utility
+    corei_always
     d3d8lib
     milesstub
     stlport

--- a/Core/Libraries/Source/WWVegas/WWDebug/CMakeLists.txt
+++ b/Core/Libraries/Source/WWVegas/WWDebug/CMakeLists.txt
@@ -15,5 +15,4 @@ target_sources(core_wwdebug PRIVATE ${WWDEBUG_SRC})
 
 target_link_libraries(core_wwdebug PRIVATE
     core_wwcommon
-    corei_always
 )

--- a/Core/Libraries/Source/WWVegas/WWLib/CMakeLists.txt
+++ b/Core/Libraries/Source/WWVegas/WWLib/CMakeLists.txt
@@ -176,6 +176,7 @@ target_include_directories(core_wwlib PUBLIC
 )
 
 target_precompile_headers(core_wwlib PRIVATE
+    [["Utility/CppMacros.h"]] # Must be first, to be removed when abandoning VC6
     always.h
     STLUtils.h
     win.h
@@ -186,5 +187,4 @@ target_precompile_headers(core_wwlib PRIVATE
 
 target_link_libraries(core_wwlib PRIVATE
     core_wwcommon
-    corei_always
 )

--- a/Core/Libraries/Source/WWVegas/WWLib/STLUtils.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/STLUtils.h
@@ -22,7 +22,6 @@
 #include <cstddef>
 #include <map>
 #include <utility>
-#include <Utility/CppMacros.h>
 
 namespace stl
 {

--- a/Core/Libraries/Source/WWVegas/WWStub/CMakeLists.txt
+++ b/Core/Libraries/Source/WWVegas/WWStub/CMakeLists.txt
@@ -10,5 +10,4 @@ target_sources(core_wwstub PRIVATE ${WWSTUB_SRC})
 
 target_link_libraries(core_wwstub PRIVATE
     core_wwcommon
-    corei_always
 )

--- a/Core/Libraries/Source/debug/CMakeLists.txt
+++ b/Core/Libraries/Source/debug/CMakeLists.txt
@@ -30,6 +30,7 @@ target_include_directories(core_debug INTERFACE
 )
 
 target_precompile_headers(core_debug PRIVATE
+    [["Utility/CppMacros.h"]] # Must be first, to be removed when abandoning VC6
     "debug.h"
     "internal.h"
     "internal_except.h"

--- a/Core/Libraries/Source/profile/CMakeLists.txt
+++ b/Core/Libraries/Source/profile/CMakeLists.txt
@@ -25,6 +25,7 @@ target_include_directories(core_profile INTERFACE
 )
 
 target_precompile_headers(core_profile PRIVATE
+    [["Utility/CppMacros.h"]] # Must be first, to be removed when abandoning VC6
     "profile.h"
     "internal.h"
     <windows.h>

--- a/Core/Libraries/Source/profile/internal.h
+++ b/Core/Libraries/Source/profile/internal.h
@@ -34,7 +34,6 @@
 #include "internal_highlevel.h"
 #include "internal_cmd.h"
 #include "internal_result.h"
-#include "Utility/CppMacros.h"
 #include <windows.h>
 
 #if !(defined(_MSC_VER) && _MSC_VER < 1300)

--- a/Core/Tools/W3DView/CMakeLists.txt
+++ b/Core/Tools/W3DView/CMakeLists.txt
@@ -171,6 +171,7 @@ add_library(corei_w3dview INTERFACE)
 target_sources(corei_w3dview INTERFACE ${W3DVIEW_SRC})
 
 target_precompile_headers(corei_w3dview INTERFACE
+    [["Utility/CppMacros.h"]] # Must be first, to be removed when abandoning VC6
     "StdAfx.h"
     [["always.h"]]
     [["STLUtils.h"]]

--- a/Core/Tools/WW3D/max2w3d/util.h
+++ b/Core/Tools/WW3D/max2w3d/util.h
@@ -99,14 +99,14 @@ INode *Find_Named_Node (char *nodename, INode *root);
 /*
 ** Macros
 */
-#define SAFE_DELETE(pobject)					\
-			if (pobject) {							\
-				delete pobject;					\
-				pobject = NULL;					\
-			}											\
+#define SAFE_DELETE(pobject) \
+			if (pobject) { \
+				delete pobject; \
+				pobject = NULL; \
+			}
 
-#define SAFE_DELETE_ARRAY(pobject)			\
-			if (pobject) {							\
-				delete [] pobject;				\
-				pobject = NULL;					\
-			}											\
+#define SAFE_DELETE_ARRAY(pobject) \
+			if (pobject) { \
+				delete [] pobject; \
+				pobject = NULL; \
+			}

--- a/Dependencies/Utility/Utility/endian_compat.h
+++ b/Dependencies/Utility/Utility/endian_compat.h
@@ -22,7 +22,6 @@
 #ifndef ENDIAN_COMPAT_H
 #define ENDIAN_COMPAT_H
 
-#include <Utility/CppMacros.h>
 #include <Utility/stdint_adapter.h>
 
 

--- a/Generals/Code/CMakeLists.txt
+++ b/Generals/Code/CMakeLists.txt
@@ -15,10 +15,9 @@ target_compile_definitions(gi_always INTERFACE
     RTS_GENERALS=1
 )
 target_link_libraries(gi_always INTERFACE
-    core_utility
     gi_libraries_include
     # Must stay below so headers from game are included first
-    corei_libraries_include
+    corei_always
 )
 
 # Contains internal libraries

--- a/Generals/Code/GameEngine/CMakeLists.txt
+++ b/Generals/Code/GameEngine/CMakeLists.txt
@@ -1096,4 +1096,7 @@ target_link_libraries(g_gameengine PUBLIC
     g_wwvegas
 )
 
-target_precompile_headers(g_gameengine PRIVATE Include/Precompiled/PreRTS.h)
+target_precompile_headers(g_gameengine PRIVATE
+    [["Utility/CppMacros.h"]] # Must be first, to be removed when abandoning VC6
+    Include/Precompiled/PreRTS.h
+)

--- a/Generals/Code/GameEngineDevice/CMakeLists.txt
+++ b/Generals/Code/GameEngineDevice/CMakeLists.txt
@@ -190,6 +190,7 @@ target_include_directories(g_gameenginedevice PUBLIC
 )
 
 target_precompile_headers(g_gameenginedevice PRIVATE
+    [["Utility/CppMacros.h"]] # Must be first, to be removed when abandoning VC6
     [["Common/STLTypedefs.h"]]
     [["Common/SubsystemInterface.h"]]
     [["INI.h"]]
@@ -199,8 +200,8 @@ target_precompile_headers(g_gameenginedevice PRIVATE
 
 target_link_libraries(g_gameenginedevice PRIVATE
     corei_gameenginedevice_private
-    gi_always    
-    gi_main  
+    gi_always
+    gi_main
 )
 
 target_link_libraries(g_gameenginedevice PUBLIC

--- a/Generals/Code/Libraries/Source/WWVegas/CMakeLists.txt
+++ b/Generals/Code/Libraries/Source/WWVegas/CMakeLists.txt
@@ -3,9 +3,9 @@ add_library(g_wwcommon INTERFACE)
 
 target_link_libraries(g_wwcommon INTERFACE
     core_config
-    core_utility
     core_wwcommon
     d3d8lib
+    gi_always
     milesstub
     stlport
 )

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/CMakeLists.txt
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/CMakeLists.txt
@@ -238,6 +238,7 @@ target_compile_definitions(g_ww3d2 PRIVATE
 )
 
 target_precompile_headers(g_ww3d2 PRIVATE
+    [["Utility/CppMacros.h"]] # Must be first, to be removed when abandoning VC6
     dx8wrapper.h
     [["always.h"]]
     [["STLUtils.h"]]

--- a/Generals/Code/Tools/ParticleEditor/CMakeLists.txt
+++ b/Generals/Code/Tools/ParticleEditor/CMakeLists.txt
@@ -36,16 +36,14 @@ target_include_directories(g_particleeditor PRIVATE
     res
 )
 
-target_compile_definitions(g_particleeditor PRIVATE _AFXDLL)
-
 target_link_libraries(g_particleeditor PRIVATE
+    core_config
     corei_libraries_source_wwvegas
     corei_libraries_source_wwvegas_wwlib
     d3d8lib
-    gi_gameengine_include
     gi_always
+    gi_gameengine_include
     gi_libraries_source_wwvegas
-    core_config
     imm32
     stlport
     vfw32
@@ -54,7 +52,7 @@ target_link_libraries(g_particleeditor PRIVATE
 
 if(WIN32 OR "${CMAKE_SYSTEM}" MATCHES "Windows")
     target_link_options(g_particleeditor PRIVATE /NODEFAULTLIB:libci.lib /NODEFAULTLIB:libc.lib)
-
+    target_compile_definitions(g_particleeditor PRIVATE _AFXDLL)
     target_sources(g_particleeditor PRIVATE ParticleEditor.rc)
     set_target_properties(g_particleeditor PROPERTIES OUTPUT_NAME ParticleEditor)
 else()

--- a/Generals/Code/Tools/WorldBuilder/CMakeLists.txt
+++ b/Generals/Code/Tools/WorldBuilder/CMakeLists.txt
@@ -205,6 +205,7 @@ target_include_directories(g_worldbuilder PRIVATE
 target_compile_definitions(g_worldbuilder PRIVATE _AFXDLL)
 
 target_precompile_headers(g_worldbuilder PRIVATE
+    [["Utility/CppMacros.h"]] # Must be first, to be removed when abandoning VC6
     [["always.h"]]
     [["Common/STLTypedefs.h"]]
     [["StdAfx.h"]]

--- a/GeneralsMD/Code/CMakeLists.txt
+++ b/GeneralsMD/Code/CMakeLists.txt
@@ -15,10 +15,9 @@ target_compile_definitions(zi_always INTERFACE
     RTS_ZEROHOUR=1
 )
 target_link_libraries(zi_always INTERFACE
-    core_utility
     zi_libraries_include
     # Must stay below so headers from game are included first
-    corei_libraries_include
+    corei_always
 )
 
 # Contains internal libraries

--- a/GeneralsMD/Code/GameEngine/CMakeLists.txt
+++ b/GeneralsMD/Code/GameEngine/CMakeLists.txt
@@ -1174,4 +1174,7 @@ target_link_libraries(z_gameengine PUBLIC
     z_wwvegas
 )
 
-target_precompile_headers(z_gameengine PRIVATE Include/Precompiled/PreRTS.h)
+target_precompile_headers(z_gameengine PRIVATE
+    [["Utility/CppMacros.h"]] # Must be first, to be removed when abandoning VC6
+    Include/Precompiled/PreRTS.h
+)

--- a/GeneralsMD/Code/GameEngineDevice/CMakeLists.txt
+++ b/GeneralsMD/Code/GameEngineDevice/CMakeLists.txt
@@ -203,6 +203,7 @@ target_include_directories(z_gameenginedevice PUBLIC
 )
 
 target_precompile_headers(z_gameenginedevice PRIVATE
+    [["Utility/CppMacros.h"]] # Must be first, to be removed when abandoning VC6
     [["Common/STLTypedefs.h"]]
     [["Common/SubsystemInterface.h"]]
     [["INI.h"]]

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/CMakeLists.txt
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/CMakeLists.txt
@@ -3,11 +3,11 @@ add_library(z_wwcommon INTERFACE)
 
 target_link_libraries(z_wwcommon INTERFACE
     core_config
-    core_utility
     core_wwcommon
     d3d8lib
     milesstub
     stlport
+    zi_always
 )
 
 target_include_directories(z_wwcommon INTERFACE

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/CMakeLists.txt
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/CMakeLists.txt
@@ -243,6 +243,7 @@ target_compile_definitions(z_ww3d2 PRIVATE
 )
 
 target_precompile_headers(z_ww3d2 PRIVATE
+    [["Utility/CppMacros.h"]] # Must be first, to be removed when abandoning VC6
     dx8wrapper.h
     [["always.h"]]
     [["STLUtils.h"]]

--- a/GeneralsMD/Code/Tools/ParticleEditor/CMakeLists.txt
+++ b/GeneralsMD/Code/Tools/ParticleEditor/CMakeLists.txt
@@ -37,18 +37,18 @@ target_include_directories(z_particleeditor PRIVATE
 )
 
 target_link_libraries(z_particleeditor PRIVATE
+    core_config
     core_debug
     core_profile
     corei_libraries_source_wwvegas
     corei_libraries_source_wwvegas_wwlib
     d3d8lib
     imm32
-    core_config
     stlport
     vfw32
     winmm
-    zi_gameengine_include
     zi_always
+    zi_gameengine_include
     zi_libraries_source_wwvegas
 )
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/CMakeLists.txt
+++ b/GeneralsMD/Code/Tools/WorldBuilder/CMakeLists.txt
@@ -210,6 +210,7 @@ target_include_directories(z_worldbuilder PRIVATE
 )
 
 target_precompile_headers(z_worldbuilder PRIVATE
+    [["Utility/CppMacros.h"]] # Must be first, to be removed when abandoning VC6
     [["always.h"]]
     [["Common/STLTypedefs.h"]]
     [["StdAfx.h"]]

--- a/GeneralsMD/Code/Tools/wdump/CMakeLists.txt
+++ b/GeneralsMD/Code/Tools/wdump/CMakeLists.txt
@@ -19,12 +19,12 @@ target_sources(z_wdump PRIVATE ${WDUMP_SRC})
 
 target_link_libraries(z_wdump PRIVATE
     core_config
-    core_utility
     core_wwstub # avoid linking GameEngine
     imm32
     vfw32
     winmm
     z_wwvegas
+    zi_always
 )
 
 if(WIN32 OR "${CMAKE_SYSTEM}" MATCHES "Windows")


### PR DESCRIPTION
This change moves all CppMacros.h includes into precompiled headers.

This way CppMacros.h is made available everywhere with `corei_always`, `gi_always` or `zi_always`.