### PR TITLE
fix(core): Add missing virtual keyword to ParticleSystemManagerDummy overrides

### DIFF
--- a/Core/GameEngine/Include/GameClient/ParticleSys.h
+++ b/Core/GameEngine/Include/GameClient/ParticleSys.h
@@ -840,14 +840,14 @@ private:
 class ParticleSystemManagerDummy : public ParticleSystemManager
 {
 public:
-	Int getOnScreenParticleCount() override { return 0; }
-	void doParticles(RenderInfoClass &rinfo) override {}
-	void queueParticleRender() override {}
+	virtual Int getOnScreenParticleCount() override { return 0; }
+	virtual void doParticles(RenderInfoClass &rinfo) override {}
+	virtual void queueParticleRender() override {}
 
 protected:
-	void crc( Xfer *xfer ) override {}
-	void xfer( Xfer *xfer ) override {}
-	void loadPostProcess() override {}
+	virtual void crc( Xfer *xfer ) override {}
+	virtual void xfer( Xfer *xfer ) override {}
+	virtual void loadPostProcess() override {}
 };
 
 /// The particle system manager singleton


### PR DESCRIPTION
* Relates to #2101

Add missing `virtual` keyword to 6 override functions in `ParticleSystemManagerDummy`. This class was added after the GameEngine override PRs (#2391/#2392) merged, so it was missed in the sweep.