### PR TITLE
fix(typos): Fix spelling errors in debug/diagnostic strings

### DIFF
--- a/Core/Libraries/Source/WWVegas/WW3D2/matinfo.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/matinfo.cpp
@@ -190,7 +190,7 @@ TextureClass * MaterialRemapperClass::Remap_Texture(TextureClass * src)
 			return TextureRemaps[i].Dest;
 		}
 	}
-	WWASSERT(0); // uh-oh didn't find the texture, what happend???
+	WWASSERT(0); // uh-oh didn't find the texture, what happened???
 	return NULL;
 }
 
@@ -205,7 +205,7 @@ VertexMaterialClass * MaterialRemapperClass::Remap_Vertex_Material(VertexMateria
 			return VertexMaterialRemaps[i].Dest;
 		}
 	}
-	WWASSERT(0); // uh-oh didn't find the material, what happend???
+	WWASSERT(0); // uh-oh didn't find the material, what happened???
 	return NULL;
 }
 

--- a/Core/Tools/ImagePacker/Source/ImagePacker.cpp
+++ b/Core/Tools/ImagePacker/Source/ImagePacker.cpp
@@ -809,7 +809,7 @@ void ImagePacker::addImage( char *path )
 	if( info->m_path == NULL )
 	{
 
-		MessageBox( NULL, "Unable to allcoate image path info", "Error",
+		MessageBox( NULL, "Unable to allocate image path info", "Error",
 								MB_OK | MB_ICONERROR );
 		delete info;
 		return;

--- a/Generals/Code/GameEngine/Source/Common/INI/INITerrainBridge.cpp
+++ b/Generals/Code/GameEngine/Source/Common/INI/INITerrainBridge.cpp
@@ -62,7 +62,7 @@ void INI::parseTerrainBridgeDefinition( INI* ini )
 	if( bridge == NULL )
 		bridge = TheTerrainRoads->newBridge( name );
 
-	DEBUG_ASSERTCRASH( bridge, ("Unable to allcoate bridge '%s'", name.str()) );
+	DEBUG_ASSERTCRASH( bridge, ("Unable to allocate bridge '%s'", name.str()) );
 
 	// parse the ini definition
 	ini->initFromINI( bridge, bridge->getBridgeFieldParse() );

--- a/Generals/Code/GameEngine/Source/Common/System/SaveGame/GameStateMap.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/SaveGame/GameStateMap.cpp
@@ -102,7 +102,7 @@ static void embedPristineMap( AsciiString map, Xfer *xfer )
 	if( file->read( buffer, fileSize ) != fileSize )
 	{
 
-		DEBUG_CRASH(( "embeddPristineMap - Error reading from file '%s'", map.str() ));
+		DEBUG_CRASH(( "embedPristineMap - Error reading from file '%s'", map.str() ));
 		throw SC_INVALID_DATA;
 
 	}
@@ -111,7 +111,7 @@ static void embedPristineMap( AsciiString map, Xfer *xfer )
 	file->close();
 
 	// write the contents to the save file
-	DEBUG_ASSERTCRASH( xfer->getXferMode() == XFER_SAVE, ("embedPristineMap - Unsupposed xfer mode") );
+	DEBUG_ASSERTCRASH( xfer->getXferMode() == XFER_SAVE, ("embedPristineMap - Unsupported xfer mode") );
 	xfer->beginBlock();
 	xfer->xferUser( buffer, fileSize );
 	xfer->endBlock();

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarStructureInventory.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarStructureInventory.cpp
@@ -213,7 +213,7 @@ void ControlBar::updateContextStructureInventory( void )
 	// about we need to repopulate the buttons of the interface
 	//
 	ContainModuleInterface *contain = source->getContain();
-	DEBUG_ASSERTCRASH( contain, ("No contain module defined for object in the iventory bar") );
+	DEBUG_ASSERTCRASH( contain, ("No contain module defined for object in the inventory bar") );
 	if (!contain)
 		return;
 

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -1330,7 +1330,7 @@ static void saveOptions( void )
 	if(val > 0)
 	{
 		TheWritableGlobalData->m_keyboardScrollFactor = val/100.0f;
-		DEBUG_LOG(("Scroll Spped val %d, keyboard scroll factor %f", val, TheGlobalData->m_keyboardScrollFactor));
+		DEBUG_LOG(("Scroll Speed val %d, keyboard scroll factor %f", val, TheGlobalData->m_keyboardScrollFactor));
 		AsciiString prefString;
 		prefString.format("%d", val);
 		(*pref)["ScrollFactor"] = prefString;

--- a/Generals/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
@@ -302,10 +302,10 @@ void PolygonTrigger::removePolygonTrigger(PolygonTrigger *pTrigger)
 	DEBUG_ASSERTCRASH(pTrig, ("Attempting to remove a polygon not in the list."));
 	if (pTrig) {
 		if (pPrev) {
-			DEBUG_ASSERTCRASH(pTrigger==pPrev->m_nextPolygonTrigger, ("Logic errror.  jba."));
+			DEBUG_ASSERTCRASH(pTrigger==pPrev->m_nextPolygonTrigger, ("Logic error.  jba."));
 			pPrev->m_nextPolygonTrigger = pTrig->m_nextPolygonTrigger;
 		} else {
-			DEBUG_ASSERTCRASH(pTrigger==ThePolygonTriggerListPtr, ("Logic errror.  jba."));
+			DEBUG_ASSERTCRASH(pTrigger==ThePolygonTriggerListPtr, ("Logic error.  jba."));
 			ThePolygonTriggerListPtr = pTrig->m_nextPolygonTrigger;
 		}
 	}

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/MobNexusContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/MobNexusContain.cpp
@@ -206,7 +206,7 @@ void MobNexusContain::onContaining( Object *rider )
 
 	Int mobNexusSlotCount = rider->getTransportSlotCount();
 
-	DEBUG_ASSERTCRASH(mobNexusSlotCount > 0, ("Hmm, this object isnt MobNexusable"));
+	DEBUG_ASSERTCRASH(mobNexusSlotCount > 0, ("Hmm, this object isn't MobNexusable"));
 	m_extraSlotsInUse += mobNexusSlotCount - 1;
 	DEBUG_ASSERTCRASH(m_extraSlotsInUse >= 0 && m_extraSlotsInUse + getContainCount() <= getContainMax(), ("Hmm, bad slot count"));
 
@@ -277,7 +277,7 @@ void MobNexusContain::onRemoving( Object *rider )
 		scatterToNearbyPosition(rider);
 
 	Int mobNexusSlotCount = rider->getTransportSlotCount();
-	DEBUG_ASSERTCRASH(mobNexusSlotCount > 0, ("This object isnt MobNexusable"));
+	DEBUG_ASSERTCRASH(mobNexusSlotCount > 0, ("This object isn't MobNexusable"));
 	m_extraSlotsInUse -= mobNexusSlotCount - 1;
 	DEBUG_ASSERTCRASH(m_extraSlotsInUse >= 0 && m_extraSlotsInUse + getContainCount() <= getContainMax(), ("Bad slot count, MobNexus"));
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
@@ -212,7 +212,7 @@ void TransportContain::onContaining( Object *rider )
 
 	Int transportSlotCount = rider->getTransportSlotCount();
 
-	DEBUG_ASSERTCRASH(transportSlotCount > 0, ("Hmm, this object isnt transportable"));
+	DEBUG_ASSERTCRASH(transportSlotCount > 0, ("Hmm, this object isn't transportable"));
 	m_extraSlotsInUse += transportSlotCount - 1;
 	DEBUG_ASSERTCRASH(m_extraSlotsInUse >= 0 && m_extraSlotsInUse + getContainCount() <= getContainMax(), ("Hmm, bad slot count"));
 
@@ -280,7 +280,7 @@ void TransportContain::onRemoving( Object *rider )
 	}
 
 	Int transportSlotCount = rider->getTransportSlotCount();
-	DEBUG_ASSERTCRASH(transportSlotCount > 0, ("Hmm, this object isnt transportable"));
+	DEBUG_ASSERTCRASH(transportSlotCount > 0, ("Hmm, this object isn't transportable"));
 	m_extraSlotsInUse -= transportSlotCount - 1;
 	DEBUG_ASSERTCRASH(m_extraSlotsInUse >= 0 && m_extraSlotsInUse + getContainCount() <= getContainMax(), ("Hmm, bad slot count"));
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -2465,7 +2465,7 @@ void Object::setLayer(PathfindLayerEnum layer)
 		DEBUG_LOG(("Changing layer from %d to %d", m_layer, layer));
 		if (m_layer != LAYER_GROUND) {
 			if (TheTerrainLogic->objectInteractsWithBridgeLayer(this, m_layer)) {
-				DEBUG_CRASH(("Probably shouldn't be chaging layer. jba."));
+				DEBUG_CRASH(("Probably shouldn't be changing layer. jba."));
 			}
 		}
 #endif

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -4149,7 +4149,7 @@ UnsignedInt AIUpdateInterface::getMoodMatrixActionAdjustment( MoodMatrixAction a
 {
 	// Angry Mob Members (but not Nexi) are never subject to moods. In particular,
 	// they must never, ever, ever convert a move into an attack move, or Bad Things
-	// will happend, since MobMemberSlavedUpdate expects a moveto to remain a moveto.
+	// will happened, since MobMemberSlavedUpdate expects a moveto to remain a moveto.
 	// Mark L sez that members do not, in fact, need any mood adjustment whatsoever,
 	// since the mood of the nexus wants to control all this anyway. Unfortunately, there
 	// is no KINDOF_MOB_MEMBER, and we don't want to add one at the eleventh hour...

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/Scripts.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/Scripts.cpp
@@ -523,7 +523,7 @@ Bool ScriptList::ParseScriptsDataChunk(DataChunkInput &file, DataChunkInfo *info
 {
 	Int i;
 	file.registerParser( "ScriptList", info->label, ScriptList::ParseScriptListDataChunk );
-	DEBUG_ASSERTCRASH(s_numInReadList==0, ("Leftover scripts floating aroung."));
+	DEBUG_ASSERTCRASH(s_numInReadList==0, ("Leftover scripts floating around."));
 	for (i=0; i<s_numInReadList; i++) {
 		deleteInstance(s_readLists[i]);
 		s_readLists[i] = NULL;

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -100,7 +100,7 @@ static int thePlanSubjectCount = 0;
 static void doMoveTo( Object *obj, const Coord3D *pos )
 {
 	AIUpdateInterface *ai = obj->getAIUpdateInterface();
-	DEBUG_ASSERTCRASH(ai, ("Attemped doMoveTo() on an Object with no AI"));
+	DEBUG_ASSERTCRASH(ai, ("Attempted doMoveTo() on an Object with no AI"));
 	if (ai)
 	{
 		if (theBuildPlan)
@@ -1558,7 +1558,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Player *player = ThePlayerList->getNthPlayer(msg->getPlayerIndex());
 
 			if (player == NULL) {
-				DEBUG_CRASH(("GameLogicDispatch - MSG_CREATE_SELECTED_GROUP had an invalid player nubmer"));
+				DEBUG_CRASH(("GameLogicDispatch - MSG_CREATE_SELECTED_GROUP had an invalid player number"));
 				break;
 			}
 
@@ -1584,7 +1584,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Player *player = ThePlayerList->getNthPlayer(msg->getPlayerIndex());
 
 			if (player == NULL) {
-				DEBUG_CRASH(("GameLogicDispatch - MSG_CREATE_SELECTED_GROUP had an invalid player nubmer"));
+				DEBUG_CRASH(("GameLogicDispatch - MSG_CREATE_SELECTED_GROUP had an invalid player number"));
 				break;
 			}
 

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp
@@ -3146,7 +3146,7 @@ Bool W3DVolumetricShadow::allocateSilhouette(Int meshIndex, Int numVertices )
 	if( m_silhouetteIndex[meshIndex] == NULL )
 	{
 
-//		DBGPRINTF(( "Unable to allcoate silhouette storage '%d'\n", numEntries ));
+//		DBGPRINTF(( "Unable to allocate silhouette storage '%d'\n", numEntries ));
 		assert( 0 );
 		return FALSE;
 

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayStringManager.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayStringManager.cpp
@@ -116,7 +116,7 @@ DisplayString *W3DDisplayStringManager::newDisplayString( void )
 	if( newString == NULL )
 	{
 
-		DEBUG_LOG(( "newDisplayString: Could not allcoate new W3D display string" ));
+		DEBUG_LOG(( "newDisplayString: Could not allocate new W3D display string" ));
 		assert( 0 );
 		return NULL;
 

--- a/Generals/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIKeyboard.cpp
+++ b/Generals/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIKeyboard.cpp
@@ -139,7 +139,7 @@ void DirectInputKeyboard::openKeyboard( void )
 	if( FAILED( hr ) )
 	{
 
-		DEBUG_LOG(( "ERROR - openKeyboard: Unabled to create keyboard device" ));
+		DEBUG_LOG(( "ERROR - openKeyboard: Unable to create keyboard device" ));
 		assert( 0 );
 		closeKeyboard();
 		return;
@@ -151,7 +151,7 @@ void DirectInputKeyboard::openKeyboard( void )
 	if( FAILED( hr ) )
 	{
 
-		DEBUG_LOG(( "ERROR - openKeyboard: Unabled to set data format for keyboard" ));
+		DEBUG_LOG(( "ERROR - openKeyboard: Unable to set data format for keyboard" ));
 		assert( 0 );
 		closeKeyboard();
 		return;
@@ -169,7 +169,7 @@ void DirectInputKeyboard::openKeyboard( void )
 	if( FAILED( hr ) )
 	{
 
-		DEBUG_LOG(( "ERROR - openKeyboard: Unabled to set cooperative level" ));
+		DEBUG_LOG(( "ERROR - openKeyboard: Unable to set cooperative level" ));
 		assert( 0 );
 		closeKeyboard();
 		return;

--- a/Generals/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIMouse.cpp
+++ b/Generals/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIMouse.cpp
@@ -54,7 +54,7 @@ void DirectInputMouse::openMouse( void )
 	if( FAILED( hr ) )
 	{
 
-		DEBUG_LOG(( "ERROR - openMouse: Unabled to create direct input interface" ));
+		DEBUG_LOG(( "ERROR - openMouse: Unable to create direct input interface" ));
 		assert( 0 );
 		closeMouse();
 		return;
@@ -80,7 +80,7 @@ void DirectInputMouse::openMouse( void )
 	if( FAILED( hr ) )
 	{
 
-		DEBUG_LOG(( "ERROR - openMouse: Unabled to set mouse data format" ));
+		DEBUG_LOG(( "ERROR - openMouse: Unable to set mouse data format" ));
 		assert( 0 );
 		closeMouse();
 		return;
@@ -94,7 +94,7 @@ void DirectInputMouse::openMouse( void )
 	if( FAILED( hr ) )
 	{
 
-		DEBUG_LOG(( "ERROR - openMouse: Unabled to set coop level" ));
+		DEBUG_LOG(( "ERROR - openMouse: Unable to set coop level" ));
 		assert( 0 );
 		closeMouse();
 		return;
@@ -112,7 +112,7 @@ void DirectInputMouse::openMouse( void )
 	if( FAILED( hr ) )
 	{
 
-		DEBUG_LOG(( "ERROR - openMouse: Unabled to set buffer property" ));
+		DEBUG_LOG(( "ERROR - openMouse: Unable to set buffer property" ));
 		assert( 0 );
 		closeMouse();
 		return;
@@ -124,7 +124,7 @@ void DirectInputMouse::openMouse( void )
 	if( FAILED( hr ) )
 	{
 
-		DEBUG_LOG(( "ERROR - openMouse: Unabled to acquire mouse" ));
+		DEBUG_LOG(( "ERROR - openMouse: Unable to acquire mouse" ));
 		assert( 0 );
 		closeMouse();
 		return;

--- a/Generals/Code/Tools/GUIEdit/Source/GUIEdit.cpp
+++ b/Generals/Code/Tools/GUIEdit/Source/GUIEdit.cpp
@@ -4058,7 +4058,7 @@ void GUIEdit::bringSelectedToTop( void )
 	if( snapshot == NULL )
 	{
 
-		DEBUG_LOG(( "bringSelectedToTop: Unabled to allocate selectList" ));
+		DEBUG_LOG(( "bringSelectedToTop: Unable to allocate selectList" ));
 		assert( 0 );
 		return;
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/INI/INITerrainBridge.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/INI/INITerrainBridge.cpp
@@ -62,7 +62,7 @@ void INI::parseTerrainBridgeDefinition( INI* ini )
 	if( bridge == NULL )
 		bridge = TheTerrainRoads->newBridge( name );
 
-	DEBUG_ASSERTCRASH( bridge, ("Unable to allcoate bridge '%s'", name.str()) );
+	DEBUG_ASSERTCRASH( bridge, ("Unable to allocate bridge '%s'", name.str()) );
 
 	// parse the ini definition
 	ini->initFromINI( bridge, bridge->getBridgeFieldParse() );

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/SaveGame/GameStateMap.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/SaveGame/GameStateMap.cpp
@@ -104,7 +104,7 @@ static void embedPristineMap( AsciiString map, Xfer *xfer )
 	if( file->read( buffer, fileSize ) != fileSize )
 	{
 
-		DEBUG_CRASH(( "embeddPristineMap - Error reading from file '%s'", map.str() ));
+		DEBUG_CRASH(( "embedPristineMap - Error reading from file '%s'", map.str() ));
 		throw SC_INVALID_DATA;
 
 	}
@@ -113,7 +113,7 @@ static void embedPristineMap( AsciiString map, Xfer *xfer )
 	file->close();
 
 	// write the contents to the save file
-	DEBUG_ASSERTCRASH( xfer->getXferMode() == XFER_SAVE, ("embedPristineMap - Unsupposed xfer mode") );
+	DEBUG_ASSERTCRASH( xfer->getXferMode() == XFER_SAVE, ("embedPristineMap - Unsupported xfer mode") );
 	xfer->beginBlock();
 	xfer->xferUser( buffer, fileSize );
 	xfer->endBlock();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarStructureInventory.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarStructureInventory.cpp
@@ -223,7 +223,7 @@ void ControlBar::updateContextStructureInventory( void )
 	// about we need to repopulate the buttons of the interface
 	//
 	ContainModuleInterface *contain = source->getContain();
-	DEBUG_ASSERTCRASH( contain, ("No contain module defined for object in the iventory bar") );
+	DEBUG_ASSERTCRASH( contain, ("No contain module defined for object in the inventory bar") );
 	if (!contain)
 		return;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -1390,7 +1390,7 @@ static void saveOptions( void )
 	if(val > 0)
 	{
 		TheWritableGlobalData->m_keyboardScrollFactor = val/100.0f;
-		DEBUG_LOG(("Scroll Spped val %d, keyboard scroll factor %f", val, TheGlobalData->m_keyboardScrollFactor));
+		DEBUG_LOG(("Scroll Speed val %d, keyboard scroll factor %f", val, TheGlobalData->m_keyboardScrollFactor));
 		AsciiString prefString;
 		prefString.format("%d", val);
 		(*pref)["ScrollFactor"] = prefString;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
@@ -318,10 +318,10 @@ void PolygonTrigger::removePolygonTrigger(PolygonTrigger *pTrigger)
 	DEBUG_ASSERTCRASH(pTrig, ("Attempting to remove a polygon not in the list."));
 	if (pTrig) {
 		if (pPrev) {
-			DEBUG_ASSERTCRASH(pTrigger==pPrev->m_nextPolygonTrigger, ("Logic errror.  jba."));
+			DEBUG_ASSERTCRASH(pTrigger==pPrev->m_nextPolygonTrigger, ("Logic error.  jba."));
 			pPrev->m_nextPolygonTrigger = pTrig->m_nextPolygonTrigger;
 		} else {
-			DEBUG_ASSERTCRASH(pTrigger==ThePolygonTriggerListPtr, ("Logic errror.  jba."));
+			DEBUG_ASSERTCRASH(pTrigger==ThePolygonTriggerListPtr, ("Logic error.  jba."));
 			ThePolygonTriggerListPtr = pTrig->m_nextPolygonTrigger;
 		}
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/MobNexusContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/MobNexusContain.cpp
@@ -206,7 +206,7 @@ void MobNexusContain::onContaining( Object *rider, Bool wasSelected )
 
 	Int mobNexusSlotCount = rider->getTransportSlotCount();
 
-	DEBUG_ASSERTCRASH(mobNexusSlotCount > 0, ("Hmm, this object isnt MobNexusable"));
+	DEBUG_ASSERTCRASH(mobNexusSlotCount > 0, ("Hmm, this object isn't MobNexusable"));
 	m_extraSlotsInUse += mobNexusSlotCount - 1;
 	DEBUG_ASSERTCRASH(m_extraSlotsInUse >= 0 && m_extraSlotsInUse + getContainCount() <= getContainMax(), ("Hmm, bad slot count"));
 
@@ -277,7 +277,7 @@ void MobNexusContain::onRemoving( Object *rider )
 		scatterToNearbyPosition(rider);
 
 	Int mobNexusSlotCount = rider->getTransportSlotCount();
-	DEBUG_ASSERTCRASH(mobNexusSlotCount > 0, ("This object isnt MobNexusable"));
+	DEBUG_ASSERTCRASH(mobNexusSlotCount > 0, ("This object isn't MobNexusable"));
 	m_extraSlotsInUse -= mobNexusSlotCount - 1;
 	DEBUG_ASSERTCRASH(m_extraSlotsInUse >= 0 && m_extraSlotsInUse + getContainCount() <= getContainMax(), ("Bad slot count, MobNexus"));
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
@@ -284,7 +284,7 @@ void TransportContain::onContaining( Object *rider, Bool wasSelected )
 
 	Int transportSlotCount = rider->getTransportSlotCount();
 
-	DEBUG_ASSERTCRASH(transportSlotCount > 0, ("Hmm, this object isnt transportable"));
+	DEBUG_ASSERTCRASH(transportSlotCount > 0, ("Hmm, this object isn't transportable"));
 	m_extraSlotsInUse += transportSlotCount - 1;
 	DEBUG_ASSERTCRASH(m_extraSlotsInUse >= 0 && m_extraSlotsInUse + getContainCount() <= getContainMax(), ("Hmm, bad slot count"));
 
@@ -369,7 +369,7 @@ void TransportContain::onRemoving( Object *rider )
 	}
 
 	Int transportSlotCount = rider->getTransportSlotCount();
-	DEBUG_ASSERTCRASH(transportSlotCount > 0, ("Hmm, this object isnt transportable"));
+	DEBUG_ASSERTCRASH(transportSlotCount > 0, ("Hmm, this object isn't transportable"));
 	m_extraSlotsInUse -= transportSlotCount - 1;
 	DEBUG_ASSERTCRASH(m_extraSlotsInUse >= 0 && m_extraSlotsInUse + getContainCount() <= getContainMax(), ("Hmm, bad slot count"));
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -2759,7 +2759,7 @@ void Object::setLayer(PathfindLayerEnum layer)
 		DEBUG_LOG(("Changing layer from %d to %d", m_layer, layer));
 		if (m_layer != LAYER_GROUND) {
 			if (TheTerrainLogic->objectInteractsWithBridgeLayer(this, m_layer)) {
-				DEBUG_CRASH(("Probably shouldn't be chaging layer. jba."));
+				DEBUG_CRASH(("Probably shouldn't be changing layer. jba."));
 			}
 		}
 #endif

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -4378,7 +4378,7 @@ UnsignedInt AIUpdateInterface::getMoodMatrixActionAdjustment( MoodMatrixAction a
 {
 	// Angry Mob Members (but not Nexi) are never subject to moods. In particular,
 	// they must never, ever, ever convert a move into an attack move, or Bad Things
-	// will happend, since MobMemberSlavedUpdate expects a moveto to remain a moveto.
+	// will happened, since MobMemberSlavedUpdate expects a moveto to remain a moveto.
 	// Mark L sez that members do not, in fact, need any mood adjustment whatsoever,
 	// since the mood of the nexus wants to control all this anyway. Unfortunately, there
 	// is no KINDOF_MOB_MEMBER, and we don't want to add one at the eleventh hour...

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/Scripts.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/Scripts.cpp
@@ -526,7 +526,7 @@ Bool ScriptList::ParseScriptsDataChunk(DataChunkInput &file, DataChunkInfo *info
 {
 	Int i;
 	file.registerParser( "ScriptList", info->label, ScriptList::ParseScriptListDataChunk );
-	DEBUG_ASSERTCRASH(s_numInReadList==0, ("Leftover scripts floating aroung."));
+	DEBUG_ASSERTCRASH(s_numInReadList==0, ("Leftover scripts floating around."));
 	for (i=0; i<s_numInReadList; i++) {
 		deleteInstance(s_readLists[i]);
 		s_readLists[i] = NULL;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -101,7 +101,7 @@ static int thePlanSubjectCount = 0;
 static void doMoveTo( Object *obj, const Coord3D *pos )
 {
 	AIUpdateInterface *ai = obj->getAIUpdateInterface();
-	DEBUG_ASSERTCRASH(ai, ("Attemped doMoveTo() on an Object with no AI"));
+	DEBUG_ASSERTCRASH(ai, ("Attempted doMoveTo() on an Object with no AI"));
 	if (ai)
 	{
 		if (theBuildPlan)
@@ -1586,7 +1586,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Player *player = ThePlayerList->getNthPlayer(msg->getPlayerIndex());
 
 			if (player == NULL) {
-				DEBUG_CRASH(("GameLogicDispatch - MSG_CREATE_SELECTED_GROUP had an invalid player nubmer"));
+				DEBUG_CRASH(("GameLogicDispatch - MSG_CREATE_SELECTED_GROUP had an invalid player number"));
 				break;
 			}
 
@@ -1612,7 +1612,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Player *player = ThePlayerList->getNthPlayer(msg->getPlayerIndex());
 
 			if (player == NULL) {
-				DEBUG_CRASH(("GameLogicDispatch - MSG_CREATE_SELECTED_GROUP had an invalid player nubmer"));
+				DEBUG_CRASH(("GameLogicDispatch - MSG_CREATE_SELECTED_GROUP had an invalid player number"));
 				break;
 			}
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp
@@ -3290,7 +3290,7 @@ Bool W3DVolumetricShadow::allocateSilhouette(Int meshIndex, Int numVertices )
 	if( m_silhouetteIndex[meshIndex] == NULL )
 	{
 
-//		DBGPRINTF(( "Unable to allcoate silhouette storage '%d'\n", numEntries ));
+//		DBGPRINTF(( "Unable to allocate silhouette storage '%d'\n", numEntries ));
 		assert( 0 );
 		return FALSE;
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayStringManager.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayStringManager.cpp
@@ -116,7 +116,7 @@ DisplayString *W3DDisplayStringManager::newDisplayString( void )
 	if( newString == NULL )
 	{
 
-		DEBUG_LOG(( "newDisplayString: Could not allcoate new W3D display string" ));
+		DEBUG_LOG(( "newDisplayString: Could not allocate new W3D display string" ));
 		assert( 0 );
 		return NULL;
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIKeyboard.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIKeyboard.cpp
@@ -139,7 +139,7 @@ void DirectInputKeyboard::openKeyboard( void )
 	if( FAILED( hr ) )
 	{
 
-		DEBUG_LOG(( "ERROR - openKeyboard: Unabled to create keyboard device" ));
+		DEBUG_LOG(( "ERROR - openKeyboard: Unable to create keyboard device" ));
 		assert( 0 );
 		closeKeyboard();
 		return;
@@ -151,7 +151,7 @@ void DirectInputKeyboard::openKeyboard( void )
 	if( FAILED( hr ) )
 	{
 
-		DEBUG_LOG(( "ERROR - openKeyboard: Unabled to set data format for keyboard" ));
+		DEBUG_LOG(( "ERROR - openKeyboard: Unable to set data format for keyboard" ));
 		assert( 0 );
 		closeKeyboard();
 		return;
@@ -169,7 +169,7 @@ void DirectInputKeyboard::openKeyboard( void )
 	if( FAILED( hr ) )
 	{
 
-		DEBUG_LOG(( "ERROR - openKeyboard: Unabled to set cooperative level" ));
+		DEBUG_LOG(( "ERROR - openKeyboard: Unable to set cooperative level" ));
 		assert( 0 );
 		closeKeyboard();
 		return;

--- a/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIMouse.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIMouse.cpp
@@ -54,7 +54,7 @@ void DirectInputMouse::openMouse( void )
 	if( FAILED( hr ) )
 	{
 
-		DEBUG_LOG(( "ERROR - openMouse: Unabled to create direct input interface" ));
+		DEBUG_LOG(( "ERROR - openMouse: Unable to create direct input interface" ));
 		assert( 0 );
 		closeMouse();
 		return;
@@ -80,7 +80,7 @@ void DirectInputMouse::openMouse( void )
 	if( FAILED( hr ) )
 	{
 
-		DEBUG_LOG(( "ERROR - openMouse: Unabled to set mouse data format" ));
+		DEBUG_LOG(( "ERROR - openMouse: Unable to set mouse data format" ));
 		assert( 0 );
 		closeMouse();
 		return;
@@ -94,7 +94,7 @@ void DirectInputMouse::openMouse( void )
 	if( FAILED( hr ) )
 	{
 
-		DEBUG_LOG(( "ERROR - openMouse: Unabled to set coop level" ));
+		DEBUG_LOG(( "ERROR - openMouse: Unable to set coop level" ));
 		assert( 0 );
 		closeMouse();
 		return;
@@ -112,7 +112,7 @@ void DirectInputMouse::openMouse( void )
 	if( FAILED( hr ) )
 	{
 
-		DEBUG_LOG(( "ERROR - openMouse: Unabled to set buffer property" ));
+		DEBUG_LOG(( "ERROR - openMouse: Unable to set buffer property" ));
 		assert( 0 );
 		closeMouse();
 		return;
@@ -124,7 +124,7 @@ void DirectInputMouse::openMouse( void )
 	if( FAILED( hr ) )
 	{
 
-		DEBUG_LOG(( "ERROR - openMouse: Unabled to acquire mouse" ));
+		DEBUG_LOG(( "ERROR - openMouse: Unable to acquire mouse" ));
 		assert( 0 );
 		closeMouse();
 		return;

--- a/GeneralsMD/Code/Tools/GUIEdit/Source/GUIEdit.cpp
+++ b/GeneralsMD/Code/Tools/GUIEdit/Source/GUIEdit.cpp
@@ -4058,7 +4058,7 @@ void GUIEdit::bringSelectedToTop( void )
 	if( snapshot == NULL )
 	{
 
-		DEBUG_LOG(( "bringSelectedToTop: Unabled to allocate selectList" ));
+		DEBUG_LOG(( "bringSelectedToTop: Unable to allocate selectList" ));
 		assert( 0 );
 		return;
 


### PR DESCRIPTION
## Summary
  - Fix spelling errors in debug/diagnostic string literals
  - Affects DEBUG_LOG, DEBUG_ASSERTCRASH, DEBUG_CRASH, WWASSERT messages
  - No user-visible changes - debug output only

## Example fixes
  - `"Unable to allcoate"` → `"Unable to allocate"`
  - `"Unsupposed xfer mode"` → `"Unsupported xfer mode"`
  - `"this object isnt"` → `"this object isn't"`
  - `"invalid player nubmer"` → `"invalid player number"`
  - `"Logic errror"` → `"Logic error"`