### PR TITLE
bugfix(view): Recalculate Camera Area Constraints when toggling Control Bar or changing Pitch, FOV

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -193,6 +193,11 @@ void W3DView::setHeight(Int height)
  	m_3DCamera->Get_Viewport(vMin,vMax);
  	vMax.Y=(Real)(m_originY+height)/(Real)TheDisplay->getHeight();
  	m_3DCamera->Set_Viewport(vMin,vMax);
+
+	// TheSuperHackers @bugfix Now recalculates the camera constraints because
+	// showing or hiding the control bar will change the viewable area.
+	m_cameraAreaConstraintsValid = false;
+	m_recalcCamera = true;
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -212,6 +217,9 @@ void W3DView::setWidth(Int width)
 	//we want to maintain the same scale, so we'll need to adjust the fov.
 	//default W3D fov for full-screen is 50 degrees.
 	m_3DCamera->Set_View_Plane((Real)width/(Real)TheDisplay->getWidth()*DEG_TO_RADF(50.0f),-1);
+
+	m_cameraAreaConstraintsValid = false;
+	m_recalcCamera = true;
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1805,6 +1813,7 @@ void W3DView::scrollBy( Coord2D *delta )
 //-------------------------------------------------------------------------------------------------
 void W3DView::forceRedraw()
 {
+	m_cameraAreaConstraintsValid = false;
 	m_recalcCamera = true;
 }
 
@@ -1837,6 +1846,9 @@ void W3DView::setPitch( Real radians )
 	m_doingPitchCamera = false;
 	m_doingZoomCamera = false;
 	m_doingScriptedCameraLock = false;
+	// TheSuperHackers @fix Now recalculates the camera constraints because
+	// the camera pitch can change the camera distance towards the map border.
+	m_cameraAreaConstraintsValid = false;
 	m_recalcCamera = true;
 }
 
@@ -1859,6 +1871,9 @@ void W3DView::setPitchToDefault( void )
 
 	m_FXPitch = 1.0f;
 
+	// TheSuperHackers @fix Now recalculates the camera constraints because
+	// the camera pitch can change the camera distance towards the map border.
+	m_cameraAreaConstraintsValid = false;
 	m_recalcCamera = true;
 }
 
@@ -1948,6 +1963,7 @@ void W3DView::setFieldOfView( Real angle )
 #if defined(RTS_DEBUG)
 	// this is only for testing, and recalculating the
 	// camera every frame is wasteful
+	m_cameraAreaConstraintsValid = false;
 	m_recalcCamera = true;
 #endif
 }


### PR DESCRIPTION
This change recalculates the Camera Area Constraints when toggling the Control Bar or changing Camera Pitch or FOV. Right now Pitch and FOV can only be changed in Debug. But it will become available in Release in the future.

The Camera Area Constraints are responsible for binding the camera into the visible map area, preventing the player from scrolling into oblivion.