### PR TITLE
bugfix(contain): Prevent undefined behaviour when a dead unit enters a container

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -273,10 +273,16 @@ void OpenContain::addOrRemoveObjFromWorld(Object* obj, Bool add)
 //-------------------------------------------------------------------------------------------------
 void OpenContain::addToContain( Object *rider )
 {
-
+#if RETAIL_COMPATIBLE_CRC
 	// sanity
 	if( rider == nullptr )
 		return;
+#else
+	// TheSuperHackers @bugfix Stubbjax 06/02/2026 Always ensure interacting objects are alive.
+	// This prevents undefined behaviour if a unit dies and enters a container on the same frame.
+	if (rider == nullptr || rider->isEffectivelyDead() || getObject()->isEffectivelyDead())
+		return;
+#endif
 
 #if defined(RTS_DEBUG)
 	if( !isValidContainerFor( rider, false ) )

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -278,8 +278,9 @@ void OpenContain::addToContain( Object *rider )
 	if( rider == nullptr )
 		return;
 
-	// TheSuperHackers @bugfix Stubbjax 06/02/2026 Always ensure interacting objects are alive.
-	// This prevents undefined behaviour if a unit dies and enters a container on the same frame.
+	// TheSuperHackers @bugfix Stubbjax 06/02/2026 Ensure the rider is not destroyed to prevent a
+	// likely crash if it enters the container on the same frame. If this occurs with an unpatched
+	// client present in a match, the game has a small chance to mismatch.
 	if (rider->isDestroyed())
 		return;
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -280,7 +280,7 @@ void OpenContain::addToContain( Object *rider )
 #else
 	// TheSuperHackers @bugfix Stubbjax 06/02/2026 Always ensure interacting objects are alive.
 	// This prevents undefined behaviour if a unit dies and enters a container on the same frame.
-	if (rider == nullptr || rider->isEffectivelyDead() || getObject()->isEffectivelyDead())
+	if (rider == nullptr || (rider->isEffectivelyDead() && !rider->getBodyModule()->isIndestructible()) || getObject()->isEffectivelyDead())
 		return;
 #endif
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -280,7 +280,7 @@ void OpenContain::addToContain( Object *rider )
 
 	// TheSuperHackers @bugfix Stubbjax 06/02/2026 Always ensure interacting objects are alive.
 	// This prevents undefined behaviour if a unit dies and enters a container on the same frame.
-	if (rider->isDestroyed() || getObject()->isDestroyed())
+	if (rider->isDestroyed())
 		return;
 
 #if defined(RTS_DEBUG)

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -273,16 +273,15 @@ void OpenContain::addOrRemoveObjFromWorld(Object* obj, Bool add)
 //-------------------------------------------------------------------------------------------------
 void OpenContain::addToContain( Object *rider )
 {
-#if RETAIL_COMPATIBLE_CRC
+
 	// sanity
 	if( rider == nullptr )
 		return;
-#else
+
 	// TheSuperHackers @bugfix Stubbjax 06/02/2026 Always ensure interacting objects are alive.
 	// This prevents undefined behaviour if a unit dies and enters a container on the same frame.
-	if (rider == nullptr || rider->isDestroyed() || getObject()->isDestroyed())
+	if (rider->isDestroyed() || getObject()->isDestroyed())
 		return;
-#endif
 
 #if defined(RTS_DEBUG)
 	if( !isValidContainerFor( rider, false ) )

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -280,7 +280,7 @@ void OpenContain::addToContain( Object *rider )
 #else
 	// TheSuperHackers @bugfix Stubbjax 06/02/2026 Always ensure interacting objects are alive.
 	// This prevents undefined behaviour if a unit dies and enters a container on the same frame.
-	if (rider == nullptr || (rider->isEffectivelyDead() && !rider->getBodyModule()->isIndestructible()) || getObject()->isEffectivelyDead())
+	if (rider == nullptr || rider->isDestroyed() || getObject()->isDestroyed())
 		return;
 #endif
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -298,7 +298,7 @@ void OpenContain::addToContain( Object *rider )
 
 	// TheSuperHackers @bugfix Stubbjax 06/02/2026 Always ensure interacting objects are alive.
 	// This prevents undefined behaviour if a unit dies and enters a container on the same frame.
-	if (rider == nullptr || rider->isEffectivelyDead() || getObject()->isEffectivelyDead())
+	if (rider == nullptr || (rider->isEffectivelyDead() && !rider->getBodyModule()->isIndestructible()) || getObject()->isEffectivelyDead())
 		return;
 #endif
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -295,7 +295,7 @@ void OpenContain::addToContain( Object *rider )
 
 	// TheSuperHackers @bugfix Stubbjax 06/02/2026 Always ensure interacting objects are alive.
 	// This prevents undefined behaviour if a unit dies and enters a container on the same frame.
-	if (rider->isDestroyed() || getObject()->isDestroyed())
+	if (rider->isDestroyed())
 		return;
 
 	Drawable *riderDraw = rider->getDrawable();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -280,7 +280,6 @@ void OpenContain::addOrRemoveObjFromWorld(Object* obj, Bool add)
 //-------------------------------------------------------------------------------------------------
 void OpenContain::addToContain( Object *rider )
 {
-#if RETAIL_COMPATIBLE_CRC
 	if( getObject()->checkAndDetonateBoobyTrap(rider) )
 	{
 		// Whoops, I was mined.  Cancel if I (or they) am now dead.
@@ -293,14 +292,11 @@ void OpenContain::addToContain( Object *rider )
 	// sanity
 	if( rider == nullptr )
 		return;
-#else
-	getObject()->checkAndDetonateBoobyTrap(rider);
 
 	// TheSuperHackers @bugfix Stubbjax 06/02/2026 Always ensure interacting objects are alive.
 	// This prevents undefined behaviour if a unit dies and enters a container on the same frame.
-	if (rider == nullptr || rider->isDestroyed() || getObject()->isDestroyed())
+	if (rider->isDestroyed() || getObject()->isDestroyed())
 		return;
-#endif
 
 	Drawable *riderDraw = rider->getDrawable();
 	Bool wasSelected = FALSE;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -280,6 +280,7 @@ void OpenContain::addOrRemoveObjFromWorld(Object* obj, Bool add)
 //-------------------------------------------------------------------------------------------------
 void OpenContain::addToContain( Object *rider )
 {
+#if RETAIL_COMPATIBLE_CRC
 	if( getObject()->checkAndDetonateBoobyTrap(rider) )
 	{
 		// Whoops, I was mined.  Cancel if I (or they) am now dead.
@@ -292,6 +293,14 @@ void OpenContain::addToContain( Object *rider )
 	// sanity
 	if( rider == nullptr )
 		return;
+#else
+	getObject()->checkAndDetonateBoobyTrap(rider);
+
+	// TheSuperHackers @bugfix Stubbjax 06/02/2026 Always ensure interacting objects are alive.
+	// This prevents undefined behaviour if a unit dies and enters a container on the same frame.
+	if (rider == nullptr || rider->isEffectivelyDead() || getObject()->isEffectivelyDead())
+		return;
+#endif
 
 	Drawable *riderDraw = rider->getDrawable();
 	Bool wasSelected = FALSE;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -293,8 +293,9 @@ void OpenContain::addToContain( Object *rider )
 	if( rider == nullptr )
 		return;
 
-	// TheSuperHackers @bugfix Stubbjax 06/02/2026 Always ensure interacting objects are alive.
-	// This prevents undefined behaviour if a unit dies and enters a container on the same frame.
+	// TheSuperHackers @bugfix Stubbjax 06/02/2026 Ensure the rider is not destroyed to prevent a
+	// likely crash if it enters the container on the same frame. If this occurs with an unpatched
+	// client present in a match, the game has a small chance to mismatch.
 	if (rider->isDestroyed())
 		return;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -298,7 +298,7 @@ void OpenContain::addToContain( Object *rider )
 
 	// TheSuperHackers @bugfix Stubbjax 06/02/2026 Always ensure interacting objects are alive.
 	// This prevents undefined behaviour if a unit dies and enters a container on the same frame.
-	if (rider == nullptr || (rider->isEffectivelyDead() && !rider->getBodyModule()->isIndestructible()) || getObject()->isEffectivelyDead())
+	if (rider == nullptr || rider->isDestroyed() || getObject()->isDestroyed())
 		return;
 #endif
 


### PR DESCRIPTION
Closes #130

This change fixes an issue where a dead unit can enter a container if the unit happens to die on the same frame that it enters the container. The issue can cause the game to crash or lead to strange and undefined behaviour, such as the unit teleportation detailed in #130.

### Before
When the right-hand RPG Trooper dies, it also enters the Technical and takes up the second slot

<img width="1440" height="400" alt="image" src="https://github.com/user-attachments/assets/3cd2fb67-d369-4ad5-a8cc-b35e1e8d8800" />

### After
When the right-hand RPG Trooper dies, it does not enter the Technical because it is dead

<img width="1440" height="400" alt="image" src="https://github.com/user-attachments/assets/01df18af-8be5-4de8-9873-4194412e46c0" />