### PR TITLE
bugfix(worldbuilder): Fix incorrect access of empty list in ObjectOptions::_FindOrDont()

### DIFF
--- a/Generals/Code/Tools/WorldBuilder/src/ObjectOptions.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/ObjectOptions.cpp
@@ -402,10 +402,11 @@ HTREEITEM ObjectOptions::_FindOrDont(const char* pLabel, HTREEITEM startPoint)
 	std::list<HTREEITEM> itemsToEx;
 	itemsToEx.push_back(startPoint);
 
-	while (!itemsToEx.empty() && itemsToEx.front()) {
+	while (!itemsToEx.empty()) {
 		char buffer[_MAX_PATH];
 		HTREEITEM hItem = itemsToEx.front();
 		itemsToEx.pop_front();
+		DEBUG_ASSERTCRASH(hItem != nullptr, ("Unexpected tree item pointer in ObjectOptions::_FindOrDont"));
 
 		if (!m_objectTreeView.ItemHasChildren(hItem)) {
 			TVITEM item;

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/ObjectOptions.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/ObjectOptions.cpp
@@ -402,10 +402,11 @@ HTREEITEM ObjectOptions::_FindOrDont(const char* pLabel, HTREEITEM startPoint)
 	std::list<HTREEITEM> itemsToEx;
 	itemsToEx.push_back(startPoint);
 
-	while (!itemsToEx.empty() && itemsToEx.front()) {
+	while (!itemsToEx.empty()) {
 		char buffer[_MAX_PATH];
 		HTREEITEM hItem = itemsToEx.front();
 		itemsToEx.pop_front();
+		DEBUG_ASSERTCRASH(hItem != nullptr, ("Unexpected tree item pointer in ObjectOptions::_FindOrDont"));
 
 		if (!m_objectTreeView.ItemHasChildren(hItem)) {
 			TVITEM item;


### PR DESCRIPTION
<img width="1030" height="867" alt="image" src="https://github.com/user-attachments/assets/973d007b-bced-49b5-a6b3-84321f26ab4d" />

If you open the map Sand Serpent with the World Builder and click on the green object in the center of the blue circle, you get a debug assertion that accessing the front element of an empty list is not allowed. This PR fixes that.