### PR TITLE
fix(network): Fix slightly unstable latency calculation in FrameMetrics::processLatencyResponse()

### DIFF
--- a/Core/GameEngine/Source/GameNetwork/FrameMetrics.cpp
+++ b/Core/GameEngine/Source/GameNetwork/FrameMetrics.cpp
@@ -26,6 +26,8 @@
 
 #include "PreRTS.h"	// This must go first in EVERY cpp file in the GameEngine
 
+#include <numeric>
+
 #include "GameNetwork/FrameMetrics.h"
 #include "GameClient/Display.h"
 #include "GameNetwork/networkutil.h"
@@ -105,9 +107,9 @@ void FrameMetrics::processLatencyResponse(UnsignedInt frame) {
 	time_t timeDiff = curTime - m_pendingLatencies[pendingIndex];
 
 	Int latencyListIndex = frame % TheGlobalData->m_networkLatencyHistoryLength;
-	m_averageLatency -= m_latencyList[latencyListIndex] / TheGlobalData->m_networkLatencyHistoryLength;
 	m_latencyList[latencyListIndex] = (Real)timeDiff / (Real)1000; // convert to seconds from milliseconds.
-	m_averageLatency += m_latencyList[latencyListIndex] / TheGlobalData->m_networkLatencyHistoryLength;
+	const Real latencySum = std::accumulate(m_latencyList, m_latencyList + TheGlobalData->m_networkLatencyHistoryLength, 0.0f);
+	m_averageLatency = latencySum / (Real)TheGlobalData->m_networkLatencyHistoryLength;
 
 	if (frame % 16 == 0) {
 //		DEBUG_LOG(("ConnectionManager::processFrameInfoAck - average latency = %f", m_averageLatency));


### PR DESCRIPTION
This PR aims to stabalise the latency calculation within the networking.

Previously a stored latency value was converted to a proportion of calculated latency in ms and subtracted from the current latency, the latency replacing it in it's bin was then added in a similar fashion.
This is an unstable operation when using floats and can cause the value to drift over time in unpredicatble ways.

Instead we accumulate all of the stored latency history and calculate the latency across the summed value.