### PR TITLE
refactor(view): Change scripted state booleans to enum flags in W3DView

### DIFF
--- a/Core/GameEngine/Include/GameClient/View.h
+++ b/Core/GameEngine/Include/GameClient/View.h
@@ -172,6 +172,9 @@ public:
 	virtual void zoomCamera( Real finalZoom, Int milliseconds, Real easeIn=0.0f, Real easeOut=0.0f ) {};
 	virtual void pitchCamera( Real finalPitch, Int milliseconds, Real easeIn=0.0f, Real easeOut=0.0f ) {};
 
+	virtual Bool isDoingScriptedCamera() = 0;
+	virtual void stopDoingScriptedCamera() = 0;
+
 	virtual void setAngle( Real radians );															///< Rotate the view around the vertical axis to the given angle (yaw)
 	virtual Real getAngle() { return m_angle; }										///< Return current camera angle
 	virtual void setPitch( Real radians );															///< Rotate the view around the horizontal axis to the given angle (pitch)

--- a/Generals/Code/Tools/WorldBuilder/src/wbview3d.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/wbview3d.cpp
@@ -196,6 +196,9 @@ public:
 
 	virtual void forceRedraw() { }
 
+	virtual Bool isDoingScriptedCamera() { return false; }
+	virtual void stopDoingScriptedCamera() {}
+
 	virtual void lookAt( const Coord3D *o ){};														///< Center the view on the given coordinate
 	virtual void initHeightForMap( void ) {};														///<  Init the camera height for the map at the current position.
 	virtual void scrollBy( Coord2D *delta ){};														///< Shift the view by the given delta

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/wbview3d.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/wbview3d.cpp
@@ -197,6 +197,9 @@ public:
 
 	virtual void forceRedraw() { }
 
+	virtual Bool isDoingScriptedCamera() { return false; }
+	virtual void stopDoingScriptedCamera() {}
+
 	virtual void lookAt( const Coord3D *o ){};														///< Center the view on the given coordinate
 	virtual void initHeightForMap( void ) {};														///<  Init the camera height for the map at the current position.
 	virtual void scrollBy( Coord2D *delta ){};														///< Shift the view by the given delta


### PR DESCRIPTION
This changes scripted state booleans to enum flags in W3DView. Functionality wise nothing should change. 

This does not look like it makes much sense yet, but it will be useful in later changes when we can add additional logic into the new functions that now control the scripted camera states.

The nearby code formatting was also improved a bit for readability.