### PR TITLE
fix(logic): Improve validation of MSG_DO_SPECIAL_POWER and variants in GameLogicDispatch

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -657,6 +657,18 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Object* source = findObjectByID(sourceID);
 			if (source != nullptr)
 			{
+#if !RETAIL_COMPATIBLE_CRC
+				// TheSuperHackers @fix stephanmeesters 01/03/2026 Validate the origin of the source object
+				if ( source->getControllingPlayer() != thisPlayer )
+				{
+					DEBUG_CRASH( ("MSG_DO_SPECIAL_POWER: Player '%ls' attempted to control the object '%s' owned by player '%ls'.",
+						 thisPlayer->getPlayerDisplayName().str(),
+						 source->getTemplate()->getName().str(),
+						 source->getControllingPlayer()->getPlayerDisplayName().str()) );
+					break;
+				}
+#endif
+
 				AIGroupPtr theGroup = TheAI->createGroup();
 				theGroup->add(source);
 				theGroup->groupDoSpecialPower( specialPowerID, options );
@@ -699,6 +711,18 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Object* source = findObjectByID(sourceID);
 			if (source != nullptr)
 			{
+#if !RETAIL_COMPATIBLE_CRC
+				// TheSuperHackers @fix stephanmeesters 01/03/2026 Validate the origin of the source object
+				if ( source->getControllingPlayer() != thisPlayer )
+				{
+					DEBUG_CRASH( ("MSG_DO_SPECIAL_POWER_AT_LOCATION: Player '%ls' attempted to control the object '%s' owned by player '%ls'.",
+						 thisPlayer->getPlayerDisplayName().str(),
+						 source->getTemplate()->getName().str(),
+						 source->getControllingPlayer()->getPlayerDisplayName().str()) );
+					break;
+				}
+#endif
+
 				AIGroupPtr theGroup = TheAI->createGroup();
 				theGroup->add(source);
 				theGroup->groupDoSpecialPowerAtLocation( specialPowerID, &targetCoord, INVALID_ANGLE, objectInWay, options );
@@ -742,6 +766,18 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Object* source = findObjectByID(sourceID);
 			if (source != nullptr)
 			{
+#if !RETAIL_COMPATIBLE_CRC
+				// TheSuperHackers @fix stephanmeesters 01/03/2026 Validate the origin of the source object
+				if ( source->getControllingPlayer() != thisPlayer )
+				{
+					DEBUG_CRASH( ("MSG_DO_SPECIAL_POWER_AT_OBJECT: Player '%ls' attempted to control the object '%s' owned by player '%ls'.",
+						 thisPlayer->getPlayerDisplayName().str(),
+						 source->getTemplate()->getName().str(),
+						 source->getControllingPlayer()->getPlayerDisplayName().str()) );
+					break;
+				}
+#endif
+
 				AIGroupPtr theGroup = TheAI->createGroup();
 				theGroup->add(source);
 				theGroup->groupDoSpecialPowerAtObject( specialPowerID, target, options );
@@ -1183,6 +1219,18 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Object* source = findObjectByID(sourceID);
 			if (source != nullptr)
 			{
+#if !RETAIL_COMPATIBLE_CRC
+				// TheSuperHackers @fix stephanmeesters 01/03/2026 Validate the origin of the source object
+				if ( source->getControllingPlayer() != thisPlayer )
+				{
+					DEBUG_CRASH( ("MSG_DO_SPECIAL_POWER_OVERRIDE_DESTINATION: Player '%ls' attempted to control the object '%s' owned by player '%ls'.",
+						 thisPlayer->getPlayerDisplayName().str(),
+						 source->getTemplate()->getName().str(),
+						 source->getControllingPlayer()->getPlayerDisplayName().str()) );
+					break;
+				}
+#endif
+
 				AIGroupPtr theGroup = TheAI->createGroup();
 				theGroup->add(source);
 				theGroup->groupOverrideSpecialPowerDestination( spType, loc, CMD_FROM_PLAYER );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -680,6 +680,14 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Object* source = findObjectByID(sourceID);
 			if (source != nullptr)
 			{
+				// TheSuperHackers @fix stephanmeesters 01/03/2026 Validate the origin of the source object
+				Player *player = ThePlayerList->getNthPlayer(msg->getPlayerIndex());
+				if ( player && source->getControllingPlayer() != player )
+				{
+					DEBUG_CRASH( ("MSG_DO_SPECIAL_POWER: Player at index '%d' doesn't control the object with sourceID '%d'.", player->getPlayerIndex(), (Int)sourceID) );
+					break;
+				}
+
 				AIGroupPtr theGroup = TheAI->createGroup();
 				theGroup->add(source);
 				theGroup->groupDoSpecialPower( specialPowerID, options );
@@ -725,6 +733,14 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Object* source = findObjectByID(sourceID);
 			if (source != nullptr)
 			{
+				// TheSuperHackers @fix stephanmeesters 01/03/2026 Validate the origin of the source object
+				Player *player = ThePlayerList->getNthPlayer(msg->getPlayerIndex());
+				if ( player && source->getControllingPlayer() != player )
+				{
+					DEBUG_CRASH( ("MSG_DO_SPECIAL_POWER_AT_LOCATION: Player at index '%d' doesn't control the object with sourceID '%d'.", player->getPlayerIndex(), (Int)sourceID) );
+					break;
+				}
+				
 				AIGroupPtr theGroup = TheAI->createGroup();
 				theGroup->add(source);
 				theGroup->groupDoSpecialPowerAtLocation( specialPowerID, &targetCoord, angle, objectInWay, options );
@@ -768,6 +784,14 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Object* source = findObjectByID(sourceID);
 			if (source != nullptr)
 			{
+				// TheSuperHackers @fix stephanmeesters 01/03/2026 Validate the origin of the source object
+				Player *player = ThePlayerList->getNthPlayer(msg->getPlayerIndex());
+				if ( player && source->getControllingPlayer() != player )
+				{
+					DEBUG_CRASH( ("MSG_DO_SPECIAL_POWER_AT_OBJECT: Player at index '%d' doesn't control the object with sourceID '%d'.", player->getPlayerIndex(), (Int)sourceID) );
+					break;
+				}
+				
 				AIGroupPtr theGroup = TheAI->createGroup();
 				theGroup->add(source);
 				theGroup->groupDoSpecialPowerAtObject( specialPowerID, target, options );
@@ -1211,6 +1235,14 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Object* source = findObjectByID(sourceID);
 			if (source != nullptr)
 			{
+				// TheSuperHackers @fix stephanmeesters 01/03/2026 Validate the origin of the source object
+				Player *player = ThePlayerList->getNthPlayer(msg->getPlayerIndex());
+				if ( player && source->getControllingPlayer() != player )
+				{
+					DEBUG_CRASH( ("MSG_DO_SPECIAL_POWER_OVERRIDE_DESTINATION: Player at index '%d' doesn't control the object with sourceID '%d'.", player->getPlayerIndex(), (Int)sourceID) );
+					break;
+				}
+				
 				AIGroupPtr theGroup = TheAI->createGroup();
 				theGroup->add(source);
 				theGroup->groupOverrideSpecialPowerDestination( spType, loc, CMD_FROM_PLAYER );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -680,6 +680,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Object* source = findObjectByID(sourceID);
 			if (source != nullptr)
 			{
+#if !RETAIL_COMPATIBLE_CRC
 				// TheSuperHackers @fix stephanmeesters 01/03/2026 Validate the origin of the source object
 				if ( source->getControllingPlayer() != thisPlayer )
 				{
@@ -689,6 +690,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 						 source->getControllingPlayer()->getPlayerDisplayName().str()) );
 					break;
 				}
+#endif
 
 				AIGroupPtr theGroup = TheAI->createGroup();
 				theGroup->add(source);
@@ -735,6 +737,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Object* source = findObjectByID(sourceID);
 			if (source != nullptr)
 			{
+#if !RETAIL_COMPATIBLE_CRC
 				// TheSuperHackers @fix stephanmeesters 01/03/2026 Validate the origin of the source object
 				if ( source->getControllingPlayer() != thisPlayer )
 				{
@@ -744,7 +747,8 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 						 source->getControllingPlayer()->getPlayerDisplayName().str()) );
 					break;
 				}
-				
+#endif
+
 				AIGroupPtr theGroup = TheAI->createGroup();
 				theGroup->add(source);
 				theGroup->groupDoSpecialPowerAtLocation( specialPowerID, &targetCoord, angle, objectInWay, options );
@@ -788,6 +792,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Object* source = findObjectByID(sourceID);
 			if (source != nullptr)
 			{
+#if !RETAIL_COMPATIBLE_CRC
 				// TheSuperHackers @fix stephanmeesters 01/03/2026 Validate the origin of the source object
 				if ( source->getControllingPlayer() != thisPlayer )
 				{
@@ -797,7 +802,8 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 						 source->getControllingPlayer()->getPlayerDisplayName().str()) );
 					break;
 				}
-				
+#endif
+
 				AIGroupPtr theGroup = TheAI->createGroup();
 				theGroup->add(source);
 				theGroup->groupDoSpecialPowerAtObject( specialPowerID, target, options );
@@ -1241,6 +1247,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			Object* source = findObjectByID(sourceID);
 			if (source != nullptr)
 			{
+#if !RETAIL_COMPATIBLE_CRC
 				// TheSuperHackers @fix stephanmeesters 01/03/2026 Validate the origin of the source object
 				if ( source->getControllingPlayer() != thisPlayer )
 				{
@@ -1250,7 +1257,8 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 						 source->getControllingPlayer()->getPlayerDisplayName().str()) );
 					break;
 				}
-				
+#endif
+
 				AIGroupPtr theGroup = TheAI->createGroup();
 				theGroup->add(source);
 				theGroup->groupOverrideSpecialPowerDestination( spType, loc, CMD_FROM_PLAYER );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -683,7 +683,10 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 				// TheSuperHackers @fix stephanmeesters 01/03/2026 Validate the origin of the source object
 				if ( source->getControllingPlayer() != thisPlayer )
 				{
-					DEBUG_CRASH( ("MSG_DO_SPECIAL_POWER: Player at index '%d' doesn't control the object with sourceID '%d'.", thisPlayer->getPlayerIndex(), (Int)sourceID) );
+					DEBUG_CRASH( ("MSG_DO_SPECIAL_POWER: Player '%ls' attempted to control the object '%s' owned by player '%ls'.",
+						 thisPlayer->getPlayerDisplayName().str(),
+						 source->getTemplate()->getName().str(),
+						 source->getControllingPlayer()->getPlayerDisplayName().str()) );
 					break;
 				}
 
@@ -735,7 +738,10 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 				// TheSuperHackers @fix stephanmeesters 01/03/2026 Validate the origin of the source object
 				if ( source->getControllingPlayer() != thisPlayer )
 				{
-					DEBUG_CRASH( ("MSG_DO_SPECIAL_POWER_AT_LOCATION: Player at index '%d' doesn't control the object with sourceID '%d'.", thisPlayer->getPlayerIndex(), (Int)sourceID) );
+					DEBUG_CRASH( ("MSG_DO_SPECIAL_POWER_AT_LOCATION: Player '%ls' attempted to control the object '%s' owned by player '%ls'.",
+						 thisPlayer->getPlayerDisplayName().str(),
+						 source->getTemplate()->getName().str(),
+						 source->getControllingPlayer()->getPlayerDisplayName().str()) );
 					break;
 				}
 				
@@ -785,7 +791,10 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 				// TheSuperHackers @fix stephanmeesters 01/03/2026 Validate the origin of the source object
 				if ( source->getControllingPlayer() != thisPlayer )
 				{
-					DEBUG_CRASH( ("MSG_DO_SPECIAL_POWER_AT_OBJECT: Player at index '%d' doesn't control the object with sourceID '%d'.", thisPlayer->getPlayerIndex(), (Int)sourceID) );
+					DEBUG_CRASH( ("MSG_DO_SPECIAL_POWER_AT_OBJECT: Player '%ls' attempted to control the object '%s' owned by player '%ls'.",
+						 thisPlayer->getPlayerDisplayName().str(),
+						 source->getTemplate()->getName().str(),
+						 source->getControllingPlayer()->getPlayerDisplayName().str()) );
 					break;
 				}
 				
@@ -1235,7 +1244,10 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 				// TheSuperHackers @fix stephanmeesters 01/03/2026 Validate the origin of the source object
 				if ( source->getControllingPlayer() != thisPlayer )
 				{
-					DEBUG_CRASH( ("MSG_DO_SPECIAL_POWER_OVERRIDE_DESTINATION: Player at index '%d' doesn't control the object with sourceID '%d'.", thisPlayer->getPlayerIndex(), (Int)sourceID) );
+					DEBUG_CRASH( ("MSG_DO_SPECIAL_POWER_OVERRIDE_DESTINATION: Player '%ls' attempted to control the object '%s' owned by player '%ls'.",
+						 thisPlayer->getPlayerDisplayName().str(),
+						 source->getTemplate()->getName().str(),
+						 source->getControllingPlayer()->getPlayerDisplayName().str()) );
 					break;
 				}
 				

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -681,10 +681,9 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			if (source != nullptr)
 			{
 				// TheSuperHackers @fix stephanmeesters 01/03/2026 Validate the origin of the source object
-				Player *player = ThePlayerList->getNthPlayer(msg->getPlayerIndex());
-				if ( player && source->getControllingPlayer() != player )
+				if ( source->getControllingPlayer() != thisPlayer )
 				{
-					DEBUG_CRASH( ("MSG_DO_SPECIAL_POWER: Player at index '%d' doesn't control the object with sourceID '%d'.", player->getPlayerIndex(), (Int)sourceID) );
+					DEBUG_CRASH( ("MSG_DO_SPECIAL_POWER: Player at index '%d' doesn't control the object with sourceID '%d'.", thisPlayer->getPlayerIndex(), (Int)sourceID) );
 					break;
 				}
 
@@ -734,10 +733,9 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			if (source != nullptr)
 			{
 				// TheSuperHackers @fix stephanmeesters 01/03/2026 Validate the origin of the source object
-				Player *player = ThePlayerList->getNthPlayer(msg->getPlayerIndex());
-				if ( player && source->getControllingPlayer() != player )
+				if ( source->getControllingPlayer() != thisPlayer )
 				{
-					DEBUG_CRASH( ("MSG_DO_SPECIAL_POWER_AT_LOCATION: Player at index '%d' doesn't control the object with sourceID '%d'.", player->getPlayerIndex(), (Int)sourceID) );
+					DEBUG_CRASH( ("MSG_DO_SPECIAL_POWER_AT_LOCATION: Player at index '%d' doesn't control the object with sourceID '%d'.", thisPlayer->getPlayerIndex(), (Int)sourceID) );
 					break;
 				}
 				
@@ -785,10 +783,9 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			if (source != nullptr)
 			{
 				// TheSuperHackers @fix stephanmeesters 01/03/2026 Validate the origin of the source object
-				Player *player = ThePlayerList->getNthPlayer(msg->getPlayerIndex());
-				if ( player && source->getControllingPlayer() != player )
+				if ( source->getControllingPlayer() != thisPlayer )
 				{
-					DEBUG_CRASH( ("MSG_DO_SPECIAL_POWER_AT_OBJECT: Player at index '%d' doesn't control the object with sourceID '%d'.", player->getPlayerIndex(), (Int)sourceID) );
+					DEBUG_CRASH( ("MSG_DO_SPECIAL_POWER_AT_OBJECT: Player at index '%d' doesn't control the object with sourceID '%d'.", thisPlayer->getPlayerIndex(), (Int)sourceID) );
 					break;
 				}
 				
@@ -1236,10 +1233,9 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 			if (source != nullptr)
 			{
 				// TheSuperHackers @fix stephanmeesters 01/03/2026 Validate the origin of the source object
-				Player *player = ThePlayerList->getNthPlayer(msg->getPlayerIndex());
-				if ( player && source->getControllingPlayer() != player )
+				if ( source->getControllingPlayer() != thisPlayer )
 				{
-					DEBUG_CRASH( ("MSG_DO_SPECIAL_POWER_OVERRIDE_DESTINATION: Player at index '%d' doesn't control the object with sourceID '%d'.", player->getPlayerIndex(), (Int)sourceID) );
+					DEBUG_CRASH( ("MSG_DO_SPECIAL_POWER_OVERRIDE_DESTINATION: Player at index '%d' doesn't control the object with sourceID '%d'.", thisPlayer->getPlayerIndex(), (Int)sourceID) );
 					break;
 				}
 				


### PR DESCRIPTION
This PR improves the stability of network games by validating the origin of source objects in `MSG_DO_SPECIAL_POWER` and related MSG variants in `GameLogicDispatch`. Tested on ~1k replays.

## Todo

- [x] Replicate in Generals