### PR TITLE
bugfix(energy): Don't apply power production bonus for disabled power plants on save game load

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/RTS/Energy.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/Energy.cpp
@@ -169,6 +169,8 @@ void Energy::addPowerBonus( Object *obj )
 	if( obj == nullptr )
 		return;
 
+	DEBUG_ASSERTCRASH(!obj->isDisabled(), ("power bonus should not be added to disabled power plant"));
+
 	addProduction(obj->getTemplate()->getEnergyBonus());
 
 	// sanity

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/OverchargeBehavior.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/OverchargeBehavior.cpp
@@ -317,7 +317,15 @@ void OverchargeBehavior::loadPostProcess()
 	UpdateModule::loadPostProcess();
 
 	// Our effect is a fire and forget effect, not an upgrade state that is itself saved, so need to re-fire.
-	if( m_overchargeActive && getObject()->getControllingPlayer() )
-		getObject()->getControllingPlayer()->addPowerBonus( getObject() );
+	if (m_overchargeActive)
+	{
+		Object* obj = getObject();
+		Player* player = obj->getControllingPlayer();
+
+		if (player && !obj->isDisabled())
+		{
+			player->addPowerBonus(obj);
+		}
+	}
 
 }

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Upgrade/PowerPlantUpgrade.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Upgrade/PowerPlantUpgrade.cpp
@@ -167,13 +167,15 @@ void PowerPlantUpgrade::loadPostProcess()
 
 	// Most upgrade modules have state change effects that are themselves saved.  This one is a fire and forget.
 	// So we need to re-fire on load if we are turned on.
-	if( isAlreadyUpgraded() )
+	if (isAlreadyUpgraded())
 	{
-		Player *player = getObject()->getControllingPlayer();
+		Object* obj = getObject();
+		Player* player = obj->getControllingPlayer();
 
-		// add the new power production to the object
-		if( player )
-			player->addPowerBonus(getObject());
+		if (player && !obj->isDisabled())
+		{
+			player->addPowerBonus(obj);
+		}
 	}
 
 }

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Energy.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Energy.cpp
@@ -188,6 +188,8 @@ void Energy::addPowerBonus( Object *obj )
 	if( obj == nullptr )
 		return;
 
+	DEBUG_ASSERTCRASH(!obj->isDisabled(), ("power bonus should not be added to disabled power plant"));
+
 	addProduction(obj->getTemplate()->getEnergyBonus());
 
 	// sanity

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/OverchargeBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/OverchargeBehavior.cpp
@@ -317,7 +317,15 @@ void OverchargeBehavior::loadPostProcess()
 	UpdateModule::loadPostProcess();
 
 	// Our effect is a fire and forget effect, not an upgrade state that is itself saved, so need to re-fire.
-	if( m_overchargeActive && getObject()->getControllingPlayer() )
-		getObject()->getControllingPlayer()->addPowerBonus( getObject() );
+	if (m_overchargeActive)
+	{
+		Object* obj = getObject();
+		Player* player = obj->getControllingPlayer();
+
+		if (player && !obj->isDisabled())
+		{
+			player->addPowerBonus(obj);
+		}
+	}
 
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Upgrade/PowerPlantUpgrade.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Upgrade/PowerPlantUpgrade.cpp
@@ -167,13 +167,15 @@ void PowerPlantUpgrade::loadPostProcess()
 
 	// Most upgrade modules have state change effects that are themselves saved.  This one is a fire and forget.
 	// So we need to re-fire on load if we are turned on.
-	if( isAlreadyUpgraded() )
+	if (isAlreadyUpgraded())
 	{
-		Player *player = getObject()->getControllingPlayer();
+		Object* obj = getObject();
+		Player* player = obj->getControllingPlayer();
 
-		// add the new power production to the object
-		if( player )
-			player->addPowerBonus(getObject());
+		if (player && !obj->isDisabled())
+		{
+			player->addPowerBonus(obj);
+		}
 	}
 
 }


### PR DESCRIPTION
When loading a save game with disabled power plants, players still get the power production bonus from those plants if they're either overcharged or upgraded. That's because the power production is increased without a check if the plant is disabled. This PR fixes that.

## TODO:
- [x] Replicate in Generals.