### PR TITLE
bugfix(behavior): Only detonate Bunker Busters if the missile reaches its destination

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/BunkerBusterBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/BunkerBusterBehavior.cpp
@@ -165,6 +165,13 @@ UpdateSleepTime BunkerBusterBehavior::update( void )
 // ------------------------------------------------------------------------------------------------
 void BunkerBusterBehavior::onDie( const DamageInfo *damageInfo )
 {
+#if !RETAIL_COMPATIBLE_CRC
+  // TheSuperHackers @bugfix Stubbjax 17/02/2026 Only bust the bunker if the missile kills itself
+  // by reaching its destination and not when killed via external sources such as a zap from a PDL.
+  if (!getObject()->testStatus(OBJECT_STATUS_MISSILE_KILLING_SELF))
+    return;
+#endif
+
   // do what we came here to do!
   bustTheBunker();
 }


### PR DESCRIPTION
Closes [#632](https://github.com/TheSuperHackers/GeneralsGamePatch/issues/632) from the patch repository

This change fixes an issue where a Bunker Buster missile will trigger its detonation damage/effect on the target even if it's destroyed before reaching it. The detonation is now only triggered if the missile is destroyed by reaching its destination.

### Before
The bunker buster immediately detonates on the target when zapped by the Avenger's PDL

https://github.com/user-attachments/assets/d98dcd22-2497-4365-bd3c-cdfec8a4853b

https://github.com/user-attachments/assets/3e133cae-1e52-401c-ac8d-a193d550b9c1

### After
The bunker buster does not detonate when zapped by the Avenger's PDL

https://github.com/user-attachments/assets/91d936e1-dcbe-4fef-9dd0-3f3bd9dbbc42