### PR TITLE
fix(refcount): Fix compile warning in constructors of RefCountClass

### DIFF
--- a/Core/Libraries/Source/WWVegas/WWLib/LISTNODE.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/LISTNODE.h
@@ -222,7 +222,6 @@ class DataNode : public GenericNode {
 	T Value;
 public:
 	DataNode() {};
-	DataNode(T value) { Set(value); };
 	void Set(T value) { Value = value; };
 	T Get() const { return Value; };
 

--- a/Core/Libraries/Source/WWVegas/WWLib/refcount.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/refcount.h
@@ -95,9 +95,6 @@ public:
 
 	RefCountClass()
 		: NumRefs(1)
-#ifdef RTS_DEBUG
-		, ActiveRefNode()
-#endif
 	{
 #ifdef RTS_DEBUG
 		ActiveRefNode.Set(this);
@@ -111,9 +108,6 @@ public:
 	*/
 	RefCountClass(const RefCountClass & )
 		: NumRefs(1)
-#ifdef RTS_DEBUG
-		, ActiveRefNode()
-#endif
 	{
 #ifdef RTS_DEBUG
 		ActiveRefNode.Set(this);

--- a/Core/Libraries/Source/WWVegas/WWLib/refcount.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/refcount.h
@@ -96,10 +96,11 @@ public:
 	RefCountClass()
 		: NumRefs(1)
 #ifdef RTS_DEBUG
-		, ActiveRefNode(this)
+		, ActiveRefNode()
 #endif
 	{
 #ifdef RTS_DEBUG
+		ActiveRefNode.Set(this);
 		Add_Active_Ref(this);
 		Inc_Total_Refs(this);
 #endif
@@ -111,10 +112,11 @@ public:
 	RefCountClass(const RefCountClass & )
 		: NumRefs(1)
 #ifdef RTS_DEBUG
-		, ActiveRefNode(this)
+		, ActiveRefNode()
 #endif
 	{
 #ifdef RTS_DEBUG
+		ActiveRefNode.Set(this);
 		Add_Active_Ref(this);
 		Inc_Total_Refs(this);
 #endif


### PR DESCRIPTION
- Relates to: #503
- Relates to: #499

RefCountClass when compiled under `RTS_DEBUG` returns a compile warning *'this' : used in base member initializer list* for lines 99 and 114 when `ActiveRefNode` is initialized with `this` as argument

This PR resolves this, by initializing `ActiveRefNode` with the empty argument constructor and calling `ActiveRefNode.Set(this)` in the `RefCountClass`' constructor body.

The `DataNode(T value)` is then no longer being used and removed.