### PR TITLE
fix(pathfinder): Remove invalid retail compatible compilation conditional

### DIFF
--- a/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -8694,7 +8694,7 @@ Path *Pathfinder::findClosestPath( Object *obj, const LocomotorSet& locomotorSet
 			PathfindCell *ignoreCell = getClippedCell(goalObj->getLayer(), goalObj->getPosition());
 			if ( (goalCell->getObstacleID()==ignoreCell->getObstacleID()) && (goalCell->getObstacleID() != INVALID_ID) ) {
 				Object* newObstacle = TheGameLogic->findObjectByID(goalCell->getObstacleID());
-#if RTS_GENERALS && RETAIL_COMPATIBLE_PATHFINDING
+#if RTS_GENERALS
 				if (newObstacle != nullptr && newObstacle->isKindOf(KINDOF_AIRFIELD))
 #else
 				if (newObstacle != nullptr && newObstacle->isKindOf(KINDOF_FS_AIRFIELD))


### PR DESCRIPTION
This PR fixes a non retail build issue with Generals.

the `KindOf` enumerations changed btween Generals and Zero Hour, where some were removed and many more added.

The kinf of airfield enumeration was removed and new "Faction Structure" types were added. in it's place `KINDOF_FS_AIRFIELD` was introduced that deprecated `KINDOF_AIRFIELD`.

I am sure these are data dependent but didn't want to touch them at the moment. I already have an issue about these.

Therefore it was incorrect to also include the retail compatible pathfinding conditional with the block covering these `KindOf` checks.