### PR TITLE
fix(ini): Handle leading '+' sign in std::from_chars parsing

### DIFF
--- a/Core/GameEngine/Source/Common/INI/INI.cpp
+++ b/Core/GameEngine/Source/Common/INI/INI.cpp
@@ -1618,6 +1618,10 @@ void INI::initFromINIMulti( void *what, const MultiIniFieldParse& parseTableList
 template <typename Type>
 Type scanType(std::string_view token)
 {
+	// TheSuperHackers @info std::from_chars does not accept a leading '+' sign, so skip it to match the original sscanf behavior.
+	if (!token.empty() && token.front() == '+')
+		token.remove_prefix(1);
+
 	// TheSuperHackers @info std::from_chars cannot parse "-1" as uint32 so the result needs to be int64 for integers.
 	std::conditional_t<std::is_integral_v<Type>, Int64, Real> result{};
 	const auto [ptr, ec] = std::from_chars(token.data(), token.data() + token.size(), result);


### PR DESCRIPTION
## Summary

- `std::from_chars` does not accept a leading `+` sign, unlike the `sscanf` it replaced in #2532. This causes a crash when parsing INI values like `Percentage = +20` which previously worked.
- Skip the `+` prefix before calling `std::from_chars` to restore the original behavior.

## Test plan

- [ ] Verify INI fields with `+` prefix (e.g. `Percentage = +20`) no longer crash
- [ ] Verify negative values still parse correctly
- [ ] Verify unsigned values with `+` prefix parse correctly