### PR TITLE
bugfix(gui): Fix application hang from scrolling a map list with arrow keys

### DIFF
--- a/Generals/Code/GameEngine/Include/GameClient/Gadget.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Gadget.h
@@ -371,11 +371,11 @@ typedef struct _ListboxData
 	Int					selectPos;				// Position of current selected entry (for SINGLE select)
 	Int					*selections;			// Pointer to array of selections (for MULTI select)
 
-	Short				displayHeight;		// Height in pixels of listbox display region
+	Int					displayHeight;		// Height in pixels of listbox display region
 																// this is computed based on the existence
 																// of a title or not.
 	UnsignedInt doubleClickTime;	//
-	Short				displayPos;				// Position of current display entry in pixels
+	Int					displayPos;				// Position of current display entry in pixels
 
 } ListboxData;
 

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Gadget.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Gadget.h
@@ -374,11 +374,11 @@ typedef struct _ListboxData
 	Int					selectPos;				// Position of current selected entry (for SINGLE select)
 	Int					*selections;			// Pointer to array of selections (for MULTI select)
 
-	Short				displayHeight;		// Height in pixels of listbox display region
+	Int					displayHeight;		// Height in pixels of listbox display region
 																// this is computed based on the existence
 																// of a title or not.
 	UnsignedInt doubleClickTime;	//
-	Short				displayPos;				// Position of current display entry in pixels
+	Int					displayPos;				// Position of current display entry in pixels
 
 } ListboxData;
 


### PR DESCRIPTION
* fixes #1851

## Steps to reproduce

- Edit for example WindowZH.big: SkirmishMapSelectWindow.wnd to increase the max number of maps you can see in the map list to a high number
```
LISTBOXDATA = LENGTH: 1200
```
- Put a ton of maps in your folder, I used 1200 maps
- Go to skirmish lobby and scroll down with arrow keys until the game freezes

Credits to DrGoldFish for helping reproduce this.

## Fix

It was caused by the listbox height and current scroll position overflowing. Both were stored as `short`, so with enough maps the values would wrap once the height got large. You can also see this in the bug report video: when you drag the scrollbar all the way to the end, the list wraps around and shows the first maps again instead of the last ones. When scrolling with the arrow keys this gets you stuck in an infinite loop.