### PR TITLE
feat(gui): Add replay dates to replay list in Replay Menu

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
@@ -290,7 +290,7 @@ void PopulateReplayFileListbox(GameWindow *listbox)
 			// name
 			UnicodeString replayNameToShow = createReplayName(asciistr);
 
-			// TheSuperHackers @tweak Caball009 07/02/2025 Display both time and date instead only time.
+			// TheSuperHackers @tweak Caball009 07/02/2025 Display both time and date instead of only time.
 			UnicodeString displayDateTimeBuffer;
 			displayDateTimeBuffer.format(L"%s %s", getUnicodeTimeBuffer(header.timeVal).str(), getUnicodeDateBuffer(header.timeVal).str());
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
@@ -290,7 +290,7 @@ void PopulateReplayFileListbox(GameWindow *listbox)
 			// name
 			UnicodeString replayNameToShow = createReplayName(asciistr);
 
-			// TheSuperHackers @tweak Caball009 07/02/2025 Display both time and date instead only time.
+			// TheSuperHackers @tweak Caball009 07/02/2025 Display both time and date instead of only time.
 			UnicodeString displayDateTimeBuffer;
 			displayDateTimeBuffer.format(L"%s %s", getUnicodeTimeBuffer(header.timeVal).str(), getUnicodeDateBuffer(header.timeVal).str());
 


### PR DESCRIPTION
This PR switches the column widths of the time and version columns for listed replays, because the latter is wider. This provides enough space to display both time and date in the second column.

We should sort the replays by date instead of name, but that's outside the scope of this PR.

## TODO:
- [x] Replicate in Generals.