### PR TITLE
bugfix(actionmanager): Restore retail compatibility after construction cursor change in ActionManager

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/RTS/ActionManager.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/ActionManager.cpp
@@ -455,8 +455,16 @@ Bool ActionManager::canResumeConstructionOf( const Object *obj,
 		return FALSE;
 
 	// TheSuperHackers @bugfix Stubbjax 06/01/2025 Ensure only the owner of the construction can resume it.
+#if RETAIL_COMPATIBLE_CRC
+	Relationship r = obj->getRelationship(objectBeingConstructed);
+
+	// only available to our allies
+	if( r != ALLIES )
+		return FALSE;
+#else
 	if (obj->getControllingPlayer() != objectBeingConstructed->getControllingPlayer())
 		return FALSE;
+#endif
 
 	// if the objectBeingConstructed is not actually under construction we can't resume that!
 	if( !objectBeingConstructed->getStatusBits().test( OBJECT_STATUS_UNDER_CONSTRUCTION ) )

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/ActionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/ActionManager.cpp
@@ -459,8 +459,16 @@ Bool ActionManager::canResumeConstructionOf( const Object *obj,
 		return FALSE;
 
 	// TheSuperHackers @bugfix Stubbjax 06/01/2025 Ensure only the owner of the construction can resume it.
+#if RETAIL_COMPATIBLE_CRC
+	Relationship r = obj->getRelationship(objectBeingConstructed);
+
+	// only available to our allies
+	if( r != ALLIES )
+		return FALSE;
+#else
 	if (obj->getControllingPlayer() != objectBeingConstructed->getControllingPlayer())
 		return FALSE;
+#endif
 
 	// if the objectBeingConstructed is not actually under construction we can't resume that!
 	if( !objectBeingConstructed->getStatusBits().test( OBJECT_STATUS_UNDER_CONSTRUCTION ) )


### PR DESCRIPTION
* Follow up for #2068

#2068 introduced a change that is not compatible with retail. This PR fixes that by putting it behind the retail compatibility macro.

I noticed the issue with this replay file: [01-37-47_2v6_GenXiaom_theorder_HardAI_HardAI_HardAI_HardAI_HardAI_HardAI.zip](https://github.com/user-attachments/files/24639753/01-37-47_2v6_GenXiaom_theorder_HardAI_HardAI_HardAI_HardAI_HardAI_HardAI.zip)

```
Simulating Replay "01-37-47_2v6_GenXiaom_theorder_HardAI_HardAI_HardAI_HardAI_HardAI_HardAI.rep"
Elapsed Time: 02:35 Game Time: 10:00/40:40
Elapsed Time: 10:08 Game Time: 20:00/40:40
CRC Mismatch in Frame 42410
Elapsed Time: 13:47 Game Time: 23:33/40:40
```
```
Simulating Replay "01-37-47_2v6_GenXiaom_theorder_HardAI_HardAI_HardAI_HardAI_HardAI_HardAI.rep"
Elapsed Time: 02:22 Game Time: 10:00/40:40
Elapsed Time: 09:04 Game Time: 20:00/40:40
Elapsed Time: 18:48 Game Time: 30:00/40:40
Elapsed Time: 19:38 Game Time: 40:00/40:40
CRC Mismatch in Frame 73110
Elapsed Time: 19:40 Game Time: 40:37/40:40
```

The second log shows a mismatch caused by the change in the ActionManager code. At the time of creating this PR, this replay is also affected by a second issue shown in the first log, for which I created a PR here: 
- https://github.com/TheSuperHackers/GeneralsGameCode/pull/2126