### PR TITLE
fix(logic): Fix potential null pointer deferences in GameLogicDispatch

### DIFF
--- a/Generals/Code/GameEngine/Include/GameLogic/AI.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AI.h
@@ -945,7 +945,7 @@ public:
 	void computeIndividualDestination( Coord3D *dest, const Coord3D *groupDest,
 		Object *obj, const Coord3D *center, Bool isFormation ); ///< compute destination of individual object, based on group destination
 	Int getCount();										///< return the number of objects in the group
-	Bool isEmpty();										///< returns true if the group has no members
+	Bool isEmpty() const;										///< returns true if the group has no members
 	void queueUpgrade( const UpgradeTemplate *upgrade );	///< queue an upgrade
 
 	void add( Object *obj );								///< add object to group

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
@@ -502,7 +502,7 @@ Int AIGroup::getCount()
 /**
  * Returns true if the group has no members
  */
-Bool AIGroup::isEmpty()
+Bool AIGroup::isEmpty() const
 {
 	return m_memberList.empty();
 }

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -207,7 +207,7 @@ static void doSetRallyPoint( Object *obj, const Coord3D& pos )
 
 static Object * getSingleObjectFromSelection(const AIGroup *currentlySelectedGroup)
 {
-	if( currentlySelectedGroup )
+	if( currentlySelectedGroup && !currentlySelectedGroup->isEmpty() )
 	{
 		const VecObjectID& selectedObjects = currentlySelectedGroup->getAllIDs();
 		DEBUG_ASSERTCRASH(selectedObjects.size() == 1, ("Trying to get single object from multiple selection!"));
@@ -532,7 +532,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Object *targetObject = findObjectByID( msg->getArgument( 0 )->objectID );
 
 			// issue command for either single object or for selected group
-			if( currentlySelectedGroup )
+			if( currentlySelectedGroup && targetObject )
 				currentlySelectedGroup->groupCombatDrop( targetObject,
 																								 *targetObject->getPosition(),
 																								 CMD_FROM_PLAYER );

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
@@ -984,7 +984,7 @@ public:
 	void computeIndividualDestination( Coord3D *dest, const Coord3D *groupDest,
 		Object *obj, const Coord3D *center, Bool isFormation ); ///< compute destination of individual object, based on group destination
 	Int getCount();										///< return the number of objects in the group
-	Bool isEmpty();										///< returns true if the group has no members
+	Bool isEmpty() const;										///< returns true if the group has no members
 	void queueUpgrade( const UpgradeTemplate *upgrade );	///< queue an upgrade
 
 	void add( Object *obj );								///< add object to group

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
@@ -502,7 +502,7 @@ Int AIGroup::getCount()
 /**
  * Returns true if the group has no members
  */
-Bool AIGroup::isEmpty()
+Bool AIGroup::isEmpty() const
 {
 	return m_memberList.empty();
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -208,7 +208,7 @@ static void doSetRallyPoint( Object *obj, const Coord3D& pos )
 
 static Object * getSingleObjectFromSelection(const AIGroup *currentlySelectedGroup)
 {
-	if( currentlySelectedGroup )
+	if( currentlySelectedGroup && !currentlySelectedGroup->isEmpty() )
 	{
 		const VecObjectID& selectedObjects = currentlySelectedGroup->getAllIDs();
 		DEBUG_ASSERTCRASH(selectedObjects.size() == 1, ("Trying to get single object from multiple selection!"));
@@ -541,7 +541,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Object *targetObject = findObjectByID( msg->getArgument( 0 )->objectID );
 
 			// issue command for either single object or for selected group
-			if( currentlySelectedGroup )
+			if( currentlySelectedGroup && targetObject )
 				currentlySelectedGroup->groupCombatDrop( targetObject,
 																								 *targetObject->getPosition(),
 																								 CMD_FROM_PLAYER );


### PR DESCRIPTION
Scanned through `GameLogicDispatch` and found some possible null pointer deference issues.