### PR TITLE
fix(draw): Replace ParticleSystem pointers with ParticleSystemID for safe particle lookups in W3DTrankDraw, W3DTankTruckDraw, W3DTruckDraw

### DIFF
--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DTankDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DTankDraw.h
@@ -75,7 +75,7 @@ protected:
 protected:
 
 	/// left and right debris emitters for when tank is moving
-	ParticleSystem* m_treadDebris[2];
+	ParticleSystemID m_treadDebrisIDs[2];
 
 	RenderObjClass *m_prevRenderObj;
 
@@ -96,7 +96,6 @@ protected:
 	void createEmitters( void );					///< Create particle effects.
 	void tossEmitters( void );					///< Create particle effects.
 
-	void startMoveDebris( void );												///< start creating debris from the tank treads
 	void stopMoveDebris( void );												///< stop creating debris from the tank treads
 	void updateTreadObjects(void);												///< update pointers to sub-objects like treads.
 	void updateTreadPositions(Real uvDelta);									///< update uv coordinates on each tread

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DTankTruckDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DTankTruckDraw.h
@@ -99,7 +99,7 @@ protected:
 
 	/// debris emitters for when tank is moving
 	enum { DustEffect, DirtEffect, PowerslideEffect };
-	ParticleSystem* m_truckEffects[3];
+	ParticleSystemID m_truckEffectIDs[3];
 
 	Real						m_frontWheelRotation;
 	Real						m_rearWheelRotation;
@@ -122,7 +122,7 @@ protected:
 	//Tank Data
 
 	/// left and right debris emitters for when tank is moving
-	ParticleSystem* m_treadDebris[2];
+	ParticleSystemID m_treadDebrisIDs[2];
 
 	enum TreadType { TREAD_LEFT, TREAD_RIGHT, TREAD_MIDDLE };	//types of treads for different vehicles
 	enum {MAX_TREADS_PER_TANK=4};
@@ -144,7 +144,6 @@ protected:
 	void enableEmitters( Bool enable );						///< stop creating debris from the tank treads
 	void updateBones( void );
 
-	void startMoveDebris( void );												///< start creating debris from the tank treads
 	void stopMoveDebris( void );												///< stop creating debris from the tank treads
 	void updateTreadObjects(void);												///< update pointers to sub-objects like treads.
 	void updateTreadPositions(Real uvDelta);									///< update uv coordinates on each tread

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DTruckDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DTruckDraw.h
@@ -102,7 +102,7 @@ protected:
 
 	/// debris emitters for when tank is moving
 	enum { DustEffect, DirtEffect, PowerslideEffect };
-	ParticleSystem* m_truckEffects[3];
+	ParticleSystemID m_truckEffectIDs[3];
 
 	Real						m_frontWheelRotation;
 	Real						m_rearWheelRotation;

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankTruckDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankTruckDraw.cpp
@@ -101,13 +101,13 @@ m_frontRightTireBone(0), m_frontLeftTireBone(0), m_rearLeftTireBone(0),m_rearRig
 m_prevRenderObj(nullptr)
 {
 	//Truck Data
-	std::fill(m_truckEffects, m_truckEffects + ARRAY_SIZE(m_truckEffects), nullptr);
+	std::fill(m_truckEffectIDs, m_truckEffectIDs + ARRAY_SIZE(m_truckEffectIDs), INVALID_PARTICLE_SYSTEM_ID);
 
 	m_landingSound = *(thing->getTemplate()->getPerUnitSound("TruckLandingSound"));
 	m_powerslideSound = *(thing->getTemplate()->getPerUnitSound("TruckPowerslideSound"));
 
 	//Tank data
-	std::fill(m_treadDebris, m_treadDebris + ARRAY_SIZE(m_treadDebris), nullptr);
+	std::fill(m_treadDebrisIDs, m_treadDebrisIDs + ARRAY_SIZE(m_treadDebrisIDs), INVALID_PARTICLE_SYSTEM_ID);
 
 	for (Int i=0; i<MAX_TREADS_PER_TANK; i++)
 		m_treads[i].m_robj = nullptr;
@@ -118,23 +118,24 @@ m_prevRenderObj(nullptr)
 	if (getW3DTankTruckDrawModuleData())
 	{
 		const AsciiString *treadDebrisNames[2];
-		static_assert(ARRAY_SIZE(treadDebrisNames) == ARRAY_SIZE(m_treadDebris), "Array size must match");
+		static_assert(ARRAY_SIZE(treadDebrisNames) == ARRAY_SIZE(m_treadDebrisIDs), "Array size must match");
 		treadDebrisNames[0] = &getW3DTankTruckDrawModuleData()->m_treadDebrisNameLeft;
 		treadDebrisNames[1] = &getW3DTankTruckDrawModuleData()->m_treadDebrisNameRight;
 
-		for (size_t i = 0; i < ARRAY_SIZE(m_treadDebris); ++i)
+		for (size_t i = 0; i < ARRAY_SIZE(m_treadDebrisIDs); ++i)
 		{
-			if (m_treadDebris[i] == nullptr)
+			if (m_treadDebrisIDs[i] == INVALID_PARTICLE_SYSTEM_ID)
 			{
 				if (const ParticleSystemTemplate *sysTemplate = TheParticleSystemManager->findTemplate(*treadDebrisNames[i]))
 				{
-					m_treadDebris[i] = TheParticleSystemManager->createParticleSystem( sysTemplate );
-					m_treadDebris[i]->attachToDrawable(getDrawable());
+					ParticleSystem *particleSys = TheParticleSystemManager->createParticleSystem( sysTemplate );
+					particleSys->attachToDrawable(getDrawable());
 					DEBUG_CRASH(("test me, may not work (srj)"));
 					// important: mark it as do-not-save, since we'll just re-create it when we reload.
-					m_treadDebris[i]->setSaveable(FALSE);
+					particleSys->setSaveable(FALSE);
 					// they come into being stopped.
-					//m_treadDebris[i]->stop();
+					//particleSys->stop();
+					m_treadDebrisIDs[i] = particleSys->getSystemID();
 				}
 			}
 		}
@@ -156,30 +157,16 @@ W3DTankTruckDraw::~W3DTankTruckDraw()
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
 /**
- * Start creating debris from the tank treads
- */
-void W3DTankTruckDraw::startMoveDebris( void )
-{
-	if (getDrawable()->isDrawableEffectivelyHidden())
-		return;
-	for (size_t i = 0; i < ARRAY_SIZE(m_treadDebris); ++i)
-	{
-		if (m_treadDebris[i] != nullptr)
-			m_treadDebris[i]->start();
-	}
-}
-
-//-------------------------------------------------------------------------------------------------
-//-------------------------------------------------------------------------------------------------
-/**
  * Stop creating debris from the tank treads
  */
 void W3DTankTruckDraw::stopMoveDebris( void )
 {
-	for (size_t i = 0; i < ARRAY_SIZE(m_treadDebris); ++i)
+	for (size_t i = 0; i < ARRAY_SIZE(m_treadDebrisIDs); ++i)
 	{
-		if (m_treadDebris[i] != nullptr)
-			m_treadDebris[i]->stop();
+		if (ParticleSystem *particleSys = TheParticleSystemManager->findParticleSystem(m_treadDebrisIDs[i]))
+		{
+			particleSys->stop();
+		}
 	}
 }
 
@@ -187,14 +174,14 @@ void W3DTankTruckDraw::stopMoveDebris( void )
 //-------------------------------------------------------------------------------------------------
 void W3DTankTruckDraw::tossEmitters()
 {
-	for (size_t i = 0; i < ARRAY_SIZE(m_truckEffects); ++i)
+	for (size_t i = 0; i < ARRAY_SIZE(m_truckEffectIDs); ++i)
 	{
-		if (m_truckEffects[i] != nullptr)
+		if (ParticleSystem *particleSys = TheParticleSystemManager->findParticleSystem(m_truckEffectIDs[i]))
 		{
-			m_truckEffects[i]->attachToObject(nullptr);
-			m_truckEffects[i]->destroy();
-			m_truckEffects[i] = nullptr;
+			particleSys->attachToObject(nullptr);
+			particleSys->destroy();
 		}
+		m_truckEffectIDs[i] = INVALID_PARTICLE_SYSTEM_ID;
 	}
 }
 
@@ -223,21 +210,22 @@ void W3DTankTruckDraw::createEmitters( void )
 	if (getW3DTankTruckDrawModuleData())
 	{
 		const AsciiString *effectNames[3];
-		static_assert(ARRAY_SIZE(effectNames) == ARRAY_SIZE(m_truckEffects), "Array size must match");
+		static_assert(ARRAY_SIZE(effectNames) == ARRAY_SIZE(m_truckEffectIDs), "Array size must match");
 		effectNames[0] = &getW3DTankTruckDrawModuleData()->m_dustEffectName;
 		effectNames[1] = &getW3DTankTruckDrawModuleData()->m_dirtEffectName;
 		effectNames[2] = &getW3DTankTruckDrawModuleData()->m_powerslideEffectName;
 
-		for (size_t i = 0; i < ARRAY_SIZE(m_truckEffects); ++i)
+		for (size_t i = 0; i < ARRAY_SIZE(m_truckEffectIDs); ++i)
 		{
-			if (m_truckEffects[i] == nullptr)
+			if (m_truckEffectIDs[i] == INVALID_PARTICLE_SYSTEM_ID)
 			{
 				if (const ParticleSystemTemplate *sysTemplate = TheParticleSystemManager->findTemplate(*effectNames[i]))
 				{
-					m_truckEffects[i] = TheParticleSystemManager->createParticleSystem( sysTemplate );
-					m_truckEffects[i]->attachToObject(getDrawable()->getObject());
+					ParticleSystem *particleSys = TheParticleSystemManager->createParticleSystem( sysTemplate );
+					particleSys->attachToObject(getDrawable()->getObject());
 					// important: mark it as do-not-save, since we'll just re-create it when we reload.
-					m_truckEffects[i]->setSaveable(FALSE);
+					particleSys->setSaveable(FALSE);
+					m_truckEffectIDs[i] = particleSys->getSystemID();
 				}
 				else
 				{
@@ -266,26 +254,26 @@ void W3DTankTruckDraw::enableEmitters( Bool enable  )
 		m_effectsInitialized=true;
 	}
 
-	if (m_truckEffects[DustEffect])
+	if (ParticleSystem *particleSys = TheParticleSystemManager->findParticleSystem(m_truckEffectIDs[DustEffect]))
 	{
 		if (enable)
-			m_truckEffects[DustEffect]->start();
+			particleSys->start();
 		else
-			m_truckEffects[DustEffect]->stop();
+			particleSys->stop();
 	}
 
-	if (m_truckEffects[DirtEffect])
+	if (ParticleSystem *particleSys = TheParticleSystemManager->findParticleSystem(m_truckEffectIDs[DirtEffect]))
 	{
 		if (enable)
-			m_truckEffects[DirtEffect]->start();
+			particleSys->start();
 		else
-			m_truckEffects[DirtEffect]->stop();
+			particleSys->stop();
 	}
 
-	if (m_truckEffects[PowerslideEffect])
+	if (ParticleSystem *particleSys = TheParticleSystemManager->findParticleSystem(m_truckEffectIDs[PowerslideEffect]))
 	{
 		if (!enable)
-			m_truckEffects[PowerslideEffect]->stop();
+			particleSys->stop();
 	}
 }
 //-------------------------------------------------------------------------------------------------
@@ -596,7 +584,7 @@ void W3DTankTruckDraw::doDrawModule(const Matrix3D* transformMtx)
 				accelerating = false;  // decelerating, actually.
 			}
 		}
-		if (m_truckEffects[DustEffect]) {
+		if (ParticleSystem *particleSys = TheParticleSystemManager->findParticleSystem(m_truckEffectIDs[DustEffect])) {
 			// Need more dust the faster we go.
 			if (speed>SIZE_CAP) {
 				speed = SIZE_CAP;
@@ -604,25 +592,25 @@ void W3DTankTruckDraw::doDrawModule(const Matrix3D* transformMtx)
 			if (wheelInfo && wheelInfo->m_framesAirborne>3) {
 				Real factor = 1 + wheelInfo->m_framesAirborne/16;
 				if (factor>2.0) factor = 2.0;
-				m_truckEffects[DustEffect]->setSizeMultiplier(factor*SIZE_CAP);
-				m_truckEffects[DustEffect]->trigger();
+				particleSys->setSizeMultiplier(factor*SIZE_CAP);
+				particleSys->trigger();
 				m_landingSound.setPosition(obj->getPosition());
 				TheAudio->addAudioEvent(&m_landingSound);
 			} else {
-				m_truckEffects[DustEffect]->setSizeMultiplier(speed);
+				particleSys->setSizeMultiplier(speed);
 			}
 		}
-		if (m_truckEffects[PowerslideEffect]) {
+		if (ParticleSystem *particleSys = TheParticleSystemManager->findParticleSystem(m_truckEffectIDs[PowerslideEffect])) {
 			if (physics->getTurning() == TURN_NONE) {
-				m_truckEffects[PowerslideEffect]->stop();
+				particleSys->stop();
 			}	else {
 				m_isPowersliding = true;
-				m_truckEffects[PowerslideEffect]->start();
+				particleSys->start();
 			}
 		}
-		if (m_truckEffects[DirtEffect]) {
+		if (ParticleSystem *particleSys = TheParticleSystemManager->findParticleSystem(m_truckEffectIDs[DirtEffect])) {
 			if (!accelerating) {
-				m_truckEffects[DirtEffect]->stop();
+				particleSys->stop();
 			}
 		}
 	}
@@ -646,10 +634,7 @@ void W3DTankTruckDraw::doDrawModule(const Matrix3D* transformMtx)
 		// if tank is moving, kick up dust and debris
 	Real velMag = vel->x*vel->x + vel->y*vel->y;		// only care about moving on the ground
 
-	if (velMag > DEBRIS_THRESHOLD && !getDrawable()->isDrawableEffectivelyHidden() && !getFullyObscuredByShroud())
-		startMoveDebris();
-	else
-		stopMoveDebris();
+	const Bool doStartMoveDebris = velMag > DEBRIS_THRESHOLD && !getDrawable()->isDrawableEffectivelyHidden() && !getFullyObscuredByShroud();
 
 	// kick debris higher the faster we move
 	Coord3D velMult;
@@ -665,10 +650,18 @@ void W3DTankTruckDraw::doDrawModule(const Matrix3D* transformMtx)
 	if (velMult.z > 1.0f)
 		velMult.z = 1.0f;
 
-	for (size_t i = 0; i < ARRAY_SIZE(m_treadDebris); ++i)
+	for (size_t i = 0; i < ARRAY_SIZE(m_treadDebrisIDs); ++i)
 	{
-		m_treadDebris[i]->setVelocityMultiplier( &velMult );
-		m_treadDebris[i]->setBurstCountMultiplier( velMult.z );
+		if (ParticleSystem *particleSys = TheParticleSystemManager->findParticleSystem(m_treadDebrisIDs[i]))
+		{
+			if (doStartMoveDebris)
+				particleSys->start();
+			else
+				particleSys->stop();
+
+			particleSys->setVelocityMultiplier( &velMult );
+			particleSys->setBurstCountMultiplier( velMult.z );
+		}
 	}
 #endif
 	//Update movement of treads


### PR DESCRIPTION
**Merge with Rebase**

* Merge after #2217
* Merge after #2234
* Closes #2137

This change has 2 commits.

The first commit is a refactor to simplify the particle code in `W3DTankDraw`, `W3DTankTruckDraw`, `W3DTruckDraw`. There was a lot of code duplication which has been simplified with arrays and loops.

The second commit replaces `ParticleSystem*` pointers with `ParticleSystemID` for safe particle lookups in `W3DTankDraw`, `W3DTankTruckDraw`, `W3DTruckDraw`. This was only a concern in these 3 W3D classes. All other code already uses ID's for lookup.

Why does this matter? `ParticleSystemManager` owns all `ParticleSystem`'s and has the authority to delete them. ParticleSystem's are not reference counted. Therefore it is safer to lookup particles by ID, instead of keeping them as pointers.

Unloading a replay level in headless has shown crashing in `W3DTrankDraw`, when the `ParticleSystemManager` has cleared its particles while `W3DTankDraw` instances still had dangling ParticleSystem references.

With this change crashing is prevented, because expired ID's will simply reference no ParticleSystem. The ideal solution would be reference counted Particle ID's, but that would require changes to how the Particle System works. Given that the other game systems already use ParticleSystemID's to keep a reference, this is an established use pattern and a reasonable solution for now.

The Particle System lookup by ID is expected to be a bit more expensive that the direct pointer access, but with change #2217 the particle lookup is efficient using a hash map.