### PR TITLE
feat(gui): Add support for extra column to separate time and date in Replay Menu

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
@@ -241,6 +241,7 @@ void PopulateReplayFileListbox(GameWindow *listbox)
 
 	GadgetListBoxReset(listbox);
 	const Int listboxLength = GadgetListBoxGetListLength(listbox);
+	const Int columns = GadgetListBoxGetNumColumns(listbox);
 
 	// TheSuperHackers @tweak xezon 08/06/2025 Now shows missing maps in red color.
 	enum {
@@ -291,8 +292,8 @@ void PopulateReplayFileListbox(GameWindow *listbox)
 			UnicodeString replayNameToShow = createReplayName(asciistr);
 
 			// TheSuperHackers @tweak Caball009 07/02/2025 Display both time and date instead of only time.
-			UnicodeString displayDateTimeBuffer;
-			displayDateTimeBuffer.format(L"%s %s", getUnicodeTimeBuffer(header.timeVal).str(), getUnicodeDateBuffer(header.timeVal).str());
+			const UnicodeString displayTimeBuffer = getUnicodeTimeBuffer(header.timeVal);
+			const UnicodeString displayDateBuffer = getUnicodeDateBuffer(header.timeVal);
 
 			// version (no-op)
 
@@ -353,9 +354,29 @@ void PopulateReplayFileListbox(GameWindow *listbox)
 
 			const Int insertionIndex = GadgetListBoxAddEntryText(listbox, replayNameToShow, color, -1, 0);
 			DEBUG_ASSERTCRASH(insertionIndex >= 0, ("Expects valid index"));
-			GadgetListBoxAddEntryText(listbox, displayDateTimeBuffer, color, insertionIndex, 1);
-			GadgetListBoxAddEntryText(listbox, header.versionString, color, insertionIndex, 2);
-			GadgetListBoxAddEntryText(listbox, mapStr, mapColor, insertionIndex, 3);
+
+			// TheSuperHackers @info Caball009 09/02/2026 Original replay menu has 4 columns; the code now supports a future 5-column layout.
+			// If there aren't two columns for time and date, concatenate them for a single column.
+			if (columns == 4)
+			{
+				UnicodeString displayDateTimeBuffer;
+				displayDateTimeBuffer.format(L"%s %s", displayTimeBuffer.str(), displayDateBuffer.str());
+
+				GadgetListBoxAddEntryText(listbox, displayDateTimeBuffer, color, insertionIndex, 1);
+				GadgetListBoxAddEntryText(listbox, header.versionString, color, insertionIndex, 2);
+				GadgetListBoxAddEntryText(listbox, mapStr, mapColor, insertionIndex, 3);
+			}
+			else if (columns == 5)
+			{
+				GadgetListBoxAddEntryText(listbox, displayTimeBuffer, color, insertionIndex, 1);
+				GadgetListBoxAddEntryText(listbox, displayDateBuffer, color, insertionIndex, 2);
+				GadgetListBoxAddEntryText(listbox, header.versionString, color, insertionIndex, 3);
+				GadgetListBoxAddEntryText(listbox, mapStr, mapColor, insertionIndex, 4);
+			}
+			else
+			{
+				DEBUG_CRASH(("Replay menu uses %d columns; expected either 4 or 5", columns));
+			}
 
 			// TheSuperHackers @performance Now stops processing when the list is full.
 			if (insertionIndex == listboxLength - 1)

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
@@ -298,7 +298,7 @@ void PopulateReplayFileListbox(GameWindow *listbox)
 			UnicodeString displayDateTimeBuffer;
 			if (columns == 4)
 			{
-				// TheSuperHackers @info Caball009 09/02/2025 The original replay window menu has only 4 columns.
+				// TheSuperHackers @info Caball009 09/02/2025 The original replay window menu has only four columns.
 				// Concatenate time and date for a single column if there aren't two dedicated columns for time and date.
 				displayDateTimeBuffer.format(L"%s %s", displayTimeBuffer.str(), displayDateBuffer.str());
 			}

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
@@ -375,6 +375,10 @@ void PopulateReplayFileListbox(GameWindow *listbox)
 				GadgetListBoxAddEntryText(listbox, header.versionString, color, insertionIndex, 3);
 				GadgetListBoxAddEntryText(listbox, mapStr, mapColor, insertionIndex, 4);
 			}
+			else
+			{
+				DEBUG_CRASH(("Replay menu uses %d columns; expected either 4 or 5", columns));
+			}
 
 			// TheSuperHackers @performance Now stops processing when the list is full.
 			if (insertionIndex == listboxLength - 1)

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
@@ -241,6 +241,7 @@ void PopulateReplayFileListbox(GameWindow *listbox)
 
 	GadgetListBoxReset(listbox);
 	const Int listboxLength = GadgetListBoxGetListLength(listbox);
+	const Int columns = GadgetListBoxGetNumColumns(listbox);
 
 	// TheSuperHackers @tweak xezon 08/06/2025 Now shows missing maps in red color.
 	enum {
@@ -291,8 +292,16 @@ void PopulateReplayFileListbox(GameWindow *listbox)
 			UnicodeString replayNameToShow = createReplayName(asciistr);
 
 			// TheSuperHackers @tweak Caball009 07/02/2025 Display both time and date instead of only time.
+			const UnicodeString displayTimeBuffer = getUnicodeTimeBuffer(header.timeVal);
+			const UnicodeString displayDateBuffer = getUnicodeDateBuffer(header.timeVal);
+
 			UnicodeString displayDateTimeBuffer;
-			displayDateTimeBuffer.format(L"%s %s", getUnicodeTimeBuffer(header.timeVal).str(), getUnicodeDateBuffer(header.timeVal).str());
+			if (columns == 4)
+			{
+				// TheSuperHackers @info Caball009 09/02/2025 The original replay window menu has only 4 columns.
+				// Concatenate time and date for a single column if there aren't two dedicated columns for time and date.
+				displayDateTimeBuffer.format(L"%s %s", displayTimeBuffer.str(), displayDateBuffer.str());
+			}
 
 			// version (no-op)
 
@@ -353,9 +362,19 @@ void PopulateReplayFileListbox(GameWindow *listbox)
 
 			const Int insertionIndex = GadgetListBoxAddEntryText(listbox, replayNameToShow, color, -1, 0);
 			DEBUG_ASSERTCRASH(insertionIndex >= 0, ("Expects valid index"));
-			GadgetListBoxAddEntryText(listbox, displayDateTimeBuffer, color, insertionIndex, 1);
-			GadgetListBoxAddEntryText(listbox, header.versionString, color, insertionIndex, 2);
-			GadgetListBoxAddEntryText(listbox, mapStr, mapColor, insertionIndex, 3);
+			if (columns == 4)
+			{
+				GadgetListBoxAddEntryText(listbox, displayDateTimeBuffer, color, insertionIndex, 1);
+				GadgetListBoxAddEntryText(listbox, header.versionString, color, insertionIndex, 2);
+				GadgetListBoxAddEntryText(listbox, mapStr, mapColor, insertionIndex, 3);
+			}
+			else if (columns == 5)
+			{
+				GadgetListBoxAddEntryText(listbox, displayTimeBuffer, color, insertionIndex, 1);
+				GadgetListBoxAddEntryText(listbox, displayDateBuffer, color, insertionIndex, 2);
+				GadgetListBoxAddEntryText(listbox, header.versionString, color, insertionIndex, 3);
+				GadgetListBoxAddEntryText(listbox, mapStr, mapColor, insertionIndex, 4);
+			}
 
 			// TheSuperHackers @performance Now stops processing when the list is full.
 			if (insertionIndex == listboxLength - 1)

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
@@ -354,10 +354,11 @@ void PopulateReplayFileListbox(GameWindow *listbox)
 
 			const Int insertionIndex = GadgetListBoxAddEntryText(listbox, replayNameToShow, color, -1, 0);
 			DEBUG_ASSERTCRASH(insertionIndex >= 0, ("Expects valid index"));
+
+			// TheSuperHackers @info Caball009 09/02/2026 Original replay menu has 4 columns; the code now supports a future 5-column layout.
+			// If there aren't two columns for time and date, concatenate them for a single column.
 			if (columns == 4)
 			{
-				// TheSuperHackers @info Caball009 09/02/2025 The original replay window menu has only four columns.
-				// Concatenate time and date for a single column if there aren't two dedicated columns for time and date.
 				UnicodeString displayDateTimeBuffer;
 				displayDateTimeBuffer.format(L"%s %s", displayTimeBuffer.str(), displayDateBuffer.str());
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
@@ -295,14 +295,6 @@ void PopulateReplayFileListbox(GameWindow *listbox)
 			const UnicodeString displayTimeBuffer = getUnicodeTimeBuffer(header.timeVal);
 			const UnicodeString displayDateBuffer = getUnicodeDateBuffer(header.timeVal);
 
-			UnicodeString displayDateTimeBuffer;
-			if (columns == 4)
-			{
-				// TheSuperHackers @info Caball009 09/02/2025 The original replay window menu has only four columns.
-				// Concatenate time and date for a single column if there aren't two dedicated columns for time and date.
-				displayDateTimeBuffer.format(L"%s %s", displayTimeBuffer.str(), displayDateBuffer.str());
-			}
-
 			// version (no-op)
 
 			// map
@@ -364,6 +356,11 @@ void PopulateReplayFileListbox(GameWindow *listbox)
 			DEBUG_ASSERTCRASH(insertionIndex >= 0, ("Expects valid index"));
 			if (columns == 4)
 			{
+				// TheSuperHackers @info Caball009 09/02/2025 The original replay window menu has only four columns.
+				// Concatenate time and date for a single column if there aren't two dedicated columns for time and date.
+				UnicodeString displayDateTimeBuffer;
+				displayDateTimeBuffer.format(L"%s %s", displayTimeBuffer.str(), displayDateBuffer.str());
+
 				GadgetListBoxAddEntryText(listbox, displayDateTimeBuffer, color, insertionIndex, 1);
 				GadgetListBoxAddEntryText(listbox, header.versionString, color, insertionIndex, 2);
 				GadgetListBoxAddEntryText(listbox, mapStr, mapColor, insertionIndex, 3);


### PR DESCRIPTION
* Follow-up for https://github.com/TheSuperHackers/GeneralsGameCode/pull/2255

This PR adds support for an updated replay menu window (in the future) that has a fifth column, so that the time and date can both be in separate columns (2 and 3).

## TODO:
- [x] Replicate in Generals.