### PR TITLE
refactor(gamelogic): Rearrange local variables in GameLogic::startNewGame()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -1046,7 +1046,6 @@ void GameLogic::startNewGame( Bool saveGame )
 
 	// Fill in the game color and Factions before we do the Load Screen
 	TheGameInfo = nullptr;
-	Int localSlot = 0;
 	if (TheNetwork)
 	{
 		if (TheLAN)
@@ -1150,6 +1149,7 @@ void GameLogic::startNewGame( Bool saveGame )
 	DEBUG_LOG(("%s", Buf));
 	#endif
 
+	Int localSlot = 0;
 	Int progressCount = LOAD_PROGRESS_SIDE_POPULATION;
 	if (TheGameInfo)
 	{
@@ -1469,7 +1469,6 @@ void GameLogic::startNewGame( Bool saveGame )
 	updateLoadProgress(LOAD_PROGRESS_POST_VICTORY_CONDITION_SETUP);
 
 	Player *localPlayer = ThePlayerList->getLocalPlayer();
-	Player *observerPlayer = ThePlayerList->findPlayerWithNameKey(TheNameKeyGenerator->nameToKey("ReplayObserver"));
 
 	// set the radar as on a new map
 	TheRadar->newMap( TheTerrainLogic );
@@ -1577,6 +1576,7 @@ void GameLogic::startNewGame( Bool saveGame )
 	updateLoadProgress(LOAD_PROGRESS_POST_PATHFINDER_NEW_MAP);
 
 	// reveal the map for the permanent observer
+	Player *observerPlayer = ThePlayerList->findPlayerWithNameKey(TheNameKeyGenerator->nameToKey("ReplayObserver"));
 	ThePartitionManager->revealMapForPlayerPermanently( observerPlayer->getPlayerIndex() );
 	DEBUG_LOG(("Reveal shroud for %ls whose index is %d", observerPlayer->getPlayerDisplayName().str(), observerPlayer->getPlayerIndex()));
 
@@ -4641,4 +4641,3 @@ void GameLogic::loadPostProcess( void )
 	remakeSleepyUpdate();
 
 }
-

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -1161,7 +1161,6 @@ void GameLogic::startNewGame( Bool saveGame )
 		}
 
 		//DEBUG_LOG(("Starting LAN game with %d players", TheGameInfo->getNumPlayers()));
-		Dict d;
 		for (int i=0; i<MAX_SLOTS; ++i)
 		{
 			// Add a Side to TheSidesList
@@ -1176,6 +1175,7 @@ void GameLogic::startNewGame( Bool saveGame )
 			if (!slot || !slot->isOccupied())
 				continue;
 
+			Dict d;
 			d.clear();
 			AsciiString playerName;
 			playerName.format("player%d", i);
@@ -1523,16 +1523,14 @@ void GameLogic::startNewGame( Bool saveGame )
 	#endif
 
 		// Special case, load any bridge map objects.
- 	const ThingTemplate *thingTemplate;
-	MapObject *pMapObj;
-	for (pMapObj = MapObject::getFirstMapObject(); pMapObj; pMapObj = pMapObj->getNext())
+	for (MapObject *pMapObj = MapObject::getFirstMapObject(); pMapObj; pMapObj = pMapObj->getNext())
 	{
 
 		if (pMapObj->getFlag(FLAG_BRIDGE_FLAGS) || pMapObj->getFlag(FLAG_ROAD_FLAGS))
 			continue;	// these roads & bridges are special cased in the terrain side.
 
 		// get thing template based from map object name
-		thingTemplate = pMapObj->getThingTemplate();
+		const ThingTemplate *thingTemplate = pMapObj->getThingTemplate();
 		if( thingTemplate == nullptr )
 			continue;
 
@@ -1615,12 +1613,11 @@ void GameLogic::startNewGame( Bool saveGame )
 	DEBUG_LOG(("%s", Buf));
 	#endif
 
-	progressCount = LOAD_PROGRESS_LOOP_ALL_THE_FREAKN_OBJECTS;
-	Int timer = timeGetTime();
 	if( saveGame == FALSE )
 	{
-
-		for (pMapObj = MapObject::getFirstMapObject(); pMapObj; pMapObj = pMapObj->getNext())
+		Int progressCount = LOAD_PROGRESS_LOOP_ALL_THE_FREAKN_OBJECTS;
+		Int timer = timeGetTime();
+		for (MapObject *pMapObj = MapObject::getFirstMapObject(); pMapObj; pMapObj = pMapObj->getNext())
 		{
 
 			if (pMapObj->getFlag(FLAG_BRIDGE_FLAGS) || pMapObj->getFlag(FLAG_ROAD_FLAGS)) {
@@ -1631,7 +1628,7 @@ void GameLogic::startNewGame( Bool saveGame )
 			handleNameChange( pMapObj );
 
 			// get thing template based from map object name
-			thingTemplate = pMapObj->getThingTemplate();
+			const ThingTemplate *thingTemplate = pMapObj->getThingTemplate();
 
 			//
 			// if no template continue, some map objects don't have thing templates like
@@ -1718,10 +1715,10 @@ void GameLogic::startNewGame( Bool saveGame )
 	DEBUG_LOG(("%s", Buf));
 	#endif
 
-	progressCount = LOAD_PROGRESS_LOOP_INITIAL_NETWORK_BUILDINGS;
 	// place initial network buildings/units
 	if (TheGameInfo && !saveGame)
 	{
+		Int progressCount = LOAD_PROGRESS_LOOP_INITIAL_NETWORK_BUILDINGS;
 		for (int i=0; i<MAX_SLOTS; ++i)
 		{
 			GameSlot *slot = TheGameInfo->getSlot(i);
@@ -4644,5 +4641,4 @@ void GameLogic::loadPostProcess( void )
 	remakeSleepyUpdate();
 
 }
-
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -1322,7 +1322,6 @@ void GameLogic::startNewGame( Bool loadingSaveGame )
 		}
 
 		//DEBUG_LOG(("Starting LAN game with %d players", game->getNumPlayers()));
-		Dict d;
 		for (int i=0; i<MAX_SLOTS; ++i)
 		{
 			// Add a Side to TheSidesList
@@ -1337,6 +1336,7 @@ void GameLogic::startNewGame( Bool loadingSaveGame )
 			if (!slot || !slot->isOccupied())
 				continue;
 
+			Dict d;
 			d.clear();
 			AsciiString playerName;
 			playerName.format("player%d", i);
@@ -1684,16 +1684,14 @@ void GameLogic::startNewGame( Bool loadingSaveGame )
 	#endif
 
 		// Special case, load any bridge map objects.
- 	const ThingTemplate *thingTemplate;
-	MapObject *pMapObj;
-	for (pMapObj = MapObject::getFirstMapObject(); pMapObj; pMapObj = pMapObj->getNext())
+	for (MapObject *pMapObj = MapObject::getFirstMapObject(); pMapObj; pMapObj = pMapObj->getNext())
 	{
 
 		if (pMapObj->getFlag(FLAG_BRIDGE_FLAGS) || pMapObj->getFlag(FLAG_ROAD_FLAGS))
 			continue;	// these roads & bridges are special cased in the terrain side.
 
 		// get thing template based from map object name
-		thingTemplate = pMapObj->getThingTemplate();
+		const ThingTemplate *thingTemplate = pMapObj->getThingTemplate();
 		if( thingTemplate == nullptr )
 			continue;
 
@@ -1792,14 +1790,12 @@ void GameLogic::startNewGame( Bool loadingSaveGame )
 		forceFluffToProp = TRUE; // Always do client side fluff - faster, and syncs properly. jba.
 	}
 
-	progressCount = LOAD_PROGRESS_LOOP_ALL_THE_FREAKN_OBJECTS;
-	Int timer = timeGetTime();
 	if( loadingSaveGame ) {
 		// Loading a loadingSaveGame, need to add the trees to the client. jba. [8/11/2003]
-		for (pMapObj = MapObject::getFirstMapObject(); pMapObj; pMapObj = pMapObj->getNext())
+		for (MapObject *pMapObj = MapObject::getFirstMapObject(); pMapObj; pMapObj = pMapObj->getNext())
 		{
 			// get thing template based from map object name
-			thingTemplate = pMapObj->getThingTemplate();
+			const ThingTemplate *thingTemplate = pMapObj->getThingTemplate();
 			if( thingTemplate == nullptr )
 				continue;
 			// don't create trees and shrubs if this is one and we have that option off
@@ -1817,8 +1813,9 @@ void GameLogic::startNewGame( Bool loadingSaveGame )
 	}
 	else
 	{
-
-		for (pMapObj = MapObject::getFirstMapObject(); pMapObj; pMapObj = pMapObj->getNext())
+		Int progressCount = LOAD_PROGRESS_LOOP_ALL_THE_FREAKN_OBJECTS;
+		Int timer = timeGetTime();
+		for (MapObject *pMapObj = MapObject::getFirstMapObject(); pMapObj; pMapObj = pMapObj->getNext())
 		{
 
 			if (pMapObj->getFlag(FLAG_BRIDGE_FLAGS) || pMapObj->getFlag(FLAG_ROAD_FLAGS)) {
@@ -1829,7 +1826,7 @@ void GameLogic::startNewGame( Bool loadingSaveGame )
 			handleNameChange( pMapObj );
 
 			// get thing template based from map object name
-			thingTemplate = pMapObj->getThingTemplate();
+			const ThingTemplate *thingTemplate = pMapObj->getThingTemplate();
 
 			//
 			// if no template continue, some map objects don't have thing templates like
@@ -1931,10 +1928,10 @@ void GameLogic::startNewGame( Bool loadingSaveGame )
 	DEBUG_LOG(("%s", Buf));
 	#endif
 
-	progressCount = LOAD_PROGRESS_LOOP_INITIAL_NETWORK_BUILDINGS;
 	// place initial network buildings/units
 	if (TheGameInfo && !loadingSaveGame)
 	{
+		Int progressCount = LOAD_PROGRESS_LOOP_INITIAL_NETWORK_BUILDINGS;
 		for (int i=0; i<MAX_SLOTS; ++i)
 		{
 			GameSlot *slot = TheGameInfo->getSlot(i);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -1187,7 +1187,6 @@ void GameLogic::startNewGame( Bool loadingSaveGame )
 
 	// Fill in the game color and Factions before we do the Load Screen
 	TheGameInfo = nullptr;
-	Int localSlot = 0;
 	if (TheNetwork)
 	{
 		if (TheLAN)
@@ -1311,6 +1310,7 @@ void GameLogic::startNewGame( Bool loadingSaveGame )
 	DEBUG_LOG(("%s", Buf));
 	#endif
 
+	Int localSlot = 0;
 	Int progressCount = LOAD_PROGRESS_SIDE_POPULATION;
 	if (TheGameInfo)
 	{
@@ -1630,7 +1630,6 @@ void GameLogic::startNewGame( Bool loadingSaveGame )
 	updateLoadProgress(LOAD_PROGRESS_POST_VICTORY_CONDITION_SETUP);
 
 	Player *localPlayer = ThePlayerList->getLocalPlayer();
-	Player *observerPlayer = ThePlayerList->findPlayerWithNameKey(TheNameKeyGenerator->nameToKey("ReplayObserver"));
 
 	// set the radar as on a new map
 	TheRadar->newMap( TheTerrainLogic );
@@ -1738,6 +1737,7 @@ void GameLogic::startNewGame( Bool loadingSaveGame )
 	updateLoadProgress(LOAD_PROGRESS_POST_PATHFINDER_NEW_MAP);
 
 	// reveal the map for the permanent observer
+	Player *observerPlayer = ThePlayerList->findPlayerWithNameKey(TheNameKeyGenerator->nameToKey("ReplayObserver"));
 	ThePartitionManager->revealMapForPlayerPermanently( observerPlayer->getPlayerIndex() );
 	DEBUG_LOG(("Reveal shroud for %ls whose index is %d", observerPlayer->getPlayerDisplayName().str(), observerPlayer->getPlayerIndex()));
 
@@ -5209,5 +5209,3 @@ void GameLogic::loadPostProcess( void )
 	remakeSleepyUpdate();
 
 }
-
-


### PR DESCRIPTION
- [x] Some variables were declared once and re-used in multiple contexts, these are now defined in a local scope when it was safe to do so.
- [x] Some variables were moved to be closer to first use