### PR TITLE
bugfix(energy): Don't increase power production for disabled power plants on save game load

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -3638,19 +3638,6 @@ void Object::xfer( Xfer *xfer )
 	// private status
 	xfer->xferUnsignedByte( &m_privateStatus );
 
-	// OK, now that we have xferred our status bits, it's safe to set the team...
-	if( xfer->getXferMode() == XFER_LOAD )
-	{
-		Team *team = TheTeamFactory->findTeamByID( teamID );
-		if( team == nullptr )
-		{
-			DEBUG_CRASH(( "Object::xfer - Unable to load team" ));
-			throw SC_INVALID_DATA;
-		}
-		const Bool restoring = true;
-		setOrRestoreTeam( team, restoring );
-	}
-
 	// geometry info
 	xfer->xferSnapshot( &m_geometryInfo );
 
@@ -3692,6 +3679,20 @@ void Object::xfer( Xfer *xfer )
 
 	// disabled till frame
 	xfer->xferUser( m_disabledTillFrame, sizeof( UnsignedInt ) * DISABLED_COUNT );
+
+	// OK, now that we have xferred our status bits and disabled data, it's safe to set the team...
+	// TheSuperHackers @todo Refactor so that this code can be moved to loadPostProcess.
+	if( xfer->getXferMode() == XFER_LOAD )
+	{
+		Team *team = TheTeamFactory->findTeamByID( teamID );
+		if( team == nullptr )
+		{
+			DEBUG_CRASH(( "Object::xfer - Unable to load team" ));
+			throw SC_INVALID_DATA;
+		}
+		const Bool restoring = true;
+		setOrRestoreTeam( team, restoring );
+	}
 
 	// special model condition until
 	xfer->xferUnsignedInt( &m_smcUntil );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -4160,19 +4160,6 @@ void Object::xfer( Xfer *xfer )
 	// private status
 	xfer->xferUnsignedByte( &m_privateStatus );
 
-	// OK, now that we have xferred our status bits, it's safe to set the team...
-	if( xfer->getXferMode() == XFER_LOAD )
-	{
-		Team *team = TheTeamFactory->findTeamByID( teamID );
-		if( team == nullptr )
-		{
-			DEBUG_CRASH(( "Object::xfer - Unable to load team" ));
-			throw SC_INVALID_DATA;
-		}
-		const Bool restoring = true;
-		setOrRestoreTeam( team, restoring );
-	}
-
 	// geometry info
 	xfer->xferSnapshot( &m_geometryInfo );
 
@@ -4223,6 +4210,19 @@ void Object::xfer( Xfer *xfer )
 
 	// disabled till frame
 	xfer->xferUser( m_disabledTillFrame, sizeof( UnsignedInt ) * DISABLED_COUNT );
+
+	// OK, now that we have xferred our status bits, it's safe to set the team...
+	if( xfer->getXferMode() == XFER_LOAD )
+	{
+		Team *team = TheTeamFactory->findTeamByID( teamID );
+		if( team == nullptr )
+		{
+			DEBUG_CRASH(( "Object::xfer - Unable to load team" ));
+			throw SC_INVALID_DATA;
+		}
+		const Bool restoring = true;
+		setOrRestoreTeam( team, restoring );
+	}
 
 	// special model condition until
 	xfer->xferUnsignedInt( &m_smcUntil );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -4211,7 +4211,7 @@ void Object::xfer( Xfer *xfer )
 	// disabled till frame
 	xfer->xferUser( m_disabledTillFrame, sizeof( UnsignedInt ) * DISABLED_COUNT );
 
-	// OK, now that we have xferred our status bits, it's safe to set the team...
+	// OK, now that we have xferred our status bits and disabled data, it's safe to set the team...
 	if( xfer->getXferMode() == XFER_LOAD )
 	{
 		Team *team = TheTeamFactory->findTeamByID( teamID );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -4212,6 +4212,7 @@ void Object::xfer( Xfer *xfer )
 	xfer->xferUser( m_disabledTillFrame, sizeof( UnsignedInt ) * DISABLED_COUNT );
 
 	// OK, now that we have xferred our status bits and disabled data, it's safe to set the team...
+	// TheSuperHackers @todo Refactor so that this code can be moved to loadPostProcess.
 	if( xfer->getXferMode() == XFER_LOAD )
 	{
 		Team *team = TheTeamFactory->findTeamByID( teamID );


### PR DESCRIPTION
When loading a save game with disabled power plants, players still get the power production from those plants. That's because the power production is increased before the `Object` disabled flags are xfer'd. The following code is supposed to prevent the increase in power production, but the disabled flag would have to be xfer'd before this is called. This PR fixes that.

https://github.com/TheSuperHackers/GeneralsGameCode/blob/920c4e6393927a6488edcee7382207529077eed6/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp#L3829-L3835

Callstack:
```
generalszh.exe!Object::friend_adjustPowerForPlayer(bool incoming)
generalszh.exe!Player::becomingTeamMember(Object * obj, bool yes)
generalszh.exe!Object::setOrRestoreTeam(Team * team, bool restoring)
generalszh.exe!Object::xfer(Xfer * xfer)
```

## TODO:
- [x] Replicate in Generals.