### PR TITLE
feat(intro): Add short Intro Logo for The Super Hackers team

### DIFF
--- a/Core/GameEngine/CMakeLists.txt
+++ b/Core/GameEngine/CMakeLists.txt
@@ -197,6 +197,7 @@ set(GAMEENGINE_SRC
     Include/GameClient/Image.h
     Include/GameClient/IMEManager.h
 #    Include/GameClient/InGameUI.h
+    Include/GameClient/Intro.h
     Include/GameClient/Keyboard.h
 #    Include/GameClient/KeyDefs.h
     Include/GameClient/LanguageFilter.h
@@ -806,6 +807,7 @@ set(GAMEENGINE_SRC
 #    Source/GameClient/InGameUI.cpp
     Source/GameClient/Input/Keyboard.cpp
     Source/GameClient/Input/Mouse.cpp
+    Source/GameClient/Intro.cpp
     Source/GameClient/LanguageFilter.cpp
     Source/GameClient/Line2D.cpp
     Source/GameClient/MapUtil.cpp

--- a/Core/GameEngine/Include/GameClient/Display.h
+++ b/Core/GameEngine/Include/GameClient/Display.h
@@ -153,7 +153,6 @@ public:
 													Int endX, Int endY ) = 0;
 
 	/// FullScreen video playback
-	virtual void playLogoMovie( AsciiString movieName, Int minMovieLength, Int minCopyrightLength );
 	virtual void playMovie( AsciiString movieName );
 	virtual void stopMovie();
 	virtual Bool isMoviePlaying();
@@ -216,11 +215,6 @@ protected:
 	Real	m_letterBoxFadeLevel;	///<tracks the current alpha level for fading letter-boxed mode in/out.
 	Bool	m_letterBoxEnabled;		///<current state of letterbox
 	UnsignedInt	m_letterBoxFadeStartTime;		///< time of letterbox fade start
-	Int		m_movieHoldTime;									///< time that we hold on the last frame of the movie
-	Int		m_copyrightHoldTime;							///< time that the copyright must be on the screen
-	UnsignedInt m_elapsedMovieTime;					///< used to make sure we show the stuff long enough
-	UnsignedInt m_elapsedCopywriteTime;			///< Hold on the last frame until both have expired
-	DisplayString *m_copyrightDisplayString;///< this'll hold the display string
 };
 
 // the singleton

--- a/Core/GameEngine/Include/GameClient/Intro.h
+++ b/Core/GameEngine/Include/GameClient/Intro.h
@@ -26,7 +26,6 @@ class Intro
 		IntroState_EALogoMovie,
 		IntroState_SizzleMovieWait,
 		IntroState_SizzleMovie,
-		IntroState_LegalPage,
 		IntroState_Done,
 	};
 
@@ -44,7 +43,6 @@ private:
 
 	void doEALogoMovie();
 	void doSizzleMovie();
-	void doLegalPage();
 	void doPostIntro();
 	void doAsyncWait(UnsignedInt milliseconds);
 

--- a/Core/GameEngine/Include/GameClient/Intro.h
+++ b/Core/GameEngine/Include/GameClient/Intro.h
@@ -1,0 +1,35 @@
+/*
+**	Command & Conquer Generals Zero Hour(tm)
+**	Copyright 2026 TheSuperHackers
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+class Intro
+{
+public:
+
+	Intro();
+
+	void update();
+
+	Bool isDone() const { return m_done; }
+
+private:
+
+	Bool m_playSizzle;
+	Bool m_done;
+};

--- a/Core/GameEngine/Include/GameClient/Intro.h
+++ b/Core/GameEngine/Include/GameClient/Intro.h
@@ -24,6 +24,7 @@ class Intro
 	{
 		IntroState_Start,
 		IntroState_EALogoMovie,
+		IntroState_SizzleMovieWait,
 		IntroState_SizzleMovie,
 		IntroState_LegalPage,
 		IntroState_Done,
@@ -45,7 +46,9 @@ private:
 	void doSizzleMovie();
 	void doLegalPage();
 	void doPostIntro();
+	void doAsyncWait(UnsignedInt milliseconds);
 
 	IntroState m_currentState;
 	UnsignedInt m_allowedStateFlags;
+	UnsignedInt m_waitUntilMs;
 };

--- a/Core/GameEngine/Include/GameClient/Intro.h
+++ b/Core/GameEngine/Include/GameClient/Intro.h
@@ -20,16 +20,32 @@
 
 class Intro
 {
+	enum IntroState
+	{
+		IntroState_Start,
+		IntroState_EALogoMovie,
+		IntroState_SizzleMovie,
+		IntroState_LegalPage,
+		IntroState_Done,
+	};
+
 public:
 
 	Intro();
 
 	void update();
 
-	Bool isDone() const { return m_done; }
+	Bool isDone() const { return m_currentState == IntroState_Done; }
 
 private:
 
-	Bool m_playSizzle;
-	Bool m_done;
+	void enterNextState();
+
+	void doEALogoMovie();
+	void doSizzleMovie();
+	void doLegalPage();
+	void doPostIntro();
+
+	IntroState m_currentState;
+	UnsignedInt m_allowedStateFlags;
 };

--- a/Core/GameEngine/Include/GameClient/Intro.h
+++ b/Core/GameEngine/Include/GameClient/Intro.h
@@ -18,15 +18,40 @@
 
 #pragma once
 
+#include <vector>
+
+class DisplayString;
+class Image;
+
 class Intro
 {
 	enum IntroState
 	{
 		IntroState_Start,
 		IntroState_EALogoMovie,
+		IntroState_TheSuperHackersWait,
+		IntroState_TheSuperHackers,
 		IntroState_SizzleMovieWait,
 		IntroState_SizzleMovie,
 		IntroState_Done,
+	};
+
+	struct DisplayEntity
+	{
+		DisplayEntity()
+			: displayString(nullptr)
+			, image(nullptr)
+			, sizeX(10)
+			, sizeY(10)
+			, centerOffsetY(0)
+		{}
+		~DisplayEntity();
+
+		DisplayString* displayString; // is owner
+		const Image* image;
+		Int sizeX;
+		Int sizeY;
+		Int centerOffsetY;
 	};
 
 public:
@@ -34,6 +59,7 @@ public:
 	Intro();
 
 	void update();
+	void draw();
 
 	Bool isDone() const { return m_currentState == IntroState_Done; }
 
@@ -42,11 +68,19 @@ private:
 	void enterNextState();
 
 	void doEALogoMovie();
+	void doTheSuperHackers();
 	void doSizzleMovie();
 	void doPostIntro();
 	void doAsyncWait(UnsignedInt milliseconds);
 
+	void drawDisplayEntities();
+
+private:
+
 	IntroState m_currentState;
 	UnsignedInt m_allowedStateFlags;
 	UnsignedInt m_waitUntilMs;
+	UnicodeString m_unicodeStrings[1];
+	std::vector<DisplayEntity> m_displayEntities;
+	Real m_fadeValue;
 };

--- a/Core/GameEngine/Source/GameClient/Display.cpp
+++ b/Core/GameEngine/Source/GameClient/Display.cpp
@@ -58,11 +58,6 @@ Display::Display()
 	m_cinematicText = AsciiString::TheEmptyString;
 	m_cinematicFont = nullptr;
 	m_cinematicTextFrames = 0;
-	m_movieHoldTime	= -1;
-	m_copyrightHoldTime = -1;
-	m_elapsedMovieTime = 0;
-	m_elapsedCopywriteTime = 0;
-	m_copyrightDisplayString = nullptr;
 
 	m_currentlyPlayingMovie.clear();
 	m_letterBoxFadeStartTime = 0;
@@ -201,41 +196,6 @@ void Display::setHeight( UnsignedInt height )
 }
 
 //============================================================================
-// Display::playLogoMovie
-// minMovieLength is in milliseconds
-// minCopyrightLength
-//============================================================================
-
-void Display::playLogoMovie( AsciiString movieName, Int minMovieLength, Int minCopyrightLength )
-{
-
-	stopMovie();
-
-	m_videoStream = TheVideoPlayer->open( movieName );
-
-	if ( m_videoStream == nullptr )
-	{
-		return;
-	}
-
-	m_currentlyPlayingMovie = movieName;
-	m_movieHoldTime = minMovieLength;
-	m_copyrightHoldTime = minCopyrightLength;
-	m_elapsedMovieTime = timeGetTime();  // we're using time get time because legal wants actual "Seconds"
-
-	m_videoBuffer = createVideoBuffer();
-	if (	m_videoBuffer == nullptr ||
-				!m_videoBuffer->allocate(	m_videoStream->width(),
-													m_videoStream->height())
-		)
-	{
-		stopMovie();
-		return;
-	}
-
-}
-
-//============================================================================
 // Display::playMovie
 //============================================================================
 
@@ -286,13 +246,6 @@ void Display::stopMovie()
 		//TheScriptEngine->notifyOfCompletedVideo(m_currentlyPlayingMovie); // Removing this sync-error cause MDC
 		m_currentlyPlayingMovie = AsciiString::TheEmptyString;
 	}
-	if(m_copyrightDisplayString)
-	{
-		TheDisplayStringManager->freeDisplayString(m_copyrightDisplayString);
-		m_copyrightDisplayString = nullptr;
-	}
-	m_copyrightHoldTime = -1;
-	m_movieHoldTime = -1;
 }
 
 //============================================================================
@@ -308,34 +261,8 @@ void Display::update()
 			m_videoStream->frameDecompress();
 			m_videoStream->frameRender( m_videoBuffer );
 			if( m_videoStream->frameIndex() != m_videoStream->frameCount() - 1)
-				m_videoStream->frameNext();
-			else if( m_copyrightHoldTime >= 0 ||m_movieHoldTime >= 0 )
 			{
-				if( m_elapsedCopywriteTime == 0 && m_elapsedCopywriteTime >= 0)
-				{
-					//display the copyrighttext;
-					deleteInstance(m_copyrightDisplayString);
-					m_copyrightDisplayString = TheDisplayStringManager->newDisplayString();
-					m_copyrightDisplayString->setText(TheGameText->fetch("GUI:EACopyright"));
-					if (TheGlobalLanguageData && TheGlobalLanguageData->m_copyrightFont.name.isNotEmpty())
-					{	FontDesc	*fontdesc=&TheGlobalLanguageData->m_copyrightFont;
-						m_copyrightDisplayString->setFont(TheFontLibrary->getFont(fontdesc->name,
-							TheGlobalLanguageData->adjustFontSize(fontdesc->size),
-							fontdesc->bold));
-					}
-					else
-						m_copyrightDisplayString->setFont(TheFontLibrary->getFont("Courier",
-						TheGlobalLanguageData->adjustFontSize(12), TRUE));
-					m_elapsedCopywriteTime = timeGetTime();
-				}
-				if(m_movieHoldTime + m_elapsedMovieTime < timeGetTime() &&
-						m_copyrightHoldTime + m_elapsedCopywriteTime < timeGetTime())
-				{
-					m_movieHoldTime = -1;
-					m_elapsedMovieTime = 0;
-					m_elapsedCopywriteTime = 0;
-					m_copyrightHoldTime = -1;
-				}
+				m_videoStream->frameNext();
 			}
 			else
 			{

--- a/Core/GameEngine/Source/GameClient/Intro.cpp
+++ b/Core/GameEngine/Source/GameClient/Intro.cpp
@@ -1,0 +1,95 @@
+/*
+**	Command & Conquer Generals Zero Hour(tm)
+**	Copyright 2026 TheSuperHackers
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "PreRTS.h"
+#include "GameClient/Intro.h"
+
+#include "Common/GameLOD.h"
+
+#include "GameClient/Display.h"
+#include "GameClient/GameWindowManager.h"
+
+#include "GameLogic/FPUControl.h"
+
+
+Intro::Intro()
+	: m_playSizzle(false)
+	, m_done(false)
+{
+}
+
+void Intro::update()
+{
+	// We need to show the movie first.
+	if(TheGlobalData->m_playIntro && !TheDisplay->isMoviePlaying())
+	{
+		if(TheGameLODManager && TheGameLODManager->didMemPass())
+			TheDisplay->playLogoMovie("EALogoMovie", 5000, 3000);
+		else
+			TheDisplay->playLogoMovie("EALogoMovie640", 5000, 3000);
+		TheWritableGlobalData->m_playIntro = FALSE;
+		TheWritableGlobalData->m_afterIntro = TRUE;
+		m_playSizzle = TRUE;
+	}
+
+	// We must show the movie first and then we can display the shell.
+	if(TheGlobalData->m_afterIntro && !TheDisplay->isMoviePlaying())
+	{
+		if( m_playSizzle && TheGlobalData->m_playSizzle )
+		{
+			TheWritableGlobalData->m_allowExitOutOfMovies = TRUE;
+			if(TheGameLODManager && TheGameLODManager->didMemPass())
+				TheDisplay->playMovie("Sizzle");
+			else
+				TheDisplay->playMovie("Sizzle640");
+			m_playSizzle = FALSE;
+		}
+		else
+		{
+			TheWritableGlobalData->m_breakTheMovie = TRUE;
+			TheWritableGlobalData->m_allowExitOutOfMovies = TRUE;
+
+			if(TheGameLODManager && !TheGameLODManager->didMemPass())
+			{
+				TheWritableGlobalData->m_breakTheMovie = FALSE;
+
+				WindowLayout *legal = TheWindowManager->winCreateLayout("Menus/LegalPage.wnd");
+				if(legal)
+				{
+					legal->hide(FALSE);
+					legal->bringForward();
+					Int beginTime = timeGetTime();
+					while(beginTime + 4000 > timeGetTime() )
+					{
+						TheWindowManager->update();
+						// redraw all views, update the GUI
+						TheDisplay->draw();
+						Sleep(100);
+					}
+					setFPMode();
+					legal->destroyWindows();
+					deleteInstance(legal);
+				}
+				TheWritableGlobalData->m_breakTheMovie = TRUE;
+			}
+
+			TheWritableGlobalData->m_afterIntro = FALSE;
+			m_done = TRUE;
+		}
+	}
+}

--- a/Core/GameEngine/Source/GameClient/Intro.cpp
+++ b/Core/GameEngine/Source/GameClient/Intro.cpp
@@ -28,68 +28,98 @@
 
 
 Intro::Intro()
-	: m_playSizzle(false)
-	, m_done(false)
+	: m_currentState(IntroState_Start)
+	, m_allowedStateFlags(0)
 {
+	if (TheGlobalData->m_playIntro)
+	{
+		m_allowedStateFlags |= 1u << IntroState_EALogoMovie;
+	}
+
+	if (TheGlobalData->m_playSizzle)
+	{
+		m_allowedStateFlags |= 1u << IntroState_SizzleMovie;
+	}
+
+	if (TheGameLODManager && !TheGameLODManager->didMemPass())
+	{
+		m_allowedStateFlags |= 1u << IntroState_LegalPage;
+	}
+}
+
+void Intro::enterNextState()
+{
+	Int currentState = m_currentState;
+	while (currentState < IntroState_Done)
+	{
+		++currentState;
+		if (m_allowedStateFlags & (1u << currentState))
+			break;
+	}
+
+	m_currentState = static_cast<IntroState>(currentState);
 }
 
 void Intro::update()
 {
-	// We need to show the movie first.
-	if(TheGlobalData->m_playIntro && !TheDisplay->isMoviePlaying())
+	if (!TheDisplay->isMoviePlaying())
 	{
-		if(TheGameLODManager && TheGameLODManager->didMemPass())
-			TheDisplay->playLogoMovie("EALogoMovie", 5000, 3000);
-		else
-			TheDisplay->playLogoMovie("EALogoMovie640", 5000, 3000);
-		TheWritableGlobalData->m_playIntro = FALSE;
-		TheWritableGlobalData->m_afterIntro = TRUE;
-		m_playSizzle = TRUE;
-	}
+		enterNextState();
 
-	// We must show the movie first and then we can display the shell.
-	if(TheGlobalData->m_afterIntro && !TheDisplay->isMoviePlaying())
-	{
-		if( m_playSizzle && TheGlobalData->m_playSizzle )
+		switch (m_currentState)
 		{
-			TheWritableGlobalData->m_allowExitOutOfMovies = TRUE;
-			if(TheGameLODManager && TheGameLODManager->didMemPass())
-				TheDisplay->playMovie("Sizzle");
-			else
-				TheDisplay->playMovie("Sizzle640");
-			m_playSizzle = FALSE;
-		}
-		else
-		{
-			TheWritableGlobalData->m_breakTheMovie = TRUE;
-			TheWritableGlobalData->m_allowExitOutOfMovies = TRUE;
-
-			if(TheGameLODManager && !TheGameLODManager->didMemPass())
-			{
-				TheWritableGlobalData->m_breakTheMovie = FALSE;
-
-				WindowLayout *legal = TheWindowManager->winCreateLayout("Menus/LegalPage.wnd");
-				if(legal)
-				{
-					legal->hide(FALSE);
-					legal->bringForward();
-					Int beginTime = timeGetTime();
-					while(beginTime + 4000 > timeGetTime() )
-					{
-						TheWindowManager->update();
-						// redraw all views, update the GUI
-						TheDisplay->draw();
-						Sleep(100);
-					}
-					setFPMode();
-					legal->destroyWindows();
-					deleteInstance(legal);
-				}
-				TheWritableGlobalData->m_breakTheMovie = TRUE;
-			}
-
-			TheWritableGlobalData->m_afterIntro = FALSE;
-			m_done = TRUE;
+		case IntroState_EALogoMovie: doEALogoMovie(); break;
+		case IntroState_SizzleMovie: doSizzleMovie(); break;
+		case IntroState_LegalPage: doLegalPage(); break;
+		case IntroState_Done: doPostIntro(); break;
 		}
 	}
+}
+
+void Intro::doEALogoMovie()
+{
+	TheWritableGlobalData->m_allowExitOutOfMovies = FALSE;
+	if (TheGameLODManager && TheGameLODManager->didMemPass())
+		TheDisplay->playLogoMovie("EALogoMovie", 5000, 3000);
+	else
+		TheDisplay->playLogoMovie("EALogoMovie640", 5000, 3000);
+}
+
+void Intro::doSizzleMovie()
+{
+	TheWritableGlobalData->m_allowExitOutOfMovies = TRUE;
+	if (TheGameLODManager && TheGameLODManager->didMemPass())
+		TheDisplay->playMovie("Sizzle");
+	else
+		TheDisplay->playMovie("Sizzle640");
+}
+
+
+void Intro::doLegalPage()
+{
+	TheWritableGlobalData->m_breakTheMovie = FALSE;
+	WindowLayout *legal = TheWindowManager->winCreateLayout("Menus/LegalPage.wnd");
+	if (legal)
+	{
+		legal->hide(FALSE);
+		legal->bringForward();
+		Int beginTime = timeGetTime();
+		while (beginTime + 4000 > timeGetTime() )
+		{
+			TheWindowManager->update();
+			// redraw all views, update the GUI
+			TheDisplay->draw();
+			Sleep(100);
+		}
+		setFPMode();
+		legal->destroyWindows();
+		deleteInstance(legal);
+	}
+	TheWritableGlobalData->m_breakTheMovie = TRUE;
+}
+
+void Intro::doPostIntro()
+{
+	TheWritableGlobalData->m_breakTheMovie = TRUE;
+	TheWritableGlobalData->m_allowExitOutOfMovies = TRUE;
 }

--- a/Core/GameEngine/Source/GameClient/Intro.cpp
+++ b/Core/GameEngine/Source/GameClient/Intro.cpp
@@ -30,6 +30,7 @@
 Intro::Intro()
 	: m_currentState(IntroState_Start)
 	, m_allowedStateFlags(0)
+	, m_waitUntilMs(0)
 {
 	if (TheGlobalData->m_playIntro)
 	{
@@ -38,6 +39,9 @@ Intro::Intro()
 
 	if (TheGlobalData->m_playSizzle)
 	{
+		if (TheGlobalData->m_playIntro)
+			m_allowedStateFlags |= 1u << IntroState_SizzleMovieWait;
+
 		m_allowedStateFlags |= 1u << IntroState_SizzleMovie;
 	}
 
@@ -62,13 +66,14 @@ void Intro::enterNextState()
 
 void Intro::update()
 {
-	if (!TheDisplay->isMoviePlaying())
+	if (!TheDisplay->isMoviePlaying() && m_waitUntilMs < timeGetTime())
 	{
 		enterNextState();
 
 		switch (m_currentState)
 		{
 		case IntroState_EALogoMovie: doEALogoMovie(); break;
+		case IntroState_SizzleMovieWait: doAsyncWait(1000); break;
 		case IntroState_SizzleMovie: doSizzleMovie(); break;
 		case IntroState_LegalPage: doLegalPage(); break;
 		case IntroState_Done: doPostIntro(); break;
@@ -80,9 +85,9 @@ void Intro::doEALogoMovie()
 {
 	TheWritableGlobalData->m_allowExitOutOfMovies = FALSE;
 	if (TheGameLODManager && TheGameLODManager->didMemPass())
-		TheDisplay->playLogoMovie("EALogoMovie", 5000, 3000);
+		TheDisplay->playMovie("EALogoMovie");
 	else
-		TheDisplay->playLogoMovie("EALogoMovie640", 5000, 3000);
+		TheDisplay->playMovie("EALogoMovie640");
 }
 
 void Intro::doSizzleMovie()
@@ -122,4 +127,9 @@ void Intro::doPostIntro()
 {
 	TheWritableGlobalData->m_breakTheMovie = TRUE;
 	TheWritableGlobalData->m_allowExitOutOfMovies = TRUE;
+}
+
+void Intro::doAsyncWait(UnsignedInt milliseconds)
+{
+	m_waitUntilMs = timeGetTime() + milliseconds;
 }

--- a/Core/GameEngine/Source/GameClient/Intro.cpp
+++ b/Core/GameEngine/Source/GameClient/Intro.cpp
@@ -19,20 +19,35 @@
 #include "PreRTS.h"
 #include "GameClient/Intro.h"
 
+#include "Common/FramePacer.h"
 #include "Common/GameLOD.h"
 
 #include "GameClient/Display.h"
+#include "GameClient/DisplayStringManager.h"
+#include "GameClient/GameText.h"
 #include "GameClient/GameWindowManager.h"
+#include "GameClient/GlobalLanguage.h"
+#include "GameClient/Image.h"
 
+
+Intro::DisplayEntity::~DisplayEntity()
+{
+	TheDisplayStringManager->freeDisplayString(displayString);
+}
 
 Intro::Intro()
 	: m_currentState(IntroState_Start)
 	, m_allowedStateFlags(0)
 	, m_waitUntilMs(0)
+	, m_fadeValue(0.0f)
 {
 	if (TheGlobalData->m_playIntro)
 	{
+		// Please be kind and do not remove the EA logo movie. This game was built by EA. It lasts just 3 seconds.
 		m_allowedStateFlags |= 1u << IntroState_EALogoMovie;
+		// Please be kind and do not remove the custom logo screen when building on top of the work of The Super Hackers.
+		m_allowedStateFlags |= 1u << IntroState_TheSuperHackersWait;
+		m_allowedStateFlags |= 1u << IntroState_TheSuperHackers;
 	}
 
 	if (TheGlobalData->m_playSizzle)
@@ -66,10 +81,20 @@ void Intro::update()
 		switch (m_currentState)
 		{
 		case IntroState_EALogoMovie: doEALogoMovie(); break;
+		case IntroState_TheSuperHackersWait: doAsyncWait(800); break;
+		case IntroState_TheSuperHackers: doTheSuperHackers(); break;
 		case IntroState_SizzleMovieWait: doAsyncWait(1000); break;
 		case IntroState_SizzleMovie: doSizzleMovie(); break;
 		case IntroState_Done: doPostIntro(); break;
 		}
+	}
+}
+
+void Intro::draw()
+{
+	switch (m_currentState)
+	{
+		case IntroState_TheSuperHackers: drawDisplayEntities(); break;
 	}
 }
 
@@ -80,6 +105,118 @@ void Intro::doEALogoMovie()
 		TheDisplay->playMovie("EALogoMovie");
 	else
 		TheDisplay->playMovie("EALogoMovie640");
+}
+
+struct DisplaySetting
+{
+	DisplaySetting()
+		: imageName(nullptr)
+		, font("Arial")
+		, text(nullptr)
+		, centerOffsetY(0)
+		, sizeX(10)
+		, sizeY(10)
+		, bold(false)
+		, centered(false)
+	{}
+
+	const Char* imageName;
+	const Char* font;
+	const WideChar* text;
+	Int centerOffsetY;
+	Int sizeX;
+	Int sizeY;
+	Bool bold;
+	Bool centered;
+};
+
+void Intro::doTheSuperHackers()
+{
+	std::vector<DisplaySetting> settings;
+
+	const Real resolutionScale = GlobalLanguage::getResolutionFontSizeScale(GlobalLanguage::ResolutionFontSizeMethod_Strict);
+	const Int screenWidth = TheDisplay->getWidth();
+	const Int screenHeight = TheDisplay->getHeight();
+	Int centerOffsetY = -(screenHeight * 0.05f);
+
+	// "Consolas" is Windows Vista native, can be installed in 2000, XP
+
+	{
+		// Pretext
+		m_unicodeStrings[0] = TheGameText->FETCH_OR_SUBSTITUTE("CREDITS:CustomIntroPretext", L"Game improved by");
+		DisplaySetting setting;
+		setting.font = "Consolas";
+		setting.text = m_unicodeStrings[0].str();
+		setting.sizeY = 16;
+		centerOffsetY -= setting.sizeY * resolutionScale * 2;
+		setting.centerOffsetY = centerOffsetY;
+		centerOffsetY += setting.sizeY * resolutionScale * 2;
+		setting.bold = false;
+		setting.centered = true;
+		settings.push_back(setting);
+	}
+	{
+		// Team name
+		DisplaySetting setting;
+		setting.font = "Consolas";
+		setting.text = L"THE SUPER HACKERS";
+		setting.sizeY = 32;
+		setting.centerOffsetY = centerOffsetY;
+		centerOffsetY += setting.sizeY * resolutionScale * 2;
+		setting.bold = true;
+		setting.centered = true;
+		settings.push_back(setting);
+	}
+	if constexpr (false)
+	{
+		// Website
+		DisplaySetting setting;
+		setting.font = "Consolas";
+		setting.text = L"thesuperhackers.org";
+		setting.sizeY = 16;
+		setting.centerOffsetY = centerOffsetY;
+		centerOffsetY += setting.sizeY * resolutionScale * 2;
+		setting.bold = false;
+		setting.centered = true;
+		settings.push_back(setting);
+	}
+	{
+		// China Hacker image
+		DisplaySetting setting;
+		setting.imageName = "SNHacker2_L";
+		setting.centerOffsetY = centerOffsetY;
+		setting.sizeX = (Int)(122 * 0.50f);
+		setting.sizeY = (Int)(98 * 0.50f);
+		settings.push_back(setting);
+	}
+
+	m_displayEntities.resize(settings.size());
+
+	for (size_t i = 0; i < m_displayEntities.size(); ++i)
+	{
+		const DisplaySetting& s = settings[i];
+		DisplayEntity& e = m_displayEntities[i];
+		e.sizeX = Int(s.sizeX * resolutionScale);
+		e.sizeY = Int(s.sizeY * resolutionScale);
+
+		if (s.text != nullptr)
+		{
+			e.displayString = TheDisplayStringManager->newDisplayString();
+			e.displayString->setText(s.text);
+			e.displayString->setFont(TheFontLibrary->getFont(s.font, e.sizeY, s.bold));
+			e.displayString->setWordWrap(screenWidth);
+		}
+
+		if (s.imageName != nullptr)
+		{
+			e.image = TheMappedImageCollection->findImageByName(s.imageName);
+		}
+
+		e.centerOffsetY = s.centerOffsetY;
+	}
+
+	doAsyncWait(3000);
+	m_fadeValue = 0.0f;
 }
 
 void Intro::doSizzleMovie()
@@ -100,4 +237,60 @@ void Intro::doPostIntro()
 void Intro::doAsyncWait(UnsignedInt milliseconds)
 {
 	m_waitUntilMs = timeGetTime() + milliseconds;
+}
+
+void Intro::drawDisplayEntities()
+{
+	const Real alpha = 255.0f * clamp(0.0f, m_fadeValue, 1.0f);
+	const Color color = GameMakeColor(255, 255, 255, (Int)alpha);
+	const Color dropColor = GameMakeColor(255, 255, 255, 0);
+	const Int screenWidth = TheDisplay->getWidth();
+	const Int screenHeight = TheDisplay->getHeight();
+
+	for (size_t i = 0; i < m_displayEntities.size(); ++i)
+	{
+		DisplayEntity& e = m_displayEntities[i];
+
+		if (e.displayString != nullptr)
+		{
+			ICoord2D pos;
+			e.displayString->getSize(&pos.x, &pos.y);
+			pos.x = (screenWidth / 2) - (pos.x / 2);
+			pos.y = (screenHeight / 2) + e.centerOffsetY;
+			e.displayString->draw(pos.x, pos.y, color, dropColor);
+		}
+
+		if (e.image != nullptr)
+		{
+			IRegion2D region;
+			region.lo.x = (screenWidth / 2) - (e.sizeX / 2);
+			region.hi.x = (screenWidth / 2) + (e.sizeX / 2);
+			region.lo.y = (screenHeight / 2) + e.centerOffsetY;
+			region.hi.y = region.lo.y + e.sizeY;
+			TheDisplay->drawImage(e.image, region.lo.x, region.lo.y, region.hi.x, region.hi.y, color);
+		}
+	}
+
+	// Note: Applies fade after drawing the text once because originally the text takes one draw update to 'settle in' first.
+
+	constexpr const Real fadeInMs = 500.f;
+	constexpr const Real fadeOutMs = 125.f;
+
+	if (timeGetTime() + fadeOutMs > m_waitUntilMs)
+	{
+		if (m_fadeValue > 0.0f)
+		{
+			// Fade out
+			m_fadeValue -= TheFramePacer->getUpdateTime() * (1000.f / fadeOutMs);
+			if (m_fadeValue < 0.0f)
+				m_fadeValue = 0.0f;
+		}
+	}
+	else if (m_fadeValue < 1.0f)
+	{
+		// Fade in
+		m_fadeValue += TheFramePacer->getUpdateTime() * (1000.f / fadeInMs);
+		if (m_fadeValue > 1.0f)
+			m_fadeValue = 1.0f;
+	}
 }

--- a/Core/GameEngine/Source/GameClient/Intro.cpp
+++ b/Core/GameEngine/Source/GameClient/Intro.cpp
@@ -24,8 +24,6 @@
 #include "GameClient/Display.h"
 #include "GameClient/GameWindowManager.h"
 
-#include "GameLogic/FPUControl.h"
-
 
 Intro::Intro()
 	: m_currentState(IntroState_Start)
@@ -43,11 +41,6 @@ Intro::Intro()
 			m_allowedStateFlags |= 1u << IntroState_SizzleMovieWait;
 
 		m_allowedStateFlags |= 1u << IntroState_SizzleMovie;
-	}
-
-	if (TheGameLODManager && !TheGameLODManager->didMemPass())
-	{
-		m_allowedStateFlags |= 1u << IntroState_LegalPage;
 	}
 }
 
@@ -75,7 +68,6 @@ void Intro::update()
 		case IntroState_EALogoMovie: doEALogoMovie(); break;
 		case IntroState_SizzleMovieWait: doAsyncWait(1000); break;
 		case IntroState_SizzleMovie: doSizzleMovie(); break;
-		case IntroState_LegalPage: doLegalPage(); break;
 		case IntroState_Done: doPostIntro(); break;
 		}
 	}
@@ -97,30 +89,6 @@ void Intro::doSizzleMovie()
 		TheDisplay->playMovie("Sizzle");
 	else
 		TheDisplay->playMovie("Sizzle640");
-}
-
-
-void Intro::doLegalPage()
-{
-	TheWritableGlobalData->m_breakTheMovie = FALSE;
-	WindowLayout *legal = TheWindowManager->winCreateLayout("Menus/LegalPage.wnd");
-	if (legal)
-	{
-		legal->hide(FALSE);
-		legal->bringForward();
-		Int beginTime = timeGetTime();
-		while (beginTime + 4000 > timeGetTime() )
-		{
-			TheWindowManager->update();
-			// redraw all views, update the GUI
-			TheDisplay->draw();
-			Sleep(100);
-		}
-		setFPMode();
-		legal->destroyWindows();
-		deleteInstance(legal);
-	}
-	TheWritableGlobalData->m_breakTheMovie = TRUE;
 }
 
 void Intro::doPostIntro()

--- a/Generals/Code/GameEngine/Include/Common/GlobalData.h
+++ b/Generals/Code/GameEngine/Include/Common/GlobalData.h
@@ -364,7 +364,6 @@ public:
 	Bool m_shellMapOn;								///< User can set the shell map not to load
 	Bool m_playIntro;									///< Flag to say if we're to play the intro or not
 	Bool m_playSizzle;								///< Flag to say whether we play the sizzle movie after the logo movie.
-	Bool m_afterIntro;								///< we need to tell the game our intro is done
 	Bool m_allowExitOutOfMovies;			///< flag to allow exit out of movies only after the Intro has played
 
 	Bool m_loadScreenRender;						///< flag to disallow rendering of almost everything during a loadscreen

--- a/Generals/Code/GameEngine/Include/GameClient/GameClient.h
+++ b/Generals/Code/GameEngine/Include/GameClient/GameClient.h
@@ -88,6 +88,7 @@ public:
 	// subsystem methods
 	virtual void init() override;																					///< Initialize resources
 	virtual void update() override;																				///< Updates the GUI, display, audio, etc
+	virtual void draw() override;
 	virtual void reset() override;																					///< reset system
 
 	virtual void setFrame( UnsignedInt frame ) { m_frame = frame; }			///< Set the GameClient's internal frame number

--- a/Generals/Code/GameEngine/Include/GameClient/GameClient.h
+++ b/Generals/Code/GameEngine/Include/GameClient/GameClient.h
@@ -44,6 +44,7 @@ class Drawable;
 class FontLibrary;
 class GameWindowManager;
 class InGameUI;
+class Intro;
 class Keyboard;
 class Mouse;
 class ParticleSystemManager;
@@ -173,6 +174,7 @@ protected:
 
 private:
 
+	Intro* m_intro;
 	UnsignedInt m_renderedObjectCount;													///< Keeps track of the number of rendered objects -- resets each frame.
 
 	//---------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/Common/CommandLine.cpp
+++ b/Generals/Code/GameEngine/Source/Common/CommandLine.cpp
@@ -412,7 +412,6 @@ Int parseHeadless(char *args[], int num)
 {
 	TheWritableGlobalData->m_headless = TRUE;
 	TheWritableGlobalData->m_playIntro = FALSE;
-	TheWritableGlobalData->m_afterIntro = TRUE;
 	TheWritableGlobalData->m_playSizzle = FALSE;
 
 	// TheSuperHackers @fix bobtista 03/02/2026 Set DX8Wrapper_IsWindowed to false in headless
@@ -437,7 +436,6 @@ Int parseReplay(char *args[], int num)
 		TheWritableGlobalData->m_simulateReplays.push_back(filename);
 
 		TheWritableGlobalData->m_playIntro = FALSE;
-		TheWritableGlobalData->m_afterIntro = TRUE;
 		TheWritableGlobalData->m_playSizzle = FALSE;
 		TheWritableGlobalData->m_shellMapOn = FALSE;
 
@@ -790,7 +788,6 @@ Int parseNoShaders(char *args[], int)
 Int parseNoLogo(char *args[], int)
 {
 	TheWritableGlobalData->m_playIntro = FALSE;
-	TheWritableGlobalData->m_afterIntro = TRUE;
 	TheWritableGlobalData->m_playSizzle = FALSE;
 
 	return 1;

--- a/Generals/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -578,9 +578,6 @@ void GameEngine::init()
 			}
 		}
 
-		if(!TheGlobalData->m_playIntro)
-			TheWritableGlobalData->m_afterIntro = TRUE;
-
 	}
 	catch (ErrorCode ec)
 	{
@@ -601,9 +598,6 @@ void GameEngine::init()
 	{
 		RELEASE_CRASH(("Uncaught Exception during initialization."));
 	}
-
-	if(!TheGlobalData->m_playIntro)
-		TheWritableGlobalData->m_afterIntro = TRUE;
 
 	resetSubsystems();
 

--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -1007,7 +1007,6 @@ GlobalData::GlobalData()
 	m_shellMapOn =TRUE;
 	m_playIntro = TRUE;
 	m_playSizzle = TRUE;
-	m_afterIntro = FALSE;
 	m_allowExitOutOfMovies = FALSE;
 	m_loadScreenRender = FALSE;
 

--- a/Generals/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -540,7 +540,7 @@ void GameClient::update()
 
 	}
 
-	if(TheGlobalData->m_playIntro || TheGlobalData->m_afterIntro)
+	if (m_intro != nullptr)
 	{
 		// redraw all views, update the GUI
 		TheDisplay->UPDATE();

--- a/Generals/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -43,7 +43,6 @@
 #include "Common/ThingFactory.h"
 #include "Common/ThingTemplate.h"
 #include "Common/Xfer.h"
-#include "Common/GameLOD.h"
 #include "GameClient/Anim2D.h"
 #include "GameClient/CampaignManager.h"
 #include "GameClient/CommandXlat.h"
@@ -63,6 +62,7 @@
 #include "GameClient/HotKey.h"
 #include "GameClient/IMEManager.h"
 #include "GameClient/InGameUI.h"
+#include "GameClient/Intro.h"
 #include "GameClient/Keyboard.h"
 #include "GameClient/LanguageFilter.h"
 #include "GameClient/LookAtXlat.h"
@@ -77,7 +77,6 @@
 #include "GameClient/View.h"
 #include "GameClient/VideoPlayer.h"
 #include "GameClient/WindowXlat.h"
-#include "GameLogic/FPUControl.h"
 #include "GameLogic/GameLogic.h"
 #include "GameLogic/GhostObject.h"
 #include "GameLogic/Object.h"
@@ -107,6 +106,8 @@ GameClient::GameClient()
 
 	m_nextDrawableID = (DrawableID)1;
 	TheDrawGroupInfo = new DrawGroupInfo;
+
+	m_intro = nullptr;
 }
 
 //std::vector<std::string>	preloadTextureNamesGlobalHack;
@@ -149,6 +150,10 @@ GameClient::~GameClient()
 		destroyDrawable( draw );
 	}
 	m_drawableList = nullptr;
+
+	// Should be destroyed before the Display String Manager
+	delete m_intro;
+	m_intro = nullptr;
 
 	// delete the ray effects
 	delete TheRayEffects;
@@ -414,6 +419,8 @@ void GameClient::init()
 
 	TheDisplayStringManager->postProcessLoad();
 
+	m_intro = NEW Intro;
+
 #ifdef PERF_TIMERS
 	TheGraphDraw = new GraphDraw;
 #endif
@@ -495,73 +502,19 @@ void GameClient::update()
 	// create the FRAME_TICK message
 	GameMessage *frameMsg = TheMessageStream->appendMessage( GameMessage::MSG_FRAME_TICK );
 	frameMsg->appendTimestampArgument( getFrame() );
-	static Bool playSizzle = FALSE;
-	// We need to show the movie first.
-	if(TheGlobalData->m_playIntro && !TheDisplay->isMoviePlaying())
+
+	// Update intro
+	if (m_intro != nullptr)
 	{
-		if(TheGameLODManager && TheGameLODManager->didMemPass())
-			TheDisplay->playLogoMovie("EALogoMovie", 5000, 3000);
-		else
-			TheDisplay->playLogoMovie("EALogoMovie640", 5000, 3000);
-		TheWritableGlobalData->m_playIntro = FALSE;
-		TheWritableGlobalData->m_afterIntro = TRUE;
-		playSizzle = TRUE;
-	}
+		m_intro->update();
 
-	//Initial Game Condition.  We must show the movie first and then we can display the shell
-	if(TheGlobalData->m_afterIntro && !TheDisplay->isMoviePlaying())
-	{
-		if( playSizzle && TheGlobalData->m_playSizzle )
+		if (m_intro->isDone())
 		{
-			TheWritableGlobalData->m_allowExitOutOfMovies = TRUE;
-			if(TheGameLODManager && TheGameLODManager->didMemPass())
-				TheDisplay->playMovie("Sizzle");
-			else
-				TheDisplay->playMovie("Sizzle640");
-			playSizzle = FALSE;
-		}
-		else
-		{
-			TheWritableGlobalData->m_breakTheMovie = TRUE;
-			TheWritableGlobalData->m_allowExitOutOfMovies = TRUE;
-
-			if(TheGameLODManager && !TheGameLODManager->didMemPass())
-			{
-				TheWritableGlobalData->m_breakTheMovie = FALSE;
-
-				WindowLayout *legal = TheWindowManager->winCreateLayout("Menus/LegalPage.wnd");
-				if(legal)
-				{
-					legal->hide(FALSE);
-					legal->bringForward();
-					Int beginTime = timeGetTime();
-					while(beginTime + 4000 > timeGetTime() )
-					{
-						if (GameClient::isMovieAbortRequested())
-						{
-							break;
-						}
-
-						TheWindowManager->update();
-						// redraw all views, update the GUI
-						TheDisplay->draw();
-						Sleep(100);
-					}
-					setFPMode();
-
-
-					legal->destroyWindows();
-					deleteInstance(legal);
-
-				}
-				TheWritableGlobalData->m_breakTheMovie = TRUE;
-
-
-			}
+			delete m_intro;
+			m_intro = nullptr;
 
 			TheShell->showShellMap(TRUE);
 			TheShell->showShell();
-			TheWritableGlobalData->m_afterIntro = FALSE;
 		}
 	}
 

--- a/Generals/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -698,6 +698,14 @@ void GameClient::update()
 	}
 }
 
+void GameClient::draw()
+{
+	if (m_intro != nullptr)
+	{
+		m_intro->draw();
+	}
+}
+
 void GameClient::step()
 {
 	TheDisplay->step();

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -1908,7 +1908,7 @@ AGAIN:
 				// draw the user interface
 				TheInGameUI->DRAW();
 
-				// end of video example code
+				TheGameClient->DRAW();
 
 				// draw the mouse
 				if( TheMouse )

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -1919,14 +1919,7 @@ AGAIN:
 					// TheSuperHackers @bugfix Mauller 20/07/2025 scale videos based on screen size so they are shown in their original aspect
 					drawScaledVideoBuffer( m_videoBuffer, m_videoStream );
 				}
-				if( m_copyrightDisplayString )
-				{
-					Int x, y, dX, dY;
-					m_copyrightDisplayString->getSize(&dX, &dY);
-					x = (getWidth() / 2) - (dX /2);
-					y = getHeight()  - dY - 20 ;
-					m_copyrightDisplayString->draw(x, y, GameMakeColor(0,0,0,255), GameMakeColor(0,0,0,0),0,0);
-				}
+
 				// render letter box before debug display so debug info isn't hidden
 				renderLetterBox(now);
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
@@ -365,7 +365,6 @@ public:
 	Bool m_shellMapOn;								///< User can set the shell map not to load
 	Bool m_playIntro;									///< Flag to say if we're to play the intro or not
 	Bool m_playSizzle;								///< Flag to say whether we play the sizzle movie after the logo movie.
-	Bool m_afterIntro;								///< we need to tell the game our intro is done
 	Bool m_allowExitOutOfMovies;			///< flag to allow exit out of movies only after the Intro has played
 
 	Bool m_loadScreenRender;						///< flag to disallow rendering of almost everything during a loadscreen

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/GameClient.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/GameClient.h
@@ -92,6 +92,7 @@ public:
 	// subsystem methods
 	virtual void init() override;																					///< Initialize resources
 	virtual void update() override;																				///< Updates the GUI, display, audio, etc
+	virtual void draw() override;
 	virtual void reset() override;																					///< reset system
 
 	virtual void setFrame( UnsignedInt frame ) { m_frame = frame; }			///< Set the GameClient's internal frame number

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/GameClient.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/GameClient.h
@@ -44,6 +44,7 @@ class Drawable;
 class FontLibrary;
 class GameWindowManager;
 class InGameUI;
+class Intro;
 class Keyboard;
 class Mouse;
 class ParticleSystemManager;
@@ -179,6 +180,7 @@ protected:
 
 private:
 
+	Intro* m_intro;
 	UnsignedInt m_renderedObjectCount;													///< Keeps track of the number of rendered objects -- resets each frame.
 
 	//---------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/Common/CommandLine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/CommandLine.cpp
@@ -412,7 +412,6 @@ Int parseHeadless(char *args[], int num)
 {
 	TheWritableGlobalData->m_headless = TRUE;
 	TheWritableGlobalData->m_playIntro = FALSE;
-	TheWritableGlobalData->m_afterIntro = TRUE;
 	TheWritableGlobalData->m_playSizzle = FALSE;
 
 	// TheSuperHackers @fix bobtista 03/02/2026 Set DX8Wrapper_IsWindowed to false in headless
@@ -437,7 +436,6 @@ Int parseReplay(char *args[], int num)
 		TheWritableGlobalData->m_simulateReplays.push_back(filename);
 
 		TheWritableGlobalData->m_playIntro = FALSE;
-		TheWritableGlobalData->m_afterIntro = TRUE;
 		TheWritableGlobalData->m_playSizzle = FALSE;
 		TheWritableGlobalData->m_shellMapOn = FALSE;
 
@@ -790,7 +788,6 @@ Int parseNoShaders(char *args[], int)
 Int parseNoLogo(char *args[], int)
 {
 	TheWritableGlobalData->m_playIntro = FALSE;
-	TheWritableGlobalData->m_afterIntro = TRUE;
 	TheWritableGlobalData->m_playSizzle = FALSE;
 
 	return 1;

--- a/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -745,9 +745,6 @@ void GameEngine::init()
 			}
 		}
 
-		if(!TheGlobalData->m_playIntro)
-			TheWritableGlobalData->m_afterIntro = TRUE;
-
 	}
 	catch (ErrorCode ec)
 	{
@@ -768,9 +765,6 @@ void GameEngine::init()
 	{
 		RELEASE_CRASH(("Uncaught Exception during initialization."));
 	}
-
-	if(!TheGlobalData->m_playIntro)
-		TheWritableGlobalData->m_afterIntro = TRUE;
 
 	resetSubsystems();
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -1014,7 +1014,6 @@ GlobalData::GlobalData()
 	m_shellMapOn =TRUE;
 	m_playIntro = TRUE;
 	m_playSizzle = TRUE;
-	m_afterIntro = FALSE;
 	m_allowExitOutOfMovies = FALSE;
 	m_loadScreenRender = FALSE;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -577,7 +577,7 @@ void GameClient::update()
       TheInGameUI->setCameraTrackingDrawable( FALSE );
   }
 
-	if(TheGlobalData->m_playIntro || TheGlobalData->m_afterIntro)
+	if (m_intro != nullptr)
 	{
 		// redraw all views, update the GUI
 		TheDisplay->UPDATE();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -735,6 +735,14 @@ void GameClient::update()
 	}
 }
 
+void GameClient::draw()
+{
+	if (m_intro != nullptr)
+	{
+		m_intro->draw();
+	}
+}
+
 void GameClient::step()
 {
 	TheDisplay->step();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -43,7 +43,6 @@
 #include "Common/ThingFactory.h"
 #include "Common/ThingTemplate.h"
 #include "Common/Xfer.h"
-#include "Common/GameLOD.h"
 #include "GameClient/Anim2D.h"
 #include "GameClient/CampaignManager.h"
 #include "GameClient/ChallengeGenerals.h"
@@ -64,6 +63,7 @@
 #include "GameClient/HotKey.h"
 #include "GameClient/IMEManager.h"
 #include "GameClient/InGameUI.h"
+#include "GameClient/Intro.h"
 #include "GameClient/Keyboard.h"
 #include "GameClient/LanguageFilter.h"
 #include "GameClient/LookAtXlat.h"
@@ -79,7 +79,6 @@
 #include "GameClient/View.h"
 #include "GameClient/VideoPlayer.h"
 #include "GameClient/WindowXlat.h"
-#include "GameLogic/FPUControl.h"
 #include "GameLogic/GameLogic.h"
 #include "GameLogic/GhostObject.h"
 #include "GameLogic/Object.h"
@@ -109,6 +108,8 @@ GameClient::GameClient()
 
 	m_nextDrawableID = (DrawableID)1;
 	TheDrawGroupInfo = new DrawGroupInfo;
+
+	m_intro = nullptr;
 }
 
 //std::vector<std::string>	preloadTextureNamesGlobalHack;
@@ -151,6 +152,10 @@ GameClient::~GameClient()
 		destroyDrawable( draw );
 	}
 	m_drawableList = nullptr;
+
+	// Should be destroyed before the Display String Manager
+	delete m_intro;
+	m_intro = nullptr;
 
 	// delete the ray effects
 	delete TheRayEffects;
@@ -434,6 +439,8 @@ void GameClient::init()
 		TheSnowManager->setName("TheSnowManager");
 	}
 
+	m_intro = NEW Intro;
+
 #ifdef PERF_TIMERS
 	TheGraphDraw = new GraphDraw;
 #endif
@@ -516,73 +523,19 @@ void GameClient::update()
 	// create the FRAME_TICK message
 	GameMessage *frameMsg = TheMessageStream->appendMessage( GameMessage::MSG_FRAME_TICK );
 	frameMsg->appendTimestampArgument( getFrame() );
-	static Bool playSizzle = FALSE;
-	// We need to show the movie first.
-	if(TheGlobalData->m_playIntro && !TheDisplay->isMoviePlaying())
+
+	// Update intro
+	if (m_intro != nullptr)
 	{
-		if(TheGameLODManager && TheGameLODManager->didMemPass())
-			TheDisplay->playLogoMovie("EALogoMovie", 5000, 3000);
-		else
-			TheDisplay->playLogoMovie("EALogoMovie640", 5000, 3000);
-		TheWritableGlobalData->m_playIntro = FALSE;
-		TheWritableGlobalData->m_afterIntro = TRUE;
-		playSizzle = TRUE;
-	}
+		m_intro->update();
 
-	//Initial Game Condition.  We must show the movie first and then we can display the shell
-	if(TheGlobalData->m_afterIntro && !TheDisplay->isMoviePlaying())
-	{
-		if( playSizzle && TheGlobalData->m_playSizzle )
+		if (m_intro->isDone())
 		{
-			TheWritableGlobalData->m_allowExitOutOfMovies = TRUE;
-			if(TheGameLODManager && TheGameLODManager->didMemPass())
-				TheDisplay->playMovie("Sizzle");
-			else
-				TheDisplay->playMovie("Sizzle640");
-			playSizzle = FALSE;
-		}
-		else
-		{
-			TheWritableGlobalData->m_breakTheMovie = TRUE;
-			TheWritableGlobalData->m_allowExitOutOfMovies = TRUE;
-
-			if(TheGameLODManager && !TheGameLODManager->didMemPass())
-			{
-				TheWritableGlobalData->m_breakTheMovie = FALSE;
-
-				WindowLayout *legal = TheWindowManager->winCreateLayout("Menus/LegalPage.wnd");
-				if(legal)
-				{
-					legal->hide(FALSE);
-					legal->bringForward();
-					Int beginTime = timeGetTime();
-					while(beginTime + 4000 > timeGetTime() )
-					{
-						if (GameClient::isMovieAbortRequested())
-						{
-							break;
-						}
-
-						TheWindowManager->update();
-						// redraw all views, update the GUI
-						TheDisplay->draw();
-						Sleep(100);
-					}
-					setFPMode();
-
-
-					legal->destroyWindows();
-					deleteInstance(legal);
-
-				}
-				TheWritableGlobalData->m_breakTheMovie = TRUE;
-
-
-			}
+			delete m_intro;
+			m_intro = nullptr;
 
 			TheShell->showShellMap(TRUE);
 			TheShell->showShell();
-			TheWritableGlobalData->m_afterIntro = FALSE;
 		}
 	}
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -1997,7 +1997,7 @@ AGAIN:
 				// draw the user interface
 				TheInGameUI->DRAW();
 
-				// end of video example code
+				TheGameClient->DRAW();
 
 				// draw the mouse
 				if( TheMouse )

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -2008,14 +2008,7 @@ AGAIN:
 					// TheSuperHackers @bugfix Mauller 20/07/2025 scale videos based on screen size so they are shown in their original aspect
 					drawScaledVideoBuffer( m_videoBuffer, m_videoStream );
 				}
-				if( m_copyrightDisplayString )
-				{
-					Int x, y, dX, dY;
-					m_copyrightDisplayString->getSize(&dX, &dY);
-					x = (getWidth() / 2) - (dX /2);
-					y = getHeight()  - dY - 20 ;
-					m_copyrightDisplayString->draw(x, y, GameMakeColor(0,0,0,255), GameMakeColor(0,0,0,0),0,0);
-				}
+
 				// render letter box before debug display so debug info isn't hidden
 				renderLetterBox(now);
 


### PR DESCRIPTION
**Merge with Rebase**

* Relevant friend change: #2266

This change has 5 commits:

1. Move intro related code to new file and class
2. Simplify the intro state machine to make it easier to modify and extend
3. Remove the non functional copyright string and simplify the EA logo movie code. This also shortens the effective EA logo duration by 3 to 5 seconds.
4. Remove the superfluous legal page from intro sequence, which would have lasted 4 seconds after Sizzle video but was practically never visible except if the mem pass would have failed (relevant for 2000 era computers). I think the condition was actually meant to be the inverse...
5. Add new intro screen for The Super Hacker team

## Old Intro Sequence

1. EA Logo, 3 seconds, non skippable
2. Black Screen, 3-5 seconds (*1), non skippable
3. Sizzle Video, skippable
4. Legal Page, 4 seconds, practically never shown
5. Shell Map load screen

(*1) I did not measure how long the black screen was. According to code somewhere between 3 to 5 seconds.

## New Intro Sequence

1. EA Logo, 3 seconds, non skippable
2. Black Screen, 800 milliseconds, non skippable
3. The Super Hackers Logo, 3 seconds, non skippable
4. Black Screen, 1 second, non skippable
5. Sizzle Video, skippable
6. Shell Map load screen

<img width="1600" height="1200" alt="shot_20260710_224403_1" src="https://github.com/user-attachments/assets/82393d08-42ee-438f-a112-fc6918cecbe1" />


## TODO

- [x] Replicate in Generals
- [x] Add pull id to commit titles
- [x] Verify each commit compiles individually