### PR TITLE
fix(headless): Set DX8Wrapper_IsWindowed to false to suppress assertion dialogs during shutdown

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/CommandLine.cpp
+++ b/Generals/Code/GameEngine/Source/Common/CommandLine.cpp
@@ -414,6 +414,13 @@ Int parseHeadless(char *args[], int num)
 	TheWritableGlobalData->m_playIntro = FALSE;
 	TheWritableGlobalData->m_afterIntro = TRUE;
 	TheWritableGlobalData->m_playSizzle = FALSE;
+
+	// TheSuperHackers @fix bobtista 03/02/2026 Set DX8Wrapper_IsWindowed to false in headless
+	// mode so that ignoringAsserts() works correctly throughout the entire process lifetime,
+	// including during shutdown after TheGlobalData has been destroyed.
+	extern bool DX8Wrapper_IsWindowed;
+	DX8Wrapper_IsWindowed = false;
+
 	return 1;
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/CommandLine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/CommandLine.cpp
@@ -414,6 +414,13 @@ Int parseHeadless(char *args[], int num)
 	TheWritableGlobalData->m_playIntro = FALSE;
 	TheWritableGlobalData->m_afterIntro = TRUE;
 	TheWritableGlobalData->m_playSizzle = FALSE;
+
+	// TheSuperHackers @fix bobtista 03/02/2026 Set DX8Wrapper_IsWindowed to false in headless
+	// mode so that ignoringAsserts() works correctly throughout the entire process lifetime,
+	// including during shutdown after TheGlobalData has been destroyed.
+	extern bool DX8Wrapper_IsWindowed;
+	DX8Wrapper_IsWindowed = false;
+
 	return 1;
 }
 

--- a/GeneralsMD/Code/Main/WinMain.cpp
+++ b/GeneralsMD/Code/Main/WinMain.cpp
@@ -884,7 +884,9 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 			DX8Wrapper_IsWindowed = false;
 		}
 		else if (initializeAppWindows(hInstance, nCmdShow, TheGlobalData->m_windowed) == false)
+		{
 			return exitcode;
+		}
 
 		// save our application instance for future use
 		ApplicationHInstance = hInstance;

--- a/GeneralsMD/Code/Main/WinMain.cpp
+++ b/GeneralsMD/Code/Main/WinMain.cpp
@@ -875,7 +875,15 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 #endif
 
 		// register windows class and create application window
-		if(!TheGlobalData->m_headless && initializeAppWindows(hInstance, nCmdShow, TheGlobalData->m_windowed) == false)
+		// TheSuperHackers @fix bobtista 02/03/2026 Set DX8Wrapper_IsWindowed to false in headless
+		// mode so that ignoringAsserts() works correctly throughout the entire process lifetime,
+		// including during shutdown after TheGlobalData has been destroyed.
+		if (TheGlobalData->m_headless)
+		{
+			extern bool DX8Wrapper_IsWindowed;
+			DX8Wrapper_IsWindowed = false;
+		}
+		else if (initializeAppWindows(hInstance, nCmdShow, TheGlobalData->m_windowed) == false)
 			return exitcode;
 
 		// save our application instance for future use

--- a/GeneralsMD/Code/Main/WinMain.cpp
+++ b/GeneralsMD/Code/Main/WinMain.cpp
@@ -875,18 +875,8 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 #endif
 
 		// register windows class and create application window
-		// TheSuperHackers @fix bobtista 03/02/2026 Set DX8Wrapper_IsWindowed to false in headless
-		// mode so that ignoringAsserts() works correctly throughout the entire process lifetime,
-		// including during shutdown after TheGlobalData has been destroyed.
-		if (TheGlobalData->m_headless)
-		{
-			extern bool DX8Wrapper_IsWindowed;
-			DX8Wrapper_IsWindowed = false;
-		}
-		else if (initializeAppWindows(hInstance, nCmdShow, TheGlobalData->m_windowed) == false)
-		{
+		if(!TheGlobalData->m_headless && initializeAppWindows(hInstance, nCmdShow, TheGlobalData->m_windowed) == false)
 			return exitcode;
-		}
 
 		// save our application instance for future use
 		ApplicationHInstance = hInstance;

--- a/GeneralsMD/Code/Main/WinMain.cpp
+++ b/GeneralsMD/Code/Main/WinMain.cpp
@@ -875,7 +875,7 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 #endif
 
 		// register windows class and create application window
-		// TheSuperHackers @fix bobtista 02/03/2026 Set DX8Wrapper_IsWindowed to false in headless
+		// TheSuperHackers @fix bobtista 03/02/2026 Set DX8Wrapper_IsWindowed to false in headless
 		// mode so that ignoringAsserts() works correctly throughout the entire process lifetime,
 		// including during shutdown after TheGlobalData has been destroyed.
 		if (TheGlobalData->m_headless)


### PR DESCRIPTION
## Summary
- Set `DX8Wrapper_IsWindowed` to false in headless mode so `ignoringAsserts()` works - particularly during shutdown after `TheGlobalData` has been destroyed.

## Testing
  - [x] Run headless replay to completion (`-replay test.rep -headless -ignoreAsserts`)
  - [x] Verify no assertion dialogs appear during shutdown
  - [x] Replicate in Generals
