### PR TITLE
bugfix: Fix delays when requesting paths too quickly

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -491,6 +491,7 @@ void AIUpdateInterface::requestPath( Coord3D *destination, Bool isFinalGoal )
 		return;
 	}
 	m_waitingForPath = TRUE;
+#if RETAIL_COMPATIBLE_CRC
 	if (m_pathTimestamp > TheGameLogic->getFrame()-3) {
 		/* Requesting path very quickly.  Can cause a spin. */
 		//DEBUG_LOG(("%d Pathfind - repathing in less than 3 frames.  Waiting 1 second",
@@ -507,6 +508,7 @@ void AIUpdateInterface::requestPath( Coord3D *destination, Bool isFinalGoal )
 		}
 		return;
 	}
+#endif
 	TheAI->pathfinder()->queueForPath(getObject()->getID());
 
 }
@@ -524,12 +526,14 @@ void AIUpdateInterface::requestAttackPath( ObjectID victimID, const Coord3D* vic
 	m_isApproachPath = FALSE;
 	m_isSafePath = FALSE;
 	m_waitingForPath = TRUE;
+#if RETAIL_COMPATIBLE_CRC
 	if (m_pathTimestamp > TheGameLogic->getFrame()-3) {
 		/* Requesting path very quickly.  Can cause a spin. */
 		//DEBUG_LOG(("%d Pathfind - repathing in less than 3 frames.  Waiting 2 second",TheGameLogic->getFrame()));
 		setQueueForPathTime(2*LOGICFRAMES_PER_SECOND);
 		return;
 	}
+#endif
 	TheAI->pathfinder()->queueForPath(getObject()->getID());
 }
 
@@ -547,12 +551,14 @@ void AIUpdateInterface::requestApproachPath( Coord3D *destination )
 	m_isApproachPath = TRUE;
 	m_isSafePath = FALSE;
 	m_waitingForPath = TRUE;
+#if RETAIL_COMPATIBLE_CRC
 	if (m_pathTimestamp > TheGameLogic->getFrame()-3) {
 		/* Requesting path very quickly.  Can cause a spin. */
 		//DEBUG_LOG(("%d Pathfind - repathing in less than 3 frames.  Waiting 2 second",TheGameLogic->getFrame()));
 		setQueueForPathTime(2*LOGICFRAMES_PER_SECOND);
 		return;
 	}
+#endif
 	TheAI->pathfinder()->queueForPath(getObject()->getID());
 }
 
@@ -571,12 +577,14 @@ void AIUpdateInterface::requestSafePath( ObjectID repulsor )
 	m_isApproachPath = FALSE;
 	m_isSafePath = TRUE;
 	m_waitingForPath = TRUE;
+#if RETAIL_COMPATIBLE_CRC
 	if (m_pathTimestamp > TheGameLogic->getFrame()-3) {
 		/* Requesting path very quickly.  Can cause a spin. */
 		//DEBUG_LOG(("%d Pathfind - repathing in less than 3 frames.  Waiting 2 second",TheGameLogic->getFrame()));
 		setQueueForPathTime(2*LOGICFRAMES_PER_SECOND);
 		return;
 	}
+#endif
 	TheAI->pathfinder()->queueForPath(getObject()->getID());
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -496,6 +496,7 @@ void AIUpdateInterface::requestPath( Coord3D *destination, Bool isFinalGoal )
 		return;
 	}
 	m_waitingForPath = TRUE;
+#if RETAIL_COMPATIBLE_CRC
 	if (m_pathTimestamp > TheGameLogic->getFrame()-3) {
 		/* Requesting path very quickly.  Can cause a spin. */
 		//DEBUG_LOG(("%d Pathfind - repathing in less than 3 frames.  Waiting 1 second",
@@ -512,6 +513,7 @@ void AIUpdateInterface::requestPath( Coord3D *destination, Bool isFinalGoal )
 		}
 		return;
 	}
+#endif
 	TheAI->pathfinder()->queueForPath(getObject()->getID());
 
 }
@@ -529,6 +531,7 @@ void AIUpdateInterface::requestAttackPath( ObjectID victimID, const Coord3D* vic
 	m_isApproachPath = FALSE;
 	m_isSafePath = FALSE;
 	m_waitingForPath = TRUE;
+#if RETAIL_COMPATIBLE_CRC
 	if (m_pathTimestamp > TheGameLogic->getFrame()-3) {
 		/* Requesting path very quickly.  Can cause a spin. */
 		//DEBUG_LOG(("%d Pathfind - repathing in less than 3 frames.  Waiting 2 second",TheGameLogic->getFrame()));
@@ -536,6 +539,7 @@ void AIUpdateInterface::requestAttackPath( ObjectID victimID, const Coord3D* vic
 		setLocomotorGoalNone();
 		return;
 	}
+#endif
 	TheAI->pathfinder()->queueForPath(getObject()->getID());
 }
 
@@ -553,12 +557,14 @@ void AIUpdateInterface::requestApproachPath( Coord3D *destination )
 	m_isApproachPath = TRUE;
 	m_isSafePath = FALSE;
 	m_waitingForPath = TRUE;
+#if RETAIL_COMPATIBLE_CRC
 	if (m_pathTimestamp > TheGameLogic->getFrame()-3) {
 		/* Requesting path very quickly.  Can cause a spin. */
 		//DEBUG_LOG(("%d Pathfind - repathing in less than 3 frames.  Waiting 2 second",TheGameLogic->getFrame()));
 		setQueueForPathTime(2*LOGICFRAMES_PER_SECOND);
 		return;
 	}
+#endif
 	TheAI->pathfinder()->queueForPath(getObject()->getID());
 }
 
@@ -577,12 +583,14 @@ void AIUpdateInterface::requestSafePath( ObjectID repulsor )
 	m_isApproachPath = FALSE;
 	m_isSafePath = TRUE;
 	m_waitingForPath = TRUE;
+#if RETAIL_COMPATIBLE_CRC
 	if (m_pathTimestamp > TheGameLogic->getFrame()-3) {
 		/* Requesting path very quickly.  Can cause a spin. */
 		//DEBUG_LOG(("%d Pathfind - repathing in less than 3 frames.  Waiting 2 second",TheGameLogic->getFrame()));
 		setQueueForPathTime(2*LOGICFRAMES_PER_SECOND);
 		return;
 	}
+#endif
 	TheAI->pathfinder()->queueForPath(getObject()->getID());
 }
 


### PR DESCRIPTION
This change fixes an issue where a path request that is issued within 3 frames of the previous one is delayed by up to 2 seconds. This issue is most notable and impactful when rapidly commanding Terrorists, which conspicuously moonwalk when this occurs, though the issue is apparent with all units. I imagine most players have probably experienced this behaviour at some point but do not consciously recall it.

The code comments left by the original developers indicate that the logic to delay rapidly requested paths is intentional, however the resulting unresponsiveness appears as a bug to players.

It is not yet clear what issues rapid path requests may cause, or whether it was just a precaution or a lazy performance optimisation. I've played several skirmish matches with many units and have not encountered any regressions or performance issues. Ideally any performance issues are addressed at a higher level rather than via an ungraceful workaround placed directly within the path request logic.

### Demonstrations of the issue

A rapid succession of force-fire commands leave these units temporarily catatonic

https://github.com/user-attachments/assets/f8852d30-0f39-4da4-8aa4-a1c2f5bbfb67

The classic two-second terrorist moonwalk

https://github.com/user-attachments/assets/70bd7676-acb9-416a-9920-f270621cbcc2

Easily reproduced by stepping frames

https://github.com/user-attachments/assets/cc6075b2-9c63-4b71-a70e-5e7ea2955df0

It's particularly bad when it comes to jets

https://github.com/user-attachments/assets/f701642a-686e-4794-bdb6-c9c98616e85d