### PR TITLE
fix(intro): Fix order of Display Update and Draw in intro loop

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -583,8 +583,8 @@ void GameClient::update( void )
 	if(TheGlobalData->m_playIntro || TheGlobalData->m_afterIntro)
 	{
 		// redraw all views, update the GUI
-		TheDisplay->DRAW();
 		TheDisplay->UPDATE();
+		TheDisplay->DRAW();
 		return;
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -621,8 +621,8 @@ void GameClient::update( void )
 	if(TheGlobalData->m_playIntro || TheGlobalData->m_afterIntro)
 	{
 		// redraw all views, update the GUI
-		TheDisplay->DRAW();
 		TheDisplay->UPDATE();
+		TheDisplay->DRAW();
 		return;
 	}
 


### PR DESCRIPTION
This change fixes the order of Display Update and Draw in intro loop.

This matches the Update and Draw order in the regular client update loop.

I was unable to observe any consequences for this.