### PR TITLE
bugfix(savegame): Fix crashes when saving a game in headless mode

### DIFF
--- a/Core/GameEngine/Include/GameClient/ParticleSys.h
+++ b/Core/GameEngine/Include/GameClient/ParticleSys.h
@@ -835,6 +835,21 @@ private:
 	ParticleSystemIDMap m_systemMap; ///< a hash map of all particle systems
 };
 
+// TheSuperHackers @feature bobtista 31/01/2026
+// ParticleSystemManager that does nothing. Used for Headless Mode.
+class ParticleSystemManagerDummy : public ParticleSystemManager
+{
+public:
+	virtual Int getOnScreenParticleCount( void ) { return 0; }
+	virtual void doParticles(RenderInfoClass &rinfo) {}
+	virtual void queueParticleRender() {}
+
+protected:
+	virtual void crc( Xfer *xfer ) {}
+	virtual void xfer( Xfer *xfer ) {}
+	virtual void loadPostProcess( void ) {}
+};
+
 /// The particle system manager singleton
 extern ParticleSystemManager *TheParticleSystemManager;
 

--- a/Core/GameEngine/Include/GameClient/TerrainVisual.h
+++ b/Core/GameEngine/Include/GameClient/TerrainVisual.h
@@ -306,5 +306,47 @@ protected:
 
 };
 
+// TheSuperHackers @feature bobtista 31/01/2026
+// TerrainVisual that does nothing. Used for Headless Mode.
+class TerrainVisualDummy : public TerrainVisual
+{
+public:
+	virtual void getTerrainColorAt( Real x, Real y, RGBColor *pColor ) {}
+	virtual TerrainType *getTerrainTile( Real x, Real y ) { return nullptr; }
+	virtual void enableWaterGrid( Bool enable ) {}
+	virtual void setWaterGridHeightClamps( const WaterHandle *waterTable, Real minZ, Real maxZ ) {}
+	virtual void setWaterAttenuationFactors( const WaterHandle *waterTable, Real a, Real b, Real c, Real range ) {}
+	virtual void setWaterTransform( const WaterHandle *waterTable, Real angle, Real x, Real y, Real z ) {}
+	virtual void setWaterTransform( const Matrix3D *transform ) {}
+	virtual void getWaterTransform( const WaterHandle *waterTable, Matrix3D *transform ) {}
+	virtual void setWaterGridResolution( const WaterHandle *waterTable, Real gridCellsX, Real gridCellsY, Real cellSize ) {}
+	virtual void getWaterGridResolution( const WaterHandle *waterTable, Real *gridCellsX, Real *gridCellsY, Real *cellSize ) {}
+	virtual void changeWaterHeight( Real x, Real y, Real delta ) {}
+	virtual void addWaterVelocity( Real worldX, Real worldY, Real velocity, Real preferredHeight ) {}
+	virtual Bool getWaterGridHeight( Real worldX, Real worldY, Real *height) { return FALSE; }
+	virtual void setTerrainTracksDetail(void) {}
+	virtual void setShoreLineDetail(void) {}
+	virtual void addFactionBib(Object *factionBuilding, Bool highlight, Real extra = 0) {}
+	virtual void removeFactionBib(Object *factionBuilding) {}
+	virtual void addFactionBibDrawable(Drawable *factionBuilding, Bool highlight, Real extra = 0) {}
+	virtual void removeFactionBibDrawable(Drawable *factionBuilding) {}
+	virtual void removeAllBibs(void) {}
+	virtual void removeBibHighlighting(void) {}
+	virtual void removeTreesAndPropsForConstruction( const Coord3D* pos, const GeometryInfo& geom, Real angle ) {}
+	virtual void addProp(const ThingTemplate *tt, const Coord3D *pos, Real angle) {}
+	virtual void setRawMapHeight(const ICoord2D *gridPos, Int height) {}
+	virtual Int getRawMapHeight(const ICoord2D *gridPos) { return 0; }
+#ifdef DO_SEISMIC_SIMULATIONS
+	virtual void updateSeismicSimulations( void ) {}
+	virtual void addSeismicSimulation( const SeismicSimulationNode& sim ) {}
+#endif
+	virtual void replaceSkyboxTextures(const AsciiString *oldTexName[NumSkyboxTextures], const AsciiString *newTexName[NumSkyboxTextures]) {}
+
+protected:
+	virtual void crc( Xfer *xfer ) {}
+	virtual void xfer( Xfer *xfer ) {}
+	virtual void loadPostProcess( void ) {}
+};
+
 // EXTERNALS //////////////////////////////////////////////////////////////////////////////////////
 extern TerrainVisual *TheTerrainVisual;  ///< singleton extern

--- a/Core/GameEngine/Include/GameClient/View.h
+++ b/Core/GameEngine/Include/GameClient/View.h
@@ -376,5 +376,27 @@ class ViewLocation
 		}
 };
 
+// TheSuperHackers @feature bobtista 31/01/2026
+// View that does nothing. Used for Headless Mode.
+class ViewDummy : public View
+{
+public:
+	virtual Drawable *pickDrawable( const ICoord2D *screen, Bool forceAttack, PickType pickType ) { return nullptr; }
+	virtual Int iterateDrawablesInRegion( IRegion2D *screenRegion, Bool (*callback)( Drawable *draw, void *userData ), void *userData ) { return 0; }
+	virtual void forceRedraw() {}
+	virtual const Coord3D& get3DCameraPosition() const { static Coord3D zero = {0,0,0}; return zero; }
+	virtual WorldToScreenReturn worldToScreenTriReturn(const Coord3D *w, ICoord2D *s ) { return WTS_INVALID; }
+	virtual void screenToWorld( const ICoord2D *s, Coord3D *w ) {}
+	virtual void screenToTerrain( const ICoord2D *screen, Coord3D *world ) {}
+	virtual void screenToWorldAtZ( const ICoord2D *s, Coord3D *w, Real z ) {}
+	virtual void drawView( void ) {}
+	virtual void updateView(void) {}
+	virtual void stepView() {}
+	virtual void setGuardBandBias( const Coord2D *gb ) {}
+
+protected:
+	virtual void xfer( Xfer *xfer ) {}
+};
+
 // EXTERNALS //////////////////////////////////////////////////////////////////////////////////////
 extern View *TheTacticalView;		///< the main tactical interface to the game world

--- a/Generals/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
@@ -1362,7 +1362,7 @@ void GameState::xferSaveData( Xfer *xfer, SnapshotType which )
 			// get block name
 			blockName = blockInfo->blockName;
 
-			DEBUG_LOG(("Looking at block '%s'", blockName.str()));
+			DEBUG_LOG(("GameState::xferSaveData - Looking at block '%s'", blockName.str()));
 
 			//
 			// for mission save files, we only save the game state block and campaign manager

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -2325,6 +2325,10 @@ void InGameUI::messageColor( const RGBColor *rgbColor, UnicodeString format, ...
 //-------------------------------------------------------------------------------------------------
 void InGameUI::addMessageText( const UnicodeString& formattedMessage, const RGBColor *rgbColor )
 {
+	// TheSuperHackers @fix bobtista 30/01/2026 Skip message display in headless mode to prevent crashes from font/display system
+	if (TheGlobalData && TheGlobalData->m_headless)
+		return;
+
 	Int i;
 	Color color1 = m_messageColor1;
 	Color color2 = m_messageColor2;

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayString.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayString.cpp
@@ -300,7 +300,10 @@ void W3DDisplayString::setFont( GameFont *font )
 	// set the font in our renderer
 	m_textRenderer.Set_Font( static_cast<FontCharsClass *>(m_font->fontData) );
 
-	m_textRendererHotKey.Set_Font( static_cast<FontCharsClass *>(TheFontLibrary->getFont(font->nameString,font->pointSize, TRUE)->fontData) );
+	// TheSuperHackers @fix bobtista 30/01/2026 Check for null before dereferencing to prevent crash if font loading fails
+	GameFont *boldFont = TheFontLibrary->getFont(font->nameString, font->pointSize, TRUE);
+	if (boldFont != nullptr)
+		m_textRendererHotKey.Set_Font( static_cast<FontCharsClass *>(boldFont->fontData) );
 	// recompute extents for text with new font
 	computeExtents();
 

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/GameWindowManager.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/GameWindowManager.h
@@ -389,6 +389,16 @@ public:
 
 	virtual GameWindow *allocateNewWindow() { return newInstance(GameWindowDummy); }
 
+	// TheSuperHackers @fix bobtista 31/01/2026 Return nullptr for message boxes in headless mode
+	virtual GameWindow *gogoMessageBox(Int x, Int y, Int width, Int height, UnsignedShort buttonFlags,
+		UnicodeString titleString, UnicodeString bodyString,
+		GameWinMsgBoxFunc yesCallback, GameWinMsgBoxFunc noCallback,
+		GameWinMsgBoxFunc okCallback, GameWinMsgBoxFunc cancelCallback) { return nullptr; }
+	virtual GameWindow *gogoMessageBox(Int x, Int y, Int width, Int height, UnsignedShort buttonFlags,
+		UnicodeString titleString, UnicodeString bodyString,
+		GameWinMsgBoxFunc yesCallback, GameWinMsgBoxFunc noCallback,
+		GameWinMsgBoxFunc okCallback, GameWinMsgBoxFunc cancelCallback, Bool useLogo) { return nullptr; }
+
 	virtual GameWinDrawFunc getPushButtonImageDrawFunc() { return nullptr; }
 	virtual GameWinDrawFunc getPushButtonDrawFunc() { return nullptr; }
 	virtual GameWinDrawFunc getCheckBoxImageDrawFunc() { return nullptr; }

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/GhostObject.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/GhostObject.h
@@ -108,5 +108,19 @@ inline Bool GhostObjectManager::trackAllPlayers() const
 #endif
 }
 
+// TheSuperHackers @feature bobtista 19/01/2026
+// GhostObjectManager that does nothing for headless mode.
+// Note: Does NOT override crc/xfer/loadPostProcess to maintain save compatibility.
+class GhostObjectManagerDummy : public GhostObjectManager
+{
+public:
+	virtual void reset(void) {}
+	virtual GhostObject *addGhostObject(Object *object, PartitionData *pd) { return nullptr; }
+	virtual void removeGhostObject(GhostObject *mod) {}
+	virtual void updateOrphanedObjects(int *playerIndexList, int playerIndexCount) {}
+	virtual void releasePartitionData(void) {}
+	virtual void restorePartitionData(void) {}
+};
+
 // the singleton
 extern GhostObjectManager *TheGhostObjectManager;

--- a/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -539,7 +539,7 @@ void GameEngine::init()
 		initSubsystem(TheCaveSystem,"TheCaveSystem", MSGNEW("GameEngineSubsystem") CaveSystem(), nullptr);
 		initSubsystem(TheRankInfoStore,"TheRankInfoStore", MSGNEW("GameEngineSubsystem") RankInfoStore(), &xferCRC, nullptr, "Data\\INI\\Rank");
 		initSubsystem(ThePlayerTemplateStore,"ThePlayerTemplateStore", MSGNEW("GameEngineSubsystem") PlayerTemplateStore(), &xferCRC, "Data\\INI\\Default\\PlayerTemplate", "Data\\INI\\PlayerTemplate");
-		initSubsystem(TheParticleSystemManager,"TheParticleSystemManager", createParticleSystemManager(), nullptr);
+		initSubsystem(TheParticleSystemManager,"TheParticleSystemManager", TheGlobalData->m_headless ? NEW ParticleSystemManagerDummy : createParticleSystemManager(), nullptr);
 
 	#ifdef DUMP_PERF_STATS///////////////////////////////////////////////////////////////////////////
 	GetPrecisionTimer(&endTime64);//////////////////////////////////////////////////////////////////

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
@@ -1363,12 +1363,12 @@ void GameState::xferSaveData( Xfer *xfer, SnapshotType which )
 			// get block name
 			blockName = blockInfo->blockName;
 
-			DEBUG_LOG(("Looking at block '%s'", blockName.str()));
+			DEBUG_LOG(("GameState::xferSaveData - Looking at block '%s'", blockName.str()));
 
 			// Skip blocks with nullptr snapshot (can happen in headless mode)
 			if( blockInfo->snapshot == nullptr )
 			{
-				DEBUG_LOG(("Skipping block '%s' because snapshot is nullptr", blockName.str()));
+				DEBUG_LOG(("GameState::xferSaveData - Skipping block '%s' because snapshot is nullptr", blockName.str()));
 				continue;
 			}
 
@@ -1465,7 +1465,7 @@ void GameState::xferSaveData( Xfer *xfer, SnapshotType which )
 				// Skip blocks with nullptr snapshot (can happen in headless mode)
 				if( blockInfo->snapshot == nullptr )
 				{
-					DEBUG_LOG(("Skipping block '%s' because snapshot is nullptr", blockInfo->blockName.str()));
+					DEBUG_LOG(("GameState::xferSaveData - Skipping block '%s' because snapshot is nullptr", blockInfo->blockName.str()));
 					Int dataSize = xfer->beginBlock();
 					xfer->skip( dataSize );
 					continue;

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
@@ -563,8 +563,7 @@ SaveCode GameState::saveGame( AsciiString filename, UnicodeString desc,
 		xferSave.open( filepath );
 	} catch(...) {
 		// print error message to the user
-		if (TheGlobalData && !TheGlobalData->m_headless)
-			TheInGameUI->message( "GUI:Error" );
+		TheInGameUI->message( "GUI:Error" );
 		DEBUG_LOG(( "Error opening file '%s'", filepath.str() ));
 		return SC_ERROR;
 	}
@@ -594,16 +593,13 @@ SaveCode GameState::saveGame( AsciiString filename, UnicodeString desc,
 	catch( ... )
 	{
 
-		if (TheGlobalData && !TheGlobalData->m_headless)
-		{
-			UnicodeString ufilepath;
-			ufilepath.translate(filepath);
+		UnicodeString ufilepath;
+		ufilepath.translate(filepath);
 
-			UnicodeString msg;
-			msg.format( TheGameText->fetch("GUI:ErrorSavingGame"), ufilepath.str() );
+		UnicodeString msg;
+		msg.format( TheGameText->fetch("GUI:ErrorSavingGame"), ufilepath.str() );
 
-			MessageBoxOk(TheGameText->fetch("GUI:Error"), msg, nullptr);
-		}
+		MessageBoxOk(TheGameText->fetch("GUI:Error"), msg, nullptr);
 
 		// close the file and get out of here
 		xferSave.close();
@@ -615,11 +611,8 @@ SaveCode GameState::saveGame( AsciiString filename, UnicodeString desc,
 	xferSave.close();
 
 	// print message to the user for game successfully saved
-	if (TheGlobalData && !TheGlobalData->m_headless)
-	{
-		UnicodeString msg = TheGameText->fetch( "GUI:GameSaveComplete" );
-		TheInGameUI->message( msg );
-	}
+	UnicodeString msg = TheGameText->fetch( "GUI:GameSaveComplete" );
+	TheInGameUI->message( msg );
 
 	return SC_OK;
 
@@ -726,16 +719,13 @@ SaveCode GameState::loadGame( AvailableGameInfo gameInfo )
 		TheGameEngine->reset();
 
 		// print error message to the user
-		if (TheGlobalData && !TheGlobalData->m_headless)
-		{
-			UnicodeString ufilepath;
-			ufilepath.translate(filepath);
+		UnicodeString ufilepath;
+		ufilepath.translate(filepath);
 
-			UnicodeString msg;
-			msg.format( TheGameText->fetch("GUI:ErrorLoadingGame"), ufilepath.str() );
+		UnicodeString msg;
+		msg.format( TheGameText->fetch("GUI:ErrorLoadingGame"), ufilepath.str() );
 
-			MessageBoxOk(TheGameText->fetch("GUI:Error"), msg, nullptr);
-		}
+		MessageBoxOk(TheGameText->fetch("GUI:Error"), msg, nullptr);
 
 		return SC_INVALID_DATA;	// you can't use a naked "throw" outside of a catch statement!
 
@@ -1379,17 +1369,6 @@ void GameState::xferSaveData( Xfer *xfer, SnapshotType which )
 			if( blockInfo->snapshot == nullptr )
 			{
 				DEBUG_LOG(("Skipping block '%s' because snapshot is nullptr", blockName.str()));
-				continue;
-			}
-
-			// Skip visual-only blocks when saving in headless mode
-			if( TheGlobalData && TheGlobalData->m_headless &&
-				(blockName.compareNoCase( "CHUNK_TerrainVisual" ) == 0 ||
-				 blockName.compareNoCase( "CHUNK_TacticalView" ) == 0 ||
-				 blockName.compareNoCase( "CHUNK_ParticleSystem" ) == 0 ||
-				 blockName.compareNoCase( "CHUNK_GhostObject" ) == 0) )
-			{
-				DEBUG_LOG(("Skipping block '%s' in headless mode", blockName.str()));
 				continue;
 			}
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
@@ -34,6 +34,7 @@
 #include "Common/GameEngine.h"
 #include "Common/GameState.h"
 #include "Common/GameStateMap.h"
+#include "Common/GlobalData.h"
 #include "Common/LatchRestore.h"
 #include "Common/MapObject.h"
 #include "Common/PlayerList.h"
@@ -562,7 +563,8 @@ SaveCode GameState::saveGame( AsciiString filename, UnicodeString desc,
 		xferSave.open( filepath );
 	} catch(...) {
 		// print error message to the user
-		TheInGameUI->message( "GUI:Error" );
+		if (!TheGlobalData->m_headless)
+			TheInGameUI->message( "GUI:Error" );
 		DEBUG_LOG(( "Error opening file '%s'", filepath.str() ));
 		return SC_ERROR;
 	}
@@ -592,13 +594,16 @@ SaveCode GameState::saveGame( AsciiString filename, UnicodeString desc,
 	catch( ... )
 	{
 
-		UnicodeString ufilepath;
-		ufilepath.translate(filepath);
+		if (!TheGlobalData->m_headless)
+		{
+			UnicodeString ufilepath;
+			ufilepath.translate(filepath);
 
-		UnicodeString msg;
-		msg.format( TheGameText->fetch("GUI:ErrorSavingGame"), ufilepath.str() );
+			UnicodeString msg;
+			msg.format( TheGameText->fetch("GUI:ErrorSavingGame"), ufilepath.str() );
 
-		MessageBoxOk(TheGameText->fetch("GUI:Error"), msg, nullptr);
+			MessageBoxOk(TheGameText->fetch("GUI:Error"), msg, nullptr);
+		}
 
 		// close the file and get out of here
 		xferSave.close();
@@ -610,8 +615,11 @@ SaveCode GameState::saveGame( AsciiString filename, UnicodeString desc,
 	xferSave.close();
 
 	// print message to the user for game successfully saved
-	UnicodeString msg = TheGameText->fetch( "GUI:GameSaveComplete" );
-	TheInGameUI->message( msg );
+	if (!TheGlobalData->m_headless)
+	{
+		UnicodeString msg = TheGameText->fetch( "GUI:GameSaveComplete" );
+		TheInGameUI->message( msg );
+	}
 
 	return SC_OK;
 
@@ -718,13 +726,16 @@ SaveCode GameState::loadGame( AvailableGameInfo gameInfo )
 		TheGameEngine->reset();
 
 		// print error message to the user
-		UnicodeString ufilepath;
-		ufilepath.translate(filepath);
+		if (!TheGlobalData->m_headless)
+		{
+			UnicodeString ufilepath;
+			ufilepath.translate(filepath);
 
-		UnicodeString msg;
-		msg.format( TheGameText->fetch("GUI:ErrorLoadingGame"), ufilepath.str() );
+			UnicodeString msg;
+			msg.format( TheGameText->fetch("GUI:ErrorLoadingGame"), ufilepath.str() );
 
-		MessageBoxOk(TheGameText->fetch("GUI:Error"), msg, nullptr);
+			MessageBoxOk(TheGameText->fetch("GUI:Error"), msg, nullptr);
+		}
 
 		return SC_INVALID_DATA;	// you can't use a naked "throw" outside of a catch statement!
 
@@ -1363,6 +1374,24 @@ void GameState::xferSaveData( Xfer *xfer, SnapshotType which )
 			blockName = blockInfo->blockName;
 
 			DEBUG_LOG(("Looking at block '%s'", blockName.str()));
+
+			// Skip blocks with nullptr snapshot (can happen in headless mode)
+			if( blockInfo->snapshot == nullptr )
+			{
+				DEBUG_LOG(("Skipping block '%s' because snapshot is nullptr", blockName.str()));
+				continue;
+			}
+
+			// Skip visual-only blocks when saving in headless mode
+			if( TheGlobalData->m_headless &&
+				(blockName.compareNoCase( "CHUNK_TerrainVisual" ) == 0 ||
+				 blockName.compareNoCase( "CHUNK_TacticalView" ) == 0 ||
+				 blockName.compareNoCase( "CHUNK_ParticleSystem" ) == 0 ||
+				 blockName.compareNoCase( "CHUNK_GhostObject" ) == 0) )
+			{
+				DEBUG_LOG(("Skipping block '%s' in headless mode", blockName.str()));
+				continue;
+			}
 
 			//
 			// for mission save files, we only save the game state block and campaign manager

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
@@ -1483,6 +1483,15 @@ void GameState::xferSaveData( Xfer *xfer, SnapshotType which )
 
 				}
 
+				// Skip blocks with nullptr snapshot (can happen in headless mode)
+				if( blockInfo->snapshot == nullptr )
+				{
+					DEBUG_LOG(("Skipping block '%s' because snapshot is nullptr", blockInfo->blockName.str()));
+					Int dataSize = xfer->beginBlock();
+					xfer->skip( dataSize );
+					continue;
+				}
+
 				try
 				{
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/SaveGame/GameState.cpp
@@ -563,7 +563,7 @@ SaveCode GameState::saveGame( AsciiString filename, UnicodeString desc,
 		xferSave.open( filepath );
 	} catch(...) {
 		// print error message to the user
-		if (!TheGlobalData->m_headless)
+		if (TheGlobalData && !TheGlobalData->m_headless)
 			TheInGameUI->message( "GUI:Error" );
 		DEBUG_LOG(( "Error opening file '%s'", filepath.str() ));
 		return SC_ERROR;
@@ -594,7 +594,7 @@ SaveCode GameState::saveGame( AsciiString filename, UnicodeString desc,
 	catch( ... )
 	{
 
-		if (!TheGlobalData->m_headless)
+		if (TheGlobalData && !TheGlobalData->m_headless)
 		{
 			UnicodeString ufilepath;
 			ufilepath.translate(filepath);
@@ -615,7 +615,7 @@ SaveCode GameState::saveGame( AsciiString filename, UnicodeString desc,
 	xferSave.close();
 
 	// print message to the user for game successfully saved
-	if (!TheGlobalData->m_headless)
+	if (TheGlobalData && !TheGlobalData->m_headless)
 	{
 		UnicodeString msg = TheGameText->fetch( "GUI:GameSaveComplete" );
 		TheInGameUI->message( msg );
@@ -726,7 +726,7 @@ SaveCode GameState::loadGame( AvailableGameInfo gameInfo )
 		TheGameEngine->reset();
 
 		// print error message to the user
-		if (!TheGlobalData->m_headless)
+		if (TheGlobalData && !TheGlobalData->m_headless)
 		{
 			UnicodeString ufilepath;
 			ufilepath.translate(filepath);
@@ -1383,7 +1383,7 @@ void GameState::xferSaveData( Xfer *xfer, SnapshotType which )
 			}
 
 			// Skip visual-only blocks when saving in headless mode
-			if( TheGlobalData->m_headless &&
+			if( TheGlobalData && TheGlobalData->m_headless &&
 				(blockName.compareNoCase( "CHUNK_TerrainVisual" ) == 0 ||
 				 blockName.compareNoCase( "CHUNK_TacticalView" ) == 0 ||
 				 blockName.compareNoCase( "CHUNK_ParticleSystem" ) == 0 ||

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -381,7 +381,7 @@ void GameClient::init()
 	TheTerrainVisual = createTerrainVisual();
 	if( TheTerrainVisual ) {
 		TheTerrainVisual->init();
- 		TheTerrainVisual->setName("TheTerrainVisual");
+		TheTerrainVisual->setName("TheTerrainVisual");
 	}
 
 	// allocate the ray effects manager

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -2382,6 +2382,10 @@ void InGameUI::messageColor( const RGBColor *rgbColor, UnicodeString format, ...
 //-------------------------------------------------------------------------------------------------
 void InGameUI::addMessageText( const UnicodeString& formattedMessage, const RGBColor *rgbColor )
 {
+	// TheSuperHackers @fix bobtista 30/01/2026 Skip message display in headless mode to prevent crashes from font/display system
+	if (TheGlobalData && TheGlobalData->m_headless)
+		return;
+
 	Int i;
 	Color color1 = m_messageColor1;
 	Color color2 = m_messageColor2;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -1367,17 +1367,17 @@ void InGameUI::init()
 	been moved to where all the other translators are attached in game client */
 
 	// create the tactical view
-	if (TheDisplay)
+	TheTacticalView = createView();
+	if (TheTacticalView && TheDisplay)
 	{
-		TheTacticalView = createView();
 		TheTacticalView->init();
 		TheDisplay->attachView( TheTacticalView );
 
 		// make the tactical display the full screen width and height
 		TheTacticalView->setWidth( TheDisplay->getWidth() );
 		TheTacticalView->setHeight( TheDisplay->getHeight() );
+		TheTacticalView->setDefaultView(0.0f, 0.0f, 1.0f);
 	}
-	TheTacticalView->setDefaultView(0.0f, 0.0f, 1.0f);
 
 	/** @todo this may be the wrong place to create the sidebar, but for now
 	this is where it lives */

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DGameClient.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DGameClient.h
@@ -119,7 +119,7 @@ protected:
 #endif
 	/// factory for creating the TerrainVisual
 	// TheSuperHackers @fix bobtista 31/01/2026 Return dummy in headless mode
-	virtual TerrainVisual *createTerrainVisual() { return TheGlobalData->m_headless ? NEW TerrainVisualDummy : NEW W3DTerrainVisual; }
+	virtual TerrainVisual *createTerrainVisual() { return TheGlobalData->m_headless ? static_cast<TerrainVisual*>(NEW TerrainVisualDummy) : NEW W3DTerrainVisual; }
 
 	/// factory for creating the snow manager
 	virtual SnowManager *createSnowManager() { return NEW W3DSnowManager; }

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DGameClient.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DGameClient.h
@@ -37,6 +37,7 @@
 // SYSTEM INCLUDES ////////////////////////////////////////////////////////////
 
 // USER INCLUDES //////////////////////////////////////////////////////////////
+#include "Common/GlobalData.h"
 #include "GameClient/GameClient.h"
 #include "W3DDevice/GameClient/W3DParticleSys.h"
 #include "W3DDevice/GameClient/W3DDisplay.h"
@@ -117,7 +118,8 @@ protected:
 	virtual VideoPlayerInterface *createVideoPlayer() { return NEW BinkVideoPlayer; }
 #endif
 	/// factory for creating the TerrainVisual
-	virtual TerrainVisual *createTerrainVisual() { return NEW W3DTerrainVisual; }
+	// TheSuperHackers @fix bobtista 31/01/2026 Return dummy in headless mode
+	virtual TerrainVisual *createTerrainVisual() { return TheGlobalData->m_headless ? NEW TerrainVisualDummy : NEW W3DTerrainVisual; }
 
 	/// factory for creating the snow manager
 	virtual SnowManager *createSnowManager() { return NEW W3DSnowManager; }

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DInGameUI.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DInGameUI.h
@@ -71,7 +71,7 @@ protected:
 
 	/// factory for views
 	// TheSuperHackers @fix bobtista 31/01/2026 Return dummy in headless mode
-	virtual View *createView() { return TheGlobalData->m_headless ? NEW ViewDummy : NEW W3DView; }
+	virtual View *createView() { return TheGlobalData->m_headless ? static_cast<View*>(NEW ViewDummy) : NEW W3DView; }
 
 	virtual void drawSelectionRegion();			///< draw the selection region on screen
 	virtual void drawMoveHints( View *view );			///< draw move hint visual feedback

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DInGameUI.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DInGameUI.h
@@ -36,6 +36,7 @@
 // SYSTEM INCLUDES ////////////////////////////////////////////////////////////
 
 // USER INCLUDES //////////////////////////////////////////////////////////////
+#include "Common/GlobalData.h"
 #include "GameClient/InGameUI.h"
 #include "GameClient/View.h"
 #include "W3DDevice/GameClient/W3DView.h"
@@ -69,7 +70,8 @@ public:
 protected:
 
 	/// factory for views
-	virtual View *createView() { return NEW W3DView; }
+	// TheSuperHackers @fix bobtista 31/01/2026 Return dummy in headless mode
+	virtual View *createView() { return TheGlobalData->m_headless ? NEW ViewDummy : NEW W3DView; }
 
 	virtual void drawSelectionRegion();			///< draw the selection region on screen
 	virtual void drawMoveHints( View *view );			///< draw move hint visual feedback

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameLogic/W3DGameLogic.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameLogic/W3DGameLogic.h
@@ -39,6 +39,7 @@
 #include "GameLogic/GameLogic.h"
 #include "W3DDevice/GameLogic/W3DTerrainLogic.h"
 #include "W3DDevice/GameLogic/W3DGhostObject.h"
+#include "Common/GlobalData.h"
 
 class W3DGhostObjectManager;
 ///////////////////////////////////////////////////////////////////////////////
@@ -59,6 +60,7 @@ protected:
 
 	/// factory for TheTerrainLogic, called from init()
 	virtual TerrainLogic *createTerrainLogic() { return NEW W3DTerrainLogic; };
-	virtual GhostObjectManager *createGhostObjectManager() { return NEW W3DGhostObjectManager; }
+	// TheSuperHackers @feature bobtista 19/01/2026 Use dummy for headless mode
+	virtual GhostObjectManager *createGhostObjectManager() { return TheGlobalData->m_headless ? static_cast<GhostObjectManager*>(NEW GhostObjectManagerDummy) : NEW W3DGhostObjectManager; }
 
 };

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayString.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayString.cpp
@@ -300,7 +300,10 @@ void W3DDisplayString::setFont( GameFont *font )
 	// set the font in our renderer
 	m_textRenderer.Set_Font( static_cast<FontCharsClass *>(m_font->fontData) );
 
-	m_textRendererHotKey.Set_Font( static_cast<FontCharsClass *>(TheFontLibrary->getFont(font->nameString,font->pointSize, TRUE)->fontData) );
+	// TheSuperHackers @fix bobtista 30/01/2026 Check for null before dereferencing to prevent crash if font loading fails
+	GameFont *boldFont = TheFontLibrary->getFont(font->nameString, font->pointSize, TRUE);
+	if (boldFont != nullptr)
+		m_textRendererHotKey.Set_Font( static_cast<FontCharsClass *>(boldFont->fontData) );
 	// recompute extents for text with new font
 	computeExtents();
 


### PR DESCRIPTION
## Summary
  - Guard UI calls (message boxes, in-game messages) with headless mode checks to prevent crashes when saving/loading without a display
  - Skip visual-only snapshot blocks (TerrainVisual, TacticalView, ParticleSystem, GhostObject) when saving in headless mode
  - Handle null snapshot pointers that can occur when visual subsystems aren't initialized

  ## Testing
  - [x] Run headless replay simulation that triggers a save
  - [x] Verify save completes without crashes
  - [ ] Load the headless-created save in normal mode and verify it works
  
  ## Todo
  - [] Replicate to Generals