### PR TITLE
bugfix(network): Increase message buffer and max packet sizes to reduce connection issues

### DIFF
--- a/Core/GameEngine/Include/Common/GameDefines.h
+++ b/Core/GameEngine/Include/Common/GameDefines.h
@@ -45,6 +45,11 @@
 #define RETAIL_COMPATIBLE_PATHFINDING_ALLOCATION (1)
 #endif
 
+// Disable non retail fixes in the networking, such as putting more data per UDP packet
+#ifndef RETAIL_COMPATIBLE_NETWORKING
+#define RETAIL_COMPATIBLE_NETWORKING (1)
+#endif
+
 // This is essentially synonymous for RETAIL_COMPATIBLE_CRC. There is a lot wrong with AIGroup, such as use-after-free, double-free, leaks,
 // but we cannot touch it much without breaking retail compatibility. Do not shy away from using massive hacks when fixing issues with AIGroup,
 // but put them behind this macro.

--- a/Core/GameEngine/Include/GameNetwork/LANAPI.h
+++ b/Core/GameEngine/Include/GameNetwork/LANAPI.h
@@ -44,7 +44,7 @@ static const Int g_lanHostNameLength = 1;
 static const Int g_lanGameNameLength = 16; // reduced length because of game option length
 static const Int g_lanGameNameReservedLength = 16; // save N wchars for ID info
 static const Int g_lanMaxChatLength = 100;
-static const Int m_lanMaxOptionsLength = MAX_PACKET_SIZE - ( 8 + (g_lanGameNameLength+1)*2 + 4 + (g_lanPlayerNameLength+1)*2
+static const Int m_lanMaxOptionsLength = MAX_LANAPI_PACKET_SIZE - ( 8 + (g_lanGameNameLength+1)*2 + 4 + (g_lanPlayerNameLength+1)*2
 																														+ (g_lanLoginNameLength+1) + (g_lanHostNameLength+1) );
 static const Int g_maxSerialLength = 23; // including the trailing '\0'
 
@@ -271,7 +271,7 @@ struct LANMessage
 };
 #pragma pack(pop)
 
-static_assert(sizeof(LANMessage) <= MAX_PACKET_SIZE, "LANMessage struct cannot be larger than the max packet size");
+static_assert(sizeof(LANMessage) <= MAX_LANAPI_PACKET_SIZE, "LANMessage struct cannot be larger than the max packet size");
 
 
 /**

--- a/Core/GameEngine/Source/GameNetwork/LANAPI.cpp
+++ b/Core/GameEngine/Source/GameNetwork/LANAPI.cpp
@@ -67,8 +67,8 @@ LANGame::LANGame( void )
 
 LANAPI::LANAPI( void ) : m_transport(nullptr)
 {
-	DEBUG_LOG(("LANAPI::LANAPI() - max game option size is %d, sizeof(LANMessage)=%d, MAX_PACKET_SIZE=%d",
-		m_lanMaxOptionsLength, sizeof(LANMessage), MAX_PACKET_SIZE));
+	DEBUG_LOG(("LANAPI::LANAPI() - max game option size is %d, sizeof(LANMessage)=%d, MAX_LANAPI_PACKET_SIZE=%d",
+		m_lanMaxOptionsLength, sizeof(LANMessage), MAX_LANAPI_PACKET_SIZE));
 
 	m_lastResendTime = 0;
 	//

--- a/Core/GameEngine/Source/GameNetwork/Network.cpp
+++ b/Core/GameEngine/Source/GameNetwork/Network.cpp
@@ -74,7 +74,7 @@ struct ConnectionMessage
 {
 	Int id;
 	NetMessageFlags flags;
-	UnsignedByte data[MAX_MESSAGE_LEN];
+	UnsignedByte data[MAX_NETWORK_MESSAGE_LEN];
 	time_t lastSendTime;
 	Int retries;
 	Int length;


### PR DESCRIPTION
Closes: #203 

This PR increases the send and receive buffer sizes, this can help to alleviate network pressure that can lead to the DC menu appearing when the game is waiting for more network data or has to wait for a resend.

The PR also implements a non retail change to increase the amount of data stored per UDP packet.

The retail game was designed with Dialup limitations in mind, which tended to limit the MTU side to 576 bytes.
Internally they chose 512 bytes as their packet size limit and then incorrectly calculated a lower max UDP payload than necessary on top of this.

The fix allows the game to use 1100 Bytes as the UDP payload for the greatest compatibility between different types of network connections. This should take into account overhead of PPPOE, VPN's and IPV6 on supporting networks without causing fragmentation.

As 6 bytes is required for the current network packet header, game data packets can only be up to 1094 bytes in size.

At 1094 bytes per game packet we are now handling ~2.3x the amount of data per packet compared to retail, this should allow a reduction of network traffic by up to 2/3's depending on how game commands are being generated.

When testing this on GO with a full 8 player Mayhem game, we did not see a single DC screen popup.
All players were creating large armies and using QQA repeatedly to move them.