### PR TITLE
refactor(loadscreen): Refactor the single player load screen to use TheDisplay for intro video playback

### DIFF
--- a/Core/GameEngine/Include/GameClient/LoadScreen.h
+++ b/Core/GameEngine/Include/GameClient/LoadScreen.h
@@ -110,9 +110,6 @@ private:
 
 	UnicodeString m_unicodeObjectiveLines[MAX_OBJECTIVE_LINES];
 
-	VideoBuffer *m_videoBuffer;
-	VideoStreamInterface *m_videoStream;
-
 	void moveWindows( Int frame );
 
 	AudioEventRTS m_ambientLoop;

--- a/Generals/Code/GameEngine/Include/GameClient/Display.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Display.h
@@ -143,8 +143,9 @@ public:
 
 	/// draw a video buffer fit within the screen coordinates
 	virtual void drawScaledVideoBuffer( VideoBuffer *buffer, VideoStreamInterface *stream ) = 0;
-	virtual void drawVideoBuffer( VideoBuffer *buffer, Int startX, Int startY,
-													Int endX, Int endY ) = 0;
+	virtual void drawScaledVideoBuffer() = 0;
+	virtual void drawVideoBuffer( VideoBuffer *buffer, Int startX, Int startY, Int endX, Int endY ) = 0;
+	virtual void drawVideoBuffer(Int startX, Int startY, Int endX, Int endY) = 0;
 
 	/// FullScreen video playback
 	virtual void playLogoMovie( AsciiString movieName, Int minMovieLength, Int minCopyrightLength );

--- a/Generals/Code/GameEngine/Include/GameClient/Display.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Display.h
@@ -151,6 +151,7 @@ public:
 	virtual void playLogoMovie( AsciiString movieName, Int minMovieLength, Int minCopyrightLength );
 	virtual void playMovie( AsciiString movieName );
 	virtual void stopMovie( void );
+	virtual Real getMovieProgress(); ///< returns the playback progress in the range 0.0 to 1.0
 	virtual Bool isMoviePlaying(void);
 
 	/// Register debug display callback

--- a/Generals/Code/GameEngine/Source/GameClient/Display.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Display.cpp
@@ -361,6 +361,16 @@ void Display::reset()
 }
 
 //============================================================================
+// Display::getMovieProgress
+//============================================================================
+
+Real Display::getMovieProgress()
+{
+	return m_videoStream && m_videoStream->frameCount() > 0 ?
+		(Real)m_videoStream->frameIndex() / (Real)m_videoStream->frameCount() : 0.0f;
+}
+
+//============================================================================
 // Display::isMoviePlaying
 //============================================================================
 

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -115,8 +115,9 @@ public:
 
 	/// draw a video buffer fit within the screen coordinates
 	virtual void drawScaledVideoBuffer( VideoBuffer *buffer, VideoStreamInterface *stream );
-	virtual void drawVideoBuffer( VideoBuffer *buffer, Int startX, Int startY,
-													Int endX, Int endY );
+	virtual void drawScaledVideoBuffer();
+	virtual void drawVideoBuffer( VideoBuffer *buffer, Int startX, Int startY, Int endX, Int endY );
+	virtual void drawVideoBuffer( Int startX, Int startY, Int endX, Int endY );
 
 	virtual VideoBuffer*	createVideoBuffer( void ) ;							///< Create a video buffer that can be used for this display
 

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/W3DGameWindow.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/W3DGameWindow.cpp
@@ -379,6 +379,7 @@ void W3DGameWinDefaultDraw( GameWindow *window, WinInstanceData *instData )
 	}
 
 	// if we have a video buffer, draw the video buffer
+	// else if the display has a movie playing then we need to draw the displays video buffer
 	if ( instData->m_videoBuffer )
 	{
 		ICoord2D pos, size;
@@ -386,6 +387,14 @@ void W3DGameWinDefaultDraw( GameWindow *window, WinInstanceData *instData )
 		window->winGetSize( &size.x, &size.y );
 
 		TheDisplay->drawVideoBuffer( instData->m_videoBuffer, pos.x, pos.y, pos.x + size.x, pos.y + size.y );
+	}
+	else if (TheDisplay->isMoviePlaying()) 
+	{
+		ICoord2D pos, size;
+		window->winGetScreenPosition(&pos.x, &pos.y);
+		window->winGetSize(&size.x, &size.y);
+
+		TheDisplay->drawVideoBuffer(pos.x, pos.y, pos.x + size.x, pos.y + size.y);
 	}
 
 }

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -2735,6 +2735,11 @@ void W3DDisplay::drawScaledVideoBuffer( VideoBuffer *buffer, VideoStreamInterfac
 	drawVideoBuffer( buffer, startX, startY, endX, endY );
 }
 
+void W3DDisplay::drawScaledVideoBuffer()
+{
+	drawScaledVideoBuffer(m_videoBuffer, m_videoStream);
+}
+
 //============================================================================
 // W3DDisplay::drawVideoBuffer
 //============================================================================
@@ -2750,6 +2755,11 @@ void W3DDisplay::drawVideoBuffer( VideoBuffer *buffer, Int startX, Int startY, I
 												vbuffer->Rect( 0, 0, 1, 1) );
 	m_2DRender->Render();
 
+}
+
+void W3DDisplay::drawVideoBuffer( Int startX, Int startY, Int endX, Int endY )
+{
+	drawVideoBuffer(m_videoBuffer, startX, startY, endX, endY);
 }
 
 // W3DDisplay::setClipRegion ============================================

--- a/Generals/Code/Tools/GUIEdit/Include/GUIEditDisplay.h
+++ b/Generals/Code/Tools/GUIEdit/Include/GUIEditDisplay.h
@@ -98,9 +98,11 @@ public:
 	virtual VideoBuffer*	createVideoBuffer( void ) { return nullptr; }
 
 	/// draw a video buffer fit within the screen coordinates
-	virtual void drawScaledVideoBuffer( VideoBuffer *buffer, VideoStreamInterface *stream ) { }
-	virtual void drawVideoBuffer( VideoBuffer *buffer, Int startX, Int startY,
-																Int endX, Int endY ) { }
+	virtual void drawScaledVideoBuffer(VideoBuffer* buffer, VideoStreamInterface* stream) { }
+	virtual void drawScaledVideoBuffer() { }
+	virtual void drawVideoBuffer(VideoBuffer* buffer, Int startX, Int startY, Int endX, Int endY) { }
+	virtual void drawVideoBuffer(Int startX, Int startY, Int endX, Int endY) { }
+
 	virtual void takeScreenShot(void){ }
 	virtual void toggleMovieCapture(void) {}
 

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Display.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Display.h
@@ -143,8 +143,9 @@ public:
 
 	/// draw a video buffer fit within the screen coordinates
 	virtual void drawScaledVideoBuffer( VideoBuffer *buffer, VideoStreamInterface *stream ) = 0;
-	virtual void drawVideoBuffer( VideoBuffer *buffer, Int startX, Int startY,
-													Int endX, Int endY ) = 0;
+	virtual void drawScaledVideoBuffer() = 0;
+	virtual void drawVideoBuffer( VideoBuffer *buffer, Int startX, Int startY, Int endX, Int endY ) = 0;
+	virtual void drawVideoBuffer(Int startX, Int startY, Int endX, Int endY) = 0;
 
 	/// FullScreen video playback
 	virtual void playLogoMovie( AsciiString movieName, Int minMovieLength, Int minCopyrightLength );

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Display.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Display.h
@@ -151,6 +151,7 @@ public:
 	virtual void playLogoMovie( AsciiString movieName, Int minMovieLength, Int minCopyrightLength );
 	virtual void playMovie( AsciiString movieName );
 	virtual void stopMovie( void );
+	virtual Real getMovieProgress(); ///< returns the playback progress in the range 0.0 to 1.0
 	virtual Bool isMoviePlaying(void);
 
 	/// Register debug display callback

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Display.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Display.cpp
@@ -361,6 +361,16 @@ void Display::reset()
 }
 
 //============================================================================
+// Display::getMovieProgress
+//============================================================================
+
+Real Display::getMovieProgress()
+{
+	return m_videoStream && m_videoStream->frameCount() > 0 ?
+		(Real)m_videoStream->frameIndex() / (Real)m_videoStream->frameCount() : 0.0f;
+}
+
+//============================================================================
 // Display::isMoviePlaying
 //============================================================================
 

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -115,8 +115,9 @@ public:
 
 	/// draw a video buffer fit within the screen coordinates
 	virtual void drawScaledVideoBuffer( VideoBuffer *buffer, VideoStreamInterface *stream );
-	virtual void drawVideoBuffer( VideoBuffer *buffer, Int startX, Int startY,
-													Int endX, Int endY );
+	virtual void drawScaledVideoBuffer();
+	virtual void drawVideoBuffer( VideoBuffer *buffer, Int startX, Int startY, Int endX, Int endY );
+	virtual void drawVideoBuffer( Int startX, Int startY, Int endX, Int endY );
 
 	virtual VideoBuffer*	createVideoBuffer( void ) ;							///< Create a video buffer that can be used for this display
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/W3DGameWindow.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/W3DGameWindow.cpp
@@ -379,6 +379,7 @@ void W3DGameWinDefaultDraw( GameWindow *window, WinInstanceData *instData )
 	}
 
 	// if we have a video buffer, draw the video buffer
+	// else if the display has a movie playing then we need to draw the displays video buffer
 	if ( instData->m_videoBuffer )
 	{
 		ICoord2D pos, size;
@@ -386,6 +387,14 @@ void W3DGameWinDefaultDraw( GameWindow *window, WinInstanceData *instData )
 		window->winGetSize( &size.x, &size.y );
 
 		TheDisplay->drawVideoBuffer( instData->m_videoBuffer, pos.x, pos.y, pos.x + size.x, pos.y + size.y );
+	}
+	else if (TheDisplay->isMoviePlaying()) 
+	{
+		ICoord2D pos, size;
+		window->winGetScreenPosition(&pos.x, &pos.y);
+		window->winGetSize(&size.x, &size.y);
+
+		TheDisplay->drawVideoBuffer(pos.x, pos.y, pos.x + size.x, pos.y + size.y);
 	}
 
 }

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -2844,6 +2844,11 @@ void W3DDisplay::drawScaledVideoBuffer( VideoBuffer *buffer, VideoStreamInterfac
 	drawVideoBuffer( buffer, startX, startY, endX, endY );
 }
 
+void W3DDisplay::drawScaledVideoBuffer()
+{
+	drawScaledVideoBuffer(m_videoBuffer, m_videoStream);
+}
+
 //============================================================================
 // W3DDisplay::drawVideoBuffer
 //============================================================================
@@ -2859,6 +2864,11 @@ void W3DDisplay::drawVideoBuffer( VideoBuffer *buffer, Int startX, Int startY, I
 												vbuffer->Rect( 0, 0, 1, 1) );
 	m_2DRender->Render();
 
+}
+
+void W3DDisplay::drawVideoBuffer( Int startX, Int startY, Int endX, Int endY )
+{
+	drawVideoBuffer(m_videoBuffer, startX, startY, endX, endY);
 }
 
 // W3DDisplay::setClipRegion ============================================

--- a/GeneralsMD/Code/Tools/GUIEdit/Include/GUIEditDisplay.h
+++ b/GeneralsMD/Code/Tools/GUIEdit/Include/GUIEditDisplay.h
@@ -98,9 +98,11 @@ public:
 	virtual VideoBuffer*	createVideoBuffer( void ) { return nullptr; }
 
 	/// draw a video buffer fit within the screen coordinates
-	virtual void drawScaledVideoBuffer( VideoBuffer *buffer, VideoStreamInterface *stream ) { }
-	virtual void drawVideoBuffer( VideoBuffer *buffer, Int startX, Int startY,
-																Int endX, Int endY ) { }
+	virtual void drawScaledVideoBuffer(VideoBuffer* buffer, VideoStreamInterface* stream) { }
+	virtual void drawScaledVideoBuffer() { }
+	virtual void drawVideoBuffer(VideoBuffer* buffer, Int startX, Int startY, Int endX, Int endY) { }
+	virtual void drawVideoBuffer(Int startX, Int startY, Int endX, Int endY) { }
+
 	virtual void takeScreenShot(void){ }
 	virtual void toggleMovieCapture(void) {}
 


### PR DESCRIPTION
**Merge with rebase**

* Merge after #2332

This breaks out changes from #2053 that involve the refactoring of the video playback.

I split this into two commits, one with the changes to TheDisplay for adding extra functionality, the second is the load screen refactor changes.

The other changes will come along after for video scaling options and for disabling the custom overlay during video playback.

This also fixes how the video playback is displayed in the progress bar.
Now the video progress filles the entire bar before resetting the bar for the normal data loading portion of the intro screen.

---

- [x] Replicate in generals