### PR TITLE
fix(activebody): Subdual damage can no longer go negative

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Body/ActiveBody.cpp
@@ -1266,7 +1266,7 @@ void ActiveBody::internalAddSubdualDamage( Real delta )
 #if RETAIL_COMPATIBLE_CRC
 	m_currentSubdualDamage = min(m_currentSubdualDamage, data->m_subdualDamageCap);
 #else
-	// TheSuperHackers @bugfix Stubbjax 25/01/2026 Subdual damage can no longer go negative. This
+	// TheSuperHackers @bugfix Stubbjax 25/01/2026 Subdual damage can no longer go negative, which
 	// stops weak subdual damage + rapid healing from negatively stacking subdual damage over time.
 	m_currentSubdualDamage = clamp(0.0f, m_currentSubdualDamage, data->m_subdualDamageCap);
 #endif


### PR DESCRIPTION
This change fixes an issue where subdual damage (dealt by the ECM Tank and Microwave Tank in retail) can continuously negatively stack if the target's heal rate is faster than the subdual weapon's damage rate.

<img width="313" height="58" alt="image" src="https://github.com/user-attachments/assets/5b6f0314-1ae6-46e3-9787-1e6f91c8a353" />

There are no cases where this happens in the retail game, but it is still a logical flaw that can be encountered through modding or custom maps.

For example:

- A target has a `SubdualDamageHealRate` of 100 and `SubdualDamageHealAmount` of 200
- A subdual weapon has a `DelayBetweenShots` of 200 and `PrimaryDamage` of 100
```
Frame 01: Subdual weapon deals 100 subdual damage, target subdual damage is now 100
Frame 02: ...
Frame 03: ...
Frame 04: ...
Frame 05: Target heals 200 subdual damage, target subdual damage is now -100
Frame 06: ...
Frame 07: ...
Frame 08: ...
Frame 09: Subdual weapon deals 100 subdual damage, target subdual damage is now 0
Frame 10: ...
Frame 11: ...
Frame 12: ...
Frame 13: Target heals 200 subdual damage, subdual damage is now -200
Frame 14: ...
Frame 15: ...
Frame 16: ...
Frame 17: Subdual weapon deals 100 subdual damage, target subdual damage is now -100
Frame 18: ...
Frame 19: ...
Frame 20: ...
Frame 21: Target heals 200 subdual damage, subdual damage is now -300
...
```
