### PR TITLE
bugfix(gui): Fix game window animation movements to scale with display resolution

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ProcessAnimateWindow.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ProcessAnimateWindow.cpp
@@ -149,8 +149,8 @@ void ProcessAnimateWindowSlideFromRight::initAnimateWindow( wnd::AnimateWindow *
 	//set the window's position to the new start positions.
 	win->winSetPosition(startPos.x, startPos.y);
 
-	// TheSuperHackers @bugfix tophroxx 31/01/2026 Use scaled pixel constants
-	// for slowdown threshold and velocity.
+	// TheSuperHackers @bugfix tophroxx 31/01/2026 Scale movement by display size so that it looks
+	// consistent regardless of the display resolution.
 	const Real widthScaler = getDisplayWidthScaler();
 	m_maxVel.x = -40 * widthScaler;
 	m_slowDownThreshold = 80 * widthScaler;
@@ -335,8 +335,8 @@ void ProcessAnimateWindowSlideFromLeft::initAnimateWindow( wnd::AnimateWindow *a
 	//set the window's position to the new start positions.
 	win->winSetPosition(startPos.x, startPos.y);
 
-	// TheSuperHackers @bugfix tophroxx 31/01/2026 Use scaled pixel constants
-	// for slowdown threshold and velocity.
+	// TheSuperHackers @bugfix tophroxx 31/01/2026 Scale movement by display size so that it looks
+	// consistent regardless of the display resolution.
 	const Real widthScaler = getDisplayWidthScaler();
 	m_maxVel.x = 40 * widthScaler;
 	m_slowDownThreshold = 80 * widthScaler;
@@ -518,8 +518,8 @@ void ProcessAnimateWindowSlideFromTop::initAnimateWindow( wnd::AnimateWindow *an
 	//set the window's position to the new start positions.
 	win->winSetPosition(startPos.x, startPos.y);
 
-	// TheSuperHackers @bugfix tophroxx 31/01/2026 Use scaled pixel constants
-	// for slowdown threshold and velocity.
+	// TheSuperHackers @bugfix tophroxx 31/01/2026 Scale movement by display size so that it looks
+	// consistent regardless of the display resolution.
 	const Real heightScaler = getDisplayHeightScaler();
 	m_maxVel.y = 40 * heightScaler;
 	m_slowDownThreshold = 80 * heightScaler;
@@ -703,8 +703,8 @@ void ProcessAnimateWindowSlideFromBottom::initAnimateWindow( wnd::AnimateWindow 
 	//set the window's position to the new start positions.
 	win->winSetPosition(startPos.x, startPos.y);
 
-	// TheSuperHackers @bugfix tophroxx 31/01/2026 Use scaled pixel constants
-	// for slowdown threshold and velocity.
+	// TheSuperHackers @bugfix tophroxx 31/01/2026 Scale movement by display size so that it looks
+	// consistent regardless of the display resolution.
 	const Real heightScaler = getDisplayHeightScaler();
 	m_maxVel.y = -40 * heightScaler;
 	m_slowDownThreshold = 80 * heightScaler;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ProcessAnimateWindow.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ProcessAnimateWindow.cpp
@@ -149,8 +149,8 @@ void ProcessAnimateWindowSlideFromRight::initAnimateWindow( wnd::AnimateWindow *
 	//set the window's position to the new start positions.
 	win->winSetPosition(startPos.x, startPos.y);
 
-	// TheSuperHackers @bugfix tophroxx 31/01/2026 Use scaled pixel constants
-	// for slowdown threshold and velocity.
+	// TheSuperHackers @bugfix tophroxx 31/01/2026 Scale movement by display size so that it looks
+	// consistent regardless of the display resolution.
 	const Real widthScaler = getDisplayWidthScaler();
 	m_maxVel.x = -40 * widthScaler;
 	m_slowDownThreshold = 80 * widthScaler;
@@ -335,8 +335,8 @@ void ProcessAnimateWindowSlideFromLeft::initAnimateWindow( wnd::AnimateWindow *a
 	//set the window's position to the new start positions.
 	win->winSetPosition(startPos.x, startPos.y);
 
-	// TheSuperHackers @bugfix tophroxx 31/01/2026 Use scaled pixel constants
-	// for slowdown threshold and velocity.
+	// TheSuperHackers @bugfix tophroxx 31/01/2026 Scale movement by display size so that it looks
+	// consistent regardless of the display resolution.
 	const Real widthScaler = getDisplayWidthScaler();
 	m_maxVel.x = 40 * widthScaler;
 	m_slowDownThreshold = 80 * widthScaler;
@@ -518,8 +518,8 @@ void ProcessAnimateWindowSlideFromTop::initAnimateWindow( wnd::AnimateWindow *an
 	//set the window's position to the new start positions.
 	win->winSetPosition(startPos.x, startPos.y);
 
-	// TheSuperHackers @bugfix tophroxx 31/01/2026 Use scaled pixel constants
-	// for slowdown threshold and velocity.
+	// TheSuperHackers @bugfix tophroxx 31/01/2026 Scale movement by display size so that it looks
+	// consistent regardless of the display resolution.
 	const Real heightScaler = getDisplayHeightScaler();
 	m_maxVel.y = 40 * heightScaler;
 	m_slowDownThreshold = 80 * heightScaler;
@@ -703,8 +703,8 @@ void ProcessAnimateWindowSlideFromBottom::initAnimateWindow( wnd::AnimateWindow 
 	//set the window's position to the new start positions.
 	win->winSetPosition(startPos.x, startPos.y);
 
-	// TheSuperHackers @bugfix tophroxx 31/01/2026 Use scaled pixel constants
-	// for slowdown threshold and velocity.
+	// TheSuperHackers @bugfix tophroxx 31/01/2026 Scale movement by display size so that it looks
+	// consistent regardless of the display resolution.
 	const Real heightScaler = getDisplayHeightScaler();
 	m_maxVel.y = -40 * heightScaler;
 	m_slowDownThreshold = 80 * heightScaler;


### PR DESCRIPTION
This fixes window animation speeds and smoothing on different display resolutions. Closes #2130

I've made a quick video showcasing new behavior and retail behavior side-by-side. Unfortunately it was too big for GitHub, so i uploaded it to YouTube.

https://youtu.be/wDQdis7Z1L4

Pay attention to how fast the control bar slides from the bottom when i'm loading into a match, and also how fast the diplomacy screen slides from the top.

This PR adds 2 new ~~methods to the Display class~~ local helper functions and changes 4 children of the `ProcessAnimateWindow` class - `SlideFromLeft`, `SlideFromRight`, `SlideFromTop` and `SlideFromBottom`, making them benefit from these new methods. 
It also moves velocity and slowdown threshold initialization from the constructor into `initAnimateWindow`, which means that these values will scale properly even if user changes their resolution in runtime. 
I've made little changes to minimize the possibility of new issues appearing while still fixing the issue.