### PR TITLE
refactor(cmake): Move core_config into corei_always for simplification

### DIFF
--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -14,11 +14,13 @@ target_include_directories(corei_libraries_source_wwvegas_wwlib INTERFACE "Libra
 target_include_directories(corei_main INTERFACE "Main")
 
 target_link_libraries(corei_always INTERFACE
+    core_config
     core_utility
     corei_libraries_include
     resources
 )
 target_link_libraries(corei_always_no_pch INTERFACE
+    core_config
     core_utility_no_pch
     corei_libraries_include
     resources

--- a/Core/GameEngine/CMakeLists.txt
+++ b/Core/GameEngine/CMakeLists.txt
@@ -1192,9 +1192,7 @@ target_include_directories(corei_gameengine_public INTERFACE
 
 target_link_libraries(corei_gameengine_public INTERFACE
     core_compression
-    core_config
     core_browserdispatch
-    core_utility
     #core_wwvegas
     d3d8lib
     gamespy::gamespy

--- a/Core/Libraries/Source/Compression/CMakeLists.txt
+++ b/Core/Libraries/Source/Compression/CMakeLists.txt
@@ -29,7 +29,6 @@ target_include_directories(core_compression INTERFACE
 )
 
 target_link_libraries(core_compression PRIVATE
-    core_config
     corei_libraries_include
     corei_always
 )

--- a/Core/Libraries/Source/WWVegas/CMakeLists.txt
+++ b/Core/Libraries/Source/WWVegas/CMakeLists.txt
@@ -7,8 +7,6 @@ target_compile_definitions(core_wwcommon INTERFACE
 )
 
 target_link_libraries(core_wwcommon INTERFACE
-    core_config
-    core_utility
     d3d8lib
     milesstub
     stlport

--- a/Core/Libraries/Source/debug/CMakeLists.txt
+++ b/Core/Libraries/Source/debug/CMakeLists.txt
@@ -39,7 +39,6 @@ target_precompile_headers(core_debug PRIVATE
 )
 
 target_link_libraries(core_debug PRIVATE
-    core_config
     core_wwcommon
     corei_always
 )

--- a/Core/Libraries/Source/profile/CMakeLists.txt
+++ b/Core/Libraries/Source/profile/CMakeLists.txt
@@ -32,7 +32,6 @@ target_precompile_headers(core_profile PRIVATE
 )
 
 target_link_libraries(core_profile PRIVATE
-    core_config
     core_wwcommon
     corei_always
 )

--- a/Core/Tools/Autorun/CMakeLists.txt
+++ b/Core/Tools/Autorun/CMakeLists.txt
@@ -53,8 +53,6 @@ add_library(corei_autorun INTERFACE)
 target_sources(corei_autorun INTERFACE ${AUTORUN_SRC})
 
 target_link_libraries(corei_autorun INTERFACE
-    core_config
-    core_utility
     winmm
 )
 

--- a/Core/Tools/Babylon/CMakeLists.txt
+++ b/Core/Tools/Babylon/CMakeLists.txt
@@ -57,7 +57,6 @@ set_target_properties(core_babylon PROPERTIES OUTPUT_NAME babylon)
 target_sources(core_babylon PRIVATE ${BABYLON_SRC})
 
 target_link_libraries(core_babylon PRIVATE
-    core_config
     corei_always
 )
 

--- a/Core/Tools/CRCDiff/CMakeLists.txt
+++ b/Core/Tools/CRCDiff/CMakeLists.txt
@@ -15,8 +15,6 @@ set_target_properties(core_crcdiff PROPERTIES OUTPUT_NAME crcdiff)
 target_sources(core_crcdiff PRIVATE ${CRCDIFF_SRC})
 
 target_link_libraries(core_crcdiff PRIVATE
-    core_config
-    core_utility
     corei_always
     stlport
 )

--- a/Core/Tools/Compress/CMakeLists.txt
+++ b/Core/Tools/Compress/CMakeLists.txt
@@ -8,7 +8,6 @@ set_target_properties(core_compress PROPERTIES OUTPUT_NAME compress)
 target_sources(core_compress PRIVATE ${COMRPESS_SRC})
 
 target_link_libraries(core_compress PRIVATE
-    core_config
     core_compression
     corei_always
 )

--- a/Core/Tools/DebugWindow/CMakeLists.txt
+++ b/Core/Tools/DebugWindow/CMakeLists.txt
@@ -13,7 +13,6 @@ add_library(core_debugwindow SHARED)
 target_sources(core_debugwindow PRIVATE ${DEBUGWINDOW_SRC})
 
 target_link_libraries(core_debugwindow PRIVATE
-    core_config
     corei_always_no_pch
 )
 

--- a/Core/Tools/Launcher/CMakeLists.txt
+++ b/Core/Tools/Launcher/CMakeLists.txt
@@ -62,8 +62,6 @@ target_compile_definitions(corei_launcher INTERFACE
 
 target_link_libraries(corei_launcher INTERFACE
     comctl32
-    core_config
-    core_utility
 )
 
 if(WIN32 OR "${CMAKE_SYSTEM}" MATCHES "Windows")

--- a/Core/Tools/Launcher/DatGen/CMakeLists.txt
+++ b/Core/Tools/Launcher/DatGen/CMakeLists.txt
@@ -14,7 +14,6 @@ target_include_directories(corei_datgen INTERFACE
 )
 
 target_link_libraries(corei_datgen INTERFACE
-    core_config
 )
 
 target_sources(corei_datgen INTERFACE ${DATGEN_SRC})

--- a/Core/Tools/assetcull/CMakeLists.txt
+++ b/Core/Tools/assetcull/CMakeLists.txt
@@ -8,7 +8,6 @@ set_target_properties(core_assetcull PROPERTIES OUTPUT_NAME assetcull)
 target_sources(core_assetcull PRIVATE ${ASSETCULL_SRC})
 
 target_link_libraries(core_assetcull PRIVATE
-    core_config
     corei_always
 )
 

--- a/Core/Tools/buildVersionUpdate/CMakeLists.txt
+++ b/Core/Tools/buildVersionUpdate/CMakeLists.txt
@@ -8,7 +8,6 @@ set_target_properties(core_buildversionupdate PROPERTIES OUTPUT_NAME buildversio
 target_sources(core_buildversionupdate PRIVATE ${BUILDVERSIONUPDATE_SRC})
 
 target_link_libraries(core_buildversionupdate PRIVATE
-    core_config
     core_wwlib
     corei_always
 )

--- a/Core/Tools/mangler/CMakeLists.txt
+++ b/Core/Tools/mangler/CMakeLists.txt
@@ -67,7 +67,6 @@ target_include_directories(core_manglerlib PRIVATE
 )
 target_link_libraries(core_manglerlib PRIVATE wsock32)
 target_link_libraries(core_manglerlib PUBLIC
-    core_config
     corei_always
 )
 

--- a/Core/Tools/matchbot/CMakeLists.txt
+++ b/Core/Tools/matchbot/CMakeLists.txt
@@ -71,9 +71,8 @@ target_include_directories(core_matchbot PRIVATE
 )
 
 target_link_libraries(core_matchbot PRIVATE
-    gamespy::gamespy
-    core_config
     corei_always
+    gamespy::gamespy
     stlport
 )
 

--- a/Core/Tools/textureCompress/CMakeLists.txt
+++ b/Core/Tools/textureCompress/CMakeLists.txt
@@ -9,7 +9,6 @@ set_target_properties(core_texturecompress PROPERTIES OUTPUT_NAME texturecompres
 target_sources(core_texturecompress PRIVATE ${TEXTURECOMPRESS_SRC})
 
 target_link_libraries(core_texturecompress PRIVATE
-    core_config
     core_wwlib
     corei_always
 )

--- a/Core/Tools/timingTest/CMakeLists.txt
+++ b/Core/Tools/timingTest/CMakeLists.txt
@@ -10,7 +10,6 @@ set_target_properties(core_timingtest PROPERTIES OUTPUT_NAME timingtest)
 target_sources(core_timingtest PRIVATE ${TIMINGTEST_SRC})
 
 target_link_libraries(core_timingtest PRIVATE
-    core_config
     corei_always
     winmm
 )

--- a/Core/Tools/versionUpdate/CMakeLists.txt
+++ b/Core/Tools/versionUpdate/CMakeLists.txt
@@ -8,7 +8,6 @@ set_target_properties(core_versionupdate PROPERTIES OUTPUT_NAME versionupdate)
 target_sources(core_versionupdate PRIVATE ${VERSIONUPDATE_SRC})
 
 target_link_libraries(core_versionupdate PRIVATE
-    core_config
     core_wwlib
     corei_always
 )

--- a/Core/Tools/wolSetup/CMakeLists.txt
+++ b/Core/Tools/wolSetup/CMakeLists.txt
@@ -21,7 +21,6 @@ set_target_properties(core_wolsetup PROPERTIES OUTPUT_NAME wolsetup)
 target_sources(core_wolsetup PRIVATE ${WOLSETUP_SRC})
 
 target_link_libraries(core_wolsetup PRIVATE
-    core_config
     corei_always
     Version
 )

--- a/Generals/Code/Libraries/Source/WWVegas/CMakeLists.txt
+++ b/Generals/Code/Libraries/Source/WWVegas/CMakeLists.txt
@@ -2,8 +2,6 @@
 add_library(g_wwcommon INTERFACE)
 
 target_link_libraries(g_wwcommon INTERFACE
-    core_config
-    core_utility
     core_wwcommon
     d3d8lib
     milesstub

--- a/Generals/Code/Tools/ParticleEditor/CMakeLists.txt
+++ b/Generals/Code/Tools/ParticleEditor/CMakeLists.txt
@@ -37,7 +37,6 @@ target_include_directories(g_particleeditor PRIVATE
 )
 
 target_link_libraries(g_particleeditor PRIVATE
-    core_config
     corei_libraries_source_wwvegas
     corei_libraries_source_wwvegas_wwlib
     gi_always_no_pch

--- a/Generals/Code/Tools/W3DView/CMakeLists.txt
+++ b/Generals/Code/Tools/W3DView/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_executable(g_w3dview WIN32)
 
 target_link_libraries(g_w3dview PRIVATE
-    core_config
     core_wwstub # avoid linking GameEngine
     corei_w3dview # this interface gets the source files for the tool
     d3d8

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/CMakeLists.txt
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/CMakeLists.txt
@@ -2,8 +2,6 @@
 add_library(z_wwcommon INTERFACE)
 
 target_link_libraries(z_wwcommon INTERFACE
-    core_config
-    core_utility
     core_wwcommon
     d3d8lib
     milesstub

--- a/GeneralsMD/Code/Tools/ParticleEditor/CMakeLists.txt
+++ b/GeneralsMD/Code/Tools/ParticleEditor/CMakeLists.txt
@@ -37,7 +37,6 @@ target_include_directories(z_particleeditor PRIVATE
 )
 
 target_link_libraries(z_particleeditor PRIVATE
-    core_config
     core_debug
     core_profile
     corei_libraries_source_wwvegas

--- a/GeneralsMD/Code/Tools/W3DView/CMakeLists.txt
+++ b/GeneralsMD/Code/Tools/W3DView/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_executable(z_w3dview WIN32)
 
 target_link_libraries(z_w3dview PRIVATE
-    core_config
     core_wwstub # avoid linking GameEngine
     corei_w3dview # this interface gets the source files for the tool
     d3d8

--- a/GeneralsMD/Code/Tools/wdump/CMakeLists.txt
+++ b/GeneralsMD/Code/Tools/wdump/CMakeLists.txt
@@ -18,7 +18,6 @@ set_target_properties(z_wdump PROPERTIES OUTPUT_NAME wdump)
 target_sources(z_wdump PRIVATE ${WDUMP_SRC})
 
 target_link_libraries(z_wdump PRIVATE
-    core_config
     core_wwstub # avoid linking GameEngine
     imm32
     vfw32


### PR DESCRIPTION
This change moves library linkage `core_config` into `corei_always` to simplify the setup. Redundant linkages are removed.