### PR TITLE
fix(netpacket): Fix incorrect improbable return value in NetPacket::GetBufferSizeNeededForCommand()

### DIFF
--- a/Core/GameEngine/Source/GameNetwork/NetPacket.cpp
+++ b/Core/GameEngine/Source/GameNetwork/NetPacket.cpp
@@ -276,7 +276,7 @@ UnsignedInt NetPacket::GetBufferSizeNeededForCommand(NetCommandMsg *msg) {
 	// This is where the fun begins...
 
 	if (msg == nullptr) {
-		return TRUE; // There was nothing to add, so it was successful.
+		return 0; // There was nothing to add.
 	}
 	// Use the virtual function for all command message types
 	return msg->getPackedByteCount();


### PR DESCRIPTION
This change fixes a small incorrect improbable return value in `NetPacket::GetBufferSizeNeededForCommand()`. It likely is wrong because it is copy pasta of 

```cpp
Bool NetPacket::addCommand(NetCommandRef *msg) {
	// This is where the fun begins...

	if (msg == nullptr) {
		return TRUE; // There was nothing to add, so it was successful.
	}
...
```


This change should be without consequence because we never expect this code path to be taken in practice.