### PR TITLE
bugfix(pathfinder): Fix some pinched cells being changed to impassable cells in internal_classifyObjectFootprint()

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -4093,6 +4093,7 @@ void Pathfinder::internal_classifyObjectFootprint( Object *obj, Bool insert )
 		}
 	}
 
+#if RETAIL_COMPATIBLE_PATHFINDING
 	for( j=cellBounds.lo.y; j<=cellBounds.hi.y; j++ )
 	{
 		for( i=cellBounds.lo.x; i<=cellBounds.hi.x; i++ )
@@ -4103,6 +4104,7 @@ void Pathfinder::internal_classifyObjectFootprint( Object *obj, Bool insert )
 			}
 		}
 	}
+#endif
 
 	// Expand building bounds 1 cell.
 	for( j=cellBounds.lo.y; j<=cellBounds.hi.y; j++ )

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -4373,6 +4373,7 @@ void Pathfinder::internal_classifyObjectFootprint( Object *obj, Bool insert )
 		}
 	}
 
+#if RETAIL_COMPATIBLE_PATHFINDING
 	for( j=cellBounds.lo.y; j<=cellBounds.hi.y; j++ )
 	{
 		for( i=cellBounds.lo.x; i<=cellBounds.hi.x; i++ )
@@ -4383,6 +4384,7 @@ void Pathfinder::internal_classifyObjectFootprint( Object *obj, Bool insert )
 			}
 		}
 	}
+#endif
 
 	// Expand building bounds 1 cell.
 	for( j=cellBounds.lo.y; j<=cellBounds.hi.y; j++ )


### PR DESCRIPTION
Closes: #2158 

This PR simply removes a block of code from non retail compilation.

To me it seems like this block was erroneously left as it causes sporadic behaviour with pinched cells being changed to impassable cells. These impassable cells cannot be moved over or built over.

As a bit of background, pinched cells (in light blue on the pathfinding debug overlay) normally can't be pathed over. So these pinched celks that are changed to the green impassable cells don't add anything currently to gameplay.

Many of the initial pinched cells are created when an object is placed and it's footprint is classified, this algorithm needs improving in general as the area taken by buildings is oversized at times.

Without fix:
<img width="930" height="671" alt="image" src="https://github.com/user-attachments/assets/da434743-a6ba-48b6-8e21-38dc392bd27c" />

With fix:
<img width="1098" height="657" alt="image" src="https://github.com/user-attachments/assets/b01aaaf8-2403-4f39-991a-6a113a599229" />

the blue pinched cells are still not passable by units so behaviour is mostly unchanged, the biggest thing this helps with is when placed buildings generate a pinched cell, that gets turned impassable, as shown in #2158. This then prevents the close placement of new buildings.

---
**TODO:**

- [x] Replicate in generals