### PR TITLE
bugfix(pathfinder): Fix inaccurate single unit movement destinations when unobstructed

### DIFF
--- a/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -5543,7 +5543,7 @@ Bool Pathfinder::adjustDestination(Object *obj, const LocomotorSet& locomotorSet
 	Int i = cell.x;
 	Int j = cell.y;
 	// Check the center cell
-#if RETAIL_COMPATIBLE_CRC
+#if RETAIL_COMPATIBLE_PATHFINDING
 	if (checkForAdjust(obj, locomotorSet, isHuman, i, j, layer, iRadius, center, dest, groupDest)) {
 		return true;
 	}

--- a/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -5550,9 +5550,9 @@ Bool Pathfinder::adjustDestination(Object *obj, const LocomotorSet& locomotorSet
 #else
 	Coord3D adjustDest = *dest;
 	if (checkForAdjust(obj, locomotorSet, isHuman, i, j, layer, iRadius, center, &adjustDest, groupDest)) {
-		// TheSuperHackers @fix stephanmeesters 15/06/2026 Destination adjustment always snaps to the nearest grid cell
+		// TheSuperHackers @bugfix stephanmeesters 15/06/2026 Destination adjustment always snaps to the nearest grid cell
 		// even when no adjustment is necessary because there are no obstructions. For single units this adjustment
-		// can be skipped in order to provide more predictable movement, which is especially noticeable for chinooks.
+		// can be skipped in order to provide more accurate movement, which is especially noticeable for chinooks.
 		const Bool singleUnit = obj && obj->getGroup() && obj->getGroup()->getCount() == 1;
 		const Bool useExactDestination = isHuman && singleUnit;
 		if (!useExactDestination) {

--- a/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -5529,12 +5529,12 @@ Bool Pathfinder::adjustDestination(Object *obj, const LocomotorSet& locomotorSet
 	Bool center;
 	getRadiusAndCenter(obj, iRadius, center);
 	ICoord2D cell;
-	Coord3D adjustDest = *dest;
+	Coord3D cellDest = *dest;
 	if (!center) {
-		adjustDest.x += PATHFIND_CELL_SIZE_F/2;
-		adjustDest.y += PATHFIND_CELL_SIZE_F/2;
+		cellDest.x += PATHFIND_CELL_SIZE_F/2;
+		cellDest.y += PATHFIND_CELL_SIZE_F/2;
 	}
-	worldToCell( &adjustDest, &cell );
+	worldToCell( &cellDest, &cell );
 	PathfindLayerEnum layer = TheTerrainLogic->getLayerForDestination(dest);
 	if (groupDest) {
 		layer = TheTerrainLogic->getLayerForDestination(groupDest);
@@ -5543,9 +5543,24 @@ Bool Pathfinder::adjustDestination(Object *obj, const LocomotorSet& locomotorSet
 	Int i = cell.x;
 	Int j = cell.y;
 	// Check the center cell
-	if (checkForAdjust(obj, locomotorSet, isHuman, i,j, layer, iRadius, center, dest, groupDest)) {
+#if RETAIL_COMPATIBLE_CRC
+	if (checkForAdjust(obj, locomotorSet, isHuman, i, j, layer, iRadius, center, dest, groupDest)) {
 		return true;
 	}
+#else
+	Coord3D adjustDest = *dest;
+	if (checkForAdjust(obj, locomotorSet, isHuman, i, j, layer, iRadius, center, &adjustDest, groupDest)) {
+		// TheSuperHackers @fix stephanmeesters 15/06/2026 Destination adjustment always snaps to the nearest grid cell
+		// even when no adjustment is necessary because there are no obstructions. For single units this adjustment
+		// can be skipped in order to provide more predictable movement, which is especially noticeable for chinooks.
+		const Bool singleUnit = obj && obj->getGroup() && obj->getGroup()->getCount() == 1;
+		const Bool useExactDestination = isHuman && singleUnit;
+		if (!useExactDestination) {
+			*dest = adjustDest;
+		}
+		return true;
+	}
+#endif
 
 	// TheSuperHackers @info Expanding counter-clockwise spiral search around center cell C. Each full lap walks right->up->left->down.
 	// After every pair of directions (right+up, then left+down) length of the segment grows by 1.

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -5278,9 +5278,21 @@ Bool Pathfinder::adjustDestination(Object *obj, const LocomotorSet& locomotorSet
 	Int i, j;
 	i = cell.x;
 	j = cell.y;
+#if RETAIL_COMPATIBLE_CRC
 	if (checkForAdjust(obj, locomotorSet, isHuman, i,j, layer, iRadius, center, dest, groupDest)) {
 		return true;
 	}
+#else
+	// TheSuperHackers @bugfix stephanmeesters 11/02/2026
+	// Keep the original destination when dealing with a single unit and there is no obstruction.
+	const Coord3D originalDest = *dest;
+	if (checkForAdjust(obj, locomotorSet, isHuman, i,j, layer, iRadius, center, dest, groupDest)) {
+		if (isHuman && obj && obj->getGroup() && obj->getGroup()->getCount() == 1) {
+			*dest = originalDest;
+		}
+		return true;
+	}
+#endif
 
 	Int delta=1;
 	Int count;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -5283,11 +5283,13 @@ Bool Pathfinder::adjustDestination(Object *obj, const LocomotorSet& locomotorSet
 		return true;
 	}
 #else
-	// TheSuperHackers @bugfix stephanmeesters 11/02/2026
-	// Keep the original destination when dealing with a single unit and there is no obstruction.
 	const Coord3D originalDest = *dest;
 	if (checkForAdjust(obj, locomotorSet, isHuman, i,j, layer, iRadius, center, dest, groupDest)) {
-		if (isHuman && obj && obj->getGroup() && obj->getGroup()->getCount() == 1) {
+		// --> affect single unit only
+		// if (isHuman && obj && obj->getGroup() && obj->getGroup()->getCount() == 1) {
+
+		// ---> affect groups
+		if (isHuman) {
 			*dest = originalDest;
 		}
 		return true;


### PR DESCRIPTION
* Fixes #247
* Fixes #1998
* Relates to TheSuperHackers/GeneralsGamePatch#1408

When moving units the exact destination will be determined by pathfinding: the  `Pathfinder::adjustDestination` will adjust a given coordinate to account for obstacles. It will however also adjust the destination when there are no obstacles and place it in the middle of a path find cell (as Mauller suspected in the linked issue).

The fix here is to use the original destination when there is no obstruction.

In testing it appears to fix the chinook landing issue (only when the path where it lands is unobstructed).

~~It should be determined whether the change to group unit movement is desirable.~~
**The change affects single unit movement only.** In testing this would negatively impact the feel of moving around a group of units.

----------

## Chinook landing motion
https://github.com/user-attachments/assets/f4fdfde7-4f9c-49bb-9193-4e523674eaa2

## Demonstrate accuracy relative to mouse click
https://github.com/user-attachments/assets/619bfc92-2bd0-416e-b099-d0132a3762a0

## Pathcells debug for single unit
https://github.com/user-attachments/assets/25d61f4f-40da-4744-8212-81513d54ff47

## Pathcells debug for a group of unit
https://github.com/user-attachments/assets/bfbebc92-e211-4f07-afad-9b191c477af9

## Todo

- [x] Add comment