### PR TITLE
bugfix(player): Fix transferred in-progress upgrades

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -1772,6 +1772,10 @@ void Player::transferAssetsFromThat(Player *that)
 	{
 		that->iterateObjects(cancelUpgradeInProduction, (void*)upgradeTemplate);
 	}
+
+	// TheSuperHackers @bugfix Stubbjax 03/02/2026 Ensure the in-progress upgrade mask is copied from 'that'
+	// player to 'this' player to prevent duplicate player upgrades being purchased.
+	m_upgradesInProgress.set(that->m_upgradesInProgress);
 #endif
 
 	std::list<Object *> objsToTransfer;

--- a/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -96,6 +96,7 @@
 #include "GameLogic/Module/SpecialPowerModule.h"
 #include "GameLogic/Module/SupplyTruckAIUpdate.h"
 #include "GameLogic/Module/BattlePlanUpdate.h"
+#include "GameLogic/Module/ProductionUpdate.h"
 #include "GameLogic/VictoryConditions.h"
 
 #include "GameNetwork/GameInfo.h"
@@ -1732,12 +1733,46 @@ void Player::setObjectsEnabled(AsciiString templateTypeToAffect, Bool enable)
 }
 
 //=============================================================================
+static void cancelUpgradeInProduction(Object* obj, void* userData)
+{
+	const UpgradeTemplate* upgradeTemplate = (const UpgradeTemplate*)userData;
+	ProductionUpdateInterface* pui = ProductionUpdate::getProductionUpdateInterfaceFromObject(obj);
+
+	if (pui && pui->isUpgradeInQueue(upgradeTemplate))
+	{
+		pui->cancelUpgrade(upgradeTemplate);
+	}
+}
+
+//=============================================================================
 void Player::transferAssetsFromThat(Player *that)
 {
 	Team *defaultTeam = getDefaultTeam();
 	if (!defaultTeam) {
 		return;
 	}
+
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix Stubbjax 03/02/2026 Cancel any in-progress player upgrades 'that'
+	// player currently has in progress that 'this' player already has in progress or completed.
+	std::vector<const UpgradeTemplate*> upgradesToCancel;
+	for (Upgrade* upgrade = that->m_upgradeList; upgrade; upgrade = upgrade->friend_getNext())
+	{
+		const UpgradeTemplate* upgradeTemplate = upgrade->getTemplate();
+
+		if (upgrade->getStatus() == UPGRADE_STATUS_IN_PRODUCTION
+			&& upgradeTemplate->getUpgradeType() == UPGRADE_TYPE_PLAYER
+			&& (hasUpgradeComplete(upgradeTemplate) || hasUpgradeInProduction(upgradeTemplate)))
+		{
+			upgradesToCancel.push_back(upgradeTemplate);
+		}
+	}
+
+	for (const UpgradeTemplate* upgradeTemplate : upgradesToCancel)
+	{
+		that->iterateObjects(cancelUpgradeInProduction, (void*)upgradeTemplate);
+	}
+#endif
 
 	std::list<Object *> objsToTransfer;
 

--- a/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -1735,7 +1735,7 @@ void Player::setObjectsEnabled(AsciiString templateTypeToAffect, Bool enable)
 //=============================================================================
 static void cancelUpgradeInProduction(Object* obj, void* userData)
 {
-	const UpgradeTemplate* upgradeTemplate = (const UpgradeTemplate*)userData;
+	const UpgradeTemplate* upgradeTemplate = static_cast<const UpgradeTemplate*>(userData);
 	ProductionUpdateInterface* pui = ProductionUpdate::getProductionUpdateInterfaceFromObject(obj);
 
 	if (pui && pui->isUpgradeInQueue(upgradeTemplate))

--- a/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -1771,7 +1771,7 @@ void Player::transferAssetsFromThat(Player *that)
 	for (std::vector<const UpgradeTemplate*>::iterator cancelIt = upgradesToCancel.begin(); cancelIt != upgradesToCancel.end(); ++cancelIt)
 	{
 		const UpgradeTemplate* upgradeTemplate = *cancelIt;
-		that->iterateObjects(cancelUpgradeInProduction, (void*)upgradeTemplate);
+		that->iterateObjects(cancelUpgradeInProduction, const_cast<UpgradeTemplate*>(upgradeTemplate));
 	}
 
 	// TheSuperHackers @bugfix Stubbjax 03/02/2026 Ensure the in-progress upgrade mask is copied from 'that'

--- a/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -1768,8 +1768,9 @@ void Player::transferAssetsFromThat(Player *that)
 		}
 	}
 
-	for (const UpgradeTemplate* upgradeTemplate : upgradesToCancel)
+	for (std::vector<const UpgradeTemplate*>::iterator cancelIt = upgradesToCancel.begin(); cancelIt != upgradesToCancel.end(); ++cancelIt)
 	{
+		const UpgradeTemplate* upgradeTemplate = *cancelIt;
 		that->iterateObjects(cancelUpgradeInProduction, (void*)upgradeTemplate);
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -2156,6 +2156,10 @@ void Player::transferAssetsFromThat(Player *that)
 	{
 		that->iterateObjects(cancelUpgradeInProduction, (void*)upgradeTemplate);
 	}
+
+	// TheSuperHackers @bugfix Stubbjax 03/02/2026 Ensure the in-progress upgrade mask is copied from 'that'
+	// player to 'this' player to prevent duplicate player upgrades being purchased.
+	m_upgradesInProgress.set(that->m_upgradesInProgress);
 #endif
 
 	std::list<Object *> objsToTransfer;

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -2117,12 +2117,46 @@ void Player::setObjectsEnabled(AsciiString templateTypeToAffect, Bool enable)
 }
 
 //=============================================================================
+static void cancelUpgradeInProduction(Object* obj, void* userData)
+{
+	const UpgradeTemplate* upgradeTemplate = (const UpgradeTemplate*)userData;
+	ProductionUpdateInterface* pui = ProductionUpdate::getProductionUpdateInterfaceFromObject(obj);
+
+	if (pui && pui->isUpgradeInQueue(upgradeTemplate))
+	{
+		pui->cancelUpgrade(upgradeTemplate);
+	}
+}
+
+//=============================================================================
 void Player::transferAssetsFromThat(Player *that)
 {
 	Team *defaultTeam = getDefaultTeam();
 	if (!defaultTeam) {
 		return;
 	}
+
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix Stubbjax 03/02/2026 Cancel any in-progress player upgrades 'that'
+	// player currently has in progress that 'this' player already has in progress or completed.
+	std::vector<const UpgradeTemplate*> upgradesToCancel;
+	for (Upgrade* upgrade = that->m_upgradeList; upgrade; upgrade = upgrade->friend_getNext())
+	{
+		const UpgradeTemplate* upgradeTemplate = upgrade->getTemplate();
+
+		if (upgrade->getStatus() == UPGRADE_STATUS_IN_PRODUCTION
+			&& upgradeTemplate->getUpgradeType() == UPGRADE_TYPE_PLAYER
+			&& (hasUpgradeComplete(upgradeTemplate) || hasUpgradeInProduction(upgradeTemplate)))
+		{
+			upgradesToCancel.push_back(upgradeTemplate);
+		}
+	}
+
+	for (const UpgradeTemplate* upgradeTemplate : upgradesToCancel)
+	{
+		that->iterateObjects(cancelUpgradeInProduction, (void*)upgradeTemplate);
+	}
+#endif
 
 	std::list<Object *> objsToTransfer;
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -2119,7 +2119,7 @@ void Player::setObjectsEnabled(AsciiString templateTypeToAffect, Bool enable)
 //=============================================================================
 static void cancelUpgradeInProduction(Object* obj, void* userData)
 {
-	const UpgradeTemplate* upgradeTemplate = (const UpgradeTemplate*)userData;
+	const UpgradeTemplate* upgradeTemplate = static_cast<const UpgradeTemplate*>(userData);
 	ProductionUpdateInterface* pui = ProductionUpdate::getProductionUpdateInterfaceFromObject(obj);
 
 	if (pui && pui->isUpgradeInQueue(upgradeTemplate))

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -2152,8 +2152,9 @@ void Player::transferAssetsFromThat(Player *that)
 		}
 	}
 
-	for (const UpgradeTemplate* upgradeTemplate : upgradesToCancel)
+	for (std::vector<const UpgradeTemplate*>::iterator cancelIt = upgradesToCancel.begin(); cancelIt != upgradesToCancel.end(); ++cancelIt)
 	{
+		const UpgradeTemplate* upgradeTemplate = *cancelIt;
 		that->iterateObjects(cancelUpgradeInProduction, (void*)upgradeTemplate);
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -2155,7 +2155,7 @@ void Player::transferAssetsFromThat(Player *that)
 	for (std::vector<const UpgradeTemplate*>::iterator cancelIt = upgradesToCancel.begin(); cancelIt != upgradesToCancel.end(); ++cancelIt)
 	{
 		const UpgradeTemplate* upgradeTemplate = *cancelIt;
-		that->iterateObjects(cancelUpgradeInProduction, (void*)upgradeTemplate);
+		that->iterateObjects(cancelUpgradeInProduction, const_cast<UpgradeTemplate*>(upgradeTemplate));
 	}
 
 	// TheSuperHackers @bugfix Stubbjax 03/02/2026 Ensure the in-progress upgrade mask is copied from 'that'


### PR DESCRIPTION
This change fixes two issues with in-progress upgrades when they are transferred to another player.

1. If a team mate surrenders, the surviving team mate's `m_upgradesInProgress` mask does not append any of the surrendering player's in-progress upgrades. This incorrectly allows the surviving player to purchase a duplicate instance of any upgrades that the surrendering player had in progress.<p>For example, Bob starts researching Black Napalm and then surrenders. Fred selects a different War Factory and is able to research a new/separate instance of Black Napalm, despite it already being in progress in another War Factory.

2. The second problem arises when it comes to transferring in-progress upgrades that the surviving player already has in progress or completed. Once an upgrade has been completed, any duplicate in-progress upgrades can no longer be cancelled, and attempting to do so leads to strange UI behaviour.<p>For example, Bob starts researching Black Napalm and then surrenders. But Fred already has Black Napalm researched. Fred discovers the second instance of Black Napalm that Bob had begun researching and tries to cancel it, but the upgrade cannot be cancelled.

The solution is to cancel any of the old player's in-progress upgrades if the new player already has them in progress or completed (and the refund is a nice bonus). The `m_upgradesInProgress` mask is also appropriately updated so that the new player cannot purchase any duplicate upgrades that the old player had in progress.

### Before

https://github.com/user-attachments/assets/90f71c01-12ff-421a-b3fb-c475a6b4e72e

### After

https://github.com/user-attachments/assets/1a8b9ba3-ed75-4068-90a2-27dc678c6b35