### PR TITLE
fix(radar): Always keep Radar View Box in sync with the actual Camera View

### DIFF
--- a/Core/GameEngine/Include/Common/Radar.h
+++ b/Core/GameEngine/Include/Common/Radar.h
@@ -224,6 +224,8 @@ public:
 	virtual void beginSetShroudLevel() {} ///< call this once before multiple calls to setShroudLevel for better performance
 	virtual void endSetShroudLevel() {} ///< call this once after beginSetShroudLevel and setShroudLevel
 
+	virtual void notifyViewChanged() {} ///< signals that the camera view has changed
+
 protected:
 
 	// snapshot methods

--- a/Core/GameEngineDevice/Include/W3DDevice/Common/W3DRadar.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/Common/W3DRadar.h
@@ -71,6 +71,8 @@ public:
 	virtual void refreshTerrain( TerrainLogic *terrain );
 	virtual void refreshObjects();
 
+	virtual void notifyViewChanged(); ///< signals that the camera view has changed
+
 protected:
 
 	void drawSingleBeaconEvent( Int pixelX, Int pixelY, Int width, Int height, Int index );
@@ -117,14 +119,11 @@ protected:
 	Int m_textureHeight;													///< height for all radar textures
 
 	//
-	// we want to keep a flag that tells us when to reconstruct the view box, we want
-	// to reconstruct the box on map change, and when the camera changes height
-	// or orientation.  We want to avoid making the view box every frame because
-	// the 4 points visible on the edge of the screen will "jitter" unevenly as we
-	// translate real world coords to integer radar spots
+	// We want to keep a flag that tells us when to reconstruct the view box.
+	// We want to avoid making the view box every frame because the 4 points
+	// visible on the edge of the screen will "jitter" unevenly as we translate
+	// real world coordinates to integer radar positions.
 	//
 	Bool m_reconstructViewBox;										///< true when we need to reconstruct the box
-	Real m_viewAngle;															///< camera angle used for the view box we have
-	Real m_viewZoom;															///< camera zoom used for the view box we have
 	ICoord2D m_viewBox[ 4 ];											///< radar cell points for the 4 corners of view box
 };

--- a/Core/GameEngineDevice/Source/W3DDevice/Common/System/W3DRadar.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/Common/System/W3DRadar.cpp
@@ -221,14 +221,6 @@ void W3DRadar::reconstructViewBox( void )
 
 	}
 
-	//
-	// save the camera settings for this view box, we will need to make it again only
-	// if some of these change
-	//
-	m_viewAngle = TheTacticalView->getAngle();
-	Coord3D pos;
-	TheTacticalView->getPosition( &pos );
-	m_viewZoom = TheTacticalView->getZoom();
 	m_reconstructViewBox = FALSE;
 
 }
@@ -871,8 +863,7 @@ W3DRadar::W3DRadar( void )
 	m_textureHeight = RADAR_CELL_HEIGHT;
 
 	m_reconstructViewBox = TRUE;
-	m_viewAngle = 0.0f;
-	m_viewZoom = 0.0f;
+
 	for( Int i = 0; i < 4; i++ )
 	{
 
@@ -1516,14 +1507,10 @@ void W3DRadar::draw( Int pixelX, Int pixelY, Int width, Int height )
 	// draw any radar events
 	drawEvents( ul.x, ul.y, scaledWidth, scaledHeight );
 
-	// see if we need to reconstruct the view box
-	if( TheTacticalView->getZoom() != m_viewZoom )
-		m_reconstructViewBox = TRUE;
-	if( TheTacticalView->getAngle() != m_viewAngle )
-		m_reconstructViewBox = TRUE;
-
-	if( m_reconstructViewBox == TRUE )
+	if( m_reconstructViewBox )
+	{
 		reconstructViewBox();
+	}
 
 	// draw the view region on top of the radar reconstructing if necessary
 	drawViewBox( ul.x, ul.y, scaledWidth, scaledHeight );
@@ -1556,6 +1543,12 @@ void W3DRadar::refreshObjects()
 	}
 }
 
+// ------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
+void W3DRadar::notifyViewChanged()
+{
+	m_reconstructViewBox = TRUE;
+}
 
 
 ///The following is an "archive" of an attempt to foil the mapshroud hack... saved for later, since it is too close to release to try it

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -42,6 +42,7 @@
 #include "Common/GameUtility.h"
 #include "Common/GlobalData.h"
 #include "Common/Module.h"
+#include "Common/Radar.h"
 #include "Common/RandomValue.h"
 #include "Common/ThingTemplate.h"
 #include "Common/ThingSort.h"
@@ -623,6 +624,13 @@ void W3DView::setCameraTransform( void )
 		 W3DDisplay::m_3DScene->destroyLightsIterator(it);
 		 it = nullptr;
 		}
+	}
+
+	// TheSuperHackers @fix Notify the Radar about the changed view always.
+	// This way the radar view box should always be in sync with the camera view.
+	if (TheRadar)
+	{
+		TheRadar->notifyViewChanged();
 	}
 }
 


### PR DESCRIPTION
This change always keeps the Radar View Box in sync with the actual Camera View.

Originally this worked fine for Camera Pitch and Zoom, but it would not work with FOV changes and similar unaccounted camera modifications that can be added in future changes.

The change implicitly also simplifies the code.