### PR TITLE
bugfix(radar): Fix incorrect 2D distance calculation in Radar::tryEvent

### DIFF
--- a/Core/GameEngine/Source/Common/System/Radar.cpp
+++ b/Core/GameEngine/Source/Common/System/Radar.cpp
@@ -1186,8 +1186,9 @@ Bool Radar::tryEvent( RadarEventType event, const Coord3D *pos )
 		{
 
 			// get distance from our new event location to this event location in 2D
-			Real distSquared = m_event[ i ].worldLoc.x - pos->x * m_event[ i ].worldLoc.x - pos->x +
-												 m_event[ i ].worldLoc.y - pos->y * m_event[ i ].worldLoc.y - pos->y;
+			Real dx = m_event[i].worldLoc.x - pos->x;
+			Real dy = m_event[i].worldLoc.y - pos->y;
+			Real distSquared = dx * dx + dy * dy;
 
 			if( distSquared <= closeEnoughDistanceSq )
 			{

--- a/Core/GameEngine/Source/Common/System/Radar.cpp
+++ b/Core/GameEngine/Source/Common/System/Radar.cpp
@@ -1186,9 +1186,9 @@ Bool Radar::tryEvent( RadarEventType event, const Coord3D *pos )
 		{
 
 			// get distance from our new event location to this event location in 2D
-			Real dx = m_event[i].worldLoc.x - pos->x;
-			Real dy = m_event[i].worldLoc.y - pos->y;
-			Real distSquared = dx * dx + dy * dy;
+			const Real dx = m_event[i].worldLoc.x - pos->x;
+			const Real dy = m_event[i].worldLoc.y - pos->y;
+			const Real distSquared = dx * dx + dy * dy;
 
 			if( distSquared <= closeEnoughDistanceSq )
 			{

--- a/Core/GameEngine/Source/Common/System/Radar.cpp
+++ b/Core/GameEngine/Source/Common/System/Radar.cpp
@@ -1186,9 +1186,7 @@ Bool Radar::tryEvent( RadarEventType event, const Coord3D *pos )
 		{
 
 			// get distance from our new event location to this event location in 2D
-			const Real dx = m_event[i].worldLoc.x - pos->x;
-			const Real dy = m_event[i].worldLoc.y - pos->y;
-			const Real distSquared = dx * dx + dy * dy;
+      const Real distSquared = sqr(m_event[ i ].worldLoc.x - pos->x) + sqr(m_event[ i ].worldLoc.y - pos->y);
 
 			if( distSquared <= closeEnoughDistanceSq )
 			{

--- a/Core/GameEngine/Source/Common/System/Radar.cpp
+++ b/Core/GameEngine/Source/Common/System/Radar.cpp
@@ -1186,7 +1186,7 @@ Bool Radar::tryEvent( RadarEventType event, const Coord3D *pos )
 		{
 
 			// get distance from our new event location to this event location in 2D
-      const Real distSquared = sqr(m_event[ i ].worldLoc.x - pos->x) + sqr(m_event[ i ].worldLoc.y - pos->y);
+			const Real distSquared = sqr(m_event[ i ].worldLoc.x - pos->x) + sqr(m_event[ i ].worldLoc.y - pos->y);
 
 			if( distSquared <= closeEnoughDistanceSq )
 			{


### PR DESCRIPTION
## Summary

The 2D distance calculation in `Radar::tryEvent` was incorrect due to operator precedence.

The previous implementation:

```cpp
Real distSquared =
    m_event[i].worldLoc.x - pos->x * m_event[i].worldLoc.x - pos->x +
    m_event[i].worldLoc.y - pos->y * m_event[i].worldLoc.y - pos->y;
````

does **not** compute the squared distance:

```
(x1 - x2)^2 + (y1 - y2)^2
```

Because multiplication has higher precedence than subtraction, the expression is evaluated as:

```
x1 - (x2 * x1) - x2 + y1 - (y2 * y1) - y2
```

This can produce incorrect values, including negative results, which are invalid for squared distance.

---

## Example

Using:

```
x1 = 10
y1 = 5
x2 = 3
y2 = 1
```

### Expected result (correct formula)

```
dx = 10 - 3 = 7
dy = 5 - 1 = 4

distSquared = 7*7 + 4*4
            = 49 + 16
            = 65
```

### Previous implementation result

```
10 - (3 * 10) - 3 + 5 - (1 * 5) - 1
= 10 - 30 - 3 + 5 - 5 - 1
= -24
```

Squared distance should never be negative, which demonstrates the calculation was incorrect.

---

## Fix

Replaced the calculation with the proper squared distance formula:

```cpp
Real dx = m_event[i].worldLoc.x - pos->x;
Real dy = m_event[i].worldLoc.y - pos->y;
Real distSquared = dx * dx + dy * dy;
```
