### PR TITLE
feat(input): Use force attack to get the latest building orientation

### DIFF
--- a/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -444,6 +444,8 @@ public:  // ********************************************************************
 	virtual Bool isPlacementAnchored( void );													///< is placement arrow anchor set
 	virtual void getPlacementPoints( ICoord2D *start, ICoord2D *end );///< get the placemnt arrow points
 	virtual Real getPlacementAngle( void );														///< placement angle of drawable at cursor when placing down structures
+	virtual Real getLatestBuildingOrientation() const { return m_latestBuildingOrientation; } ///< TBD
+	virtual void setLatestBuildingOrientation(Real angle) { m_latestBuildingOrientation = angle; } ///< TBD
 
 	// Drawable selection mechanisms
 	virtual void selectDrawable( Drawable *draw );					///< Mark given Drawable as "selected"
@@ -742,7 +744,7 @@ protected:
 	Bool												m_placeAnchorInProgress;								///< is place angle interface for placement active
 	ICoord2D										m_placeAnchorStart;											///< place angle anchor start
 	ICoord2D										m_placeAnchorEnd;												///< place angle anchor end
-	Real												m_placeAnchorOrientation;								///< latest building orientation from placement anchoring
+	Real												m_latestBuildingOrientation;						///< latest building orientation
 	Int													m_selectCount;													///< Number of objects currently "selected"
 	Int													m_maxSelectCount;												///< Max number of objects to select
 	UnsignedInt									m_frameSelectionChanged;								///< Frame when the selection last changed.

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -742,6 +742,7 @@ protected:
 	Bool												m_placeAnchorInProgress;								///< is place angle interface for placement active
 	ICoord2D										m_placeAnchorStart;											///< place angle anchor start
 	ICoord2D										m_placeAnchorEnd;												///< place angle anchor end
+	Real												m_placeAnchorOrientation;								///< latest building orientation from placement anchoring
 	Int													m_selectCount;													///< Number of objects currently "selected"
 	Int													m_maxSelectCount;												///< Max number of objects to select
 	UnsignedInt									m_frameSelectionChanged;								///< Frame when the selection last changed.

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -1618,7 +1618,7 @@ void InGameUI::handleBuildPlacements( void )
 		Coord3D world;
 
 		// TheSuperHackers @tweak Caball009 09/02/2026 Use force attack to get the latest building orientation from placement anchoring for convenience.
-		Real angle = (isInForceAttackMode()) ? m_placeAnchorOrientation : m_placeIcon[ 0 ]->getOrientation();
+		Real angle = isInForceAttackMode() ? m_placeAnchorOrientation : m_placeIcon[ 0 ]->getOrientation();
 
 		// update the angle of the icon to match any placement angle and pick the
 		// location the icon will be at (anchored is the start, otherwise it's the mouse)

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -1131,6 +1131,7 @@ InGameUI::InGameUI()
 	m_placeAnchorStart.x = m_placeAnchorStart.y = 0;
 	m_placeAnchorEnd.x = m_placeAnchorEnd.y = 0;
 	m_placeAnchorInProgress = FALSE;
+	m_placeAnchorOrientation = 0.0f;
 
 	m_videoStream = nullptr;
 	m_videoBuffer = nullptr;
@@ -1615,7 +1616,9 @@ void InGameUI::handleBuildPlacements( void )
 	{
 		ICoord2D loc;
 		Coord3D world;
-		Real angle = m_placeIcon[ 0 ]->getOrientation();
+
+		// TheSuperHackers @tweak Caball009 09/02/2026 Use force fire to get the latest building orientation from placement anchoring for convenience.
+		Real angle = (isInForceAttackMode()) ? m_placeAnchorOrientation : m_placeIcon[ 0 ]->getOrientation();
 
 		// update the angle of the icon to match any placement angle and pick the
 		// location the icon will be at (anchored is the start, otherwise it's the mouse)
@@ -1650,6 +1653,8 @@ void InGameUI::handleBuildPlacements( void )
 					const Real snapRadians = DEG_TO_RADF(45);
 					angle = WWMath::Round(angle / snapRadians) * snapRadians;
 				}
+
+				m_placeAnchorOrientation = angle;
 			}
 
 		}

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -1131,7 +1131,7 @@ InGameUI::InGameUI()
 	m_placeAnchorStart.x = m_placeAnchorStart.y = 0;
 	m_placeAnchorEnd.x = m_placeAnchorEnd.y = 0;
 	m_placeAnchorInProgress = FALSE;
-	m_placeAnchorOrientation = 0.0f;
+	m_latestBuildingOrientation = RANDOM_START_ANGLE;
 
 	m_videoStream = nullptr;
 	m_videoBuffer = nullptr;
@@ -1616,9 +1616,7 @@ void InGameUI::handleBuildPlacements( void )
 	{
 		ICoord2D loc;
 		Coord3D world;
-
-		// TheSuperHackers @tweak Caball009 09/02/2026 Use force attack to get the latest building orientation from placement anchoring for convenience.
-		Real angle = isInForceAttackMode() ? m_placeAnchorOrientation : m_placeIcon[ 0 ]->getOrientation();
+		Real angle = m_placeIcon[ 0 ]->getOrientation();
 
 		// update the angle of the icon to match any placement angle and pick the
 		// location the icon will be at (anchored is the start, otherwise it's the mouse)
@@ -1653,13 +1651,16 @@ void InGameUI::handleBuildPlacements( void )
 					const Real snapRadians = DEG_TO_RADF(45);
 					angle = WWMath::Round(angle / snapRadians) * snapRadians;
 				}
-
-				m_placeAnchorOrientation = angle;
 			}
 
+			m_latestBuildingOrientation = RANDOM_START_ANGLE;
 		}
 		else
 		{
+			// TheSuperHackers @tweak Caball009 10/02/2026 Use force attack to get the latest building orientation for convenience.
+			if (isInForceAttackMode() && m_latestBuildingOrientation != RANDOM_START_ANGLE)
+				angle = m_latestBuildingOrientation;
+
 			const MouseIO *mouseIO = TheMouse->getMouseStatus();
 
 			// location is the mouse position
@@ -2164,6 +2165,7 @@ void InGameUI::reset( void )
 
 	// remove any build available status
 	placeBuildAvailable( nullptr, nullptr );
+	m_latestBuildingOrientation = RANDOM_START_ANGLE;
 
 	// free any message resources allocated
 	freeMessageResources();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -1617,7 +1617,7 @@ void InGameUI::handleBuildPlacements( void )
 		ICoord2D loc;
 		Coord3D world;
 
-		// TheSuperHackers @tweak Caball009 09/02/2026 Use force fire to get the latest building orientation from placement anchoring for convenience.
+		// TheSuperHackers @tweak Caball009 09/02/2026 Use force attack to get the latest building orientation from placement anchoring for convenience.
 		Real angle = (isInForceAttackMode()) ? m_placeAnchorOrientation : m_placeIcon[ 0 ]->getOrientation();
 
 		// update the angle of the icon to match any placement angle and pick the

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/PlaceEventTranslator.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/PlaceEventTranslator.cpp
@@ -284,6 +284,8 @@ GameMessageDisposition PlaceEventTranslator::translateGameMessage(const GameMess
 					// get out of pending placement mode, this will also clear the arrow anchor status
 					TheInGameUI->placeBuildAvailable( nullptr, nullptr );
 
+					// TheSuperHackers @tweak Caball009 10/02/2026 Store the latest building orientation for convenience.
+					TheInGameUI->setLatestBuildingOrientation(angle);
 				}
 				else
 				{


### PR DESCRIPTION
* Related PR: https://github.com/TheSuperHackers/GeneralsGameCode/pull/1472

This PR allows the use of force attack (i.e. pressing `CTRL`) to get the latest building orientation ~that was used for the placement anchoring~.

https://github.com/user-attachments/assets/ea08c490-8f1e-45d1-b934-878151a812c7

## TODO:
- [ ] Replicate in Generals.