### PR TITLE
bugfix(worldbuilder): Fix optimized trees not being shown in object placer preview window

### DIFF
--- a/GeneralsMD/Code/Tools/WorldBuilder/src/wbview3d.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/wbview3d.cpp
@@ -1120,7 +1120,7 @@ AsciiString WbView3d::getBestModelName(const ThingTemplate* tt, const ModelCondi
 				return md->getBestModelNameForWB(c);
 			}
 
-			// TheSuperHackers @bugfix ViTeXFTW 15/02/2025 Fix tree objects not showing a preview in
+			// TheSuperHackers @bugfix ViTeXFTW 15/02/2026 Fix tree objects not showing a preview in
 			// WB object placer. The W3DTreeDraw module stores its model name differently from W3DModelDraw.
 			const W3DTreeDrawModuleData* treeData = mdd ? mdd->getAsW3DTreeDrawModuleData() : nullptr;
 			if (treeData)


### PR DESCRIPTION
- Fixes #381

**Description**
When making Zero Hour the devs created an optimized module (W3DTreeDraw) for drawing trees. They forgot to add the preview handling in WorldBuilder to handle this new draw type, which results in the preview not showing anything when having an object of the W3DTreeDraw module selected.

**Root Cause**
WorldBuilder attempts to get the module data for getting the model name of the object. However the format of the `W3DModelDraw` module data and `W3DTreeDraw` module data are different and there is not an exposed and generic way to get the information without explicitly casting the data to the expected type (`W3DModelDrawModuleData` or `W3DTreeDrawModuleData`).

**Fix**
Added a fallback function call to get the `W3DTreeDrawModuleData` if the normal `W3DModelDraw` fails which preserves the original behavior and also enables preview of tree types. 

Old:
<img width="315" height="455" alt="image" src="https://github.com/user-attachments/assets/5515b435-c232-4155-b743-83e5894427b9" />

New:
<img width="315" height="455" alt="image" src="https://github.com/user-attachments/assets/25dd4c05-fdce-4de6-8dbb-a90aaaf20399" />

## TODO

-  ~~Replicate in Generals~~