### PR TITLE
fix(view): Prevent float division by zero in W3DView::setupWaypointPath()

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -2823,14 +2823,14 @@ void W3DView::setupWaypointPath(Bool orient)
 	Real angle = getAngle();
 	for (i=1; i<m_mcwpInfo.numWaypoints; i++) {
 		Vector2 dir(m_mcwpInfo.waypoints[i+1].x-m_mcwpInfo.waypoints[i].x, m_mcwpInfo.waypoints[i+1].y-m_mcwpInfo.waypoints[i].y);
-		m_mcwpInfo.waySegLength[i] = dir.Length();
+		const Real dirLength = dir.Length();
+		m_mcwpInfo.waySegLength[i] = dirLength;
 		m_mcwpInfo.totalDistance += m_mcwpInfo.waySegLength[i];
-		if (orient) {
-			angle = WWMath::Acos(dir.X/m_mcwpInfo.waySegLength[i]);
+		if (orient && dirLength >= 0.1f) {
+			angle = WWMath::Acos(dir.X/dirLength);
 			if (dir.Y<0.0f) {
 				angle = -angle;
 			}
-
 			// Default camera is rotated 90 degrees, so match.
 			angle -= PI/2;
 			normAngle(angle);


### PR DESCRIPTION
This change prevents a float division by zero in `W3DView::setupWaypointPath()`.

This was seen during debugging. Length can be zero, which gives inf float on division. It did not have any catastophic runtime consequences, because further down below it then does `m_mcwpInfo.cameraAngle[1] = getAngle();` which writes over the malformed value.

The `dirLength >= 0.1f` test is consistent with other similar tests in this class. See other references to `WWMath::Acos(dir.X/dirLength)`.