### PR TITLE
fix(targa): Fix TGA2 footer signature truncation by using strncpy

### DIFF
--- a/Core/Libraries/Source/WWVegas/WWLib/TARGA.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/TARGA.cpp
@@ -735,7 +735,7 @@ long Targa::Save(const char* name, long flags, bool addextension)
 		if (!error)
 			{
 			footer.Developer = 0;
-			strlcpy(footer.Signature, TGA2_SIGNATURE, sizeof(footer.Signature));
+			memcpy(footer.Signature, TGA2_SIGNATURE, sizeof(footer.Signature)); // TheSuperHackers @bugfix bobtista 02/04/2026 Use memcpy to copy all 16 bytes of the TGA2 signature without null termination, as the field is a fixed-size binary field per the TGA 2.0 spec
 			footer.RsvdChar = '.';
 			footer.BZST = 0;
 

--- a/Core/Libraries/Source/WWVegas/WWLib/TARGA.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/TARGA.cpp
@@ -713,7 +713,7 @@ long Targa::Save(const char* name, long flags, bool addextension)
 			if (!error) {
 
 				mExtension.ExtSize = 495;
-				strcpy(mExtension.SoftID, "Denzil's Targa Code");
+				strlcpy_t(mExtension.SoftID, "Denzil's Targa Code"); // TheSuperHackers @fix bobtista 03/04/2026 Replace strcpy with strlcpy_t
 				mExtension.SoftVer.Number = (1 * 100);
 				mExtension.SoftVer.Letter = 0;
 
@@ -735,7 +735,8 @@ long Targa::Save(const char* name, long flags, bool addextension)
 		if (!error)
 			{
 			footer.Developer = 0;
-			memcpy(footer.Signature, TGA2_SIGNATURE, sizeof(footer.Signature)); // TheSuperHackers @bugfix bobtista 02/04/2026 Use memcpy to copy all 16 bytes of the TGA2 signature without null termination, as the field is a fixed-size binary field per the TGA 2.0 spec
+			static_assert(sizeof(TGA2_SIGNATURE) - 1 == sizeof(footer.Signature), "TGA2 signature length mismatch"); // TheSuperHackers @bugfix bobtista 02/04/2026 Verify TGA2 signature sizes match
+			strncpy(footer.Signature, TGA2_SIGNATURE, sizeof(footer.Signature));
 			footer.RsvdChar = '.';
 			footer.BZST = 0;
 

--- a/Core/Libraries/Source/WWVegas/WWLib/TARGA.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/TARGA.cpp
@@ -713,7 +713,7 @@ long Targa::Save(const char* name, long flags, bool addextension)
 			if (!error) {
 
 				mExtension.ExtSize = 495;
-				strlcpy_t(mExtension.SoftID, "Denzil's Targa Code"); // TheSuperHackers @fix bobtista 03/04/2026 Replace strcpy with strlcpy_t
+				strlcpy_t(mExtension.SoftID, "Denzil's Targa Code");
 				mExtension.SoftVer.Number = (1 * 100);
 				mExtension.SoftVer.Letter = 0;
 
@@ -735,7 +735,7 @@ long Targa::Save(const char* name, long flags, bool addextension)
 		if (!error)
 			{
 			footer.Developer = 0;
-			static_assert(sizeof(TGA2_SIGNATURE) - 1 == sizeof(footer.Signature), "TGA2 signature length mismatch"); // TheSuperHackers @bugfix bobtista 02/04/2026 Verify TGA2 signature sizes match
+			static_assert(sizeof(TGA2_SIGNATURE) - 1 == sizeof(footer.Signature), "TGA2 signature length mismatch");
 			strncpy(footer.Signature, TGA2_SIGNATURE, sizeof(footer.Signature));
 			footer.RsvdChar = '.';
 			footer.BZST = 0;

--- a/Core/Libraries/Source/WWVegas/WWLib/TARGA.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/TARGA.cpp
@@ -713,7 +713,7 @@ long Targa::Save(const char* name, long flags, bool addextension)
 			if (!error) {
 
 				mExtension.ExtSize = 495;
-				strlcpy_t(mExtension.SoftID, "Denzil's Targa Code");
+				strlcpy(mExtension.SoftID, "Denzil's Targa Code", sizeof(mExtension.SoftID));
 				mExtension.SoftVer.Number = (1 * 100);
 				mExtension.SoftVer.Letter = 0;
 


### PR DESCRIPTION
* Follow up for #1808
* Fixes #1828

PR 1808 fixed most of this issue, but this PR addresses a remaining item

`strlcpy` was used to write the 16-byte TGA 2.0 footer signature `"TRUEVISION-XFILE"` into `footer.Signature[16]`. Because `strlcpy` always null-terminates, it could only copy 15 characters before writing `\0`, silently truncating the last character of the signature field.

The `Signature` field is a fixed-size binary field per the TGA 2.0 spec — it is not null-terminated (reads confirm this by using `strncmp(..., 16)`). `strncpy` with `n` equal to the field size copies all 16 bytes without writing a null terminator, which is the correct behavior here. A `static_assert` is added to guarantee at compile time that the signature constant and the field are the same size.

This matches the behavior already in `Core/Tools/WW3D/max2w3d/TARGA.cpp` which uses `strncpy(..., 16)` for the same purpose.