### PR TITLE
bugfix(pathfinder): Fix late game unit lockups and erroneous impassable terrain

### DIFF
--- a/Core/GameEngine/Include/Common/GameDefines.h
+++ b/Core/GameEngine/Include/Common/GameDefines.h
@@ -36,10 +36,13 @@
 #endif
 
 // This is here to easily toggle between the retail compatible with fixed pathfinding fallback and pure fixed pathfinding mode
-#if RETAIL_COMPATIBLE_CRC
+#ifndef RETAIL_COMPATIBLE_PATHFINDING
 #define RETAIL_COMPATIBLE_PATHFINDING (1)
-#else
-#define RETAIL_COMPATIBLE_PATHFINDING (0)
+#endif
+
+// This is here to easily toggle between the retail compatible pathfinding memory allocation and the new static allocated data mode
+#ifndef RETAIL_COMPATIBLE_PATHFINDING_ALLOCATION
+#define RETAIL_COMPATIBLE_PATHFINDING_ALLOCATION (1)
 #endif
 
 // This is essentially synonymous for RETAIL_COMPATIBLE_CRC. There is a lot wrong with AIGroup, such as use-after-free, double-free, leaks,

--- a/Generals/Code/GameEngine/Include/GameLogic/AIPathfind.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AIPathfind.h
@@ -46,6 +46,9 @@ class PathfindZoneManager;
 
 #define INFANTRY_MOVES_THROUGH_INFANTRY
 
+#if !RETAIL_COMPATIBLE_PATHFINDING
+#undef RETAIL_COMPATIBLE_PATHFINDING_ALLOCATION
+#endif
 
   typedef UnsignedShort zoneStorageType;
 
@@ -287,6 +290,11 @@ public:
 	Bool isAircraftGoal( void) const {return m_aircraftGoal != 0;}
 
 	Bool isObstaclePresent( ObjectID objID ) const;					///< return true if the given object ID is registered as an obstacle in this cell
+#if RETAIL_COMPATIBLE_PATHFINDING_ALLOCATION
+	// TheSuperHackers @info isObstructionInvalid() and clearObstruction() only used during retail compatible pathfinding failover cleanup
+	Bool isObstructionInvalid() const { return m_obstacleID != INVALID_ID && m_info == nullptr && (m_type == CELL_OBSTACLE || m_type == CELL_IMPASSABLE); }
+	void clearObstruction() { m_type = CELL_CLEAR; m_obstacleID = INVALID_ID; m_obstacleIsFence = false; m_obstacleIsTransparent = false; }
+#endif
 
 	inline Bool isObstacleTransparent() const;
 	inline Bool isObstacleFence(void) const;
@@ -363,6 +371,11 @@ public:
 
 private:
 	PathfindCellInfo *m_info;
+	ObjectID m_obstacleID;	                  ///< the object ID who overlaps this cell
+	UnsignedInt m_blockedByAlly : 1;          ///< True if this cell is blocked by an allied unit.
+	UnsignedInt m_obstacleIsFence : 1;        ///< True if occupied by a fence.
+	UnsignedInt m_obstacleIsTransparent : 1;  ///< True if obstacle is transparent (undefined if obstacleid is invalid)
+
 	zoneStorageType m_zone : 14;              ///< Zone. Each zone is a set of adjacent terrain type.  If from & to in the same zone, you can successfully pathfind.  If not,
 	                                          /// you still may be able to if you can cross multiple terrain types.
 	UnsignedShort m_aircraftGoal : 1;         ///< This is an aircraft goal cell.

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -1111,6 +1111,15 @@ void Pathfinder::forceCleanCells()
 
 	for (int j = 0; j <= m_extent.hi.y; ++j) {
 		for (int i = 0; i <= m_extent.hi.x; ++i) {
+#if RETAIL_COMPATIBLE_PATHFINDING_ALLOCATION
+			// TheSuperHackers @bugfix Mauller/DrGoldFish 20/01/2026 when pathfinding resources cannot be allocated to a pathfindCell,
+			// The function to remove an obstacle returns early and PathfindCells remain flagged as obstacles.
+			// We need to make sure to reset pathfindCells with a set m_obstacleID and no m_info.
+			// The use of PathfindCellInfo data for obstacle handling also exausted them resulting in pathfinding lockups.
+			if (m_map[i][j].isObstructionInvalid()) {
+				m_map[i][j].clearObstruction();
+			}
+#endif
 			if (m_map[i][j].hasInfo()) {
 				m_map[i][j].releaseInfo();
 			}
@@ -1238,6 +1247,11 @@ void PathfindCell::reset( )
 		PathfindCellInfo::releaseACellInfo(m_info);
 		m_info = nullptr;
 	}
+	m_obstacleID = INVALID_ID;
+	m_blockedByAlly = false;
+	m_obstacleIsFence = false;
+	m_obstacleIsTransparent = false;
+
 	m_connectsToLayer = LAYER_INVALID;
 	m_layer = LAYER_GROUND;
 
@@ -1274,11 +1288,29 @@ Bool PathfindCell::startPathfind( PathfindCell *goalCell  )
  */
 inline Bool PathfindCell::isBlockedByAlly(void) const
 {
+#if RETAIL_COMPATIBLE_PATHFINDING_ALLOCATION
+	if (s_useFixedPathfinding) {
+		return m_blockedByAlly;
+	}
+
 	return m_info->m_blockedByAlly;
+#else
+	return m_blockedByAlly;
+#endif
 }
+
 inline void PathfindCell::setBlockedByAlly(Bool blocked)
 {
+#if RETAIL_COMPATIBLE_PATHFINDING_ALLOCATION
+	if (s_useFixedPathfinding) {
+		m_blockedByAlly = (blocked != 0);
+		return;
+	}
+
 	m_info->m_blockedByAlly = (blocked != 0);
+#else
+	m_blockedByAlly = (blocked != 0);
+#endif
 }
 
 /**
@@ -1488,7 +1520,15 @@ void PathfindCell::setPosUnit(ObjectID unitID, const ICoord2D &pos )
  */
 inline ObjectID PathfindCell::getObstacleID(void) const
 {
+#if RETAIL_COMPATIBLE_PATHFINDING_ALLOCATION
+	if (s_useFixedPathfinding) {
+		return m_obstacleID;
+	}
+
 	return m_info ? m_info->m_obstacleID : INVALID_ID;
+#else
+	return m_obstacleID;
+#endif
 }
 
 
@@ -1509,14 +1549,33 @@ void PathfindCell::setTypeAsObstacle( Object *obstacle, Bool isFence, const ICoo
 
 	if (isRubble) {
 		m_type = PathfindCell::CELL_RUBBLE;
+		m_obstacleID = INVALID_ID;
+		m_obstacleIsFence = false;
+		m_obstacleIsTransparent = false;
+#if RETAIL_COMPATIBLE_PATHFINDING_ALLOCATION
+		if (s_useFixedPathfinding) {
+			return;
+		}
+
 		if (m_info) {
 			m_info->m_obstacleID = INVALID_ID;
 			releaseInfo();
 		}
+#endif
 		return;
 	}
 
 	m_type = PathfindCell::CELL_OBSTACLE;
+	m_obstacleID = obstacle->getID();
+	m_obstacleIsFence = isFence;
+	m_obstacleIsTransparent = obstacle->isKindOf(KINDOF_CAN_SEE_THROUGH_STRUCTURE);
+#if RETAIL_COMPATIBLE_PATHFINDING_ALLOCATION
+	// TheSuperHackers @info In retail mode we need to track orphaned cells set as obstacles so we can cleanup and failover properly
+	// So we always make sure to set and clear the local obstacle data on the PathfindCell regardless of retail compat or not
+	if (s_useFixedPathfinding) {
+		return;
+	}
+
 	if (!m_info) {
 		m_info = PathfindCellInfo::getACellInfo(this, pos);
 		if (!m_info) {
@@ -1527,6 +1586,8 @@ void PathfindCell::setTypeAsObstacle( Object *obstacle, Bool isFence, const ICoo
 	m_info->m_obstacleID = obstacle->getID();
 	m_info->m_obstacleIsFence = isFence;
 	m_info->m_obstacleIsTransparent = obstacle->isKindOf(KINDOF_CAN_SEE_THROUGH_STRUCTURE);
+#endif
+	return;
 }
 
 /**
@@ -1534,29 +1595,62 @@ void PathfindCell::setTypeAsObstacle( Object *obstacle, Bool isFence, const ICoo
  */
 void PathfindCell::setType( CellType type )
 {
+#if RETAIL_COMPATIBLE_PATHFINDING_ALLOCATION
+	if (s_useFixedPathfinding) {
+		if (m_obstacleID != INVALID_ID) {
+			DEBUG_ASSERTCRASH(type == PathfindCell::CELL_OBSTACLE, ("Wrong type."));
+			m_type = PathfindCell::CELL_OBSTACLE;
+			return;
+		}
+	}
+
 	if (m_info && (m_info->m_obstacleID != INVALID_ID)) {
 		DEBUG_ASSERTCRASH(type==PathfindCell::CELL_OBSTACLE, ("Wrong type."));
 		m_type = PathfindCell::CELL_OBSTACLE;
 		return;
 	}
+#else
+	if (m_obstacleID != INVALID_ID) {
+		DEBUG_ASSERTCRASH(type == PathfindCell::CELL_OBSTACLE, ("Wrong type."));
+		m_type = PathfindCell::CELL_OBSTACLE;
+		return;
+	}
+#endif
 	m_type = type;
 }
 
 /**
- * Flag this cell as an obstacle, from the given one
+ * Unflag this cell as an obstacle, from the given one.
  */
 void PathfindCell::removeObstacle( Object *obstacle )
 {
 	if (m_type == PathfindCell::CELL_RUBBLE) {
 		m_type = PathfindCell::CELL_CLEAR;
 	}
+#if RETAIL_COMPATIBLE_PATHFINDING_ALLOCATION
+	if (s_useFixedPathfinding) {
+		if (m_obstacleID != obstacle->getID()) return;
+		m_type = PathfindCell::CELL_CLEAR;
+		m_obstacleID = INVALID_ID;
+		m_obstacleIsFence = false;
+		m_obstacleIsTransparent = false;
+		return;
+	}
+
 	if (!m_info) return;
 	if (m_info->m_obstacleID != obstacle->getID()) return;
 	m_type = PathfindCell::CELL_CLEAR;
-	if (m_info) {
-		m_info->m_obstacleID = INVALID_ID;
-		releaseInfo();
-	}
+	m_info->m_obstacleID = INVALID_ID;
+	releaseInfo();
+
+#else
+	if (m_obstacleID != obstacle->getID()) return;
+	m_type = PathfindCell::CELL_CLEAR;
+#endif
+	m_obstacleID = INVALID_ID;
+	m_obstacleIsFence = false;
+	m_obstacleIsTransparent = false;
+	return;
 }
 
 /// put self on "open" list in ascending cost order, return new list
@@ -1762,8 +1856,16 @@ inline Bool PathfindCell::isObstaclePresent(ObjectID objID) const
 {
 	if (objID != INVALID_ID && (getType() == PathfindCell::CELL_OBSTACLE))
 	{
+#if RETAIL_COMPATIBLE_PATHFINDING_ALLOCATION
+		if (s_useFixedPathfinding) {
+			return m_obstacleID == objID;
+		}
+
 		DEBUG_ASSERTCRASH(m_info, ("Should have info to be obstacle."));
 		return (m_info && m_info->m_obstacleID == objID);
+#else
+		return m_obstacleID == objID;
+#endif
 	}
 
 	return false;
@@ -1775,7 +1877,15 @@ inline Bool PathfindCell::isObstaclePresent(ObjectID objID) const
  */
 inline Bool PathfindCell::isObstacleTransparent() const
 {
+#if RETAIL_COMPATIBLE_PATHFINDING_ALLOCATION
+	if (s_useFixedPathfinding) {
+		return m_obstacleIsTransparent;
+	}
+
 	return m_info ? m_info->m_obstacleIsTransparent : false;
+#else
+	return m_obstacleIsTransparent;
+#endif
 }
 
 /**
@@ -1783,7 +1893,15 @@ inline Bool PathfindCell::isObstacleTransparent() const
  */
 inline Bool PathfindCell::isObstacleFence(void) const
 {
+#if RETAIL_COMPATIBLE_PATHFINDING_ALLOCATION
+	if (s_useFixedPathfinding) {
+		return m_obstacleIsFence;
+	}
+
 	return m_info ? m_info->m_obstacleIsFence : false;
+#else
+	return m_obstacleIsFence;
+#endif
 }
 
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AIPathfind.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AIPathfind.h
@@ -47,6 +47,9 @@ class PathfindZoneManager;
 
 #define INFANTRY_MOVES_THROUGH_INFANTRY
 
+#if !RETAIL_COMPATIBLE_PATHFINDING
+#undef RETAIL_COMPATIBLE_PATHFINDING_ALLOCATION
+#endif
 
   typedef UnsignedShort zoneStorageType;
 
@@ -288,6 +291,11 @@ public:
 	Bool isAircraftGoal( void) const {return m_aircraftGoal != 0;}
 
 	Bool isObstaclePresent( ObjectID objID ) const;					///< return true if the given object ID is registered as an obstacle in this cell
+#if RETAIL_COMPATIBLE_PATHFINDING_ALLOCATION
+	// TheSuperHackers @info isObstructionInvalid() and clearObstruction() only used during retail compatible pathfinding failover cleanup
+	Bool isObstructionInvalid() const { return m_obstacleID != INVALID_ID && m_info == nullptr && (m_type == CELL_OBSTACLE || m_type == CELL_IMPASSABLE); }
+	void clearObstruction() { m_type = CELL_CLEAR; m_obstacleID = INVALID_ID; m_obstacleIsFence = false; m_obstacleIsTransparent = false; }
+#endif
 
 	inline Bool isObstacleTransparent() const;
 	inline Bool isObstacleFence(void) const;
@@ -364,6 +372,11 @@ public:
 
 private:
 	PathfindCellInfo *m_info;
+	ObjectID m_obstacleID;	                  ///< the object ID who overlaps this cell
+	UnsignedInt m_blockedByAlly : 1;          ///< True if this cell is blocked by an allied unit.
+	UnsignedInt m_obstacleIsFence : 1;        ///< True if occupied by a fence.
+	UnsignedInt m_obstacleIsTransparent : 1;  ///< True if obstacle is transparent (undefined if obstacleid is invalid)
+
 	zoneStorageType m_zone : 14;              ///< Zone. Each zone is a set of adjacent terrain type.  If from & to in the same zone, you can successfully pathfind.  If not,
 	                                          /// you still may be able to if you can cross multiple terrain types.
 	UnsignedShort m_aircraftGoal : 1;         ///< This is an aircraft goal cell.


### PR DESCRIPTION
**Merge by rebase**

- Closes: #1984 
- Closes: #1985 
- Closed: #2156 

This PR come in two parts, a retail compatible version, with a failover when the pathfinding crashes, and a non retail compatible path.

The new define `RETAIL_COMPATIBLE_PATHFINDING_ALLOCATION` was added and will be used for further pathfinding changes that are not retail compatible that will be upcoming. These changes alter data handling within the pathfinding.

The main issue resolved is when units stop moving late game and where parts of the map become impassable after a building has been removed. Buildings placed after the late game lockup leave impassable map tiles when removed.
The reason units stop moving is that objects / buildings placed on the map use up PathfindCellInfo resources which are in a limited pool and are used during the A* Pathfinding.
And impassable terrain occurs because the code to remove terrain objects exits early if the PathfindCell has no PathfindCellInfo allocated to it.

In this PR we first refactor the obstacle handling functions within PathfindCell from the header and into the cpp, this was required to allow the retail compatible changes to make use of the static variable that signals the pathfinding failover within the cpp file.

In the second commit, the objectID, object blocked by ally, object is transparent and object is fence variables were added to the PathfindCell from the PathfindCellInfo. These variables are then used explicitly in the non retail codepath, in the retail mode they are used in parallel before failover to help identify invalid impassable terrain, then used in a dedicated way in the fixed pathfinding pathway.

Might need better names on the commits but can discuss it bellow

---

- [x] Replicate in generals