### PR TITLE
refactor(pathfinder): Implement PathfindCellList class for PathfindCell open and closed lists

### DIFF
--- a/Generals/Code/GameEngine/Include/GameLogic/AIPathfind.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AIPathfind.h
@@ -332,13 +332,13 @@ public:
 	void removeFromOpenList( PathfindCellList &list );
 
 	/// put self on "closed" list, return new list
-	PathfindCell *putOnClosedList( PathfindCell *list );
+	void putOnClosedList( PathfindCellList &list );
 
 	/// remove self from "closed" list
-	PathfindCell *removeFromClosedList( PathfindCell *list );
+	void removeFromClosedList( PathfindCellList &list );
 
 	/// remove all cells from closed list.
-	static Int releaseClosedList( PathfindCell *list );
+	static Int releaseClosedList( PathfindCellList &list );
 
 	/// remove all cells from closed list.
 	static Int releaseOpenList( PathfindCellList &list );
@@ -867,7 +867,7 @@ private:
 	IRegion2D m_logicalExtent;										///< Logical grid extent limits
 
 	PathfindCellList m_openList;									///< Cells ready to be explored
-	PathfindCell *m_closedList;										///< Cells already explored
+	PathfindCellList m_closedList;								///< Cells already explored
 
 	Bool m_isMapReady;														///< True if all cells of map have been classified
 	Bool m_isTunneling;														///< True if path started in an obstacle

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AIPathfind.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AIPathfind.h
@@ -333,13 +333,13 @@ public:
 	void removeFromOpenList( PathfindCellList &list );
 
 	/// put self on "closed" list, return new list
-	PathfindCell *putOnClosedList( PathfindCell *list );
+	void putOnClosedList( PathfindCellList &list );
 
 	/// remove self from "closed" list
-	PathfindCell *removeFromClosedList( PathfindCell *list );
+	void removeFromClosedList( PathfindCellList &list );
 
 	/// remove all cells from closed list.
-	static Int releaseClosedList( PathfindCell *list );
+	static Int releaseClosedList( PathfindCellList &list );
 
 	/// remove all cells from closed list.
 	static Int releaseOpenList( PathfindCellList &list );
@@ -875,7 +875,7 @@ private:
 	IRegion2D m_logicalExtent;										///< Logical grid extent limits
 
 	PathfindCellList m_openList;									///< Cells ready to be explored
-	PathfindCell *m_closedList;										///< Cells already explored
+	PathfindCellList m_closedList;								///< Cells already explored
 
 	Bool m_isMapReady;														///< True if all cells of map have been classified
 	Bool m_isTunneling;														///< True if path started in an obstacle


### PR DESCRIPTION
**Merge by rebase**

This PR is a refactor that is the start of a stage of functional improvement and optimisation changes to the pathfinder open list handling.

The goal of this Refactor was to create a dedicated list handling header for the open and closed lists.
In further refactors this new list header class becomes more important for allowing newer functionality to be implemented when performing sorted insertions into the PathfincCell open list.

This has been tested and is retail compatible, there are two slightly different paths for handling the list head initialisation.
1. The retail path needs the list head to be directly initialised with the first starting position PathfindCell.
2. The non retail functionality uses the insertion sort function to initialise the list with the starting position cell. Internally it performs more sanitation to the head node, when adding it, which is not retail compatible.

---

- [x] Replicate in generals
- [x] Update Commit description