### PR TITLE
unify(logic): Merge game loading related variables and functions from Zero Hour

### DIFF
--- a/Generals/Code/GameEngine/Include/GameLogic/GameLogic.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/GameLogic.h
@@ -152,13 +152,18 @@ public:
 	ObjectID allocateObjectID();							///< Returns a new unique object id
 
 	// super hack
-	void startNewGame( Bool saveGame );
+	void startNewGame( Bool loadSaveGame );
 	void loadMapINI( AsciiString mapName );
 
 	void updateLoadProgress( Int progress );
 	void deleteLoadScreen();
 
-	void setGameLoading( Bool loading );
+	//Kris: Cut setGameLoading() and replaced with setLoadingMap() and setLoadingSave() -- reason: nomenclature
+	//void setGameLoading( Bool loading ) { m_loadingScene = loading; }
+	void setLoadingMap( Bool loading ) { m_loadingMap = loading; }
+	void setLoadingSave( Bool loading ) { m_loadingSave = loading; }
+	void setClearingGameData( Bool clearing ) { m_clearingGameData = clearing; }
+
 	void setGameMode( GameMode mode );
 	GameMode getGameMode();
 
@@ -174,7 +179,12 @@ public:
 
 	static Bool isInInteractiveGame(GameMode mode) { return mode != GAME_NONE && mode != GAME_SHELL; }
 
-	Bool isLoadingGame();
+	//Kris: Cut isLoadingGame() and replaced with isLoadingMap() and isLoadingSave() -- reason: nomenclature
+	//Bool isLoadingGame() const { return m_loadingScene; }		// This is the old function that isn't very clear on it's definition.
+	Bool isLoadingMap() const { return m_loadingMap; }			// Whenever a map is in the process of loading.
+	Bool isLoadingSave() const { return m_loadingSave; }		// Whenever a saved game is in the process of loading.
+	Bool isClearingGameData() const { return m_clearingGameData; }
+
 	void enableScoring(Bool score) { m_isScoringEnabled = score; }
 	Bool isScoringEnabled() const { return m_isScoringEnabled; }
 
@@ -292,7 +302,10 @@ private:
 	std::map<Int, UnsignedInt> m_cachedCRCs;								///< CRCs we've seen this frame
 	Bool m_shouldValidateCRCs;															///< Should we validate CRCs this frame?
 	//-----------------------------------------------------------------------------------------------
-	Bool m_loadingScene;
+	//Bool m_loadingScene;
+	Bool m_loadingMap;
+	Bool m_loadingSave;
+	Bool m_clearingGameData;
 
 	Bool m_isInUpdate;
 	Bool m_hasUpdated;
@@ -398,8 +411,6 @@ inline Bool GameLogic::isInInteractiveGame() const { return isInInteractiveGame(
 inline Bool GameLogic::isInReplayGame() { return (m_gameMode == GAME_REPLAY); }
 inline Bool GameLogic::isInInternetGame() { return (m_gameMode == GAME_INTERNET); }
 inline Bool GameLogic::isInShellGame() { return (m_gameMode == GAME_SHELL); }
-//Check for loading scene
-inline Bool GameLogic::isLoadingGame(){ return m_loadingScene;}
 
 inline Object* GameLogic::findObjectByID( ObjectID id )
 {

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Diplomacy.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Diplomacy.cpp
@@ -194,7 +194,7 @@ void UpdateDiplomacyBriefingText(AsciiString newText, Bool clear)
 void ShowDiplomacy( Bool immediate )
 {
 	if (!TheInGameUI->getInputEnabled() || TheGameLogic->isIntroMoviePlaying() ||
-			TheGameLogic->isLoadingGame())
+			TheGameLogic->isLoadingMap())
 		return;
 
 

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/QuitMenu.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/QuitMenu.cpp
@@ -281,7 +281,7 @@ void HideQuitMenu()
 //-------------------------------------------------------------------------------------------------
 void ToggleQuitMenu()
 {
-	if (TheGameLogic->isIntroMoviePlaying() || TheGameLogic->isLoadingGame() ||TheScriptEngine->isGameEnding())
+	if (TheGameLogic->isIntroMoviePlaying() || TheGameLogic->isLoadingMap() ||TheScriptEngine->isGameEnding())
 		return;
 
 	// BGC- If we are currently in the disconnect screen, don't let the quit menu come up.

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -247,6 +247,10 @@ GameLogic::GameLogic()
 #ifdef DUMP_PERF_STATS
 	m_overallFailedPathfinds = 0;
 #endif
+
+	m_loadingMap = FALSE;
+	m_loadingSave = FALSE;
+	m_clearingGameData = FALSE;
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -933,11 +937,6 @@ void GameLogic::deleteLoadScreen()
 
 }
 
-void GameLogic::setGameLoading( Bool loading )
-{
-	m_loadingScene = loading;
-}
-
 // ------------------------------------------------------------------------------------------------
 // ------------------------------------------------------------------------------------------------
 void GameLogic::updateDisplayBusyState()
@@ -964,7 +963,7 @@ void GameLogic::setGameMode( GameMode mode )
 /** Entry point for starting a new game, the engine is already in clean state at this
 	* point and ready to load up with all the data */
 // ------------------------------------------------------------------------------------------------
-void GameLogic::startNewGame( Bool saveGame )
+void GameLogic::startNewGame( Bool loadingSaveGame )
 {
 
 	#ifdef DUMP_PERF_STATS
@@ -984,7 +983,9 @@ void GameLogic::startNewGame( Bool saveGame )
 	CRCDebugStartNewGame();
 #endif
 
-	if( saveGame == FALSE )
+	setLoadingMap( TRUE );
+
+	if( loadingSaveGame == FALSE )
 	{
 
 		// record pristine map name when we're loading from the map (not a save game)
@@ -1015,7 +1016,7 @@ void GameLogic::startNewGame( Bool saveGame )
 					deleteInstance(m_background);
 					m_background = nullptr;
 				}
-				m_loadScreen = getLoadScreen( saveGame );
+				m_loadScreen = getLoadScreen( loadingSaveGame );
 				if(m_loadScreen)
 				{
 					TheWritableGlobalData->m_loadScreenRender = TRUE;	///< mark it so only a few select things are rendered during load
@@ -1038,7 +1039,7 @@ void GameLogic::startNewGame( Bool saveGame )
 	// for save games, we read this value out of the save game file and it is important
 	// that we preserve it as we load and execute the game
 	//
-	if( saveGame == FALSE )
+	if( loadingSaveGame == FALSE )
 		m_nextObjID = (ObjectID)1;
 
 	TheWritableGlobalData->m_loadScreenRender = TRUE;	///< mark it so only a few select things are rendered during load
@@ -1079,7 +1080,7 @@ void GameLogic::startNewGame( Bool saveGame )
 		for (Int i=0; i<MAX_SLOTS; ++i)
 		{
 			GameSlot *slot = TheGameInfo->getSlot(i);
-			if (!saveGame) {
+			if (!loadingSaveGame) {
 				slot->saveOffOriginalInfo();
 			}
 			if (slot->isAI())
@@ -1104,7 +1105,7 @@ void GameLogic::startNewGame( Bool saveGame )
 	// Get the m_loadScreen for this kind of game
 	if(!m_loadScreen && !(TheRecorder && TheRecorder->getMode() == RECORDERMODETYPE_SIMULATION_PLAYBACK))
 	{
-		m_loadScreen = getLoadScreen( saveGame );
+		m_loadScreen = getLoadScreen( loadingSaveGame );
 		if(m_loadScreen && !TheGlobalData->m_headless)
 		{
 			TheMouse->setVisibility(FALSE);
@@ -1510,7 +1511,7 @@ void GameLogic::startNewGame( Bool saveGame )
 	updateLoadProgress(LOAD_PROGRESS_POST_GHOST_OBJECT_MANAGER_RESET);
 
 	// update the terrain logic now that all is loaded
-	TheTerrainLogic->newMap( saveGame );
+	TheTerrainLogic->newMap( loadingSaveGame );
 
 	// update the loadscreen
 	updateLoadProgress(LOAD_PROGRESS_POST_TERRAIN_LOGIC_NEW_MAP);
@@ -1613,7 +1614,7 @@ void GameLogic::startNewGame( Bool saveGame )
 	DEBUG_LOG(("%s", Buf));
 	#endif
 
-	if( saveGame == FALSE )
+	if( loadingSaveGame == FALSE )
 	{
 		Int progressCount = LOAD_PROGRESS_LOOP_ALL_THE_FREAKN_OBJECTS;
 		Int timer = timeGetTime();
@@ -1716,7 +1717,7 @@ void GameLogic::startNewGame( Bool saveGame )
 	#endif
 
 	// place initial network buildings/units
-	if (TheGameInfo && !saveGame)
+	if (TheGameInfo && !loadingSaveGame)
 	{
 		Int progressCount = LOAD_PROGRESS_LOOP_INITIAL_NETWORK_BUILDINGS;
 		for (int i=0; i<MAX_SLOTS; ++i)
@@ -1852,11 +1853,11 @@ void GameLogic::startNewGame( Bool saveGame )
 
 
 	// final step, run newMap for all players
-	if( saveGame == FALSE )
+	if( loadingSaveGame == FALSE )
 		ThePlayerList->newMap();
 
 	// reset all the skill points in a single player game
-	if(saveGame == FALSE && isInSinglePlayerGame())
+	if(loadingSaveGame == FALSE && isInSinglePlayerGame())
 	{
 		for (Int i=0; i<MAX_PLAYER_COUNT; ++i)
 		{
@@ -1889,7 +1890,7 @@ void GameLogic::startNewGame( Bool saveGame )
 	}
 
 	// if we're in a load game, don't fade yet
-	if(saveGame == FALSE && TheTransitionHandler != nullptr && m_loadScreen)
+	if(loadingSaveGame == FALSE && TheTransitionHandler != nullptr && m_loadScreen)
 	{
 		TheTransitionHandler->setGroup("FadeWholeScreen");
 		while(!TheTransitionHandler->isFinished())
@@ -1915,7 +1916,7 @@ void GameLogic::startNewGame( Bool saveGame )
 		// have more work to do and the load screen will be deleted elsewhere after
 		// we're all done with the load game progress
 		//
-		if( saveGame == FALSE )
+		if( loadingSaveGame == FALSE )
 */
 			deleteLoadScreen();
 
@@ -2048,7 +2049,8 @@ void GameLogic::startNewGame( Bool saveGame )
 	}
 
 	//ReAllows quit menu to work during loading scene
-	setGameLoading(FALSE);
+	//setGameLoading(FALSE);
+	setLoadingMap( FALSE );
 
 #ifdef DUMP_PERF_STATS
 	GetPrecisionTimer(&endTime64);

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -248,6 +248,8 @@ void GameLogic::clearGameData( Bool showScoreScreen )
 		return;
 	}
 
+	setClearingGameData( TRUE );
+
 //	m_background = TheWindowManager->winCreateLayout("Menus/BlankWindow.wnd");
 //	DEBUG_ASSERTCRASH(m_background,("We Couldn't Load Menus/BlankWindow.wnd"));
 //	m_background->hide(FALSE);
@@ -292,6 +294,8 @@ void GameLogic::clearGameData( Bool showScoreScreen )
 		m_background = nullptr;
 	}
 
+	setClearingGameData( FALSE );
+
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -299,7 +303,9 @@ void GameLogic::clearGameData( Bool showScoreScreen )
 // ------------------------------------------------------------------------------------------------
 void GameLogic::prepareNewGame( GameMode gameMode, GameDifficulty diff, Int rankPoints )
 {
-	setGameLoading(TRUE);
+	//Kris: Commented this out, but leaving it around incase it bites us later. I cleaned up the
+	//      nomenclature. Look for setLoadingMap() and setLoadingSave()
+	//setGameLoading(TRUE);
 
 	TheScriptEngine->setGlobalDifficulty(diff);
 


### PR DESCRIPTION
This unifies some variables/functions used for loading : 

Removed (commented out): `isLoadingGame()`

Added: `isLoadingMap()` , `isLoadingSave()`, `isClearingGameData()`

This was done for the replicate to Generals in #2440.

Tested skirmish/campaign in Generals.

Replicated by hand using WinMerge