### PR TITLE
bugfix: Fix spelling errors in debug/diagnostic strings

### DIFF
--- a/Core/Tools/ImagePacker/Source/ImagePacker.cpp
+++ b/Core/Tools/ImagePacker/Source/ImagePacker.cpp
@@ -809,7 +809,7 @@ void ImagePacker::addImage( char *path )
 	if( info->m_path == nullptr )
 	{
 
-		MessageBox( nullptr, "Unable to allcoate image path info", "Error",
+		MessageBox( nullptr, "Unable to allocate image path info", "Error",
 								MB_OK | MB_ICONERROR );
 		delete info;
 		return;

--- a/Generals/Code/GameEngine/Source/Common/INI/INITerrainBridge.cpp
+++ b/Generals/Code/GameEngine/Source/Common/INI/INITerrainBridge.cpp
@@ -62,7 +62,7 @@ void INI::parseTerrainBridgeDefinition( INI* ini )
 	if( bridge == nullptr )
 		bridge = TheTerrainRoads->newBridge( name );
 
-	DEBUG_ASSERTCRASH( bridge, ("Unable to allcoate bridge '%s'", name.str()) );
+	DEBUG_ASSERTCRASH( bridge, ("Unable to allocate bridge '%s'", name.str()) );
 
 	// parse the ini definition
 	ini->initFromINI( bridge, bridge->getBridgeFieldParse() );

--- a/Generals/Code/GameEngine/Source/Common/System/SaveGame/GameStateMap.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/SaveGame/GameStateMap.cpp
@@ -111,7 +111,7 @@ static void embedPristineMap( AsciiString map, Xfer *xfer )
 	file->close();
 
 	// write the contents to the save file
-	DEBUG_ASSERTCRASH( xfer->getXferMode() == XFER_SAVE, ("embedPristineMap - Unsupposed xfer mode") );
+	DEBUG_ASSERTCRASH( xfer->getXferMode() == XFER_SAVE, ("embedPristineMap - Unsupported xfer mode") );
 	xfer->beginBlock();
 	xfer->xferUser( buffer, fileSize );
 	xfer->endBlock();

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarStructureInventory.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarStructureInventory.cpp
@@ -213,7 +213,7 @@ void ControlBar::updateContextStructureInventory( void )
 	// about we need to repopulate the buttons of the interface
 	//
 	ContainModuleInterface *contain = source->getContain();
-	DEBUG_ASSERTCRASH( contain, ("No contain module defined for object in the iventory bar") );
+	DEBUG_ASSERTCRASH( contain, ("No contain module defined for object in the inventory bar") );
 	if (!contain)
 		return;
 

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -1330,7 +1330,7 @@ static void saveOptions( void )
 	if(val > 0)
 	{
 		TheWritableGlobalData->m_keyboardScrollFactor = val/100.0f;
-		DEBUG_LOG(("Scroll Spped val %d, keyboard scroll factor %f", val, TheGlobalData->m_keyboardScrollFactor));
+		DEBUG_LOG(("Scroll Speed val %d, keyboard scroll factor %f", val, TheGlobalData->m_keyboardScrollFactor));
 		AsciiString prefString;
 		prefString.format("%d", val);
 		(*pref)["ScrollFactor"] = prefString;

--- a/Generals/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
@@ -302,10 +302,10 @@ void PolygonTrigger::removePolygonTrigger(PolygonTrigger *pTrigger)
 	DEBUG_ASSERTCRASH(pTrig, ("Attempting to remove a polygon not in the list."));
 	if (pTrig) {
 		if (pPrev) {
-			DEBUG_ASSERTCRASH(pTrigger==pPrev->m_nextPolygonTrigger, ("Logic errror.  jba."));
+			DEBUG_ASSERTCRASH(pTrigger==pPrev->m_nextPolygonTrigger, ("Logic error.  jba."));
 			pPrev->m_nextPolygonTrigger = pTrig->m_nextPolygonTrigger;
 		} else {
-			DEBUG_ASSERTCRASH(pTrigger==ThePolygonTriggerListPtr, ("Logic errror.  jba."));
+			DEBUG_ASSERTCRASH(pTrigger==ThePolygonTriggerListPtr, ("Logic error.  jba."));
 			ThePolygonTriggerListPtr = pTrig->m_nextPolygonTrigger;
 		}
 	}

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -2465,7 +2465,7 @@ void Object::setLayer(PathfindLayerEnum layer)
 		DEBUG_LOG(("Changing layer from %d to %d", m_layer, layer));
 		if (m_layer != LAYER_GROUND) {
 			if (TheTerrainLogic->objectInteractsWithBridgeLayer(this, m_layer)) {
-				DEBUG_CRASH(("Probably shouldn't be chaging layer. jba."));
+				DEBUG_CRASH(("Probably shouldn't be changing layer. jba."));
 			}
 		}
 #endif

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/Scripts.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/Scripts.cpp
@@ -523,7 +523,7 @@ Bool ScriptList::ParseScriptsDataChunk(DataChunkInput &file, DataChunkInfo *info
 {
 	Int i;
 	file.registerParser( "ScriptList", info->label, ScriptList::ParseScriptListDataChunk );
-	DEBUG_ASSERTCRASH(s_numInReadList==0, ("Leftover scripts floating aroung."));
+	DEBUG_ASSERTCRASH(s_numInReadList==0, ("Leftover scripts floating around."));
 	for (i=0; i<s_numInReadList; i++) {
 		deleteInstance(s_readLists[i]);
 		s_readLists[i] = nullptr;

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -100,7 +100,7 @@ static int thePlanSubjectCount = 0;
 static void doMoveTo( Object *obj, const Coord3D *pos )
 {
 	AIUpdateInterface *ai = obj->getAIUpdateInterface();
-	DEBUG_ASSERTCRASH(ai, ("Attemped doMoveTo() on an Object with no AI"));
+	DEBUG_ASSERTCRASH(ai, ("Attempted doMoveTo() on an Object with no AI"));
 	if (ai)
 	{
 		if (theBuildPlan)
@@ -1558,7 +1558,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Player *player = ThePlayerList->getNthPlayer(msg->getPlayerIndex());
 
 			if (player == nullptr) {
-				DEBUG_CRASH(("GameLogicDispatch - MSG_CREATE_SELECTED_GROUP had an invalid player nubmer"));
+				DEBUG_CRASH(("GameLogicDispatch - MSG_CREATE_SELECTED_GROUP had an invalid player number"));
 				break;
 			}
 
@@ -1584,7 +1584,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Player *player = ThePlayerList->getNthPlayer(msg->getPlayerIndex());
 
 			if (player == nullptr) {
-				DEBUG_CRASH(("GameLogicDispatch - MSG_CREATE_SELECTED_GROUP had an invalid player nubmer"));
+				DEBUG_CRASH(("GameLogicDispatch - MSG_CREATE_SELECTED_GROUP had an invalid player number"));
 				break;
 			}
 

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayStringManager.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayStringManager.cpp
@@ -116,7 +116,7 @@ DisplayString *W3DDisplayStringManager::newDisplayString( void )
 	if( newString == nullptr )
 	{
 
-		DEBUG_LOG(( "newDisplayString: Could not allcoate new W3D display string" ));
+		DEBUG_LOG(( "newDisplayString: Could not allocate new W3D display string" ));
 		assert( 0 );
 		return nullptr;
 

--- a/Generals/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIKeyboard.cpp
+++ b/Generals/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIKeyboard.cpp
@@ -139,7 +139,7 @@ void DirectInputKeyboard::openKeyboard( void )
 	if( FAILED( hr ) )
 	{
 
-		DEBUG_LOG(( "ERROR - openKeyboard: Unabled to create keyboard device" ));
+		DEBUG_LOG(( "ERROR - openKeyboard: Unable to create keyboard device" ));
 		assert( 0 );
 		closeKeyboard();
 		return;
@@ -151,7 +151,7 @@ void DirectInputKeyboard::openKeyboard( void )
 	if( FAILED( hr ) )
 	{
 
-		DEBUG_LOG(( "ERROR - openKeyboard: Unabled to set data format for keyboard" ));
+		DEBUG_LOG(( "ERROR - openKeyboard: Unable to set data format for keyboard" ));
 		assert( 0 );
 		closeKeyboard();
 		return;
@@ -169,7 +169,7 @@ void DirectInputKeyboard::openKeyboard( void )
 	if( FAILED( hr ) )
 	{
 
-		DEBUG_LOG(( "ERROR - openKeyboard: Unabled to set cooperative level" ));
+		DEBUG_LOG(( "ERROR - openKeyboard: Unable to set cooperative level" ));
 		assert( 0 );
 		closeKeyboard();
 		return;

--- a/Generals/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIMouse.cpp
+++ b/Generals/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIMouse.cpp
@@ -54,7 +54,7 @@ void DirectInputMouse::openMouse( void )
 	if( FAILED( hr ) )
 	{
 
-		DEBUG_LOG(( "ERROR - openMouse: Unabled to create direct input interface" ));
+		DEBUG_LOG(( "ERROR - openMouse: Unable to create direct input interface" ));
 		assert( 0 );
 		closeMouse();
 		return;
@@ -80,7 +80,7 @@ void DirectInputMouse::openMouse( void )
 	if( FAILED( hr ) )
 	{
 
-		DEBUG_LOG(( "ERROR - openMouse: Unabled to set mouse data format" ));
+		DEBUG_LOG(( "ERROR - openMouse: Unable to set mouse data format" ));
 		assert( 0 );
 		closeMouse();
 		return;
@@ -94,7 +94,7 @@ void DirectInputMouse::openMouse( void )
 	if( FAILED( hr ) )
 	{
 
-		DEBUG_LOG(( "ERROR - openMouse: Unabled to set coop level" ));
+		DEBUG_LOG(( "ERROR - openMouse: Unable to set coop level" ));
 		assert( 0 );
 		closeMouse();
 		return;
@@ -112,7 +112,7 @@ void DirectInputMouse::openMouse( void )
 	if( FAILED( hr ) )
 	{
 
-		DEBUG_LOG(( "ERROR - openMouse: Unabled to set buffer property" ));
+		DEBUG_LOG(( "ERROR - openMouse: Unable to set buffer property" ));
 		assert( 0 );
 		closeMouse();
 		return;
@@ -124,7 +124,7 @@ void DirectInputMouse::openMouse( void )
 	if( FAILED( hr ) )
 	{
 
-		DEBUG_LOG(( "ERROR - openMouse: Unabled to acquire mouse" ));
+		DEBUG_LOG(( "ERROR - openMouse: Unable to acquire mouse" ));
 		assert( 0 );
 		closeMouse();
 		return;

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8vertexbuffer.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8vertexbuffer.cpp
@@ -468,7 +468,7 @@ void DX8VertexBufferClass::Create_Vertex_Buffer(UsageType usage)
 		&VertexBuffer);
 
 	if (SUCCEEDED(ret)) {
-		WWDEBUG_SAY(("...Vertex buffer creation succesful"));
+		WWDEBUG_SAY(("...Vertex buffer creation successful"));
 	}
 
 	// If it still fails it is fatal

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
@@ -2445,7 +2445,7 @@ IDirect3DTexture8 * DX8Wrapper::_Create_DX8_ZTexture
 
 		if (SUCCEEDED(ret))
 		{
-			WWDEBUG_SAY(("...Render target creation succesful."));
+			WWDEBUG_SAY(("...Render target creation successful."));
 		}
 		else
 		{
@@ -2536,7 +2536,7 @@ IDirect3DCubeTexture8* DX8Wrapper::_Create_DX8_Cube_Texture
 
 			if (SUCCEEDED(ret))
 			{
-				WWDEBUG_SAY(("...Render target creation succesful."));
+				WWDEBUG_SAY(("...Render target creation successful."));
 			}
 			else
 			{
@@ -2591,7 +2591,7 @@ IDirect3DCubeTexture8* DX8Wrapper::_Create_DX8_Cube_Texture
 		);
 		if (SUCCEEDED(ret))
 		{
-			WWDEBUG_SAY(("...Texture creation succesful."));
+			WWDEBUG_SAY(("...Texture creation successful."));
 		}
 		else
 		{
@@ -2670,7 +2670,7 @@ IDirect3DVolumeTexture8* DX8Wrapper::_Create_DX8_Volume_Texture
 		);
 		if (SUCCEEDED(ret))
 		{
-			WWDEBUG_SAY(("...Texture creation succesful."));
+			WWDEBUG_SAY(("...Texture creation successful."));
 		}
 		else
 		{

--- a/Generals/Code/Tools/GUIEdit/Source/Dialog Procedures/SliderProperties.cpp
+++ b/Generals/Code/Tools/GUIEdit/Source/Dialog Procedures/SliderProperties.cpp
@@ -295,7 +295,7 @@ static LRESULT CALLBACK sliderPropertiesCallback( HWND hWndDialog,
 							sliderData->minVal = sliderData->maxVal;
 							sliderData->maxVal = temp;
 
-							MessageBox( nullptr, "Slider min greated than max, the values were swapped",
+							MessageBox( nullptr, "Slider min greater than max, the values were swapped",
 													"Warning", MB_OK | MB_ICONINFORMATION );
 
 						}

--- a/Generals/Code/Tools/GUIEdit/Source/GUIEdit.cpp
+++ b/Generals/Code/Tools/GUIEdit/Source/GUIEdit.cpp
@@ -4058,7 +4058,7 @@ void GUIEdit::bringSelectedToTop( void )
 	if( snapshot == nullptr )
 	{
 
-		DEBUG_LOG(( "bringSelectedToTop: Unabled to allocate selectList" ));
+		DEBUG_LOG(( "bringSelectedToTop: Unable to allocate selectList" ));
 		assert( 0 );
 		return;
 

--- a/Generals/Code/Tools/WorldBuilder/src/EditParameter.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/EditParameter.cpp
@@ -1850,7 +1850,7 @@ BOOL EditParameter::OnInitDialog()
 			pList->InsertString(-1, "Passive");
 			pList->InsertString(-1, "Normal");
 			pList->InsertString(-1, "Alert");
-			pList->InsertString(-1, "Agressive");
+			pList->InsertString(-1, "Aggressive");
 			pList->SetCurSel(m_parameter->getInt() - ATTITUDE_SLEEP);
 			showList = true;
 			break;

--- a/Generals/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp
@@ -2093,7 +2093,7 @@ void CWorldBuilderDoc::OnDumpDocToText(void)
 {
 	MapObject *pMapObj = nullptr;
 	const char* vetStrings[] = {"Green", "Regular", "Veteran", "Elite"};
-	const char* aggroStrings[] = {"Passive", "Normal", "Guard", "Hunt", "Agressive", "Sleep"};
+	const char* aggroStrings[] = {"Passive", "Normal", "Guard", "Hunt", "Aggressive", "Sleep"};
 	AsciiString noOwner = "No Owner";
 	static FILE *theLogFile = nullptr;
 	Bool open = false;

--- a/GeneralsMD/Code/GameEngine/Source/Common/INI/INITerrainBridge.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/INI/INITerrainBridge.cpp
@@ -62,7 +62,7 @@ void INI::parseTerrainBridgeDefinition( INI* ini )
 	if( bridge == nullptr )
 		bridge = TheTerrainRoads->newBridge( name );
 
-	DEBUG_ASSERTCRASH( bridge, ("Unable to allcoate bridge '%s'", name.str()) );
+	DEBUG_ASSERTCRASH( bridge, ("Unable to allocate bridge '%s'", name.str()) );
 
 	// parse the ini definition
 	ini->initFromINI( bridge, bridge->getBridgeFieldParse() );

--- a/GeneralsMD/Code/GameEngine/Source/Common/StateMachine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/StateMachine.cpp
@@ -520,7 +520,7 @@ State *StateMachine::internalGetState( StateID id )
 	if (i == m_stateMap.end())
 	{
 		DEBUG_CRASH( ("StateMachine::internalGetState(): Invalid state for object %s using state %d", m_owner->getTemplate()->getName().str(), id) );
-		DEBUG_LOG(("Transisioning to state #d", (Int)id));
+		DEBUG_LOG(("Transitioning to state #d", (Int)id));
 		DEBUG_LOG(("Attempting to recover - locating default state..."));
 		i = m_stateMap.find(m_defaultStateID);
 		if (i == m_stateMap.end()) {

--- a/GeneralsMD/Code/GameEngine/Source/Common/StateMachine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/StateMachine.cpp
@@ -520,7 +520,7 @@ State *StateMachine::internalGetState( StateID id )
 	if (i == m_stateMap.end())
 	{
 		DEBUG_CRASH( ("StateMachine::internalGetState(): Invalid state for object %s using state %d", m_owner->getTemplate()->getName().str(), id) );
-		DEBUG_LOG(("Transitioning to state #d", (Int)id));
+		DEBUG_LOG(("Transitioning to state %d", (Int)id));
 		DEBUG_LOG(("Attempting to recover - locating default state..."));
 		i = m_stateMap.find(m_defaultStateID);
 		if (i == m_stateMap.end()) {

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/SaveGame/GameStateMap.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/SaveGame/GameStateMap.cpp
@@ -113,7 +113,7 @@ static void embedPristineMap( AsciiString map, Xfer *xfer )
 	file->close();
 
 	// write the contents to the save file
-	DEBUG_ASSERTCRASH( xfer->getXferMode() == XFER_SAVE, ("embedPristineMap - Unsupposed xfer mode") );
+	DEBUG_ASSERTCRASH( xfer->getXferMode() == XFER_SAVE, ("embedPristineMap - Unsupported xfer mode") );
 	xfer->beginBlock();
 	xfer->xferUser( buffer, fileSize );
 	xfer->endBlock();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarStructureInventory.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarStructureInventory.cpp
@@ -223,7 +223,7 @@ void ControlBar::updateContextStructureInventory( void )
 	// about we need to repopulate the buttons of the interface
 	//
 	ContainModuleInterface *contain = source->getContain();
-	DEBUG_ASSERTCRASH( contain, ("No contain module defined for object in the iventory bar") );
+	DEBUG_ASSERTCRASH( contain, ("No contain module defined for object in the inventory bar") );
 	if (!contain)
 		return;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -1390,7 +1390,7 @@ static void saveOptions( void )
 	if(val > 0)
 	{
 		TheWritableGlobalData->m_keyboardScrollFactor = val/100.0f;
-		DEBUG_LOG(("Scroll Spped val %d, keyboard scroll factor %f", val, TheGlobalData->m_keyboardScrollFactor));
+		DEBUG_LOG(("Scroll Speed val %d, keyboard scroll factor %f", val, TheGlobalData->m_keyboardScrollFactor));
 		AsciiString prefString;
 		prefString.format("%d", val);
 		(*pref)["ScrollFactor"] = prefString;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/PolygonTrigger.cpp
@@ -318,10 +318,10 @@ void PolygonTrigger::removePolygonTrigger(PolygonTrigger *pTrigger)
 	DEBUG_ASSERTCRASH(pTrig, ("Attempting to remove a polygon not in the list."));
 	if (pTrig) {
 		if (pPrev) {
-			DEBUG_ASSERTCRASH(pTrigger==pPrev->m_nextPolygonTrigger, ("Logic errror.  jba."));
+			DEBUG_ASSERTCRASH(pTrigger==pPrev->m_nextPolygonTrigger, ("Logic error.  jba."));
 			pPrev->m_nextPolygonTrigger = pTrig->m_nextPolygonTrigger;
 		} else {
-			DEBUG_ASSERTCRASH(pTrigger==ThePolygonTriggerListPtr, ("Logic errror.  jba."));
+			DEBUG_ASSERTCRASH(pTrigger==ThePolygonTriggerListPtr, ("Logic error.  jba."));
 			ThePolygonTriggerListPtr = pTrig->m_nextPolygonTrigger;
 		}
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -2759,7 +2759,7 @@ void Object::setLayer(PathfindLayerEnum layer)
 		DEBUG_LOG(("Changing layer from %d to %d", m_layer, layer));
 		if (m_layer != LAYER_GROUND) {
 			if (TheTerrainLogic->objectInteractsWithBridgeLayer(this, m_layer)) {
-				DEBUG_CRASH(("Probably shouldn't be chaging layer. jba."));
+				DEBUG_CRASH(("Probably shouldn't be changing layer. jba."));
 			}
 		}
 #endif

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/Scripts.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/Scripts.cpp
@@ -526,7 +526,7 @@ Bool ScriptList::ParseScriptsDataChunk(DataChunkInput &file, DataChunkInfo *info
 {
 	Int i;
 	file.registerParser( "ScriptList", info->label, ScriptList::ParseScriptListDataChunk );
-	DEBUG_ASSERTCRASH(s_numInReadList==0, ("Leftover scripts floating aroung."));
+	DEBUG_ASSERTCRASH(s_numInReadList==0, ("Leftover scripts floating around."));
 	for (i=0; i<s_numInReadList; i++) {
 		deleteInstance(s_readLists[i]);
 		s_readLists[i] = nullptr;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -1011,7 +1011,7 @@ static void populateRandomStartPosition( GameInfo *game )
 						closestIdx = n;
 					}
 				}
-				DEBUG_ASSERTCRASH( closestDist < FLT_MAX, ("Couldn't find a closest starting positon!"));
+				DEBUG_ASSERTCRASH( closestDist < FLT_MAX, ("Couldn't find a closest starting position!"));
 				slot->setStartPos(closestIdx);
 				taken[closestIdx] = TRUE;
 			}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -101,7 +101,7 @@ static int thePlanSubjectCount = 0;
 static void doMoveTo( Object *obj, const Coord3D *pos )
 {
 	AIUpdateInterface *ai = obj->getAIUpdateInterface();
-	DEBUG_ASSERTCRASH(ai, ("Attemped doMoveTo() on an Object with no AI"));
+	DEBUG_ASSERTCRASH(ai, ("Attempted doMoveTo() on an Object with no AI"));
 	if (ai)
 	{
 		if (theBuildPlan)
@@ -1586,7 +1586,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Player *player = ThePlayerList->getNthPlayer(msg->getPlayerIndex());
 
 			if (player == nullptr) {
-				DEBUG_CRASH(("GameLogicDispatch - MSG_CREATE_SELECTED_GROUP had an invalid player nubmer"));
+				DEBUG_CRASH(("GameLogicDispatch - MSG_CREATE_SELECTED_GROUP had an invalid player number"));
 				break;
 			}
 
@@ -1612,7 +1612,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Player *player = ThePlayerList->getNthPlayer(msg->getPlayerIndex());
 
 			if (player == nullptr) {
-				DEBUG_CRASH(("GameLogicDispatch - MSG_CREATE_SELECTED_GROUP had an invalid player nubmer"));
+				DEBUG_CRASH(("GameLogicDispatch - MSG_CREATE_SELECTED_GROUP had an invalid player number"));
 				break;
 			}
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayStringManager.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayStringManager.cpp
@@ -116,7 +116,7 @@ DisplayString *W3DDisplayStringManager::newDisplayString( void )
 	if( newString == nullptr )
 	{
 
-		DEBUG_LOG(( "newDisplayString: Could not allcoate new W3D display string" ));
+		DEBUG_LOG(( "newDisplayString: Could not allocate new W3D display string" ));
 		assert( 0 );
 		return nullptr;
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIKeyboard.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIKeyboard.cpp
@@ -139,7 +139,7 @@ void DirectInputKeyboard::openKeyboard( void )
 	if( FAILED( hr ) )
 	{
 
-		DEBUG_LOG(( "ERROR - openKeyboard: Unabled to create keyboard device" ));
+		DEBUG_LOG(( "ERROR - openKeyboard: Unable to create keyboard device" ));
 		assert( 0 );
 		closeKeyboard();
 		return;
@@ -151,7 +151,7 @@ void DirectInputKeyboard::openKeyboard( void )
 	if( FAILED( hr ) )
 	{
 
-		DEBUG_LOG(( "ERROR - openKeyboard: Unabled to set data format for keyboard" ));
+		DEBUG_LOG(( "ERROR - openKeyboard: Unable to set data format for keyboard" ));
 		assert( 0 );
 		closeKeyboard();
 		return;
@@ -169,7 +169,7 @@ void DirectInputKeyboard::openKeyboard( void )
 	if( FAILED( hr ) )
 	{
 
-		DEBUG_LOG(( "ERROR - openKeyboard: Unabled to set cooperative level" ));
+		DEBUG_LOG(( "ERROR - openKeyboard: Unable to set cooperative level" ));
 		assert( 0 );
 		closeKeyboard();
 		return;

--- a/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIMouse.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIMouse.cpp
@@ -54,7 +54,7 @@ void DirectInputMouse::openMouse( void )
 	if( FAILED( hr ) )
 	{
 
-		DEBUG_LOG(( "ERROR - openMouse: Unabled to create direct input interface" ));
+		DEBUG_LOG(( "ERROR - openMouse: Unable to create direct input interface" ));
 		assert( 0 );
 		closeMouse();
 		return;
@@ -78,7 +78,7 @@ void DirectInputMouse::openMouse( void )
 	if( FAILED( hr ) )
 	{
 
-		DEBUG_LOG(( "ERROR - openMouse: Unabled to set mouse data format" ));
+		DEBUG_LOG(( "ERROR - openMouse: Unable to set mouse data format" ));
 		assert( 0 );
 		closeMouse();
 		return;
@@ -92,7 +92,7 @@ void DirectInputMouse::openMouse( void )
 	if( FAILED( hr ) )
 	{
 
-		DEBUG_LOG(( "ERROR - openMouse: Unabled to set coop level" ));
+		DEBUG_LOG(( "ERROR - openMouse: Unable to set coop level" ));
 		assert( 0 );
 		closeMouse();
 		return;
@@ -110,7 +110,7 @@ void DirectInputMouse::openMouse( void )
 	if( FAILED( hr ) )
 	{
 
-		DEBUG_LOG(( "ERROR - openMouse: Unabled to set buffer property" ));
+		DEBUG_LOG(( "ERROR - openMouse: Unable to set buffer property" ));
 		assert( 0 );
 		closeMouse();
 		return;
@@ -122,7 +122,7 @@ void DirectInputMouse::openMouse( void )
 	if( FAILED( hr ) )
 	{
 
-		DEBUG_LOG(( "ERROR - openMouse: Unabled to acquire mouse" ));
+		DEBUG_LOG(( "ERROR - openMouse: Unable to acquire mouse" ));
 		assert( 0 );
 		closeMouse();
 		return;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8indexbuffer.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8indexbuffer.cpp
@@ -327,7 +327,7 @@ DX8IndexBufferClass::DX8IndexBufferClass(unsigned short index_count_,UsageType u
 		&index_buffer);
 
 	if (SUCCEEDED(ret)) {
-		WWDEBUG_SAY(("...Index buffer creation succesful"));
+		WWDEBUG_SAY(("...Index buffer creation successful"));
 	}
 
 	// If it still fails it is fatal

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8vertexbuffer.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8vertexbuffer.cpp
@@ -478,7 +478,7 @@ void DX8VertexBufferClass::Create_Vertex_Buffer(UsageType usage)
 		&VertexBuffer);
 
 	if (SUCCEEDED(ret)) {
-		WWDEBUG_SAY(("...Vertex buffer creation succesful"));
+		WWDEBUG_SAY(("...Vertex buffer creation successful"));
 	}
 
 	// If it still fails it is fatal

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
@@ -2469,7 +2469,7 @@ IDirect3DTexture8 * DX8Wrapper::_Create_DX8_Texture
 				&texture);
 
 			if (SUCCEEDED(ret)) {
-				WWDEBUG_SAY(("...Render target creation succesful."));
+				WWDEBUG_SAY(("...Render target creation successful."));
 			}
 			else {
 				WWDEBUG_SAY(("...Render target creation failed."));
@@ -2518,7 +2518,7 @@ IDirect3DTexture8 * DX8Wrapper::_Create_DX8_Texture
 			pool,
 			&texture);
 		if (SUCCEEDED(ret)) {
-			WWDEBUG_SAY(("...Texture creation succesful."));
+			WWDEBUG_SAY(("...Texture creation successful."));
 		}
 		else {
 			StringClass format_name(0,true);
@@ -2670,7 +2670,7 @@ IDirect3DTexture8 * DX8Wrapper::_Create_DX8_ZTexture
 
 		if (SUCCEEDED(ret))
 		{
-			WWDEBUG_SAY(("...Render target creation succesful."));
+			WWDEBUG_SAY(("...Render target creation successful."));
 		}
 		else
 		{
@@ -2761,7 +2761,7 @@ IDirect3DCubeTexture8* DX8Wrapper::_Create_DX8_Cube_Texture
 
 			if (SUCCEEDED(ret))
 			{
-				WWDEBUG_SAY(("...Render target creation succesful."));
+				WWDEBUG_SAY(("...Render target creation successful."));
 			}
 			else
 			{
@@ -2816,7 +2816,7 @@ IDirect3DCubeTexture8* DX8Wrapper::_Create_DX8_Cube_Texture
 		);
 		if (SUCCEEDED(ret))
 		{
-			WWDEBUG_SAY(("...Texture creation succesful."));
+			WWDEBUG_SAY(("...Texture creation successful."));
 		}
 		else
 		{
@@ -2895,7 +2895,7 @@ IDirect3DVolumeTexture8* DX8Wrapper::_Create_DX8_Volume_Texture
 		);
 		if (SUCCEEDED(ret))
 		{
-			WWDEBUG_SAY(("...Texture creation succesful."));
+			WWDEBUG_SAY(("...Texture creation successful."));
 		}
 		else
 		{

--- a/GeneralsMD/Code/Tools/GUIEdit/Source/Dialog Procedures/SliderProperties.cpp
+++ b/GeneralsMD/Code/Tools/GUIEdit/Source/Dialog Procedures/SliderProperties.cpp
@@ -295,7 +295,7 @@ static LRESULT CALLBACK sliderPropertiesCallback( HWND hWndDialog,
 							sliderData->minVal = sliderData->maxVal;
 							sliderData->maxVal = temp;
 
-							MessageBox( nullptr, "Slider min greated than max, the values were swapped",
+							MessageBox( nullptr, "Slider min greater than max, the values were swapped",
 													"Warning", MB_OK | MB_ICONINFORMATION );
 
 						}

--- a/GeneralsMD/Code/Tools/GUIEdit/Source/GUIEdit.cpp
+++ b/GeneralsMD/Code/Tools/GUIEdit/Source/GUIEdit.cpp
@@ -4058,7 +4058,7 @@ void GUIEdit::bringSelectedToTop( void )
 	if( snapshot == nullptr )
 	{
 
-		DEBUG_LOG(( "bringSelectedToTop: Unabled to allocate selectList" ));
+		DEBUG_LOG(( "bringSelectedToTop: Unable to allocate selectList" ));
 		assert( 0 );
 		return;
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/EditParameter.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/EditParameter.cpp
@@ -1893,7 +1893,7 @@ BOOL EditParameter::OnInitDialog()
 			pList->InsertString(-1, "Passive");
 			pList->InsertString(-1, "Normal");
 			pList->InsertString(-1, "Alert");
-			pList->InsertString(-1, "Agressive");
+			pList->InsertString(-1, "Aggressive");
 			pList->SetCurSel(m_parameter->getInt() - ATTITUDE_SLEEP);
 			showList = true;
 			break;

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/WorldBuilderDoc.cpp
@@ -2150,7 +2150,7 @@ void CWorldBuilderDoc::OnDumpDocToText(void)
 {
 	MapObject *pMapObj = nullptr;
 	const char* vetStrings[] = {"Green", "Regular", "Veteran", "Elite"};
-	const char* aggroStrings[] = {"Passive", "Normal", "Guard", "Hunt", "Agressive", "Sleep"};
+	const char* aggroStrings[] = {"Passive", "Normal", "Guard", "Hunt", "Aggressive", "Sleep"};
 	AsciiString noOwner = "No Owner";
 	static FILE *theLogFile = nullptr;
 	Bool open = false;


### PR DESCRIPTION
## Summary
- Fix spelling errors in debug/diagnostic string literals
- Affects DEBUG_LOG, DEBUG_ASSERTCRASH, DEBUG_CRASH, WWASSERT messages
- No user-visible changes - debug output only
 

## Example fixes
- "Unable to allcoate" → "Unable to allocate"
- "Unsupposed xfer mode" → "Unsupported xfer mode"
- "this object isnt" → "this object isn't"
- "invalid player nubmer" → "invalid player number"
- "Logic errror" → "Logic error"