### PR TITLE
bugfix(particlesys): Restore Particle System IDs on save load before registering to ParticleSystemManager

### DIFF
--- a/Core/GameEngine/Source/GameClient/System/ParticleSys.cpp
+++ b/Core/GameEngine/Source/GameClient/System/ParticleSys.cpp
@@ -1263,8 +1263,10 @@ ParticleSystem::~ParticleSystem()
 
 	m_controlParticle = nullptr;
 
-	if (m_systemID != INVALID_PARTICLE_SYSTEM_ID)
+	if ( m_systemID != INVALID_PARTICLE_SYSTEM_ID )
+	{
 		TheParticleSystemManager->friend_removeParticleSystem(this);
+	}
 	//DEBUG_ASSERTLOG(!(m_totalParticleSystemCount % 10 == 0), ( "TotalParticleSystemCount = %d", m_totalParticleSystemCount ));
 }
 


### PR DESCRIPTION
- Closes #2315

Some savegames would error due to being unable to reconnect master/slave systems to a particle system.

This appeared to be caused because during xfer of the ParticleSystemManager, the particle systems would initially be assigned with a new (temporary) system ID, and only moments later be properly restored with xferSnapshot and receive the real system ID. However, particle systems were registered with ParticleSystemManager using this old invalid ID, which would cause lookup failures later.

The fix here is to defer the registration of particle systems with ParticleSystemManager until the system ID has been properly restored.