### PR TITLE
bugfix(treebuffer): Fix crash in W3DTreeBuffer::updateVertexBuffer()

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTreeBuffer.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTreeBuffer.cpp
@@ -705,14 +705,14 @@ void W3DTreeBuffer::loadTreesInVertexAndIndexBuffers(RefRenderObjListIterator *p
 		m_shadow = TheW3DProjectedShadowManager->createDecalShadow(&shadowInfo);
 	}
 
+	// TheSuperHackers @bugfix Reset bufferNdx so updateVertexBuffer skips trees absent from this rebuild.
+	for (Int t = 0; t < m_numTrees; t++) {
+		m_trees[t].bufferNdx = -1;
+	}
 	m_anythingChanged = false;
 	Int curTree=0;
 	Int bNdx;
 	const GlobalData::TerrainLighting *objectLighting = TheGlobalData->m_terrainObjectsLighting[TheGlobalData->m_timeOfDay];
-	// TheSuperHackers @info Reset bufferNdx so updateVertexBuffer skips trees absent from this rebuild.
-	for (Int t = 0; t < m_numTrees; t++) {
-		m_trees[t].bufferNdx = -1;
-	}
 	for (bNdx=0; bNdx<MAX_BUFFERS; bNdx++) {
 		m_curNumTreeVertices[bNdx] = 0;
 		m_curNumTreeIndices[bNdx] = 0;
@@ -745,17 +745,14 @@ void W3DTreeBuffer::loadTreesInVertexAndIndexBuffers(RefRenderObjListIterator *p
 
 		for ( ;curTree<m_numTrees;curTree++) {
 			Int type = m_trees[curTree].treeType;
-			if (type<0) {
-				continue; // Deleted tree. [6/9/2003]
+			if (type<0 || m_treeTypes[type].m_mesh == nullptr) {
+				continue; // Deleted tree or missing mesh. [6/9/2003]
 			}
 			if (!m_trees[curTree].visible) continue;
 			Real scale = m_trees[curTree].scale;
 			Vector3 loc = m_trees[curTree].location;
 			Real theSin = m_trees[curTree].sin;
 			Real theCos = m_trees[curTree].cos;
-			if (type<0 || m_treeTypes[type].m_mesh == nullptr) {
-				continue;
-			}
 
 			Bool doVertexLighting = true;
 
@@ -995,7 +992,6 @@ void W3DTreeBuffer::updateVertexBuffer()
 		DX8VertexBufferClass::WriteLockClass lockVtxBuffer(m_vertexTree[bNdx], D3DLOCK_DISCARD);
 	#endif
 		vb=(VertexFormatXYZNDUV1*)lockVtxBuffer.Get_Vertex_Array();
-		// TheSuperHackers @info Guard against a failed vertex buffer lock returning null.
 		if (!vb) {
 			continue;
 		}
@@ -1008,9 +1004,6 @@ void W3DTreeBuffer::updateVertexBuffer()
 				continue;
 			}
 			Int type = m_trees[curTree].treeType;
-			if (type<0) {
-				continue; // Deleted tree. [6/9/2003]
-			}
 			if (m_trees[curTree].pushAsideDelta==0.0f && m_trees[curTree].m_toppleState == TOPPLE_UPRIGHT) {
 				continue; // not toppling or pushed, no need to update. jba [7/11/2003]
 			}
@@ -1020,10 +1013,7 @@ void W3DTreeBuffer::updateVertexBuffer()
 			Vector3 loc = m_trees[curTree].location;
 			Real theSin = m_trees[curTree].sin;
 			Real theCos = m_trees[curTree].cos;
-			// TheSuperHackers @info Skip missing mesh trees to avoid using the wrong vertex count.
-			if (type<0 || m_treeTypes[type].m_mesh == nullptr) {
-				continue;
-			}
+			DEBUG_ASSERTCRASH(type>=0 && m_treeTypes[type].m_mesh!=nullptr, ("Invalid tree type or mesh."));
 
 			Int startVertex = m_trees[curTree].firstIndex;
 			curVb = vb+startVertex;


### PR DESCRIPTION
Fixes a crash in W3DTreeBuffer::updateVertexBuffer caused by stale bufferNdx/firstIndex values from a previous vertex buffer rebuild. When a tree was pushed aside after the buffer layout changed, the old offset was used to write into the wrong location. Additional guards were added for failed vertex buffer locks and missing tree meshes.

Fixes Air force general challenge 2 easy on 1280 x 960 with raised camera height (or anywhere there is massive tree culling)

```
generalszh.exe!W3DTreeBuffer::updateVertexBuffer() Line 1050 (\Core\GameEngineDevice\Source\W3DDevice\GameClient\W3DTreeBuffer.cpp:1050)
generalszh.exe!W3DTreeBuffer::drawTrees(CameraClass * camera, RefMultiListIterator<RenderObjClass> * pDynamicLightsIterator) Line 1633 (\Core\GameEngineDevice\Source\W3DDevice\GameClient\W3DTreeBuffer.cpp:1633)
generalszh.exe!BaseHeightMapRenderObjClass::renderTrees(CameraClass * camera) Line 2967 (\Core\GameEngineDevice\Source\W3DDevice\GameClient\BaseHeightMap.cpp:2967)
generalszh.exe!DoTrees(RenderInfoClass & rinfo) Line 123 (\Core\GameEngineDevice\Source\W3DDevice\GameClient\BaseHeightMap.cpp:123)
generalszh.exe!RTS3DScene::Flush(RenderInfoClass & rinfo) Line 870 (\GeneralsMD\Code\GameEngineDevice\Source\W3DDevice\GameClient\W3DScene.cpp:870)
generalszh.exe!RTS3DScene::Render(RenderInfoClass & rinfo) Line 988 (\GeneralsMD\Code\GameEngineDevice\Source\W3DDevice\GameClient\W3DScene.cpp:988)
generalszh.exe!WW3D::Render(SceneClass * scene, CameraClass * cam, bool clear, bool clearz, const Vector3 & color) Line 975 (\GeneralsMD\Code\Libraries\Source\WWVegas\WW3D2\ww3d.cpp:975)
generalszh.exe!RTS3DScene::draw() Line 1763 (\GeneralsMD\Code\GameEngineDevice\Source\W3DDevice\GameClient\W3DScene.cpp:1763)
generalszh.exe!SubsystemInterface::DRAW() Line 132 (\Core\GameEngine\Include\Common\SubsystemInterface.h:132)
generalszh.exe!RTS3DScene::doRender(CameraClass * cam) Line 1748 (\GeneralsMD\Code\GameEngineDevice\Source\W3DDevice\GameClient\W3DScene.cpp:1748)
generalszh.exe!W3DView::draw() Line 1677 (\Core\GameEngineDevice\Source\W3DDevice\GameClient\W3DView.cpp:1677)
generalszh.exe!SubsystemInterface::DRAW() Line 132 (\Core\GameEngine\Include\Common\SubsystemInterface.h:132)
generalszh.exe!W3DView::drawView() Line 1641 (\Core\GameEngineDevice\Source\W3DDevice\GameClient\W3DView.cpp:1641)
generalszh.exe!Display::drawViews() Line 115 (\GeneralsMD\Code\GameEngine\Source\GameClient\Display.cpp:115)
generalszh.exe!W3DDisplay::draw() Line 1860 (\GeneralsMD\Code\GameEngineDevice\Source\W3DDevice\GameClient\W3DDisplay.cpp:1860)
generalszh.exe!SubsystemInterface::DRAW() Line 132 (\Core\GameEngine\Include\Common\SubsystemInterface.h:132)
generalszh.exe!GameClient::update() Line 759 (\GeneralsMD\Code\GameEngine\Source\GameClient\GameClient.cpp:759)
generalszh.exe!W3DGameClient::update() Line 94 (\GeneralsMD\Code\GameEngineDevice\Source\W3DDevice\GameClient\W3DGameClient.cpp:94)
generalszh.exe!SubsystemInterface::UPDATE() Line 131 (\Core\GameEngine\Include\Common\SubsystemInterface.h:131)
generalszh.exe!GameEngine::update() Line 906 (\GeneralsMD\Code\GameEngine\Source\Common\GameEngine.cpp:906)
```