### PR TITLE
refactor: Add override keyword to virtual function overrides in GameEngine (2)

### DIFF
--- a/Core/GameEngine/Include/Common/ArchiveFileSystem.h
+++ b/Core/GameEngine/Include/Common/ArchiveFileSystem.h
@@ -124,12 +124,12 @@ class ArchiveFileSystem : public SubsystemInterface
 {
 public:
 	ArchiveFileSystem();
-	virtual ~ArchiveFileSystem();
+	virtual ~ArchiveFileSystem() override;
 
-	virtual void init() = 0;
-	virtual void update() = 0;
-	virtual void reset() = 0;
-	virtual void postProcessLoad() = 0;
+	virtual void init() override = 0;
+	virtual void update() override = 0;
+	virtual void reset() override = 0;
+	virtual void postProcessLoad() override = 0;
 
 	// ArchiveFile operations
 	virtual ArchiveFile*	openArchiveFile( const Char *filename ) = 0;		///< Create new or return existing Archive file from file name

--- a/Core/GameEngine/Include/Common/ArchiveFileSystem.h
+++ b/Core/GameEngine/Include/Common/ArchiveFileSystem.h
@@ -126,10 +126,10 @@ public:
 	ArchiveFileSystem();
 	virtual ~ArchiveFileSystem() override;
 
-	virtual void init() override = 0;
-	virtual void update() override = 0;
-	virtual void reset() override = 0;
-	virtual void postProcessLoad() override = 0;
+	virtual void init() = 0;
+	virtual void update() = 0;
+	virtual void reset() = 0;
+	virtual void postProcessLoad() = 0;
 
 	// ArchiveFile operations
 	virtual ArchiveFile*	openArchiveFile( const Char *filename ) = 0;		///< Create new or return existing Archive file from file name

--- a/Core/GameEngine/Include/Common/DynamicAudioEventInfo.h
+++ b/Core/GameEngine/Include/Common/DynamicAudioEventInfo.h
@@ -51,9 +51,9 @@ class DynamicAudioEventInfo : public AudioEventInfo
     explicit DynamicAudioEventInfo( const AudioEventInfo & baseInfo );
 
     // DynamicAudioEventInfo interfacing function overrides
-    virtual Bool isLevelSpecific() const;
-    virtual DynamicAudioEventInfo * getDynamicAudioEventInfo();
-    virtual const DynamicAudioEventInfo * getDynamicAudioEventInfo() const;
+    virtual Bool isLevelSpecific() const override;
+    virtual DynamicAudioEventInfo * getDynamicAudioEventInfo() override;
+    virtual const DynamicAudioEventInfo * getDynamicAudioEventInfo() const override;
 
     // Change various fields from their default (INI) values
     void overrideAudioName( const AsciiString & newName );

--- a/Core/GameEngine/Include/Common/FileSystem.h
+++ b/Core/GameEngine/Include/Common/FileSystem.h
@@ -142,11 +142,11 @@ class FileSystem : public SubsystemInterface
 
 public:
 	FileSystem();
-	virtual	~FileSystem();
+	virtual ~FileSystem() override;
 
-	void init();
-	void reset();
-	void update();
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override;
 
 	File* openFile( const Char *filename, Int access = File::NONE, size_t bufferSize = File::BUFFERSIZE, FileInstance instance = 0 ); ///< opens a File interface to the specified file
 	Bool doesFileExist(const Char *filename, FileInstance instance = 0) const; ///< returns TRUE if the file exists.  filename should have no directory.

--- a/Core/GameEngine/Include/Common/GameAudio.h
+++ b/Core/GameEngine/Include/Common/GameAudio.h
@@ -143,16 +143,16 @@ class AudioManager : public SubsystemInterface
 		static const char *const MuteAudioReasonNames[];
 
 		AudioManager();
-		virtual ~AudioManager();
+		virtual ~AudioManager() override;
 #if defined(RTS_DEBUG)
 		virtual void audioDebugDisplay(DebugDisplayInterface *dd, void *userData, FILE *fp = nullptr ) = 0;
 #endif
 
 		// From SubsystemInterface
-		virtual void init();
-		virtual void postProcessLoad();
-		virtual void reset();
-		virtual void update();
+		virtual void init() override;
+		virtual void postProcessLoad() override;
+		virtual void reset() override;
+		virtual void update() override;
 
 		// device dependent stop, pause and resume
 		virtual void stopAudio( AudioAffect which ) = 0;
@@ -390,47 +390,47 @@ class AudioManagerDummy : public AudioManager
 #if defined(RTS_DEBUG)
 	virtual void audioDebugDisplay(DebugDisplayInterface* dd, void* userData, FILE* fp) {}
 #endif
-	virtual void stopAudio(AudioAffect which) {}
-	virtual void pauseAudio(AudioAffect which) {}
-	virtual void resumeAudio(AudioAffect which) {}
-	virtual void pauseAmbient(Bool shouldPause) {}
-	virtual void killAudioEventImmediately(AudioHandle audioEvent) {}
-	virtual void nextMusicTrack() {}
-	virtual void prevMusicTrack() {}
-	virtual Bool isMusicPlaying() const { return false; }
-	virtual Bool hasMusicTrackCompleted(const AsciiString& trackName, Int numberOfTimes) const { return false; }
-	virtual AsciiString getMusicTrackName() const { return ""; }
-	virtual void openDevice() {}
-	virtual void closeDevice() {}
-	virtual void* getDevice() { return nullptr; }
-	virtual void notifyOfAudioCompletion(UnsignedInt audioCompleted, UnsignedInt flags) {}
-	virtual UnsignedInt getProviderCount() const { return 0; };
-	virtual AsciiString getProviderName(UnsignedInt providerNum) const { return ""; }
-	virtual UnsignedInt getProviderIndex(AsciiString providerName) const { return 0; }
-	virtual void selectProvider(UnsignedInt providerNdx) {}
-	virtual void unselectProvider() {}
-	virtual UnsignedInt getSelectedProvider() const { return 0; }
-	virtual void setSpeakerType(UnsignedInt speakerType) {}
-	virtual UnsignedInt getSpeakerType() { return 0; }
-	virtual UnsignedInt getNum2DSamples() const { return 0; }
-	virtual UnsignedInt getNum3DSamples() const { return 0; }
-	virtual UnsignedInt getNumStreams() const { return 0; }
-	virtual Bool doesViolateLimit(AudioEventRTS* event) const { return false; }
-	virtual Bool isPlayingLowerPriority(AudioEventRTS* event) const { return false; }
-	virtual Bool isPlayingAlready(AudioEventRTS* event) const { return false; }
-	virtual Bool isObjectPlayingVoice(UnsignedInt objID) const { return false; }
-	virtual void adjustVolumeOfPlayingAudio(AsciiString eventName, Real newVolume) {}
-	virtual void removePlayingAudio(AsciiString eventName) {}
-	virtual void removeAllDisabledAudio() {}
-	virtual Bool has3DSensitiveStreamsPlaying() const { return false; }
-	virtual void* getHandleForBink() { return nullptr; }
-	virtual void releaseHandleForBink() {}
-	virtual void friend_forcePlayAudioEventRTS(const AudioEventRTS* eventToPlay) {}
-	virtual void setPreferredProvider(AsciiString providerNdx) {}
-	virtual void setPreferredSpeaker(AsciiString speakerType) {}
-	virtual Real getFileLengthMS(AsciiString strToLoad) const { return -1; }
-	virtual void closeAnySamplesUsingFile(const void* fileToClose) {}
-	virtual void setDeviceListenerPosition() {}
+	virtual void stopAudio(AudioAffect which) override {}
+	virtual void pauseAudio(AudioAffect which) override {}
+	virtual void resumeAudio(AudioAffect which) override {}
+	virtual void pauseAmbient(Bool shouldPause) override {}
+	virtual void killAudioEventImmediately(AudioHandle audioEvent) override {}
+	virtual void nextMusicTrack() override {}
+	virtual void prevMusicTrack() override {}
+	virtual Bool isMusicPlaying() const override { return false; }
+	virtual Bool hasMusicTrackCompleted(const AsciiString& trackName, Int numberOfTimes) const override { return false; }
+	virtual AsciiString getMusicTrackName() const override { return ""; }
+	virtual void openDevice() override {}
+	virtual void closeDevice() override {}
+	virtual void* getDevice() override { return nullptr; }
+	virtual void notifyOfAudioCompletion(UnsignedInt audioCompleted, UnsignedInt flags) override {}
+	virtual UnsignedInt getProviderCount() const override { return 0; };
+	virtual AsciiString getProviderName(UnsignedInt providerNum) const override { return ""; }
+	virtual UnsignedInt getProviderIndex(AsciiString providerName) const override { return 0; }
+	virtual void selectProvider(UnsignedInt providerNdx) override {}
+	virtual void unselectProvider() override {}
+	virtual UnsignedInt getSelectedProvider() const override { return 0; }
+	virtual void setSpeakerType(UnsignedInt speakerType) override {}
+	virtual UnsignedInt getSpeakerType() override { return 0; }
+	virtual UnsignedInt getNum2DSamples() const override { return 0; }
+	virtual UnsignedInt getNum3DSamples() const override { return 0; }
+	virtual UnsignedInt getNumStreams() const override { return 0; }
+	virtual Bool doesViolateLimit(AudioEventRTS* event) const override { return false; }
+	virtual Bool isPlayingLowerPriority(AudioEventRTS* event) const override { return false; }
+	virtual Bool isPlayingAlready(AudioEventRTS* event) const override { return false; }
+	virtual Bool isObjectPlayingVoice(UnsignedInt objID) const override { return false; }
+	virtual void adjustVolumeOfPlayingAudio(AsciiString eventName, Real newVolume) override {}
+	virtual void removePlayingAudio(AsciiString eventName) override {}
+	virtual void removeAllDisabledAudio() override {}
+	virtual Bool has3DSensitiveStreamsPlaying() const override { return false; }
+	virtual void* getHandleForBink() override { return nullptr; }
+	virtual void releaseHandleForBink() override {}
+	virtual void friend_forcePlayAudioEventRTS(const AudioEventRTS* eventToPlay) override {}
+	virtual void setPreferredProvider(AsciiString providerNdx) override {}
+	virtual void setPreferredSpeaker(AsciiString speakerType) override {}
+	virtual Real getFileLengthMS(AsciiString strToLoad) const override { return -1; }
+	virtual void closeAnySamplesUsingFile(const void* fileToClose) override {}
+	virtual void setDeviceListenerPosition() override {}
 };
 
 

--- a/Core/GameEngine/Include/Common/GameSounds.h
+++ b/Core/GameEngine/Include/Common/GameSounds.h
@@ -52,12 +52,12 @@ class SoundManager : public SubsystemInterface
 {
 	public:
 		SoundManager();
-		virtual ~SoundManager();
+		virtual ~SoundManager() override;
 
-		virtual void init();										///< Initializes the sounds system
-		virtual void postProcessLoad();
-		virtual void update();									///< Services sounds tasks. Called by AudioInterface
-		virtual void reset();										///< Reset the sounds system
+		virtual void init() override;										///< Initializes the sounds system
+		virtual void postProcessLoad() override;
+		virtual void update() override;									///< Services sounds tasks. Called by AudioInterface
+		virtual void reset() override;										///< Reset the sounds system
 
 		virtual void loseFocus();								///< Called when application loses focus
 		virtual void regainFocus();							///< Called when application regains focus

--- a/Core/GameEngine/Include/Common/LocalFile.h
+++ b/Core/GameEngine/Include/Common/LocalFile.h
@@ -91,22 +91,22 @@ class LocalFile : public File
 		//virtual				~LocalFile();
 
 
-		virtual Bool	open( const Char *filename, Int access = NONE, size_t bufferSize = BUFFERSIZE ); ///< Open a file for access
-		virtual void	close();																			///< Close the file
-		virtual Int		read( void *buffer, Int bytes );										///< Read the specified number of bytes in to buffer: See File::read
-		virtual Int		readChar();																///< Read a character from the file
-		virtual Int		readWideChar();															///< Read a wide character from the file
-		virtual Int		write( const void *buffer, Int bytes );							///< Write the specified number of bytes from the buffer: See File::write
-		virtual Int		writeFormat( const Char* format, ... );							///< Write an unterminated formatted string to the file
-		virtual Int		writeFormat( const WideChar* format, ... );						///< Write an unterminated formatted string to the file
-		virtual Int		writeChar( const Char* character );								///< Write a character to the file
-		virtual Int		writeChar( const WideChar* character );							///< Write a wide character to the file
-		virtual Int		seek( Int new_pos, seekMode mode = CURRENT );				///< Set file position: See File::seek
-		virtual Bool	flush();													///< flush data to disk
-		virtual void	nextLine(Char *buf = nullptr, Int bufSize = 0);				///< moves file position to after the next new-line
-		virtual Bool	scanInt(Int &newInt);																///< return what gets read in as an integer at the current file position.
-		virtual Bool	scanReal(Real &newReal);														///< return what gets read in as a float at the current file position.
-		virtual	Bool	scanString(AsciiString &newString);									///< return what gets read in as a string at the current file position.
+		virtual Bool	open( const Char *filename, Int access = NONE, size_t bufferSize = BUFFERSIZE ) override; ///< Open a file for access
+		virtual void	close() override;																			///< Close the file
+		virtual Int		read( void *buffer, Int bytes ) override;										///< Read the specified number of bytes in to buffer: See File::read
+		virtual Int		readChar() override;																///< Read a character from the file
+		virtual Int		readWideChar() override;															///< Read a wide character from the file
+		virtual Int		write( const void *buffer, Int bytes ) override;							///< Write the specified number of bytes from the buffer: See File::write
+		virtual Int		writeFormat( const Char* format, ... ) override;							///< Write an unterminated formatted string to the file
+		virtual Int		writeFormat( const WideChar* format, ... ) override;						///< Write an unterminated formatted string to the file
+		virtual Int		writeChar( const Char* character ) override;								///< Write a character to the file
+		virtual Int		writeChar( const WideChar* character ) override;							///< Write a wide character to the file
+		virtual Int		seek( Int new_pos, seekMode mode = CURRENT ) override;				///< Set file position: See File::seek
+		virtual Bool	flush() override;													///< flush data to disk
+		virtual void	nextLine(Char *buf = nullptr, Int bufSize = 0) override;				///< moves file position to after the next new-line
+		virtual Bool	scanInt(Int &newInt) override;																///< return what gets read in as an integer at the current file position.
+		virtual Bool	scanReal(Real &newReal) override;														///< return what gets read in as a float at the current file position.
+		virtual	Bool	scanString(AsciiString &newString) override;									///< return what gets read in as a string at the current file position.
 		/**
 			Allocate a buffer large enough to hold entire file, read
 			the entire file into the buffer, then close the file.
@@ -114,8 +114,8 @@ class LocalFile : public File
 			for freeing is (via delete[]). This is a Good Thing to
 			use because it minimizes memory copies for BIG files.
 		*/
-		virtual char* readEntireAndClose();
-		virtual File* convertToRAMFile();
+		virtual char* readEntireAndClose() override;
+		virtual File* convertToRAMFile() override;
 
 	protected:
 

--- a/Core/GameEngine/Include/Common/LocalFileSystem.h
+++ b/Core/GameEngine/Include/Common/LocalFileSystem.h
@@ -34,11 +34,11 @@
 class LocalFileSystem : public SubsystemInterface
 {
 public:
-	virtual ~LocalFileSystem() {}
+	virtual ~LocalFileSystem() override {}
 
-	virtual void init() = 0;
-	virtual void reset() = 0;
-	virtual void update() = 0;
+	virtual void init() override = 0;
+	virtual void reset() override = 0;
+	virtual void update() override = 0;
 
 	virtual File * openFile(const Char *filename, Int access = File::NONE, size_t bufferSize = File::BUFFERSIZE) = 0;
 	virtual Bool doesFileExist(const Char *filename) const = 0;

--- a/Core/GameEngine/Include/Common/LocalFileSystem.h
+++ b/Core/GameEngine/Include/Common/LocalFileSystem.h
@@ -36,9 +36,9 @@ class LocalFileSystem : public SubsystemInterface
 public:
 	virtual ~LocalFileSystem() override {}
 
-	virtual void init() override = 0;
-	virtual void reset() override = 0;
-	virtual void update() override = 0;
+	virtual void init() = 0;
+	virtual void reset() = 0;
+	virtual void update() = 0;
 
 	virtual File * openFile(const Char *filename, Int access = File::NONE, size_t bufferSize = File::BUFFERSIZE) = 0;
 	virtual Bool doesFileExist(const Char *filename) const = 0;

--- a/Core/GameEngine/Include/Common/OptionPreferences.h
+++ b/Core/GameEngine/Include/Common/OptionPreferences.h
@@ -42,7 +42,7 @@ class OptionPreferences : public UserPreferences
 {
 public:
 	OptionPreferences();
-	virtual ~OptionPreferences();
+	virtual ~OptionPreferences() override;
 
 	Bool loadFromIniFile();
 

--- a/Core/GameEngine/Include/Common/RAMFile.h
+++ b/Core/GameEngine/Include/Common/RAMFile.h
@@ -82,23 +82,23 @@ class RAMFile : public File
 		//virtual				~RAMFile();
 
 
-		virtual Bool	open( const Char *filename, Int access = NONE, size_t bufferSize = 0 ); ///< Open a file for access
-		virtual void	close();																			///< Close the file
-		virtual Int		read( void *buffer, Int bytes );										///< Read the specified number of bytes in to buffer: See File::read
-		virtual Int		readChar();																///< Read a character from the file
-		virtual Int		readWideChar();															///< Read a wide character from the file
-		virtual Int		write( const void *buffer, Int bytes );							///< Write the specified number of bytes from the buffer: See File::write
-		virtual Int		writeFormat( const Char* format, ... );							///< Write the formatted string to the file
-		virtual Int		writeFormat( const WideChar* format, ... );						///< Write the formatted string to the file
-		virtual Int		writeChar( const Char* character );								///< Write a character to the file
-		virtual Int		writeChar( const WideChar* character );							///< Write a wide character to the file
-		virtual Int		seek( Int new_pos, seekMode mode = CURRENT );				///< Set file position: See File::seek
-		virtual Bool	flush();													///< flush data to disk
-		virtual void	nextLine(Char *buf = nullptr, Int bufSize = 0);				///< moves current position to after the next new-line
+		virtual Bool	open( const Char *filename, Int access = NONE, size_t bufferSize = 0 ) override; ///< Open a file for access
+		virtual void	close() override;																			///< Close the file
+		virtual Int		read( void *buffer, Int bytes ) override;										///< Read the specified number of bytes in to buffer: See File::read
+		virtual Int		readChar() override;																///< Read a character from the file
+		virtual Int		readWideChar() override;															///< Read a wide character from the file
+		virtual Int		write( const void *buffer, Int bytes ) override;							///< Write the specified number of bytes from the buffer: See File::write
+		virtual Int		writeFormat( const Char* format, ... ) override;							///< Write the formatted string to the file
+		virtual Int		writeFormat( const WideChar* format, ... ) override;						///< Write the formatted string to the file
+		virtual Int		writeChar( const Char* character ) override;								///< Write a character to the file
+		virtual Int		writeChar( const WideChar* character ) override;							///< Write a wide character to the file
+		virtual Int		seek( Int new_pos, seekMode mode = CURRENT ) override;				///< Set file position: See File::seek
+		virtual Bool	flush() override;													///< flush data to disk
+		virtual void	nextLine(Char *buf = nullptr, Int bufSize = 0) override;				///< moves current position to after the next new-line
 
-		virtual Bool	scanInt(Int &newInt);																///< return what gets read as an integer from the current memory position.
-		virtual Bool	scanReal(Real &newReal);														///< return what gets read as a float from the current memory position.
-		virtual Bool	scanString(AsciiString &newString);									///< return what gets read as a string from the current memory position.
+		virtual Bool	scanInt(Int &newInt) override;																///< return what gets read as an integer from the current memory position.
+		virtual Bool	scanReal(Real &newReal) override;														///< return what gets read as a float from the current memory position.
+		virtual Bool	scanString(AsciiString &newString) override;									///< return what gets read as a string from the current memory position.
 
 		virtual Bool	open( File *file );																	///< Open file for fast RAM access
 		virtual Bool	openFromArchive(File *archiveFile, const AsciiString& filename, Int offset, Int size); ///< copy file data from the given file at the given offset for the given size.
@@ -111,8 +111,8 @@ class RAMFile : public File
 			for freeing is (via delete[]). This is a Good Thing to
 			use because it minimizes memory copies for BIG files.
 		*/
-		virtual char* readEntireAndClose();
-		virtual File* convertToRAMFile();
+		virtual char* readEntireAndClose() override;
+		virtual File* convertToRAMFile() override;
 
 	protected:
 

--- a/Core/GameEngine/Include/Common/Radar.h
+++ b/Core/GameEngine/Include/Common/Radar.h
@@ -110,9 +110,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	Object *m_object;				///< the object
 	RadarObject *m_next;		///< next radar object
@@ -157,11 +157,11 @@ class Radar : public Snapshot,
 public:
 
 	Radar();
-	virtual ~Radar();
+	virtual ~Radar() override;
 
-	virtual void init() { }														///< subsystem initialization
-	virtual void reset();															///< subsystem reset
-	virtual void update();														///< subsystem per frame update
+	virtual void init() override { }														///< subsystem initialization
+	virtual void reset() override;															///< subsystem reset
+	virtual void update() override;														///< subsystem per frame update
 
 	// is the game window parameter the radar window
 	Bool isRadarWindow( GameWindow *window ) { return (m_radarWindow == window) && (m_radarWindow != nullptr); }
@@ -228,9 +228,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	/// internal method for creating a radar event with specific colors
 	void internalCreateEvent( const Coord3D *world, RadarEventType type, Real secondsToLive,
@@ -304,7 +304,7 @@ extern Radar *TheRadar;  ///< the radar singleton extern
 class RadarDummy : public Radar
 {
 public:
-	virtual void draw(Int pixelX, Int pixelY, Int width, Int height) { }
-	virtual void clearShroud() { }
-	virtual void setShroudLevel(Int x, Int y, CellShroudStatus setting) { }
+	virtual void draw(Int pixelX, Int pixelY, Int width, Int height) override { }
+	virtual void clearShroud() override { }
+	virtual void setShroudLevel(Int x, Int y, CellShroudStatus setting) override { }
 };

--- a/Core/GameEngine/Include/Common/StreamingArchiveFile.h
+++ b/Core/GameEngine/Include/Common/StreamingArchiveFile.h
@@ -83,24 +83,24 @@ class StreamingArchiveFile : public RAMFile
 		//virtual				~StreamingArchiveFile();
 
 
-		virtual Bool	open( const Char *filename, Int access = NONE, size_t bufferSize = BUFFERSIZE ); ///< Open a file for access
-		virtual void	close();																			///< Close the file
-		virtual Int		read( void *buffer, Int bytes );										///< Read the specified number of bytes in to buffer: See File::read
-		virtual Int		write( const void *buffer, Int bytes );							///< Write the specified number of bytes from the buffer: See File::write
-		virtual Int		seek( Int new_pos, seekMode mode = CURRENT );				///< Set file position: See File::seek
+		virtual Bool	open( const Char *filename, Int access = NONE, size_t bufferSize = BUFFERSIZE ) override; ///< Open a file for access
+		virtual void	close() override;																			///< Close the file
+		virtual Int		read( void *buffer, Int bytes ) override;										///< Read the specified number of bytes in to buffer: See File::read
+		virtual Int		write( const void *buffer, Int bytes ) override;							///< Write the specified number of bytes from the buffer: See File::write
+		virtual Int		seek( Int new_pos, seekMode mode = CURRENT ) override;				///< Set file position: See File::seek
 
 		// Ini's should not be parsed with streaming files, that's just dumb.
-		virtual void	nextLine(Char *buf = nullptr, Int bufSize = 0) { DEBUG_CRASH(("Should not call nextLine on a streaming file.")); }
-		virtual Bool	scanInt(Int &newInt) { DEBUG_CRASH(("Should not call scanInt on a streaming file."));  return FALSE; }
-		virtual Bool	scanReal(Real &newReal) { DEBUG_CRASH(("Should not call scanReal on a streaming file.")); return FALSE; }
-		virtual Bool	scanString(AsciiString &newString) { DEBUG_CRASH(("Should not call scanString on a streaming file.")); return FALSE; }
+		virtual void	nextLine(Char *buf = nullptr, Int bufSize = 0) override { DEBUG_CRASH(("Should not call nextLine on a streaming file.")); }
+		virtual Bool	scanInt(Int &newInt) override { DEBUG_CRASH(("Should not call scanInt on a streaming file."));  return FALSE; }
+		virtual Bool	scanReal(Real &newReal) override { DEBUG_CRASH(("Should not call scanReal on a streaming file.")); return FALSE; }
+		virtual Bool	scanString(AsciiString &newString) override { DEBUG_CRASH(("Should not call scanString on a streaming file.")); return FALSE; }
 
-		virtual Bool	open( File *file );																	///< Open file for fast RAM access
-		virtual Bool	openFromArchive(File *archiveFile, const AsciiString& filename, Int offset, Int size); ///< copy file data from the given file at the given offset for the given size.
-		virtual Bool	copyDataToFile(File *localFile) { DEBUG_CRASH(("Are you sure you meant to copyDataToFile on a streaming file?")); return FALSE; }
+		virtual Bool	open( File *file ) override;																	///< Open file for fast RAM access
+		virtual Bool	openFromArchive(File *archiveFile, const AsciiString& filename, Int offset, Int size) override; ///< copy file data from the given file at the given offset for the given size.
+		virtual Bool	copyDataToFile(File *localFile) override { DEBUG_CRASH(("Are you sure you meant to copyDataToFile on a streaming file?")); return FALSE; }
 
-		virtual char* readEntireAndClose() { DEBUG_CRASH(("Are you sure you meant to readEntireAndClose on a streaming file?")); return nullptr; }
-		virtual File* convertToRAMFile() { DEBUG_CRASH(("Are you sure you meant to readEntireAndClose on a streaming file?")); return this; }
+		virtual char* readEntireAndClose() override { DEBUG_CRASH(("Are you sure you meant to readEntireAndClose on a streaming file?")); return nullptr; }
+		virtual File* convertToRAMFile() override { DEBUG_CRASH(("Are you sure you meant to readEntireAndClose on a streaming file?")); return this; }
 };
 
 

--- a/Core/GameEngine/Include/Common/UserPreferences.h
+++ b/Core/GameEngine/Include/Common/UserPreferences.h
@@ -77,7 +77,7 @@ class LANPreferences : public UserPreferences
 {
 public:
 	LANPreferences();
-	virtual ~LANPreferences();
+	virtual ~LANPreferences() override;
 
 	Bool loadFromIniFile();
 

--- a/Core/GameEngine/Include/Common/XferCRC.h
+++ b/Core/GameEngine/Include/Common/XferCRC.h
@@ -43,23 +43,23 @@ class XferCRC : public Xfer
 public:
 
 	XferCRC();
-	virtual ~XferCRC();
+	virtual ~XferCRC() override;
 
 	// Xfer methods
-	virtual void open( AsciiString identifier );		///< start a CRC session with this xfer instance
-	virtual void close();											///< stop CRC session
-	virtual Int beginBlock();									///< start block event
-	virtual void endBlock();									///< end block event
-	virtual void skip( Int dataSize );							///< skip xfer event
+	virtual void open( AsciiString identifier ) override;		///< start a CRC session with this xfer instance
+	virtual void close() override;											///< stop CRC session
+	virtual Int beginBlock() override;									///< start block event
+	virtual void endBlock() override;									///< end block event
+	virtual void skip( Int dataSize ) override;							///< skip xfer event
 
-	virtual void xferSnapshot( Snapshot *snapshot );		///< entry point for xfering a snapshot
+	virtual void xferSnapshot( Snapshot *snapshot ) override;		///< entry point for xfering a snapshot
 
 	// Xfer CRC methods
 	virtual UnsignedInt getCRC();										///< get computed CRC in network byte order
 
 protected:
 
-	virtual void xferImplementation( void *data, Int dataSize );
+	virtual void xferImplementation( void *data, Int dataSize ) override;
 
 	inline void addCRC( UnsignedInt val );								///< CRC a 4-byte block
 

--- a/Core/GameEngine/Include/Common/XferDeepCRC.h
+++ b/Core/GameEngine/Include/Common/XferDeepCRC.h
@@ -44,20 +44,20 @@ class XferDeepCRC : public XferCRC
 public:
 
 	XferDeepCRC();
-	virtual ~XferDeepCRC();
+	virtual ~XferDeepCRC() override;
 
 	// Xfer methods
-	virtual void open( AsciiString identifier );		///< start a CRC session with this xfer instance
-	virtual void close();											///< stop CRC session
+	virtual void open( AsciiString identifier ) override;		///< start a CRC session with this xfer instance
+	virtual void close() override;											///< stop CRC session
 
 	// xfer methods
-	virtual void xferMarkerLabel( AsciiString asciiStringData );  ///< xfer ascii string (need our own)
-	virtual void xferAsciiString( AsciiString *asciiStringData );  ///< xfer ascii string (need our own)
-	virtual void xferUnicodeString( UnicodeString *unicodeStringData );	///< xfer unicode string (need our own);
+	virtual void xferMarkerLabel( AsciiString asciiStringData ) override;  ///< xfer ascii string (need our own)
+	virtual void xferAsciiString( AsciiString *asciiStringData ) override;  ///< xfer ascii string (need our own)
+	virtual void xferUnicodeString( UnicodeString *unicodeStringData ) override;	///< xfer unicode string (need our own);
 
 protected:
 
-	virtual void xferImplementation( void *data, Int dataSize );
+	virtual void xferImplementation( void *data, Int dataSize ) override;
 
 	FILE * m_fileFP;																			///< pointer to file
 };

--- a/Core/GameEngine/Include/Common/XferLoad.h
+++ b/Core/GameEngine/Include/Common/XferLoad.h
@@ -43,23 +43,23 @@ class XferLoad : public Xfer
 public:
 
 	XferLoad();
-	virtual ~XferLoad();
+	virtual ~XferLoad() override;
 
-	virtual void open( AsciiString identifier );				///< open file for writing
-	virtual void close();													///< close file
-	virtual Int beginBlock();														///< read placeholder block size
-	virtual void endBlock();											///< reading an end block is a no-op
-	virtual void skip( Int dataSize );									///< skip forward dataSize bytes in file
+	virtual void open( AsciiString identifier ) override;				///< open file for writing
+	virtual void close() override;													///< close file
+	virtual Int beginBlock() override;														///< read placeholder block size
+	virtual void endBlock() override;											///< reading an end block is a no-op
+	virtual void skip( Int dataSize ) override;									///< skip forward dataSize bytes in file
 
-	virtual void xferSnapshot( Snapshot *snapshot );		///< entry point for xfering a snapshot
+	virtual void xferSnapshot( Snapshot *snapshot ) override;		///< entry point for xfering a snapshot
 
 	// xfer methods
-	virtual void xferAsciiString( AsciiString *asciiStringData );  ///< xfer ascii string (need our own)
-	virtual void xferUnicodeString( UnicodeString *unicodeStringData );	///< xfer unicode string (need our own);
+	virtual void xferAsciiString( AsciiString *asciiStringData ) override;  ///< xfer ascii string (need our own)
+	virtual void xferUnicodeString( UnicodeString *unicodeStringData ) override;	///< xfer unicode string (need our own);
 
 protected:
 
-	virtual void xferImplementation( void *data, Int dataSize );		///< the xfer implementation
+	virtual void xferImplementation( void *data, Int dataSize ) override;		///< the xfer implementation
 
 	FILE * m_fileFP;																					///< pointer to file
 

--- a/Core/GameEngine/Include/Common/XferSave.h
+++ b/Core/GameEngine/Include/Common/XferSave.h
@@ -47,24 +47,24 @@ class XferSave : public Xfer
 public:
 
 	XferSave();
-	virtual ~XferSave();
+	virtual ~XferSave() override;
 
 	// Xfer methods
-	virtual void open( AsciiString identifier );		///< open file for writing
-	virtual void close();											///< close file
-	virtual Int beginBlock();									///< write placeholder block size
-	virtual void endBlock();									///< backup to last begin block and write size
-	virtual void skip( Int dataSize );							///< skipping during a write is a no-op
+	virtual void open( AsciiString identifier ) override;		///< open file for writing
+	virtual void close() override;											///< close file
+	virtual Int beginBlock() override;									///< write placeholder block size
+	virtual void endBlock() override;									///< backup to last begin block and write size
+	virtual void skip( Int dataSize ) override;							///< skipping during a write is a no-op
 
-	virtual void xferSnapshot( Snapshot *snapshot );		///< entry point for xfering a snapshot
+	virtual void xferSnapshot( Snapshot *snapshot ) override;		///< entry point for xfering a snapshot
 
 	// xfer methods
-	virtual void xferAsciiString( AsciiString *asciiStringData );  ///< xfer ascii string (need our own)
-	virtual void xferUnicodeString( UnicodeString *unicodeStringData );	///< xfer unicode string (need our own);
+	virtual void xferAsciiString( AsciiString *asciiStringData ) override;  ///< xfer ascii string (need our own)
+	virtual void xferUnicodeString( UnicodeString *unicodeStringData ) override;	///< xfer unicode string (need our own);
 
 protected:
 
-	virtual void xferImplementation( void *data, Int dataSize );		///< the xfer implementation
+	virtual void xferImplementation( void *data, Int dataSize ) override;		///< the xfer implementation
 
 	FILE * m_fileFP;																			///< pointer to file
 	XferBlockData *m_blockStack;													///< stack of block data

--- a/Core/GameEngine/Include/GameClient/Credits.h
+++ b/Core/GameEngine/Include/GameClient/Credits.h
@@ -111,13 +111,13 @@ class CreditsManager: public SubsystemInterface
 {
 public:
 	CreditsManager();
-	~CreditsManager() override;
+	virtual ~CreditsManager() override;
 
-	void init() override;
+	virtual void init() override;
 	void load();
-	void reset() override;
-	void update() override;
-	void draw() override;
+	virtual void reset() override;
+	virtual void update() override;
+	virtual void draw() override;
 
 	const FieldParse *getFieldParse() const { return m_creditsFieldParseTable; }								///< returns the parsing fields
 	static const FieldParse m_creditsFieldParseTable[];																				///< the parse table

--- a/Core/GameEngine/Include/GameClient/Credits.h
+++ b/Core/GameEngine/Include/GameClient/Credits.h
@@ -111,13 +111,13 @@ class CreditsManager: public SubsystemInterface
 {
 public:
 	CreditsManager();
-	~CreditsManager();
+	~CreditsManager() override;
 
-	void init();
+	void init() override;
 	void load();
-	void reset();
-	void update();
-	void draw();
+	void reset() override;
+	void update() override;
+	void draw() override;
 
 	const FieldParse *getFieldParse() const { return m_creditsFieldParseTable; }								///< returns the parsing fields
 	static const FieldParse m_creditsFieldParseTable[];																				///< the parse table

--- a/Core/GameEngine/Include/GameClient/DisplayStringManager.h
+++ b/Core/GameEngine/Include/GameClient/DisplayStringManager.h
@@ -41,11 +41,11 @@ class DisplayStringManager : public SubsystemInterface
 public:
 
 	DisplayStringManager();
-	virtual ~DisplayStringManager();
+	virtual ~DisplayStringManager() override;
 
-	virtual void init() {}			///< initialize the factory
-	virtual void reset() {}			///< reset system
-	virtual void update() {};		///< update anything we need to in our strings
+	virtual void init() override {}			///< initialize the factory
+	virtual void reset() override {}			///< reset system
+	virtual void update() override {};		///< update anything we need to in our strings
 
 	virtual DisplayString *newDisplayString() = 0;  ///< allocate new display string
 	virtual void freeDisplayString( DisplayString *string ) = 0;  ///< free string

--- a/Core/GameEngine/Include/GameClient/FXList.h
+++ b/Core/GameEngine/Include/GameClient/FXList.h
@@ -192,11 +192,11 @@ class FXListStore : public SubsystemInterface
 public:
 
 	FXListStore();
-	~FXListStore();
+	virtual ~FXListStore() override;
 
-	void init() { }
-	void reset() { }
-	void update() { }
+	virtual void init() override { }
+	virtual void reset() override { }
+	virtual void update() override { }
 
 	/**
 		return the FXList with the given namekey.

--- a/Core/GameEngine/Include/GameClient/GameFont.h
+++ b/Core/GameEngine/Include/GameClient/GameFont.h
@@ -62,11 +62,11 @@ public:
 public:
 
 	FontLibrary();
-	virtual ~FontLibrary();
+	virtual ~FontLibrary() override;
 
-	virtual void init();
-	virtual void reset();
-	virtual void update() { }
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override { }
 
 	GameFont *getFont( AsciiString name, Int pointSize, Bool bold );  ///< get a font pointer
 

--- a/Core/GameEngine/Include/GameClient/GameText.h
+++ b/Core/GameEngine/Include/GameClient/GameText.h
@@ -70,7 +70,7 @@ class GameTextInterface : public SubsystemInterface
 
 	public:
 
-		virtual ~GameTextInterface() {};
+		virtual ~GameTextInterface() override {};
 
 		virtual UnicodeString fetch( const Char *label, Bool *exists = nullptr ) = 0;		///< Returns the associated labeled unicode text
 		virtual UnicodeString fetch( AsciiString label, Bool *exists = nullptr ) = 0;		///< Returns the associated labeled unicode text ; TheSuperHackers @todo Remove

--- a/Core/GameEngine/Include/GameClient/GameWindow.h
+++ b/Core/GameEngine/Include/GameClient/GameWindow.h
@@ -438,8 +438,8 @@ class GameWindowDummy : public GameWindow
 {
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(GameWindowDummy, "GameWindowDummy")
 public:
-	virtual void winDrawBorder() {}
-	virtual void* winGetUserData() { return nullptr; }
+	virtual void winDrawBorder() override {}
+	virtual void* winGetUserData() override { return nullptr; }
 };
 
 // ModalWindow ----------------------------------------------------------------

--- a/Core/GameEngine/Include/GameClient/GameWindowTransitions.h
+++ b/Core/GameEngine/Include/GameClient/GameWindowTransitions.h
@@ -656,13 +656,13 @@ class GameWindowTransitionsHandler: public SubsystemInterface
 {
 public:
 	GameWindowTransitionsHandler();
-	~GameWindowTransitionsHandler() override;
+	virtual ~GameWindowTransitionsHandler() override;
 
-	void init() override;
+	virtual void init() override;
 	void load();
-	void reset() override;
-	void update() override;
-	void draw() override;
+	virtual void reset() override;
+	virtual void update() override;
+	virtual void draw() override;
 	Bool isFinished();
 	const FieldParse *getFieldParse() const { return m_gameWindowTransitionsFieldParseTable; }								///< returns the parsing fields
 	static const FieldParse m_gameWindowTransitionsFieldParseTable[];																				///< the parse table

--- a/Core/GameEngine/Include/GameClient/GameWindowTransitions.h
+++ b/Core/GameEngine/Include/GameClient/GameWindowTransitions.h
@@ -139,14 +139,14 @@ class TextOnFrameTransition : public Transition
 {
 public:
 	TextOnFrameTransition ();
-	virtual ~TextOnFrameTransition();
+	virtual ~TextOnFrameTransition() override;
 
-	virtual void init( GameWindow *win );
-	virtual void update( Int frame );
-	virtual void reverse();
-	virtual void draw();
+	virtual void init( GameWindow *win ) override;
+	virtual void update( Int frame ) override;
+	virtual void reverse() override;
+	virtual void draw() override;
 
-	virtual void skip();
+	virtual void skip() override;
 
 protected:
 	enum{
@@ -161,14 +161,14 @@ class ReverseSoundTransition : public Transition
 {
 public:
 	ReverseSoundTransition ();
-	virtual ~ReverseSoundTransition();
+	virtual ~ReverseSoundTransition() override;
 
-	virtual void init( GameWindow *win );
-	virtual void update( Int frame );
-	virtual void reverse();
-	virtual void draw();
+	virtual void init( GameWindow *win ) override;
+	virtual void update( Int frame ) override;
+	virtual void reverse() override;
+	virtual void draw() override;
 
-	virtual void skip();
+	virtual void skip() override;
 
 protected:
 	enum{
@@ -184,14 +184,14 @@ class FullFadeTransition : public Transition
 {
 public:
 	FullFadeTransition ();
-	virtual ~FullFadeTransition();
+	virtual ~FullFadeTransition() override;
 
-	virtual void init( GameWindow *win );
-	virtual void update( Int frame );
-	virtual void reverse();
-	virtual void draw();
+	virtual void init( GameWindow *win ) override;
+	virtual void update( Int frame ) override;
+	virtual void reverse() override;
+	virtual void draw() override;
 
-	virtual void skip();
+	virtual void skip() override;
 
 protected:
 	enum{
@@ -209,14 +209,14 @@ class ControlBarArrowTransition : public Transition
 {
 public:
 	ControlBarArrowTransition ();
-	virtual ~ControlBarArrowTransition();
+	virtual ~ControlBarArrowTransition() override;
 
-	virtual void init( GameWindow *win );
-	virtual void update( Int frame );
-	virtual void reverse();
-	virtual void draw();
+	virtual void init( GameWindow *win ) override;
+	virtual void update( Int frame ) override;
+	virtual void reverse() override;
+	virtual void draw() override;
 
-	virtual void skip();
+	virtual void skip() override;
 
 protected:
 	enum{
@@ -238,14 +238,14 @@ class ScreenFadeTransition : public Transition
 {
 public:
 	ScreenFadeTransition ();
-	virtual ~ScreenFadeTransition();
+	virtual ~ScreenFadeTransition() override;
 
-	virtual void init( GameWindow *win );
-	virtual void update( Int frame );
-	virtual void reverse();
-	virtual void draw();
+	virtual void init( GameWindow *win ) override;
+	virtual void update( Int frame ) override;
+	virtual void reverse() override;
+	virtual void draw() override;
 
-	virtual void skip();
+	virtual void skip() override;
 
 protected:
 	enum{
@@ -263,14 +263,14 @@ class CountUpTransition : public Transition
 {
 public:
 	CountUpTransition ();
-	virtual ~CountUpTransition();
+	virtual ~CountUpTransition() override;
 
-	virtual void init( GameWindow *win );
-	virtual void update( Int frame );
-	virtual void reverse();
-	virtual void draw();
+	virtual void init( GameWindow *win ) override;
+	virtual void update( Int frame ) override;
+	virtual void reverse() override;
+	virtual void draw() override;
 
-	virtual void skip();
+	virtual void skip() override;
 
 protected:
 	enum{
@@ -297,14 +297,14 @@ class TextTypeTransition : public Transition
 {
 public:
 	TextTypeTransition ();
-	virtual ~TextTypeTransition();
+	virtual ~TextTypeTransition() override;
 
-	virtual void init( GameWindow *win );
-	virtual void update( Int frame );
-	virtual void reverse();
-	virtual void draw();
+	virtual void init( GameWindow *win ) override;
+	virtual void update( Int frame ) override;
+	virtual void reverse() override;
+	virtual void draw() override;
 
-	virtual void skip();
+	virtual void skip() override;
 
 protected:
 	enum{
@@ -324,14 +324,14 @@ class MainMenuScaleUpTransition : public Transition
 {
 public:
 	MainMenuScaleUpTransition ();
-	virtual ~MainMenuScaleUpTransition();
+	virtual ~MainMenuScaleUpTransition() override;
 
-	virtual void init( GameWindow *win );
-	virtual void update( Int frame );
-	virtual void reverse();
-	virtual void draw();
+	virtual void init( GameWindow *win ) override;
+	virtual void update( Int frame ) override;
+	virtual void reverse() override;
+	virtual void draw() override;
 
-	virtual void skip();
+	virtual void skip() override;
 
 protected:
 	enum{
@@ -354,14 +354,14 @@ class MainMenuMediumScaleUpTransition : public Transition
 {
 public:
 	MainMenuMediumScaleUpTransition ();
-	virtual ~MainMenuMediumScaleUpTransition();
+	virtual ~MainMenuMediumScaleUpTransition() override;
 
-	virtual void init( GameWindow *win );
-	virtual void update( Int frame );
-	virtual void reverse();
-	virtual void draw();
+	virtual void init( GameWindow *win ) override;
+	virtual void update( Int frame ) override;
+	virtual void reverse() override;
+	virtual void draw() override;
 
-	virtual void skip();
+	virtual void skip() override;
 
 protected:
 	enum{
@@ -382,14 +382,14 @@ class MainMenuSmallScaleDownTransition : public Transition
 {
 public:
 	MainMenuSmallScaleDownTransition ();
-	virtual ~MainMenuSmallScaleDownTransition();
+	virtual ~MainMenuSmallScaleDownTransition() override;
 
-	virtual void init( GameWindow *win );
-	virtual void update( Int frame );
-	virtual void reverse();
-	virtual void draw();
+	virtual void init( GameWindow *win ) override;
+	virtual void update( Int frame ) override;
+	virtual void reverse() override;
+	virtual void draw() override;
 
-	virtual void skip();
+	virtual void skip() override;
 
 protected:
 	enum{
@@ -415,14 +415,14 @@ class ScaleUpTransition : public Transition
 {
 public:
 	ScaleUpTransition ();
-	virtual ~ScaleUpTransition();
+	virtual ~ScaleUpTransition() override;
 
-	virtual void init( GameWindow *win );
-	virtual void update( Int frame );
-	virtual void reverse();
-	virtual void draw();
+	virtual void init( GameWindow *win ) override;
+	virtual void update( Int frame ) override;
+	virtual void reverse() override;
+	virtual void draw() override;
 
-	virtual void skip();
+	virtual void skip() override;
 
 protected:
 	enum{
@@ -460,14 +460,14 @@ class ScoreScaleUpTransition : public Transition
 {
 public:
 	ScoreScaleUpTransition ();
-	virtual ~ScoreScaleUpTransition();
+	virtual ~ScoreScaleUpTransition() override;
 
-	virtual void init( GameWindow *win );
-	virtual void update( Int frame );
-	virtual void reverse();
-	virtual void draw();
+	virtual void init( GameWindow *win ) override;
+	virtual void update( Int frame ) override;
+	virtual void reverse() override;
+	virtual void draw() override;
 
-	virtual void skip();
+	virtual void skip() override;
 
 protected:
 	enum{
@@ -494,14 +494,14 @@ class FadeTransition : public Transition
 {
 public:
 	FadeTransition ();
-	virtual ~FadeTransition();
+	virtual ~FadeTransition() override;
 
-	virtual void init( GameWindow *win );
-	virtual void update( Int frame );
-	virtual void reverse();
-	virtual void draw();
+	virtual void init( GameWindow *win ) override;
+	virtual void update( Int frame ) override;
+	virtual void reverse() override;
+	virtual void draw() override;
 
-	virtual void skip();
+	virtual void skip() override;
 
 protected:
 	enum{
@@ -529,14 +529,14 @@ class FlashTransition : public Transition
 {
 public:
 	FlashTransition ();
-	virtual ~FlashTransition();
+	virtual ~FlashTransition() override;
 
-	virtual void init( GameWindow *win );
-	virtual void update( Int frame );
-	virtual void reverse();
-	virtual void draw();
+	virtual void init( GameWindow *win ) override;
+	virtual void update( Int frame ) override;
+	virtual void reverse() override;
+	virtual void draw() override;
 
-	virtual void skip();
+	virtual void skip() override;
 
 protected:
 	enum{
@@ -560,14 +560,14 @@ class ButtonFlashTransition : public Transition
 {
 public:
 	ButtonFlashTransition ();
-	virtual ~ButtonFlashTransition();
+	virtual ~ButtonFlashTransition() override;
 
-	virtual void init( GameWindow *win );
-	virtual void update( Int frame );
-	virtual void reverse();
-	virtual void draw();
+	virtual void init( GameWindow *win ) override;
+	virtual void update( Int frame ) override;
+	virtual void reverse() override;
+	virtual void draw() override;
 
-	virtual void skip();
+	virtual void skip() override;
 
 protected:
 	enum{
@@ -656,13 +656,13 @@ class GameWindowTransitionsHandler: public SubsystemInterface
 {
 public:
 	GameWindowTransitionsHandler();
-	~GameWindowTransitionsHandler();
+	~GameWindowTransitionsHandler() override;
 
-	void init();
+	void init() override;
 	void load();
-	void reset();
-	void update();
-	void draw();
+	void reset() override;
+	void update() override;
+	void draw() override;
 	Bool isFinished();
 	const FieldParse *getFieldParse() const { return m_gameWindowTransitionsFieldParseTable; }								///< returns the parsing fields
 	static const FieldParse m_gameWindowTransitionsFieldParseTable[];																				///< the parse table

--- a/Core/GameEngine/Include/GameClient/GlobalLanguage.h
+++ b/Core/GameEngine/Include/GameClient/GlobalLanguage.h
@@ -82,11 +82,11 @@ public:
 public:
 
 	GlobalLanguage();
-	virtual ~GlobalLanguage();
+	virtual ~GlobalLanguage() override;
 
-	void init();
-	void reset();
-	void update() {}
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override {}
 
 	Real getResolutionFontSizeAdjustment() const;
 	Int adjustFontSize(Int theFontSize); // Adjusts font size for resolution. jba.

--- a/Core/GameEngine/Include/GameClient/IMEManager.h
+++ b/Core/GameEngine/Include/GameClient/IMEManager.h
@@ -72,7 +72,7 @@ class IMEManagerInterface : public SubsystemInterface
 
 	public:
 
-		virtual ~IMEManagerInterface() {};
+		virtual ~IMEManagerInterface() override {};
 
 		virtual void					attach( GameWindow *window ) = 0;		///< attach IME to specified window
 		virtual void					detach() = 0;								///< detach IME from current window

--- a/Core/GameEngine/Include/GameClient/Keyboard.h
+++ b/Core/GameEngine/Include/GameClient/Keyboard.h
@@ -95,13 +95,13 @@ class Keyboard : public SubsystemInterface
 public:
 
 	Keyboard();
-	virtual ~Keyboard();
+	virtual ~Keyboard() override;
 
 	// you may extend the functionality of these for your device
-	virtual void init();							/**< initialize the keyboard, only extend this
+	virtual void init() override;							/**< initialize the keyboard, only extend this
 																							 functionality, do not replace */
-	virtual void reset();							///< Reset keyboard system
-	virtual void update();						/**< gather current state of all keys, extend
+	virtual void reset() override;							///< Reset keyboard system
+	virtual void update() override;						/**< gather current state of all keys, extend
 																							 this functionality, do not replace */
 	virtual Bool getCapsState() = 0;  ///< get state of caps lock key, return TRUE if down
 

--- a/Core/GameEngine/Include/GameClient/LanguageFilter.h
+++ b/Core/GameEngine/Include/GameClient/LanguageFilter.h
@@ -65,11 +65,11 @@ static const char BadWordFileName[] = "langdata.dat";
 class LanguageFilter : public SubsystemInterface {
 public:
 	LanguageFilter();
-	~LanguageFilter();
+	virtual ~LanguageFilter() override;
 
-	void init();
-	void reset();
-	void update();
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override;
 	void filterLine(UnicodeString &line);
 
 protected:

--- a/Core/GameEngine/Include/GameClient/LoadScreen.h
+++ b/Core/GameEngine/Include/GameClient/LoadScreen.h
@@ -78,21 +78,21 @@ class SinglePlayerLoadScreen : public LoadScreen
 {
 public:
 	SinglePlayerLoadScreen();
-	virtual ~SinglePlayerLoadScreen();
+	virtual ~SinglePlayerLoadScreen() override;
 
-	virtual void init( GameInfo *game );		///< Init the loadscreen
-	virtual void reset();		///< Reset the system
+	virtual void init( GameInfo *game ) override;		///< Init the loadscreen
+	virtual void reset() override;		///< Reset the system
 	virtual void update()
 	{
 		DEBUG_CRASH(("Call update(Int) instead.  This update isn't supported"));
 	};
-	virtual void update(Int percent);		 ///< Update the state of the progress bar
-	virtual void processProgress(Int playerId, Int percentage)
+	virtual void update(Int percent) override;		 ///< Update the state of the progress bar
+	virtual void processProgress(Int playerId, Int percentage) override
 	{
 		DEBUG_CRASH(("We Got to a single player load screen throw the Network..."));
 	}
 
-	virtual void setProgressRange( Int min, Int max );
+	virtual void setProgressRange( Int min, Int max ) override;
 
 private:
 	GameWindow *m_progressBar;				///< Pointer to the Progress Bar on the window
@@ -128,21 +128,21 @@ class ChallengeLoadScreen : public LoadScreen
 {
 public:
 	ChallengeLoadScreen();
-	virtual ~ChallengeLoadScreen();
+	virtual ~ChallengeLoadScreen() override;
 
-	virtual void init( GameInfo *game );		///< Init the loadscreen
-	virtual void reset();		///< Reset the system
+	virtual void init( GameInfo *game ) override;		///< Init the loadscreen
+	virtual void reset() override;		///< Reset the system
 	virtual void update()
 	{
 		DEBUG_CRASH(("Call update(Int) instead.  This update isn't supported"));
 	};
-	virtual void update(Int percent);		 ///< Update the state of the progress bar
-	virtual void processProgress(Int playerId, Int percentage)
+	virtual void update(Int percent) override;		 ///< Update the state of the progress bar
+	virtual void processProgress(Int playerId, Int percentage) override
 	{
 		DEBUG_CRASH(("We Got to a single player load screen throw the Network..."));
 	}
 
-	virtual void setProgressRange( Int min, Int max );
+	virtual void setProgressRange( Int min, Int max ) override;
 
 private:
 	GameWindow *m_progressBar;				///< Pointer to the Progress Bar on the window
@@ -200,20 +200,20 @@ class ShellGameLoadScreen : public LoadScreen
 {
 public:
 	ShellGameLoadScreen();
-	virtual ~ShellGameLoadScreen();
+	virtual ~ShellGameLoadScreen() override;
 
-	virtual void init( GameInfo *game );		///< Init the loadscreen
-	virtual void reset();		///< Reset the system
+	virtual void init( GameInfo *game ) override;		///< Init the loadscreen
+	virtual void reset() override;		///< Reset the system
 	virtual void update()
 	{
 		DEBUG_CRASH(("Call update(Int) instead.  This update isn't supported"));
 	};
-	virtual void update(Int percent);		 ///< Update the state of the progress bar
-	virtual void processProgress(Int playerId, Int percentage)
+	virtual void update(Int percent) override;		 ///< Update the state of the progress bar
+	virtual void processProgress(Int playerId, Int percentage) override
 	{
 		DEBUG_CRASH(("We Got to a single player load screen throw the Network..."));
 	}
-	virtual void setProgressRange( Int min, Int max ) { }
+	virtual void setProgressRange( Int min, Int max ) override { }
 
 private:
 	GameWindow *m_progressBar	;				///< Pointer to the Progress Bar on the window
@@ -228,17 +228,17 @@ class MultiPlayerLoadScreen : public LoadScreen
 {
 public:
 	MultiPlayerLoadScreen();
-	virtual ~MultiPlayerLoadScreen();
+	virtual ~MultiPlayerLoadScreen() override;
 
-	virtual void init( GameInfo *game );		///< Init the loadscreen
-	virtual void reset();		///< Reset the system
+	virtual void init( GameInfo *game ) override;		///< Init the loadscreen
+	virtual void reset() override;		///< Reset the system
 	virtual void update()
 	{
 		DEBUG_CRASH(("Call update(Int) instead.  This update isn't supported"));
 	};
-	virtual void update(Int percent);		 ///< Update the state of the progress bar
-	void processProgress(Int playerId, Int percentage);
-	virtual void setProgressRange( Int min, Int max ) { }
+	virtual void update(Int percent) override;		 ///< Update the state of the progress bar
+	virtual void processProgress(Int playerId, Int percentage) override;
+	virtual void setProgressRange( Int min, Int max ) override { }
 private:
 	GameWindow *m_progressBars[MAX_SLOTS];	///< pointer array to all the progress bars on the window
 	GameWindow *m_playerNames[MAX_SLOTS];		///< pointer array to all the static text player names on the window
@@ -259,17 +259,17 @@ class GameSpyLoadScreen : public LoadScreen
 {
 public:
 	GameSpyLoadScreen();
-	virtual ~GameSpyLoadScreen();
+	virtual ~GameSpyLoadScreen() override;
 
-	virtual void init( GameInfo *game );		///< Init the loadscreen
-	virtual void reset();		///< Reset the system
+	virtual void init( GameInfo *game ) override;		///< Init the loadscreen
+	virtual void reset() override;		///< Reset the system
 	virtual void update()
 	{
 		DEBUG_CRASH(("Call update(Int) instead.  This update isn't supported"));
 	};
-	virtual void update(Int percent);		 ///< Update the state of the progress bar
-	void processProgress(Int playerId, Int percentage);
-	virtual void setProgressRange( Int min, Int max ) { }
+	virtual void update(Int percent) override;		 ///< Update the state of the progress bar
+	virtual void processProgress(Int playerId, Int percentage) override;
+	virtual void setProgressRange( Int min, Int max ) override { }
 private:
 	GameWindow *m_progressBars[MAX_SLOTS];	///< pointer array to all the progress bars on the window
 	GameWindow *m_playerNames[MAX_SLOTS];		///< pointer array to all the static text player names on the window
@@ -297,21 +297,21 @@ class MapTransferLoadScreen : public LoadScreen
 {
 public:
 	MapTransferLoadScreen();
-	virtual ~MapTransferLoadScreen();
+	virtual ~MapTransferLoadScreen() override;
 
-	virtual void init( GameInfo *game );		///< Init the loadscreen
-	virtual void reset();							///< Reset the system
+	virtual void init( GameInfo *game ) override;		///< Init the loadscreen
+	virtual void reset() override;							///< Reset the system
 	virtual void update()
 	{
 		DEBUG_CRASH(("Call update(Int) instead.  This update isn't supported"));
 	};
-	virtual void update(Int percent);				///< Update the state of the progress bar
-	virtual void processProgress(Int playerId, Int percentage)
+	virtual void update(Int percent) override;				///< Update the state of the progress bar
+	virtual void processProgress(Int playerId, Int percentage) override
 	{
 		DEBUG_CRASH(("Call processProgress(Int, Int, AsciiString) instead."));
 	}
 	void processProgress(Int playerId, Int percentage, AsciiString stateStr);
-	virtual void setProgressRange( Int min, Int max ) { }
+	virtual void setProgressRange( Int min, Int max ) override { }
 	void processTimeout(Int secondsLeft);
 	void setCurrentFilename(AsciiString filename);
 private:

--- a/Core/GameEngine/Include/GameClient/Mouse.h
+++ b/Core/GameEngine/Include/GameClient/Mouse.h
@@ -268,20 +268,20 @@ public:
 public:
 
 	Mouse();
-	virtual ~Mouse();
+	virtual ~Mouse() override;
 
 	// you may need to extend these for your device
 	virtual void parseIni();	///< parse ini settings associated with mouse (do this before init()).
-	virtual void init();		///< init mouse, extend this functionality, do not replace
-	virtual void reset();		///< Reset the system
-	virtual void update();  ///< update the state of the mouse position and buttons
+	virtual void init() override;		///< init mouse, extend this functionality, do not replace
+	virtual void reset() override;		///< Reset the system
+	virtual void update() override;  ///< update the state of the mouse position and buttons
 	virtual void initCursorResources()=0;	///< needed so Win32 cursors can load resources before D3D device created.
 
 	virtual void createStreamMessages();  /**< given state of device, create
 																									 messages and put them on the
 																									 stream for the raw state. */
 
-	virtual void draw();													///< draw the mouse
+	virtual void draw() override;													///< draw the mouse
 	virtual void setPosition( Int x, Int y );						///< set the mouse position
 	virtual void setCursor( MouseCursor cursor ) = 0;		///< set mouse cursor
 
@@ -424,14 +424,14 @@ protected:
 // Mouse that does nothing. Used for Headless Mode.
 class MouseDummy : public Mouse
 {
-	virtual void parseIni() {}
-	virtual void update() {}
-	virtual void initCursorResources() {}
-	virtual void createStreamMessages() {}
-	virtual void setCursor(MouseCursor cursor) {}
-	virtual void capture() {}
-	virtual void releaseCapture() {}
-	virtual UnsignedByte getMouseEvent(MouseIO *result, Bool flush) { return MOUSE_NONE; }
+	virtual void parseIni() override {}
+	virtual void update() override {}
+	virtual void initCursorResources() override {}
+	virtual void createStreamMessages() override {}
+	virtual void setCursor(MouseCursor cursor) override {}
+	virtual void capture() override {}
+	virtual void releaseCapture() override {}
+	virtual UnsignedByte getMouseEvent(MouseIO *result, Bool flush) override { return MOUSE_NONE; }
 };
 
 

--- a/Core/GameEngine/Include/GameClient/ParticleSys.h
+++ b/Core/GameEngine/Include/GameClient/ParticleSys.h
@@ -157,9 +157,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 };
 
@@ -206,9 +206,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	void computeAlphaRate();							///< compute alpha rate to get to next key
 	void computeColorRate();							///< compute color change to get to next key
@@ -264,9 +264,9 @@ public:
 	ParticleSystemInfo();												///< to set defaults.
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	Bool m_isOneShot;														///< if true, destroy system after one burst has occurred
 
@@ -662,9 +662,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	virtual Particle *createParticle( const ParticleInfo *data,
 																		ParticlePriorityType priority,
@@ -747,11 +747,11 @@ public:
 	typedef std::hash_map<AsciiString, ParticleSystemTemplate *, rts::hash<AsciiString>, rts::equal_to<AsciiString> > TemplateMap;
 
 	ParticleSystemManager();
-	virtual ~ParticleSystemManager();
+	virtual ~ParticleSystemManager() override;
 
-	virtual void init();									///< initialize the manager
-	virtual void reset();									///< reset the manager and all particle systems
-	virtual void update();								///< update all particle systems
+	virtual void init() override;									///< initialize the manager
+	virtual void reset() override;									///< reset the manager and all particle systems
+	virtual void update() override;								///< update all particle systems
 
 	virtual Int getOnScreenParticleCount() = 0;   ///< returns the number of particles on screen
   virtual void setOnScreenParticleCount(int count);
@@ -812,9 +812,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	Particle *m_allParticlesHead[ NUM_PARTICLE_PRIORITIES ];
 	Particle *m_allParticlesTail[ NUM_PARTICLE_PRIORITIES ];

--- a/Core/GameEngine/Include/GameClient/ProcessAnimateWindow.h
+++ b/Core/GameEngine/Include/GameClient/ProcessAnimateWindow.h
@@ -91,12 +91,12 @@ class ProcessAnimateWindowSlideFromRight : public ProcessAnimateWindow
 public:
 
 	ProcessAnimateWindowSlideFromRight();
-	virtual ~ProcessAnimateWindowSlideFromRight();
+	virtual ~ProcessAnimateWindowSlideFromRight() override;
 
-	virtual void initAnimateWindow( wnd::AnimateWindow *animWin );
-	virtual void initReverseAnimateWindow( wnd::AnimateWindow *animWin, UnsignedInt maxDelay = 0 );
-	virtual Bool updateAnimateWindow( wnd::AnimateWindow *animWin );
-	virtual Bool reverseAnimateWindow( wnd::AnimateWindow *animWin );
+	virtual void initAnimateWindow( wnd::AnimateWindow *animWin ) override;
+	virtual void initReverseAnimateWindow( wnd::AnimateWindow *animWin, UnsignedInt maxDelay = 0 ) override;
+	virtual Bool updateAnimateWindow( wnd::AnimateWindow *animWin ) override;
+	virtual Bool reverseAnimateWindow( wnd::AnimateWindow *animWin ) override;
 private:
 Coord2D m_maxVel;  // top speed windows travel in x and y
 Int m_slowDownThreshold;  // when windows get this close to their resting
@@ -114,12 +114,12 @@ class ProcessAnimateWindowSlideFromLeft : public ProcessAnimateWindow
 public:
 
 	ProcessAnimateWindowSlideFromLeft();
-	virtual ~ProcessAnimateWindowSlideFromLeft();
+	virtual ~ProcessAnimateWindowSlideFromLeft() override;
 
-	virtual void initAnimateWindow( wnd::AnimateWindow *animWin );
-	virtual void initReverseAnimateWindow( wnd::AnimateWindow *animWin, UnsignedInt maxDelay = 0 );
-	virtual Bool updateAnimateWindow( wnd::AnimateWindow *animWin );
-	virtual Bool reverseAnimateWindow( wnd::AnimateWindow *animWin );
+	virtual void initAnimateWindow( wnd::AnimateWindow *animWin ) override;
+	virtual void initReverseAnimateWindow( wnd::AnimateWindow *animWin, UnsignedInt maxDelay = 0 ) override;
+	virtual Bool updateAnimateWindow( wnd::AnimateWindow *animWin ) override;
+	virtual Bool reverseAnimateWindow( wnd::AnimateWindow *animWin ) override;
 private:
 Coord2D m_maxVel;  // top speed windows travel in x and y
 Int m_slowDownThreshold;  // when windows get this close to their resting
@@ -137,12 +137,12 @@ class ProcessAnimateWindowSlideFromTop : public ProcessAnimateWindow
 public:
 
 	ProcessAnimateWindowSlideFromTop();
-	virtual ~ProcessAnimateWindowSlideFromTop();
+	virtual ~ProcessAnimateWindowSlideFromTop() override;
 
-	virtual void initAnimateWindow( wnd::AnimateWindow *animWin );
-	virtual void initReverseAnimateWindow( wnd::AnimateWindow *animWin, UnsignedInt maxDelay = 0 );
-	virtual Bool updateAnimateWindow( wnd::AnimateWindow *animWin );
-	virtual Bool reverseAnimateWindow( wnd::AnimateWindow *animWin );
+	virtual void initAnimateWindow( wnd::AnimateWindow *animWin ) override;
+	virtual void initReverseAnimateWindow( wnd::AnimateWindow *animWin, UnsignedInt maxDelay = 0 ) override;
+	virtual Bool updateAnimateWindow( wnd::AnimateWindow *animWin ) override;
+	virtual Bool reverseAnimateWindow( wnd::AnimateWindow *animWin ) override;
 private:
 Coord2D m_maxVel;  // top speed windows travel in x and y
 Int m_slowDownThreshold;  // when windows get this close to their resting
@@ -158,12 +158,12 @@ class ProcessAnimateWindowSlideFromTopFast : public ProcessAnimateWindow
 public:
 
 	ProcessAnimateWindowSlideFromTopFast();
-	virtual ~ProcessAnimateWindowSlideFromTopFast();
+	virtual ~ProcessAnimateWindowSlideFromTopFast() override;
 
-	virtual void initAnimateWindow( wnd::AnimateWindow *animWin );
-	virtual void initReverseAnimateWindow( wnd::AnimateWindow *animWin, UnsignedInt maxDelay = 0 );
-	virtual Bool updateAnimateWindow( wnd::AnimateWindow *animWin );
-	virtual Bool reverseAnimateWindow( wnd::AnimateWindow *animWin );
+	virtual void initAnimateWindow( wnd::AnimateWindow *animWin ) override;
+	virtual void initReverseAnimateWindow( wnd::AnimateWindow *animWin, UnsignedInt maxDelay = 0 ) override;
+	virtual Bool updateAnimateWindow( wnd::AnimateWindow *animWin ) override;
+	virtual Bool reverseAnimateWindow( wnd::AnimateWindow *animWin ) override;
 private:
 Coord2D m_maxVel;  // top speed windows travel in x and y
 Int m_slowDownThreshold;  // when windows get this close to their resting
@@ -181,12 +181,12 @@ class ProcessAnimateWindowSlideFromBottom : public ProcessAnimateWindow
 public:
 
 	ProcessAnimateWindowSlideFromBottom();
-	virtual ~ProcessAnimateWindowSlideFromBottom();
+	virtual ~ProcessAnimateWindowSlideFromBottom() override;
 
-	virtual void initAnimateWindow( wnd::AnimateWindow *animWin );
-	virtual void initReverseAnimateWindow( wnd::AnimateWindow *animWin, UnsignedInt maxDelay = 0 );
-	virtual Bool updateAnimateWindow( wnd::AnimateWindow *animWin );
-	virtual Bool reverseAnimateWindow( wnd::AnimateWindow *animWin );
+	virtual void initAnimateWindow( wnd::AnimateWindow *animWin ) override;
+	virtual void initReverseAnimateWindow( wnd::AnimateWindow *animWin, UnsignedInt maxDelay = 0 ) override;
+	virtual Bool updateAnimateWindow( wnd::AnimateWindow *animWin ) override;
+	virtual Bool reverseAnimateWindow( wnd::AnimateWindow *animWin ) override;
 private:
 Coord2D m_maxVel;  // top speed windows travel in x and y
 Int m_slowDownThreshold;  // when windows get this close to their resting
@@ -203,12 +203,12 @@ class ProcessAnimateWindowSpiral : public ProcessAnimateWindow
 public:
 
 	ProcessAnimateWindowSpiral();
-	virtual ~ProcessAnimateWindowSpiral();
+	virtual ~ProcessAnimateWindowSpiral() override;
 
-	virtual void initAnimateWindow( wnd::AnimateWindow *animWin );
-	virtual void initReverseAnimateWindow( wnd::AnimateWindow *animWin, UnsignedInt maxDelay = 0 );
-	virtual Bool updateAnimateWindow( wnd::AnimateWindow *animWin );
-	virtual Bool reverseAnimateWindow( wnd::AnimateWindow *animWin );
+	virtual void initAnimateWindow( wnd::AnimateWindow *animWin ) override;
+	virtual void initReverseAnimateWindow( wnd::AnimateWindow *animWin, UnsignedInt maxDelay = 0 ) override;
+	virtual Bool updateAnimateWindow( wnd::AnimateWindow *animWin ) override;
+	virtual Bool reverseAnimateWindow( wnd::AnimateWindow *animWin ) override;
 private:
 	Real m_deltaTheta;
 	Int m_maxR;
@@ -221,13 +221,13 @@ class ProcessAnimateWindowSlideFromBottomTimed : public ProcessAnimateWindow
 public:
 
 	ProcessAnimateWindowSlideFromBottomTimed();
-	virtual ~ProcessAnimateWindowSlideFromBottomTimed();
+	virtual ~ProcessAnimateWindowSlideFromBottomTimed() override;
 
-	virtual void initAnimateWindow( wnd::AnimateWindow *animWin );
-	virtual void initReverseAnimateWindow( wnd::AnimateWindow *animWin, UnsignedInt maxDelay = 0 );
-	virtual Bool updateAnimateWindow( wnd::AnimateWindow *animWin );
-	virtual Bool reverseAnimateWindow( wnd::AnimateWindow *animWin );
-	virtual void setMaxDuration(UnsignedInt maxDuration) { m_maxDuration = maxDuration; }
+	virtual void initAnimateWindow( wnd::AnimateWindow *animWin ) override;
+	virtual void initReverseAnimateWindow( wnd::AnimateWindow *animWin, UnsignedInt maxDelay = 0 ) override;
+	virtual Bool updateAnimateWindow( wnd::AnimateWindow *animWin ) override;
+	virtual Bool reverseAnimateWindow( wnd::AnimateWindow *animWin ) override;
+	virtual void setMaxDuration(UnsignedInt maxDuration) override { m_maxDuration = maxDuration; }
 
 private:
 	UnsignedInt m_maxDuration;
@@ -239,12 +239,12 @@ class ProcessAnimateWindowSlideFromRightFast : public ProcessAnimateWindow
 public:
 
 	ProcessAnimateWindowSlideFromRightFast();
-	virtual ~ProcessAnimateWindowSlideFromRightFast();
+	virtual ~ProcessAnimateWindowSlideFromRightFast() override;
 
-	virtual void initAnimateWindow( wnd::AnimateWindow *animWin );
-	virtual void initReverseAnimateWindow( wnd::AnimateWindow *animWin, UnsignedInt maxDelay = 0 );
-	virtual Bool updateAnimateWindow( wnd::AnimateWindow *animWin );
-	virtual Bool reverseAnimateWindow( wnd::AnimateWindow *animWin );
+	virtual void initAnimateWindow( wnd::AnimateWindow *animWin ) override;
+	virtual void initReverseAnimateWindow( wnd::AnimateWindow *animWin, UnsignedInt maxDelay = 0 ) override;
+	virtual Bool updateAnimateWindow( wnd::AnimateWindow *animWin ) override;
+	virtual Bool reverseAnimateWindow( wnd::AnimateWindow *animWin ) override;
 private:
 Coord2D m_maxVel;  // top speed windows travel in x and y
 Int m_slowDownThreshold;  // when windows get this close to their resting

--- a/Core/GameEngine/Include/GameClient/Smudge.h
+++ b/Core/GameEngine/Include/GameClient/Smudge.h
@@ -51,7 +51,7 @@ public:
 	friend class SmudgeManager;
 
 	SmudgeSet();
-	virtual ~SmudgeSet();
+	virtual ~SmudgeSet() override;
 	void reset();
 
 	Smudge *addSmudgeToSet();

--- a/Core/GameEngine/Include/GameClient/Snow.h
+++ b/Core/GameEngine/Include/GameClient/Snow.h
@@ -87,10 +87,10 @@ class SnowManager : public SubsystemInterface
 	  };
 
 	 SnowManager();
-	~SnowManager();
+	~SnowManager() override;
 
-	virtual void init();
-	virtual void reset();
+	virtual void init() override;
+	virtual void reset() override;
 	virtual void updateIniSettings ();
 	void setVisible(Bool showWeather);	///<enable/disable rendering of weather - assuming it's available on map.
 

--- a/Core/GameEngine/Include/GameClient/Snow.h
+++ b/Core/GameEngine/Include/GameClient/Snow.h
@@ -87,7 +87,7 @@ class SnowManager : public SubsystemInterface
 	  };
 
 	 SnowManager();
-	~SnowManager() override;
+	virtual ~SnowManager() override;
 
 	virtual void init() override;
 	virtual void reset() override;

--- a/Core/GameEngine/Include/GameClient/TerrainRoads.h
+++ b/Core/GameEngine/Include/GameClient/TerrainRoads.h
@@ -199,7 +199,7 @@ class TerrainRoadCollection : public SubsystemInterface
 public:
 
 	TerrainRoadCollection();
-	~TerrainRoadCollection() override;
+	virtual ~TerrainRoadCollection() override;
 
 	virtual void init() override { }
 	virtual void reset() override { }

--- a/Core/GameEngine/Include/GameClient/TerrainRoads.h
+++ b/Core/GameEngine/Include/GameClient/TerrainRoads.h
@@ -199,11 +199,11 @@ class TerrainRoadCollection : public SubsystemInterface
 public:
 
 	TerrainRoadCollection();
-	~TerrainRoadCollection();
+	~TerrainRoadCollection() override;
 
-	void init() { }
-	void reset() { }
-	void update() { }
+	virtual void init() override { }
+	virtual void reset() override { }
+	virtual void update() override { }
 
 	TerrainRoadType *findRoad( AsciiString name );		///< find road with matching name
 	TerrainRoadType *newRoad( AsciiString name );			///< allocate new road, assign name, and link to list

--- a/Core/GameEngine/Include/GameClient/TerrainVisual.h
+++ b/Core/GameEngine/Include/GameClient/TerrainVisual.h
@@ -148,8 +148,8 @@ typedef SeismicSimulationList::iterator SeismicSimulationListIt;
 
 class DomeStyleSeismicFilter : public SeismicSimulationFilterBase
 {
-  virtual SeismicSimStatusCode filterCallback( WorldHeightMapInterfaceClass *heightMap, const SeismicSimulationNode *node );
-  virtual Real applyGravityCallback( Real velocityIn );
+  virtual SeismicSimStatusCode filterCallback( WorldHeightMapInterfaceClass *heightMap, const SeismicSimulationNode *node ) override;
+  virtual Real applyGravityCallback( Real velocityIn ) override;
 };
 
 
@@ -203,11 +203,11 @@ public:
 	enum {NumSkyboxTextures = 5};
 
 	TerrainVisual();
-	virtual ~TerrainVisual();
+	virtual ~TerrainVisual() override;
 
-	virtual void init();
-	virtual void reset();
-	virtual void update();
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override;
 
 	virtual Bool load( AsciiString filename );
 
@@ -298,9 +298,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	AsciiString m_filenameString;							///< file with terrain data
 

--- a/Core/GameEngine/Include/GameClient/VideoPlayer.h
+++ b/Core/GameEngine/Include/GameClient/VideoPlayer.h
@@ -223,9 +223,9 @@ class VideoPlayerInterface : public SubsystemInterface
 
 	public:
 
-		virtual void	init() override = 0;														///< Initialize video playback
-		virtual void	reset() override = 0;													///< Reset video playback
-		virtual void	update() override = 0;													///< Services all video tasks. Should be called frequently
+		virtual void	init() = 0;														///< Initialize video playback
+		virtual void	reset() = 0;													///< Reset video playback
+		virtual void	update() = 0;													///< Services all video tasks. Should be called frequently
 
 		virtual void	deinit() = 0;													///< Close down player
 

--- a/Core/GameEngine/Include/GameClient/VideoPlayer.h
+++ b/Core/GameEngine/Include/GameClient/VideoPlayer.h
@@ -189,23 +189,23 @@ class VideoStream : public VideoStreamInterface
 		VideoStream							*m_next;									///< Next open stream
 
 		VideoStream();																		///< only VideoPlayer can create these
-		virtual ~VideoStream();
+		virtual ~VideoStream() override;
 
 	public:
 
- 		virtual	VideoStreamInterface* next();				///< Returns next open stream
-		virtual void update();											///< Update stream
-		virtual void close();												///< Close and free stream
+ 		virtual	VideoStreamInterface* next() override;				///< Returns next open stream
+		virtual void update() override;											///< Update stream
+		virtual void close() override;												///< Close and free stream
 
-		virtual Bool	isFrameReady();								///< Is the frame ready to be displayed
-		virtual void	frameDecompress();						///< Render current frame in to buffer
-		virtual void	frameRender( VideoBuffer *buffer ); ///< Render current frame in to buffer
-		virtual void	frameNext();									///< Advance to next frame
-		virtual Int		frameIndex();									///< Returns zero based index of current frame
-		virtual Int		frameCount();									///< Returns the total number of frames in the stream
-		virtual void	frameGoto( Int index );							///< Go to the spcified frame index
-		virtual Int		height();											///< Return the height of the video
-		virtual Int		width();											///< Return the width of the video
+		virtual Bool	isFrameReady() override;								///< Is the frame ready to be displayed
+		virtual void	frameDecompress() override;						///< Render current frame in to buffer
+		virtual void	frameRender( VideoBuffer *buffer ) override; ///< Render current frame in to buffer
+		virtual void	frameNext() override;									///< Advance to next frame
+		virtual Int		frameIndex() override;									///< Returns zero based index of current frame
+		virtual Int		frameCount() override;									///< Returns the total number of frames in the stream
+		virtual void	frameGoto( Int index ) override;							///< Go to the spcified frame index
+		virtual Int		height() override;											///< Return the height of the video
+		virtual Int		width() override;											///< Return the width of the video
 
 
 };
@@ -223,13 +223,13 @@ class VideoPlayerInterface : public SubsystemInterface
 
 	public:
 
-		virtual void	init() = 0;														///< Initialize video playback
-		virtual void	reset() = 0;													///< Reset video playback
-		virtual void	update() = 0;													///< Services all video tasks. Should be called frequently
+		virtual void	init() override = 0;														///< Initialize video playback
+		virtual void	reset() override = 0;													///< Reset video playback
+		virtual void	update() override = 0;													///< Services all video tasks. Should be called frequently
 
 		virtual void	deinit() = 0;													///< Close down player
 
-		virtual				~VideoPlayerInterface() {};
+		virtual ~VideoPlayerInterface() override {};
 
 		// service
 		virtual void	loseFocus() = 0;											///< Should be called when application loses focus
@@ -271,33 +271,33 @@ class VideoPlayer : public VideoPlayerInterface
 	public:
 
 		// subsytem requirements
-		virtual void	init();														///< Initialize video playback code
-		virtual void	reset();													///< Reset video playback
-		virtual void	update();													///< Services all audio tasks. Should be called frequently
+		virtual void	init() override;														///< Initialize video playback code
+		virtual void	reset() override;													///< Reset video playback
+		virtual void	update() override;													///< Services all audio tasks. Should be called frequently
 
-		virtual void	deinit();													///< Close down player
+		virtual void	deinit() override;													///< Close down player
 
 
 		VideoPlayer();
-		~VideoPlayer();
+		virtual ~VideoPlayer() override;
 
 		// service
-		virtual void	loseFocus();											///< Should be called when application loses focus
-		virtual void	regainFocus();										///< Should be called when application regains focus
+		virtual void	loseFocus() override;											///< Should be called when application loses focus
+		virtual void	regainFocus() override;										///< Should be called when application regains focus
 
-		virtual VideoStreamInterface*	open( AsciiString movieTitle );	///< Open video file for playback
-		virtual VideoStreamInterface*	load( AsciiString movieTitle );	///< Load video file in to memory for playback
-		virtual VideoStreamInterface* firstStream();		///< Return the first open/loaded video stream
-		virtual void	closeAllStreams();								///< Close all open streams
+		virtual VideoStreamInterface*	open( AsciiString movieTitle ) override;	///< Open video file for playback
+		virtual VideoStreamInterface*	load( AsciiString movieTitle ) override;	///< Load video file in to memory for playback
+		virtual VideoStreamInterface* firstStream() override;		///< Return the first open/loaded video stream
+		virtual void	closeAllStreams() override;								///< Close all open streams
 
-		virtual void	addVideo( Video* videoToAdd );					///< Add a video to the list of videos we can play
-		virtual void	removeVideo( Video* videoToRemove );		///< Remove a video to the list of videos we can play
-		virtual Int getNumVideos();											///< Retrieve info about the number of videos currently listed
-		virtual const Video* getVideo( AsciiString movieTitle );	///< Retrieve info about a movie based on internal name
-		virtual const Video* getVideo( Int index );						///< Retrieve info about a movie based on index
-		virtual const FieldParse *getFieldParse() const { return m_videoFieldParseTable; }		///< Return the field parse info
+		virtual void	addVideo( Video* videoToAdd ) override;					///< Add a video to the list of videos we can play
+		virtual void	removeVideo( Video* videoToRemove ) override;		///< Remove a video to the list of videos we can play
+		virtual Int getNumVideos() override;											///< Retrieve info about the number of videos currently listed
+		virtual const Video* getVideo( AsciiString movieTitle ) override;	///< Retrieve info about a movie based on internal name
+		virtual const Video* getVideo( Int index ) override;						///< Retrieve info about a movie based on index
+		virtual const FieldParse *getFieldParse() const override { return m_videoFieldParseTable; }		///< Return the field parse info
 
-		virtual void notifyVideoPlayerOfNewProvider( Bool nowHasValid ) { }
+		virtual void notifyVideoPlayerOfNewProvider( Bool nowHasValid ) override { }
 
 		// Implementation specific
 		void remove( VideoStream *stream );										///< remove stream from active list

--- a/Core/GameEngine/Include/GameClient/View.h
+++ b/Core/GameEngine/Include/GameClient/View.h
@@ -255,9 +255,9 @@ protected:
 	friend class Display;
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer ) { }
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess() { }
+	virtual void crc( Xfer *xfer ) override { }
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override { }
 
 	const Coord3D *getPosition() const { return &m_pos; }
 

--- a/Core/GameEngine/Include/GameClient/WindowVideoManager.h
+++ b/Core/GameEngine/Include/GameClient/WindowVideoManager.h
@@ -120,12 +120,12 @@ class WindowVideoManager : public SubsystemInterface
 {
 public:
 	WindowVideoManager();
-	~WindowVideoManager();
+	~WindowVideoManager() override;
 
 	// Inhertited from subsystem ====================================================================
-	virtual void init();
-	virtual void reset();
-	virtual void update();
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override;
 	//===============================================================================================
 
 

--- a/Core/GameEngine/Include/GameClient/WindowVideoManager.h
+++ b/Core/GameEngine/Include/GameClient/WindowVideoManager.h
@@ -120,7 +120,7 @@ class WindowVideoManager : public SubsystemInterface
 {
 public:
 	WindowVideoManager();
-	~WindowVideoManager() override;
+	virtual ~WindowVideoManager() override;
 
 	// Inhertited from subsystem ====================================================================
 	virtual void init() override;

--- a/Core/GameEngine/Include/GameLogic/AIPathfind.h
+++ b/Core/GameEngine/Include/GameLogic/AIPathfind.h
@@ -647,9 +647,9 @@ public:
 	void reset();														///< Reset system in preparation for new map
 
 	// --------------- inherited from Snapshot interface --------------
-	void crc( Xfer *xfer ) override;
-	void xfer( Xfer *xfer ) override;
-	void loadPostProcess() override;
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	Bool clientSafeQuickDoesPathExist( const LocomotorSet& locomotorSet, const Coord3D *from, const Coord3D *to );  ///< Can we build any path at all between the locations	(terrain & buildings check - fast)
 	Bool clientSafeQuickDoesPathExistForUI( const LocomotorSet& locomotorSet, const Coord3D *from, const Coord3D *to );  ///< Can we build any path at all between the locations	(terrain only - fast)

--- a/Core/GameEngine/Include/GameLogic/AIPathfind.h
+++ b/Core/GameEngine/Include/GameLogic/AIPathfind.h
@@ -177,9 +177,9 @@ public:
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 	enum {MAX_CPOP=20};			///< Max times we will return the cached cpop.
@@ -620,25 +620,25 @@ class Pathfinder : PathfindServicesInterface, public Snapshot
 {
 // The following routines are private, but available through the doPathfind callback to aiInterface. jba.
 private:
-	virtual Path *findPath( Object *obj, const LocomotorSet& locomotorSet, const Coord3D *from, const Coord3D *to);	///< Find a short, valid path between given locations
+	virtual Path *findPath( Object *obj, const LocomotorSet& locomotorSet, const Coord3D *from, const Coord3D *to) override;	///< Find a short, valid path between given locations
 	/** Find a short, valid path to a location NEAR the to location.
 		This succeeds when the destination is unreachable (like inside a building).
 		If the destination is unreachable, it will adjust the to point.  */
 	virtual Path *findClosestPath( Object *obj, const LocomotorSet& locomotorSet, const Coord3D *from,
-		Coord3D *to, Bool blocked, Real pathCostMultiplier, Bool moveAllies );
+		Coord3D *to, Bool blocked, Real pathCostMultiplier, Bool moveAllies ) override;
 
 	/** Find a short, valid path to a location that obj can attack victim from.  */
 	virtual Path *findAttackPath( const Object *obj, const LocomotorSet& locomotorSet, const Coord3D *from,
-		const Object *victim, const Coord3D* victimPos, const Weapon *weapon );
+		const Object *victim, const Coord3D* victimPos, const Weapon *weapon ) override;
 
 	/** Find a short, valid path to a location that is away from the repulsors.  */
 	virtual Path *findSafePath( const Object *obj, const LocomotorSet& locomotorSet,
-		const Coord3D *from, const Coord3D* repulsorPos1, const Coord3D* repulsorPos2, Real repulsorRadius );
+		const Coord3D *from, const Coord3D* repulsorPos1, const Coord3D* repulsorPos2, Real repulsorRadius ) override;
 
 	/** Patch to the exiting path from the current position, either because we became blocked,
   or because we had to move off the path to avoid other units. */
 	virtual Path *patchPath( const Object *obj, const LocomotorSet& locomotorSet,
-		Path *originalPath, Bool blocked );
+		Path *originalPath, Bool blocked ) override;
 
 public:
 	Pathfinder();
@@ -647,9 +647,9 @@ public:
 	void reset();														///< Reset system in preparation for new map
 
 	// --------------- inherited from Snapshot interface --------------
-	void crc( Xfer *xfer );
-	void xfer( Xfer *xfer );
-	void loadPostProcess();
+	void crc( Xfer *xfer ) override;
+	void xfer( Xfer *xfer ) override;
+	void loadPostProcess() override;
 
 	Bool clientSafeQuickDoesPathExist( const LocomotorSet& locomotorSet, const Coord3D *from, const Coord3D *to );  ///< Can we build any path at all between the locations	(terrain & buildings check - fast)
 	Bool clientSafeQuickDoesPathExistForUI( const LocomotorSet& locomotorSet, const Coord3D *from, const Coord3D *to );  ///< Can we build any path at all between the locations	(terrain only - fast)

--- a/Core/GameEngine/Include/GameNetwork/DownloadManager.h
+++ b/Core/GameEngine/Include/GameNetwork/DownloadManager.h
@@ -58,11 +58,11 @@ public:
 	HRESULT update();
 	void reset();
 
-	virtual HRESULT OnError( Int error );
-	virtual HRESULT OnEnd();
-	virtual HRESULT OnQueryResume();
-	virtual HRESULT OnProgressUpdate( Int bytesread, Int totalsize, Int timetaken, Int timeleft );
-	virtual HRESULT OnStatusUpdate( Int status );
+	virtual HRESULT OnError( Int error ) override;
+	virtual HRESULT OnEnd() override;
+	virtual HRESULT OnQueryResume() override;
+	virtual HRESULT OnProgressUpdate( Int bytesread, Int totalsize, Int timetaken, Int timeleft ) override;
+	virtual HRESULT OnStatusUpdate( Int status ) override;
 
 	virtual HRESULT downloadFile( AsciiString server, AsciiString username, AsciiString password, AsciiString file, AsciiString localfile, AsciiString regkey, Bool tryResume );
 	AsciiString getLastLocalFile();

--- a/Core/GameEngine/Include/GameNetwork/GameInfo.h
+++ b/Core/GameEngine/Include/GameNetwork/GameInfo.h
@@ -289,9 +289,9 @@ private:
 
 protected:
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 public:
 	SkirmishGameInfo()

--- a/Core/GameEngine/Include/GameNetwork/GameSpy/GameResultsThread.h
+++ b/Core/GameEngine/Include/GameNetwork/GameSpy/GameResultsThread.h
@@ -56,7 +56,7 @@ public:
 class GameResultsInterface : public SubsystemInterface
 {
 public:
-	virtual ~GameResultsInterface() {}
+	virtual ~GameResultsInterface() override {}
 	virtual void startThreads() = 0;
 	virtual void endThreads() = 0;
 	virtual Bool areThreadsRunning() = 0;

--- a/Core/GameEngine/Include/GameNetwork/GameSpy/PeerDefsImplementation.h
+++ b/Core/GameEngine/Include/GameNetwork/GameSpy/PeerDefsImplementation.h
@@ -36,105 +36,105 @@ class GameSpyInfo : public GameSpyInfoInterface
 {
 public:
 	GameSpyInfo();
-	virtual ~GameSpyInfo();
-	virtual void reset();
-	virtual void clearGroupRoomList() { m_groupRooms.clear(); m_gotGroupRoomList = false; }
-	virtual GroupRoomMap* getGroupRoomList() { return &m_groupRooms; }
-	virtual void addGroupRoom( GameSpyGroupRoom room );
-	virtual Bool gotGroupRoomList() { return m_gotGroupRoomList; }
-	virtual void joinGroupRoom( Int groupID );
-	virtual void leaveGroupRoom();
-	virtual void joinBestGroupRoom();
-	virtual void setCurrentGroupRoom( Int groupID ) { m_currentGroupRoomID = groupID; m_playerInfoMap.clear(); }
-	virtual Int  getCurrentGroupRoom() { return m_currentGroupRoomID; }
-	virtual void updatePlayerInfo( PlayerInfo pi, AsciiString oldNick = AsciiString::TheEmptyString );
-	virtual void playerLeftGroupRoom( AsciiString nick );
-	virtual PlayerInfoMap* getPlayerInfoMap() { return &m_playerInfoMap; }
+	virtual ~GameSpyInfo() override;
+	virtual void reset() override;
+	virtual void clearGroupRoomList() override { m_groupRooms.clear(); m_gotGroupRoomList = false; }
+	virtual GroupRoomMap* getGroupRoomList() override { return &m_groupRooms; }
+	virtual void addGroupRoom( GameSpyGroupRoom room ) override;
+	virtual Bool gotGroupRoomList() override { return m_gotGroupRoomList; }
+	virtual void joinGroupRoom( Int groupID ) override;
+	virtual void leaveGroupRoom() override;
+	virtual void joinBestGroupRoom() override;
+	virtual void setCurrentGroupRoom( Int groupID ) override { m_currentGroupRoomID = groupID; m_playerInfoMap.clear(); }
+	virtual Int  getCurrentGroupRoom() override { return m_currentGroupRoomID; }
+	virtual void updatePlayerInfo( PlayerInfo pi, AsciiString oldNick = AsciiString::TheEmptyString ) override;
+	virtual void playerLeftGroupRoom( AsciiString nick ) override;
+	virtual PlayerInfoMap* getPlayerInfoMap() override { return &m_playerInfoMap; }
 
-	virtual void setLocalName( AsciiString name ) { m_localName = name; }
-	virtual AsciiString getLocalName() { return m_localName; }
-	virtual void setLocalProfileID( Int profileID ) { m_localProfileID = profileID; }
-	virtual Int getLocalProfileID() { return m_localProfileID; }
-	virtual AsciiString getLocalEmail() { return m_localEmail; }
-	virtual void setLocalEmail( AsciiString email ) { m_localEmail = email;	}
-	virtual AsciiString getLocalPassword(){ return m_localPasswd;	}
-	virtual void setLocalPassword( AsciiString passwd ) { m_localPasswd = passwd;	}
-	virtual void setLocalBaseName( AsciiString name ) { m_localBaseName = name; }
-	virtual AsciiString getLocalBaseName(){ return m_localBaseName; }
-	virtual void setCachedLocalPlayerStats( PSPlayerStats stats ) {m_cachedLocalPlayerStats = stats;	}
-	virtual PSPlayerStats getCachedLocalPlayerStats(){ return m_cachedLocalPlayerStats;	}
+	virtual void setLocalName( AsciiString name ) override { m_localName = name; }
+	virtual AsciiString getLocalName() override { return m_localName; }
+	virtual void setLocalProfileID( Int profileID ) override { m_localProfileID = profileID; }
+	virtual Int getLocalProfileID() override { return m_localProfileID; }
+	virtual AsciiString getLocalEmail() override { return m_localEmail; }
+	virtual void setLocalEmail( AsciiString email ) override { m_localEmail = email;	}
+	virtual AsciiString getLocalPassword() override { return m_localPasswd;	}
+	virtual void setLocalPassword( AsciiString passwd ) override { m_localPasswd = passwd;	}
+	virtual void setLocalBaseName( AsciiString name ) override { m_localBaseName = name; }
+	virtual AsciiString getLocalBaseName() override { return m_localBaseName; }
+	virtual void setCachedLocalPlayerStats( PSPlayerStats stats ) override {m_cachedLocalPlayerStats = stats;	}
+	virtual PSPlayerStats getCachedLocalPlayerStats() override { return m_cachedLocalPlayerStats;	}
 
-	virtual BuddyInfoMap* getBuddyMap() { return &m_buddyMap; }
-	virtual BuddyInfoMap* getBuddyRequestMap() { return &m_buddyRequestMap; }
-	virtual BuddyMessageList* getBuddyMessages() { return &m_buddyMessages; }
-	virtual Bool isBuddy( Int id );
+	virtual BuddyInfoMap* getBuddyMap() override { return &m_buddyMap; }
+	virtual BuddyInfoMap* getBuddyRequestMap() override { return &m_buddyRequestMap; }
+	virtual BuddyMessageList* getBuddyMessages() override { return &m_buddyMessages; }
+	virtual Bool isBuddy( Int id ) override;
 
-	virtual void clearStagingRoomList();
-	virtual StagingRoomMap* getStagingRoomList() { return &m_stagingRooms; }
-	virtual GameSpyStagingRoom* findStagingRoomByID( Int id );
-	virtual void addStagingRoom( GameSpyStagingRoom room );
-	virtual void updateStagingRoom( GameSpyStagingRoom room );
-	virtual void removeStagingRoom( GameSpyStagingRoom room );
-	virtual Bool hasStagingRoomListChanged();
-	virtual void leaveStagingRoom();
-	virtual void markAsStagingRoomHost();
-	virtual void markAsStagingRoomJoiner( Int game );
-	virtual Int getCurrentStagingRoomID() { return m_localStagingRoomID; }
+	virtual void clearStagingRoomList() override;
+	virtual StagingRoomMap* getStagingRoomList() override { return &m_stagingRooms; }
+	virtual GameSpyStagingRoom* findStagingRoomByID( Int id ) override;
+	virtual void addStagingRoom( GameSpyStagingRoom room ) override;
+	virtual void updateStagingRoom( GameSpyStagingRoom room ) override;
+	virtual void removeStagingRoom( GameSpyStagingRoom room ) override;
+	virtual Bool hasStagingRoomListChanged() override;
+	virtual void leaveStagingRoom() override;
+	virtual void markAsStagingRoomHost() override;
+	virtual void markAsStagingRoomJoiner( Int game ) override;
+	virtual Int getCurrentStagingRoomID() override { return m_localStagingRoomID; }
 
-	virtual void sawFullGameList() { m_sawFullGameList = TRUE; }
+	virtual void sawFullGameList() override { m_sawFullGameList = TRUE; }
 
-	virtual void setDisallowAsianText( Bool val );
-	virtual void setDisallowNonAsianText( Bool val );
-	virtual Bool getDisallowAsianText();
-	virtual Bool getDisallowNonAsianText();
+	virtual void setDisallowAsianText( Bool val ) override;
+	virtual void setDisallowNonAsianText( Bool val ) override;
+	virtual Bool getDisallowAsianText() override;
+	virtual Bool getDisallowNonAsianText() override;
 	// chat
-	virtual void registerTextWindow( GameWindow *win );
-	virtual void unregisterTextWindow( GameWindow *win );
-	virtual Int addText( UnicodeString message, Color c, GameWindow *win );
-	virtual void addChat( PlayerInfo p, UnicodeString msg, Bool isPublic, Bool isAction, GameWindow *win );
-	virtual void addChat( AsciiString nick, Int profileID, UnicodeString msg, Bool isPublic, Bool isAction, GameWindow *win );
-	virtual Bool sendChat( UnicodeString message, Bool isAction, GameWindow *playerListbox );
+	virtual void registerTextWindow( GameWindow *win ) override;
+	virtual void unregisterTextWindow( GameWindow *win ) override;
+	virtual Int addText( UnicodeString message, Color c, GameWindow *win ) override;
+	virtual void addChat( PlayerInfo p, UnicodeString msg, Bool isPublic, Bool isAction, GameWindow *win ) override;
+	virtual void addChat( AsciiString nick, Int profileID, UnicodeString msg, Bool isPublic, Bool isAction, GameWindow *win ) override;
+	virtual Bool sendChat( UnicodeString message, Bool isAction, GameWindow *playerListbox ) override;
 
-	virtual void setMOTD( const AsciiString& motd );
-	virtual const AsciiString& getMOTD();
-	virtual void setConfig( const AsciiString& config );
-	virtual const AsciiString& getConfig();
+	virtual void setMOTD( const AsciiString& motd ) override;
+	virtual const AsciiString& getMOTD() override;
+	virtual void setConfig( const AsciiString& config ) override;
+	virtual const AsciiString& getConfig() override;
 
-	virtual void setPingString( const AsciiString& ping ) { m_pingString = ping; }
-	virtual const AsciiString& getPingString() { return m_pingString; }
-	virtual Int getPingValue( const AsciiString& otherPing );
+	virtual void setPingString( const AsciiString& ping ) override { m_pingString = ping; }
+	virtual const AsciiString& getPingString() override { return m_pingString; }
+	virtual Int getPingValue( const AsciiString& otherPing ) override;
 
-	virtual Bool amIHost();
-	virtual GameSpyStagingRoom* getCurrentStagingRoom();
-	virtual void setGameOptions();
+	virtual Bool amIHost() override;
+	virtual GameSpyStagingRoom* getCurrentStagingRoom() override;
+	virtual void setGameOptions() override;
 
-	virtual void addToIgnoreList( AsciiString nick );
-	virtual void removeFromIgnoreList( AsciiString nick );
-	virtual Bool isIgnored( AsciiString nick );
-	virtual IgnoreList returnIgnoreList();
+	virtual void addToIgnoreList( AsciiString nick ) override;
+	virtual void removeFromIgnoreList( AsciiString nick ) override;
+	virtual Bool isIgnored( AsciiString nick ) override;
+	virtual IgnoreList returnIgnoreList() override;
 
-	virtual void loadSavedIgnoreList();
-	virtual SavedIgnoreMap returnSavedIgnoreList();
-	virtual void addToSavedIgnoreList( Int profileID, AsciiString nick);
-	virtual void removeFromSavedIgnoreList( Int profileID );
-	virtual Bool isSavedIgnored( Int profileID );
-	virtual void setLocalIPs(UnsignedInt internalIP, UnsignedInt externalIP);
-	virtual UnsignedInt getInternalIP() { return m_internalIP; }
-	virtual UnsignedInt getExternalIP() { return m_externalIP; }
+	virtual void loadSavedIgnoreList() override;
+	virtual SavedIgnoreMap returnSavedIgnoreList() override;
+	virtual void addToSavedIgnoreList( Int profileID, AsciiString nick) override;
+	virtual void removeFromSavedIgnoreList( Int profileID ) override;
+	virtual Bool isSavedIgnored( Int profileID ) override;
+	virtual void setLocalIPs(UnsignedInt internalIP, UnsignedInt externalIP) override;
+	virtual UnsignedInt getInternalIP() override { return m_internalIP; }
+	virtual UnsignedInt getExternalIP() override { return m_externalIP; }
 
-	virtual Bool isDisconnectedAfterGameStart(Int *reason) const { if (reason) *reason = m_disconReason; return m_isDisconAfterGameStart; }
-	virtual void markAsDisconnectedAfterGameStart(Int reason) { m_isDisconAfterGameStart = TRUE; m_disconReason = reason; }
+	virtual Bool isDisconnectedAfterGameStart(Int *reason) const override { if (reason) *reason = m_disconReason; return m_isDisconAfterGameStart; }
+	virtual void markAsDisconnectedAfterGameStart(Int reason) override { m_isDisconAfterGameStart = TRUE; m_disconReason = reason; }
 
-	virtual Bool didPlayerPreorder( Int profileID ) const;
-	virtual void markPlayerAsPreorder( Int profileID );
+	virtual Bool didPlayerPreorder( Int profileID ) const override;
+	virtual void markPlayerAsPreorder( Int profileID ) override;
 
-	virtual void setMaxMessagesPerUpdate( Int num );
-	virtual Int getMaxMessagesPerUpdate();
+	virtual void setMaxMessagesPerUpdate( Int num ) override;
+	virtual Int getMaxMessagesPerUpdate() override;
 
-	virtual Int getAdditionalDisconnects();
-	virtual void clearAdditionalDisconnects();
-	virtual void readAdditionalDisconnects();
-	virtual void updateAdditionalGameSpyDisconnections(Int count);
+	virtual Int getAdditionalDisconnects() override;
+	virtual void clearAdditionalDisconnects() override;
+	virtual void readAdditionalDisconnects() override;
+	virtual void updateAdditionalGameSpyDisconnections(Int count) override;
 private:
 	Bool m_sawFullGameList;
 	Bool m_isDisconAfterGameStart;

--- a/Core/GameEngine/Include/GameNetwork/GameSpy/StagingRoomGameInfo.h
+++ b/Core/GameEngine/Include/GameNetwork/GameSpy/StagingRoomGameInfo.h
@@ -96,7 +96,7 @@ private:
 
 public:
 	GameSpyStagingRoom();
-	virtual void reset();
+	virtual void reset() override;
 
 	void cleanUpSlotPointers();
 	void setID(Int id) { m_id = id; }
@@ -131,7 +131,7 @@ public:
 	AsciiString getPingString() const { return m_pingStr; }
 	Int getPingAsInt() const { return m_pingInt; }
 
-	virtual Bool amIHost() const;															///< Convenience function - is the local player the game host?
+	virtual Bool amIHost() const override;															///< Convenience function - is the local player the game host?
 
 	GameSpyGameSlot *getGameSpySlot( Int index );
 
@@ -141,11 +141,11 @@ public:
 	Bool isQMGame() { return m_isQM; }
 
 	virtual void init();
-	virtual void resetAccepted();															///< Reset the accepted flag on all players
+	virtual void resetAccepted() override;															///< Reset the accepted flag on all players
 
-	virtual void startGame(Int gameID);														///< Mark our game as started and record the game ID.
+	virtual void startGame(Int gameID) override;														///< Mark our game as started and record the game ID.
 	void launchGame();																			///< NAT negotiation has finished - really start
-	virtual Int getLocalSlotNum() const;										///< Get the local slot number, or -1 if we're not present
+	virtual Int getLocalSlotNum() const override;										///< Get the local slot number, or -1 if we're not present
 
 	void setGameName( UnicodeString name ) { m_gameName = name; }
 	UnicodeString getGameName() const { return m_gameName; }

--- a/Core/GameEngine/Include/GameNetwork/LANAPI.h
+++ b/Core/GameEngine/Include/GameNetwork/LANAPI.h
@@ -58,11 +58,11 @@ class LANAPIInterface : public SubsystemInterface
 {
 public:
 
-	virtual ~LANAPIInterface() { };
+	virtual ~LANAPIInterface() override { };
 
-	virtual void init() = 0;															///< Initialize or re-initialize the instance
-	virtual void reset() = 0;															///< reset the logic system
-	virtual void update() = 0;														///< update the world
+	virtual void init() override = 0;															///< Initialize or re-initialize the instance
+	virtual void reset() override = 0;															///< reset the logic system
+	virtual void update() override = 0;														///< update the world
 
 	virtual void setIsActive(Bool isActive ) = 0;								///< Tell TheLAN whether or not the app is active.
 
@@ -283,65 +283,65 @@ class LANAPI : public LANAPIInterface
 public:
 
 	LANAPI();
-	virtual ~LANAPI();
+	virtual ~LANAPI() override;
 
-	virtual void init();															///< Initialize or re-initialize the instance
-	virtual void reset();															///< reset the logic system
-	virtual void update();														///< update the world
+	virtual void init() override;															///< Initialize or re-initialize the instance
+	virtual void reset() override;															///< reset the logic system
+	virtual void update() override;														///< update the world
 
-	virtual void setIsActive(Bool isActive);								///< tell TheLAN whether or not
+	virtual void setIsActive(Bool isActive) override;								///< tell TheLAN whether or not
 
 	// Request functions generate network traffic
-	virtual void RequestLocations();																				///< Request everybody to respond with where they are
-	virtual void RequestGameJoin( LANGameInfo *game, UnsignedInt ip = 0 );				///< Request to join a game
-	virtual void RequestGameJoinDirectConnect( UnsignedInt ipaddress );						///< Request to join a game at an IP address
-	virtual void RequestGameLeave();																				///< Tell everyone we're leaving
-	virtual void RequestAccept();																						///< Indicate we're OK with the game options
-	virtual void RequestHasMap();																						///< Send our map status
-	virtual void RequestChat( UnicodeString message, ChatType format );						///< Send a chat message
-	virtual void RequestGameStart();																				///< Tell everyone the game is starting
-	virtual void RequestGameStartTimer( Int seconds );
-	virtual void RequestGameOptions( AsciiString gameOptions, Bool isPublic, UnsignedInt ip = 0 );		///< Change the game options
-	virtual void RequestGameCreate( UnicodeString gameName, Bool isDirectConnect );	///< Try to host a game
-	virtual void RequestGameAnnounce();																			///< Send out game info if host
-	virtual void RequestSetName( UnicodeString newName );													///< Pick a new name
+	virtual void RequestLocations() override;																				///< Request everybody to respond with where they are
+	virtual void RequestGameJoin( LANGameInfo *game, UnsignedInt ip = 0 ) override;				///< Request to join a game
+	virtual void RequestGameJoinDirectConnect( UnsignedInt ipaddress ) override;						///< Request to join a game at an IP address
+	virtual void RequestGameLeave() override;																				///< Tell everyone we're leaving
+	virtual void RequestAccept() override;																						///< Indicate we're OK with the game options
+	virtual void RequestHasMap() override;																						///< Send our map status
+	virtual void RequestChat( UnicodeString message, ChatType format ) override;						///< Send a chat message
+	virtual void RequestGameStart() override;																				///< Tell everyone the game is starting
+	virtual void RequestGameStartTimer( Int seconds ) override;
+	virtual void RequestGameOptions( AsciiString gameOptions, Bool isPublic, UnsignedInt ip = 0 ) override;		///< Change the game options
+	virtual void RequestGameCreate( UnicodeString gameName, Bool isDirectConnect ) override;	///< Try to host a game
+	virtual void RequestGameAnnounce() override;																			///< Send out game info if host
+	virtual void RequestSetName( UnicodeString newName ) override;													///< Pick a new name
 //	virtual void RequestSlotList();																					///< Pump out the Slot info.
-	virtual void RequestLobbyLeave( Bool forced );																///< Announce that we're leaving the lobby
-	virtual void ResetGameStartTimer();
+	virtual void RequestLobbyLeave( Bool forced ) override;																///< Announce that we're leaving the lobby
+	virtual void ResetGameStartTimer() override;
 
 	// On functions are (generally) the result of network traffic
-	virtual void OnGameList( LANGameInfo *gameList );																							///< List of games
-	virtual void OnPlayerList( LANPlayer *playerList );																				///< List of players in the Lobby
-	virtual void OnGameJoin( ReturnType ret, LANGameInfo *theGame );															///< Did we get in the game?
-	virtual void OnPlayerJoin( Int slot, UnicodeString playerName );													///< Someone else joined our game (host only; joiners get a slotlist)
-	virtual void OnHostLeave();																													///< Host left the game
-	virtual void OnPlayerLeave( UnicodeString player );																				///< Someone left the game
-	virtual void OnAccept( UnsignedInt playerIP, Bool status );																///< Someone's accept status changed
-	virtual void OnHasMap( UnsignedInt playerIP, Bool status );																///< Someone's map status changed
+	virtual void OnGameList( LANGameInfo *gameList ) override;																							///< List of games
+	virtual void OnPlayerList( LANPlayer *playerList ) override;																				///< List of players in the Lobby
+	virtual void OnGameJoin( ReturnType ret, LANGameInfo *theGame ) override;															///< Did we get in the game?
+	virtual void OnPlayerJoin( Int slot, UnicodeString playerName ) override;													///< Someone else joined our game (host only; joiners get a slotlist)
+	virtual void OnHostLeave() override;																													///< Host left the game
+	virtual void OnPlayerLeave( UnicodeString player ) override;																				///< Someone left the game
+	virtual void OnAccept( UnsignedInt playerIP, Bool status ) override;																///< Someone's accept status changed
+	virtual void OnHasMap( UnsignedInt playerIP, Bool status ) override;																///< Someone's map status changed
 	virtual void OnChat( UnicodeString player, UnsignedInt ip,
-											 UnicodeString message, ChatType format );														///< Chat message from someone
-	virtual void OnGameStart();																													///< The game is starting
-	virtual void OnGameStartTimer( Int seconds );
-	virtual void OnGameOptions( UnsignedInt playerIP, Int playerSlot, AsciiString options );	///< Someone sent game options
-	virtual void OnGameCreate( ReturnType ret );																							///< Your game is created
+											 UnicodeString message, ChatType format ) override;														///< Chat message from someone
+	virtual void OnGameStart() override;																													///< The game is starting
+	virtual void OnGameStartTimer( Int seconds ) override;
+	virtual void OnGameOptions( UnsignedInt playerIP, Int playerSlot, AsciiString options ) override;	///< Someone sent game options
+	virtual void OnGameCreate( ReturnType ret ) override;																							///< Your game is created
 	//virtual void OnSlotList( ReturnType ret, LANGameInfo *theGame );															///< Slotlist for a game in setup
-	virtual void OnNameChange( UnsignedInt IP, UnicodeString newName );												///< Someone has morphed
+	virtual void OnNameChange( UnsignedInt IP, UnicodeString newName ) override;												///< Someone has morphed
 	virtual void OnInActive( UnsignedInt IP );																								///< Someone has alt-tabbed out.
 
 
 	// Misc utility functions
-	virtual LANGameInfo * LookupGame( UnicodeString gameName );														///< return a pointer to a game we know about
-	virtual LANGameInfo * LookupGameByListOffset( Int offset );														///< return a pointer to a game we know about
-	virtual LANGameInfo * LookupGameByHost( UnsignedInt hostIP );													///< return a pointer to the most recent game associated to the host IP address
+	virtual LANGameInfo * LookupGame( UnicodeString gameName ) override;														///< return a pointer to a game we know about
+	virtual LANGameInfo * LookupGameByListOffset( Int offset ) override;														///< return a pointer to a game we know about
+	virtual LANGameInfo * LookupGameByHost( UnsignedInt hostIP ) override;													///< return a pointer to the most recent game associated to the host IP address
 	virtual LANPlayer * LookupPlayer( UnsignedInt playerIP );													///< return a pointer to a player we know about
-	virtual Bool SetLocalIP( UnsignedInt localIP );																		///< For multiple NIC machines
-	virtual void SetLocalIP( AsciiString localIP );																		///< For multiple NIC machines
-	virtual Bool AmIHost();																											///< Am I hosting a game?
-	virtual UnicodeString GetMyName() { return m_name; }                 ///< What's my name?
-	virtual LANGameInfo* GetMyGame() { return m_currentGame; }					      ///< What's my Game?
+	virtual Bool SetLocalIP( UnsignedInt localIP ) override;																		///< For multiple NIC machines
+	virtual void SetLocalIP( AsciiString localIP ) override;																		///< For multiple NIC machines
+	virtual Bool AmIHost() override;																											///< Am I hosting a game?
+	virtual UnicodeString GetMyName() override { return m_name; }                 ///< What's my name?
+	virtual LANGameInfo* GetMyGame() override { return m_currentGame; }					      ///< What's my Game?
 	virtual UnsignedInt GetLocalIP() { return m_localIP; }								///< What's my IP?
-	virtual void fillInLANMessage( LANMessage *msg );																	///< Fill in default params
-	virtual void checkMOTD();
+	virtual void fillInLANMessage( LANMessage *msg ) override;																	///< Fill in default params
+	virtual void checkMOTD() override;
 protected:
 
 	enum PendingActionType

--- a/Core/GameEngine/Include/GameNetwork/LANAPI.h
+++ b/Core/GameEngine/Include/GameNetwork/LANAPI.h
@@ -60,9 +60,9 @@ public:
 
 	virtual ~LANAPIInterface() override { };
 
-	virtual void init() override = 0;															///< Initialize or re-initialize the instance
-	virtual void reset() override = 0;															///< reset the logic system
-	virtual void update() override = 0;														///< update the world
+	virtual void init() = 0;															///< Initialize or re-initialize the instance
+	virtual void reset() = 0;															///< reset the logic system
+	virtual void update() = 0;														///< update the world
 
 	virtual void setIsActive(Bool isActive ) = 0;								///< Tell TheLAN whether or not the app is active.
 

--- a/Core/GameEngine/Include/GameNetwork/LANGameInfo.h
+++ b/Core/GameEngine/Include/GameNetwork/LANGameInfo.h
@@ -82,7 +82,7 @@ public:
 	void setSlot( Int slotNum, LANGameSlot slotInfo );	///< Set the slot state (human, open, AI, etc)
 	LANGameSlot* getLANSlot( Int slotNum );							///< Get the slot
 	const LANGameSlot* getConstLANSlot( Int slotNum ) const;							///< Get the slot
-	virtual Int getLocalSlotNum() const;												///< Get the local slot number, or -1 if we're not present
+	virtual Int getLocalSlotNum() const override;												///< Get the local slot number, or -1 if we're not present
 	Int getSlotNum( UnicodeString userName );						///< Get the slot number corresponding to a specific user, or -1 if he's not present
 
 	UnsignedInt getLastHeard() { return m_lastHeard; }
@@ -98,7 +98,7 @@ public:
 	UnicodeString getName() { return m_gameName; }					///< Get the Name of the Game
 
 	// Convenience functions that interface with the LANPlayer held in the slot list
-	virtual void resetAccepted();														///< Reset the accepted flag on all players
+	virtual void resetAccepted() override;														///< Reset the accepted flag on all players
 	Bool amIHost();																///< Convenience function - is the local player the game host?
 
 	/// Get the IP of selected player or return 0

--- a/Core/GameEngine/Include/GameNetwork/NetCommandMsg.h
+++ b/Core/GameEngine/Include/GameNetwork/NetCommandMsg.h
@@ -77,22 +77,22 @@ protected:
 template<typename NetPacketType, typename SmallNetPacketType>
 class NetCommandMsgT : public NetCommandMsg
 {
-	virtual size_t getSizeForNetPacket() const
+	virtual size_t getSizeForNetPacket() const override
 	{
 		return NetPacketType::getSize(*this);
 	}
 
-	virtual size_t copyBytesForNetPacket(UnsignedByte* buffer, const NetCommandRef& ref) const
+	virtual size_t copyBytesForNetPacket(UnsignedByte* buffer, const NetCommandRef& ref) const override
 	{
 		return NetPacketType::copyBytes(buffer, ref);
 	}
 
-	virtual size_t getSizeForSmallNetPacket(const Select* select = nullptr) const
+	virtual size_t getSizeForSmallNetPacket(const Select* select = nullptr) const override
 	{
 		return SmallNetPacketType::getSize(*this, select);
 	}
 
-	virtual size_t copyBytesForSmallNetPacket(UnsignedByte* buffer, const NetCommandRef& ref, const Select* select = nullptr) const
+	virtual size_t copyBytesForSmallNetPacket(UnsignedByte* buffer, const NetCommandRef& ref, const Select* select = nullptr) const override
 	{
 		return SmallNetPacketType::copyBytes(buffer, ref, select);
 	}
@@ -114,7 +114,7 @@ public:
 	void addArgument(const GameMessageArgumentDataType type, GameMessageArgumentType arg);
 	void setGameMessageType(GameMessage::Type type);
 
-	virtual Select getSmallNetPacketSelect() const;
+	virtual Select getSmallNetPacketSelect() const override;
 
 protected:
 	Int m_numArgs;
@@ -146,9 +146,9 @@ public:
 	void setCommandID(UnsignedShort commandID);
 	UnsignedByte getOriginalPlayerID() const;
 	void setOriginalPlayerID(UnsignedByte originalPlayerID);
-	virtual Int getSortNumber() const;
+	virtual Int getSortNumber() const override;
 
-	virtual Select getSmallNetPacketSelect() const;
+	virtual Select getSmallNetPacketSelect() const override;
 
 protected:
 	UnsignedShort m_commandID;
@@ -208,7 +208,7 @@ public:
 	void setCommandCount(UnsignedShort commandCount);
 	UnsignedShort getCommandCount() const;
 
-	virtual Select getSmallNetPacketSelect() const;
+	virtual Select getSmallNetPacketSelect() const override;
 
 protected:
 	UnsignedShort m_commandCount;
@@ -225,7 +225,7 @@ public:
 	UnsignedByte getLeavingPlayerID() const;
 	void setLeavingPlayerID(UnsignedByte id);
 
-	virtual Select getSmallNetPacketSelect() const;
+	virtual Select getSmallNetPacketSelect() const override;
 
 protected:
 	UnsignedByte m_leavingPlayerID;
@@ -244,7 +244,7 @@ public:
 	Int  getAverageFps() const;
 	void setAverageFps(Int fps);
 
-	virtual Select getSmallNetPacketSelect() const;
+	virtual Select getSmallNetPacketSelect() const override;
 
 protected:
 	Real m_averageLatency;
@@ -265,7 +265,7 @@ public:
 	UnsignedByte getFrameRate() const;
 	void setFrameRate(UnsignedByte frameRate);
 
-	virtual Select getSmallNetPacketSelect() const;
+	virtual Select getSmallNetPacketSelect() const override;
 
 protected:
 	UnsignedShort m_runAhead;
@@ -283,7 +283,7 @@ public:
 	UnsignedInt getPlayerIndex() const;
 	void setPlayerIndex(UnsignedInt playerIndex);
 
-	virtual Select getSmallNetPacketSelect() const;
+	virtual Select getSmallNetPacketSelect() const override;
 
 protected:
 	UnsignedInt m_playerIndex;
@@ -297,7 +297,7 @@ public:
 	NetKeepAliveCommandMsg();
 	//virtual ~NetKeepAliveCommandMsg();
 
-	virtual Select getSmallNetPacketSelect() const;
+	virtual Select getSmallNetPacketSelect() const override;
 };
 
 //-----------------------------------------------------------------------------
@@ -308,7 +308,7 @@ public:
 	NetDisconnectKeepAliveCommandMsg();
 	//virtual ~NetDisconnectKeepAliveCommandMsg();
 
-	virtual Select getSmallNetPacketSelect() const;
+	virtual Select getSmallNetPacketSelect() const override;
 };
 
 //-----------------------------------------------------------------------------
@@ -325,7 +325,7 @@ public:
 	UnsignedInt getDisconnectFrame() const;
 	void setDisconnectFrame(UnsignedInt frame);
 
-	virtual Select getSmallNetPacketSelect() const;
+	virtual Select getSmallNetPacketSelect() const override;
 
 protected:
 	UnsignedByte m_disconnectSlot;
@@ -340,7 +340,7 @@ public:
 	NetPacketRouterQueryCommandMsg();
 	//virtual ~NetPacketRouterQueryCommandMsg();
 
-	virtual Select getSmallNetPacketSelect() const;
+	virtual Select getSmallNetPacketSelect() const override;
 };
 
 //-----------------------------------------------------------------------------
@@ -351,7 +351,7 @@ public:
 	NetPacketRouterAckCommandMsg();
 	//virtual ~NetPacketRouterAckCommandMsg();
 
-	virtual Select getSmallNetPacketSelect() const;
+	virtual Select getSmallNetPacketSelect() const override;
 };
 
 //-----------------------------------------------------------------------------
@@ -365,7 +365,7 @@ public:
 	UnicodeString getText() const;
 	void setText(UnicodeString text);
 
-	virtual Select getSmallNetPacketSelect() const;
+	virtual Select getSmallNetPacketSelect() const override;
 
 protected:
 	UnicodeString m_text;
@@ -385,7 +385,7 @@ public:
 	Int getPlayerMask() const;
 	void setPlayerMask( Int playerMask );
 
-	virtual Select getSmallNetPacketSelect() const;
+	virtual Select getSmallNetPacketSelect() const override;
 
 protected:
 	UnicodeString m_text;
@@ -406,7 +406,7 @@ public:
 	UnsignedInt getVoteFrame() const;
 	void setVoteFrame(UnsignedInt voteFrame);
 
-	virtual Select getSmallNetPacketSelect() const;
+	virtual Select getSmallNetPacketSelect() const override;
 
 protected:
 	UnsignedByte m_slot;
@@ -424,7 +424,7 @@ public:
 	UnsignedByte getPercentage() const;
 	void setPercentage( UnsignedByte percent );
 
-	virtual Select getSmallNetPacketSelect() const;
+	virtual Select getSmallNetPacketSelect() const override;
 
 protected:
 	UnsignedByte m_percent;
@@ -459,7 +459,7 @@ public:
 	UnsignedShort getWrappedCommandID() const;
 	void setWrappedCommandID(UnsignedShort wrappedCommandID);
 
-	virtual Select getSmallNetPacketSelect() const;
+	virtual Select getSmallNetPacketSelect() const override;
 
 private:
 	UnsignedByte *m_data;
@@ -492,7 +492,7 @@ public:
 	UnsignedByte * getFileData();
 	void setFileData(UnsignedByte *data, UnsignedInt dataLength);
 
-	virtual Select getSmallNetPacketSelect() const;
+	virtual Select getSmallNetPacketSelect() const override;
 
 protected:
 	AsciiString m_portableFilename;
@@ -521,7 +521,7 @@ public:
 	UnsignedByte getPlayerMask() const;
 	void setPlayerMask(UnsignedByte playerMask);
 
-	virtual Select getSmallNetPacketSelect() const;
+	virtual Select getSmallNetPacketSelect() const override;
 
 protected:
 	AsciiString m_portableFilename;
@@ -543,7 +543,7 @@ public:
 	Int getProgress() const;
 	void setProgress(Int val);
 
-	virtual Select getSmallNetPacketSelect() const;
+	virtual Select getSmallNetPacketSelect() const override;
 
 protected:
 	UnsignedShort m_fileID;
@@ -560,7 +560,7 @@ public:
 	UnsignedInt getDisconnectFrame() const;
 	void setDisconnectFrame(UnsignedInt disconnectFrame);
 
-	virtual Select getSmallNetPacketSelect() const;
+	virtual Select getSmallNetPacketSelect() const override;
 
 protected:
 	UnsignedInt m_disconnectFrame;
@@ -576,7 +576,7 @@ public:
 	UnsignedInt getNewFrame() const;
 	void setNewFrame(UnsignedInt newFrame);
 
-	virtual Select getSmallNetPacketSelect() const;
+	virtual Select getSmallNetPacketSelect() const override;
 
 protected:
 	UnsignedInt m_newFrame;
@@ -592,7 +592,7 @@ public:
 	UnsignedInt getFrameToResend() const;
 	void setFrameToResend(UnsignedInt frame);
 
-	virtual Select getSmallNetPacketSelect() const;
+	virtual Select getSmallNetPacketSelect() const override;
 
 protected:
 	UnsignedInt m_frameToResend;
@@ -605,7 +605,7 @@ public:
 	NetLoadCompleteCommandMsg();
 	//virtual ~NetLoadCompleteCommandMsg();
 
-	virtual Select getSmallNetPacketSelect() const;
+	virtual Select getSmallNetPacketSelect() const override;
 };
 
 class NetTimeOutGameStartCommandMsg : public NetCommandMsgT<NetPacketTimeOutGameStartCommand, SmallNetPacketTimeOutGameStartCommand>
@@ -615,5 +615,5 @@ public:
 	NetTimeOutGameStartCommandMsg();
 	//virtual ~NetTimeOutGameStartCommandMsg();
 
-	virtual Select getSmallNetPacketSelect() const;
+	virtual Select getSmallNetPacketSelect() const override;
 };

--- a/Core/GameEngine/Include/GameNetwork/NetworkInterface.h
+++ b/Core/GameEngine/Include/GameNetwork/NetworkInterface.h
@@ -58,9 +58,9 @@ public:
 
 	//---------------------------------------------------------------------------------------
 	// SubsystemInterface functions
-	virtual void init() override = 0;																		///< Initialize the network
-	virtual void reset() override = 0;																		///< Re-initialize the network
-	virtual void update() override = 0;																	///< Updates the network
+	virtual void init() = 0;																		///< Initialize the network
+	virtual void reset() = 0;																		///< Re-initialize the network
+	virtual void update() = 0;																	///< Updates the network
 	virtual void liteupdate() = 0;															///< does a lightweight update for passing messages around.
 
 	virtual void setLocalAddress(UnsignedInt ip, UnsignedInt port) = 0;	///< Tell the network what local ip and port to bind to.

--- a/Core/GameEngine/Include/GameNetwork/NetworkInterface.h
+++ b/Core/GameEngine/Include/GameNetwork/NetworkInterface.h
@@ -52,15 +52,15 @@ class NetworkInterface : public SubsystemInterface
 protected:
 
 public:
-	virtual ~NetworkInterface() { };
+	virtual ~NetworkInterface() override { };
 
 	static NetworkInterface * createNetwork();
 
 	//---------------------------------------------------------------------------------------
 	// SubsystemInterface functions
-	virtual void init() = 0;																		///< Initialize the network
-	virtual void reset() = 0;																		///< Re-initialize the network
-	virtual void update() = 0;																	///< Updates the network
+	virtual void init() override = 0;																		///< Initialize the network
+	virtual void reset() override = 0;																		///< Re-initialize the network
+	virtual void update() override = 0;																	///< Updates the network
 	virtual void liteupdate() = 0;															///< does a lightweight update for passing messages around.
 
 	virtual void setLocalAddress(UnsignedInt ip, UnsignedInt port) = 0;	///< Tell the network what local ip and port to bind to.

--- a/Core/GameEngine/Include/GameNetwork/WOLBrowser/WebBrowser.h
+++ b/Core/GameEngine/Include/GameNetwork/WOLBrowser/WebBrowser.h
@@ -79,9 +79,9 @@ class WebBrowser :
 		public SubsystemInterface
 	{
 	public:
-		void init() override;
-		void reset() override;
-		void update() override;
+		virtual void init() override;
+		virtual void reset() override;
+		virtual void update() override;
 
 		// Create an instance of the embedded browser for Dune Emperor.
 		virtual Bool createBrowserWindow(const char *tag, GameWindow *win) = 0;

--- a/Core/GameEngine/Include/GameNetwork/WOLBrowser/WebBrowser.h
+++ b/Core/GameEngine/Include/GameNetwork/WOLBrowser/WebBrowser.h
@@ -79,9 +79,9 @@ class WebBrowser :
 		public SubsystemInterface
 	{
 	public:
-		void init();
-		void reset();
-		void update();
+		void init() override;
+		void reset() override;
+		void update() override;
 
 		// Create an instance of the embedded browser for Dune Emperor.
 		virtual Bool createBrowserWindow(const char *tag, GameWindow *win) = 0;
@@ -93,7 +93,7 @@ class WebBrowser :
 	protected:
 		// Protected to prevent direct construction via new, use CreateInstance() instead.
 		WebBrowser();
-		virtual ~WebBrowser();
+		virtual ~WebBrowser() override;
 
 		// Protected to prevent copy and assignment
 		WebBrowser(const WebBrowser&);

--- a/Core/GameEngine/Source/GameClient/FXList.cpp
+++ b/Core/GameEngine/Source/GameClient/FXList.cpp
@@ -95,7 +95,7 @@ class SoundFXNugget : public FXNugget
 
 public:
 
-	virtual void doFXPos(const Coord3D *primary, const Matrix3D* /*primaryMtx*/, const Real /*primarySpeed*/, const Coord3D * /*secondary*/, const Real /*overrideRadius*/ ) const
+	virtual void doFXPos(const Coord3D *primary, const Matrix3D* /*primaryMtx*/, const Real /*primarySpeed*/, const Coord3D * /*secondary*/, const Real /*overrideRadius*/ ) const override
 	{
 		AudioEventRTS sound(m_soundName);
 
@@ -107,7 +107,7 @@ public:
 		TheAudio->addAudioEvent(&sound);
 	}
 
-	virtual void doFXObj(const Object* primary, const Object* secondary = nullptr) const
+	virtual void doFXObj(const Object* primary, const Object* secondary = nullptr) const override
 	{
 		AudioEventRTS sound(m_soundName);
 		if (primary)
@@ -165,7 +165,7 @@ public:
 		m_probability = 1.0f;
 	}
 
-	virtual void doFXPos(const Coord3D *primary, const Matrix3D* primaryMtx, const Real primarySpeed, const Coord3D *secondary, const Real /*overrideRadius*/ ) const
+	virtual void doFXPos(const Coord3D *primary, const Matrix3D* primaryMtx, const Real primarySpeed, const Coord3D *secondary, const Real /*overrideRadius*/ ) const override
 	{
 		if (m_probability <= GameClientRandomValueReal(0, 1))
 			return;
@@ -263,7 +263,7 @@ public:
 		m_secondaryOffset.x = m_secondaryOffset.y = m_secondaryOffset.z = 0;
 	}
 
-	virtual void doFXPos(const Coord3D *primary, const Matrix3D* /*primaryMtx*/, const Real /*primarySpeed*/, const Coord3D * secondary, const Real /*overrideRadius*/ ) const
+	virtual void doFXPos(const Coord3D *primary, const Matrix3D* /*primaryMtx*/, const Real /*primarySpeed*/, const Coord3D * secondary, const Real /*overrideRadius*/ ) const override
 	{
 		const ThingTemplate* tmpl = TheThingFactory->findTemplate(m_templateName);
 		DEBUG_ASSERTCRASH(tmpl, ("RayEffect %s not found",m_templateName.str()));
@@ -320,7 +320,7 @@ public:
 		m_color.red = m_color.green = m_color.blue = 0;
 	}
 
-	virtual void doFXObj(const Object* primary, const Object* /*secondary*/) const
+	virtual void doFXObj(const Object* primary, const Object* /*secondary*/) const override
 	{
 		if (primary)
 		{
@@ -337,7 +337,7 @@ public:
 		}
 	}
 
-	virtual void doFXPos(const Coord3D *primary, const Matrix3D* /*primaryMtx*/, const Real /*primarySpeed*/, const Coord3D * /*secondary*/, const Real /*overrideRadius*/ ) const
+	virtual void doFXPos(const Coord3D *primary, const Matrix3D* /*primaryMtx*/, const Real /*primarySpeed*/, const Coord3D * /*secondary*/, const Real /*overrideRadius*/ ) const override
 	{
 		if (primary)
 		{
@@ -385,7 +385,7 @@ public:
 	{
 	}
 
-	virtual void doFXPos(const Coord3D *primary, const Matrix3D* /*primaryMtx*/, const Real /*primarySpeed*/, const Coord3D * /*secondary*/, const Real /*overrideRadius*/ ) const
+	virtual void doFXPos(const Coord3D *primary, const Matrix3D* /*primaryMtx*/, const Real /*primarySpeed*/, const Coord3D * /*secondary*/, const Real /*overrideRadius*/ ) const override
 	{
 		if (primary)
 		{
@@ -445,7 +445,7 @@ public:
 	{
 	}
 
-	virtual void doFXPos(const Coord3D *primary, const Matrix3D* /*primaryMtx*/, const Real /*primarySpeed*/, const Coord3D * /*secondary*/, const Real /*overrideRadius*/ ) const
+	virtual void doFXPos(const Coord3D *primary, const Matrix3D* /*primaryMtx*/, const Real /*primarySpeed*/, const Coord3D * /*secondary*/, const Real /*overrideRadius*/ ) const override
 	{
 		if (primary)
 		{
@@ -523,7 +523,7 @@ public:
 		m_rotateX = m_rotateY = m_rotateZ = 0;
 	}
 
-	virtual void doFXPos(const Coord3D *primary, const Matrix3D* primaryMtx, const Real /*primarySpeed*/, const Coord3D * /*secondary*/, const Real overrideRadius ) const
+	virtual void doFXPos(const Coord3D *primary, const Matrix3D* primaryMtx, const Real /*primarySpeed*/, const Coord3D * /*secondary*/, const Real overrideRadius ) const override
 	{
 		if (primary)
 		{
@@ -535,7 +535,7 @@ public:
 		}
 	}
 
-	virtual void doFXObj(const Object* primary, const Object* secondary) const
+	virtual void doFXObj(const Object* primary, const Object* secondary) const override
 	{
 		if (primary)
 		{
@@ -694,12 +694,12 @@ public:
     m_orientToBone = true;
 	}
 
-	virtual void doFXPos(const Coord3D *primary, const Matrix3D* primaryMtx, const Real /*primarySpeed*/, const Coord3D * /*secondary*/, const Real /*overrideRadius*/ ) const
+	virtual void doFXPos(const Coord3D *primary, const Matrix3D* primaryMtx, const Real /*primarySpeed*/, const Coord3D * /*secondary*/, const Real /*overrideRadius*/ ) const override
 	{
 		DEBUG_CRASH(("You must use the object form for this effect"));
 	}
 
-	virtual void doFXObj(const Object* primary, const Object* /*secondary*/) const
+	virtual void doFXObj(const Object* primary, const Object* /*secondary*/) const override
 	{
 		if (primary)
 		{

--- a/Core/GameEngine/Source/GameClient/GameText.cpp
+++ b/Core/GameEngine/Source/GameClient/GameText.cpp
@@ -138,23 +138,23 @@ class GameTextManager : public GameTextInterface
 	public:
 
 		GameTextManager();
-		virtual ~GameTextManager();
+		virtual ~GameTextManager() override;
 
-		virtual void					init();						///< Initializes the text system
+		virtual void					init() override;						///< Initializes the text system
 		virtual void					deinit();					///< Shuts down the text system
-		virtual void					update() {};			///< update text manager
-		virtual void					reset();					///< Resets the text system
+		virtual void					update() override {};			///< update text manager
+		virtual void					reset() override;					///< Resets the text system
 
-		virtual UnicodeString fetch( const Char *label, Bool *exists = nullptr );		///< Returns the associated labeled unicode text
-		virtual UnicodeString fetch( AsciiString label, Bool *exists = nullptr );		///< Returns the associated labeled unicode text
-		virtual UnicodeString fetchFormat( const Char *label, ... );
-		virtual UnicodeString fetchOrSubstitute( const Char *label, const WideChar *substituteText );
-		virtual UnicodeString fetchOrSubstituteFormat( const Char *label, const WideChar *substituteFormat, ... );
-		virtual UnicodeString fetchOrSubstituteFormatVA( const Char *label, const WideChar *substituteFormat, va_list args );
+		virtual UnicodeString fetch( const Char *label, Bool *exists = nullptr ) override;		///< Returns the associated labeled unicode text
+		virtual UnicodeString fetch( AsciiString label, Bool *exists = nullptr ) override;		///< Returns the associated labeled unicode text
+		virtual UnicodeString fetchFormat( const Char *label, ... ) override;
+		virtual UnicodeString fetchOrSubstitute( const Char *label, const WideChar *substituteText ) override;
+		virtual UnicodeString fetchOrSubstituteFormat( const Char *label, const WideChar *substituteFormat, ... ) override;
+		virtual UnicodeString fetchOrSubstituteFormatVA( const Char *label, const WideChar *substituteFormat, va_list args ) override;
 
-		virtual AsciiStringVec& getStringsWithLabelPrefix(AsciiString label);
+		virtual AsciiStringVec& getStringsWithLabelPrefix(AsciiString label) override;
 
-		virtual void					initMapStringFile( const AsciiString& filename );
+		virtual void					initMapStringFile( const AsciiString& filename ) override;
 
 	protected:
 

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/GSConfig.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/GSConfig.cpp
@@ -45,40 +45,40 @@ class GameSpyConfig : public GameSpyConfigInterface
 {
 public:
 	GameSpyConfig( AsciiString config );
-	~GameSpyConfig() {}
+	virtual ~GameSpyConfig() override {}
 
 	// Pings
-	std::list<AsciiString> getPingServers()	{ return m_pingServers; }
-	Int getNumPingRepetitions()							{ return m_pingReps; }
-	Int getPingTimeoutInMs()								{ return m_pingTimeout; }
-	virtual Int getPingCutoffGood()				{	return m_pingCutoffGood; }
-	virtual Int getPingCutoffBad()				{ return m_pingCutoffBad;	}
+	std::list<AsciiString> getPingServers() override	{ return m_pingServers; }
+	Int getNumPingRepetitions() override							{ return m_pingReps; }
+	Int getPingTimeoutInMs() override								{ return m_pingTimeout; }
+	virtual Int getPingCutoffGood() override				{	return m_pingCutoffGood; }
+	virtual Int getPingCutoffBad() override				{ return m_pingCutoffBad;	}
 
 	// QM
-	std::list<AsciiString> getQMMaps()			{ return m_qmMaps; }
-	Int getQMBotID()												{ return m_qmBotID; }
-	Int getQMChannel()											{ return m_qmChannel; }
-	void setQMChannel(Int channel)							{ m_qmChannel = channel; }
+	std::list<AsciiString> getQMMaps() override			{ return m_qmMaps; }
+	Int getQMBotID() override												{ return m_qmBotID; }
+	Int getQMChannel() override											{ return m_qmChannel; }
+	void setQMChannel(Int channel) override							{ m_qmChannel = channel; }
 
 	// Player Info
-	Int getPointsForRank(Int rank);
-	virtual Bool isPlayerVIP(Int id);
+	virtual Int getPointsForRank(Int rank) override;
+	virtual Bool isPlayerVIP(Int id) override;
 
-	virtual Bool getManglerLocation(Int index, AsciiString& host, UnsignedShort& port);
+	virtual Bool getManglerLocation(Int index, AsciiString& host, UnsignedShort& port) override;
 
 	// Ladder / Any other external parsing
-	AsciiString getLeftoverConfig()					{ return m_leftoverConfig; }
+	AsciiString getLeftoverConfig() override					{ return m_leftoverConfig; }
 
 	// NAT Timeouts
-	virtual Int getTimeBetweenRetries() { return m_natRetryInterval; }
-	virtual Int getMaxManglerRetries() { return m_natMaxManglerRetries; }
-	virtual time_t getRetryInterval() { return m_natManglerRetryInterval; }
-	virtual time_t getKeepaliveInterval() { return m_natKeepaliveInterval; }
-	virtual time_t getPortTimeout() { return m_natPortTimeout; }
-	virtual time_t getRoundTimeout() { return m_natRoundTimeout; }
+	virtual Int getTimeBetweenRetries() override { return m_natRetryInterval; }
+	virtual Int getMaxManglerRetries() override { return m_natMaxManglerRetries; }
+	virtual time_t getRetryInterval() override { return m_natManglerRetryInterval; }
+	virtual time_t getKeepaliveInterval() override { return m_natKeepaliveInterval; }
+	virtual time_t getPortTimeout() override { return m_natPortTimeout; }
+	virtual time_t getRoundTimeout() override { return m_natRoundTimeout; }
 
 	// Custom match
-	virtual Bool restrictGamesToLobby() { return m_restrictGamesToLobby; }
+	virtual Bool restrictGamesToLobby() override { return m_restrictGamesToLobby; }
 
 protected:
 	std::list<AsciiString> m_pingServers;

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/GSConfig.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/GSConfig.cpp
@@ -48,17 +48,17 @@ public:
 	virtual ~GameSpyConfig() override {}
 
 	// Pings
-	std::list<AsciiString> getPingServers() override	{ return m_pingServers; }
-	Int getNumPingRepetitions() override							{ return m_pingReps; }
-	Int getPingTimeoutInMs() override								{ return m_pingTimeout; }
+	virtual std::list<AsciiString> getPingServers() override	{ return m_pingServers; }
+	virtual Int getNumPingRepetitions() override							{ return m_pingReps; }
+	virtual Int getPingTimeoutInMs() override								{ return m_pingTimeout; }
 	virtual Int getPingCutoffGood() override				{	return m_pingCutoffGood; }
 	virtual Int getPingCutoffBad() override				{ return m_pingCutoffBad;	}
 
 	// QM
-	std::list<AsciiString> getQMMaps() override			{ return m_qmMaps; }
-	Int getQMBotID() override												{ return m_qmBotID; }
-	Int getQMChannel() override											{ return m_qmChannel; }
-	void setQMChannel(Int channel) override							{ m_qmChannel = channel; }
+	virtual std::list<AsciiString> getQMMaps() override			{ return m_qmMaps; }
+	virtual Int getQMBotID() override												{ return m_qmBotID; }
+	virtual Int getQMChannel() override											{ return m_qmChannel; }
+	virtual void setQMChannel(Int channel) override							{ m_qmChannel = channel; }
 
 	// Player Info
 	virtual Int getPointsForRank(Int rank) override;
@@ -67,7 +67,7 @@ public:
 	virtual Bool getManglerLocation(Int index, AsciiString& host, UnsignedShort& port) override;
 
 	// Ladder / Any other external parsing
-	AsciiString getLeftoverConfig() override					{ return m_leftoverConfig; }
+	virtual AsciiString getLeftoverConfig() override					{ return m_leftoverConfig; }
 
 	// NAT Timeouts
 	virtual Int getTimeBetweenRetries() override { return m_natRetryInterval; }

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/BuddyThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/BuddyThread.cpp
@@ -49,21 +49,21 @@ class BuddyThreadClass;
 class GameSpyBuddyMessageQueue : public GameSpyBuddyMessageQueueInterface
 {
 public:
-	virtual ~GameSpyBuddyMessageQueue();
+	virtual ~GameSpyBuddyMessageQueue() override;
 	GameSpyBuddyMessageQueue();
-	virtual void startThread();
-	virtual void endThread();
-	virtual Bool isThreadRunning();
-	virtual Bool isConnected();
-	virtual Bool isConnecting();
+	virtual void startThread() override;
+	virtual void endThread() override;
+	virtual Bool isThreadRunning() override;
+	virtual Bool isConnected() override;
+	virtual Bool isConnecting() override;
 
-	virtual void addRequest( const BuddyRequest& req );
-	virtual Bool getRequest( BuddyRequest& req );
+	virtual void addRequest( const BuddyRequest& req ) override;
+	virtual Bool getRequest( BuddyRequest& req ) override;
 
-	virtual void addResponse( const BuddyResponse& resp );
-	virtual Bool getResponse( BuddyResponse& resp );
+	virtual void addResponse( const BuddyResponse& resp ) override;
+	virtual Bool getResponse( BuddyResponse& resp ) override;
 
-	virtual GPProfile getLocalProfileID();
+	virtual GPProfile getLocalProfileID() override;
 
 	BuddyThreadClass* getThread();
 
@@ -91,7 +91,7 @@ class BuddyThreadClass : public ThreadClass
 public:
 	BuddyThreadClass() : ThreadClass() { m_isNewAccount = m_isdeleting = m_isConnecting = m_isConnected = false; m_profileID = 0; m_lastErrorCode = 0; }
 
-	void Thread_Function();
+	virtual void Thread_Function() override;
 
 	void errorCallback( GPConnection *con, GPErrorArg *arg );
 	void messageCallback( GPConnection *con, GPRecvBuddyMessageArg *arg );

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/GameResultsThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/GameResultsThread.cpp
@@ -47,24 +47,24 @@ class GameResultsThreadClass;
 class GameResultsQueue : public GameResultsInterface
 {
 public:
-	virtual ~GameResultsQueue();
+	virtual ~GameResultsQueue() override;
 	GameResultsQueue();
 
-	virtual void init() {}
-	virtual void reset() {}
-	virtual void update() {}
+	virtual void init() override {}
+	virtual void reset() override {}
+	virtual void update() override {}
 
-	virtual void startThreads();
-	virtual void endThreads();
-	virtual Bool areThreadsRunning();
+	virtual void startThreads() override;
+	virtual void endThreads() override;
+	virtual Bool areThreadsRunning() override;
 
-	virtual void addRequest( const GameResultsRequest& req );
-	virtual Bool getRequest( GameResultsRequest& resp );
+	virtual void addRequest( const GameResultsRequest& req ) override;
+	virtual Bool getRequest( GameResultsRequest& resp ) override;
 
-	virtual void addResponse( const GameResultsResponse& resp );
-	virtual Bool getResponse( GameResultsResponse& resp );
+	virtual void addResponse( const GameResultsResponse& resp ) override;
+	virtual Bool getResponse( GameResultsResponse& resp ) override;
 
-	virtual Bool areGameResultsBeingSent();
+	virtual Bool areGameResultsBeingSent() override;
 
 private:
 	MutexClass m_requestMutex;
@@ -92,7 +92,7 @@ class GameResultsThreadClass : public ThreadClass
 public:
 	GameResultsThreadClass() : ThreadClass() {}
 
-	void Thread_Function();
+	virtual void Thread_Function() override;
 
 private:
 	Int sendGameResults( UnsignedInt IP, UnsignedShort port, const std::string& results );

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
@@ -134,21 +134,21 @@ class PeerThreadClass;
 class GameSpyPeerMessageQueue : public GameSpyPeerMessageQueueInterface
 {
 public:
-	virtual ~GameSpyPeerMessageQueue();
+	virtual ~GameSpyPeerMessageQueue() override;
 	GameSpyPeerMessageQueue();
-	virtual void startThread();
-	virtual void endThread();
-	virtual Bool isThreadRunning();
-	virtual Bool isConnected();
-	virtual Bool isConnecting();
+	virtual void startThread() override;
+	virtual void endThread() override;
+	virtual Bool isThreadRunning() override;
+	virtual Bool isConnected() override;
+	virtual Bool isConnecting() override;
 
-	virtual void addRequest( const PeerRequest& req );
-	virtual Bool getRequest( PeerRequest& req );
+	virtual void addRequest( const PeerRequest& req ) override;
+	virtual Bool getRequest( PeerRequest& req ) override;
 
-	virtual void addResponse( const PeerResponse& resp );
-	virtual Bool getResponse( PeerResponse& resp );
+	virtual void addResponse( const PeerResponse& resp ) override;
+	virtual Bool getResponse( PeerResponse& resp ) override;
 
-	virtual SerialAuthResult getSerialAuthResult() { return m_serialAuth; }
+	virtual SerialAuthResult getSerialAuthResult() override { return m_serialAuth; }
 	void setSerialAuthResult( SerialAuthResult result ) { m_serialAuth = result; }
 
 	PeerThreadClass* getThread();
@@ -206,7 +206,7 @@ public:
 		}
 	}
 
-	void Thread_Function();
+	virtual void Thread_Function() override;
 
 	void markAsDisconnected() { m_isConnecting = m_isConnected = false; }
 

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PersistentStorageThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PersistentStorageThread.cpp
@@ -368,20 +368,20 @@ class PSThreadClass;
 class GameSpyPSMessageQueue : public GameSpyPSMessageQueueInterface
 {
 public:
-	virtual ~GameSpyPSMessageQueue();
+	virtual ~GameSpyPSMessageQueue() override;
 	GameSpyPSMessageQueue();
-	virtual void startThread();
-	virtual void endThread();
-	virtual Bool isThreadRunning();
+	virtual void startThread() override;
+	virtual void endThread() override;
+	virtual Bool isThreadRunning() override;
 
-	virtual void addRequest( const PSRequest& req );
-	virtual Bool getRequest( PSRequest& req );
+	virtual void addRequest( const PSRequest& req ) override;
+	virtual Bool getRequest( PSRequest& req ) override;
 
-	virtual void addResponse( const PSResponse& resp );
-	virtual Bool getResponse( PSResponse& resp );
+	virtual void addResponse( const PSResponse& resp ) override;
+	virtual Bool getResponse( PSResponse& resp ) override;
 
-	virtual void trackPlayerStats( PSPlayerStats stats );
-	virtual PSPlayerStats findPlayerStatsByID( Int id );
+	virtual void trackPlayerStats( PSPlayerStats stats ) override;
+	virtual PSPlayerStats findPlayerStatsByID( Int id ) override;
 
 	PSThreadClass* getThread();
 
@@ -431,7 +431,7 @@ public:
 		m_opCount = 0;
 	}
 
-	void Thread_Function();
+	virtual void Thread_Function() override;
 
 	void persAuthCallback( Bool val ) { m_loginOK = val; m_doneTryingToLogin = true; }
 	void decrOpCount() { --m_opCount; }

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PingThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PingThread.cpp
@@ -47,23 +47,23 @@ class PingThreadClass;
 class Pinger : public PingerInterface
 {
 public:
-	virtual ~Pinger();
+	virtual ~Pinger() override;
 	Pinger();
-	virtual void startThreads();
-	virtual void endThreads();
-	virtual Bool areThreadsRunning();
+	virtual void startThreads() override;
+	virtual void endThreads() override;
+	virtual Bool areThreadsRunning() override;
 
-	virtual void addRequest( const PingRequest& req );
-	virtual Bool getRequest( PingRequest& resp );
+	virtual void addRequest( const PingRequest& req ) override;
+	virtual Bool getRequest( PingRequest& resp ) override;
 
-	virtual void addResponse( const PingResponse& resp );
-	virtual Bool getResponse( PingResponse& resp );
+	virtual void addResponse( const PingResponse& resp ) override;
+	virtual Bool getResponse( PingResponse& resp ) override;
 
-	virtual Bool arePingsInProgress();
-	virtual Int getPing( AsciiString hostname );
+	virtual Bool arePingsInProgress() override;
+	virtual Int getPing( AsciiString hostname ) override;
 
-	virtual void clearPingMap();
-	virtual AsciiString getPingString( Int timeout );
+	virtual void clearPingMap() override;
+	virtual AsciiString getPingString( Int timeout ) override;
 
 private:
 	MutexClass m_requestMutex;
@@ -94,7 +94,7 @@ class PingThreadClass : public ThreadClass
 public:
 	PingThreadClass() : ThreadClass() {}
 
-	void Thread_Function();
+	virtual void Thread_Function() override;
 
 private:
 	Int doPing( UnsignedInt IP, Int timeout );

--- a/Core/GameEngine/Source/GameNetwork/Network.cpp
+++ b/Core/GameEngine/Source/GameNetwork/Network.cpp
@@ -104,49 +104,49 @@ public:
 	//---------------------------------------------------------------------------------------
 	// Setup / Teardown functions
 	Network();
-	~Network();
-	void init();																				///< Initialize or re-initialize the instance
-	void reset();																				///< Reinitialize the network
-	void update();																			///< Process command list
-	void liteupdate();																	///< Do a lightweight update to send packets and pass messages.
+	~Network() override;
+	void init() override;																				///< Initialize or re-initialize the instance
+	void reset() override;																				///< Reinitialize the network
+	void update() override;																			///< Process command list
+	void liteupdate() override;																	///< Do a lightweight update to send packets and pass messages.
 	Bool deinit();																			///< Shutdown connections, release memory
 
-	void setLocalAddress(UnsignedInt ip, UnsignedInt port);
-	UnsignedInt getRunAhead() { return m_runAhead; }
-	UnsignedInt getFrameRate() { return m_frameRate; }
-	UnsignedInt getPacketArrivalCushion();								///< Returns the smallest packet arrival cushion since this was last called.
-	Bool isFrameDataReady();
-	virtual Bool isStalling();
-	void parseUserList( const GameInfo *game );
-	void startGame();																			///< Sets the network game frame counter to -1
+	void setLocalAddress(UnsignedInt ip, UnsignedInt port) override;
+	UnsignedInt getRunAhead() override { return m_runAhead; }
+	UnsignedInt getFrameRate() override { return m_frameRate; }
+	UnsignedInt getPacketArrivalCushion() override;								///< Returns the smallest packet arrival cushion since this was last called.
+	Bool isFrameDataReady() override;
+	virtual Bool isStalling() override;
+	void parseUserList( const GameInfo *game ) override;
+	void startGame() override;																			///< Sets the network game frame counter to -1
 
-	void sendChat(UnicodeString text, Int playerMask);
-	void sendDisconnectChat(UnicodeString text);
+	virtual void sendChat(UnicodeString text, Int playerMask) override;
+	virtual void sendDisconnectChat(UnicodeString text) override;
 
-	void sendFile(AsciiString path, UnsignedByte playerMask, UnsignedShort commandID);
-	UnsignedShort sendFileAnnounce(AsciiString path, UnsignedByte playerMask);
-	Int getFileTransferProgress(Int playerID, AsciiString path);
-	Bool areAllQueuesEmpty();
+	void sendFile(AsciiString path, UnsignedByte playerMask, UnsignedShort commandID) override;
+	UnsignedShort sendFileAnnounce(AsciiString path, UnsignedByte playerMask) override;
+	Int getFileTransferProgress(Int playerID, AsciiString path) override;
+	Bool areAllQueuesEmpty() override;
 
-	void quitGame();
-	virtual void selfDestructPlayer(Int index);
+	virtual void quitGame() override;
+	virtual void selfDestructPlayer(Int index) override;
 
 
-	void voteForPlayerDisconnect(Int slot);
-	virtual Bool isPacketRouter();
+	void voteForPlayerDisconnect(Int slot) override;
+	virtual Bool isPacketRouter() override;
 
 	// Bandwidth metrics
-	Real getIncomingBytesPerSecond();
-	Real getIncomingPacketsPerSecond();
-	Real getOutgoingBytesPerSecond();
-	Real getOutgoingPacketsPerSecond();
-	Real getUnknownBytesPerSecond();
-	Real getUnknownPacketsPerSecond();
+	Real getIncomingBytesPerSecond() override;
+	Real getIncomingPacketsPerSecond() override;
+	Real getOutgoingBytesPerSecond() override;
+	Real getOutgoingPacketsPerSecond() override;
+	Real getUnknownBytesPerSecond() override;
+	Real getUnknownPacketsPerSecond() override;
 
 	// Multiplayer Load Progress Functions
-	void updateLoadProgress( Int percent );
-	void loadProgressComplete();
-	void sendTimeOutGameStart();
+	void updateLoadProgress( Int percent ) override;
+	void loadProgressComplete() override;
+	void sendTimeOutGameStart() override;
 
 #if defined(RTS_DEBUG)
 	// Disconnect screen testing
@@ -154,29 +154,29 @@ public:
 #endif
 
 	// Exposing some info contained in the Connection Manager
-	UnsignedInt getLocalPlayerID();
-	UnicodeString getPlayerName(Int playerNum);
-	Int getNumPlayers();
+	UnsignedInt getLocalPlayerID() override;
+	UnicodeString getPlayerName(Int playerNum) override;
+	Int getNumPlayers() override;
 
-	Int getAverageFPS() { return m_conMgr->getAverageFPS(); }
-	Int getSlotAverageFPS(Int slot);
+	virtual Int getAverageFPS() override { return m_conMgr->getAverageFPS(); }
+	virtual Int getSlotAverageFPS(Int slot) override;
 
-	void attachTransport(Transport *transport);
-	void initTransport();
+	virtual void attachTransport(Transport *transport) override;
+	virtual void initTransport() override;
 
-	void setSawCRCMismatch();
-	Bool sawCRCMismatch() { return m_sawCRCMismatch; }
-	Bool isPlayerConnected( Int playerID );
+	void setSawCRCMismatch() override;
+	Bool sawCRCMismatch() override { return m_sawCRCMismatch; }
+	Bool isPlayerConnected( Int playerID ) override;
 
-	void notifyOthersOfCurrentFrame();														///< Tells all the other players what frame we are on.
-	void notifyOthersOfNewFrame(UnsignedInt frame);								///< Tells all the other players that we are on a new frame.
+	virtual void notifyOthersOfCurrentFrame() override;														///< Tells all the other players what frame we are on.
+	virtual void notifyOthersOfNewFrame(UnsignedInt frame) override;								///< Tells all the other players that we are on a new frame.
 
-	Int  getExecutionFrame();																			///< Returns the next valid frame for simultaneous command execution.
+	virtual Int  getExecutionFrame() override;																			///< Returns the next valid frame for simultaneous command execution.
 
 	// For disconnect blame assignment
-	UnsignedInt getPingFrame();
-	Int getPingsSent();
-	Int getPingsReceived();
+	virtual UnsignedInt getPingFrame() override;
+	virtual Int getPingsSent() override;
+	virtual Int getPingsReceived() override;
 
 protected:
 	void GetCommandsFromCommandList();														///< Remove commands from TheCommandList and put them on the Network command list.

--- a/Core/GameEngine/Source/GameNetwork/Network.cpp
+++ b/Core/GameEngine/Source/GameNetwork/Network.cpp
@@ -104,49 +104,49 @@ public:
 	//---------------------------------------------------------------------------------------
 	// Setup / Teardown functions
 	Network();
-	~Network() override;
-	void init() override;																				///< Initialize or re-initialize the instance
-	void reset() override;																				///< Reinitialize the network
-	void update() override;																			///< Process command list
-	void liteupdate() override;																	///< Do a lightweight update to send packets and pass messages.
+	virtual ~Network() override;
+	virtual void init() override;																				///< Initialize or re-initialize the instance
+	virtual void reset() override;																				///< Reinitialize the network
+	virtual void update() override;																			///< Process command list
+	virtual void liteupdate() override;																	///< Do a lightweight update to send packets and pass messages.
 	Bool deinit();																			///< Shutdown connections, release memory
 
-	void setLocalAddress(UnsignedInt ip, UnsignedInt port) override;
-	UnsignedInt getRunAhead() override { return m_runAhead; }
-	UnsignedInt getFrameRate() override { return m_frameRate; }
-	UnsignedInt getPacketArrivalCushion() override;								///< Returns the smallest packet arrival cushion since this was last called.
-	Bool isFrameDataReady() override;
+	virtual void setLocalAddress(UnsignedInt ip, UnsignedInt port) override;
+	virtual UnsignedInt getRunAhead() override { return m_runAhead; }
+	virtual UnsignedInt getFrameRate() override { return m_frameRate; }
+	virtual UnsignedInt getPacketArrivalCushion() override;								///< Returns the smallest packet arrival cushion since this was last called.
+	virtual Bool isFrameDataReady() override;
 	virtual Bool isStalling() override;
-	void parseUserList( const GameInfo *game ) override;
-	void startGame() override;																			///< Sets the network game frame counter to -1
+	virtual void parseUserList( const GameInfo *game ) override;
+	virtual void startGame() override;																			///< Sets the network game frame counter to -1
 
 	virtual void sendChat(UnicodeString text, Int playerMask) override;
 	virtual void sendDisconnectChat(UnicodeString text) override;
 
-	void sendFile(AsciiString path, UnsignedByte playerMask, UnsignedShort commandID) override;
-	UnsignedShort sendFileAnnounce(AsciiString path, UnsignedByte playerMask) override;
-	Int getFileTransferProgress(Int playerID, AsciiString path) override;
-	Bool areAllQueuesEmpty() override;
+	virtual void sendFile(AsciiString path, UnsignedByte playerMask, UnsignedShort commandID) override;
+	virtual UnsignedShort sendFileAnnounce(AsciiString path, UnsignedByte playerMask) override;
+	virtual Int getFileTransferProgress(Int playerID, AsciiString path) override;
+	virtual Bool areAllQueuesEmpty() override;
 
 	virtual void quitGame() override;
 	virtual void selfDestructPlayer(Int index) override;
 
 
-	void voteForPlayerDisconnect(Int slot) override;
+	virtual void voteForPlayerDisconnect(Int slot) override;
 	virtual Bool isPacketRouter() override;
 
 	// Bandwidth metrics
-	Real getIncomingBytesPerSecond() override;
-	Real getIncomingPacketsPerSecond() override;
-	Real getOutgoingBytesPerSecond() override;
-	Real getOutgoingPacketsPerSecond() override;
-	Real getUnknownBytesPerSecond() override;
-	Real getUnknownPacketsPerSecond() override;
+	virtual Real getIncomingBytesPerSecond() override;
+	virtual Real getIncomingPacketsPerSecond() override;
+	virtual Real getOutgoingBytesPerSecond() override;
+	virtual Real getOutgoingPacketsPerSecond() override;
+	virtual Real getUnknownBytesPerSecond() override;
+	virtual Real getUnknownPacketsPerSecond() override;
 
 	// Multiplayer Load Progress Functions
-	void updateLoadProgress( Int percent ) override;
-	void loadProgressComplete() override;
-	void sendTimeOutGameStart() override;
+	virtual void updateLoadProgress( Int percent ) override;
+	virtual void loadProgressComplete() override;
+	virtual void sendTimeOutGameStart() override;
 
 #if defined(RTS_DEBUG)
 	// Disconnect screen testing
@@ -154,9 +154,9 @@ public:
 #endif
 
 	// Exposing some info contained in the Connection Manager
-	UnsignedInt getLocalPlayerID() override;
-	UnicodeString getPlayerName(Int playerNum) override;
-	Int getNumPlayers() override;
+	virtual UnsignedInt getLocalPlayerID() override;
+	virtual UnicodeString getPlayerName(Int playerNum) override;
+	virtual Int getNumPlayers() override;
 
 	virtual Int getAverageFPS() override { return m_conMgr->getAverageFPS(); }
 	virtual Int getSlotAverageFPS(Int slot) override;
@@ -164,9 +164,9 @@ public:
 	virtual void attachTransport(Transport *transport) override;
 	virtual void initTransport() override;
 
-	void setSawCRCMismatch() override;
-	Bool sawCRCMismatch() override { return m_sawCRCMismatch; }
-	Bool isPlayerConnected( Int playerID ) override;
+	virtual void setSawCRCMismatch() override;
+	virtual Bool sawCRCMismatch() override { return m_sawCRCMismatch; }
+	virtual Bool isPlayerConnected( Int playerID ) override;
 
 	virtual void notifyOthersOfCurrentFrame() override;														///< Tells all the other players what frame we are on.
 	virtual void notifyOthersOfNewFrame(UnsignedInt frame) override;								///< Tells all the other players that we are on a new frame.

--- a/Generals/Code/GameEngine/Include/Common/ActionManager.h
+++ b/Generals/Code/GameEngine/Include/Common/ActionManager.h
@@ -61,11 +61,11 @@ class ActionManager : public SubsystemInterface
 public:
 
 	ActionManager();
-	virtual ~ActionManager();
+	virtual ~ActionManager() override;
 
-	virtual void init() { };							///< subsystem interface
-	virtual void reset() { };							///< subsystem interface
-	virtual void update() { };						///< subsystem interface
+	virtual void init() override { };							///< subsystem interface
+	virtual void reset() override { };							///< subsystem interface
+	virtual void update() override { };						///< subsystem interface
 
 	//Single unit to unit check
 	Bool canGetRepairedAt( const Object *obj, const Object *repairDest, CommandSourceType commandSource );

--- a/Generals/Code/GameEngine/Include/Common/BuildAssistant.h
+++ b/Generals/Code/GameEngine/Include/Common/BuildAssistant.h
@@ -120,11 +120,11 @@ public:
 public:
 
 	BuildAssistant();
-	virtual ~BuildAssistant();
+	virtual ~BuildAssistant() override;
 
-	virtual void init();					///< for subsytem
-	virtual void reset();					///< for subsytem
-	virtual void update();				///< for subsytem
+	virtual void init() override;					///< for subsytem
+	virtual void reset() override;					///< for subsytem
+	virtual void update() override;				///< for subsytem
 
 	/// iterate the "footprint" area of a structure at the given "sample resolution"
 	void iterateFootprint( const ThingTemplate *build,

--- a/Generals/Code/GameEngine/Include/Common/CustomMatchPreferences.h
+++ b/Generals/Code/GameEngine/Include/Common/CustomMatchPreferences.h
@@ -42,7 +42,7 @@ class CustomMatchPreferences : public UserPreferences
 {
 public:
 	CustomMatchPreferences();
-	virtual ~CustomMatchPreferences();
+	virtual ~CustomMatchPreferences() override;
 
 	void setLastLadder(const AsciiString& addr, UnsignedShort port);
 	AsciiString getLastLadderAddr();

--- a/Generals/Code/GameEngine/Include/Common/DamageFX.h
+++ b/Generals/Code/GameEngine/Include/Common/DamageFX.h
@@ -138,11 +138,11 @@ class DamageFXStore : public SubsystemInterface
 public:
 
 	DamageFXStore();
-	~DamageFXStore();
+	virtual ~DamageFXStore() override;
 
-	void init();
-	void reset();
-	void update();
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override;
 
 	/**
 		Find the DamageFX with the given name. If no such DamageFX exists, return null.

--- a/Generals/Code/GameEngine/Include/Common/Energy.h
+++ b/Generals/Code/GameEngine/Include/Common/Energy.h
@@ -102,9 +102,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	void addProduction(Int amt);
 	void addConsumption(Int amt);

--- a/Generals/Code/GameEngine/Include/Common/FunctionLexicon.h
+++ b/Generals/Code/GameEngine/Include/Common/FunctionLexicon.h
@@ -71,11 +71,11 @@ public:
 public:
 
 	FunctionLexicon();
-	virtual ~FunctionLexicon();
+	virtual ~FunctionLexicon() override;
 
-	virtual void init();
-	virtual void reset();
-	virtual void update();
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override;
 
 	/// validate the tables and make sure all entries are unique
 	Bool validate();

--- a/Generals/Code/GameEngine/Include/Common/GameEngine.h
+++ b/Generals/Code/GameEngine/Include/Common/GameEngine.h
@@ -55,11 +55,11 @@ class GameEngine : public SubsystemInterface
 public:
 
 	GameEngine();
-	virtual ~GameEngine();
+	virtual ~GameEngine() override;
 
-	virtual void init();								///< Init engine by creating client and logic
-	virtual void reset();								///< reset system to starting state
-	virtual void update();							///< per frame update
+	virtual void init() override;								///< Init engine by creating client and logic
+	virtual void reset() override;								///< reset system to starting state
+	virtual void update() override;							///< per frame update
 
 	virtual void execute();											/**< The "main loop" of the game engine.
 																								 It will not return until the game exits. */

--- a/Generals/Code/GameEngine/Include/Common/GameSpyMiscPreferences.h
+++ b/Generals/Code/GameEngine/Include/Common/GameSpyMiscPreferences.h
@@ -42,7 +42,7 @@ class GameSpyMiscPreferences : public UserPreferences
 {
 public:
 	GameSpyMiscPreferences();
-	virtual ~GameSpyMiscPreferences();
+	virtual ~GameSpyMiscPreferences() override;
 
 	Int getLocale();
 	void setLocale( Int val );

--- a/Generals/Code/GameEngine/Include/Common/GameState.h
+++ b/Generals/Code/GameEngine/Include/Common/GameState.h
@@ -148,12 +148,12 @@ class GameState : public SubsystemInterface,
 public:
 
 	GameState();
-	virtual ~GameState();
+	virtual ~GameState() override;
 
 	// subsystem interface
-	virtual void init();
-	virtual void reset();
-	virtual void update() { }
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override { }
 
 	// save game methods
 	SaveCode saveGame( AsciiString filename,
@@ -191,9 +191,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer ) { }
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess() { }
+	virtual void crc( Xfer *xfer ) override { }
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override { }
 
 private:
 

--- a/Generals/Code/GameEngine/Include/Common/GameStateMap.h
+++ b/Generals/Code/GameEngine/Include/Common/GameStateMap.h
@@ -45,17 +45,17 @@ class GameStateMap : public SubsystemInterface,
 public:
 
 	GameStateMap();
-	virtual ~GameStateMap();
+	virtual ~GameStateMap() override;
 
 	// subsystem interface methods
-	virtual void init() { }
-	virtual void reset() { }
-	virtual void update() { }
+	virtual void init() override { }
+	virtual void reset() override { }
+	virtual void update() override { }
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer ) { }
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess() { }
+	virtual void crc( Xfer *xfer ) override { }
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override { }
 
 	void clearScratchPadMaps();		///< clear any scratch pad maps from the save directory
 

--- a/Generals/Code/GameEngine/Include/Common/Geometry.h
+++ b/Generals/Code/GameEngine/Include/Common/Geometry.h
@@ -97,9 +97,9 @@ private:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 public:
 

--- a/Generals/Code/GameEngine/Include/Common/GlobalData.h
+++ b/Generals/Code/GameEngine/Include/Common/GlobalData.h
@@ -574,7 +574,7 @@ private:
 
 	static GlobalData *m_theOriginal;		///< the original global data instance (no overrides)
 	GlobalData *m_next;									///< next instance (for overrides)
-	GlobalData *newOverride();		/** create a new override, copy data from previous
+	virtual GlobalData *newOverride();		/** create a new override, copy data from previous
 																			override, and return it */
 
 #if defined(_MSC_VER) && _MSC_VER < 1300

--- a/Generals/Code/GameEngine/Include/Common/GlobalData.h
+++ b/Generals/Code/GameEngine/Include/Common/GlobalData.h
@@ -80,11 +80,11 @@ class GlobalData : public SubsystemInterface
 public:
 
 	GlobalData();
-	virtual ~GlobalData();
+	virtual ~GlobalData() override;
 
-	virtual void init();
-	virtual void reset();
-	virtual void update() { }
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override { }
 
 	Bool setTimeOfDay( TimeOfDay tod );		///< Use this function to set the Time of day;
 

--- a/Generals/Code/GameEngine/Include/Common/IgnorePreferences.h
+++ b/Generals/Code/GameEngine/Include/Common/IgnorePreferences.h
@@ -66,7 +66,7 @@ class IgnorePreferences : public UserPreferences
 {
 public:
 	IgnorePreferences();
-	virtual ~IgnorePreferences();
+	virtual ~IgnorePreferences() override;
 	void setIgnore(const AsciiString& userName, Int profileID, Bool ignore);
 	IgnorePrefMap getIgnores();
 

--- a/Generals/Code/GameEngine/Include/Common/LadderPreferences.h
+++ b/Generals/Code/GameEngine/Include/Common/LadderPreferences.h
@@ -62,10 +62,10 @@ class LadderPreferences : public UserPreferences
 {
 public:
 	LadderPreferences();
-	virtual ~LadderPreferences();
+	virtual ~LadderPreferences() override;
 
 	Bool loadProfile( Int profileID );
-	virtual bool write();
+	virtual bool write() override;
 
 	const LadderPrefMap& getRecentLadders();
 	void addRecentLadder( LadderPref ladder );

--- a/Generals/Code/GameEngine/Include/Common/MapReaderWriterInfo.h
+++ b/Generals/Code/GameEngine/Include/Common/MapReaderWriterInfo.h
@@ -70,7 +70,7 @@ public:
 variety of sources, such as FILE* or CFile. */
 class ChunkInputStream : public InputStream{
 public:
-	virtual Int read(void *pData, Int numBytes) = 0;
+	virtual Int read(void *pData, Int numBytes) override = 0;
 	virtual UnsignedInt tell() = 0;
 	virtual Bool absoluteSeek(UnsignedInt pos) = 0;
 	virtual Bool eof() = 0;
@@ -88,10 +88,10 @@ public:
 	~CachedFileInputStream();
 	Bool open(AsciiString path);	///< Returns true if open succeeded.
 	void close();  ///< Explict close.  Destructor closes if file is left open.
-	virtual Int read(void *pData, Int numBytes);
-	virtual UnsignedInt tell();
-	virtual Bool absoluteSeek(UnsignedInt pos);
-	virtual Bool eof();
+	virtual Int read(void *pData, Int numBytes) override;
+	virtual UnsignedInt tell() override;
+	virtual Bool absoluteSeek(UnsignedInt pos) override;
+	virtual Bool eof() override;
 	void rewind();
 };
 

--- a/Generals/Code/GameEngine/Include/Common/MapReaderWriterInfo.h
+++ b/Generals/Code/GameEngine/Include/Common/MapReaderWriterInfo.h
@@ -70,7 +70,7 @@ public:
 variety of sources, such as FILE* or CFile. */
 class ChunkInputStream : public InputStream{
 public:
-	virtual Int read(void *pData, Int numBytes) override = 0;
+	virtual Int read(void *pData, Int numBytes) = 0;
 	virtual UnsignedInt tell() = 0;
 	virtual Bool absoluteSeek(UnsignedInt pos) = 0;
 	virtual Bool eof() = 0;

--- a/Generals/Code/GameEngine/Include/Common/MessageStream.h
+++ b/Generals/Code/GameEngine/Include/Common/MessageStream.h
@@ -667,11 +667,11 @@ class GameMessageList : public SubsystemInterface
 public:
 
 	GameMessageList();
-	virtual ~GameMessageList();
+	virtual ~GameMessageList() override;
 
-	virtual void init() { };			///< Initialize system
-	virtual void reset() { };			///< Reset system
-	virtual void update() { };		///< Update system
+	virtual void init() override { };			///< Initialize system
+	virtual void reset() override { };			///< Reset system
+	virtual void update() override { };		///< Update system
 
 	GameMessage *getFirstMessage() { return m_firstMessage; }	///< Return the first message
 
@@ -714,12 +714,12 @@ class MessageStream : public GameMessageList
 public:
 
 	MessageStream();
-	virtual ~MessageStream();
+	virtual ~MessageStream() override;
 
 	// Inherited Methods ----------------------------------------------------------------------------
-	virtual void init();
-	virtual void reset();
-	virtual void update();
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override;
 
 	virtual GameMessage *appendMessage( GameMessage::Type type );		///< Append a message to the end of the stream
 	virtual GameMessage *insertMessage( GameMessage::Type type, GameMessage *messageToInsertAfter );	// Insert message after messageToInsertAfter.
@@ -770,11 +770,11 @@ class CommandList : public GameMessageList
 {
 public:
 	CommandList();
-	virtual ~CommandList();
+	virtual ~CommandList() override;
 
-	virtual void init();			///< Init command list
-	virtual void reset();			///< Destroy all messages and reset list to empty
-	virtual void update();		///< Update hook
+	virtual void init() override;			///< Init command list
+	virtual void reset() override;			///< Destroy all messages and reset list to empty
+	virtual void update() override;		///< Update hook
 
 	void appendMessageList( GameMessage *list );			///< Adds messages to the end of the command list
 

--- a/Generals/Code/GameEngine/Include/Common/MissionStats.h
+++ b/Generals/Code/GameEngine/Include/Common/MissionStats.h
@@ -70,9 +70,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 

--- a/Generals/Code/GameEngine/Include/Common/Module.h
+++ b/Generals/Code/GameEngine/Include/Common/Module.h
@@ -117,9 +117,9 @@ public:
 	}
 
 public:
-	virtual void crc( Xfer *xfer ) {}
-	virtual void xfer( Xfer *xfer ) {}
-	virtual void loadPostProcess() {}
+	virtual void crc( Xfer *xfer ) override {}
+	virtual void xfer( Xfer *xfer ) override {}
+	virtual void loadPostProcess() override {}
 
 private:
 	NameKeyType m_moduleTagNameKey;		///< module tag key, unique among all modules for an object instance
@@ -213,9 +213,9 @@ protected:
 
 	const ModuleData* getModuleData() const { return m_moduleData; }
 
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	const ModuleData* m_moduleData;
@@ -251,9 +251,9 @@ protected:
 	Object *getObject() { return m_object; }
 	const Object *getObject() const { return m_object; }
 
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 
@@ -294,9 +294,9 @@ protected:
 	Drawable *getDrawable() { return m_drawable; }
 	const Drawable *getDrawable() const { return m_drawable; }
 
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 

--- a/Generals/Code/GameEngine/Include/Common/ModuleFactory.h
+++ b/Generals/Code/GameEngine/Include/Common/ModuleFactory.h
@@ -68,11 +68,11 @@ class ModuleFactory : public SubsystemInterface, public Snapshot
 public:
 
 	ModuleFactory();
-	virtual ~ModuleFactory();
+	virtual ~ModuleFactory() override;
 
-	virtual void init();
-	virtual void reset() { }					///< We don't reset during the lifetime of the app
-	virtual void update() { }					///< As of now, we don't have a need for an update
+	virtual void init() override;
+	virtual void reset() override { }					///< We don't reset during the lifetime of the app
+	virtual void update() override { }					///< As of now, we don't have a need for an update
 
 	Module *newModule( Thing *thing, const AsciiString& name, const ModuleData* data, ModuleType type );  ///< allocate a new module
 
@@ -81,9 +81,9 @@ public:
 
 	Int findModuleInterfaceMask(const AsciiString& name, ModuleType type);
 
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/Common/Money.h
+++ b/Generals/Code/GameEngine/Include/Common/Money.h
@@ -99,9 +99,9 @@ protected:
 	void triggerAudioEvent(const AudioEventRTS& audioEvent);
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 

--- a/Generals/Code/GameEngine/Include/Common/MultiplayerSettings.h
+++ b/Generals/Code/GameEngine/Include/Common/MultiplayerSettings.h
@@ -80,9 +80,9 @@ public:
 
 	MultiplayerSettings();
 
-	virtual void init() { }
-	virtual void update() { }
-	virtual void reset() { }
+	virtual void init() override { }
+	virtual void update() override { }
+	virtual void reset() override { }
 
 	//-----------------------------------------------------------------------------------------------
 	static const FieldParse m_multiplayerSettingsFieldParseTable[];		///< the parse table for INI definition

--- a/Generals/Code/GameEngine/Include/Common/NameKeyGenerator.h
+++ b/Generals/Code/GameEngine/Include/Common/NameKeyGenerator.h
@@ -83,11 +83,11 @@ class NameKeyGenerator : public SubsystemInterface
 public:
 
 	NameKeyGenerator();
-	virtual ~NameKeyGenerator();
+	virtual ~NameKeyGenerator() override;
 
-	virtual void init();
-	virtual void reset();
-	virtual void update() { }
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override { }
 
 	/// Given a string, convert into a unique integer key.
 	NameKeyType nameToKey(const AsciiString& name);

--- a/Generals/Code/GameEngine/Include/Common/Player.h
+++ b/Generals/Code/GameEngine/Include/Common/Player.h
@@ -165,9 +165,9 @@ public:
 
 protected:
 
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 };
 
@@ -695,9 +695,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	void deleteUpgradeList();															///< delete all our upgrades
 

--- a/Generals/Code/GameEngine/Include/Common/PlayerList.h
+++ b/Generals/Code/GameEngine/Include/Common/PlayerList.h
@@ -77,12 +77,12 @@ class PlayerList : public SubsystemInterface,
 public:
 
 	PlayerList();
-	~PlayerList();
+	virtual ~PlayerList() override;
 
 	// subsystem methods
-	virtual void init();
-	virtual void reset();
-	virtual void update();
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override;
 
 	virtual void newGame(); // called during GameLogic::startNewGame()
 	virtual void newMap();	 // Called after a new map is loaded.
@@ -153,9 +153,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 

--- a/Generals/Code/GameEngine/Include/Common/PlayerTemplate.h
+++ b/Generals/Code/GameEngine/Include/Common/PlayerTemplate.h
@@ -190,11 +190,11 @@ class PlayerTemplateStore : public SubsystemInterface
 public:
 
 	PlayerTemplateStore();
-	~PlayerTemplateStore();
+	virtual ~PlayerTemplateStore() override;
 
-	virtual void init();
-	virtual void reset();
-	virtual void update();
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override;
 
 	static void parsePlayerTemplateDefinition( INI* ini );
 

--- a/Generals/Code/GameEngine/Include/Common/QuickmatchPreferences.h
+++ b/Generals/Code/GameEngine/Include/Common/QuickmatchPreferences.h
@@ -42,7 +42,7 @@ class QuickMatchPreferences : public UserPreferences
 {
 public:
 	QuickMatchPreferences();
-	virtual ~QuickMatchPreferences();
+	virtual ~QuickMatchPreferences() override;
 
 	void setMapSelected(const AsciiString& mapName, Bool selected);
 	Bool isMapSelected(const AsciiString& mapName);

--- a/Generals/Code/GameEngine/Include/Common/Recorder.h
+++ b/Generals/Code/GameEngine/Include/Common/Recorder.h
@@ -61,11 +61,11 @@ public:
 
 public:
 	RecorderClass();																	///< Constructor.
-	virtual ~RecorderClass();													///< Destructor.
+	virtual ~RecorderClass() override;													///< Destructor.
 
-	void init();																			///< Initialize TheRecorder.
-	void reset();																			///< Reset the state of TheRecorder.
-	void update();																		///< General purpose update function.
+	virtual void init() override;																			///< Initialize TheRecorder.
+	virtual void reset() override;																			///< Reset the state of TheRecorder.
+	virtual void update() override;																		///< General purpose update function.
 
 	// Methods dealing with recording.
 	void updateRecord();															///< The update function for recording.

--- a/Generals/Code/GameEngine/Include/Common/ResourceGatheringManager.h
+++ b/Generals/Code/GameEngine/Include/Common/ResourceGatheringManager.h
@@ -56,9 +56,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	/// @todo Make sure the allocator for std::list<> is a good one.  Otherwise override it.

--- a/Generals/Code/GameEngine/Include/Common/Science.h
+++ b/Generals/Code/GameEngine/Include/Common/Science.h
@@ -78,11 +78,11 @@ class ScienceStore : public SubsystemInterface
 	friend class ScienceInfo;
 
 public:
-	virtual ~ScienceStore();
+	virtual ~ScienceStore() override;
 
-	void init();
-	void reset();
-	void update() { }
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override { }
 
 	Bool isValidScience(ScienceType st) const;
 

--- a/Generals/Code/GameEngine/Include/Common/ScoreKeeper.h
+++ b/Generals/Code/GameEngine/Include/Common/ScoreKeeper.h
@@ -99,9 +99,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 

--- a/Generals/Code/GameEngine/Include/Common/SkirmishBattleHonors.h
+++ b/Generals/Code/GameEngine/Include/Common/SkirmishBattleHonors.h
@@ -47,7 +47,7 @@ class SkirmishBattleHonors : public UserPreferences
 {
 public:
 	SkirmishBattleHonors();
-	virtual ~SkirmishBattleHonors();
+	virtual ~SkirmishBattleHonors() override;
 
 	Bool loadFromIniFile();
 

--- a/Generals/Code/GameEngine/Include/Common/SkirmishPreferences.h
+++ b/Generals/Code/GameEngine/Include/Common/SkirmishPreferences.h
@@ -42,11 +42,11 @@ class SkirmishPreferences : public UserPreferences
 {
 public:
 	SkirmishPreferences();
-	virtual ~SkirmishPreferences();
+	virtual ~SkirmishPreferences() override;
 
 	Bool loadFromIniFile();
 
-	virtual Bool write();
+	virtual Bool write() override;
 	AsciiString getSlotList();
 	void setSlotList();
 	UnicodeString getUserName();		// convenience function

--- a/Generals/Code/GameEngine/Include/Common/SpecialPower.h
+++ b/Generals/Code/GameEngine/Include/Common/SpecialPower.h
@@ -154,7 +154,7 @@ class SpecialPowerStore : public SubsystemInterface
 public:
 
 	SpecialPowerStore();
-	~SpecialPowerStore() override;
+	virtual ~SpecialPowerStore() override;
 
 	virtual void init() override { };
 	virtual void update() override { };

--- a/Generals/Code/GameEngine/Include/Common/SpecialPower.h
+++ b/Generals/Code/GameEngine/Include/Common/SpecialPower.h
@@ -154,11 +154,11 @@ class SpecialPowerStore : public SubsystemInterface
 public:
 
 	SpecialPowerStore();
-	~SpecialPowerStore();
+	~SpecialPowerStore() override;
 
-	virtual void init() { };
-	virtual void update() { };
-	virtual void reset();
+	virtual void init() override { };
+	virtual void update() override { };
+	virtual void reset() override;
 
 	const SpecialPowerTemplate *findSpecialPowerTemplate( AsciiString name ) { return findSpecialPowerTemplatePrivate(name); }
 	const SpecialPowerTemplate *findSpecialPowerTemplateByID( UnsignedInt id );

--- a/Generals/Code/GameEngine/Include/Common/StateMachine.h
+++ b/Generals/Code/GameEngine/Include/Common/StateMachine.h
@@ -185,9 +185,9 @@ protected:
 	// Essentially all the member data gets set up on creation and shouldn't change.
 	// So none of it needs to be saved, and it nicely forces all user states to
 	// remember to implement crc, xfer & loadPostProcess.  jba
-	virtual void crc( Xfer *xfer )=0;
-	virtual void xfer( Xfer *xfer )=0;
-	virtual void loadPostProcess()=0;
+	virtual void crc( Xfer *xfer ) override =0;
+	virtual void xfer( Xfer *xfer ) override =0;
+	virtual void loadPostProcess() override =0;
 
 private:
 
@@ -334,9 +334,9 @@ public:
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 
@@ -402,13 +402,13 @@ class SuccessState : public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(SuccessState, "SuccessState")
 public:
 	SuccessState( StateMachine *machine ) : State( machine, "SuccessState") { }
-	virtual StateReturnType onEnter() { return STATE_SUCCESS; }
-	virtual StateReturnType update() { return STATE_SUCCESS; }
+	virtual StateReturnType onEnter() override { return STATE_SUCCESS; }
+	virtual StateReturnType update() override { return STATE_SUCCESS; }
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override{};
 
 };
 EMPTY_DTOR(SuccessState)
@@ -422,13 +422,13 @@ class FailureState : public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(FailureState, "FailureState")
 public:
 	FailureState( StateMachine *machine ) : State( machine, "FailureState") { }
-	virtual StateReturnType onEnter() { return STATE_FAILURE; }
-	virtual StateReturnType update() { return STATE_FAILURE; }
+	virtual StateReturnType onEnter() override { return STATE_FAILURE; }
+	virtual StateReturnType update() override { return STATE_FAILURE; }
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override{};
 };
 EMPTY_DTOR(FailureState)
 
@@ -442,13 +442,13 @@ class ContinueState :  public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(ContinueState, "ContinueState")
 public:
 	ContinueState( StateMachine *machine ) : State( machine, "ContinueState" ) { }
-	virtual StateReturnType onEnter() { return STATE_CONTINUE; }
-	virtual StateReturnType update() { return STATE_CONTINUE; }
+	virtual StateReturnType onEnter() override { return STATE_CONTINUE; }
+	virtual StateReturnType update() override { return STATE_CONTINUE; }
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override{};
 };
 EMPTY_DTOR(ContinueState)
 
@@ -462,13 +462,13 @@ class SleepState :  public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(SleepState, "SleepState")
 public:
 	SleepState( StateMachine *machine ) : State( machine, "SleepState" ) { }
-	virtual StateReturnType onEnter() { return STATE_SLEEP_FOREVER; }
-	virtual StateReturnType update() { return STATE_SLEEP_FOREVER; }
+	virtual StateReturnType onEnter() override { return STATE_SLEEP_FOREVER; }
+	virtual StateReturnType update() override { return STATE_SLEEP_FOREVER; }
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override{};
 };
 EMPTY_DTOR(SleepState)
 

--- a/Generals/Code/GameEngine/Include/Common/StateMachine.h
+++ b/Generals/Code/GameEngine/Include/Common/StateMachine.h
@@ -185,9 +185,9 @@ protected:
 	// Essentially all the member data gets set up on creation and shouldn't change.
 	// So none of it needs to be saved, and it nicely forces all user states to
 	// remember to implement crc, xfer & loadPostProcess.  jba
-	virtual void crc( Xfer *xfer ) override =0;
-	virtual void xfer( Xfer *xfer ) override =0;
-	virtual void loadPostProcess() override =0;
+	virtual void crc( Xfer *xfer ) =0;
+	virtual void xfer( Xfer *xfer ) =0;
+	virtual void loadPostProcess() =0;
 
 private:
 

--- a/Generals/Code/GameEngine/Include/Common/StateMachine.h
+++ b/Generals/Code/GameEngine/Include/Common/StateMachine.h
@@ -185,9 +185,9 @@ protected:
 	// Essentially all the member data gets set up on creation and shouldn't change.
 	// So none of it needs to be saved, and it nicely forces all user states to
 	// remember to implement crc, xfer & loadPostProcess.  jba
-	virtual void crc( Xfer *xfer ) =0;
-	virtual void xfer( Xfer *xfer ) =0;
-	virtual void loadPostProcess() =0;
+	virtual void crc( Xfer *xfer )=0;
+	virtual void xfer( Xfer *xfer )=0;
+	virtual void loadPostProcess()=0;
 
 private:
 
@@ -406,9 +406,9 @@ public:
 	virtual StateReturnType update() override { return STATE_SUCCESS; }
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ) override{};
-	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess() override{};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 
 };
 EMPTY_DTOR(SuccessState)
@@ -426,9 +426,9 @@ public:
 	virtual StateReturnType update() override { return STATE_FAILURE; }
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ) override{};
-	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess() override{};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 };
 EMPTY_DTOR(FailureState)
 
@@ -446,9 +446,9 @@ public:
 	virtual StateReturnType update() override { return STATE_CONTINUE; }
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ) override{};
-	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess() override{};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 };
 EMPTY_DTOR(ContinueState)
 
@@ -466,9 +466,9 @@ public:
 	virtual StateReturnType update() override { return STATE_SLEEP_FOREVER; }
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ) override{};
-	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess() override{};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 };
 EMPTY_DTOR(SleepState)
 

--- a/Generals/Code/GameEngine/Include/Common/Team.h
+++ b/Generals/Code/GameEngine/Include/Common/Team.h
@@ -60,9 +60,9 @@ public:
 
 protected:
 
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 };
 
@@ -168,9 +168,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 };
 
@@ -233,9 +233,9 @@ private:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 public:
 
@@ -635,9 +635,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 
@@ -680,12 +680,12 @@ class TeamFactory : public SubsystemInterface,
 public:
 
 	TeamFactory();
-	~TeamFactory();
+	virtual ~TeamFactory() override;
 
 	// subsystem methods
-	virtual void init();
-	virtual void reset();
-	virtual void update();
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override;
 
 	void clear();
 	void initFromSides(SidesList *sides);
@@ -727,9 +727,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 

--- a/Generals/Code/GameEngine/Include/Common/TerrainTypes.h
+++ b/Generals/Code/GameEngine/Include/Common/TerrainTypes.h
@@ -213,7 +213,7 @@ class TerrainTypeCollection : public SubsystemInterface
 public:
 
 	TerrainTypeCollection();
-	~TerrainTypeCollection() override;
+	virtual ~TerrainTypeCollection() override;
 
 	virtual void init() override { }
 	virtual void reset() override { }

--- a/Generals/Code/GameEngine/Include/Common/TerrainTypes.h
+++ b/Generals/Code/GameEngine/Include/Common/TerrainTypes.h
@@ -213,11 +213,11 @@ class TerrainTypeCollection : public SubsystemInterface
 public:
 
 	TerrainTypeCollection();
-	~TerrainTypeCollection();
+	~TerrainTypeCollection() override;
 
-	void init() { }
-	void reset() { }
-	void update() { }
+	virtual void init() override { }
+	virtual void reset() override { }
+	virtual void update() override { }
 
 	TerrainType *findTerrain( AsciiString name );		///< find terrain by name
 	TerrainType *newTerrain( AsciiString name );			///< allocate a new terrain

--- a/Generals/Code/GameEngine/Include/Common/ThingFactory.h
+++ b/Generals/Code/GameEngine/Include/Common/ThingFactory.h
@@ -54,13 +54,13 @@ class ThingFactory : public SubsystemInterface
 public:
 
 	ThingFactory();
-	virtual ~ThingFactory();
+	virtual ~ThingFactory() override;
 
 	// From the subsystem interface =================================================================
-	virtual void init();
-	virtual void postProcessLoad();
-	virtual void reset();
-	virtual void update();
+	virtual void init() override;
+	virtual void postProcessLoad() override;
+	virtual void reset() override;
+	virtual void update() override;
 	//===============================================================================================
 
 	/// create a new template with name 'name' and add to template list

--- a/Generals/Code/GameEngine/Include/Common/TunnelTracker.h
+++ b/Generals/Code/GameEngine/Include/Common/TunnelTracker.h
@@ -75,9 +75,9 @@ public:
 
 protected:
 
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	void updateFullHealTime();

--- a/Generals/Code/GameEngine/Include/Common/Upgrade.h
+++ b/Generals/Code/GameEngine/Include/Common/Upgrade.h
@@ -230,9 +230,9 @@ public:
 	UpgradeCenter();
 	virtual ~UpgradeCenter() override;
 
-	void init() override;												///< subsystem interface
-	void reset() override;												///< subsystem interface
-	void update() override { }										///< subsystem interface
+	virtual void init() override;												///< subsystem interface
+	virtual void reset() override;												///< subsystem interface
+	virtual void update() override { }										///< subsystem interface
 
 	UpgradeTemplate *firstUpgradeTemplate(); ///< return the first upgrade template
 	const UpgradeTemplate *findUpgradeByKey( NameKeyType key ) const; ///< find upgrade by name key

--- a/Generals/Code/GameEngine/Include/Common/Upgrade.h
+++ b/Generals/Code/GameEngine/Include/Common/Upgrade.h
@@ -130,9 +130,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	const UpgradeTemplate *m_template;	///< template this upgrade instance is based on
 	UpgradeStatusType m_status;							///< status of upgrade
@@ -228,11 +228,11 @@ class UpgradeCenter : public SubsystemInterface
 public:
 
 	UpgradeCenter();
-	virtual ~UpgradeCenter();
+	virtual ~UpgradeCenter() override;
 
-	void init();												///< subsystem interface
-	void reset();												///< subsystem interface
-	void update() { }										///< subsystem interface
+	void init() override;												///< subsystem interface
+	void reset() override;												///< subsystem interface
+	void update() override { }										///< subsystem interface
 
 	UpgradeTemplate *firstUpgradeTemplate(); ///< return the first upgrade template
 	const UpgradeTemplate *findUpgradeByKey( NameKeyType key ) const; ///< find upgrade by name key

--- a/Generals/Code/GameEngine/Include/GameClient/Anim2D.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Anim2D.h
@@ -167,9 +167,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer ) { }
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess() { }
+	virtual void crc( Xfer *xfer ) override { }
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override { }
 
 	void tryNextFrame();						///< we've just drawn ... try to update our frame if necessary
 
@@ -196,11 +196,11 @@ class Anim2DCollection : public SubsystemInterface
 public:
 
 	Anim2DCollection();
-	virtual ~Anim2DCollection();
+	virtual ~Anim2DCollection() override;
 
-	virtual void init();						///< initialize system
-	virtual void reset() { };				///< reset system
-	virtual void update();					///< update system
+	virtual void init() override;						///< initialize system
+	virtual void reset() override { };				///< reset system
+	virtual void update() override;					///< update system
 
 	Anim2DTemplate *findTemplate( const AsciiString& name );				///< find animation template
 	Anim2DTemplate *newTemplate( const AsciiString& name );				///< allocate a new template to be loaded

--- a/Generals/Code/GameEngine/Include/GameClient/AnimateWindowManager.h
+++ b/Generals/Code/GameEngine/Include/GameClient/AnimateWindowManager.h
@@ -163,7 +163,7 @@ class AnimateWindowManager : public SubsystemInterface
 {
 public:
 	AnimateWindowManager();
-	~AnimateWindowManager() override;
+	virtual ~AnimateWindowManager() override;
 
 	// Inhertited from subsystem ====================================================================
 	virtual void init() override;

--- a/Generals/Code/GameEngine/Include/GameClient/AnimateWindowManager.h
+++ b/Generals/Code/GameEngine/Include/GameClient/AnimateWindowManager.h
@@ -163,12 +163,12 @@ class AnimateWindowManager : public SubsystemInterface
 {
 public:
 	AnimateWindowManager();
-	~AnimateWindowManager();
+	~AnimateWindowManager() override;
 
 	// Inhertited from subsystem ====================================================================
-	virtual void init();
-	virtual void reset();
-	virtual void update();
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override;
 	//===============================================================================================
 
 	void registerGameWindow(GameWindow *win, AnimTypes animType, Bool needsToFinish, UnsignedInt ms = 0, UnsignedInt delayMs = 0);			// Registers a new window to animate.

--- a/Generals/Code/GameEngine/Include/GameClient/CampaignManager.h
+++ b/Generals/Code/GameEngine/Include/GameClient/CampaignManager.h
@@ -115,9 +115,9 @@ public:
 	~CampaignManager();
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer ) { }
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess() { }
+	virtual void crc( Xfer *xfer ) override { }
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override { }
 
 	void init();
 	Campaign *getCurrentCampaign();		///< Returns a point to the current Campaign

--- a/Generals/Code/GameEngine/Include/GameClient/CommandXlat.h
+++ b/Generals/Code/GameEngine/Include/GameClient/CommandXlat.h
@@ -37,7 +37,7 @@ class CommandTranslator : public GameMessageTranslator
 public:
 
 	CommandTranslator();
-	~CommandTranslator();
+	virtual ~CommandTranslator() override;
 
 	enum CommandEvaluateType { DO_COMMAND, DO_HINT, EVALUATE_ONLY };
 
@@ -65,7 +65,7 @@ private:
 	GameMessage::Type issueFireWeaponCommand( const CommandButton *command, CommandEvaluateType commandType, Drawable *target, const Coord3D *pos );
 	GameMessage::Type issueCombatDropCommand( const CommandButton *command, CommandEvaluateType commandType, Drawable *target, const Coord3D *pos );
 
-	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg);
+	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg) override;
 };
 
 

--- a/Generals/Code/GameEngine/Include/GameClient/ControlBar.h
+++ b/Generals/Code/GameEngine/Include/GameClient/ControlBar.h
@@ -632,11 +632,11 @@ class ControlBar : public SubsystemInterface
 public:
 
 	ControlBar();
-	virtual ~ControlBar();
+	virtual ~ControlBar() override;
 
-	virtual void init();					///< from subsystem interface
-	virtual void reset();					///< from subsystem interface
-	virtual void update();				///< from subsystem interface
+	virtual void init() override;					///< from subsystem interface
+	virtual void reset() override;					///< from subsystem interface
+	virtual void update() override;				///< from subsystem interface
 
 	/// mark the UI as dirty so the context of everything is re-evaluated
 	void markUIDirty();

--- a/Generals/Code/GameEngine/Include/GameClient/DebugDisplay.h
+++ b/Generals/Code/GameEngine/Include/GameClient/DebugDisplay.h
@@ -110,18 +110,18 @@ class DebugDisplay : public DebugDisplayInterface
 	public:
 
 		DebugDisplay();
-		virtual ~DebugDisplay() {};
+		virtual ~DebugDisplay() override {};
 
-		virtual void	printf( const Char *format, ...);			///< Print formatted text at current cursor position
-		virtual void	setCursorPos( Int x, Int y );		///< Set new cursor position
-		virtual Int		getCursorXPos();					///< Get current X position of cursor
-		virtual Int		getCursorYPos();					///< Get current Y position of cursor
-		virtual Int		getWidth();								///< Get character width of display
-		virtual Int		getHeight();							///< Get character height of display
-		virtual void	setTextColor( Color color );		///< set text color
-		virtual void	setRightMargin( Int rightPos );	///< set right margin position
-		virtual void	setLeftMargin( Int leftPos );		///< set left margin position
-		virtual void	reset();									///< Reset back to default settings
+		virtual void	printf( const Char *format, ...) override;			///< Print formatted text at current cursor position
+		virtual void	setCursorPos( Int x, Int y ) override;		///< Set new cursor position
+		virtual Int		getCursorXPos() override;					///< Get current X position of cursor
+		virtual Int		getCursorYPos() override;					///< Get current Y position of cursor
+		virtual Int		getWidth() override;								///< Get character width of display
+		virtual Int		getHeight() override;							///< Get character height of display
+		virtual void	setTextColor( Color color ) override;		///< set text color
+		virtual void	setRightMargin( Int rightPos ) override;	///< set right margin position
+		virtual void	setLeftMargin( Int leftPos ) override;		///< set left margin position
+		virtual void	reset() override;									///< Reset back to default settings
 
 	protected:
 

--- a/Generals/Code/GameEngine/Include/GameClient/Display.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Display.h
@@ -64,11 +64,11 @@ public:
 	typedef void (DebugDisplayCallback)( DebugDisplayInterface *debugDisplay, void *userData, FILE *fp );
 
 	Display();
-	virtual ~Display();
+	virtual ~Display() override;
 
-	virtual void init() { };																///< Initialize
-	virtual void reset();																		///< Reset system
-	virtual void update();																	///< Update system
+	virtual void init() override { };																///< Initialize
+	virtual void reset() override;																		///< Reset system
+	virtual void update() override;																	///< Update system
 
 	//---------------------------------------------------------------------------------------
 	// Display attribute methods
@@ -114,7 +114,7 @@ public:
 	virtual	void enableClipping( Bool onoff ) = 0;
 
 	virtual void step() {}; ///< Do one fixed time step
-	virtual void draw();																		///< Redraw the entire display
+	virtual void draw() override;																		///< Redraw the entire display
 	virtual void setTimeOfDay( TimeOfDay tod ) = 0;								///< Set the time of day for this display
 	virtual void createLightPulse( const Coord3D *pos, const RGBColor *color, Real innerRadius,Real attenuationWidth,
 																 UnsignedInt increaseFrameTime, UnsignedInt decayFrameTime//, Bool donut = FALSE

--- a/Generals/Code/GameEngine/Include/GameClient/Drawable.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Drawable.h
@@ -178,9 +178,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 
@@ -562,15 +562,15 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 	void xferDrawableModules( Xfer *xfer );
 
 	void	startAmbientSound(BodyDamageType dt, TimeOfDay tod);
 
-	Drawable *asDrawableMeth() { return this; }
-	const Drawable *asDrawableMeth() const { return this; }
+	virtual Drawable *asDrawableMeth() override { return this; }
+	virtual const Drawable *asDrawableMeth() const override { return this; }
 
 	Module** getModuleList(ModuleType i)
 	{
@@ -608,7 +608,7 @@ protected:
 	void validatePos() const;
 #endif
 
-	virtual void reactToTransformChange(const Matrix3D* oldMtx, const Coord3D* oldPos, Real oldAngle);
+	virtual void reactToTransformChange(const Matrix3D* oldMtx, const Coord3D* oldPos, Real oldAngle) override;
 	void updateHiddenStatus();
 
 	void replaceModelConditionStateInDrawable();

--- a/Generals/Code/GameEngine/Include/GameClient/Drawable.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Drawable.h
@@ -517,10 +517,10 @@ public:
 
 	TerrainDecalType getTerrainDecalType() const { return m_terrainDecalType; }
 
-	void setDrawableOpacity( Real value ) { m_explicitOpacity = value; }	///< set alpha/opacity value used to override defaults when drawing.
+	virtual void setDrawableOpacity( Real value ) { m_explicitOpacity = value; }	///< set alpha/opacity value used to override defaults when drawing.
 
 	// note that this is not the 'get' inverse of setDrawableOpacity, since stealthing can also affect the effective opacity!
-	Real getEffectiveOpacity() const { return m_explicitOpacity * m_effectiveStealthOpacity; }		///< get alpha/opacity value used to override defaults when drawing.
+	virtual Real getEffectiveOpacity() const { return m_explicitOpacity * m_effectiveStealthOpacity; }		///< get alpha/opacity value used to override defaults when drawing.
 	void setEffectiveOpacity( Real pulseFactor, Real explicitOpacity = -1.0f );
 
 	// this is for the heatvision effect which operates completely independently of the stealth opacity effects. Draw() does the fading every frame.

--- a/Generals/Code/GameEngine/Include/GameClient/Drawable.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Drawable.h
@@ -517,10 +517,10 @@ public:
 
 	TerrainDecalType getTerrainDecalType() const { return m_terrainDecalType; }
 
-	virtual void setDrawableOpacity( Real value ) { m_explicitOpacity = value; }	///< set alpha/opacity value used to override defaults when drawing.
+	void setDrawableOpacity( Real value ) { m_explicitOpacity = value; }	///< set alpha/opacity value used to override defaults when drawing.
 
 	// note that this is not the 'get' inverse of setDrawableOpacity, since stealthing can also affect the effective opacity!
-	virtual Real getEffectiveOpacity() const { return m_explicitOpacity * m_effectiveStealthOpacity; }		///< get alpha/opacity value used to override defaults when drawing.
+	Real getEffectiveOpacity() const { return m_explicitOpacity * m_effectiveStealthOpacity; }		///< get alpha/opacity value used to override defaults when drawing.
 	void setEffectiveOpacity( Real pulseFactor, Real explicitOpacity = -1.0f );
 
 	// this is for the heatvision effect which operates completely independently of the stealth opacity effects. Draw() does the fading every frame.

--- a/Generals/Code/GameEngine/Include/GameClient/Eva.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Eva.h
@@ -141,12 +141,12 @@ class Eva : public SubsystemInterface
 
 	public:
 		Eva();
-		virtual ~Eva();
+		virtual ~Eva() override;
 
 	public:		// From SubsystemInterface
-		virtual void init();
-		virtual void reset();
-		virtual void update();
+		virtual void init() override;
+		virtual void reset() override;
+		virtual void update() override;
 
 		static EvaMessage nameToMessage(const AsciiString& name);
 		static AsciiString messageToName(EvaMessage message);

--- a/Generals/Code/GameEngine/Include/GameClient/GUICommandTranslator.h
+++ b/Generals/Code/GameEngine/Include/GameClient/GUICommandTranslator.h
@@ -42,7 +42,7 @@ class GUICommandTranslator : public GameMessageTranslator
 public:
 
 	GUICommandTranslator();
-	~GUICommandTranslator();
+	~GUICommandTranslator() override;
 
-	virtual GameMessageDisposition translateGameMessage( const GameMessage *msg );
+	virtual GameMessageDisposition translateGameMessage( const GameMessage *msg ) override;
 };

--- a/Generals/Code/GameEngine/Include/GameClient/GUICommandTranslator.h
+++ b/Generals/Code/GameEngine/Include/GameClient/GUICommandTranslator.h
@@ -42,7 +42,7 @@ class GUICommandTranslator : public GameMessageTranslator
 public:
 
 	GUICommandTranslator();
-	~GUICommandTranslator() override;
+	virtual ~GUICommandTranslator() override;
 
 	virtual GameMessageDisposition translateGameMessage( const GameMessage *msg ) override;
 };

--- a/Generals/Code/GameEngine/Include/GameClient/GameClient.h
+++ b/Generals/Code/GameEngine/Include/GameClient/GameClient.h
@@ -65,8 +65,8 @@ typedef DrawablePtrHash::iterator DrawablePtrHashIt;
 class GameClientMessageDispatcher : public GameMessageTranslator
 {
 public:
-	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg);
-	virtual ~GameClientMessageDispatcher() { }
+	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg) override;
+	virtual ~GameClientMessageDispatcher() override { }
 };
 
 
@@ -82,12 +82,12 @@ class GameClient : public SubsystemInterface,
 public:
 
 	GameClient();
-	virtual ~GameClient();
+	virtual ~GameClient() override;
 
 	// subsystem methods
-	virtual void init();																					///< Initialize resources
-	virtual void update();																				///< Updates the GUI, display, audio, etc
-	virtual void reset();																					///< reset system
+	virtual void init() override;																					///< Initialize resources
+	virtual void update() override;																				///< Updates the GUI, display, audio, etc
+	virtual void reset() override;																					///< reset system
 
 	virtual void setFrame( UnsignedInt frame ) { m_frame = frame; }			///< Set the GameClient's internal frame number
 	virtual void registerDrawable( Drawable *draw );										///< Given a drawable, register it with the GameClient and give it a unique ID
@@ -153,9 +153,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	// @todo Should there be a separate GameClient frame counter?
 	UnsignedInt m_frame;																				///< Simulation frame number from server

--- a/Generals/Code/GameEngine/Include/GameClient/GameWindowManager.h
+++ b/Generals/Code/GameEngine/Include/GameClient/GameWindowManager.h
@@ -77,12 +77,12 @@ friend class GameWindow;
 public:
 
 	GameWindowManager();
-	virtual ~GameWindowManager();
+	virtual ~GameWindowManager() override;
 
 	//-----------------------------------------------------------------------------------------------
-	virtual void init();		///< initialize function
-	virtual void reset();		///< reset the system
-	virtual void update();  ///< update method, called once per frame
+	virtual void init() override;		///< initialize function
+	virtual void reset() override;		///< reset the system
+	virtual void update() override;  ///< update method, called once per frame
 
 	virtual GameWindow *allocateNewWindow() = 0;  ///< new game window
 
@@ -384,31 +384,31 @@ extern WindowMsgHandledType PassMessagesToParentSystem( GameWindow *window,
 class GameWindowManagerDummy : public GameWindowManager
 {
 public:
-	virtual GameWindow *winGetWindowFromId(GameWindow *window, Int id);
-	virtual GameWindow *winCreateFromScript(AsciiString filenameString, WindowLayoutInfo *info);
+	virtual GameWindow *winGetWindowFromId(GameWindow *window, Int id) override;
+	virtual GameWindow *winCreateFromScript(AsciiString filenameString, WindowLayoutInfo *info) override;
 
-	virtual GameWindow *allocateNewWindow() { return newInstance(GameWindowDummy); }
+	virtual GameWindow *allocateNewWindow() override { return newInstance(GameWindowDummy); }
 
-	virtual GameWinDrawFunc getPushButtonImageDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getPushButtonDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getCheckBoxImageDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getCheckBoxDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getRadioButtonImageDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getRadioButtonDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getTabControlImageDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getTabControlDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getListBoxImageDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getListBoxDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getComboBoxImageDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getComboBoxDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getHorizontalSliderImageDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getHorizontalSliderDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getVerticalSliderImageDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getVerticalSliderDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getProgressBarImageDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getProgressBarDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getStaticTextImageDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getStaticTextDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getTextEntryImageDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getTextEntryDrawFunc() { return nullptr; }
+	virtual GameWinDrawFunc getPushButtonImageDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getPushButtonDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getCheckBoxImageDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getCheckBoxDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getRadioButtonImageDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getRadioButtonDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getTabControlImageDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getTabControlDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getListBoxImageDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getListBoxDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getComboBoxImageDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getComboBoxDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getHorizontalSliderImageDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getHorizontalSliderDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getVerticalSliderImageDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getVerticalSliderDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getProgressBarImageDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getProgressBarDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getStaticTextImageDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getStaticTextDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getTextEntryImageDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getTextEntryDrawFunc() override { return nullptr; }
 };

--- a/Generals/Code/GameEngine/Include/GameClient/HintSpy.h
+++ b/Generals/Code/GameEngine/Include/GameClient/HintSpy.h
@@ -33,6 +33,6 @@
 class HintSpyTranslator : public GameMessageTranslator
 {
 public:
-	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg);
-	virtual ~HintSpyTranslator() { }
+	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg) override;
+	virtual ~HintSpyTranslator() override { }
 };

--- a/Generals/Code/GameEngine/Include/GameClient/HotKey.h
+++ b/Generals/Code/GameEngine/Include/GameClient/HotKey.h
@@ -85,7 +85,7 @@ class HotKeyManager : public SubsystemInterface
 {
 public:
 	HotKeyManager();
-	~HotKeyManager() override;
+	virtual ~HotKeyManager() override;
 	// Inherited from subsystem interface -----------------------------------------------------------
 	virtual	void init() override;															///< Initialize the Hotkey system
 	virtual void update() override {}														///< A No-op for us

--- a/Generals/Code/GameEngine/Include/GameClient/HotKey.h
+++ b/Generals/Code/GameEngine/Include/GameClient/HotKey.h
@@ -66,8 +66,8 @@ class GameWindow;
 class HotKeyTranslator : public GameMessageTranslator
 {
 public:
-	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg);
-	virtual ~HotKeyTranslator() { }
+	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg) override;
+	virtual ~HotKeyTranslator() override { }
 };
 
 //-----------------------------------------------------------------------------
@@ -85,11 +85,11 @@ class HotKeyManager : public SubsystemInterface
 {
 public:
 	HotKeyManager();
-	~HotKeyManager();
+	~HotKeyManager() override;
 	// Inherited from subsystem interface -----------------------------------------------------------
-	virtual	void init();															///< Initialize the Hotkey system
-	virtual void update() {}														///< A No-op for us
-	virtual void reset();															///< Reset
+	virtual	void init() override;															///< Initialize the Hotkey system
+	virtual void update() override {}														///< A No-op for us
+	virtual void reset() override;															///< Reset
 	//-----------------------------------------------------------------------------------------------
 
 	void addHotKey( GameWindow *win, const AsciiString& key);

--- a/Generals/Code/GameEngine/Include/GameClient/Image.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Image.h
@@ -121,11 +121,11 @@ class ImageCollection : public SubsystemInterface
 public:
 
 	ImageCollection();
-	virtual ~ImageCollection();
+	virtual ~ImageCollection() override;
 
-	virtual void init() { };				///< initialize system
-	virtual void reset() { };				///< reset system
-	virtual void update() { };			///< update system
+	virtual void init() override { };				///< initialize system
+	virtual void reset() override { };				///< reset system
+	virtual void update() override { };			///< update system
 
 	void load( Int textureSize );												 ///< load images
 

--- a/Generals/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/Generals/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -455,7 +455,7 @@ public:  // ********************************************************************
 	virtual void disregardDrawable( Drawable *draw );				///< Drawable is being destroyed, clean up any UI elements associated with it
 
 	virtual void preDraw();														///< Logic which needs to occur before the UI renders
-	virtual void draw() override = 0;													///< Render the in-game user interface
+	virtual void draw() = 0;													///< Render the in-game user interface
 	virtual void postDraw();													///< Logic which needs to occur after the UI renders
 	virtual void postWindowDraw();											///< Logic which needs to occur after the WindowManager has repainted the menus
 

--- a/Generals/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/Generals/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -347,12 +347,12 @@ public:  // ********************************************************************
 	};
 
 	InGameUI();
-	virtual ~InGameUI();
+	virtual ~InGameUI() override;
 
 	// Inherited from subsystem interface -----------------------------------------------------------
-	virtual	void init();															///< Initialize the in-game user interface
-	virtual void update();														///< Update the UI by calling preDraw(), draw(), and postDraw()
-	virtual void reset();															///< Reset
+	virtual	void init() override;															///< Initialize the in-game user interface
+	virtual void update() override;														///< Update the UI by calling preDraw(), draw(), and postDraw()
+	virtual void reset() override;															///< Reset
 	//-----------------------------------------------------------------------------------------------
 
 	// interface for the popup messages
@@ -455,7 +455,7 @@ public:  // ********************************************************************
 	virtual void disregardDrawable( Drawable *draw );				///< Drawable is being destroyed, clean up any UI elements associated with it
 
 	virtual void preDraw();														///< Logic which needs to occur before the UI renders
-	virtual void draw() = 0;													///< Render the in-game user interface
+	virtual void draw() override = 0;													///< Render the in-game user interface
 	virtual void postDraw();													///< Logic which needs to occur after the UI renders
 	virtual void postWindowDraw();											///< Logic which needs to occur after the WindowManager has repainted the menus
 
@@ -600,9 +600,9 @@ public:
 
 protected:
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameClient/LookAtXlat.h
+++ b/Generals/Code/GameEngine/Include/GameClient/LookAtXlat.h
@@ -46,9 +46,9 @@ class LookAtTranslator : public GameMessageTranslator
 {
 public:
 	LookAtTranslator();
-	~LookAtTranslator();
+	virtual ~LookAtTranslator() override;
 
-	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg);
+	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg) override;
 	virtual const ICoord2D* getRMBScrollAnchor(); // get m_anchor ICoord2D if we're RMB scrolling
 	Bool hasMouseMovedRecently();
 	void setCurrentPos( const ICoord2D& pos );

--- a/Generals/Code/GameEngine/Include/GameClient/MetaEvent.h
+++ b/Generals/Code/GameEngine/Include/GameClient/MetaEvent.h
@@ -364,8 +364,8 @@ private:
 
 public:
 	MetaEventTranslator();
-	~MetaEventTranslator();
-	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg);
+	virtual ~MetaEventTranslator() override;
+	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg) override;
 };
 
 //-----------------------------------------------------------------------------
@@ -383,11 +383,11 @@ protected:
 public:
 
 	MetaMap();
-	~MetaMap();
+	virtual ~MetaMap() override;
 
-	void init() { }
-	void reset() { }
-	void update() { }
+	virtual void init() override { }
+	virtual void reset() override { }
+	virtual void update() override { }
 
 	static void parseMetaMap(INI* ini);
 

--- a/Generals/Code/GameEngine/Include/GameClient/Module/AnimatedParticleSysBoneClientUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Module/AnimatedParticleSysBoneClientUpdate.h
@@ -47,7 +47,7 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	/// the client update callback
-	virtual void clientUpdate();
+	virtual void clientUpdate() override;
 
 
 protected:

--- a/Generals/Code/GameEngine/Include/GameClient/Module/BeaconClientUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Module/BeaconClientUpdate.h
@@ -44,7 +44,7 @@ public:
 	UnsignedInt m_radarPulseDuration;
 
 	BeaconClientUpdateModuleData();
-	~BeaconClientUpdateModuleData();
+	virtual ~BeaconClientUpdateModuleData() override;
 	static void buildFieldParse(MultiIniFieldParse& p);
 };
 
@@ -63,7 +63,7 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	/// the client update callback
-	virtual void clientUpdate();
+	virtual void clientUpdate() override;
 	void hideBeacon();
 
 protected:

--- a/Generals/Code/GameEngine/Include/GameClient/Module/SwayClientUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Module/SwayClientUpdate.h
@@ -50,7 +50,7 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	/// the client update callback
-	virtual void clientUpdate();
+	virtual void clientUpdate() override;
 
 	void stopSway() { m_swaying = false; }
 

--- a/Generals/Code/GameEngine/Include/GameClient/PlaceEventTranslator.h
+++ b/Generals/Code/GameEngine/Include/GameClient/PlaceEventTranslator.h
@@ -37,6 +37,6 @@ private:
 
 public:
 	PlaceEventTranslator();
-	~PlaceEventTranslator();
-	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg);
+	virtual ~PlaceEventTranslator() override;
+	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg) override;
 };

--- a/Generals/Code/GameEngine/Include/GameClient/RayEffect.h
+++ b/Generals/Code/GameEngine/Include/GameClient/RayEffect.h
@@ -57,7 +57,7 @@ class RayEffectSystem : public SubsystemInterface
 public:
 
 	RayEffectSystem();
-	~RayEffectSystem() override;
+	virtual ~RayEffectSystem() override;
 
 	virtual void init() override;
 	virtual void reset() override;

--- a/Generals/Code/GameEngine/Include/GameClient/RayEffect.h
+++ b/Generals/Code/GameEngine/Include/GameClient/RayEffect.h
@@ -57,11 +57,11 @@ class RayEffectSystem : public SubsystemInterface
 public:
 
 	RayEffectSystem();
-	~RayEffectSystem();
+	~RayEffectSystem() override;
 
-	virtual void init();
-	virtual void reset();
-	virtual void update() { }
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override { }
 
 	/// add a ray effect entry for this drawable
 	void addRayEffect( const Drawable *draw, const Coord3D *startLoc, const Coord3D *endLoc );

--- a/Generals/Code/GameEngine/Include/GameClient/SelectionXlat.h
+++ b/Generals/Code/GameEngine/Include/GameClient/SelectionXlat.h
@@ -60,8 +60,8 @@ private:
 
 public:
 	SelectionTranslator();
-	~SelectionTranslator();
-	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg);
+	virtual ~SelectionTranslator() override;
+	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg) override;
 	//added for fix to the drag selection when entering control bar
 	//changes the mode of drag selecting to it's opposite
 	void setDragSelecting(Bool dragSelect);

--- a/Generals/Code/GameEngine/Include/GameClient/Shell.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Shell.h
@@ -114,12 +114,12 @@ class Shell : public SubsystemInterface
 public:
 
 	Shell();
-	~Shell();
+	~Shell() override;
 
 	// Inhertited from subsystem ====================================================================
-	virtual void init();
-	virtual void reset();
-	virtual void update();
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override;
 	//===============================================================================================
 
 	void recreateWindowLayouts();

--- a/Generals/Code/GameEngine/Include/GameClient/Shell.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Shell.h
@@ -114,7 +114,7 @@ class Shell : public SubsystemInterface
 public:
 
 	Shell();
-	~Shell() override;
+	virtual ~Shell() override;
 
 	// Inhertited from subsystem ====================================================================
 	virtual void init() override;

--- a/Generals/Code/GameEngine/Include/GameClient/WindowXlat.h
+++ b/Generals/Code/GameEngine/Include/GameClient/WindowXlat.h
@@ -36,6 +36,6 @@ private:
 	// nothing
 public:
 	WindowTranslator();
-	~WindowTranslator();
-	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg);
+	virtual ~WindowTranslator() override;
+	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg) override;
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/AI.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AI.h
@@ -147,9 +147,9 @@ public:
 	void addFactionBuildList(AISideBuildList *buildList);
 
 	// --------------- inherited from Snapshot interface --------------
-	void crc( Xfer *xfer );
-	void xfer( Xfer *xfer );
-	void loadPostProcess();
+	void crc( Xfer *xfer ) override;
+	void xfer( Xfer *xfer ) override;
+	void loadPostProcess() override;
 
 	Real m_structureSeconds;		// Try to build a structure every N seconds.
 	Real m_teamSeconds;					// Try to build a team every N seconds.
@@ -241,11 +241,11 @@ class AI : public SubsystemInterface, public Snapshot
 {
 public:
 	AI();
-	~AI();
+	~AI() override;
 
-	virtual void init();						///< initialize AI to default values
-	virtual void reset();						///< reset the AI system to prepare for a new map
-	virtual void update();					///< do one frame of AI computation
+	virtual void init() override;						///< initialize AI to default values
+	virtual void reset() override;						///< reset the AI system to prepare for a new map
+	virtual void update() override;					///< do one frame of AI computation
 
 	Pathfinder *pathfinder() { return m_pathfinder; }	///< public access to the pathfind system
 	enum
@@ -265,9 +265,9 @@ public:
 	Object *findClosestAlly( const Object *me, Real range, UnsignedInt qualifiers);
 
 	// --------------- inherited from Snapshot interface --------------
-	void crc( Xfer *xfer );
-	void xfer( Xfer *xfer );
-	void loadPostProcess();
+	void crc( Xfer *xfer ) override;
+	void xfer( Xfer *xfer ) override;
+	void loadPostProcess() override;
 
 	// AI Groups -----------------------------------------------------------------------------------------------
 	AIGroupPtr createGroup(); ///< instantiate a new AI Group
@@ -854,9 +854,9 @@ private:
 public:
 
 	// --------------- inherited from Snapshot interface --------------
-	void crc( Xfer *xfer );
-	void xfer( Xfer *xfer );
-	void loadPostProcess();
+	void crc( Xfer *xfer ) override;
+	void xfer( Xfer *xfer ) override;
+	void loadPostProcess() override;
 
 #if !RETAIL_COMPATIBLE_AIGROUP
 	void Add_Ref() const { m_refCount.Add_Ref(); }

--- a/Generals/Code/GameEngine/Include/GameLogic/AI.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AI.h
@@ -147,9 +147,9 @@ public:
 	void addFactionBuildList(AISideBuildList *buildList);
 
 	// --------------- inherited from Snapshot interface --------------
-	void crc( Xfer *xfer ) override;
-	void xfer( Xfer *xfer ) override;
-	void loadPostProcess() override;
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	Real m_structureSeconds;		// Try to build a structure every N seconds.
 	Real m_teamSeconds;					// Try to build a team every N seconds.
@@ -241,7 +241,7 @@ class AI : public SubsystemInterface, public Snapshot
 {
 public:
 	AI();
-	~AI() override;
+	virtual ~AI() override;
 
 	virtual void init() override;						///< initialize AI to default values
 	virtual void reset() override;						///< reset the AI system to prepare for a new map
@@ -265,9 +265,9 @@ public:
 	Object *findClosestAlly( const Object *me, Real range, UnsignedInt qualifiers);
 
 	// --------------- inherited from Snapshot interface --------------
-	void crc( Xfer *xfer ) override;
-	void xfer( Xfer *xfer ) override;
-	void loadPostProcess() override;
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	// AI Groups -----------------------------------------------------------------------------------------------
 	AIGroupPtr createGroup(); ///< instantiate a new AI Group
@@ -854,9 +854,9 @@ private:
 public:
 
 	// --------------- inherited from Snapshot interface --------------
-	void crc( Xfer *xfer ) override;
-	void xfer( Xfer *xfer ) override;
-	void loadPostProcess() override;
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 #if !RETAIL_COMPATIBLE_AIGROUP
 	void Add_Ref() const { m_refCount.Add_Ref(); }

--- a/Generals/Code/GameEngine/Include/GameLogic/AIDock.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AIDock.h
@@ -62,15 +62,15 @@ public:
 	AIDockMachine( Object *owner );
 
 	static Bool ableToAdvance( State *thisState, void* userData ); // Condition for scooting forward in line while waiting
-	virtual void halt(); ///< Stops the state machine & disables it in preparation for deleting it.
+	virtual void halt() override; ///< Stops the state machine & disables it in preparation for deleting it.
 
 	Int m_approachPosition;	///< The Approach Position I am holding, to make scoot forward checks quicker.
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 };
 
@@ -82,14 +82,14 @@ class AIDockApproachState : public AIInternalMoveToState
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIDockApproachState, "AIDockApproachState")
 public:
 	AIDockApproachState( StateMachine *machine ) : AIInternalMoveToState( machine, "AIDockApproachState" ) { }
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override{};
 };
 EMPTY_DTOR(AIDockApproachState)
 
@@ -99,16 +99,16 @@ class AIDockWaitForClearanceState : public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIDockWaitForClearanceState, "AIDockWaitForClearanceState")
 public:
 	AIDockWaitForClearanceState( StateMachine *machine ) : State( machine, "AIDockWaitForClearanceState" ), m_enterFrame(0) { }
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
 	UnsignedInt m_enterFrame;
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override{};
 };
 EMPTY_DTOR(AIDockWaitForClearanceState)
 
@@ -118,9 +118,9 @@ class AIDockAdvancePositionState : public AIInternalMoveToState
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIDockAdvancePositionState, "AIDockAdvancePositionState")
 public:
 	AIDockAdvancePositionState( StateMachine *machine ) : AIInternalMoveToState( machine, "AIDockApproachState" ) { }
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 };
 EMPTY_DTOR(AIDockAdvancePositionState)
 
@@ -130,9 +130,9 @@ class AIDockMoveToEntryState : public AIInternalMoveToState
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIDockMoveToEntryState, "AIDockMoveToEntryState")
 public:
 	AIDockMoveToEntryState( StateMachine *machine ) : AIInternalMoveToState( machine, "AIDockMoveToEntryState" ) { }
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 };
 EMPTY_DTOR(AIDockMoveToEntryState)
 
@@ -142,9 +142,9 @@ class AIDockMoveToDockState : public AIInternalMoveToState
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIDockMoveToDockState, "AIDockMoveToDockState")
 public:
 	AIDockMoveToDockState( StateMachine *machine ) : AIInternalMoveToState( machine, "AIDockMoveToDockState" ) { }
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 };
 EMPTY_DTOR(AIDockMoveToDockState)
 
@@ -154,9 +154,9 @@ class AIDockMoveToRallyState : public AIInternalMoveToState
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIDockMoveToRallyState, "AIDockMoveToRallyState")
 public:
 	AIDockMoveToRallyState( StateMachine *machine ) : AIInternalMoveToState( machine, "AIDockMoveToRallyState" ) { }
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 };
 EMPTY_DTOR(AIDockMoveToRallyState)
 
@@ -166,9 +166,9 @@ class AIDockProcessDockState : public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIDockProcessDockState, "AIDockProcessDockState")
 public:
 	AIDockProcessDockState( StateMachine *machine );
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 
 	void setNextDockActionFrame();//This puts a delay between callings of Action to tweak the speed of docking.
 	UnsignedInt m_nextDockActionFrame;// In the unlikely event of saving a game in the middle of docking, you may
@@ -177,9 +177,9 @@ public:
 
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override{};
 
 private:
 	ObjectID m_droneID;			///< If I have a drone, the drone will get repaired too.
@@ -193,9 +193,9 @@ class AIDockMoveToExitState : public AIInternalMoveToState
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIDockMoveToExitState, "AIDockMoveToExitState")
 public:
 	AIDockMoveToExitState( StateMachine *machine ) : AIInternalMoveToState( machine, "AIDockMoveToExitState" ) { }
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 };
 EMPTY_DTOR(AIDockMoveToExitState)
 

--- a/Generals/Code/GameEngine/Include/GameLogic/AIDock.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AIDock.h
@@ -87,9 +87,9 @@ public:
 	virtual StateReturnType update() override;
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ) override{};
+	virtual void crc( Xfer *xfer ) override {};
 	virtual void xfer( Xfer *xfer ) override;
-	virtual void loadPostProcess() override{};
+	virtual void loadPostProcess() override {};
 };
 EMPTY_DTOR(AIDockApproachState)
 
@@ -106,9 +106,9 @@ protected:
 	UnsignedInt m_enterFrame;
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ) override{};
+	virtual void crc( Xfer *xfer ) override {};
 	virtual void xfer( Xfer *xfer ) override;
-	virtual void loadPostProcess() override{};
+	virtual void loadPostProcess() override {};
 };
 EMPTY_DTOR(AIDockWaitForClearanceState)
 
@@ -177,9 +177,9 @@ public:
 
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ) override{};
-	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess() override{};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 
 private:
 	ObjectID m_droneID;			///< If I have a drone, the drone will get repaired too.

--- a/Generals/Code/GameEngine/Include/GameLogic/AIGuard.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AIGuard.h
@@ -81,7 +81,7 @@ public:
 		m_center.zero();
 	}
 
-	virtual Bool shouldExit(const StateMachine* machine) const;
+	virtual Bool shouldExit(const StateMachine* machine) const override;
 };
 
 
@@ -101,9 +101,9 @@ private:
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 public:
 	/**
@@ -140,14 +140,14 @@ public:
 	{
 		m_attackState = nullptr;
 	}
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 private:
 	AIGuardMachine* getGuardMachine() { return (AIGuardMachine*)getMachine(); }
 
@@ -161,14 +161,14 @@ class AIGuardIdleState : public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIGuardIdleState, "AIGuardIdleState")
 public:
 	AIGuardIdleState( StateMachine *machine ) : State( machine, "AIGuardIdleState" ) { }
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 private:
 	AIGuardMachine* getGuardMachine() { return (AIGuardMachine*)getMachine(); }
 
@@ -186,14 +186,14 @@ public:
 	{
 		m_attackState = nullptr;
 	}
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 private:
 	AIGuardMachine* getGuardMachine() { return (AIGuardMachine*)getMachine(); }
 
@@ -212,14 +212,14 @@ public:
 	{
 		m_nextReturnScanTime = 0;
 	}
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 private:
 	UnsignedInt m_nextReturnScanTime;
 };
@@ -232,9 +232,9 @@ class AIGuardPickUpCrateState : public AIPickUpCrateState
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIGuardPickUpCrateState, "AIGuardPickUpCrateState")
 public:
 	AIGuardPickUpCrateState( StateMachine *machine );
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 };
 EMPTY_DTOR(AIGuardPickUpCrateState)
 
@@ -244,14 +244,14 @@ class AIGuardAttackAggressorState : public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIGuardAttackAggressorState, "AIGuardAttackAggressorState")
 public:
 	AIGuardAttackAggressorState( StateMachine *machine );
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 private:
 	AIGuardMachine* getGuardMachine() { return (AIGuardMachine*)getMachine(); }
 	ExitConditions m_exitConditions;

--- a/Generals/Code/GameEngine/Include/GameLogic/AIPlayer.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AIPlayer.h
@@ -68,9 +68,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 };
 
@@ -99,9 +99,9 @@ private:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 public:
 
@@ -209,9 +209,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	virtual void doBaseBuilding();
 	virtual void checkReadyTeams();

--- a/Generals/Code/GameEngine/Include/GameLogic/AISkirmishPlayer.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AISkirmishPlayer.h
@@ -45,56 +45,56 @@ class AISkirmishPlayer : public AIPlayer
 public:	 // AISkirmish specific methods.
 
 	AISkirmishPlayer( Player *p );							///< constructor
-	virtual void computeSuperweaponTarget(const SpecialPowerTemplate *power, Coord3D *pos, Int playerNdx, Real weaponRadius); ///< Calculates best pos for weapon given radius.
+	virtual void computeSuperweaponTarget(const SpecialPowerTemplate *power, Coord3D *pos, Int playerNdx, Real weaponRadius) override; ///< Calculates best pos for weapon given radius.
 
 public:	// AIPlayer interface methods.
 
-	virtual void update();											///< simulates the behavior of a player
+	virtual void update() override;											///< simulates the behavior of a player
 
-	virtual void newMap();											///< New map loaded call.
+	virtual void newMap() override;											///< New map loaded call.
 
 	/// Invoked when a unit I am training comes into existence
-	virtual void onUnitProduced( Object *factory, Object *unit );
+	virtual void onUnitProduced( Object *factory, Object *unit ) override;
 
-	virtual void buildSpecificAITeam(TeamPrototype *teamProto, Bool priorityBuild); ///< Builds this team immediately.
+	virtual void buildSpecificAITeam(TeamPrototype *teamProto, Bool priorityBuild) override; ///< Builds this team immediately.
 
-	virtual void buildSpecificAIBuilding(const AsciiString &thingName); ///< Builds this building as soon as possible.
+	virtual void buildSpecificAIBuilding(const AsciiString &thingName) override; ///< Builds this building as soon as possible.
 
-	virtual void buildAIBaseDefense(Bool flank); ///< Builds base defense on front or flank of base.
+	virtual void buildAIBaseDefense(Bool flank) override; ///< Builds base defense on front or flank of base.
 
-	virtual void buildAIBaseDefenseStructure(const AsciiString &thingName, Bool flank); ///< Builds base defense on front or flank of base.
+	virtual void buildAIBaseDefenseStructure(const AsciiString &thingName, Bool flank) override; ///< Builds base defense on front or flank of base.
 
-	virtual void recruitSpecificAITeam(TeamPrototype *teamProto, Real recruitRadius); ///< Builds this team immediately.
+	virtual void recruitSpecificAITeam(TeamPrototype *teamProto, Real recruitRadius) override; ///< Builds this team immediately.
 
-	virtual Bool isSkirmishAI() {return true;}
+	virtual Bool isSkirmishAI() override {return true;}
 
-	virtual Bool checkBridges(Object *unit, Waypoint *way);
+	virtual Bool checkBridges(Object *unit, Waypoint *way) override;
 
-	virtual Player *getAiEnemy();	///< Solo AI attacks based on scripting.  Only skirmish auto-acquires an enemy at this point.  jba.
+	virtual Player *getAiEnemy() override;	///< Solo AI attacks based on scripting.  Only skirmish auto-acquires an enemy at this point.  jba.
 
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
-	virtual void doBaseBuilding();
-	virtual void checkReadyTeams();
-	virtual void checkQueuedTeams();
-	virtual void doTeamBuilding();
-	virtual Object *findDozer(const Coord3D *pos);
-	virtual void queueDozer();
+	virtual void doBaseBuilding() override;
+	virtual void checkReadyTeams() override;
+	virtual void checkQueuedTeams() override;
+	virtual void doTeamBuilding() override;
+	virtual Object *findDozer(const Coord3D *pos) override;
+	virtual void queueDozer() override;
 
 protected:
 
-	virtual Bool selectTeamToBuild();			///< determine the next team to build
-	virtual Bool selectTeamToReinforce( Int minPriority );			///< determine the next team to reinforce
-	virtual Bool startTraining( WorkOrder *order, Bool busyOK, AsciiString teamName);	///< find a production building that can handle the order, and start building
+	virtual Bool selectTeamToBuild() override;			///< determine the next team to build
+	virtual Bool selectTeamToReinforce( Int minPriority ) override;			///< determine the next team to reinforce
+	virtual Bool startTraining( WorkOrder *order, Bool busyOK, AsciiString teamName) override;	///< find a production building that can handle the order, and start building
 
-	virtual Bool isAGoodIdeaToBuildTeam( TeamPrototype *proto );		///< return true if team should be built
-	virtual void processBaseBuilding();		///< do base-building behaviors
-	virtual void processTeamBuilding();		///< do team-building behaviors
+	virtual Bool isAGoodIdeaToBuildTeam( TeamPrototype *proto ) override;		///< return true if team should be built
+	virtual void processBaseBuilding() override;		///< do base-building behaviors
+	virtual void processTeamBuilding() override;		///< do team-building behaviors
 
 protected:
 	void adjustBuildList(BuildListInfo *list);

--- a/Generals/Code/GameEngine/Include/GameLogic/AIStateMachine.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AIStateMachine.h
@@ -342,9 +342,9 @@ public:
 	virtual Bool isBusy() const override { return true; }
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ) override{};
-	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess() override{};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 
 };
 EMPTY_DTOR(AIBusyState)
@@ -916,9 +916,9 @@ public:
 	virtual StateReturnType update() override;
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ) override{};
-	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess() override{};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 };
 EMPTY_DTOR(AIWaitState)
 
@@ -948,9 +948,9 @@ public:
 	virtual StateReturnType onEnter() override;
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ) override{};
-	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess() override{};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 private:
 	NotifyWeaponFiredInterface *const m_att;		// this is NOT owned by us and should not be freed
 };
@@ -1047,9 +1047,9 @@ public:
 	virtual void onExit( StateExitType status ) override;
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ) override{};
-	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess() override{};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 };
 EMPTY_DTOR(AIDeadState)
 

--- a/Generals/Code/GameEngine/Include/GameLogic/AIStateMachine.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AIStateMachine.h
@@ -133,9 +133,9 @@ public:
 	 */
 	AIStateMachine( Object *owner, AsciiString name );
 
-	virtual void clear();
-	virtual StateReturnType resetToDefaultState();
-	virtual StateReturnType setState( StateID newStateID );
+	virtual void clear() override;
+	virtual StateReturnType resetToDefaultState() override;
+	virtual StateReturnType setState( StateID newStateID ) override;
 
 	/// @todo Rethink state parameter passing. Continuing in this fashion will have a pile of params in the machine (MSB)
 	void setGoalPath( std::vector<Coord3D>* path );
@@ -158,16 +158,16 @@ public:
 	StateID getTemporaryState() const {return m_temporaryState?m_temporaryState->getID():INVALID_STATE_ID;}
 
 public:	// overrides.
-	virtual StateReturnType updateStateMachine();				///< run one step of the machine
+	virtual StateReturnType updateStateMachine() override;				///< run one step of the machine
 #ifdef STATE_MACHINE_DEBUG
 	virtual AsciiString getCurrentStateName() const ;
 #endif
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	std::vector<Coord3D>	m_goalPath;					///< defines a simple path to follow
@@ -199,9 +199,9 @@ enum StateType CPP_11(: Int)
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 };
 
 //-----------------------------------------------------------------------------------------------------------
@@ -222,16 +222,16 @@ public:
 		LOOK_FOR_TARGETS,
 		DO_NOT_LOOK_FOR_TARGETS
 	};
-	virtual Bool isIdle() const { return true; }
+	virtual Bool isIdle() const override { return true; }
 	AIIdleState( StateMachine *machine, AIIdleTargetingType shouldLookForTargets);
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 };
 EMPTY_DTOR(AIIdleState)
@@ -255,9 +255,9 @@ public:
 		m_goalLayer = LAYER_INVALID;
 	}
 
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 
 protected:
 
@@ -280,9 +280,9 @@ private:
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	enum { MIN_REPATH_TIME = 10 };										///< minimum # of frames must elapse before re-pathing
@@ -315,15 +315,15 @@ protected:
 	Bool m_targetIsBldg;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 public:
 	AIRappelState( StateMachine *machine );
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 };
 EMPTY_DTOR(AIRappelState)
 
@@ -336,15 +336,15 @@ class AIBusyState : public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIBusyState, "AIBusyState")
 public:
 	AIBusyState( StateMachine *machine ) : State( machine, "AIBusyState" ) { }
-	virtual StateReturnType onEnter() { return STATE_CONTINUE; }
-	virtual void onExit( StateExitType status ) { }
-	virtual StateReturnType update() { return STATE_CONTINUE; }
-	virtual Bool isBusy() const { return true; }
+	virtual StateReturnType onEnter() override { return STATE_CONTINUE; }
+	virtual void onExit( StateExitType status ) override { }
+	virtual StateReturnType update() override { return STATE_CONTINUE; }
+	virtual Bool isBusy() const override { return true; }
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override{};
 
 };
 EMPTY_DTOR(AIBusyState)
@@ -360,9 +360,9 @@ protected:
 	Bool m_isMoveTo;
 public:
 	AIMoveToState( StateMachine *machine );
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 };
 EMPTY_DTOR(AIMoveToState)
 
@@ -375,11 +375,11 @@ class AIMoveOutOfTheWayState : public AIInternalMoveToState
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIMoveOutOfTheWayState, "AIMoveOutOfTheWayState")
 public:
 	AIMoveOutOfTheWayState( StateMachine *machine ) : AIInternalMoveToState( machine, "AIMoveOutOfTheWayState" ) { }
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 protected:
-	virtual Bool computePath();												///< compute the path
+	virtual Bool computePath() override;												///< compute the path
 
 };
 EMPTY_DTOR(AIMoveOutOfTheWayState)
@@ -402,17 +402,17 @@ public:
 		m_checkForPath = false;
 		m_okToRepathTimes = 0;
 	}
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
 protected:
-	virtual Bool computePath();												///< compute the path
+	virtual Bool computePath() override;												///< compute the path
 	Int m_okToRepathTimes;
 	Bool m_checkForPath;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 };
 EMPTY_DTOR(AIMoveAndTightenState)
 
@@ -425,11 +425,11 @@ class AIMoveAwayFromRepulsorsState : public AIMoveAndTightenState
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIMoveAwayFromRepulsorsState, "AIMoveAwayFromRepulsorsState")
 public:
 	AIMoveAwayFromRepulsorsState( StateMachine *machine ) : AIMoveAndTightenState( machine, "AIMoveAwayFromRepulsors" ) { }
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
-	virtual Bool computePath();												///< compute the path
+	virtual Bool computePath() override;												///< compute the path
 
 };
 EMPTY_DTOR(AIMoveAwayFromRepulsorsState)
@@ -452,17 +452,17 @@ public:
 		// we're setting m_isInitialApproach to true in the constructor because we want the first pass
 		// through this state to allow a unit to attack incidental targets (if it is turreted)
 	}
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 protected:
-	virtual Bool computePath();												///< compute the path
+	virtual Bool computePath() override;												///< compute the path
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 
@@ -500,17 +500,17 @@ public:
 		// we're setting m_isInitialApproach to true in the constructor because we want the first pass
 		// through this state to allow a unit to attack incidental targets (if it is turreted)
 	}
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 protected:
-	virtual Bool computePath();												///< compute the path
+	virtual Bool computePath() override;												///< compute the path
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 
@@ -542,19 +542,19 @@ public:
 		// we're setting m_isInitialApproach to true in the constructor because we want the first pass
 		// through this state to allow a unit to attack incidental targets (if it is turreted)
 	}
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 protected:
-	virtual Bool computePath();												///< compute the path
+	virtual Bool computePath() override;												///< compute the path
 
 private:
 	Int			m_delayCounter;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 };
 EMPTY_DTOR(AIPickUpCrateState)
 
@@ -569,9 +569,9 @@ public:
 	AIAttackMoveToState( StateMachine *machine );
 	//virtual ~AIAttackMoveToState();
 
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 #ifdef STATE_MACHINE_DEBUG
 	virtual AsciiString getName() const ;
 #endif
@@ -585,9 +585,9 @@ protected:
 	Int						m_retryCount;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 };
 
 //-----------------------------------------------------------------------------------------------------------
@@ -609,15 +609,15 @@ public:
 	{
 		m_angle = 0.0f;
 	}
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 	Coord2D m_groupOffset;
@@ -651,15 +651,15 @@ public:
 	AIFollowWaypointPathExactState( StateMachine *machine, Bool asGroup ) : m_moveAsGroup(asGroup),
 		m_lastWaypoint(nullptr),
 		AIInternalMoveToState( machine, "AIFollowWaypointPathExactState" ) { }
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 	const Waypoint *m_lastWaypoint;
@@ -677,9 +677,9 @@ class AIAttackFollowWaypointPathState : public AIFollowWaypointPathState
 public:
 	AIAttackFollowWaypointPathState( StateMachine *machine, Bool asGroup );
 	//virtual ~AIAttackFollowWaypointPathState();
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 #ifdef STATE_MACHINE_DEBUG
 	virtual AsciiString getName() const ;
 #endif
@@ -689,9 +689,9 @@ protected:
 	StateMachine *m_attackFollowMachine;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 };
 
 //-----------------------------------------------------------------------------------------------------------
@@ -710,15 +710,15 @@ public:
 		m_timer = 0;
 		m_waitFrames = 0;
 	}
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 	Int		m_waitFrames;
@@ -740,15 +740,15 @@ public:
 		m_waitFrames = 0;
 		m_timer = 0;
 	}
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 	void computeWanderGoal();
@@ -772,14 +772,14 @@ public:
 		setName("AIPanicState");
 #endif
 	}
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 	Int		m_waitFrames;
@@ -802,9 +802,9 @@ public:
 		m_index(0),
 		m_retryCount(10),
 		AIInternalMoveToState( machine, name ) { }
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 
 protected:
 
@@ -814,9 +814,9 @@ protected:
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	Int m_index;																		///< current path index
@@ -838,14 +838,14 @@ public:
 	{
 		m_origin.zero();
 	}
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	Coord3D m_origin;													///< current position - set as goal on exit in case we follow with MoveToAndDelete.
@@ -864,14 +864,14 @@ public:
 	{
 		m_appendGoalPosition = FALSE;
 	}
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 	Bool m_appendGoalPosition;
@@ -891,14 +891,14 @@ public:
 		m_setLocomotor(false)
 	{
 	}
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 private:
 	const Bool m_isAttackingObject;
 	Bool m_canTurnInPlace;
@@ -913,12 +913,12 @@ class AIWaitState : public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIWaitState, "AIWaitState")
 public:
 	AIWaitState( StateMachine *machine ) : State( machine,"AIWaitState" ) { }
-	virtual StateReturnType update();
+	virtual StateReturnType update() override;
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override{};
 };
 EMPTY_DTOR(AIWaitState)
 
@@ -943,14 +943,14 @@ public:
 		m_att(att)
 	{
 	}
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType onEnter();
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType onEnter() override;
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override{};
 private:
 	NotifyWeaponFiredInterface *const m_att;		// this is NOT owned by us and should not be freed
 };
@@ -972,27 +972,27 @@ public:
 	AIAttackState( StateMachine *machine, Bool follow, Bool attackingObject, Bool forceAttacking, AttackExitConditionsInterface* attackParameters);
 	//~AIAttackState();
 
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 
-	virtual void notifyFired() { /* nothing */ }
-	virtual void notifyNewVictimChosen(Object* victim);
-	virtual const Coord3D* getOriginalVictimPos() const { return &m_originalVictimPos; }
-	virtual Bool isWeaponSlotOkToFire(WeaponSlotType wslot) const { return true; }
-	virtual Bool isAttackingObject() const { return m_isAttackingObject; }
+	virtual void notifyFired() override { /* nothing */ }
+	virtual void notifyNewVictimChosen(Object* victim) override;
+	virtual const Coord3D* getOriginalVictimPos() const override { return &m_originalVictimPos; }
+	virtual Bool isWeaponSlotOkToFire(WeaponSlotType wslot) const override { return true; }
+	virtual Bool isAttackingObject() const override { return m_isAttackingObject; }
 	virtual Bool isForceAttacking() const { return m_isForceAttacking; }
 #ifdef STATE_MACHINE_DEBUG
 	virtual AsciiString getName() const ;
 #endif
 
-	virtual Bool isAttack() const { return TRUE; }
+	virtual Bool isAttack() const override { return TRUE; }
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 
@@ -1017,9 +1017,9 @@ public:
 			State( machine , "AIAttackSquadState") {	}
 	//~AIAttackSquadState();
 
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 	Object *chooseVictim();
 #ifdef STATE_MACHINE_DEBUG
 	virtual AsciiString getName() const ;
@@ -1028,9 +1028,9 @@ public:
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	StateMachine *m_attackSquadMachine;						///< state sub-machine for attack behavior
@@ -1042,14 +1042,14 @@ class AIDeadState : public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIDeadState, "AIDeadState")
 public:
 	AIDeadState( StateMachine *machine ) : State( machine, "AIDeadState" ) { }
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override{};
 };
 EMPTY_DTOR(AIDeadState)
 
@@ -1060,18 +1060,18 @@ class AIDockState : public State
 public:
 	AIDockState( StateMachine *machine ) : State( machine, "AIDockState" ), m_dockMachine(nullptr), m_usingPrecisionMovement(FALSE) { }
 	//~AIDockState();
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 #ifdef STATE_MACHINE_DEBUG
 	virtual AsciiString getName() const ;
 #endif
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	StateMachine *m_dockMachine;				///< state sub-machine for docking behavior
@@ -1088,14 +1088,14 @@ protected:
 	ObjectID m_entryToClear;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 public:
 	AIEnterState( StateMachine *machine ) : AIInternalMoveToState( machine, "AIEnterState" ) { }
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 };
 EMPTY_DTOR(AIEnterState)
 
@@ -1107,14 +1107,14 @@ protected:
 	ObjectID m_entryToClear;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 public:
 	AIExitState( StateMachine *machine ) : State( machine, "AIExitState" ) { }
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 };
 EMPTY_DTOR(AIExitState)
 
@@ -1131,17 +1131,17 @@ public:
 		m_guardMachine = nullptr;
 	}
 	//~AIGuardState();
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 #ifdef STATE_MACHINE_DEBUG
 	virtual AsciiString getName() const ;
 #endif
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	AIGuardMachine *m_guardMachine;					///< state sub-machine for guard behavior
@@ -1160,17 +1160,17 @@ public:
 		m_guardMachine = nullptr;
 	}
 	//~AIGuardState();
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 #ifdef STATE_MACHINE_DEBUG
 	virtual AsciiString getName() const ;
 #endif
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	AITNGuardMachine *m_guardMachine;					///< state sub-machine for guard behavior
@@ -1189,18 +1189,18 @@ public:
 		m_nextEnemyScanTime = 0;
 	}
 	//~AIHuntState();
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 #ifdef STATE_MACHINE_DEBUG
 	virtual AsciiString getName() const ;
 #endif
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	StateMachine* m_huntMachine;					///< state sub-machine for hunt behavior
@@ -1219,18 +1219,18 @@ public:
 	AIAttackAreaState( StateMachine *machine ) : State( machine, "AIAttackAreaState" ), m_attackMachine(nullptr),
 		m_nextEnemyScanTime(0) { }
 	//~AIAttackAreaState();
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 #ifdef STATE_MACHINE_DEBUG
 	virtual AsciiString getName() const ;
 #endif
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	StateMachine *m_attackMachine;					///< state sub-machine for attack behavior
@@ -1246,14 +1246,14 @@ class AIFaceState : public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIFaceState, "AIFaceState")
 public:
 	AIFaceState( StateMachine *machine, Bool obj ) : State( machine, "AIFaceState" ), m_canTurnInPlace(false), m_obj(obj) { }
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 protected:
 	// snapshot interface .
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 	const Bool m_obj;

--- a/Generals/Code/GameEngine/Include/GameLogic/AITNGuard.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AITNGuard.h
@@ -70,7 +70,7 @@ public:
 	{
 	}
 
-	virtual Bool shouldExit(const StateMachine* machine) const;
+	virtual Bool shouldExit(const StateMachine* machine) const override;
 };
 
 
@@ -88,9 +88,9 @@ private:
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 public:
 	/**
@@ -122,14 +122,14 @@ public:
 	{
 		m_attackState = nullptr;
 	}
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 private:
 	AITNGuardMachine* getGuardMachine() { return (AITNGuardMachine*)getMachine(); }
 
@@ -144,14 +144,14 @@ class AITNGuardIdleState : public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AITNGuardIdleState, "AITNGuardIdleState")
 public:
 	AITNGuardIdleState( StateMachine *machine ) : State( machine, "AITNGuardIdleState" ) { }
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 private:
 	AITNGuardMachine* getGuardMachine() { return (AITNGuardMachine*)getMachine(); }
 
@@ -169,14 +169,14 @@ public:
 	{
 		m_attackState = nullptr;
 	}
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 private:
 	AITNGuardMachine* getGuardMachine() { return (AITNGuardMachine*)getMachine(); }
 
@@ -195,18 +195,18 @@ public:
 	{
 		m_nextReturnScanTime = 0;
 	}
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 
 protected:
 	UnsignedInt m_nextReturnScanTime;
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 };
 EMPTY_DTOR(AITNGuardReturnState)
 
@@ -217,9 +217,9 @@ class AITNGuardPickUpCrateState : public AIPickUpCrateState
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AITNGuardPickUpCrateState, "AITNGuardPickUpCrateState")
 public:
 	AITNGuardPickUpCrateState( StateMachine *machine );
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 };
 EMPTY_DTOR(AITNGuardPickUpCrateState)
 
@@ -229,14 +229,14 @@ class AITNGuardAttackAggressorState : public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AITNGuardAttackAggressorState, "AITNGuardAttackAggressorState")
 public:
 	AITNGuardAttackAggressorState( StateMachine *machine );
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 private:
 	AITNGuardMachine* getGuardMachine() { return (AITNGuardMachine*)getMachine(); }
 	TunnelNetworkExitConditions m_exitConditions;

--- a/Generals/Code/GameEngine/Include/GameLogic/Armor.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Armor.h
@@ -99,11 +99,11 @@ class ArmorStore : public SubsystemInterface
 public:
 
 	ArmorStore();
-	~ArmorStore();
+	virtual ~ArmorStore() override;
 
-	void init() { }
-	void reset() { }
-	void update() { }
+	virtual void init() override { }
+	virtual void reset() override { }
+	virtual void update() override { }
 
 	const ArmorTemplate* findArmorTemplate(NameKeyType namekey) const;
 	/**

--- a/Generals/Code/GameEngine/Include/GameLogic/CaveSystem.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/CaveSystem.h
@@ -44,11 +44,11 @@ class CaveSystem : public SubsystemInterface,
 {
 public:
 	CaveSystem();
-	~CaveSystem();
+	virtual ~CaveSystem() override;
 
-	void init();
-	void reset();
-	void update();
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override;
 
 	Bool canSwitchIndexToIndex( Int oldIndex, Int newIndex ); // If either Index has guys in it, no, you can't
 	void registerNewCave( Int theIndex );			// All Caves are born with a default index, which could be new
@@ -58,9 +58,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer ) { }
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess() { }
+	virtual void crc( Xfer *xfer ) override { }
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override { }
 
 private:
 	std::vector<TunnelTracker*> m_tunnelTrackerVector;// A vector of pointers where the indexes are known by

--- a/Generals/Code/GameEngine/Include/GameLogic/CrateSystem.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/CrateSystem.h
@@ -92,7 +92,7 @@ public:
 
 	virtual void init() override;
 	virtual void reset() override;
-	virtual void update() override{}
+	virtual void update() override {}
 
 	const CrateTemplate *findCrateTemplate(AsciiString name) const;
 	CrateTemplate *friend_findCrateTemplate(AsciiString name);

--- a/Generals/Code/GameEngine/Include/GameLogic/CrateSystem.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/CrateSystem.h
@@ -88,11 +88,11 @@ class CrateSystem : public SubsystemInterface
 {
 public:
 	CrateSystem();
-	~CrateSystem();
+	virtual ~CrateSystem() override;
 
-	void init();
-	void reset();
-	void update(){}
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override{}
 
 	const CrateTemplate *findCrateTemplate(AsciiString name) const;
 	CrateTemplate *friend_findCrateTemplate(AsciiString name);

--- a/Generals/Code/GameEngine/Include/GameLogic/Damage.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Damage.h
@@ -297,9 +297,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer ) { }
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess() { }
+	virtual void crc( Xfer *xfer ) override { }
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override { }
 
 };
 
@@ -340,9 +340,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer ) { }
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess() { }
+	virtual void crc( Xfer *xfer ) override { }
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override { }
 
 };
 
@@ -366,8 +366,8 @@ public:
 
 protected:
 
-	virtual void crc( Xfer *xfer ) { }
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess(){ }
+	virtual void crc( Xfer *xfer ) override { }
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override { }
 
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/ExperienceTracker.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/ExperienceTracker.h
@@ -63,9 +63,9 @@ public:
 	void setExperienceScalar( Real scalar ) { m_experienceScalar = scalar; }
 
 	// --------------- inherited from Snapshot interface --------------
-	void crc( Xfer *xfer ) override;
-	void xfer( Xfer *xfer ) override;
-	void loadPostProcess() override;
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	Object*						m_parent;														///< Object I am owned by

--- a/Generals/Code/GameEngine/Include/GameLogic/ExperienceTracker.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/ExperienceTracker.h
@@ -63,9 +63,9 @@ public:
 	void setExperienceScalar( Real scalar ) { m_experienceScalar = scalar; }
 
 	// --------------- inherited from Snapshot interface --------------
-	void crc( Xfer *xfer );
-	void xfer( Xfer *xfer );
-	void loadPostProcess();
+	void crc( Xfer *xfer ) override;
+	void xfer( Xfer *xfer ) override;
+	void loadPostProcess() override;
 
 private:
 	Object*						m_parent;														///< Object I am owned by

--- a/Generals/Code/GameEngine/Include/GameLogic/FiringTracker.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/FiringTracker.h
@@ -57,9 +57,9 @@ public:
 	Int getNumConsecutiveShotsAtVictim( const Object *victim ) const;
 
 	/// this is never disabled, since we want disabled things to continue to slowly "spin down"... (srj)
-	virtual DisabledMaskType getDisabledTypesToProcess() const { return DISABLEDMASK_ALL; }
+	virtual DisabledMaskType getDisabledTypesToProcess() const override { return DISABLEDMASK_ALL; }
 
-	virtual UpdateSleepTime update();	///< See if spin down is needed because we haven't shot in a while
+	virtual UpdateSleepTime update() override;	///< See if spin down is needed because we haven't shot in a while
 
 protected:
 
@@ -68,7 +68,7 @@ protected:
 		user update modules, so it redefines this. Please don't redefine this
 		for other modules without very careful deliberation. (srj)
 	*/
-	virtual SleepyUpdatePhase getUpdatePhase() const
+	virtual SleepyUpdatePhase getUpdatePhase() const override
 	{
 		return PHASE_FINAL;
 	}

--- a/Generals/Code/GameEngine/Include/GameLogic/GameLogic.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/GameLogic.h
@@ -101,12 +101,12 @@ class GameLogic : public SubsystemInterface, public Snapshot
 public:
 
 	GameLogic();
-	virtual ~GameLogic();
+	virtual ~GameLogic() override;
 
 	// subsystem methods
-	virtual void init();															///< Initialize or re-initialize the instance
-	virtual void reset();															///< Reset the logic system
-	virtual void update();														///< update the world
+	virtual void init() override;															///< Initialize or re-initialize the instance
+	virtual void reset() override;															///< Reset the logic system
+	virtual void update() override;														///< update the world
 
 	void preUpdate();
 
@@ -246,9 +246,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/GhostObject.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/GhostObject.h
@@ -56,9 +56,9 @@ public:
 	const Coord3D *getParentPosition() const {return &m_parentPosition;}
 
 protected:
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	Object *m_parentObject;		///< object which we are ghosting
 	GeometryType m_parentGeometryType;
@@ -89,9 +89,9 @@ public:
 	inline Bool trackAllPlayers() const; ///< returns whether the ghost object status is tracked for all players or for the local player only
 
 protected:
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	Int m_localPlayer;
 	Bool m_lockGhostObjects;

--- a/Generals/Code/GameEngine/Include/GameLogic/Locomotor.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Locomotor.h
@@ -383,9 +383,9 @@ protected:
 
 protected:
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 
@@ -457,11 +457,11 @@ class LocomotorStore : public SubsystemInterface
 public:
 
 	LocomotorStore();
-	~LocomotorStore();
+	virtual ~LocomotorStore() override;
 
-	void init() { };
-	void reset();
-	void update();
+	virtual void init() override { };
+	virtual void reset() override;
+	virtual void update() override;
 
 	/**
 		Find the LocomotorTemplate with the given name. If no such LocomotorTemplate exists, return null.

--- a/Generals/Code/GameEngine/Include/GameLogic/LocomotorSet.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/LocomotorSet.h
@@ -86,9 +86,9 @@ private:
 
 protected:
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 public:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Object.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Object.h
@@ -607,9 +607,9 @@ protected:
 
 
 	// snapshot methods
-	void crc( Xfer *xfer );
-	void xfer( Xfer *xfer );
-	void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	void handleShroud();
 	void handleValueMap();
@@ -623,10 +623,10 @@ protected:
 	Bool didEnterOrExit() const;
 
 	void setID( ObjectID id );
-	virtual Object *asObjectMeth() { return this; }
-	virtual const Object *asObjectMeth() const { return this; }
+	virtual Object *asObjectMeth() override { return this; }
+	virtual const Object *asObjectMeth() const override { return this; }
 
-	virtual Real calculateHeightAboveTerrain() const;		// Calculates the actual height above terrain.  Doesn't use cache.
+	virtual Real calculateHeightAboveTerrain() const override;		// Calculates the actual height above terrain.  Doesn't use cache.
 
 	void updateTriggerAreaFlags();
 	void setTriggerAreaFlagsForChangeInPosition();
@@ -644,7 +644,7 @@ protected:
 	void addThreat();
 	void removeThreat();
 
-	virtual void reactToTransformChange(const Matrix3D* oldMtx, const Coord3D* oldPos, Real oldAngle);
+	virtual void reactToTransformChange(const Matrix3D* oldMtx, const Coord3D* oldPos, Real oldAngle) override;
 
 private:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/ObjectCreationList.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/ObjectCreationList.h
@@ -187,11 +187,11 @@ class ObjectCreationListStore : public SubsystemInterface
 public:
 
 	ObjectCreationListStore();
-	~ObjectCreationListStore();
+	virtual ~ObjectCreationListStore() override;
 
-	void init() { }
-	void reset() { }
-	void update() { }
+	virtual void init() override { }
+	virtual void reset() override { }
+	virtual void update() override { }
 
 	/**
 		return the ObjectCreationList with the given namekey.

--- a/Generals/Code/GameEngine/Include/GameLogic/ObjectIter.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/ObjectIter.h
@@ -121,8 +121,8 @@ private:
 public:
 	SimpleObjectIterator();
 //~SimpleObjectIterator();	// provided by MPO
-	Object *first() { return firstWithNumeric(nullptr); }
-	Object *next() { return nextWithNumeric(nullptr); }
+	virtual Object *first() override { return firstWithNumeric(nullptr); }
+	virtual Object *next() override { return nextWithNumeric(nullptr); }
 
 	Object *firstWithNumeric(Real *num = nullptr) { reset(); return nextWithNumeric(num); }
 	Object *nextWithNumeric(Real *num = nullptr);

--- a/Generals/Code/GameEngine/Include/GameLogic/ObjectTypes.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/ObjectTypes.h
@@ -50,9 +50,9 @@ private:
 
 protected:
 	// snapshot methods
-	virtual void crc(Xfer *xfer);
-	virtual void xfer(Xfer *xfer);
-	virtual void loadPostProcess();
+	virtual void crc(Xfer *xfer) override;
+	virtual void xfer(Xfer *xfer) override;
+	virtual void loadPostProcess() override;
 
 public:
 	ObjectTypes();

--- a/Generals/Code/GameEngine/Include/GameLogic/PartitionManager.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/PartitionManager.h
@@ -315,9 +315,9 @@ public:
 	~PartitionCell();
 
 	// --------------- inherited from Snapshot interface --------------
-	void crc( Xfer *xfer ) override;
-	void xfer( Xfer *xfer ) override;
-	void loadPostProcess() override;
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	Int getCoiCount() const { return m_coiCount; }		///< return number of COIs touching this cell.
 	Int getCellX() const { return m_cellX; }
@@ -1285,9 +1285,9 @@ public:
 	// ----------------------------------------------------------------
 
 	// --------------- inherited from Snapshot interface --------------
-	void crc( Xfer *xfer ) override;
-	void xfer( Xfer *xfer ) override;
-	void loadPostProcess() override;
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	Bool getUpdatedSinceLastReset() const { return m_updatedSinceLastReset; }
 
@@ -1453,7 +1453,7 @@ public:
 	}
 
 	/**
-		Reveals the map for the given player, but does not override Shroud generation.  (Script)
+		virtual Reveals the map for the given player, but does not override Shroud generation.  (Script)
 		*/
 	void revealMapForPlayer( Int playerIndex );
 

--- a/Generals/Code/GameEngine/Include/GameLogic/PartitionManager.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/PartitionManager.h
@@ -257,9 +257,9 @@ public:
 protected:
 
 	// snapshot method
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 };
 
@@ -315,9 +315,9 @@ public:
 	~PartitionCell();
 
 	// --------------- inherited from Snapshot interface --------------
-	void crc( Xfer *xfer );
-	void xfer( Xfer *xfer );
-	void loadPostProcess();
+	void crc( Xfer *xfer ) override;
+	void xfer( Xfer *xfer ) override;
+	void loadPostProcess() override;
 
 	Int getCoiCount() const { return m_coiCount; }		///< return number of COIs touching this cell.
 	Int getCellX() const { return m_cellX; }
@@ -609,7 +609,7 @@ class PartitionFilterIsFlying : public PartitionFilter
 {
 public:
 	PartitionFilterIsFlying() { }
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterIsFlying"; }
 #endif
@@ -625,7 +625,7 @@ private:
   Bool m_desiredCollisionResult;  // collision must match this for allow to return true
 public:
 	PartitionFilterWouldCollide(const Coord3D& pos, const GeometryInfo& geom, Real angle, Bool desired);
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterWouldCollide"; }
 #endif
@@ -641,7 +641,7 @@ private:
 	const Player *m_player;
 public:
 	PartitionFilterSamePlayer(const Player *player) : m_player(player) { }
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterSamePlayer"; }
 #endif
@@ -667,7 +667,7 @@ public:
 		ALLOW_NEUTRAL					= (1<<NEUTRAL)		///< allow objects that m_obj considers neutral
 	};
 	PartitionFilterRelationship(const Object *obj, Int flags) : m_obj(obj), m_flags(flags) { }
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterRelationship"; }
 #endif
@@ -684,7 +684,7 @@ private:
 	const Team *m_team;
 public:
 	PartitionFilterAcceptOnTeam(const Team *team);
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterAcceptOnTeam"; }
 #endif
@@ -701,7 +701,7 @@ private:
 	const Squad *m_squad;
 public:
 	PartitionFilterAcceptOnSquad(const Squad *squad);
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterAcceptOnSquad"; }
 #endif
@@ -724,7 +724,7 @@ private:
 	const Object *m_obj;
 public:
 	PartitionFilterLineOfSight(const Object *obj);
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterLineOfSight"; }
 #endif
@@ -742,7 +742,7 @@ private:
 	AbleToAttackType m_attackType;
 public:
 	PartitionFilterPossibleToAttack(AbleToAttackType t, const Object *obj, CommandSourceType commandSource);
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterPossibleToAttack"; }
 #endif
@@ -758,7 +758,7 @@ private:
 	ObjectID m_lastAttackedBy;
 public:
 	PartitionFilterLastAttackedBy(Object *obj);
-	virtual Bool allow(Object *other);
+	virtual Bool allow(Object *other) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterLastAttackedBy"; }
 #endif
@@ -774,7 +774,7 @@ private:
 	ObjectStatusMaskType m_mustBeSet, m_mustBeClear;
 public:
 	PartitionFilterAcceptByObjectStatus(ObjectStatusMaskType mustBeSet, ObjectStatusMaskType mustBeClear) : m_mustBeSet(mustBeSet), m_mustBeClear(mustBeClear) { }
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterAcceptByObjectStatus"; }
 #endif
@@ -794,7 +794,7 @@ public:
 		: m_mustBeSet(mustBeSet), m_mustBeClear(mustBeClear)
 	{
 	}
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterRejectByObjectStatus"; }
 #endif
@@ -811,7 +811,7 @@ private:
 	Bool m_allow;
 public:
 	PartitionFilterStealthedAndUndetected( const Object *obj, Bool allow ) { m_obj = obj; m_allow = allow; }
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterStealthedAndUndetected"; }
 #endif
@@ -827,7 +827,7 @@ private:
 	KindOfMaskType m_mustBeSet, m_mustBeClear;
 public:
 	PartitionFilterAcceptByKindOf(const KindOfMaskType& mustBeSet, const KindOfMaskType& mustBeClear) : m_mustBeSet(mustBeSet), m_mustBeClear(mustBeClear) { }
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterAcceptByKindOf"; }
 #endif
@@ -847,7 +847,7 @@ public:
 		: m_mustBeSet(mustBeSet), m_mustBeClear(mustBeClear)
 	{
 	}
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterRejectByKindOf"; }
 #endif
@@ -864,7 +864,7 @@ private:
 	Object *m_obj;
 public:
 	PartitionFilterRejectBehind( Object *obj );
-	virtual Bool allow( Object *other );
+	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterRejectBehind"; }
 #endif
@@ -879,7 +879,7 @@ class PartitionFilterAlive : public PartitionFilter
 public:
 	PartitionFilterAlive() { }
 protected:
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterAlive"; }
 #endif
@@ -897,7 +897,7 @@ private:
 public:
 	PartitionFilterSameMapStatus(const Object *obj) : m_obj(obj) { }
 protected:
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterSameMapStatus"; }
 #endif
@@ -912,7 +912,7 @@ class PartitionFilterOnMap : public PartitionFilter
 public:
 	PartitionFilterOnMap() { }
 protected:
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterOnMap"; }
 #endif
@@ -932,7 +932,7 @@ private:
 public:
 	PartitionFilterRejectBuildings(const Object *o);
 protected:
-	virtual Bool allow( Object *other );
+	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterRejectBuildings"; }
 #endif
@@ -952,7 +952,7 @@ public:
 	PartitionFilterInsignificantBuildings(Bool allowNonBuildings, Bool allowInsignificant) :
 			m_allowNonBuildings(allowNonBuildings), m_allowInsignificant(allowInsignificant) {}
 protected:
-	virtual Bool allow( Object *other );
+	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterInsignificantBuildings"; }
 #endif
@@ -970,7 +970,7 @@ public:
 	PartitionFilterFreeOfFog(Int toWhom) :
 			m_comparisonIndex(toWhom){}
 protected:
-	virtual Bool allow( Object *other );
+	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterFreeOfFog"; }
 #endif
@@ -987,7 +987,7 @@ private:
 public:
 	PartitionFilterRepulsor(const Object *o) : m_self(o) { }
 protected:
-	virtual Bool allow( Object *other );
+	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterRepulsor"; }
 #endif
@@ -1008,7 +1008,7 @@ private:
 public:
 	PartitionFilterIrregularArea(Coord3D* area, Int numPointsInArea) : m_area(area), m_numPointsInArea(numPointsInArea) {}
 protected:
-	virtual Bool allow( Object *other );
+	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterIrregularArea"; }
 #endif
@@ -1028,7 +1028,7 @@ private:
 public:
 	PartitionFilterPolygonTrigger(const PolygonTrigger *trigger) : m_trigger(trigger) {}
 protected:
-	virtual Bool allow( Object *other );
+	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterPolygonTrigger"; }
 #endif
@@ -1048,7 +1048,7 @@ private:
 public:
 	PartitionFilterPlayer(const Player *player, Bool match) : m_player(player), m_match(match) {}
 protected:
-	virtual Bool allow( Object *other );
+	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterPlayer"; }
 #endif
@@ -1073,7 +1073,7 @@ public:
 	{
 	}
 protected:
-	virtual Bool allow( Object *other );
+	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterPlayerAffiliation"; }
 #endif
@@ -1095,7 +1095,7 @@ public:
 		DEBUG_ASSERTCRASH(m_tThing != nullptr, ("ThingTemplate for PartitionFilterThing is null"));
 	}
 protected:
-	virtual Bool allow( Object *other );
+	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterThing"; }
 #endif
@@ -1117,7 +1117,7 @@ public:
 		m_player = nullptr;
 	}
 protected:
-	virtual Bool allow( Object *other );
+	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterGarrisonable"; }
 #endif
@@ -1140,7 +1140,7 @@ public:
 	{
 	}
 protected:
-	virtual Bool allow( Object *other );
+	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterGarrisonableByPlayer"; }
 #endif
@@ -1158,7 +1158,7 @@ private:
 public:
 	PartitionFilterUnmannedObject( Bool match ) : m_match(match) {}
 protected:
-	virtual Bool allow( Object *other );
+	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterUnmannedObject"; }
 #endif
@@ -1180,7 +1180,7 @@ public:
 	PartitionFilterValidCommandButtonTarget( Object *source, const CommandButton *commandButton, Bool match, CommandSourceType commandSource) :
 		m_source(source), m_commandButton(commandButton), m_match(match), m_commandSource(commandSource) {}
 protected:
-	virtual Bool allow( Object *other );
+	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterValidCommandButtonTarget"; }
 #endif
@@ -1276,18 +1276,18 @@ protected:
 public:
 
 	PartitionManager();
-	virtual ~PartitionManager();
+	virtual ~PartitionManager() override;
 
 	// --------------- inherited from Subsystem interface -------------
-	virtual void init();			///< initialize
-	virtual void reset();			///< system reset
-	virtual void update();		///< system update
+	virtual void init() override;			///< initialize
+	virtual void reset() override;			///< system reset
+	virtual void update() override;		///< system update
 	// ----------------------------------------------------------------
 
 	// --------------- inherited from Snapshot interface --------------
-	void crc( Xfer *xfer );
-	void xfer( Xfer *xfer );
-	void loadPostProcess();
+	void crc( Xfer *xfer ) override;
+	void xfer( Xfer *xfer ) override;
+	void loadPostProcess() override;
 
 	Bool getUpdatedSinceLastReset() const { return m_updatedSinceLastReset; }
 

--- a/Generals/Code/GameEngine/Include/GameLogic/PolygonTrigger.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/PolygonTrigger.h
@@ -90,9 +90,9 @@ protected:
 	void updateBounds() const;
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 public:
 	PolygonTrigger(Int initialAllocation);

--- a/Generals/Code/GameEngine/Include/GameLogic/RankInfo.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/RankInfo.h
@@ -52,12 +52,12 @@ public:
 class RankInfoStore : public SubsystemInterface
 {
 public:
-	virtual ~RankInfoStore();
+	virtual ~RankInfoStore() override;
 
 public:
-	void init();
-	void reset();
-	void update() { }
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override { }
 
 	Int getRankLevelCount() const;
 

--- a/Generals/Code/GameEngine/Include/GameLogic/ScriptActions.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/ScriptActions.h
@@ -48,9 +48,9 @@ public:
 
 	virtual ~ScriptActionsInterface() override { };
 
-	virtual void init() override = 0;		///< Init
-	virtual void reset() override = 0;		///< Reset
-	virtual void update() override = 0;	///< Update
+	virtual void init() = 0;		///< Init
+	virtual void reset() = 0;		///< Reset
+	virtual void update() = 0;	///< Update
 
 	virtual void executeAction( ScriptAction *pAction ) = 0; ///< execute a script action.
 	virtual void closeWindows( Bool suppressNewWindows ) = 0;

--- a/Generals/Code/GameEngine/Include/GameLogic/ScriptActions.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/ScriptActions.h
@@ -46,11 +46,11 @@ class ScriptActionsInterface : public SubsystemInterface
 
 public:
 
-	virtual ~ScriptActionsInterface() { };
+	virtual ~ScriptActionsInterface() override { };
 
-	virtual void init() = 0;		///< Init
-	virtual void reset() = 0;		///< Reset
-	virtual void update() = 0;	///< Update
+	virtual void init() override = 0;		///< Init
+	virtual void reset() override = 0;		///< Reset
+	virtual void update() override = 0;	///< Update
 
 	virtual void executeAction( ScriptAction *pAction ) = 0; ///< execute a script action.
 	virtual void closeWindows( Bool suppressNewWindows ) = 0;
@@ -71,17 +71,17 @@ class ScriptActions : public ScriptActionsInterface
 
 public:
 	ScriptActions();
-	~ScriptActions();
+	virtual ~ScriptActions() override;
 
 public:
-	virtual void init();		///< Init
-	virtual void reset();		///< Reset
-	virtual void update();	///< Update
+	virtual void init() override;		///< Init
+	virtual void reset() override;		///< Reset
+	virtual void update() override;	///< Update
 
-	void executeAction( ScriptAction *pAction );
-	void closeWindows( Bool suppressNewWindows );
+	virtual void executeAction( ScriptAction *pAction ) override;
+	virtual void closeWindows( Bool suppressNewWindows ) override;
 
-	void doEnableOrDisableObjectDifficultyBonuses(Bool enableBonuses);
+	virtual void doEnableOrDisableObjectDifficultyBonuses(Bool enableBonuses) override;
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/ScriptConditions.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/ScriptConditions.h
@@ -45,9 +45,9 @@ public:
 
 	virtual ~ScriptConditionsInterface() override { };
 
-	virtual void init() override = 0;		///< Init
-	virtual void reset() override = 0;		///< Reset
-	virtual void update() override = 0;	///< Update
+	virtual void init() = 0;		///< Init
+	virtual void reset() = 0;		///< Reset
+	virtual void update() = 0;	///< Update
 
 	virtual Bool evaluateCondition( Condition *pCondition ) = 0; ///< evaluate a a script condition.
 

--- a/Generals/Code/GameEngine/Include/GameLogic/ScriptConditions.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/ScriptConditions.h
@@ -43,11 +43,11 @@ class ScriptConditionsInterface : public SubsystemInterface
 
 public:
 
-	virtual ~ScriptConditionsInterface() { };
+	virtual ~ScriptConditionsInterface() override { };
 
-	virtual void init() = 0;		///< Init
-	virtual void reset() = 0;		///< Reset
-	virtual void update() = 0;	///< Update
+	virtual void init() override = 0;		///< Init
+	virtual void reset() override = 0;		///< Reset
+	virtual void update() override = 0;	///< Update
 
 	virtual Bool evaluateCondition( Condition *pCondition ) = 0; ///< evaluate a a script condition.
 
@@ -68,15 +68,15 @@ class ScriptConditions : public ScriptConditionsInterface
 
 public:
 	ScriptConditions();
-	~ScriptConditions();
+	virtual ~ScriptConditions() override;
 
 public:
 
-	virtual void init();		///< Init
-	virtual void reset();		///< Reset
-	virtual void update();	///< Update
+	virtual void init() override;		///< Init
+	virtual void reset() override;		///< Reset
+	virtual void update() override;	///< Update
 
-	Bool evaluateCondition( Condition *pCondition );
+	virtual Bool evaluateCondition( Condition *pCondition ) override;
 
 protected:
 	Player *playerFromParam(Parameter *pSideParm);			// Gets a player from a parameter.
@@ -153,7 +153,7 @@ protected:
 	Bool evaluatePlayerHasUnitTypeInArea(Condition *pCondition, Parameter *pPlayerParm, Parameter *pComparisonParm, Parameter *pCountParm, Parameter *pTypeParm, Parameter *pTriggerParm);
 	Bool evaluatePlayerHasUnitKindInArea(Condition *pCondition, Parameter *pPlayerParm, Parameter *pComparisonParm, Parameter *pCountParm,Parameter *pKindParm, Parameter *pTriggerParm);
 	Bool evaluateUnitHasEmptied(Parameter *pUnitParm);
-	Bool evaluateTeamIsContained(Parameter *pTeamParm, Bool allContained);
+	virtual Bool evaluateTeamIsContained(Parameter *pTeamParm, Bool allContained) override;
 	Bool evaluateMusicHasCompleted(Parameter *pMusicParm, Parameter *pIntParm);
 	Bool evaluatePlayerLostObjectType(Parameter *pPlayerParm, Parameter *pTypeParm);
 
@@ -164,7 +164,7 @@ protected:
 	Bool evaluateSkirmishPlayerIsFaction(Parameter *pSkirmishPlayerParm, Parameter *pFactionParm);
 	Bool evaluateSkirmishSuppliesWithinDistancePerimeter(Parameter *pSkirmishPlayerParm, Parameter *pDistanceParm, Parameter *pLocationParm, Parameter *pValueParm);
 	Bool evaluateSkirmishPlayerTechBuildingWithinDistancePerimeter(Condition *pCondition, Parameter *pSkirmishPlayerParm, Parameter *pDistanceParm, Parameter *pLocationParm);
-	Bool evaluateSkirmishCommandButtonIsReady( Parameter *pSkirmishPlayerParm, Parameter *pTeamParm, Parameter *pCommandButtonParm, Bool allReady );
+	virtual Bool evaluateSkirmishCommandButtonIsReady( Parameter *pSkirmishPlayerParm, Parameter *pTeamParm, Parameter *pCommandButtonParm, Bool allReady ) override;
 	Bool evaluateSkirmishUnownedFactionUnitComparison( Parameter *pSkirmishPlayerParm, Parameter *pComparisonParm, Parameter *pCountParm );
 	Bool evaluateSkirmishPlayerHasPrereqsToBuild( Parameter *pSkirmishPlayerParm, Parameter *pObjectTypeParm );
 	Bool evaluateSkirmishPlayerHasComparisonGarrisoned(Parameter *pSkirmishPlayerParm, Parameter *pComparisonParm, Parameter *pCountParm );

--- a/Generals/Code/GameEngine/Include/GameLogic/ScriptEngine.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/ScriptEngine.h
@@ -145,9 +145,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	AsciiString m_name;
 	Int	m_defaultPriority;
@@ -177,9 +177,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 };
 EMPTY_DTOR(SequentialScript)
@@ -218,11 +218,11 @@ public:
 	enum {MAX_COUNTERS=256, MAX_FLAGS=256, MAX_ATTACK_PRIORITIES=256};
 	enum TFade {FADE_NONE, FADE_SUBTRACT, FADE_ADD, FADE_SATURATE, FADE_MULTIPLY};
 	ScriptEngine();
-	virtual ~ScriptEngine();
+	virtual ~ScriptEngine() override;
 
-	virtual void init();		///< Init
-	virtual void reset();		///< Reset
-	virtual void update();	///< Update
+	virtual void init() override;		///< Init
+	virtual void reset() override;		///< Reset
+	virtual void update() override;	///< Update
 
 	void appendSequentialScript(const SequentialScript *scriptToSequence);
 	void removeSequentialScript(SequentialScript *scriptToRemove);
@@ -360,9 +360,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	Int allocateCounter( const AsciiString& name);
 	Int allocateFlag( const AsciiString& name);

--- a/Generals/Code/GameEngine/Include/GameLogic/Scripts.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Scripts.h
@@ -114,9 +114,9 @@ class ScriptGroup : public MemoryPoolObject, public Snapshot
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 	Script			*m_firstScript;
@@ -596,9 +596,9 @@ class Script : public MemoryPoolObject, public Snapshot
 protected:	// Note - If you add any member vars, you must take them into account in duplicate() and updateFrom(), as well as file read/write.
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	AsciiString	m_scriptName;   ///<Short name.
 	AsciiString m_comment;			///< Long comment.
@@ -1060,9 +1060,9 @@ class ScriptList : public MemoryPoolObject, public Snapshot
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	ScriptGroup		*m_firstGroup;
 	Script				*m_firstScript;

--- a/Generals/Code/GameEngine/Include/GameLogic/SidesList.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/SidesList.h
@@ -136,11 +136,11 @@ class SidesList : public SubsystemInterface,
 public:
 
 	SidesList();
-	~SidesList();
+	virtual ~SidesList() override;
 
-	void init() { }
-	void update() { }
-	void reset();
+	virtual void init() override { }
+	virtual void update() override { }
+	virtual void reset() override;
 
 	/// Reads sides (including build list info && player dicts.)
 	static Bool ParseSidesDataChunk(DataChunkInput &file, DataChunkInfo *info, void *userData);
@@ -186,9 +186,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	Int					m_numSides;
 	SidesInfo		m_sides[MAX_PLAYER_COUNT];
@@ -269,9 +269,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	AsciiString			m_buildingName;			///< The name of this building.
 	AsciiString			m_templateName;			///< The thing template name for this model's info.

--- a/Generals/Code/GameEngine/Include/GameLogic/Squad.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Squad.h
@@ -64,9 +64,9 @@ class Squad : public MemoryPoolObject, public Snapshot
 
 protected:
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	VecObjectID m_objectIDs;
 

--- a/Generals/Code/GameEngine/Include/GameLogic/TerrainLogic.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/TerrainLogic.h
@@ -218,11 +218,11 @@ class TerrainLogic : public Snapshot,
 public:
 
 	TerrainLogic();
-	virtual ~TerrainLogic();
+	virtual ~TerrainLogic() override;
 
-	virtual void init();		///< Init
-	virtual void reset();		///< Reset
-	virtual void update();	///< Update
+	virtual void init() override;		///< Init
+	virtual void reset() override;		///< Reset
+	virtual void update() override;	///< Update
 
 	virtual Bool loadMap( AsciiString filename, Bool query );
 	virtual void newMap( Bool saveGame );	///< Initialize the logic for new map.
@@ -316,9 +316,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	/// Chunk parser callback.
  	static Bool parseWaypointDataChunk(DataChunkInput &file, DataChunkInfo *info, void *userData);

--- a/Generals/Code/GameEngine/Include/GameLogic/TurretAI.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/TurretAI.h
@@ -73,18 +73,18 @@ public:
 
 	TurretAI* getTurretAI() const { return m_turretAI; }
 
-	virtual void clear();
-	virtual StateReturnType resetToDefaultState();
-	virtual StateReturnType setState( StateID newStateID );
+	virtual void clear() override;
+	virtual StateReturnType resetToDefaultState() override;
+	virtual StateReturnType setState( StateID newStateID ) override;
 
 private:
 	TurretAI* m_turretAI;
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 };
 
 //-----------------------------------------------------------------------------------------------------------
@@ -103,14 +103,14 @@ class TurretAIIdleState : public TurretState
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(TurretAIIdleState, "TurretAIIdleState")
 public:
 	TurretAIIdleState( TurretStateMachine* machine ) : TurretState( machine, "TurretAIIdleState"), m_nextIdleScan(0) { }
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 private:
 	void resetIdleScan();
 	UnsignedInt m_nextIdleScan;
@@ -123,15 +123,15 @@ class TurretAIIdleScanState : public TurretState
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(TurretAIIdleScanState, "TurretAIIdleScanState")
 public:
 	TurretAIIdleScanState( TurretStateMachine* machine ) : TurretState( machine, "TurretAIIdleScanState"), m_desiredAngle(0) { }
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 private:
 	Real m_desiredAngle;
 };
@@ -153,14 +153,14 @@ public:
 	{
 
 	}
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 protected:
 	// snapshot interface	STUBBED - no member vars to save. jba.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override{};
 };
 EMPTY_DTOR(TurretAIAimTurretState)
 
@@ -173,14 +173,14 @@ class TurretAIRecenterTurretState : public TurretState
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(TurretAIRecenterTurretState, "TurretAIRecenterTurretState")
 public:
 	TurretAIRecenterTurretState( TurretStateMachine* machine ) : TurretState( machine, "TurretAIRecenterTurretState" ) { }
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 protected:
 	// snapshot interface	STUBBED - no member vars to save. jba.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override{};
 };
 EMPTY_DTOR(TurretAIRecenterTurretState)
 
@@ -198,14 +198,14 @@ public:
 	{
 		m_timestamp = 0;
 	}
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 };
 EMPTY_DTOR(TurretAIHoldTurretState)
 
@@ -286,7 +286,7 @@ public:
 
 	Bool isOwnersCurWeaponOnTurret() const;
 	Bool isWeaponSlotOnTurret(WeaponSlotType wslot) const;
-	Bool isAttackingObject() const { return m_target == TARGET_OBJECT; }
+	virtual Bool isAttackingObject() const override { return m_target == TARGET_OBJECT; }
 	Bool isForceAttacking() const { return m_isForceAttacking; }
 
 	// this will cause the turret to continuously track the given victim.
@@ -307,10 +307,10 @@ public:
 
 	UpdateSleepTime updateTurretAI();			///< implement this module's behavior
 
-	virtual void notifyFired();
-	virtual void notifyNewVictimChosen(Object* victim);
-	virtual const Coord3D* getOriginalVictimPos() const { return nullptr; }	// yes, we return nullptr here
-	virtual Bool isWeaponSlotOkToFire(WeaponSlotType wslot) const;
+	virtual void notifyFired() override;
+	virtual void notifyNewVictimChosen(Object* victim) override;
+	virtual const Coord3D* getOriginalVictimPos() const override { return nullptr; }	// yes, we return nullptr here
+	virtual Bool isWeaponSlotOkToFire(WeaponSlotType wslot) const override;
 
 	// these are only for use by the state machines... don't call them otherwise, please
 	Bool friend_turnTowardsAngle(Real desiredAngle, Real rateModifier, Real relThresh);
@@ -332,9 +332,9 @@ public:
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/TurretAI.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/TurretAI.h
@@ -158,9 +158,9 @@ public:
 	virtual StateReturnType update() override;
 protected:
 	// snapshot interface	STUBBED - no member vars to save. jba.
-	virtual void crc( Xfer *xfer ) override{};
-	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess() override{};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 };
 EMPTY_DTOR(TurretAIAimTurretState)
 
@@ -178,9 +178,9 @@ public:
 	virtual StateReturnType update() override;
 protected:
 	// snapshot interface	STUBBED - no member vars to save. jba.
-	virtual void crc( Xfer *xfer ) override{};
-	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess() override{};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 };
 EMPTY_DTOR(TurretAIRecenterTurretState)
 

--- a/Generals/Code/GameEngine/Include/GameLogic/VictoryConditions.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/VictoryConditions.h
@@ -51,9 +51,9 @@ class VictoryConditionsInterface : public SubsystemInterface
 public:
 	VictoryConditionsInterface() { m_victoryConditions = 0; }
 
-	virtual void init() override = 0;
-	virtual void reset() override = 0;
-	virtual void update() override = 0;
+	virtual void init() = 0;
+	virtual void reset() = 0;
+	virtual void update() = 0;
 
 	void setVictoryConditions( Int victoryConditions ) { m_victoryConditions = victoryConditions; }
 	Int getVictoryConditions() { return m_victoryConditions; }

--- a/Generals/Code/GameEngine/Include/GameLogic/VictoryConditions.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/VictoryConditions.h
@@ -51,9 +51,9 @@ class VictoryConditionsInterface : public SubsystemInterface
 public:
 	VictoryConditionsInterface() { m_victoryConditions = 0; }
 
-	virtual void init() = 0;
-	virtual void reset() = 0;
-	virtual void update() = 0;
+	virtual void init() override = 0;
+	virtual void reset() override = 0;
+	virtual void update() override = 0;
 
 	void setVictoryConditions( Int victoryConditions ) { m_victoryConditions = victoryConditions; }
 	Int getVictoryConditions() { return m_victoryConditions; }

--- a/Generals/Code/GameEngine/Include/GameLogic/Weapon.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Weapon.h
@@ -568,9 +568,9 @@ private:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 public:
 
@@ -804,12 +804,12 @@ class WeaponStore : public SubsystemInterface
 public:
 
 	WeaponStore();
-	~WeaponStore();
+	virtual ~WeaponStore() override;
 
-	void init() { };
-	void postProcessLoad();
-	void reset();
-	void update();
+	virtual void init() override { };
+	virtual void postProcessLoad() override;
+	virtual void reset() override;
+	virtual void update() override;
 
 	/**
 		Find the WeaponTemplate with the given name. If no such WeaponTemplate exists, return null.

--- a/Generals/Code/GameEngine/Include/GameLogic/WeaponSet.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/WeaponSet.h
@@ -189,9 +189,9 @@ private:
 
 protected:
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 public:
 

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/DownloadMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/DownloadMenu.cpp
@@ -122,11 +122,11 @@ class DownloadManagerMunkee : public DownloadManager
 {
 public:
 	DownloadManagerMunkee() {m_shouldQuitOnSuccess = true; m_shouldQuitOnSuccess = false;}
-	virtual HRESULT OnError( Int error );
-	virtual HRESULT OnEnd();
-	virtual HRESULT OnProgressUpdate( Int bytesread, Int totalsize, Int timetaken, Int timeleft );
-	virtual HRESULT OnStatusUpdate( Int status );
-	virtual HRESULT downloadFile( AsciiString server, AsciiString username, AsciiString password, AsciiString file, AsciiString localfile, AsciiString regkey, Bool tryResume );
+	virtual HRESULT OnError( Int error ) override;
+	virtual HRESULT OnEnd() override;
+	virtual HRESULT OnProgressUpdate( Int bytesread, Int totalsize, Int timetaken, Int timeleft ) override;
+	virtual HRESULT OnStatusUpdate( Int status ) override;
+	virtual HRESULT downloadFile( AsciiString server, AsciiString username, AsciiString password, AsciiString file, AsciiString localfile, AsciiString regkey, Bool tryResume ) override;
 
 private:
 	Bool m_shouldQuitOnSuccess;

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLoginMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLoginMenu.cpp
@@ -88,12 +88,12 @@ class GameSpyLoginPreferences : public UserPreferences
 {
 public:
 	GameSpyLoginPreferences();
-	virtual ~GameSpyLoginPreferences();
+	virtual ~GameSpyLoginPreferences() override;
 
 	Bool loadFromIniFile();
 
-	virtual Bool load(AsciiString fname);
-	virtual Bool write();
+	virtual Bool load(AsciiString fname) override;
+	virtual Bool write() override;
 
 	AsciiString getPasswordForEmail( AsciiString email );
 	AsciiString getDateForEmail( AsciiString email, AsciiString &month, AsciiString &date, AsciiString &year  );

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AI.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AI.cpp
@@ -513,7 +513,7 @@ private:
 public:
 	PartitionFilterLiveMapEnemies(const Object *obj) : m_obj(obj) { }
 
-	virtual Bool allow(Object *objOther)
+	virtual Bool allow(Object *objOther) override
 	{
 		// this is way fast (bit test) so do it first.
 		if (objOther->isEffectivelyDead())
@@ -543,7 +543,7 @@ private:
 public:
 	PartitionFilterWithinAttackRange(const Object* obj) : m_obj(obj) { }
 
-	virtual Bool allow(Object* objOther)
+	virtual Bool allow(Object* objOther) override
 	{
 		for (Int i = 0; i < WEAPONSLOT_COUNT;	i++ )
 		{

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -1906,9 +1906,9 @@ public:
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 };
 
 // ------------------------------------------------------------------------------------------------
@@ -5535,9 +5535,9 @@ public:
 	AIAttackThenIdleStateMachine( Object *owner, AsciiString name );
 protected:
 	// snapshot interface .
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 };
 
 // ------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
@@ -123,7 +123,7 @@ public:
 	{
 	}
 
-	virtual Object* create( const Object* primaryObj, const Coord3D *primary, const Coord3D* secondary, UnsignedInt lifetimeFrames = 0 ) const
+	virtual Object* create( const Object* primaryObj, const Coord3D *primary, const Coord3D* secondary, UnsignedInt lifetimeFrames = 0 ) const override
 	{
 		if (!primaryObj || !primary || !secondary)
 		{
@@ -170,7 +170,7 @@ public:
 	{
 	}
 
-	virtual Object* create( const Object* primaryObj, const Coord3D *primary, const Coord3D* secondary, UnsignedInt lifetimeFrames = 0 ) const
+	virtual Object* create( const Object* primaryObj, const Coord3D *primary, const Coord3D* secondary, UnsignedInt lifetimeFrames = 0 ) const override
 	{
 		if (!primaryObj || !primary || !secondary)
 		{
@@ -252,12 +252,12 @@ public:
 		m_transportName.clear();
 	}
 
-	virtual Object* create(const Object *primaryObj, const Coord3D *primary, const Coord3D *secondary, UnsignedInt lifetimeFrames = 0 ) const
+	virtual Object* create(const Object *primaryObj, const Coord3D *primary, const Coord3D *secondary, UnsignedInt lifetimeFrames = 0 ) const override
 	{
 		return create( primaryObj, primary, secondary, true, lifetimeFrames );
 	}
 
-	virtual Object* create(const Object* primaryObj, const Coord3D *primary, const Coord3D* secondary, Bool createOwner, UnsignedInt lifetimeFrames = 0 ) const
+	virtual Object* create(const Object* primaryObj, const Coord3D *primary, const Coord3D* secondary, Bool createOwner, UnsignedInt lifetimeFrames = 0 ) const override
 	{
 		if (!primaryObj || !primary || !secondary)
 		{
@@ -610,7 +610,7 @@ public:
 	{
 	}
 
-	virtual Object* create( const Object* primary, const Object* secondary, UnsignedInt lifetimeFrames = 0 ) const
+	virtual Object* create( const Object* primary, const Object* secondary, UnsignedInt lifetimeFrames = 0 ) const override
 	{
 		if (primary)
 		{
@@ -641,7 +641,7 @@ public:
 		return nullptr;
 	}
 
-	virtual Object* create(const Object* primaryObj, const Coord3D *primary, const Coord3D* secondary, UnsignedInt lifetimeFrames = 0 ) const
+	virtual Object* create(const Object* primaryObj, const Coord3D *primary, const Coord3D* secondary, UnsignedInt lifetimeFrames = 0 ) const override
 	{
 		DEBUG_CRASH(("You must call this effect with an object, not a location"));
 		return nullptr;
@@ -765,7 +765,7 @@ public:
 		m_offset.zero();
 	}
 
-	virtual Object* create(const Object* primary, const Object* secondary, UnsignedInt lifetimeFrames = 0 ) const
+	virtual Object* create(const Object* primary, const Object* secondary, UnsignedInt lifetimeFrames = 0 ) const override
 	{
 		if (primary)
 		{
@@ -781,7 +781,7 @@ public:
 		return nullptr;
 	}
 
-	virtual Object* create(const Object* primaryObj, const Coord3D *primary, const Coord3D* secondary, UnsignedInt lifetimeFrames = 0 ) const
+	virtual Object* create(const Object* primaryObj, const Coord3D *primary, const Coord3D* secondary, UnsignedInt lifetimeFrames = 0 ) const override
 	{
 		if (primary)
 		{

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
@@ -110,13 +110,13 @@ class ChinookEvacuateState : public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(ChinookEvacuateState, "ChinookEvacuateState")
 protected:
 	// snapshot interface	STUBBED - no member vars to save. jba.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){};
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {};
+	virtual void loadPostProcess() override {};
 public:
 	ChinookEvacuateState( StateMachine *machine ) : State( machine, "ChinookEvacuateState" ) { }
 
-	StateReturnType onEnter()
+	virtual StateReturnType onEnter() override
 	{
 		Object* obj = getMachineOwner();
 		if( obj->getContain() )
@@ -127,7 +127,7 @@ public:
 		return STATE_SUCCESS;
 	}
 
-	virtual StateReturnType update()
+	virtual StateReturnType update() override
 	{
 		return STATE_SUCCESS;
 	}
@@ -141,13 +141,13 @@ class ChinookHeadOffMapState :  public State
 	//I'm outta here
 protected:
 	// snapshot interface	STUBBED - no member vars to save. jba.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){};
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {};
+	virtual void loadPostProcess() override {};
 public:
 	ChinookHeadOffMapState( StateMachine *machine ) : State( machine, "ChinookHeadOffMapState" ) {}
 
-	StateReturnType onEnter() // Give move order out of town
+	virtual StateReturnType onEnter() override // Give move order out of town
 	{
 		Object *owner = getMachineOwner();
 		AIUpdateInterface *ai = owner->getAIUpdateInterface();
@@ -170,7 +170,7 @@ public:
 		return STATE_CONTINUE;
 	}
 
-	StateReturnType update()
+	virtual StateReturnType update() override
 	{
 		Object *owner = getMachineOwner();
 
@@ -197,12 +197,12 @@ private:
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer )
+	virtual void crc( Xfer *xfer ) override
 	{
 		// empty
 	}
 
-	virtual void xfer( Xfer *xfer )
+	virtual void xfer( Xfer *xfer ) override
 	{
 		// version
 		XferVersion currentVersion = 1;
@@ -213,7 +213,7 @@ protected:
 		xfer->xferBool(&m_landing);
 	}
 
-	virtual void loadPostProcess()
+	virtual void loadPostProcess() override
 	{
 		// empty
 	}
@@ -224,7 +224,7 @@ public:
 		m_destLoc.zero();
 	}
 
-	virtual StateReturnType onEnter()
+	virtual StateReturnType onEnter() override
 	{
 		Object* obj = getMachineOwner();
 		ChinookAIUpdate* ai = (ChinookAIUpdate*)obj->getAIUpdateInterface();
@@ -281,7 +281,7 @@ public:
 		return STATE_CONTINUE;
 	}
 
-	virtual StateReturnType update()
+	virtual StateReturnType update() override
 	{
 		Object* obj = getMachineOwner();
 		if (obj->isEffectivelyDead())
@@ -299,7 +299,7 @@ public:
 		return STATE_CONTINUE;
 	}
 
-	virtual void onExit( StateExitType status )
+	virtual void onExit( StateExitType status ) override
 	{
 		Object* obj = getMachineOwner();
 		ChinookAIUpdate* ai = (ChinookAIUpdate*)obj->getAIUpdateInterface();
@@ -415,12 +415,12 @@ private:
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer )
+	virtual void crc( Xfer *xfer ) override
 	{
 		// empty
 	}
 
-	virtual void xfer( Xfer *xfer )
+	virtual void xfer( Xfer *xfer ) override
 	{
 		// version
 		const XferVersion currentVersion = 2;
@@ -467,7 +467,7 @@ protected:
 		}
 	}
 
-	virtual void loadPostProcess()
+	virtual void loadPostProcess() override
 	{
 		for (std::vector<RopeInfo>::iterator it = m_ropes.begin(); it != m_ropes.end(); ++it)
 		{
@@ -481,7 +481,7 @@ public:
 	ChinookCombatDropState( StateMachine *machine ): State( machine, "ChinookCombatDropState" ) { }
 
 	// --------------
-	virtual StateReturnType onEnter()
+	virtual StateReturnType onEnter() override
 	{
 		Object* obj = getMachineOwner();
 		Drawable* draw = obj->getDrawable();
@@ -547,7 +547,7 @@ public:
 	}
 
 	// --------------
-	virtual StateReturnType update()
+	virtual StateReturnType update() override
 	{
 		Object* obj = getMachineOwner();
 		ChinookAIUpdate* ai = (ChinookAIUpdate*)obj->getAIUpdateInterface();
@@ -639,7 +639,7 @@ public:
 	}
 
 	// --------------
-	virtual void onExit( StateExitType status )
+	virtual void onExit( StateExitType status ) override
 	{
 		Object* obj = getMachineOwner();
 		ChinookAIUpdate* ai = (ChinookAIUpdate*)obj->getAIUpdateInterface();
@@ -697,12 +697,12 @@ private:
 	Real m_destZ;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer )
+	virtual void crc( Xfer *xfer ) override
 	{
 		// empty
 	}
 
-	virtual void xfer( Xfer *xfer )
+	virtual void xfer( Xfer *xfer ) override
 	{
 		// version
 		XferVersion currentVersion = 1;
@@ -714,7 +714,7 @@ protected:
 		xfer->xferReal(&m_destZ);
 	}
 
-	virtual void loadPostProcess()
+	virtual void loadPostProcess() override
 	{
 		// empty
 	}
@@ -722,7 +722,7 @@ protected:
 public:
 	ChinookMoveToBldgState( StateMachine *machine ): AIMoveToState( machine ) { }
 
-	virtual StateReturnType onEnter()
+	virtual StateReturnType onEnter() override
 	{
 		Object* obj = getMachineOwner();
 		ChinookAIUpdate* ai = (ChinookAIUpdate*)obj->getAIUpdateInterface();
@@ -753,7 +753,7 @@ public:
 		return AIMoveToState::onEnter();
 	}
 
-	virtual StateReturnType update()
+	virtual StateReturnType update() override
 	{
 		Object* obj = getMachineOwner();
 
@@ -767,7 +767,7 @@ public:
 		return status;
 	}
 
-	virtual void onExit( StateExitType status )
+	virtual void onExit( StateExitType status ) override
 	{
 		Object* obj = getMachineOwner();
 		ChinookAIUpdate* ai = (ChinookAIUpdate*)obj->getAIUpdateInterface();

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -86,13 +86,13 @@ class DozerActionPickActionPosState : public State
 public:
 
 	DozerActionPickActionPosState( StateMachine *machine, DozerTask task );
-	virtual StateReturnType update();
+	virtual StateReturnType update() override;
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 
@@ -243,13 +243,13 @@ class DozerActionMoveToActionPosState : public State
 public:
 
 	DozerActionMoveToActionPosState( StateMachine *machine, DozerTask task ) : State( machine, "DozerActionMoveToActionPosState" ) { m_task = task; }
-	virtual StateReturnType update();
+	virtual StateReturnType update() override;
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 
@@ -386,15 +386,15 @@ public:
 		m_task = task;
 		m_enterFrame = 0;
 	}
-	virtual StateReturnType update();
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status ) { }
+	virtual StateReturnType update() override;
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override { }
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 
@@ -792,9 +792,9 @@ public:
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 
@@ -967,15 +967,15 @@ public:
 		m_idlePlayerNumber = 0;
 		m_isMarkedAsIdle   = FALSE;
 	}
-	virtual StateReturnType update();
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType update() override;
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 
@@ -1154,16 +1154,16 @@ public:
 		Note that we DON'T use CONVERT_SLEEP_TO_CONTINUE; since we're not doing anything else
 		interesting in update, we can sleep when this machine sleeps
 	*/
-	virtual StateReturnType update() { return m_actionMachine->updateStateMachine(); }
+	virtual StateReturnType update() override { return m_actionMachine->updateStateMachine(); }
 
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 
@@ -1253,14 +1253,14 @@ class DozerPrimaryGoingHomeState : public State
 
 protected:
 	// snapshot interface	 STUBBED no member vars
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){};
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {};
+	virtual void loadPostProcess() override {};
 
 public:
 
 	DozerPrimaryGoingHomeState( StateMachine *machine ) : State( machine, "DozerPrimaryGoingHomeState" ) { }
-	virtual StateReturnType update() { return STATE_FAILURE; }
+	virtual StateReturnType update() override { return STATE_FAILURE; }
 
 };
 EMPTY_DTOR(DozerPrimaryGoingHomeState)

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -134,7 +134,7 @@ protected:
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterHasParkingPlace"; }
 #endif
-	virtual Bool allow(Object *objOther)
+	virtual Bool allow(Object *objOther) override
 	{
 		ParkingPlaceBehaviorInterface* pp = getPP(objOther->getID());
 		if (pp != nullptr && pp->reserveSpace(m_id, 0.0f, nullptr))
@@ -182,16 +182,16 @@ class JetAwaitingRunwayState : public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(JetAwaitingRunwayState, "JetAwaitingRunwayState")
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 private:
 	const Bool m_landing;
 
 public:
 	JetAwaitingRunwayState( StateMachine *machine, Bool landing ) : m_landing(landing), State( machine, "JetAwaitingRunwayState") { }
 
-	virtual StateReturnType onEnter()
+	virtual StateReturnType onEnter() override
 	{
 		Object* jet = getMachineOwner();
 		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();
@@ -204,7 +204,7 @@ public:
 		return STATE_CONTINUE;
 	}
 
-	virtual StateReturnType update()
+	virtual StateReturnType update() override
 	{
 		Object* jet = getMachineOwner();
 		if (jet->isEffectivelyDead())
@@ -238,7 +238,7 @@ public:
 		return STATE_CONTINUE;
 	}
 
-	virtual void onExit(StateExitType status)
+	virtual void onExit(StateExitType status) override
 	{
 		Object* jet = getMachineOwner();
 		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();
@@ -264,9 +264,9 @@ class JetOrHeliCirclingDeadAirfieldState : public State
 protected:
 	// snapshot interface	 STUBBED.
 	// The state will check immediately after a load game, but I think that's ok.  jba.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 
 private:
 	Int m_checkAirfield;
@@ -282,7 +282,7 @@ public:
 		State( machine, "JetOrHeliCirclingDeadAirfieldState"),
 		m_checkAirfield(0) { }
 
-	virtual StateReturnType onEnter()
+	virtual StateReturnType onEnter() override
 	{
 		Object* jet = getMachineOwner();
 		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();
@@ -313,7 +313,7 @@ public:
 		return STATE_CONTINUE;
 	}
 
-	virtual StateReturnType update()
+	virtual StateReturnType update() override
 	{
 		Object* jet = getMachineOwner();
 		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();
@@ -369,7 +369,7 @@ class JetOrHeliReturningToDeadAirfieldState : public AIInternalMoveToState
 public:
 	JetOrHeliReturningToDeadAirfieldState( StateMachine *machine ) : AIInternalMoveToState( machine, "JetOrHeliReturningToDeadAirfieldState") { }
 
-	virtual StateReturnType onEnter()
+	virtual StateReturnType onEnter() override
 	{
 		Object* jet = getMachineOwner();
 		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();
@@ -430,7 +430,7 @@ private:
 public:
 	JetOrHeliTaxiState( StateMachine *machine, TaxiType m ) : m_taxiMode(m), AIMoveOutOfTheWayState( machine ) { }
 
-	virtual StateReturnType onEnter()
+	virtual StateReturnType onEnter() override
 	{
 		Object* jet = getMachineOwner();
 		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();
@@ -509,7 +509,7 @@ public:
 		return ret;
 	}
 
-	virtual void onExit( StateExitType status )
+	virtual void onExit( StateExitType status ) override
 	{
 		Object* jet = getMachineOwner();
 		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();
@@ -550,7 +550,7 @@ private:
 public:
 	JetTakeoffOrLandingState( StateMachine *machine, Bool landing ) : m_landing(landing), AIFollowPathState( machine, "JetTakeoffOrLandingState" ) { }
 
-	virtual StateReturnType onEnter()
+	virtual StateReturnType onEnter() override
 	{
 		Object* jet = getMachineOwner();
 		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();
@@ -633,7 +633,7 @@ public:
 		return ret;
 	}
 
-	virtual StateReturnType update()
+	virtual StateReturnType update() override
 	{
 		Object* jet = getMachineOwner();
 		if (jet->isEffectivelyDead())
@@ -695,7 +695,7 @@ public:
 		return ret;
 	}
 
-	virtual void onExit( StateExitType status )
+	virtual void onExit( StateExitType status ) override
 	{
 		AIFollowPathState::onExit(status);
 
@@ -753,12 +753,12 @@ class HeliTakeoffOrLandingState : public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(HeliTakeoffOrLandingState, "HeliTakeoffOrLandingState")
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer )
+	virtual void crc( Xfer *xfer ) override
 	{
 		// empty. jba.
 	}
 
-	virtual void xfer( Xfer *xfer )
+	virtual void xfer( Xfer *xfer ) override
 	{
 		// version
 		XferVersion currentVersion = 1;
@@ -772,7 +772,7 @@ protected:
 		xfer->xferCoord3D(&m_parkingLoc);
 		xfer->xferReal(&m_parkingOrientation);
 	}
-	virtual void loadPostProcess()
+	virtual void loadPostProcess() override
 	{
 		// empty. jba.
 	}
@@ -790,7 +790,7 @@ public:
 			m_parkingLoc.zero();
 		}
 
-	virtual StateReturnType onEnter()
+	virtual StateReturnType onEnter() override
 	{
 		Object* jet = getMachineOwner();
 		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();
@@ -856,7 +856,7 @@ public:
 		return STATE_CONTINUE;
 	}
 
-	virtual StateReturnType update()
+	virtual StateReturnType update() override
 	{
 		Object* jet = getMachineOwner();
 		if (jet->isEffectivelyDead())
@@ -918,7 +918,7 @@ public:
 		return STATE_CONTINUE;
 	}
 
-	virtual void onExit( StateExitType status )
+	virtual void onExit( StateExitType status ) override
 	{
 		// just in case.
 		Object* jet = getMachineOwner();
@@ -965,14 +965,14 @@ class JetOrHeliParkOrientState : public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(JetOrHeliParkOrientState, "JetOrHeliParkOrientState")
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 
 public:
 	JetOrHeliParkOrientState( StateMachine *machine ) : State( machine, "JetOrHeliParkOrientState") { }
 
-	virtual StateReturnType onEnter()
+	virtual StateReturnType onEnter() override
 	{
 		Object* jet = getMachineOwner();
 		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();
@@ -991,7 +991,7 @@ public:
 		return STATE_CONTINUE;
 	}
 
-	virtual StateReturnType update()
+	virtual StateReturnType update() override
 	{
 		Object* jet = getMachineOwner();
 		if (jet->isEffectivelyDead())
@@ -1026,7 +1026,7 @@ public:
 		return STATE_CONTINUE;
 	}
 
-	virtual void onExit( StateExitType status )
+	virtual void onExit( StateExitType status ) override
 	{
 		Object* jet = getMachineOwner();
 		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();
@@ -1046,12 +1046,12 @@ class JetPauseBeforeTakeoffState : public AIFaceState
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(JetPauseBeforeTakeoffState, "JetPauseBeforeTakeoffState")
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer )
+	virtual void crc( Xfer *xfer ) override
 	{
 		// empty. jba.
 	}
 
-	virtual void xfer( Xfer *xfer )
+	virtual void xfer( Xfer *xfer ) override
 	{
 		// version
 #if RETAIL_COMPATIBLE_CRC || RETAIL_COMPATIBLE_XFER_SAVE
@@ -1085,7 +1085,7 @@ protected:
 		xfer->xferObjectID(&m_waitedForTaxiID);
 	}
 
-	virtual void loadPostProcess()
+	virtual void loadPostProcess() override
 	{
 		// empty. jba.
 	}
@@ -1177,7 +1177,7 @@ public:
 		// nothing
 	}
 
-	virtual StateReturnType onEnter()
+	virtual StateReturnType onEnter() override
 	{
 		Object* jet = getMachineOwner();
 		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();
@@ -1209,7 +1209,7 @@ public:
 	}
 
 #if RETAIL_COMPATIBLE_CRC || RETAIL_COMPATIBLE_XFER_SAVE
-	virtual StateReturnType update()
+	virtual StateReturnType update() override
 	{
 		Object* jet = getMachineOwner();
 		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();
@@ -1263,7 +1263,7 @@ public:
 #else
 	// TheSuperHackers @bugfix Reimplements the update to wait for another Jet on another runway.
 	// If this must work with more than 2 runways, then this logic needs another look.
-	virtual StateReturnType update()
+	virtual StateReturnType update() override
 	{
 		Object* jet = getMachineOwner();
 		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();
@@ -1336,7 +1336,7 @@ public:
 	}
 #endif
 
-	virtual void onExit(StateExitType status)
+	virtual void onExit(StateExitType status) override
 	{
 		Object* jet = getMachineOwner();
 		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();
@@ -1359,12 +1359,12 @@ private:
 protected:
 
 	// snapshot interface
-	virtual void crc( Xfer *xfer )
+	virtual void crc( Xfer *xfer ) override
 	{
 		// empty. jba.
 	}
 
-	virtual void xfer( Xfer *xfer )
+	virtual void xfer( Xfer *xfer ) override
 	{
 		// version
 		XferVersion currentVersion = 1;
@@ -1375,7 +1375,7 @@ protected:
 		xfer->xferUnsignedInt(&m_reloadTime);
 		xfer->xferUnsignedInt(&m_reloadDoneFrame);
 	}
-	virtual void loadPostProcess()
+	virtual void loadPostProcess() override
 	{
 		// empty. jba.
 	}
@@ -1383,7 +1383,7 @@ protected:
 public:
 	JetOrHeliReloadAmmoState( StateMachine *machine ) : State( machine, "JetOrHeliReloadAmmoState") { }
 
-	virtual StateReturnType onEnter()
+	virtual StateReturnType onEnter() override
 	{
 		Object* jet = getMachineOwner();
 		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();
@@ -1420,7 +1420,7 @@ public:
 		return STATE_CONTINUE;
 	}
 
-	virtual StateReturnType update()
+	virtual StateReturnType update() override
 	{
 		Object* jet = getMachineOwner();
 		UnsignedInt now = TheGameLogic->getFrame();
@@ -1446,7 +1446,7 @@ public:
 		return STATE_CONTINUE;
 	}
 
-	virtual void onExit(StateExitType status)
+	virtual void onExit(StateExitType status) override
 	{
 		Object* jet = getMachineOwner();
 		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();
@@ -1468,7 +1468,7 @@ class JetOrHeliReturnForLandingState : public AIInternalMoveToState
 public:
 	JetOrHeliReturnForLandingState( StateMachine *machine ) : AIInternalMoveToState( machine, "JetOrHeliReturnForLandingState") { }
 
-	virtual StateReturnType onEnter()
+	virtual StateReturnType onEnter() override
 	{
 		Object* jet = getMachineOwner();
 		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/RailroadGuideAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/RailroadGuideAIUpdate.cpp
@@ -866,7 +866,7 @@ public:
 	virtual const char* debugGetName() { return "PartitionFilterIsValidCarriage"; }
 #endif
 
-	virtual Bool allow(Object *objOther)
+	virtual Bool allow(Object *objOther) override
 	{
 
 		// must exist!

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cpp
@@ -287,13 +287,13 @@ class SupplyTruckBusyState :  public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(SupplyTruckBusyState, "SupplyTruckBusyState")
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){};
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {};
+	virtual void loadPostProcess() override {};
 
 public:
 	SupplyTruckBusyState( StateMachine *machine ) : State( machine, "SupplyTruckBusyState" ) { }
-	virtual StateReturnType onEnter()
+	virtual StateReturnType onEnter() override
 	{
 		if( getMachineOwner() && getMachineOwner()->getAI() )
 		{
@@ -311,11 +311,11 @@ TheInGameUI->DEBUG_addFloatingText("entering busy state", getMachineOwner()->get
 #endif
 		return STATE_CONTINUE;
 	}
-	virtual StateReturnType update()
+	virtual StateReturnType update() override
 	{
 		return STATE_CONTINUE;
 	}
-	virtual void onExit(StateExitType status)
+	virtual void onExit(StateExitType status) override
 	{
 #ifdef DEBUG_SUPPLY_STATE
 TheInGameUI->DEBUG_addFloatingText("exiting busy state", getMachineOwner()->getPosition(), GameMakeColor(255, 0, 0, 255));
@@ -331,18 +331,18 @@ class SupplyTruckIdleState :  public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(SupplyTruckIdleState, "SupplyTruckIdleState")
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){};
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {};
+	virtual void loadPostProcess() override {};
 
 public:
 	SupplyTruckIdleState( StateMachine *machine ) : State( machine, "SupplyTruckIdleState" ) { }
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update()
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override
 	{
 		return STATE_CONTINUE;
 	}
-	virtual void onExit(StateExitType status)
+	virtual void onExit(StateExitType status) override
 	{
 #ifdef DEBUG_SUPPLY_STATE
 TheInGameUI->DEBUG_addFloatingText("exiting idle state", getMachineOwner()->getPosition(), GameMakeColor(255, 0, 0, 255));

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -1162,14 +1162,14 @@ class ActAsDozerState :  public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(ActAsDozerState, "ActAsDozerState")
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){};
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {};
+	virtual void loadPostProcess() override {};
 
 public:
 	ActAsDozerState( StateMachine *machine ) :State( machine, "ActAsDozerState" ){}
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
 	virtual StateReturnType onExit();
 };
 EMPTY_DTOR(ActAsDozerState)
@@ -1181,14 +1181,14 @@ class ActAsSupplyTruckState :  public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(ActAsSupplyTruckState, "ActAsSupplyTruckState")
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){};
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {};
+	virtual void loadPostProcess() override {};
 
 public:
 	ActAsSupplyTruckState( StateMachine *machine ) :State( machine, "ActAsSupplyTruckState" ){}
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
 	virtual StateReturnType onExit();
 };
 EMPTY_DTOR(ActAsSupplyTruckState)

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/FireSpreadUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/FireSpreadUpdate.cpp
@@ -50,7 +50,7 @@ public:
 
 	PartitionFilterFlammable(){ }
 
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterFlammable"; }
 #endif

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/HordeUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/HordeUpdate.cpp
@@ -78,7 +78,7 @@ public:
 	virtual const char* debugGetName() { return "PartitionFilterHordeMember"; }
 #endif
 
-	virtual Bool allow(Object *objOther)
+	virtual Bool allow(Object *objOther) override
 	{
 		// must be exact same type as us (well, maybe)
 		if (m_data->m_exactMatch && m_obj->getTemplate() != objOther->getTemplate())

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/StealthDetectorUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/StealthDetectorUpdate.cpp
@@ -114,7 +114,7 @@ class PartitionFilterStealthedOrStealthGarrisoned : public PartitionFilter
 public:
 	PartitionFilterStealthedOrStealthGarrisoned() { }
 
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterStealthedOrStealthGarrisoned"; }

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/TensileFormationUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/TensileFormationUpdate.cpp
@@ -74,7 +74,7 @@ public:
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterTensileFormationMember"; }
 #endif
-	virtual Bool allow( Object *objOther )
+	virtual Bool allow( Object *objOther ) override
 	{
 		return ( getTFU( objOther ) != nullptr );
 	}

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/VictoryConditions.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/VictoryConditions.cpp
@@ -76,21 +76,21 @@ class VictoryConditions : public VictoryConditionsInterface
 public:
 	VictoryConditions();
 
-	void init();
-	void reset();
-	void update();
+	void init() override;
+	void reset() override;
+	void update() override;
 
-	Bool hasAchievedVictory(Player *player);					///< has a specific player and his allies won?
-	Bool hasBeenDefeated(Player *player);							///< has a specific player and his allies lost?
-	Bool hasSinglePlayerBeenDefeated(Player *player);	///< has a specific player lost?
+	virtual Bool hasAchievedVictory(Player *player) override;					///< has a specific player and his allies won?
+	virtual Bool hasBeenDefeated(Player *player) override;							///< has a specific player and his allies lost?
+	virtual Bool hasSinglePlayerBeenDefeated(Player *player) override;	///< has a specific player lost?
 
-	void cachePlayerPtrs();											///< players have been created - cache the ones of interest
+	void cachePlayerPtrs() override;											///< players have been created - cache the ones of interest
 
-	Bool isLocalAlliedVictory();								///< convenience function
-	Bool isLocalAlliedDefeat();									///< convenience function
-	Bool isLocalDefeat();												///< convenience function
-	Bool amIObserver() { return m_isObserver;} 	///< Am I an observer?( need this for scripts )
-	virtual UnsignedInt getEndFrame() { return m_endFrame; }	///< on which frame was the game effectively over?
+	Bool isLocalAlliedVictory() override;								///< convenience function
+	Bool isLocalAlliedDefeat() override;									///< convenience function
+	Bool isLocalDefeat() override;												///< convenience function
+	Bool amIObserver() override { return m_isObserver;} 	///< Am I an observer?( need this for scripts )
+	virtual UnsignedInt getEndFrame() override { return m_endFrame; }	///< on which frame was the game effectively over?
 private:
 	Player* findFirstUndefeatedPlayer(); ///< Find the first player that has not been defeated.
 	void markAllianceVictorious(Player* victoriousPlayer); ///< Mark the victorious player and his allies as victorious.

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/VictoryConditions.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/VictoryConditions.cpp
@@ -76,20 +76,20 @@ class VictoryConditions : public VictoryConditionsInterface
 public:
 	VictoryConditions();
 
-	void init() override;
-	void reset() override;
-	void update() override;
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override;
 
 	virtual Bool hasAchievedVictory(Player *player) override;					///< has a specific player and his allies won?
 	virtual Bool hasBeenDefeated(Player *player) override;							///< has a specific player and his allies lost?
 	virtual Bool hasSinglePlayerBeenDefeated(Player *player) override;	///< has a specific player lost?
 
-	void cachePlayerPtrs() override;											///< players have been created - cache the ones of interest
+	virtual void cachePlayerPtrs() override;											///< players have been created - cache the ones of interest
 
-	Bool isLocalAlliedVictory() override;								///< convenience function
-	Bool isLocalAlliedDefeat() override;									///< convenience function
-	Bool isLocalDefeat() override;												///< convenience function
-	Bool amIObserver() override { return m_isObserver;} 	///< Am I an observer?( need this for scripts )
+	virtual Bool isLocalAlliedVictory() override;								///< convenience function
+	virtual Bool isLocalAlliedDefeat() override;									///< convenience function
+	virtual Bool isLocalDefeat() override;												///< convenience function
+	virtual Bool amIObserver() override { return m_isObserver;} 	///< Am I an observer?( need this for scripts )
 	virtual UnsignedInt getEndFrame() override { return m_endFrame; }	///< on which frame was the game effectively over?
 private:
 	Player* findFirstUndefeatedPlayer(); ///< Find the first player that has not been defeated.

--- a/GeneralsMD/Code/GameEngine/Include/Common/AcademyStats.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/AcademyStats.h
@@ -128,9 +128,9 @@ public:
 
 protected:
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/ActionManager.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/ActionManager.h
@@ -61,11 +61,11 @@ class ActionManager : public SubsystemInterface
 public:
 
 	ActionManager();
-	virtual ~ActionManager();
+	virtual ~ActionManager() override;
 
-	virtual void init() { };							///< subsystem interface
-	virtual void reset() { };							///< subsystem interface
-	virtual void update() { };						///< subsystem interface
+	virtual void init() override { };							///< subsystem interface
+	virtual void reset() override { };							///< subsystem interface
+	virtual void update() override { };						///< subsystem interface
 
 	//Single unit to unit check
 	Bool canGetRepairedAt( const Object *obj, const Object *repairDest, CommandSourceType commandSource );

--- a/GeneralsMD/Code/GameEngine/Include/Common/BuildAssistant.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/BuildAssistant.h
@@ -123,11 +123,11 @@ public:
 public:
 
 	BuildAssistant();
-	virtual ~BuildAssistant();
+	virtual ~BuildAssistant() override;
 
-	virtual void init();					///< for subsytem
-	virtual void reset();					///< for subsytem
-	virtual void update();				///< for subsytem
+	virtual void init() override;					///< for subsytem
+	virtual void reset() override;					///< for subsytem
+	virtual void update() override;				///< for subsytem
 
 	/// iterate the "footprint" area of a structure at the given "sample resolution"
 	void iterateFootprint( const ThingTemplate *build,

--- a/GeneralsMD/Code/GameEngine/Include/Common/CustomMatchPreferences.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/CustomMatchPreferences.h
@@ -42,7 +42,7 @@ class CustomMatchPreferences : public UserPreferences
 {
 public:
 	CustomMatchPreferences();
-	virtual ~CustomMatchPreferences();
+	virtual ~CustomMatchPreferences() override;
 
 	void setLastLadder(const AsciiString& addr, UnsignedShort port);
 	AsciiString getLastLadderAddr();

--- a/GeneralsMD/Code/GameEngine/Include/Common/DamageFX.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/DamageFX.h
@@ -138,11 +138,11 @@ class DamageFXStore : public SubsystemInterface
 public:
 
 	DamageFXStore();
-	~DamageFXStore();
+	virtual ~DamageFXStore() override;
 
-	void init();
-	void reset();
-	void update();
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override;
 
 	/**
 		Find the DamageFX with the given name. If no such DamageFX exists, return null.

--- a/GeneralsMD/Code/GameEngine/Include/Common/Energy.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Energy.h
@@ -106,9 +106,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	void addProduction(Int amt);
 	void addConsumption(Int amt);

--- a/GeneralsMD/Code/GameEngine/Include/Common/FunctionLexicon.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/FunctionLexicon.h
@@ -71,11 +71,11 @@ public:
 public:
 
 	FunctionLexicon();
-	virtual ~FunctionLexicon();
+	virtual ~FunctionLexicon() override;
 
-	virtual void init();
-	virtual void reset();
-	virtual void update();
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override;
 
 	/// validate the tables and make sure all entries are unique
 	Bool validate();

--- a/GeneralsMD/Code/GameEngine/Include/Common/GameEngine.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GameEngine.h
@@ -55,11 +55,11 @@ class GameEngine : public SubsystemInterface
 public:
 
 	GameEngine();
-	virtual ~GameEngine();
+	virtual ~GameEngine() override;
 
-	virtual void init();								///< Init engine by creating client and logic
-	virtual void reset();								///< reset system to starting state
-	virtual void update();							///< per frame update
+	virtual void init() override;								///< Init engine by creating client and logic
+	virtual void reset() override;								///< reset system to starting state
+	virtual void update() override;							///< per frame update
 
 	virtual void execute();											/**< The "main loop" of the game engine.
 																								 It will not return until the game exits. */

--- a/GeneralsMD/Code/GameEngine/Include/Common/GameSpyMiscPreferences.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GameSpyMiscPreferences.h
@@ -42,7 +42,7 @@ class GameSpyMiscPreferences : public UserPreferences
 {
 public:
 	GameSpyMiscPreferences();
-	virtual ~GameSpyMiscPreferences();
+	virtual ~GameSpyMiscPreferences() override;
 
 	Int getLocale();
 	void setLocale( Int val );

--- a/GeneralsMD/Code/GameEngine/Include/Common/GameState.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GameState.h
@@ -148,12 +148,12 @@ class GameState : public SubsystemInterface,
 public:
 
 	GameState();
-	virtual ~GameState();
+	virtual ~GameState() override;
 
 	// subsystem interface
-	virtual void init();
-	virtual void reset();
-	virtual void update() { }
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override { }
 
 	// save game methods
 	SaveCode saveGame( AsciiString filename,
@@ -191,9 +191,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer ) { }
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess() { }
+	virtual void crc( Xfer *xfer ) override { }
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override { }
 
 private:
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/GameStateMap.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GameStateMap.h
@@ -45,17 +45,17 @@ class GameStateMap : public SubsystemInterface,
 public:
 
 	GameStateMap();
-	virtual ~GameStateMap();
+	virtual ~GameStateMap() override;
 
 	// subsystem interface methods
-	virtual void init() { }
-	virtual void reset() { }
-	virtual void update() { }
+	virtual void init() override { }
+	virtual void reset() override { }
+	virtual void update() override { }
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer ) { }
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess() { }
+	virtual void crc( Xfer *xfer ) override { }
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override { }
 
 	void clearScratchPadMaps();		///< clear any scratch pad maps from the save directory
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/Geometry.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Geometry.h
@@ -97,9 +97,9 @@ private:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 public:
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
@@ -579,7 +579,7 @@ private:
 
 	static GlobalData *m_theOriginal;		///< the original global data instance (no overrides)
 	GlobalData *m_next;									///< next instance (for overrides)
-	GlobalData *newOverride();		/** create a new override, copy data from previous
+	virtual GlobalData *newOverride();		/** create a new override, copy data from previous
 																			override, and return it */
 
 #if defined(_MSC_VER) && _MSC_VER < 1300

--- a/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
@@ -81,11 +81,11 @@ class GlobalData : public SubsystemInterface
 public:
 
 	GlobalData();
-	virtual ~GlobalData();
+	virtual ~GlobalData() override;
 
-	virtual void init();
-	virtual void reset();
-	virtual void update() { }
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override { }
 
 	Bool setTimeOfDay( TimeOfDay tod );		///< Use this function to set the Time of day;
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/IgnorePreferences.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/IgnorePreferences.h
@@ -66,7 +66,7 @@ class IgnorePreferences : public UserPreferences
 {
 public:
 	IgnorePreferences();
-	virtual ~IgnorePreferences();
+	virtual ~IgnorePreferences() override;
 	void setIgnore(const AsciiString& userName, Int profileID, Bool ignore);
 	IgnorePrefMap getIgnores();
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/LadderPreferences.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/LadderPreferences.h
@@ -62,10 +62,10 @@ class LadderPreferences : public UserPreferences
 {
 public:
 	LadderPreferences();
-	virtual ~LadderPreferences();
+	virtual ~LadderPreferences() override;
 
 	Bool loadProfile( Int profileID );
-	virtual bool write();
+	virtual bool write() override;
 
 	const LadderPrefMap& getRecentLadders();
 	void addRecentLadder( LadderPref ladder );

--- a/GeneralsMD/Code/GameEngine/Include/Common/MapReaderWriterInfo.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/MapReaderWriterInfo.h
@@ -72,7 +72,7 @@ public:
 variety of sources, such as FILE* or CFile. */
 class ChunkInputStream : public InputStream{
 public:
-	virtual Int read(void *pData, Int numBytes) override = 0;
+	virtual Int read(void *pData, Int numBytes) = 0;
 	virtual UnsignedInt tell() = 0;
 	virtual Bool absoluteSeek(UnsignedInt pos) = 0;
 	virtual Bool eof() = 0;

--- a/GeneralsMD/Code/GameEngine/Include/Common/MapReaderWriterInfo.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/MapReaderWriterInfo.h
@@ -72,7 +72,7 @@ public:
 variety of sources, such as FILE* or CFile. */
 class ChunkInputStream : public InputStream{
 public:
-	virtual Int read(void *pData, Int numBytes) = 0;
+	virtual Int read(void *pData, Int numBytes) override = 0;
 	virtual UnsignedInt tell() = 0;
 	virtual Bool absoluteSeek(UnsignedInt pos) = 0;
 	virtual Bool eof() = 0;
@@ -90,10 +90,10 @@ public:
 	~CachedFileInputStream();
 	Bool open(AsciiString path);	///< Returns true if open succeeded.
 	void close();  ///< Explict close.  Destructor closes if file is left open.
-	virtual Int read(void *pData, Int numBytes);
-	virtual UnsignedInt tell();
-	virtual Bool absoluteSeek(UnsignedInt pos);
-	virtual Bool eof();
+	virtual Int read(void *pData, Int numBytes) override;
+	virtual UnsignedInt tell() override;
+	virtual Bool absoluteSeek(UnsignedInt pos) override;
+	virtual Bool eof() override;
 	void rewind();
 };
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/MessageStream.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/MessageStream.h
@@ -701,11 +701,11 @@ class GameMessageList : public SubsystemInterface
 public:
 
 	GameMessageList();
-	virtual ~GameMessageList();
+	virtual ~GameMessageList() override;
 
-	virtual void init() { };			///< Initialize system
-	virtual void reset() { };			///< Reset system
-	virtual void update() { };		///< Update system
+	virtual void init() override { };			///< Initialize system
+	virtual void reset() override { };			///< Reset system
+	virtual void update() override { };		///< Update system
 
 	GameMessage *getFirstMessage() { return m_firstMessage; }	///< Return the first message
 
@@ -748,12 +748,12 @@ class MessageStream : public GameMessageList
 public:
 
 	MessageStream();
-	virtual ~MessageStream();
+	virtual ~MessageStream() override;
 
 	// Inherited Methods ----------------------------------------------------------------------------
-	virtual void init();
-	virtual void reset();
-	virtual void update();
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override;
 
 	virtual GameMessage *appendMessage( GameMessage::Type type );		///< Append a message to the end of the stream
 	virtual GameMessage *insertMessage( GameMessage::Type type, GameMessage *messageToInsertAfter );	// Insert message after messageToInsertAfter.
@@ -804,11 +804,11 @@ class CommandList : public GameMessageList
 {
 public:
 	CommandList();
-	virtual ~CommandList();
+	virtual ~CommandList() override;
 
-	virtual void init();			///< Init command list
-	virtual void reset();			///< Destroy all messages and reset list to empty
-	virtual void update();		///< Update hook
+	virtual void init() override;			///< Init command list
+	virtual void reset() override;			///< Destroy all messages and reset list to empty
+	virtual void update() override;		///< Update hook
 
 	void appendMessageList( GameMessage *list );			///< Adds messages to the end of the command list
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/MissionStats.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/MissionStats.h
@@ -70,9 +70,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/Module.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Module.h
@@ -120,9 +120,9 @@ public:
 	}
 
 public:
-	virtual void crc( Xfer *xfer ) {}
-	virtual void xfer( Xfer *xfer ) {}
-	virtual void loadPostProcess() {}
+	virtual void crc( Xfer *xfer ) override {}
+	virtual void xfer( Xfer *xfer ) override {}
+	virtual void loadPostProcess() override {}
 
 private:
 	NameKeyType m_moduleTagNameKey;		///< module tag key, unique among all modules for an object instance
@@ -216,9 +216,9 @@ protected:
 
 	const ModuleData* getModuleData() const { return m_moduleData; }
 
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	const ModuleData* m_moduleData;
@@ -255,9 +255,9 @@ protected:
 	Object *getObject() { return m_object; }
 	const Object *getObject() const { return m_object; }
 
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 
@@ -298,9 +298,9 @@ protected:
 	Drawable *getDrawable() { return m_drawable; }
 	const Drawable *getDrawable() const { return m_drawable; }
 
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/ModuleFactory.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/ModuleFactory.h
@@ -68,11 +68,11 @@ class ModuleFactory : public SubsystemInterface, public Snapshot
 public:
 
 	ModuleFactory();
-	virtual ~ModuleFactory();
+	virtual ~ModuleFactory() override;
 
-	virtual void init();
-	virtual void reset() { }					///< We don't reset during the lifetime of the app
-	virtual void update() { }					///< As of now, we don't have a need for an update
+	virtual void init() override;
+	virtual void reset() override { }					///< We don't reset during the lifetime of the app
+	virtual void update() override { }					///< As of now, we don't have a need for an update
 
 	Module *newModule( Thing *thing, const AsciiString& name, const ModuleData* data, ModuleType type );  ///< allocate a new module
 
@@ -81,9 +81,9 @@ public:
 
 	Int findModuleInterfaceMask(const AsciiString& name, ModuleType type);
 
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/Money.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Money.h
@@ -99,9 +99,9 @@ protected:
 	void triggerAudioEvent(const AudioEventRTS& audioEvent);
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/MultiplayerSettings.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/MultiplayerSettings.h
@@ -80,9 +80,9 @@ public:
 
 	MultiplayerSettings();
 
-	virtual void init() { }
-	virtual void update() { }
-	virtual void reset() { }
+	virtual void init() override { }
+	virtual void update() override { }
+	virtual void reset() override { }
 
 	//-----------------------------------------------------------------------------------------------
 	static const FieldParse m_multiplayerSettingsFieldParseTable[];		///< the parse table for INI definition

--- a/GeneralsMD/Code/GameEngine/Include/Common/NameKeyGenerator.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/NameKeyGenerator.h
@@ -83,11 +83,11 @@ class NameKeyGenerator : public SubsystemInterface
 public:
 
 	NameKeyGenerator();
-	virtual ~NameKeyGenerator();
+	virtual ~NameKeyGenerator() override;
 
-	virtual void init();
-	virtual void reset();
-	virtual void update() { }
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override { }
 
 	/// Given a string, convert into a unique integer key.
 	NameKeyType nameToKey(const AsciiString& name);

--- a/GeneralsMD/Code/GameEngine/Include/Common/Player.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Player.h
@@ -166,9 +166,9 @@ public:
 
 protected:
 
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 };
 
@@ -730,9 +730,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	void deleteUpgradeList();															///< delete all our upgrades
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/PlayerList.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/PlayerList.h
@@ -77,12 +77,12 @@ class PlayerList : public SubsystemInterface,
 public:
 
 	PlayerList();
-	~PlayerList();
+	virtual ~PlayerList() override;
 
 	// subsystem methods
-	virtual void init();
-	virtual void reset();
-	virtual void update();
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override;
 
 	virtual void newGame(); // called during GameLogic::startNewGame()
 	virtual void newMap();	 // Called after a new map is loaded.
@@ -153,9 +153,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/PlayerTemplate.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/PlayerTemplate.h
@@ -205,11 +205,11 @@ class PlayerTemplateStore : public SubsystemInterface
 public:
 
 	PlayerTemplateStore();
-	~PlayerTemplateStore();
+	virtual ~PlayerTemplateStore() override;
 
-	virtual void init();
-	virtual void reset();
-	virtual void update();
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override;
 
 	static void parsePlayerTemplateDefinition( INI* ini );
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/QuickmatchPreferences.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/QuickmatchPreferences.h
@@ -42,7 +42,7 @@ class QuickMatchPreferences : public UserPreferences
 {
 public:
 	QuickMatchPreferences();
-	virtual ~QuickMatchPreferences();
+	virtual ~QuickMatchPreferences() override;
 
 	void setMapSelected(const AsciiString& mapName, Bool selected);
 	Bool isMapSelected(const AsciiString& mapName);

--- a/GeneralsMD/Code/GameEngine/Include/Common/Recorder.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Recorder.h
@@ -61,11 +61,11 @@ public:
 
 public:
 	RecorderClass();																	///< Constructor.
-	virtual ~RecorderClass();													///< Destructor.
+	virtual ~RecorderClass() override;													///< Destructor.
 
-	void init();																			///< Initialize TheRecorder.
-	void reset();																			///< Reset the state of TheRecorder.
-	void update();																		///< General purpose update function.
+	virtual void init() override;																			///< Initialize TheRecorder.
+	virtual void reset() override;																			///< Reset the state of TheRecorder.
+	virtual void update() override;																		///< General purpose update function.
 
 	// Methods dealing with recording.
 	void updateRecord();															///< The update function for recording.

--- a/GeneralsMD/Code/GameEngine/Include/Common/ResourceGatheringManager.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/ResourceGatheringManager.h
@@ -56,9 +56,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	/// @todo Make sure the allocator for std::list<> is a good one.  Otherwise override it.

--- a/GeneralsMD/Code/GameEngine/Include/Common/Science.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Science.h
@@ -78,11 +78,11 @@ class ScienceStore : public SubsystemInterface
 	friend class ScienceInfo;
 
 public:
-	virtual ~ScienceStore();
+	virtual ~ScienceStore() override;
 
-	void init();
-	void reset();
-	void update() { }
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override { }
 
 	Bool isValidScience(ScienceType st) const;
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/ScoreKeeper.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/ScoreKeeper.h
@@ -99,9 +99,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/SkirmishBattleHonors.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/SkirmishBattleHonors.h
@@ -47,7 +47,7 @@ class SkirmishBattleHonors : public UserPreferences
 {
 public:
 	SkirmishBattleHonors();
-	virtual ~SkirmishBattleHonors();
+	virtual ~SkirmishBattleHonors() override;
 
 	Bool loadFromIniFile();
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/SkirmishPreferences.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/SkirmishPreferences.h
@@ -42,11 +42,11 @@ class SkirmishPreferences : public UserPreferences
 {
 public:
 	SkirmishPreferences();
-	virtual ~SkirmishPreferences();
+	virtual ~SkirmishPreferences() override;
 
 	Bool loadFromIniFile();
 
-	virtual Bool write();
+	virtual Bool write() override;
 	AsciiString getSlotList();
 	void setSlotList();
 	UnicodeString getUserName();		// convenience function

--- a/GeneralsMD/Code/GameEngine/Include/Common/SpecialPower.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/SpecialPower.h
@@ -157,7 +157,7 @@ class SpecialPowerStore : public SubsystemInterface
 public:
 
 	SpecialPowerStore();
-	~SpecialPowerStore() override;
+	virtual ~SpecialPowerStore() override;
 
 	virtual void init() override { };
 	virtual void update() override { };

--- a/GeneralsMD/Code/GameEngine/Include/Common/SpecialPower.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/SpecialPower.h
@@ -157,11 +157,11 @@ class SpecialPowerStore : public SubsystemInterface
 public:
 
 	SpecialPowerStore();
-	~SpecialPowerStore();
+	~SpecialPowerStore() override;
 
-	virtual void init() { };
-	virtual void update() { };
-	virtual void reset();
+	virtual void init() override { };
+	virtual void update() override { };
+	virtual void reset() override;
 
 	const SpecialPowerTemplate *findSpecialPowerTemplate( AsciiString name ) { return findSpecialPowerTemplatePrivate(name); }
 	const SpecialPowerTemplate *findSpecialPowerTemplateByID( UnsignedInt id );

--- a/GeneralsMD/Code/GameEngine/Include/Common/StateMachine.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/StateMachine.h
@@ -186,9 +186,9 @@ protected:
 	// Essentially all the member data gets set up on creation and shouldn't change.
 	// So none of it needs to be saved, and it nicely forces all user states to
 	// remember to implement crc, xfer & loadPostProcess.  jba
-	virtual void crc( Xfer *xfer )=0;
-	virtual void xfer( Xfer *xfer )=0;
-	virtual void loadPostProcess()=0;
+	virtual void crc( Xfer *xfer ) override =0;
+	virtual void xfer( Xfer *xfer ) override =0;
+	virtual void loadPostProcess() override =0;
 
 private:
 
@@ -336,9 +336,9 @@ public:
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 
@@ -404,13 +404,13 @@ class SuccessState : public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(SuccessState, "SuccessState")
 public:
 	SuccessState( StateMachine *machine ) : State( machine, "SuccessState") { }
-	virtual StateReturnType onEnter() { return STATE_SUCCESS; }
-	virtual StateReturnType update() { return STATE_SUCCESS; }
+	virtual StateReturnType onEnter() override { return STATE_SUCCESS; }
+	virtual StateReturnType update() override { return STATE_SUCCESS; }
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override{};
 
 };
 EMPTY_DTOR(SuccessState)
@@ -424,13 +424,13 @@ class FailureState : public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(FailureState, "FailureState")
 public:
 	FailureState( StateMachine *machine ) : State( machine, "FailureState") { }
-	virtual StateReturnType onEnter() { return STATE_FAILURE; }
-	virtual StateReturnType update() { return STATE_FAILURE; }
+	virtual StateReturnType onEnter() override { return STATE_FAILURE; }
+	virtual StateReturnType update() override { return STATE_FAILURE; }
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override{};
 };
 EMPTY_DTOR(FailureState)
 
@@ -444,13 +444,13 @@ class ContinueState :  public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(ContinueState, "ContinueState")
 public:
 	ContinueState( StateMachine *machine ) : State( machine, "ContinueState" ) { }
-	virtual StateReturnType onEnter() { return STATE_CONTINUE; }
-	virtual StateReturnType update() { return STATE_CONTINUE; }
+	virtual StateReturnType onEnter() override { return STATE_CONTINUE; }
+	virtual StateReturnType update() override { return STATE_CONTINUE; }
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override{};
 };
 EMPTY_DTOR(ContinueState)
 
@@ -464,13 +464,13 @@ class SleepState :  public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(SleepState, "SleepState")
 public:
 	SleepState( StateMachine *machine ) : State( machine, "SleepState" ) { }
-	virtual StateReturnType onEnter() { return STATE_SLEEP_FOREVER; }
-	virtual StateReturnType update() { return STATE_SLEEP_FOREVER; }
+	virtual StateReturnType onEnter() override { return STATE_SLEEP_FOREVER; }
+	virtual StateReturnType update() override { return STATE_SLEEP_FOREVER; }
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override{};
 };
 EMPTY_DTOR(SleepState)
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/StateMachine.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/StateMachine.h
@@ -186,9 +186,9 @@ protected:
 	// Essentially all the member data gets set up on creation and shouldn't change.
 	// So none of it needs to be saved, and it nicely forces all user states to
 	// remember to implement crc, xfer & loadPostProcess.  jba
-	virtual void crc( Xfer *xfer ) =0;
-	virtual void xfer( Xfer *xfer ) =0;
-	virtual void loadPostProcess() =0;
+	virtual void crc( Xfer *xfer )=0;
+	virtual void xfer( Xfer *xfer )=0;
+	virtual void loadPostProcess()=0;
 
 private:
 
@@ -408,9 +408,9 @@ public:
 	virtual StateReturnType update() override { return STATE_SUCCESS; }
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ) override{};
-	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess() override{};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 
 };
 EMPTY_DTOR(SuccessState)
@@ -428,9 +428,9 @@ public:
 	virtual StateReturnType update() override { return STATE_FAILURE; }
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ) override{};
-	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess() override{};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 };
 EMPTY_DTOR(FailureState)
 
@@ -448,9 +448,9 @@ public:
 	virtual StateReturnType update() override { return STATE_CONTINUE; }
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ) override{};
-	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess() override{};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 };
 EMPTY_DTOR(ContinueState)
 
@@ -468,9 +468,9 @@ public:
 	virtual StateReturnType update() override { return STATE_SLEEP_FOREVER; }
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ) override{};
-	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess() override{};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 };
 EMPTY_DTOR(SleepState)
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/StateMachine.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/StateMachine.h
@@ -186,9 +186,9 @@ protected:
 	// Essentially all the member data gets set up on creation and shouldn't change.
 	// So none of it needs to be saved, and it nicely forces all user states to
 	// remember to implement crc, xfer & loadPostProcess.  jba
-	virtual void crc( Xfer *xfer ) override =0;
-	virtual void xfer( Xfer *xfer ) override =0;
-	virtual void loadPostProcess() override =0;
+	virtual void crc( Xfer *xfer ) =0;
+	virtual void xfer( Xfer *xfer ) =0;
+	virtual void loadPostProcess() =0;
 
 private:
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/Team.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Team.h
@@ -60,9 +60,9 @@ public:
 
 protected:
 
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 };
 
@@ -168,9 +168,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 };
 
@@ -233,9 +233,9 @@ private:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 public:
 
@@ -635,9 +635,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 
@@ -680,12 +680,12 @@ class TeamFactory : public SubsystemInterface,
 public:
 
 	TeamFactory();
-	~TeamFactory();
+	virtual ~TeamFactory() override;
 
 	// subsystem methods
-	virtual void init();
-	virtual void reset();
-	virtual void update();
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override;
 
 	void clear();
 	void initFromSides(SidesList *sides);
@@ -727,9 +727,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/TerrainTypes.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/TerrainTypes.h
@@ -213,7 +213,7 @@ class TerrainTypeCollection : public SubsystemInterface
 public:
 
 	TerrainTypeCollection();
-	~TerrainTypeCollection() override;
+	virtual ~TerrainTypeCollection() override;
 
 	virtual void init() override { }
 	virtual void reset() override { }

--- a/GeneralsMD/Code/GameEngine/Include/Common/TerrainTypes.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/TerrainTypes.h
@@ -213,11 +213,11 @@ class TerrainTypeCollection : public SubsystemInterface
 public:
 
 	TerrainTypeCollection();
-	~TerrainTypeCollection();
+	~TerrainTypeCollection() override;
 
-	void init() { }
-	void reset() { }
-	void update() { }
+	virtual void init() override { }
+	virtual void reset() override { }
+	virtual void update() override { }
 
 	TerrainType *findTerrain( AsciiString name );		///< find terrain by name
 	TerrainType *newTerrain( AsciiString name );			///< allocate a new terrain

--- a/GeneralsMD/Code/GameEngine/Include/Common/ThingFactory.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/ThingFactory.h
@@ -54,13 +54,13 @@ class ThingFactory : public SubsystemInterface
 public:
 
 	ThingFactory();
-	virtual ~ThingFactory();
+	virtual ~ThingFactory() override;
 
 	// From the subsystem interface =================================================================
-	virtual void init();
-	virtual void postProcessLoad();
-	virtual void reset();
-	virtual void update();
+	virtual void init() override;
+	virtual void postProcessLoad() override;
+	virtual void reset() override;
+	virtual void update() override;
 	//===============================================================================================
 
 	/// create a new template with name 'name' and add to template list

--- a/GeneralsMD/Code/GameEngine/Include/Common/TunnelTracker.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/TunnelTracker.h
@@ -75,9 +75,9 @@ public:
 
 protected:
 
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	void updateFullHealTime();

--- a/GeneralsMD/Code/GameEngine/Include/Common/Upgrade.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Upgrade.h
@@ -131,9 +131,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	const UpgradeTemplate *m_template;	///< template this upgrade instance is based on
 	UpgradeStatusType m_status;							///< status of upgrade
@@ -231,11 +231,11 @@ class UpgradeCenter : public SubsystemInterface
 public:
 
 	UpgradeCenter();
-	virtual ~UpgradeCenter();
+	virtual ~UpgradeCenter() override;
 
-	void init();												///< subsystem interface
-	void reset();												///< subsystem interface
-	void update() { }										///< subsystem interface
+	void init() override;												///< subsystem interface
+	void reset() override;												///< subsystem interface
+	void update() override { }										///< subsystem interface
 
 	UpgradeTemplate *firstUpgradeTemplate(); ///< return the first upgrade template
 	const UpgradeTemplate *findUpgradeByKey( NameKeyType key ) const; ///< find upgrade by name key

--- a/GeneralsMD/Code/GameEngine/Include/Common/Upgrade.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Upgrade.h
@@ -233,9 +233,9 @@ public:
 	UpgradeCenter();
 	virtual ~UpgradeCenter() override;
 
-	void init() override;												///< subsystem interface
-	void reset() override;												///< subsystem interface
-	void update() override { }										///< subsystem interface
+	virtual void init() override;												///< subsystem interface
+	virtual void reset() override;												///< subsystem interface
+	virtual void update() override { }										///< subsystem interface
 
 	UpgradeTemplate *firstUpgradeTemplate(); ///< return the first upgrade template
 	const UpgradeTemplate *findUpgradeByKey( NameKeyType key ) const; ///< find upgrade by name key

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Anim2D.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Anim2D.h
@@ -167,9 +167,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer ) { }
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess() { }
+	virtual void crc( Xfer *xfer ) override { }
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override { }
 
 	void tryNextFrame();						///< we've just drawn ... try to update our frame if necessary
 
@@ -196,11 +196,11 @@ class Anim2DCollection : public SubsystemInterface
 public:
 
 	Anim2DCollection();
-	virtual ~Anim2DCollection();
+	virtual ~Anim2DCollection() override;
 
-	virtual void init();						///< initialize system
-	virtual void reset() { };				///< reset system
-	virtual void update();					///< update system
+	virtual void init() override;						///< initialize system
+	virtual void reset() override { };				///< reset system
+	virtual void update() override;					///< update system
 
 	Anim2DTemplate *findTemplate( const AsciiString& name );				///< find animation template
 	Anim2DTemplate *newTemplate( const AsciiString& name );				///< allocate a new template to be loaded

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/AnimateWindowManager.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/AnimateWindowManager.h
@@ -163,7 +163,7 @@ class AnimateWindowManager : public SubsystemInterface
 {
 public:
 	AnimateWindowManager();
-	~AnimateWindowManager() override;
+	virtual ~AnimateWindowManager() override;
 
 	// Inhertited from subsystem ====================================================================
 	virtual void init() override;

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/AnimateWindowManager.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/AnimateWindowManager.h
@@ -163,12 +163,12 @@ class AnimateWindowManager : public SubsystemInterface
 {
 public:
 	AnimateWindowManager();
-	~AnimateWindowManager();
+	~AnimateWindowManager() override;
 
 	// Inhertited from subsystem ====================================================================
-	virtual void init();
-	virtual void reset();
-	virtual void update();
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override;
 	//===============================================================================================
 
 	void registerGameWindow(GameWindow *win, AnimTypes animType, Bool needsToFinish, UnsignedInt ms = 0, UnsignedInt delayMs = 0);			// Registers a new window to animate.

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/CampaignManager.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/CampaignManager.h
@@ -118,9 +118,9 @@ public:
 	~CampaignManager();
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer ) { }
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override { }
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	void init();
 	Campaign *getCurrentCampaign();		///< Returns a point to the current Campaign

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/CommandXlat.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/CommandXlat.h
@@ -37,7 +37,7 @@ class CommandTranslator : public GameMessageTranslator
 public:
 
 	CommandTranslator();
-	~CommandTranslator();
+	virtual ~CommandTranslator() override;
 
 	enum CommandEvaluateType { DO_COMMAND, DO_HINT, EVALUATE_ONLY };
 
@@ -65,7 +65,7 @@ private:
 	GameMessage::Type issueFireWeaponCommand( const CommandButton *command, CommandEvaluateType commandType, Drawable *target, const Coord3D *pos );
 	GameMessage::Type issueCombatDropCommand( const CommandButton *command, CommandEvaluateType commandType, Drawable *target, const Coord3D *pos );
 
-	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg);
+	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg) override;
 };
 
 

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/ControlBar.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/ControlBar.h
@@ -646,11 +646,11 @@ class ControlBar : public SubsystemInterface
 public:
 
 	ControlBar();
-	virtual ~ControlBar();
+	virtual ~ControlBar() override;
 
-	virtual void init();					///< from subsystem interface
-	virtual void reset();					///< from subsystem interface
-	virtual void update();				///< from subsystem interface
+	virtual void init() override;					///< from subsystem interface
+	virtual void reset() override;					///< from subsystem interface
+	virtual void update() override;				///< from subsystem interface
 
 	/// mark the UI as dirty so the context of everything is re-evaluated
 	void markUIDirty();

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/DebugDisplay.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/DebugDisplay.h
@@ -110,18 +110,18 @@ class DebugDisplay : public DebugDisplayInterface
 	public:
 
 		DebugDisplay();
-		virtual ~DebugDisplay() {};
+		virtual ~DebugDisplay() override {};
 
-		virtual void	printf( const Char *format, ...);			///< Print formatted text at current cursor position
-		virtual void	setCursorPos( Int x, Int y );		///< Set new cursor position
-		virtual Int		getCursorXPos();					///< Get current X position of cursor
-		virtual Int		getCursorYPos();					///< Get current Y position of cursor
-		virtual Int		getWidth();								///< Get character width of display
-		virtual Int		getHeight();							///< Get character height of display
-		virtual void	setTextColor( Color color );		///< set text color
-		virtual void	setRightMargin( Int rightPos );	///< set right margin position
-		virtual void	setLeftMargin( Int leftPos );		///< set left margin position
-		virtual void	reset();									///< Reset back to default settings
+		virtual void	printf( const Char *format, ...) override;			///< Print formatted text at current cursor position
+		virtual void	setCursorPos( Int x, Int y ) override;		///< Set new cursor position
+		virtual Int		getCursorXPos() override;					///< Get current X position of cursor
+		virtual Int		getCursorYPos() override;					///< Get current Y position of cursor
+		virtual Int		getWidth() override;								///< Get character width of display
+		virtual Int		getHeight() override;							///< Get character height of display
+		virtual void	setTextColor( Color color ) override;		///< set text color
+		virtual void	setRightMargin( Int rightPos ) override;	///< set right margin position
+		virtual void	setLeftMargin( Int leftPos ) override;		///< set left margin position
+		virtual void	reset() override;									///< Reset back to default settings
 
 	protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Display.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Display.h
@@ -64,11 +64,11 @@ public:
 	typedef void (DebugDisplayCallback)( DebugDisplayInterface *debugDisplay, void *userData, FILE *fp );
 
 	Display();
-	virtual ~Display();
+	virtual ~Display() override;
 
-	virtual void init() { };																///< Initialize
-	virtual void reset();																		///< Reset system
-	virtual void update();																	///< Update system
+	virtual void init() override { };																///< Initialize
+	virtual void reset() override;																		///< Reset system
+	virtual void update() override;																	///< Update system
 
 	//---------------------------------------------------------------------------------------
 	// Display attribute methods
@@ -114,7 +114,7 @@ public:
 	virtual	void enableClipping( Bool onoff ) = 0;
 
 	virtual void step() {}; ///< Do one fixed time step
-	virtual void draw();																		///< Redraw the entire display
+	virtual void draw() override;																		///< Redraw the entire display
 	virtual void setTimeOfDay( TimeOfDay tod ) = 0;								///< Set the time of day for this display
 	virtual void createLightPulse( const Coord3D *pos, const RGBColor *color, Real innerRadius,Real attenuationWidth,
 																 UnsignedInt increaseFrameTime, UnsignedInt decayFrameTime//, Bool donut = FALSE

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Drawable.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Drawable.h
@@ -181,9 +181,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 
@@ -595,15 +595,15 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 	void xferDrawableModules( Xfer *xfer );
 
 	void	startAmbientSound( BodyDamageType dt, TimeOfDay tod, Bool onlyIfPermanent = false );
 
-	Drawable *asDrawableMeth() { return this; }
-	const Drawable *asDrawableMeth() const { return this; }
+	virtual Drawable *asDrawableMeth() override { return this; }
+	virtual const Drawable *asDrawableMeth() const override { return this; }
 
 	Module** getModuleList(ModuleType i)
 	{
@@ -644,7 +644,7 @@ protected:
 	void validatePos() const;
 #endif
 
-	virtual void reactToTransformChange(const Matrix3D* oldMtx, const Coord3D* oldPos, Real oldAngle);
+	virtual void reactToTransformChange(const Matrix3D* oldMtx, const Coord3D* oldPos, Real oldAngle) override;
 	void updateHiddenStatus();
 
 	void replaceModelConditionStateInDrawable();

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Drawable.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Drawable.h
@@ -535,10 +535,10 @@ public:
 
 	TerrainDecalType getTerrainDecalType() const { return m_terrainDecalType; }
 
-	virtual void setDrawableOpacity( Real value ) { m_explicitOpacity = value; }	///< set alpha/opacity value used to override defaults when drawing.
+	void setDrawableOpacity( Real value ) { m_explicitOpacity = value; }	///< set alpha/opacity value used to override defaults when drawing.
 
 	// note that this is not the 'get' inverse of setDrawableOpacity, since stealthing can also affect the effective opacity!
-	virtual Real getEffectiveOpacity() const { return m_explicitOpacity * m_effectiveStealthOpacity; }		///< get alpha/opacity value used to override defaults when drawing.
+	Real getEffectiveOpacity() const { return m_explicitOpacity * m_effectiveStealthOpacity; }		///< get alpha/opacity value used to override defaults when drawing.
 	void setEffectiveOpacity( Real pulseFactor, Real explicitOpacity = -1.0f );
 
 	// this is for the add'l pass fx which operates completely independently of the stealth opacity effects. Draw() does the fading every frame.

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Drawable.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Drawable.h
@@ -535,10 +535,10 @@ public:
 
 	TerrainDecalType getTerrainDecalType() const { return m_terrainDecalType; }
 
-	void setDrawableOpacity( Real value ) { m_explicitOpacity = value; }	///< set alpha/opacity value used to override defaults when drawing.
+	virtual void setDrawableOpacity( Real value ) { m_explicitOpacity = value; }	///< set alpha/opacity value used to override defaults when drawing.
 
 	// note that this is not the 'get' inverse of setDrawableOpacity, since stealthing can also affect the effective opacity!
-	Real getEffectiveOpacity() const { return m_explicitOpacity * m_effectiveStealthOpacity; }		///< get alpha/opacity value used to override defaults when drawing.
+	virtual Real getEffectiveOpacity() const { return m_explicitOpacity * m_effectiveStealthOpacity; }		///< get alpha/opacity value used to override defaults when drawing.
 	void setEffectiveOpacity( Real pulseFactor, Real explicitOpacity = -1.0f );
 
 	// this is for the add'l pass fx which operates completely independently of the stealth opacity effects. Draw() does the fading every frame.

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Eva.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Eva.h
@@ -178,12 +178,12 @@ class Eva : public SubsystemInterface
 
 	public:
 		Eva();
-		virtual ~Eva();
+		virtual ~Eva() override;
 
 	public:		// From SubsystemInterface
-		virtual void init();
-		virtual void reset();
-		virtual void update();
+		virtual void init() override;
+		virtual void reset() override;
+		virtual void update() override;
 
 		static EvaMessage nameToMessage(const AsciiString& name);
 		static AsciiString messageToName(EvaMessage message);

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/GUICommandTranslator.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/GUICommandTranslator.h
@@ -42,7 +42,7 @@ class GUICommandTranslator : public GameMessageTranslator
 public:
 
 	GUICommandTranslator();
-	~GUICommandTranslator();
+	~GUICommandTranslator() override;
 
-	virtual GameMessageDisposition translateGameMessage( const GameMessage *msg );
+	virtual GameMessageDisposition translateGameMessage( const GameMessage *msg ) override;
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/GUICommandTranslator.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/GUICommandTranslator.h
@@ -42,7 +42,7 @@ class GUICommandTranslator : public GameMessageTranslator
 public:
 
 	GUICommandTranslator();
-	~GUICommandTranslator() override;
+	virtual ~GUICommandTranslator() override;
 
 	virtual GameMessageDisposition translateGameMessage( const GameMessage *msg ) override;
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/GameClient.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/GameClient.h
@@ -69,8 +69,8 @@ typedef std::vector<Drawable*> DrawablePtrVector;
 class GameClientMessageDispatcher : public GameMessageTranslator
 {
 public:
-	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg);
-	virtual ~GameClientMessageDispatcher() { }
+	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg) override;
+	virtual ~GameClientMessageDispatcher() override { }
 };
 
 
@@ -86,12 +86,12 @@ class GameClient : public SubsystemInterface,
 public:
 
 	GameClient();
-	virtual ~GameClient();
+	virtual ~GameClient() override;
 
 	// subsystem methods
-	virtual void init();																					///< Initialize resources
-	virtual void update();																				///< Updates the GUI, display, audio, etc
-	virtual void reset();																					///< reset system
+	virtual void init() override;																					///< Initialize resources
+	virtual void update() override;																				///< Updates the GUI, display, audio, etc
+	virtual void reset() override;																					///< reset system
 
 	virtual void setFrame( UnsignedInt frame ) { m_frame = frame; }			///< Set the GameClient's internal frame number
 	virtual void registerDrawable( Drawable *draw );										///< Given a drawable, register it with the GameClient and give it a unique ID
@@ -159,9 +159,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	// @todo Should there be a separate GameClient frame counter?
 	UnsignedInt m_frame;																				///< Simulation frame number from server

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/GameWindowManager.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/GameWindowManager.h
@@ -77,12 +77,12 @@ friend class GameWindow;
 public:
 
 	GameWindowManager();
-	virtual ~GameWindowManager();
+	virtual ~GameWindowManager() override;
 
 	//-----------------------------------------------------------------------------------------------
-	virtual void init();		///< initialize function
-	virtual void reset();		///< reset the system
-	virtual void update();  ///< update method, called once per frame
+	virtual void init() override;		///< initialize function
+	virtual void reset() override;		///< reset the system
+	virtual void update() override;  ///< update method, called once per frame
 
 	virtual GameWindow *allocateNewWindow() = 0;  ///< new game window
 
@@ -384,31 +384,31 @@ extern WindowMsgHandledType PassMessagesToParentSystem( GameWindow *window,
 class GameWindowManagerDummy : public GameWindowManager
 {
 public:
-	virtual GameWindow *winGetWindowFromId(GameWindow *window, Int id);
-	virtual GameWindow *winCreateFromScript(AsciiString filenameString, WindowLayoutInfo *info);
+	virtual GameWindow *winGetWindowFromId(GameWindow *window, Int id) override;
+	virtual GameWindow *winCreateFromScript(AsciiString filenameString, WindowLayoutInfo *info) override;
 
-	virtual GameWindow *allocateNewWindow() { return newInstance(GameWindowDummy); }
+	virtual GameWindow *allocateNewWindow() override { return newInstance(GameWindowDummy); }
 
-	virtual GameWinDrawFunc getPushButtonImageDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getPushButtonDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getCheckBoxImageDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getCheckBoxDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getRadioButtonImageDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getRadioButtonDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getTabControlImageDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getTabControlDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getListBoxImageDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getListBoxDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getComboBoxImageDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getComboBoxDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getHorizontalSliderImageDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getHorizontalSliderDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getVerticalSliderImageDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getVerticalSliderDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getProgressBarImageDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getProgressBarDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getStaticTextImageDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getStaticTextDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getTextEntryImageDrawFunc() { return nullptr; }
-	virtual GameWinDrawFunc getTextEntryDrawFunc() { return nullptr; }
+	virtual GameWinDrawFunc getPushButtonImageDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getPushButtonDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getCheckBoxImageDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getCheckBoxDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getRadioButtonImageDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getRadioButtonDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getTabControlImageDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getTabControlDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getListBoxImageDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getListBoxDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getComboBoxImageDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getComboBoxDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getHorizontalSliderImageDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getHorizontalSliderDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getVerticalSliderImageDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getVerticalSliderDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getProgressBarImageDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getProgressBarDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getStaticTextImageDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getStaticTextDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getTextEntryImageDrawFunc() override { return nullptr; }
+	virtual GameWinDrawFunc getTextEntryDrawFunc() override { return nullptr; }
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/HintSpy.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/HintSpy.h
@@ -33,6 +33,6 @@
 class HintSpyTranslator : public GameMessageTranslator
 {
 public:
-	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg);
-	virtual ~HintSpyTranslator() { }
+	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg) override;
+	virtual ~HintSpyTranslator() override { }
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/HotKey.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/HotKey.h
@@ -85,7 +85,7 @@ class HotKeyManager : public SubsystemInterface
 {
 public:
 	HotKeyManager();
-	~HotKeyManager() override;
+	virtual ~HotKeyManager() override;
 	// Inherited from subsystem interface -----------------------------------------------------------
 	virtual	void init() override;															///< Initialize the Hotkey system
 	virtual void update() override {}														///< A No-op for us

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/HotKey.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/HotKey.h
@@ -66,8 +66,8 @@ class GameWindow;
 class HotKeyTranslator : public GameMessageTranslator
 {
 public:
-	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg);
-	virtual ~HotKeyTranslator() { }
+	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg) override;
+	virtual ~HotKeyTranslator() override { }
 };
 
 //-----------------------------------------------------------------------------
@@ -85,11 +85,11 @@ class HotKeyManager : public SubsystemInterface
 {
 public:
 	HotKeyManager();
-	~HotKeyManager();
+	~HotKeyManager() override;
 	// Inherited from subsystem interface -----------------------------------------------------------
-	virtual	void init();															///< Initialize the Hotkey system
-	virtual void update() {}														///< A No-op for us
-	virtual void reset();															///< Reset
+	virtual	void init() override;															///< Initialize the Hotkey system
+	virtual void update() override {}														///< A No-op for us
+	virtual void reset() override;															///< Reset
 	//-----------------------------------------------------------------------------------------------
 
 	void addHotKey( GameWindow *win, const AsciiString& key);

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Image.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Image.h
@@ -121,11 +121,11 @@ class ImageCollection : public SubsystemInterface
 public:
 
 	ImageCollection();
-	virtual ~ImageCollection();
+	virtual ~ImageCollection() override;
 
-	virtual void init() { };				///< initialize system
-	virtual void reset() { };				///< reset system
-	virtual void update() { };			///< update system
+	virtual void init() override { };				///< initialize system
+	virtual void reset() override { };				///< reset system
+	virtual void update() override { };			///< update system
 
 	void load( Int textureSize );												 ///< load images
 

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -362,12 +362,12 @@ public:  // ********************************************************************
 	};
 
 	InGameUI();
-	virtual ~InGameUI();
+	virtual ~InGameUI() override;
 
 	// Inherited from subsystem interface -----------------------------------------------------------
-	virtual	void init();															///< Initialize the in-game user interface
-	virtual void update();														///< Update the UI by calling preDraw(), draw(), and postDraw()
-	virtual void reset();															///< Reset
+	virtual	void init() override;															///< Initialize the in-game user interface
+	virtual void update() override;														///< Update the UI by calling preDraw(), draw(), and postDraw()
+	virtual void reset() override;															///< Reset
 	//-----------------------------------------------------------------------------------------------
 
 	// interface for the popup messages
@@ -470,7 +470,7 @@ public:  // ********************************************************************
 	virtual void disregardDrawable( Drawable *draw );				///< Drawable is being destroyed, clean up any UI elements associated with it
 
 	virtual void preDraw();														///< Logic which needs to occur before the UI renders
-	virtual void draw() = 0;													///< Render the in-game user interface
+	virtual void draw() override = 0;													///< Render the in-game user interface
 	virtual void postDraw();													///< Logic which needs to occur after the UI renders
 	virtual void postWindowDraw();											///< Logic which needs to occur after the WindowManager has repainted the menus
 
@@ -620,9 +620,9 @@ public:
 
 protected:
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -470,7 +470,7 @@ public:  // ********************************************************************
 	virtual void disregardDrawable( Drawable *draw );				///< Drawable is being destroyed, clean up any UI elements associated with it
 
 	virtual void preDraw();														///< Logic which needs to occur before the UI renders
-	virtual void draw() override = 0;													///< Render the in-game user interface
+	virtual void draw() = 0;													///< Render the in-game user interface
 	virtual void postDraw();													///< Logic which needs to occur after the UI renders
 	virtual void postWindowDraw();											///< Logic which needs to occur after the WindowManager has repainted the menus
 

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/LookAtXlat.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/LookAtXlat.h
@@ -46,9 +46,9 @@ class LookAtTranslator : public GameMessageTranslator
 {
 public:
 	LookAtTranslator();
-	~LookAtTranslator();
+	virtual ~LookAtTranslator() override;
 
-	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg);
+	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg) override;
 	virtual const ICoord2D* getRMBScrollAnchor(); // get m_anchor ICoord2D if we're RMB scrolling
 	Bool hasMouseMovedRecently();
 	void setCurrentPos( const ICoord2D& pos );

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/MetaEvent.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/MetaEvent.h
@@ -364,8 +364,8 @@ private:
 
 public:
 	MetaEventTranslator();
-	~MetaEventTranslator();
-	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg);
+	virtual ~MetaEventTranslator() override;
+	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg) override;
 };
 
 //-----------------------------------------------------------------------------
@@ -383,11 +383,11 @@ protected:
 public:
 
 	MetaMap();
-	~MetaMap();
+	virtual ~MetaMap() override;
 
-	void init() { }
-	void reset() { }
-	void update() { }
+	virtual void init() override { }
+	virtual void reset() override { }
+	virtual void update() override { }
 
 	static void parseMetaMap(INI* ini);
 

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Module/AnimatedParticleSysBoneClientUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Module/AnimatedParticleSysBoneClientUpdate.h
@@ -47,7 +47,7 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	/// the client update callback
-	virtual void clientUpdate();
+	virtual void clientUpdate() override;
 
 
 protected:

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Module/BeaconClientUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Module/BeaconClientUpdate.h
@@ -44,7 +44,7 @@ public:
 	UnsignedInt m_radarPulseDuration;
 
 	BeaconClientUpdateModuleData();
-	~BeaconClientUpdateModuleData();
+	virtual ~BeaconClientUpdateModuleData() override;
 	static void buildFieldParse(MultiIniFieldParse& p);
 };
 
@@ -63,7 +63,7 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	/// the client update callback
-	virtual void clientUpdate();
+	virtual void clientUpdate() override;
 	void hideBeacon();
 
 protected:

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Module/SwayClientUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Module/SwayClientUpdate.h
@@ -50,7 +50,7 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	/// the client update callback
-	virtual void clientUpdate();
+	virtual void clientUpdate() override;
 
 	void stopSway() { m_swaying = false; }
 

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/PlaceEventTranslator.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/PlaceEventTranslator.h
@@ -37,6 +37,6 @@ private:
 
 public:
 	PlaceEventTranslator();
-	~PlaceEventTranslator();
-	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg);
+	virtual ~PlaceEventTranslator() override;
+	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg) override;
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/RayEffect.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/RayEffect.h
@@ -57,7 +57,7 @@ class RayEffectSystem : public SubsystemInterface
 public:
 
 	RayEffectSystem();
-	~RayEffectSystem() override;
+	virtual ~RayEffectSystem() override;
 
 	virtual void init() override;
 	virtual void reset() override;

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/RayEffect.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/RayEffect.h
@@ -57,11 +57,11 @@ class RayEffectSystem : public SubsystemInterface
 public:
 
 	RayEffectSystem();
-	~RayEffectSystem();
+	~RayEffectSystem() override;
 
-	virtual void init();
-	virtual void reset();
-	virtual void update() { }
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override { }
 
 	/// add a ray effect entry for this drawable
 	void addRayEffect( const Drawable *draw, const Coord3D *startLoc, const Coord3D *endLoc );

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/SelectionXlat.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/SelectionXlat.h
@@ -62,8 +62,8 @@ private:
 
 public:
 	SelectionTranslator();
-	~SelectionTranslator();
-	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg);
+	virtual ~SelectionTranslator() override;
+	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg) override;
 	//added for fix to the drag selection when entering control bar
 	//changes the mode of drag selecting to it's opposite
 	void setDragSelecting(Bool dragSelect);

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Shell.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Shell.h
@@ -114,12 +114,12 @@ class Shell : public SubsystemInterface
 public:
 
 	Shell();
-	~Shell();
+	~Shell() override;
 
 	// Inhertited from subsystem ====================================================================
-	virtual void init();
-	virtual void reset();
-	virtual void update();
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override;
 	//===============================================================================================
 
 	void recreateWindowLayouts();

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Shell.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Shell.h
@@ -114,7 +114,7 @@ class Shell : public SubsystemInterface
 public:
 
 	Shell();
-	~Shell() override;
+	virtual ~Shell() override;
 
 	// Inhertited from subsystem ====================================================================
 	virtual void init() override;

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/WindowXlat.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/WindowXlat.h
@@ -36,6 +36,6 @@ private:
 	// nothing
 public:
 	WindowTranslator();
-	~WindowTranslator();
-	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg);
+	virtual ~WindowTranslator() override;
+	virtual GameMessageDisposition translateGameMessage(const GameMessage *msg) override;
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
@@ -147,9 +147,9 @@ public:
 	void addFactionBuildList(AISideBuildList *buildList);
 
 	// --------------- inherited from Snapshot interface --------------
-	void crc( Xfer *xfer ) override;
-	void xfer( Xfer *xfer ) override;
-	void loadPostProcess() override;
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	Real m_structureSeconds;		// Try to build a structure every N seconds.
 	Real m_teamSeconds;					// Try to build a team every N seconds.
@@ -247,7 +247,7 @@ class AI : public SubsystemInterface, public Snapshot
 {
 public:
 	AI();
-	~AI() override;
+	virtual ~AI() override;
 
 	virtual void init() override;						///< initialize AI to default values
 	virtual void reset() override;						///< reset the AI system to prepare for a new map
@@ -271,9 +271,9 @@ public:
 	Object *findClosestAlly( const Object *me, Real range, UnsignedInt qualifiers);
 
 	// --------------- inherited from Snapshot interface --------------
-	void crc( Xfer *xfer ) override;
-	void xfer( Xfer *xfer ) override;
-	void loadPostProcess() override;
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	// AI Groups -----------------------------------------------------------------------------------------------
 	AIGroupPtr createGroup(); ///< instantiate a new AI Group
@@ -891,9 +891,9 @@ private:
 public:
 
 	// --------------- inherited from Snapshot interface --------------
-	void crc( Xfer *xfer ) override;
-	void xfer( Xfer *xfer ) override;
-	void loadPostProcess() override;
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 #if !RETAIL_COMPATIBLE_AIGROUP
 	void Add_Ref() const { m_refCount.Add_Ref(); }

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
@@ -147,9 +147,9 @@ public:
 	void addFactionBuildList(AISideBuildList *buildList);
 
 	// --------------- inherited from Snapshot interface --------------
-	void crc( Xfer *xfer );
-	void xfer( Xfer *xfer );
-	void loadPostProcess();
+	void crc( Xfer *xfer ) override;
+	void xfer( Xfer *xfer ) override;
+	void loadPostProcess() override;
 
 	Real m_structureSeconds;		// Try to build a structure every N seconds.
 	Real m_teamSeconds;					// Try to build a team every N seconds.
@@ -247,11 +247,11 @@ class AI : public SubsystemInterface, public Snapshot
 {
 public:
 	AI();
-	~AI();
+	~AI() override;
 
-	virtual void init();						///< initialize AI to default values
-	virtual void reset();						///< reset the AI system to prepare for a new map
-	virtual void update();					///< do one frame of AI computation
+	virtual void init() override;						///< initialize AI to default values
+	virtual void reset() override;						///< reset the AI system to prepare for a new map
+	virtual void update() override;					///< do one frame of AI computation
 
 	Pathfinder *pathfinder() { return m_pathfinder; }	///< public access to the pathfind system
 	enum
@@ -271,9 +271,9 @@ public:
 	Object *findClosestAlly( const Object *me, Real range, UnsignedInt qualifiers);
 
 	// --------------- inherited from Snapshot interface --------------
-	void crc( Xfer *xfer );
-	void xfer( Xfer *xfer );
-	void loadPostProcess();
+	void crc( Xfer *xfer ) override;
+	void xfer( Xfer *xfer ) override;
+	void loadPostProcess() override;
 
 	// AI Groups -----------------------------------------------------------------------------------------------
 	AIGroupPtr createGroup(); ///< instantiate a new AI Group
@@ -891,9 +891,9 @@ private:
 public:
 
 	// --------------- inherited from Snapshot interface --------------
-	void crc( Xfer *xfer );
-	void xfer( Xfer *xfer );
-	void loadPostProcess();
+	void crc( Xfer *xfer ) override;
+	void xfer( Xfer *xfer ) override;
+	void loadPostProcess() override;
 
 #if !RETAIL_COMPATIBLE_AIGROUP
 	void Add_Ref() const { m_refCount.Add_Ref(); }

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AIDock.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AIDock.h
@@ -62,15 +62,15 @@ public:
 	AIDockMachine( Object *owner );
 
 	static Bool ableToAdvance( State *thisState, void* userData ); // Condition for scooting forward in line while waiting
-	virtual void halt(); ///< Stops the state machine & disables it in preparation for deleting it.
+	virtual void halt() override; ///< Stops the state machine & disables it in preparation for deleting it.
 
 	Int m_approachPosition;	///< The Approach Position I am holding, to make scoot forward checks quicker.
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 };
 
@@ -82,14 +82,14 @@ class AIDockApproachState : public AIInternalMoveToState
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIDockApproachState, "AIDockApproachState")
 public:
 	AIDockApproachState( StateMachine *machine ) : AIInternalMoveToState( machine, "AIDockApproachState" ) { }
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override{};
 };
 EMPTY_DTOR(AIDockApproachState)
 
@@ -99,16 +99,16 @@ class AIDockWaitForClearanceState : public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIDockWaitForClearanceState, "AIDockWaitForClearanceState")
 public:
 	AIDockWaitForClearanceState( StateMachine *machine ) : State( machine, "AIDockWaitForClearanceState" ), m_enterFrame(0) { }
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
 	UnsignedInt m_enterFrame;
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override{};
 };
 EMPTY_DTOR(AIDockWaitForClearanceState)
 
@@ -118,9 +118,9 @@ class AIDockAdvancePositionState : public AIInternalMoveToState
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIDockAdvancePositionState, "AIDockAdvancePositionState")
 public:
 	AIDockAdvancePositionState( StateMachine *machine ) : AIInternalMoveToState( machine, "AIDockApproachState" ) { }
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 };
 EMPTY_DTOR(AIDockAdvancePositionState)
 
@@ -130,9 +130,9 @@ class AIDockMoveToEntryState : public AIInternalMoveToState
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIDockMoveToEntryState, "AIDockMoveToEntryState")
 public:
 	AIDockMoveToEntryState( StateMachine *machine ) : AIInternalMoveToState( machine, "AIDockMoveToEntryState" ) { }
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 };
 EMPTY_DTOR(AIDockMoveToEntryState)
 
@@ -142,9 +142,9 @@ class AIDockMoveToDockState : public AIInternalMoveToState
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIDockMoveToDockState, "AIDockMoveToDockState")
 public:
 	AIDockMoveToDockState( StateMachine *machine ) : AIInternalMoveToState( machine, "AIDockMoveToDockState" ) { }
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 };
 EMPTY_DTOR(AIDockMoveToDockState)
 
@@ -154,9 +154,9 @@ class AIDockMoveToRallyState : public AIInternalMoveToState
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIDockMoveToRallyState, "AIDockMoveToRallyState")
 public:
 	AIDockMoveToRallyState( StateMachine *machine ) : AIInternalMoveToState( machine, "AIDockMoveToRallyState" ) { }
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 };
 EMPTY_DTOR(AIDockMoveToRallyState)
 
@@ -166,9 +166,9 @@ class AIDockProcessDockState : public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIDockProcessDockState, "AIDockProcessDockState")
 public:
 	AIDockProcessDockState( StateMachine *machine );
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 
 	void setNextDockActionFrame();//This puts a delay between callings of Action to tweak the speed of docking.
 	UnsignedInt m_nextDockActionFrame;// In the unlikely event of saving a game in the middle of docking, you may
@@ -177,9 +177,9 @@ public:
 
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override{};
 
 private:
 	ObjectID m_droneID;			///< If I have a drone, the drone will get repaired too.
@@ -193,9 +193,9 @@ class AIDockMoveToExitState : public AIInternalMoveToState
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIDockMoveToExitState, "AIDockMoveToExitState")
 public:
 	AIDockMoveToExitState( StateMachine *machine ) : AIInternalMoveToState( machine, "AIDockMoveToExitState" ) { }
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 };
 EMPTY_DTOR(AIDockMoveToExitState)
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AIDock.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AIDock.h
@@ -87,9 +87,9 @@ public:
 	virtual StateReturnType update() override;
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ) override{};
+	virtual void crc( Xfer *xfer ) override {};
 	virtual void xfer( Xfer *xfer ) override;
-	virtual void loadPostProcess() override{};
+	virtual void loadPostProcess() override {};
 };
 EMPTY_DTOR(AIDockApproachState)
 
@@ -106,9 +106,9 @@ protected:
 	UnsignedInt m_enterFrame;
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ) override{};
+	virtual void crc( Xfer *xfer ) override {};
 	virtual void xfer( Xfer *xfer ) override;
-	virtual void loadPostProcess() override{};
+	virtual void loadPostProcess() override {};
 };
 EMPTY_DTOR(AIDockWaitForClearanceState)
 
@@ -177,9 +177,9 @@ public:
 
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ) override{};
-	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess() override{};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 
 private:
 	ObjectID m_droneID;			///< If I have a drone, the drone will get repaired too.

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AIGuard.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AIGuard.h
@@ -81,7 +81,7 @@ public:
 		m_center.zero();
 	}
 
-	virtual Bool shouldExit(const StateMachine* machine) const;
+	virtual Bool shouldExit(const StateMachine* machine) const override;
 };
 
 
@@ -101,9 +101,9 @@ private:
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 public:
 	/**
@@ -141,15 +141,15 @@ public:
 		m_attackState = nullptr;
 		m_enterState = nullptr;
 	}
-	virtual Bool isAttack() const { return m_attackState ? m_attackState->isAttack() : FALSE; }
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual Bool isAttack() const override { return m_attackState ? m_attackState->isAttack() : FALSE; }
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 private:
 	AIGuardMachine* getGuardMachine() { return (AIGuardMachine*)getMachine(); }
 
@@ -164,16 +164,16 @@ class AIGuardIdleState : public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIGuardIdleState, "AIGuardIdleState")
 public:
 	AIGuardIdleState( StateMachine *machine ) : State( machine, "AIGuardIdleState" ) { }
-	virtual Bool isAttack() const { return FALSE; }
-	virtual Bool isGuardIdle() const { return TRUE; }
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual Bool isAttack() const override { return FALSE; }
+	virtual Bool isGuardIdle() const override { return TRUE; }
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 private:
 	AIGuardMachine* getGuardMachine() { return (AIGuardMachine*)getMachine(); }
 
@@ -191,15 +191,15 @@ public:
 	{
 		m_attackState = nullptr;
 	}
-	virtual Bool isAttack() const { return m_attackState ? m_attackState->isAttack() : FALSE; }
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual Bool isAttack() const override { return m_attackState ? m_attackState->isAttack() : FALSE; }
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 private:
 	AIGuardMachine* getGuardMachine() { return (AIGuardMachine*)getMachine(); }
 
@@ -218,15 +218,15 @@ public:
 	{
 		m_nextReturnScanTime = 0;
 	}
-	virtual Bool isAttack() const { return FALSE; }
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual Bool isAttack() const override { return FALSE; }
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 private:
 	UnsignedInt m_nextReturnScanTime;
 };
@@ -239,10 +239,10 @@ class AIGuardPickUpCrateState : public AIPickUpCrateState
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIGuardPickUpCrateState, "AIGuardPickUpCrateState")
 public:
 	AIGuardPickUpCrateState( StateMachine *machine );
-	virtual Bool isAttack() const { return FALSE; }
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual Bool isAttack() const override { return FALSE; }
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 };
 EMPTY_DTOR(AIGuardPickUpCrateState)
 
@@ -252,15 +252,15 @@ class AIGuardAttackAggressorState : public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIGuardAttackAggressorState, "AIGuardAttackAggressorState")
 public:
 	AIGuardAttackAggressorState( StateMachine *machine );
-	virtual Bool isAttack() const { return m_attackState ? m_attackState->isAttack() : FALSE; }
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual Bool isAttack() const override { return m_attackState ? m_attackState->isAttack() : FALSE; }
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 private:
 	AIGuardMachine* getGuardMachine() { return (AIGuardMachine*)getMachine(); }
 	ExitConditions m_exitConditions;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AIGuardRetaliate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AIGuardRetaliate.h
@@ -79,7 +79,7 @@ public:
 		m_center.zero();
 	}
 
-	virtual Bool shouldExit(const StateMachine* machine) const;
+	virtual Bool shouldExit(const StateMachine* machine) const override;
 };
 
 
@@ -96,9 +96,9 @@ private:
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 public:
 	/**
@@ -130,14 +130,14 @@ public:
 		m_attackState = 0;
 		m_enterState = 0;
 	}
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 private:
 	AIGuardRetaliateMachine* getGuardMachine() { return (AIGuardRetaliateMachine*)getMachine(); }
 
@@ -152,14 +152,14 @@ class AIGuardRetaliateIdleState : public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIGuardRetaliateIdleState, "AIGuardRetaliateIdleState")
 public:
 	AIGuardRetaliateIdleState( StateMachine *machine ) : State( machine, "AIGuardRetaliateIdleState" ) { }
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 private:
 	AIGuardRetaliateMachine* getGuardMachine() { return (AIGuardRetaliateMachine*)getMachine(); }
 
@@ -177,14 +177,14 @@ public:
 	{
 		m_attackState = nullptr;
 	}
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 private:
 	AIGuardRetaliateMachine* getGuardMachine() { return (AIGuardRetaliateMachine*)getMachine(); }
 
@@ -203,14 +203,14 @@ public:
 	{
 		m_nextReturnScanTime = 0;
 	}
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 private:
 	UnsignedInt m_nextReturnScanTime;
 };
@@ -223,9 +223,9 @@ class AIGuardRetaliatePickUpCrateState : public AIPickUpCrateState
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIGuardRetaliatePickUpCrateState, "AIGuardRetaliatePickUpCrateState")
 public:
 	AIGuardRetaliatePickUpCrateState( StateMachine *machine );
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 };
 EMPTY_DTOR(AIGuardRetaliatePickUpCrateState)
 
@@ -235,17 +235,17 @@ class AIGuardRetaliateAttackAggressorState : public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIGuardRetaliateAttackAggressorState, "AIGuardRetaliateAttackAggressorState")
 public:
 	AIGuardRetaliateAttackAggressorState( StateMachine *machine );
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 #ifdef STATE_MACHINE_DEBUG
 	virtual AsciiString getName() const ;
 #endif
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 private:
 	AIGuardRetaliateMachine* getGuardMachine() { return (AIGuardRetaliateMachine*)getMachine(); }
 	GuardRetaliateExitConditions m_exitConditions;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AIPlayer.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AIPlayer.h
@@ -68,9 +68,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 };
 
@@ -99,9 +99,9 @@ private:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 public:
 
@@ -213,9 +213,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	virtual void doBaseBuilding();
 	virtual void checkReadyTeams();

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AISkirmishPlayer.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AISkirmishPlayer.h
@@ -45,56 +45,56 @@ class AISkirmishPlayer : public AIPlayer
 public:	 // AISkirmish specific methods.
 
 	AISkirmishPlayer( Player *p );							///< constructor
-	virtual Bool computeSuperweaponTarget(const SpecialPowerTemplate *power, Coord3D *pos, Int playerNdx, Real weaponRadius); ///< Calculates best pos for weapon given radius.
+	virtual Bool computeSuperweaponTarget(const SpecialPowerTemplate *power, Coord3D *pos, Int playerNdx, Real weaponRadius) override; ///< Calculates best pos for weapon given radius.
 
 public:	// AIPlayer interface methods.
 
-	virtual void update();											///< simulates the behavior of a player
+	virtual void update() override;											///< simulates the behavior of a player
 
-	virtual void newMap();											///< New map loaded call.
+	virtual void newMap() override;											///< New map loaded call.
 
 	/// Invoked when a unit I am training comes into existence
-	virtual void onUnitProduced( Object *factory, Object *unit );
+	virtual void onUnitProduced( Object *factory, Object *unit ) override;
 
-	virtual void buildSpecificAITeam(TeamPrototype *teamProto, Bool priorityBuild); ///< Builds this team immediately.
+	virtual void buildSpecificAITeam(TeamPrototype *teamProto, Bool priorityBuild) override; ///< Builds this team immediately.
 
-	virtual void buildSpecificAIBuilding(const AsciiString &thingName); ///< Builds this building as soon as possible.
+	virtual void buildSpecificAIBuilding(const AsciiString &thingName) override; ///< Builds this building as soon as possible.
 
-	virtual void buildAIBaseDefense(Bool flank); ///< Builds base defense on front or flank of base.
+	virtual void buildAIBaseDefense(Bool flank) override; ///< Builds base defense on front or flank of base.
 
-	virtual void buildAIBaseDefenseStructure(const AsciiString &thingName, Bool flank); ///< Builds base defense on front or flank of base.
+	virtual void buildAIBaseDefenseStructure(const AsciiString &thingName, Bool flank) override; ///< Builds base defense on front or flank of base.
 
-	virtual void recruitSpecificAITeam(TeamPrototype *teamProto, Real recruitRadius); ///< Builds this team immediately.
+	virtual void recruitSpecificAITeam(TeamPrototype *teamProto, Real recruitRadius) override; ///< Builds this team immediately.
 
-	virtual Bool isSkirmishAI() {return true;}
+	virtual Bool isSkirmishAI() override {return true;}
 
-	virtual Bool checkBridges(Object *unit, Waypoint *way);
+	virtual Bool checkBridges(Object *unit, Waypoint *way) override;
 
-	virtual Player *getAiEnemy();	///< Solo AI attacks based on scripting.  Only skirmish auto-acquires an enemy at this point.  jba.
+	virtual Player *getAiEnemy() override;	///< Solo AI attacks based on scripting.  Only skirmish auto-acquires an enemy at this point.  jba.
 
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
-	virtual void doBaseBuilding();
-	virtual void checkReadyTeams();
-	virtual void checkQueuedTeams();
-	virtual void doTeamBuilding();
-	virtual Object *findDozer(const Coord3D *pos);
-	virtual void queueDozer();
+	virtual void doBaseBuilding() override;
+	virtual void checkReadyTeams() override;
+	virtual void checkQueuedTeams() override;
+	virtual void doTeamBuilding() override;
+	virtual Object *findDozer(const Coord3D *pos) override;
+	virtual void queueDozer() override;
 
 protected:
 
-	virtual Bool selectTeamToBuild();			///< determine the next team to build
-	virtual Bool selectTeamToReinforce( Int minPriority );			///< determine the next team to reinforce
-	virtual Bool startTraining( WorkOrder *order, Bool busyOK, AsciiString teamName);	///< find a production building that can handle the order, and start building
+	virtual Bool selectTeamToBuild() override;			///< determine the next team to build
+	virtual Bool selectTeamToReinforce( Int minPriority ) override;			///< determine the next team to reinforce
+	virtual Bool startTraining( WorkOrder *order, Bool busyOK, AsciiString teamName) override;	///< find a production building that can handle the order, and start building
 
-	virtual Bool isAGoodIdeaToBuildTeam( TeamPrototype *proto );		///< return true if team should be built
-	virtual void processBaseBuilding();		///< do base-building behaviors
-	virtual void processTeamBuilding();		///< do team-building behaviors
+	virtual Bool isAGoodIdeaToBuildTeam( TeamPrototype *proto ) override;		///< return true if team should be built
+	virtual void processBaseBuilding() override;		///< do base-building behaviors
+	virtual void processTeamBuilding() override;		///< do team-building behaviors
 
 protected:
 	void adjustBuildList(BuildListInfo *list);

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AIStateMachine.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AIStateMachine.h
@@ -136,9 +136,9 @@ public:
 	 */
 	AIStateMachine( Object *owner, AsciiString name );
 
-	virtual void clear();
-	virtual StateReturnType resetToDefaultState();
-	virtual StateReturnType setState( StateID newStateID );
+	virtual void clear() override;
+	virtual StateReturnType resetToDefaultState() override;
+	virtual StateReturnType setState( StateID newStateID ) override;
 
 	/// @todo Rethink state parameter passing. Continuing in this fashion will have a pile of params in the machine (MSB)
 	void setGoalPath( std::vector<Coord3D>* path );
@@ -161,16 +161,16 @@ public:
 	StateID getTemporaryState() const {return m_temporaryState?m_temporaryState->getID():INVALID_STATE_ID;}
 
 public:	// overrides.
-	virtual StateReturnType updateStateMachine();				///< run one step of the machine
+	virtual StateReturnType updateStateMachine() override;				///< run one step of the machine
 #ifdef STATE_MACHINE_DEBUG
 	virtual AsciiString getCurrentStateName() const ;
 #endif
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	std::vector<Coord3D>	m_goalPath;					///< defines a simple path to follow
@@ -202,9 +202,9 @@ enum StateType CPP_11(: Int)
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 };
 
 //-----------------------------------------------------------------------------------------------------------
@@ -225,16 +225,16 @@ public:
 		LOOK_FOR_TARGETS,
 		DO_NOT_LOOK_FOR_TARGETS
 	};
-	virtual Bool isIdle() const { return true; }
+	virtual Bool isIdle() const override { return true; }
 	AIIdleState( StateMachine *machine, AIIdleTargetingType shouldLookForTargets);
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 };
 EMPTY_DTOR(AIIdleState)
@@ -258,9 +258,9 @@ public:
 		m_goalLayer = LAYER_INVALID;
 	}
 
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 
 protected:
 
@@ -283,9 +283,9 @@ private:
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	enum { MIN_REPATH_TIME = 10 };										///< minimum # of frames must elapse before re-pathing
@@ -318,15 +318,15 @@ protected:
 	Bool m_targetIsBldg;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 public:
 	AIRappelState( StateMachine *machine );
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 };
 EMPTY_DTOR(AIRappelState)
 
@@ -339,15 +339,15 @@ class AIBusyState : public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIBusyState, "AIBusyState")
 public:
 	AIBusyState( StateMachine *machine ) : State( machine, "AIBusyState" ) { }
-	virtual StateReturnType onEnter() { return STATE_CONTINUE; }
-	virtual void onExit( StateExitType status ) { }
-	virtual StateReturnType update() { return STATE_CONTINUE; }
-	virtual Bool isBusy() const { return true; }
+	virtual StateReturnType onEnter() override { return STATE_CONTINUE; }
+	virtual void onExit( StateExitType status ) override { }
+	virtual StateReturnType update() override { return STATE_CONTINUE; }
+	virtual Bool isBusy() const override { return true; }
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override{};
 
 };
 EMPTY_DTOR(AIBusyState)
@@ -363,9 +363,9 @@ protected:
 	Bool m_isMoveTo;
 public:
 	AIMoveToState( StateMachine *machine );
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 };
 EMPTY_DTOR(AIMoveToState)
 
@@ -378,11 +378,11 @@ class AIMoveOutOfTheWayState : public AIInternalMoveToState
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIMoveOutOfTheWayState, "AIMoveOutOfTheWayState")
 public:
 	AIMoveOutOfTheWayState( StateMachine *machine ) : AIInternalMoveToState( machine, "AIMoveOutOfTheWayState" ) { }
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 protected:
-	virtual Bool computePath();												///< compute the path
+	virtual Bool computePath() override;												///< compute the path
 
 };
 EMPTY_DTOR(AIMoveOutOfTheWayState)
@@ -405,17 +405,17 @@ public:
 		m_checkForPath = false;
 		m_okToRepathTimes = 0;
 	}
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
 protected:
-	virtual Bool computePath();												///< compute the path
+	virtual Bool computePath() override;												///< compute the path
 	Int m_okToRepathTimes;
 	Bool m_checkForPath;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 };
 EMPTY_DTOR(AIMoveAndTightenState)
 
@@ -428,11 +428,11 @@ class AIMoveAwayFromRepulsorsState : public AIMoveAndTightenState
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIMoveAwayFromRepulsorsState, "AIMoveAwayFromRepulsorsState")
 public:
 	AIMoveAwayFromRepulsorsState( StateMachine *machine ) : AIMoveAndTightenState( machine, "AIMoveAwayFromRepulsors" ) { }
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
-	virtual Bool computePath();												///< compute the path
+	virtual Bool computePath() override;												///< compute the path
 
 };
 EMPTY_DTOR(AIMoveAwayFromRepulsorsState)
@@ -455,18 +455,18 @@ public:
 		// we're setting m_isInitialApproach to true in the constructor because we want the first pass
 		// through this state to allow a unit to attack incidental targets (if it is turreted)
 	}
-	virtual Bool isAttack() const { return TRUE; }
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual Bool isAttack() const override { return TRUE; }
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 protected:
-	virtual Bool computePath();												///< compute the path
+	virtual Bool computePath() override;												///< compute the path
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 
@@ -504,18 +504,18 @@ public:
 		// we're setting m_isInitialApproach to true in the constructor because we want the first pass
 		// through this state to allow a unit to attack incidental targets (if it is turreted)
 	}
-	virtual Bool isAttack() const { return TRUE; }
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual Bool isAttack() const override { return TRUE; }
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 protected:
-	virtual Bool computePath();												///< compute the path
+	virtual Bool computePath() override;												///< compute the path
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 
@@ -547,19 +547,19 @@ public:
 		// we're setting m_isInitialApproach to true in the constructor because we want the first pass
 		// through this state to allow a unit to attack incidental targets (if it is turreted)
 	}
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 protected:
-	virtual Bool computePath();												///< compute the path
+	virtual Bool computePath() override;												///< compute the path
 
 private:
 	Int			m_delayCounter;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 };
 EMPTY_DTOR(AIPickUpCrateState)
 
@@ -574,10 +574,10 @@ public:
 	AIAttackMoveToState( StateMachine *machine );
 	//virtual ~AIAttackMoveToState();
 
-	virtual Bool isAttack() const { return m_attackMoveMachine ? m_attackMoveMachine->isInAttackState() : FALSE; }
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual Bool isAttack() const override { return m_attackMoveMachine ? m_attackMoveMachine->isInAttackState() : FALSE; }
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 #ifdef STATE_MACHINE_DEBUG
 	virtual AsciiString getName() const ;
 #endif
@@ -591,9 +591,9 @@ protected:
 	Int						m_retryCount;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 };
 
 //-----------------------------------------------------------------------------------------------------------
@@ -615,15 +615,15 @@ public:
 	{
 		m_angle = 0.0f;
 	}
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 	Coord2D m_groupOffset;
@@ -657,15 +657,15 @@ public:
 	AIFollowWaypointPathExactState( StateMachine *machine, Bool asGroup ) : m_moveAsGroup(asGroup),
 		m_lastWaypoint(nullptr),
 		AIInternalMoveToState( machine, "AIFollowWaypointPathExactState" ) { }
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 	const Waypoint *m_lastWaypoint;
@@ -684,11 +684,11 @@ public:
 	AIAttackFollowWaypointPathState( StateMachine *machine, Bool asGroup );
 	//virtual ~AIAttackFollowWaypointPathState();
 
-	virtual Bool isAttack() const { return m_attackFollowMachine ? m_attackFollowMachine->isInAttackState() : FALSE; }
+	virtual Bool isAttack() const override { return m_attackFollowMachine ? m_attackFollowMachine->isInAttackState() : FALSE; }
 
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 #ifdef STATE_MACHINE_DEBUG
 	virtual AsciiString getName() const ;
 #endif
@@ -698,9 +698,9 @@ protected:
 	StateMachine *m_attackFollowMachine;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 };
 
 //-----------------------------------------------------------------------------------------------------------
@@ -719,15 +719,15 @@ public:
 		m_timer = 0;
 		m_waitFrames = 0;
 	}
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 	Int		m_waitFrames;
@@ -749,15 +749,15 @@ public:
 		m_waitFrames = 0;
 		m_timer = 0;
 	}
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 	void computeWanderGoal();
@@ -781,14 +781,14 @@ public:
 		setName("AIPanicState");
 #endif
 	}
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 	Int		m_waitFrames;
@@ -811,9 +811,9 @@ public:
 		m_index(0),
 		m_retryCount(10),
 		AIInternalMoveToState( machine, name ) { }
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 
 protected:
 
@@ -823,9 +823,9 @@ protected:
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	Int m_index;																		///< current path index
@@ -847,14 +847,14 @@ public:
 	{
 		m_origin.zero();
 	}
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	Coord3D m_origin;													///< current position - set as goal on exit in case we follow with MoveToAndDelete.
@@ -873,14 +873,14 @@ public:
 	{
 		m_appendGoalPosition = FALSE;
 	}
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 	Bool m_appendGoalPosition;
@@ -900,15 +900,15 @@ public:
 		m_setLocomotor(false)
 	{
 	}
-	virtual Bool isAttack() const { return TRUE; }
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual Bool isAttack() const override { return TRUE; }
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 private:
 	const Bool m_isAttackingObject;
 	Bool m_canTurnInPlace;
@@ -923,12 +923,12 @@ class AIWaitState : public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIWaitState, "AIWaitState")
 public:
 	AIWaitState( StateMachine *machine ) : State( machine,"AIWaitState" ) { }
-	virtual StateReturnType update();
+	virtual StateReturnType update() override;
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override{};
 };
 EMPTY_DTOR(AIWaitState)
 
@@ -953,15 +953,15 @@ public:
 		m_att(att)
 	{
 	}
-	virtual Bool isAttack() const { return TRUE; }
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType onEnter();
+	virtual Bool isAttack() const override { return TRUE; }
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType onEnter() override;
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override{};
 private:
 	NotifyWeaponFiredInterface *const m_att;		// this is NOT owned by us and should not be freed
 };
@@ -983,16 +983,16 @@ public:
 	AIAttackState( StateMachine *machine, Bool follow, Bool attackingObject, Bool forceAttacking, AttackExitConditionsInterface* attackParameters);
 	//~AIAttackState();
 
-	virtual Bool isAttack() const { return TRUE; }
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual Bool isAttack() const override { return TRUE; }
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 
-	virtual void notifyFired() { /* nothing */ }
-	virtual void notifyNewVictimChosen(Object* victim);
-	virtual const Coord3D* getOriginalVictimPos() const { return &m_originalVictimPos; }
-	virtual Bool isWeaponSlotOkToFire(WeaponSlotType wslot) const { return true; }
-	virtual Bool isAttackingObject() const { return m_isAttackingObject; }
+	virtual void notifyFired() override { /* nothing */ }
+	virtual void notifyNewVictimChosen(Object* victim) override;
+	virtual const Coord3D* getOriginalVictimPos() const override { return &m_originalVictimPos; }
+	virtual Bool isWeaponSlotOkToFire(WeaponSlotType wslot) const override { return true; }
+	virtual Bool isAttackingObject() const override { return m_isAttackingObject; }
 	virtual Bool isForceAttacking() const { return m_isForceAttacking; }
 #ifdef STATE_MACHINE_DEBUG
 	virtual AsciiString getName() const ;
@@ -1000,9 +1000,9 @@ public:
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 
@@ -1027,10 +1027,10 @@ public:
 			State( machine , "AIAttackSquadState") {	}
 	//~AIAttackSquadState();
 
-	virtual Bool isAttack() const { return m_attackSquadMachine ? m_attackSquadMachine->isInAttackState() : FALSE; }
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual Bool isAttack() const override { return m_attackSquadMachine ? m_attackSquadMachine->isInAttackState() : FALSE; }
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 	Object *chooseVictim();
 #ifdef STATE_MACHINE_DEBUG
 	virtual AsciiString getName() const ;
@@ -1039,9 +1039,9 @@ public:
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	StateMachine *m_attackSquadMachine;						///< state sub-machine for attack behavior
@@ -1053,14 +1053,14 @@ class AIDeadState : public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIDeadState, "AIDeadState")
 public:
 	AIDeadState( StateMachine *machine ) : State( machine, "AIDeadState" ) { }
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override{};
 };
 EMPTY_DTOR(AIDeadState)
 
@@ -1071,19 +1071,19 @@ class AIDockState : public State
 public:
 	AIDockState( StateMachine *machine ) : State( machine, "AIDockState" ), m_dockMachine(nullptr), m_usingPrecisionMovement(FALSE) { }
 	//~AIDockState();
-	virtual Bool isAttack() const { return m_dockMachine ? m_dockMachine->isInAttackState() : FALSE; }
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual Bool isAttack() const override { return m_dockMachine ? m_dockMachine->isInAttackState() : FALSE; }
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 #ifdef STATE_MACHINE_DEBUG
 	virtual AsciiString getName() const ;
 #endif
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	StateMachine *m_dockMachine;				///< state sub-machine for docking behavior
@@ -1100,14 +1100,14 @@ protected:
 	ObjectID m_entryToClear;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 public:
 	AIEnterState( StateMachine *machine ) : AIInternalMoveToState( machine, "AIEnterState" ) { }
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 };
 EMPTY_DTOR(AIEnterState)
 
@@ -1119,14 +1119,14 @@ protected:
 	ObjectID m_entryToClear;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 public:
 	AIExitState( StateMachine *machine ) : State( machine, "AIExitState" ) { }
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 };
 EMPTY_DTOR(AIExitState)
 
@@ -1138,14 +1138,14 @@ protected:
 	ObjectID m_entryToClear;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 public:
 	AIExitInstantlyState( StateMachine *machine ) : State( machine, "AIExitInstantlyState" ) { }
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 };
 EMPTY_DTOR(AIExitInstantlyState)
 
@@ -1163,19 +1163,19 @@ public:
 		m_guardMachine = nullptr;
 	}
 	//~AIGuardState();
-	virtual Bool isAttack() const;
-	virtual Bool isGuardIdle() const;
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual Bool isAttack() const override;
+	virtual Bool isGuardIdle() const override;
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 #ifdef STATE_MACHINE_DEBUG
 	virtual AsciiString getName() const ;
 #endif
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	AIGuardMachine *m_guardMachine;					///< state sub-machine for guard behavior
@@ -1191,18 +1191,18 @@ class AIGuardRetaliateState : public State
 public:
 	AIGuardRetaliateState( StateMachine *machine ) : State( machine, "AIGuardRetaliateState" ), m_guardRetaliateMachine(nullptr) {}
 	//~AIGuardRetaliateState();
-	virtual Bool isAttack() const;
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual Bool isAttack() const override;
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 #ifdef STATE_MACHINE_DEBUG
 	virtual AsciiString getName() const ;
 #endif
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	AIGuardRetaliateMachine *m_guardRetaliateMachine;					///< state sub-machine for retaliate behavior
@@ -1221,18 +1221,18 @@ public:
 		m_guardMachine = nullptr;
 	}
 	//~AIGuardState();
-	virtual Bool isAttack() const;
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual Bool isAttack() const override;
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 #ifdef STATE_MACHINE_DEBUG
 	virtual AsciiString getName() const ;
 #endif
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	AITNGuardMachine *m_guardMachine;					///< state sub-machine for guard behavior
@@ -1251,19 +1251,19 @@ public:
 		m_nextEnemyScanTime = 0;
 	}
 	//~AIHuntState();
-	virtual Bool isAttack() const;
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual Bool isAttack() const override;
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 #ifdef STATE_MACHINE_DEBUG
 	virtual AsciiString getName() const ;
 #endif
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	StateMachine* m_huntMachine;					///< state sub-machine for hunt behavior
@@ -1282,19 +1282,19 @@ public:
 	AIAttackAreaState( StateMachine *machine ) : State( machine, "AIAttackAreaState" ), m_attackMachine(nullptr),
 		m_nextEnemyScanTime(0) { }
 	//~AIAttackAreaState();
-	virtual Bool isAttack() const { return m_attackMachine ? m_attackMachine->isInAttackState() : FALSE; }
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual Bool isAttack() const override { return m_attackMachine ? m_attackMachine->isInAttackState() : FALSE; }
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 #ifdef STATE_MACHINE_DEBUG
 	virtual AsciiString getName() const ;
 #endif
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	StateMachine *m_attackMachine;					///< state sub-machine for attack behavior
@@ -1310,14 +1310,14 @@ class AIFaceState : public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AIFaceState, "AIFaceState")
 public:
 	AIFaceState( StateMachine *machine, Bool obj ) : State( machine, "AIFaceState" ), m_canTurnInPlace(false), m_obj(obj) { }
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 protected:
 	// snapshot interface .
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 	const Bool m_obj;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AIStateMachine.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AIStateMachine.h
@@ -345,9 +345,9 @@ public:
 	virtual Bool isBusy() const override { return true; }
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ) override{};
-	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess() override{};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 
 };
 EMPTY_DTOR(AIBusyState)
@@ -926,9 +926,9 @@ public:
 	virtual StateReturnType update() override;
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ) override{};
-	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess() override{};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 };
 EMPTY_DTOR(AIWaitState)
 
@@ -959,9 +959,9 @@ public:
 	virtual StateReturnType onEnter() override;
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ) override{};
-	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess() override{};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 private:
 	NotifyWeaponFiredInterface *const m_att;		// this is NOT owned by us and should not be freed
 };
@@ -1058,9 +1058,9 @@ public:
 	virtual void onExit( StateExitType status ) override;
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ) override{};
-	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess() override{};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 };
 EMPTY_DTOR(AIDeadState)
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AITNGuard.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AITNGuard.h
@@ -70,7 +70,7 @@ public:
 	{
 	}
 
-	virtual Bool shouldExit(const StateMachine* machine) const;
+	virtual Bool shouldExit(const StateMachine* machine) const override;
 };
 
 
@@ -88,9 +88,9 @@ private:
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 public:
 	/**
@@ -122,14 +122,14 @@ public:
 	{
 		m_attackState = nullptr;
 	}
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 private:
 	AITNGuardMachine* getGuardMachine() { return (AITNGuardMachine*)getMachine(); }
 
@@ -144,14 +144,14 @@ class AITNGuardIdleState : public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AITNGuardIdleState, "AITNGuardIdleState")
 public:
 	AITNGuardIdleState( StateMachine *machine ) : State( machine, "AITNGuardIdleState" ) { }
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 private:
 	AITNGuardMachine* getGuardMachine() { return (AITNGuardMachine*)getMachine(); }
 
@@ -169,14 +169,14 @@ public:
 	{
 		m_attackState = nullptr;
 	}
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 private:
 	AITNGuardMachine* getGuardMachine() { return (AITNGuardMachine*)getMachine(); }
 
@@ -195,18 +195,18 @@ public:
 	{
 		m_nextReturnScanTime = 0;
 	}
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 
 protected:
 	UnsignedInt m_nextReturnScanTime;
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 };
 EMPTY_DTOR(AITNGuardReturnState)
 
@@ -217,9 +217,9 @@ class AITNGuardPickUpCrateState : public AIPickUpCrateState
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AITNGuardPickUpCrateState, "AITNGuardPickUpCrateState")
 public:
 	AITNGuardPickUpCrateState( StateMachine *machine );
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 };
 EMPTY_DTOR(AITNGuardPickUpCrateState)
 
@@ -229,14 +229,14 @@ class AITNGuardAttackAggressorState : public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(AITNGuardAttackAggressorState, "AITNGuardAttackAggressorState")
 public:
 	AITNGuardAttackAggressorState( StateMachine *machine );
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
+	virtual void onExit( StateExitType status ) override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 private:
 	AITNGuardMachine* getGuardMachine() { return (AITNGuardMachine*)getMachine(); }
 	TunnelNetworkExitConditions m_exitConditions;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Armor.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Armor.h
@@ -99,11 +99,11 @@ class ArmorStore : public SubsystemInterface
 public:
 
 	ArmorStore();
-	~ArmorStore();
+	virtual ~ArmorStore() override;
 
-	void init() { }
-	void reset() { }
-	void update() { }
+	virtual void init() override { }
+	virtual void reset() override { }
+	virtual void update() override { }
 
 	const ArmorTemplate* findArmorTemplate(NameKeyType namekey) const;
 	/**

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/CaveSystem.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/CaveSystem.h
@@ -44,11 +44,11 @@ class CaveSystem : public SubsystemInterface,
 {
 public:
 	CaveSystem();
-	~CaveSystem();
+	virtual ~CaveSystem() override;
 
-	void init();
-	void reset();
-	void update();
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override;
 
 	Bool canSwitchIndexToIndex( Int oldIndex, Int newIndex ); // If either Index has guys in it, no, you can't
 	void registerNewCave( Int theIndex );			// All Caves are born with a default index, which could be new
@@ -58,9 +58,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer ) { }
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess() { }
+	virtual void crc( Xfer *xfer ) override { }
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override { }
 
 private:
 	std::vector<TunnelTracker*> m_tunnelTrackerVector;// A vector of pointers where the indexes are known by

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/CrateSystem.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/CrateSystem.h
@@ -92,7 +92,7 @@ public:
 
 	virtual void init() override;
 	virtual void reset() override;
-	virtual void update() override{}
+	virtual void update() override {}
 
 	const CrateTemplate *findCrateTemplate(AsciiString name) const;
 	CrateTemplate *friend_findCrateTemplate(AsciiString name);

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/CrateSystem.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/CrateSystem.h
@@ -88,11 +88,11 @@ class CrateSystem : public SubsystemInterface
 {
 public:
 	CrateSystem();
-	~CrateSystem();
+	virtual ~CrateSystem() override;
 
-	void init();
-	void reset();
-	void update(){}
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override{}
 
 	const CrateTemplate *findCrateTemplate(AsciiString name) const;
 	CrateTemplate *friend_findCrateTemplate(AsciiString name);

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Damage.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Damage.h
@@ -297,9 +297,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer ) { }
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess() { }
+	virtual void crc( Xfer *xfer ) override { }
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override { }
 
 };
 
@@ -340,9 +340,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer ) { }
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess() { }
+	virtual void crc( Xfer *xfer ) override { }
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override { }
 
 };
 
@@ -366,8 +366,8 @@ public:
 
 protected:
 
-	virtual void crc( Xfer *xfer ) { }
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess(){ }
+	virtual void crc( Xfer *xfer ) override { }
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override { }
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/ExperienceTracker.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/ExperienceTracker.h
@@ -63,9 +63,9 @@ public:
 	void setExperienceScalar( Real scalar ) { m_experienceScalar = scalar; }
 
 	// --------------- inherited from Snapshot interface --------------
-	void crc( Xfer *xfer ) override;
-	void xfer( Xfer *xfer ) override;
-	void loadPostProcess() override;
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 	Object*						m_parent;														///< Object I am owned by

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/ExperienceTracker.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/ExperienceTracker.h
@@ -63,9 +63,9 @@ public:
 	void setExperienceScalar( Real scalar ) { m_experienceScalar = scalar; }
 
 	// --------------- inherited from Snapshot interface --------------
-	void crc( Xfer *xfer );
-	void xfer( Xfer *xfer );
-	void loadPostProcess();
+	void crc( Xfer *xfer ) override;
+	void xfer( Xfer *xfer ) override;
+	void loadPostProcess() override;
 
 private:
 	Object*						m_parent;														///< Object I am owned by

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/FiringTracker.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/FiringTracker.h
@@ -57,9 +57,9 @@ public:
 	Int getNumConsecutiveShotsAtVictim( const Object *victim ) const;
 
 	/// this is never disabled, since we want disabled things to continue to slowly "spin down"... (srj)
-	virtual DisabledMaskType getDisabledTypesToProcess() const { return DISABLEDMASK_ALL; }
+	virtual DisabledMaskType getDisabledTypesToProcess() const override { return DISABLEDMASK_ALL; }
 
-	virtual UpdateSleepTime update();	///< See if spin down is needed because we haven't shot in a while
+	virtual UpdateSleepTime update() override;	///< See if spin down is needed because we haven't shot in a while
 
 protected:
 
@@ -68,7 +68,7 @@ protected:
 		user update modules, so it redefines this. Please don't redefine this
 		for other modules without very careful deliberation. (srj)
 	*/
-	virtual SleepyUpdatePhase getUpdatePhase() const
+	virtual SleepyUpdatePhase getUpdatePhase() const override
 	{
 		return PHASE_FINAL;
 	}

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/GameLogic.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/GameLogic.h
@@ -103,12 +103,12 @@ class GameLogic : public SubsystemInterface, public Snapshot
 public:
 
 	GameLogic();
-	virtual ~GameLogic();
+	virtual ~GameLogic() override;
 
 	// subsystem methods
-	virtual void init();															///< Initialize or re-initialize the instance
-	virtual void reset();															///< Reset the logic system
-	virtual void update();														///< update the world
+	virtual void init() override;															///< Initialize or re-initialize the instance
+	virtual void reset() override;															///< Reset the logic system
+	virtual void update() override;														///< update the world
 
 	void preUpdate();
 
@@ -264,9 +264,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/GhostObject.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/GhostObject.h
@@ -56,9 +56,9 @@ public:
 	const Coord3D *getParentPosition() const {return &m_parentPosition;}
 
 protected:
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	Object *m_parentObject;		///< object which we are ghosting
 	GeometryType m_parentGeometryType;
@@ -89,9 +89,9 @@ public:
 	inline Bool trackAllPlayers() const; ///< returns whether the ghost object status is tracked for all players or for the local player only
 
 protected:
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	Int m_localPlayer;
 	Bool m_lockGhostObjects;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Locomotor.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Locomotor.h
@@ -401,9 +401,9 @@ protected:
 
 protected:
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 
@@ -475,11 +475,11 @@ class LocomotorStore : public SubsystemInterface
 public:
 
 	LocomotorStore();
-	~LocomotorStore();
+	virtual ~LocomotorStore() override;
 
-	void init() { };
-	void reset();
-	void update();
+	virtual void init() override { };
+	virtual void reset() override;
+	virtual void update() override;
 
 	/**
 		Find the LocomotorTemplate with the given name. If no such LocomotorTemplate exists, return null.

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/LocomotorSet.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/LocomotorSet.h
@@ -86,9 +86,9 @@ private:
 
 protected:
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 public:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
@@ -646,9 +646,9 @@ protected:
 
 
 	// snapshot methods
-	void crc( Xfer *xfer );
-	void xfer( Xfer *xfer );
-	void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	void handleShroud();
 	void handleValueMap();
@@ -662,10 +662,10 @@ protected:
 	Bool didEnterOrExit() const;
 
 	void setID( ObjectID id );
-	virtual Object *asObjectMeth() { return this; }
-	virtual const Object *asObjectMeth() const { return this; }
+	virtual Object *asObjectMeth() override { return this; }
+	virtual const Object *asObjectMeth() const override { return this; }
 
-	virtual Real calculateHeightAboveTerrain() const;		// Calculates the actual height above terrain.  Doesn't use cache.
+	virtual Real calculateHeightAboveTerrain() const override;		// Calculates the actual height above terrain.  Doesn't use cache.
 
 	void updateTriggerAreaFlags();
 	void setTriggerAreaFlagsForChangeInPosition();
@@ -683,7 +683,7 @@ protected:
 	void addThreat();
 	void removeThreat();
 
-	virtual void reactToTransformChange(const Matrix3D* oldMtx, const Coord3D* oldPos, Real oldAngle);
+	virtual void reactToTransformChange(const Matrix3D* oldMtx, const Coord3D* oldPos, Real oldAngle) override;
 
 private:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/ObjectCreationList.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/ObjectCreationList.h
@@ -187,11 +187,11 @@ class ObjectCreationListStore : public SubsystemInterface
 public:
 
 	ObjectCreationListStore();
-	~ObjectCreationListStore();
+	virtual ~ObjectCreationListStore() override;
 
-	void init() { }
-	void reset() { }
-	void update() { }
+	virtual void init() override { }
+	virtual void reset() override { }
+	virtual void update() override { }
 
 	/**
 		return the ObjectCreationList with the given namekey.

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/ObjectIter.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/ObjectIter.h
@@ -121,8 +121,8 @@ private:
 public:
 	SimpleObjectIterator();
 //~SimpleObjectIterator();	// provided by MPO
-	Object *first() { return firstWithNumeric(nullptr); }
-	Object *next() { return nextWithNumeric(nullptr); }
+	virtual Object *first() override { return firstWithNumeric(nullptr); }
+	virtual Object *next() override { return nextWithNumeric(nullptr); }
 
 	Object *firstWithNumeric(Real *num = nullptr) { reset(); return nextWithNumeric(num); }
 	Object *nextWithNumeric(Real *num = nullptr);

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/ObjectTypes.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/ObjectTypes.h
@@ -50,9 +50,9 @@ private:
 
 protected:
 	// snapshot methods
-	virtual void crc(Xfer *xfer);
-	virtual void xfer(Xfer *xfer);
-	virtual void loadPostProcess();
+	virtual void crc(Xfer *xfer) override;
+	virtual void xfer(Xfer *xfer) override;
+	virtual void loadPostProcess() override;
 
 public:
 	ObjectTypes();

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/PartitionManager.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/PartitionManager.h
@@ -316,9 +316,9 @@ public:
 	~PartitionCell();
 
 	// --------------- inherited from Snapshot interface --------------
-	void crc( Xfer *xfer ) override;
-	void xfer( Xfer *xfer ) override;
-	void loadPostProcess() override;
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	Int getCoiCount() const { return m_coiCount; }		///< return number of COIs touching this cell.
 	Int getCellX() const { return m_cellX; }
@@ -1322,9 +1322,9 @@ public:
 	// ----------------------------------------------------------------
 
 	// --------------- inherited from Snapshot interface --------------
-	void crc( Xfer *xfer ) override;
-	void xfer( Xfer *xfer ) override;
-	void loadPostProcess() override;
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	Bool getUpdatedSinceLastReset() const { return m_updatedSinceLastReset; }
 
@@ -1490,7 +1490,7 @@ public:
 	}
 
 	/**
-		Reveals the map for the given player, but does not override Shroud generation.  (Script)
+		virtual Reveals the map for the given player, but does not override Shroud generation.  (Script)
 		*/
 	void revealMapForPlayer( Int playerIndex );
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/PartitionManager.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/PartitionManager.h
@@ -258,9 +258,9 @@ public:
 protected:
 
 	// snapshot method
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 };
 
@@ -316,9 +316,9 @@ public:
 	~PartitionCell();
 
 	// --------------- inherited from Snapshot interface --------------
-	void crc( Xfer *xfer );
-	void xfer( Xfer *xfer );
-	void loadPostProcess();
+	void crc( Xfer *xfer ) override;
+	void xfer( Xfer *xfer ) override;
+	void loadPostProcess() override;
 
 	Int getCoiCount() const { return m_coiCount; }		///< return number of COIs touching this cell.
 	Int getCellX() const { return m_cellX; }
@@ -610,7 +610,7 @@ class PartitionFilterIsFlying : public PartitionFilter
 {
 public:
 	PartitionFilterIsFlying() { }
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterIsFlying"; }
 #endif
@@ -626,7 +626,7 @@ private:
   Bool m_desiredCollisionResult;  // collision must match this for allow to return true
 public:
 	PartitionFilterWouldCollide(const Coord3D& pos, const GeometryInfo& geom, Real angle, Bool desired);
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterWouldCollide"; }
 #endif
@@ -642,7 +642,7 @@ private:
 	const Player *m_player;
 public:
 	PartitionFilterSamePlayer(const Player *player) : m_player(player) { }
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterSamePlayer"; }
 #endif
@@ -668,7 +668,7 @@ public:
 		ALLOW_NEUTRAL					= (1<<NEUTRAL)		///< allow objects that m_obj considers neutral
 	};
 	PartitionFilterRelationship(const Object *obj, Int flags) : m_obj(obj), m_flags(flags) { }
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterRelationship"; }
 #endif
@@ -685,7 +685,7 @@ private:
 	const Team *m_team;
 public:
 	PartitionFilterAcceptOnTeam(const Team *team);
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterAcceptOnTeam"; }
 #endif
@@ -702,7 +702,7 @@ private:
 	const Squad *m_squad;
 public:
 	PartitionFilterAcceptOnSquad(const Squad *squad);
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterAcceptOnSquad"; }
 #endif
@@ -725,7 +725,7 @@ private:
 	const Object *m_obj;
 public:
 	PartitionFilterLineOfSight(const Object *obj);
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterLineOfSight"; }
 #endif
@@ -743,7 +743,7 @@ private:
 	AbleToAttackType m_attackType;
 public:
 	PartitionFilterPossibleToAttack(AbleToAttackType t, const Object *obj, CommandSourceType commandSource);
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterPossibleToAttack"; }
 #endif
@@ -761,7 +761,7 @@ private:
 
 public:
 	PartitionFilterPossibleToEnter(const Object *obj, CommandSourceType commandSource);
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterPossibleToEnter"; }
 #endif
@@ -779,7 +779,7 @@ private:
 
 public:
 	PartitionFilterPossibleToHijack(const Object *obj, CommandSourceType commandSource);
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterPossibleToHijack"; }
 #endif
@@ -795,7 +795,7 @@ private:
 	ObjectID m_lastAttackedBy;
 public:
 	PartitionFilterLastAttackedBy(Object *obj);
-	virtual Bool allow(Object *other);
+	virtual Bool allow(Object *other) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterLastAttackedBy"; }
 #endif
@@ -811,7 +811,7 @@ private:
 	ObjectStatusMaskType m_mustBeSet, m_mustBeClear;
 public:
 	PartitionFilterAcceptByObjectStatus( ObjectStatusMaskType mustBeSet, ObjectStatusMaskType mustBeClear) : m_mustBeSet(mustBeSet), m_mustBeClear(mustBeClear) { }
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterAcceptByObjectStatus"; }
 #endif
@@ -831,7 +831,7 @@ public:
 		: m_mustBeSet(mustBeSet), m_mustBeClear(mustBeClear)
 	{
 	}
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterRejectByObjectStatus"; }
 #endif
@@ -848,7 +848,7 @@ private:
 	Bool m_allow;
 public:
 	PartitionFilterStealthedAndUndetected( const Object *obj, Bool allow ) { m_obj = obj; m_allow = allow; }
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterStealthedAndUndetected"; }
 #endif
@@ -864,7 +864,7 @@ private:
 	KindOfMaskType m_mustBeSet, m_mustBeClear;
 public:
 	PartitionFilterAcceptByKindOf(const KindOfMaskType& mustBeSet, const KindOfMaskType& mustBeClear) : m_mustBeSet(mustBeSet), m_mustBeClear(mustBeClear) { }
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterAcceptByKindOf"; }
 #endif
@@ -884,7 +884,7 @@ public:
 		: m_mustBeSet(mustBeSet), m_mustBeClear(mustBeClear)
 	{
 	}
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterRejectByKindOf"; }
 #endif
@@ -901,7 +901,7 @@ private:
 	Object *m_obj;
 public:
 	PartitionFilterRejectBehind( Object *obj );
-	virtual Bool allow( Object *other );
+	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterRejectBehind"; }
 #endif
@@ -916,7 +916,7 @@ class PartitionFilterAlive : public PartitionFilter
 public:
 	PartitionFilterAlive() { }
 protected:
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterAlive"; }
 #endif
@@ -934,7 +934,7 @@ private:
 public:
 	PartitionFilterSameMapStatus(const Object *obj) : m_obj(obj) { }
 protected:
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterSameMapStatus"; }
 #endif
@@ -949,7 +949,7 @@ class PartitionFilterOnMap : public PartitionFilter
 public:
 	PartitionFilterOnMap() { }
 protected:
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterOnMap"; }
 #endif
@@ -969,7 +969,7 @@ private:
 public:
 	PartitionFilterRejectBuildings(const Object *o);
 protected:
-	virtual Bool allow( Object *other );
+	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterRejectBuildings"; }
 #endif
@@ -989,7 +989,7 @@ public:
 	PartitionFilterInsignificantBuildings(Bool allowNonBuildings, Bool allowInsignificant) :
 			m_allowNonBuildings(allowNonBuildings), m_allowInsignificant(allowInsignificant) {}
 protected:
-	virtual Bool allow( Object *other );
+	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterInsignificantBuildings"; }
 #endif
@@ -1007,7 +1007,7 @@ public:
 	PartitionFilterFreeOfFog(Int toWhom) :
 			m_comparisonIndex(toWhom){}
 protected:
-	virtual Bool allow( Object *other );
+	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterFreeOfFog"; }
 #endif
@@ -1024,7 +1024,7 @@ private:
 public:
 	PartitionFilterRepulsor(const Object *o) : m_self(o) { }
 protected:
-	virtual Bool allow( Object *other );
+	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterRepulsor"; }
 #endif
@@ -1045,7 +1045,7 @@ private:
 public:
 	PartitionFilterIrregularArea(Coord3D* area, Int numPointsInArea) : m_area(area), m_numPointsInArea(numPointsInArea) {}
 protected:
-	virtual Bool allow( Object *other );
+	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterIrregularArea"; }
 #endif
@@ -1065,7 +1065,7 @@ private:
 public:
 	PartitionFilterPolygonTrigger(const PolygonTrigger *trigger) : m_trigger(trigger) {}
 protected:
-	virtual Bool allow( Object *other );
+	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterPolygonTrigger"; }
 #endif
@@ -1085,7 +1085,7 @@ private:
 public:
 	PartitionFilterPlayer(const Player *player, Bool match) : m_player(player), m_match(match) {}
 protected:
-	virtual Bool allow( Object *other );
+	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterPlayer"; }
 #endif
@@ -1110,7 +1110,7 @@ public:
 	{
 	}
 protected:
-	virtual Bool allow( Object *other );
+	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterPlayerAffiliation"; }
 #endif
@@ -1132,7 +1132,7 @@ public:
 		DEBUG_ASSERTCRASH(m_tThing != nullptr, ("ThingTemplate for PartitionFilterThing is null"));
 	}
 protected:
-	virtual Bool allow( Object *other );
+	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterThing"; }
 #endif
@@ -1154,7 +1154,7 @@ public:
 		m_player = nullptr;
 	}
 protected:
-	virtual Bool allow( Object *other );
+	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterGarrisonable"; }
 #endif
@@ -1177,7 +1177,7 @@ public:
 	{
 	}
 protected:
-	virtual Bool allow( Object *other );
+	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterGarrisonableByPlayer"; }
 #endif
@@ -1195,7 +1195,7 @@ private:
 public:
 	PartitionFilterUnmannedObject( Bool match ) : m_match(match) {}
 protected:
-	virtual Bool allow( Object *other );
+	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterUnmannedObject"; }
 #endif
@@ -1217,7 +1217,7 @@ public:
 	PartitionFilterValidCommandButtonTarget( Object *source, const CommandButton *commandButton, Bool match, CommandSourceType commandSource) :
 		m_source(source), m_commandButton(commandButton), m_match(match), m_commandSource(commandSource) {}
 protected:
-	virtual Bool allow( Object *other );
+	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterValidCommandButtonTarget"; }
 #endif
@@ -1313,18 +1313,18 @@ protected:
 public:
 
 	PartitionManager();
-	virtual ~PartitionManager();
+	virtual ~PartitionManager() override;
 
 	// --------------- inherited from Subsystem interface -------------
-	virtual void init();			///< initialize
-	virtual void reset();			///< system reset
-	virtual void update();		///< system update
+	virtual void init() override;			///< initialize
+	virtual void reset() override;			///< system reset
+	virtual void update() override;		///< system update
 	// ----------------------------------------------------------------
 
 	// --------------- inherited from Snapshot interface --------------
-	void crc( Xfer *xfer );
-	void xfer( Xfer *xfer );
-	void loadPostProcess();
+	void crc( Xfer *xfer ) override;
+	void xfer( Xfer *xfer ) override;
+	void loadPostProcess() override;
 
 	Bool getUpdatedSinceLastReset() const { return m_updatedSinceLastReset; }
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/PolygonTrigger.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/PolygonTrigger.h
@@ -93,9 +93,9 @@ protected:
 	void updateBounds() const;
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 public:
 	PolygonTrigger(Int initialAllocation);

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/RankInfo.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/RankInfo.h
@@ -52,12 +52,12 @@ public:
 class RankInfoStore : public SubsystemInterface
 {
 public:
-	virtual ~RankInfoStore();
+	virtual ~RankInfoStore() override;
 
 public:
-	void init();
-	void reset();
-	void update() { }
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override { }
 
 	Int getRankLevelCount() const;
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/ScriptActions.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/ScriptActions.h
@@ -48,9 +48,9 @@ public:
 
 	virtual ~ScriptActionsInterface() override { };
 
-	virtual void init() override = 0;		///< Init
-	virtual void reset() override = 0;		///< Reset
-	virtual void update() override = 0;	///< Update
+	virtual void init() = 0;		///< Init
+	virtual void reset() = 0;		///< Reset
+	virtual void update() = 0;	///< Update
 
 	virtual void executeAction( ScriptAction *pAction ) = 0; ///< execute a script action.
 	virtual void closeWindows( Bool suppressNewWindows ) = 0;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/ScriptActions.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/ScriptActions.h
@@ -46,11 +46,11 @@ class ScriptActionsInterface : public SubsystemInterface
 
 public:
 
-	virtual ~ScriptActionsInterface() { };
+	virtual ~ScriptActionsInterface() override { };
 
-	virtual void init() = 0;		///< Init
-	virtual void reset() = 0;		///< Reset
-	virtual void update() = 0;	///< Update
+	virtual void init() override = 0;		///< Init
+	virtual void reset() override = 0;		///< Reset
+	virtual void update() override = 0;	///< Update
 
 	virtual void executeAction( ScriptAction *pAction ) = 0; ///< execute a script action.
 	virtual void closeWindows( Bool suppressNewWindows ) = 0;
@@ -71,17 +71,17 @@ class ScriptActions : public ScriptActionsInterface
 
 public:
 	ScriptActions();
-	~ScriptActions();
+	virtual ~ScriptActions() override;
 
 public:
-	virtual void init();		///< Init
-	virtual void reset();		///< Reset
-	virtual void update();	///< Update
+	virtual void init() override;		///< Init
+	virtual void reset() override;		///< Reset
+	virtual void update() override;	///< Update
 
-	void executeAction( ScriptAction *pAction );
-	void closeWindows( Bool suppressNewWindows );
+	virtual void executeAction( ScriptAction *pAction ) override;
+	virtual void closeWindows( Bool suppressNewWindows ) override;
 
-	void doEnableOrDisableObjectDifficultyBonuses(Bool enableBonuses);
+	virtual void doEnableOrDisableObjectDifficultyBonuses(Bool enableBonuses) override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/ScriptConditions.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/ScriptConditions.h
@@ -43,11 +43,11 @@ class ScriptConditionsInterface : public SubsystemInterface
 
 public:
 
-	virtual ~ScriptConditionsInterface() { };
+	virtual ~ScriptConditionsInterface() override { };
 
-	virtual void init() = 0;		///< Init
-	virtual void reset() = 0;		///< Reset
-	virtual void update() = 0;	///< Update
+	virtual void init() override = 0;		///< Init
+	virtual void reset() override = 0;		///< Reset
+	virtual void update() override = 0;	///< Update
 
 	virtual Bool evaluateCondition( Condition *pCondition ) = 0; ///< evaluate a a script condition.
 
@@ -68,15 +68,15 @@ class ScriptConditions : public ScriptConditionsInterface
 
 public:
 	ScriptConditions();
-	~ScriptConditions();
+	virtual ~ScriptConditions() override;
 
 public:
 
-	virtual void init();		///< Init
-	virtual void reset();		///< Reset
-	virtual void update();	///< Update
+	virtual void init() override;		///< Init
+	virtual void reset() override;		///< Reset
+	virtual void update() override;	///< Update
 
-	Bool evaluateCondition( Condition *pCondition );
+	virtual Bool evaluateCondition( Condition *pCondition ) override;
 
 protected:
 	Player *playerFromParam(Parameter *pSideParm);			// Gets a player from a parameter.
@@ -154,7 +154,7 @@ protected:
 	Bool evaluatePlayerHasUnitTypeInArea(Condition *pCondition, Parameter *pPlayerParm, Parameter *pComparisonParm, Parameter *pCountParm, Parameter *pTypeParm, Parameter *pTriggerParm);
 	Bool evaluatePlayerHasUnitKindInArea(Condition *pCondition, Parameter *pPlayerParm, Parameter *pComparisonParm, Parameter *pCountParm,Parameter *pKindParm, Parameter *pTriggerParm);
 	Bool evaluateUnitHasEmptied(Parameter *pUnitParm);
-	Bool evaluateTeamIsContained(Parameter *pTeamParm, Bool allContained);
+	virtual Bool evaluateTeamIsContained(Parameter *pTeamParm, Bool allContained) override;
 	Bool evaluateMusicHasCompleted(Parameter *pMusicParm, Parameter *pIntParm);
 	Bool evaluatePlayerLostObjectType(Parameter *pPlayerParm, Parameter *pTypeParm);
 
@@ -165,7 +165,7 @@ protected:
 	Bool evaluateSkirmishPlayerIsFaction(Parameter *pSkirmishPlayerParm, Parameter *pFactionParm);
 	Bool evaluateSkirmishSuppliesWithinDistancePerimeter(Parameter *pSkirmishPlayerParm, Parameter *pDistanceParm, Parameter *pLocationParm, Parameter *pValueParm);
 	Bool evaluateSkirmishPlayerTechBuildingWithinDistancePerimeter(Condition *pCondition, Parameter *pSkirmishPlayerParm, Parameter *pDistanceParm, Parameter *pLocationParm);
-	Bool evaluateSkirmishCommandButtonIsReady( Parameter *pSkirmishPlayerParm, Parameter *pTeamParm, Parameter *pCommandButtonParm, Bool allReady );
+	virtual Bool evaluateSkirmishCommandButtonIsReady( Parameter *pSkirmishPlayerParm, Parameter *pTeamParm, Parameter *pCommandButtonParm, Bool allReady ) override;
 	Bool evaluateSkirmishUnownedFactionUnitComparison( Parameter *pSkirmishPlayerParm, Parameter *pComparisonParm, Parameter *pCountParm );
 	Bool evaluateSkirmishPlayerHasPrereqsToBuild( Parameter *pSkirmishPlayerParm, Parameter *pObjectTypeParm );
 	Bool evaluateSkirmishPlayerHasComparisonGarrisoned(Parameter *pSkirmishPlayerParm, Parameter *pComparisonParm, Parameter *pCountParm );

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/ScriptConditions.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/ScriptConditions.h
@@ -45,9 +45,9 @@ public:
 
 	virtual ~ScriptConditionsInterface() override { };
 
-	virtual void init() override = 0;		///< Init
-	virtual void reset() override = 0;		///< Reset
-	virtual void update() override = 0;	///< Update
+	virtual void init() = 0;		///< Init
+	virtual void reset() = 0;		///< Reset
+	virtual void update() = 0;	///< Update
 
 	virtual Bool evaluateCondition( Condition *pCondition ) = 0; ///< evaluate a a script condition.
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/ScriptEngine.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/ScriptEngine.h
@@ -145,9 +145,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	AsciiString m_name;
 	Int	m_defaultPriority;
@@ -177,9 +177,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 };
 EMPTY_DTOR(SequentialScript)
@@ -218,11 +218,11 @@ public:
 	enum {MAX_COUNTERS=256, MAX_FLAGS=256, MAX_ATTACK_PRIORITIES=256};
 	enum TFade {FADE_NONE, FADE_SUBTRACT, FADE_ADD, FADE_SATURATE, FADE_MULTIPLY};
 	ScriptEngine();
-	virtual ~ScriptEngine();
+	virtual ~ScriptEngine() override;
 
-	virtual void init();		///< Init
-	virtual void reset();		///< Reset
-	virtual void update();	///< Update
+	virtual void init() override;		///< Init
+	virtual void reset() override;		///< Reset
+	virtual void update() override;	///< Update
 
 	void appendSequentialScript(const SequentialScript *scriptToSequence);
 	void removeSequentialScript(SequentialScript *scriptToRemove);
@@ -361,9 +361,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	void addActionTemplateInfo(Template *actionTemplate);
 	void addConditionTemplateInfo(Template *conditionTemplate);

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Scripts.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Scripts.h
@@ -107,9 +107,9 @@ class ScriptGroup : public MemoryPoolObject, public Snapshot
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 	Script			*m_firstScript;
@@ -604,9 +604,9 @@ class Script : public MemoryPoolObject, public Snapshot
 protected:	// Note - If you add any member vars, you must take them into account in duplicate() and updateFrom(), as well as file read/write.
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	AsciiString	m_scriptName;   ///<Short name.
 	AsciiString m_comment;			///< Long comment.
@@ -1088,9 +1088,9 @@ class ScriptList : public MemoryPoolObject, public Snapshot
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	ScriptGroup		*m_firstGroup;
 	Script				*m_firstScript;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/SidesList.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/SidesList.h
@@ -136,11 +136,11 @@ class SidesList : public SubsystemInterface,
 public:
 
 	SidesList();
-	~SidesList();
+	virtual ~SidesList() override;
 
-	void init() { }
-	void update() { }
-	void reset();
+	virtual void init() override { }
+	virtual void update() override { }
+	virtual void reset() override;
 
 	/// Reads sides (including build list info && player dicts.)
 	static Bool ParseSidesDataChunk(DataChunkInput &file, DataChunkInfo *info, void *userData);
@@ -186,9 +186,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	Int					m_numSides;
 	SidesInfo		m_sides[MAX_PLAYER_COUNT];
@@ -269,9 +269,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	AsciiString			m_buildingName;			///< The name of this building.
 	AsciiString			m_templateName;			///< The thing template name for this model's info.

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Squad.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Squad.h
@@ -64,9 +64,9 @@ class Squad : public MemoryPoolObject, public Snapshot
 
 protected:
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	VecObjectID m_objectIDs;
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/TerrainLogic.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/TerrainLogic.h
@@ -218,11 +218,11 @@ class TerrainLogic : public Snapshot,
 public:
 
 	TerrainLogic();
-	virtual ~TerrainLogic();
+	virtual ~TerrainLogic() override;
 
-	virtual void init();		///< Init
-	virtual void reset();		///< Reset
-	virtual void update();	///< Update
+	virtual void init() override;		///< Init
+	virtual void reset() override;		///< Reset
+	virtual void update() override;	///< Update
 
 	virtual Bool loadMap( AsciiString filename, Bool query );
 	virtual void newMap( Bool saveGame );	///< Initialize the logic for new map.
@@ -317,9 +317,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	/// Chunk parser callback.
  	static Bool parseWaypointDataChunk(DataChunkInput &file, DataChunkInfo *info, void *userData);

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/TurretAI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/TurretAI.h
@@ -73,18 +73,18 @@ public:
 
 	TurretAI* getTurretAI() const { return m_turretAI; }
 
-	virtual void clear();
-	virtual StateReturnType resetToDefaultState();
-	virtual StateReturnType setState( StateID newStateID );
+	virtual void clear() override;
+	virtual StateReturnType resetToDefaultState() override;
+	virtual StateReturnType setState( StateID newStateID ) override;
 
 private:
 	TurretAI* m_turretAI;
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 };
 
 //-----------------------------------------------------------------------------------------------------------
@@ -103,14 +103,14 @@ class TurretAIIdleState : public TurretState
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(TurretAIIdleState, "TurretAIIdleState")
 public:
 	TurretAIIdleState( TurretStateMachine* machine ) : TurretState( machine, "TurretAIIdleState"), m_nextIdleScan(0) { }
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 private:
 	void resetIdleScan();
 	UnsignedInt m_nextIdleScan;
@@ -123,15 +123,15 @@ class TurretAIIdleScanState : public TurretState
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(TurretAIIdleScanState, "TurretAIIdleScanState")
 public:
 	TurretAIIdleScanState( TurretStateMachine* machine ) : TurretState( machine, "TurretAIIdleScanState"), m_desiredAngle(0) { }
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 private:
 	Real m_desiredAngle;
 };
@@ -153,14 +153,14 @@ public:
 	{
 
 	}
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 protected:
 	// snapshot interface	STUBBED - no member vars to save. jba.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override{};
 };
 EMPTY_DTOR(TurretAIAimTurretState)
 
@@ -173,14 +173,14 @@ class TurretAIRecenterTurretState : public TurretState
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(TurretAIRecenterTurretState, "TurretAIRecenterTurretState")
 public:
 	TurretAIRecenterTurretState( TurretStateMachine* machine ) : TurretState( machine, "TurretAIRecenterTurretState" ) { }
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 protected:
 	// snapshot interface	STUBBED - no member vars to save. jba.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override{};
+	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override{};
 };
 EMPTY_DTOR(TurretAIRecenterTurretState)
 
@@ -198,14 +198,14 @@ public:
 	{
 		m_timestamp = 0;
 	}
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
+	virtual StateReturnType update() override;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 };
 EMPTY_DTOR(TurretAIHoldTurretState)
 
@@ -286,7 +286,7 @@ public:
 
 	Bool isOwnersCurWeaponOnTurret() const;
 	Bool isWeaponSlotOnTurret(WeaponSlotType wslot) const;
-	Bool isAttackingObject() const { return m_target == TARGET_OBJECT; }
+	virtual Bool isAttackingObject() const override { return m_target == TARGET_OBJECT; }
 	Bool isForceAttacking() const { return m_isForceAttacking; }
 
 	// this will cause the turret to continuously track the given victim.
@@ -307,10 +307,10 @@ public:
 
 	UpdateSleepTime updateTurretAI();			///< implement this module's behavior
 
-	virtual void notifyFired();
-	virtual void notifyNewVictimChosen(Object* victim);
-	virtual const Coord3D* getOriginalVictimPos() const { return nullptr; }	// yes, we return nullptr here
-	virtual Bool isWeaponSlotOkToFire(WeaponSlotType wslot) const;
+	virtual void notifyFired() override;
+	virtual void notifyNewVictimChosen(Object* victim) override;
+	virtual const Coord3D* getOriginalVictimPos() const override { return nullptr; }	// yes, we return nullptr here
+	virtual Bool isWeaponSlotOkToFire(WeaponSlotType wslot) const override;
 
 	// these are only for use by the state machines... don't call them otherwise, please
 	Bool friend_turnTowardsAngle(Real desiredAngle, Real rateModifier, Real relThresh);
@@ -332,9 +332,9 @@ public:
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 private:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/TurretAI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/TurretAI.h
@@ -158,9 +158,9 @@ public:
 	virtual StateReturnType update() override;
 protected:
 	// snapshot interface	STUBBED - no member vars to save. jba.
-	virtual void crc( Xfer *xfer ) override{};
-	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess() override{};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 };
 EMPTY_DTOR(TurretAIAimTurretState)
 
@@ -178,9 +178,9 @@ public:
 	virtual StateReturnType update() override;
 protected:
 	// snapshot interface	STUBBED - no member vars to save. jba.
-	virtual void crc( Xfer *xfer ) override{};
-	virtual void xfer( Xfer *xfer ) override{XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess() override{};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 };
 EMPTY_DTOR(TurretAIRecenterTurretState)
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/VictoryConditions.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/VictoryConditions.h
@@ -51,9 +51,9 @@ class VictoryConditionsInterface : public SubsystemInterface
 public:
 	VictoryConditionsInterface() { m_victoryConditions = 0; }
 
-	virtual void init() override = 0;
-	virtual void reset() override = 0;
-	virtual void update() override = 0;
+	virtual void init() = 0;
+	virtual void reset() = 0;
+	virtual void update() = 0;
 
 	void setVictoryConditions( Int victoryConditions ) { m_victoryConditions = victoryConditions; }
 	Int getVictoryConditions() { return m_victoryConditions; }

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/VictoryConditions.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/VictoryConditions.h
@@ -51,9 +51,9 @@ class VictoryConditionsInterface : public SubsystemInterface
 public:
 	VictoryConditionsInterface() { m_victoryConditions = 0; }
 
-	virtual void init() = 0;
-	virtual void reset() = 0;
-	virtual void update() = 0;
+	virtual void init() override = 0;
+	virtual void reset() override = 0;
+	virtual void update() override = 0;
 
 	void setVictoryConditions( Int victoryConditions ) { m_victoryConditions = victoryConditions; }
 	Int getVictoryConditions() { return m_victoryConditions; }

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Weapon.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Weapon.h
@@ -585,9 +585,9 @@ private:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 public:
 
@@ -829,12 +829,12 @@ class WeaponStore : public SubsystemInterface
 public:
 
 	WeaponStore();
-	~WeaponStore();
+	virtual ~WeaponStore() override;
 
-	void init() { };
-	void postProcessLoad();
-	void reset();
-	void update();
+	virtual void init() override { };
+	virtual void postProcessLoad() override;
+	virtual void reset() override;
+	virtual void update() override;
 
 	/**
 		Find the WeaponTemplate with the given name. If no such WeaponTemplate exists, return null.

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/WeaponSet.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/WeaponSet.h
@@ -208,9 +208,9 @@ private:
 
 protected:
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 public:
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/DownloadMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/DownloadMenu.cpp
@@ -122,11 +122,11 @@ class DownloadManagerMunkee : public DownloadManager
 {
 public:
 	DownloadManagerMunkee() {m_shouldQuitOnSuccess = true; m_shouldQuitOnSuccess = false;}
-	virtual HRESULT OnError( Int error );
-	virtual HRESULT OnEnd();
-	virtual HRESULT OnProgressUpdate( Int bytesread, Int totalsize, Int timetaken, Int timeleft );
-	virtual HRESULT OnStatusUpdate( Int status );
-	virtual HRESULT downloadFile( AsciiString server, AsciiString username, AsciiString password, AsciiString file, AsciiString localfile, AsciiString regkey, Bool tryResume );
+	virtual HRESULT OnError( Int error ) override;
+	virtual HRESULT OnEnd() override;
+	virtual HRESULT OnProgressUpdate( Int bytesread, Int totalsize, Int timetaken, Int timeleft ) override;
+	virtual HRESULT OnStatusUpdate( Int status ) override;
+	virtual HRESULT downloadFile( AsciiString server, AsciiString username, AsciiString password, AsciiString file, AsciiString localfile, AsciiString regkey, Bool tryResume ) override;
 
 private:
 	Bool m_shouldQuitOnSuccess;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLoginMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLLoginMenu.cpp
@@ -88,12 +88,12 @@ class GameSpyLoginPreferences : public UserPreferences
 {
 public:
 	GameSpyLoginPreferences();
-	virtual ~GameSpyLoginPreferences();
+	virtual ~GameSpyLoginPreferences() override;
 
 	Bool loadFromIniFile();
 
-	virtual Bool load(AsciiString fname);
-	virtual Bool write();
+	virtual Bool load(AsciiString fname) override;
+	virtual Bool write() override;
 
 	AsciiString getPasswordForEmail( AsciiString email );
 	AsciiString getDateForEmail( AsciiString email, AsciiString &month, AsciiString &date, AsciiString &year  );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AI.cpp
@@ -516,7 +516,7 @@ private:
 public:
 	PartitionFilterLiveMapEnemies(const Object *obj) : m_obj(obj) { }
 
-	virtual Bool allow(Object *objOther)
+	virtual Bool allow(Object *objOther) override
 	{
 		// this is way fast (bit test) so do it first.
 		if (objOther->isEffectivelyDead())
@@ -546,7 +546,7 @@ private:
 public:
 	PartitionFilterWithinAttackRange(const Object* obj) : m_obj(obj) { }
 
-	virtual Bool allow(Object* objOther)
+	virtual Bool allow(Object* objOther) override
 	{
 		for (Int i = 0; i < WEAPONSLOT_COUNT;	i++ )
 		{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIStates.cpp
@@ -1950,9 +1950,9 @@ public:
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 };
 
 // ------------------------------------------------------------------------------------------------
@@ -5747,9 +5747,9 @@ public:
 	AIAttackThenIdleStateMachine( Object *owner, AsciiString name );
 protected:
 	// snapshot interface .
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 };
 
 // ------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
@@ -132,7 +132,7 @@ public:
 	{
 	}
 
-	virtual Object* create( const Object* primaryObj, const Coord3D *primary, const Coord3D* secondary, Real angle, UnsignedInt lifetimeFrames = 0 ) const
+	virtual Object* create( const Object* primaryObj, const Coord3D *primary, const Coord3D* secondary, Real angle, UnsignedInt lifetimeFrames = 0 ) const override
 	{
 		if (!primaryObj || !primary || !secondary)
 		{
@@ -179,7 +179,7 @@ public:
 	{
 	}
 
-	virtual Object* create( const Object* primaryObj, const Coord3D *primary, const Coord3D* secondary, Real angle, UnsignedInt lifetimeFrames = 0 ) const
+	virtual Object* create( const Object* primaryObj, const Coord3D *primary, const Coord3D* secondary, Real angle, UnsignedInt lifetimeFrames = 0 ) const override
 	{
 		if (!primaryObj || !primary || !secondary)
 		{
@@ -261,12 +261,12 @@ public:
 		m_transportName.clear();
 	}
 
-	virtual Object* create(const Object *primaryObj, const Coord3D *primary, const Coord3D *secondary, Real angle, UnsignedInt lifetimeFrames = 0 ) const
+	virtual Object* create(const Object *primaryObj, const Coord3D *primary, const Coord3D *secondary, Real angle, UnsignedInt lifetimeFrames = 0 ) const override
 	{
 		return create( primaryObj, primary, secondary, true, lifetimeFrames );
 	}
 
-	virtual Object* create(const Object* primaryObj, const Coord3D *primary, const Coord3D* secondary, Bool createOwner, UnsignedInt lifetimeFrames = 0 ) const
+	virtual Object* create(const Object* primaryObj, const Coord3D *primary, const Coord3D* secondary, Bool createOwner, UnsignedInt lifetimeFrames = 0 ) const override
 	{
 		if (!primaryObj || !primary || !secondary)
 		{
@@ -619,7 +619,7 @@ public:
 	{
 	}
 
-	virtual Object* create( const Object* primary, const Object* secondary, UnsignedInt lifetimeFrames = 0 ) const
+	virtual Object* create( const Object* primary, const Object* secondary, UnsignedInt lifetimeFrames = 0 ) const override
 	{
 		if (primary)
 		{
@@ -650,7 +650,7 @@ public:
 		return nullptr;
 	}
 
-	virtual Object* create(const Object* primaryObj, const Coord3D *primary, const Coord3D* secondary, Real angle, UnsignedInt lifetimeFrames = 0 ) const
+	virtual Object* create(const Object* primaryObj, const Coord3D *primary, const Coord3D* secondary, Real angle, UnsignedInt lifetimeFrames = 0 ) const override
 	{
 		DEBUG_CRASH(("You must call this effect with an object, not a location"));
 		return nullptr;
@@ -775,7 +775,7 @@ public:
 		m_offset.zero();
 	}
 
-	virtual Object* create(const Object* primary, const Object* secondary, UnsignedInt lifetimeFrames = 0 ) const
+	virtual Object* create(const Object* primary, const Object* secondary, UnsignedInt lifetimeFrames = 0 ) const override
 	{
 		if (primary)
 		{
@@ -791,7 +791,7 @@ public:
 		return nullptr;
 	}
 
-	virtual Object* create(const Object* primaryObj, const Coord3D *primary, const Coord3D* secondary, Real angle, UnsignedInt lifetimeFrames = 0 ) const
+	virtual Object* create(const Object* primaryObj, const Coord3D *primary, const Coord3D* secondary, Real angle, UnsignedInt lifetimeFrames = 0 ) const override
 	{
 		if (primary)
 		{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/ChinookAIUpdate.cpp
@@ -114,13 +114,13 @@ class ChinookEvacuateState : public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(ChinookEvacuateState, "ChinookEvacuateState")
 protected:
 	// snapshot interface	STUBBED - no member vars to save. jba.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){};
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {};
+	virtual void loadPostProcess() override {};
 public:
 	ChinookEvacuateState( StateMachine *machine ) : State( machine, "ChinookEvacuateState" ) { }
 
-	StateReturnType onEnter()
+	virtual StateReturnType onEnter() override
 	{
 		Object* obj = getMachineOwner();
 		if( obj->getContain() )
@@ -131,7 +131,7 @@ public:
 		return STATE_SUCCESS;
 	}
 
-	virtual StateReturnType update()
+	virtual StateReturnType update() override
 	{
 		return STATE_SUCCESS;
 	}
@@ -145,13 +145,13 @@ class ChinookHeadOffMapState :  public State
 	//I'm outta here
 protected:
 	// snapshot interface	STUBBED - no member vars to save. jba.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){};
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {};
+	virtual void loadPostProcess() override {};
 public:
 	ChinookHeadOffMapState( StateMachine *machine ) : State( machine, "ChinookHeadOffMapState" ) {}
 
-	StateReturnType onEnter() // Give move order out of town
+	virtual StateReturnType onEnter() override // Give move order out of town
 	{
 		Object *owner = getMachineOwner();
 		ChinookAIUpdate* ai = (ChinookAIUpdate*)owner->getAIUpdateInterface();
@@ -163,7 +163,7 @@ public:
 		return STATE_CONTINUE;
 	}
 
-	StateReturnType update()
+	virtual StateReturnType update() override
 	{
 		Object *owner = getMachineOwner();
 
@@ -196,12 +196,12 @@ private:
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer )
+	virtual void crc( Xfer *xfer ) override
 	{
 		// empty
 	}
 
-	virtual void xfer( Xfer *xfer )
+	virtual void xfer( Xfer *xfer ) override
 	{
 		// version
 		XferVersion currentVersion = 1;
@@ -212,7 +212,7 @@ protected:
 		xfer->xferBool(&m_landing);
 	}
 
-	virtual void loadPostProcess()
+	virtual void loadPostProcess() override
 	{
 		// empty
 	}
@@ -223,7 +223,7 @@ public:
 		m_destLoc.zero();
 	}
 
-	virtual StateReturnType onEnter()
+	virtual StateReturnType onEnter() override
 	{
 		Object* obj = getMachineOwner();
 		ChinookAIUpdate* ai = (ChinookAIUpdate*)obj->getAIUpdateInterface();
@@ -280,7 +280,7 @@ public:
 		return STATE_CONTINUE;
 	}
 
-	virtual StateReturnType update()
+	virtual StateReturnType update() override
 	{
 		Object* obj = getMachineOwner();
 		if (obj->isEffectivelyDead())
@@ -298,7 +298,7 @@ public:
 		return STATE_CONTINUE;
 	}
 
-	virtual void onExit( StateExitType status )
+	virtual void onExit( StateExitType status ) override
 	{
 		Object* obj = getMachineOwner();
 		ChinookAIUpdate* ai = (ChinookAIUpdate*)obj->getAIUpdateInterface();
@@ -416,12 +416,12 @@ private:
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer )
+	virtual void crc( Xfer *xfer ) override
 	{
 		// empty
 	}
 
-	virtual void xfer( Xfer *xfer )
+	virtual void xfer( Xfer *xfer ) override
 	{
 		// version
 		const XferVersion currentVersion = 2;
@@ -468,7 +468,7 @@ protected:
 		}
 	}
 
-	virtual void loadPostProcess()
+	virtual void loadPostProcess() override
 	{
 		for (std::vector<RopeInfo>::iterator it = m_ropes.begin(); it != m_ropes.end(); ++it)
 		{
@@ -482,7 +482,7 @@ public:
 	ChinookCombatDropState( StateMachine *machine ): State( machine, "ChinookCombatDropState" ) { }
 
 	// --------------
-	virtual StateReturnType onEnter()
+	virtual StateReturnType onEnter() override
 	{
 		Object* obj = getMachineOwner();
 		Drawable* draw = obj->getDrawable();
@@ -548,7 +548,7 @@ public:
 	}
 
 	// --------------
-	virtual StateReturnType update()
+	virtual StateReturnType update() override
 	{
 		Object* obj = getMachineOwner();
 		ChinookAIUpdate* ai = (ChinookAIUpdate*)obj->getAIUpdateInterface();
@@ -640,7 +640,7 @@ public:
 	}
 
 	// --------------
-	virtual void onExit( StateExitType status )
+	virtual void onExit( StateExitType status ) override
 	{
 		Object* obj = getMachineOwner();
 		ChinookAIUpdate* ai = (ChinookAIUpdate*)obj->getAIUpdateInterface();
@@ -698,12 +698,12 @@ private:
 	Real m_destZ;
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer )
+	virtual void crc( Xfer *xfer ) override
 	{
 		// empty
 	}
 
-	virtual void xfer( Xfer *xfer )
+	virtual void xfer( Xfer *xfer ) override
 	{
 		// version
 		XferVersion currentVersion = 1;
@@ -715,7 +715,7 @@ protected:
 		xfer->xferReal(&m_destZ);
 	}
 
-	virtual void loadPostProcess()
+	virtual void loadPostProcess() override
 	{
 		// empty
 	}
@@ -723,7 +723,7 @@ protected:
 public:
 	ChinookMoveToBldgState( StateMachine *machine ): AIMoveToState( machine ) { }
 
-	virtual StateReturnType onEnter()
+	virtual StateReturnType onEnter() override
 	{
 		Object* obj = getMachineOwner();
 		ChinookAIUpdate* ai = (ChinookAIUpdate*)obj->getAIUpdateInterface();
@@ -754,7 +754,7 @@ public:
 		return AIMoveToState::onEnter();
 	}
 
-	virtual StateReturnType update()
+	virtual StateReturnType update() override
 	{
 		Object* obj = getMachineOwner();
 
@@ -768,7 +768,7 @@ public:
 		return status;
 	}
 
-	virtual void onExit( StateExitType status )
+	virtual void onExit( StateExitType status ) override
 	{
 		Object* obj = getMachineOwner();
 		ChinookAIUpdate* ai = (ChinookAIUpdate*)obj->getAIUpdateInterface();
@@ -790,12 +790,12 @@ class ChinookRecordCreationState : public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(ChinookRecordCreationState, "ChinookRecordCreationState")
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer )
+	virtual void crc( Xfer *xfer ) override
 	{
 		// empty
 	}
 
-	virtual void xfer( Xfer *xfer )
+	virtual void xfer( Xfer *xfer ) override
 	{
 		// version
 		XferVersion currentVersion = 1;
@@ -803,7 +803,7 @@ protected:
 		xfer->xferVersion( &version, currentVersion );
 	}
 
-	virtual void loadPostProcess()
+	virtual void loadPostProcess() override
 	{
 		// empty
 	}
@@ -811,7 +811,7 @@ protected:
 public:
 	ChinookRecordCreationState( StateMachine *machine ): State( machine, "ChinookRecordCreationState" ) { }
 
-	virtual StateReturnType onEnter()
+	virtual StateReturnType onEnter() override
 	{
 		Object* obj = getMachineOwner();
 		ChinookAIUpdate* ai = (ChinookAIUpdate*)obj->getAIUpdateInterface();
@@ -822,7 +822,7 @@ public:
 		return STATE_SUCCESS;
 	}
 
-	virtual StateReturnType update()
+	virtual StateReturnType update() override
 	{
 		return STATE_SUCCESS;
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/DozerAIUpdate.cpp
@@ -86,13 +86,13 @@ class DozerActionPickActionPosState : public State
 public:
 
 	DozerActionPickActionPosState( StateMachine *machine, DozerTask task );
-	virtual StateReturnType update();
+	virtual StateReturnType update() override;
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 
@@ -243,13 +243,13 @@ class DozerActionMoveToActionPosState : public State
 public:
 
 	DozerActionMoveToActionPosState( StateMachine *machine, DozerTask task ) : State( machine, "DozerActionMoveToActionPosState" ) { m_task = task; }
-	virtual StateReturnType update();
+	virtual StateReturnType update() override;
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 
@@ -386,15 +386,15 @@ public:
 		m_task = task;
 		m_enterFrame = 0;
 	}
-	virtual StateReturnType update();
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status ) { }
+	virtual StateReturnType update() override;
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override { }
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 
@@ -797,9 +797,9 @@ public:
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 
@@ -972,15 +972,15 @@ public:
 		m_idlePlayerNumber = 0;
 		m_isMarkedAsIdle   = FALSE;
 	}
-	virtual StateReturnType update();
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType update() override;
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 
@@ -1159,16 +1159,16 @@ public:
 		Note that we DON'T use CONVERT_SLEEP_TO_CONTINUE; since we're not doing anything else
 		interesting in update, we can sleep when this machine sleeps
 	*/
-	virtual StateReturnType update() { return m_actionMachine->updateStateMachine(); }
+	virtual StateReturnType update() override { return m_actionMachine->updateStateMachine(); }
 
-	virtual StateReturnType onEnter();
-	virtual void onExit( StateExitType status );
+	virtual StateReturnType onEnter() override;
+	virtual void onExit( StateExitType status ) override;
 
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 
@@ -1258,14 +1258,14 @@ class DozerPrimaryGoingHomeState : public State
 
 protected:
 	// snapshot interface	 STUBBED no member vars
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){};
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {};
+	virtual void loadPostProcess() override {};
 
 public:
 
 	DozerPrimaryGoingHomeState( StateMachine *machine ) : State( machine, "DozerPrimaryGoingHomeState" ) { }
-	virtual StateReturnType update() { return STATE_FAILURE; }
+	virtual StateReturnType update() override { return STATE_FAILURE; }
 
 };
 EMPTY_DTOR(DozerPrimaryGoingHomeState)

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -152,7 +152,7 @@ protected:
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterHasParkingPlace"; }
 #endif
-	virtual Bool allow(Object *objOther)
+	virtual Bool allow(Object *objOther) override
 	{
 		ParkingPlaceBehaviorInterface* pp = getPP(objOther->getID());
 		if (pp != nullptr && pp->reserveSpace(m_id, 0.0f, nullptr))
@@ -200,16 +200,16 @@ class JetAwaitingRunwayState : public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(JetAwaitingRunwayState, "JetAwaitingRunwayState")
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 private:
 	const Bool m_landing;
 
 public:
 	JetAwaitingRunwayState( StateMachine *machine, Bool landing ) : m_landing(landing), State( machine, "JetAwaitingRunwayState") { }
 
-	virtual StateReturnType onEnter()
+	virtual StateReturnType onEnter() override
 	{
 		Object* jet = getMachineOwner();
 		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();
@@ -222,7 +222,7 @@ public:
 		return STATE_CONTINUE;
 	}
 
-	virtual StateReturnType update()
+	virtual StateReturnType update() override
 	{
 		Object* jet = getMachineOwner();
 		if (jet->isEffectivelyDead())
@@ -287,7 +287,7 @@ public:
 		return STATE_CONTINUE;
 	}
 
-	virtual void onExit(StateExitType status)
+	virtual void onExit(StateExitType status) override
 	{
 		Object* jet = getMachineOwner();
 		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();
@@ -313,9 +313,9 @@ class JetOrHeliCirclingDeadAirfieldState : public State
 protected:
 	// snapshot interface	 STUBBED.
 	// The state will check immediately after a load game, but I think that's ok.  jba.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 
 private:
 	Int m_checkAirfield;
@@ -331,7 +331,7 @@ public:
 		State( machine, "JetOrHeliCirclingDeadAirfieldState"),
 		m_checkAirfield(0) { }
 
-	virtual StateReturnType onEnter()
+	virtual StateReturnType onEnter() override
 	{
 		Object* jet = getMachineOwner();
 		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();
@@ -362,7 +362,7 @@ public:
 		return STATE_CONTINUE;
 	}
 
-	virtual StateReturnType update()
+	virtual StateReturnType update() override
 	{
 		Object* jet = getMachineOwner();
 		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();
@@ -418,7 +418,7 @@ class JetOrHeliReturningToDeadAirfieldState : public AIInternalMoveToState
 public:
 	JetOrHeliReturningToDeadAirfieldState( StateMachine *machine ) : AIInternalMoveToState( machine, "JetOrHeliReturningToDeadAirfieldState") { }
 
-	virtual StateReturnType onEnter()
+	virtual StateReturnType onEnter() override
 	{
 		Object* jet = getMachineOwner();
 		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();
@@ -479,7 +479,7 @@ private:
 public:
 	JetOrHeliTaxiState( StateMachine *machine, TaxiType m ) : m_taxiMode(m), AIMoveOutOfTheWayState( machine ) { }
 
-	virtual StateReturnType onEnter()
+	virtual StateReturnType onEnter() override
 	{
 		Object* jet = getMachineOwner();
 		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();
@@ -640,7 +640,7 @@ public:
 		return ret;
 	}
 
-	virtual StateReturnType update()
+	virtual StateReturnType update() override
 	{
 		Object* jet = getMachineOwner();
 		if (jet->isEffectivelyDead())
@@ -671,7 +671,7 @@ public:
 		return AIMoveOutOfTheWayState::update();
 	}
 
-	virtual void onExit( StateExitType status )
+	virtual void onExit( StateExitType status ) override
 	{
 		Object* jet = getMachineOwner();
 		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();
@@ -712,7 +712,7 @@ private:
 public:
 	JetTakeoffOrLandingState( StateMachine *machine, Bool landing ) : m_landing(landing), AIFollowPathState( machine, "JetTakeoffOrLandingState" ) { }
 
-	virtual StateReturnType onEnter()
+	virtual StateReturnType onEnter() override
 	{
 		Object* jet = getMachineOwner();
 		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();
@@ -805,7 +805,7 @@ public:
 		return ret;
 	}
 
-	virtual StateReturnType update()
+	virtual StateReturnType update() override
 	{
 		Object* jet = getMachineOwner();
 		if (jet->isEffectivelyDead())
@@ -882,7 +882,7 @@ public:
 		return ret;
 	}
 
-	virtual void onExit( StateExitType status )
+	virtual void onExit( StateExitType status ) override
 	{
 		AIFollowPathState::onExit(status);
 
@@ -940,12 +940,12 @@ class HeliTakeoffOrLandingState : public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(HeliTakeoffOrLandingState, "HeliTakeoffOrLandingState")
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer )
+	virtual void crc( Xfer *xfer ) override
 	{
 		// empty. jba.
 	}
 
-	virtual void xfer( Xfer *xfer )
+	virtual void xfer( Xfer *xfer ) override
 	{
 		// version
 		XferVersion currentVersion = 1;
@@ -959,7 +959,7 @@ protected:
 		xfer->xferCoord3D(&m_parkingLoc);
 		xfer->xferReal(&m_parkingOrientation);
 	}
-	virtual void loadPostProcess()
+	virtual void loadPostProcess() override
 	{
 		// empty. jba.
 	}
@@ -977,7 +977,7 @@ public:
 			m_parkingLoc.zero();
 		}
 
-	virtual StateReturnType onEnter()
+	virtual StateReturnType onEnter() override
 	{
 		Object* jet = getMachineOwner();
 		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();
@@ -1043,7 +1043,7 @@ public:
 		return STATE_CONTINUE;
 	}
 
-	virtual StateReturnType update()
+	virtual StateReturnType update() override
 	{
 		Object* jet = getMachineOwner();
 		if (jet->isEffectivelyDead())
@@ -1105,7 +1105,7 @@ public:
 		return STATE_CONTINUE;
 	}
 
-	virtual void onExit( StateExitType status )
+	virtual void onExit( StateExitType status ) override
 	{
 		// just in case.
 		Object* jet = getMachineOwner();
@@ -1152,14 +1152,14 @@ class JetOrHeliParkOrientState : public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(JetOrHeliParkOrientState, "JetOrHeliParkOrientState")
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {XferVersion cv = 1;	XferVersion v = cv; xfer->xferVersion( &v, cv );}
+	virtual void loadPostProcess() override {};
 
 public:
 	JetOrHeliParkOrientState( StateMachine *machine ) : State( machine, "JetOrHeliParkOrientState") { }
 
-	virtual StateReturnType onEnter()
+	virtual StateReturnType onEnter() override
 	{
 		Object* jet = getMachineOwner();
 		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();
@@ -1178,7 +1178,7 @@ public:
 		return STATE_CONTINUE;
 	}
 
-	virtual StateReturnType update()
+	virtual StateReturnType update() override
 	{
 		Object* jet = getMachineOwner();
 		if (jet->isEffectivelyDead())
@@ -1218,7 +1218,7 @@ public:
 		return STATE_CONTINUE;
 	}
 
-	virtual void onExit( StateExitType status )
+	virtual void onExit( StateExitType status ) override
 	{
 		Object* jet = getMachineOwner();
 		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();
@@ -1238,12 +1238,12 @@ class JetPauseBeforeTakeoffState : public AIFaceState
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(JetPauseBeforeTakeoffState, "JetPauseBeforeTakeoffState")
 protected:
 	// snapshot interface
-	virtual void crc( Xfer *xfer )
+	virtual void crc( Xfer *xfer ) override
 	{
 		// empty. jba.
 	}
 
-	virtual void xfer( Xfer *xfer )
+	virtual void xfer( Xfer *xfer ) override
 	{
 		// version
 #if RETAIL_COMPATIBLE_CRC || RETAIL_COMPATIBLE_XFER_SAVE
@@ -1277,7 +1277,7 @@ protected:
 		xfer->xferObjectID(&m_waitedForTaxiID);
 	}
 
-	virtual void loadPostProcess()
+	virtual void loadPostProcess() override
 	{
 		// empty. jba.
 	}
@@ -1369,7 +1369,7 @@ public:
 		// nothing
 	}
 
-	virtual StateReturnType onEnter()
+	virtual StateReturnType onEnter() override
 	{
 		Object* jet = getMachineOwner();
 		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();
@@ -1401,7 +1401,7 @@ public:
 	}
 
 #if RETAIL_COMPATIBLE_CRC || RETAIL_COMPATIBLE_XFER_SAVE
-	virtual StateReturnType update()
+	virtual StateReturnType update() override
 	{
 		Object* jet = getMachineOwner();
 		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();
@@ -1455,7 +1455,7 @@ public:
 #else
 	// TheSuperHackers @bugfix Reimplements the update to wait for another Jet on another runway.
 	// If this must work with more than 2 runways, then this logic needs another look.
-	virtual StateReturnType update()
+	virtual StateReturnType update() override
 	{
 		Object* jet = getMachineOwner();
 		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();
@@ -1528,7 +1528,7 @@ public:
 	}
 #endif
 
-	virtual void onExit(StateExitType status)
+	virtual void onExit(StateExitType status) override
 	{
 		Object* jet = getMachineOwner();
 		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();
@@ -1551,12 +1551,12 @@ private:
 protected:
 
 	// snapshot interface
-	virtual void crc( Xfer *xfer )
+	virtual void crc( Xfer *xfer ) override
 	{
 		// empty. jba.
 	}
 
-	virtual void xfer( Xfer *xfer )
+	virtual void xfer( Xfer *xfer ) override
 	{
 		// version
 		XferVersion currentVersion = 1;
@@ -1567,7 +1567,7 @@ protected:
 		xfer->xferUnsignedInt(&m_reloadTime);
 		xfer->xferUnsignedInt(&m_reloadDoneFrame);
 	}
-	virtual void loadPostProcess()
+	virtual void loadPostProcess() override
 	{
 		// empty. jba.
 	}
@@ -1575,7 +1575,7 @@ protected:
 public:
 	JetOrHeliReloadAmmoState( StateMachine *machine ) : State( machine, "JetOrHeliReloadAmmoState") { }
 
-	virtual StateReturnType onEnter()
+	virtual StateReturnType onEnter() override
 	{
 		Object* jet = getMachineOwner();
 		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();
@@ -1612,7 +1612,7 @@ public:
 		return STATE_CONTINUE;
 	}
 
-	virtual StateReturnType update()
+	virtual StateReturnType update() override
 	{
 		Object* jet = getMachineOwner();
 		UnsignedInt now = TheGameLogic->getFrame();
@@ -1638,7 +1638,7 @@ public:
 		return STATE_CONTINUE;
 	}
 
-	virtual void onExit(StateExitType status)
+	virtual void onExit(StateExitType status) override
 	{
 		Object* jet = getMachineOwner();
 		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();
@@ -1660,7 +1660,7 @@ class JetOrHeliReturnForLandingState : public AIInternalMoveToState
 public:
 	JetOrHeliReturnForLandingState( StateMachine *machine ) : AIInternalMoveToState( machine, "JetOrHeliReturnForLandingState") { }
 
-	virtual StateReturnType onEnter()
+	virtual StateReturnType onEnter() override
 	{
 		Object* jet = getMachineOwner();
 		JetAIUpdate* jetAI = (JetAIUpdate*)jet->getAIUpdateInterface();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/RailroadGuideAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/RailroadGuideAIUpdate.cpp
@@ -906,7 +906,7 @@ public:
 	virtual const char* debugGetName() { return "PartitionFilterIsValidCarriage"; }
 #endif
 
-	virtual Bool allow(Object *objOther)
+	virtual Bool allow(Object *objOther) override
 	{
 
 		// must exist!

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/SupplyTruckAIUpdate.cpp
@@ -293,13 +293,13 @@ class SupplyTruckBusyState :  public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(SupplyTruckBusyState, "SupplyTruckBusyState")
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){};
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {};
+	virtual void loadPostProcess() override {};
 
 public:
 	SupplyTruckBusyState( StateMachine *machine ) : State( machine, "SupplyTruckBusyState" ) { }
-	virtual StateReturnType onEnter()
+	virtual StateReturnType onEnter() override
 	{
 		if( getMachineOwner() && getMachineOwner()->getAI() )
 		{
@@ -317,11 +317,11 @@ TheInGameUI->DEBUG_addFloatingText("entering busy state", getMachineOwner()->get
 #endif
 		return STATE_CONTINUE;
 	}
-	virtual StateReturnType update()
+	virtual StateReturnType update() override
 	{
 		return STATE_CONTINUE;
 	}
-	virtual void onExit(StateExitType status)
+	virtual void onExit(StateExitType status) override
 	{
 #ifdef DEBUG_SUPPLY_STATE
 TheInGameUI->DEBUG_addFloatingText("exiting busy state", getMachineOwner()->getPosition(), GameMakeColor(255, 0, 0, 255));
@@ -337,18 +337,18 @@ class SupplyTruckIdleState :  public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(SupplyTruckIdleState, "SupplyTruckIdleState")
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){};
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {};
+	virtual void loadPostProcess() override {};
 
 public:
 	SupplyTruckIdleState( StateMachine *machine ) : State( machine, "SupplyTruckIdleState" ) { }
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update()
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override
 	{
 		return STATE_CONTINUE;
 	}
-	virtual void onExit(StateExitType status)
+	virtual void onExit(StateExitType status) override
 	{
 #ifdef DEBUG_SUPPLY_STATE
 TheInGameUI->DEBUG_addFloatingText("exiting idle state", getMachineOwner()->getPosition(), GameMakeColor(255, 0, 0, 255));

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/WorkerAIUpdate.cpp
@@ -1162,14 +1162,14 @@ class ActAsDozerState :  public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(ActAsDozerState, "ActAsDozerState")
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){};
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {};
+	virtual void loadPostProcess() override {};
 
 public:
 	ActAsDozerState( StateMachine *machine ) :State( machine, "ActAsDozerState" ){}
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
 	virtual StateReturnType onExit();
 };
 EMPTY_DTOR(ActAsDozerState)
@@ -1181,14 +1181,14 @@ class ActAsSupplyTruckState :  public State
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(ActAsSupplyTruckState, "ActAsSupplyTruckState")
 protected:
 	// snapshot interface STUBBED.
-	virtual void crc( Xfer *xfer ){};
-	virtual void xfer( Xfer *xfer ){};
-	virtual void loadPostProcess(){};
+	virtual void crc( Xfer *xfer ) override {};
+	virtual void xfer( Xfer *xfer ) override {};
+	virtual void loadPostProcess() override {};
 
 public:
 	ActAsSupplyTruckState( StateMachine *machine ) :State( machine, "ActAsSupplyTruckState" ){}
-	virtual StateReturnType onEnter();
-	virtual StateReturnType update();
+	virtual StateReturnType onEnter() override;
+	virtual StateReturnType update() override;
 	virtual StateReturnType onExit();
 };
 EMPTY_DTOR(ActAsSupplyTruckState)

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/FireSpreadUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/FireSpreadUpdate.cpp
@@ -50,7 +50,7 @@ public:
 
 	PartitionFilterFlammable(){ }
 
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterFlammable"; }
 #endif

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/HordeUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/HordeUpdate.cpp
@@ -78,7 +78,7 @@ public:
 	virtual const char* debugGetName() { return "PartitionFilterHordeMember"; }
 #endif
 
-	virtual Bool allow(Object *objOther)
+	virtual Bool allow(Object *objOther) override
 	{
 		// must be exact same type as us (well, maybe)
 		if (m_data->m_exactMatch && m_obj->getTemplate() != objOther->getTemplate())

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpectreGunshipUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpectreGunshipUpdate.cpp
@@ -322,7 +322,7 @@ private:
 public:
 	PartitionFilterLiveMapEnemies(const Object *obj) : m_obj(obj) { }
 
-	virtual Bool allow(Object *objOther)
+	virtual Bool allow(Object *objOther) override
 	{
 		// this is way fast (bit test) so do it first.
 		if (objOther->isEffectivelyDead())

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/StealthDetectorUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/StealthDetectorUpdate.cpp
@@ -115,7 +115,7 @@ class PartitionFilterStealthedOrStealthGarrisoned : public PartitionFilter
 public:
 	PartitionFilterStealthedOrStealthGarrisoned() { }
 
-	virtual Bool allow(Object *objOther);
+	virtual Bool allow(Object *objOther) override;
 
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterStealthedOrStealthGarrisoned"; }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/TensileFormationUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/TensileFormationUpdate.cpp
@@ -74,7 +74,7 @@ public:
 #if defined(RTS_DEBUG)
 	virtual const char* debugGetName() { return "PartitionFilterTensileFormationMember"; }
 #endif
-	virtual Bool allow( Object *objOther )
+	virtual Bool allow( Object *objOther ) override
 	{
 		return ( getTFU( objOther ) != nullptr );
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/VictoryConditions.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/VictoryConditions.cpp
@@ -77,21 +77,21 @@ class VictoryConditions : public VictoryConditionsInterface
 public:
 	VictoryConditions();
 
-	void init();
-	void reset();
-	void update();
+	void init() override;
+	void reset() override;
+	void update() override;
 
-	Bool hasAchievedVictory(Player *player);					///< has a specific player and his allies won?
-	Bool hasBeenDefeated(Player *player);							///< has a specific player and his allies lost?
-	Bool hasSinglePlayerBeenDefeated(Player *player);	///< has a specific player lost?
+	virtual Bool hasAchievedVictory(Player *player) override;					///< has a specific player and his allies won?
+	virtual Bool hasBeenDefeated(Player *player) override;							///< has a specific player and his allies lost?
+	virtual Bool hasSinglePlayerBeenDefeated(Player *player) override;	///< has a specific player lost?
 
-	void cachePlayerPtrs();											///< players have been created - cache the ones of interest
+	void cachePlayerPtrs() override;											///< players have been created - cache the ones of interest
 
-	Bool isLocalAlliedVictory();								///< convenience function
-	Bool isLocalAlliedDefeat();									///< convenience function
-	Bool isLocalDefeat();												///< convenience function
-	Bool amIObserver() { return m_isObserver;} 	///< Am I an observer?( need this for scripts )
-	virtual UnsignedInt getEndFrame() { return m_endFrame; }	///< on which frame was the game effectively over?
+	Bool isLocalAlliedVictory() override;								///< convenience function
+	Bool isLocalAlliedDefeat() override;									///< convenience function
+	Bool isLocalDefeat() override;												///< convenience function
+	Bool amIObserver() override { return m_isObserver;} 	///< Am I an observer?( need this for scripts )
+	virtual UnsignedInt getEndFrame() override { return m_endFrame; }	///< on which frame was the game effectively over?
 private:
 	Player* findFirstUndefeatedPlayer(); ///< Find the first player that has not been defeated.
 	void markAllianceVictorious(Player* victoriousPlayer); ///< Mark the victorious player and his allies as victorious.

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/VictoryConditions.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/VictoryConditions.cpp
@@ -77,20 +77,20 @@ class VictoryConditions : public VictoryConditionsInterface
 public:
 	VictoryConditions();
 
-	void init() override;
-	void reset() override;
-	void update() override;
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override;
 
 	virtual Bool hasAchievedVictory(Player *player) override;					///< has a specific player and his allies won?
 	virtual Bool hasBeenDefeated(Player *player) override;							///< has a specific player and his allies lost?
 	virtual Bool hasSinglePlayerBeenDefeated(Player *player) override;	///< has a specific player lost?
 
-	void cachePlayerPtrs() override;											///< players have been created - cache the ones of interest
+	virtual void cachePlayerPtrs() override;											///< players have been created - cache the ones of interest
 
-	Bool isLocalAlliedVictory() override;								///< convenience function
-	Bool isLocalAlliedDefeat() override;									///< convenience function
-	Bool isLocalDefeat() override;												///< convenience function
-	Bool amIObserver() override { return m_isObserver;} 	///< Am I an observer?( need this for scripts )
+	virtual Bool isLocalAlliedVictory() override;								///< convenience function
+	virtual Bool isLocalAlliedDefeat() override;									///< convenience function
+	virtual Bool isLocalDefeat() override;												///< convenience function
+	virtual Bool amIObserver() override { return m_isObserver;} 	///< Am I an observer?( need this for scripts )
 	virtual UnsignedInt getEndFrame() override { return m_endFrame; }	///< on which frame was the game effectively over?
 private:
 	Player* findFirstUndefeatedPlayer(); ///< Find the first player that has not been defeated.


### PR DESCRIPTION
## Summary
- Add `override` keyword to virtual function overrides in GameEngine (excluding GameLogic/Module)
- Covers Include/Common, Include/GameClient, Include/GameNetwork, Include/GameLogic (non-Module), and Source
- Changes across Core, Generals, and GeneralsMD

## Context
Part 4/6 of splitting #2101. Depends on #2389 merging first.

## Notes
- 294 files changed, purely mechanical `override` keyword additions
- Includes bugfix: remove spurious `virtual` keyword from enum entries in Scripts.h
- All lines retain the `virtual` keyword