### PR TITLE
fix(display): Fix VideoBuffer format selection in W3DDisplay::createVideoBuffer()

### DIFF
--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -2688,8 +2688,8 @@ VideoBuffer*	W3DDisplay::createVideoBuffer( void )
 			return nullptr;
 		}
 	}
-	// on low mem machines, render every video in 16bit except for the EA Logo movie
-	if(!TheGlobalData->m_playIntro )//&& TheGameLODManager && (!TheGameLODManager->didMemPass() || W3DShaderManager::getChipset() == DC_GEFORCE2))
+	// on low mem machines, render every video in 16bit
+	if (TheGameLODManager && (!TheGameLODManager->didMemPass() || W3DShaderManager::getChipset() == DC_GEFORCE2))
 		format = VideoBuffer::TYPE_R5G6B5;
 
 	W3DVideoBuffer *buffer = NEW W3DVideoBuffer( format );

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -2797,8 +2797,8 @@ VideoBuffer*	W3DDisplay::createVideoBuffer( void )
 			return nullptr;
 		}
 	}
-	// on low mem machines, render every video in 16bit except for the EA Logo movie
-	if(!TheGlobalData->m_playIntro )//&& TheGameLODManager && (!TheGameLODManager->didMemPass() || W3DShaderManager::getChipset() == DC_GEFORCE2))
+	// on low mem machines, render every video in 16bit
+	if (TheGameLODManager && (!TheGameLODManager->didMemPass() || W3DShaderManager::getChipset() == DC_GEFORCE2))
 		format = VideoBuffer::TYPE_R5G6B5;
 
 	W3DVideoBuffer *buffer = NEW W3DVideoBuffer( format );


### PR DESCRIPTION
This change fixes the VideoBuffer format selection in `W3DDisplay::createVideoBuffer()`.

Every video that is not the Intro would pick `VideoBuffer::TYPE_R5G6B5`, which makes no sense.

I restored this to the previous code. No user facing change was observed. All the videos render as usual.