### PR TITLE
bugfix(gunship): Select Spectre Gunship only on the client that controls the unit

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpectreGunshipDeploymentUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpectreGunshipDeploymentUpdate.cpp
@@ -235,8 +235,8 @@ Bool SpectreGunshipDeploymentUpdate::initiateIntentToDoSpecialPower(const Specia
 	  }
 
     // MAKE THE GUNSHIP SELECTED
-
-    TheGameLogic->selectObject( newGunship, TRUE, getObject()->getControllingPlayer()->getPlayerMask(), TRUE );
+    // TheSuperHackers @bugfix arcticdolphin 04/03/2026 Only select the gunship on the local client that controls the unit.
+    TheGameLogic->selectObject( newGunship, TRUE, getObject()->getControllingPlayer()->getPlayerMask(), newGunship->isLocallyControlled() );
 
 
   }


### PR DESCRIPTION
This pull request fixes the gunship selection logic to only select on the client that controls the unit instead of all clients.

Closes #19 