### PR TITLE
bugfix(battleplanupdate): Prevent using the Bombardment Cannon while switching Battle Plans

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/BattlePlanUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/BattlePlanUpdate.cpp
@@ -370,6 +370,10 @@ UpdateSleepTime BattlePlanUpdate::update()
 							{
 								//It's not centered, and not trying to center, so order it to center.
 								ai->aiIdle( CMD_FROM_AI );
+#if !RETAIL_COMPATIBLE_CRC
+								// TheSuperHackers @bugfix Stubbjax 19/02/2026 Prevent using the turret while it recenters.
+								enableTurret(false);
+#endif
 								recenterTurret();
 								m_centeringTurret = true;
 							}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/BattlePlanUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/BattlePlanUpdate.cpp
@@ -371,6 +371,10 @@ UpdateSleepTime BattlePlanUpdate::update()
 							{
 								//It's not centered, and not trying to center, so order it to center.
 								ai->aiIdle( CMD_FROM_AI );
+#if !RETAIL_COMPATIBLE_CRC
+								// TheSuperHackers @bugfix Stubbjax 19/02/2026 Prevent using the turret while it recenters.
+								enableTurret(false);
+#endif
 								recenterTurret();
 								m_centeringTurret = true;
 							}


### PR DESCRIPTION
This change fixes an issue where the Strategy Center's bombardment cannon can be manually fired while switching to another battle plan, blocking the switch in the process. The turret is now disabled as soon as it is time to pack up, rather than after the turret has finished centring.