### PR TITLE
refactor(dozeraiupdate): Streamline dozer task cancellation logic

### DIFF
--- a/Generals/Code/GameEngine/Include/GameLogic/Module/DozerAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/DozerAIUpdate.h
@@ -140,6 +140,7 @@ public:
 	// task actions
 	virtual void newTask( DozerTask task, Object *target ) = 0;	///< set a desire to do the requrested task
 	virtual void cancelTask( DozerTask task ) = 0;							///< cancel this task from the queue, if it's the current task the dozer will stop working on it
+	virtual void cancelAllTasks() = 0;													///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
 	virtual void resumePreviousTask() = 0;									///< resume the previous task if there was one
 
 	// internal methods to manage behavior from within the dozer state machine
@@ -240,6 +241,7 @@ public:
 	// task actions
 	virtual void newTask( DozerTask task, Object *target );	///< set a desire to do the requrested task
 	virtual void cancelTask( DozerTask task );							///< cancel this task from the queue, if it's the current task the dozer will stop working on it
+	virtual void cancelAllTasks();													///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
 	virtual void resumePreviousTask();									///< resume the previous task if there was one
 
 	// internal methods to manage behavior from within the dozer state machine

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/WorkerAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/WorkerAIUpdate.h
@@ -155,6 +155,7 @@ public:
 	// task actions
 	virtual void newTask( DozerTask task, Object* target );	///< set a desire to do the requrested task
 	virtual void cancelTask( DozerTask task );						///< cancel this task from the queue, if it's the current task the dozer will stop working on it
+	virtual void cancelAllTasks();												///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
 	virtual void resumePreviousTask();									///< resume the previous task if there was one
 
 	// internal methods to manage behavior from within the dozer state machine

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Collide/CrateCollide/ConvertToHijackedVehicleCrateCollide.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Collide/CrateCollide/ConvertToHijackedVehicleCrateCollide.cpp
@@ -162,10 +162,7 @@ Bool ConvertToHijackedVehicleCrateCollide::executeCrateBehavior( Object *other )
 	DozerAIInterface * dozerAI = targetAI->getDozerAIInterface();
 	if ( dozerAI )
 	{
-		for (UnsignedInt task = DOZER_TASK_FIRST; task < DOZER_NUM_TASKS; ++task)
-		{
-			dozerAI->cancelTask( (DozerTask)task );
-		}
+		dozerAI->cancelAllTasks();
 	}
 
 	AudioEventRTS hijackEvent( "HijackDriver", obj->getID() );

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -74,6 +74,7 @@
 #include "GameLogic/Module/DeletionUpdate.h"
 #include "GameLogic/Module/DestroyModule.h"
 #include "GameLogic/Module/DieModule.h"
+#include "GameLogic/Module/DozerAIUpdate.h"
 #include "GameLogic/Module/ObjectDefectionHelper.h"
 #include "GameLogic/Module/ObjectRepulsorHelper.h"
 #include "GameLogic/Module/ObjectSMCHelper.h"
@@ -4052,10 +4053,7 @@ void Object::onCapture( Player *oldOwner, Player *newOwner )
 			DozerAIInterface* dozerAI = getAIUpdateInterface()->getDozerAIInterface();
 			if (dozerAI)
 			{
-				for (UnsignedInt task = DOZER_TASK_FIRST; task < DOZER_NUM_TASKS; ++task)
-				{
-					dozerAI->cancelTask((DozerTask)task);
-				}
+				dozerAI->cancelAllTasks();
 			}
 		}
 #endif

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2041,6 +2041,14 @@ void DozerAIUpdate::cancelTask( DozerTask task )
 
 }
 
+void DozerAIUpdate::cancelAllTasks()
+{
+	for (UnsignedInt task = DOZER_TASK_FIRST; task < DOZER_NUM_TASKS; ++task)
+		internalCancelTask((DozerTask)task);
+
+	m_dozerMachine->resetToDefaultState();
+}
+
 //-------------------------------------------------------------------------------------------------
 /** Attempt to resume the previous task */
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -696,6 +696,14 @@ void WorkerAIUpdate::cancelTask( DozerTask task )
 
 }
 
+void WorkerAIUpdate::cancelAllTasks()
+{
+	for (UnsignedInt task = DOZER_TASK_FIRST; task < DOZER_NUM_TASKS; ++task)
+		internalCancelTask((DozerTask)task);
+
+	m_dozerMachine->resetToDefaultState();
+}
+
 //-------------------------------------------------------------------------------------------------
 /** Attempt to resume the previous task */
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DozerAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DozerAIUpdate.h
@@ -140,6 +140,7 @@ public:
 	// task actions
 	virtual void newTask( DozerTask task, Object *target ) = 0;	///< set a desire to do the requested task
 	virtual void cancelTask( DozerTask task ) = 0;							///< cancel this task from the queue, if it's the current task the dozer will stop working on it
+	virtual void cancelAllTasks() = 0;													///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
 	virtual void resumePreviousTask() = 0;									///< resume the previous task if there was one
 
 	// internal methods to manage behavior from within the dozer state machine
@@ -240,6 +241,7 @@ public:
 	// task actions
 	virtual void newTask( DozerTask task, Object *target );	///< set a desire to do the requested task
 	virtual void cancelTask( DozerTask task );							///< cancel this task from the queue, if it's the current task the dozer will stop working on it
+	virtual void cancelAllTasks();													///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
 	virtual void resumePreviousTask();									///< resume the previous task if there was one
 
 	// internal methods to manage behavior from within the dozer state machine

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/WorkerAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/WorkerAIUpdate.h
@@ -158,6 +158,7 @@ public:
 	// task actions
 	virtual void newTask( DozerTask task, Object* target );	///< set a desire to do the requested task
 	virtual void cancelTask( DozerTask task );						///< cancel this task from the queue, if it's the current task the dozer will stop working on it
+	virtual void cancelAllTasks();												///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
 	virtual void resumePreviousTask();									///< resume the previous task if there was one
 
 	// internal methods to manage behavior from within the dozer state machine

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Collide/CrateCollide/ConvertToHijackedVehicleCrateCollide.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Collide/CrateCollide/ConvertToHijackedVehicleCrateCollide.cpp
@@ -173,10 +173,7 @@ Bool ConvertToHijackedVehicleCrateCollide::executeCrateBehavior( Object *other )
 	DozerAIInterface * dozerAI = targetAI->getDozerAIInterface();
 	if ( dozerAI )
 	{
-		for (UnsignedInt task = DOZER_TASK_FIRST; task < DOZER_NUM_TASKS; ++task)
-		{
-			dozerAI->cancelTask( (DozerTask)task );
-		}
+		dozerAI->cancelAllTasks();
 	}
 
 	AudioEventRTS hijackEvent( "HijackDriver", obj->getID() );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -4584,10 +4584,7 @@ void Object::onCapture( Player *oldOwner, Player *newOwner )
 			DozerAIInterface* dozerAI = getAIUpdateInterface()->getDozerAIInterface();
 			if (dozerAI)
 			{
-				for (UnsignedInt task = DOZER_TASK_FIRST; task < DOZER_NUM_TASKS; ++task)
-				{
-					dozerAI->cancelTask((DozerTask)task);
-				}
+				dozerAI->cancelAllTasks();
 			}
 		}
 #endif

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -2046,6 +2046,14 @@ void DozerAIUpdate::cancelTask( DozerTask task )
 
 }
 
+void DozerAIUpdate::cancelAllTasks()
+{
+	for (UnsignedInt task = DOZER_TASK_FIRST; task < DOZER_NUM_TASKS; ++task)
+		internalCancelTask((DozerTask)task);
+
+	m_dozerMachine->resetToDefaultState();
+}
+
 //-------------------------------------------------------------------------------------------------
 /** Attempt to resume the previous task */
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -696,6 +696,14 @@ void WorkerAIUpdate::cancelTask( DozerTask task )
 
 }
 
+void WorkerAIUpdate::cancelAllTasks()
+{
+	for (UnsignedInt task = DOZER_TASK_FIRST; task < DOZER_NUM_TASKS; ++task)
+		internalCancelTask((DozerTask)task);
+
+	m_dozerMachine->resetToDefaultState();
+}
+
 //-------------------------------------------------------------------------------------------------
 /** Attempt to resume the previous task */
 //-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This change is a follow-up to #2237 and streamlines instances where all of a dozer's tasks are cancelled into a single `cancelAllTasks` method. This method also marginally improves performance by only resetting the dozer state machine to its default state once, rather than with every task cancellation.