### PR TITLE
fix(smudge): Align smudges Y offset range with X offset range

### DIFF
--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DParticleSys.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DParticleSys.cpp
@@ -181,7 +181,7 @@ void W3DParticleSystemManager::doParticles(RenderInfoClass &rinfo)
 					Smudge *smudge = set->addSmudgeToSet();
 
 					smudge->m_pos.Set( pos->x, pos->y, pos->z );
-					smudge->m_offset.Set( GameClientRandomValueReal(-0.06f,0.06f), GameClientRandomValueReal(-0.03f,0.03f) );
+					smudge->m_offset.Set( GameClientRandomValueReal(-0.06f,0.06f), GameClientRandomValueReal(-0.06f,0.06f) );
 					smudge->m_size = psize;
 					smudge->m_opacity = p->getAlpha();
 					visibleSmudgeCount++;


### PR DESCRIPTION
* Follow up for #2483

This change aligns the smudges Y offset range with the X offset range.

This tweak is a follow up for #2483 which fixed using the Y offset.

<img width="908" height="87" alt="image" src="https://github.com/user-attachments/assets/8745f632-9963-4ade-88cb-547a83d1cfc7" />
