### PR TITLE
bugfix(particlesystem): Prevent double-destroy and use-after-free in ParticleSystem::destroy

### DIFF
--- a/Core/GameEngine/Source/GameClient/System/ParticleSys.cpp
+++ b/Core/GameEngine/Source/GameClient/System/ParticleSys.cpp
@@ -1314,10 +1314,16 @@ void ParticleSystem::stop( void )
 // ------------------------------------------------------------------------------------------------
 void ParticleSystem::destroy( void )
 {
+	if (m_isDestroyed)
+	{
+		return;
+	}
+
 	m_isDestroyed = true;
 	if( m_slaveSystem )
 	{
 		m_slaveSystem->destroy();  // If we don't it will leak forever.  We are solely responsible for it.
+		m_slaveSystem = nullptr;
 	}
 }
 


### PR DESCRIPTION
## Summary
  - Add early return in `ParticleSystem::destroy()` if already destroyed
  - Clear `m_slaveSystem` pointer after calling destroy on slave

## Problem
During shutdown, `W3DTankDraw::tossEmitters()` can call `destroy()` on particle systems that have already been freed by `ParticleSystemManager::update()`. This causes a crash in debug builds where freed memory is filled with `0xDEADBEEF`.

The crash occurs because:
  1. W3DTankDraw holds raw pointers to particle systems (`m_treadDebrisLeft`, `m_treadDebrisRight`)
  2. `ParticleSystemManager::update()` deletes systems after `destroy()` is called and particles finish
  3. W3DTankDraw's destructor later calls `tossEmitters()` on the now-freed memory

This fix is just to return if m_isDestroyed is truthy, which prevents the crash for me.

## Notes
W3DTankDraw's pointers can become dangling when ParticleSystemManager deletes the systems. Are there any better ways to handle this? eg

  1. Should callers use ParticleSystemID and findParticleSystem() instead of raw pointers?
  2. Should particle systems notify attached drawables when deleted?

## Testing
- [x] Debug build no longer crashes during headless replay shutdown
- [ ] Verify normal gameplay particle effects still work correctly