### PR TITLE
bugfix(ai): Fix bugged unit behavior when attacked during guard mode

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIGuard.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIGuard.cpp
@@ -175,7 +175,13 @@ AIGuardMachine::AIGuardMachine( Object *owner ) :
 	// order matters: first state is the default state.
 // srj sez: I made "return" the start state, so that if ordered to guard a position
 // that isn't the unit's current position, it moves to that position first.
+#if RETAIL_COMPATIBLE_CRC
 	defineState( AI_GUARD_RETURN,						newInstance(AIGuardReturnState)( this ), AI_GUARD_IDLE, AI_GUARD_INNER, attackAggressors );
+#else
+	// TheSuperHackers @bugfix 09/04/2026 The attack aggressors conditions for AI_GUARD_RETURN
+	// were removed to fix the conflicting movement and fire behavior in guard mode when the unit is under attack.
+	defineState( AI_GUARD_RETURN,						newInstance(AIGuardReturnState)( this ), AI_GUARD_IDLE, AI_GUARD_INNER );
+#endif
 	defineState( AI_GUARD_IDLE,							newInstance(AIGuardIdleState)( this ), AI_GUARD_INNER, AI_GUARD_RETURN, attackAggressors );
 	defineState( AI_GUARD_INNER,						newInstance(AIGuardInnerState)( this ), AI_GUARD_OUTER, AI_GUARD_OUTER );
 	defineState( AI_GUARD_OUTER,						newInstance(AIGuardOuterState)( this ), AI_GUARD_GET_CRATE, AI_GUARD_GET_CRATE );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGuard.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGuard.cpp
@@ -179,8 +179,8 @@ AIGuardMachine::AIGuardMachine( Object *owner ) :
 	//Kris: Except that guard return is more like an attack move, and will acquire targets while moving there.
 	//This breaks deployAI units because they have to completely unpack before realizing that there is a target in range.
 	//So I'm making AI_GUARD_INNER the first state.
-	defineState( AI_GUARD_INNER,						newInstance(AIGuardInnerState)( this ), AI_GUARD_OUTER, AI_GUARD_OUTER, attackAggressors );
-	defineState( AI_GUARD_RETURN,						newInstance(AIGuardReturnState)( this ), AI_GUARD_IDLE, AI_GUARD_INNER, attackAggressors );
+	defineState( AI_GUARD_INNER,						newInstance(AIGuardInnerState)( this ), AI_GUARD_OUTER, AI_GUARD_OUTER );
+	defineState( AI_GUARD_RETURN,						newInstance(AIGuardReturnState)( this ), AI_GUARD_IDLE, AI_GUARD_INNER );
 	defineState( AI_GUARD_IDLE,							newInstance(AIGuardIdleState)( this ), AI_GUARD_INNER, AI_GUARD_RETURN, attackAggressors );
 	defineState( AI_GUARD_OUTER,						newInstance(AIGuardOuterState)( this ), AI_GUARD_GET_CRATE, AI_GUARD_GET_CRATE );
 	defineState( AI_GUARD_GET_CRATE,				newInstance(AIGuardPickUpCrateState)( this ), AI_GUARD_RETURN, AI_GUARD_RETURN );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGuard.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGuard.cpp
@@ -179,8 +179,30 @@ AIGuardMachine::AIGuardMachine( Object *owner ) :
 	//Kris: Except that guard return is more like an attack move, and will acquire targets while moving there.
 	//This breaks deployAI units because they have to completely unpack before realizing that there is a target in range.
 	//So I'm making AI_GUARD_INNER the first state.
-	defineState( AI_GUARD_INNER,						newInstance(AIGuardInnerState)( this ), AI_GUARD_OUTER, AI_GUARD_OUTER );
-	defineState( AI_GUARD_RETURN,						newInstance(AIGuardReturnState)( this ), AI_GUARD_IDLE, AI_GUARD_INNER );
+#if RETAIL_COMPATIBLE_CRC
+	defineState(AI_GUARD_INNER, newInstance(AIGuardInnerState)(this), AI_GUARD_OUTER, AI_GUARD_OUTER, attackAggressors);
+	defineState(AI_GUARD_RETURN, newInstance(AIGuardReturnState)(this), AI_GUARD_IDLE, AI_GUARD_INNER, attackAggressors);
+#else
+	// TheSuperHackers @bugfix 9/4/2026:
+	///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// This fixes the conflicting movement and fire behavior in Guard mode when the unit is under attack
+	// (see https://github.com/TheSuperHackers/GeneralsGameCode/issues/2097).
+	//
+	// Root cause: In retail, both AI_GUARD_INNER and AI_GUARD_RETURN had the attackAggressors
+	// handler attached.
+	// While the INNER state was issuing attack orders or RETURN state was
+	// issuing movement orders back to the guard position,
+	// the aggressor handler kept firing attack commands on every shot.
+	// This resulted in confliction in orders, causing the unit to do unexpected behavior.
+	//
+	// Fix: Remove the attackAggressors handler from AI_GUARD_INNER and AI_GUARD_RETURN.
+  // The inner guard engagement logic is still handled within the AI_GUARD_INNER state,
+	// and once the unit decides to return (RETURN state), it performs a clean movement without
+	// competing attack orders (unless something enters its Inner guard range).
+	///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	defineState(AI_GUARD_INNER, newInstance(AIGuardInnerState)(this), AI_GUARD_OUTER, AI_GUARD_OUTER);
+	defineState(AI_GUARD_RETURN, newInstance(AIGuardReturnState)(this), AI_GUARD_IDLE, AI_GUARD_INNER);
+#endif
 	defineState( AI_GUARD_IDLE,							newInstance(AIGuardIdleState)( this ), AI_GUARD_INNER, AI_GUARD_RETURN, attackAggressors );
 	defineState( AI_GUARD_OUTER,						newInstance(AIGuardOuterState)( this ), AI_GUARD_GET_CRATE, AI_GUARD_GET_CRATE );
 	defineState( AI_GUARD_GET_CRATE,				newInstance(AIGuardPickUpCrateState)( this ), AI_GUARD_RETURN, AI_GUARD_RETURN );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGuard.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGuard.cpp
@@ -179,8 +179,15 @@ AIGuardMachine::AIGuardMachine( Object *owner ) :
 	//Kris: Except that guard return is more like an attack move, and will acquire targets while moving there.
 	//This breaks deployAI units because they have to completely unpack before realizing that there is a target in range.
 	//So I'm making AI_GUARD_INNER the first state.
+#if RETAIL_COMPATIBLE_CRC
 	defineState( AI_GUARD_INNER,						newInstance(AIGuardInnerState)( this ), AI_GUARD_OUTER, AI_GUARD_OUTER, attackAggressors );
 	defineState( AI_GUARD_RETURN,						newInstance(AIGuardReturnState)( this ), AI_GUARD_IDLE, AI_GUARD_INNER, attackAggressors );
+#else
+	// TheSuperHackers @bugfix 09/04/2026 The attack aggressors conditions for AI_GUARD_INNER and AI_GUARD_RETURN
+	// were removed to fix the conflicting movement and fire behavior in guard mode when the unit is under attack.
+	defineState( AI_GUARD_INNER,						newInstance(AIGuardInnerState)( this ), AI_GUARD_OUTER, AI_GUARD_OUTER );
+	defineState( AI_GUARD_RETURN,						newInstance(AIGuardReturnState)( this ), AI_GUARD_IDLE, AI_GUARD_INNER );
+#endif
 	defineState( AI_GUARD_IDLE,							newInstance(AIGuardIdleState)( this ), AI_GUARD_INNER, AI_GUARD_RETURN, attackAggressors );
 	defineState( AI_GUARD_OUTER,						newInstance(AIGuardOuterState)( this ), AI_GUARD_GET_CRATE, AI_GUARD_GET_CRATE );
 	defineState( AI_GUARD_GET_CRATE,				newInstance(AIGuardPickUpCrateState)( this ), AI_GUARD_RETURN, AI_GUARD_RETURN );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGuardRetaliate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGuardRetaliate.cpp
@@ -184,7 +184,7 @@ AIGuardRetaliateMachine::AIGuardRetaliateMachine( Object *owner ) :
 // srj sez: I made "return" the start state, so that if ordered to guard a position
 // that isn't the unit's current position, it moves to that position first.
 	defineState( AI_GUARD_RETALIATE_ATTACK_AGGRESSOR, newInstance(AIGuardRetaliateAttackAggressorState)( this ), AI_GUARD_RETALIATE_RETURN, AI_GUARD_RETALIATE_RETURN );
-	defineState( AI_GUARD_RETALIATE_RETURN,						newInstance(AIGuardRetaliateReturnState)( this ), AI_GUARD_RETALIATE_IDLE, AI_GUARD_RETALIATE_INNER, attackAggressors );
+	defineState( AI_GUARD_RETALIATE_RETURN,						newInstance(AIGuardRetaliateReturnState)( this ), AI_GUARD_RETALIATE_IDLE, AI_GUARD_RETALIATE_INNER );
 	defineState( AI_GUARD_RETALIATE_IDLE,							newInstance(AIGuardRetaliateIdleState)( this ), AI_GUARD_RETALIATE_INNER, EXIT_MACHINE_WITH_SUCCESS, attackAggressors );
 	defineState( AI_GUARD_RETALIATE_INNER,						newInstance(AIGuardRetaliateInnerState)( this ), AI_GUARD_RETALIATE_OUTER, AI_GUARD_RETALIATE_OUTER );
 	defineState( AI_GUARD_RETALIATE_OUTER,						newInstance(AIGuardRetaliateOuterState)( this ), AI_GUARD_RETALIATE_GET_CRATE, AI_GUARD_RETALIATE_GET_CRATE );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGuardRetaliate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGuardRetaliate.cpp
@@ -184,7 +184,28 @@ AIGuardRetaliateMachine::AIGuardRetaliateMachine( Object *owner ) :
 // srj sez: I made "return" the start state, so that if ordered to guard a position
 // that isn't the unit's current position, it moves to that position first.
 	defineState( AI_GUARD_RETALIATE_ATTACK_AGGRESSOR, newInstance(AIGuardRetaliateAttackAggressorState)( this ), AI_GUARD_RETALIATE_RETURN, AI_GUARD_RETALIATE_RETURN );
-	defineState( AI_GUARD_RETALIATE_RETURN,						newInstance(AIGuardRetaliateReturnState)( this ), AI_GUARD_RETALIATE_IDLE, AI_GUARD_RETALIATE_INNER );
+#if RETAIL_COMPATIBLE_CRC
+	defineState(AI_GUARD_RETALIATE_RETURN, newInstance(AIGuardRetaliateReturnState)(this), AI_GUARD_RETALIATE_IDLE, AI_GUARD_RETALIATE_INNER, attackAggressors);
+#else
+	// TheSuperHackers @bugfix 9/4/2026:
+	///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// This fixes the conflicting movement and fire behavior in Guard mode when the unit is under attack
+	// (see https://github.com/TheSuperHackers/GeneralsGameCode/issues/2097).
+	//
+	// Root cause: In retail, both AI_GUARD_INNER and AI_GUARD_RETURN had the attackAggressors
+	// handler attached.
+	// While the INNER state was issuing attack orders or RETURN state was
+	// issuing movement orders back to the guard position,
+	// the aggressor handler kept firing attack commands on every shot.
+	// This resulted in confliction in orders, causing the unit to do unexpected behavior.
+	//
+	// Fix: Remove the attackAggressors handler from AI_GUARD_INNER and AI_GUARD_RETURN.
+	// The inner guard engagement logic is still handled within the AI_GUARD_INNER state,
+	// and once the unit decides to return (RETURN state), it performs a clean movement without
+	// competing attack orders (unless something enters its Inner guard range).
+	///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	defineState(AI_GUARD_RETALIATE_RETURN, newInstance(AIGuardRetaliateReturnState)(this), AI_GUARD_RETALIATE_IDLE, AI_GUARD_RETALIATE_INNER);
+#endif
 	defineState( AI_GUARD_RETALIATE_IDLE,							newInstance(AIGuardRetaliateIdleState)( this ), AI_GUARD_RETALIATE_INNER, EXIT_MACHINE_WITH_SUCCESS, attackAggressors );
 	defineState( AI_GUARD_RETALIATE_INNER,						newInstance(AIGuardRetaliateInnerState)( this ), AI_GUARD_RETALIATE_OUTER, AI_GUARD_RETALIATE_OUTER );
 	defineState( AI_GUARD_RETALIATE_OUTER,						newInstance(AIGuardRetaliateOuterState)( this ), AI_GUARD_RETALIATE_GET_CRATE, AI_GUARD_RETALIATE_GET_CRATE );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGuardRetaliate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGuardRetaliate.cpp
@@ -184,7 +184,13 @@ AIGuardRetaliateMachine::AIGuardRetaliateMachine( Object *owner ) :
 // srj sez: I made "return" the start state, so that if ordered to guard a position
 // that isn't the unit's current position, it moves to that position first.
 	defineState( AI_GUARD_RETALIATE_ATTACK_AGGRESSOR, newInstance(AIGuardRetaliateAttackAggressorState)( this ), AI_GUARD_RETALIATE_RETURN, AI_GUARD_RETALIATE_RETURN );
+#if RETAIL_COMPATIBLE_CRC
 	defineState( AI_GUARD_RETALIATE_RETURN,						newInstance(AIGuardRetaliateReturnState)( this ), AI_GUARD_RETALIATE_IDLE, AI_GUARD_RETALIATE_INNER, attackAggressors );
+#else
+	// TheSuperHackers @bugfix 09/04/2026 The attack aggressors conditions for AI_GUARD_RETALIATE_RETURN
+	// were removed to fix the conflicting movement and fire behavior in guard mode when the unit is under attack.
+	defineState( AI_GUARD_RETALIATE_RETURN,						newInstance(AIGuardRetaliateReturnState)( this ), AI_GUARD_RETALIATE_IDLE, AI_GUARD_RETALIATE_INNER );
+#endif
 	defineState( AI_GUARD_RETALIATE_IDLE,							newInstance(AIGuardRetaliateIdleState)( this ), AI_GUARD_RETALIATE_INNER, EXIT_MACHINE_WITH_SUCCESS, attackAggressors );
 	defineState( AI_GUARD_RETALIATE_INNER,						newInstance(AIGuardRetaliateInnerState)( this ), AI_GUARD_RETALIATE_OUTER, AI_GUARD_RETALIATE_OUTER );
 	defineState( AI_GUARD_RETALIATE_OUTER,						newInstance(AIGuardRetaliateOuterState)( this ), AI_GUARD_RETALIATE_GET_CRATE, AI_GUARD_RETALIATE_GET_CRATE );


### PR DESCRIPTION
* Closes issue https://github.com/TheSuperHackers/GeneralsGameCode/issues/2097

Made Guard do what its supposed to instead of retaliating when its not supposed to.

EDIT: Most of the bug description was moved from the code to here:
```
// This fixes the conflicting movement and fire behavior in Guard mode when the unit is under attack
//
// Root cause: In retail, both AI_GUARD_INNER and AI_GUARD_RETURN had the attackAggressors
// handler attached.
// While the INNER state was issuing attack orders or RETURN state was
// issuing movement orders back to the guard position,
// the aggressor handler kept firing attack commands on every shot.
// This resulted in confliction in orders, causing the unit to do unexpected behavior.
//
// Fix: Remove the attackAggressors handler from AI_GUARD_INNER and AI_GUARD_RETURN.
// The inner guard engagement logic is still handled within the AI_GUARD_INNER state,
// and once the unit decides to return (RETURN state), it performs a clean movement without
// competing attack orders (unless something enters its Inner guard range).
```