### PR TITLE
refactor(netpacket): Clean up net packet code comments, struct names and duplicate code

### DIFF
--- a/Core/GameEngine/Include/GameNetwork/NetPacketStructs.h
+++ b/Core/GameEngine/Include/GameNetwork/NetPacketStructs.h
@@ -70,7 +70,7 @@ struct NetPacketCommandIdField {
 	UnsignedShort commandId;
 };
 
-struct NetPacketDataFieldHeader {
+struct NetPacketDataField {
 	char header;
 };
 
@@ -81,7 +81,7 @@ struct NetPacketDataFieldHeader {
 struct NetPacketAckCommand {
 	NetPacketCommandTypeField commandType;
 	NetPacketPlayerIdField playerId;
-	NetPacketDataFieldHeader dataHeader;
+	NetPacketDataField dataHeader;
 	UnsignedShort commandId;           // Command ID being acknowledged
 	UnsignedByte originalPlayerId;     // Original player who sent the command
 };
@@ -92,7 +92,7 @@ struct NetPacketFrameCommand {
 	NetPacketRelayField relay;
 	NetPacketPlayerIdField playerId;
 	NetPacketCommandIdField commandId;
-	NetPacketDataFieldHeader dataHeader;
+	NetPacketDataField dataHeader;
 	UnsignedShort commandCount;
 };
 
@@ -102,7 +102,7 @@ struct NetPacketPlayerLeaveCommand {
 	NetPacketFrameField frame;
 	NetPacketPlayerIdField playerId;
 	NetPacketCommandIdField commandId;
-	NetPacketDataFieldHeader dataHeader;
+	NetPacketDataField dataHeader;
 	UnsignedByte leavingPlayerId;
 };
 
@@ -111,7 +111,7 @@ struct NetPacketRunAheadMetricsCommand {
 	NetPacketRelayField relay;
 	NetPacketPlayerIdField playerId;
 	NetPacketCommandIdField commandId;
-	NetPacketDataFieldHeader dataHeader;
+	NetPacketDataField dataHeader;
 	Real averageLatency;
 	UnsignedShort averageFps;
 };
@@ -122,7 +122,7 @@ struct NetPacketRunAheadCommand {
 	NetPacketFrameField frame;
 	NetPacketPlayerIdField playerId;
 	NetPacketCommandIdField commandId;
-	NetPacketDataFieldHeader dataHeader;
+	NetPacketDataField dataHeader;
 	UnsignedShort runAhead;
 	UnsignedByte frameRate;
 };
@@ -133,7 +133,7 @@ struct NetPacketDestroyPlayerCommand {
 	NetPacketFrameField frame;
 	NetPacketPlayerIdField playerId;
 	NetPacketCommandIdField commandId;
-	NetPacketDataFieldHeader dataHeader;
+	NetPacketDataField dataHeader;
 	UnsignedInt playerIndex;
 };
 
@@ -141,14 +141,14 @@ struct NetPacketKeepAliveCommand {
 	NetPacketCommandTypeField commandType;
 	NetPacketRelayField relay;
 	NetPacketPlayerIdField playerId;
-	NetPacketDataFieldHeader dataHeader;
+	NetPacketDataField dataHeader;
 };
 
 struct NetPacketDisconnectKeepAliveCommand {
 	NetPacketCommandTypeField commandType;
 	NetPacketRelayField relay;
 	NetPacketPlayerIdField playerId;
-	NetPacketDataFieldHeader dataHeader;
+	NetPacketDataField dataHeader;
 };
 
 struct NetPacketDisconnectPlayerCommand {
@@ -156,7 +156,7 @@ struct NetPacketDisconnectPlayerCommand {
 	NetPacketRelayField relay;
 	NetPacketPlayerIdField playerId;
 	NetPacketCommandIdField commandId;
-	NetPacketDataFieldHeader dataHeader;
+	NetPacketDataField dataHeader;
 	UnsignedByte slot;
 	UnsignedInt disconnectFrame;
 };
@@ -165,14 +165,14 @@ struct NetPacketRouterQueryCommand {
 	NetPacketCommandTypeField commandType;
 	NetPacketRelayField relay;
 	NetPacketPlayerIdField playerId;
-	NetPacketDataFieldHeader dataHeader;
+	NetPacketDataField dataHeader;
 };
 
 struct NetPacketRouterAckCommand {
 	NetPacketCommandTypeField commandType;
 	NetPacketRelayField relay;
 	NetPacketPlayerIdField playerId;
-	NetPacketDataFieldHeader dataHeader;
+	NetPacketDataField dataHeader;
 };
 
 struct NetPacketDisconnectVoteCommand {
@@ -180,38 +180,38 @@ struct NetPacketDisconnectVoteCommand {
 	NetPacketRelayField relay;
 	NetPacketPlayerIdField playerId;
 	NetPacketCommandIdField commandId;
-	NetPacketDataFieldHeader dataHeader;
+	NetPacketDataField dataHeader;
 	UnsignedByte slot;
 	UnsignedInt voteFrame;
 };
 
-struct NetPacketChatCommandHeader {
+struct NetPacketChatCommand {
 	NetPacketCommandTypeField commandType;
 	NetPacketFrameField frame;
 	NetPacketRelayField relay;
 	NetPacketPlayerIdField playerId;
 	NetPacketCommandIdField commandId;
-	NetPacketDataFieldHeader dataHeader;
+	NetPacketDataField dataHeader;
 	UnsignedByte textLength;
 	// Variable fields: WideChar text[textLength] + Int playerMask
 };
 
-struct NetPacketDisconnectChatCommandHeader {
+struct NetPacketDisconnectChatCommand {
 	NetPacketCommandTypeField commandType;
 	NetPacketRelayField relay;
 	NetPacketPlayerIdField playerId;
-	NetPacketDataFieldHeader dataHeader;
+	NetPacketDataField dataHeader;
 	UnsignedByte textLength;
 	// Variable fields: WideChar text[textLength]
 };
 
-struct NetPacketGameCommandHeader {
+struct NetPacketGameCommand {
 	NetPacketCommandTypeField commandType;
 	NetPacketFrameField frame;
 	NetPacketRelayField relay;
 	NetPacketPlayerIdField playerId;
 	NetPacketCommandIdField commandId;
-	NetPacketDataFieldHeader dataHeader;
+	NetPacketDataField dataHeader;
 	// Variable fields: GameMessage type + argument types + argument data
 };
 
@@ -220,7 +220,7 @@ struct NetPacketWrapperCommand {
 	NetPacketRelayField relay;
 	NetPacketPlayerIdField playerId;
 	NetPacketCommandIdField commandId;
-	NetPacketDataFieldHeader dataHeader;
+	NetPacketDataField dataHeader;
 	UnsignedShort wrappedCommandId;
 	UnsignedInt chunkNumber;
 	UnsignedInt numChunks;
@@ -234,7 +234,7 @@ struct NetPacketFileCommand {
 	NetPacketRelayField relay;
 	NetPacketPlayerIdField playerId;
 	NetPacketCommandIdField commandId;
-	NetPacketDataFieldHeader dataHeader;
+	NetPacketDataField dataHeader;
 	// Variable fields: null-terminated filename + UnsignedInt fileDataLength + file data
 };
 
@@ -243,7 +243,7 @@ struct NetPacketFileAnnounceCommand {
 	NetPacketRelayField relay;
 	NetPacketPlayerIdField playerId;
 	NetPacketCommandIdField commandId;
-	NetPacketDataFieldHeader dataHeader;
+	NetPacketDataField dataHeader;
 	// Variable fields: null-terminated filename + UnsignedShort fileID + UnsignedByte playerMask
 };
 
@@ -252,33 +252,33 @@ struct NetPacketFileProgressCommand {
 	NetPacketRelayField relay;
 	NetPacketPlayerIdField playerId;
 	NetPacketCommandIdField commandId;
-	NetPacketDataFieldHeader dataHeader;
+	NetPacketDataField dataHeader;
 	UnsignedShort fileId;
 	Int progress;
 };
 
-struct NetPacketProgressMessage {
+struct NetPacketProgressCommand {
 	NetPacketCommandTypeField commandType;
 	NetPacketRelayField relay;
 	NetPacketPlayerIdField playerId;
-	NetPacketDataFieldHeader dataHeader;
+	NetPacketDataField dataHeader;
 	UnsignedByte percentage;
 };
 
-struct NetPacketLoadCompleteMessage {
+struct NetPacketLoadCompleteCommand {
 	NetPacketCommandTypeField commandType;
 	NetPacketRelayField relay;
 	NetPacketPlayerIdField playerId;
 	NetPacketCommandIdField commandId;
-	NetPacketDataFieldHeader dataHeader;
+	NetPacketDataField dataHeader;
 };
 
-struct NetPacketTimeOutGameStartMessage {
+struct NetPacketTimeOutGameStartCommand {
 	NetPacketCommandTypeField commandType;
 	NetPacketRelayField relay;
 	NetPacketPlayerIdField playerId;
 	NetPacketCommandIdField commandId;
-	NetPacketDataFieldHeader dataHeader;
+	NetPacketDataField dataHeader;
 };
 
 struct NetPacketDisconnectFrameCommand {
@@ -286,7 +286,7 @@ struct NetPacketDisconnectFrameCommand {
 	NetPacketRelayField relay;
 	NetPacketPlayerIdField playerId;
 	NetPacketCommandIdField commandId;
-	NetPacketDataFieldHeader dataHeader;
+	NetPacketDataField dataHeader;
 	UnsignedInt disconnectFrame;
 };
 
@@ -295,7 +295,7 @@ struct NetPacketDisconnectScreenOffCommand {
 	NetPacketRelayField relay;
 	NetPacketPlayerIdField playerId;
 	NetPacketCommandIdField commandId;
-	NetPacketDataFieldHeader dataHeader;
+	NetPacketDataField dataHeader;
 	UnsignedInt newFrame;
 };
 
@@ -304,7 +304,7 @@ struct NetPacketFrameResendRequestCommand {
 	NetPacketRelayField relay;
 	NetPacketPlayerIdField playerId;
 	NetPacketCommandIdField commandId;
-	NetPacketDataFieldHeader dataHeader;
+	NetPacketDataField dataHeader;
 	UnsignedInt frameToResend;
 };
 

--- a/Core/GameEngine/Source/GameNetwork/NetCommandMsg.cpp
+++ b/Core/GameEngine/Source/GameNetwork/NetCommandMsg.cpp
@@ -225,7 +225,7 @@ void NetGameCommandMsg::setGameMessageType(GameMessage::Type type) {
 }
 
 size_t NetGameCommandMsg::getPackedByteCount() const {
-	UnsignedShort msglen = sizeof(NetPacketGameCommandHeader);
+	UnsignedShort msglen = sizeof(NetPacketGameCommand);
 
 	// Variable data portion
 	GameMessage *gmsg = constructGameMessage();
@@ -870,7 +870,7 @@ void NetChatCommandMsg::setPlayerMask( Int playerMask )
 
 size_t NetChatCommandMsg::getPackedByteCount() const
 {
-	return sizeof(NetPacketChatCommandHeader)
+	return sizeof(NetPacketChatCommand)
 		+ m_text.getByteCount()
 		+ sizeof(m_playerMask);
 }
@@ -880,7 +880,7 @@ size_t NetChatCommandMsg::getPackedByteCount() const
 //-------------------------
 size_t NetDisconnectChatCommandMsg::getPackedByteCount() const
 {
-	return sizeof(NetPacketDisconnectChatCommandHeader)
+	return sizeof(NetPacketDisconnectChatCommand)
 		+ m_text.getByteCount();
 }
 
@@ -955,7 +955,7 @@ void NetProgressCommandMsg::setPercentage( UnsignedByte percent )
 }
 
 size_t NetProgressCommandMsg::getPackedByteCount() const {
-	return sizeof(NetPacketProgressMessage);
+	return sizeof(NetPacketProgressCommand);
 }
 
 //-------------------------
@@ -1244,7 +1244,7 @@ NetLoadCompleteCommandMsg::~NetLoadCompleteCommandMsg() {
 }
 
 size_t NetLoadCompleteCommandMsg::getPackedByteCount() const {
-	return sizeof(NetPacketLoadCompleteMessage);
+	return sizeof(NetPacketLoadCompleteCommand);
 }
 
 //-------------------------
@@ -1258,5 +1258,5 @@ NetTimeOutGameStartCommandMsg::~NetTimeOutGameStartCommandMsg() {
 }
 
 size_t NetTimeOutGameStartCommandMsg::getPackedByteCount() const {
-	return sizeof(NetPacketTimeOutGameStartMessage);
+	return sizeof(NetPacketTimeOutGameStartCommand);
 }

--- a/Core/GameEngine/Source/GameNetwork/NetPacket.cpp
+++ b/Core/GameEngine/Source/GameNetwork/NetPacket.cpp
@@ -377,7 +377,7 @@ void NetPacket::FillBufferWithGameCommand(UnsignedByte *buffer, NetCommandRef *m
 
 	//DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::FillBufferWithGameCommand for command ID %d", cmdMsg->getID()));
 
-	NetPacketGameCommandHeader* packet = reinterpret_cast<NetPacketGameCommandHeader*>(buffer);
+	NetPacketGameCommand* packet = reinterpret_cast<NetPacketGameCommand*>(buffer);
 	packet->commandType.header = NetPacketFieldTypes::CommandType;
 	packet->commandType.commandType = cmdMsg->getNetCommandType();
 	packet->frame.header = NetPacketFieldTypes::Frame;
@@ -391,7 +391,7 @@ void NetPacket::FillBufferWithGameCommand(UnsignedByte *buffer, NetCommandRef *m
 	packet->dataHeader.header = NetPacketFieldTypes::Data;
 
 	// Variable data portion
-	UnsignedShort offset = sizeof(NetPacketGameCommandHeader);
+	UnsignedShort offset = sizeof(NetPacketGameCommand);
 
 	// Now copy the GameMessage type into the packet.
 	GameMessage::Type newType = gmsg->getType();
@@ -704,7 +704,7 @@ void NetPacket::FillBufferWithDisconnectChatCommand(UnsignedByte *buffer, NetCom
 	NetDisconnectChatCommandMsg *cmdMsg = (NetDisconnectChatCommandMsg *)(msg->getCommand());
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addDisconnectChatCommand - adding run ahead command"));
 
-	NetPacketDisconnectChatCommandHeader* packet = reinterpret_cast<NetPacketDisconnectChatCommandHeader*>(buffer);
+	NetPacketDisconnectChatCommand* packet = reinterpret_cast<NetPacketDisconnectChatCommand*>(buffer);
 	packet->commandType.header = NetPacketFieldTypes::CommandType;
 	packet->commandType.commandType = cmdMsg->getNetCommandType();
 	packet->relay.header = NetPacketFieldTypes::Relay;
@@ -717,7 +717,7 @@ void NetPacket::FillBufferWithDisconnectChatCommand(UnsignedByte *buffer, NetCom
 	packet->textLength = unitext.getLength();
 
 	// Variable data portion
-	UnsignedShort offset = sizeof(NetPacketDisconnectChatCommandHeader);
+	UnsignedShort offset = sizeof(NetPacketDisconnectChatCommand);
 	memcpy(buffer + offset, unitext.str(), packet->textLength * sizeof(UnsignedShort));
 	offset += packet->textLength * sizeof(UnsignedShort);
 }
@@ -744,7 +744,7 @@ void NetPacket::FillBufferWithChatCommand(UnsignedByte *buffer, NetCommandRef *m
 	NetChatCommandMsg *cmdMsg = static_cast<NetChatCommandMsg *>(msg->getCommand());
 //		DEBUG_LOG_LEVEL(DEBUG_LEVEL_NET, ("NetPacket::addDisconnectChatCommand - adding run ahead command"));
 
-	NetPacketChatCommandHeader* packet = reinterpret_cast<NetPacketChatCommandHeader*>(buffer);
+	NetPacketChatCommand* packet = reinterpret_cast<NetPacketChatCommand*>(buffer);
 	packet->commandType.header = NetPacketFieldTypes::CommandType;
 	packet->commandType.commandType = cmdMsg->getNetCommandType();
 	packet->frame.header = NetPacketFieldTypes::Frame;
@@ -761,7 +761,7 @@ void NetPacket::FillBufferWithChatCommand(UnsignedByte *buffer, NetCommandRef *m
 	packet->textLength = unitext.getLength();
 
 	// Variable data portion
-	UnsignedShort offset = sizeof(NetPacketChatCommandHeader);
+	UnsignedShort offset = sizeof(NetPacketChatCommand);
 	memcpy(buffer + offset, unitext.str(), packet->textLength * sizeof(UnsignedShort));
 	offset += packet->textLength * sizeof(UnsignedShort);
 
@@ -773,7 +773,7 @@ void NetPacket::FillBufferWithChatCommand(UnsignedByte *buffer, NetCommandRef *m
 void NetPacket::FillBufferWithProgressMessage(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetProgressCommandMsg *cmdMsg = (NetProgressCommandMsg *)(msg->getCommand());
 
-	NetPacketProgressMessage* packet = reinterpret_cast<NetPacketProgressMessage*>(buffer);
+	NetPacketProgressCommand* packet = reinterpret_cast<NetPacketProgressCommand*>(buffer);
 	packet->commandType.header = NetPacketFieldTypes::CommandType;
 	packet->commandType.commandType = cmdMsg->getNetCommandType();
 	packet->relay.header = NetPacketFieldTypes::Relay;
@@ -787,7 +787,7 @@ void NetPacket::FillBufferWithProgressMessage(UnsignedByte *buffer, NetCommandRe
 void NetPacket::FillBufferWithLoadCompleteMessage(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetCommandMsg *cmdMsg = static_cast<NetCommandMsg *>(msg->getCommand());
 
-	NetPacketLoadCompleteMessage* packet = reinterpret_cast<NetPacketLoadCompleteMessage*>(buffer);
+	NetPacketLoadCompleteCommand* packet = reinterpret_cast<NetPacketLoadCompleteCommand*>(buffer);
 	packet->commandType.header = NetPacketFieldTypes::CommandType;
 	packet->commandType.commandType = cmdMsg->getNetCommandType();
 	packet->relay.header = NetPacketFieldTypes::Relay;
@@ -802,7 +802,7 @@ void NetPacket::FillBufferWithLoadCompleteMessage(UnsignedByte *buffer, NetComma
 void NetPacket::FillBufferWithTimeOutGameStartMessage(UnsignedByte *buffer, NetCommandRef *msg) {
 	NetCommandMsg *cmdMsg = static_cast<NetCommandMsg *>(msg->getCommand());
 
-	NetPacketTimeOutGameStartMessage* packet = reinterpret_cast<NetPacketTimeOutGameStartMessage*>(buffer);
+	NetPacketTimeOutGameStartCommand* packet = reinterpret_cast<NetPacketTimeOutGameStartCommand*>(buffer);
 	packet->commandType.header = NetPacketFieldTypes::CommandType;
 	packet->commandType.commandType = cmdMsg->getNetCommandType();
 	packet->relay.header = NetPacketFieldTypes::Relay;


### PR DESCRIPTION
**Merge with Rebase**

* Follow up for #1675
* Follow up for #1680

This change contains 2 commits and cleans up the new net packet code a bit.

It removes a bunch of superfluous comments that do not helps the reader, removes 3 duplicated structs and renames structs to achieve more consistent naming tailored to humans.

## TODO

- [x] Add pull id to commit titles
- [x] Test Network match