### PR TITLE
bugfix(behavior): Prevent fallen Angry Mob members from respawning at the Barracks after loading a save

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/SpawnBehavior.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/SpawnBehavior.cpp
@@ -1008,8 +1008,9 @@ void SpawnBehavior::xfer( Xfer *xfer )
 		xfer->xferBool(&m_initialBurstTimesInited);
 	}
 
-	if (version >= 3)
+	if (version >= 3) {
 		xfer->xferUnsignedInt(&m_initialBurstCountdown);
+	}
 
 	// spawn template
 	name = m_spawnTemplate ? m_spawnTemplate->getName() : AsciiString::TheEmptyString;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/SpawnBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/SpawnBehavior.cpp
@@ -1093,8 +1093,9 @@ void SpawnBehavior::xfer( Xfer *xfer )
 		xfer->xferBool(&m_initialBurstTimesInited);
 	}
 
-	if (version >= 3)
+	if (version >= 3) {
 		xfer->xferUnsignedInt(&m_initialBurstCountdown);
+	}
 
 	// spawn template
 	name = m_spawnTemplate ? m_spawnTemplate->getName() : AsciiString::TheEmptyString;


### PR DESCRIPTION
Closes #11

This change fixes an issue where fallen Angry Mob members respawn at the Barracks after loading a save.

Angry Mob members spawn from the Barracks if `m_initialBurstCountdown` is greater than 0. As `m_initialBurstCountdown` is not saved in the retail game, it is always reset to its default/retail value of 5 when loading a saved game. This results in up to 5 Angry Mob members respawning from the Barracks and attempting to run across the map to join the nexus, where they often die again in the process due to being too far away.

### Before
Fallen Angry Mob members respawn at the Barracks

https://github.com/user-attachments/assets/289b2cfb-b7b9-435d-997f-3cdcec52c3df

### After
Fallen Angry Mob members respawn at the nexus

https://github.com/user-attachments/assets/17da4760-b145-44f1-9fd5-b8148c3de2e6