### PR TITLE
feat(headless): Implement ViewDummy

### DIFF
--- a/Core/GameEngine/Include/GameClient/View.h
+++ b/Core/GameEngine/Include/GameClient/View.h
@@ -331,5 +331,27 @@ class ViewLocation
 		}
 };
 
+// TheSuperHackers @feature bobtista 31/01/2026
+// View that does nothing. Used for Headless Mode.
+class ViewDummy : public View
+{
+public:
+	virtual Drawable *pickDrawable( const ICoord2D *screen, Bool forceAttack, PickType pickType ) { return nullptr; }
+	virtual Int iterateDrawablesInRegion( IRegion2D *screenRegion, Bool (*callback)( Drawable *draw, void *userData ), void *userData ) { return 0; }
+	virtual void forceRedraw() {}
+	virtual const Coord3D& get3DCameraPosition() const { static Coord3D zero = {0,0,0}; return zero; }
+	virtual WorldToScreenReturn worldToScreenTriReturn(const Coord3D *w, ICoord2D *s ) { return WTS_INVALID; }
+	virtual void screenToWorld( const ICoord2D *s, Coord3D *w ) {}
+	virtual void screenToTerrain( const ICoord2D *screen, Coord3D *world ) {}
+	virtual void screenToWorldAtZ( const ICoord2D *s, Coord3D *w, Real z ) {}
+	virtual void drawView( void ) {}
+	virtual void updateView(void) {}
+	virtual void stepView() {}
+	virtual void setGuardBandBias( const Coord2D *gb ) {}
+
+protected:
+	virtual void xfer( Xfer *xfer ) {}
+};
+
 // EXTERNALS //////////////////////////////////////////////////////////////////////////////////////
 extern View *TheTacticalView;		///< the main tactical interface to the game world

--- a/Core/GameEngine/Include/GameClient/View.h
+++ b/Core/GameEngine/Include/GameClient/View.h
@@ -349,8 +349,8 @@ public:
 	virtual void stepView() {}
 	virtual void setGuardBandBias( const Coord2D *gb ) {}
 
-protected:
-	virtual void xfer( Xfer *xfer ) {}
+	// TheSuperHackers @bugfix bobtista 03/02/2026 Do not override View::xfer(). The base
+	// implementation must run to serialize valid view state for save file compatibility.
 };
 
 // EXTERNALS //////////////////////////////////////////////////////////////////////////////////////

--- a/Core/GameEngine/Include/GameClient/View.h
+++ b/Core/GameEngine/Include/GameClient/View.h
@@ -336,18 +336,47 @@ class ViewLocation
 class ViewDummy : public View
 {
 public:
-	virtual Drawable *pickDrawable( const ICoord2D *screen, Bool forceAttack, PickType pickType ) { return nullptr; }
-	virtual Int iterateDrawablesInRegion( IRegion2D *screenRegion, Bool (*callback)( Drawable *draw, void *userData ), void *userData ) { return 0; }
-	virtual void forceRedraw() {}
-	virtual const Coord3D& get3DCameraPosition() const { static Coord3D zero = {0,0,0}; return zero; }
-	virtual WorldToScreenReturn worldToScreenTriReturn(const Coord3D *w, ICoord2D *s ) { return WTS_INVALID; }
-	virtual void screenToWorld( const ICoord2D *s, Coord3D *w ) {}
-	virtual void screenToTerrain( const ICoord2D *screen, Coord3D *world ) {}
-	virtual void screenToWorldAtZ( const ICoord2D *s, Coord3D *w, Real z ) {}
-	virtual void drawView( void ) {}
-	virtual void updateView(void) {}
-	virtual void stepView() {}
-	virtual void setGuardBandBias( const Coord2D *gb ) {}
+	virtual Drawable *pickDrawable( const ICoord2D *screen, Bool forceAttack, PickType pickType )
+	{
+		return nullptr;
+	}
+	virtual Int iterateDrawablesInRegion( IRegion2D *screenRegion, Bool (*callback)( Drawable *draw, void *userData ), void *userData )
+	{
+		return 0;
+	}
+	virtual void forceRedraw()
+	{
+	}
+	virtual const Coord3D& get3DCameraPosition() const
+	{
+		static Coord3D zero = {0,0,0};
+		return zero;
+	}
+	virtual WorldToScreenReturn worldToScreenTriReturn(const Coord3D *w, ICoord2D *s )
+	{
+		return WTS_INVALID;
+	}
+	virtual void screenToWorld( const ICoord2D *s, Coord3D *w )
+	{
+	}
+	virtual void screenToTerrain( const ICoord2D *screen, Coord3D *world )
+	{
+	}
+	virtual void screenToWorldAtZ( const ICoord2D *s, Coord3D *w, Real z )
+	{
+	}
+	virtual void drawView( void )
+	{
+	}
+	virtual void updateView(void)
+	{
+	}
+	virtual void stepView()
+	{
+	}
+	virtual void setGuardBandBias( const Coord2D *gb )
+	{
+	}
 
 	// TheSuperHackers @bugfix bobtista 03/02/2026 Do not override View::xfer(). The base
 	// implementation must run to serialize valid view state for save file compatibility.

--- a/Core/GameEngine/Include/GameClient/View.h
+++ b/Core/GameEngine/Include/GameClient/View.h
@@ -360,6 +360,8 @@ public:
 	virtual void updateView(void) override {}
 	virtual void stepView() override {}
 	virtual void setGuardBandBias( const Coord2D *gb ) override {}
+	virtual Bool isDoingScriptedCamera() override { return false; }
+	virtual void stopDoingScriptedCamera() override {}
 
 	// TheSuperHackers @bugfix bobtista 03/02/2026 Do not override View::xfer(). The base
 	// implementation must run to serialize valid view state for save file compatibility.

--- a/Core/GameEngine/Include/GameClient/View.h
+++ b/Core/GameEngine/Include/GameClient/View.h
@@ -336,47 +336,31 @@ class ViewLocation
 class ViewDummy : public View
 {
 public:
-	virtual Drawable *pickDrawable( const ICoord2D *screen, Bool forceAttack, PickType pickType )
+	virtual Drawable *pickDrawable( const ICoord2D *screen, Bool forceAttack, PickType pickType ) override
 	{
 		return nullptr;
 	}
-	virtual Int iterateDrawablesInRegion( IRegion2D *screenRegion, Bool (*callback)( Drawable *draw, void *userData ), void *userData )
+	virtual Int iterateDrawablesInRegion( IRegion2D *screenRegion, Bool (*callback)( Drawable *draw, void *userData ), void *userData ) override
 	{
 		return 0;
 	}
-	virtual void forceRedraw()
-	{
-	}
-	virtual const Coord3D& get3DCameraPosition() const
+	virtual void forceRedraw() override {}
+	virtual const Coord3D& get3DCameraPosition() const override
 	{
 		static Coord3D zero = {0,0,0};
 		return zero;
 	}
-	virtual WorldToScreenReturn worldToScreenTriReturn(const Coord3D *w, ICoord2D *s )
+	virtual WorldToScreenReturn worldToScreenTriReturn(const Coord3D *w, ICoord2D *s ) override
 	{
 		return WTS_INVALID;
 	}
-	virtual void screenToWorld( const ICoord2D *s, Coord3D *w )
-	{
-	}
-	virtual void screenToTerrain( const ICoord2D *screen, Coord3D *world )
-	{
-	}
-	virtual void screenToWorldAtZ( const ICoord2D *s, Coord3D *w, Real z )
-	{
-	}
-	virtual void drawView( void )
-	{
-	}
-	virtual void updateView(void)
-	{
-	}
-	virtual void stepView()
-	{
-	}
-	virtual void setGuardBandBias( const Coord2D *gb )
-	{
-	}
+	virtual void screenToWorld( const ICoord2D *s, Coord3D *w ) override {}
+	virtual void screenToTerrain( const ICoord2D *screen, Coord3D *world ) override {}
+	virtual void screenToWorldAtZ( const ICoord2D *s, Coord3D *w, Real z ) override {}
+	virtual void drawView( void ) override {}
+	virtual void updateView(void) override {}
+	virtual void stepView() override {}
+	virtual void setGuardBandBias( const Coord2D *gb ) override {}
 
 	// TheSuperHackers @bugfix bobtista 03/02/2026 Do not override View::xfer(). The base
 	// implementation must run to serialize valid view state for save file compatibility.

--- a/Core/GameEngine/Include/GameClient/View.h
+++ b/Core/GameEngine/Include/GameClient/View.h
@@ -363,8 +363,7 @@ public:
 	virtual Bool isDoingScriptedCamera() override { return false; }
 	virtual void stopDoingScriptedCamera() override {}
 
-	// TheSuperHackers @bugfix bobtista 03/02/2026 Do not override View::xfer(). The base
-	// implementation must run to serialize valid view state for save file compatibility.
+	// Do not override View::xfer(). The base implementation must run to serialize valid view state for save file compatibility.
 };
 
 // EXTERNALS //////////////////////////////////////////////////////////////////////////////////////

--- a/Core/GameEngine/Include/GameClient/View.h
+++ b/Core/GameEngine/Include/GameClient/View.h
@@ -354,7 +354,6 @@ public:
 	{
 		return WTS_INVALID;
 	}
-	virtual void screenToWorld( const ICoord2D *s, Coord3D *w ) override {}
 	virtual void screenToTerrain( const ICoord2D *screen, Coord3D *world ) override {}
 	virtual void screenToWorldAtZ( const ICoord2D *s, Coord3D *w, Real z ) override {}
 	virtual void drawView( void ) override {}

--- a/Generals/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/Generals/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -669,7 +669,7 @@ protected:
 
 	void incrementSelectCount() { ++m_selectCount; }			///< Increase by one the running total of "selected" drawables
 	void decrementSelectCount() { --m_selectCount; }			///< Decrease by one the running total of "selected" drawables
-	virtual View *createView() = 0;												///< Factory for Views
+	virtual View *createView(bool dummy = false) = 0;								///< Factory for Views
 	void evaluateSoloNexus( Drawable *newlyAddedDrawable = nullptr );
 
 	/// expire a hint from of the specified type at the hint index

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -1337,17 +1337,17 @@ void InGameUI::init()
 	been moved to where all the other translators are attached in game client */
 
 	// create the tactical view
-	if (TheDisplay)
+	TheTacticalView = createView();
+	if (TheTacticalView && TheDisplay)
 	{
-		TheTacticalView = createView();
 		TheTacticalView->init();
 		TheDisplay->attachView( TheTacticalView );
 
 		// make the tactical display the full screen width and height
 		TheTacticalView->setWidth( TheDisplay->getWidth() );
 		TheTacticalView->setHeight( TheDisplay->getHeight() );
+		TheTacticalView->setDefaultView(0.0f, 0.0f, 1.0f);
 	}
-	TheTacticalView->setDefaultView(0.0f, 0.0f, 1.0f);
 
 	/** @todo this may be the wrong place to create the sidebar, but for now
 	this is where it lives */

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -1337,7 +1337,7 @@ void InGameUI::init()
 	been moved to where all the other translators are attached in game client */
 
 	// create the tactical view
-	TheTacticalView = createView();
+	TheTacticalView = createView(TheGlobalData->m_headless);
 	if (TheTacticalView && TheDisplay)
 	{
 		TheTacticalView->init();

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DInGameUI.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DInGameUI.h
@@ -71,7 +71,7 @@ protected:
 
 	/// factory for views
 	// TheSuperHackers @fix bobtista 31/01/2026 Return dummy in headless mode
-	virtual View *createView() { return TheGlobalData->m_headless ? NEW ViewDummy : NEW W3DView; }
+	virtual View *createView() { return TheGlobalData->m_headless ? static_cast<View*>(NEW ViewDummy) : NEW W3DView; }
 
 	virtual void drawSelectionRegion();			///< draw the selection region on screen
 	virtual void drawMoveHints( View *view );			///< draw move hint visual feedback

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DInGameUI.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DInGameUI.h
@@ -36,6 +36,7 @@
 // SYSTEM INCLUDES ////////////////////////////////////////////////////////////
 
 // USER INCLUDES //////////////////////////////////////////////////////////////
+#include "Common/GlobalData.h"
 #include "GameClient/InGameUI.h"
 #include "GameClient/View.h"
 #include "W3DDevice/GameClient/W3DView.h"
@@ -69,7 +70,8 @@ public:
 protected:
 
 	/// factory for views
-	virtual View *createView() { return NEW W3DView; }
+	// TheSuperHackers @fix bobtista 31/01/2026 Return dummy in headless mode
+	virtual View *createView() { return TheGlobalData->m_headless ? NEW ViewDummy : NEW W3DView; }
 
 	virtual void drawSelectionRegion();			///< draw the selection region on screen
 	virtual void drawMoveHints( View *view );			///< draw move hint visual feedback

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DInGameUI.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DInGameUI.h
@@ -71,7 +71,10 @@ protected:
 
 	/// factory for views
 	// TheSuperHackers @fix bobtista 31/01/2026 Return dummy in headless mode
-	virtual View *createView() { return TheGlobalData->m_headless ? static_cast<View*>(NEW ViewDummy) : NEW W3DView; }
+	virtual View *createView()
+	{
+		return TheGlobalData->m_headless ? static_cast<View*>(NEW ViewDummy) : NEW W3DView;
+	}
 
 	virtual void drawSelectionRegion();			///< draw the selection region on screen
 	virtual void drawMoveHints( View *view );			///< draw move hint visual feedback

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DInGameUI.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DInGameUI.h
@@ -36,7 +36,6 @@
 // SYSTEM INCLUDES ////////////////////////////////////////////////////////////
 
 // USER INCLUDES //////////////////////////////////////////////////////////////
-#include "Common/GlobalData.h"
 #include "GameClient/InGameUI.h"
 #include "GameClient/View.h"
 #include "W3DDevice/GameClient/W3DView.h"
@@ -70,10 +69,11 @@ public:
 protected:
 
 	/// factory for views
-	// TheSuperHackers @fix bobtista 31/01/2026 Return dummy in headless mode
-	virtual View *createView()
+	virtual View *createView(bool dummy)
 	{
-		return TheGlobalData->m_headless ? static_cast<View*>(NEW ViewDummy) : NEW W3DView;
+		if (dummy)
+			return NEW ViewDummy;
+		return NEW W3DView;
 	}
 
 	virtual void drawSelectionRegion();			///< draw the selection region on screen

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -689,7 +689,7 @@ protected:
 
 	void incrementSelectCount() { ++m_selectCount; }			///< Increase by one the running total of "selected" drawables
 	void decrementSelectCount() { --m_selectCount; }			///< Decrease by one the running total of "selected" drawables
-	virtual View *createView() = 0;												///< Factory for Views
+	virtual View *createView(bool dummy = false) = 0;								///< Factory for Views
 	void evaluateSoloNexus( Drawable *newlyAddedDrawable = nullptr );
 
 	/// expire a hint from of the specified type at the hint index

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -1367,17 +1367,17 @@ void InGameUI::init()
 	been moved to where all the other translators are attached in game client */
 
 	// create the tactical view
-	if (TheDisplay)
+	TheTacticalView = createView();
+	if (TheTacticalView && TheDisplay)
 	{
-		TheTacticalView = createView();
 		TheTacticalView->init();
 		TheDisplay->attachView( TheTacticalView );
 
 		// make the tactical display the full screen width and height
 		TheTacticalView->setWidth( TheDisplay->getWidth() );
 		TheTacticalView->setHeight( TheDisplay->getHeight() );
+		TheTacticalView->setDefaultView(0.0f, 0.0f, 1.0f);
 	}
-	TheTacticalView->setDefaultView(0.0f, 0.0f, 1.0f);
 
 	/** @todo this may be the wrong place to create the sidebar, but for now
 	this is where it lives */

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -1367,7 +1367,7 @@ void InGameUI::init()
 	been moved to where all the other translators are attached in game client */
 
 	// create the tactical view
-	TheTacticalView = createView();
+	TheTacticalView = createView(TheGlobalData->m_headless);
 	if (TheTacticalView && TheDisplay)
 	{
 		TheTacticalView->init();

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DInGameUI.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DInGameUI.h
@@ -71,7 +71,7 @@ protected:
 
 	/// factory for views
 	// TheSuperHackers @fix bobtista 31/01/2026 Return dummy in headless mode
-	virtual View *createView() { return TheGlobalData->m_headless ? NEW ViewDummy : NEW W3DView; }
+	virtual View *createView() { return TheGlobalData->m_headless ? static_cast<View*>(NEW ViewDummy) : NEW W3DView; }
 
 	virtual void drawSelectionRegion();			///< draw the selection region on screen
 	virtual void drawMoveHints( View *view );			///< draw move hint visual feedback

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DInGameUI.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DInGameUI.h
@@ -36,6 +36,7 @@
 // SYSTEM INCLUDES ////////////////////////////////////////////////////////////
 
 // USER INCLUDES //////////////////////////////////////////////////////////////
+#include "Common/GlobalData.h"
 #include "GameClient/InGameUI.h"
 #include "GameClient/View.h"
 #include "W3DDevice/GameClient/W3DView.h"
@@ -69,7 +70,8 @@ public:
 protected:
 
 	/// factory for views
-	virtual View *createView() { return NEW W3DView; }
+	// TheSuperHackers @fix bobtista 31/01/2026 Return dummy in headless mode
+	virtual View *createView() { return TheGlobalData->m_headless ? NEW ViewDummy : NEW W3DView; }
 
 	virtual void drawSelectionRegion();			///< draw the selection region on screen
 	virtual void drawMoveHints( View *view );			///< draw move hint visual feedback

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DInGameUI.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DInGameUI.h
@@ -71,7 +71,10 @@ protected:
 
 	/// factory for views
 	// TheSuperHackers @fix bobtista 31/01/2026 Return dummy in headless mode
-	virtual View *createView() { return TheGlobalData->m_headless ? static_cast<View*>(NEW ViewDummy) : NEW W3DView; }
+	virtual View *createView()
+	{
+		return TheGlobalData->m_headless ? static_cast<View*>(NEW ViewDummy) : NEW W3DView;
+	}
 
 	virtual void drawSelectionRegion();			///< draw the selection region on screen
 	virtual void drawMoveHints( View *view );			///< draw move hint visual feedback

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DInGameUI.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DInGameUI.h
@@ -36,7 +36,6 @@
 // SYSTEM INCLUDES ////////////////////////////////////////////////////////////
 
 // USER INCLUDES //////////////////////////////////////////////////////////////
-#include "Common/GlobalData.h"
 #include "GameClient/InGameUI.h"
 #include "GameClient/View.h"
 #include "W3DDevice/GameClient/W3DView.h"
@@ -70,10 +69,11 @@ public:
 protected:
 
 	/// factory for views
-	// TheSuperHackers @fix bobtista 31/01/2026 Return dummy in headless mode
-	virtual View *createView()
+	virtual View *createView(bool dummy)
 	{
-		return TheGlobalData->m_headless ? static_cast<View*>(NEW ViewDummy) : NEW W3DView;
+		if (dummy)
+			return NEW ViewDummy;
+		return NEW W3DView;
 	}
 
 	virtual void drawSelectionRegion();			///< draw the selection region on screen


### PR DESCRIPTION
## Summary
- Adds ViewDummy class in Core/GameEngine/Include/GameClient/View.h with no-op implementations for headless mode
- Factory in W3DInGameUI returns dummy when m_headless is true
- Refactors InGameUI::init() to always create TheTacticalView, but only init/attach to display when TheDisplay exists
- Empty xfer() to skip view block in saves

## Related
Split from #2139 per @xezon's suggestion to review each dummy class separately.