### PR TITLE
bugfix(projectile): Fix out-of-bounds access in DumbProjectile which causes mismatch with very high speed weapons at small hit distances

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
@@ -665,7 +665,10 @@ UpdateSleepTime DumbProjectileBehavior::update()
 			}
 			else
 			{
-				DEBUG_CRASH(("Vector is expected to contain two or more elements; check the weapon speed value"));
+#if RETAIL_COMPATIBLE_CRC
+				DEBUG_CRASH(("A mismatch is likely to happen if this code path is used in a match with unpatched clients."
+					" Vector is expected to contain two or more elements; check the weapon speed value."));
+#endif
 
 				prevPos = m_flightPathStart;
 				curPos = m_flightPathEnd;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
@@ -450,7 +450,6 @@ Bool DumbProjectileBehavior::calcFlightPath(Bool recalcNumSegments)
 	// TheSuperHackers @info The way flight paths are used requires at least two curve points.
 	// DumbProjectileBehavior::update has been modified to handle cases where the flight path consists of one or zero curve points.
 	flightCurve.getSegmentPoints(m_flightPathSegments, &m_flightPath);
-
 	DEBUG_ASSERTCRASH(m_flightPathSegments == m_flightPath.size(), ("m_flightPathSegments mismatch"));
 
 #if defined(RTS_DEBUG)
@@ -655,10 +654,7 @@ UpdateSleepTime DumbProjectileBehavior::update()
     {
 			// TheSuperHackers @bugfix Caball009 10/01/2026 Check vector size before accessing the second element to prevent out of bounds access.
 			// The non-deterministic behavior for retail clients cannot be fixed, so this will remain a source of potential mismatches in retail compatibility mode.
-			// If there are fewer than two elements, set current position to a valid value so that the behavior is deterministic for patched clients.
-			DEBUG_ASSERTCRASH(m_flightPath.size() >= 2, ("Vector is expected to contain two or more elements; check the weapon speed value"));
-
-#if RETAIL_COMPATIBLE_CRC
+			// Use the flight path start and end coordinates if needed, so that the behavior is deterministic for patched clients.
 			Coord3D prevPos;
 			Coord3D curPos;
 
@@ -669,20 +665,11 @@ UpdateSleepTime DumbProjectileBehavior::update()
 			}
 			else
 			{
-				prevPos.set(0.0f, 0.0f, 0.0f);
-				curPos.set(0.0f, 1.0f, 0.0f);
-			}
-#else
-			if (m_flightPath.size() < 2)
-			{
-				// there is no valid flight path to calculate but detonation needs to be delayed by a single frame
-				++m_currentFlightPathStep;
-				return UPDATE_SLEEP_NONE;
-			}
+				DEBUG_CRASH(("Vector is expected to contain two or more elements; check the weapon speed value"));
 
-			const Coord3D prevPos = m_flightPath[0];
-			const Coord3D curPos = m_flightPath[1];
-#endif
+				prevPos = m_flightPathStart;
+				curPos = m_flightPathEnd;
+			}
 
 		  Vector3 curDir(curPos.x - prevPos.x, curPos.y - prevPos.y, curPos.z - prevPos.z);
 		  curDir.Normalize();	// buildTransformMatrix wants it this way

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
@@ -673,7 +673,7 @@ UpdateSleepTime DumbProjectileBehavior::update()
 				curPos.set(0.0f, 1.0f, 0.0f);
 			}
 #else
-			if (m_flightPath.size() <= 2)
+			if (m_flightPath.size() < 2)
 			{
 				// there is no valid flight path to calculate but detonation needs to be delayed by a single frame
 				++m_currentFlightPathStep;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
@@ -670,6 +670,7 @@ UpdateSleepTime DumbProjectileBehavior::update()
 					" Vector is expected to contain two or more elements; check the weapon speed value."));
 #endif
 
+				flightStep = m_flightPathStart;
 				prevPos = m_flightPathStart;
 				curPos = m_flightPathEnd;
 			}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
@@ -670,9 +670,9 @@ UpdateSleepTime DumbProjectileBehavior::update()
 					" Vector is expected to contain two or more elements; check the weapon speed value."));
 #endif
 
-				flightStep = m_flightPathStart;
 				prevPos = m_flightPathStart;
 				curPos = m_flightPathEnd;
+				flightStep = m_flightPathEnd;
 			}
 
 		  Vector3 curDir(curPos.x - prevPos.x, curPos.y - prevPos.y, curPos.z - prevPos.z);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
@@ -653,13 +653,15 @@ UpdateSleepTime DumbProjectileBehavior::update()
       //long, blurry projectile graphics which look badly oriented on step 0 of the flight path
       // so lets orient it the same as if it were on frame 1!
     {
+			// TheSuperHackers @bugfix Caball009 10/01/2026 Check vector size before accessing the second element to prevent out of bounds access.
+			// The non-deterministic behavior for retail clients cannot be fixed, so this will remain a source of potential mismatches in retail compatibility mode.
+			// If there are fewer than two elements, set current position to a valid value so that the behavior is deterministic for patched clients.
+			DEBUG_ASSERTCRASH(m_flightPath.size() >= 2, ("Vector is expected to contain two or more elements; check the weapon speed value"));
+
 #if RETAIL_COMPATIBLE_CRC
 			Coord3D prevPos;
 			Coord3D curPos;
 
-			// TheSuperHackers @bugfix Caball009 10/01/2026 Check vector size before accessing the second element to prevent out of bounds access.
-			// The non-deterministic behavior for retail clients cannot be fixed, so this will remain a source of potential mismatches in retail compatibility mode.
-			// If there are fewer than two elements, set current position to a valid value so that the behavior is deterministic for patched clients.
 			if (m_flightPath.size() >= 2)
 			{
 				prevPos = m_flightPath[0];
@@ -667,8 +669,6 @@ UpdateSleepTime DumbProjectileBehavior::update()
 			}
 			else
 			{
-				DEBUG_CRASH(("Vector must contain two or more elements; check the weapon speed value"));
-
 				prevPos.set(0.0f, 0.0f, 0.0f);
 				curPos.set(0.0f, 1.0f, 0.0f);
 			}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
@@ -687,8 +687,8 @@ UpdateSleepTime DumbProjectileBehavior::update()
 			{
 				DEBUG_CRASH(("Vector must contain two or more elements; check the weapon speed value"));
 
-				prevPos = Coord3D(0.0f, 0.0f, 0.0f);
-				curPos = Coord3D(0.0f, 1.0f, 0.0f);
+				prevPos.set(0.0f, 0.0f, 0.0f);
+				curPos.set(0.0f, 1.0f, 0.0f);
 			}
 #else
 			const Coord3D prevPos = m_flightPath[0];

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
@@ -447,6 +447,8 @@ Bool DumbProjectileBehavior::calcFlightPath(Bool recalcNumSegments)
 		m_flightPathSegments = ceil( flightDistance / m_flightPathSpeed );
 	}
 
+	// TheSuperHackers @bugfix Caball009 10/01/2026 The way flight paths are used requires at least two curve points.
+	// getSegmentPoints will create only 1 element with default values for m_flightPath if m_flightPathSegments equals 1.
 #if RETAIL_COMPATIBLE_CRC
 	flightCurve.getSegmentPoints(m_flightPathSegments, &m_flightPath);
 #else

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
@@ -677,7 +677,7 @@ UpdateSleepTime DumbProjectileBehavior::update()
 
 			// TheSuperHackers @bugfix Caball009 10/01/2026 Check vector size before accessing the second element to prevent out of bounds access.
 			// The non-deterministic behavior for retail clients cannot be fixed, so this will remain a source of potential mismatches in retail compatibility mode.
-			// If there's only one element, set current position to a fixed value so that the behavior is deterministic for patched clients.
+			// If there's only one element, set current position to a valid value so that the behavior is deterministic for patched clients.
 			if (m_flightPath.size() >= 2)
 			{
 				curPos = m_flightPath[1];

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
@@ -668,13 +668,14 @@ UpdateSleepTime DumbProjectileBehavior::update()
       //long, blurry projectile graphics which look badly oriented on step 0 of the flight path
       // so lets orient it the same as if it were on frame 1!
     {
-		  Coord3D prevPos = m_flightPath[0];
-		  Coord3D curPos;
+		  const Coord3D prevPos = m_flightPath[0];
 
 #if RETAIL_COMPATIBLE_CRC
+			Coord3D curPos;
+
 			// TheSuperHackers @bugfix Caball009 10/01/2026 Check vector size before accessing the second element to prevent out of bounds access.
-			// If there's only one element, set current position to a fixed garbage value in a poor attempt to imitate retail behavior.
-			// Using a fixed value means that the behavior is deterministic for patched clients.
+			// The non-deterministic behavior for retail clients cannot be fixed, so this will remain a source of potential mismatches in retail compatibility mode.
+			// If there's only one element, set current position to a fixed value so that the behavior is deterministic for patched clients.
 			if (m_flightPath.size() >= 2)
 			{
 				curPos = m_flightPath[1];
@@ -682,12 +683,10 @@ UpdateSleepTime DumbProjectileBehavior::update()
 			else
 			{
 				DEBUG_CRASH(("Vector must contain two or more elements; check the weapon speed value"));
-
-				const Coord3D indeterminateValue = Coord3D(-NAN, -NAN, -NAN);
-				curPos = indeterminateValue;
+				curPos = prevPos;
 			}
 #else
-			curPos = m_flightPath[1];
+			const Coord3D curPos = m_flightPath[1];
 #endif
 
 		  Vector3 curDir(curPos.x - prevPos.x, curPos.y - prevPos.y, curPos.z - prevPos.z);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
@@ -670,9 +670,9 @@ UpdateSleepTime DumbProjectileBehavior::update()
       //long, blurry projectile graphics which look badly oriented on step 0 of the flight path
       // so lets orient it the same as if it were on frame 1!
     {
-		  const Coord3D prevPos = m_flightPath[0];
 
 #if RETAIL_COMPATIBLE_CRC
+			Coord3D prevPos;
 			Coord3D curPos;
 
 			// TheSuperHackers @bugfix Caball009 10/01/2026 Check vector size before accessing the second element to prevent out of bounds access.
@@ -680,14 +680,18 @@ UpdateSleepTime DumbProjectileBehavior::update()
 			// If there's only one element, set current position to a valid value so that the behavior is deterministic for patched clients.
 			if (m_flightPath.size() >= 2)
 			{
+				prevPos = m_flightPath[0];
 				curPos = m_flightPath[1];
 			}
 			else
 			{
 				DEBUG_CRASH(("Vector must contain two or more elements; check the weapon speed value"));
-				curPos = prevPos;
+
+				prevPos = Coord3D(0.0f, 0.0f, 0.0f);
+				curPos = Coord3D(0.0f, 1.0f, 0.0f);
 			}
 #else
+			const Coord3D prevPos = m_flightPath[0];
 			const Coord3D curPos = m_flightPath[1];
 #endif
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
@@ -670,7 +670,6 @@ UpdateSleepTime DumbProjectileBehavior::update()
       //long, blurry projectile graphics which look badly oriented on step 0 of the flight path
       // so lets orient it the same as if it were on frame 1!
     {
-
 #if RETAIL_COMPATIBLE_CRC
 			Coord3D prevPos;
 			Coord3D curPos;


### PR DESCRIPTION
* Closes https://github.com/TheSuperHackers/GeneralsGameCode/issues/43

Sufficiently high weapon speeds expose an out-of-bounds access bug for `DumbProjectile`, which is the reason for non-deterministic behavior across clients (i.e. mismatches).

This PR should fix the bug properly, and make the behavior deterministic for retail and non-retail clients.

## TODO:
- ~[ ] Replicate in Generals~ 
Generals doesn't have this particular out-of-bounds bug.