### PR TITLE
fix(draw): Fix illogical dirt effect update code in W3DTruckDraw::doDrawModule(), W3DTankTruckDraw::doDrawModule()

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankTruckDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankTruckDraw.cpp
@@ -631,9 +631,6 @@ void W3DTankTruckDraw::doDrawModule(const Matrix3D* transformMtx)
 			if (speed>SIZE_CAP) {
 				speed = SIZE_CAP;
 			}
-			m_dustEffect->setSizeMultiplier(speed);
-		}
-		if (m_dirtEffect) {
 			if (wheelInfo && wheelInfo->m_framesAirborne>3) {
 				Real factor = 1 + wheelInfo->m_framesAirborne/16;
 				if (factor>2.0) factor = 2.0;
@@ -642,9 +639,7 @@ void W3DTankTruckDraw::doDrawModule(const Matrix3D* transformMtx)
 				m_landingSound.setPosition(obj->getPosition());
 				TheAudio->addAudioEvent(&m_landingSound);
 			} else {
-				if (!accelerating || speed>2.0f) {
-					m_dirtEffect->stop();
-				}
+				m_dustEffect->setSizeMultiplier(speed);
 			}
 		}
 		if (m_powerslideEffect) {
@@ -656,7 +651,7 @@ void W3DTankTruckDraw::doDrawModule(const Matrix3D* transformMtx)
 			}
 		}
 		if (m_dirtEffect) {
-			if (!accelerating || speed>2.0f) {
+			if (!accelerating) {
 				m_dirtEffect->stop();
 			}
 		}

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTruckDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTruckDraw.cpp
@@ -588,9 +588,6 @@ void W3DTruckDraw::doDrawModule(const Matrix3D* transformMtx)
 			if (speed>SIZE_CAP) {
 				speed = SIZE_CAP;
 			}
-			m_dustEffect->setSizeMultiplier(speed);
-		}
-		if (m_dirtEffect) {
 			if (wheelInfo && wheelInfo->m_framesAirborne>3) {
 				Real factor = 1 + wheelInfo->m_framesAirborne/16;
 				if (factor>2.0) factor = 2.0;
@@ -599,9 +596,7 @@ void W3DTruckDraw::doDrawModule(const Matrix3D* transformMtx)
 				m_landingSound.setObjectID(obj->getID());
 				TheAudio->addAudioEvent(&m_landingSound);
 			} else {
-				if (!accelerating || speed>2.0f) {
-					m_dirtEffect->stop();
-				}
+				m_dustEffect->setSizeMultiplier(speed);
 			}
 		}
 		if (m_powerslideEffect) {
@@ -613,7 +608,7 @@ void W3DTruckDraw::doDrawModule(const Matrix3D* transformMtx)
 			}
 		}
 		if (m_dirtEffect) {
-			if (!accelerating || speed>2.0f) {
+			if (!accelerating) {
 				m_dirtEffect->stop();
 			}
 		}


### PR DESCRIPTION
This change fixes the illogical dirt effect update code in `W3DTruckDraw::doDrawModule()`, `W3DTankTruckDraw::doDrawModule()`.

I spotted this by reading over this code while working on Particle stuff.

Consider the following things:
```cpp
if (m_dustEffect) {
    // Need more dust the faster we go.
    if (speed>SIZE_CAP) {
        speed = SIZE_CAP;
    }
    m_dustEffect->setSizeMultiplier(speed);
}
if (m_dirtEffect) { // <--- This tests m_dirtEffect, but m_dustEffect is dereferenced afterwards
    if (wheelInfo && wheelInfo->m_framesAirborne>3) {
        Real factor = 1 + wheelInfo->m_framesAirborne/16;
        if (factor>2.0) factor = 2.0;
        m_dustEffect->setSizeMultiplier(factor*SIZE_CAP);
        m_dustEffect->trigger(); // <--- This dereferences m_dustEffect, when only m_dirtEffect was tested
        m_landingSound.setPosition(obj->getPosition());
        TheAudio->addAudioEvent(&m_landingSound);
    } else {
        if (!accelerating || speed>2.0f) {
            m_dirtEffect->stop(); // <--- This is effectively a duplicate of the m_dirtEffect->stop below
        }
    }
}
if (m_powerslideEffect) {
    if (physics->getTurning() == TURN_NONE) {
        m_powerslideEffect->stop();
    }	else {
        m_isPowersliding = true;
        m_powerslideEffect->start();
    }
}
if (m_dirtEffect) {
    if (!accelerating || speed>2.0f) { // speed>2.0f can never be true when m_dustEffect is not NULL, because of the speed cap to SIZE_CAP=2
        m_dirtEffect->stop();
    }
}
```

So according the above findings, I decided to apply the changes that I applied:

* Replace `if (m_dirtEffect)` with `if (m_dustEffect)` and merge the condition bodies
* Remove duplicate `m_dirtEffect->stop();`
* Remove illogical `speed>2.0f` test

My impression is the EA guy puffed one to many times on his crack pipe.

Tested with:

* USA Humvee
* China Truck
* GLA Quad Cannon
 
They looked at usual. But I am not 100% sure this creates no unexpected issue. But ultimately I think it is desirable to clean this code to set predictable expectations for how the Truck particles are supposed to work.