### PR TITLE
fix(lookat): Fix mouse anchor and direction issue for camera pitch

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -295,8 +295,8 @@ void W3DView::buildCameraPosition( Vector3& sourcePos, Vector3& targetPos )
 	// construct a matrix to rotate around the up vector by the given angle
 	const Matrix3D angleTransform( Vector3( 0.0f, 0.0f, 1.0f ), angle );
 
-	// construct a matrix to rotate around the horizontal vector by the given angle
-	const Matrix3D pitchTransform( Vector3( 1.0f, 0.0f, 0.0f ), pitch );
+	// construct a matrix to rotate around the left vector by the given angle
+	const Matrix3D pitchTransform( Vector3( -1.0f, 0.0f, 0.0f ), pitch );
 
 	// rotate camera position (pitch, then angle)
 #ifdef ALLOW_TEMPORARIES

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
@@ -382,7 +382,7 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 			{
 				constexpr const Real Scale = 0.01f;
 				const Real angle = Scale * (m_currentPos.y - m_anchor.y);
-				TheTacticalView->userSetPitch( TheTacticalView->getPitch() + angle );
+				TheTacticalView->userSetPitch( TheTacticalView->getPitch() - angle );
 				m_anchor = msg->getArgument( 0 )->pixel;
 			}
 
@@ -547,6 +547,7 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 		{
 			DEBUG_ASSERTCRASH(!m_isPitching, ("hmm, mismatched m_isPitching"));
 			m_isPitching = true;
+			m_anchor = m_currentPos;
 			disp = DESTROY_MESSAGE;
 			break;
 		}
@@ -602,6 +603,7 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 			//DEBUG_ASSERTCRASH(!m_isChangingFOV, ("hmm, mismatched m_isChangingFOV"));
 			m_isChangingFOV = true;
 			m_anchor = m_currentPos;
+			disp = DESTROY_MESSAGE;
 			break;
 		}
 #endif // #if defined(RTS_DEBUG)
@@ -612,6 +614,7 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 		{
 		//	DEBUG_ASSERTCRASH(m_isChangingFOV, ("hmm, mismatched m_isChangingFOV"));
 			m_isChangingFOV = false;
+			disp = DESTROY_MESSAGE;
 			break;
 		}
 #endif // #if defined(RTS_DEBUG)


### PR DESCRIPTION
This change fixes the mouse anchor and direction issue for the camera pitch.

The camera can be pitched in Debug with the Comma key.