### PR TITLE
chore(pathfinder): Cleanup formatting and fix an incomplete optimization in PathfindZoneManager:calculateZones()

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -2746,12 +2746,14 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
 						notTerrainOrCrusher = FALSE;
 					}
 
-					if (waterGround(r_thisCell,r_topCell))
-						applyZone(r_thisCell, r_topCell, m_groundWaterZones, m_maxZone);
-					else if (groundRubble(r_thisCell, r_topCell))
-						applyZone(r_thisCell, r_topCell, m_groundRubbleZones, m_maxZone);
-					else if (groundCliff(r_thisCell,r_topCell))
-						applyZone(r_thisCell, r_topCell, m_groundCliffZones, m_maxZone);
+					if (notTerrainOrCrusher) {
+						if (waterGround(r_thisCell, r_topCell))
+							applyZone(r_thisCell, r_topCell, m_groundWaterZones, m_maxZone);
+						else if (groundRubble(r_thisCell, r_topCell))
+							applyZone(r_thisCell, r_topCell, m_groundRubbleZones, m_maxZone);
+						else if (groundCliff(r_thisCell, r_topCell))
+							applyZone(r_thisCell, r_topCell, m_groundCliffZones, m_maxZone);
+					}
 
 				}
 


### PR DESCRIPTION
**merge by rebase**

This PR is split out from the AiPathfind unification PR to reduce the difference in the merge between Generals and Zero Hours AiPathfind.cpp files.

It also contains a fix for an optimization that was missed in the zero hour code, this fix does not cause any mismatching and is why this PR should be merged by rebase.

There was extensive changes made to `PathfindZoneManager:calculateZones()` which introduced a large number of formatting differences relative to the rest of the code.

This PR more closely aligns Zero Hours PathfindZoneManager:calculateZones() with Generals implementation by doing the following:

- Fixes leading spaces by changing them for leading tabs
- Changes while loops back to for loops to match the original implementaitons in generals ( makes the code much cleaner too )
- Fixes style of open braces to match the rest of the code by placing them inline with their conditional/logical statement ( K&R style )
- Reverts a few small refactors in the zero hour code to their Generals implementation since they were cleaner in style