### PR TITLE
fix(logic): Improve handling of ENABLE_RETALIATION_MODE in GameLogicDispatch

### DIFF
--- a/GeneralsMD/Code/GameEngine/Include/Common/MessageStream.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/MessageStream.h
@@ -600,7 +600,7 @@ public:
 		MSG_CREATE_FORMATION,												///< Creates a formation.
 		MSG_LOGIC_CRC,															///< CRC from the logic passed around in a network game :)
 		MSG_SET_MINE_CLEARING_DETAIL,								///< CRC from the logic passed around in a network game :)
-		MSG_ENABLE_RETALIATION_MODE,								///< Turn retaliation mode on or off for the specified player.
+		MSG_ENABLE_RETALIATION_MODE,								///< Turn retaliation mode on or off.
 
 		MSG_BEGIN_DEBUG_NETWORK_MESSAGES = 1900,		///< network messages that exist only in debug/internal builds. all grouped separately.
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -707,7 +707,9 @@ void Player::update()
 				GameMessage *msg = TheMessageStream->appendMessage( GameMessage::MSG_ENABLE_RETALIATION_MODE );
 				if( msg )
 				{
+#if RETAIL_COMPATIBLE_CRC
 					msg->appendIntegerArgument( getPlayerIndex() );
+#endif
 					msg->appendBooleanArgument( TheGlobalData->m_clientRetaliationModeEnabled );
 				}
 			}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -634,9 +634,9 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 		{
 #if RETAIL_COMPATIBLE_CRC
 			// TheSuperHackers @info The first argument is unused.
-			Bool enableRetaliation = msg->getArgument( 1 )->boolean;
+			const Bool enableRetaliation = msg->getArgument( 1 )->boolean;
 #else
-			Bool enableRetaliation = msg->getArgument( 0 )->boolean;
+			const Bool enableRetaliation = msg->getArgument( 0 )->boolean;
 #endif
 			thisPlayer->setLogicalRetaliationModeEnabled( enableRetaliation );
 			break;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -632,8 +632,12 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 
 		case GameMessage::MSG_ENABLE_RETALIATION_MODE:
 		{
+#if RETAIL_COMPATIBLE_CRC
 			// TheSuperHackers @info The first argument is unused.
 			Bool enableRetaliation = msg->getArgument( 1 )->boolean;
+#else
+			Bool enableRetaliation = msg->getArgument( 0 )->boolean;
+#endif
 			thisPlayer->setLogicalRetaliationModeEnabled( enableRetaliation );
 			break;
 		}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -632,15 +632,9 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 
 		case GameMessage::MSG_ENABLE_RETALIATION_MODE:
 		{
-			//Logically turns on or off retaliation mode for a specified player.
-			Int playerIndex = msg->getArgument( 0 )->integer;
+			// TheSuperHackers @info The first argument is unused.
 			Bool enableRetaliation = msg->getArgument( 1 )->boolean;
-
-			Player *player = ThePlayerList->getNthPlayer( playerIndex );
-			if( player )
-			{
-				player->setLogicalRetaliationModeEnabled( enableRetaliation );
-			}
+			thisPlayer->setLogicalRetaliationModeEnabled( enableRetaliation );
 			break;
 		}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -633,12 +633,25 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 		case GameMessage::MSG_ENABLE_RETALIATION_MODE:
 		{
 #if RETAIL_COMPATIBLE_CRC
-			// TheSuperHackers @info The first argument is unused.
+			//Logically turns on or off retaliation mode for a specified player.
+			const Int playerIndex = msg->getArgument( 0 )->integer;
 			const Bool enableRetaliation = msg->getArgument( 1 )->boolean;
+
+			Player *player = ThePlayerList->getNthPlayer( playerIndex );
+			if( player )
+			{
+				DEBUG_ASSERTCRASH(player == thisPlayer,
+					("Retaliation mode of player '%ls' was illegally set by player '%ls'. Before: '%d', after: '%d'.",
+						player->getPlayerDisplayName().str(), thisPlayer->getPlayerDisplayName().str(),
+						player->isLogicalRetaliationModeEnabled(), enableRetaliation) );
+
+				player->setLogicalRetaliationModeEnabled( enableRetaliation );
+			}
 #else
+			// TheSuperHackers @fix stephanmeesters 08/03/2026 Ensure that players can only set their own retaliation mode.
 			const Bool enableRetaliation = msg->getArgument( 0 )->boolean;
-#endif
 			thisPlayer->setLogicalRetaliationModeEnabled( enableRetaliation );
+#endif
 			break;
 		}
 


### PR DESCRIPTION
Simplifies the code and prevents other players from setting each others retaliation mode. Tested with 1k replays and with own replay where I swap the retaliation mode on both sides couple times and test with some combat.

Generals (not Zero Hour) does not have a retaliation mode

Null check of `thisPlayer` will be handled by #2383