### PR TITLE
fix(comments): Use 2026 for this year's code comments

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/RTS/ActionManager.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/ActionManager.cpp
@@ -454,7 +454,7 @@ Bool ActionManager::canResumeConstructionOf( const Object *obj,
 	if( obj->isKindOf( KINDOF_DOZER ) == FALSE )
 		return FALSE;
 
-	// TheSuperHackers @bugfix Stubbjax 06/01/2025 Ensure only the owner of the construction can resume it.
+	// TheSuperHackers @bugfix Stubbjax 06/01/2026 Ensure only the owner of the construction can resume it.
 #if RETAIL_COMPATIBLE_CRC
 	Relationship r = obj->getRelationship(objectBeingConstructed);
 

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
@@ -290,7 +290,7 @@ void PopulateReplayFileListbox(GameWindow *listbox)
 			// name
 			UnicodeString replayNameToShow = createReplayName(asciistr);
 
-			// TheSuperHackers @tweak Caball009 07/02/2025 Display both time and date instead of only time.
+			// TheSuperHackers @tweak Caball009 07/02/2026 Display both time and date instead of only time.
 			UnicodeString displayDateTimeBuffer;
 			displayDateTimeBuffer.format(L"%s %s", getUnicodeTimeBuffer(header.timeVal).str(), getUnicodeDateBuffer(header.timeVal).str());
 
@@ -389,7 +389,7 @@ void ReplayMenuInit( WindowLayout *layout, void *userData )
 	buttonCopy = TheWindowManager->winGetWindowFromId( parentReplayMenu, buttonCopyID );
 
 #if ENABLE_GUI_HACKS
-	// TheSuperHackers @tweak Caball009 07/02/2025 The version column is wider than the time / date column.
+	// TheSuperHackers @tweak Caball009 07/02/2026 The version column is wider than the time / date column.
 	// Switch them so that there's enough space to show both time and date without a line break.
 	ListboxData* list = static_cast<ListboxData*>(listboxReplayFiles->winGetUserData());
 

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8caps.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8caps.cpp
@@ -708,7 +708,7 @@ void DX8Caps::Vendor_Specific_Hacks(const D3DADAPTER_IDENTIFIER8& adapter_id)
 	}
 
 	if (adapter_id.VendorId==VENDOR_ID_VMWARE) {
-		// TheSuperHackers @bugfix Stubbjax 15/01/2025 Disable DOT3 support for VMWare's virtual GPU.
+		// TheSuperHackers @bugfix Stubbjax 15/01/2026 Disable DOT3 support for VMWare's virtual GPU.
 		// The D3DTA_ALPHAREPLICATE modifier fails when passed to a D3DTOP_MULTIPLYADD operation.
 		SupportDot3 = false;
 	}

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/render2d.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/render2d.cpp
@@ -612,7 +612,7 @@ void Render2DClass::Render(void)
 			DX8Wrapper::Set_DX8_Texture_Stage_State( 0, D3DTSS_COLORARG2, D3DTA_TFACTOR);
 			DX8Wrapper::Set_DX8_Texture_Stage_State( 0, D3DTSS_COLOROP, D3DTOP_MODULATE);
 
-			// TheSuperHackers @bugfix Stubbjax 08/01/2025 Fix possible greyscale rendering issues on hardware without DOT3 support.
+			// TheSuperHackers @bugfix Stubbjax 08/01/2026 Fix possible greyscale rendering issues on hardware without DOT3 support.
 			DX8Wrapper::Set_DX8_Texture_Stage_State( 1, D3DTSS_COLOROP, D3DTOP_DISABLE);
 		}
 	}

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/ActionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/ActionManager.cpp
@@ -458,7 +458,7 @@ Bool ActionManager::canResumeConstructionOf( const Object *obj,
 	if( obj->isKindOf( KINDOF_DOZER ) == FALSE )
 		return FALSE;
 
-	// TheSuperHackers @bugfix Stubbjax 06/01/2025 Ensure only the owner of the construction can resume it.
+	// TheSuperHackers @bugfix Stubbjax 06/01/2026 Ensure only the owner of the construction can resume it.
 #if RETAIL_COMPATIBLE_CRC
 	Relationship r = obj->getRelationship(objectBeingConstructed);
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ReplayMenu.cpp
@@ -290,7 +290,7 @@ void PopulateReplayFileListbox(GameWindow *listbox)
 			// name
 			UnicodeString replayNameToShow = createReplayName(asciistr);
 
-			// TheSuperHackers @tweak Caball009 07/02/2025 Display both time and date instead of only time.
+			// TheSuperHackers @tweak Caball009 07/02/2026 Display both time and date instead of only time.
 			UnicodeString displayDateTimeBuffer;
 			displayDateTimeBuffer.format(L"%s %s", getUnicodeTimeBuffer(header.timeVal).str(), getUnicodeDateBuffer(header.timeVal).str());
 
@@ -389,7 +389,7 @@ void ReplayMenuInit( WindowLayout *layout, void *userData )
 	buttonCopy = TheWindowManager->winGetWindowFromId( parentReplayMenu, buttonCopyID );
 
 #if ENABLE_GUI_HACKS
-	// TheSuperHackers @tweak Caball009 07/02/2025 The version column is wider than the time / date column.
+	// TheSuperHackers @tweak Caball009 07/02/2026 The version column is wider than the time / date column.
 	// Switch them so that there's enough space to show both time and date without a line break.
 	ListboxData* list = static_cast<ListboxData*>(listboxReplayFiles->winGetUserData());
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8caps.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8caps.cpp
@@ -1162,7 +1162,7 @@ void DX8Caps::Vendor_Specific_Hacks(const D3DADAPTER_IDENTIFIER8& adapter_id)
 	}
 
 	if (VendorId==VENDOR_VMWARE) {
-		// TheSuperHackers @bugfix Stubbjax 15/01/2025 Disable DOT3 support for VMWare's virtual GPU.
+		// TheSuperHackers @bugfix Stubbjax 15/01/2026 Disable DOT3 support for VMWare's virtual GPU.
 		// The D3DTA_ALPHAREPLICATE modifier fails when passed to a D3DTOP_MULTIPLYADD operation.
 		DXLOG(("Disabling DOT3 on VMWare\r\n"));
 		SupportDot3 = false;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/render2d.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/render2d.cpp
@@ -686,7 +686,7 @@ void Render2DClass::Render(void)
 			DX8Wrapper::Set_DX8_Texture_Stage_State( 0, D3DTSS_COLORARG2, D3DTA_TFACTOR);
 			DX8Wrapper::Set_DX8_Texture_Stage_State( 0, D3DTSS_COLOROP, D3DTOP_MODULATE);
 
-			// TheSuperHackers @bugfix Stubbjax 08/01/2025 Fix possible greyscale rendering issues on hardware without DOT3 support.
+			// TheSuperHackers @bugfix Stubbjax 08/01/2026 Fix possible greyscale rendering issues on hardware without DOT3 support.
 			DX8Wrapper::Set_DX8_Texture_Stage_State( 1, D3DTSS_COLOROP, D3DTOP_DISABLE);
 		}
 	}


### PR DESCRIPTION
I noticed that in a couple of places there are 'TheSuperHackers' comments with a date that should use 2026 instead of 2025. This PR fixes that. I used the following regex query: `TheSuperHackers.*\d\d/0[12]/2025`

Replicated in Generals in the second commit.