### PR TITLE
bugfix(contain): Restore retail compatibility after crash fix in OpenContain::killAllContained

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -448,7 +448,7 @@ void OpenContain::removeAllContained( Bool exposeStealthUnits )
 void OpenContain::killAllContained()
 {
 	// TheSuperHackers @bugfix Caball009 11/03/2026 The contain list must be updated while iterating over it,
-	// because e.g. GarrisonContain::onRemoving relies on that behavior for the team ownership of civilian buildings.
+	// because e.g. garrisoned infantry relies on that behavior for the team ownership of civilian buildings.
 
 	ContainedItemsList::iterator it = m_containList.begin();
 	while ( it != m_containList.end() )
@@ -465,7 +465,7 @@ void OpenContain::killAllContained()
 			rider->onRemovedFrom( getObject() );
 			rider->kill();
 
-			// After Object::kill, the iterator may or may not be invalidated and the list may or may not be empty.
+			// After kill, the iterator may or may not be invalidated and the list may or may not be empty.
 			// Set the iterator to the beginning of the list.
 			it = m_containList.begin();
 		}


### PR DESCRIPTION
* Closes https://github.com/TheSuperHackers/GeneralsGameCode/issues/2215
* Follow up for https://github.com/TheSuperHackers/GeneralsGameCode/pull/921

The way the crash fix was implemented in #921 assumes that the logic behavior doesn't change if `m_containList` / `m_containListSize` is already empty with the first iteration. This is not the case in the attached replay in #2215.

If `m_containList` / `m_containListSize` is empty, it'll make garrisoned civilian buildings unoccupied on the first iteration instead of the last iteration, and the GLA Demolition upgrade would cause damage to the building for each occupant instead of just the last one when hit with a neutron shell.

https://github.com/user-attachments/assets/031ba286-2610-4461-bc66-e02bca46ba65

https://github.com/user-attachments/assets/59e187f3-1a0e-4689-b48e-94e6938757ff

Pay attention to the health of the civilian building. In the correct version, only the detonation of the last GLA RPG Trooper causes damage instead of every one.

TODO:
- [x] Polish comments.

