### PR TITLE
build(cmake): Dial back BINK upgrade to get the CMake INSTALL target to work again

### DIFF
--- a/cmake/bink.cmake
+++ b/cmake/bink.cmake
@@ -1,7 +1,7 @@
 FetchContent_Declare(
     bink
     GIT_REPOSITORY https://github.com/TheSuperHackers/bink-sdk-stub.git
-    GIT_TAG        f554b7fa68c97d4e6b607d535e726ef37622fe65
+    GIT_TAG        180fc4620ed72fd700347ab837a5271fd0259901
 )
 
 FetchContent_MakeAvailable(bink)


### PR DESCRIPTION
* Relates to #2166
* Follow up for #2067

https://github.com/TheSuperHackers/GeneralsGameCode/commit/c1caa58974eea25e3b10414025b097e27785090e introduced a breaking change to the INSTALL target by upgrading BINK.

BINK CMake needs fixing before we can upgrade it again.