### PR TITLE
unify(common): Merge CriticalSection, ScopedMutex code from Generals

### DIFF
--- a/GeneralsMD/Code/GameEngine/Include/Common/CriticalSection.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/CriticalSection.h
@@ -92,8 +92,6 @@ class ScopedCriticalSection
 		}
 };
 
-#include "mutex.h"
-
 // These should be null on creation then non-null in WinMain or equivalent.
 // This allows us to be silently non-threadsafe for WB and other single-threaded apps.
 extern CriticalSection *TheAsciiStringCriticalSection;

--- a/GeneralsMD/Code/GameEngine/Include/Common/ScopedMutex.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/ScopedMutex.h
@@ -31,10 +31,7 @@ class ScopedMutex
 	public:
 		ScopedMutex(HANDLE mutex) : m_mutex(mutex)
 		{
-			DWORD status = WaitForSingleObject(m_mutex, 500);
-			if (status != WAIT_OBJECT_0) {
-				DEBUG_LOG(("ScopedMutex WaitForSingleObject timed out - status %d", status));
-			}
+			WaitForSingleObject(m_mutex, INFINITE);
 		}
 
 		~ScopedMutex()


### PR DESCRIPTION
This change merges code of CriticalSection and ScopedMutex.

I decided to copy from Generals to Zero Hour, because that makes more sense.

## Zero Hour gets

- ScopedMutex no longer has a timeout of 500 ms. It seems counter productive to time out mutexes.