### PR TITLE
refactor(lanapi): Make LANMessage accessible in LANAPI

### DIFF
--- a/Core/GameEngine/Include/GameNetwork/LANAPI.h
+++ b/Core/GameEngine/Include/GameNetwork/LANAPI.h
@@ -270,6 +270,8 @@ struct LANMessage
 };
 #pragma pack(pop)
 
+static_assert(sizeof(LANMessage) <= MAX_PACKET_SIZE, "LANMessage struct cannot be larger than the max packet size");
+
 
 /**
  * The LANAPI class is used to instantiate a singleton which


### PR DESCRIPTION
This change moves the `LANMessage` struct before the `LANAPI` class, so that the former can be used in the latter.

First commit is the move which includes no other changes.