### PR TITLE
bugfix(battleplan): Multiple battle plans are now always applied correctly

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -3160,7 +3160,7 @@ void Player::applyBattlePlanBonusesForPlayerObjects( const BattlePlanBonusesData
 	newBonus.m_armorScalar = bonus->m_armorScalar;
 	newBonus.m_sightRangeScalar = bonus->m_sightRangeScalar;
 
-	iterateObjects(localApplyBattlePlanBonusesToObject, (void*)&newBonus);
+	iterateObjects(localApplyBattlePlanBonusesToObject, &newBonus);
 #endif
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -3651,7 +3651,7 @@ void Player::applyBattlePlanBonusesForPlayerObjects( const BattlePlanBonusesData
 	newBonus.m_armorScalar = bonus->m_armorScalar;
 	newBonus.m_sightRangeScalar = bonus->m_sightRangeScalar;
 
-	iterateObjects(localApplyBattlePlanBonusesToObject, (void*)&newBonus);
+	iterateObjects(localApplyBattlePlanBonusesToObject, &newBonus);
 #endif
 }
 


### PR DESCRIPTION
* Fixes #46
* Fixes #2209
* Merge after #2335

This change fixes an issue where multiple Strategy Center battle plans are not correctly applied. The issue is that only the most recent plan is applied, as only the new plan data is passed to the battle plan application logic.

For example, in retail, if the player has Search and Destroy on one Strategy Center, and then selects Bombardment on another, the data that gets applied to all units becomes:

```
Search and Destroy: 0 (this undoes the range bonus)
Bombardment: 1 (new bonus is applied)
Hold the Line: 0
```

After this change, the logic correctly accounts for existing plans, and so the data becomes this:

```
Search and Destroy: 1 (range bonus remains intact)
Bombardment: 1 (new bonus is applied)
Hold the Line: 0
```

In the `Player::applyBattlePlanBonusesForPlayerObjects` method, the `bonus` is essentially the delta, while `m_battlePlanBonuses` is the combined bonus. The problem was that the `bonus` was being applied to units instead of `m_battlePlanBonuses`. However, the armour scalar is still expected as a delta when being applied to units, so a temporary `newBonus` is now used to merge the armour scalar delta with the combined bonus.