### PR TITLE
ci(vcpkg): Fix recurring binary cache invalidation from runner image updates

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -112,20 +112,13 @@ jobs:
         run: |
           $baseline = (Get-Content vcpkg.json | ConvertFrom-Json)."builtin-baseline"
 
-          $msvc = $env:VCToolsVersion
-          if (-not $msvc) { $msvc = "unknown" }
-
-          # Reduce churn: keep major.minor (e.g. 14.44)
-          $msvcMajorMinor = ($msvc -split '\.')[0..1] -join '.'
-
           $triplet = "x86-windows"
           if ("${{ inputs.preset }}" -like "x64*") { $triplet = "x64-windows" }
 
           "baseline=$baseline" >> $env:GITHUB_OUTPUT
-          "msvc=$msvcMajorMinor" >> $env:GITHUB_OUTPUT
           "triplet=$triplet" >> $env:GITHUB_OUTPUT
 
-          Write-Host "vcpkg cache key parts: baseline=$baseline, msvc=$msvcMajorMinor, triplet=$triplet"
+          Write-Host "vcpkg cache key parts: baseline=$baseline, triplet=$triplet"
 
       - name: Restore vcpkg binary cache
         if: startsWith(inputs.preset, 'win32')
@@ -133,10 +126,10 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ github.workspace }}\vcpkg-bincache
-          key: vcpkg-bincache-v2-${{ runner.os }}-msvc${{ steps.vcpkg_key.outputs.msvc }}-baseline${{ steps.vcpkg_key.outputs.baseline }}-${{ steps.vcpkg_key.outputs.triplet }}
+          key: vcpkg-bincache-v3-${{ runner.os }}-baseline${{ steps.vcpkg_key.outputs.baseline }}-${{ steps.vcpkg_key.outputs.triplet }}-${{ hashFiles('triplets/*.cmake') }}
           restore-keys: |
-            vcpkg-bincache-v2-${{ runner.os }}-msvc${{ steps.vcpkg_key.outputs.msvc }}-baseline${{ steps.vcpkg_key.outputs.baseline }}-
-            vcpkg-bincache-v2-${{ runner.os }}-
+            vcpkg-bincache-v3-${{ runner.os }}-baseline${{ steps.vcpkg_key.outputs.baseline }}-
+            vcpkg-bincache-v3-${{ runner.os }}-
 
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11
@@ -157,6 +150,8 @@ jobs:
 
           "VCPKG_DEFAULT_BINARY_CACHE=$cacheDir" >> $env:GITHUB_ENV
           "VCPKG_BINARY_SOURCES=$env:VCPKG_BINARY_SOURCES" >> $env:GITHUB_ENV
+          "VCPKG_OVERLAY_TRIPLETS=${{ github.workspace }}\triplets" >> $env:GITHUB_ENV
+          "VCPKG_INSTALL_OPTIONS=--x-abi-tools-use-exact-versions" >> $env:GITHUB_ENV
 
       - name: Configure ${{ inputs.game }} with CMake Using ${{ inputs.preset }}${{ inputs.tools && '+t' || '' }}${{ inputs.extras && '+e' || '' }} Preset
         shell: pwsh
@@ -186,7 +181,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: ${{ github.workspace }}\vcpkg-bincache
-          key: vcpkg-bincache-v2-${{ runner.os }}-msvc${{ steps.vcpkg_key.outputs.msvc }}-baseline${{ steps.vcpkg_key.outputs.baseline }}-${{ steps.vcpkg_key.outputs.triplet }}
+          key: vcpkg-bincache-v3-${{ runner.os }}-baseline${{ steps.vcpkg_key.outputs.baseline }}-${{ steps.vcpkg_key.outputs.triplet }}-${{ hashFiles('triplets/*.cmake') }}
 
       - name: Collect ${{ inputs.game }} ${{ inputs.preset }}${{ inputs.tools && '+t' || '' }}${{ inputs.extras && '+e' || '' }} Artifact
         shell: pwsh

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -83,7 +83,8 @@
                 "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
                 "CMAKE_MSVC_DEBUG_INFORMATION_FORMAT": "$<$<CONFIG:Release,Debug,RelWithDebInfo>:Embedded>",
                 "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL",
-                "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+                "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+                "VCPKG_OVERLAY_TRIPLETS": "${sourceDir}/triplets"
             }
         },
         {

--- a/triplets/x86-windows.cmake
+++ b/triplets/x86-windows.cmake
@@ -1,0 +1,9 @@
+# Include the default x86-windows triplet
+set(VCPKG_TARGET_ARCHITECTURE x86)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+
+# Exclude compiler version from ABI hash so that weekly GitHub runner image
+# updates don't invalidate the binary cache. Minor MSVC version bumps do not
+# cause ABI incompatibilities for this project.
+set(VCPKG_DISABLE_COMPILER_TRACKING ON)


### PR DESCRIPTION
## Summary
- Add custom x86-windows triplet overlay with `VCPKG_DISABLE_COMPILER_TRACKING` so weekly MSVC version bumps on GitHub-hosted runners don't invalidate the vcpkg binary cache
- Add `--x-abi-tools-use-exact-versions` to pin tool versions from vcpkg's own manifest instead of using system-installed versions
- Bump cache key to `v3` to flush the current stale cache and remove MSVC version from the key since compiler tracking is now disabled
- Add `VCPKG_OVERLAY_TRIPLETS` to CMakePresets.json so the custom triplet is used in both CI and local builds

## Test plan
- [x] First CI run will cache-miss (new `v3` key prefix), build from source, and save cache
- [x] Subsequent CI runs should restore cached packages and skip ffmpeg rebuild (~17 min savings)