### PR TITLE
build(cmake): Force include CppMacros.h globally for VC6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,13 @@ if (IS_VS6_BUILD)
     add_subdirectory(Dependencies/MaxSDK)
 endif()
 add_subdirectory(Dependencies/Utility)
+
+# To be removed when abandoning VC6
+if (IS_VS6_BUILD)
+    include_directories(Dependencies/Utility)
+    add_compile_options(/FIUtility/CppMacros.h)
+endif()
+
 add_subdirectory(resources)
 
 add_subdirectory(Core)


### PR DESCRIPTION
Many source files in Generals and GeneralsMD use modern C++ features like 'nullptr' (polyfilled in CppMacros.h) without explicitly including the header. This caused build failures on VC6 (Fixes #2165).

This change:
1. Adds 'Dependencies/Utility' to the global include path (guarded by IS_VS6_BUILD).
2. Uses the MSVC '/FI' flag to force include 'Utility/CppMacros.h' when compiling with VC6. This ensures compatibility macros like 'nullptr' (defined as 0) are always available.