### PR TITLE
build(cmake): Add retail compatibility option in CMake config

### DIFF
--- a/cmake/config-debug.cmake
+++ b/cmake/config-debug.cmake
@@ -15,10 +15,10 @@ option(RTS_DEBUG_INCLUDE_DEBUG_LOG_IN_CRC_LOG "Includes normal debug log in crc 
 option(RTS_DEBUG_MULTI_INSTANCE "Enables multi client instance support" OFF)
 
 
-define_option(RTS_DEBUG_LOGGING    DebugLogging    "Build with Debug Logging"     "DEBUG_LOGGING=1"    "DISABLE_DEBUG_LOGGING=1"    FALSE)
-define_option(RTS_DEBUG_CRASHING   DebugCrashing   "Build with Debug Crashing"     "DEBUG_CRASHING=1"   "DISABLE_DEBUG_CRASHING=1"   FALSE)
-define_option(RTS_DEBUG_STACKTRACE DebugStacktrace "Build with Debug Stacktracing" "DEBUG_STACKTRACE=1" "DISABLE_DEBUG_STACKTRACE=1" FALSE)
-define_option(RTS_DEBUG_PROFILE    DebugProfile    "Build with Debug Profiling"    "DEBUG_PROFILE=1"    "DISABLE_DEBUG_PROFILE=1"    FALSE)
+define_tristate_option(RTS_DEBUG_LOGGING    DebugLogging    "Build with Debug Logging"      DEBUG_LOGGING    DISABLE_DEBUG_LOGGING)
+define_tristate_option(RTS_DEBUG_CRASHING   DebugCrashing   "Build with Debug Crashing"     DEBUG_CRASHING   DISABLE_DEBUG_CRASHING)
+define_tristate_option(RTS_DEBUG_STACKTRACE DebugStacktrace "Build with Debug Stacktracing" DEBUG_STACKTRACE DISABLE_DEBUG_STACKTRACE)
+define_tristate_option(RTS_DEBUG_PROFILE    DebugProfile    "Build with Debug Profiling"    DEBUG_PROFILE    DISABLE_DEBUG_PROFILE)
 
 add_feature_info(DebugCheats RTS_DEBUG_CHEATS "Build with Debug Cheats in release builds")
 add_feature_info(DebugIncludeDebugLogInCrcLog RTS_DEBUG_INCLUDE_DEBUG_LOG_IN_CRC_LOG "Build with Debug Logging in CRC log")

--- a/cmake/config-debug.cmake
+++ b/cmake/config-debug.cmake
@@ -15,26 +15,10 @@ option(RTS_DEBUG_INCLUDE_DEBUG_LOG_IN_CRC_LOG "Includes normal debug log in crc 
 option(RTS_DEBUG_MULTI_INSTANCE "Enables multi client instance support" OFF)
 
 
-# Helper macro that handles DEFAULT ON OFF options
-macro(define_debug_option OptionName OptionEnabledCompileDef OptionDisabledCompileDef FeatureInfoName FeatureInfoDescription)
-    if(${OptionName} STREQUAL "DEFAULT")
-        # Does nothing
-    elseif(${OptionName} STREQUAL "ON")
-        target_compile_definitions(core_config INTERFACE ${OptionEnabledCompileDef}=1)
-        add_feature_info(${FeatureInfoName} TRUE ${FeatureInfoDescription})
-    elseif(${OptionName} STREQUAL "OFF")
-        target_compile_definitions(core_config INTERFACE ${OptionDisabledCompileDef}=1)
-        add_feature_info(${FeatureInfoName} FALSE ${FeatureInfoDescription})
-    else()
-        message(FATAL_ERROR "Unhandled option")
-    endif()
-endmacro()
-
-
-define_debug_option(RTS_DEBUG_LOGGING    DEBUG_LOGGING    DISABLE_DEBUG_LOGGING    DebugLogging    "Build with Debug Logging")
-define_debug_option(RTS_DEBUG_CRASHING   DEBUG_CRASHING   DISABLE_DEBUG_CRASHING   DebugCrashing   "Build with Debug Crashing")
-define_debug_option(RTS_DEBUG_STACKTRACE DEBUG_STACKTRACE DISABLE_DEBUG_STACKTRACE DebugStacktrace "Build with Debug Stacktracing")
-define_debug_option(RTS_DEBUG_PROFILE    DEBUG_PROFILE    DISABLE_DEBUG_PROFILE    DebugProfile    "Build with Debug Profiling")
+define_option(RTS_DEBUG_LOGGING    DebugLogging    "Build with Debug Logging"     "DEBUG_LOGGING=1"    "DISABLE_DEBUG_LOGGING=1"    FALSE)
+define_option(RTS_DEBUG_CRASHING   DebugCrashing   "Build with Debug Crashing"     "DEBUG_CRASHING=1"   "DISABLE_DEBUG_CRASHING=1"   FALSE)
+define_option(RTS_DEBUG_STACKTRACE DebugStacktrace "Build with Debug Stacktracing" "DEBUG_STACKTRACE=1" "DISABLE_DEBUG_STACKTRACE=1" FALSE)
+define_option(RTS_DEBUG_PROFILE    DebugProfile    "Build with Debug Profiling"    "DEBUG_PROFILE=1"    "DISABLE_DEBUG_PROFILE=1"    FALSE)
 
 add_feature_info(DebugCheats RTS_DEBUG_CHEATS "Build with Debug Cheats in release builds")
 add_feature_info(DebugIncludeDebugLogInCrcLog RTS_DEBUG_INCLUDE_DEBUG_LOG_IN_CRC_LOG "Build with Debug Logging in CRC log")

--- a/cmake/config-macros.cmake
+++ b/cmake/config-macros.cmake
@@ -1,0 +1,51 @@
+# Shared helper macros for the config-*.cmake files.
+
+# Handles a DEFAULT/ON/OFF option, applying OnDefs or OffDefs accordingly.
+macro(define_option OptionName FeatureInfoName FeatureInfoDescription OnDefs OffDefs ShowDefaultFeature)
+    if(${OptionName} STREQUAL "DEFAULT")
+        if(${ShowDefaultFeature})
+            add_feature_info(${FeatureInfoName} TRUE ${FeatureInfoDescription})
+        endif()
+    elseif(${OptionName} STREQUAL "ON")
+        foreach(_option_def ${OnDefs})
+            target_compile_definitions(core_config INTERFACE ${_option_def})
+        endforeach()
+        add_feature_info(${FeatureInfoName} TRUE ${FeatureInfoDescription})
+    elseif(${OptionName} STREQUAL "OFF")
+        foreach(_option_def ${OffDefs})
+            target_compile_definitions(core_config INTERFACE ${_option_def})
+        endforeach()
+        add_feature_info(${FeatureInfoName} FALSE ${FeatureInfoDescription})
+    else()
+        message(FATAL_ERROR "Unhandled ${OptionName} value: ${${OptionName}}")
+    endif()
+endmacro()
+
+
+# Discovers GuardPrefix guards in HeaderFile and applies them via define_option.
+macro(define_guarded_option OptionName FeatureInfoName FeatureInfoDescription HeaderFile GuardPrefix)
+    file(STRINGS "${HeaderFile}" _guarded_option_defines REGEX "^#[ \t]*define[ \t]+${GuardPrefix}[A-Z0-9_]+")
+    set(_guarded_option_guards "")
+    foreach(_guarded_option_define IN LISTS _guarded_option_defines)
+        string(REGEX MATCH "${GuardPrefix}[A-Z0-9_]+" _guarded_option_name "${_guarded_option_define}")
+        list(APPEND _guarded_option_guards "${_guarded_option_name}")
+    endforeach()
+    list(REMOVE_DUPLICATES _guarded_option_guards)
+
+    if(NOT _guarded_option_guards)
+        message(FATAL_ERROR "No ${GuardPrefix}* guards found in ${HeaderFile}.")
+    endif()
+
+    set(_guarded_option_on_defs "")
+    set(_guarded_option_off_defs "")
+    foreach(_guarded_option_name IN LISTS _guarded_option_guards)
+        list(APPEND _guarded_option_on_defs "${_guarded_option_name}=1")
+        list(APPEND _guarded_option_off_defs "${_guarded_option_name}=0")
+    endforeach()
+
+    define_option(${OptionName} ${FeatureInfoName} ${FeatureInfoDescription}
+        "${_guarded_option_on_defs}" "${_guarded_option_off_defs}" TRUE)
+    unset(_guarded_option_guards)
+    unset(_guarded_option_on_defs)
+    unset(_guarded_option_off_defs)
+endmacro()

--- a/cmake/config-macros.cmake
+++ b/cmake/config-macros.cmake
@@ -1,51 +1,65 @@
 # Shared helper macros for the config-*.cmake files.
 
-# Handles a DEFAULT/ON/OFF option, applying OnDefs or OffDefs accordingly.
-macro(define_option OptionName FeatureInfoName FeatureInfoDescription OnDefs OffDefs ShowDefaultFeature)
-    if(${OptionName} STREQUAL "DEFAULT")
-        if(${ShowDefaultFeature})
-            add_feature_info(${FeatureInfoName} TRUE ${FeatureInfoDescription})
+# Toggles a DEFAULT/ON/OFF option over DefineNames (a name or list of names). ON -> <name>=1.
+# OffDefineNames empty -> OFF sets the same names to <name>=0.
+# OffDefineNames non-empty -> OFF sets these names to <off_name>=1 instead, one per DefineNames entry.
+macro(define_tristate_option OptionName FeatureInfoName FeatureInfoDescription DefineNames OffDefineNames)
+    set(_tristate_names "${DefineNames}")
+    if(NOT _tristate_names)
+        message(FATAL_ERROR "DefineNames must be a non-empty name or list of names.")
+    endif()
+
+    set(_tristate_off_names "${OffDefineNames}")
+
+    set(_tristate_on_defs "")
+    set(_tristate_off_defs "")
+    foreach(_tristate_name _tristate_off_name IN ZIP_LISTS _tristate_names _tristate_off_names)
+        if(_tristate_off_names AND (NOT _tristate_name OR NOT _tristate_off_name))
+            message(FATAL_ERROR "OffDefineNames must be empty or match DefineNames in length.")
         endif()
+        list(APPEND _tristate_on_defs "${_tristate_name}=1")
+        if(_tristate_off_names)
+            list(APPEND _tristate_off_defs "${_tristate_off_name}=1")
+        else()
+            list(APPEND _tristate_off_defs "${_tristate_name}=0")
+        endif()
+    endforeach()
+
+    if(${OptionName} STREQUAL "DEFAULT")
+        # Does nothing
     elseif(${OptionName} STREQUAL "ON")
-        foreach(_option_def ${OnDefs})
-            target_compile_definitions(core_config INTERFACE ${_option_def})
-        endforeach()
+        target_compile_definitions(core_config INTERFACE ${_tristate_on_defs})
         add_feature_info(${FeatureInfoName} TRUE ${FeatureInfoDescription})
     elseif(${OptionName} STREQUAL "OFF")
-        foreach(_option_def ${OffDefs})
-            target_compile_definitions(core_config INTERFACE ${_option_def})
-        endforeach()
+        target_compile_definitions(core_config INTERFACE ${_tristate_off_defs})
         add_feature_info(${FeatureInfoName} FALSE ${FeatureInfoDescription})
     else()
         message(FATAL_ERROR "Unhandled ${OptionName} value: ${${OptionName}}")
     endif()
+
+    unset(_tristate_names)
+    unset(_tristate_off_names)
+    unset(_tristate_on_defs)
+    unset(_tristate_off_defs)
+    unset(_tristate_name)
+    unset(_tristate_off_name)
 endmacro()
 
-
-# Discovers GuardPrefix guards in HeaderFile and applies them via define_option.
-macro(define_guarded_option OptionName FeatureInfoName FeatureInfoDescription HeaderFile GuardPrefix)
-    file(STRINGS "${HeaderFile}" _guarded_option_defines REGEX "^#[ \t]*define[ \t]+${GuardPrefix}[A-Z0-9_]+")
-    set(_guarded_option_guards "")
-    foreach(_guarded_option_define IN LISTS _guarded_option_defines)
-        string(REGEX MATCH "${GuardPrefix}[A-Z0-9_]+" _guarded_option_name "${_guarded_option_define}")
-        list(APPEND _guarded_option_guards "${_guarded_option_name}")
+# Collects defines matching DefinePrefix from InputFile into OutputVariableName.
+macro(collect_defines_from_file OutputVariableName InputFile DefinePrefix)
+    file(STRINGS "${InputFile}" _matching_lines REGEX "^#[ \t]*define[ \t]+${DefinePrefix}[A-Z0-9_]+")
+    set(${OutputVariableName} "")
+    foreach(_matching_line IN LISTS _matching_lines)
+        string(REGEX MATCH "${DefinePrefix}[A-Z0-9_]+" _define_name "${_matching_line}")
+        list(APPEND ${OutputVariableName} "${_define_name}")
     endforeach()
-    list(REMOVE_DUPLICATES _guarded_option_guards)
+    list(REMOVE_DUPLICATES ${OutputVariableName})
 
-    if(NOT _guarded_option_guards)
-        message(FATAL_ERROR "No ${GuardPrefix}* guards found in ${HeaderFile}.")
+    if(NOT ${OutputVariableName})
+        message(FATAL_ERROR "No ${DefinePrefix}* defines found in ${InputFile}.")
     endif()
 
-    set(_guarded_option_on_defs "")
-    set(_guarded_option_off_defs "")
-    foreach(_guarded_option_name IN LISTS _guarded_option_guards)
-        list(APPEND _guarded_option_on_defs "${_guarded_option_name}=1")
-        list(APPEND _guarded_option_off_defs "${_guarded_option_name}=0")
-    endforeach()
-
-    define_option(${OptionName} ${FeatureInfoName} ${FeatureInfoDescription}
-        "${_guarded_option_on_defs}" "${_guarded_option_off_defs}" TRUE)
-    unset(_guarded_option_guards)
-    unset(_guarded_option_on_defs)
-    unset(_guarded_option_off_defs)
+    unset(_matching_lines)
+    unset(_matching_line)
+    unset(_define_name)
 endmacro()

--- a/cmake/config-retail.cmake
+++ b/cmake/config-retail.cmake
@@ -4,36 +4,8 @@
 set(RTS_BUILD_OPTION_RETAIL_COMPATIBLE_GAME "DEFAULT" CACHE STRING "Build for retail game compatibility. OFF enables retail-incompatible fixes. DEFAULT follows GameDefines.h.")
 set_property(CACHE RTS_BUILD_OPTION_RETAIL_COMPATIBLE_GAME PROPERTY STRINGS DEFAULT ON OFF)
 
-file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/Core/GameEngine/Include/Common/GameDefines.h" _retail_guards
-    REGEX "^#[ \t]*define[ \t]+RETAIL_COMPATIBLE_[A-Z0-9_]+")
-set(RTS_RETAIL_COMPATIBLE_GUARDS "")
-foreach(_guard IN LISTS _retail_guards)
-    string(REGEX MATCH "RETAIL_COMPATIBLE_[A-Z0-9_]+" _guard_name "${_guard}")
-    list(APPEND RTS_RETAIL_COMPATIBLE_GUARDS "${_guard_name}")
-endforeach()
-list(REMOVE_DUPLICATES RTS_RETAIL_COMPATIBLE_GUARDS)
-
-if(NOT RTS_RETAIL_COMPATIBLE_GUARDS)
-    message(FATAL_ERROR "No RETAIL_COMPATIBLE_* guards found in GameDefines.h.")
-endif()
-
-if(RTS_BUILD_OPTION_RETAIL_COMPATIBLE_GAME STREQUAL "DEFAULT")
-    add_feature_info(RetailCompatibleGame TRUE "Building with retail compatibility from GameDefines.h")
-elseif(RTS_BUILD_OPTION_RETAIL_COMPATIBLE_GAME STREQUAL "ON")
-    set(_retail_compatible_value 1)
-    add_feature_info(RetailCompatibleGame TRUE "Building with retail compatibility forced on")
-elseif(RTS_BUILD_OPTION_RETAIL_COMPATIBLE_GAME STREQUAL "OFF")
-    set(_retail_compatible_value 0)
-    add_feature_info(RetailCompatibleGame FALSE "Building with retail compatibility forced off")
-else()
-    message(FATAL_ERROR "Unhandled RTS_BUILD_OPTION_RETAIL_COMPATIBLE_GAME value: ${RTS_BUILD_OPTION_RETAIL_COMPATIBLE_GAME}")
-endif()
-
-if(DEFINED _retail_compatible_value)
-    foreach(_guard IN LISTS RTS_RETAIL_COMPATIBLE_GUARDS)
-        target_compile_definitions(core_config INTERFACE ${_guard}=${_retail_compatible_value})
-    endforeach()
-endif()
+define_guarded_option(RTS_BUILD_OPTION_RETAIL_COMPATIBLE_GAME RetailCompatibleGame "Build with Retail Compatibility"
+    "${CMAKE_CURRENT_SOURCE_DIR}/Core/GameEngine/Include/Common/GameDefines.h" "RETAIL_COMPATIBLE_")
 
 if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL "12.0.8804" AND NOT RTS_BUILD_OPTION_RETAIL_COMPATIBLE_GAME STREQUAL "OFF")
     message(NOTICE "")

--- a/cmake/config-retail.cmake
+++ b/cmake/config-retail.cmake
@@ -1,11 +1,11 @@
 # Retail game compatibility options
-# Sets the RETAIL_COMPATIBLE_* guards from GameDefines.h
 
 set(RTS_BUILD_OPTION_RETAIL_COMPATIBLE_GAME "DEFAULT" CACHE STRING "Build for retail game compatibility. OFF enables retail-incompatible fixes. DEFAULT follows GameDefines.h.")
 set_property(CACHE RTS_BUILD_OPTION_RETAIL_COMPATIBLE_GAME PROPERTY STRINGS DEFAULT ON OFF)
 
-define_guarded_option(RTS_BUILD_OPTION_RETAIL_COMPATIBLE_GAME RetailCompatibleGame "Build with Retail Compatibility"
-    "${CMAKE_CURRENT_SOURCE_DIR}/Core/GameEngine/Include/Common/GameDefines.h" "RETAIL_COMPATIBLE_")
+collect_defines_from_file(_retail_guards "${CMAKE_CURRENT_SOURCE_DIR}/Core/GameEngine/Include/Common/GameDefines.h" "RETAIL_COMPATIBLE_")
+define_tristate_option(RTS_BUILD_OPTION_RETAIL_COMPATIBLE_GAME RetailCompatibleGame "Build with Retail Compatibility" "${_retail_guards}" "")
+unset(_retail_guards)
 
 if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL "12.0.8804" AND NOT RTS_BUILD_OPTION_RETAIL_COMPATIBLE_GAME STREQUAL "OFF")
     message(NOTICE "")

--- a/cmake/config-retail.cmake
+++ b/cmake/config-retail.cmake
@@ -1,0 +1,43 @@
+# Retail game compatibility options
+# Sets the RETAIL_COMPATIBLE_* guards from GameDefines.h
+
+set(RTS_BUILD_OPTION_RETAIL_COMPATIBLE_GAME "DEFAULT" CACHE STRING "Build for retail game compatibility. OFF enables retail-incompatible fixes. DEFAULT follows GameDefines.h.")
+set_property(CACHE RTS_BUILD_OPTION_RETAIL_COMPATIBLE_GAME PROPERTY STRINGS DEFAULT ON OFF)
+
+file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/Core/GameEngine/Include/Common/GameDefines.h" _retail_guards
+    REGEX "^#[ \t]*define[ \t]+RETAIL_COMPATIBLE_[A-Z0-9_]+")
+set(RTS_RETAIL_COMPATIBLE_GUARDS "")
+foreach(_guard IN LISTS _retail_guards)
+    string(REGEX MATCH "RETAIL_COMPATIBLE_[A-Z0-9_]+" _guard_name "${_guard}")
+    list(APPEND RTS_RETAIL_COMPATIBLE_GUARDS "${_guard_name}")
+endforeach()
+list(REMOVE_DUPLICATES RTS_RETAIL_COMPATIBLE_GUARDS)
+
+if(NOT RTS_RETAIL_COMPATIBLE_GUARDS)
+    message(FATAL_ERROR "No RETAIL_COMPATIBLE_* guards found in GameDefines.h.")
+endif()
+
+if(RTS_BUILD_OPTION_RETAIL_COMPATIBLE_GAME STREQUAL "DEFAULT")
+    add_feature_info(RetailCompatibleGame TRUE "Building with retail compatibility from GameDefines.h")
+elseif(RTS_BUILD_OPTION_RETAIL_COMPATIBLE_GAME STREQUAL "ON")
+    set(_retail_compatible_value 1)
+    add_feature_info(RetailCompatibleGame TRUE "Building with retail compatibility forced on")
+elseif(RTS_BUILD_OPTION_RETAIL_COMPATIBLE_GAME STREQUAL "OFF")
+    set(_retail_compatible_value 0)
+    add_feature_info(RetailCompatibleGame FALSE "Building with retail compatibility forced off")
+else()
+    message(FATAL_ERROR "Unhandled RTS_BUILD_OPTION_RETAIL_COMPATIBLE_GAME value: ${RTS_BUILD_OPTION_RETAIL_COMPATIBLE_GAME}")
+endif()
+
+if(DEFINED _retail_compatible_value)
+    foreach(_guard IN LISTS RTS_RETAIL_COMPATIBLE_GUARDS)
+        target_compile_definitions(core_config INTERFACE ${_guard}=${_retail_compatible_value})
+    endforeach()
+endif()
+
+if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL "12.0.8804" AND NOT RTS_BUILD_OPTION_RETAIL_COMPATIBLE_GAME STREQUAL "OFF")
+    message(NOTICE "")
+    message(NOTICE "  Retail compatibility: ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION} is not CRC-compatible with retail.")
+    message(NOTICE "  Retail builds need the VC6 SP6 compiler (12.00.8804).")
+    message(NOTICE "")
+endif()

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -1,6 +1,7 @@
 add_library(core_config INTERFACE)
 
 include(${CMAKE_CURRENT_LIST_DIR}/config-build.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/config-macros.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/config-retail.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/config-debug.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/config-memory.cmake)

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -1,5 +1,6 @@
 add_library(core_config INTERFACE)
 
 include(${CMAKE_CURRENT_LIST_DIR}/config-build.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/config-retail.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/config-debug.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/config-memory.cmake)


### PR DESCRIPTION
This pull request adds the `RTS_BUILD_OPTION_RETAIL_COMPATIBLE_GAME` configuration
option in `cmake/config-retail.cmake` to make it easier to build retail or non-retail.

Will eventually be used for #2322

Tri-state, matching `cmake/config-debug.cmake`:

| Value | |
| --- | --- |
| `DEFAULT` | follows `GameDefines.h` |
| `ON` | forces `RETAIL_COMPATIBLE_*` guards on |
| `OFF` | forces `RETAIL_COMPATIBLE_*` guards off |

The guard list is read from `GameDefines.h` at configure time, so new guards don't need CMake change.

The `DEFAULT/ON/OFF` dispatch is shared with `config-debug.cmake` via new helper macros in
`config-macros.cmake` (`define_tristate_option`).

Only the VC6 SP6 compiler produces a build that is CRC-compatible with retail,
other toolchains get a note. Skipped when `OFF`.

```
Retail compatibility: MSVC 19.44.35228.0 is not CRC-compatible with retail.
Retail builds need the VC6 SP6 compiler (12.00.8804).
```