### PR TITLE
build(docker): Fix docker WORKDIR ownership

### DIFF
--- a/resources/dockerbuild/Dockerfile
+++ b/resources/dockerbuild/Dockerfile
@@ -22,8 +22,8 @@ RUN mkdir -pm755 /etc/apt/keyrings \
     && apt clean \
     && rm -rf /var/lib/apt/lists/*
 # Setup build folder 
-RUN mkdir /build
-RUN chown  ${UID}:${GID} /build
+RUN mkdir -p /build/tools
+RUN chown -R  ${UID}:${GID} /build
 
 USER ${UID}:${GID}
 WORKDIR /build/tools


### PR DESCRIPTION
Docker will create `WORKDIR` when it doesn't exist, but it does not guarantee its ownership (often `root:root`).  
In my environment (`Docker version 29.2.1, build a5c7197d72` on Arch Linux) it caused [cmake download](https://github.com/TheSuperHackers/GeneralsGameCode/blob/39647c3b49d6c1ea5bcf15245c8060075ce2b58a/resources/dockerbuild/Dockerfile#L32) to fail because `WORKDIR /build/tools` was owned by `root` and `${UID}:${GID}` had no write permissions in it.  
This PR explicitly sets the `/build/tools` ownership to `${UID}:${GID}` by creating it before setting `WORKDIR` and making `chown  ${UID}:${GID} /build` recursive so it includes `/build/tools`.