### PR TITLE
bugfix(productionupdate): Prevent cancelling and refunding a single production entry when a number of its units already finished production

### DIFF
--- a/Generals/Code/GameEngine/Include/GameLogic/Module/ProductionUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/ProductionUpdate.h
@@ -158,7 +158,7 @@ public:
 	virtual UnsignedInt countUnitTypeInQueue( const ThingTemplate *unitType ) const = 0;
 
 	virtual Bool queueCreateUnit( const ThingTemplate *unitType, ProductionID productionID ) = 0;
-	virtual void cancelUnitCreate( ProductionID productionID ) = 0;
+	virtual Bool cancelUnitCreate( ProductionID productionID ) = 0;
 	virtual void cancelAllUnitsOfType( const ThingTemplate *unitType) = 0;
 
 	virtual void cancelAndRefundAllProduction() = 0;
@@ -214,7 +214,7 @@ public:
 	virtual UnsignedInt countUnitTypeInQueue( const ThingTemplate *unitType ) const override;  ///< count number of units with matching unit type in the production queue
 
 	virtual Bool queueCreateUnit( const ThingTemplate *unitType, ProductionID productionID ) override;					///< queue unit to be produced
-	virtual void cancelUnitCreate( ProductionID productionID ) override;		      ///< cancel construction of unit with matching production ID
+	virtual Bool cancelUnitCreate( ProductionID productionID ) override;		      ///< cancel construction of unit with matching production ID
 	virtual void cancelAllUnitsOfType( const ThingTemplate *unitType) override;	///< cancel all production of type unitType
 
 	virtual void cancelAndRefundAllProduction() override;									///< cancel and refund anything in the production queue

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
@@ -458,7 +458,7 @@ Bool ProductionUpdate::queueCreateUnit( const ThingTemplate *unitType, Productio
 //-------------------------------------------------------------------------------------------------
 /** Cancel the construction of the unit with the matching production ID */
 //-------------------------------------------------------------------------------------------------
-void ProductionUpdate::cancelUnitCreate( ProductionID productionID )
+Bool ProductionUpdate::cancelUnitCreate( ProductionID productionID )
 {
 
 	// search for the production entry in our queue
@@ -475,7 +475,7 @@ void ProductionUpdate::cancelUnitCreate( ProductionID productionID )
 #if !RETAIL_COMPATIBLE_CRC
 			// TheSuperHackers @bugfix arcticdolphin 07/09/2026 No cancel once the batch has started producing.
 			if( production->getProductionQuantityRemaining() < production->getProductionQuantity() )
-				return;
+				return FALSE;
 #endif
 
 			// give the player the cost of the object back
@@ -488,11 +488,13 @@ void ProductionUpdate::cancelUnitCreate( ProductionID productionID )
 			// delete the production entry
 			deleteInstance(production);
 
-			return;
+			return TRUE;
 
 		}
 
 	}
+
+	return FALSE;
 
 }
 
@@ -700,21 +702,8 @@ UpdateSleepTime ProductionUpdate::update()
 		// Don't cancel dozers in the queue.  jba.
 		if (!production->getProductionObject()->isKindOf(KINDOF_DOZER))
 		{
-<<<<<<< Updated upstream
-#if RETAIL_COMPATIBLE_CRC
-			cancelUnitCreate(production->getProductionID());
-			return UPDATE_SLEEP_NONE;
-#else
-			// TheSuperHackers @bugfix arcticdolphin 07/09/2026 Only cancel an untouched batch.
-			if( production->getProductionQuantityRemaining() == production->getProductionQuantity() )
-			{
-				cancelUnitCreate(production->getProductionID());
-=======
 			if( cancelUnitCreate(production->getProductionID()) )
->>>>>>> Stashed changes
 				return UPDATE_SLEEP_NONE;
-			}
-#endif
 		}
 
 	}
@@ -1153,7 +1142,6 @@ void ProductionUpdate::cancelAndRefundAllProduction()
   // Empirically, in release the code can loop forever.  So we limit to 100 passes. jba. [8/31/2003]
   const Int productionLimit = 100;// With luck, we never queue up 100 units. [8/31/2003]
 
-  // TheSuperHackers @bugfix arcticdolphin 07/09/2026 Walk entries so a non-cancellable partial batch does not stall the loop.
   Int i = 0;
   ProductionEntry *production = m_productionQueue;
   while( production != nullptr && i < productionLimit )

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
@@ -470,8 +470,15 @@ void ProductionUpdate::cancelUnitCreate( ProductionID productionID )
 		if( production->m_productionID == productionID )
 		{
 
-			// give the player the cost of the object back
 			Player *player = getObject()->getControllingPlayer();
+
+#if !RETAIL_COMPATIBLE_CRC
+			// TheSuperHackers @bugfix arcticdolphin 07/09/2026 No cancel once the batch has started producing.
+			if( production->getProductionQuantityRemaining() < production->getProductionQuantity() )
+				return;
+#endif
+
+			// give the player the cost of the object back
 			Money *money = player->getMoney();
 			money->deposit( production->m_objectToProduce->calcCostToBuild( player ), TRUE, FALSE );
 
@@ -659,7 +666,7 @@ UpdateSleepTime ProductionUpdate::update()
 	// if we've become OBJECT_STATUS_SOLD, halt all production ... leave things in the
 	// queue because if the sell process completes we get money back for them, for now we
 	// will be just frozen in time
-	// Actually, there will be nothing in the queue since everything gets cancel/refunded
+	// Actually, there will usually be nothing in the queue since everything gets cancel/refunded
 	// at the start of sell, but we still don't want to do anything here.
 	//
 	if( us->getStatusBits().test( OBJECT_STATUS_SOLD ) )
@@ -693,10 +700,21 @@ UpdateSleepTime ProductionUpdate::update()
 		// Don't cancel dozers in the queue.  jba.
 		if (!production->getProductionObject()->isKindOf(KINDOF_DOZER))
 		{
-
+<<<<<<< Updated upstream
+#if RETAIL_COMPATIBLE_CRC
 			cancelUnitCreate(production->getProductionID());
 			return UPDATE_SLEEP_NONE;
-
+#else
+			// TheSuperHackers @bugfix arcticdolphin 07/09/2026 Only cancel an untouched batch.
+			if( production->getProductionQuantityRemaining() == production->getProductionQuantity() )
+			{
+				cancelUnitCreate(production->getProductionID());
+=======
+			if( cancelUnitCreate(production->getProductionID()) )
+>>>>>>> Stashed changes
+				return UPDATE_SLEEP_NONE;
+			}
+#endif
 		}
 
 	}
@@ -1134,24 +1152,28 @@ void ProductionUpdate::cancelAndRefundAllProduction()
 {
   // Empirically, in release the code can loop forever.  So we limit to 100 passes. jba. [8/31/2003]
   const Int productionLimit = 100;// With luck, we never queue up 100 units. [8/31/2003]
-  Int i;
-  for (i=0; i<productionLimit; i++)
+
+  // TheSuperHackers @bugfix arcticdolphin 07/09/2026 Walk entries so a non-cancellable partial batch does not stall the loop.
+  Int i = 0;
+  ProductionEntry *production = m_productionQueue;
+  while( production != nullptr && i < productionLimit )
   {
-    // iterate through our production queue
-    if( m_productionQueue )
+    ProductionEntry *nextProduction = production->m_next;
+
+    if( production->getProductionType() == PRODUCTION_UNIT )
+      cancelUnitCreate( production->getProductionID() );
+    else if( production->getProductionType() == PRODUCTION_UPGRADE )
+      cancelUpgrade( production->getProductionUpgrade() );
+    else
     {
-      if( m_productionQueue->getProductionType() == PRODUCTION_UNIT )
-        cancelUnitCreate( m_productionQueue->getProductionID() );
-      else if( m_productionQueue->getProductionType() == PRODUCTION_UPGRADE )
-        cancelUpgrade( m_productionQueue->getProductionUpgrade() );
-      else
-      {
-        // unknown production type
-        DEBUG_CRASH(( "ProductionUpdate::cancelAndRefundAllProduction - Unknown production type '%d'",
-                      m_productionQueue->getProductionType() ));
-        return;
-      }
+      // unknown production type
+      DEBUG_CRASH(( "ProductionUpdate::cancelAndRefundAllProduction - Unknown production type '%d'",
+                    production->getProductionType() ));
+      return;
     }
+
+    production = nextProduction;
+    ++i;
   }
 }
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
@@ -1149,7 +1149,13 @@ void ProductionUpdate::cancelAndRefundAllProduction()
     ProductionEntry *nextProduction = production->m_next;
 
     if( production->getProductionType() == PRODUCTION_UNIT )
-      cancelUnitCreate( production->getProductionID() );
+    {
+      if( !cancelUnitCreate( production->getProductionID() ) )
+      {
+        removeFromProductionQueue( production );
+        deleteInstance( production );
+      }
+    }
     else if( production->getProductionType() == PRODUCTION_UPGRADE )
       cancelUpgrade( production->getProductionUpgrade() );
     else

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ProductionUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ProductionUpdate.h
@@ -158,7 +158,7 @@ public:
 	virtual UnsignedInt countUnitTypeInQueue( const ThingTemplate *unitType ) const = 0;
 
 	virtual Bool queueCreateUnit( const ThingTemplate *unitType, ProductionID productionID ) = 0;
-	virtual void cancelUnitCreate( ProductionID productionID ) = 0;
+	virtual Bool cancelUnitCreate( ProductionID productionID ) = 0;
 	virtual void cancelAllUnitsOfType( const ThingTemplate *unitType) = 0;
 
 	virtual void cancelAndRefundAllProduction() = 0;
@@ -214,7 +214,7 @@ public:
 	virtual UnsignedInt countUnitTypeInQueue( const ThingTemplate *unitType ) const override;  ///< count number of units with matching unit type in the production queue
 
 	virtual Bool queueCreateUnit( const ThingTemplate *unitType, ProductionID productionID ) override;					///< queue unit to be produced
-	virtual void cancelUnitCreate( ProductionID productionID ) override;		      ///< cancel construction of unit with matching production ID
+	virtual Bool cancelUnitCreate( ProductionID productionID ) override;		      ///< cancel construction of unit with matching production ID
 	virtual void cancelAllUnitsOfType( const ThingTemplate *unitType) override;	///< cancel all production of type unitType
 
 	virtual void cancelAndRefundAllProduction() override;									///< cancel and refund anything in the production queue

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
@@ -1153,7 +1153,13 @@ void ProductionUpdate::cancelAndRefundAllProduction()
 		ProductionEntry *nextProduction = production->m_next;
 
 		if( production->getProductionType() == PRODUCTION_UNIT )
-			cancelUnitCreate( production->getProductionID() );
+		{
+			if( !cancelUnitCreate( production->getProductionID() ) )
+			{
+				removeFromProductionQueue( production );
+				deleteInstance( production );
+			}
+		}
 		else if( production->getProductionType() == PRODUCTION_UPGRADE )
 			cancelUpgrade( production->getProductionUpgrade() );
 		else

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
@@ -470,8 +470,15 @@ void ProductionUpdate::cancelUnitCreate( ProductionID productionID )
 		if( production->m_productionID == productionID )
 		{
 
-			// give the player the cost of the object back
 			Player *player = getObject()->getControllingPlayer();
+
+#if !RETAIL_COMPATIBLE_CRC
+			// TheSuperHackers @bugfix arcticdolphin 07/09/2026 No cancel once the batch has started producing.
+			if( production->getProductionQuantityRemaining() < production->getProductionQuantity() )
+				return;
+#endif
+
+			// give the player the cost of the object back
 			Money *money = player->getMoney();
 			money->deposit( production->m_objectToProduce->calcCostToBuild( player ), TRUE, FALSE );
 
@@ -659,7 +666,7 @@ UpdateSleepTime ProductionUpdate::update()
 	// if we've become OBJECT_STATUS_SOLD, halt all production ... leave things in the
 	// queue because if the sell process completes we get money back for them, for now we
 	// will be just frozen in time
-	// Actually, there will be nothing in the queue since everything gets cancel/refunded
+	// Actually, there will usually be nothing in the queue since everything gets cancel/refunded
 	// at the start of sell, but we still don't want to do anything here.
 	//
 	if( us->getStatusBits().test( OBJECT_STATUS_SOLD ) )
@@ -693,10 +700,21 @@ UpdateSleepTime ProductionUpdate::update()
 		// Don't cancel dozers in the queue.  jba.
 		if (!production->getProductionObject()->isKindOf(KINDOF_DOZER))
 		{
-
+<<<<<<< Updated upstream
+#if RETAIL_COMPATIBLE_CRC
 			cancelUnitCreate(production->getProductionID());
 			return UPDATE_SLEEP_NONE;
-
+#else
+			// TheSuperHackers @bugfix arcticdolphin 07/09/2026 Only cancel an untouched batch.
+			if( production->getProductionQuantityRemaining() == production->getProductionQuantity() )
+			{
+				cancelUnitCreate(production->getProductionID());
+=======
+			if( cancelUnitCreate(production->getProductionID()) )
+>>>>>>> Stashed changes
+				return UPDATE_SLEEP_NONE;
+			}
+#endif
 		}
 
 	}
@@ -1138,23 +1156,27 @@ void ProductionUpdate::cancelAndRefundAllProduction()
 {
 	// Empirically, in release the code can loop forever.  So we limit to 100 passes. jba. [8/31/2003]
 	const Int productionLimit = 100;// With luck, we never queue up 100 units. [8/31/2003]
-	Int i;
-	for (i=0; i<productionLimit; i++)
+
+	// TheSuperHackers @bugfix arcticdolphin 07/09/2026 Walk entries so a non-cancellable partial batch does not stall the loop.
+	Int i = 0;
+	ProductionEntry *production = m_productionQueue;
+	while( production != nullptr && i < productionLimit )
 	{
-		// iterate through our production queue
-		if( m_productionQueue )
+		ProductionEntry *nextProduction = production->m_next;
+
+		if( production->getProductionType() == PRODUCTION_UNIT )
+			cancelUnitCreate( production->getProductionID() );
+		else if( production->getProductionType() == PRODUCTION_UPGRADE )
+			cancelUpgrade( production->getProductionUpgrade() );
+		else
 		{
-			if( m_productionQueue->getProductionType() == PRODUCTION_UNIT )
-				cancelUnitCreate( m_productionQueue->getProductionID() );
-			else if( m_productionQueue->getProductionType() == PRODUCTION_UPGRADE )
-				cancelUpgrade( m_productionQueue->getProductionUpgrade() );
-			else
-			{
-				// unknown production type
-				DEBUG_CRASH(( "ProductionUpdate::cancelAndRefundAllProduction - Unknown production type '%d'", m_productionQueue->getProductionType() ));
-				return;
-			}
+			// unknown production type
+			DEBUG_CRASH(( "ProductionUpdate::cancelAndRefundAllProduction - Unknown production type '%d'", production->getProductionType() ));
+			return;
 		}
+
+		production = nextProduction;
+		++i;
 	}
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
@@ -458,7 +458,7 @@ Bool ProductionUpdate::queueCreateUnit( const ThingTemplate *unitType, Productio
 //-------------------------------------------------------------------------------------------------
 /** Cancel the construction of the unit with the matching production ID */
 //-------------------------------------------------------------------------------------------------
-void ProductionUpdate::cancelUnitCreate( ProductionID productionID )
+Bool ProductionUpdate::cancelUnitCreate( ProductionID productionID )
 {
 
 	// search for the production entry in our queue
@@ -475,7 +475,7 @@ void ProductionUpdate::cancelUnitCreate( ProductionID productionID )
 #if !RETAIL_COMPATIBLE_CRC
 			// TheSuperHackers @bugfix arcticdolphin 07/09/2026 No cancel once the batch has started producing.
 			if( production->getProductionQuantityRemaining() < production->getProductionQuantity() )
-				return;
+				return FALSE;
 #endif
 
 			// give the player the cost of the object back
@@ -488,11 +488,13 @@ void ProductionUpdate::cancelUnitCreate( ProductionID productionID )
 			// delete the production entry
 			deleteInstance(production);
 
-			return;
+			return TRUE;
 
 		}
 
 	}
+
+	return FALSE;
 
 }
 
@@ -700,21 +702,8 @@ UpdateSleepTime ProductionUpdate::update()
 		// Don't cancel dozers in the queue.  jba.
 		if (!production->getProductionObject()->isKindOf(KINDOF_DOZER))
 		{
-<<<<<<< Updated upstream
-#if RETAIL_COMPATIBLE_CRC
-			cancelUnitCreate(production->getProductionID());
-			return UPDATE_SLEEP_NONE;
-#else
-			// TheSuperHackers @bugfix arcticdolphin 07/09/2026 Only cancel an untouched batch.
-			if( production->getProductionQuantityRemaining() == production->getProductionQuantity() )
-			{
-				cancelUnitCreate(production->getProductionID());
-=======
 			if( cancelUnitCreate(production->getProductionID()) )
->>>>>>> Stashed changes
 				return UPDATE_SLEEP_NONE;
-			}
-#endif
 		}
 
 	}
@@ -1157,7 +1146,6 @@ void ProductionUpdate::cancelAndRefundAllProduction()
 	// Empirically, in release the code can loop forever.  So we limit to 100 passes. jba. [8/31/2003]
 	const Int productionLimit = 100;// With luck, we never queue up 100 units. [8/31/2003]
 
-	// TheSuperHackers @bugfix arcticdolphin 07/09/2026 Walk entries so a non-cancellable partial batch does not stall the loop.
 	Int i = 0;
 	ProductionEntry *production = m_productionQueue;
 	while( production != nullptr && i < productionLimit )


### PR DESCRIPTION
This pull request updates the logic for refunding player resources when canceling unit production, addressing a bug where players could receive a refund even after some units had already been produced.

Resolves #133 (China Red Guard can be built for free when construction is cancelled in last moment)

Once any unit of a batch has been produced you can no longer cancel it. If nothing has been produced yet, cancelling still refunds the full cost like before.

Other cases:

- If the building is sold or destroyed, a batch that has not started yet is still refunded. A batch that already started is just dropped with no refund.
- If a script disallows the unit while a batch is running, a batch that has not started is cancelled and refunded. A batch that already started is left to finish.

I also changed `cancelAndRefundAllProduction` to walk the queue one entry at a time. The old loop kept retrying the first entry, and now that a started batch cannot be cancelled that loop would get stuck on it.

## Before:

https://github.com/user-attachments/assets/f8ab283e-723c-47a1-b0bf-d37d50cda689

## After :

https://github.com/user-attachments/assets/13474a28-afec-40f7-a656-2e6324b72134