### PR TITLE
bugfix(heightmap): Revert optimization for m_vertexBufferTiles in HeightMapRenderObjClass because it does not work properly

### DIFF
--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/HeightMap.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/HeightMap.h
@@ -49,7 +49,7 @@ virtually everything to do with the terrain, including: drawing, lighting,
 scorchmarks and intersection tests.
 
 TheSuperHackers @performance xezon 13/01/2026
-Class now stores the vertex buffers as one big buffer each for optimal data locality.
+Class now stores the vertex buffer backup as one big array for optimal data locality.
 */
 class HeightMapRenderObjClass : public BaseHeightMapRenderObjClass
 {
@@ -89,7 +89,7 @@ protected:
 	Int m_numExtraBlendTiles;		///<number of blend tiles in m_extraBlendTilePositions.
 	Int	m_numVisibleExtraBlendTiles; ///<number rendered last frame.
 	Int m_extraBlendTilePositionsSize; //<total size of array including unused memory.
-	DX8VertexBufferClass *m_vertexBufferTiles;	///<collection of smaller vertex buffers that make up 1 heightmap
+	DX8VertexBufferClass **m_vertexBufferTiles; ///<collection of smaller vertex buffers that make up 1 heightmap
 	VERTEX_FORMAT *m_vertexBufferBackup; ///< In memory copy of the vertex buffer data for quick update of dynamic lighting.
 	Int m_originX; ///<  Origin point in the grid.  Slides around.
 	Int m_originY; ///< Origin point in the grid.  Slides around.

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8vertexbuffer.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8vertexbuffer.h
@@ -196,13 +196,12 @@ inline VertexFormatXYZNDUV2 * DynamicVBAccessClass::WriteLockClass::Get_Formatte
 /**
 ** DX8VertexBufferClass
 ** This class wraps a DX8 vertex buffer.  Use the lock objects to modify or append to the vertex buffer.
-**
-** TheSuperHackers @performance Allow placement new and bypass the W3DMemPool to create big buffers.
 */
 class DX8VertexBufferClass : public VertexBufferClass
 {
 	W3DMPO_GLUE(DX8VertexBufferClass)
-
+protected:
+	~DX8VertexBufferClass();
 public:
 	enum UsageType {
 		USAGE_DEFAULT=0,
@@ -211,15 +210,11 @@ public:
 		USAGE_NPATCHES=4
 	};
 
-	void* operator new(size_t s, void* placement) noexcept { return placement; }
-	void operator delete(void* p, void* placement) noexcept {}
-
 	DX8VertexBufferClass(unsigned FVF, unsigned short VertexCount, UsageType usage=USAGE_DEFAULT);
 	DX8VertexBufferClass(const Vector3* vertices, const Vector3* normals, const Vector2* tex_coords, unsigned short VertexCount,UsageType usage=USAGE_DEFAULT);
 	DX8VertexBufferClass(const Vector3* vertices, const Vector3* normals, const Vector4* diffuse, const Vector2* tex_coords, unsigned short VertexCount,UsageType usage=USAGE_DEFAULT);
 	DX8VertexBufferClass(const Vector3* vertices, const Vector4* diffuse, const Vector2* tex_coords, unsigned short VertexCount,UsageType usage=USAGE_DEFAULT);
 	DX8VertexBufferClass(const Vector3* vertices, const Vector2* tex_coords, unsigned short VertexCount,UsageType usage=USAGE_DEFAULT);
-	~DX8VertexBufferClass();
 
 	IDirect3DVertexBuffer8* Get_DX8_Vertex_Buffer() { return VertexBuffer; }
 

--- a/Generals/Code/Tools/WorldBuilder/src/WBHeightMap.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/WBHeightMap.cpp
@@ -88,13 +88,10 @@ void WBHeightMap::flattenHeights(void) {
 	for (j=0; j<m_numVBTilesY; j++)
 		for (i=0; i<m_numVBTilesX; i++)
 		{
-			static int count = 0;
-			count++;
-			Int numVertex = (VERTEX_BUFFER_TILE_LENGTH*2)*(VERTEX_BUFFER_TILE_LENGTH*2);
-			DX8VertexBufferClass::WriteLockClass lockVtxBuffer(m_vertexBufferTiles + j*m_numVBTilesX+i);
+			DX8VertexBufferClass::WriteLockClass lockVtxBuffer(getVertexBufferTile(i, j));
 			VERTEX_FORMAT *vbHardware = (VERTEX_FORMAT*)lockVtxBuffer.Get_Vertex_Array();
 			Int vtx;
-			for (vtx=0; vtx<numVertex; vtx++) {
+			for (vtx=0; vtx<HEIGHTMAP_VERTEX_NUM; vtx++) {
 				vbHardware->z = theZ;
 				vbHardware++;
 			}

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8vertexbuffer.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8vertexbuffer.h
@@ -197,13 +197,12 @@ inline VertexFormatXYZNDUV2 * DynamicVBAccessClass::WriteLockClass::Get_Formatte
 /**
 ** DX8VertexBufferClass
 ** This class wraps a DX8 vertex buffer.  Use the lock objects to modify or append to the vertex buffer.
-**
-** TheSuperHackers @performance Allow placement new and bypass the W3DMemPool to create big buffers.
 */
 class DX8VertexBufferClass : public VertexBufferClass
 {
 	W3DMPO_GLUE(DX8VertexBufferClass)
-
+protected:
+	~DX8VertexBufferClass();
 public:
 	enum UsageType {
 		USAGE_DEFAULT=0,
@@ -212,15 +211,11 @@ public:
 		USAGE_NPATCHES=4
 	};
 
-	void* operator new(size_t s, void* placement) noexcept { return placement; }
-	void operator delete(void* p, void* placement) noexcept {}
-
 	DX8VertexBufferClass(unsigned FVF, unsigned short VertexCount, UsageType usage=USAGE_DEFAULT, unsigned vertex_size=0); // Vertex size not used with FVF formats
 	DX8VertexBufferClass(const Vector3* vertices, const Vector3* normals, const Vector2* tex_coords, unsigned short VertexCount,UsageType usage=USAGE_DEFAULT);
 	DX8VertexBufferClass(const Vector3* vertices, const Vector3* normals, const Vector4* diffuse, const Vector2* tex_coords, unsigned short VertexCount,UsageType usage=USAGE_DEFAULT);
 	DX8VertexBufferClass(const Vector3* vertices, const Vector4* diffuse, const Vector2* tex_coords, unsigned short VertexCount,UsageType usage=USAGE_DEFAULT);
 	DX8VertexBufferClass(const Vector3* vertices, const Vector2* tex_coords, unsigned short VertexCount,UsageType usage=USAGE_DEFAULT);
-	~DX8VertexBufferClass();
 
 	IDirect3DVertexBuffer8* Get_DX8_Vertex_Buffer() { return VertexBuffer; }
 


### PR DESCRIPTION
* Follow up for #2104

Rowdy Munkee was a bit too ambitious with #2104 and did not realize that it broke compilation with Null Memory and triggered Assert in Debug.

To avoid these problems, previous changes to `m_vertexBufferTiles` have been reverted. Otherwise we would have needed to add additonal placement new operators somewhere and also provide a way to force set reference counter to 0 before calling the destructor of the reference counted `DX8VertexBufferClass`. It is not worth it doing these hacks for this kind of optimization.

The other buffer `m_vertexBufferBackup` remains optimized.

Also code in `WBHeightMap::flattenHeights` is now in sync with Zero Hour.