### PR TITLE
refactor(audioevent): Remove const casts for calling AudioEventRTS::setPlayingAudioIndex()

### DIFF
--- a/Core/GameEngine/Include/Common/AudioEventRTS.h
+++ b/Core/GameEngine/Include/Common/AudioEventRTS.h
@@ -99,7 +99,7 @@ public:
 	void decreaseLoopCount( void );
 	Bool hasMoreLoops( void ) const;
 
-	void setAudioEventInfo( const AudioEventInfo *eventInfo ) const;
+	void setAudioEventInfo( const AudioEventInfo *eventInfo ) const; // is mutable
 	const AudioEventInfo *getAudioEventInfo( void ) const;
 
 	void setPlayingHandle( AudioHandle handle );	// for ID of this audio piece.
@@ -141,8 +141,8 @@ public:
 	Int getPlayerIndex( void ) const;
 	void setPlayerIndex( Int playerNdx );
 
-	Int getPlayingAudioIndex( void ) { return m_playingAudioIndex; };
-	void setPlayingAudioIndex( Int pai )  { m_playingAudioIndex = pai; };
+	Int getPlayingAudioIndex( void ) const { return m_playingAudioIndex; }
+	void setPlayingAudioIndex( Int pai ) const { m_playingAudioIndex = pai; } // is mutable
 
 	Bool getUninterruptible( ) const { return m_uninterruptible; }
 	void setUninterruptible( Bool uninterruptible ) { m_uninterruptible = uninterruptible; }
@@ -191,7 +191,7 @@ protected:
 	Real m_volumeShift;							///< Volume shift that should occur on this piece of audio
 	Real m_delay;										///< Amount to delay before playing this sound
 	Int m_loopCount;								///< The current loop count value. Only valid if this is a looping type event or the override has been set.
-	Int m_playingAudioIndex;				///< The sound index we are currently playing. In the case of non-random, we increment this to move to the next sound
+	mutable Int m_playingAudioIndex;	///< The sound index we are currently playing. In the case of non-random, we increment this to move to the next sound
 	Int m_allCount;									///< If this sound is an ALL type, then this is how many sounds we have played so far.
 
 	Int m_playerIndex;							///< The index of the player who owns this sound. Used for sounds that should have an owner, but don't have an object, etc.

--- a/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
+++ b/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
@@ -461,7 +461,7 @@ AudioHandle AudioManager::addAudioEvent(const AudioEventRTS *eventToAdd)
 	AudioEventRTS *audioEvent = MSGNEW("AudioEventRTS") AudioEventRTS(*eventToAdd);		// poolify
 	audioEvent->setPlayingHandle( allocateNewHandle() );
 	audioEvent->generateFilename();	// which file are we actually going to play?
-	((AudioEventRTS*)eventToAdd)->setPlayingAudioIndex( audioEvent->getPlayingAudioIndex() );
+	eventToAdd->setPlayingAudioIndex( audioEvent->getPlayingAudioIndex() );
 	audioEvent->generatePlayInfo();	// generate pitch shift and volume shift now as well
 
 	std::list<std::pair<AsciiString, Real> >::iterator it;

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -792,7 +792,7 @@ void pickAndPlayUnitVoiceResponse( const DrawableList *list, GameMessage::Type m
 
 		// This seems really hacky, and MarkL admits that it is. However, we do this so that we
 		// can "randomly" pick a different sound the next time, if we have 3 or more sounds. - jkmcd
-		((AudioEventRTS*)soundToPlayPtr)->setPlayingAudioIndex( soundToPlay.getPlayingAudioIndex() );
+		soundToPlayPtr->setPlayingAudioIndex( soundToPlay.getPlayingAudioIndex() );
 
 		if( objectWithSound->testStatus( OBJECT_STATUS_IS_CARBOMB ) )
 		{

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -850,7 +850,7 @@ void pickAndPlayUnitVoiceResponse( const DrawableList *list, GameMessage::Type m
 
 		// This seems really hacky, and MarkL admits that it is. However, we do this so that we
 		// can "randomly" pick a different sound the next time, if we have 3 or more sounds. - jkmcd
-		((AudioEventRTS*)soundToPlayPtr)->setPlayingAudioIndex( soundToPlay.getPlayingAudioIndex() );
+		soundToPlayPtr->setPlayingAudioIndex( soundToPlay.getPlayingAudioIndex() );
 
 		if( objectWithSound->testStatus( OBJECT_STATUS_IS_CARBOMB ) )
 		{


### PR DESCRIPTION
* Closes #2171

This change is an alternative to #2171 and removes const casts for calling `AudioEventRTS::setPlayingAudioIndex()`.