### PR TITLE
bugfix(gamelogic): Modules now cease updating when disabled by non-whitelisted disabled types

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -3253,7 +3253,15 @@ void GameLogic::update()
 		{
 			UpdateModulePtr u = *it;
 			DisabledMaskType dis = u->friend_getObject()->getDisabledFlags();
+#if RETAIL_COMPATIBLE_CRC
 			if (!dis.any() || dis.anyIntersectionWith(u->getDisabledTypesToProcess()))
+#else
+			// TheSuperHackers @bugfix Stubbjax 15/03/2026 The disabled-types-to-process mask is now exclusive.
+			// Previously, if the disabled mask had any bits in common with the disabled-types-to-process mask,
+			// the update would be processed. Now, if any *other* bits are set in the disabled mask, the update
+			// is no longer processed.
+			if (!dis.any() || u->getDisabledTypesToProcess().testForAll(dis))
+#endif
 			{
 				USE_PERF_TIMER(GameLogic_update_normal)
 
@@ -3293,7 +3301,15 @@ void GameLogic::update()
 			UpdateSleepTime sleepLen = UPDATE_SLEEP_NONE;	// default, if it is disabled.
 
 			DisabledMaskType dis = u->friend_getObject()->getDisabledFlags();
+#if RETAIL_COMPATIBLE_CRC
 			if (!dis.any() || dis.anyIntersectionWith(u->getDisabledTypesToProcess()))
+#else
+			// TheSuperHackers @bugfix Stubbjax 15/03/2026 The disabled-types-to-process mask is now exclusive.
+			// Previously, if the disabled mask had any bits in common with the disabled-types-to-process mask,
+			// the update would be processed. Now, if any *other* bits are set in the disabled mask, the update
+			// is no longer processed.
+			if (!dis.any() || u->getDisabledTypesToProcess().testForAll(dis))
+#endif
 			{
 				USE_PERF_TIMER(GameLogic_update_sleepy)
 

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -3260,7 +3260,7 @@ void GameLogic::update()
 			// Previously, if the disabled mask had any bits in common with the disabled-types-to-process mask,
 			// the update would be processed. Now, if any *other* bits are set in the disabled mask, the update
 			// is no longer processed.
-			if (!dis.any() || u->getDisabledTypesToProcess().testForAll(dis))
+			if (u->getDisabledTypesToProcess().testForAll(dis))
 #endif
 			{
 				USE_PERF_TIMER(GameLogic_update_normal)
@@ -3308,7 +3308,7 @@ void GameLogic::update()
 			// Previously, if the disabled mask had any bits in common with the disabled-types-to-process mask,
 			// the update would be processed. Now, if any *other* bits are set in the disabled mask, the update
 			// is no longer processed.
-			if (!dis.any() || u->getDisabledTypesToProcess().testForAll(dis))
+			if (u->getDisabledTypesToProcess().testForAll(dis))
 #endif
 			{
 				USE_PERF_TIMER(GameLogic_update_sleepy)

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -3792,7 +3792,15 @@ void GameLogic::update()
 		{
 			UpdateModulePtr u = *it;
 			DisabledMaskType dis = u->friend_getObject()->getDisabledFlags();
+#if RETAIL_COMPATIBLE_CRC
 			if (!dis.any() || dis.anyIntersectionWith(u->getDisabledTypesToProcess()))
+#else
+			// TheSuperHackers @bugfix Stubbjax 15/03/2026 The disabled-types-to-process mask is now exclusive.
+			// Previously, if the disabled mask had any bits in common with the disabled-types-to-process mask,
+			// the update would be processed. Now, if any *other* bits are set in the disabled mask, the update
+			// is no longer processed.
+			if (!dis.any() || u->getDisabledTypesToProcess().testForAll(dis))
+#endif
 			{
 				USE_PERF_TIMER(GameLogic_update_normal)
 
@@ -3832,7 +3840,15 @@ void GameLogic::update()
 			UpdateSleepTime sleepLen = UPDATE_SLEEP_NONE;	// default, if it is disabled.
 
 			DisabledMaskType dis = u->friend_getObject()->getDisabledFlags();
+#if RETAIL_COMPATIBLE_CRC
 			if (!dis.any() || dis.anyIntersectionWith(u->getDisabledTypesToProcess()))
+#else
+			// TheSuperHackers @bugfix Stubbjax 15/03/2026 The disabled-types-to-process mask is now exclusive.
+			// Previously, if the disabled mask had any bits in common with the disabled-types-to-process mask,
+			// the update would be processed. Now, if any *other* bits are set in the disabled mask, the update
+			// is no longer processed.
+			if (!dis.any() || u->getDisabledTypesToProcess().testForAll(dis))
+#endif
 			{
 				USE_PERF_TIMER(GameLogic_update_sleepy)
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -3799,7 +3799,7 @@ void GameLogic::update()
 			// Previously, if the disabled mask had any bits in common with the disabled-types-to-process mask,
 			// the update would be processed. Now, if any *other* bits are set in the disabled mask, the update
 			// is no longer processed.
-			if (!dis.any() || u->getDisabledTypesToProcess().testForAll(dis))
+			if (u->getDisabledTypesToProcess().testForAll(dis))
 #endif
 			{
 				USE_PERF_TIMER(GameLogic_update_normal)
@@ -3847,7 +3847,7 @@ void GameLogic::update()
 			// Previously, if the disabled mask had any bits in common with the disabled-types-to-process mask,
 			// the update would be processed. Now, if any *other* bits are set in the disabled mask, the update
 			// is no longer processed.
-			if (!dis.any() || u->getDisabledTypesToProcess().testForAll(dis))
+			if (u->getDisabledTypesToProcess().testForAll(dis))
 #endif
 			{
 				USE_PERF_TIMER(GameLogic_update_sleepy)


### PR DESCRIPTION
Closes TheSuperHackers/GeneralsGamePatch#147

This change fixes an issue where modules continue updating when disabled by a type that is not whitelisted.

For example, the stealth detector module has `DISABLED_HELD` whitelisted. This allows stealth detection to still run if an object is held, which in most cases is the result of containment (though `CanDetectWhileContained` typically blocks this). Any other disabling type is expected to shut the stealth detector down, such as `DISABLED_EMP` or `DISABLED_SUBDUED`. The problem is that the module only looks for whether the `DISABLED_HELD` bit is set and, if so, any other disabled type such as `DISABLED_EMP` is not considered.

This can also be seen elsewhere, such as with powered USA base defences. `BaseRegenerateUpdate` whitelists `DISABLED_UNDERPOWERED`. This means a Patriot Missile Battery will still repair itself when out of power. Conversely, if a Patriot Missile Battery is disabled by a Microwave Tank (`DISABLED_SUBDUED`), it will not repair itself. But if an underpowered Patriot Missile Battery is out of power _and_ disabled by a Microwave Tank, then it _will_ repair itself.

### Before
The EMP Patriot will not repair while subdued, but will while the power is also out

https://github.com/user-attachments/assets/17885e3f-a354-48a8-a187-a7cae5aec7fe

### After
A disabled (including unmanned) Overlord's Gattling Cannon no longer detects stealth units

https://github.com/user-attachments/assets/34d65c36-8b8c-4dd7-8269-8da402f1d938