### PR TITLE
bugfix(object): Guard GameLogic xfer version bump with RETAIL_COMPATIBLE_XFER_SAVE

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -4244,14 +4244,18 @@ void GameLogic::prepareLogicForObjectLoad()
 	*		 this version breaks compatibility with previous versions. (CBD)
 	* 5: Added xfering the BuildAssistant's sell list.
 	* 9: Added m_rankPointsToAddAtGameStart, or else on a load game, your RestartGame button will forget your exp
-	* 10: TheSuperHackers @tweak Save objects in reverse order so they load in correct order. Reverse object list for old saves.
+	* 10: TheSuperHackers @fix Save objects in reverse order so they load in correct order
 	*/
 // ------------------------------------------------------------------------------------------------
 void GameLogic::xfer( Xfer *xfer )
 {
 
 	// version
+#if RETAIL_COMPATIBLE_XFER_SAVE
+	const XferVersion currentVersion = 9;
+#else
 	const XferVersion currentVersion = 10;
+#endif
 	XferVersion version = currentVersion;
 	xfer->xferVersion( &version, currentVersion );
 
@@ -4284,14 +4288,17 @@ void GameLogic::xfer( Xfer *xfer )
 	ObjectTOCEntry *tocEntry;
 	if( xfer->getXferMode() == XFER_SAVE )
 	{
-
-		// TheSuperHackers @fix bobtista 27/01/2026 Save objects in reverse order (newest first)
+#if !RETAIL_COMPATIBLE_XFER_SAVE
+		// TheSuperHackers @fix bobtista 07/03/2026 Save objects in reverse order (newest first)
 		// so they load in the correct order (oldest objects at head of list).
 		Object *lastObj = nullptr;
 		for( obj = getFirstObject(); obj; obj = obj->getNextObject() )
 			lastObj = obj;
 
 		for( obj = lastObj; obj; obj = obj->getPrevObject() )
+#else
+		for( obj = getFirstObject(); obj; obj = obj->getNextObject() )
+#endif
 		{
 
 			// get the object TOC entry for this template
@@ -4374,9 +4381,9 @@ void GameLogic::xfer( Xfer *xfer )
 
 		}
 
-		// TheSuperHackers @fix bobtista 27/01/2026 Reverse object list for old saves.
-		// Old saves stored objects oldest-first, which results in reversed order when loaded
-		// since objects are prepended during creation. Version 10+ saves in reverse order.
+		// TheSuperHackers @fix bobtista 07/03/2026 Reverse object list after load.
+		// Objects are prepended during creation, which reverses the saved order.
+		// Version 10+ saves in reverse order so they load in the correct order.
 		if ( version <= 9 )
 		{
 			Object *prev = nullptr;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -4804,14 +4804,18 @@ void GameLogic::prepareLogicForObjectLoad()
 	* 5: Added xfering the BuildAssistant's sell list.
 	* 9: Added m_rankPointsToAddAtGameStart, or else on a load game, your RestartGame button will forget your exp
   * 10: xfer m_superweaponRestriction
-  * 11: TheSuperHackers @tweak Save objects in reverse order so they load in correct order
+  * 11: TheSuperHackers @fix Save objects in reverse order so they load in correct order
 	*/
 // ------------------------------------------------------------------------------------------------
 void GameLogic::xfer( Xfer *xfer )
 {
 
 	// version
+#if RETAIL_COMPATIBLE_XFER_SAVE
+	const XferVersion currentVersion = 10;
+#else
 	const XferVersion currentVersion = 11;
+#endif
 	XferVersion version = currentVersion;
 	xfer->xferVersion( &version, currentVersion );
 
@@ -4844,13 +4848,17 @@ void GameLogic::xfer( Xfer *xfer )
 	ObjectTOCEntry *tocEntry;
 	if( xfer->getXferMode() == XFER_SAVE )
 	{
-		// TheSuperHackers @fix bobtista 27/01/2026 Save objects in reverse order (newest first)
+#if !RETAIL_COMPATIBLE_XFER_SAVE
+		// TheSuperHackers @fix bobtista 07/03/2026 Save objects in reverse order (newest first)
 		// so they load in the correct order (oldest objects at head of list).
 		Object *lastObj = nullptr;
 		for( obj = getFirstObject(); obj; obj = obj->getNextObject() )
 			lastObj = obj;
 
 		for( obj = lastObj; obj; obj = obj->getPrevObject() )
+#else
+		for( obj = getFirstObject(); obj; obj = obj->getNextObject() )
+#endif
 		{
 
 			// get the object TOC entry for this template
@@ -4933,9 +4941,9 @@ void GameLogic::xfer( Xfer *xfer )
 
 		}
 
-		// TheSuperHackers @fix bobtista 27/01/2026 Reverse object list for old saves.
-		// Old saves stored objects oldest-first, which results in reversed order when loaded
-		// since objects are prepended during creation. Version 11+ saves in reverse order.
+		// TheSuperHackers @fix bobtista 07/03/2026 Reverse object list after load.
+		// Objects are prepended during creation, which reverses the saved order.
+		// Version 11+ saves in reverse order so they load in the correct order.
 		if ( version <= 10 )
 		{
 			Object *prev = nullptr;


### PR DESCRIPTION
## Summary
- Guards the xfer version bump in GameLogic::xfer behind `RETAIL_COMPATIBLE_XFER_SAVE`, replacing the unconditional bump from #2161
- When retail compatible: keeps original version (10 for GeneralsMD, 9 for Generals), saves objects in forward order, and always reverses the object list after load to fix the prepend-induced reversal
- When not retail compatible: bumps the version (11 for GeneralsMD, 10 for Generals), saves objects in reverse order so they load in correct order without post-load fixup

## Test plan
- [x] Save and load a game, verify object list order is correct
- [x] Load a pre-existing save file, verify it loads without error and object order is correct