### PR TITLE
fix(logic): Improve validation of MSG_NEW_GAME in GameLogicDispatch

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -410,6 +410,18 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 		//---------------------------------------------------------------------------------------------
 		case GameMessage::MSG_NEW_GAME:
 		{
+#if !RETAIL_COMPATIBLE_CRC
+			// TheSuperHackers @fix stephanmeesters 11/03/2026
+			// Make sure we're ready to start a new game. This prevents an issue where an infinite disconnect screen
+			// can be force-triggered in an online match by using cheats.
+			if ( isInGame() || isClearingGameData() || isLoadingMap() )
+			{
+				DEBUG_CRASH( ("Called MSG_NEW_GAME while game is not ready (inGame=%d, clearingData=%d, loadingMap=%d)",
+					isInGame(), isClearingGameData(), isLoadingMap()) );
+				break;
+			}
+#endif
+
 			//DEBUG_ASSERTCRASH(msg->getArgumentCount() == 1 || msg->getArgumentCount() == 2, ("%d arguments to MSG_NEW_GAME", msg->getArgumentCount()));
 			GameMode gameMode = (GameMode)msg->getArgument( 0 )->integer;
 			Int rankPoints = 0;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -422,7 +422,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 #if !RETAIL_COMPATIBLE_CRC
 			// TheSuperHackers @fix stephanmeesters 11/03/2026
 			// Make sure we're ready to start a new game. This prevents an issue where an infinite disconnect screen
-			// ("DC bug") can be triggered in an online match.
+			// can be force-triggered in an online match by using cheats.
 			if ( isInGame() || isClearingGameData() || isLoadingMap() )
 			{
 				DEBUG_CRASH( ("Called MSG_NEW_GAME while game is not ready (inGame=%d, clearingData=%d, loadingMap=%d)",

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -419,6 +419,18 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 		//---------------------------------------------------------------------------------------------
 		case GameMessage::MSG_NEW_GAME:
 		{
+#if !RETAIL_COMPATIBLE_CRC
+			// TheSuperHackers @fix stephanmeesters 11/03/2026
+			// Make sure we're ready to start a new game. This prevents an issue where an infinite disconnect screen
+			// ("DC bug") can be triggered in an online match.
+			if ( isInGame() || isClearingGameData() || isLoadingMap() )
+			{
+				DEBUG_CRASH( ("Called MSG_NEW_GAME while game is not ready (inGame=%d, clearingData=%d, loadingMap=%d)",
+					isInGame(), isClearingGameData(), isLoadingMap()) );
+				break;
+			}
+#endif
+
 			//DEBUG_ASSERTCRASH(msg->getArgumentCount() == 1 || msg->getArgumentCount() == 2, ("%d arguments to MSG_NEW_GAME", msg->getArgumentCount()));
 			GameMode gameMode = (GameMode)msg->getArgument( 0 )->integer;
 			Int rankPoints = 0;


### PR DESCRIPTION
This prevents a possible issue where the game gets stuck in the disconnect screen ("dc bug") when making a call to MSG_NEW_GAME when the game is not ready for it.

Tested with local multiplayer match, skirmish, savegame, replay, campaign, generals challeng. 1k replays passed.

Moved behind RETAIL_COMPATIBLE_CRC in the case of any replays that have a forced dc bug.

## Todo

- [x] Replicate in Generals