### PR TITLE
fix(netpacket): Fix misplaced null test in NetPacket::addCommand()

### DIFF
--- a/Core/GameEngine/Source/GameNetwork/NetPacket.cpp
+++ b/Core/GameEngine/Source/GameNetwork/NetPacket.cpp
@@ -1538,11 +1538,11 @@ void NetPacket::setAddress(Int addr, Int port) {
 Bool NetPacket::addCommand(NetCommandRef *msg) {
 	// This is where the fun begins...
 
-	NetCommandMsg *cmdMsg = msg->getCommand();
-
 	if (msg == nullptr) {
 		return TRUE; // There was nothing to add, so it was successful.
 	}
+
+	NetCommandMsg *cmdMsg = msg->getCommand();
 
 	switch(cmdMsg->getNetCommandType())
 	{


### PR DESCRIPTION
This change fixes a misplaced null test in `NetPacket::addCommand()`.