### PR TITLE
feat(texturefilter): Extend texture filtering to support; none, point, bilinear, trilinear and anisotropic filtering

### DIFF
--- a/Core/Libraries/Source/WWVegas/WW3D2/texturefilter.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/texturefilter.cpp
@@ -104,58 +104,148 @@ void TextureFilterClass::_Init_Filters(TextureFilterMode filter_type)
 {
 	const D3DCAPS8& dx8caps=DX8Wrapper::Get_Current_Caps()->Get_DX8_Caps();
 
+	// TheSuperHackers @info Init zero stage filter defaults, point filtering is the lowest type for non mip filtering
 	_MinTextureFilters[0][FILTER_TYPE_NONE]=D3DTEXF_POINT;
 	_MagTextureFilters[0][FILTER_TYPE_NONE]=D3DTEXF_POINT;
 	_MipMapFilters[0][FILTER_TYPE_NONE]=D3DTEXF_NONE;
 
+	// Bilinear
 	_MinTextureFilters[0][FILTER_TYPE_FAST]=D3DTEXF_LINEAR;
 	_MagTextureFilters[0][FILTER_TYPE_FAST]=D3DTEXF_LINEAR;
 	_MipMapFilters[0][FILTER_TYPE_FAST]=D3DTEXF_POINT;
 
-	_MagTextureFilters[0][FILTER_TYPE_BEST]=D3DTEXF_POINT;
-	_MinTextureFilters[0][FILTER_TYPE_BEST]=D3DTEXF_POINT;
-	_MipMapFilters[0][FILTER_TYPE_BEST]=D3DTEXF_POINT;
+	// Anisotropic - MipMap interlayer filtering only goes up to linear
+	_MinTextureFilters[0][FILTER_TYPE_BEST]=D3DTEXF_ANISOTROPIC;
+	_MagTextureFilters[0][FILTER_TYPE_BEST]=D3DTEXF_ANISOTROPIC;
+	_MipMapFilters[0][FILTER_TYPE_BEST]=D3DTEXF_LINEAR;
 
-	if (dx8caps.TextureFilterCaps&D3DPTFILTERCAPS_MAGFLINEAR) _MagTextureFilters[0][FILTER_TYPE_BEST]=D3DTEXF_LINEAR;
-	if (dx8caps.TextureFilterCaps&D3DPTFILTERCAPS_MINFLINEAR) _MinTextureFilters[0][FILTER_TYPE_BEST]=D3DTEXF_LINEAR;
+	// TheSuperHackers @feature Mauller 08/03/2026 Add full support for all texture filtering modes;
+	// None, Point, Bilinear, Trilinear, Anisotropic.
+	BOOL FilterSupported = false;
+	switch (filter_type) {
 
-	// Set anisotropic filtering only if requested and available
-	if (filter_type==TEXTURE_FILTER_ANISOTROPIC) {
-		if (dx8caps.TextureFilterCaps&D3DPTFILTERCAPS_MAGFANISOTROPIC) _MagTextureFilters[0][FILTER_TYPE_BEST]=D3DTEXF_ANISOTROPIC;
-		if (dx8caps.TextureFilterCaps&D3DPTFILTERCAPS_MINFANISOTROPIC) _MinTextureFilters[0][FILTER_TYPE_BEST]=D3DTEXF_ANISOTROPIC;
+	default:
+		// TheSuperHackers @info if we have an invalid filter_type, set the filtering to none
+		DEBUG_CRASH(("Invalid filter type passed into TextureFilterClass::_Init_Filters()"));
+		FALLTHROUGH;
+
+	case TEXTURE_FILTER_NONE:
+
+		_MinTextureFilters[0][FILTER_TYPE_FAST]=D3DTEXF_POINT;
+		_MagTextureFilters[0][FILTER_TYPE_FAST]=D3DTEXF_POINT;
+		_MipMapFilters[0][FILTER_TYPE_FAST]=D3DTEXF_NONE;
+
+		_MinTextureFilters[0][FILTER_TYPE_BEST]=D3DTEXF_POINT;
+		_MagTextureFilters[0][FILTER_TYPE_BEST]=D3DTEXF_POINT;
+		_MipMapFilters[0][FILTER_TYPE_BEST]=D3DTEXF_NONE;
+		break;
+
+	case TEXTURE_FILTER_POINT:
+
+		_MinTextureFilters[0][FILTER_TYPE_FAST]=D3DTEXF_POINT;
+		_MagTextureFilters[0][FILTER_TYPE_FAST]=D3DTEXF_POINT;
+		_MipMapFilters[0][FILTER_TYPE_FAST]=D3DTEXF_POINT;
+
+		_MinTextureFilters[0][FILTER_TYPE_BEST]=D3DTEXF_POINT;
+		_MagTextureFilters[0][FILTER_TYPE_BEST]=D3DTEXF_POINT;
+		_MipMapFilters[0][FILTER_TYPE_BEST]=D3DTEXF_POINT;
+		break;
+
+	case TEXTURE_FILTER_BILINEAR:
+
+		FilterSupported = (dx8caps.TextureFilterCaps & D3DPTFILTERCAPS_MINFLINEAR) &&
+			(dx8caps.TextureFilterCaps & D3DPTFILTERCAPS_MAGFLINEAR);
+
+		if (FilterSupported) {
+			_MinTextureFilters[0][FILTER_TYPE_BEST]=D3DTEXF_LINEAR;
+			_MagTextureFilters[0][FILTER_TYPE_BEST]=D3DTEXF_LINEAR;
+		}
+		else {
+			_MinTextureFilters[0][FILTER_TYPE_BEST]=D3DTEXF_POINT;
+			_MagTextureFilters[0][FILTER_TYPE_BEST]=D3DTEXF_POINT;
+		}
+
+		_MipMapFilters[0][FILTER_TYPE_BEST]=D3DTEXF_POINT;
+		break;
+
+	case TEXTURE_FILTER_TRILINEAR:
+
+		FilterSupported = (dx8caps.TextureFilterCaps & D3DPTFILTERCAPS_MINFLINEAR) &&
+			(dx8caps.TextureFilterCaps & D3DPTFILTERCAPS_MAGFLINEAR);
+
+		if (FilterSupported) {
+			_MinTextureFilters[0][FILTER_TYPE_BEST]=D3DTEXF_LINEAR;
+			_MagTextureFilters[0][FILTER_TYPE_BEST]=D3DTEXF_LINEAR;
+		}
+		else {
+			_MinTextureFilters[0][FILTER_TYPE_BEST]=D3DTEXF_POINT;
+			_MagTextureFilters[0][FILTER_TYPE_BEST]=D3DTEXF_POINT;
+		}
+
+		if (dx8caps.TextureFilterCaps & D3DPTFILTERCAPS_MIPFLINEAR) {
+			_MipMapFilters[0][FILTER_TYPE_BEST]=D3DTEXF_LINEAR;
+		}
+		else {
+			// TheSuperHackers @info if only linear mipmap filtering is unsupported,
+			// Trilinear filtering becomes Bilinear filtering by default
+			_MipMapFilters[0][FILTER_TYPE_BEST]=D3DTEXF_POINT;
+		}
+		break;
+
+	case TEXTURE_FILTER_ANISOTROPIC:
+
+		FilterSupported = (dx8caps.TextureFilterCaps & D3DPTFILTERCAPS_MAGFANISOTROPIC) &&
+			(dx8caps.TextureFilterCaps & D3DPTFILTERCAPS_MINFANISOTROPIC);
+
+		if (FilterSupported) {
+			_MinTextureFilters[0][FILTER_TYPE_BEST]=D3DTEXF_ANISOTROPIC;
+			_MagTextureFilters[0][FILTER_TYPE_BEST]=D3DTEXF_ANISOTROPIC;
+
+			// Set the Anisotropic filtering level for all stages - 2X by default
+			_Set_Max_Anisotropy(TEXTURE_FILTER_ANISOTROPIC_2X);
+		}
+		else {
+			_MinTextureFilters[0][FILTER_TYPE_BEST]=D3DTEXF_POINT;
+			_MagTextureFilters[0][FILTER_TYPE_BEST]=D3DTEXF_POINT;
+		}
+
+		if (dx8caps.TextureFilterCaps & D3DPTFILTERCAPS_MIPFLINEAR) {
+			_MipMapFilters[0][FILTER_TYPE_BEST]=D3DTEXF_LINEAR;
+		}
+		else {
+			_MipMapFilters[0][FILTER_TYPE_BEST]=D3DTEXF_POINT;
+		}
+		break;
+
 	}
 
-	// Set linear mip filter only if requested trilinear or anisotropic, and linear available
-	if (filter_type==TEXTURE_FILTER_ANISOTROPIC || filter_type==TEXTURE_FILTER_TRILINEAR) {
-		if (dx8caps.TextureFilterCaps&D3DPTFILTERCAPS_MIPFLINEAR) _MipMapFilters[0][FILTER_TYPE_BEST]=D3DTEXF_LINEAR;
-	}
 
-	// For stages above zero, set best filter to the same as the stage zero, except if anisotropic
+	// For stages above zero, set best filter to the same as the stage zero
 	int i=1;
 	for (;i<MAX_TEXTURE_STAGES;++i) {
-		_MinTextureFilters[i][FILTER_TYPE_NONE]=_MinTextureFilters[i-1][FILTER_TYPE_NONE];
-		_MagTextureFilters[i][FILTER_TYPE_NONE]=_MagTextureFilters[i-1][FILTER_TYPE_NONE];
-		_MipMapFilters[i][FILTER_TYPE_NONE]=_MipMapFilters[i-1][FILTER_TYPE_NONE];
+		_MinTextureFilters[i][FILTER_TYPE_NONE]=_MinTextureFilters[0][FILTER_TYPE_NONE];
+		_MagTextureFilters[i][FILTER_TYPE_NONE]=_MagTextureFilters[0][FILTER_TYPE_NONE];
+		_MipMapFilters[i][FILTER_TYPE_NONE]=_MipMapFilters[0][FILTER_TYPE_NONE];
 
-		_MinTextureFilters[i][FILTER_TYPE_FAST]=_MinTextureFilters[i-1][FILTER_TYPE_FAST];
-		_MagTextureFilters[i][FILTER_TYPE_FAST]=_MagTextureFilters[i-1][FILTER_TYPE_FAST];
-		_MipMapFilters[i][FILTER_TYPE_FAST]=_MipMapFilters[i-1][FILTER_TYPE_FAST];
+		_MinTextureFilters[i][FILTER_TYPE_FAST]=_MinTextureFilters[0][FILTER_TYPE_FAST];
+		_MagTextureFilters[i][FILTER_TYPE_FAST]=_MagTextureFilters[0][FILTER_TYPE_FAST];
+		_MipMapFilters[i][FILTER_TYPE_FAST]=_MipMapFilters[0][FILTER_TYPE_FAST];
 
-		if (_MagTextureFilters[i-1][FILTER_TYPE_BEST]==D3DTEXF_ANISOTROPIC) {
+		// When Anisotropic filtering is used, all stages above zero use trilinear filtering
+		if (_MagTextureFilters[0][FILTER_TYPE_BEST]==D3DTEXF_ANISOTROPIC) {
 			_MagTextureFilters[i][FILTER_TYPE_BEST]=D3DTEXF_LINEAR;
 		}
 		else {
-			_MagTextureFilters[i][FILTER_TYPE_BEST]=_MagTextureFilters[i-1][FILTER_TYPE_BEST];
+			_MagTextureFilters[i][FILTER_TYPE_BEST]=_MagTextureFilters[0][FILTER_TYPE_BEST];
 		}
 
-		if (_MinTextureFilters[i-1][FILTER_TYPE_BEST]==D3DTEXF_ANISOTROPIC) {
+		if (_MinTextureFilters[0][FILTER_TYPE_BEST]==D3DTEXF_ANISOTROPIC) {
 			_MinTextureFilters[i][FILTER_TYPE_BEST]=D3DTEXF_LINEAR;
 		}
 		else {
-			_MinTextureFilters[i][FILTER_TYPE_BEST]=_MinTextureFilters[i-1][FILTER_TYPE_BEST];
+			_MinTextureFilters[i][FILTER_TYPE_BEST]=_MinTextureFilters[0][FILTER_TYPE_BEST];
 		}
-		_MipMapFilters[i][FILTER_TYPE_BEST]=_MipMapFilters[i-1][FILTER_TYPE_BEST];
-
+		_MipMapFilters[i][FILTER_TYPE_BEST]=_MipMapFilters[0][FILTER_TYPE_BEST];
 
 	}
 
@@ -164,8 +254,6 @@ void TextureFilterClass::_Init_Filters(TextureFilterMode filter_type)
 		_MinTextureFilters[i][FILTER_TYPE_DEFAULT]=_MinTextureFilters[i][FILTER_TYPE_BEST];
 		_MagTextureFilters[i][FILTER_TYPE_DEFAULT]=_MagTextureFilters[i][FILTER_TYPE_BEST];
 		_MipMapFilters[i][FILTER_TYPE_DEFAULT]=_MipMapFilters[i][FILTER_TYPE_BEST];
-
-		DX8Wrapper::Set_DX8_Texture_Stage_State(i,D3DTSS_MAXANISOTROPY,2);
 	}
 
 }
@@ -183,6 +271,16 @@ void TextureFilterClass::Set_Mip_Mapping(FilterType mipmap)
 //		return;
 //	}
 	MipMapFilter=mipmap;
+}
+
+//**********************************************************************************************
+//! Set anisotropic filter level
+/*!
+*/
+void TextureFilterClass::_Set_Max_Anisotropy(AnisotropicFilterMode mode)
+{
+	for (int stage = 0; stage < MAX_TEXTURE_STAGES; ++stage)
+		DX8Wrapper::Set_DX8_Texture_Stage_State(stage, D3DTSS_MAXANISOTROPY, mode);
 }
 
 //**********************************************************************************************

--- a/Core/Libraries/Source/WWVegas/WW3D2/texturefilter.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/texturefilter.h
@@ -84,9 +84,19 @@ public:
 
 	enum TextureFilterMode
 	{
+		TEXTURE_FILTER_NONE,
+		TEXTURE_FILTER_POINT,
 		TEXTURE_FILTER_BILINEAR,
 		TEXTURE_FILTER_TRILINEAR,
 		TEXTURE_FILTER_ANISOTROPIC
+	};
+
+	enum AnisotropicFilterMode
+	{
+		TEXTURE_FILTER_ANISOTROPIC_2X = 2,
+		TEXTURE_FILTER_ANISOTROPIC_4X = 4,
+		TEXTURE_FILTER_ANISOTROPIC_8X = 8,
+		TEXTURE_FILTER_ANISOTROPIC_16X = 16
 	};
 
 	enum TxtAddrMode
@@ -113,8 +123,9 @@ public:
 	void Set_U_Addr_Mode(TxtAddrMode mode) { UAddressMode=mode; }
 	void Set_V_Addr_Mode(TxtAddrMode mode) { VAddressMode=mode; }
 
-	// This needs to be called after device has been created
+	// These need to be called after device has been created
 	static void _Init_Filters(TextureFilterMode texture_filter);
+	static void _Set_Max_Anisotropy(AnisotropicFilterMode mode);
 
 	static void _Set_Default_Min_Filter(FilterType filter);
 	static void _Set_Default_Mag_Filter(FilterType filter);

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
@@ -221,7 +221,7 @@ static bool												_LargeTextureExtraReductionEnabled = false;
 int														WW3D::LastFrameMemoryAllocations;
 int														WW3D::LastFrameMemoryFrees;
 
-int														WW3D::TextureFilter = 0;
+int														WW3D::TextureFilter = TextureFilterClass::TextureFilterMode::TEXTURE_FILTER_BILINEAR;
 
 bool														WW3D::Lite = false;
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
@@ -222,7 +222,7 @@ static bool												_LargeTextureExtraReductionEnabled = false;
 int														WW3D::LastFrameMemoryAllocations;
 int														WW3D::LastFrameMemoryFrees;
 
-int														WW3D::TextureFilter = 0;
+int														WW3D::TextureFilter = TextureFilterClass::TextureFilterMode::TEXTURE_FILTER_BILINEAR;
 
 bool														WW3D::Lite = false;
 


### PR DESCRIPTION
**merge by rebase**

This PR cleans up the texture filtering class and extends its functionality.

This can be squash merged, i seperated it into commits to make it easier to follow the changes when reviewing.


By default the game was stuck with Bilinear filtering, as they never added options to allow texture filtering to be altered within the game. This PR cleans up the original code and extends the support for more filtering modes.

At the moment this does nothing new. we still need to add the external code to set a different filtering mode, so the game still defaults to bilinear mode.

But now we have the following modes:

No filtering - Point filtering when minifying or maximising textures, mipmaps have no filtering
Point Filtering - The same as no filtering but mip maps now have point filtering
Bilinear - Default, Minifying and maximising now has linear filtering, mipmaps retain point filtering
Trilinear - The same as Bilinear but mipmaps now gain linear filtering
Anisotropic - Minifying and maximising now has anisotropic filtering and mip maps retain linear filtering.

Anisotropic filtering is defaulted to 2x which is the minimum and has a new static function to change the filtering mode.

---
If you want to test the changes, alter the `int WW3D::TextureFilter` variable in ww3d.cpp