### PR TITLE
bugfix(wbview3d): Fix crash on window resize in Generals World Builder

### DIFF
--- a/Generals/Code/Tools/WorldBuilder/src/wbview3d.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/wbview3d.cpp
@@ -573,16 +573,6 @@ void WbView3d::reset3dEngineDisplaySize(Int width, Int height)
 	bogusTacticalView.setOrigin(0,0);
 	m_actualWinSize.x = width;
 	m_actualWinSize.y = height;
-	// TheSuperHackers @bugfix jurassiclizard 19/01/2026  Fix Generals World-builder Crash
-	// when Switching from one Window size to another (#2008), Brought the logic to be the exact same
-	// as in the generals zero-hour WorldBuilder which is known to work without crashing: Removing shutdown and reinit
-	// when resetting the device resolution appears to resolve the issue.
-	// When shutting down and reinitializing the device might not be ready yet by the time
-	// the call is made again to Wd3ShaderManager::init() and this causes the Generals WorldBuilder to crash
-	// when resizing from a resolution to another and then back to that resolution again.
-	// nullpointer checks inside the init function didnot help alleviate the issue
-	//  See Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DShaderManager.cpp  and
-	//  GeneralsMD/Code/Tools/WorldBuilder/src/wbview3d.cpp for more information
 	if (m_ww3dInited) {
 		WW3D::Set_Device_Resolution(m_actualWinSize.x, m_actualWinSize.y, true);
 	}


### PR DESCRIPTION
  - fixes #2008
  - Note 1: This issue only affects Generals but not Zero Hour
  - Note 2: Crash happens When Switching from one Window size to another (#2008), Brought the logic to be the exact same as in the generals zero-hour WorldBuilder which is known to work without crashing: Removing shutdown and reinit when resetting the display size appears to resolve the issue. When shutting down and reinitializing the device might not be ready yet by the time the call is made again to Wd3ShaderManager::init() and this causes the Generals WorldBuilder to crash when resizing from a resolution to another and then back to that resolution again. nullpointer checks inside the init function didnot help alleviate the issue
  - See Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DShaderManager.cpp  and GeneralsMD/Code/Tools/WorldBuilder/src/wbview3d.cpp for more information

Working Zero Hour implementation from main branch : https://github.com/TheSuperHackers/GeneralsGameCode/blob/6818fae6278182c6cffee4b0e2e0752e647dd165/GeneralsMD/Code/Tools/WorldBuilder/src/wbview3d.cpp#L594