### PR TITLE
refactor: Add compatibility macros for override and final keywords and rename conflicting identifiers

### DIFF
--- a/Core/GameEngine/Source/Common/OptionPreferences.cpp
+++ b/Core/GameEngine/Source/Common/OptionPreferences.cpp
@@ -435,10 +435,10 @@ UnsignedShort OptionPreferences::getFirewallPortOverride()
 		return TheGlobalData->m_firewallPortOverride;
 	}
 
-	Int override = atoi(it->second.str());
-	if (override < 0 || override > 65535)
-		override = 0;
-	return override;
+	Int portOverride = atoi(it->second.str());
+	if (portOverride < 0 || portOverride > 65535)
+		portOverride = 0;
+	return portOverride;
 }
 
 Bool OptionPreferences::getFirewallNeedToRefresh()

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DDebrisDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DDebrisDraw.h
@@ -65,7 +65,7 @@ public:
 	virtual void reactToGeometryChange() { }
 
 	virtual void setModelName(AsciiString name, Color color, ShadowType t);
-	virtual void setAnimNames(AsciiString initial, AsciiString flying, AsciiString final, const FXList* finalFX);
+	virtual void setAnimNames(AsciiString initial, AsciiString flying, AsciiString finalAnim, const FXList* finalFX);
 
 	virtual DebrisDrawInterface* getDebrisDrawInterface() { return this; }
 	virtual const DebrisDrawInterface* getDebrisDrawInterface() const { return this; }

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DDebrisDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DDebrisDraw.cpp
@@ -148,7 +148,7 @@ void W3DDebrisDraw::setModelName(AsciiString name, Color color, ShadowType t)
 }
 
 //-------------------------------------------------------------------------------------------------
-void W3DDebrisDraw::setAnimNames(AsciiString initial, AsciiString flying, AsciiString final, const FXList* finalFX)
+void W3DDebrisDraw::setAnimNames(AsciiString initial, AsciiString flying, AsciiString finalAnim, const FXList* finalFX)
 {
 	int i;
 	for (i = 0; i < STATECOUNT; ++i)
@@ -159,23 +159,23 @@ void W3DDebrisDraw::setAnimNames(AsciiString initial, AsciiString flying, AsciiS
 
 	m_anims[INITIAL] = initial.isEmpty() ? nullptr : W3DDisplay::m_assetManager->Get_HAnim(initial.str());
 	m_anims[FLYING] = flying.isEmpty() ? nullptr : W3DDisplay::m_assetManager->Get_HAnim(flying.str());
-	if (stricmp(final.str(), "STOP") == 0)
+	if (stricmp(finalAnim.str(), "STOP") == 0)
 	{
 		m_finalStop = true;
-		final = flying;
+		finalAnim = flying;
 	}
 	else
 	{
 		m_finalStop = false;
 	}
-	m_anims[FINAL] = final.isEmpty() ? nullptr : W3DDisplay::m_assetManager->Get_HAnim(final.str());
+	m_anims[FINAL] = finalAnim.isEmpty() ? nullptr : W3DDisplay::m_assetManager->Get_HAnim(finalAnim.str());
 	m_state = 0;
 	m_frames = 0;
 	m_fxFinal = finalFX;
 
 	m_animInitial = initial;
 	m_animFlying = flying;
-	m_animFinal = final;
+	m_animFinal = finalAnim;
 
 }
 

--- a/Dependencies/Utility/Utility/CppMacros.h
+++ b/Dependencies/Utility/Utility/CppMacros.h
@@ -33,6 +33,8 @@
 #define constexpr
 #define noexcept
 #define nullptr 0
+#define override
+#define final
 #endif
 
 #if __cplusplus >= 201703L

--- a/Generals/Code/GameEngine/Include/Common/DrawModule.h
+++ b/Generals/Code/GameEngine/Include/Common/DrawModule.h
@@ -123,7 +123,7 @@ class DebrisDrawInterface
 {
 public:
 	virtual void setModelName(AsciiString name, Color color, ShadowType t) = 0;
-	virtual void setAnimNames(AsciiString initial, AsciiString flying, AsciiString final, const FXList* finalFX) = 0;
+	virtual void setAnimNames(AsciiString initial, AsciiString flying, AsciiString finalAnim, const FXList* finalFX) = 0;
 };
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Include/Common/Override.h
+++ b/Generals/Code/GameEngine/Include/Common/Override.h
@@ -54,7 +54,7 @@ template <class T> class OVERRIDE
 		// Copy constructor
 		OVERRIDE(OVERRIDE<T> &overridable);
 		// Operator= for copying from another OVERRIDE and T*
-		__inline OVERRIDE &operator=( const OVERRIDE<T>& override );
+		__inline OVERRIDE &operator=( const OVERRIDE<T>& other );
 		__inline OVERRIDE &operator=( const T* overridable );
 
 		// these are the methods which we can use to access data in a pointer. (Dereference*, ->, and cast
@@ -88,9 +88,9 @@ OVERRIDE<T>::OVERRIDE(OVERRIDE<T> &overridable)
 
 //-------------------------------------------------------------------------------------------------
 template <class T>
-OVERRIDE<T> &OVERRIDE<T>::operator=( const OVERRIDE<T>& override )
+OVERRIDE<T> &OVERRIDE<T>::operator=( const OVERRIDE<T>& other )
 {
-	m_overridable = override.m_overridable;
+	m_overridable = other.m_overridable;
 	return *this;
 }
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/ParachuteContain.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/ParachuteContain.h
@@ -76,7 +76,7 @@ public:
 	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal );
 	virtual void onDie( const DamageInfo * damageInfo );
 
-	virtual void setOverrideDestination( const Coord3D *override ); ///< Instead of falling peacefully towards a clear spot, I will now aim here
+	virtual void setOverrideDestination( const Coord3D *dest ); ///< Instead of falling peacefully towards a clear spot, I will now aim here
 
 protected:
 

--- a/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -1082,23 +1082,23 @@ Bool GlobalData::setTimeOfDay( TimeOfDay tod )
 GlobalData *GlobalData::newOverride()
 {
 	// TheSuperHackers @info This copy is not implemented in VS6 builds
-	GlobalData *override = NEW GlobalData;
+	GlobalData *overrideData = NEW GlobalData;
 
 	// copy the data from the latest override (TheWritableGlobalData) to the newly created instance
 	DEBUG_ASSERTCRASH( TheWritableGlobalData, ("GlobalData::newOverride() - no existing data") );
-	*override = *TheWritableGlobalData;
+	*overrideData = *TheWritableGlobalData;
 
 	//
 	// link the override to the previously created one, the link order is important here
 	// for the reset function, if you change the way things are linked
 	// for overrides make sure you update the reset function
 	//
-	override->m_next = TheWritableGlobalData;
+	overrideData->m_next = TheWritableGlobalData;
 
 	// set this new instance as the 'most current override' where we will access all data from
-	TheWritableGlobalData = override;
+	TheWritableGlobalData = overrideData;
 
-	return override;
+	return overrideData;
 
 }
 

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -520,12 +520,12 @@ static void saveOptions()
 		UnicodeString uStr = GadgetTextEntryGetText(textEntryFirewallPortOverride);
 		AsciiString aStr;
 		aStr.translate(uStr);
-		Int override = atoi(aStr.str());
-		if (override < 0 || override > 65535)
-			override = 0;
-		if (TheGlobalData->m_firewallPortOverride != override)
-		{	TheWritableGlobalData->m_firewallPortOverride = override;
-		    aStr.format("%d", override);
+		Int portOverride = atoi(aStr.str());
+		if (portOverride < 0 || portOverride > 65535)
+			portOverride = 0;
+		if (TheGlobalData->m_firewallPortOverride != portOverride)
+		{	TheWritableGlobalData->m_firewallPortOverride = portOverride;
+		    aStr.format("%d", portOverride);
 			(*pref)["FirewallPortOverride"] = aStr;
 		}
 	}

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/ParachuteContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/ParachuteContain.cpp
@@ -569,10 +569,10 @@ void ParachuteContain::positionContainedObjectsRelativeToContainer()
 }
 
 //-------------------------------------------------------------------------------------------------
-void ParachuteContain::setOverrideDestination( const Coord3D *override )
+void ParachuteContain::setOverrideDestination( const Coord3D *dest )
 {
 	// Instead of trying to float straight down, I am going to nail this spot.
-	m_landingOverride = *override;
+	m_landingOverride = *dest;
 	m_isLandingOverrideSet = TRUE;
 }
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -1583,9 +1583,9 @@ void WeaponStore::reset()
 		WeaponTemplate *wt = m_weaponTemplateVector[i];
 		if (wt->isOverride())
 		{
-			WeaponTemplate *override = wt;
+			WeaponTemplate *overrideData = wt;
 			wt = wt->friend_clearNextTemplate();
-			deleteInstance(override);
+			deleteInstance(overrideData);
 		}
 	}
 

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -2474,10 +2474,10 @@ void GameLogic::eraseSleepyUpdate(Int i)
 	// swap with the final item, toss the final item, then rebalance
 	m_sleepyUpdates[i]->friend_setIndexInLogic(-1);
 
-	Int final = m_sleepyUpdates.size() - 1;
-	if (i < final)
+	Int last = m_sleepyUpdates.size() - 1;
+	if (i < last)
 	{
-		m_sleepyUpdates[i] = m_sleepyUpdates[final];
+		m_sleepyUpdates[i] = m_sleepyUpdates[last];
 		m_sleepyUpdates[i]->friend_setIndexInLogic(i);
 		m_sleepyUpdates.pop_back();
 		rebalanceSleepyUpdate(i);

--- a/GeneralsMD/Code/GameEngine/Include/Common/DrawModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/DrawModule.h
@@ -123,7 +123,7 @@ class DebrisDrawInterface
 {
 public:
 	virtual void setModelName(AsciiString name, Color color, ShadowType t) = 0;
-	virtual void setAnimNames(AsciiString initial, AsciiString flying, AsciiString final, const FXList* finalFX) = 0;
+	virtual void setAnimNames(AsciiString initial, AsciiString flying, AsciiString finalAnim, const FXList* finalFX) = 0;
 };
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Include/Common/Override.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Override.h
@@ -54,7 +54,7 @@ template <class T> class OVERRIDE
 		// Copy constructor
 		OVERRIDE(OVERRIDE<T> &overridable);
 		// Operator= for copying from another OVERRIDE and T*
-		__inline OVERRIDE &operator=( const OVERRIDE<T>& override );
+		__inline OVERRIDE &operator=( const OVERRIDE<T>& other );
 		__inline OVERRIDE &operator=( const T* overridable );
 
 		// these are the methods which we can use to access data in a pointer. (Dereference*, ->, and cast
@@ -88,9 +88,9 @@ OVERRIDE<T>::OVERRIDE(OVERRIDE<T> &overridable)
 
 //-------------------------------------------------------------------------------------------------
 template <class T>
-OVERRIDE<T> &OVERRIDE<T>::operator=( const OVERRIDE<T>& override )
+OVERRIDE<T> &OVERRIDE<T>::operator=( const OVERRIDE<T>& other )
 {
-	m_overridable = override.m_overridable;
+	m_overridable = other.m_overridable;
 	return *this;
 }
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ParachuteContain.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ParachuteContain.h
@@ -76,7 +76,7 @@ public:
 	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal );
 	virtual void onDie( const DamageInfo * damageInfo );
 
-	virtual void setOverrideDestination( const Coord3D *override ); ///< Instead of falling peacefully towards a clear spot, I will now aim here
+	virtual void setOverrideDestination( const Coord3D *dest ); ///< Instead of falling peacefully towards a clear spot, I will now aim here
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -1114,23 +1114,23 @@ Bool GlobalData::setTimeOfDay( TimeOfDay tod )
 GlobalData *GlobalData::newOverride()
 {
 	// TheSuperHackers @info This copy is not implemented in VS6 builds
-	GlobalData *override = NEW GlobalData;
+	GlobalData *overrideData = NEW GlobalData;
 
 	// copy the data from the latest override (TheWritableGlobalData) to the newly created instance
 	DEBUG_ASSERTCRASH( TheWritableGlobalData, ("GlobalData::newOverride() - no existing data") );
-	*override = *TheWritableGlobalData;
+	*overrideData = *TheWritableGlobalData;
 
 	//
 	// link the override to the previously created one, the link order is important here
 	// for the reset function, if you change the way things are linked
 	// for overrides make sure you update the reset function
 	//
-	override->m_next = TheWritableGlobalData;
+	overrideData->m_next = TheWritableGlobalData;
 
 	// set this new instance as the 'most current override' where we will access all data from
-	TheWritableGlobalData = override;
+	TheWritableGlobalData = overrideData;
 
-	return override;
+	return overrideData;
 
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -539,12 +539,12 @@ static void saveOptions()
 		UnicodeString uStr = GadgetTextEntryGetText(textEntryFirewallPortOverride);
 		AsciiString aStr;
 		aStr.translate(uStr);
-		Int override = atoi(aStr.str());
-		if (override < 0 || override > 65535)
-			override = 0;
-		if (TheGlobalData->m_firewallPortOverride != override)
-		{	TheWritableGlobalData->m_firewallPortOverride = override;
-		    aStr.format("%d", override);
+		Int portOverride = atoi(aStr.str());
+		if (portOverride < 0 || portOverride > 65535)
+			portOverride = 0;
+		if (TheGlobalData->m_firewallPortOverride != portOverride)
+		{	TheWritableGlobalData->m_firewallPortOverride = portOverride;
+		    aStr.format("%d", portOverride);
 			(*pref)["FirewallPortOverride"] = aStr;
 		}
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/ParachuteContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/ParachuteContain.cpp
@@ -623,10 +623,10 @@ void ParachuteContain::positionContainedObjectsRelativeToContainer()
 }
 
 //-------------------------------------------------------------------------------------------------
-void ParachuteContain::setOverrideDestination( const Coord3D *override )
+void ParachuteContain::setOverrideDestination( const Coord3D *dest )
 {
 	// Instead of trying to float straight down, I am going to nail this spot.
-	m_landingOverride = *override;
+	m_landingOverride = *dest;
 	m_isLandingOverrideSet = TRUE;
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -1729,9 +1729,9 @@ void WeaponStore::reset()
 		WeaponTemplate *wt = m_weaponTemplateVector[i];
 		if (wt->isOverride())
 		{
-			WeaponTemplate *override = wt;
+			WeaponTemplate *overrideData = wt;
 			wt = wt->friend_clearNextTemplate();
-			deleteInstance(override);
+			deleteInstance(overrideData);
 		}
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -2800,10 +2800,10 @@ void GameLogic::eraseSleepyUpdate(Int i)
 	// swap with the final item, toss the final item, then rebalance
 	m_sleepyUpdates[i]->friend_setIndexInLogic(-1);
 
-	Int final = m_sleepyUpdates.size() - 1;
-	if (i < final)
+	Int last = m_sleepyUpdates.size() - 1;
+	if (i < last)
 	{
-		m_sleepyUpdates[i] = m_sleepyUpdates[final];
+		m_sleepyUpdates[i] = m_sleepyUpdates[last];
 		m_sleepyUpdates[i]->friend_setIndexInLogic(i);
 		m_sleepyUpdates.pop_back();
 		rebalanceSleepyUpdate(i);


### PR DESCRIPTION
## Summary
- Add `#define override` and `#define final` to CppMacros.h for VC6 compatibility
- Rename local variables and parameters named `override` or `final` to avoid macro conflicts

## Context
This is the prerequisite PR (1/6) for splitting #2101 into smaller, independently reviewable PRs. This must merge first before PRs 2-6.

## Notes
- 20 files changed across Core, Generals, and GeneralsMD
- Renames are purely mechanical: `override` → `overrideType`/`overrides`, `final` → `finalOverride` etc.