### PR TITLE
refactor: Add override keyword to virtual function overrides in GameEngine

### DIFF
--- a/Generals/Code/GameEngine/Include/GameLogic/Module/AIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/AIUpdate.h
@@ -199,9 +199,9 @@ public:
 #endif
 
 	AIUpdateModuleData();
-	virtual ~AIUpdateModuleData();
+	virtual ~AIUpdateModuleData() override;
 
-	virtual Bool isAiModuleData() const { return true; }
+	virtual Bool isAiModuleData() const override { return true; }
 
 	const LocomotorTemplateVector* findLocomotorTemplateVector(LocomotorSetType t) const;
 	static void buildFieldParse(MultiIniFieldParse& p);
@@ -291,10 +291,10 @@ public:
 	AIUpdateInterface( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual AIUpdateInterface* getAIUpdateInterface() { return this; }
+	virtual AIUpdateInterface* getAIUpdateInterface() override { return this; }
 
 	// Disabled conditions to process (AI will still process held status)
-	virtual DisabledMaskType getDisabledTypesToProcess() const { return MAKE_DISABLED_MASK( DISABLED_HELD ); }
+	virtual DisabledMaskType getDisabledTypesToProcess() const override { return MAKE_DISABLED_MASK( DISABLED_HELD ); }
 
 	// Some very specific, complex behaviors are used by more than one AIUpdate.  Here are their interfaces.
 	virtual DozerAIInterface* getDozerAIInterface() {return nullptr;}
@@ -337,10 +337,10 @@ public:
 	//Definition of busy -- when explicitly in the busy state. Moving or attacking is not considered busy!
 	virtual Bool isBusy() const;
 
-	virtual void onObjectCreated();
+	virtual void onObjectCreated() override;
 	virtual void doQuickExit( std::vector<Coord3D>* path );			///< get out of this Object
 
-	virtual void aiDoCommand(const AICommandParms* parms);
+	virtual void aiDoCommand(const AICommandParms* parms) override;
 
 	virtual const Coord3D *getGuardLocation() const { return &m_locationToGuard;	}
 	virtual ObjectID getGuardObject() const { return m_objectToGuard; }
@@ -511,7 +511,7 @@ public:
 	Bool hasHigherPathPriority(AIUpdateInterface *otherAI) const;
 	void setFinalPosition(const Coord3D *pos) { m_finalPosition = *pos; m_doFinalPosition = false;}
 
-	virtual UpdateSleepTime update();	///< update this object's AI
+	virtual UpdateSleepTime update() override;	///< update this object's AI
 
 	/// if we are attacking "fromID", stop that and attack "toID" instead
 	void transferAttack(ObjectID fromID, ObjectID toID);
@@ -589,7 +589,7 @@ protected:
 		interesting oscillations can occur in some situations, with friction being applied
 		either before or after the locomotive force, making for huge stuttery messes. (srj)
 	*/
-	virtual SleepyUpdatePhase getUpdatePhase() const { return PHASE_INITIAL; }
+	virtual SleepyUpdatePhase getUpdatePhase() const override { return PHASE_INITIAL; }
 
 	void setGoalPositionClipped(const Coord3D* in, CommandSourceType cmdSource);
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/ActiveBody.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/ActiveBody.h
@@ -68,46 +68,46 @@ public:
 	ActiveBody( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onDelete();
+	virtual void onDelete() override;
 
-	virtual void attemptDamage( DamageInfo *damageInfo );		///< try to damage this object
-	virtual Real estimateDamage( DamageInfoInput& damageInfo ) const;
-	virtual void attemptHealing( DamageInfo *damageInfo );		///< try to heal this object
-	virtual Real getHealth() const;													///< get current health
-	virtual BodyDamageType getDamageState() const;
-	virtual void setDamageState( BodyDamageType newState );	///< control damage state directly.  Will adjust hitpoints.
-	virtual void setAflame( Bool setting );///< This is a major change like a damage state.
+	virtual void attemptDamage( DamageInfo *damageInfo ) override;		///< try to damage this object
+	virtual Real estimateDamage( DamageInfoInput& damageInfo ) const override;
+	virtual void attemptHealing( DamageInfo *damageInfo ) override;		///< try to heal this object
+	virtual Real getHealth() const override;													///< get current health
+	virtual BodyDamageType getDamageState() const override;
+	virtual void setDamageState( BodyDamageType newState ) override;	///< control damage state directly.  Will adjust hitpoints.
+	virtual void setAflame( Bool setting ) override;///< This is a major change like a damage state.
 
-	virtual const DamageInfo *getLastDamageInfo() const { return &m_lastDamageInfo; }	///< return info on last damage dealt to this object
-	virtual UnsignedInt getLastDamageTimestamp() const { return m_lastDamageTimestamp; }	///< return frame of last damage dealt
-	virtual UnsignedInt getLastHealingTimestamp() const { return m_lastHealingTimestamp; }	///< return frame of last damage dealt
-	virtual ObjectID getClearableLastAttacker() const { return (m_lastDamageCleared ? INVALID_ID : m_lastDamageInfo.in.m_sourceID); }
-	virtual void clearLastAttacker() { m_lastDamageCleared = true; }
+	virtual const DamageInfo *getLastDamageInfo() const override { return &m_lastDamageInfo; }	///< return info on last damage dealt to this object
+	virtual UnsignedInt getLastDamageTimestamp() const override { return m_lastDamageTimestamp; }	///< return frame of last damage dealt
+	virtual UnsignedInt getLastHealingTimestamp() const override { return m_lastHealingTimestamp; }	///< return frame of last damage dealt
+	virtual ObjectID getClearableLastAttacker() const override { return (m_lastDamageCleared ? INVALID_ID : m_lastDamageInfo.in.m_sourceID); }
+	virtual void clearLastAttacker() override { m_lastDamageCleared = true; }
 
-	void onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel newLevel, Bool provideFeedback = TRUE );
+	virtual void onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel newLevel, Bool provideFeedback = TRUE ) override;
 
-	virtual void setArmorSetFlag(ArmorSetType ast) { m_curArmorSetFlags.set(ast, 1); }
-	virtual void clearArmorSetFlag(ArmorSetType ast) { m_curArmorSetFlags.set(ast, 0); }
+	virtual void setArmorSetFlag(ArmorSetType ast) override { m_curArmorSetFlags.set(ast, 1); }
+	virtual void clearArmorSetFlag(ArmorSetType ast) override { m_curArmorSetFlags.set(ast, 0); }
 
-	virtual void setInitialHealth(Int initialPercent); ///< Sets the initial load health %.
-	virtual void setMaxHealth( Real maxHealth, MaxHealthChangeType healthChangeType = SAME_CURRENTHEALTH ); ///< Sets the initial max health
+	virtual void setInitialHealth(Int initialPercent) override; ///< Sets the initial load health %.
+	virtual void setMaxHealth( Real maxHealth, MaxHealthChangeType healthChangeType = SAME_CURRENTHEALTH ) override; ///< Sets the initial max health
 
-	virtual Bool getFrontCrushed() const { return m_frontCrushed; }
-	virtual Bool getBackCrushed() const { return m_backCrushed; }
+	virtual Bool getFrontCrushed() const override { return m_frontCrushed; }
+	virtual Bool getBackCrushed() const override { return m_backCrushed; }
 
-	virtual void setFrontCrushed(Bool v) { m_frontCrushed = v; }
-	virtual void setBackCrushed(Bool v) { m_backCrushed = v; }
+	virtual void setFrontCrushed(Bool v) override { m_frontCrushed = v; }
+	virtual void setBackCrushed(Bool v) override { m_backCrushed = v; }
 
-	virtual Real getMaxHealth() const;  ///< return max health
-	virtual Real getInitialHealth() const;  // return initial health
+	virtual Real getMaxHealth() const override;  ///< return max health
+	virtual Real getInitialHealth() const override;  // return initial health
 
-	virtual void setIndestructible( Bool indestructible );
-	virtual Bool isIndestructible() const { return m_indestructible; }
+	virtual void setIndestructible( Bool indestructible ) override;
+	virtual Bool isIndestructible() const override { return m_indestructible; }
 
-	virtual void internalChangeHealth( Real delta );								///< change health
+	virtual void internalChangeHealth( Real delta ) override;								///< change health
 
-	virtual void evaluateVisualCondition();
-	virtual void updateBodyParticleSystems();// made public for topple anf building collapse updates -ML
+	virtual void evaluateVisualCondition() override;
+	virtual void updateBodyParticleSystems() override;// made public for topple anf building collapse updates -ML
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/ActiveShroudUpgrade.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/ActiveShroudUpgrade.h
@@ -68,7 +68,7 @@ public:
 
 protected:
 
-	virtual void upgradeImplementation(); ///< Here's the actual work of Upgrading
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation() override; ///< Here's the actual work of Upgrading
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/ArmorUpgrade.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/ArmorUpgrade.h
@@ -75,8 +75,8 @@ public:
 	// virtual destructor prototype defined by MemoryPoolObject
 
 protected:
-	virtual void upgradeImplementation( ); ///< Here's the actual work of Upgrading
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation( ) override; ///< Here's the actual work of Upgrading
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 };
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/AssaultTransportAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/AssaultTransportAIUpdate.h
@@ -90,12 +90,12 @@ public:
 	AssaultTransportAIUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
- 	virtual void aiDoCommand(const AICommandParms* parms);
-	virtual Bool isIdle() const;
-	virtual UpdateSleepTime update();
-	virtual AssaultTransportAIInterface* getAssaultTransportAIInterface() { return this; }
-	virtual const AssaultTransportAIInterface* getAssaultTransportAIInterface() const { return this; }
-	virtual void beginAssault( const Object *designatedTarget ) const;
+ 	virtual void aiDoCommand(const AICommandParms* parms) override;
+	virtual Bool isIdle() const override;
+	virtual UpdateSleepTime update() override;
+	virtual AssaultTransportAIInterface* getAssaultTransportAIInterface() override { return this; }
+	virtual const AssaultTransportAIInterface* getAssaultTransportAIInterface() const override { return this; }
+	virtual void beginAssault( const Object *designatedTarget ) const override;
 
 	UpdateSleepTime calcSleepTime();
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/AssistedTargetingUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/AssistedTargetingUpdate.h
@@ -65,7 +65,7 @@ public:
 	AssistedTargetingUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	Bool isFreeToAssist() const;
 	void assistAttack( const Object *requestingObject, Object *victimObject );

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/AutoDepositUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/AutoDepositUpdate.h
@@ -110,7 +110,7 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	void awardInitialCaptureBonus( Player *player );	// Test and award the initial capture bonus
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/AutoFindHealingUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/AutoFindHealingUpdate.h
@@ -69,8 +69,8 @@ public:
 	AutoFindHealingUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onObjectCreated();
-	virtual UpdateSleepTime update();
+	virtual void onObjectCreated() override;
+	virtual UpdateSleepTime update() override;
 
 	Object* scanClosestTarget();
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/AutoHealBehavior.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/AutoHealBehavior.h
@@ -117,46 +117,46 @@ public:
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | MODULEINTERFACE_UPGRADE | MODULEINTERFACE_DAMAGE; }
 
 	// BehaviorModule
-	virtual UpgradeModuleInterface* getUpgrade() { return this; }
-	virtual DamageModuleInterface* getDamage() { return this; }
+	virtual UpgradeModuleInterface* getUpgrade() override { return this; }
+	virtual DamageModuleInterface* getDamage() override { return this; }
 
 	// DamageModuleInterface
-	virtual void onDamage( DamageInfo *damageInfo );
-	virtual void onHealing( DamageInfo *damageInfo ) { }
-	virtual void onBodyDamageStateChange(const DamageInfo* damageInfo, BodyDamageType oldState, BodyDamageType newState) { }
+	virtual void onDamage( DamageInfo *damageInfo ) override;
+	virtual void onHealing( DamageInfo *damageInfo ) override { }
+	virtual void onBodyDamageStateChange(const DamageInfo* damageInfo, BodyDamageType oldState, BodyDamageType newState) override { }
 
 	// UpdateModuleInterface
-	virtual UpdateSleepTime update();
-	virtual DisabledMaskType getDisabledTypesToProcess() const { return MAKE_DISABLED_MASK( DISABLED_HELD ); }
+	virtual UpdateSleepTime update() override;
+	virtual DisabledMaskType getDisabledTypesToProcess() const override { return MAKE_DISABLED_MASK( DISABLED_HELD ); }
 
 	void stopHealing();
 	void undoUpgrade(); ///<pretend like we have not been activated yet, so we can be reactivated later
 
 protected:
 
-	virtual void upgradeImplementation()
+	virtual void upgradeImplementation() override
 	{
 		setWakeFrame(getObject(), UPDATE_SLEEP_NONE);
 	}
 
-	virtual void getUpgradeActivationMasks(UpgradeMaskType& activation, UpgradeMaskType& conflicting) const
+	virtual void getUpgradeActivationMasks(UpgradeMaskType& activation, UpgradeMaskType& conflicting) const override
 	{
 		getAutoHealBehaviorModuleData()->m_upgradeMuxData.getUpgradeActivationMasks(activation, conflicting);
 	}
 
-	virtual void performUpgradeFX()
+	virtual void performUpgradeFX() override
 	{
 		getAutoHealBehaviorModuleData()->m_upgradeMuxData.performUpgradeFX(getObject());
 	}
 
-	virtual Bool requiresAllActivationUpgrades() const
+	virtual Bool requiresAllActivationUpgrades() const override
 	{
 		return getAutoHealBehaviorModuleData()->m_upgradeMuxData.m_requiresAllTriggers;
 	}
 
 	Bool isUpgradeActive() const { return isAlreadyUpgraded(); }
 
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 
 private:

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/BaikonurLaunchPower.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/BaikonurLaunchPower.h
@@ -76,8 +76,8 @@ public:
 
 	BaikonurLaunchPower( Thing *thing, const ModuleData *moduleData );
 
-	virtual void doSpecialPower( UnsignedInt commandOptions );
-	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions );
+	virtual void doSpecialPower( UnsignedInt commandOptions ) override;
+	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions ) override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/BaseRegenerateUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/BaseRegenerateUpdate.h
@@ -64,16 +64,16 @@ public:
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | MODULEINTERFACE_DAMAGE; }
 
 	// BehaviorModule
-	virtual DamageModuleInterface* getDamage() { return this; }
+	virtual DamageModuleInterface* getDamage() override { return this; }
 
 	// UpdateModuleInterface
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	// DamageModuleInterface
-	virtual void onDamage( DamageInfo *damageInfo );
-	virtual void onHealing( DamageInfo *damageInfo ) { }
-	virtual void onBodyDamageStateChange(const DamageInfo* damageInfo, BodyDamageType oldState, BodyDamageType newState) { }
-	virtual DisabledMaskType getDisabledTypesToProcess() const { return MAKE_DISABLED_MASK( DISABLED_UNDERPOWERED ); }
+	virtual void onDamage( DamageInfo *damageInfo ) override;
+	virtual void onHealing( DamageInfo *damageInfo ) override { }
+	virtual void onBodyDamageStateChange(const DamageInfo* damageInfo, BodyDamageType oldState, BodyDamageType newState) override { }
+	virtual DisabledMaskType getDisabledTypesToProcess() const override { return MAKE_DISABLED_MASK( DISABLED_UNDERPOWERED ); }
 
 private:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/BattlePlanUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/BattlePlanUpdate.h
@@ -146,24 +146,24 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	// SpecialPowerUpdateInterface
-	virtual Bool initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions );
-	virtual Bool isSpecialAbility() const { return false; }
-	virtual Bool isSpecialPower() const { return true; }
-	virtual Bool isActive() const {return m_status != TRANSITIONSTATUS_IDLE;}
-	virtual SpecialPowerUpdateInterface* getSpecialPowerUpdateInterface() { return this; }
-	virtual Bool doesSpecialPowerHaveOverridableDestinationActive() const { return false; } //Is it active now?
-	virtual Bool doesSpecialPowerHaveOverridableDestination() const { return false; }	//Does it have it, even if it's not active?
-	virtual void setSpecialPowerOverridableDestination( const Coord3D *loc ) {}
-	virtual Bool isPowerCurrentlyInUse( const CommandButton *command = nullptr ) const;
+	virtual Bool initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions ) override;
+	virtual Bool isSpecialAbility() const override { return false; }
+	virtual Bool isSpecialPower() const override { return true; }
+	virtual Bool isActive() const override {return m_status != TRANSITIONSTATUS_IDLE;}
+	virtual SpecialPowerUpdateInterface* getSpecialPowerUpdateInterface() override { return this; }
+	virtual Bool doesSpecialPowerHaveOverridableDestinationActive() const override { return false; } //Is it active now?
+	virtual Bool doesSpecialPowerHaveOverridableDestination() const override { return false; }	//Does it have it, even if it's not active?
+	virtual void setSpecialPowerOverridableDestination( const Coord3D *loc ) override {}
+	virtual Bool isPowerCurrentlyInUse( const CommandButton *command = nullptr ) const override;
 
 	//Returns the currently active battle plan -- unpacked and ready... returns PLANSTATUS_NONE if in transition!
 	BattlePlanStatus getActiveBattlePlan() const;
 
-	virtual void onObjectCreated();
-	virtual void onDelete();
-	virtual UpdateSleepTime update();
+	virtual void onObjectCreated() override;
+	virtual void onDelete() override;
+	virtual UpdateSleepTime update() override;
 
-	virtual CommandOption getCommandOption() const;
+	virtual CommandOption getCommandOption() const override;
 protected:
 
 	void setStatus( TransitionStatus status );

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/BehaviorModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/BehaviorModule.h
@@ -151,49 +151,49 @@ public:
 	static Int getInterfaceMask() { return 0; }
 	static ModuleType getModuleType() { return MODULETYPE_BEHAVIOR; }
 
-	virtual BodyModuleInterface* getBody() { return nullptr; }
-	virtual CollideModuleInterface* getCollide() { return nullptr; }
-	virtual ContainModuleInterface* getContain() { return nullptr; }
-	virtual CreateModuleInterface* getCreate() { return nullptr; }
-	virtual DamageModuleInterface* getDamage() { return nullptr; }
-	virtual DestroyModuleInterface* getDestroy() { return nullptr; }
-	virtual DieModuleInterface* getDie() { return nullptr; }
-	virtual SpecialPowerModuleInterface* getSpecialPower() { return nullptr; }
-	virtual UpdateModuleInterface* getUpdate() { return nullptr; }
-	virtual UpgradeModuleInterface* getUpgrade() { return nullptr; }
+	virtual BodyModuleInterface* getBody() override { return nullptr; }
+	virtual CollideModuleInterface* getCollide() override { return nullptr; }
+	virtual ContainModuleInterface* getContain() override { return nullptr; }
+	virtual CreateModuleInterface* getCreate() override { return nullptr; }
+	virtual DamageModuleInterface* getDamage() override { return nullptr; }
+	virtual DestroyModuleInterface* getDestroy() override { return nullptr; }
+	virtual DieModuleInterface* getDie() override { return nullptr; }
+	virtual SpecialPowerModuleInterface* getSpecialPower() override { return nullptr; }
+	virtual UpdateModuleInterface* getUpdate() override { return nullptr; }
+	virtual UpgradeModuleInterface* getUpgrade() override { return nullptr; }
 	virtual StealthUpdate* getStealth() { return nullptr; }
 
-	virtual ParkingPlaceBehaviorInterface* getParkingPlaceBehaviorInterface() { return nullptr; }
-	virtual RebuildHoleBehaviorInterface* getRebuildHoleBehaviorInterface() { return nullptr; }
-	virtual BridgeBehaviorInterface* getBridgeBehaviorInterface() { return nullptr; }
-	virtual BridgeTowerBehaviorInterface* getBridgeTowerBehaviorInterface() { return nullptr; }
-	virtual BridgeScaffoldBehaviorInterface* getBridgeScaffoldBehaviorInterface() { return nullptr; }
-	virtual OverchargeBehaviorInterface* getOverchargeBehaviorInterface() { return nullptr; }
-	virtual TransportPassengerInterface* getTransportPassengerInterface() { return nullptr; }
-	virtual CaveInterface* getCaveInterface() { return nullptr; }
-	virtual LandMineInterface* getLandMineInterface() { return nullptr; }
-	virtual DieModuleInterface* getEjectPilotDieInterface() { return nullptr; }
+	virtual ParkingPlaceBehaviorInterface* getParkingPlaceBehaviorInterface() override { return nullptr; }
+	virtual RebuildHoleBehaviorInterface* getRebuildHoleBehaviorInterface() override { return nullptr; }
+	virtual BridgeBehaviorInterface* getBridgeBehaviorInterface() override { return nullptr; }
+	virtual BridgeTowerBehaviorInterface* getBridgeTowerBehaviorInterface() override { return nullptr; }
+	virtual BridgeScaffoldBehaviorInterface* getBridgeScaffoldBehaviorInterface() override { return nullptr; }
+	virtual OverchargeBehaviorInterface* getOverchargeBehaviorInterface() override { return nullptr; }
+	virtual TransportPassengerInterface* getTransportPassengerInterface() override { return nullptr; }
+	virtual CaveInterface* getCaveInterface() override { return nullptr; }
+	virtual LandMineInterface* getLandMineInterface() override { return nullptr; }
+	virtual DieModuleInterface* getEjectPilotDieInterface() override { return nullptr; }
 	// interface acquisition (moved from UpdateModule)
-	virtual ProjectileUpdateInterface* getProjectileUpdateInterface() { return nullptr; }
-	virtual AIUpdateInterface* getAIUpdateInterface() { return nullptr; }
-	virtual ExitInterface* getUpdateExitInterface() { return nullptr; }
-	virtual DelayedUpgradeUpdateInterface* getDelayedUpgradeUpdateInterface() { return nullptr; }
-	virtual DockUpdateInterface* getDockUpdateInterface() { return nullptr; }
-	virtual RailedTransportDockUpdateInterface *getRailedTransportDockUpdateInterface() { return nullptr; }
-	virtual SlowDeathBehaviorInterface* getSlowDeathBehaviorInterface() { return nullptr; }
-	virtual SpecialPowerUpdateInterface* getSpecialPowerUpdateInterface() { return nullptr; }
-	virtual SlavedUpdateInterface* getSlavedUpdateInterface() { return nullptr; }
-	virtual ProductionUpdateInterface* getProductionUpdateInterface() { return nullptr; }
-	virtual HordeUpdateInterface* getHordeUpdateInterface() { return nullptr; }
-	virtual PowerPlantUpdateInterface* getPowerPlantUpdateInterface() { return nullptr; }
-	virtual SpawnBehaviorInterface* getSpawnBehaviorInterface() { return nullptr; }
+	virtual ProjectileUpdateInterface* getProjectileUpdateInterface() override { return nullptr; }
+	virtual AIUpdateInterface* getAIUpdateInterface() override { return nullptr; }
+	virtual ExitInterface* getUpdateExitInterface() override { return nullptr; }
+	virtual DelayedUpgradeUpdateInterface* getDelayedUpgradeUpdateInterface() override { return nullptr; }
+	virtual DockUpdateInterface* getDockUpdateInterface() override { return nullptr; }
+	virtual RailedTransportDockUpdateInterface *getRailedTransportDockUpdateInterface() override { return nullptr; }
+	virtual SlowDeathBehaviorInterface* getSlowDeathBehaviorInterface() override { return nullptr; }
+	virtual SpecialPowerUpdateInterface* getSpecialPowerUpdateInterface() override { return nullptr; }
+	virtual SlavedUpdateInterface* getSlavedUpdateInterface() override { return nullptr; }
+	virtual ProductionUpdateInterface* getProductionUpdateInterface() override { return nullptr; }
+	virtual HordeUpdateInterface* getHordeUpdateInterface() override { return nullptr; }
+	virtual PowerPlantUpdateInterface* getPowerPlantUpdateInterface() override { return nullptr; }
+	virtual SpawnBehaviorInterface* getSpawnBehaviorInterface() override { return nullptr; }
 
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 };
 inline BehaviorModule::BehaviorModule( Thing *thing, const ModuleData* moduleData ) : ObjectModule( thing, moduleData ) { }

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/BodyModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/BodyModule.h
@@ -205,7 +205,7 @@ public:
 	static Int getInterfaceMask() { return MODULEINTERFACE_BODY; }
 
 	// BehaviorModule
-	virtual BodyModuleInterface* getBody() { return this; }
+	virtual BodyModuleInterface* getBody() override { return this; }
 
 	/**
 		Try to damage this Object. The module's Armor
@@ -213,13 +213,13 @@ public:
 		considerably from what you requested. Also note that (if damage is done)
 		the DamageFX will be invoked to provide a/v fx as appropriate.
 	*/
-	virtual void attemptDamage( DamageInfo *damageInfo ) = 0;
+	virtual void attemptDamage( DamageInfo *damageInfo ) override = 0;
 
 	/**
 		Instead of having negative damage count as healing, or allowing access to the private
 		changeHealth Method, we will use this parallel to attemptDamage to do healing without hack.
 	*/
-	virtual void attemptHealing( DamageInfo *healingInfo ) = 0;
+	virtual void attemptHealing( DamageInfo *healingInfo ) override = 0;
 
 	/**
 		Estimate the (unclipped) damage that would be done to this object
@@ -227,44 +227,44 @@ public:
 		but DO NOT alter the body in any way. (This is used by the AI system
 		to choose weapons.)
 	*/
-	virtual Real estimateDamage( DamageInfoInput& damageInfo ) const = 0;
+	virtual Real estimateDamage( DamageInfoInput& damageInfo ) const override = 0;
 
-	virtual Real getHealth() const = 0;													///< get current health
+	virtual Real getHealth() const override = 0;													///< get current health
 
-	virtual Real getMaxHealth() const {return 0.0f;}  ///< return max health
+	virtual Real getMaxHealth() const override {return 0.0f;}  ///< return max health
 
-	virtual Real getInitialHealth() const {return 0.0f;}  // return initial health
+	virtual Real getInitialHealth() const override {return 0.0f;}  // return initial health
 
-	virtual BodyDamageType getDamageState() const = 0;
-	virtual void setDamageState( BodyDamageType newState ) = 0;	///< control damage state directly.  Will adjust hitpoints.
-	virtual void setAflame( Bool setting ) = 0;///< This is a major change like a damage state.
+	virtual BodyDamageType getDamageState() const override = 0;
+	virtual void setDamageState( BodyDamageType newState ) override = 0;	///< control damage state directly.  Will adjust hitpoints.
+	virtual void setAflame( Bool setting ) override = 0;///< This is a major change like a damage state.
 
-	virtual void onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel newLevel, Bool provideFeedback = FALSE ) = 0;	///< I just achieved this level right this moment
+	virtual void onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel newLevel, Bool provideFeedback = FALSE ) override = 0;	///< I just achieved this level right this moment
 
-	virtual void setArmorSetFlag(ArmorSetType ast) = 0;
-	virtual void clearArmorSetFlag(ArmorSetType ast) = 0;
+	virtual void setArmorSetFlag(ArmorSetType ast) override = 0;
+	virtual void clearArmorSetFlag(ArmorSetType ast) override = 0;
 
-	virtual const DamageInfo *getLastDamageInfo() const { return nullptr; }	///< return info on last damage dealt to this object
-	virtual UnsignedInt getLastDamageTimestamp() const { return 0; }	///< return frame of last damage dealt
-	virtual UnsignedInt getLastHealingTimestamp() const { return 0; }	///< return frame of last healing dealt
-	virtual ObjectID getClearableLastAttacker() const { return INVALID_ID; }
-	virtual void clearLastAttacker() { }
-	virtual Bool getFrontCrushed() const { return false; }
-	virtual Bool getBackCrushed() const { return false; }
+	virtual const DamageInfo *getLastDamageInfo() const override { return nullptr; }	///< return info on last damage dealt to this object
+	virtual UnsignedInt getLastDamageTimestamp() const override { return 0; }	///< return frame of last damage dealt
+	virtual UnsignedInt getLastHealingTimestamp() const override { return 0; }	///< return frame of last healing dealt
+	virtual ObjectID getClearableLastAttacker() const override { return INVALID_ID; }
+	virtual void clearLastAttacker() override { }
+	virtual Bool getFrontCrushed() const override { return false; }
+	virtual Bool getBackCrushed() const override { return false; }
 
-	virtual void setInitialHealth(Int initialPercent)  {  } ///< Sets the initial load health %.
-	virtual void setMaxHealth(Real maxHealth, MaxHealthChangeType healthChangeType = SAME_CURRENTHEALTH )  {  } ///< Sets the max health.
+	virtual void setInitialHealth(Int initialPercent) override  {  } ///< Sets the initial load health %.
+	virtual void setMaxHealth(Real maxHealth, MaxHealthChangeType healthChangeType = SAME_CURRENTHEALTH ) override  {  } ///< Sets the max health.
 
-	virtual void setFrontCrushed(Bool v) { DEBUG_CRASH(("you should never call this for generic Bodys")); }
-	virtual void setBackCrushed(Bool v) { DEBUG_CRASH(("you should never call this for generic Bodys")); }
+	virtual void setFrontCrushed(Bool v) override { DEBUG_CRASH(("you should never call this for generic Bodys")); }
+	virtual void setBackCrushed(Bool v) override { DEBUG_CRASH(("you should never call this for generic Bodys")); }
 
 
-	virtual void setIndestructible( Bool indestructible ) { }
-	virtual Bool isIndestructible() const { return TRUE; }
+	virtual void setIndestructible( Bool indestructible ) override { }
+	virtual Bool isIndestructible() const override { return TRUE; }
 
 	//Allows outside systems to apply defensive bonuses or penalties (they all stack as a multiplier!)
-	virtual void applyDamageScalar( Real scalar ) { m_damageScalar *= scalar; }
-	virtual Real getDamageScalar() const { return m_damageScalar; }
+	virtual void applyDamageScalar( Real scalar ) override { m_damageScalar *= scalar; }
+	virtual Real getDamageScalar() const override { return m_damageScalar; }
 
 	/**
 		Change the module's health by the given delta. Note that
@@ -273,17 +273,17 @@ public:
 		call this directly (especially when when decreasing health, since
 		you probably want "attemptDamage" or "attemptHealing")
 	*/
-	virtual void internalChangeHealth( Real delta ) = 0;
+	virtual void internalChangeHealth( Real delta ) override = 0;
 
-	virtual void evaluateVisualCondition() { }
-	virtual void updateBodyParticleSystems() { };// made public for topple anf building collapse updates -ML
+	virtual void evaluateVisualCondition() override { }
+	virtual void updateBodyParticleSystems() override { };// made public for topple anf building collapse updates -ML
 
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	Real	m_damageScalar;
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/BodyModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/BodyModule.h
@@ -213,13 +213,13 @@ public:
 		considerably from what you requested. Also note that (if damage is done)
 		the DamageFX will be invoked to provide a/v fx as appropriate.
 	*/
-	virtual void attemptDamage( DamageInfo *damageInfo ) override = 0;
+	virtual void attemptDamage( DamageInfo *damageInfo ) = 0;
 
 	/**
 		Instead of having negative damage count as healing, or allowing access to the private
 		changeHealth Method, we will use this parallel to attemptDamage to do healing without hack.
 	*/
-	virtual void attemptHealing( DamageInfo *healingInfo ) override = 0;
+	virtual void attemptHealing( DamageInfo *healingInfo ) = 0;
 
 	/**
 		Estimate the (unclipped) damage that would be done to this object
@@ -227,22 +227,22 @@ public:
 		but DO NOT alter the body in any way. (This is used by the AI system
 		to choose weapons.)
 	*/
-	virtual Real estimateDamage( DamageInfoInput& damageInfo ) const override = 0;
+	virtual Real estimateDamage( DamageInfoInput& damageInfo ) const = 0;
 
-	virtual Real getHealth() const override = 0;													///< get current health
+	virtual Real getHealth() const = 0;													///< get current health
 
 	virtual Real getMaxHealth() const override {return 0.0f;}  ///< return max health
 
 	virtual Real getInitialHealth() const override {return 0.0f;}  // return initial health
 
-	virtual BodyDamageType getDamageState() const override = 0;
-	virtual void setDamageState( BodyDamageType newState ) override = 0;	///< control damage state directly.  Will adjust hitpoints.
-	virtual void setAflame( Bool setting ) override = 0;///< This is a major change like a damage state.
+	virtual BodyDamageType getDamageState() const = 0;
+	virtual void setDamageState( BodyDamageType newState ) = 0;	///< control damage state directly.  Will adjust hitpoints.
+	virtual void setAflame( Bool setting ) = 0;///< This is a major change like a damage state.
 
-	virtual void onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel newLevel, Bool provideFeedback = FALSE ) override = 0;	///< I just achieved this level right this moment
+	virtual void onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel newLevel, Bool provideFeedback = FALSE ) = 0;	///< I just achieved this level right this moment
 
-	virtual void setArmorSetFlag(ArmorSetType ast) override = 0;
-	virtual void clearArmorSetFlag(ArmorSetType ast) override = 0;
+	virtual void setArmorSetFlag(ArmorSetType ast) = 0;
+	virtual void clearArmorSetFlag(ArmorSetType ast) = 0;
 
 	virtual const DamageInfo *getLastDamageInfo() const override { return nullptr; }	///< return info on last damage dealt to this object
 	virtual UnsignedInt getLastDamageTimestamp() const override { return 0; }	///< return frame of last damage dealt
@@ -273,7 +273,7 @@ public:
 		call this directly (especially when when decreasing health, since
 		you probably want "attemptDamage" or "attemptHealing")
 	*/
-	virtual void internalChangeHealth( Real delta ) override = 0;
+	virtual void internalChangeHealth( Real delta ) = 0;
 
 	virtual void evaluateVisualCondition() override { }
 	virtual void updateBodyParticleSystems() override { };// made public for topple anf building collapse updates -ML

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/BoneFXDamage.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/BoneFXDamage.h
@@ -52,14 +52,14 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	// damage module methods
-	virtual void onDamage( DamageInfo *damageInfo ) { }
-	virtual void onHealing( DamageInfo *damageInfo ) { }
+	virtual void onDamage( DamageInfo *damageInfo ) override { }
+	virtual void onHealing( DamageInfo *damageInfo ) override { }
 	virtual void onBodyDamageStateChange( const DamageInfo* damageInfo,
 																				BodyDamageType oldState,
-																				BodyDamageType newState );
+																				BodyDamageType newState ) override;
 
 protected:
 
-	virtual void onObjectCreated();
+	virtual void onObjectCreated() override;
 
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/BoneFXUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/BoneFXUpdate.h
@@ -241,11 +241,11 @@ public:
 	void changeBodyDamageState( BodyDamageType oldState, BodyDamageType newState);
 	void stopAllBoneFX();
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 protected:
 
-	virtual void onObjectCreated();
+	virtual void onObjectCreated() override;
 
 	virtual void resolveBoneLocations();
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/BridgeBehavior.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/BridgeBehavior.h
@@ -95,7 +95,7 @@ class BridgeBehaviorModuleData : public BehaviorModuleData
 public:
 
 	BridgeBehaviorModuleData();
-	~BridgeBehaviorModuleData();
+	~BridgeBehaviorModuleData() override;
 
 	static void buildFieldParse( MultiIniFieldParse &p );
 
@@ -129,33 +129,33 @@ public:
 	static Int getInterfaceMask() { return (MODULEINTERFACE_DAMAGE) |
 																							 (MODULEINTERFACE_DIE) |
 																							 (MODULEINTERFACE_UPDATE); }
-	virtual BridgeBehaviorInterface* getBridgeBehaviorInterface() { return this; }
-	virtual void onDelete();
+	virtual BridgeBehaviorInterface* getBridgeBehaviorInterface() override { return this; }
+	virtual void onDelete() override;
 
 	// Damage methods
-	virtual DamageModuleInterface* getDamage() { return this; }
-	virtual void onDamage( DamageInfo *damageInfo );
-	virtual void onHealing( DamageInfo *damageInfo );
+	virtual DamageModuleInterface* getDamage() override { return this; }
+	virtual void onDamage( DamageInfo *damageInfo ) override;
+	virtual void onHealing( DamageInfo *damageInfo ) override;
 	virtual void onBodyDamageStateChange( const DamageInfo* damageInfo,
 																				BodyDamageType oldState,
-																				BodyDamageType newState );
+																				BodyDamageType newState ) override;
 
 	// Die methods
-	virtual DieModuleInterface* getDie() { return this; }
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual DieModuleInterface* getDie() override { return this; }
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 	// Update methods
-	virtual UpdateModuleInterface *getUpdate() { return this; }
-	virtual UpdateSleepTime update();
+	virtual UpdateModuleInterface *getUpdate() override { return this; }
+	virtual UpdateSleepTime update() override;
 
 	// our own methods
 	static BridgeBehaviorInterface *getBridgeBehaviorInterfaceFromObject( Object *obj );
-	virtual void setTower( BridgeTowerType towerType, Object *tower );	///< connect tower to us
-	virtual ObjectID getTowerID( BridgeTowerType towerType );						///< retrive one of our towers
-	virtual void createScaffolding();		///< create scaffolding around bridge
-	virtual void removeScaffolding();		///< remove scaffolding around bridge
-	virtual Bool isScaffoldInMotion();	///< is scaffold in motion
-	virtual Bool isScaffoldPresent() { return m_scaffoldPresent; }
+	virtual void setTower( BridgeTowerType towerType, Object *tower ) override;	///< connect tower to us
+	virtual ObjectID getTowerID( BridgeTowerType towerType ) override;						///< retrive one of our towers
+	virtual void createScaffolding() override;		///< create scaffolding around bridge
+	virtual void removeScaffolding() override;		///< remove scaffolding around bridge
+	virtual Bool isScaffoldInMotion() override;	///< is scaffold in motion
+	virtual Bool isScaffoldPresent() override { return m_scaffoldPresent; }
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/BridgeBehavior.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/BridgeBehavior.h
@@ -95,7 +95,7 @@ class BridgeBehaviorModuleData : public BehaviorModuleData
 public:
 
 	BridgeBehaviorModuleData();
-	~BridgeBehaviorModuleData() override;
+	virtual ~BridgeBehaviorModuleData() override;
 
 	static void buildFieldParse( MultiIniFieldParse &p );
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/BridgeScaffoldBehavior.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/BridgeScaffoldBehavior.h
@@ -77,20 +77,20 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	// behavior module methods
-	virtual BridgeScaffoldBehaviorInterface* getBridgeScaffoldBehaviorInterface() { return this; }
+	virtual BridgeScaffoldBehaviorInterface* getBridgeScaffoldBehaviorInterface() override { return this; }
 
 	// update methods
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	// bridge scaffold interface methods
 	virtual void setPositions( const Coord3D *createPos,
 														 const Coord3D *riseToPos,
-														 const Coord3D *buildPos );
-	virtual void setMotion( ScaffoldTargetMotion targetMotion );
-	virtual ScaffoldTargetMotion getCurrentMotion() { return m_targetMotion; }
-	virtual void reverseMotion();
-	virtual void setLateralSpeed( Real lateralSpeed ) { m_lateralSpeed = lateralSpeed; }
-	virtual void setVerticalSpeed( Real verticalSpeed ) { m_verticalSpeed = verticalSpeed; }
+														 const Coord3D *buildPos ) override;
+	virtual void setMotion( ScaffoldTargetMotion targetMotion ) override;
+	virtual ScaffoldTargetMotion getCurrentMotion() override { return m_targetMotion; }
+	virtual void reverseMotion() override;
+	virtual void setLateralSpeed( Real lateralSpeed ) override { m_lateralSpeed = lateralSpeed; }
+	virtual void setVerticalSpeed( Real verticalSpeed ) override { m_verticalSpeed = verticalSpeed; }
 
 	// public interface acquisition
 	static BridgeScaffoldBehaviorInterface *getBridgeScaffoldBehaviorInterfaceFromObject( Object *obj );

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/BridgeTowerBehavior.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/BridgeTowerBehavior.h
@@ -66,7 +66,7 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	static Int getInterfaceMask() { return (MODULEINTERFACE_DAMAGE) | (MODULEINTERFACE_DIE); }
-	BridgeTowerBehaviorInterface* getBridgeTowerBehaviorInterface() override { return this; }
+	virtual BridgeTowerBehaviorInterface* getBridgeTowerBehaviorInterface() override { return this; }
 
 	virtual void setBridge( Object *bridge ) override;
 	virtual ObjectID getBridgeID() override;

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/BridgeTowerBehavior.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/BridgeTowerBehavior.h
@@ -66,25 +66,25 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	static Int getInterfaceMask() { return (MODULEINTERFACE_DAMAGE) | (MODULEINTERFACE_DIE); }
-	BridgeTowerBehaviorInterface* getBridgeTowerBehaviorInterface() { return this; }
+	BridgeTowerBehaviorInterface* getBridgeTowerBehaviorInterface() override { return this; }
 
-	virtual void setBridge( Object *bridge );
-	virtual ObjectID getBridgeID();
-	virtual void setTowerType( BridgeTowerType type );
+	virtual void setBridge( Object *bridge ) override;
+	virtual ObjectID getBridgeID() override;
+	virtual void setTowerType( BridgeTowerType type ) override;
 
 	static BridgeTowerBehaviorInterface *getBridgeTowerBehaviorInterfaceFromObject( Object *obj );
 
 	// Damage methods
-	virtual DamageModuleInterface* getDamage() { return this; }
-	virtual void onDamage( DamageInfo *damageInfo );
-	virtual void onHealing( DamageInfo *damageInfo );
+	virtual DamageModuleInterface* getDamage() override { return this; }
+	virtual void onDamage( DamageInfo *damageInfo ) override;
+	virtual void onHealing( DamageInfo *damageInfo ) override;
 	virtual void onBodyDamageStateChange( const DamageInfo* damageInfo,
 																				BodyDamageType oldState,
-																				BodyDamageType newState );
+																				BodyDamageType newState ) override;
 
 	// Die methods
-	virtual DieModuleInterface* getDie() { return this; }
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual DieModuleInterface* getDie() override { return this; }
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/CashBountyPower.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/CashBountyPower.h
@@ -113,11 +113,11 @@ public:
 	CashBountyPower( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype defined by MemoryPoolObject
 
-	virtual void onObjectCreated();
+	virtual void onObjectCreated() override;
 
 	//virtual void onBuildComplete();	///< This is called when you are a finished game object
-	virtual void onSpecialPowerCreation();	///< This is called when you are a finished game object
-	virtual void doSpecialPower( UnsignedInt commandOptions ) { return; }
+	virtual void onSpecialPowerCreation() override;	///< This is called when you are a finished game object
+	virtual void doSpecialPower( UnsignedInt commandOptions ) override { return; }
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/CashHackSpecialPower.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/CashHackSpecialPower.h
@@ -74,8 +74,8 @@ public:
 	CashHackSpecialPower( Thing *thing, const ModuleData *moduleData );
 	// virtual destructor provided by memory pool object
 
-	virtual void doSpecialPowerAtObject( Object *obj, UnsignedInt commandOptions );
-	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions );
+	virtual void doSpecialPowerAtObject( Object *obj, UnsignedInt commandOptions ) override;
+	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions ) override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/CaveContain.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/CaveContain.h
@@ -74,44 +74,44 @@ public:
 	CaveContain( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual CreateModuleInterface* getCreate() { return this; }
-	virtual CaveInterface* getCaveInterface() { return this; }
+	virtual CreateModuleInterface* getCreate() override { return this; }
+	virtual CaveInterface* getCaveInterface() override { return this; }
 	static Int getInterfaceMask() { return OpenContain::getInterfaceMask() | (MODULEINTERFACE_CREATE); }
 
-	virtual OpenContain *asOpenContain() { return this; }  ///< treat as open container
-	virtual Bool isGarrisonable() const { return false; }	///< can this unit be Garrisoned? (ick)
-	virtual Bool isHealContain() const { return false; } ///< true when container only contains units while healing (not a transport!)
+	virtual OpenContain *asOpenContain() override { return this; }  ///< treat as open container
+	virtual Bool isGarrisonable() const override { return false; }	///< can this unit be Garrisoned? (ick)
+	virtual Bool isHealContain() const override { return false; } ///< true when container only contains units while healing (not a transport!)
 
-	virtual void onContaining( Object *obj );		///< object now contains 'obj'
-	virtual void onRemoving( Object *obj );			///< object no longer contains 'obj'
+	virtual void onContaining( Object *obj ) override;		///< object now contains 'obj'
+	virtual void onRemoving( Object *obj ) override;			///< object no longer contains 'obj'
 
-	virtual Bool isValidContainerFor(const Object* obj, Bool checkCapacity) const;
-	virtual void addToContainList( Object *obj );		///< The part of AddToContain that inheritors can override (Can't do whole thing because of all the private stuff involved)
-	virtual void removeFromContain( Object *obj, Bool exposeStealthUnits = FALSE );	///< remove 'obj' from contain list
-	virtual void removeAllContained( Bool exposeStealthUnits = FALSE );				///< remove all objects on contain list
+	virtual Bool isValidContainerFor(const Object* obj, Bool checkCapacity) const override;
+	virtual void addToContainList( Object *obj ) override;		///< The part of AddToContain that inheritors can override (Can't do whole thing because of all the private stuff involved)
+	virtual void removeFromContain( Object *obj, Bool exposeStealthUnits = FALSE ) override;	///< remove 'obj' from contain list
+	virtual void removeAllContained( Bool exposeStealthUnits = FALSE ) override;				///< remove all objects on contain list
 
 	/**
 		return the player that *appears* to control this unit. if null, use getObject()->getControllingPlayer() instead.
 	*/
-	virtual void recalcApparentControllingPlayer();
+	virtual void recalcApparentControllingPlayer() override;
 
 	// contain list access
-	virtual void iterateContained( ContainIterateFunc func, void *userData, Bool reverse );
-	virtual UnsignedInt getContainCount() const;
-	virtual Int getContainMax() const;
-	virtual const ContainedItemsList* getContainedItemsList() const;
-	virtual Bool isKickOutOnCapture(){ return FALSE; }///< Caves and Tunnels don't kick out on capture.
+	virtual void iterateContained( ContainIterateFunc func, void *userData, Bool reverse ) override;
+	virtual UnsignedInt getContainCount() const override;
+	virtual Int getContainMax() const override;
+	virtual const ContainedItemsList* getContainedItemsList() const override;
+	virtual Bool isKickOutOnCapture() override { return FALSE; }///< Caves and Tunnels don't kick out on capture.
 
 	// override the onDie we inherit from OpenContain
-	virtual void onDie( const DamageInfo *damageInfo );  ///< the die callback
+	virtual void onDie( const DamageInfo *damageInfo ) override;  ///< the die callback
 
-	virtual void onCreate();
-	virtual void onBuildComplete();	///< This is called when you are a finished game object
-	virtual Bool shouldDoOnBuildComplete() const { return m_needToRunOnBuildComplete; }
+	virtual void onCreate() override;
+	virtual void onBuildComplete() override;	///< This is called when you are a finished game object
+	virtual Bool shouldDoOnBuildComplete() const override { return m_needToRunOnBuildComplete; }
 
 	// Unique to Cave Contain
-	virtual void tryToSetCaveIndex( Int newIndex );	///< Called by script as an alternative to instancing separate objects.  'Try', because can fail.
-	virtual void setOriginalTeam( Team *oldTeam );	///< This is a distributed Garrison in terms of capturing, so when one node triggers the change, he needs to tell everyone, so anyone can do the un-change.
+	virtual void tryToSetCaveIndex( Int newIndex ) override;	///< Called by script as an alternative to instancing separate objects.  'Try', because can fail.
+	virtual void setOriginalTeam( Team *oldTeam ) override;	///< This is a distributed Garrison in terms of capturing, so when one node triggers the change, he needs to tell everyone, so anyone can do the un-change.
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/CheckpointUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/CheckpointUpdate.h
@@ -74,7 +74,7 @@ public:
 	CheckpointUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 protected:
 	Bool m_enemyNear;

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/ChinookAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/ChinookAIUpdate.h
@@ -83,31 +83,31 @@ public:
 	ChinookAIUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual UpdateSleepTime update();
- 	virtual void aiDoCommand(const AICommandParms* parms);
-	virtual Bool chooseLocomotorSet(LocomotorSetType wst);
+	virtual UpdateSleepTime update() override;
+ 	virtual void aiDoCommand(const AICommandParms* parms) override;
+	virtual Bool chooseLocomotorSet(LocomotorSetType wst) override;
 	// this is present solely for some transports to override, so that they can land before
 	// allowing people to exit...
-	virtual AIFreeToExitType getAiFreeToExit(const Object* exiter) const;
-	virtual Bool isAllowedToAdjustDestination() const;
-	virtual ObjectID getBuildingToNotPathAround() const;
+	virtual AIFreeToExitType getAiFreeToExit(const Object* exiter) const override;
+	virtual Bool isAllowedToAdjustDestination() const override;
+	virtual ObjectID getBuildingToNotPathAround() const override;
 
 	// this is present for subclasses (eg, Chinook) to override, to
 	// prevent supply-ferry behavior in some cases (eg, when toting passengers)
-	virtual Bool isAvailableForSupplying() const;
-	virtual Bool isCurrentlyFerryingSupplies() const;
+	virtual Bool isAvailableForSupplying() const override;
+	virtual Bool isCurrentlyFerryingSupplies() const override;
 
-	virtual Bool isIdle() const;
+	virtual Bool isIdle() const override;
 
 	const ChinookAIUpdateModuleData* friend_getData() const { return getChinookAIUpdateModuleData(); }
 	void friend_setFlightStatus(ChinookFlightStatus a) { m_flightStatus = a; }
 
 protected:
 
-	virtual AIStateMachine* makeStateMachine();
+	virtual AIStateMachine* makeStateMachine() override;
 
-	virtual void privateCombatDrop( Object *target, const Coord3D& pos, CommandSourceType cmdSource );
-	virtual void privateGetRepaired( Object *repairDepot, CommandSourceType cmdSource );///< get repaired at repair depot
+	virtual void privateCombatDrop( Object *target, const Coord3D& pos, CommandSourceType cmdSource ) override;
+	virtual void privateGetRepaired( Object *repairDepot, CommandSourceType cmdSource ) override;///< get repaired at repair depot
 
 private:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/CleanupAreaPower.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/CleanupAreaPower.h
@@ -70,5 +70,5 @@ public:
 	CleanupAreaPower( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype defined by MemoryPoolObject
 
-	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions );
+	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions ) override;
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/CleanupHazardUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/CleanupHazardUpdate.h
@@ -68,8 +68,8 @@ public:
 	CleanupHazardUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onObjectCreated();
-	virtual UpdateSleepTime update();
+	virtual void onObjectCreated() override;
+	virtual UpdateSleepTime update() override;
 
 	Object* scanClosestTarget();
 	void fireWhenReady();

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/CollideModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/CollideModule.h
@@ -82,16 +82,16 @@ public:
 	static Int getInterfaceMask() { return MODULEINTERFACE_COLLIDE; }
 
 	// BehaviorModule
-	virtual CollideModuleInterface* getCollide() { return this; }
+	virtual CollideModuleInterface* getCollide() override { return this; }
 
-	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal ) = 0;
+	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal ) override = 0;
 
 	/// this is used for things like pilots, to determine if they can "enter" something
-	virtual Bool wouldLikeToCollideWith(const Object* other) const { return false; }
-	virtual Bool isHijackedVehicleCrateCollide() const { return false; }
-	virtual Bool isCarBombCrateCollide() const { return false; }
-	virtual Bool isRailroad() const { return false;}
-	virtual Bool isSalvageCrateCollide() const { return false; }
+	virtual Bool wouldLikeToCollideWith(const Object* other) const override { return false; }
+	virtual Bool isHijackedVehicleCrateCollide() const override { return false; }
+	virtual Bool isCarBombCrateCollide() const override { return false; }
+	virtual Bool isRailroad() const override { return false;}
+	virtual Bool isSalvageCrateCollide() const override { return false; }
 
 };
 inline CollideModule::CollideModule( Thing *thing, const ModuleData* moduleData ) : BehaviorModule( thing, moduleData ) { }

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/CollideModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/CollideModule.h
@@ -84,7 +84,7 @@ public:
 	// BehaviorModule
 	virtual CollideModuleInterface* getCollide() override { return this; }
 
-	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal ) override = 0;
+	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal ) = 0;
 
 	/// this is used for things like pilots, to determine if they can "enter" something
 	virtual Bool wouldLikeToCollideWith(const Object* other) const override { return false; }

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/CommandButtonHuntUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/CommandButtonHuntUpdate.h
@@ -67,8 +67,8 @@ public:
 	CommandButtonHuntUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onObjectCreated();
-	virtual UpdateSleepTime update();
+	virtual void onObjectCreated() override;
+	virtual UpdateSleepTime update() override;
 
 	void setCommandButton(const AsciiString& buttonName);
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/CommandSetUpgrade.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/CommandSetUpgrade.h
@@ -58,7 +58,7 @@ public:
 	// virtual destructor prototype defined by MemoryPoolObject
 
 protected:
-	virtual void upgradeImplementation( ); ///< Here's the actual work of Upgrading
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation( ) override; ///< Here's the actual work of Upgrading
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/ConvertToCarBombCrateCollide.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/ConvertToCarBombCrateCollide.h
@@ -79,10 +79,10 @@ public:
 protected:
 
 	/// This allows specific vetoes to certain types of crates and their data
-	virtual Bool isValidToExecute( const Object *other ) const;
+	virtual Bool isValidToExecute( const Object *other ) const override;
 
 	/// This is the game logic execution function that all real CrateCollides will implement
-	virtual Bool executeCrateBehavior( Object *other );
-	virtual Bool isRailroad() const { return FALSE;};
-	virtual Bool isCarBombCrateCollide() const { return TRUE; }
+	virtual Bool executeCrateBehavior( Object *other ) override;
+	virtual Bool isRailroad() const override { return FALSE;};
+	virtual Bool isCarBombCrateCollide() const override { return TRUE; }
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/ConvertToHijackedVehicleCrateCollide.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/ConvertToHijackedVehicleCrateCollide.h
@@ -73,10 +73,10 @@ public:
 protected:
 
 	/// This allows specific vetoes to certain types of crates and their data
-	virtual Bool isValidToExecute( const Object *other ) const;
+	virtual Bool isValidToExecute( const Object *other ) const override;
 
 	/// This is the game logic execution function that all real CrateCollides will implement
-	virtual Bool executeCrateBehavior( Object *other );
+	virtual Bool executeCrateBehavior( Object *other ) override;
 
-	virtual Bool isHijackedVehicleCrateCollide() const { return TRUE; }
+	virtual Bool isHijackedVehicleCrateCollide() const override { return TRUE; }
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/CostModifierUpgrade.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/CostModifierUpgrade.h
@@ -103,12 +103,12 @@ public:
 	CostModifierUpgrade( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype defined by MemoryPoolObject
 
-	virtual void onDelete();																///< we have some work to do when this module goes away
-	virtual void onCapture( Player *oldOwner, Player *newOwner );
+	virtual void onDelete() override;																///< we have some work to do when this module goes away
+	virtual void onCapture( Player *oldOwner, Player *newOwner ) override;
 
 protected:
 
-	virtual void upgradeImplementation(); ///< Here's the actual work of Upgrading
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation() override; ///< Here's the actual work of Upgrading
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/CrateCollide.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/CrateCollide.h
@@ -74,13 +74,13 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	/// This collide method gets called when collision occur
-	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal );
+	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal ) override;
 
-	virtual Bool wouldLikeToCollideWith(const Object* other) const { return isValidToExecute(other); }
+	virtual Bool wouldLikeToCollideWith(const Object* other) const override { return isValidToExecute(other); }
 
-	virtual Bool isRailroad() const { return FALSE;};
- 	virtual Bool isCarBombCrateCollide() const { return FALSE; }
-	virtual Bool isHijackedVehicleCrateCollide() const { return FALSE; }
+	virtual Bool isRailroad() const override { return FALSE;};
+ 	virtual Bool isCarBombCrateCollide() const override { return FALSE; }
+	virtual Bool isHijackedVehicleCrateCollide() const override { return FALSE; }
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/CreateCrateDie.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/CreateCrateDie.h
@@ -48,7 +48,7 @@ public:
 	{
 		m_crateNameList.clear();
 	}
-	~CreateCrateDieModuleData()
+	virtual ~CreateCrateDieModuleData() override
 	{
 		m_crateNameList.clear();
 	}
@@ -81,7 +81,7 @@ public:
 	CreateCrateDie( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 private:
 	Bool testCreationChance( CrateTemplate const *currentCrateData );

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/CreateModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/CreateModule.h
@@ -71,11 +71,11 @@ public:
 	static Int getInterfaceMask() { return MODULEINTERFACE_CREATE; }
 
 	// BehaviorModule
-	virtual CreateModuleInterface* getCreate() { return this; }
+	virtual CreateModuleInterface* getCreate() override { return this; }
 
-	virtual void onCreate() = 0;				///< This is called when you become a code Object
-	virtual void onBuildComplete(){ m_needToRunOnBuildComplete = FALSE; }	///< This is called when you are a finished game object
-	virtual Bool shouldDoOnBuildComplete() const { return m_needToRunOnBuildComplete; }
+	virtual void onCreate() override = 0;				///< This is called when you become a code Object
+	virtual void onBuildComplete() override{ m_needToRunOnBuildComplete = FALSE; }	///< This is called when you are a finished game object
+	virtual Bool shouldDoOnBuildComplete() const override { return m_needToRunOnBuildComplete; }
 
 private:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/CreateModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/CreateModule.h
@@ -74,7 +74,7 @@ public:
 	virtual CreateModuleInterface* getCreate() override { return this; }
 
 	virtual void onCreate() = 0;				///< This is called when you become a code Object
-	virtual void onBuildComplete() override{ m_needToRunOnBuildComplete = FALSE; }	///< This is called when you are a finished game object
+	virtual void onBuildComplete() override { m_needToRunOnBuildComplete = FALSE; }	///< This is called when you are a finished game object
 	virtual Bool shouldDoOnBuildComplete() const override { return m_needToRunOnBuildComplete; }
 
 private:

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/CreateModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/CreateModule.h
@@ -73,7 +73,7 @@ public:
 	// BehaviorModule
 	virtual CreateModuleInterface* getCreate() override { return this; }
 
-	virtual void onCreate() override = 0;				///< This is called when you become a code Object
+	virtual void onCreate() = 0;				///< This is called when you become a code Object
 	virtual void onBuildComplete() override{ m_needToRunOnBuildComplete = FALSE; }	///< This is called when you are a finished game object
 	virtual Bool shouldDoOnBuildComplete() const override { return m_needToRunOnBuildComplete; }
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/CreateObjectDie.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/CreateObjectDie.h
@@ -65,6 +65,6 @@ public:
 	CreateObjectDie( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/CrushDie.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/CrushDie.h
@@ -95,6 +95,6 @@ public:
 	CrushDie( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/DamDie.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/DamDie.h
@@ -58,6 +58,6 @@ public:
 	DamDie( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by MemoryPoolObject
 
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/DamageModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/DamageModule.h
@@ -98,11 +98,11 @@ public:
 	virtual DamageModuleInterface* getDamage() override { return this; }
 
 	// damage module callbacks
-	virtual void onDamage( DamageInfo *damageInfo ) override = 0;	///< damage callback
-	virtual void onHealing( DamageInfo *damageInfo ) override = 0;	///< healing callback
+	virtual void onDamage( DamageInfo *damageInfo ) = 0;	///< damage callback
+	virtual void onHealing( DamageInfo *damageInfo ) = 0;	///< healing callback
 	virtual void onBodyDamageStateChange( const DamageInfo* damageInfo,
 																				BodyDamageType oldState,
-																				BodyDamageType newState) override = 0;  ///< state change callback
+																				BodyDamageType newState) = 0;  ///< state change callback
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/DamageModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/DamageModule.h
@@ -95,14 +95,14 @@ public:
 	static Int getInterfaceMask() { return MODULEINTERFACE_DAMAGE; }
 
 	// BehaviorModule
-	virtual DamageModuleInterface* getDamage() { return this; }
+	virtual DamageModuleInterface* getDamage() override { return this; }
 
 	// damage module callbacks
-	virtual void onDamage( DamageInfo *damageInfo ) = 0;	///< damage callback
-	virtual void onHealing( DamageInfo *damageInfo ) = 0;	///< healing callback
+	virtual void onDamage( DamageInfo *damageInfo ) override = 0;	///< damage callback
+	virtual void onHealing( DamageInfo *damageInfo ) override = 0;	///< healing callback
 	virtual void onBodyDamageStateChange( const DamageInfo* damageInfo,
 																				BodyDamageType oldState,
-																				BodyDamageType newState) = 0;  ///< state change callback
+																				BodyDamageType newState) override = 0;  ///< state change callback
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/DefaultProductionExitUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/DefaultProductionExitUpdate.h
@@ -71,23 +71,23 @@ class DefaultProductionExitUpdate : public UpdateModule, public ExitInterface
 
 public:
 
-	virtual ExitInterface* getUpdateExitInterface() { return this; }
+	virtual ExitInterface* getUpdateExitInterface() override { return this; }
 
 	DefaultProductionExitUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
 	// Required funcs to fulfill interface requirements
-	virtual Bool isExitBusy() const {return FALSE;}	///< Contain style exiters are getting the ability to space out exits, so ask this before reserveDoor as a kind of no-commitment check.
-	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject ) { return DOOR_1; }
-	virtual void exitObjectViaDoor( Object *newObj, ExitDoorType exitDoor );
-	virtual void unreserveDoorForExit( ExitDoorType exitDoor ) { /* nothing */ }
-	virtual void exitObjectByBudding( Object *newObj, Object *budHost ) { return; }
+	virtual Bool isExitBusy() const override {return FALSE;}	///< Contain style exiters are getting the ability to space out exits, so ask this before reserveDoor as a kind of no-commitment check.
+	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject ) override { return DOOR_1; }
+	virtual void exitObjectViaDoor( Object *newObj, ExitDoorType exitDoor ) override;
+	virtual void unreserveDoorForExit( ExitDoorType exitDoor ) override { /* nothing */ }
+	virtual void exitObjectByBudding( Object *newObj, Object *budHost ) override { return; }
 
-	virtual void setRallyPoint( const Coord3D *pos );				///< define a "rally point" for units to move towards
-	virtual const Coord3D *getRallyPoint() const;			///< define a "rally point" for units to move towards
-	virtual Bool getNaturalRallyPoint( Coord3D& rallyPoint, Bool offset = TRUE ) const;			///< get the natural "rally point" for units to move towards
-	virtual Bool getExitPosition( Coord3D& exitPosition ) const;					///< access to the "Door" position of the production object
-	virtual UpdateSleepTime update()										{ return UPDATE_SLEEP_FOREVER; }
+	virtual void setRallyPoint( const Coord3D *pos ) override;				///< define a "rally point" for units to move towards
+	virtual const Coord3D *getRallyPoint() const override;			///< define a "rally point" for units to move towards
+	virtual Bool getNaturalRallyPoint( Coord3D& rallyPoint, Bool offset = TRUE ) const override;			///< get the natural "rally point" for units to move towards
+	virtual Bool getExitPosition( Coord3D& exitPosition ) const override;					///< access to the "Door" position of the production object
+	virtual UpdateSleepTime update() override { return UPDATE_SLEEP_FOREVER; }
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/DefectorSpecialPower.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/DefectorSpecialPower.h
@@ -72,8 +72,8 @@ public:
 	DefectorSpecialPower( Thing *thing, const ModuleData *moduleData );
 	// virtual destructor prototype provided by memory pool object
 
-	virtual void doSpecialPowerAtObject( Object *obj, UnsignedInt commandOptions );
-	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions );
+	virtual void doSpecialPowerAtObject( Object *obj, UnsignedInt commandOptions ) override;
+	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions ) override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/DelayedUpgrade.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/DelayedUpgrade.h
@@ -75,7 +75,7 @@ public:
 
 protected:
 
-	virtual void upgradeImplementation( ); ///< Here's the actual work of Upgrading
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation( ) override; ///< Here's the actual work of Upgrading
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/DelayedWeaponSetUpgradeUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/DelayedWeaponSetUpgradeUpdate.h
@@ -58,10 +58,10 @@ public:
 	DelayedWeaponSetUpgradeUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual Bool isTriggeredBy( const UpgradeMaskType& potentialMask );	///< If you were an upgrade, would you trigger for this?
-	virtual void setDelay( UnsignedInt startingDelay );	///< Start the upgrade doing countdown
+	virtual Bool isTriggeredBy( const UpgradeMaskType& potentialMask ) override;	///< If you were an upgrade, would you trigger for this?
+	virtual void setDelay( UnsignedInt startingDelay ) override;	///< Start the upgrade doing countdown
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/DeletionUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/DeletionUpdate.h
@@ -74,7 +74,7 @@ public:
 	void setLifetimeRange( UnsignedInt minFrames, UnsignedInt maxFrames );
 	UnsignedInt getDieFrame() { return m_dieFrame; }
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/DeliverPayloadAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/DeliverPayloadAIUpdate.h
@@ -61,9 +61,9 @@ public:
 	virtual StateReturnType onEnter() override;
 protected:
 	// snapshot interface	STUBBED - no member vars to save. jba.
-	virtual void crc( Xfer *xfer ) override{};
-	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess() override{};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 };
 EMPTY_DTOR(ApproachState)
 
@@ -144,9 +144,9 @@ public:
 	virtual StateReturnType onEnter() override;
 protected:
 	// snapshot interface	STUBBED - no member vars to save. jba.
-	virtual void crc( Xfer *xfer ) override{};
-	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess() override{};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 };
 EMPTY_DTOR(HeadOffMapState)
 
@@ -157,13 +157,13 @@ class CleanUpState :  public State
 	//Made it off map, delete ourselves
 public:
 	CleanUpState( StateMachine *machine ) :State( machine, "CleanUpState" ) {}
-	virtual StateReturnType update() override{return STATE_CONTINUE;}
+	virtual StateReturnType update() override {return STATE_CONTINUE;}
 	virtual StateReturnType onEnter() override;
 protected:
 	// snapshot interface	STUBBED - no member vars to save. jba.
-	virtual void crc( Xfer *xfer ) override{};
-	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess() override{};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 };
 EMPTY_DTOR(CleanUpState)
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/DeliverPayloadAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/DeliverPayloadAIUpdate.h
@@ -45,9 +45,9 @@ public:
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 };
 
 //-------------------------------------------------------------------------------------------------
@@ -57,13 +57,13 @@ class ApproachState :  public State
 	//Approaching the drop zone
 public:
 	ApproachState( StateMachine *machine ) :State( machine, "ApproachState" ) {}
-	virtual StateReturnType update();
-	virtual StateReturnType onEnter();
+	virtual StateReturnType update() override;
+	virtual StateReturnType onEnter() override;
 protected:
 	// snapshot interface	STUBBED - no member vars to save. jba.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override{};
 };
 EMPTY_DTOR(ApproachState)
 
@@ -78,14 +78,14 @@ public:
 		m_dropDelayLeft = 0;
 		m_didOpen = false;
 	}
-	virtual StateReturnType update();
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType update() override;
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	UnsignedInt m_dropDelayLeft;
@@ -100,14 +100,14 @@ class ConsiderNewApproachState :  public State
 	//Should I try again?  Has own data to keep track.
 public:
 	ConsiderNewApproachState( StateMachine *machine ) : State( machine, "ConsiderNewApproachState" ), m_numberEntriesToState(0) { }
-	virtual StateReturnType update();
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType update() override;
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	Int m_numberEntriesToState;
@@ -120,13 +120,13 @@ class RecoverFromOffMapState :  public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(RecoverFromOffMapState, "RecoverFromOffMapState")
 public:
 	RecoverFromOffMapState( StateMachine *machine ) : State( machine, "RecoverFromOffMapState" ), m_reEntryFrame(0) { }
-	virtual StateReturnType update();
-	virtual StateReturnType onEnter();
+	virtual StateReturnType update() override;
+	virtual StateReturnType onEnter() override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	UnsignedInt m_reEntryFrame;
@@ -140,13 +140,13 @@ class HeadOffMapState :  public State
 	//I'm outta here
 public:
 	HeadOffMapState( StateMachine *machine ) :State( machine, "HeadOffMapState" ) {}
-	virtual StateReturnType update();
-	virtual StateReturnType onEnter();
+	virtual StateReturnType update() override;
+	virtual StateReturnType onEnter() override;
 protected:
 	// snapshot interface	STUBBED - no member vars to save. jba.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override{};
 };
 EMPTY_DTOR(HeadOffMapState)
 
@@ -157,13 +157,13 @@ class CleanUpState :  public State
 	//Made it off map, delete ourselves
 public:
 	CleanUpState( StateMachine *machine ) :State( machine, "CleanUpState" ) {}
-	virtual StateReturnType update(){return STATE_CONTINUE;}
-	virtual StateReturnType onEnter();
+	virtual StateReturnType update() override{return STATE_CONTINUE;}
+	virtual StateReturnType onEnter() override;
 protected:
 	// snapshot interface	STUBBED - no member vars to save. jba.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override{};
 };
 EMPTY_DTOR(CleanUpState)
 
@@ -309,7 +309,7 @@ public:
 	DeliverPayloadAIUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual AIFreeToExitType getAiFreeToExit(const Object* exiter) const;
+	virtual AIFreeToExitType getAiFreeToExit(const Object* exiter) const override;
 
 	const Coord3D* getTargetPos() const { return &m_targetPos; }
 	const Coord3D* getMoveToPos() const { return &m_moveToPos; }
@@ -336,7 +336,7 @@ public:
 
 	const DeliverPayloadData* getData() { return &m_data; }
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	void killDeliveryDecal();
 
@@ -345,8 +345,8 @@ public:
 
 protected:
 
-	virtual AIStateMachine* makeStateMachine();
-	virtual Bool isAllowedToRespondToAiCommands(const AICommandParms* parms) const;
+	virtual AIStateMachine* makeStateMachine() override;
+	virtual Bool isAllowedToRespondToAiCommands(const AICommandParms* parms) const override;
 
 	DeliverPayloadStateMachine*		m_deliverPayloadStateMachine;	///< Controls my special logic
 	Coord3D												m_targetPos;									///< Where I plan to deliver my little friends, if obj is null

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/DemoTrapUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/DemoTrapUpdate.h
@@ -73,8 +73,8 @@ public:
 	DemoTrapUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onObjectCreated();
-	virtual UpdateSleepTime update();
+	virtual void onObjectCreated() override;
+	virtual UpdateSleepTime update() override;
 
 	void detonate();
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/DeployStyleAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/DeployStyleAIUpdate.h
@@ -92,9 +92,9 @@ public:
 	DeployStyleAIUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
- 	virtual void aiDoCommand(const AICommandParms* parms);
-	virtual Bool isIdle() const;
-	virtual UpdateSleepTime update();
+ 	virtual void aiDoCommand(const AICommandParms* parms) override;
+	virtual Bool isIdle() const override;
+	virtual UpdateSleepTime update() override;
 
 	UnsignedInt getUnpackTime()					const { return getDeployStyleAIUpdateModuleData()->m_unpackTime; }
 	UnsignedInt getPackTime()						const { return getDeployStyleAIUpdateModuleData()->m_packTime; }

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/DestroyDie.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/DestroyDie.h
@@ -47,6 +47,6 @@ public:
 	DestroyDie( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/DestroyModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/DestroyModule.h
@@ -58,7 +58,7 @@ public:
 	// BehaviorModule
 	virtual DestroyModuleInterface* getDestroy() override { return this; }
 
-	virtual void onDestroy() override = 0;
+	virtual void onDestroy() = 0;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/DestroyModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/DestroyModule.h
@@ -56,9 +56,9 @@ public:
 	static Int getInterfaceMask() { return MODULEINTERFACE_DESTROY; }
 
 	// BehaviorModule
-	virtual DestroyModuleInterface* getDestroy() { return this; }
+	virtual DestroyModuleInterface* getDestroy() override { return this; }
 
-	virtual void onDestroy() = 0;
+	virtual void onDestroy() override = 0;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/DieModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/DieModule.h
@@ -95,9 +95,9 @@ public:
 	static Int getInterfaceMask() { return MODULEINTERFACE_DIE; }
 
 	// BehaviorModule
-	virtual DieModuleInterface* getDie() { return this; }
+	virtual DieModuleInterface* getDie() override { return this; }
 
-	void onDie( const DamageInfo *damageInfo ) = 0;
+	virtual void onDie( const DamageInfo *damageInfo ) override = 0;
 
 protected:
 	Bool isDieApplicable(const DamageInfo *damageInfo) const { return getDieModuleData()->isDieApplicable(getObject(), damageInfo); }

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/DieModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/DieModule.h
@@ -97,7 +97,7 @@ public:
 	// BehaviorModule
 	virtual DieModuleInterface* getDie() override { return this; }
 
-	virtual void onDie( const DamageInfo *damageInfo ) override = 0;
+	virtual void onDie( const DamageInfo *damageInfo ) = 0;
 
 protected:
 	Bool isDieApplicable(const DamageInfo *damageInfo) const { return getDieModuleData()->isDieApplicable(getObject(), damageInfo); }

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/DockUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/DockUpdate.h
@@ -72,61 +72,61 @@ public:
 	/** Returns true if it is okay for the docker to approach and prepare to dock.
 			False could mean the queue is full, for example.
 	*/
-	virtual Bool isClearToApproach( Object const* docker ) const;
+	virtual Bool isClearToApproach( Object const* docker ) const override;
 
 	/** Give me a Queue point to drive to, and record that that point is taken.
 			Returning null means there are none free
 	*/
-	virtual Bool reserveApproachPosition( Object* docker, Coord3D *position, Int *index );
+	virtual Bool reserveApproachPosition( Object* docker, Coord3D *position, Int *index ) override;
 
 	/** Give me the next Queue point to drive to, and record that that point is taken.
 	*/
-	virtual Bool advanceApproachPosition( Object* docker, Coord3D *position, Int *index );
+	virtual Bool advanceApproachPosition( Object* docker, Coord3D *position, Int *index ) override;
 
 	/** Return true when it is OK for docker to begin entering the dock
 			The Dock will lift the restriction on one particular docker on its own,
 			so you must continually ask.
 	*/
-	virtual Bool isClearToEnter( Object const* docker ) const;
+	virtual Bool isClearToEnter( Object const* docker ) const override;
 
 	/** Return true when it is OK for docker to request a new Approach position.  The dock is in
 			charge of keeping track of holes in the line, but the docker will remind us of their spot.
 	*/
-	virtual Bool isClearToAdvance( Object const* docker, Int dockerIndex ) const;
+	virtual Bool isClearToAdvance( Object const* docker, Int dockerIndex ) const override;
 
 	/** Give me the point that is the start of your docking path
 			Returning null means there is none free
 			All functions take docker as arg so we could have multiple docks on a building.
 			Docker is not assumed, it is recorded and checked.
 	*/
-	virtual void getEnterPosition( Object* docker, Coord3D *position );
+	virtual void getEnterPosition( Object* docker, Coord3D *position ) override;
 
 	/** Give me the middle point of the dock process where the action() happens */
-	virtual void getDockPosition( Object* docker, Coord3D *position );
+	virtual void getDockPosition( Object* docker, Coord3D *position ) override;
 
 	/** Give me the point to drive to when I am done */
-	virtual void getExitPosition( Object* docker, Coord3D *position );
+	virtual void getExitPosition( Object* docker, Coord3D *position ) override;
 
-	virtual void onApproachReached( Object* docker );		///< I have reached the Approach Point.
-	virtual void onEnterReached( Object* docker );			///< I have reached the Enter Point.
-	virtual void onDockReached( Object* docker );				///< I have reached the Dock point
-	virtual void onExitReached( Object* docker );				///< I have reached the exit.  You are no longer busy
+	virtual void onApproachReached( Object* docker ) override;		///< I have reached the Approach Point.
+	virtual void onEnterReached( Object* docker ) override;			///< I have reached the Enter Point.
+	virtual void onDockReached( Object* docker ) override;				///< I have reached the Dock point
+	virtual void onExitReached( Object* docker ) override;				///< I have reached the exit.  You are no longer busy
 
 	//The fact that action() is not here is intentional.  This object cannot exist.  You must
 	//derive off it and implement action().
 
-	virtual void cancelDock( Object* docker );	///< Clear me from any reserved points, and if I was the reason you were Busy, you aren't anymore.
+	virtual void cancelDock( Object* docker ) override;	///< Clear me from any reserved points, and if I was the reason you were Busy, you aren't anymore.
 
-	virtual Bool isDockOpen() { return m_dockOpen; }				///< Is the dock open to accepting dockers
-	virtual void setDockOpen( Bool open ) { m_dockOpen = open; }	///< Open/Close the dock
+	virtual Bool isDockOpen() override { return m_dockOpen; }				///< Is the dock open to accepting dockers
+	virtual void setDockOpen( Bool open ) override { m_dockOpen = open; }	///< Open/Close the dock
 
-	virtual Bool isAllowPassthroughType();	///< Not all docks allow you to path through them in your AIDock machine
+	virtual Bool isAllowPassthroughType() override;	///< Not all docks allow you to path through them in your AIDock machine
 
-	virtual Bool isRallyPointAfterDockType(){return FALSE;} ///< A minority of docks want to give you a final command to their rally point
+	virtual Bool isRallyPointAfterDockType() override{return FALSE;} ///< A minority of docks want to give you a final command to their rally point
 
-	virtual void setDockCrippled( Bool setting ); ///< Game Logic can set me as inoperative.  I get to decide what that means.
+	virtual void setDockCrippled( Bool setting ) override; ///< Game Logic can set me as inoperative.  I get to decide what that means.
 
-	virtual UpdateSleepTime update();	///< In charge of lifting dock restriction for one registered as Approached if all is ready
+	virtual UpdateSleepTime update() override;	///< In charge of lifting dock restriction for one registered as Approached if all is ready
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/DockUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/DockUpdate.h
@@ -122,7 +122,7 @@ public:
 
 	virtual Bool isAllowPassthroughType() override;	///< Not all docks allow you to path through them in your AIDock machine
 
-	virtual Bool isRallyPointAfterDockType() override{return FALSE;} ///< A minority of docks want to give you a final command to their rally point
+	virtual Bool isRallyPointAfterDockType() override {return FALSE;} ///< A minority of docks want to give you a final command to their rally point
 
 	virtual void setDockCrippled( Bool setting ) override; ///< Game Logic can set me as inoperative.  I get to decide what that means.
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/DozerAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/DozerAIUpdate.h
@@ -56,9 +56,9 @@ public:
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 };
 
 
@@ -207,76 +207,76 @@ public:
 	DozerAIUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual DozerAIInterface* getDozerAIInterface() {return this;}
-	virtual const DozerAIInterface* getDozerAIInterface() const {return this;}
+	virtual DozerAIInterface* getDozerAIInterface() override {return this;}
+	virtual const DozerAIInterface* getDozerAIInterface() const override {return this;}
 
-	virtual void onDelete();
+	virtual void onDelete() override;
 
 	//
 	// module data methods ... this is LAME, multiple inheritance off an interface with replicated
 	// data and code, ick!
 	// NOTE: If you edit module data you must do it in both the Dozer *AND* the Worker
 	//
-	virtual Real getRepairHealthPerSecond() const;	///< get health to repair per second
-	virtual Real getBoredTime() const;							///< how long till we're bored
-	virtual Real getBoredRange() const;							///< when we're bored, we look this far away to do things
+	virtual Real getRepairHealthPerSecond() const override;	///< get health to repair per second
+	virtual Real getBoredTime() const override;							///< how long till we're bored
+	virtual Real getBoredRange() const override;							///< when we're bored, we look this far away to do things
 
 	// methods to override for the dozer behaviors
 	virtual Object* construct( const ThingTemplate *what,
 														 const Coord3D *pos, Real angle,
 														 Player *owningPlayer,
-														 Bool isRebuild );								///< construct an object
+														 Bool isRebuild ) override;								///< construct an object
 
 
 	// get task information
-	virtual DozerTask getMostRecentCommand();				///< return task that was most recently issued
-	virtual Bool isTaskPending( DozerTask task );					///< is there a desire to do the requested task
-	virtual ObjectID getTaskTarget( DozerTask task );			///< get target of task
-	virtual Bool isAnyTaskPending();								///< is there any dozer task pending
-	virtual DozerTask getCurrentTask() const { return m_currentTask; }	///< return the current task we're doing
-	virtual void setCurrentTask( DozerTask task ) { m_currentTask = task; }	///< set the current task of the dozer
+	virtual DozerTask getMostRecentCommand() override;				///< return task that was most recently issued
+	virtual Bool isTaskPending( DozerTask task ) override;					///< is there a desire to do the requested task
+	virtual ObjectID getTaskTarget( DozerTask task ) override;			///< get target of task
+	virtual Bool isAnyTaskPending() override;								///< is there any dozer task pending
+	virtual DozerTask getCurrentTask() const override { return m_currentTask; }	///< return the current task we're doing
+	virtual void setCurrentTask( DozerTask task ) override { m_currentTask = task; }	///< set the current task of the dozer
 
-	virtual Bool getIsRebuild() { return m_isRebuild; }	///< get whether or not this building is a rebuild.
+	virtual Bool getIsRebuild() override { return m_isRebuild; }	///< get whether or not this building is a rebuild.
 
 	// task actions
-	virtual void newTask( DozerTask task, Object *target );	///< set a desire to do the requrested task
-	virtual void cancelTask( DozerTask task );							///< cancel this task from the queue, if it's the current task the dozer will stop working on it
-	virtual void cancelAllTasks();													///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
-	virtual void resumePreviousTask();									///< resume the previous task if there was one
+	virtual void newTask( DozerTask task, Object *target ) override;	///< set a desire to do the requrested task
+	virtual void cancelTask( DozerTask task ) override;							///< cancel this task from the queue, if it's the current task the dozer will stop working on it
+	virtual void cancelAllTasks() override;													///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
+	virtual void resumePreviousTask() override;									///< resume the previous task if there was one
 
 	// internal methods to manage behavior from within the dozer state machine
-	virtual void internalTaskComplete( DozerTask task );					///< set a dozer task as successfully completed
-	virtual void internalCancelTask( DozerTask task );						///< cancel this task from the dozer
-	virtual void internalTaskCompleteOrCancelled( DozerTask task );	///< this is called when tasks are cancelled or completed
+	virtual void internalTaskComplete( DozerTask task ) override;					///< set a dozer task as successfully completed
+	virtual void internalCancelTask( DozerTask task ) override;						///< cancel this task from the dozer
+	virtual void internalTaskCompleteOrCancelled( DozerTask task ) override;	///< this is called when tasks are cancelled or completed
 
 	/** return a dock point for the action and task (if valid) ... note it can return nullptr
 	if no point has been set for the combination of task and point */
-	virtual const Coord3D* getDockPoint( DozerTask task, DozerDockPoint point );
+	virtual const Coord3D* getDockPoint( DozerTask task, DozerDockPoint point ) override;
 
-	virtual void setBuildSubTask( DozerBuildSubTask subTask ) { m_buildSubTask = subTask; };
-	virtual DozerBuildSubTask getBuildSubTask() { return m_buildSubTask; }
+	virtual void setBuildSubTask( DozerBuildSubTask subTask ) override { m_buildSubTask = subTask; };
+	virtual DozerBuildSubTask getBuildSubTask() override { return m_buildSubTask; }
 
-	virtual UpdateSleepTime update();											///< the update entry point
+	virtual UpdateSleepTime update() override;											///< the update entry point
 
 	// repairing
-	virtual Bool canAcceptNewRepair( Object *obj );
-	virtual void createBridgeScaffolding( Object *bridgeTower );
-	virtual void removeBridgeScaffolding( Object *bridgeTower );
+	virtual Bool canAcceptNewRepair( Object *obj ) override;
+	virtual void createBridgeScaffolding( Object *bridgeTower ) override;
+	virtual void removeBridgeScaffolding( Object *bridgeTower ) override;
 
-	virtual void startBuildingSound( const AudioEventRTS *sound, ObjectID constructionSiteID );
-	virtual void finishBuildingSound();
+	virtual void startBuildingSound( const AudioEventRTS *sound, ObjectID constructionSiteID ) override;
+	virtual void finishBuildingSound() override;
 
 	//
 	// the following methods must be overridden so that if a player issues a command the dozer
 	// can exit the internal state machine and do whatever the player says
 	//
-	virtual void aiDoCommand(const AICommandParms* parms);
+	virtual void aiDoCommand(const AICommandParms* parms) override;
 
 
 protected:
 
-	virtual void privateRepair( Object *obj, CommandSourceType cmdSource );	///< repair the target
-	virtual void privateResumeConstruction( Object *obj, CommandSourceType cmdSource );  ///< resume construction on obj
+	virtual void privateRepair( Object *obj, CommandSourceType cmdSource ) override;	///< repair the target
+	virtual void privateResumeConstruction( Object *obj, CommandSourceType cmdSource ) override;  ///< resume construction on obj
 
 	struct DozerTaskInfo
 	{

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/DumbProjectileBehavior.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/DumbProjectileBehavior.h
@@ -83,15 +83,15 @@ public:
 	// virtual destructor provided by memory pool object
 
 	// UpdateModuleInterface
-	virtual UpdateSleepTime update();
-	virtual ProjectileUpdateInterface* getProjectileUpdateInterface() { return this; }
+	virtual UpdateSleepTime update() override;
+	virtual ProjectileUpdateInterface* getProjectileUpdateInterface() override { return this; }
 
 	// ProjectileUpdateInterface
-	virtual void projectileLaunchAtObjectOrPosition(const Object *victim, const Coord3D* victimPos, const Object *launcher, WeaponSlotType wslot, Int specificBarrelToUse, const WeaponTemplate* detWeap, const ParticleSystemTemplate* exhaustSysOverride);
-	virtual void projectileFireAtObjectOrPosition( const Object *victim, const Coord3D *victimPos, const WeaponTemplate *detWeap, const ParticleSystemTemplate* exhaustSysOverride );
-	virtual Bool projectileHandleCollision( Object *other );
-	virtual Bool projectileIsArmed() const { return true; }
-	virtual ObjectID projectileGetLauncherID() const { return m_launcherID; }
+	virtual void projectileLaunchAtObjectOrPosition(const Object *victim, const Coord3D* victimPos, const Object *launcher, WeaponSlotType wslot, Int specificBarrelToUse, const WeaponTemplate* detWeap, const ParticleSystemTemplate* exhaustSysOverride) override;
+	virtual void projectileFireAtObjectOrPosition( const Object *victim, const Coord3D *victimPos, const WeaponTemplate *detWeap, const ParticleSystemTemplate* exhaustSysOverride ) override;
+	virtual Bool projectileHandleCollision( Object *other ) override;
+	virtual Bool projectileIsArmed() const override { return true; }
+	virtual ObjectID projectileGetLauncherID() const override { return m_launcherID; }
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/DynamicGeometryInfoUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/DynamicGeometryInfoUpdate.h
@@ -76,7 +76,7 @@ public:
 	DynamicGeometryInfoUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/DynamicShroudClearingRangeUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/DynamicShroudClearingRangeUpdate.h
@@ -73,7 +73,7 @@ public:
 	DynamicShroudClearingRangeUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	void createGridDecals( const RadiusDecalTemplate& tmpl, Real radius, const Coord3D& pos );
 	void killGridDecals();

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/EMPUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/EMPUpdate.h
@@ -103,7 +103,7 @@ public:
 
 	UnsignedInt getDieFrame() { return m_dieFrame; }
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 	void doDisableAttack();
 
 protected:

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/EjectPilotDie.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/EjectPilotDie.h
@@ -65,7 +65,7 @@ public:
 
 	static void ejectPilot(const ObjectCreationList* ocl, const Object* dyingObject, const Object* damageDealer);
 
-	virtual void onDie( const DamageInfo *damageInfo );
-	virtual DieModuleInterface* getEjectPilotDieInterface() {return this; }
+	virtual void onDie( const DamageInfo *damageInfo ) override;
+	virtual DieModuleInterface* getEjectPilotDieInterface() override {return this; }
 
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/EnemyNearUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/EnemyNearUpdate.h
@@ -71,7 +71,7 @@ public:
 	EnemyNearUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/ExperienceScalarUpgrade.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/ExperienceScalarUpgrade.h
@@ -65,7 +65,7 @@ public:
 
 protected:
 
-	virtual void upgradeImplementation(); ///< Here's the actual work of Upgrading
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation() override; ///< Here's the actual work of Upgrading
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/FXListDie.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/FXListDie.h
@@ -78,6 +78,6 @@ public:
 	FXListDie( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/FireOCLAfterWeaponCooldownUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/FireOCLAfterWeaponCooldownUpdate.h
@@ -63,30 +63,30 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	// update methods
-	virtual UpdateSleepTime update();							///< called once per frame
+	virtual UpdateSleepTime update() override;							///< called once per frame
 
 protected:
-	virtual void upgradeImplementation()
+	virtual void upgradeImplementation() override
 	{
 		// nothing!
 	}
 
-	virtual void getUpgradeActivationMasks(UpgradeMaskType& activation, UpgradeMaskType& conflicting) const
+	virtual void getUpgradeActivationMasks(UpgradeMaskType& activation, UpgradeMaskType& conflicting) const override
 	{
 		getFireOCLAfterWeaponCooldownUpdateModuleData()->m_upgradeMuxData.getUpgradeActivationMasks(activation, conflicting);
 	}
 
-	virtual void performUpgradeFX()
+	virtual void performUpgradeFX() override
 	{
 		getFireOCLAfterWeaponCooldownUpdateModuleData()->m_upgradeMuxData.performUpgradeFX(getObject());
 	}
 
-	virtual Bool requiresAllActivationUpgrades() const
+	virtual Bool requiresAllActivationUpgrades() const override
 	{
 		return getFireOCLAfterWeaponCooldownUpdateModuleData()->m_upgradeMuxData.m_requiresAllTriggers;
 	}
 
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 	void resetStats();
 	void fireOCL();

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/FireSpreadUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/FireSpreadUpdate.h
@@ -64,7 +64,7 @@ public:
 	FireSpreadUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	void startFireSpreading();
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/FireWeaponCollide.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/FireWeaponCollide.h
@@ -68,7 +68,7 @@ public:
 
 protected:
 
-	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal );
+	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal ) override;
 
 	virtual Bool shouldFireWeapon();
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/FireWeaponUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/FireWeaponUpdate.h
@@ -59,7 +59,7 @@ public:
 	FireWeaponUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/FireWeaponWhenDamagedBehavior.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/FireWeaponWhenDamagedBehavior.h
@@ -116,42 +116,42 @@ public:
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_UPGRADE) | (MODULEINTERFACE_DAMAGE); }
 
 	// BehaviorModule
-	virtual UpgradeModuleInterface* getUpgrade() { return this; }
-	virtual DamageModuleInterface* getDamage() { return this; }
+	virtual UpgradeModuleInterface* getUpgrade() override { return this; }
+	virtual DamageModuleInterface* getDamage() override { return this; }
 
 	// DamageModuleInterface
-	virtual void onDamage( DamageInfo *damageInfo );
-	virtual void onHealing( DamageInfo *damageInfo ) { }
-	virtual void onBodyDamageStateChange(const DamageInfo* damageInfo, BodyDamageType oldState, BodyDamageType newState) { }
+	virtual void onDamage( DamageInfo *damageInfo ) override;
+	virtual void onHealing( DamageInfo *damageInfo ) override { }
+	virtual void onBodyDamageStateChange(const DamageInfo* damageInfo, BodyDamageType oldState, BodyDamageType newState) override { }
 
 	// UpdateModuleInterface
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 protected:
 
-	virtual void upgradeImplementation()
+	virtual void upgradeImplementation() override
 	{
 		setWakeFrame(getObject(), UPDATE_SLEEP_NONE);
 	}
 
-	virtual void getUpgradeActivationMasks(UpgradeMaskType& activation, UpgradeMaskType& conflicting) const
+	virtual void getUpgradeActivationMasks(UpgradeMaskType& activation, UpgradeMaskType& conflicting) const override
 	{
 		getFireWeaponWhenDamagedBehaviorModuleData()->m_upgradeMuxData.getUpgradeActivationMasks(activation, conflicting);
 	}
 
-	virtual void performUpgradeFX()
+	virtual void performUpgradeFX() override
 	{
 		getFireWeaponWhenDamagedBehaviorModuleData()->m_upgradeMuxData.performUpgradeFX(getObject());
 	}
 
-	virtual Bool requiresAllActivationUpgrades() const
+	virtual Bool requiresAllActivationUpgrades() const override
 	{
 		return getFireWeaponWhenDamagedBehaviorModuleData()->m_upgradeMuxData.m_requiresAllTriggers;
 	}
 
 	Bool isUpgradeActive() const { return isAlreadyUpgraded(); }
 
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 private:
 	Weapon *m_reactionWeaponPristine;

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/FireWeaponWhenDeadBehavior.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/FireWeaponWhenDeadBehavior.h
@@ -85,36 +85,36 @@ public:
 	static Int getInterfaceMask() { return BehaviorModule::getInterfaceMask() | (MODULEINTERFACE_UPGRADE) | (MODULEINTERFACE_DIE); }
 
 	// BehaviorModule
-	virtual UpgradeModuleInterface* getUpgrade() { return this; }
-	virtual DieModuleInterface* getDie() { return this; }
+	virtual UpgradeModuleInterface* getUpgrade() override { return this; }
+	virtual DieModuleInterface* getDie() override { return this; }
 
 	// DamageModuleInterface
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 protected:
 
-	virtual void upgradeImplementation()
+	virtual void upgradeImplementation() override
 	{
 		// nothing!
 	}
 
-	virtual void getUpgradeActivationMasks(UpgradeMaskType& activation, UpgradeMaskType& conflicting) const
+	virtual void getUpgradeActivationMasks(UpgradeMaskType& activation, UpgradeMaskType& conflicting) const override
 	{
 		getFireWeaponWhenDeadBehaviorModuleData()->m_upgradeMuxData.getUpgradeActivationMasks(activation, conflicting);
 	}
 
-	virtual void performUpgradeFX()
+	virtual void performUpgradeFX() override
 	{
 		getFireWeaponWhenDeadBehaviorModuleData()->m_upgradeMuxData.performUpgradeFX(getObject());
 	}
 
-	virtual Bool requiresAllActivationUpgrades() const
+	virtual Bool requiresAllActivationUpgrades() const override
 	{
 		return getFireWeaponWhenDeadBehaviorModuleData()->m_upgradeMuxData.m_requiresAllTriggers;
 	}
 
 	Bool isUpgradeActive() const { return isAlreadyUpgraded(); }
 
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/FirestormDynamicGeometryInfoUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/FirestormDynamicGeometryInfoUpdate.h
@@ -70,7 +70,7 @@ public:
 	FirestormDynamicGeometryInfoUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/FlammableUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/FlammableUpdate.h
@@ -80,20 +80,20 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_DAMAGE); }
-	virtual DamageModuleInterface* getDamage() { return this; }
+	virtual DamageModuleInterface* getDamage() override { return this; }
 
 	void tryToIgnite(); ///< FlammabeDamage uses this.  It is up to me to decide if I am burnable
 	Bool wouldIgnite(); ///< Since we need to cheat sometimes and light something directly, ask if this would light
 
 	//UpdateModuleInterface
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	//DamageModuleInterface
-	virtual void onDamage( DamageInfo *damageInfo );
-	virtual void onHealing( DamageInfo *damageInfo ) { }
+	virtual void onDamage( DamageInfo *damageInfo ) override;
+	virtual void onHealing( DamageInfo *damageInfo ) override { }
 	virtual void onBodyDamageStateChange( const DamageInfo *damageInfo,
 																				BodyDamageType oldState,
-																				BodyDamageType newState ) { }
+																				BodyDamageType newState ) override { }
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/FloatUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/FloatUpdate.h
@@ -63,7 +63,7 @@ public:
 
 	void setEnabled( Bool enabled ) { m_enabled = enabled; }  ///< enable/disable floating
 
-	virtual UpdateSleepTime update();	///< Deciding whether or not to make new guys
+	virtual UpdateSleepTime update() override;	///< Deciding whether or not to make new guys
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/GarrisonContain.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/GarrisonContain.h
@@ -100,45 +100,45 @@ public:
 	GarrisonContain( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual UpdateSleepTime update();						///< called once per frame
+	virtual UpdateSleepTime update() override;						///< called once per frame
 
-	virtual Bool isValidContainerFor( const Object* obj, Bool checkCapacity) const; // Garrison has an extra check forbidding any containment if ReallyDamaged
-	virtual Bool isGarrisonable() const { return true; }	///< can this unit be Garrisoned? (ick)
-	virtual Bool isImmuneToClearBuildingAttacks() const { return getGarrisonContainModuleData()->m_immuneToClearBuildingAttacks; }
-	virtual Bool isHealContain() const { return false; } ///< true when container only contains units while healing (not a transport!)
-	virtual Bool isPassengerAllowedToFire() const;	///< Hey, can I shoot out of this container?
+	virtual Bool isValidContainerFor( const Object* obj, Bool checkCapacity) const override; // Garrison has an extra check forbidding any containment if ReallyDamaged
+	virtual Bool isGarrisonable() const override { return true; }	///< can this unit be Garrisoned? (ick)
+	virtual Bool isImmuneToClearBuildingAttacks() const override { return getGarrisonContainModuleData()->m_immuneToClearBuildingAttacks; }
+	virtual Bool isHealContain() const override { return false; } ///< true when container only contains units while healing (not a transport!)
+	virtual Bool isPassengerAllowedToFire() const override;	///< Hey, can I shoot out of this container?
 
-	virtual void removeAllContained( Bool exposeStealthUnits );	///< remove all contents of this open container
+	virtual void removeAllContained( Bool exposeStealthUnits ) override;	///< remove all contents of this open container
 
-	virtual void exitObjectViaDoor( Object *exitObj, ExitDoorType exitDoor );	///< exit one of our content items from us
-	virtual void exitObjectByBudding( Object *newObj, Object *budHost ) { return; };
-	virtual void onContaining( Object *obj );				///< object now contains 'obj'
-	virtual void onRemoving( Object *obj );					///< object no longer contains 'obj'
+	virtual void exitObjectViaDoor( Object *exitObj, ExitDoorType exitDoor ) override;	///< exit one of our content items from us
+	virtual void exitObjectByBudding( Object *newObj, Object *budHost ) override { return; };
+	virtual void onContaining( Object *obj ) override;				///< object now contains 'obj'
+	virtual void onRemoving( Object *obj ) override;					///< object no longer contains 'obj'
 
 	// A Garrison Contain must eject all passengers when it crosses the ReallyDamaged threshold.
 	virtual void onBodyDamageStateChange( const DamageInfo* damageInfo,
 																				BodyDamageType oldState,
-																				BodyDamageType newState);  ///< Die Interface state change callback
+																				BodyDamageType newState) override;  ///< Die Interface state change callback
 
 
 	/**
 		return the player that *appears* to control this unit, given an observing player.
 		if null, use getObject()->getControllingPlayer() instead.
 	*/
-	virtual const Player* getApparentControllingPlayer( const Player* observingPlayer ) const;
-	virtual void recalcApparentControllingPlayer();
-	virtual Bool isDisplayedOnControlBar() const {return TRUE;}///< Does this container display its contents on the ControlBar?
+	virtual const Player* getApparentControllingPlayer( const Player* observingPlayer ) const override;
+	virtual void recalcApparentControllingPlayer() override;
+	virtual Bool isDisplayedOnControlBar() const override {return TRUE;}///< Does this container display its contents on the ControlBar?
 
 protected:
 
-	virtual void redeployOccupants();				///< redeploy the occupants of us at all available garrison points
-	virtual void onObjectCreated();
+	virtual void redeployOccupants() override;				///< redeploy the occupants of us at all available garrison points
+	virtual void onObjectCreated() override;
 
 	void validateRallyPoint();							///< validate (if necessary) and pick (if possible) an exit rally point
 
-	virtual Bool calcBestGarrisonPosition( Coord3D *sourcePos, const Coord3D *targetPos );
-	virtual Bool attemptBestFirePointPosition( Object *source, Weapon *weapon, Object *victim );
-	virtual Bool attemptBestFirePointPosition( Object *source, Weapon *weapon, const Coord3D *targetPos );
+	virtual Bool calcBestGarrisonPosition( Coord3D *sourcePos, const Coord3D *targetPos ) override;
+	virtual Bool attemptBestFirePointPosition( Object *source, Weapon *weapon, Object *victim ) override;
+	virtual Bool attemptBestFirePointPosition( Object *source, Weapon *weapon, const Coord3D *targetPos ) override;
 
 	void updateEffects();										///< do any effects needed per frame
 	void loadGarrisonPoints();							///< load garrison point position data and save for later

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/GenerateMinefieldBehavior.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/GenerateMinefieldBehavior.h
@@ -79,28 +79,28 @@ public:
 	static Int getInterfaceMask() { return (MODULEINTERFACE_DIE) | (MODULEINTERFACE_UPGRADE); }
 
 	// BehaviorModule
-	virtual DieModuleInterface* getDie() { return this; }
-	virtual UpgradeModuleInterface* getUpgrade() { return this; }
+	virtual DieModuleInterface* getDie() override { return this; }
+	virtual UpgradeModuleInterface* getUpgrade() override { return this; }
 
 	// DamageModuleInterface
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 	void setMinefieldTarget(const Coord3D* pos);
 
 protected:
 
-	virtual void upgradeImplementation();
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation() override;
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
-	virtual void getUpgradeActivationMasks(UpgradeMaskType& activation, UpgradeMaskType& conflicting) const
+	virtual void getUpgradeActivationMasks(UpgradeMaskType& activation, UpgradeMaskType& conflicting) const override
 	{
 		getGenerateMinefieldBehaviorModuleData()->m_upgradeMuxData.getUpgradeActivationMasks(activation, conflicting);
 	}
-	virtual void performUpgradeFX()
+	virtual void performUpgradeFX() override
 	{
 		getGenerateMinefieldBehaviorModuleData()->m_upgradeMuxData.performUpgradeFX(getObject());
 	}
-	virtual Bool requiresAllActivationUpgrades() const
+	virtual Bool requiresAllActivationUpgrades() const override
 	{
 		return getGenerateMinefieldBehaviorModuleData()->m_upgradeMuxData.m_requiresAllTriggers;
 	}

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/GrantUpgradeCreate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/GrantUpgradeCreate.h
@@ -68,8 +68,8 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	/// the create method
-	virtual void onCreate();
-	virtual void onBuildComplete();	///< This is called when you are a finished game object
+	virtual void onCreate() override;
+	virtual void onBuildComplete() override;	///< This is called when you are a finished game object
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/HackInternetAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/HackInternetAIUpdate.h
@@ -48,15 +48,15 @@ public:
 	{
 		m_framesRemaining = 0;
 	}
-	virtual StateReturnType update();
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType update() override;
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	UnsignedInt m_framesRemaining; //frames till next cash update
@@ -72,14 +72,14 @@ public:
 	{
 		m_framesRemaining = 0;
 	}
-	virtual StateReturnType update();
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType update() override;
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	UnsignedInt m_framesRemaining; //frames till packing animation complete
@@ -95,14 +95,14 @@ public:
 	{
 		m_framesRemaining = 0;
 	}
-	virtual StateReturnType update();
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType update() override;
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	UnsignedInt m_framesRemaining; //frames till unpacking animation complete
@@ -186,7 +186,7 @@ public:
 	HackInternetAIUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
- 	virtual void aiDoCommand(const AICommandParms* parms);
+ 	virtual void aiDoCommand(const AICommandParms* parms) override;
 
 	Real getPackUnpackVariationFactor() const { return getHackInternetAIUpdateModuleData()->m_packUnpackVariationFactor; }
 	UnsignedInt getUnpackTime()					const;
@@ -199,19 +199,19 @@ public:
 	UnsignedInt getXpPerCashUpdate()		const { return getHackInternetAIUpdateModuleData()->m_xpPerCashUpdate; }
 
 	void hackInternet();
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
-	virtual Bool isIdle() const;
+	virtual Bool isIdle() const override;
 
-	virtual HackInternetAIInterface* getHackInternetAIInterface() { return this; }
-	virtual const HackInternetAIInterface* getHackInternetAIInterface() const { return this; }
+	virtual HackInternetAIInterface* getHackInternetAIInterface() override { return this; }
+	virtual const HackInternetAIInterface* getHackInternetAIInterface() const override { return this; }
 
-	virtual Bool isHacking() const;
-	virtual Bool isHackingPackingOrUnpacking() const;
+	virtual Bool isHacking() const override;
+	virtual Bool isHackingPackingOrUnpacking() const override;
 
 protected:
 
-	virtual AIStateMachine* makeStateMachine();
+	virtual AIStateMachine* makeStateMachine() override;
 
 	AICommandParmsStorage		m_pendingCommand;
 	Bool m_hasPendingCommand;

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/HealContain.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/HealContain.h
@@ -61,9 +61,9 @@ public:
 	HealContain( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual UpdateSleepTime update();												///< called once per frame
-	virtual Bool isHealContain() const { return true; } ///< true when container only contains units while healing (not a transport!)
-	virtual Bool isTunnelContain() const { return FALSE; }
+	virtual UpdateSleepTime update() override;												///< called once per frame
+	virtual Bool isHealContain() const override { return true; } ///< true when container only contains units while healing (not a transport!)
+	virtual Bool isTunnelContain() const override { return FALSE; }
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/HealCrateCollide.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/HealCrateCollide.h
@@ -51,5 +51,5 @@ public:
 protected:
 
 	/// This is the game logic execution function that all real CrateCollides will implement
-	virtual Bool executeCrateBehavior( Object *other );
+	virtual Bool executeCrateBehavior( Object *other ) override;
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/HeightDieUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/HeightDieUpdate.h
@@ -65,7 +65,7 @@ public:
 	HeightDieUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/HelicopterSlowDeathUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/HelicopterSlowDeathUpdate.h
@@ -91,8 +91,8 @@ public:
 	HelicopterSlowDeathBehavior( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void beginSlowDeath( const DamageInfo *damageInfo );	///< begin the slow death cycle
-	virtual UpdateSleepTime update();
+	virtual void beginSlowDeath( const DamageInfo *damageInfo ) override;	///< begin the slow death cycle
+	virtual UpdateSleepTime update() override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/HighlanderBody.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/HighlanderBody.h
@@ -49,7 +49,7 @@ public:
 	HighlanderBody( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void attemptDamage( DamageInfo *damageInfo );		///< try to damage this object
+	virtual void attemptDamage( DamageInfo *damageInfo ) override;		///< try to damage this object
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/HijackerUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/HijackerUpdate.h
@@ -70,7 +70,7 @@ public:
 	HijackerUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual UpdateSleepTime update();							///< called once per frame
+	virtual UpdateSleepTime update() override;							///< called once per frame
 
 	void setTargetObject( const Object *object );
 	Object* getTargetObject() const;

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/HiveStructureBody.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/HiveStructureBody.h
@@ -76,5 +76,5 @@ public:
 
 protected:
 
-	virtual void attemptDamage( DamageInfo *damageInfo );		///< try to damage this object
+	virtual void attemptDamage( DamageInfo *damageInfo ) override;		///< try to damage this object
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/HordeUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/HordeUpdate.h
@@ -122,16 +122,16 @@ public:
 	HordeUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	HordeUpdateInterface *getHordeUpdateInterface() { return this; }
+	virtual HordeUpdateInterface *getHordeUpdateInterface() override { return this; }
 
-	virtual void onDrawableBoundToObject();
-	virtual UpdateSleepTime update();	///< update this object's AI
+	virtual void onDrawableBoundToObject() override;
+	virtual UpdateSleepTime update() override;	///< update this object's AI
 
-	virtual Bool isInHorde() const { return m_inHorde; }
-	virtual Bool hasFlag() const { return m_hasFlag; }
-	virtual Bool isTrueHordeMember() const { return m_trueHordeMember && m_inHorde; }
-	virtual Bool isAllowedNationalism() const;
-	virtual HordeActionType getHordeActionType() const { return getHordeUpdateModuleData()->m_action; };
+	virtual Bool isInHorde() const override { return m_inHorde; }
+	virtual Bool hasFlag() const override { return m_hasFlag; }
+	virtual Bool isTrueHordeMember() const override { return m_trueHordeMember && m_inHorde; }
+	virtual Bool isAllowedNationalism() const override;
+	virtual HordeActionType getHordeActionType() const override { return getHordeUpdateModuleData()->m_action; };
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/ImmortalBody.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/ImmortalBody.h
@@ -49,7 +49,7 @@ public:
 	ImmortalBody( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void internalChangeHealth( Real delta );								///< change health
+	virtual void internalChangeHealth( Real delta ) override;								///< change health
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/InactiveBody.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/InactiveBody.h
@@ -53,7 +53,7 @@ public:
 	virtual Real getHealth() const override;													///< get current health
 	virtual BodyDamageType getDamageState() const override;
 	virtual void setDamageState( BodyDamageType newState ) override;	///< control damage state directly.  Will adjust hitpoints.
-	virtual void setAflame( Bool setting ) override{}///< This is a major change like a damage state.
+	virtual void setAflame( Bool setting ) override {}///< This is a major change like a damage state.
 
 	virtual void onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel newLevel, Bool provideFeedback ) override { /* nothing */ }
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/InactiveBody.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/InactiveBody.h
@@ -47,20 +47,20 @@ public:
 	InactiveBody( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void attemptDamage( DamageInfo *damageInfo );		///< try to damage this object
-	virtual void attemptHealing( DamageInfo *damageInfo );		///< try to heal this object
-	virtual Real estimateDamage( DamageInfoInput& damageInfo ) const;
-	virtual Real getHealth() const;													///< get current health
-	virtual BodyDamageType getDamageState() const;
-	virtual void setDamageState( BodyDamageType newState );	///< control damage state directly.  Will adjust hitpoints.
-	virtual void setAflame( Bool setting ){}///< This is a major change like a damage state.
+	virtual void attemptDamage( DamageInfo *damageInfo ) override;		///< try to damage this object
+	virtual void attemptHealing( DamageInfo *damageInfo ) override;		///< try to heal this object
+	virtual Real estimateDamage( DamageInfoInput& damageInfo ) const override;
+	virtual Real getHealth() const override;													///< get current health
+	virtual BodyDamageType getDamageState() const override;
+	virtual void setDamageState( BodyDamageType newState ) override;	///< control damage state directly.  Will adjust hitpoints.
+	virtual void setAflame( Bool setting ) override{}///< This is a major change like a damage state.
 
-	void onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel newLevel, Bool provideFeedback ) { /* nothing */ }
+	virtual void onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel newLevel, Bool provideFeedback ) override { /* nothing */ }
 
-	virtual void setArmorSetFlag(ArmorSetType ast) { /* nothing */ }
-	virtual void clearArmorSetFlag(ArmorSetType ast) { /* nothing */ }
+	virtual void setArmorSetFlag(ArmorSetType ast) override { /* nothing */ }
+	virtual void clearArmorSetFlag(ArmorSetType ast) override { /* nothing */ }
 
-	virtual void internalChangeHealth( Real delta );
+	virtual void internalChangeHealth( Real delta ) override;
 
 private:
 	Bool m_dieCalled;

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/InstantDeathBehavior.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/InstantDeathBehavior.h
@@ -70,6 +70,6 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	// DieModuleInterface
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/JetAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/JetAIUpdate.h
@@ -74,27 +74,27 @@ class JetAIUpdate : public AIUpdateInterface
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( JetAIUpdate, "JetAIUpdate" )
 	MAKE_STANDARD_MODULE_MACRO_WITH_MODULE_DATA( JetAIUpdate, JetAIUpdateModuleData )
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 public:
 
 	JetAIUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onObjectCreated();
-	virtual void onDelete();
+	virtual void onObjectCreated() override;
+	virtual void onDelete() override;
 
- 	virtual void aiDoCommand(const AICommandParms* parms);
-	virtual Bool chooseLocomotorSet(LocomotorSetType wst);
-	virtual void setLocomotorGoalNone();
-	virtual Bool isIdle() const;
+ 	virtual void aiDoCommand(const AICommandParms* parms) override;
+	virtual Bool chooseLocomotorSet(LocomotorSetType wst) override;
+	virtual void setLocomotorGoalNone() override;
+	virtual Bool isIdle() const override;
 
-	virtual Bool isAllowedToMoveAwayFromUnit() const;
-	virtual Bool getSneakyTargetingOffset(Coord3D* offset) const;
-	virtual void addTargeter(ObjectID id, Bool add);
-	virtual Bool isTemporarilyPreventingAimSuccess() const;
-	virtual Bool isDoingGroundMovement() const;
-	virtual void notifyVictimIsDead();
+	virtual Bool isAllowedToMoveAwayFromUnit() const override;
+	virtual Bool getSneakyTargetingOffset(Coord3D* offset) const override;
+	virtual void addTargeter(ObjectID id, Bool add) override;
+	virtual Bool isTemporarilyPreventingAimSuccess() const override;
+	virtual Bool isDoingGroundMovement() const override;
+	virtual void notifyVictimIsDead() override;
 
 	const Coord3D* friend_getProducerLocation() const { return &m_producerLocation; }
 	Real friend_getOutOfAmmoDamagePerSecond() const { return getJetAIUpdateModuleData()->m_outOfAmmoDamagePerSecond; }
@@ -120,17 +120,17 @@ public:
 
 protected:
 
-	virtual AIStateMachine* makeStateMachine();
+	virtual AIStateMachine* makeStateMachine() override;
 
 	virtual void privateFollowPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource, Bool exitProduction );///< follow the path defined by the given array of points
-	virtual void privateFollowPathAppend( const Coord3D *pos, CommandSourceType cmdSource );
-	virtual void privateEnter( Object *obj, CommandSourceType cmdSource );							///< enter the given object
-	virtual void privateGetRepaired( Object *repairDepot, CommandSourceType cmdSource );///< get repaired at repair depot
+	virtual void privateFollowPathAppend( const Coord3D *pos, CommandSourceType cmdSource ) override;
+	virtual void privateEnter( Object *obj, CommandSourceType cmdSource ) override;							///< enter the given object
+	virtual void privateGetRepaired( Object *repairDepot, CommandSourceType cmdSource ) override;///< get repaired at repair depot
 
 	void pruneDeadTargeters();
 	void positionLockon();
 
-	virtual Bool getTreatAsAircraftForLocoDistToGoal() const;
+	virtual Bool getTreatAsAircraftForLocoDistToGoal() const override;
 	Bool isParkedAt(const Object* obj) const;
 
 private:

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/JetSlowDeathBehavior.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/JetSlowDeathBehavior.h
@@ -88,9 +88,9 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	// slow death methods
-	virtual void onDie( const DamageInfo *damageInfo );
-	virtual void beginSlowDeath( const DamageInfo *damageInfo );
-	virtual UpdateSleepTime update();
+	virtual void onDie( const DamageInfo *damageInfo ) override;
+	virtual void beginSlowDeath( const DamageInfo *damageInfo ) override;
+	virtual UpdateSleepTime update() override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/KeepObjectDie.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/KeepObjectDie.h
@@ -50,6 +50,6 @@ public:
 	KeepObjectDie( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/LaserUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/LaserUpdate.h
@@ -109,7 +109,7 @@ public:
 	void setDirty( Bool dirty ) { m_dirty = dirty; }
 	Bool isDirty() const { return m_dirty; }
 
-	virtual void clientUpdate();
+	virtual void clientUpdate() override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/LifetimeUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/LifetimeUpdate.h
@@ -74,7 +74,7 @@ public:
 	void setLifetimeRange( UnsignedInt minFrames, UnsignedInt maxFrames );
 	UnsignedInt getDieFrame() const { return m_dieFrame; }
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 private:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/LocomotorSetUpgrade.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/LocomotorSetUpgrade.h
@@ -50,7 +50,7 @@ public:
 	// virtual destructor prototype defined by MemoryPoolObject
 
 protected:
-	virtual void upgradeImplementation( ); ///< Here's the actual work of Upgrading
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation( ) override; ///< Here's the actual work of Upgrading
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/MaxHealthUpgrade.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/MaxHealthUpgrade.h
@@ -67,7 +67,7 @@ public:
 
 protected:
 
-	virtual void upgradeImplementation(); ///< Here's the actual work of Upgrading
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation() override; ///< Here's the actual work of Upgrading
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/MinefieldBehavior.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/MinefieldBehavior.h
@@ -80,33 +80,33 @@ public:
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_COLLIDE) | (MODULEINTERFACE_DAMAGE) | (MODULEINTERFACE_DIE); }
 
 	// BehaviorModule
-	virtual CollideModuleInterface* getCollide() { return this; }
-	virtual LandMineInterface* getLandMineInterface() { return this; }
-	virtual DamageModuleInterface* getDamage() { return this; }
-	virtual DieModuleInterface* getDie() { return this; }
+	virtual CollideModuleInterface* getCollide() override { return this; }
+	virtual LandMineInterface* getLandMineInterface() override { return this; }
+	virtual DamageModuleInterface* getDamage() override { return this; }
+	virtual DieModuleInterface* getDie() override { return this; }
 
 	// DamageModuleInterface
-	virtual void onDamage( DamageInfo *damageInfo );
-	virtual void onHealing( DamageInfo *damageInfo );
-	virtual void onBodyDamageStateChange(const DamageInfo* damageInfo, BodyDamageType oldState, BodyDamageType newState) { }
+	virtual void onDamage( DamageInfo *damageInfo ) override;
+	virtual void onHealing( DamageInfo *damageInfo ) override;
+	virtual void onBodyDamageStateChange(const DamageInfo* damageInfo, BodyDamageType oldState, BodyDamageType newState) override { }
 
 	// DieModuleInterface
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 	// UpdateModuleInterface
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	// CollideModuleInterface
-	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal );
-	virtual Bool wouldLikeToCollideWith(const Object* other) const { return false; }
-	virtual Bool isHijackedVehicleCrateCollide() const { return false; }
-	virtual Bool isCarBombCrateCollide() const { return false; }
-	virtual Bool isRailroad() const { return false;}
-	virtual Bool isSalvageCrateCollide() const { return false; }
+	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal ) override;
+	virtual Bool wouldLikeToCollideWith(const Object* other) const override { return false; }
+	virtual Bool isHijackedVehicleCrateCollide() const override { return false; }
+	virtual Bool isCarBombCrateCollide() const override { return false; }
+	virtual Bool isRailroad() const override { return false;}
+	virtual Bool isSalvageCrateCollide() const override { return false; }
 
 	// Minefield specific methods
-	virtual void setScootParms(const Coord3D& start, const Coord3D& end);
-	virtual void disarm();
+	virtual void setScootParms(const Coord3D& start, const Coord3D& end) override;
+	virtual void disarm() override;
 
 private:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/MissileAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/MissileAIUpdate.h
@@ -86,17 +86,17 @@ public:
 		KILL_SELF			= 7, ///< Destroy self.
 	};
 
-	virtual ProjectileUpdateInterface* getProjectileUpdateInterface() { return this; }
-	virtual void projectileFireAtObjectOrPosition( const Object *victim, const Coord3D *victimPos, const WeaponTemplate *detWeap, const ParticleSystemTemplate* exhaustSysOverride );
-	virtual void projectileLaunchAtObjectOrPosition(const Object *victim, const Coord3D* victimPos, const Object *launcher, WeaponSlotType wslot, Int specificBarrelToUse, const WeaponTemplate* detWeap, const ParticleSystemTemplate* exhaustSysOverride);
-	virtual Bool projectileHandleCollision( Object *other );
-	virtual Bool projectileIsArmed() const { return m_isArmed; }
-	virtual ObjectID projectileGetLauncherID() const { return m_launcherID; }
+	virtual ProjectileUpdateInterface* getProjectileUpdateInterface() override { return this; }
+	virtual void projectileFireAtObjectOrPosition( const Object *victim, const Coord3D *victimPos, const WeaponTemplate *detWeap, const ParticleSystemTemplate* exhaustSysOverride ) override;
+	virtual void projectileLaunchAtObjectOrPosition(const Object *victim, const Coord3D* victimPos, const Object *launcher, WeaponSlotType wslot, Int specificBarrelToUse, const WeaponTemplate* detWeap, const ParticleSystemTemplate* exhaustSysOverride) override;
+	virtual Bool projectileHandleCollision( Object *other ) override;
+	virtual Bool projectileIsArmed() const override { return m_isArmed; }
+	virtual ObjectID projectileGetLauncherID() const override { return m_launcherID; }
 
-	virtual Bool processCollision(PhysicsBehavior *physics, Object *other); ///< Returns true if the physics collide should apply the force.  Normally not.  jba.
+	virtual Bool processCollision(PhysicsBehavior *physics, Object *other) override; ///< Returns true if the physics collide should apply the force.  Normally not.  jba.
 
-	virtual UpdateSleepTime update();
-	virtual void onDelete();
+	virtual UpdateSleepTime update() override;
+	virtual void onDelete() override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/MissileLauncherBuildingUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/MissileLauncherBuildingUpdate.h
@@ -99,20 +99,20 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	//SpecialPowerUpdateInterface pure virtual implementations
-	virtual Bool initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions );
-	virtual Bool isSpecialAbility() const { return false; }
-	virtual Bool isSpecialPower() const { return true; }
-	virtual Bool isActive() const { return m_doorState != m_timeoutState; }
+	virtual Bool initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions ) override;
+	virtual Bool isSpecialAbility() const override { return false; }
+	virtual Bool isSpecialPower() const override { return true; }
+	virtual Bool isActive() const override { return m_doorState != m_timeoutState; }
 	SpecialPowerTemplate* getTemplate() const;
-	virtual Bool doesSpecialPowerHaveOverridableDestinationActive() const { return false; } //Is it active now?
-	virtual Bool doesSpecialPowerHaveOverridableDestination() const { return false; }	//Does it have it, even if it's not active?
-	virtual void setSpecialPowerOverridableDestination( const Coord3D *loc ) {}
+	virtual Bool doesSpecialPowerHaveOverridableDestinationActive() const override { return false; } //Is it active now?
+	virtual Bool doesSpecialPowerHaveOverridableDestination() const override { return false; }	//Does it have it, even if it's not active?
+	virtual void setSpecialPowerOverridableDestination( const Coord3D *loc ) override {}
 
-	virtual SpecialPowerUpdateInterface* getSpecialPowerUpdateInterface() { return this; }
-	virtual CommandOption getCommandOption() const { return (CommandOption)0; }
+	virtual SpecialPowerUpdateInterface* getSpecialPowerUpdateInterface() override { return this; }
+	virtual CommandOption getCommandOption() const override { return (CommandOption)0; }
 
-	virtual UpdateSleepTime update();	///< Deciding whether or not to make new guys
-	virtual Bool isPowerCurrentlyInUse( const CommandButton *command = nullptr ) const;
+	virtual UpdateSleepTime update() override;	///< Deciding whether or not to make new guys
+	virtual Bool isPowerCurrentlyInUse( const CommandButton *command = nullptr ) const override;
 
 private:
 	enum DoorStateType

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/MobMemberSlavedUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/MobMemberSlavedUpdate.h
@@ -97,14 +97,14 @@ public:
 	MobMemberSlavedUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual SlavedUpdateInterface* getSlavedUpdateInterface() { return this; }// hee hee... behaves just like slavedupdate
+	virtual SlavedUpdateInterface* getSlavedUpdateInterface() override { return this; }// hee hee... behaves just like slavedupdate
 
-	virtual ObjectID getSlaverID() const { return m_slaver; }
-	virtual void onEnslave( const Object *slaver );
-	virtual void onSlaverDie( const DamageInfo *info );
-	virtual void onSlaverDamage( const DamageInfo *info );
-	virtual void onObjectCreated();
-	virtual Bool isSelfTasking() const { return m_isSelfTasking; };
+	virtual ObjectID getSlaverID() const override { return m_slaver; }
+	virtual void onEnslave( const Object *slaver ) override;
+	virtual void onSlaverDie( const DamageInfo *info ) override;
+	virtual void onSlaverDamage( const DamageInfo *info ) override;
+	virtual void onObjectCreated() override;
+	virtual Bool isSelfTasking() const override { return m_isSelfTasking; };
 
 	void doCatchUpLogic( Coord3D *pinnedPosition );
 
@@ -112,7 +112,7 @@ public:
 	MobStates getMobState() { return m_mobState; };
 
 
-	virtual UpdateSleepTime update();	///< Deciding whether or not to make new guys
+	virtual UpdateSleepTime update() override;	///< Deciding whether or not to make new guys
 
 private:
 	void startSlavedEffects( const Object *slaver );	///< We have been marked as Slaved, so we can't be selected or move too far or other stuff

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/MobNexusContain.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/MobNexusContain.h
@@ -73,25 +73,25 @@ public:
 																																								// lorenzen add a MobMemberInterface
 																																								// lorenzen add a MobMemberInterface
 																																								// lorenzen add a MobMemberInterface
-	virtual TransportPassengerInterface* getTransportPassengerInterface() { return this; }// lorenzen add a MobMemberInterface
+	virtual TransportPassengerInterface* getTransportPassengerInterface() override { return this; }// lorenzen add a MobMemberInterface
 																																								// lorenzen add a MobMemberInterface
 																																								// lorenzen add a MobMemberInterface
 																																								// lorenzen add a MobMemberInterface
-	virtual Bool isValidContainerFor( const Object* obj, Bool checkCapacity) const;
+	virtual Bool isValidContainerFor( const Object* obj, Bool checkCapacity) const override;
 
-	virtual void onContaining( Object *obj );		///< object now contains 'obj'
-	virtual void onRemoving( Object *obj );			///< object no longer contains 'obj'
-	virtual UpdateSleepTime update();							///< called once per frame
+	virtual void onContaining( Object *obj ) override;		///< object now contains 'obj'
+	virtual void onRemoving( Object *obj ) override;			///< object no longer contains 'obj'
+	virtual UpdateSleepTime update() override;							///< called once per frame
 
-	virtual Int getContainMax() const;
+	virtual Int getContainMax() const override;
 
-	virtual void onObjectCreated();
-	virtual Int getExtraSlotsInUse() { return m_extraSlotsInUse; }
+	virtual void onObjectCreated() override;
+	virtual Int getExtraSlotsInUse() override { return m_extraSlotsInUse; }
 
-	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject );					///< All types can answer if they are free to exit or not, and you can ask about a specific guy or just exit anything in general
-	virtual void unreserveDoorForExit( ExitDoorType exitDoor );
+	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject ) override;					///< All types can answer if they are free to exit or not, and you can ask about a specific guy or just exit anything in general
+	virtual void unreserveDoorForExit( ExitDoorType exitDoor ) override;
 
-	virtual Bool tryToEvacuate( Bool exposeStealthedUnits ); ///< Will try to kick everybody out with game checks, and will return whether anyone made it
+	virtual Bool tryToEvacuate( Bool exposeStealthedUnits ) override; ///< Will try to kick everybody out with game checks, and will return whether anyone made it
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/MoneyCrateCollide.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/MoneyCrateCollide.h
@@ -76,5 +76,5 @@ public:
 protected:
 
 	/// This is the game logic execution function that all real CrateCollides will implement
-	virtual Bool executeCrateBehavior( Object *other );
+	virtual Bool executeCrateBehavior( Object *other ) override;
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/NeutronMissileSlowDeathUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/NeutronMissileSlowDeathUpdate.h
@@ -96,7 +96,7 @@ public:
 	NeutronMissileSlowDeathBehavior( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual UpdateSleepTime update();				 ///< the update call
+	virtual UpdateSleepTime update() override;				 ///< the update call
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/NeutronMissileUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/NeutronMissileUpdate.h
@@ -80,12 +80,12 @@ public:
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_DIE); }
 
 	// BehaviorModule
-	virtual DieModuleInterface* getDie() { return this; }
+	virtual DieModuleInterface* getDie() override { return this; }
 
 	// DieModuleInterface
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
-	virtual ProjectileUpdateInterface* getProjectileUpdateInterface() { return this; }
+	virtual ProjectileUpdateInterface* getProjectileUpdateInterface() override { return this; }
 
 	enum MissileStateType
 	{
@@ -95,15 +95,15 @@ public:
 		DEAD
 	};
 
-	virtual void projectileLaunchAtObjectOrPosition(const Object *victim, const Coord3D* victimPos, const Object *launcher, WeaponSlotType wslot, Int specificBarrelToUse, const WeaponTemplate* detWeap, const ParticleSystemTemplate* exhaustSysOverride);
-	virtual void projectileFireAtObjectOrPosition( const Object *victim, const Coord3D *victimPos, const WeaponTemplate *detWeap, const ParticleSystemTemplate* exhaustSysOverride );
-	virtual Bool projectileIsArmed() const { return m_isArmed; }											///< return true if the missile is armed and ready to explode
-	virtual ObjectID projectileGetLauncherID() const { return m_launcherID; }				///< Return firer of missile. Returns 0 if not yet fired.
-	virtual Bool projectileHandleCollision( Object *other );
+	virtual void projectileLaunchAtObjectOrPosition(const Object *victim, const Coord3D* victimPos, const Object *launcher, WeaponSlotType wslot, Int specificBarrelToUse, const WeaponTemplate* detWeap, const ParticleSystemTemplate* exhaustSysOverride) override;
+	virtual void projectileFireAtObjectOrPosition( const Object *victim, const Coord3D *victimPos, const WeaponTemplate *detWeap, const ParticleSystemTemplate* exhaustSysOverride ) override;
+	virtual Bool projectileIsArmed() const override { return m_isArmed; }											///< return true if the missile is armed and ready to explode
+	virtual ObjectID projectileGetLauncherID() const override { return m_launcherID; }				///< Return firer of missile. Returns 0 if not yet fired.
+	virtual Bool projectileHandleCollision( Object *other ) override;
 	virtual const Coord3D *getVelocity() const { return &m_vel; }		///< get current velocity
 
-	virtual UpdateSleepTime update();
-	virtual void onDelete();
+	virtual UpdateSleepTime update() override;
+	virtual void onDelete() override;
 
 private:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/OCLSpecialPower.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/OCLSpecialPower.h
@@ -87,9 +87,9 @@ public:
 	OCLSpecialPower( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool object
 
-	virtual void doSpecialPower( UnsignedInt commandOptions );
-	virtual void doSpecialPowerAtObject( Object *obj, UnsignedInt commandOptions );
-	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions );
+	virtual void doSpecialPower( UnsignedInt commandOptions ) override;
+	virtual void doSpecialPowerAtObject( Object *obj, UnsignedInt commandOptions ) override;
+	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions ) override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/OCLUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/OCLUpdate.h
@@ -64,7 +64,7 @@ public:
 	OCLUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	Real getCountdownPercent() const; ///< goes from 0% to 100%
 	UnsignedInt getRemainingFrames() const; ///< For feedback display

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/ObjectCreationUpgrade.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/ObjectCreationUpgrade.h
@@ -66,7 +66,7 @@ public:
 	ObjectCreationUpgrade( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype defined by MemoryPoolObject
 
-	void onDelete() override;																///< we have some work to do when this module goes away
+	virtual void onDelete() override;																///< we have some work to do when this module goes away
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/ObjectCreationUpgrade.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/ObjectCreationUpgrade.h
@@ -66,11 +66,11 @@ public:
 	ObjectCreationUpgrade( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype defined by MemoryPoolObject
 
-	void onDelete();																///< we have some work to do when this module goes away
+	void onDelete() override;																///< we have some work to do when this module goes away
 
 protected:
 
-	virtual void upgradeImplementation(); ///< Here's the actual work of Upgrading
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation() override; ///< Here's the actual work of Upgrading
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/ObjectDefectionHelper.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/ObjectDefectionHelper.h
@@ -68,10 +68,10 @@ public:
 	}
 	// virtual destructor prototype provided by memory pool object
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	// Disabled conditions to process -- defection helper must ignore all disabled types.
-	virtual DisabledMaskType getDisabledTypesToProcess() const { return DISABLEDMASK_ALL; }
+	virtual DisabledMaskType getDisabledTypesToProcess() const override { return DISABLEDMASK_ALL; }
 
 	// specific to this class.
 	void startDefectionTimer(UnsignedInt numFrames, Bool withDefectorFX = TRUE);

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/ObjectHelper.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/ObjectHelper.h
@@ -55,7 +55,7 @@ public:
 	}
 
 	// inherited from UpdateModuleInterface
-	virtual UpdateSleepTime update() override = 0;
+	virtual UpdateSleepTime update() = 0;
 
 	// custom to this class.
 	void sleepUntil(UnsignedInt when);

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/ObjectHelper.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/ObjectHelper.h
@@ -42,9 +42,9 @@ class ObjectHelper : public UpdateModule
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 public:
 
@@ -55,7 +55,7 @@ public:
 	}
 
 	// inherited from UpdateModuleInterface
-	virtual UpdateSleepTime update() = 0;
+	virtual UpdateSleepTime update() override = 0;
 
 	// custom to this class.
 	void sleepUntil(UnsignedInt when);

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/ObjectRepulsorHelper.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/ObjectRepulsorHelper.h
@@ -52,6 +52,6 @@ public:
 	ObjectRepulsorHelper( Thing *thing, const ModuleData *modData ) : ObjectHelper( thing, modData ) { }
 	// virtual destructor prototype provided by memory pool object
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/ObjectSMCHelper.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/ObjectSMCHelper.h
@@ -52,6 +52,6 @@ public:
 	ObjectSMCHelper( Thing *thing, const ModuleData *modData ) : ObjectHelper( thing, modData ) { }
 	// virtual destructor prototype provided by memory pool object
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/ObjectWeaponStatusHelper.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/ObjectWeaponStatusHelper.h
@@ -56,7 +56,7 @@ protected:
 		user update modules, so it redefines this. Please don't redefine this
 		for other modules without very careful deliberation. (srj)
 	*/
-	virtual SleepyUpdatePhase getUpdatePhase() const
+	virtual SleepyUpdatePhase getUpdatePhase() const override
 	{
 		return PHASE_FINAL;
 	}
@@ -71,7 +71,7 @@ public:
 	}
 	// virtual destructor prototype provided by memory pool object
 
-	virtual UpdateSleepTime update()
+	virtual UpdateSleepTime update() override
 	{
 		getObject()->adjustModelConditionForWeaponStatus();
 		// unlike other helpers, this one must run every frame.

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/OpenContain.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/OpenContain.h
@@ -91,107 +91,107 @@ public:
 	OpenContain( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual ContainModuleInterface* getContain() { return this; }
-	virtual CollideModuleInterface* getCollide() { return this; }
-	virtual DieModuleInterface* getDie() { return this; }
-	virtual DamageModuleInterface* getDamage() { return this; }
+	virtual ContainModuleInterface* getContain() override { return this; }
+	virtual CollideModuleInterface* getCollide() override { return this; }
+	virtual DieModuleInterface* getDie() override { return this; }
+	virtual DamageModuleInterface* getDamage() override { return this; }
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_CONTAIN) | (MODULEINTERFACE_COLLIDE) | (MODULEINTERFACE_DIE) | (MODULEINTERFACE_DAMAGE); }
 
-	virtual void onDie( const DamageInfo *damageInfo );  ///< the die callback
-	virtual void onDelete();	///< Last possible moment cleanup
-	virtual void onCapture( Player *oldOwner, Player *newOwner ){}
+	virtual void onDie( const DamageInfo *damageInfo ) override;  ///< the die callback
+	virtual void onDelete() override;	///< Last possible moment cleanup
+	virtual void onCapture( Player *oldOwner, Player *newOwner ) override {}
 
 	// CollideModuleInterface
-	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal );
-	virtual Bool wouldLikeToCollideWith(const Object* other) const { return false; }
-	virtual Bool isCarBombCrateCollide() const { return false; }
-	virtual Bool isHijackedVehicleCrateCollide() const { return false; }
-	virtual Bool isRailroad() const { return false;}
-	virtual Bool isSalvageCrateCollide() const { return false; }
+	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal ) override;
+	virtual Bool wouldLikeToCollideWith(const Object* other) const override { return false; }
+	virtual Bool isCarBombCrateCollide() const override { return false; }
+	virtual Bool isHijackedVehicleCrateCollide() const override { return false; }
+	virtual Bool isRailroad() const override { return false;}
+	virtual Bool isSalvageCrateCollide() const override { return false; }
 
 	// UpdateModule
-	virtual UpdateSleepTime update();				///< called once per frame
+	virtual UpdateSleepTime update() override;				///< called once per frame
 
 	// ContainModuleInterface
-	virtual OpenContain *asOpenContain() { return this; }  ///< treat as open container
+	virtual OpenContain *asOpenContain() override { return this; }  ///< treat as open container
 
 	// DamageModuleInterface
-	virtual void onDamage( DamageInfo *damageInfo ){};	///< damage callback
-	virtual void onHealing( DamageInfo *damageInfo ){};	///< healing callback
+	virtual void onDamage( DamageInfo *damageInfo ) override {};	///< damage callback
+	virtual void onHealing( DamageInfo *damageInfo ) override {};	///< healing callback
 	virtual void onBodyDamageStateChange( const DamageInfo* damageInfo,
 																				BodyDamageType oldState,
-																				BodyDamageType newState){};  ///< state change callback
+																				BodyDamageType newState) override {};  ///< state change callback
 
 
 	// our object changed position... react as appropriate.
-	virtual void containReactToTransformChange();
+	virtual void containReactToTransformChange() override;
 
-	virtual Bool calcBestGarrisonPosition( Coord3D *sourcePos, const Coord3D *targetPos ) { return FALSE; }
-	virtual Bool attemptBestFirePointPosition( Object *source, Weapon *weapon, Object *victim ) { return FALSE; }
-	virtual Bool attemptBestFirePointPosition( Object *source, Weapon *weapon, const Coord3D *targetPos ) { return FALSE; }
+	virtual Bool calcBestGarrisonPosition( Coord3D *sourcePos, const Coord3D *targetPos ) override { return FALSE; }
+	virtual Bool attemptBestFirePointPosition( Object *source, Weapon *weapon, Object *victim ) override { return FALSE; }
+	virtual Bool attemptBestFirePointPosition( Object *source, Weapon *weapon, const Coord3D *targetPos ) override { return FALSE; }
 
 	///< if my object gets selected, then my visible passengers should, too
 	///< this gets called from
-	virtual void clientVisibleContainedFlashAsSelected() {};
+	virtual void clientVisibleContainedFlashAsSelected() override {};
 
-	virtual const Player* getApparentControllingPlayer(const Player* observingPlayer) const { return nullptr; }
-	virtual void recalcApparentControllingPlayer() { }
+	virtual const Player* getApparentControllingPlayer(const Player* observingPlayer) const override { return nullptr; }
+	virtual void recalcApparentControllingPlayer() override { }
 
-	virtual void onContaining( Object *obj );		///< object now contains 'obj'
-	virtual void onRemoving( Object *obj );			///< object no longer contains 'obj'
-	virtual void onSelling();///< Container is being sold.  Open responds by kicking people out
+	virtual void onContaining( Object *obj ) override;		///< object now contains 'obj'
+	virtual void onRemoving( Object *obj ) override;			///< object no longer contains 'obj'
+	virtual void onSelling() override;///< Container is being sold.  Open responds by kicking people out
 
-	virtual void orderAllPassengersToExit( CommandSourceType commandSource ); ///< All of the smarts of exiting are in the passenger's AIExit. removeAllFrommContain is a last ditch system call, this is the game Evacuate
-	virtual void markAllPassengersDetected();										///< Cool game stuff got added to the system calls since this layer didn't exist, so this regains that functionality
+	virtual void orderAllPassengersToExit( CommandSourceType commandSource ) override; ///< All of the smarts of exiting are in the passenger's AIExit. removeAllFrommContain is a last ditch system call, this is the game Evacuate
+	virtual void markAllPassengersDetected() override;										///< Cool game stuff got added to the system calls since this layer didn't exist, so this regains that functionality
 
 	// default OpenContain has unlimited capacity...!
-	virtual Bool isValidContainerFor(const Object* obj, Bool checkCapacity) const;
-	virtual void addToContain( Object *obj );				///< add 'obj' to contain list
+	virtual Bool isValidContainerFor(const Object* obj, Bool checkCapacity) const override;
+	virtual void addToContain( Object *obj ) override;				///< add 'obj' to contain list
 	virtual void addToContainList( Object *obj );		///< The part of AddToContain that inheritors can override (Can't do whole thing because of all the private stuff involved)
-	virtual void removeFromContain( Object *obj, Bool exposeStealthUnits = FALSE );	///< remove 'obj' from contain list
-	virtual void removeAllContained( Bool exposeStealthUnits = FALSE );				///< remove all objects on contain list
-	virtual Bool isEnclosingContainerFor( const Object *obj ) const;	///< Does this type of Contain Visibly enclose its contents?
-	virtual Bool isPassengerAllowedToFire() const;	///< Hey, can I shoot out of this container?
-	virtual void setOverrideDestination( const Coord3D * ){} ///< Instead of falling peacefully towards a clear spot, I will now aim here
-	virtual Bool isDisplayedOnControlBar() const {return FALSE;}///< Does this container display its contents on the ControlBar?
-	virtual Int getExtraSlotsInUse() { return 0; }
-	virtual Bool isKickOutOnCapture(){ return TRUE; }///< By default, yes, all contain modules kick passengers out on capture
+	virtual void removeFromContain( Object *obj, Bool exposeStealthUnits = FALSE ) override;	///< remove 'obj' from contain list
+	virtual void removeAllContained( Bool exposeStealthUnits = FALSE ) override;				///< remove all objects on contain list
+	virtual Bool isEnclosingContainerFor( const Object *obj ) const override;	///< Does this type of Contain Visibly enclose its contents?
+	virtual Bool isPassengerAllowedToFire() const override;	///< Hey, can I shoot out of this container?
+	virtual void setOverrideDestination( const Coord3D * ) override {} ///< Instead of falling peacefully towards a clear spot, I will now aim here
+	virtual Bool isDisplayedOnControlBar() const override {return FALSE;}///< Does this container display its contents on the ControlBar?
+	virtual Int getExtraSlotsInUse() override { return 0; }
+	virtual Bool isKickOutOnCapture() override { return TRUE; }///< By default, yes, all contain modules kick passengers out on capture
 
 	// contain list access
-	virtual void iterateContained( ContainIterateFunc func, void *userData, Bool reverse );
-	virtual UnsignedInt getContainCount() const { return m_containListSize; }
-	virtual const ContainedItemsList* getContainedItemsList() const { return &m_containList; }
-	virtual const Object *friend_getRider() const{return nullptr;} ///< Damn.  The draw order dependency bug for riders means that our draw module needs to cheat to get around it.
-	virtual Real getContainedItemsMass() const;
-	virtual UnsignedInt getStealthUnitsContained() const { return m_stealthUnitsContained; }
-	virtual UnsignedInt getHeroUnitsContained() const { return m_heroUnitsContained; }
+	virtual void iterateContained( ContainIterateFunc func, void *userData, Bool reverse ) override;
+	virtual UnsignedInt getContainCount() const override { return m_containListSize; }
+	virtual const ContainedItemsList* getContainedItemsList() const override { return &m_containList; }
+	virtual const Object *friend_getRider() const override {return nullptr;} ///< Damn.  The draw order dependency bug for riders means that our draw module needs to cheat to get around it.
+	virtual Real getContainedItemsMass() const override;
+	virtual UnsignedInt getStealthUnitsContained() const override { return m_stealthUnitsContained; }
+	virtual UnsignedInt getHeroUnitsContained() const override { return m_heroUnitsContained; }
 
-	virtual PlayerMaskType getPlayerWhoEntered() const { return m_playerEnteredMask; }
+	virtual PlayerMaskType getPlayerWhoEntered() const override { return m_playerEnteredMask; }
 
-	virtual Int getContainMax() const;
+	virtual Int getContainMax() const override;
 
 	// ExitInterface
-	virtual Bool isExitBusy() const {return FALSE;}	///< Contain style exiters are getting the ability to space out exits, so ask this before reserveDoor as a kind of no-commitment check.
-	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject ) { return DOOR_1; }
-	virtual void exitObjectViaDoor( Object *newObj, ExitDoorType exitDoor );
-	virtual void exitObjectInAHurry( Object *newObj );
+	virtual Bool isExitBusy() const override {return FALSE;}	///< Contain style exiters are getting the ability to space out exits, so ask this before reserveDoor as a kind of no-commitment check.
+	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject ) override { return DOOR_1; }
+	virtual void exitObjectViaDoor( Object *newObj, ExitDoorType exitDoor ) override;
+	virtual void exitObjectInAHurry( Object *newObj ) override;
 
 
-	virtual void unreserveDoorForExit( ExitDoorType exitDoor ) { /*nothing*/ }
-	virtual void exitObjectByBudding( Object *newObj, Object *budHost ) { return; };
+	virtual void unreserveDoorForExit( ExitDoorType exitDoor ) override { /*nothing*/ }
+	virtual void exitObjectByBudding( Object *newObj, Object *budHost ) override { return; };
 
-	virtual void setRallyPoint( const Coord3D *pos );				///< define a "rally point" for units to move towards
-	virtual const Coord3D *getRallyPoint() const;			///< define a "rally point" for units to move towards
-	virtual Bool getExitPosition(Coord3D& exitPosition ) const { return FALSE; };					///< access to the "Door" position of the production object
-	virtual Bool getNaturalRallyPoint( Coord3D& rallyPoint, Bool offset = TRUE ) const;			///< get the natural "rally point" for units to move towards
+	virtual void setRallyPoint( const Coord3D *pos ) override;				///< define a "rally point" for units to move towards
+	virtual const Coord3D *getRallyPoint() const override;			///< define a "rally point" for units to move towards
+	virtual Bool getExitPosition(Coord3D& exitPosition ) const override { return FALSE; };					///< access to the "Door" position of the production object
+	virtual Bool getNaturalRallyPoint( Coord3D& rallyPoint, Bool offset = TRUE ) const override;			///< get the natural "rally point" for units to move towards
 
-	virtual ExitInterface* getContainExitInterface() { return this; }
+	virtual ExitInterface* getContainExitInterface() override { return this; }
 
-	virtual Bool isGarrisonable() const { return false; }		///< can this unit be Garrisoned? (ick)
-	virtual Bool isHealContain() const { return false; } ///< true when container only contains units while healing (not a transport!)
-	virtual Bool isTunnelContain() const { return FALSE; }
-	virtual Bool isSpecialZeroSlotContainer() const { return false; }
-	virtual Bool isImmuneToClearBuildingAttacks() const { return true; }
+	virtual Bool isGarrisonable() const override { return false; }		///< can this unit be Garrisoned? (ick)
+	virtual Bool isHealContain() const override { return false; } ///< true when container only contains units while healing (not a transport!)
+	virtual Bool isTunnelContain() const override { return FALSE; }
+	virtual Bool isSpecialZeroSlotContainer() const override { return false; }
+	virtual Bool isImmuneToClearBuildingAttacks() const override { return true; }
 
 	/**
 		this is used for containers that must do something to allow people to enter or exit...
@@ -199,14 +199,14 @@ public:
 		when something is in the enter state, and wants=ENTS_NOTHING when the unit has
 		either entered, or given up...
 	*/
-	virtual void onObjectWantsToEnterOrExit(Object* obj, ObjectEnterExitType wants);
+	virtual void onObjectWantsToEnterOrExit(Object* obj, ObjectEnterExitType wants) override;
 
 	// returns true iff there are objects currently waiting to enter.
-	virtual Bool hasObjectsWantingToEnterOrExit() const;
+	virtual Bool hasObjectsWantingToEnterOrExit() const override;
 
-	virtual void processDamageToContained(); ///< Do our % damage to units now.
+	virtual void processDamageToContained() override; ///< Do our % damage to units now.
 
-	virtual void enableLoadSounds( Bool enable ) { m_loadSoundsEnabled = enable; }
+	virtual void enableLoadSounds( Bool enable ) override { m_loadSoundsEnabled = enable; }
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/OverchargeBehavior.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/OverchargeBehavior.h
@@ -81,30 +81,30 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	// interface housekeeping
-	virtual OverchargeBehaviorInterface* getOverchargeBehaviorInterface() { return this; }
+	virtual OverchargeBehaviorInterface* getOverchargeBehaviorInterface() override { return this; }
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_DAMAGE); }
 
 	// BehaviorModule
-	virtual DamageModuleInterface* getDamage() { return this; }
+	virtual DamageModuleInterface* getDamage() override { return this; }
 
 	// UpdateModuleInterface
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	// DamageModuleInterface
-	virtual void onDamage( DamageInfo *damageInfo );
-	virtual void onHealing( DamageInfo *damageInfo ) { }
+	virtual void onDamage( DamageInfo *damageInfo ) override;
+	virtual void onHealing( DamageInfo *damageInfo ) override { }
 	virtual void onBodyDamageStateChange( const DamageInfo *damageInfo,
 																				BodyDamageType oldState,
-																				BodyDamageType newState ) { }
+																				BodyDamageType newState ) override { }
 
 
 	// specific methods
-	virtual void toggle();						///< toggle overcharge on/off
-	virtual void enable( Bool enable );			///< turn overcharge on/off
-	virtual Bool isOverchargeActive() { return m_overchargeActive; }
+	virtual void toggle() override;						///< toggle overcharge on/off
+	virtual void enable( Bool enable ) override;			///< turn overcharge on/off
+	virtual Bool isOverchargeActive() override { return m_overchargeActive; }
 
-	void onDelete();																///< we have some work to do when this module goes away
-	void onCapture( Player *oldOwner, Player *newOwner );	///< object containing upgrade has changed teams
+	void onDelete() override;																///< we have some work to do when this module goes away
+	void onCapture( Player *oldOwner, Player *newOwner ) override;	///< object containing upgrade has changed teams
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/OverchargeBehavior.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/OverchargeBehavior.h
@@ -103,8 +103,8 @@ public:
 	virtual void enable( Bool enable ) override;			///< turn overcharge on/off
 	virtual Bool isOverchargeActive() override { return m_overchargeActive; }
 
-	void onDelete() override;																///< we have some work to do when this module goes away
-	void onCapture( Player *oldOwner, Player *newOwner ) override;	///< object containing upgrade has changed teams
+	virtual void onDelete() override;																///< we have some work to do when this module goes away
+	virtual void onCapture( Player *oldOwner, Player *newOwner ) override;	///< object containing upgrade has changed teams
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/OverlordContain.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/OverlordContain.h
@@ -51,48 +51,48 @@ class OverlordContain : public TransportContain
 
 	virtual void onBodyDamageStateChange( const DamageInfo* damageInfo,
 																				BodyDamageType oldState,
-																				BodyDamageType newState);  ///< state change callback
+																				BodyDamageType newState) override;  ///< state change callback
 public:
 
 	OverlordContain( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual OpenContain *asOpenContain() { return this; }  ///< treat as open container
-	virtual Bool isGarrisonable() const;	///< can this unit be Garrisoned? (ick)
-	virtual Bool isHealContain() const { return false; } ///< true when container only contains units while healing (not a transport!)
-	virtual Bool isImmuneToClearBuildingAttacks() const { return true; }
+	virtual OpenContain *asOpenContain() override { return this; }  ///< treat as open container
+	virtual Bool isGarrisonable() const override;	///< can this unit be Garrisoned? (ick)
+	virtual Bool isHealContain() const override { return false; } ///< true when container only contains units while healing (not a transport!)
+	virtual Bool isImmuneToClearBuildingAttacks() const override { return true; }
 
-	virtual void onDie( const DamageInfo *damageInfo );  ///< the die callback
-	virtual void onDelete();	///< Last possible moment cleanup
-	virtual void onCapture( Player *oldOwner, Player *newOwner ); // Our main guy goes with us, but our redirected contain needs to do his thing too
+	virtual void onDie( const DamageInfo *damageInfo ) override;  ///< the die callback
+	virtual void onDelete() override;	///< Last possible moment cleanup
+	virtual void onCapture( Player *oldOwner, Player *newOwner ) override; // Our main guy goes with us, but our redirected contain needs to do his thing too
 
 	// Contain stuff we need to override to redirect on a condition
-	virtual void onContaining( Object *obj );		///< object now contains 'obj'
-	virtual void onRemoving( Object *obj );			///< object no longer contains 'obj'
+	virtual void onContaining( Object *obj ) override;		///< object now contains 'obj'
+	virtual void onRemoving( Object *obj ) override;			///< object no longer contains 'obj'
 
-	virtual Bool isValidContainerFor(const Object* obj, Bool checkCapacity) const;
-	virtual void addToContain( Object *obj );				///< add 'obj' to contain list
+	virtual Bool isValidContainerFor(const Object* obj, Bool checkCapacity) const override;
+	virtual void addToContain( Object *obj ) override;				///< add 'obj' to contain list
 	virtual void addToContainList( Object *obj );		///< The part of AddToContain that inheritors can override (Can't do whole thing because of all the private stuff involved)
-	virtual void removeFromContain( Object *obj, Bool exposeStealthUnits = FALSE );	///< remove 'obj' from contain list
-	virtual void removeAllContained( Bool exposeStealthUnits = FALSE );				///< remove all objects on contain list
-	virtual Bool isEnclosingContainerFor( const Object *obj ) const;	///< Does this type of Contain Visibly enclose its contents?
-	virtual Bool isDisplayedOnControlBar() const ;///< Does this container display its contents on the ControlBar?
-	virtual Bool isKickOutOnCapture();// The bunker may want to, but we certainly don't
+	virtual void removeFromContain( Object *obj, Bool exposeStealthUnits = FALSE ) override;	///< remove 'obj' from contain list
+	virtual void removeAllContained( Bool exposeStealthUnits = FALSE ) override;				///< remove all objects on contain list
+	virtual Bool isEnclosingContainerFor( const Object *obj ) const override;	///< Does this type of Contain Visibly enclose its contents?
+	virtual Bool isDisplayedOnControlBar() const override;///< Does this container display its contents on the ControlBar?
+	virtual Bool isKickOutOnCapture() override;// The bunker may want to, but we certainly don't
 
 	// contain list access
-	virtual void iterateContained( ContainIterateFunc func, void *userData, Bool reverse );
-	virtual UnsignedInt getContainCount() const;
-	virtual Int getContainMax() const;
-	virtual const ContainedItemsList* getContainedItemsList() const;
+	virtual void iterateContained( ContainIterateFunc func, void *userData, Bool reverse ) override;
+	virtual UnsignedInt getContainCount() const override;
+	virtual Int getContainMax() const override;
+	virtual const ContainedItemsList* getContainedItemsList() const override;
 
 	// Friend for our Draw module only.
-	virtual const Object *friend_getRider() const; ///< Damn.  The draw order dependency bug for riders means that our draw module needs to cheat to get around it.
+	virtual const Object *friend_getRider() const override; ///< Damn.  The draw order dependency bug for riders means that our draw module needs to cheat to get around it.
 
 	///< if my object gets selected, then my visible passengers should, too
 	///< this gets called from
-	virtual void clientVisibleContainedFlashAsSelected();
+	virtual void clientVisibleContainedFlashAsSelected() override;
 
-	virtual Bool getContainerPipsToShow(Int& numTotal, Int& numFull);
+	virtual Bool getContainerPipsToShow(Int& numTotal, Int& numFull) override;
 
 private:
 	/**< An empty overlord is a container, but a full one redirects calls to its passengers.  If this returns null,

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/ParachuteContain.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/ParachuteContain.h
@@ -60,28 +60,28 @@ public:
 	ParachuteContain( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onDrawableBoundToObject();
+	virtual void onDrawableBoundToObject() override;
 
-	virtual Bool isValidContainerFor( const Object* obj, bool checkCapacity) const;
-	virtual Bool isEnclosingContainerFor( const Object *obj ) const { return FALSE; }	///< Does this type of Contain Visibly enclose its contents?
-	virtual Bool isSpecialZeroSlotContainer() const { return true; }
+	virtual Bool isValidContainerFor( const Object* obj, bool checkCapacity) const override;
+	virtual Bool isEnclosingContainerFor( const Object *obj ) const override { return FALSE; }	///< Does this type of Contain Visibly enclose its contents?
+	virtual Bool isSpecialZeroSlotContainer() const override { return true; }
 
-	virtual void onContaining( Object *obj );		///< object now contains 'obj'
-	virtual void onRemoving( Object *obj );			///< object no longer contains 'obj'
+	virtual void onContaining( Object *obj ) override;		///< object now contains 'obj'
+	virtual void onRemoving( Object *obj ) override;			///< object no longer contains 'obj'
 
-	virtual UpdateSleepTime update();							///< called once per frame
+	virtual UpdateSleepTime update() override;							///< called once per frame
 
-	virtual void containReactToTransformChange();
+	virtual void containReactToTransformChange() override;
 
-	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal );
-	virtual void onDie( const DamageInfo * damageInfo );
+	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal ) override;
+	virtual void onDie( const DamageInfo * damageInfo ) override;
 
-	virtual void setOverrideDestination( const Coord3D *dest ); ///< Instead of falling peacefully towards a clear spot, I will now aim here
+	virtual void setOverrideDestination( const Coord3D *dest ) override; ///< Instead of falling peacefully towards a clear spot, I will now aim here
 
 protected:
 
 	virtual Bool isFullyEnclosingContainer() const { return false; }
-	virtual void positionContainedObjectsRelativeToContainer();
+	virtual void positionContainedObjectsRelativeToContainer() override;
 
 private:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/ParkingPlaceBehavior.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/ParkingPlaceBehavior.h
@@ -98,44 +98,44 @@ public:
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_DIE); }
 
 	// BehaviorModule
-	virtual DieModuleInterface *getDie() { return this; }
-	virtual ParkingPlaceBehaviorInterface* getParkingPlaceBehaviorInterface() { return this; }
-	virtual ExitInterface* getUpdateExitInterface() { return this; }
+	virtual DieModuleInterface *getDie() override { return this; }
+	virtual ParkingPlaceBehaviorInterface* getParkingPlaceBehaviorInterface() override { return this; }
+	virtual ExitInterface* getUpdateExitInterface() override { return this; }
 
 	// ExitInterface
-	virtual Bool isExitBusy() const {return FALSE;}	///< Contain style exiters are getting the ability to space out exits, so ask this before reserveDoor as a kind of no-commitment check.
-	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject );
-	virtual void exitObjectViaDoor( Object *newObj, ExitDoorType exitDoor );
-	virtual void unreserveDoorForExit( ExitDoorType exitDoor );
-	virtual void exitObjectByBudding( Object *newObj, Object *budHost ) { return; }
+	virtual Bool isExitBusy() const override {return FALSE;}	///< Contain style exiters are getting the ability to space out exits, so ask this before reserveDoor as a kind of no-commitment check.
+	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject ) override;
+	virtual void exitObjectViaDoor( Object *newObj, ExitDoorType exitDoor ) override;
+	virtual void unreserveDoorForExit( ExitDoorType exitDoor ) override;
+	virtual void exitObjectByBudding( Object *newObj, Object *budHost ) override { return; }
 
-	virtual Bool getExitPosition( Coord3D& rallyPoint ) const;
-	virtual Bool getNaturalRallyPoint( Coord3D& rallyPoint, Bool offset = TRUE ) const;
-	virtual void setRallyPoint( const Coord3D *pos );			///< define a "rally point" for units to move towards
-	virtual const Coord3D *getRallyPoint() const;			///< define a "rally point" for units to move towards
+	virtual Bool getExitPosition( Coord3D& rallyPoint ) const override;
+	virtual Bool getNaturalRallyPoint( Coord3D& rallyPoint, Bool offset = TRUE ) const override;
+	virtual void setRallyPoint( const Coord3D *pos ) override;			///< define a "rally point" for units to move towards
+	virtual const Coord3D *getRallyPoint() const override;			///< define a "rally point" for units to move towards
 
 	// UpdateModule
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	// DieModule
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 	// ParkingPlaceBehaviorInterface
-	Bool shouldReserveDoorWhenQueued(const ThingTemplate* thing) const;
-	Bool hasAvailableSpaceFor(const ThingTemplate* thing) const;
-	Bool hasReservedSpace(ObjectID id) const;
-	Bool reserveSpace(ObjectID id, Real parkingOffset, PPInfo* info);
-	void releaseSpace(ObjectID id);
-	Bool reserveRunway(ObjectID id, Bool forLanding);
-	void releaseRunway(ObjectID id);
-	virtual Int getRunwayIndex(ObjectID id);
-	Int getRunwayCount() const { return m_runways.size(); }
-	ObjectID getRunwayReservation(Int r);
-	void transferRunwayReservationToNextInLineForTakeoff(ObjectID id);
-	Real getApproachHeight() const { return getParkingPlaceBehaviorModuleData()->m_approachHeight; }
-	void setHealee(Object* healee, Bool add);
-	void killAllParkedUnits();
-	void defectAllParkedUnits(Team* newTeam, UnsignedInt detectionTime);
+	virtual Bool shouldReserveDoorWhenQueued(const ThingTemplate* thing) const override;
+	virtual Bool hasAvailableSpaceFor(const ThingTemplate* thing) const override;
+	virtual Bool hasReservedSpace(ObjectID id) const override;
+	virtual Bool reserveSpace(ObjectID id, Real parkingOffset, PPInfo* info) override;
+	virtual void releaseSpace(ObjectID id) override;
+	virtual Bool reserveRunway(ObjectID id, Bool forLanding) override;
+	virtual void releaseRunway(ObjectID id) override;
+	virtual Int getRunwayIndex(ObjectID id) override;
+	virtual Int getRunwayCount() const override { return m_runways.size(); }
+	virtual ObjectID getRunwayReservation(Int r) override;
+	virtual void transferRunwayReservationToNextInLineForTakeoff(ObjectID id) override;
+	virtual Real getApproachHeight() const override { return getParkingPlaceBehaviorModuleData()->m_approachHeight; }
+	virtual void setHealee(Object* healee, Bool add) override;
+	virtual void killAllParkedUnits() override;
+	virtual void defectAllParkedUnits(Team* newTeam, UnsignedInt detectionTime) override;
 
 private:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/ParticleUplinkCannonUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/ParticleUplinkCannonUpdate.h
@@ -154,16 +154,16 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	// SpecialPowerUpdateInterface
-	virtual Bool initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions );
-	virtual Bool isSpecialAbility() const { return false; }
-	virtual Bool isSpecialPower() const { return true; }
-	virtual Bool isActive() const {return m_status != STATUS_IDLE;}
-	virtual SpecialPowerUpdateInterface* getSpecialPowerUpdateInterface() { return this; }
-	virtual CommandOption getCommandOption() const { return (CommandOption)0; }
-	virtual Bool isPowerCurrentlyInUse( const CommandButton *command = nullptr ) const;
+	virtual Bool initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions ) override;
+	virtual Bool isSpecialAbility() const override { return false; }
+	virtual Bool isSpecialPower() const override { return true; }
+	virtual Bool isActive() const override {return m_status != STATUS_IDLE;}
+	virtual SpecialPowerUpdateInterface* getSpecialPowerUpdateInterface() override { return this; }
+	virtual CommandOption getCommandOption() const override { return (CommandOption)0; }
+	virtual Bool isPowerCurrentlyInUse( const CommandButton *command = nullptr ) const override;
 
-	virtual void onObjectCreated();
-	virtual UpdateSleepTime update();
+	virtual void onObjectCreated() override;
+	virtual UpdateSleepTime update() override;
 
 	void removeAllEffects();
 
@@ -178,12 +178,12 @@ public:
 	Bool calculateDefaultInformation();
 	Bool calculateUpBonePositions();
 
-	virtual Bool doesSpecialPowerHaveOverridableDestinationActive() const; //Is it active now?
-	virtual Bool doesSpecialPowerHaveOverridableDestination() const { return true; }	//Does it have it, even if it's not active?
-	virtual void setSpecialPowerOverridableDestination( const Coord3D *loc );
+	virtual Bool doesSpecialPowerHaveOverridableDestinationActive() const override; //Is it active now?
+	virtual Bool doesSpecialPowerHaveOverridableDestination() const override { return true; }	//Does it have it, even if it's not active?
+	virtual void setSpecialPowerOverridableDestination( const Coord3D *loc ) override;
 
 	// Disabled conditions to process (termination conditions!)
-	virtual DisabledMaskType getDisabledTypesToProcess() const { return MAKE_DISABLED_MASK3( DISABLED_UNDERPOWERED, DISABLED_EMP, DISABLED_HACKED ); }
+	virtual DisabledMaskType getDisabledTypesToProcess() const override { return MAKE_DISABLED_MASK3( DISABLED_UNDERPOWERED, DISABLED_EMP, DISABLED_HACKED ); }
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/PhysicsUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/PhysicsUpdate.h
@@ -83,23 +83,23 @@ public:
 
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_COLLIDE); }
 
-	virtual void onObjectCreated();
+	virtual void onObjectCreated() override;
 
 	// BehaviorModule
-	virtual CollideModuleInterface* getCollide() { return this; }
+	virtual CollideModuleInterface* getCollide() override { return this; }
 
 	// CollideModuleInterface
-	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal );
-	virtual Bool wouldLikeToCollideWith(const Object* other) const { return false; }
-	virtual Bool isCarBombCrateCollide() const { return false; }
-	virtual Bool isHijackedVehicleCrateCollide() const { return false; }
-	virtual Bool isRailroad() const { return false;}
-	virtual Bool isSalvageCrateCollide() const { return false; }
+	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal ) override;
+	virtual Bool wouldLikeToCollideWith(const Object* other) const override { return false; }
+	virtual Bool isCarBombCrateCollide() const override { return false; }
+	virtual Bool isHijackedVehicleCrateCollide() const override { return false; }
+	virtual Bool isRailroad() const override { return false;}
+	virtual Bool isSalvageCrateCollide() const override { return false; }
 
 	// UpdateModuleInterface
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 	// Disabled conditions to process -- all
-	virtual DisabledMaskType getDisabledTypesToProcess() const { return DISABLEDMASK_ALL; }
+	virtual DisabledMaskType getDisabledTypesToProcess() const override { return DISABLEDMASK_ALL; }
 
 	void applyForce( const Coord3D *force );		///< apply a force at the object's CG
 	void addVelocityTo(const Coord3D* vel) ;
@@ -206,7 +206,7 @@ protected:
 		interesting oscillations can occur in some situations, with friction being applied
 		either before or after the locomotive force, making for huge stuttery messes. (srj)
 	*/
-	virtual SleepyUpdatePhase getUpdatePhase() const { return PHASE_PHYSICS; }
+	virtual SleepyUpdatePhase getUpdatePhase() const override { return PHASE_PHYSICS; }
 
 	Real getAerodynamicFriction() const;
 	Real getForwardFriction() const;

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/PilotFindVehicleUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/PilotFindVehicleUpdate.h
@@ -68,8 +68,8 @@ public:
 	PilotFindVehicleUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onObjectCreated();
-	virtual UpdateSleepTime update();
+	virtual void onObjectCreated() override;
+	virtual UpdateSleepTime update() override;
 
 	Object* scanClosestTarget();
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/PointDefenseLaserUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/PointDefenseLaserUpdate.h
@@ -71,8 +71,8 @@ public:
 	PointDefenseLaserUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onObjectCreated();
-	virtual UpdateSleepTime update();
+	virtual void onObjectCreated() override;
+	virtual UpdateSleepTime update() override;
 
 	Object* scanClosestTarget();
 	void fireWhenReady();

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/PoisonedBehavior.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/PoisonedBehavior.h
@@ -67,17 +67,17 @@ public:
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_DAMAGE); }
 
 	// BehaviorModule
-	virtual DamageModuleInterface* getDamage() { return this; }
+	virtual DamageModuleInterface* getDamage() override { return this; }
 
 	// DamageModuleInterface
-	virtual void onDamage( DamageInfo *damageInfo );
-	virtual void onHealing( DamageInfo *damageInfo );
-	virtual void onBodyDamageStateChange(const DamageInfo* damageInfo, BodyDamageType oldState, BodyDamageType newState) { }
+	virtual void onDamage( DamageInfo *damageInfo ) override;
+	virtual void onHealing( DamageInfo *damageInfo ) override;
+	virtual void onBodyDamageStateChange(const DamageInfo* damageInfo, BodyDamageType oldState, BodyDamageType newState) override { }
 
 	// UpdateInterface
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 	// Disabled conditions to process (we should still poison disabled things)
-	virtual DisabledMaskType getDisabledTypesToProcess() const { return DISABLEDMASK_ALL; }
+	virtual DisabledMaskType getDisabledTypesToProcess() const override { return DISABLEDMASK_ALL; }
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/PowerPlantUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/PowerPlantUpdate.h
@@ -86,10 +86,10 @@ public:
 	// virtual destructor prototype defined by MemoryPoolObject
 
 	// interface housekeeping
-	virtual PowerPlantUpdateInterface* getPowerPlantUpdateInterface() { return this; }
+	virtual PowerPlantUpdateInterface* getPowerPlantUpdateInterface() override { return this; }
 
-	void extendRods( Bool extend );									 ///< extend the rods from this object
-	virtual UpdateSleepTime update(); ///< Here's the actual work of Upgrading
+	void extendRods( Bool extend ) override;									 ///< extend the rods from this object
+	virtual UpdateSleepTime update() override; ///< Here's the actual work of Upgrading
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/PowerPlantUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/PowerPlantUpdate.h
@@ -88,7 +88,7 @@ public:
 	// interface housekeeping
 	virtual PowerPlantUpdateInterface* getPowerPlantUpdateInterface() override { return this; }
 
-	void extendRods( Bool extend ) override;									 ///< extend the rods from this object
+	virtual void extendRods( Bool extend ) override;									 ///< extend the rods from this object
 	virtual UpdateSleepTime update() override; ///< Here's the actual work of Upgrading
 
 protected:

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/PowerPlantUpgrade.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/PowerPlantUpgrade.h
@@ -50,12 +50,12 @@ public:
 	PowerPlantUpgrade( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype defined by MemoryPoolObject
 
-	virtual void onDelete();																///< we have some work to do when this module goes away
-	virtual void onCapture( Player *oldOwner, Player *newOwner );	///< object containing upgrade has changed teams
+	virtual void onDelete() override;																///< we have some work to do when this module goes away
+	virtual void onCapture( Player *oldOwner, Player *newOwner ) override;	///< object containing upgrade has changed teams
 
 protected:
 
-	virtual void upgradeImplementation(); ///< Here's the actual work of Upgrading
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation() override; ///< Here's the actual work of Upgrading
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/PreorderCreate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/PreorderCreate.h
@@ -49,8 +49,8 @@ public:
 	PreorderCreate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onCreate();
-	virtual void onBuildComplete();
+	virtual void onCreate() override;
+	virtual void onBuildComplete() override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/ProductionUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/ProductionUpdate.h
@@ -189,43 +189,43 @@ public:
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_DIE); }
 
 	// Disabled conditions to process (AI will still process held status)
-	virtual DisabledMaskType getDisabledTypesToProcess() const { return getProductionUpdateModuleData()->m_disabledTypesToProcess; }
+	virtual DisabledMaskType getDisabledTypesToProcess() const override { return getProductionUpdateModuleData()->m_disabledTypesToProcess; }
 
-	virtual ProductionUpdateInterface* getProductionUpdateInterface() { return this; }
-	virtual DieModuleInterface* getDie() { return this; }
+	virtual ProductionUpdateInterface* getProductionUpdateInterface() override { return this; }
+	virtual DieModuleInterface* getDie() override { return this; }
 	static ProductionUpdateInterface *getProductionUpdateInterfaceFromObject( Object *obj );
 
-	virtual CanMakeType canQueueCreateUnit( const ThingTemplate *unitType ) const;
-	virtual CanMakeType canQueueUpgrade( const UpgradeTemplate *upgrade ) const;
+	virtual CanMakeType canQueueCreateUnit( const ThingTemplate *unitType ) const override;
+	virtual CanMakeType canQueueUpgrade( const UpgradeTemplate *upgrade ) const override;
 
 	/** this method is used to request a unique ID to assign to the production of a single
 	unit.  It is unique to all units that can be created from this source object, but is
 	not unique among multiple source objects */
-	virtual ProductionID requestUniqueUnitID() { ProductionID tmp = m_uniqueID; m_uniqueID = (ProductionID)(m_uniqueID+1); return tmp; }
+	virtual ProductionID requestUniqueUnitID() override { ProductionID tmp = m_uniqueID; m_uniqueID = (ProductionID)(m_uniqueID+1); return tmp; }
 
-	virtual Bool queueUpgrade( const UpgradeTemplate *upgrade );				///< queue upgrade "research"
-	virtual void cancelUpgrade( const UpgradeTemplate *upgrade );				///< cancel upgrade "research"
-	virtual Bool isUpgradeInQueue( const UpgradeTemplate *upgrade ) const;		///< is the upgrade in our production queue already
-	virtual UnsignedInt countUnitTypeInQueue( const ThingTemplate *unitType ) const;  ///< count number of units with matching unit type in the production queue
+	virtual Bool queueUpgrade( const UpgradeTemplate *upgrade ) override;				///< queue upgrade "research"
+	virtual void cancelUpgrade( const UpgradeTemplate *upgrade ) override;				///< cancel upgrade "research"
+	virtual Bool isUpgradeInQueue( const UpgradeTemplate *upgrade ) const override;		///< is the upgrade in our production queue already
+	virtual UnsignedInt countUnitTypeInQueue( const ThingTemplate *unitType ) const override;  ///< count number of units with matching unit type in the production queue
 
-	virtual Bool queueCreateUnit( const ThingTemplate *unitType, ProductionID productionID );					///< queue unit to be produced
-	virtual void cancelUnitCreate( ProductionID productionID );		      ///< cancel construction of unit with matching production ID
-	virtual void cancelAllUnitsOfType( const ThingTemplate *unitType);	///< cancel all production of type unitType
+	virtual Bool queueCreateUnit( const ThingTemplate *unitType, ProductionID productionID ) override;					///< queue unit to be produced
+	virtual void cancelUnitCreate( ProductionID productionID ) override;		      ///< cancel construction of unit with matching production ID
+	virtual void cancelAllUnitsOfType( const ThingTemplate *unitType) override;	///< cancel all production of type unitType
 
-	virtual void cancelAndRefundAllProduction();									///< cancel and refund anything in the production queue
+	virtual void cancelAndRefundAllProduction() override;									///< cancel and refund anything in the production queue
 
-	virtual UnsignedInt getProductionCount() const { return m_productionCount; }    ///< return # of things in the production queue
+	virtual UnsignedInt getProductionCount() const override { return m_productionCount; }    ///< return # of things in the production queue
 
 	// walking the production list from outside
-	virtual const ProductionEntry *firstProduction() const { return m_productionQueue; }
-	virtual const ProductionEntry *nextProduction( const ProductionEntry *p ) const { return p ? p->m_next : nullptr; }
+	virtual const ProductionEntry *firstProduction() const override { return m_productionQueue; }
+	virtual const ProductionEntry *nextProduction( const ProductionEntry *p ) const override { return p ? p->m_next : nullptr; }
 
-	virtual void setHoldDoorOpen(ExitDoorType exitDoor, Bool holdIt);
+	virtual void setHoldDoorOpen(ExitDoorType exitDoor, Bool holdIt) override;
 
-	virtual UpdateSleepTime update();					///< the update
+	virtual UpdateSleepTime update() override;					///< the update
 
 	// DieModuleInterface
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/ProjectileStreamUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/ProjectileStreamUpdate.h
@@ -58,7 +58,7 @@ public:
 	void getAllPoints( Vector3 *points, Int *count );					///< unroll circlular array and write down all projectile positions
 	void setPosition( const Coord3D *newPosition );						///< I need to exist at the place I want to draw since only (near) on screen Drawables get updated
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/ProneUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/ProneUpdate.h
@@ -66,7 +66,7 @@ public:
 
 	void goProne( const DamageInfo *damageInfo );
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/PropagandaTowerBehavior.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/PropagandaTowerBehavior.h
@@ -78,7 +78,7 @@ public:
 	// module methods
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_DIE); }
 	virtual void onDelete() override;
-	void onObjectCreated() override;
+	virtual void onObjectCreated() override;
 
 	// update module methods
 	virtual UpdateSleepTime update() override;

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/PropagandaTowerBehavior.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/PropagandaTowerBehavior.h
@@ -77,21 +77,21 @@ public:
 
 	// module methods
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_DIE); }
-	virtual void onDelete();
-	void onObjectCreated();
+	virtual void onDelete() override;
+	void onObjectCreated() override;
 
 	// update module methods
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	// die module methods
-	virtual DieModuleInterface *getDie() { return this; }
-	virtual void onDie( const DamageInfo *damageInfo );
-	virtual void onCapture( Player *oldOwner, Player *newOwner );
+	virtual DieModuleInterface *getDie() override { return this; }
+	virtual void onDie( const DamageInfo *damageInfo ) override;
+	virtual void onCapture( Player *oldOwner, Player *newOwner ) override;
 
 	// Disabled conditions to process. Need to process when disabled, because our update needs to actively let go
 	// of our effect on people.  We don't say "Be affected for n frames", we toggle people.  We need to process
 	// so we can toggle everyone off.
-	virtual DisabledMaskType getDisabledTypesToProcess() const { return DISABLEDMASK_ALL; }
+	virtual DisabledMaskType getDisabledTypesToProcess() const override { return DISABLEDMASK_ALL; }
 
 	// our own public module methods
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/QueueProductionExitUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/QueueProductionExitUpdate.h
@@ -80,24 +80,24 @@ class QueueProductionExitUpdate : public UpdateModule, public ExitInterface
 
 public:
 
-	virtual ExitInterface* getUpdateExitInterface() { return this; }
+	virtual ExitInterface* getUpdateExitInterface() override { return this; }
 
 	QueueProductionExitUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
 	// Required funcs to fulfill interface requirements
-	virtual Bool isExitBusy() const {return FALSE;}	///< Contain style exiters are getting the ability to space out exits, so ask this before reserveDoor as a kind of no-commitment check.
-	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject );
-	virtual void exitObjectViaDoor( Object *newObj, ExitDoorType exitDoor );
-	virtual void exitObjectByBudding( Object *newObj, Object *budHost );
-	virtual void unreserveDoorForExit( ExitDoorType exitDoor );
+	virtual Bool isExitBusy() const override {return FALSE;}	///< Contain style exiters are getting the ability to space out exits, so ask this before reserveDoor as a kind of no-commitment check.
+	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject ) override;
+	virtual void exitObjectViaDoor( Object *newObj, ExitDoorType exitDoor ) override;
+	virtual void exitObjectByBudding( Object *newObj, Object *budHost ) override;
+	virtual void unreserveDoorForExit( ExitDoorType exitDoor ) override;
 
-	virtual void setRallyPoint( const Coord3D *pos );			///< define a "rally point" for units to move towards
-	virtual const Coord3D *getRallyPoint() const;			///< define a "rally point" for units to move towards
-	virtual Bool getExitPosition( Coord3D& exitPosition ) const;					///< access to the "Door" position of the production object
-	virtual Bool getNaturalRallyPoint( Coord3D& rallyPoint, Bool offset = TRUE ) const;			///< get the natural "rally point" for units to move towards
+	virtual void setRallyPoint( const Coord3D *pos ) override;			///< define a "rally point" for units to move towards
+	virtual const Coord3D *getRallyPoint() const override;			///< define a "rally point" for units to move towards
+	virtual Bool getExitPosition( Coord3D& exitPosition ) const override;					///< access to the "Door" position of the production object
+	virtual Bool getNaturalRallyPoint( Coord3D& rallyPoint, Bool offset = TRUE ) const override;			///< get the natural "rally point" for units to move towards
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/RadarUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/RadarUpdate.h
@@ -76,7 +76,7 @@ public:
 	void extendRadar();									 ///< extend the radar from this object
 	Bool isRadarActive() { return m_radarActive; }
 
-	virtual UpdateSleepTime update(); ///< Here's the actual work of Upgrading
+	virtual UpdateSleepTime update() override; ///< Here's the actual work of Upgrading
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/RadarUpgrade.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/RadarUpgrade.h
@@ -64,14 +64,14 @@ public:
 	RadarUpgrade( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype defined by MemoryPoolObject
 
-	virtual void onDelete();																///< we have some work to do when this module goes away
-	virtual void onCapture( Player *oldOwner, Player *newOwner );	///< object containing upgrade has changed teams
+	virtual void onDelete() override;																///< we have some work to do when this module goes away
+	virtual void onCapture( Player *oldOwner, Player *newOwner ) override;	///< object containing upgrade has changed teams
 	Bool getIsDisableProof() const { return getRadarUpgradeModuleData()->m_isDisableProof; }
 
 protected:
 
-	virtual void upgradeImplementation(); ///< Here's the actual work of Upgrading
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation() override; ///< Here's the actual work of Upgrading
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/RadiusDecalUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/RadiusDecalUpdate.h
@@ -74,7 +74,7 @@ public:
 	void killWhenNoLongerAttacking(Bool v) { m_killWhenNoLongerAttacking = v; }
 	void killRadiusDecal();
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 private:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/RailedTransportAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/RailedTransportAIUpdate.h
@@ -64,14 +64,14 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	// AIUpdate interface methods
-	virtual void aiDoCommand( const AICommandParms *parms );
-	virtual UpdateSleepTime update();
+	virtual void aiDoCommand( const AICommandParms *parms ) override;
+	virtual UpdateSleepTime update() override;
 
 protected:
 
 	// ai module methods
-	virtual void privateExecuteRailedTransport( CommandSourceType cmdSource );
-	virtual void privateEvacuate( Int exposeStealthUnits, CommandSourceType cmdSource );
+	virtual void privateExecuteRailedTransport( CommandSourceType cmdSource ) override;
+	virtual void privateEvacuate( Int exposeStealthUnits, CommandSourceType cmdSource ) override;
 
 	// our methods
 	void setInTransit( Bool inTransit );

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/RailedTransportContain.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/RailedTransportContain.h
@@ -45,12 +45,12 @@ public:
 	RailedTransportContain( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onRemoving( Object *obj );			///< object no longer contains 'obj'
-	virtual void exitObjectViaDoor( Object *newObj, ExitDoorType exitDoor );
-	virtual void exitObjectByBudding( Object *newObj, Object *budHost ) { return; };
+	virtual void onRemoving( Object *obj ) override;			///< object no longer contains 'obj'
+	virtual void exitObjectViaDoor( Object *newObj, ExitDoorType exitDoor ) override;
+	virtual void exitObjectByBudding( Object *newObj, Object *budHost ) override { return; };
 
 protected:
 
-	virtual Bool isSpecificRiderFreeToExit( Object *obj );
+	virtual Bool isSpecificRiderFreeToExit( Object *obj ) override;
 
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/RailedTransportDockUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/RailedTransportDockUpdate.h
@@ -78,20 +78,20 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	// module interfaces
-	virtual RailedTransportDockUpdateInterface *getRailedTransportDockUpdateInterface() { return this; }
+	virtual RailedTransportDockUpdateInterface *getRailedTransportDockUpdateInterface() override { return this; }
 
 	// update module methods
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	// dock methods
-	virtual DockUpdateInterface* getDockUpdateInterface() { return this; }
-	virtual Bool action( Object* docker, Object *drone = nullptr );
-	virtual Bool isClearToEnter( Object const* docker ) const;
+	virtual DockUpdateInterface* getDockUpdateInterface() override { return this; }
+	virtual Bool action( Object* docker, Object *drone = nullptr ) override;
+	virtual Bool isClearToEnter( Object const* docker ) const override;
 
 	// our own methods
-	virtual Bool isLoadingOrUnloading();
-	virtual void unloadAll();
-	virtual void unloadSingleObject( Object *obj );
+	virtual Bool isLoadingOrUnloading() override;
+	virtual void unloadAll() override;
+	virtual void unloadSingleObject( Object *obj ) override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/RailroadGuideAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/RailroadGuideAIUpdate.h
@@ -219,12 +219,12 @@ public:
 //	virtual SleepyUpdatePhase getUpdatePhase() const { return PHASE_FINAL; }
 
 	// PhysicsBehavior methods
-	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal );
-	virtual Bool wouldLikeToCollideWith(const Object* other) const {return FALSE;}; // will need to add this!
-	virtual Bool isHijackedVehicleCrateCollide() const {return FALSE;};
-	virtual Bool isCarBombCrateCollide() const {return FALSE;};
-	virtual Bool isRailroad() const ;
-	virtual UpdateSleepTime update();
+	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal ) override;
+	virtual Bool wouldLikeToCollideWith(const Object* other) const override {return FALSE;}; // will need to add this!
+	virtual Bool isHijackedVehicleCrateCollide() const override {return FALSE;};
+	virtual Bool isCarBombCrateCollide() const override {return FALSE;};
+	virtual Bool isRailroad() const override;
+	virtual UpdateSleepTime update() override;
 
 	// TRAINY METHODS
 	void getPulled( PullInfo *info );

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/RebuildHoleBehavior.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/RebuildHoleBehavior.h
@@ -82,24 +82,24 @@ public:
 	RebuildHoleBehavior( Thing *thing, const ModuleData *moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual RebuildHoleBehaviorInterface* getRebuildHoleBehaviorInterface() { return this; }
+	virtual RebuildHoleBehaviorInterface* getRebuildHoleBehaviorInterface() override { return this; }
 
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_DIE); }
 
 	// BehaviorModule
-	virtual DieModuleInterface* getDie() { return this; }
+	virtual DieModuleInterface* getDie() override { return this; }
 
 	// UpdateModuleInterface
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	// DieModuleInterface
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 	// RebuildHole specific methods
-	virtual void startRebuildProcess( const ThingTemplate *rebuild, ObjectID spawnerID );
-	virtual ObjectID getSpawnerID() { return m_spawnerObjectID; }
-	virtual ObjectID getReconstructedBuildingID() { return m_reconstructingID; }
-	virtual const ThingTemplate* getRebuildTemplate() const { return m_rebuildTemplate; }
+	virtual void startRebuildProcess( const ThingTemplate *rebuild, ObjectID spawnerID ) override;
+	virtual ObjectID getSpawnerID() override { return m_spawnerObjectID; }
+	virtual ObjectID getReconstructedBuildingID() override { return m_reconstructingID; }
+	virtual const ThingTemplate* getRebuildTemplate() const override { return m_rebuildTemplate; }
 	void transferBombs( Object *reconstruction );
 
 	// interface acquisition

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/RebuildHoleExposeDie.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/RebuildHoleExposeDie.h
@@ -66,6 +66,6 @@ public:
 	RebuildHoleExposeDie( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/RepairDockUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/RepairDockUpdate.h
@@ -61,11 +61,11 @@ public:
 	RepairDockUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by MemoryPoolObject base class
 
-	virtual DockUpdateInterface* getDockUpdateInterface() { return this; }
+	virtual DockUpdateInterface* getDockUpdateInterface() override { return this; }
 
-	virtual Bool action( Object *docker, Object *drone = nullptr );	///< for me this means do some repair
+	virtual Bool action( Object *docker, Object *drone = nullptr ) override;	///< for me this means do some repair
 
-	virtual Bool isRallyPointAfterDockType(){return TRUE;} ///< A minority of docks want to give you a final command to their rally point
+	virtual Bool isRallyPointAfterDockType() override{return TRUE;} ///< A minority of docks want to give you a final command to their rally point
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/RepairDockUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/RepairDockUpdate.h
@@ -65,7 +65,7 @@ public:
 
 	virtual Bool action( Object *docker, Object *drone = nullptr ) override;	///< for me this means do some repair
 
-	virtual Bool isRallyPointAfterDockType() override{return TRUE;} ///< A minority of docks want to give you a final command to their rally point
+	virtual Bool isRallyPointAfterDockType() override {return TRUE;} ///< A minority of docks want to give you a final command to their rally point
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/SalvageCrateCollide.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/SalvageCrateCollide.h
@@ -87,15 +87,15 @@ public:
 	SalvageCrateCollide( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual Bool isSalvageCrateCollide() const { return true; }
+	virtual Bool isSalvageCrateCollide() const override { return true; }
 
 protected:
 
 	/// This allows specific vetoes to certain types of crates and their data
-	virtual Bool isValidToExecute( const Object *other ) const;
+	virtual Bool isValidToExecute( const Object *other ) const override;
 
 	/// This is the game logic execution function that all real CrateCollides will implement
-	virtual Bool executeCrateBehavior( Object *other );
+	virtual Bool executeCrateBehavior( Object *other ) override;
 
 private:
 	Bool eligibleForWeaponSet( Object *other );

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/ShroudCrateCollide.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/ShroudCrateCollide.h
@@ -51,5 +51,5 @@ public:
 protected:
 
 	/// This is the game logic execution function that all real CrateCollides will implement
-	virtual Bool executeCrateBehavior( Object *other );
+	virtual Bool executeCrateBehavior( Object *other ) override;
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/SlavedUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/SlavedUpdate.h
@@ -144,14 +144,14 @@ public:
 	SlavedUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual SlavedUpdateInterface* getSlavedUpdateInterface() { return this; }
+	virtual SlavedUpdateInterface* getSlavedUpdateInterface() override { return this; }
 
-	virtual ObjectID getSlaverID() const { return m_slaver; }
-	virtual void onEnslave( const Object *slaver );
-	virtual void onSlaverDie( const DamageInfo *info );
-	virtual void onSlaverDamage( const DamageInfo *info );
-	virtual void onObjectCreated();
-	virtual Bool isSelfTasking() const { return FALSE; };
+	virtual ObjectID getSlaverID() const override { return m_slaver; }
+	virtual void onEnslave( const Object *slaver ) override;
+	virtual void onSlaverDie( const DamageInfo *info ) override;
+	virtual void onSlaverDamage( const DamageInfo *info ) override;
+	virtual void onObjectCreated() override;
+	virtual Bool isSelfTasking() const override { return FALSE; };
 
 
 	void doScoutLogic( const Coord3D *mastersDestination );
@@ -163,7 +163,7 @@ public:
 	void setRepairModelConditionStates( ModelConditionFlagType flag );
 	void moveToNewRepairSpot();
 
-	virtual UpdateSleepTime update();	///< Deciding whether or not to make new guys
+	virtual UpdateSleepTime update() override;	///< Deciding whether or not to make new guys
 
 private:
 	void startSlavedEffects( const Object *slaver );	///< We have been marked as Slaved, so we can't be selected or move too far or other stuff

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/SlowDeathBehavior.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/SlowDeathBehavior.h
@@ -137,21 +137,21 @@ public:
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_DIE); }
 
 	// BehaviorModule
-	virtual DieModuleInterface* getDie() { return this; }
+	virtual DieModuleInterface* getDie() override { return this; }
 
 	// UpdateModuleInterface
-	virtual UpdateSleepTime update();
-	virtual SlowDeathBehaviorInterface* getSlowDeathBehaviorInterface() { return this; }
+	virtual UpdateSleepTime update() override;
+	virtual SlowDeathBehaviorInterface* getSlowDeathBehaviorInterface() override { return this; }
 	// Disabled conditions to process -- all
-	virtual DisabledMaskType getDisabledTypesToProcess() const { return DISABLEDMASK_ALL; }
+	virtual DisabledMaskType getDisabledTypesToProcess() const override { return DISABLEDMASK_ALL; }
 
 	// DieModuleInterface
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 	// SlowDeathBehaviorInterface
-	virtual void beginSlowDeath( const DamageInfo *damageInfo );
-	virtual Int getProbabilityModifier( const DamageInfo *damageInfo ) const;
-	virtual Bool isDieApplicable(const DamageInfo *damageInfo) const { return getSlowDeathBehaviorModuleData()->m_dieMuxData.isDieApplicable(getObject(), damageInfo); }
+	virtual void beginSlowDeath( const DamageInfo *damageInfo ) override;
+	virtual Int getProbabilityModifier( const DamageInfo *damageInfo ) const override;
+	virtual Bool isDieApplicable(const DamageInfo *damageInfo) const override { return getSlowDeathBehaviorModuleData()->m_dieMuxData.isDieApplicable(getObject(), damageInfo); }
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/SpawnBehavior.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/SpawnBehavior.h
@@ -131,35 +131,35 @@ public:
 
 	// module methods
 	static Int getInterfaceMask() { return (MODULEINTERFACE_UPDATE) | (MODULEINTERFACE_DIE) | (MODULEINTERFACE_DAMAGE); }
-	virtual void onDelete();
-	virtual UpdateModuleInterface *getUpdate() { return this; }
-	virtual DieModuleInterface *getDie() { return this; }
-	virtual DamageModuleInterface *getDamage() { return this; }
-	virtual SpawnBehaviorInterface* getSpawnBehaviorInterface() { return this; }
+	virtual void onDelete() override;
+	virtual UpdateModuleInterface *getUpdate() override { return this; }
+	virtual DieModuleInterface *getDie() override { return this; }
+	virtual DamageModuleInterface *getDamage() override { return this; }
+	virtual SpawnBehaviorInterface* getSpawnBehaviorInterface() override { return this; }
 
 	// update methods
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	// die methods
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 	// damage methods
-	virtual void onDamage( DamageInfo *damageInfo );
-	virtual void onHealing( DamageInfo *damageInfo ) { }
+	virtual void onDamage( DamageInfo *damageInfo ) override;
+	virtual void onHealing( DamageInfo *damageInfo ) override { }
 	virtual void onBodyDamageStateChange( const DamageInfo* damageInfo,
 																				BodyDamageType oldState,
-																				BodyDamageType newState) { }
+																				BodyDamageType newState) override { }
 
 	// SpawnBehaviorInterface methods
-	virtual Bool maySpawnSelfTaskAI( Real maxSelfTaskersRatio );
-	virtual void onSpawnDeath( ObjectID deadSpawn, DamageInfo *damageInfo );	///< Something we spawned and set up to tell us it died just died.
-	virtual Object* getClosestSlave( const Coord3D *pos );
-	virtual void orderSlavesToAttackTarget( Object *target, Int maxShotsToFire, CommandSourceType cmdSource );
-	virtual void orderSlavesToAttackPosition( const Coord3D *pos, Int maxShotsToFire, CommandSourceType cmdSource );
-	virtual CanAttackResult getCanAnySlavesAttackSpecificTarget( AbleToAttackType attackType, const Object *target, CommandSourceType cmdSource );
-	virtual CanAttackResult getCanAnySlavesUseWeaponAgainstTarget( AbleToAttackType attackType, const Object *victim, const Coord3D *pos, CommandSourceType cmdSource );
-	virtual Bool canAnySlavesAttack();
-	virtual void orderSlavesToGoIdle( CommandSourceType cmdSource );
+	virtual Bool maySpawnSelfTaskAI( Real maxSelfTaskersRatio ) override;
+	virtual void onSpawnDeath( ObjectID deadSpawn, DamageInfo *damageInfo ) override;	///< Something we spawned and set up to tell us it died just died.
+	virtual Object* getClosestSlave( const Coord3D *pos ) override;
+	virtual void orderSlavesToAttackTarget( Object *target, Int maxShotsToFire, CommandSourceType cmdSource ) override;
+	virtual void orderSlavesToAttackPosition( const Coord3D *pos, Int maxShotsToFire, CommandSourceType cmdSource ) override;
+	virtual CanAttackResult getCanAnySlavesAttackSpecificTarget( AbleToAttackType attackType, const Object *target, CommandSourceType cmdSource ) override;
+	virtual CanAttackResult getCanAnySlavesUseWeaponAgainstTarget( AbleToAttackType attackType, const Object *victim, const Coord3D *pos, CommandSourceType cmdSource ) override;
+	virtual Bool canAnySlavesAttack() override;
+	virtual void orderSlavesToGoIdle( CommandSourceType cmdSource ) override;
 
 	// **********************************************************************************************
 	// our own methods

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/SpawnPointProductionExitUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/SpawnPointProductionExitUpdate.h
@@ -68,21 +68,21 @@ class SpawnPointProductionExitUpdate : public UpdateModule, public ExitInterface
 
 public:
 
-	virtual ExitInterface* getUpdateExitInterface() { return this; }
+	virtual ExitInterface* getUpdateExitInterface() override { return this; }
 
 	SpawnPointProductionExitUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
 	// Required funcs to fulfill interface requirements
-	virtual Bool isExitBusy() const {return FALSE;}	///< Contain style exiters are getting the ability to space out exits, so ask this before reserveDoor as a kind of no-commitment check.
-	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject );
-	virtual void exitObjectViaDoor( Object *newObj, ExitDoorType exitDoor );
-	virtual void unreserveDoorForExit( ExitDoorType exitDoor );
-	virtual void setRallyPoint( const Coord3D * ){}
-	virtual const Coord3D *getRallyPoint() const { return nullptr; }
-	virtual void exitObjectByBudding( Object *newObj, Object *budHost ) { return; }
+	virtual Bool isExitBusy() const override {return FALSE;}	///< Contain style exiters are getting the ability to space out exits, so ask this before reserveDoor as a kind of no-commitment check.
+	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject ) override;
+	virtual void exitObjectViaDoor( Object *newObj, ExitDoorType exitDoor ) override;
+	virtual void unreserveDoorForExit( ExitDoorType exitDoor ) override;
+	virtual void setRallyPoint( const Coord3D * ) override{}
+	virtual const Coord3D *getRallyPoint() const override { return nullptr; }
+	virtual void exitObjectByBudding( Object *newObj, Object *budHost ) override { return; }
 
-	virtual UpdateSleepTime update()										{ return UPDATE_SLEEP_FOREVER; }
+	virtual UpdateSleepTime update() override										{ return UPDATE_SLEEP_FOREVER; }
 
 protected:
 	Bool m_bonesInitialized;													///< To prevent creation bugs, only init the World coords when first asked for one

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/SpawnPointProductionExitUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/SpawnPointProductionExitUpdate.h
@@ -78,7 +78,7 @@ public:
 	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject ) override;
 	virtual void exitObjectViaDoor( Object *newObj, ExitDoorType exitDoor ) override;
 	virtual void unreserveDoorForExit( ExitDoorType exitDoor ) override;
-	virtual void setRallyPoint( const Coord3D * ) override{}
+	virtual void setRallyPoint( const Coord3D * ) override {}
 	virtual const Coord3D *getRallyPoint() const override { return nullptr; }
 	virtual void exitObjectByBudding( Object *newObj, Object *budHost ) override { return; }
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/SpecialAbility.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/SpecialAbility.h
@@ -55,9 +55,9 @@ public:
 
 	SpecialAbility( Thing *thing, const ModuleData *moduleData );
 
-	virtual void doSpecialPowerAtObject( Object *obj, UnsignedInt commandOptions );
-	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions );
-	virtual void doSpecialPower( UnsignedInt commandOptions );
+	virtual void doSpecialPowerAtObject( Object *obj, UnsignedInt commandOptions ) override;
+	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions ) override;
+	virtual void doSpecialPower( UnsignedInt commandOptions ) override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/SpecialAbilityUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/SpecialAbilityUpdate.h
@@ -170,21 +170,21 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	// SpecialPowerUpdateInterface
-	virtual Bool initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions );
-	virtual Bool isSpecialAbility() const { return true; }
-	virtual Bool isSpecialPower() const { return false; }
-	virtual Bool isActive() const { return m_active; }
-	virtual Bool doesSpecialPowerHaveOverridableDestinationActive() const { return false; } //Is it active now?
-	virtual Bool doesSpecialPowerHaveOverridableDestination() const { return false; }	//Does it have it, even if it's not active?
-	virtual void setSpecialPowerOverridableDestination( const Coord3D *loc ) {}
-	virtual Bool isPowerCurrentlyInUse( const CommandButton *command = nullptr ) const;
+	virtual Bool initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions ) override;
+	virtual Bool isSpecialAbility() const override { return true; }
+	virtual Bool isSpecialPower() const override { return false; }
+	virtual Bool isActive() const override { return m_active; }
+	virtual Bool doesSpecialPowerHaveOverridableDestinationActive() const override { return false; } //Is it active now?
+	virtual Bool doesSpecialPowerHaveOverridableDestination() const override { return false; }	//Does it have it, even if it's not active?
+	virtual void setSpecialPowerOverridableDestination( const Coord3D *loc ) override {}
+	virtual Bool isPowerCurrentlyInUse( const CommandButton *command = nullptr ) const override;
 
 //	virtual Bool isBusy() const { return m_isBusy; }
 
 	// UpdateModule
-	virtual SpecialPowerUpdateInterface* getSpecialPowerUpdateInterface() { return this; }
-	virtual CommandOption getCommandOption() const { return (CommandOption)0; }
-	virtual UpdateSleepTime update();
+	virtual SpecialPowerUpdateInterface* getSpecialPowerUpdateInterface() override { return this; }
+	virtual CommandOption getCommandOption() const override { return (CommandOption)0; }
+	virtual UpdateSleepTime update() override;
 
 	// ??? ugh, public stuff that shouldn't be -- hell yeah!
 	UnsignedInt getSpecialObjectCount() const;

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/SpecialPowerCompletionDie.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/SpecialPowerCompletionDie.h
@@ -77,7 +77,7 @@ public:
 	void setCreator( ObjectID creatorID );
 	void notifyScriptEngine();
 
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/SpecialPowerCreate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/SpecialPowerCreate.h
@@ -48,8 +48,8 @@ public:
 	SpecialPowerCreate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onCreate();
-	virtual void onBuildComplete();	///< This is called when you are a finished game object
+	virtual void onCreate() override;
+	virtual void onBuildComplete() override;	///< This is called when you are a finished game object
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/SpecialPowerModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/SpecialPowerModule.h
@@ -102,28 +102,28 @@ public:
 	// BehaviorModule
 	virtual SpecialPowerModuleInterface* getSpecialPower() override { return this; }
 
-	Bool isModuleForPower( const SpecialPowerTemplate *specialPowerTemplate ) const override;	///< is this module for the specified special power
-	Bool isReady() const override; 						///< is this special power available now
+	virtual Bool isModuleForPower( const SpecialPowerTemplate *specialPowerTemplate ) const override;	///< is this module for the specified special power
+	virtual Bool isReady() const override; 						///< is this special power available now
 //  This is the althernate way to one-at-a-time BlackLotus' specials; we'll keep it commented her until Dustin decides, or until 12/10/02
 //	Bool isBusy() const { return FALSE; }
 
-	Real getPercentReady() const override;		///< get the percent ready (1.0 = ready now, 0.5 = half charged up etc.)
+	virtual Real getPercentReady() const override;		///< get the percent ready (1.0 = ready now, 0.5 = half charged up etc.)
 
-	UnsignedInt getReadyFrame() const override;		///< get the frame at which we are ready
-	AsciiString getPowerName() const override;
+	virtual UnsignedInt getReadyFrame() const override;		///< get the frame at which we are ready
+	virtual AsciiString getPowerName() const override;
 	void syncReadyFrameToStatusQuo();
 
-	const SpecialPowerTemplate* getSpecialPowerTemplate() const override;
-	ScienceType getRequiredScience() const override;
+	virtual const SpecialPowerTemplate* getSpecialPowerTemplate() const override;
+	virtual ScienceType getRequiredScience() const override;
 
-	void onSpecialPowerCreation() override;	// called by a create module to start our countdown
+	virtual void onSpecialPowerCreation() override;	// called by a create module to start our countdown
 	//
 	// The following methods are for use by the scripting engine ONLY
 	//
 
-	void setReadyFrame( UnsignedInt frame ) override { m_availableOnFrame = frame; }
+	virtual void setReadyFrame( UnsignedInt frame ) override { m_availableOnFrame = frame; }
 	UnsignedInt getReadyFrame() { return m_availableOnFrame; }// USED BY PLAYER TO KEEP RECHARGE TIMERS IN SYNC
-	void pauseCountdown( Bool pause ) override;
+	virtual void pauseCountdown( Bool pause ) override;
 
 	//
 	// the following methods should be *EXTENDED* for any special power module implementations

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/SpecialPowerModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/SpecialPowerModule.h
@@ -100,39 +100,39 @@ public:
 	static Int getInterfaceMask() { return MODULEINTERFACE_SPECIAL_POWER; }
 
 	// BehaviorModule
-	virtual SpecialPowerModuleInterface* getSpecialPower() { return this; }
+	virtual SpecialPowerModuleInterface* getSpecialPower() override { return this; }
 
-	Bool isModuleForPower( const SpecialPowerTemplate *specialPowerTemplate ) const;	///< is this module for the specified special power
-	Bool isReady() const; 						///< is this special power available now
+	Bool isModuleForPower( const SpecialPowerTemplate *specialPowerTemplate ) const override;	///< is this module for the specified special power
+	Bool isReady() const override; 						///< is this special power available now
 //  This is the althernate way to one-at-a-time BlackLotus' specials; we'll keep it commented her until Dustin decides, or until 12/10/02
 //	Bool isBusy() const { return FALSE; }
 
-	Real getPercentReady() const;		///< get the percent ready (1.0 = ready now, 0.5 = half charged up etc.)
+	Real getPercentReady() const override;		///< get the percent ready (1.0 = ready now, 0.5 = half charged up etc.)
 
-	UnsignedInt getReadyFrame() const;		///< get the frame at which we are ready
-	AsciiString getPowerName() const;
+	UnsignedInt getReadyFrame() const override;		///< get the frame at which we are ready
+	AsciiString getPowerName() const override;
 	void syncReadyFrameToStatusQuo();
 
-	const SpecialPowerTemplate* getSpecialPowerTemplate() const;
-	ScienceType getRequiredScience() const;
+	const SpecialPowerTemplate* getSpecialPowerTemplate() const override;
+	ScienceType getRequiredScience() const override;
 
-	void onSpecialPowerCreation();	// called by a create module to start our countdown
+	void onSpecialPowerCreation() override;	// called by a create module to start our countdown
 	//
 	// The following methods are for use by the scripting engine ONLY
 	//
 
-	void setReadyFrame( UnsignedInt frame ) { m_availableOnFrame = frame; }
+	void setReadyFrame( UnsignedInt frame ) override { m_availableOnFrame = frame; }
 	UnsignedInt getReadyFrame() { return m_availableOnFrame; }// USED BY PLAYER TO KEEP RECHARGE TIMERS IN SYNC
-	void pauseCountdown( Bool pause );
+	void pauseCountdown( Bool pause ) override;
 
 	//
 	// the following methods should be *EXTENDED* for any special power module implementations
 	// and carry out the special power executions
 	//
-	virtual void doSpecialPower( UnsignedInt commandOptions );
-	virtual void doSpecialPowerAtObject( Object *obj, UnsignedInt commandOptions );
-	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions );
-	virtual void doSpecialPowerUsingWaypoints( const Waypoint *way, UnsignedInt commandOptions );
+	virtual void doSpecialPower( UnsignedInt commandOptions ) override;
+	virtual void doSpecialPowerAtObject( Object *obj, UnsignedInt commandOptions ) override;
+	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions ) override;
+	virtual void doSpecialPowerUsingWaypoints( const Waypoint *way, UnsignedInt commandOptions ) override;
 
 	/**
 	 Now, there are special powers that require some preliminary processing before the actual
@@ -145,12 +145,12 @@ public:
 	 module. The update module then orders the unit to move within range, and it isn't until the
 	 hacker start the physical attack, that the timer is reset and the attack technically begins.
 	*/
-	virtual void markSpecialPowerTriggered( const Coord3D *location );
+	virtual void markSpecialPowerTriggered( const Coord3D *location ) override;
 
 	/** start the recharge process for this special power. public because some powers call it repeatedly.
 	*/
-	virtual void startPowerRecharge();
-	virtual const AudioEventRTS& getInitiateSound() const;
+	virtual void startPowerRecharge() override;
+	virtual const AudioEventRTS& getInitiateSound() const override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/SpyVisionSpecialPower.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/SpyVisionSpecialPower.h
@@ -65,7 +65,7 @@ public:
 	SpyVisionSpecialPower( Thing *thing, const ModuleData *moduleData );
 	// virtual destructor prototype provided by memory pool object
 
-	virtual void doSpecialPower( UnsignedInt commandOptions );
+	virtual void doSpecialPower( UnsignedInt commandOptions ) override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/SpyVisionUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/SpyVisionUpdate.h
@@ -59,8 +59,8 @@ public:
 	SpyVisionUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onDelete();
-	virtual UpdateSleepTime update();
+	virtual void onDelete() override;
+	virtual UpdateSleepTime update() override;
 
 	void activateSpyVision( UnsignedInt duration );
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/SquishCollide.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/SquishCollide.h
@@ -50,7 +50,7 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	/// This collide method gets called when collision occur
-	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal );
+	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal ) override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/StatusBitsUpgrade.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/StatusBitsUpgrade.h
@@ -91,8 +91,8 @@ public:
 	// virtual destructor prototype defined by MemoryPoolObject
 
 protected:
-	virtual void upgradeImplementation( ); ///< Here's the actual work of Upgrading
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation( ) override; ///< Here's the actual work of Upgrading
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 };
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/StealthDetectorUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/StealthDetectorUpdate.h
@@ -87,8 +87,8 @@ public:
 
 	Bool isSDEnabled() const { return m_enabled; }
 	void setSDEnabled( Bool enabled );
-	virtual UpdateSleepTime update();
-	virtual DisabledMaskType getDisabledTypesToProcess() const { return MAKE_DISABLED_MASK( DISABLED_HELD ); }
+	virtual UpdateSleepTime update() override;
+	virtual DisabledMaskType getDisabledTypesToProcess() const override { return MAKE_DISABLED_MASK( DISABLED_HELD ); }
 
 private:
 	Bool m_enabled;

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/StealthUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/StealthUpdate.h
@@ -117,12 +117,12 @@ public:
 	StealthUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual StealthUpdate* getStealth() { return this; }
+	virtual StealthUpdate* getStealth() override { return this; }
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	//Still gets called, even if held -ML
-	virtual DisabledMaskType getDisabledTypesToProcess() const { return MAKE_DISABLED_MASK( DISABLED_HELD ); }
+	virtual DisabledMaskType getDisabledTypesToProcess() const override { return MAKE_DISABLED_MASK( DISABLED_HELD ); }
 
 	// ??? ugh
 	Bool isDisguised() const { return m_disguiseAsTemplate != nullptr; }

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/StealthUpgrade.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/StealthUpgrade.h
@@ -50,7 +50,7 @@ public:
 	// virtual destructor prototype defined by MemoryPoolObject
 
 protected:
-	virtual void upgradeImplementation( ); ///< Here's the actual work of Upgrading
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation( ) override; ///< Here's the actual work of Upgrading
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/StickyBombUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/StickyBombUpdate.h
@@ -69,9 +69,9 @@ public:
 	StickyBombUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onObjectCreated();
+	virtual void onObjectCreated() override;
 
-	virtual UpdateSleepTime update();							///< called once per frame
+	virtual UpdateSleepTime update() override;							///< called once per frame
 
 	void init( const Object *object, const Object *bomber );
 	void detonate();

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/StructureCollapseUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/StructureCollapseUpdate.h
@@ -109,13 +109,13 @@ public:
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_DIE); }
 
 	// BehaviorModule
-	virtual DieModuleInterface* getDie() { return this; }
+	virtual DieModuleInterface* getDie() override { return this; }
 
 	// UpdateModuleInterface
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	// DieModuleInterface
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/StructureToppleUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/StructureToppleUpdate.h
@@ -150,13 +150,13 @@ public:
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_DIE); }
 
 	// BehaviorModule
-	virtual DieModuleInterface* getDie() { return this; }
+	virtual DieModuleInterface* getDie() override { return this; }
 
 	// UpdateModuleInterface
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	// DieModuleInterface
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/SubObjectsUpgrade.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/SubObjectsUpgrade.h
@@ -81,7 +81,7 @@ public:
 	// virtual destructor prototype defined by MemoryPoolObject
 
 protected:
-	virtual void upgradeImplementation( ); ///< Here's the actual work of Upgrading
-	virtual Bool isSubObjectsUpgrade() { return true; }
+	virtual void upgradeImplementation( ) override; ///< Here's the actual work of Upgrading
+	virtual Bool isSubObjectsUpgrade() override { return true; }
 
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/SupplyCenterCreate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/SupplyCenterCreate.h
@@ -48,8 +48,8 @@ public:
 	SupplyCenterCreate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onCreate();
-	virtual void onBuildComplete();	///< This is called when you are a finished game object
+	virtual void onCreate() override;
+	virtual void onBuildComplete() override;	///< This is called when you are a finished game object
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/SupplyCenterDockUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/SupplyCenterDockUpdate.h
@@ -58,10 +58,10 @@ public:
 
 	SupplyCenterDockUpdate( Thing *thing, const ModuleData* moduleData );
 
-	virtual DockUpdateInterface* getDockUpdateInterface() { return this; }
-	virtual Bool action( Object* docker, Object *drone = nullptr );	///<For me, this means taking boxes and turning them into money for my ownerplayer
+	virtual DockUpdateInterface* getDockUpdateInterface() override { return this; }
+	virtual Bool action( Object* docker, Object *drone = nullptr ) override;	///<For me, this means taking boxes and turning them into money for my ownerplayer
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/SupplyCenterProductionExitUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/SupplyCenterProductionExitUpdate.h
@@ -69,24 +69,24 @@ class SupplyCenterProductionExitUpdate : public UpdateModule, public ExitInterfa
 
 public:
 
-	virtual ExitInterface* getUpdateExitInterface() { return this; }
+	virtual ExitInterface* getUpdateExitInterface() override { return this; }
 
 	SupplyCenterProductionExitUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
 	// Required funcs to fulfill interface requirements
-	virtual Bool isExitBusy() const {return FALSE;}	///< Contain style exiters are getting the ability to space out exits, so ask this before reserveDoor as a kind of no-commitment check.
-	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject ) { return DOOR_1; }
-	virtual void exitObjectViaDoor( Object *newObj, ExitDoorType exitDoor );
-	virtual void unreserveDoorForExit( ExitDoorType exitDoor ) { /* nothing */ }
-	virtual void exitObjectByBudding( Object *newObj, Object *budHost ) { return; }
+	virtual Bool isExitBusy() const override {return FALSE;}	///< Contain style exiters are getting the ability to space out exits, so ask this before reserveDoor as a kind of no-commitment check.
+	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject ) override { return DOOR_1; }
+	virtual void exitObjectViaDoor( Object *newObj, ExitDoorType exitDoor ) override;
+	virtual void unreserveDoorForExit( ExitDoorType exitDoor ) override { /* nothing */ }
+	virtual void exitObjectByBudding( Object *newObj, Object *budHost ) override { return; }
 
-	virtual void setRallyPoint( const Coord3D *pos );			///< define a "rally point" for units to move towards
-	virtual const Coord3D *getRallyPoint() const;			///< define a "rally point" for units to move towards
-	virtual Bool getExitPosition( Coord3D& exitPosition ) const;					///< access to the "Door" position of the production object
-	virtual Bool getNaturalRallyPoint( Coord3D& rallyPoint, Bool offset = TRUE ) const;			///< get the natural "rally point" for units to move towards
+	virtual void setRallyPoint( const Coord3D *pos ) override;			///< define a "rally point" for units to move towards
+	virtual const Coord3D *getRallyPoint() const override;			///< define a "rally point" for units to move towards
+	virtual Bool getExitPosition( Coord3D& exitPosition ) const override;					///< access to the "Door" position of the production object
+	virtual Bool getNaturalRallyPoint( Coord3D& rallyPoint, Bool offset = TRUE ) const override;			///< get the natural "rally point" for units to move towards
 
-	virtual UpdateSleepTime update()										{ return UPDATE_SLEEP_FOREVER; }
+	virtual UpdateSleepTime update() override										{ return UPDATE_SLEEP_FOREVER; }
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/SupplyTruckAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/SupplyTruckAIUpdate.h
@@ -60,9 +60,9 @@ class SupplyTruckWantsToPickUpOrDeliverBoxesState :  public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(SupplyTruckWantsToPickUpOrDeliverBoxesState, "SupplyTruckWantsToPickUpOrDeliverBoxesState")
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ) override{};
-	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess() override{};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 
 public:
 	SupplyTruckWantsToPickUpOrDeliverBoxesState( StateMachine *machine ) : State( machine, "SupplyTruckWantsToPickUpOrDeliverBoxesState" ) {}
@@ -78,12 +78,12 @@ class RegroupingState :  public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(RegroupingState, "RegroupingState")
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ) override{};
-	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess() override{};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 public:
 	RegroupingState( StateMachine *machine ) : State( machine, "RegroupingState" ) {}
-	virtual StateReturnType update() override{ return STATE_CONTINUE;}// Nothing to do but wait for a transition
+	virtual StateReturnType update() override { return STATE_CONTINUE;}// Nothing to do but wait for a transition
 	virtual StateReturnType onEnter() override;// Will tell me to aiMove back to base.
 	virtual void onExit(StateExitType status) override;
 };
@@ -95,9 +95,9 @@ class DockingState :  public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(DockingState, "DockingState")
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ) override{};
-	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess() override{};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 public:
 	DockingState( StateMachine *machine ) :State( machine, "DockingState" ) {}
 	virtual StateReturnType update() override;

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/SupplyTruckAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/SupplyTruckAIUpdate.h
@@ -49,9 +49,9 @@ public:
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 };
 
 //-------------------------------------------------------------------------------------------------
@@ -60,15 +60,15 @@ class SupplyTruckWantsToPickUpOrDeliverBoxesState :  public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(SupplyTruckWantsToPickUpOrDeliverBoxesState, "SupplyTruckWantsToPickUpOrDeliverBoxesState")
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override{};
 
 public:
 	SupplyTruckWantsToPickUpOrDeliverBoxesState( StateMachine *machine ) : State( machine, "SupplyTruckWantsToPickUpOrDeliverBoxesState" ) {}
-	virtual StateReturnType update();
-	virtual StateReturnType onEnter();
-	virtual void onExit(StateExitType status);
+	virtual StateReturnType update() override;
+	virtual StateReturnType onEnter() override;
+	virtual void onExit(StateExitType status) override;
 };
 EMPTY_DTOR(SupplyTruckWantsToPickUpOrDeliverBoxesState)
 
@@ -78,14 +78,14 @@ class RegroupingState :  public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(RegroupingState, "RegroupingState")
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override{};
 public:
 	RegroupingState( StateMachine *machine ) : State( machine, "RegroupingState" ) {}
-	virtual StateReturnType update(){ return STATE_CONTINUE;}// Nothing to do but wait for a transition
-	virtual StateReturnType onEnter();// Will tell me to aiMove back to base.
-	virtual void onExit(StateExitType status);
+	virtual StateReturnType update() override{ return STATE_CONTINUE;}// Nothing to do but wait for a transition
+	virtual StateReturnType onEnter() override;// Will tell me to aiMove back to base.
+	virtual void onExit(StateExitType status) override;
 };
 EMPTY_DTOR(RegroupingState)
 
@@ -95,14 +95,14 @@ class DockingState :  public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(DockingState, "DockingState")
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override{};
 public:
 	DockingState( StateMachine *machine ) :State( machine, "DockingState" ) {}
-	virtual StateReturnType update();
-	virtual StateReturnType onEnter();
-	virtual void onExit(StateExitType status);
+	virtual StateReturnType update() override;
+	virtual StateReturnType onEnter() override;
+	virtual void onExit(StateExitType status) override;
 };
 EMPTY_DTOR(DockingState)
 
@@ -191,35 +191,35 @@ public:
 	SupplyTruckAIUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual SupplyTruckAIInterface* getSupplyTruckAIInterface() {return this;}
-	virtual const SupplyTruckAIInterface* getSupplyTruckAIInterface() const {return this;}
+	virtual SupplyTruckAIInterface* getSupplyTruckAIInterface() override {return this;}
+	virtual const SupplyTruckAIInterface* getSupplyTruckAIInterface() const override {return this;}
 
-	virtual Int getNumberBoxes() const { return m_numberBoxes; }
-	virtual Bool loseOneBox();
-	virtual Bool gainOneBox( Int remainingStock );
+	virtual Int getNumberBoxes() const override { return m_numberBoxes; }
+	virtual Bool loseOneBox() override;
+	virtual Bool gainOneBox( Int remainingStock ) override;
 
 	// this is present for subclasses (eg, Chinook) to override, to
 	// prevent supply-ferry behavior in some cases (eg, when toting passengers)
-	virtual Bool isAvailableForSupplying() const;
-	virtual Bool isCurrentlyFerryingSupplies() const;
-	virtual Real getWarehouseScanDistance() const; ///< How far can I look for a warehouse?
+	virtual Bool isAvailableForSupplying() const override;
+	virtual Bool isCurrentlyFerryingSupplies() const override;
+	virtual Real getWarehouseScanDistance() const override; ///< How far can I look for a warehouse?
 
-	virtual void setForceWantingState(Bool v) { m_forcePending = v; } // When a Supply Center creates us (or maybe other sources later), we need to hop into autopilot mode.
-	virtual Bool isForcedIntoWantingState() const { return m_forcePending; }
+	virtual void setForceWantingState(Bool v) override { m_forcePending = v; } // When a Supply Center creates us (or maybe other sources later), we need to hop into autopilot mode.
+	virtual Bool isForcedIntoWantingState() const override { return m_forcePending; }
 
-	virtual void setForceBusyState(Bool v) { m_forcedBusyPending = v; }
-	virtual Bool isForcedIntoBusyState() const { return m_forcedBusyPending; }
+	virtual void setForceBusyState(Bool v) override { m_forcedBusyPending = v; }
+	virtual Bool isForcedIntoBusyState() const override { return m_forcedBusyPending; }
 
-	virtual ObjectID getPreferredDockID() const { return m_preferredDock; }
-	virtual UnsignedInt getActionDelayForDock( Object *dock );
+	virtual ObjectID getPreferredDockID() const override { return m_preferredDock; }
+	virtual UnsignedInt getActionDelayForDock( Object *dock ) override;
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 protected:
 
-	virtual AIStateMachine* makeStateMachine();
-	virtual void privateDock( Object *obj, CommandSourceType cmdSource );
-	virtual void privateIdle(CommandSourceType cmdSource);						///< Enter idle state.
+	virtual AIStateMachine* makeStateMachine() override;
+	virtual void privateDock( Object *obj, CommandSourceType cmdSource ) override;
+	virtual void privateIdle(CommandSourceType cmdSource) override;						///< Enter idle state.
 
 private:
 	SupplyTruckStateMachine*	m_supplyTruckStateMachine;

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/SupplyWarehouseCreate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/SupplyWarehouseCreate.h
@@ -48,7 +48,7 @@ public:
 	SupplyWarehouseCreate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onCreate();
+	virtual void onCreate() override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/SupplyWarehouseCripplingBehavior.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/SupplyWarehouseCripplingBehavior.h
@@ -68,15 +68,15 @@ public:
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_DAMAGE); }
 
 	// BehaviorModule
-	virtual DamageModuleInterface* getDamage() { return this; }
+	virtual DamageModuleInterface* getDamage() override { return this; }
 
 	// DamageModuleInterface
-	virtual void onDamage( DamageInfo *damageInfo );
-	virtual void onHealing( DamageInfo *damageInfo ){}
-	virtual void onBodyDamageStateChange(const DamageInfo* damageInfo, BodyDamageType oldState, BodyDamageType newState);
+	virtual void onDamage( DamageInfo *damageInfo ) override;
+	virtual void onHealing( DamageInfo *damageInfo ) override{}
+	virtual void onBodyDamageStateChange(const DamageInfo* damageInfo, BodyDamageType oldState, BodyDamageType newState) override;
 
 	// UpdateInterface
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 protected:
 	virtual void resetSelfHealSupression();// Reset our able to heal timer, as we took damage

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/SupplyWarehouseCripplingBehavior.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/SupplyWarehouseCripplingBehavior.h
@@ -72,7 +72,7 @@ public:
 
 	// DamageModuleInterface
 	virtual void onDamage( DamageInfo *damageInfo ) override;
-	virtual void onHealing( DamageInfo *damageInfo ) override{}
+	virtual void onHealing( DamageInfo *damageInfo ) override {}
 	virtual void onBodyDamageStateChange(const DamageInfo* damageInfo, BodyDamageType oldState, BodyDamageType newState) override;
 
 	// UpdateInterface

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/SupplyWarehouseDockUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/SupplyWarehouseDockUpdate.h
@@ -57,18 +57,18 @@ class SupplyWarehouseDockUpdate : public DockUpdate
 
 public:
 
-	virtual DockUpdateInterface* getDockUpdateInterface() { return this; }
+	virtual DockUpdateInterface* getDockUpdateInterface() override { return this; }
 
 	SupplyWarehouseDockUpdate( Thing *thing, const ModuleData* moduleData );
 
-	virtual void setDockCrippled( Bool setting ); ///< Game Logic can set me as inoperative.  I get to decide what that means.
-	virtual Bool action( Object* docker, Object *drone = nullptr );	///<For me, this means identifying who is docking and either taking Boxes away or giving them
+	virtual void setDockCrippled( Bool setting ) override; ///< Game Logic can set me as inoperative.  I get to decide what that means.
+	virtual Bool action( Object* docker, Object *drone = nullptr ) override;	///<For me, this means identifying who is docking and either taking Boxes away or giving them
 
 	Int getBoxesStored() const { return m_boxesStored; }
 
 	void setCashValue( Int cashValue );
 
-	virtual void onObjectCreated();
+	virtual void onObjectCreated() override;
 protected:
 
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/TechBuildingBehavior.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/TechBuildingBehavior.h
@@ -64,15 +64,15 @@ public:
 	// virtual destructor prototype provided by memory pool object
 
 	// module methods
-	virtual void onCapture( Player *oldOwner, Player *newOwner );
+	virtual void onCapture( Player *oldOwner, Player *newOwner ) override;
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_DIE); }
 
 	// update methods
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	// die methods
-	virtual DieModuleInterface *getDie() { return this; }
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual DieModuleInterface *getDie() override { return this; }
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/TensileFormationUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/TensileFormationUpdate.h
@@ -63,7 +63,7 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	void setEnabled( Bool enabled ) { m_enabled = enabled; }  ///< enable/disable formation
-	virtual UpdateSleepTime update();	///< Deciding whether or not to make new guys
+	virtual UpdateSleepTime update() override;	///< Deciding whether or not to make new guys
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/ToppleUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/ToppleUpdate.h
@@ -86,22 +86,22 @@ public:
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_COLLIDE); }
 
 	// BehaviorModule
-	virtual CollideModuleInterface* getCollide() { return this; }
+	virtual CollideModuleInterface* getCollide() override { return this; }
 
 	void applyTopplingForce( const Coord3D* toppleDirection, Real toppleSpeed, UnsignedInt options);
 	Bool isAbleToBeToppled() const;
 
 	// UpdateModuleInterface
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	// CollideModuleInterface
-	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal );
+	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal ) override;
 	/// this is used for things like pilots, to determine if they can "enter" something
-	virtual Bool wouldLikeToCollideWith(const Object* other) const { return false; }
-	virtual Bool isHijackedVehicleCrateCollide() const { return false; }
-	virtual Bool isCarBombCrateCollide() const { return false; }
-	virtual Bool isRailroad() const { return false; }
-	virtual Bool isSalvageCrateCollide() const { return false; }
+	virtual Bool wouldLikeToCollideWith(const Object* other) const override { return false; }
+	virtual Bool isHijackedVehicleCrateCollide() const override { return false; }
+	virtual Bool isCarBombCrateCollide() const override { return false; }
+	virtual Bool isRailroad() const override { return false; }
+	virtual Bool isSalvageCrateCollide() const override { return false; }
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/TransitionDamageFX.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/TransitionDamageFX.h
@@ -248,11 +248,11 @@ public:
 	TransitionDamageFX( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onDamage( DamageInfo *damageInfo ) { }
-	virtual void onHealing( DamageInfo *damageInfo ) { }
+	virtual void onDamage( DamageInfo *damageInfo ) override { }
+	virtual void onHealing( DamageInfo *damageInfo ) override { }
 	virtual void onBodyDamageStateChange( const DamageInfo* damageInfo,
 																				BodyDamageType oldState,
-																				BodyDamageType newState );
+																				BodyDamageType newState ) override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/TransportAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/TransportAIUpdate.h
@@ -51,14 +51,14 @@ public:
 
 	TransportAIUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
-	virtual AIFreeToExitType getAiFreeToExit(const Object* exiter) const;
+	virtual AIFreeToExitType getAiFreeToExit(const Object* exiter) const override;
 
 protected:
 
-	virtual AIStateMachine* makeStateMachine();
+	virtual AIStateMachine* makeStateMachine() override;
 
 protected:
-	virtual void privateAttackObject( Object *victim, Int maxShotsToFire, CommandSourceType cmdSource );///< Extension.  Also tell occupants to attackObject
-	virtual void privateAttackPosition( const Coord3D *pos, Int maxShotsToFire, CommandSourceType cmdSource );///< Extension.  Also tell occupants to attackPosition
-	virtual void privateForceAttackObject( Object *victim, Int maxShotsToFire, CommandSourceType cmdSource );///< Extension.  Also tell occupants to forceAttackObject
+	virtual void privateAttackObject( Object *victim, Int maxShotsToFire, CommandSourceType cmdSource ) override;///< Extension.  Also tell occupants to attackObject
+	virtual void privateAttackPosition( const Coord3D *pos, Int maxShotsToFire, CommandSourceType cmdSource ) override;///< Extension.  Also tell occupants to attackPosition
+	virtual void privateForceAttackObject( Object *victim, Int maxShotsToFire, CommandSourceType cmdSource ) override;///< Extension.  Also tell occupants to forceAttackObject
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/TransportContain.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/TransportContain.h
@@ -74,26 +74,26 @@ public:
 	TransportContain( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual Bool isValidContainerFor( const Object* obj, Bool checkCapacity) const;
+	virtual Bool isValidContainerFor( const Object* obj, Bool checkCapacity) const override;
 
-	virtual void onCapture( Player *oldOwner, Player *newOwner ); // have to kick everyone out on capture.
-	virtual void onContaining( Object *obj );		///< object now contains 'obj'
-	virtual void onRemoving( Object *obj );			///< object no longer contains 'obj'
-	virtual UpdateSleepTime update();							///< called once per frame
+	virtual void onCapture( Player *oldOwner, Player *newOwner ) override; // have to kick everyone out on capture.
+	virtual void onContaining( Object *obj ) override;		///< object now contains 'obj'
+	virtual void onRemoving( Object *obj ) override;			///< object no longer contains 'obj'
+	virtual UpdateSleepTime update() override;							///< called once per frame
 
-	virtual Int getContainMax() const;
+	virtual Int getContainMax() const override;
 
-	virtual Int getExtraSlotsInUse() { return m_extraSlotsInUse; }///< Transports have the ability to carry guys how take up more than spot.
+	virtual Int getExtraSlotsInUse() override { return m_extraSlotsInUse; }///< Transports have the ability to carry guys how take up more than spot.
 
-	virtual Bool isExitBusy() const;	///< Contain style exiters are getting the ability to space out exits, so ask this before reserveDoor as a kind of no-commitment check.
-	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject );
-	virtual void unreserveDoorForExit( ExitDoorType exitDoor );
-	virtual Bool isDisplayedOnControlBar() const {return TRUE;}///< Does this container display its contents on the ControlBar?
+	virtual Bool isExitBusy() const override;	///< Contain style exiters are getting the ability to space out exits, so ask this before reserveDoor as a kind of no-commitment check.
+	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject ) override;
+	virtual void unreserveDoorForExit( ExitDoorType exitDoor ) override;
+	virtual Bool isDisplayedOnControlBar() const override {return TRUE;}///< Does this container display its contents on the ControlBar?
 
 protected:
 
 	// exists primarily for TransportContain to override
-	virtual void killRidersWhoAreNotFreeToExit();
+	virtual void killRidersWhoAreNotFreeToExit() override;
 	virtual Bool isSpecificRiderFreeToExit(Object* obj);
 
 private:

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/TunnelContain.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/TunnelContain.h
@@ -83,46 +83,46 @@ public:
 	TunnelContain( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual CreateModuleInterface* getCreate() { return this; }
+	virtual CreateModuleInterface* getCreate() override { return this; }
 	static Int getInterfaceMask() { return OpenContain::getInterfaceMask() | (MODULEINTERFACE_CREATE); }
 
-	virtual OpenContain *asOpenContain() { return this; }  ///< treat as open container
-	virtual Bool isGarrisonable() const { return false; }	///< can this unit be Garrisoned? (ick)
-	virtual Bool isHealContain() const { return false; } ///< true when container only contains units while healing (not a transport!)
-	virtual Bool isImmuneToClearBuildingAttacks() const { return true; }
+	virtual OpenContain *asOpenContain() override { return this; }  ///< treat as open container
+	virtual Bool isGarrisonable() const override { return false; }	///< can this unit be Garrisoned? (ick)
+	virtual Bool isHealContain() const override { return false; } ///< true when container only contains units while healing (not a transport!)
+	virtual Bool isImmuneToClearBuildingAttacks() const override { return true; }
 
-	virtual void onContaining( Object *obj );		///< object now contains 'obj'
-	virtual void onRemoving( Object *obj );			///< object no longer contains 'obj'
-	virtual void onSelling();///< Container is being sold.  Tunnel responds by kicking people out if this is the last tunnel.
-	virtual void onCapture( Player *oldOwner, Player *newOwner ); // Need to change who we are registered with.
+	virtual void onContaining( Object *obj ) override;		///< object now contains 'obj'
+	virtual void onRemoving( Object *obj ) override;			///< object no longer contains 'obj'
+	virtual void onSelling() override;///< Container is being sold.  Tunnel responds by kicking people out if this is the last tunnel.
+	virtual void onCapture( Player *oldOwner, Player *newOwner ) override; // Need to change who we are registered with.
 
-	virtual void orderAllPassengersToExit( CommandSourceType commandSource ); ///< All of the smarts of exiting are in the passenger's AIExit. removeAllFrommContain is a last ditch system call, this is the game Evacuate
+	virtual void orderAllPassengersToExit( CommandSourceType commandSource ) override; ///< All of the smarts of exiting are in the passenger's AIExit. removeAllFrommContain is a last ditch system call, this is the game Evacuate
 
-	virtual Bool isValidContainerFor(const Object* obj, Bool checkCapacity) const;
-	virtual void addToContainList( Object *obj );		///< The part of AddToContain that inheritors can override (Can't do whole thing because of all the private stuff involved)
-	virtual void removeFromContain( Object *obj, Bool exposeStealthUnits = FALSE );	///< remove 'obj' from contain list
-	virtual void removeAllContained( Bool exposeStealthUnits = FALSE );				///< remove all objects on contain list
+	virtual Bool isValidContainerFor(const Object* obj, Bool checkCapacity) const override;
+	virtual void addToContainList( Object *obj ) override;		///< The part of AddToContain that inheritors can override (Can't do whole thing because of all the private stuff involved)
+	virtual void removeFromContain( Object *obj, Bool exposeStealthUnits = FALSE ) override;	///< remove 'obj' from contain list
+	virtual void removeAllContained( Bool exposeStealthUnits = FALSE ) override;				///< remove all objects on contain list
 
 	// contain list access
-	virtual void iterateContained( ContainIterateFunc func, void *userData, Bool reverse );
-	virtual UnsignedInt getContainCount() const;
-	virtual UnsignedInt getHeroUnitsContained() const;
-	virtual Int getContainMax() const;
-	virtual const ContainedItemsList* getContainedItemsList() const;
+	virtual void iterateContained( ContainIterateFunc func, void *userData, Bool reverse ) override;
+	virtual UnsignedInt getContainCount() const override;
+	virtual UnsignedInt getHeroUnitsContained() const override;
+	virtual Int getContainMax() const override;
+	virtual const ContainedItemsList* getContainedItemsList() const override;
 	virtual UnsignedInt getFullTimeForHeal() const; ///< Returns the time in frames until a contained object becomes fully healed
-	virtual Bool isDisplayedOnControlBar() const { return TRUE; } ///< Does this container display its contents on the ControlBar?
-	virtual Bool isKickOutOnCapture(){ return FALSE; }///< Caves and Tunnels don't kick out on capture.
+	virtual Bool isDisplayedOnControlBar() const override { return TRUE; } ///< Does this container display its contents on the ControlBar?
+	virtual Bool isKickOutOnCapture() override { return FALSE; }///< Caves and Tunnels don't kick out on capture.
 
 	// override the onDie we inherit from OpenContain
-	virtual void onDie( const DamageInfo *damageInfo );  ///< the die callback
+	virtual void onDie( const DamageInfo *damageInfo ) override;  ///< the die callback
 
-	virtual void onDelete();
-	virtual void onCreate();
-	virtual void onBuildComplete();	///< This is called when you are a finished game object
-	virtual Bool shouldDoOnBuildComplete() const { return m_needToRunOnBuildComplete; }
+	virtual void onDelete() override;
+	virtual void onCreate() override;
+	virtual void onBuildComplete() override;	///< This is called when you are a finished game object
+	virtual Bool shouldDoOnBuildComplete() const override { return m_needToRunOnBuildComplete; }
 
 	// so that the ppl within the tunnel network can get healed
-	virtual UpdateSleepTime update();												///< called once per frame
+	virtual UpdateSleepTime update() override;												///< called once per frame
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/UnitCrateCollide.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/UnitCrateCollide.h
@@ -76,7 +76,7 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	/// This is the game logic execution function that all real CrateCollides will implement
-	virtual Bool executeCrateBehavior( Object *other );
+	virtual Bool executeCrateBehavior( Object *other ) override;
 protected:
 
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/UnpauseSpecialPowerUpgrade.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/UnpauseSpecialPowerUpgrade.h
@@ -68,7 +68,7 @@ public:
 
 protected:
 
-	virtual void upgradeImplementation(); ///< Here's the actual work of Upgrading
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation() override; ///< Here's the actual work of Upgrading
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/UpdateModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/UpdateModule.h
@@ -169,12 +169,12 @@ public:
 	static Int getInterfaceMask() { return (MODULEINTERFACE_UPDATE); }
 
 	// BehaviorModule
-	virtual UpdateModuleInterface* getUpdate() { return this; }
+	virtual UpdateModuleInterface* getUpdate() override { return this; }
 
 	// UpdateModuleInterface
-	virtual UpdateSleepTime update() = 0;
+	virtual UpdateSleepTime update() override = 0;
 
-	DisabledMaskType getDisabledTypesToProcess() const
+	virtual DisabledMaskType getDisabledTypesToProcess() const override
 	{
 		return DISABLEDMASK_NONE;
 	}

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/UpdateModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/UpdateModule.h
@@ -172,7 +172,7 @@ public:
 	virtual UpdateModuleInterface* getUpdate() override { return this; }
 
 	// UpdateModuleInterface
-	virtual UpdateSleepTime update() override = 0;
+	virtual UpdateSleepTime update() = 0;
 
 	virtual DisabledMaskType getDisabledTypesToProcess() const override
 	{

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/UpgradeDie.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/UpgradeDie.h
@@ -72,6 +72,6 @@ public:
 	UpgradeDie( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/UpgradeModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/UpgradeModule.h
@@ -105,13 +105,13 @@ public:
 
 	UpgradeMux();
 
-	virtual Bool isAlreadyUpgraded() const ;
+	virtual Bool isAlreadyUpgraded() const override ;
 	// ***DANGER! DANGER! Don't use this, unless you are forcing an already made upgrade to refresh!!
-	virtual void forceRefreshUpgrade();
-	virtual Bool attemptUpgrade( const UpgradeMaskType& keyMask );
-	virtual Bool wouldUpgrade( const UpgradeMaskType& keyMask ) const;
-	virtual Bool resetUpgrade( const UpgradeMaskType& keyMask );
-	virtual Bool testUpgradeConditions( const UpgradeMaskType& keyMask ) const;
+	virtual void forceRefreshUpgrade() override;
+	virtual Bool attemptUpgrade( const UpgradeMaskType& keyMask ) override;
+	virtual Bool wouldUpgrade( const UpgradeMaskType& keyMask ) const override;
+	virtual Bool resetUpgrade( const UpgradeMaskType& keyMask ) override;
+	virtual Bool testUpgradeConditions( const UpgradeMaskType& keyMask ) const override;
 
 protected:
 
@@ -120,7 +120,7 @@ protected:
 	virtual void getUpgradeActivationMasks(UpgradeMaskType& activation, UpgradeMaskType& conflicting) const = 0; ///< Here's the actual work of Upgrading
 	virtual void performUpgradeFX() = 0;	///< perform the associated fx list
 	virtual Bool requiresAllActivationUpgrades() const = 0;
-	virtual Bool isSubObjectsUpgrade() = 0;
+	virtual Bool isSubObjectsUpgrade() override = 0;
 
 	void giveSelfUpgrade()
 	{
@@ -174,21 +174,21 @@ public:
 	static Int getInterfaceMask() { return MODULEINTERFACE_UPGRADE; }
 
 	// BehaviorModule
-	virtual UpgradeModuleInterface* getUpgrade() { return this; }
+	virtual UpgradeModuleInterface* getUpgrade() override { return this; }
 
 protected:
 
-	virtual Bool requiresAllActivationUpgrades() const
+	virtual Bool requiresAllActivationUpgrades() const override
 	{
 		return getUpgradeModuleData()->m_upgradeMuxData.m_requiresAllTriggers;
 	}
 
-	virtual void getUpgradeActivationMasks(UpgradeMaskType& activation, UpgradeMaskType& conflicting) const
+	virtual void getUpgradeActivationMasks(UpgradeMaskType& activation, UpgradeMaskType& conflicting) const override
 	{
 		getUpgradeModuleData()->m_upgradeMuxData.getUpgradeActivationMasks(activation, conflicting);
 	}
 
-	virtual void performUpgradeFX()
+	virtual void performUpgradeFX() override
 	{
 		getUpgradeModuleData()->m_upgradeMuxData.performUpgradeFX(getObject());
 	}

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/UpgradeModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/UpgradeModule.h
@@ -120,7 +120,7 @@ protected:
 	virtual void getUpgradeActivationMasks(UpgradeMaskType& activation, UpgradeMaskType& conflicting) const = 0; ///< Here's the actual work of Upgrading
 	virtual void performUpgradeFX() = 0;	///< perform the associated fx list
 	virtual Bool requiresAllActivationUpgrades() const = 0;
-	virtual Bool isSubObjectsUpgrade() override = 0;
+	virtual Bool isSubObjectsUpgrade() = 0;
 
 	void giveSelfUpgrade()
 	{

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/VeterancyCrateCollide.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/VeterancyCrateCollide.h
@@ -82,10 +82,10 @@ public:
 protected:
 
 	/// This allows specific vetoes to certain types of crates and their data
-	virtual Bool isValidToExecute( const Object *other ) const;
+	virtual Bool isValidToExecute( const Object *other ) const override;
 
 	/// This is the game logic execution function that all real CrateCollides will implement
-	virtual Bool executeCrateBehavior( Object *other );
+	virtual Bool executeCrateBehavior( Object *other ) override;
 
 	Int getLevelsToGain() const;
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/VeterancyGainCreate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/VeterancyGainCreate.h
@@ -62,7 +62,7 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	/// the create method
-	virtual void onCreate();
+	virtual void onCreate() override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/WanderAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/WanderAIUpdate.h
@@ -47,7 +47,7 @@ class WanderAIUpdate : public AIUpdateInterface
 		for an example.)
 	*/
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 public:
 
@@ -57,6 +57,6 @@ public:
 
 protected:
 
-	virtual AIStateMachine* makeStateMachine();
+	virtual AIStateMachine* makeStateMachine() override;
 
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/WaveGuideUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/WaveGuideUpdate.h
@@ -77,7 +77,7 @@ public:
   WaveGuideUpdate( Thing *thing, const ModuleData *moduleData );
 	// virtual destructor prototype provided by MemoryPoolObject
 
-	virtual UpdateSleepTime update();		///< the update implementation
+	virtual UpdateSleepTime update() override;		///< the update implementation
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/WeaponBonusUpgrade.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/WeaponBonusUpgrade.h
@@ -75,8 +75,8 @@ public:
 	// virtual destructor prototype defined by MemoryPoolObject
 
 protected:
-	virtual void upgradeImplementation( ); ///< Here's the actual work of Upgrading
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation( ) override; ///< Here's the actual work of Upgrading
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 };
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/WeaponSetUpgrade.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/WeaponSetUpgrade.h
@@ -50,7 +50,7 @@ public:
 	// virtual destructor prototype defined by MemoryPoolObject
 
 protected:
-	virtual void upgradeImplementation( ); ///< Here's the actual work of Upgrading
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation( ) override; ///< Here's the actual work of Upgrading
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/WorkerAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/WorkerAIUpdate.h
@@ -50,9 +50,9 @@ public:
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 };
 
 // ------------------------------------------------------------------------------------------------
@@ -123,91 +123,91 @@ public:
 	WorkerAIUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual DozerAIInterface* getDozerAIInterface() {return this;}
-	virtual const DozerAIInterface* getDozerAIInterface() const {return this;}
-	virtual SupplyTruckAIInterface* getSupplyTruckAIInterface() {return this;}
-	virtual const SupplyTruckAIInterface* getSupplyTruckAIInterface() const {return this;}
-	virtual WorkerAIInterface* getWorkerAIInterface() { return this; }
-	virtual const WorkerAIInterface* getWorkerAIInterface() const { return this; }
+	virtual DozerAIInterface* getDozerAIInterface() override {return this;}
+	virtual const DozerAIInterface* getDozerAIInterface() const override {return this;}
+	virtual SupplyTruckAIInterface* getSupplyTruckAIInterface() override {return this;}
+	virtual const SupplyTruckAIInterface* getSupplyTruckAIInterface() const override {return this;}
+	virtual WorkerAIInterface* getWorkerAIInterface() override { return this; }
+	virtual const WorkerAIInterface* getWorkerAIInterface() const override { return this; }
 
 	// Dozer side
-	virtual void onDelete();
+	virtual void onDelete() override;
 
-	virtual Real getRepairHealthPerSecond() const;	///< get health to repair per second
-	virtual Real getBoredTime() const;							///< how long till we're bored
-	virtual Real getBoredRange() const;							///< when we're bored, we look this far away to do things
+	virtual Real getRepairHealthPerSecond() const override;	///< get health to repair per second
+	virtual Real getBoredTime() const override;							///< how long till we're bored
+	virtual Real getBoredRange() const override;							///< when we're bored, we look this far away to do things
 
 	virtual Object *construct( const ThingTemplate *what,
 														 const Coord3D *pos, Real angle,
 														 Player *owningPlayer,
-														 Bool isRebuild );			///< construct a building
+														 Bool isRebuild ) override;			///< construct a building
 
 	// get task information
-	virtual DozerTask getMostRecentCommand();				///< return task that was most recently issued
-	virtual Bool isTaskPending( DozerTask task );					///< is there a desire to do the requested task
-	virtual ObjectID getTaskTarget( DozerTask task );			///< get target of task
-	virtual Bool isAnyTaskPending();								///< is there any dozer task pending
-	virtual DozerTask getCurrentTask() const { return m_currentTask; }	///< return the current task we're doing
-	virtual void setCurrentTask( DozerTask task ) { m_currentTask = task; }		///< set the current task of the dozer
+	virtual DozerTask getMostRecentCommand() override;				///< return task that was most recently issued
+	virtual Bool isTaskPending( DozerTask task ) override;					///< is there a desire to do the requested task
+	virtual ObjectID getTaskTarget( DozerTask task ) override;			///< get target of task
+	virtual Bool isAnyTaskPending() override;								///< is there any dozer task pending
+	virtual DozerTask getCurrentTask() const override { return m_currentTask; }	///< return the current task we're doing
+	virtual void setCurrentTask( DozerTask task ) override { m_currentTask = task; }		///< set the current task of the dozer
 
-	virtual Bool getIsRebuild() { return m_isRebuild; } ///< get whether or not our task is a rebuild.
+	virtual Bool getIsRebuild() override { return m_isRebuild; } ///< get whether or not our task is a rebuild.
 
 	// task actions
-	virtual void newTask( DozerTask task, Object* target );	///< set a desire to do the requrested task
-	virtual void cancelTask( DozerTask task );						///< cancel this task from the queue, if it's the current task the dozer will stop working on it
-	virtual void cancelAllTasks();												///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
-	virtual void resumePreviousTask();									///< resume the previous task if there was one
+	virtual void newTask( DozerTask task, Object* target ) override;	///< set a desire to do the requrested task
+	virtual void cancelTask( DozerTask task ) override;						///< cancel this task from the queue, if it's the current task the dozer will stop working on it
+	virtual void cancelAllTasks() override;												///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
+	virtual void resumePreviousTask() override;									///< resume the previous task if there was one
 
 	// internal methods to manage behavior from within the dozer state machine
-	virtual void internalTaskComplete( DozerTask task );					///< set a dozer task as successfully completed
-	virtual void internalCancelTask( DozerTask task );						///< cancel this task from the dozer
-	virtual void internalTaskCompleteOrCancelled( DozerTask task );	///< this is called when tasks are cancelled or completed
+	virtual void internalTaskComplete( DozerTask task ) override;					///< set a dozer task as successfully completed
+	virtual void internalCancelTask( DozerTask task ) override;						///< cancel this task from the dozer
+	virtual void internalTaskCompleteOrCancelled( DozerTask task ) override;	///< this is called when tasks are cancelled or completed
 
 	/** return a dock point for the action and task (if valid) ... note it can return nullptr
 	if no point has been set for the combination of task and point */
-	virtual const Coord3D* getDockPoint( DozerTask task, DozerDockPoint point );
+	virtual const Coord3D* getDockPoint( DozerTask task, DozerDockPoint point ) override;
 
-	virtual void setBuildSubTask( DozerBuildSubTask subTask ) { m_buildSubTask = subTask; };
-	virtual DozerBuildSubTask getBuildSubTask() { return m_buildSubTask; }
+	virtual void setBuildSubTask( DozerBuildSubTask subTask ) override { m_buildSubTask = subTask; };
+	virtual DozerBuildSubTask getBuildSubTask() override { return m_buildSubTask; }
 	//
 	// the following methods must be overridden so that if a player issues a command the dozer
 	// can exit the internal state machine and do whatever the player says
 	//
-	virtual void aiDoCommand(const AICommandParms* parms);
+	virtual void aiDoCommand(const AICommandParms* parms) override;
 
 // Supply truck stuff
-	virtual Int getNumberBoxes() const { return m_numberBoxes; }
-	virtual Bool loseOneBox();
-	virtual Bool gainOneBox( Int remainingStock );
+	virtual Int getNumberBoxes() const override { return m_numberBoxes; }
+	virtual Bool loseOneBox() override;
+	virtual Bool gainOneBox( Int remainingStock ) override;
 
-	virtual Bool isAvailableForSupplying() const;
-	virtual Bool isCurrentlyFerryingSupplies() const;
-	virtual Real getWarehouseScanDistance() const; ///< How far can I look for a warehouse?
+	virtual Bool isAvailableForSupplying() const override;
+	virtual Bool isCurrentlyFerryingSupplies() const override;
+	virtual Real getWarehouseScanDistance() const override; ///< How far can I look for a warehouse?
 
-	virtual void setForceBusyState(Bool v) { m_forcedBusyPending = v; }
-	virtual Bool isForcedIntoBusyState() const { return m_forcedBusyPending; }
+	virtual void setForceBusyState(Bool v) override { m_forcedBusyPending = v; }
+	virtual Bool isForcedIntoBusyState() const override { return m_forcedBusyPending; }
 
-	virtual void setForceWantingState(Bool v){ m_forcePending = v; }
-	virtual Bool isForcedIntoWantingState() const { return m_forcePending; }
-	virtual ObjectID getPreferredDockID() const { return m_preferredDock; }
-	virtual UnsignedInt getActionDelayForDock( Object *dock );
+	virtual void setForceWantingState(Bool v) override { m_forcePending = v; }
+	virtual Bool isForcedIntoWantingState() const override { return m_forcePending; }
+	virtual ObjectID getPreferredDockID() const override { return m_preferredDock; }
+	virtual UnsignedInt getActionDelayForDock( Object *dock ) override;
 
 // worker specific
 	Bool isSupplyTruckBrainActiveAndBusy();
 	void resetSupplyTruckBrain();
 	void resetDozerBrain();
 
-	virtual void exitingSupplyTruckState(); ///< This worker is leaving a supply truck task and should go back to Dozer mode.
+	virtual void exitingSupplyTruckState() override; ///< This worker is leaving a supply truck task and should go back to Dozer mode.
 
-	virtual UpdateSleepTime update();				///< the update entry point
+	virtual UpdateSleepTime update() override;				///< the update entry point
 
 	// repairing
-	virtual Bool canAcceptNewRepair( Object *obj );
-	virtual void createBridgeScaffolding( Object *bridgeTower );
-	virtual void removeBridgeScaffolding( Object *bridgeTower );
+	virtual Bool canAcceptNewRepair( Object *obj ) override;
+	virtual void createBridgeScaffolding( Object *bridgeTower ) override;
+	virtual void removeBridgeScaffolding( Object *bridgeTower ) override;
 
-	virtual void startBuildingSound( const AudioEventRTS *sound, ObjectID constructionSiteID );
-	virtual void finishBuildingSound();
+	virtual void startBuildingSound( const AudioEventRTS *sound, ObjectID constructionSiteID ) override;
+	virtual void finishBuildingSound() override;
 
 protected:
 
@@ -259,10 +259,10 @@ protected:
 	AudioEventRTS	m_buildingSound;			///< sound is pulled from the object we are building!
 
 protected:
-	virtual void privateRepair( Object *obj, CommandSourceType cmdSource );	///< repair the target
-	virtual void privateResumeConstruction( Object *obj, CommandSourceType cmdSource );  ///< resume construction on obj
-	virtual void privateDock( Object *obj, CommandSourceType cmdSource );
-	virtual void privateIdle(CommandSourceType cmdSource);						///< Enter idle state.
+	virtual void privateRepair( Object *obj, CommandSourceType cmdSource ) override;	///< repair the target
+	virtual void privateResumeConstruction( Object *obj, CommandSourceType cmdSource ) override;  ///< resume construction on obj
+	virtual void privateDock( Object *obj, CommandSourceType cmdSource ) override;
+	virtual void privateIdle(CommandSourceType cmdSource) override;						///< Enter idle state.
 
 private:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/AIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/AIUpdate.h
@@ -203,9 +203,9 @@ public:
 
 
   AIUpdateModuleData();
-	virtual ~AIUpdateModuleData();
+	virtual ~AIUpdateModuleData() override;
 
-	virtual Bool isAiModuleData() const { return true; }
+	virtual Bool isAiModuleData() const override { return true; }
 
 	const LocomotorTemplateVector* findLocomotorTemplateVector(LocomotorSetType t) const;
 	static void buildFieldParse(MultiIniFieldParse& p);
@@ -299,10 +299,10 @@ public:
 	AIUpdateInterface( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual AIUpdateInterface* getAIUpdateInterface() { return this; }
+	virtual AIUpdateInterface* getAIUpdateInterface() override { return this; }
 
 	// Disabled conditions to process (AI will still process held status)
-	virtual DisabledMaskType getDisabledTypesToProcess() const { return MAKE_DISABLED_MASK( DISABLED_HELD ); }
+	virtual DisabledMaskType getDisabledTypesToProcess() const override { return MAKE_DISABLED_MASK( DISABLED_HELD ); }
 
 	// Some very specific, complex behaviors are used by more than one AIUpdate.  Here are their interfaces.
 	virtual DozerAIInterface* getDozerAIInterface() {return nullptr;}
@@ -350,10 +350,10 @@ public:
 	//Definition of busy -- when explicitly in the busy state. Moving or attacking is not considered busy!
 	virtual Bool isBusy() const;
 
-	virtual void onObjectCreated();
+	virtual void onObjectCreated() override;
 	virtual void doQuickExit( std::vector<Coord3D>* path );			///< get out of this Object
 
-	virtual void aiDoCommand(const AICommandParms* parms);
+	virtual void aiDoCommand(const AICommandParms* parms) override;
 
 	virtual const Coord3D *getGuardLocation() const { return &m_locationToGuard;	}
 	virtual ObjectID getGuardObject() const { return m_objectToGuard; }
@@ -524,7 +524,7 @@ public:
 	Bool hasHigherPathPriority(AIUpdateInterface *otherAI) const;
 	void setFinalPosition(const Coord3D *pos) { m_finalPosition = *pos; m_doFinalPosition = false;}
 
-	virtual UpdateSleepTime update();	///< update this object's AI
+	virtual UpdateSleepTime update() override;	///< update this object's AI
 
 	/// if we are attacking "fromID", stop that and attack "toID" instead
 	void transferAttack(ObjectID fromID, ObjectID toID);
@@ -604,7 +604,7 @@ protected:
 		interesting oscillations can occur in some situations, with friction being applied
 		either before or after the locomotive force, making for huge stuttery messes. (srj)
 	*/
-	virtual SleepyUpdatePhase getUpdatePhase() const { return PHASE_INITIAL; }
+	virtual SleepyUpdatePhase getUpdatePhase() const override { return PHASE_INITIAL; }
 
 	void setGoalPositionClipped(const Coord3D* in, CommandSourceType cmdSource);
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ActiveBody.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ActiveBody.h
@@ -72,53 +72,53 @@ public:
 	ActiveBody( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onDelete();
+	virtual void onDelete() override;
 
-	virtual void attemptDamage( DamageInfo *damageInfo );		///< try to damage this object
-	virtual Real estimateDamage( DamageInfoInput& damageInfo ) const;
-	virtual void attemptHealing( DamageInfo *damageInfo );		///< try to heal this object
-	virtual Real getHealth() const;													///< get current health
-	virtual BodyDamageType getDamageState() const;
-	virtual void setDamageState( BodyDamageType newState );	///< control damage state directly.  Will adjust hitpoints.
-	virtual void setAflame( Bool setting );///< This is a major change like a damage state.
-	virtual UnsignedInt getSubdualDamageHealRate() const;
-	virtual Real getSubdualDamageHealAmount() const;
-	virtual Bool hasAnySubdualDamage() const;
-	virtual Real getCurrentSubdualDamageAmount() const { return m_currentSubdualDamage; }
+	virtual void attemptDamage( DamageInfo *damageInfo ) override;		///< try to damage this object
+	virtual Real estimateDamage( DamageInfoInput& damageInfo ) const override;
+	virtual void attemptHealing( DamageInfo *damageInfo ) override;		///< try to heal this object
+	virtual Real getHealth() const override;													///< get current health
+	virtual BodyDamageType getDamageState() const override;
+	virtual void setDamageState( BodyDamageType newState ) override;	///< control damage state directly.  Will adjust hitpoints.
+	virtual void setAflame( Bool setting ) override;///< This is a major change like a damage state.
+	virtual UnsignedInt getSubdualDamageHealRate() const override;
+	virtual Real getSubdualDamageHealAmount() const override;
+	virtual Bool hasAnySubdualDamage() const override;
+	virtual Real getCurrentSubdualDamageAmount() const override { return m_currentSubdualDamage; }
 
-	virtual const DamageInfo *getLastDamageInfo() const { return &m_lastDamageInfo; }	///< return info on last damage dealt to this object
-	virtual UnsignedInt getLastDamageTimestamp() const { return m_lastDamageTimestamp; }	///< return frame of last damage dealt
-	virtual UnsignedInt getLastHealingTimestamp() const { return m_lastHealingTimestamp; }	///< return frame of last damage dealt
-	virtual ObjectID getClearableLastAttacker() const { return (m_lastDamageCleared ? INVALID_ID : m_lastDamageInfo.in.m_sourceID); }
-	virtual void clearLastAttacker() { m_lastDamageCleared = true; }
+	virtual const DamageInfo *getLastDamageInfo() const override { return &m_lastDamageInfo; }	///< return info on last damage dealt to this object
+	virtual UnsignedInt getLastDamageTimestamp() const override { return m_lastDamageTimestamp; }	///< return frame of last damage dealt
+	virtual UnsignedInt getLastHealingTimestamp() const override { return m_lastHealingTimestamp; }	///< return frame of last damage dealt
+	virtual ObjectID getClearableLastAttacker() const override { return (m_lastDamageCleared ? INVALID_ID : m_lastDamageInfo.in.m_sourceID); }
+	virtual void clearLastAttacker() override { m_lastDamageCleared = true; }
 
-	void onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel newLevel, Bool provideFeedback = TRUE );
+	virtual void onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel newLevel, Bool provideFeedback = TRUE ) override;
 
-	virtual void setArmorSetFlag(ArmorSetType ast) { m_curArmorSetFlags.set(ast, 1); }
-	virtual void clearArmorSetFlag(ArmorSetType ast) { m_curArmorSetFlags.set(ast, 0); }
-	virtual Bool testArmorSetFlag(ArmorSetType ast) { return m_curArmorSetFlags.test(ast); }
+	virtual void setArmorSetFlag(ArmorSetType ast) override { m_curArmorSetFlags.set(ast, 1); }
+	virtual void clearArmorSetFlag(ArmorSetType ast) override { m_curArmorSetFlags.set(ast, 0); }
+	virtual Bool testArmorSetFlag(ArmorSetType ast) override { return m_curArmorSetFlags.test(ast); }
 
-	virtual void setInitialHealth(Int initialPercent); ///< Sets the initial load health %.
-	virtual void setMaxHealth( Real maxHealth, MaxHealthChangeType healthChangeType = SAME_CURRENTHEALTH ); ///< Sets the initial max health
+	virtual void setInitialHealth(Int initialPercent) override; ///< Sets the initial load health %.
+	virtual void setMaxHealth( Real maxHealth, MaxHealthChangeType healthChangeType = SAME_CURRENTHEALTH ) override; ///< Sets the initial max health
 
-	virtual Bool getFrontCrushed() const { return m_frontCrushed; }
-	virtual Bool getBackCrushed() const { return m_backCrushed; }
+	virtual Bool getFrontCrushed() const override { return m_frontCrushed; }
+	virtual Bool getBackCrushed() const override { return m_backCrushed; }
 
-	virtual void setFrontCrushed(Bool v) { m_frontCrushed = v; }
-	virtual void setBackCrushed(Bool v) { m_backCrushed = v; }
+	virtual void setFrontCrushed(Bool v) override { m_frontCrushed = v; }
+	virtual void setBackCrushed(Bool v) override { m_backCrushed = v; }
 
-	virtual Real getMaxHealth() const;  ///< return max health
-	virtual Real getInitialHealth() const;  // return initial health
+	virtual Real getMaxHealth() const override;  ///< return max health
+	virtual Real getInitialHealth() const override;  // return initial health
 
-	virtual Real getPreviousHealth() const { return m_prevHealth; }
+	virtual Real getPreviousHealth() const override { return m_prevHealth; }
 
-	virtual void setIndestructible( Bool indestructible );
-	virtual Bool isIndestructible() const { return m_indestructible; }
+	virtual void setIndestructible( Bool indestructible ) override;
+	virtual Bool isIndestructible() const override { return m_indestructible; }
 
-	virtual void internalChangeHealth( Real delta );								///< change health
+	virtual void internalChangeHealth( Real delta ) override;								///< change health
 
-	virtual void evaluateVisualCondition();
-	virtual void updateBodyParticleSystems();// made public for topple anf building collapse updates -ML
+	virtual void evaluateVisualCondition() override;
+	virtual void updateBodyParticleSystems() override;// made public for topple anf building collapse updates -ML
 
 	// Subdual Damage
 	virtual Bool isSubdued() const;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ActiveShroudUpgrade.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ActiveShroudUpgrade.h
@@ -68,7 +68,7 @@ public:
 
 protected:
 
-	virtual void upgradeImplementation(); ///< Here's the actual work of Upgrading
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation() override; ///< Here's the actual work of Upgrading
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/AnimationSteeringUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/AnimationSteeringUpdate.h
@@ -73,7 +73,7 @@ public:
 	AnimationSteeringUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype defined by MemoryPoolObject
 
-	virtual UpdateSleepTime update(); ///< Here's the actual work of Upgrading
+	virtual UpdateSleepTime update() override; ///< Here's the actual work of Upgrading
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ArmorUpgrade.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ArmorUpgrade.h
@@ -75,8 +75,8 @@ public:
 	// virtual destructor prototype defined by MemoryPoolObject
 
 protected:
-	virtual void upgradeImplementation( ); ///< Here's the actual work of Upgrading
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation( ) override; ///< Here's the actual work of Upgrading
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 };
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/AssaultTransportAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/AssaultTransportAIUpdate.h
@@ -90,12 +90,12 @@ public:
 	AssaultTransportAIUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
- 	virtual void aiDoCommand(const AICommandParms* parms);
-	virtual Bool isIdle() const;
-	virtual UpdateSleepTime update();
-	virtual AssaultTransportAIInterface* getAssaultTransportAIInterface() { return this; }
-	virtual const AssaultTransportAIInterface* getAssaultTransportAIInterface() const { return this; }
-	virtual void beginAssault( const Object *designatedTarget ) const;
+ 	virtual void aiDoCommand(const AICommandParms* parms) override;
+	virtual Bool isIdle() const override;
+	virtual UpdateSleepTime update() override;
+	virtual AssaultTransportAIInterface* getAssaultTransportAIInterface() override { return this; }
+	virtual const AssaultTransportAIInterface* getAssaultTransportAIInterface() const override { return this; }
+	virtual void beginAssault( const Object *designatedTarget ) const override;
 
 	UpdateSleepTime calcSleepTime();
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/AssistedTargetingUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/AssistedTargetingUpdate.h
@@ -66,7 +66,7 @@ public:
 	AssistedTargetingUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	Bool isFreeToAssist() const;
 	void assistAttack( const Object *requestingObject, Object *victimObject );

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/AutoDepositUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/AutoDepositUpdate.h
@@ -117,7 +117,7 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	void awardInitialCaptureBonus( Player *player );	// Test and award the initial capture bonus
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/AutoFindHealingUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/AutoFindHealingUpdate.h
@@ -69,8 +69,8 @@ public:
 	AutoFindHealingUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onObjectCreated();
-	virtual UpdateSleepTime update();
+	virtual void onObjectCreated() override;
+	virtual UpdateSleepTime update() override;
 
 	Object* scanClosestTarget();
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/AutoHealBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/AutoHealBehavior.h
@@ -123,52 +123,52 @@ public:
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | MODULEINTERFACE_UPGRADE | MODULEINTERFACE_DAMAGE; }
 
 	// BehaviorModule
-	virtual UpgradeModuleInterface* getUpgrade() { return this; }
-	virtual DamageModuleInterface* getDamage() { return this; }
+	virtual UpgradeModuleInterface* getUpgrade() override { return this; }
+	virtual DamageModuleInterface* getDamage() override { return this; }
 
 	// DamageModuleInterface
-	virtual void onDamage( DamageInfo *damageInfo );
-	virtual void onHealing( DamageInfo *damageInfo ) { }
-	virtual void onBodyDamageStateChange(const DamageInfo* damageInfo, BodyDamageType oldState, BodyDamageType newState) { }
+	virtual void onDamage( DamageInfo *damageInfo ) override;
+	virtual void onHealing( DamageInfo *damageInfo ) override { }
+	virtual void onBodyDamageStateChange(const DamageInfo* damageInfo, BodyDamageType oldState, BodyDamageType newState) override { }
 
 	// UpdateModuleInterface
-	virtual UpdateSleepTime update();
-	virtual DisabledMaskType getDisabledTypesToProcess() const { return MAKE_DISABLED_MASK( DISABLED_HELD ); }
+	virtual UpdateSleepTime update() override;
+	virtual DisabledMaskType getDisabledTypesToProcess() const override { return MAKE_DISABLED_MASK( DISABLED_HELD ); }
 
 	void stopHealing();
 	void undoUpgrade(); ///<pretend like we have not been activated yet, so we can be reactivated later
 
 protected:
 
-	virtual void upgradeImplementation()
+	virtual void upgradeImplementation() override
 	{
 		setWakeFrame(getObject(), UPDATE_SLEEP_NONE);
 	}
 
-	virtual void getUpgradeActivationMasks(UpgradeMaskType& activation, UpgradeMaskType& conflicting) const
+	virtual void getUpgradeActivationMasks(UpgradeMaskType& activation, UpgradeMaskType& conflicting) const override
 	{
 		getAutoHealBehaviorModuleData()->m_upgradeMuxData.getUpgradeActivationMasks(activation, conflicting);
 	}
 
-	virtual void performUpgradeFX()
+	virtual void performUpgradeFX() override
 	{
 		getAutoHealBehaviorModuleData()->m_upgradeMuxData.performUpgradeFX(getObject());
 	}
 
-	virtual void processUpgradeRemoval()
+	virtual void processUpgradeRemoval() override
 	{
 		// I can't take it any more.  Let the record show that I think the UpgradeMux multiple inheritance is CRAP.
 		getAutoHealBehaviorModuleData()->m_upgradeMuxData.muxDataProcessUpgradeRemoval(getObject());
 	}
 
-	virtual Bool requiresAllActivationUpgrades() const
+	virtual Bool requiresAllActivationUpgrades() const override
 	{
 		return getAutoHealBehaviorModuleData()->m_upgradeMuxData.m_requiresAllTriggers;
 	}
 
 	Bool isUpgradeActive() const { return isAlreadyUpgraded(); }
 
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 
 private:

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BaikonurLaunchPower.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BaikonurLaunchPower.h
@@ -76,8 +76,8 @@ public:
 
 	BaikonurLaunchPower( Thing *thing, const ModuleData *moduleData );
 
-	virtual void doSpecialPower( UnsignedInt commandOptions );
-	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions );
+	virtual void doSpecialPower( UnsignedInt commandOptions ) override;
+	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions ) override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BaseRegenerateUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BaseRegenerateUpdate.h
@@ -64,16 +64,16 @@ public:
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | MODULEINTERFACE_DAMAGE; }
 
 	// BehaviorModule
-	virtual DamageModuleInterface* getDamage() { return this; }
+	virtual DamageModuleInterface* getDamage() override { return this; }
 
 	// UpdateModuleInterface
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	// DamageModuleInterface
-	virtual void onDamage( DamageInfo *damageInfo );
-	virtual void onHealing( DamageInfo *damageInfo ) { }
-	virtual void onBodyDamageStateChange(const DamageInfo* damageInfo, BodyDamageType oldState, BodyDamageType newState) { }
-	virtual DisabledMaskType getDisabledTypesToProcess() const { return MAKE_DISABLED_MASK( DISABLED_UNDERPOWERED ); }
+	virtual void onDamage( DamageInfo *damageInfo ) override;
+	virtual void onHealing( DamageInfo *damageInfo ) override { }
+	virtual void onBodyDamageStateChange(const DamageInfo* damageInfo, BodyDamageType oldState, BodyDamageType newState) override { }
+	virtual DisabledMaskType getDisabledTypesToProcess() const override { return MAKE_DISABLED_MASK( DISABLED_UNDERPOWERED ); }
 
 private:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BattleBusSlowDeathBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BattleBusSlowDeathBehavior.h
@@ -73,9 +73,9 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	// slow death methods
-	virtual void onDie( const DamageInfo *damageInfo );
-	virtual void beginSlowDeath( const DamageInfo *damageInfo );
-	virtual UpdateSleepTime update();
+	virtual void onDie( const DamageInfo *damageInfo ) override;
+	virtual void beginSlowDeath( const DamageInfo *damageInfo ) override;
+	virtual UpdateSleepTime update() override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BattlePlanUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BattlePlanUpdate.h
@@ -146,24 +146,24 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	// SpecialPowerUpdateInterface
-	virtual Bool initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions );
-	virtual Bool isSpecialAbility() const { return false; }
-	virtual Bool isSpecialPower() const { return true; }
-	virtual Bool isActive() const {return m_status != TRANSITIONSTATUS_IDLE;}
-	virtual SpecialPowerUpdateInterface* getSpecialPowerUpdateInterface() { return this; }
-	virtual Bool doesSpecialPowerHaveOverridableDestinationActive() const { return false; } //Is it active now?
-	virtual Bool doesSpecialPowerHaveOverridableDestination() const { return false; }	//Does it have it, even if it's not active?
-	virtual void setSpecialPowerOverridableDestination( const Coord3D *loc ) {}
-	virtual Bool isPowerCurrentlyInUse( const CommandButton *command = nullptr ) const;
+	virtual Bool initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions ) override;
+	virtual Bool isSpecialAbility() const override { return false; }
+	virtual Bool isSpecialPower() const override { return true; }
+	virtual Bool isActive() const override {return m_status != TRANSITIONSTATUS_IDLE;}
+	virtual SpecialPowerUpdateInterface* getSpecialPowerUpdateInterface() override { return this; }
+	virtual Bool doesSpecialPowerHaveOverridableDestinationActive() const override { return false; } //Is it active now?
+	virtual Bool doesSpecialPowerHaveOverridableDestination() const override { return false; }	//Does it have it, even if it's not active?
+	virtual void setSpecialPowerOverridableDestination( const Coord3D *loc ) override {}
+	virtual Bool isPowerCurrentlyInUse( const CommandButton *command = nullptr ) const override;
 
 	//Returns the currently active battle plan -- unpacked and ready... returns PLANSTATUS_NONE if in transition!
 	BattlePlanStatus getActiveBattlePlan() const;
 
-	virtual void onObjectCreated();
-	virtual void onDelete();
-	virtual UpdateSleepTime update();
+	virtual void onObjectCreated() override;
+	virtual void onDelete() override;
+	virtual UpdateSleepTime update() override;
 
-	virtual CommandOption getCommandOption() const;
+	virtual CommandOption getCommandOption() const override;
 protected:
 
 	void setStatus( TransitionStatus status );

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BehaviorModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BehaviorModule.h
@@ -153,51 +153,51 @@ public:
 	static Int getInterfaceMask() { return 0; }
 	static ModuleType getModuleType() { return MODULETYPE_BEHAVIOR; }
 
-	virtual BodyModuleInterface* getBody() { return nullptr; }
-	virtual CollideModuleInterface* getCollide() { return nullptr; }
-	virtual ContainModuleInterface* getContain() { return nullptr; }
-	virtual CreateModuleInterface* getCreate() { return nullptr; }
-	virtual DamageModuleInterface* getDamage() { return nullptr; }
-	virtual DestroyModuleInterface* getDestroy() { return nullptr; }
-	virtual DieModuleInterface* getDie() { return nullptr; }
-	virtual SpecialPowerModuleInterface* getSpecialPower() { return nullptr; }
-	virtual UpdateModuleInterface* getUpdate() { return nullptr; }
-	virtual UpgradeModuleInterface* getUpgrade() { return nullptr; }
+	virtual BodyModuleInterface* getBody() override { return nullptr; }
+	virtual CollideModuleInterface* getCollide() override { return nullptr; }
+	virtual ContainModuleInterface* getContain() override { return nullptr; }
+	virtual CreateModuleInterface* getCreate() override { return nullptr; }
+	virtual DamageModuleInterface* getDamage() override { return nullptr; }
+	virtual DestroyModuleInterface* getDestroy() override { return nullptr; }
+	virtual DieModuleInterface* getDie() override { return nullptr; }
+	virtual SpecialPowerModuleInterface* getSpecialPower() override { return nullptr; }
+	virtual UpdateModuleInterface* getUpdate() override { return nullptr; }
+	virtual UpgradeModuleInterface* getUpgrade() override { return nullptr; }
   virtual StealthUpdate* getStealth() { return nullptr; }
 	virtual SpyVisionUpdate* getSpyVisionUpdate() { return nullptr; }
 
-	virtual ParkingPlaceBehaviorInterface* getParkingPlaceBehaviorInterface() { return nullptr; }
-	virtual RebuildHoleBehaviorInterface* getRebuildHoleBehaviorInterface() { return nullptr; }
-	virtual BridgeBehaviorInterface* getBridgeBehaviorInterface() { return nullptr; }
-	virtual BridgeTowerBehaviorInterface* getBridgeTowerBehaviorInterface() { return nullptr; }
-	virtual BridgeScaffoldBehaviorInterface* getBridgeScaffoldBehaviorInterface() { return nullptr; }
-	virtual OverchargeBehaviorInterface* getOverchargeBehaviorInterface() { return nullptr; }
-	virtual TransportPassengerInterface* getTransportPassengerInterface() { return nullptr; }
-	virtual CaveInterface* getCaveInterface() { return nullptr; }
-	virtual LandMineInterface* getLandMineInterface() { return nullptr; }
-	virtual DieModuleInterface* getEjectPilotDieInterface() { return nullptr; }
+	virtual ParkingPlaceBehaviorInterface* getParkingPlaceBehaviorInterface() override { return nullptr; }
+	virtual RebuildHoleBehaviorInterface* getRebuildHoleBehaviorInterface() override { return nullptr; }
+	virtual BridgeBehaviorInterface* getBridgeBehaviorInterface() override { return nullptr; }
+	virtual BridgeTowerBehaviorInterface* getBridgeTowerBehaviorInterface() override { return nullptr; }
+	virtual BridgeScaffoldBehaviorInterface* getBridgeScaffoldBehaviorInterface() override { return nullptr; }
+	virtual OverchargeBehaviorInterface* getOverchargeBehaviorInterface() override { return nullptr; }
+	virtual TransportPassengerInterface* getTransportPassengerInterface() override { return nullptr; }
+	virtual CaveInterface* getCaveInterface() override { return nullptr; }
+	virtual LandMineInterface* getLandMineInterface() override { return nullptr; }
+	virtual DieModuleInterface* getEjectPilotDieInterface() override { return nullptr; }
 	// interface acquisition (moved from UpdateModule)
-	virtual ProjectileUpdateInterface* getProjectileUpdateInterface() { return nullptr; }
-	virtual AIUpdateInterface* getAIUpdateInterface() { return nullptr; }
-	virtual ExitInterface* getUpdateExitInterface() { return nullptr; }
-	virtual DockUpdateInterface* getDockUpdateInterface() { return nullptr; }
-	virtual RailedTransportDockUpdateInterface *getRailedTransportDockUpdateInterface() { return nullptr; }
-	virtual SlowDeathBehaviorInterface* getSlowDeathBehaviorInterface() { return nullptr; }
-	virtual SpecialPowerUpdateInterface* getSpecialPowerUpdateInterface() { return nullptr; }
-	virtual SlavedUpdateInterface* getSlavedUpdateInterface() { return nullptr; }
-	virtual ProductionUpdateInterface* getProductionUpdateInterface() { return nullptr; }
-	virtual HordeUpdateInterface* getHordeUpdateInterface() { return nullptr; }
-	virtual PowerPlantUpdateInterface* getPowerPlantUpdateInterface() { return nullptr; }
-	virtual SpawnBehaviorInterface* getSpawnBehaviorInterface() { return nullptr; }
-	virtual CountermeasuresBehaviorInterface* getCountermeasuresBehaviorInterface() { return nullptr; }
-	virtual const CountermeasuresBehaviorInterface* getCountermeasuresBehaviorInterface() const { return nullptr; }
+	virtual ProjectileUpdateInterface* getProjectileUpdateInterface() override { return nullptr; }
+	virtual AIUpdateInterface* getAIUpdateInterface() override { return nullptr; }
+	virtual ExitInterface* getUpdateExitInterface() override { return nullptr; }
+	virtual DockUpdateInterface* getDockUpdateInterface() override { return nullptr; }
+	virtual RailedTransportDockUpdateInterface *getRailedTransportDockUpdateInterface() override { return nullptr; }
+	virtual SlowDeathBehaviorInterface* getSlowDeathBehaviorInterface() override { return nullptr; }
+	virtual SpecialPowerUpdateInterface* getSpecialPowerUpdateInterface() override { return nullptr; }
+	virtual SlavedUpdateInterface* getSlavedUpdateInterface() override { return nullptr; }
+	virtual ProductionUpdateInterface* getProductionUpdateInterface() override { return nullptr; }
+	virtual HordeUpdateInterface* getHordeUpdateInterface() override { return nullptr; }
+	virtual PowerPlantUpdateInterface* getPowerPlantUpdateInterface() override { return nullptr; }
+	virtual SpawnBehaviorInterface* getSpawnBehaviorInterface() override { return nullptr; }
+	virtual CountermeasuresBehaviorInterface* getCountermeasuresBehaviorInterface() override { return nullptr; }
+	virtual const CountermeasuresBehaviorInterface* getCountermeasuresBehaviorInterface() const override { return nullptr; }
 
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 };
 inline BehaviorModule::BehaviorModule( Thing *thing, const ModuleData* moduleData ) : ObjectModule( thing, moduleData ) { }

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BodyModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BodyModule.h
@@ -246,7 +246,7 @@ public:
 
 	virtual UnsignedInt getSubdualDamageHealRate() const override {return 0;}
 	virtual Real getSubdualDamageHealAmount() const override {return 0.0f;}
-	virtual Bool hasAnySubdualDamage() const override{return FALSE;}
+	virtual Bool hasAnySubdualDamage() const override {return FALSE;}
 	virtual Real getCurrentSubdualDamageAmount() const override { return 0.0f; }
 
 	virtual Real getInitialHealth() const override {return 0.0f;}  // return initial health

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BodyModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BodyModule.h
@@ -223,13 +223,13 @@ public:
 		considerably from what you requested. Also note that (if damage is done)
 		the DamageFX will be invoked to provide a/v fx as appropriate.
 	*/
-	virtual void attemptDamage( DamageInfo *damageInfo ) override = 0;
+	virtual void attemptDamage( DamageInfo *damageInfo ) = 0;
 
 	/**
 		Instead of having negative damage count as healing, or allowing access to the private
 		changeHealth Method, we will use this parallel to attemptDamage to do healing without hack.
 	*/
-	virtual void attemptHealing( DamageInfo *healingInfo ) override = 0;
+	virtual void attemptHealing( DamageInfo *healingInfo ) = 0;
 
 	/**
 		Estimate the (unclipped) damage that would be done to this object
@@ -237,9 +237,9 @@ public:
 		but DO NOT alter the body in any way. (This is used by the AI system
 		to choose weapons.)
 	*/
-	virtual Real estimateDamage( DamageInfoInput& damageInfo ) const override = 0;
+	virtual Real estimateDamage( DamageInfoInput& damageInfo ) const = 0;
 
-	virtual Real getHealth() const override = 0;													///< get current health
+	virtual Real getHealth() const = 0;													///< get current health
 
 	virtual Real getMaxHealth() const override {return 0.0f;}  ///< return max health
 	virtual Real getPreviousHealth() const override { return 0.0f; } ///< return previous health
@@ -251,15 +251,15 @@ public:
 
 	virtual Real getInitialHealth() const override {return 0.0f;}  // return initial health
 
-	virtual BodyDamageType getDamageState() const override = 0;
-	virtual void setDamageState( BodyDamageType newState ) override = 0;	///< control damage state directly.  Will adjust hitpoints.
-	virtual void setAflame( Bool setting ) override = 0;///< This is a major change like a damage state.
+	virtual BodyDamageType getDamageState() const = 0;
+	virtual void setDamageState( BodyDamageType newState ) = 0;	///< control damage state directly.  Will adjust hitpoints.
+	virtual void setAflame( Bool setting ) = 0;///< This is a major change like a damage state.
 
-	virtual void onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel newLevel, Bool provideFeedback = FALSE ) override = 0;	///< I just achieved this level right this moment
+	virtual void onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel newLevel, Bool provideFeedback = FALSE ) = 0;	///< I just achieved this level right this moment
 
-	virtual void setArmorSetFlag(ArmorSetType ast) override = 0;
-	virtual void clearArmorSetFlag(ArmorSetType ast) override = 0;
-	virtual Bool testArmorSetFlag(ArmorSetType ast) override = 0;
+	virtual void setArmorSetFlag(ArmorSetType ast) = 0;
+	virtual void clearArmorSetFlag(ArmorSetType ast) = 0;
+	virtual Bool testArmorSetFlag(ArmorSetType ast) = 0;
 
 	virtual const DamageInfo *getLastDamageInfo() const override { return nullptr; }	///< return info on last damage dealt to this object
 	virtual UnsignedInt getLastDamageTimestamp() const override { return 0; }	///< return frame of last damage dealt
@@ -290,7 +290,7 @@ public:
 		call this directly (especially when when decreasing health, since
 		you probably want "attemptDamage" or "attemptHealing")
 	*/
-	virtual void internalChangeHealth( Real delta ) override = 0;
+	virtual void internalChangeHealth( Real delta ) = 0;
 
 	virtual void evaluateVisualCondition() override { }
 	virtual void updateBodyParticleSystems() override { };// made public for topple anf building collapse updates -ML

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BodyModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BodyModule.h
@@ -215,7 +215,7 @@ public:
 	static Int getInterfaceMask() { return MODULEINTERFACE_BODY; }
 
 	// BehaviorModule
-	virtual BodyModuleInterface* getBody() { return this; }
+	virtual BodyModuleInterface* getBody() override { return this; }
 
 	/**
 		Try to damage this Object. The module's Armor
@@ -223,13 +223,13 @@ public:
 		considerably from what you requested. Also note that (if damage is done)
 		the DamageFX will be invoked to provide a/v fx as appropriate.
 	*/
-	virtual void attemptDamage( DamageInfo *damageInfo ) = 0;
+	virtual void attemptDamage( DamageInfo *damageInfo ) override = 0;
 
 	/**
 		Instead of having negative damage count as healing, or allowing access to the private
 		changeHealth Method, we will use this parallel to attemptDamage to do healing without hack.
 	*/
-	virtual void attemptHealing( DamageInfo *healingInfo ) = 0;
+	virtual void attemptHealing( DamageInfo *healingInfo ) override = 0;
 
 	/**
 		Estimate the (unclipped) damage that would be done to this object
@@ -237,51 +237,51 @@ public:
 		but DO NOT alter the body in any way. (This is used by the AI system
 		to choose weapons.)
 	*/
-	virtual Real estimateDamage( DamageInfoInput& damageInfo ) const = 0;
+	virtual Real estimateDamage( DamageInfoInput& damageInfo ) const override = 0;
 
-	virtual Real getHealth() const = 0;													///< get current health
+	virtual Real getHealth() const override = 0;													///< get current health
 
-	virtual Real getMaxHealth() const {return 0.0f;}  ///< return max health
-	virtual Real getPreviousHealth() const { return 0.0f; } ///< return previous health
+	virtual Real getMaxHealth() const override {return 0.0f;}  ///< return max health
+	virtual Real getPreviousHealth() const override { return 0.0f; } ///< return previous health
 
-	virtual UnsignedInt getSubdualDamageHealRate() const {return 0;}
-	virtual Real getSubdualDamageHealAmount() const {return 0.0f;}
-	virtual Bool hasAnySubdualDamage() const{return FALSE;}
-	virtual Real getCurrentSubdualDamageAmount() const { return 0.0f; }
+	virtual UnsignedInt getSubdualDamageHealRate() const override {return 0;}
+	virtual Real getSubdualDamageHealAmount() const override {return 0.0f;}
+	virtual Bool hasAnySubdualDamage() const override{return FALSE;}
+	virtual Real getCurrentSubdualDamageAmount() const override { return 0.0f; }
 
-	virtual Real getInitialHealth() const {return 0.0f;}  // return initial health
+	virtual Real getInitialHealth() const override {return 0.0f;}  // return initial health
 
-	virtual BodyDamageType getDamageState() const = 0;
-	virtual void setDamageState( BodyDamageType newState ) = 0;	///< control damage state directly.  Will adjust hitpoints.
-	virtual void setAflame( Bool setting ) = 0;///< This is a major change like a damage state.
+	virtual BodyDamageType getDamageState() const override = 0;
+	virtual void setDamageState( BodyDamageType newState ) override = 0;	///< control damage state directly.  Will adjust hitpoints.
+	virtual void setAflame( Bool setting ) override = 0;///< This is a major change like a damage state.
 
-	virtual void onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel newLevel, Bool provideFeedback = FALSE ) = 0;	///< I just achieved this level right this moment
+	virtual void onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel newLevel, Bool provideFeedback = FALSE ) override = 0;	///< I just achieved this level right this moment
 
-	virtual void setArmorSetFlag(ArmorSetType ast) = 0;
-	virtual void clearArmorSetFlag(ArmorSetType ast) = 0;
-	virtual Bool testArmorSetFlag(ArmorSetType ast) = 0;
+	virtual void setArmorSetFlag(ArmorSetType ast) override = 0;
+	virtual void clearArmorSetFlag(ArmorSetType ast) override = 0;
+	virtual Bool testArmorSetFlag(ArmorSetType ast) override = 0;
 
-	virtual const DamageInfo *getLastDamageInfo() const { return nullptr; }	///< return info on last damage dealt to this object
-	virtual UnsignedInt getLastDamageTimestamp() const { return 0; }	///< return frame of last damage dealt
-	virtual UnsignedInt getLastHealingTimestamp() const { return 0; }	///< return frame of last healing dealt
-	virtual ObjectID getClearableLastAttacker() const { return INVALID_ID; }
-	virtual void clearLastAttacker() { }
-	virtual Bool getFrontCrushed() const { return false; }
-	virtual Bool getBackCrushed() const { return false; }
+	virtual const DamageInfo *getLastDamageInfo() const override { return nullptr; }	///< return info on last damage dealt to this object
+	virtual UnsignedInt getLastDamageTimestamp() const override { return 0; }	///< return frame of last damage dealt
+	virtual UnsignedInt getLastHealingTimestamp() const override { return 0; }	///< return frame of last healing dealt
+	virtual ObjectID getClearableLastAttacker() const override { return INVALID_ID; }
+	virtual void clearLastAttacker() override { }
+	virtual Bool getFrontCrushed() const override { return false; }
+	virtual Bool getBackCrushed() const override { return false; }
 
-	virtual void setInitialHealth(Int initialPercent)  {  } ///< Sets the initial load health %.
-	virtual void setMaxHealth(Real maxHealth, MaxHealthChangeType healthChangeType = SAME_CURRENTHEALTH )  {  } ///< Sets the max health.
+	virtual void setInitialHealth(Int initialPercent) override  {  } ///< Sets the initial load health %.
+	virtual void setMaxHealth(Real maxHealth, MaxHealthChangeType healthChangeType = SAME_CURRENTHEALTH ) override  {  } ///< Sets the max health.
 
-	virtual void setFrontCrushed(Bool v) { DEBUG_CRASH(("you should never call this for generic Bodys")); }
-	virtual void setBackCrushed(Bool v) { DEBUG_CRASH(("you should never call this for generic Bodys")); }
+	virtual void setFrontCrushed(Bool v) override { DEBUG_CRASH(("you should never call this for generic Bodys")); }
+	virtual void setBackCrushed(Bool v) override { DEBUG_CRASH(("you should never call this for generic Bodys")); }
 
 
-	virtual void setIndestructible( Bool indestructible ) { }
-	virtual Bool isIndestructible() const { return TRUE; }
+	virtual void setIndestructible( Bool indestructible ) override { }
+	virtual Bool isIndestructible() const override { return TRUE; }
 
 	//Allows outside systems to apply defensive bonuses or penalties (they all stack as a multiplier!)
-	virtual void applyDamageScalar( Real scalar ) { m_damageScalar *= scalar; }
-	virtual Real getDamageScalar() const { return m_damageScalar; }
+	virtual void applyDamageScalar( Real scalar ) override { m_damageScalar *= scalar; }
+	virtual Real getDamageScalar() const override { return m_damageScalar; }
 
 	/**
 		Change the module's health by the given delta. Note that
@@ -290,17 +290,17 @@ public:
 		call this directly (especially when when decreasing health, since
 		you probably want "attemptDamage" or "attemptHealing")
 	*/
-	virtual void internalChangeHealth( Real delta ) = 0;
+	virtual void internalChangeHealth( Real delta ) override = 0;
 
-	virtual void evaluateVisualCondition() { }
-	virtual void updateBodyParticleSystems() { };// made public for topple anf building collapse updates -ML
+	virtual void evaluateVisualCondition() override { }
+	virtual void updateBodyParticleSystems() override { };// made public for topple anf building collapse updates -ML
 
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	Real	m_damageScalar;
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BoneFXDamage.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BoneFXDamage.h
@@ -52,14 +52,14 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	// damage module methods
-	virtual void onDamage( DamageInfo *damageInfo ) { }
-	virtual void onHealing( DamageInfo *damageInfo ) { }
+	virtual void onDamage( DamageInfo *damageInfo ) override { }
+	virtual void onHealing( DamageInfo *damageInfo ) override { }
 	virtual void onBodyDamageStateChange( const DamageInfo* damageInfo,
 																				BodyDamageType oldState,
-																				BodyDamageType newState );
+																				BodyDamageType newState ) override;
 
 protected:
 
-	virtual void onObjectCreated();
+	virtual void onObjectCreated() override;
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BoneFXUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BoneFXUpdate.h
@@ -241,11 +241,11 @@ public:
 	void changeBodyDamageState( BodyDamageType oldState, BodyDamageType newState);
 	void stopAllBoneFX();
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 protected:
 
-	virtual void onObjectCreated();
+	virtual void onObjectCreated() override;
 
 	virtual void resolveBoneLocations();
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BridgeBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BridgeBehavior.h
@@ -95,7 +95,7 @@ class BridgeBehaviorModuleData : public BehaviorModuleData
 public:
 
 	BridgeBehaviorModuleData();
-	~BridgeBehaviorModuleData();
+	~BridgeBehaviorModuleData() override;
 
 	static void buildFieldParse( MultiIniFieldParse &p );
 
@@ -129,33 +129,33 @@ public:
 	static Int getInterfaceMask() { return (MODULEINTERFACE_DAMAGE) |
 																							 (MODULEINTERFACE_DIE) |
 																							 (MODULEINTERFACE_UPDATE); }
-	virtual BridgeBehaviorInterface* getBridgeBehaviorInterface() { return this; }
-	virtual void onDelete();
+	virtual BridgeBehaviorInterface* getBridgeBehaviorInterface() override { return this; }
+	virtual void onDelete() override;
 
 	// Damage methods
-	virtual DamageModuleInterface* getDamage() { return this; }
-	virtual void onDamage( DamageInfo *damageInfo );
-	virtual void onHealing( DamageInfo *damageInfo );
+	virtual DamageModuleInterface* getDamage() override { return this; }
+	virtual void onDamage( DamageInfo *damageInfo ) override;
+	virtual void onHealing( DamageInfo *damageInfo ) override;
 	virtual void onBodyDamageStateChange( const DamageInfo* damageInfo,
 																				BodyDamageType oldState,
-																				BodyDamageType newState );
+																				BodyDamageType newState ) override;
 
 	// Die methods
-	virtual DieModuleInterface* getDie() { return this; }
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual DieModuleInterface* getDie() override { return this; }
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 	// Update methods
-	virtual UpdateModuleInterface *getUpdate() { return this; }
-	virtual UpdateSleepTime update();
+	virtual UpdateModuleInterface *getUpdate() override { return this; }
+	virtual UpdateSleepTime update() override;
 
 	// our own methods
 	static BridgeBehaviorInterface *getBridgeBehaviorInterfaceFromObject( Object *obj );
-	virtual void setTower( BridgeTowerType towerType, Object *tower );	///< connect tower to us
-	virtual ObjectID getTowerID( BridgeTowerType towerType );						///< retrieve one of our towers
-	virtual void createScaffolding();		///< create scaffolding around bridge
-	virtual void removeScaffolding();		///< remove scaffolding around bridge
-	virtual Bool isScaffoldInMotion();	///< is scaffold in motion
-	virtual Bool isScaffoldPresent() { return m_scaffoldPresent; }
+	virtual void setTower( BridgeTowerType towerType, Object *tower ) override;	///< connect tower to us
+	virtual ObjectID getTowerID( BridgeTowerType towerType ) override;						///< retrieve one of our towers
+	virtual void createScaffolding() override;		///< create scaffolding around bridge
+	virtual void removeScaffolding() override;		///< remove scaffolding around bridge
+	virtual Bool isScaffoldInMotion() override;	///< is scaffold in motion
+	virtual Bool isScaffoldPresent() override { return m_scaffoldPresent; }
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BridgeBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BridgeBehavior.h
@@ -95,7 +95,7 @@ class BridgeBehaviorModuleData : public BehaviorModuleData
 public:
 
 	BridgeBehaviorModuleData();
-	~BridgeBehaviorModuleData() override;
+	virtual ~BridgeBehaviorModuleData() override;
 
 	static void buildFieldParse( MultiIniFieldParse &p );
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BridgeScaffoldBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BridgeScaffoldBehavior.h
@@ -77,20 +77,20 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	// behavior module methods
-	virtual BridgeScaffoldBehaviorInterface* getBridgeScaffoldBehaviorInterface() { return this; }
+	virtual BridgeScaffoldBehaviorInterface* getBridgeScaffoldBehaviorInterface() override { return this; }
 
 	// update methods
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	// bridge scaffold interface methods
 	virtual void setPositions( const Coord3D *createPos,
 														 const Coord3D *riseToPos,
-														 const Coord3D *buildPos );
-	virtual void setMotion( ScaffoldTargetMotion targetMotion );
-	virtual ScaffoldTargetMotion getCurrentMotion() { return m_targetMotion; }
-	virtual void reverseMotion();
-	virtual void setLateralSpeed( Real lateralSpeed ) { m_lateralSpeed = lateralSpeed; }
-	virtual void setVerticalSpeed( Real verticalSpeed ) { m_verticalSpeed = verticalSpeed; }
+														 const Coord3D *buildPos ) override;
+	virtual void setMotion( ScaffoldTargetMotion targetMotion ) override;
+	virtual ScaffoldTargetMotion getCurrentMotion() override { return m_targetMotion; }
+	virtual void reverseMotion() override;
+	virtual void setLateralSpeed( Real lateralSpeed ) override { m_lateralSpeed = lateralSpeed; }
+	virtual void setVerticalSpeed( Real verticalSpeed ) override { m_verticalSpeed = verticalSpeed; }
 
 	// public interface acquisition
 	static BridgeScaffoldBehaviorInterface *getBridgeScaffoldBehaviorInterfaceFromObject( Object *obj );

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BridgeTowerBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BridgeTowerBehavior.h
@@ -66,7 +66,7 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	static Int getInterfaceMask() { return (MODULEINTERFACE_DAMAGE) | (MODULEINTERFACE_DIE); }
-	BridgeTowerBehaviorInterface* getBridgeTowerBehaviorInterface() override { return this; }
+	virtual BridgeTowerBehaviorInterface* getBridgeTowerBehaviorInterface() override { return this; }
 
 	virtual void setBridge( Object *bridge ) override;
 	virtual ObjectID getBridgeID() override;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BridgeTowerBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BridgeTowerBehavior.h
@@ -66,25 +66,25 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	static Int getInterfaceMask() { return (MODULEINTERFACE_DAMAGE) | (MODULEINTERFACE_DIE); }
-	BridgeTowerBehaviorInterface* getBridgeTowerBehaviorInterface() { return this; }
+	BridgeTowerBehaviorInterface* getBridgeTowerBehaviorInterface() override { return this; }
 
-	virtual void setBridge( Object *bridge );
-	virtual ObjectID getBridgeID();
-	virtual void setTowerType( BridgeTowerType type );
+	virtual void setBridge( Object *bridge ) override;
+	virtual ObjectID getBridgeID() override;
+	virtual void setTowerType( BridgeTowerType type ) override;
 
 	static BridgeTowerBehaviorInterface *getBridgeTowerBehaviorInterfaceFromObject( Object *obj );
 
 	// Damage methods
-	virtual DamageModuleInterface* getDamage() { return this; }
-	virtual void onDamage( DamageInfo *damageInfo );
-	virtual void onHealing( DamageInfo *damageInfo );
+	virtual DamageModuleInterface* getDamage() override { return this; }
+	virtual void onDamage( DamageInfo *damageInfo ) override;
+	virtual void onHealing( DamageInfo *damageInfo ) override;
 	virtual void onBodyDamageStateChange( const DamageInfo* damageInfo,
 																				BodyDamageType oldState,
-																				BodyDamageType newState );
+																				BodyDamageType newState ) override;
 
 	// Die methods
-	virtual DieModuleInterface* getDie() { return this; }
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual DieModuleInterface* getDie() override { return this; }
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BunkerBusterBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BunkerBusterBehavior.h
@@ -83,12 +83,12 @@ public:
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_DIE); }
 
 	// update module methods
-	virtual UpdateSleepTime update();
-  virtual void onObjectCreated();
+	virtual UpdateSleepTime update() override;
+  virtual void onObjectCreated() override;
 
 	// die module methods
-	virtual DieModuleInterface *getDie() { return this; }
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual DieModuleInterface *getDie() override { return this; }
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CashBountyPower.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CashBountyPower.h
@@ -113,11 +113,11 @@ public:
 	CashBountyPower( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype defined by MemoryPoolObject
 
-	virtual void onObjectCreated();
+	virtual void onObjectCreated() override;
 
 	//virtual void onBuildComplete();	///< This is called when you are a finished game object
-	virtual void onSpecialPowerCreation();	///< This is called when you are a finished game object
-	virtual void doSpecialPower( UnsignedInt commandOptions ) { return; }
+	virtual void onSpecialPowerCreation() override;	///< This is called when you are a finished game object
+	virtual void doSpecialPower( UnsignedInt commandOptions ) override { return; }
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CashHackSpecialPower.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CashHackSpecialPower.h
@@ -74,8 +74,8 @@ public:
 	CashHackSpecialPower( Thing *thing, const ModuleData *moduleData );
 	// virtual destructor provided by memory pool object
 
-	virtual void doSpecialPowerAtObject( Object *obj, UnsignedInt commandOptions );
-	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions );
+	virtual void doSpecialPowerAtObject( Object *obj, UnsignedInt commandOptions ) override;
+	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions ) override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CaveContain.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CaveContain.h
@@ -74,45 +74,45 @@ public:
 	CaveContain( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual CreateModuleInterface* getCreate() { return this; }
-	virtual CaveInterface* getCaveInterface() { return this; }
+	virtual CreateModuleInterface* getCreate() override { return this; }
+	virtual CaveInterface* getCaveInterface() override { return this; }
 	static Int getInterfaceMask() { return OpenContain::getInterfaceMask() | (MODULEINTERFACE_CREATE); }
 
-	virtual OpenContain *asOpenContain() { return this; }  ///< treat as open container
-	virtual Bool isGarrisonable() const { return false; }	///< can this unit be Garrisoned? (ick)
-	virtual Bool isBustable() const { return TRUE; }	///< can this container get busted by a bunkerbuster
-	virtual Bool isHealContain() const { return false; } ///< true when container only contains units while healing (not a transport!)
+	virtual OpenContain *asOpenContain() override { return this; }  ///< treat as open container
+	virtual Bool isGarrisonable() const override { return false; }	///< can this unit be Garrisoned? (ick)
+	virtual Bool isBustable() const override { return TRUE; }	///< can this container get busted by a bunkerbuster
+	virtual Bool isHealContain() const override { return false; } ///< true when container only contains units while healing (not a transport!)
 
-	virtual void onContaining( Object *obj, Bool wasSelected );		///< object now contains 'obj'
-	virtual void onRemoving( Object *obj );			///< object no longer contains 'obj'
+	virtual void onContaining( Object *obj, Bool wasSelected ) override;		///< object now contains 'obj'
+	virtual void onRemoving( Object *obj ) override;			///< object no longer contains 'obj'
 
-	virtual Bool isValidContainerFor(const Object* obj, Bool checkCapacity) const;
-	virtual void addToContainList( Object *obj );		///< The part of AddToContain that inheritors can override (Can't do whole thing because of all the private stuff involved)
-	virtual void removeFromContain( Object *obj, Bool exposeStealthUnits = FALSE );	///< remove 'obj' from contain list
-	virtual void removeAllContained( Bool exposeStealthUnits = FALSE );				///< remove all objects on contain list
+	virtual Bool isValidContainerFor(const Object* obj, Bool checkCapacity) const override;
+	virtual void addToContainList( Object *obj ) override;		///< The part of AddToContain that inheritors can override (Can't do whole thing because of all the private stuff involved)
+	virtual void removeFromContain( Object *obj, Bool exposeStealthUnits = FALSE ) override;	///< remove 'obj' from contain list
+	virtual void removeAllContained( Bool exposeStealthUnits = FALSE ) override;				///< remove all objects on contain list
 
 	/**
 		return the player that *appears* to control this unit. if null, use getObject()->getControllingPlayer() instead.
 	*/
-	virtual void recalcApparentControllingPlayer();
+	virtual void recalcApparentControllingPlayer() override;
 
 	// contain list access
-	virtual void iterateContained( ContainIterateFunc func, void *userData, Bool reverse );
-	virtual UnsignedInt getContainCount() const;
-	virtual Int getContainMax() const;
-	virtual const ContainedItemsList* getContainedItemsList() const;
-	virtual Bool isKickOutOnCapture(){ return FALSE; }///< Caves and Tunnels don't kick out on capture.
+	virtual void iterateContained( ContainIterateFunc func, void *userData, Bool reverse ) override;
+	virtual UnsignedInt getContainCount() const override;
+	virtual Int getContainMax() const override;
+	virtual const ContainedItemsList* getContainedItemsList() const override;
+	virtual Bool isKickOutOnCapture() override { return FALSE; }///< Caves and Tunnels don't kick out on capture.
 
 	// override the onDie we inherit from OpenContain
-	virtual void onDie( const DamageInfo *damageInfo );  ///< the die callback
+	virtual void onDie( const DamageInfo *damageInfo ) override;  ///< the die callback
 
-	virtual void onCreate();
-	virtual void onBuildComplete();	///< This is called when you are a finished game object
-	virtual Bool shouldDoOnBuildComplete() const { return m_needToRunOnBuildComplete; }
+	virtual void onCreate() override;
+	virtual void onBuildComplete() override;	///< This is called when you are a finished game object
+	virtual Bool shouldDoOnBuildComplete() const override { return m_needToRunOnBuildComplete; }
 
 	// Unique to Cave Contain
-	virtual void tryToSetCaveIndex( Int newIndex );	///< Called by script as an alternative to instancing separate objects.  'Try', because can fail.
-	virtual void setOriginalTeam( Team *oldTeam );	///< This is a distributed Garrison in terms of capturing, so when one node triggers the change, he needs to tell everyone, so anyone can do the un-change.
+	virtual void tryToSetCaveIndex( Int newIndex ) override;	///< Called by script as an alternative to instancing separate objects.  'Try', because can fail.
+	virtual void setOriginalTeam( Team *oldTeam ) override;	///< This is a distributed Garrison in terms of capturing, so when one node triggers the change, he needs to tell everyone, so anyone can do the un-change.
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CheckpointUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CheckpointUpdate.h
@@ -74,7 +74,7 @@ public:
 	CheckpointUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 protected:
 	Bool m_enemyNear;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ChinookAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ChinookAIUpdate.h
@@ -85,21 +85,21 @@ public:
 	ChinookAIUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual UpdateSleepTime update();
- 	virtual void aiDoCommand(const AICommandParms* parms);
-	virtual Bool chooseLocomotorSet(LocomotorSetType wst);
+	virtual UpdateSleepTime update() override;
+ 	virtual void aiDoCommand(const AICommandParms* parms) override;
+	virtual Bool chooseLocomotorSet(LocomotorSetType wst) override;
 	// this is present solely for some transports to override, so that they can land before
 	// allowing people to exit...
-	virtual AIFreeToExitType getAiFreeToExit(const Object* exiter) const;
-	virtual Bool isAllowedToAdjustDestination() const;
-	virtual ObjectID getBuildingToNotPathAround() const;
+	virtual AIFreeToExitType getAiFreeToExit(const Object* exiter) const override;
+	virtual Bool isAllowedToAdjustDestination() const override;
+	virtual ObjectID getBuildingToNotPathAround() const override;
 
 	// this is present for subclasses (eg, Chinook) to override, to
 	// prevent supply-ferry behavior in some cases (eg, when toting passengers)
-	virtual Bool isAvailableForSupplying() const;
-	virtual Bool isCurrentlyFerryingSupplies() const;
+	virtual Bool isAvailableForSupplying() const override;
+	virtual Bool isCurrentlyFerryingSupplies() const override;
 
-	virtual Bool isIdle() const;
+	virtual Bool isIdle() const override;
 
 	const ChinookAIUpdateModuleData* friend_getData() const { return getChinookAIUpdateModuleData(); }
 	void friend_setFlightStatus(ChinookFlightStatus a) { m_flightStatus = a; }
@@ -107,21 +107,21 @@ public:
 	void recordOriginalPosition( const Coord3D &pos ) { m_originalPos.set( &pos ); }
 	const Coord3D* getOriginalPosition() const { return &m_originalPos; }
 
-	Int getUpgradedSupplyBoost() const;
+	virtual Int getUpgradedSupplyBoost() const override;
 
 protected:
 
-	virtual AIStateMachine* makeStateMachine();
+	virtual AIStateMachine* makeStateMachine() override;
 
-	virtual void privateCombatDrop( Object *target, const Coord3D& pos, CommandSourceType cmdSource );
-	virtual void privateGetRepaired( Object *repairDepot, CommandSourceType cmdSource );///< get repaired at repair depot
+	virtual void privateCombatDrop( Object *target, const Coord3D& pos, CommandSourceType cmdSource ) override;
+	virtual void privateGetRepaired( Object *repairDepot, CommandSourceType cmdSource ) override;///< get repaired at repair depot
 
 
-	virtual void privateAttackObject( Object *victim, Int maxShotsToFire, CommandSourceType cmdSource );///< Extension.  Also tell occupants to attackObject
-	virtual void privateAttackPosition( const Coord3D *pos, Int maxShotsToFire, CommandSourceType cmdSource );///< Extension.  Also tell occupants to attackPosition
-	virtual void privateForceAttackObject( Object *victim, Int maxShotsToFire, CommandSourceType cmdSource );///< Extension.  Also tell occupants to forceAttackObject
+	virtual void privateAttackObject( Object *victim, Int maxShotsToFire, CommandSourceType cmdSource ) override;///< Extension.  Also tell occupants to attackObject
+	virtual void privateAttackPosition( const Coord3D *pos, Int maxShotsToFire, CommandSourceType cmdSource ) override;///< Extension.  Also tell occupants to attackPosition
+	virtual void privateForceAttackObject( Object *victim, Int maxShotsToFire, CommandSourceType cmdSource ) override;///< Extension.  Also tell occupants to forceAttackObject
 
-  virtual void privateIdle(CommandSourceType cmdSource);
+  virtual void privateIdle(CommandSourceType cmdSource) override;
 
   void private___TellPortableStructureToAttackWithMe( Object *victim, Int maxShotsToFire, CommandSourceType cmdSource );
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CleanupAreaPower.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CleanupAreaPower.h
@@ -70,5 +70,5 @@ public:
 	CleanupAreaPower( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype defined by MemoryPoolObject
 
-	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions );
+	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions ) override;
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CleanupHazardUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CleanupHazardUpdate.h
@@ -68,8 +68,8 @@ public:
 	CleanupHazardUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onObjectCreated();
-	virtual UpdateSleepTime update();
+	virtual void onObjectCreated() override;
+	virtual UpdateSleepTime update() override;
 
 	Object* scanClosestTarget();
 	void fireWhenReady();

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CollideModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CollideModule.h
@@ -83,17 +83,17 @@ public:
 	static Int getInterfaceMask() { return MODULEINTERFACE_COLLIDE; }
 
 	// BehaviorModule
-	virtual CollideModuleInterface* getCollide() { return this; }
+	virtual CollideModuleInterface* getCollide() override { return this; }
 
-	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal ) = 0;
+	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal ) override = 0;
 
 	/// this is used for things like pilots, to determine if they can "enter" something
-	virtual Bool wouldLikeToCollideWith(const Object* other) const { return false; }
-	virtual Bool isHijackedVehicleCrateCollide() const { return false; }
-	virtual Bool isSabotageBuildingCrateCollide() const { return false; }
-	virtual Bool isCarBombCrateCollide() const { return false; }
-	virtual Bool isRailroad() const { return false;}
-	virtual Bool isSalvageCrateCollide() const { return false; }
+	virtual Bool wouldLikeToCollideWith(const Object* other) const override { return false; }
+	virtual Bool isHijackedVehicleCrateCollide() const override { return false; }
+	virtual Bool isSabotageBuildingCrateCollide() const override { return false; }
+	virtual Bool isCarBombCrateCollide() const override { return false; }
+	virtual Bool isRailroad() const override { return false;}
+	virtual Bool isSalvageCrateCollide() const override { return false; }
 
 };
 inline CollideModule::CollideModule( Thing *thing, const ModuleData* moduleData ) : BehaviorModule( thing, moduleData ) { }

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CollideModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CollideModule.h
@@ -85,7 +85,7 @@ public:
 	// BehaviorModule
 	virtual CollideModuleInterface* getCollide() override { return this; }
 
-	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal ) override = 0;
+	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal ) = 0;
 
 	/// this is used for things like pilots, to determine if they can "enter" something
 	virtual Bool wouldLikeToCollideWith(const Object* other) const override { return false; }

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CommandButtonHuntUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CommandButtonHuntUpdate.h
@@ -67,8 +67,8 @@ public:
 	CommandButtonHuntUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onObjectCreated();
-	virtual UpdateSleepTime update();
+	virtual void onObjectCreated() override;
+	virtual UpdateSleepTime update() override;
 
 	void setCommandButton(const AsciiString& buttonName);
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CommandSetUpgrade.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CommandSetUpgrade.h
@@ -62,7 +62,7 @@ public:
 	// virtual destructor prototype defined by MemoryPoolObject
 
 protected:
-	virtual void upgradeImplementation( ); ///< Here's the actual work of Upgrading
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation( ) override; ///< Here's the actual work of Upgrading
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ConvertToCarBombCrateCollide.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ConvertToCarBombCrateCollide.h
@@ -79,10 +79,10 @@ public:
 protected:
 
 	/// This allows specific vetoes to certain types of crates and their data
-	virtual Bool isValidToExecute( const Object *other ) const;
+	virtual Bool isValidToExecute( const Object *other ) const override;
 
 	/// This is the game logic execution function that all real CrateCollides will implement
-	virtual Bool executeCrateBehavior( Object *other );
-	virtual Bool isRailroad() const { return FALSE;};
-	virtual Bool isCarBombCrateCollide() const { return TRUE; }
+	virtual Bool executeCrateBehavior( Object *other ) override;
+	virtual Bool isRailroad() const override { return FALSE;};
+	virtual Bool isCarBombCrateCollide() const override { return TRUE; }
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ConvertToHijackedVehicleCrateCollide.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ConvertToHijackedVehicleCrateCollide.h
@@ -73,10 +73,10 @@ public:
 protected:
 
 	/// This allows specific vetoes to certain types of crates and their data
-	virtual Bool isValidToExecute( const Object *other ) const;
+	virtual Bool isValidToExecute( const Object *other ) const override;
 
 	/// This is the game logic execution function that all real CrateCollides will implement
-	virtual Bool executeCrateBehavior( Object *other );
+	virtual Bool executeCrateBehavior( Object *other ) override;
 
-	virtual Bool isHijackedVehicleCrateCollide() const { return TRUE; }
+	virtual Bool isHijackedVehicleCrateCollide() const override { return TRUE; }
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CostModifierUpgrade.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CostModifierUpgrade.h
@@ -103,12 +103,12 @@ public:
 	CostModifierUpgrade( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype defined by MemoryPoolObject
 
-	virtual void onDelete();																///< we have some work to do when this module goes away
-	virtual void onCapture( Player *oldOwner, Player *newOwner );
+	virtual void onDelete() override;																///< we have some work to do when this module goes away
+	virtual void onCapture( Player *oldOwner, Player *newOwner ) override;
 
 protected:
 
-	virtual void upgradeImplementation(); ///< Here's the actual work of Upgrading
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation() override; ///< Here's the actual work of Upgrading
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CountermeasuresBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CountermeasuresBehavior.h
@@ -130,52 +130,52 @@ public:
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | MODULEINTERFACE_UPGRADE; }
 
 	// BehaviorModule
-	virtual UpgradeModuleInterface* getUpgrade() { return this; }
-	virtual CountermeasuresBehaviorInterface* getCountermeasuresBehaviorInterface() { return this; }
-	virtual const CountermeasuresBehaviorInterface* getCountermeasuresBehaviorInterface() const { return this; }
+	virtual UpgradeModuleInterface* getUpgrade() override { return this; }
+	virtual CountermeasuresBehaviorInterface* getCountermeasuresBehaviorInterface() override { return this; }
+	virtual const CountermeasuresBehaviorInterface* getCountermeasuresBehaviorInterface() const override { return this; }
 
 	// UpdateModuleInterface
-	virtual UpdateSleepTime update();
-	virtual DisabledMaskType getDisabledTypesToProcess() const { return MAKE_DISABLED_MASK( DISABLED_HELD ); }
+	virtual UpdateSleepTime update() override;
+	virtual DisabledMaskType getDisabledTypesToProcess() const override { return MAKE_DISABLED_MASK( DISABLED_HELD ); }
 
 	// CountermeasuresBehaviorInterface
-	virtual void reportMissileForCountermeasures( Object *missile );
-	virtual ObjectID calculateCountermeasureToDivertTo( const Object& victim );
-	virtual void reloadCountermeasures();
-	virtual Bool isActive() const;
+	virtual void reportMissileForCountermeasures( Object *missile ) override;
+	virtual ObjectID calculateCountermeasureToDivertTo( const Object& victim ) override;
+	virtual void reloadCountermeasures() override;
+	virtual Bool isActive() const override;
 
 
 protected:
 
-	virtual void upgradeImplementation()
+	virtual void upgradeImplementation() override
 	{
 		setWakeFrame(getObject(), UPDATE_SLEEP_NONE);
 	}
 
-	virtual void getUpgradeActivationMasks(UpgradeMaskType& activation, UpgradeMaskType& conflicting) const
+	virtual void getUpgradeActivationMasks(UpgradeMaskType& activation, UpgradeMaskType& conflicting) const override
 	{
 		getCountermeasuresBehaviorModuleData()->m_upgradeMuxData.getUpgradeActivationMasks(activation, conflicting);
 	}
 
-	virtual void performUpgradeFX()
+	virtual void performUpgradeFX() override
 	{
 		getCountermeasuresBehaviorModuleData()->m_upgradeMuxData.performUpgradeFX(getObject());
 	}
 
-	virtual void processUpgradeRemoval()
+	virtual void processUpgradeRemoval() override
 	{
 		// I can't take it any more.  Let the record show that I think the UpgradeMux multiple inheritance is CRAP.
 		getCountermeasuresBehaviorModuleData()->m_upgradeMuxData.muxDataProcessUpgradeRemoval(getObject());
 	}
 
-	virtual Bool requiresAllActivationUpgrades() const
+	virtual Bool requiresAllActivationUpgrades() const override
 	{
 		return getCountermeasuresBehaviorModuleData()->m_upgradeMuxData.m_requiresAllTriggers;
 	}
 
 	Bool isUpgradeActive() const { return isAlreadyUpgraded(); }
 
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 	void launchVolley();
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CrateCollide.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CrateCollide.h
@@ -87,14 +87,14 @@ enum SabotageVictimType CPP_11(: Int)
 	// virtual destructor prototype provided by memory pool declaration
 
 	/// This collide method gets called when collision occur
-	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal );
+	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal ) override;
 
-	virtual Bool wouldLikeToCollideWith(const Object* other) const { return isValidToExecute(other); }
+	virtual Bool wouldLikeToCollideWith(const Object* other) const override { return isValidToExecute(other); }
 
-	virtual Bool isRailroad() const { return FALSE;};
- 	virtual Bool isCarBombCrateCollide() const { return FALSE; }
-	virtual Bool isHijackedVehicleCrateCollide() const { return FALSE; }
-	virtual Bool isSabotageBuildingCrateCollide() const { return FALSE; }
+	virtual Bool isRailroad() const override { return FALSE;};
+ 	virtual Bool isCarBombCrateCollide() const override { return FALSE; }
+	virtual Bool isHijackedVehicleCrateCollide() const override { return FALSE; }
+	virtual Bool isSabotageBuildingCrateCollide() const override { return FALSE; }
 
   void doSabotageFeedbackFX( const Object *other, SabotageVictimType type = SAB_VICTIM_GENERIC );
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CreateCrateDie.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CreateCrateDie.h
@@ -48,7 +48,7 @@ public:
 	{
 		m_crateNameList.clear();
 	}
-	~CreateCrateDieModuleData()
+	virtual ~CreateCrateDieModuleData() override
 	{
 		m_crateNameList.clear();
 	}
@@ -81,7 +81,7 @@ public:
 	CreateCrateDie( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 private:
 	Bool testCreationChance( CrateTemplate const *currentCrateData );

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CreateModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CreateModule.h
@@ -71,11 +71,11 @@ public:
 	static Int getInterfaceMask() { return MODULEINTERFACE_CREATE; }
 
 	// BehaviorModule
-	virtual CreateModuleInterface* getCreate() { return this; }
+	virtual CreateModuleInterface* getCreate() override { return this; }
 
-	virtual void onCreate() = 0;				///< This is called when you become a code Object
-	virtual void onBuildComplete(){ m_needToRunOnBuildComplete = FALSE; }	///< This is called when you are a finished game object
-	virtual Bool shouldDoOnBuildComplete() const { return m_needToRunOnBuildComplete; }
+	virtual void onCreate() override = 0;				///< This is called when you become a code Object
+	virtual void onBuildComplete() override{ m_needToRunOnBuildComplete = FALSE; }	///< This is called when you are a finished game object
+	virtual Bool shouldDoOnBuildComplete() const override { return m_needToRunOnBuildComplete; }
 
 private:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CreateModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CreateModule.h
@@ -74,7 +74,7 @@ public:
 	virtual CreateModuleInterface* getCreate() override { return this; }
 
 	virtual void onCreate() = 0;				///< This is called when you become a code Object
-	virtual void onBuildComplete() override{ m_needToRunOnBuildComplete = FALSE; }	///< This is called when you are a finished game object
+	virtual void onBuildComplete() override { m_needToRunOnBuildComplete = FALSE; }	///< This is called when you are a finished game object
 	virtual Bool shouldDoOnBuildComplete() const override { return m_needToRunOnBuildComplete; }
 
 private:

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CreateModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CreateModule.h
@@ -73,7 +73,7 @@ public:
 	// BehaviorModule
 	virtual CreateModuleInterface* getCreate() override { return this; }
 
-	virtual void onCreate() override = 0;				///< This is called when you become a code Object
+	virtual void onCreate() = 0;				///< This is called when you become a code Object
 	virtual void onBuildComplete() override{ m_needToRunOnBuildComplete = FALSE; }	///< This is called when you are a finished game object
 	virtual Bool shouldDoOnBuildComplete() const override { return m_needToRunOnBuildComplete; }
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CreateObjectDie.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CreateObjectDie.h
@@ -67,6 +67,6 @@ public:
 	CreateObjectDie( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CrushDie.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CrushDie.h
@@ -95,6 +95,6 @@ public:
 	CrushDie( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DamDie.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DamDie.h
@@ -58,6 +58,6 @@ public:
 	DamDie( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by MemoryPoolObject
 
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DamageModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DamageModule.h
@@ -98,11 +98,11 @@ public:
 	virtual DamageModuleInterface* getDamage() override { return this; }
 
 	// damage module callbacks
-	virtual void onDamage( DamageInfo *damageInfo ) override = 0;	///< damage callback
-	virtual void onHealing( DamageInfo *damageInfo ) override = 0;	///< healing callback
+	virtual void onDamage( DamageInfo *damageInfo ) = 0;	///< damage callback
+	virtual void onHealing( DamageInfo *damageInfo ) = 0;	///< healing callback
 	virtual void onBodyDamageStateChange( const DamageInfo* damageInfo,
 																				BodyDamageType oldState,
-																				BodyDamageType newState) override = 0;  ///< state change callback
+																				BodyDamageType newState) = 0;  ///< state change callback
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DamageModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DamageModule.h
@@ -95,14 +95,14 @@ public:
 	static Int getInterfaceMask() { return MODULEINTERFACE_DAMAGE; }
 
 	// BehaviorModule
-	virtual DamageModuleInterface* getDamage() { return this; }
+	virtual DamageModuleInterface* getDamage() override { return this; }
 
 	// damage module callbacks
-	virtual void onDamage( DamageInfo *damageInfo ) = 0;	///< damage callback
-	virtual void onHealing( DamageInfo *damageInfo ) = 0;	///< healing callback
+	virtual void onDamage( DamageInfo *damageInfo ) override = 0;	///< damage callback
+	virtual void onHealing( DamageInfo *damageInfo ) override = 0;	///< healing callback
 	virtual void onBodyDamageStateChange( const DamageInfo* damageInfo,
 																				BodyDamageType oldState,
-																				BodyDamageType newState) = 0;  ///< state change callback
+																				BodyDamageType newState) override = 0;  ///< state change callback
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DefaultProductionExitUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DefaultProductionExitUpdate.h
@@ -74,24 +74,24 @@ class DefaultProductionExitUpdate : public UpdateModule, public ExitInterface
 
 public:
 
-	virtual ExitInterface* getUpdateExitInterface() { return this; }
+	virtual ExitInterface* getUpdateExitInterface() override { return this; }
 
 	DefaultProductionExitUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
 	// Required funcs to fulfill interface requirements
-	virtual Bool isExitBusy() const {return FALSE;}	///< Contain style exiters are getting the ability to space out exits, so ask this before reserveDoor as a kind of no-commitment check.
-	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject ) { return DOOR_1; }
-	virtual void exitObjectViaDoor( Object *newObj, ExitDoorType exitDoor );
-	virtual void unreserveDoorForExit( ExitDoorType exitDoor ) { /* nothing */ }
-	virtual void exitObjectByBudding( Object *newObj, Object *budHost ) { return; }
+	virtual Bool isExitBusy() const override {return FALSE;}	///< Contain style exiters are getting the ability to space out exits, so ask this before reserveDoor as a kind of no-commitment check.
+	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject ) override { return DOOR_1; }
+	virtual void exitObjectViaDoor( Object *newObj, ExitDoorType exitDoor ) override;
+	virtual void unreserveDoorForExit( ExitDoorType exitDoor ) override { /* nothing */ }
+	virtual void exitObjectByBudding( Object *newObj, Object *budHost ) override { return; }
 
-	virtual void setRallyPoint( const Coord3D *pos );				///< define a "rally point" for units to move towards
-	virtual const Coord3D *getRallyPoint() const;			///< define a "rally point" for units to move towards
-	virtual Bool useSpawnRallyPoint() const;
-	virtual Bool getNaturalRallyPoint( Coord3D& rallyPoint, Bool offset = TRUE ) const;			///< get the natural "rally point" for units to move towards
-	virtual Bool getExitPosition( Coord3D& exitPosition ) const;					///< access to the "Door" position of the production object
-	virtual UpdateSleepTime update()										{ return UPDATE_SLEEP_FOREVER; }
+	virtual void setRallyPoint( const Coord3D *pos ) override;				///< define a "rally point" for units to move towards
+	virtual const Coord3D *getRallyPoint() const override;			///< define a "rally point" for units to move towards
+	virtual Bool useSpawnRallyPoint() const override;
+	virtual Bool getNaturalRallyPoint( Coord3D& rallyPoint, Bool offset = TRUE ) const override;			///< get the natural "rally point" for units to move towards
+	virtual Bool getExitPosition( Coord3D& exitPosition ) const override;					///< access to the "Door" position of the production object
+	virtual UpdateSleepTime update() override { return UPDATE_SLEEP_FOREVER; }
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DefectorSpecialPower.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DefectorSpecialPower.h
@@ -72,8 +72,8 @@ public:
 	DefectorSpecialPower( Thing *thing, const ModuleData *moduleData );
 	// virtual destructor prototype provided by memory pool object
 
-	virtual void doSpecialPowerAtObject( Object *obj, UnsignedInt commandOptions );
-	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions );
+	virtual void doSpecialPowerAtObject( Object *obj, UnsignedInt commandOptions ) override;
+	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions ) override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DeletionUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DeletionUpdate.h
@@ -74,7 +74,7 @@ public:
 	void setLifetimeRange( UnsignedInt minFrames, UnsignedInt maxFrames );
 	UnsignedInt getDieFrame() { return m_dieFrame; }
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DeliverPayloadAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DeliverPayloadAIUpdate.h
@@ -45,9 +45,9 @@ public:
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 };
 
 //-------------------------------------------------------------------------------------------------
@@ -57,13 +57,13 @@ class ApproachState :  public State
 	//Approaching the drop zone
 public:
 	ApproachState( StateMachine *machine ) :State( machine, "ApproachState" ) {}
-	virtual StateReturnType update();
-	virtual StateReturnType onEnter();
+	virtual StateReturnType update() override;
+	virtual StateReturnType onEnter() override;
 protected:
 	// snapshot interface	STUBBED - no member vars to save. jba.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override{};
 };
 EMPTY_DTOR(ApproachState)
 
@@ -78,14 +78,14 @@ public:
 		m_dropDelayLeft = 0;
 		m_didOpen = false;
 	}
-	virtual StateReturnType update();
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType update() override;
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	UnsignedInt m_dropDelayLeft;
@@ -100,14 +100,14 @@ class ConsiderNewApproachState :  public State
 	//Should I try again?  Has own data to keep track.
 public:
 	ConsiderNewApproachState( StateMachine *machine ) : State( machine, "ConsiderNewApproachState" ), m_numberEntriesToState(0) { }
-	virtual StateReturnType update();
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType update() override;
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	Int m_numberEntriesToState;
@@ -120,13 +120,13 @@ class RecoverFromOffMapState :  public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(RecoverFromOffMapState, "RecoverFromOffMapState")
 public:
 	RecoverFromOffMapState( StateMachine *machine ) : State( machine, "RecoverFromOffMapState" ), m_reEntryFrame(0) { }
-	virtual StateReturnType update();
-	virtual StateReturnType onEnter();
+	virtual StateReturnType update() override;
+	virtual StateReturnType onEnter() override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	UnsignedInt m_reEntryFrame;
@@ -140,13 +140,13 @@ class HeadOffMapState :  public State
 	//I'm outta here
 public:
   HeadOffMapState( StateMachine *machine ) :State( machine, "HeadOffMapState" ) { facingDirectionUponDelivery.zero(); }
-	virtual StateReturnType update();
-	virtual StateReturnType onEnter();
+	virtual StateReturnType update() override;
+	virtual StateReturnType onEnter() override;
 protected:
 	// snapshot interface	STUBBED - no member vars to save. jba.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override{};
 
   Coord3D facingDirectionUponDelivery;
 };
@@ -159,13 +159,13 @@ class CleanUpState :  public State
 	//Made it off map, delete ourselves
 public:
 	CleanUpState( StateMachine *machine ) :State( machine, "CleanUpState" ) {}
-	virtual StateReturnType update(){return STATE_CONTINUE;}
-	virtual StateReturnType onEnter();
+	virtual StateReturnType update() override{return STATE_CONTINUE;}
+	virtual StateReturnType onEnter() override;
 protected:
 	// snapshot interface	STUBBED - no member vars to save. jba.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override{};
 };
 EMPTY_DTOR(CleanUpState)
 
@@ -311,7 +311,7 @@ public:
 	DeliverPayloadAIUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual AIFreeToExitType getAiFreeToExit(const Object* exiter) const;
+	virtual AIFreeToExitType getAiFreeToExit(const Object* exiter) const override;
 
 	const Coord3D* getTargetPos() const { return &m_targetPos; }
 	const Coord3D* getMoveToPos() const { return &m_moveToPos; }
@@ -338,7 +338,7 @@ public:
 
 	const DeliverPayloadData* getData() { return &m_data; }
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	void killDeliveryDecal();
 
@@ -347,8 +347,8 @@ public:
 
 protected:
 
-	virtual AIStateMachine* makeStateMachine();
-	virtual Bool isAllowedToRespondToAiCommands(const AICommandParms* parms) const;
+	virtual AIStateMachine* makeStateMachine() override;
+	virtual Bool isAllowedToRespondToAiCommands(const AICommandParms* parms) const override;
 
 	DeliverPayloadStateMachine*		m_deliverPayloadStateMachine;	///< Controls my special logic
 	Coord3D												m_targetPos;									///< Where I plan to deliver my little friends, if obj is null

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DeliverPayloadAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DeliverPayloadAIUpdate.h
@@ -61,9 +61,9 @@ public:
 	virtual StateReturnType onEnter() override;
 protected:
 	// snapshot interface	STUBBED - no member vars to save. jba.
-	virtual void crc( Xfer *xfer ) override{};
-	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess() override{};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 };
 EMPTY_DTOR(ApproachState)
 
@@ -144,9 +144,9 @@ public:
 	virtual StateReturnType onEnter() override;
 protected:
 	// snapshot interface	STUBBED - no member vars to save. jba.
-	virtual void crc( Xfer *xfer ) override{};
-	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess() override{};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 
   Coord3D facingDirectionUponDelivery;
 };
@@ -159,13 +159,13 @@ class CleanUpState :  public State
 	//Made it off map, delete ourselves
 public:
 	CleanUpState( StateMachine *machine ) :State( machine, "CleanUpState" ) {}
-	virtual StateReturnType update() override{return STATE_CONTINUE;}
+	virtual StateReturnType update() override {return STATE_CONTINUE;}
 	virtual StateReturnType onEnter() override;
 protected:
 	// snapshot interface	STUBBED - no member vars to save. jba.
-	virtual void crc( Xfer *xfer ) override{};
-	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess() override{};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 };
 EMPTY_DTOR(CleanUpState)
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DemoTrapUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DemoTrapUpdate.h
@@ -73,8 +73,8 @@ public:
 	DemoTrapUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onObjectCreated();
-	virtual UpdateSleepTime update();
+	virtual void onObjectCreated() override;
+	virtual UpdateSleepTime update() override;
 
 	void detonate();
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DeployStyleAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DeployStyleAIUpdate.h
@@ -95,9 +95,9 @@ public:
 	DeployStyleAIUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
- 	virtual void aiDoCommand(const AICommandParms* parms);
-	virtual Bool isIdle() const;
-	virtual UpdateSleepTime update();
+ 	virtual void aiDoCommand(const AICommandParms* parms) override;
+	virtual Bool isIdle() const override;
+	virtual UpdateSleepTime update() override;
 
 	UnsignedInt getUnpackTime()					const { return getDeployStyleAIUpdateModuleData()->m_unpackTime; }
 	UnsignedInt getPackTime()						const { return getDeployStyleAIUpdateModuleData()->m_packTime; }

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DestroyDie.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DestroyDie.h
@@ -47,6 +47,6 @@ public:
 	DestroyDie( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DestroyModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DestroyModule.h
@@ -58,7 +58,7 @@ public:
 	// BehaviorModule
 	virtual DestroyModuleInterface* getDestroy() override { return this; }
 
-	virtual void onDestroy() override = 0;
+	virtual void onDestroy() = 0;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DestroyModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DestroyModule.h
@@ -56,9 +56,9 @@ public:
 	static Int getInterfaceMask() { return MODULEINTERFACE_DESTROY; }
 
 	// BehaviorModule
-	virtual DestroyModuleInterface* getDestroy() { return this; }
+	virtual DestroyModuleInterface* getDestroy() override { return this; }
 
-	virtual void onDestroy() = 0;
+	virtual void onDestroy() override = 0;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DieModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DieModule.h
@@ -95,9 +95,9 @@ public:
 	static Int getInterfaceMask() { return MODULEINTERFACE_DIE; }
 
 	// BehaviorModule
-	virtual DieModuleInterface* getDie() { return this; }
+	virtual DieModuleInterface* getDie() override { return this; }
 
-	void onDie( const DamageInfo *damageInfo ) = 0;
+	virtual void onDie( const DamageInfo *damageInfo ) override = 0;
 
 protected:
 	Bool isDieApplicable(const DamageInfo *damageInfo) const { return getDieModuleData()->isDieApplicable(getObject(), damageInfo); }

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DieModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DieModule.h
@@ -97,7 +97,7 @@ public:
 	// BehaviorModule
 	virtual DieModuleInterface* getDie() override { return this; }
 
-	virtual void onDie( const DamageInfo *damageInfo ) override = 0;
+	virtual void onDie( const DamageInfo *damageInfo ) = 0;
 
 protected:
 	Bool isDieApplicable(const DamageInfo *damageInfo) const { return getDieModuleData()->isDieApplicable(getObject(), damageInfo); }

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DockUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DockUpdate.h
@@ -72,61 +72,61 @@ public:
 	/** Returns true if it is okay for the docker to approach and prepare to dock.
 			False could mean the queue is full, for example.
 	*/
-	virtual Bool isClearToApproach( Object const* docker ) const;
+	virtual Bool isClearToApproach( Object const* docker ) const override;
 
 	/** Give me a Queue point to drive to, and record that that point is taken.
 			Returning null means there are none free
 	*/
-	virtual Bool reserveApproachPosition( Object* docker, Coord3D *position, Int *index );
+	virtual Bool reserveApproachPosition( Object* docker, Coord3D *position, Int *index ) override;
 
 	/** Give me the next Queue point to drive to, and record that that point is taken.
 	*/
-	virtual Bool advanceApproachPosition( Object* docker, Coord3D *position, Int *index );
+	virtual Bool advanceApproachPosition( Object* docker, Coord3D *position, Int *index ) override;
 
 	/** Return true when it is OK for docker to begin entering the dock
 			The Dock will lift the restriction on one particular docker on its own,
 			so you must continually ask.
 	*/
-	virtual Bool isClearToEnter( Object const* docker ) const;
+	virtual Bool isClearToEnter( Object const* docker ) const override;
 
 	/** Return true when it is OK for docker to request a new Approach position.  The dock is in
 			charge of keeping track of holes in the line, but the docker will remind us of their spot.
 	*/
-	virtual Bool isClearToAdvance( Object const* docker, Int dockerIndex ) const;
+	virtual Bool isClearToAdvance( Object const* docker, Int dockerIndex ) const override;
 
 	/** Give me the point that is the start of your docking path
 			Returning null means there is none free
 			All functions take docker as arg so we could have multiple docks on a building.
 			Docker is not assumed, it is recorded and checked.
 	*/
-	virtual void getEnterPosition( Object* docker, Coord3D *position );
+	virtual void getEnterPosition( Object* docker, Coord3D *position ) override;
 
 	/** Give me the middle point of the dock process where the action() happens */
-	virtual void getDockPosition( Object* docker, Coord3D *position );
+	virtual void getDockPosition( Object* docker, Coord3D *position ) override;
 
 	/** Give me the point to drive to when I am done */
-	virtual void getExitPosition( Object* docker, Coord3D *position );
+	virtual void getExitPosition( Object* docker, Coord3D *position ) override;
 
-	virtual void onApproachReached( Object* docker );		///< I have reached the Approach Point.
-	virtual void onEnterReached( Object* docker );			///< I have reached the Enter Point.
-	virtual void onDockReached( Object* docker );				///< I have reached the Dock point
-	virtual void onExitReached( Object* docker );				///< I have reached the exit.  You are no longer busy
+	virtual void onApproachReached( Object* docker ) override;		///< I have reached the Approach Point.
+	virtual void onEnterReached( Object* docker ) override;			///< I have reached the Enter Point.
+	virtual void onDockReached( Object* docker ) override;				///< I have reached the Dock point
+	virtual void onExitReached( Object* docker ) override;				///< I have reached the exit.  You are no longer busy
 
 	//The fact that action() is not here is intentional.  This object cannot exist.  You must
 	//derive off it and implement action().
 
-	virtual void cancelDock( Object* docker );	///< Clear me from any reserved points, and if I was the reason you were Busy, you aren't anymore.
+	virtual void cancelDock( Object* docker ) override;	///< Clear me from any reserved points, and if I was the reason you were Busy, you aren't anymore.
 
-	virtual Bool isDockOpen() { return m_dockOpen; }				///< Is the dock open to accepting dockers
-	virtual void setDockOpen( Bool open ) { m_dockOpen = open; }	///< Open/Close the dock
+	virtual Bool isDockOpen() override { return m_dockOpen; }				///< Is the dock open to accepting dockers
+	virtual void setDockOpen( Bool open ) override { m_dockOpen = open; }	///< Open/Close the dock
 
-	virtual Bool isAllowPassthroughType();	///< Not all docks allow you to path through them in your AIDock machine
+	virtual Bool isAllowPassthroughType() override;	///< Not all docks allow you to path through them in your AIDock machine
 
-	virtual Bool isRallyPointAfterDockType(){return FALSE;} ///< A minority of docks want to give you a final command to their rally point
+	virtual Bool isRallyPointAfterDockType() override{return FALSE;} ///< A minority of docks want to give you a final command to their rally point
 
-	virtual void setDockCrippled( Bool setting ); ///< Game Logic can set me as inoperative.  I get to decide what that means.
+	virtual void setDockCrippled( Bool setting ) override; ///< Game Logic can set me as inoperative.  I get to decide what that means.
 
-	virtual UpdateSleepTime update();	///< In charge of lifting dock restriction for one registered as Approached if all is ready
+	virtual UpdateSleepTime update() override;	///< In charge of lifting dock restriction for one registered as Approached if all is ready
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DockUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DockUpdate.h
@@ -122,7 +122,7 @@ public:
 
 	virtual Bool isAllowPassthroughType() override;	///< Not all docks allow you to path through them in your AIDock machine
 
-	virtual Bool isRallyPointAfterDockType() override{return FALSE;} ///< A minority of docks want to give you a final command to their rally point
+	virtual Bool isRallyPointAfterDockType() override {return FALSE;} ///< A minority of docks want to give you a final command to their rally point
 
 	virtual void setDockCrippled( Bool setting ) override; ///< Game Logic can set me as inoperative.  I get to decide what that means.
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DozerAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DozerAIUpdate.h
@@ -56,9 +56,9 @@ public:
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 };
 
 
@@ -207,76 +207,76 @@ public:
 	DozerAIUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual DozerAIInterface* getDozerAIInterface() {return this;}
-	virtual const DozerAIInterface* getDozerAIInterface() const {return this;}
+	virtual DozerAIInterface* getDozerAIInterface() override {return this;}
+	virtual const DozerAIInterface* getDozerAIInterface() const override {return this;}
 
-	virtual void onDelete();
+	virtual void onDelete() override;
 
 	//
 	// module data methods ... this is LAME, multiple inheritance off an interface with replicated
 	// data and code, ick!
 	// NOTE: If you edit module data you must do it in both the Dozer *AND* the Worker
 	//
-	virtual Real getRepairHealthPerSecond() const;	///< get health to repair per second
-	virtual Real getBoredTime() const;							///< how long till we're bored
-	virtual Real getBoredRange() const;							///< when we're bored, we look this far away to do things
+	virtual Real getRepairHealthPerSecond() const override;	///< get health to repair per second
+	virtual Real getBoredTime() const override;							///< how long till we're bored
+	virtual Real getBoredRange() const override;							///< when we're bored, we look this far away to do things
 
 	// methods to override for the dozer behaviors
 	virtual Object* construct( const ThingTemplate *what,
 														 const Coord3D *pos, Real angle,
 														 Player *owningPlayer,
-														 Bool isRebuild );								///< construct an object
+														 Bool isRebuild ) override;								///< construct an object
 
 
 	// get task information
-	virtual DozerTask getMostRecentCommand();				///< return task that was most recently issued
-	virtual Bool isTaskPending( DozerTask task );					///< is there a desire to do the requested task
-	virtual ObjectID getTaskTarget( DozerTask task );			///< get target of task
-	virtual Bool isAnyTaskPending();								///< is there any dozer task pending
-	virtual DozerTask getCurrentTask() const { return m_currentTask; }	///< return the current task we're doing
-	virtual void setCurrentTask( DozerTask task ) { m_currentTask = task; }	///< set the current task of the dozer
+	virtual DozerTask getMostRecentCommand() override;				///< return task that was most recently issued
+	virtual Bool isTaskPending( DozerTask task ) override;					///< is there a desire to do the requested task
+	virtual ObjectID getTaskTarget( DozerTask task ) override;			///< get target of task
+	virtual Bool isAnyTaskPending() override;								///< is there any dozer task pending
+	virtual DozerTask getCurrentTask() const override { return m_currentTask; }	///< return the current task we're doing
+	virtual void setCurrentTask( DozerTask task ) override { m_currentTask = task; }	///< set the current task of the dozer
 
-	virtual Bool getIsRebuild() { return m_isRebuild; }	///< get whether or not this building is a rebuild.
+	virtual Bool getIsRebuild() override { return m_isRebuild; }	///< get whether or not this building is a rebuild.
 
 	// task actions
-	virtual void newTask( DozerTask task, Object *target );	///< set a desire to do the requested task
-	virtual void cancelTask( DozerTask task );							///< cancel this task from the queue, if it's the current task the dozer will stop working on it
-	virtual void cancelAllTasks();													///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
-	virtual void resumePreviousTask();									///< resume the previous task if there was one
+	virtual void newTask( DozerTask task, Object *target ) override;	///< set a desire to do the requested task
+	virtual void cancelTask( DozerTask task ) override;							///< cancel this task from the queue, if it's the current task the dozer will stop working on it
+	virtual void cancelAllTasks() override;													///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
+	virtual void resumePreviousTask() override;									///< resume the previous task if there was one
 
 	// internal methods to manage behavior from within the dozer state machine
-	virtual void internalTaskComplete( DozerTask task );					///< set a dozer task as successfully completed
-	virtual void internalCancelTask( DozerTask task );						///< cancel this task from the dozer
-	virtual void internalTaskCompleteOrCancelled( DozerTask task );	///< this is called when tasks are cancelled or completed
+	virtual void internalTaskComplete( DozerTask task ) override;					///< set a dozer task as successfully completed
+	virtual void internalCancelTask( DozerTask task ) override;						///< cancel this task from the dozer
+	virtual void internalTaskCompleteOrCancelled( DozerTask task ) override;	///< this is called when tasks are cancelled or completed
 
 	/** return a dock point for the action and task (if valid) ... note it can return nullptr
 	if no point has been set for the combination of task and point */
-	virtual const Coord3D* getDockPoint( DozerTask task, DozerDockPoint point );
+	virtual const Coord3D* getDockPoint( DozerTask task, DozerDockPoint point ) override;
 
-	virtual void setBuildSubTask( DozerBuildSubTask subTask ) { m_buildSubTask = subTask; };
-	virtual DozerBuildSubTask getBuildSubTask() { return m_buildSubTask; }
+	virtual void setBuildSubTask( DozerBuildSubTask subTask ) override { m_buildSubTask = subTask; };
+	virtual DozerBuildSubTask getBuildSubTask() override { return m_buildSubTask; }
 
-	virtual UpdateSleepTime update();											///< the update entry point
+	virtual UpdateSleepTime update() override;											///< the update entry point
 
 	// repairing
-	virtual Bool canAcceptNewRepair( Object *obj );
-	virtual void createBridgeScaffolding( Object *bridgeTower );
-	virtual void removeBridgeScaffolding( Object *bridgeTower );
+	virtual Bool canAcceptNewRepair( Object *obj ) override;
+	virtual void createBridgeScaffolding( Object *bridgeTower ) override;
+	virtual void removeBridgeScaffolding( Object *bridgeTower ) override;
 
-	virtual void startBuildingSound( const AudioEventRTS *sound, ObjectID constructionSiteID );
-	virtual void finishBuildingSound();
+	virtual void startBuildingSound( const AudioEventRTS *sound, ObjectID constructionSiteID ) override;
+	virtual void finishBuildingSound() override;
 
 	//
 	// the following methods must be overridden so that if a player issues a command the dozer
 	// can exit the internal state machine and do whatever the player says
 	//
-	virtual void aiDoCommand(const AICommandParms* parms);
+	virtual void aiDoCommand(const AICommandParms* parms) override;
 
 
 protected:
 
-	virtual void privateRepair( Object *obj, CommandSourceType cmdSource );	///< repair the target
-	virtual void privateResumeConstruction( Object *obj, CommandSourceType cmdSource );  ///< resume construction on obj
+	virtual void privateRepair( Object *obj, CommandSourceType cmdSource ) override;	///< repair the target
+	virtual void privateResumeConstruction( Object *obj, CommandSourceType cmdSource ) override;  ///< resume construction on obj
 
 	struct DozerTaskInfo
 	{

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DumbProjectileBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DumbProjectileBehavior.h
@@ -83,17 +83,17 @@ public:
 	// virtual destructor provided by memory pool object
 
 	// UpdateModuleInterface
-	virtual UpdateSleepTime update();
-	virtual ProjectileUpdateInterface* getProjectileUpdateInterface() { return this; }
+	virtual UpdateSleepTime update() override;
+	virtual ProjectileUpdateInterface* getProjectileUpdateInterface() override { return this; }
 
 	// ProjectileUpdateInterface
-	virtual void projectileLaunchAtObjectOrPosition(const Object *victim, const Coord3D* victimPos, const Object *launcher, WeaponSlotType wslot, Int specificBarrelToUse, const WeaponTemplate* detWeap, const ParticleSystemTemplate* exhaustSysOverride);
-	virtual void projectileFireAtObjectOrPosition( const Object *victim, const Coord3D *victimPos, const WeaponTemplate *detWeap, const ParticleSystemTemplate* exhaustSysOverride );
-	virtual Bool projectileHandleCollision( Object *other );
-	virtual Bool projectileIsArmed() const { return true; }
-	virtual ObjectID projectileGetLauncherID() const { return m_launcherID; }
-	virtual void setFramesTillCountermeasureDiversionOccurs( UnsignedInt frames ) {}
-	virtual void projectileNowJammed() {}
+	virtual void projectileLaunchAtObjectOrPosition(const Object *victim, const Coord3D* victimPos, const Object *launcher, WeaponSlotType wslot, Int specificBarrelToUse, const WeaponTemplate* detWeap, const ParticleSystemTemplate* exhaustSysOverride) override;
+	virtual void projectileFireAtObjectOrPosition( const Object *victim, const Coord3D *victimPos, const WeaponTemplate *detWeap, const ParticleSystemTemplate* exhaustSysOverride ) override;
+	virtual Bool projectileHandleCollision( Object *other ) override;
+	virtual Bool projectileIsArmed() const override { return true; }
+	virtual ObjectID projectileGetLauncherID() const override { return m_launcherID; }
+	virtual void setFramesTillCountermeasureDiversionOccurs( UnsignedInt frames ) override {}
+	virtual void projectileNowJammed() override {}
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DynamicGeometryInfoUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DynamicGeometryInfoUpdate.h
@@ -76,7 +76,7 @@ public:
 	DynamicGeometryInfoUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DynamicShroudClearingRangeUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DynamicShroudClearingRangeUpdate.h
@@ -73,7 +73,7 @@ public:
 	DynamicShroudClearingRangeUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	void createGridDecals( const RadiusDecalTemplate& tmpl, Real radius, const Coord3D& pos );
 	void killGridDecals();

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/EMPUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/EMPUpdate.h
@@ -122,7 +122,7 @@ public:
 
 	UnsignedInt getDieFrame() { return m_dieFrame; }
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 	void doDisableAttack();
 
 protected:
@@ -202,14 +202,14 @@ public:
 	LeafletDropBehavior( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 	void doDisableAttack();
 
   // BehaviorModule
-	virtual DieModuleInterface* getDie() { return this; }
+	virtual DieModuleInterface* getDie() override { return this; }
 
 	// DieModuleInterface
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/EjectPilotDie.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/EjectPilotDie.h
@@ -65,7 +65,7 @@ public:
 
 	static void ejectPilot(const ObjectCreationList* ocl, const Object* dyingObject, const Object* damageDealer);
 
-	virtual void onDie( const DamageInfo *damageInfo );
-	virtual DieModuleInterface* getEjectPilotDieInterface() {return this; }
+	virtual void onDie( const DamageInfo *damageInfo ) override;
+	virtual DieModuleInterface* getEjectPilotDieInterface() override {return this; }
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/EnemyNearUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/EnemyNearUpdate.h
@@ -71,7 +71,7 @@ public:
 	EnemyNearUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ExperienceScalarUpgrade.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ExperienceScalarUpgrade.h
@@ -65,7 +65,7 @@ public:
 
 protected:
 
-	virtual void upgradeImplementation(); ///< Here's the actual work of Upgrading
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation() override; ///< Here's the actual work of Upgrading
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/FXListDie.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/FXListDie.h
@@ -88,42 +88,42 @@ public:
 	static Int getInterfaceMask() { return BehaviorModule::getInterfaceMask() | (MODULEINTERFACE_UPGRADE) | (MODULEINTERFACE_DIE); }
 
 	// BehaviorModule
-	virtual UpgradeModuleInterface* getUpgrade() { return this; }
-	virtual DieModuleInterface* getDie() { return this; }
+	virtual UpgradeModuleInterface* getUpgrade() override { return this; }
+	virtual DieModuleInterface* getDie() override { return this; }
 
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 protected:
 
-	virtual void upgradeImplementation()
+	virtual void upgradeImplementation() override
 	{
 		// nothing!
 	}
 
-	virtual void getUpgradeActivationMasks(UpgradeMaskType& activation, UpgradeMaskType& conflicting) const
+	virtual void getUpgradeActivationMasks(UpgradeMaskType& activation, UpgradeMaskType& conflicting) const override
 	{
 		getFXListDieModuleData()->m_upgradeMuxData.getUpgradeActivationMasks(activation, conflicting);
 	}
 
-	virtual void performUpgradeFX()
+	virtual void performUpgradeFX() override
 	{
 		getFXListDieModuleData()->m_upgradeMuxData.performUpgradeFX(getObject());
 	}
 
-	virtual void processUpgradeRemoval()
+	virtual void processUpgradeRemoval() override
 	{
 		// I can't take it any more.  Let the record show that I think the UpgradeMux multiple inheritance is CRAP.
 		getFXListDieModuleData()->m_upgradeMuxData.muxDataProcessUpgradeRemoval(getObject());
 	}
 
-	virtual Bool requiresAllActivationUpgrades() const
+	virtual Bool requiresAllActivationUpgrades() const override
 	{
 		return getFXListDieModuleData()->m_upgradeMuxData.m_requiresAllTriggers;
 	}
 
 	Bool isUpgradeActive() const { return isAlreadyUpgraded(); }
 
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/FireOCLAfterWeaponCooldownUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/FireOCLAfterWeaponCooldownUpdate.h
@@ -63,36 +63,36 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	// update methods
-	virtual UpdateSleepTime update();							///< called once per frame
+	virtual UpdateSleepTime update() override;							///< called once per frame
 
 protected:
-	virtual void upgradeImplementation()
+	virtual void upgradeImplementation() override
 	{
 		// nothing!
 	}
 
-	virtual void getUpgradeActivationMasks(UpgradeMaskType& activation, UpgradeMaskType& conflicting) const
+	virtual void getUpgradeActivationMasks(UpgradeMaskType& activation, UpgradeMaskType& conflicting) const override
 	{
 		getFireOCLAfterWeaponCooldownUpdateModuleData()->m_upgradeMuxData.getUpgradeActivationMasks(activation, conflicting);
 	}
 
-	virtual void performUpgradeFX()
+	virtual void performUpgradeFX() override
 	{
 		getFireOCLAfterWeaponCooldownUpdateModuleData()->m_upgradeMuxData.performUpgradeFX(getObject());
 	}
 
-	virtual void processUpgradeRemoval()
+	virtual void processUpgradeRemoval() override
 	{
 		// I can't take it any more.  Let the record show that I think the UpgradeMux multiple inheritance is CRAP.
 		getFireOCLAfterWeaponCooldownUpdateModuleData()->m_upgradeMuxData.muxDataProcessUpgradeRemoval(getObject());
 	}
 
-	virtual Bool requiresAllActivationUpgrades() const
+	virtual Bool requiresAllActivationUpgrades() const override
 	{
 		return getFireOCLAfterWeaponCooldownUpdateModuleData()->m_upgradeMuxData.m_requiresAllTriggers;
 	}
 
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 	void resetStats();
 	void fireOCL();

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/FireSpreadUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/FireSpreadUpdate.h
@@ -64,7 +64,7 @@ public:
 	FireSpreadUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	void startFireSpreading();
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/FireWeaponCollide.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/FireWeaponCollide.h
@@ -68,7 +68,7 @@ public:
 
 protected:
 
-	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal );
+	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal ) override;
 
 	virtual Bool shouldFireWeapon();
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/FireWeaponPower.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/FireWeaponPower.h
@@ -75,9 +75,9 @@ public:
 
 	FireWeaponPower( Thing *thing, const ModuleData *moduleData );
 
-	virtual void doSpecialPower( UnsignedInt commandOptions );
-	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions );
-	virtual void doSpecialPowerAtObject( Object *obj, UnsignedInt commandOptions );
+	virtual void doSpecialPower( UnsignedInt commandOptions ) override;
+	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions ) override;
+	virtual void doSpecialPowerAtObject( Object *obj, UnsignedInt commandOptions ) override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/FireWeaponUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/FireWeaponUpdate.h
@@ -62,7 +62,7 @@ public:
 	FireWeaponUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/FireWeaponWhenDamagedBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/FireWeaponWhenDamagedBehavior.h
@@ -116,48 +116,48 @@ public:
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_UPGRADE) | (MODULEINTERFACE_DAMAGE); }
 
 	// BehaviorModule
-	virtual UpgradeModuleInterface* getUpgrade() { return this; }
-	virtual DamageModuleInterface* getDamage() { return this; }
+	virtual UpgradeModuleInterface* getUpgrade() override { return this; }
+	virtual DamageModuleInterface* getDamage() override { return this; }
 
 	// DamageModuleInterface
-	virtual void onDamage( DamageInfo *damageInfo );
-	virtual void onHealing( DamageInfo *damageInfo ) { }
-	virtual void onBodyDamageStateChange(const DamageInfo* damageInfo, BodyDamageType oldState, BodyDamageType newState) { }
+	virtual void onDamage( DamageInfo *damageInfo ) override;
+	virtual void onHealing( DamageInfo *damageInfo ) override { }
+	virtual void onBodyDamageStateChange(const DamageInfo* damageInfo, BodyDamageType oldState, BodyDamageType newState) override { }
 
 	// UpdateModuleInterface
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 protected:
 
-	virtual void upgradeImplementation()
+	virtual void upgradeImplementation() override
 	{
 		setWakeFrame(getObject(), UPDATE_SLEEP_NONE);
 	}
 
-	virtual void getUpgradeActivationMasks(UpgradeMaskType& activation, UpgradeMaskType& conflicting) const
+	virtual void getUpgradeActivationMasks(UpgradeMaskType& activation, UpgradeMaskType& conflicting) const override
 	{
 		getFireWeaponWhenDamagedBehaviorModuleData()->m_upgradeMuxData.getUpgradeActivationMasks(activation, conflicting);
 	}
 
-	virtual void performUpgradeFX()
+	virtual void performUpgradeFX() override
 	{
 		getFireWeaponWhenDamagedBehaviorModuleData()->m_upgradeMuxData.performUpgradeFX(getObject());
 	}
 
-	virtual void processUpgradeRemoval()
+	virtual void processUpgradeRemoval() override
 	{
 		// I can't take it any more.  Let the record show that I think the UpgradeMux multiple inheritance is CRAP.
 		getFireWeaponWhenDamagedBehaviorModuleData()->m_upgradeMuxData.muxDataProcessUpgradeRemoval(getObject());
 	}
 
-	virtual Bool requiresAllActivationUpgrades() const
+	virtual Bool requiresAllActivationUpgrades() const override
 	{
 		return getFireWeaponWhenDamagedBehaviorModuleData()->m_upgradeMuxData.m_requiresAllTriggers;
 	}
 
 	Bool isUpgradeActive() const { return isAlreadyUpgraded(); }
 
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 private:
 	Weapon *m_reactionWeaponPristine;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/FireWeaponWhenDeadBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/FireWeaponWhenDeadBehavior.h
@@ -86,42 +86,42 @@ public:
 	static Int getInterfaceMask() { return BehaviorModule::getInterfaceMask() | (MODULEINTERFACE_UPGRADE) | (MODULEINTERFACE_DIE); }
 
 	// BehaviorModule
-	virtual UpgradeModuleInterface* getUpgrade() { return this; }
-	virtual DieModuleInterface* getDie() { return this; }
+	virtual UpgradeModuleInterface* getUpgrade() override { return this; }
+	virtual DieModuleInterface* getDie() override { return this; }
 
 	// DamageModuleInterface
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 protected:
 
-	virtual void upgradeImplementation()
+	virtual void upgradeImplementation() override
 	{
 		// nothing!
 	}
 
-	virtual void getUpgradeActivationMasks(UpgradeMaskType& activation, UpgradeMaskType& conflicting) const
+	virtual void getUpgradeActivationMasks(UpgradeMaskType& activation, UpgradeMaskType& conflicting) const override
 	{
 		getFireWeaponWhenDeadBehaviorModuleData()->m_upgradeMuxData.getUpgradeActivationMasks(activation, conflicting);
 	}
 
-	virtual void performUpgradeFX()
+	virtual void performUpgradeFX() override
 	{
 		getFireWeaponWhenDeadBehaviorModuleData()->m_upgradeMuxData.performUpgradeFX(getObject());
 	}
 
-	virtual void processUpgradeRemoval()
+	virtual void processUpgradeRemoval() override
 	{
 		// I can't take it any more.  Let the record show that I think the UpgradeMux multiple inheritance is CRAP.
 		getFireWeaponWhenDeadBehaviorModuleData()->m_upgradeMuxData.muxDataProcessUpgradeRemoval(getObject());
 	}
 
-	virtual Bool requiresAllActivationUpgrades() const
+	virtual Bool requiresAllActivationUpgrades() const override
 	{
 		return getFireWeaponWhenDeadBehaviorModuleData()->m_upgradeMuxData.m_requiresAllTriggers;
 	}
 
 	Bool isUpgradeActive() const { return isAlreadyUpgraded(); }
 
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/FirestormDynamicGeometryInfoUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/FirestormDynamicGeometryInfoUpdate.h
@@ -70,7 +70,7 @@ public:
 	FirestormDynamicGeometryInfoUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/FlammableUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/FlammableUpdate.h
@@ -80,20 +80,20 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_DAMAGE); }
-	virtual DamageModuleInterface* getDamage() { return this; }
+	virtual DamageModuleInterface* getDamage() override { return this; }
 
 	void tryToIgnite(); ///< FlammabeDamage uses this.  It is up to me to decide if I am burnable
 	Bool wouldIgnite(); ///< Since we need to cheat sometimes and light something directly, ask if this would light
 
 	//UpdateModuleInterface
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	//DamageModuleInterface
-	virtual void onDamage( DamageInfo *damageInfo );
-	virtual void onHealing( DamageInfo *damageInfo ) { }
+	virtual void onDamage( DamageInfo *damageInfo ) override;
+	virtual void onHealing( DamageInfo *damageInfo ) override { }
 	virtual void onBodyDamageStateChange( const DamageInfo *damageInfo,
 																				BodyDamageType oldState,
-																				BodyDamageType newState ) { }
+																				BodyDamageType newState ) override { }
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/FlightDeckBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/FlightDeckBehavior.h
@@ -105,50 +105,50 @@ public:
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_DIE); }
 
 	// BehaviorModule
-	virtual ParkingPlaceBehaviorInterface* getParkingPlaceBehaviorInterface() { return this; }
-	virtual ExitInterface* getUpdateExitInterface() { return this; }
-	virtual DieModuleInterface* getDie() { return this; }
+	virtual ParkingPlaceBehaviorInterface* getParkingPlaceBehaviorInterface() override { return this; }
+	virtual ExitInterface* getUpdateExitInterface() override { return this; }
+	virtual DieModuleInterface* getDie() override { return this; }
 
 	// ExitInterface
-	virtual Bool isExitBusy() const {return FALSE;}	///< Contain style exiters are getting the ability to space out exits, so ask this before reserveDoor as a kind of no-commitment check.
-	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject );
-	virtual void exitObjectViaDoor( Object *newObj, ExitDoorType exitDoor );
-	virtual void unreserveDoorForExit( ExitDoorType exitDoor );
-	virtual void exitObjectByBudding( Object *newObj, Object *budHost ) { return; }
-	virtual Bool getExitPosition( Coord3D& rallyPoint ) const { return FALSE; }
+	virtual Bool isExitBusy() const override {return FALSE;}	///< Contain style exiters are getting the ability to space out exits, so ask this before reserveDoor as a kind of no-commitment check.
+	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject ) override;
+	virtual void exitObjectViaDoor( Object *newObj, ExitDoorType exitDoor ) override;
+	virtual void unreserveDoorForExit( ExitDoorType exitDoor ) override;
+	virtual void exitObjectByBudding( Object *newObj, Object *budHost ) override { return; }
+	virtual Bool getExitPosition( Coord3D& rallyPoint ) const override { return FALSE; }
 	virtual Bool getNaturalRallyPoint( Coord3D& rallyPoint, Bool offset = TRUE ) { return FALSE; }
-	virtual void setRallyPoint( const Coord3D *pos ) {}
-	virtual const Coord3D *getRallyPoint() const { return nullptr;}
+	virtual void setRallyPoint( const Coord3D *pos ) override {}
+	virtual const Coord3D *getRallyPoint() const override { return nullptr;}
 
 	// UpdateModule
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	// DieModule
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 	// ParkingPlaceBehaviorInterface
-	virtual Bool shouldReserveDoorWhenQueued(const ThingTemplate* thing) const;
-	virtual Bool hasAvailableSpaceFor(const ThingTemplate* thing) const;
-	virtual Bool hasReservedSpace(ObjectID id) const;
-	virtual Int  getSpaceIndex( ObjectID id ) const;
-	virtual Bool reserveSpace(ObjectID id, Real parkingOffset, PPInfo* info);
-	virtual void releaseSpace(ObjectID id);
-	virtual Bool reserveRunway(ObjectID id, Bool forLanding);
-	virtual void releaseRunway(ObjectID id);
-	virtual void calcPPInfo( ObjectID id, PPInfo *info );
-	virtual Int getRunwayIndex(ObjectID id);
-	virtual Int getRunwayCount() const { return m_runways.size(); }
-	virtual ObjectID getRunwayReservation( Int r, RunwayReservationType type );
-	virtual void transferRunwayReservationToNextInLineForTakeoff(ObjectID id);
-	virtual Real getApproachHeight() const { return getFlightDeckBehaviorModuleData()->m_approachHeight; }
-	virtual Real getLandingDeckHeightOffset() const { return getFlightDeckBehaviorModuleData()->m_landingDeckHeightOffset; }
-	virtual void setHealee(Object* healee, Bool add);
-	virtual void killAllParkedUnits();
-	virtual void defectAllParkedUnits(Team* newTeam, UnsignedInt detectionTime);
-	virtual Bool calcBestParkingAssignment( ObjectID id, Coord3D *pos, Int *oldIndex = nullptr, Int *newIndex = nullptr );
+	virtual Bool shouldReserveDoorWhenQueued(const ThingTemplate* thing) const override;
+	virtual Bool hasAvailableSpaceFor(const ThingTemplate* thing) const override;
+	virtual Bool hasReservedSpace(ObjectID id) const override;
+	virtual Int  getSpaceIndex( ObjectID id ) const override;
+	virtual Bool reserveSpace(ObjectID id, Real parkingOffset, PPInfo* info) override;
+	virtual void releaseSpace(ObjectID id) override;
+	virtual Bool reserveRunway(ObjectID id, Bool forLanding) override;
+	virtual void releaseRunway(ObjectID id) override;
+	virtual void calcPPInfo( ObjectID id, PPInfo *info ) override;
+	virtual Int getRunwayIndex(ObjectID id) override;
+	virtual Int getRunwayCount() const override { return m_runways.size(); }
+	virtual ObjectID getRunwayReservation( Int r, RunwayReservationType type ) override;
+	virtual void transferRunwayReservationToNextInLineForTakeoff(ObjectID id) override;
+	virtual Real getApproachHeight() const override { return getFlightDeckBehaviorModuleData()->m_approachHeight; }
+	virtual Real getLandingDeckHeightOffset() const override { return getFlightDeckBehaviorModuleData()->m_landingDeckHeightOffset; }
+	virtual void setHealee(Object* healee, Bool add) override;
+	virtual void killAllParkedUnits() override;
+	virtual void defectAllParkedUnits(Team* newTeam, UnsignedInt detectionTime) override;
+	virtual Bool calcBestParkingAssignment( ObjectID id, Coord3D *pos, Int *oldIndex = nullptr, Int *newIndex = nullptr ) override;
 
 	// AIUpdateInterface
-	virtual void aiDoCommand(const AICommandParms* parms);
+	virtual void aiDoCommand(const AICommandParms* parms) override;
 
 	virtual const std::vector<Coord3D>* getTaxiLocations( ObjectID id ) const;
 	virtual const std::vector<Coord3D>* getCreationLocations( ObjectID id ) const;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/FloatUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/FloatUpdate.h
@@ -63,7 +63,7 @@ public:
 
 	void setEnabled( Bool enabled ) { m_enabled = enabled; }  ///< enable/disable floating
 
-	virtual UpdateSleepTime update();	///< Deciding whether or not to make new guys
+	virtual UpdateSleepTime update() override;	///< Deciding whether or not to make new guys
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/GarrisonContain.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/GarrisonContain.h
@@ -105,54 +105,54 @@ public:
 	GarrisonContain( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual UpdateSleepTime update();						///< called once per frame
+	virtual UpdateSleepTime update() override;						///< called once per frame
 
-	virtual Bool isValidContainerFor( const Object* obj, Bool checkCapacity) const; // Garrison has an extra check forbidding any containment if ReallyDamaged
-	virtual Bool isGarrisonable() const { return true; }	///< can this unit be Garrisoned? (ick)
-	virtual Bool isBustable() const { return TRUE; }	///< can this container get busted by a bunkerbuster
-	virtual Bool isImmuneToClearBuildingAttacks() const { return getGarrisonContainModuleData()->m_immuneToClearBuildingAttacks; }
-	virtual Bool isHealContain() const { return false; } ///< true when container only contains units while healing (not a transport!)
-	virtual Bool isTunnelContain() const { return FALSE; }
-	virtual Bool isPassengerAllowedToFire(  ObjectID id = INVALID_ID  ) const;	///< Hey, can I shoot out of this container?
-  virtual Bool isEnclosingContainerFor( const Object *obj ) const { return getGarrisonContainModuleData()->m_isEnclosingContainer; }
-  virtual Bool isSpecialOverlordStyleContainer() const {return FALSE;}
+	virtual Bool isValidContainerFor( const Object* obj, Bool checkCapacity) const override; // Garrison has an extra check forbidding any containment if ReallyDamaged
+	virtual Bool isGarrisonable() const override { return true; }	///< can this unit be Garrisoned? (ick)
+	virtual Bool isBustable() const override { return TRUE; }	///< can this container get busted by a bunkerbuster
+	virtual Bool isImmuneToClearBuildingAttacks() const override { return getGarrisonContainModuleData()->m_immuneToClearBuildingAttacks; }
+	virtual Bool isHealContain() const override { return false; } ///< true when container only contains units while healing (not a transport!)
+	virtual Bool isTunnelContain() const override { return FALSE; }
+	virtual Bool isPassengerAllowedToFire(  ObjectID id = INVALID_ID  ) const override;	///< Hey, can I shoot out of this container?
+  virtual Bool isEnclosingContainerFor( const Object *obj ) const override { return getGarrisonContainModuleData()->m_isEnclosingContainer; }
+  virtual Bool isSpecialOverlordStyleContainer() const override {return FALSE;}
 
-	virtual void removeAllContained( Bool exposeStealthUnits );	///< remove all contents of this open container
+	virtual void removeAllContained( Bool exposeStealthUnits ) override;	///< remove all contents of this open container
 
-	virtual void exitObjectViaDoor( Object *exitObj, ExitDoorType exitDoor );	///< exit one of our content items from us
-	virtual void exitObjectByBudding( Object *newObj, Object *budHost ) { return; };
-	virtual void onContaining( Object *obj, Bool wasSelected );				///< object now contains 'obj'
-	virtual void onRemoving( Object *obj );					///< object no longer contains 'obj'
-  virtual void onSelling();
+	virtual void exitObjectViaDoor( Object *exitObj, ExitDoorType exitDoor ) override;	///< exit one of our content items from us
+	virtual void exitObjectByBudding( Object *newObj, Object *budHost ) override { return; };
+	virtual void onContaining( Object *obj, Bool wasSelected ) override;				///< object now contains 'obj'
+	virtual void onRemoving( Object *obj ) override;					///< object no longer contains 'obj'
+  virtual void onSelling() override;
 
 
 	// A Garrison Contain must eject all passengers when it crosses the ReallyDamaged threshold.
 	virtual void onBodyDamageStateChange( const DamageInfo* damageInfo,
 																				BodyDamageType oldState,
-																				BodyDamageType newState);  ///< Die Interface state change callback
+																				BodyDamageType newState) override;  ///< Die Interface state change callback
 
 	/**
 		return the player that *appears* to control this unit, given an observing player.
 		if null, use getObject()->getControllingPlayer() instead.
 	*/
-	virtual const Player* getApparentControllingPlayer( const Player* observingPlayer ) const;
-	virtual void recalcApparentControllingPlayer();
-	virtual Bool isDisplayedOnControlBar() const {return TRUE;}///< Does this container display its contents on the ControlBar?
+	virtual const Player* getApparentControllingPlayer( const Player* observingPlayer ) const override;
+	virtual void recalcApparentControllingPlayer() override;
+	virtual Bool isDisplayedOnControlBar() const override {return TRUE;}///< Does this container display its contents on the ControlBar?
 
-  virtual void onDamage( DamageInfo *info );
+  virtual void onDamage( DamageInfo *info ) override;
 
-  virtual void setEvacDisposition( EvacDisposition disp ) { m_evacDisposition = disp; };
+  virtual void setEvacDisposition( EvacDisposition disp ) override { m_evacDisposition = disp; };
 
 protected:
 
-	virtual void redeployOccupants();				///< redeploy the occupants of us at all available garrison points
-	virtual void onObjectCreated();
+	virtual void redeployOccupants() override;				///< redeploy the occupants of us at all available garrison points
+	virtual void onObjectCreated() override;
 
 	void validateRallyPoint();							///< validate (if necessary) and pick (if possible) an exit rally point
 
-	virtual Bool calcBestGarrisonPosition( Coord3D *sourcePos, const Coord3D *targetPos );
-	virtual Bool attemptBestFirePointPosition( Object *source, Weapon *weapon, Object *victim );
-	virtual Bool attemptBestFirePointPosition( Object *source, Weapon *weapon, const Coord3D *targetPos );
+	virtual Bool calcBestGarrisonPosition( Coord3D *sourcePos, const Coord3D *targetPos ) override;
+	virtual Bool attemptBestFirePointPosition( Object *source, Weapon *weapon, Object *victim ) override;
+	virtual Bool attemptBestFirePointPosition( Object *source, Weapon *weapon, const Coord3D *targetPos ) override;
 
 	void updateEffects();										///< do any effects needed per frame
 	void loadGarrisonPoints();							///< load garrison point position data and save for later

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/GenerateMinefieldBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/GenerateMinefieldBehavior.h
@@ -82,35 +82,35 @@ public:
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_DIE) | (MODULEINTERFACE_UPGRADE); }
 
 	// BehaviorModule
-	virtual DieModuleInterface* getDie() { return this; }
-	virtual UpgradeModuleInterface* getUpgrade() { return this; }
-	virtual UpdateSleepTime update();
+	virtual DieModuleInterface* getDie() override { return this; }
+	virtual UpgradeModuleInterface* getUpgrade() override { return this; }
+	virtual UpdateSleepTime update() override;
 
 	// DamageModuleInterface
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 	void setMinefieldTarget(const Coord3D* pos);
 
 protected:
 
-	virtual void upgradeImplementation();
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation() override;
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
-	virtual void getUpgradeActivationMasks(UpgradeMaskType& activation, UpgradeMaskType& conflicting) const
+	virtual void getUpgradeActivationMasks(UpgradeMaskType& activation, UpgradeMaskType& conflicting) const override
 	{
 		getGenerateMinefieldBehaviorModuleData()->m_upgradeMuxData.getUpgradeActivationMasks(activation, conflicting);
 	}
-	virtual void performUpgradeFX()
+	virtual void performUpgradeFX() override
 	{
 		getGenerateMinefieldBehaviorModuleData()->m_upgradeMuxData.performUpgradeFX(getObject());
 	}
-	virtual void processUpgradeRemoval()
+	virtual void processUpgradeRemoval() override
 	{
 		// I can't take it any more.  Let the record show that I think the UpgradeMux multiple inheritance is CRAP.
 		getGenerateMinefieldBehaviorModuleData()->m_upgradeMuxData.muxDataProcessUpgradeRemoval(getObject());
 	}
 
-	virtual Bool requiresAllActivationUpgrades() const
+	virtual Bool requiresAllActivationUpgrades() const override
 	{
 		return getGenerateMinefieldBehaviorModuleData()->m_upgradeMuxData.m_requiresAllTriggers;
 	}

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/GrantScienceUpgrade.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/GrantScienceUpgrade.h
@@ -71,8 +71,8 @@ public:
 	// virtual destructor prototype defined by MemoryPoolObject
 
 protected:
-	virtual void upgradeImplementation( ); ///< Here's the actual work of Upgrading
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation( ) override; ///< Here's the actual work of Upgrading
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 private:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/GrantStealthBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/GrantStealthBehavior.h
@@ -95,7 +95,7 @@ public:
 	GrantStealthBehavior( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 
 private:

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/GrantUpgradeCreate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/GrantUpgradeCreate.h
@@ -68,8 +68,8 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	/// the create method
-	virtual void onCreate();
-	virtual void onBuildComplete();	///< This is called when you are a finished game object
+	virtual void onCreate() override;
+	virtual void onBuildComplete() override;	///< This is called when you are a finished game object
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/HackInternetAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/HackInternetAIUpdate.h
@@ -48,15 +48,15 @@ public:
 	{
 		m_framesRemaining = 0;
 	}
-	virtual StateReturnType update();
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType update() override;
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	UnsignedInt m_framesRemaining; //frames till next cash update
@@ -72,14 +72,14 @@ public:
 	{
 		m_framesRemaining = 0;
 	}
-	virtual StateReturnType update();
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType update() override;
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	UnsignedInt m_framesRemaining; //frames till packing animation complete
@@ -95,14 +95,14 @@ public:
 	{
 		m_framesRemaining = 0;
 	}
-	virtual StateReturnType update();
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType update() override;
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	UnsignedInt m_framesRemaining; //frames till unpacking animation complete
@@ -189,7 +189,7 @@ public:
 	HackInternetAIUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
- 	virtual void aiDoCommand(const AICommandParms* parms);
+ 	virtual void aiDoCommand(const AICommandParms* parms) override;
 
 	Real getPackUnpackVariationFactor() const { return getHackInternetAIUpdateModuleData()->m_packUnpackVariationFactor; }
 	UnsignedInt getUnpackTime()					const;
@@ -202,19 +202,19 @@ public:
 	UnsignedInt getXpPerCashUpdate()		const { return getHackInternetAIUpdateModuleData()->m_xpPerCashUpdate; }
 
 	void hackInternet();
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
-	virtual Bool isIdle() const;
+	virtual Bool isIdle() const override;
 
-	virtual HackInternetAIInterface* getHackInternetAIInterface() { return this; }
-	virtual const HackInternetAIInterface* getHackInternetAIInterface() const { return this; }
+	virtual HackInternetAIInterface* getHackInternetAIInterface() override { return this; }
+	virtual const HackInternetAIInterface* getHackInternetAIInterface() const override { return this; }
 
-	virtual Bool isHacking() const;
-	virtual Bool isHackingPackingOrUnpacking() const;
+	virtual Bool isHacking() const override;
+	virtual Bool isHackingPackingOrUnpacking() const override;
 
 protected:
 
-	virtual AIStateMachine* makeStateMachine();
+	virtual AIStateMachine* makeStateMachine() override;
 
 	AICommandParmsStorage		m_pendingCommand;
 	Bool m_hasPendingCommand;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/HealContain.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/HealContain.h
@@ -61,9 +61,9 @@ public:
 	HealContain( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual UpdateSleepTime update();												///< called once per frame
-	virtual Bool isHealContain() const { return true; } ///< true when container only contains units while healing (not a transport!)
-	virtual Bool isTunnelContain() const { return FALSE; }
+	virtual UpdateSleepTime update() override;												///< called once per frame
+	virtual Bool isHealContain() const override { return true; } ///< true when container only contains units while healing (not a transport!)
+	virtual Bool isTunnelContain() const override { return FALSE; }
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/HealCrateCollide.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/HealCrateCollide.h
@@ -51,5 +51,5 @@ public:
 protected:
 
 	/// This is the game logic execution function that all real CrateCollides will implement
-	virtual Bool executeCrateBehavior( Object *other );
+	virtual Bool executeCrateBehavior( Object *other ) override;
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/HeightDieUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/HeightDieUpdate.h
@@ -65,7 +65,7 @@ public:
 	HeightDieUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/HelicopterSlowDeathUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/HelicopterSlowDeathUpdate.h
@@ -91,8 +91,8 @@ public:
 	HelicopterSlowDeathBehavior( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void beginSlowDeath( const DamageInfo *damageInfo );	///< begin the slow death cycle
-	virtual UpdateSleepTime update();
+	virtual void beginSlowDeath( const DamageInfo *damageInfo ) override;	///< begin the slow death cycle
+	virtual UpdateSleepTime update() override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/HelixContain.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/HelixContain.h
@@ -63,50 +63,50 @@ class HelixContain : public TransportContain
 
 	virtual void onBodyDamageStateChange( const DamageInfo* damageInfo,
 																				BodyDamageType oldState,
-																				BodyDamageType newState);  ///< state change callback
+																				BodyDamageType newState) override;  ///< state change callback
 public:
 
 	HelixContain( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual OpenContain *asOpenContain() { return this; }  ///< treat as open container
-	virtual Bool isHealContain() const { return false; } ///< true when container only contains units while healing (not a transport!)
-	virtual Bool isTunnelContain() const { return FALSE; }
-	virtual Bool isImmuneToClearBuildingAttacks() const { return true; }
-  virtual Bool isSpecialOverlordStyleContainer() const {return TRUE;}
+	virtual OpenContain *asOpenContain() override { return this; }  ///< treat as open container
+	virtual Bool isHealContain() const override { return false; } ///< true when container only contains units while healing (not a transport!)
+	virtual Bool isTunnelContain() const override { return FALSE; }
+	virtual Bool isImmuneToClearBuildingAttacks() const override { return true; }
+  virtual Bool isSpecialOverlordStyleContainer() const override {return TRUE;}
 
-	virtual void onDie( const DamageInfo *damageInfo );  ///< the die callback
-	virtual void onDelete();	///< Last possible moment cleanup
-	virtual void onCapture( Player *oldOwner, Player *newOwner );
-	virtual void onObjectCreated();
-  virtual void onContaining( Object *obj, Bool wasSelected  );
-  virtual void onRemoving( Object *obj );
+	virtual void onDie( const DamageInfo *damageInfo ) override;  ///< the die callback
+	virtual void onDelete() override;	///< Last possible moment cleanup
+	virtual void onCapture( Player *oldOwner, Player *newOwner ) override;
+	virtual void onObjectCreated() override;
+  virtual void onContaining( Object *obj, Bool wasSelected  ) override;
+  virtual void onRemoving( Object *obj ) override;
 
 
-  virtual UpdateSleepTime update();							///< called once per frame
+  virtual UpdateSleepTime update() override;							///< called once per frame
 
 
  // virtual void onContaining( Object *obj, Bool wasSelected );		///< object now contains 'obj'
 //	virtual void onRemoving( Object *obj );			///< object no longer contains 'obj'
 
-	virtual Bool isValidContainerFor(const Object* obj, Bool checkCapacity) const;
-	virtual void addToContain( Object *obj );				///< add 'obj' to contain list
+	virtual Bool isValidContainerFor(const Object* obj, Bool checkCapacity) const override;
+	virtual void addToContain( Object *obj ) override;				///< add 'obj' to contain list
 	virtual void addToContainList( Object *obj );		///< The part of AddToContain that inheritors can override (Can't do whole thing because of all the private stuff involved)
-	virtual void removeFromContain( Object *obj, Bool exposeStealthUnits = FALSE );	///< remove 'obj' from contain list
+	virtual void removeFromContain( Object *obj, Bool exposeStealthUnits = FALSE ) override;	///< remove 'obj' from contain list
 	//virtual void removeAllContained( Bool exposeStealthUnits = FALSE );				///< remove all objects on contain list
-	virtual Bool isEnclosingContainerFor( const Object *obj ) const;	///< Does this type of Contain Visibly enclose its contents?
-	virtual Bool isPassengerAllowedToFire(  ObjectID id = INVALID_ID  ) const;	///< Hey, can I shoot out of this container?
+	virtual Bool isEnclosingContainerFor( const Object *obj ) const override;	///< Does this type of Contain Visibly enclose its contents?
+	virtual Bool isPassengerAllowedToFire(  ObjectID id = INVALID_ID  ) const override;	///< Hey, can I shoot out of this container?
 
 	// Friend for our Draw module only.
-	virtual const Object *friend_getRider() const; ///< Damn.  The draw order dependency bug for riders means that our draw module needs to cheat to get around it.
+	virtual const Object *friend_getRider() const override; ///< Damn.  The draw order dependency bug for riders means that our draw module needs to cheat to get around it.
 
 	///< if my object gets selected, then my visible passengers should, too
 	///< this gets called from
-	virtual void clientVisibleContainedFlashAsSelected();
+	virtual void clientVisibleContainedFlashAsSelected() override;
 
-  virtual void redeployOccupants();
+  virtual void redeployOccupants() override;
 
-	virtual Bool getContainerPipsToShow(Int& numTotal, Int& numFull)
+	virtual Bool getContainerPipsToShow(Int& numTotal, Int& numFull) override
   {
     if ( getHelixContainModuleData()->m_drawPips == FALSE )
     {
@@ -118,7 +118,7 @@ public:
     return ContainModuleInterface::getContainerPipsToShow( numTotal, numFull );
   }
 
-	virtual void createPayload();
+	virtual void createPayload() override;
 
 private:
   void parseInitialPayload( INI* ini, void *instance, void *store, const void* /*userData*/ );

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/HighlanderBody.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/HighlanderBody.h
@@ -49,7 +49,7 @@ public:
 	HighlanderBody( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void attemptDamage( DamageInfo *damageInfo );		///< try to damage this object
+	virtual void attemptDamage( DamageInfo *damageInfo ) override;		///< try to damage this object
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/HijackerUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/HijackerUpdate.h
@@ -70,7 +70,7 @@ public:
 	HijackerUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual UpdateSleepTime update();							///< called once per frame
+	virtual UpdateSleepTime update() override;							///< called once per frame
 
 	void setTargetObject( const Object *object );
 	Object* getTargetObject() const;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/HiveStructureBody.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/HiveStructureBody.h
@@ -76,5 +76,5 @@ public:
 
 protected:
 
-	virtual void attemptDamage( DamageInfo *damageInfo );		///< try to damage this object
+	virtual void attemptDamage( DamageInfo *damageInfo ) override;		///< try to damage this object
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/HordeUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/HordeUpdate.h
@@ -122,16 +122,16 @@ public:
 	HordeUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	HordeUpdateInterface *getHordeUpdateInterface() { return this; }
+	virtual HordeUpdateInterface *getHordeUpdateInterface() override { return this; }
 
-	virtual void onDrawableBoundToObject();
-	virtual UpdateSleepTime update();	///< update this object's AI
+	virtual void onDrawableBoundToObject() override;
+	virtual UpdateSleepTime update() override;	///< update this object's AI
 
-	virtual Bool isInHorde() const { return m_inHorde; }
-	virtual Bool hasFlag() const { return m_hasFlag; }
-	virtual Bool isTrueHordeMember() const { return m_trueHordeMember && m_inHorde; }
-	virtual Bool isAllowedNationalism() const;
-	virtual HordeActionType getHordeActionType() const { return getHordeUpdateModuleData()->m_action; };
+	virtual Bool isInHorde() const override { return m_inHorde; }
+	virtual Bool hasFlag() const override { return m_hasFlag; }
+	virtual Bool isTrueHordeMember() const override { return m_trueHordeMember && m_inHorde; }
+	virtual Bool isAllowedNationalism() const override;
+	virtual HordeActionType getHordeActionType() const override { return getHordeUpdateModuleData()->m_action; };
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ImmortalBody.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ImmortalBody.h
@@ -49,7 +49,7 @@ public:
 	ImmortalBody( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void internalChangeHealth( Real delta );								///< change health
+	virtual void internalChangeHealth( Real delta ) override;								///< change health
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/InactiveBody.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/InactiveBody.h
@@ -47,21 +47,21 @@ public:
 	InactiveBody( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void attemptDamage( DamageInfo *damageInfo );		///< try to damage this object
-	virtual void attemptHealing( DamageInfo *damageInfo );		///< try to heal this object
-	virtual Real estimateDamage( DamageInfoInput& damageInfo ) const;
-	virtual Real getHealth() const;													///< get current health
-	virtual BodyDamageType getDamageState() const;
-	virtual void setDamageState( BodyDamageType newState );	///< control damage state directly.  Will adjust hitpoints.
-	virtual void setAflame( Bool setting ){}///< This is a major change like a damage state.
+	virtual void attemptDamage( DamageInfo *damageInfo ) override;		///< try to damage this object
+	virtual void attemptHealing( DamageInfo *damageInfo ) override;		///< try to heal this object
+	virtual Real estimateDamage( DamageInfoInput& damageInfo ) const override;
+	virtual Real getHealth() const override;													///< get current health
+	virtual BodyDamageType getDamageState() const override;
+	virtual void setDamageState( BodyDamageType newState ) override;	///< control damage state directly.  Will adjust hitpoints.
+	virtual void setAflame( Bool setting ) override{}///< This is a major change like a damage state.
 
-	void onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel newLevel, Bool provideFeedback ) { /* nothing */ }
+	virtual void onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel newLevel, Bool provideFeedback ) override { /* nothing */ }
 
-	virtual void setArmorSetFlag(ArmorSetType ast) { /* nothing */ }
-	virtual void clearArmorSetFlag(ArmorSetType ast) { /* nothing */ }
-	virtual Bool testArmorSetFlag(ArmorSetType ast){ return FALSE; }
+	virtual void setArmorSetFlag(ArmorSetType ast) override { /* nothing */ }
+	virtual void clearArmorSetFlag(ArmorSetType ast) override { /* nothing */ }
+	virtual Bool testArmorSetFlag(ArmorSetType ast) override{ return FALSE; }
 
-	virtual void internalChangeHealth( Real delta );
+	virtual void internalChangeHealth( Real delta ) override;
 
 private:
 	Bool m_dieCalled;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/InactiveBody.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/InactiveBody.h
@@ -53,13 +53,13 @@ public:
 	virtual Real getHealth() const override;													///< get current health
 	virtual BodyDamageType getDamageState() const override;
 	virtual void setDamageState( BodyDamageType newState ) override;	///< control damage state directly.  Will adjust hitpoints.
-	virtual void setAflame( Bool setting ) override{}///< This is a major change like a damage state.
+	virtual void setAflame( Bool setting ) override {}///< This is a major change like a damage state.
 
 	virtual void onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel newLevel, Bool provideFeedback ) override { /* nothing */ }
 
 	virtual void setArmorSetFlag(ArmorSetType ast) override { /* nothing */ }
 	virtual void clearArmorSetFlag(ArmorSetType ast) override { /* nothing */ }
-	virtual Bool testArmorSetFlag(ArmorSetType ast) override{ return FALSE; }
+	virtual Bool testArmorSetFlag(ArmorSetType ast) override { return FALSE; }
 
 	virtual void internalChangeHealth( Real delta ) override;
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/InstantDeathBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/InstantDeathBehavior.h
@@ -70,6 +70,6 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	// DieModuleInterface
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/InternetHackContain.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/InternetHackContain.h
@@ -57,7 +57,7 @@ public:
 	InternetHackContain( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onContaining( Object *obj, Bool wasSelected );		///< object now contains 'obj'
+	virtual void onContaining( Object *obj, Bool wasSelected ) override;		///< object now contains 'obj'
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/JetAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/JetAIUpdate.h
@@ -74,32 +74,32 @@ class JetAIUpdate : public AIUpdateInterface
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( JetAIUpdate, "JetAIUpdate" )
 	MAKE_STANDARD_MODULE_MACRO_WITH_MODULE_DATA( JetAIUpdate, JetAIUpdateModuleData )
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 public:
 
 	JetAIUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onObjectCreated();
-	virtual void onDelete();
+	virtual void onObjectCreated() override;
+	virtual void onDelete() override;
 
-	virtual JetAIUpdate* getJetAIUpdate() { return this; }
-	virtual const JetAIUpdate* getJetAIUpdate() const { return this; }
+	virtual JetAIUpdate* getJetAIUpdate() override { return this; }
+	virtual const JetAIUpdate* getJetAIUpdate() const override { return this; }
 
- 	virtual void aiDoCommand(const AICommandParms* parms);
-	virtual Bool chooseLocomotorSet(LocomotorSetType wst);
-	virtual void setLocomotorGoalNone();
-	virtual Bool isIdle() const;
-	virtual Bool isTaxiingToParking() const; //only applies to jets interacting with runways.
+ 	virtual void aiDoCommand(const AICommandParms* parms) override;
+	virtual Bool chooseLocomotorSet(LocomotorSetType wst) override;
+	virtual void setLocomotorGoalNone() override;
+	virtual Bool isIdle() const override;
+	virtual Bool isTaxiingToParking() const override; //only applies to jets interacting with runways.
 	virtual Bool isReloading() const;
 
-	virtual Bool isAllowedToMoveAwayFromUnit() const;
-	virtual Bool getSneakyTargetingOffset(Coord3D* offset) const;
-	virtual void addTargeter(ObjectID id, Bool add);
-	virtual Bool isTemporarilyPreventingAimSuccess() const;
-	virtual Bool isDoingGroundMovement() const;
-	virtual void notifyVictimIsDead();
+	virtual Bool isAllowedToMoveAwayFromUnit() const override;
+	virtual Bool getSneakyTargetingOffset(Coord3D* offset) const override;
+	virtual void addTargeter(ObjectID id, Bool add) override;
+	virtual Bool isTemporarilyPreventingAimSuccess() const override;
+	virtual Bool isDoingGroundMovement() const override;
+	virtual void notifyVictimIsDead() override;
 	virtual Bool isOutOfSpecialReloadAmmo() const;
 
 	const Coord3D* friend_getProducerLocation() const { return &m_producerLocation; }
@@ -129,17 +129,17 @@ public:
 
 protected:
 
-	virtual AIStateMachine* makeStateMachine();
+	virtual AIStateMachine* makeStateMachine() override;
 
 	virtual void privateFollowPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource, Bool exitProduction );///< follow the path defined by the given array of points
-	virtual void privateFollowPathAppend( const Coord3D *pos, CommandSourceType cmdSource );
-	virtual void privateEnter( Object *obj, CommandSourceType cmdSource );							///< enter the given object
-	virtual void privateGetRepaired( Object *repairDepot, CommandSourceType cmdSource );///< get repaired at repair depot
+	virtual void privateFollowPathAppend( const Coord3D *pos, CommandSourceType cmdSource ) override;
+	virtual void privateEnter( Object *obj, CommandSourceType cmdSource ) override;							///< enter the given object
+	virtual void privateGetRepaired( Object *repairDepot, CommandSourceType cmdSource ) override;///< get repaired at repair depot
 
 	void pruneDeadTargeters();
 	void positionLockon();
 
-	virtual Bool getTreatAsAircraftForLocoDistToGoal() const;
+	virtual Bool getTreatAsAircraftForLocoDistToGoal() const override;
 	Bool isParkedAt(const Object* obj) const;
 
 private:

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/JetSlowDeathBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/JetSlowDeathBehavior.h
@@ -88,9 +88,9 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	// slow death methods
-	virtual void onDie( const DamageInfo *damageInfo );
-	virtual void beginSlowDeath( const DamageInfo *damageInfo );
-	virtual UpdateSleepTime update();
+	virtual void onDie( const DamageInfo *damageInfo ) override;
+	virtual void beginSlowDeath( const DamageInfo *damageInfo ) override;
+	virtual UpdateSleepTime update() override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/KeepObjectDie.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/KeepObjectDie.h
@@ -50,6 +50,6 @@ public:
 	KeepObjectDie( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/LaserUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/LaserUpdate.h
@@ -109,7 +109,7 @@ public:
 	void setDirty( Bool dirty ) { m_dirty = dirty; }
 	Bool isDirty() const { return m_dirty; }
 
-	virtual void clientUpdate();
+	virtual void clientUpdate() override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/LifetimeUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/LifetimeUpdate.h
@@ -74,7 +74,7 @@ public:
 	void setLifetimeRange( UnsignedInt minFrames, UnsignedInt maxFrames );
 	UnsignedInt getDieFrame() const { return m_dieFrame; }
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 private:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/LockWeaponCreate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/LockWeaponCreate.h
@@ -62,8 +62,8 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	/// the create method
-	virtual void onCreate();
-	virtual void onBuildComplete();	///< This is called when you are a finished game object
+	virtual void onCreate() override;
+	virtual void onBuildComplete() override;	///< This is called when you are a finished game object
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/LocomotorSetUpgrade.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/LocomotorSetUpgrade.h
@@ -50,7 +50,7 @@ public:
 	// virtual destructor prototype defined by MemoryPoolObject
 
 protected:
-	virtual void upgradeImplementation( ); ///< Here's the actual work of Upgrading
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation( ) override; ///< Here's the actual work of Upgrading
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/MaxHealthUpgrade.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/MaxHealthUpgrade.h
@@ -67,7 +67,7 @@ public:
 
 protected:
 
-	virtual void upgradeImplementation(); ///< Here's the actual work of Upgrading
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation() override; ///< Here's the actual work of Upgrading
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/MinefieldBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/MinefieldBehavior.h
@@ -82,34 +82,34 @@ public:
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_COLLIDE) | (MODULEINTERFACE_DAMAGE) | (MODULEINTERFACE_DIE); }
 
 	// BehaviorModule
-	virtual CollideModuleInterface* getCollide() { return this; }
-	virtual LandMineInterface* getLandMineInterface() { return this; }
-	virtual DamageModuleInterface* getDamage() { return this; }
-	virtual DieModuleInterface* getDie() { return this; }
+	virtual CollideModuleInterface* getCollide() override { return this; }
+	virtual LandMineInterface* getLandMineInterface() override { return this; }
+	virtual DamageModuleInterface* getDamage() override { return this; }
+	virtual DieModuleInterface* getDie() override { return this; }
 
 	// DamageModuleInterface
-	virtual void onDamage( DamageInfo *damageInfo );
-	virtual void onHealing( DamageInfo *damageInfo );
-	virtual void onBodyDamageStateChange(const DamageInfo* damageInfo, BodyDamageType oldState, BodyDamageType newState) { }
+	virtual void onDamage( DamageInfo *damageInfo ) override;
+	virtual void onHealing( DamageInfo *damageInfo ) override;
+	virtual void onBodyDamageStateChange(const DamageInfo* damageInfo, BodyDamageType oldState, BodyDamageType newState) override { }
 
 	// DieModuleInterface
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 	// UpdateModuleInterface
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	// CollideModuleInterface
-	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal );
-	virtual Bool wouldLikeToCollideWith(const Object* other) const { return false; }
-	virtual Bool isHijackedVehicleCrateCollide() const { return false; }
-	virtual Bool isCarBombCrateCollide() const { return false; }
-	virtual Bool isRailroad() const { return false;}
-	virtual Bool isSalvageCrateCollide() const { return false; }
-	virtual Bool isSabotageBuildingCrateCollide() const { return FALSE; }
+	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal ) override;
+	virtual Bool wouldLikeToCollideWith(const Object* other) const override { return false; }
+	virtual Bool isHijackedVehicleCrateCollide() const override { return false; }
+	virtual Bool isCarBombCrateCollide() const override { return false; }
+	virtual Bool isRailroad() const override { return false;}
+	virtual Bool isSalvageCrateCollide() const override { return false; }
+	virtual Bool isSabotageBuildingCrateCollide() const override { return FALSE; }
 
 	// Minefield specific methods
-	virtual void setScootParms(const Coord3D& start, const Coord3D& end);
-	virtual void disarm();
+	virtual void setScootParms(const Coord3D& start, const Coord3D& end) override;
+	virtual void disarm() override;
 
 private:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/MissileAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/MissileAIUpdate.h
@@ -88,19 +88,19 @@ public:
 		KILL_SELF			= 7, ///< Destroy self.
 	};
 
-	virtual ProjectileUpdateInterface* getProjectileUpdateInterface() { return this; }
-	virtual void projectileFireAtObjectOrPosition( const Object *victim, const Coord3D *victimPos, const WeaponTemplate *detWeap, const ParticleSystemTemplate* exhaustSysOverride );
-	virtual void projectileLaunchAtObjectOrPosition(const Object *victim, const Coord3D* victimPos, const Object *launcher, WeaponSlotType wslot, Int specificBarrelToUse, const WeaponTemplate* detWeap, const ParticleSystemTemplate* exhaustSysOverride);
-	virtual Bool projectileHandleCollision( Object *other );
-	virtual Bool projectileIsArmed() const { return m_isArmed; }
-	virtual ObjectID projectileGetLauncherID() const { return m_launcherID; }
-	virtual void setFramesTillCountermeasureDiversionOccurs( UnsignedInt frames ); ///< Number of frames till missile diverts to countermeasures.
-	virtual void projectileNowJammed();///< We lose our Object target and scatter to the ground
+	virtual ProjectileUpdateInterface* getProjectileUpdateInterface() override { return this; }
+	virtual void projectileFireAtObjectOrPosition( const Object *victim, const Coord3D *victimPos, const WeaponTemplate *detWeap, const ParticleSystemTemplate* exhaustSysOverride ) override;
+	virtual void projectileLaunchAtObjectOrPosition(const Object *victim, const Coord3D* victimPos, const Object *launcher, WeaponSlotType wslot, Int specificBarrelToUse, const WeaponTemplate* detWeap, const ParticleSystemTemplate* exhaustSysOverride) override;
+	virtual Bool projectileHandleCollision( Object *other ) override;
+	virtual Bool projectileIsArmed() const override { return m_isArmed; }
+	virtual ObjectID projectileGetLauncherID() const override { return m_launcherID; }
+	virtual void setFramesTillCountermeasureDiversionOccurs( UnsignedInt frames ) override; ///< Number of frames till missile diverts to countermeasures.
+	virtual void projectileNowJammed() override;///< We lose our Object target and scatter to the ground
 
-	virtual Bool processCollision(PhysicsBehavior *physics, Object *other); ///< Returns true if the physics collide should apply the force.  Normally not.  jba.
+	virtual Bool processCollision(PhysicsBehavior *physics, Object *other) override; ///< Returns true if the physics collide should apply the force.  Normally not.  jba.
 
-	virtual UpdateSleepTime update();
-	virtual void onDelete();
+	virtual UpdateSleepTime update() override;
+	virtual void onDelete() override;
 
 
 protected:

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/MissileLauncherBuildingUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/MissileLauncherBuildingUpdate.h
@@ -99,20 +99,20 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	//SpecialPowerUpdateInterface pure virtual implementations
-	virtual Bool initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions );
-	virtual Bool isSpecialAbility() const { return false; }
-	virtual Bool isSpecialPower() const { return true; }
-	virtual Bool isActive() const { return m_doorState != m_timeoutState; }
+	virtual Bool initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions ) override;
+	virtual Bool isSpecialAbility() const override { return false; }
+	virtual Bool isSpecialPower() const override { return true; }
+	virtual Bool isActive() const override { return m_doorState != m_timeoutState; }
 	SpecialPowerTemplate* getTemplate() const;
-	virtual Bool doesSpecialPowerHaveOverridableDestinationActive() const { return false; } //Is it active now?
-	virtual Bool doesSpecialPowerHaveOverridableDestination() const { return false; }	//Does it have it, even if it's not active?
-	virtual void setSpecialPowerOverridableDestination( const Coord3D *loc ) {}
+	virtual Bool doesSpecialPowerHaveOverridableDestinationActive() const override { return false; } //Is it active now?
+	virtual Bool doesSpecialPowerHaveOverridableDestination() const override { return false; }	//Does it have it, even if it's not active?
+	virtual void setSpecialPowerOverridableDestination( const Coord3D *loc ) override {}
 
-	virtual SpecialPowerUpdateInterface* getSpecialPowerUpdateInterface() { return this; }
-	virtual CommandOption getCommandOption() const { return (CommandOption)0; }
+	virtual SpecialPowerUpdateInterface* getSpecialPowerUpdateInterface() override { return this; }
+	virtual CommandOption getCommandOption() const override { return (CommandOption)0; }
 
-	virtual UpdateSleepTime update();	///< Deciding whether or not to make new guys
-	virtual Bool isPowerCurrentlyInUse( const CommandButton *command = nullptr ) const;
+	virtual UpdateSleepTime update() override;	///< Deciding whether or not to make new guys
+	virtual Bool isPowerCurrentlyInUse( const CommandButton *command = nullptr ) const override;
 
 private:
 	enum DoorStateType

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/MobMemberSlavedUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/MobMemberSlavedUpdate.h
@@ -97,14 +97,14 @@ public:
 	MobMemberSlavedUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual SlavedUpdateInterface* getSlavedUpdateInterface() { return this; }// hee hee... behaves just like slavedupdate
+	virtual SlavedUpdateInterface* getSlavedUpdateInterface() override { return this; }// hee hee... behaves just like slavedupdate
 
-	virtual ObjectID getSlaverID() const { return m_slaver; }
-	virtual void onEnslave( const Object *slaver );
-	virtual void onSlaverDie( const DamageInfo *info );
-	virtual void onSlaverDamage( const DamageInfo *info );
-	virtual void onObjectCreated();
-	virtual Bool isSelfTasking() const { return m_isSelfTasking; };
+	virtual ObjectID getSlaverID() const override { return m_slaver; }
+	virtual void onEnslave( const Object *slaver ) override;
+	virtual void onSlaverDie( const DamageInfo *info ) override;
+	virtual void onSlaverDamage( const DamageInfo *info ) override;
+	virtual void onObjectCreated() override;
+	virtual Bool isSelfTasking() const override { return m_isSelfTasking; };
 
 	void doCatchUpLogic( Coord3D *pinnedPosition );
 
@@ -112,7 +112,7 @@ public:
 	MobStates getMobState() { return m_mobState; };
 
 
-	virtual UpdateSleepTime update();	///< Deciding whether or not to make new guys
+	virtual UpdateSleepTime update() override;	///< Deciding whether or not to make new guys
 
 private:
 	void startSlavedEffects( const Object *slaver );	///< We have been marked as Slaved, so we can't be selected or move too far or other stuff

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/MobNexusContain.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/MobNexusContain.h
@@ -73,25 +73,25 @@ public:
 																																								// lorenzen add a MobMemberInterface
 																																								// lorenzen add a MobMemberInterface
 																																								// lorenzen add a MobMemberInterface
-	virtual TransportPassengerInterface* getTransportPassengerInterface() { return this; }// lorenzen add a MobMemberInterface
+	virtual TransportPassengerInterface* getTransportPassengerInterface() override { return this; }// lorenzen add a MobMemberInterface
 																																								// lorenzen add a MobMemberInterface
 																																								// lorenzen add a MobMemberInterface
 																																								// lorenzen add a MobMemberInterface
-	virtual Bool isValidContainerFor( const Object* obj, Bool checkCapacity) const;
+	virtual Bool isValidContainerFor( const Object* obj, Bool checkCapacity) const override;
 
-	virtual void onContaining( Object *obj, Bool wasSelected );		///< object now contains 'obj'
-	virtual void onRemoving( Object *obj );			///< object no longer contains 'obj'
-	virtual UpdateSleepTime update();							///< called once per frame
+	virtual void onContaining( Object *obj, Bool wasSelected ) override;		///< object now contains 'obj'
+	virtual void onRemoving( Object *obj ) override;			///< object no longer contains 'obj'
+	virtual UpdateSleepTime update() override;							///< called once per frame
 
-	virtual Int getContainMax() const;
+	virtual Int getContainMax() const override;
 
-	virtual void onObjectCreated();
-	virtual Int getExtraSlotsInUse() { return m_extraSlotsInUse; }
+	virtual void onObjectCreated() override;
+	virtual Int getExtraSlotsInUse() override { return m_extraSlotsInUse; }
 
-	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject );					///< All types can answer if they are free to exit or not, and you can ask about a specific guy or just exit anything in general
-	virtual void unreserveDoorForExit( ExitDoorType exitDoor );
+	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject ) override;					///< All types can answer if they are free to exit or not, and you can ask about a specific guy or just exit anything in general
+	virtual void unreserveDoorForExit( ExitDoorType exitDoor ) override;
 
-	virtual Bool tryToEvacuate( Bool exposeStealthedUnits ); ///< Will try to kick everybody out with game checks, and will return whether anyone made it
+	virtual Bool tryToEvacuate( Bool exposeStealthedUnits ) override; ///< Will try to kick everybody out with game checks, and will return whether anyone made it
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ModelConditionUpgrade.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ModelConditionUpgrade.h
@@ -56,7 +56,7 @@ public:
 	// virtual destructor prototype defined by MemoryPoolObject
 
 protected:
-	virtual void upgradeImplementation( ); ///< Here's the actual work of Upgrading
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation( ) override; ///< Here's the actual work of Upgrading
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/MoneyCrateCollide.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/MoneyCrateCollide.h
@@ -81,7 +81,7 @@ public:
 protected:
 
 	/// This is the game logic execution function that all real CrateCollides will implement
-	virtual Bool executeCrateBehavior( Object *other );
+	virtual Bool executeCrateBehavior( Object *other ) override;
 
 	Int getUpgradedSupplyBoost( Object *other ) const;
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/NeutronBlastBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/NeutronBlastBehavior.h
@@ -80,11 +80,11 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | MODULEINTERFACE_DIE; }
-	virtual DieModuleInterface* getDie() { return this; }
+	virtual DieModuleInterface* getDie() override { return this; }
 
 
-	virtual UpdateSleepTime update();
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual UpdateSleepTime update() override;
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 
 private:

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/NeutronMissileSlowDeathUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/NeutronMissileSlowDeathUpdate.h
@@ -96,7 +96,7 @@ public:
 	NeutronMissileSlowDeathBehavior( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual UpdateSleepTime update();				 ///< the update call
+	virtual UpdateSleepTime update() override;				 ///< the update call
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/NeutronMissileUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/NeutronMissileUpdate.h
@@ -80,12 +80,12 @@ public:
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_DIE); }
 
 	// BehaviorModule
-	virtual DieModuleInterface* getDie() { return this; }
+	virtual DieModuleInterface* getDie() override { return this; }
 
 	// DieModuleInterface
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
-	virtual ProjectileUpdateInterface* getProjectileUpdateInterface() { return this; }
+	virtual ProjectileUpdateInterface* getProjectileUpdateInterface() override { return this; }
 
 	enum MissileStateType
 	{
@@ -95,17 +95,17 @@ public:
 		DEAD
 	};
 
-	virtual void projectileLaunchAtObjectOrPosition(const Object *victim, const Coord3D* victimPos, const Object *launcher, WeaponSlotType wslot, Int specificBarrelToUse, const WeaponTemplate* detWeap, const ParticleSystemTemplate* exhaustSysOverride);
-	virtual void projectileFireAtObjectOrPosition( const Object *victim, const Coord3D *victimPos, const WeaponTemplate *detWeap, const ParticleSystemTemplate* exhaustSysOverride );
-	virtual Bool projectileIsArmed() const { return m_isArmed; }											///< return true if the missile is armed and ready to explode
-	virtual ObjectID projectileGetLauncherID() const { return m_launcherID; }				///< Return firer of missile. Returns 0 if not yet fired.
-	virtual Bool projectileHandleCollision( Object *other );
+	virtual void projectileLaunchAtObjectOrPosition(const Object *victim, const Coord3D* victimPos, const Object *launcher, WeaponSlotType wslot, Int specificBarrelToUse, const WeaponTemplate* detWeap, const ParticleSystemTemplate* exhaustSysOverride) override;
+	virtual void projectileFireAtObjectOrPosition( const Object *victim, const Coord3D *victimPos, const WeaponTemplate *detWeap, const ParticleSystemTemplate* exhaustSysOverride ) override;
+	virtual Bool projectileIsArmed() const override { return m_isArmed; }											///< return true if the missile is armed and ready to explode
+	virtual ObjectID projectileGetLauncherID() const override { return m_launcherID; }				///< Return firer of missile. Returns 0 if not yet fired.
+	virtual Bool projectileHandleCollision( Object *other ) override;
 	virtual const Coord3D *getVelocity() const { return &m_vel; }		///< get current velocity
-	virtual void setFramesTillCountermeasureDiversionOccurs( UnsignedInt frames ) {}
-	virtual void projectileNowJammed() {}
+	virtual void setFramesTillCountermeasureDiversionOccurs( UnsignedInt frames ) override {}
+	virtual void projectileNowJammed() override {}
 
-	virtual UpdateSleepTime update();
-	virtual void onDelete();
+	virtual UpdateSleepTime update() override;
+	virtual void onDelete() override;
 
 private:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OCLSpecialPower.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OCLSpecialPower.h
@@ -92,12 +92,12 @@ public:
 	OCLSpecialPower( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool object
 
-	virtual void doSpecialPower( UnsignedInt commandOptions );
-	virtual void doSpecialPowerAtObject( Object *obj, UnsignedInt commandOptions );
-	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions );
+	virtual void doSpecialPower( UnsignedInt commandOptions ) override;
+	virtual void doSpecialPowerAtObject( Object *obj, UnsignedInt commandOptions ) override;
+	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions ) override;
 
 	//If the special power launches a construction site, we need to know the final product for placement purposes.
-	virtual const ThingTemplate* getReferenceThingTemplate() const;
+	virtual const ThingTemplate* getReferenceThingTemplate() const override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OCLUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OCLUpdate.h
@@ -75,12 +75,12 @@ public:
 	OCLUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	Real getCountdownPercent() const; ///< goes from 0% to 100%
 	UnsignedInt getRemainingFrames() const; ///< For feedback display
 	void resetTimer(); ///< added for sabotage purposes.
-	virtual DisabledMaskType getDisabledTypesToProcess() const { return DISABLEDMASK_ALL; }
+	virtual DisabledMaskType getDisabledTypesToProcess() const override { return DISABLEDMASK_ALL; }
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ObjectCreationUpgrade.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ObjectCreationUpgrade.h
@@ -66,7 +66,7 @@ public:
 	ObjectCreationUpgrade( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype defined by MemoryPoolObject
 
-	void onDelete() override;																///< we have some work to do when this module goes away
+	virtual void onDelete() override;																///< we have some work to do when this module goes away
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ObjectCreationUpgrade.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ObjectCreationUpgrade.h
@@ -66,11 +66,11 @@ public:
 	ObjectCreationUpgrade( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype defined by MemoryPoolObject
 
-	void onDelete();																///< we have some work to do when this module goes away
+	void onDelete() override;																///< we have some work to do when this module goes away
 
 protected:
 
-	virtual void upgradeImplementation(); ///< Here's the actual work of Upgrading
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation() override; ///< Here's the actual work of Upgrading
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ObjectDefectionHelper.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ObjectDefectionHelper.h
@@ -68,10 +68,10 @@ public:
 	}
 	// virtual destructor prototype provided by memory pool object
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	// Disabled conditions to process -- defection helper must ignore all disabled types.
-	virtual DisabledMaskType getDisabledTypesToProcess() const { return DISABLEDMASK_ALL; }
+	virtual DisabledMaskType getDisabledTypesToProcess() const override { return DISABLEDMASK_ALL; }
 
 	// specific to this class.
 	void startDefectionTimer(UnsignedInt numFrames, Bool withDefectorFX = TRUE);

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ObjectHelper.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ObjectHelper.h
@@ -55,7 +55,7 @@ public:
 	}
 
 	// inherited from UpdateModuleInterface
-	virtual UpdateSleepTime update() override = 0;
+	virtual UpdateSleepTime update() = 0;
 
 	// custom to this class.
 	void sleepUntil(UnsignedInt when);

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ObjectHelper.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ObjectHelper.h
@@ -42,9 +42,9 @@ class ObjectHelper : public UpdateModule
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 public:
 
@@ -55,7 +55,7 @@ public:
 	}
 
 	// inherited from UpdateModuleInterface
-	virtual UpdateSleepTime update() = 0;
+	virtual UpdateSleepTime update() override = 0;
 
 	// custom to this class.
 	void sleepUntil(UnsignedInt when);

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ObjectRepulsorHelper.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ObjectRepulsorHelper.h
@@ -52,6 +52,6 @@ public:
 	ObjectRepulsorHelper( Thing *thing, const ModuleData *modData ) : ObjectHelper( thing, modData ) { }
 	// virtual destructor prototype provided by memory pool object
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ObjectSMCHelper.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ObjectSMCHelper.h
@@ -52,6 +52,6 @@ public:
 	ObjectSMCHelper( Thing *thing, const ModuleData *modData ) : ObjectHelper( thing, modData ) { }
 	// virtual destructor prototype provided by memory pool object
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ObjectWeaponStatusHelper.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ObjectWeaponStatusHelper.h
@@ -56,7 +56,7 @@ protected:
 		user update modules, so it redefines this. Please don't redefine this
 		for other modules without very careful deliberation. (srj)
 	*/
-	virtual SleepyUpdatePhase getUpdatePhase() const
+	virtual SleepyUpdatePhase getUpdatePhase() const override
 	{
 		return PHASE_FINAL;
 	}
@@ -71,7 +71,7 @@ public:
 	}
 	// virtual destructor prototype provided by memory pool object
 
-	virtual UpdateSleepTime update()
+	virtual UpdateSleepTime update() override
 	{
 		getObject()->adjustModelConditionForWeaponStatus();
 		// unlike other helpers, this one must run every frame.

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OpenContain.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OpenContain.h
@@ -93,119 +93,119 @@ public:
 	OpenContain( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual ContainModuleInterface* getContain() { return this; }
-	virtual CollideModuleInterface* getCollide() { return this; }
-	virtual DieModuleInterface* getDie() { return this; }
-	virtual DamageModuleInterface* getDamage() { return this; }
+	virtual ContainModuleInterface* getContain() override { return this; }
+	virtual CollideModuleInterface* getCollide() override { return this; }
+	virtual DieModuleInterface* getDie() override { return this; }
+	virtual DamageModuleInterface* getDamage() override { return this; }
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_CONTAIN) | (MODULEINTERFACE_COLLIDE) | (MODULEINTERFACE_DIE) | (MODULEINTERFACE_DAMAGE); }
 
-	virtual void onDie( const DamageInfo *damageInfo );  ///< the die callback
-	virtual void onDelete();	///< Last possible moment cleanup
-	virtual void onCapture( Player *oldOwner, Player *newOwner ){}
+	virtual void onDie( const DamageInfo *damageInfo ) override;  ///< the die callback
+	virtual void onDelete() override;	///< Last possible moment cleanup
+	virtual void onCapture( Player *oldOwner, Player *newOwner ) override {}
 
 	// CollideModuleInterface
-	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal );
-	virtual Bool wouldLikeToCollideWith(const Object* other) const { return false; }
-	virtual Bool isCarBombCrateCollide() const { return false; }
-	virtual Bool isHijackedVehicleCrateCollide() const { return false; }
-	virtual Bool isRailroad() const { return false;}
-	virtual Bool isSalvageCrateCollide() const { return false; }
-	virtual Bool isSabotageBuildingCrateCollide() const { return FALSE; }
+	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal ) override;
+	virtual Bool wouldLikeToCollideWith(const Object* other) const override { return false; }
+	virtual Bool isCarBombCrateCollide() const override { return false; }
+	virtual Bool isHijackedVehicleCrateCollide() const override { return false; }
+	virtual Bool isRailroad() const override { return false;}
+	virtual Bool isSalvageCrateCollide() const override { return false; }
+	virtual Bool isSabotageBuildingCrateCollide() const override { return FALSE; }
 
 	// UpdateModule
-	virtual UpdateSleepTime update();				///< called once per frame
+	virtual UpdateSleepTime update() override;				///< called once per frame
 
 	// ContainModuleInterface
-	virtual OpenContain *asOpenContain() { return this; }  ///< treat as open container
+	virtual OpenContain *asOpenContain() override { return this; }  ///< treat as open container
 
 	// DamageModuleInterface
-	virtual void onDamage( DamageInfo *damageInfo ){};	///< damage callback
-	virtual void onHealing( DamageInfo *damageInfo ){};	///< healing callback
+	virtual void onDamage( DamageInfo *damageInfo ) override {};	///< damage callback
+	virtual void onHealing( DamageInfo *damageInfo ) override {};	///< healing callback
 	virtual void onBodyDamageStateChange( const DamageInfo* damageInfo,
 																				BodyDamageType oldState,
-																				BodyDamageType newState){};  ///< state change callback
+																				BodyDamageType newState) override {};  ///< state change callback
 
 
 	// our object changed position... react as appropriate.
-	virtual void containReactToTransformChange();
+	virtual void containReactToTransformChange() override;
 
-	virtual Bool calcBestGarrisonPosition( Coord3D *sourcePos, const Coord3D *targetPos ) { return FALSE; }
-	virtual Bool attemptBestFirePointPosition( Object *source, Weapon *weapon, Object *victim ) { return FALSE; }
-	virtual Bool attemptBestFirePointPosition( Object *source, Weapon *weapon, const Coord3D *targetPos ) { return FALSE; }
+	virtual Bool calcBestGarrisonPosition( Coord3D *sourcePos, const Coord3D *targetPos ) override { return FALSE; }
+	virtual Bool attemptBestFirePointPosition( Object *source, Weapon *weapon, Object *victim ) override { return FALSE; }
+	virtual Bool attemptBestFirePointPosition( Object *source, Weapon *weapon, const Coord3D *targetPos ) override { return FALSE; }
 
 	///< if my object gets selected, then my visible passengers should, too
 	///< this gets called from
-	virtual void clientVisibleContainedFlashAsSelected() {};
+	virtual void clientVisibleContainedFlashAsSelected() override {};
 
-	virtual const Player* getApparentControllingPlayer(const Player* observingPlayer) const { return nullptr; }
-	virtual void recalcApparentControllingPlayer() { }
+	virtual const Player* getApparentControllingPlayer(const Player* observingPlayer) const override { return nullptr; }
+	virtual void recalcApparentControllingPlayer() override { }
 
-	virtual void onContaining( Object *obj, Bool wasSelected );		///< object now contains 'obj'
-	virtual void onRemoving( Object *obj );			///< object no longer contains 'obj'
-	virtual void onSelling();///< Container is being sold.  Open responds by kicking people out
+	virtual void onContaining( Object *obj, Bool wasSelected ) override;		///< object now contains 'obj'
+	virtual void onRemoving( Object *obj ) override;			///< object no longer contains 'obj'
+	virtual void onSelling() override;///< Container is being sold.  Open responds by kicking people out
 
-	virtual void orderAllPassengersToExit( CommandSourceType commandSource, Bool instantly ); ///< All of the smarts of exiting are in the passenger's AIExit. removeAllFrommContain is a last ditch system call, this is the game Evacuate
-	virtual void orderAllPassengersToIdle( CommandSourceType commandSource ); ///< Just like it sounds
-	virtual void orderAllPassengersToHackInternet( CommandSourceType ); ///< Just like it sounds
-	virtual void markAllPassengersDetected();										///< Cool game stuff got added to the system calls since this layer didn't exist, so this regains that functionality
+	virtual void orderAllPassengersToExit( CommandSourceType commandSource, Bool instantly ) override; ///< All of the smarts of exiting are in the passenger's AIExit. removeAllFrommContain is a last ditch system call, this is the game Evacuate
+	virtual void orderAllPassengersToIdle( CommandSourceType commandSource ) override; ///< Just like it sounds
+	virtual void orderAllPassengersToHackInternet( CommandSourceType ) override; ///< Just like it sounds
+	virtual void markAllPassengersDetected() override;										///< Cool game stuff got added to the system calls since this layer didn't exist, so this regains that functionality
 
 	// default OpenContain has unlimited capacity...!
-	virtual Bool isValidContainerFor(const Object* obj, Bool checkCapacity) const;
-	virtual void addToContain( Object *obj );				///< add 'obj' to contain list
+	virtual Bool isValidContainerFor(const Object* obj, Bool checkCapacity) const override;
+	virtual void addToContain( Object *obj ) override;				///< add 'obj' to contain list
 	virtual void addToContainList( Object *obj );		///< The part of AddToContain that inheritors can override (Can't do whole thing because of all the private stuff involved)
-	virtual void removeFromContain( Object *obj, Bool exposeStealthUnits = FALSE );	///< remove 'obj' from contain list
-	virtual void removeAllContained( Bool exposeStealthUnits = FALSE );				///< remove all objects on contain list
-	virtual void killAllContained();				///< kill all objects on contain list
-  virtual void harmAndForceExitAllContained( DamageInfo *info ); // apply canned damage against those contains
-	virtual Bool isEnclosingContainerFor( const Object *obj ) const;	///< Does this type of Contain Visibly enclose its contents?
-	virtual Bool isPassengerAllowedToFire( ObjectID id = INVALID_ID ) const;	///< Hey, can I shoot out of this container?
+	virtual void removeFromContain( Object *obj, Bool exposeStealthUnits = FALSE ) override;	///< remove 'obj' from contain list
+	virtual void removeAllContained( Bool exposeStealthUnits = FALSE ) override;				///< remove all objects on contain list
+	virtual void killAllContained() override;				///< kill all objects on contain list
+  virtual void harmAndForceExitAllContained( DamageInfo *info ) override; // apply canned damage against those contains
+	virtual Bool isEnclosingContainerFor( const Object *obj ) const override;	///< Does this type of Contain Visibly enclose its contents?
+	virtual Bool isPassengerAllowedToFire( ObjectID id = INVALID_ID ) const override;	///< Hey, can I shoot out of this container?
 
-  virtual void setPassengerAllowedToFire( Bool permission = TRUE ) { m_passengerAllowedToFire = permission; }	///< Hey, can I shoot out of this container?
+  virtual void setPassengerAllowedToFire( Bool permission = TRUE ) override { m_passengerAllowedToFire = permission; }	///< Hey, can I shoot out of this container?
 
-  virtual void setOverrideDestination( const Coord3D * ){} ///< Instead of falling peacefully towards a clear spot, I will now aim here
-	virtual Bool isDisplayedOnControlBar() const {return FALSE;}///< Does this container display its contents on the ControlBar?
-	virtual Int getExtraSlotsInUse() { return 0; }
-	virtual Bool isKickOutOnCapture(){ return TRUE; }///< By default, yes, all contain modules kick passengers out on capture
+  virtual void setOverrideDestination( const Coord3D * ) override {} ///< Instead of falling peacefully towards a clear spot, I will now aim here
+	virtual Bool isDisplayedOnControlBar() const override {return FALSE;}///< Does this container display its contents on the ControlBar?
+	virtual Int getExtraSlotsInUse() override { return 0; }
+	virtual Bool isKickOutOnCapture() override { return TRUE; }///< By default, yes, all contain modules kick passengers out on capture
 
 	// contain list access
-	virtual void iterateContained( ContainIterateFunc func, void *userData, Bool reverse );
-	virtual UnsignedInt getContainCount() const { return m_containListSize; }
-	virtual const ContainedItemsList* getContainedItemsList() const { return &m_containList; }
-	virtual const Object *friend_getRider() const{return nullptr;} ///< Damn.  The draw order dependency bug for riders means that our draw module needs to cheat to get around it.
-	virtual Real getContainedItemsMass() const;
-	virtual UnsignedInt getStealthUnitsContained() const { return m_stealthUnitsContained; }
-	virtual UnsignedInt getHeroUnitsContained() const { return m_heroUnitsContained; }
+	virtual void iterateContained( ContainIterateFunc func, void *userData, Bool reverse ) override;
+	virtual UnsignedInt getContainCount() const override { return m_containListSize; }
+	virtual const ContainedItemsList* getContainedItemsList() const override { return &m_containList; }
+	virtual const Object *friend_getRider() const override {return nullptr;} ///< Damn.  The draw order dependency bug for riders means that our draw module needs to cheat to get around it.
+	virtual Real getContainedItemsMass() const override;
+	virtual UnsignedInt getStealthUnitsContained() const override { return m_stealthUnitsContained; }
+	virtual UnsignedInt getHeroUnitsContained() const override { return m_heroUnitsContained; }
 
-	virtual PlayerMaskType getPlayerWhoEntered() const { return m_playerEnteredMask; }
+	virtual PlayerMaskType getPlayerWhoEntered() const override { return m_playerEnteredMask; }
 
-	virtual Int getContainMax() const;
+	virtual Int getContainMax() const override;
 
 	// ExitInterface
-	virtual Bool isExitBusy() const {return FALSE;}	///< Contain style exiters are getting the ability to space out exits, so ask this before reserveDoor as a kind of no-commitment check.
-	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject ) { return DOOR_1; }
-	virtual void exitObjectViaDoor( Object *newObj, ExitDoorType exitDoor );
-	virtual void exitObjectInAHurry( Object *newObj );
+	virtual Bool isExitBusy() const override {return FALSE;}	///< Contain style exiters are getting the ability to space out exits, so ask this before reserveDoor as a kind of no-commitment check.
+	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject ) override { return DOOR_1; }
+	virtual void exitObjectViaDoor( Object *newObj, ExitDoorType exitDoor ) override;
+	virtual void exitObjectInAHurry( Object *newObj ) override;
 
 
-	virtual void unreserveDoorForExit( ExitDoorType exitDoor ) { /*nothing*/ }
-	virtual void exitObjectByBudding( Object *newObj, Object *budHost ) { return; };
+	virtual void unreserveDoorForExit( ExitDoorType exitDoor ) override { /*nothing*/ }
+	virtual void exitObjectByBudding( Object *newObj, Object *budHost ) override { return; };
 
-	virtual void setRallyPoint( const Coord3D *pos );				///< define a "rally point" for units to move towards
-	virtual const Coord3D *getRallyPoint() const;			///< define a "rally point" for units to move towards
-	virtual Bool getExitPosition(Coord3D& exitPosition ) const { return FALSE; };					///< access to the "Door" position of the production object
-	virtual Bool getNaturalRallyPoint( Coord3D& rallyPoint, Bool offset = TRUE ) const;			///< get the natural "rally point" for units to move towards
+	virtual void setRallyPoint( const Coord3D *pos ) override;				///< define a "rally point" for units to move towards
+	virtual const Coord3D *getRallyPoint() const override;			///< define a "rally point" for units to move towards
+	virtual Bool getExitPosition(Coord3D& exitPosition ) const override { return FALSE; };					///< access to the "Door" position of the production object
+	virtual Bool getNaturalRallyPoint( Coord3D& rallyPoint, Bool offset = TRUE ) const override;			///< get the natural "rally point" for units to move towards
 
-	virtual ExitInterface* getContainExitInterface() { return this; }
+	virtual ExitInterface* getContainExitInterface() override { return this; }
 
-	virtual Bool isGarrisonable() const { return false; }		///< can this unit be Garrisoned? (ick)
-	virtual Bool isBustable() const { return false; }		///< can this container get busted by a bunkerbuster
-	virtual Bool isHealContain() const { return false; } ///< true when container only contains units while healing (not a transport!)
-	virtual Bool isTunnelContain() const { return FALSE; }
-	virtual Bool isRiderChangeContain() const { return FALSE; }
-	virtual Bool isSpecialZeroSlotContainer() const { return false; }
-	virtual Bool isImmuneToClearBuildingAttacks() const { return true; }
-  virtual Bool isSpecialOverlordStyleContainer() const { return false; }
-  virtual Bool isAnyRiderAttacking() const;
+	virtual Bool isGarrisonable() const override { return false; }		///< can this unit be Garrisoned? (ick)
+	virtual Bool isBustable() const override { return false; }		///< can this container get busted by a bunkerbuster
+	virtual Bool isHealContain() const override { return false; } ///< true when container only contains units while healing (not a transport!)
+	virtual Bool isTunnelContain() const override { return FALSE; }
+	virtual Bool isRiderChangeContain() const override { return FALSE; }
+	virtual Bool isSpecialZeroSlotContainer() const override { return false; }
+	virtual Bool isImmuneToClearBuildingAttacks() const override { return true; }
+  virtual Bool isSpecialOverlordStyleContainer() const override { return false; }
+  virtual Bool isAnyRiderAttacking() const override;
 
 	/**
 		this is used for containers that must do something to allow people to enter or exit...
@@ -213,22 +213,22 @@ public:
 		when something is in the enter state, and wants=ENTS_NOTHING when the unit has
 		either entered, or given up...
 	*/
-	virtual void onObjectWantsToEnterOrExit(Object* obj, ObjectEnterExitType wants);
+	virtual void onObjectWantsToEnterOrExit(Object* obj, ObjectEnterExitType wants) override;
 
 	// returns true iff there are objects currently waiting to enter.
-	virtual Bool hasObjectsWantingToEnterOrExit() const;
+	virtual Bool hasObjectsWantingToEnterOrExit() const override;
 
-	virtual void processDamageToContained(Real percentDamage); ///< Do our % damage to units now.
+	virtual void processDamageToContained(Real percentDamage) override; ///< Do our % damage to units now.
 
-	virtual Bool isWeaponBonusPassedToPassengers() const;
-	virtual WeaponBonusConditionFlags getWeaponBonusPassedToPassengers() const;
+	virtual Bool isWeaponBonusPassedToPassengers() const override;
+	virtual WeaponBonusConditionFlags getWeaponBonusPassedToPassengers() const override;
 
-	virtual void enableLoadSounds( Bool enable ) { m_loadSoundsEnabled = enable; }
+	virtual void enableLoadSounds( Bool enable ) override { m_loadSoundsEnabled = enable; }
 
   Real getDamagePercentageToUnits();
-  virtual Object* getClosestRider ( const Coord3D *pos );
+  virtual Object* getClosestRider ( const Coord3D *pos ) override;
 
-  virtual void setEvacDisposition( EvacDisposition disp ) {};
+  virtual void setEvacDisposition( EvacDisposition disp ) override {};
 protected:
 
 	virtual void monitorConditionChanges();				///< check to see if we need to update our occupant positions from a model change or anything else

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OverchargeBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OverchargeBehavior.h
@@ -81,30 +81,30 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	// interface housekeeping
-	virtual OverchargeBehaviorInterface* getOverchargeBehaviorInterface() { return this; }
+	virtual OverchargeBehaviorInterface* getOverchargeBehaviorInterface() override { return this; }
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_DAMAGE); }
 
 	// BehaviorModule
-	virtual DamageModuleInterface* getDamage() { return this; }
+	virtual DamageModuleInterface* getDamage() override { return this; }
 
 	// UpdateModuleInterface
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	// DamageModuleInterface
-	virtual void onDamage( DamageInfo *damageInfo );
-	virtual void onHealing( DamageInfo *damageInfo ) { }
+	virtual void onDamage( DamageInfo *damageInfo ) override;
+	virtual void onHealing( DamageInfo *damageInfo ) override { }
 	virtual void onBodyDamageStateChange( const DamageInfo *damageInfo,
 																				BodyDamageType oldState,
-																				BodyDamageType newState ) { }
+																				BodyDamageType newState ) override { }
 
 
 	// specific methods
-	virtual void toggle();						///< toggle overcharge on/off
-	virtual void enable( Bool enable );			///< turn overcharge on/off
-	virtual Bool isOverchargeActive() { return m_overchargeActive; }
+	virtual void toggle() override;						///< toggle overcharge on/off
+	virtual void enable( Bool enable ) override;			///< turn overcharge on/off
+	virtual Bool isOverchargeActive() override { return m_overchargeActive; }
 
-	void onDelete();																///< we have some work to do when this module goes away
-	void onCapture( Player *oldOwner, Player *newOwner );	///< object containing upgrade has changed teams
+	void onDelete() override;																///< we have some work to do when this module goes away
+	void onCapture( Player *oldOwner, Player *newOwner ) override;	///< object containing upgrade has changed teams
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OverchargeBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OverchargeBehavior.h
@@ -103,8 +103,8 @@ public:
 	virtual void enable( Bool enable ) override;			///< turn overcharge on/off
 	virtual Bool isOverchargeActive() override { return m_overchargeActive; }
 
-	void onDelete() override;																///< we have some work to do when this module goes away
-	void onCapture( Player *oldOwner, Player *newOwner ) override;	///< object containing upgrade has changed teams
+	virtual void onDelete() override;																///< we have some work to do when this module goes away
+	virtual void onCapture( Player *oldOwner, Player *newOwner ) override;	///< object containing upgrade has changed teams
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OverlordContain.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OverlordContain.h
@@ -61,56 +61,56 @@ class OverlordContain : public TransportContain
 
 	virtual void onBodyDamageStateChange( const DamageInfo* damageInfo,
 																				BodyDamageType oldState,
-																				BodyDamageType newState);  ///< state change callback
+																				BodyDamageType newState) override;  ///< state change callback
 public:
 
 	OverlordContain( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual OpenContain *asOpenContain() { return this; }  ///< treat as open container
-	virtual Bool isGarrisonable() const;	///< can this unit be Garrisoned? (ick)
+	virtual OpenContain *asOpenContain() override { return this; }  ///< treat as open container
+	virtual Bool isGarrisonable() const override;	///< can this unit be Garrisoned? (ick)
   virtual Bool isBustable() { return false;};	///< can this container get busted by bunkerbuster? (ick)
-	virtual Bool isHealContain() const { return false; } ///< true when container only contains units while healing (not a transport!)
-	virtual Bool isTunnelContain() const { return FALSE; }
-	virtual Bool isImmuneToClearBuildingAttacks() const { return true; }
-  virtual Bool isSpecialOverlordStyleContainer() const {return TRUE;}
-	virtual Bool isPassengerAllowedToFire( ObjectID id = INVALID_ID ) const;	///< Hey, can I shoot out of this container?
+	virtual Bool isHealContain() const override { return false; } ///< true when container only contains units while healing (not a transport!)
+	virtual Bool isTunnelContain() const override { return FALSE; }
+	virtual Bool isImmuneToClearBuildingAttacks() const override { return true; }
+  virtual Bool isSpecialOverlordStyleContainer() const override {return TRUE;}
+	virtual Bool isPassengerAllowedToFire( ObjectID id = INVALID_ID ) const override;	///< Hey, can I shoot out of this container?
 
 
-	virtual void onDie( const DamageInfo *damageInfo );  ///< the die callback
-	virtual void onDelete();	///< Last possible moment cleanup
-	virtual void onCapture( Player *oldOwner, Player *newOwner ); // Our main guy goes with us, but our redirected contain needs to do his thing too
-	virtual void onObjectCreated();
+	virtual void onDie( const DamageInfo *damageInfo ) override;  ///< the die callback
+	virtual void onDelete() override;	///< Last possible moment cleanup
+	virtual void onCapture( Player *oldOwner, Player *newOwner ) override; // Our main guy goes with us, but our redirected contain needs to do his thing too
+	virtual void onObjectCreated() override;
 
 	// Contain stuff we need to override to redirect on a condition
-	virtual void onContaining( Object *obj, Bool wasSelected );		///< object now contains 'obj'
-	virtual void onRemoving( Object *obj );			///< object no longer contains 'obj'
+	virtual void onContaining( Object *obj, Bool wasSelected ) override;		///< object now contains 'obj'
+	virtual void onRemoving( Object *obj ) override;			///< object no longer contains 'obj'
 
-	virtual Bool isValidContainerFor(const Object* obj, Bool checkCapacity) const;
-	virtual void addToContain( Object *obj );				///< add 'obj' to contain list
+	virtual Bool isValidContainerFor(const Object* obj, Bool checkCapacity) const override;
+	virtual void addToContain( Object *obj ) override;				///< add 'obj' to contain list
 	virtual void addToContainList( Object *obj );		///< The part of AddToContain that inheritors can override (Can't do whole thing because of all the private stuff involved)
-	virtual void removeFromContain( Object *obj, Bool exposeStealthUnits = FALSE );	///< remove 'obj' from contain list
-	virtual void removeAllContained( Bool exposeStealthUnits = FALSE );				///< remove all objects on contain list
-	virtual Bool isEnclosingContainerFor( const Object *obj ) const;	///< Does this type of Contain Visibly enclose its contents?
-	virtual Bool isDisplayedOnControlBar() const ;///< Does this container display its contents on the ControlBar?
-	virtual Bool isKickOutOnCapture();// The bunker may want to, but we certainly don't
-	virtual void killAllContained();				///< kill all objects inside.  For us, this does not mean our rider
+	virtual void removeFromContain( Object *obj, Bool exposeStealthUnits = FALSE ) override;	///< remove 'obj' from contain list
+	virtual void removeAllContained( Bool exposeStealthUnits = FALSE ) override;				///< remove all objects on contain list
+	virtual Bool isEnclosingContainerFor( const Object *obj ) const override;	///< Does this type of Contain Visibly enclose its contents?
+	virtual Bool isDisplayedOnControlBar() const override;///< Does this container display its contents on the ControlBar?
+	virtual Bool isKickOutOnCapture() override;// The bunker may want to, but we certainly don't
+	virtual void killAllContained() override;				///< kill all objects inside.  For us, this does not mean our rider
 
 	// contain list access
-	virtual void iterateContained( ContainIterateFunc func, void *userData, Bool reverse );
-	virtual UnsignedInt getContainCount() const;
-	virtual Int getContainMax() const;
-	virtual const ContainedItemsList* getContainedItemsList() const;
+	virtual void iterateContained( ContainIterateFunc func, void *userData, Bool reverse ) override;
+	virtual UnsignedInt getContainCount() const override;
+	virtual Int getContainMax() const override;
+	virtual const ContainedItemsList* getContainedItemsList() const override;
 
 	// Friend for our Draw module only.
-	virtual const Object *friend_getRider() const; ///< Damn.  The draw order dependency bug for riders means that our draw module needs to cheat to get around it.
+	virtual const Object *friend_getRider() const override; ///< Damn.  The draw order dependency bug for riders means that our draw module needs to cheat to get around it.
 
 	///< if my object gets selected, then my visible passengers should, too
 	///< this gets called from
-	virtual void clientVisibleContainedFlashAsSelected();
+	virtual void clientVisibleContainedFlashAsSelected() override;
 
-	virtual Bool getContainerPipsToShow(Int& numTotal, Int& numFull);
-	virtual void createPayload();
+	virtual Bool getContainerPipsToShow(Int& numTotal, Int& numFull) override;
+	virtual void createPayload() override;
 
 private:
 	/**< An empty overlord is a container, but a full one redirects calls to its passengers.  If this returns null,

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ParachuteContain.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ParachuteContain.h
@@ -60,28 +60,28 @@ public:
 	ParachuteContain( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onDrawableBoundToObject();
+	virtual void onDrawableBoundToObject() override;
 
-	virtual Bool isValidContainerFor( const Object* obj, bool checkCapacity) const;
-	virtual Bool isEnclosingContainerFor( const Object *obj ) const { return FALSE; }	///< Does this type of Contain Visibly enclose its contents?
-	virtual Bool isSpecialZeroSlotContainer() const { return true; }
+	virtual Bool isValidContainerFor( const Object* obj, bool checkCapacity) const override;
+	virtual Bool isEnclosingContainerFor( const Object *obj ) const override { return FALSE; }	///< Does this type of Contain Visibly enclose its contents?
+	virtual Bool isSpecialZeroSlotContainer() const override { return true; }
 
-	virtual void onContaining( Object *obj, Bool wasSelected );		///< object now contains 'obj'
-	virtual void onRemoving( Object *obj );			///< object no longer contains 'obj'
+	virtual void onContaining( Object *obj, Bool wasSelected ) override;		///< object now contains 'obj'
+	virtual void onRemoving( Object *obj ) override;			///< object no longer contains 'obj'
 
-	virtual UpdateSleepTime update();							///< called once per frame
+	virtual UpdateSleepTime update() override;							///< called once per frame
 
-	virtual void containReactToTransformChange();
+	virtual void containReactToTransformChange() override;
 
-	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal );
-	virtual void onDie( const DamageInfo * damageInfo );
+	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal ) override;
+	virtual void onDie( const DamageInfo * damageInfo ) override;
 
-	virtual void setOverrideDestination( const Coord3D *dest ); ///< Instead of falling peacefully towards a clear spot, I will now aim here
+	virtual void setOverrideDestination( const Coord3D *dest ) override; ///< Instead of falling peacefully towards a clear spot, I will now aim here
 
 protected:
 
 	virtual Bool isFullyEnclosingContainer() const { return false; }
-	virtual void positionContainedObjectsRelativeToContainer();
+	virtual void positionContainedObjectsRelativeToContainer() override;
 
 private:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ParkingPlaceBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ParkingPlaceBehavior.h
@@ -107,48 +107,48 @@ public:
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_DIE); }
 
 	// BehaviorModule
-	virtual DieModuleInterface *getDie() { return this; }
-	virtual ParkingPlaceBehaviorInterface* getParkingPlaceBehaviorInterface() { return this; }
-	virtual ExitInterface* getUpdateExitInterface() { return this; }
+	virtual DieModuleInterface *getDie() override { return this; }
+	virtual ParkingPlaceBehaviorInterface* getParkingPlaceBehaviorInterface() override { return this; }
+	virtual ExitInterface* getUpdateExitInterface() override { return this; }
 
 	// ExitInterface
-	virtual Bool isExitBusy() const {return FALSE;}	///< Contain style exiters are getting the ability to space out exits, so ask this before reserveDoor as a kind of no-commitment check.
-	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject );
-	virtual void exitObjectViaDoor( Object *newObj, ExitDoorType exitDoor );
-	virtual void unreserveDoorForExit( ExitDoorType exitDoor );
-	virtual void exitObjectByBudding( Object *newObj, Object *budHost ) { return; }
+	virtual Bool isExitBusy() const override {return FALSE;}	///< Contain style exiters are getting the ability to space out exits, so ask this before reserveDoor as a kind of no-commitment check.
+	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject ) override;
+	virtual void exitObjectViaDoor( Object *newObj, ExitDoorType exitDoor ) override;
+	virtual void unreserveDoorForExit( ExitDoorType exitDoor ) override;
+	virtual void exitObjectByBudding( Object *newObj, Object *budHost ) override { return; }
 
-	virtual Bool getExitPosition( Coord3D& rallyPoint ) const;
-	virtual Bool getNaturalRallyPoint( Coord3D& rallyPoint, Bool offset = TRUE ) const;
-	virtual void setRallyPoint( const Coord3D *pos );			///< define a "rally point" for units to move towards
-	virtual const Coord3D *getRallyPoint() const;			///< define a "rally point" for units to move towards
+	virtual Bool getExitPosition( Coord3D& rallyPoint ) const override;
+	virtual Bool getNaturalRallyPoint( Coord3D& rallyPoint, Bool offset = TRUE ) const override;
+	virtual void setRallyPoint( const Coord3D *pos ) override;			///< define a "rally point" for units to move towards
+	virtual const Coord3D *getRallyPoint() const override;			///< define a "rally point" for units to move towards
 
 	// UpdateModule
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	// DieModule
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 	// ParkingPlaceBehaviorInterface
-	virtual Bool shouldReserveDoorWhenQueued(const ThingTemplate* thing) const;
-	virtual Bool hasAvailableSpaceFor(const ThingTemplate* thing) const;
-	virtual Bool hasReservedSpace(ObjectID id) const;
-	virtual Int  getSpaceIndex( ObjectID id ) const;
-	virtual Bool reserveSpace(ObjectID id, Real parkingOffset, PPInfo* info);
-	virtual void releaseSpace(ObjectID id);
-	virtual Bool reserveRunway(ObjectID id, Bool forLanding);
-	virtual void releaseRunway(ObjectID id);
-	virtual void calcPPInfo( ObjectID id, PPInfo *info );
-	virtual Int getRunwayIndex(ObjectID id);
-	virtual Int getRunwayCount() const { return m_runways.size(); }
-	virtual ObjectID getRunwayReservation( Int r, RunwayReservationType type );
-	virtual void transferRunwayReservationToNextInLineForTakeoff(ObjectID id);
-	virtual Real getApproachHeight() const { return getParkingPlaceBehaviorModuleData()->m_approachHeight; }
-	virtual Real getLandingDeckHeightOffset() const { return getParkingPlaceBehaviorModuleData()->m_landingDeckHeightOffset; }
-	virtual void setHealee(Object* healee, Bool add);
-	virtual void killAllParkedUnits();
-	virtual void defectAllParkedUnits(Team* newTeam, UnsignedInt detectionTime);
-	virtual Bool calcBestParkingAssignment( ObjectID id, Coord3D *pos, Int *oldIndex = nullptr, Int *newIndex = nullptr ) { return FALSE; }
+	virtual Bool shouldReserveDoorWhenQueued(const ThingTemplate* thing) const override;
+	virtual Bool hasAvailableSpaceFor(const ThingTemplate* thing) const override;
+	virtual Bool hasReservedSpace(ObjectID id) const override;
+	virtual Int  getSpaceIndex( ObjectID id ) const override;
+	virtual Bool reserveSpace(ObjectID id, Real parkingOffset, PPInfo* info) override;
+	virtual void releaseSpace(ObjectID id) override;
+	virtual Bool reserveRunway(ObjectID id, Bool forLanding) override;
+	virtual void releaseRunway(ObjectID id) override;
+	virtual void calcPPInfo( ObjectID id, PPInfo *info ) override;
+	virtual Int getRunwayIndex(ObjectID id) override;
+	virtual Int getRunwayCount() const override { return m_runways.size(); }
+	virtual ObjectID getRunwayReservation( Int r, RunwayReservationType type ) override;
+	virtual void transferRunwayReservationToNextInLineForTakeoff(ObjectID id) override;
+	virtual Real getApproachHeight() const override { return getParkingPlaceBehaviorModuleData()->m_approachHeight; }
+	virtual Real getLandingDeckHeightOffset() const override { return getParkingPlaceBehaviorModuleData()->m_landingDeckHeightOffset; }
+	virtual void setHealee(Object* healee, Bool add) override;
+	virtual void killAllParkedUnits() override;
+	virtual void defectAllParkedUnits(Team* newTeam, UnsignedInt detectionTime) override;
+	virtual Bool calcBestParkingAssignment( ObjectID id, Coord3D *pos, Int *oldIndex = nullptr, Int *newIndex = nullptr ) override { return FALSE; }
 	virtual const std::vector<Coord3D>* getTaxiLocations( ObjectID id ) const { return nullptr; }
 	virtual const std::vector<Coord3D>* getCreationLocations( ObjectID id ) const { return nullptr; }
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ParticleUplinkCannonUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ParticleUplinkCannonUpdate.h
@@ -155,17 +155,17 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	// SpecialPowerUpdateInterface
-	virtual Bool initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions );
-	virtual Bool isSpecialAbility() const { return false; }
-	virtual Bool isSpecialPower() const { return true; }
-	virtual Bool isActive() const {return m_status != STATUS_IDLE;}
-	virtual SpecialPowerUpdateInterface* getSpecialPowerUpdateInterface() { return this; }
-	virtual CommandOption getCommandOption() const { return (CommandOption)0; }
-	virtual Bool isPowerCurrentlyInUse( const CommandButton *command = nullptr ) const;
-	virtual ScienceType getExtraRequiredScience() const { return SCIENCE_INVALID; } //Does this object have more than one special power module with the same spTemplate?
+	virtual Bool initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions ) override;
+	virtual Bool isSpecialAbility() const override { return false; }
+	virtual Bool isSpecialPower() const override { return true; }
+	virtual Bool isActive() const override {return m_status != STATUS_IDLE;}
+	virtual SpecialPowerUpdateInterface* getSpecialPowerUpdateInterface() override { return this; }
+	virtual CommandOption getCommandOption() const override { return (CommandOption)0; }
+	virtual Bool isPowerCurrentlyInUse( const CommandButton *command = nullptr ) const override;
+	virtual ScienceType getExtraRequiredScience() const override { return SCIENCE_INVALID; } //Does this object have more than one special power module with the same spTemplate?
 
-	virtual void onObjectCreated();
-	virtual UpdateSleepTime update();
+	virtual void onObjectCreated() override;
+	virtual UpdateSleepTime update() override;
 
 	void removeAllEffects();
 
@@ -180,12 +180,12 @@ public:
 	Bool calculateDefaultInformation();
 	Bool calculateUpBonePositions();
 
-	virtual Bool doesSpecialPowerHaveOverridableDestinationActive() const; //Is it active now?
-	virtual Bool doesSpecialPowerHaveOverridableDestination() const { return true; }	//Does it have it, even if it's not active?
-	virtual void setSpecialPowerOverridableDestination( const Coord3D *loc );
+	virtual Bool doesSpecialPowerHaveOverridableDestinationActive() const override; //Is it active now?
+	virtual Bool doesSpecialPowerHaveOverridableDestination() const override { return true; }	//Does it have it, even if it's not active?
+	virtual void setSpecialPowerOverridableDestination( const Coord3D *loc ) override;
 
 	// Disabled conditions to process (termination conditions!)
-	virtual DisabledMaskType getDisabledTypesToProcess() const { return MAKE_DISABLED_MASK4( DISABLED_SUBDUED, DISABLED_UNDERPOWERED, DISABLED_EMP, DISABLED_HACKED ); }
+	virtual DisabledMaskType getDisabledTypesToProcess() const override { return MAKE_DISABLED_MASK4( DISABLED_SUBDUED, DISABLED_UNDERPOWERED, DISABLED_EMP, DISABLED_HACKED ); }
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/PassengersFireUpgrade.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/PassengersFireUpgrade.h
@@ -48,8 +48,8 @@ public:
 	// virtual destructor prototype defined by MemoryPoolObject
 
 protected:
-	virtual void upgradeImplementation( ); ///< Here's the actual work of Upgrading
-  virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation( ) override; ///< Here's the actual work of Upgrading
+  virtual Bool isSubObjectsUpgrade() override { return false; }
 
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/PhysicsUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/PhysicsUpdate.h
@@ -88,24 +88,24 @@ public:
 
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_COLLIDE); }
 
-	virtual void onObjectCreated();
+	virtual void onObjectCreated() override;
 
 	// BehaviorModule
-	virtual CollideModuleInterface* getCollide() { return this; }
+	virtual CollideModuleInterface* getCollide() override { return this; }
 
 	// CollideModuleInterface
-	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal );
-	virtual Bool wouldLikeToCollideWith(const Object* other) const { return false; }
-	virtual Bool isCarBombCrateCollide() const { return false; }
-	virtual Bool isHijackedVehicleCrateCollide() const { return false; }
-	virtual Bool isRailroad() const { return false;}
-	virtual Bool isSalvageCrateCollide() const { return false; }
-	virtual Bool isSabotageBuildingCrateCollide() const { return FALSE; }
+	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal ) override;
+	virtual Bool wouldLikeToCollideWith(const Object* other) const override { return false; }
+	virtual Bool isCarBombCrateCollide() const override { return false; }
+	virtual Bool isHijackedVehicleCrateCollide() const override { return false; }
+	virtual Bool isRailroad() const override { return false;}
+	virtual Bool isSalvageCrateCollide() const override { return false; }
+	virtual Bool isSabotageBuildingCrateCollide() const override { return FALSE; }
 
 	// UpdateModuleInterface
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 	// Disabled conditions to process -- all
-	virtual DisabledMaskType getDisabledTypesToProcess() const { return DISABLEDMASK_ALL; }
+	virtual DisabledMaskType getDisabledTypesToProcess() const override { return DISABLEDMASK_ALL; }
 
 	void applyForce( const Coord3D *force );		///< apply a force at the object's CG
 	void applyShock( const Coord3D *force );					///< apply a shockwave force against the object's CG
@@ -217,7 +217,7 @@ protected:
 		interesting oscillations can occur in some situations, with friction being applied
 		either before or after the locomotive force, making for huge stuttery messes. (srj)
 	*/
-	virtual SleepyUpdatePhase getUpdatePhase() const { return PHASE_PHYSICS; }
+	virtual SleepyUpdatePhase getUpdatePhase() const override { return PHASE_PHYSICS; }
 
 	Real getAerodynamicFriction() const;
 	Real getForwardFriction() const;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/PilotFindVehicleUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/PilotFindVehicleUpdate.h
@@ -68,8 +68,8 @@ public:
 	PilotFindVehicleUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onObjectCreated();
-	virtual UpdateSleepTime update();
+	virtual void onObjectCreated() override;
+	virtual UpdateSleepTime update() override;
 
 	Object* scanClosestTarget();
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/PointDefenseLaserUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/PointDefenseLaserUpdate.h
@@ -71,8 +71,8 @@ public:
 	PointDefenseLaserUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onObjectCreated();
-	virtual UpdateSleepTime update();
+	virtual void onObjectCreated() override;
+	virtual UpdateSleepTime update() override;
 
 	Object* scanClosestTarget();
 	void fireWhenReady();

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/PoisonedBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/PoisonedBehavior.h
@@ -67,17 +67,17 @@ public:
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_DAMAGE); }
 
 	// BehaviorModule
-	virtual DamageModuleInterface* getDamage() { return this; }
+	virtual DamageModuleInterface* getDamage() override { return this; }
 
 	// DamageModuleInterface
-	virtual void onDamage( DamageInfo *damageInfo );
-	virtual void onHealing( DamageInfo *damageInfo );
-	virtual void onBodyDamageStateChange(const DamageInfo* damageInfo, BodyDamageType oldState, BodyDamageType newState) { }
+	virtual void onDamage( DamageInfo *damageInfo ) override;
+	virtual void onHealing( DamageInfo *damageInfo ) override;
+	virtual void onBodyDamageStateChange(const DamageInfo* damageInfo, BodyDamageType oldState, BodyDamageType newState) override { }
 
 	// UpdateInterface
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 	// Disabled conditions to process (we should still poison disabled things)
-	virtual DisabledMaskType getDisabledTypesToProcess() const { return DISABLEDMASK_ALL; }
+	virtual DisabledMaskType getDisabledTypesToProcess() const override { return DISABLEDMASK_ALL; }
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/PowerPlantUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/PowerPlantUpdate.h
@@ -86,10 +86,10 @@ public:
 	// virtual destructor prototype defined by MemoryPoolObject
 
 	// interface housekeeping
-	virtual PowerPlantUpdateInterface* getPowerPlantUpdateInterface() { return this; }
+	virtual PowerPlantUpdateInterface* getPowerPlantUpdateInterface() override { return this; }
 
-	void extendRods( Bool extend );									 ///< extend the rods from this object
-	virtual UpdateSleepTime update(); ///< Here's the actual work of Upgrading
+	void extendRods( Bool extend ) override;									 ///< extend the rods from this object
+	virtual UpdateSleepTime update() override; ///< Here's the actual work of Upgrading
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/PowerPlantUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/PowerPlantUpdate.h
@@ -88,7 +88,7 @@ public:
 	// interface housekeeping
 	virtual PowerPlantUpdateInterface* getPowerPlantUpdateInterface() override { return this; }
 
-	void extendRods( Bool extend ) override;									 ///< extend the rods from this object
+	virtual void extendRods( Bool extend ) override;									 ///< extend the rods from this object
 	virtual UpdateSleepTime update() override; ///< Here's the actual work of Upgrading
 
 protected:

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/PowerPlantUpgrade.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/PowerPlantUpgrade.h
@@ -50,12 +50,12 @@ public:
 	PowerPlantUpgrade( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype defined by MemoryPoolObject
 
-	virtual void onDelete();																///< we have some work to do when this module goes away
-	virtual void onCapture( Player *oldOwner, Player *newOwner );	///< object containing upgrade has changed teams
+	virtual void onDelete() override;																///< we have some work to do when this module goes away
+	virtual void onCapture( Player *oldOwner, Player *newOwner ) override;	///< object containing upgrade has changed teams
 
 protected:
 
-	virtual void upgradeImplementation(); ///< Here's the actual work of Upgrading
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation() override; ///< Here's the actual work of Upgrading
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/PreorderCreate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/PreorderCreate.h
@@ -49,8 +49,8 @@ public:
 	PreorderCreate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onCreate();
-	virtual void onBuildComplete();
+	virtual void onCreate() override;
+	virtual void onBuildComplete() override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ProductionUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ProductionUpdate.h
@@ -194,48 +194,48 @@ public:
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_DIE); }
 
 	// Disabled conditions to process (AI will still process held status)
-	virtual DisabledMaskType getDisabledTypesToProcess() const { return getProductionUpdateModuleData()->m_disabledTypesToProcess; }
+	virtual DisabledMaskType getDisabledTypesToProcess() const override { return getProductionUpdateModuleData()->m_disabledTypesToProcess; }
 
-	virtual ProductionUpdateInterface* getProductionUpdateInterface() { return this; }
-	virtual DieModuleInterface* getDie() { return this; }
+	virtual ProductionUpdateInterface* getProductionUpdateInterface() override { return this; }
+	virtual DieModuleInterface* getDie() override { return this; }
 	static ProductionUpdateInterface *getProductionUpdateInterfaceFromObject( Object *obj );
 
-	virtual CanMakeType canQueueCreateUnit( const ThingTemplate *unitType ) const;
-	virtual CanMakeType canQueueUpgrade( const UpgradeTemplate *upgrade ) const;
+	virtual CanMakeType canQueueCreateUnit( const ThingTemplate *unitType ) const override;
+	virtual CanMakeType canQueueUpgrade( const UpgradeTemplate *upgrade ) const override;
 
 	/** this method is used to request a unique ID to assign to the production of a single
 	unit.  It is unique to all units that can be created from this source object, but is
 	not unique among multiple source objects */
-	virtual ProductionID requestUniqueUnitID() { ProductionID tmp = m_uniqueID; m_uniqueID = (ProductionID)(m_uniqueID+1); return tmp; }
+	virtual ProductionID requestUniqueUnitID() override { ProductionID tmp = m_uniqueID; m_uniqueID = (ProductionID)(m_uniqueID+1); return tmp; }
 
-	virtual Bool queueUpgrade( const UpgradeTemplate *upgrade );				///< queue upgrade "research"
-	virtual void cancelUpgrade( const UpgradeTemplate *upgrade );				///< cancel upgrade "research"
-	virtual Bool isUpgradeInQueue( const UpgradeTemplate *upgrade ) const;		///< is the upgrade in our production queue already
-	virtual UnsignedInt countUnitTypeInQueue( const ThingTemplate *unitType ) const;  ///< count number of units with matching unit type in the production queue
+	virtual Bool queueUpgrade( const UpgradeTemplate *upgrade ) override;				///< queue upgrade "research"
+	virtual void cancelUpgrade( const UpgradeTemplate *upgrade ) override;				///< cancel upgrade "research"
+	virtual Bool isUpgradeInQueue( const UpgradeTemplate *upgrade ) const override;		///< is the upgrade in our production queue already
+	virtual UnsignedInt countUnitTypeInQueue( const ThingTemplate *unitType ) const override;  ///< count number of units with matching unit type in the production queue
 
-	virtual Bool queueCreateUnit( const ThingTemplate *unitType, ProductionID productionID );					///< queue unit to be produced
-	virtual void cancelUnitCreate( ProductionID productionID );		      ///< cancel construction of unit with matching production ID
-	virtual void cancelAllUnitsOfType( const ThingTemplate *unitType);	///< cancel all production of type unitType
+	virtual Bool queueCreateUnit( const ThingTemplate *unitType, ProductionID productionID ) override;					///< queue unit to be produced
+	virtual void cancelUnitCreate( ProductionID productionID ) override;		      ///< cancel construction of unit with matching production ID
+	virtual void cancelAllUnitsOfType( const ThingTemplate *unitType) override;	///< cancel all production of type unitType
 
-	virtual void cancelAndRefundAllProduction();									///< cancel and refund anything in the production queue
+	virtual void cancelAndRefundAllProduction() override;									///< cancel and refund anything in the production queue
 
-	virtual UnsignedInt getProductionCount() const { return m_productionCount; }    ///< return # of things in the production queue
+	virtual UnsignedInt getProductionCount() const override { return m_productionCount; }    ///< return # of things in the production queue
 
 	// walking the production list from outside
-	virtual const ProductionEntry *firstProduction() const { return m_productionQueue; }
-	virtual const ProductionEntry *nextProduction( const ProductionEntry *p ) const { return p ? p->m_next : nullptr; }
+	virtual const ProductionEntry *firstProduction() const override { return m_productionQueue; }
+	virtual const ProductionEntry *nextProduction( const ProductionEntry *p ) const override { return p ? p->m_next : nullptr; }
 
-	virtual void setHoldDoorOpen(ExitDoorType exitDoor, Bool holdIt);
+	virtual void setHoldDoorOpen(ExitDoorType exitDoor, Bool holdIt) override;
 
-	virtual UpdateSleepTime update();					///< the update
+	virtual UpdateSleepTime update() override;					///< the update
 
 	//These functions keep track of the special power construction of a new building via a special power instead of standard production interface.
 	//This was added for the sneak attack building functionality.
-	virtual const CommandButton* getSpecialPowerConstructionCommandButton() const { return m_specialPowerConstructionCommandButton; }
-	virtual void setSpecialPowerConstructionCommandButton( const CommandButton *commandButton ) { m_specialPowerConstructionCommandButton = commandButton; }
+	virtual const CommandButton* getSpecialPowerConstructionCommandButton() const override { return m_specialPowerConstructionCommandButton; }
+	virtual void setSpecialPowerConstructionCommandButton( const CommandButton *commandButton ) override { m_specialPowerConstructionCommandButton = commandButton; }
 
 	// DieModuleInterface
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ProjectileStreamUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ProjectileStreamUpdate.h
@@ -58,7 +58,7 @@ public:
 	void getAllPoints( Vector3 *points, Int *count );					///< unroll circular array and write down all projectile positions
 	void setPosition( const Coord3D *newPosition );						///< I need to exist at the place I want to draw since only (near) on screen Drawables get updated
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ProneUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ProneUpdate.h
@@ -66,7 +66,7 @@ public:
 
 	void goProne( const DamageInfo *damageInfo );
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/PropagandaTowerBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/PropagandaTowerBehavior.h
@@ -79,7 +79,7 @@ public:
 	// module methods
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_DIE); }
 	virtual void onDelete() override;
-	void onObjectCreated() override;
+	virtual void onObjectCreated() override;
 
 	// update module methods
 	virtual UpdateSleepTime update() override;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/PropagandaTowerBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/PropagandaTowerBehavior.h
@@ -78,21 +78,21 @@ public:
 
 	// module methods
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_DIE); }
-	virtual void onDelete();
-	void onObjectCreated();
+	virtual void onDelete() override;
+	void onObjectCreated() override;
 
 	// update module methods
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	// die module methods
-	virtual DieModuleInterface *getDie() { return this; }
-	virtual void onDie( const DamageInfo *damageInfo );
-	virtual void onCapture( Player *oldOwner, Player *newOwner );
+	virtual DieModuleInterface *getDie() override { return this; }
+	virtual void onDie( const DamageInfo *damageInfo ) override;
+	virtual void onCapture( Player *oldOwner, Player *newOwner ) override;
 
 	// Disabled conditions to process. Need to process when disabled, because our update needs to actively let go
 	// of our effect on people.  We don't say "Be affected for n frames", we toggle people.  We need to process
 	// so we can toggle everyone off.
-	virtual DisabledMaskType getDisabledTypesToProcess() const { return DISABLEDMASK_ALL; }
+	virtual DisabledMaskType getDisabledTypesToProcess() const override { return DISABLEDMASK_ALL; }
 
 	// our own public module methods
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/QueueProductionExitUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/QueueProductionExitUpdate.h
@@ -80,24 +80,24 @@ class QueueProductionExitUpdate : public UpdateModule, public ExitInterface
 
 public:
 
-	virtual ExitInterface* getUpdateExitInterface() { return this; }
+	virtual ExitInterface* getUpdateExitInterface() override { return this; }
 
 	QueueProductionExitUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
 	// Required funcs to fulfill interface requirements
-	virtual Bool isExitBusy() const {return FALSE;}	///< Contain style exiters are getting the ability to space out exits, so ask this before reserveDoor as a kind of no-commitment check.
-	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject );
-	virtual void exitObjectViaDoor( Object *newObj, ExitDoorType exitDoor );
-	virtual void exitObjectByBudding( Object *newObj, Object *budHost );
-	virtual void unreserveDoorForExit( ExitDoorType exitDoor );
+	virtual Bool isExitBusy() const override {return FALSE;}	///< Contain style exiters are getting the ability to space out exits, so ask this before reserveDoor as a kind of no-commitment check.
+	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject ) override;
+	virtual void exitObjectViaDoor( Object *newObj, ExitDoorType exitDoor ) override;
+	virtual void exitObjectByBudding( Object *newObj, Object *budHost ) override;
+	virtual void unreserveDoorForExit( ExitDoorType exitDoor ) override;
 
-	virtual void setRallyPoint( const Coord3D *pos );			///< define a "rally point" for units to move towards
-	virtual const Coord3D *getRallyPoint() const;			///< define a "rally point" for units to move towards
-	virtual Bool getExitPosition( Coord3D& exitPosition ) const;					///< access to the "Door" position of the production object
-	virtual Bool getNaturalRallyPoint( Coord3D& rallyPoint, Bool offset = TRUE ) const;			///< get the natural "rally point" for units to move towards
+	virtual void setRallyPoint( const Coord3D *pos ) override;			///< define a "rally point" for units to move towards
+	virtual const Coord3D *getRallyPoint() const override;			///< define a "rally point" for units to move towards
+	virtual Bool getExitPosition( Coord3D& exitPosition ) const override;					///< access to the "Door" position of the production object
+	virtual Bool getNaturalRallyPoint( Coord3D& rallyPoint, Bool offset = TRUE ) const override;			///< get the natural "rally point" for units to move towards
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/RadarUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/RadarUpdate.h
@@ -76,7 +76,7 @@ public:
 	void extendRadar();									 ///< extend the radar from this object
 	Bool isRadarActive() { return m_radarActive; }
 
-	virtual UpdateSleepTime update(); ///< Here's the actual work of Upgrading
+	virtual UpdateSleepTime update() override; ///< Here's the actual work of Upgrading
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/RadarUpgrade.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/RadarUpgrade.h
@@ -64,14 +64,14 @@ public:
 	RadarUpgrade( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype defined by MemoryPoolObject
 
-	virtual void onDelete();																///< we have some work to do when this module goes away
-	virtual void onCapture( Player *oldOwner, Player *newOwner );	///< object containing upgrade has changed teams
+	virtual void onDelete() override;																///< we have some work to do when this module goes away
+	virtual void onCapture( Player *oldOwner, Player *newOwner ) override;	///< object containing upgrade has changed teams
 	Bool getIsDisableProof() const { return getRadarUpgradeModuleData()->m_isDisableProof; }
 
 protected:
 
-	virtual void upgradeImplementation(); ///< Here's the actual work of Upgrading
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation() override; ///< Here's the actual work of Upgrading
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/RadiusDecalUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/RadiusDecalUpdate.h
@@ -74,7 +74,7 @@ public:
 	void killWhenNoLongerAttacking(Bool v) { m_killWhenNoLongerAttacking = v; }
 	void killRadiusDecal();
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 private:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/RailedTransportAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/RailedTransportAIUpdate.h
@@ -64,14 +64,14 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	// AIUpdate interface methods
-	virtual void aiDoCommand( const AICommandParms *parms );
-	virtual UpdateSleepTime update();
+	virtual void aiDoCommand( const AICommandParms *parms ) override;
+	virtual UpdateSleepTime update() override;
 
 protected:
 
 	// ai module methods
-	virtual void privateExecuteRailedTransport( CommandSourceType cmdSource );
-	virtual void privateEvacuate( Int exposeStealthUnits, CommandSourceType cmdSource );
+	virtual void privateExecuteRailedTransport( CommandSourceType cmdSource ) override;
+	virtual void privateEvacuate( Int exposeStealthUnits, CommandSourceType cmdSource ) override;
 
 	// our methods
 	void setInTransit( Bool inTransit );

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/RailedTransportContain.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/RailedTransportContain.h
@@ -45,12 +45,12 @@ public:
 	RailedTransportContain( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onRemoving( Object *obj );			///< object no longer contains 'obj'
-	virtual void exitObjectViaDoor( Object *newObj, ExitDoorType exitDoor );
-	virtual void exitObjectByBudding( Object *newObj, Object *budHost ) { return; };
+	virtual void onRemoving( Object *obj ) override;			///< object no longer contains 'obj'
+	virtual void exitObjectViaDoor( Object *newObj, ExitDoorType exitDoor ) override;
+	virtual void exitObjectByBudding( Object *newObj, Object *budHost ) override { return; };
 
 protected:
 
-	virtual Bool isSpecificRiderFreeToExit( Object *obj );
+	virtual Bool isSpecificRiderFreeToExit( Object *obj ) override;
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/RailedTransportDockUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/RailedTransportDockUpdate.h
@@ -79,20 +79,20 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	// module interfaces
-	virtual RailedTransportDockUpdateInterface *getRailedTransportDockUpdateInterface() { return this; }
+	virtual RailedTransportDockUpdateInterface *getRailedTransportDockUpdateInterface() override { return this; }
 
 	// update module methods
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	// dock methods
-	virtual DockUpdateInterface* getDockUpdateInterface() { return this; }
-	virtual Bool action( Object* docker, Object *drone = nullptr );
-	virtual Bool isClearToEnter( Object const* docker ) const;
+	virtual DockUpdateInterface* getDockUpdateInterface() override { return this; }
+	virtual Bool action( Object* docker, Object *drone = nullptr ) override;
+	virtual Bool isClearToEnter( Object const* docker ) const override;
 
 	// our own methods
-	virtual Bool isLoadingOrUnloading();
-	virtual void unloadAll();
-	virtual void unloadSingleObject( Object *obj );
+	virtual Bool isLoadingOrUnloading() override;
+	virtual void unloadAll() override;
+	virtual void unloadSingleObject( Object *obj ) override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/RailroadGuideAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/RailroadGuideAIUpdate.h
@@ -219,9 +219,9 @@ public:
 //	virtual SleepyUpdatePhase getUpdatePhase() const { return PHASE_FINAL; }
 
 	// PhysicsBehavior methods
-	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal );
-	virtual Bool isRailroad() const ;
-	virtual UpdateSleepTime update();
+	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal ) override;
+	virtual Bool isRailroad() const override;
+	virtual UpdateSleepTime update() override;
 
 
 	// TRAINY METHODS

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/RebuildHoleBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/RebuildHoleBehavior.h
@@ -82,24 +82,24 @@ public:
 	RebuildHoleBehavior( Thing *thing, const ModuleData *moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual RebuildHoleBehaviorInterface* getRebuildHoleBehaviorInterface() { return this; }
+	virtual RebuildHoleBehaviorInterface* getRebuildHoleBehaviorInterface() override { return this; }
 
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_DIE); }
 
 	// BehaviorModule
-	virtual DieModuleInterface* getDie() { return this; }
+	virtual DieModuleInterface* getDie() override { return this; }
 
 	// UpdateModuleInterface
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	// DieModuleInterface
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 	// RebuildHole specific methods
-	virtual void startRebuildProcess( const ThingTemplate *rebuild, ObjectID spawnerID );
-	virtual ObjectID getSpawnerID() { return m_spawnerObjectID; }
-	virtual ObjectID getReconstructedBuildingID() { return m_reconstructingID; }
-	virtual const ThingTemplate* getRebuildTemplate() const { return m_rebuildTemplate; }
+	virtual void startRebuildProcess( const ThingTemplate *rebuild, ObjectID spawnerID ) override;
+	virtual ObjectID getSpawnerID() override { return m_spawnerObjectID; }
+	virtual ObjectID getReconstructedBuildingID() override { return m_reconstructingID; }
+	virtual const ThingTemplate* getRebuildTemplate() const override { return m_rebuildTemplate; }
 	void transferBombs( Object *reconstruction );
 
 	// interface acquisition

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/RebuildHoleExposeDie.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/RebuildHoleExposeDie.h
@@ -66,6 +66,6 @@ public:
 	RebuildHoleExposeDie( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/RepairDockUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/RepairDockUpdate.h
@@ -61,11 +61,11 @@ public:
 	RepairDockUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by MemoryPoolObject base class
 
-	virtual DockUpdateInterface* getDockUpdateInterface() { return this; }
+	virtual DockUpdateInterface* getDockUpdateInterface() override { return this; }
 
-	virtual Bool action( Object *docker, Object *drone = nullptr );	///< for me this means do some repair
+	virtual Bool action( Object *docker, Object *drone = nullptr ) override;	///< for me this means do some repair
 
-	virtual Bool isRallyPointAfterDockType(){return TRUE;} ///< A minority of docks want to give you a final command to their rally point
+	virtual Bool isRallyPointAfterDockType() override{return TRUE;} ///< A minority of docks want to give you a final command to their rally point
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/RepairDockUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/RepairDockUpdate.h
@@ -65,7 +65,7 @@ public:
 
 	virtual Bool action( Object *docker, Object *drone = nullptr ) override;	///< for me this means do some repair
 
-	virtual Bool isRallyPointAfterDockType() override{return TRUE;} ///< A minority of docks want to give you a final command to their rally point
+	virtual Bool isRallyPointAfterDockType() override {return TRUE;} ///< A minority of docks want to give you a final command to their rally point
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ReplaceObjectUpgrade.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ReplaceObjectUpgrade.h
@@ -57,7 +57,7 @@ public:
 	// virtual destructor prototype defined by MemoryPoolObject
 
 protected:
-	virtual void upgradeImplementation( ); ///< Here's the actual work of Upgrading
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation( ) override; ///< Here's the actual work of Upgrading
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/RiderChangeContain.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/RiderChangeContain.h
@@ -76,33 +76,33 @@ public:
 	RiderChangeContain( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual Bool isValidContainerFor( const Object* obj, Bool checkCapacity) const;
+	virtual Bool isValidContainerFor( const Object* obj, Bool checkCapacity) const override;
 
-	virtual void onCapture( Player *oldOwner, Player *newOwner ); // have to kick everyone out on capture.
-	virtual void onContaining( Object *obj, Bool wasSelected );		///< object now contains 'obj'
-	virtual void onRemoving( Object *obj );			///< object no longer contains 'obj'
-	virtual UpdateSleepTime update();							///< called once per frame
+	virtual void onCapture( Player *oldOwner, Player *newOwner ) override; // have to kick everyone out on capture.
+	virtual void onContaining( Object *obj, Bool wasSelected ) override;		///< object now contains 'obj'
+	virtual void onRemoving( Object *obj ) override;			///< object no longer contains 'obj'
+	virtual UpdateSleepTime update() override;							///< called once per frame
 
-	virtual Bool isRiderChangeContain() const { return TRUE; }
-	virtual const Object *friend_getRider() const;
+	virtual Bool isRiderChangeContain() const override { return TRUE; }
+	virtual const Object *friend_getRider() const override;
 
-	virtual Int getContainMax() const;
+	virtual Int getContainMax() const override;
 
-	virtual Int getExtraSlotsInUse() { return m_extraSlotsInUse; }///< Transports have the ability to carry guys how take up more than spot.
+	virtual Int getExtraSlotsInUse() override { return m_extraSlotsInUse; }///< Transports have the ability to carry guys how take up more than spot.
 
-	virtual Bool isExitBusy() const;	///< Contain style exiters are getting the ability to space out exits, so ask this before reserveDoor as a kind of no-commitment check.
-	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject );
-	virtual void unreserveDoorForExit( ExitDoorType exitDoor );
-	virtual Bool isDisplayedOnControlBar() const {return TRUE;}///< Does this container display its contents on the ControlBar?
+	virtual Bool isExitBusy() const override;	///< Contain style exiters are getting the ability to space out exits, so ask this before reserveDoor as a kind of no-commitment check.
+	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject ) override;
+	virtual void unreserveDoorForExit( ExitDoorType exitDoor ) override;
+	virtual Bool isDisplayedOnControlBar() const override {return TRUE;}///< Does this container display its contents on the ControlBar?
 
-	virtual Bool getContainerPipsToShow( Int& numTotal, Int& numFull );
+	virtual Bool getContainerPipsToShow( Int& numTotal, Int& numFull ) override;
 
 protected:
 
 	// exists primarily for RiderChangeContain to override
-	virtual void killRidersWhoAreNotFreeToExit();
-	virtual Bool isSpecificRiderFreeToExit(Object* obj);
-	virtual void createPayload();
+	virtual void killRidersWhoAreNotFreeToExit() override;
+	virtual Bool isSpecificRiderFreeToExit(Object* obj) override;
+	virtual void createPayload() override;
 
 private:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SabotageCommandCenterCrateCollide.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SabotageCommandCenterCrateCollide.h
@@ -76,11 +76,11 @@ public:
 protected:
 
 	/// This allows specific vetoes to certain types of crates and their data
-	virtual Bool isValidToExecute( const Object *other ) const;
+	virtual Bool isValidToExecute( const Object *other ) const override;
 
 	/// This is the game logic execution function that all real CrateCollides will implement
-	virtual Bool executeCrateBehavior( Object *other );
+	virtual Bool executeCrateBehavior( Object *other ) override;
 
-	virtual Bool isSabotageBuildingCrateCollide() const { return TRUE; }
+	virtual Bool isSabotageBuildingCrateCollide() const override { return TRUE; }
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SabotageFakeBuildingCrateCollide.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SabotageFakeBuildingCrateCollide.h
@@ -76,11 +76,11 @@ public:
 protected:
 
 	/// This allows specific vetoes to certain types of crates and their data
-	virtual Bool isValidToExecute( const Object *other ) const;
+	virtual Bool isValidToExecute( const Object *other ) const override;
 
 	/// This is the game logic execution function that all real CrateCollides will implement
-	virtual Bool executeCrateBehavior( Object *other );
+	virtual Bool executeCrateBehavior( Object *other ) override;
 
-	virtual Bool isSabotageBuildingCrateCollide() const { return TRUE; }
+	virtual Bool isSabotageBuildingCrateCollide() const override { return TRUE; }
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SabotageInternetCenterCrateCollide.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SabotageInternetCenterCrateCollide.h
@@ -79,11 +79,11 @@ public:
 protected:
 
 	/// This allows specific vetoes to certain types of crates and their data
-	virtual Bool isValidToExecute( const Object *other ) const;
+	virtual Bool isValidToExecute( const Object *other ) const override;
 
 	/// This is the game logic execution function that all real CrateCollides will implement
-	virtual Bool executeCrateBehavior( Object *other );
+	virtual Bool executeCrateBehavior( Object *other ) override;
 
-	virtual Bool isSabotageBuildingCrateCollide() const { return TRUE; }
+	virtual Bool isSabotageBuildingCrateCollide() const override { return TRUE; }
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SabotageMilitaryFactoryCrateCollide.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SabotageMilitaryFactoryCrateCollide.h
@@ -79,11 +79,11 @@ public:
 protected:
 
 	/// This allows specific vetoes to certain types of crates and their data
-	virtual Bool isValidToExecute( const Object *other ) const;
+	virtual Bool isValidToExecute( const Object *other ) const override;
 
 	/// This is the game logic execution function that all real CrateCollides will implement
-	virtual Bool executeCrateBehavior( Object *other );
+	virtual Bool executeCrateBehavior( Object *other ) override;
 
-	virtual Bool isSabotageBuildingCrateCollide() const { return TRUE; }
+	virtual Bool isSabotageBuildingCrateCollide() const override { return TRUE; }
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SabotagePowerPlantCrateCollide.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SabotagePowerPlantCrateCollide.h
@@ -79,11 +79,11 @@ public:
 protected:
 
 	/// This allows specific vetoes to certain types of crates and their data
-	virtual Bool isValidToExecute( const Object *other ) const;
+	virtual Bool isValidToExecute( const Object *other ) const override;
 
 	/// This is the game logic execution function that all real CrateCollides will implement
-	virtual Bool executeCrateBehavior( Object *other );
+	virtual Bool executeCrateBehavior( Object *other ) override;
 
-	virtual Bool isSabotageBuildingCrateCollide() const { return TRUE; }
+	virtual Bool isSabotageBuildingCrateCollide() const override { return TRUE; }
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SabotageSuperweaponCrateCollide.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SabotageSuperweaponCrateCollide.h
@@ -76,11 +76,11 @@ public:
 protected:
 
 	/// This allows specific vetoes to certain types of crates and their data
-	virtual Bool isValidToExecute( const Object *other ) const;
+	virtual Bool isValidToExecute( const Object *other ) const override;
 
 	/// This is the game logic execution function that all real CrateCollides will implement
-	virtual Bool executeCrateBehavior( Object *other );
+	virtual Bool executeCrateBehavior( Object *other ) override;
 
-	virtual Bool isSabotageBuildingCrateCollide() const { return TRUE; }
+	virtual Bool isSabotageBuildingCrateCollide() const override { return TRUE; }
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SabotageSupplyCenterCrateCollide.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SabotageSupplyCenterCrateCollide.h
@@ -79,11 +79,11 @@ public:
 protected:
 
 	/// This allows specific vetoes to certain types of crates and their data
-	virtual Bool isValidToExecute( const Object *other ) const;
+	virtual Bool isValidToExecute( const Object *other ) const override;
 
 	/// This is the game logic execution function that all real CrateCollides will implement
-	virtual Bool executeCrateBehavior( Object *other );
+	virtual Bool executeCrateBehavior( Object *other ) override;
 
-	virtual Bool isSabotageBuildingCrateCollide() const { return TRUE; }
+	virtual Bool isSabotageBuildingCrateCollide() const override { return TRUE; }
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SabotageSupplyDropzoneCrateCollide.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SabotageSupplyDropzoneCrateCollide.h
@@ -79,11 +79,11 @@ public:
 protected:
 
 	/// This allows specific vetoes to certain types of crates and their data
-	virtual Bool isValidToExecute( const Object *other ) const;
+	virtual Bool isValidToExecute( const Object *other ) const override;
 
 	/// This is the game logic execution function that all real CrateCollides will implement
-	virtual Bool executeCrateBehavior( Object *other );
+	virtual Bool executeCrateBehavior( Object *other ) override;
 
-	virtual Bool isSabotageBuildingCrateCollide() const { return TRUE; }
+	virtual Bool isSabotageBuildingCrateCollide() const override { return TRUE; }
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SalvageCrateCollide.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SalvageCrateCollide.h
@@ -87,15 +87,15 @@ public:
 	SalvageCrateCollide( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual Bool isSalvageCrateCollide() const { return true; }
+	virtual Bool isSalvageCrateCollide() const override { return true; }
 
 protected:
 
 	/// This allows specific vetoes to certain types of crates and their data
-	virtual Bool isValidToExecute( const Object *other ) const;
+	virtual Bool isValidToExecute( const Object *other ) const override;
 
 	/// This is the game logic execution function that all real CrateCollides will implement
-	virtual Bool executeCrateBehavior( Object *other );
+	virtual Bool executeCrateBehavior( Object *other ) override;
 
 private:
 	Bool eligibleForWeaponSet( Object *other );

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ShroudCrateCollide.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ShroudCrateCollide.h
@@ -51,5 +51,5 @@ public:
 protected:
 
 	/// This is the game logic execution function that all real CrateCollides will implement
-	virtual Bool executeCrateBehavior( Object *other );
+	virtual Bool executeCrateBehavior( Object *other ) override;
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SlavedUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SlavedUpdate.h
@@ -144,14 +144,14 @@ public:
 	SlavedUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual SlavedUpdateInterface* getSlavedUpdateInterface() { return this; }
+	virtual SlavedUpdateInterface* getSlavedUpdateInterface() override { return this; }
 
-	virtual ObjectID getSlaverID() const { return m_slaver; }
-	virtual void onEnslave( const Object *slaver );
-	virtual void onSlaverDie( const DamageInfo *info );
-	virtual void onSlaverDamage( const DamageInfo *info );
-	virtual void onObjectCreated();
-	virtual Bool isSelfTasking() const { return FALSE; };
+	virtual ObjectID getSlaverID() const override { return m_slaver; }
+	virtual void onEnslave( const Object *slaver ) override;
+	virtual void onSlaverDie( const DamageInfo *info ) override;
+	virtual void onSlaverDamage( const DamageInfo *info ) override;
+	virtual void onObjectCreated() override;
+	virtual Bool isSelfTasking() const override { return FALSE; };
 
 
 	void doScoutLogic( const Coord3D *mastersDestination );
@@ -163,7 +163,7 @@ public:
 	void setRepairModelConditionStates( ModelConditionFlagType flag );
 	void moveToNewRepairSpot();
 
-	virtual UpdateSleepTime update();	///< Deciding whether or not to make new guys
+	virtual UpdateSleepTime update() override;	///< Deciding whether or not to make new guys
 
 private:
 	void startSlavedEffects( const Object *slaver );	///< We have been marked as Slaved, so we can't be selected or move too far or other stuff

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SlowDeathBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SlowDeathBehavior.h
@@ -137,21 +137,21 @@ public:
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_DIE); }
 
 	// BehaviorModule
-	virtual DieModuleInterface* getDie() { return this; }
+	virtual DieModuleInterface* getDie() override { return this; }
 
 	// UpdateModuleInterface
-	virtual UpdateSleepTime update();
-	virtual SlowDeathBehaviorInterface* getSlowDeathBehaviorInterface() { return this; }
+	virtual UpdateSleepTime update() override;
+	virtual SlowDeathBehaviorInterface* getSlowDeathBehaviorInterface() override { return this; }
 	// Disabled conditions to process -- all
-	virtual DisabledMaskType getDisabledTypesToProcess() const { return DISABLEDMASK_ALL; }
+	virtual DisabledMaskType getDisabledTypesToProcess() const override { return DISABLEDMASK_ALL; }
 
 	// DieModuleInterface
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 	// SlowDeathBehaviorInterface
-	virtual void beginSlowDeath( const DamageInfo *damageInfo );
-	virtual Int getProbabilityModifier( const DamageInfo *damageInfo ) const;
-	virtual Bool isDieApplicable(const DamageInfo *damageInfo) const { return getSlowDeathBehaviorModuleData()->m_dieMuxData.isDieApplicable(getObject(), damageInfo); }
+	virtual void beginSlowDeath( const DamageInfo *damageInfo ) override;
+	virtual Int getProbabilityModifier( const DamageInfo *damageInfo ) const override;
+	virtual Bool isDieApplicable(const DamageInfo *damageInfo) const override { return getSlowDeathBehaviorModuleData()->m_dieMuxData.isDieApplicable(getObject(), damageInfo); }
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SmartBombTargetHomingUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SmartBombTargetHomingUpdate.h
@@ -70,7 +70,7 @@ public:
 
   void SetTargetPosition( const Coord3D& target );
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SpawnBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SpawnBehavior.h
@@ -142,41 +142,41 @@ public:
 
 	// module methods
 	static Int getInterfaceMask() { return (MODULEINTERFACE_UPDATE) | (MODULEINTERFACE_DIE) | (MODULEINTERFACE_DAMAGE); }
-	virtual void onDelete();
-	virtual UpdateModuleInterface *getUpdate() { return this; }
-	virtual DieModuleInterface *getDie() { return this; }
-	virtual DamageModuleInterface *getDamage() { return this; }
-	virtual SpawnBehaviorInterface* getSpawnBehaviorInterface() { return this; }
+	virtual void onDelete() override;
+	virtual UpdateModuleInterface *getUpdate() override { return this; }
+	virtual DieModuleInterface *getDie() override { return this; }
+	virtual DamageModuleInterface *getDamage() override { return this; }
+	virtual SpawnBehaviorInterface* getSpawnBehaviorInterface() override { return this; }
 
 	// update methods
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	// die methods
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 	// damage methods
-	virtual void onDamage( DamageInfo *damageInfo );
-	virtual void onHealing( DamageInfo *damageInfo ) { }
+	virtual void onDamage( DamageInfo *damageInfo ) override;
+	virtual void onHealing( DamageInfo *damageInfo ) override { }
 	virtual void onBodyDamageStateChange( const DamageInfo* damageInfo,
 																				BodyDamageType oldState,
-																				BodyDamageType newState) { }
+																				BodyDamageType newState) override { }
 
 	// SpawnBehaviorInterface methods
-	virtual Bool maySpawnSelfTaskAI( Real maxSelfTaskersRatio );
-	virtual void onSpawnDeath( ObjectID deadSpawn, DamageInfo *damageInfo );	///< Something we spawned and set up to tell us it died just died.
-	virtual Object* getClosestSlave( const Coord3D *pos );
-	virtual void orderSlavesToAttackTarget( Object *target, Int maxShotsToFire, CommandSourceType cmdSource );
-	virtual void orderSlavesToAttackPosition( const Coord3D *pos, Int maxShotsToFire, CommandSourceType cmdSource );
-	virtual CanAttackResult getCanAnySlavesAttackSpecificTarget( AbleToAttackType attackType, const Object *target, CommandSourceType cmdSource );
-	virtual CanAttackResult getCanAnySlavesUseWeaponAgainstTarget( AbleToAttackType attackType, const Object *victim, const Coord3D *pos, CommandSourceType cmdSource );
-	virtual Bool canAnySlavesAttack();
-	virtual void orderSlavesToGoIdle( CommandSourceType cmdSource );
-	virtual void orderSlavesDisabledUntil( DisabledType type, UnsignedInt frame );
-	virtual void orderSlavesToClearDisabled( DisabledType type );
-	virtual void giveSlavesStealthUpgrade( Bool grantStealth );
-	virtual Bool areAllSlavesStealthed() const;
-	virtual void revealSlaves();
-	virtual Bool doSlavesHaveFreedom() const { return getSpawnBehaviorModuleData()->m_slavesHaveFreeWill; }
+	virtual Bool maySpawnSelfTaskAI( Real maxSelfTaskersRatio ) override;
+	virtual void onSpawnDeath( ObjectID deadSpawn, DamageInfo *damageInfo ) override;	///< Something we spawned and set up to tell us it died just died.
+	virtual Object* getClosestSlave( const Coord3D *pos ) override;
+	virtual void orderSlavesToAttackTarget( Object *target, Int maxShotsToFire, CommandSourceType cmdSource ) override;
+	virtual void orderSlavesToAttackPosition( const Coord3D *pos, Int maxShotsToFire, CommandSourceType cmdSource ) override;
+	virtual CanAttackResult getCanAnySlavesAttackSpecificTarget( AbleToAttackType attackType, const Object *target, CommandSourceType cmdSource ) override;
+	virtual CanAttackResult getCanAnySlavesUseWeaponAgainstTarget( AbleToAttackType attackType, const Object *victim, const Coord3D *pos, CommandSourceType cmdSource ) override;
+	virtual Bool canAnySlavesAttack() override;
+	virtual void orderSlavesToGoIdle( CommandSourceType cmdSource ) override;
+	virtual void orderSlavesDisabledUntil( DisabledType type, UnsignedInt frame ) override;
+	virtual void orderSlavesToClearDisabled( DisabledType type ) override;
+	virtual void giveSlavesStealthUpgrade( Bool grantStealth ) override;
+	virtual Bool areAllSlavesStealthed() const override;
+	virtual void revealSlaves() override;
+	virtual Bool doSlavesHaveFreedom() const override { return getSpawnBehaviorModuleData()->m_slavesHaveFreeWill; }
 
 	// **********************************************************************************************
 	// our own methods

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SpawnPointProductionExitUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SpawnPointProductionExitUpdate.h
@@ -68,21 +68,21 @@ class SpawnPointProductionExitUpdate : public UpdateModule, public ExitInterface
 
 public:
 
-	virtual ExitInterface* getUpdateExitInterface() { return this; }
+	virtual ExitInterface* getUpdateExitInterface() override { return this; }
 
 	SpawnPointProductionExitUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
 	// Required funcs to fulfill interface requirements
-	virtual Bool isExitBusy() const {return FALSE;}	///< Contain style exiters are getting the ability to space out exits, so ask this before reserveDoor as a kind of no-commitment check.
-	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject );
-	virtual void exitObjectViaDoor( Object *newObj, ExitDoorType exitDoor );
-	virtual void unreserveDoorForExit( ExitDoorType exitDoor );
-	virtual void setRallyPoint( const Coord3D * ){}
-	virtual const Coord3D *getRallyPoint() const { return nullptr; }
-	virtual void exitObjectByBudding( Object *newObj, Object *budHost ) { return; }
+	virtual Bool isExitBusy() const override {return FALSE;}	///< Contain style exiters are getting the ability to space out exits, so ask this before reserveDoor as a kind of no-commitment check.
+	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject ) override;
+	virtual void exitObjectViaDoor( Object *newObj, ExitDoorType exitDoor ) override;
+	virtual void unreserveDoorForExit( ExitDoorType exitDoor ) override;
+	virtual void setRallyPoint( const Coord3D * ) override{}
+	virtual const Coord3D *getRallyPoint() const override { return nullptr; }
+	virtual void exitObjectByBudding( Object *newObj, Object *budHost ) override { return; }
 
-	virtual UpdateSleepTime update()										{ return UPDATE_SLEEP_FOREVER; }
+	virtual UpdateSleepTime update() override										{ return UPDATE_SLEEP_FOREVER; }
 
 protected:
 	Bool m_bonesInitialized;													///< To prevent creation bugs, only init the World coords when first asked for one

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SpawnPointProductionExitUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SpawnPointProductionExitUpdate.h
@@ -78,7 +78,7 @@ public:
 	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject ) override;
 	virtual void exitObjectViaDoor( Object *newObj, ExitDoorType exitDoor ) override;
 	virtual void unreserveDoorForExit( ExitDoorType exitDoor ) override;
-	virtual void setRallyPoint( const Coord3D * ) override{}
+	virtual void setRallyPoint( const Coord3D * ) override {}
 	virtual const Coord3D *getRallyPoint() const override { return nullptr; }
 	virtual void exitObjectByBudding( Object *newObj, Object *budHost ) override { return; }
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SpecialAbility.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SpecialAbility.h
@@ -55,9 +55,9 @@ public:
 
 	SpecialAbility( Thing *thing, const ModuleData *moduleData );
 
-	virtual void doSpecialPowerAtObject( Object *obj, UnsignedInt commandOptions );
-	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions );
-	virtual void doSpecialPower( UnsignedInt commandOptions );
+	virtual void doSpecialPowerAtObject( Object *obj, UnsignedInt commandOptions ) override;
+	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions ) override;
+	virtual void doSpecialPower( UnsignedInt commandOptions ) override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SpecialAbilityUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SpecialAbilityUpdate.h
@@ -178,21 +178,21 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	// SpecialPowerUpdateInterface
-	virtual Bool initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions );
-	virtual Bool isSpecialAbility() const { return true; }
-	virtual Bool isSpecialPower() const { return false; }
-	virtual Bool isActive() const { return m_active; }
-	virtual Bool doesSpecialPowerHaveOverridableDestinationActive() const { return false; } //Is it active now?
-	virtual Bool doesSpecialPowerHaveOverridableDestination() const { return false; }	//Does it have it, even if it's not active?
-	virtual void setSpecialPowerOverridableDestination( const Coord3D *loc ) {}
-	virtual Bool isPowerCurrentlyInUse( const CommandButton *command = nullptr ) const;
+	virtual Bool initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions ) override;
+	virtual Bool isSpecialAbility() const override { return true; }
+	virtual Bool isSpecialPower() const override { return false; }
+	virtual Bool isActive() const override { return m_active; }
+	virtual Bool doesSpecialPowerHaveOverridableDestinationActive() const override { return false; } //Is it active now?
+	virtual Bool doesSpecialPowerHaveOverridableDestination() const override { return false; }	//Does it have it, even if it's not active?
+	virtual void setSpecialPowerOverridableDestination( const Coord3D *loc ) override {}
+	virtual Bool isPowerCurrentlyInUse( const CommandButton *command = nullptr ) const override;
 
 //	virtual Bool isBusy() const { return m_isBusy; }
 
 	// UpdateModule
-	virtual SpecialPowerUpdateInterface* getSpecialPowerUpdateInterface() { return this; }
-	virtual CommandOption getCommandOption() const { return (CommandOption)0; }
-	virtual UpdateSleepTime update();
+	virtual SpecialPowerUpdateInterface* getSpecialPowerUpdateInterface() override { return this; }
+	virtual CommandOption getCommandOption() const override { return (CommandOption)0; }
+	virtual UpdateSleepTime update() override;
 
 	// ??? ugh, public stuff that shouldn't be -- hell yeah!
 	UnsignedInt getSpecialObjectCount() const;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SpecialPowerCompletionDie.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SpecialPowerCompletionDie.h
@@ -77,7 +77,7 @@ public:
 	void setCreator( ObjectID creatorID );
 	void notifyScriptEngine();
 
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SpecialPowerCreate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SpecialPowerCreate.h
@@ -48,8 +48,8 @@ public:
 	SpecialPowerCreate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onCreate();
-	virtual void onBuildComplete();	///< This is called when you are a finished game object
+	virtual void onCreate() override;
+	virtual void onBuildComplete() override;	///< This is called when you are a finished game object
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SpecialPowerModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SpecialPowerModule.h
@@ -105,39 +105,39 @@ public:
 	static Int getInterfaceMask() { return MODULEINTERFACE_SPECIAL_POWER; }
 
 	// BehaviorModule
-	virtual SpecialPowerModuleInterface* getSpecialPower() { return this; }
+	virtual SpecialPowerModuleInterface* getSpecialPower() override { return this; }
 
-	Bool isModuleForPower( const SpecialPowerTemplate *specialPowerTemplate ) const;	///< is this module for the specified special power
-	Bool isReady() const; 						///< is this special power available now
+	Bool isModuleForPower( const SpecialPowerTemplate *specialPowerTemplate ) const override;	///< is this module for the specified special power
+	Bool isReady() const override; 						///< is this special power available now
 //  This is the althernate way to one-at-a-time BlackLotus' specials; we'll keep it commented her until Dustin decides, or until 12/10/02
 //	Bool isBusy() const { return FALSE; }
 
-	Real getPercentReady() const;		///< get the percent ready (1.0 = ready now, 0.5 = half charged up etc.)
+	Real getPercentReady() const override;		///< get the percent ready (1.0 = ready now, 0.5 = half charged up etc.)
 
-	UnsignedInt getReadyFrame() const;		///< get the frame at which we are ready
-	AsciiString getPowerName() const;
+	UnsignedInt getReadyFrame() const override;		///< get the frame at which we are ready
+	AsciiString getPowerName() const override;
 	void syncReadyFrameToStatusQuo();
 
-	const SpecialPowerTemplate* getSpecialPowerTemplate() const;
-	ScienceType getRequiredScience() const;
+	const SpecialPowerTemplate* getSpecialPowerTemplate() const override;
+	ScienceType getRequiredScience() const override;
 
-	void onSpecialPowerCreation();	// called by a create module to start our countdown
+	void onSpecialPowerCreation() override;	// called by a create module to start our countdown
 	//
 	// The following methods are for use by the scripting engine ONLY
 	//
 
-	void setReadyFrame( UnsignedInt frame );
+	void setReadyFrame( UnsignedInt frame ) override;
 	UnsignedInt getReadyFrame() { return m_availableOnFrame; }// USED BY PLAYER TO KEEP RECHARGE TIMERS IN SYNC
-	void pauseCountdown( Bool pause );
+	void pauseCountdown( Bool pause ) override;
 
 	//
 	// the following methods should be *EXTENDED* for any special power module implementations
 	// and carry out the special power executions
 	//
-	virtual void doSpecialPower( UnsignedInt commandOptions );
-	virtual void doSpecialPowerAtObject( Object *obj, UnsignedInt commandOptions );
-	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions );
-	virtual void doSpecialPowerUsingWaypoints( const Waypoint *way, UnsignedInt commandOptions );
+	virtual void doSpecialPower( UnsignedInt commandOptions ) override;
+	virtual void doSpecialPowerAtObject( Object *obj, UnsignedInt commandOptions ) override;
+	virtual void doSpecialPowerAtLocation( const Coord3D *loc, Real angle, UnsignedInt commandOptions ) override;
+	virtual void doSpecialPowerUsingWaypoints( const Waypoint *way, UnsignedInt commandOptions ) override;
 
 	/**
 	 Now, there are special powers that require some preliminary processing before the actual
@@ -150,17 +150,17 @@ public:
 	 module. The update module then orders the unit to move within range, and it isn't until the
 	 hacker start the physical attack, that the timer is reset and the attack technically begins.
 	*/
-	virtual void markSpecialPowerTriggered( const Coord3D *location );
+	virtual void markSpecialPowerTriggered( const Coord3D *location ) override;
 
 	/** start the recharge process for this special power. public because some powers call it repeatedly.
 	*/
-	virtual void startPowerRecharge();
-	virtual const AudioEventRTS& getInitiateSound() const;
+	virtual void startPowerRecharge() override;
+	virtual const AudioEventRTS& getInitiateSound() const override;
 
-	virtual Bool isScriptOnly() const;
+	virtual Bool isScriptOnly() const override;
 
 	//If the special power launches a construction site, we need to know the final product for placement purposes.
-	virtual const ThingTemplate* getReferenceThingTemplate() const { return nullptr; }
+	virtual const ThingTemplate* getReferenceThingTemplate() const override { return nullptr; }
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SpecialPowerModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SpecialPowerModule.h
@@ -107,28 +107,28 @@ public:
 	// BehaviorModule
 	virtual SpecialPowerModuleInterface* getSpecialPower() override { return this; }
 
-	Bool isModuleForPower( const SpecialPowerTemplate *specialPowerTemplate ) const override;	///< is this module for the specified special power
-	Bool isReady() const override; 						///< is this special power available now
+	virtual Bool isModuleForPower( const SpecialPowerTemplate *specialPowerTemplate ) const override;	///< is this module for the specified special power
+	virtual Bool isReady() const override; 						///< is this special power available now
 //  This is the althernate way to one-at-a-time BlackLotus' specials; we'll keep it commented her until Dustin decides, or until 12/10/02
 //	Bool isBusy() const { return FALSE; }
 
-	Real getPercentReady() const override;		///< get the percent ready (1.0 = ready now, 0.5 = half charged up etc.)
+	virtual Real getPercentReady() const override;		///< get the percent ready (1.0 = ready now, 0.5 = half charged up etc.)
 
-	UnsignedInt getReadyFrame() const override;		///< get the frame at which we are ready
-	AsciiString getPowerName() const override;
+	virtual UnsignedInt getReadyFrame() const override;		///< get the frame at which we are ready
+	virtual AsciiString getPowerName() const override;
 	void syncReadyFrameToStatusQuo();
 
-	const SpecialPowerTemplate* getSpecialPowerTemplate() const override;
-	ScienceType getRequiredScience() const override;
+	virtual const SpecialPowerTemplate* getSpecialPowerTemplate() const override;
+	virtual ScienceType getRequiredScience() const override;
 
-	void onSpecialPowerCreation() override;	// called by a create module to start our countdown
+	virtual void onSpecialPowerCreation() override;	// called by a create module to start our countdown
 	//
 	// The following methods are for use by the scripting engine ONLY
 	//
 
-	void setReadyFrame( UnsignedInt frame ) override;
+	virtual void setReadyFrame( UnsignedInt frame ) override;
 	UnsignedInt getReadyFrame() { return m_availableOnFrame; }// USED BY PLAYER TO KEEP RECHARGE TIMERS IN SYNC
-	void pauseCountdown( Bool pause ) override;
+	virtual void pauseCountdown( Bool pause ) override;
 
 	//
 	// the following methods should be *EXTENDED* for any special power module implementations

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SpecialPowerUpdateModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SpecialPowerUpdateModule.h
@@ -63,18 +63,18 @@ public:
 	// virtual destructor prototype defined by MemoryPoolObject
 
 	//SpecialPowerUpdateInterface virtual implementations
-	virtual Bool doesSpecialPowerUpdatePassScienceTest() const;
-	virtual ScienceType getExtraRequiredScience() const { return SCIENCE_INVALID; } //Does this object have more than one special power module with the same spTemplate?
+	virtual Bool doesSpecialPowerUpdatePassScienceTest() const override;
+	virtual ScienceType getExtraRequiredScience() const override { return SCIENCE_INVALID; } //Does this object have more than one special power module with the same spTemplate?
 
 	//SpecialPowerUpdateInterface PURE virtual implementations
-	virtual Bool initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions ) = 0;
-	virtual Bool isSpecialAbility() const = 0;
-	virtual Bool isSpecialPower() const = 0;
-	virtual Bool isActive() const = 0;
-	virtual CommandOption getCommandOption() const = 0;
-	virtual Bool doesSpecialPowerHaveOverridableDestinationActive() const = 0; //Is it active now?
-	virtual Bool doesSpecialPowerHaveOverridableDestination() const = 0;	//Does it have it, even if it's not active?
-	virtual void setSpecialPowerOverridableDestination( const Coord3D *loc ) = 0;
-	virtual Bool isPowerCurrentlyInUse( const CommandButton *command = nullptr ) const = 0;
+	virtual Bool initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions ) override = 0;
+	virtual Bool isSpecialAbility() const override = 0;
+	virtual Bool isSpecialPower() const override = 0;
+	virtual Bool isActive() const override = 0;
+	virtual CommandOption getCommandOption() const override = 0;
+	virtual Bool doesSpecialPowerHaveOverridableDestinationActive() const override = 0; //Is it active now?
+	virtual Bool doesSpecialPowerHaveOverridableDestination() const override = 0;	//Does it have it, even if it's not active?
+	virtual void setSpecialPowerOverridableDestination( const Coord3D *loc ) override = 0;
+	virtual Bool isPowerCurrentlyInUse( const CommandButton *command = nullptr ) const override = 0;
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SpecialPowerUpdateModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SpecialPowerUpdateModule.h
@@ -67,14 +67,14 @@ public:
 	virtual ScienceType getExtraRequiredScience() const override { return SCIENCE_INVALID; } //Does this object have more than one special power module with the same spTemplate?
 
 	//SpecialPowerUpdateInterface PURE virtual implementations
-	virtual Bool initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions ) override = 0;
-	virtual Bool isSpecialAbility() const override = 0;
-	virtual Bool isSpecialPower() const override = 0;
-	virtual Bool isActive() const override = 0;
-	virtual CommandOption getCommandOption() const override = 0;
-	virtual Bool doesSpecialPowerHaveOverridableDestinationActive() const override = 0; //Is it active now?
-	virtual Bool doesSpecialPowerHaveOverridableDestination() const override = 0;	//Does it have it, even if it's not active?
-	virtual void setSpecialPowerOverridableDestination( const Coord3D *loc ) override = 0;
-	virtual Bool isPowerCurrentlyInUse( const CommandButton *command = nullptr ) const override = 0;
+	virtual Bool initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions ) = 0;
+	virtual Bool isSpecialAbility() const = 0;
+	virtual Bool isSpecialPower() const = 0;
+	virtual Bool isActive() const = 0;
+	virtual CommandOption getCommandOption() const = 0;
+	virtual Bool doesSpecialPowerHaveOverridableDestinationActive() const = 0; //Is it active now?
+	virtual Bool doesSpecialPowerHaveOverridableDestination() const = 0;	//Does it have it, even if it's not active?
+	virtual void setSpecialPowerOverridableDestination( const Coord3D *loc ) = 0;
+	virtual Bool isPowerCurrentlyInUse( const CommandButton *command = nullptr ) const = 0;
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SpectreGunshipDeploymentUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SpectreGunshipDeploymentUpdate.h
@@ -111,28 +111,28 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	// SpecialPowerUpdateInterface
-	virtual Bool initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions );
-	virtual Bool isSpecialAbility() const { return false; }
-	virtual Bool isSpecialPower() const { return true; }
-	virtual Bool isActive() const {return FALSE;}
-	virtual SpecialPowerUpdateInterface* getSpecialPowerUpdateInterface() { return this; }
-	virtual CommandOption getCommandOption() const { return (CommandOption)0; }
-  virtual Bool isPowerCurrentlyInUse( const CommandButton *command = nullptr ) const { return FALSE; };
-	virtual ScienceType getExtraRequiredScience() const { return getSpectreGunshipDeploymentUpdateModuleData()->m_extraRequiredScience; } //Does this object have more than one special power module with the same spTemplate?
+	virtual Bool initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions ) override;
+	virtual Bool isSpecialAbility() const override { return false; }
+	virtual Bool isSpecialPower() const override { return true; }
+	virtual Bool isActive() const override {return FALSE;}
+	virtual SpecialPowerUpdateInterface* getSpecialPowerUpdateInterface() override { return this; }
+	virtual CommandOption getCommandOption() const override { return (CommandOption)0; }
+  virtual Bool isPowerCurrentlyInUse( const CommandButton *command = nullptr ) const override { return FALSE; };
+	virtual ScienceType getExtraRequiredScience() const override { return getSpectreGunshipDeploymentUpdateModuleData()->m_extraRequiredScience; } //Does this object have more than one special power module with the same spTemplate?
 
-	virtual void onObjectCreated();
-	virtual UpdateSleepTime update();
+	virtual void onObjectCreated() override;
+	virtual UpdateSleepTime update() override;
 
 	void cleanUp();
 
 
 
-  virtual Bool doesSpecialPowerHaveOverridableDestinationActive() const { return FALSE; };
-	virtual Bool doesSpecialPowerHaveOverridableDestination() const { return FALSE; }	//Does it have it, even if it's not active?
-  virtual void setSpecialPowerOverridableDestination( const Coord3D *loc ) {};
+  virtual Bool doesSpecialPowerHaveOverridableDestinationActive() const override { return FALSE; };
+	virtual Bool doesSpecialPowerHaveOverridableDestination() const override { return FALSE; }	//Does it have it, even if it's not active?
+  virtual void setSpecialPowerOverridableDestination( const Coord3D *loc ) override {};
 
 	// Disabled conditions to process (termination conditions!)
-	virtual DisabledMaskType getDisabledTypesToProcess() const { return MAKE_DISABLED_MASK4( DISABLED_SUBDUED, DISABLED_UNDERPOWERED, DISABLED_EMP, DISABLED_HACKED ); }
+	virtual DisabledMaskType getDisabledTypesToProcess() const override { return MAKE_DISABLED_MASK4( DISABLED_SUBDUED, DISABLED_UNDERPOWERED, DISABLED_EMP, DISABLED_HACKED ); }
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SpectreGunshipUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SpectreGunshipUpdate.h
@@ -99,27 +99,27 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	// SpecialPowerUpdateInterface
-	virtual Bool initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions );
-	virtual Bool isSpecialAbility() const { return false; }
-	virtual Bool isSpecialPower() const { return true; }
-	virtual Bool isActive() const {return m_status < GUNSHIP_STATUS_DEPARTING;}
-	virtual SpecialPowerUpdateInterface* getSpecialPowerUpdateInterface() { return this; }
-	virtual CommandOption getCommandOption() const { return (CommandOption)0; }
-	virtual Bool isPowerCurrentlyInUse( const CommandButton *command = nullptr ) const;
+	virtual Bool initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions ) override;
+	virtual Bool isSpecialAbility() const override { return false; }
+	virtual Bool isSpecialPower() const override { return true; }
+	virtual Bool isActive() const override {return m_status < GUNSHIP_STATUS_DEPARTING;}
+	virtual SpecialPowerUpdateInterface* getSpecialPowerUpdateInterface() override { return this; }
+	virtual CommandOption getCommandOption() const override { return (CommandOption)0; }
+	virtual Bool isPowerCurrentlyInUse( const CommandButton *command = nullptr ) const override;
 
-	virtual void onObjectCreated();
-	virtual UpdateSleepTime update();
+	virtual void onObjectCreated() override;
+	virtual UpdateSleepTime update() override;
 
 	void cleanUp();
 
 
 
-	virtual Bool doesSpecialPowerHaveOverridableDestinationActive() const;
-	virtual Bool doesSpecialPowerHaveOverridableDestination() const { return true; }	//Does it have it, even if it's not active?
-	virtual void setSpecialPowerOverridableDestination( const Coord3D *loc );
+	virtual Bool doesSpecialPowerHaveOverridableDestinationActive() const override;
+	virtual Bool doesSpecialPowerHaveOverridableDestination() const override { return true; }	//Does it have it, even if it's not active?
+	virtual void setSpecialPowerOverridableDestination( const Coord3D *loc ) override;
 
 	// Disabled conditions to process (termination conditions!)
-	virtual DisabledMaskType getDisabledTypesToProcess() const { return MAKE_DISABLED_MASK4( DISABLED_SUBDUED, DISABLED_UNDERPOWERED, DISABLED_EMP, DISABLED_HACKED ); }
+	virtual DisabledMaskType getDisabledTypesToProcess() const override { return MAKE_DISABLED_MASK4( DISABLED_SUBDUED, DISABLED_UNDERPOWERED, DISABLED_EMP, DISABLED_HACKED ); }
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SpyVisionSpecialPower.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SpyVisionSpecialPower.h
@@ -65,7 +65,7 @@ public:
 	SpyVisionSpecialPower( Thing *thing, const ModuleData *moduleData );
 	// virtual destructor prototype provided by memory pool object
 
-	virtual void doSpecialPower( UnsignedInt commandOptions );
+	virtual void doSpecialPower( UnsignedInt commandOptions ) override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SpyVisionUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SpyVisionUpdate.h
@@ -90,19 +90,19 @@ public:
 	SpyVisionUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual SpyVisionUpdate* getSpyVisionUpdate() { return this; }
+	virtual SpyVisionUpdate* getSpyVisionUpdate() override { return this; }
 
 	// module methods
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | MODULEINTERFACE_UPGRADE; }
-	virtual void onDelete();
-	virtual void onCapture( Player *oldOwner, Player *newOwner );
-	virtual void onDisabledEdge( Bool nowDisabled );
+	virtual void onDelete() override;
+	virtual void onCapture( Player *oldOwner, Player *newOwner ) override;
+	virtual void onDisabledEdge( Bool nowDisabled ) override;
 
 	// BehaviorModule
-	virtual UpgradeModuleInterface* getUpgrade() { return this; }
+	virtual UpgradeModuleInterface* getUpgrade() override { return this; }
 
 	//Update module
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	void activateSpyVision( UnsignedInt duration );
 
@@ -112,27 +112,27 @@ public:
 protected:
 
 	// UpgradeMux functions.  Mux standing, of course, for Majorly Ugly Xhitcode
-	virtual void upgradeImplementation();
-	virtual void getUpgradeActivationMasks(UpgradeMaskType& activation, UpgradeMaskType& conflicting) const
+	virtual void upgradeImplementation() override;
+	virtual void getUpgradeActivationMasks(UpgradeMaskType& activation, UpgradeMaskType& conflicting) const override
 	{
 		getSpyVisionUpdateModuleData()->m_upgradeMuxData.getUpgradeActivationMasks(activation, conflicting);
 	}
-	virtual void performUpgradeFX()
+	virtual void performUpgradeFX() override
 	{
 		getSpyVisionUpdateModuleData()->m_upgradeMuxData.performUpgradeFX(getObject());
 	}
-	virtual void processUpgradeRemoval()
+	virtual void processUpgradeRemoval() override
 	{
 		// I can't take it any more.  Let the record show that I think the UpgradeMux multiple inheritance is CRAP.
 		getSpyVisionUpdateModuleData()->m_upgradeMuxData.muxDataProcessUpgradeRemoval(getObject());
 	}
 
-	virtual Bool requiresAllActivationUpgrades() const
+	virtual Bool requiresAllActivationUpgrades() const override
 	{
 		return getSpyVisionUpdateModuleData()->m_upgradeMuxData.m_requiresAllTriggers;
 	}
 	Bool isUpgradeActive() const { return isAlreadyUpgraded(); }
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 private:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SquishCollide.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SquishCollide.h
@@ -50,7 +50,7 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	/// This collide method gets called when collision occur
-	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal );
+	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal ) override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/StatusBitsUpgrade.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/StatusBitsUpgrade.h
@@ -91,8 +91,8 @@ public:
 	// virtual destructor prototype defined by MemoryPoolObject
 
 protected:
-	virtual void upgradeImplementation( ); ///< Here's the actual work of Upgrading
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation( ) override; ///< Here's the actual work of Upgrading
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 };
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/StatusDamageHelper.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/StatusDamageHelper.h
@@ -52,8 +52,8 @@ public:
 	StatusDamageHelper( Thing *thing, const ModuleData *modData );
 	// virtual destructor prototype provided by memory pool object
 
-	virtual DisabledMaskType getDisabledTypesToProcess() const { return DISABLEDMASK_ALL; }
-	virtual UpdateSleepTime update();
+	virtual DisabledMaskType getDisabledTypesToProcess() const override { return DISABLEDMASK_ALL; }
+	virtual UpdateSleepTime update() override;
 
 	void doStatusDamage( ObjectStatusTypes status, Real duration );
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/StealthDetectorUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/StealthDetectorUpdate.h
@@ -87,8 +87,8 @@ public:
 
 	Bool isSDEnabled() const { return m_enabled; }
 	void setSDEnabled( Bool enabled );
-	virtual UpdateSleepTime update();
-	virtual DisabledMaskType getDisabledTypesToProcess() const { return MAKE_DISABLED_MASK( DISABLED_HELD ); }
+	virtual UpdateSleepTime update() override;
+	virtual DisabledMaskType getDisabledTypesToProcess() const override { return MAKE_DISABLED_MASK( DISABLED_HELD ); }
 
 private:
 	Bool m_enabled;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/StealthUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/StealthUpdate.h
@@ -116,13 +116,13 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 
-  virtual StealthUpdate* getStealth() { return this; }
+  virtual StealthUpdate* getStealth() override { return this; }
 
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	//Still gets called, even if held -ML
-	virtual DisabledMaskType getDisabledTypesToProcess() const { return MAKE_DISABLED_MASK( DISABLED_HELD ); }
+	virtual DisabledMaskType getDisabledTypesToProcess() const override { return MAKE_DISABLED_MASK( DISABLED_HELD ); }
 
 	// ??? ugh
 	Bool isDisguised() const { return m_disguiseAsTemplate != nullptr; }

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/StealthUpgrade.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/StealthUpgrade.h
@@ -50,7 +50,7 @@ public:
 	// virtual destructor prototype defined by MemoryPoolObject
 
 protected:
-	virtual void upgradeImplementation( ); ///< Here's the actual work of Upgrading
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation( ) override; ///< Here's the actual work of Upgrading
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/StickyBombUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/StickyBombUpdate.h
@@ -78,9 +78,9 @@ public:
 	StickyBombUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onObjectCreated();
+	virtual void onObjectCreated() override;
 
-	virtual UpdateSleepTime update();							///< called once per frame
+	virtual UpdateSleepTime update() override;							///< called once per frame
 
 	void initStickyBomb( Object *object, const Object *bomber, const Coord3D *specificPos = nullptr );
 	void detonate();

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/StructureCollapseUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/StructureCollapseUpdate.h
@@ -109,13 +109,13 @@ public:
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_DIE); }
 
 	// BehaviorModule
-	virtual DieModuleInterface* getDie() { return this; }
+	virtual DieModuleInterface* getDie() override { return this; }
 
 	// UpdateModuleInterface
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	// DieModuleInterface
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/StructureToppleUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/StructureToppleUpdate.h
@@ -151,13 +151,13 @@ public:
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_DIE); }
 
 	// BehaviorModule
-	virtual DieModuleInterface* getDie() { return this; }
+	virtual DieModuleInterface* getDie() override { return this; }
 
 	// UpdateModuleInterface
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	// DieModuleInterface
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SubObjectsUpgrade.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SubObjectsUpgrade.h
@@ -81,7 +81,7 @@ public:
 	// virtual destructor prototype defined by MemoryPoolObject
 
 protected:
-	virtual void upgradeImplementation( ); ///< Here's the actual work of Upgrading
-	virtual Bool isSubObjectsUpgrade() { return true; }
+	virtual void upgradeImplementation( ) override; ///< Here's the actual work of Upgrading
+	virtual Bool isSubObjectsUpgrade() override { return true; }
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SubdualDamageHelper.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SubdualDamageHelper.h
@@ -52,8 +52,8 @@ public:
 	SubdualDamageHelper( Thing *thing, const ModuleData *modData );
 	// virtual destructor prototype provided by memory pool object
 
-	virtual DisabledMaskType getDisabledTypesToProcess() const { return DISABLEDMASK_ALL; }
-	virtual UpdateSleepTime update();
+	virtual DisabledMaskType getDisabledTypesToProcess() const override { return DISABLEDMASK_ALL; }
+	virtual UpdateSleepTime update() override;
 
 	void notifySubdualDamage( Real amount );
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SupplyCenterCreate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SupplyCenterCreate.h
@@ -48,8 +48,8 @@ public:
 	SupplyCenterCreate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onCreate();
-	virtual void onBuildComplete();	///< This is called when you are a finished game object
+	virtual void onCreate() override;
+	virtual void onBuildComplete() override;	///< This is called when you are a finished game object
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SupplyCenterDockUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SupplyCenterDockUpdate.h
@@ -57,10 +57,10 @@ public:
 
 	SupplyCenterDockUpdate( Thing *thing, const ModuleData* moduleData );
 
-	virtual DockUpdateInterface* getDockUpdateInterface() { return this; }
-	virtual Bool action( Object* docker, Object *drone = nullptr );	///<For me, this means taking boxes and turning them into money for my ownerplayer
+	virtual DockUpdateInterface* getDockUpdateInterface() override { return this; }
+	virtual Bool action( Object* docker, Object *drone = nullptr ) override;	///<For me, this means taking boxes and turning them into money for my ownerplayer
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SupplyCenterProductionExitUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SupplyCenterProductionExitUpdate.h
@@ -71,24 +71,24 @@ class SupplyCenterProductionExitUpdate : public UpdateModule, public ExitInterfa
 
 public:
 
-	virtual ExitInterface* getUpdateExitInterface() { return this; }
+	virtual ExitInterface* getUpdateExitInterface() override { return this; }
 
 	SupplyCenterProductionExitUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
 	// Required funcs to fulfill interface requirements
-	virtual Bool isExitBusy() const {return FALSE;}	///< Contain style exiters are getting the ability to space out exits, so ask this before reserveDoor as a kind of no-commitment check.
-	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject ) { return DOOR_1; }
-	virtual void exitObjectViaDoor( Object *newObj, ExitDoorType exitDoor );
-	virtual void unreserveDoorForExit( ExitDoorType exitDoor ) { /* nothing */ }
-	virtual void exitObjectByBudding( Object *newObj, Object *budHost ) { return; }
+	virtual Bool isExitBusy() const override {return FALSE;}	///< Contain style exiters are getting the ability to space out exits, so ask this before reserveDoor as a kind of no-commitment check.
+	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject ) override { return DOOR_1; }
+	virtual void exitObjectViaDoor( Object *newObj, ExitDoorType exitDoor ) override;
+	virtual void unreserveDoorForExit( ExitDoorType exitDoor ) override { /* nothing */ }
+	virtual void exitObjectByBudding( Object *newObj, Object *budHost ) override { return; }
 
-	virtual void setRallyPoint( const Coord3D *pos );			///< define a "rally point" for units to move towards
-	virtual const Coord3D *getRallyPoint() const;			///< define a "rally point" for units to move towards
-	virtual Bool getExitPosition( Coord3D& exitPosition ) const;					///< access to the "Door" position of the production object
-	virtual Bool getNaturalRallyPoint( Coord3D& rallyPoint, Bool offset = TRUE ) const;			///< get the natural "rally point" for units to move towards
+	virtual void setRallyPoint( const Coord3D *pos ) override;			///< define a "rally point" for units to move towards
+	virtual const Coord3D *getRallyPoint() const override;			///< define a "rally point" for units to move towards
+	virtual Bool getExitPosition( Coord3D& exitPosition ) const override;					///< access to the "Door" position of the production object
+	virtual Bool getNaturalRallyPoint( Coord3D& rallyPoint, Bool offset = TRUE ) const override;			///< get the natural "rally point" for units to move towards
 
-	virtual UpdateSleepTime update()										{ return UPDATE_SLEEP_FOREVER; }
+	virtual UpdateSleepTime update() override										{ return UPDATE_SLEEP_FOREVER; }
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SupplyTruckAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SupplyTruckAIUpdate.h
@@ -50,9 +50,9 @@ public:
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 };
 
 //-------------------------------------------------------------------------------------------------
@@ -61,15 +61,15 @@ class SupplyTruckWantsToPickUpOrDeliverBoxesState :  public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(SupplyTruckWantsToPickUpOrDeliverBoxesState, "SupplyTruckWantsToPickUpOrDeliverBoxesState")
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override{};
 
 public:
 	SupplyTruckWantsToPickUpOrDeliverBoxesState( StateMachine *machine ) : State( machine, "SupplyTruckWantsToPickUpOrDeliverBoxesState" ) {}
-	virtual StateReturnType update();
-	virtual StateReturnType onEnter();
-	virtual void onExit(StateExitType status);
+	virtual StateReturnType update() override;
+	virtual StateReturnType onEnter() override;
+	virtual void onExit(StateExitType status) override;
 };
 EMPTY_DTOR(SupplyTruckWantsToPickUpOrDeliverBoxesState)
 
@@ -79,14 +79,14 @@ class RegroupingState :  public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(RegroupingState, "RegroupingState")
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override{};
 public:
 	RegroupingState( StateMachine *machine ) : State( machine, "RegroupingState" ) {}
-	virtual StateReturnType update();
-	virtual StateReturnType onEnter();// Will tell me to aiMove back to base.
-	virtual void onExit(StateExitType status);
+	virtual StateReturnType update() override;
+	virtual StateReturnType onEnter() override;// Will tell me to aiMove back to base.
+	virtual void onExit(StateExitType status) override;
 };
 EMPTY_DTOR(RegroupingState)
 
@@ -96,14 +96,14 @@ class DockingState :  public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(DockingState, "DockingState")
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override{};
 public:
 	DockingState( StateMachine *machine ) :State( machine, "DockingState" ) {}
-	virtual StateReturnType update();
-	virtual StateReturnType onEnter();
-	virtual void onExit(StateExitType status);
+	virtual StateReturnType update() override;
+	virtual StateReturnType onEnter() override;
+	virtual void onExit(StateExitType status) override;
 };
 EMPTY_DTOR(DockingState)
 
@@ -193,36 +193,36 @@ public:
 	SupplyTruckAIUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual SupplyTruckAIInterface* getSupplyTruckAIInterface() {return this;}
-	virtual const SupplyTruckAIInterface* getSupplyTruckAIInterface() const {return this;}
+	virtual SupplyTruckAIInterface* getSupplyTruckAIInterface() override {return this;}
+	virtual const SupplyTruckAIInterface* getSupplyTruckAIInterface() const override {return this;}
 
-	virtual Int getNumberBoxes() const { return m_numberBoxes; }
-	virtual Bool loseOneBox();
-	virtual Bool gainOneBox( Int remainingStock );
+	virtual Int getNumberBoxes() const override { return m_numberBoxes; }
+	virtual Bool loseOneBox() override;
+	virtual Bool gainOneBox( Int remainingStock ) override;
 
 	// this is present for subclasses (eg, Chinook) to override, to
 	// prevent supply-ferry behavior in some cases (eg, when toting passengers)
-	virtual Bool isAvailableForSupplying() const;
-	virtual Bool isCurrentlyFerryingSupplies() const;
-	virtual Real getWarehouseScanDistance() const; ///< How far can I look for a warehouse?
+	virtual Bool isAvailableForSupplying() const override;
+	virtual Bool isCurrentlyFerryingSupplies() const override;
+	virtual Real getWarehouseScanDistance() const override; ///< How far can I look for a warehouse?
 
-	virtual void setForceWantingState(Bool v) { m_forcePending = v; } // When a Supply Center creates us (or maybe other sources later), we need to hop into autopilot mode.
-	virtual Bool isForcedIntoWantingState() const { return m_forcePending; }
+	virtual void setForceWantingState(Bool v) override { m_forcePending = v; } // When a Supply Center creates us (or maybe other sources later), we need to hop into autopilot mode.
+	virtual Bool isForcedIntoWantingState() const override { return m_forcePending; }
 
-	virtual void setForceBusyState(Bool v) { m_forcedBusyPending = v; }
-	virtual Bool isForcedIntoBusyState() const { return m_forcedBusyPending; }
+	virtual void setForceBusyState(Bool v) override { m_forcedBusyPending = v; }
+	virtual Bool isForcedIntoBusyState() const override { return m_forcedBusyPending; }
 
-	virtual ObjectID getPreferredDockID() const { return m_preferredDock; }
-	virtual UnsignedInt getActionDelayForDock( Object *dock );
-	virtual Int getUpgradedSupplyBoost() const { return 0; }
+	virtual ObjectID getPreferredDockID() const override { return m_preferredDock; }
+	virtual UnsignedInt getActionDelayForDock( Object *dock ) override;
+	virtual Int getUpgradedSupplyBoost() const override { return 0; }
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 protected:
 
-	virtual AIStateMachine* makeStateMachine();
-	virtual void privateDock( Object *obj, CommandSourceType cmdSource );
-	virtual void privateIdle(CommandSourceType cmdSource);						///< Enter idle state.
+	virtual AIStateMachine* makeStateMachine() override;
+	virtual void privateDock( Object *obj, CommandSourceType cmdSource ) override;
+	virtual void privateIdle(CommandSourceType cmdSource) override;						///< Enter idle state.
 
 private:
 	SupplyTruckStateMachine*	m_supplyTruckStateMachine;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SupplyTruckAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SupplyTruckAIUpdate.h
@@ -61,9 +61,9 @@ class SupplyTruckWantsToPickUpOrDeliverBoxesState :  public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(SupplyTruckWantsToPickUpOrDeliverBoxesState, "SupplyTruckWantsToPickUpOrDeliverBoxesState")
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ) override{};
-	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess() override{};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 
 public:
 	SupplyTruckWantsToPickUpOrDeliverBoxesState( StateMachine *machine ) : State( machine, "SupplyTruckWantsToPickUpOrDeliverBoxesState" ) {}
@@ -79,9 +79,9 @@ class RegroupingState :  public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(RegroupingState, "RegroupingState")
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ) override{};
-	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess() override{};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 public:
 	RegroupingState( StateMachine *machine ) : State( machine, "RegroupingState" ) {}
 	virtual StateReturnType update() override;
@@ -96,9 +96,9 @@ class DockingState :  public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(DockingState, "DockingState")
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ) override{};
-	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess() override{};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 public:
 	DockingState( StateMachine *machine ) :State( machine, "DockingState" ) {}
 	virtual StateReturnType update() override;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SupplyWarehouseCreate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SupplyWarehouseCreate.h
@@ -48,7 +48,7 @@ public:
 	SupplyWarehouseCreate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onCreate();
+	virtual void onCreate() override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SupplyWarehouseCripplingBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SupplyWarehouseCripplingBehavior.h
@@ -68,15 +68,15 @@ public:
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_DAMAGE); }
 
 	// BehaviorModule
-	virtual DamageModuleInterface* getDamage() { return this; }
+	virtual DamageModuleInterface* getDamage() override { return this; }
 
 	// DamageModuleInterface
-	virtual void onDamage( DamageInfo *damageInfo );
-	virtual void onHealing( DamageInfo *damageInfo ){}
-	virtual void onBodyDamageStateChange(const DamageInfo* damageInfo, BodyDamageType oldState, BodyDamageType newState);
+	virtual void onDamage( DamageInfo *damageInfo ) override;
+	virtual void onHealing( DamageInfo *damageInfo ) override{}
+	virtual void onBodyDamageStateChange(const DamageInfo* damageInfo, BodyDamageType oldState, BodyDamageType newState) override;
 
 	// UpdateInterface
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 protected:
 	virtual void resetSelfHealSupression();// Reset our able to heal timer, as we took damage

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SupplyWarehouseCripplingBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SupplyWarehouseCripplingBehavior.h
@@ -72,7 +72,7 @@ public:
 
 	// DamageModuleInterface
 	virtual void onDamage( DamageInfo *damageInfo ) override;
-	virtual void onHealing( DamageInfo *damageInfo ) override{}
+	virtual void onHealing( DamageInfo *damageInfo ) override {}
 	virtual void onBodyDamageStateChange(const DamageInfo* damageInfo, BodyDamageType oldState, BodyDamageType newState) override;
 
 	// UpdateInterface

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SupplyWarehouseDockUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SupplyWarehouseDockUpdate.h
@@ -57,18 +57,18 @@ class SupplyWarehouseDockUpdate : public DockUpdate
 
 public:
 
-	virtual DockUpdateInterface* getDockUpdateInterface() { return this; }
+	virtual DockUpdateInterface* getDockUpdateInterface() override { return this; }
 
 	SupplyWarehouseDockUpdate( Thing *thing, const ModuleData* moduleData );
 
-	virtual void setDockCrippled( Bool setting ); ///< Game Logic can set me as inoperative.  I get to decide what that means.
-	virtual Bool action( Object* docker, Object *drone = nullptr );	///<For me, this means identifying who is docking and either taking Boxes away or giving them
+	virtual void setDockCrippled( Bool setting ) override; ///< Game Logic can set me as inoperative.  I get to decide what that means.
+	virtual Bool action( Object* docker, Object *drone = nullptr ) override;	///<For me, this means identifying who is docking and either taking Boxes away or giving them
 
 	Int getBoxesStored() const { return m_boxesStored; }
 
 	void setCashValue( Int cashValue );
 
-	virtual void onObjectCreated();
+	virtual void onObjectCreated() override;
 protected:
 
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/TechBuildingBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/TechBuildingBehavior.h
@@ -64,15 +64,15 @@ public:
 	// virtual destructor prototype provided by memory pool object
 
 	// module methods
-	virtual void onCapture( Player *oldOwner, Player *newOwner );
+	virtual void onCapture( Player *oldOwner, Player *newOwner ) override;
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_DIE); }
 
 	// update methods
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	// die methods
-	virtual DieModuleInterface *getDie() { return this; }
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual DieModuleInterface *getDie() override { return this; }
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/TempWeaponBonusHelper.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/TempWeaponBonusHelper.h
@@ -54,8 +54,8 @@ public:
 	TempWeaponBonusHelper( Thing *thing, const ModuleData *modData );
 	// virtual destructor prototype provided by memory pool object
 
-	virtual DisabledMaskType getDisabledTypesToProcess() const { return DISABLEDMASK_ALL; }
-	virtual UpdateSleepTime update();
+	virtual DisabledMaskType getDisabledTypesToProcess() const override { return DISABLEDMASK_ALL; }
+	virtual UpdateSleepTime update() override;
 
 	void doTempWeaponBonus( WeaponBonusConditionType status, UnsignedInt duration );
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/TensileFormationUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/TensileFormationUpdate.h
@@ -63,7 +63,7 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	void setEnabled( Bool enabled ) { m_enabled = enabled; }  ///< enable/disable formation
-	virtual UpdateSleepTime update();	///< Deciding whether or not to make new guys
+	virtual UpdateSleepTime update() override;	///< Deciding whether or not to make new guys
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ToppleUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ToppleUpdate.h
@@ -86,23 +86,23 @@ public:
 	static Int getInterfaceMask() { return UpdateModule::getInterfaceMask() | (MODULEINTERFACE_COLLIDE); }
 
 	// BehaviorModule
-	virtual CollideModuleInterface* getCollide() { return this; }
+	virtual CollideModuleInterface* getCollide() override { return this; }
 
 	void applyTopplingForce( const Coord3D* toppleDirection, Real toppleSpeed, UnsignedInt options);
 	Bool isAbleToBeToppled() const;
 
 	// UpdateModuleInterface
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 	// CollideModuleInterface
-	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal );
+	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal ) override;
 	/// this is used for things like pilots, to determine if they can "enter" something
-	virtual Bool wouldLikeToCollideWith(const Object* other) const { return false; }
-	virtual Bool isHijackedVehicleCrateCollide() const { return false; }
-	virtual Bool isCarBombCrateCollide() const { return false; }
-	virtual Bool isRailroad() const { return false; }
-	virtual Bool isSalvageCrateCollide() const { return false; }
-	virtual Bool isSabotageBuildingCrateCollide() const { return FALSE; }
+	virtual Bool wouldLikeToCollideWith(const Object* other) const override { return false; }
+	virtual Bool isHijackedVehicleCrateCollide() const override { return false; }
+	virtual Bool isCarBombCrateCollide() const override { return false; }
+	virtual Bool isRailroad() const override { return false; }
+	virtual Bool isSalvageCrateCollide() const override { return false; }
+	virtual Bool isSabotageBuildingCrateCollide() const override { return FALSE; }
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/TransitionDamageFX.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/TransitionDamageFX.h
@@ -248,11 +248,11 @@ public:
 	TransitionDamageFX( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onDamage( DamageInfo *damageInfo ) { }
-	virtual void onHealing( DamageInfo *damageInfo ) { }
+	virtual void onDamage( DamageInfo *damageInfo ) override { }
+	virtual void onHealing( DamageInfo *damageInfo ) override { }
 	virtual void onBodyDamageStateChange( const DamageInfo* damageInfo,
 																				BodyDamageType oldState,
-																				BodyDamageType newState );
+																				BodyDamageType newState ) override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/TransportAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/TransportAIUpdate.h
@@ -51,14 +51,14 @@ public:
 
 	TransportAIUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
-	virtual AIFreeToExitType getAiFreeToExit(const Object* exiter) const;
+	virtual AIFreeToExitType getAiFreeToExit(const Object* exiter) const override;
 
 protected:
 
-	virtual AIStateMachine* makeStateMachine();
+	virtual AIStateMachine* makeStateMachine() override;
 
 protected:
-	virtual void privateAttackObject( Object *victim, Int maxShotsToFire, CommandSourceType cmdSource );///< Extension.  Also tell occupants to attackObject
-	virtual void privateAttackPosition( const Coord3D *pos, Int maxShotsToFire, CommandSourceType cmdSource );///< Extension.  Also tell occupants to attackPosition
-	virtual void privateForceAttackObject( Object *victim, Int maxShotsToFire, CommandSourceType cmdSource );///< Extension.  Also tell occupants to forceAttackObject
+	virtual void privateAttackObject( Object *victim, Int maxShotsToFire, CommandSourceType cmdSource ) override;///< Extension.  Also tell occupants to attackObject
+	virtual void privateAttackPosition( const Coord3D *pos, Int maxShotsToFire, CommandSourceType cmdSource ) override;///< Extension.  Also tell occupants to attackPosition
+	virtual void privateForceAttackObject( Object *victim, Int maxShotsToFire, CommandSourceType cmdSource ) override;///< Extension.  Also tell occupants to forceAttackObject
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/TransportContain.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/TransportContain.h
@@ -76,31 +76,31 @@ public:
 	TransportContain( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual Bool isValidContainerFor( const Object* obj, Bool checkCapacity) const;
+	virtual Bool isValidContainerFor( const Object* obj, Bool checkCapacity) const override;
 
-	virtual void onCapture( Player *oldOwner, Player *newOwner ); // have to kick everyone out on capture.
-	virtual void onContaining( Object *obj, Bool wasSelected );		///< object now contains 'obj'
-	virtual void onRemoving( Object *obj );			///< object no longer contains 'obj'
-	virtual UpdateSleepTime update();							///< called once per frame
+	virtual void onCapture( Player *oldOwner, Player *newOwner ) override; // have to kick everyone out on capture.
+	virtual void onContaining( Object *obj, Bool wasSelected ) override;		///< object now contains 'obj'
+	virtual void onRemoving( Object *obj ) override;			///< object no longer contains 'obj'
+	virtual UpdateSleepTime update() override;							///< called once per frame
 
-	virtual Bool isRiderChangeContain() const { return FALSE; }
-  virtual Bool isSpecialOverlordStyleContainer() const {return FALSE;}
+	virtual Bool isRiderChangeContain() const override { return FALSE; }
+  virtual Bool isSpecialOverlordStyleContainer() const override {return FALSE;}
 
-	virtual Int getContainMax() const;
+	virtual Int getContainMax() const override;
 
-	virtual Int getExtraSlotsInUse() { return m_extraSlotsInUse; }///< Transports have the ability to carry guys how take up more than spot.
+	virtual Int getExtraSlotsInUse() override { return m_extraSlotsInUse; }///< Transports have the ability to carry guys how take up more than spot.
 
-	virtual Bool isExitBusy() const;	///< Contain style exiters are getting the ability to space out exits, so ask this before reserveDoor as a kind of no-commitment check.
-	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject );
-	virtual void unreserveDoorForExit( ExitDoorType exitDoor );
-	virtual Bool isDisplayedOnControlBar() const {return TRUE;}///< Does this container display its contents on the ControlBar?
+	virtual Bool isExitBusy() const override;	///< Contain style exiters are getting the ability to space out exits, so ask this before reserveDoor as a kind of no-commitment check.
+	virtual ExitDoorType reserveDoorForExit( const ThingTemplate* objType, Object *specificObject ) override;
+	virtual void unreserveDoorForExit( ExitDoorType exitDoor ) override;
+	virtual Bool isDisplayedOnControlBar() const override {return TRUE;}///< Does this container display its contents on the ControlBar?
 
 protected:
 
 	// exists primarily for TransportContain to override
-	virtual void killRidersWhoAreNotFreeToExit();
+	virtual void killRidersWhoAreNotFreeToExit() override;
 	virtual Bool isSpecificRiderFreeToExit(Object* obj);
-	virtual Bool isPassengerAllowedToFire( ObjectID id = INVALID_ID ) const;	///< Hey, can I shoot out of this container?
+	virtual Bool isPassengerAllowedToFire( ObjectID id = INVALID_ID ) const override;	///< Hey, can I shoot out of this container?
 
 	virtual void createPayload();
 	void letRidersUpgradeWeaponSet();

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/TunnelContain.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/TunnelContain.h
@@ -83,53 +83,53 @@ public:
 	TunnelContain( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual CreateModuleInterface* getCreate() { return this; }
+	virtual CreateModuleInterface* getCreate() override { return this; }
 	static Int getInterfaceMask() { return OpenContain::getInterfaceMask() | (MODULEINTERFACE_CREATE); }
 
-	virtual OpenContain *asOpenContain() { return this; }  ///< treat as open container
-	virtual Bool isGarrisonable() const { return false; }	///< can this unit be Garrisoned? (ick)
-	virtual Bool isBustable() const { return TRUE; }	///< can this container get busted by a bunkerbuster
-	virtual Bool isHealContain() const { return false; } ///< true when container only contains units while healing (not a transport!)
-	virtual Bool isTunnelContain() const { return TRUE; }
-	virtual Bool isImmuneToClearBuildingAttacks() const { return true; }
-  virtual Bool isSpecialOverlordStyleContainer() const {return FALSE;}
+	virtual OpenContain *asOpenContain() override { return this; }  ///< treat as open container
+	virtual Bool isGarrisonable() const override { return false; }	///< can this unit be Garrisoned? (ick)
+	virtual Bool isBustable() const override { return TRUE; }	///< can this container get busted by a bunkerbuster
+	virtual Bool isHealContain() const override { return false; } ///< true when container only contains units while healing (not a transport!)
+	virtual Bool isTunnelContain() const override { return TRUE; }
+	virtual Bool isImmuneToClearBuildingAttacks() const override { return true; }
+  virtual Bool isSpecialOverlordStyleContainer() const override {return FALSE;}
 
-	virtual void onContaining( Object *obj, Bool wasSelected );		///< object now contains 'obj'
-	virtual void onRemoving( Object *obj );			///< object no longer contains 'obj'
-	virtual void onSelling();///< Container is being sold.  Tunnel responds by kicking people out if this is the last tunnel.
-	virtual void onCapture( Player *oldOwner, Player *newOwner ); // Need to change who we are registered with.
+	virtual void onContaining( Object *obj, Bool wasSelected ) override;		///< object now contains 'obj'
+	virtual void onRemoving( Object *obj ) override;			///< object no longer contains 'obj'
+	virtual void onSelling() override;///< Container is being sold.  Tunnel responds by kicking people out if this is the last tunnel.
+	virtual void onCapture( Player *oldOwner, Player *newOwner ) override; // Need to change who we are registered with.
 
-	virtual void orderAllPassengersToExit( CommandSourceType commandSource, Bool instantly ); ///< All of the smarts of exiting are in the passenger's AIExit. removeAllFrommContain is a last ditch system call, this is the game Evacuate
-	virtual void orderAllPassengersToIdle( CommandSourceType commandSource ); ///< Just like it sounds
+	virtual void orderAllPassengersToExit( CommandSourceType commandSource, Bool instantly ) override; ///< All of the smarts of exiting are in the passenger's AIExit. removeAllFrommContain is a last ditch system call, this is the game Evacuate
+	virtual void orderAllPassengersToIdle( CommandSourceType commandSource ) override; ///< Just like it sounds
 
-	virtual Bool isValidContainerFor(const Object* obj, Bool checkCapacity) const;
+	virtual Bool isValidContainerFor(const Object* obj, Bool checkCapacity) const override;
 	virtual void addToContainList( Object *obj );		///< The part of AddToContain that inheritors can override (Can't do whole thing because of all the private stuff involved)
-	virtual void removeFromContain( Object *obj, Bool exposeStealthUnits = FALSE );	///< remove 'obj' from contain list
-	virtual void removeAllContained( Bool exposeStealthUnits = FALSE );				///< remove all objects on contain list
-  virtual void harmAndForceExitAllContained( DamageInfo *info );
-  virtual void killAllContained();				///< kill all objects on contain list
+	virtual void removeFromContain( Object *obj, Bool exposeStealthUnits = FALSE ) override;	///< remove 'obj' from contain list
+	virtual void removeAllContained( Bool exposeStealthUnits = FALSE ) override;				///< remove all objects on contain list
+  virtual void harmAndForceExitAllContained( DamageInfo *info ) override;
+  virtual void killAllContained() override;				///< kill all objects on contain list
 
 	// contain list access
-	virtual void iterateContained( ContainIterateFunc func, void *userData, Bool reverse );
-	virtual UnsignedInt getContainCount() const;
-	virtual UnsignedInt getHeroUnitsContained() const;
-	virtual Int getContainMax() const;
-	virtual const ContainedItemsList* getContainedItemsList() const;
+	virtual void iterateContained( ContainIterateFunc func, void *userData, Bool reverse ) override;
+	virtual UnsignedInt getContainCount() const override;
+	virtual UnsignedInt getHeroUnitsContained() const override;
+	virtual Int getContainMax() const override;
+	virtual const ContainedItemsList* getContainedItemsList() const override;
 	virtual UnsignedInt getFullTimeForHeal() const; ///< Returns the time in frames until a contained object becomes fully healed
-	virtual Bool isDisplayedOnControlBar() const { return TRUE; } ///< Does this container display its contents on the ControlBar?
-	virtual Bool isKickOutOnCapture(){ return FALSE; }///< Caves and Tunnels don't kick out on capture.
+	virtual Bool isDisplayedOnControlBar() const override { return TRUE; } ///< Does this container display its contents on the ControlBar?
+	virtual Bool isKickOutOnCapture() override { return FALSE; }///< Caves and Tunnels don't kick out on capture.
 
 	// override the onDie we inherit from OpenContain
-	virtual void onDie( const DamageInfo *damageInfo );  ///< the die callback
+	virtual void onDie( const DamageInfo *damageInfo ) override;  ///< the die callback
 
-	virtual void onDelete();
-	virtual void onCreate();
-	virtual void onObjectCreated();
-	virtual void onBuildComplete();
-	virtual Bool shouldDoOnBuildComplete() const { return m_needToRunOnBuildComplete; }
+	virtual void onDelete() override;
+	virtual void onCreate() override;
+	virtual void onObjectCreated() override;
+	virtual void onBuildComplete() override;
+	virtual Bool shouldDoOnBuildComplete() const override { return m_needToRunOnBuildComplete; }
 
 	// so that the ppl within the tunnel network can get healed
-	virtual UpdateSleepTime update();												///< called once per frame
+	virtual UpdateSleepTime update() override;												///< called once per frame
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/UndeadBody.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/UndeadBody.h
@@ -59,7 +59,7 @@ public:
 	UndeadBody( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void attemptDamage( DamageInfo *damageInfo );		///< try to damage this object
+	virtual void attemptDamage( DamageInfo *damageInfo ) override;		///< try to damage this object
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/UnitCrateCollide.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/UnitCrateCollide.h
@@ -76,7 +76,7 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	/// This is the game logic execution function that all real CrateCollides will implement
-	virtual Bool executeCrateBehavior( Object *other );
+	virtual Bool executeCrateBehavior( Object *other ) override;
 protected:
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/UnpauseSpecialPowerUpgrade.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/UnpauseSpecialPowerUpgrade.h
@@ -68,7 +68,7 @@ public:
 
 protected:
 
-	virtual void upgradeImplementation(); ///< Here's the actual work of Upgrading
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation() override; ///< Here's the actual work of Upgrading
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/UpdateModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/UpdateModule.h
@@ -167,12 +167,12 @@ public:
 	static Int getInterfaceMask() { return (MODULEINTERFACE_UPDATE); }
 
 	// BehaviorModule
-	virtual UpdateModuleInterface* getUpdate() { return this; }
+	virtual UpdateModuleInterface* getUpdate() override { return this; }
 
 	// UpdateModuleInterface
-	virtual UpdateSleepTime update() = 0;
+	virtual UpdateSleepTime update() override = 0;
 
-	DisabledMaskType getDisabledTypesToProcess() const
+	virtual DisabledMaskType getDisabledTypesToProcess() const override
 	{
 		return DISABLEDMASK_NONE;
 	}

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/UpdateModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/UpdateModule.h
@@ -170,7 +170,7 @@ public:
 	virtual UpdateModuleInterface* getUpdate() override { return this; }
 
 	// UpdateModuleInterface
-	virtual UpdateSleepTime update() override = 0;
+	virtual UpdateSleepTime update() = 0;
 
 	virtual DisabledMaskType getDisabledTypesToProcess() const override
 	{

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/UpgradeDie.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/UpgradeDie.h
@@ -72,6 +72,6 @@ public:
 	UpgradeDie( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void onDie( const DamageInfo *damageInfo );
+	virtual void onDie( const DamageInfo *damageInfo ) override;
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/UpgradeModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/UpgradeModule.h
@@ -116,13 +116,13 @@ public:
 
 	UpgradeMux();
 
-	virtual Bool isAlreadyUpgraded() const ;
+	virtual Bool isAlreadyUpgraded() const override ;
 	// ***DANGER! DANGER! Don't use this, unless you are forcing an already made upgrade to refresh!!
-	virtual void forceRefreshUpgrade();
-	virtual Bool attemptUpgrade( const UpgradeMaskType& keyMask );
-	virtual Bool wouldUpgrade( const UpgradeMaskType& keyMask ) const;
-	virtual Bool resetUpgrade( const UpgradeMaskType& keyMask );
-	virtual Bool testUpgradeConditions( const UpgradeMaskType& keyMask ) const;
+	virtual void forceRefreshUpgrade() override;
+	virtual Bool attemptUpgrade( const UpgradeMaskType& keyMask ) override;
+	virtual Bool wouldUpgrade( const UpgradeMaskType& keyMask ) const override;
+	virtual Bool resetUpgrade( const UpgradeMaskType& keyMask ) override;
+	virtual Bool testUpgradeConditions( const UpgradeMaskType& keyMask ) const override;
 
 protected:
 
@@ -131,7 +131,7 @@ protected:
 	virtual void getUpgradeActivationMasks(UpgradeMaskType& activation, UpgradeMaskType& conflicting) const = 0; ///< Here's the actual work of Upgrading
 	virtual void performUpgradeFX() = 0;	///< perform the associated fx list
 	virtual Bool requiresAllActivationUpgrades() const = 0;
-	virtual Bool isSubObjectsUpgrade() = 0;
+	virtual Bool isSubObjectsUpgrade() override = 0;
 	virtual void processUpgradeRemoval() = 0;
 
 	void giveSelfUpgrade();
@@ -180,29 +180,29 @@ public:
 	static Int getInterfaceMask() { return MODULEINTERFACE_UPGRADE; }
 
 	// BehaviorModule
-	virtual UpgradeModuleInterface* getUpgrade() { return this; }
+	virtual UpgradeModuleInterface* getUpgrade() override { return this; }
 
 	bool isTriggeredBy(const std::string & upgrade) const { return getUpgradeModuleData()->m_upgradeMuxData.isTriggeredBy(upgrade); }
 
 protected:
 
-	virtual void processUpgradeRemoval()
+	virtual void processUpgradeRemoval() override
 	{
 		// I can't take it any more.  Let the record show that I think the UpgradeMux multiple inheritance is CRAP.
 		getUpgradeModuleData()->m_upgradeMuxData.muxDataProcessUpgradeRemoval(getObject());
 	}
 
-	virtual Bool requiresAllActivationUpgrades() const
+	virtual Bool requiresAllActivationUpgrades() const override
 	{
 		return getUpgradeModuleData()->m_upgradeMuxData.m_requiresAllTriggers;
 	}
 
-	virtual void getUpgradeActivationMasks(UpgradeMaskType& activation, UpgradeMaskType& conflicting) const
+	virtual void getUpgradeActivationMasks(UpgradeMaskType& activation, UpgradeMaskType& conflicting) const override
 	{
 		getUpgradeModuleData()->m_upgradeMuxData.getUpgradeActivationMasks(activation, conflicting);
 	}
 
-	virtual void performUpgradeFX()
+	virtual void performUpgradeFX() override
 	{
 		getUpgradeModuleData()->m_upgradeMuxData.performUpgradeFX(getObject());
 	}

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/UpgradeModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/UpgradeModule.h
@@ -131,7 +131,7 @@ protected:
 	virtual void getUpgradeActivationMasks(UpgradeMaskType& activation, UpgradeMaskType& conflicting) const = 0; ///< Here's the actual work of Upgrading
 	virtual void performUpgradeFX() = 0;	///< perform the associated fx list
 	virtual Bool requiresAllActivationUpgrades() const = 0;
-	virtual Bool isSubObjectsUpgrade() override = 0;
+	virtual Bool isSubObjectsUpgrade() = 0;
 	virtual void processUpgradeRemoval() = 0;
 
 	void giveSelfUpgrade();

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/VeterancyCrateCollide.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/VeterancyCrateCollide.h
@@ -82,10 +82,10 @@ public:
 protected:
 
 	/// This allows specific vetoes to certain types of crates and their data
-	virtual Bool isValidToExecute( const Object *other ) const;
+	virtual Bool isValidToExecute( const Object *other ) const override;
 
 	/// This is the game logic execution function that all real CrateCollides will implement
-	virtual Bool executeCrateBehavior( Object *other );
+	virtual Bool executeCrateBehavior( Object *other ) override;
 
 	Int getLevelsToGain() const;
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/VeterancyGainCreate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/VeterancyGainCreate.h
@@ -62,7 +62,7 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	/// the create method
-	virtual void onCreate();
+	virtual void onCreate() override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/WanderAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/WanderAIUpdate.h
@@ -47,7 +47,7 @@ class WanderAIUpdate : public AIUpdateInterface
 		for an example.)
 	*/
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 public:
 
@@ -57,6 +57,6 @@ public:
 
 protected:
 
-	virtual AIStateMachine* makeStateMachine();
+	virtual AIStateMachine* makeStateMachine() override;
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/WaveGuideUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/WaveGuideUpdate.h
@@ -77,7 +77,7 @@ public:
   WaveGuideUpdate( Thing *thing, const ModuleData *moduleData );
 	// virtual destructor prototype provided by MemoryPoolObject
 
-	virtual UpdateSleepTime update();		///< the update implementation
+	virtual UpdateSleepTime update() override;		///< the update implementation
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/WeaponBonusUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/WeaponBonusUpdate.h
@@ -91,7 +91,7 @@ public:
 	WeaponBonusUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual UpdateSleepTime update();
+	virtual UpdateSleepTime update() override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/WeaponBonusUpgrade.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/WeaponBonusUpgrade.h
@@ -75,8 +75,8 @@ public:
 	// virtual destructor prototype defined by MemoryPoolObject
 
 protected:
-	virtual void upgradeImplementation( ); ///< Here's the actual work of Upgrading
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation( ) override; ///< Here's the actual work of Upgrading
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 };
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/WeaponSetUpgrade.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/WeaponSetUpgrade.h
@@ -50,7 +50,7 @@ public:
 	// virtual destructor prototype defined by MemoryPoolObject
 
 protected:
-	virtual void upgradeImplementation( ); ///< Here's the actual work of Upgrading
-	virtual Bool isSubObjectsUpgrade() { return false; }
+	virtual void upgradeImplementation( ) override; ///< Here's the actual work of Upgrading
+	virtual Bool isSubObjectsUpgrade() override { return false; }
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/WorkerAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/WorkerAIUpdate.h
@@ -50,9 +50,9 @@ public:
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 };
 
 // ------------------------------------------------------------------------------------------------
@@ -126,93 +126,93 @@ public:
 	WorkerAIUpdate( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual DozerAIInterface* getDozerAIInterface() {return this;}
-	virtual const DozerAIInterface* getDozerAIInterface() const {return this;}
-	virtual SupplyTruckAIInterface* getSupplyTruckAIInterface() {return this;}
-	virtual const SupplyTruckAIInterface* getSupplyTruckAIInterface() const {return this;}
-	virtual WorkerAIInterface* getWorkerAIInterface() { return this; }
-	virtual const WorkerAIInterface* getWorkerAIInterface() const { return this; }
+	virtual DozerAIInterface* getDozerAIInterface() override {return this;}
+	virtual const DozerAIInterface* getDozerAIInterface() const override {return this;}
+	virtual SupplyTruckAIInterface* getSupplyTruckAIInterface() override {return this;}
+	virtual const SupplyTruckAIInterface* getSupplyTruckAIInterface() const override {return this;}
+	virtual WorkerAIInterface* getWorkerAIInterface() override { return this; }
+	virtual const WorkerAIInterface* getWorkerAIInterface() const override { return this; }
 
 	// Dozer side
-	virtual void onDelete();
+	virtual void onDelete() override;
 
-	virtual Real getRepairHealthPerSecond() const;	///< get health to repair per second
-	virtual Real getBoredTime() const;							///< how long till we're bored
-	virtual Real getBoredRange() const;							///< when we're bored, we look this far away to do things
+	virtual Real getRepairHealthPerSecond() const override;	///< get health to repair per second
+	virtual Real getBoredTime() const override;							///< how long till we're bored
+	virtual Real getBoredRange() const override;							///< when we're bored, we look this far away to do things
 
 	virtual Object *construct( const ThingTemplate *what,
 														 const Coord3D *pos, Real angle,
 														 Player *owningPlayer,
-														 Bool isRebuild );			///< construct a building
+														 Bool isRebuild ) override;			///< construct a building
 
 	// get task information
-	virtual DozerTask getMostRecentCommand();				///< return task that was most recently issued
-	virtual Bool isTaskPending( DozerTask task );					///< is there a desire to do the requested task
-	virtual ObjectID getTaskTarget( DozerTask task );			///< get target of task
-	virtual Bool isAnyTaskPending();								///< is there any dozer task pending
-	virtual DozerTask getCurrentTask() const { return m_currentTask; }	///< return the current task we're doing
-	virtual void setCurrentTask( DozerTask task ) { m_currentTask = task; }		///< set the current task of the dozer
+	virtual DozerTask getMostRecentCommand() override;				///< return task that was most recently issued
+	virtual Bool isTaskPending( DozerTask task ) override;					///< is there a desire to do the requested task
+	virtual ObjectID getTaskTarget( DozerTask task ) override;			///< get target of task
+	virtual Bool isAnyTaskPending() override;								///< is there any dozer task pending
+	virtual DozerTask getCurrentTask() const override { return m_currentTask; }	///< return the current task we're doing
+	virtual void setCurrentTask( DozerTask task ) override { m_currentTask = task; }		///< set the current task of the dozer
 
-	virtual Bool getIsRebuild() { return m_isRebuild; } ///< get whether or not our task is a rebuild.
+	virtual Bool getIsRebuild() override { return m_isRebuild; } ///< get whether or not our task is a rebuild.
 
 	// task actions
-	virtual void newTask( DozerTask task, Object* target );	///< set a desire to do the requested task
-	virtual void cancelTask( DozerTask task );						///< cancel this task from the queue, if it's the current task the dozer will stop working on it
-	virtual void cancelAllTasks();												///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
-	virtual void resumePreviousTask();									///< resume the previous task if there was one
+	virtual void newTask( DozerTask task, Object* target ) override;	///< set a desire to do the requested task
+	virtual void cancelTask( DozerTask task ) override;						///< cancel this task from the queue, if it's the current task the dozer will stop working on it
+	virtual void cancelAllTasks() override;												///< cancel all tasks from the queue, if it's the current task the dozer will stop working on it
+	virtual void resumePreviousTask() override;									///< resume the previous task if there was one
 
 	// internal methods to manage behavior from within the dozer state machine
-	virtual void internalTaskComplete( DozerTask task );					///< set a dozer task as successfully completed
-	virtual void internalCancelTask( DozerTask task );						///< cancel this task from the dozer
-	virtual void internalTaskCompleteOrCancelled( DozerTask task );	///< this is called when tasks are cancelled or completed
+	virtual void internalTaskComplete( DozerTask task ) override;					///< set a dozer task as successfully completed
+	virtual void internalCancelTask( DozerTask task ) override;						///< cancel this task from the dozer
+	virtual void internalTaskCompleteOrCancelled( DozerTask task ) override;	///< this is called when tasks are cancelled or completed
 
 	/** return a dock point for the action and task (if valid) ... note it can return nullptr
 	if no point has been set for the combination of task and point */
-	virtual const Coord3D* getDockPoint( DozerTask task, DozerDockPoint point );
+	virtual const Coord3D* getDockPoint( DozerTask task, DozerDockPoint point ) override;
 
-	virtual void setBuildSubTask( DozerBuildSubTask subTask ) { m_buildSubTask = subTask; };
-	virtual DozerBuildSubTask getBuildSubTask() { return m_buildSubTask; }
+	virtual void setBuildSubTask( DozerBuildSubTask subTask ) override { m_buildSubTask = subTask; };
+	virtual DozerBuildSubTask getBuildSubTask() override { return m_buildSubTask; }
 	//
 	// the following methods must be overridden so that if a player issues a command the dozer
 	// can exit the internal state machine and do whatever the player says
 	//
-	virtual void aiDoCommand(const AICommandParms* parms);
+	virtual void aiDoCommand(const AICommandParms* parms) override;
 
 // Supply truck stuff
-	virtual Int getNumberBoxes() const { return m_numberBoxes; }
-	virtual Bool loseOneBox();
-	virtual Bool gainOneBox( Int remainingStock );
+	virtual Int getNumberBoxes() const override { return m_numberBoxes; }
+	virtual Bool loseOneBox() override;
+	virtual Bool gainOneBox( Int remainingStock ) override;
 
-	virtual Bool isAvailableForSupplying() const;
-	virtual Bool isCurrentlyFerryingSupplies() const;
-	virtual Real getWarehouseScanDistance() const; ///< How far can I look for a warehouse?
+	virtual Bool isAvailableForSupplying() const override;
+	virtual Bool isCurrentlyFerryingSupplies() const override;
+	virtual Real getWarehouseScanDistance() const override; ///< How far can I look for a warehouse?
 
-	virtual void setForceBusyState(Bool v) { m_forcedBusyPending = v; }
-	virtual Bool isForcedIntoBusyState() const { return m_forcedBusyPending; }
+	virtual void setForceBusyState(Bool v) override { m_forcedBusyPending = v; }
+	virtual Bool isForcedIntoBusyState() const override { return m_forcedBusyPending; }
 
-	virtual void setForceWantingState(Bool v){ m_forcePending = v; }
-	virtual Bool isForcedIntoWantingState() const { return m_forcePending; }
-	virtual ObjectID getPreferredDockID() const { return m_preferredDock; }
-	virtual UnsignedInt getActionDelayForDock( Object *dock );
+	virtual void setForceWantingState(Bool v) override { m_forcePending = v; }
+	virtual Bool isForcedIntoWantingState() const override { return m_forcePending; }
+	virtual ObjectID getPreferredDockID() const override { return m_preferredDock; }
+	virtual UnsignedInt getActionDelayForDock( Object *dock ) override;
 
 // worker specific
 	Bool isSupplyTruckBrainActiveAndBusy();
 	void resetSupplyTruckBrain();
 	void resetDozerBrain();
 
-	virtual void exitingSupplyTruckState(); ///< This worker is leaving a supply truck task and should go back to Dozer mode.
+	virtual void exitingSupplyTruckState() override; ///< This worker is leaving a supply truck task and should go back to Dozer mode.
 
-	virtual UpdateSleepTime update();				///< the update entry point
+	virtual UpdateSleepTime update() override;				///< the update entry point
 
 	// repairing
-	virtual Bool canAcceptNewRepair( Object *obj );
-	virtual void createBridgeScaffolding( Object *bridgeTower );
-	virtual void removeBridgeScaffolding( Object *bridgeTower );
+	virtual Bool canAcceptNewRepair( Object *obj ) override;
+	virtual void createBridgeScaffolding( Object *bridgeTower ) override;
+	virtual void removeBridgeScaffolding( Object *bridgeTower ) override;
 
-	virtual void startBuildingSound( const AudioEventRTS *sound, ObjectID constructionSiteID );
-	virtual void finishBuildingSound();
+	virtual void startBuildingSound( const AudioEventRTS *sound, ObjectID constructionSiteID ) override;
+	virtual void finishBuildingSound() override;
 
-	virtual Int getUpgradedSupplyBoost() const;
+	virtual Int getUpgradedSupplyBoost() const override;
 
 protected:
 
@@ -264,10 +264,10 @@ protected:
 	AudioEventRTS	m_buildingSound;			///< sound is pulled from the object we are building!
 
 protected:
-	virtual void privateRepair( Object *obj, CommandSourceType cmdSource );	///< repair the target
-	virtual void privateResumeConstruction( Object *obj, CommandSourceType cmdSource );  ///< resume construction on obj
-	virtual void privateDock( Object *obj, CommandSourceType cmdSource );
-	virtual void privateIdle(CommandSourceType cmdSource);						///< Enter idle state.
+	virtual void privateRepair( Object *obj, CommandSourceType cmdSource ) override;	///< repair the target
+	virtual void privateResumeConstruction( Object *obj, CommandSourceType cmdSource ) override;  ///< resume construction on obj
+	virtual void privateDock( Object *obj, CommandSourceType cmdSource ) override;
+	virtual void privateIdle(CommandSourceType cmdSource) override;						///< Enter idle state.
 
 private:
 


### PR DESCRIPTION
## Summary
- Add `override` keyword to virtual function overrides in GameEngine/Include/GameLogic/Module
- Changes across Generals and GeneralsMD

## Context
Part 3/6 of splitting #2101. Depends on #2389 merging first.

## Notes
- 397 files changed, purely mechanical `override` keyword additions
- All lines retain the `virtual` keyword