### PR TITLE
fix(debug): Allocate enough terrain debug icons based on the map dimensions in W3DDebugIcons()

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTerrainVisual.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTerrainVisual.cpp
@@ -630,7 +630,7 @@ Bool W3DTerrainVisual::load( AsciiString filename )
 	// Icon drawing utility object for pathfinding.
 	if (W3DDisplay::m_3DScene != nullptr)
 	{
-		W3DDebugIcons *icons = NEW W3DDebugIcons;
+		W3DDebugIcons *icons = NEW W3DDebugIcons(m_logicHeightMap->getXExtent(), m_logicHeightMap->getYExtent());
 		W3DDisplay::m_3DScene->Add_Render_Object( icons );
 		icons->Release_Ref(); // belongs to scene.
 	}

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDebugIcons.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDebugIcons.h
@@ -40,7 +40,7 @@ class W3DDebugIcons : public RenderObjClass
 
 public:
 
-	W3DDebugIcons(void);
+	W3DDebugIcons(Int mapWidth, Int mapHeight);
 	W3DDebugIcons(const W3DDebugIcons & src);
 	W3DDebugIcons & operator = (const W3DDebugIcons &);
 	~W3DDebugIcons(void);
@@ -61,11 +61,11 @@ protected:
 	VertexMaterialClass	  	*m_vertexMaterialClass;
 
 protected:
-	static DebugIcon				*m_debugIcons;
-	static Int							m_numDebugIcons;
+	static DebugIcon        *m_debugIcons;
+	static Int              m_numDebugIcons;
+	static Int              m_maxDebugIcons;
 
 protected:
-	enum {MAX_ICONS = 100000};
 	void allocateIconsArray(void);
 	void compressIconsArray(void);
 

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDebugIcons.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDebugIcons.cpp
@@ -95,18 +95,19 @@ struct DebugIcon {
 
 DebugIcon	*W3DDebugIcons::m_debugIcons = nullptr;
 Int				 W3DDebugIcons::m_numDebugIcons = 0;
+Int				 W3DDebugIcons::m_maxDebugIcons = 0;
 
 W3DDebugIcons::~W3DDebugIcons(void)
 {
 	REF_PTR_RELEASE(m_vertexMaterialClass);
-	delete m_debugIcons;
+	delete[] m_debugIcons;
 	m_debugIcons = nullptr;
 	m_numDebugIcons = 0;
 }
 
-W3DDebugIcons::W3DDebugIcons(void)
-
+W3DDebugIcons::W3DDebugIcons(Int mapWidth, Int mapHeight)
 {
+	m_maxDebugIcons = mapWidth * mapHeight;
 	//go with a preset material for now.
 	m_vertexMaterialClass=VertexMaterialClass::Get_Preset(VertexMaterialClass::PRELIT_DIFFUSE);
 	allocateIconsArray();
@@ -161,7 +162,8 @@ RenderObjClass * W3DDebugIcons::Clone(void) const
 
 void W3DDebugIcons::allocateIconsArray(void)
 {
-	m_debugIcons = NEW DebugIcon[MAX_ICONS];
+	DEBUG_ASSERTCRASH(m_debugIcons == nullptr, ("debugIcons array already allocated!"));
+	m_debugIcons = NEW DebugIcon[m_maxDebugIcons];
 	m_numDebugIcons = 0;
 }
 
@@ -193,7 +195,7 @@ void W3DDebugIcons::addIcon(const Coord3D *pos, Real width, Int numFramesDuratio
 		m_numDebugIcons = 0;
 		return;
 	}
-	if (m_numDebugIcons>= MAX_ICONS) return;
+	if (m_numDebugIcons>= m_maxDebugIcons) return;
 	if (m_debugIcons==nullptr) return;
 	m_debugIcons[m_numDebugIcons].position = *pos;
 	m_debugIcons[m_numDebugIcons].width = width;

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDebugIcons.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDebugIcons.h
@@ -40,7 +40,7 @@ class W3DDebugIcons : public RenderObjClass
 
 public:
 
-	W3DDebugIcons(void);
+	W3DDebugIcons(Int mapWidth, Int mapHeight);
 	W3DDebugIcons(const W3DDebugIcons & src);
 	W3DDebugIcons & operator = (const W3DDebugIcons &);
 	~W3DDebugIcons(void);
@@ -61,11 +61,11 @@ protected:
 	VertexMaterialClass	  	*m_vertexMaterialClass;
 
 protected:
-	static DebugIcon				*m_debugIcons;
-	static Int							m_numDebugIcons;
+	static DebugIcon        *m_debugIcons;
+	static Int              m_numDebugIcons;
+	static Int              m_maxDebugIcons;
 
 protected:
-	enum {MAX_ICONS = 100000};
 	void allocateIconsArray(void);
 	void compressIconsArray(void);
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDebugIcons.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDebugIcons.cpp
@@ -95,18 +95,19 @@ struct DebugIcon {
 
 DebugIcon	*W3DDebugIcons::m_debugIcons = nullptr;
 Int				 W3DDebugIcons::m_numDebugIcons = 0;
+Int				 W3DDebugIcons::m_maxDebugIcons = 0;
 
 W3DDebugIcons::~W3DDebugIcons(void)
 {
 	REF_PTR_RELEASE(m_vertexMaterialClass);
-	delete m_debugIcons;
+	delete[] m_debugIcons;
 	m_debugIcons = nullptr;
 	m_numDebugIcons = 0;
 }
 
-W3DDebugIcons::W3DDebugIcons(void)
-
+W3DDebugIcons::W3DDebugIcons(Int mapWidth, Int mapHeight)
 {
+	m_maxDebugIcons = mapWidth * mapHeight;
 	//go with a preset material for now.
 	m_vertexMaterialClass=VertexMaterialClass::Get_Preset(VertexMaterialClass::PRELIT_DIFFUSE);
 	allocateIconsArray();
@@ -161,7 +162,8 @@ RenderObjClass * W3DDebugIcons::Clone(void) const
 
 void W3DDebugIcons::allocateIconsArray(void)
 {
-	m_debugIcons = NEW DebugIcon[MAX_ICONS];
+	DEBUG_ASSERTCRASH(m_debugIcons == nullptr, ("debugIcons array already allocated!"));
+	m_debugIcons = NEW DebugIcon[m_maxDebugIcons];
 	m_numDebugIcons = 0;
 }
 
@@ -193,7 +195,7 @@ void W3DDebugIcons::addIcon(const Coord3D *pos, Real width, Int numFramesDuratio
 		m_numDebugIcons = 0;
 		return;
 	}
-	if (m_numDebugIcons>= MAX_ICONS) return;
+	if (m_numDebugIcons>= m_maxDebugIcons) return;
 	if (m_debugIcons==nullptr) return;
 	m_debugIcons[m_numDebugIcons].position = *pos;
 	m_debugIcons[m_numDebugIcons].width = width;


### PR DESCRIPTION
Edit: Updated the PR to now allocate based on the map dimensions.

A simple PR that helps with debugging pathfinding and other systems that draw overlay tiles on the map.

In some instances the defaulT 100k tiles is not enought, resulting in areas of the map missing debug icons.

The following example is an extreme case, but i have seen some complex maps where parts of the map are missing debug icons on the terrain before any buildings are constructed.

Before:
<img width="1895" height="783" alt="image" src="https://github.com/user-attachments/assets/d21172e1-0577-448a-afca-be9c933cc9a5" />
<img width="1617" height="734" alt="image" src="https://github.com/user-attachments/assets/68fdd1f7-3a3f-4950-8222-a6e2adc913d3" />


After:
<img width="1902" height="806" alt="image" src="https://github.com/user-attachments/assets/c61e4bd3-3d00-4c52-a8ef-4a7c59347108" />
<img width="1910" height="805" alt="image" src="https://github.com/user-attachments/assets/8f003dc4-48dc-4f29-91b6-54bae69cc790" />
