### PR TITLE
bugfix: Delay creation of object bound particle emitters until ParticleSystemManager is xfer-loaded

### DIFF
--- a/Core/GameEngine/Source/GameClient/System/ParticleSys.cpp
+++ b/Core/GameEngine/Source/GameClient/System/ParticleSys.cpp
@@ -3346,6 +3346,8 @@ void ParticleSystemManager::xfer( Xfer *xfer )
 	}
 	else
 	{
+		DEBUG_ASSERTCRASH(m_allParticleSystemList.size()==0, ("ParticleSystemManager: particle systems list must be empty at start of xfer-load."));
+
 		const ParticleSystemTemplate *systemTemplate;
 
 		// read each particle system

--- a/Core/GameEngine/Source/GameClient/System/ParticleSys.cpp
+++ b/Core/GameEngine/Source/GameClient/System/ParticleSys.cpp
@@ -3346,7 +3346,7 @@ void ParticleSystemManager::xfer( Xfer *xfer )
 	}
 	else
 	{
-		DEBUG_ASSERTCRASH(m_allParticleSystemList.size()==0, ("ParticleSystemManager: particle systems list must be empty at start of xfer-load."));
+		DEBUG_ASSERTCRASH(m_allParticleSystemList.empty(), ("ParticleSystemManager: particle systems list is expected empty at start of xfer-load."));
 
 		const ParticleSystemTemplate *systemTemplate;
 

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankDraw.cpp
@@ -34,6 +34,7 @@
 #include "Common/Thing.h"
 #include "Common/ThingFactory.h"
 #include "Common/GameAudio.h"
+#include "Common/GameState.h"
 #include "Common/ThingTemplate.h"
 #include "Common/Xfer.h"
 #include "GameLogic/Weapon.h"
@@ -106,7 +107,12 @@ W3DTankDraw::W3DTankDraw( Thing *thing, const ModuleData* moduleData )
 	m_lastDirection.y=0.0f;
 	m_lastDirection.z=0.0f;
 
-	createTreadEmitters();
+	// TheSuperHackers @bugfix stephanmeesters 20/02/2026
+	// If loading from savegame, delay non-saveable emitter creation until postProcess.
+	if (TheGameState == nullptr || TheGameState->isInLoadGame() == FALSE)
+	{
+		createTreadEmitters();
+	}
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -435,8 +441,6 @@ void W3DTankDraw::loadPostProcess()
 	// extend base class
 	W3DModelDraw::loadPostProcess();
 
-	// toss any existing tread emitters and re-create 'em (since this module expects 'em to always be around)
-	tossTreadEmitters();
 	createTreadEmitters();
 
 }

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankDraw.cpp
@@ -125,27 +125,33 @@ void W3DTankDraw::tossTreadEmitters()
 
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
+static ParticleSystemID createParticleSystem( const AsciiString &name, const Drawable *drawable )
+{
+	const ParticleSystemTemplate *sysTemplate = TheParticleSystemManager->findTemplate(name);
+	ParticleSystem *particleSys = TheParticleSystemManager->createParticleSystem( sysTemplate );
+	if (!particleSys)
+		return INVALID_PARTICLE_SYSTEM_ID;
+
+	particleSys->attachToDrawable(drawable);
+	// important: mark it as do-not-save, since we'll just re-create it when we reload.
+	particleSys->setSaveable(FALSE);
+	// they come into being stopped.
+	particleSys->stop();
+
+	return particleSys->getSystemID();
+}
+
 void W3DTankDraw::createTreadEmitters()
 {
-	const AsciiString *treadDebrisNames[2];
-	static_assert(ARRAY_SIZE(treadDebrisNames) == ARRAY_SIZE(m_treadDebrisIDs), "Array size must match");
-	treadDebrisNames[0] = &getW3DTankDrawModuleData()->m_treadDebrisNameLeft;
-	treadDebrisNames[1] = &getW3DTankDrawModuleData()->m_treadDebrisNameRight;
-
-	for (size_t i = 0; i < ARRAY_SIZE(m_treadDebrisIDs); ++i)
+	if (getW3DTankDrawModuleData())
 	{
-		if (m_treadDebrisIDs[i] == INVALID_PARTICLE_SYSTEM_ID)
+		if (m_treadDebrisIDs[0] == INVALID_PARTICLE_SYSTEM_ID)
 		{
-			if (const ParticleSystemTemplate *sysTemplate = TheParticleSystemManager->findTemplate(*treadDebrisNames[i]))
-			{
-				ParticleSystem *particleSys = TheParticleSystemManager->createParticleSystem( sysTemplate );
-				particleSys->attachToDrawable(getDrawable());
-				// important: mark it as do-not-save, since we'll just re-create it when we reload.
-				particleSys->setSaveable(FALSE);
-				// they come into being stopped.
-				particleSys->stop();
-				m_treadDebrisIDs[i] = particleSys->getSystemID();
-			}
+			m_treadDebrisIDs[0] = createParticleSystem(getW3DTankDrawModuleData()->m_treadDebrisNameLeft, getDrawable());
+		}
+		if (m_treadDebrisIDs[1] == INVALID_PARTICLE_SYSTEM_ID)
+		{
+			m_treadDebrisIDs[1] = createParticleSystem(getW3DTankDrawModuleData()->m_treadDebrisNameRight, getDrawable());
 		}
 	}
 }

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankDraw.cpp
@@ -34,7 +34,6 @@
 #include "Common/Thing.h"
 #include "Common/ThingFactory.h"
 #include "Common/GameAudio.h"
-#include "Common/GameState.h"
 #include "Common/ThingTemplate.h"
 #include "Common/Xfer.h"
 #include "GameLogic/Weapon.h"
@@ -107,12 +106,6 @@ W3DTankDraw::W3DTankDraw( Thing *thing, const ModuleData* moduleData )
 	m_lastDirection.y=0.0f;
 	m_lastDirection.z=0.0f;
 
-	// TheSuperHackers @bugfix stephanmeesters 20/02/2026
-	// If loading from savegame, delay non-saveable emitter creation until postProcess.
-	if (TheGameState == nullptr || TheGameState->isInLoadGame() == FALSE)
-	{
-		createTreadEmitters();
-	}
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -315,6 +308,9 @@ void W3DTankDraw::doDrawModule(const Matrix3D* transformMtx)
 	Object *obj = getDrawable()->getObject();
 	if (obj == nullptr)
 		return;
+
+	// TheSuperHackers @bugfix stephanmeesters 14/03/2026 Delay emitter creation until draw
+	createTreadEmitters();
 
 	// get object physics state
 	PhysicsBehavior *physics = obj->getPhysics();

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankDraw.cpp
@@ -145,6 +145,8 @@ void W3DTankDraw::createTreadEmitters()
 {
 	if (getW3DTankDrawModuleData())
 	{
+		static_assert(ARRAY_SIZE(m_treadDebrisIDs) == 2, "m_treadDebrisIDs array size is expected to be 2");
+
 		if (m_treadDebrisIDs[0] == INVALID_PARTICLE_SYSTEM_ID)
 		{
 			m_treadDebrisIDs[0] = createParticleSystem(getW3DTankDrawModuleData()->m_treadDebrisNameLeft, getDrawable());
@@ -315,9 +317,6 @@ void W3DTankDraw::doDrawModule(const Matrix3D* transformMtx)
 	if (obj == nullptr)
 		return;
 
-	// TheSuperHackers @bugfix stephanmeesters 14/03/2026 Delay emitter creation until draw
-	createTreadEmitters();
-
 	// get object physics state
 	PhysicsBehavior *physics = obj->getPhysics();
 	if (physics == nullptr)
@@ -343,6 +342,9 @@ void W3DTankDraw::doDrawModule(const Matrix3D* transformMtx)
 	velMult.z = velMag + 0.1f;
 	if (velMult.z > 1.0f)
 		velMult.z = 1.0f;
+
+	// TheSuperHackers @bugfix 14/03/2026 Delay emitter creation until draw
+	createTreadEmitters();
 
 	for (size_t i = 0; i < ARRAY_SIZE(m_treadDebrisIDs); ++i)
 	{
@@ -442,7 +444,5 @@ void W3DTankDraw::loadPostProcess()
 
 	// extend base class
 	W3DModelDraw::loadPostProcess();
-
-	createTreadEmitters();
 
 }

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankDraw.cpp
@@ -343,7 +343,8 @@ void W3DTankDraw::doDrawModule(const Matrix3D* transformMtx)
 	if (velMult.z > 1.0f)
 		velMult.z = 1.0f;
 
-	// TheSuperHackers @bugfix 14/03/2026 Delay emitter creation until draw
+	// TheSuperHackers @bugfix stephanmeesters 18/04/2026 Delay emitter creation until draw, to ensure that the particle
+	// systems are not created before ParticleManager has xfer-loaded.
 	createTreadEmitters();
 
 	for (size_t i = 0; i < ARRAY_SIZE(m_treadDebrisIDs); ++i)

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankTruckDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankTruckDraw.cpp
@@ -32,6 +32,7 @@
 #include "Common/Thing.h"
 #include "Common/ThingFactory.h"
 #include "Common/GameAudio.h"
+#include "Common/GameState.h"
 #include "Common/GlobalData.h"
 #include "Common/ThingTemplate.h"
 #include "Common/Xfer.h"
@@ -119,7 +120,12 @@ m_prevRenderObj(nullptr)
 
 	m_treadCount=0;
 
-	createTreadEmitters();
+	// TheSuperHackers @bugfix stephanmeesters 20/02/2026
+	// If loading from savegame, delay non-saveable emitter creation until postProcess.
+	if (TheGameState == nullptr || TheGameState->isInLoadGame() == FALSE)
+	{
+		createTreadEmitters();
+	}
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -761,8 +767,6 @@ void W3DTankTruckDraw::loadPostProcess()
 	// toss any existing wheel emitters (no need to re-create; we'll do that on demand)
 	tossWheelEmitters();
 
-	// toss any existing tread emitters and re-create 'em (since this module expects 'em to always be around)
-	tossTreadEmitters();
 	createTreadEmitters();
 
 }

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankTruckDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankTruckDraw.cpp
@@ -181,30 +181,33 @@ void W3DTankTruckDraw::setFullyObscuredByShroud(Bool fullyObscured)
 
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
+static ParticleSystemID createParticleSystem( const AsciiString &name, const Drawable *drawable )
+{
+	const ParticleSystemTemplate *sysTemplate = TheParticleSystemManager->findTemplate(name);
+	ParticleSystem *particleSys = TheParticleSystemManager->createParticleSystem( sysTemplate );
+	if (!particleSys)
+		return INVALID_PARTICLE_SYSTEM_ID;
+
+	particleSys->attachToDrawable(drawable);
+	// important: mark it as do-not-save, since we'll just re-create it when we reload.
+	particleSys->setSaveable(FALSE);
+	// they come into being stopped.
+	particleSys->stop();
+
+	return particleSys->getSystemID();
+}
+
 void W3DTankTruckDraw::createTreadEmitters()
 {
 	if (getW3DTankTruckDrawModuleData())
 	{
-		const AsciiString *treadDebrisNames[2];
-		static_assert(ARRAY_SIZE(treadDebrisNames) == ARRAY_SIZE(m_treadDebrisIDs), "Array size must match");
-		treadDebrisNames[0] = &getW3DTankTruckDrawModuleData()->m_treadDebrisNameLeft;
-		treadDebrisNames[1] = &getW3DTankTruckDrawModuleData()->m_treadDebrisNameRight;
-
-		for (size_t i = 0; i < ARRAY_SIZE(m_treadDebrisIDs); ++i)
+		if (m_treadDebrisIDs[0] == INVALID_PARTICLE_SYSTEM_ID)
 		{
-			if (m_treadDebrisIDs[i] == INVALID_PARTICLE_SYSTEM_ID)
-			{
-				if (const ParticleSystemTemplate *sysTemplate = TheParticleSystemManager->findTemplate(*treadDebrisNames[i]))
-				{
-					ParticleSystem *particleSys = TheParticleSystemManager->createParticleSystem( sysTemplate );
-					particleSys->attachToDrawable(getDrawable());
-					// important: mark it as do-not-save, since we'll just re-create it when we reload.
-					particleSys->setSaveable(FALSE);
-					// they come into being stopped.
-					particleSys->stop();
-					m_treadDebrisIDs[i] = particleSys->getSystemID();
-				}
-			}
+			m_treadDebrisIDs[0] = createParticleSystem(getW3DTankTruckDrawModuleData()->m_treadDebrisNameLeft, getDrawable());
+		}
+		if (m_treadDebrisIDs[1] == INVALID_PARTICLE_SYSTEM_ID)
+		{
+			m_treadDebrisIDs[1] = createParticleSystem(getW3DTankTruckDrawModuleData()->m_treadDebrisNameRight, getDrawable());
 		}
 	}
 }

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankTruckDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankTruckDraw.cpp
@@ -32,7 +32,6 @@
 #include "Common/Thing.h"
 #include "Common/ThingFactory.h"
 #include "Common/GameAudio.h"
-#include "Common/GameState.h"
 #include "Common/GlobalData.h"
 #include "Common/ThingTemplate.h"
 #include "Common/Xfer.h"
@@ -120,12 +119,6 @@ m_prevRenderObj(nullptr)
 
 	m_treadCount=0;
 
-	// TheSuperHackers @bugfix stephanmeesters 20/02/2026
-	// If loading from savegame, delay non-saveable emitter creation until postProcess.
-	if (TheGameState == nullptr || TheGameState->isInLoadGame() == FALSE)
-	{
-		createTreadEmitters();
-	}
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -509,6 +502,9 @@ void W3DTankTruckDraw::doDrawModule(const Matrix3D* transformMtx)
 	Object *obj = getDrawable()->getObject();
 	if (obj == nullptr)
 		return;
+
+	// TheSuperHackers @bugfix stephanmeesters 14/03/2026 Delay emitter creation until draw
+	createTreadEmitters();
 
 	if (getRenderObject()==nullptr) return;
 	if (getRenderObject() != m_prevRenderObj) {

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankTruckDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankTruckDraw.cpp
@@ -201,6 +201,8 @@ void W3DTankTruckDraw::createTreadEmitters()
 {
 	if (getW3DTankTruckDrawModuleData())
 	{
+		static_assert(ARRAY_SIZE(m_treadDebrisIDs) == 2, "m_treadDebrisIDs array size is expected to be 2");
+
 		if (m_treadDebrisIDs[0] == INVALID_PARTICLE_SYSTEM_ID)
 		{
 			m_treadDebrisIDs[0] = createParticleSystem(getW3DTankTruckDrawModuleData()->m_treadDebrisNameLeft, getDrawable());
@@ -506,14 +508,12 @@ void W3DTankTruckDraw::doDrawModule(const Matrix3D* transformMtx)
 	if (obj == nullptr)
 		return;
 
-	// TheSuperHackers @bugfix stephanmeesters 14/03/2026 Delay emitter creation until draw
-	createTreadEmitters();
-
 	if (getRenderObject()==nullptr) return;
 	if (getRenderObject() != m_prevRenderObj) {
 		updateBones();
 		updateTreadObjects();
 	}
+
 	// get object physics state
 	PhysicsBehavior *physics = obj->getPhysics();
 	if (physics == nullptr)
@@ -673,6 +673,9 @@ void W3DTankTruckDraw::doDrawModule(const Matrix3D* transformMtx)
 	if (velMult.z > 1.0f)
 		velMult.z = 1.0f;
 
+	// TheSuperHackers @bugfix 14/03/2026 Delay emitter creation until draw
+	createTreadEmitters();
+
 	for (size_t i = 0; i < ARRAY_SIZE(m_treadDebrisIDs); ++i)
 	{
 		if (ParticleSystem *particleSys = TheParticleSystemManager->findParticleSystem(m_treadDebrisIDs[i]))
@@ -765,7 +768,5 @@ void W3DTankTruckDraw::loadPostProcess()
 
 	// toss any existing wheel emitters (no need to re-create; we'll do that on demand)
 	tossWheelEmitters();
-
-	createTreadEmitters();
 
 }

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankTruckDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankTruckDraw.cpp
@@ -673,7 +673,8 @@ void W3DTankTruckDraw::doDrawModule(const Matrix3D* transformMtx)
 	if (velMult.z > 1.0f)
 		velMult.z = 1.0f;
 
-	// TheSuperHackers @bugfix 14/03/2026 Delay emitter creation until draw
+	// TheSuperHackers @bugfix stephanmeesters 18/04/2026 Delay emitter creation until draw, to ensure that the particle
+	// systems are not created before ParticleManager has xfer-loaded.
 	createTreadEmitters();
 
 	for (size_t i = 0; i < ARRAY_SIZE(m_treadDebrisIDs); ++i)

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/AutoHealBehavior.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/AutoHealBehavior.h
@@ -162,6 +162,7 @@ protected:
 private:
 
 	void pulseHealObject( Object *obj );
+	void createEmitters();
 
 	ParticleSystemID m_radiusParticleSystemID;
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/AutoHealBehavior.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/AutoHealBehavior.cpp
@@ -86,21 +86,6 @@ AutoHealBehavior::AutoHealBehavior( Thing *thing, const ModuleData* moduleData )
 	m_radiusParticleSystemID = INVALID_PARTICLE_SYSTEM_ID;
 	m_soonestHealFrame = 0;
 	m_stopped = false;
-	Object *obj = getObject();
-
-	{
-		if( d->m_radiusParticleSystemTmpl )
-		{
-			ParticleSystem *particleSystem;
-
-			particleSystem = TheParticleSystemManager->createParticleSystem( d->m_radiusParticleSystemTmpl );
-			if( particleSystem )
-			{
-				particleSystem->setPosition( obj->getPosition() );
-				m_radiusParticleSystemID = particleSystem->getSystemID();
-			}
-		}
-	}
 
 	if (d->m_initiallyActive)
 	{
@@ -185,6 +170,10 @@ UpdateSleepTime AutoHealBehavior::update()
 		DEBUG_ASSERTCRASH(isUpgradeActive(), ("hmm, this should not be possible"));
 		return UPDATE_SLEEP_FOREVER;
 	}
+
+	// TheSuperHackers @bugfix stephanmeesters 18/04/2026 Delay emitter creation until update, to ensure that the particle
+	// systems are not created before ParticleManager has xfer-loaded.
+	createEmitters();
 
 //DEBUG_LOG(("doing auto heal %d",TheGameLogic->getFrame()));
 
@@ -358,4 +347,20 @@ void AutoHealBehavior::loadPostProcess()
 	// extend base class
 	UpgradeMux::upgradeMuxLoadPostProcess();
 
+}
+
+// ------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
+void AutoHealBehavior::createEmitters()
+{
+	if( m_radiusParticleSystemID == INVALID_PARTICLE_SYSTEM_ID )
+	{
+		const AutoHealBehaviorModuleData *d = getAutoHealBehaviorModuleData();
+		ParticleSystem *particleSystem = TheParticleSystemManager->createParticleSystem(d->m_radiusParticleSystemTmpl);
+		if( particleSystem )
+		{
+			particleSystem->setPosition( getObject()->getPosition() );
+			m_radiusParticleSystemID = particleSystem->getSystemID();
+		}
+	}
 }

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/AutoHealBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/AutoHealBehavior.h
@@ -108,9 +108,7 @@ public:
 //-------------------------------------------------------------------------------------------------
 class AutoHealBehavior : public UpdateModule,
 												 public UpgradeMux,
-												 public DamageModuleInterface
-{
-
+												 public DamageModuleInterface {
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( AutoHealBehavior, "AutoHealBehavior" )
 	MAKE_STANDARD_MODULE_MACRO_WITH_MODULE_DATA( AutoHealBehavior, AutoHealBehaviorModuleData )
 
@@ -174,6 +172,7 @@ protected:
 private:
 
 	void pulseHealObject( Object *obj );
+	void createEmitters();
 
 	ParticleSystemID m_radiusParticleSystemID;
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/AutoHealBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/AutoHealBehavior.h
@@ -108,7 +108,9 @@ public:
 //-------------------------------------------------------------------------------------------------
 class AutoHealBehavior : public UpdateModule,
 												 public UpgradeMux,
-												 public DamageModuleInterface {
+												 public DamageModuleInterface
+{
+
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( AutoHealBehavior, "AutoHealBehavior" )
 	MAKE_STANDARD_MODULE_MACRO_WITH_MODULE_DATA( AutoHealBehavior, AutoHealBehaviorModuleData )
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/GrantStealthBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/GrantStealthBehavior.h
@@ -101,6 +101,8 @@ public:
 private:
 
 	void grantStealthToObject( Object *obj );
+	void createEmitters();
+
 	ParticleSystemID m_radiusParticleSystemID;
   Real m_currentScanRadius;
 };

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/AutoHealBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/AutoHealBehavior.cpp
@@ -168,9 +168,6 @@ UpdateSleepTime AutoHealBehavior::update()
 	if (m_stopped)
 		return UPDATE_SLEEP_FOREVER;
 
-	// TheSuperHackers @bugfix stephanmeesters 14/03/2026 Delay emitter creation until update
-	createEmitters();
-
 	Object *obj = getObject();
 	const AutoHealBehaviorModuleData *d = getAutoHealBehaviorModuleData();
 
@@ -181,6 +178,9 @@ UpdateSleepTime AutoHealBehavior::update()
 		DEBUG_ASSERTCRASH(isUpgradeActive(), ("hmm, this should not be possible"));
 		return UPDATE_SLEEP_FOREVER;
 	}
+
+	// TheSuperHackers @bugfix stephanmeesters 14/03/2026 Delay emitter creation until update
+	createEmitters();
 
 //DEBUG_LOG(("doing auto heal %d",TheGameLogic->getFrame()));
 
@@ -369,9 +369,9 @@ void AutoHealBehavior::loadPostProcess()
 // ------------------------------------------------------------------------------------------------
 void AutoHealBehavior::createEmitters( void )
 {
-	const AutoHealBehaviorModuleData *d = getAutoHealBehaviorModuleData();
-	if( m_radiusParticleSystemID == INVALID_PARTICLE_SYSTEM_ID && d->m_radiusParticleSystemTmpl )
+	if( m_radiusParticleSystemID == INVALID_PARTICLE_SYSTEM_ID )
 	{
+		const AutoHealBehaviorModuleData *d = getAutoHealBehaviorModuleData();
 		ParticleSystem *particleSystem = TheParticleSystemManager->createParticleSystem(d->m_radiusParticleSystemTmpl);
 		if( particleSystem )
 		{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/AutoHealBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/AutoHealBehavior.cpp
@@ -375,7 +375,7 @@ void AutoHealBehavior::loadPostProcess()
 void AutoHealBehavior::createEmitters( void )
 {
     const AutoHealBehaviorModuleData *d = getAutoHealBehaviorModuleData();
-	if( d->m_radiusParticleSystemTmpl )
+	if( m_radiusParticleSystemID == INVALID_PARTICLE_SYSTEM_ID && d->m_radiusParticleSystemTmpl )
 	{
 		ParticleSystem *particleSystem = TheParticleSystemManager->createParticleSystem(d->m_radiusParticleSystemTmpl);
 		if( particleSystem )

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/AutoHealBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/AutoHealBehavior.cpp
@@ -34,6 +34,7 @@
 #include "Common/ThingTemplate.h"
 #include "Common/INI.h"
 #include "Common/Player.h"
+#include "Common/GameState.h"
 #include "Common/Xfer.h"
 #include "GameClient/ParticleSys.h"
 #include "GameClient/Anim2D.h"
@@ -94,20 +95,12 @@ AutoHealBehavior::AutoHealBehavior( Thing *thing, const ModuleData* moduleData )
 	m_radiusParticleSystemID = INVALID_PARTICLE_SYSTEM_ID;
 	m_soonestHealFrame = 0;
 	m_stopped = false;
-	Object *obj = getObject();
 
+	// TheSuperHackers @bugfix stephanmeesters 20/02/2026
+	// If loading from savegame, delay non-saveable emitter creation until postProcess.
+	if (TheGameState == nullptr || TheGameState->isInLoadGame() == FALSE)
 	{
-		if( d->m_radiusParticleSystemTmpl )
-		{
-			ParticleSystem *particleSystem;
-
-			particleSystem = TheParticleSystemManager->createParticleSystem( d->m_radiusParticleSystemTmpl );
-			if( particleSystem )
-			{
-				particleSystem->setPosition( obj->getPosition() );
-				m_radiusParticleSystemID = particleSystem->getSystemID();
-			}
-		}
+		createEmitters();
 	}
 
 	if (d->m_initiallyActive)
@@ -373,4 +366,22 @@ void AutoHealBehavior::loadPostProcess()
 	// extend base class
 	UpgradeMux::upgradeMuxLoadPostProcess();
 
+	createEmitters();
+
+}
+
+// ------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
+void AutoHealBehavior::createEmitters( void )
+{
+    const AutoHealBehaviorModuleData *d = getAutoHealBehaviorModuleData();
+	if( d->m_radiusParticleSystemTmpl )
+	{
+		ParticleSystem *particleSystem = TheParticleSystemManager->createParticleSystem(d->m_radiusParticleSystemTmpl);
+		if( particleSystem )
+		{
+			particleSystem->setPosition( getObject()->getPosition() );
+			m_radiusParticleSystemID = particleSystem->getSystemID();
+		}
+	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/AutoHealBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/AutoHealBehavior.cpp
@@ -367,7 +367,7 @@ void AutoHealBehavior::loadPostProcess()
 
 // ------------------------------------------------------------------------------------------------
 // ------------------------------------------------------------------------------------------------
-void AutoHealBehavior::createEmitters( void )
+void AutoHealBehavior::createEmitters()
 {
 	if( m_radiusParticleSystemID == INVALID_PARTICLE_SYSTEM_ID )
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/AutoHealBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/AutoHealBehavior.cpp
@@ -374,7 +374,7 @@ void AutoHealBehavior::loadPostProcess()
 // ------------------------------------------------------------------------------------------------
 void AutoHealBehavior::createEmitters( void )
 {
-    const AutoHealBehaviorModuleData *d = getAutoHealBehaviorModuleData();
+	const AutoHealBehaviorModuleData *d = getAutoHealBehaviorModuleData();
 	if( m_radiusParticleSystemID == INVALID_PARTICLE_SYSTEM_ID && d->m_radiusParticleSystemTmpl )
 	{
 		ParticleSystem *particleSystem = TheParticleSystemManager->createParticleSystem(d->m_radiusParticleSystemTmpl);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/AutoHealBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/AutoHealBehavior.cpp
@@ -34,7 +34,6 @@
 #include "Common/ThingTemplate.h"
 #include "Common/INI.h"
 #include "Common/Player.h"
-#include "Common/GameState.h"
 #include "Common/Xfer.h"
 #include "GameClient/ParticleSys.h"
 #include "GameClient/Anim2D.h"
@@ -95,13 +94,6 @@ AutoHealBehavior::AutoHealBehavior( Thing *thing, const ModuleData* moduleData )
 	m_radiusParticleSystemID = INVALID_PARTICLE_SYSTEM_ID;
 	m_soonestHealFrame = 0;
 	m_stopped = false;
-
-	// TheSuperHackers @bugfix stephanmeesters 20/02/2026
-	// If loading from savegame, delay non-saveable emitter creation until postProcess.
-	if (TheGameState == nullptr || TheGameState->isInLoadGame() == FALSE)
-	{
-		createEmitters();
-	}
 
 	if (d->m_initiallyActive)
 	{
@@ -175,6 +167,9 @@ UpdateSleepTime AutoHealBehavior::update()
 {
 	if (m_stopped)
 		return UPDATE_SLEEP_FOREVER;
+
+	// TheSuperHackers @bugfix stephanmeesters 14/03/2026 Delay emitter creation until update
+	createEmitters();
 
 	Object *obj = getObject();
 	const AutoHealBehaviorModuleData *d = getAutoHealBehaviorModuleData();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/AutoHealBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/AutoHealBehavior.cpp
@@ -179,7 +179,8 @@ UpdateSleepTime AutoHealBehavior::update()
 		return UPDATE_SLEEP_FOREVER;
 	}
 
-	// TheSuperHackers @bugfix stephanmeesters 14/03/2026 Delay emitter creation until update
+	// TheSuperHackers @bugfix stephanmeesters 18/04/2026 Delay emitter creation until update, to ensure that the particle
+	// systems are not created before ParticleManager has xfer-loaded.
 	createEmitters();
 
 //DEBUG_LOG(("doing auto heal %d",TheGameLogic->getFrame()));

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/AutoHealBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/AutoHealBehavior.cpp
@@ -361,8 +361,6 @@ void AutoHealBehavior::loadPostProcess()
 	// extend base class
 	UpgradeMux::upgradeMuxLoadPostProcess();
 
-	createEmitters();
-
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/GrantStealthBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/GrantStealthBehavior.cpp
@@ -245,7 +245,7 @@ void GrantStealthBehavior::loadPostProcess()
 void GrantStealthBehavior::createEmitters( void )
 {
 	const GrantStealthBehaviorModuleData *d = getGrantStealthBehaviorModuleData();
-	if( d->m_radiusParticleSystemTmpl )
+	if( m_radiusParticleSystemID == INVALID_PARTICLE_SYSTEM_ID && d->m_radiusParticleSystemTmpl )
 	{
 		ParticleSystem *particleSystem = TheParticleSystemManager->createParticleSystem(d->m_radiusParticleSystemTmpl);
 		if( particleSystem )

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/GrantStealthBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/GrantStealthBehavior.cpp
@@ -33,6 +33,7 @@
 #include "Common/ThingTemplate.h"
 #include "Common/INI.h"
 #include "Common/Player.h"
+#include "Common/GameState.h"
 #include "Common/Xfer.h"
 #include "GameClient/ParticleSys.h"
 #include "GameClient/Anim2D.h"
@@ -96,21 +97,11 @@ GrantStealthBehavior::GrantStealthBehavior( Thing *thing, const ModuleData* modu
 
   m_currentScanRadius = d->m_startRadius;
 
-
-  Object *obj = getObject();
-
+	// TheSuperHackers @bugfix stephanmeesters 20/02/2026
+	// If loading from savegame, delay non-saveable emitter creation until postProcess.
+	if ( TheGameState == nullptr || TheGameState->isInLoadGame() == FALSE )
 	{
-		if( d->m_radiusParticleSystemTmpl )
-		{
-			ParticleSystem *particleSystem;
-
-			particleSystem = TheParticleSystemManager->createParticleSystem( d->m_radiusParticleSystemTmpl );
-			if( particleSystem )
-			{
-				particleSystem->setPosition( obj->getPosition() );
-				m_radiusParticleSystemID = particleSystem->getSystemID();
-			}
-		}
+		createEmitters();
 	}
 
 		setWakeFrame( getObject(), UPDATE_SLEEP_NONE );
@@ -246,5 +237,21 @@ void GrantStealthBehavior::loadPostProcess()
 	// extend base class
 	UpdateModule::loadPostProcess();
 
+	createEmitters();
+}
 
+// ------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
+void GrantStealthBehavior::createEmitters( void )
+{
+	const GrantStealthBehaviorModuleData *d = getGrantStealthBehaviorModuleData();
+	if( d->m_radiusParticleSystemTmpl )
+	{
+		ParticleSystem *particleSystem = TheParticleSystemManager->createParticleSystem(d->m_radiusParticleSystemTmpl);
+		if( particleSystem )
+		{
+			particleSystem->setPosition( getObject()->getPosition() );
+			m_radiusParticleSystemID = particleSystem->getSystemID();
+		}
+	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/GrantStealthBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/GrantStealthBehavior.cpp
@@ -33,7 +33,6 @@
 #include "Common/ThingTemplate.h"
 #include "Common/INI.h"
 #include "Common/Player.h"
-#include "Common/GameState.h"
 #include "Common/Xfer.h"
 #include "GameClient/ParticleSys.h"
 #include "GameClient/Anim2D.h"
@@ -97,14 +96,7 @@ GrantStealthBehavior::GrantStealthBehavior( Thing *thing, const ModuleData* modu
 
   m_currentScanRadius = d->m_startRadius;
 
-	// TheSuperHackers @bugfix stephanmeesters 20/02/2026
-	// If loading from savegame, delay non-saveable emitter creation until postProcess.
-	if ( TheGameState == nullptr || TheGameState->isInLoadGame() == FALSE )
-	{
-		createEmitters();
-	}
-
-		setWakeFrame( getObject(), UPDATE_SLEEP_NONE );
+	setWakeFrame( getObject(), UPDATE_SLEEP_NONE );
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -129,6 +121,9 @@ UpdateSleepTime GrantStealthBehavior::update()
 
 	if ( self->isEffectivelyDead())
 		return UPDATE_SLEEP_FOREVER;
+
+	// TheSuperHackers @bugfix stephanmeesters 14/03/2026 Delay emitter creation until update
+	createEmitters();
 
 	const GrantStealthBehaviorModuleData *d = getGrantStealthBehaviorModuleData();
 	// setup scan filters

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/GrantStealthBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/GrantStealthBehavior.cpp
@@ -239,9 +239,9 @@ void GrantStealthBehavior::loadPostProcess()
 // ------------------------------------------------------------------------------------------------
 void GrantStealthBehavior::createEmitters( void )
 {
-	const GrantStealthBehaviorModuleData *d = getGrantStealthBehaviorModuleData();
-	if( m_radiusParticleSystemID == INVALID_PARTICLE_SYSTEM_ID && d->m_radiusParticleSystemTmpl )
+	if( m_radiusParticleSystemID == INVALID_PARTICLE_SYSTEM_ID )
 	{
+		const GrantStealthBehaviorModuleData *d = getGrantStealthBehaviorModuleData();
 		ParticleSystem *particleSystem = TheParticleSystemManager->createParticleSystem(d->m_radiusParticleSystemTmpl);
 		if( particleSystem )
 		{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/GrantStealthBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/GrantStealthBehavior.cpp
@@ -237,7 +237,7 @@ void GrantStealthBehavior::loadPostProcess()
 
 // ------------------------------------------------------------------------------------------------
 // ------------------------------------------------------------------------------------------------
-void GrantStealthBehavior::createEmitters( void )
+void GrantStealthBehavior::createEmitters()
 {
 	if( m_radiusParticleSystemID == INVALID_PARTICLE_SYSTEM_ID )
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/GrantStealthBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/GrantStealthBehavior.cpp
@@ -122,7 +122,8 @@ UpdateSleepTime GrantStealthBehavior::update()
 	if ( self->isEffectivelyDead())
 		return UPDATE_SLEEP_FOREVER;
 
-	// TheSuperHackers @bugfix stephanmeesters 14/03/2026 Delay emitter creation until update
+	// TheSuperHackers @bugfix stephanmeesters 18/04/2026 Delay emitter creation until update, to ensure that the particle
+	// systems are not created before ParticleManager has xfer-loaded.
 	createEmitters();
 
 	const GrantStealthBehaviorModuleData *d = getGrantStealthBehaviorModuleData();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/GrantStealthBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/GrantStealthBehavior.cpp
@@ -232,7 +232,6 @@ void GrantStealthBehavior::loadPostProcess()
 	// extend base class
 	UpdateModule::loadPostProcess();
 
-	createEmitters();
 }
 
 // ------------------------------------------------------------------------------------------------


### PR DESCRIPTION
 - Closes #754
 - Relates to #2316

During loading a savegame, some particle systems were created before `ParticleSystemManager` had the opportunity to xfer-load the saved particle systems, which led to the possibility that some of these early created  particle systems could be overwritten in `m_systemMap` of `ParticleSystemManager`. When that happens they would no longer reliably be able to use master/slave systems. The retail game does not use master/slave on the involved effects but it could appear as an issue with some mods (as the bug report describes too).

## Todo
 - [x] Replicate in Generals