### PR TITLE
tweak(pathfinder): Add audio event and message to announce pathfinding failover

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -49,6 +49,12 @@
 #include "GameLogic/PartitionManager.h"
 #include "GameLogic/TerrainLogic.h"
 #include "GameLogic/Weapon.h"
+#if RETAIL_COMPATIBLE_PATHFINDING
+#include "GameClient/InGameUI.h"
+#include "GameClient/GameText.h"
+#include "Common/GameAudio.h"
+#include "Common/MiscAudio.h"
+#endif
 
 #include "Common/UnitTimings.h" //Contains the DO_UNIT_TIMINGS define jba.
 
@@ -1105,6 +1111,11 @@ void PathfindCellInfo::forceCleanPathFindCellInfos()
 
 void Pathfinder::forceCleanCells()
 {
+	UnicodeString pathfinderFailoverMessage = TheGameText->FETCH_OR_SUBSTITUTE("GUI:PathfindingCrashPrevented", L"A pathfinding crash was prevented, now switching to the crash fixed pathfinding.");
+	TheInGameUI->message(pathfinderFailoverMessage);
+
+	TheAudio->addAudioEvent(&TheAudio->getMiscAudio()->m_allCheerSound);
+
 	PathfindCellInfo::forceCleanPathFindCellInfos();
 	m_openList = nullptr;
 	m_closedList = nullptr;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -49,6 +49,12 @@
 #include "GameLogic/PartitionManager.h"
 #include "GameLogic/TerrainLogic.h"
 #include "GameLogic/Weapon.h"
+#if RETAIL_COMPATIBLE_PATHFINDING
+#include "GameClient/InGameUI.h"
+#include "GameClient/GameText.h"
+#include "Common/GameAudio.h"
+#include "Common/MiscAudio.h"
+#endif
 
 #include "Common/UnitTimings.h" //Contains the DO_UNIT_TIMINGS define jba.
 
@@ -1120,6 +1126,11 @@ void PathfindCellInfo::forceCleanPathFindCellInfos()
 
 void Pathfinder::forceCleanCells()
 {
+	UnicodeString pathfinderFailoverMessage = TheGameText->FETCH_OR_SUBSTITUTE("GUI:PathfindingCrashPrevented", L"A pathfinding crash was prevented, now switching to the crash fixed pathfinding.");
+	TheInGameUI->message(pathfinderFailoverMessage);
+
+	TheAudio->addAudioEvent(&TheAudio->getMiscAudio()->m_allCheerSound);
+
 	PathfindCellInfo::forceCleanPathFindCellInfos();
 	m_openList = nullptr;
 	m_closedList = nullptr;


### PR DESCRIPTION
This PR is to help people, on the TSH or TSH vs Retail, know that the pathfinding has switched to the crash fixed code path.

The Unicode Message is used simply since it can write straight to the game ui without any kind of tags.

I chose the cheering audio event since it's noticeable and people don't often use it during a game.

Example of the notification ingame. (ignore the mismatch message, this pathfinder crash replay always mismatches near the end).

<img width="878" height="428" alt="image" src="https://github.com/user-attachments/assets/06f3fff7-938d-4f04-a678-7dca874477d0" />
