### PR TITLE
perf(pathfinder): Implement conditional reverse insertion sorting algorithm to reduce cost of long pathfinding by 50-66%

### DIFF
--- a/Core/GameEngine/Include/GameLogic/AIPathfind.h
+++ b/Core/GameEngine/Include/GameLogic/AIPathfind.h
@@ -341,6 +341,9 @@ public:
 	// Forward insertion sort, in ascending cost order
 	void forwardInsertionSort(PathfindCellList& list);
 
+	// Reverse insertion sort, in ascending cost order
+	void reverseInsertionSort(PathfindCellList& list);
+
 	/// put self on "open" list in ascending cost order
 	void putOnSortedOpenList( PathfindCellList &list );
 

--- a/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -1355,7 +1355,7 @@ inline void PathfindCell::setBlockedByAlly(Bool blocked)
 inline UnsignedInt PathfindCell::getTotalCostDifference(PathfindCell& other) const
 {
 	if (m_info && other.m_info)
-		return abs(m_info->m_totalCost - other.m_info->m_totalCost);
+		return abs((Int)m_info->m_totalCost - (Int)other.m_info->m_totalCost);
 
 	return UINT_MAX;
 }
@@ -1756,7 +1756,7 @@ void PathfindCell::forwardInsertionSortRetailCompatible(PathfindCellList& list)
 }
 #endif
 
-// Forward insertion sort, returns early if the list is being initialised or we are prepending the list
+// Forward insertion sort, returns early if the list is being initialized or we are prepending the list
 void PathfindCell::forwardInsertionSort(PathfindCellList& list)
 {
 	DEBUG_ASSERTCRASH(m_info, ("Has to have info."));
@@ -1770,6 +1770,7 @@ void PathfindCell::forwardInsertionSort(PathfindCellList& list)
 		m_info->m_prevOpen = nullptr;
 		m_info->m_nextOpen = nullptr;
 		list.m_head = this;
+		list.m_tail = this;
 		return;
 	}
 
@@ -1793,8 +1794,58 @@ void PathfindCell::forwardInsertionSort(PathfindCellList& list)
 	if (current->m_info->m_nextOpen != nullptr) {
 		current->m_info->m_nextOpen->m_prevOpen = this->m_info;
 	}
+	else {
+		list.m_tail = this;
+	}
+
 	current->m_info->m_nextOpen = this->m_info;
 	m_info->m_prevOpen = current->m_info;
+}
+
+// Reverse insertion sort, returns early if the list is being initialized or we are appending the list
+void PathfindCell::reverseInsertionSort(PathfindCellList& list)
+{
+	DEBUG_ASSERTCRASH(m_info, ("Has to have info."));
+	DEBUG_ASSERTCRASH(m_info->m_closed == FALSE && m_info->m_open == FALSE, ("Serious error - Invalid flags. jba"));
+
+	// mark the new cell as being on the open list
+	m_info->m_open = true;
+	m_info->m_closed = false;
+
+	if (list.m_tail == nullptr) {
+		m_info->m_prevOpen = nullptr;
+		m_info->m_nextOpen = nullptr;
+		list.m_tail = this;
+		list.m_head = this;
+		return;
+	}
+
+	// If the node needs inserting after the current list tail
+	if (m_info->m_totalCost >= list.m_tail->m_info->m_totalCost) {
+		m_info->m_prevOpen = list.m_tail->m_info;
+		list.m_tail->m_info->m_nextOpen = this->m_info;
+		m_info->m_nextOpen = nullptr;
+		list.m_tail = this;
+		return;
+	}
+
+	// Traverse the list to find correct position
+	PathfindCell* current = list.m_tail;
+	while (current->m_info->m_prevOpen && current->m_info->m_prevOpen->m_totalCost > m_info->m_totalCost) {
+		current = current->getPrevOpen();
+	}
+
+	// Insert the new node in the correct position
+	m_info->m_prevOpen = current->m_info->m_prevOpen;
+	if (current->m_info->m_prevOpen != nullptr) {
+		current->m_info->m_prevOpen->m_nextOpen = this->m_info;
+	}
+	else {
+		list.m_head = this;
+	}
+
+	current->m_info->m_prevOpen = this->m_info;
+	m_info->m_nextOpen = current->m_info;
 }
 
 /// put self on "open" list in ascending cost order, return new list
@@ -1807,7 +1858,15 @@ void PathfindCell::putOnSortedOpenList( PathfindCellList &list )
 	}
 #endif
 
-	forwardInsertionSort(list);
+	// TheSuperHackers @performance Mauller 20/03/2026 Implement reverse insertion sorting.
+	// Long and complex paths often append PathfindCell's, with high total path costs, to the open list.
+	// Appending and reverse traversal allow faster insertion of these cells, reducing pathfinding overhead by 50 - 66%.
+	if (list.canReverseSort(*this)) {
+		reverseInsertionSort(list);
+	}
+	else {
+		forwardInsertionSort(list);
+	}
 }
 
 /// remove self from "open" list
@@ -1817,6 +1876,9 @@ void PathfindCell::removeFromOpenList( PathfindCellList &list )
 	DEBUG_ASSERTCRASH(m_info->m_closed==FALSE && m_info->m_open==TRUE, ("Serious error - Invalid flags. jba"));
 	if (m_info->m_nextOpen)
 		m_info->m_nextOpen->m_prevOpen = m_info->m_prevOpen;
+	else {
+		list.m_tail = getPrevOpen();
+	}
 
 	if (m_info->m_prevOpen)
 		m_info->m_prevOpen->m_nextOpen = m_info->m_nextOpen;
@@ -1854,7 +1916,7 @@ Int PathfindCell::releaseOpenList( PathfindCellList &list )
 		if (curInfo->m_nextOpen) {
 			list.m_head = curInfo->m_nextOpen->m_cell;
 		} else {
-			list.m_head = nullptr;
+			list.reset();
 		}
 		DEBUG_ASSERTCRASH(cur == curInfo->m_cell, ("Bad backpointer in PathfindCellInfo"));
 		curInfo->m_nextOpen = nullptr;
@@ -1889,7 +1951,7 @@ Int PathfindCell::releaseClosedList( PathfindCellList &list )
 		if (curInfo->m_nextOpen) {
 			list.m_head = curInfo->m_nextOpen->m_cell;
 		} else {
-			list.m_head = nullptr;
+			list.reset();
 		}
 		DEBUG_ASSERTCRASH(cur == curInfo->m_cell, ("Bad backpointer in PathfindCellInfo"));
 		curInfo->m_nextOpen = nullptr;


### PR DESCRIPTION
This PR adds conditionaly selected reverse insertion sorting.

`putOnSortedOpenList()` now acts as a dispatching function that chooses if a new node is inserted by traversing the list from the head or tail. The code determines if the new nodes total cost is closer to the head or tail to determine which list traversal direction to use.

This provides a significant performance improvement to long paths, allowing them to finish in half to a third of the time of just using forward insertion sorting alone.

The likely reason for this is that longer and more complex paths tend to append larger values to the list which requires a full list traversal when forward inserting. Or they are adding large path costs so will typically be inserting in the upper 50% of the list.

On average we would have expected at least a 50% performance improvement, due to the logical splitting in half of the list length, since we now approach any node position from either end of the list.

With the conditional reverse insertion sort we would have expected the algorithm to be O(N/2) in time, but for the above reasons, allowing quick appends dramatically improves the performance of some pathing sorts.

In other words, pathfinder go brrrrrr already at stage 1 tuning!

----

Some comparison values from a debug build, the pathfinding times are in second.
<img width="1064" height="704" alt="image" src="https://github.com/user-attachments/assets/50a38e59-4e89-4495-b908-0d2bad8c5184" />

<img width="1054" height="663" alt="image" src="https://github.com/user-attachments/assets/d3eacf1f-1e17-4d9f-8b03-2fb80290d147" />

Shorter paths are not as significantly affected, but the followup skip list enhancement should provide a further boost for these.
<img width="1060" height="744" alt="image" src="https://github.com/user-attachments/assets/bcd327b2-722c-47dd-ac42-2dc661aeee34" />

Some variation is also down to CPU load as i often would see variation between runs but overall significantly lower times on the longer paths.