### PR TITLE
bugfix(network): Revert changes to ConnectionManager::getMaximumLatency() to avoid a higher latency runahead than required

### DIFF
--- a/Core/GameEngine/Include/GameNetwork/ConnectionManager.h
+++ b/Core/GameEngine/Include/GameNetwork/ConnectionManager.h
@@ -171,7 +171,7 @@ private:
 
 	//	void doPerFrameMetrics(UnsignedInt frame);
 	void getMinimumFps(Int &minFps, Int &minFpsPlayer);			///< Returns the smallest FPS in the m_fpsAverages list.
-	Real getMaximumLatency(); ///< Returns the highest average latency between players.
+	Real getMaximumLatency(); ///< Returns the average of the two highest average latencies between players.
 
 	void requestFrameDataResend(Int playerID, UnsignedInt frame); ///< request of this player that he send the specified frame's data.
 

--- a/Core/GameEngine/Source/GameNetwork/ConnectionManager.cpp
+++ b/Core/GameEngine/Source/GameNetwork/ConnectionManager.cpp
@@ -1362,15 +1362,25 @@ void ConnectionManager::updateRunAhead(Int oldRunAhead, Int frameRate, Bool didS
 }
 
 Real ConnectionManager::getMaximumLatency() {
-	Real maxLatency = 0.0f;
+
+	Real lat1 = 0.0f;
+	Real lat2 = 0.0f;
 
 	for (Int i = 0; i < MAX_SLOTS; ++i) {
-		if (isPlayerConnected(i) && m_latencyAverages[i] > maxLatency) {
-				maxLatency = m_latencyAverages[i];
+		if (isPlayerConnected(i)) {
+			if (m_latencyAverages[i] != 0.0f) {
+				if (m_latencyAverages[i] > lat1) {
+					lat2 = lat1;
+					lat1 = m_latencyAverages[i];
+				}
+				else if (m_latencyAverages[i] > lat2) {
+					lat2 = m_latencyAverages[i];
+				}
+			}
 		}
 	}
 
-	return maxLatency;
+	return (lat1 + lat2) / 2.0f;
 }
 
 void ConnectionManager::getMinimumFps(Int &minFps, Int &minFpsPlayer) {


### PR DESCRIPTION
This PR reverts a change made to ConnectionManager::getMaximumLatency() in PR #1482.

It has been noticed that other problems in the networking code are causing latency spikes to appear within the measured network latencies, this can cause the game to set a significantly higher Runahead than required.

For now this is being reverted, but the division by two is being added within the function which was handled externally in the original version.

It will require other changes to the network handling to fix these latency spike issues that have been seen.

---

When making custom builds for Legi i was adding this code back as it appeared to fix the latency issues that were being seen.
The original premis for the change was reasonable, but the aformentioned issues with latency spikes and problems in the rest of the networking code were causign issues.