### PR TITLE
fix: Resolve macro redefinition warnings

### DIFF
--- a/Core/Libraries/Source/WWVegas/WWDownload/registry.cpp
+++ b/Core/Libraries/Source/WWVegas/WWDownload/registry.cpp
@@ -21,10 +21,7 @@
 // Author: Matthew D. Campbell, December 2001
 
 #include <string>
-
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
+#include <win.h>
 #include <windows.h>
 
 #include "Registry.h"

--- a/Core/Libraries/Source/WWVegas/WWDownload/registry.cpp
+++ b/Core/Libraries/Source/WWVegas/WWDownload/registry.cpp
@@ -20,9 +20,9 @@
 // Simple interface for storing/retrieving registry values
 // Author: Matthew D. Campbell, December 2001
 
+#include "Registry.h"
 #include <string>
 #include <win.h>
-#include "Registry.h"
 
 bool  getStringFromRegistry(HKEY root, std::string path, std::string key, std::string& val)
 {

--- a/Core/Libraries/Source/WWVegas/WWDownload/registry.cpp
+++ b/Core/Libraries/Source/WWVegas/WWDownload/registry.cpp
@@ -22,8 +22,6 @@
 
 #include <string>
 #include <win.h>
-#include <windows.h>
-
 #include "Registry.h"
 
 bool  getStringFromRegistry(HKEY root, std::string path, std::string key, std::string& val)

--- a/Core/Libraries/Source/WWVegas/WWDownload/registry.cpp
+++ b/Core/Libraries/Source/WWVegas/WWDownload/registry.cpp
@@ -22,7 +22,7 @@
 
 #include "Registry.h"
 #include <string>
-#include <win.h>
+#include "win.h"
 
 bool  getStringFromRegistry(HKEY root, std::string path, std::string key, std::string& val)
 {

--- a/Core/Libraries/Source/WWVegas/WWDownload/registry.cpp
+++ b/Core/Libraries/Source/WWVegas/WWDownload/registry.cpp
@@ -22,7 +22,9 @@
 
 #include <string>
 
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 
 #include "Registry.h"

--- a/Core/Libraries/Source/WWVegas/WWLib/thread.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/thread.cpp
@@ -16,7 +16,9 @@
 **	along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#ifndef _WIN32_WINNT
 #define _WIN32_WINNT 0x0400
+#endif
 
 #include "thread.h"
 #include "Except.h"

--- a/Core/Libraries/Source/WWVegas/WWLib/thread.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/thread.cpp
@@ -16,9 +16,6 @@
 **	along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef _WIN32_WINNT
-#define _WIN32_WINNT 0x0400
-#endif
 
 #include "thread.h"
 #include "Except.h"

--- a/Generals/Code/Tools/WorldBuilder/include/WHeightMapEdit.h
+++ b/Generals/Code/Tools/WorldBuilder/include/WHeightMapEdit.h
@@ -57,10 +57,6 @@ typedef struct
 } TGlobalTextureClass;
 
 
-#ifndef NUM_ALPHA_TILES
-#define NUM_ALPHA_TILES 8
-#endif
-
 class WorldHeightMapEdit : public WorldHeightMap
 {
 protected:

--- a/Generals/Code/Tools/WorldBuilder/include/WHeightMapEdit.h
+++ b/Generals/Code/Tools/WorldBuilder/include/WHeightMapEdit.h
@@ -57,7 +57,9 @@ typedef struct
 } TGlobalTextureClass;
 
 
+#ifndef NUM_ALPHA_TILES
 #define NUM_ALPHA_TILES 8
+#endif
 
 class WorldHeightMapEdit : public WorldHeightMap
 {


### PR DESCRIPTION
- Related to #499
- Related to #503

`NUM_ALPHA_TILES` in `Generals\Wheightmapedit.h` was unused and is removed
`_WIN32_WINNT` was unused and is removed
`WIN32_LEAN_AND_MEAN` was redefined in `registry.cpp`. Included win.h instead, which already handles this macro correctly.