### PR TITLE
fix(smudge): Fix minor errors in W3DSmudge

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DSmudge.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DSmudge.cpp
@@ -70,8 +70,11 @@ void W3DSmudgeManager::ReleaseResources()
 	REF_PTR_RELEASE(m_indexBuffer);
 }
 
-//Make sure (SMUDGE_DRAW_SIZE * 12) < 65535 because that's the max index buffer size.
+
 #define SMUDGE_DRAW_SIZE	500	//draw at most 50 smudges per call. Tweak value to improve CPU/GPU parallelism.
+
+static_assert(SMUDGE_DRAW_SIZE * 5 < 0x10000, "Vertex index exceeds 16-bit limit");
+
 
 void W3DSmudgeManager::ReAcquireResources()
 {
@@ -237,16 +240,20 @@ Bool W3DSmudgeManager::testHardwareSupport()
 
 		//bottom right
 		v[0].p = Vector4( BLOCK_SIZE-0.5f, BLOCK_SIZE-0.5f, 0.0f, 1.0f );
-		v[0].u = BLOCK_SIZE/(Real)TheDisplay->getWidth();	v[0].v = BLOCK_SIZE/(Real)TheDisplay->getHeight();
+		v[0].u = BLOCK_SIZE/(Real)TheDisplay->getWidth();
+		v[0].v = BLOCK_SIZE/(Real)TheDisplay->getHeight();
 		//top right
 		v[1].p = Vector4( BLOCK_SIZE-0.5f, 0-0.5f, 0.0f, 1.0f );
-		v[1].u = BLOCK_SIZE/(Real)TheDisplay->getWidth();	v[1].v = 0;
+		v[1].u = BLOCK_SIZE/(Real)TheDisplay->getWidth();
+		v[1].v = 0;
 		//bottom left
 		v[2].p = Vector4(  0-0.5f, BLOCK_SIZE-0.5f, 0.0f, 1.0f );
-		v[2].u = 0;	v[2].v = BLOCK_SIZE/(Real)TheDisplay->getHeight();
+		v[2].u = 0;
+		v[2].v = BLOCK_SIZE/(Real)TheDisplay->getHeight();
 		//top left
 		v[3].p = Vector4(  0-0.5f,  0-0.5f, 0.0f, 1.0f );
-		v[3].u = 0;	v[3].v = 0;
+		v[3].u = 0;
+		v[3].v = 0;
 
 		v[0].color = UNIQUE_COLOR;
 		v[1].color = UNIQUE_COLOR;
@@ -390,19 +397,12 @@ void W3DSmudgeManager::render(RenderInfoClass &rinfo)
 
 				Vector2 &thisUV=verts[i].uv;
 
-				//Clamp coordinates so we're not referencing texels outside the view.
-				if (thisUV.X > texClampX)
-					smudge->m_offset.X = 0;
-				else
-				if (thisUV.X < 0)
+				// Zero coordinates that fall outside valid texel bounds
+				if (thisUV.X < 0 || thisUV.X > texClampX)
 					smudge->m_offset.X = 0;
 
-				if (thisUV.Y > texClampY)
+				if (thisUV.Y < 0 || thisUV.Y > texClampY)
 					smudge->m_offset.Y = 0;
-				else
-				if (thisUV.Y < 0)
-					smudge->m_offset.Y = 0;
-
 			}
 
 			//Finish center vertex
@@ -410,7 +410,7 @@ void W3DSmudgeManager::render(RenderInfoClass &rinfo)
 			uvSpanX=verts[3].uv.X - verts[0].uv.X;
 			uvSpanY=verts[1].uv.Y - verts[0].uv.Y;
 			verts[4].uv.X=verts[0].uv.X+uvSpanX*(0.5f+smudge->m_offset.X);
-			verts[4].uv.Y=verts[0].uv.Y+uvSpanY*(0.5f+smudge->m_offset.X);
+			verts[4].uv.Y=verts[0].uv.Y+uvSpanY*(0.5f+smudge->m_offset.Y);
 
 			count++;	//increment visible smudge count.
 			smudge=smudge->Succ();
@@ -487,7 +487,8 @@ void W3DSmudgeManager::render(RenderInfoClass &rinfo)
 
 					//Check if we exceeded maximum number of smudges allowed per draw call.
 					if (smudgesInRenderBatch >= count)
-					{	remainingSmudgeStart = smudge;
+					{
+						remainingSmudgeStart = smudge;
 						goto flushSmudges;
 					}
 
@@ -520,11 +521,12 @@ void W3DSmudgeManager::render(RenderInfoClass &rinfo)
 				if (set)	//start next batch at beginning of set.
 					remainingSmudgeStart = set->getUsedSmudgeList().Head();
 			}
-flushSmudges:
-			DX8Wrapper::Set_Vertex_Buffer(vb_access);
 		}
 
-		DX8Wrapper::Draw_Triangles(	0,smudgesInRenderBatch*4, 0, smudgesInRenderBatch*5);
+flushSmudges:
+		DX8Wrapper::Set_Vertex_Buffer(vb_access);
+
+		DX8Wrapper::Draw_Triangles(0,smudgesInRenderBatch*4, 0, smudgesInRenderBatch*5);
 
 //Debug Code which draws outline around smudge
 /*		DX8Wrapper::_Get_D3D_Device8()->SetRenderState(D3DRS_FILLMODE,D3DFILL_WIREFRAME);


### PR DESCRIPTION
* Split off of #1073

This change adds a few minor fixes to W3DSmudge.

1. The static assert turns the comment to a compile guarantee.

2. The smudge offset Y is now used correctly, but visually appears to have no obvious impact.

3. The `vb_access` buffer in `W3DSmudgeManager::render` is no longer forwarded to rendering before the lock is lifted.