### PR TITLE
fix(headless): Use ParticleSystemManager update instead of reset in headless replay

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -745,14 +745,11 @@ void GameClient::step()
 
 void GameClient::updateHeadless()
 {
-	// TheSuperHackers @info helmutbuhler 03/05/2025
-	// When we play a replay back in headless mode, we want to skip the update of GameClient
-	// because it's not necessary for CRC checking.
-	// But we do reset the particles. The problem is that particles can be generated during
-	// GameLogic and are only cleaned up during rendering. If we don't clean this up here,
-	// the particles accumulate and slow things down a lot and can even cause a crash on
-	// longer replays.
-	TheParticleSystemManager->reset();
+	// TheSuperHackers @info helmutbuhler 03/05/2025 bobtista 02/02/2026
+	// Update particles to prevent accumulation in headless mode. Particles are generated
+	// during GameLogic and only cleaned up during rendering. update() lets particles finish
+	// their lifecycle naturally instead of abruptly removing them with reset().
+	TheParticleSystemManager->update();
 }
 
 /** -----------------------------------------------------------------------------------------------

--- a/Generals/Code/Main/WinMain.cpp
+++ b/Generals/Code/Main/WinMain.cpp
@@ -826,7 +826,9 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 #endif
 		// register windows class and create application window
 		if(!TheGlobalData->m_headless && initializeAppWindows(hInstance, nCmdShow, TheGlobalData->m_windowed) == false)
+		{
 			return exitcode;
+		}
 
 		// save our application instance for future use
 		ApplicationHInstance = hInstance;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -786,11 +786,16 @@ void GameClient::updateHeadless()
 	// TheSuperHackers @info helmutbuhler 03/05/2025
 	// When we play a replay back in headless mode, we want to skip the update of GameClient
 	// because it's not necessary for CRC checking.
-	// But we do reset the particles. The problem is that particles can be generated during
+	// But we do update the particles. The problem is that particles can be generated during
 	// GameLogic and are only cleaned up during rendering. If we don't clean this up here,
 	// the particles accumulate and slow things down a lot and can even cause a crash on
 	// longer replays.
-	TheParticleSystemManager->reset();
+	// TheSuperHackers @fix bobtista 02/02/2026 Use update() instead of reset() to avoid
+	// use-after-free crash. reset() deletes all particle systems immediately, but DrawModules
+	// (W3DTruckDraw, W3DTankDraw, etc.) hold raw pointers to particle systems. When those
+	// DrawModules are later destroyed during game shutdown, they crash accessing freed memory.
+	// update() only cleans up finished particle systems, leaving active ones intact.
+	TheParticleSystemManager->update();
 }
 
 /** -----------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -783,18 +783,9 @@ void GameClient::step()
 
 void GameClient::updateHeadless()
 {
-	// TheSuperHackers @info helmutbuhler 03/05/2025
-	// When we play a replay back in headless mode, we want to skip the update of GameClient
-	// because it's not necessary for CRC checking.
-	// But we do update the particles. The problem is that particles can be generated during
-	// GameLogic and are only cleaned up during rendering. If we don't clean this up here,
-	// the particles accumulate and slow things down a lot and can even cause a crash on
-	// longer replays.
-	// TheSuperHackers @fix bobtista 02/02/2026 Use update() instead of reset() to avoid
-	// use-after-free crash. reset() deletes all particle systems immediately, but DrawModules
-	// (W3DTruckDraw, W3DTankDraw, etc.) hold raw pointers to particle systems. When those
-	// DrawModules are later destroyed during game shutdown, they crash accessing freed memory.
-	// update() only cleans up finished particle systems, leaving active ones intact.
+	// TheSuperHackers @info helmutbuhler 03/05/2025 bobtista 02/02/2026
+	// Update particles to prevent accumulation in headless mode. update() has slightly more
+	// CPU overhead than reset() but is semantically correct - particles finish naturally.
 	TheParticleSystemManager->update();
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -784,8 +784,9 @@ void GameClient::step()
 void GameClient::updateHeadless()
 {
 	// TheSuperHackers @info helmutbuhler 03/05/2025 bobtista 02/02/2026
-	// Update particles to prevent accumulation in headless mode. update() has slightly more
-	// CPU overhead than reset() but is semantically correct - particles finish naturally.
+	// Update particles to prevent accumulation in headless mode. Particles are generated
+	// during GameLogic and only cleaned up during rendering. update() lets particles finish
+	// their lifecycle naturally instead of abruptly removing them with reset().
 	TheParticleSystemManager->update();
 }
 

--- a/GeneralsMD/Code/Main/WinMain.cpp
+++ b/GeneralsMD/Code/Main/WinMain.cpp
@@ -873,7 +873,9 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 
 		// register windows class and create application window
 		if(!TheGlobalData->m_headless && initializeAppWindows(hInstance, nCmdShow, TheGlobalData->m_windowed) == false)
+		{
 			return exitcode;
+		}
 
 		// save our application instance for future use
 		ApplicationHInstance = hInstance;


### PR DESCRIPTION
## Summary
- Fix particle lifecycle management in headless replay by using `ParticleSystemManager::update()` instead of `reset()`. Using `update()` lets particles finish their lifecycle naturally instead of abruptly removing them.

## Test plan
- [x] Run headless replay to completion (`-replay test.rep -headless`)
- [x] Verify no particle accumulation slowdown