### PR TITLE
bugfix(audio): Fix particle cannon being inaudible after saveload

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
@@ -1464,6 +1464,38 @@ void ParticleUplinkCannonUpdate::loadPostProcess( void )
 				DEBUG_CRASH(( "ParticleUplinkCannonUpdate::loadPostProcess - Unable to find drawable for m_orbitToTargetBeamID" ));
 			}
 		}
+
+		// TheSuperHackers @bugfix stephanmeesters 13/02/2026
+		// For retail game compatibility, this fixes an issue where particle cannon sounds are not audible after saveload.
+		if( (m_status == STATUS_CHARGING || m_status == STATUS_PREPARING || m_status == STATUS_ALMOST_READY) &&
+			m_powerupSound.getEventName().isNotEmpty() )
+		{
+			m_powerupSound.setObjectID( getObject()->getID() );
+			m_powerupSound.setPlayingHandle( TheAudio->addAudioEvent( &m_powerupSound ) );
+		}
+
+		if( (m_status == STATUS_PREPARING || m_status == STATUS_ALMOST_READY || m_status == STATUS_READY_TO_FIRE || m_status == STATUS_PREFIRE) &&
+			m_unpackToReadySound.getEventName().isNotEmpty() )
+		{
+			m_unpackToReadySound.setObjectID( getObject()->getID() );
+			m_unpackToReadySound.setPlayingHandle( TheAudio->addAudioEvent( &m_unpackToReadySound ) );
+		}
+
+		if( m_status == STATUS_FIRING || m_status == STATUS_POSTFIRE ||
+			(m_status == STATUS_PACKING && (m_laserStatus == LASERSTATUS_DECAYING || m_laserStatus == LASERSTATUS_DEAD)) )
+		{
+			if( m_firingToIdleSound.getEventName().isNotEmpty() )
+			{
+				m_firingToIdleSound.setObjectID( getObject()->getID() );
+				m_firingToIdleSound.setPlayingHandle( TheAudio->addAudioEvent( &m_firingToIdleSound ) );
+			}
+
+			if( m_orbitToTargetBeamID != INVALID_DRAWABLE_ID && m_annihilationSound.getEventName().isNotEmpty() )
+			{
+				m_annihilationSound.setDrawableID( m_orbitToTargetBeamID );
+				m_annihilationSound.setPlayingHandle( TheAudio->addAudioEvent( &m_annihilationSound ) );
+			}
+		}
 	}
 
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
@@ -1559,20 +1559,36 @@ void ParticleUplinkCannonUpdate::loadPostProcess( void )
 		}
 	}
 
-	// TheSuperHackers @info stephanmeesters 13/02/2026
-	// Fix issue where sound from the particle cannon is not audible after saveload
-	if( m_status == STATUS_FIRING || m_status == STATUS_POSTFIRE || m_status == STATUS_PACKING )
+	// TheSuperHackers @bugfix stephanmeesters 13/02/2026
+	// Fix issue where particle cannon sounds are not audible after saveload.
+
+	if( (m_status == STATUS_CHARGING || m_status == STATUS_PREPARING || m_status == STATUS_ALMOST_READY) &&
+		m_powerupSound.getEventName().isNotEmpty() )
+	{
+		m_powerupSound.setObjectID( getObject()->getID() );
+		m_powerupSound.setPlayingHandle( TheAudio->addAudioEvent( &m_powerupSound ) );
+	}
+
+	if( (m_status == STATUS_PREPARING || m_status == STATUS_ALMOST_READY || m_status == STATUS_READY_TO_FIRE || m_status == STATUS_PREFIRE) &&
+		m_unpackToReadySound.getEventName().isNotEmpty() )
+	{
+		m_unpackToReadySound.setObjectID( getObject()->getID() );
+		m_unpackToReadySound.setPlayingHandle( TheAudio->addAudioEvent( &m_unpackToReadySound ) );
+	}
+
+	if ( m_status == STATUS_FIRING || m_status == STATUS_POSTFIRE ||
+		(m_status == STATUS_PACKING && (m_laserStatus == LASERSTATUS_DECAYING || m_laserStatus == LASERSTATUS_DEAD)) )
 	{
 		if( m_firingToIdleSound.getEventName().isNotEmpty() )
 		{
 			m_firingToIdleSound.setObjectID( getObject()->getID() );
 			m_firingToIdleSound.setPlayingHandle( TheAudio->addAudioEvent( &m_firingToIdleSound ) );
 		}
+
 		if( m_orbitToTargetBeamID != INVALID_DRAWABLE_ID && m_annihilationSound.getEventName().isNotEmpty() )
 		{
 			m_annihilationSound.setDrawableID( m_orbitToTargetBeamID );
 			m_annihilationSound.setPlayingHandle( TheAudio->addAudioEvent( &m_annihilationSound ) );
 		}
 	}
-
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
@@ -1559,4 +1559,20 @@ void ParticleUplinkCannonUpdate::loadPostProcess( void )
 		}
 	}
 
+	// TheSuperHackers @info stephanmeesters 13/02/2026
+	// Fix issue where sound from the particle cannon is not audible after saveload
+	if( m_status == STATUS_FIRING || m_status == STATUS_POSTFIRE || m_status == STATUS_PACKING )
+	{
+		if( m_firingToIdleSound.getEventName().isNotEmpty() )
+		{
+			m_firingToIdleSound.setObjectID( getObject()->getID() );
+			m_firingToIdleSound.setPlayingHandle( TheAudio->addAudioEvent( &m_firingToIdleSound ) );
+		}
+		if( m_orbitToTargetBeamID != INVALID_DRAWABLE_ID && m_annihilationSound.getEventName().isNotEmpty() )
+		{
+			m_annihilationSound.setDrawableID( m_orbitToTargetBeamID );
+			m_annihilationSound.setPlayingHandle( TheAudio->addAudioEvent( &m_annihilationSound ) );
+		}
+	}
+
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
@@ -1557,38 +1557,37 @@ void ParticleUplinkCannonUpdate::loadPostProcess( void )
 				DEBUG_CRASH(( "ParticleUplinkCannonUpdate::loadPostProcess - Unable to find drawable for m_orbitToTargetBeamID" ));
 			}
 		}
-	}
 
-	// TheSuperHackers @bugfix stephanmeesters 13/02/2026
-	// Fix issue where particle cannon sounds are not audible after saveload.
-
-	if( (m_status == STATUS_CHARGING || m_status == STATUS_PREPARING || m_status == STATUS_ALMOST_READY) &&
-		m_powerupSound.getEventName().isNotEmpty() )
-	{
-		m_powerupSound.setObjectID( getObject()->getID() );
-		m_powerupSound.setPlayingHandle( TheAudio->addAudioEvent( &m_powerupSound ) );
-	}
-
-	if( (m_status == STATUS_PREPARING || m_status == STATUS_ALMOST_READY || m_status == STATUS_READY_TO_FIRE || m_status == STATUS_PREFIRE) &&
-		m_unpackToReadySound.getEventName().isNotEmpty() )
-	{
-		m_unpackToReadySound.setObjectID( getObject()->getID() );
-		m_unpackToReadySound.setPlayingHandle( TheAudio->addAudioEvent( &m_unpackToReadySound ) );
-	}
-
-	if ( m_status == STATUS_FIRING || m_status == STATUS_POSTFIRE ||
-		(m_status == STATUS_PACKING && (m_laserStatus == LASERSTATUS_DECAYING || m_laserStatus == LASERSTATUS_DEAD)) )
-	{
-		if( m_firingToIdleSound.getEventName().isNotEmpty() )
+		// TheSuperHackers @bugfix stephanmeesters 13/02/2026
+		// For retail game compatibility, this fixes an issue where particle cannon sounds are not audible after saveload.
+		if( (m_status == STATUS_CHARGING || m_status == STATUS_PREPARING || m_status == STATUS_ALMOST_READY) &&
+			m_powerupSound.getEventName().isNotEmpty() )
 		{
-			m_firingToIdleSound.setObjectID( getObject()->getID() );
-			m_firingToIdleSound.setPlayingHandle( TheAudio->addAudioEvent( &m_firingToIdleSound ) );
+			m_powerupSound.setObjectID( getObject()->getID() );
+			m_powerupSound.setPlayingHandle( TheAudio->addAudioEvent( &m_powerupSound ) );
 		}
 
-		if( m_orbitToTargetBeamID != INVALID_DRAWABLE_ID && m_annihilationSound.getEventName().isNotEmpty() )
+		if( (m_status == STATUS_PREPARING || m_status == STATUS_ALMOST_READY || m_status == STATUS_READY_TO_FIRE || m_status == STATUS_PREFIRE) &&
+			m_unpackToReadySound.getEventName().isNotEmpty() )
 		{
-			m_annihilationSound.setDrawableID( m_orbitToTargetBeamID );
-			m_annihilationSound.setPlayingHandle( TheAudio->addAudioEvent( &m_annihilationSound ) );
+			m_unpackToReadySound.setObjectID( getObject()->getID() );
+			m_unpackToReadySound.setPlayingHandle( TheAudio->addAudioEvent( &m_unpackToReadySound ) );
+		}
+
+		if ( m_status == STATUS_FIRING || m_status == STATUS_POSTFIRE ||
+			(m_status == STATUS_PACKING && (m_laserStatus == LASERSTATUS_DECAYING || m_laserStatus == LASERSTATUS_DEAD)) )
+		{
+			if( m_firingToIdleSound.getEventName().isNotEmpty() )
+			{
+				m_firingToIdleSound.setObjectID( getObject()->getID() );
+				m_firingToIdleSound.setPlayingHandle( TheAudio->addAudioEvent( &m_firingToIdleSound ) );
+			}
+
+			if( m_orbitToTargetBeamID != INVALID_DRAWABLE_ID && m_annihilationSound.getEventName().isNotEmpty() )
+			{
+				m_annihilationSound.setDrawableID( m_orbitToTargetBeamID );
+				m_annihilationSound.setPlayingHandle( TheAudio->addAudioEvent( &m_annihilationSound ) );
+			}
 		}
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
@@ -1574,7 +1574,7 @@ void ParticleUplinkCannonUpdate::loadPostProcess( void )
 			m_unpackToReadySound.setPlayingHandle( TheAudio->addAudioEvent( &m_unpackToReadySound ) );
 		}
 
-		if ( m_status == STATUS_FIRING || m_status == STATUS_POSTFIRE ||
+		if( m_status == STATUS_FIRING || m_status == STATUS_POSTFIRE ||
 			(m_status == STATUS_PACKING && (m_laserStatus == LASERSTATUS_DECAYING || m_laserStatus == LASERSTATUS_DEAD)) )
 		{
 			if( m_firingToIdleSound.getEventName().isNotEmpty() )


### PR DESCRIPTION
* Relates to #2023

Fixes issue where sound from the particle cannon is not audible after saveload.

A savegame can be made during any of combinations of `STATUS_` and `LASERSTATUS_` below. Sounds are triggered only during state change, so when loading a savegame any of the sounds in the Active column need to be added.

Tested with a savegame for each `STATUS_`.

## Repeating sequence of the particle cannon

| `STATUS_` | `LASERSTATUS_` | Add sound | Clear sound | Active sound |
  |---|---|---|---|---|
  | `PACKING` (1) | `NONE` | none | none | none |
  | `CHARGING` | `NONE` | `powerupSound` | `unpackToReadySound`<br>`firingToIdleSound`<br>`annihilationSound` | `powerupSound` |
  | `PREPARING` | `NONE` | `unpackToReadySound` | `firingToIdleSound`<br>`annihilationSound` | `powerupSound`<br>`unpackToReadySound` |
  | `ALMOST_READY` | `NONE` | none | none | `powerupSound`<br>`unpackToReadySound` |
  | `READY_TO_FIRE` | `NONE` | none | `powerupSound`<br>`firingToIdleSound`<br>`annihilationSound` | `unpackToReadySound` |
  | `PREFIRE` | `NONE` | none | none | `unpackToReadySound` |
  | `FIRING` | `NONE`<br>`BORN` | `firingToIdleSound`<br>`annihilationSound`¹ | `powerupSound`<br>`unpackToReadySound` | `firingToIdleSound`<br>`annihilationSound` |
  | `POSTFIRE` | `BORN` | none | none | `firingToIdleSound`<br>`annihilationSound` |
  | `PACKING` (2) | `DECAYING`<br>`DEAD` | none | `annihilationSound`² | `firingToIdleSound`<br>`annihilationSound` |
  | `IDLE` | `NONE` | none | `powerupSound`<br>`unpackToReadySound`<br>`firingToIdleSound`<br>`annihilationSound` | none |

¹ Sound added at `LASERSTATUS_BORN`
² Sound cleared at `LASERSTATUS_DEAD`

`PACKING` appears twice for some reason.

## Status meanings

  -  `PACKING` (1): Particle cannon is inactive and fully reset. Idle state.
  - `CHARGING`: Early pre-ready phase; charging loop plays.
  - `PREPARING`: Antenna/deploy preparation phase.
  - `ALMOST_READY`: Near-ready phase before final ready state.
  - `READY_TO_FIRE`: Weapon is available and waiting for fire command.
  - `PREFIRE`: Transitional pre-shot state (defined and checked, typically brief/rare in this flow).
  - `FIRING`: Main active attack phase while beam is operating.
  - `POSTFIRE`: Attack is decaying after firing window ends.
  - `PACKING` (2): Pack-up phase after attack/ready path.
  -  `IDLE`: Another form of idle, used to reset audio, lasts very short.

## Laser status meanings

  - `NONE`: No orbital beam lifecycle started yet for current cycle.
  - `BORN`: Orbit-to-target beam was created and is in active phase.
  - `DECAYING`: Beam is in decay/shutdown window.
  - `DEAD`: Beam lifecycle is finished (end state before reset to `NONE` on next cycle setup).

## Sound meanings

- `powerupSound`: Charge, at particle cannon.
- `unpackToReadySound`: Prep, at particle cannon.
- `firingToIdleSound`: Firing/packing, at particle cannon.
- `annihilationSound`: Beam-impact, at origin beam.

## Todo
- [x] Replicate to Generals