### PR TITLE
perf(gui): Significantly reduce cost of 2d render elements

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -1880,7 +1880,10 @@ void W3DView::draw()
 	/// @todo we might want to consider wiping this iterate out if there is nothing to post draw
 	//
 	TheGameClient->resetRenderedObjectCount();
+
+	TheDisplay->beginBatch();
 	TheGameClient->iterateDrawablesInRegion( &axisAlignedRegion, drawablePostDraw, this );
+	TheDisplay->endBatch();
 
 	TheGameClient->flushTextBearingDrawables();
 

--- a/Generals/Code/GameEngine/Include/GameClient/Display.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Display.h
@@ -113,14 +113,11 @@ public:
 	virtual	Bool isClippingEnabled() = 0;
 	virtual	void enableClipping( Bool onoff ) = 0;
 
-	// TheSuperHackers @info start batching 2D draw operations.
-	virtual void beginBatch();
-	// TheSuperHackers @info stop batching and flush pending 2D draw operations.
-	virtual void endBatch();
-	// TheSuperHackers @info flush pending 2D draw operations without ending the batch.
-	virtual void flush();
-	// TheSuperHackers @info returns true if currently batching 2D draw operations.
-	virtual Bool isBatching() const { return m_isBatching; }
+	// TheSuperHackers @performance Batching 2D draw operations to reduce state changes and draw call overhead.
+	virtual void beginBatch(); 									///< start batching 2D draw operations.
+	virtual void endBatch();   									///< stop batching and flush pending 2D draw operations.
+	virtual void flush();      									///< flush pending 2D draw operations without ending the batch.
+	virtual Bool isBatching() const { return m_isBatching; }	///< returns true if currently batching 2D draw operations.
 
 	virtual void step() {}; ///< Do one fixed time step
 	virtual void draw() override;																		///< Redraw the entire display

--- a/Generals/Code/GameEngine/Include/GameClient/Display.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Display.h
@@ -116,7 +116,7 @@ public:
 	virtual void beginBatch();
 	virtual void endBatch();
 	virtual void flush();
-	virtual Bool isBatching() { return m_isBatching; }
+	virtual Bool isBatching() const { return m_isBatching; }
 
 	virtual void step() {}; ///< Do one fixed time step
 	virtual void draw() override;																		///< Redraw the entire display

--- a/Generals/Code/GameEngine/Include/GameClient/Display.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Display.h
@@ -113,6 +113,11 @@ public:
 	virtual	Bool isClippingEnabled() = 0;
 	virtual	void enableClipping( Bool onoff ) = 0;
 
+	virtual void beginBatch();
+	virtual void endBatch();
+	virtual void flush();
+	virtual Bool isBatching() { return m_isBatching; }
+
 	virtual void step() {}; ///< Do one fixed time step
 	virtual void draw() override;																		///< Redraw the entire display
 	virtual void setTimeOfDay( TimeOfDay tod ) = 0;								///< Set the time of day for this display
@@ -182,11 +187,15 @@ public:
 	virtual Int getLastFrameDrawCalls() = 0;  ///< returns the number of draw calls issued in the previous frame
 
 protected:
+	virtual void onBeginBatch() { }
+	virtual void onEndBatch() { }
+	virtual void onFlush() { }
 
 	virtual void deleteViews();   ///< delete all views
 	UnsignedInt m_width, m_height;			///< Dimensions of the display
 	UnsignedInt m_bitDepth;							///< bit depth of the display
 	Bool m_windowed;										///< TRUE when windowed, FALSE when fullscreen
+	Bool m_isBatching;
 	View *m_viewList;										///< All of the views into the world
 
 	// Cinematic text data

--- a/Generals/Code/GameEngine/Include/GameClient/Display.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Display.h
@@ -113,9 +113,13 @@ public:
 	virtual	Bool isClippingEnabled() = 0;
 	virtual	void enableClipping( Bool onoff ) = 0;
 
+	// TheSuperHackers @info start batching 2D draw operations.
 	virtual void beginBatch();
+	// TheSuperHackers @info stop batching and flush pending 2D draw operations.
 	virtual void endBatch();
+	// TheSuperHackers @info flush pending 2D draw operations without ending the batch.
 	virtual void flush();
+	// TheSuperHackers @info returns true if currently batching 2D draw operations.
 	virtual Bool isBatching() const { return m_isBatching; }
 
 	virtual void step() {}; ///< Do one fixed time step

--- a/Generals/Code/GameEngine/Source/GameClient/Display.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Display.cpp
@@ -66,6 +66,7 @@ Display::Display()
 
 	m_currentlyPlayingMovie.clear();
 	m_letterBoxFadeStartTime = 0;
+	m_isBatching = FALSE;
 }
 
 /**
@@ -386,4 +387,29 @@ void Display::setDebugDisplayCallback( DebugDisplayCallback *callback, void *use
 Display::DebugDisplayCallback *Display::getDebugDisplayCallback()
 {
 	return m_debugDisplayCallback;
+}
+
+void Display::beginBatch()
+{
+	if (m_isBatching)
+	{
+		return;
+	}
+	m_isBatching = TRUE;
+	onBeginBatch();
+}
+
+void Display::endBatch()
+{
+	if (!m_isBatching)
+	{
+		return;
+	}
+	m_isBatching = FALSE;
+	onEndBatch();
+}
+
+void Display::flush()
+{
+	onFlush();
 }

--- a/Generals/Code/GameEngine/Source/GameClient/Display.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Display.cpp
@@ -406,6 +406,7 @@ void Display::endBatch()
 		return;
 	}
 	m_isBatching = FALSE;
+	onFlush();
 	onEndBatch();
 }
 

--- a/Generals/Code/GameEngine/Source/GameClient/Display.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Display.cpp
@@ -405,8 +405,8 @@ void Display::endBatch()
 	{
 		return;
 	}
-	m_isBatching = FALSE;
 	onFlush();
+	m_isBatching = FALSE;
 	onEndBatch();
 }
 

--- a/Generals/Code/GameEngine/Source/GameClient/Display.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Display.cpp
@@ -411,5 +411,8 @@ void Display::endBatch()
 
 void Display::flush()
 {
-	onFlush();
+	if (m_isBatching)
+	{
+		onFlush();
+	}
 }

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -45,6 +45,7 @@ class Render2DClass;
 class RTS3DScene;
 class RTS2DScene;
 class RTS3DInterfaceScene;
+class TextureClass;
 
 
 //=============================================================================
@@ -160,6 +161,10 @@ protected:
 	void calculateTerrainLOD();						///< Calculate terrain LOD.
 	void renderLetterBox(UnsignedInt time);							///< draw letter box border
 	void updateAverageFPS();	///< calculate the average fps over the last 30 frames.
+	void setup2DRenderState(TextureClass *tex, DrawImageMode mode, Bool grayscale);
+	virtual void onBeginBatch() override;
+	virtual void onEndBatch() override;
+	virtual void onFlush() override;
 
 	Byte m_initialized;												///< TRUE when system is initialized
 	LightClass *m_myLight[LightEnvironmentClass::MAX_LIGHTS];										///< light hack for now
@@ -168,6 +173,12 @@ protected:
 	Bool m_isClippedEnabled;	///<used by 2D drawing operations to define clip re
 	Real m_averageFPS;		///<average fps over the last 30 frames.
 	Real m_currentFPS;		///<current fps value.
+
+	TextureClass *m_batchTexture;
+	DrawImageMode m_batchMode;
+	Bool m_batchGrayscale;
+	Bool m_batchNeedsInit;
+
 #if defined(RTS_DEBUG)
 	Int64 m_timerAtCumuFPSStart;
 #endif

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -543,11 +543,12 @@ void W3DDisplay::onBeginBatch()
 	m_batchTexture = nullptr;
 	m_batchMode = DRAW_IMAGE_ALPHA;
 	m_batchGrayscale = FALSE;
+	m_batchNeedsInit = TRUE;
+
 	if (m_2DRender)
 	{
 		m_2DRender->Reset();
 	}
-	m_batchNeedsInit = TRUE;
 }
 
 void W3DDisplay::onEndBatch()
@@ -591,6 +592,7 @@ void W3DDisplay::setup2DRenderState(TextureClass *tex, DrawImageMode mode, Bool 
 			{
 				m_batchTexture->Release_Ref();
 			}
+
 			m_batchTexture = tex;
 		}
 
@@ -598,12 +600,9 @@ void W3DDisplay::setup2DRenderState(TextureClass *tex, DrawImageMode mode, Bool 
 		m_batchGrayscale = grayscale;
 		m_batchNeedsInit = FALSE;
 	}
-	else
+	else if (m_2DRender)
 	{
-		if (m_2DRender)
-		{
-			m_2DRender->Reset();
-		}
+		m_2DRender->Reset();
 	}
 
 	if (m_2DRender)
@@ -620,26 +619,26 @@ void W3DDisplay::setup2DRenderState(TextureClass *tex, DrawImageMode mode, Bool 
 
 		switch (mode)
 		{
-		case DRAW_IMAGE_ALPHA:
-			m_2DRender->Enable_Additive(FALSE);
-			m_2DRender->Enable_Alpha(TRUE);
-			m_2DRender->Enable_Grayscale(grayscale);
-			break;
-		case DRAW_IMAGE_GRAYSCALE:
-			m_2DRender->Enable_Additive(FALSE);
-			m_2DRender->Enable_Alpha(TRUE);
-			m_2DRender->Enable_Grayscale(TRUE);
-			break;
-		case DRAW_IMAGE_ADDITIVE:
-			m_2DRender->Enable_Additive(TRUE);
-			m_2DRender->Enable_Alpha(FALSE);
-			m_2DRender->Enable_Grayscale(grayscale);
-			break;
-		case DRAW_IMAGE_SOLID:
-			m_2DRender->Enable_Additive(FALSE);
-			m_2DRender->Enable_Alpha(FALSE);
-			m_2DRender->Enable_Grayscale(grayscale);
-			break;
+			case DRAW_IMAGE_ALPHA:
+				m_2DRender->Enable_Additive(FALSE);
+				m_2DRender->Enable_Alpha(TRUE);
+				m_2DRender->Enable_Grayscale(grayscale);
+				break;
+			case DRAW_IMAGE_GRAYSCALE:
+				m_2DRender->Enable_Additive(FALSE);
+				m_2DRender->Enable_Alpha(TRUE);
+				m_2DRender->Enable_Grayscale(TRUE);
+				break;
+			case DRAW_IMAGE_ADDITIVE:
+				m_2DRender->Enable_Additive(TRUE);
+				m_2DRender->Enable_Alpha(FALSE);
+				m_2DRender->Enable_Grayscale(grayscale);
+				break;
+			case DRAW_IMAGE_SOLID:
+				m_2DRender->Enable_Additive(FALSE);
+				m_2DRender->Enable_Alpha(FALSE);
+				m_2DRender->Enable_Grayscale(grayscale);
+				break;
 		}
 	}
 }
@@ -2630,7 +2629,6 @@ void W3DDisplay::drawImage( const Image *image, Int startX, Int startY,
 		tex = WW3DAssetManager::Get_Instance()->Get_Texture(image->getFilename().str(), MIP_LEVELS_1);
 
 	Bool grayscale = (mode == DRAW_IMAGE_GRAYSCALE);
-	///@todo: Why are we alpha blending all images?  Reduces our fillrate. -MW
 	setup2DRenderState(tex, mode, grayscale);
 
 	RectClass screen_rect(startX,startY,endX,endY);

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -614,8 +614,8 @@ void W3DDisplay::setup2DRenderState(TextureClass *tex, DrawImageMode mode, Bool 
 
 		switch (mode)
 		{
-			case DRAW_IMAGE_ALPHA:
 			default:
+			case DRAW_IMAGE_ALPHA:
 				m_2DRender->Enable_Additive(FALSE);
 				m_2DRender->Enable_Alpha(TRUE);
 				m_2DRender->Enable_Grayscale(grayscale);

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -2422,8 +2422,7 @@ void W3DDisplay::drawRemainingRectClock(Int startX, Int startY, Int width, Int h
 	if( percent < 0 || percent > 99 )
 		return;
 
-	m_2DRender->Reset();
-	m_2DRender->Enable_Texturing( FALSE );
+	setup2DRenderState(nullptr, DRAW_IMAGE_ALPHA, FALSE);
 
 // The rectanges are numbered as follows
 //(x,y)	|---------|

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -354,6 +354,10 @@ W3DDisplay::W3DDisplay()
 	for (i = 0; i < DisplayStringCount; i++)
 		m_displayStrings[i] = nullptr;
 
+	m_batchTexture = nullptr;
+	m_batchMode = DRAW_IMAGE_ALPHA;
+	m_batchGrayscale = FALSE;
+	m_batchNeedsInit = FALSE;
 }
 
 // W3DDisplay::~W3DDisplay ====================================================
@@ -532,6 +536,112 @@ void W3DDisplay::setHeight( UnsignedInt height )
 	// of the screen with (width,height) at the lower right
 	m_2DRender->Set_Coordinate_Range( RectClass( 0, 0, getWidth(), getHeight() ) );
 
+}
+
+void W3DDisplay::onBeginBatch()
+{
+	m_batchTexture = nullptr;
+	m_batchMode = DRAW_IMAGE_ALPHA;
+	m_batchGrayscale = FALSE;
+	if (m_2DRender)
+	{
+		m_2DRender->Reset();
+	}
+	m_batchNeedsInit = TRUE;
+}
+
+void W3DDisplay::onEndBatch()
+{
+	onFlush();
+	if (m_batchTexture)
+	{
+		m_batchTexture->Release_Ref();
+		m_batchTexture = nullptr;
+	}
+}
+
+void W3DDisplay::onFlush()
+{
+	if (m_2DRender && !m_batchNeedsInit)
+	{
+		m_2DRender->Render();
+		m_2DRender->Reset();
+		m_batchNeedsInit = TRUE;
+	}
+}
+
+void W3DDisplay::setup2DRenderState(TextureClass *tex, DrawImageMode mode, Bool grayscale)
+{
+	if (m_isBatching)
+	{
+		if (!m_batchNeedsInit && m_batchTexture == tex && m_batchMode == mode && m_batchGrayscale == grayscale)
+		{
+			return;
+		}
+
+		onFlush();
+
+		if (tex != m_batchTexture)
+		{
+			if (tex)
+			{
+				tex->Add_Ref();
+			}
+			if (m_batchTexture)
+			{
+				m_batchTexture->Release_Ref();
+			}
+			m_batchTexture = tex;
+		}
+
+		m_batchMode = mode;
+		m_batchGrayscale = grayscale;
+		m_batchNeedsInit = FALSE;
+	}
+	else
+	{
+		if (m_2DRender)
+		{
+			m_2DRender->Reset();
+		}
+	}
+
+	if (m_2DRender)
+	{
+		if (tex)
+		{
+			m_2DRender->Enable_Texturing(TRUE);
+			m_2DRender->Set_Texture(tex);
+		}
+		else
+		{
+			m_2DRender->Enable_Texturing(FALSE);
+		}
+
+		switch (mode)
+		{
+		case DRAW_IMAGE_ALPHA:
+			m_2DRender->Enable_Additive(FALSE);
+			m_2DRender->Enable_Alpha(TRUE);
+			m_2DRender->Enable_Grayscale(grayscale);
+			break;
+		case DRAW_IMAGE_GRAYSCALE:
+			m_2DRender->Enable_Additive(FALSE);
+			m_2DRender->Enable_Alpha(TRUE);
+			m_2DRender->Enable_Grayscale(TRUE);
+			break;
+		case DRAW_IMAGE_ADDITIVE:
+			m_2DRender->Enable_Additive(TRUE);
+			m_2DRender->Enable_Alpha(FALSE);
+			m_2DRender->Enable_Grayscale(grayscale);
+			break;
+		case DRAW_IMAGE_SOLID:
+			m_2DRender->Enable_Additive(FALSE);
+			m_2DRender->Enable_Alpha(FALSE);
+			m_2DRender->Enable_Grayscale(grayscale);
+			break;
+		}
+	}
 }
 
 // W3DDisplay::initAssets =====================================================
@@ -2039,13 +2149,14 @@ void W3DDisplay::drawLine( Int startX, Int startY,
 													 Real lineWidth,
 													 UnsignedInt lineColor )
 {
+	setup2DRenderState(nullptr, DRAW_IMAGE_ALPHA, FALSE);
 
-	/// @todo we need to consider the efficiency of the 2D renderer
-	m_2DRender->Reset();
-	m_2DRender->Enable_Texturing( FALSE );
 	m_2DRender->Add_Line( Vector2( startX, startY ), Vector2( endX, endY ),
 												lineWidth, lineColor );
-	m_2DRender->Render();
+	if (!m_isBatching)
+	{
+		m_2DRender->Render();
+	}
 
 }
 
@@ -2057,13 +2168,15 @@ void W3DDisplay::drawLine( Int startX, Int startY,
 													 Real lineWidth,
 													 UnsignedInt lineColor1,UnsignedInt lineColor2 )
 {
+	setup2DRenderState(nullptr, DRAW_IMAGE_ALPHA, FALSE);
 
-	/// @todo we need to consider the efficiency of the 2D renderer
-	m_2DRender->Reset();
-	m_2DRender->Enable_Texturing( FALSE );
 	m_2DRender->Add_Line( Vector2( startX, startY ), Vector2( endX, endY ),
 												lineWidth, lineColor1, lineColor2 );
-	m_2DRender->Render();
+
+	if (!m_isBatching)
+	{
+		m_2DRender->Render();
+	}
 
 }
 
@@ -2106,16 +2219,17 @@ void W3DDisplay::drawOpenRect( Int startX, Int startY, Int width, Int height,
 	}
 	else
 	{
-		/// @todo we need to consider the efficiency of the 2D renderer
-		m_2DRender->Reset();
-		m_2DRender->Enable_Texturing( FALSE );
+		setup2DRenderState(nullptr, DRAW_IMAGE_ALPHA, FALSE);
 
 		m_2DRender->Add_Outline( RectClass( startX, startY,
 																				startX + width, startY + height ),
 														 lineWidth, lineColor );
 
 		// render it now!
-		m_2DRender->Render();
+		if (!m_isBatching)
+		{
+			m_2DRender->Render();
+		}
 	}
 
 }
@@ -2125,17 +2239,17 @@ void W3DDisplay::drawOpenRect( Int startX, Int startY, Int width, Int height,
 void W3DDisplay::drawFillRect( Int startX, Int startY, Int width, Int height,
 															 UnsignedInt color )
 {
+	setup2DRenderState(nullptr, DRAW_IMAGE_ALPHA, FALSE);
 
-	/// @todo we need to consider the efficiency of the 2D renderer
-	m_2DRender->Reset();
-	m_2DRender->Enable_Texturing( FALSE );
 	m_2DRender->Add_Rect( RectClass( startX, startY,
 																	 startX + width, startY + height ),
 												0, 0, color );
 
 	// render it now!
-	m_2DRender->Render();
-
+	if (!m_isBatching)
+	{
+		m_2DRender->Render();
+	}
 }
 
 void W3DDisplay::drawRectClock(Int startX, Int startY, Int width, Int height, Int percent, UnsignedInt color)
@@ -2144,8 +2258,7 @@ void W3DDisplay::drawRectClock(Int startX, Int startY, Int width, Int height, In
 	if(percent < 1 || percent > 100)
 		return;
 
-	m_2DRender->Reset();
-	m_2DRender->Enable_Texturing( FALSE );
+	setup2DRenderState(nullptr, DRAW_IMAGE_ALPHA, FALSE);
 
 // The rectanges are numberd as follows
 //(x,y)	|---------|
@@ -2291,8 +2404,10 @@ void W3DDisplay::drawRectClock(Int startX, Int startY, Int width, Int height, In
 	}
 
 	// render it now!
-	m_2DRender->Render();
-
+	if (!m_isBatching)
+	{
+		m_2DRender->Render();
+	}
 }
 
 
@@ -2470,7 +2585,10 @@ void W3DDisplay::drawRemainingRectClock(Int startX, Int startY, Int width, Int h
 	}
 
 	// render it now!
-	m_2DRender->Render();
+	if (!m_isBatching)
+	{
+		m_2DRender->Render();
+	}
 }
 
 
@@ -2486,6 +2604,17 @@ void W3DDisplay::drawImage( const Image *image, Int startX, Int startY,
 	if( image == nullptr )
 		return;
 
+	if (m_isClippedEnabled)
+	{
+		if (	endX <= m_clipRegion.lo.x ||
+				endY <= m_clipRegion.lo.y ||
+				startX >= m_clipRegion.hi.x ||
+				startY >= m_clipRegion.hi.y)
+		{
+			return;	//nothing to render
+		}
+	}
+
 	// !!
 	// Remember to update the GUIEditDisplay::drawImage when you make
 	// changes to this, it technically uses W3D code to render itself,
@@ -2494,52 +2623,23 @@ void W3DDisplay::drawImage( const Image *image, Int startX, Int startY,
 
 	const Region2D *uv = image->getUV();
 
-	m_2DRender->Reset();
-	m_2DRender->Enable_Texturing( TRUE );
-
-	Bool doAlphaReset=FALSE;
-
-	///@todo: Why are we alpha blending all images?  Reduces our fillrate. -MW
-	switch (mode)
-	{
-		case DRAW_IMAGE_ALPHA:	//nothing to do since alpha is the default state
-			break;
-		case DRAW_IMAGE_GRAYSCALE:
-			m_2DRender->Enable_Grayscale(true);
-			break;
-		case DRAW_IMAGE_ADDITIVE:
-			m_2DRender->Enable_Additive(true);
-			doAlphaReset = TRUE;
-			break;
-		case DRAW_IMAGE_SOLID:
-			m_2DRender->Enable_Additive(false);
-			m_2DRender->Enable_Alpha(false);
-			doAlphaReset = TRUE;
-			break;
-		default:
-			break;
-	}
-
-	// if we have raw texture data we will use it, otherwise we are referencing filenames
-	if( BitIsSet( image->getStatus(), IMAGE_STATUS_RAW_TEXTURE ) )
-		m_2DRender->Set_Texture( (TextureClass *)(image->getRawTextureData()) );
+	TextureClass *tex = nullptr;
+	if (BitIsSet(image->getStatus(), IMAGE_STATUS_RAW_TEXTURE))
+		tex = (TextureClass *)(image->getRawTextureData());
 	else
-		m_2DRender->Set_Texture( image->getFilename().str() );
+		tex = WW3DAssetManager::Get_Instance()->Get_Texture(image->getFilename().str(), MIP_LEVELS_1);
+
+	Bool grayscale = (mode == DRAW_IMAGE_GRAYSCALE);
+	///@todo: Why are we alpha blending all images?  Reduces our fillrate. -MW
+	setup2DRenderState(tex, mode, grayscale);
 
 	RectClass screen_rect(startX,startY,endX,endY);
 	RectClass uv_rect(uv->lo.x,uv->lo.y,uv->hi.x,uv->hi.y);
 
 	if (m_isClippedEnabled)
 	{	//need to clip this quad to clip rectangle
-
-		//
-		//	Check for completely clipped
-		//
-		if (	endX <= m_clipRegion.lo.x ||
-				endY <= m_clipRegion.lo.y)
+		if (screen_rect.Left < m_clipRegion.lo.x || screen_rect.Right > m_clipRegion.hi.x || screen_rect.Top < m_clipRegion.lo.y || screen_rect.Bottom > m_clipRegion.hi.y)
 		{
-			return;	//nothing to render
-		} else {
 			RectClass clipped_rect;
 			RectClass clipped_uv_rect;
 
@@ -2639,12 +2739,20 @@ void W3DDisplay::drawImage( const Image *image, Int startX, Int startY,
 
 	}
 
-	m_2DRender->Render();
+	if (!m_isBatching)
+	{
+		m_2DRender->Render();
+		m_2DRender->Enable_Grayscale(false);
+		if (mode == DRAW_IMAGE_ADDITIVE || mode == DRAW_IMAGE_SOLID)
+		{
+			m_2DRender->Enable_Alpha(true);
+		}
+	}
 
-	//reset to default states for next time this method is called.
-	m_2DRender->Enable_Grayscale(false);	//never leave it in this mode
-	if (doAlphaReset)
-		m_2DRender->Enable_Alpha(true);
+	if (tex != nullptr && !BitIsSet(image->getStatus(), IMAGE_STATUS_RAW_TEXTURE))
+	{
+		tex->Release_Ref();
+	}
 
 }
 
@@ -2746,12 +2854,15 @@ void W3DDisplay::drawVideoBuffer( VideoBuffer *buffer, Int startX, Int startY, I
 {
 	W3DVideoBuffer *vbuffer = (W3DVideoBuffer*) buffer;
 
-	m_2DRender->Reset();
-	m_2DRender->Enable_Texturing( TRUE );
-	m_2DRender->Set_Texture( vbuffer->texture() );
+	setup2DRenderState(vbuffer->texture(), DRAW_IMAGE_ALPHA, FALSE);
+
 	m_2DRender->Add_Quad( RectClass( startX, startY, endX, endY ),
 												vbuffer->Rect( 0, 0, 1, 1) );
-	m_2DRender->Render();
+	
+	if (!m_isBatching)
+	{
+		m_2DRender->Render();
+	}
 
 }
 

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -553,7 +553,7 @@ void W3DDisplay::onBeginBatch()
 
 void W3DDisplay::onEndBatch()
 {
-	SAFE_RELEASE(m_batchTexture);
+	REF_PTR_RELEASE(m_batchTexture);
 }
 
 void W3DDisplay::onFlush()

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -553,12 +553,7 @@ void W3DDisplay::onBeginBatch()
 
 void W3DDisplay::onEndBatch()
 {
-	onFlush();
-	if (m_batchTexture)
-	{
-		m_batchTexture->Release_Ref();
-		m_batchTexture = nullptr;
-	}
+	SAFE_RELEASE(m_batchTexture);
 }
 
 void W3DDisplay::onFlush()
@@ -2225,7 +2220,6 @@ void W3DDisplay::drawOpenRect( Int startX, Int startY, Int width, Int height,
 																				startX + width, startY + height ),
 														 lineWidth, lineColor );
 
-		// render it now!
 		if (!m_isBatching)
 		{
 			m_2DRender->Render();
@@ -2245,7 +2239,6 @@ void W3DDisplay::drawFillRect( Int startX, Int startY, Int width, Int height,
 																	 startX + width, startY + height ),
 												0, 0, color );
 
-	// render it now!
 	if (!m_isBatching)
 	{
 		m_2DRender->Render();
@@ -2403,7 +2396,6 @@ void W3DDisplay::drawRectClock(Int startX, Int startY, Int width, Int height, In
 		}
 	}
 
-	// render it now!
 	if (!m_isBatching)
 	{
 		m_2DRender->Render();
@@ -2583,7 +2575,6 @@ void W3DDisplay::drawRemainingRectClock(Int startX, Int startY, Int width, Int h
 		}
 	}
 
-	// render it now!
 	if (!m_isBatching)
 	{
 		m_2DRender->Render();
@@ -2605,10 +2596,10 @@ void W3DDisplay::drawImage( const Image *image, Int startX, Int startY,
 
 	if (m_isClippedEnabled)
 	{
-		if (	endX <= m_clipRegion.lo.x ||
-				endY <= m_clipRegion.lo.y ||
-				startX >= m_clipRegion.hi.x ||
-				startY >= m_clipRegion.hi.y)
+		if (endX <= m_clipRegion.lo.x ||
+			endY <= m_clipRegion.lo.y ||
+			startX >= m_clipRegion.hi.x ||
+			startY >= m_clipRegion.hi.y)
 		{
 			return;	//nothing to render
 		}

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -620,6 +620,7 @@ void W3DDisplay::setup2DRenderState(TextureClass *tex, DrawImageMode mode, Bool 
 		switch (mode)
 		{
 			case DRAW_IMAGE_ALPHA:
+			default:
 				m_2DRender->Enable_Additive(FALSE);
 				m_2DRender->Enable_Alpha(TRUE);
 				m_2DRender->Enable_Grayscale(grayscale);

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayString.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayString.cpp
@@ -226,10 +226,7 @@ void W3DDisplayString::draw( Int x, Int y, Color color, Color dropColor, Int xDr
 
 	}
 
-	if (TheDisplay->isBatching())
-	{
-		TheDisplay->flush();
-	}
+	TheDisplay->flush();
 
 	if(m_useHotKey)
 	{

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayString.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayString.cpp
@@ -49,6 +49,7 @@
 #include <stdlib.h>
 
 // USER INCLUDES //////////////////////////////////////////////////////////////
+#include "GameClient/Display.h"
 #include "GameClient/GameClient.h"
 #include "W3DDevice/GameClient/W3DDisplayString.h"
 #include "GameClient/HotKey.h"
@@ -216,17 +217,25 @@ void W3DDisplayString::draw( Int x, Int y, Color color, Color dropColor, Int xDr
 		m_textRenderer.Set_Location( Vector2( m_textPos.x, m_textPos.y ) );
 		m_textRenderer.Draw_Sentence( m_currTextColor );
 
-		if(m_useHotKey)
+		if (m_useHotKey)
 		{
 			m_textRendererHotKey.Reset_Polys();
 			m_textRendererHotKey.Set_Location( Vector2( m_textPos.x + m_hotKeyPos.x , m_textPos.y +m_hotKeyPos.y) );
 			m_textRendererHotKey.Draw_Sentence( m_hotKeyColor );
-			m_textRendererHotKey.Render();
 		}
 
 	}
 
-	// render the text
+	if (TheDisplay->isBatching())
+	{
+		TheDisplay->flush();
+	}
+
+	if(m_useHotKey)
+	{
+		m_textRendererHotKey.Render();
+	}
+
 	m_textRenderer.Render();
 
 	// we are for sure using display resources now

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayString.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayString.cpp
@@ -228,7 +228,7 @@ void W3DDisplayString::draw( Int x, Int y, Color color, Color dropColor, Int xDr
 
 	TheDisplay->flush();
 
-	if(m_useHotKey)
+	if (m_useHotKey)
 	{
 		m_textRendererHotKey.Render();
 	}

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DInGameUI.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DInGameUI.cpp
@@ -387,6 +387,7 @@ void W3DInGameUI::reset()
 //-------------------------------------------------------------------------------------------------
 void W3DInGameUI::draw()
 {
+	TheDisplay->beginBatch();
 	preDraw();
 
 	// draw selection region if drag selecting
@@ -438,6 +439,8 @@ void W3DInGameUI::draw()
 #ifdef EXTENDED_STATS
 	}
 #endif
+
+	TheDisplay->endBatch();
 
 }
 

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Display.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Display.h
@@ -113,6 +113,10 @@ public:
 	virtual	Bool isClippingEnabled() = 0;
 	virtual	void enableClipping( Bool onoff ) = 0;
 
+	virtual void beginBatch() { }
+	virtual void endBatch() { }
+	virtual Bool isBatching() { return m_isBatching; }
+
 	virtual void step() {}; ///< Do one fixed time step
 	virtual void draw() override;																		///< Redraw the entire display
 	virtual void setTimeOfDay( TimeOfDay tod ) = 0;								///< Set the time of day for this display
@@ -187,6 +191,7 @@ protected:
 	UnsignedInt m_width, m_height;			///< Dimensions of the display
 	UnsignedInt m_bitDepth;							///< bit depth of the display
 	Bool m_windowed;										///< TRUE when windowed, FALSE when fullscreen
+	Bool m_isBatching;
 	View *m_viewList;										///< All of the views into the world
 
 	// Cinematic text data

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Display.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Display.h
@@ -113,14 +113,11 @@ public:
 	virtual	Bool isClippingEnabled() = 0;
 	virtual	void enableClipping( Bool onoff ) = 0;
 
-	// TheSuperHackers @info start batching 2D draw operations.
-	virtual void beginBatch();
-	// TheSuperHackers @info stop batching and flush pending 2D draw operations.
-	virtual void endBatch();
-	// TheSuperHackers @info flush pending 2D draw operations without ending the batch.
-	virtual void flush();
-	// TheSuperHackers @info returns true if currently batching 2D draw operations.
-	virtual Bool isBatching() const { return m_isBatching; }
+	// TheSuperHackers @performance Batching 2D draw operations to reduce state changes and draw call overhead.
+	virtual void beginBatch(); 									///< start batching 2D draw operations.
+	virtual void endBatch();   									///< stop batching and flush pending 2D draw operations.
+	virtual void flush();      									///< flush pending 2D draw operations without ending the batch.
+	virtual Bool isBatching() const { return m_isBatching; }	///< returns true if currently batching 2D draw operations.
 
 	virtual void step() {}; ///< Do one fixed time step
 	virtual void draw() override;																		///< Redraw the entire display

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Display.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Display.h
@@ -116,7 +116,7 @@ public:
 	virtual void beginBatch();
 	virtual void endBatch();
 	virtual void flush();
-	virtual Bool isBatching() { return m_isBatching; }
+	virtual Bool isBatching() const { return m_isBatching; }
 
 	virtual void step() {}; ///< Do one fixed time step
 	virtual void draw() override;																		///< Redraw the entire display

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Display.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Display.h
@@ -58,7 +58,8 @@ public:
 		DRAW_IMAGE_SOLID,
 		DRAW_IMAGE_GRAYSCALE,		//draw image without blending and ignoring alpha
 		DRAW_IMAGE_ALPHA,		//alpha blend the image into frame buffer
-		DRAW_IMAGE_ADDITIVE	//additive blend the image into frame buffer
+		DRAW_IMAGE_ADDITIVE,	//additive blend the image into frame buffer
+		DRAW_IMAGE_PRIMITIVE	//non-textured primitive (lines, rects)
 	};
 
 	typedef void (DebugDisplayCallback)( DebugDisplayInterface *debugDisplay, void *userData, FILE *fp );

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Display.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Display.h
@@ -114,8 +114,9 @@ public:
 	virtual	Bool isClippingEnabled() = 0;
 	virtual	void enableClipping( Bool onoff ) = 0;
 
-	virtual void beginBatch() { }
-	virtual void endBatch() { }
+	virtual void beginBatch();
+	virtual void endBatch();
+	virtual void flush();
 	virtual Bool isBatching() { return m_isBatching; }
 
 	virtual void step() {}; ///< Do one fixed time step
@@ -187,6 +188,9 @@ public:
 	virtual Int getLastFrameDrawCalls() = 0;  ///< returns the number of draw calls issued in the previous frame
 
 protected:
+	virtual void onBeginBatch() { }
+	virtual void onEndBatch() { }
+	virtual void onFlush() { }
 
 	virtual void deleteViews();   ///< delete all views
 	UnsignedInt m_width, m_height;			///< Dimensions of the display

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Display.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Display.h
@@ -113,9 +113,13 @@ public:
 	virtual	Bool isClippingEnabled() = 0;
 	virtual	void enableClipping( Bool onoff ) = 0;
 
+	// TheSuperHackers @info start batching 2D draw operations.
 	virtual void beginBatch();
+	// TheSuperHackers @info stop batching and flush pending 2D draw operations.
 	virtual void endBatch();
+	// TheSuperHackers @info flush pending 2D draw operations without ending the batch.
 	virtual void flush();
+	// TheSuperHackers @info returns true if currently batching 2D draw operations.
 	virtual Bool isBatching() const { return m_isBatching; }
 
 	virtual void step() {}; ///< Do one fixed time step

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Display.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Display.h
@@ -58,8 +58,7 @@ public:
 		DRAW_IMAGE_SOLID,
 		DRAW_IMAGE_GRAYSCALE,		//draw image without blending and ignoring alpha
 		DRAW_IMAGE_ALPHA,		//alpha blend the image into frame buffer
-		DRAW_IMAGE_ADDITIVE,	//additive blend the image into frame buffer
-		DRAW_IMAGE_PRIMITIVE	//non-textured primitive (lines, rects)
+		DRAW_IMAGE_ADDITIVE	//additive blend the image into frame buffer
 	};
 
 	typedef void (DebugDisplayCallback)( DebugDisplayInterface *debugDisplay, void *userData, FILE *fp );

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Display.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Display.cpp
@@ -405,6 +405,7 @@ void Display::endBatch()
 	{
 		return;
 	}
+	onFlush();
 	m_isBatching = FALSE;
 	onEndBatch();
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Display.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Display.cpp
@@ -405,8 +405,8 @@ void Display::endBatch()
 	{
 		return;
 	}
-	onEndBatch();
 	m_isBatching = FALSE;
+	onEndBatch();
 }
 
 void Display::flush()

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Display.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Display.cpp
@@ -391,14 +391,20 @@ Display::DebugDisplayCallback *Display::getDebugDisplayCallback()
 
 void Display::beginBatch()
 {
-	if (m_isBatching) return;
+	if (m_isBatching)
+	{
+		return;
+	}
 	m_isBatching = TRUE;
 	onBeginBatch();
 }
 
 void Display::endBatch()
 {
-	if (!m_isBatching) return;
+	if (!m_isBatching)
+	{
+		return;
+	}
 	onEndBatch();
 	m_isBatching = FALSE;
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Display.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Display.cpp
@@ -411,5 +411,8 @@ void Display::endBatch()
 
 void Display::flush()
 {
-	onFlush();
+	if (m_isBatching)
+	{
+		onFlush();
+	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Display.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Display.cpp
@@ -66,6 +66,7 @@ Display::Display()
 
 	m_currentlyPlayingMovie.clear();
 	m_letterBoxFadeStartTime = 0;
+	m_isBatching = FALSE;
 }
 
 /**
@@ -386,4 +387,23 @@ void Display::setDebugDisplayCallback( DebugDisplayCallback *callback, void *use
 Display::DebugDisplayCallback *Display::getDebugDisplayCallback()
 {
 	return m_debugDisplayCallback;
+}
+
+void Display::beginBatch()
+{
+	if (m_isBatching) return;
+	m_isBatching = TRUE;
+	onBeginBatch();
+}
+
+void Display::endBatch()
+{
+	if (!m_isBatching) return;
+	onEndBatch();
+	m_isBatching = FALSE;
+}
+
+void Display::flush()
+{
+	onFlush();
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowManager.cpp
@@ -1269,6 +1269,8 @@ void GameWindowManager::winRepaint()
 {
 	GameWindow *window, *next;
 
+	TheDisplay->beginBatch();
+
 	// draw below windows
 	for( window = m_windowTail; window; window = next )
 	{
@@ -1299,6 +1301,8 @@ void GameWindowManager::winRepaint()
 
 	if(TheTransitionHandler)
 		TheTransitionHandler->draw();
+
+	TheDisplay->endBatch();
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GameWindowManager.cpp
@@ -1269,8 +1269,6 @@ void GameWindowManager::winRepaint()
 {
 	GameWindow *window, *next;
 
-	TheDisplay->beginBatch();
-
 	// draw below windows
 	for( window = m_windowTail; window; window = next )
 	{
@@ -1301,8 +1299,6 @@ void GameWindowManager::winRepaint()
 
 	if(TheTransitionHandler)
 		TheTransitionHandler->draw();
-
-	TheDisplay->endBatch();
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -45,6 +45,7 @@ class Render2DClass;
 class RTS3DScene;
 class RTS2DScene;
 class RTS3DInterfaceScene;
+class TextureClass;
 
 
 //=============================================================================
@@ -80,6 +81,9 @@ public:
 
 	virtual void step() override; ///< Do one fixed time step
 	virtual void draw() override;  ///< redraw the entire display
+
+	virtual void beginBatch();
+	virtual void endBatch();
 
 	/// @todo Replace these light management routines with a LightManager singleton
 	virtual void createLightPulse( const Coord3D *pos, const RGBColor *color, Real innerRadius,Real outerRadius,
@@ -168,6 +172,11 @@ protected:
 	Bool m_isClippedEnabled;	///<used by 2D drawing operations to define clip re
 	Real m_averageFPS;		///<average fps over the last 30 frames.
 	Real m_currentFPS;		///<current fps value.
+
+	TextureClass *m_batchTexture;
+	DrawImageMode m_batchMode;
+	Bool m_batchGrayscale;
+
 #if defined(RTS_DEBUG)
 	Int64 m_timerAtCumuFPSStart;
 #endif

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -164,6 +164,7 @@ protected:
 	void calculateTerrainLOD();						///< Calculate terrain LOD.
 	void renderLetterBox(UnsignedInt time);							///< draw letter box border
 	void updateAverageFPS();	///< calculate the average fps over the last 30 frames.
+	void setup2DRenderState(TextureClass *tex, DrawImageMode mode, Bool grayscale);
 
 	Byte m_initialized;												///< TRUE when system is initialized
 	LightClass *m_myLight[LightEnvironmentClass::MAX_LIGHTS];										///< light hack for now

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -82,9 +82,6 @@ public:
 	virtual void step() override; ///< Do one fixed time step
 	virtual void draw() override;  ///< redraw the entire display
 
-	virtual void beginBatch();
-	virtual void endBatch();
-
 	/// @todo Replace these light management routines with a LightManager singleton
 	virtual void createLightPulse( const Coord3D *pos, const RGBColor *color, Real innerRadius,Real outerRadius,
 																 UnsignedInt increaseFrameTime, UnsignedInt decayFrameTime//, Bool donut = FALSE
@@ -165,6 +162,9 @@ protected:
 	void renderLetterBox(UnsignedInt time);							///< draw letter box border
 	void updateAverageFPS();	///< calculate the average fps over the last 30 frames.
 	void setup2DRenderState(TextureClass *tex, DrawImageMode mode, Bool grayscale);
+	virtual void onBeginBatch() override;
+	virtual void onEndBatch() override;
+	virtual void onFlush() override;
 
 	Byte m_initialized;												///< TRUE when system is initialized
 	LightClass *m_myLight[LightEnvironmentClass::MAX_LIGHTS];										///< light hack for now
@@ -177,6 +177,7 @@ protected:
 	TextureClass *m_batchTexture;
 	DrawImageMode m_batchMode;
 	Bool m_batchGrayscale;
+	Bool m_batchNeedsInit;
 
 #if defined(RTS_DEBUG)
 	Int64 m_timerAtCumuFPSStart;

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -408,7 +408,7 @@ W3DDisplay::W3DDisplay()
 	m_batchTexture = nullptr;
 	m_batchMode = DRAW_IMAGE_ALPHA;
 	m_batchGrayscale = FALSE;
-	m_batchNeedsInit = TRUE;
+	m_batchNeedsInit = FALSE;
 }
 
 // W3DDisplay::~W3DDisplay ====================================================
@@ -594,12 +594,11 @@ void W3DDisplay::onBeginBatch()
 	m_batchTexture = nullptr;
 	m_batchMode = DRAW_IMAGE_ALPHA;
 	m_batchGrayscale = FALSE;
-	m_batchNeedsInit = FALSE;
-
 	if (m_2DRender)
 	{
-		setup2DRenderState(nullptr, DRAW_IMAGE_ALPHA, FALSE);
+		m_2DRender->Reset();
 	}
+	m_batchNeedsInit = TRUE;
 }
 
 void W3DDisplay::onEndBatch()
@@ -614,9 +613,12 @@ void W3DDisplay::onEndBatch()
 
 void W3DDisplay::onFlush()
 {
-	if (m_2DRender && !m_batchNeedsInit)
+	if (m_2DRender)
 	{
-		m_2DRender->Render();
+		if (!m_batchNeedsInit)
+		{
+			m_2DRender->Render();
+		}
 		m_2DRender->Reset();
 		m_batchNeedsInit = TRUE;
 	}

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -591,15 +591,11 @@ void W3DDisplay::setHeight( UnsignedInt height )
 void W3DDisplay::beginBatch()
 {
 	m_isBatching = TRUE;
-	m_batchTexture = nullptr;
-	m_batchGrayscale = FALSE;
+	m_batchTexture = (TextureClass*)-1;
 	m_batchMode = DRAW_IMAGE_ALPHA;
-	if (m_2DRender)
-	{
-		m_2DRender->Reset();
-		m_2DRender->Enable_Texturing(FALSE);
-		m_2DRender->Enable_Alpha(TRUE);
-	}
+	m_batchGrayscale = FALSE;
+
+	setup2DRenderState(nullptr, DRAW_IMAGE_PRIMITIVE, FALSE);
 }
 
 void W3DDisplay::endBatch()
@@ -612,6 +608,79 @@ void W3DDisplay::endBatch()
 			m_2DRender->Reset();
 		}
 		m_isBatching = FALSE;
+		m_batchTexture = nullptr;
+		m_batchMode = DRAW_IMAGE_ALPHA;
+		m_batchGrayscale = FALSE;
+	}
+}
+
+void W3DDisplay::setup2DRenderState(TextureClass *tex, DrawImageMode mode, Bool grayscale)
+{
+	if (m_isBatching)
+	{
+		if (m_batchTexture == tex && m_batchMode == mode && m_batchGrayscale == grayscale)
+		{
+			return;
+		}
+
+		if (m_2DRender)
+		{
+			// if m_batchTexture == -1, this is the very first setup in a batch, we don't render/reset yet
+			if (m_batchTexture != (TextureClass*)-1)
+			{
+				m_2DRender->Render();
+				m_2DRender->Reset();
+			}
+		}
+		m_batchTexture = tex;
+		m_batchMode = mode;
+		m_batchGrayscale = grayscale;
+	}
+	else
+	{
+		if (m_2DRender)
+		{
+			m_2DRender->Reset();
+		}
+	}
+
+	if (m_2DRender)
+	{
+		if (tex)
+		{
+			m_2DRender->Enable_Texturing(TRUE);
+			m_2DRender->Set_Texture(tex);
+		}
+		else
+		{
+			m_2DRender->Enable_Texturing(FALSE);
+		}
+
+		// Strictly mirroring original commit's state setting logic per mode
+		switch (mode)
+		{
+		case DRAW_IMAGE_ALPHA:
+			m_2DRender->Enable_Alpha(TRUE);
+			m_2DRender->Enable_Grayscale(grayscale);
+			break;
+		case DRAW_IMAGE_GRAYSCALE:
+			m_2DRender->Enable_Grayscale(TRUE);
+			break;
+		case DRAW_IMAGE_ADDITIVE:
+			m_2DRender->Enable_Additive(TRUE);
+			m_2DRender->Enable_Grayscale(grayscale);
+			break;
+		case DRAW_IMAGE_SOLID:
+			m_2DRender->Enable_Additive(FALSE);
+			m_2DRender->Enable_Alpha(FALSE);
+			m_2DRender->Enable_Grayscale(grayscale);
+			break;
+		case DRAW_IMAGE_PRIMITIVE:
+			m_2DRender->Enable_Additive(FALSE);
+			m_2DRender->Enable_Alpha(TRUE);
+			m_2DRender->Enable_Grayscale(FALSE);
+			break;
+		}
 	}
 }
 
@@ -2179,24 +2248,7 @@ void W3DDisplay::drawLine( Int startX, Int startY,
 													 Real lineWidth,
 													 UnsignedInt lineColor )
 {
-	if (m_isBatching)
-	{
-		if (m_batchTexture != nullptr || m_batchMode != DRAW_IMAGE_SOLID)
-		{
-			m_2DRender->Render();
-			m_2DRender->Reset();
-			m_batchTexture = nullptr;
-			m_batchMode = DRAW_IMAGE_SOLID;
-			m_2DRender->Enable_Texturing(FALSE);
-			m_2DRender->Enable_Alpha(TRUE);
-		}
-	}
-	else
-	{
-		m_2DRender->Reset();
-		m_2DRender->Enable_Texturing( FALSE );
-		m_2DRender->Enable_Alpha(TRUE);
-	}
+	setup2DRenderState(nullptr, DRAW_IMAGE_PRIMITIVE, FALSE);
 
 	m_2DRender->Add_Line( Vector2( startX, startY ), Vector2( endX, endY ),
 												lineWidth, lineColor );
@@ -2215,24 +2267,7 @@ void W3DDisplay::drawLine( Int startX, Int startY,
 													 Real lineWidth,
 													 UnsignedInt lineColor1,UnsignedInt lineColor2 )
 {
-	if (m_isBatching)
-	{
-		if (m_batchTexture != nullptr || m_batchMode != DRAW_IMAGE_SOLID)
-		{
-			m_2DRender->Render();
-			m_2DRender->Reset();
-			m_batchTexture = nullptr;
-			m_batchMode = DRAW_IMAGE_SOLID;
-			m_2DRender->Enable_Texturing(FALSE);
-			m_2DRender->Enable_Alpha(TRUE);
-		}
-	}
-	else
-	{
-		m_2DRender->Reset();
-		m_2DRender->Enable_Texturing( FALSE );
-		m_2DRender->Enable_Alpha(TRUE);
-	}
+	setup2DRenderState(nullptr, DRAW_IMAGE_PRIMITIVE, FALSE);
 
 	m_2DRender->Add_Line( Vector2( startX, startY ), Vector2( endX, endY ),
 												lineWidth, lineColor1, lineColor2 );
@@ -2283,24 +2318,7 @@ void W3DDisplay::drawOpenRect( Int startX, Int startY, Int width, Int height,
 	}
 	else
 	{
-		if (m_isBatching)
-		{
-			if (m_batchTexture != nullptr || m_batchMode != DRAW_IMAGE_SOLID)
-			{
-				m_2DRender->Render();
-				m_2DRender->Reset();
-				m_batchTexture = nullptr;
-				m_batchMode = DRAW_IMAGE_SOLID;
-				m_2DRender->Enable_Texturing(FALSE);
-				m_2DRender->Enable_Alpha(TRUE);
-			}
-		}
-		else
-		{
-			m_2DRender->Reset();
-			m_2DRender->Enable_Texturing( FALSE );
-			m_2DRender->Enable_Alpha(TRUE);
-		}
+		setup2DRenderState(nullptr, DRAW_IMAGE_PRIMITIVE, FALSE);
 
 		m_2DRender->Add_Outline( RectClass( startX, startY,
 																				startX + width, startY + height ),
@@ -2320,24 +2338,7 @@ void W3DDisplay::drawOpenRect( Int startX, Int startY, Int width, Int height,
 void W3DDisplay::drawFillRect( Int startX, Int startY, Int width, Int height,
 															 UnsignedInt color )
 {
-	if (m_isBatching)
-	{
-		if (m_batchTexture != nullptr || m_batchMode != DRAW_IMAGE_SOLID)
-		{
-			m_2DRender->Render();
-			m_2DRender->Reset();
-			m_batchTexture = nullptr;
-			m_batchMode = DRAW_IMAGE_SOLID;
-			m_2DRender->Enable_Texturing(FALSE);
-			m_2DRender->Enable_Alpha(TRUE);
-		}
-	}
-	else
-	{
-		m_2DRender->Reset();
-		m_2DRender->Enable_Texturing( FALSE );
-		m_2DRender->Enable_Alpha(TRUE);
-	}
+	setup2DRenderState(nullptr, DRAW_IMAGE_PRIMITIVE, FALSE);
 
 	m_2DRender->Add_Rect( RectClass( startX, startY,
 																	 startX + width, startY + height ),
@@ -2356,24 +2357,7 @@ void W3DDisplay::drawRectClock(Int startX, Int startY, Int width, Int height, In
 	if(percent < 1 || percent > 100)
 		return;
 
-	if (m_isBatching)
-	{
-		if (m_batchTexture != nullptr || m_batchMode != DRAW_IMAGE_SOLID)
-		{
-			m_2DRender->Render();
-			m_2DRender->Reset();
-			m_batchTexture = nullptr;
-			m_batchMode = DRAW_IMAGE_SOLID;
-			m_2DRender->Enable_Texturing(FALSE);
-			m_2DRender->Enable_Alpha(TRUE);
-		}
-	}
-	else
-	{
-		m_2DRender->Reset();
-		m_2DRender->Enable_Texturing( FALSE );
-		m_2DRender->Enable_Alpha(TRUE);
-	}
+	setup2DRenderState(nullptr, DRAW_IMAGE_PRIMITIVE, FALSE);
 
 // The rectangles are numberd as follows
 //(x,y)	|---------|
@@ -2538,24 +2522,7 @@ void W3DDisplay::drawRemainingRectClock(Int startX, Int startY, Int width, Int h
 	if( percent < 0 || percent > 99 )
 		return;
 
-	if (m_isBatching)
-	{
-		if (m_batchTexture != nullptr || m_batchMode != DRAW_IMAGE_SOLID)
-		{
-			m_2DRender->Render();
-			m_2DRender->Reset();
-			m_batchTexture = nullptr;
-			m_batchMode = DRAW_IMAGE_SOLID;
-			m_2DRender->Enable_Texturing(FALSE);
-			m_2DRender->Enable_Alpha(TRUE);
-		}
-	}
-	else
-	{
-		m_2DRender->Reset();
-		m_2DRender->Enable_Texturing( FALSE );
-		m_2DRender->Enable_Alpha(TRUE);
-	}
+	setup2DRenderState(nullptr, DRAW_IMAGE_PRIMITIVE, FALSE);
 
 // The rectangles are numbered as follows
 //(x,y)	|---------|
@@ -2751,58 +2718,7 @@ void W3DDisplay::drawImage( const Image *image, Int startX, Int startY,
 
 	Bool grayscale = (mode == DRAW_IMAGE_GRAYSCALE);
 	///@todo: Why are we alpha blending all images?  Reduces our fillrate. -MW
-	if (m_isBatching)
-	{
-		if (m_batchTexture != tex || m_batchMode != mode || m_batchGrayscale != grayscale)
-		{
-			m_2DRender->Render();
-			m_2DRender->Reset();
-			m_batchTexture = tex;
-			m_batchMode = mode;
-			m_batchGrayscale = grayscale;
-
-			m_2DRender->Enable_Texturing(TRUE);
-			m_2DRender->Set_Texture(tex);
-			switch (mode)
-			{
-			case DRAW_IMAGE_ALPHA:
-				m_2DRender->Enable_Alpha(TRUE);
-				break;
-			case DRAW_IMAGE_GRAYSCALE:
-				m_2DRender->Enable_Grayscale(true);
-				break;
-			case DRAW_IMAGE_ADDITIVE:
-				m_2DRender->Enable_Additive(true);
-				break;
-			case DRAW_IMAGE_SOLID:
-				m_2DRender->Enable_Additive(false);
-				m_2DRender->Enable_Alpha(false);
-				break;
-			}
-		}
-	}
-	else
-	{
-		m_2DRender->Reset();
-		m_2DRender->Enable_Texturing(TRUE);
-		m_2DRender->Set_Texture(tex);
-		switch (mode)
-		{
-		case DRAW_IMAGE_ALPHA:
-			m_2DRender->Enable_Alpha(TRUE);
-			break;
-		case DRAW_IMAGE_GRAYSCALE:
-			m_2DRender->Enable_Grayscale(TRUE);
-			break;
-		case DRAW_IMAGE_ADDITIVE:
-			m_2DRender->Enable_Additive(TRUE);
-			break;
-		case DRAW_IMAGE_SOLID:
-			m_2DRender->Enable_Additive(FALSE);
-			m_2DRender->Enable_Alpha(FALSE);
-			break;
-		}
-	}
+	setup2DRenderState(tex, mode, grayscale);
 
 	if (tex != nullptr && !BitIsSet(image->getStatus(), IMAGE_STATUS_RAW_TEXTURE))
 	{
@@ -2926,7 +2842,10 @@ void W3DDisplay::drawImage( const Image *image, Int startX, Int startY,
 	{
 		m_2DRender->Render();
 		m_2DRender->Enable_Grayscale(false);
-		m_2DRender->Enable_Alpha(true);
+		if (mode == DRAW_IMAGE_ADDITIVE || mode == DRAW_IMAGE_SOLID)
+		{
+			m_2DRender->Enable_Alpha(true);
+		}
 	}
 
 }
@@ -3029,21 +2948,8 @@ void W3DDisplay::drawVideoBuffer( VideoBuffer *buffer, Int startX, Int startY, I
 {
 	W3DVideoBuffer *vbuffer = (W3DVideoBuffer*) buffer;
 
-	if (m_isBatching)
-	{
-		m_2DRender->Render();
-		m_2DRender->Reset();
-		m_batchTexture = vbuffer->texture();
-		m_batchMode = DRAW_IMAGE_ALPHA;
-		m_batchGrayscale = FALSE;
-	}
-	else
-	{
-		m_2DRender->Reset();
-	}
+	setup2DRenderState(vbuffer->texture(), DRAW_IMAGE_ALPHA, FALSE);
 
-	m_2DRender->Enable_Texturing( TRUE );
-	m_2DRender->Set_Texture( vbuffer->texture() );
 	m_2DRender->Add_Quad( RectClass( startX, startY, endX, endY ),
 												vbuffer->Rect( 0, 0, 1, 1) );
 	

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -408,6 +408,7 @@ W3DDisplay::W3DDisplay()
 	m_batchTexture = nullptr;
 	m_batchMode = DRAW_IMAGE_ALPHA;
 	m_batchGrayscale = FALSE;
+	m_batchNeedsInit = TRUE;
 }
 
 // W3DDisplay::~W3DDisplay ====================================================

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -593,11 +593,12 @@ void W3DDisplay::onBeginBatch()
 	m_batchTexture = nullptr;
 	m_batchMode = DRAW_IMAGE_ALPHA;
 	m_batchGrayscale = FALSE;
+	m_batchNeedsInit = TRUE;
+
 	if (m_2DRender)
 	{
 		m_2DRender->Reset();
 	}
-	m_batchNeedsInit = TRUE;
 }
 
 void W3DDisplay::onEndBatch()
@@ -641,6 +642,7 @@ void W3DDisplay::setup2DRenderState(TextureClass *tex, DrawImageMode mode, Bool 
 			{
 				m_batchTexture->Release_Ref();
 			}
+
 			m_batchTexture = tex;
 		}
 
@@ -648,12 +650,9 @@ void W3DDisplay::setup2DRenderState(TextureClass *tex, DrawImageMode mode, Bool 
 		m_batchGrayscale = grayscale;
 		m_batchNeedsInit = FALSE;
 	}
-	else
+	else if (m_2DRender)
 	{
-		if (m_2DRender)
-		{
-			m_2DRender->Reset();
-		}
+		m_2DRender->Reset();
 	}
 
 	if (m_2DRender)
@@ -670,26 +669,26 @@ void W3DDisplay::setup2DRenderState(TextureClass *tex, DrawImageMode mode, Bool 
 
 		switch (mode)
 		{
-		case DRAW_IMAGE_ALPHA:
-			m_2DRender->Enable_Additive(FALSE);
-			m_2DRender->Enable_Alpha(TRUE);
-			m_2DRender->Enable_Grayscale(grayscale);
-			break;
-		case DRAW_IMAGE_GRAYSCALE:
-			m_2DRender->Enable_Additive(FALSE);
-			m_2DRender->Enable_Alpha(TRUE);
-			m_2DRender->Enable_Grayscale(TRUE);
-			break;
-		case DRAW_IMAGE_ADDITIVE:
-			m_2DRender->Enable_Additive(TRUE);
-			m_2DRender->Enable_Alpha(FALSE);
-			m_2DRender->Enable_Grayscale(grayscale);
-			break;
-		case DRAW_IMAGE_SOLID:
-			m_2DRender->Enable_Additive(FALSE);
-			m_2DRender->Enable_Alpha(FALSE);
-			m_2DRender->Enable_Grayscale(grayscale);
-			break;
+			case DRAW_IMAGE_ALPHA:
+				m_2DRender->Enable_Additive(FALSE);
+				m_2DRender->Enable_Alpha(TRUE);
+				m_2DRender->Enable_Grayscale(grayscale);
+				break;
+			case DRAW_IMAGE_GRAYSCALE:
+				m_2DRender->Enable_Additive(FALSE);
+				m_2DRender->Enable_Alpha(TRUE);
+				m_2DRender->Enable_Grayscale(TRUE);
+				break;
+			case DRAW_IMAGE_ADDITIVE:
+				m_2DRender->Enable_Additive(TRUE);
+				m_2DRender->Enable_Alpha(FALSE);
+				m_2DRender->Enable_Grayscale(grayscale);
+				break;
+			case DRAW_IMAGE_SOLID:
+				m_2DRender->Enable_Additive(FALSE);
+				m_2DRender->Enable_Alpha(FALSE);
+				m_2DRender->Enable_Grayscale(grayscale);
+				break;
 		}
 	}
 }
@@ -2738,7 +2737,6 @@ void W3DDisplay::drawImage( const Image *image, Int startX, Int startY,
 		tex = WW3DAssetManager::Get_Instance()->Get_Texture(image->getFilename().str(), MIP_LEVELS_1);
 
 	Bool grayscale = (mode == DRAW_IMAGE_GRAYSCALE);
-	///@todo: Why are we alpha blending all images?  Reduces our fillrate. -MW
 	setup2DRenderState(tex, mode, grayscale);
 
 	RectClass screen_rect(startX,startY,endX,endY);

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -598,10 +598,8 @@ void W3DDisplay::onBeginBatch()
 
 	if (m_2DRender)
 	{
-		m_2DRender->Reset();
+		setup2DRenderState(nullptr, DRAW_IMAGE_PRIMITIVE, FALSE);
 	}
-
-	setup2DRenderState(nullptr, DRAW_IMAGE_PRIMITIVE, FALSE);
 }
 
 void W3DDisplay::onEndBatch()
@@ -2725,6 +2723,17 @@ void W3DDisplay::drawImage( const Image *image, Int startX, Int startY,
 	if( image == nullptr )
 		return;
 
+	if (m_isClippedEnabled)
+	{
+		if (	endX <= m_clipRegion.lo.x ||
+				endY <= m_clipRegion.lo.y ||
+				startX >= m_clipRegion.hi.x ||
+				startY >= m_clipRegion.hi.y)
+		{
+			return;	//nothing to render
+		}
+	}
+
 	// !!
 	// Remember to update the GUIEditDisplay::drawImage when you make
 	// changes to this, it technically uses W3D code to render itself,
@@ -2748,21 +2757,7 @@ void W3DDisplay::drawImage( const Image *image, Int startX, Int startY,
 
 	if (m_isClippedEnabled)
 	{	//need to clip this quad to clip rectangle
-
-		//
-		//	Check for completely clipped
-		//
-		if (	endX <= m_clipRegion.lo.x ||
-				endY <= m_clipRegion.lo.y ||
-				startX >= m_clipRegion.hi.x ||
-				startY >= m_clipRegion.hi.y)
 		{
-			if (tex != nullptr && !BitIsSet(image->getStatus(), IMAGE_STATUS_RAW_TEXTURE))
-			{
-				tex->Release_Ref();
-			}
-			return;	//nothing to render
-		} else {
 			RectClass clipped_rect;
 			RectClass clipped_uv_rect;
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -664,8 +664,8 @@ void W3DDisplay::setup2DRenderState(TextureClass *tex, DrawImageMode mode, Bool 
 
 		switch (mode)
 		{
-			case DRAW_IMAGE_ALPHA:
 			default:
+			case DRAW_IMAGE_ALPHA:
 				m_2DRender->Enable_Additive(FALSE);
 				m_2DRender->Enable_Alpha(TRUE);
 				m_2DRender->Enable_Grayscale(grayscale);

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -404,6 +404,10 @@ W3DDisplay::W3DDisplay()
 	for (i = 0; i < DisplayStringCount; i++)
 		m_displayStrings[i] = nullptr;
 
+	m_isBatching = FALSE;
+	m_batchTexture = nullptr;
+	m_batchMode = DRAW_IMAGE_ALPHA;
+	m_batchGrayscale = FALSE;
 }
 
 // W3DDisplay::~W3DDisplay ====================================================
@@ -582,6 +586,33 @@ void W3DDisplay::setHeight( UnsignedInt height )
 	// of the screen with (width,height) at the lower right
 	m_2DRender->Set_Coordinate_Range( RectClass( 0, 0, getWidth(), getHeight() ) );
 
+}
+
+void W3DDisplay::beginBatch()
+{
+	m_isBatching = TRUE;
+	m_batchTexture = nullptr;
+	m_batchGrayscale = FALSE;
+	m_batchMode = DRAW_IMAGE_ALPHA;
+	if (m_2DRender)
+	{
+		m_2DRender->Reset();
+		m_2DRender->Enable_Texturing(FALSE);
+		m_2DRender->Enable_Alpha(TRUE);
+	}
+}
+
+void W3DDisplay::endBatch()
+{
+	if (m_isBatching)
+	{
+		if (m_2DRender)
+		{
+			m_2DRender->Render();
+			m_2DRender->Reset();
+		}
+		m_isBatching = FALSE;
+	}
 }
 
 // W3DDisplay::initAssets =====================================================
@@ -2148,14 +2179,32 @@ void W3DDisplay::drawLine( Int startX, Int startY,
 													 Real lineWidth,
 													 UnsignedInt lineColor )
 {
+	if (m_isBatching)
+	{
+		if (m_batchTexture != nullptr || m_batchMode != DRAW_IMAGE_SOLID)
+		{
+			m_2DRender->Render();
+			m_2DRender->Reset();
+			m_batchTexture = nullptr;
+			m_batchMode = DRAW_IMAGE_SOLID;
+			m_2DRender->Enable_Texturing(FALSE);
+			m_2DRender->Enable_Alpha(TRUE);
+		}
+	}
+	else
+	{
+		m_2DRender->Reset();
+		m_2DRender->Enable_Texturing( FALSE );
+		m_2DRender->Enable_Alpha(TRUE);
+	}
 
-	/// @todo we need to consider the efficiency of the 2D renderer
-	m_2DRender->Reset();
-	m_2DRender->Enable_Texturing( FALSE );
 	m_2DRender->Add_Line( Vector2( startX, startY ), Vector2( endX, endY ),
 												lineWidth, lineColor );
-	m_2DRender->Render();
 
+	if (!m_isBatching)
+	{
+		m_2DRender->Render();
+	}
 }
 
 // W3DDisplay::drawLine =======================================================
@@ -2166,13 +2215,32 @@ void W3DDisplay::drawLine( Int startX, Int startY,
 													 Real lineWidth,
 													 UnsignedInt lineColor1,UnsignedInt lineColor2 )
 {
+	if (m_isBatching)
+	{
+		if (m_batchTexture != nullptr || m_batchMode != DRAW_IMAGE_SOLID)
+		{
+			m_2DRender->Render();
+			m_2DRender->Reset();
+			m_batchTexture = nullptr;
+			m_batchMode = DRAW_IMAGE_SOLID;
+			m_2DRender->Enable_Texturing(FALSE);
+			m_2DRender->Enable_Alpha(TRUE);
+		}
+	}
+	else
+	{
+		m_2DRender->Reset();
+		m_2DRender->Enable_Texturing( FALSE );
+		m_2DRender->Enable_Alpha(TRUE);
+	}
 
-	/// @todo we need to consider the efficiency of the 2D renderer
-	m_2DRender->Reset();
-	m_2DRender->Enable_Texturing( FALSE );
 	m_2DRender->Add_Line( Vector2( startX, startY ), Vector2( endX, endY ),
 												lineWidth, lineColor1, lineColor2 );
-	m_2DRender->Render();
+
+	if (!m_isBatching)
+	{
+		m_2DRender->Render();
+	}
 
 }
 
@@ -2215,16 +2283,34 @@ void W3DDisplay::drawOpenRect( Int startX, Int startY, Int width, Int height,
 	}
 	else
 	{
-		/// @todo we need to consider the efficiency of the 2D renderer
-		m_2DRender->Reset();
-		m_2DRender->Enable_Texturing( FALSE );
+		if (m_isBatching)
+		{
+			if (m_batchTexture != nullptr || m_batchMode != DRAW_IMAGE_SOLID)
+			{
+				m_2DRender->Render();
+				m_2DRender->Reset();
+				m_batchTexture = nullptr;
+				m_batchMode = DRAW_IMAGE_SOLID;
+				m_2DRender->Enable_Texturing(FALSE);
+				m_2DRender->Enable_Alpha(TRUE);
+			}
+		}
+		else
+		{
+			m_2DRender->Reset();
+			m_2DRender->Enable_Texturing( FALSE );
+			m_2DRender->Enable_Alpha(TRUE);
+		}
 
 		m_2DRender->Add_Outline( RectClass( startX, startY,
 																				startX + width, startY + height ),
 														 lineWidth, lineColor );
 
 		// render it now!
-		m_2DRender->Render();
+		if (!m_isBatching)
+		{
+			m_2DRender->Render();
+		}
 	}
 
 }
@@ -2234,17 +2320,34 @@ void W3DDisplay::drawOpenRect( Int startX, Int startY, Int width, Int height,
 void W3DDisplay::drawFillRect( Int startX, Int startY, Int width, Int height,
 															 UnsignedInt color )
 {
+	if (m_isBatching)
+	{
+		if (m_batchTexture != nullptr || m_batchMode != DRAW_IMAGE_SOLID)
+		{
+			m_2DRender->Render();
+			m_2DRender->Reset();
+			m_batchTexture = nullptr;
+			m_batchMode = DRAW_IMAGE_SOLID;
+			m_2DRender->Enable_Texturing(FALSE);
+			m_2DRender->Enable_Alpha(TRUE);
+		}
+	}
+	else
+	{
+		m_2DRender->Reset();
+		m_2DRender->Enable_Texturing( FALSE );
+		m_2DRender->Enable_Alpha(TRUE);
+	}
 
-	/// @todo we need to consider the efficiency of the 2D renderer
-	m_2DRender->Reset();
-	m_2DRender->Enable_Texturing( FALSE );
 	m_2DRender->Add_Rect( RectClass( startX, startY,
 																	 startX + width, startY + height ),
 												0, 0, color );
 
 	// render it now!
-	m_2DRender->Render();
-
+	if (!m_isBatching)
+	{
+		m_2DRender->Render();
+	}
 }
 
 void W3DDisplay::drawRectClock(Int startX, Int startY, Int width, Int height, Int percent, UnsignedInt color)
@@ -2253,8 +2356,24 @@ void W3DDisplay::drawRectClock(Int startX, Int startY, Int width, Int height, In
 	if(percent < 1 || percent > 100)
 		return;
 
-	m_2DRender->Reset();
-	m_2DRender->Enable_Texturing( FALSE );
+	if (m_isBatching)
+	{
+		if (m_batchTexture != nullptr || m_batchMode != DRAW_IMAGE_SOLID)
+		{
+			m_2DRender->Render();
+			m_2DRender->Reset();
+			m_batchTexture = nullptr;
+			m_batchMode = DRAW_IMAGE_SOLID;
+			m_2DRender->Enable_Texturing(FALSE);
+			m_2DRender->Enable_Alpha(TRUE);
+		}
+	}
+	else
+	{
+		m_2DRender->Reset();
+		m_2DRender->Enable_Texturing( FALSE );
+		m_2DRender->Enable_Alpha(TRUE);
+	}
 
 // The rectangles are numberd as follows
 //(x,y)	|---------|
@@ -2400,8 +2519,10 @@ void W3DDisplay::drawRectClock(Int startX, Int startY, Int width, Int height, In
 	}
 
 	// render it now!
-	m_2DRender->Render();
-
+	if (!m_isBatching)
+	{
+		m_2DRender->Render();
+	}
 }
 
 
@@ -2417,8 +2538,24 @@ void W3DDisplay::drawRemainingRectClock(Int startX, Int startY, Int width, Int h
 	if( percent < 0 || percent > 99 )
 		return;
 
-	m_2DRender->Reset();
-	m_2DRender->Enable_Texturing( FALSE );
+	if (m_isBatching)
+	{
+		if (m_batchTexture != nullptr || m_batchMode != DRAW_IMAGE_SOLID)
+		{
+			m_2DRender->Render();
+			m_2DRender->Reset();
+			m_batchTexture = nullptr;
+			m_batchMode = DRAW_IMAGE_SOLID;
+			m_2DRender->Enable_Texturing(FALSE);
+			m_2DRender->Enable_Alpha(TRUE);
+		}
+	}
+	else
+	{
+		m_2DRender->Reset();
+		m_2DRender->Enable_Texturing( FALSE );
+		m_2DRender->Enable_Alpha(TRUE);
+	}
 
 // The rectangles are numbered as follows
 //(x,y)	|---------|
@@ -2579,7 +2716,10 @@ void W3DDisplay::drawRemainingRectClock(Int startX, Int startY, Int width, Int h
 	}
 
 	// render it now!
-	m_2DRender->Render();
+	if (!m_isBatching)
+	{
+		m_2DRender->Render();
+	}
 }
 
 
@@ -2603,37 +2743,71 @@ void W3DDisplay::drawImage( const Image *image, Int startX, Int startY,
 
 	const Region2D *uv = image->getUV();
 
-	m_2DRender->Reset();
-	m_2DRender->Enable_Texturing( TRUE );
+	TextureClass *tex = nullptr;
+	if (BitIsSet(image->getStatus(), IMAGE_STATUS_RAW_TEXTURE))
+		tex = (TextureClass *)(image->getRawTextureData());
+	else
+		tex = WW3DAssetManager::Get_Instance()->Get_Texture(image->getFilename().str(), MIP_LEVELS_1);
 
-	Bool doAlphaReset=FALSE;
-
+	Bool grayscale = (mode == DRAW_IMAGE_GRAYSCALE);
 	///@todo: Why are we alpha blending all images?  Reduces our fillrate. -MW
-	switch (mode)
+	if (m_isBatching)
 	{
-		case DRAW_IMAGE_ALPHA:	//nothing to do since alpha is the default state
+		if (m_batchTexture != tex || m_batchMode != mode || m_batchGrayscale != grayscale)
+		{
+			m_2DRender->Render();
+			m_2DRender->Reset();
+			m_batchTexture = tex;
+			m_batchMode = mode;
+			m_batchGrayscale = grayscale;
+
+			m_2DRender->Enable_Texturing(TRUE);
+			m_2DRender->Set_Texture(tex);
+			switch (mode)
+			{
+			case DRAW_IMAGE_ALPHA:
+				m_2DRender->Enable_Alpha(TRUE);
+				break;
+			case DRAW_IMAGE_GRAYSCALE:
+				m_2DRender->Enable_Grayscale(true);
+				break;
+			case DRAW_IMAGE_ADDITIVE:
+				m_2DRender->Enable_Additive(true);
+				break;
+			case DRAW_IMAGE_SOLID:
+				m_2DRender->Enable_Additive(false);
+				m_2DRender->Enable_Alpha(false);
+				break;
+			}
+		}
+	}
+	else
+	{
+		m_2DRender->Reset();
+		m_2DRender->Enable_Texturing(TRUE);
+		m_2DRender->Set_Texture(tex);
+		switch (mode)
+		{
+		case DRAW_IMAGE_ALPHA:
+			m_2DRender->Enable_Alpha(TRUE);
 			break;
 		case DRAW_IMAGE_GRAYSCALE:
-			m_2DRender->Enable_Grayscale(true);
+			m_2DRender->Enable_Grayscale(TRUE);
 			break;
 		case DRAW_IMAGE_ADDITIVE:
-			m_2DRender->Enable_Additive(true);
-			doAlphaReset = TRUE;
+			m_2DRender->Enable_Additive(TRUE);
 			break;
 		case DRAW_IMAGE_SOLID:
-			m_2DRender->Enable_Additive(false);
-			m_2DRender->Enable_Alpha(false);
-			doAlphaReset = TRUE;
+			m_2DRender->Enable_Additive(FALSE);
+			m_2DRender->Enable_Alpha(FALSE);
 			break;
-		default:
-			break;
+		}
 	}
 
-	// if we have raw texture data we will use it, otherwise we are referencing filenames
-	if( BitIsSet( image->getStatus(), IMAGE_STATUS_RAW_TEXTURE ) )
-		m_2DRender->Set_Texture( (TextureClass *)(image->getRawTextureData()) );
-	else
-		m_2DRender->Set_Texture( image->getFilename().str() );
+	if (tex != nullptr && !BitIsSet(image->getStatus(), IMAGE_STATUS_RAW_TEXTURE))
+	{
+		tex->Release_Ref();
+	}
 
 	RectClass screen_rect(startX,startY,endX,endY);
 	RectClass uv_rect(uv->lo.x,uv->lo.y,uv->hi.x,uv->hi.y);
@@ -2748,12 +2922,12 @@ void W3DDisplay::drawImage( const Image *image, Int startX, Int startY,
 
 	}
 
-	m_2DRender->Render();
-
-	//reset to default states for next time this method is called.
-	m_2DRender->Enable_Grayscale(false);	//never leave it in this mode
-	if (doAlphaReset)
+	if (!m_isBatching)
+	{
+		m_2DRender->Render();
+		m_2DRender->Enable_Grayscale(false);
 		m_2DRender->Enable_Alpha(true);
+	}
 
 }
 
@@ -2855,12 +3029,28 @@ void W3DDisplay::drawVideoBuffer( VideoBuffer *buffer, Int startX, Int startY, I
 {
 	W3DVideoBuffer *vbuffer = (W3DVideoBuffer*) buffer;
 
-	m_2DRender->Reset();
+	if (m_isBatching)
+	{
+		m_2DRender->Render();
+		m_2DRender->Reset();
+		m_batchTexture = vbuffer->texture();
+		m_batchMode = DRAW_IMAGE_ALPHA;
+		m_batchGrayscale = FALSE;
+	}
+	else
+	{
+		m_2DRender->Reset();
+	}
+
 	m_2DRender->Enable_Texturing( TRUE );
 	m_2DRender->Set_Texture( vbuffer->texture() );
 	m_2DRender->Add_Quad( RectClass( startX, startY, endX, endY ),
 												vbuffer->Rect( 0, 0, 1, 1) );
-	m_2DRender->Render();
+	
+	if (!m_isBatching)
+	{
+		m_2DRender->Render();
+	}
 
 }
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -2750,6 +2750,7 @@ void W3DDisplay::drawImage( const Image *image, Int startX, Int startY,
 	if (m_isClippedEnabled)
 	{	//need to clip this quad to clip rectangle
 		if (screen_rect.Left < m_clipRegion.lo.x || screen_rect.Right > m_clipRegion.hi.x || screen_rect.Top < m_clipRegion.lo.y || screen_rect.Bottom > m_clipRegion.hi.y)
+		{
 			RectClass clipped_rect;
 			RectClass clipped_uv_rect;
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -612,12 +612,9 @@ void W3DDisplay::onEndBatch()
 
 void W3DDisplay::onFlush()
 {
-	if (m_2DRender)
+	if (m_2DRender && !m_batchNeedsInit)
 	{
-		if (!m_batchNeedsInit)
-		{
-			m_2DRender->Render();
-		}
+		m_2DRender->Render();
 		m_2DRender->Reset();
 		m_batchNeedsInit = TRUE;
 	}

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -2753,8 +2753,14 @@ void W3DDisplay::drawImage( const Image *image, Int startX, Int startY,
 		//	Check for completely clipped
 		//
 		if (	endX <= m_clipRegion.lo.x ||
-				endY <= m_clipRegion.lo.y)
+				endY <= m_clipRegion.lo.y ||
+				startX >= m_clipRegion.hi.x ||
+				startY >= m_clipRegion.hi.y)
 		{
+			if (tex != nullptr && !BitIsSet(image->getStatus(), IMAGE_STATUS_RAW_TEXTURE))
+			{
+				tex->Release_Ref();
+			}
 			return;	//nothing to render
 		} else {
 			RectClass clipped_rect;

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -606,7 +606,11 @@ void W3DDisplay::onBeginBatch()
 void W3DDisplay::onEndBatch()
 {
 	onFlush();
-	m_batchTexture = nullptr;
+	if (m_batchTexture)
+	{
+		m_batchTexture->Release_Ref();
+		m_batchTexture = nullptr;
+	}
 }
 
 void W3DDisplay::onFlush()
@@ -633,7 +637,14 @@ void W3DDisplay::setup2DRenderState(TextureClass *tex, DrawImageMode mode, Bool 
 			m_2DRender->Render();
 			m_2DRender->Reset();
 		}
-		m_batchTexture = tex;
+
+		if (tex != m_batchTexture)
+		{
+			if (tex) tex->Add_Ref();
+			if (m_batchTexture) m_batchTexture->Release_Ref();
+			m_batchTexture = tex;
+		}
+
 		m_batchMode = mode;
 		m_batchGrayscale = grayscale;
 		m_batchNeedsInit = FALSE;

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -681,7 +681,7 @@ void W3DDisplay::setup2DRenderState(TextureClass *tex, DrawImageMode mode, Bool 
 			break;
 		case DRAW_IMAGE_GRAYSCALE:
 			m_2DRender->Enable_Additive(FALSE);
-			m_2DRender->Enable_Alpha(FALSE);
+			m_2DRender->Enable_Alpha(TRUE);
 			m_2DRender->Enable_Grayscale(TRUE);
 			break;
 		case DRAW_IMAGE_ADDITIVE:

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -687,8 +687,8 @@ void W3DDisplay::setup2DRenderState(TextureClass *tex, DrawImageMode mode, Bool 
 			m_2DRender->Enable_Grayscale(TRUE);
 			break;
 		case DRAW_IMAGE_ADDITIVE:
-			m_2DRender->Enable_Alpha(FALSE);
 			m_2DRender->Enable_Additive(TRUE);
+			m_2DRender->Enable_Alpha(FALSE);
 			m_2DRender->Enable_Grayscale(grayscale);
 			break;
 		case DRAW_IMAGE_SOLID:

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -641,8 +641,14 @@ void W3DDisplay::setup2DRenderState(TextureClass *tex, DrawImageMode mode, Bool 
 
 		if (tex != m_batchTexture)
 		{
-			if (tex) tex->Add_Ref();
-			if (m_batchTexture) m_batchTexture->Release_Ref();
+			if (tex)
+			{
+				tex->Add_Ref();
+			}
+			if (m_batchTexture)
+			{
+				m_batchTexture->Release_Ref();
+			}
 			m_batchTexture = tex;
 		}
 
@@ -2737,11 +2743,6 @@ void W3DDisplay::drawImage( const Image *image, Int startX, Int startY,
 	///@todo: Why are we alpha blending all images?  Reduces our fillrate. -MW
 	setup2DRenderState(tex, mode, grayscale);
 
-	if (tex != nullptr && !BitIsSet(image->getStatus(), IMAGE_STATUS_RAW_TEXTURE))
-	{
-		tex->Release_Ref();
-	}
-
 	RectClass screen_rect(startX,startY,endX,endY);
 	RectClass uv_rect(uv->lo.x,uv->lo.y,uv->hi.x,uv->hi.y);
 
@@ -2863,6 +2864,11 @@ void W3DDisplay::drawImage( const Image *image, Int startX, Int startY,
 		{
 			m_2DRender->Enable_Alpha(true);
 		}
+	}
+
+	if (tex != nullptr && !BitIsSet(image->getStatus(), IMAGE_STATUS_RAW_TEXTURE))
+	{
+		tex->Release_Ref();
 	}
 
 }

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -598,7 +598,7 @@ void W3DDisplay::onBeginBatch()
 
 	if (m_2DRender)
 	{
-		setup2DRenderState(nullptr, DRAW_IMAGE_PRIMITIVE, FALSE);
+		setup2DRenderState(nullptr, DRAW_IMAGE_ALPHA, FALSE);
 	}
 }
 
@@ -631,11 +631,7 @@ void W3DDisplay::setup2DRenderState(TextureClass *tex, DrawImageMode mode, Bool 
 			return;
 		}
 
-		if (m_2DRender)
-		{
-			m_2DRender->Render();
-			m_2DRender->Reset();
-		}
+		onFlush();
 
 		if (tex != m_batchTexture)
 		{
@@ -695,11 +691,6 @@ void W3DDisplay::setup2DRenderState(TextureClass *tex, DrawImageMode mode, Bool 
 			m_2DRender->Enable_Additive(FALSE);
 			m_2DRender->Enable_Alpha(FALSE);
 			m_2DRender->Enable_Grayscale(grayscale);
-			break;
-		case DRAW_IMAGE_PRIMITIVE:
-			m_2DRender->Enable_Additive(FALSE);
-			m_2DRender->Enable_Alpha(TRUE);
-			m_2DRender->Enable_Grayscale(FALSE);
 			break;
 		}
 	}
@@ -2269,7 +2260,7 @@ void W3DDisplay::drawLine( Int startX, Int startY,
 													 Real lineWidth,
 													 UnsignedInt lineColor )
 {
-	setup2DRenderState(nullptr, DRAW_IMAGE_PRIMITIVE, FALSE);
+	setup2DRenderState(nullptr, DRAW_IMAGE_ALPHA, FALSE);
 
 	m_2DRender->Add_Line( Vector2( startX, startY ), Vector2( endX, endY ),
 												lineWidth, lineColor );
@@ -2288,7 +2279,7 @@ void W3DDisplay::drawLine( Int startX, Int startY,
 													 Real lineWidth,
 													 UnsignedInt lineColor1,UnsignedInt lineColor2 )
 {
-	setup2DRenderState(nullptr, DRAW_IMAGE_PRIMITIVE, FALSE);
+	setup2DRenderState(nullptr, DRAW_IMAGE_ALPHA, FALSE);
 
 	m_2DRender->Add_Line( Vector2( startX, startY ), Vector2( endX, endY ),
 												lineWidth, lineColor1, lineColor2 );
@@ -2339,7 +2330,7 @@ void W3DDisplay::drawOpenRect( Int startX, Int startY, Int width, Int height,
 	}
 	else
 	{
-		setup2DRenderState(nullptr, DRAW_IMAGE_PRIMITIVE, FALSE);
+		setup2DRenderState(nullptr, DRAW_IMAGE_ALPHA, FALSE);
 
 		m_2DRender->Add_Outline( RectClass( startX, startY,
 																				startX + width, startY + height ),
@@ -2359,7 +2350,7 @@ void W3DDisplay::drawOpenRect( Int startX, Int startY, Int width, Int height,
 void W3DDisplay::drawFillRect( Int startX, Int startY, Int width, Int height,
 															 UnsignedInt color )
 {
-	setup2DRenderState(nullptr, DRAW_IMAGE_PRIMITIVE, FALSE);
+	setup2DRenderState(nullptr, DRAW_IMAGE_ALPHA, FALSE);
 
 	m_2DRender->Add_Rect( RectClass( startX, startY,
 																	 startX + width, startY + height ),
@@ -2378,7 +2369,7 @@ void W3DDisplay::drawRectClock(Int startX, Int startY, Int width, Int height, In
 	if(percent < 1 || percent > 100)
 		return;
 
-	setup2DRenderState(nullptr, DRAW_IMAGE_PRIMITIVE, FALSE);
+	setup2DRenderState(nullptr, DRAW_IMAGE_ALPHA, FALSE);
 
 // The rectangles are numberd as follows
 //(x,y)	|---------|
@@ -2543,7 +2534,7 @@ void W3DDisplay::drawRemainingRectClock(Int startX, Int startY, Int width, Int h
 	if( percent < 0 || percent > 99 )
 		return;
 
-	setup2DRenderState(nullptr, DRAW_IMAGE_PRIMITIVE, FALSE);
+	setup2DRenderState(nullptr, DRAW_IMAGE_ALPHA, FALSE);
 
 // The rectangles are numbered as follows
 //(x,y)	|---------|

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -603,7 +603,7 @@ void W3DDisplay::onBeginBatch()
 
 void W3DDisplay::onEndBatch()
 {
-	SAFE_RELEASE(m_batchTexture);
+	REF_PTR_RELEASE(m_batchTexture);
 }
 
 void W3DDisplay::onFlush()

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -670,6 +670,7 @@ void W3DDisplay::setup2DRenderState(TextureClass *tex, DrawImageMode mode, Bool 
 		switch (mode)
 		{
 			case DRAW_IMAGE_ALPHA:
+			default:
 				m_2DRender->Enable_Additive(FALSE);
 				m_2DRender->Enable_Alpha(TRUE);
 				m_2DRender->Enable_Grayscale(grayscale);

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -588,29 +588,34 @@ void W3DDisplay::setHeight( UnsignedInt height )
 
 }
 
-void W3DDisplay::beginBatch()
+void W3DDisplay::onBeginBatch()
 {
-	m_isBatching = TRUE;
-	m_batchTexture = (TextureClass*)-1;
+	m_batchTexture = nullptr;
 	m_batchMode = DRAW_IMAGE_ALPHA;
 	m_batchGrayscale = FALSE;
+	m_batchNeedsInit = FALSE;
+
+	if (m_2DRender)
+	{
+		m_2DRender->Reset();
+	}
 
 	setup2DRenderState(nullptr, DRAW_IMAGE_PRIMITIVE, FALSE);
 }
 
-void W3DDisplay::endBatch()
+void W3DDisplay::onEndBatch()
 {
-	if (m_isBatching)
+	onFlush();
+	m_batchTexture = nullptr;
+}
+
+void W3DDisplay::onFlush()
+{
+	if (m_2DRender && !m_batchNeedsInit)
 	{
-		if (m_2DRender)
-		{
-			m_2DRender->Render();
-			m_2DRender->Reset();
-		}
-		m_isBatching = FALSE;
-		m_batchTexture = nullptr;
-		m_batchMode = DRAW_IMAGE_ALPHA;
-		m_batchGrayscale = FALSE;
+		m_2DRender->Render();
+		m_2DRender->Reset();
+		m_batchNeedsInit = TRUE;
 	}
 }
 
@@ -618,23 +623,20 @@ void W3DDisplay::setup2DRenderState(TextureClass *tex, DrawImageMode mode, Bool 
 {
 	if (m_isBatching)
 	{
-		if (m_batchTexture == tex && m_batchMode == mode && m_batchGrayscale == grayscale)
+		if (!m_batchNeedsInit && m_batchTexture == tex && m_batchMode == mode && m_batchGrayscale == grayscale)
 		{
 			return;
 		}
 
 		if (m_2DRender)
 		{
-			// if m_batchTexture == -1, this is the very first setup in a batch, we don't render/reset yet
-			if (m_batchTexture != (TextureClass*)-1)
-			{
-				m_2DRender->Render();
-				m_2DRender->Reset();
-			}
+			m_2DRender->Render();
+			m_2DRender->Reset();
 		}
 		m_batchTexture = tex;
 		m_batchMode = mode;
 		m_batchGrayscale = grayscale;
+		m_batchNeedsInit = FALSE;
 	}
 	else
 	{
@@ -656,17 +658,20 @@ void W3DDisplay::setup2DRenderState(TextureClass *tex, DrawImageMode mode, Bool 
 			m_2DRender->Enable_Texturing(FALSE);
 		}
 
-		// Strictly mirroring original commit's state setting logic per mode
 		switch (mode)
 		{
 		case DRAW_IMAGE_ALPHA:
+			m_2DRender->Enable_Additive(FALSE);
 			m_2DRender->Enable_Alpha(TRUE);
 			m_2DRender->Enable_Grayscale(grayscale);
 			break;
 		case DRAW_IMAGE_GRAYSCALE:
+			m_2DRender->Enable_Additive(FALSE);
+			m_2DRender->Enable_Alpha(FALSE);
 			m_2DRender->Enable_Grayscale(TRUE);
 			break;
 		case DRAW_IMAGE_ADDITIVE:
+			m_2DRender->Enable_Alpha(FALSE);
 			m_2DRender->Enable_Additive(TRUE);
 			m_2DRender->Enable_Grayscale(grayscale);
 			break;

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -404,7 +404,6 @@ W3DDisplay::W3DDisplay()
 	for (i = 0; i < DisplayStringCount; i++)
 		m_displayStrings[i] = nullptr;
 
-	m_isBatching = FALSE;
 	m_batchTexture = nullptr;
 	m_batchMode = DRAW_IMAGE_ALPHA;
 	m_batchGrayscale = FALSE;
@@ -2750,7 +2749,7 @@ void W3DDisplay::drawImage( const Image *image, Int startX, Int startY,
 
 	if (m_isClippedEnabled)
 	{	//need to clip this quad to clip rectangle
-		{
+		if (screen_rect.Left < m_clipRegion.lo.x || screen_rect.Right > m_clipRegion.hi.x || screen_rect.Top < m_clipRegion.lo.y || screen_rect.Bottom > m_clipRegion.hi.y)
 			RectClass clipped_rect;
 			RectClass clipped_uv_rect;
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -603,12 +603,7 @@ void W3DDisplay::onBeginBatch()
 
 void W3DDisplay::onEndBatch()
 {
-	onFlush();
-	if (m_batchTexture)
-	{
-		m_batchTexture->Release_Ref();
-		m_batchTexture = nullptr;
-	}
+	SAFE_RELEASE(m_batchTexture);
 }
 
 void W3DDisplay::onFlush()
@@ -2334,7 +2329,6 @@ void W3DDisplay::drawOpenRect( Int startX, Int startY, Int width, Int height,
 																				startX + width, startY + height ),
 														 lineWidth, lineColor );
 
-		// render it now!
 		if (!m_isBatching)
 		{
 			m_2DRender->Render();
@@ -2354,7 +2348,6 @@ void W3DDisplay::drawFillRect( Int startX, Int startY, Int width, Int height,
 																	 startX + width, startY + height ),
 												0, 0, color );
 
-	// render it now!
 	if (!m_isBatching)
 	{
 		m_2DRender->Render();
@@ -2512,7 +2505,6 @@ void W3DDisplay::drawRectClock(Int startX, Int startY, Int width, Int height, In
 		}
 	}
 
-	// render it now!
 	if (!m_isBatching)
 	{
 		m_2DRender->Render();
@@ -2692,7 +2684,6 @@ void W3DDisplay::drawRemainingRectClock(Int startX, Int startY, Int width, Int h
 		}
 	}
 
-	// render it now!
 	if (!m_isBatching)
 	{
 		m_2DRender->Render();
@@ -2714,10 +2705,10 @@ void W3DDisplay::drawImage( const Image *image, Int startX, Int startY,
 
 	if (m_isClippedEnabled)
 	{
-		if (	endX <= m_clipRegion.lo.x ||
-				endY <= m_clipRegion.lo.y ||
-				startX >= m_clipRegion.hi.x ||
-				startY >= m_clipRegion.hi.y)
+		if (endX <= m_clipRegion.lo.x ||
+			endY <= m_clipRegion.lo.y ||
+			startX >= m_clipRegion.hi.x ||
+			startY >= m_clipRegion.hi.y)
 		{
 			return;	//nothing to render
 		}

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayString.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayString.cpp
@@ -49,6 +49,7 @@
 #include <stdlib.h>
 
 // USER INCLUDES //////////////////////////////////////////////////////////////
+#include "GameClient/Display.h"
 #include "GameClient/GameClient.h"
 #include "W3DDevice/GameClient/W3DDisplayString.h"
 #include "GameClient/HotKey.h"
@@ -227,6 +228,11 @@ void W3DDisplayString::draw( Int x, Int y, Color color, Color dropColor, Int xDr
 	}
 
 	// render the text
+	if (TheDisplay->isBatching())
+	{
+		TheDisplay->endBatch();
+		TheDisplay->beginBatch();
+	}
 	m_textRenderer.Render();
 
 	// we are for sure using display resources now

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayString.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayString.cpp
@@ -226,10 +226,7 @@ void W3DDisplayString::draw( Int x, Int y, Color color, Color dropColor, Int xDr
 
 	}
 
-	if (TheDisplay->isBatching())
-	{
-		TheDisplay->flush();
-	}
+	TheDisplay->flush();
 
 	if(m_useHotKey)
 	{

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayString.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayString.cpp
@@ -217,22 +217,21 @@ void W3DDisplayString::draw( Int x, Int y, Color color, Color dropColor, Int xDr
 		m_textRenderer.Set_Location( Vector2( m_textPos.x, m_textPos.y ) );
 		m_textRenderer.Draw_Sentence( m_currTextColor );
 
-		if(m_useHotKey)
-		{
-			m_textRendererHotKey.Reset_Polys();
-			m_textRendererHotKey.Set_Location( Vector2( m_textPos.x + m_hotKeyPos.x , m_textPos.y +m_hotKeyPos.y) );
-			m_textRendererHotKey.Draw_Sentence( m_hotKeyColor );
-			m_textRendererHotKey.Render();
-		}
-
 	}
 
-	// render the text
 	if (TheDisplay->isBatching())
 	{
-		TheDisplay->endBatch();
-		TheDisplay->beginBatch();
+		TheDisplay->flush();
 	}
+
+	if(m_useHotKey)
+	{
+		m_textRendererHotKey.Reset_Polys();
+		m_textRendererHotKey.Set_Location( Vector2( m_textPos.x + m_hotKeyPos.x , m_textPos.y +m_hotKeyPos.y) );
+		m_textRendererHotKey.Draw_Sentence( m_hotKeyColor );
+		m_textRendererHotKey.Render();
+	}
+
 	m_textRenderer.Render();
 
 	// we are for sure using display resources now

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayString.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayString.cpp
@@ -228,7 +228,7 @@ void W3DDisplayString::draw( Int x, Int y, Color color, Color dropColor, Int xDr
 
 	TheDisplay->flush();
 
-	if(m_useHotKey)
+	if (m_useHotKey)
 	{
 		m_textRendererHotKey.Render();
 	}

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayString.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplayString.cpp
@@ -217,6 +217,13 @@ void W3DDisplayString::draw( Int x, Int y, Color color, Color dropColor, Int xDr
 		m_textRenderer.Set_Location( Vector2( m_textPos.x, m_textPos.y ) );
 		m_textRenderer.Draw_Sentence( m_currTextColor );
 
+		if (m_useHotKey)
+		{
+			m_textRendererHotKey.Reset_Polys();
+			m_textRendererHotKey.Set_Location( Vector2( m_textPos.x + m_hotKeyPos.x , m_textPos.y +m_hotKeyPos.y) );
+			m_textRendererHotKey.Draw_Sentence( m_hotKeyColor );
+		}
+
 	}
 
 	if (TheDisplay->isBatching())
@@ -226,9 +233,6 @@ void W3DDisplayString::draw( Int x, Int y, Color color, Color dropColor, Int xDr
 
 	if(m_useHotKey)
 	{
-		m_textRendererHotKey.Reset_Polys();
-		m_textRendererHotKey.Set_Location( Vector2( m_textPos.x + m_hotKeyPos.x , m_textPos.y +m_hotKeyPos.y) );
-		m_textRendererHotKey.Draw_Sentence( m_hotKeyColor );
 		m_textRendererHotKey.Render();
 	}
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DInGameUI.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DInGameUI.cpp
@@ -387,6 +387,7 @@ void W3DInGameUI::reset()
 //-------------------------------------------------------------------------------------------------
 void W3DInGameUI::draw()
 {
+	TheDisplay->beginBatch();
 	preDraw();
 
 	// draw selection region if drag selecting
@@ -438,6 +439,8 @@ void W3DInGameUI::draw()
 #ifdef EXTENDED_STATS
 	}
 #endif
+
+	TheDisplay->endBatch();
 
 }
 


### PR DESCRIPTION
Reduces draw calls by batching 2D elements by texture state in setup2DRenderState.

| Environment | Scenario (-quickstart) | Before | After |
| :--- | :--- | :--- | :--- |
| **Main Machine** | Skirmish Screen | 477 FPS | **918 FPS** |
| **M1 Macbook (Wine)** | Skirmish Screen | 16 FPS | **61 FPS** |
| **M1 Macbook (Wine)** | In-Game (Match Start) | 22 FPS | **33 FPS** |
| **Main Machine** | Selecting a thousand units in skirmish | 45 FPS | **56 FPS** |


Added early-out clipping and refined bounds checks to skip rendering objects outside the active region.

Optimized HotKey rendering by removing a redundant Render() call.