### PR TITLE
bugfix(physics): Prevent dead units from repeatedly dealing crash damage on collision with non-buildings

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
@@ -1260,7 +1260,12 @@ void PhysicsBehavior::onCollide( Object *other, const Coord3D *loc, const Coord3
 				else
 				{
 					// fall into a nonbuilding -- whatever. if we're a vehicle, quietly do a little damage.
+#if RETAIL_COMPATIBLE_CRC
 					if (obj->isKindOf(KINDOF_VEHICLE))
+#else
+					// TheSuperHackers @bugfix Stubbjax 28/01/2026 Prevent dead units from repeatedly dealing damage.
+					if (obj->isKindOf(KINDOF_VEHICLE) && !obj->isEffectivelyDead())
+#endif
 					{
 						TheWeaponStore->createAndFireTempWeapon(getPhysicsBehaviorModuleData()->m_vehicleCrashesIntoNonBuildingWeaponTemplate, obj, obj->getPosition());
 					}

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
@@ -34,6 +34,7 @@
 #include "Common/PerfTimer.h"
 #include "Common/ThingTemplate.h"
 #include "Common/Xfer.h"
+#include "GameClient/FXList.h"
 #include "GameLogic/GameLogic.h"
 #include "GameLogic/Module/AIUpdate.h"
 #include "GameLogic/Module/BodyModule.h"
@@ -1278,6 +1279,7 @@ void PhysicsBehavior::onCollide( Object *other, const Coord3D *loc, const Coord3
 							damageInfo.in.m_amount = weaponTemplate->getPrimaryDamage(nullBonus);
 
 							other->attemptDamage(&damageInfo);
+							FXList::doFXObj(weaponTemplate->getFireFX(obj->getVeterancyLevel()), obj);
 						}
 #endif
 					}

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
@@ -1260,14 +1260,23 @@ void PhysicsBehavior::onCollide( Object *other, const Coord3D *loc, const Coord3
 				else
 				{
 					// fall into a nonbuilding -- whatever. if we're a vehicle, quietly do a little damage.
-#if RETAIL_COMPATIBLE_CRC
 					if (obj->isKindOf(KINDOF_VEHICLE))
-#else
-					// TheSuperHackers @bugfix Stubbjax 28/01/2026 Prevent dead units from repeatedly dealing damage.
-					if (obj->isKindOf(KINDOF_VEHICLE) && !obj->isEffectivelyDead())
-#endif
 					{
+#if RETAIL_COMPATIBLE_CRC
 						TheWeaponStore->createAndFireTempWeapon(getPhysicsBehaviorModuleData()->m_vehicleCrashesIntoNonBuildingWeaponTemplate, obj, obj->getPosition());
+#else
+						// TheSuperHackers @bugfix Stubbjax 19/04/2026 Prevent non-building collisions from repeatedly dealing collateral damage to other objects.
+						const WeaponTemplate* weaponTemplate = getPhysicsBehaviorModuleData()->m_vehicleCrashesIntoNonBuildingWeaponTemplate;
+						WeaponBonus nullBonus;
+
+						DamageInfo damageInfo;
+						damageInfo.in.m_damageType = weaponTemplate->getDamageType();
+						damageInfo.in.m_deathType = weaponTemplate->getDeathType();
+						damageInfo.in.m_sourceID = obj->getID();
+						damageInfo.in.m_amount = weaponTemplate->getPrimaryDamage(nullBonus);
+
+						other->attemptDamage(&damageInfo);
+#endif
 					}
 				}
 			}

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
@@ -1267,15 +1267,18 @@ void PhysicsBehavior::onCollide( Object *other, const Coord3D *loc, const Coord3
 #else
 						// TheSuperHackers @bugfix Stubbjax 19/04/2026 Prevent non-building collisions from repeatedly dealing collateral damage to other objects.
 						const WeaponTemplate* weaponTemplate = getPhysicsBehaviorModuleData()->m_vehicleCrashesIntoNonBuildingWeaponTemplate;
-						WeaponBonus nullBonus;
+						if (weaponTemplate != nullptr)
+						{
+							WeaponBonus nullBonus;
 
-						DamageInfo damageInfo;
-						damageInfo.in.m_damageType = weaponTemplate->getDamageType();
-						damageInfo.in.m_deathType = weaponTemplate->getDeathType();
-						damageInfo.in.m_sourceID = obj->getID();
-						damageInfo.in.m_amount = weaponTemplate->getPrimaryDamage(nullBonus);
+							DamageInfo damageInfo;
+							damageInfo.in.m_damageType = weaponTemplate->getDamageType();
+							damageInfo.in.m_deathType = weaponTemplate->getDeathType();
+							damageInfo.in.m_sourceID = obj->getID();
+							damageInfo.in.m_amount = weaponTemplate->getPrimaryDamage(nullBonus);
 
-						other->attemptDamage(&damageInfo);
+							other->attemptDamage(&damageInfo);
+						}
 #endif
 					}
 				}

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
@@ -32,6 +32,7 @@
 #define NO_DEBUG_CRC
 
 #include "Common/PerfTimer.h"
+#include "Common/Player.h"
 #include "Common/ThingTemplate.h"
 #include "Common/Xfer.h"
 #include "GameClient/FXList.h"
@@ -1276,6 +1277,7 @@ void PhysicsBehavior::onCollide( Object *other, const Coord3D *loc, const Coord3
 							damageInfo.in.m_damageType = weaponTemplate->getDamageType();
 							damageInfo.in.m_deathType = weaponTemplate->getDeathType();
 							damageInfo.in.m_sourceID = obj->getID();
+							damageInfo.in.m_sourcePlayerMask = obj->getControllingPlayer() ? obj->getControllingPlayer()->getPlayerMask() : 0;
 							damageInfo.in.m_amount = weaponTemplate->getPrimaryDamage(nullBonus);
 
 							other->attemptDamage(&damageInfo);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
@@ -1385,7 +1385,12 @@ void PhysicsBehavior::onCollide( Object *other, const Coord3D *loc, const Coord3
 				else
 				{
 					// fall into a nonbuilding -- whatever. if we're a vehicle, quietly do a little damage.
+#if RETAIL_COMPATIBLE_CRC
 					if (obj->isKindOf(KINDOF_VEHICLE))
+#else
+					// TheSuperHackers @bugfix Stubbjax 28/01/2026 Prevent dead units from repeatedly dealing damage.
+					if (obj->isKindOf(KINDOF_VEHICLE) && !obj->isEffectivelyDead())
+#endif
 					{
 						TheWeaponStore->createAndFireTempWeapon(getPhysicsBehaviorModuleData()->m_vehicleCrashesIntoNonBuildingWeaponTemplate, obj, obj->getPosition());
 					}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
@@ -34,6 +34,7 @@
 #include "Common/PerfTimer.h"
 #include "Common/ThingTemplate.h"
 #include "Common/Xfer.h"
+#include "GameClient/FXList.h"
 #include "GameLogic/GameLogic.h"
 #include "GameLogic/Module/AIUpdate.h"
 #include "GameLogic/Module/BodyModule.h"
@@ -1403,6 +1404,7 @@ void PhysicsBehavior::onCollide( Object *other, const Coord3D *loc, const Coord3
 							damageInfo.in.m_amount = weaponTemplate->getPrimaryDamage(nullBonus);
 
 							other->attemptDamage(&damageInfo);
+							FXList::doFXObj(weaponTemplate->getFireFX(obj->getVeterancyLevel()), obj);
 						}
 #endif
 					}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
@@ -32,6 +32,7 @@
 #define NO_DEBUG_CRC
 
 #include "Common/PerfTimer.h"
+#include "Common/Player.h"
 #include "Common/ThingTemplate.h"
 #include "Common/Xfer.h"
 #include "GameClient/FXList.h"
@@ -1401,6 +1402,7 @@ void PhysicsBehavior::onCollide( Object *other, const Coord3D *loc, const Coord3
 							damageInfo.in.m_damageType = weaponTemplate->getDamageType();
 							damageInfo.in.m_deathType = weaponTemplate->getDeathType();
 							damageInfo.in.m_sourceID = obj->getID();
+							damageInfo.in.m_sourcePlayerMask = obj->getControllingPlayer() ? obj->getControllingPlayer()->getPlayerMask() : 0;
 							damageInfo.in.m_amount = weaponTemplate->getPrimaryDamage(nullBonus);
 
 							other->attemptDamage(&damageInfo);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
@@ -1385,14 +1385,23 @@ void PhysicsBehavior::onCollide( Object *other, const Coord3D *loc, const Coord3
 				else
 				{
 					// fall into a nonbuilding -- whatever. if we're a vehicle, quietly do a little damage.
-#if RETAIL_COMPATIBLE_CRC
 					if (obj->isKindOf(KINDOF_VEHICLE))
-#else
-					// TheSuperHackers @bugfix Stubbjax 28/01/2026 Prevent dead units from repeatedly dealing damage.
-					if (obj->isKindOf(KINDOF_VEHICLE) && !obj->isEffectivelyDead())
-#endif
 					{
+#if RETAIL_COMPATIBLE_CRC
 						TheWeaponStore->createAndFireTempWeapon(getPhysicsBehaviorModuleData()->m_vehicleCrashesIntoNonBuildingWeaponTemplate, obj, obj->getPosition());
+#else
+						// TheSuperHackers @bugfix Stubbjax 19/04/2026 Prevent non-building collisions from repeatedly dealing collateral damage to other objects.
+						const WeaponTemplate* weaponTemplate = getPhysicsBehaviorModuleData()->m_vehicleCrashesIntoNonBuildingWeaponTemplate;
+						WeaponBonus nullBonus;
+
+						DamageInfo damageInfo;
+						damageInfo.in.m_damageType = weaponTemplate->getDamageType();
+						damageInfo.in.m_deathType = weaponTemplate->getDeathType();
+						damageInfo.in.m_sourceID = obj->getID();
+						damageInfo.in.m_amount = weaponTemplate->getPrimaryDamage(nullBonus);
+
+						other->attemptDamage(&damageInfo);
+#endif
 					}
 				}
 			}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
@@ -1392,15 +1392,18 @@ void PhysicsBehavior::onCollide( Object *other, const Coord3D *loc, const Coord3
 #else
 						// TheSuperHackers @bugfix Stubbjax 19/04/2026 Prevent non-building collisions from repeatedly dealing collateral damage to other objects.
 						const WeaponTemplate* weaponTemplate = getPhysicsBehaviorModuleData()->m_vehicleCrashesIntoNonBuildingWeaponTemplate;
-						WeaponBonus nullBonus;
+						if (weaponTemplate != nullptr)
+						{
+							WeaponBonus nullBonus;
 
-						DamageInfo damageInfo;
-						damageInfo.in.m_damageType = weaponTemplate->getDamageType();
-						damageInfo.in.m_deathType = weaponTemplate->getDeathType();
-						damageInfo.in.m_sourceID = obj->getID();
-						damageInfo.in.m_amount = weaponTemplate->getPrimaryDamage(nullBonus);
+							DamageInfo damageInfo;
+							damageInfo.in.m_damageType = weaponTemplate->getDamageType();
+							damageInfo.in.m_deathType = weaponTemplate->getDeathType();
+							damageInfo.in.m_sourceID = obj->getID();
+							damageInfo.in.m_amount = weaponTemplate->getPrimaryDamage(nullBonus);
 
-						other->attemptDamage(&damageInfo);
+							other->attemptDamage(&damageInfo);
+						}
 #endif
 					}
 				}


### PR DESCRIPTION
Closes #2015

This change fixes an issue where dead vehicles repeatedly trigger `VehicleCrashesIntoNonBuildingWeapon` when colliding with mines, causing continuous damage to nearby units and structures.

This weapon is hardcoded into the physics update, and is fired when a vehicle falls onto a non-building object - the intent being that a vehicle deals some 'crush' damage to a victim it lands on. It is especially problematic in the case of mines as the mines cannot destroy the already-dead vehicle. The issue is most apparent with Technicals due to their frequent involvement in bombing runs and their tendency to fling themselves forwards upon death.

The fix makes the weapon only deal damage to the collided target.

There is also a building-specific crash block that fires `VehicleCrashesIntoBuildingWeapon` when a vehicle crashes into a building, however this results in the immediate destruction of the crashing vehicle, and so is not as problematic.

### Before
The Propaganda Center dies due to dead Technicals firing `VehicleCrashesIntoNonBuildingWeapon` every frame

https://github.com/user-attachments/assets/d96c2797-e912-4ba4-b282-22d07aa1c67d

### After
The Propaganda Center survives unscathed as `VehicleCrashesIntoNonBuildingWeapon` only targets the mines

https://github.com/user-attachments/assets/5993de4b-480c-4c91-9290-e2e91f1f735a