### PR TITLE
fix: Replace sprintf with snprintf to prevent potential stack overflows

### DIFF
--- a/Core/GameEngine/Source/Common/INI/INI.cpp
+++ b/Core/GameEngine/Source/Common/INI/INI.cpp
@@ -425,7 +425,8 @@ UnsignedInt INI::load( AsciiString filename, INILoadType loadType, Xfer *pXfer )
 					} catch (...) {
 						DEBUG_CRASH(("Error parsing block '%s' in INI file '%s'", token, m_filename.str()) );
 						char buff[1024];
-						sprintf(buff, "Error parsing INI file '%s' (Line: '%s')\n", m_filename.str(), currentLine.str());
+						snprintf(buff, sizeof(buff), "Error parsing INI file '%s' (Line: '%s')\n",
+							m_filename.str(), currentLine.str());
 
 						throw INIException(buff);
 					}
@@ -1564,7 +1565,8 @@ void INI::initFromINIMulti( void *what, const MultiIniFieldParse& parseTableList
 
 
 							char buff[1024];
-							sprintf(buff, "[LINE: %d - FILE: '%s'] Error reading field '%s'\n", INI::getLineNum(), INI::getFilename().str(), field);
+							snprintf(buff, sizeof(buff), "[LINE: %d - FILE: '%s'] Error reading field '%s'\n",
+								INI::getLineNum(), INI::getFilename().str(), field);
 							throw INIException(buff);
 						}
 

--- a/Core/GameEngine/Source/Common/INI/INI.cpp
+++ b/Core/GameEngine/Source/Common/INI/INI.cpp
@@ -425,7 +425,7 @@ UnsignedInt INI::load( AsciiString filename, INILoadType loadType, Xfer *pXfer )
 					} catch (...) {
 						DEBUG_CRASH(("Error parsing block '%s' in INI file '%s'", token, m_filename.str()) );
 						char buff[1024];
-						snprintf(buff, sizeof(buff), "Error parsing INI file '%s' (Line: '%s')\n",
+						snprintf(buff, ARRAY_SIZE(buff), "Error parsing INI file '%s' (Line: '%s')\n",
 							m_filename.str(), currentLine.str());
 
 						throw INIException(buff);
@@ -1565,7 +1565,7 @@ void INI::initFromINIMulti( void *what, const MultiIniFieldParse& parseTableList
 
 
 							char buff[1024];
-							snprintf(buff, sizeof(buff), "[LINE: %d - FILE: '%s'] Error reading field '%s'\n",
+							snprintf(buff, ARRAY_SIZE(buff), "[LINE: %d - FILE: '%s'] Error reading field '%s'\n",
 								INI::getLineNum(), INI::getFilename().str(), field);
 							throw INIException(buff);
 						}

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/StagingRoomGameInfo.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/StagingRoomGameInfo.cpp
@@ -861,7 +861,7 @@ void GameSpyStagingRoom::launchGame( void )
 	req.buddyRequestType = BuddyRequest::BUDDYREQUEST_SETSTATUS;
 	req.arg.status.status = GP_PLAYING;
 	strcpy(req.arg.status.statusString, "Loading");
-	snprintf(req.arg.status.locationString, sizeof(req.arg.status.locationString), "%s",
+	snprintf(req.arg.status.locationString, ARRAY_SIZE(req.arg.status.locationString), "%s",
 		WideCharStringToMultiByte(getGameName().str()).c_str());
 	TheGameSpyBuddyMessageQueue->addRequest(req);
 

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/StagingRoomGameInfo.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/StagingRoomGameInfo.cpp
@@ -861,7 +861,8 @@ void GameSpyStagingRoom::launchGame( void )
 	req.buddyRequestType = BuddyRequest::BUDDYREQUEST_SETSTATUS;
 	req.arg.status.status = GP_PLAYING;
 	strcpy(req.arg.status.statusString, "Loading");
-	sprintf(req.arg.status.locationString, "%s", WideCharStringToMultiByte(getGameName().str()).c_str());
+	snprintf(req.arg.status.locationString, sizeof(req.arg.status.locationString), "%s",
+		WideCharStringToMultiByte(getGameName().str()).c_str());
 	TheGameSpyBuddyMessageQueue->addRequest(req);
 
 	delete TheNAT;

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/StagingRoomGameInfo.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/StagingRoomGameInfo.cpp
@@ -861,8 +861,8 @@ void GameSpyStagingRoom::launchGame( void )
 	req.buddyRequestType = BuddyRequest::BUDDYREQUEST_SETSTATUS;
 	req.arg.status.status = GP_PLAYING;
 	strcpy(req.arg.status.statusString, "Loading");
-	snprintf(req.arg.status.locationString, ARRAY_SIZE(req.arg.status.locationString), "%s",
-		WideCharStringToMultiByte(getGameName().str()).c_str());
+	strlcpy(req.arg.status.locationString, WideCharStringToMultiByte(getGameName().str()).c_str(),
+		ARRAY_SIZE(req.arg.status.locationString));
 	TheGameSpyBuddyMessageQueue->addRequest(req);
 
 	delete TheNAT;

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
@@ -675,17 +675,17 @@ static void updateBuddyStatus( GameSpyBuddyStatus status, Int groupRoom = 0, std
 		case BUDDY_STAGING:
 			req.arg.status.status = GP_STAGING;
 			strcpy(req.arg.status.statusString, "Staging");
-			snprintf(req.arg.status.locationString, ARRAY_SIZE(req.arg.status.locationString), "%s", gameName.c_str());
+			strlcpy(req.arg.status.locationString, gameName.c_str(), ARRAY_SIZE(req.arg.status.locationString));
 			break;
 		case BUDDY_LOADING:
 			req.arg.status.status = GP_PLAYING;
 			strcpy(req.arg.status.statusString, "Loading");
-			snprintf(req.arg.status.locationString, ARRAY_SIZE(req.arg.status.locationString), "%s", gameName.c_str());
+			strlcpy(req.arg.status.locationString, gameName.c_str(), ARRAY_SIZE(req.arg.status.locationString));
 			break;
 		case BUDDY_PLAYING:
 			req.arg.status.status = GP_PLAYING;
 			strcpy(req.arg.status.statusString, "Playing");
-			snprintf(req.arg.status.locationString, ARRAY_SIZE(req.arg.status.locationString), "%s", gameName.c_str());
+			strlcpy(req.arg.status.locationString, gameName.c_str(), ARRAY_SIZE(req.arg.status.locationString));
 			break;
 		case BUDDY_MATCHING:
 			req.arg.status.status = GP_ONLINE;

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
@@ -670,22 +670,22 @@ static void updateBuddyStatus( GameSpyBuddyStatus status, Int groupRoom = 0, std
 		case BUDDY_LOBBY:
 			req.arg.status.status = GP_CHATTING;
 			strcpy(req.arg.status.statusString, "Chatting");
-			snprintf(req.arg.status.locationString, sizeof(req.arg.status.locationString), "%d", groupRoom);
+			snprintf(req.arg.status.locationString, ARRAY_SIZE(req.arg.status.locationString), "%d", groupRoom);
 			break;
 		case BUDDY_STAGING:
 			req.arg.status.status = GP_STAGING;
 			strcpy(req.arg.status.statusString, "Staging");
-			snprintf(req.arg.status.locationString, sizeof(req.arg.status.locationString), "%s", gameName.c_str());
+			snprintf(req.arg.status.locationString, ARRAY_SIZE(req.arg.status.locationString), "%s", gameName.c_str());
 			break;
 		case BUDDY_LOADING:
 			req.arg.status.status = GP_PLAYING;
 			strcpy(req.arg.status.statusString, "Loading");
-			snprintf(req.arg.status.locationString, sizeof(req.arg.status.locationString), "%s", gameName.c_str());
+			snprintf(req.arg.status.locationString, ARRAY_SIZE(req.arg.status.locationString), "%s", gameName.c_str());
 			break;
 		case BUDDY_PLAYING:
 			req.arg.status.status = GP_PLAYING;
 			strcpy(req.arg.status.statusString, "Playing");
-			snprintf(req.arg.status.locationString, sizeof(req.arg.status.locationString), "%s", gameName.c_str());
+			snprintf(req.arg.status.locationString, ARRAY_SIZE(req.arg.status.locationString), "%s", gameName.c_str());
 			break;
 		case BUDDY_MATCHING:
 			req.arg.status.status = GP_ONLINE;

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
@@ -670,22 +670,22 @@ static void updateBuddyStatus( GameSpyBuddyStatus status, Int groupRoom = 0, std
 		case BUDDY_LOBBY:
 			req.arg.status.status = GP_CHATTING;
 			strcpy(req.arg.status.statusString, "Chatting");
-			sprintf(req.arg.status.locationString, "%d", groupRoom);
+			snprintf(req.arg.status.locationString, sizeof(req.arg.status.locationString), "%d", groupRoom);
 			break;
 		case BUDDY_STAGING:
 			req.arg.status.status = GP_STAGING;
 			strcpy(req.arg.status.statusString, "Staging");
-			sprintf(req.arg.status.locationString, "%s", gameName.c_str());
+			snprintf(req.arg.status.locationString, sizeof(req.arg.status.locationString), "%s", gameName.c_str());
 			break;
 		case BUDDY_LOADING:
 			req.arg.status.status = GP_PLAYING;
 			strcpy(req.arg.status.statusString, "Loading");
-			sprintf(req.arg.status.locationString, "%s", gameName.c_str());
+			snprintf(req.arg.status.locationString, sizeof(req.arg.status.locationString), "%s", gameName.c_str());
 			break;
 		case BUDDY_PLAYING:
 			req.arg.status.status = GP_PLAYING;
 			strcpy(req.arg.status.statusString, "Playing");
-			sprintf(req.arg.status.locationString, "%s", gameName.c_str());
+			snprintf(req.arg.status.locationString, sizeof(req.arg.status.locationString), "%s", gameName.c_str());
 			break;
 		case BUDDY_MATCHING:
 			req.arg.status.status = GP_ONLINE;

--- a/Core/GameEngineDevice/Source/VideoDevice/Bink/BinkVideoPlayer.cpp
+++ b/Core/GameEngineDevice/Source/VideoDevice/Bink/BinkVideoPlayer.cpp
@@ -229,7 +229,7 @@ VideoStreamInterface*	BinkVideoPlayer::open( AsciiString movieTitle )
 		if (TheGlobalData->m_modDir.isNotEmpty())
 		{
 			char filePath[ _MAX_PATH ];
-			sprintf( filePath, "%s%s\\%s.%s", TheGlobalData->m_modDir.str(), VIDEO_PATH, pVideo->m_filename.str(), VIDEO_EXT );
+			snprintf( filePath, sizeof(filePath), "%s%s\\%s.%s", TheGlobalData->m_modDir.str(), VIDEO_PATH, pVideo->m_filename.str(), VIDEO_EXT );
 			HBINK handle = BinkOpen(filePath , BINKPRELOADALL );
 			DEBUG_ASSERTLOG(!handle, ("opened bink file %s", filePath));
 			if (handle)
@@ -239,13 +239,13 @@ VideoStreamInterface*	BinkVideoPlayer::open( AsciiString movieTitle )
 		}
 
 		char localizedFilePath[ _MAX_PATH ];
-		sprintf( localizedFilePath, VIDEO_LANG_PATH_FORMAT, GetRegistryLanguage().str(), pVideo->m_filename.str(), VIDEO_EXT );
+		snprintf( localizedFilePath, sizeof(localizedFilePath), VIDEO_LANG_PATH_FORMAT, GetRegistryLanguage().str(), pVideo->m_filename.str(), VIDEO_EXT );
 		HBINK handle = BinkOpen(localizedFilePath , BINKPRELOADALL );
 		DEBUG_ASSERTLOG(!handle, ("opened localized bink file %s", localizedFilePath));
 		if (!handle)
 		{
 			char filePath[ _MAX_PATH ];
-			sprintf( filePath, "%s\\%s.%s", VIDEO_PATH, pVideo->m_filename.str(), VIDEO_EXT );
+			snprintf( filePath, sizeof(filePath), "%s\\%s.%s", VIDEO_PATH, pVideo->m_filename.str(), VIDEO_EXT );
 			handle = BinkOpen(filePath , BINKPRELOADALL );
 			DEBUG_ASSERTLOG(!handle, ("opened bink file %s", localizedFilePath));
 		}

--- a/Core/GameEngineDevice/Source/VideoDevice/Bink/BinkVideoPlayer.cpp
+++ b/Core/GameEngineDevice/Source/VideoDevice/Bink/BinkVideoPlayer.cpp
@@ -229,7 +229,7 @@ VideoStreamInterface*	BinkVideoPlayer::open( AsciiString movieTitle )
 		if (TheGlobalData->m_modDir.isNotEmpty())
 		{
 			char filePath[ _MAX_PATH ];
-			snprintf( filePath, sizeof(filePath), "%s%s\\%s.%s", TheGlobalData->m_modDir.str(), VIDEO_PATH, pVideo->m_filename.str(), VIDEO_EXT );
+			snprintf( filePath, ARRAY_SIZE(filePath), "%s%s\\%s.%s", TheGlobalData->m_modDir.str(), VIDEO_PATH, pVideo->m_filename.str(), VIDEO_EXT );
 			HBINK handle = BinkOpen(filePath , BINKPRELOADALL );
 			DEBUG_ASSERTLOG(!handle, ("opened bink file %s", filePath));
 			if (handle)
@@ -239,13 +239,13 @@ VideoStreamInterface*	BinkVideoPlayer::open( AsciiString movieTitle )
 		}
 
 		char localizedFilePath[ _MAX_PATH ];
-		snprintf( localizedFilePath, sizeof(localizedFilePath), VIDEO_LANG_PATH_FORMAT, GetRegistryLanguage().str(), pVideo->m_filename.str(), VIDEO_EXT );
+		snprintf( localizedFilePath, ARRAY_SIZE(localizedFilePath), VIDEO_LANG_PATH_FORMAT, GetRegistryLanguage().str(), pVideo->m_filename.str(), VIDEO_EXT );
 		HBINK handle = BinkOpen(localizedFilePath , BINKPRELOADALL );
 		DEBUG_ASSERTLOG(!handle, ("opened localized bink file %s", localizedFilePath));
 		if (!handle)
 		{
 			char filePath[ _MAX_PATH ];
-			snprintf( filePath, sizeof(filePath), "%s\\%s.%s", VIDEO_PATH, pVideo->m_filename.str(), VIDEO_EXT );
+			snprintf( filePath, ARRAY_SIZE(filePath), "%s\\%s.%s", VIDEO_PATH, pVideo->m_filename.str(), VIDEO_EXT );
 			handle = BinkOpen(filePath , BINKPRELOADALL );
 			DEBUG_ASSERTLOG(!handle, ("opened bink file %s", localizedFilePath));
 		}

--- a/Core/GameEngineDevice/Source/VideoDevice/FFmpeg/FFmpegVideoPlayer.cpp
+++ b/Core/GameEngineDevice/Source/VideoDevice/FFmpeg/FFmpegVideoPlayer.cpp
@@ -235,7 +235,7 @@ VideoStreamInterface*	FFmpegVideoPlayer::open( AsciiString movieTitle )
 		if (TheGlobalData->m_modDir.isNotEmpty())
 		{
 			char filePath[ _MAX_PATH ];
-			snprintf( filePath, sizeof(filePath), "%s%s\\%s.%s", TheGlobalData->m_modDir.str(), VIDEO_PATH, pVideo->m_filename.str(), VIDEO_EXT );
+			snprintf( filePath, ARRAY_SIZE(filePath), "%s%s\\%s.%s", TheGlobalData->m_modDir.str(), VIDEO_PATH, pVideo->m_filename.str(), VIDEO_EXT );
 			File* file =  TheFileSystem->openFile(filePath);
 			DEBUG_ASSERTLOG(!file, ("opened bink file %s", filePath));
 			if (file)
@@ -245,13 +245,13 @@ VideoStreamInterface*	FFmpegVideoPlayer::open( AsciiString movieTitle )
 		}
 
 		char localizedFilePath[ _MAX_PATH ];
-		snprintf( localizedFilePath, sizeof(localizedFilePath), VIDEO_LANG_PATH_FORMAT, GetRegistryLanguage().str(), pVideo->m_filename.str(), VIDEO_EXT );
+		snprintf( localizedFilePath, ARRAY_SIZE(localizedFilePath), VIDEO_LANG_PATH_FORMAT, GetRegistryLanguage().str(), pVideo->m_filename.str(), VIDEO_EXT );
 		File* file =  TheFileSystem->openFile(localizedFilePath);
 		DEBUG_ASSERTLOG(!file, ("opened localized bink file %s", localizedFilePath));
 		if (!file)
 		{
 			char filePath[ _MAX_PATH ];
-			snprintf( filePath, sizeof(filePath), "%s\\%s.%s", VIDEO_PATH, pVideo->m_filename.str(), VIDEO_EXT );
+			snprintf( filePath, ARRAY_SIZE(filePath), "%s\\%s.%s", VIDEO_PATH, pVideo->m_filename.str(), VIDEO_EXT );
 			file = TheFileSystem->openFile(filePath);
 			DEBUG_ASSERTLOG(!file, ("opened bink file %s", filePath));
 		}

--- a/Core/GameEngineDevice/Source/VideoDevice/FFmpeg/FFmpegVideoPlayer.cpp
+++ b/Core/GameEngineDevice/Source/VideoDevice/FFmpeg/FFmpegVideoPlayer.cpp
@@ -235,7 +235,7 @@ VideoStreamInterface*	FFmpegVideoPlayer::open( AsciiString movieTitle )
 		if (TheGlobalData->m_modDir.isNotEmpty())
 		{
 			char filePath[ _MAX_PATH ];
-			sprintf( filePath, "%s%s\\%s.%s", TheGlobalData->m_modDir.str(), VIDEO_PATH, pVideo->m_filename.str(), VIDEO_EXT );
+			snprintf( filePath, sizeof(filePath), "%s%s\\%s.%s", TheGlobalData->m_modDir.str(), VIDEO_PATH, pVideo->m_filename.str(), VIDEO_EXT );
 			File* file =  TheFileSystem->openFile(filePath);
 			DEBUG_ASSERTLOG(!file, ("opened bink file %s", filePath));
 			if (file)
@@ -245,13 +245,13 @@ VideoStreamInterface*	FFmpegVideoPlayer::open( AsciiString movieTitle )
 		}
 
 		char localizedFilePath[ _MAX_PATH ];
-		sprintf( localizedFilePath, VIDEO_LANG_PATH_FORMAT, GetRegistryLanguage().str(), pVideo->m_filename.str(), VIDEO_EXT );
+		snprintf( localizedFilePath, sizeof(localizedFilePath), VIDEO_LANG_PATH_FORMAT, GetRegistryLanguage().str(), pVideo->m_filename.str(), VIDEO_EXT );
 		File* file =  TheFileSystem->openFile(localizedFilePath);
 		DEBUG_ASSERTLOG(!file, ("opened localized bink file %s", localizedFilePath));
 		if (!file)
 		{
 			char filePath[ _MAX_PATH ];
-			sprintf( filePath, "%s\\%s.%s", VIDEO_PATH, pVideo->m_filename.str(), VIDEO_EXT );
+			snprintf( filePath, sizeof(filePath), "%s\\%s.%s", VIDEO_PATH, pVideo->m_filename.str(), VIDEO_EXT );
 			file = TheFileSystem->openFile(filePath);
 			DEBUG_ASSERTLOG(!file, ("opened bink file %s", filePath));
 		}

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
@@ -763,12 +763,12 @@ void ModelConditionInfo::validateWeaponBarrelInfo() const
 
 				if (!recoilBoneName.isEmpty())
 				{
-					snprintf(buffer, sizeof(buffer), "%s%02d", recoilBoneName.str(), i);
+					snprintf(buffer, ARRAY_SIZE(buffer), "%s%02d", recoilBoneName.str(), i);
 					findPristineBone(NAMEKEY(buffer), &info.m_recoilBone);
 				}
 				if (!mfName.isEmpty())
 				{
-					snprintf(buffer, sizeof(buffer), "%s%02d", mfName.str(), i);
+					snprintf(buffer, ARRAY_SIZE(buffer), "%s%02d", mfName.str(), i);
 					findPristineBone(NAMEKEY(buffer), &info.m_muzzleFlashBone);
 #if defined(RTS_DEBUG) || defined(DEBUG_CRASHING)
 					if (info.m_muzzleFlashBone)
@@ -777,7 +777,7 @@ void ModelConditionInfo::validateWeaponBarrelInfo() const
 				}
 				if (!fxBoneName.isEmpty())
 				{
-					snprintf(buffer, sizeof(buffer), "%s%02d", fxBoneName.str(), i);
+					snprintf(buffer, ARRAY_SIZE(buffer), "%s%02d", fxBoneName.str(), i);
 					findPristineBone(NAMEKEY(buffer), &info.m_fxBone);
 					// special case: if we have multiple muzzleflashes, but only one fxbone, use that fxbone for everything.
 					if (info.m_fxBone == 0 && info.m_muzzleFlashBone != 0)
@@ -787,7 +787,7 @@ void ModelConditionInfo::validateWeaponBarrelInfo() const
 				Int plbBoneIndex = 0;
 				if (!plbName.isEmpty())
 				{
-					snprintf(buffer, sizeof(buffer), "%s%02d", plbName.str(), i);
+					snprintf(buffer, ARRAY_SIZE(buffer), "%s%02d", plbName.str(), i);
 					const Matrix3D* mtx = findPristineBone(NAMEKEY(buffer), &plbBoneIndex);
 					if (mtx != nullptr)
 						info.m_projectileOffsetMtx = *mtx;
@@ -3446,7 +3446,7 @@ Int W3DModelDraw::getPristineBonePositionsForConditionState(
 		if (i == 0)
 			strlcpy(buffer, boneNamePrefix, ARRAY_SIZE(buffer));
 		else
-			snprintf(buffer, sizeof(buffer), "%s%02d", boneNamePrefix, i);
+			snprintf(buffer, ARRAY_SIZE(buffer), "%s%02d", boneNamePrefix, i);
 
 		for (char *c = buffer; c && *c; ++c)
 		{
@@ -3603,7 +3603,7 @@ Int W3DModelDraw::getCurrentBonePositions(
 		if (i == 0)
 			strlcpy(buffer, boneNamePrefix, ARRAY_SIZE(buffer));
 		else
-			snprintf(buffer, sizeof(buffer), "%s%02d", boneNamePrefix, i);
+			snprintf(buffer, ARRAY_SIZE(buffer), "%s%02d", boneNamePrefix, i);
 
 		Int boneIndex = m_renderObject->Get_Bone_Index(buffer);
 		if (boneIndex == 0)

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
@@ -763,12 +763,12 @@ void ModelConditionInfo::validateWeaponBarrelInfo() const
 
 				if (!recoilBoneName.isEmpty())
 				{
-					sprintf(buffer, "%s%02d", recoilBoneName.str(), i);
+					snprintf(buffer, sizeof(buffer), "%s%02d", recoilBoneName.str(), i);
 					findPristineBone(NAMEKEY(buffer), &info.m_recoilBone);
 				}
 				if (!mfName.isEmpty())
 				{
-					sprintf(buffer, "%s%02d", mfName.str(), i);
+					snprintf(buffer, sizeof(buffer), "%s%02d", mfName.str(), i);
 					findPristineBone(NAMEKEY(buffer), &info.m_muzzleFlashBone);
 #if defined(RTS_DEBUG) || defined(DEBUG_CRASHING)
 					if (info.m_muzzleFlashBone)
@@ -777,7 +777,7 @@ void ModelConditionInfo::validateWeaponBarrelInfo() const
 				}
 				if (!fxBoneName.isEmpty())
 				{
-					sprintf(buffer, "%s%02d", fxBoneName.str(), i);
+					snprintf(buffer, sizeof(buffer), "%s%02d", fxBoneName.str(), i);
 					findPristineBone(NAMEKEY(buffer), &info.m_fxBone);
 					// special case: if we have multiple muzzleflashes, but only one fxbone, use that fxbone for everything.
 					if (info.m_fxBone == 0 && info.m_muzzleFlashBone != 0)
@@ -787,7 +787,7 @@ void ModelConditionInfo::validateWeaponBarrelInfo() const
 				Int plbBoneIndex = 0;
 				if (!plbName.isEmpty())
 				{
-					sprintf(buffer, "%s%02d", plbName.str(), i);
+					snprintf(buffer, sizeof(buffer), "%s%02d", plbName.str(), i);
 					const Matrix3D* mtx = findPristineBone(NAMEKEY(buffer), &plbBoneIndex);
 					if (mtx != nullptr)
 						info.m_projectileOffsetMtx = *mtx;
@@ -3446,7 +3446,7 @@ Int W3DModelDraw::getPristineBonePositionsForConditionState(
 		if (i == 0)
 			strlcpy(buffer, boneNamePrefix, ARRAY_SIZE(buffer));
 		else
-			sprintf(buffer, "%s%02d", boneNamePrefix, i);
+			snprintf(buffer, sizeof(buffer), "%s%02d", boneNamePrefix, i);
 
 		for (char *c = buffer; c && *c; ++c)
 		{
@@ -3603,7 +3603,7 @@ Int W3DModelDraw::getCurrentBonePositions(
 		if (i == 0)
 			strlcpy(buffer, boneNamePrefix, ARRAY_SIZE(buffer));
 		else
-			sprintf(buffer, "%s%02d", boneNamePrefix, i);
+			snprintf(buffer, sizeof(buffer), "%s%02d", boneNamePrefix, i);
 
 		Int boneIndex = m_renderObject->Get_Bone_Index(buffer);
 		if (boneIndex == 0)

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DSupplyDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DSupplyDraw.cpp
@@ -96,7 +96,7 @@ void W3DSupplyDraw::updateDrawModuleSupplyStatus( Int maxSupply, Int currentSupp
 		while( currentIndex <= highIndex )
 		{
 			char buffer[16];
-			sprintf( buffer, "%s%02d", boneName.str(), currentIndex );
+			snprintf( buffer, sizeof(buffer), "%s%02d", boneName.str(), currentIndex );
 			ModelConditionInfo::HideShowSubObjInfo info;
 			info.hide = hide;
 			info.subObjName = buffer;

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DSupplyDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DSupplyDraw.cpp
@@ -96,7 +96,7 @@ void W3DSupplyDraw::updateDrawModuleSupplyStatus( Int maxSupply, Int currentSupp
 		while( currentIndex <= highIndex )
 		{
 			char buffer[16];
-			snprintf( buffer, sizeof(buffer), "%s%02d", boneName.str(), currentIndex );
+			snprintf( buffer, ARRAY_SIZE(buffer), "%s%02d", boneName.str(), currentIndex );
 			ModelConditionInfo::HideShowSubObjInfo info;
 			info.hide = hide;
 			info.subObjName = buffer;

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTreeBuffer.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTreeBuffer.cpp
@@ -458,10 +458,10 @@ void W3DTreeBuffer::updateTexture(void)
 	for (i=0; i<m_numTreeTypes; i++) {
 		char texturePath[ _MAX_PATH ];
 		m_treeTypes[i].m_numTiles = 0;
-		sprintf( texturePath, "%s%s", TERRAIN_TGA_DIR_PATH, m_treeTypes[i].m_data->m_textureName.str() );
+		snprintf( texturePath, sizeof(texturePath), "%s%s", TERRAIN_TGA_DIR_PATH, m_treeTypes[i].m_data->m_textureName.str() );
 		theFile = TheFileSystem->openFile( texturePath, File::READ|File::BINARY);
 		if (theFile==nullptr) {
-			sprintf( texturePath, "%s%s", TGA_DIR_PATH, m_treeTypes[i].m_data->m_textureName.str() );
+			snprintf( texturePath, sizeof(texturePath), "%s%s", TGA_DIR_PATH, m_treeTypes[i].m_data->m_textureName.str() );
 			theFile = TheFileSystem->openFile( texturePath, File::READ|File::BINARY);
 		}
 		if (theFile != nullptr) {

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTreeBuffer.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTreeBuffer.cpp
@@ -458,10 +458,10 @@ void W3DTreeBuffer::updateTexture(void)
 	for (i=0; i<m_numTreeTypes; i++) {
 		char texturePath[ _MAX_PATH ];
 		m_treeTypes[i].m_numTiles = 0;
-		snprintf( texturePath, sizeof(texturePath), "%s%s", TERRAIN_TGA_DIR_PATH, m_treeTypes[i].m_data->m_textureName.str() );
+		snprintf( texturePath, ARRAY_SIZE(texturePath), "%s%s", TERRAIN_TGA_DIR_PATH, m_treeTypes[i].m_data->m_textureName.str() );
 		theFile = TheFileSystem->openFile( texturePath, File::READ|File::BINARY);
 		if (theFile==nullptr) {
-			snprintf( texturePath, sizeof(texturePath), "%s%s", TGA_DIR_PATH, m_treeTypes[i].m_data->m_textureName.str() );
+			snprintf( texturePath, ARRAY_SIZE(texturePath), "%s%s", TGA_DIR_PATH, m_treeTypes[i].m_data->m_textureName.str() );
 			theFile = TheFileSystem->openFile( texturePath, File::READ|File::BINARY);
 		}
 		if (theFile != nullptr) {

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/WorldHeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/WorldHeightMap.cpp
@@ -1004,7 +1004,7 @@ void WorldHeightMap::readTexClass(TXTextureClass *texClass, TileData **tileData)
 	}
 	else
 	{
-		sprintf( texturePath, "%s%s", TERRAIN_TGA_DIR_PATH, terrain->getTexture().str() );
+		snprintf( texturePath, sizeof(texturePath), "%s%s", TERRAIN_TGA_DIR_PATH, terrain->getTexture().str() );
 		theFile = TheFileSystem->openFile( texturePath, File::READ|File::BINARY);
 	}
 

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/WorldHeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/WorldHeightMap.cpp
@@ -1004,7 +1004,7 @@ void WorldHeightMap::readTexClass(TXTextureClass *texClass, TileData **tileData)
 	}
 	else
 	{
-		snprintf( texturePath, sizeof(texturePath), "%s%s", TERRAIN_TGA_DIR_PATH, terrain->getTexture().str() );
+		snprintf( texturePath, ARRAY_SIZE(texturePath), "%s%s", TERRAIN_TGA_DIR_PATH, terrain->getTexture().str() );
 		theFile = TheFileSystem->openFile( texturePath, File::READ|File::BINARY);
 	}
 

--- a/Core/Libraries/Source/WWVegas/WW3D2/FramGrab.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/FramGrab.cpp
@@ -49,7 +49,7 @@ FrameGrabClass::FrameGrabClass(const char *filename, MODE mode, int width, int h
 	int result;
 	char file[256];
 	do {
-		sprintf(file, "%s%d.AVI", filename, counter++);
+		snprintf(file, sizeof(file), "%s%d.AVI", filename, counter++);
 		result = _access(file, 0);
 	} while(result != -1);
 
@@ -57,7 +57,7 @@ FrameGrabClass::FrameGrabClass(const char *filename, MODE mode, int width, int h
     hr = AVIFileOpen(&AVIFile, file, OF_WRITE | OF_CREATE, nullptr);
     if (hr != 0) {
 		char buf[256];
-		sprintf(buf, "Unable to open %s\n", Filename);
+		snprintf(buf, sizeof(buf), "Unable to open %s\n", Filename);
 		OutputDebugString(buf);
 		CleanupAVI();
 		return;

--- a/Core/Libraries/Source/WWVegas/WW3D2/FramGrab.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/FramGrab.cpp
@@ -49,7 +49,7 @@ FrameGrabClass::FrameGrabClass(const char *filename, MODE mode, int width, int h
 	int result;
 	char file[256];
 	do {
-		snprintf(file, sizeof(file), "%s%d.AVI", filename, counter++);
+		snprintf(file, ARRAY_SIZE(file), "%s%d.AVI", filename, counter++);
 		result = _access(file, 0);
 	} while(result != -1);
 
@@ -57,7 +57,7 @@ FrameGrabClass::FrameGrabClass(const char *filename, MODE mode, int width, int h
     hr = AVIFileOpen(&AVIFile, file, OF_WRITE | OF_CREATE, nullptr);
     if (hr != 0) {
 		char buf[256];
-		snprintf(buf, sizeof(buf), "Unable to open %s\n", Filename);
+		snprintf(buf, ARRAY_SIZE(buf), "Unable to open %s\n", Filename);
 		OutputDebugString(buf);
 		CleanupAVI();
 		return;

--- a/Core/Libraries/Source/WWVegas/WWDownload/FTP.cpp
+++ b/Core/Libraries/Source/WWVegas/WWDownload/FTP.cpp
@@ -494,7 +494,7 @@ HRESULT  Cftp::LoginToServer( LPCSTR szUserName, LPCSTR szPassword )
 
 	if( m_iStatus == FTPSTAT_CONNECTED )
 	{
-		sprintf( command, "USER %s\r\n", m_szUserName );
+		snprintf( command, sizeof(command), "USER %s\r\n", m_szUserName );
 
 		if( SendCommand( command, 7 + strlen( m_szUserName ) ) < 0 )
 		{
@@ -517,7 +517,7 @@ HRESULT  Cftp::LoginToServer( LPCSTR szUserName, LPCSTR szPassword )
 
 	if( m_iStatus == FTPSTAT_SENTUSER )
 	{
-		sprintf( command, "PASS %s\r\n", m_szPassword );
+		snprintf( command, sizeof(command), "PASS %s\r\n", m_szPassword );
 
 		if( SendCommand( command, 7 + strlen( m_szPassword ) ) < 0 )
 		{
@@ -694,7 +694,7 @@ HRESULT  Cftp::FindFile( LPCSTR szRemoteFileName, int * piSize )
 
 	if( ( m_iStatus == FTPSTAT_LOGGEDIN ) || ( m_iStatus == FTPSTAT_FILEFOUND ) )
 	{
-		sprintf( command, "CWD %s\r\n", m_szRemoteFilePath );
+		snprintf( command, sizeof(command), "CWD %s\r\n", m_szRemoteFilePath );
 
 		if( SendCommand( command, 6 + strlen( m_szRemoteFilePath ) ) < 0 )
 		{
@@ -747,7 +747,7 @@ HRESULT  Cftp::FindFile( LPCSTR szRemoteFileName, int * piSize )
 
 	if( m_iStatus == FTPSTAT_SENTPORT )
 	{
-		sprintf( command, "LIST %s\r\n", m_szRemoteFileName );
+		snprintf( command, sizeof(command), "LIST %s\r\n", m_szRemoteFileName );
 
 		if( SendCommand( command, 7 + strlen( m_szRemoteFileName ) ) < 0 )
 		{
@@ -1507,7 +1507,7 @@ HRESULT  Cftp::GetNextFileBlock( LPCSTR szLocalFileName, int * piTotalRead )
 
 	if( m_iStatus == FTPSTAT_SENTREST )
 	{
-		sprintf( command, "RETR %s\r\n", m_szRemoteFileName );
+		snprintf( command, sizeof(command), "RETR %s\r\n", m_szRemoteFileName );
 
 		if( SendCommand( command, strlen( command ) ) < 0 )
 		{
@@ -1803,7 +1803,7 @@ void Cftp::GetDownloadFilename(const char *localname, char *downloadname)
 			*s = '_';
 		++s;
 	}
-	sprintf(downloadname,"download\\%s_%d.tmp",name,m_iFileSize);
+	snprintf(downloadname, 256, "download\\%s_%d.tmp", name, m_iFileSize);
 	free(name);
 	/*
 	Wstring name;
@@ -1831,7 +1831,7 @@ bool Prepare_Directories(const char *rootdir, const char *filename)
 	while(cptr=strchr(cptr,'\\'))
 	{
 		strlcpy(tempstr,filename,cptr-filename + 1);
-		sprintf(newdir,"%s\\%s",rootdir, tempstr);
+		snprintf(newdir, sizeof(newdir), "%s\\%s", rootdir, tempstr);
 		if (!CreateDirectory(newdir, nullptr))
 			return false;
 		//if ((_mkdir(newdir) == -1) && ((errno == ENOENT || errno==EACCES)))

--- a/Core/Libraries/Source/WWVegas/WWDownload/FTP.cpp
+++ b/Core/Libraries/Source/WWVegas/WWDownload/FTP.cpp
@@ -494,7 +494,7 @@ HRESULT  Cftp::LoginToServer( LPCSTR szUserName, LPCSTR szPassword )
 
 	if( m_iStatus == FTPSTAT_CONNECTED )
 	{
-		snprintf( command, sizeof(command), "USER %s\r\n", m_szUserName );
+		snprintf( command, ARRAY_SIZE(command), "USER %s\r\n", m_szUserName );
 
 		if( SendCommand( command, (int)strlen( command ) ) < 0 )
 		{
@@ -517,7 +517,7 @@ HRESULT  Cftp::LoginToServer( LPCSTR szUserName, LPCSTR szPassword )
 
 	if( m_iStatus == FTPSTAT_SENTUSER )
 	{
-		snprintf( command, sizeof(command), "PASS %s\r\n", m_szPassword );
+		snprintf( command, ARRAY_SIZE(command), "PASS %s\r\n", m_szPassword );
 
 		if( SendCommand( command, (int)strlen( command ) ) < 0 )
 		{
@@ -694,7 +694,7 @@ HRESULT  Cftp::FindFile( LPCSTR szRemoteFileName, int * piSize )
 
 	if( ( m_iStatus == FTPSTAT_LOGGEDIN ) || ( m_iStatus == FTPSTAT_FILEFOUND ) )
 	{
-		snprintf( command, sizeof(command), "CWD %s\r\n", m_szRemoteFilePath );
+		snprintf( command, ARRAY_SIZE(command), "CWD %s\r\n", m_szRemoteFilePath );
 
 		if( SendCommand( command, (int)strlen( command ) ) < 0 )
 		{
@@ -747,7 +747,7 @@ HRESULT  Cftp::FindFile( LPCSTR szRemoteFileName, int * piSize )
 
 	if( m_iStatus == FTPSTAT_SENTPORT )
 	{
-		snprintf( command, sizeof(command), "LIST %s\r\n", m_szRemoteFileName );
+		snprintf( command, ARRAY_SIZE(command), "LIST %s\r\n", m_szRemoteFileName );
 
 		if( SendCommand( command, (int)strlen( command ) ) < 0 )
 		{
@@ -1391,7 +1391,7 @@ HRESULT  Cftp::GetNextFileBlock( LPCSTR szLocalFileName, int * piTotalRead )
 	int res, iReply;
 
 	char downloadfilename[256];
-	GetDownloadFilename(szLocalFileName, downloadfilename, sizeof(downloadfilename));
+	GetDownloadFilename(szLocalFileName, downloadfilename, ARRAY_SIZE(downloadfilename));
 
 
 	//char str[ 256 ];
@@ -1507,7 +1507,7 @@ HRESULT  Cftp::GetNextFileBlock( LPCSTR szLocalFileName, int * piTotalRead )
 
 	if( m_iStatus == FTPSTAT_SENTREST )
 	{
-		snprintf( command, sizeof(command), "RETR %s\r\n", m_szRemoteFileName );
+		snprintf( command, ARRAY_SIZE(command), "RETR %s\r\n", m_szRemoteFileName );
 
 		if( SendCommand( command, strlen( command ) ) < 0 )
 		{
@@ -1607,7 +1607,7 @@ HRESULT  Cftp::GetNextFileBlock( LPCSTR szLocalFileName, int * piTotalRead )
 		 */
 
 		char downloadfilename[256];
-		GetDownloadFilename(m_szLocalFileName, downloadfilename, sizeof(downloadfilename));
+		GetDownloadFilename(m_szLocalFileName, downloadfilename, ARRAY_SIZE(downloadfilename));
 
 		// Make sure the path exists for the new file
 		char curdir[256];
@@ -1688,7 +1688,7 @@ HRESULT  Cftp::GetNextFileBlock( LPCSTR szLocalFileName, int * piTotalRead )
 HRESULT  Cftp::FileRecoveryPosition( LPCSTR szLocalFileName, LPCSTR szRegistryRoot )
 {
 	char downloadfilename[256];
-	GetDownloadFilename(szLocalFileName, downloadfilename, sizeof(downloadfilename));
+	GetDownloadFilename(szLocalFileName, downloadfilename, ARRAY_SIZE(downloadfilename));
 
 	FILE *testfp = fopen( downloadfilename, "rb" );
 	if( testfp == nullptr )
@@ -1831,7 +1831,7 @@ bool Prepare_Directories(const char *rootdir, const char *filename)
 	while(cptr=strchr(cptr,'\\'))
 	{
 		strlcpy(tempstr,filename,cptr-filename + 1);
-		snprintf(newdir, sizeof(newdir), "%s\\%s", rootdir, tempstr);
+		snprintf(newdir, ARRAY_SIZE(newdir), "%s\\%s", rootdir, tempstr);
 		if (!CreateDirectory(newdir, nullptr))
 			return false;
 		//if ((_mkdir(newdir) == -1) && ((errno == ENOENT || errno==EACCES)))

--- a/Core/Libraries/Source/WWVegas/WWDownload/FTP.cpp
+++ b/Core/Libraries/Source/WWVegas/WWDownload/FTP.cpp
@@ -496,7 +496,7 @@ HRESULT  Cftp::LoginToServer( LPCSTR szUserName, LPCSTR szPassword )
 	{
 		snprintf( command, sizeof(command), "USER %s\r\n", m_szUserName );
 
-		if( SendCommand( command, 7 + strlen( m_szUserName ) ) < 0 )
+		if( SendCommand( command, (int)strlen( command ) ) < 0 )
 		{
 			return( FTP_TRYING );
 		}
@@ -519,7 +519,7 @@ HRESULT  Cftp::LoginToServer( LPCSTR szUserName, LPCSTR szPassword )
 	{
 		snprintf( command, sizeof(command), "PASS %s\r\n", m_szPassword );
 
-		if( SendCommand( command, 7 + strlen( m_szPassword ) ) < 0 )
+		if( SendCommand( command, (int)strlen( command ) ) < 0 )
 		{
 			return( FTP_TRYING );
 		}
@@ -696,7 +696,7 @@ HRESULT  Cftp::FindFile( LPCSTR szRemoteFileName, int * piSize )
 	{
 		snprintf( command, sizeof(command), "CWD %s\r\n", m_szRemoteFilePath );
 
-		if( SendCommand( command, 6 + strlen( m_szRemoteFilePath ) ) < 0 )
+		if( SendCommand( command, (int)strlen( command ) ) < 0 )
 		{
 			return( FTP_TRYING );
 		}
@@ -749,7 +749,7 @@ HRESULT  Cftp::FindFile( LPCSTR szRemoteFileName, int * piSize )
 	{
 		snprintf( command, sizeof(command), "LIST %s\r\n", m_szRemoteFileName );
 
-		if( SendCommand( command, 7 + strlen( m_szRemoteFileName ) ) < 0 )
+		if( SendCommand( command, (int)strlen( command ) ) < 0 )
 		{
 			return( FTP_TRYING );
 		}
@@ -1391,7 +1391,7 @@ HRESULT  Cftp::GetNextFileBlock( LPCSTR szLocalFileName, int * piTotalRead )
 	int res, iReply;
 
 	char downloadfilename[256];
-	GetDownloadFilename(szLocalFileName, downloadfilename);
+	GetDownloadFilename(szLocalFileName, downloadfilename, sizeof(downloadfilename));
 
 
 	//char str[ 256 ];
@@ -1607,7 +1607,7 @@ HRESULT  Cftp::GetNextFileBlock( LPCSTR szLocalFileName, int * piTotalRead )
 		 */
 
 		char downloadfilename[256];
-		GetDownloadFilename(m_szLocalFileName, downloadfilename);
+		GetDownloadFilename(m_szLocalFileName, downloadfilename, sizeof(downloadfilename));
 
 		// Make sure the path exists for the new file
 		char curdir[256];
@@ -1688,7 +1688,7 @@ HRESULT  Cftp::GetNextFileBlock( LPCSTR szLocalFileName, int * piTotalRead )
 HRESULT  Cftp::FileRecoveryPosition( LPCSTR szLocalFileName, LPCSTR szRegistryRoot )
 {
 	char downloadfilename[256];
-	GetDownloadFilename(szLocalFileName, downloadfilename);
+	GetDownloadFilename(szLocalFileName, downloadfilename, sizeof(downloadfilename));
 
 	FILE *testfp = fopen( downloadfilename, "rb" );
 	if( testfp == nullptr )
@@ -1793,7 +1793,7 @@ HRESULT  Cftp::FileRecoveryPosition( LPCSTR szLocalFileName, LPCSTR szRegistryRo
 //
 // convert a local name to a temp filename to use for downloading
 //
-void Cftp::GetDownloadFilename(const char *localname, char *downloadname)
+void Cftp::GetDownloadFilename(const char *localname, char *downloadname, size_t downloadname_size)
 {
 	char *name = strdup(localname);
 	char *s = name;
@@ -1803,7 +1803,7 @@ void Cftp::GetDownloadFilename(const char *localname, char *downloadname)
 			*s = '_';
 		++s;
 	}
-	snprintf(downloadname, 256, "download\\%s_%d.tmp", name, m_iFileSize);
+	snprintf(downloadname, downloadname_size, "download\\%s_%d.tmp", name, m_iFileSize);
 	free(name);
 	/*
 	Wstring name;

--- a/Core/Libraries/Source/WWVegas/WWDownload/ftp.h
+++ b/Core/Libraries/Source/WWVegas/WWDownload/ftp.h
@@ -22,6 +22,7 @@
 
 //#include "../resource.h"       // main symbols
 
+#include <cstddef>
 #include <winsock.h>
 #include <Utility/stdio_adapter.h>
 
@@ -83,7 +84,7 @@ private:
 	int		AsyncGetHostByName( char * szName, struct sockaddr_in &address );
 
 				// Convert a local filename into a temp filename to download into
-	void		GetDownloadFilename( const char* localname, char* downloadname);
+	void		GetDownloadFilename( const char* localname, char* downloadname, size_t downloadname_size);
 
 	void		CloseSockets(void);
 	void		ZeroStuff(void);

--- a/Core/Libraries/Source/WWVegas/WWLib/Except.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/Except.cpp
@@ -469,7 +469,7 @@ void Dump_Exception_Info(EXCEPTION_POINTERS *e_info)
 
 	if (!IsBadCodePtr((FARPROC)context->Eip)) {
 		if (_SymGetSymFromAddr != nullptr && _SymGetSymFromAddr (GetCurrentProcess(), context->Eip, &displacement, symptr)) {
-			snprintf(scrap, sizeof(scrap), "Exception occurred at %08X - %s + %08X\r\n",
+			snprintf(scrap, ARRAY_SIZE(scrap), "Exception occurred at %08X - %s + %08X\r\n",
 				context->Eip, symptr->Name, displacement);
 		} else {
 			DebugString ("Exception Handler: Failed to get symbol for EIP\r\n");
@@ -510,7 +510,7 @@ void Dump_Exception_Info(EXCEPTION_POINTERS *e_info)
 
 				if (_SymGetSymFromAddr != nullptr && _SymGetSymFromAddr (GetCurrentProcess(), temp_addr, &displacement, symptr)) {
 					char symbuf[256];
-					snprintf(symbuf, sizeof(symbuf), "%s + %08X\r\n", symptr->Name, displacement);
+					snprintf(symbuf, ARRAY_SIZE(symbuf), "%s + %08X\r\n", symptr->Name, displacement);
 					Add_Txt(symbuf);
 				}
 			} else {
@@ -547,7 +547,7 @@ void Dump_Exception_Info(EXCEPTION_POINTERS *e_info)
 #endif	//(0)
 
 	if (AppVersionCallback) {
-		snprintf(scrap, sizeof(scrap), "%s\r\n\r\n", AppVersionCallback());
+		snprintf(scrap, ARRAY_SIZE(scrap), "%s\r\n\r\n", AppVersionCallback());
 		Add_Txt(scrap);
 	}
 
@@ -560,7 +560,7 @@ void Dump_Exception_Info(EXCEPTION_POINTERS *e_info)
 	** Get the thread info from ThreadClass.
 	*/
 	for (int thread = 0 ; thread < ThreadList.Count() ; thread++) {
-		snprintf(scrap, sizeof(scrap), "  ID: %08X - %s",
+		snprintf(scrap, ARRAY_SIZE(scrap), "  ID: %08X - %s",
 			ThreadList[thread]->ThreadID, ThreadList[thread]->ThreadName);
 		Add_Txt(scrap);
 		if (GetCurrentThreadId() == ThreadList[thread]->ThreadID) {
@@ -572,7 +572,7 @@ void Dump_Exception_Info(EXCEPTION_POINTERS *e_info)
 	/*
 	** CPU type
 	*/
-	snprintf(scrap, sizeof(scrap), "\r\nCPU %s, %d Mhz, Vendor: %s\r\n",
+	snprintf(scrap, ARRAY_SIZE(scrap), "\r\nCPU %s, %d Mhz, Vendor: %s\r\n",
 		(char*)CPUDetectClass::Get_Processor_String(), Get_RDTSC_CPU_Speed(),
 		(char*)CPUDetectClass::Get_Processor_Manufacturer_Name());
 	Add_Txt(scrap);
@@ -694,7 +694,7 @@ void Dump_Exception_Info(EXCEPTION_POINTERS *e_info)
 
 					if (_SymGetSymFromAddr != nullptr && _SymGetSymFromAddr (GetCurrentProcess(), *stackptr, &displacement, symptr)) {
 						char symbuf[256];
-						snprintf(symbuf, sizeof(symbuf), " - %s + %08X", symptr->Name, displacement);
+						snprintf(symbuf, ARRAY_SIZE(symbuf), " - %s + %08X", symptr->Name, displacement);
 						strlcat(scrap, symbuf, ARRAY_SIZE(scrap));
 					}
 				} else {

--- a/Core/Libraries/Source/WWVegas/WWLib/Except.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/Except.cpp
@@ -469,7 +469,8 @@ void Dump_Exception_Info(EXCEPTION_POINTERS *e_info)
 
 	if (!IsBadCodePtr((FARPROC)context->Eip)) {
 		if (_SymGetSymFromAddr != nullptr && _SymGetSymFromAddr (GetCurrentProcess(), context->Eip, &displacement, symptr)) {
-			sprintf (scrap, "Exception occurred at %08X - %s + %08X\r\n", context->Eip, symptr->Name, displacement);
+			snprintf(scrap, sizeof(scrap), "Exception occurred at %08X - %s + %08X\r\n",
+				context->Eip, symptr->Name, displacement);
 		} else {
 			DebugString ("Exception Handler: Failed to get symbol for EIP\r\n");
 			if (_SymGetSymFromAddr != nullptr) {
@@ -509,7 +510,7 @@ void Dump_Exception_Info(EXCEPTION_POINTERS *e_info)
 
 				if (_SymGetSymFromAddr != nullptr && _SymGetSymFromAddr (GetCurrentProcess(), temp_addr, &displacement, symptr)) {
 					char symbuf[256];
-					sprintf(symbuf, "%s + %08X\r\n", symptr->Name, displacement);
+					snprintf(symbuf, sizeof(symbuf), "%s + %08X\r\n", symptr->Name, displacement);
 					Add_Txt(symbuf);
 				}
 			} else {
@@ -546,7 +547,7 @@ void Dump_Exception_Info(EXCEPTION_POINTERS *e_info)
 #endif	//(0)
 
 	if (AppVersionCallback) {
-		sprintf(scrap, "%s\r\n\r\n", AppVersionCallback());
+		snprintf(scrap, sizeof(scrap), "%s\r\n\r\n", AppVersionCallback());
 		Add_Txt(scrap);
 	}
 
@@ -559,7 +560,8 @@ void Dump_Exception_Info(EXCEPTION_POINTERS *e_info)
 	** Get the thread info from ThreadClass.
 	*/
 	for (int thread = 0 ; thread < ThreadList.Count() ; thread++) {
-		sprintf(scrap, "  ID: %08X - %s", ThreadList[thread]->ThreadID, ThreadList[thread]->ThreadName);
+		snprintf(scrap, sizeof(scrap), "  ID: %08X - %s",
+			ThreadList[thread]->ThreadID, ThreadList[thread]->ThreadName);
 		Add_Txt(scrap);
 		if (GetCurrentThreadId() == ThreadList[thread]->ThreadID) {
 			Add_Txt("   ***CURRENT THREAD***");
@@ -570,7 +572,9 @@ void Dump_Exception_Info(EXCEPTION_POINTERS *e_info)
 	/*
 	** CPU type
 	*/
-	sprintf(scrap, "\r\nCPU %s, %d Mhz, Vendor: %s\r\n", (char*)CPUDetectClass::Get_Processor_String(), Get_RDTSC_CPU_Speed(), (char*)CPUDetectClass::Get_Processor_Manufacturer_Name());
+	snprintf(scrap, sizeof(scrap), "\r\nCPU %s, %d Mhz, Vendor: %s\r\n",
+		(char*)CPUDetectClass::Get_Processor_String(), Get_RDTSC_CPU_Speed(),
+		(char*)CPUDetectClass::Get_Processor_Manufacturer_Name());
 	Add_Txt(scrap);
 
 
@@ -690,7 +694,7 @@ void Dump_Exception_Info(EXCEPTION_POINTERS *e_info)
 
 					if (_SymGetSymFromAddr != nullptr && _SymGetSymFromAddr (GetCurrentProcess(), *stackptr, &displacement, symptr)) {
 						char symbuf[256];
-						sprintf(symbuf, " - %s + %08X", symptr->Name, displacement);
+						snprintf(symbuf, sizeof(symbuf), " - %s + %08X", symptr->Name, displacement);
 						strlcat(scrap, symbuf, ARRAY_SIZE(scrap));
 					}
 				} else {

--- a/Core/Libraries/Source/WWVegas/WWLib/ini.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/ini.cpp
@@ -866,7 +866,7 @@ unsigned INIClass::Enumerate_Entries(const char *Section, const char * Entry_Pre
 	char entry[256];
 	do
 	{
-		snprintf(entry, sizeof(entry), "%s%d", Entry_Prefix, count);
+		snprintf(entry, ARRAY_SIZE(entry), "%s%d", Entry_Prefix, count);
 		present = Is_Present(Section, entry);
 		if(present)
 			count++;

--- a/Core/Libraries/Source/WWVegas/WWLib/ini.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/ini.cpp
@@ -866,7 +866,7 @@ unsigned INIClass::Enumerate_Entries(const char *Section, const char * Entry_Pre
 	char entry[256];
 	do
 	{
-		sprintf(entry, "%s%d", Entry_Prefix, count);
+		snprintf(entry, sizeof(entry), "%s%d", Entry_Prefix, count);
 		present = Is_Present(Section, entry);
 		if(present)
 			count++;

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GameWindowManagerScript.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GameWindowManagerScript.cpp
@@ -2714,7 +2714,7 @@ GameWindow *GameWindowManager::winCreateFromScript( AsciiString filenameString,
 	// place for the window files subdirectory
 	//
 	if( strchr( filename, '\\' ) == nullptr )
-		sprintf( filepath, "Window\\%s", filename );
+		snprintf( filepath, ARRAY_SIZE(filepath), "Window\\%s", filename );
 	else
 		strlcpy(filepath, filename, ARRAY_SIZE(filepath));
 

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -2042,7 +2042,8 @@ void GameLogic::startNewGame( Bool saveGame )
 		req.buddyRequestType = BuddyRequest::BUDDYREQUEST_SETSTATUS;
 		req.arg.status.status = GP_PLAYING;
 		strcpy(req.arg.status.statusString, "Playing");
-		sprintf(req.arg.status.locationString, "%s", WideCharStringToMultiByte(TheGameSpyGame->getGameName().str()).c_str());
+		strlcpy(req.arg.status.locationString, WideCharStringToMultiByte(TheGameSpyGame->getGameName().str()).c_str(),
+			ARRAY_SIZE(req.arg.status.locationString));
 		TheGameSpyBuddyMessageQueue->addRequest(req);
 	}
 
@@ -2124,7 +2125,7 @@ void GameLogic::loadMapINI( AsciiString mapName )
 
 
 	char fullFledgeFilename[_MAX_PATH];
-	sprintf(fullFledgeFilename, "%s\\map.ini", filename);
+	snprintf(fullFledgeFilename, ARRAY_SIZE(fullFledgeFilename), "%s\\map.ini", filename);
 	if (TheFileSystem->doesFileExist(fullFledgeFilename)) {
 		DEBUG_LOG(("Loading map.ini"));
 		INI ini;
@@ -2134,7 +2135,7 @@ void GameLogic::loadMapINI( AsciiString mapName )
 	// TheSuperHackers @todo Implement ini load directory for map folder.
 	// Requires adjustments in map transfer.
 
-	sprintf(fullFledgeFilename, "%s\\solo.ini", filename);
+	snprintf(fullFledgeFilename, ARRAY_SIZE(fullFledgeFilename), "%s\\solo.ini", filename);
 	if (TheFileSystem->doesFileExist(fullFledgeFilename)) {
 		DEBUG_LOG(("Loading solo.ini"));
 		INI ini;
@@ -2144,7 +2145,7 @@ void GameLogic::loadMapINI( AsciiString mapName )
 	// No error here. There could've just *not* been a map.ini file.
 
 	// now look for a string file
-	sprintf(fullFledgeFilename, "%s\\map.str", filename);
+	snprintf(fullFledgeFilename, ARRAY_SIZE(fullFledgeFilename), "%s\\map.str", filename);
 
 	if (TheFileSystem->doesFileExist(fullFledgeFilename)) {
 		TheGameText->initMapStringFile(fullFledgeFilename);
@@ -2154,7 +2155,7 @@ void GameLogic::loadMapINI( AsciiString mapName )
 	if (TheDisplay)
 	{
 		const char* ASSET_USAGE_FILE_NAME = "AssetUsage.txt";
-		sprintf(fullFledgeFilename, "%s\\%s", filename, ASSET_USAGE_FILE_NAME);
+		snprintf(fullFledgeFilename, ARRAY_SIZE(fullFledgeFilename), "%s\\%s", filename, ASSET_USAGE_FILE_NAME);
 		// note: call this EVEN IF THE FILE IN QUESTION DOES NOT EXIST.
 		TheDisplay->doSmartAssetPurgeAndPreload(fullFledgeFilename);
 	}

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DAssetManager.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DAssetManager.cpp
@@ -236,7 +236,8 @@ RenderObjClass * W3DAssetManager::Create_Render_Obj(const char* name)
 
 //---------------------------------------------------------------------
 /** 'Generals' specific munging to encode team color and scale in model name */
-static inline void Munge_Render_Obj_Name(char *newname, const char *oldname, float scale, const int color, const char *textureName)
+static inline void Munge_Render_Obj_Name(char *newname, size_t newname_size, const char *oldname, float scale,
+	const int color, const char *textureName)
 {
 	char lower_case_name[255];
 	strlcpy(lower_case_name, oldname, ARRAY_SIZE(lower_case_name));
@@ -245,16 +246,16 @@ static inline void Munge_Render_Obj_Name(char *newname, const char *oldname, flo
 	if (!textureName)
 		textureName = "";
 
-	sprintf(newname,"#%d!%g!%s#%s",color,scale,textureName,lower_case_name);
+	snprintf(newname, newname_size, "#%d!%g!%s#%s", color, scale, textureName, lower_case_name);
 }
 
 //---------------------------------------------------------------------
-static inline void Munge_Texture_Name(char *newname, const char *oldname, const int color)
+static inline void Munge_Texture_Name(char *newname, size_t newname_size, const char *oldname, const int color)
 {
 	char lower_case_name[255];
 	strlcpy(lower_case_name, oldname, ARRAY_SIZE(lower_case_name));
 	_strlwr(lower_case_name);
-	sprintf(newname,"#%d#%s", color, lower_case_name);
+	snprintf(newname, newname_size, "#%d#%s", color, lower_case_name);
 }
 
 //---------------------------------------------------------------------
@@ -337,7 +338,7 @@ int W3DAssetManager::replacePrototypeTexture(RenderObjClass *robj, const char * 
 TextureClass * W3DAssetManager::Find_Texture(const char * name, const int color)
 {
 	char newname[512];
-	Munge_Texture_Name(newname, name, color);
+	Munge_Texture_Name(newname, ARRAY_SIZE(newname), name, color);
 
 	// see if we have a cached copy
 	TextureClass *newtex = TextureHash.Get(newname);
@@ -655,7 +656,7 @@ TextureClass * W3DAssetManager::Recolor_Texture_One_Time(TextureClass *texture, 
 	newtex->Get_Filter().Set_V_Addr_Mode(texture->Get_Filter().Get_V_Addr_Mode());
 
 	char newname[512];
-	Munge_Texture_Name(newname, name, color);
+	Munge_Texture_Name(newname, ARRAY_SIZE(newname), name, color);
 	newtex->Set_Texture_Name(newname);
 
 	TextureHash.Insert(newtex->Get_Texture_Name(), newtex);
@@ -703,7 +704,7 @@ RenderObjClass * W3DAssetManager::Create_Render_Obj(
 	}
 
 	char newname[512];
-	Munge_Render_Obj_Name(newname, name, scale, color, newTexture);
+	Munge_Render_Obj_Name(newname, ARRAY_SIZE(newname), name, scale, color, newTexture);
 
 	// see if we got a cached version
 	RenderObjClass *rendobj = nullptr;
@@ -743,7 +744,7 @@ RenderObjClass * W3DAssetManager::Create_Render_Obj(
 			lstrcpyn(filename, name, ((int)mesh_name) - ((int)name) + 1);
 			lstrcat(filename, ".w3d");
 		} else {
-			sprintf( filename, "%s.w3d", name);
+			snprintf( filename, ARRAY_SIZE(filename), "%s.w3d", name);
 		}
 
 		// If we can't find it, try the parent directory

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DMouse.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DMouse.cpp
@@ -191,7 +191,7 @@ Bool W3DMouse::loadD3DCursorTextures(MouseCursor cursor)
 
 	if (animFrames == 1)
 	{	//single animation frame without trailing numbers
-		sprintf(FrameName,"%s.tga",baseName);
+		snprintf(FrameName, ARRAY_SIZE(FrameName), "%s.tga", baseName);
 		cursorTextures[cursor][0]=	am->Get_Texture(FrameName);
 		m_currentD3DSurface[0]=cursorTextures[cursor][0]->Get_Surface_Level();
 		m_currentFrames = 1;
@@ -199,7 +199,7 @@ Bool W3DMouse::loadD3DCursorTextures(MouseCursor cursor)
 	else
 	for (Int i=0; i<animFrames; i++)
 	{
-		sprintf(FrameName,"%s%04d.tga",baseName,i);
+		snprintf(FrameName, ARRAY_SIZE(FrameName), "%s%04d.tga", baseName, i);
 		if ((cursorTextures[cursor][i]=am->Get_Texture(FrameName)) != nullptr)
 		{	m_currentD3DSurface[m_currentFrames]=cursorTextures[cursor][i]->Get_Surface_Level();
 			m_currentFrames++;

--- a/Generals/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32Mouse.cpp
+++ b/Generals/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32Mouse.cpp
@@ -373,9 +373,11 @@ void Win32Mouse::initCursorResources(void)
 				char resourcePath[256];
 				//Check if this is a directional cursor
 				if (m_cursorInfo[cursor].numDirections > 1)
-					sprintf(resourcePath,"data\\cursors\\%s%d.ANI",m_cursorInfo[cursor].textureName.str(),direction);
+					snprintf(resourcePath, ARRAY_SIZE(resourcePath), "data\\cursors\\%s%d.ANI",
+						m_cursorInfo[cursor].textureName.str(), direction);
 				else
-					sprintf(resourcePath,"data\\cursors\\%s.ANI",m_cursorInfo[cursor].textureName.str());
+					snprintf(resourcePath, ARRAY_SIZE(resourcePath), "data\\cursors\\%s.ANI",
+						m_cursorInfo[cursor].textureName.str());
 
 				// check for a MOD cursor.
 				Bool loaded = FALSE;

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/assetmgr.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/assetmgr.cpp
@@ -797,7 +797,7 @@ RenderObjClass * WW3DAssetManager::Create_Render_Obj(const char * name)
 			::lstrcpyn (filename, name, ((int)mesh_name) - ((int)name) + 1);
 			::lstrcat (filename, ".w3d");
 		} else {
-			sprintf( filename, "%s.w3d", name);
+			snprintf( filename, ARRAY_SIZE(filename), "%s.w3d", name);
 		}
 
 		// If we can't find it, try the parent directory
@@ -975,7 +975,7 @@ HAnimClass *	WW3DAssetManager::Get_HAnim(const char * name)
 			char filename[ MAX_PATH ];
 			const char *animname = strchr( name, '.');
 			if (animname != nullptr) {
-				sprintf( filename, "%s.w3d", animname+1);
+				snprintf( filename, ARRAY_SIZE(filename), "%s.w3d", animname+1);
 			} else {
 				WWDEBUG_SAY(( "Animation %s has no . in the name", name ));
 				WWASSERT( 0 );
@@ -1025,7 +1025,7 @@ HTreeClass *	WW3DAssetManager::Get_HTree(const char * name)
 		AssetStatusClass::Peek_Instance()->Report_Load_On_Demand_HTree(name);
 
 		char filename[ MAX_PATH ];
-		sprintf( filename, "%s.w3d", name);
+		snprintf( filename, ARRAY_SIZE(filename), "%s.w3d", name);
 
 		// If we can't find it, try the parent directory
 		if ( Load_3D_Assets( filename ) == false ) {

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/vertmaterial.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/vertmaterial.cpp
@@ -510,7 +510,7 @@ WW3DErrorType VertexMaterialClass::Load_W3D(ChunkLoadClass & cload)
 	if (mapping0_arg_buffer) {
 
 		char *extended_arg_buffer = MSGW3DNEWARRAY("VertexMaterialClassTemp") char[mapping0_arg_len + 10];
-		sprintf(extended_arg_buffer, "[Args]\n%s", mapping0_arg_buffer);
+		snprintf(extended_arg_buffer, mapping0_arg_len + 10, "[Args]\n%s", mapping0_arg_buffer);
 		mapping0_arg_len = strlen(extended_arg_buffer) + 1;
 
 		delete [] mapping0_arg_buffer;
@@ -527,7 +527,7 @@ WW3DErrorType VertexMaterialClass::Load_W3D(ChunkLoadClass & cload)
 	if (mapping1_arg_buffer) {
 
 		char *extended_arg_buffer = MSGW3DNEWARRAY("VertexMaterialClassTemp") char[mapping1_arg_len + 20];
-		sprintf(extended_arg_buffer, "[Args]\n%s", mapping1_arg_buffer);
+		snprintf(extended_arg_buffer, mapping1_arg_len + 20, "[Args]\n%s", mapping1_arg_buffer);
 		mapping1_arg_len = strlen(extended_arg_buffer) + 1;
 
 		delete [] mapping1_arg_buffer;

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
@@ -1323,7 +1323,7 @@ void WW3D::Make_Screen_Shot( const char * filename_base , const float gamma, con
 
 	bool done = false;
 	while (!done) {
-		sprintf( filename, "%s%.2d.%s", filename_base, frame_number++, ext);
+		snprintf( filename, ARRAY_SIZE(filename), "%s%.2d.%s", filename_base, frame_number++, ext);
 		FileClass*file=_TheFileFactory->Get_File( filename );
 		if ( file ) {
 			file->Open();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowManagerScript.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowManagerScript.cpp
@@ -2722,7 +2722,7 @@ GameWindow *GameWindowManager::winCreateFromScript( AsciiString filenameString,
 	// place for the window files subdirectory
 	//
 	if( strchr( filename, '\\' ) == nullptr )
-		snprintf( filepath, sizeof(filepath), "Window\\%s", filename );
+		snprintf( filepath, ARRAY_SIZE(filepath), "Window\\%s", filename );
 	else
 		strlcpy(filepath, filename, ARRAY_SIZE(filepath));
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowManagerScript.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowManagerScript.cpp
@@ -2722,7 +2722,7 @@ GameWindow *GameWindowManager::winCreateFromScript( AsciiString filenameString,
 	// place for the window files subdirectory
 	//
 	if( strchr( filename, '\\' ) == nullptr )
-		sprintf( filepath, "Window\\%s", filename );
+		snprintf( filepath, sizeof(filepath), "Window\\%s", filename );
 	else
 		strlcpy(filepath, filename, ARRAY_SIZE(filepath));
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -2331,7 +2331,8 @@ void GameLogic::startNewGame( Bool loadingSaveGame )
 		req.buddyRequestType = BuddyRequest::BUDDYREQUEST_SETSTATUS;
 		req.arg.status.status = GP_PLAYING;
 		strcpy(req.arg.status.statusString, "Playing");
-		sprintf(req.arg.status.locationString, "%s", WideCharStringToMultiByte(TheGameSpyGame->getGameName().str()).c_str());
+		snprintf(req.arg.status.locationString, sizeof(req.arg.status.locationString), "%s",
+			WideCharStringToMultiByte(TheGameSpyGame->getGameName().str()).c_str());
 		TheGameSpyBuddyMessageQueue->addRequest(req);
 	}
 
@@ -2440,7 +2441,7 @@ void GameLogic::loadMapINI( AsciiString mapName )
 
 
 	char fullFledgeFilename[_MAX_PATH];
-	sprintf(fullFledgeFilename, "%s\\map.ini", filename);
+	snprintf(fullFledgeFilename, sizeof(fullFledgeFilename), "%s\\map.ini", filename);
 	if (TheFileSystem->doesFileExist(fullFledgeFilename)) {
 		DEBUG_LOG(("Loading map.ini"));
 		INI ini;
@@ -2450,7 +2451,7 @@ void GameLogic::loadMapINI( AsciiString mapName )
 	// TheSuperHackers @todo Implement ini load directory for map folder.
 	// Requires adjustments in map transfer.
 
-	sprintf(fullFledgeFilename, "%s\\solo.ini", filename);
+	snprintf(fullFledgeFilename, sizeof(fullFledgeFilename), "%s\\solo.ini", filename);
 	if (TheFileSystem->doesFileExist(fullFledgeFilename)) {
 		DEBUG_LOG(("Loading solo.ini"));
 		INI ini;
@@ -2460,7 +2461,7 @@ void GameLogic::loadMapINI( AsciiString mapName )
 	// No error here. There could've just *not* been a map.ini file.
 
 	// now look for a string file
-	sprintf(fullFledgeFilename, "%s\\map.str", filename);
+	snprintf(fullFledgeFilename, sizeof(fullFledgeFilename), "%s\\map.str", filename);
 
 	if (TheFileSystem->doesFileExist(fullFledgeFilename)) {
 		TheGameText->initMapStringFile(fullFledgeFilename);
@@ -2470,7 +2471,7 @@ void GameLogic::loadMapINI( AsciiString mapName )
 	if (TheDisplay)
 	{
 		const char* ASSET_USAGE_FILE_NAME = "AssetUsage.txt";
-		sprintf(fullFledgeFilename, "%s\\%s", filename, ASSET_USAGE_FILE_NAME);
+		snprintf(fullFledgeFilename, sizeof(fullFledgeFilename), "%s\\%s", filename, ASSET_USAGE_FILE_NAME);
 		// note: call this EVEN IF THE FILE IN QUESTION DOES NOT EXIST.
 		TheDisplay->doSmartAssetPurgeAndPreload(fullFledgeFilename);
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -2331,7 +2331,7 @@ void GameLogic::startNewGame( Bool loadingSaveGame )
 		req.buddyRequestType = BuddyRequest::BUDDYREQUEST_SETSTATUS;
 		req.arg.status.status = GP_PLAYING;
 		strcpy(req.arg.status.statusString, "Playing");
-		snprintf(req.arg.status.locationString, sizeof(req.arg.status.locationString), "%s",
+		snprintf(req.arg.status.locationString, ARRAY_SIZE(req.arg.status.locationString), "%s",
 			WideCharStringToMultiByte(TheGameSpyGame->getGameName().str()).c_str());
 		TheGameSpyBuddyMessageQueue->addRequest(req);
 	}
@@ -2441,7 +2441,7 @@ void GameLogic::loadMapINI( AsciiString mapName )
 
 
 	char fullFledgeFilename[_MAX_PATH];
-	snprintf(fullFledgeFilename, sizeof(fullFledgeFilename), "%s\\map.ini", filename);
+	snprintf(fullFledgeFilename, ARRAY_SIZE(fullFledgeFilename), "%s\\map.ini", filename);
 	if (TheFileSystem->doesFileExist(fullFledgeFilename)) {
 		DEBUG_LOG(("Loading map.ini"));
 		INI ini;
@@ -2451,7 +2451,7 @@ void GameLogic::loadMapINI( AsciiString mapName )
 	// TheSuperHackers @todo Implement ini load directory for map folder.
 	// Requires adjustments in map transfer.
 
-	snprintf(fullFledgeFilename, sizeof(fullFledgeFilename), "%s\\solo.ini", filename);
+	snprintf(fullFledgeFilename, ARRAY_SIZE(fullFledgeFilename), "%s\\solo.ini", filename);
 	if (TheFileSystem->doesFileExist(fullFledgeFilename)) {
 		DEBUG_LOG(("Loading solo.ini"));
 		INI ini;
@@ -2461,7 +2461,7 @@ void GameLogic::loadMapINI( AsciiString mapName )
 	// No error here. There could've just *not* been a map.ini file.
 
 	// now look for a string file
-	snprintf(fullFledgeFilename, sizeof(fullFledgeFilename), "%s\\map.str", filename);
+	snprintf(fullFledgeFilename, ARRAY_SIZE(fullFledgeFilename), "%s\\map.str", filename);
 
 	if (TheFileSystem->doesFileExist(fullFledgeFilename)) {
 		TheGameText->initMapStringFile(fullFledgeFilename);
@@ -2471,7 +2471,7 @@ void GameLogic::loadMapINI( AsciiString mapName )
 	if (TheDisplay)
 	{
 		const char* ASSET_USAGE_FILE_NAME = "AssetUsage.txt";
-		snprintf(fullFledgeFilename, sizeof(fullFledgeFilename), "%s\\%s", filename, ASSET_USAGE_FILE_NAME);
+		snprintf(fullFledgeFilename, ARRAY_SIZE(fullFledgeFilename), "%s\\%s", filename, ASSET_USAGE_FILE_NAME);
 		// note: call this EVEN IF THE FILE IN QUESTION DOES NOT EXIST.
 		TheDisplay->doSmartAssetPurgeAndPreload(fullFledgeFilename);
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -2331,8 +2331,8 @@ void GameLogic::startNewGame( Bool loadingSaveGame )
 		req.buddyRequestType = BuddyRequest::BUDDYREQUEST_SETSTATUS;
 		req.arg.status.status = GP_PLAYING;
 		strcpy(req.arg.status.statusString, "Playing");
-		snprintf(req.arg.status.locationString, ARRAY_SIZE(req.arg.status.locationString), "%s",
-			WideCharStringToMultiByte(TheGameSpyGame->getGameName().str()).c_str());
+		strlcpy(req.arg.status.locationString, WideCharStringToMultiByte(TheGameSpyGame->getGameName().str()).c_str(),
+			ARRAY_SIZE(req.arg.status.locationString));
 		TheGameSpyBuddyMessageQueue->addRequest(req);
 	}
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DAssetManager.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DAssetManager.cpp
@@ -368,7 +368,7 @@ int W3DAssetManager::replacePrototypeTexture(RenderObjClass *robj, const char * 
 TextureClass * W3DAssetManager::Find_Texture(const char * name, const int color)
 {
 	char newname[512];
-	Munge_Texture_Name(newname, sizeof(newname), name, color);
+	Munge_Texture_Name(newname, ARRAY_SIZE(newname), name, color);
 
 	// see if we have a cached copy
 	TextureClass *newtex = TextureHash.Get(newname);
@@ -686,7 +686,7 @@ TextureClass * W3DAssetManager::Recolor_Texture_One_Time(TextureClass *texture, 
 	newtex->Get_Filter().Set_V_Addr_Mode(texture->Get_Filter().Get_V_Addr_Mode());
 
 	char newname[512];
-	Munge_Texture_Name(newname, sizeof(newname), name, color);
+	Munge_Texture_Name(newname, ARRAY_SIZE(newname), name, color);
 	newtex->Set_Texture_Name(newname);
 
 	TextureHash.Insert(newtex->Get_Texture_Name(), newtex);
@@ -734,7 +734,7 @@ RenderObjClass * W3DAssetManager::Create_Render_Obj(
 	}
 
 	char newname[512];
-	Munge_Render_Obj_Name(newname, sizeof(newname), name, scale, color, newTexture);
+	Munge_Render_Obj_Name(newname, ARRAY_SIZE(newname), name, scale, color, newTexture);
 
 	// see if we got a cached version
 	RenderObjClass *rendobj = nullptr;
@@ -774,7 +774,7 @@ RenderObjClass * W3DAssetManager::Create_Render_Obj(
 			lstrcpyn(filename, name, ((int)mesh_name) - ((int)name) + 1);
 			lstrcat(filename, ".w3d");
 		} else {
-			snprintf( filename, sizeof(filename), "%s.w3d", name);
+			snprintf( filename, ARRAY_SIZE(filename), "%s.w3d", name);
 		}
 
 		// If we can't find it, try the parent directory

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DAssetManager.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DAssetManager.cpp
@@ -266,7 +266,8 @@ RenderObjClass * W3DAssetManager::Create_Render_Obj(const char* name)
 
 //---------------------------------------------------------------------
 /** 'Generals' specific munging to encode team color and scale in model name */
-static inline void Munge_Render_Obj_Name(char *newname, const char *oldname, float scale, const int color, const char *textureName)
+static inline void Munge_Render_Obj_Name(char *newname, size_t newname_size, const char *oldname, float scale,
+	const int color, const char *textureName)
 {
 	char lower_case_name[255];
 	strlcpy(lower_case_name, oldname, ARRAY_SIZE(lower_case_name));
@@ -275,16 +276,16 @@ static inline void Munge_Render_Obj_Name(char *newname, const char *oldname, flo
 	if (!textureName)
 		textureName = "";
 
-	sprintf(newname,"#%d!%g!%s#%s",color,scale,textureName,lower_case_name);
+	snprintf(newname, newname_size, "#%d!%g!%s#%s", color, scale, textureName, lower_case_name);
 }
 
 //---------------------------------------------------------------------
-static inline void Munge_Texture_Name(char *newname, const char *oldname, const int color)
+static inline void Munge_Texture_Name(char *newname, size_t newname_size, const char *oldname, const int color)
 {
 	char lower_case_name[255];
 	strlcpy(lower_case_name, oldname, ARRAY_SIZE(lower_case_name));
 	_strlwr(lower_case_name);
-	sprintf(newname,"#%d#%s", color, lower_case_name);
+	snprintf(newname, newname_size, "#%d#%s", color, lower_case_name);
 }
 
 //---------------------------------------------------------------------
@@ -367,7 +368,7 @@ int W3DAssetManager::replacePrototypeTexture(RenderObjClass *robj, const char * 
 TextureClass * W3DAssetManager::Find_Texture(const char * name, const int color)
 {
 	char newname[512];
-	Munge_Texture_Name(newname, name, color);
+	Munge_Texture_Name(newname, sizeof(newname), name, color);
 
 	// see if we have a cached copy
 	TextureClass *newtex = TextureHash.Get(newname);
@@ -685,7 +686,7 @@ TextureClass * W3DAssetManager::Recolor_Texture_One_Time(TextureClass *texture, 
 	newtex->Get_Filter().Set_V_Addr_Mode(texture->Get_Filter().Get_V_Addr_Mode());
 
 	char newname[512];
-	Munge_Texture_Name(newname, name, color);
+	Munge_Texture_Name(newname, sizeof(newname), name, color);
 	newtex->Set_Texture_Name(newname);
 
 	TextureHash.Insert(newtex->Get_Texture_Name(), newtex);
@@ -733,7 +734,7 @@ RenderObjClass * W3DAssetManager::Create_Render_Obj(
 	}
 
 	char newname[512];
-	Munge_Render_Obj_Name(newname, name, scale, color, newTexture);
+	Munge_Render_Obj_Name(newname, sizeof(newname), name, scale, color, newTexture);
 
 	// see if we got a cached version
 	RenderObjClass *rendobj = nullptr;
@@ -773,7 +774,7 @@ RenderObjClass * W3DAssetManager::Create_Render_Obj(
 			lstrcpyn(filename, name, ((int)mesh_name) - ((int)name) + 1);
 			lstrcat(filename, ".w3d");
 		} else {
-			sprintf( filename, "%s.w3d", name);
+			snprintf( filename, sizeof(filename), "%s.w3d", name);
 		}
 
 		// If we can't find it, try the parent directory

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DMouse.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DMouse.cpp
@@ -191,7 +191,7 @@ Bool W3DMouse::loadD3DCursorTextures(MouseCursor cursor)
 
 	if (animFrames == 1)
 	{	//single animation frame without trailing numbers
-		sprintf(FrameName,"%s.tga",baseName);
+		snprintf(FrameName, sizeof(FrameName), "%s.tga", baseName);
 		cursorTextures[cursor][0]=	am->Get_Texture(FrameName);
 		m_currentD3DSurface[0]=cursorTextures[cursor][0]->Get_Surface_Level();
 		m_currentFrames = 1;
@@ -199,7 +199,7 @@ Bool W3DMouse::loadD3DCursorTextures(MouseCursor cursor)
 	else
 	for (Int i=0; i<animFrames; i++)
 	{
-		sprintf(FrameName,"%s%04d.tga",baseName,i);
+		snprintf(FrameName, sizeof(FrameName), "%s%04d.tga", baseName, i);
 		if ((cursorTextures[cursor][i]=am->Get_Texture(FrameName)) != nullptr)
 		{	m_currentD3DSurface[m_currentFrames]=cursorTextures[cursor][i]->Get_Surface_Level();
 			m_currentFrames++;

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DMouse.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DMouse.cpp
@@ -191,7 +191,7 @@ Bool W3DMouse::loadD3DCursorTextures(MouseCursor cursor)
 
 	if (animFrames == 1)
 	{	//single animation frame without trailing numbers
-		snprintf(FrameName, sizeof(FrameName), "%s.tga", baseName);
+		snprintf(FrameName, ARRAY_SIZE(FrameName), "%s.tga", baseName);
 		cursorTextures[cursor][0]=	am->Get_Texture(FrameName);
 		m_currentD3DSurface[0]=cursorTextures[cursor][0]->Get_Surface_Level();
 		m_currentFrames = 1;
@@ -199,7 +199,7 @@ Bool W3DMouse::loadD3DCursorTextures(MouseCursor cursor)
 	else
 	for (Int i=0; i<animFrames; i++)
 	{
-		snprintf(FrameName, sizeof(FrameName), "%s%04d.tga", baseName, i);
+		snprintf(FrameName, ARRAY_SIZE(FrameName), "%s%04d.tga", baseName, i);
 		if ((cursorTextures[cursor][i]=am->Get_Texture(FrameName)) != nullptr)
 		{	m_currentD3DSurface[m_currentFrames]=cursorTextures[cursor][i]->Get_Surface_Level();
 			m_currentFrames++;

--- a/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32Mouse.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32Mouse.cpp
@@ -373,10 +373,10 @@ void Win32Mouse::initCursorResources(void)
 				char resourcePath[256];
 				//Check if this is a directional cursor
 				if (m_cursorInfo[cursor].numDirections > 1)
-					snprintf(resourcePath, sizeof(resourcePath), "data\\cursors\\%s%d.ANI",
+					snprintf(resourcePath, ARRAY_SIZE(resourcePath), "data\\cursors\\%s%d.ANI",
 						m_cursorInfo[cursor].textureName.str(), direction);
 				else
-					snprintf(resourcePath, sizeof(resourcePath), "data\\cursors\\%s.ANI",
+					snprintf(resourcePath, ARRAY_SIZE(resourcePath), "data\\cursors\\%s.ANI",
 						m_cursorInfo[cursor].textureName.str());
 
 				// check for a MOD cursor.

--- a/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32Mouse.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32Mouse.cpp
@@ -373,9 +373,11 @@ void Win32Mouse::initCursorResources(void)
 				char resourcePath[256];
 				//Check if this is a directional cursor
 				if (m_cursorInfo[cursor].numDirections > 1)
-					sprintf(resourcePath,"data\\cursors\\%s%d.ANI",m_cursorInfo[cursor].textureName.str(),direction);
+					snprintf(resourcePath, sizeof(resourcePath), "data\\cursors\\%s%d.ANI",
+						m_cursorInfo[cursor].textureName.str(), direction);
 				else
-					sprintf(resourcePath,"data\\cursors\\%s.ANI",m_cursorInfo[cursor].textureName.str());
+					snprintf(resourcePath, sizeof(resourcePath), "data\\cursors\\%s.ANI",
+						m_cursorInfo[cursor].textureName.str());
 
 				// check for a MOD cursor.
 				Bool loaded = FALSE;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/assetmgr.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/assetmgr.cpp
@@ -802,7 +802,7 @@ RenderObjClass * WW3DAssetManager::Create_Render_Obj(const char * name)
 			::lstrcpyn (filename, name, ((int)mesh_name) - ((int)name) + 1);
 			::lstrcat (filename, ".w3d");
 		} else {
-			sprintf( filename, "%s.w3d", name);
+			snprintf( filename, sizeof(filename), "%s.w3d", name);
 		}
 
 		// If we can't find it, try the parent directory
@@ -980,7 +980,7 @@ HAnimClass *	WW3DAssetManager::Get_HAnim(const char * name)
 			char filename[ MAX_PATH ];
 			const char *animname = strchr( name, '.');
 			if (animname != nullptr) {
-				sprintf( filename, "%s.w3d", animname+1);
+				snprintf( filename, sizeof(filename), "%s.w3d", animname+1);
 			} else {
 				WWDEBUG_SAY(( "Animation %s has no . in the name", name ));
 				WWASSERT( 0 );
@@ -1030,7 +1030,7 @@ HTreeClass *	WW3DAssetManager::Get_HTree(const char * name)
 		AssetStatusClass::Peek_Instance()->Report_Load_On_Demand_HTree(name);
 
 		char filename[ MAX_PATH ];
-		sprintf( filename, "%s.w3d", name);
+		snprintf( filename, sizeof(filename), "%s.w3d", name);
 
 		// If we can't find it, try the parent directory
 		if ( Load_3D_Assets( filename ) == false ) {

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/assetmgr.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/assetmgr.cpp
@@ -802,7 +802,7 @@ RenderObjClass * WW3DAssetManager::Create_Render_Obj(const char * name)
 			::lstrcpyn (filename, name, ((int)mesh_name) - ((int)name) + 1);
 			::lstrcat (filename, ".w3d");
 		} else {
-			snprintf( filename, sizeof(filename), "%s.w3d", name);
+			snprintf( filename, ARRAY_SIZE(filename), "%s.w3d", name);
 		}
 
 		// If we can't find it, try the parent directory
@@ -980,7 +980,7 @@ HAnimClass *	WW3DAssetManager::Get_HAnim(const char * name)
 			char filename[ MAX_PATH ];
 			const char *animname = strchr( name, '.');
 			if (animname != nullptr) {
-				snprintf( filename, sizeof(filename), "%s.w3d", animname+1);
+				snprintf( filename, ARRAY_SIZE(filename), "%s.w3d", animname+1);
 			} else {
 				WWDEBUG_SAY(( "Animation %s has no . in the name", name ));
 				WWASSERT( 0 );
@@ -1030,7 +1030,7 @@ HTreeClass *	WW3DAssetManager::Get_HTree(const char * name)
 		AssetStatusClass::Peek_Instance()->Report_Load_On_Demand_HTree(name);
 
 		char filename[ MAX_PATH ];
-		snprintf( filename, sizeof(filename), "%s.w3d", name);
+		snprintf( filename, ARRAY_SIZE(filename), "%s.w3d", name);
 
 		// If we can't find it, try the parent directory
 		if ( Load_3D_Assets( filename ) == false ) {

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/vertmaterial.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/vertmaterial.cpp
@@ -554,7 +554,7 @@ void VertexMaterialClass::Parse_Mapping_Args(const W3dVertexMaterialStruct & vma
 		int mapping0_arg_len = strlen(mapping0_arg_buffer);
 
 		char *extended_arg_buffer = MSGW3DNEWARRAY("VertexMaterialClassTemp") char[mapping0_arg_len + 10];
-		sprintf(extended_arg_buffer, "[Args]\n%s", mapping0_arg_buffer);
+		snprintf(extended_arg_buffer, mapping0_arg_len + 10, "[Args]\n%s", mapping0_arg_buffer);
 		mapping0_arg_len = strlen(extended_arg_buffer) + 1;
 
 		BufferStraw map_arg_buf_straw((void *)extended_arg_buffer, mapping0_arg_len);
@@ -570,7 +570,7 @@ void VertexMaterialClass::Parse_Mapping_Args(const W3dVertexMaterialStruct & vma
 		int mapping1_arg_len = strlen(mapping1_arg_buffer);
 
 		char *extended_arg_buffer = MSGW3DNEWARRAY("VertexMaterialClassTemp") char[mapping1_arg_len + 20];
-		sprintf(extended_arg_buffer, "[Args]\n%s", mapping1_arg_buffer);
+		snprintf(extended_arg_buffer, mapping1_arg_len + 20, "[Args]\n%s", mapping1_arg_buffer);
 		mapping1_arg_len = strlen(extended_arg_buffer) + 1;
 
 		BufferStraw map_arg_buf_straw((void *)extended_arg_buffer, mapping1_arg_len);

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
@@ -1326,7 +1326,7 @@ void WW3D::Make_Screen_Shot( const char * filename_base , const float gamma, con
 
 	bool done = false;
 	while (!done) {
-		snprintf( filename, sizeof(filename), "%s%.2d.%s", filename_base, frame_number++, ext);
+		snprintf( filename, ARRAY_SIZE(filename), "%s%.2d.%s", filename_base, frame_number++, ext);
 		FileClass*file=_TheFileFactory->Get_File( filename );
 		if ( file ) {
 			file->Open();

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
@@ -1326,7 +1326,7 @@ void WW3D::Make_Screen_Shot( const char * filename_base , const float gamma, con
 
 	bool done = false;
 	while (!done) {
-		sprintf( filename, "%s%.2d.%s", filename_base, frame_number++, ext);
+		snprintf( filename, sizeof(filename), "%s%.2d.%s", filename_base, frame_number++, ext);
 		FileClass*file=_TheFileFactory->Get_File( filename );
 		if ( file ) {
 			file->Open();


### PR DESCRIPTION
- Relates to: #1518

This PR replaces `sprintf` with `snprintf` in cases where variable-length inputs (unknown at compile time) are formatted into fixed-size buffers, which may lead to stack buffer overflows. This does not include code in Tools. 

Note that there are many more (safer) `sprintf` cases still remaining so this does not resolve the linked issue.

# Todo

- [x] Replicate to Generals