### PR TITLE
bugfix(buildassistant): Restore retail compatibility after build assistant shroud logic change

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
@@ -688,8 +688,10 @@ Bool BuildAssistant::isLocationClearOfObjects( const Coord3D *worldPos,
 			}
 		}
 
+#if !RETAIL_COMPATIBLE_CRC
 		if (builderObject && them->getShroudedStatus(builderObject->getControllingPlayer()->getPlayerIndex()) >= OBJECTSHROUD_FOGGED)
 			return false;
+#endif
 
 		// an immobile object may obstruct our building depending on flags.
 		if( them->isKindOf( KINDOF_IMMOBILE ) )	{

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
@@ -710,8 +710,10 @@ LegalBuildCode BuildAssistant::isLocationClearOfObjects( const Coord3D *worldPos
 				continue;
 		}
 
+#if !RETAIL_COMPATIBLE_CRC
 		if (builderObject && them->getShroudedStatus(builderObject->getControllingPlayer()->getPlayerIndex()) >= OBJECTSHROUD_FOGGED)
 			return LBC_SHROUD;
+#endif
 
 		//Kris: Patch 1.01 - November 5, 2003
 		//Prevent busy units (black lotus hacking from being moved by trying to place a building -- exploit).


### PR DESCRIPTION
This change fixes a retail incompatibility that was introduced with #1646.

The offending replay no longer mismatches:
[01-41-42_2v2v2_Dad_blakeybo_MediAI_HardAI_MediAI_MediAI.zip](https://github.com/user-attachments/files/24671670/01-41-42_2v2v2_Dad_blakeybo_MediAI_HardAI_MediAI_MediAI.zip)
