### PR TITLE
feat(terrain): add RenderAllTerrain flag to allow full-map visibility

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTerrainVisual.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTerrainVisual.cpp
@@ -604,29 +604,27 @@ Bool W3DTerrainVisual::load( AsciiString filename )
 
 	RefRenderObjListIterator *it = W3DDisplay::m_3DScene ? W3DDisplay::m_3DScene->createLightsIterator() : nullptr;
 	// apply the heightmap to the terrain render object
+
 #ifdef DO_SEISMIC_SIMULATIONS
-	WorldHeightMap* heightMap = m_clientHeightMap;
+	if (TheGlobalData->m_renderAllTerrain) {
+		m_clientHeightMap->setDrawWidth(m_clientHeightMap->getXExtent());
+		m_clientHeightMap->setDrawHeight(m_clientHeightMap->getYExtent());
+	}
+	m_terrainRenderObject->initHeightData( m_clientHeightMap->getDrawWidth(),
+																				 m_clientHeightMap->getDrawHeight(),
+																				 m_clientHeightMap,
+																				 it);
 #else
-	WorldHeightMap* heightMap = m_logicHeightMap;
+	if (TheGlobalData->m_renderAllTerrain) {
+		m_logicHeightMap->setDrawWidth(m_logicHeightMap->getXExtent());
+		m_logicHeightMap->setDrawHeight(m_logicHeightMap->getYExtent());
+	}
+	m_terrainRenderObject->initHeightData( m_logicHeightMap->getDrawWidth(),
+																				 m_logicHeightMap->getDrawHeight(),
+																				 m_logicHeightMap,
+																				 it);
 #endif
 
-	const Bool isRenderAllTerrain = TheGlobalData->m_renderAllTerrain;
-
-	Int xExt, yExt;
-
-	if (isRenderAllTerrain) {
-		xExt = heightMap->getXExtent();
-		yExt = heightMap->getYExtent();
-
-		// TheSuperHackers @feature explicitly draw boundaries to match full extent
-		heightMap->setDrawWidth(xExt);
-		heightMap->setDrawHeight(yExt);
-	} else {
-		xExt = heightMap->getDrawWidth();
-		yExt = heightMap->getDrawHeight();
-	}
-
-	m_terrainRenderObject->initHeightData(xExt, yExt, heightMap, it);
 
 	if (it) {
 	 W3DDisplay::m_3DScene->destroyLightsIterator(it);

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTerrainVisual.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTerrainVisual.cpp
@@ -604,19 +604,29 @@ Bool W3DTerrainVisual::load( AsciiString filename )
 
 	RefRenderObjListIterator *it = W3DDisplay::m_3DScene ? W3DDisplay::m_3DScene->createLightsIterator() : nullptr;
 	// apply the heightmap to the terrain render object
-
 #ifdef DO_SEISMIC_SIMULATIONS
-	m_terrainRenderObject->initHeightData( m_clientHeightMap->getDrawWidth(),
-																				 m_clientHeightMap->getDrawHeight(),
-																				 m_clientHeightMap,
-																				 it);
+	WorldHeightMap* heightMap = m_clientHeightMap;
 #else
-	m_terrainRenderObject->initHeightData( m_logicHeightMap->getDrawWidth(),
-																				 m_logicHeightMap->getDrawHeight(),
-																				 m_logicHeightMap,
-																				 it);
+	WorldHeightMap* heightMap = m_logicHeightMap;
 #endif
 
+	const Bool isRenderAllTerrain = TheGlobalData->m_renderAllTerrain;
+
+	Int xExt, yExt;
+
+	if (isRenderAllTerrain) {
+		xExt = heightMap->getXExtent();
+		yExt = heightMap->getYExtent();
+
+		// TheSuperHackers @feature explicitly draw boundaries to match full extent
+		heightMap->setDrawWidth(xExt);
+		heightMap->setDrawHeight(yExt);
+	} else {
+		xExt = heightMap->getDrawWidth();
+		yExt = heightMap->getDrawHeight();
+	}
+
+	m_terrainRenderObject->initHeightData(xExt, yExt, heightMap, it);
 
 	if (it) {
 	 W3DDisplay::m_3DScene->destroyLightsIterator(it);

--- a/Generals/Code/GameEngine/Include/Common/GlobalData.h
+++ b/Generals/Code/GameEngine/Include/Common/GlobalData.h
@@ -119,7 +119,7 @@ public:
 	// TheSuperHackers @feature helmutbuhler 11/04/2025
 	// Run game without graphics, input or audio.
 	Bool m_headless;
-
+	Bool m_renderAllTerrain;
 	Bool m_windowed;
 	Int m_xResolution;
 	Int m_yResolution;

--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -427,7 +427,7 @@ GlobalData* GlobalData::m_theOriginal = nullptr;
 	{ "ShellMapName",								INI::parseAsciiString,nullptr,			offsetof( GlobalData, m_shellMapName ) },
 	{ "ShellMapOn",									INI::parseBool,				nullptr,			offsetof( GlobalData, m_shellMapOn ) },
 	{	"PlayIntro",									INI::parseBool,				nullptr,			offsetof( GlobalData, m_playIntro ) },
-
+	{ "RenderAllTerrain",					INI::parseBool,				nullptr,			offsetof( GlobalData, m_renderAllTerrain ) },
 	{ "FirewallBehavior",						INI::parseInt,				nullptr,			offsetof( GlobalData, m_firewallBehavior ) },
 	{ "FirewallPortOverride",				INI::parseInt,				nullptr,			offsetof( GlobalData, m_firewallPortOverride ) },
 	{	"FirewallPortAllocationDelta",INI::parseInt,				nullptr,			offsetof( GlobalData, m_firewallPortAllocationDelta) },
@@ -627,6 +627,7 @@ GlobalData::GlobalData()
 	m_framesPerSecondLimit = 0;
 	m_chipSetType = 0;
 	m_headless = FALSE;
+	m_renderAllTerrain = FALSE;
 	m_windowed = 0;
 	m_xResolution = DEFAULT_DISPLAY_WIDTH;
 	m_yResolution = DEFAULT_DISPLAY_HEIGHT;

--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -1226,6 +1226,7 @@ void GlobalData::parseGameDataDefinition( INI* ini )
 
 	TheWritableGlobalData->m_xResolution = xres;
 	TheWritableGlobalData->m_yResolution = yres;
+	TheWritableGlobalData->m_renderAllTerrain = optionPref.getBool("RenderAllTerrain", TheWritableGlobalData->m_renderAllTerrain);
 }
 
 void GlobalData::parseCustomDefinition()

--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -91,7 +91,7 @@ GlobalData* GlobalData::m_theOriginal = nullptr;
 	{ "UseHalfHeightMap",					INI::parseBool,				nullptr,			offsetof( GlobalData, m_useHalfHeightMap ) },
 	{ "UserDataLeafName",					INI::parseQuotedAsciiString,	nullptr,			offsetof( GlobalData, m_userDataLeafName ) },
 
-
+	{ "RenderAllTerrain",					INI::parseBool,				nullptr,			offsetof( GlobalData, m_renderAllTerrain ) },
 	{ "DrawEntireTerrain",					INI::parseBool,				nullptr,			offsetof( GlobalData, m_drawEntireTerrain ) },
 	{ "TerrainLOD",									INI::parseIndexList,	TerrainLODNames,	offsetof( GlobalData, m_terrainLOD ) },
 	{ "TerrainLODTargetTimeMS",			INI::parseInt,				nullptr,			offsetof( GlobalData, m_terrainLODTargetTimeMS ) },
@@ -427,7 +427,6 @@ GlobalData* GlobalData::m_theOriginal = nullptr;
 	{ "ShellMapName",								INI::parseAsciiString,nullptr,			offsetof( GlobalData, m_shellMapName ) },
 	{ "ShellMapOn",									INI::parseBool,				nullptr,			offsetof( GlobalData, m_shellMapOn ) },
 	{	"PlayIntro",									INI::parseBool,				nullptr,			offsetof( GlobalData, m_playIntro ) },
-	{ "RenderAllTerrain",					INI::parseBool,				nullptr,			offsetof( GlobalData, m_renderAllTerrain ) },
 	{ "FirewallBehavior",						INI::parseInt,				nullptr,			offsetof( GlobalData, m_firewallBehavior ) },
 	{ "FirewallPortOverride",				INI::parseInt,				nullptr,			offsetof( GlobalData, m_firewallPortOverride ) },
 	{	"FirewallPortAllocationDelta",INI::parseInt,				nullptr,			offsetof( GlobalData, m_firewallPortAllocationDelta) },

--- a/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
@@ -120,7 +120,7 @@ public:
 	// TheSuperHackers @feature helmutbuhler 11/04/2025
 	// Run game without graphics, input or audio.
 	Bool m_headless;
-
+	Bool m_renderAllTerrain;
 	Bool m_windowed;
 	Int m_xResolution;
 	Int m_yResolution;

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -427,7 +427,7 @@ GlobalData* GlobalData::m_theOriginal = nullptr;
 	{ "ShellMapName",								INI::parseAsciiString,nullptr,			offsetof( GlobalData, m_shellMapName ) },
 	{ "ShellMapOn",									INI::parseBool,				nullptr,			offsetof( GlobalData, m_shellMapOn ) },
 	{	"PlayIntro",									INI::parseBool,				nullptr,			offsetof( GlobalData, m_playIntro ) },
-
+	{ "RenderAllTerrain",					INI::parseBool,				nullptr,			offsetof( GlobalData, m_renderAllTerrain ) },
 	{ "FirewallBehavior",						INI::parseInt,				nullptr,			offsetof( GlobalData, m_firewallBehavior ) },
 	{ "FirewallPortOverride",				INI::parseInt,				nullptr,			offsetof( GlobalData, m_firewallPortOverride ) },
 	{	"FirewallPortAllocationDelta",INI::parseInt,				nullptr,			offsetof( GlobalData, m_firewallPortAllocationDelta) },
@@ -631,6 +631,7 @@ GlobalData::GlobalData()
 	m_framesPerSecondLimit = 0;
 	m_chipSetType = 0;
 	m_headless = FALSE;
+	m_renderAllTerrain = FALSE;
 	m_windowed = 0;
 	m_xResolution = DEFAULT_DISPLAY_WIDTH;
 	m_yResolution = DEFAULT_DISPLAY_HEIGHT;

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -1246,6 +1246,7 @@ void GlobalData::parseGameDataDefinition( INI* ini )
 
 	TheWritableGlobalData->m_xResolution = xres;
 	TheWritableGlobalData->m_yResolution = yres;
+	TheWritableGlobalData->m_renderAllTerrain = optionPref.getBool("RenderAllTerrain", TheWritableGlobalData->m_renderAllTerrain);
 }
 
 void GlobalData::parseCustomDefinition()

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -91,7 +91,7 @@ GlobalData* GlobalData::m_theOriginal = nullptr;
 	{ "StretchTerrain",						INI::parseBool,				nullptr,			offsetof( GlobalData, m_stretchTerrain ) },
 	{ "UseHalfHeightMap",					INI::parseBool,				nullptr,			offsetof( GlobalData, m_useHalfHeightMap ) },
 
-
+	{ "RenderAllTerrain",					INI::parseBool,				nullptr,			offsetof( GlobalData, m_renderAllTerrain ) },
 	{ "DrawEntireTerrain",					INI::parseBool,				nullptr,			offsetof( GlobalData, m_drawEntireTerrain ) },
 	{ "TerrainLOD",									INI::parseIndexList,	TerrainLODNames,	offsetof( GlobalData, m_terrainLOD ) },
 	{ "TerrainLODTargetTimeMS",			INI::parseInt,				nullptr,			offsetof( GlobalData, m_terrainLODTargetTimeMS ) },
@@ -427,7 +427,6 @@ GlobalData* GlobalData::m_theOriginal = nullptr;
 	{ "ShellMapName",								INI::parseAsciiString,nullptr,			offsetof( GlobalData, m_shellMapName ) },
 	{ "ShellMapOn",									INI::parseBool,				nullptr,			offsetof( GlobalData, m_shellMapOn ) },
 	{	"PlayIntro",									INI::parseBool,				nullptr,			offsetof( GlobalData, m_playIntro ) },
-	{ "RenderAllTerrain",					INI::parseBool,				nullptr,			offsetof( GlobalData, m_renderAllTerrain ) },
 	{ "FirewallBehavior",						INI::parseInt,				nullptr,			offsetof( GlobalData, m_firewallBehavior ) },
 	{ "FirewallPortOverride",				INI::parseInt,				nullptr,			offsetof( GlobalData, m_firewallPortOverride ) },
 	{	"FirewallPortAllocationDelta",INI::parseInt,				nullptr,			offsetof( GlobalData, m_firewallPortAllocationDelta) },


### PR DESCRIPTION
They thought they could hide in the fog of the old world, General. They were wrong. By initializing the RenderAllTerrain protocols, we have stripped away the limits of our vision.

The earth no longer crumbles at the horizon. To hold the world together, we have diverted at least one hundred megabytes of video memory to the display on our large battlefields. Your GPU will feel the weight of this vast landscape, drawing extra power to render the full scale of our battlefield.

But look! The Americans are exposed. From this height, their bases are a joke and their walls are like sand. Command from the heavens, General, and let our wrath fall upon them. Let nothing remain hidden!


**Description**: This PR fixes visual clipping issues when running the game with the _RenderAllTerrain = Yes_. Previously, the terrain rendering system would cull geometry based on the standard camera view frustum logic, which caused terrain segments to disappear when zooming out beyond standard limits.

Modified W3DTerrainVisual::load in Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTerrainVisual.cpp

Extent Overrides: When RenderAllTerrain is active, the heightmap's DrawWidth and DrawHeight are forced to match the full map extents (getXExtent/getYExtent). This bypasses the standard culling system's calculated values to ensure the entire map remains visible.

Before:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/21ddd297-7c0f-42aa-b62c-29ddb35a0d07" />

After:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/4f1e8b91-5820-4fe8-ae97-d160f06f4c5d" />
