### PR TITLE
tweak(jetaiupdate): Defer offensive commands for parked jets without ammo

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -2337,6 +2337,27 @@ void JetAIUpdate::aiDoCommand(const AICommandParms* parms)
 				// don't need (or want) to take off for these
 				break;
 
+#if !RETAIL_COMPATIBLE_CRC
+			// TheSuperHackers @tweak Stubbjax 23/01/2026 Parked jets now defer offensive commands when out of ammo.
+			case AICMD_ATTACKMOVE_TO_POSITION:
+			case AICMD_ATTACK_AREA:
+			case AICMD_ATTACK_OBJECT:
+			case AICMD_ATTACK_POSITION:
+			case AICMD_ATTACK_TEAM:
+			case AICMD_FORCE_ATTACK_OBJECT:
+			case AICMD_GUARD_AREA:
+			case AICMD_GUARD_OBJECT:
+			case AICMD_GUARD_POSITION:
+			case AICMD_HUNT:
+				if (isOutOfSpecialReloadAmmo(getObject()))
+				{
+					setFlag(HAS_PENDING_COMMAND, true);
+					return;
+				}
+
+				FALLTHROUGH;
+#endif
+
 			case AICMD_ENTER:
 			case AICMD_GET_REPAIRED:
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -2571,6 +2571,28 @@ void JetAIUpdate::aiDoCommand(const AICommandParms* parms)
 				// don't need (or want) to take off for these
 				break;
 
+#if !RETAIL_COMPATIBLE_CRC
+			// TheSuperHackers @tweak Stubbjax 23/01/2026 Parked jets now defer offensive commands when out of ammo.
+			case AICMD_ATTACKMOVE_TO_POSITION:
+			case AICMD_ATTACK_AREA:
+			case AICMD_ATTACK_OBJECT:
+			case AICMD_ATTACK_POSITION:
+			case AICMD_ATTACK_TEAM:
+			case AICMD_FORCE_ATTACK_OBJECT:
+			case AICMD_GUARD_AREA:
+			case AICMD_GUARD_OBJECT:
+			case AICMD_GUARD_POSITION:
+			case AICMD_GUARD_RETALIATE:
+			case AICMD_HUNT:
+				if (isOutOfSpecialReloadAmmo())
+				{
+					setFlag(HAS_PENDING_COMMAND, true);
+					return;
+				}
+
+				FALLTHROUGH;
+#endif
+
 			case AICMD_ENTER:
 			case AICMD_GET_REPAIRED:
 


### PR DESCRIPTION
This is a supplemental / preliminary change to #1757 and modifies jet behaviour so that offensive commands such as attack and guard are deferred when parked with no ammo. This aligns the behaviour a bit more with the in-flight logic, in which command behaviour is dependent on whether the jet has ammo.

The change essentially expands the command deferral window until the jet has reloaded at least one shot. This can be considered an objective improvement to the game as it ensures offensive commands do not end up launching jets without any ammo.

<img width="881" height="361" alt="image" src="https://github.com/user-attachments/assets/f7fcdb0d-7236-4e19-b0db-9fc9bfebc3ae" /></p>

It should be noted that this rule is not consistently applied to all states, and jets that are issued a command during landing and taxiing states will always defer the respective command until fully reloaded, regardless of existing ammo status.

### Demonstration 1

A Raptor with no ammo defers its attack until it is fully reloaded

https://github.com/user-attachments/assets/4cbe09d7-ec36-4d01-b92a-83a037b95f20

### Demonstration 2

Attack and guard commands are deferred with no ammo, but immediately performed when partially reloaded

https://github.com/user-attachments/assets/7f11ae5e-5e5c-4d06-a2d3-f8fbbf7a419e