### PR TITLE
fix(logic): Improve validation of MSG_SET_RALLY_POINT in GameLogicDispatch

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -502,8 +502,21 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 		{
 			Object *obj = findObjectByID( msg->getArgument( 0 )->objectID );
 			Coord3D dest = msg->getArgument( 1 )->location;
+
 			if (obj)
 			{
+#if !RETAIL_COMPATIBLE_CRC
+				// TheSuperHackers @fix stephanmeesters 11/03/2026 Validate the owner of the source object
+				if ( obj->getControllingPlayer() != thisPlayer )
+				{
+					DEBUG_CRASH( ("MSG_SET_RALLY_POINT: Player '%ls' attempted to set the rally point of object '%s' owned by player '%ls'.",
+						 thisPlayer->getPlayerDisplayName().str(),
+						 obj->getTemplate()->getName().str(),
+						 obj->getControllingPlayer()->getPlayerDisplayName().str()) );
+					break;
+				}
+#endif
+
 				doSetRallyPoint( obj, dest );
 			}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -511,8 +511,21 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 		{
 			Object *obj = findObjectByID( msg->getArgument( 0 )->objectID );
 			Coord3D dest = msg->getArgument( 1 )->location;
+
 			if (obj)
 			{
+#if !RETAIL_COMPATIBLE_CRC
+				// TheSuperHackers @fix stephanmeesters 11/03/2026 Validate the owner of the source object
+				if ( obj->getControllingPlayer() != thisPlayer )
+				{
+					DEBUG_CRASH( ("MSG_SET_RALLY_POINT: Player '%ls' attempted to set the rally point of object '%s' owned by player '%ls'.",
+						 thisPlayer->getPlayerDisplayName().str(),
+						 obj->getTemplate()->getName().str(),
+						 obj->getControllingPlayer()->getPlayerDisplayName().str()) );
+					break;
+				}
+#endif
+
 				doSetRallyPoint( obj, dest );
 			}
 


### PR DESCRIPTION
This fix prevents players from controlling rally points of buildings of another player in a multiplayer match.

Moved behind RETAIL_COMPATIBLE_CRC in case of any replays that have control hacks.

## Todo

- [x] Replicate in Generals