### PR TITLE
feat(headless): Implement GhostObjectManagerDummy

### DIFF
--- a/Generals/Code/GameEngine/Include/GameLogic/GameLogic.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/GameLogic.h
@@ -335,7 +335,7 @@ private:
 
 	/// factory for TheTerrainLogic, called from init()
 	virtual TerrainLogic *createTerrainLogic();
-	virtual GhostObjectManager *createGhostObjectManager();
+	virtual GhostObjectManager *createGhostObjectManager(bool headless = false);
 
 	GameMode m_gameMode;
 	Int m_rankLevelLimit;

--- a/Generals/Code/GameEngine/Include/GameLogic/GameLogic.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/GameLogic.h
@@ -335,7 +335,7 @@ private:
 
 	/// factory for TheTerrainLogic, called from init()
 	virtual TerrainLogic *createTerrainLogic();
-	virtual GhostObjectManager *createGhostObjectManager(bool headless = false);
+	virtual GhostObjectManager *createGhostObjectManager(bool dummy = false);
 
 	GameMode m_gameMode;
 	Int m_rankLevelLimit;

--- a/Generals/Code/GameEngine/Include/GameLogic/GhostObject.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/GhostObject.h
@@ -108,5 +108,19 @@ inline Bool GhostObjectManager::trackAllPlayers() const
 #endif
 }
 
+// TheSuperHackers @feature bobtista 19/01/2026
+// GhostObjectManager that does nothing for headless mode.
+// Note: Does NOT override crc/xfer/loadPostProcess to maintain save compatibility.
+class GhostObjectManagerDummy : public GhostObjectManager
+{
+public:
+	virtual void reset(void) {}
+	virtual GhostObject *addGhostObject(Object *object, PartitionData *pd) { return nullptr; }
+	virtual void removeGhostObject(GhostObject *mod) {}
+	virtual void updateOrphanedObjects(int *playerIndexList, int playerIndexCount) {}
+	virtual void releasePartitionData(void) {}
+	virtual void restorePartitionData(void) {}
+};
+
 // the singleton
 extern GhostObjectManager *TheGhostObjectManager;

--- a/Generals/Code/GameEngine/Include/GameLogic/GhostObject.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/GhostObject.h
@@ -114,12 +114,12 @@ inline Bool GhostObjectManager::trackAllPlayers() const
 class GhostObjectManagerDummy : public GhostObjectManager
 {
 public:
-	virtual void reset(void) {}
-	virtual GhostObject *addGhostObject(Object *object, PartitionData *pd) { return nullptr; }
-	virtual void removeGhostObject(GhostObject *mod) {}
-	virtual void updateOrphanedObjects(int *playerIndexList, int playerIndexCount) {}
-	virtual void releasePartitionData(void) {}
-	virtual void restorePartitionData(void) {}
+	virtual void reset() override {}
+	virtual GhostObject *addGhostObject(Object *object, PartitionData *pd) override { return nullptr; }
+	virtual void removeGhostObject(GhostObject *mod) override {}
+	virtual void updateOrphanedObjects(int *playerIndexList, int playerIndexCount) override {}
+	virtual void releasePartitionData() override {}
+	virtual void restorePartitionData() override {}
 };
 
 // the singleton

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -349,7 +349,7 @@ void GameLogic::init()
 	// Create system for holding deleted objects that are
 	// still in the partition manager because player has a fogged
 	// view of them.
-	TheGhostObjectManager = createGhostObjectManager();
+	TheGhostObjectManager = createGhostObjectManager(TheGlobalData->m_headless);
 
 	// create the terrain logic
 	TheTerrainLogic = createTerrainLogic();
@@ -3933,7 +3933,7 @@ UnsignedInt GameLogic::getObjectCount()
 
 // ------------------------------------------------------------------------------------------------
 // ------------------------------------------------------------------------------------------------
-GhostObjectManager *GameLogic::createGhostObjectManager()
+GhostObjectManager *GameLogic::createGhostObjectManager(bool)
 {
 	return NEW GhostObjectManager;
 }

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -3933,8 +3933,10 @@ UnsignedInt GameLogic::getObjectCount()
 
 // ------------------------------------------------------------------------------------------------
 // ------------------------------------------------------------------------------------------------
-GhostObjectManager *GameLogic::createGhostObjectManager(bool)
+GhostObjectManager *GameLogic::createGhostObjectManager(bool dummy)
 {
+	if (dummy)
+		return NEW GhostObjectManagerDummy;
 	return NEW GhostObjectManager;
 }
 

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameLogic/W3DGameLogic.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameLogic/W3DGameLogic.h
@@ -36,6 +36,7 @@
 // SYSTEM INCLUDES ////////////////////////////////////////////////////////////
 
 // USER INCLUDES //////////////////////////////////////////////////////////////
+#include "Common/GlobalData.h"
 #include "GameLogic/GameLogic.h"
 #include "W3DDevice/GameLogic/W3DTerrainLogic.h"
 #include "W3DDevice/GameLogic/W3DGhostObject.h"
@@ -59,6 +60,7 @@ protected:
 
 	/// factory for TheTerrainLogic, called from init()
 	virtual TerrainLogic *createTerrainLogic() { return NEW W3DTerrainLogic; };
-	virtual GhostObjectManager *createGhostObjectManager() { return NEW W3DGhostObjectManager; }
+	// TheSuperHackers @feature bobtista 19/01/2026 Use dummy for headless mode
+	virtual GhostObjectManager *createGhostObjectManager() { return TheGlobalData->m_headless ? static_cast<GhostObjectManager*>(NEW GhostObjectManagerDummy) : NEW W3DGhostObjectManager; }
 
 };

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameLogic/W3DGameLogic.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameLogic/W3DGameLogic.h
@@ -36,7 +36,6 @@
 // SYSTEM INCLUDES ////////////////////////////////////////////////////////////
 
 // USER INCLUDES //////////////////////////////////////////////////////////////
-#include "Common/GlobalData.h"
 #include "GameLogic/GameLogic.h"
 #include "W3DDevice/GameLogic/W3DTerrainLogic.h"
 #include "W3DDevice/GameLogic/W3DGhostObject.h"
@@ -61,6 +60,6 @@ protected:
 	/// factory for TheTerrainLogic, called from init()
 	virtual TerrainLogic *createTerrainLogic() { return NEW W3DTerrainLogic; };
 	// TheSuperHackers @feature bobtista 19/01/2026 Use dummy for headless mode
-	virtual GhostObjectManager *createGhostObjectManager() { return TheGlobalData->m_headless ? static_cast<GhostObjectManager*>(NEW GhostObjectManagerDummy) : NEW W3DGhostObjectManager; }
+	virtual GhostObjectManager *createGhostObjectManager(bool headless) { return headless ? static_cast<GhostObjectManager*>(NEW GhostObjectManagerDummy) : NEW W3DGhostObjectManager; }
 
 };

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameLogic/W3DGameLogic.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameLogic/W3DGameLogic.h
@@ -59,7 +59,6 @@ protected:
 
 	/// factory for TheTerrainLogic, called from init()
 	virtual TerrainLogic *createTerrainLogic() { return NEW W3DTerrainLogic; };
-	// TheSuperHackers @feature bobtista 19/01/2026 Use dummy for headless mode
-	virtual GhostObjectManager *createGhostObjectManager(bool headless) { return headless ? static_cast<GhostObjectManager*>(NEW GhostObjectManagerDummy) : NEW W3DGhostObjectManager; }
+	virtual GhostObjectManager *createGhostObjectManager(bool dummy) { if (dummy) return NEW GhostObjectManagerDummy; return NEW W3DGhostObjectManager; }
 
 };

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameLogic/W3DGameLogic.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameLogic/W3DGameLogic.h
@@ -59,6 +59,11 @@ protected:
 
 	/// factory for TheTerrainLogic, called from init()
 	virtual TerrainLogic *createTerrainLogic() { return NEW W3DTerrainLogic; };
-	virtual GhostObjectManager *createGhostObjectManager(bool dummy) { if (dummy) return NEW GhostObjectManagerDummy; return NEW W3DGhostObjectManager; }
+	virtual GhostObjectManager *createGhostObjectManager(bool dummy)
+	{
+		if (dummy)
+			return NEW GhostObjectManagerDummy;
+		return NEW W3DGhostObjectManager;
+	}
 
 };

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameLogic/W3DGhostObject.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameLogic/W3DGhostObject.cpp
@@ -153,7 +153,7 @@ void W3DRenderObjectSnapshot::update(RenderObjClass *robj, DrawableInfo *drawInf
 // ------------------------------------------------------------------------------------------------
 Bool W3DRenderObjectSnapshot::addToScene()
 {
-	if (W3DDisplay::m_3DScene != nullptr && !m_robj->Is_In_Scene())
+	if (!m_robj->Is_In_Scene())
 	{
 		W3DDisplay::m_3DScene->Add_Render_Object(m_robj);
 		return true;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/GameLogic.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/GameLogic.h
@@ -359,7 +359,7 @@ private:
 
 	/// factory for TheTerrainLogic, called from init()
 	virtual TerrainLogic *createTerrainLogic();
-	virtual GhostObjectManager *createGhostObjectManager();
+	virtual GhostObjectManager *createGhostObjectManager(bool headless = false);
 
 	GameMode m_gameMode;
 	Int m_rankLevelLimit;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/GameLogic.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/GameLogic.h
@@ -359,7 +359,7 @@ private:
 
 	/// factory for TheTerrainLogic, called from init()
 	virtual TerrainLogic *createTerrainLogic();
-	virtual GhostObjectManager *createGhostObjectManager(bool headless = false);
+	virtual GhostObjectManager *createGhostObjectManager(bool dummy = false);
 
 	GameMode m_gameMode;
 	Int m_rankLevelLimit;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/GhostObject.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/GhostObject.h
@@ -108,5 +108,19 @@ inline Bool GhostObjectManager::trackAllPlayers() const
 #endif
 }
 
+// TheSuperHackers @feature bobtista 19/01/2026
+// GhostObjectManager that does nothing for headless mode.
+// Note: Does NOT override crc/xfer/loadPostProcess to maintain save compatibility.
+class GhostObjectManagerDummy : public GhostObjectManager
+{
+public:
+	virtual void reset(void) {}
+	virtual GhostObject *addGhostObject(Object *object, PartitionData *pd) { return nullptr; }
+	virtual void removeGhostObject(GhostObject *mod) {}
+	virtual void updateOrphanedObjects(int *playerIndexList, int playerIndexCount) {}
+	virtual void releasePartitionData(void) {}
+	virtual void restorePartitionData(void) {}
+};
+
 // the singleton
 extern GhostObjectManager *TheGhostObjectManager;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/GhostObject.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/GhostObject.h
@@ -114,12 +114,12 @@ inline Bool GhostObjectManager::trackAllPlayers() const
 class GhostObjectManagerDummy : public GhostObjectManager
 {
 public:
-	virtual void reset(void) {}
-	virtual GhostObject *addGhostObject(Object *object, PartitionData *pd) { return nullptr; }
-	virtual void removeGhostObject(GhostObject *mod) {}
-	virtual void updateOrphanedObjects(int *playerIndexList, int playerIndexCount) {}
-	virtual void releasePartitionData(void) {}
-	virtual void restorePartitionData(void) {}
+	virtual void reset() override {}
+	virtual GhostObject *addGhostObject(Object *object, PartitionData *pd) override { return nullptr; }
+	virtual void removeGhostObject(GhostObject *mod) override {}
+	virtual void updateOrphanedObjects(int *playerIndexList, int playerIndexCount) override {}
+	virtual void releasePartitionData() override {}
+	virtual void restorePartitionData() override {}
 };
 
 // the singleton

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -364,7 +364,7 @@ void GameLogic::init()
 	// Create system for holding deleted objects that are
 	// still in the partition manager because player has a fogged
 	// view of them.
-	TheGhostObjectManager = createGhostObjectManager();
+	TheGhostObjectManager = createGhostObjectManager(TheGlobalData->m_headless);
 
 	// create the terrain logic
 	TheTerrainLogic = createTerrainLogic();
@@ -4492,7 +4492,7 @@ UnsignedInt GameLogic::getObjectCount()
 
 // ------------------------------------------------------------------------------------------------
 // ------------------------------------------------------------------------------------------------
-GhostObjectManager *GameLogic::createGhostObjectManager()
+GhostObjectManager *GameLogic::createGhostObjectManager(bool)
 {
 	return NEW GhostObjectManager;
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -4492,8 +4492,10 @@ UnsignedInt GameLogic::getObjectCount()
 
 // ------------------------------------------------------------------------------------------------
 // ------------------------------------------------------------------------------------------------
-GhostObjectManager *GameLogic::createGhostObjectManager(bool)
+GhostObjectManager *GameLogic::createGhostObjectManager(bool dummy)
 {
+	if (dummy)
+		return NEW GhostObjectManagerDummy;
 	return NEW GhostObjectManager;
 }
 

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameLogic/W3DGameLogic.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameLogic/W3DGameLogic.h
@@ -36,6 +36,7 @@
 // SYSTEM INCLUDES ////////////////////////////////////////////////////////////
 
 // USER INCLUDES //////////////////////////////////////////////////////////////
+#include "Common/GlobalData.h"
 #include "GameLogic/GameLogic.h"
 #include "W3DDevice/GameLogic/W3DTerrainLogic.h"
 #include "W3DDevice/GameLogic/W3DGhostObject.h"
@@ -59,6 +60,7 @@ protected:
 
 	/// factory for TheTerrainLogic, called from init()
 	virtual TerrainLogic *createTerrainLogic() { return NEW W3DTerrainLogic; };
-	virtual GhostObjectManager *createGhostObjectManager() { return NEW W3DGhostObjectManager; }
+	// TheSuperHackers @feature bobtista 19/01/2026 Use dummy for headless mode
+	virtual GhostObjectManager *createGhostObjectManager() { return TheGlobalData->m_headless ? static_cast<GhostObjectManager*>(NEW GhostObjectManagerDummy) : NEW W3DGhostObjectManager; }
 
 };

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameLogic/W3DGameLogic.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameLogic/W3DGameLogic.h
@@ -36,7 +36,6 @@
 // SYSTEM INCLUDES ////////////////////////////////////////////////////////////
 
 // USER INCLUDES //////////////////////////////////////////////////////////////
-#include "Common/GlobalData.h"
 #include "GameLogic/GameLogic.h"
 #include "W3DDevice/GameLogic/W3DTerrainLogic.h"
 #include "W3DDevice/GameLogic/W3DGhostObject.h"
@@ -61,6 +60,6 @@ protected:
 	/// factory for TheTerrainLogic, called from init()
 	virtual TerrainLogic *createTerrainLogic() { return NEW W3DTerrainLogic; };
 	// TheSuperHackers @feature bobtista 19/01/2026 Use dummy for headless mode
-	virtual GhostObjectManager *createGhostObjectManager() { return TheGlobalData->m_headless ? static_cast<GhostObjectManager*>(NEW GhostObjectManagerDummy) : NEW W3DGhostObjectManager; }
+	virtual GhostObjectManager *createGhostObjectManager(bool headless) { return headless ? static_cast<GhostObjectManager*>(NEW GhostObjectManagerDummy) : NEW W3DGhostObjectManager; }
 
 };

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameLogic/W3DGameLogic.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameLogic/W3DGameLogic.h
@@ -59,7 +59,6 @@ protected:
 
 	/// factory for TheTerrainLogic, called from init()
 	virtual TerrainLogic *createTerrainLogic() { return NEW W3DTerrainLogic; };
-	// TheSuperHackers @feature bobtista 19/01/2026 Use dummy for headless mode
-	virtual GhostObjectManager *createGhostObjectManager(bool headless) { return headless ? static_cast<GhostObjectManager*>(NEW GhostObjectManagerDummy) : NEW W3DGhostObjectManager; }
+	virtual GhostObjectManager *createGhostObjectManager(bool dummy) { if (dummy) return NEW GhostObjectManagerDummy; return NEW W3DGhostObjectManager; }
 
 };

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameLogic/W3DGameLogic.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameLogic/W3DGameLogic.h
@@ -59,6 +59,11 @@ protected:
 
 	/// factory for TheTerrainLogic, called from init()
 	virtual TerrainLogic *createTerrainLogic() { return NEW W3DTerrainLogic; };
-	virtual GhostObjectManager *createGhostObjectManager(bool dummy) { if (dummy) return NEW GhostObjectManagerDummy; return NEW W3DGhostObjectManager; }
+	virtual GhostObjectManager *createGhostObjectManager(bool dummy)
+	{
+		if (dummy)
+			return NEW GhostObjectManagerDummy;
+		return NEW W3DGhostObjectManager;
+	}
 
 };

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameLogic/W3DGhostObject.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameLogic/W3DGhostObject.cpp
@@ -157,7 +157,7 @@ void W3DRenderObjectSnapshot::update(RenderObjClass *robj, DrawableInfo *drawInf
 // ------------------------------------------------------------------------------------------------
 Bool W3DRenderObjectSnapshot::addToScene()
 {
-	if (W3DDisplay::m_3DScene != nullptr && !m_robj->Is_In_Scene())
+	if (!m_robj->Is_In_Scene())
 	{
 		W3DDisplay::m_3DScene->Add_Render_Object(m_robj);
 		return true;


### PR DESCRIPTION
## Summary
- Adds GhostObjectManagerDummy class that provides no-op implementations for headless mode
- Factory in W3DGameLogic returns dummy when m_headless is true
- Intentionally does NOT override crc/xfer/loadPostProcess to maintain save compatibility

## Related
Split from #2139 per @xezon's suggestion to review each dummy class separately.