### PR TITLE
ci(vcpkg): disable compiler tracking for x64-windows host triplet

### DIFF
--- a/triplets/x64-windows.cmake
+++ b/triplets/x64-windows.cmake
@@ -1,0 +1,10 @@
+# Include the default x64-windows triplet
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+
+# Exclude compiler version from ABI hash so that Visual Studio version updates
+# on GitHub runner images do not invalidate the binary cache for host tools.
+# These are build-only tools (cmake, meson, pkgconf) whose ABIs propagate into
+# target package hashes; compiler version bumps do not affect their output.
+set(VCPKG_DISABLE_COMPILER_TRACKING ON)


### PR DESCRIPTION
* Follow up for #2371

The binary cache introduced in #2371 disabled compiler tracking for the `x86-windows` target triplet, but not for the `x64-windows` host triplet. vcpkg builds host tools (`vcpkg-cmake`, `vcpkg-cmake-get-vars`, `vcpkg-tool-meson`, `pkgconf`) against the host triplet, and their ABI hashes propagate transitively into every target package hash — including `ffmpeg:x86-windows` and `zlib:x86-windows`.

When the runner image updated from `20260301.50.1` to `20260317.73.1`, the full Visual Studio version changed from `17.14.37012.4` to `17.14.37111.16` (even though `VCToolsVersion` stayed at `14.44.35207`). This was enough to shift every x64-windows ABI hash, which cascaded into all x86-windows package hashes. The GHA cache key (which only hashes the triplet files) still matched the old entry, so GHA reported a hit and restored the 55 MB archive — but vcpkg found zero matching packages inside it and rebuilt ffmpeg from source (~17 min) on every run.

This also triggered a doom loop: the save step is gated on `cache-hit != 'true'`, so the freshly rebuilt binaries were never saved, and every subsequent run also rebuilt from scratch.

Adding `triplets/x64-windows.cmake` with `VCPKG_DISABLE_COMPILER_TRACKING` fixes both issues:
- Host tool ABI hashes become stable across VS updates
- Adding the new file changes `hashFiles('triplets/*.cmake')`, so the GHA key automatically gets a new hash, the first run is a clean miss, the cache saves correctly, and all subsequent runs hit

## Test plan
- [ ] First CI run after merge will cache-miss (new triplet hash), rebuild ffmpeg once, and save
- [ ] Subsequent CI runs restore all packages and skip the ffmpeg rebuild