### PR TITLE
fix(update): Extend the height of the USA Particle Cannon laser beam for enormous camera heights

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
@@ -58,7 +58,9 @@
 #include "GameLogic/Module/PhysicsUpdate.h"
 #include "GameLogic/Module/ActiveBody.h"
 
-
+// TheSuperHackers @fix Mirelle 04/02/2026: Raised from 500.0f so that
+// enormous camera heights cannot see above the laser origin.
+constexpr const Real ORBITAL_BEAM_Z_OFFSET = 3500.0f;
 
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
@@ -550,7 +552,7 @@ UpdateSleepTime ParticleUplinkCannonUpdate::update()
 
 			Coord3D orbitPosition;
 			orbitPosition.set( &m_currentTargetPosition );
-			orbitPosition.z += 500.0f;
+			orbitPosition.z += ORBITAL_BEAM_Z_OFFSET;
 
 			Real scorchRadius = 0.0f;
 			Real damageRadius = 0.0f;
@@ -918,7 +920,7 @@ void ParticleUplinkCannonUpdate::createGroundToOrbitLaser( UnsignedInt growthFra
 				{
 					Coord3D orbitPosition;
 					orbitPosition.set( &m_laserOriginPosition );
-					orbitPosition.z += 500.0f;
+					orbitPosition.z += ORBITAL_BEAM_Z_OFFSET;
 					update->initLaser( nullptr, &m_laserOriginPosition, &orbitPosition, growthFrames );
 				}
 			}
@@ -957,7 +959,7 @@ void ParticleUplinkCannonUpdate::createOrbitToTargetLaser( UnsignedInt growthFra
 				{
 					Coord3D orbitPosition;
 					orbitPosition.set( &m_initialTargetPosition );
-					orbitPosition.z += 500.0f;
+					orbitPosition.z += ORBITAL_BEAM_Z_OFFSET;
 					update->initLaser( nullptr, &orbitPosition, &m_initialTargetPosition, growthFrames );
 				}
 			}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
@@ -58,7 +58,9 @@
 #include "GameLogic/Module/PhysicsUpdate.h"
 #include "GameLogic/Module/ActiveBody.h"
 
-
+// TheSuperHackers @fix Mirelle 04/02/2026: Raised from 500.0f so that
+// enormous camera heights cannot see above the laser origin.
+constexpr const Real ORBITAL_BEAM_Z_OFFSET = 3500.0f;
 
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
@@ -625,7 +627,7 @@ UpdateSleepTime ParticleUplinkCannonUpdate::update()
 
 			Coord3D orbitPosition;
 			orbitPosition.set( &m_currentTargetPosition );
-			orbitPosition.z += 500.0f;
+			orbitPosition.z += ORBITAL_BEAM_Z_OFFSET;
 
 			Real scorchRadius = 0.0f;
 			Real damageRadius = 0.0f;
@@ -1003,7 +1005,7 @@ void ParticleUplinkCannonUpdate::createGroundToOrbitLaser( UnsignedInt growthFra
 				{
 					Coord3D orbitPosition;
 					orbitPosition.set( &m_laserOriginPosition );
-					orbitPosition.z += 500.0f;
+					orbitPosition.z += ORBITAL_BEAM_Z_OFFSET;
 					update->initLaser( nullptr, nullptr, &m_laserOriginPosition, &orbitPosition, "", growthFrames );
 				}
 			}
@@ -1042,7 +1044,7 @@ void ParticleUplinkCannonUpdate::createOrbitToTargetLaser( UnsignedInt growthFra
 				{
 					Coord3D orbitPosition;
 					orbitPosition.set( &m_initialTargetPosition );
-					orbitPosition.z += 500.0f;
+					orbitPosition.z += ORBITAL_BEAM_Z_OFFSET;
 					update->initLaser( nullptr, nullptr, &orbitPosition, &m_initialTargetPosition, "", growthFrames );
 				}
 			}


### PR DESCRIPTION
Particle Cannon "Short Beam" Fix Walkthrough

## Goal

Fix the visual bug where the Particle Uplink Cannon's laser beam appeared cut off or "floating" mid-air when viewed from a distance or on high-elevation maps, rather than striking from orbit.

## Changes

We modified ParticleUplinkCannonUpdate.cpp to increase the orbital origin height of the beam.

ParticleUplinkCannonUpdate.cpp
Increased Height: Changed the vertical offset from 500.0f to 3500.0f in three key locations:
update()
createGroundToOrbitLaser()
createOrbitToTargetLaser()

Introduced Named Constant: Defined ORBITAL_BEAM_Z_OFFSET to replace the magic number.
```
constexpr const Real ORBITAL_BEAM_Z_OFFSET = 3500.0f;
```

These changes ensure the beam's origin point is high enough even when zoomed out or on high maps, maintaining the illusion of an orbital strike.