### PR TITLE
fix(actionmanager): Improve validation of Sneak Attack placement legality

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/BuildAssistant.h
+++ b/Generals/Code/GameEngine/Include/Common/BuildAssistant.h
@@ -148,14 +148,14 @@ public:
 																								 const ThingTemplate *build,
 																								 Real angle,  // angle to construct 'build' at
 																								 UnsignedInt options,		// use LocationLegalToBuildOptions
-																								 Object *builderObject,
+																								 const Object *builderObject,
 																								 Player *player);
 
 	/// query if we can build at this location
 	virtual Bool isLocationClearOfObjects( const Coord3D *worldPos,
 																								 const ThingTemplate *build,
 																								 Real angle,  // angle to construct 'build' a
-																								 Object *builderObject,
+																								 const Object *builderObject,
 																								 UnsignedInt options,
 																								 Player *thePlayer);
 

--- a/Generals/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
@@ -656,7 +656,7 @@ void BuildAssistant::iterateFootprint( const ThingTemplate *build,
 Bool BuildAssistant::isLocationClearOfObjects( const Coord3D *worldPos,
 																											 const ThingTemplate *build,
 																											 Real angle,
-																											 Object *builderObject,
+																											 const Object *builderObject,
 																											 UnsignedInt options,
 																											 Player *thePlayer)
 {
@@ -842,7 +842,7 @@ LegalBuildCode BuildAssistant::isLocationLegalToBuild( const Coord3D *worldPos,
 																											 const ThingTemplate *build,
 																											 Real angle,
 																											 UnsignedInt options,
-																											 Object *builderObject,
+																											 const Object *builderObject,
 																											 Player *player)
 {
 
@@ -928,7 +928,7 @@ LegalBuildCode BuildAssistant::isLocationLegalToBuild( const Coord3D *worldPos,
 	// if clear path is requested check to see if the builder object can get there
 	if( BitIsSet( options, CLEAR_PATH ) && builderObject )
 	{
-		AIUpdateInterface *ai = builderObject->getAIUpdateInterface();
+		const AIUpdateInterface *ai = builderObject->getAIUpdateInterface();
 
 		//
 		// if there is no AI interface for this object, it cannot possible pass a clear path

--- a/GeneralsMD/Code/GameEngine/Include/Common/BuildAssistant.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/BuildAssistant.h
@@ -151,14 +151,14 @@ public:
 																								 const ThingTemplate *build,
 																								 Real angle,  // angle to construct 'build' at
 																								 UnsignedInt options,		// use LocationLegalToBuildOptions
-																								 Object *builderObject,
+																								 const Object *builderObject,
 																								 Player *player);
 
 	/// query if we can build at this location
 	virtual LegalBuildCode isLocationClearOfObjects( const Coord3D *worldPos,
 																								 const ThingTemplate *build,
 																								 Real angle,  // angle to construct 'build' a
-																								 Object *builderObject,
+																								 const Object *builderObject,
 																								 UnsignedInt options,
 																								 Player *thePlayer);
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/ActionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/ActionManager.cpp
@@ -36,6 +36,7 @@
 #include "PreRTS.h"	// This must go first in EVERY cpp file in the GameEngine
 
 #include "Common/ActionManager.h"
+#include "Common/BuildAssistant.h"
 #include "Common/GlobalData.h"
 #include "Common/Player.h"
 #include "Common/PlayerList.h"
@@ -1506,7 +1507,7 @@ Bool ActionManager::canDoSpecialPowerAtLocation( const Object *obj, const Coord3
 			}
 		}
 
-		// Last check is shroudedness, if it is cared about
+		// Second check is shroudedness, if it is cared about
 		switch( spTemplate->getSpecialPowerType() )
 		{
 			case SPECIAL_DAISY_CUTTER:
@@ -1552,7 +1553,6 @@ Bool ActionManager::canDoSpecialPowerAtLocation( const Object *obj, const Coord3
 			case SUPW_SPECIAL_PARTICLE_UPLINK_CANNON:
 			case LAZR_SPECIAL_PARTICLE_UPLINK_CANNON:
 			case SPECIAL_CLEANUP_AREA:
-			case SPECIAL_SNEAK_ATTACK:
 			case SPECIAL_BATTLESHIP_BOMBARDMENT:
 				//Don't allow "damaging" special powers in shrouded areas, but Fogged are okay.
 				return ThePartitionManager->getShroudStatusForPlayer( obj->getControllingPlayer()->getPlayerIndex(), loc ) != CELLSHROUD_SHROUDED;
@@ -1585,6 +1585,35 @@ Bool ActionManager::canDoSpecialPowerAtLocation( const Object *obj, const Coord3
 			case SPECIAL_CASH_BOUNTY:
 			case SPECIAL_CHANGE_BATTLE_PLANS:
 				return false;
+		}
+
+		// TheSuperHackers @fix stephanmeesters 04/04/2026 Some special powers can spawn a building. To avoid cheating
+		// we must verify that it is legal to place this building.
+		switch( spTemplate->getSpecialPowerType() )
+		{
+			case SPECIAL_SNEAK_ATTACK:
+			{
+#if RETAIL_COMPATIBLE_CRC
+				return ThePartitionManager->getShroudStatusForPlayer( obj->getControllingPlayer()->getPlayerIndex(), loc ) != CELLSHROUD_SHROUDED;
+#elif
+				const ThingTemplate* referenceThing = mod->getReferenceThingTemplate();
+				DEBUG_ASSERTCRASH(referenceThing, ("canDoSpecialPowerAtLocation: SpecialPowerTemplate has a null ThingTemplate") );
+				if (!referenceThing)
+					return FALSE;
+
+				return TheBuildAssistant->isLocationLegalToBuild(loc,
+																 referenceThing,
+																 referenceThing->getPlacementViewAngle(),
+																 BuildAssistant::USE_QUICK_PATHFIND |
+																 BuildAssistant::TERRAIN_RESTRICTIONS |
+																 BuildAssistant::CLEAR_PATH |
+																 BuildAssistant::NO_OBJECT_OVERLAP |
+																 BuildAssistant::SHROUD_REVEALED |
+																 BuildAssistant::IGNORE_STEALTHED,
+																 obj,
+																 nullptr) == LBC_OK;
+#endif
+			}
 		}
 	}
 	return false;

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/ActionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/ActionManager.cpp
@@ -1595,7 +1595,7 @@ Bool ActionManager::canDoSpecialPowerAtLocation( const Object *obj, const Coord3
 			{
 #if RETAIL_COMPATIBLE_CRC
 				return ThePartitionManager->getShroudStatusForPlayer( obj->getControllingPlayer()->getPlayerIndex(), loc ) != CELLSHROUD_SHROUDED;
-#elif
+#else
 				const ThingTemplate* referenceThing = mod->getReferenceThingTemplate();
 				DEBUG_ASSERTCRASH(referenceThing, ("canDoSpecialPowerAtLocation: SpecialPowerTemplate has a null ThingTemplate") );
 				if (!referenceThing)

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/ActionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/ActionManager.cpp
@@ -1587,8 +1587,8 @@ Bool ActionManager::canDoSpecialPowerAtLocation( const Object *obj, const Coord3
 				return false;
 		}
 
-		// TheSuperHackers @fix stephanmeesters 04/04/2026 Some special powers can spawn a building. To avoid cheating
-		// verify that it is legal to place this building.
+		// TheSuperHackers @fix stephanmeesters 04/04/2026 Some special powers can spawn a building.
+		// To avoid cheating, verify that it is legal to place this building.
 		switch( spTemplate->getSpecialPowerType() )
 		{
 			case SPECIAL_SNEAK_ATTACK:
@@ -1600,18 +1600,17 @@ Bool ActionManager::canDoSpecialPowerAtLocation( const Object *obj, const Coord3
 				if (!referenceThing)
 					return FALSE;
 
+				const Real angle = referenceThing->getPlacementViewAngle();
+
 				return TheBuildAssistant->isLocationLegalToBuild(
-					loc,
-					referenceThing,
-					referenceThing->getPlacementViewAngle(),
+					loc, referenceThing, angle,
 					BuildAssistant::USE_QUICK_PATHFIND |
 					BuildAssistant::TERRAIN_RESTRICTIONS |
 					BuildAssistant::CLEAR_PATH |
 					BuildAssistant::NO_OBJECT_OVERLAP |
 					BuildAssistant::SHROUD_REVEALED |
 					BuildAssistant::IGNORE_STEALTHED,
-					obj,
-					nullptr) == LBC_OK;
+					obj, nullptr) == LBC_OK;
 #endif
 			}
 		}

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/ActionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/ActionManager.cpp
@@ -1588,7 +1588,7 @@ Bool ActionManager::canDoSpecialPowerAtLocation( const Object *obj, const Coord3
 		}
 
 		// TheSuperHackers @fix stephanmeesters 04/04/2026 Some special powers can spawn a building. To avoid cheating
-		// we must verify that it is legal to place this building.
+		// verify that it is legal to place this building.
 		switch( spTemplate->getSpecialPowerType() )
 		{
 			case SPECIAL_SNEAK_ATTACK:
@@ -1597,21 +1597,21 @@ Bool ActionManager::canDoSpecialPowerAtLocation( const Object *obj, const Coord3
 				return ThePartitionManager->getShroudStatusForPlayer( obj->getControllingPlayer()->getPlayerIndex(), loc ) != CELLSHROUD_SHROUDED;
 #else
 				const ThingTemplate* referenceThing = mod->getReferenceThingTemplate();
-				DEBUG_ASSERTCRASH(referenceThing, ("canDoSpecialPowerAtLocation: SpecialPowerTemplate has a null ThingTemplate") );
 				if (!referenceThing)
 					return FALSE;
 
-				return TheBuildAssistant->isLocationLegalToBuild(loc,
-																 referenceThing,
-																 referenceThing->getPlacementViewAngle(),
-																 BuildAssistant::USE_QUICK_PATHFIND |
-																 BuildAssistant::TERRAIN_RESTRICTIONS |
-																 BuildAssistant::CLEAR_PATH |
-																 BuildAssistant::NO_OBJECT_OVERLAP |
-																 BuildAssistant::SHROUD_REVEALED |
-																 BuildAssistant::IGNORE_STEALTHED,
-																 obj,
-																 nullptr) == LBC_OK;
+				return TheBuildAssistant->isLocationLegalToBuild(
+					loc,
+					referenceThing,
+					referenceThing->getPlacementViewAngle(),
+					BuildAssistant::USE_QUICK_PATHFIND |
+					BuildAssistant::TERRAIN_RESTRICTIONS |
+					BuildAssistant::CLEAR_PATH |
+					BuildAssistant::NO_OBJECT_OVERLAP |
+					BuildAssistant::SHROUD_REVEALED |
+					BuildAssistant::IGNORE_STEALTHED,
+					obj,
+					nullptr) == LBC_OK;
 #endif
 			}
 		}

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/BuildAssistant.cpp
@@ -656,7 +656,7 @@ void BuildAssistant::iterateFootprint( const ThingTemplate *build,
 LegalBuildCode BuildAssistant::isLocationClearOfObjects( const Coord3D *worldPos,
 																											 const ThingTemplate *build,
 																											 Real angle,
-																											 Object *builderObject,
+																											 const Object *builderObject,
 																											 UnsignedInt options,
 																											 Player *thePlayer)
 {
@@ -915,7 +915,7 @@ LegalBuildCode BuildAssistant::isLocationLegalToBuild( const Coord3D *worldPos,
 																											 const ThingTemplate *build,
 																											 Real angle,
 																											 UnsignedInt options,
-																											 Object *builderObject,
+																											 const Object *builderObject,
 																											 Player *player)
 {
 
@@ -1002,7 +1002,7 @@ LegalBuildCode BuildAssistant::isLocationLegalToBuild( const Coord3D *worldPos,
 	// if clear path is requested check to see if the builder object can get there (unless it's a structure)
 	if( BitIsSet( options, CLEAR_PATH ) && builderObject && !builderObject->isKindOf( KINDOF_IMMOBILE ) )
 	{
-		AIUpdateInterface *ai = builderObject->getAIUpdateInterface();
+		const AIUpdateInterface *ai = builderObject->getAIUpdateInterface();
 
 		//
 		// if there is no AI interface for this object, it cannot possible pass a clear path


### PR DESCRIPTION
This PR fixes potential cheating in the placement of a Sneak Attack, where the validity of the building placement was only checked locally. This means a Sneak Attack could be placed in the fog, on top of any other building, steep mountain slope, water etc. A second check is placed that runs on all clients and mirrors the first check at `InGameUI:1688`.

## Todo

* [x] Replicate in Generals (first commit only)