### PR TITLE
fix(thingfactory): Prevent use-after-free from assert in ThingFactory::reset()

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/Thing/ThingFactory.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Thing/ThingFactory.cpp
@@ -215,6 +215,8 @@ void ThingFactory::reset( void )
 		// t itself can be deleted if it is something created for this map only. Therefore,
 		// we need to store what the next item is so that we don't orphan a bunch of templates.
 		ThingTemplate *nextT = t->friend_getNextTemplate();
+		DEBUG_ASSERTCRASH(!nextT || t->getTemplateID() == nextT->getTemplateID() + 1, ("Next template ID is unexpected"));
+
 		if (t == m_firstTemplate) {
 			possibleAdjustment = TRUE;
 		}
@@ -235,8 +237,6 @@ void ThingFactory::reset( void )
 			// Also needs to be removed from the Hash map.
 			m_templateHashMap.erase(templateName);
 		}
-
-		DEBUG_ASSERTCRASH(!nextT || t->getTemplateID() == nextT->getTemplateID() + 1, ("Next template ID is unexpected"));
 
 		t = nextT;
 	}

--- a/GeneralsMD/Code/GameEngine/Source/Common/Thing/ThingFactory.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Thing/ThingFactory.cpp
@@ -215,6 +215,8 @@ void ThingFactory::reset( void )
 		// t itself can be deleted if it is something created for this map only. Therefore,
 		// we need to store what the next item is so that we don't orphan a bunch of templates.
 		ThingTemplate *nextT = t->friend_getNextTemplate();
+		DEBUG_ASSERTCRASH(!nextT || t->getTemplateID() == nextT->getTemplateID() + 1, ("Next template ID is unexpected"));
+
 		if (t == m_firstTemplate) {
 			possibleAdjustment = TRUE;
 		}
@@ -235,8 +237,6 @@ void ThingFactory::reset( void )
 			// Also needs to be removed from the Hash map.
 			m_templateHashMap.erase(templateName);
 		}
-
-		DEBUG_ASSERTCRASH(!nextT || t->getTemplateID() == nextT->getTemplateID() + 1, ("Next template ID is unexpected"));
 
 		t = nextT;
 	}


### PR DESCRIPTION
* Follow up for https://github.com/TheSuperHackers/GeneralsGameCode/pull/2034

`DEBUG_ASSERTCRASH(!nextT || t->getTemplateID() == nextT->getTemplateID() + 1, ("Next template ID is unexpected"));`
`t` can potentially point to deallocated / freed memory, so the assertion needs to happen earlier in the function.

Not sure whether it's a 'fix' or 'bugfix', but this is not an issue for standard release builds.