### PR TITLE
fix(object): Save and load game object list in correct order

### DIFF
--- a/Generals/Code/GameEngine/Include/GameLogic/Object.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Object.h
@@ -166,6 +166,10 @@ public:
 
 	Object* getNextObject() { return m_next; }
 	const Object* getNextObject() const { return m_next; }
+	Object* getPrevObject() { return m_prev; }
+	const Object* getPrevObject() const { return m_prev; }
+	void friend_setNextObject(Object* obj) { m_next = obj; }
+	void friend_setPrevObject(Object* obj) { m_prev = obj; }
 
 	void updateObjValuesFromMapProperties(Dict* properties);			///< Brings in properties set in the editor.
 

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -4282,7 +4282,7 @@ void GameLogic::xfer( Xfer *xfer )
 	if( xfer->getXferMode() == XFER_SAVE )
 	{
 
-		// TheSuperHackers @bugfix bobtista 27/01/2026 Save objects in reverse order (newest first)
+		// TheSuperHackers @fix bobtista 27/01/2026 Save objects in reverse order (newest first)
 		// so they load in the correct order (oldest objects at head of list).
 		Object *lastObj = nullptr;
 		for( obj = getFirstObject(); obj; obj = obj->getNextObject() )

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -4241,7 +4241,7 @@ void GameLogic::prepareLogicForObjectLoad( void )
 	*		 this version breaks compatibility with previous versions. (CBD)
 	* 5: Added xfering the BuildAssistant's sell list.
 	* 9: Added m_rankPointsToAddAtGameStart, or else on a load game, your RestartGame button will forget your exp
-	* 10: Save objects in reverse order so they load in correct order. Reverse object list for old saves.
+	* 10: TheSuperHackers @tweak Save objects in reverse order so they load in correct order. Reverse object list for old saves.
 	*/
 // ------------------------------------------------------------------------------------------------
 void GameLogic::xfer( Xfer *xfer )
@@ -4371,10 +4371,10 @@ void GameLogic::xfer( Xfer *xfer )
 
 		}
 
-		// TheSuperHackers @bugfix bobtista 27/01/2026 Reverse object list for old saves.
+		// TheSuperHackers @fix bobtista 27/01/2026 Reverse object list for old saves.
 		// Old saves stored objects oldest-first, which results in reversed order when loaded
 		// since objects are prepended during creation. Version 10+ saves in reverse order.
-		if ( version < 10 )
+		if ( version <= 9 )
 		{
 			Object *prev = nullptr;
 			Object *current = m_objList;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
@@ -172,6 +172,9 @@ public:
 
 	Object* getNextObject() { return m_next; }
 	const Object* getNextObject() const { return m_next; }
+	// TheSuperHackers @info bobtista 19/01/2026 Friend methods to allow GameLogic to fix object list order after load
+	void friend_setNextObject(Object* obj) { m_next = obj; }
+	void friend_setPrevObject(Object* obj) { m_prev = obj; }
 
 	void updateObjValuesFromMapProperties(Dict* properties);			///< Brings in properties set in the editor.
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
@@ -172,7 +172,8 @@ public:
 
 	Object* getNextObject() { return m_next; }
 	const Object* getNextObject() const { return m_next; }
-	// TheSuperHackers @info bobtista 19/01/2026 Friend methods to allow GameLogic to fix object list order after load
+	Object* getPrevObject() { return m_prev; }
+	const Object* getPrevObject() const { return m_prev; }
 	void friend_setNextObject(Object* obj) { m_next = obj; }
 	void friend_setPrevObject(Object* obj) { m_prev = obj; }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -4924,6 +4924,23 @@ void GameLogic::xfer( Xfer *xfer )
 
 		}
 
+		// TheSuperHackers @fix bobtista 19/01/2026
+		// Reverse the object list to restore the original order.
+		// Objects are prepended during registration, so loading them in save order
+		// (oldest first in original list) results in a reversed list.
+		Object *prev = nullptr;
+		Object *current = m_objList;
+		Object *next = nullptr;
+		while ( current != nullptr )
+		{
+			next = current->getNextObject();
+			current->friend_setNextObject( prev );
+			current->friend_setPrevObject( next );
+			prev = current;
+			current = next;
+		}
+		m_objList = prev;
+
 	}
 
 	// campaign info

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -4801,7 +4801,7 @@ void GameLogic::prepareLogicForObjectLoad( void )
 	* 5: Added xfering the BuildAssistant's sell list.
 	* 9: Added m_rankPointsToAddAtGameStart, or else on a load game, your RestartGame button will forget your exp
   * 10: xfer m_superweaponRestriction
-  * 11: Save objects in reverse order so they load in correct order
+  * 11: TheSuperHackers @tweak Save objects in reverse order so they load in correct order
 	*/
 // ------------------------------------------------------------------------------------------------
 void GameLogic::xfer( Xfer *xfer )
@@ -4930,10 +4930,10 @@ void GameLogic::xfer( Xfer *xfer )
 
 		}
 
-		// TheSuperHackers @bugfix bobtista 27/01/2026 Reverse object list for old saves.
+		// TheSuperHackers @fix bobtista 27/01/2026 Reverse object list for old saves.
 		// Old saves stored objects oldest-first, which results in reversed order when loaded
 		// since objects are prepended during creation. Version 11+ saves in reverse order.
-		if ( version < 11 )
+		if ( version <= 10 )
 		{
 			Object *prev = nullptr;
 			Object *current = m_objList;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -4841,7 +4841,7 @@ void GameLogic::xfer( Xfer *xfer )
 	ObjectTOCEntry *tocEntry;
 	if( xfer->getXferMode() == XFER_SAVE )
 	{
-		// TheSuperHackers @bugfix bobtista 27/01/2026 Save objects in reverse order (newest first)
+		// TheSuperHackers @fix bobtista 27/01/2026 Save objects in reverse order (newest first)
 		// so they load in the correct order (oldest objects at head of list).
 		Object *lastObj = nullptr;
 		for( obj = getFirstObject(); obj; obj = obj->getNextObject() )


### PR DESCRIPTION
 ## Summary
  - Objects were saved oldest-first but loaded via prepending, which reversed their order                                                                            
  - New saves now write objects in reverse order (newest first) so they load correctly                                                                               
  - Old saves have their object list reversed after loading to fix the order                                                                                         
  - Bumped xfer version to 11 (Zero Hour) and 10 (Generals) for backwards compatibility                                                                              
                                                                                                                                                                     
  ## Test plan                                                                                                                                                       
  - [x] Load an existing save from before this change, verify objects behave correctly                                                                               
  - [x] Create a new save, reload it, verify object order matches the original session                                                                               
  - [x] Verify game runs normally

Todo:
- [X] Replicate to Generals