### PR TITLE
bugfix(cratecollide): Prevent crates from being collected multiple times in a single frame

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Collide/CrateCollide/CrateCollide.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Collide/CrateCollide/CrateCollide.cpp
@@ -162,6 +162,12 @@ Bool CrateCollide::isValidToExecute( const Object *other ) const
 	if( getObject()->isAboveTerrain() && !validBuildingAttempt )
 		return FALSE;
 
+	// TheSuperHackers @bugfix Stubbjax 09/02/2026 Prevent the crate from being collected multiple times in a single frame.
+#if !RETAIL_COMPATIBLE_CRC
+	if (getObject()->isDestroyed())
+		return FALSE;
+#endif
+
 	if( md->m_isForbidOwnerPlayer  &&  (getObject()->getControllingPlayer() == other->getControllingPlayer()) )
 		return FALSE; // Design has decreed this to not be picked up by the dead guy's team.
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Collide/CrateCollide/CrateCollide.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Collide/CrateCollide/CrateCollide.cpp
@@ -165,6 +165,12 @@ Bool CrateCollide::isValidToExecute( const Object *other ) const
 	if( getObject()->isAboveTerrain() && !validBuildingAttempt )
 		return FALSE;
 
+	// TheSuperHackers @bugfix Stubbjax 09/02/2026 Prevent the crate from being collected multiple times in a single frame.
+#if !RETAIL_COMPATIBLE_CRC
+	if (getObject()->isDestroyed())
+		return FALSE;
+#endif
+
 	if( md->m_isForbidOwnerPlayer  &&  (getObject()->getControllingPlayer() == other->getControllingPlayer()) )
 		return FALSE; // Design has decreed this to not be picked up by the dead guy's team.
 


### PR DESCRIPTION
Closes #31
Closes #391

This change fixes an issue where crates can be collected multiple times in a single frame. The fix applies to all crates, but it most prominently affects two cases in particular:

- Supply Drop Zone crate: Can be collected multiple times when dropped over densely populated buildings of the same height
- Salvage crate: Neighbouring units often collect the same salvage crate when a GLA vehicle is destroyed within a group

### Before
Collecting six $1,000 crates returns $10,000

https://github.com/user-attachments/assets/46f2993d-2644-40e5-90b0-f3a7d433ea8d

### After
Collecting six $1,000 crates returns $6,000

https://github.com/user-attachments/assets/2817e394-0f1b-4829-8122-c7cefac5ca52