### PR TITLE
fix(basetype): Add min/max template functions to BaseType.h

### DIFF
--- a/Core/Libraries/Include/Lib/BaseType.h
+++ b/Core/Libraries/Include/Lib/BaseType.h
@@ -201,8 +201,8 @@ struct RealRange
 	// both ranges
 	void combine( RealRange &other )
 	{
-		lo = MIN( lo, other.lo );
-		hi = MAX( hi, other.hi );
+		lo = min( lo, other.lo );
+		hi = max( hi, other.hi );
 	}
 };
 


### PR DESCRIPTION
* Merge after #2185

Fixes: https://github.com/TheSuperHackers/GeneralsGameCode/pull/2177 (closes the ternary operator workaround PR)
Alternative to: Ternary operator approach (less readable)

Adds lowercase `min/max` template functions to BaseType.h for GameEngine layer, providing readable alternatives to uppercase MIN/MAX macros and ternary operators.

Both BaseType.h and always.h provide min/max independently:
BaseType.h → GameEngine code that doesn't need WW3D
always.h → WWVegas/WW3D code

MinGW-w64 locally tested and CI tested: https://github.com/JohnsterID/GeneralsGameCode/actions/runs/21322546177

## TODO

- [ ] Rebase on Main after BaseType.h is in Core