### PR TITLE
refactor: Add override keyword to virtual function overrides in GameEngineDevice

### DIFF
--- a/Core/GameEngineDevice/Include/MilesAudioDevice/MilesAudioManager.h
+++ b/Core/GameEngineDevice/Include/MilesAudioDevice/MilesAudioManager.h
@@ -142,70 +142,70 @@ class MilesAudioManager : public AudioManager
 #endif
 
 		// from AudioDevice
-		virtual void init();
-		virtual void postProcessLoad();
-		virtual void reset();
-		virtual void update();
+		virtual void init() override;
+		virtual void postProcessLoad() override;
+		virtual void reset() override;
+		virtual void update() override;
 
 		MilesAudioManager();
-		virtual ~MilesAudioManager();
+		virtual ~MilesAudioManager() override;
 
 
-		virtual void nextMusicTrack();
-		virtual void prevMusicTrack();
-		virtual Bool isMusicPlaying() const;
-		virtual Bool hasMusicTrackCompleted( const AsciiString& trackName, Int numberOfTimes ) const;
-		virtual AsciiString getMusicTrackName() const;
+		virtual void nextMusicTrack() override;
+		virtual void prevMusicTrack() override;
+		virtual Bool isMusicPlaying() const override;
+		virtual Bool hasMusicTrackCompleted( const AsciiString& trackName, Int numberOfTimes ) const override;
+		virtual AsciiString getMusicTrackName() const override;
 
-		virtual void openDevice();
-		virtual void closeDevice();
-		virtual void *getDevice() { return m_digitalHandle; }
+		virtual void openDevice() override;
+		virtual void closeDevice() override;
+		virtual void *getDevice() override { return m_digitalHandle; }
 
-		virtual void stopAudio( AudioAffect which );
-		virtual void pauseAudio( AudioAffect which );
-		virtual void resumeAudio( AudioAffect which );
-		virtual void pauseAmbient( Bool shouldPause );
+		virtual void stopAudio( AudioAffect which ) override;
+		virtual void pauseAudio( AudioAffect which ) override;
+		virtual void resumeAudio( AudioAffect which ) override;
+		virtual void pauseAmbient( Bool shouldPause ) override;
 
-		virtual void killAudioEventImmediately( AudioHandle audioEvent );
+		virtual void killAudioEventImmediately( AudioHandle audioEvent ) override;
 
 		///< Return whether the current audio is playing or not.
 		///< NOTE NOTE NOTE !!DO NOT USE THIS IN FOR GAMELOGIC PURPOSES!! NOTE NOTE NOTE
-		virtual Bool isCurrentlyPlaying( AudioHandle handle );
+		virtual Bool isCurrentlyPlaying( AudioHandle handle ) override;
 
-		virtual void notifyOfAudioCompletion( UnsignedInt audioCompleted, UnsignedInt flags );
+		virtual void notifyOfAudioCompletion( UnsignedInt audioCompleted, UnsignedInt flags ) override;
 		virtual PlayingAudio *findPlayingAudioFrom( UnsignedInt audioCompleted, UnsignedInt flags );
 
-		virtual UnsignedInt getProviderCount() const;
-		virtual AsciiString getProviderName( UnsignedInt providerNum ) const;
-		virtual UnsignedInt getProviderIndex( AsciiString providerName ) const;
-		virtual void selectProvider( UnsignedInt providerNdx );
-		virtual void unselectProvider();
-		virtual UnsignedInt getSelectedProvider() const;
-		virtual void setSpeakerType( UnsignedInt speakerType );
-		virtual UnsignedInt getSpeakerType();
+		virtual UnsignedInt getProviderCount() const override;
+		virtual AsciiString getProviderName( UnsignedInt providerNum ) const override;
+		virtual UnsignedInt getProviderIndex( AsciiString providerName ) const override;
+		virtual void selectProvider( UnsignedInt providerNdx ) override;
+		virtual void unselectProvider() override;
+		virtual UnsignedInt getSelectedProvider() const override;
+		virtual void setSpeakerType( UnsignedInt speakerType ) override;
+		virtual UnsignedInt getSpeakerType() override;
 
- 		virtual void *getHandleForBink();
- 		virtual void releaseHandleForBink();
+ 		virtual void *getHandleForBink() override;
+ 		virtual void releaseHandleForBink() override;
 
-		virtual void friend_forcePlayAudioEventRTS(const AudioEventRTS* eventToPlay);
+		virtual void friend_forcePlayAudioEventRTS(const AudioEventRTS* eventToPlay) override;
 
-		virtual UnsignedInt getNum2DSamples() const;
-		virtual UnsignedInt getNum3DSamples() const;
-		virtual UnsignedInt getNumStreams() const;
+		virtual UnsignedInt getNum2DSamples() const override;
+		virtual UnsignedInt getNum3DSamples() const override;
+		virtual UnsignedInt getNumStreams() const override;
 
-		virtual Bool doesViolateLimit( AudioEventRTS *event ) const;
-		virtual Bool isPlayingLowerPriority( AudioEventRTS *event ) const;
-		virtual Bool isPlayingAlready( AudioEventRTS *event ) const;
-		virtual Bool isObjectPlayingVoice( UnsignedInt objID ) const;
+		virtual Bool doesViolateLimit( AudioEventRTS *event ) const override;
+		virtual Bool isPlayingLowerPriority( AudioEventRTS *event ) const override;
+		virtual Bool isPlayingAlready( AudioEventRTS *event ) const override;
+		virtual Bool isObjectPlayingVoice( UnsignedInt objID ) const override;
 		Bool killLowestPrioritySoundImmediately( AudioEventRTS *event );
 		AudioEventRTS* findLowestPrioritySound( AudioEventRTS *event );
 
-		virtual void adjustVolumeOfPlayingAudio(AsciiString eventName, Real newVolume);
+		virtual void adjustVolumeOfPlayingAudio(AsciiString eventName, Real newVolume) override;
 
-		virtual void removePlayingAudio( AsciiString eventName );
-		virtual void removeAllDisabledAudio();
+		virtual void removePlayingAudio( AsciiString eventName ) override;
+		virtual void removeAllDisabledAudio() override;
 
-		virtual void processRequestList();
+		virtual void processRequestList() override;
 		virtual void processPlayingList();
 		virtual void processFadingList();
 		virtual void processStoppedList();
@@ -214,23 +214,23 @@ class MilesAudioManager : public AudioManager
 		void adjustRequest( AudioRequest *req );
 		Bool checkForSample( AudioRequest *req );
 
-		virtual void setHardwareAccelerated(Bool accel);
-		virtual void setSpeakerSurround(Bool surround);
+		virtual void setHardwareAccelerated(Bool accel) override;
+		virtual void setSpeakerSurround(Bool surround) override;
 
-		virtual void setPreferredProvider(AsciiString provider) { m_pref3DProvider = provider; }
-		virtual void setPreferredSpeaker(AsciiString speakerType) { m_prefSpeaker = speakerType; }
+		virtual void setPreferredProvider(AsciiString provider) override { m_pref3DProvider = provider; }
+		virtual void setPreferredSpeaker(AsciiString speakerType) override { m_prefSpeaker = speakerType; }
 
-		virtual Real getFileLengthMS( AsciiString strToLoad ) const;
+		virtual Real getFileLengthMS( AsciiString strToLoad ) const override;
 
-		virtual void closeAnySamplesUsingFile( const void *fileToClose );
+		virtual void closeAnySamplesUsingFile( const void *fileToClose ) override;
 
 
-    virtual Bool has3DSensitiveStreamsPlaying() const;
+    virtual Bool has3DSensitiveStreamsPlaying() const override;
 
 
 	protected:
 		// 3-D functions
-		virtual void setDeviceListenerPosition();
+		virtual void setDeviceListenerPosition() override;
 		const Coord3D *getCurrentPositionFromEvent( AudioEventRTS *event );
 		Bool isOnScreen( const Coord3D *pos ) const;
 		Real getEffectiveVolume(AudioEventRTS *event) const;

--- a/Core/GameEngineDevice/Include/StdDevice/Common/StdBIGFile.h
+++ b/Core/GameEngineDevice/Include/StdDevice/Common/StdBIGFile.h
@@ -36,15 +36,15 @@ class StdBIGFile : public ArchiveFile
 {
 	public:
 		StdBIGFile(AsciiString name, AsciiString path);
-		virtual ~StdBIGFile();
+		virtual ~StdBIGFile() override;
 
-		virtual Bool					getFileInfo(const AsciiString& filename, FileInfo *fileInfo) const;	///< fill in the fileInfo struct with info about the requested file.
-		virtual File*					openFile( const Char *filename, Int access = 0 );///< Open the specified file within the BIG file
-		virtual void					closeAllFiles();									///< Close all file opened in this BIG file
-		virtual AsciiString		getName();												///< Returns the name of the BIG file
-		virtual AsciiString		getPath();												///< Returns full path and name of BIG file
-		virtual void					setSearchPriority( Int new_priority );	///< Set this BIG file's search priority
-		virtual void					close();													///< Close this BIG file
+		virtual Bool					getFileInfo(const AsciiString& filename, FileInfo *fileInfo) const override;	///< fill in the fileInfo struct with info about the requested file.
+		virtual File*					openFile( const Char *filename, Int access = 0 ) override;///< Open the specified file within the BIG file
+		virtual void					closeAllFiles() override;									///< Close all file opened in this BIG file
+		virtual AsciiString		getName() override;												///< Returns the name of the BIG file
+		virtual AsciiString		getPath() override;												///< Returns full path and name of BIG file
+		virtual void					setSearchPriority( Int new_priority ) override;	///< Set this BIG file's search priority
+		virtual void					close() override;													///< Close this BIG file
 
 	protected:
 

--- a/Core/GameEngineDevice/Include/StdDevice/Common/StdBIGFileSystem.h
+++ b/Core/GameEngineDevice/Include/StdDevice/Common/StdBIGFileSystem.h
@@ -34,22 +34,22 @@ class StdBIGFileSystem : public ArchiveFileSystem
 {
 public:
 	StdBIGFileSystem();
-	virtual ~StdBIGFileSystem();
+	virtual ~StdBIGFileSystem() override;
 
-	virtual void init();
-	virtual void update();
-	virtual void reset();
-	virtual void postProcessLoad();
+	virtual void init() override;
+	virtual void update() override;
+	virtual void reset() override;
+	virtual void postProcessLoad() override;
 
 	// ArchiveFile operations
-	virtual void closeAllArchiveFiles();											///< Close all Archivefiles currently open
+	virtual void closeAllArchiveFiles() override;											///< Close all Archivefiles currently open
 
 	// File operations
-	virtual ArchiveFile * openArchiveFile(const Char *filename);
-	virtual void closeArchiveFile(const Char *filename);
-	virtual void closeAllFiles();															///< Close all files associated with ArchiveFiles
+	virtual ArchiveFile * openArchiveFile(const Char *filename) override;
+	virtual void closeArchiveFile(const Char *filename) override;
+	virtual void closeAllFiles() override;															///< Close all files associated with ArchiveFiles
 
-	virtual Bool loadBigFilesFromDirectory(AsciiString dir, AsciiString fileMask, Bool overwrite = FALSE);
+	virtual Bool loadBigFilesFromDirectory(AsciiString dir, AsciiString fileMask, Bool overwrite = FALSE) override;
 protected:
 
 };

--- a/Core/GameEngineDevice/Include/StdDevice/Common/StdLocalFileSystem.h
+++ b/Core/GameEngineDevice/Include/StdDevice/Common/StdLocalFileSystem.h
@@ -34,20 +34,20 @@ class StdLocalFileSystem : public LocalFileSystem
 {
 public:
 	StdLocalFileSystem();
-	virtual ~StdLocalFileSystem();
+	virtual ~StdLocalFileSystem() override;
 
-	virtual void init();
-	virtual void reset();
-	virtual void update();
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override;
 
-	virtual File * openFile(const Char *filename, Int access = File::NONE, size_t bufferSize = File::BUFFERSIZE);	///< open the given file.
-	virtual Bool doesFileExist(const Char *filename) const;								///< does the given file exist?
+	virtual File * openFile(const Char *filename, Int access = File::NONE, size_t bufferSize = File::BUFFERSIZE) override;	///< open the given file.
+	virtual Bool doesFileExist(const Char *filename) const override;								///< does the given file exist?
 
-	virtual void getFileListInDirectory(const AsciiString& currentDirectory, const AsciiString& originalDirectory, const AsciiString& searchName, FilenameList &filenameList, Bool searchSubdirectories) const; ///< search the given directory for files matching the searchName (egs. *.ini, *.rep).  Possibly search subdirectories.
-	virtual Bool getFileInfo(const AsciiString& filename, FileInfo *fileInfo) const;
+	virtual void getFileListInDirectory(const AsciiString& currentDirectory, const AsciiString& originalDirectory, const AsciiString& searchName, FilenameList &filenameList, Bool searchSubdirectories) const override; ///< search the given directory for files matching the searchName (egs. *.ini, *.rep).  Possibly search subdirectories.
+	virtual Bool getFileInfo(const AsciiString& filename, FileInfo *fileInfo) const override;
 
-	virtual Bool createDirectory(AsciiString directory);
-	virtual AsciiString normalizePath(const AsciiString& filePath) const;
+	virtual Bool createDirectory(AsciiString directory) override;
+	virtual AsciiString normalizePath(const AsciiString& filePath) const override;
 
 protected:
 };

--- a/Core/GameEngineDevice/Include/VideoDevice/Bink/BinkVideoPlayer.h
+++ b/Core/GameEngineDevice/Include/VideoDevice/Bink/BinkVideoPlayer.h
@@ -72,21 +72,21 @@ class BinkVideoStream : public VideoStream
 		Char					*m_memFile;													///< Pointer to memory resident file
 
 		BinkVideoStream();																///< only BinkVideoPlayer can create these
-		virtual ~BinkVideoStream();
+		virtual ~BinkVideoStream() override;
 
 	public:
 
-		virtual void update();											///< Update bink stream
+		virtual void update() override;											///< Update bink stream
 
-		virtual Bool	isFrameReady();								///< Is the frame ready to be displayed
-		virtual void	frameDecompress();						///< Render current frame in to buffer
-		virtual void	frameRender( VideoBuffer *buffer ); ///< Render current frame in to buffer
-		virtual void	frameNext();									///< Advance to next frame
-		virtual Int		frameIndex();									///< Returns zero based index of current frame
-		virtual Int		frameCount();									///< Returns the total number of frames in the stream
-		virtual void	frameGoto( Int index );							///< Go to the spcified frame index
-		virtual Int		height();											///< Return the height of the video
-		virtual Int		width();											///< Return the width of the video
+		virtual Bool	isFrameReady() override;								///< Is the frame ready to be displayed
+		virtual void	frameDecompress() override;						///< Render current frame in to buffer
+		virtual void	frameRender( VideoBuffer *buffer ) override; ///< Render current frame in to buffer
+		virtual void	frameNext() override;									///< Advance to next frame
+		virtual Int		frameIndex() override;									///< Returns zero based index of current frame
+		virtual Int		frameCount() override;									///< Returns the total number of frames in the stream
+		virtual void	frameGoto( Int index ) override;							///< Go to the spcified frame index
+		virtual Int		height() override;											///< Return the height of the video
+		virtual Int		width() override;											///< Return the width of the video
 
 
 };
@@ -109,24 +109,24 @@ class BinkVideoPlayer : public VideoPlayer
 	public:
 
 		// subsytem requirements
-		virtual void	init();														///< Initialize video playback code
-		virtual void	reset();													///< Reset video playback
-		virtual void	update();													///< Services all audio tasks. Should be called frequently
+		virtual void	init() override;														///< Initialize video playback code
+		virtual void	reset() override;													///< Reset video playback
+		virtual void	update() override;													///< Services all audio tasks. Should be called frequently
 
-		virtual void	deinit();													///< Close down player
+		virtual void	deinit() override;													///< Close down player
 
 
 		BinkVideoPlayer();
-		~BinkVideoPlayer();
+		virtual ~BinkVideoPlayer() override;
 
 		// service
-		virtual void	loseFocus();											///< Should be called when application loses focus
-		virtual void	regainFocus();										///< Should be called when application regains focus
+		virtual void	loseFocus() override;											///< Should be called when application loses focus
+		virtual void	regainFocus() override;										///< Should be called when application regains focus
 
-		virtual VideoStreamInterface*	open( AsciiString movieTitle );	///< Open video file for playback
-		virtual VideoStreamInterface*	load( AsciiString movieTitle );	///< Load video file in to memory for playback
+		virtual VideoStreamInterface*	open( AsciiString movieTitle ) override;	///< Open video file for playback
+		virtual VideoStreamInterface*	load( AsciiString movieTitle ) override;	///< Load video file in to memory for playback
 
-		virtual void notifyVideoPlayerOfNewProvider( Bool nowHasValid );
+		virtual void notifyVideoPlayerOfNewProvider( Bool nowHasValid ) override;
 		virtual void initializeBinkWithMiles();
 };
 

--- a/Core/GameEngineDevice/Include/W3DDevice/Common/W3DRadar.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/Common/W3DRadar.h
@@ -51,27 +51,27 @@ class W3DRadar : public Radar
 public:
 
 	W3DRadar();
-	~W3DRadar();
+	~W3DRadar() override;
 
-	virtual void xfer( Xfer *xfer );
+	virtual void xfer( Xfer *xfer ) override;
 
-	virtual void init();																		///< subsystem init
-	virtual void update();																	///< subsystem update
-	virtual void reset();																		///< subsystem reset
+	virtual void init() override;																		///< subsystem init
+	virtual void update() override;																	///< subsystem update
+	virtual void reset() override;																		///< subsystem reset
 
-	virtual void newMap( TerrainLogic *terrain );				///< reset radar for new map
+	virtual void newMap( TerrainLogic *terrain ) override;				///< reset radar for new map
 
-	virtual void draw( Int pixelX, Int pixelY, Int width, Int height );		///< draw the radar
+	virtual void draw( Int pixelX, Int pixelY, Int width, Int height ) override;		///< draw the radar
 
-	virtual void clearShroud();
-	virtual void setShroudLevel(Int x, Int y, CellShroudStatus setting); ///< set the shroud level at shroud cell x,y
-	virtual void beginSetShroudLevel(); ///< call this once before multiple calls to setShroudLevel for better performance
-	virtual void endSetShroudLevel(); ///< call this once after beginSetShroudLevel and setShroudLevel
+	virtual void clearShroud() override;
+	virtual void setShroudLevel(Int x, Int y, CellShroudStatus setting) override; ///< set the shroud level at shroud cell x,y
+	virtual void beginSetShroudLevel() override; ///< call this once before multiple calls to setShroudLevel for better performance
+	virtual void endSetShroudLevel() override; ///< call this once after beginSetShroudLevel and setShroudLevel
 
-	virtual void refreshTerrain( TerrainLogic *terrain );
-	virtual void refreshObjects();
+	virtual void refreshTerrain( TerrainLogic *terrain ) override;
+	virtual void refreshObjects() override;
 
-	virtual void notifyViewChanged(); ///< signals that the camera view has changed
+	virtual void notifyViewChanged() override; ///< signals that the camera view has changed
 
 protected:
 

--- a/Core/GameEngineDevice/Include/W3DDevice/Common/W3DRadar.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/Common/W3DRadar.h
@@ -51,7 +51,7 @@ class W3DRadar : public Radar
 public:
 
 	W3DRadar();
-	~W3DRadar() override;
+	virtual ~W3DRadar() override;
 
 	virtual void xfer( Xfer *xfer ) override;
 

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/BaseHeightMap.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/BaseHeightMap.h
@@ -93,26 +93,26 @@ class BaseHeightMapRenderObjClass : public RenderObjClass, public DX8_CleanupHoo
 public:
 
 	BaseHeightMapRenderObjClass();
-	virtual ~BaseHeightMapRenderObjClass();
+	virtual ~BaseHeightMapRenderObjClass() override;
 
 	// DX8_CleanupHook methods
-	virtual void ReleaseResources();	///< Release all dx8 resources so the device can be reset.
-	virtual void ReAcquireResources();  ///< Reacquire all resources after device reset.
+	virtual void ReleaseResources() override;	///< Release all dx8 resources so the device can be reset.
+	virtual void ReAcquireResources() override;  ///< Reacquire all resources after device reset.
 
 
 	/////////////////////////////////////////////////////////////////////////////
 	// Render Object Interface (W3D methods)
 	/////////////////////////////////////////////////////////////////////////////
-	virtual RenderObjClass *	Clone() const;
-	virtual int						Class_ID() const;
-	virtual void					Render(RenderInfoClass & rinfo) = 0;
-	virtual bool					Cast_Ray(RayCollisionTestClass & raytest); // This CANNOT be Bool, as it will not inherit properly if you make Bool == Int
-	virtual void					Get_Obj_Space_Bounding_Sphere(SphereClass & sphere) const;
-	virtual void					Get_Obj_Space_Bounding_Box(AABoxClass & aabox) const;
+	virtual RenderObjClass *	Clone() const override;
+	virtual int						Class_ID() const override;
+	virtual void					Render(RenderInfoClass & rinfo) override = 0;
+	virtual bool					Cast_Ray(RayCollisionTestClass & raytest) override; // This CANNOT be Bool, as it will not inherit properly if you make Bool == Int
+	virtual void					Get_Obj_Space_Bounding_Sphere(SphereClass & sphere) const override;
+	virtual void					Get_Obj_Space_Bounding_Box(AABoxClass & aabox) const override;
 
 
-	virtual void					On_Frame_Update();
-	virtual void					Notify_Added(SceneClass * scene);
+	virtual void					On_Frame_Update() override;
+	virtual void					Notify_Added(SceneClass * scene) override;
 
   // Other VIRTUAL methods. [3/20/2003]
 
@@ -229,9 +229,9 @@ public:
 
 protected:
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 	Int	m_x;	///< dimensions of heightmap

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/BaseHeightMap.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/BaseHeightMap.h
@@ -105,7 +105,7 @@ public:
 	/////////////////////////////////////////////////////////////////////////////
 	virtual RenderObjClass *	Clone() const override;
 	virtual int						Class_ID() const override;
-	virtual void					Render(RenderInfoClass & rinfo) override = 0;
+	virtual void					Render(RenderInfoClass & rinfo) = 0;
 	virtual bool					Cast_Ray(RayCollisionTestClass & raytest) override; // This CANNOT be Bool, as it will not inherit properly if you make Bool == Int
 	virtual void					Get_Obj_Space_Bounding_Sphere(SphereClass & sphere) const override;
 	virtual void					Get_Obj_Space_Bounding_Box(AABoxClass & aabox) const override;

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/CameraShakeSystem.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/CameraShakeSystem.h
@@ -80,7 +80,7 @@ public:
 	{
 	public:
 		CameraShakerClass(const Vector3 & position,float radius,float duration,float power);
-		~CameraShakerClass() override;
+		virtual ~CameraShakerClass() override;
 
 		void					Timestep(float dt)							{ ElapsedTime += dt; }
 		bool					Is_Expired()								{ return (ElapsedTime >= Duration); }

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/CameraShakeSystem.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/CameraShakeSystem.h
@@ -80,7 +80,7 @@ public:
 	{
 	public:
 		CameraShakerClass(const Vector3 & position,float radius,float duration,float power);
-		~CameraShakerClass();
+		~CameraShakerClass() override;
 
 		void					Timestep(float dt)							{ ElapsedTime += dt; }
 		bool					Is_Expired()								{ return (ElapsedTime >= Duration); }

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/FlatHeightMap.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/FlatHeightMap.h
@@ -50,29 +50,29 @@ class FlatHeightMapRenderObjClass : public BaseHeightMapRenderObjClass
 public:
 
 	FlatHeightMapRenderObjClass();
-	virtual ~FlatHeightMapRenderObjClass();
+	virtual ~FlatHeightMapRenderObjClass() override;
 
 	// DX8_CleanupHook methods
-	virtual void ReleaseResources();	///< Release all dx8 resources so the device can be reset.
-	virtual void ReAcquireResources();  ///< Reacquire all resources after device reset.
+	virtual void ReleaseResources() override;	///< Release all dx8 resources so the device can be reset.
+	virtual void ReAcquireResources() override;  ///< Reacquire all resources after device reset.
 
 
 	/////////////////////////////////////////////////////////////////////////////
 	// Render Object Interface (W3D methods)
 	/////////////////////////////////////////////////////////////////////////////
-	virtual void					Render(RenderInfoClass & rinfo);
-	virtual void					On_Frame_Update();
+	virtual void					Render(RenderInfoClass & rinfo) override;
+	virtual void					On_Frame_Update() override;
 
 	///allocate resources needed to render heightmap
-	virtual int initHeightData(Int width, Int height, WorldHeightMap *pMap, RefRenderObjListIterator *pLightsIterator,Bool updateExtraPassTiles=TRUE);
-	virtual Int freeMapResources();	///< free resources used to render heightmap
-	virtual void updateCenter(CameraClass *camera, RefRenderObjListIterator *pLightsIterator);
- 	virtual void adjustTerrainLOD(Int adj);
-	virtual void reset();
-	virtual void oversizeTerrain(Int tilesToOversize);
-	virtual void staticLightingChanged();
-	virtual void doPartialUpdate(const IRegion2D &partialRange, WorldHeightMap *htMap, RefRenderObjListIterator *pLightsIterator);
-  virtual int updateBlock(Int x0, Int y0, Int x1, Int y1, WorldHeightMap *pMap, RefRenderObjListIterator *pLightsIterator){return 0;};
+	virtual int initHeightData(Int width, Int height, WorldHeightMap *pMap, RefRenderObjListIterator *pLightsIterator,Bool updateExtraPassTiles=TRUE) override;
+	virtual Int freeMapResources() override;	///< free resources used to render heightmap
+	virtual void updateCenter(CameraClass *camera, RefRenderObjListIterator *pLightsIterator) override;
+ 	virtual void adjustTerrainLOD(Int adj) override;
+	virtual void reset() override;
+	virtual void oversizeTerrain(Int tilesToOversize) override;
+	virtual void staticLightingChanged() override;
+	virtual void doPartialUpdate(const IRegion2D &partialRange, WorldHeightMap *htMap, RefRenderObjListIterator *pLightsIterator) override;
+  virtual int updateBlock(Int x0, Int y0, Int x1, Int y1, WorldHeightMap *pMap, RefRenderObjListIterator *pLightsIterator) override {return 0;};
 
 protected:
 	W3DTerrainBackground	*m_tiles;

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/HeightMap.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/HeightMap.h
@@ -57,32 +57,32 @@ class HeightMapRenderObjClass : public BaseHeightMapRenderObjClass
 public:
 
 	HeightMapRenderObjClass();
-	virtual ~HeightMapRenderObjClass();
+	virtual ~HeightMapRenderObjClass() override;
 
 	// DX8_CleanupHook methods
-	virtual void ReleaseResources();	///< Release all dx8 resources so the device can be reset.
-	virtual void ReAcquireResources();  ///< Reacquire all resources after device reset.
+	virtual void ReleaseResources() override;	///< Release all dx8 resources so the device can be reset.
+	virtual void ReAcquireResources() override;  ///< Reacquire all resources after device reset.
 
 
 	/////////////////////////////////////////////////////////////////////////////
 	// Render Object Interface (W3D methods)
 	/////////////////////////////////////////////////////////////////////////////
-	virtual void					Render(RenderInfoClass & rinfo);
-	virtual void					On_Frame_Update();
+	virtual void					Render(RenderInfoClass & rinfo) override;
+	virtual void					On_Frame_Update() override;
 
 	///allocate resources needed to render heightmap
-	virtual int initHeightData(Int width, Int height, WorldHeightMap *pMap, RefRenderObjListIterator *pLightsIterator, Bool updateExtraPassTiles=TRUE);
-	virtual Int freeMapResources();	///< free resources used to render heightmap
-	virtual void updateCenter(CameraClass *camera, RefRenderObjListIterator *pLightsIterator);
+	virtual int initHeightData(Int width, Int height, WorldHeightMap *pMap, RefRenderObjListIterator *pLightsIterator, Bool updateExtraPassTiles=TRUE) override;
+	virtual Int freeMapResources() override;	///< free resources used to render heightmap
+	virtual void updateCenter(CameraClass *camera, RefRenderObjListIterator *pLightsIterator) override;
 
-	virtual void staticLightingChanged();
-	virtual	void adjustTerrainLOD(Int adj);
-	virtual void reset();
-	virtual void doPartialUpdate(const IRegion2D &partialRange, WorldHeightMap *htMap, RefRenderObjListIterator *pLightsIterator);
+	virtual void staticLightingChanged() override;
+	virtual	void adjustTerrainLOD(Int adj) override;
+	virtual void reset() override;
+	virtual void doPartialUpdate(const IRegion2D &partialRange, WorldHeightMap *htMap, RefRenderObjListIterator *pLightsIterator) override;
 
-	virtual void oversizeTerrain(Int tilesToOversize);
+	virtual void oversizeTerrain(Int tilesToOversize) override;
 
-	virtual int updateBlock(Int x0, Int y0, Int x1, Int y1, WorldHeightMap *pMap, RefRenderObjListIterator *pLightsIterator);
+	virtual int updateBlock(Int x0, Int y0, Int x1, Int y1, WorldHeightMap *pMap, RefRenderObjListIterator *pLightsIterator) override;
 
 protected:
 	Int *m_extraBlendTilePositions;	///<array holding x,y tile positions of all extra blend tiles. (used for 3 textures per tile).
@@ -113,7 +113,7 @@ protected:
 	///update vertex buffers associated with the given rectangle
 	void initDestAlphaLUT();	///<initialize water depth LUT stored in m_destAlphaTexture
 	void renderTerrainPass(CameraClass *pCamera);	///< renders additional terrain pass.
-	Int	getNumExtraBlendTiles(Bool visible) { return visible?m_numVisibleExtraBlendTiles:m_numExtraBlendTiles;}
+	Int	getNumExtraBlendTiles(Bool visible) override { return visible?m_numVisibleExtraBlendTiles:m_numExtraBlendTiles;}
 	void freeIndexVertexBuffers();
 	void renderExtraBlendTiles();	///< render 3-way blend tiles that have blend of 3 textures.
 };

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/HeightMap.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/HeightMap.h
@@ -113,7 +113,7 @@ protected:
 	///update vertex buffers associated with the given rectangle
 	void initDestAlphaLUT();	///<initialize water depth LUT stored in m_destAlphaTexture
 	void renderTerrainPass(CameraClass *pCamera);	///< renders additional terrain pass.
-	Int	getNumExtraBlendTiles(Bool visible) override { return visible?m_numVisibleExtraBlendTiles:m_numExtraBlendTiles;}
+	virtual Int	getNumExtraBlendTiles(Bool visible) override { return visible?m_numVisibleExtraBlendTiles:m_numExtraBlendTiles;}
 	void freeIndexVertexBuffers();
 	void renderExtraBlendTiles();	///< render 3-way blend tiles that have blend of 3 textures.
 };

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DDebrisDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DDebrisDraw.h
@@ -54,21 +54,21 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	/// the draw method
-	virtual void doDrawModule(const Matrix3D* transformMtx);
+	virtual void doDrawModule(const Matrix3D* transformMtx) override;
 
-	virtual void setShadowsEnabled(Bool enable);
-	virtual void releaseShadows() {};	///< we don't care about preserving temporary shadows.
-	virtual void allocateShadows() {};	///< we don't care about preserving temporary shadows.
+	virtual void setShadowsEnabled(Bool enable) override;
+	virtual void releaseShadows() override {};	///< we don't care about preserving temporary shadows.
+	virtual void allocateShadows() override {};	///< we don't care about preserving temporary shadows.
 
-	virtual void setFullyObscuredByShroud(Bool fullyObscured);
-	virtual void reactToTransformChange(const Matrix3D* oldMtx, const Coord3D* oldPos, Real oldAngle);
-	virtual void reactToGeometryChange() { }
+	virtual void setFullyObscuredByShroud(Bool fullyObscured) override;
+	virtual void reactToTransformChange(const Matrix3D* oldMtx, const Coord3D* oldPos, Real oldAngle) override;
+	virtual void reactToGeometryChange() override { }
 
-	virtual void setModelName(AsciiString name, Color color, ShadowType t);
-	virtual void setAnimNames(AsciiString initial, AsciiString flying, AsciiString finalAnim, const FXList* finalFX);
+	virtual void setModelName(AsciiString name, Color color, ShadowType t) override;
+	virtual void setAnimNames(AsciiString initial, AsciiString flying, AsciiString finalAnim, const FXList* finalFX) override;
 
-	virtual DebrisDrawInterface* getDebrisDrawInterface() { return this; }
-	virtual const DebrisDrawInterface* getDebrisDrawInterface() const { return this; }
+	virtual DebrisDrawInterface* getDebrisDrawInterface() override { return this; }
+	virtual const DebrisDrawInterface* getDebrisDrawInterface() const override { return this; }
 
 private:
 

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DDefaultDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DDefaultDraw.h
@@ -56,14 +56,14 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
 	/// the draw method
-	virtual void doDrawModule(const Matrix3D* transformMtx);
+	virtual void doDrawModule(const Matrix3D* transformMtx) override;
 
-	virtual void setShadowsEnabled(Bool enable);
-	virtual void releaseShadows() {};	///< we don't care about preserving temporary shadows.
-	virtual void allocateShadows() {};	///< we don't care about preserving temporary shadows.
-	virtual void setFullyObscuredByShroud(Bool fullyObscured);
-	virtual void reactToTransformChange(const Matrix3D* oldMtx, const Coord3D* oldPos, Real oldAngle);
-	virtual void reactToGeometryChange() { }
+	virtual void setShadowsEnabled(Bool enable) override;
+	virtual void releaseShadows() override {};	///< we don't care about preserving temporary shadows.
+	virtual void allocateShadows() override {};	///< we don't care about preserving temporary shadows.
+	virtual void setFullyObscuredByShroud(Bool fullyObscured) override;
+	virtual void reactToTransformChange(const Matrix3D* oldMtx, const Coord3D* oldPos, Real oldAngle) override;
+	virtual void reactToGeometryChange() override { }
 
 private:
 

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DDependencyModelDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DDependencyModelDraw.h
@@ -44,7 +44,7 @@ public:
 	AsciiString	m_attachToDrawableBoneInContainer;// Not just a different draw module, this bone is in our container
 
 	W3DDependencyModelDrawModuleData();
-	~W3DDependencyModelDrawModuleData();
+	virtual ~W3DDependencyModelDrawModuleData() override;
 	static void buildFieldParse(MultiIniFieldParse& p);
 };
 
@@ -59,9 +59,9 @@ public:
 
 	W3DDependencyModelDraw( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
-	virtual void doDrawModule(const Matrix3D* transformMtx);
-	virtual void notifyDrawModuleDependencyCleared( );///< if you were waiting for something before you drew, it's ready now
-	virtual void adjustTransformMtx(Matrix3D& mtx) const;
+	virtual void doDrawModule(const Matrix3D* transformMtx) override;
+	virtual void notifyDrawModuleDependencyCleared( ) override;///< if you were waiting for something before you drew, it's ready now
+	virtual void adjustTransformMtx(Matrix3D& mtx) const override;
 
 protected:
 	Bool m_dependencyCleared; // The thing we depend on will clear this, and we will relatch it after we draw.

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DLaserDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DLaserDraw.h
@@ -57,7 +57,7 @@ public:
 	Real m_tilingScalar;
 
 	W3DLaserDrawModuleData();
-	~W3DLaserDrawModuleData();
+	virtual ~W3DLaserDrawModuleData() override;
 	static void buildFieldParse(MultiIniFieldParse& p);
 };
 
@@ -75,18 +75,18 @@ public:
 	W3DLaserDraw( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void doDrawModule(const Matrix3D* transformMtx);
-	virtual void releaseShadows() {};	///< we don't care about preserving temporary shadows.
-	virtual void allocateShadows() {};	///< we don't care about preserving temporary shadows.
-	virtual void setShadowsEnabled(Bool enable) { }
-	virtual void setFullyObscuredByShroud(Bool fullyObscured) { };
-	virtual void reactToTransformChange(const Matrix3D* oldMtx, const Coord3D* oldPos, Real oldAngle) { }
-	virtual void reactToGeometryChange() { }
-	virtual Bool isLaser() const { return true; }
-	Real getLaserTemplateWidth() const;
+	virtual void doDrawModule(const Matrix3D* transformMtx) override;
+	virtual void releaseShadows() override {};	///< we don't care about preserving temporary shadows.
+	virtual void allocateShadows() override {};	///< we don't care about preserving temporary shadows.
+	virtual void setShadowsEnabled(Bool enable) override { }
+	virtual void setFullyObscuredByShroud(Bool fullyObscured) override { };
+	virtual void reactToTransformChange(const Matrix3D* oldMtx, const Coord3D* oldPos, Real oldAngle) override { }
+	virtual void reactToGeometryChange() override { }
+	virtual Bool isLaser() const override { return true; }
+	Real getLaserTemplateWidth() const override;
 
-	virtual LaserDrawInterface* getLaserDrawInterface() { return this; }
-	virtual const LaserDrawInterface* getLaserDrawInterface() const { return this; }
+	virtual LaserDrawInterface* getLaserDrawInterface() override { return this; }
+	virtual const LaserDrawInterface* getLaserDrawInterface() const override { return this; }
 
 protected:
 

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DLaserDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DLaserDraw.h
@@ -83,7 +83,7 @@ public:
 	virtual void reactToTransformChange(const Matrix3D* oldMtx, const Coord3D* oldPos, Real oldAngle) override { }
 	virtual void reactToGeometryChange() override { }
 	virtual Bool isLaser() const override { return true; }
-	Real getLaserTemplateWidth() const override;
+	virtual Real getLaserTemplateWidth() const override;
 
 	virtual LaserDrawInterface* getLaserDrawInterface() override { return this; }
 	virtual const LaserDrawInterface* getLaserDrawInterface() const override { return this; }

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DModelDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DModelDraw.h
@@ -312,7 +312,7 @@ public:
 
 
 	W3DModelDrawModuleData();
-	~W3DModelDrawModuleData();
+	virtual ~W3DModelDrawModuleData() override;
 	void validateStuffForTimeAndWeather(const Drawable* draw, Bool night, Bool snowy) const;
 	static void buildFieldParse(MultiIniFieldParse& p);
  	AsciiString getBestModelNameForWB(const ModelConditionFlags& c) const;
@@ -323,16 +323,16 @@ public:
 #endif
 
 	// ugh, hack
-	virtual const W3DModelDrawModuleData* getAsW3DModelDrawModuleData() const { return this; }
-	virtual StaticGameLODLevel getMinimumRequiredGameLOD() const { return m_minLODRequired;}
+	virtual const W3DModelDrawModuleData* getAsW3DModelDrawModuleData() const override { return this; }
+	virtual StaticGameLODLevel getMinimumRequiredGameLOD() const override { return m_minLODRequired;}
 
 private:
 	static void parseConditionState( INI* ini, void *instance, void * /*store*/, const void* /*userData*/ );
 
 public:
- 	virtual void crc( Xfer *xfer );
- 	virtual void xfer( Xfer *xfer );
- 	virtual void loadPostProcess();
+ 	virtual void crc( Xfer *xfer ) override;
+ 	virtual void xfer( Xfer *xfer ) override;
+ 	virtual void loadPostProcess() override;
 };
 
 //-------------------------------------------------------------------------------------------------
@@ -348,44 +348,44 @@ public:
 	// virtual destructor prototype provided by memory pool declaration
 
   /// preloading assets
-	virtual void preloadAssets( TimeOfDay timeOfDay );
+	virtual void preloadAssets( TimeOfDay timeOfDay ) override;
 
 	/// the draw method
-	virtual void doDrawModule(const Matrix3D* transformMtx);
-	virtual void setShadowsEnabled(Bool enable);
-	virtual void releaseShadows();	///< frees all shadow resources used by this module - used by Options screen.
-	virtual void allocateShadows(); ///< create shadow resources if not already present. Used by Options screen.
+	virtual void doDrawModule(const Matrix3D* transformMtx) override;
+	virtual void setShadowsEnabled(Bool enable) override;
+	virtual void releaseShadows() override;	///< frees all shadow resources used by this module - used by Options screen.
+	virtual void allocateShadows() override; ///< create shadow resources if not already present. Used by Options screen.
 
 #if defined(RTS_DEBUG)
 	virtual void getRenderCost(RenderCost & rc) const;  ///< estimates the render cost of this draw module
 	void getRenderCostRecursive(RenderCost & rc,RenderObjClass * robj) const;
 #endif
 
-	virtual void setFullyObscuredByShroud(Bool fullyObscured);
-	virtual void setTerrainDecal(TerrainDecalType type);
+	virtual void setFullyObscuredByShroud(Bool fullyObscured) override;
+	virtual void setTerrainDecal(TerrainDecalType type) override;
 
-	virtual Bool isVisible() const;
-	virtual void reactToTransformChange(const Matrix3D* oldMtx, const Coord3D* oldPos, Real oldAngle);
-	virtual void reactToGeometryChange() { }
+	virtual Bool isVisible() const override;
+	virtual void reactToTransformChange(const Matrix3D* oldMtx, const Coord3D* oldPos, Real oldAngle) override;
+	virtual void reactToGeometryChange() override { }
 
 	// this method must ONLY be called from the client, NEVER From the logic, not even indirectly.
-	virtual Bool clientOnly_getRenderObjInfo(Coord3D* pos, Real* boundingSphereRadius, Matrix3D* transform) const;
-	virtual Bool clientOnly_getRenderObjBoundBox(OBBoxClass * boundbox) const;
-	virtual Bool clientOnly_getRenderObjBoneTransform(const AsciiString & boneName,Matrix3D * set_tm) const;
-	virtual Int getPristineBonePositionsForConditionState(const ModelConditionFlags& condition, const char* boneNamePrefix, Int startIndex, Coord3D* positions, Matrix3D* transforms, Int maxBones) const;
-	virtual Int getCurrentBonePositions(const char* boneNamePrefix, Int startIndex, Coord3D* positions, Matrix3D* transforms, Int maxBones) const;
-	virtual Bool getCurrentWorldspaceClientBonePositions(const char* boneName, Matrix3D& transform) const;
-	virtual Bool getProjectileLaunchOffset(const ModelConditionFlags& condition, WeaponSlotType wslot, Int specificBarrelToUse, Matrix3D* launchPos, WhichTurretType tur, Coord3D* turretRotPos, Coord3D* turretPitchPos = nullptr) const;
-	virtual void updateProjectileClipStatus( UnsignedInt shotsRemaining, UnsignedInt maxShots, WeaponSlotType slot ); ///< This will do the show/hide work if ProjectileBoneFeedbackEnabled is set.
-	virtual void updateDrawModuleSupplyStatus( Int maxSupply, Int currentSupply ); ///< This will do visual feedback on Supplies carried
-	virtual void notifyDrawModuleDependencyCleared(){}///< if you were waiting for something before you drew, it's ready now
+	virtual Bool clientOnly_getRenderObjInfo(Coord3D* pos, Real* boundingSphereRadius, Matrix3D* transform) const override;
+	virtual Bool clientOnly_getRenderObjBoundBox(OBBoxClass * boundbox) const override;
+	virtual Bool clientOnly_getRenderObjBoneTransform(const AsciiString & boneName,Matrix3D * set_tm) const override;
+	virtual Int getPristineBonePositionsForConditionState(const ModelConditionFlags& condition, const char* boneNamePrefix, Int startIndex, Coord3D* positions, Matrix3D* transforms, Int maxBones) const override;
+	virtual Int getCurrentBonePositions(const char* boneNamePrefix, Int startIndex, Coord3D* positions, Matrix3D* transforms, Int maxBones) const override;
+	virtual Bool getCurrentWorldspaceClientBonePositions(const char* boneName, Matrix3D& transform) const override;
+	virtual Bool getProjectileLaunchOffset(const ModelConditionFlags& condition, WeaponSlotType wslot, Int specificBarrelToUse, Matrix3D* launchPos, WhichTurretType tur, Coord3D* turretRotPos, Coord3D* turretPitchPos = nullptr) const override;
+	virtual void updateProjectileClipStatus( UnsignedInt shotsRemaining, UnsignedInt maxShots, WeaponSlotType slot ) override; ///< This will do the show/hide work if ProjectileBoneFeedbackEnabled is set.
+	virtual void updateDrawModuleSupplyStatus( Int maxSupply, Int currentSupply ) override; ///< This will do visual feedback on Supplies carried
+	virtual void notifyDrawModuleDependencyCleared() override {}///< if you were waiting for something before you drew, it's ready now
 
-	virtual void setHidden(Bool h);
-	virtual void replaceModelConditionState(const ModelConditionFlags& c);
-	virtual void replaceIndicatorColor(Color color);
-	virtual Bool handleWeaponFireFX(WeaponSlotType wslot, Int specificBarrelToUse, const FXList* fxl, Real weaponSpeed, const Coord3D* victimPos, Real damageRadius);
-	virtual Int getBarrelCount(WeaponSlotType wslot) const;
-	virtual void setSelectable(Bool selectable); // Change the selectability of the model.
+	virtual void setHidden(Bool h) override;
+	virtual void replaceModelConditionState(const ModelConditionFlags& c) override;
+	virtual void replaceIndicatorColor(Color color) override;
+	virtual Bool handleWeaponFireFX(WeaponSlotType wslot, Int specificBarrelToUse, const FXList* fxl, Real weaponSpeed, const Coord3D* victimPos, Real damageRadius) override;
+	virtual Int getBarrelCount(WeaponSlotType wslot) const override;
+	virtual void setSelectable(Bool selectable) override; // Change the selectability of the model.
 
 	/**
 		This call says, "I want the current animation (if any) to take n frames to complete a single cycle".
@@ -393,41 +393,41 @@ public:
 		"pad" frames at the start and/or end, but for now, we always just "stretch" the animation to fit.
 		Note that you must call this AFTER setting the condition codes.
 	*/
-	virtual void setAnimationLoopDuration(UnsignedInt numFrames);
+	virtual void setAnimationLoopDuration(UnsignedInt numFrames) override;
 
 	/**
 		similar to the above, but assumes that the current state is a "ONCE",
 		and is smart about transition states... if there is a transition state
 		"in between", it is included in the completion time.
 	*/
-	virtual void setAnimationCompletionTime(UnsignedInt numFrames);
+	virtual void setAnimationCompletionTime(UnsignedInt numFrames) override;
 
 	/**
 	  This call is used to pause or resume an animation.
 	*/
-	virtual void setPauseAnimation(Bool pauseAnim);
+	virtual void setPauseAnimation(Bool pauseAnim) override;
 
 	//Kris: Manually set a drawable's current animation to specific frame.
 	virtual void setAnimationFrame( int frame );
 
-	virtual void updateSubObjects();
-	virtual void showSubObject( const AsciiString& name, Bool show );
+	virtual void updateSubObjects() override;
+	virtual void showSubObject( const AsciiString& name, Bool show ) override;
 
 #ifdef ALLOW_ANIM_INQUIRIES
 // srj sez: not sure if this is a good idea, for net sync reasons...
 	virtual Real getAnimationScrubScalar() const;
 #endif
 
-	virtual ObjectDrawInterface* getObjectDrawInterface() { return this; }
-	virtual const ObjectDrawInterface* getObjectDrawInterface() const { return this; }
+	virtual ObjectDrawInterface* getObjectDrawInterface() override { return this; }
+	virtual const ObjectDrawInterface* getObjectDrawInterface() const override { return this; }
 
 	///@todo: I had to make this public because W3DDevice needs access for casting shadows -MW
 	RenderObjClass *getRenderObject() { return m_renderObject; }
-	virtual Bool updateBonesForClientParticleSystems();///< this will reposition particle systems on the fly ML
+	virtual Bool updateBonesForClientParticleSystems() override;///< this will reposition particle systems on the fly ML
 
-	virtual void onDrawableBoundToObject();
-	virtual void setTerrainDecalSize(Real x, Real y);
-	virtual void setTerrainDecalOpacity(Real o);
+	virtual void onDrawableBoundToObject() override;
+	virtual void setTerrainDecalSize(Real x, Real y) override;
+	virtual void setTerrainDecalOpacity(Real o) override;
 
 protected:
 

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DOverlordAircraftDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DOverlordAircraftDraw.h
@@ -45,7 +45,7 @@ class W3DOverlordAircraftDrawModuleData : public W3DModelDrawModuleData
 public:
 
 	W3DOverlordAircraftDrawModuleData();
-	~W3DOverlordAircraftDrawModuleData();
+	virtual ~W3DOverlordAircraftDrawModuleData() override;
 	static void buildFieldParse(MultiIniFieldParse& p);
 };
 
@@ -61,8 +61,8 @@ public:
 	W3DOverlordAircraftDraw( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
- 	virtual void setHidden(Bool h);
-	virtual void doDrawModule(const Matrix3D* transformMtx);
+ 	virtual void setHidden(Bool h) override;
+	virtual void doDrawModule(const Matrix3D* transformMtx) override;
 
 protected:
 

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DOverlordTankDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DOverlordTankDraw.h
@@ -45,7 +45,7 @@ public:
 	Real m_treadDriveSpeedFraction;	///<fraction of locomotor speed below which treads stop animating.
 
 	W3DOverlordTankDrawModuleData();
-	~W3DOverlordTankDrawModuleData();
+	virtual ~W3DOverlordTankDrawModuleData() override;
 	static void buildFieldParse(MultiIniFieldParse& p);
 };
 
@@ -61,8 +61,8 @@ public:
 	W3DOverlordTankDraw( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
- 	virtual void setHidden(Bool h);
-	virtual void doDrawModule(const Matrix3D* transformMtx);
+ 	virtual void setHidden(Bool h) override;
+	virtual void doDrawModule(const Matrix3D* transformMtx) override;
 
 protected:
 

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DOverlordTruckDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DOverlordTruckDraw.h
@@ -45,7 +45,7 @@ public:
 	Real m_treadDriveSpeedFraction;	///<fraction of locomotor speed below which treads stop animating.
 
 	W3DOverlordTruckDrawModuleData();
-	~W3DOverlordTruckDrawModuleData();
+	virtual ~W3DOverlordTruckDrawModuleData() override;
 	static void buildFieldParse(MultiIniFieldParse& p);
 };
 
@@ -61,8 +61,8 @@ public:
 	W3DOverlordTruckDraw( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
- 	virtual void setHidden(Bool h);
-	virtual void doDrawModule(const Matrix3D* transformMtx);
+ 	virtual void setHidden(Bool h) override;
+	virtual void doDrawModule(const Matrix3D* transformMtx) override;
 
 protected:
 

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DPoliceCarDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DPoliceCarDraw.h
@@ -49,7 +49,7 @@ public:
 	W3DPoliceCarDraw( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void doDrawModule(const Matrix3D* transformMtx);
+	virtual void doDrawModule(const Matrix3D* transformMtx) override;
 
 protected:
 

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DProjectileStreamDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DProjectileStreamDraw.h
@@ -49,7 +49,7 @@ public:
 	Int m_maxSegments;
 
 	W3DProjectileStreamDrawModuleData();
-	~W3DProjectileStreamDrawModuleData();
+	virtual ~W3DProjectileStreamDrawModuleData() override;
 	static void buildFieldParse(MultiIniFieldParse& p);
 };
 
@@ -65,13 +65,13 @@ public:
 	W3DProjectileStreamDraw( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void doDrawModule(const Matrix3D* transformMtx);
-	virtual void releaseShadows() {};	///< we don't care about preserving temporary shadows.
-	virtual void allocateShadows() {};	///< we don't care about preserving temporary shadows.
-	virtual void setShadowsEnabled(Bool ) { }
-	virtual void setFullyObscuredByShroud(Bool);
-	virtual void reactToTransformChange(const Matrix3D* oldMtx, const Coord3D* oldPos, Real oldAngle) { }
-	virtual void reactToGeometryChange() { }
+	virtual void doDrawModule(const Matrix3D* transformMtx) override;
+	virtual void releaseShadows() override {};	///< we don't care about preserving temporary shadows.
+	virtual void allocateShadows() override {};	///< we don't care about preserving temporary shadows.
+	virtual void setShadowsEnabled(Bool ) override { }
+	virtual void setFullyObscuredByShroud(Bool) override;
+	virtual void reactToTransformChange(const Matrix3D* oldMtx, const Coord3D* oldPos, Real oldAngle) override { }
+	virtual void reactToGeometryChange() override { }
 
 protected:
 	void makeOrUpdateLine( Vector3 *points, UnsignedInt pointCount, Int lineIndex );

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DPropDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DPropDraw.h
@@ -40,7 +40,7 @@ public:
 	AsciiString m_modelName;
 
 	W3DPropDrawModuleData();
-	~W3DPropDrawModuleData();
+	virtual ~W3DPropDrawModuleData() override;
 	static void buildFieldParse(MultiIniFieldParse& p);
 	// ugh, hack
 	virtual const W3DPropDrawModuleData* getAsW3DPropDrawModuleData() const { return this; }
@@ -60,13 +60,13 @@ public:
 	W3DPropDraw( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void doDrawModule(const Matrix3D* transformMtx);
-	virtual void setShadowsEnabled(Bool enable) { }
-	virtual void releaseShadows() {};	///< we don't care about preserving temporary shadows.
-	virtual void allocateShadows() {};	///< we don't care about preserving temporary shadows.
-	virtual void setFullyObscuredByShroud(Bool fullyObscured) { }
-	virtual void reactToTransformChange(const Matrix3D* oldMtx, const Coord3D* oldPos, Real oldAngle);
-	virtual void reactToGeometryChange() { }
+	virtual void doDrawModule(const Matrix3D* transformMtx) override;
+	virtual void setShadowsEnabled(Bool enable) override { }
+	virtual void releaseShadows() override {};	///< we don't care about preserving temporary shadows.
+	virtual void allocateShadows() override {};	///< we don't care about preserving temporary shadows.
+	virtual void setFullyObscuredByShroud(Bool fullyObscured) override { }
+	virtual void reactToTransformChange(const Matrix3D* oldMtx, const Coord3D* oldPos, Real oldAngle) override;
+	virtual void reactToGeometryChange() override { }
 
 protected:
 	Bool m_propAdded;

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DRopeDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DRopeDraw.h
@@ -47,20 +47,20 @@ public:
 	W3DRopeDraw( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void doDrawModule(const Matrix3D* transformMtx);
-	virtual void setShadowsEnabled(Bool enable) { }
-	virtual void releaseShadows() {};	///< we don't care about preserving temporary shadows.
-	virtual void allocateShadows() {};	///< we don't care about preserving temporary shadows.
-	virtual void setFullyObscuredByShroud(Bool fullyObscured) { }
-	virtual void reactToTransformChange(const Matrix3D* oldMtx, const Coord3D* oldPos, Real oldAngle) { }
-	virtual void reactToGeometryChange() { }
+	virtual void doDrawModule(const Matrix3D* transformMtx) override;
+	virtual void setShadowsEnabled(Bool enable) override { }
+	virtual void releaseShadows() override {};	///< we don't care about preserving temporary shadows.
+	virtual void allocateShadows() override {};	///< we don't care about preserving temporary shadows.
+	virtual void setFullyObscuredByShroud(Bool fullyObscured) override { }
+	virtual void reactToTransformChange(const Matrix3D* oldMtx, const Coord3D* oldPos, Real oldAngle) override { }
+	virtual void reactToGeometryChange() override { }
 
-	virtual void initRopeParms(Real length, Real width, const RGBColor& color, Real wobbleLen, Real wobbleAmp, Real wobbleRate);
-	virtual void setRopeCurLen(Real length);
-	virtual void setRopeSpeed(Real curSpeed, Real maxSpeed, Real accel);
+	virtual void initRopeParms(Real length, Real width, const RGBColor& color, Real wobbleLen, Real wobbleAmp, Real wobbleRate) override;
+	virtual void setRopeCurLen(Real length) override;
+	virtual void setRopeSpeed(Real curSpeed, Real maxSpeed, Real accel) override;
 
-	virtual RopeDrawInterface* getRopeDrawInterface() { return this; }
-	virtual const RopeDrawInterface* getRopeDrawInterface() const { return this; }
+	virtual RopeDrawInterface* getRopeDrawInterface() override { return this; }
+	virtual const RopeDrawInterface* getRopeDrawInterface() const override { return this; }
 
 private:
 

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DScienceModelDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DScienceModelDraw.h
@@ -41,7 +41,7 @@ public:
 	ScienceType m_requiredScience; ///< Local player must have this science for me to ever draw
 
 	W3DScienceModelDrawModuleData();
-	~W3DScienceModelDrawModuleData();
+	virtual ~W3DScienceModelDrawModuleData() override;
 	static void buildFieldParse(MultiIniFieldParse& p);
 };
 
@@ -56,7 +56,7 @@ public:
 
 	W3DScienceModelDraw( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
-	virtual void doDrawModule(const Matrix3D* transformMtx);///< checks a property on the local player before passing this up
+	virtual void doDrawModule(const Matrix3D* transformMtx) override;///< checks a property on the local player before passing this up
 
 protected:
 };

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DSupplyDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DSupplyDraw.h
@@ -39,7 +39,7 @@ public:
 	AsciiString m_supplyBonePrefix;
 
 	W3DSupplyDrawModuleData();
-	~W3DSupplyDrawModuleData();
+	virtual ~W3DSupplyDrawModuleData() override;
 	static void buildFieldParse(MultiIniFieldParse& p);
 };
 
@@ -55,8 +55,8 @@ public:
 	W3DSupplyDraw( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void updateDrawModuleSupplyStatus( Int maxSupply, Int currentSupply ); ///< This will do visual feedback on Supplies carried
-	virtual void reactToGeometryChange() { }
+	virtual void updateDrawModuleSupplyStatus( Int maxSupply, Int currentSupply ) override; ///< This will do visual feedback on Supplies carried
+	virtual void reactToGeometryChange() override { }
 
 protected:
 	Int m_totalBones;

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DTankDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DTankDraw.h
@@ -49,7 +49,7 @@ public:
 	Real m_treadDriveSpeedFraction;	///<fraction of locomotor speed below which treads stop animating.
 
 	W3DTankDrawModuleData();
-	~W3DTankDrawModuleData();
+	virtual ~W3DTankDrawModuleData() override;
 	static void buildFieldParse(MultiIniFieldParse& p);
 };
 
@@ -65,12 +65,12 @@ public:
 	W3DTankDraw( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void setHidden(Bool h);
-	virtual void doDrawModule(const Matrix3D* transformMtx);
-	virtual void setFullyObscuredByShroud(Bool fullyObscured);
+	virtual void setHidden(Bool h) override;
+	virtual void doDrawModule(const Matrix3D* transformMtx) override;
+	virtual void setFullyObscuredByShroud(Bool fullyObscured) override;
 
 protected:
-	virtual void onRenderObjRecreated();
+	virtual void onRenderObjRecreated() override;
 
 protected:
 

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DTankTruckDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DTankTruckDraw.h
@@ -70,7 +70,7 @@ public:
 	Real m_treadDriveSpeedFraction;	///<fraction of locomotor speed below which treads stop animating.
 
 	W3DTankTruckDrawModuleData();
-	~W3DTankTruckDrawModuleData();
+	virtual ~W3DTankTruckDrawModuleData() override;
 	static void buildFieldParse(MultiIniFieldParse& p);
 };
 
@@ -86,13 +86,13 @@ public:
 	W3DTankTruckDraw( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void setHidden(Bool h);
-	virtual void doDrawModule(const Matrix3D* transformMtx);
-	virtual void setFullyObscuredByShroud(Bool fullyObscured);
-	virtual void reactToGeometryChange() { }
+	virtual void setHidden(Bool h) override;
+	virtual void doDrawModule(const Matrix3D* transformMtx) override;
+	virtual void setFullyObscuredByShroud(Bool fullyObscured) override;
+	virtual void reactToGeometryChange() override { }
 
 protected:
-	virtual void onRenderObjRecreated();
+	virtual void onRenderObjRecreated() override;
 
 protected:
 	Bool						m_effectsInitialized;

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DTracerDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DTracerDraw.h
@@ -47,18 +47,18 @@ public:
 	W3DTracerDraw( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void doDrawModule(const Matrix3D* transformMtx);
-	virtual void setShadowsEnabled(Bool enable) { }
-	virtual void releaseShadows() {};	///< we don't care about preserving temporary shadows.
-	virtual void allocateShadows() {};	///< we don't care about preserving temporary shadows.
-	virtual void setFullyObscuredByShroud(Bool fullyObscured) { }
-	virtual void reactToTransformChange(const Matrix3D* oldMtx, const Coord3D* oldPos, Real oldAngle);
-	virtual void reactToGeometryChange() { }
+	virtual void doDrawModule(const Matrix3D* transformMtx) override;
+	virtual void setShadowsEnabled(Bool enable) override { }
+	virtual void releaseShadows() override {};	///< we don't care about preserving temporary shadows.
+	virtual void allocateShadows() override {};	///< we don't care about preserving temporary shadows.
+	virtual void setFullyObscuredByShroud(Bool fullyObscured) override { }
+	virtual void reactToTransformChange(const Matrix3D* oldMtx, const Coord3D* oldPos, Real oldAngle) override;
+	virtual void reactToGeometryChange() override { }
 
-	virtual void setTracerParms(Real speed, Real length, Real width, const RGBColor& color, Real initialOpacity);
+	virtual void setTracerParms(Real speed, Real length, Real width, const RGBColor& color, Real initialOpacity) override;
 
-	virtual TracerDrawInterface* getTracerDrawInterface() { return this; }
-	virtual const TracerDrawInterface* getTracerDrawInterface() const { return this; }
+	virtual TracerDrawInterface* getTracerDrawInterface() override { return this; }
+	virtual const TracerDrawInterface* getTracerDrawInterface() const override { return this; }
 
 protected:
 

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DTreeDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DTreeDraw.h
@@ -61,7 +61,7 @@ public:
 	Bool m_doShadow;
 
 	W3DTreeDrawModuleData();
-	~W3DTreeDrawModuleData();
+	virtual ~W3DTreeDrawModuleData() override;
 	static void buildFieldParse(MultiIniFieldParse& p);
 	// ugh, hack
 	virtual const W3DTreeDrawModuleData* getAsW3DTreeDrawModuleData() const { return this; }
@@ -81,13 +81,13 @@ public:
 	W3DTreeDraw( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void doDrawModule(const Matrix3D* transformMtx) {}
-	virtual void setShadowsEnabled(Bool enable) {}
-	virtual void releaseShadows() {}	///< we don't care about preserving temporary shadows.
-	virtual void allocateShadows() {}	///< we don't care about preserving temporary shadows.
-	virtual void setFullyObscuredByShroud(Bool fullyObscured) {}
-	virtual void reactToTransformChange(const Matrix3D* oldMtx, const Coord3D* oldPos, Real oldAngle) {}
-	virtual void reactToGeometryChange() {}
+	virtual void doDrawModule(const Matrix3D* transformMtx) override {}
+	virtual void setShadowsEnabled(Bool enable) override {}
+	virtual void releaseShadows() override {}	///< we don't care about preserving temporary shadows.
+	virtual void allocateShadows() override {}	///< we don't care about preserving temporary shadows.
+	virtual void setFullyObscuredByShroud(Bool fullyObscured) override {}
+	virtual void reactToTransformChange(const Matrix3D* oldMtx, const Coord3D* oldPos, Real oldAngle) override {}
+	virtual void reactToGeometryChange() override {}
 
 protected:
 

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DTruckDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DTruckDraw.h
@@ -71,7 +71,7 @@ public:
 	Real				m_powerslideRotationAddition;
 
 	W3DTruckDrawModuleData();
-	~W3DTruckDrawModuleData();
+	virtual ~W3DTruckDrawModuleData() override;
 	static void buildFieldParse(MultiIniFieldParse& p);
 };
 
@@ -87,13 +87,13 @@ public:
 	W3DTruckDraw( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-	virtual void setHidden(Bool h);
-	virtual void doDrawModule(const Matrix3D* transformMtx);
-	virtual void setFullyObscuredByShroud(Bool fullyObscured);
-	virtual void reactToGeometryChange() { }
+	virtual void setHidden(Bool h) override;
+	virtual void doDrawModule(const Matrix3D* transformMtx) override;
+	virtual void setFullyObscuredByShroud(Bool fullyObscured) override;
+	virtual void reactToGeometryChange() override { }
 
 protected:
-	virtual void onRenderObjRecreated();
+	virtual void onRenderObjRecreated() override;
 
 protected:
 	Bool						m_effectsInitialized;

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/TerrainTex.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/TerrainTex.h
@@ -43,7 +43,7 @@ class TerrainTextureClass : public TextureClass
 {
 	W3DMPO_GLUE(TerrainTextureClass)
 protected:
-	virtual void Apply(unsigned int stage);
+	virtual void Apply(unsigned int stage) override;
 
 public:
 		/// Create texture for a height map.
@@ -64,7 +64,7 @@ class AlphaTerrainTextureClass : public TextureClass
 {
 	W3DMPO_GLUE(AlphaTerrainTextureClass)
 protected:
-		virtual void Apply(unsigned int stage);
+		virtual void Apply(unsigned int stage) override;
 public:
 		// Create texture for a height map.
 		AlphaTerrainTextureClass(TextureClass *pBaseTex );
@@ -80,7 +80,7 @@ class AlphaEdgeTextureClass : public TextureClass
 {
 	W3DMPO_GLUE(AlphaEdgeTextureClass)
 protected:
-	virtual void Apply(unsigned int stage);
+	virtual void Apply(unsigned int stage) override;
 	int update256(WorldHeightMap *htMap);///< Sets the pixels, and returns the actual height of the texture.
 
 public:
@@ -97,7 +97,7 @@ class LightMapTerrainTextureClass : public TextureClass
 {
 	W3DMPO_GLUE(LightMapTerrainTextureClass)
 protected:
-		virtual void Apply(unsigned int stage);
+		virtual void Apply(unsigned int stage) override;
 
 public:
 		// Create texture from a height map.
@@ -110,7 +110,7 @@ class ScorchTextureClass : public TextureClass
 {
 	W3DMPO_GLUE(ScorchTextureClass)
 protected:
-		virtual void Apply(unsigned int stage);
+		virtual void Apply(unsigned int stage) override;
 
 public:
 		// Create texture.
@@ -123,7 +123,7 @@ class CloudMapTerrainTextureClass : public TextureClass
 {
 	W3DMPO_GLUE(CloudMapTerrainTextureClass)
 protected:
-		virtual void Apply(unsigned int stage);
+		virtual void Apply(unsigned int stage) override;
 
 protected:
 		float m_xSlidePerSecond ;	 ///< How far the clouds move per second.

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DMouse.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DMouse.h
@@ -65,14 +65,14 @@ class W3DMouse : public Win32Mouse
 public:
 
 	W3DMouse();
-	virtual ~W3DMouse();
+	virtual ~W3DMouse() override;
 
-	virtual void init();		///< init mouse, extend this functionality, do not replace
-	virtual void reset();		///< reset the system
+	virtual void init() override;		///< init mouse, extend this functionality, do not replace
+	virtual void reset() override;		///< reset the system
 
-	virtual void setCursor( MouseCursor cursor );		///< set mouse cursor
-	virtual void draw();		///< draw the cursor or refresh the image
-	virtual void setRedrawMode(RedrawMode mode);	///<set cursor drawing method.
+	virtual void setCursor( MouseCursor cursor ) override;		///< set mouse cursor
+	virtual void draw() override;		///< draw the cursor or refresh the image
+	virtual void setRedrawMode(RedrawMode mode) override;	///<set cursor drawing method.
 
 private:
 	MouseCursor m_currentD3DCursor;	///< keep track of last cursor image sent to D3D.

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DPropBuffer.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DPropBuffer.h
@@ -125,9 +125,9 @@ public:
 
 protected:
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 	enum { MAX_PROPS=4000};

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DShaderManager.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DShaderManager.h
@@ -153,13 +153,13 @@ protected:
 class ScreenMotionBlurFilter : public W3DFilterInterface
 {
 public:
-	virtual Int set(FilterModes mode);		///<setup shader for the specified rendering pass.
-	virtual Int init();			///<perform any one time initialization and validation
-	virtual void reset();		///<do any custom resetting necessary to bring W3D in sync.
-	virtual Int shutdown();		///<release resources used by shader
-	virtual Bool preRender(Bool &skipRender, CustomScenePassModes &scenePassMode); ///< Set up at start of render.  Only applies to screen filter shaders.
-	virtual Bool postRender(FilterModes mode, Coord2D &scrollDelta, Bool &doExtraRender); ///< Called after render.  Only applies to screen filter shaders.
-	virtual Bool setup(FilterModes mode); ///< Called when the filter is started, one time before the first prerender.
+	virtual Int set(FilterModes mode) override;		///<setup shader for the specified rendering pass.
+	virtual Int init() override;			///<perform any one time initialization and validation
+	virtual void reset() override;		///<do any custom resetting necessary to bring W3D in sync.
+	virtual Int shutdown() override;		///<release resources used by shader
+	virtual Bool preRender(Bool &skipRender, CustomScenePassModes &scenePassMode) override; ///< Set up at start of render.  Only applies to screen filter shaders.
+	virtual Bool postRender(FilterModes mode, Coord2D &scrollDelta, Bool &doExtraRender) override; ///< Called after render.  Only applies to screen filter shaders.
+	virtual Bool setup(FilterModes mode) override; ///< Called when the filter is started, one time before the first prerender.
 	ScreenMotionBlurFilter();
 
 	static void setZoomToPos(const Coord3D *pos) {m_zoomToPos = *pos; m_zoomToValid = true;}
@@ -189,11 +189,11 @@ class ScreenBWFilter : public W3DFilterInterface
 {
 	DWORD	m_dwBWPixelShader;		///<D3D handle to pixel shader which tints texture to black & white.
 public:
-	virtual Int init();			///<perform any one time initialization and validation
-	virtual Int shutdown();		///<release resources used by shader
-	virtual Bool preRender(Bool &skipRender, CustomScenePassModes &scenePassMode); ///< Set up at start of render.  Only applies to screen filter shaders.
-	virtual Bool postRender(FilterModes mode, Coord2D &scrollDelta,Bool &doExtraRender); ///< Called after render.  Only applies to screen filter shaders.
-	virtual Bool setup(FilterModes mode){return true;} ///< Called when the filter is started, one time before the first prerender.
+	virtual Int init() override;			///<perform any one time initialization and validation
+	virtual Int shutdown() override;		///<release resources used by shader
+	virtual Bool preRender(Bool &skipRender, CustomScenePassModes &scenePassMode) override; ///< Set up at start of render.  Only applies to screen filter shaders.
+	virtual Bool postRender(FilterModes mode, Coord2D &scrollDelta,Bool &doExtraRender) override; ///< Called after render.  Only applies to screen filter shaders.
+	virtual Bool setup(FilterModes mode) override {return true;} ///< Called when the filter is started, one time before the first prerender.
 	static void setFadeParameters(Int fadeFrames, Int direction)
 	{
 		m_curFadeFrame = 0;
@@ -201,8 +201,8 @@ public:
 		m_fadeDirection = direction;
 	}
 protected:
-	virtual Int set(FilterModes mode);		///<setup shader for the specified rendering pass.
-	virtual void reset();		///<do any custom resetting necessary to bring W3D in sync.
+	virtual Int set(FilterModes mode) override;		///<setup shader for the specified rendering pass.
+	virtual void reset() override;		///<do any custom resetting necessary to bring W3D in sync.
 	static Int m_fadeFrames;
 	static Int m_fadeDirection;
 	static Int m_curFadeFrame;
@@ -212,14 +212,14 @@ protected:
 class ScreenBWFilterDOT3 : public ScreenBWFilter
 {
 public:
-	virtual Int init();			///<perform any one time initialization and validation
-	virtual Int shutdown();		///<release resources used by shader
-	virtual Bool preRender(Bool &skipRender, CustomScenePassModes &scenePassMode); ///< Set up at start of render.  Only applies to screen filter shaders.
-	virtual Bool postRender(FilterModes mode, Coord2D &scrollDelta,Bool &doExtraRender); ///< Called after render.  Only applies to screen filter shaders.
-	virtual Bool setup(FilterModes mode){return true;} ///< Called when the filter is started, one time before the first prerender.
+	virtual Int init() override;			///<perform any one time initialization and validation
+	virtual Int shutdown() override;		///<release resources used by shader
+	virtual Bool preRender(Bool &skipRender, CustomScenePassModes &scenePassMode) override; ///< Set up at start of render.  Only applies to screen filter shaders.
+	virtual Bool postRender(FilterModes mode, Coord2D &scrollDelta,Bool &doExtraRender) override; ///< Called after render.  Only applies to screen filter shaders.
+	virtual Bool setup(FilterModes mode) override {return true;} ///< Called when the filter is started, one time before the first prerender.
 protected:
-	virtual Int set(FilterModes mode);		///<setup shader for the specified rendering pass.
-	virtual void reset();		///<do any custom resetting necessary to bring W3D in sync.
+	virtual Int set(FilterModes mode) override;		///<setup shader for the specified rendering pass.
+	virtual void reset() override;		///<do any custom resetting necessary to bring W3D in sync.
 };
 
 /*=========  ScreenCrossFadeFilter	=============================================================*/
@@ -227,11 +227,11 @@ protected:
 class ScreenCrossFadeFilter : public W3DFilterInterface
 {
 public:
-	virtual Int init();			///<perform any one time initialization and validation
-	virtual Int shutdown();		///<release resources used by shader
-	virtual Bool preRender(Bool &skipRender, CustomScenePassModes &scenePassMode); ///< Set up at start of render.  Only applies to screen filter shaders.
-	virtual Bool postRender(FilterModes mode, Coord2D &scrollDelta,Bool &doExtraRender); ///< Called after render.  Only applies to screen filter shaders.
-	virtual Bool setup(FilterModes mode){return true;} ///< Called when the filter is started, one time before the first prerender.
+	virtual Int init() override;			///<perform any one time initialization and validation
+	virtual Int shutdown() override;		///<release resources used by shader
+	virtual Bool preRender(Bool &skipRender, CustomScenePassModes &scenePassMode) override; ///< Set up at start of render.  Only applies to screen filter shaders.
+	virtual Bool postRender(FilterModes mode, Coord2D &scrollDelta,Bool &doExtraRender) override; ///< Called after render.  Only applies to screen filter shaders.
+	virtual Bool setup(FilterModes mode) override {return true;} ///< Called when the filter is started, one time before the first prerender.
 	static void setFadeParameters(Int fadeFrames, Int direction)
 	{
 		m_curFadeFrame = 0;
@@ -241,8 +241,8 @@ public:
 	static Real getCurrentFadeValue()	{ return m_curFadeValue;}
 	static TextureClass *getCurrentMaskTexture() { return m_fadePatternTexture;}
 protected:
-	virtual Int set(FilterModes mode);		///<setup shader for the specified rendering pass.
-	virtual void reset();		///<do any custom resetting necessary to bring W3D in sync.
+	virtual Int set(FilterModes mode) override;		///<setup shader for the specified rendering pass.
+	virtual void reset() override;		///<do any custom resetting necessary to bring W3D in sync.
 	Bool updateFadeLevel();		///<updated current state of fade and return true if not finished.
 	static Int m_fadeFrames;
 	static Int m_fadeDirection;

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DSmudge.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DSmudge.h
@@ -36,14 +36,14 @@ class W3DSmudgeManager : public SmudgeManager
 {
 public:
 	W3DSmudgeManager();
-	virtual ~W3DSmudgeManager();
+	virtual ~W3DSmudgeManager() override;
 
-	virtual void init();
-	virtual void reset ();
+	virtual void init() override;
+	virtual void reset () override;
 
 	void render (RenderInfoClass &rinfo);
-	void ReleaseResources();
-	void ReAcquireResources();
+	void ReleaseResources() override;
+	void ReAcquireResources() override;
 
 private:
 	Bool testHardwareSupport();		///<test if video card supports the effect.

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DSmudge.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DSmudge.h
@@ -42,8 +42,8 @@ public:
 	virtual void reset () override;
 
 	void render (RenderInfoClass &rinfo);
-	void ReleaseResources() override;
-	void ReAcquireResources() override;
+	virtual void ReleaseResources() override;
+	virtual void ReAcquireResources() override;
 
 private:
 	Bool testHardwareSupport();		///<test if video card supports the effect.

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DSnow.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DSnow.h
@@ -32,12 +32,12 @@ class W3DSnowManager : public SnowManager
   public :
 
 	W3DSnowManager();
-	~W3DSnowManager();
+	~W3DSnowManager() override;
 
-	virtual void init();
-	virtual void reset();
-	virtual void update ();
-	virtual void updateIniSettings();
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update () override;
+	virtual void updateIniSettings() override;
 
 	void	render(RenderInfoClass &rinfo);
 	void	renderAsQuads(RenderInfoClass &rinfo, Int cubeOriginX, Int cubeOriginY, Int cubeDimX, Int cubeDimY);

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DSnow.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DSnow.h
@@ -32,7 +32,7 @@ class W3DSnowManager : public SnowManager
   public :
 
 	W3DSnowManager();
-	~W3DSnowManager() override;
+	virtual ~W3DSnowManager() override;
 
 	virtual void init() override;
 	virtual void reset() override;

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DTerrainTracks.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DTerrainTracks.h
@@ -53,16 +53,16 @@ class TerrainTracksRenderObjClass : public W3DMPO, public RenderObjClass
 public:
 
 	TerrainTracksRenderObjClass();
-	~TerrainTracksRenderObjClass();
+	~TerrainTracksRenderObjClass() override;
 
 	/////////////////////////////////////////////////////////////////////////////
 	// Render Object Interface (W3D methods)
 	/////////////////////////////////////////////////////////////////////////////
-	virtual RenderObjClass *	Clone() const;
-	virtual int						Class_ID() const;
-	virtual void					Render(RenderInfoClass & rinfo);
-	virtual void					Get_Obj_Space_Bounding_Sphere(SphereClass & sphere) const;
-    virtual void					Get_Obj_Space_Bounding_Box(AABoxClass & aabox) const;
+	virtual RenderObjClass *	Clone() const override;
+	virtual int						Class_ID() const override;
+	virtual void					Render(RenderInfoClass & rinfo) override;
+	virtual void					Get_Obj_Space_Bounding_Sphere(SphereClass & sphere) const override;
+    virtual void					Get_Obj_Space_Bounding_Box(AABoxClass & aabox) const override;
 
 	Int freeTerrainTracksResources();	///<free W3D assets used for this track
 	void init( Real width, Real length, const Char *texturename);	///<allocate W3D resources and set size

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DTerrainTracks.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DTerrainTracks.h
@@ -53,7 +53,7 @@ class TerrainTracksRenderObjClass : public W3DMPO, public RenderObjClass
 public:
 
 	TerrainTracksRenderObjClass();
-	~TerrainTracksRenderObjClass() override;
+	virtual ~TerrainTracksRenderObjClass() override;
 
 	/////////////////////////////////////////////////////////////////////////////
 	// Render Object Interface (W3D methods)

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DTerrainVisual.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DTerrainVisual.h
@@ -47,83 +47,83 @@ class W3DTerrainVisual : public TerrainVisual
 public:
 
 	W3DTerrainVisual();
-	virtual ~W3DTerrainVisual();
+	virtual ~W3DTerrainVisual() override;
 
-	virtual void init();
-	virtual void reset();
-	virtual void update();
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override;
 
-	virtual Bool load( AsciiString filename );
+	virtual Bool load( AsciiString filename ) override;
 
-	void getTerrainColorAt( Real x, Real y, RGBColor *pColor );
+	void getTerrainColorAt( Real x, Real y, RGBColor *pColor ) override;
 
 	/// get the terrain tile type at the world location in the (x,y) plane ignoring Z
-	TerrainType *getTerrainTile( Real x, Real y );
+	TerrainType *getTerrainTile( Real x, Real y ) override;
 
 	/** intersect the ray with the terrain, if a hit occurs TRUE is returned
 	and the result point on the terrain is returned in "result" */
-	virtual Bool intersectTerrain( Coord3D *rayStart, Coord3D *rayEnd, Coord3D *result );
+	virtual Bool intersectTerrain( Coord3D *rayStart, Coord3D *rayEnd, Coord3D *result ) override;
 
 	//
 	// water methods
 	//
 	/// enable/disable the water grid
-	virtual void enableWaterGrid( Bool enable );
+	virtual void enableWaterGrid( Bool enable ) override;
 	/// set min/max height values allowed in water grid pointed to by waterTable
-	virtual void setWaterGridHeightClamps( const WaterHandle *waterTable, Real minZ, Real maxZ );
+	virtual void setWaterGridHeightClamps( const WaterHandle *waterTable, Real minZ, Real maxZ ) override;
 	/// adjust fallof parameters for grid change method
 	virtual void setWaterAttenuationFactors( const WaterHandle *waterTable,
-																					 Real a, Real b, Real c, Real range );
+																					 Real a, Real b, Real c, Real range ) override;
 	/// set the water table position and orientation in world space
 	virtual void setWaterTransform( const WaterHandle *waterTable,
-																	Real angle, Real x, Real y, Real z );
-	virtual void setWaterTransform( const Matrix3D *transform );
-	virtual void getWaterTransform( const WaterHandle *waterTable, Matrix3D *transform );
+																	Real angle, Real x, Real y, Real z ) override;
+	virtual void setWaterTransform( const Matrix3D *transform ) override;
+	virtual void getWaterTransform( const WaterHandle *waterTable, Matrix3D *transform ) override;
 	/// water grid resolution spacing
 	virtual void setWaterGridResolution( const WaterHandle *waterTable,
-																			 Real gridCellsX, Real gridCellsY, Real cellSize );
+																			 Real gridCellsX, Real gridCellsY, Real cellSize ) override;
 	virtual void getWaterGridResolution( const WaterHandle *waterTable,
-																			 Real *gridCellsX, Real *gridCellsY, Real *cellSize );
+																			 Real *gridCellsX, Real *gridCellsY, Real *cellSize ) override;
 	/// adjust the water grid in world coords by the delta
-	virtual void changeWaterHeight( Real x, Real y, Real delta );
+	virtual void changeWaterHeight( Real x, Real y, Real delta ) override;
 	/// adjust the velocity at a water grid point corresponding to the world x,y
 	virtual void addWaterVelocity( Real worldX, Real worldY,
-																 Real velocity, Real preferredHeight );
-	virtual Bool getWaterGridHeight( Real worldX, Real worldY, Real *height);
+																 Real velocity, Real preferredHeight ) override;
+	virtual Bool getWaterGridHeight( Real worldX, Real worldY, Real *height) override;
 
-	virtual void setTerrainTracksDetail();
-	virtual void setShoreLineDetail();
-
-	/// Add a bib at location.
-	void addFactionBib(Object *factionBuilding, Bool highlight, Real extra = 0);
-	/// Remove a bib.
-	void removeFactionBib(Object *factionBuilding);
+	virtual void setTerrainTracksDetail() override;
+	virtual void setShoreLineDetail() override;
 
 	/// Add a bib at location.
-	void addFactionBibDrawable(Drawable *factionBuilding, Bool highlight, Real extra = 0);
+	void addFactionBib(Object *factionBuilding, Bool highlight, Real extra = 0) override;
 	/// Remove a bib.
-	void removeFactionBibDrawable(Drawable *factionBuilding);
+	void removeFactionBib(Object *factionBuilding) override;
 
-	virtual void removeAllBibs();
-	virtual void removeBibHighlighting();
+	/// Add a bib at location.
+	void addFactionBibDrawable(Drawable *factionBuilding, Bool highlight, Real extra = 0) override;
+	/// Remove a bib.
+	void removeFactionBibDrawable(Drawable *factionBuilding) override;
 
-	virtual void addProp(const ThingTemplate *tt, const Coord3D *pos, Real angle);
+	virtual void removeAllBibs() override;
+	virtual void removeBibHighlighting() override;
+
+	virtual void addProp(const ThingTemplate *tt, const Coord3D *pos, Real angle) override;
 
 	virtual void removeTreesAndPropsForConstruction(
 		const Coord3D* pos,
 		const GeometryInfo& geom,
 		Real angle
-	);
+	) override;
 
 
 	//
 	// Modify height.
 	//
-	virtual void setRawMapHeight(const ICoord2D *gridPos, Int height);
-	virtual Int getRawMapHeight(const ICoord2D *gridPos);
+	virtual void setRawMapHeight(const ICoord2D *gridPos, Int height) override;
+	virtual Int getRawMapHeight(const ICoord2D *gridPos) override;
 
 	/// Replace the skybox texture
-	virtual void replaceSkyboxTextures(const AsciiString *oldTexName[NumSkyboxTextures], const AsciiString *newTexName[NumSkyboxTextures]);
+	virtual void replaceSkyboxTextures(const AsciiString *oldTexName[NumSkyboxTextures], const AsciiString *newTexName[NumSkyboxTextures]) override;
 
   ////////////////////////////////////////////////////
   ////////////////////////////////////////////////////
@@ -131,8 +131,8 @@ public:
 #ifdef DO_SEISMIC_SIMULATIONS
   virtual void addSeismicSimulation( const SeismicSimulationNode& sim );
 #endif
-  WorldHeightMap* getLogicHeightMap() {return m_logicHeightMap;};
-  WorldHeightMap* getClientHeightMap()
+  WorldHeightMap* getLogicHeightMap() override {return m_logicHeightMap;};
+  WorldHeightMap* getClientHeightMap() override
   {
 #ifdef DO_SEISMIC_SIMULATIONS
     return m_clientHeightMap;
@@ -147,9 +147,9 @@ public:
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 #ifdef DO_SEISMIC_SIMULATIONS
   ////////////////////////////////////////////////////

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DTerrainVisual.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DTerrainVisual.h
@@ -55,10 +55,10 @@ public:
 
 	virtual Bool load( AsciiString filename ) override;
 
-	void getTerrainColorAt( Real x, Real y, RGBColor *pColor ) override;
+	virtual void getTerrainColorAt( Real x, Real y, RGBColor *pColor ) override;
 
 	/// get the terrain tile type at the world location in the (x,y) plane ignoring Z
-	TerrainType *getTerrainTile( Real x, Real y ) override;
+	virtual TerrainType *getTerrainTile( Real x, Real y ) override;
 
 	/** intersect the ray with the terrain, if a hit occurs TRUE is returned
 	and the result point on the terrain is returned in "result" */
@@ -95,14 +95,14 @@ public:
 	virtual void setShoreLineDetail() override;
 
 	/// Add a bib at location.
-	void addFactionBib(Object *factionBuilding, Bool highlight, Real extra = 0) override;
+	virtual void addFactionBib(Object *factionBuilding, Bool highlight, Real extra = 0) override;
 	/// Remove a bib.
-	void removeFactionBib(Object *factionBuilding) override;
+	virtual void removeFactionBib(Object *factionBuilding) override;
 
 	/// Add a bib at location.
-	void addFactionBibDrawable(Drawable *factionBuilding, Bool highlight, Real extra = 0) override;
+	virtual void addFactionBibDrawable(Drawable *factionBuilding, Bool highlight, Real extra = 0) override;
 	/// Remove a bib.
-	void removeFactionBibDrawable(Drawable *factionBuilding) override;
+	virtual void removeFactionBibDrawable(Drawable *factionBuilding) override;
 
 	virtual void removeAllBibs() override;
 	virtual void removeBibHighlighting() override;
@@ -131,8 +131,8 @@ public:
 #ifdef DO_SEISMIC_SIMULATIONS
   virtual void addSeismicSimulation( const SeismicSimulationNode& sim );
 #endif
-  WorldHeightMap* getLogicHeightMap() override {return m_logicHeightMap;};
-  WorldHeightMap* getClientHeightMap() override
+  virtual WorldHeightMap* getLogicHeightMap() override {return m_logicHeightMap;};
+  virtual WorldHeightMap* getClientHeightMap() override
   {
 #ifdef DO_SEISMIC_SIMULATIONS
     return m_clientHeightMap;

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DTreeBuffer.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DTreeBuffer.h
@@ -155,7 +155,7 @@ class W3DTreeBuffer : public Snapshot
 	{
 		W3DMPO_GLUE(W3DTreeTextureClass)
 	protected:
-		virtual void Apply(unsigned int stage);
+		virtual void Apply(unsigned int stage) override;
 
 	public:
 			/// Create texture.
@@ -258,9 +258,9 @@ private:
 
 protected:
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 protected:
 	/// Updates the sway offsets.

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DVideoBuffer.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DVideoBuffer.h
@@ -77,13 +77,13 @@ class W3DVideoBuffer : public VideoBuffer
 	public:
 
 		W3DVideoBuffer( Type format );
-		virtual ~W3DVideoBuffer();
+		virtual ~W3DVideoBuffer() override;
 
-		virtual	Bool		allocate( UnsignedInt width, UnsignedInt height); ///< Allocates buffer
-		virtual void		free();					///< Free buffer
-		virtual	void*		lock();					///< Returns memory pointer to start of buffer
-		virtual void		unlock();				///< Release buffer
-		virtual Bool		valid();				///< Is the buffer valid to use
+		virtual	Bool		allocate( UnsignedInt width, UnsignedInt height) override; ///< Allocates buffer
+		virtual void		free() override;					///< Free buffer
+		virtual	void*		lock() override;					///< Returns memory pointer to start of buffer
+		virtual void		unlock() override;				///< Release buffer
+		virtual Bool		valid() override;				///< Is the buffer valid to use
 
 		TextureClass		*texture();			///< Returns texture object
 

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DView.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DView.h
@@ -140,7 +140,7 @@ class W3DView : public View, public SubsystemInterface
 
 public:
 	W3DView();
-	~W3DView() override;
+	virtual ~W3DView() override;
 
 	virtual void init() override;  ///< init/re-init the W3DView
 	virtual void reset() override;

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DView.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DView.h
@@ -140,107 +140,107 @@ class W3DView : public View, public SubsystemInterface
 
 public:
 	W3DView();
-	~W3DView();
+	~W3DView() override;
 
-	virtual void init();  ///< init/re-init the W3DView
-	virtual void reset();
-	virtual void drawView();  ///< draw this view
-	virtual void updateView();	///<called once per frame to determine the final camera and object transforms
-	virtual void stepView(); ///< Update view for every fixed time step
+	virtual void init() override;  ///< init/re-init the W3DView
+	virtual void reset() override;
+	virtual void drawView() override;  ///< draw this view
+	virtual void updateView() override;	///<called once per frame to determine the final camera and object transforms
+	virtual void stepView() override; ///< Update view for every fixed time step
 
-	virtual void draw();  ///< draw this view
-	virtual void update();	///<called once per frame to determine the final camera and object transforms
+	virtual void draw() override;  ///< draw this view
+	virtual void update() override;	///<called once per frame to determine the final camera and object transforms
 
-	virtual Drawable *pickDrawable( const ICoord2D *screen, Bool forceAttack, PickType pickType );  ///< pick drawable given the screen pixel coords.  If force attack, picks bridges.
+	virtual Drawable *pickDrawable( const ICoord2D *screen, Bool forceAttack, PickType pickType ) override;  ///< pick drawable given the screen pixel coords.  If force attack, picks bridges.
 
 	/// all drawables in the 2D screen region will call the 'callback'
 	virtual Int iterateDrawablesInRegion( IRegion2D *screenRegion,
 																Bool (*callback)( Drawable *draw, void *userData ),
-																void *userData );
+																void *userData ) override;
 
-	virtual void setWidth( Int width );
-	virtual void setHeight( Int height );
-	virtual void setOrigin( Int x, Int y);			///< Sets location of top-left view corner on display
+	virtual void setWidth( Int width ) override;
+	virtual void setHeight( Int height ) override;
+	virtual void setOrigin( Int x, Int y) override;			///< Sets location of top-left view corner on display
 
-	virtual void scrollBy( const Coord2D *delta );  ///< Shift the view by the given delta
+	virtual void scrollBy( const Coord2D *delta ) override;  ///< Shift the view by the given delta
 
-	virtual void forceRedraw();
+	virtual void forceRedraw() override;
 
 	virtual Bool isDoingScriptedCamera();
 	virtual void stopDoingScriptedCamera();
 
-	virtual void setAngle( Real radians );									///< Rotate the view around the vertical axis to the given angle (yaw)
-	virtual void setPitch( Real radians );									///< Rotate the view around the horizontal axis to the given angle (pitch)
-	virtual void setAngleToDefault();									///< Set the view angle back to default
-	virtual void setPitchToDefault();									///< Set the view pitch back to default
+	virtual void setAngle( Real radians ) override;									///< Rotate the view around the vertical axis to the given angle (yaw)
+	virtual void setPitch( Real radians ) override;									///< Rotate the view around the horizontal axis to the given angle (pitch)
+	virtual void setAngleToDefault() override;									///< Set the view angle back to default
+	virtual void setPitchToDefault() override;									///< Set the view pitch back to default
 
-	virtual void lookAt( const Coord3D *o );											///< Center the view on the given coordinate
-	virtual void initHeightForMap();												///<  Init the camera height for the map at the current position.
-	virtual void moveCameraTo(const Coord3D *o, Int milliseconds,  Int shutter, Bool orient, Real easeIn, Real easeOut);
-	virtual void moveCameraAlongWaypointPath(Waypoint *pWay, Int frames, Int shutter, Bool orient, Real easeIn, Real easeOut);
-	virtual Bool isCameraMovementFinished();
+	virtual void lookAt( const Coord3D *o ) override;											///< Center the view on the given coordinate
+	virtual void initHeightForMap() override;												///<  Init the camera height for the map at the current position.
+	virtual void moveCameraTo(const Coord3D *o, Int milliseconds,  Int shutter, Bool orient, Real easeIn, Real easeOut) override;
+	virtual void moveCameraAlongWaypointPath(Waypoint *pWay, Int frames, Int shutter, Bool orient, Real easeIn, Real easeOut) override;
+	virtual Bool isCameraMovementFinished() override;
 	virtual Bool isCameraMovementAtWaypointAlongPath();
- 	virtual void resetCamera(const Coord3D *location, Int frames, Real easeIn, Real easeOut);	///< Move camera to location, and reset to default angle & zoom.
- 	virtual void rotateCamera(Real rotations, Int frames, Real easeIn, Real easeOut);					///< Rotate camera about current viewpoint.
-	virtual void rotateCameraTowardObject(ObjectID id, Int milliseconds, Int holdMilliseconds, Real easeIn, Real easeOut);	///< Rotate camera to face an object, and hold on it
-	virtual void rotateCameraTowardPosition(const Coord3D *pLoc, Int milliseconds, Real easeIn, Real easeOut, Bool reverseRotation);	///< Rotate camera to face a location.
+ 	virtual void resetCamera(const Coord3D *location, Int frames, Real easeIn, Real easeOut) override;	///< Move camera to location, and reset to default angle & zoom.
+ 	virtual void rotateCamera(Real rotations, Int frames, Real easeIn, Real easeOut) override;					///< Rotate camera about current viewpoint.
+	virtual void rotateCameraTowardObject(ObjectID id, Int milliseconds, Int holdMilliseconds, Real easeIn, Real easeOut) override;	///< Rotate camera to face an object, and hold on it
+	virtual void rotateCameraTowardPosition(const Coord3D *pLoc, Int milliseconds, Real easeIn, Real easeOut, Bool reverseRotation) override;	///< Rotate camera to face a location.
 	virtual void cameraModFreezeTime(){ m_freezeTimeForCameraMovement = true;}					///< Freezes time during the next camera movement.
-	virtual void cameraModFreezeAngle();												///< Freezes time during the next camera movement.
+	virtual void cameraModFreezeAngle() override;												///< Freezes time during the next camera movement.
 	virtual Bool isTimeFrozen(){ return m_freezeTimeForCameraMovement;}					///< Freezes time during the next camera movement.
-	virtual void cameraModFinalZoom(Real finalZoom, Real easeIn, Real easeOut);	///< Final zoom for current camera movement.
-	virtual void cameraModRollingAverage(Int framesToAverage);			///< Number of frames to average movement for current camera movement.
-	virtual void cameraModFinalTimeMultiplier(Int finalMultiplier); ///< Final time multiplier for current camera movement.
-	virtual void cameraModFinalPitch(Real finalPitch, Real easeIn, Real easeOut);	///< Final pitch for current camera movement.
-	virtual void cameraModLookToward(Coord3D *pLoc);								///< Sets a look at point during camera movement.
-	virtual void cameraModFinalLookToward(Coord3D *pLoc);						///< Sets a look at point during camera movement.
-	virtual void cameraModFinalMoveTo(Coord3D *pLoc);			///< Sets a final move to.
+	virtual void cameraModFinalZoom(Real finalZoom, Real easeIn, Real easeOut) override;	///< Final zoom for current camera movement.
+	virtual void cameraModRollingAverage(Int framesToAverage) override;			///< Number of frames to average movement for current camera movement.
+	virtual void cameraModFinalTimeMultiplier(Int finalMultiplier) override; ///< Final time multiplier for current camera movement.
+	virtual void cameraModFinalPitch(Real finalPitch, Real easeIn, Real easeOut) override;	///< Final pitch for current camera movement.
+	virtual void cameraModLookToward(Coord3D *pLoc) override;								///< Sets a look at point during camera movement.
+	virtual void cameraModFinalLookToward(Coord3D *pLoc) override;						///< Sets a look at point during camera movement.
+	virtual void cameraModFinalMoveTo(Coord3D *pLoc) override;			///< Sets a final move to.
 	// (gth) C&C3 animation controlled camera feature
-	virtual void cameraEnableSlaveMode(const AsciiString & thingtemplateName, const AsciiString & boneName);
-	virtual void cameraDisableSlaveMode();
+	virtual void cameraEnableSlaveMode(const AsciiString & thingtemplateName, const AsciiString & boneName) override;
+	virtual void cameraDisableSlaveMode() override;
 	virtual void cameraEnableRealZoomMode(); //WST 10.18.2002
 	virtual void cameraDisableRealZoomMode();
 
-	virtual	void Add_Camera_Shake(const Coord3D & position,float radius, float duration, float power); //WST 10.18.2002
-	virtual Int	 getTimeMultiplier() {return m_timeMultiplier;};///< Get the time multiplier.
-	virtual void setTimeMultiplier(Int multiple) {m_timeMultiplier = multiple;}; ///< Set the time multiplier.
-	virtual void setDefaultView(Real pitch, Real angle, Real maxHeight);
-	virtual void zoomCamera( Real finalZoom, Int milliseconds, Real easeIn, Real easeOut );
-	virtual void pitchCamera( Real finalPitch, Int milliseconds, Real easeIn, Real easeOut );
+	virtual	void Add_Camera_Shake(const Coord3D & position,float radius, float duration, float power) override; //WST 10.18.2002
+	virtual Int	 getTimeMultiplier() override {return m_timeMultiplier;};///< Get the time multiplier.
+	virtual void setTimeMultiplier(Int multiple) override {m_timeMultiplier = multiple;}; ///< Set the time multiplier.
+	virtual void setDefaultView(Real pitch, Real angle, Real maxHeight) override;
+	virtual void zoomCamera( Real finalZoom, Int milliseconds, Real easeIn, Real easeOut ) override;
+	virtual void pitchCamera( Real finalPitch, Int milliseconds, Real easeIn, Real easeOut ) override;
 
-	virtual void setHeightAboveGround(Real z);
-	virtual void setZoom(Real z);
-	virtual void setZoomToDefault();									///< Set zoom to default value
+	virtual void setHeightAboveGround(Real z) override;
+	virtual void setZoom(Real z) override;
+	virtual void setZoomToDefault() override;									///< Set zoom to default value
 
-	virtual void setFieldOfView( Real angle );							///< Set the horizontal field of view angle
+	virtual void setFieldOfView( Real angle ) override;							///< Set the horizontal field of view angle
 
-  virtual WorldToScreenReturn worldToScreenTriReturn( const Coord3D *w, ICoord2D *s );	///< Transform world coordinate "w" into screen coordinate "s"
-	virtual void screenToTerrain( const ICoord2D *screen, Coord3D *world );  ///< transform screen coord to a point on the 3D terrain
-	virtual void screenToWorldAtZ( const ICoord2D *s, Coord3D *w, Real z );  ///< transform screen point to world point at the specified world Z value
+  virtual WorldToScreenReturn worldToScreenTriReturn( const Coord3D *w, ICoord2D *s ) override;	///< Transform world coordinate "w" into screen coordinate "s"
+	virtual void screenToTerrain( const ICoord2D *screen, Coord3D *world ) override;  ///< transform screen coord to a point on the 3D terrain
+	virtual void screenToWorldAtZ( const ICoord2D *s, Coord3D *w, Real z ) override;  ///< transform screen point to world point at the specified world Z value
 
 	CameraClass *get3DCamera() const { return m_3DCamera; }
 
-	virtual const Coord3D& get3DCameraPosition() const;
+	virtual const Coord3D& get3DCameraPosition() const override;
 
-	virtual void setCameraLock(ObjectID id);
-	virtual void setSnapMode( CameraLockType lockType, Real lockDist );
+	virtual void setCameraLock(ObjectID id) override;
+	virtual void setSnapMode( CameraLockType lockType, Real lockDist ) override;
 
 	/// Add an impulse force to shake the camera
-	virtual void shake( const Coord3D *epicenter, CameraShakeType shakeType );
+	virtual void shake( const Coord3D *epicenter, CameraShakeType shakeType ) override;
 
-	virtual Real getFXPitch() const { return m_FXPitch; }					///< returns the FX pitch angle
+	virtual Real getFXPitch() const override { return m_FXPitch; }					///< returns the FX pitch angle
 
-	virtual Bool setViewFilterMode(FilterModes filterMode);			///< Turns on viewport special effect (black & white mode)
-	virtual Bool setViewFilter(FilterTypes filter);			///< Turns on viewport special effect (black & white mode)
-	virtual void setViewFilterPos(const Coord3D *pos);			///<  Passes a position to the special effect filter.
-	virtual FilterModes getViewFilterMode() {return m_viewFilterMode;}			///< Turns on viewport special effect (black & white mode)
-	virtual FilterTypes getViewFilterType() {return m_viewFilter;}			///< Turns on viewport special effect (black & white mode)
-	virtual void setFadeParameters(Int fadeFrames, Int direction);
-	virtual void set3DWireFrameMode(Bool enable);	///<enables custom wireframe rendering of 3D viewport
+	virtual Bool setViewFilterMode(FilterModes filterMode) override;			///< Turns on viewport special effect (black & white mode)
+	virtual Bool setViewFilter(FilterTypes filter) override;			///< Turns on viewport special effect (black & white mode)
+	virtual void setViewFilterPos(const Coord3D *pos) override;			///<  Passes a position to the special effect filter.
+	virtual FilterModes getViewFilterMode() override {return m_viewFilterMode;}			///< Turns on viewport special effect (black & white mode)
+	virtual FilterTypes getViewFilterType() override {return m_viewFilter;}			///< Turns on viewport special effect (black & white mode)
+	virtual void setFadeParameters(Int fadeFrames, Int direction) override;
+	virtual void set3DWireFrameMode(Bool enable) override;	///<enables custom wireframe rendering of 3D viewport
 
 	Bool updateCameraMovements();
-	virtual void forceCameraAreaConstraintRecalc() { calcCameraAreaConstraints(); }
+	virtual void forceCameraAreaConstraintRecalc() override { calcCameraAreaConstraints(); }
 
-	virtual void setGuardBandBias( const Coord2D *gb ) { m_guardBandBias.x = gb->x; m_guardBandBias.y = gb->y; }
+	virtual void setGuardBandBias( const Coord2D *gb ) override { m_guardBandBias.x = gb->x; m_guardBandBias.y = gb->y; }
 
 private:
 

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DWater.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DWater.h
@@ -73,7 +73,7 @@ public:
 	};
 
 	WaterRenderObjClass();
-	~WaterRenderObjClass() override;
+	virtual ~WaterRenderObjClass() override;
 
 	/////////////////////////////////////////////////////////////////////////////
 	// Render Object Interface (W3D methods)

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DWater.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DWater.h
@@ -73,14 +73,14 @@ public:
 	};
 
 	WaterRenderObjClass();
-	~WaterRenderObjClass();
+	~WaterRenderObjClass() override;
 
 	/////////////////////////////////////////////////////////////////////////////
 	// Render Object Interface (W3D methods)
 	/////////////////////////////////////////////////////////////////////////////
-	virtual RenderObjClass *	Clone() const;
-	virtual int						Class_ID() const;
-	virtual void					Render(RenderInfoClass & rinfo);
+	virtual RenderObjClass *	Clone() const override;
+	virtual int						Class_ID() const override;
+	virtual void					Render(RenderInfoClass & rinfo) override;
 /// @todo: Add methods for collision detection with water surface
 //	virtual Bool					Cast_Ray(RayCollisionTestClass & raytest);
 //	virtual Bool					Cast_AABox(AABoxCollisionTestClass & boxtest);
@@ -88,11 +88,11 @@ public:
 //	virtual Bool					Intersect_AABox(AABoxIntersectionTestClass & boxtest);
 //	virtual Bool					Intersect_OBBox(OBBoxIntersectionTestClass & boxtest);
 
-	virtual void					Get_Obj_Space_Bounding_Sphere(SphereClass & sphere) const;
-    virtual void					Get_Obj_Space_Bounding_Box(AABoxClass & aabox) const;
+	virtual void					Get_Obj_Space_Bounding_Sphere(SphereClass & sphere) const override;
+    virtual void					Get_Obj_Space_Bounding_Box(AABoxClass & aabox) const override;
 	// Get and set static sort level
-	virtual int		Get_Sort_Level() const		{ return m_sortLevel; }
-  	virtual void	Set_Sort_Level(int level)		{ m_sortLevel = level;}
+	virtual int		Get_Sort_Level() const override { return m_sortLevel; }
+  	virtual void	Set_Sort_Level(int level) override { m_sortLevel = level;}
 
 	///allocate W3D resources needed to render water
 	void renderWater();				///<draw the water surface (flat)
@@ -258,9 +258,9 @@ protected:
 	HRESULT generateVertexBuffer( Int sizeX, Int sizeY, Int vertexSize, Bool doFill);///<Generate static vertex buffer
 
 	// snapshot methods for save/load
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 };
 

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/WorldHeightMap.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/WorldHeightMap.h
@@ -221,7 +221,7 @@ protected:
 
 public: // constructors/destructors
 	WorldHeightMap(ChunkInputStream *pFile, Bool bHMapOnly=false);	// read from file.
-	~WorldHeightMap() override;			// destroy.
+	virtual ~WorldHeightMap() override;			// destroy.
 
 public:  // Boundary info
 	const VecICoord2D& getAllBoundaries() const { return m_boundaries; }

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/WorldHeightMap.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/WorldHeightMap.h
@@ -221,7 +221,7 @@ protected:
 
 public: // constructors/destructors
 	WorldHeightMap(ChunkInputStream *pFile, Bool bHMapOnly=false);	// read from file.
-	~WorldHeightMap();			// destroy.
+	~WorldHeightMap() override;			// destroy.
 
 public:  // Boundary info
 	const VecICoord2D& getAllBoundaries() const { return m_boundaries; }
@@ -243,7 +243,7 @@ public:  // height map info.
 	Int getDrawHeight() {return m_drawHeightY;}
 	void setDrawWidth(Int width) {m_drawWidthX = width; if (m_drawWidthX>m_width) m_drawWidthX = m_width;}
 	void setDrawHeight(Int height) {m_drawHeightY = height; if (m_drawHeightY>m_height) m_drawHeightY = m_height;}
-	virtual Int getBorderSize() {return m_borderSize;}
+	virtual Int getBorderSize() override {return m_borderSize;}
   Int getBorderSizeInline() const { return m_borderSize; }
 	/// Get height with the offset that HeightMapRenderObjClass uses built in.
 	UnsignedByte getDisplayHeight(Int x, Int y) { return m_data[x+m_drawOriginX+m_width*(y+m_drawOriginY)];}
@@ -296,10 +296,10 @@ public:  // tile and texture info.
   Bool getSeismicUpdateFlag(Int xIndex, Int yIndex) const;
   void setSeismicUpdateFlag(Int xIndex, Int yIndex, Bool value);
   void clearSeismicUpdateFlags() ;
-  virtual Real getSeismicZVelocity(Int xIndex, Int yIndex) const;
-  virtual void setSeismicZVelocity(Int xIndex, Int yIndex, Real value);
+  virtual Real getSeismicZVelocity(Int xIndex, Int yIndex) const override;
+  virtual void setSeismicZVelocity(Int xIndex, Int yIndex, Real value) override;
   void fillSeismicZVelocities( Real value );
-  virtual Real getBilinearSampleSeismicZVelocity( Int x, Int y);
+  virtual Real getBilinearSampleSeismicZVelocity( Int x, Int y) override;
 
 
 

--- a/Core/GameEngineDevice/Include/Win32Device/Common/Win32BIGFile.h
+++ b/Core/GameEngineDevice/Include/Win32Device/Common/Win32BIGFile.h
@@ -36,15 +36,15 @@ class Win32BIGFile : public ArchiveFile
 {
 	public:
 		Win32BIGFile(AsciiString name, AsciiString path);
-		virtual ~Win32BIGFile();
+		virtual ~Win32BIGFile() override;
 
-		virtual Bool					getFileInfo(const AsciiString& filename, FileInfo *fileInfo) const;	///< fill in the fileInfo struct with info about the requested file.
-		virtual File*					openFile( const Char *filename, Int access = 0 );///< Open the specified file within the BIG file
-		virtual void					closeAllFiles();									///< Close all file opened in this BIG file
-		virtual AsciiString		getName();												///< Returns the name of the BIG file
-		virtual AsciiString		getPath();												///< Returns full path and name of BIG file
-		virtual void					setSearchPriority( Int new_priority );	///< Set this BIG file's search priority
-		virtual void					close();													///< Close this BIG file
+		virtual Bool					getFileInfo(const AsciiString& filename, FileInfo *fileInfo) const override;	///< fill in the fileInfo struct with info about the requested file.
+		virtual File*					openFile( const Char *filename, Int access = 0 ) override;///< Open the specified file within the BIG file
+		virtual void					closeAllFiles() override;									///< Close all file opened in this BIG file
+		virtual AsciiString		getName() override;												///< Returns the name of the BIG file
+		virtual AsciiString		getPath() override;												///< Returns full path and name of BIG file
+		virtual void					setSearchPriority( Int new_priority ) override;	///< Set this BIG file's search priority
+		virtual void					close() override;													///< Close this BIG file
 
 	protected:
 

--- a/Core/GameEngineDevice/Include/Win32Device/Common/Win32BIGFileSystem.h
+++ b/Core/GameEngineDevice/Include/Win32Device/Common/Win32BIGFileSystem.h
@@ -34,22 +34,22 @@ class Win32BIGFileSystem : public ArchiveFileSystem
 {
 public:
 	Win32BIGFileSystem();
-	virtual ~Win32BIGFileSystem();
+	virtual ~Win32BIGFileSystem() override;
 
-	virtual void init();
-	virtual void update();
-	virtual void reset();
-	virtual void postProcessLoad();
+	virtual void init() override;
+	virtual void update() override;
+	virtual void reset() override;
+	virtual void postProcessLoad() override;
 
 	// ArchiveFile operations
-	virtual void closeAllArchiveFiles();											///< Close all Archivefiles currently open
+	virtual void closeAllArchiveFiles() override;											///< Close all Archivefiles currently open
 
 	// File operations
-	virtual ArchiveFile * openArchiveFile(const Char *filename);
-	virtual void closeArchiveFile(const Char *filename);
-	virtual void closeAllFiles();															///< Close all files associated with ArchiveFiles
+	virtual ArchiveFile * openArchiveFile(const Char *filename) override;
+	virtual void closeArchiveFile(const Char *filename) override;
+	virtual void closeAllFiles() override;															///< Close all files associated with ArchiveFiles
 
-	virtual Bool loadBigFilesFromDirectory(AsciiString dir, AsciiString fileMask, Bool overwrite = FALSE);
+	virtual Bool loadBigFilesFromDirectory(AsciiString dir, AsciiString fileMask, Bool overwrite = FALSE) override;
 protected:
 
 };

--- a/Core/GameEngineDevice/Include/Win32Device/Common/Win32LocalFileSystem.h
+++ b/Core/GameEngineDevice/Include/Win32Device/Common/Win32LocalFileSystem.h
@@ -34,20 +34,20 @@ class Win32LocalFileSystem : public LocalFileSystem
 {
 public:
 	Win32LocalFileSystem();
-	virtual ~Win32LocalFileSystem();
+	virtual ~Win32LocalFileSystem() override;
 
-	virtual void init();
-	virtual void reset();
-	virtual void update();
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override;
 
-	virtual File * openFile(const Char *filename, Int access = File::NONE, size_t bufferSize = File::BUFFERSIZE);	///< open the given file.
-	virtual Bool doesFileExist(const Char *filename) const;								///< does the given file exist?
+	virtual File * openFile(const Char *filename, Int access = File::NONE, size_t bufferSize = File::BUFFERSIZE) override;	///< open the given file.
+	virtual Bool doesFileExist(const Char *filename) const override;								///< does the given file exist?
 
-	virtual void getFileListInDirectory(const AsciiString& currentDirectory, const AsciiString& originalDirectory, const AsciiString& searchName, FilenameList &filenameList, Bool searchSubdirectories) const; ///< search the given directory for files matching the searchName (egs. *.ini, *.rep).  Possibly search subdirectories.
-	virtual Bool getFileInfo(const AsciiString& filename, FileInfo *fileInfo) const;
+	virtual void getFileListInDirectory(const AsciiString& currentDirectory, const AsciiString& originalDirectory, const AsciiString& searchName, FilenameList &filenameList, Bool searchSubdirectories) const override; ///< search the given directory for files matching the searchName (egs. *.ini, *.rep).  Possibly search subdirectories.
+	virtual Bool getFileInfo(const AsciiString& filename, FileInfo *fileInfo) const override;
 
-	virtual Bool createDirectory(AsciiString directory);
-	virtual AsciiString normalizePath(const AsciiString& filePath) const;
+	virtual Bool createDirectory(AsciiString directory) override;
+	virtual AsciiString normalizePath(const AsciiString& filePath) const override;
 
 protected:
 };

--- a/Core/GameEngineDevice/Include/Win32Device/GameClient/Win32DIKeyboard.h
+++ b/Core/GameEngineDevice/Include/Win32Device/GameClient/Win32DIKeyboard.h
@@ -70,18 +70,18 @@ class DirectInputKeyboard : public Keyboard
 public:
 
 	DirectInputKeyboard();
-	virtual ~DirectInputKeyboard();
+	virtual ~DirectInputKeyboard() override;
 
 	// extend methods from the base class
-	virtual void init();		///< initialize the keyboard, extending init functionality
-	virtual void reset();		///< Reset the keyboard system
-	virtual void update();  ///< update call, extending update functionality
-	virtual Bool getCapsState();		///< get state of caps lock key, return TRUE if down
+	virtual void init() override;		///< initialize the keyboard, extending init functionality
+	virtual void reset() override;		///< Reset the keyboard system
+	virtual void update() override;  ///< update call, extending update functionality
+	virtual Bool getCapsState() override;		///< get state of caps lock key, return TRUE if down
 
 protected:
 
 	// extended methods from the base class
-	virtual void getKey( KeyboardIO *key );  ///< get a single key event
+	virtual void getKey( KeyboardIO *key ) override;  ///< get a single key event
 
 	//-----------------------------------------------------------------------------------------------
 

--- a/Core/GameEngineDevice/Include/Win32Device/GameClient/Win32DIMouse.h
+++ b/Core/GameEngineDevice/Include/Win32Device/GameClient/Win32DIMouse.h
@@ -62,25 +62,25 @@ class DirectInputMouse : public Mouse
 public:
 
 	DirectInputMouse();
-	virtual ~DirectInputMouse();
+	virtual ~DirectInputMouse() override;
 
 	// extended methods from base class
-	virtual void init();		///< initialize the direct input mouse, extending functionality
-	virtual void reset();		///< reset system
-	virtual void update();  ///< update the mouse data, extending functionality
-	virtual void setPosition( Int x, Int y );  ///< set position for mouse
+	virtual void init() override;		///< initialize the direct input mouse, extending functionality
+	virtual void reset() override;		///< reset system
+	virtual void update() override;  ///< update the mouse data, extending functionality
+	virtual void setPosition( Int x, Int y ) override;  ///< set position for mouse
 
-	virtual void setMouseLimits();  ///< update the limit extents the mouse can move in
+	virtual void setMouseLimits() override;  ///< update the limit extents the mouse can move in
 
-	virtual void setCursor( MouseCursor cursor );  ///< set mouse cursor
+	virtual void setCursor( MouseCursor cursor ) override;  ///< set mouse cursor
 
-	virtual void capture();  ///< capture the mouse
-	virtual void releaseCapture();  ///< release mouse capture
+	virtual void capture() override;  ///< capture the mouse
+	virtual void releaseCapture() override;  ///< release mouse capture
 
 protected:
 
 	/// device implementation to get mouse event
-	virtual UnsignedByte getMouseEvent( MouseIO *result, Bool flush );
+	virtual UnsignedByte getMouseEvent( MouseIO *result, Bool flush ) override;
 
 	// new internal methods for our direct input implementation
 	void openMouse();  ///< create the direct input mouse

--- a/Core/GameEngineDevice/Include/Win32Device/GameClient/Win32Mouse.h
+++ b/Core/GameEngineDevice/Include/Win32Device/GameClient/Win32Mouse.h
@@ -63,30 +63,30 @@ class Win32Mouse : public Mouse
 public:
 
 	Win32Mouse();
-	virtual ~Win32Mouse();
+	virtual ~Win32Mouse() override;
 
-	virtual void init();		///< init mouse, extend this functionality, do not replace
-	virtual void reset();		///< reset the system
-	virtual void update();	///< update
-	virtual void initCursorResources();	///< load windows resources needed for 2d cursors.
+	virtual void init() override;		///< init mouse, extend this functionality, do not replace
+	virtual void reset() override;		///< reset the system
+	virtual void update() override;	///< update
+	virtual void initCursorResources() override;	///< load windows resources needed for 2d cursors.
 
-	virtual void setCursor( MouseCursor cursor );		///< set mouse cursor
+	virtual void setCursor( MouseCursor cursor ) override;		///< set mouse cursor
 
-	virtual void setVisibility(Bool visible);
+	virtual void setVisibility(Bool visible) override;
 
-	virtual void loseFocus();
-	virtual void regainFocus();
+	virtual void loseFocus() override;
+	virtual void regainFocus() override;
 
 	/// add an event from a win32 window procedure
 	void addWin32Event( UINT msg, WPARAM wParam, LPARAM lParam, DWORD time );
 
 protected:
 
-	virtual void capture(); ///< capture the mouse
-	virtual void releaseCapture(); ///< release mouse capture
+	virtual void capture() override; ///< capture the mouse
+	virtual void releaseCapture() override; ///< release mouse capture
 
 	/// get the next event available in the buffer
-	virtual UnsignedByte getMouseEvent( MouseIO *result, Bool flush );
+	virtual UnsignedByte getMouseEvent( MouseIO *result, Bool flush ) override;
 
 	/// translate a win32 mouse event to our own info
 	void translateEvent( UnsignedInt eventIndex, MouseIO *result );

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DMouse.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DMouse.cpp
@@ -63,7 +63,7 @@ static class MouseThreadClass : public ThreadClass
 public:
 	MouseThreadClass() : ThreadClass() {}
 
-	void Thread_Function();
+	virtual void Thread_Function() override;
 
 } thread;
 

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DShaderManager.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DShaderManager.cpp
@@ -120,13 +120,13 @@ IDirect3DSurface8 *W3DShaderManager::m_oldDepthSurface=nullptr;	///<previous dep
 class ScreenDefaultFilter : public W3DFilterInterface
 {
 public:
-	virtual Int init();			///<perform any one time initialization and validation
-	virtual Bool preRender(Bool &skipRender, CustomScenePassModes &scenePassMode); ///< Set up at start of render.  Only applies to screen filter shaders.
-	virtual Bool postRender(FilterModes mode, Coord2D &scrollDelta,Bool &doExtraRender); ///< Called after render.  Only applies to screen filter shaders.
-	virtual Bool setup(FilterModes mode){return true;} ///< Called when the filter is started, one time before the first prerender.
+	virtual Int init() override;			///<perform any one time initialization and validation
+	virtual Bool preRender(Bool &skipRender, CustomScenePassModes &scenePassMode) override; ///< Set up at start of render.  Only applies to screen filter shaders.
+	virtual Bool postRender(FilterModes mode, Coord2D &scrollDelta,Bool &doExtraRender) override; ///< Called after render.  Only applies to screen filter shaders.
+	virtual Bool setup(FilterModes mode) override {return true;} ///< Called when the filter is started, one time before the first prerender.
 protected:
-	virtual Int set(FilterModes mode);		///<setup shader for the specified rendering pass.
-	virtual void reset();		///<do any custom resetting necessary to bring W3D in sync.
+	virtual Int set(FilterModes mode) override;		///<setup shader for the specified rendering pass.
+	virtual void reset() override;		///<do any custom resetting necessary to bring W3D in sync.
 };
 
 ScreenDefaultFilter screenDefaultFilter;
@@ -1175,9 +1175,9 @@ Int ScreenMotionBlurFilter::shutdown()
 ///Shroud layer rendering shader
 class ShroudTextureShader : public W3DShaderInterface
 {
-	virtual Int set(Int pass);		///<setup shader for the specified rendering pass.
-	virtual Int init();			///<perform any one time initialization and validation
-	virtual void reset();		///<do any custom resetting necessary to bring W3D in sync.
+	virtual Int set(Int pass) override;		///<setup shader for the specified rendering pass.
+	virtual Int init() override;			///<perform any one time initialization and validation
+	virtual void reset() override;		///<do any custom resetting necessary to bring W3D in sync.
 	Int m_stageOfSet;
 } shroudTextureShader;
 
@@ -1275,9 +1275,9 @@ void ShroudTextureShader::reset()
 ///Shroud layer rendering shader
 class FlatShroudTextureShader : public W3DShaderInterface
 {
-	virtual Int set(Int pass);		///<setup shader for the specified rendering pass.
-	virtual Int init();			///<perform any one time initialization and validation
-	virtual void reset();		///<do any custom resetting necessary to bring W3D in sync.
+	virtual Int set(Int pass) override;		///<setup shader for the specified rendering pass.
+	virtual Int init() override;			///<perform any one time initialization and validation
+	virtual void reset() override;		///<do any custom resetting necessary to bring W3D in sync.
 	Int m_stageOfSet;
 } flatShroudTextureShader;
 
@@ -1368,9 +1368,9 @@ void FlatShroudTextureShader::reset()
 ///Mask layer rendering shader
 class MaskTextureShader : public W3DShaderInterface
 {
-	virtual Int set(Int pass);		///<setup shader for the specified rendering pass.
-	virtual Int init();			///<perform any one time initialization and validation
-	virtual void reset();		///<do any custom resetting necessary to bring W3D in sync.
+	virtual Int set(Int pass) override;		///<setup shader for the specified rendering pass.
+	virtual Int init() override;			///<perform any one time initialization and validation
+	virtual void reset() override;		///<do any custom resetting necessary to bring W3D in sync.
 } maskTextureShader;
 
 ///List of different shroud shader implementations in order of preference
@@ -1484,9 +1484,9 @@ public:
 	float m_xOffset;
 	float m_yOffset;
 
-	virtual Int set(Int pass);		///<setup shader for the specified rendering pass.
-	virtual Int init();			///<perform any one time initialization and validation
-	virtual void reset();		///<do any custom resetting necessary to bring W3D in sync.
+	virtual Int set(Int pass) override;		///<setup shader for the specified rendering pass.
+	virtual Int init() override;			///<perform any one time initialization and validation
+	virtual void reset() override;		///<do any custom resetting necessary to bring W3D in sync.
 
 	void updateCloud();
 	void updateNoise1 (D3DXMATRIX *destMatrix,D3DXMATRIX *curViewInverse, Bool doUpdate=true);	///<generate the uv coordinates for Noise1 (i.e clouds)
@@ -1497,9 +1497,9 @@ public:
 class FlatTerrainShader2Stage : public W3DShaderInterface
 {
 public:
-	virtual Int set(Int pass);		///<setup shader for the specified rendering pass.
-	virtual Int init();			///<perform any one time initialization and validation
-	virtual void reset();		///<do any custom resetting necessary to bring W3D in sync.
+	virtual Int set(Int pass) override;		///<setup shader for the specified rendering pass.
+	virtual Int init() override;			///<perform any one time initialization and validation
+	virtual void reset() override;		///<do any custom resetting necessary to bring W3D in sync.
 } flatTerrainShader2Stage;
 
 ///regular terrain shader that should work on all multi-texture video cards (slowest version)
@@ -1510,18 +1510,18 @@ public:
 	DWORD					m_dwBaseNoise1PixelShader;	///<handle to terrain/single noise D3D pixel shader
 	DWORD					m_dwBaseNoise2PixelShader;	///<handle to terrain/double noise D3D pixel shader
 	DWORD					m_dwBase0PixelShader;	///<handle to terrain only pixel shader
-	virtual Int set(Int pass);		///<setup shader for the specified rendering pass.
-	virtual Int init();			///<perform any one time initialization and validation
-	virtual void reset();		///<do any custom resetting necessary to bring W3D in sync.
-	virtual Int shutdown();			///<release resources used by shader
+	virtual Int set(Int pass) override;		///<setup shader for the specified rendering pass.
+	virtual Int init() override;			///<perform any one time initialization and validation
+	virtual void reset() override;		///<do any custom resetting necessary to bring W3D in sync.
+	virtual Int shutdown() override;			///<release resources used by shader
 } flatTerrainShaderPixelShader;
 
 ///8 stage terrain shader which only works on certain Nvidia cards.
 class TerrainShader8Stage : public W3DShaderInterface
 {
-	virtual Int set(Int pass);		///<setup shader for the specified rendering pass.
-	virtual void reset();		///<do any custom resetting necessary to bring W3D in sync.
-	virtual Int init();			///<perform any one time initialization and validation
+	virtual Int set(Int pass) override;		///<setup shader for the specified rendering pass.
+	virtual void reset() override;		///<do any custom resetting necessary to bring W3D in sync.
+	virtual Int init() override;			///<perform any one time initialization and validation
 } terrainShader8Stage;
 
 //Offsets into constant register pool used by vertex shader
@@ -1534,10 +1534,10 @@ class TerrainShaderPixelShader : public W3DShaderInterface
 	DWORD					m_dwBaseNoise1PixelShader;	///<handle to terrain/single noise D3D pixel shader
 	DWORD					m_dwBaseNoise2PixelShader;	///<handle to terrain/double noise D3D pixel shader
 
-	virtual Int set(Int pass);		///<setup shader for the specified rendering pass.
-	virtual void reset();		///<do any custom resetting necessary to bring W3D in sync.
-	virtual Int init();			///<perform any one time initialization and validation
-	virtual Int shutdown();			///<release resources used by shader
+	virtual Int set(Int pass) override;		///<setup shader for the specified rendering pass.
+	virtual void reset() override;		///<do any custom resetting necessary to bring W3D in sync.
+	virtual Int init() override;			///<perform any one time initialization and validation
+	virtual Int shutdown() override;			///<release resources used by shader
 } terrainShaderPixelShader;
 
 ///List of different terrain shader implementations in order of preference
@@ -2131,9 +2131,9 @@ void TerrainShaderPixelShader::reset()
 ///Cloud layer rendering shader - used for objects similar to terrain which only need the cloud layer.
 class CloudTextureShader : public W3DShaderInterface
 {
-	virtual Int set(Int stage);		///<setup shader for the specified rendering pass.
-	virtual Int init();			///<perform any one time initialization and validation
-	virtual void reset();		///<do any custom resetting necessary to bring W3D in sync.
+	virtual Int set(Int stage) override;		///<setup shader for the specified rendering pass.
+	virtual Int init() override;			///<perform any one time initialization and validation
+	virtual void reset() override;		///<do any custom resetting necessary to bring W3D in sync.
 	Int m_stageOfSet;
 } cloudTextureShader;
 
@@ -2206,18 +2206,18 @@ class RoadShaderPixelShader : public W3DShaderInterface
 {
 	DWORD					m_dwBaseNoise2PixelShader;	///<handle to road/double noise D3D pixel shader
 
-	virtual Int set(Int pass);		///<setup shader for the specified rendering pass.
-	virtual void reset();		///<do any custom resetting necessary to bring W3D in sync.
-	virtual Int init();			///<perform any one time initialization and validation
-	virtual Int shutdown();			///<release resources used by shader
+	virtual Int set(Int pass) override;		///<setup shader for the specified rendering pass.
+	virtual void reset() override;		///<do any custom resetting necessary to bring W3D in sync.
+	virtual Int init() override;			///<perform any one time initialization and validation
+	virtual Int shutdown() override;			///<release resources used by shader
 } roadShaderPixelShader;
 
 class RoadShader2Stage : public W3DShaderInterface
 {	friend class RoadShaderPixelShader;	//pixel shader version uses some of the same features.
 
-	virtual Int set(Int pass);		///<setup shader for the specified rendering pass.
-	virtual Int init();			///<perform any one time initialization and validation
-	virtual void reset();
+	virtual Int set(Int pass) override;		///<setup shader for the specified rendering pass.
+	virtual Int init() override;			///<perform any one time initialization and validation
+	virtual void reset() override;
 } roadShader2Stage;
 
 ///List of different terrain shader implementations in order of preference

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTerrainVisual.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTerrainVisual.cpp
@@ -69,7 +69,7 @@
 class TestSeismicFilter : public SeismicSimulationFilterBase
 {
 
-  virtual SeismicSimStatusCode filterCallback( WorldHeightMapInterfaceClass *heightMap, const SeismicSimulationNode *node )
+  virtual SeismicSimStatusCode filterCallback( WorldHeightMapInterfaceClass *heightMap, const SeismicSimulationNode *node ) override
   {
 
 
@@ -140,7 +140,7 @@ class TestSeismicFilter : public SeismicSimulationFilterBase
       return SEISMIC_STATUS_ZERO_ENERGY;
   }
 
-  virtual Real applyGravityCallback( Real velocityIn )
+  virtual Real applyGravityCallback( Real velocityIn ) override
   {
     Real velocityOut = velocityIn;
     velocityOut -= 1.5f;

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTreeBuffer.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTreeBuffer.cpp
@@ -421,7 +421,7 @@ protected:
 public:
 	GDIFileStream2():m_file(nullptr) {};
 	GDIFileStream2(File* pFile):m_file(pFile) {};
-	virtual Int read(void *pData, Int numBytes) {
+	virtual Int read(void *pData, Int numBytes) override {
 		return(m_file?m_file->read(pData, numBytes):0);
 	};
 };

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/WorldHeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/WorldHeightMap.cpp
@@ -73,7 +73,7 @@ protected:
 	File* m_file;
 public:
 	GDIFileStream(File* pFile):m_file(pFile) {};
-	virtual Int read(void *pData, Int numBytes) {
+	virtual Int read(void *pData, Int numBytes) override {
 			return(m_file->read(pData, numBytes));
 	};
 };

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/Common/W3DFunctionLexicon.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/Common/W3DFunctionLexicon.h
@@ -40,11 +40,11 @@ class W3DFunctionLexicon : public FunctionLexicon
 public:
 
 	W3DFunctionLexicon();
-	virtual ~W3DFunctionLexicon();
+	virtual ~W3DFunctionLexicon() override;
 
-	virtual void init();
-	virtual void reset();
-	virtual void update();
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override;
 
 protected:
 

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/Common/W3DModuleFactory.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/Common/W3DModuleFactory.h
@@ -43,6 +43,6 @@ class W3DModuleFactory : public ModuleFactory
 
 public:
 
-	virtual void init();
+	virtual void init() override;
 
 };

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/Common/W3DThingFactory.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/Common/W3DThingFactory.h
@@ -42,5 +42,5 @@ class W3DThingFactory : public ThingFactory
 public:
 
 	W3DThingFactory();
-	virtual ~W3DThingFactory();
+	virtual ~W3DThingFactory() override;
 };

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DAssetManager.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DAssetManager.h
@@ -54,12 +54,12 @@ class W3DAssetManager: public WW3DAssetManager
 {
 public:
 	W3DAssetManager();
-	virtual ~W3DAssetManager();
+	virtual ~W3DAssetManager() override;
 
-	virtual RenderObjClass * Create_Render_Obj(const char * name);
+	virtual RenderObjClass * Create_Render_Obj(const char * name) override;
 	// unique to W3DAssetManager
-	virtual HAnimClass *	Get_HAnim(const char * name);
-	virtual bool Load_3D_Assets( const char * filename ); // This CANNOT be Bool, as it will not inherit properly if you make Bool == Int
+	virtual HAnimClass *	Get_HAnim(const char * name) override;
+	virtual bool Load_3D_Assets( const char * filename ) override; // This CANNOT be Bool, as it will not inherit properly if you make Bool == Int
 	virtual TextureClass *			Get_Texture(
 		const char * filename,
 		MipCountType mip_level_count=MIP_LEVELS_ALL,

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDebugDisplay.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDebugDisplay.h
@@ -72,7 +72,7 @@ class W3DDebugDisplay : public DebugDisplay
 	public:
 
 		W3DDebugDisplay();
-		virtual ~W3DDebugDisplay();
+		virtual ~W3DDebugDisplay() override;
 
 		void init();																						///< Initialized the display
 		void setFont( GameFont *font );																///< Set the font to render with
@@ -86,7 +86,7 @@ class W3DDebugDisplay : public DebugDisplay
 		Int m_fontHeight;
 		DisplayString *m_displayString;
 
-		virtual void drawText( Int x, Int y, Char *text );			///< Render null ternimated string at current cursor position
+		virtual void drawText( Int x, Int y, Char *text ) override;			///< Render null ternimated string at current cursor position
 
 };
 

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -56,7 +56,7 @@ class W3DDisplay : public Display
 
 public:
 	W3DDisplay();
-	~W3DDisplay() override;
+	virtual ~W3DDisplay() override;
 
 	virtual void init() override;  ///< initialize or re-initialize the sytsem
  	virtual void reset() override;																///< Reset system

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -56,87 +56,87 @@ class W3DDisplay : public Display
 
 public:
 	W3DDisplay();
-	~W3DDisplay();
+	~W3DDisplay() override;
 
-	virtual void init();  ///< initialize or re-initialize the sytsem
- 	virtual void reset() ;																///< Reset system
+	virtual void init() override;  ///< initialize or re-initialize the sytsem
+ 	virtual void reset() override;																///< Reset system
 
-	virtual void setWidth( UnsignedInt width );
-	virtual void setHeight( UnsignedInt height );
-	virtual Bool setDisplayMode( UnsignedInt xres, UnsignedInt yres, UnsignedInt bitdepth, Bool windowed );
-	virtual Int getDisplayModeCount();	///<return number of display modes/resolutions supported by video card.
-	virtual void getDisplayModeDescription(Int modeIndex, Int *xres, Int *yres, Int *bitDepth);	///<return description of mode
- 	virtual void setGamma(Real gamma, Real bright, Real contrast, Bool calibrate);
-	virtual void doSmartAssetPurgeAndPreload(const char* usageFileName);
+	virtual void setWidth( UnsignedInt width ) override;
+	virtual void setHeight( UnsignedInt height ) override;
+	virtual Bool setDisplayMode( UnsignedInt xres, UnsignedInt yres, UnsignedInt bitdepth, Bool windowed ) override;
+	virtual Int getDisplayModeCount() override;	///<return number of display modes/resolutions supported by video card.
+	virtual void getDisplayModeDescription(Int modeIndex, Int *xres, Int *yres, Int *bitDepth) override;	///<return description of mode
+ 	virtual void setGamma(Real gamma, Real bright, Real contrast, Bool calibrate) override;
+	virtual void doSmartAssetPurgeAndPreload(const char* usageFileName) override;
 #if defined(RTS_DEBUG)
 	virtual void dumpAssetUsage(const char* mapname);
 #endif
 
 	//---------------------------------------------------------------------------
 	// Drawing management
-	virtual void setClipRegion( IRegion2D *region );	///< Set clip rectangle for 2D draw operations.
-	virtual Bool	isClippingEnabled() 	{ return m_isClippedEnabled; }
-	virtual void	enableClipping( Bool onoff )		{ m_isClippedEnabled = onoff; }
+	virtual void setClipRegion( IRegion2D *region ) override;	///< Set clip rectangle for 2D draw operations.
+	virtual Bool	isClippingEnabled() override { return m_isClippedEnabled; }
+	virtual void	enableClipping( Bool onoff ) override { m_isClippedEnabled = onoff; }
 
-	virtual void step(); ///< Do one fixed time step
-	virtual void draw();  ///< redraw the entire display
+	virtual void step() override; ///< Do one fixed time step
+	virtual void draw() override;  ///< redraw the entire display
 
 	/// @todo Replace these light management routines with a LightManager singleton
 	virtual void createLightPulse( const Coord3D *pos, const RGBColor *color, Real innerRadius,Real outerRadius,
 																 UnsignedInt increaseFrameTime, UnsignedInt decayFrameTime//, Bool donut = FALSE
-																 );
-	virtual void setTimeOfDay ( TimeOfDay tod );
+																 ) override;
+	virtual void setTimeOfDay ( TimeOfDay tod ) override;
 
 	/// draw a line on the display in screen coordinates
 	virtual void drawLine( Int startX, Int startY, Int endX, Int endY,
-												 Real lineWidth, UnsignedInt lineColor );
+												 Real lineWidth, UnsignedInt lineColor ) override;
 
 	/// draw a line on the display in screen coordinates
 	virtual void drawLine( Int startX, Int startY, Int endX, Int endY,
-												 Real lineWidth, UnsignedInt lineColor1, UnsignedInt lineColor2 );
+												 Real lineWidth, UnsignedInt lineColor1, UnsignedInt lineColor2 ) override;
 
 	/// draw a rect border on the display in pixel coordinates with the specified color
 	virtual void drawOpenRect( Int startX, Int startY, Int width, Int height,
-														 Real lineWidth, UnsignedInt lineColor );
+														 Real lineWidth, UnsignedInt lineColor ) override;
 
 	/// draw a filled rect on the display in pixel coords with the specified color
 	virtual void drawFillRect( Int startX, Int startY, Int width, Int height,
-														 UnsignedInt color );
+														 UnsignedInt color ) override;
 
 	/// Draw a percentage of a rectangle, much like a clock (0 to x%)
-	virtual void drawRectClock(Int startX, Int startY, Int width, Int height, Int percent, UnsignedInt color);
+	virtual void drawRectClock(Int startX, Int startY, Int width, Int height, Int percent, UnsignedInt color) override;
 
 	/// Draw's the remaining percentage of a rectangle (x% to 100)
-	virtual void drawRemainingRectClock(Int startX, Int startY, Int width, Int height, Int percent, UnsignedInt color);
+	virtual void drawRemainingRectClock(Int startX, Int startY, Int width, Int height, Int percent, UnsignedInt color) override;
 
 	/// draw an image fit within the screen coordinates
 	virtual void drawImage( const Image *image, Int startX, Int startY,
-													Int endX, Int endY, Color color = 0xFFFFFFFF, DrawImageMode mode=DRAW_IMAGE_ALPHA);
+													Int endX, Int endY, Color color = 0xFFFFFFFF, DrawImageMode mode=DRAW_IMAGE_ALPHA) override;
 
 	/// draw a video buffer fit within the screen coordinates
-	virtual void drawScaledVideoBuffer( VideoBuffer *buffer, VideoStreamInterface *stream );
+	virtual void drawScaledVideoBuffer( VideoBuffer *buffer, VideoStreamInterface *stream ) override;
 	virtual void drawVideoBuffer( VideoBuffer *buffer, Int startX, Int startY,
-													Int endX, Int endY );
+													Int endX, Int endY ) override;
 
-	virtual VideoBuffer*	createVideoBuffer() ;							///< Create a video buffer that can be used for this display
+	virtual VideoBuffer*	createVideoBuffer() override;							///< Create a video buffer that can be used for this display
 
-	virtual void takeScreenShot();						//save screenshot to file
-	virtual void toggleMovieCapture();			//enable AVI or frame capture mode.
+	virtual void takeScreenShot() override;						//save screenshot to file
+	virtual void toggleMovieCapture() override;			//enable AVI or frame capture mode.
 
-	virtual void toggleLetterBox();	///<enabled letter-boxed display
-	virtual void enableLetterBox(Bool enable);	///<forces letter-boxed display on/off
+	virtual void toggleLetterBox() override;	///<enabled letter-boxed display
+	virtual void enableLetterBox(Bool enable) override;	///<forces letter-boxed display on/off
 
-	virtual Bool isLetterBoxFading();	///<returns true while letterbox fades in/out
-	virtual Bool isLetterBoxed();
+	virtual Bool isLetterBoxFading() override;	///<returns true while letterbox fades in/out
+	virtual Bool isLetterBoxed() override;
 
-	virtual void clearShroud();
-	virtual void setShroudLevel(Int x, Int y, CellShroudStatus setting);
-	virtual void setBorderShroudLevel(UnsignedByte level);	///<color that will appear in unused border terrain.
+	virtual void clearShroud() override;
+	virtual void setShroudLevel(Int x, Int y, CellShroudStatus setting) override;
+	virtual void setBorderShroudLevel(UnsignedByte level) override;	///<color that will appear in unused border terrain.
 #if defined(RTS_DEBUG)
 	virtual void dumpModelAssets(const char *path);	///< dump all used models/textures to a file.
 #endif
-	virtual void preloadModelAssets( AsciiString model );			///< preload model asset
-	virtual void preloadTextureAssets( AsciiString texture );	///< preload texture asset
+	virtual void preloadModelAssets( AsciiString model ) override;			///< preload model asset
+	virtual void preloadTextureAssets( AsciiString texture ) override;	///< preload texture asset
 
 	/// @todo Need a scene abstraction
 	static RTS3DScene *m_3DScene;							///< our 3d scene representation
@@ -145,9 +145,9 @@ public:
 	static W3DAssetManager *m_assetManager;		///< W3D asset manager
 
 	void drawFPSStats();								///< draw the fps on the screen
-	virtual Real getAverageFPS();						///< return the average FPS.
-	virtual Real getCurrentFPS();						///< return the current FPS.
-	virtual Int getLastFrameDrawCalls();				///< returns the number of draw calls issued in the previous frame
+	virtual Real getAverageFPS() override;						///< return the average FPS.
+	virtual Real getCurrentFPS() override;						///< return the current FPS.
+	virtual Int getLastFrameDrawCalls() override;				///< returns the number of draw calls issued in the previous frame
 
 protected:
 

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplayString.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplayString.h
@@ -74,16 +74,16 @@ public:
 	W3DDisplayString();
 	// ~W3DDisplayString();  // destructor defined by memory pool
 
-	void notifyTextChanged();							///< called when text contents change
-	void draw( Int x, Int y, Color color, Color dropColor );  ///< render text
-	void draw( Int x, Int y, Color color, Color dropColor, Int xDrop, Int yDrop );  ///< render text with the drop shadow being at the offsets passed in
-	void getSize( Int *width, Int *height );		///< get render size
-	Int	getWidth( Int charPos = -1);
-	void setWordWrap( Int wordWrap );						///< set the word wrap width
-	void setWordWrapCentered( Bool isCentered ); ///< If this is set to true, the text on a new line is centered
-	void setFont( GameFont *font );							///< set a font for display
-	void setUseHotkey( Bool useHotkey, Color hotKeyColor = 0xffffffff );
-	void setClipRegion( IRegion2D *region );		///< clip text in this region
+	void notifyTextChanged() override;							///< called when text contents change
+	void draw( Int x, Int y, Color color, Color dropColor ) override;  ///< render text
+	void draw( Int x, Int y, Color color, Color dropColor, Int xDrop, Int yDrop ) override;  ///< render text with the drop shadow being at the offsets passed in
+	void getSize( Int *width, Int *height ) override;		///< get render size
+	Int	getWidth( Int charPos = -1) override;
+	void setWordWrap( Int wordWrap ) override;						///< set the word wrap width
+	void setWordWrapCentered( Bool isCentered ) override; ///< If this is set to true, the text on a new line is centered
+	void setFont( GameFont *font ) override;							///< set a font for display
+	void setUseHotkey( Bool useHotkey, Color hotKeyColor = 0xffffffff ) override;
+	void setClipRegion( IRegion2D *region ) override;		///< clip text in this region
 
 protected:
 

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplayString.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplayString.h
@@ -74,16 +74,16 @@ public:
 	W3DDisplayString();
 	// ~W3DDisplayString();  // destructor defined by memory pool
 
-	void notifyTextChanged() override;							///< called when text contents change
-	void draw( Int x, Int y, Color color, Color dropColor ) override;  ///< render text
-	void draw( Int x, Int y, Color color, Color dropColor, Int xDrop, Int yDrop ) override;  ///< render text with the drop shadow being at the offsets passed in
-	void getSize( Int *width, Int *height ) override;		///< get render size
-	Int	getWidth( Int charPos = -1) override;
-	void setWordWrap( Int wordWrap ) override;						///< set the word wrap width
-	void setWordWrapCentered( Bool isCentered ) override; ///< If this is set to true, the text on a new line is centered
-	void setFont( GameFont *font ) override;							///< set a font for display
-	void setUseHotkey( Bool useHotkey, Color hotKeyColor = 0xffffffff ) override;
-	void setClipRegion( IRegion2D *region ) override;		///< clip text in this region
+	virtual void notifyTextChanged() override;							///< called when text contents change
+	virtual void draw( Int x, Int y, Color color, Color dropColor ) override;  ///< render text
+	virtual void draw( Int x, Int y, Color color, Color dropColor, Int xDrop, Int yDrop ) override;  ///< render text with the drop shadow being at the offsets passed in
+	virtual void getSize( Int *width, Int *height ) override;		///< get render size
+	virtual Int	getWidth( Int charPos = -1) override;
+	virtual void setWordWrap( Int wordWrap ) override;						///< set the word wrap width
+	virtual void setWordWrapCentered( Bool isCentered ) override; ///< If this is set to true, the text on a new line is centered
+	virtual void setFont( GameFont *font ) override;							///< set a font for display
+	virtual void setUseHotkey( Bool useHotkey, Color hotKeyColor = 0xffffffff ) override;
+	virtual void setClipRegion( IRegion2D *region ) override;		///< clip text in this region
 
 protected:
 

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplayStringManager.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplayStringManager.h
@@ -44,24 +44,24 @@ class W3DDisplayStringManager : public DisplayStringManager
 public:
 
 	W3DDisplayStringManager();
-	virtual ~W3DDisplayStringManager();
+	virtual ~W3DDisplayStringManager() override;
 
 	// Initialize our numeral strings in postProcessLoad
-	virtual void postProcessLoad();
+	virtual void postProcessLoad() override;
 
 	/// update method for all our display strings
-	virtual void update();
+	virtual void update() override;
 
 	/// allocate a new display string
-	virtual DisplayString *newDisplayString();
+	virtual DisplayString *newDisplayString() override;
 
 	/// free a display string
-	virtual void freeDisplayString( DisplayString *string );
+	virtual void freeDisplayString( DisplayString *string ) override;
 
 	// This is used to save us a few FPS and storage space. There's no reason to
 	// duplicate the DisplayString on every drawable when 1 copy will suffice.
-	virtual DisplayString *getGroupNumeralString( Int numeral );
-	virtual DisplayString *getFormationLetterString() { return m_formationLetterDisplayString; };
+	virtual DisplayString *getGroupNumeralString( Int numeral ) override;
+	virtual DisplayString *getFormationLetterString() override { return m_formationLetterDisplayString; };
 
 protected:
 	DisplayString *m_groupNumeralStrings[ MAX_GROUPS ];

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDynamicLight.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDynamicLight.h
@@ -62,7 +62,7 @@ protected:
 
 public:
 	W3DDynamicLight();
-	~W3DDynamicLight() override;
+	virtual ~W3DDynamicLight() override;
 
 public:
 	virtual void					On_Frame_Update() override;

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDynamicLight.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDynamicLight.h
@@ -62,10 +62,10 @@ protected:
 
 public:
 	W3DDynamicLight();
-	~W3DDynamicLight();
+	~W3DDynamicLight() override;
 
 public:
-	virtual void					On_Frame_Update();
+	virtual void					On_Frame_Update() override;
 
 	void setEnabled(Bool enabled) { m_enabled = enabled; m_decayRange = false; m_decayFrameCount = 0; m_decayColor = false; m_increaseFrameCount = 0;};
 	Bool isEnabled() {return m_enabled;};

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DFileSystem.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DFileSystem.h
@@ -84,7 +84,7 @@ protected:
 class	W3DFileSystem : public FileFactoryClass {
 public:
 	W3DFileSystem();
-	~W3DFileSystem() override;
+	virtual ~W3DFileSystem() override;
 
 	virtual FileClass * Get_File( char const *filename ) override;
 	virtual void Return_File( FileClass *file ) override;

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DFileSystem.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DFileSystem.h
@@ -48,24 +48,24 @@ public:
 
 	GameFileClass(char const *filename);
 	GameFileClass();
-	virtual ~GameFileClass();
+	virtual ~GameFileClass() override;
 
-	virtual char const * File_Name() const;
-	virtual char const * Set_Name(char const *filename);
+	virtual char const * File_Name() const override;
+	virtual char const * Set_Name(char const *filename) override;
 
 	// (gth) had to re-instate these functions in the base class, for now just give empty implementations...
-	virtual int Create() { assert(0); return 1; }
-	virtual int Delete() { assert(0); return 1; }
+	virtual int Create() override { assert(0); return 1; }
+	virtual int Delete() override { assert(0); return 1; }
 
-	virtual bool Is_Available(int forced=false);
-	virtual bool Is_Open() const;
-	virtual int Open(char const *filename, int rights=READ);
-	virtual int Open(int rights=READ);
-	virtual int Read(void *buffer, int len);
-	virtual int Seek(int pos, int dir=SEEK_CUR);
-	virtual int Size();
-	virtual int Write(void const *buffer, int len);
-	virtual void Close();
+	virtual bool Is_Available(int forced=false) override;
+	virtual bool Is_Open() const override;
+	virtual int Open(char const *filename, int rights=READ) override;
+	virtual int Open(int rights=READ) override;
+	virtual int Read(void *buffer, int len) override;
+	virtual int Seek(int pos, int dir=SEEK_CUR) override;
+	virtual int Size() override;
+	virtual int Write(void const *buffer, int len) override;
+	virtual void Close() override;
 
 protected:
 
@@ -84,10 +84,10 @@ protected:
 class	W3DFileSystem : public FileFactoryClass {
 public:
 	W3DFileSystem();
-	~W3DFileSystem();
+	~W3DFileSystem() override;
 
-	virtual FileClass * Get_File( char const *filename );
-	virtual void Return_File( FileClass *file );
+	virtual FileClass * Get_File( char const *filename ) override;
+	virtual void Return_File( FileClass *file ) override;
 
 private:
 

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DGameClient.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DGameClient.h
@@ -68,50 +68,50 @@ class W3DGameClient : public GameClient
 public:
 
 	W3DGameClient();
-	virtual ~W3DGameClient();
+	virtual ~W3DGameClient() override;
 
 	/// given a type, create a drawable
-	virtual Drawable *friend_createDrawable( const ThingTemplate *thing, DrawableStatusBits statusBits = DRAWABLE_STATUS_DEFAULT );
+	virtual Drawable *friend_createDrawable( const ThingTemplate *thing, DrawableStatusBits statusBits = DRAWABLE_STATUS_DEFAULT ) override;
 
-	virtual void init();		///< initialize resources
-	virtual void update();  ///< per frame update
-	virtual void reset();   ///< reset system
+	virtual void init() override;		///< initialize resources
+	virtual void update() override;  ///< per frame update
+	virtual void reset() override;   ///< reset system
 
-	virtual void addScorch(const Coord3D *pos, Real radius, Scorches type);
-	virtual void createRayEffectByTemplate( const Coord3D *start, const Coord3D *end, const ThingTemplate* tmpl );  ///< create effect needing start and end location
+	virtual void addScorch(const Coord3D *pos, Real radius, Scorches type) override;
+	virtual void createRayEffectByTemplate( const Coord3D *start, const Coord3D *end, const ThingTemplate* tmpl ) override;  ///< create effect needing start and end location
 	//virtual Bool getBonePos(Drawable *draw, AsciiString boneName, Coord3D* pos, Matrix3D* transform) const;
 
-	virtual void setTimeOfDay( TimeOfDay tod );							///< Tell all the drawables what time of day it is now
+	virtual void setTimeOfDay( TimeOfDay tod ) override;							///< Tell all the drawables what time of day it is now
 
 	//---------------------------------------------------------------------------
-	virtual void setTeamColor( Int red, Int green, Int blue );  ///< @todo superhack for demo, remove!!!
-	virtual void setTextureLOD( Int level );
+	virtual void setTeamColor( Int red, Int green, Int blue ) override;  ///< @todo superhack for demo, remove!!!
+	virtual void setTextureLOD( Int level ) override;
 
 protected:
 
-	virtual Keyboard *createKeyboard();								///< factory for the keyboard
-	virtual Mouse *createMouse();											///< factory for the mouse
+	virtual Keyboard *createKeyboard() override;								///< factory for the keyboard
+	virtual Mouse *createMouse() override;											///< factory for the mouse
 
 	/// factory for creating TheDisplay
-	virtual Display *createGameDisplay() { return NEW W3DDisplay; }
+	virtual Display *createGameDisplay() override { return NEW W3DDisplay; }
 
 	/// factory for creating TheInGameUI
-	virtual InGameUI *createInGameUI() { return NEW W3DInGameUI; }
+	virtual InGameUI *createInGameUI() override { return NEW W3DInGameUI; }
 
 	/// factory for creating the window manager
-	virtual GameWindowManager *createWindowManager() { return NEW W3DGameWindowManager; }
+	virtual GameWindowManager *createWindowManager() override { return NEW W3DGameWindowManager; }
 
 	/// factory for creating the font library
-	virtual FontLibrary *createFontLibrary() { return NEW W3DFontLibrary; }
+	virtual FontLibrary *createFontLibrary() override { return NEW W3DFontLibrary; }
 
   /// Manager for display strings
-	virtual DisplayStringManager *createDisplayStringManager() { return NEW W3DDisplayStringManager; }
+	virtual DisplayStringManager *createDisplayStringManager() override { return NEW W3DDisplayStringManager; }
 
-	virtual VideoPlayerInterface *createVideoPlayer() { return NEW BinkVideoPlayer; }
+	virtual VideoPlayerInterface *createVideoPlayer() override { return NEW BinkVideoPlayer; }
 	/// factory for creating the TerrainVisual
-	virtual TerrainVisual *createTerrainVisual() { return NEW W3DTerrainVisual; }
+	virtual TerrainVisual *createTerrainVisual() override { return NEW W3DTerrainVisual; }
 
-	virtual void setFrameRate(Real msecsPerFrame) { TheW3DFrameLengthInMsec = msecsPerFrame; }
+	virtual void setFrameRate(Real msecsPerFrame) override { TheW3DFrameLengthInMsec = msecsPerFrame; }
 
 };
 

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DGameFont.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DGameFont.h
@@ -63,14 +63,14 @@ class W3DFontLibrary : public FontLibrary
 public:
 
 	W3DFontLibrary() { }
-	~W3DFontLibrary() { }
+	~W3DFontLibrary() override { }
 
 protected:
 
 	/// load the font data pointer based on everything else we already have set
-	Bool loadFontData( GameFont *font );
+	virtual Bool loadFontData( GameFont *font ) override;
 	/// release the font data pointer
-	void releaseFontData( GameFont *font );
+	virtual void releaseFontData( GameFont *font ) override;
 
 };
 

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DGameFont.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DGameFont.h
@@ -63,7 +63,7 @@ class W3DFontLibrary : public FontLibrary
 public:
 
 	W3DFontLibrary() { }
-	~W3DFontLibrary() override { }
+	virtual ~W3DFontLibrary() override { }
 
 protected:
 

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DGameWindow.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DGameWindow.h
@@ -69,11 +69,11 @@ public:
 	//~W3DGameWindow();
 
 	/// draw borders for this window only, NO child windows or anything else
-	void winDrawBorder();
+	void winDrawBorder() override;
 
 	Int winSetPosition( Int x, Int y );  ///< set window position
-	Int winSetText( UnicodeString newText );  ///< set text string
-	void winSetFont( GameFont *font );  ///< set font for window
+	virtual Int winSetText( UnicodeString newText ) override;  ///< set text string
+	virtual void winSetFont( GameFont *font ) override;  ///< set font for window
 
 	void getTextSize( Int *width, Int *height );  ///< get size of text
 	void setTextLoc( Int x, Int y );  ///< set text screen coord loc

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DGameWindow.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DGameWindow.h
@@ -69,7 +69,7 @@ public:
 	//~W3DGameWindow();
 
 	/// draw borders for this window only, NO child windows or anything else
-	void winDrawBorder() override;
+	virtual void winDrawBorder() override;
 
 	Int winSetPosition( Int x, Int y );  ///< set window position
 	virtual Int winSetText( UnicodeString newText ) override;  ///< set text string

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DGameWindowManager.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DGameWindowManager.h
@@ -45,35 +45,35 @@ class W3DGameWindowManager : public GameWindowManager
 public:
 
 	W3DGameWindowManager();
-	virtual ~W3DGameWindowManager();
+	virtual ~W3DGameWindowManager() override;
 
-	virtual void init();  ///< initialize the singlegon
+	virtual void init() override;  ///< initialize the singlegon
 
-	virtual GameWindow *allocateNewWindow();  ///< allocate a new game window
-	virtual GameWinDrawFunc getDefaultDraw();  ///< return default draw func to use
+	virtual GameWindow *allocateNewWindow() override;  ///< allocate a new game window
+	virtual GameWinDrawFunc getDefaultDraw() override;  ///< return default draw func to use
 
-	virtual GameWinDrawFunc getPushButtonImageDrawFunc();
-	virtual GameWinDrawFunc getPushButtonDrawFunc();
-	virtual GameWinDrawFunc getCheckBoxImageDrawFunc();
-	virtual GameWinDrawFunc getCheckBoxDrawFunc();
-	virtual GameWinDrawFunc getRadioButtonImageDrawFunc();
-	virtual GameWinDrawFunc getRadioButtonDrawFunc();
-	virtual GameWinDrawFunc getTabControlImageDrawFunc();
-	virtual GameWinDrawFunc getTabControlDrawFunc();
-	virtual GameWinDrawFunc getListBoxImageDrawFunc();
-	virtual GameWinDrawFunc getListBoxDrawFunc();
-	virtual GameWinDrawFunc getComboBoxImageDrawFunc();
-	virtual GameWinDrawFunc getComboBoxDrawFunc();
-	virtual GameWinDrawFunc getHorizontalSliderImageDrawFunc();
-	virtual GameWinDrawFunc getHorizontalSliderDrawFunc();
-	virtual GameWinDrawFunc getVerticalSliderImageDrawFunc();
-	virtual GameWinDrawFunc getVerticalSliderDrawFunc();
-	virtual GameWinDrawFunc getProgressBarImageDrawFunc();
-	virtual GameWinDrawFunc getProgressBarDrawFunc();
-	virtual GameWinDrawFunc getStaticTextImageDrawFunc();
-	virtual GameWinDrawFunc getStaticTextDrawFunc();
-	virtual GameWinDrawFunc getTextEntryImageDrawFunc();
-	virtual GameWinDrawFunc getTextEntryDrawFunc();
+	virtual GameWinDrawFunc getPushButtonImageDrawFunc() override;
+	virtual GameWinDrawFunc getPushButtonDrawFunc() override;
+	virtual GameWinDrawFunc getCheckBoxImageDrawFunc() override;
+	virtual GameWinDrawFunc getCheckBoxDrawFunc() override;
+	virtual GameWinDrawFunc getRadioButtonImageDrawFunc() override;
+	virtual GameWinDrawFunc getRadioButtonDrawFunc() override;
+	virtual GameWinDrawFunc getTabControlImageDrawFunc() override;
+	virtual GameWinDrawFunc getTabControlDrawFunc() override;
+	virtual GameWinDrawFunc getListBoxImageDrawFunc() override;
+	virtual GameWinDrawFunc getListBoxDrawFunc() override;
+	virtual GameWinDrawFunc getComboBoxImageDrawFunc() override;
+	virtual GameWinDrawFunc getComboBoxDrawFunc() override;
+	virtual GameWinDrawFunc getHorizontalSliderImageDrawFunc() override;
+	virtual GameWinDrawFunc getHorizontalSliderDrawFunc() override;
+	virtual GameWinDrawFunc getVerticalSliderImageDrawFunc() override;
+	virtual GameWinDrawFunc getVerticalSliderDrawFunc() override;
+	virtual GameWinDrawFunc getProgressBarImageDrawFunc() override;
+	virtual GameWinDrawFunc getProgressBarDrawFunc() override;
+	virtual GameWinDrawFunc getStaticTextImageDrawFunc() override;
+	virtual GameWinDrawFunc getStaticTextDrawFunc() override;
+	virtual GameWinDrawFunc getTextEntryImageDrawFunc() override;
+	virtual GameWinDrawFunc getTextEntryDrawFunc() override;
 
 protected:
 

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DInGameUI.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DInGameUI.h
@@ -56,20 +56,20 @@ class W3DInGameUI : public InGameUI
 public:
 
 	W3DInGameUI();
-	virtual ~W3DInGameUI();
+	virtual ~W3DInGameUI() override;
 
 	// Inherited from subsystem interface -----------------------------------------------------------
-	virtual	void init();		///< Initialize the in-game user interface
-	virtual void update();	//< Update the UI by calling preDraw(), draw(), and postDraw()
-	virtual void reset();		///< Reset
+	virtual	void init() override;		///< Initialize the in-game user interface
+	virtual void update() override;	//< Update the UI by calling preDraw(), draw(), and postDraw()
+	virtual void reset() override;		///< Reset
 	//-----------------------------------------------------------------------------------------------
 
-	virtual void draw(); ///< Render the in-game user interface
+	virtual void draw() override; ///< Render the in-game user interface
 
 protected:
 
 	/// factory for views
-	virtual View *createView(bool dummy)
+	virtual View *createView(bool dummy) override
 	{
 		if (dummy)
 			return NEW ViewDummy;

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DParticleSys.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DParticleSys.h
@@ -42,12 +42,12 @@ class W3DParticleSystemManager : public ParticleSystemManager
 
 public:
 	W3DParticleSystemManager();
-	~W3DParticleSystemManager();
+	virtual ~W3DParticleSystemManager() override;
 
-	virtual void doParticles(RenderInfoClass &rinfo);
-	virtual void queueParticleRender();
+	virtual void doParticles(RenderInfoClass &rinfo) override;
+	virtual void queueParticleRender() override;
 	///< returns the number of particles shown on screen per frame
-	virtual Int getOnScreenParticleCount() { return m_onScreenParticleCount; }
+	virtual Int getOnScreenParticleCount() override { return m_onScreenParticleCount; }
 
 private:
 	enum { MAX_POINTS_PER_GROUP = 512 };

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DProjectedShadow.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DProjectedShadow.h
@@ -51,7 +51,7 @@ class W3DProjectedShadowManager	: public ProjectedShadowManager
 */
 	public:
 		W3DProjectedShadowManager();
-		~W3DProjectedShadowManager();
+		~W3DProjectedShadowManager() override;
 		Bool init();					///<allocate one-time shadow assets for length of entire game.
 		void reset();					///<free all existing shadows - ready for next map.
 		void shutdown();			///<free all assets prior to shutdown of entire game.
@@ -61,8 +61,8 @@ class W3DProjectedShadowManager	: public ProjectedShadowManager
 		Bool ReAcquireResources();	///<allocate device dependent D3D resources.
 		void invalidateCachedLightPositions();	///<forces shadows to update regardless of last lightposition
 
-		virtual Shadow	*addDecal(RenderObjClass *robj, Shadow::ShadowTypeInfo *shadowInfo);	///<add a non-shadow decal
-		virtual Shadow	*addDecal(Shadow::ShadowTypeInfo *shadowInfo);	///<add a non-shadow decal which does not follow an object.
+		virtual Shadow	*addDecal(RenderObjClass *robj, Shadow::ShadowTypeInfo *shadowInfo) override;	///<add a non-shadow decal
+		virtual Shadow	*addDecal(Shadow::ShadowTypeInfo *shadowInfo) override;	///<add a non-shadow decal which does not follow an object.
 		W3DProjectedShadow	*addShadow( RenderObjClass *robj, Shadow::ShadowTypeInfo *shadowInfo, Drawable *draw);	///<add a new shadow with texture of given name or that of robj.
 		W3DProjectedShadow	*createDecalShadow( Shadow::ShadowTypeInfo *shadowInfo);	///<add a new shadow with texture of given name or that of robj.
 		void removeShadow (W3DProjectedShadow *shadow);
@@ -132,5 +132,5 @@ class W3DProjectedShadow	: public Shadow
 		Real	m_decalOffsetU;		/// texture coordinate offset so not centered at object origin.
 		Real	m_decalOffsetV;		/// texture coordinate offset so not centered at object origin.
 		Int		m_flags;			/// custom rendering flags
-		virtual void release()	{TheW3DProjectedShadowManager->removeShadow(this);}	///<release shadow from manager
+		virtual void release() override	{TheW3DProjectedShadowManager->removeShadow(this);}	///<release shadow from manager
 };

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DProjectedShadow.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DProjectedShadow.h
@@ -51,7 +51,7 @@ class W3DProjectedShadowManager	: public ProjectedShadowManager
 */
 	public:
 		W3DProjectedShadowManager();
-		~W3DProjectedShadowManager() override;
+		virtual ~W3DProjectedShadowManager() override;
 		Bool init();					///<allocate one-time shadow assets for length of entire game.
 		void reset();					///<free all existing shadows - ready for next map.
 		void shutdown();			///<free all assets prior to shutdown of entire game.

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DScene.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DScene.h
@@ -95,7 +95,7 @@ public:
 	virtual void init() override {}
 	virtual void update() override {}
 	virtual void draw() override;
-	virtual void reset() override{}
+	virtual void reset() override {}
 	void doRender(CameraClass * cam);
 
 protected:
@@ -155,7 +155,7 @@ public:
 	virtual void init() override {}
 	virtual void update() override {}
 	virtual void draw() override;
-	virtual void reset() override{}
+	virtual void reset() override {}
 	void doRender(CameraClass * cam);
 
 protected:

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DScene.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DScene.h
@@ -62,15 +62,15 @@ class RTS3DScene : public SimpleSceneClass, public SubsystemInterface
 public:
 
 	RTS3DScene();  ///< RTSScene constructor
-	~RTS3DScene();  ///< RTSScene destructor
+	virtual ~RTS3DScene() override;  ///< RTSScene destructor
 
 	/// ray picking against objects in scene
 	Bool castRay(RayCollisionTestClass & raytest, Bool testAll, Int collisionType);
 
 	/// customizable renderer for the RTS3DScene
-	virtual void	Customized_Render( RenderInfoClass &rinfo );
-	virtual void	Visibility_Check(CameraClass * camera);
-	virtual void  Render(RenderInfoClass & rinfo);
+	virtual void	Customized_Render( RenderInfoClass &rinfo ) override;
+	virtual void	Visibility_Check(CameraClass * camera) override;
+	virtual void  Render(RenderInfoClass & rinfo) override;
 
 	void setCustomPassMode (CustomScenePassModes mode) {m_customPassMode = mode;}
 	CustomScenePassModes getCustomPassMode ()	{return m_customPassMode;}
@@ -92,10 +92,10 @@ public:
 	void setGlobalLight(LightClass *pLight,Int lightIndex=0);
 	LightEnvironmentClass &getDefaultLightEnv() {return m_defaultLightEnv;}
 
-	void init() {}
-	void update() {}
-	void draw();
-	void reset(){}
+	virtual void init() override {}
+	virtual void update() override {}
+	virtual void draw() override;
+	virtual void reset() override{}
 	void doRender(CameraClass * cam);
 
 protected:
@@ -148,14 +148,14 @@ class RTS2DScene : public SimpleSceneClass, public SubsystemInterface
 public:
 
 	RTS2DScene();
-	~RTS2DScene();
+	virtual ~RTS2DScene() override;
 
 	/// customizable renderer for the RTS2DScene
-	virtual void Customized_Render( RenderInfoClass &rinfo );
-	void init() {}
-	void update() {}
-	void draw();
-	void reset(){}
+	virtual void Customized_Render( RenderInfoClass &rinfo ) override;
+	virtual void init() override {}
+	virtual void update() override {}
+	virtual void draw() override;
+	virtual void reset() override{}
 	void doRender(CameraClass * cam);
 
 protected:
@@ -174,8 +174,8 @@ class RTS3DInterfaceScene : public SimpleSceneClass
 public:
 
 	RTS3DInterfaceScene();
-	~RTS3DInterfaceScene();
+	virtual ~RTS3DInterfaceScene() override;
 
 	/// customizable renderer for the RTS3DInterfaceScene
-	virtual void Customized_Render( RenderInfoClass &rinfo );
+	virtual void Customized_Render( RenderInfoClass &rinfo ) override;
 };

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DShroud.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DShroud.h
@@ -43,8 +43,8 @@ class W3DShroudMaterialPassClass : public MaterialPassClass
 {
 public:
 	W3DShroudMaterialPassClass() : m_isTransparentObjectPass(FALSE) {}
-	virtual void	Install_Materials() const;
-	virtual void	UnInstall_Materials() const;
+	virtual void	Install_Materials() const override;
+	virtual void	UnInstall_Materials() const override;
 	void enableTransparentObjectPass(Bool enable) {m_isTransparentObjectPass = enable;}
 protected:
 	//customized version to deal with transparent (alpha-tested) polys.
@@ -60,8 +60,8 @@ class W3DMaskMaterialPassClass : public MaterialPassClass
 {
 public:
 	W3DMaskMaterialPassClass() : m_texture(nullptr), m_allowUninstall(TRUE) {}
-	virtual void	Install_Materials() const;
-	virtual void	UnInstall_Materials() const;
+	virtual void	Install_Materials() const override;
+	virtual void	UnInstall_Materials() const override;
 	void	setTexture(TextureClass *texture)	{m_texture=texture;}
 	void	setAllowUninstall(Bool state)	{ m_allowUninstall = state;}
 

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DStatusCircle.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DStatusCircle.h
@@ -46,26 +46,26 @@ public:
 	W3DStatusCircle();
 	W3DStatusCircle(const W3DStatusCircle & src);
 	W3DStatusCircle & operator = (const W3DStatusCircle &);
-	~W3DStatusCircle();
+	~W3DStatusCircle() override;
 
 	/////////////////////////////////////////////////////////////////////////////
 	// Render Object Interface
 	/////////////////////////////////////////////////////////////////////////////
-	virtual RenderObjClass *	Clone() const;
-	virtual int						Class_ID() const;
-	virtual void					Render(RenderInfoClass & rinfo);
+	virtual RenderObjClass *	Clone() const override;
+	virtual int						Class_ID() const override;
+	virtual void					Render(RenderInfoClass & rinfo) override;
 //	virtual void					Special_Render(SpecialRenderInfoClass & rinfo);
 //	virtual void 					Set_Transform(const Matrix3D &m);
 //	virtual void 					Set_Position(const Vector3 &v);
 //TODO: MW: do these later - only needed for collision detection
-	virtual bool					Cast_Ray(RayCollisionTestClass & raytest);
+	virtual bool					Cast_Ray(RayCollisionTestClass & raytest) override;
 //	virtual Bool					Cast_AABox(AABoxCollisionTestClass & boxtest);
 //	virtual Bool					Cast_OBBox(OBBoxCollisionTestClass & boxtest);
 //	virtual Bool					Intersect_AABox(AABoxIntersectionTestClass & boxtest);
 //	virtual Bool					Intersect_OBBox(OBBoxIntersectionTestClass & boxtest);
 
-	virtual void					Get_Obj_Space_Bounding_Sphere(SphereClass & sphere) const;
-    virtual void					Get_Obj_Space_Bounding_Box(AABoxClass & aabox) const;
+	virtual void					Get_Obj_Space_Bounding_Sphere(SphereClass & sphere) const override;
+    virtual void					Get_Obj_Space_Bounding_Box(AABoxClass & aabox) const override;
 
 
 //	virtual int					 	Get_Num_Polys() const;

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DStatusCircle.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DStatusCircle.h
@@ -46,7 +46,7 @@ public:
 	W3DStatusCircle();
 	W3DStatusCircle(const W3DStatusCircle & src);
 	W3DStatusCircle & operator = (const W3DStatusCircle &);
-	~W3DStatusCircle() override;
+	virtual ~W3DStatusCircle() override;
 
 	/////////////////////////////////////////////////////////////////////////////
 	// Render Object Interface

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DVolumetricShadow.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DVolumetricShadow.h
@@ -102,7 +102,7 @@ class W3DVolumetricShadow	: public Shadow
 
 	protected:
 
-		virtual void release()	{TheW3DVolumetricShadowManager->removeShadow(this);}	///<release shadow from manager
+		virtual void release() override	{TheW3DVolumetricShadowManager->removeShadow(this);}	///<release shadow from manager
 
 		#if defined(RTS_DEBUG)
 		virtual void getRenderCost(RenderCost & rc) const;

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DWebBrowser.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DWebBrowser.h
@@ -38,7 +38,7 @@ class W3DWebBrowser : public WebBrowser
 	public:
 		W3DWebBrowser();
 
-		virtual Bool createBrowserWindow(const char *tag, GameWindow *win);
-		virtual void closeBrowserWindow(GameWindow *win);
+		virtual Bool createBrowserWindow(const char *tag, GameWindow *win) override;
+		virtual void closeBrowserWindow(GameWindow *win) override;
 
 };

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameLogic/W3DGameLogic.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameLogic/W3DGameLogic.h
@@ -58,8 +58,8 @@ public:
 protected:
 
 	/// factory for TheTerrainLogic, called from init()
-	virtual TerrainLogic *createTerrainLogic() { return NEW W3DTerrainLogic; };
-	virtual GhostObjectManager *createGhostObjectManager(bool dummy)
+	virtual TerrainLogic *createTerrainLogic() override { return NEW W3DTerrainLogic; };
+	virtual GhostObjectManager *createGhostObjectManager(bool dummy) override
 	{
 		if (dummy)
 			return NEW GhostObjectManagerDummy;

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameLogic/W3DGhostObject.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameLogic/W3DGhostObject.h
@@ -45,15 +45,15 @@ class W3DGhostObject: public GhostObject
 
 public:
 	W3DGhostObject();
-	virtual ~W3DGhostObject();
-	virtual void snapShot(int playerIndex);
-	virtual void updateParentObject(Object *object, PartitionData *mod);
-	virtual void freeSnapShot(int playerIndex);
+	virtual ~W3DGhostObject() override;
+	virtual void snapShot(int playerIndex) override;
+	virtual void updateParentObject(Object *object, PartitionData *mod) override;
+	virtual void freeSnapShot(int playerIndex) override;
 
 protected:
-	virtual void crc( Xfer *xfer);
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 	void removeParentObject();
 	void restoreParentObject();	///< restore the original non-ghosted object to scene.
 	Bool addToScene(int playerIndex);
@@ -73,19 +73,19 @@ class W3DGhostObjectManager : public GhostObjectManager
 {
 public:
 	W3DGhostObjectManager();
-	virtual ~W3DGhostObjectManager();
-	virtual void reset();
-	virtual GhostObject *addGhostObject(Object *object, PartitionData *pd);
-	virtual void removeGhostObject(GhostObject *mod);
-	virtual void setLocalPlayerIndex(int playerIndex);
-	virtual void updateOrphanedObjects(int *playerIndexList, int playerIndexCount);
-	virtual void releasePartitionData();
-	virtual void restorePartitionData();
+	virtual ~W3DGhostObjectManager() override;
+	virtual void reset() override;
+	virtual GhostObject *addGhostObject(Object *object, PartitionData *pd) override;
+	virtual void removeGhostObject(GhostObject *mod) override;
+	virtual void setLocalPlayerIndex(int playerIndex) override;
+	virtual void updateOrphanedObjects(int *playerIndexList, int playerIndexCount) override;
+	virtual void releasePartitionData() override;
+	virtual void restorePartitionData() override;
 
 protected:
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	///@todo this list should really be part of the device independent base class (CBD 12-3-2002)
 	W3DGhostObject	*m_freeModules;

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameLogic/W3DTerrainLogic.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameLogic/W3DTerrainLogic.h
@@ -43,36 +43,36 @@ class W3DTerrainLogic : public TerrainLogic
 public:
 
 	W3DTerrainLogic();
-	virtual ~W3DTerrainLogic();
+	virtual ~W3DTerrainLogic() override;
 
-	virtual void init();		///< Init
-	virtual void reset();		///< Reset
-	virtual void update();	///< Update
+	virtual void init() override;		///< Init
+	virtual void reset() override;		///< Reset
+	virtual void update() override;	///< Update
 
 	/// @todo The loading of the raw height data should be device independent
-	virtual Bool loadMap( AsciiString filename , Bool query );
-	virtual void newMap( Bool saveGame );	///< Initialize the logic for new map.
+	virtual Bool loadMap( AsciiString filename , Bool query ) override;
+	virtual void newMap( Bool saveGame ) override;	///< Initialize the logic for new map.
 
-	virtual Real getGroundHeight( Real x, Real y, Coord3D* normal = nullptr ) const;
+	virtual Real getGroundHeight( Real x, Real y, Coord3D* normal = nullptr ) const override;
 
-	virtual Bool isCliffCell( Real x, Real y) const;			///< is point cliff cell.
+	virtual Bool isCliffCell( Real x, Real y) const override;			///< is point cliff cell.
 
-	virtual Real getLayerHeight(Real x, Real y, PathfindLayerEnum layer, Coord3D* normal = nullptr, Bool clip = true) const;
+	virtual Real getLayerHeight(Real x, Real y, PathfindLayerEnum layer, Coord3D* normal = nullptr, Bool clip = true) const override;
 
-	virtual void getExtent( Region3D *extent ) const ;					///< Get the 3D extent of the terrain in world coordinates
+	virtual void getExtent( Region3D *extent ) const override ;					///< Get the 3D extent of the terrain in world coordinates
 
-	virtual void getMaximumPathfindExtent( Region3D *extent ) const;
+	virtual void getMaximumPathfindExtent( Region3D *extent ) const override;
 
-	virtual void getExtentIncludingBorder( Region3D *extent ) const;
+	virtual void getExtentIncludingBorder( Region3D *extent ) const override;
 
-	virtual Bool isClearLineOfSight(const Coord3D& pos, const Coord3D& posOther) const;
+	virtual Bool isClearLineOfSight(const Coord3D& pos, const Coord3D& posOther) const override;
 
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	Real m_mapMinZ;	///< Minimum terrain z value.
 	Real m_mapMaxZ;	///< Maximum terrain z value.

--- a/Generals/Code/GameEngineDevice/Include/Win32Device/Common/Win32GameEngine.h
+++ b/Generals/Code/GameEngineDevice/Include/Win32Device/Common/Win32GameEngine.h
@@ -59,27 +59,27 @@ class Win32GameEngine : public GameEngine
 public:
 
 	Win32GameEngine();
-	virtual ~Win32GameEngine();
+	virtual ~Win32GameEngine() override;
 
-	virtual void init();															///< initialization
-	virtual void reset();															///< reset engine
-	virtual void update();														///< update the game engine
-	virtual void serviceWindowsOS();									///< allow windows maintenance in background
+	virtual void init() override;															///< initialization
+	virtual void reset() override;															///< reset engine
+	virtual void update() override;														///< update the game engine
+	virtual void serviceWindowsOS() override;									///< allow windows maintenance in background
 
 protected:
 
-	virtual GameLogic *createGameLogic();							///< factory for game logic
- 	virtual GameClient *createGameClient();						///< factory for game client
-	virtual ModuleFactory *createModuleFactory();			///< factory for creating modules
-	virtual ThingFactory *createThingFactory();				///< factory for the thing factory
-	virtual FunctionLexicon *createFunctionLexicon(); ///< factory for function lexicon
-	virtual LocalFileSystem *createLocalFileSystem(); ///< factory for local file system
-	virtual ArchiveFileSystem *createArchiveFileSystem();	///< factory for archive file system
+	virtual GameLogic *createGameLogic() override;							///< factory for game logic
+ 	virtual GameClient *createGameClient() override;						///< factory for game client
+	virtual ModuleFactory *createModuleFactory() override;			///< factory for creating modules
+	virtual ThingFactory *createThingFactory() override;				///< factory for the thing factory
+	virtual FunctionLexicon *createFunctionLexicon() override; ///< factory for function lexicon
+	virtual LocalFileSystem *createLocalFileSystem() override; ///< factory for local file system
+	virtual ArchiveFileSystem *createArchiveFileSystem() override;	///< factory for archive file system
 	virtual NetworkInterface *createNetwork();				///< Factory for the network
-	virtual Radar *createRadar();											///< Factory for radar
-	virtual WebBrowser *createWebBrowser();						///< Factory for embedded browser
-	virtual AudioManager *createAudioManager();				///< Factory for audio device
-	virtual ParticleSystemManager* createParticleSystemManager(Bool dummy);
+	virtual Radar *createRadar() override;											///< Factory for radar
+	virtual WebBrowser *createWebBrowser() override;						///< Factory for embedded browser
+	virtual AudioManager *createAudioManager() override;				///< Factory for audio device
+	virtual ParticleSystemManager* createParticleSystemManager(Bool dummy) override;
 
 
 protected:

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DProjectedShadow.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DProjectedShadow.cpp
@@ -151,9 +151,9 @@ class W3DShadowTexture : public RefCountClass, public	HashableClass
 			m_shadowUV[0].Set(1.0f,0.0f,0.0f);	//u runs along world x axis
 			m_shadowUV[1].Set(0.0f,-1.0f,0.0f);	//v runs along world -y axis
 		}
-		~W3DShadowTexture() { REF_PTR_RELEASE(m_texture);}
+		~W3DShadowTexture() override { REF_PTR_RELEASE(m_texture);}
 
-		virtual	const char * Get_Key()	{ return m_namebuf;	}
+		virtual	const char * Get_Key() override { return m_namebuf;	}
 
 		Int init (RenderObjClass *robj);
 
@@ -2376,9 +2376,9 @@ class MissingTextureClass : public HashableClass {
 
 public:
 	MissingTextureClass( const char * name ) : Name( name ) {}
-	virtual	~MissingTextureClass() {}
+	virtual	~MissingTextureClass() override {}
 
-	virtual	const char * Get_Key()	{ return Name;	}
+	virtual	const char * Get_Key() override { return Name;	}
 
 private:
 	StringClass	Name;

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DProjectedShadow.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DProjectedShadow.cpp
@@ -151,7 +151,7 @@ class W3DShadowTexture : public RefCountClass, public	HashableClass
 			m_shadowUV[0].Set(1.0f,0.0f,0.0f);	//u runs along world x axis
 			m_shadowUV[1].Set(0.0f,-1.0f,0.0f);	//v runs along world -y axis
 		}
-		~W3DShadowTexture() override { REF_PTR_RELEASE(m_texture);}
+		virtual ~W3DShadowTexture() override { REF_PTR_RELEASE(m_texture);}
 
 		virtual	const char * Get_Key() override { return m_namebuf;	}
 

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp
@@ -569,9 +569,9 @@ class W3DShadowGeometry : public RefCountClass, public	HashableClass
 	public:
 
 		W3DShadowGeometry() { };
-		~W3DShadowGeometry() { };
+		~W3DShadowGeometry() override { };
 
-		virtual	const char * Get_Key()	{ return m_namebuf;	}
+		virtual	const char * Get_Key() override { return m_namebuf;	}
 
 		Int init (RenderObjClass *robj);
 		Int initFromHLOD (RenderObjClass *robj);	///<initialize the geometry from a W3D HLOD object.
@@ -3819,9 +3819,9 @@ class MissingGeomClass : public HashableClass {
 
 public:
 	MissingGeomClass( const char * name ) : Name( name ) {}
-	virtual	~MissingGeomClass() {}
+	virtual	~MissingGeomClass() override {}
 
-	virtual	const char * Get_Key()	{ return Name;	}
+	virtual	const char * Get_Key() override { return Name;	}
 
 private:
 	StringClass	Name;

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp
@@ -569,7 +569,7 @@ class W3DShadowGeometry : public RefCountClass, public	HashableClass
 	public:
 
 		W3DShadowGeometry() { };
-		~W3DShadowGeometry() override { };
+		virtual ~W3DShadowGeometry() override { };
 
 		virtual	const char * Get_Key() override { return m_namebuf;	}
 

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DAssetManager.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DAssetManager.cpp
@@ -99,10 +99,10 @@ class W3DPrototypeClass : public MemoryPoolObject, public PrototypeClass
 public:
 	W3DPrototypeClass(RenderObjClass * proto, const AsciiString& name);
 
-	virtual const char*					Get_Name() const			{ return Name.str(); }
-	virtual int									Get_Class_ID() const	{ return Proto->Class_ID(); }
-	virtual RenderObjClass *		Create();
-	virtual void								DeleteSelf()							{	deleteInstance(this); }
+	virtual const char*					Get_Name() const override { return Name.str(); }
+	virtual int									Get_Class_ID() const override { return Proto->Class_ID(); }
+	virtual RenderObjClass *		Create() override;
+	virtual void								DeleteSelf() override							{	deleteInstance(this); }
 
 protected:
 	//virtual ~W3DPrototypeClass();

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameLogic/W3DGhostObject.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameLogic/W3DGhostObject.cpp
@@ -68,9 +68,9 @@ class W3DRenderObjectSnapshot : public Snapshot
 
 protected:
 
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 #ifdef DEBUG_FOG_MEMORY
 	const char *m_robjName;		///<debug pointer so we know what this is a snapshot of.

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/Common/W3DFunctionLexicon.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/Common/W3DFunctionLexicon.h
@@ -40,11 +40,11 @@ class W3DFunctionLexicon : public FunctionLexicon
 public:
 
 	W3DFunctionLexicon();
-	virtual ~W3DFunctionLexicon();
+	virtual ~W3DFunctionLexicon() override;
 
-	virtual void init();
-	virtual void reset();
-	virtual void update();
+	virtual void init() override;
+	virtual void reset() override;
+	virtual void update() override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/Common/W3DModuleFactory.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/Common/W3DModuleFactory.h
@@ -43,6 +43,6 @@ class W3DModuleFactory : public ModuleFactory
 
 public:
 
-	virtual void init();
+	virtual void init() override;
 
 };

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/Common/W3DThingFactory.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/Common/W3DThingFactory.h
@@ -42,5 +42,5 @@ class W3DThingFactory : public ThingFactory
 public:
 
 	W3DThingFactory();
-	virtual ~W3DThingFactory();
+	virtual ~W3DThingFactory() override;
 };

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DAssetManager.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DAssetManager.h
@@ -54,12 +54,12 @@ class W3DAssetManager: public WW3DAssetManager
 {
 public:
 	W3DAssetManager();
-	virtual ~W3DAssetManager();
+	virtual ~W3DAssetManager() override;
 
-	virtual RenderObjClass * Create_Render_Obj(const char * name);
+	virtual RenderObjClass * Create_Render_Obj(const char * name) override;
 	// unique to W3DAssetManager
-	virtual HAnimClass *	Get_HAnim(const char * name);
-	virtual bool Load_3D_Assets( const char * filename ); // This CANNOT be Bool, as it will not inherit properly if you make Bool == Int
+	virtual HAnimClass *	Get_HAnim(const char * name) override;
+	virtual bool Load_3D_Assets( const char * filename ) override; // This CANNOT be Bool, as it will not inherit properly if you make Bool == Int
 
 	virtual TextureClass *	Get_Texture
 	(
@@ -69,7 +69,7 @@ public:
 		bool allow_compression=true,
 		TextureBaseClass::TexAssetType type=TextureBaseClass::TEX_REGULAR,
 		bool allow_reduction=true
-	);
+	) override;
 
 	//'Generals' customizations
 	void Report_Used_Assets();

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDebugDisplay.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDebugDisplay.h
@@ -72,7 +72,7 @@ class W3DDebugDisplay : public DebugDisplay
 	public:
 
 		W3DDebugDisplay();
-		virtual ~W3DDebugDisplay();
+		virtual ~W3DDebugDisplay() override;
 
 		void init();																						///< Initialized the display
 		void setFont( GameFont *font );																///< Set the font to render with
@@ -86,7 +86,7 @@ class W3DDebugDisplay : public DebugDisplay
 		Int m_fontHeight;
 		DisplayString *m_displayString;
 
-		virtual void drawText( Int x, Int y, Char *text );			///< Render null terminated string at current cursor position
+		virtual void drawText( Int x, Int y, Char *text ) override;			///< Render null terminated string at current cursor position
 
 };
 

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -56,87 +56,87 @@ class W3DDisplay : public Display
 
 public:
 	W3DDisplay();
-	~W3DDisplay();
+	~W3DDisplay() override;
 
-	virtual void init();  ///< initialize or re-initialize the system
- 	virtual void reset() ;																///< Reset system
+	virtual void init() override;  ///< initialize or re-initialize the system
+ 	virtual void reset() override;																///< Reset system
 
-	virtual void setWidth( UnsignedInt width );
-	virtual void setHeight( UnsignedInt height );
-	virtual Bool setDisplayMode( UnsignedInt xres, UnsignedInt yres, UnsignedInt bitdepth, Bool windowed );
-	virtual Int getDisplayModeCount();	///<return number of display modes/resolutions supported by video card.
-	virtual void getDisplayModeDescription(Int modeIndex, Int *xres, Int *yres, Int *bitDepth);	///<return description of mode
- 	virtual void setGamma(Real gamma, Real bright, Real contrast, Bool calibrate);
-	virtual void doSmartAssetPurgeAndPreload(const char* usageFileName);
+	virtual void setWidth( UnsignedInt width ) override;
+	virtual void setHeight( UnsignedInt height ) override;
+	virtual Bool setDisplayMode( UnsignedInt xres, UnsignedInt yres, UnsignedInt bitdepth, Bool windowed ) override;
+	virtual Int getDisplayModeCount() override;	///<return number of display modes/resolutions supported by video card.
+	virtual void getDisplayModeDescription(Int modeIndex, Int *xres, Int *yres, Int *bitDepth) override;	///<return description of mode
+ 	virtual void setGamma(Real gamma, Real bright, Real contrast, Bool calibrate) override;
+	virtual void doSmartAssetPurgeAndPreload(const char* usageFileName) override;
 #if defined(RTS_DEBUG)
 	virtual void dumpAssetUsage(const char* mapname);
 #endif
 
 	//---------------------------------------------------------------------------
 	// Drawing management
-	virtual void setClipRegion( IRegion2D *region );	///< Set clip rectangle for 2D draw operations.
-	virtual Bool	isClippingEnabled() 	{ return m_isClippedEnabled; }
-	virtual void	enableClipping( Bool onoff )		{ m_isClippedEnabled = onoff; }
+	virtual void setClipRegion( IRegion2D *region ) override;	///< Set clip rectangle for 2D draw operations.
+	virtual Bool	isClippingEnabled() override { return m_isClippedEnabled; }
+	virtual void	enableClipping( Bool onoff ) override { m_isClippedEnabled = onoff; }
 
-	virtual void step(); ///< Do one fixed time step
-	virtual void draw();  ///< redraw the entire display
+	virtual void step() override; ///< Do one fixed time step
+	virtual void draw() override;  ///< redraw the entire display
 
 	/// @todo Replace these light management routines with a LightManager singleton
 	virtual void createLightPulse( const Coord3D *pos, const RGBColor *color, Real innerRadius,Real outerRadius,
 																 UnsignedInt increaseFrameTime, UnsignedInt decayFrameTime//, Bool donut = FALSE
-																 );
-	virtual void setTimeOfDay ( TimeOfDay tod );
+																 ) override;
+	virtual void setTimeOfDay ( TimeOfDay tod ) override;
 
 	/// draw a line on the display in screen coordinates
 	virtual void drawLine( Int startX, Int startY, Int endX, Int endY,
-												 Real lineWidth, UnsignedInt lineColor );
+												 Real lineWidth, UnsignedInt lineColor ) override;
 
 	/// draw a line on the display in screen coordinates
 	virtual void drawLine( Int startX, Int startY, Int endX, Int endY,
-												 Real lineWidth, UnsignedInt lineColor1, UnsignedInt lineColor2 );
+												 Real lineWidth, UnsignedInt lineColor1, UnsignedInt lineColor2 ) override;
 
 	/// draw a rect border on the display in pixel coordinates with the specified color
 	virtual void drawOpenRect( Int startX, Int startY, Int width, Int height,
-														 Real lineWidth, UnsignedInt lineColor );
+														 Real lineWidth, UnsignedInt lineColor ) override;
 
 	/// draw a filled rect on the display in pixel coords with the specified color
 	virtual void drawFillRect( Int startX, Int startY, Int width, Int height,
-														 UnsignedInt color );
+														 UnsignedInt color ) override;
 
 	/// Draw a percentage of a rectangle, much like a clock (0 to x%)
-	virtual void drawRectClock(Int startX, Int startY, Int width, Int height, Int percent, UnsignedInt color);
+	virtual void drawRectClock(Int startX, Int startY, Int width, Int height, Int percent, UnsignedInt color) override;
 
 	/// Draw's the remaining percentage of a rectangle (x% to 100)
-	virtual void drawRemainingRectClock(Int startX, Int startY, Int width, Int height, Int percent, UnsignedInt color);
+	virtual void drawRemainingRectClock(Int startX, Int startY, Int width, Int height, Int percent, UnsignedInt color) override;
 
 	/// draw an image fit within the screen coordinates
 	virtual void drawImage( const Image *image, Int startX, Int startY,
-													Int endX, Int endY, Color color = 0xFFFFFFFF, DrawImageMode mode=DRAW_IMAGE_ALPHA);
+													Int endX, Int endY, Color color = 0xFFFFFFFF, DrawImageMode mode=DRAW_IMAGE_ALPHA) override;
 
 	/// draw a video buffer fit within the screen coordinates
-	virtual void drawScaledVideoBuffer( VideoBuffer *buffer, VideoStreamInterface *stream );
+	virtual void drawScaledVideoBuffer( VideoBuffer *buffer, VideoStreamInterface *stream ) override;
 	virtual void drawVideoBuffer( VideoBuffer *buffer, Int startX, Int startY,
-													Int endX, Int endY );
+													Int endX, Int endY ) override;
 
-	virtual VideoBuffer*	createVideoBuffer() ;							///< Create a video buffer that can be used for this display
+	virtual VideoBuffer*	createVideoBuffer() override;							///< Create a video buffer that can be used for this display
 
-	virtual void takeScreenShot();						//save screenshot to file
-	virtual void toggleMovieCapture();			//enable AVI or frame capture mode.
+	virtual void takeScreenShot() override;						//save screenshot to file
+	virtual void toggleMovieCapture() override;			//enable AVI or frame capture mode.
 
-	virtual void toggleLetterBox();	///<enabled letter-boxed display
-	virtual void enableLetterBox(Bool enable);	///<forces letter-boxed display on/off
+	virtual void toggleLetterBox() override;	///<enabled letter-boxed display
+	virtual void enableLetterBox(Bool enable) override;	///<forces letter-boxed display on/off
 
-	virtual Bool isLetterBoxFading();	///<returns true while letterbox fades in/out
-	virtual Bool isLetterBoxed();
+	virtual Bool isLetterBoxFading() override;	///<returns true while letterbox fades in/out
+	virtual Bool isLetterBoxed() override;
 
-	virtual void clearShroud();
-	virtual void setShroudLevel(Int x, Int y, CellShroudStatus setting);
-	virtual void setBorderShroudLevel(UnsignedByte level);	///<color that will appear in unused border terrain.
+	virtual void clearShroud() override;
+	virtual void setShroudLevel(Int x, Int y, CellShroudStatus setting) override;
+	virtual void setBorderShroudLevel(UnsignedByte level) override;	///<color that will appear in unused border terrain.
 #if defined(RTS_DEBUG)
 	virtual void dumpModelAssets(const char *path);	///< dump all used models/textures to a file.
 #endif
-	virtual void preloadModelAssets( AsciiString model );			///< preload model asset
-	virtual void preloadTextureAssets( AsciiString texture );	///< preload texture asset
+	virtual void preloadModelAssets( AsciiString model ) override;			///< preload model asset
+	virtual void preloadTextureAssets( AsciiString texture ) override;	///< preload texture asset
 
 	/// @todo Need a scene abstraction
 	static RTS3DScene *m_3DScene;							///< our 3d scene representation
@@ -145,9 +145,9 @@ public:
 	static W3DAssetManager *m_assetManager;		///< W3D asset manager
 
 	void drawFPSStats();								///< draw the fps on the screen
-	virtual Real getAverageFPS();						///< return the average FPS.
-	virtual Real getCurrentFPS();						///< return the current FPS.
-	virtual Int getLastFrameDrawCalls();				///< returns the number of draw calls issued in the previous frame
+	virtual Real getAverageFPS() override;						///< return the average FPS.
+	virtual Real getCurrentFPS() override;						///< return the current FPS.
+	virtual Int getLastFrameDrawCalls() override;				///< returns the number of draw calls issued in the previous frame
 
 protected:
 

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -56,7 +56,7 @@ class W3DDisplay : public Display
 
 public:
 	W3DDisplay();
-	~W3DDisplay() override;
+	virtual ~W3DDisplay() override;
 
 	virtual void init() override;  ///< initialize or re-initialize the system
  	virtual void reset() override;																///< Reset system

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplayString.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplayString.h
@@ -74,16 +74,16 @@ public:
 	W3DDisplayString();
 	// ~W3DDisplayString();  // destructor defined by memory pool
 
-	void notifyTextChanged();							///< called when text contents change
-	void draw( Int x, Int y, Color color, Color dropColor );  ///< render text
-	void draw( Int x, Int y, Color color, Color dropColor, Int xDrop, Int yDrop );  ///< render text with the drop shadow being at the offsets passed in
-	void getSize( Int *width, Int *height );		///< get render size
-	Int	getWidth( Int charPos = -1);
-	void setWordWrap( Int wordWrap );						///< set the word wrap width
-	void setWordWrapCentered( Bool isCentered ); ///< If this is set to true, the text on a new line is centered
-	void setFont( GameFont *font );							///< set a font for display
-	void setUseHotkey( Bool useHotkey, Color hotKeyColor = 0xffffffff );
-	void setClipRegion( IRegion2D *region );		///< clip text in this region
+	void notifyTextChanged() override;							///< called when text contents change
+	void draw( Int x, Int y, Color color, Color dropColor ) override;  ///< render text
+	void draw( Int x, Int y, Color color, Color dropColor, Int xDrop, Int yDrop ) override;  ///< render text with the drop shadow being at the offsets passed in
+	void getSize( Int *width, Int *height ) override;		///< get render size
+	Int	getWidth( Int charPos = -1) override;
+	void setWordWrap( Int wordWrap ) override;						///< set the word wrap width
+	void setWordWrapCentered( Bool isCentered ) override; ///< If this is set to true, the text on a new line is centered
+	void setFont( GameFont *font ) override;							///< set a font for display
+	void setUseHotkey( Bool useHotkey, Color hotKeyColor = 0xffffffff ) override;
+	void setClipRegion( IRegion2D *region ) override;		///< clip text in this region
 
 protected:
 

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplayString.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplayString.h
@@ -74,16 +74,16 @@ public:
 	W3DDisplayString();
 	// ~W3DDisplayString();  // destructor defined by memory pool
 
-	void notifyTextChanged() override;							///< called when text contents change
-	void draw( Int x, Int y, Color color, Color dropColor ) override;  ///< render text
-	void draw( Int x, Int y, Color color, Color dropColor, Int xDrop, Int yDrop ) override;  ///< render text with the drop shadow being at the offsets passed in
-	void getSize( Int *width, Int *height ) override;		///< get render size
-	Int	getWidth( Int charPos = -1) override;
-	void setWordWrap( Int wordWrap ) override;						///< set the word wrap width
-	void setWordWrapCentered( Bool isCentered ) override; ///< If this is set to true, the text on a new line is centered
-	void setFont( GameFont *font ) override;							///< set a font for display
-	void setUseHotkey( Bool useHotkey, Color hotKeyColor = 0xffffffff ) override;
-	void setClipRegion( IRegion2D *region ) override;		///< clip text in this region
+	virtual void notifyTextChanged() override;							///< called when text contents change
+	virtual void draw( Int x, Int y, Color color, Color dropColor ) override;  ///< render text
+	virtual void draw( Int x, Int y, Color color, Color dropColor, Int xDrop, Int yDrop ) override;  ///< render text with the drop shadow being at the offsets passed in
+	virtual void getSize( Int *width, Int *height ) override;		///< get render size
+	virtual Int	getWidth( Int charPos = -1) override;
+	virtual void setWordWrap( Int wordWrap ) override;						///< set the word wrap width
+	virtual void setWordWrapCentered( Bool isCentered ) override; ///< If this is set to true, the text on a new line is centered
+	virtual void setFont( GameFont *font ) override;							///< set a font for display
+	virtual void setUseHotkey( Bool useHotkey, Color hotKeyColor = 0xffffffff ) override;
+	virtual void setClipRegion( IRegion2D *region ) override;		///< clip text in this region
 
 protected:
 

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplayStringManager.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplayStringManager.h
@@ -44,24 +44,24 @@ class W3DDisplayStringManager : public DisplayStringManager
 public:
 
 	W3DDisplayStringManager();
-	virtual ~W3DDisplayStringManager();
+	virtual ~W3DDisplayStringManager() override;
 
 	// Initialize our numeral strings in postProcessLoad
-	virtual void postProcessLoad();
+	virtual void postProcessLoad() override;
 
 	/// update method for all our display strings
-	virtual void update();
+	virtual void update() override;
 
 	/// allocate a new display string
-	virtual DisplayString *newDisplayString();
+	virtual DisplayString *newDisplayString() override;
 
 	/// free a display string
-	virtual void freeDisplayString( DisplayString *string );
+	virtual void freeDisplayString( DisplayString *string ) override;
 
 	// This is used to save us a few FPS and storage space. There's no reason to
 	// duplicate the DisplayString on every drawable when 1 copy will suffice.
-	virtual DisplayString *getGroupNumeralString( Int numeral );
-	virtual DisplayString *getFormationLetterString() { return m_formationLetterDisplayString; };
+	virtual DisplayString *getGroupNumeralString( Int numeral ) override;
+	virtual DisplayString *getFormationLetterString() override { return m_formationLetterDisplayString; };
 
 protected:
 	DisplayString *m_groupNumeralStrings[ MAX_GROUPS ];

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDynamicLight.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDynamicLight.h
@@ -63,7 +63,7 @@ protected:
 
 public:
 	W3DDynamicLight();
-	~W3DDynamicLight() override;
+	virtual ~W3DDynamicLight() override;
 
 public:
 	virtual void					On_Frame_Update() override;

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDynamicLight.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDynamicLight.h
@@ -63,10 +63,10 @@ protected:
 
 public:
 	W3DDynamicLight();
-	~W3DDynamicLight();
+	~W3DDynamicLight() override;
 
 public:
-	virtual void					On_Frame_Update();
+	virtual void					On_Frame_Update() override;
 
 	void setEnabled(Bool enabled) { m_enabled = enabled; m_decayRange = false; m_decayFrameCount = 0; m_decayColor = false; m_increaseFrameCount = 0;};
 	Bool isEnabled() {return m_enabled;};

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DFileSystem.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DFileSystem.h
@@ -84,7 +84,7 @@ protected:
 class	W3DFileSystem : public FileFactoryClass {
 public:
 	W3DFileSystem();
-	~W3DFileSystem() override;
+	virtual ~W3DFileSystem() override;
 
 	virtual FileClass * Get_File( char const *filename ) override;
 	virtual void Return_File( FileClass *file ) override;

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DFileSystem.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DFileSystem.h
@@ -48,24 +48,24 @@ public:
 
 	GameFileClass(char const *filename);
 	GameFileClass();
-	virtual ~GameFileClass();
+	virtual ~GameFileClass() override;
 
-	virtual char const * File_Name() const;
-	virtual char const * Set_Name(char const *filename);
+	virtual char const * File_Name() const override;
+	virtual char const * Set_Name(char const *filename) override;
 
 	// (gth) had to re-instate these functions in the base class, for now just give empty implementations...
-	virtual int Create() { assert(0); return 1; }
-	virtual int Delete() { assert(0); return 1; }
+	virtual int Create() override { assert(0); return 1; }
+	virtual int Delete() override { assert(0); return 1; }
 
-	virtual bool Is_Available(int forced=false);
-	virtual bool Is_Open() const;
-	virtual int Open(char const *filename, int rights=READ);
-	virtual int Open(int rights=READ);
-	virtual int Read(void *buffer, int len);
-	virtual int Seek(int pos, int dir=SEEK_CUR);
-	virtual int Size();
-	virtual int Write(void const *buffer, int len);
-	virtual void Close();
+	virtual bool Is_Available(int forced=false) override;
+	virtual bool Is_Open() const override;
+	virtual int Open(char const *filename, int rights=READ) override;
+	virtual int Open(int rights=READ) override;
+	virtual int Read(void *buffer, int len) override;
+	virtual int Seek(int pos, int dir=SEEK_CUR) override;
+	virtual int Size() override;
+	virtual int Write(void const *buffer, int len) override;
+	virtual void Close() override;
 
 protected:
 
@@ -84,10 +84,10 @@ protected:
 class	W3DFileSystem : public FileFactoryClass {
 public:
 	W3DFileSystem();
-	~W3DFileSystem();
+	~W3DFileSystem() override;
 
-	virtual FileClass * Get_File( char const *filename );
-	virtual void Return_File( FileClass *file );
+	virtual FileClass * Get_File( char const *filename ) override;
+	virtual void Return_File( FileClass *file ) override;
 
 private:
 

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DGameClient.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DGameClient.h
@@ -72,57 +72,57 @@ class W3DGameClient : public GameClient
 public:
 
 	W3DGameClient();
-	virtual ~W3DGameClient();
+	virtual ~W3DGameClient() override;
 
 	/// given a type, create a drawable
-	virtual Drawable *friend_createDrawable( const ThingTemplate *thing, DrawableStatusBits statusBits = DRAWABLE_STATUS_DEFAULT );
+	virtual Drawable *friend_createDrawable( const ThingTemplate *thing, DrawableStatusBits statusBits = DRAWABLE_STATUS_DEFAULT ) override;
 
-	virtual void init();		///< initialize resources
-	virtual void update();  ///< per frame update
-	virtual void reset();   ///< reset system
+	virtual void init() override;		///< initialize resources
+	virtual void update() override;  ///< per frame update
+	virtual void reset() override;   ///< reset system
 
-	virtual void addScorch(const Coord3D *pos, Real radius, Scorches type);
-	virtual void createRayEffectByTemplate( const Coord3D *start, const Coord3D *end, const ThingTemplate* tmpl );  ///< create effect needing start and end location
+	virtual void addScorch(const Coord3D *pos, Real radius, Scorches type) override;
+	virtual void createRayEffectByTemplate( const Coord3D *start, const Coord3D *end, const ThingTemplate* tmpl ) override;  ///< create effect needing start and end location
 	//virtual Bool getBonePos(Drawable *draw, AsciiString boneName, Coord3D* pos, Matrix3D* transform) const;
 
-	virtual void setTimeOfDay( TimeOfDay tod );							///< Tell all the drawables what time of day it is now
+	virtual void setTimeOfDay( TimeOfDay tod ) override;							///< Tell all the drawables what time of day it is now
 
 	//---------------------------------------------------------------------------
-	virtual void setTeamColor( Int red, Int green, Int blue );  ///< @todo superhack for demo, remove!!!
-	virtual void setTextureLOD( Int level );
-	virtual void notifyTerrainObjectMoved(Object *obj);
+	virtual void setTeamColor( Int red, Int green, Int blue ) override;  ///< @todo superhack for demo, remove!!!
+	virtual void setTextureLOD( Int level ) override;
+	virtual void notifyTerrainObjectMoved(Object *obj) override;
 
 protected:
 
-	virtual Keyboard *createKeyboard();								///< factory for the keyboard
-	virtual Mouse *createMouse();											///< factory for the mouse
+	virtual Keyboard *createKeyboard() override;								///< factory for the keyboard
+	virtual Mouse *createMouse() override;											///< factory for the mouse
 
 	/// factory for creating TheDisplay
-	virtual Display *createGameDisplay() { return NEW W3DDisplay; }
+	virtual Display *createGameDisplay() override { return NEW W3DDisplay; }
 
 	/// factory for creating TheInGameUI
-	virtual InGameUI *createInGameUI() { return NEW W3DInGameUI; }
+	virtual InGameUI *createInGameUI() override { return NEW W3DInGameUI; }
 
 	/// factory for creating the window manager
-	virtual GameWindowManager *createWindowManager() { return NEW W3DGameWindowManager; }
+	virtual GameWindowManager *createWindowManager() override { return NEW W3DGameWindowManager; }
 
 	/// factory for creating the font library
-	virtual FontLibrary *createFontLibrary() { return NEW W3DFontLibrary; }
+	virtual FontLibrary *createFontLibrary() override { return NEW W3DFontLibrary; }
 
   /// Manager for display strings
-	virtual DisplayStringManager *createDisplayStringManager() { return NEW W3DDisplayStringManager; }
+	virtual DisplayStringManager *createDisplayStringManager() override { return NEW W3DDisplayStringManager; }
 #ifdef RTS_HAS_FFMPEG
 	virtual VideoPlayerInterface *createVideoPlayer() { return NEW FFmpegVideoPlayer; }
 #else
-	virtual VideoPlayerInterface *createVideoPlayer() { return NEW BinkVideoPlayer; }
+	virtual VideoPlayerInterface *createVideoPlayer() override { return NEW BinkVideoPlayer; }
 #endif
 	/// factory for creating the TerrainVisual
-	virtual TerrainVisual *createTerrainVisual() { return NEW W3DTerrainVisual; }
+	virtual TerrainVisual *createTerrainVisual() override { return NEW W3DTerrainVisual; }
 
 	/// factory for creating the snow manager
-	virtual SnowManager *createSnowManager() { return NEW W3DSnowManager; }
+	virtual SnowManager *createSnowManager() override { return NEW W3DSnowManager; }
 
-	virtual void setFrameRate(Real msecsPerFrame) { TheW3DFrameLengthInMsec = msecsPerFrame; }
+	virtual void setFrameRate(Real msecsPerFrame) override { TheW3DFrameLengthInMsec = msecsPerFrame; }
 
 };
 

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DGameFont.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DGameFont.h
@@ -63,14 +63,14 @@ class W3DFontLibrary : public FontLibrary
 public:
 
 	W3DFontLibrary() { }
-	~W3DFontLibrary() { }
+	~W3DFontLibrary() override { }
 
 protected:
 
 	/// load the font data pointer based on everything else we already have set
-	Bool loadFontData( GameFont *font );
+	virtual Bool loadFontData( GameFont *font ) override;
 	/// release the font data pointer
-	void releaseFontData( GameFont *font );
+	virtual void releaseFontData( GameFont *font ) override;
 
 };
 

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DGameFont.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DGameFont.h
@@ -63,7 +63,7 @@ class W3DFontLibrary : public FontLibrary
 public:
 
 	W3DFontLibrary() { }
-	~W3DFontLibrary() override { }
+	virtual ~W3DFontLibrary() override { }
 
 protected:
 

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DGameWindow.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DGameWindow.h
@@ -69,11 +69,11 @@ public:
 	//~W3DGameWindow();
 
 	/// draw borders for this window only, NO child windows or anything else
-	void winDrawBorder();
+	void winDrawBorder() override;
 
 	Int winSetPosition( Int x, Int y );  ///< set window position
-	Int winSetText( UnicodeString newText );  ///< set text string
-	void winSetFont( GameFont *font );  ///< set font for window
+	virtual Int winSetText( UnicodeString newText ) override;  ///< set text string
+	virtual void winSetFont( GameFont *font ) override;  ///< set font for window
 
 	void getTextSize( Int *width, Int *height );  ///< get size of text
 	void setTextLoc( Int x, Int y );  ///< set text screen coord loc

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DGameWindow.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DGameWindow.h
@@ -69,7 +69,7 @@ public:
 	//~W3DGameWindow();
 
 	/// draw borders for this window only, NO child windows or anything else
-	void winDrawBorder() override;
+	virtual void winDrawBorder() override;
 
 	Int winSetPosition( Int x, Int y );  ///< set window position
 	virtual Int winSetText( UnicodeString newText ) override;  ///< set text string

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DGameWindowManager.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DGameWindowManager.h
@@ -45,35 +45,35 @@ class W3DGameWindowManager : public GameWindowManager
 public:
 
 	W3DGameWindowManager();
-	virtual ~W3DGameWindowManager();
+	virtual ~W3DGameWindowManager() override;
 
-	virtual void init();  ///< initialize the singlegon
+	virtual void init() override;  ///< initialize the singlegon
 
-	virtual GameWindow *allocateNewWindow();  ///< allocate a new game window
-	virtual GameWinDrawFunc getDefaultDraw();  ///< return default draw func to use
+	virtual GameWindow *allocateNewWindow() override;  ///< allocate a new game window
+	virtual GameWinDrawFunc getDefaultDraw() override;  ///< return default draw func to use
 
-	virtual GameWinDrawFunc getPushButtonImageDrawFunc();
-	virtual GameWinDrawFunc getPushButtonDrawFunc();
-	virtual GameWinDrawFunc getCheckBoxImageDrawFunc();
-	virtual GameWinDrawFunc getCheckBoxDrawFunc();
-	virtual GameWinDrawFunc getRadioButtonImageDrawFunc();
-	virtual GameWinDrawFunc getRadioButtonDrawFunc();
-	virtual GameWinDrawFunc getTabControlImageDrawFunc();
-	virtual GameWinDrawFunc getTabControlDrawFunc();
-	virtual GameWinDrawFunc getListBoxImageDrawFunc();
-	virtual GameWinDrawFunc getListBoxDrawFunc();
-	virtual GameWinDrawFunc getComboBoxImageDrawFunc();
-	virtual GameWinDrawFunc getComboBoxDrawFunc();
-	virtual GameWinDrawFunc getHorizontalSliderImageDrawFunc();
-	virtual GameWinDrawFunc getHorizontalSliderDrawFunc();
-	virtual GameWinDrawFunc getVerticalSliderImageDrawFunc();
-	virtual GameWinDrawFunc getVerticalSliderDrawFunc();
-	virtual GameWinDrawFunc getProgressBarImageDrawFunc();
-	virtual GameWinDrawFunc getProgressBarDrawFunc();
-	virtual GameWinDrawFunc getStaticTextImageDrawFunc();
-	virtual GameWinDrawFunc getStaticTextDrawFunc();
-	virtual GameWinDrawFunc getTextEntryImageDrawFunc();
-	virtual GameWinDrawFunc getTextEntryDrawFunc();
+	virtual GameWinDrawFunc getPushButtonImageDrawFunc() override;
+	virtual GameWinDrawFunc getPushButtonDrawFunc() override;
+	virtual GameWinDrawFunc getCheckBoxImageDrawFunc() override;
+	virtual GameWinDrawFunc getCheckBoxDrawFunc() override;
+	virtual GameWinDrawFunc getRadioButtonImageDrawFunc() override;
+	virtual GameWinDrawFunc getRadioButtonDrawFunc() override;
+	virtual GameWinDrawFunc getTabControlImageDrawFunc() override;
+	virtual GameWinDrawFunc getTabControlDrawFunc() override;
+	virtual GameWinDrawFunc getListBoxImageDrawFunc() override;
+	virtual GameWinDrawFunc getListBoxDrawFunc() override;
+	virtual GameWinDrawFunc getComboBoxImageDrawFunc() override;
+	virtual GameWinDrawFunc getComboBoxDrawFunc() override;
+	virtual GameWinDrawFunc getHorizontalSliderImageDrawFunc() override;
+	virtual GameWinDrawFunc getHorizontalSliderDrawFunc() override;
+	virtual GameWinDrawFunc getVerticalSliderImageDrawFunc() override;
+	virtual GameWinDrawFunc getVerticalSliderDrawFunc() override;
+	virtual GameWinDrawFunc getProgressBarImageDrawFunc() override;
+	virtual GameWinDrawFunc getProgressBarDrawFunc() override;
+	virtual GameWinDrawFunc getStaticTextImageDrawFunc() override;
+	virtual GameWinDrawFunc getStaticTextDrawFunc() override;
+	virtual GameWinDrawFunc getTextEntryImageDrawFunc() override;
+	virtual GameWinDrawFunc getTextEntryDrawFunc() override;
 
 protected:
 

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DInGameUI.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DInGameUI.h
@@ -56,20 +56,20 @@ class W3DInGameUI : public InGameUI
 public:
 
 	W3DInGameUI();
-	virtual ~W3DInGameUI();
+	virtual ~W3DInGameUI() override;
 
 	// Inherited from subsystem interface -----------------------------------------------------------
-	virtual	void init();		///< Initialize the in-game user interface
-	virtual void update();	//< Update the UI by calling preDraw(), draw(), and postDraw()
-	virtual void reset();		///< Reset
+	virtual	void init() override;		///< Initialize the in-game user interface
+	virtual void update() override;	//< Update the UI by calling preDraw(), draw(), and postDraw()
+	virtual void reset() override;		///< Reset
 	//-----------------------------------------------------------------------------------------------
 
-	virtual void draw(); ///< Render the in-game user interface
+	virtual void draw() override; ///< Render the in-game user interface
 
 protected:
 
 	/// factory for views
-	virtual View *createView(bool dummy)
+	virtual View *createView(bool dummy) override
 	{
 		if (dummy)
 			return NEW ViewDummy;

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DParticleSys.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DParticleSys.h
@@ -42,12 +42,12 @@ class W3DParticleSystemManager : public ParticleSystemManager
 
 public:
 	W3DParticleSystemManager();
-	~W3DParticleSystemManager();
+	virtual ~W3DParticleSystemManager() override;
 
-	virtual void doParticles(RenderInfoClass &rinfo);
-	virtual void queueParticleRender();
+	virtual void doParticles(RenderInfoClass &rinfo) override;
+	virtual void queueParticleRender() override;
 	///< returns the number of particles shown on screen per frame
-	virtual Int getOnScreenParticleCount() { return m_onScreenParticleCount; }
+	virtual Int getOnScreenParticleCount() override { return m_onScreenParticleCount; }
 
 private:
 	enum { MAX_POINTS_PER_GROUP = 512 };

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DProjectedShadow.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DProjectedShadow.h
@@ -51,7 +51,7 @@ class W3DProjectedShadowManager	: public ProjectedShadowManager
 */
 	public:
 		W3DProjectedShadowManager();
-		~W3DProjectedShadowManager();
+		~W3DProjectedShadowManager() override;
 		Bool init();					///<allocate one-time shadow assets for length of entire game.
 		void reset();					///<free all existing shadows - ready for next map.
 		void shutdown();			///<free all assets prior to shutdown of entire game.
@@ -61,8 +61,8 @@ class W3DProjectedShadowManager	: public ProjectedShadowManager
 		Bool ReAcquireResources();	///<allocate device dependent D3D resources.
 		void invalidateCachedLightPositions();	///<forces shadows to update regardless of last lightposition
 
-		virtual Shadow	*addDecal(RenderObjClass *robj, Shadow::ShadowTypeInfo *shadowInfo);	///<add a non-shadow decal
-		virtual Shadow	*addDecal(Shadow::ShadowTypeInfo *shadowInfo);	///<add a non-shadow decal which does not follow an object.
+		virtual Shadow	*addDecal(RenderObjClass *robj, Shadow::ShadowTypeInfo *shadowInfo) override;	///<add a non-shadow decal
+		virtual Shadow	*addDecal(Shadow::ShadowTypeInfo *shadowInfo) override;	///<add a non-shadow decal which does not follow an object.
 		W3DProjectedShadow	*addShadow( RenderObjClass *robj, Shadow::ShadowTypeInfo *shadowInfo, Drawable *draw);	///<add a new shadow with texture of given name or that of robj.
 		W3DProjectedShadow	*createDecalShadow( Shadow::ShadowTypeInfo *shadowInfo);	///<add a new shadow with texture of given name or that of robj.
 		void removeShadow (W3DProjectedShadow *shadow);
@@ -132,5 +132,5 @@ class W3DProjectedShadow	: public Shadow
 		Real	m_decalOffsetU;		/// texture coordinate offset so not centered at object origin.
 		Real	m_decalOffsetV;		/// texture coordinate offset so not centered at object origin.
 		Int		m_flags;			/// custom rendering flags
-		virtual void release()	{TheW3DProjectedShadowManager->removeShadow(this);}	///<release shadow from manager
+		virtual void release() override	{TheW3DProjectedShadowManager->removeShadow(this);}	///<release shadow from manager
 };

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DProjectedShadow.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DProjectedShadow.h
@@ -51,7 +51,7 @@ class W3DProjectedShadowManager	: public ProjectedShadowManager
 */
 	public:
 		W3DProjectedShadowManager();
-		~W3DProjectedShadowManager() override;
+		virtual ~W3DProjectedShadowManager() override;
 		Bool init();					///<allocate one-time shadow assets for length of entire game.
 		void reset();					///<free all existing shadows - ready for next map.
 		void shutdown();			///<free all assets prior to shutdown of entire game.

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DScene.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DScene.h
@@ -62,15 +62,15 @@ class RTS3DScene : public SimpleSceneClass, public SubsystemInterface
 public:
 
 	RTS3DScene();  ///< RTSScene constructor
-	~RTS3DScene();  ///< RTSScene destructor
+	virtual ~RTS3DScene() override;  ///< RTSScene destructor
 
 	/// ray picking against objects in scene
 	Bool castRay(RayCollisionTestClass & raytest, Bool testAll, Int collisionType);
 
 	/// customizable renderer for the RTS3DScene
-	virtual void	Customized_Render( RenderInfoClass &rinfo );
-	virtual void	Visibility_Check(CameraClass * camera);
-	virtual void  Render(RenderInfoClass & rinfo);
+	virtual void	Customized_Render( RenderInfoClass &rinfo ) override;
+	virtual void	Visibility_Check(CameraClass * camera) override;
+	virtual void  Render(RenderInfoClass & rinfo) override;
 
 	void setCustomPassMode (CustomScenePassModes mode) {m_customPassMode = mode;}
 	CustomScenePassModes getCustomPassMode ()	{return m_customPassMode;}
@@ -92,10 +92,10 @@ public:
 	void setGlobalLight(LightClass *pLight,Int lightIndex=0);
 	LightEnvironmentClass &getDefaultLightEnv() {return m_defaultLightEnv;}
 
-	void init() {}
-	void update() {}
-	void draw();
-	void reset(){}
+	virtual void init() override {}
+	virtual void update() override {}
+	virtual void draw() override;
+	virtual void reset() override{}
 	void doRender(CameraClass * cam);
 
 protected:
@@ -149,14 +149,14 @@ class RTS2DScene : public SimpleSceneClass, public SubsystemInterface
 public:
 
 	RTS2DScene();
-	~RTS2DScene();
+	virtual ~RTS2DScene() override;
 
 	/// customizable renderer for the RTS2DScene
-	virtual void Customized_Render( RenderInfoClass &rinfo );
-	void init() {}
-	void update() {}
-	void draw();
-	void reset(){}
+	virtual void Customized_Render( RenderInfoClass &rinfo ) override;
+	virtual void init() override {}
+	virtual void update() override {}
+	virtual void draw() override;
+	virtual void reset() override{}
 	void doRender(CameraClass * cam);
 
 protected:
@@ -175,8 +175,8 @@ class RTS3DInterfaceScene : public SimpleSceneClass
 public:
 
 	RTS3DInterfaceScene();
-	~RTS3DInterfaceScene();
+	virtual ~RTS3DInterfaceScene() override;
 
 	/// customizable renderer for the RTS3DInterfaceScene
-	virtual void Customized_Render( RenderInfoClass &rinfo );
+	virtual void Customized_Render( RenderInfoClass &rinfo ) override;
 };

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DScene.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DScene.h
@@ -95,7 +95,7 @@ public:
 	virtual void init() override {}
 	virtual void update() override {}
 	virtual void draw() override;
-	virtual void reset() override{}
+	virtual void reset() override {}
 	void doRender(CameraClass * cam);
 
 protected:
@@ -156,7 +156,7 @@ public:
 	virtual void init() override {}
 	virtual void update() override {}
 	virtual void draw() override;
-	virtual void reset() override{}
+	virtual void reset() override {}
 	void doRender(CameraClass * cam);
 
 protected:

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DShroud.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DShroud.h
@@ -43,8 +43,8 @@ class W3DShroudMaterialPassClass : public MaterialPassClass
 {
 public:
 	W3DShroudMaterialPassClass() : m_isTransparentObjectPass(FALSE) {}
-	virtual void	Install_Materials() const;
-	virtual void	UnInstall_Materials() const;
+	virtual void	Install_Materials() const override;
+	virtual void	UnInstall_Materials() const override;
 	void enableTransparentObjectPass(Bool enable) {m_isTransparentObjectPass = enable;}
 protected:
 	//customized version to deal with transparent (alpha-tested) polys.
@@ -60,8 +60,8 @@ class W3DMaskMaterialPassClass : public MaterialPassClass
 {
 public:
 	W3DMaskMaterialPassClass() : m_texture(nullptr), m_allowUninstall(TRUE) {}
-	virtual void	Install_Materials() const;
-	virtual void	UnInstall_Materials() const;
+	virtual void	Install_Materials() const override;
+	virtual void	UnInstall_Materials() const override;
 	void	setTexture(TextureClass *texture)	{m_texture=texture;}
 	void	setAllowUninstall(Bool state)	{ m_allowUninstall = state;}
 

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DStatusCircle.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DStatusCircle.h
@@ -46,26 +46,26 @@ public:
 	W3DStatusCircle();
 	W3DStatusCircle(const W3DStatusCircle & src);
 	W3DStatusCircle & operator = (const W3DStatusCircle &);
-	~W3DStatusCircle();
+	~W3DStatusCircle() override;
 
 	/////////////////////////////////////////////////////////////////////////////
 	// Render Object Interface
 	/////////////////////////////////////////////////////////////////////////////
-	virtual RenderObjClass *	Clone() const;
-	virtual int						Class_ID() const;
-	virtual void					Render(RenderInfoClass & rinfo);
+	virtual RenderObjClass *	Clone() const override;
+	virtual int						Class_ID() const override;
+	virtual void					Render(RenderInfoClass & rinfo) override;
 //	virtual void					Special_Render(SpecialRenderInfoClass & rinfo);
 //	virtual void 					Set_Transform(const Matrix3D &m);
 //	virtual void 					Set_Position(const Vector3 &v);
 //TODO: MW: do these later - only needed for collision detection
-	virtual bool					Cast_Ray(RayCollisionTestClass & raytest);
+	virtual bool					Cast_Ray(RayCollisionTestClass & raytest) override;
 //	virtual Bool					Cast_AABox(AABoxCollisionTestClass & boxtest);
 //	virtual Bool					Cast_OBBox(OBBoxCollisionTestClass & boxtest);
 //	virtual Bool					Intersect_AABox(AABoxIntersectionTestClass & boxtest);
 //	virtual Bool					Intersect_OBBox(OBBoxIntersectionTestClass & boxtest);
 
-	virtual void					Get_Obj_Space_Bounding_Sphere(SphereClass & sphere) const;
-    virtual void					Get_Obj_Space_Bounding_Box(AABoxClass & aabox) const;
+	virtual void					Get_Obj_Space_Bounding_Sphere(SphereClass & sphere) const override;
+    virtual void					Get_Obj_Space_Bounding_Box(AABoxClass & aabox) const override;
 
 
 //	virtual int					 	Get_Num_Polys() const;

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DStatusCircle.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DStatusCircle.h
@@ -46,7 +46,7 @@ public:
 	W3DStatusCircle();
 	W3DStatusCircle(const W3DStatusCircle & src);
 	W3DStatusCircle & operator = (const W3DStatusCircle &);
-	~W3DStatusCircle() override;
+	virtual ~W3DStatusCircle() override;
 
 	/////////////////////////////////////////////////////////////////////////////
 	// Render Object Interface

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DVolumetricShadow.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DVolumetricShadow.h
@@ -102,7 +102,7 @@ class W3DVolumetricShadow	: public Shadow
 
 	protected:
 
-		virtual void release()	{TheW3DVolumetricShadowManager->removeShadow(this);}	///<release shadow from manager
+		virtual void release() override	{TheW3DVolumetricShadowManager->removeShadow(this);}	///<release shadow from manager
 
 		#if defined(RTS_DEBUG)
 		virtual void getRenderCost(RenderCost & rc) const;

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DWebBrowser.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DWebBrowser.h
@@ -38,7 +38,7 @@ class W3DWebBrowser : public WebBrowser
 	public:
 		W3DWebBrowser();
 
-		virtual Bool createBrowserWindow(const char *tag, GameWindow *win);
-		virtual void closeBrowserWindow(GameWindow *win);
+		virtual Bool createBrowserWindow(const char *tag, GameWindow *win) override;
+		virtual void closeBrowserWindow(GameWindow *win) override;
 
 };

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameLogic/W3DGameLogic.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameLogic/W3DGameLogic.h
@@ -58,8 +58,8 @@ public:
 protected:
 
 	/// factory for TheTerrainLogic, called from init()
-	virtual TerrainLogic *createTerrainLogic() { return NEW W3DTerrainLogic; };
-	virtual GhostObjectManager *createGhostObjectManager(bool dummy)
+	virtual TerrainLogic *createTerrainLogic() override { return NEW W3DTerrainLogic; };
+	virtual GhostObjectManager *createGhostObjectManager(bool dummy) override
 	{
 		if (dummy)
 			return NEW GhostObjectManagerDummy;

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameLogic/W3DGhostObject.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameLogic/W3DGhostObject.h
@@ -45,15 +45,15 @@ class W3DGhostObject: public GhostObject
 
 public:
 	W3DGhostObject();
-	virtual ~W3DGhostObject();
-	virtual void snapShot(int playerIndex);
-	virtual void updateParentObject(Object *object, PartitionData *mod);
-	virtual void freeSnapShot(int playerIndex);
+	virtual ~W3DGhostObject() override;
+	virtual void snapShot(int playerIndex) override;
+	virtual void updateParentObject(Object *object, PartitionData *mod) override;
+	virtual void freeSnapShot(int playerIndex) override;
 
 protected:
-	virtual void crc( Xfer *xfer);
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 	void removeParentObject();
 	void restoreParentObject();	///< restore the original non-ghosted object to scene.
 	Bool addToScene(int playerIndex);
@@ -73,19 +73,19 @@ class W3DGhostObjectManager : public GhostObjectManager
 {
 public:
 	W3DGhostObjectManager();
-	virtual ~W3DGhostObjectManager();
-	virtual void reset();
-	virtual GhostObject *addGhostObject(Object *object, PartitionData *pd);
-	virtual void removeGhostObject(GhostObject *mod);
-	virtual void setLocalPlayerIndex(int playerIndex);
-	virtual void updateOrphanedObjects(int *playerIndexList, int playerIndexCount);
-	virtual void releasePartitionData();
-	virtual void restorePartitionData();
+	virtual ~W3DGhostObjectManager() override;
+	virtual void reset() override;
+	virtual GhostObject *addGhostObject(Object *object, PartitionData *pd) override;
+	virtual void removeGhostObject(GhostObject *mod) override;
+	virtual void setLocalPlayerIndex(int playerIndex) override;
+	virtual void updateOrphanedObjects(int *playerIndexList, int playerIndexCount) override;
+	virtual void releasePartitionData() override;
+	virtual void restorePartitionData() override;
 
 protected:
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	///@todo this list should really be part of the device independent base class (CBD 12-3-2002)
 	W3DGhostObject	*m_freeModules;

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameLogic/W3DTerrainLogic.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameLogic/W3DTerrainLogic.h
@@ -43,36 +43,36 @@ class W3DTerrainLogic : public TerrainLogic
 public:
 
 	W3DTerrainLogic();
-	virtual ~W3DTerrainLogic();
+	virtual ~W3DTerrainLogic() override;
 
-	virtual void init();		///< Init
-	virtual void reset();		///< Reset
-	virtual void update();	///< Update
+	virtual void init() override;		///< Init
+	virtual void reset() override;		///< Reset
+	virtual void update() override;	///< Update
 
 	/// @todo The loading of the raw height data should be device independent
-	virtual Bool loadMap( AsciiString filename , Bool query );
-	virtual void newMap( Bool saveGame );	///< Initialize the logic for new map.
+	virtual Bool loadMap( AsciiString filename , Bool query ) override;
+	virtual void newMap( Bool saveGame ) override;	///< Initialize the logic for new map.
 
-	virtual Real getGroundHeight( Real x, Real y, Coord3D* normal = nullptr ) const;
+	virtual Real getGroundHeight( Real x, Real y, Coord3D* normal = nullptr ) const override;
 
-	virtual Bool isCliffCell( Real x, Real y) const;			///< is point cliff cell.
+	virtual Bool isCliffCell( Real x, Real y) const override;			///< is point cliff cell.
 
-	virtual Real getLayerHeight(Real x, Real y, PathfindLayerEnum layer, Coord3D* normal = nullptr, Bool clip = true) const;
+	virtual Real getLayerHeight(Real x, Real y, PathfindLayerEnum layer, Coord3D* normal = nullptr, Bool clip = true) const override;
 
-	virtual void getExtent( Region3D *extent ) const ;					///< Get the 3D extent of the terrain in world coordinates
+	virtual void getExtent( Region3D *extent ) const override ;					///< Get the 3D extent of the terrain in world coordinates
 
-	virtual void getMaximumPathfindExtent( Region3D *extent ) const;
+	virtual void getMaximumPathfindExtent( Region3D *extent ) const override;
 
-	virtual void getExtentIncludingBorder( Region3D *extent ) const;
+	virtual void getExtentIncludingBorder( Region3D *extent ) const override;
 
-	virtual Bool isClearLineOfSight(const Coord3D& pos, const Coord3D& posOther) const;
+	virtual Bool isClearLineOfSight(const Coord3D& pos, const Coord3D& posOther) const override;
 
 protected:
 
 	// snapshot methods
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 	Real m_mapMinZ;	///< Minimum terrain z value.
 	Real m_mapMaxZ;	///< Maximum terrain z value.

--- a/GeneralsMD/Code/GameEngineDevice/Include/Win32Device/Common/Win32GameEngine.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/Win32Device/Common/Win32GameEngine.h
@@ -59,27 +59,27 @@ class Win32GameEngine : public GameEngine
 public:
 
 	Win32GameEngine();
-	virtual ~Win32GameEngine();
+	virtual ~Win32GameEngine() override;
 
-	virtual void init();															///< initialization
-	virtual void reset();															///< reset engine
-	virtual void update();														///< update the game engine
-	virtual void serviceWindowsOS();									///< allow windows maintenance in background
+	virtual void init() override;															///< initialization
+	virtual void reset() override;															///< reset engine
+	virtual void update() override;														///< update the game engine
+	virtual void serviceWindowsOS() override;									///< allow windows maintenance in background
 
 protected:
 
-	virtual GameLogic *createGameLogic();							///< factory for game logic
- 	virtual GameClient *createGameClient();						///< factory for game client
-	virtual ModuleFactory *createModuleFactory();			///< factory for creating modules
-	virtual ThingFactory *createThingFactory();				///< factory for the thing factory
-	virtual FunctionLexicon *createFunctionLexicon(); ///< factory for function lexicon
-	virtual LocalFileSystem *createLocalFileSystem(); ///< factory for local file system
-	virtual ArchiveFileSystem *createArchiveFileSystem();	///< factory for archive file system
+	virtual GameLogic *createGameLogic() override;							///< factory for game logic
+ 	virtual GameClient *createGameClient() override;						///< factory for game client
+	virtual ModuleFactory *createModuleFactory() override;			///< factory for creating modules
+	virtual ThingFactory *createThingFactory() override;				///< factory for the thing factory
+	virtual FunctionLexicon *createFunctionLexicon() override; ///< factory for function lexicon
+	virtual LocalFileSystem *createLocalFileSystem() override; ///< factory for local file system
+	virtual ArchiveFileSystem *createArchiveFileSystem() override;	///< factory for archive file system
 	virtual NetworkInterface *createNetwork();				///< Factory for the network
-	virtual Radar *createRadar();											///< Factory for radar
-	virtual WebBrowser *createWebBrowser();						///< Factory for embedded browser
-	virtual AudioManager *createAudioManager();				///< Factory for audio device
-	virtual ParticleSystemManager* createParticleSystemManager(Bool dummy);
+	virtual Radar *createRadar() override;											///< Factory for radar
+	virtual WebBrowser *createWebBrowser() override;						///< Factory for embedded browser
+	virtual AudioManager *createAudioManager() override;				///< Factory for audio device
+	virtual ParticleSystemManager* createParticleSystemManager(Bool dummy) override;
 
 
 protected:

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DProjectedShadow.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DProjectedShadow.cpp
@@ -151,9 +151,9 @@ class W3DShadowTexture : public RefCountClass, public	HashableClass
 			m_shadowUV[0].Set(1.0f,0.0f,0.0f);	//u runs along world x axis
 			m_shadowUV[1].Set(0.0f,-1.0f,0.0f);	//v runs along world -y axis
 		}
-		~W3DShadowTexture() { REF_PTR_RELEASE(m_texture);}
+		~W3DShadowTexture() override { REF_PTR_RELEASE(m_texture);}
 
-		virtual	const char * Get_Key()	{ return m_namebuf;	}
+		virtual	const char * Get_Key() override { return m_namebuf;	}
 
 		Int init (RenderObjClass *robj);
 
@@ -2380,9 +2380,9 @@ class MissingTextureClass : public HashableClass {
 
 public:
 	MissingTextureClass( const char * name ) : Name( name ) {}
-	virtual	~MissingTextureClass() {}
+	virtual	~MissingTextureClass() override {}
 
-	virtual	const char * Get_Key()	{ return Name;	}
+	virtual	const char * Get_Key() override { return Name;	}
 
 private:
 	StringClass	Name;

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DProjectedShadow.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DProjectedShadow.cpp
@@ -151,7 +151,7 @@ class W3DShadowTexture : public RefCountClass, public	HashableClass
 			m_shadowUV[0].Set(1.0f,0.0f,0.0f);	//u runs along world x axis
 			m_shadowUV[1].Set(0.0f,-1.0f,0.0f);	//v runs along world -y axis
 		}
-		~W3DShadowTexture() override { REF_PTR_RELEASE(m_texture);}
+		virtual ~W3DShadowTexture() override { REF_PTR_RELEASE(m_texture);}
 
 		virtual	const char * Get_Key() override { return m_namebuf;	}
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp
@@ -589,9 +589,9 @@ class W3DShadowGeometry : public RefCountClass, public	HashableClass
 	public:
 
 		W3DShadowGeometry() { };
-		~W3DShadowGeometry() { };
+		~W3DShadowGeometry() override { };
 
-		virtual	const char * Get_Key()	{ return m_namebuf;	}
+		virtual	const char * Get_Key() override { return m_namebuf;	}
 
 		Int init (RenderObjClass *robj);
 		Int initFromHLOD (RenderObjClass *robj);	///<initialize the geometry from a W3D HLOD object.
@@ -3963,9 +3963,9 @@ class MissingGeomClass : public HashableClass {
 
 public:
 	MissingGeomClass( const char * name ) : Name( name ) {}
-	virtual	~MissingGeomClass() {}
+	virtual	~MissingGeomClass() override {}
 
-	virtual	const char * Get_Key()	{ return Name;	}
+	virtual	const char * Get_Key() override { return Name;	}
 
 private:
 	StringClass	Name;

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/Shadow/W3DVolumetricShadow.cpp
@@ -589,7 +589,7 @@ class W3DShadowGeometry : public RefCountClass, public	HashableClass
 	public:
 
 		W3DShadowGeometry() { };
-		~W3DShadowGeometry() override { };
+		virtual ~W3DShadowGeometry() override { };
 
 		virtual	const char * Get_Key() override { return m_namebuf;	}
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DAssetManager.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DAssetManager.cpp
@@ -100,10 +100,10 @@ class W3DPrototypeClass : public MemoryPoolObject, public PrototypeClass
 public:
 	W3DPrototypeClass(RenderObjClass * proto, const AsciiString& name);
 
-	virtual const char*					Get_Name() const			{ return Name.str(); }
-	virtual int									Get_Class_ID() const	{ return Proto->Class_ID(); }
-	virtual RenderObjClass *		Create();
-	virtual void								DeleteSelf()							{	deleteInstance(this); }
+	virtual const char*					Get_Name() const override { return Name.str(); }
+	virtual int									Get_Class_ID() const override { return Proto->Class_ID(); }
+	virtual RenderObjClass *		Create() override;
+	virtual void								DeleteSelf() override							{	deleteInstance(this); }
 
 protected:
 	//virtual ~W3DPrototypeClass();

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameLogic/W3DGhostObject.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameLogic/W3DGhostObject.cpp
@@ -68,9 +68,9 @@ class W3DRenderObjectSnapshot : public Snapshot
 
 protected:
 
-	virtual void crc( Xfer *xfer );
-	virtual void xfer( Xfer *xfer );
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 
 #ifdef DEBUG_FOG_MEMORY
 	const char *m_robjName;		///<debug pointer so we know what this is a snapshot of.


### PR DESCRIPTION
## Summary
- Add `override` keyword to virtual function overrides in GameEngineDevice
- Covers W3DDevice, Win32Device, StdDevice, VideoDevice
- Changes across Core, Generals, and GeneralsMD

## Context
Part 5/6 of splitting #2101. Depends on #2389 merging first.

## Notes
- 113 files changed, purely mechanical `override` keyword additions
- Includes bugfix: remove incorrect `override` from methods without matching virtual base class
- All lines retain the `virtual` keyword