### PR TITLE
fix(saveload): Use getFinalOverride in WeaponSet xfer load to match Object constructor

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/Thing.h
+++ b/Generals/Code/GameEngine/Include/Common/Thing.h
@@ -95,9 +95,7 @@ public:
 
 	Thing( const ThingTemplate *thingTemplate );
 
-	/**
-		return the thing template for this thing.
-	*/
+	/** Return the final override of this thing's template. */
 	const ThingTemplate *getTemplate() const;
 
 	// convenience method for patching isKindOf thru to template.

--- a/Generals/Code/GameEngine/Include/Common/ThingFactory.h
+++ b/Generals/Code/GameEngine/Include/Common/ThingFactory.h
@@ -66,18 +66,18 @@ public:
 	/// create a new template with name 'name' and add to template list
 	ThingTemplate *newTemplate( const AsciiString& name );
 
-	// get the first template in our list
+	// Get the first template in the database. Does not resolve the final override.
 	const ThingTemplate *firstTemplate() { return m_firstTemplate; }
 
 	/**
-		get a template given template database name. return null if not found.
-		note, this is now substantially faster (does a hash-table lookup)
+		Get a template by database name. Returns null if not found.
+		Does not resolve the final override.
 	*/
 	const ThingTemplate *findTemplate( const AsciiString& name, Bool check = TRUE ) { return findTemplateInternal( name, check ); }
 
 	/**
-		get a template given ID. return null if not found.
-		note, this is not particularly fast (does a linear search).
+		Get a template by ID. Returns null if not found.
+		Does not resolve the final override.
 	*/
 	const ThingTemplate *findByTemplateID( UnsignedShort id );
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/WeaponSet.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/WeaponSet.cpp
@@ -231,6 +231,11 @@ void WeaponSet::xfer( Xfer *xfer )
 			if (tt == nullptr)
 				throw INI_INVALID_DATA;
 
+			// TheSuperHackers @fix bobtista 27/01/2026 findTemplate returns the base template, but Object
+			// uses getFinalOverride() in its constructor. We must do the same here so m_curWeaponTemplateSet
+			// points to the same ThingTemplate's weapon sets, avoiding unnecessary reallocation in updateWeaponSet.
+			tt = static_cast<const ThingTemplate*>(tt->getFinalOverride());
+
 			m_curWeaponTemplateSet = tt->findWeaponTemplateSet(wsFlags);
 			if (m_curWeaponTemplateSet == nullptr)
 				throw INI_INVALID_DATA;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/WeaponSet.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/WeaponSet.cpp
@@ -231,9 +231,7 @@ void WeaponSet::xfer( Xfer *xfer )
 			if (tt == nullptr)
 				throw INI_INVALID_DATA;
 
-			// TheSuperHackers @fix bobtista 27/01/2026 findTemplate returns the base template, but Object
-			// uses getFinalOverride() in its constructor. We must do the same here so m_curWeaponTemplateSet
-			// points to the same ThingTemplate's weapon sets, avoiding unnecessary reallocation in updateWeaponSet.
+			// TheSuperHackers @fix bobtista 27/01/2026 Use the same final override as Object.
 			tt = static_cast<const ThingTemplate*>(tt->getFinalOverride());
 
 			m_curWeaponTemplateSet = tt->findWeaponTemplateSet(wsFlags);

--- a/GeneralsMD/Code/GameEngine/Include/Common/Thing.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Thing.h
@@ -95,8 +95,7 @@ public:
 
 	Thing( const ThingTemplate *thingTemplate );
 
-	// TheSuperHackers @info bobtista 17/08/2026 m_template is an OVERRIDE, so getTemplate() dynamically
-	// returns the final override rather than the database entry originally stored by this Thing.
+	/** Return the final override of this thing's template. */
 	const ThingTemplate *getTemplate() const;
 
 	// convenience method for patching isKindOf thru to template.

--- a/GeneralsMD/Code/GameEngine/Include/Common/Thing.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Thing.h
@@ -95,9 +95,8 @@ public:
 
 	Thing( const ThingTemplate *thingTemplate );
 
-	/**
-		return the thing template for this thing.
-	*/
+	// TheSuperHackers @info bobtista 17/08/2026 m_template is an OVERRIDE, so getTemplate() dynamically
+	// returns the final override rather than the database entry originally stored by this Thing.
 	const ThingTemplate *getTemplate() const;
 
 	// convenience method for patching isKindOf thru to template.

--- a/GeneralsMD/Code/GameEngine/Include/Common/ThingFactory.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/ThingFactory.h
@@ -66,19 +66,26 @@ public:
 	/// create a new template with name 'name' and add to template list
 	ThingTemplate *newTemplate( const AsciiString& name );
 
-	// get the first template in our list
+	// TheSuperHackers @info bobtista 17/08/2026 Return the first database entry without resolving its
+	// override chain.
 	const ThingTemplate *firstTemplate() { return m_firstTemplate; }
 
 	/**
 		get a template given template database name. return null if not found.
 		note, this is now substantially faster (does a hash-table lookup)
 	*/
+	// TheSuperHackers @info bobtista 17/08/2026 findTemplate returns the stored database entry without
+	// following its override chain. Call getFinalOverride() when the active map or mission override is
+	// required. Override nodes are deleted by ThingFactory::reset(), so do not cache a resolved override
+	// across matches.
 	const ThingTemplate *findTemplate( const AsciiString& name, Bool check = TRUE ) { return findTemplateInternal( name, check ); }
 
 	/**
 		get a template given ID. return null if not found.
 		note, this is not particularly fast (does a linear search).
 	*/
+	// TheSuperHackers @info bobtista 17/08/2026 Like findTemplate(), this returns the stored database
+	// entry rather than its final override.
 	const ThingTemplate *findByTemplateID( UnsignedShort id );
 
 	/** request a new object using the given template.

--- a/GeneralsMD/Code/GameEngine/Include/Common/ThingFactory.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/ThingFactory.h
@@ -66,26 +66,19 @@ public:
 	/// create a new template with name 'name' and add to template list
 	ThingTemplate *newTemplate( const AsciiString& name );
 
-	// TheSuperHackers @info bobtista 17/08/2026 Return the first database entry without resolving its
-	// override chain.
+	// Get the first template in the database. Does not resolve the final override.
 	const ThingTemplate *firstTemplate() { return m_firstTemplate; }
 
 	/**
-		get a template given template database name. return null if not found.
-		note, this is now substantially faster (does a hash-table lookup)
+		Get a template by database name. Returns null if not found.
+		Does not resolve the final override.
 	*/
-	// TheSuperHackers @info bobtista 17/08/2026 findTemplate returns the stored database entry without
-	// following its override chain. Call getFinalOverride() when the active map or mission override is
-	// required. Override nodes are deleted by ThingFactory::reset(), so do not cache a resolved override
-	// across matches.
 	const ThingTemplate *findTemplate( const AsciiString& name, Bool check = TRUE ) { return findTemplateInternal( name, check ); }
 
 	/**
-		get a template given ID. return null if not found.
-		note, this is not particularly fast (does a linear search).
+		Get a template by ID. Returns null if not found.
+		Does not resolve the final override.
 	*/
-	// TheSuperHackers @info bobtista 17/08/2026 Like findTemplate(), this returns the stored database
-	// entry rather than its final override.
 	const ThingTemplate *findByTemplateID( UnsignedShort id );
 
 	/** request a new object using the given template.

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/WeaponSet.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/WeaponSet.cpp
@@ -317,7 +317,22 @@ void WeaponSet::updateWeaponSet(const Object* obj)
 {
 	const WeaponTemplateSet* set = obj->getTemplate()->findWeaponTemplateSet(obj->getWeaponSetFlags());
 	DEBUG_ASSERTCRASH(set, ("findWeaponSet should never return null"));
-	if (set && set != m_curWeaponTemplateSet)
+	// TheSuperHackers @bugfix bobtista 20/01/2026 After checkpoint load, the m_curWeaponTemplateSet pointer
+	// may differ from set even though they represent the same weapon set (pointer aliasing after load).
+	// Compare by flags instead of by pointer to avoid unnecessary weapon reallocation which corrupts
+	// weapon timing state and causes CRC mismatches during replay.
+	Bool needsUpdate = set && set != m_curWeaponTemplateSet;
+	if (needsUpdate && m_curWeaponTemplateSet)
+	{
+		// If flags match, the weapon sets are logically equivalent - no need to reallocate
+		if (obj->getWeaponSetFlags() == m_curWeaponTemplateSet->friend_getWeaponSetFlags())
+		{
+			// Just update the pointer to the correct address without reallocating weapons
+			m_curWeaponTemplateSet = set;
+			needsUpdate = false;
+		}
+	}
+	if (needsUpdate)
 	{
 		if( ! set->isWeaponLockSharedAcrossSets() )
 		{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/WeaponSet.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/WeaponSet.cpp
@@ -239,6 +239,9 @@ void WeaponSet::xfer( Xfer *xfer )
 			if (tt == nullptr)
 				throw INI_INVALID_DATA;
 
+			// TheSuperHackers @bugfix bobtista 23/01/2026 Use final override to match what Object uses.
+			tt = (const ThingTemplate*)tt->getFinalOverride();
+
 			m_curWeaponTemplateSet = tt->findWeaponTemplateSet(wsFlags);
 			if (m_curWeaponTemplateSet == nullptr)
 				throw INI_INVALID_DATA;
@@ -317,22 +320,7 @@ void WeaponSet::updateWeaponSet(const Object* obj)
 {
 	const WeaponTemplateSet* set = obj->getTemplate()->findWeaponTemplateSet(obj->getWeaponSetFlags());
 	DEBUG_ASSERTCRASH(set, ("findWeaponSet should never return null"));
-	// TheSuperHackers @bugfix bobtista 20/01/2026 After checkpoint load, the m_curWeaponTemplateSet pointer
-	// may differ from set even though they represent the same weapon set (pointer aliasing after load).
-	// Compare by flags instead of by pointer to avoid unnecessary weapon reallocation which corrupts
-	// weapon timing state and causes CRC mismatches during replay.
-	Bool needsUpdate = set && set != m_curWeaponTemplateSet;
-	if (needsUpdate && m_curWeaponTemplateSet)
-	{
-		// If flags match, the weapon sets are logically equivalent - no need to reallocate
-		if (obj->getWeaponSetFlags() == m_curWeaponTemplateSet->friend_getWeaponSetFlags())
-		{
-			// Just update the pointer to the correct address without reallocating weapons
-			m_curWeaponTemplateSet = set;
-			needsUpdate = false;
-		}
-	}
-	if (needsUpdate)
+	if (set && set != m_curWeaponTemplateSet)
 	{
 		if( ! set->isWeaponLockSharedAcrossSets() )
 		{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/WeaponSet.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/WeaponSet.cpp
@@ -239,9 +239,7 @@ void WeaponSet::xfer( Xfer *xfer )
 			if (tt == nullptr)
 				throw INI_INVALID_DATA;
 
-			// TheSuperHackers @fix bobtista 27/01/2026 findTemplate returns the base template, but Object
-			// uses getFinalOverride() in its constructor. We must do the same here so m_curWeaponTemplateSet
-			// points to the same ThingTemplate's weapon sets, avoiding unnecessary reallocation in updateWeaponSet.
+			// TheSuperHackers @fix bobtista 27/01/2026 Use the same final override as Object.
 			tt = static_cast<const ThingTemplate*>(tt->getFinalOverride());
 
 			m_curWeaponTemplateSet = tt->findWeaponTemplateSet(wsFlags);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/WeaponSet.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/WeaponSet.cpp
@@ -239,8 +239,10 @@ void WeaponSet::xfer( Xfer *xfer )
 			if (tt == nullptr)
 				throw INI_INVALID_DATA;
 
-			// TheSuperHackers @bugfix bobtista 23/01/2026 Use final override to match what Object uses.
-			tt = (const ThingTemplate*)tt->getFinalOverride();
+			// TheSuperHackers @fix bobtista 27/01/2026 findTemplate returns the base template, but Object
+			// uses getFinalOverride() in its constructor. We must do the same here so m_curWeaponTemplateSet
+			// points to the same ThingTemplate's weapon sets, avoiding unnecessary reallocation in updateWeaponSet.
+			tt = static_cast<const ThingTemplate*>(tt->getFinalOverride());
 
 			m_curWeaponTemplateSet = tt->findWeaponTemplateSet(wsFlags);
 			if (m_curWeaponTemplateSet == nullptr)


### PR DESCRIPTION
## Summary                                                                                                                                                      
Fixes weapon timing state corruption after loading a saved game by ensuring WeaponSet uses the same template override as Object.                                  
                                                                                                                                                                     
### Notes
- `Object` constructor calls `getFinalOverride()` on the template (Object.cpp:230)                                                                                
- `WeaponSet::xfer(LOAD)` was using `TheThingFactory->findTemplate()` which returns the base template, not the final override                                     
- This caused `m_curWeaponTemplateSet` to point to a different ThingTemplate's weapon sets than `obj->getTemplate()`                                              
- The pointer mismatch in `updateWeaponSet()` triggered unnecessary weapon reallocation, resetting timing state                                                   
                                                                                                                                                                     
### Fix                                                                                                                                                           
Add `getFinalOverride()` call in `WeaponSet::xfer(LOAD)` to match what Object does, ensuring consistent template pointers.                                        
                                                                                                                                                                     
## Testing                                                                                                                                                        
- [x] Save game with units that have weapons mid-reload                                                                                                           
- [x] Load the save and verify weapons maintain their reload state                                                                                                
- [x] Verify normal weapon switching still works correctly                                                                                                        
                                                                                                                                                                     
## Todo                                                                                                                                                           
- [X] Replicate to Generals