### PR TITLE
refactor(recorder): Remove code duplications related to file write and logging in RecorderClass

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Recorder.cpp
@@ -71,58 +71,60 @@ static const UnsignedInt desyncOffset = frameCountOffset + sizeof(UnsignedInt);
 static const UnsignedInt quitEarlyOffset = desyncOffset + sizeof(Bool);
 static const UnsignedInt disconOffset = quitEarlyOffset + sizeof(Bool);
 
+static void writeAtHeaderOffset(File* file, Int offset, const void* data, Int dataSize)
+{
+	UnsignedInt fileSize = file->size();
+	if (file->seek(offset, File::seekMode::START) == offset)
+	{
+		file->write(data, dataSize);
+	}
+#ifdef DEBUG_CRASHING
+	Int res =
+#endif
+	file->seek(fileSize, File::seekMode::START);
+	DEBUG_ASSERTCRASH(res == fileSize, ("Could not seek to end of file!"));
+}
+
+#if defined(RTS_DEBUG)
+static FILE* openStatsLogFile()
+{
+	unsigned long bufSize = MAX_COMPUTERNAME_LENGTH + 1;
+	char computerName[MAX_COMPUTERNAME_LENGTH + 1];
+	if (!GetComputerName(computerName, &bufSize))
+	{
+		strcpy(computerName, "unknown");
+	}
+	AsciiString statsFile = TheGlobalData->m_baseStatsDir;
+	statsFile.concat(computerName);
+	statsFile.concat(".txt");
+	return fopen(statsFile.str(), "a+");
+}
+#endif
+
 void RecorderClass::logGameStart(AsciiString options)
 {
 	if (!m_file)
 		return;
 
 	time(&startTime);
-	UnsignedInt fileSize = m_file->size();
-	// move to appropriate offset
-	if ( m_file->seek(startTimeOffset, File::seekMode::START) == startTimeOffset )
-	{
-		// save off start time
-		replay_time_t tmp = (replay_time_t)startTime;
-		m_file->write(&tmp, sizeof(tmp));
-	}
-	// move back to end of stream
-#ifdef DEBUG_CRASHING
-	Int res =
-#endif
-	m_file->seek(fileSize, File::seekMode::START);
-	DEBUG_ASSERTCRASH(res == fileSize, ("Could not seek to end of file!"));
+	replay_time_t tmp = (replay_time_t)startTime;
+	writeAtHeaderOffset(m_file, startTimeOffset, &tmp, sizeof(tmp));
 
 #if defined(RTS_DEBUG)
 	if (TheNetwork && TheGlobalData->m_saveStats)
 	{
-		//if (TheLAN)
+		TheFileSystem->createDirectory(TheGlobalData->m_baseStatsDir);
+		FILE *logFP = openStatsLogFile();
+		if (!logFP)
 		{
-			unsigned long bufSize = MAX_COMPUTERNAME_LENGTH + 1;
-			char computerName[MAX_COMPUTERNAME_LENGTH + 1];
-			if (!GetComputerName(computerName, &bufSize))
-			{
-				strcpy(computerName, "unknown");
-			}
-			AsciiString statsFile = TheGlobalData->m_baseStatsDir;
-			TheFileSystem->createDirectory(statsFile);
-			statsFile.concat(computerName);
-			statsFile.concat(".txt");
-			FILE *logFP = fopen(statsFile.str(), "a+");
-			if (!logFP)
-			{
-				// try again locally
-				TheWritableGlobalData->m_baseStatsDir = TheGlobalData->getPath_UserData();
-				statsFile = TheGlobalData->m_baseStatsDir;
-				statsFile.concat(computerName);
-				statsFile.concat(".txt");
-				logFP = fopen(statsFile.str(), "a+");
-			}
-			if (logFP)
-			{
-				struct tm *t2 = localtime(&startTime);
-				fprintf(logFP, "\nGame start at %s\tOptions are %s\n", asctime(t2), options.str());
-				fclose(logFP);
-			}
+			TheWritableGlobalData->m_baseStatsDir = TheGlobalData->getPath_UserData();
+			logFP = openStatsLogFile();
+		}
+		if (logFP)
+		{
+			struct tm *t2 = localtime(&startTime);
+			fprintf(logFP, "\nGame start at %s\tOptions are %s\n", asctime(t2), options.str());
+			fclose(logFP);
 		}
 	}
 #endif
@@ -138,35 +140,14 @@ void RecorderClass::logPlayerDisconnect(UnicodeString player, Int slot)
 	{
 		return;
 	}
-	UnsignedInt fileSize = m_file->size();
-	// move to appropriate offset
+	Bool flag = TRUE;
 	Int playerSlotDisconOffset = disconOffset + slot * sizeof(Bool);
-	if ( m_file->seek(playerSlotDisconOffset, File::seekMode::START) == playerSlotDisconOffset )
-	{
-		// save off discon status
-		Bool flag = TRUE;
-		m_file->write(&flag, sizeof(flag));
-	}
-	// move back to end of stream
-#ifdef DEBUG_CRASHING
-	Int res =
-#endif
-	m_file->seek(fileSize, File::seekMode::START);
-	DEBUG_ASSERTCRASH(res == fileSize, ("Could not seek to end of file!"));
+	writeAtHeaderOffset(m_file, playerSlotDisconOffset, &flag, sizeof(flag));
 
 #if defined(RTS_DEBUG)
 	if (TheGlobalData->m_saveStats)
 	{
-		unsigned long bufSize = MAX_COMPUTERNAME_LENGTH + 1;
-		char computerName[MAX_COMPUTERNAME_LENGTH + 1];
-		if (!GetComputerName(computerName, &bufSize))
-		{
-			strcpy(computerName, "unknown");
-		}
-		AsciiString statsFile = TheGlobalData->m_baseStatsDir;
-		statsFile.concat(computerName);
-		statsFile.concat(".txt");
-		FILE *logFP = fopen(statsFile.str(), "a+");
+		FILE *logFP = openStatsLogFile();
 		if (logFP)
 		{
 			time_t t;
@@ -184,35 +165,14 @@ void RecorderClass::logCRCMismatch()
 	if (!m_file)
 		return;
 
-	UnsignedInt fileSize = m_file->size();
-	// move to appropriate offset
-	if ( m_file->seek(desyncOffset, File::seekMode::START) == desyncOffset )
-	{
-		// save off desync status
-		Bool flag = TRUE;
-		m_file->write(&flag, sizeof(flag));
-	}
-	// move back to end of stream
-#ifdef DEBUG_CRASHING
-	Int res =
-#endif
-	m_file->seek(fileSize, File::seekMode::START);
-	DEBUG_ASSERTCRASH(res == fileSize, ("Could not seek to end of file!"));
+	Bool flag = TRUE;
+	writeAtHeaderOffset(m_file, desyncOffset, &flag, sizeof(flag));
 
 #if defined(RTS_DEBUG)
 	if (TheGlobalData->m_saveStats)
 	{
 		m_wasDesync = TRUE;
-		unsigned long bufSize = MAX_COMPUTERNAME_LENGTH + 1;
-		char computerName[MAX_COMPUTERNAME_LENGTH + 1];
-		if (!GetComputerName(computerName, &bufSize))
-		{
-			strcpy(computerName, "unknown");
-		}
-		AsciiString statsFile = TheGlobalData->m_baseStatsDir;
-		statsFile.concat(computerName);
-		statsFile.concat(".txt");
-		FILE *logFP = fopen(statsFile.str(), "a+");
+		FILE *logFP = openStatsLogFile();
 		if (logFP)
 		{
 			time_t t;
@@ -233,51 +193,22 @@ void RecorderClass::logGameEnd()
 	time_t t;
 	time(&t);
 	UnsignedInt frameCount = TheGameLogic->getFrame();
-	UnsignedInt fileSize = m_file->size();
-	// move to appropriate offset
-	if ( m_file->seek(endTimeOffset, File::seekMode::START) == endTimeOffset )
-	{
-		// save off end time
-		replay_time_t tmp = (replay_time_t)t;
-		m_file->write(&tmp, sizeof(tmp));
-	}
-	// move to appropriate offset
-	if ( m_file->seek(frameCountOffset, File::seekMode::START) == frameCountOffset )
-	{
-		// save off frameCount
-		m_file->write(&frameCount, sizeof(frameCount));
-	}
-	// move back to end of stream
-#ifdef DEBUG_CRASHING
-	Int res =
-#endif
-	m_file->seek(fileSize, File::seekMode::START);
-	DEBUG_ASSERTCRASH(res == fileSize, ("Could not seek to end of file!"));
+	replay_time_t tmp = (replay_time_t)t;
+	writeAtHeaderOffset(m_file, endTimeOffset, &tmp, sizeof(tmp));
+	writeAtHeaderOffset(m_file, frameCountOffset, &frameCount, sizeof(frameCount));
 
 #if defined(RTS_DEBUG)
 	if (TheNetwork && TheGlobalData->m_saveStats)
 	{
-		//if (TheLAN)
+		FILE *logFP = openStatsLogFile();
+		if (logFP)
 		{
-			unsigned long bufSize = MAX_COMPUTERNAME_LENGTH + 1;
-			char computerName[MAX_COMPUTERNAME_LENGTH + 1];
-			if (!GetComputerName(computerName, &bufSize))
-			{
-				strcpy(computerName, "unknown");
-			}
-			AsciiString statsFile = TheGlobalData->m_baseStatsDir;
-			statsFile.concat(computerName);
-			statsFile.concat(".txt");
-			FILE *logFP = fopen(statsFile.str(), "a+");
-			if (logFP)
-			{
-				struct tm *t2 = localtime(&t);
-				time_t duration = t - startTime;
-				Int minutes = duration/60;
-				Int seconds = duration%60;
-				fprintf(logFP, "Game end at   %s(%d:%2.2d elapsed time)\n", asctime(t2), minutes, seconds);
-				fclose(logFP);
-			}
+			struct tm *t2 = localtime(&t);
+			time_t duration = t - startTime;
+			Int minutes = duration/60;
+			Int seconds = duration%60;
+			fprintf(logFP, "Game end at   %s(%d:%2.2d elapsed time)\n", asctime(t2), minutes, seconds);
+			fclose(logFP);
 		}
 	}
 #endif

--- a/Generals/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Recorder.cpp
@@ -71,9 +71,10 @@ static const UnsignedInt desyncOffset = frameCountOffset + sizeof(UnsignedInt);
 static const UnsignedInt quitEarlyOffset = desyncOffset + sizeof(Bool);
 static const UnsignedInt disconOffset = quitEarlyOffset + sizeof(Bool);
 
-static void writeAtHeaderOffset(File* file, Int offset, const void* data, Int dataSize)
+static void writeAtOffset(File* file, Int offset, const void* data, Int dataSize)
 {
 	UnsignedInt fileSize = file->size();
+	DEBUG_ASSERTCRASH((UnsignedInt)(offset + dataSize) <= fileSize, ("writeAtOffset would exceed file size!"));
 	if (file->seek(offset, File::seekMode::START) == offset)
 	{
 		file->write(data, dataSize);
@@ -108,7 +109,7 @@ void RecorderClass::logGameStart(AsciiString options)
 
 	time(&startTime);
 	replay_time_t tmp = (replay_time_t)startTime;
-	writeAtHeaderOffset(m_file, startTimeOffset, &tmp, sizeof(tmp));
+	writeAtOffset(m_file, startTimeOffset, &tmp, sizeof(tmp));
 
 #if defined(RTS_DEBUG)
 	if (TheNetwork && TheGlobalData->m_saveStats)
@@ -142,7 +143,7 @@ void RecorderClass::logPlayerDisconnect(UnicodeString player, Int slot)
 	}
 	Bool flag = TRUE;
 	Int playerSlotDisconOffset = disconOffset + slot * sizeof(Bool);
-	writeAtHeaderOffset(m_file, playerSlotDisconOffset, &flag, sizeof(flag));
+	writeAtOffset(m_file, playerSlotDisconOffset, &flag, sizeof(flag));
 
 #if defined(RTS_DEBUG)
 	if (TheGlobalData->m_saveStats)
@@ -166,7 +167,7 @@ void RecorderClass::logCRCMismatch()
 		return;
 
 	Bool flag = TRUE;
-	writeAtHeaderOffset(m_file, desyncOffset, &flag, sizeof(flag));
+	writeAtOffset(m_file, desyncOffset, &flag, sizeof(flag));
 
 #if defined(RTS_DEBUG)
 	if (TheGlobalData->m_saveStats)
@@ -194,8 +195,8 @@ void RecorderClass::logGameEnd()
 	time(&t);
 	UnsignedInt frameCount = TheGameLogic->getFrame();
 	replay_time_t tmp = (replay_time_t)t;
-	writeAtHeaderOffset(m_file, endTimeOffset, &tmp, sizeof(tmp));
-	writeAtHeaderOffset(m_file, frameCountOffset, &frameCount, sizeof(frameCount));
+	writeAtOffset(m_file, endTimeOffset, &tmp, sizeof(tmp));
+	writeAtOffset(m_file, frameCountOffset, &frameCount, sizeof(frameCount));
 
 #if defined(RTS_DEBUG)
 	if (TheNetwork && TheGlobalData->m_saveStats)

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -71,58 +71,60 @@ static const UnsignedInt desyncOffset = frameCountOffset + sizeof(UnsignedInt);
 static const UnsignedInt quitEarlyOffset = desyncOffset + sizeof(Bool);
 static const UnsignedInt disconOffset = quitEarlyOffset + sizeof(Bool);
 
+static void writeAtHeaderOffset(File* file, Int offset, const void* data, Int dataSize)
+{
+	UnsignedInt fileSize = file->size();
+	if (file->seek(offset, File::seekMode::START) == offset)
+	{
+		file->write(data, dataSize);
+	}
+#ifdef DEBUG_CRASHING
+	Int res =
+#endif
+	file->seek(fileSize, File::seekMode::START);
+	DEBUG_ASSERTCRASH(res == fileSize, ("Could not seek to end of file!"));
+}
+
+#if defined(RTS_DEBUG)
+static FILE* openStatsLogFile()
+{
+	unsigned long bufSize = MAX_COMPUTERNAME_LENGTH + 1;
+	char computerName[MAX_COMPUTERNAME_LENGTH + 1];
+	if (!GetComputerName(computerName, &bufSize))
+	{
+		strcpy(computerName, "unknown");
+	}
+	AsciiString statsFile = TheGlobalData->m_baseStatsDir;
+	statsFile.concat(computerName);
+	statsFile.concat(".txt");
+	return fopen(statsFile.str(), "a+");
+}
+#endif
+
 void RecorderClass::logGameStart(AsciiString options)
 {
 	if (!m_file)
 		return;
 
 	time(&startTime);
-	UnsignedInt fileSize = m_file->size();
-	// move to appropriate offset
-	if ( m_file->seek(startTimeOffset, File::seekMode::START) == startTimeOffset )
-	{
-		// save off start time
-		replay_time_t tmp = (replay_time_t)startTime;
-		m_file->write(&tmp, sizeof(tmp));
-	}
-	// move back to end of stream
-#ifdef DEBUG_CRASHING
-	Int res =
-#endif
-	m_file->seek(fileSize, File::seekMode::START);
-	DEBUG_ASSERTCRASH(res == fileSize, ("Could not seek to end of file!"));
+	replay_time_t tmp = (replay_time_t)startTime;
+	writeAtHeaderOffset(m_file, startTimeOffset, &tmp, sizeof(tmp));
 
 #if defined(RTS_DEBUG)
 	if (TheNetwork && TheGlobalData->m_saveStats)
 	{
-		//if (TheLAN)
+		TheFileSystem->createDirectory(TheGlobalData->m_baseStatsDir);
+		FILE *logFP = openStatsLogFile();
+		if (!logFP)
 		{
-			unsigned long bufSize = MAX_COMPUTERNAME_LENGTH + 1;
-			char computerName[MAX_COMPUTERNAME_LENGTH + 1];
-			if (!GetComputerName(computerName, &bufSize))
-			{
-				strcpy(computerName, "unknown");
-			}
-			AsciiString statsFile = TheGlobalData->m_baseStatsDir;
-			TheFileSystem->createDirectory(statsFile);
-			statsFile.concat(computerName);
-			statsFile.concat(".txt");
-			FILE *logFP = fopen(statsFile.str(), "a+");
-			if (!logFP)
-			{
-				// try again locally
-				TheWritableGlobalData->m_baseStatsDir = TheGlobalData->getPath_UserData();
-				statsFile = TheGlobalData->m_baseStatsDir;
-				statsFile.concat(computerName);
-				statsFile.concat(".txt");
-				logFP = fopen(statsFile.str(), "a+");
-			}
-			if (logFP)
-			{
-				struct tm *t2 = localtime(&startTime);
-				fprintf(logFP, "\nGame start at %s\tOptions are %s\n", asctime(t2), options.str());
-				fclose(logFP);
-			}
+			TheWritableGlobalData->m_baseStatsDir = TheGlobalData->getPath_UserData();
+			logFP = openStatsLogFile();
+		}
+		if (logFP)
+		{
+			struct tm *t2 = localtime(&startTime);
+			fprintf(logFP, "\nGame start at %s\tOptions are %s\n", asctime(t2), options.str());
+			fclose(logFP);
 		}
 	}
 #endif
@@ -138,35 +140,14 @@ void RecorderClass::logPlayerDisconnect(UnicodeString player, Int slot)
 	{
 		return;
 	}
-	UnsignedInt fileSize = m_file->size();
-	// move to appropriate offset
+	Bool flag = TRUE;
 	Int playerSlotDisconOffset = disconOffset + slot * sizeof(Bool);
-	if ( m_file->seek(playerSlotDisconOffset, File::seekMode::START) == playerSlotDisconOffset )
-	{
-		// save off discon status
-		Bool flag = TRUE;
-		m_file->write(&flag, sizeof(flag));
-	}
-	// move back to end of stream
-#ifdef DEBUG_CRASHING
-	Int res =
-#endif
-	m_file->seek(fileSize, File::seekMode::START);
-	DEBUG_ASSERTCRASH(res == fileSize, ("Could not seek to end of file!"));
+	writeAtHeaderOffset(m_file, playerSlotDisconOffset, &flag, sizeof(flag));
 
 #if defined(RTS_DEBUG)
 	if (TheGlobalData->m_saveStats)
 	{
-		unsigned long bufSize = MAX_COMPUTERNAME_LENGTH + 1;
-		char computerName[MAX_COMPUTERNAME_LENGTH + 1];
-		if (!GetComputerName(computerName, &bufSize))
-		{
-			strcpy(computerName, "unknown");
-		}
-		AsciiString statsFile = TheGlobalData->m_baseStatsDir;
-		statsFile.concat(computerName);
-		statsFile.concat(".txt");
-		FILE *logFP = fopen(statsFile.str(), "a+");
+		FILE *logFP = openStatsLogFile();
 		if (logFP)
 		{
 			time_t t;
@@ -184,35 +165,14 @@ void RecorderClass::logCRCMismatch()
 	if (!m_file)
 		return;
 
-	UnsignedInt fileSize = m_file->size();
-	// move to appropriate offset
-	if ( m_file->seek(desyncOffset, File::seekMode::START) == desyncOffset )
-	{
-		// save off desync status
-		Bool flag = TRUE;
-		m_file->write(&flag, sizeof(flag));
-	}
-	// move back to end of stream
-#ifdef DEBUG_CRASHING
-	Int res =
-#endif
-	m_file->seek(fileSize, File::seekMode::START);
-	DEBUG_ASSERTCRASH(res == fileSize, ("Could not seek to end of file!"));
+	Bool flag = TRUE;
+	writeAtHeaderOffset(m_file, desyncOffset, &flag, sizeof(flag));
 
 #if defined(RTS_DEBUG)
 	if (TheGlobalData->m_saveStats)
 	{
 		m_wasDesync = TRUE;
-		unsigned long bufSize = MAX_COMPUTERNAME_LENGTH + 1;
-		char computerName[MAX_COMPUTERNAME_LENGTH + 1];
-		if (!GetComputerName(computerName, &bufSize))
-		{
-			strcpy(computerName, "unknown");
-		}
-		AsciiString statsFile = TheGlobalData->m_baseStatsDir;
-		statsFile.concat(computerName);
-		statsFile.concat(".txt");
-		FILE *logFP = fopen(statsFile.str(), "a+");
+		FILE *logFP = openStatsLogFile();
 		if (logFP)
 		{
 			time_t t;
@@ -233,51 +193,22 @@ void RecorderClass::logGameEnd()
 	time_t t;
 	time(&t);
 	UnsignedInt frameCount = TheGameLogic->getFrame();
-	UnsignedInt fileSize = m_file->size();
-	// move to appropriate offset
-	if ( m_file->seek(endTimeOffset, File::seekMode::START) == endTimeOffset )
-	{
-		// save off end time
-		replay_time_t tmp = (replay_time_t)t;
-		m_file->write(&tmp, sizeof(tmp));
-	}
-	// move to appropriate offset
-	if ( m_file->seek(frameCountOffset, File::seekMode::START) == frameCountOffset )
-	{
-		// save off frameCount
-		m_file->write(&frameCount, sizeof(frameCount));
-	}
-	// move back to end of stream
-#ifdef DEBUG_CRASHING
-	Int res =
-#endif
-	m_file->seek(fileSize, File::seekMode::START);
-	DEBUG_ASSERTCRASH(res == fileSize, ("Could not seek to end of file!"));
+	replay_time_t tmp = (replay_time_t)t;
+	writeAtHeaderOffset(m_file, endTimeOffset, &tmp, sizeof(tmp));
+	writeAtHeaderOffset(m_file, frameCountOffset, &frameCount, sizeof(frameCount));
 
 #if defined(RTS_DEBUG)
 	if (TheNetwork && TheGlobalData->m_saveStats)
 	{
-		//if (TheLAN)
+		FILE *logFP = openStatsLogFile();
+		if (logFP)
 		{
-			unsigned long bufSize = MAX_COMPUTERNAME_LENGTH + 1;
-			char computerName[MAX_COMPUTERNAME_LENGTH + 1];
-			if (!GetComputerName(computerName, &bufSize))
-			{
-				strcpy(computerName, "unknown");
-			}
-			AsciiString statsFile = TheGlobalData->m_baseStatsDir;
-			statsFile.concat(computerName);
-			statsFile.concat(".txt");
-			FILE *logFP = fopen(statsFile.str(), "a+");
-			if (logFP)
-			{
-				struct tm *t2 = localtime(&t);
-				time_t duration = t - startTime;
-				Int minutes = duration/60;
-				Int seconds = duration%60;
-				fprintf(logFP, "Game end at   %s(%d:%2.2d elapsed time)\n", asctime(t2), minutes, seconds);
-				fclose(logFP);
-			}
+			struct tm *t2 = localtime(&t);
+			time_t duration = t - startTime;
+			Int minutes = duration/60;
+			Int seconds = duration%60;
+			fprintf(logFP, "Game end at   %s(%d:%2.2d elapsed time)\n", asctime(t2), minutes, seconds);
+			fclose(logFP);
 		}
 	}
 #endif

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -71,9 +71,10 @@ static const UnsignedInt desyncOffset = frameCountOffset + sizeof(UnsignedInt);
 static const UnsignedInt quitEarlyOffset = desyncOffset + sizeof(Bool);
 static const UnsignedInt disconOffset = quitEarlyOffset + sizeof(Bool);
 
-static void writeAtHeaderOffset(File* file, Int offset, const void* data, Int dataSize)
+static void writeAtOffset(File* file, Int offset, const void* data, Int dataSize)
 {
 	UnsignedInt fileSize = file->size();
+	DEBUG_ASSERTCRASH((UnsignedInt)(offset + dataSize) <= fileSize, ("writeAtOffset would exceed file size!"));
 	if (file->seek(offset, File::seekMode::START) == offset)
 	{
 		file->write(data, dataSize);
@@ -108,7 +109,7 @@ void RecorderClass::logGameStart(AsciiString options)
 
 	time(&startTime);
 	replay_time_t tmp = (replay_time_t)startTime;
-	writeAtHeaderOffset(m_file, startTimeOffset, &tmp, sizeof(tmp));
+	writeAtOffset(m_file, startTimeOffset, &tmp, sizeof(tmp));
 
 #if defined(RTS_DEBUG)
 	if (TheNetwork && TheGlobalData->m_saveStats)
@@ -142,7 +143,7 @@ void RecorderClass::logPlayerDisconnect(UnicodeString player, Int slot)
 	}
 	Bool flag = TRUE;
 	Int playerSlotDisconOffset = disconOffset + slot * sizeof(Bool);
-	writeAtHeaderOffset(m_file, playerSlotDisconOffset, &flag, sizeof(flag));
+	writeAtOffset(m_file, playerSlotDisconOffset, &flag, sizeof(flag));
 
 #if defined(RTS_DEBUG)
 	if (TheGlobalData->m_saveStats)
@@ -166,7 +167,7 @@ void RecorderClass::logCRCMismatch()
 		return;
 
 	Bool flag = TRUE;
-	writeAtHeaderOffset(m_file, desyncOffset, &flag, sizeof(flag));
+	writeAtOffset(m_file, desyncOffset, &flag, sizeof(flag));
 
 #if defined(RTS_DEBUG)
 	if (TheGlobalData->m_saveStats)
@@ -194,8 +195,8 @@ void RecorderClass::logGameEnd()
 	time(&t);
 	UnsignedInt frameCount = TheGameLogic->getFrame();
 	replay_time_t tmp = (replay_time_t)t;
-	writeAtHeaderOffset(m_file, endTimeOffset, &tmp, sizeof(tmp));
-	writeAtHeaderOffset(m_file, frameCountOffset, &frameCount, sizeof(frameCount));
+	writeAtOffset(m_file, endTimeOffset, &tmp, sizeof(tmp));
+	writeAtOffset(m_file, frameCountOffset, &frameCount, sizeof(frameCount));
 
 #if defined(RTS_DEBUG)
 	if (TheNetwork && TheGlobalData->m_saveStats)


### PR DESCRIPTION
Extract two helpers to reduce duplication across `logGameStart`, `logPlayerDisconnect`,
`logCRCMismatch`, and `logGameEnd`:

- `writeAtHeaderOffset`: handles the repeated seek → write → restore-position
  pattern used to update replay header fields (start time, end time, frame count,
  desync flag, disconnect flags)

- `openStatsLogFile`: handles the repeated `GetComputerName` + path construction +
  `fopen` pattern used for debug stats logging (RTS_DEBUG only)

No behavior change. Net reduction of ~70 lines per codebase.