### PR TITLE
chore: Remove debug code for KRIS_BRUTAL_HACK_FOR_AIRCRAFT_CARRIER_DEBUGGING

### DIFF
--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplayStringManager.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplayStringManager.h
@@ -35,13 +35,8 @@
 //-------------------------------------------------------------------------------------------------
 /** Access for creating game managed display strings */
 //-------------------------------------------------------------------------------------------------
-//#define KRIS_BRUTAL_HACK_FOR_AIRCRAFT_CARRIER_DEBUGGING
 
-#ifdef KRIS_BRUTAL_HACK_FOR_AIRCRAFT_CARRIER_DEBUGGING
-	#define MAX_GROUPS 20
-#else
-	#define MAX_GROUPS 10
-#endif
+#define MAX_GROUPS 10
 
 class W3DDisplayStringManager : public DisplayStringManager
 {

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayStringManager.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayStringManager.cpp
@@ -83,16 +83,9 @@ void W3DDisplayStringManager::postProcessLoad()
 	{
 		m_groupNumeralStrings[i] = newDisplayString();
 		m_groupNumeralStrings[i]->setFont(font);
-
-#ifdef KRIS_BRUTAL_HACK_FOR_AIRCRAFT_CARRIER_DEBUGGING
-		UnicodeString displayNumber;
-		displayNumber.format( L"%d", i);
-		m_groupNumeralStrings[i]->setText( displayNumber );
-#else
  		AsciiString displayNumber;
  		displayNumber.format("NUMBER:%d", i);
  		m_groupNumeralStrings[i]->setText(TheGameText->fetch(displayNumber));
-#endif
 	}
 
 	m_formationLetterDisplayString = newDisplayString();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Drawable.cpp
@@ -81,12 +81,6 @@
 
 #include "ww3d.h"
 
-//#define KRIS_BRUTAL_HACK_FOR_AIRCRAFT_CARRIER_DEBUGGING
-#ifdef KRIS_BRUTAL_HACK_FOR_AIRCRAFT_CARRIER_DEBUGGING
-	#include "GameLogic/Module/ParkingPlaceBehavior.h"
-#endif
-
-
 #define VERY_TRANSPARENT_MATERIAL_PASS_OPACITY (0.001f)
 #define MATERIAL_PASS_OPACITY_FADE_SCALAR (0.8f)
 
@@ -2791,10 +2785,6 @@ void Drawable::drawIconUI()
 
 		//Moved this to last so that it shows up over contained and ammo icons.
 		drawVeterancy( healthBarRegion );
-
-#ifdef KRIS_BRUTAL_HACK_FOR_AIRCRAFT_CARRIER_DEBUGGING
-		drawUIText();
-#endif
 	}
 }
 
@@ -3173,48 +3163,6 @@ void Drawable::drawUIText()
 													TheDrawGroupInfo->m_dropShadowOffsetY);
 
 	}
-
-#ifdef KRIS_BRUTAL_HACK_FOR_AIRCRAFT_CARRIER_DEBUGGING
-	if( obj->testStatus( OBJECT_STATUS_DECK_HEIGHT_OFFSET ) )
-	{
-		Object *carrier = TheGameLogic->findObjectByID( obj->getProducerID() );
-		if( carrier )
-		{
-			for (BehaviorModule** i = carrier->getBehaviorModules(); *i; ++i)
-			{
-				ParkingPlaceBehaviorInterface *pp = (*i)->getParkingPlaceBehaviorInterface();
-				if( pp )
-				{
-					Int index = pp->getSpaceIndex( obj->getID() );
-
-					Int xPos = healthBarRegion->lo.x;
-					Int yPos = healthBarRegion->lo.y;
-
-					if (TheDrawGroupInfo->m_usingPixelOffsetX) {
-						xPos += TheDrawGroupInfo->m_pixelOffsetX;
-					} else {
-						xPos += (healthBarRegion->width() * TheDrawGroupInfo->m_percentOffsetX);
-					}
-
-					if (TheDrawGroupInfo->m_usingPixelOffsetY) {
-						yPos += TheDrawGroupInfo->m_pixelOffsetY;
-					} else {
-						yPos += (healthBarRegion->width() * TheDrawGroupInfo->m_percentOffsetY);
-					}
-
-					m_groupNumber = TheDisplayStringManager->getGroupNumeralString(index);
-
-
-					m_groupNumber->draw(xPos, yPos, color,
-															TheDrawGroupInfo->m_colorForTextDropShadow,
-															TheDrawGroupInfo->m_dropShadowOffsetX,
-															TheDrawGroupInfo->m_dropShadowOffsetY);
-					break;
-				}
-			}
-		}
-	}
-#endif
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplayStringManager.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplayStringManager.h
@@ -35,13 +35,8 @@
 //-------------------------------------------------------------------------------------------------
 /** Access for creating game managed display strings */
 //-------------------------------------------------------------------------------------------------
-//#define KRIS_BRUTAL_HACK_FOR_AIRCRAFT_CARRIER_DEBUGGING
 
-#ifdef KRIS_BRUTAL_HACK_FOR_AIRCRAFT_CARRIER_DEBUGGING
-	#define MAX_GROUPS 20
-#else
-	#define MAX_GROUPS 10
-#endif
+#define MAX_GROUPS 10
 
 class W3DDisplayStringManager : public DisplayStringManager
 {

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayStringManager.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayStringManager.cpp
@@ -83,16 +83,9 @@ void W3DDisplayStringManager::postProcessLoad()
 	{
 		m_groupNumeralStrings[i] = newDisplayString();
 		m_groupNumeralStrings[i]->setFont(font);
-
-#ifdef KRIS_BRUTAL_HACK_FOR_AIRCRAFT_CARRIER_DEBUGGING
-		UnicodeString displayNumber;
-		displayNumber.format( L"%d", i);
-		m_groupNumeralStrings[i]->setText( displayNumber );
-#else
  		AsciiString displayNumber;
  		displayNumber.format("NUMBER:%d", i);
  		m_groupNumeralStrings[i]->setText(TheGameText->fetch(displayNumber));
-#endif
 	}
 
 	m_formationLetterDisplayString = newDisplayString();


### PR DESCRIPTION
feat: Remove aircraft carrier debugging hack

Removes legacy Aircraft Carrier debugging code that was originally introduced for temporary deck-logic troubleshooting. This hack was already inactive in the game as it was commented out in the source.

- Removed KRIS_BRUTAL_HACK_FOR_AIRCRAFT_CARRIER_DEBUGGING macro.
- Standardized MAX_GROUPS to 10 in W3DDisplayStringManager.
- Removed debug numeral formatting and aircraft carrier deck indexing logic.
- Cleaned up associated conditional includes and code blocks.
- Applied changes to both Generals and GeneralsMD for consistency.

Reasoning: Cleaning up old development debt and removing logic that is no longer active or helpful. This reduces noise in the source files and simplifies the W3D initialization and rendering paths.
