### PR TITLE
bugfix(supply): Implement proportional supply bonus scaling to fix too generous money deposits for partial supply drops

### DIFF
--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SupplyTruckAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SupplyTruckAIUpdate.h
@@ -161,6 +161,7 @@ class SupplyTruckAIInterface
 	// who look this up by name.
 public:
 	virtual Int getNumberBoxes() const = 0;
+	virtual Int getMaxBoxes() const = 0;
 	virtual Bool loseOneBox() = 0;
 	virtual Bool gainOneBox( Int remainingStock ) = 0;
 
@@ -197,6 +198,7 @@ public:
 	virtual const SupplyTruckAIInterface* getSupplyTruckAIInterface() const override {return this;}
 
 	virtual Int getNumberBoxes() const override { return m_numberBoxes; }
+	virtual Int getMaxBoxes() const override { return getSupplyTruckAIUpdateModuleData()->m_maxBoxesData; }
 	virtual Bool loseOneBox() override;
 	virtual Bool gainOneBox( Int remainingStock ) override;
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/WorkerAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/WorkerAIUpdate.h
@@ -180,6 +180,7 @@ public:
 
 // Supply truck stuff
 	virtual Int getNumberBoxes() const override { return m_numberBoxes; }
+	virtual Int getMaxBoxes() const override { return getWorkerAIUpdateModuleData()->m_maxBoxesData; }
 	virtual Bool loseOneBox() override;
 	virtual Bool gainOneBox( Int remainingStock ) override;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/DockUpdate/SupplyCenterDockUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/DockUpdate/SupplyCenterDockUpdate.cpp
@@ -79,6 +79,23 @@ SupplyCenterDockUpdate::~SupplyCenterDockUpdate()
 {
 }
 
+// TheSuperHackers @bugfix arcticdolphin 12/03/2026 Scale supply bonus proportionally to delivered boxes.
+static UnsignedInt getUpgradedSupplyBoostValue( SupplyTruckAIInterface* supplyTruckAI )
+{
+#if RETAIL_COMPATIBLE_CRC
+	return supplyTruckAI->getUpgradedSupplyBoost();
+#else
+	const Int maxBoxes = supplyTruckAI->getMaxBoxes();
+	if (maxBoxes > 0)
+	{
+		const Int upgradedSupplyBoost = supplyTruckAI->getUpgradedSupplyBoost();
+		const Int deliveredBoxes = supplyTruckAI->getNumberBoxes();
+		return (upgradedSupplyBoost * deliveredBoxes) / maxBoxes;
+	}
+	return 0;
+#endif
+}
+
 // ------------------------------------------------------------------------------------------------
 // ------------------------------------------------------------------------------------------------
 Bool SupplyCenterDockUpdate::action( Object* docker, Object *drone )
@@ -95,12 +112,12 @@ Bool SupplyCenterDockUpdate::action( Object* docker, Object *drone )
 		return FALSE;
 
 	UnsignedInt value = 0;
+
+	value += getUpgradedSupplyBoostValue( supplyTruckAI );
+
 	Player *ownerPlayer = getObject()->getControllingPlayer();
 	while( supplyTruckAI->loseOneBox() )
 		value += ownerPlayer->getSupplyBoxValue();
-
-	// Add money boost from upgrades that give extra money
-	value += supplyTruckAI->getUpgradedSupplyBoost();
 
 	if( value > 0)
 	{


### PR DESCRIPTION
* Resolves #132 

* Added a new `getMaxBoxes()` method to `SupplyTruckAIInterface` and implemented it in both `SupplyTruckAIUpdate` and `WorkerAIUpdate` to expose the configured maximum box capacity. 

* Updated `SupplyCenterDockUpdate::action` to snapshot the box count before unloading and scale the upgrade bonus proportionally to the delivered cargo.

