### PR TITLE
bugfix(player): Fix rounding inaccuracies with money awarded by Cash Bounty

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -2032,7 +2032,7 @@ void Player::doBountyForKill(const Object* killer, const Object* victim)
 	Int bounty = REAL_TO_INT_CEIL(costToBuild * m_cashBountyPercent);
 #else
 	// TheSuperHackers @bugfix Stubbjax 20/02/2026 Subtract epsilon to ensure bounty is rounded up correctly.
-	Int bounty = REAL_TO_INT_CEIL((costToBuild * m_cashBountyPercent) - WWMATH_EPSILON);
+	Int bounty = ceil((costToBuild * m_cashBountyPercent) - WWMATH_EPSILON);
 #endif
 
 	if( bounty )

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -2431,7 +2431,7 @@ void Player::doBountyForKill(const Object* killer, const Object* victim)
 	Int bounty = REAL_TO_INT_CEIL(costToBuild * m_cashBountyPercent);
 #else
 	// TheSuperHackers @bugfix Stubbjax 20/02/2026 Subtract epsilon to ensure bounty is rounded up correctly.
-	Int bounty = REAL_TO_INT_CEIL((costToBuild * m_cashBountyPercent) - WWMATH_EPSILON);
+	Int bounty = ceil((costToBuild * m_cashBountyPercent) - WWMATH_EPSILON);
 #endif
 
 	if( bounty )


### PR DESCRIPTION
Closes #251

This change fixes an issue with the money awarded by Cash Bounty, where particular percentage calculations can cause a rounding error and return the incorrect amount.

For example, a Cash Bounty value of 26% causes an object with a value of $1,000 to unexpectedly yield $261. This is because calculations like 1000 × 0.26 can effectively return 260.0000000001 due to [floating point inaccuracies](https://en.wikipedia.org/wiki/Floating-point_arithmetic#Accuracy_problems), which is then rounded up.