### PR TITLE
feat(string): Implement UTF-8 string conversion and validation functions

### DIFF
--- a/Core/GameEngine/Source/Common/System/AsciiString.cpp
+++ b/Core/GameEngine/Source/Common/System/AsciiString.cpp
@@ -284,7 +284,7 @@ void AsciiString::translate(const UnicodeString& stringSrc)
 	}
 	ensureUniqueBufferOfSize((Int)len + 1, false, nullptr, nullptr);
 	char* buf = peek();
-	if (Utf16Le_To_Utf8(buf, len + 1, src, srcLen, true) == 0)
+	if (Utf16Le_To_Utf8(buf, len + 1, src, srcLen) == 0)
 		clear();
 	validate();
 }

--- a/Core/GameEngine/Source/Common/System/AsciiString.cpp
+++ b/Core/GameEngine/Source/Common/System/AsciiString.cpp
@@ -276,15 +276,15 @@ void AsciiString::translate(const UnicodeString& stringSrc)
 	// TheSuperHackers @fix bobtista 02/04/2026 Implement UTF-8 conversion replacing 7-bit ASCII only implementation
 	const WideChar* src = stringSrc.str();
 	size_t srcLen = wcslen(src);
-	size_t size = Get_Utf8_Size(src, srcLen);
-	if (size == 0)
+	size_t len = Get_Utf8_Len(src, srcLen);
+	if (len == 0)
 	{
 		clear();
 		return;
 	}
-	ensureUniqueBufferOfSize((Int)size + 1, false, nullptr, nullptr);
+	ensureUniqueBufferOfSize((Int)len + 1, false, nullptr, nullptr);
 	char* buf = peek();
-	if (!Unicode_To_Utf8(buf, src, srcLen, size))
+	if (Unicode_To_Utf8(buf, len + 1, src, srcLen) == 0)
 		clear();
 	validate();
 }

--- a/Core/GameEngine/Source/Common/System/AsciiString.cpp
+++ b/Core/GameEngine/Source/Common/System/AsciiString.cpp
@@ -45,6 +45,7 @@
 #include "PreRTS.h"	// This must go first in EVERY cpp file in the GameEngine
 
 #include "Common/CriticalSection.h"
+#include "utf8.h"
 
 
 // -----------------------------------------------------
@@ -137,8 +138,8 @@ void AsciiString::ensureUniqueBufferOfSize(int numCharsNeeded, Bool preserveData
 			// TheSuperHackers @fix Mauller 04/04/2025 Replace strcpy with safer memmove as memory regions can overlap when part of string is copied to itself
 			DEBUG_ASSERTCRASH(usableNumChars <= strlen(strToCopy), ("strToCopy is too small"));
 			memmove(m_data->peek(), strToCopy, usableNumChars);
-			m_data->peek()[usableNumChars] = 0;
 		}
+		m_data->peek()[usableNumChars] = 0;
 		if (strToCat)
 			strcat(m_data->peek(), strToCat);
 		return;
@@ -166,8 +167,8 @@ void AsciiString::ensureUniqueBufferOfSize(int numCharsNeeded, Bool preserveData
 	{
 		DEBUG_ASSERTCRASH(usableNumChars <= strlen(strToCopy), ("strToCopy is too small"));
 		strncpy(newData->peek(), strToCopy, usableNumChars);
-		newData->peek()[usableNumChars] = 0;
 	}
+	newData->peek()[usableNumChars] = 0;
 	if (strToCat)
 		strcat(newData->peek(), strToCat);
 
@@ -272,11 +273,19 @@ char*  AsciiString::getBufferForRead(Int len)
 void AsciiString::translate(const UnicodeString& stringSrc)
 {
 	validate();
-	/// @todo srj put in a real translation here; this will only work for 7-bit ascii
-	clear();
-	Int len = stringSrc.getLength();
-	for (Int i = 0; i < len; i++)
-		concat((char)stringSrc.getCharAt(i));
+	// TheSuperHackers @fix bobtista 02/04/2026 Implement UTF-8 conversion replacing 7-bit ASCII only implementation
+	const WideChar* src = stringSrc.str();
+	size_t srcLen = wcslen(src);
+	size_t size = Get_Utf8_Size(src, srcLen);
+	if (size == 0)
+	{
+		clear();
+		return;
+	}
+	ensureUniqueBufferOfSize((Int)size + 1, false, nullptr, nullptr);
+	char* buf = peek();
+	if (!Unicode_To_Utf8(buf, src, srcLen, size))
+		clear();
 	validate();
 }
 

--- a/Core/GameEngine/Source/Common/System/AsciiString.cpp
+++ b/Core/GameEngine/Source/Common/System/AsciiString.cpp
@@ -284,7 +284,7 @@ void AsciiString::translate(const UnicodeString& stringSrc)
 	}
 	ensureUniqueBufferOfSize((Int)len + 1, false, nullptr, nullptr);
 	char* buf = peek();
-	if (Utf16Le_To_Utf8(buf, len + 1, src, srcLen) == 0)
+	if (Utf16Le_To_Utf8(buf, len + 1, src, srcLen, true) == 0)
 		clear();
 	validate();
 }

--- a/Core/GameEngine/Source/Common/System/AsciiString.cpp
+++ b/Core/GameEngine/Source/Common/System/AsciiString.cpp
@@ -276,7 +276,7 @@ void AsciiString::translate(const UnicodeString& stringSrc)
 	// TheSuperHackers @fix bobtista 02/04/2026 Implement UTF-8 conversion replacing 7-bit ASCII only implementation
 	const WideChar* src = stringSrc.str();
 	size_t srcLen = wcslen(src);
-	size_t len = Get_Utf8_Len(src, srcLen);
+	size_t len = Utf16Le_To_Utf8_Len(src, srcLen);
 	if (len == 0)
 	{
 		clear();
@@ -284,7 +284,7 @@ void AsciiString::translate(const UnicodeString& stringSrc)
 	}
 	ensureUniqueBufferOfSize((Int)len + 1, false, nullptr, nullptr);
 	char* buf = peek();
-	if (Unicode_To_Utf8(buf, len + 1, src, srcLen) == 0)
+	if (Utf16Le_To_Utf8(buf, len + 1, src, srcLen) == 0)
 		clear();
 	validate();
 }

--- a/Core/GameEngine/Source/Common/System/AsciiString.cpp
+++ b/Core/GameEngine/Source/Common/System/AsciiString.cpp
@@ -285,7 +285,9 @@ void AsciiString::translate(const UnicodeString& stringSrc)
 	ensureUniqueBufferOfSize((Int)len + 1, false, nullptr, nullptr);
 	char* buf = peek();
 	if (Utf16Le_To_Utf8(buf, len + 1, src, srcLen) == 0)
+	{
 		clear();
+	}
 	validate();
 }
 

--- a/Core/GameEngine/Source/Common/System/AsciiString.cpp
+++ b/Core/GameEngine/Source/Common/System/AsciiString.cpp
@@ -276,15 +276,15 @@ void AsciiString::translate(const UnicodeString& stringSrc)
 	// TheSuperHackers @fix bobtista 02/04/2026 Implement UTF-8 conversion replacing 7-bit ASCII only implementation
 	const WideChar* src = stringSrc.str();
 	const size_t srcLen = wcslen(src);
-	const size_t len = Wide_To_Utf8_Len(src, srcLen);
-	if (len == 0)
+	const size_t dstLen = Wide_To_Utf8_Len(src, srcLen);
+	if (dstLen == 0)
 	{
 		clear();
 	}
 	else
 	{
-		ensureUniqueBufferOfSize((Int)len + 1, false, nullptr, nullptr);
-		Wide_To_Utf8(peek(), len + 1, src, srcLen);
+		ensureUniqueBufferOfSize((Int)dstLen + 1, false, nullptr, nullptr);
+		Wide_To_Utf8(peek(), dstLen + 1, src, srcLen);
 	}
 	validate();
 }

--- a/Core/GameEngine/Source/Common/System/AsciiString.cpp
+++ b/Core/GameEngine/Source/Common/System/AsciiString.cpp
@@ -276,7 +276,7 @@ void AsciiString::translate(const UnicodeString& stringSrc)
 	// TheSuperHackers @fix bobtista 02/04/2026 Implement UTF-8 conversion replacing 7-bit ASCII only implementation
 	const WideChar* src = stringSrc.str();
 	const size_t srcLen = wcslen(src);
-	const size_t len = Utf16Le_To_Utf8_Len(src, srcLen);
+	const size_t len = Wide_To_Utf8_Len(src, srcLen);
 	if (len == 0)
 	{
 		clear();
@@ -284,7 +284,7 @@ void AsciiString::translate(const UnicodeString& stringSrc)
 	else
 	{
 		ensureUniqueBufferOfSize((Int)len + 1, false, nullptr, nullptr);
-		Utf16Le_To_Utf8(peek(), len + 1, src, srcLen);
+		Wide_To_Utf8(peek(), len + 1, src, srcLen);
 	}
 	validate();
 }

--- a/Core/GameEngine/Source/Common/System/AsciiString.cpp
+++ b/Core/GameEngine/Source/Common/System/AsciiString.cpp
@@ -45,7 +45,7 @@
 #include "PreRTS.h"	// This must go first in EVERY cpp file in the GameEngine
 
 #include "Common/CriticalSection.h"
-#include "utf8.h"
+#include "WWLib/utf8.h"
 
 
 // -----------------------------------------------------

--- a/Core/GameEngine/Source/Common/System/AsciiString.cpp
+++ b/Core/GameEngine/Source/Common/System/AsciiString.cpp
@@ -138,8 +138,8 @@ void AsciiString::ensureUniqueBufferOfSize(int numCharsNeeded, Bool preserveData
 			// TheSuperHackers @fix Mauller 04/04/2025 Replace strcpy with safer memmove as memory regions can overlap when part of string is copied to itself
 			DEBUG_ASSERTCRASH(usableNumChars <= strlen(strToCopy), ("strToCopy is too small"));
 			memmove(m_data->peek(), strToCopy, usableNumChars);
+			m_data->peek()[usableNumChars] = 0;
 		}
-		m_data->peek()[usableNumChars] = 0;
 		if (strToCat)
 			strcat(m_data->peek(), strToCat);
 		return;
@@ -167,8 +167,8 @@ void AsciiString::ensureUniqueBufferOfSize(int numCharsNeeded, Bool preserveData
 	{
 		DEBUG_ASSERTCRASH(usableNumChars <= strlen(strToCopy), ("strToCopy is too small"));
 		strncpy(newData->peek(), strToCopy, usableNumChars);
+		newData->peek()[usableNumChars] = 0;
 	}
-	newData->peek()[usableNumChars] = 0;
 	if (strToCat)
 		strcat(newData->peek(), strToCat);
 

--- a/Core/GameEngine/Source/Common/System/AsciiString.cpp
+++ b/Core/GameEngine/Source/Common/System/AsciiString.cpp
@@ -275,18 +275,16 @@ void AsciiString::translate(const UnicodeString& stringSrc)
 	validate();
 	// TheSuperHackers @fix bobtista 02/04/2026 Implement UTF-8 conversion replacing 7-bit ASCII only implementation
 	const WideChar* src = stringSrc.str();
-	size_t srcLen = wcslen(src);
-	size_t len = Utf16Le_To_Utf8_Len(src, srcLen);
+	const size_t srcLen = wcslen(src);
+	const size_t len = Utf16Le_To_Utf8_Len(src, srcLen);
 	if (len == 0)
 	{
 		clear();
-		return;
 	}
-	ensureUniqueBufferOfSize((Int)len + 1, false, nullptr, nullptr);
-	char* buf = peek();
-	if (Utf16Le_To_Utf8(buf, len + 1, src, srcLen) == 0)
+	else
 	{
-		clear();
+		ensureUniqueBufferOfSize((Int)len + 1, false, nullptr, nullptr);
+		Utf16Le_To_Utf8(peek(), len + 1, src, srcLen);
 	}
 	validate();
 }

--- a/Core/GameEngine/Source/Common/System/UnicodeString.cpp
+++ b/Core/GameEngine/Source/Common/System/UnicodeString.cpp
@@ -225,15 +225,15 @@ void UnicodeString::translate(const AsciiString& stringSrc)
 	// TheSuperHackers @fix bobtista 02/04/2026 Implement UTF-8 conversion replacing 7-bit ASCII only implementation
 	const char* src = stringSrc.str();
 	size_t srcLen = strlen(src);
-	size_t size = Get_Unicode_Size(src, srcLen);
-	if (size == 0)
+	size_t len = Get_Unicode_Len(src, srcLen);
+	if (len == 0)
 	{
 		clear();
 		return;
 	}
-	ensureUniqueBufferOfSize((Int)size + 1, false, nullptr, nullptr);
+	ensureUniqueBufferOfSize((Int)len + 1, false, nullptr, nullptr);
 	WideChar* buf = peek();
-	if (!Utf8_To_Unicode(buf, src, srcLen, size))
+	if (Utf8_To_Unicode(buf, len + 1, src, srcLen) == 0)
 		clear();
 	validate();
 }

--- a/Core/GameEngine/Source/Common/System/UnicodeString.cpp
+++ b/Core/GameEngine/Source/Common/System/UnicodeString.cpp
@@ -45,6 +45,7 @@
 #include "PreRTS.h"	// This must go first in EVERY cpp file in the GameEngine
 
 #include "Common/CriticalSection.h"
+#include "utf8.h"
 
 
 // -----------------------------------------------------
@@ -88,8 +89,8 @@ void UnicodeString::ensureUniqueBufferOfSize(int numCharsNeeded, Bool preserveDa
 			// TheSuperHackers @fix Mauller 04/04/2025 Replace wcscpy with safer memmove as memory regions can overlap when part of string is copied to itself
 			DEBUG_ASSERTCRASH(usableNumChars <= wcslen(strToCopy), ("strToCopy is too small"));
 			memmove(m_data->peek(), strToCopy, usableNumChars * sizeof(WideChar));
-			m_data->peek()[usableNumChars] = 0;
 		}
+		m_data->peek()[usableNumChars] = 0;
 		if (strToCat)
 			wcscat(m_data->peek(), strToCat);
 		return;
@@ -117,8 +118,8 @@ void UnicodeString::ensureUniqueBufferOfSize(int numCharsNeeded, Bool preserveDa
 	{
 		DEBUG_ASSERTCRASH(usableNumChars <= wcslen(strToCopy), ("strToCopy is too small"));
 		wcsncpy(newData->peek(), strToCopy, usableNumChars);
-		newData->peek()[usableNumChars] = 0;
 	}
+	newData->peek()[usableNumChars] = 0;
 	if (strToCat)
 		wcscat(newData->peek(), strToCat);
 
@@ -221,11 +222,19 @@ WideChar* UnicodeString::getBufferForRead(Int len)
 void UnicodeString::translate(const AsciiString& stringSrc)
 {
 	validate();
-	/// @todo srj put in a real translation here; this will only work for 7-bit ascii
-	clear();
-	Int len = stringSrc.getLength();
-	for (Int i = 0; i < len; i++)
-		concat((WideChar)stringSrc.getCharAt(i));
+	// TheSuperHackers @fix bobtista 02/04/2026 Implement UTF-8 conversion replacing 7-bit ASCII only implementation
+	const char* src = stringSrc.str();
+	size_t srcLen = strlen(src);
+	size_t size = Get_Unicode_Size(src, srcLen);
+	if (size == 0)
+	{
+		clear();
+		return;
+	}
+	ensureUniqueBufferOfSize((Int)size + 1, false, nullptr, nullptr);
+	WideChar* buf = peek();
+	if (!Utf8_To_Unicode(buf, src, srcLen, size))
+		clear();
 	validate();
 }
 

--- a/Core/GameEngine/Source/Common/System/UnicodeString.cpp
+++ b/Core/GameEngine/Source/Common/System/UnicodeString.cpp
@@ -233,7 +233,7 @@ void UnicodeString::translate(const AsciiString& stringSrc)
 	}
 	ensureUniqueBufferOfSize((Int)len + 1, false, nullptr, nullptr);
 	WideChar* buf = peek();
-	if (Utf8_To_Utf16Le(buf, len + 1, src, srcLen) == 0)
+	if (Utf8_To_Utf16Le(buf, len + 1, src, srcLen, true) == 0)
 		clear();
 	validate();
 }

--- a/Core/GameEngine/Source/Common/System/UnicodeString.cpp
+++ b/Core/GameEngine/Source/Common/System/UnicodeString.cpp
@@ -233,7 +233,7 @@ void UnicodeString::translate(const AsciiString& stringSrc)
 	}
 	ensureUniqueBufferOfSize((Int)len + 1, false, nullptr, nullptr);
 	WideChar* buf = peek();
-	if (Utf8_To_Utf16Le(buf, len + 1, src, srcLen, true) == 0)
+	if (Utf8_To_Utf16Le(buf, len + 1, src, srcLen) == 0)
 		clear();
 	validate();
 }

--- a/Core/GameEngine/Source/Common/System/UnicodeString.cpp
+++ b/Core/GameEngine/Source/Common/System/UnicodeString.cpp
@@ -225,7 +225,7 @@ void UnicodeString::translate(const AsciiString& stringSrc)
 	// TheSuperHackers @fix bobtista 02/04/2026 Implement UTF-8 conversion replacing 7-bit ASCII only implementation
 	const char* src = stringSrc.str();
 	size_t srcLen = strlen(src);
-	size_t len = Get_Unicode_Len(src, srcLen);
+	size_t len = Utf8_To_Utf16Le_Len(src, srcLen);
 	if (len == 0)
 	{
 		clear();
@@ -233,7 +233,7 @@ void UnicodeString::translate(const AsciiString& stringSrc)
 	}
 	ensureUniqueBufferOfSize((Int)len + 1, false, nullptr, nullptr);
 	WideChar* buf = peek();
-	if (Utf8_To_Unicode(buf, len + 1, src, srcLen) == 0)
+	if (Utf8_To_Utf16Le(buf, len + 1, src, srcLen) == 0)
 		clear();
 	validate();
 }

--- a/Core/GameEngine/Source/Common/System/UnicodeString.cpp
+++ b/Core/GameEngine/Source/Common/System/UnicodeString.cpp
@@ -222,20 +222,31 @@ WideChar* UnicodeString::getBufferForRead(Int len)
 void UnicodeString::translate(const AsciiString& stringSrc)
 {
 	validate();
-	// TheSuperHackers @fix bobtista 02/04/2026 Implement UTF-8 conversion replacing 7-bit ASCII only implementation
+	// TheSuperHackers @fix bobtista 02/04/2026 Convert UTF-8 to wide, replacing the 7-bit ASCII only
+	// implementation. Data that is not valid UTF-8 (e.g. legacy CP1252) falls back to a 1:1 byte cast
+	// to preserve the original characters instead of producing replacement characters.
 	const char* src = stringSrc.str();
-	size_t srcLen = strlen(src);
-	size_t len = Utf8_To_Utf16Le_Len(src, srcLen);
-	if (len == 0)
+	const size_t srcLen = strlen(src);
+	if (srcLen == 0)
 	{
 		clear();
 		return;
 	}
-	ensureUniqueBufferOfSize((Int)len + 1, false, nullptr, nullptr);
-	WideChar* buf = peek();
-	if (Utf8_To_Utf16Le(buf, len + 1, src, srcLen) == 0)
+	if (Utf8_Validate(src, srcLen))
 	{
-		clear();
+		const size_t len = Utf8_To_Utf16Le_Len(src, srcLen);
+		ensureUniqueBufferOfSize((Int)len + 1, false, nullptr, nullptr);
+		Utf8_To_Utf16Le(peek(), len + 1, src, srcLen);
+	}
+	else
+	{
+		ensureUniqueBufferOfSize((Int)srcLen + 1, false, nullptr, nullptr);
+		WideChar* buf = peek();
+		for (size_t i = 0; i < srcLen; ++i)
+		{
+			buf[i] = (WideChar)(unsigned char)src[i];
+		}
+		buf[srcLen] = 0;
 	}
 	validate();
 }

--- a/Core/GameEngine/Source/Common/System/UnicodeString.cpp
+++ b/Core/GameEngine/Source/Common/System/UnicodeString.cpp
@@ -227,7 +227,7 @@ void UnicodeString::translate(const AsciiString& stringSrc)
 	// to preserve the original characters instead of producing replacement characters.
 	const char* src = stringSrc.str();
 	const size_t srcLen = strlen(src);
-	const size_t len = Utf8_To_Utf16Le_Len(src, srcLen);
+	const size_t len = Utf8_To_Wide_Len(src, srcLen);
 	if (srcLen == 0)
 	{
 		clear();
@@ -245,7 +245,7 @@ void UnicodeString::translate(const AsciiString& stringSrc)
 	else
 	{
 		ensureUniqueBufferOfSize((Int)len + 1, false, nullptr, nullptr);
-		Utf8_To_Utf16Le(peek(), len + 1, src, srcLen);
+		Utf8_To_Wide(peek(), len + 1, src, srcLen);
 	}
 	validate();
 }

--- a/Core/GameEngine/Source/Common/System/UnicodeString.cpp
+++ b/Core/GameEngine/Source/Common/System/UnicodeString.cpp
@@ -228,11 +228,19 @@ void UnicodeString::translate(const AsciiString& stringSrc)
 	const char* src = stringSrc.str();
 	const size_t srcLen = strlen(src);
 	const size_t dstLen = Utf8_To_Wide_Len(src, srcLen);
-	if (srcLen == 0)
+	if (dstLen != UTF8_INVALID)
 	{
-		clear();
+		if (dstLen == 0)
+		{
+			clear();
+		}
+		else
+		{
+			ensureUniqueBufferOfSize((Int)dstLen + 1, false, nullptr, nullptr);
+			Utf8_To_Wide(peek(), dstLen + 1, src, srcLen);
+		}
 	}
-	else if (dstLen == UTF8_INVALID)
+	else
 	{
 		ensureUniqueBufferOfSize((Int)srcLen + 1, false, nullptr, nullptr);
 		WideChar* buf = peek();
@@ -241,11 +249,6 @@ void UnicodeString::translate(const AsciiString& stringSrc)
 			buf[i] = (WideChar)(unsigned char)src[i];
 		}
 		buf[srcLen] = 0;
-	}
-	else
-	{
-		ensureUniqueBufferOfSize((Int)dstLen + 1, false, nullptr, nullptr);
-		Utf8_To_Wide(peek(), dstLen + 1, src, srcLen);
 	}
 	validate();
 }

--- a/Core/GameEngine/Source/Common/System/UnicodeString.cpp
+++ b/Core/GameEngine/Source/Common/System/UnicodeString.cpp
@@ -227,18 +227,12 @@ void UnicodeString::translate(const AsciiString& stringSrc)
 	// to preserve the original characters instead of producing replacement characters.
 	const char* src = stringSrc.str();
 	const size_t srcLen = strlen(src);
+	const size_t len = Utf8_To_Utf16Le_Len(src, srcLen);
 	if (srcLen == 0)
 	{
 		clear();
-		return;
 	}
-	if (Utf8_Validate(src, srcLen))
-	{
-		const size_t len = Utf8_To_Utf16Le_Len(src, srcLen);
-		ensureUniqueBufferOfSize((Int)len + 1, false, nullptr, nullptr);
-		Utf8_To_Utf16Le(peek(), len + 1, src, srcLen);
-	}
-	else
+	else if (len == UTF8_INVALID)
 	{
 		ensureUniqueBufferOfSize((Int)srcLen + 1, false, nullptr, nullptr);
 		WideChar* buf = peek();
@@ -247,6 +241,11 @@ void UnicodeString::translate(const AsciiString& stringSrc)
 			buf[i] = (WideChar)(unsigned char)src[i];
 		}
 		buf[srcLen] = 0;
+	}
+	else
+	{
+		ensureUniqueBufferOfSize((Int)len + 1, false, nullptr, nullptr);
+		Utf8_To_Utf16Le(peek(), len + 1, src, srcLen);
 	}
 	validate();
 }

--- a/Core/GameEngine/Source/Common/System/UnicodeString.cpp
+++ b/Core/GameEngine/Source/Common/System/UnicodeString.cpp
@@ -89,8 +89,8 @@ void UnicodeString::ensureUniqueBufferOfSize(int numCharsNeeded, Bool preserveDa
 			// TheSuperHackers @fix Mauller 04/04/2025 Replace wcscpy with safer memmove as memory regions can overlap when part of string is copied to itself
 			DEBUG_ASSERTCRASH(usableNumChars <= wcslen(strToCopy), ("strToCopy is too small"));
 			memmove(m_data->peek(), strToCopy, usableNumChars * sizeof(WideChar));
+			m_data->peek()[usableNumChars] = 0;
 		}
-		m_data->peek()[usableNumChars] = 0;
 		if (strToCat)
 			wcscat(m_data->peek(), strToCat);
 		return;
@@ -118,8 +118,8 @@ void UnicodeString::ensureUniqueBufferOfSize(int numCharsNeeded, Bool preserveDa
 	{
 		DEBUG_ASSERTCRASH(usableNumChars <= wcslen(strToCopy), ("strToCopy is too small"));
 		wcsncpy(newData->peek(), strToCopy, usableNumChars);
+		newData->peek()[usableNumChars] = 0;
 	}
-	newData->peek()[usableNumChars] = 0;
 	if (strToCat)
 		wcscat(newData->peek(), strToCat);
 

--- a/Core/GameEngine/Source/Common/System/UnicodeString.cpp
+++ b/Core/GameEngine/Source/Common/System/UnicodeString.cpp
@@ -45,7 +45,7 @@
 #include "PreRTS.h"	// This must go first in EVERY cpp file in the GameEngine
 
 #include "Common/CriticalSection.h"
-#include "utf8.h"
+#include "WWLib/utf8.h"
 
 
 // -----------------------------------------------------

--- a/Core/GameEngine/Source/Common/System/UnicodeString.cpp
+++ b/Core/GameEngine/Source/Common/System/UnicodeString.cpp
@@ -234,7 +234,9 @@ void UnicodeString::translate(const AsciiString& stringSrc)
 	ensureUniqueBufferOfSize((Int)len + 1, false, nullptr, nullptr);
 	WideChar* buf = peek();
 	if (Utf8_To_Utf16Le(buf, len + 1, src, srcLen) == 0)
+	{
 		clear();
+	}
 	validate();
 }
 

--- a/Core/GameEngine/Source/Common/System/UnicodeString.cpp
+++ b/Core/GameEngine/Source/Common/System/UnicodeString.cpp
@@ -227,12 +227,12 @@ void UnicodeString::translate(const AsciiString& stringSrc)
 	// to preserve the original characters instead of producing replacement characters.
 	const char* src = stringSrc.str();
 	const size_t srcLen = strlen(src);
-	const size_t len = Utf8_To_Wide_Len(src, srcLen);
+	const size_t dstLen = Utf8_To_Wide_Len(src, srcLen);
 	if (srcLen == 0)
 	{
 		clear();
 	}
-	else if (len == UTF8_INVALID)
+	else if (dstLen == UTF8_INVALID)
 	{
 		ensureUniqueBufferOfSize((Int)srcLen + 1, false, nullptr, nullptr);
 		WideChar* buf = peek();
@@ -244,8 +244,8 @@ void UnicodeString::translate(const AsciiString& stringSrc)
 	}
 	else
 	{
-		ensureUniqueBufferOfSize((Int)len + 1, false, nullptr, nullptr);
-		Utf8_To_Wide(peek(), len + 1, src, srcLen);
+		ensureUniqueBufferOfSize((Int)dstLen + 1, false, nullptr, nullptr);
+		Utf8_To_Wide(peek(), dstLen + 1, src, srcLen);
 	}
 	validate();
 }

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/ThreadUtils.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/ThreadUtils.cpp
@@ -41,7 +41,7 @@ std::wstring MultiByteToWideCharSingleLine( const char *orig )
 		return std::wstring();
 	std::wstring ret;
 	ret.resize(len);
-	Utf8_To_Utf16Le(&ret[0], len, orig, srcLen, true);
+	Utf8_To_Utf16Le(&ret[0], len, orig, srcLen);
 	WideChar *c = nullptr;
 	do
 	{
@@ -73,7 +73,7 @@ std::string WideCharStringToMultiByte( const WideChar *orig )
 		return std::string();
 	std::string ret;
 	ret.resize(len);
-	Utf16Le_To_Utf8(&ret[0], len, orig, srcLen, true);
+	Utf16Le_To_Utf8(&ret[0], len, orig, srcLen);
 	return ret;
 }
 

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/ThreadUtils.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/ThreadUtils.cpp
@@ -36,12 +36,12 @@
 std::wstring MultiByteToWideCharSingleLine( const char *orig )
 {
 	size_t srcLen = strlen(orig);
-	size_t len = Get_Unicode_Len(orig, srcLen);
+	size_t len = Utf8_To_Utf16Le_Len(orig, srcLen);
 	if (len == 0)
 		return std::wstring();
 	std::wstring ret;
 	ret.resize(len);
-	Utf8_To_Unicode(&ret[0], len, orig, srcLen);
+	Utf8_To_Utf16Le(&ret[0], len, orig, srcLen);
 	WideChar *c = nullptr;
 	do
 	{
@@ -68,12 +68,12 @@ std::wstring MultiByteToWideCharSingleLine( const char *orig )
 std::string WideCharStringToMultiByte( const WideChar *orig )
 {
 	size_t srcLen = wcslen(orig);
-	size_t len = Get_Utf8_Len(orig, srcLen);
+	size_t len = Utf16Le_To_Utf8_Len(orig, srcLen);
 	if (len == 0)
 		return std::string();
 	std::string ret;
 	ret.resize(len);
-	Unicode_To_Utf8(&ret[0], len, orig, srcLen);
+	Utf16Le_To_Utf8(&ret[0], len, orig, srcLen);
 	return ret;
 }
 

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/ThreadUtils.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/ThreadUtils.cpp
@@ -41,7 +41,7 @@ std::wstring MultiByteToWideCharSingleLine( const char *orig )
 		return std::wstring();
 	std::wstring ret;
 	ret.resize(len);
-	Utf8_To_Utf16Le(&ret[0], len, orig, srcLen);
+	Utf8_To_Utf16Le(&ret[0], len, orig, srcLen, true);
 	WideChar *c = nullptr;
 	do
 	{
@@ -73,7 +73,7 @@ std::string WideCharStringToMultiByte( const WideChar *orig )
 		return std::string();
 	std::string ret;
 	ret.resize(len);
-	Utf16Le_To_Utf8(&ret[0], len, orig, srcLen);
+	Utf16Le_To_Utf8(&ret[0], len, orig, srcLen, true);
 	return ret;
 }
 

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/ThreadUtils.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/ThreadUtils.cpp
@@ -28,18 +28,24 @@
 
 #include "PreRTS.h"	// This must go first in EVERY cpp file in the GameEngine
 
+#include "utf8.h"
+
 //-------------------------------------------------------------------------
 
+// TheSuperHackers @refactor bobtista 02/04/2026 Use WWLib UTF-8 functions instead of raw Win32 API calls
 std::wstring MultiByteToWideCharSingleLine( const char *orig )
 {
-	Int len = strlen(orig);
-	WideChar *dest = NEW WideChar[len+1];
-
-	MultiByteToWideChar(CP_UTF8, 0, orig, -1, dest, len);
+	size_t srcLen = strlen(orig);
+	size_t size = Get_Unicode_Size(orig, srcLen);
+	if (size == 0)
+		return std::wstring();
+	std::wstring ret;
+	ret.resize(size);
+	Utf8_To_Unicode(&ret[0], orig, srcLen, size);
 	WideChar *c = nullptr;
 	do
 	{
-		c = wcschr(dest, L'\n');
+		c = wcschr(&ret[0], L'\n');
 		if (c)
 		{
 			*c = L' ';
@@ -48,7 +54,7 @@ std::wstring MultiByteToWideCharSingleLine( const char *orig )
 	while ( c != nullptr );
 	do
 	{
-		c = wcschr(dest, L'\r');
+		c = wcschr(&ret[0], L'\r');
 		if (c)
 		{
 			*c = L' ';
@@ -56,24 +62,18 @@ std::wstring MultiByteToWideCharSingleLine( const char *orig )
 	}
 	while ( c != nullptr );
 
-	dest[len] = 0;
-	std::wstring ret = dest;
-	delete[] dest;
 	return ret;
 }
 
 std::string WideCharStringToMultiByte( const WideChar *orig )
 {
+	size_t srcLen = wcslen(orig);
+	size_t size = Get_Utf8_Size(orig, srcLen);
+	if (size == 0)
+		return std::string();
 	std::string ret;
-	Int len = WideCharToMultiByte( CP_UTF8, 0, orig, wcslen(orig), nullptr, 0, nullptr, nullptr ) + 1;
-	if (len > 0)
-	{
-		char *dest = NEW char[len];
-		WideCharToMultiByte( CP_UTF8, 0, orig, -1, dest, len, nullptr, nullptr );
-		dest[len-1] = 0;
-		ret = dest;
-		delete[] dest;
-	}
+	ret.resize(size);
+	Unicode_To_Utf8(&ret[0], orig, srcLen, size);
 	return ret;
 }
 

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/ThreadUtils.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/ThreadUtils.cpp
@@ -36,12 +36,12 @@
 std::wstring MultiByteToWideCharSingleLine( const char *orig )
 {
 	size_t srcLen = strlen(orig);
-	size_t size = Get_Unicode_Size(orig, srcLen);
-	if (size == 0)
+	size_t len = Get_Unicode_Len(orig, srcLen);
+	if (len == 0)
 		return std::wstring();
 	std::wstring ret;
-	ret.resize(size);
-	Utf8_To_Unicode(&ret[0], orig, srcLen, size);
+	ret.resize(len);
+	Utf8_To_Unicode(&ret[0], len, orig, srcLen);
 	WideChar *c = nullptr;
 	do
 	{
@@ -68,12 +68,12 @@ std::wstring MultiByteToWideCharSingleLine( const char *orig )
 std::string WideCharStringToMultiByte( const WideChar *orig )
 {
 	size_t srcLen = wcslen(orig);
-	size_t size = Get_Utf8_Size(orig, srcLen);
-	if (size == 0)
+	size_t len = Get_Utf8_Len(orig, srcLen);
+	if (len == 0)
 		return std::string();
 	std::string ret;
-	ret.resize(size);
-	Unicode_To_Utf8(&ret[0], orig, srcLen, size);
+	ret.resize(len);
+	Unicode_To_Utf8(&ret[0], len, orig, srcLen);
 	return ret;
 }
 

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/ThreadUtils.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/ThreadUtils.cpp
@@ -37,11 +37,24 @@ std::wstring MultiByteToWideCharSingleLine( const char *orig )
 {
 	const size_t srcLen = strlen(orig);
 	const size_t len = Utf8_To_Utf16Le_Len(orig, srcLen);
-	if (len == 0 || len == UTF8_INVALID)
+	if (len == 0)
 		return std::wstring();
 	std::wstring ret;
-	ret.resize(len);
-	Utf8_To_Utf16Le(&ret[0], len, orig, srcLen);
+	if (len == UTF8_INVALID)
+	{
+		// Not UTF-8. Fall back to a 1:1 byte cast so legacy data keeps its characters, matching
+		// UnicodeString::translate.
+		ret.resize(srcLen);
+		for (size_t i = 0; i < srcLen; ++i)
+		{
+			ret[i] = (WideChar)(unsigned char)orig[i];
+		}
+	}
+	else
+	{
+		ret.resize(len);
+		Utf8_To_Utf16Le(&ret[0], len, orig, srcLen);
+	}
 	WideChar *c = nullptr;
 	do
 	{

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/ThreadUtils.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/ThreadUtils.cpp
@@ -36,11 +36,11 @@
 std::wstring MultiByteToWideCharSingleLine( const char *orig )
 {
 	const size_t srcLen = strlen(orig);
-	const size_t len = Utf8_To_Wide_Len(orig, srcLen);
-	if (len == 0)
+	const size_t dstLen = Utf8_To_Wide_Len(orig, srcLen);
+	if (dstLen == 0)
 		return std::wstring();
 	std::wstring ret;
-	if (len == UTF8_INVALID)
+	if (dstLen == UTF8_INVALID)
 	{
 		// Not UTF-8. Fall back to a 1:1 byte cast so legacy data keeps its characters, matching
 		// UnicodeString::translate.
@@ -52,8 +52,8 @@ std::wstring MultiByteToWideCharSingleLine( const char *orig )
 	}
 	else
 	{
-		ret.resize(len);
-		Utf8_To_Wide(&ret[0], len, orig, srcLen);
+		ret.resize(dstLen);
+		Utf8_To_Wide(&ret[0], dstLen, orig, srcLen);
 	}
 	WideChar *c = nullptr;
 	do
@@ -81,12 +81,12 @@ std::wstring MultiByteToWideCharSingleLine( const char *orig )
 std::string WideCharStringToMultiByte( const WideChar *orig )
 {
 	const size_t srcLen = wcslen(orig);
-	const size_t len = Wide_To_Utf8_Len(orig, srcLen);
-	if (len == 0)
+	const size_t dstLen = Wide_To_Utf8_Len(orig, srcLen);
+	if (dstLen == 0)
 		return std::string();
 	std::string ret;
-	ret.resize(len);
-	Wide_To_Utf8(&ret[0], len, orig, srcLen);
+	ret.resize(dstLen);
+	Wide_To_Utf8(&ret[0], dstLen, orig, srcLen);
 	return ret;
 }
 

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/ThreadUtils.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/ThreadUtils.cpp
@@ -28,7 +28,7 @@
 
 #include "PreRTS.h"	// This must go first in EVERY cpp file in the GameEngine
 
-#include "utf8.h"
+#include "WWLib/utf8.h"
 
 //-------------------------------------------------------------------------
 

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/ThreadUtils.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/ThreadUtils.cpp
@@ -41,7 +41,10 @@ std::wstring MultiByteToWideCharSingleLine( const char *orig )
 		return std::wstring();
 	std::wstring ret;
 	ret.resize(len);
-	Utf8_To_Utf16Le(&ret[0], len, orig, srcLen);
+	if (Utf8_To_Utf16Le(&ret[0], len, orig, srcLen) == 0)
+	{
+		return std::wstring();
+	}
 	WideChar *c = nullptr;
 	do
 	{
@@ -73,7 +76,10 @@ std::string WideCharStringToMultiByte( const WideChar *orig )
 		return std::string();
 	std::string ret;
 	ret.resize(len);
-	Utf16Le_To_Utf8(&ret[0], len, orig, srcLen);
+	if (Utf16Le_To_Utf8(&ret[0], len, orig, srcLen) == 0)
+	{
+		return std::string();
+	}
 	return ret;
 }
 

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/ThreadUtils.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/ThreadUtils.cpp
@@ -36,7 +36,7 @@
 std::wstring MultiByteToWideCharSingleLine( const char *orig )
 {
 	const size_t srcLen = strlen(orig);
-	const size_t len = Utf8_To_Utf16Le_Len(orig, srcLen);
+	const size_t len = Utf8_To_Wide_Len(orig, srcLen);
 	if (len == 0)
 		return std::wstring();
 	std::wstring ret;
@@ -53,7 +53,7 @@ std::wstring MultiByteToWideCharSingleLine( const char *orig )
 	else
 	{
 		ret.resize(len);
-		Utf8_To_Utf16Le(&ret[0], len, orig, srcLen);
+		Utf8_To_Wide(&ret[0], len, orig, srcLen);
 	}
 	WideChar *c = nullptr;
 	do
@@ -81,12 +81,12 @@ std::wstring MultiByteToWideCharSingleLine( const char *orig )
 std::string WideCharStringToMultiByte( const WideChar *orig )
 {
 	const size_t srcLen = wcslen(orig);
-	const size_t len = Utf16Le_To_Utf8_Len(orig, srcLen);
+	const size_t len = Wide_To_Utf8_Len(orig, srcLen);
 	if (len == 0)
 		return std::string();
 	std::string ret;
 	ret.resize(len);
-	Utf16Le_To_Utf8(&ret[0], len, orig, srcLen);
+	Wide_To_Utf8(&ret[0], len, orig, srcLen);
 	return ret;
 }
 

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/ThreadUtils.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/ThreadUtils.cpp
@@ -35,16 +35,13 @@
 // TheSuperHackers @refactor bobtista 02/04/2026 Use WWLib UTF-8 functions instead of raw Win32 API calls
 std::wstring MultiByteToWideCharSingleLine( const char *orig )
 {
-	size_t srcLen = strlen(orig);
-	size_t len = Utf8_To_Utf16Le_Len(orig, srcLen);
-	if (len == 0)
+	const size_t srcLen = strlen(orig);
+	const size_t len = Utf8_To_Utf16Le_Len(orig, srcLen);
+	if (len == 0 || len == UTF8_INVALID)
 		return std::wstring();
 	std::wstring ret;
 	ret.resize(len);
-	if (Utf8_To_Utf16Le(&ret[0], len, orig, srcLen) == 0)
-	{
-		return std::wstring();
-	}
+	Utf8_To_Utf16Le(&ret[0], len, orig, srcLen);
 	WideChar *c = nullptr;
 	do
 	{
@@ -70,16 +67,13 @@ std::wstring MultiByteToWideCharSingleLine( const char *orig )
 
 std::string WideCharStringToMultiByte( const WideChar *orig )
 {
-	size_t srcLen = wcslen(orig);
-	size_t len = Utf16Le_To_Utf8_Len(orig, srcLen);
+	const size_t srcLen = wcslen(orig);
+	const size_t len = Utf16Le_To_Utf8_Len(orig, srcLen);
 	if (len == 0)
 		return std::string();
 	std::string ret;
 	ret.resize(len);
-	if (Utf16Le_To_Utf8(&ret[0], len, orig, srcLen) == 0)
-	{
-		return std::string();
-	}
+	Utf16Le_To_Utf8(&ret[0], len, orig, srcLen);
 	return ret;
 }
 

--- a/Core/Libraries/Source/WWVegas/WWLib/CMakeLists.txt
+++ b/Core/Libraries/Source/WWVegas/WWLib/CMakeLists.txt
@@ -133,6 +133,8 @@ set(WWLIB_SRC
     trim.cpp
     trim.h
     uarray.h
+    utf8.cpp
+    utf8.h
     vector.cpp
     Vector.h
     visualc.h

--- a/Core/Libraries/Source/WWVegas/WWLib/utf8.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/utf8.cpp
@@ -85,6 +85,9 @@ bool Utf8_Validate(const char* str, size_t length)
 			return false;
 		if (bytes == 3 && s[i] == 0xE0 && s[i + 1] < 0xA0)
 			return false;
+		// Reject UTF-16 surrogates (U+D800-U+DFFF) per RFC 3629
+		if (bytes == 3 && s[i] == 0xED && s[i + 1] > 0x9F)
+			return false;
 		if (bytes == 4 && s[i] == 0xF0 && s[i + 1] < 0x90)
 			return false;
 		// Reject codepoints above U+10FFFF
@@ -109,24 +112,9 @@ size_t Utf8_To_Utf16Le_Len(const char* src, size_t srcLen)
 	return (wchars > 0) ? (size_t)wchars : 0;
 }
 
-size_t Utf16Le_To_Utf8(char* dest, size_t destLen, const wchar_t* src, size_t srcLen, bool writeDirect)
+size_t Utf16Le_To_Utf8(char* dest, size_t destLen, const wchar_t* src, size_t srcLen)
 {
-	if (!writeDirect)
-	{
-		const size_t required = Utf16Le_To_Utf8_Len(src, srcLen);
-		if (required == 0)
-		{
-			if (destLen > 0)
-				dest[0] = '\0';
-			return 0;
-		}
-		if (required > destLen)
-		{
-			if (destLen > 0)
-				dest[0] = '\0';
-			return required;
-		}
-	}
+	WWASSERT(destLen >= Utf16Le_To_Utf8_Len(src, srcLen));
 	const int written = WideCharToMultiByte(CP_UTF8, 0, src, (int)srcLen, dest, (int)destLen, nullptr, nullptr);
 	if (written <= 0)
 	{
@@ -139,24 +127,9 @@ size_t Utf16Le_To_Utf8(char* dest, size_t destLen, const wchar_t* src, size_t sr
 	return (size_t)written;
 }
 
-size_t Utf8_To_Utf16Le(wchar_t* dest, size_t destLen, const char* src, size_t srcLen, bool writeDirect)
+size_t Utf8_To_Utf16Le(wchar_t* dest, size_t destLen, const char* src, size_t srcLen)
 {
-	if (!writeDirect)
-	{
-		const size_t required = Utf8_To_Utf16Le_Len(src, srcLen);
-		if (required == 0)
-		{
-			if (destLen > 0)
-				dest[0] = L'\0';
-			return 0;
-		}
-		if (required > destLen)
-		{
-			if (destLen > 0)
-				dest[0] = L'\0';
-			return required;
-		}
-	}
+	WWASSERT(destLen >= Utf8_To_Utf16Le_Len(src, srcLen));
 	const int written = MultiByteToWideChar(CP_UTF8, 0, src, (int)srcLen, dest, (int)destLen);
 	if (written <= 0)
 	{

--- a/Core/Libraries/Source/WWVegas/WWLib/utf8.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/utf8.cpp
@@ -1,0 +1,134 @@
+/*
+**	Command & Conquer Generals Zero Hour(tm)
+**	Copyright 2026 TheSuperHackers
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "always.h"
+#include "utf8.h"
+
+#include <string.h>
+
+#ifdef _WIN32
+#include <windows.h>
+
+static bool Is_Trail_Byte(char c)
+{
+	return (c & 0xC0) == 0x80;
+}
+
+size_t Utf8_Num_Bytes(char lead)
+{
+	if ((lead & 0x80) == 0x00) return 1;
+	if ((lead & 0xE0) == 0xC0) return 2;
+	if ((lead & 0xF0) == 0xE0) return 3;
+	if ((lead & 0xF8) == 0xF0) return 4;
+	return 0;
+}
+
+size_t Utf8_Trailing_Invalid_Bytes(const char* str, size_t length)
+{
+	if (length == 0)
+		return 0;
+
+	size_t i = length;
+	while (i > 0 && Is_Trail_Byte(str[i - 1]))
+		--i;
+
+	if (i == 0)
+		return length;
+
+	size_t claimed = Utf8_Num_Bytes(str[i - 1]);
+	size_t actual = length - (i - 1);
+
+	if (claimed == 0 || claimed != actual)
+		return actual;
+
+	return 0;
+}
+
+bool Utf8_Validate(const char* str)
+{
+	return Utf8_Validate(str, strlen(str));
+}
+
+bool Utf8_Validate(const char* str, size_t length)
+{
+	const unsigned char* s = (const unsigned char*)str;
+	size_t i = 0;
+	while (i < length)
+	{
+		size_t bytes = Utf8_Num_Bytes(str[i]);
+		if (bytes == 0)
+			return false;
+		if (i + bytes > length)
+			return false;
+		for (size_t j = 1; j < bytes; ++j)
+		{
+			if (!Is_Trail_Byte(str[i + j]))
+				return false;
+		}
+		// Reject overlong encodings per RFC 3629
+		if (bytes == 2 && s[i] < 0xC2)
+			return false;
+		if (bytes == 3 && s[i] == 0xE0 && s[i + 1] < 0xA0)
+			return false;
+		if (bytes == 4 && s[i] == 0xF0 && s[i + 1] < 0x90)
+			return false;
+		// Reject codepoints above U+10FFFF
+		if (bytes == 4 && s[i] > 0xF4)
+			return false;
+		if (bytes == 4 && s[i] == 0xF4 && s[i + 1] > 0x8F)
+			return false;
+		i += bytes;
+	}
+	return true;
+}
+
+size_t Get_Utf8_Size(const wchar_t* src, size_t srcLen)
+{
+	int bytes = WideCharToMultiByte(CP_UTF8, 0, src, (int)srcLen, nullptr, 0, nullptr, nullptr);
+	return (bytes > 0) ? (size_t)bytes : 0;
+}
+
+size_t Get_Unicode_Size(const char* src, size_t srcLen)
+{
+	int wchars = MultiByteToWideChar(CP_UTF8, 0, src, (int)srcLen, nullptr, 0);
+	return (wchars > 0) ? (size_t)wchars : 0;
+}
+
+bool Unicode_To_Utf8(char* dest, const wchar_t* src, size_t srcLen, size_t destSize)
+{
+	if (destSize == 0)
+		return false;
+	int result = WideCharToMultiByte(CP_UTF8, 0, src, (int)srcLen, dest, (int)destSize, nullptr, nullptr);
+	if (result == 0)
+		dest[0] = '\0';
+	return result != 0;
+}
+
+bool Utf8_To_Unicode(wchar_t* dest, const char* src, size_t srcLen, size_t destSize)
+{
+	if (destSize == 0)
+		return false;
+	int result = MultiByteToWideChar(CP_UTF8, 0, src, (int)srcLen, dest, (int)destSize);
+	if (result == 0)
+		dest[0] = L'\0';
+	return result != 0;
+}
+
+#else
+#error "Not implemented"
+#endif

--- a/Core/Libraries/Source/WWVegas/WWLib/utf8.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/utf8.cpp
@@ -97,36 +97,46 @@ bool Utf8_Validate(const char* str, size_t length)
 	return true;
 }
 
-size_t Get_Utf8_Size(const wchar_t* src, size_t srcLen)
+size_t Get_Utf8_Len(const wchar_t* src, size_t srcLen)
 {
 	int bytes = WideCharToMultiByte(CP_UTF8, 0, src, (int)srcLen, nullptr, 0, nullptr, nullptr);
 	return (bytes > 0) ? (size_t)bytes : 0;
 }
 
-size_t Get_Unicode_Size(const char* src, size_t srcLen)
+size_t Get_Unicode_Len(const char* src, size_t srcLen)
 {
 	int wchars = MultiByteToWideChar(CP_UTF8, 0, src, (int)srcLen, nullptr, 0);
 	return (wchars > 0) ? (size_t)wchars : 0;
 }
 
-bool Unicode_To_Utf8(char* dest, const wchar_t* src, size_t srcLen, size_t destSize)
+size_t Unicode_To_Utf8(char* dest, size_t destLen, const wchar_t* src, size_t srcLen)
 {
-	if (destSize == 0)
-		return false;
-	int result = WideCharToMultiByte(CP_UTF8, 0, src, (int)srcLen, dest, (int)destSize, nullptr, nullptr);
-	if (result == 0)
+	if (destLen == 0)
+		return 0;
+	int written = WideCharToMultiByte(CP_UTF8, 0, src, (int)srcLen, dest, (int)destLen, nullptr, nullptr);
+	if (written == 0)
+	{
 		dest[0] = '\0';
-	return result != 0;
+		return 0;
+	}
+	if ((size_t)written < destLen)
+		dest[written] = '\0';
+	return (size_t)written;
 }
 
-bool Utf8_To_Unicode(wchar_t* dest, const char* src, size_t srcLen, size_t destSize)
+size_t Utf8_To_Unicode(wchar_t* dest, size_t destLen, const char* src, size_t srcLen)
 {
-	if (destSize == 0)
-		return false;
-	int result = MultiByteToWideChar(CP_UTF8, 0, src, (int)srcLen, dest, (int)destSize);
-	if (result == 0)
+	if (destLen == 0)
+		return 0;
+	int written = MultiByteToWideChar(CP_UTF8, 0, src, (int)srcLen, dest, (int)destLen);
+	if (written == 0)
+	{
 		dest[0] = L'\0';
-	return result != 0;
+		return 0;
+	}
+	if ((size_t)written < destLen)
+		dest[written] = L'\0';
+	return (size_t)written;
 }
 
 #else

--- a/Core/Libraries/Source/WWVegas/WWLib/utf8.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/utf8.cpp
@@ -109,23 +109,26 @@ size_t Utf8_To_Utf16Le_Len(const char* src, size_t srcLen)
 	return (wchars > 0) ? (size_t)wchars : 0;
 }
 
-size_t Utf16Le_To_Utf8(char* dest, size_t destLen, const wchar_t* src, size_t srcLen)
+size_t Utf16Le_To_Utf8(char* dest, size_t destLen, const wchar_t* src, size_t srcLen, bool writeDirect)
 {
-	int required = WideCharToMultiByte(CP_UTF8, 0, src, (int)srcLen, nullptr, 0, nullptr, nullptr);
-	if (required <= 0)
+	if (!writeDirect)
 	{
-		if (destLen > 0)
-			dest[0] = '\0';
-		return 0;
+		const size_t required = Utf16Le_To_Utf8_Len(src, srcLen);
+		if (required == 0)
+		{
+			if (destLen > 0)
+				dest[0] = '\0';
+			return 0;
+		}
+		if (required > destLen)
+		{
+			if (destLen > 0)
+				dest[0] = '\0';
+			return required;
+		}
 	}
-	if ((size_t)required > destLen)
-	{
-		if (destLen > 0)
-			dest[0] = '\0';
-		return (size_t)required;
-	}
-	int written = WideCharToMultiByte(CP_UTF8, 0, src, (int)srcLen, dest, (int)destLen, nullptr, nullptr);
-	if (written == 0)
+	const int written = WideCharToMultiByte(CP_UTF8, 0, src, (int)srcLen, dest, (int)destLen, nullptr, nullptr);
+	if (written <= 0)
 	{
 		if (destLen > 0)
 			dest[0] = '\0';
@@ -136,23 +139,26 @@ size_t Utf16Le_To_Utf8(char* dest, size_t destLen, const wchar_t* src, size_t sr
 	return (size_t)written;
 }
 
-size_t Utf8_To_Utf16Le(wchar_t* dest, size_t destLen, const char* src, size_t srcLen)
+size_t Utf8_To_Utf16Le(wchar_t* dest, size_t destLen, const char* src, size_t srcLen, bool writeDirect)
 {
-	int required = MultiByteToWideChar(CP_UTF8, 0, src, (int)srcLen, nullptr, 0);
-	if (required <= 0)
+	if (!writeDirect)
 	{
-		if (destLen > 0)
-			dest[0] = L'\0';
-		return 0;
+		const size_t required = Utf8_To_Utf16Le_Len(src, srcLen);
+		if (required == 0)
+		{
+			if (destLen > 0)
+				dest[0] = L'\0';
+			return 0;
+		}
+		if (required > destLen)
+		{
+			if (destLen > 0)
+				dest[0] = L'\0';
+			return required;
+		}
 	}
-	if ((size_t)required > destLen)
-	{
-		if (destLen > 0)
-			dest[0] = L'\0';
-		return (size_t)required;
-	}
-	int written = MultiByteToWideChar(CP_UTF8, 0, src, (int)srcLen, dest, (int)destLen);
-	if (written == 0)
+	const int written = MultiByteToWideChar(CP_UTF8, 0, src, (int)srcLen, dest, (int)destLen);
+	if (written <= 0)
 	{
 		if (destLen > 0)
 			dest[0] = L'\0';

--- a/Core/Libraries/Source/WWVegas/WWLib/utf8.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/utf8.cpp
@@ -102,43 +102,51 @@ bool Utf8_Validate(const char* str, size_t length)
 
 size_t Utf16Le_To_Utf8_Len(const wchar_t* src, size_t srcLen)
 {
-	int bytes = WideCharToMultiByte(CP_UTF8, 0, src, (int)srcLen, nullptr, 0, nullptr, nullptr);
+	const int bytes = WideCharToMultiByte(CP_UTF8, 0, src, (int)srcLen, nullptr, 0, nullptr, nullptr);
 	return (bytes > 0) ? (size_t)bytes : 0;
 }
 
 size_t Utf8_To_Utf16Le_Len(const char* src, size_t srcLen)
 {
-	int wchars = MultiByteToWideChar(CP_UTF8, 0, src, (int)srcLen, nullptr, 0);
+	const int wchars = MultiByteToWideChar(CP_UTF8, 0, src, (int)srcLen, nullptr, 0);
 	return (wchars > 0) ? (size_t)wchars : 0;
 }
 
 size_t Utf16Le_To_Utf8(char* dest, size_t destLen, const wchar_t* src, size_t srcLen)
 {
-	WWASSERT(destLen >= Utf16Le_To_Utf8_Len(src, srcLen));
 	const int written = WideCharToMultiByte(CP_UTF8, 0, src, (int)srcLen, dest, (int)destLen, nullptr, nullptr);
+	WWASSERT(written > 0 && (size_t)written <= destLen);
 	if (written <= 0)
 	{
 		if (destLen > 0)
+		{
 			dest[0] = '\0';
+		}
 		return 0;
 	}
 	if ((size_t)written < destLen)
+	{
 		dest[written] = '\0';
+	}
 	return (size_t)written;
 }
 
 size_t Utf8_To_Utf16Le(wchar_t* dest, size_t destLen, const char* src, size_t srcLen)
 {
-	WWASSERT(destLen >= Utf8_To_Utf16Le_Len(src, srcLen));
 	const int written = MultiByteToWideChar(CP_UTF8, 0, src, (int)srcLen, dest, (int)destLen);
+	WWASSERT(written > 0 && (size_t)written <= destLen);
 	if (written <= 0)
 	{
 		if (destLen > 0)
+		{
 			dest[0] = L'\0';
+		}
 		return 0;
 	}
 	if ((size_t)written < destLen)
+	{
 		dest[written] = L'\0';
+	}
 	return (size_t)written;
 }
 

--- a/Core/Libraries/Source/WWVegas/WWLib/utf8.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/utf8.cpp
@@ -103,13 +103,13 @@ bool Utf8_Validate(const char* str, size_t length)
 size_t Utf16Le_To_Utf8_Len(const wchar_t* src, size_t srcLen)
 {
 	const int bytes = WideCharToMultiByte(CP_UTF8, 0, src, (int)srcLen, nullptr, 0, nullptr, nullptr);
-	return (bytes > 0) ? (size_t)bytes : 0;
+	return (bytes >= 0) ? (size_t)bytes : 0;
 }
 
 size_t Utf8_To_Utf16Le_Len(const char* src, size_t srcLen)
 {
 	const int wchars = MultiByteToWideChar(CP_UTF8, 0, src, (int)srcLen, nullptr, 0);
-	return (wchars > 0) ? (size_t)wchars : 0;
+	return (wchars >= 0) ? (size_t)wchars : 0;
 }
 
 size_t Utf16Le_To_Utf8(char* dest, size_t destLen, const wchar_t* src, size_t srcLen)

--- a/Core/Libraries/Source/WWVegas/WWLib/utf8.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/utf8.cpp
@@ -97,26 +97,38 @@ bool Utf8_Validate(const char* str, size_t length)
 	return true;
 }
 
-size_t Get_Utf8_Len(const wchar_t* src, size_t srcLen)
+size_t Utf16Le_To_Utf8_Len(const wchar_t* src, size_t srcLen)
 {
 	int bytes = WideCharToMultiByte(CP_UTF8, 0, src, (int)srcLen, nullptr, 0, nullptr, nullptr);
 	return (bytes > 0) ? (size_t)bytes : 0;
 }
 
-size_t Get_Unicode_Len(const char* src, size_t srcLen)
+size_t Utf8_To_Utf16Le_Len(const char* src, size_t srcLen)
 {
 	int wchars = MultiByteToWideChar(CP_UTF8, 0, src, (int)srcLen, nullptr, 0);
 	return (wchars > 0) ? (size_t)wchars : 0;
 }
 
-size_t Unicode_To_Utf8(char* dest, size_t destLen, const wchar_t* src, size_t srcLen)
+size_t Utf16Le_To_Utf8(char* dest, size_t destLen, const wchar_t* src, size_t srcLen)
 {
-	if (destLen == 0)
+	int required = WideCharToMultiByte(CP_UTF8, 0, src, (int)srcLen, nullptr, 0, nullptr, nullptr);
+	if (required <= 0)
+	{
+		if (destLen > 0)
+			dest[0] = '\0';
 		return 0;
+	}
+	if ((size_t)required > destLen)
+	{
+		if (destLen > 0)
+			dest[0] = '\0';
+		return (size_t)required;
+	}
 	int written = WideCharToMultiByte(CP_UTF8, 0, src, (int)srcLen, dest, (int)destLen, nullptr, nullptr);
 	if (written == 0)
 	{
-		dest[0] = '\0';
+		if (destLen > 0)
+			dest[0] = '\0';
 		return 0;
 	}
 	if ((size_t)written < destLen)
@@ -124,14 +136,26 @@ size_t Unicode_To_Utf8(char* dest, size_t destLen, const wchar_t* src, size_t sr
 	return (size_t)written;
 }
 
-size_t Utf8_To_Unicode(wchar_t* dest, size_t destLen, const char* src, size_t srcLen)
+size_t Utf8_To_Utf16Le(wchar_t* dest, size_t destLen, const char* src, size_t srcLen)
 {
-	if (destLen == 0)
+	int required = MultiByteToWideChar(CP_UTF8, 0, src, (int)srcLen, nullptr, 0);
+	if (required <= 0)
+	{
+		if (destLen > 0)
+			dest[0] = L'\0';
 		return 0;
+	}
+	if ((size_t)required > destLen)
+	{
+		if (destLen > 0)
+			dest[0] = L'\0';
+		return (size_t)required;
+	}
 	int written = MultiByteToWideChar(CP_UTF8, 0, src, (int)srcLen, dest, (int)destLen);
 	if (written == 0)
 	{
-		dest[0] = L'\0';
+		if (destLen > 0)
+			dest[0] = L'\0';
 		return 0;
 	}
 	if ((size_t)written < destLen)

--- a/Core/Libraries/Source/WWVegas/WWLib/utf8.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/utf8.cpp
@@ -19,86 +19,8 @@
 #include "always.h"
 #include "utf8.h"
 
-#include <string.h>
-
 #ifdef _WIN32
 #include <windows.h>
-
-static bool Is_Trail_Byte(char c)
-{
-	return (c & 0xC0) == 0x80;
-}
-
-size_t Utf8_Num_Bytes(char lead)
-{
-	if ((lead & 0x80) == 0x00) return 1;
-	if ((lead & 0xE0) == 0xC0) return 2;
-	if ((lead & 0xF0) == 0xE0) return 3;
-	if ((lead & 0xF8) == 0xF0) return 4;
-	return 0;
-}
-
-size_t Utf8_Trailing_Invalid_Bytes(const char* str, size_t length)
-{
-	if (length == 0)
-		return 0;
-
-	size_t i = length;
-	while (i > 0 && Is_Trail_Byte(str[i - 1]))
-		--i;
-
-	if (i == 0)
-		return length;
-
-	size_t claimed = Utf8_Num_Bytes(str[i - 1]);
-	size_t actual = length - (i - 1);
-
-	if (claimed == 0 || claimed != actual)
-		return actual;
-
-	return 0;
-}
-
-bool Utf8_Validate(const char* str)
-{
-	return Utf8_Validate(str, strlen(str));
-}
-
-bool Utf8_Validate(const char* str, size_t length)
-{
-	const unsigned char* s = (const unsigned char*)str;
-	size_t i = 0;
-	while (i < length)
-	{
-		size_t bytes = Utf8_Num_Bytes(str[i]);
-		if (bytes == 0)
-			return false;
-		if (i + bytes > length)
-			return false;
-		for (size_t j = 1; j < bytes; ++j)
-		{
-			if (!Is_Trail_Byte(str[i + j]))
-				return false;
-		}
-		// Reject overlong encodings per RFC 3629
-		if (bytes == 2 && s[i] < 0xC2)
-			return false;
-		if (bytes == 3 && s[i] == 0xE0 && s[i + 1] < 0xA0)
-			return false;
-		// Reject UTF-16 surrogates (U+D800-U+DFFF) per RFC 3629
-		if (bytes == 3 && s[i] == 0xED && s[i + 1] > 0x9F)
-			return false;
-		if (bytes == 4 && s[i] == 0xF0 && s[i + 1] < 0x90)
-			return false;
-		// Reject codepoints above U+10FFFF
-		if (bytes == 4 && s[i] > 0xF4)
-			return false;
-		if (bytes == 4 && s[i] == 0xF4 && s[i + 1] > 0x8F)
-			return false;
-		i += bytes;
-	}
-	return true;
-}
 
 size_t Utf16Le_To_Utf8_Len(const wchar_t* src, size_t srcLen)
 {
@@ -115,15 +37,7 @@ size_t Utf8_To_Utf16Le_Len(const char* src, size_t srcLen)
 size_t Utf16Le_To_Utf8(char* dest, size_t destLen, const wchar_t* src, size_t srcLen)
 {
 	const int written = WideCharToMultiByte(CP_UTF8, 0, src, (int)srcLen, dest, (int)destLen, nullptr, nullptr);
-	WWASSERT(written > 0 && (size_t)written <= destLen);
-	if (written <= 0)
-	{
-		if (destLen > 0)
-		{
-			dest[0] = '\0';
-		}
-		return 0;
-	}
+	WWASSERT(written >= 0 && (size_t)written <= destLen);
 	if ((size_t)written < destLen)
 	{
 		dest[written] = '\0';
@@ -134,15 +48,7 @@ size_t Utf16Le_To_Utf8(char* dest, size_t destLen, const wchar_t* src, size_t sr
 size_t Utf8_To_Utf16Le(wchar_t* dest, size_t destLen, const char* src, size_t srcLen)
 {
 	const int written = MultiByteToWideChar(CP_UTF8, 0, src, (int)srcLen, dest, (int)destLen);
-	WWASSERT(written > 0 && (size_t)written <= destLen);
-	if (written <= 0)
-	{
-		if (destLen > 0)
-		{
-			dest[0] = L'\0';
-		}
-		return 0;
-	}
+	WWASSERT(written >= 0 && (size_t)written <= destLen);
 	if ((size_t)written < destLen)
 	{
 		dest[written] = L'\0';

--- a/Core/Libraries/Source/WWVegas/WWLib/utf8.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/utf8.cpp
@@ -196,20 +196,20 @@ static size_t Wide_Write(wchar_t* dest, unsigned int cp)
 
 size_t Wide_To_Utf8_Len(const wchar_t* src, size_t srcLen)
 {
-	size_t bytes = 0;
+	size_t needed = 0;
 	size_t i = 0;
 	while (i < srcLen)
 	{
 		unsigned int cp;
 		i += Wide_Read(src + i, srcLen - i, cp);
-		bytes += Utf8_Encoded_Length(cp);
+		needed += Utf8_Encoded_Length(cp);
 	}
-	return bytes;
+	return needed;
 }
 
 size_t Utf8_To_Wide_Len(const char* src, size_t srcLen)
 {
-	size_t units = 0;
+	size_t needed = 0;
 	size_t i = 0;
 	while (i < srcLen)
 	{
@@ -220,9 +220,9 @@ size_t Utf8_To_Wide_Len(const char* src, size_t srcLen)
 			return UTF8_INVALID;
 		}
 		i += consumed;
-		units += Wide_Encoded_Length(cp);
+		needed += Wide_Encoded_Length(cp);
 	}
-	return units;
+	return needed;
 }
 
 size_t Wide_To_Utf8(char* dest, size_t destLen, const wchar_t* src, size_t srcLen)

--- a/Core/Libraries/Source/WWVegas/WWLib/utf8.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/utf8.cpp
@@ -137,33 +137,34 @@ static size_t Utf8_Decode(const char* src, size_t srcLen, unsigned int& cp)
 	return count;
 }
 
-// Read one codepoint from a wide buffer, advancing i. Combines UTF-16 surrogate pairs where wchar_t
-// is 16-bit; treats each element as a whole codepoint where wchar_t is 32-bit. Wide data that has
-// no UTF-8 representation is reported as U+FFFD, so the encoder never emits a sequence that the
-// decoder would reject.
-static unsigned int Wide_Read(const wchar_t* src, size_t srcLen, size_t& i)
+// Read one codepoint at src, with srcLen wide characters remaining. Returns the number of wide
+// characters consumed (1-2) and sets cp. Combines UTF-16 surrogate pairs where wchar_t is 16-bit;
+// treats each element as a whole codepoint where wchar_t is 32-bit. Wide data that has no UTF-8
+// representation is reported as U+FFFD, so the encoder never emits a sequence that the decoder
+// would reject.
+static size_t Wide_Read(const wchar_t* src, size_t srcLen, unsigned int& cp)
 {
-	unsigned int cp;
+	size_t consumed = 1;
 #if UTF8_WCHAR_IS_UTF16
-	cp = (unsigned int)src[i++] & 0xFFFF;
-	if (cp >= UTF8_SURROGATE_MIN && cp <= 0xDBFF && i < srcLen)
+	cp = (unsigned int)src[0] & 0xFFFF;
+	if (cp >= UTF8_SURROGATE_MIN && cp <= 0xDBFF && srcLen > 1)
 	{
-		const unsigned int low = (unsigned int)src[i] & 0xFFFF;
+		const unsigned int low = (unsigned int)src[1] & 0xFFFF;
 		if (low >= 0xDC00 && low <= UTF8_SURROGATE_MAX)
 		{
 			cp = 0x10000 + ((cp - UTF8_SURROGATE_MIN) << 10) + (low - 0xDC00);
-			++i;
+			consumed = 2;
 		}
 	}
 #else
 	(void)srcLen;
-	cp = (unsigned int)src[i++];
+	cp = (unsigned int)src[0];
 #endif
 	if (cp > UTF8_CODEPOINT_MAX || (cp >= UTF8_SURROGATE_MIN && cp <= UTF8_SURROGATE_MAX))
 	{
 		cp = UTF8_REPLACEMENT_CHAR;
 	}
-	return cp;
+	return consumed;
 }
 
 // Number of wide characters required to store a codepoint.
@@ -199,7 +200,8 @@ size_t Wide_To_Utf8_Len(const wchar_t* src, size_t srcLen)
 	size_t i = 0;
 	while (i < srcLen)
 	{
-		const unsigned int cp = Wide_Read(src, srcLen, i);
+		unsigned int cp;
+		i += Wide_Read(src + i, srcLen - i, cp);
 		bytes += Utf8_Encoded_Length(cp);
 	}
 	return bytes;
@@ -229,7 +231,8 @@ size_t Wide_To_Utf8(char* dest, size_t destLen, const wchar_t* src, size_t srcLe
 	size_t i = 0;
 	while (i < srcLen)
 	{
-		const unsigned int cp = Wide_Read(src, srcLen, i);
+		unsigned int cp;
+		i += Wide_Read(src + i, srcLen - i, cp);
 		const size_t need = Utf8_Encoded_Length(cp);
 		if (out + need > destLen)
 		{

--- a/Core/Libraries/Source/WWVegas/WWLib/utf8.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/utf8.cpp
@@ -227,6 +227,7 @@ size_t Utf8_To_Wide_Len(const char* src, size_t srcLen)
 
 size_t Wide_To_Utf8(char* dest, size_t destLen, const wchar_t* src, size_t srcLen)
 {
+	size_t needed = 0;
 	size_t out = 0;
 	size_t i = 0;
 	while (i < srcLen)
@@ -234,22 +235,23 @@ size_t Wide_To_Utf8(char* dest, size_t destLen, const wchar_t* src, size_t srcLe
 		unsigned int cp;
 		i += Wide_Read(src + i, srcLen - i, cp);
 		const size_t need = Utf8_Encoded_Length(cp);
-		if (out + need > destLen)
+		// Stop writing at the first codepoint that does not fit, but keep counting for the caller.
+		if (needed == out && out + need <= destLen)
 		{
-			WWASSERT(false);
-			break;
+			out += Utf8_Encode(dest + out, cp);
 		}
-		out += Utf8_Encode(dest + out, cp);
+		needed += need;
 	}
 	if (out < destLen)
 	{
 		dest[out] = '\0';
 	}
-	return out;
+	return needed;
 }
 
 size_t Utf8_To_Wide(wchar_t* dest, size_t destLen, const char* src, size_t srcLen)
 {
+	size_t needed = 0;
 	size_t out = 0;
 	size_t i = 0;
 	while (i < srcLen)
@@ -266,16 +268,16 @@ size_t Utf8_To_Wide(wchar_t* dest, size_t destLen, const char* src, size_t srcLe
 		}
 		i += consumed;
 		const size_t need = Wide_Encoded_Length(cp);
-		if (out + need > destLen)
+		// Stop writing at the first codepoint that does not fit, but keep counting for the caller.
+		if (needed == out && out + need <= destLen)
 		{
-			WWASSERT(false);
-			break;
+			out += Wide_Write(dest + out, cp);
 		}
-		out += Wide_Write(dest + out, cp);
+		needed += need;
 	}
 	if (out < destLen)
 	{
 		dest[out] = L'\0';
 	}
-	return out;
+	return needed;
 }

--- a/Core/Libraries/Source/WWVegas/WWLib/utf8.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/utf8.cpp
@@ -193,22 +193,6 @@ static size_t Wide_Write(wchar_t* dest, unsigned int cp)
 	return 1;
 }
 
-bool Utf8_Validate(const char* str, size_t length)
-{
-	size_t i = 0;
-	while (i < length)
-	{
-		unsigned int cp;
-		const size_t consumed = Utf8_Decode(str + i, length - i, cp);
-		if (consumed == 0)
-		{
-			return false;
-		}
-		i += consumed;
-	}
-	return true;
-}
-
 size_t Wide_To_Utf8_Len(const wchar_t* src, size_t srcLen)
 {
 	size_t bytes = 0;

--- a/Core/Libraries/Source/WWVegas/WWLib/utf8.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/utf8.cpp
@@ -31,6 +31,7 @@
 static const unsigned int UTF8_CODEPOINT_MAX = 0x10FFFF;
 static const unsigned int UTF8_SURROGATE_MIN = 0xD800;
 static const unsigned int UTF8_SURROGATE_MAX = 0xDFFF;
+static const unsigned int UTF8_REPLACEMENT_CHAR = 0xFFFD;
 
 // Number of UTF-8 bytes required to encode a codepoint.
 static size_t Utf8_Encoded_Length(unsigned int cp)
@@ -137,25 +138,32 @@ static size_t Utf8_Decode(const char* src, size_t srcLen, unsigned int& cp)
 }
 
 // Read one codepoint from a wide buffer, advancing i. Combines UTF-16 surrogate pairs where wchar_t
-// is 16-bit; treats each element as a whole codepoint where wchar_t is 32-bit.
+// is 16-bit; treats each element as a whole codepoint where wchar_t is 32-bit. Wide data that has
+// no UTF-8 representation is reported as U+FFFD, so the encoder never emits a sequence that the
+// decoder would reject.
 static unsigned int Wide_Read(const wchar_t* src, size_t srcLen, size_t& i)
 {
+	unsigned int cp;
 #if UTF8_WCHAR_IS_UTF16
-	unsigned int cp = (unsigned int)src[i++] & 0xFFFF;
-	if (cp >= 0xD800 && cp <= 0xDBFF && i < srcLen)
+	cp = (unsigned int)src[i++] & 0xFFFF;
+	if (cp >= UTF8_SURROGATE_MIN && cp <= 0xDBFF && i < srcLen)
 	{
 		const unsigned int low = (unsigned int)src[i] & 0xFFFF;
-		if (low >= 0xDC00 && low <= 0xDFFF)
+		if (low >= 0xDC00 && low <= UTF8_SURROGATE_MAX)
 		{
-			cp = 0x10000 + ((cp - 0xD800) << 10) + (low - 0xDC00);
+			cp = 0x10000 + ((cp - UTF8_SURROGATE_MIN) << 10) + (low - 0xDC00);
 			++i;
 		}
 	}
-	return cp;
 #else
 	(void)srcLen;
-	return (unsigned int)src[i++];
+	cp = (unsigned int)src[i++];
 #endif
+	if (cp > UTF8_CODEPOINT_MAX || (cp >= UTF8_SURROGATE_MIN && cp <= UTF8_SURROGATE_MAX))
+	{
+		cp = UTF8_REPLACEMENT_CHAR;
+	}
+	return cp;
 }
 
 // Number of wide characters required to store a codepoint.

--- a/Core/Libraries/Source/WWVegas/WWLib/utf8.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/utf8.cpp
@@ -19,43 +19,268 @@
 #include "always.h"
 #include "utf8.h"
 
-#ifdef _WIN32
-#include <windows.h>
+// wchar_t is a 16-bit UTF-16 code unit on Windows and a 32-bit UTF-32 codepoint on most other
+// platforms. WCHAR_MAX lets us distinguish the two at compile time so the surrogate-pair paths
+// are excluded entirely (not just constant-folded) where wchar_t is wide enough to hold a codepoint.
+#if defined(WCHAR_MAX) && (WCHAR_MAX <= 0xFFFF)
+#define UTF8_WCHAR_IS_UTF16 1
+#else
+#define UTF8_WCHAR_IS_UTF16 0
+#endif
+
+static const unsigned int UTF8_CODEPOINT_MAX = 0x10FFFF;
+static const unsigned int UTF8_SURROGATE_MIN = 0xD800;
+static const unsigned int UTF8_SURROGATE_MAX = 0xDFFF;
+
+// Number of UTF-8 bytes required to encode a codepoint.
+static size_t Utf8_Encoded_Length(unsigned int cp)
+{
+	if (cp < 0x80)
+	{
+		return 1;
+	}
+	if (cp < 0x800)
+	{
+		return 2;
+	}
+	if (cp < 0x10000)
+	{
+		return 3;
+	}
+	return 4;
+}
+
+// Encode a codepoint to dest, which is assumed to have room. Returns the number of bytes written.
+static size_t Utf8_Encode(char* dest, unsigned int cp)
+{
+	if (cp < 0x80)
+	{
+		dest[0] = (char)cp;
+		return 1;
+	}
+	if (cp < 0x800)
+	{
+		dest[0] = (char)(0xC0 | (cp >> 6));
+		dest[1] = (char)(0x80 | (cp & 0x3F));
+		return 2;
+	}
+	if (cp < 0x10000)
+	{
+		dest[0] = (char)(0xE0 | (cp >> 12));
+		dest[1] = (char)(0x80 | ((cp >> 6) & 0x3F));
+		dest[2] = (char)(0x80 | (cp & 0x3F));
+		return 3;
+	}
+	dest[0] = (char)(0xF0 | (cp >> 18));
+	dest[1] = (char)(0x80 | ((cp >> 12) & 0x3F));
+	dest[2] = (char)(0x80 | ((cp >> 6) & 0x3F));
+	dest[3] = (char)(0x80 | (cp & 0x3F));
+	return 4;
+}
+
+// Decode one UTF-8 sequence at src, with srcLen bytes remaining. On success returns the number of
+// bytes consumed (1-4) and sets cp. Returns 0 on any malformed, overlong, out-of-range or surrogate
+// encoding.
+static size_t Utf8_Decode(const char* src, size_t srcLen, unsigned int& cp)
+{
+	const unsigned char lead = (unsigned char)src[0];
+	if (lead < 0x80)
+	{
+		cp = lead;
+		return 1;
+	}
+
+	size_t count;
+	unsigned int lowerBound;
+	if ((lead & 0xE0) == 0xC0)
+	{
+		count = 2;
+		cp = lead & 0x1F;
+		lowerBound = 0x80;
+	}
+	else if ((lead & 0xF0) == 0xE0)
+	{
+		count = 3;
+		cp = lead & 0x0F;
+		lowerBound = 0x800;
+	}
+	else if ((lead & 0xF8) == 0xF0)
+	{
+		count = 4;
+		cp = lead & 0x07;
+		lowerBound = 0x10000;
+	}
+	else
+	{
+		return 0; // a continuation byte or a 5/6-byte form cannot start a sequence
+	}
+
+	if (srcLen < count)
+	{
+		return 0; // truncated sequence
+	}
+	for (size_t i = 1; i < count; ++i)
+	{
+		const unsigned char trail = (unsigned char)src[i];
+		if ((trail & 0xC0) != 0x80)
+		{
+			return 0; // not a continuation byte
+		}
+		cp = (cp << 6) | (trail & 0x3F);
+	}
+
+	if (cp < lowerBound || cp > UTF8_CODEPOINT_MAX || (cp >= UTF8_SURROGATE_MIN && cp <= UTF8_SURROGATE_MAX))
+	{
+		return 0; // overlong, out of range, or a surrogate codepoint
+	}
+	return count;
+}
+
+// Read one codepoint from a wide buffer, advancing i. Combines UTF-16 surrogate pairs where wchar_t
+// is 16-bit; treats each element as a whole codepoint where wchar_t is 32-bit.
+static unsigned int Wide_Read(const wchar_t* src, size_t srcLen, size_t& i)
+{
+#if UTF8_WCHAR_IS_UTF16
+	unsigned int cp = (unsigned int)src[i++] & 0xFFFF;
+	if (cp >= 0xD800 && cp <= 0xDBFF && i < srcLen)
+	{
+		const unsigned int low = (unsigned int)src[i] & 0xFFFF;
+		if (low >= 0xDC00 && low <= 0xDFFF)
+		{
+			cp = 0x10000 + ((cp - 0xD800) << 10) + (low - 0xDC00);
+			++i;
+		}
+	}
+	return cp;
+#else
+	(void)srcLen;
+	return (unsigned int)src[i++];
+#endif
+}
+
+// Number of wide characters required to store a codepoint.
+static size_t Wide_Encoded_Length(unsigned int cp)
+{
+#if UTF8_WCHAR_IS_UTF16
+	return (cp >= 0x10000) ? 2 : 1;
+#else
+	(void)cp;
+	return 1;
+#endif
+}
+
+// Write one codepoint to a wide buffer, which is assumed to have room. Returns wide characters written.
+static size_t Wide_Write(wchar_t* dest, unsigned int cp)
+{
+#if UTF8_WCHAR_IS_UTF16
+	if (cp >= 0x10000)
+	{
+		cp -= 0x10000;
+		dest[0] = (wchar_t)(0xD800 + (cp >> 10));
+		dest[1] = (wchar_t)(0xDC00 + (cp & 0x3FF));
+		return 2;
+	}
+#endif
+	dest[0] = (wchar_t)cp;
+	return 1;
+}
+
+bool Utf8_Validate(const char* str, size_t length)
+{
+	size_t i = 0;
+	while (i < length)
+	{
+		unsigned int cp;
+		const size_t consumed = Utf8_Decode(str + i, length - i, cp);
+		if (consumed == 0)
+		{
+			return false;
+		}
+		i += consumed;
+	}
+	return true;
+}
 
 size_t Utf16Le_To_Utf8_Len(const wchar_t* src, size_t srcLen)
 {
-	const int bytes = WideCharToMultiByte(CP_UTF8, 0, src, (int)srcLen, nullptr, 0, nullptr, nullptr);
-	return (bytes >= 0) ? (size_t)bytes : 0;
+	size_t bytes = 0;
+	size_t i = 0;
+	while (i < srcLen)
+	{
+		const unsigned int cp = Wide_Read(src, srcLen, i);
+		bytes += Utf8_Encoded_Length(cp);
+	}
+	return bytes;
 }
 
 size_t Utf8_To_Utf16Le_Len(const char* src, size_t srcLen)
 {
-	const int wchars = MultiByteToWideChar(CP_UTF8, 0, src, (int)srcLen, nullptr, 0);
-	return (wchars >= 0) ? (size_t)wchars : 0;
+	size_t units = 0;
+	size_t i = 0;
+	while (i < srcLen)
+	{
+		unsigned int cp;
+		const size_t consumed = Utf8_Decode(src + i, srcLen - i, cp);
+		if (consumed == 0)
+		{
+			return 0;
+		}
+		i += consumed;
+		units += Wide_Encoded_Length(cp);
+	}
+	return units;
 }
 
 size_t Utf16Le_To_Utf8(char* dest, size_t destLen, const wchar_t* src, size_t srcLen)
 {
-	const int written = WideCharToMultiByte(CP_UTF8, 0, src, (int)srcLen, dest, (int)destLen, nullptr, nullptr);
-	WWASSERT(written >= 0 && (size_t)written <= destLen);
-	if ((size_t)written < destLen)
+	size_t out = 0;
+	size_t i = 0;
+	while (i < srcLen)
 	{
-		dest[written] = '\0';
+		const unsigned int cp = Wide_Read(src, srcLen, i);
+		const size_t need = Utf8_Encoded_Length(cp);
+		if (out + need > destLen)
+		{
+			WWASSERT(false);
+			break;
+		}
+		out += Utf8_Encode(dest + out, cp);
 	}
-	return (size_t)written;
+	if (out < destLen)
+	{
+		dest[out] = '\0';
+	}
+	return out;
 }
 
 size_t Utf8_To_Utf16Le(wchar_t* dest, size_t destLen, const char* src, size_t srcLen)
 {
-	const int written = MultiByteToWideChar(CP_UTF8, 0, src, (int)srcLen, dest, (int)destLen);
-	WWASSERT(written >= 0 && (size_t)written <= destLen);
-	if ((size_t)written < destLen)
+	size_t out = 0;
+	size_t i = 0;
+	while (i < srcLen)
 	{
-		dest[written] = L'\0';
+		unsigned int cp;
+		const size_t consumed = Utf8_Decode(src + i, srcLen - i, cp);
+		if (consumed == 0)
+		{
+			if (destLen > 0)
+			{
+				dest[0] = L'\0';
+			}
+			return 0;
+		}
+		i += consumed;
+		const size_t need = Wide_Encoded_Length(cp);
+		if (out + need > destLen)
+		{
+			WWASSERT(false);
+			break;
+		}
+		out += Wide_Write(dest + out, cp);
 	}
-	return (size_t)written;
+	if (out < destLen)
+	{
+		dest[out] = L'\0';
+	}
+	return out;
 }
-
-#else
-#error "Not implemented"
-#endif

--- a/Core/Libraries/Source/WWVegas/WWLib/utf8.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/utf8.cpp
@@ -231,7 +231,7 @@ size_t Utf8_To_Utf16Le_Len(const char* src, size_t srcLen)
 		const size_t consumed = Utf8_Decode(src + i, srcLen - i, cp);
 		if (consumed == 0)
 		{
-			return 0;
+			return UTF8_INVALID;
 		}
 		i += consumed;
 		units += Wide_Encoded_Length(cp);
@@ -275,7 +275,7 @@ size_t Utf8_To_Utf16Le(wchar_t* dest, size_t destLen, const char* src, size_t sr
 			{
 				dest[0] = L'\0';
 			}
-			return 0;
+			return UTF8_INVALID;
 		}
 		i += consumed;
 		const size_t need = Wide_Encoded_Length(cp);

--- a/Core/Libraries/Source/WWVegas/WWLib/utf8.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/utf8.cpp
@@ -209,7 +209,7 @@ bool Utf8_Validate(const char* str, size_t length)
 	return true;
 }
 
-size_t Utf16Le_To_Utf8_Len(const wchar_t* src, size_t srcLen)
+size_t Wide_To_Utf8_Len(const wchar_t* src, size_t srcLen)
 {
 	size_t bytes = 0;
 	size_t i = 0;
@@ -221,7 +221,7 @@ size_t Utf16Le_To_Utf8_Len(const wchar_t* src, size_t srcLen)
 	return bytes;
 }
 
-size_t Utf8_To_Utf16Le_Len(const char* src, size_t srcLen)
+size_t Utf8_To_Wide_Len(const char* src, size_t srcLen)
 {
 	size_t units = 0;
 	size_t i = 0;
@@ -239,7 +239,7 @@ size_t Utf8_To_Utf16Le_Len(const char* src, size_t srcLen)
 	return units;
 }
 
-size_t Utf16Le_To_Utf8(char* dest, size_t destLen, const wchar_t* src, size_t srcLen)
+size_t Wide_To_Utf8(char* dest, size_t destLen, const wchar_t* src, size_t srcLen)
 {
 	size_t out = 0;
 	size_t i = 0;
@@ -261,7 +261,7 @@ size_t Utf16Le_To_Utf8(char* dest, size_t destLen, const wchar_t* src, size_t sr
 	return out;
 }
 
-size_t Utf8_To_Utf16Le(wchar_t* dest, size_t destLen, const char* src, size_t srcLen)
+size_t Utf8_To_Wide(wchar_t* dest, size_t destLen, const char* src, size_t srcLen)
 {
 	size_t out = 0;
 	size_t i = 0;

--- a/Core/Libraries/Source/WWVegas/WWLib/utf8.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/utf8.h
@@ -21,6 +21,10 @@
 #include <stddef.h>
 #include <wchar.h>
 
+// NOTE: The current implementation is Windows-only and treats wchar_t as UTF-16LE.
+// On non-Windows platforms wchar_t is typically UTF-32, so a future cross-platform
+// implementation should migrate the wide parameters to uint16_t / char16_t.
+
 // Returns the number of bytes in a UTF-8 character based on its lead byte.
 // Returns 0 if the lead byte is invalid.
 size_t Utf8_Num_Bytes(char lead);
@@ -33,25 +37,33 @@ size_t Utf8_Trailing_Invalid_Bytes(const char* str, size_t length);
 bool Utf8_Validate(const char* str);
 bool Utf8_Validate(const char* str, size_t length);
 
-// Returns the number of bytes needed for the UTF-8 representation of srcLen wide
+// Returns the number of bytes needed for the UTF-8 representation of srcLen UTF-16LE
 // characters from src, not counting a null terminator. Returns 0 on failure or if srcLen is 0.
-size_t Get_Utf8_Len(const wchar_t* src, size_t srcLen);
+size_t Utf16Le_To_Utf8_Len(const wchar_t* src, size_t srcLen);
 
-// Returns the number of wchar_t elements needed for the wide character representation
+// Returns the number of UTF-16LE elements needed for the UTF-16LE representation
 // of srcLen bytes from the UTF-8 string src, not counting a null terminator.
 // Returns 0 on failure or if srcLen is 0.
-size_t Get_Unicode_Len(const char* src, size_t srcLen);
+size_t Utf8_To_Utf16Le_Len(const char* src, size_t srcLen);
 
-// Converts srcLen wide characters from src to UTF-8.
-// destLen is the destination buffer capacity in bytes, not counting a null terminator.
-// Returns the number of bytes written on success, or 0 on failure.
-// Writes a null terminator if destLen > bytes written. Does not write one if destLen
-// equals bytes written (exact fit). On failure, dest[0] is set to '\0' if destLen > 0.
-size_t Unicode_To_Utf8(char* dest, size_t destLen, const wchar_t* src, size_t srcLen);
+// Converts srcLen UTF-16LE characters from src to UTF-8.
+// destLen is the destination buffer capacity in bytes (including room for a null terminator).
+// Returns the number of bytes required to hold the conversion, not counting a null terminator.
+//   * If the returned value is <= destLen, the conversion was written to dest. A null terminator
+//     is written if destLen > returned value (room for it). If returned value == destLen, the
+//     output exactly fills the buffer and no null terminator is written.
+//   * If the returned value is > destLen, the buffer was too small; dest[0] is set to '\0' (if
+//     destLen > 0) and callers should reallocate to the returned size and retry.
+//   * Returns 0 on conversion failure (e.g. invalid UTF-16LE input); dest[0] is set to '\0' if destLen > 0.
+size_t Utf16Le_To_Utf8(char* dest, size_t destLen, const wchar_t* src, size_t srcLen);
 
-// Converts srcLen bytes from the UTF-8 string src to wide characters.
-// destLen is the destination buffer capacity in wchar_t elements, not counting a null terminator.
-// Returns the number of wchar_t elements written on success, or 0 on failure.
-// Writes a null terminator if destLen > elements written. Does not write one if destLen
-// equals elements written (exact fit). On failure, dest[0] is set to L'\0' if destLen > 0.
-size_t Utf8_To_Unicode(wchar_t* dest, size_t destLen, const char* src, size_t srcLen);
+// Converts srcLen bytes from the UTF-8 string src to UTF-16LE characters.
+// destLen is the destination buffer capacity in wchar_t elements (including room for a null terminator).
+// Returns the number of wchar_t elements required to hold the conversion, not counting a null terminator.
+//   * If the returned value is <= destLen, the conversion was written to dest. A null terminator
+//     is written if destLen > returned value (room for it). If returned value == destLen, the
+//     output exactly fills the buffer and no null terminator is written.
+//   * If the returned value is > destLen, the buffer was too small; dest[0] is set to L'\0' (if
+//     destLen > 0) and callers should reallocate to the returned size and retry.
+//   * Returns 0 on conversion failure (e.g. invalid UTF-8 input); dest[0] is set to L'\0' if destLen > 0.
+size_t Utf8_To_Utf16Le(wchar_t* dest, size_t destLen, const char* src, size_t srcLen);

--- a/Core/Libraries/Source/WWVegas/WWLib/utf8.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/utf8.h
@@ -48,22 +48,22 @@ size_t Utf8_To_Utf16Le_Len(const char* src, size_t srcLen);
 
 // Converts srcLen UTF-16LE characters from src to UTF-8.
 // destLen is the destination buffer capacity in bytes (including room for a null terminator).
-// Returns the number of bytes required to hold the conversion, not counting a null terminator.
-//   * If the returned value is <= destLen, the conversion was written to dest. A null terminator
-//     is written if destLen > returned value (room for it). If returned value == destLen, the
-//     output exactly fills the buffer and no null terminator is written.
-//   * If the returned value is > destLen, the buffer was too small; dest[0] is set to '\0' (if
-//     destLen > 0) and callers should reallocate to the returned size and retry.
-//   * Returns 0 on conversion failure (e.g. invalid UTF-16LE input); dest[0] is set to '\0' if destLen > 0.
-size_t Utf16Le_To_Utf8(char* dest, size_t destLen, const wchar_t* src, size_t srcLen);
+// Writes a null terminator if room remains, otherwise not (strncpy-like).
+// When writeDirect is false (default): queries required size first. Returns required byte count
+//   (not counting null terminator). If returned value > destLen, buffer was too small and dest[0]
+//   is set to '\0'; callers should reallocate to the returned size and retry.
+// When writeDirect is true: skips the size pre-check and writes directly. Use this when the
+//   buffer was already sized via Utf16Le_To_Utf8_Len to avoid a redundant Win32 call.
+// Returns 0 on conversion failure; dest[0] is set to '\0' if destLen > 0.
+size_t Utf16Le_To_Utf8(char* dest, size_t destLen, const wchar_t* src, size_t srcLen, bool writeDirect = false);
 
 // Converts srcLen bytes from the UTF-8 string src to UTF-16LE characters.
 // destLen is the destination buffer capacity in wchar_t elements (including room for a null terminator).
-// Returns the number of wchar_t elements required to hold the conversion, not counting a null terminator.
-//   * If the returned value is <= destLen, the conversion was written to dest. A null terminator
-//     is written if destLen > returned value (room for it). If returned value == destLen, the
-//     output exactly fills the buffer and no null terminator is written.
-//   * If the returned value is > destLen, the buffer was too small; dest[0] is set to L'\0' (if
-//     destLen > 0) and callers should reallocate to the returned size and retry.
-//   * Returns 0 on conversion failure (e.g. invalid UTF-8 input); dest[0] is set to L'\0' if destLen > 0.
-size_t Utf8_To_Utf16Le(wchar_t* dest, size_t destLen, const char* src, size_t srcLen);
+// Writes a null terminator if room remains, otherwise not (strncpy-like).
+// When writeDirect is false (default): queries required size first. Returns required element count
+//   (not counting null terminator). If returned value > destLen, buffer was too small and dest[0]
+//   is set to L'\0'; callers should reallocate to the returned size and retry.
+// When writeDirect is true: skips the size pre-check and writes directly. Use this when the
+//   buffer was already sized via Utf8_To_Utf16Le_Len to avoid a redundant Win32 call.
+// Returns 0 on conversion failure; dest[0] is set to L'\0' if destLen > 0.
+size_t Utf8_To_Utf16Le(wchar_t* dest, size_t destLen, const char* src, size_t srcLen, bool writeDirect = false);

--- a/Core/Libraries/Source/WWVegas/WWLib/utf8.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/utf8.h
@@ -1,0 +1,54 @@
+/*
+**	Command & Conquer Generals Zero Hour(tm)
+**	Copyright 2026 TheSuperHackers
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <stddef.h>
+#include <wchar.h>
+
+// Returns the number of bytes in a UTF-8 character based on its lead byte.
+// Returns 0 if the lead byte is invalid.
+size_t Utf8_Num_Bytes(char lead);
+
+// Returns the number of invalid bytes at the end of the string due to an
+// incomplete multi-byte sequence. Returns 0 if the string ends on a complete sequence.
+size_t Utf8_Trailing_Invalid_Bytes(const char* str, size_t length);
+
+// Returns true if the null-terminated string is valid UTF-8, false otherwise.
+bool Utf8_Validate(const char* str);
+bool Utf8_Validate(const char* str, size_t length);
+
+// Returns the number of bytes in the UTF-8 representation of srcLen wide characters
+// from src. Returns 0 on failure or if srcLen is 0.
+size_t Get_Utf8_Size(const wchar_t* src, size_t srcLen);
+
+// Returns the number of wchar_t elements in the wide character representation of
+// srcLen bytes from the UTF-8 string src. Returns 0 on failure or if srcLen is 0.
+size_t Get_Unicode_Size(const char* src, size_t srcLen);
+
+// Converts srcLen wide characters from src to UTF-8. destSize is in bytes.
+// Does not write a null terminator. Caller must allocate destSize + 1 and
+// write the terminator if one is needed. Returns true on success, false on failure.
+// On failure, dest[0] is set to '\0'.
+bool Unicode_To_Utf8(char* dest, const wchar_t* src, size_t srcLen, size_t destSize);
+
+// Converts srcLen bytes from the UTF-8 string src to wide characters. destSize is in wchar_t elements.
+// Does not write a null terminator. Caller must allocate destSize + 1 and
+// write the terminator if one is needed. Returns true on success, false on failure.
+// On failure, dest[0] is set to L'\0'.
+bool Utf8_To_Unicode(wchar_t* dest, const char* src, size_t srcLen, size_t destSize);

--- a/Core/Libraries/Source/WWVegas/WWLib/utf8.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/utf8.h
@@ -33,22 +33,25 @@ size_t Utf8_Trailing_Invalid_Bytes(const char* str, size_t length);
 bool Utf8_Validate(const char* str);
 bool Utf8_Validate(const char* str, size_t length);
 
-// Returns the number of bytes in the UTF-8 representation of srcLen wide characters
-// from src. Returns 0 on failure or if srcLen is 0.
-size_t Get_Utf8_Size(const wchar_t* src, size_t srcLen);
+// Returns the number of bytes needed for the UTF-8 representation of srcLen wide
+// characters from src, not counting a null terminator. Returns 0 on failure or if srcLen is 0.
+size_t Get_Utf8_Len(const wchar_t* src, size_t srcLen);
 
-// Returns the number of wchar_t elements in the wide character representation of
-// srcLen bytes from the UTF-8 string src. Returns 0 on failure or if srcLen is 0.
-size_t Get_Unicode_Size(const char* src, size_t srcLen);
+// Returns the number of wchar_t elements needed for the wide character representation
+// of srcLen bytes from the UTF-8 string src, not counting a null terminator.
+// Returns 0 on failure or if srcLen is 0.
+size_t Get_Unicode_Len(const char* src, size_t srcLen);
 
-// Converts srcLen wide characters from src to UTF-8. destSize is in bytes.
-// Does not write a null terminator. Caller must allocate destSize + 1 and
-// write the terminator if one is needed. Returns true on success, false on failure.
-// On failure, dest[0] is set to '\0'.
-bool Unicode_To_Utf8(char* dest, const wchar_t* src, size_t srcLen, size_t destSize);
+// Converts srcLen wide characters from src to UTF-8.
+// destLen is the destination buffer capacity in bytes, not counting a null terminator.
+// Returns the number of bytes written on success, or 0 on failure.
+// Writes a null terminator if destLen > bytes written. Does not write one if destLen
+// equals bytes written (exact fit). On failure, dest[0] is set to '\0' if destLen > 0.
+size_t Unicode_To_Utf8(char* dest, size_t destLen, const wchar_t* src, size_t srcLen);
 
-// Converts srcLen bytes from the UTF-8 string src to wide characters. destSize is in wchar_t elements.
-// Does not write a null terminator. Caller must allocate destSize + 1 and
-// write the terminator if one is needed. Returns true on success, false on failure.
-// On failure, dest[0] is set to L'\0'.
-bool Utf8_To_Unicode(wchar_t* dest, const char* src, size_t srcLen, size_t destSize);
+// Converts srcLen bytes from the UTF-8 string src to wide characters.
+// destLen is the destination buffer capacity in wchar_t elements, not counting a null terminator.
+// Returns the number of wchar_t elements written on success, or 0 on failure.
+// Writes a null terminator if destLen > elements written. Does not write one if destLen
+// equals elements written (exact fit). On failure, dest[0] is set to L'\0' if destLen > 0.
+size_t Utf8_To_Unicode(wchar_t* dest, size_t destLen, const char* src, size_t srcLen);

--- a/Core/Libraries/Source/WWVegas/WWLib/utf8.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/utf8.h
@@ -47,23 +47,15 @@ size_t Utf16Le_To_Utf8_Len(const wchar_t* src, size_t srcLen);
 size_t Utf8_To_Utf16Le_Len(const char* src, size_t srcLen);
 
 // Converts srcLen UTF-16LE characters from src to UTF-8.
-// destLen is the destination buffer capacity in bytes (including room for a null terminator).
-// Writes a null terminator if room remains, otherwise not (strncpy-like).
-// When writeDirect is false (default): queries required size first. Returns required byte count
-//   (not counting null terminator). If returned value > destLen, buffer was too small and dest[0]
-//   is set to '\0'; callers should reallocate to the returned size and retry.
-// When writeDirect is true: skips the size pre-check and writes directly. Use this when the
-//   buffer was already sized via Utf16Le_To_Utf8_Len to avoid a redundant Win32 call.
-// Returns 0 on conversion failure; dest[0] is set to '\0' if destLen > 0.
-size_t Utf16Le_To_Utf8(char* dest, size_t destLen, const wchar_t* src, size_t srcLen, bool writeDirect = false);
+// destLen is the destination buffer capacity in bytes. Caller must ensure destLen is large enough
+// by querying Utf16Le_To_Utf8_Len first. Writes a null terminator if room remains, otherwise not.
+// Returns the number of bytes written on success, or 0 on failure.
+// On failure, dest[0] is set to '\0' if destLen > 0.
+size_t Utf16Le_To_Utf8(char* dest, size_t destLen, const wchar_t* src, size_t srcLen);
 
 // Converts srcLen bytes from the UTF-8 string src to UTF-16LE characters.
-// destLen is the destination buffer capacity in wchar_t elements (including room for a null terminator).
-// Writes a null terminator if room remains, otherwise not (strncpy-like).
-// When writeDirect is false (default): queries required size first. Returns required element count
-//   (not counting null terminator). If returned value > destLen, buffer was too small and dest[0]
-//   is set to L'\0'; callers should reallocate to the returned size and retry.
-// When writeDirect is true: skips the size pre-check and writes directly. Use this when the
-//   buffer was already sized via Utf8_To_Utf16Le_Len to avoid a redundant Win32 call.
-// Returns 0 on conversion failure; dest[0] is set to L'\0' if destLen > 0.
-size_t Utf8_To_Utf16Le(wchar_t* dest, size_t destLen, const char* src, size_t srcLen, bool writeDirect = false);
+// destLen is the destination buffer capacity in wchar_t elements. Caller must ensure destLen is
+// large enough by querying Utf8_To_Utf16Le_Len first. Writes a null terminator if room remains,
+// otherwise not. Returns the number of wchar_t elements written on success, or 0 on failure.
+// On failure, dest[0] is set to L'\0' if destLen > 0.
+size_t Utf8_To_Utf16Le(wchar_t* dest, size_t destLen, const char* src, size_t srcLen);

--- a/Core/Libraries/Source/WWVegas/WWLib/utf8.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/utf8.h
@@ -40,16 +40,19 @@ size_t Wide_To_Utf8_Len(const wchar_t* src, size_t srcLen);
 // src is not well-formed UTF-8.
 size_t Utf8_To_Wide_Len(const char* src, size_t srcLen);
 
-// Converts srcLen wide characters from src to UTF-8.
-// destLen is the destination buffer capacity in bytes. Caller must ensure destLen is large enough
-// by querying Wide_To_Utf8_Len first. Writes a null terminator if room remains, otherwise not.
-// Returns the number of bytes written, or 0 if srcLen is 0. Wide values that have no UTF-8
+// Converts srcLen wide characters from src to UTF-8. destLen is the destination buffer capacity in
+// bytes. Writes a null terminator if room remains, otherwise not. Wide values that have no UTF-8
 // representation are written as U+FFFD, so the output always decodes back through Utf8_To_Wide.
+// Returns the bytes the whole conversion needs, not counting a null terminator, which is what gets
+// written when it fits. More than destLen means the output was truncated on a codepoint boundary
+// and that is the size to retry with, plus one for the terminator. Pass destLen 0 to measure.
 size_t Wide_To_Utf8(char* dest, size_t destLen, const wchar_t* src, size_t srcLen);
 
-// Converts srcLen bytes from the UTF-8 string src to wide characters.
-// destLen is the destination buffer capacity in wide characters. Caller must ensure destLen is
-// large enough by querying Utf8_To_Wide_Len first. Writes a null terminator if room remains,
-// otherwise not. Returns the number of wide characters written, 0 if srcLen is 0, or UTF8_INVALID
-// if src is not well-formed UTF-8. On failure, dest[0] is set to L'\0' if destLen > 0.
+// Converts srcLen bytes from the UTF-8 string src to wide characters. destLen is the destination
+// buffer capacity in wide characters. Writes a null terminator if room remains, otherwise not.
+// Returns the wide characters the whole conversion needs, not counting a null terminator, which is
+// what gets written when it fits. More than destLen means the output was truncated on a codepoint
+// boundary and that is the size to retry with, plus one for the terminator. Pass destLen 0 to
+// measure. Returns UTF8_INVALID if src is not well-formed UTF-8, setting dest[0] to L'\0' if
+// destLen > 0.
 size_t Utf8_To_Wide(wchar_t* dest, size_t destLen, const char* src, size_t srcLen);

--- a/Core/Libraries/Source/WWVegas/WWLib/utf8.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/utf8.h
@@ -21,29 +21,32 @@
 #include <stddef.h>
 #include <wchar.h>
 
-// NOTE: The current implementation is Windows-only and treats wchar_t as UTF-16LE.
-// On non-Windows platforms wchar_t is typically UTF-32, so a future cross-platform
-// implementation should migrate the wide parameters to uint16_t / char16_t.
+// UTF-8 <-> wide-character transcoding, hand-rolled per RFC 3629, using no platform text APIs.
+// The wide side is wchar_t, whose width is platform-dependent: on Windows it is a 16-bit UTF-16
+// code unit (astral codepoints use surrogate pairs); on most other platforms it is a 32-bit
+// UTF-32 codepoint. Both are handled transparently based on the width of wchar_t.
 
-// Returns the number of bytes needed for the UTF-8 representation of srcLen UTF-16LE
-// characters from src, not counting a null terminator. Returns 0 on failure or if srcLen is 0.
+// Returns true if the length bytes at str are well-formed UTF-8 per RFC 3629. Rejects overlong
+// encodings, codepoints above U+10FFFF, and UTF-16 surrogate codepoints. An empty range is valid.
+bool Utf8_Validate(const char* str, size_t length);
+
+// Returns the number of UTF-8 bytes needed for the UTF-8 representation of srcLen wide characters
+// from src, not counting a null terminator. Returns 0 if srcLen is 0.
 size_t Utf16Le_To_Utf8_Len(const wchar_t* src, size_t srcLen);
 
-// Returns the number of UTF-16LE elements needed for the UTF-16LE representation
-// of srcLen bytes from the UTF-8 string src, not counting a null terminator.
-// Returns 0 on failure or if srcLen is 0.
+// Returns the number of wide characters needed for the wide representation of srcLen bytes from the
+// UTF-8 string src, not counting a null terminator. Returns 0 on invalid UTF-8 or if srcLen is 0.
 size_t Utf8_To_Utf16Le_Len(const char* src, size_t srcLen);
 
-// Converts srcLen UTF-16LE characters from src to UTF-8.
+// Converts srcLen wide characters from src to UTF-8.
 // destLen is the destination buffer capacity in bytes. Caller must ensure destLen is large enough
 // by querying Utf16Le_To_Utf8_Len first. Writes a null terminator if room remains, otherwise not.
-// Returns the number of bytes written on success, or 0 on failure.
-// On failure, dest[0] is set to '\0' if destLen > 0.
+// Returns the number of bytes written, or 0 if srcLen is 0.
 size_t Utf16Le_To_Utf8(char* dest, size_t destLen, const wchar_t* src, size_t srcLen);
 
-// Converts srcLen bytes from the UTF-8 string src to UTF-16LE characters.
-// destLen is the destination buffer capacity in wchar_t elements. Caller must ensure destLen is
+// Converts srcLen bytes from the UTF-8 string src to wide characters.
+// destLen is the destination buffer capacity in wide characters. Caller must ensure destLen is
 // large enough by querying Utf8_To_Utf16Le_Len first. Writes a null terminator if room remains,
-// otherwise not. Returns the number of wchar_t elements written on success, or 0 on failure.
-// On failure, dest[0] is set to L'\0' if destLen > 0.
+// otherwise not. Returns the number of wide characters written, or 0 on invalid UTF-8 or if srcLen
+// is 0. On failure, dest[0] is set to L'\0' if destLen > 0.
 size_t Utf8_To_Utf16Le(wchar_t* dest, size_t destLen, const char* src, size_t srcLen);

--- a/Core/Libraries/Source/WWVegas/WWLib/utf8.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/utf8.h
@@ -35,23 +35,25 @@ const size_t UTF8_INVALID = (size_t)-1;
 bool Utf8_Validate(const char* str, size_t length);
 
 // Returns the number of UTF-8 bytes needed for the UTF-8 representation of srcLen wide characters
-// from src, not counting a null terminator. Returns 0 if srcLen is 0.
-size_t Utf16Le_To_Utf8_Len(const wchar_t* src, size_t srcLen);
+// from src, not counting a null terminator. Returns 0 if srcLen is 0. Wide values that have no
+// UTF-8 representation are counted as U+FFFD.
+size_t Wide_To_Utf8_Len(const wchar_t* src, size_t srcLen);
 
 // Returns the number of wide characters needed for the wide representation of srcLen bytes from the
 // UTF-8 string src, not counting a null terminator. Returns 0 if srcLen is 0, or UTF8_INVALID if
 // src is not well-formed UTF-8.
-size_t Utf8_To_Utf16Le_Len(const char* src, size_t srcLen);
+size_t Utf8_To_Wide_Len(const char* src, size_t srcLen);
 
 // Converts srcLen wide characters from src to UTF-8.
 // destLen is the destination buffer capacity in bytes. Caller must ensure destLen is large enough
-// by querying Utf16Le_To_Utf8_Len first. Writes a null terminator if room remains, otherwise not.
-// Returns the number of bytes written, or 0 if srcLen is 0.
-size_t Utf16Le_To_Utf8(char* dest, size_t destLen, const wchar_t* src, size_t srcLen);
+// by querying Wide_To_Utf8_Len first. Writes a null terminator if room remains, otherwise not.
+// Returns the number of bytes written, or 0 if srcLen is 0. Wide values that have no UTF-8
+// representation are written as U+FFFD, so the output always decodes back through Utf8_To_Wide.
+size_t Wide_To_Utf8(char* dest, size_t destLen, const wchar_t* src, size_t srcLen);
 
 // Converts srcLen bytes from the UTF-8 string src to wide characters.
 // destLen is the destination buffer capacity in wide characters. Caller must ensure destLen is
-// large enough by querying Utf8_To_Utf16Le_Len first. Writes a null terminator if room remains,
+// large enough by querying Utf8_To_Wide_Len first. Writes a null terminator if room remains,
 // otherwise not. Returns the number of wide characters written, 0 if srcLen is 0, or UTF8_INVALID
 // if src is not well-formed UTF-8. On failure, dest[0] is set to L'\0' if destLen > 0.
-size_t Utf8_To_Utf16Le(wchar_t* dest, size_t destLen, const char* src, size_t srcLen);
+size_t Utf8_To_Wide(wchar_t* dest, size_t destLen, const char* src, size_t srcLen);

--- a/Core/Libraries/Source/WWVegas/WWLib/utf8.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/utf8.h
@@ -43,16 +43,15 @@ size_t Utf8_To_Wide_Len(const char* src, size_t srcLen);
 // Converts srcLen wide characters from src to UTF-8. destLen is the destination buffer capacity in
 // bytes. Writes a null terminator if room remains, otherwise not. Wide values that have no UTF-8
 // representation are written as U+FFFD, so the output always decodes back through Utf8_To_Wide.
-// Returns the bytes the whole conversion needs, not counting a null terminator, which is what gets
-// written when it fits. More than destLen means the output was truncated on a codepoint boundary
-// and that is the size to retry with, plus one for the terminator. Pass destLen 0 to measure.
+// Returns the number of bytes the whole conversion needs, not counting a null terminator. A return
+// greater than destLen means the output was truncated on a codepoint boundary; retry with that many
+// bytes plus one for the terminator. Pass destLen 0 to measure without writing.
 size_t Wide_To_Utf8(char* dest, size_t destLen, const wchar_t* src, size_t srcLen);
 
 // Converts srcLen bytes from the UTF-8 string src to wide characters. destLen is the destination
 // buffer capacity in wide characters. Writes a null terminator if room remains, otherwise not.
-// Returns the wide characters the whole conversion needs, not counting a null terminator, which is
-// what gets written when it fits. More than destLen means the output was truncated on a codepoint
-// boundary and that is the size to retry with, plus one for the terminator. Pass destLen 0 to
-// measure. Returns UTF8_INVALID if src is not well-formed UTF-8, setting dest[0] to L'\0' if
-// destLen > 0.
+// Returns the number of wide characters the whole conversion needs, not counting a null terminator.
+// A return greater than destLen means the output was truncated on a codepoint boundary; retry with
+// that many wide characters plus one for the terminator. Pass destLen 0 to measure without writing.
+// Returns UTF8_INVALID if src is not well-formed UTF-8, setting dest[0] to L'\0' if destLen > 0.
 size_t Utf8_To_Wide(wchar_t* dest, size_t destLen, const char* src, size_t srcLen);

--- a/Core/Libraries/Source/WWVegas/WWLib/utf8.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/utf8.h
@@ -30,10 +30,6 @@
 // an empty result, which is a success and must not be confused with a decoding failure.
 const size_t UTF8_INVALID = (size_t)-1;
 
-// Returns true if the length bytes at str are well-formed UTF-8 per RFC 3629. Rejects overlong
-// encodings, codepoints above U+10FFFF, and UTF-16 surrogate codepoints. An empty range is valid.
-bool Utf8_Validate(const char* str, size_t length);
-
 // Returns the number of UTF-8 bytes needed for the UTF-8 representation of srcLen wide characters
 // from src, not counting a null terminator. Returns 0 if srcLen is 0. Wide values that have no
 // UTF-8 representation are counted as U+FFFD.

--- a/Core/Libraries/Source/WWVegas/WWLib/utf8.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/utf8.h
@@ -25,18 +25,6 @@
 // On non-Windows platforms wchar_t is typically UTF-32, so a future cross-platform
 // implementation should migrate the wide parameters to uint16_t / char16_t.
 
-// Returns the number of bytes in a UTF-8 character based on its lead byte.
-// Returns 0 if the lead byte is invalid.
-size_t Utf8_Num_Bytes(char lead);
-
-// Returns the number of invalid bytes at the end of the string due to an
-// incomplete multi-byte sequence. Returns 0 if the string ends on a complete sequence.
-size_t Utf8_Trailing_Invalid_Bytes(const char* str, size_t length);
-
-// Returns true if the null-terminated string is valid UTF-8, false otherwise.
-bool Utf8_Validate(const char* str);
-bool Utf8_Validate(const char* str, size_t length);
-
 // Returns the number of bytes needed for the UTF-8 representation of srcLen UTF-16LE
 // characters from src, not counting a null terminator. Returns 0 on failure or if srcLen is 0.
 size_t Utf16Le_To_Utf8_Len(const wchar_t* src, size_t srcLen);

--- a/Core/Libraries/Source/WWVegas/WWLib/utf8.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/utf8.h
@@ -26,6 +26,10 @@
 // code unit (astral codepoints use surrogate pairs); on most other platforms it is a 32-bit
 // UTF-32 codepoint. Both are handled transparently based on the width of wchar_t.
 
+// Returned by the decoding functions when the source is not well-formed UTF-8. A return of 0 means
+// an empty result, which is a success and must not be confused with a decoding failure.
+const size_t UTF8_INVALID = (size_t)-1;
+
 // Returns true if the length bytes at str are well-formed UTF-8 per RFC 3629. Rejects overlong
 // encodings, codepoints above U+10FFFF, and UTF-16 surrogate codepoints. An empty range is valid.
 bool Utf8_Validate(const char* str, size_t length);
@@ -35,7 +39,8 @@ bool Utf8_Validate(const char* str, size_t length);
 size_t Utf16Le_To_Utf8_Len(const wchar_t* src, size_t srcLen);
 
 // Returns the number of wide characters needed for the wide representation of srcLen bytes from the
-// UTF-8 string src, not counting a null terminator. Returns 0 on invalid UTF-8 or if srcLen is 0.
+// UTF-8 string src, not counting a null terminator. Returns 0 if srcLen is 0, or UTF8_INVALID if
+// src is not well-formed UTF-8.
 size_t Utf8_To_Utf16Le_Len(const char* src, size_t srcLen);
 
 // Converts srcLen wide characters from src to UTF-8.
@@ -47,6 +52,6 @@ size_t Utf16Le_To_Utf8(char* dest, size_t destLen, const wchar_t* src, size_t sr
 // Converts srcLen bytes from the UTF-8 string src to wide characters.
 // destLen is the destination buffer capacity in wide characters. Caller must ensure destLen is
 // large enough by querying Utf8_To_Utf16Le_Len first. Writes a null terminator if room remains,
-// otherwise not. Returns the number of wide characters written, or 0 on invalid UTF-8 or if srcLen
-// is 0. On failure, dest[0] is set to L'\0' if destLen > 0.
+// otherwise not. Returns the number of wide characters written, 0 if srcLen is 0, or UTF8_INVALID
+// if src is not well-formed UTF-8. On failure, dest[0] is set to L'\0' if destLen > 0.
 size_t Utf8_To_Utf16Le(wchar_t* dest, size_t destLen, const char* src, size_t srcLen);


### PR DESCRIPTION
* Relates to #2045

Adds portable UTF-8/wide-character conversion helpers to WWLib and uses them for engine string translation and the existing GameSpy conversion paths.

This picks up the work from #2045 with API and behavior changes based on review feedback.

### `WWLib/utf8.h` / `utf8.cpp`

Adds four conversion functions:

- `Wide_To_Utf8_Len`
- `Utf8_To_Wide_Len`
- `Wide_To_Utf8`
- `Utf8_To_Wide`

The `_Len` functions return the required destination size without counting a null terminator. The conversion functions return the number of units written and write a null terminator when the destination has spare capacity.

Malformed UTF-8 is reported as `UTF8_INVALID`, keeping it distinct from a successful empty conversion, which returns `0`.

The decoder validates UTF-8 according to RFC 3629, rejecting:

- malformed and truncated sequences;
- overlong encodings;
- surrogate codepoints;
- codepoints above U+10FFFF.

The encoder substitutes U+FFFD for unpaired UTF-16 surrogates and wide values that have no valid UTF-8 representation. Its output therefore always decodes successfully through `Utf8_To_Wide`.

The implementation uses no platform text APIs. It adapts to the platform width of `wchar_t`:

- 16-bit `wchar_t` is handled as UTF-16, including surrogate pairs;
- 32-bit `wchar_t` is handled as UTF-32 codepoints.

### `AsciiString::translate`

Replaces the original 7-bit-only wide-to-narrow translation with UTF-8 encoding.

### `UnicodeString::translate`

Decodes valid UTF-8 into the platform wide-character representation.

When the input is not valid UTF-8, translation falls back to the previous unsigned-byte-to-wide-character behavior. This preserves legacy byte values instead of rejecting or replacing the input. It is a compatibility fallback, not a complete code-page-specific decoder.

Because `AsciiString` does not carry encoding metadata, valid UTF-8 is preferred over the legacy fallback.

### `ThreadUtils.cpp`

Replaces the GameSpy-specific Win32 conversion calls with the shared WWLib functions.

`MultiByteToWideCharSingleLine` uses the same invalid-UTF-8 fallback as `UnicodeString::translate`. Newline and carriage-return replacement remains unchanged.

### Non-goals

This change does not make narrow filesystem APIs Unicode-aware. Paths are still passed to the existing narrow platform APIs; updating those APIs belongs in a separate change.

### Verification

- Tested ASCII and 2-, 3-, and 4-byte UTF-8 round trips.
- Tested both 16-bit and 32-bit `wchar_t` paths.
- Tested rejection of malformed, truncated, overlong, surrogate, and out-of-range UTF-8 sequences.
- Tested replacement of unpaired wide surrogates and out-of-range wide values.
- All Generals and GeneralsMD VC6 and Win32 CI configurations pass.
- GeneralsMD replay checks pass.