### PR TITLE
bugfix(bitflags): Replace unqualified min() with inline ternary operator

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/BitFlags.h
+++ b/Generals/Code/GameEngine/Include/Common/BitFlags.h
@@ -257,7 +257,7 @@ public:
 	UnsignedInt toUnsignedInt() const noexcept
 	{
 		UnsignedInt val = 0;
-		const UnsignedInt count = min(m_bits.size(), sizeof(val) * 8);
+		const UnsignedInt count = (m_bits.size() < sizeof(val) * 8) ? m_bits.size() : sizeof(val) * 8;
 		for (UnsignedInt i = 0; i < count; ++i)
 			val |= m_bits.test(i) * (1u << i);
 		return val;

--- a/GeneralsMD/Code/GameEngine/Include/Common/BitFlags.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/BitFlags.h
@@ -257,7 +257,7 @@ public:
 	UnsignedInt toUnsignedInt() const noexcept
 	{
 		UnsignedInt val = 0;
-		const UnsignedInt count = min(m_bits.size(), sizeof(val) * 8);
+		const UnsignedInt count = (m_bits.size() < sizeof(val) * 8) ? m_bits.size() : sizeof(val) * 8;
 		for (UnsignedInt i = 0; i < count; ++i)
 			val |= m_bits.test(i) * (1u << i);
 		return val;


### PR DESCRIPTION
i686-w64-mingw32-gcc build broke with commit d38f6925a. Inline ternary works for all builds.

Changes:
- Replace min(m_bits.size(), sizeof(val) * 8) with inline ternary operator
- Avoids dependency on <algorithm> or always.h
- Fixes both Generals and GeneralsMD BitFlags.h files

This resolves:
- MinGW-w64 GCC 14 error: 'min' was not declared in this scope
- VC6 error: syntax error : '::' if using std::min
- MSVC error: '(' : illegal token on right side of '::' if using std::min

Root cause analysis:
- Original code used unqualified min() expecting always.h's template
- BitFlags.h doesn't include always.h (it's in WWVegas, not GameEngine)
- VC6's <algorithm> doesn't have std::min (only min_element)
- VC6's <minmax.h> has min() macro, but NOMINMAX disables it
- Inline ternary is simple, portable, and VC6-compatible