### PR TITLE
bugfix(object): Cancel previous tasks for captured dozers

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -4046,7 +4046,18 @@ void Object::onCapture( Player *oldOwner, Player *newOwner )
 		getAIUpdateInterface()->aiIdle(CMD_FROM_AI);
 #else
 		if (oldOwner->getRelationship(newOwner->getDefaultTeam()) != ALLIES)
+		{
 			getAIUpdateInterface()->aiIdle(CMD_FROM_AI);
+
+			DozerAIInterface* dozerAI = getAIUpdateInterface()->getDozerAIInterface();
+			if (dozerAI)
+			{
+				for (UnsignedInt task = DOZER_TASK_FIRST; task < DOZER_NUM_TASKS; ++task)
+				{
+					dozerAI->cancelTask((DozerTask)task);
+				}
+			}
+		}
 #endif
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -4578,7 +4578,18 @@ void Object::onCapture( Player *oldOwner, Player *newOwner )
 		getAIUpdateInterface()->aiIdle(CMD_FROM_AI);
 #else
 		if (oldOwner->getRelationship(newOwner->getDefaultTeam()) != ALLIES)
+		{
 			getAIUpdateInterface()->aiIdle(CMD_FROM_AI);
+
+			DozerAIInterface* dozerAI = getAIUpdateInterface()->getDozerAIInterface();
+			if (dozerAI)
+			{
+				for (UnsignedInt task = DOZER_TASK_FIRST; task < DOZER_NUM_TASKS; ++task)
+				{
+					dozerAI->cancelTask((DozerTask)task);
+				}
+			}
+		}
 #endif
 	}
 


### PR DESCRIPTION
This change resolves a minor issue introduced by #1870 that causes builders to attempt resumption of a previous task when captured after having been unmanned. The fix follows the same logic pattern used in `ConvertToHijackedVehicleCrateCollide::executeCrateBehavior`.

Ideally the dozer's behaviour on becoming idle should be encapsulated within the dozer AI logic, but that can be addressed in a later refactor.