### PR TITLE
docs: Fix spelling errors in Core/Tools and Core/GameEngine comments

### DIFF
--- a/Core/GameEngine/Include/Common/AsciiString.h
+++ b/Core/GameEngine/Include/Common/AsciiString.h
@@ -252,7 +252,7 @@ public:
 	void trimEnd(void);
 
 	/**
-	  Remove all consecutive occurances of c from the end of the string.
+	  Remove all consecutive occurrences of c from the end of the string.
 	*/
 	void trimEnd(const char c);
 

--- a/Core/GameEngine/Include/Common/AudioEventInfo.h
+++ b/Core/GameEngine/Include/Common/AudioEventInfo.h
@@ -126,7 +126,7 @@ public:
   virtual DynamicAudioEventInfo * getDynamicAudioEventInfo() { return nullptr; }  ///< If this object is REALLY a DynamicAudioEventInfo, return a pointer to the derived class
   virtual const DynamicAudioEventInfo * getDynamicAudioEventInfo() const { return nullptr; } ///< If this object is REALLY a DynamicAudioEventInfo, return a pointer to the derived class
 
-  /// Is this a permenant sound? That is, if I start this sound up, will it ever end
+  /// Is this a permanent sound? That is, if I start this sound up, will it ever end
   /// "on its own" or only if I explicitly kill it?
   Bool isPermanentSound() const { return BitIsSet( m_control, AC_LOOP ) && (m_loopCount == 0 );  }
 

--- a/Core/GameEngine/Include/Common/UnicodeString.h
+++ b/Core/GameEngine/Include/Common/UnicodeString.h
@@ -252,7 +252,7 @@ public:
 	void trimEnd(void);
 
 	/**
-	  Remove all consecutive occurances of c from the end of the string.
+	  Remove all consecutive occurrences of c from the end of the string.
 	*/
 	void trimEnd(const WideChar c);
 

--- a/Core/GameEngine/Include/Common/file.h
+++ b/Core/GameEngine/Include/Common/file.h
@@ -189,7 +189,7 @@ class File : public MemoryPoolObject
 		virtual Bool	scanReal(Real &newReal) = 0;												///< read a real number from the current file position.
 		virtual Bool	scanString(AsciiString &newString) = 0;							///< read a string from the current file position.
 
-		virtual Bool	print ( const Char *format, ...);										///< Prints formated string to text file
+		virtual Bool	print ( const Char *format, ...);										///< Prints formatted string to text file
 		virtual Int		size( void );																				///< Returns the size of the file
 		virtual Int		position( void );																		///< Returns the current read/write position
 

--- a/Core/GameEngine/Include/GameClient/TerrainRoads.h
+++ b/Core/GameEngine/Include/GameClient/TerrainRoads.h
@@ -206,7 +206,7 @@ public:
 	void update() { }
 
 	TerrainRoadType *findRoad( AsciiString name );		///< find road with matching name
-	TerrainRoadType *newRoad( AsciiString name );			///< allocate new road, assing name, and link to list
+	TerrainRoadType *newRoad( AsciiString name );			///< allocate new road, assign name, and link to list
 	TerrainRoadType *firstRoad( void ) { return m_roadList; }			///< return first road
 	TerrainRoadType *nextRoad( TerrainRoadType *road );						///< get next road
 

--- a/Core/GameEngine/Include/GameClient/View.h
+++ b/Core/GameEngine/Include/GameClient/View.h
@@ -148,7 +148,7 @@ public:
 	virtual void cameraModFinalLookToward(Coord3D *pLoc){}			///< Sets a look at point during camera movement.
 	virtual void cameraModFinalMoveTo(Coord3D *pLoc){ };			///< Sets a final move to.
 
-	// (gth) C&C3 animation controled camera feature
+	// (gth) C&C3 animation controlled camera feature
 	virtual void cameraEnableSlaveMode(const AsciiString & thingtemplateName, const AsciiString & boneName) {}
 	virtual void cameraDisableSlaveMode(void) {}
 	virtual	void Add_Camera_Shake(const Coord3D & position,float radius, float duration, float power) {}

--- a/Core/GameEngine/Include/GameNetwork/Connection.h
+++ b/Core/GameEngine/Include/GameNetwork/Connection.h
@@ -18,7 +18,7 @@
 
 /**
  * The Connection class handles queues for individual players, one connection per player.
- * Connections are identified by their names (m_name).  This should accomodate changing IPs
+ * Connections are identified by their names (m_name).  This should accommodate changing IPs
  * in the face of modem disconnects, NAT irregularities, etc.
  * Messages can be guaranteed or non-guaranteed, sequenced or not.
  *

--- a/Core/GameEngine/Include/GameNetwork/GameSpy/PeerDefs.h
+++ b/Core/GameEngine/Include/GameNetwork/GameSpy/PeerDefs.h
@@ -291,7 +291,7 @@ void GetAdditionalDisconnectsFromUserFile(PSPlayerStats *stats);
 extern Int GetAdditionalDisconnectsFromUserFile(Int playerID);
 
 //-------------------------------------------------------------------------
-// These functions set up the globals and threads neccessary for our GameSpy impl.
+// These functions set up the globals and threads necessary for our GameSpy impl.
 
 void SetUpGameSpy( const char *motdBuffer, const char *configBuffer );
 void TearDownGameSpy( void );

--- a/Core/GameEngine/Include/GameNetwork/NetCommandList.h
+++ b/Core/GameEngine/Include/GameNetwork/NetCommandList.h
@@ -35,7 +35,7 @@
  * adding commands in order more efficiently since that is whats going to be
  * done most of the time.  If the new message doesn't go after the last message
  * inserted, then the list will be traversed linearly until the proper spot is
- * found.  We can get away with this inefficient method since these occurances
+ * found.  We can get away with this inefficient method since these occurrences
  * will be rare.  Also, the list is not expected to ever have more than 30 or so
  * commands on it at a time.  Five commands would probably be a normal amount.
  */

--- a/Core/GameEngine/Include/GameNetwork/NetworkDefs.h
+++ b/Core/GameEngine/Include/GameNetwork/NetworkDefs.h
@@ -136,7 +136,7 @@ enum NetCommandType CPP_11(: Int) {
 	NETCOMMANDTYPE_PROGRESS,
 	NETCOMMANDTYPE_LOADCOMPLETE,
 	NETCOMMANDTYPE_TIMEOUTSTART,
-	NETCOMMANDTYPE_WRAPPER,							// A wrapper command that holds a command thats too big to fit in a single packet.
+	NETCOMMANDTYPE_WRAPPER,							// A wrapper command that holds a command that's too big to fit in a single packet.
 	NETCOMMANDTYPE_FILE,
 	NETCOMMANDTYPE_FILEANNOUNCE,
 	NETCOMMANDTYPE_FILEPROGRESS,
@@ -196,7 +196,7 @@ static const UnsignedShort GENERALS_MAGIC_NUMBER = 0xF00D;
 //static const Int NETWORK_DISCONNECT_TIME = 5000;
 
 // The number of miliseconds between when a player's last disconnect keep alive command
-// was recieved and when they are considered disconnected from the game.
+// was received and when they are considered disconnected from the game.
 //static const Int NETWORK_PLAYER_TIMEOUT_TIME = 60000;
 
 // The base port number used for the transport socket.  A players slot number is added to this

--- a/Core/GameEngine/Source/Common/System/AsciiString.cpp
+++ b/Core/GameEngine/Source/Common/System/AsciiString.cpp
@@ -350,7 +350,7 @@ void AsciiString::trimEnd(const char c)
 
 	if (m_data)
 	{
-		// Clip trailing consecutive occurances of c from the string.
+		// Clip trailing consecutive occurrences of c from the string.
 		const int len = strlen(peek());
 		int index = len;
 		while (index > 0 && getCharAt(index - 1) == c)

--- a/Core/GameEngine/Source/Common/System/UnicodeString.cpp
+++ b/Core/GameEngine/Source/Common/System/UnicodeString.cpp
@@ -302,7 +302,7 @@ void UnicodeString::trimEnd(const WideChar c)
 
 	if (m_data)
 	{
-		// Clip trailing consecutive occurances of c from the string.
+		// Clip trailing consecutive occurrences of c from the string.
 		const int len = wcslen(peek());
 		int index = len;
 		while (index > 0 && getCharAt(index - 1) == c)

--- a/Core/GameEngine/Source/GameNetwork/NAT.cpp
+++ b/Core/GameEngine/Source/GameNetwork/NAT.cpp
@@ -445,7 +445,7 @@ NATConnectionState NAT::connectionUpdate() {
 }
 
 // this is the function that starts the NAT/firewall negotiation process.
-// after calling this, you should call the update function untill it returns
+// after calling this, you should call the update function until it returns
 // NATSTATE_DONE.
 void NAT::establishConnectionPaths() {
 	DEBUG_LOG(("NAT::establishConnectionPaths - entering"));

--- a/Core/GameEngine/Source/GameNetwork/NetMessageStream.cpp
+++ b/Core/GameEngine/Source/GameNetwork/NetMessageStream.cpp
@@ -91,7 +91,7 @@ static Bool AddToNetCommandList(GameMessage *msg, UnsignedInt timestamp, Command
 }
 
 /**
- * AddToRemoteNetCommandList is used by TheNetwork to queue up commands recieved from other players.
+ * AddToRemoteNetCommandList is used by TheNetwork to queue up commands received from other players.
  *
 Bool AddToNetCommandList(Int playerNum, GameMessage *msg, UnsignedInt timestamp)
 {

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/HeightMap.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/HeightMap.h
@@ -110,7 +110,7 @@ protected:
 	Int updateVBForLightOptimized(DX8VertexBufferClass	*pVB, VERTEX_FORMAT *data, Int x0, Int y0, Int x1, Int y1, Int originX, Int originY, W3DDynamicLight *pLights[], Int numLights);
 	///update vertex buffer vertices inside given rectangle
 	Int updateVB(DX8VertexBufferClass	*pVB, VERTEX_FORMAT *data, Int x0, Int y0, Int x1, Int y1, Int originX, Int originY, WorldHeightMap *pMap, RefRenderObjListIterator *pLightsIterator);
-	///upate vertex buffers associated with the given rectangle
+	///update vertex buffers associated with the given rectangle
 	void initDestAlphaLUT(void);	///<initialize water depth LUT stored in m_destAlphaTexture
 	void renderTerrainPass(CameraClass *pCamera);	///< renders additional terrain pass.
 	Int	getNumExtraBlendTiles(Bool visible) { return visible?m_numVisibleExtraBlendTiles:m_numExtraBlendTiles;}

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/BaseHeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/BaseHeightMap.cpp
@@ -670,9 +670,9 @@ relative to the ray so we can early exit as soon as we have a hit.
 /** Return intersection of a ray with the heightmap mesh.
 This is a quick version that just checks every polygon inside
 a 2D bounding rectangle of the ray projected onto the heightfield plane.
-For most of our view-picking cases the ray in almost perpendicular to the
+For most of our view-picking cases the ray is almost perpendicular to the
 map plane so this is very quick (small bounding box).  But it can become slow
-for arbitrary rays such as those used in AI visbility checks.(2 units on
+for arbitrary rays such as those used in AI visibility checks(2 units on
 opposite corners of the map would check every polygon in the map).
 */
 //=============================================================================

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTerrainVisual.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTerrainVisual.cpp
@@ -905,7 +905,7 @@ void W3DTerrainVisual::setRawMapHeight(const ICoord2D *gridPos, Int height)
       if ( m_clientHeightMap )
       {
         if ( height < m_clientHeightMap->getHeight( x,y ) )
-          m_clientHeightMap->setRawHeight( x, y, height ); // if the client map is heigher than this height, it will fall down to it anyway!
+          m_clientHeightMap->setRawHeight( x, y, height ); // if the client map is higher than this height, it will fall down to it anyway!
       }
 #endif
 

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTreeBuffer.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTreeBuffer.cpp
@@ -298,7 +298,7 @@ void W3DTreeBuffer::cull(const CameraClass * camera)
 {
 	Int curTree;
 
-	// Calulate the vector direction that the camera is looking at.
+	// Calculate the vector direction that the camera is looking at.
 	Matrix3D camera_matrix = camera->Get_Transform();
 	float zmod = -1;
 	float x = zmod * camera_matrix[0][2] ;
@@ -825,7 +825,7 @@ void W3DTreeBuffer::loadTreesInVertexAndIndexBuffers(RefRenderObjListIterator *p
 				}
 				// panel start is index offset, there are 3 index per triangle.
 				if (m_trees[curTree].panelStart/3 + 2 > numIndex) {
-					continue; // not enought polygons for the offset.  jba.
+					continue; // not enough polygons for the offset.  jba.
 				}
 				for (j=0; j<6; j++) {
 					i = ((Int *)pPoly)[j+m_trees[curTree].panelStart];

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -905,7 +905,7 @@ static void drawAudioLocations( Drawable *draw, void *userData )
   }
 
   // Copied in hideously inappropriate code copying ways from DrawObject.cpp
-  // Should definately be a global, probably read in from an INI file <gasp>
+  // Should definitely be a global, probably read in from an INI file <gasp>
   static const Int poleHeight = 20;
   static const Int flagHeight = 10;
   static const Int flagWidth = 10;

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
@@ -3408,7 +3408,7 @@ void WaterRenderObjClass::renderSkyBody(Matrix3D *mat)
 	DX8Wrapper::Set_Vertex_Buffer(vb_access);
 
 	Matrix3D tm(1);
-	//set postion of skybody in world
+	//set position of skybody in world
 //	tm.Set_Translation(Vector3(40,0,0));
 	DX8Wrapper::Set_Transform(D3DTS_WORLD,tm);
 

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/WorldHeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/WorldHeightMap.cpp
@@ -1880,7 +1880,7 @@ Bool WorldHeightMap::getUVForTileIndex(Int ndx, Short tileNdx, float U[4], float
 				return;
 #endif
 				Real dx = (h3-h2)*HEIGHT_SCALE;
-				dx = sqrt(1+dx*dx); // lenght of the bottom of the cell
+				dx = sqrt(1+dx*dx); // length of the bottom of the cell
 				Real dy =	(h3-h0)*HEIGHT_SCALE;
 				dy = sqrt(1+dy*dy); // length of the left side.
 				if (dx<STRETCH_LIMIT) dx = 1.0f; // don't make a seam unless there is great stretch.
@@ -1896,7 +1896,7 @@ Bool WorldHeightMap::getUVForTileIndex(Int ndx, Short tileNdx, float U[4], float
 				}
 				// recalc for point 1.
 				dx = (h1-h0)*HEIGHT_SCALE;
-				dx = sqrt(1+dx*dx); // lenght of the bottom of the cell
+				dx = sqrt(1+dx*dx); // length of the bottom of the cell
 				dy =	(h2-h1)*HEIGHT_SCALE;
 				dy = sqrt(1+dy*dy); // length of the left side.
 				if (dx<STRETCH_LIMIT) dx = 1.0f; // don't make a seam unless there is great stretch.

--- a/Core/Tools/Autorun/CDCNTRL.cpp
+++ b/Core/Tools/Autorun/CDCNTRL.cpp
@@ -382,7 +382,7 @@ bool CDControlClass::Prevent_Removal_Of_Volume( HANDLE volume, bool prevent )
  *                                                                                             *
  * INPUT:    HANDLE of volume to eject                                                         *
  *                                                                                             *
- * OUTPUT:   true if ejection occured                                                          *
+ * OUTPUT:   true if ejection occurred                                                         *
  *                                                                                             *
  * WARNINGS: None                                                                              *
  *                                                                                             *

--- a/Core/Tools/Autorun/DrawButton.cpp
+++ b/Core/Tools/Autorun/DrawButton.cpp
@@ -289,7 +289,7 @@ void DrawButton::Draw_Text ( HDC hDC )
 //	OUTPUT: 	bool -- true of false.
 //
 // WARNINGS:	No keyboard/mouse/paint handling built in.  Do manually.
-//				Note: width is shortened below to accomodate actual bitmap area.
+//				Note: width is shortened below to accommodate actual bitmap area.
 //
 // HISTORY:
 //   07/15/1996  MML : Created.

--- a/Core/Tools/Autorun/Locale_API.cpp
+++ b/Core/Tools/Autorun/Locale_API.cpp
@@ -303,7 +303,7 @@ void Locale_Restore ( void )
 }
 
 /****************************************************************************/
-/* retreiving strings												 		*/
+/* retrieving strings												 		*/
 /****************************************************************************/
 
 const char* Locale_GetString( int StringID, char *String )

--- a/Core/Tools/Autorun/TTFont.h
+++ b/Core/Tools/Autorun/TTFont.h
@@ -272,7 +272,7 @@ bool			Is_True_Type_Font	( TextPrintType flags );	// True Type???
 
 //-------------------------------------------------------------------------
 // This class is a wrapper around all the fonts that we want to be available.
-// The constructer will make them, and the destructor will remove them for us.
+// The constructor will make them, and the destructor will remove them for us.
 //-------------------------------------------------------------------------
 class FontManagerClass
 {

--- a/Core/Tools/Autorun/WSYS_file.h
+++ b/Core/Tools/Autorun/WSYS_file.h
@@ -113,15 +113,15 @@ class File
 
 		virtual Int		read( void *buffer, Int bytes ) = 0 ;						/**< Read the specified number of bytes from the file in to the
 																																			  *  memory pointed at by buffer. Returns the number of bytes read.
-																																			  *  Returns -1 if an error occured.
+																																			  *  Returns -1 if an error occurred.
 																																			  */
 		virtual Int		write( void *buffer, Int bytes ) = 0 ;						/**< Write the specified number of bytes from the
 																																			  *	 memory pointed at by buffer to the file. Returns the number of bytes written.
-																																			  *	 Returns -1 if an error occured.
+																																			  *	 Returns -1 if an error occurred.
 																																			  */
 		virtual Int		seek( Int bytes, seekMode mode = CURRENT ) = 0;	/**< Sets the file position of the next read/write operation. Returns the new file
 																																				*  position as the number of bytes from the start of the file.
-																																				*  Returns -1 if an error occured.
+																																				*  Returns -1 if an error occurred.
 																																				*
 																																				*  seekMode determines how the seek is done:
 																																				*
@@ -129,7 +129,7 @@ class File
 																																				*  CURRENT: means seek the specified the number of bytes from the current file position
 																																				*  END: means seek the specified number of bytes back from the end of the file
 																																				*/
-		virtual Bool	printf ( const Char *format, ...);									///< Prints formated string to text file
+		virtual Bool	printf ( const Char *format, ...);									///< Prints formatted string to text file
 		virtual Int		size( void );																				///< Returns the size of the file
 		virtual Int		position( void );																		///< Returns the current read/write position
 

--- a/Core/Tools/Autorun/locale.cpp
+++ b/Core/Tools/Autorun/locale.cpp
@@ -415,7 +415,7 @@ int LOCALE_getbankstringcount(void)
 ; DESCRIPTION
 ;
 ; Loads the specified language from the string file into the
-; current bank.  Returns non zero if the operation was succesful.
+; current bank.  Returns non-zero if the operation was successful.
 ; The bank must be free before you can call LOCALE_loadtable.  To
 ; free a bank use the LOCALE_freetable function.  To determine
 ; if the bank is free use the LOCALE_getbankstringcount function.

--- a/Core/Tools/Babylon/BabylonDlg.cpp
+++ b/Core/Tools/Babylon/BabylonDlg.cpp
@@ -1538,7 +1538,7 @@ int CBabylonDlg::UpdateLabel( BabylonLabel *source, BabylonLabel *destination, U
 	}
 
 
-	// ask the user to resolve remaing unmatched strings
+	// ask the user to resolve remaining unmatched strings
 
 	{
 

--- a/Core/Tools/ImagePacker/Source/TexturePage.cpp
+++ b/Core/Tools/ImagePacker/Source/TexturePage.cpp
@@ -892,7 +892,7 @@ Bool TexturePage::addImage( ImageInfo *image )
 {
 	IRegion2D region;
 
-	// santiy
+	// sanity
 	if( image == nullptr )
 	{
 

--- a/Core/Tools/Launcher/Toolkit/Debug/DebugPrint.cpp
+++ b/Core/Tools/Launcher/Toolkit/Debug/DebugPrint.cpp
@@ -50,7 +50,7 @@ char debugLogName[_MAX_PATH];
 *     DebugPrint(String, ArgList...)
 *
 * DESCRIPTION
-*     Ouput debug print messages to the debugger and log file.
+*     Output debug print messages to the debugger and log file.
 *
 * INPUTS
 *     String  - String to output.

--- a/Core/Tools/Launcher/Toolkit/Debug/DebugPrint.h
+++ b/Core/Tools/Launcher/Toolkit/Debug/DebugPrint.h
@@ -43,7 +43,7 @@ extern "C"
 {
 #endif
 
-//! Ouput debug print messages to the debugger and log file.
+//! Output debug print messages to the debugger and log file.
 void __cdecl DebugPrint(const char* string, ...);
 void __cdecl PrintWin32Error(const char* string, ...);
 

--- a/Core/Tools/Launcher/Toolkit/Storage/File.cpp
+++ b/Core/Tools/Launcher/Toolkit/Storage/File.cpp
@@ -592,7 +592,7 @@ File::EFileError File::Load(void*& outBuffer, UInt32& outSize)
 		outBuffer = malloc(size);
 		outSize = size;
 
-		// If allocation succeded then load file data.
+		// If allocation succeeded then load file data.
 		if (outBuffer != nullptr)
 			{
 			// Fill the buffer with the file contents
@@ -1069,7 +1069,7 @@ UInt32 File::PutBytes(const void* ptr, UInt32 bytes)
 *     Bytes  - Number of bytes to retrieve
 *
 * RESULT
-*     Actual number of bytes transfered
+*     Actual number of bytes transferred
 *
 ******************************************************************************/
 

--- a/Core/Tools/Launcher/Toolkit/Support/UString.cpp
+++ b/Core/Tools/Launcher/Toolkit/Support/UString.cpp
@@ -739,7 +739,7 @@ Int UString::CompareNoCase(const UString& s) const
 *     UString::Find - ANSI character
 *
 * DESCRIPTION
-*     Find the first occurance of character
+*     Find the first occurrence of character
 *
 * INPUTS
 *     Char - ANSI character to search for
@@ -761,7 +761,7 @@ Int UString::Find(Char c) const
 *     UString::Find - Unicode character
 *
 * DESCRIPTION
-*     Find the first occurance of character
+*     Find the first occurrence of character
 *
 * INPUTS
 *     Char - Unicode character to search for.
@@ -791,7 +791,7 @@ Int UString::Find(WChar c) const
 *     UString::FindLast - ANSI character
 *
 * DESCRIPTION
-*     Find the last occurance of a character
+*     Find the last occurrence of a character
 *
 * INPUTS
 *     Char - ANSI character
@@ -813,7 +813,7 @@ Int UString::FindLast(Char c) const
 *     UString::FindLast - Unicode character
 *
 * DESCRIPTION
-*     Find the last occurance of a character
+*     Find the last occurrence of a character
 *
 * INPUTS
 *     Char - Unicode character

--- a/Core/Tools/Launcher/Toolkit/Support/UString.h
+++ b/Core/Tools/Launcher/Toolkit/Support/UString.h
@@ -74,11 +74,11 @@ class UString
 		Int CompareNoCase(const WChar* ws) const;
 		Int CompareNoCase(const UString& s) const;
 
-		//! Find the first occurance of character
+		//! Find the first occurrence of character
 		Int Find(Char c) const;
 		Int Find(WChar wc) const;
 
-		//! Find the last occurance of a character
+		//! Find the last occurrence of a character
 		Int FindLast(Char c) const;
 		Int FindLast(WChar c) const;
 

--- a/Core/Tools/Launcher/wdebug.h
+++ b/Core/Tools/Launcher/wdebug.h
@@ -25,8 +25,8 @@ MT-LEVEL
 The debugging module is pretty good for debugging and it has some message
 printing stuff as well.  The basic idea is that you write a class that
 inherits from OutputDevice (severall are provided) and assign that output
-device to a stream.  There are seperate streams for debugging, information,
-warning, and error messages.  Each one can have a seperate output device,
+device to a stream.  There are separate streams for debugging, information,
+warning, and error messages.  Each one can have a separate output device,
 or they can all have the same one.  Debugging messages only get compiled
 in if your module defines 'DEBUG'. If you don't define debug, then not even
 the text of the debugging message gets into the binary.   All the other

--- a/Core/Tools/Launcher/wstring.cpp
+++ b/Core/Tools/Launcher/wstring.cpp
@@ -556,7 +556,7 @@ bit8 Wstring::truncate(char c)
   return(TRUE);
 }
 
-// Get a token from this string that's seperated by one or more
+// Get a token from this string that's separated by one or more
 //  chars from the 'delim' string , start at offset & return offset
 sint32 Wstring::getToken(int offset,const char *delim,Wstring &out)
 {

--- a/Core/Tools/PATCHGET/Registry.h
+++ b/Core/Tools/PATCHGET/Registry.h
@@ -17,7 +17,7 @@
 */
 
 // Registry.h
-// Simple interface for storing/retreiving registry values
+// Simple interface for storing/retrieving registry values
 // Author: Matthew D. Campbell, December 2001
 
 #pragma once

--- a/Core/Tools/PATCHGET/registry.cpp
+++ b/Core/Tools/PATCHGET/registry.cpp
@@ -17,7 +17,7 @@
 */
 
 // Registry.cpp
-// Simple interface for storing/retreiving registry values
+// Simple interface for storing/retrieving registry values
 // Author: Matthew D. Campbell, December 2001
 
 #include <string>

--- a/Core/Tools/W3DView/AdvancedAnimSheet.h
+++ b/Core/Tools/W3DView/AdvancedAnimSheet.h
@@ -46,7 +46,7 @@ public:
 	CAnimMixingPage	m_MixingPage;
 	CAnimReportPage	m_ReportPage;
 
-	// Indeces of animations selected in the mixing page.
+	// Indices of animations selected in the mixing page.
 	DynamicVectorClass<int>	m_SelectedAnims;
 
 // Operations

--- a/Core/Tools/W3DView/CameraSettingsDialog.cpp
+++ b/Core/Tools/W3DView/CameraSettingsDialog.cpp
@@ -168,7 +168,7 @@ CameraSettingsDialogClass::OnOK (void)
 	//
 	// Update the fog settings. The fog near clip plane should always be equal
 	// to the camera near clip plane, but the fog far clip plane is scene
-	// dependant. We will be sure to modify only the near clip plane here.
+	// dependent. We will be sure to modify only the near clip plane here.
 	//
 	float fog_near, fog_far;
 	doc->GetScene()->Get_Fog_Range(&fog_near, &fog_far);

--- a/Core/Tools/W3DView/ColorPicker.cpp
+++ b/Core/Tools/W3DView/ColorPicker.cpp
@@ -590,7 +590,7 @@ ColorPickerClass::Paint_DIB
 	width = rect.Width ();
 	height = rect.Height ();
 
-	// Build an array of column indicies where we will switch color
+	// Build an array of column indices where we will switch color
 	// components...
 	int col_remainder = (width % 6);
 	int channel_switch_cols[6];

--- a/Core/Tools/W3DView/EmitterPropertySheet.cpp
+++ b/Core/Tools/W3DView/EmitterPropertySheet.cpp
@@ -244,7 +244,7 @@ void
 EmitterPropertySheetClass::Update_Emitter (void)
 {
 	//
-	//	Update those pages that are dependant on the particle's
+	//	Update those pages that are dependent on the particle's
 	// lifetime.
 	//
 	float lifetime = m_GeneralPage.Get_Lifetime ();

--- a/Core/Tools/W3DView/GraphicView.cpp
+++ b/Core/Tools/W3DView/GraphicView.cpp
@@ -1238,8 +1238,8 @@ CGraphicView::Reset_Camera_To_Display_Sphere (SphereClass &sphere)
 		m_pCamera->Set_Clip_Planes (min_dist, max_dist);
 
 		// Adjust the fog near clipping plane to the new value, but
-		// leave the far clip plane alone (since it is scene dependant
-		// not camera dependant).
+		// leave the far clip plane alone (since it is scene dependent
+		// not camera dependent).
 		float fog_near, fog_far;
 		doc->GetScene()->Get_Fog_Range(&fog_near, &fog_far);
 		doc->GetScene()->Set_Fog_Range(min_dist, fog_far);

--- a/Core/Tools/W3DView/MainFrm.cpp
+++ b/Core/Tools/W3DView/MainFrm.cpp
@@ -4039,7 +4039,7 @@ CMainFrame::OnUpdateBindSubobjectLod (CCmdUI *pCmdUI)
 	if (doc != nullptr && doc->GetDisplayedObject () != nullptr) {
 
 		//
-		//	Set the check if we are currenly forcing sub object matching
+		//	Set the check if we are currently forcing sub object matching
 		//
 		RenderObjClass *render_obj = doc->GetDisplayedObject ();
 		bool is_enabled = (render_obj->Is_Sub_Objects_Match_LOD_Enabled () != 0);

--- a/Core/Tools/W3DView/TextureMgrDialog.h
+++ b/Core/Tools/W3DView/TextureMgrDialog.h
@@ -153,7 +153,7 @@ class TextureListNodeClass
 __inline void
 TextureListNodeClass::Free_Subobj_List (void)
 {
-	// Loop through all the subobject entries and free thier pointers
+	// Loop through all the subobject entries and free their pointers
 	for (int index = 0; index < m_SubObjectList.Count (); index ++) {
 		SAFE_DELETE (m_SubObjectList[index]);
 	}

--- a/Core/Tools/W3DView/Toolbar.cpp
+++ b/Core/Tools/W3DView/Toolbar.cpp
@@ -351,7 +351,7 @@ CFancyToolbar::OnLButtonDown
             // 2 state button
             m_iCurrentButton = -1;
 
-            // Send the message to the window's parent to let them know a command has occured
+            // Send the message to the window's parent to let them know a command has occurred
             ::AfxGetMainWnd ()->PostMessage (WM_COMMAND,
                                              MAKELONG (m_pButtonArray[iButton].iCommandID, BN_CLICKED),
                                              (LPARAM)m_hWnd);

--- a/Core/Tools/W3DView/Utils.cpp
+++ b/Core/Tools/W3DView/Utils.cpp
@@ -414,7 +414,7 @@ Filename_From_Asset_Name (LPCTSTR asset_name)
 CString
 Get_Filename_From_Path (LPCTSTR path)
 {
-	// Find the last occurance of the directory deliminator
+	// Find the last occurrence of the directory deliminator
 	LPCTSTR filename = ::strrchr (path, '\\');
 	if (filename != nullptr) {
 		// Increment past the directory deliminator
@@ -439,7 +439,7 @@ Strip_Filename_From_Path (LPCTSTR path)
 	TCHAR temp_path[MAX_PATH];
 	::lstrcpy (temp_path, path);
 
-	// Find the last occurance of the directory deliminator
+	// Find the last occurrence of the directory deliminator
 	LPTSTR filename = ::strrchr (temp_path, '\\');
 	if (filename != nullptr) {
 		// Strip off the filename
@@ -763,7 +763,7 @@ Load_RC_Texture (LPCTSTR resource_name)
 
 	// TheSuperHackers @info Not implemented
 
-	// Reutrn a pointer to the new texture
+	// Return a pointer to the new texture
 	return texture;
 }
 

--- a/Core/Tools/W3DView/ViewerScene.cpp
+++ b/Core/Tools/W3DView/ViewerScene.cpp
@@ -105,7 +105,7 @@ RenderObjClass * ViewerSceneIterator::Current_Item(void)
 //
 //	Visibility_Check
 //
-//	Note: We overide this method to remove the LOD preparation.  We
+//	Note: We override this method to remove the LOD preparation.  We
 // need to be able to specify an LOD and not have it switch on us.
 //
 ////////////////////////////////////////////////////////////////////////
@@ -150,7 +150,7 @@ ViewerSceneClass::Add_To_Lineup (RenderObjClass *obj)
 	assert(obj);
 
 	// If this is an insignificant object (ie. we don't need to
-	// rearrange existing objects to accomodate it), don't bother
+	// rearrange existing objects to accommodate it), don't bother
 	// adding it to the lineup. Ex: Adding a light to the lineup
 	// is pretty silly.
 	if (!Can_Line_Up(obj))

--- a/Core/Tools/W3DView/W3DViewDoc.h
+++ b/Core/Tools/W3DView/W3DViewDoc.h
@@ -238,7 +238,7 @@ public:
 	void					Update_LOD_Prototype (HLodClass &hlod);
 
 	//
-	//	Cursor managment
+	//	Cursor management
 	//
 	void					Show_Cursor (bool onoff);
 	void					Set_Cursor (LPCTSTR resource_name);

--- a/Core/Tools/WW3D/max2w3d/GameMtl.cpp
+++ b/Core/Tools/WW3D/max2w3d/GameMtl.cpp
@@ -2227,7 +2227,7 @@ int GameMtl::Compute_PC_Shader_From_PS2_Shader(int pass)
 		}
 	}
 
-	// The alpha paramater.
+	// The alpha parameter.
 	switch(param_value[3])
 	{
 			case PSS_SRC_ALPHA:

--- a/Core/Tools/WW3D/max2w3d/MeshDeform.h
+++ b/Core/Tools/WW3D/max2w3d/MeshDeform.h
@@ -147,7 +147,7 @@ class MeshDeformClass : public OSModifier
 		int							SubObjectIndex (HitRecord *hitRec) { return hitRec->hitInfo; }
 		void							ClearSelection (int selLevel);
 
-		// Transformation managment
+		// Transformation management
 		void							Move (TimeValue time_val, Matrix3 &parent_tm, Matrix3 &tm_axis, Point3 &point, BOOL local_origin);
 		void							Rotate (TimeValue time_val, Matrix3 &parent_tm, Matrix3 &tm_axis, Quat &rotation, BOOL local_origin);
 		void							Scale (TimeValue time_val, Matrix3 &parent_tm, Matrix3 &tm_axis, Point3 &value, BOOL local_origin);
@@ -186,7 +186,7 @@ class MeshDeformClass : public OSModifier
 		NUScaleModBoxCMode *		m_ModeNUScale;
 		SquashModBoxCMode *		m_ModeSquash;
 
-		// Set managment
+		// Set management
 		bool							m_bSetDirty;
 		int							m_CurrentSet;
 		int							m_MaxSets;

--- a/Core/Tools/WW3D/max2w3d/MeshDeformData.h
+++ b/Core/Tools/WW3D/max2w3d/MeshDeformData.h
@@ -87,7 +87,7 @@ class MeshDeformModData : public LocalModData
 		void						Set_Vertex_Position (int index, const Point3 &value) { m_SetsList[m_CurrentSet]->Set_Vertex_Position (index, value); }
 		void						Set_Vertex_Color (int index, int color_index, const VertColor &value) { m_SetsList[m_CurrentSet]->Set_Vertex_Color (index, color_index, value); }
 
-		// Set managment
+		// Set management
 		void						Set_Max_Deform_Sets (int max);
 		void						Set_Current_Set (int set_index)			{ m_CurrentSet = set_index; }
 		int						Get_Current_Set (void) const				{ return m_CurrentSet; }
@@ -117,7 +117,7 @@ class MeshDeformModData : public LocalModData
 		//	Private member data
 		//////////////////////////////////////////////////////////////////////
 
-		// Set managment
+		// Set management
 		int						m_CurrentSet;
 		SETS_LIST				m_SetsList;
 };

--- a/Core/Tools/WW3D/max2w3d/MeshDeformSaveSet.h
+++ b/Core/Tools/WW3D/max2w3d/MeshDeformSaveSet.h
@@ -101,11 +101,11 @@ public:
 		//	Public methods
 		//////////////////////////////////////////////////////////////////////
 
-		// Keyframe managment
+		// Keyframe management
 		void					Begin_Keyframe (float state);
 		void					End_Keyframe (void);
 
-		// Vertex managment
+		// Vertex management
 		void					Add_Vert (UINT vert_index, const Point3 &position, const VertColor &color);
 
 		// Misc

--- a/Core/Tools/WW3D/max2w3d/meshbuild.cpp
+++ b/Core/Tools/WW3D/max2w3d/meshbuild.cpp
@@ -834,7 +834,7 @@ void MeshBuilderClass::Compute_Vertex_Normals(void)
 	}
 
 	/*
-	** Propogate the accumulated normals to all of the other verts which share them
+	** Propagate the accumulated normals to all of the other verts which share them
 	*/
 	for (vertidx = 0; vertidx < VertCount; vertidx++) {
 		int shadeindex = Verts[vertidx].ShadeIndex;

--- a/Core/Tools/WW3D/max2w3d/meshbuild.h
+++ b/Core/Tools/WW3D/max2w3d/meshbuild.h
@@ -220,7 +220,7 @@ public:
 	void							Compute_Bounding_Sphere(Vector3 * set_center,float * set_radius);
 
 	/*
-	** World information managment.  Used to give the mesh builder information
+	** World information management.  Used to give the mesh builder information
 	** about the world outside of its mesh.
 	*/
 	WorldInfoClass *			Peek_World_Info(void) const						{ return WorldInfo; }

--- a/Core/Tools/WW3D/max2w3d/motion.cpp
+++ b/Core/Tools/WW3D/max2w3d/motion.cpp
@@ -428,7 +428,7 @@ void MotionClass::compute_frame_motion(int frame)
          if ((node)&&(vis))  {
 
 	         if (frame != 0) {
-					// sample previous frame, and an inbetween time
+					// sample previous frame, and an in between time
 					// to determine if there's a binary movement
 
 					TimeValue frametime_prev = frametime - GetTicksPerFrame();

--- a/Core/Tools/WW3D/max2w3d/simpdib.cpp
+++ b/Core/Tools/WW3D/max2w3d/simpdib.cpp
@@ -91,7 +91,7 @@ SimpleDIBClass::SimpleDIBClass(HWND hwnd,int width,int height,PaletteClass & pal
 	Pitch = (Width + 3) & 0xfffffffC;
 
 	// Check if the DIB is bottom-up or top-down.
-	// (it better be top-down, thats what I'm asking for!!!)
+	// (it better be top-down, that's what I'm asking for!!!)
 	if (Info->bmiHeader.biHeight > 0) {
 
 		// bottom-up DIB

--- a/Core/Tools/WW3D/max2w3d/skin.cpp
+++ b/Core/Tools/WW3D/max2w3d/skin.cpp
@@ -297,7 +297,7 @@ RefResult SkinWSMObjectClass::NotifyRefChanged(Interval changeInt,RefTargetHandl
 			}
 			if (i < BoneTab.Count()) {
 				BoneTab.Delete(i,1);
-				// TODO: cause all Modifier objects to re-index to accomodate
+				// TODO: cause all Modifier objects to re-index to accommodate
 				// the deletion of this bone!!
 			}
 			break;

--- a/Core/Tools/WW3D/max2w3d/w3d_file.h
+++ b/Core/Tools/WW3D/max2w3d/w3d_file.h
@@ -593,7 +593,7 @@ struct W3dRGBAStruct
 // MATERIALS
 //
 // Surrender 1.40 significantly changed the way that materials are described.  To
-// accomodate this, the w3d file format has changed since there are new features and
+// accommodate this, the w3d file format has changed since there are new features and
 // optimizations that we want to take advangage of.
 //
 // The VertexMaterial defines parameters which control the calculation of the primary

--- a/Core/Tools/WW3D/max2w3d/w3dappdata.cpp
+++ b/Core/Tools/WW3D/max2w3d/w3dappdata.cpp
@@ -683,7 +683,7 @@ bool Is_Vehicle_Collision(INode * node)
  *                                                                                             *
  * WARNINGS:                                                                                   *
  * This has nothing to do with its hidden status inside of max.  Things hidden in max are      *
- * ignored by the exporter.  (artist request way back...wierd huh?)                            *
+ * ignored by the exporter.  (artist request way back...weird huh?)                            *
  *                                                                                             *
  * HISTORY:                                                                                    *
  *   11/18/98   GTH : Created.                                                                 *

--- a/Core/Tools/WW3D/max2w3d/w3dappdata.h
+++ b/Core/Tools/WW3D/max2w3d/w3dappdata.h
@@ -58,7 +58,7 @@
 ** structure!
 **
 **  - There are bits stored in AppData for each node
-**  - These bits indicate wether something should be exported as hierarchy,
+**  - These bits indicate whether something should be exported as hierarchy,
 **    geometry (and if so, what type of geometry: mesh, collision box, bitmap, etc)
 **
 ** When we say something is "Hierarchy" that means its transform should be put

--- a/Core/Tools/WW3D/max2w3d/w3dexp.cpp
+++ b/Core/Tools/WW3D/max2w3d/w3dexp.cpp
@@ -1019,7 +1019,7 @@ INodeListClass * W3dExportClass::get_origin_list(void)
 	/*
 	** If we didn't find any origins, add the scene root as an origin.
 	** NOTE: it would also be a problem if the origin list contained both the scene root
-	** and the user placed origins.  Thats not happening now because the OriginList
+	** and the user placed origins.  That's not happening now because the OriginList
 	** does not collect the scene root... were that to change we'd have to update this
 	** code as well.
 	*/
@@ -1219,7 +1219,7 @@ static bool check_lod_extensions (INodeListClass &list, INode *origin)
 	{
 		char *this_ext = strrchr(list[i]->GetName(), '.');
 
-		// Check for the existance of an extension in this node.
+		// Check for the existence of an extension in this node.
 		if (this_ext == nullptr)
 			return false;
 

--- a/Core/Tools/WW3D/pluglib/Vector.h
+++ b/Core/Tools/WW3D/pluglib/Vector.h
@@ -637,7 +637,7 @@ int DynamicVectorClass<T>::ID(T const & object)
  * DynamicVectorClass<T>::Add -- Add an element to the vector.                                 *
  *                                                                                             *
  *    Use this routine to add an element to the vector. The vector will automatically be       *
- *    resized to accomodate the new element IF the vector was allocated previously and the     *
+ *    resized to accommodate the new element IF the vector was allocated previously and the    *
  *    growth rate is not zero.                                                                 *
  *                                                                                             *
  * INPUT:   object   -- Reference to the object that will be added to the vector.              *
@@ -809,7 +809,7 @@ bool DynamicVectorClass<T>::Delete(int index)
  * INPUT:   none.                                                                              *
  *                                                                                             *
  * OUTPUT:  T *; Points to the empty space where the new object is to be created. (If the      *
- *               space was not added succesfully, returns nullptr).                              *
+ *               space was not added successfully, returns nullptr).                            *
  *                                                                                             *
  * WARNINGS:   If memory area is left uninitialized, Very Bad Things will happen.              *
  *                                                                                             *

--- a/Core/Tools/WW3D/pluglib/always.h
+++ b/Core/Tools/WW3D/pluglib/always.h
@@ -88,7 +88,7 @@ void* __cdecl operator new(unsigned int s);
 ** Define the MIN and MAX macros.
 ** NOTE: Joe used to #include <minmax.h> in the various compiler header files.  This
 ** header defines 'min' and 'max' macros which conflict with the surrender code so
-** I'm relpacing all occurances of 'min' and 'max with 'MIN' and 'MAX'.  For code which
+** I'm relpacing all occurrences of 'min' and 'max with 'MIN' and 'MAX'.  For code which
 ** is out of our domain (e.g. Max sdk) I'm declaring template functions for 'min' and 'max'
 */
 #define NOMINMAX

--- a/Core/Tools/WW3D/pluglib/rawfile.cpp
+++ b/Core/Tools/WW3D/pluglib/rawfile.cpp
@@ -799,7 +799,7 @@ int RawFileClass::Seek(int pos, int dir)
 	/*
 	**	A file that is biased will have a seek operation modified so that the file appears to
 	**	exist only within the bias range. All bytes outside of this range appear to be
-	**	non-existant.
+	**	non-existent.
 	*/
 	if (BiasLength != -1) {
 		switch (dir) {

--- a/Core/Tools/WW3D/pluglib/rgb.h
+++ b/Core/Tools/WW3D/pluglib/rgb.h
@@ -42,7 +42,7 @@ class HSVClass;
 
 /*
 **	Each color entry is represented by this class. It holds the values for the color
-**	guns. The gun values are recorded in device dependant format, but the interface
+**	guns. The gun values are recorded in device dependent format, but the interface
 **	uses gun values from 0 to 255.
 */
 class RGBClass
@@ -78,7 +78,7 @@ class RGBClass
 		friend class PaletteClass;
 
 		/*
-		**	These hold the actual color gun values in machine independant scale. This
+		**	These hold the actual color gun values in machine independent scale. This
 		**	means the values range from 0 to 255.
 		*/
 		unsigned char Red;

--- a/Core/Tools/WW3D/pluglib/vector2.h
+++ b/Core/Tools/WW3D/pluglib/vector2.h
@@ -36,7 +36,7 @@
  *   Scalar Division Operator -- Divide a vector by a scalar                                   *
  *   Scalar Multiply Operator -- Multiply a vector by a scalar                                 *
  *   Vector Addition Operator -- Add two vectors                                               *
- *   Vector Subtraction Operator -- Subract two vectors                                        *
+ *   Vector Subtraction Operator -- Subtract two vectors                                       *
  *   Vector Inner Product Operator -- Compute the inner or dot product                         *
  *   Vector Equality Operator -- Detemine if two vectors are identical                         *
  *   Equal_Within_Epsilon -- Determine if two vectors are identical within                     *
@@ -45,7 +45,7 @@
  *   Vector2::Is_Valid -- Verifies that all components are valid floats                        *
  *	  Vector2::Update_Min -- sets each component of the vector to the min of this and a.        *
  *	  Vector2::Update_Max -- sets each component of the vector to the max of this and a.        *
- *   Vector2::Scale -- multiply components of a vector by independant scaling factors.			  *
+ *   Vector2::Scale -- multiply components of a vector by independent scaling factors.			  *
  *   Vector2::Lerp -- linearly interpolates two Vector2's                                      *
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
@@ -208,7 +208,7 @@ inline Vector2 operator + (const Vector2 &a,const Vector2 &b)
 }
 
 /**************************************************************************
- * Vector Subtraction Operator -- Subract two vectors                     *
+ * Vector Subtraction Operator -- Subtract two vectors                    *
  *                                                                        *
  * INPUT:                                                                 *
  *                                                                        *
@@ -533,7 +533,7 @@ inline void Vector2::Update_Max (const Vector2 & a)
 
 
 /***********************************************************************************************
- * Vector2::Scale -- multiply components of a vector by independant scaling factors.			  *
+ * Vector2::Scale -- multiply components of a vector by independent scaling factors.			  *
  *                                                                                             *
  * INPUT:                                                                                      *
  *                                                                                             *

--- a/Core/Tools/WW3D/pluglib/vector3.h
+++ b/Core/Tools/WW3D/pluglib/vector3.h
@@ -36,7 +36,7 @@
  *   Scalar Division Operator -- Divide a vector by a scalar                                   *
  *   Scalar Multiply Operator -- Multiply a vector by a scalar                                 *
  *   Vector Addition Operator -- Add two vectors                                               *
- *   Vector Subtraction Operator -- Subract two vectors                                        *
+ *   Vector Subtraction Operator -- Subtract two vectors                                       *
  *   Vector Inner Product Operator -- Compute the inner or dot product                         *
  *   Vector Equality Operator -- Determine if two vectors are identical                        *
  *   Vector Inequality Operator -- Determine if two vectors are identical                      *
@@ -244,7 +244,7 @@ WWINLINE Vector3 operator + (const Vector3 &a,const Vector3 &b)
 }
 
 /**************************************************************************
- * Vector Subtraction Operator -- Subract two vectors                     *
+ * Vector Subtraction Operator -- Subtract two vectors                    *
  *                                                                        *
  * INPUT:                                                                 *
  *                                                                        *

--- a/Core/Tools/WW3D/pluglib/vector4.h
+++ b/Core/Tools/WW3D/pluglib/vector4.h
@@ -36,7 +36,7 @@
  *   Scalar Division Operator -- Divide a vector by a scalar               *
  *   Scalar Multiply Operator -- Multiply a vector by a scalar             *
  *   Vector Addition Operator -- Add two vectors                           *
- *   Vector Subtraction Operator -- Subract two vectors                    *
+ *   Vector Subtraction Operator -- Subtract two vectors                   *
  *   Vector Inner Product Operator -- Compute the inner or dot product     *
  *   Vector Equality Operator -- Detemine if two vectors are identical     *
  *   Vector Inequality Operator -- Detemine if two vectors are identical   *
@@ -175,7 +175,7 @@ inline Vector4 operator + (const Vector4 &a,const Vector4 &b)
 }
 
 /**************************************************************************
- * Vector Subtraction Operator -- Subract two vectors                     *
+ * Vector Subtraction Operator -- Subtract two vectors                    *
  *                                                                        *
  * INPUT:                                                                 *
  *                                                                        *

--- a/Core/Tools/WW3D/pluglib/w3dquat.h
+++ b/Core/Tools/WW3D/pluglib/w3dquat.h
@@ -125,7 +125,7 @@ inline Quaternion operator + (const Quaternion & a,const Quaternion & b)
 	return Quaternion(a[0] + b[0], a[1] + b[1], a[2] + b[2], a[3] + b[3]);
 }
 
-// Subract two quaternions
+// Subtract two quaternions
 inline Quaternion operator - (const Quaternion & a,const Quaternion & b)
 {
 	return Quaternion(a[0] - b[0], a[1] - b[1], a[2] - b[2], a[3] - b[3]);

--- a/Core/Tools/mangler/wlib/wdebug.h
+++ b/Core/Tools/mangler/wlib/wdebug.h
@@ -25,8 +25,8 @@ MT-LEVEL
 The debugging module is pretty good for debugging and it has some message
 printing stuff as well.  The basic idea is that you write a class that
 inherits from OutputDevice (several are provided) and assign that output
-device to a stream.  There are seperate streams for debugging, information,
-warning, and error messages.  Each one can have a seperate output device,
+device to a stream.  There are separate streams for debugging, information,
+warning, and error messages.  Each one can have a separate output device,
 or they can all have the same one.  Debugging messages only get compiled
 in if your module defines 'DEBUG'. If you don't define debug, then not even
 the text of the debugging message gets into the binary.   All the other

--- a/Core/Tools/mangler/wlib/wstring.cpp
+++ b/Core/Tools/mangler/wlib/wstring.cpp
@@ -517,7 +517,7 @@ bit8 Wstring::truncate(char c)
   return(TRUE);
 }
 
-// Get a token from this string that's seperated by one or more
+// Get a token from this string that's separated by one or more
 //  chars from the 'delim' string , start at offset & return offset
 sint32 Wstring::getToken(int offset,const char *delim,Wstring &out) const
 {

--- a/Core/Tools/matchbot/generals.cpp
+++ b/Core/Tools/matchbot/generals.cpp
@@ -533,7 +533,7 @@ void GeneralsMatcher::checkMatchesInUserMap(UserMap& userMap, int ladderID, int 
 		s.append(intToString(userMap.size()));
 	}
 
-	// iterate through users, timing them out as neccessary
+	// iterate through users, timing them out as necessary
 	for (i1 = userMap.begin(); i1 != userMap.end(); ++i1)
 	{
 		if (showPoolSize)

--- a/Core/Tools/matchbot/matcher.cpp
+++ b/Core/Tools/matchbot/matcher.cpp
@@ -312,7 +312,7 @@ static void AuthenticateCDKeyCallback
 
 void MatcherClass::connectAndLoop(void)
 {
-	// Game-specific initializations, if neccessary
+	// Game-specific initializations, if necessary
 	init();
 
 	// Check for possible quit from init()-based self-tests

--- a/Core/Tools/matchbot/mydebug.h
+++ b/Core/Tools/matchbot/mydebug.h
@@ -25,8 +25,8 @@ MT-LEVEL
 The debugging module is pretty good for debugging and it has some message
 printing stuff as well.  The basic idea is that you write a class that
 inherits from OutputDevice (several are provided) and assign that output
-device to a stream.  There are seperate streams for debugging, information,
-warning, and error messages.  Each one can have a seperate output device,
+device to a stream.  There are separate streams for debugging, information,
+warning, and error messages.  Each one can have a separate output device,
 or they can all have the same one.  Debugging messages only get compiled
 in if your module defines 'DEBUG'. If you don't define debug, then not even
 the text of the debugging message gets into the binary.   All the other

--- a/Core/Tools/matchbot/wlib/wdebug.h
+++ b/Core/Tools/matchbot/wlib/wdebug.h
@@ -25,8 +25,8 @@ MT-LEVEL
 The debugging module is pretty good for debugging and it has some message
 printing stuff as well.  The basic idea is that you write a class that
 inherits from OutputDevice (several are provided) and assign that output
-device to a stream.  There are seperate streams for debugging, information,
-warning, and error messages.  Each one can have a seperate output device,
+device to a stream.  There are separate streams for debugging, information,
+warning, and error messages.  Each one can have a separate output device,
 or they can all have the same one.  Debugging messages only get compiled
 in if your module defines 'DEBUG'. If you don't define debug, then not even
 the text of the debugging message gets into the binary.   All the other

--- a/Core/Tools/matchbot/wlib/wstring.cpp
+++ b/Core/Tools/matchbot/wlib/wstring.cpp
@@ -517,7 +517,7 @@ bit8 Wstring::truncate(char c)
   return(TRUE);
 }
 
-// Get a token from this string that's seperated by one or more
+// Get a token from this string that's separated by one or more
 //  chars from the 'delim' string , start at offset & return offset
 sint32 Wstring::getToken(int offset,const char *delim,Wstring &out) const
 {

--- a/Core/Tools/wolSetup/WOLAPI/chatdefs.h
+++ b/Core/Tools/wolSetup/WOLAPI/chatdefs.h
@@ -34,13 +34,13 @@
 #define CHAT_E_NICKINUSE       MAKE_HRESULT( SEVERITY_ERROR, FACILITY_ITF, 100)
 // Your password is incorrect during login
 #define CHAT_E_BADPASS         MAKE_HRESULT( SEVERITY_ERROR, FACILITY_ITF, 101)
-// Reference made to non-existant user or channel
+// Reference made to non-existent user or channel
 #define CHAT_E_NONESUCH		   MAKE_HRESULT( SEVERITY_ERROR, FACILITY_ITF, 102)
 // The network layer is down or cannot be initialized for some reason
 #define CHAT_E_CON_NETDOWN        MAKE_HRESULT( SEVERITY_ERROR, FACILITY_ITF, 103)
 // Name lookup (e.g DNS) failed for some reason
 #define CHAT_E_CON_LOOKUP_FAILED  MAKE_HRESULT( SEVERITY_ERROR, FACILITY_ITF, 104)
-// Some fatal error occured with the net connection
+// Some fatal error occurred with the net connection
 #define CHAT_E_CON_ERROR          MAKE_HRESULT( SEVERITY_ERROR, FACILITY_ITF, 105)
 // General request timeout for a request
 #define CHAT_E_TIMEOUT            MAKE_HRESULT( SEVERITY_ERROR, FACILITY_ITF, 106)
@@ -48,7 +48,7 @@
 #define CHAT_E_MUSTPATCH        MAKE_HRESULT( SEVERITY_ERROR, FACILITY_ITF, 107)
 // Miscellaneous internal status error
 #define CHAT_E_STATUSERROR		MAKE_HRESULT( SEVERITY_ERROR, FACILITY_ITF, 108)
-// Server has returned something we don't recognise
+// Server has returned something we don't recognize
 #define CHAT_E_UNKNOWNRESPONSE	MAKE_HRESULT( SEVERITY_ERROR, FACILITY_ITF, 109)
 // Tried to join a channel that has enough players already
 #define CHAT_E_CHANNELFULL		MAKE_HRESULT( SEVERITY_ERROR, FACILITY_ITF, 110)
@@ -129,7 +129,7 @@
 #define CHAT_E_LEAVECHANNEL		MAKE_HRESULT( SEVERITY_ERROR, FACILITY_ITF, 508)
 // Tried to send something to a channel when not a member of any channel
 #define CHAT_E_JOINCHANNEL		MAKE_HRESULT( SEVERITY_ERROR, FACILITY_ITF, 509)
-// Tried to join a non-existant channel
+// Tried to join a non-existent channel
 #define CHAT_E_UNKNOWNCHANNEL	MAKE_HRESULT( SEVERITY_ERROR, FACILITY_ITF, 510)
 
 

--- a/Core/Tools/wolSetup/wolSetup.cpp
+++ b/Core/Tools/wolSetup/wolSetup.cpp
@@ -68,7 +68,7 @@ int APIENTRY WinMain(HINSTANCE hInstance,
 }
 
 
-// Mesage handler for generals setup box.
+// Message handler for generals setup box.
 LRESULT CALLBACK GeneralsSetupDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 {
 	switch (message)
@@ -121,7 +121,7 @@ void updateDisplay(HWND hDlg)
 	SetDlgItemText(hDlg, IDC_TEXT_GENERALSDIR, g_generalsFilename);
 }
 
-// Mesage handler for main dialog box.
+// Message handler for main dialog box.
 LRESULT CALLBACK MainDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 {
 	switch (message)


### PR DESCRIPTION
Fixing typos in code comments.