### PR TITLE
style: Convert leading spaces to tabs in Core engine and libraries

### DIFF
--- a/Core/GameEngine/Include/Common/AudioEventInfo.h
+++ b/Core/GameEngine/Include/Common/AudioEventInfo.h
@@ -121,14 +121,14 @@ public:
 	AudioType m_soundType;	// This should be either Music, Streaming or SoundEffect
 
 
-  // DynamicAudioEventInfo interfacing functions
-  virtual Bool isLevelSpecific() const { return false; } ///< If true, this sound is only defined on the current level and can be deleted when that level ends
-  virtual DynamicAudioEventInfo * getDynamicAudioEventInfo() { return nullptr; }  ///< If this object is REALLY a DynamicAudioEventInfo, return a pointer to the derived class
-  virtual const DynamicAudioEventInfo * getDynamicAudioEventInfo() const { return nullptr; } ///< If this object is REALLY a DynamicAudioEventInfo, return a pointer to the derived class
+	// DynamicAudioEventInfo interfacing functions
+	virtual Bool isLevelSpecific() const { return false; } ///< If true, this sound is only defined on the current level and can be deleted when that level ends
+	virtual DynamicAudioEventInfo * getDynamicAudioEventInfo() { return nullptr; }  ///< If this object is REALLY a DynamicAudioEventInfo, return a pointer to the derived class
+	virtual const DynamicAudioEventInfo * getDynamicAudioEventInfo() const { return nullptr; } ///< If this object is REALLY a DynamicAudioEventInfo, return a pointer to the derived class
 
-  /// Is this a permanent sound? That is, if I start this sound up, will it ever end
-  /// "on its own" or only if I explicitly kill it?
-  Bool isPermanentSound() const { return BitIsSet( m_control, AC_LOOP ) && (m_loopCount == 0 );  }
+	/// Is this a permanent sound? That is, if I start this sound up, will it ever end
+	/// "on its own" or only if I explicitly kill it?
+	Bool isPermanentSound() const { return BitIsSet( m_control, AC_LOOP ) && (m_loopCount == 0 );  }
 
 	static const FieldParse m_audioEventInfo[];		///< the parse table for INI definition
 	const FieldParse *getFieldParse() const { return m_audioEventInfo; }

--- a/Core/GameEngine/Include/Common/AudioSettings.h
+++ b/Core/GameEngine/Include/Common/AudioSettings.h
@@ -60,7 +60,7 @@ struct AudioSettings
 	Int m_streamCount;
 	Bool m_use3DSoundRangeVolumeFade; // TheSuperHackers @feature Enables 3D sound range volume fade as originally intended
 	Real m_3DSoundRangeVolumeFadeExponent; // TheSuperHackers @feature Sets 3D sound range volume fade exponent for non-linear fade.
-	                                       // The higher the exponent, the sharper the decline at the max range.
+	// The higher the exponent, the sharper the decline at the max range.
 	Int m_globalMinRange;
 	Int m_globalMaxRange;
 	Int m_drawableAmbientFrames;
@@ -96,10 +96,10 @@ struct AudioSettings
 	Real m_microphoneMaxPercentageBetweenGroundAndCamera;
 
 	//Handles changing sound volume whenever the camera is close to the microphone.
-  Real m_zoomMinDistance;			//If we're closer than the minimum distance, then apply the full bonus no matter how close.
-  Real m_zoomMaxDistance;			//The maximum distance from microphone we need to be before benefiting from any bonus.
+	Real m_zoomMinDistance;			//If we're closer than the minimum distance, then apply the full bonus no matter how close.
+	Real m_zoomMaxDistance;			//The maximum distance from microphone we need to be before benefiting from any bonus.
 
-  //NOTE: The higher this value is, the lower normal sounds will be! If you specify a sound volume value of 25%, then sounds will play
+	//NOTE: The higher this value is, the lower normal sounds will be! If you specify a sound volume value of 25%, then sounds will play
 	//between 75% and 100%, not 100% to 125%!
-  Real m_zoomSoundVolumePercentageAmount;	//The amount of sound volume dedicated to zooming.
+	Real m_zoomSoundVolumePercentageAmount;	//The amount of sound volume dedicated to zooming.
 };

--- a/Core/GameEngine/Include/Common/DynamicAudioEventInfo.h
+++ b/Core/GameEngine/Include/Common/DynamicAudioEventInfo.h
@@ -39,115 +39,115 @@ class Xfer;
  *****************************************************************************/
 class DynamicAudioEventInfo : public AudioEventInfo
 {
-    // NOTE: This implementation would be a lot cleaner & safer if AudioEventInfo was better
-    // written. Ideally, AudioEventInfo would be a class, not a struct, and provide only
-    // "get" functions, not "set" functions except for the INI parsing. Then we could
-    // force people to go through our override...() functions.
+	// NOTE: This implementation would be a lot cleaner & safer if AudioEventInfo was better
+	// written. Ideally, AudioEventInfo would be a class, not a struct, and provide only
+	// "get" functions, not "set" functions except for the INI parsing. Then we could
+	// force people to go through our override...() functions.
 
-    MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( DynamicAudioEventInfo, "DynamicAudioEventInfo" )
+	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( DynamicAudioEventInfo, "DynamicAudioEventInfo" )
 
-  public:
-    DynamicAudioEventInfo();
-    explicit DynamicAudioEventInfo( const AudioEventInfo & baseInfo );
+public:
+	DynamicAudioEventInfo();
+	explicit DynamicAudioEventInfo( const AudioEventInfo & baseInfo );
 
-    // DynamicAudioEventInfo interfacing function overrides
-    virtual Bool isLevelSpecific() const override;
-    virtual DynamicAudioEventInfo * getDynamicAudioEventInfo() override;
-    virtual const DynamicAudioEventInfo * getDynamicAudioEventInfo() const override;
+	// DynamicAudioEventInfo interfacing function overrides
+	virtual Bool isLevelSpecific() const override;
+	virtual DynamicAudioEventInfo * getDynamicAudioEventInfo() override;
+	virtual const DynamicAudioEventInfo * getDynamicAudioEventInfo() const override;
 
-    // Change various fields from their default (INI) values
-    void overrideAudioName( const AsciiString & newName );
-    void overrideLoopFlag( Bool newLoopFlag );
-    void overrideLoopCount( Int newLoopCount );
-    void overrideVolume( Real newVolume );
-    void overrideMinVolume( Real newMinVolume );
-    void overrideMinRange( Real newMinRange );
-    void overrideMaxRange( Real newMaxRange );
-    void overridePriority( AudioPriority newPriority );
+	// Change various fields from their default (INI) values
+	void overrideAudioName( const AsciiString & newName );
+	void overrideLoopFlag( Bool newLoopFlag );
+	void overrideLoopCount( Int newLoopCount );
+	void overrideVolume( Real newVolume );
+	void overrideMinVolume( Real newMinVolume );
+	void overrideMinRange( Real newMinRange );
+	void overrideMaxRange( Real newMaxRange );
+	void overridePriority( AudioPriority newPriority );
 
-    // Query fields to see if they have been changed from their INI values
-    Bool wasAudioNameOverriden() const;
-    Bool wasLoopFlagOverriden() const;
-    Bool wasLoopCountOverriden() const;
-    Bool wasVolumeOverriden() const;
-    Bool wasMinVolumeOverriden() const;
-    Bool wasMinRangeOverriden() const;
-    Bool wasMaxRangeOverriden() const;
-    Bool wasPriorityOverriden() const;
+	// Query fields to see if they have been changed from their INI values
+	Bool wasAudioNameOverriden() const;
+	Bool wasLoopFlagOverriden() const;
+	Bool wasLoopCountOverriden() const;
+	Bool wasVolumeOverriden() const;
+	Bool wasMinVolumeOverriden() const;
+	Bool wasMinRangeOverriden() const;
+	Bool wasMaxRangeOverriden() const;
+	Bool wasPriorityOverriden() const;
 
-    // Get the name of the audio event which this was based off of
-    const AsciiString & getOriginalName() const;
+	// Get the name of the audio event which this was based off of
+	const AsciiString & getOriginalName() const;
 
-    // Transfer all overridden fields except the customized name
-    void xferNoName( Xfer * xfer );
+	// Transfer all overridden fields except the customized name
+	void xferNoName( Xfer * xfer );
 
-  private:
-    // List of fields we can override
-    enum OverriddenFields CPP_11(: Int)
-    {
-      OVERRIDE_NAME = 0,
-      OVERRIDE_LOOP_FLAG,
-      OVERRIDE_LOOP_COUNT,
-      OVERRIDE_VOLUME,
-      OVERRIDE_MIN_VOLUME,
-      OVERRIDE_MIN_RANGE,
-      OVERRIDE_MAX_RANGE,
-      OVERRIDE_PRIORITY,
+private:
+	// List of fields we can override
+	enum OverriddenFields CPP_11(: Int)
+	{
+		OVERRIDE_NAME = 0,
+		OVERRIDE_LOOP_FLAG,
+		OVERRIDE_LOOP_COUNT,
+		OVERRIDE_VOLUME,
+		OVERRIDE_MIN_VOLUME,
+		OVERRIDE_MIN_RANGE,
+		OVERRIDE_MAX_RANGE,
+		OVERRIDE_PRIORITY,
 
-      OVERRIDE_COUNT  // Keep list
-    };
-    // Warning: update xferNoName if you modify the enum list!
+		OVERRIDE_COUNT  // Keep list
+	};
+	// Warning: update xferNoName if you modify the enum list!
 
-    BitFlags< OVERRIDE_COUNT > m_overriddenFields;
+	BitFlags< OVERRIDE_COUNT > m_overriddenFields;
 
-    // Retain the original name so we can look it up later
-    AsciiString m_originalName;
+	// Retain the original name so we can look it up later
+	AsciiString m_originalName;
 };
 
 /** Query: was overrideAudioName called? */
 inline Bool DynamicAudioEventInfo::wasAudioNameOverriden() const
 {
-  return m_overriddenFields.test( OVERRIDE_NAME );
+	return m_overriddenFields.test( OVERRIDE_NAME );
 }
 
 /** Query: was overrideLoopFlag called? */
 inline Bool DynamicAudioEventInfo::wasLoopFlagOverriden() const
 {
-  return m_overriddenFields.test( OVERRIDE_LOOP_FLAG );
+	return m_overriddenFields.test( OVERRIDE_LOOP_FLAG );
 }
 
 /** Query: was overrideLoopCount called? */
 inline Bool DynamicAudioEventInfo::wasLoopCountOverriden() const
 {
-  return m_overriddenFields.test( OVERRIDE_LOOP_COUNT );
+	return m_overriddenFields.test( OVERRIDE_LOOP_COUNT );
 }
 
 /** Query: was overrideVolume called? */
 inline Bool DynamicAudioEventInfo::wasVolumeOverriden() const
 {
-  return m_overriddenFields.test( OVERRIDE_VOLUME );
+	return m_overriddenFields.test( OVERRIDE_VOLUME );
 }
 
 /** Query: was overrideMinVolume called? */
 inline Bool DynamicAudioEventInfo::wasMinVolumeOverriden() const
 {
-  return m_overriddenFields.test( OVERRIDE_MIN_VOLUME );
+	return m_overriddenFields.test( OVERRIDE_MIN_VOLUME );
 }
 
 /** Query: was overrideMinRange called? */
 inline Bool DynamicAudioEventInfo::wasMinRangeOverriden() const
 {
-  return m_overriddenFields.test( OVERRIDE_MIN_RANGE );
+	return m_overriddenFields.test( OVERRIDE_MIN_RANGE );
 }
 
 /** Query: was overrideMaxRange called? */
 inline Bool DynamicAudioEventInfo::wasMaxRangeOverriden() const
 {
-  return m_overriddenFields.test( OVERRIDE_MAX_RANGE );
+	return m_overriddenFields.test( OVERRIDE_MAX_RANGE );
 }
 
 /** Query: was overridePriority called? */
 inline Bool DynamicAudioEventInfo::wasPriorityOverriden() const
 {
-  return m_overriddenFields.test( OVERRIDE_PRIORITY );
+	return m_overriddenFields.test( OVERRIDE_PRIORITY );
 }

--- a/Core/GameEngine/Include/Common/FileSystem.h
+++ b/Core/GameEngine/Include/Common/FileSystem.h
@@ -137,8 +137,8 @@ struct FileInfo {
 //===============================
 class FileSystem : public SubsystemInterface
 {
-  FileSystem(const FileSystem&);
-  FileSystem& operator=(const FileSystem&);
+	FileSystem(const FileSystem&);
+	FileSystem& operator=(const FileSystem&);
 
 public:
 	FileSystem();

--- a/Core/GameEngine/Include/Common/GameAudio.h
+++ b/Core/GameEngine/Include/Common/GameAudio.h
@@ -243,10 +243,10 @@ class AudioManager : public SubsystemInterface
 		// on zoom.
 		virtual void set3DVolumeAdjustment( Real volumeAdjustment );
 
-    virtual Bool has3DSensitiveStreamsPlaying() const = 0;
+	virtual Bool has3DSensitiveStreamsPlaying() const = 0;
 
- 		virtual void *getHandleForBink() = 0;
- 		virtual void releaseHandleForBink() = 0;
+	virtual void *getHandleForBink() = 0;
+	virtual void releaseHandleForBink() = 0;
 
 		// this function will play an audio event rts by loading it into memory. It should not be used
 		// by anything except for the load screens.
@@ -262,7 +262,7 @@ class AudioManager : public SubsystemInterface
 		virtual void processRequestList();
 
 		virtual AudioEventInfo *newAudioEventInfo( AsciiString newEventName );
-    virtual void addAudioEventInfo( AudioEventInfo * newEventInfo );
+	virtual void addAudioEventInfo( AudioEventInfo * newEventInfo );
 		virtual AudioEventInfo *findAudioEventInfo( AsciiString eventName ) const;
 
 		const AudioSettings *getAudioSettings() const;
@@ -303,7 +303,7 @@ class AudioManager : public SubsystemInterface
 
 		// For Worldbuilder, to build lists from which to select
 		virtual void findAllAudioEventsOfType( AudioType audioType, std::vector<AudioEventInfo*>& allEvents );
-    virtual const AudioEventInfoHash & getAllAudioEvents() const { return m_allAudioEventInfo; }
+	virtual const AudioEventInfoHash & getAllAudioEvents() const { return m_allAudioEventInfo; }
 
 		Real getZoomVolume() const { return m_zoomVolume; }
 	protected:
@@ -323,10 +323,10 @@ class AudioManager : public SubsystemInterface
 		// For tracking purposes
 		virtual AudioHandle allocateNewHandle();
 
-    // Remove all AudioEventInfo's with the m_isLevelSpecific flag
-    virtual void removeLevelSpecificAudioEventInfos();
+	// Remove all AudioEventInfo's with the m_isLevelSpecific flag
+	virtual void removeLevelSpecificAudioEventInfos();
 
-    void removeAllAudioRequests();
+	void removeAllAudioRequests();
 
 	protected:
 		AudioSettings *m_audioSettings;

--- a/Core/GameEngine/Include/Common/INI.h
+++ b/Core/GameEngine/Include/Common/INI.h
@@ -160,8 +160,8 @@ typedef void (*BuildMultiIniFieldProc)(MultiIniFieldParse& p);
 //-------------------------------------------------------------------------------------------------
 class INI
 {
-  INI(const INI&);
-  INI& operator=(const INI&);
+	INI(const INI&);
+	INI& operator=(const INI&);
 
 public:
 
@@ -219,7 +219,7 @@ public:
 	static void parseObjectCreationListDefinition( INI* ini );
 	static void parseMultiplayerSettingsDefinition( INI* ini );
 	static void parseMultiplayerColorDefinition( INI* ini );
-  static void parseMultiplayerStartingMoneyChoiceDefinition( INI* ini );
+	static void parseMultiplayerStartingMoneyChoiceDefinition( INI* ini );
 	static void parseOnlineChatColorDefinition( INI* ini );
 	static void parseMapCacheDefinition( INI* ini );
 	static void parseVideoDefinition( INI* ini );

--- a/Core/GameEngine/Include/Common/MapObject.h
+++ b/Core/GameEngine/Include/Common/MapObject.h
@@ -39,10 +39,10 @@ class WorldHeightMapInterfaceClass
 {
 public:
 
-  virtual Int getBorderSize() = 0;
-  virtual Real getSeismicZVelocity(Int xIndex, Int yIndex) const = 0;
-  virtual void setSeismicZVelocity(Int xIndex, Int yIndex, Real value) = 0;
-  virtual Real getBilinearSampleSeismicZVelocity( Int x, Int y) = 0;
+	virtual Int getBorderSize() = 0;
+	virtual Real getSeismicZVelocity(Int xIndex, Int yIndex) const = 0;
+	virtual void setSeismicZVelocity(Int xIndex, Int yIndex, Real value) = 0;
+	virtual Real getBilinearSampleSeismicZVelocity( Int x, Int y) = 0;
 
 };
 

--- a/Core/GameEngine/Include/Common/ObjectStatusTypes.h
+++ b/Core/GameEngine/Include/Common/ObjectStatusTypes.h
@@ -83,7 +83,7 @@ enum ObjectStatusTypes CPP_11(: Int)
 	OBJECT_STATUS_RIDER7,
 	OBJECT_STATUS_RIDER8,
 	OBJECT_STATUS_FAERIE_FIRE,			///< Anyone shooting at you shoots faster than normal
-  OBJECT_STATUS_MISSILE_KILLING_SELF, ///< Object (likely a missile or bomb) is *BUSTING* its way through the *BUNKER*, building or ground, awaiting death at the bottom.
+	OBJECT_STATUS_MISSILE_KILLING_SELF, ///< Object (likely a missile or bomb) is *BUSTING* its way through the *BUNKER*, building or ground, awaiting death at the bottom.
 	OBJECT_STATUS_REASSIGN_PARKING,			///< Jet is trying to get a better parking assignment.
 	OBJECT_STATUS_BOOBY_TRAPPED,				///< We need to know we have a booby trap on us so we can detonate it from many different code segments
 	OBJECT_STATUS_IMMOBILE,							///< Do not move!

--- a/Core/GameEngine/Include/Common/Radar.h
+++ b/Core/GameEngine/Include/Common/Radar.h
@@ -185,7 +185,7 @@ public:
 	Bool getLastEventLoc( Coord3D *eventPos );							///< get last event loc (if any)
 	void tryUnderAttackEvent( const Object *obj );					///< try to make an "under attack" event if it's the proper time
 	void tryInfiltrationEvent( const Object *obj );					///< try to make an "infiltration" event if it's the proper time
- 	Bool tryEvent( RadarEventType event, const Coord3D *pos );	///< try to make a "stealth" event
+	Bool tryEvent( RadarEventType event, const Coord3D *pos );	///< try to make a "stealth" event
 
 	// adding and removing objects from the radar
 	virtual Bool addObject( Object *obj ); ///< add object to radar

--- a/Core/GameEngine/Include/Common/UserPreferences.h
+++ b/Core/GameEngine/Include/Common/UserPreferences.h
@@ -89,8 +89,8 @@ public:
 	Int getNumRemoteIPs();					// convenience function
 	UnicodeString getRemoteIPEntry(Int i);	// convenience function
 
-  Bool getSuperweaponRestricted() const;
-  Money getStartingCash() const;
-  void setSuperweaponRestricted( Bool superweaponRestricted);
-  void setStartingCash( const Money & startingCash );
+	Bool getSuperweaponRestricted() const;
+	Money getStartingCash() const;
+	void setSuperweaponRestricted( Bool superweaponRestricted);
+	void setStartingCash( const Money & startingCash );
 };

--- a/Core/GameEngine/Include/Common/crc.h
+++ b/Core/GameEngine/Include/Common/crc.h
@@ -45,10 +45,10 @@ public:
 	UnsignedInt get();
 
 #if (defined(_MSC_VER) && _MSC_VER < 1300) && RETAIL_COMPATIBLE_CRC
-  void set( UnsignedInt v )
-  {
-    crc = v;
-  }
+	void set( UnsignedInt v )
+	{
+		crc = v;
+	}
 #endif
 
 private:
@@ -65,70 +65,70 @@ class CRC
 public:
 	CRC() { crc=0; }
 
-  /// Compute the CRC for a buffer, added into current CRC
+	/// Compute the CRC for a buffer, added into current CRC
 	__forceinline void computeCRC( const void *buf, Int len )
-  {
-    if (!buf||len<1)
-      return;
+	{
+		if (!buf||len<1)
+		return;
 
 #if !(defined(_MSC_VER) && _MSC_VER < 1300)
-    // C++ version left in for reference purposes
-	  for (UnsignedByte *uintPtr=(UnsignedByte *)buf;len>0;len--,uintPtr++)
-    {
-    	int hibit;
-    	if (crc & 0x80000000)
-      {
-		    hibit = 1;
-	    }
-      else
-      {
-		    hibit = 0;
-	    }
+		// C++ version left in for reference purposes
+		for (UnsignedByte *uintPtr=(UnsignedByte *)buf;len>0;len--,uintPtr++)
+		{
+			int hibit;
+			if (crc & 0x80000000)
+			{
+				hibit = 1;
+			}
+			else
+			{
+				hibit = 0;
+			}
 
-	    crc <<= 1;
-	    crc += *uintPtr;
-	    crc += hibit;
-    }
+			crc <<= 1;
+			crc += *uintPtr;
+			crc += hibit;
+		}
 #else
-    // ASM version, verified by comparing resulting data with C++ version data
-    unsigned *crcPtr=&crc;
-    _asm
-    {
-      mov esi,[buf]
-      mov ecx,[len]
-      dec ecx
+		// ASM version, verified by comparing resulting data with C++ version data
+		unsigned *crcPtr=&crc;
+		_asm
+		{
+			mov esi,[buf]
+			mov ecx,[len]
+			dec ecx
       mov edi,[crcPtr]
-      mov ebx,dword ptr [edi]
-      xor eax,eax
+			mov ebx,dword ptr [edi]
+			xor eax,eax
     lp:
       mov al,byte ptr [esi]
-      shl ebx,1
+			shl ebx,1
       inc esi
       adc ebx,eax
       dec ecx
       jns lp
       mov dword ptr [edi],ebx
-    };
+		};
 #endif
-  }
+	}
 
-  /// Clears the CRC to 0
+	/// Clears the CRC to 0
 	void clear()
-  {
-    crc = 0;
-  }
+	{
+		crc = 0;
+	}
 
-  ///< Get the combined CRC
+	///< Get the combined CRC
 	UnsignedInt get() const
-  {
-    return crc;
-  }
+	{
+		return crc;
+	}
 
 #if (defined(_MSC_VER) && _MSC_VER < 1300) && RETAIL_COMPATIBLE_CRC
-  void set( UnsignedInt v )
-  {
-    crc = v;
-  }
+	void set( UnsignedInt v )
+	{
+		crc = v;
+	}
 #endif
 
 private:

--- a/Core/GameEngine/Include/Common/file.h
+++ b/Core/GameEngine/Include/Common/file.h
@@ -141,37 +141,37 @@ class File : public MemoryPoolObject
 		virtual void	close();																			///< Close the file !!! File object no longer valid after this call !!!
 
 		virtual Int		read( void *buffer, Int bytes ) = 0 ;						/**< Read the specified number of bytes from the file in to the
-																																			  *  memory pointed at by buffer. Returns the number of bytes read.
-																																			  *  Returns -1 if an error occurred.
-																																			  */
+	*  memory pointed at by buffer. Returns the number of bytes read.
+	*  Returns -1 if an error occurred.
+	*/
 		virtual Int		readChar() = 0 ;											/**< Read a character from the file
-																																			  *  Returns the character converted to an integer.
-																																			  *  Returns EOF if an error occurred.
-																																			  */
+	*  Returns the character converted to an integer.
+	*  Returns EOF if an error occurred.
+	*/
 		virtual Int		readWideChar() = 0 ;										/**< Read a wide character from the file
-																																			  *  Returns the wide character converted to an integer.
-																																			  *  Returns wide EOF if an error occurred.
-																																			  */
+	*  Returns the wide character converted to an integer.
+	*  Returns wide EOF if an error occurred.
+	*/
 		virtual Int		write( const void *buffer, Int bytes ) = 0 ;						/**< Write the specified number of bytes from the
-																																			  *	 memory pointed at by buffer to the file. Returns the number of bytes written.
-																																			  *	 Returns -1 if an error occurred.
-																																			  */
+	*	 memory pointed at by buffer to the file. Returns the number of bytes written.
+	*	 Returns -1 if an error occurred.
+	*/
 		virtual Int		writeFormat( const Char* format, ... ) = 0 ;						/**< Write an unterminated formatted string to the file
-																																			  *	 Returns the number of bytes written.
-																																			  *	 Returns -1 if an error occurred.
-																																			  */
+	*	 Returns the number of bytes written.
+	*	 Returns -1 if an error occurred.
+	*/
 		virtual Int		writeFormat( const WideChar* format, ... ) = 0 ;						/**< Write an unterminated formatted wide character string to the file
-																																			  *	 Returns the number of bytes written.
-																																			  *	 Returns -1 if an error occurred.
-																																			  */
+	*	 Returns the number of bytes written.
+	*	 Returns -1 if an error occurred.
+	*/
 		virtual Int		writeChar( const Char* character ) = 0 ;						/**< Write a character to the file
-																																			  *	 Returns a copy of the character written.
-																																			  *	 Returns EOF if an error occurred.
-																																			  */
+	*	 Returns a copy of the character written.
+	*	 Returns EOF if an error occurred.
+	*/
 		virtual Int		writeChar( const WideChar* character ) = 0 ;						/**< Write a wide character to the file
-																																			  *	 Returns a copy of the wide character written.
-																																			  *	 Returns wide EOF if an error occurred.
-																																			  */
+	*	 Returns a copy of the wide character written.
+	*	 Returns wide EOF if an error occurred.
+	*/
 		virtual Int		seek( Int bytes, seekMode mode = CURRENT ) = 0;	/**< Sets the file position of the next read/write operation. Returns the new file
 																																				*  position as the number of bytes from the start of the file.
 																																				*  Returns -1 if an error occurred.

--- a/Core/GameEngine/Include/Common/simpleplayer.h
+++ b/Core/GameEngine/Include/Common/simpleplayer.h
@@ -25,8 +25,8 @@
 // caller to unprepare and free
 //
 typedef struct WAVEHDR_LIST {
-    LPWAVEHDR           pwh;
-    struct WAVEHDR_LIST *next;
+	LPWAVEHDR           pwh;
+	struct WAVEHDR_LIST *next;
 }   WAVEHDR_LIST;
 
 #define SIMPLE_PLAYER_OPEN_EVENT  _T( "45ab58e0-382e-4d1c-ac50-88a5f9601851" )
@@ -36,27 +36,27 @@ typedef struct WAVEHDR_LIST {
 class CSimplePlayer : public IWMReaderCallback
 {
 public:
-    CSimplePlayer( HRESULT* phr );
-    ~CSimplePlayer();
+	CSimplePlayer( HRESULT* phr );
+	~CSimplePlayer();
 
-    virtual HRESULT Play( LPCWSTR pszUrl, DWORD dwSecDuration, HANDLE hCompletionEvent, HRESULT *phrCompletion );
+	virtual HRESULT Play( LPCWSTR pszUrl, DWORD dwSecDuration, HANDLE hCompletionEvent, HRESULT *phrCompletion );
 
 //
 // IUnknown Implemenation
 //
 public:
-    virtual HRESULT STDMETHODCALLTYPE QueryInterface(
-        REFIID riid,
-        void **ppvObject );
+	virtual HRESULT STDMETHODCALLTYPE QueryInterface(
+		REFIID riid,
+		void **ppvObject );
 
-    virtual ULONG STDMETHODCALLTYPE AddRef();
-    virtual ULONG STDMETHODCALLTYPE Release();
+	virtual ULONG STDMETHODCALLTYPE AddRef();
+	virtual ULONG STDMETHODCALLTYPE Release();
 
 //
 // IWMReaderCallback Implemenation
 //
 public:
-    virtual HRESULT STDMETHODCALLTYPE OnSample(
+	virtual HRESULT STDMETHODCALLTYPE OnSample(
         /* [in] */ DWORD dwOutputNum,
         /* [in] */ QWORD cnsSampleTime,
         /* [in] */ QWORD cnsSampleDuration,
@@ -64,7 +64,7 @@ public:
         /* [in] */ INSSBuffer __RPC_FAR *pSample,
         /* [in] */ void __RPC_FAR *pvContext);
 
-    virtual HRESULT STDMETHODCALLTYPE OnStatus(
+	virtual HRESULT STDMETHODCALLTYPE OnStatus(
         /* [in] */ WMT_STATUS Status,
         /* [in] */ HRESULT hr,
         /* [in] */ WMT_ATTR_DATATYPE dwType,
@@ -76,44 +76,44 @@ public:
 //
 protected:
 
-    HRESULT Close();
+	HRESULT Close();
 
-    void OnWaveOutMsg( UINT uMsg, DWORD dwParam1, DWORD dwParam2 );
+	void OnWaveOutMsg( UINT uMsg, DWORD dwParam1, DWORD dwParam2 );
 
-    static void CALLBACK WaveProc(
-                          HWAVEOUT hwo,
-                          UINT uMsg,
-                          DWORD dwInstance,
-                          DWORD dwParam1,
-                          DWORD dwParam2 );
+	static void CALLBACK WaveProc(
+		HWAVEOUT hwo,
+		UINT uMsg,
+		DWORD dwInstance,
+		DWORD dwParam1,
+		DWORD dwParam2 );
 
-    HRESULT AddWaveHeader( LPWAVEHDR pwh );
-    void    RemoveWaveHeaders();
+	HRESULT AddWaveHeader( LPWAVEHDR pwh );
+	void    RemoveWaveHeaders();
 
-    CRITICAL_SECTION    m_CriSec;
-    WAVEHDR_LIST       *m_whdrHead;
+	CRITICAL_SECTION    m_CriSec;
+	WAVEHDR_LIST       *m_whdrHead;
 
-    LONG    m_cRef;
-    LONG    m_cBuffersOutstanding;
-    BOOL    m_fEof;
-    HANDLE  m_hCompletionEvent;
+	LONG    m_cRef;
+	LONG    m_cBuffersOutstanding;
+	BOOL    m_fEof;
+	HANDLE  m_hCompletionEvent;
 
-    IWMReader *m_pReader;
-    IWMHeaderInfo *m_pHeader;
-    HWAVEOUT m_hwo;
+	IWMReader *m_pReader;
+	IWMHeaderInfo *m_pHeader;
+	HWAVEOUT m_hwo;
 
-    HRESULT *m_phrCompletion;
+	HRESULT *m_phrCompletion;
 
-    HRESULT m_hrOpen;
-    HANDLE m_hOpenEvent;
-    HANDLE m_hCloseEvent;
+	HRESULT m_hrOpen;
+	HANDLE m_hOpenEvent;
+	HANDLE m_hCloseEvent;
 
-    union
-    {
-        WAVEFORMATEX m_wfx;
-        BYTE m_WfxBuf[1024];
-    };
+	union
+	{
+		WAVEFORMATEX m_wfx;
+		BYTE m_WfxBuf[1024];
+	};
 
-    LPWSTR  m_pszUrl;
+	LPWSTR  m_pszUrl;
 
 };

--- a/Core/GameEngine/Include/GameClient/Color.h
+++ b/Core/GameEngine/Include/GameClient/Color.h
@@ -69,10 +69,10 @@ inline Color GameMakeColor( UnsignedByte red, UnsignedByte green, UnsignedByte b
 }
 
 extern void GameGetColorComponents( Color color,
-																	  UnsignedByte *red,
-																	  UnsignedByte *green,
-																	  UnsignedByte *blue,
-																	  UnsignedByte *alpha );
+	UnsignedByte *red,
+	UnsignedByte *green,
+	UnsignedByte *blue,
+	UnsignedByte *alpha );
 
 // Put on ice until later - M Lorenzen
 //extern void GameGetColorComponentsWithCheatSpy( Color color,

--- a/Core/GameEngine/Include/GameClient/GameWindow.h
+++ b/Core/GameEngine/Include/GameClient/GameWindow.h
@@ -81,7 +81,7 @@ enum WindowMsgHandledType CPP_11(: Int) { MSG_IGNORED, MSG_HANDLED };
 // callback types -------------------------------------------------------------
 typedef void (*GameWinMsgBoxFunc)(); //used for the Message box callbacks.
 typedef void (*GameWinDrawFunc)( GameWindow *,
-																 WinInstanceData * );
+	WinInstanceData * );
 typedef void (*GameWinTooltipFunc)( GameWindow *,
 																		WinInstanceData *,
 																		UnsignedInt );
@@ -90,9 +90,9 @@ typedef WindowMsgHandledType (*GameWinInputFunc)( GameWindow *,
 																	WindowMsgData,
 																	WindowMsgData );
 typedef WindowMsgHandledType (*GameWinSystemFunc)( GameWindow *,
-																	 UnsignedInt,
-																	 WindowMsgData,
-																	 WindowMsgData );
+	UnsignedInt,
+	WindowMsgData,
+	WindowMsgData );
 
 enum
 {
@@ -204,9 +204,9 @@ enum
 struct WindowMessageBoxData
 {
 	GameWinMsgBoxFunc yesCallback; ///<Function pointer to the Yes Button Callback
-  GameWinMsgBoxFunc noCallback;///<Function pointer to the No Button Callback
-  GameWinMsgBoxFunc okCallback;///<Function pointer to the Ok Button Callback
-  GameWinMsgBoxFunc cancelCallback;///<Function pointer to the Cancel Button Callback
+	GameWinMsgBoxFunc noCallback;///<Function pointer to the No Button Callback
+	GameWinMsgBoxFunc okCallback;///<Function pointer to the Ok Button Callback
+	GameWinMsgBoxFunc cancelCallback;///<Function pointer to the Cancel Button Callback
 };
 
 // GameWindowEditData ---------------------------------------------------------
@@ -250,8 +250,8 @@ public:
 	Int winActivate();  ///< pop window to top of list and activate
 	Int winBringToTop();  ///< bring this window to the top of the win list
 	Int winEnable( Bool enable );  /**< enable/disable a window, a disbled
-																 window can be seen but accepts no input */
-  Bool winGetEnabled(); ///< Is window enabled?
+	window can be seen but accepts no input */
+	Bool winGetEnabled(); ///< Is window enabled?
 	Int winHide( Bool hide );  ///< hide/unhide a window
 	Bool winIsHidden();  ///< is this window hidden/
 	UnsignedInt winSetStatus( UnsignedInt status );  ///< set status bits
@@ -297,8 +297,8 @@ public:
 	void winGetDrawOffset( Int *x, Int *y );  ///< get draw offset
 	void winSetHiliteState( Bool state );  ///< set hilite state
 	void winSetTooltip( UnicodeString tip );  ///< set tooltip text
-  Int  getTooltipDelay() { return m_instData.m_tooltipDelay; } ///< get tooltip delay
-  void setTooltipDelay(Int delay) { m_instData.m_tooltipDelay = delay; } ///< set tooltip delay
+	Int  getTooltipDelay() { return m_instData.m_tooltipDelay; } ///< get tooltip delay
+	void setTooltipDelay(Int delay) { m_instData.m_tooltipDelay = delay; } ///< set tooltip delay
 
 	//-----------------------------------------------------------------------------
 	// text methods
@@ -352,8 +352,8 @@ public:
 	Int winSetDrawFunc( GameWinDrawFunc draw );  ///< set draw
 	Int winSetTooltipFunc( GameWinTooltipFunc tooltip );  ///< set tooltip
 	Int winSetCallbacks( GameWinInputFunc input,
-											 GameWinDrawFunc draw,
-											 GameWinTooltipFunc tooltip );  ///< set draw, input, tooltip
+		GameWinDrawFunc draw,
+		GameWinTooltipFunc tooltip );  ///< set draw, input, tooltip
 
 	// pick correlation ---------------------------------------------------------
 	Bool winPointInWindow( Int x, Int y );  /**is point inside this window?
@@ -367,7 +367,7 @@ public:
 	the enabled status of the child */
 	GameWindow *winPointInAnyChild( Int x, Int y, Bool ignoreHidden, Bool ignoreEnableCheck = FALSE );
 
-  // get the callbacks for a window -------------------------------------------
+	// get the callbacks for a window -------------------------------------------
 	GameWinInputFunc		winGetInputFunc();
 	GameWinSystemFunc		winGetSystemFunc();
 	GameWinDrawFunc			winGetDrawFunc();
@@ -405,7 +405,7 @@ protected:
 	WinInstanceData m_instData;					// Class data, varies by window type
 	void *m_inputData;								  // Client data
 
-  // user defined callbacks
+	// user defined callbacks
 	GameWinInputFunc			m_input;					///< callback for input
 	GameWinSystemFunc			m_system;					///< callback for system messages
 	GameWinDrawFunc				m_draw;						///< callback for drawing
@@ -485,19 +485,19 @@ extern void GameWinDefaultDraw( GameWindow *window,
 																WinInstanceData *instData );
 extern WindowMsgHandledType GameWinDefaultSystem( GameWindow *window,
 																	UnsignedInt msg,
-																  WindowMsgData mData1,
+	WindowMsgData mData1,
 																	WindowMsgData mData2 );
 extern WindowMsgHandledType GameWinDefaultInput( GameWindow *window,
-																 UnsignedInt msg,
-																 WindowMsgData mData1,
-																 WindowMsgData mData2 );
+	UnsignedInt msg,
+	WindowMsgData mData1,
+	WindowMsgData mData2 );
 extern WindowMsgHandledType GameWinBlockInput( GameWindow *window,
-																 UnsignedInt msg,
-																 WindowMsgData mData1,
-																 WindowMsgData mData2 );
+	UnsignedInt msg,
+	WindowMsgData mData1,
+	WindowMsgData mData2 );
 extern void GameWinDefaultTooltip( GameWindow *window,
-																	 WinInstanceData *instData,
-																	 UnsignedInt mouse );
+	WinInstanceData *instData,
+	UnsignedInt mouse );
 
 extern const char *const WindowStatusNames[];
 extern const char *const WindowStyleNames[];

--- a/Core/GameEngine/Include/GameClient/Keyboard.h
+++ b/Core/GameEngine/Include/GameClient/Keyboard.h
@@ -99,10 +99,10 @@ public:
 
 	// you may extend the functionality of these for your device
 	virtual void init() override;							/**< initialize the keyboard, only extend this
-																							 functionality, do not replace */
+	functionality, do not replace */
 	virtual void reset() override;							///< Reset keyboard system
 	virtual void update() override;						/**< gather current state of all keys, extend
-																							 this functionality, do not replace */
+	this functionality, do not replace */
 	virtual Bool getCapsState() = 0;  ///< get state of caps lock key, return TRUE if down
 
 	virtual void createStreamMessages();  /**< given state of device, create
@@ -119,7 +119,7 @@ public:
 	KeyboardIO *getFirstKey();							///< get first key ready for processing
 	KeyboardIO *findKey( KeyDefType key, KeyboardIO::StatusType status ); ///< get key ready for processing, can return nullptr
 	void setKeyStatusData( KeyDefType key,
-												 KeyboardIO::StatusType data );   ///< set key status
+		KeyboardIO::StatusType data );   ///< set key status
 	WideChar translateKey( WideChar keyCode );		///< translate key code to printable UNICODE char
 	WideChar getPrintableKey( KeyDefType key, Int state );
 	enum { MAX_KEY_STATES = 3};

--- a/Core/GameEngine/Include/GameClient/Line2D.h
+++ b/Core/GameEngine/Include/GameClient/Line2D.h
@@ -47,8 +47,8 @@ extern Bool IntersectLine2D( const Coord2D *a, const Coord2D *b,
 ///< PointInsideRect2D will return true iff inputPoint lies iside of the rectangle specified
 ///< by bl, tl, br, tr.
 extern Bool PointInsideRect2D( const Coord2D *bl, const Coord2D *tl,
-															 const Coord2D *br, const Coord2D *tr,
-															 const Coord2D *inputPoint);
+	const Coord2D *br, const Coord2D *tr,
+	const Coord2D *inputPoint);
 
 ///< Checks if a point is inside a perfect rectangle (top left and bottom right)
 extern Bool Coord3DInsideRect2D( const Coord3D *inputPoint, const Coord2D *tl, const Coord2D *br );
@@ -60,22 +60,22 @@ extern void ScaleRect2D( Coord2D *tl, Coord2D *br, Real scaleFactor );
 by bl, tl, br, tr. It does not actually consider the Z value, it is merely a convenience function
 for calling PointInsideRect2D */
 extern Bool PointInsideRect3D( const Coord3D *bl, const Coord3D *tl,
-															 const Coord3D *br, const Coord3D *tr,
-															 const Coord3D *inputPoint);
+	const Coord3D *br, const Coord3D *tr,
+	const Coord3D *inputPoint);
 
 
 ///< This function will take the ptToTest and will perform even-odd checking against the area.
 ///< If the area is not closed, it will be closed for this check.
 extern Bool PointInsideArea2D( const Coord2D *ptToTest,
-															 const Coord2D *area,
-															 Int numPointsInArea);
+	const Coord2D *area,
+	Int numPointsInArea);
 
 ///< This function will take the ptToTest and will perform even-odd checking against the area.
 ///< The area and the ptToTest will be flattened first, so a 2-D check will be sufficient.
 ///< This function is only for convenience so that points do not need to first be flattened.
 extern Bool PointInsideArea2D( const Coord3D *ptToTest,
-															 const Coord3D *area,
-															 Int numPointsInArea);
+	const Coord3D *area,
+	Int numPointsInArea);
 
 ///< This function will find the shortest distance between the given segment (ab) and the pt.
 ///< It will also give the intersection points on the segment (ab) if desired.

--- a/Core/GameEngine/Include/GameClient/MapUtil.h
+++ b/Core/GameEngine/Include/GameClient/MapUtil.h
@@ -146,5 +146,5 @@ AsciiString getDefaultOfficialMap();
 Bool isOfficialMap( AsciiString mapName );
 Bool parseMapPreviewChunk(DataChunkInput &file, DataChunkInfo *info, void *userData);
 void findDrawPositions( Int startX, Int startY, Int width, Int height, Region3D extent,
-															 ICoord2D *ul, ICoord2D *lr );
+	ICoord2D *ul, ICoord2D *lr );
 Bool WouldMapTransfer( const AsciiString& mapName );

--- a/Core/GameEngine/Include/GameClient/Mouse.h
+++ b/Core/GameEngine/Include/GameClient/Mouse.h
@@ -103,7 +103,7 @@ struct MouseIO
 	UnsignedInt time;	///< The time that this message was posted.
 
 	Int wheelPos;  /**< mouse wheel position, 0 is no event, + is up/away from
-								 user while - is down/toward user */
+	user while - is down/toward user */
 	ICoord2D deltaPos;  ///< overall change in mouse pointer this frame
 
 	MouseButtonState leftState;					// button state: None (no event), Up, Down, DoubleClick
@@ -278,8 +278,8 @@ public:
 	virtual void initCursorResources()=0;	///< needed so Win32 cursors can load resources before D3D device created.
 
 	virtual void createStreamMessages();  /**< given state of device, create
-																									 messages and put them on the
-																									 stream for the raw state. */
+	messages and put them on the
+	stream for the raw state. */
 
 	virtual void draw() override;													///< draw the mouse
 	virtual void setPosition( Int x, Int y );						///< set the mouse position
@@ -293,8 +293,8 @@ public:
 	// access methods for the mouse data
 	const MouseIO *getMouseStatus() { return &m_currMouse; }							///< get current mouse status
 
-  Int  getCursorTooltipDelay() { return m_tooltipDelay; }
-  void setCursorTooltipDelay(Int delay) { m_tooltipDelay = delay; }
+	Int  getCursorTooltipDelay() { return m_tooltipDelay; }
+	void setCursorTooltipDelay(Int delay) { m_tooltipDelay = delay; }
 
 	void setCursorTooltip( UnicodeString tooltip, Int tooltipDelay = -1, const RGBColor *color = nullptr, Real width = 1.0f );		///< set tooltip string at cursor
 	void setMouseText( UnicodeString text, const RGBAColorInt *color, const RGBAColorInt *dropColor );					///< set the cursor text, *NOT* the tooltip text
@@ -405,7 +405,7 @@ protected:
 	RGBAColorInt m_cursorTextColor;							///< color of the cursor text
 	RGBAColorInt m_cursorTextDropColor;					///< color of the cursor text drop shadow
 
-  Int m_tooltipDelay;                                ///< millisecond delay for tooltips
+	Int m_tooltipDelay;                                ///< millisecond delay for tooltips
 
 	Int m_highlightPos;
 	UnsignedInt m_highlightUpdateStart;

--- a/Core/GameEngine/Include/GameClient/ParabolicEase.h
+++ b/Core/GameEngine/Include/GameClient/ParabolicEase.h
@@ -67,7 +67,7 @@
  */
 class ParabolicEase
 {
-  public:
+public:
 		explicit ParabolicEase(Real easeInTime = 0.0f, Real easeOutTime = 0.0f)
 			{ setEaseTimes(easeInTime, easeOutTime); }
 

--- a/Core/GameEngine/Include/GameClient/ParticleSys.h
+++ b/Core/GameEngine/Include/GameClient/ParticleSys.h
@@ -754,7 +754,7 @@ public:
 	virtual void update() override;								///< update all particle systems
 
 	virtual Int getOnScreenParticleCount() = 0;   ///< returns the number of particles on screen
-  virtual void setOnScreenParticleCount(int count);
+	virtual void setOnScreenParticleCount(int count);
 
 	ParticleSystemTemplate *findTemplate( const AsciiString &name ) const;
 	ParticleSystemTemplate *findParentTemplate( const AsciiString &name, int parentNum ) const;

--- a/Core/GameEngine/Include/GameClient/Snow.h
+++ b/Core/GameEngine/Include/GameClient/Snow.h
@@ -80,13 +80,13 @@ extern OVERRIDE<WeatherSetting> TheWeatherSetting;
 
 class SnowManager : public SubsystemInterface
 {
-  public :
-	  enum{
-		 SNOW_NOISE_X=64,			//dimensions table holding noise function used for initial snow positions.
-		 SNOW_NOISE_Y=64,			//dimensions table holding noise function used for initial snow positions.
-	  };
+public :
+	enum{
+		SNOW_NOISE_X=64,			//dimensions table holding noise function used for initial snow positions.
+		SNOW_NOISE_Y=64,			//dimensions table holding noise function used for initial snow positions.
+	};
 
-	 SnowManager();
+	SnowManager();
 	virtual ~SnowManager() override;
 
 	virtual void init() override;
@@ -94,7 +94,7 @@ class SnowManager : public SubsystemInterface
 	virtual void updateIniSettings ();
 	void setVisible(Bool showWeather);	///<enable/disable rendering of weather - assuming it's available on map.
 
-  protected :
+protected :
 
 	Real				*m_startingHeights;
 	Real				m_time;	///<time elapsed since it started snowing.

--- a/Core/GameEngine/Include/GameClient/TerrainVisual.h
+++ b/Core/GameEngine/Include/GameClient/TerrainVisual.h
@@ -52,95 +52,95 @@ struct SeismicSimulationNode; // just a forward declaration folks, no cause for 
 class SeismicSimulationFilterBase
 {
 public:
-  enum SeismicSimStatusCode CPP_11(: Int)
-  {
-    SEISMIC_STATUS_INVALID,
-    SEISMIC_STATUS_ACTIVE,
-    SEISMIC_STATUS_ZERO_ENERGY,
-  };
+	enum SeismicSimStatusCode CPP_11(: Int)
+	{
+		SEISMIC_STATUS_INVALID,
+		SEISMIC_STATUS_ACTIVE,
+		SEISMIC_STATUS_ZERO_ENERGY,
+	};
 
-  virtual SeismicSimStatusCode filterCallback( WorldHeightMapInterfaceClass *heightMap, const SeismicSimulationNode *node ) = 0;
-  virtual Real applyGravityCallback( Real velocityIn ) = 0;
+	virtual SeismicSimStatusCode filterCallback( WorldHeightMapInterfaceClass *heightMap, const SeismicSimulationNode *node ) = 0;
+	virtual Real applyGravityCallback( Real velocityIn ) = 0;
 };
 
 struct SeismicSimulationNode
 {
-  SeismicSimulationNode()
-  {
-    m_center.x    = 0;
-    m_center.y    = 0;
-    m_radius      = 0;
-    m_region.lo.x = 0;
-    m_region.lo.y = 0;
-    m_region.hi.x = 0;
-    m_region.hi.y = 0;
-    m_clean = FALSE;
-    callbackFilter = nullptr;
-    m_life = 0;
-    m_magnitude = DEFAULT_SEISMIC_SIMULATION_MAGNITUDE;
+	SeismicSimulationNode()
+	{
+		m_center.x    = 0;
+		m_center.y    = 0;
+		m_radius      = 0;
+		m_region.lo.x = 0;
+		m_region.lo.y = 0;
+		m_region.hi.x = 0;
+		m_region.hi.y = 0;
+		m_clean = FALSE;
+		callbackFilter = nullptr;
+		m_life = 0;
+		m_magnitude = DEFAULT_SEISMIC_SIMULATION_MAGNITUDE;
 
-  }
-  SeismicSimulationNode( const SeismicSimulationNode &ssn )
-  {
-    m_center.x    = ssn.m_center.x;
-    m_center.y    = ssn.m_center.y;
-    m_radius      = ssn.m_radius;
-    m_region.lo.x = ssn.m_region.lo.x;
-    m_region.lo.y = ssn.m_region.lo.y;
-    m_region.hi.x = ssn.m_region.hi.x;
-    m_region.hi.y = ssn.m_region.hi.y;
-    m_clean       = ssn.m_clean;
-    callbackFilter= ssn.callbackFilter;
-    m_life        = ssn.m_life;
-    m_magnitude   = ssn.m_magnitude;
+	}
+	SeismicSimulationNode( const SeismicSimulationNode &ssn )
+	{
+		m_center.x    = ssn.m_center.x;
+		m_center.y    = ssn.m_center.y;
+		m_radius      = ssn.m_radius;
+		m_region.lo.x = ssn.m_region.lo.x;
+		m_region.lo.y = ssn.m_region.lo.y;
+		m_region.hi.x = ssn.m_region.hi.x;
+		m_region.hi.y = ssn.m_region.hi.y;
+		m_clean       = ssn.m_clean;
+		callbackFilter= ssn.callbackFilter;
+		m_life        = ssn.m_life;
+		m_magnitude   = ssn.m_magnitude;
 
-  }
-  SeismicSimulationNode( const Coord3D* ctr, Real rad, Real mag, SeismicSimulationFilterBase *cbf = nullptr )
-  {
-    m_center.x    = REAL_TO_INT_FLOOR(ctr->x/MAP_XY_FACTOR);
-    m_center.y    = REAL_TO_INT_FLOOR(ctr->y/MAP_XY_FACTOR);
-    m_radius      = (rad-1)/MAP_XY_FACTOR;
-    UnsignedInt regionSize = rad/MAP_XY_FACTOR;
-    m_region.lo.x = m_center.x - regionSize;
-    m_region.lo.y = m_center.y - regionSize;
-    m_region.hi.x = m_center.x + regionSize;
-    m_region.hi.y = m_center.y + regionSize;
-    m_clean       = false;
-    callbackFilter= cbf;
-    m_life        = 0;
-    m_magnitude   = mag;
+	}
+	SeismicSimulationNode( const Coord3D* ctr, Real rad, Real mag, SeismicSimulationFilterBase *cbf = nullptr )
+	{
+		m_center.x    = REAL_TO_INT_FLOOR(ctr->x/MAP_XY_FACTOR);
+		m_center.y    = REAL_TO_INT_FLOOR(ctr->y/MAP_XY_FACTOR);
+		m_radius      = (rad-1)/MAP_XY_FACTOR;
+		UnsignedInt regionSize = rad/MAP_XY_FACTOR;
+		m_region.lo.x = m_center.x - regionSize;
+		m_region.lo.y = m_center.y - regionSize;
+		m_region.hi.x = m_center.x + regionSize;
+		m_region.hi.y = m_center.y + regionSize;
+		m_clean       = false;
+		callbackFilter= cbf;
+		m_life        = 0;
+		m_magnitude   = mag;
 
-  }
+	}
 
-  SeismicSimulationFilterBase::SeismicSimStatusCode handleFilterCallback( WorldHeightMapInterfaceClass *heightMap )
-  {
-    if ( callbackFilter == nullptr )
-      return SeismicSimulationFilterBase::SEISMIC_STATUS_INVALID;
+	SeismicSimulationFilterBase::SeismicSimStatusCode handleFilterCallback( WorldHeightMapInterfaceClass *heightMap )
+	{
+		if ( callbackFilter == nullptr )
+		return SeismicSimulationFilterBase::SEISMIC_STATUS_INVALID;
 
-    ++m_life;
+		++m_life;
 
-    return callbackFilter->filterCallback( heightMap, this );
-  }
+		return callbackFilter->filterCallback( heightMap, this );
+	}
 
-  Real applyGravity( Real velocityIn )
-  {
-    DEBUG_ASSERTCRASH( callbackFilter, ("SeismicSimulationNode::applyGravity() has no callback filter!") );
+	Real applyGravity( Real velocityIn )
+	{
+		DEBUG_ASSERTCRASH( callbackFilter, ("SeismicSimulationNode::applyGravity() has no callback filter!") );
 
-    if ( callbackFilter == nullptr )
-      return velocityIn;//oops, we have no callback!
+		if ( callbackFilter == nullptr )
+		return velocityIn;//oops, we have no callback!
 
-    return callbackFilter->applyGravityCallback( velocityIn );
+		return callbackFilter->applyGravityCallback( velocityIn );
 
-  }
+	}
 
-  IRegion2D   m_region;
-  ICoord2D    m_center;
-  Bool        m_clean;
-  Real        m_magnitude;
-  UnsignedInt m_radius;
-  UnsignedInt m_life;
+	IRegion2D   m_region;
+	ICoord2D    m_center;
+	Bool        m_clean;
+	Real        m_magnitude;
+	UnsignedInt m_radius;
+	UnsignedInt m_life;
 
-  SeismicSimulationFilterBase *callbackFilter;
+	SeismicSimulationFilterBase *callbackFilter;
 
 };
 typedef std::list<SeismicSimulationNode> SeismicSimulationList;
@@ -148,8 +148,8 @@ typedef SeismicSimulationList::iterator SeismicSimulationListIt;
 
 class DomeStyleSeismicFilter : public SeismicSimulationFilterBase
 {
-  virtual SeismicSimStatusCode filterCallback( WorldHeightMapInterfaceClass *heightMap, const SeismicSimulationNode *node ) override;
-  virtual Real applyGravityCallback( Real velocityIn ) override;
+	virtual SeismicSimStatusCode filterCallback( WorldHeightMapInterfaceClass *heightMap, const SeismicSimulationNode *node ) override;
+	virtual Real applyGravityCallback( Real velocityIn ) override;
 };
 
 
@@ -220,8 +220,8 @@ public:
 	/** intersect the ray with the terrain, if a hit occurs TRUE is returned
 	and the result point on the terrain is returned in "result" */
 	virtual Bool intersectTerrain( Coord3D *rayStart,
-																 Coord3D *rayEnd,
-																 Coord3D *result ) { return FALSE; }
+			Coord3D *rayEnd,
+			Coord3D *result ) { return FALSE; }
 
 	//
 	// water methods
@@ -278,18 +278,18 @@ public:
 	virtual Int getRawMapHeight(const ICoord2D *gridPos)=0;
 
 
-  ////////////////////////////////////////////////////
-  ////////////////////////////////////////////////////
-  ////////////////////////////////////////////////////
+		////////////////////////////////////////////////////
+		////////////////////////////////////////////////////
+		////////////////////////////////////////////////////
 #ifdef DO_SEISMIC_SIMULATIONS
-  virtual void updateSeismicSimulations() = 0; /// walk the SeismicSimulationList and, well, do it.
-  virtual void addSeismicSimulation( const SeismicSimulationNode& sim ) = 0;
+		virtual void updateSeismicSimulations() = 0; /// walk the SeismicSimulationList and, well, do it.
+		virtual void addSeismicSimulation( const SeismicSimulationNode& sim ) = 0;
 #endif
-  virtual WorldHeightMap* getLogicHeightMap() {return nullptr;};
-  virtual WorldHeightMap* getClientHeightMap() {return nullptr;};
-  ////////////////////////////////////////////////////
-  ////////////////////////////////////////////////////
-  ////////////////////////////////////////////////////
+		virtual WorldHeightMap* getLogicHeightMap() {return nullptr;};
+		virtual WorldHeightMap* getClientHeightMap() {return nullptr;};
+		////////////////////////////////////////////////////
+		////////////////////////////////////////////////////
+		////////////////////////////////////////////////////
 
 
 	/// Replace the skybox texture

--- a/Core/GameEngine/Include/GameClient/VideoPlayer.h
+++ b/Core/GameEngine/Include/GameClient/VideoPlayer.h
@@ -193,7 +193,7 @@ class VideoStream : public VideoStreamInterface
 
 	public:
 
- 		virtual	VideoStreamInterface* next() override;				///< Returns next open stream
+	virtual	VideoStreamInterface* next() override;				///< Returns next open stream
 		virtual void update() override;											///< Update stream
 		virtual void close() override;												///< Close and free stream
 

--- a/Core/GameEngine/Include/GameClient/View.h
+++ b/Core/GameEngine/Include/GameClient/View.h
@@ -87,13 +87,13 @@ public:
 		SHAKE_COUNT
 	};
 
-  // Return values for worldToScreenTriReturn
-  enum WorldToScreenReturn CPP_11(: Int)
-  {
-    WTS_INSIDE_FRUSTUM = 0, // On the screen (inside frustum of camera)
-    WTS_OUTSIDE_FRUSTUM,    // Return is valid but off the screen (outside frustum of camera)
-    WTS_INVALID,            // No transform possible
-  };
+	// Return values for worldToScreenTriReturn
+	enum WorldToScreenReturn CPP_11(: Int)
+	{
+		WTS_INSIDE_FRUSTUM = 0, // On the screen (inside frustum of camera)
+		WTS_OUTSIDE_FRUSTUM,    // Return is valid but off the screen (outside frustum of camera)
+		WTS_INVALID,            // No transform possible
+	};
 
 public:
 
@@ -161,8 +161,8 @@ public:
 	virtual void setFadeParameters(Int fadeFrames, Int direction) { };
 	virtual void set3DWireFrameMode(Bool enable) { };
 
- 	virtual void resetCamera(const Coord3D *location, Int frames, Real easeIn=0.0f, Real easeOut=0.0f) {}; ///< Move camera to location, and reset to default angle & zoom.
- 	virtual void rotateCamera(Real rotations, Int frames, Real easeIn=0.0f, Real easeOut=0.0f) {}; ///< Rotate camera about current viewpoint.
+	virtual void resetCamera(const Coord3D *location, Int frames, Real easeIn=0.0f, Real easeOut=0.0f) {}; ///< Move camera to location, and reset to default angle & zoom.
+	virtual void rotateCamera(Real rotations, Int frames, Real easeIn=0.0f, Real easeOut=0.0f) {}; ///< Rotate camera about current viewpoint.
 	virtual void rotateCameraTowardObject(ObjectID id, Int milliseconds, Int holdMilliseconds, Real easeIn=0.0f, Real easeOut=0.0f) {};	///< Rotate camera to face an object, and hold on it
 	virtual void rotateCameraTowardPosition(const Coord3D *pLoc, Int milliseconds, Real easeIn=0.0f, Real easeOut=0.0f, Bool reverseRotation=FALSE) {};	///< Rotate camera to face a location.
 	virtual Bool isTimeFrozen(){ return false;}					///< Freezes time during the next camera movement.
@@ -221,8 +221,8 @@ public:
 	virtual void setFieldOfView( Real angle ) { m_FOV = angle; }				///< Set the horizontal field of view angle
 	virtual Real getFieldOfView() { return m_FOV; }								///< Get the horizontal field of view angle
 
-  Bool worldToScreen( const Coord3D *w, ICoord2D *s ) { return worldToScreenTriReturn( w, s ) == WTS_INSIDE_FRUSTUM; }	///< Transform world coordinate "w" into screen coordinate "s"
-  virtual WorldToScreenReturn worldToScreenTriReturn(const Coord3D *w, ICoord2D *s ) = 0; ///< Like worldToScreen(), but with a more informative return value
+	Bool worldToScreen( const Coord3D *w, ICoord2D *s ) { return worldToScreenTriReturn( w, s ) == WTS_INSIDE_FRUSTUM; }	///< Transform world coordinate "w" into screen coordinate "s"
+	virtual WorldToScreenReturn worldToScreenTriReturn(const Coord3D *w, ICoord2D *s ) = 0; ///< Like worldToScreen(), but with a more informative return value
 	virtual void screenToTerrain( const ICoord2D *screen, Coord3D *world ) = 0;  ///< transform screen coord to a point on the 3D terrain
 	virtual void screenToWorldAtZ( const ICoord2D *s, Coord3D *w, Real z ) = 0;  ///< transform screen point to world point at the specified world Z value
 

--- a/Core/GameEngine/Include/GameClient/WinInstanceData.h
+++ b/Core/GameEngine/Include/GameClient/WinInstanceData.h
@@ -135,11 +135,11 @@ public:
 	really should be protected and have the rest of the code use access
 	functions to edit them */
 
-  Int m_id;								            // Id of the window (used mainly for scripts)
-  Int m_state;                 // Flags indicating state of window
-  UnsignedInt m_style;         // Flags indicating style of window
+	Int m_id;								            // Id of the window (used mainly for scripts)
+	Int m_state;                 // Flags indicating state of window
+	UnsignedInt m_style;         // Flags indicating style of window
 	UnsignedInt m_status;	       // Status bits for this window (mirrored in GameWindow)
-  GameWindow *m_owner;
+	GameWindow *m_owner;
 
 	WinDrawData m_enabledDrawData[ MAX_DRAW_DATA ];  ///< image/color info for enabled state
 	WinDrawData m_disabledDrawData[ MAX_DRAW_DATA ];  ///< image/color info for disabled state
@@ -150,7 +150,7 @@ public:
 	TextDrawData m_hiliteText;		///< hilite text colors
 	TextDrawData m_imeCompositeText;///< IME composite text colors
 
-  ICoord2D	m_imageOffset;		 // dx, dy for blitting bkgnd images
+	ICoord2D	m_imageOffset;		 // dx, dy for blitting bkgnd images
 
 	GameFont *m_font;								 // font which this window should use
 
@@ -160,7 +160,7 @@ public:
 
 	AsciiString m_headerTemplateName;		///< name of the template we're going to base our font off of.
 
-  Int m_tooltipDelay;           ///< desired delay before showing tooltip
+	Int m_tooltipDelay;           ///< desired delay before showing tooltip
 
 	DisplayString *m_text;				 ///< generic text for any window to display
 	DisplayString *m_tooltip;		 ///< tooltip for display

--- a/Core/GameEngine/Include/GameLogic/AIPathfind.h
+++ b/Core/GameEngine/Include/GameLogic/AIPathfind.h
@@ -52,7 +52,7 @@ class PathfindCell;
 #undef RETAIL_COMPATIBLE_PATHFINDING_ALLOCATION
 #endif
 
-  typedef UnsignedShort zoneStorageType;
+typedef UnsignedShort zoneStorageType;
 
 
 //----------------------------------------------------------------------------------------------------------
@@ -418,7 +418,7 @@ private:
 	UnsignedInt m_obstacleIsTransparent : 1;  ///< True if obstacle is transparent (undefined if obstacleid is invalid)
 
 	zoneStorageType m_zone : 14;              ///< Zone. Each zone is a set of adjacent terrain type.  If from & to in the same zone, you can successfully pathfind.  If not,
-	                                          /// you still may be able to if you can cross multiple terrain types.
+	/// you still may be able to if you can cross multiple terrain types.
 	UnsignedShort m_aircraftGoal : 1;         ///< This is an aircraft goal cell.
 	UnsignedShort m_pinched : 1;              ///< This cell is surrounded by obstacle cells.
 	UnsignedByte m_type : 4;                  ///< what type of cell terrain this is.
@@ -526,7 +526,7 @@ protected:
 
 	zoneStorageType m_firstZone; // First zone in this block.
 	UnsignedShort m_numZones;	 // Number of zones in this block.  If == 1, there is only one zone, and
-														 // no zone equivalency arrays will be allocated.
+	// no zone equivalency arrays will be allocated.
 
 	UnsignedShort m_zonesAllocated;
 	zoneStorageType *m_groundCliffZones;
@@ -838,9 +838,9 @@ protected:
 	static Int lineBlockedByObstacleCallback(Pathfinder* pathfinder, PathfindCell* from, PathfindCell* to, Int to_x, Int to_y, void* userData);
 	static Int tightenPathCallback(Pathfinder* pathfinder, PathfindCell* from, PathfindCell* to, Int to_x, Int to_y, void* userData);
 	static Int attackBlockedByObstacleCallback(Pathfinder* pathfinder, PathfindCell* from, PathfindCell* to, Int to_x, Int to_y, void* userData);
- 	static Int examineCellsCallback(Pathfinder* pathfinder, PathfindCell* from, PathfindCell* to, Int to_x, Int to_y, void* userData);
- 	static Int groundCellsCallback(Pathfinder* pathfinder, PathfindCell* from, PathfindCell* to, Int to_x, Int to_y, void* userData);
- 	static Int moveAlliesDestinationCallback(Pathfinder* pathfinder, PathfindCell* from, PathfindCell* to, Int to_x, Int to_y, void* userData);
+	static Int examineCellsCallback(Pathfinder* pathfinder, PathfindCell* from, PathfindCell* to, Int to_x, Int to_y, void* userData);
+	static Int groundCellsCallback(Pathfinder* pathfinder, PathfindCell* from, PathfindCell* to, Int to_x, Int to_y, void* userData);
+	static Int moveAlliesDestinationCallback(Pathfinder* pathfinder, PathfindCell* from, PathfindCell* to, Int to_x, Int to_y, void* userData);
 
 	static Int segmentIntersectsBuildingCallback(Pathfinder* pathfinder, PathfindCell* from, PathfindCell* to, Int to_x, Int to_y, void* userData);
 
@@ -858,8 +858,8 @@ protected:
 
 	Bool evaluateCell(PathfindCell* newCell, PathfindCell *parentCell,
 									const LocomotorSet& locomotorSet,
-									 Bool centerInCell, Int radius,
-									 const Object *obj, Int attackDistance);
+		Bool centerInCell, Int radius,
+		const Object *obj, Int attackDistance);
 
 	Path *buildActualPath( const Object *obj, LocomotorSurfaceTypeMask acceptableSurfaces,
 		const Coord3D *fromPos, PathfindCell *goalCell, Bool center, Bool blocked );	///< Work backwards from goal cell to construct final path

--- a/Core/GameEngine/Include/GameNetwork/FirewallHelper.h
+++ b/Core/GameEngine/Include/GameNetwork/FirewallHelper.h
@@ -96,10 +96,10 @@ struct ManglerData {
 
 // size = TransportMessageHeader + ManglerData + 10 bytes = 26 bytes
 struct ManglerMessage {
-        ManglerData							data;
-        int											length;
-        unsigned int						ip;
-        unsigned short					port;
+	ManglerData							data;
+	int											length;
+	unsigned int						ip;
+	unsigned short					port;
 };
 
 #pragma pack(pop)

--- a/Core/GameEngine/Include/GameNetwork/GameInfo.h
+++ b/Core/GameEngine/Include/GameNetwork/GameInfo.h
@@ -82,7 +82,7 @@ public:
 	{ m_playerTemplate = playerTemplate;
 		if (playerTemplate <= PLAYERTEMPLATE_MIN)
 			m_startPos = -1;
-	 }
+	}
 	Int getPlayerTemplate() const { return m_playerTemplate; }
 
 	void setTeamNumber( Int teamNumber ) { m_teamNumber = teamNumber; }
@@ -196,10 +196,10 @@ public:
 	inline Int getUseStats() const;		///< Does this game count towards gamespy stats?
 	inline void setUseStats( Int useStats );
 
-  inline UnsignedShort getSuperweaponRestriction() const; ///< Get any optional limits on superweapons
-  void setSuperweaponRestriction( UnsignedShort restriction ); ///< Set the optional limits on superweapons
-  inline const Money & getStartingCash() const;
-  void setStartingCash( const Money & startingCash );
+	inline UnsignedShort getSuperweaponRestriction() const; ///< Get any optional limits on superweapons
+	void setSuperweaponRestriction( UnsignedShort restriction ); ///< Set the optional limits on superweapons
+	inline const Money & getStartingCash() const;
+	void setStartingCash( const Money & startingCash );
 
 	void setSlotPointer( Int index, GameSlot *slot );	///< Set the slot info pointer
 
@@ -229,8 +229,8 @@ public:
 	Bool isPlayerPreorder(Int index);
 	void markPlayerAsPreorder(Int index);
 
-  inline Bool oldFactionsOnly() const;
-  inline void setOldFactionsOnly( Bool oldFactionsOnly );
+	inline Bool oldFactionsOnly() const;
+	inline void setOldFactionsOnly( Bool oldFactionsOnly );
 
 protected:
 	Int m_preorderMask;
@@ -250,9 +250,9 @@ protected:
 	Int m_mapMask;
 	Int m_seed;
 	Int m_useStats;
-  Money         m_startingCash;
-  UnsignedShort m_superweaponRestriction;
-  Bool m_oldFactionsOnly; // Only USA, China, GLA -- not USA Air Force General, GLA Toxic General, et al
+	Money         m_startingCash;
+	UnsignedShort m_superweaponRestriction;
+	Bool m_oldFactionsOnly; // Only USA, China, GLA -- not USA Air Force General, GLA Toxic General, et al
 };
 
 extern GameInfo *TheGameInfo;

--- a/Core/GameEngine/Include/GameNetwork/GameSpy/PeerThread.h
+++ b/Core/GameEngine/Include/GameNetwork/GameSpy/PeerThread.h
@@ -116,7 +116,7 @@ public:
 			UnsignedInt iniCRC;
 			UnsignedInt gameVersion;
 			Bool allowObservers;
-      Bool useStats;
+			Bool useStats;
 			UnsignedShort ladPort;
 			UnsignedInt ladPassCRC;
 			Bool restrictGameList;
@@ -329,7 +329,7 @@ public:
 			Bool isStaging;
 			Bool requiresPassword;
 			Bool allowObservers;
-      Bool useStats;
+			Bool useStats;
 			UnsignedInt version;
 			UnsignedInt exeCRC;
 			UnsignedInt iniCRC;

--- a/Core/GameEngine/Include/GameNetwork/GameSpy/PersistentStorageDefs.h
+++ b/Core/GameEngine/Include/GameNetwork/GameSpy/PersistentStorageDefs.h
@@ -30,9 +30,9 @@
 
 enum LocaleType CPP_11(: Int)
 {
-    LOC_UNKNOWN = 0,
-    LOC_MIN = 1,
-    LOC_MAX = 37
+	LOC_UNKNOWN = 0,
+	LOC_MIN = 1,
+	LOC_MAX = 37
 };
 
 void HandlePersistentStorageResponses();

--- a/Core/GameEngine/Include/GameNetwork/LANAPI.h
+++ b/Core/GameEngine/Include/GameNetwork/LANAPI.h
@@ -119,7 +119,7 @@ public:
 	virtual void OnAccept( UnsignedInt playerIP, Bool status ) = 0;																///< Someone's accept status changed
 	virtual void OnHasMap( UnsignedInt playerIP, Bool status ) = 0;																///< Someone's map status changed
 	virtual void OnChat( UnicodeString player, UnsignedInt ip,
-											 UnicodeString message, ChatType format ) = 0;														///< Chat message from someone
+		UnicodeString message, ChatType format ) = 0;														///< Chat message from someone
 	virtual void OnGameStart() = 0;																													///< The game is starting
 	virtual void OnGameStartTimer( Int seconds ) = 0;
 	virtual void OnGameOptions( UnsignedInt playerIP, Int playerSlot, AsciiString options ) = 0;	///< Someone sent game options
@@ -319,7 +319,7 @@ public:
 	virtual void OnAccept( UnsignedInt playerIP, Bool status ) override;																///< Someone's accept status changed
 	virtual void OnHasMap( UnsignedInt playerIP, Bool status ) override;																///< Someone's map status changed
 	virtual void OnChat( UnicodeString player, UnsignedInt ip,
-											 UnicodeString message, ChatType format ) override;														///< Chat message from someone
+		UnicodeString message, ChatType format ) override;														///< Chat message from someone
 	virtual void OnGameStart() override;																													///< The game is starting
 	virtual void OnGameStartTimer( Int seconds ) override;
 	virtual void OnGameOptions( UnsignedInt playerIP, Int playerSlot, AsciiString options ) override;	///< Someone sent game options

--- a/Core/GameEngine/Include/GameNetwork/NAT.h
+++ b/Core/GameEngine/Include/GameNetwork/NAT.h
@@ -145,12 +145,12 @@ protected:
 	time_t m_timeoutTime; ///< the time at which we will time out waiting for the other player's port number.
 	time_t m_roundTimeout;	///< the time at which we will time out this connection round.
 
- static Int m_timeBetweenRetries; // 1 second between retries sounds good to me.
- static time_t m_manglerRetryTimeInterval; // sounds good to me.
- static Int m_maxAllowedManglerRetries; // works for me.
- static time_t m_keepaliveInterval; // 15 seconds between keepalive packets seems good.
- static time_t m_timeToWaitForPort; // wait for ten seconds for the other player's port number.
- static time_t m_timeForRoundTimeout; // wait for at most ten seconds for each connection round to finish.
+	static Int m_timeBetweenRetries; // 1 second between retries sounds good to me.
+	static time_t m_manglerRetryTimeInterval; // sounds good to me.
+	static Int m_maxAllowedManglerRetries; // works for me.
+	static time_t m_keepaliveInterval; // 15 seconds between keepalive packets seems good.
+	static time_t m_timeToWaitForPort; // wait for ten seconds for the other player's port number.
+	static time_t m_timeForRoundTimeout; // wait for at most ten seconds for each connection round to finish.
 
 };
 

--- a/Core/GameEngine/Include/GameNetwork/networkutil.h
+++ b/Core/GameEngine/Include/GameNetwork/networkutil.h
@@ -47,8 +47,8 @@ void dumpBufferToLog(const void *vBuf, Int len, const char *fname, Int line);
 
 inline UnsignedInt AssembleIp(UnsignedByte a, UnsignedByte b, UnsignedByte c, UnsignedByte d)
 {
-    return ((UnsignedInt)(a) << 24) |
-           ((UnsignedInt)(b) << 16) |
-           ((UnsignedInt)(c) << 8) |
-           ((UnsignedInt)(d));
+	return ((UnsignedInt)(a) << 24) |
+		((UnsignedInt)(b) << 16) |
+		((UnsignedInt)(c) << 8) |
+		((UnsignedInt)(d));
 }

--- a/Core/GameEngine/Include/GameNetwork/udp.h
+++ b/Core/GameEngine/Include/GameNetwork/udp.h
@@ -60,63 +60,63 @@
 
 class UDP
 {
- // DATA
- private:
-  Int       fd;
-  UnsignedInt       myIP;
-  UnsignedShort       myPort;
-  struct       sockaddr_in  addr;
+	// DATA
+private:
+	Int       fd;
+	UnsignedInt       myIP;
+	UnsignedShort       myPort;
+	struct       sockaddr_in  addr;
 
- public:
-  // These defines specify a system independent way to
-  //   get error codes for socket services.
-  enum sockStat CPP_11(: Int)
-  {
-    OK           =  0,     // Everything's cool
-    UNKNOWN      = -1,     // There was an error of unknown type
-    ISCONN       = -2,     // The socket is already connected
-    INPROGRESS   = -3,     // The socket is non-blocking and the operation
-                           //   isn't done yet
-    ALREADY      = -4,     // The socket is already attempting a connection
-                           //   but isn't done yet
-    AGAIN        = -5,     // Try again.
-    ADDRINUSE    = -6,     // Address already in use
-    ADDRNOTAVAIL = -7,     // That address is not available on the remote host
-    BADF         = -8,     // Not a valid FD
-    CONNREFUSED  = -9,     // Connection was refused
-    INTR         =-10,     // Operation was interrupted
-    NOTSOCK      =-11,     // FD wasn't a socket
-    PIPE         =-12,     // That operation just made a SIGPIPE
-    WOULDBLOCK   =-13,     // That operation would block
-    INVAL        =-14,     // Invalid
-    TIMEDOUT     =-15      // Timeout
-  };
+public:
+	// These defines specify a system independent way to
+	//   get error codes for socket services.
+	enum sockStat CPP_11(: Int)
+	{
+		OK           =  0,     // Everything's cool
+		UNKNOWN      = -1,     // There was an error of unknown type
+		ISCONN       = -2,     // The socket is already connected
+		INPROGRESS   = -3,     // The socket is non-blocking and the operation
+		//   isn't done yet
+		ALREADY      = -4,     // The socket is already attempting a connection
+		//   but isn't done yet
+		AGAIN        = -5,     // Try again.
+		ADDRINUSE    = -6,     // Address already in use
+		ADDRNOTAVAIL = -7,     // That address is not available on the remote host
+		BADF         = -8,     // Not a valid FD
+		CONNREFUSED  = -9,     // Connection was refused
+		INTR         =-10,     // Operation was interrupted
+		NOTSOCK      =-11,     // FD wasn't a socket
+		PIPE         =-12,     // That operation just made a SIGPIPE
+		WOULDBLOCK   =-13,     // That operation would block
+		INVAL        =-14,     // Invalid
+		TIMEDOUT     =-15      // Timeout
+	};
 
 // CODE
- private:
-  Int           SetBlocking(Int block);
+private:
+	Int           SetBlocking(Int block);
 
 	Int m_lastError;
 
- public:
-                   UDP();
-                  ~UDP();
-  Int           Bind(UnsignedInt IP,UnsignedShort port);
-  Int           Bind(const char *Host,UnsignedShort port);
-  Int           Write(const unsigned char *msg,UnsignedInt len,UnsignedInt IP,UnsignedShort port);
-  Int           Read(unsigned char *msg,UnsignedInt len,sockaddr_in *from);
-  sockStat         GetStatus();
-  void             ClearStatus();
-  //int              Wait(Int sec,Int usec,fd_set &returnSet);
-  //int              Wait(Int sec,Int usec,fd_set &givenSet,fd_set &returnSet);
+public:
+	UDP();
+	~UDP();
+	Int           Bind(UnsignedInt IP,UnsignedShort port);
+	Int           Bind(const char *Host,UnsignedShort port);
+	Int           Write(const unsigned char *msg,UnsignedInt len,UnsignedInt IP,UnsignedShort port);
+	Int           Read(unsigned char *msg,UnsignedInt len,sockaddr_in *from);
+	sockStat         GetStatus();
+	void             ClearStatus();
+	//int              Wait(Int sec,Int usec,fd_set &returnSet);
+	//int              Wait(Int sec,Int usec,fd_set &givenSet,fd_set &returnSet);
 
-  Int             getLocalAddr(UnsignedInt &ip, UnsignedShort &port);
-  Int           getFD() { return(fd); }
+	Int             getLocalAddr(UnsignedInt &ip, UnsignedShort &port);
+	Int           getFD() { return(fd); }
 
-  Int             SetInputBuffer(UnsignedInt bytes);
-  Int             SetOutputBuffer(UnsignedInt bytes);
-  int              GetInputBuffer();
-  int              GetOutputBuffer();
+	Int             SetInputBuffer(UnsignedInt bytes);
+	Int             SetOutputBuffer(UnsignedInt bytes);
+	int              GetInputBuffer();
+	int              GetOutputBuffer();
 	Int						AllowBroadcasts(Bool status);
 };
 

--- a/Core/GameEngine/Source/Common/Audio/DynamicAudioEventInfo.cpp
+++ b/Core/GameEngine/Source/Common/Audio/DynamicAudioEventInfo.cpp
@@ -49,185 +49,185 @@ DynamicAudioEventInfo::~DynamicAudioEventInfo()
 /** Override; dynamic audio events are used only for level-specific stuff at the moment */
 Bool DynamicAudioEventInfo::isLevelSpecific() const
 {
-  return true;
+	return true;
 }
 
 /** Override; cheap dynamic casting */
 DynamicAudioEventInfo * DynamicAudioEventInfo::getDynamicAudioEventInfo()
 {
-  return this;
+	return this;
 }
 
 /** Override; cheap dynamic casting */
 const DynamicAudioEventInfo * DynamicAudioEventInfo::getDynamicAudioEventInfo() const
 {
-  return this;
+	return this;
 }
 
 
 /** Override; change the name of this audio event*/
 void DynamicAudioEventInfo::overrideAudioName( const AsciiString & newName )
 {
-  // Record new name. Needed later for load & save
-  m_originalName = m_audioName;
+	// Record new name. Needed later for load & save
+	m_originalName = m_audioName;
 
-  m_overriddenFields.set( OVERRIDE_NAME );
+	m_overriddenFields.set( OVERRIDE_NAME );
 
-  m_audioName = newName;
+	m_audioName = newName;
 }
 
 /** Override; change the looping property of this audio event */
 void DynamicAudioEventInfo::overrideLoopFlag( Bool newLoopFlag )
 {
-  m_overriddenFields.set( OVERRIDE_LOOP_FLAG );
+	m_overriddenFields.set( OVERRIDE_LOOP_FLAG );
 
-  if ( newLoopFlag)
-    BitSet( m_control, AC_LOOP );
-  else
-    BitClear( m_control, AC_LOOP );
+	if ( newLoopFlag)
+	BitSet( m_control, AC_LOOP );
+	else
+	BitClear( m_control, AC_LOOP );
 }
 
 /** Override; change the looping properties of this audio event*/
 void DynamicAudioEventInfo::overrideLoopCount( Int newLoopCount )
 {
-  m_overriddenFields.set( OVERRIDE_LOOP_COUNT );
+	m_overriddenFields.set( OVERRIDE_LOOP_COUNT );
 
-  m_loopCount = newLoopCount;
+	m_loopCount = newLoopCount;
 }
 
 /** Override; change the volume of this audio event*/
 void DynamicAudioEventInfo::overrideVolume( Real newVolume )
 {
-  m_overriddenFields.set( OVERRIDE_VOLUME );
+	m_overriddenFields.set( OVERRIDE_VOLUME );
 
-  m_volume = newVolume;
+	m_volume = newVolume;
 }
 
 /** Override; change the minimum volume of this audio event*/
 void DynamicAudioEventInfo::overrideMinVolume( Real newMinVolume )
 {
-  m_overriddenFields.set( OVERRIDE_MIN_VOLUME );
+	m_overriddenFields.set( OVERRIDE_MIN_VOLUME );
 
-  m_minVolume = newMinVolume;
+	m_minVolume = newMinVolume;
 }
 
 /** Override; change the name of this audio event*/
 void DynamicAudioEventInfo::overrideMinRange( Real newMinRange )
 {
-  m_overriddenFields.set( OVERRIDE_MIN_RANGE );
+	m_overriddenFields.set( OVERRIDE_MIN_RANGE );
 
-  m_minDistance = newMinRange;
+	m_minDistance = newMinRange;
 }
 
 /** Override; change the name of this audio event*/
 void DynamicAudioEventInfo::overrideMaxRange( Real newMaxRange )
 {
-  m_overriddenFields.set( OVERRIDE_MAX_RANGE );
+	m_overriddenFields.set( OVERRIDE_MAX_RANGE );
 
-  m_maxDistance = newMaxRange;
+	m_maxDistance = newMaxRange;
 }
 
 /** Override; change the name of this audio event*/
 void DynamicAudioEventInfo::overridePriority( AudioPriority newPriority )
 {
-  m_overriddenFields.set( OVERRIDE_PRIORITY );
+	m_overriddenFields.set( OVERRIDE_PRIORITY );
 
-  m_priority = newPriority;
+	m_priority = newPriority;
 }
 
 /** Get the name of the INI entry this event info was derived from */
 const AsciiString & DynamicAudioEventInfo::getOriginalName() const
 {
-  if ( wasAudioNameOverriden() )
-  {
-    return m_originalName;
-  }
-  else
-  {
-    return m_audioName;
-  }
+	if ( wasAudioNameOverriden() )
+	{
+		return m_originalName;
+	}
+	else
+	{
+		return m_audioName;
+	}
 }
 
 /** Transfer all overridden fields except the customized name */
 void DynamicAudioEventInfo::xferNoName( Xfer * xfer )
 {
-  const XferVersion currentVersion = 1;
-  XferVersion version = currentVersion;
-  xfer->xferVersion( &version, currentVersion );
+	const XferVersion currentVersion = 1;
+	XferVersion version = currentVersion;
+	xfer->xferVersion( &version, currentVersion );
 
-  // The default BitFlags xfer function is really strange. It also requires us to name our
-  // bits, which I don't want to do, since it forces anyone who has the same number of bits
-  // as us to use our names. Instead, just transfer directly and count on our local version
-  // to keep things straight, If you change the list, be sure to change this code too...
-  if ( xfer->getXferMode() == XFER_LOAD )
-  {
-    UnsignedByte overriddenFlags;
-    DEBUG_ASSERTCRASH( OVERRIDE_COUNT <= sizeof( overriddenFlags ) * 8, ("Save/load code assumes override flags can fit into UnsignedByte, but it doesn't work anymore! Move up to larger integer type") );
-    xfer->xferUnsignedByte( &overriddenFlags );
-    Int field;
-    for ( field = 0; field < OVERRIDE_COUNT; field++ )
-    {
-      m_overriddenFields.set( field, BitIsSet( overriddenFlags, 1 << field ) );
-    }
-  }
-  else
-  {
-    UnsignedByte overriddenFlags = 0;
-    DEBUG_ASSERTCRASH( OVERRIDE_COUNT <= sizeof( overriddenFlags ) * 8, ("Save/load code assumes override flags can fit into UnsignedByte, but it doesn't work anymore! Move up to larger integer type") );
-    Int field;
-    for ( field = 0; field < OVERRIDE_COUNT; field++ )
-    {
-      if ( m_overriddenFields.test( field ) )
-      {
-        BitSet( overriddenFlags, 1 << field );
-      }
-    }
-    xfer->xferUnsignedByte( &overriddenFlags );
-  }
+	// The default BitFlags xfer function is really strange. It also requires us to name our
+	// bits, which I don't want to do, since it forces anyone who has the same number of bits
+	// as us to use our names. Instead, just transfer directly and count on our local version
+	// to keep things straight, If you change the list, be sure to change this code too...
+	if ( xfer->getXferMode() == XFER_LOAD )
+	{
+		UnsignedByte overriddenFlags;
+		DEBUG_ASSERTCRASH( OVERRIDE_COUNT <= sizeof( overriddenFlags ) * 8, ("Save/load code assumes override flags can fit into UnsignedByte, but it doesn't work anymore! Move up to larger integer type") );
+		xfer->xferUnsignedByte( &overriddenFlags );
+		Int field;
+		for ( field = 0; field < OVERRIDE_COUNT; field++ )
+		{
+			m_overriddenFields.set( field, BitIsSet( overriddenFlags, 1 << field ) );
+		}
+	}
+	else
+	{
+		UnsignedByte overriddenFlags = 0;
+		DEBUG_ASSERTCRASH( OVERRIDE_COUNT <= sizeof( overriddenFlags ) * 8, ("Save/load code assumes override flags can fit into UnsignedByte, but it doesn't work anymore! Move up to larger integer type") );
+		Int field;
+		for ( field = 0; field < OVERRIDE_COUNT; field++ )
+		{
+			if ( m_overriddenFields.test( field ) )
+			{
+				BitSet( overriddenFlags, 1 << field );
+			}
+		}
+		xfer->xferUnsignedByte( &overriddenFlags );
+	}
 
-  if ( wasLoopFlagOverriden() )
-  {
-    Bool loopFlag = BitIsSet( m_control, AC_LOOP );
-    xfer->xferBool( &loopFlag );
-    if ( loopFlag )
-    {
-      BitSet( m_control, AC_LOOP );
-    }
-    else
-    {
-      BitClear( m_control, AC_LOOP );
-    }
-  }
+	if ( wasLoopFlagOverriden() )
+	{
+		Bool loopFlag = BitIsSet( m_control, AC_LOOP );
+		xfer->xferBool( &loopFlag );
+		if ( loopFlag )
+		{
+			BitSet( m_control, AC_LOOP );
+		}
+		else
+		{
+			BitClear( m_control, AC_LOOP );
+		}
+	}
 
-  if ( wasLoopCountOverriden() )
-  {
-    xfer->xferInt( &m_loopCount );
-  }
+	if ( wasLoopCountOverriden() )
+	{
+		xfer->xferInt( &m_loopCount );
+	}
 
-  if ( wasVolumeOverriden() )
-  {
-    xfer->xferReal( &m_volume );
-  }
+	if ( wasVolumeOverriden() )
+	{
+		xfer->xferReal( &m_volume );
+	}
 
-  if ( wasMinVolumeOverriden() )
-  {
-    xfer->xferReal( &m_minVolume );
-  }
+	if ( wasMinVolumeOverriden() )
+	{
+		xfer->xferReal( &m_minVolume );
+	}
 
-  if ( wasMinRangeOverriden() )
-  {
-    xfer->xferReal( &m_minDistance );
-  }
+	if ( wasMinRangeOverriden() )
+	{
+		xfer->xferReal( &m_minDistance );
+	}
 
-  if ( wasMaxRangeOverriden() )
-  {
-    xfer->xferReal( &m_maxDistance );
-  }
+	if ( wasMaxRangeOverriden() )
+	{
+		xfer->xferReal( &m_maxDistance );
+	}
 
-  if ( wasPriorityOverriden() )
-  {
-    UnsignedByte priority = (UnsignedByte)m_priority;
-    xfer->xferUnsignedByte( &priority );
-    m_priority = (AudioPriority)priority;
-  }
+	if ( wasPriorityOverriden() )
+	{
+		UnsignedByte priority = (UnsignedByte)m_priority;
+		xfer->xferUnsignedByte( &priority );
+		m_priority = (AudioPriority)priority;
+	}
 }

--- a/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
+++ b/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
@@ -131,9 +131,9 @@ static const FieldParse audioSettingsFieldParseTable[] =
 	{ "DefaultMoneyTransactionVolume", INI::parsePercentToReal,		nullptr,							offsetof( AudioSettings, m_defaultMoneyTransactionVolume) },
 	{ "MicrophoneDesiredHeightAboveTerrain",	INI::parseReal,			nullptr,							offsetof( AudioSettings, m_microphoneDesiredHeightAboveTerrain ) },
 	{ "MicrophoneMaxPercentageBetweenGroundAndCamera", INI::parsePercentToReal,	nullptr,	offsetof( AudioSettings, m_microphoneMaxPercentageBetweenGroundAndCamera ) },
-  { "ZoomMinDistance",		INI::parseReal,									nullptr,							offsetof( AudioSettings, m_zoomMinDistance ) },
-  { "ZoomMaxDistance",		INI::parseReal,									nullptr,							offsetof( AudioSettings, m_zoomMaxDistance ) },
-  { "ZoomSoundVolumePercentageAmount",		INI::parsePercentToReal,	nullptr,		offsetof( AudioSettings, m_zoomSoundVolumePercentageAmount ) },
+	{ "ZoomMinDistance",		INI::parseReal,									nullptr,							offsetof( AudioSettings, m_zoomMinDistance ) },
+	{ "ZoomMaxDistance",		INI::parseReal,									nullptr,							offsetof( AudioSettings, m_zoomMaxDistance ) },
+	{ "ZoomSoundVolumePercentageAmount",		INI::parsePercentToReal,	nullptr,		offsetof( AudioSettings, m_zoomSoundVolumePercentageAmount ) },
 
 	{ nullptr, nullptr, nullptr, 0 }
 };
@@ -768,8 +768,8 @@ void AudioManager::set3DVolumeAdjustment( Real volumeAdjustment )
 	if (m_sound3DVolume > 1.0f)
 		m_sound3DVolume = 1.0f;
 
-  if ( ! has3DSensitiveStreamsPlaying() )
-  	m_volumeHasChanged = TRUE;
+	if ( ! has3DSensitiveStreamsPlaying() )
+	m_volumeHasChanged = TRUE;
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -810,12 +810,12 @@ void AudioManager::appendAudioRequest( AudioRequest *m_request )
 // Remove all pending audio requests
 void AudioManager::removeAllAudioRequests()
 {
-  std::list<AudioRequest*>::iterator it;
-  for ( it = m_audioRequests.begin(); it != m_audioRequests.end(); it++ ) {
-    releaseAudioRequest( *it );
-  }
+	std::list<AudioRequest*>::iterator it;
+	for ( it = m_audioRequests.begin(); it != m_audioRequests.end(); it++ ) {
+		releaseAudioRequest( *it );
+	}
 
-  m_audioRequests.clear();
+	m_audioRequests.clear();
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -841,17 +841,17 @@ AudioEventInfo *AudioManager::newAudioEventInfo( AsciiString audioName )
 // Add an AudioEventInfo structure allocated elsewhere to the audio event list
 void AudioManager::addAudioEventInfo( AudioEventInfo * newEvent )
 {
-  // Warning: Don't try to copy the structure. It may be a derived class
-  AudioEventInfo *eventInfo = findAudioEventInfo( newEvent->m_audioName );
-  if (eventInfo)
-  {
-    DEBUG_CRASH(("Requested add of '%s' multiple times. Is this intentional? - jkmcd", newEvent->m_audioName.str()));
-    *eventInfo = *newEvent;
-  }
-  else
-  {
-    m_allAudioEventInfo[newEvent->m_audioName] = newEvent;
-  }
+	// Warning: Don't try to copy the structure. It may be a derived class
+	AudioEventInfo *eventInfo = findAudioEventInfo( newEvent->m_audioName );
+	if (eventInfo)
+	{
+		DEBUG_CRASH(("Requested add of '%s' multiple times. Is this intentional? - jkmcd", newEvent->m_audioName.str()));
+		*eventInfo = *newEvent;
+	}
+	else
+	{
+		m_allAudioEventInfo[newEvent->m_audioName] = newEvent;
+	}
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -870,21 +870,21 @@ AudioEventInfo *AudioManager::findAudioEventInfo( AsciiString eventName ) const
 // Remove all AudioEventInfo's with the m_isLevelSpecific flag
 void AudioManager::removeLevelSpecificAudioEventInfos()
 {
-  AudioEventInfoHash::iterator it = m_allAudioEventInfo.begin();
+	AudioEventInfoHash::iterator it = m_allAudioEventInfo.begin();
 
-  while ( it != m_allAudioEventInfo.end() )
-  {
-    AudioEventInfoHash::iterator next = it; // Make sure erase doesn't cause problems
-    next++;
+	while ( it != m_allAudioEventInfo.end() )
+	{
+		AudioEventInfoHash::iterator next = it; // Make sure erase doesn't cause problems
+		next++;
 
-    if ( it->second->isLevelSpecific() )
-    {
-      deleteInstance(it->second);
-      m_allAudioEventInfo.erase( it );
-    }
+		if ( it->second->isLevelSpecific() )
+		{
+			deleteInstance(it->second);
+			m_allAudioEventInfo.erase( it );
+		}
 
-    it = next;
-  }
+		it = next;
+	}
 
 }
 
@@ -940,8 +940,8 @@ Real AudioManager::getAudioLengthMS( const AudioEventRTS *event )
 	tmpEvent.generateFilename();
 	tmpEvent.generatePlayInfo();
 	return getFileLengthMS(tmpEvent.getAttackFilename()) +
-				 getFileLengthMS(tmpEvent.getFilename()) +
-				 getFileLengthMS(tmpEvent.getDecayFilename());
+		getFileLengthMS(tmpEvent.getFilename()) +
+		getFileLengthMS(tmpEvent.getDecayFilename());
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Core/GameEngine/Source/Common/Audio/GameSounds.cpp
+++ b/Core/GameEngine/Source/Common/Audio/GameSounds.cpp
@@ -232,7 +232,7 @@ Bool SoundManager::canPlayNow( AudioEventRTS *event )
 			const Int localPlayerIndex = rts::getObservedOrLocalPlayer()->getPlayerIndex();
 
 			if( (event->getAudioEventInfo()->m_type & ST_SHROUDED) &&
-					 ThePartitionManager->getShroudStatusForPlayer(localPlayerIndex, pos) != CELLSHROUD_CLEAR )
+				ThePartitionManager->getShroudStatusForPlayer(localPlayerIndex, pos) != CELLSHROUD_CLEAR )
 			{
 #ifdef INTENSIVE_AUDIO_DEBUG
 				DEBUG_LOG(("- culled due to shroud."));

--- a/Core/GameEngine/Source/Common/Audio/simpleplayer.cpp
+++ b/Core/GameEngine/Source/Common/Audio/simpleplayer.cpp
@@ -24,109 +24,109 @@
 ///////////////////////////////////////////////////////////////////////////////
 CSimplePlayer::CSimplePlayer( HRESULT* phr )
 {
-    m_cRef = 1;
-    m_cBuffersOutstanding = 0;
+	m_cRef = 1;
+	m_cBuffersOutstanding = 0;
 
-    m_pReader = nullptr;
+	m_pReader = nullptr;
 
-    m_pHeader = nullptr;
-    m_hwo = nullptr;
+	m_pHeader = nullptr;
+	m_hwo = nullptr;
 
-    m_fEof = FALSE;
-    m_pszUrl = nullptr;
+	m_fEof = FALSE;
+	m_pszUrl = nullptr;
 
 	*phr = S_OK;
 
-    m_hOpenEvent = CreateEvent( nullptr, FALSE, FALSE, SIMPLE_PLAYER_OPEN_EVENT );
+	m_hOpenEvent = CreateEvent( nullptr, FALSE, FALSE, SIMPLE_PLAYER_OPEN_EVENT );
 	if ( nullptr == m_hOpenEvent )
 	{
 		*phr = E_OUTOFMEMORY;
 	}
-    m_hCloseEvent = CreateEvent( nullptr, FALSE, FALSE, SIMPLE_PLAYER_CLOSE_EVENT );
+	m_hCloseEvent = CreateEvent( nullptr, FALSE, FALSE, SIMPLE_PLAYER_CLOSE_EVENT );
 	if ( nullptr == m_hCloseEvent )
 	{
 		*phr = E_OUTOFMEMORY;
 	}
 
-    m_hrOpen = S_OK;
+	m_hrOpen = S_OK;
 
 	m_hCompletionEvent = nullptr;
 
-    InitializeCriticalSection( &m_CriSec );
-    m_whdrHead = nullptr;
+	InitializeCriticalSection( &m_CriSec );
+	m_whdrHead = nullptr;
 }
 
 
 ///////////////////////////////////////////////////////////////////////////////
 CSimplePlayer::~CSimplePlayer()
 {
-    DEBUG_ASSERTCRASH( 0 == m_cBuffersOutstanding,("CSimplePlayer destructor m_cBuffersOutstanding != 0") );
+	DEBUG_ASSERTCRASH( 0 == m_cBuffersOutstanding,("CSimplePlayer destructor m_cBuffersOutstanding != 0") );
 
-    Close();
+	Close();
 
-    //
-    // final remove of everything in the wave header list
-    //
-    RemoveWaveHeaders();
-    DeleteCriticalSection( &m_CriSec );
+	//
+	// final remove of everything in the wave header list
+	//
+	RemoveWaveHeaders();
+	DeleteCriticalSection( &m_CriSec );
 
-    if( m_pHeader != nullptr )
-    {
-        m_pHeader->Release();
-        m_pHeader = nullptr;
-    }
+	if( m_pHeader != nullptr )
+	{
+		m_pHeader->Release();
+		m_pHeader = nullptr;
+	}
 
-    if( m_pReader != nullptr )
-    {
-        m_pReader->Release();
-        m_pReader = nullptr;
-    }
+	if( m_pReader != nullptr )
+	{
+		m_pReader->Release();
+		m_pReader = nullptr;
+	}
 
-    if( m_hwo != nullptr )
-    {
-        waveOutClose( m_hwo );
-    }
+	if( m_hwo != nullptr )
+	{
+		waveOutClose( m_hwo );
+	}
 
-    delete [] m_pszUrl;
+	delete [] m_pszUrl;
 
 	if ( m_hOpenEvent )
 	{
-	    CloseHandle( m_hOpenEvent );
+		CloseHandle( m_hOpenEvent );
 	}
 	if ( m_hCloseEvent )
 	{
-        CloseHandle( m_hCloseEvent );
+		CloseHandle( m_hCloseEvent );
 	}
 }
 
 
 ///////////////////////////////////////////////////////////////////////////////
 HRESULT STDMETHODCALLTYPE CSimplePlayer::QueryInterface(
-    REFIID riid,
-    void **ppvObject )
+	REFIID riid,
+	void **ppvObject )
 {
-    return( E_NOINTERFACE );
+	return( E_NOINTERFACE );
 }
 
 
 ///////////////////////////////////////////////////////////////////////////////
 ULONG STDMETHODCALLTYPE CSimplePlayer::AddRef()
 {
-    return( InterlockedIncrement( &m_cRef ) );
+	return( InterlockedIncrement( &m_cRef ) );
 }
 
 
 ///////////////////////////////////////////////////////////////////////////////
 ULONG STDMETHODCALLTYPE CSimplePlayer::Release()
 {
-    ULONG uRet = InterlockedDecrement( &m_cRef );
+	ULONG uRet = InterlockedDecrement( &m_cRef );
 
-    if( 0 == uRet )
-    {
-        delete this;
-    }
+	if( 0 == uRet )
+	{
+		delete this;
+	}
 
-    return( uRet );
+	return( uRet );
 }
 
 
@@ -139,361 +139,361 @@ HRESULT STDMETHODCALLTYPE CSimplePlayer::OnSample(
         /* [in] */ INSSBuffer __RPC_FAR *pSample,
         /* [in] */ VOID *pvContext )
 {
-    if( 0 != dwOutputNum )
-    {
-        return( S_OK );
-    }
+	if( 0 != dwOutputNum )
+	{
+		return( S_OK );
+	}
 
-    HRESULT hr = S_OK;
-    BYTE *pData;
-    DWORD cbData;
+	HRESULT hr = S_OK;
+	BYTE *pData;
+	DWORD cbData;
 
-    //
-    // first UnprepareHeader and remove everthing in the ready list
-    //
-    RemoveWaveHeaders( );
+	//
+	// first UnprepareHeader and remove everthing in the ready list
+	//
+	RemoveWaveHeaders( );
 
-    hr = pSample->GetBufferAndLength( &pData, &cbData );
-    if ( FAILED( hr ) )
-    {
-        return( E_UNEXPECTED );
-    }
+	hr = pSample->GetBufferAndLength( &pData, &cbData );
+	if ( FAILED( hr ) )
+	{
+		return( E_UNEXPECTED );
+	}
 
-    DEBUG_LOG(( " New Sample of length %d and PS time %d ms",
-              cbData, ( DWORD ) ( cnsSampleTime / 10000 ) ));
+	DEBUG_LOG(( " New Sample of length %d and PS time %d ms",
+		cbData, ( DWORD ) ( cnsSampleTime / 10000 ) ));
 
-    LPWAVEHDR pwh = (LPWAVEHDR) new BYTE[ sizeof( WAVEHDR ) + cbData ];
+	LPWAVEHDR pwh = (LPWAVEHDR) new BYTE[ sizeof( WAVEHDR ) + cbData ];
 
-    if( nullptr == pwh )
-    {
-        DEBUG_LOG(( "OnSample OUT OF MEMORY! "));
+	if( nullptr == pwh )
+	{
+		DEBUG_LOG(( "OnSample OUT OF MEMORY! "));
 
-        *m_phrCompletion = E_OUTOFMEMORY;
-        SetEvent( m_hCompletionEvent );
-        return( E_UNEXPECTED );
-    }
+		*m_phrCompletion = E_OUTOFMEMORY;
+		SetEvent( m_hCompletionEvent );
+		return( E_UNEXPECTED );
+	}
 
-    pwh->lpData = (LPSTR)&pwh[1];
-    pwh->dwBufferLength = cbData;
-    pwh->dwBytesRecorded = cbData;
-    pwh->dwUser = 0;
-    pwh->dwLoops = 0;
-    pwh->dwFlags = 0;
+	pwh->lpData = (LPSTR)&pwh[1];
+	pwh->dwBufferLength = cbData;
+	pwh->dwBytesRecorded = cbData;
+	pwh->dwUser = 0;
+	pwh->dwLoops = 0;
+	pwh->dwFlags = 0;
 
-    CopyMemory( pwh->lpData, pData, cbData );
+	CopyMemory( pwh->lpData, pData, cbData );
 
-    MMRESULT mmr;
+	MMRESULT mmr;
 
-    mmr = waveOutPrepareHeader( m_hwo, pwh, sizeof(WAVEHDR) );
-    mmr = MMSYSERR_NOERROR;
+	mmr = waveOutPrepareHeader( m_hwo, pwh, sizeof(WAVEHDR) );
+	mmr = MMSYSERR_NOERROR;
 
-    if( mmr != MMSYSERR_NOERROR )
-    {
-        DEBUG_LOG(( "failed to prepare wave buffer, error=%lu" , mmr ));
-        *m_phrCompletion = E_UNEXPECTED;
-        SetEvent( m_hCompletionEvent );
-        return( E_UNEXPECTED );
-    }
+	if( mmr != MMSYSERR_NOERROR )
+	{
+		DEBUG_LOG(( "failed to prepare wave buffer, error=%lu" , mmr ));
+		*m_phrCompletion = E_UNEXPECTED;
+		SetEvent( m_hCompletionEvent );
+		return( E_UNEXPECTED );
+	}
 
-    mmr = waveOutWrite( m_hwo, pwh, sizeof(WAVEHDR) );
-    mmr = MMSYSERR_NOERROR;
+	mmr = waveOutWrite( m_hwo, pwh, sizeof(WAVEHDR) );
+	mmr = MMSYSERR_NOERROR;
 
-    if( mmr != MMSYSERR_NOERROR )
-    {
-        delete pwh;
+	if( mmr != MMSYSERR_NOERROR )
+	{
+		delete pwh;
 
-        DEBUG_LOG(( "failed to write wave sample, error=%lu" , mmr ));
-        *m_phrCompletion = E_UNEXPECTED;
-        SetEvent( m_hCompletionEvent );
-        return( E_UNEXPECTED );
-    }
+		DEBUG_LOG(( "failed to write wave sample, error=%lu" , mmr ));
+		*m_phrCompletion = E_UNEXPECTED;
+		SetEvent( m_hCompletionEvent );
+		return( E_UNEXPECTED );
+	}
 
-    InterlockedIncrement( &m_cBuffersOutstanding );
+	InterlockedIncrement( &m_cBuffersOutstanding );
 
-    return( S_OK );
+	return( S_OK );
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 HRESULT CSimplePlayer::Play( LPCWSTR pszUrl, DWORD dwSecDuration, HANDLE hCompletionEvent, HRESULT *phrCompletion )
 {
-    HRESULT hr;
+	HRESULT hr;
 
-    //
-    // If the URL is not a UNC path, a full path, or an Internet-style URL then assume it is
-    // a relative local file name that needs to be expanded to a full path.
-    //
-    WCHAR wszFullUrl[ MAX_PATH ];
+	//
+	// If the URL is not a UNC path, a full path, or an Internet-style URL then assume it is
+	// a relative local file name that needs to be expanded to a full path.
+	//
+	WCHAR wszFullUrl[ MAX_PATH ];
 
-    if( ( 0 == wcsstr( pszUrl, L"\\\\" ) )
-        && ( 0 == wcsstr( pszUrl, L":\\" ) )
-        && ( 0 == wcsstr( pszUrl, L"://" ) ) )
-    {
-        //
-        // Expand to a full path name
-        //
-        LPWSTR pszCheck = _wfullpath( wszFullUrl, pszUrl, MAX_PATH );
+	if( ( 0 == wcsstr( pszUrl, L"\\\\" ) )
+		&& ( 0 == wcsstr( pszUrl, L":\\" ) )
+		&& ( 0 == wcsstr( pszUrl, L"://" ) ) )
+	{
+		//
+		// Expand to a full path name
+		//
+		LPWSTR pszCheck = _wfullpath( wszFullUrl, pszUrl, MAX_PATH );
 
-        if( nullptr == pszCheck )
-        {
-           DEBUG_LOG(( "internal error %lu" , GetLastError() ));
-           return E_UNEXPECTED ;
-        }
+		if( nullptr == pszCheck )
+		{
+			DEBUG_LOG(( "internal error %lu" , GetLastError() ));
+			return E_UNEXPECTED ;
+		}
 
 		pszUrl = wszFullUrl;
-    }
+	}
 
-    //
-    // Save a copy of the URL
-    //
-    delete[] m_pszUrl;
+	//
+	// Save a copy of the URL
+	//
+	delete[] m_pszUrl;
 
-    m_pszUrl = new WCHAR[ wcslen( pszUrl ) + 1 ];
+	m_pszUrl = new WCHAR[ wcslen( pszUrl ) + 1 ];
 
-    if( nullptr == m_pszUrl )
-    {
-        DEBUG_LOG(( "insufficient Memory"  )) ;
-        return( E_OUTOFMEMORY );
-    }
+	if( nullptr == m_pszUrl )
+	{
+		DEBUG_LOG(( "insufficient Memory"  )) ;
+		return( E_OUTOFMEMORY );
+	}
 
-    wcscpy( m_pszUrl, pszUrl );
+	wcscpy( m_pszUrl, pszUrl );
 
-    //
-    // Attempt to open the URL
-    //
-    m_hCompletionEvent = hCompletionEvent;
+	//
+	// Attempt to open the URL
+	//
+	m_hCompletionEvent = hCompletionEvent;
 
-    m_phrCompletion = phrCompletion;
+	m_phrCompletion = phrCompletion;
 
 #ifdef SUPPORT_DRM
 
-    hr = WMCreateReader( nullptr, WMT_RIGHT_PLAYBACK, &m_pReader );
+	hr = WMCreateReader( nullptr, WMT_RIGHT_PLAYBACK, &m_pReader );
 
 #else
 
-    hr = WMCreateReader( nullptr, 0, &m_pReader );
+	hr = WMCreateReader( nullptr, 0, &m_pReader );
 
 #endif
 
-    if( FAILED( hr ) )
-    {
-        DEBUG_LOG(( "failed to create audio reader (hr=0x%08x)" , hr ));
-        return( hr );
-    }
+	if( FAILED( hr ) )
+	{
+		DEBUG_LOG(( "failed to create audio reader (hr=0x%08x)" , hr ));
+		return( hr );
+	}
 
-    //
-    // Open the file
-    //
-    hr = m_pReader->Open( m_pszUrl, this, nullptr );
-    if ( SUCCEEDED( hr ) )
-    {
-        WaitForSingleObject( m_hOpenEvent, INFINITE );
-        hr = m_hrOpen;
-    }
-    if ( NS_E_NO_STREAM == hr )
-    {
-        DEBUG_LOG(( "Waiting for transmission to begin..." ));
-        WaitForSingleObject( m_hOpenEvent, INFINITE );
-        hr = m_hrOpen;
-    }
-    if ( FAILED( hr ) )
-    {
-        DEBUG_LOG(( "failed to open (hr=0x%08x)", hr ));
-        return( hr );
-    }
+	//
+	// Open the file
+	//
+	hr = m_pReader->Open( m_pszUrl, this, nullptr );
+	if ( SUCCEEDED( hr ) )
+	{
+		WaitForSingleObject( m_hOpenEvent, INFINITE );
+		hr = m_hrOpen;
+	}
+	if ( NS_E_NO_STREAM == hr )
+	{
+		DEBUG_LOG(( "Waiting for transmission to begin..." ));
+		WaitForSingleObject( m_hOpenEvent, INFINITE );
+		hr = m_hrOpen;
+	}
+	if ( FAILED( hr ) )
+	{
+		DEBUG_LOG(( "failed to open (hr=0x%08x)", hr ));
+		return( hr );
+	}
 
 
-    //
-    // It worked!  Display various attributes
-    //
-    hr = m_pReader->QueryInterface( IID_IWMHeaderInfo, ( VOID ** )&m_pHeader );
-    if ( FAILED( hr ) )
-    {
-        DEBUG_LOG(( "failed to qi for header interface (hr=0x%08x)" , hr ));
-        return( hr );
-    }
+	//
+	// It worked!  Display various attributes
+	//
+	hr = m_pReader->QueryInterface( IID_IWMHeaderInfo, ( VOID ** )&m_pHeader );
+	if ( FAILED( hr ) )
+	{
+		DEBUG_LOG(( "failed to qi for header interface (hr=0x%08x)" , hr ));
+		return( hr );
+	}
 
-    WORD i, wAttrCnt;
+	WORD i, wAttrCnt;
 
-    hr = m_pHeader->GetAttributeCount( 0, &wAttrCnt );
-    if ( FAILED( hr ) )
-    {
-        DEBUG_LOG(( "GetAttributeCount Failed (hr=0x%08x)" , hr ));
-        return( hr );
-    }
+	hr = m_pHeader->GetAttributeCount( 0, &wAttrCnt );
+	if ( FAILED( hr ) )
+	{
+		DEBUG_LOG(( "GetAttributeCount Failed (hr=0x%08x)" , hr ));
+		return( hr );
+	}
 
-    WCHAR *pwszName = nullptr;
-    BYTE *pValue = nullptr;
+	WCHAR *pwszName = nullptr;
+	BYTE *pValue = nullptr;
 
-    for ( i = 0; i < wAttrCnt ; i++ )
-    {
-        WORD wStream = 0;
-        WORD cchNamelen = 0;
-        WMT_ATTR_DATATYPE type;
-        WORD cbLength = 0;
+	for ( i = 0; i < wAttrCnt ; i++ )
+	{
+		WORD wStream = 0;
+		WORD cchNamelen = 0;
+		WMT_ATTR_DATATYPE type;
+		WORD cbLength = 0;
 
-        hr = m_pHeader->GetAttributeByIndex( i, &wStream, nullptr, &cchNamelen, &type, nullptr, &cbLength );
-        if ( FAILED( hr ) )
-        {
-            DEBUG_LOG(( "GetAttributeByIndex Failed (hr=0x%08x)" , hr ));
-            break;
-        }
+		hr = m_pHeader->GetAttributeByIndex( i, &wStream, nullptr, &cchNamelen, &type, nullptr, &cbLength );
+		if ( FAILED( hr ) )
+		{
+			DEBUG_LOG(( "GetAttributeByIndex Failed (hr=0x%08x)" , hr ));
+			break;
+		}
 
-        pwszName = new WCHAR[ cchNamelen ];
-        pValue = new BYTE[ cbLength ];
+		pwszName = new WCHAR[ cchNamelen ];
+		pValue = new BYTE[ cbLength ];
 
-        if( nullptr == pwszName || nullptr == pValue )
-        {
-            hr = E_OUTOFMEMORY;
-            break;
-        }
+		if( nullptr == pwszName || nullptr == pValue )
+		{
+			hr = E_OUTOFMEMORY;
+			break;
+		}
 
-        hr = m_pHeader->GetAttributeByIndex( i, &wStream, pwszName, &cchNamelen, &type, pValue, &cbLength );
-        if ( FAILED( hr ) )
-        {
-            DEBUG_LOG(( "GetAttributeByIndex Failed (hr=0x%08x)" , hr ));
-            break;
-        }
+		hr = m_pHeader->GetAttributeByIndex( i, &wStream, pwszName, &cchNamelen, &type, pValue, &cbLength );
+		if ( FAILED( hr ) )
+		{
+			DEBUG_LOG(( "GetAttributeByIndex Failed (hr=0x%08x)" , hr ));
+			break;
+		}
 
-        switch ( type )
-        {
-        case WMT_TYPE_DWORD:
-            DEBUG_LOG(("%ws:  %u" , pwszName, *((DWORD *) pValue) ));
-            break;
-        case WMT_TYPE_STRING:
-            DEBUG_LOG(("%ws:   %ws" , pwszName, (WCHAR *) pValue ));
-            break;
-        case WMT_TYPE_BINARY:
-            DEBUG_LOG(("%ws:   Type = Binary of Length %u" , pwszName, cbLength ));
-            break;
-        case WMT_TYPE_BOOL:
-            DEBUG_LOG(("%ws:   %s" , pwszName, ( * ( ( BOOL * ) pValue) ? _T( "true" ) : _T( "false" ) ) ));
-            break;
-        case WMT_TYPE_WORD:
-            DEBUG_LOG(("%ws:  %hu" , pwszName, *((WORD *) pValue) ));
-            break;
-        case WMT_TYPE_QWORD:
-            DEBUG_LOG(("%ws:  %I64u" , pwszName, *((QWORD *) pValue) ));
-            break;
-        case WMT_TYPE_GUID:
-            DEBUG_LOG(("%ws:  %I64x%I64x" , pwszName, *((QWORD *) pValue), *((QWORD *) pValue + 1) ));
-            break;
-        default:
-            DEBUG_LOG(("%ws:   Type = %d, Length %u" , pwszName, type, cbLength ));
-            break;
-        }
+		switch ( type )
+		{
+			case WMT_TYPE_DWORD:
+				DEBUG_LOG(("%ws:  %u" , pwszName, *((DWORD *) pValue) ));
+				break;
+			case WMT_TYPE_STRING:
+				DEBUG_LOG(("%ws:   %ws" , pwszName, (WCHAR *) pValue ));
+				break;
+			case WMT_TYPE_BINARY:
+				DEBUG_LOG(("%ws:   Type = Binary of Length %u" , pwszName, cbLength ));
+				break;
+			case WMT_TYPE_BOOL:
+				DEBUG_LOG(("%ws:   %s" , pwszName, ( * ( ( BOOL * ) pValue) ? _T( "true" ) : _T( "false" ) ) ));
+				break;
+			case WMT_TYPE_WORD:
+				DEBUG_LOG(("%ws:  %hu" , pwszName, *((WORD *) pValue) ));
+				break;
+			case WMT_TYPE_QWORD:
+				DEBUG_LOG(("%ws:  %I64u" , pwszName, *((QWORD *) pValue) ));
+				break;
+			case WMT_TYPE_GUID:
+				DEBUG_LOG(("%ws:  %I64x%I64x" , pwszName, *((QWORD *) pValue), *((QWORD *) pValue + 1) ));
+				break;
+			default:
+				DEBUG_LOG(("%ws:   Type = %d, Length %u" , pwszName, type, cbLength ));
+				break;
+		}
 
-        delete pwszName;
-        pwszName = nullptr;
+		delete pwszName;
+		pwszName = nullptr;
 
-        delete pValue;
-        pValue = nullptr;
-    }
+		delete pValue;
+		pValue = nullptr;
+	}
 
-    delete pwszName;
-    pwszName = nullptr;
+	delete pwszName;
+	pwszName = nullptr;
 
-    delete pValue;
-    pValue = nullptr;
+	delete pValue;
+	pValue = nullptr;
 
-    if ( FAILED( hr ) )
-    {
-        return( hr );
-    }
+	if ( FAILED( hr ) )
+	{
+		return( hr );
+	}
 
-    //
-    // Make sure we're audio only
-    //
-    DWORD cOutputs;
+	//
+	// Make sure we're audio only
+	//
+	DWORD cOutputs;
 
-    hr = m_pReader->GetOutputCount( &cOutputs );
-    if ( FAILED( hr ) )
-    {
-        DEBUG_LOG(( "failed GetOutputCount(), (hr=0x%08x)" , hr ));
-        return( hr );
-    }
+	hr = m_pReader->GetOutputCount( &cOutputs );
+	if ( FAILED( hr ) )
+	{
+		DEBUG_LOG(( "failed GetOutputCount(), (hr=0x%08x)" , hr ));
+		return( hr );
+	}
 
-    if ( cOutputs != 1 )
-    {
-        DEBUG_LOG(( "Not audio only (cOutputs = %d)." , cOutputs ));
-        // return( E_UNEXPECTED );
-    }
+	if ( cOutputs != 1 )
+	{
+		DEBUG_LOG(( "Not audio only (cOutputs = %d)." , cOutputs ));
+		// return( E_UNEXPECTED );
+	}
 
-    IWMOutputMediaProps *pProps;
-    hr = m_pReader->GetOutputProps( 0, &pProps );
-    if ( FAILED( hr ) )
-    {
-        DEBUG_LOG(( "failed GetOutputProps(), (hr=0x%08x)" , hr ));
-        return( hr );
-    }
+	IWMOutputMediaProps *pProps;
+	hr = m_pReader->GetOutputProps( 0, &pProps );
+	if ( FAILED( hr ) )
+	{
+		DEBUG_LOG(( "failed GetOutputProps(), (hr=0x%08x)" , hr ));
+		return( hr );
+	}
 
-    DWORD cbBuffer = 0;
+	DWORD cbBuffer = 0;
 
-    hr = pProps->GetMediaType( nullptr, &cbBuffer );
-    if ( FAILED( hr ) )
-    {
-        pProps->Release( );
-        DEBUG_LOG(( "GetMediaType failed (hr=0x%08x)" , hr ));
-        return( hr );
-    }
+	hr = pProps->GetMediaType( nullptr, &cbBuffer );
+	if ( FAILED( hr ) )
+	{
+		pProps->Release( );
+		DEBUG_LOG(( "GetMediaType failed (hr=0x%08x)" , hr ));
+		return( hr );
+	}
 
 	WM_MEDIA_TYPE *pMediaType = ( WM_MEDIA_TYPE * ) new BYTE[cbBuffer] ;
 
 	hr = pProps->GetMediaType( pMediaType, &cbBuffer );
-    if ( FAILED( hr ) )
-    {
-        pProps->Release( );
-        DEBUG_LOG(( "GetMediaType failed (hr=0x%08x)" , hr ));
-        return( hr );
-    }
+	if ( FAILED( hr ) )
+	{
+		pProps->Release( );
+		DEBUG_LOG(( "GetMediaType failed (hr=0x%08x)" , hr ));
+		return( hr );
+	}
 
-    pProps->Release( );
+	pProps->Release( );
 
-    if ( pMediaType->majortype != WMMEDIATYPE_Audio )
-    {
+	if ( pMediaType->majortype != WMMEDIATYPE_Audio )
+	{
 		delete[] (BYTE *) pMediaType ;
-        DEBUG_LOG(( "Not audio only (major type mismatch)."  ));
-        return( E_UNEXPECTED );
-    }
+		DEBUG_LOG(( "Not audio only (major type mismatch)."  ));
+		return( E_UNEXPECTED );
+	}
 
-    //
-    // Set up for audio playback
-    //
-    WAVEFORMATEX *pwfx = ( WAVEFORMATEX * )pMediaType->pbFormat;
-    memcpy( &m_wfx, pwfx, sizeof( WAVEFORMATEX ) + pwfx->cbSize );
+	//
+	// Set up for audio playback
+	//
+	WAVEFORMATEX *pwfx = ( WAVEFORMATEX * )pMediaType->pbFormat;
+	memcpy( &m_wfx, pwfx, sizeof( WAVEFORMATEX ) + pwfx->cbSize );
 
-    delete[] (BYTE *)pMediaType ;
+	delete[] (BYTE *)pMediaType ;
 	pMediaType = nullptr ;
 
-    MMRESULT mmr;
+	MMRESULT mmr;
 
-    mmr = waveOutOpen( &m_hwo,
-                       WAVE_MAPPER,
-                       &m_wfx,
-                       (DWORD)WaveProc,
-                       (DWORD)this,
-                       CALLBACK_FUNCTION );
-    mmr = MMSYSERR_NOERROR;
+	mmr = waveOutOpen( &m_hwo,
+		WAVE_MAPPER,
+		&m_wfx,
+		(DWORD)WaveProc,
+		(DWORD)this,
+		CALLBACK_FUNCTION );
+	mmr = MMSYSERR_NOERROR;
 
-    if( mmr != MMSYSERR_NOERROR  )
-    {
+	if( mmr != MMSYSERR_NOERROR  )
+	{
 
-        DEBUG_LOG(( "failed to open wav output device, error=%lu" , mmr ));
-        return( E_UNEXPECTED );
-    }
+		DEBUG_LOG(( "failed to open wav output device, error=%lu" , mmr ));
+		return( E_UNEXPECTED );
+	}
 
-    //
-    // Start reading the data (and rendering the audio)
-    //
-    QWORD cnsDuration = ( QWORD ) dwSecDuration * 10000000;
-    hr = m_pReader->Start( 0, cnsDuration, 1.0, nullptr );
+	//
+	// Start reading the data (and rendering the audio)
+	//
+	QWORD cnsDuration = ( QWORD ) dwSecDuration * 10000000;
+	hr = m_pReader->Start( 0, cnsDuration, 1.0, nullptr );
 
-    if( FAILED( hr ) )
-    {
-        DEBUG_LOG(( "failed Start(), (hr=0x%08x)" , hr ));
-        return( hr );
-    }
+	if( FAILED( hr ) )
+	{
+		DEBUG_LOG(( "failed Start(), (hr=0x%08x)" , hr ));
+		return( hr );
+	}
 
-    return( hr );
+	return( hr );
 }
 
 
@@ -505,204 +505,204 @@ HRESULT STDMETHODCALLTYPE CSimplePlayer::OnStatus(
         /* [in] */ BYTE __RPC_FAR *pValue,
         /* [in] */ void __RPC_FAR *pvContext)
 {
-    switch( Status )
-    {
-    case WMT_OPENED:
-        DEBUG_LOG(( "OnStatus( WMT_OPENED )"  ));
-        m_hrOpen = hr;
-        SetEvent( m_hOpenEvent );
-        break;
+	switch( Status )
+	{
+		case WMT_OPENED:
+			DEBUG_LOG(( "OnStatus( WMT_OPENED )"  ));
+			m_hrOpen = hr;
+			SetEvent( m_hOpenEvent );
+			break;
 
-    case WMT_SOURCE_SWITCH:
-        DEBUG_LOG(( "OnStatus( WMT_SOURCE_SWITCH )"  ));
-        m_hrOpen = hr;
-        SetEvent( m_hOpenEvent );
-        break;
+		case WMT_SOURCE_SWITCH:
+			DEBUG_LOG(( "OnStatus( WMT_SOURCE_SWITCH )"  ));
+			m_hrOpen = hr;
+			SetEvent( m_hOpenEvent );
+			break;
 
-    case WMT_ERROR:
-        DEBUG_LOG(( "OnStatus( WMT_ERROR )"  ));
-        break;
+		case WMT_ERROR:
+			DEBUG_LOG(( "OnStatus( WMT_ERROR )"  ));
+			break;
 
-    case WMT_STARTED:
-        DEBUG_LOG(( "OnStatus( WMT_STARTED )"  ));
-        break;
+		case WMT_STARTED:
+			DEBUG_LOG(( "OnStatus( WMT_STARTED )"  ));
+			break;
 
-    case WMT_STOPPED:
-        DEBUG_LOG(( "OnStatus( WMT_STOPPED )"  ));
-        break;
+		case WMT_STOPPED:
+			DEBUG_LOG(( "OnStatus( WMT_STOPPED )"  ));
+			break;
 
-    case WMT_BUFFERING_START:
-        DEBUG_LOG(( "OnStatus( WMT_BUFFERING START)"  ));
-        break;
+		case WMT_BUFFERING_START:
+			DEBUG_LOG(( "OnStatus( WMT_BUFFERING START)"  ));
+			break;
 
-    case WMT_BUFFERING_STOP:
-        DEBUG_LOG(( "OnStatus( WMT_BUFFERING STOP)"  ));
-        break;
+		case WMT_BUFFERING_STOP:
+			DEBUG_LOG(( "OnStatus( WMT_BUFFERING STOP)"  ));
+			break;
 
-    case WMT_EOF:
-        DEBUG_LOG(( "OnStatus( WMT_EOF )"  ));
+		case WMT_EOF:
+			DEBUG_LOG(( "OnStatus( WMT_EOF )"  ));
 
-        //
-        // cleanup and exit
-        //
+			//
+			// cleanup and exit
+			//
 
-        m_fEof = TRUE;
+			m_fEof = TRUE;
 
-        if( 0 == m_cBuffersOutstanding )
-        {
-            SetEvent( m_hCompletionEvent );
-        }
+			if( 0 == m_cBuffersOutstanding )
+			{
+				SetEvent( m_hCompletionEvent );
+			}
 
-        break;
+			break;
 
-    case WMT_END_OF_SEGMENT:
-        DEBUG_LOG(( "OnStatus( WMT_END_OF_SEGMENT )"  ));
+		case WMT_END_OF_SEGMENT:
+			DEBUG_LOG(( "OnStatus( WMT_END_OF_SEGMENT )"  ));
 
-        //
-        // cleanup and exit
-        //
+			//
+			// cleanup and exit
+			//
 
-        m_fEof = TRUE;
+			m_fEof = TRUE;
 
-        if( 0 == m_cBuffersOutstanding )
-        {
-            SetEvent( m_hCompletionEvent );
-        }
+			if( 0 == m_cBuffersOutstanding )
+			{
+				SetEvent( m_hCompletionEvent );
+			}
 
-        break;
+			break;
 
-    case WMT_LOCATING:
-        DEBUG_LOG(( "OnStatus( WMT_LOCATING )"  ));
-        break;
+		case WMT_LOCATING:
+			DEBUG_LOG(( "OnStatus( WMT_LOCATING )"  ));
+			break;
 
-    case WMT_CONNECTING:
-        DEBUG_LOG(( "OnStatus( WMT_CONNECTING )"  ));
-        break;
+		case WMT_CONNECTING:
+			DEBUG_LOG(( "OnStatus( WMT_CONNECTING )"  ));
+			break;
 
-    case WMT_NO_RIGHTS:
-        {
-            LPWSTR pwszEscapedURL = nullptr;
+		case WMT_NO_RIGHTS:
+		{
+			LPWSTR pwszEscapedURL = nullptr;
 
-            hr = MakeEscapedURL( m_pszUrl, &pwszEscapedURL );
+			hr = MakeEscapedURL( m_pszUrl, &pwszEscapedURL );
 
-            if( SUCCEEDED( hr ) )
-            {
-                WCHAR wszURL[ 0x1000 ];
+			if( SUCCEEDED( hr ) )
+			{
+				WCHAR wszURL[ 0x1000 ];
 
-                swprintf( wszURL, L"%s&filename=%s&embedded=false", pValue, pwszEscapedURL );
+				swprintf( wszURL, L"%s&filename=%s&embedded=false", pValue, pwszEscapedURL );
 
-                hr = LaunchURL( wszURL );
+				hr = LaunchURL( wszURL );
 
-                if( FAILED( hr ) )
-                {
-                    DEBUG_LOG(( "Unable to launch web browser to retrieve playback license (hr=0x%08x)" , hr ));
-                }
+				if( FAILED( hr ) )
+				{
+					DEBUG_LOG(( "Unable to launch web browser to retrieve playback license (hr=0x%08x)" , hr ));
+				}
 
-                delete [] pwszEscapedURL;
+				delete [] pwszEscapedURL;
 				pwszEscapedURL = nullptr ;
-            }
-        }
-        break;
+			}
+		}
+			break;
 
-    case WMT_MISSING_CODEC:
+		case WMT_MISSING_CODEC:
 		{
 			DEBUG_LOG(( "Missing codec: (hr=0x%08x)" , hr ));
 			break;
 		}
 
-    case WMT_CLOSED:
-        SetEvent( m_hCloseEvent );
-        break;
-    };
+		case WMT_CLOSED:
+			SetEvent( m_hCloseEvent );
+			break;
+	};
 
-    return( S_OK );
+	return( S_OK );
 }
 
 
 ///////////////////////////////////////////////////////////////////////////////
 HRESULT CSimplePlayer::Close()
 {
-    HRESULT hr = S_OK;
+	HRESULT hr = S_OK;
 
-    if( nullptr != m_pReader )
-    {
-        hr = m_pReader->Close();
+	if( nullptr != m_pReader )
+	{
+		hr = m_pReader->Close();
 
-        if( SUCCEEDED( hr ) )
-        {
-            WaitForSingleObject( m_hCloseEvent, INFINITE );
-        }
-    }
+		if( SUCCEEDED( hr ) )
+		{
+			WaitForSingleObject( m_hCloseEvent, INFINITE );
+		}
+	}
 
-    return( hr );
+	return( hr );
 }
 
 
 ///////////////////////////////////////////////////////////////////////////////
 void CSimplePlayer::OnWaveOutMsg( UINT uMsg, DWORD dwParam1, DWORD dwParam2 )
 {
-    if( WOM_DONE == uMsg )
-    {
-        //
-        // add the wave header to ready-to-free list for the caller
-        // to pick up and free in the next OnSample call
-        //
-        AddWaveHeader( ( LPWAVEHDR )dwParam1 );
+	if( WOM_DONE == uMsg )
+	{
+		//
+		// add the wave header to ready-to-free list for the caller
+		// to pick up and free in the next OnSample call
+		//
+		AddWaveHeader( ( LPWAVEHDR )dwParam1 );
 
-        InterlockedDecrement( &m_cBuffersOutstanding );
+		InterlockedDecrement( &m_cBuffersOutstanding );
 
-        if( m_fEof && ( 0 == m_cBuffersOutstanding ) )
-        {
-            SetEvent( m_hCompletionEvent );
-        }
-    }
+		if( m_fEof && ( 0 == m_cBuffersOutstanding ) )
+		{
+			SetEvent( m_hCompletionEvent );
+		}
+	}
 }
 
 
 ///////////////////////////////////////////////////////////////////////////////
 void CALLBACK CSimplePlayer::WaveProc(
-                                HWAVEOUT hwo,
-                                UINT uMsg,
-                                DWORD dwInstance,
-                                DWORD dwParam1,
-                                DWORD dwParam2 )
+	HWAVEOUT hwo,
+	UINT uMsg,
+	DWORD dwInstance,
+	DWORD dwParam1,
+	DWORD dwParam2 )
 {
-    CSimplePlayer *pThis = (CSimplePlayer*)dwInstance;
+	CSimplePlayer *pThis = (CSimplePlayer*)dwInstance;
 
-    pThis->OnWaveOutMsg( uMsg, dwParam1, dwParam2 );
+	pThis->OnWaveOutMsg( uMsg, dwParam1, dwParam2 );
 }
 
 //////////////////////////////////////////////////////////////////////////////
 HRESULT CSimplePlayer::AddWaveHeader( LPWAVEHDR pwh )
 {
-    WAVEHDR_LIST *tmp = new WAVEHDR_LIST;
-    if( nullptr == tmp )
-    {
-        return( E_OUTOFMEMORY );
-    }
-    tmp->pwh = pwh;
+	WAVEHDR_LIST *tmp = new WAVEHDR_LIST;
+	if( nullptr == tmp )
+	{
+		return( E_OUTOFMEMORY );
+	}
+	tmp->pwh = pwh;
 
-    EnterCriticalSection( &m_CriSec );
-    tmp->next = m_whdrHead;
-    m_whdrHead = tmp;
-    LeaveCriticalSection( &m_CriSec );
-    return( S_OK );
+	EnterCriticalSection( &m_CriSec );
+	tmp->next = m_whdrHead;
+	m_whdrHead = tmp;
+	LeaveCriticalSection( &m_CriSec );
+	return( S_OK );
 }
 
 //////////////////////////////////////////////////////////////////////////////
 void CSimplePlayer::RemoveWaveHeaders( )
 {
-    WAVEHDR_LIST *tmp;
+	WAVEHDR_LIST *tmp;
 
-    EnterCriticalSection( &m_CriSec );
-    while( nullptr != m_whdrHead )
-    {
-        tmp = m_whdrHead->next;
-        DEBUG_ASSERTCRASH( m_whdrHead->pwh->dwFlags & WHDR_DONE, ("RemoveWaveHeaders!") );
-        waveOutUnprepareHeader( m_hwo, m_whdrHead->pwh, sizeof( WAVEHDR ) );
-        delete m_whdrHead->pwh;
-        delete m_whdrHead;
-        m_whdrHead = tmp;
-    }
-    LeaveCriticalSection( &m_CriSec );
+	EnterCriticalSection( &m_CriSec );
+	while( nullptr != m_whdrHead )
+	{
+		tmp = m_whdrHead->next;
+		DEBUG_ASSERTCRASH( m_whdrHead->pwh->dwFlags & WHDR_DONE, ("RemoveWaveHeaders!") );
+		waveOutUnprepareHeader( m_hwo, m_whdrHead->pwh, sizeof( WAVEHDR ) );
+		delete m_whdrHead->pwh;
+		delete m_whdrHead;
+		m_whdrHead = tmp;
+	}
+	LeaveCriticalSection( &m_CriSec );
 }

--- a/Core/GameEngine/Source/Common/Audio/urllaunch.cpp
+++ b/Core/GameEngine/Source/Common/Audio/urllaunch.cpp
@@ -25,314 +25,314 @@
 ///////////////////////////////////////////////////////////////////////////////
 HRESULT MakeEscapedURL( LPWSTR pszInURL, LPWSTR *ppszOutURL )
 {
-    if( ( nullptr == pszInURL ) || ( nullptr == ppszOutURL ) )
-    {
-        return( E_INVALIDARG );
-    }
+	if( ( nullptr == pszInURL ) || ( nullptr == ppszOutURL ) )
+	{
+		return( E_INVALIDARG );
+	}
 
-    //
-    // Do we need to pre-pend file://?
-    //
-    BOOL fNeedFilePrefix = ( 0 == wcsstr( pszInURL, L"://" ) );
+	//
+	// Do we need to pre-pend file://?
+	//
+	BOOL fNeedFilePrefix = ( 0 == wcsstr( pszInURL, L"://" ) );
 
-    //
-    // Count how many characters need to be escaped
-    //
-    LPWSTR pszTemp = pszInURL;
-    DWORD cEscapees = 0;
+	//
+	// Count how many characters need to be escaped
+	//
+	LPWSTR pszTemp = pszInURL;
+	DWORD cEscapees = 0;
 
-    while( TRUE )
-    {
-        LPWSTR pchToEscape = wcspbrk( pszTemp, L" #$%&\\+,;=@[]^{}" );
+	while( TRUE )
+	{
+		LPWSTR pchToEscape = wcspbrk( pszTemp, L" #$%&\\+,;=@[]^{}" );
 
-        if( nullptr == pchToEscape )
-        {
-            break;
-        }
+		if( nullptr == pchToEscape )
+		{
+			break;
+		}
 
-        cEscapees++;
+		cEscapees++;
 
-        pszTemp = pchToEscape + 1;
-    }
+		pszTemp = pchToEscape + 1;
+	}
 
-    //
-    // Allocate sufficient outgoing buffer space
-    //
-    int cchNeeded = wcslen( pszInURL ) + ( 2 * cEscapees ) + 1;
+	//
+	// Allocate sufficient outgoing buffer space
+	//
+	int cchNeeded = wcslen( pszInURL ) + ( 2 * cEscapees ) + 1;
 
-    if( fNeedFilePrefix )
-    {
-        cchNeeded += wcslen( FILE_PREFIX );
-    }
+	if( fNeedFilePrefix )
+	{
+		cchNeeded += wcslen( FILE_PREFIX );
+	}
 
-    *ppszOutURL = new WCHAR[ cchNeeded ];
+	*ppszOutURL = new WCHAR[ cchNeeded ];
 
-    if( nullptr == *ppszOutURL )
-    {
-        return( E_OUTOFMEMORY );
-    }
+	if( nullptr == *ppszOutURL )
+	{
+		return( E_OUTOFMEMORY );
+	}
 
-    //
-    // Fill in the outgoing escaped buffer
-    //
-    pszTemp = pszInURL;
+	//
+	// Fill in the outgoing escaped buffer
+	//
+	pszTemp = pszInURL;
 
-    LPWSTR pchNext = *ppszOutURL;
+	LPWSTR pchNext = *ppszOutURL;
 
-    if( fNeedFilePrefix )
-    {
-        wcscpy( *ppszOutURL, FILE_PREFIX );
-        pchNext += wcslen( FILE_PREFIX );
-    }
+	if( fNeedFilePrefix )
+	{
+		wcscpy( *ppszOutURL, FILE_PREFIX );
+		pchNext += wcslen( FILE_PREFIX );
+	}
 
-    while( TRUE )
-    {
-        LPWSTR pchToEscape = wcspbrk( pszTemp, L" #$%&\\+,;=@[]^{}" );
+	while( TRUE )
+	{
+		LPWSTR pchToEscape = wcspbrk( pszTemp, L" #$%&\\+,;=@[]^{}" );
 
-        if( nullptr == pchToEscape )
-        {
-            //
-            // Copy the rest of the input string and get out
-            //
-            wcscpy( pchNext, pszTemp );
-            break;
-        }
+		if( nullptr == pchToEscape )
+		{
+			//
+			// Copy the rest of the input string and get out
+			//
+			wcscpy( pchNext, pszTemp );
+			break;
+		}
 
-        //
-        // Copy all characters since the previous escapee
-        //
-        int cchToCopy = pchToEscape - pszTemp;
+		//
+		// Copy all characters since the previous escapee
+		//
+		int cchToCopy = pchToEscape - pszTemp;
 
-        if( cchToCopy > 0 )
-        {
-            wcsncpy( pchNext, pszTemp, cchToCopy );
+		if( cchToCopy > 0 )
+		{
+			wcsncpy( pchNext, pszTemp, cchToCopy );
 
-            pchNext += cchToCopy;
-        }
+			pchNext += cchToCopy;
+		}
 
-        //
-        // Expand this character into an escape code and move on
-        //
-        pchNext += swprintf( pchNext, L"%%%02x", *pchToEscape );
+		//
+		// Expand this character into an escape code and move on
+		//
+		pchNext += swprintf( pchNext, L"%%%02x", *pchToEscape );
 
-        pszTemp = pchToEscape + 1;
-    }
+		pszTemp = pchToEscape + 1;
+	}
 
-    return( S_OK );
+	return( S_OK );
 }
 
 
 ///////////////////////////////////////////////////////////////////////////////
 HRESULT GetShellOpenCommand( LPTSTR ptszShellOpenCommand, DWORD cbShellOpenCommand )
 {
-    LONG lResult;
+	LONG lResult;
 
-    HKEY hKey = nullptr;
-    HKEY hFileKey = nullptr;
+	HKEY hKey = nullptr;
+	HKEY hFileKey = nullptr;
 
-    BOOL fFoundExtensionCommand = FALSE;
+	BOOL fFoundExtensionCommand = FALSE;
 
-    do
-    {
-        //
-        // Look for the file type associated with .html files
-        //
-        TCHAR szFileType[ MAX_PATH ];
+	do
+	{
+		//
+		// Look for the file type associated with .html files
+		//
+		TCHAR szFileType[ MAX_PATH ];
 
-        lResult = RegOpenKeyEx( HKEY_CLASSES_ROOT, _T( ".html" ), 0, KEY_READ, &hKey );
+		lResult = RegOpenKeyEx( HKEY_CLASSES_ROOT, _T( ".html" ), 0, KEY_READ, &hKey );
 
-        if( ERROR_SUCCESS != lResult )
-        {
-            break;
-        }
+		if( ERROR_SUCCESS != lResult )
+		{
+			break;
+		}
 
-        DWORD dwLength = sizeof( szFileType );
+		DWORD dwLength = sizeof( szFileType );
 
-        lResult = RegQueryValueEx( hKey, nullptr, 0, nullptr, (BYTE *)szFileType, &dwLength );
+		lResult = RegQueryValueEx( hKey, nullptr, 0, nullptr, (BYTE *)szFileType, &dwLength );
 
-        if( ERROR_SUCCESS != lResult )
-        {
-            break;
-        }
+		if( ERROR_SUCCESS != lResult )
+		{
+			break;
+		}
 
-        //
-        // Find the command for the shell's open verb associated with this file type
-        //
-        TCHAR szKeyName[ MAX_PATH + 20 ];
+		//
+		// Find the command for the shell's open verb associated with this file type
+		//
+		TCHAR szKeyName[ MAX_PATH + 20 ];
 
-        wsprintf( szKeyName, _T( "%s\\shell\\open\\command" ), szFileType );
+		wsprintf( szKeyName, _T( "%s\\shell\\open\\command" ), szFileType );
 
-        lResult = RegOpenKeyEx( HKEY_CLASSES_ROOT, szKeyName, 0, KEY_READ, &hFileKey );
+		lResult = RegOpenKeyEx( HKEY_CLASSES_ROOT, szKeyName, 0, KEY_READ, &hFileKey );
 
-        if( ERROR_SUCCESS != lResult )
-        {
-            break;
-        }
+		if( ERROR_SUCCESS != lResult )
+		{
+			break;
+		}
 
-        dwLength = cbShellOpenCommand;
+		dwLength = cbShellOpenCommand;
 
-        lResult = RegQueryValueEx( hFileKey, nullptr, 0, nullptr, (BYTE *)ptszShellOpenCommand, &dwLength );
+		lResult = RegQueryValueEx( hFileKey, nullptr, 0, nullptr, (BYTE *)ptszShellOpenCommand, &dwLength );
 
-        if( 0 == lResult )
-        {
-            fFoundExtensionCommand = TRUE;
-        }
-    }
-    while( FALSE );
+		if( 0 == lResult )
+		{
+			fFoundExtensionCommand = TRUE;
+		}
+	}
+	while( FALSE );
 
-    //
-    // If there was no application associated with .html files by extension, look for
-    // an application associated with the http protocol
-    //
-    if( !fFoundExtensionCommand )
-    {
-        if( nullptr != hKey )
-        {
-            RegCloseKey( hKey );
-        }
+	//
+	// If there was no application associated with .html files by extension, look for
+	// an application associated with the http protocol
+	//
+	if( !fFoundExtensionCommand )
+	{
+		if( nullptr != hKey )
+		{
+			RegCloseKey( hKey );
+		}
 
-        do
-        {
-            //
-            // Find the command for the shell's open verb associated with the http protocol
-            //
-            lResult = RegOpenKeyEx( HKEY_CLASSES_ROOT, _T( "http\\shell\\open\\command" ), 0, KEY_READ, &hKey );
+		do
+		{
+			//
+			// Find the command for the shell's open verb associated with the http protocol
+			//
+			lResult = RegOpenKeyEx( HKEY_CLASSES_ROOT, _T( "http\\shell\\open\\command" ), 0, KEY_READ, &hKey );
 
-            if( ERROR_SUCCESS != lResult )
-            {
-                break;
-            }
+			if( ERROR_SUCCESS != lResult )
+			{
+				break;
+			}
 
-            DWORD dwLength = cbShellOpenCommand;
+			DWORD dwLength = cbShellOpenCommand;
 
-            lResult = RegQueryValueEx( hKey, nullptr, 0, nullptr, (BYTE *)ptszShellOpenCommand, &dwLength );
-        }
-        while( FALSE );
-    }
+			lResult = RegQueryValueEx( hKey, nullptr, 0, nullptr, (BYTE *)ptszShellOpenCommand, &dwLength );
+		}
+		while( FALSE );
+	}
 
-    if( nullptr != hKey )
-    {
-        RegCloseKey( hKey );
-    }
+	if( nullptr != hKey )
+	{
+		RegCloseKey( hKey );
+	}
 
-    if( nullptr != hFileKey )
-    {
-        RegCloseKey( hFileKey );
-    }
+	if( nullptr != hFileKey )
+	{
+		RegCloseKey( hFileKey );
+	}
 
-    return( HRESULT_FROM_WIN32( lResult ) );
+	return( HRESULT_FROM_WIN32( lResult ) );
 }
 
 
 ///////////////////////////////////////////////////////////////////////////////
 HRESULT LaunchURL( LPCWSTR pszURL )
 {
-    HRESULT hr;
+	HRESULT hr;
 
-    //
-    // Find the appropriate command to launch URLs with
-    //
-    TCHAR szShellOpenCommand[ MAX_PATH * 2 ];
+	//
+	// Find the appropriate command to launch URLs with
+	//
+	TCHAR szShellOpenCommand[ MAX_PATH * 2 ];
 
-    hr = GetShellOpenCommand( szShellOpenCommand, sizeof( szShellOpenCommand ) );
+	hr = GetShellOpenCommand( szShellOpenCommand, sizeof( szShellOpenCommand ) );
 
-    if( FAILED( hr ) )
-    {
-        return( hr );
-    }
+	if( FAILED( hr ) )
+	{
+		return( hr );
+	}
 
-    //
-    // Build the appropriate command line, substituting our URL parameter
-    //
-    TCHAR szLaunchCommand[ 2000 ];
+	//
+	// Build the appropriate command line, substituting our URL parameter
+	//
+	TCHAR szLaunchCommand[ 2000 ];
 
-    LPTSTR pszParam = _tcsstr( szShellOpenCommand, _T( "\"%1\"" ) );
+	LPTSTR pszParam = _tcsstr( szShellOpenCommand, _T( "\"%1\"" ) );
 
-    if( nullptr == pszParam )
-    {
-        pszParam = _tcsstr( szShellOpenCommand, _T( "\"%*\"" ) );
-    }
+	if( nullptr == pszParam )
+	{
+		pszParam = _tcsstr( szShellOpenCommand, _T( "\"%*\"" ) );
+	}
 
-    if( nullptr != pszParam )
-    {
-        *pszParam = _T( '\0' ) ;
+	if( nullptr != pszParam )
+	{
+		*pszParam = _T( '\0' ) ;
 
-        wsprintf( szLaunchCommand, _T( "%s%ws%s" ), szShellOpenCommand, pszURL, pszParam + 4 );
-    }
-    else
-    {
-        wsprintf( szLaunchCommand, _T( "%s %ws" ), szShellOpenCommand, pszURL );
-    }
+		wsprintf( szLaunchCommand, _T( "%s%ws%s" ), szShellOpenCommand, pszURL, pszParam + 4 );
+	}
+	else
+	{
+		wsprintf( szLaunchCommand, _T( "%s %ws" ), szShellOpenCommand, pszURL );
+	}
 
-    //
-    // Find the application name, stripping quotes if necessary
-    //
-    TCHAR szExe[ MAX_PATH * 2 ];
-    LPTSTR pchFirst = szShellOpenCommand;
-    LPTSTR pchNext = nullptr;
+	//
+	// Find the application name, stripping quotes if necessary
+	//
+	TCHAR szExe[ MAX_PATH * 2 ];
+	LPTSTR pchFirst = szShellOpenCommand;
+	LPTSTR pchNext = nullptr;
 
-    while( _T( ' ' ) == *pchFirst )
-    {
-        pchFirst++;
-    }
+	while( _T( ' ' ) == *pchFirst )
+	{
+		pchFirst++;
+	}
 
-    if( _T( '"' ) == *pchFirst )
-    {
-        pchFirst++;
+	if( _T( '"' ) == *pchFirst )
+	{
+		pchFirst++;
 
-        pchNext = _tcschr( pchFirst, _T( '"' ) );
-    }
-    else
-    {
-        pchNext = _tcschr( pchFirst + 1, _T( ' ' ) );
-    }
+		pchNext = _tcschr( pchFirst, _T( '"' ) );
+	}
+	else
+	{
+		pchNext = _tcschr( pchFirst + 1, _T( ' ' ) );
+	}
 
-    if( nullptr == pchNext )
-    {
-        pchNext = szShellOpenCommand + _tcslen( szShellOpenCommand );
-    }
+	if( nullptr == pchNext )
+	{
+		pchNext = szShellOpenCommand + _tcslen( szShellOpenCommand );
+	}
 
-    _tcsncpy( szExe, pchFirst, pchNext - pchFirst );
-    szExe[ pchNext - pchFirst ] = _T( '\0' ) ;
+	_tcsncpy( szExe, pchFirst, pchNext - pchFirst );
+	szExe[ pchNext - pchFirst ] = _T( '\0' ) ;
 
-    //
-    // Because of the extremely long length of the URLs, neither
-    // WinExec, nor ShellExecute, were working correctly.  For this reason
-    // we use CreateProcess.  The CreateProcess documentation in MSDN says
-    // that the most robust way to call CreateProcess is to pass the full
-    // command line, where the first element is the application name, in the
-    // lpCommandLine parameter.  In our case this is necesssary to get Netscape
-    // to function properly.
-    //
-    PROCESS_INFORMATION ProcInfo;
-    ZeroMemory( (LPVOID)&ProcInfo, sizeof( PROCESS_INFORMATION ) );
+	//
+	// Because of the extremely long length of the URLs, neither
+	// WinExec, nor ShellExecute, were working correctly.  For this reason
+	// we use CreateProcess.  The CreateProcess documentation in MSDN says
+	// that the most robust way to call CreateProcess is to pass the full
+	// command line, where the first element is the application name, in the
+	// lpCommandLine parameter.  In our case this is necesssary to get Netscape
+	// to function properly.
+	//
+	PROCESS_INFORMATION ProcInfo;
+	ZeroMemory( (LPVOID)&ProcInfo, sizeof( PROCESS_INFORMATION ) );
 
-    STARTUPINFO StartUp;
-    ZeroMemory( (LPVOID)&StartUp, sizeof( STARTUPINFO ) );
+	STARTUPINFO StartUp;
+	ZeroMemory( (LPVOID)&StartUp, sizeof( STARTUPINFO ) );
 
-    StartUp.cb = sizeof(STARTUPINFO);
+	StartUp.cb = sizeof(STARTUPINFO);
 
-    if( !CreateProcess( szExe, szLaunchCommand, nullptr, nullptr,
-                        FALSE, 0, nullptr, nullptr, &StartUp, &ProcInfo) )
-    {
-        hr = HRESULT_FROM_WIN32( GetLastError() );
-    }
-    else
-    {
-        //
-        // CreateProcess succeeded and we do not need the handles to the thread
-        // or the process, so close them now.
-        //
-        if( nullptr != ProcInfo.hThread )
-        {
-            CloseHandle( ProcInfo.hThread );
-        }
+	if( !CreateProcess( szExe, szLaunchCommand, nullptr, nullptr,
+		FALSE, 0, nullptr, nullptr, &StartUp, &ProcInfo) )
+	{
+		hr = HRESULT_FROM_WIN32( GetLastError() );
+	}
+	else
+	{
+		//
+		// CreateProcess succeeded and we do not need the handles to the thread
+		// or the process, so close them now.
+		//
+		if( nullptr != ProcInfo.hThread )
+		{
+			CloseHandle( ProcInfo.hThread );
+		}
 
-        if( nullptr != ProcInfo.hProcess )
-        {
-            CloseHandle( ProcInfo.hProcess );
-        }
-    }
+		if( nullptr != ProcInfo.hProcess )
+		{
+			CloseHandle( ProcInfo.hProcess );
+		}
+	}
 
-    return( hr );
+	return( hr );
 }

--- a/Core/GameEngine/Source/Common/CRCDebug.cpp
+++ b/Core/GameEngine/Source/Common/CRCDebug.cpp
@@ -226,10 +226,10 @@ static void addCRCDebugLineInternal(bool count, const char *fmt, va_list args)
 
 void addCRCDebugLine(const char *fmt, ...)
 {
-    va_list args;
-    va_start(args, fmt);
-    addCRCDebugLineInternal(true, fmt, args);
-    va_end(args);
+	va_list args;
+	va_start(args, fmt);
+	addCRCDebugLineInternal(true, fmt, args);
+	va_end(args);
 }
 
 void addCRCDebugLineNoCounter(const char *fmt, ...)
@@ -238,10 +238,10 @@ void addCRCDebugLineNoCounter(const char *fmt, ...)
 	// This version doesn't increase the lastCRCDebugIndex counter
 	// and can be used for logging lines that don't necessarily match up on all peers.
 	// (Otherwise the numbers would no longer match up and the diff would be very difficult to read)
-    va_list args;
-    va_start(args, fmt);
-    addCRCDebugLineInternal(false, fmt, args);
-    va_end(args);
+	va_list args;
+	va_start(args, fmt);
+	addCRCDebugLineInternal(false, fmt, args);
+	va_end(args);
 }
 
 void addCRCGenLine(const char *fmt, ...)

--- a/Core/GameEngine/Source/Common/Diagnostic/SimulationMathCrc.cpp
+++ b/Core/GameEngine/Source/Common/Diagnostic/SimulationMathCrc.cpp
@@ -28,46 +28,46 @@
 
 static void appendSimulationMathCrc(XferCRC &xfer)
 {
-    Matrix3D matrix;
-    Matrix3D factorsMatrix;
+	Matrix3D matrix;
+	Matrix3D factorsMatrix;
 
-    matrix.Set(
-        4.1f, 1.2f, 0.3f, 0.4f,
-        0.5f, 3.6f, 0.7f, 0.8f,
-        0.9f, 1.0f, 2.1f, 1.2f);
+	matrix.Set(
+		4.1f, 1.2f, 0.3f, 0.4f,
+		0.5f, 3.6f, 0.7f, 0.8f,
+		0.9f, 1.0f, 2.1f, 1.2f);
 
-    factorsMatrix.Set(
-        WWMath::Sin(0.7f) * log10f(2.3f),
-        WWMath::Cos(1.1f) * powf(1.1f, 2.0f),
-        tanf(0.3f),
-        asinf(0.967302263f),
-        acosf(0.967302263f),
-        atanf(0.967302263f) * powf(1.1f, 2.0f),
-        atan2f(0.4f, 1.3f),
-        sinhf(0.2f),
-        coshf(0.4f) * tanhf(0.5f),
-        sqrtf(55788.84375f),
-        expf(0.1f) * log10f(2.3f),
-        logf(1.4f));
+	factorsMatrix.Set(
+		WWMath::Sin(0.7f) * log10f(2.3f),
+		WWMath::Cos(1.1f) * powf(1.1f, 2.0f),
+		tanf(0.3f),
+		asinf(0.967302263f),
+		acosf(0.967302263f),
+		atanf(0.967302263f) * powf(1.1f, 2.0f),
+		atan2f(0.4f, 1.3f),
+		sinhf(0.2f),
+		coshf(0.4f) * tanhf(0.5f),
+		sqrtf(55788.84375f),
+		expf(0.1f) * log10f(2.3f),
+		logf(1.4f));
 
-    Matrix3D::Multiply(matrix, factorsMatrix, &matrix);
-    matrix.Get_Inverse(matrix);
+	Matrix3D::Multiply(matrix, factorsMatrix, &matrix);
+	matrix.Get_Inverse(matrix);
 
-    xfer.xferMatrix3D(&matrix);
+	xfer.xferMatrix3D(&matrix);
 }
 
 UnsignedInt SimulationMathCrc::calculate()
 {
-    XferCRC xfer;
-    xfer.open("SimulationMathCrc");
+	XferCRC xfer;
+	xfer.open("SimulationMathCrc");
 
-    setFPMode();
+	setFPMode();
 
-    appendSimulationMathCrc(xfer);
+	appendSimulationMathCrc(xfer);
 
-    _fpreset();
+	_fpreset();
 
-    xfer.close();
+	xfer.close();
 
-    return xfer.getCRC();
+	return xfer.getCRC();
 }

--- a/Core/GameEngine/Source/Common/INI/INI.cpp
+++ b/Core/GameEngine/Source/Common/INI/INI.cpp
@@ -425,7 +425,7 @@ UnsignedInt INI::load( AsciiString filename, INILoadType loadType, Xfer *pXfer )
 				else
 				{
 					DEBUG_CRASH( ("[LINE: %d - FILE: '%s'] Unknown block '%s'",
-														 getLineNum(), getFilename().str(), token ) );
+						getLineNum(), getFilename().str(), token ) );
 					throw INI_UNKNOWN_TOKEN;
 				}
 
@@ -1549,7 +1549,7 @@ void INI::initFromINIMulti( void *what, const MultiIniFieldParse& parseTableList
 
 						} catch (...) {
 							DEBUG_CRASH( ("[LINE: %d - FILE: '%s'] Error reading field '%s' of block '%s'",
-																 INI::getLineNum(), INI::getFilename().str(), field, m_curBlockStart) );
+								INI::getLineNum(), INI::getFilename().str(), field, m_curBlockStart) );
 
 
 							char buff[1024];
@@ -1567,7 +1567,7 @@ void INI::initFromINIMulti( void *what, const MultiIniFieldParse& parseTableList
 				if (!found)
 				{
 					DEBUG_CRASH( ("[LINE: %d - FILE: '%s'] Unknown field '%s' in block '%s'",
-														 INI::getLineNum(), INI::getFilename().str(), field, m_curBlockStart) );
+						INI::getLineNum(), INI::getFilename().str(), field, m_curBlockStart) );
 				}
 
 			}
@@ -1580,7 +1580,7 @@ void INI::initFromINIMulti( void *what, const MultiIniFieldParse& parseTableList
 
 			done = TRUE;
 			DEBUG_CRASH( ("Error parsing block '%s', in INI file '%s'.  Missing '%s' token",
-												 m_curBlockStart, getFilename().str(), m_blockEndToken) );
+				m_curBlockStart, getFilename().str(), m_blockEndToken) );
 			throw INI_MISSING_END_TOKEN;
 
 		}

--- a/Core/GameEngine/Source/Common/INI/INIMiscAudio.cpp
+++ b/Core/GameEngine/Source/Common/INI/INIMiscAudio.cpp
@@ -65,7 +65,7 @@ const FieldParse MiscAudio::m_fieldParseTable[] =
 	{ "RepairSparks",													INI::parseAudioEventRTS, nullptr, offsetof( MiscAudio, m_repairSparks ) },
 	{ "SabotageShutDownBuilding",							INI::parseAudioEventRTS, nullptr, offsetof( MiscAudio, m_sabotageShutDownBuilding ) },
 	{ "SabotageResetTimeBuilding",						INI::parseAudioEventRTS, nullptr, offsetof( MiscAudio, m_sabotageResetTimerBuilding ) },
-  { "AircraftWheelScreech",									INI::parseAudioEventRTS, nullptr, offsetof( MiscAudio, m_aircraftWheelScreech ) },
+	{ "AircraftWheelScreech",									INI::parseAudioEventRTS, nullptr, offsetof( MiscAudio, m_aircraftWheelScreech ) },
 
 	{ nullptr, nullptr, nullptr, 0 }
 };

--- a/Core/GameEngine/Source/Common/System/AsciiString.cpp
+++ b/Core/GameEngine/Source/Common/System/AsciiString.cpp
@@ -434,9 +434,9 @@ void AsciiString::format(AsciiString format, ...)
 {
 	validate();
 	va_list args;
-  va_start(args, format);
+	va_start(args, format);
 	format_va(format, args);
-  va_end(args);
+	va_end(args);
 	validate();
 }
 
@@ -445,9 +445,9 @@ void AsciiString::format(const char* format, ...)
 {
 	validate();
 	va_list args;
-  va_start(args, format);
+	va_start(args, format);
 	format_va(format, args);
-  va_end(args);
+	va_end(args);
 	validate();
 }
 

--- a/Core/GameEngine/Source/Common/System/Debug.cpp
+++ b/Core/GameEngine/Source/Common/System/Debug.cpp
@@ -769,7 +769,7 @@ void ReleaseCrash(const char *reason)
 	strlcpy(curbuf, TheGlobalData->getPath_UserData().str(), ARRAY_SIZE(curbuf));
 	strlcat(curbuf, RELEASECRASH_FILE_NAME, ARRAY_SIZE(curbuf));
 
- 	remove(prevbuf);
+	remove(prevbuf);
 	if (rename(curbuf, prevbuf) != 0)
 	{
 #ifdef DEBUG_LOGGING
@@ -815,9 +815,9 @@ void ReleaseCrash(const char *reason)
 //	::MessageBox(nullptr, "You have encountered a serious error.  Serious errors can be caused by many things including viruses, overheated hardware and hardware that does not meet the minimum specifications for the game. Please visit the forums at www.generals.ea.com for suggested courses of action or consult your manual for Technical Support contact information.", "Technical Difficulties...", MB_OK|MB_TASKMODAL|MB_ICONERROR);
 
 // crash error message changed again 8/22/03 M Lorenzen... made this message box modal to the system so it will appear on top of any task-modal windows, splash-screen, etc.
-  ::MessageBox(nullptr, "You have encountered a serious error.  Serious errors can be caused by many things including viruses, overheated hardware and hardware that does not meet the minimum specifications for the game. Please visit the forums at www.generals.ea.com for suggested courses of action or consult your manual for Technical Support contact information.",
-   "Technical Difficulties...",
-   MB_OK|MB_SYSTEMMODAL|MB_ICONERROR);
+	::MessageBox(nullptr, "You have encountered a serious error.  Serious errors can be caused by many things including viruses, overheated hardware and hardware that does not meet the minimum specifications for the game. Please visit the forums at www.generals.ea.com for suggested courses of action or consult your manual for Technical Support contact information.",
+		"Technical Difficulties...",
+		MB_OK|MB_SYSTEMMODAL|MB_ICONERROR);
 
 
 #endif
@@ -857,7 +857,7 @@ void ReleaseCrashLocalized(const AsciiString& p, const AsciiString& m)
 	strlcpy(curbuf, TheGlobalData->getPath_UserData().str(), ARRAY_SIZE(curbuf));
 	strlcat(curbuf, RELEASECRASH_FILE_NAME, ARRAY_SIZE(curbuf));
 
- 	remove(prevbuf);
+	remove(prevbuf);
 	if (rename(curbuf, prevbuf) != 0)
 	{
 #ifdef DEBUG_LOGGING

--- a/Core/GameEngine/Source/Common/System/GameMemory.cpp
+++ b/Core/GameEngine/Source/Common/System/GameMemory.cpp
@@ -1638,12 +1638,12 @@ void* MemoryPool::allocateBlockDoNotZeroImplementation(DECLARE_LITERALSTRING_ARG
 		for (; blob != nullptr; blob = blob->getNextInList())
 		{
 			if (blob->hasAnyFreeBlocks())
-			 	break;
+			break;
 		}
 
 		// note that if we walk thru the list without finding anything, this will
 		// reset m_firstBlobWithFreeBlocks to null and fall thru.
-	 	m_firstBlobWithFreeBlocks = blob;
+		m_firstBlobWithFreeBlocks = blob;
 	}
 
 	// OK, if we are here then we have no blobs with freespace... darn.
@@ -2247,9 +2247,9 @@ void *DynamicMemoryAllocator::allocateBytesDoNotZeroImplementation(Int numBytes 
 #endif
 
 #if defined(RTS_DEBUG)
-  // check alignment
-  if (unsigned(result)&3)
-    throw ERROR_OUT_OF_MEMORY;
+	// check alignment
+	if (unsigned(result)&3)
+	throw ERROR_OUT_OF_MEMORY;
 #endif
 
 	return result;

--- a/Core/GameEngine/Source/Common/System/ObjectStatusTypes.cpp
+++ b/Core/GameEngine/Source/Common/System/ObjectStatusTypes.cpp
@@ -75,7 +75,7 @@ const char* const ObjectStatusMaskType::s_bitNameList[] =
 	"STATUS_RIDER7",
 	"STATUS_RIDER8",
 	"FAERIE_FIRE",
-  "KILLING_SELF",
+	"KILLING_SELF",
 	"REASSIGN_PARKING",
 	"BOOBY_TRAPPED",
 	"IMMOBILE",

--- a/Core/GameEngine/Source/Common/System/Radar.cpp
+++ b/Core/GameEngine/Source/Common/System/Radar.cpp
@@ -387,8 +387,8 @@ Bool Radar::addObject( Object *obj )
 
 	// sanity
 	DEBUG_ASSERTCRASH( obj->friend_getRadarData() == nullptr,
-										 ("Radar: addObject - non null radar data for '%s'",
-										 obj->getTemplate()->getName().str()) );
+		("Radar: addObject - non null radar data for '%s'",
+		obj->getTemplate()->getName().str()) );
 
 	// allocate a new object
 	newObj = newInstance(RadarObject);
@@ -479,7 +479,7 @@ Bool Radar::removeObject( Object *obj )
 	else
 	{
 		DEBUG_CRASH( ("Radar: Tried to remove object '%s' which was not found",
-											 obj->getTemplate()->getName().str()) );
+			obj->getTemplate()->getName().str()) );
 		return FALSE;
 	}
 
@@ -516,7 +516,7 @@ Bool Radar::radarToWorld2D( const ICoord2D *radar, Coord3D *world )
 	// translate to world
 	world->x = x * m_xSample;
 	world->y = y * m_ySample;
-  return TRUE;
+	return TRUE;
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -527,8 +527,8 @@ Bool Radar::radarToWorld2D( const ICoord2D *radar, Coord3D *world )
 //-------------------------------------------------------------------------------------------------
 Bool Radar::radarToWorld( const ICoord2D *radar, Coord3D *world )
 {
-  if (!radarToWorld2D(radar,world))
-    return FALSE;
+	if (!radarToWorld2D(radar,world))
+	return FALSE;
 
 	// find the terrain height here
 	world->z = TheTerrainLogic->getGroundHeight( world->x, world->y );
@@ -769,7 +769,7 @@ Object *Radar::searchListForRadarLocationMatch( RadarObject *listHead, ICoord2D 
 	* aspect ratio of the map */
 // ------------------------------------------------------------------------------------------------
 void Radar::findDrawPositions( Int startX, Int startY, Int width, Int height,
-															 ICoord2D *ul, ICoord2D *lr )
+	ICoord2D *ul, ICoord2D *lr )
 {
 
 	Real ratioWidth;
@@ -931,7 +931,7 @@ void Radar::createEvent( const Coord3D *world, RadarEventType type, Real seconds
 /** Create radar event using a specific colors from the player */
 // ------------------------------------------------------------------------------------------------
 void Radar::createPlayerEvent( Player *player, const Coord3D *world,
-															 RadarEventType type, Real secondsToLive )
+	RadarEventType type, Real secondsToLive )
 {
 
 	// sanity
@@ -973,7 +973,7 @@ void Radar::createPlayerEvent( Player *player, const Coord3D *world,
 /** Create a new radar event */
 //-------------------------------------------------------------------------------------------------
 void Radar::internalCreateEvent( const Coord3D *world, RadarEventType type, Real secondsToLive,
-																 const RGBAColorInt *color1, const RGBAColorInt *color2 )
+	const RGBAColorInt *color1, const RGBAColorInt *color2 )
 {
 	static Real secondsBeforeDieToFade = 0.5f;  ///< this many seconds before we hit the die frame we start to fade away
 

--- a/Core/GameEngine/Source/Common/System/UnicodeString.cpp
+++ b/Core/GameEngine/Source/Common/System/UnicodeString.cpp
@@ -366,9 +366,9 @@ void UnicodeString::format(UnicodeString format, ...)
 {
 	validate();
 	va_list args;
-  va_start(args, format);
+	va_start(args, format);
 	format_va(format, args);
-  va_end(args);
+	va_end(args);
 	validate();
 }
 
@@ -377,9 +377,9 @@ void UnicodeString::format(const WideChar* format, ...)
 {
 	validate();
 	va_list args;
-  va_start(args, format);
+	va_start(args, format);
 	format_va(format, args);
-  va_end(args);
+	va_end(args);
 	validate();
 }
 

--- a/Core/GameEngine/Source/Common/System/Xfer.cpp
+++ b/Core/GameEngine/Source/Common/System/Xfer.cpp
@@ -849,9 +849,9 @@ void Xfer::xferMatrix3D( Matrix3D* mtx )
 	XferVersion version = currentVersion;
 	xferVersion( &version, currentVersion );
 
- 	Vector4& tmp0 = (*mtx)[0];
- 	Vector4& tmp1 = (*mtx)[1];
- 	Vector4& tmp2 = (*mtx)[2];
+	Vector4& tmp0 = (*mtx)[0];
+	Vector4& tmp1 = (*mtx)[1];
+	Vector4& tmp2 = (*mtx)[2];
 
 	xferReal(&tmp0.X);
 	xferReal(&tmp0.Y);

--- a/Core/GameEngine/Source/Common/System/XferCRC.cpp
+++ b/Core/GameEngine/Source/Common/System/XferCRC.cpp
@@ -269,7 +269,7 @@ void XferDeepCRC::xferImplementation( void *data, Int dataSize )
 
 	// sanity
 	DEBUG_ASSERTCRASH( m_fileFP != nullptr, ("XferSave - file pointer for '%s' is null",
-										 m_identifier.str()) );
+		m_identifier.str()) );
 
 	// write data to file
 	if( fwrite( data, dataSize, 1, m_fileFP ) != 1 )

--- a/Core/GameEngine/Source/Common/System/XferLoad.cpp
+++ b/Core/GameEngine/Source/Common/System/XferLoad.cpp
@@ -123,7 +123,7 @@ Int XferLoad::beginBlock()
 
 	// sanity
 	DEBUG_ASSERTCRASH( m_fileFP != nullptr, ("Xfer begin block - file pointer for '%s' is null",
-										 m_identifier.str()) );
+		m_identifier.str()) );
 
 	// read block size
 	XferBlockSize blockSize;
@@ -156,11 +156,11 @@ void XferLoad::skip( Int dataSize )
 
 	// sanity
 	DEBUG_ASSERTCRASH( m_fileFP != nullptr, ("XferLoad::skip - file pointer for '%s' is null",
-										 m_identifier.str()) );
+		m_identifier.str()) );
 
 	// sanity
 	DEBUG_ASSERTCRASH( dataSize >=0, ("XferLoad::skip - dataSize '%d' must be greater than 0",
-										 dataSize) );
+		dataSize) );
 
 	// skip datasize in the file from the current position
 	if( fseek( m_fileFP, dataSize, SEEK_CUR ) != 0 )
@@ -245,7 +245,7 @@ void XferLoad::xferImplementation( void *data, Int dataSize )
 
 	// sanity
 	DEBUG_ASSERTCRASH( m_fileFP != nullptr, ("XferLoad - file pointer for '%s' is null",
-										 m_identifier.str()) );
+		m_identifier.str()) );
 
 	// read data from file
 	if( fread( data, dataSize, 1, m_fileFP ) != 1 )

--- a/Core/GameEngine/Source/Common/System/XferSave.cpp
+++ b/Core/GameEngine/Source/Common/System/XferSave.cpp
@@ -167,7 +167,7 @@ Int XferSave::beginBlock()
 
 	// sanity
 	DEBUG_ASSERTCRASH( m_fileFP != nullptr, ("Xfer begin block - file pointer for '%s' is null",
-										 m_identifier.str()) );
+		m_identifier.str()) );
 
 	// get the current file position so we can back up here for the next end block call
 	XferFilePos filePos = ftell( m_fileFP );
@@ -212,7 +212,7 @@ void XferSave::endBlock()
 
 	// sanity
 	DEBUG_ASSERTCRASH( m_fileFP != nullptr, ("Xfer end block - file pointer for '%s' is null",
-										 m_identifier.str()) );
+		m_identifier.str()) );
 
 	// sanity, make sure we have a block started
 	if( m_blockStack == nullptr )
@@ -259,7 +259,7 @@ void XferSave::skip( Int dataSize )
 
 	// sanity
 	DEBUG_ASSERTCRASH( m_fileFP != nullptr, ("XferSave - file pointer for '%s' is null",
-										 m_identifier.str()) );
+		m_identifier.str()) );
 
 
 	// skip forward dataSize bytes
@@ -344,7 +344,7 @@ void XferSave::xferImplementation( void *data, Int dataSize )
 
 	// sanity
 	DEBUG_ASSERTCRASH( m_fileFP != nullptr, ("XferSave - file pointer for '%s' is null",
-										 m_identifier.str()) );
+		m_identifier.str()) );
 
 	// write data to file
 	if( fwrite( data, dataSize, 1, m_fileFP ) != 1 )

--- a/Core/GameEngine/Source/Common/UserPreferences.cpp
+++ b/Core/GameEngine/Source/Common/UserPreferences.cpp
@@ -692,42 +692,42 @@ static const char superweaponRestrictionKey[] = "SuperweaponRestrict";
 
 Bool CustomMatchPreferences::getSuperweaponRestricted() const
 {
-  const_iterator it = find(superweaponRestrictionKey);
-  if (it == end())
-  {
-    return false;
-  }
+	const_iterator it = find(superweaponRestrictionKey);
+	if (it == end())
+	{
+		return false;
+	}
 
-  return ( it->second.compareNoCase( "yes" ) == 0 );
+	return ( it->second.compareNoCase( "yes" ) == 0 );
 }
 
 void CustomMatchPreferences::setSuperweaponRestricted( Bool superweaponRestricted )
 {
-  (*this)[superweaponRestrictionKey] = superweaponRestricted ? "Yes" : "No";
+	(*this)[superweaponRestrictionKey] = superweaponRestricted ? "Yes" : "No";
 }
 
 static const char startingCashKey[] = "StartingCash";
 Money CustomMatchPreferences::getStartingCash() const
 {
-  const_iterator it = find(startingCashKey);
-  if (it == end())
-  {
-    return TheMultiplayerSettings->getDefaultStartingMoney();
-  }
+	const_iterator it = find(startingCashKey);
+	if (it == end())
+	{
+		return TheMultiplayerSettings->getDefaultStartingMoney();
+	}
 
-  Money money;
-  money.deposit( strtoul( it->second.str(), nullptr, 10 ), FALSE, FALSE );
+	Money money;
+	money.deposit( strtoul( it->second.str(), nullptr, 10 ), FALSE, FALSE );
 
-  return money;
+	return money;
 }
 
 void CustomMatchPreferences::setStartingCash( const Money & startingCash )
 {
-  AsciiString option;
+	AsciiString option;
 
-  option.format( "%d", startingCash.countMoney() );
+	option.format( "%d", startingCash.countMoney() );
 
-  (*this)[startingCashKey] = option;
+	(*this)[startingCashKey] = option;
 }
 
 
@@ -736,18 +736,18 @@ static const char limitFactionsKey[] = "LimitArmies";
 // Prefers to only use the original 3 sides, not USA Air Force General, GLA Toxin General, et al
 Bool CustomMatchPreferences::getFactionsLimited() const
 {
-  const_iterator it = find(limitFactionsKey);
-  if (it == end())
-  {
-    return false; // The default
-  }
+	const_iterator it = find(limitFactionsKey);
+	if (it == end())
+	{
+		return false; // The default
+	}
 
-  return ( it->second.compareNoCase( "yes" ) == 0 );
+	return ( it->second.compareNoCase( "yes" ) == 0 );
 }
 
 void CustomMatchPreferences::setFactionsLimited( Bool factionsLimited )
 {
-  (*this)[limitFactionsKey] = factionsLimited ? "Yes" : "No";
+	(*this)[limitFactionsKey] = factionsLimited ? "Yes" : "No";
 }
 
 
@@ -755,18 +755,18 @@ static const char useStatsKey[] = "UseStats";
 
 Bool CustomMatchPreferences::getUseStats() const
 {
-  const_iterator it = find(useStatsKey);
-  if (it == end())
-  {
-    return true; // The default
-  }
+	const_iterator it = find(useStatsKey);
+	if (it == end())
+	{
+		return true; // The default
+	}
 
-  return ( it->second.compareNoCase( "yes" ) == 0 );
+	return ( it->second.compareNoCase( "yes" ) == 0 );
 }
 
 void CustomMatchPreferences::setUseStats( Bool useStats )
 {
-  (*this)[useStatsKey] = useStats ? "Yes" : "No";
+	(*this)[useStatsKey] = useStats ? "Yes" : "No";
 }
 
 //-----------------------------------------------------------------------------

--- a/Core/GameEngine/Source/GameClient/Color.cpp
+++ b/Core/GameEngine/Source/GameClient/Color.cpp
@@ -85,10 +85,10 @@
 //static UnsignedByte s_cheaterHasBeenSpied = 0;
 
 void GameGetColorComponents( Color color,
-														 UnsignedByte *red,
-														 UnsignedByte *green,
-														 UnsignedByte *blue,
-														 UnsignedByte *alpha )
+	UnsignedByte *red,
+	UnsignedByte *green,
+	UnsignedByte *blue,
+	UnsignedByte *alpha )
 {
 
 	*alpha	= (color & 0xFF000000) >> 24;

--- a/Core/GameEngine/Source/GameClient/Credits.cpp
+++ b/Core/GameEngine/Source/GameClient/Credits.cpp
@@ -274,7 +274,7 @@ void CreditsManager::update()
 		}
 		break;
 	case CREDIT_STYLE_NORMAL:
-	 {
+		{
 			cLine->m_color = m_normalColor;
 
 			if(TheGlobalLanguageData && !cLine->m_text.isEmpty())
@@ -443,7 +443,7 @@ void CreditsManager::addText( AsciiString text )
 				CreditsLineList::reverse_iterator rIt = m_creditLineList.rbegin();
 				CreditsLine *rcLine = *rIt;
 				if(rIt == m_creditLineList.rend() || rcLine->m_style != CREDIT_STYLE_COLUMN
-				   || (rcLine->m_style == CREDIT_STYLE_COLUMN && rcLine->m_done == TRUE))
+				|| (rcLine->m_style == CREDIT_STYLE_COLUMN && rcLine->m_done == TRUE))
 				{
 					cLine->m_text = getUnicodeString(text);
 					cLine->m_style = CREDIT_STYLE_COLUMN;

--- a/Core/GameEngine/Source/GameClient/FXList.cpp
+++ b/Core/GameEngine/Source/GameClient/FXList.cpp
@@ -141,10 +141,10 @@ EMPTY_DTOR(SoundFXNugget)
 //-------------------------------------------------------------------------------------------------
 static Real calcDist(const Coord3D& src, const Coord3D& dst)
 {
-  Real dx = dst.x - src.x;
-  Real dy = dst.y - src.y;
-  Real dz = dst.z - src.z;
-  return sqrt(dx*dx + dy*dy + dz*dz);
+	Real dx = dst.x - src.x;
+	Real dy = dst.y - src.y;
+	Real dz = dst.z - src.z;
+	return sqrt(dx*dx + dy*dy + dz*dz);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -156,9 +156,9 @@ public:
 	TracerFXNugget()
 	{
 		m_tracerName.set("GenericTracer");
-    m_boneName.clear();
-    m_speed = 0.0f; // means "use passed-in speed"
-    m_decayAt = 1.0f;
+		m_boneName.clear();
+		m_speed = 0.0f; // means "use passed-in speed"
+		m_decayAt = 1.0f;
 		m_length = 10.0f;
 		m_width = 1.0f;
 		m_color.red = m_color.green = m_color.blue = 1.0f;
@@ -224,12 +224,12 @@ public:
 		{
 			{ "TracerName",			INI::parseAsciiString,			nullptr, offsetof( TracerFXNugget, m_tracerName ) },
 			{ "BoneName",				INI::parseAsciiString,			nullptr, offsetof( TracerFXNugget, m_boneName ) },
-      { "Speed",          INI::parseVelocityReal,     nullptr, offsetof( TracerFXNugget, m_speed ) },
-      { "DecayAt",        INI::parseReal,             nullptr, offsetof( TracerFXNugget, m_decayAt ) },
-      { "Length",					INI::parseReal,             nullptr, offsetof( TracerFXNugget, m_length ) },
-      { "Width",					INI::parseReal,             nullptr, offsetof( TracerFXNugget, m_width ) },
-      { "Color",					INI::parseRGBColor,					nullptr, offsetof( TracerFXNugget, m_color ) },
-      { "Probability",		INI::parseReal,             nullptr, offsetof( TracerFXNugget, m_probability ) },
+			{ "Speed",          INI::parseVelocityReal,     nullptr, offsetof( TracerFXNugget, m_speed ) },
+			{ "DecayAt",        INI::parseReal,             nullptr, offsetof( TracerFXNugget, m_decayAt ) },
+			{ "Length",					INI::parseReal,             nullptr, offsetof( TracerFXNugget, m_length ) },
+			{ "Width",					INI::parseReal,             nullptr, offsetof( TracerFXNugget, m_width ) },
+			{ "Color",					INI::parseRGBColor,					nullptr, offsetof( TracerFXNugget, m_color ) },
+			{ "Probability",		INI::parseReal,             nullptr, offsetof( TracerFXNugget, m_probability ) },
 			{ nullptr, nullptr, nullptr, 0 }
 		};
 
@@ -240,9 +240,9 @@ public:
 
 private:
 	AsciiString			m_tracerName;
-  AsciiString     m_boneName;
-  Real            m_speed;
-  Real            m_decayAt;
+	AsciiString     m_boneName;
+	Real            m_speed;
+	Real            m_decayAt;
 	Real						m_length;
 	Real						m_width;
 	RGBColor				m_color;
@@ -690,8 +690,8 @@ public:
 	FXListAtBonePosFXNugget()
 	{
 		m_fx = nullptr;
-    m_boneName.clear();
-    m_orientToBone = true;
+		m_boneName.clear();
+		m_orientToBone = true;
 	}
 
 	virtual void doFXPos(const Coord3D *primary, const Matrix3D* primaryMtx, const Real /*primarySpeed*/, const Coord3D * /*secondary*/, const Real /*overrideRadius*/ ) const override
@@ -703,10 +703,10 @@ public:
 	{
 		if (primary)
 		{
-      // first, try the unadorned name.
+			// first, try the unadorned name.
 			doFxAtBones(primary, 0);
 
-      // then, try the 01,02,03...etc names.
+			// then, try the 01,02,03...etc names.
 			doFxAtBones(primary, 1);
 		}
 		else
@@ -734,10 +734,10 @@ protected:
 
 	void doFxAtBones(const Object* obj, Int start) const
 	{
-    Coord3D bonePos[MAX_BONE_POINTS];
-    Matrix3D boneMtx[MAX_BONE_POINTS];
+		Coord3D bonePos[MAX_BONE_POINTS];
+		Matrix3D boneMtx[MAX_BONE_POINTS];
 
-    Drawable* draw = obj->getDrawable();
+		Drawable* draw = obj->getDrawable();
 		if (draw)
 		{
 			// yes, BONEPOS_CURRENT_CLIENT_ONLY -- this is client-only, so should be safe to do.
@@ -757,8 +757,8 @@ private:
 	enum { MAX_BONE_POINTS = 40 };
 
 	const FXList*		m_fx;
-  AsciiString     m_boneName;
-  Bool            m_orientToBone;
+	AsciiString     m_boneName;
+	Bool            m_orientToBone;
 };
 EMPTY_DTOR(FXListAtBonePosFXNugget)
 
@@ -854,8 +854,8 @@ const FXList *FXListStore::findFXList(const char* name) const
 	if (stricmp(name, "None") == 0)
 		return nullptr;
 
-  FXListMap::const_iterator it = m_fxmap.find(NAMEKEY(name));
-  if (it != m_fxmap.end())
+	FXListMap::const_iterator it = m_fxmap.find(NAMEKEY(name));
+	if (it != m_fxmap.end())
 	{
 		return &(*it).second;
 	}

--- a/Core/GameEngine/Source/GameClient/GUI/GameWindow.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/GameWindow.cpp
@@ -260,7 +260,7 @@ GameWindow *GameWindow::findPrevLeaf()
 		leaf = leaf->m_prev;
 
 		while( leaf->m_child &&
-					 BitIsSet( leaf->m_status, WIN_STATUS_TAB_STOP ) == FALSE )
+			BitIsSet( leaf->m_status, WIN_STATUS_TAB_STOP ) == FALSE )
 		{
 
 			leaf = leaf->m_child;
@@ -287,7 +287,7 @@ GameWindow *GameWindow::findPrevLeaf()
 				leaf = leaf->m_prev;
 
 				while( leaf->m_child &&
-							 BitIsSet( leaf->m_status, WIN_STATUS_TAB_STOP ) == FALSE )
+					BitIsSet( leaf->m_status, WIN_STATUS_TAB_STOP ) == FALSE )
 				{
 
 					leaf = leaf->m_child;
@@ -458,8 +458,8 @@ Int GameWindow::winBringToTop()
 
 		// sanity, make sure this window is in the window list
 		for( current = TheWindowManager->winGetWindowList();
-				 current != this;
-				 current = current->m_next)
+		current != this;
+		current = current->m_next)
 			if (current == nullptr)
 				return WIN_ERR_INVALID_PARAMETER;
 
@@ -701,7 +701,7 @@ Int GameWindow::winEnable( Bool enable )
 //=============================================================================
 Bool GameWindow::winGetEnabled()
 {
-  return BitIsSet( m_status, WIN_STATUS_ENABLED );
+	return BitIsSet( m_status, WIN_STATUS_ENABLED );
 
 }
 
@@ -1396,8 +1396,8 @@ Int GameWindow::winSetTooltipFunc( GameWinTooltipFunc tooltip )
 /** Sets the window's input, tooltip, and redraw callback functions. */
 //=============================================================================
 Int GameWindow::winSetCallbacks( GameWinInputFunc input,
-																 GameWinDrawFunc draw,
-																 GameWinTooltipFunc tooltip )
+	GameWinDrawFunc draw,
+	GameWinTooltipFunc tooltip )
 {
 
 	winSetInputFunc( input );
@@ -1565,7 +1565,7 @@ WindowMsgHandledType GameWinBlockInput( GameWindow *window, UnsignedInt msg,
 /** The default system callback.  Currently does nothing. */
 //=============================================================================
 WindowMsgHandledType GameWinDefaultSystem( GameWindow *window, UnsignedInt msg,
-													 WindowMsgData mData1, WindowMsgData mData2 )
+	WindowMsgData mData1, WindowMsgData mData2 )
 {
 
 	return MSG_IGNORED;

--- a/Core/GameEngine/Source/GameClient/GUI/GameWindowGlobal.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/GameWindowGlobal.cpp
@@ -85,8 +85,8 @@ void GameWindowManager::winDrawImage( const Image *image, Int startX, Int startY
 /** draw filled rect, coords are absolute screen coords */
 //=============================================================================
 void GameWindowManager::winFillRect( Color color, Real width,
-																		 Int startX, Int startY,
-																		 Int endX, Int endY )
+	Int startX, Int startY,
+	Int endX, Int endY )
 {
 
 	TheDisplay->drawFillRect( startX, startY,
@@ -99,8 +99,8 @@ void GameWindowManager::winFillRect( Color color, Real width,
 /** draw rect outline, coords are absolute screen coords */
 //=============================================================================
 void GameWindowManager::winOpenRect( Color color, Real width,
-																		 Int startX, Int startY,
-																		 Int endX, Int endY )
+	Int startX, Int startY,
+	Int endX, Int endY )
 {
 
 	TheDisplay->drawOpenRect( startX, startY,
@@ -113,8 +113,8 @@ void GameWindowManager::winOpenRect( Color color, Real width,
 /** draw line, coords are absolute screen coords */
 //=============================================================================
 void GameWindowManager::winDrawLine( Color color, Real width,
-																		 Int startX, Int startY,
-																		 Int endX, Int endY )
+	Int startX, Int startY,
+	Int endX, Int endY )
 {
 
 	TheDisplay->drawLine( startX, startY, endX, endY, width, color );
@@ -142,9 +142,9 @@ const Image *GameWindowManager::winFindImage( const char *name )
 	* individual project needs */
 //=============================================================================
 Color GameWindowManager::winMakeColor( UnsignedByte red,
-																			 UnsignedByte green,
-																			 UnsignedByte blue,
-																			 UnsignedByte alpha )
+	UnsignedByte green,
+	UnsignedByte blue,
+	UnsignedByte alpha )
 {
 
 	return GameMakeColor( red, green, blue, alpha );
@@ -155,7 +155,7 @@ Color GameWindowManager::winMakeColor( UnsignedByte red,
 /** draw text to the screen */
 //=============================================================================
 void GameWindowManager::winFormatText( GameFont *font, UnicodeString text, Color color,
-																			 Int x, Int y, Int width, Int height )
+	Int x, Int y, Int width, Int height )
 {
 
 	/// @todo make all display string rendering go through here!

--- a/Core/GameEngine/Source/GameClient/GUI/GameWindowTransitions.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/GameWindowTransitions.cpp
@@ -572,7 +572,7 @@ void GameWindowTransitionsHandler::parseWindow( INI* ini, void *instance, void *
 	static const FieldParse myFieldParse[] =
 		{
 			{ "WinName",				INI::parseAsciiString,		nullptr,									offsetof( TransitionWindow, m_winName ) },
-      { "Style",					INI::parseLookupList,			TransitionStyleNames,	offsetof( TransitionWindow, m_style ) },
+		{ "Style",					INI::parseLookupList,			TransitionStyleNames,	offsetof( TransitionWindow, m_style ) },
 			{ "FrameDelay",			INI::parseInt,						nullptr,									offsetof( TransitionWindow, m_frameDelay ) },
 			{ nullptr,							nullptr,											nullptr, 0 }
 		};

--- a/Core/GameEngine/Source/GameClient/GUI/IMEManager.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/IMEManager.cpp
@@ -267,7 +267,7 @@ IMEManager::MessageInfo IMEManager::m_controlInfo[] =
 	{ "IMC_SETSTATUSWINDOWPOS"		, IMC_SETSTATUSWINDOWPOS  },
 	{ "IMC_CLOSESTATUSWINDOW"			, IMC_CLOSESTATUSWINDOW   },
 	{ "IMC_OPENSTATUSWINDOW"			, IMC_OPENSTATUSWINDOW    },
- 	{ nullptr, 0 }
+	{ nullptr, 0 }
 };
 
 IMEManager::MessageInfo IMEManager::m_setContextInfo[] =
@@ -555,9 +555,9 @@ IMEManager::~IMEManager()
 void IMEManager::init()
 {
 	//HWND ImeWindow = ImmGetDefaultIMEWnd(ApplicationHWnd);
-  // if(ImeWindow)
+	// if(ImeWindow)
 	// {
-  //    DestroyWindow(ImeWindow);
+	//    DestroyWindow(ImeWindow);
 	//	}
 
 	m_context = ImmCreateContext();
@@ -668,7 +668,7 @@ Bool IMEManager::serviceIMEMessage(	void *windowsHandle, UnsignedInt message,	In
 	printMessageInfo( message, wParam, lParam );
 	#endif
 
-   switch(message){
+	switch(message){
 
 			// --------------------------------------------------------------------
 			case WM_IME_CHAR:
@@ -706,20 +706,20 @@ Bool IMEManager::serviceIMEMessage(	void *windowsHandle, UnsignedInt message,	In
 			}
 
 			// --------------------------------------------------------------------
-      case WM_IME_SELECT:
+		case WM_IME_SELECT:
 					DEBUG_LOG(("IMM: WM_IME_SELECT"));
 				return FALSE;
-      case WM_IME_STARTCOMPOSITION:
-        //The WM_IME_STARTCOMPOSITION message is sent immediately before an
-        //IME generates a composition string as a result of a user's keystroke.
-        //
+		case WM_IME_STARTCOMPOSITION:
+			//The WM_IME_STARTCOMPOSITION message is sent immediately before an
+			//IME generates a composition string as a result of a user's keystroke.
+			//
 				m_composing = TRUE;
 				m_compositionCharsDisplayed = 0;
 				updateCompositionString();
-        m_result = 1;
+			m_result = 1;
 				return TRUE;
 			// --------------------------------------------------------------------
-      case WM_IME_ENDCOMPOSITION:
+		case WM_IME_ENDCOMPOSITION:
 			{
 				//First remove the composition characters
 				m_composing = FALSE;
@@ -734,12 +734,12 @@ Bool IMEManager::serviceIMEMessage(	void *windowsHandle, UnsignedInt message,	In
 				// the strings real time inside WM_IME_COMPOSITION
 				// instead of waiting for user to enter separator. -MW
 
-        //IMEs send this message to the application when the IMEs' composition
-        //windows have closed. Applications that display their own composition
-        //characters should process this message. Other applications should
-        //send the message to the application IME window or to DefWindowProc,
-        //which will pass the message to  the default IME window.
-        //
+			//IMEs send this message to the application when the IMEs' composition
+			//windows have closed. Applications that display their own composition
+			//characters should process this message. Other applications should
+			//send the message to the application IME window or to DefWindowProc,
+			//which will pass the message to  the default IME window.
+			//
 
 				m_composing = FALSE; // reset this flag before calling GWM_IME_CHAR
 
@@ -907,7 +907,7 @@ Bool IMEManager::serviceIMEMessage(	void *windowsHandle, UnsignedInt message,	In
 						//
 						updateCandidateList( lParam );
 						m_result =  1;
-				 	  return TRUE;
+					return TRUE;
 					}
 					case IMN_GUIDELINE:              //This message is sent when an IME is about to show an error message or other data.
 					{
@@ -954,18 +954,18 @@ Bool IMEManager::serviceIMEMessage(	void *windowsHandle, UnsignedInt message,	In
 		}
 
 			// --------------------------------------------------------------------
-      case WM_IME_COMPOSITIONFULL:
+		case WM_IME_COMPOSITIONFULL:
 			{
 				//IMEs send this message to the application when they are unable to
-        //extend the composition window to accommodate any more characters.
-        //Applications should tell IMEs how to display the composition window
-        //using the IMC_SETCOMPOSITIONWINDOW message.
-        //
-        //I'm not sure what to do here.
-        m_result = 1;
+			//extend the composition window to accommodate any more characters.
+			//Applications should tell IMEs how to display the composition window
+			//using the IMC_SETCOMPOSITIONWINDOW message.
+			//
+			//I'm not sure what to do here.
+			m_result = 1;
 				return TRUE;
 			}
-   }
+	}
 
 	return FALSE;
 }
@@ -1170,7 +1170,7 @@ void IMEManager::getResultsString ()
 
 		if ( result >= 0 )
 		{
-		 stringLen = result/2;
+			stringLen = result/2;
 		}
 		else
 		{
@@ -1205,7 +1205,7 @@ void IMEManager::getResultsString ()
 
 void IMEManager::convertToUnicode ( Char *mbcs, UnicodeString &unicode )
 {
- 	int size = MultiByteToWideChar( CP_ACP, 0, mbcs, strlen(mbcs), nullptr, 0 );
+	int size = MultiByteToWideChar( CP_ACP, 0, mbcs, strlen(mbcs), nullptr, 0 );
 
 	unicode.clear();
 
@@ -1246,7 +1246,7 @@ void IMEManager::openCandidateList( Int candidateFlags )
 	}
 	// first get latest candidate list info
 	updateCandidateList( candidateFlags );
-  resizeCandidateWindow( m_pageSize );
+	resizeCandidateWindow( m_pageSize );
 
 	m_candidateWindow->winHide( FALSE );
 	m_candidateWindow->winBringToTop();
@@ -1395,13 +1395,13 @@ void IMEManager::updateCandidateList( Int candidateFlags  )
 
 			if ( ok && clist->dwStyle != IME_CAND_UNKNOWN && clist->dwStyle != IME_CAND_CODE  )
 			{
-		    //Apparently there is an "IME98 bug" (IME bug under Windows 98?) that
-		    //causes you to have to execute the following code.
-		    if(( clist->dwPageStart >  clist->dwSelection) ||
-		       (clist->dwSelection >= clist->dwPageStart + clist->dwPageSize))
-		    {
-		       clist->dwPageStart = (clist->dwSelection / clist->dwPageSize) * clist->dwPageSize;
-		    }
+				//Apparently there is an "IME98 bug" (IME bug under Windows 98?) that
+				//causes you to have to execute the following code.
+				if(( clist->dwPageStart >  clist->dwSelection) ||
+					(clist->dwSelection >= clist->dwPageStart + clist->dwPageSize))
+				{
+					clist->dwPageStart = (clist->dwSelection / clist->dwPageSize) * clist->dwPageSize;
+				}
 
 				m_pageSize = clist->dwPageSize;
 				m_candidateCount = clist->dwCount;

--- a/Core/GameEngine/Source/GameClient/GUI/LoadScreen.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/LoadScreen.cpp
@@ -653,8 +653,8 @@ void SinglePlayerLoadScreen::init( GameInfo *game )
 
 void SinglePlayerLoadScreen::reset()
 {
- setLoadScreen(nullptr);
- m_progressBar = nullptr;
+	setLoadScreen(nullptr);
+	m_progressBar = nullptr;
 }
 
 void SinglePlayerLoadScreen::update( Int percent )
@@ -1148,8 +1148,8 @@ void ChallengeLoadScreen::init( GameInfo *game )
 
 void ChallengeLoadScreen::reset()
 {
- setLoadScreen(nullptr);
- m_progressBar = nullptr;
+	setLoadScreen(nullptr);
+	m_progressBar = nullptr;
 }
 
 void ChallengeLoadScreen::update( Int percent )
@@ -1212,8 +1212,8 @@ void ShellGameLoadScreen::init( GameInfo *game )
 
 void ShellGameLoadScreen::reset()
 {
- setLoadScreen(nullptr);
- m_progressBar = nullptr;
+	setLoadScreen(nullptr);
+	m_progressBar = nullptr;
 }
 
 void ShellGameLoadScreen::update( Int percent )

--- a/Core/GameEngine/Source/GameClient/GUI/WinInstanceData.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/WinInstanceData.cpp
@@ -136,7 +136,7 @@ void WinInstanceData::init()
 	m_owner = nullptr;
 	m_textLabelString.clear();
 	m_tooltipString.clear();
-  m_tooltipDelay = -1; ///< default value
+	m_tooltipDelay = -1; ///< default value
 	m_decoratedNameString.clear();
 
 	m_imageOffset.x = 0;

--- a/Core/GameEngine/Source/GameClient/GUI/WindowLayout.cpp
+++ b/Core/GameEngine/Source/GameClient/GUI/WindowLayout.cpp
@@ -100,9 +100,9 @@ void WindowLayout::addWindow( GameWindow *window )
 	{
 
 		DEBUG_ASSERTCRASH( window->winGetNextInLayout() == nullptr,
-											 ("NextInLayout should be null before adding") );
+			("NextInLayout should be null before adding") );
 		DEBUG_ASSERTCRASH( window->winGetPrevInLayout() == nullptr,
-											 ("PrevInLayout should be null before adding") );
+			("PrevInLayout should be null before adding") );
 
 		window->winSetPrevInLayout( nullptr );
 		window->winSetNextInLayout( m_windowList );

--- a/Core/GameEngine/Source/GameClient/GameText.cpp
+++ b/Core/GameEngine/Source/GameClient/GameText.cpp
@@ -933,14 +933,14 @@ Bool GameTextManager::parseCSF( const Char *filename )
 
 		while ( num < num_strings )
 		{
-		 	file->read ( &id, sizeof ( Int ) );
+			file->read ( &id, sizeof ( Int ) );
 
 			if ( id != CSF_STRING && id != CSF_STRINGWITHWAVE )
 			{
 				goto quit;
 			}
 
-		 	file->read ( &len, sizeof ( Int ) );
+			file->read ( &len, sizeof ( Int ) );
 
 			if ( len )
 			{
@@ -970,7 +970,7 @@ Bool GameTextManager::parseCSF( const Char *filename )
 
 			if ( id == CSF_STRINGWITHWAVE )
 			{
-			 	file->read ( &len, sizeof ( Int ) );
+				file->read ( &len, sizeof ( Int ) );
 				if ( len )
 				{
 					file->read ( m_buffer, len );

--- a/Core/GameEngine/Source/GameClient/Input/Keyboard.cpp
+++ b/Core/GameEngine/Source/GameClient/Input/Keyboard.cpp
@@ -157,12 +157,12 @@ void Keyboard::updateKeys()
 			}
 		}
 		else if( m_keys[ index ].key == KEY_CAPS	 ||
-						 m_keys[ index ].key == KEY_LCTRL  ||
-						 m_keys[ index ].key == KEY_RCTRL	 ||
-						 m_keys[ index ].key == KEY_LSHIFT ||
-						 m_keys[ index ].key == KEY_RSHIFT ||
-						 m_keys[ index ].key == KEY_LALT	 ||
-						 m_keys[ index ].key == KEY_RALT )
+			m_keys[ index ].key == KEY_LCTRL  ||
+			m_keys[ index ].key == KEY_RCTRL	 ||
+			m_keys[ index ].key == KEY_LSHIFT ||
+			m_keys[ index ].key == KEY_RSHIFT ||
+			m_keys[ index ].key == KEY_LALT	 ||
+			m_keys[ index ].key == KEY_RALT )
 
 		{
 
@@ -344,10 +344,10 @@ void Keyboard::initKeyNames()
 	Int low = (UnsignedInt)kLayout & 0xFFFF;
 	LanguageID currentLanguage = OurLanguage;
 	if(low == 0x040c
-		 || low == 0x080c
-		 || low == 0x0c0c
-		 || low == 0x100c
-		 || low == 0x140c)
+		|| low == 0x080c
+		|| low == 0x0c0c
+		|| low == 0x100c
+		|| low == 0x140c)
 		currentLanguage = LANGUAGE_ID_FRENCH;
 
 	switch( currentLanguage )

--- a/Core/GameEngine/Source/GameClient/Input/Mouse.cpp
+++ b/Core/GameEngine/Source/GameClient/Input/Mouse.cpp
@@ -172,7 +172,7 @@ void Mouse::updateMouseData()
 			index++;
 		}
 		while( (result != MOUSE_NONE) &&
-					 (index < sizeof( m_mouseEvents ) / sizeof( MouseIO )) );
+			(index < sizeof( m_mouseEvents ) / sizeof( MouseIO )) );
 
 		busy = FALSE;
 
@@ -211,8 +211,8 @@ void Mouse::processMouseEvent( Int index )
 
 	// add Mouse Position Changes to Master Position
 	moveMouse( m_mouseEvents[ index ].pos.x,
-						 m_mouseEvents[ index ].pos.y,
-						 movementType );
+		m_mouseEvents[ index ].pos.y,
+		movementType );
 
 	// Cumulate Wheel Adjustments
 	m_currMouse.wheelPos += m_mouseEvents[ index ].wheelPos;
@@ -450,7 +450,7 @@ Mouse::Mouse()
 	//m_tooltipString.clear();	// redundant
 	m_displayTooltip = FALSE;
 	m_tooltipDisplayString = nullptr;
-  m_tooltipDelay = -1;  // default value
+	m_tooltipDelay = -1;  // default value
 	// initialize all the mouse io data
 	memset( m_mouseEvents, 0, sizeof( m_mouseEvents ) );
 	memset( &m_currMouse, 0, sizeof( m_currMouse ) );
@@ -580,7 +580,7 @@ void Mouse::init()
 
 	m_currentCursor = ARROW;
 
- 	// allocate a new display string
+	// allocate a new display string
 	m_cursorTextDisplayString = TheDisplayStringManager->newDisplayString();
 }
 
@@ -642,8 +642,8 @@ void Mouse::reset()
 	///@ todo Write Mouse::reset() if there needs to be anything here
 
 	// reset the text of the cursor text
-  if ( m_cursorTextDisplayString )
-  	m_cursorTextDisplayString->reset();
+	if ( m_cursorTextDisplayString )
+	m_cursorTextDisplayString->reset();
 
 	blockCapture(CursorCaptureBlockReason_NoInit);
 
@@ -681,9 +681,9 @@ void Mouse::createStreamMessages()
 	msg->appendPixelArgument( m_currMouse.pos );
 	msg->appendIntegerArgument( TheKeyboard->getModifierFlags() );
 
-  Int delay = m_tooltipDelayTime;
-  if(m_tooltipDelay >= 0 )
-     delay = m_tooltipDelay;
+	Int delay = m_tooltipDelayTime;
+	if(m_tooltipDelay >= 0 )
+	delay = m_tooltipDelay;
 	if( TheGlobalData->m_scriptDebug )
 	{
 		//No delay while scriptdebugging!
@@ -840,7 +840,7 @@ void Mouse::setCursorTooltip( UnicodeString tooltip, Int delay, const RGBColor *
 	//DEBUG_LOG(("%d Tooltip: %ls", TheGameClient->getFrame(), tooltip.str()));
 
 	m_isTooltipEmpty = tooltip.isEmpty();
-  m_tooltipDelay = delay;
+	m_tooltipDelay = delay;
 
 	Bool forceRecalc = FALSE;
 	if ( !tooltip.isEmpty() && width != m_lastTooltipWidth )
@@ -1211,13 +1211,13 @@ void Mouse::drawCursorText()
 	// get the colors to draw the text in an acceptable format
 	Color color, dropColor;
 	color = GameMakeColor( m_cursorTextColor.red,
-												 m_cursorTextColor.green,
-												 m_cursorTextColor.blue,
-												 m_cursorTextColor.alpha );
+		m_cursorTextColor.green,
+		m_cursorTextColor.blue,
+		m_cursorTextColor.alpha );
 	dropColor = GameMakeColor( m_cursorTextDropColor.red,
-														 m_cursorTextDropColor.green,
-														 m_cursorTextDropColor.blue,
-														 m_cursorTextDropColor.alpha );
+		m_cursorTextDropColor.green,
+		m_cursorTextDropColor.blue,
+		m_cursorTextDropColor.alpha );
 
 	// get the size of the text to draw
 	Int width, height;
@@ -1243,7 +1243,7 @@ Int Mouse::getCursorIndex(const AsciiString& name)
 	static const char *CursorININames[NUM_MOUSE_CURSORS] =
 	{
 		//"InvalidMouseCursor",  // this entry is not actually a mouse cursor, but just a
-														 // reminder that it does exist
+		// reminder that it does exist
 		"None",
 		"Normal",
 		"Arrow",
@@ -1329,8 +1329,8 @@ void Mouse::setCursor( MouseCursor cursor )
 		//
 		if( cursorInfo->cursorText.isEmpty() == FALSE )
 			setMouseText( TheGameText->fetch( cursorInfo->cursorText.str() ),
-										 &(cursorInfo->cursorTextColor),
-										 &(cursorInfo->cursorTextDropColor) );
+			&(cursorInfo->cursorTextColor),
+			&(cursorInfo->cursorTextDropColor) );
 		else
 			setMouseText( L"", nullptr, nullptr );
 

--- a/Core/GameEngine/Source/GameClient/Line2D.cpp
+++ b/Core/GameEngine/Source/GameClient/Line2D.cpp
@@ -55,7 +55,7 @@ const static Coord2D reallyFarPoint = { 1000000.0, 1000000.0 };
 	*/
 //-------------------------------------------------------------------------------------------------
 Bool ClipLine2D( ICoord2D *p1, ICoord2D *p2, ICoord2D *c1, ICoord2D *c2,
-								 IRegion2D *clipRegion )
+	IRegion2D *clipRegion )
 {
 	Int x1, y1, x2, y2;
 	Int clipLeft;
@@ -206,7 +206,7 @@ Bool ClipLine2D( ICoord2D *p1, ICoord2D *p2, ICoord2D *c1, ICoord2D *c2,
 		}
 	}
 
-  c1->x = x1;
+	c1->x = x1;
 	c1->y = y1;
 	c2->x = x2;
 	c2->y = y2;
@@ -220,7 +220,7 @@ Bool ClipLine2D( ICoord2D *p1, ICoord2D *p2, ICoord2D *c1, ICoord2D *c2,
 
 	// Line is visible
 	return (x1 >= clipLeft && x1 <= clipRight &&
-		    y1 >= clipTop && y1 <= clipBottom &&
+		y1 >= clipTop && y1 <= clipBottom &&
 			x2 >= clipLeft && x2 <= clipRight &&
 			y2 >= clipTop && y2 <= clipBottom);
 
@@ -231,8 +231,8 @@ Bool ClipLine2D( ICoord2D *p1, ICoord2D *p2, ICoord2D *c1, ICoord2D *c2,
 // http://www.faqs.org/faqs/graphics/algorithms-faq/
 // Subject 1.03
 Bool IntersectLine2D( const Coord2D *a, const Coord2D *b,
-										   const Coord2D *c, const Coord2D *d,
-											 Coord2D *intersection)
+	const Coord2D *c, const Coord2D *d,
+	Coord2D *intersection)
 {
 	if (!a || !b || !c || !d) {
 		// sanity. Lines that do not have endpoints do not intersect.
@@ -266,7 +266,7 @@ Bool IntersectLine2D( const Coord2D *a, const Coord2D *b,
 // determines whether a point lies within a rectangle. Doesn't determine whether the shape is
 // actually a rectangle or not.
 Bool PointInsideRect2D(const Coord2D *bl, const Coord2D *tl, const Coord2D *br, const Coord2D *tr,
-											 const Coord2D *inputPoint)
+	const Coord2D *inputPoint)
 {
 	if (!(bl && br && tl && tr && inputPoint)) {
 		return FALSE;
@@ -286,7 +286,7 @@ Bool PointInsideRect2D(const Coord2D *bl, const Coord2D *tl, const Coord2D *br, 
 
 // convenience. Just prunes out the Z coordinate for a call to PointInsideRect2D
 Bool PointInsideRect3D(const Coord3D *bl, const Coord3D *tl, const Coord3D *br, const Coord3D *tr,
-											 const Coord3D *inputPoint)
+	const Coord3D *inputPoint)
 {
 	Coord2D bl2d, tl2d, br2d, tr2d, pt;
 	bl2d.x = bl->x;
@@ -368,7 +368,7 @@ void ScaleRect2D( Coord2D *tl, Coord2D *br, Real scaleFactor )
 
 // Solution taken from http://astronomy.swin.edu.au/~pbourke/geometry/pointline/
 void ShortestDistancePointToSegment2D( const Coord2D *a, const Coord2D *b, const Coord2D *pt,
-																			 Real *outDistance, Coord2D *outPosition, Real *outU )
+	Real *outDistance, Coord2D *outPosition, Real *outU )
 {
 	if (!a || !b || !pt) {
 		return;
@@ -400,7 +400,7 @@ void ShortestDistancePointToSegment2D( const Coord2D *a, const Coord2D *b, const
 
 	// General case
 	Real u = ((pt->x - a->x) * (b->x - a->x) + (pt->y - a->y) * (b->y - a->y)) /
-					 sqr(segAB.length());
+		sqr(segAB.length());
 
 	Coord2D intersectSegment;
 

--- a/Core/GameEngine/Source/GameClient/MapUtil.cpp
+++ b/Core/GameEngine/Source/GameClient/MapUtil.cpp
@@ -1194,7 +1194,7 @@ Image *getMapPreviewImage( AsciiString mapName )
 
 		if (success)
 		{
-    	image = newInstance(Image);
+			image = newInstance(Image);
 			image->setName(tempName);
 			//image->setFullPath("mission.tga");
 			image->setFilename(name);
@@ -1314,7 +1314,7 @@ Bool parseMapPreviewChunk(DataChunkInput &file, DataChunkInfo *info, void *userD
 }
 
 void findDrawPositions( Int startX, Int startY, Int width, Int height, Region3D extent,
-															 ICoord2D *ul, ICoord2D *lr )
+	ICoord2D *ul, ICoord2D *lr )
 {
 
 	Real ratioWidth;

--- a/Core/GameEngine/Source/GameClient/ParabolicEase.cpp
+++ b/Core/GameEngine/Source/GameClient/ParabolicEase.cpp
@@ -83,7 +83,7 @@ ParabolicEase::operator ()(Real param) const
 		return v0*(m_in/2.0f + (param - m_in));
 	} else {
 		return v0*(m_in/2.0f + (m_out - m_in) +
-					 (param - m_out + (m_out*m_out - param*param)/2.0f)/(1.0f - m_out));
+			(param - m_out + (m_out*m_out - param*param)/2.0f)/(1.0f - m_out));
 	}
 #else
 	const Real v0 = 1.0f + m_out - m_in;

--- a/Core/GameEngine/Source/GameClient/RadiusDecal.cpp
+++ b/Core/GameEngine/Source/GameClient/RadiusDecal.cpp
@@ -95,15 +95,15 @@ void RadiusDecalTemplate::createRadiusDecal(const Coord3D& pos, Real radius, con
 // ------------------------------------------------------------------------------------------------
 void RadiusDecalTemplate::xferRadiusDecalTemplate( Xfer *xfer )
 {
-  // version
-  XferVersion currentVersion = 1;
-  XferVersion version = currentVersion;
-  xfer->xferVersion( &version, currentVersion );
+	// version
+	XferVersion currentVersion = 1;
+	XferVersion version = currentVersion;
+	xfer->xferVersion( &version, currentVersion );
 
 	xfer->xferAsciiString(&m_name);
 	xfer->xferUser(&m_shadowType, sizeof(m_shadowType));
 	xfer->xferReal(&m_minOpacity);
-  xfer->xferReal(&m_maxOpacity);
+	xfer->xferReal(&m_maxOpacity);
 	xfer->xferUnsignedInt(&m_opacityThrobTime);
 	xfer->xferColor(&m_color);
 	xfer->xferBool(&m_onlyVisibleToOwningPlayer);

--- a/Core/GameEngine/Source/GameClient/SelectionInfo.cpp
+++ b/Core/GameEngine/Source/GameClient/SelectionInfo.cpp
@@ -361,20 +361,20 @@ Bool addDrawableToList( Drawable *draw, void *userData )
 		return FALSE;
 
 	if (!draw->isSelectable())
-  {
-    const Object *obj = draw->getObject();
-    if ( obj && obj->getContainedBy() )//hmm, interesting... he is not selectable but he is contained
-    {// What we are after here is to propagate the selection the selection ti the container
-      // if the container is non-enclosing... see also SelectionXlat, in the left_click case
+	{
+		const Object *obj = draw->getObject();
+		if ( obj && obj->getContainedBy() )//hmm, interesting... he is not selectable but he is contained
+		{// What we are after here is to propagate the selection the selection ti the container
+			// if the container is non-enclosing... see also SelectionXlat, in the left_click case
 
-      ContainModuleInterface *contain = obj->getContainedBy()->getContain();
-      Drawable *containDraw = obj->getContainedBy()->getDrawable();
-      if (contain && ! contain->isEnclosingContainerFor( obj ) && containDraw )
-        return addDrawableToList( containDraw, userData );
-    }
-    else
-      return FALSE;
-  }
+			ContainModuleInterface *contain = obj->getContainedBy()->getContain();
+			Drawable *containDraw = obj->getContainedBy()->getDrawable();
+			if (contain && ! contain->isEnclosingContainerFor( obj ) && containDraw )
+			return addDrawableToList( containDraw, userData );
+		}
+		else
+		return FALSE;
+	}
 
 #if !RTS_GENERALS && PRESERVE_RETAIL_BEHAVIOR
 	// TheSuperHackers @info

--- a/Core/GameEngine/Source/GameClient/Statistics.cpp
+++ b/Core/GameEngine/Source/GameClient/Statistics.cpp
@@ -46,7 +46,7 @@ Real MuLaw(Real valueToRun, Real maxValueForVal, Real mu)
 {
 	Real testVal = (valueToRun - maxValueForVal / 2) / (maxValueForVal / 2);
 	return (sign(testVal) * log(1 + mu * fabs(testVal)) /
-														 log(1 + mu));
+		log(1 + mu));
 }
 
 // from my head. jkmcd

--- a/Core/GameEngine/Source/GameClient/System/ParticleSys.cpp
+++ b/Core/GameEngine/Source/GameClient/System/ParticleSys.cpp
@@ -81,7 +81,7 @@ ParticleInfo::ParticleInfo()
 	m_angularRateZ = 0.0f;
 	m_angularDamping = 0.0f;
 	m_colorScale =0.0f;
-  m_size = 0.0f;
+	m_size = 0.0f;
 	m_sizeRate = 0.0f;
 	m_sizeRateDamping = 0.0f;
 	m_velDamping = 0.0f;
@@ -1746,7 +1746,7 @@ Particle *ParticleSystem::createParticle( const ParticleInfo *info,
 		//
 		if( priority < TheGameLODManager->getMinDynamicParticlePriority() ||
 				(priority < TheGameLODManager->getMinDynamicParticleSkipPriority() &&
-				 TheGameLODManager->isParticleSkipped()) )
+			TheGameLODManager->isParticleSkipped()) )
 			return nullptr;
 
 		if ( getParticleCount() > 0 && priority == AREA_EFFECT && m_isGroundAligned && TheParticleSystemManager->getFieldParticleCount() > (UnsignedInt)TheGlobalData->m_maxFieldParticleCount )
@@ -2209,10 +2209,10 @@ void ParticleSystem::updateWindMotion()
 					// pick new start and end angles
 					m_windMotionStartAngle =
 							GameClientRandomValueReal( m_windMotionStartAngleMin,
-																				 m_windMotionStartAngleMax );
+						m_windMotionStartAngleMax );
 					m_windMotionEndAngle =
 							GameClientRandomValueReal( m_windMotionEndAngleMin,
-																				 m_windMotionEndAngleMax );
+						m_windMotionEndAngleMax );
 
 				}
 
@@ -2237,10 +2237,10 @@ void ParticleSystem::updateWindMotion()
 					// pick new start and end angles
 					m_windMotionStartAngle =
 							GameClientRandomValueReal( m_windMotionStartAngleMin,
-																				 m_windMotionStartAngleMax );
+						m_windMotionStartAngleMax );
 					m_windMotionEndAngle =
 							GameClientRandomValueReal( m_windMotionEndAngleMin,
-																				 m_windMotionEndAngleMax );
+						m_windMotionEndAngleMax );
 
 				}
 
@@ -2766,7 +2766,7 @@ const FieldParse ParticleSystemTemplate::m_fieldParseTable[] =
  * The format is "FIELD = low high frame". */
 // ------------------------------------------------------------------------------------------------
 void ParticleSystemTemplate::parseRandomKeyframe( INI* ini, void *instance,
-																											 void *store, const void* /*userData*/ )
+	void *store, const void* /*userData*/ )
 {
 	RandomKeyframe *key = static_cast<RandomKeyframe *>(store);
 
@@ -2796,7 +2796,7 @@ void ParticleSystemTemplate::parseRGBColorKeyframe( INI* ini, void *instance,
  * Note that the components may be negative, as this is used for rates, as well. */
 // ------------------------------------------------------------------------------------------------
 void ParticleSystemTemplate::parseRandomRGBColor( INI* ini, void *instance,
-																											 void *store, const void* /*userData*/ )
+	void *store, const void* /*userData*/ )
 {
 #if 0
 	char seps[] = " \n\r\t=:RGB,";
@@ -3174,8 +3174,8 @@ void ParticleSystemManager::destroyAttachedSystems( Object *obj )
 
 	// iterate through all systems
 	for( ParticleSystemListIt it = m_allParticleSystemList.begin();
-			 it != m_allParticleSystemList.end();
-			 ++it )
+	it != m_allParticleSystemList.end();
+	++it )
 	{
 
 		ParticleSystem *system = *it;
@@ -3288,8 +3288,8 @@ Int ParticleSystemManager::removeOldestParticles( UnsignedInt count,
 	while (count-- && getParticleCount())
 	{
 		for( Int i = PARTICLE_PRIORITY_LOWEST;
-				 i < priorityCap;
-				 ++i )
+		i < priorityCap;
+		++i )
 		{
 			if( m_allParticlesHead[ i ] )
 			{
@@ -3315,7 +3315,7 @@ void ParticleSystemManager::preloadAssets( TimeOfDay timeOfDay )
 	for (; begin != end; ++begin) {
 		const ParticleSystemTemplate *tmplate = (*begin).second;
 		if (tmplate->m_particleType == ParticleSystemInfo::PARTICLE &&
-			 	(! tmplate->m_particleTypeName.isEmpty()))
+			(! tmplate->m_particleTypeName.isEmpty()))
 		{
 			TheDisplay->preloadTextureAssets(tmplate->m_particleTypeName);
 		}

--- a/Core/GameEngine/Source/GameClient/Terrain/TerrainRoads.cpp
+++ b/Core/GameEngine/Source/GameClient/Terrain/TerrainRoads.cpp
@@ -95,9 +95,9 @@ const FieldParse TerrainRoadType::m_terrainBridgeFieldParseTable[] =
 	* Label = Transition:<Damage|Repair> ToState:<BODYTYPE> EffectNum:<INT> OCL:<OCL NAME> */
 // ------------------------------------------------------------------------------------------------
 /*static*/ void TerrainRoadType::parseTransitionToOCL( INI *ini,
-																											 void *instance,
-																											 void *store,
-																											 const void *userData )
+	void *instance,
+	void *store,
+	const void *userData )
 {
 	const char *token;
 	TerrainRoadType *theInstance = (TerrainRoadType *)instance;

--- a/Core/GameEngine/Source/GameClient/Terrain/TerrainVisual.cpp
+++ b/Core/GameEngine/Source/GameClient/Terrain/TerrainVisual.cpp
@@ -133,76 +133,76 @@ void TerrainVisual::loadPostProcess()
 SeismicSimulationFilterBase::SeismicSimStatusCode DomeStyleSeismicFilter::filterCallback( WorldHeightMapInterfaceClass *heightMap, const SeismicSimulationNode *node )
 {
 
-  Int life = node->m_life;
+	Int life = node->m_life;
 
-  if ( heightMap == nullptr )
-    return SEISMIC_STATUS_INVALID;
-
-
-  if ( life == 0 )
-    return SEISMIC_STATUS_ACTIVE;
-  if ( life < 15 )
-  {
-    // ADD HEIGHT BECAUSE THE EXPLOSION IS PUSHING DIRT UP
-
-    Real magnitude = node->m_magnitude;
-
-    Real offsScalar =  magnitude / (Real)life; // real-life, get it?
-    Int radius = node->m_radius;
-    Int border = heightMap->getBorderSize();
-    Int centerX = node->m_center.x + border ;
-    Int centerY = node->m_center.y + border ;
-
-    UnsignedInt workspaceWidth = radius*2;
-    Real *workspace = NEW Real[ sqr(workspaceWidth) ];
-    Real *workspaceEnd = workspace + sqr(workspaceWidth);
+	if ( heightMap == nullptr )
+	return SEISMIC_STATUS_INVALID;
 
 
-    for ( Real *t = workspace; t < workspaceEnd; ++t ) *t = 0.0f;// clear the workspace
+	if ( life == 0 )
+	return SEISMIC_STATUS_ACTIVE;
+	if ( life < 15 )
+	{
+		// ADD HEIGHT BECAUSE THE EXPLOSION IS PUSHING DIRT UP
 
-    Int x, y;
-    for (x = 0; x < radius; ++x)
-    {
-      for (y = 0; y < radius; ++y)
-      {
+		Real magnitude = node->m_magnitude;
 
-        Real distance = sqrt( sqr(x) + sqr(y) );//Pythagoras
+		Real offsScalar =  magnitude / (Real)life; // real-life, get it?
+		Int radius = node->m_radius;
+		Int border = heightMap->getBorderSize();
+		Int centerX = node->m_center.x + border ;
+		Int centerY = node->m_center.y + border ;
 
-        if ( distance < radius )
-        {
-          Real distScalar = cos( ( distance / radius * (PI/2) ) );
-          Real height = (offsScalar * distScalar);
+		UnsignedInt workspaceWidth = radius*2;
+		Real *workspace = NEW Real[ sqr(workspaceWidth) ];
+		Real *workspaceEnd = workspace + sqr(workspaceWidth);
 
-          workspace[ (radius + x) +  workspaceWidth * (radius + y) ] = height + heightMap->getBilinearSampleSeismicZVelocity( centerX + x,  centerY + y ) ;//kaleidoscope
 
-          if ( x != 0 ) // non-zero test prevents cross-shaped double stamp
-          {
-      			workspace[ (radius - x) + workspaceWidth * (radius + y) ] = height + heightMap->getBilinearSampleSeismicZVelocity( centerX - x,  centerY + y ) ;
-            if ( y != 0 )
-              workspace[ (radius - x) + workspaceWidth * (radius - y) ] =  height + heightMap->getBilinearSampleSeismicZVelocity( centerX - x,  centerY - y ) ;
-          }
-          if ( y != 0 )
-      			workspace[ (radius + x) + workspaceWidth * (radius - y) ] = height + heightMap->getBilinearSampleSeismicZVelocity( centerX + x,  centerY - y ) ;
-        }
-      }
-    }
+		for ( Real *t = workspace; t < workspaceEnd; ++t ) *t = 0.0f;// clear the workspace
 
-    // stuff the values from the workspace into the heightmap's velocities
-    for (x = 0; x < workspaceWidth; ++x)
-      for (y = 0; y < workspaceWidth; ++y)
-    		heightMap->setSeismicZVelocity( centerX - radius + x, centerY - radius + y,  MIN( 9.0f, workspace[  x + workspaceWidth * y ])  );
+		Int x, y;
+		for (x = 0; x < radius; ++x)
+		{
+			for (y = 0; y < radius; ++y)
+			{
 
-    delete [] workspace;
+				Real distance = sqrt( sqr(x) + sqr(y) );//Pythagoras
 
-    return SEISMIC_STATUS_ACTIVE;
-  }
-  else
-    return SEISMIC_STATUS_ZERO_ENERGY;
+				if ( distance < radius )
+				{
+					Real distScalar = cos( ( distance / radius * (PI/2) ) );
+					Real height = (offsScalar * distScalar);
+
+					workspace[ (radius + x) +  workspaceWidth * (radius + y) ] = height + heightMap->getBilinearSampleSeismicZVelocity( centerX + x,  centerY + y ) ;//kaleidoscope
+
+					if ( x != 0 ) // non-zero test prevents cross-shaped double stamp
+					{
+						workspace[ (radius - x) + workspaceWidth * (radius + y) ] = height + heightMap->getBilinearSampleSeismicZVelocity( centerX - x,  centerY + y ) ;
+						if ( y != 0 )
+						workspace[ (radius - x) + workspaceWidth * (radius - y) ] =  height + heightMap->getBilinearSampleSeismicZVelocity( centerX - x,  centerY - y ) ;
+					}
+					if ( y != 0 )
+					workspace[ (radius + x) + workspaceWidth * (radius - y) ] = height + heightMap->getBilinearSampleSeismicZVelocity( centerX + x,  centerY - y ) ;
+				}
+			}
+		}
+
+		// stuff the values from the workspace into the heightmap's velocities
+		for (x = 0; x < workspaceWidth; ++x)
+		for (y = 0; y < workspaceWidth; ++y)
+		heightMap->setSeismicZVelocity( centerX - radius + x, centerY - radius + y,  MIN( 9.0f, workspace[  x + workspaceWidth * y ])  );
+
+		delete [] workspace;
+
+		return SEISMIC_STATUS_ACTIVE;
+	}
+	else
+	return SEISMIC_STATUS_ZERO_ENERGY;
 }
 
 Real DomeStyleSeismicFilter::applyGravityCallback( Real velocityIn )
 {
-  Real velocityOut = velocityIn;
-  velocityOut -= 1.5f;
-  return velocityOut;
+	Real velocityOut = velocityIn;
+	velocityOut -= 1.5f;
+	return velocityOut;
 }

--- a/Core/GameEngine/Source/GameClient/Water.cpp
+++ b/Core/GameEngine/Source/GameClient/Water.cpp
@@ -43,16 +43,16 @@ const FieldParse WaterSetting::m_waterSettingFieldParseTable[] =
 
 	{ "SkyTexture",									INI::parseAsciiString,			nullptr, offsetof( WaterSetting, m_skyTextureFile ) },
 	{ "WaterTexture",								INI::parseAsciiString,			nullptr, offsetof( WaterSetting, m_waterTextureFile ) },
-  { "Vertex00Color",							INI::parseRGBAColorInt,			nullptr, offsetof( WaterSetting, m_vertex00Diffuse ) },
+	{ "Vertex00Color",							INI::parseRGBAColorInt,			nullptr, offsetof( WaterSetting, m_vertex00Diffuse ) },
 	{ "Vertex10Color",							INI::parseRGBAColorInt,			nullptr, offsetof( WaterSetting, m_vertex10Diffuse ) },
 	{ "Vertex01Color",							INI::parseRGBAColorInt,			nullptr, offsetof( WaterSetting, m_vertex01Diffuse ) },
-  { "Vertex11Color",							INI::parseRGBAColorInt,			nullptr, offsetof( WaterSetting, m_vertex11Diffuse ) },
+	{ "Vertex11Color",							INI::parseRGBAColorInt,			nullptr, offsetof( WaterSetting, m_vertex11Diffuse ) },
 	{ "DiffuseColor",								INI::parseRGBAColorInt,			nullptr, offsetof( WaterSetting, m_waterDiffuseColor ) },
-  { "TransparentDiffuseColor",		INI::parseRGBAColorInt,			nullptr, offsetof( WaterSetting, m_transparentWaterDiffuse ) },
-  { "UScrollPerMS",								INI::parseReal,							nullptr, offsetof( WaterSetting, m_uScrollPerMs ) },
-  { "VScrollPerMS",								INI::parseReal,							nullptr, offsetof( WaterSetting, m_vScrollPerMs ) },
+	{ "TransparentDiffuseColor",		INI::parseRGBAColorInt,			nullptr, offsetof( WaterSetting, m_transparentWaterDiffuse ) },
+	{ "UScrollPerMS",								INI::parseReal,							nullptr, offsetof( WaterSetting, m_uScrollPerMs ) },
+	{ "VScrollPerMS",								INI::parseReal,							nullptr, offsetof( WaterSetting, m_vScrollPerMs ) },
 	{ "SkyTexelsPerUnit",						INI::parseReal,							nullptr, offsetof( WaterSetting, m_skyTexelsPerUnit ) },
-  { "WaterRepeatCount",						INI::parseInt,							nullptr, offsetof( WaterSetting, m_waterRepeatCount ) },
+	{ "WaterRepeatCount",						INI::parseInt,							nullptr, offsetof( WaterSetting, m_waterRepeatCount ) },
 
 	{ nullptr,													nullptr,												nullptr, 0 },
 

--- a/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -283,10 +283,10 @@ void Path::crc( Xfer *xfer )
 // ------------------------------------------------------------------------------------------------
 void Path::xfer( Xfer *xfer )
 {
-  // version
-  XferVersion currentVersion = 1;
-  XferVersion version = currentVersion;
-  xfer->xferVersion( &version, currentVersion );
+	// version
+	XferVersion currentVersion = 1;
+	XferVersion version = currentVersion;
+	xfer->xferVersion( &version, currentVersion );
 
 	PathNode *node = m_path;
 	Int count = 0;
@@ -365,7 +365,7 @@ void Path::xfer( Xfer *xfer )
 	if (TheGlobalData->m_debugAI == AI_DEBUG_PATHS)
 	{
 		extern void addIcon(const Coord3D *pos, Real width, Int numFramesDuration, RGBColor color);
- 		RGBColor color;
+		RGBColor color;
 		color.blue = 0;
 		color.red = color.green = 1;
 		Coord3D pos;
@@ -2237,11 +2237,11 @@ inline Bool groundCliff(const PathfindCell &targetCell, const PathfindCell &sour
 	PathfindCell::CellType srcType = sourceCell.getType();
 
 	if ( (targetType==PathfindCell::CELL_CLIFF ) &&
-			 (srcType==PathfindCell::CELL_CLEAR) ) {
+		(srcType==PathfindCell::CELL_CLEAR) ) {
 			return true;
 	}
 	if ( (targetType==PathfindCell::CELL_CLEAR ) &&
-			 (srcType==PathfindCell::CELL_CLIFF) ) {
+		(srcType==PathfindCell::CELL_CLIFF) ) {
 			return true;
 	}
 	return false;
@@ -2331,7 +2331,7 @@ inline void applyZone(PathfindCell &targetCell, const PathfindCell &sourceCell, 
 }
 
 inline void applyBlockZone(PathfindCell &targetCell, const PathfindCell &sourceCell,
-													 zoneStorageType *zoneEquivalency, Int firstZone, Int sizeOfZE)
+	zoneStorageType *zoneEquivalency, Int firstZone, Int sizeOfZE)
 {
 	DEBUG_ASSERTCRASH(sourceCell.getZone()>=firstZone && sourceCell.getZone()<firstZone+sizeOfZE, ("Memory overrun - FATAL ERROR."));
 	Int srcZone = zoneEquivalency[sourceCell.getZone()-firstZone];
@@ -2453,7 +2453,7 @@ void ZoneBlock::blockCalculateZones(PathfindCell **map, PathfindLayer layers[], 
 // Return the zone at this location.
 //
 zoneStorageType ZoneBlock::getEffectiveZone( LocomotorSurfaceTypeMask acceptableSurfaces,
-																					 Bool crusher, zoneStorageType zone) const
+	Bool crusher, zoneStorageType zone) const
 {
 #if !(RTS_GENERALS && RETAIL_COMPATIBLE_PATHFINDING)
 	if (zone==PathfindZoneManager::UNINITIALIZED_ZONE) {
@@ -2744,12 +2744,12 @@ void PathfindZoneManager::calculateZones( PathfindCell **map, PathfindLayer laye
 #endif
 					}
 					if (cell->getConnectLayer() > LAYER_GROUND) {
- 						m_zoneBlocks[xBlock][yBlock].setInteractsWithBridge(true);
+						m_zoneBlocks[xBlock][yBlock].setInteractsWithBridge(true);
 					}
 
 				}
 			}
- 		}
+		}
 	}
 
 	Int totalZones = m_maxZone;
@@ -4128,7 +4128,7 @@ void Pathfinder::removeWallPiece(Object *wallPiece)
 {
 
 	// sanity
-  if( wallPiece == nullptr )
+		if( wallPiece == nullptr )
 		return;
 
 	// find entry
@@ -4218,26 +4218,26 @@ void Pathfinder::classifyFence( Object *obj, Bool insert )
 #endif
 
 	const Coord3D *pos = obj->getPosition();
-  Real angle = obj->getOrientation();
+		Real angle = obj->getOrientation();
 
- 	Real halfsizeX = obj->getTemplate()->getFenceWidth()/2;
- 	Real halfsizeY = PATHFIND_CELL_SIZE_F/10.0f;
- 	Real fenceOffset = obj->getTemplate()->getFenceXOffset();
+		Real halfsizeX = obj->getTemplate()->getFenceWidth()/2;
+		Real halfsizeY = PATHFIND_CELL_SIZE_F/10.0f;
+		Real fenceOffset = obj->getTemplate()->getFenceXOffset();
 
- 	Real c = (Real)Cos(angle);
- 	Real s = (Real)Sin(angle);
+		Real c = (Real)Cos(angle);
+		Real s = (Real)Sin(angle);
 
- 	const Real STEP_SIZE = PATHFIND_CELL_SIZE_F * 0.5f;	// in theory, should be PATHFIND_CELL_SIZE_F exactly, but needs to be smaller to avoid aliasing problems
- 	Real ydx = s * STEP_SIZE;
- 	Real ydy = -c * STEP_SIZE;
- 	Real xdx = c * STEP_SIZE;
- 	Real xdy = s * STEP_SIZE;
+		const Real STEP_SIZE = PATHFIND_CELL_SIZE_F * 0.5f;	// in theory, should be PATHFIND_CELL_SIZE_F exactly, but needs to be smaller to avoid aliasing problems
+		Real ydx = s * STEP_SIZE;
+		Real ydy = -c * STEP_SIZE;
+		Real xdx = c * STEP_SIZE;
+		Real xdy = s * STEP_SIZE;
 
- 	Int numStepsX = REAL_TO_INT_CEIL(2.0f * halfsizeX / STEP_SIZE);
- 	Int numStepsY = REAL_TO_INT_CEIL(2.0f * halfsizeY / STEP_SIZE);
+		Int numStepsX = REAL_TO_INT_CEIL(2.0f * halfsizeX / STEP_SIZE);
+		Int numStepsY = REAL_TO_INT_CEIL(2.0f * halfsizeY / STEP_SIZE);
 
- 	Real tl_x = pos->x - fenceOffset*c - halfsizeY*s;
- 	Real tl_y = pos->y + halfsizeY*c - fenceOffset*s;
+		Real tl_x = pos->x - fenceOffset*c - halfsizeY*s;
+		Real tl_y = pos->y + halfsizeY*c - fenceOffset*s;
 
 #if !(RTS_GENERALS && RETAIL_COMPATIBLE_PATHFINDING)
 	IRegion2D cellBounds;
@@ -4266,49 +4266,49 @@ void Pathfinder::classifyFence( Object *obj, Bool insert )
 	Bool didAnything = false;
 #endif // !(RTS_GENERALS && RETAIL_COMPATIBLE_PATHFINDING)
 
- 	for (Int iy = 0; iy < numStepsY; ++iy, tl_x += ydx, tl_y += ydy)
- 	{
- 		Real x = tl_x;
- 		Real y = tl_y;
- 		for (Int ix = 0; ix < numStepsX; ++ix, x += xdx, y += xdy)
- 		{
- 			Int cx = REAL_TO_INT_FLOOR((x + 0.5f)/PATHFIND_CELL_SIZE_F);
- 			Int cy = REAL_TO_INT_FLOOR((y + 0.5f)/PATHFIND_CELL_SIZE_F);
- 			if (cx >= 0 && cy >= 0 && cx < m_extent.hi.x && cy < m_extent.hi.y)
- 			{
+		for (Int iy = 0; iy < numStepsY; ++iy, tl_x += ydx, tl_y += ydy)
+		{
+			Real x = tl_x;
+			Real y = tl_y;
+			for (Int ix = 0; ix < numStepsX; ++ix, x += xdx, y += xdy)
+			{
+				Int cx = REAL_TO_INT_FLOOR((x + 0.5f)/PATHFIND_CELL_SIZE_F);
+				Int cy = REAL_TO_INT_FLOOR((y + 0.5f)/PATHFIND_CELL_SIZE_F);
+				if (cx >= 0 && cy >= 0 && cx < m_extent.hi.x && cy < m_extent.hi.y)
+				{
 #if RTS_GENERALS && RETAIL_COMPATIBLE_PATHFINDING
- 				if (insert) {
- 					ICoord2D pos;
- 					pos.x = cx;
- 					pos.y = cy;
- 					m_map[cx][cy].setTypeAsObstacle( obj, true, pos );
- 				}
- 				else
- 					m_map[cx][cy].removeObstacle(obj);
+					if (insert) {
+						ICoord2D pos;
+						pos.x = cx;
+						pos.y = cy;
+						m_map[cx][cy].setTypeAsObstacle( obj, true, pos );
+					}
+					else
+					m_map[cx][cy].removeObstacle(obj);
 #else
- 				if (insert) {
- 					ICoord2D pos;
- 					pos.x = cx;
- 					pos.y = cy;
+					if (insert) {
+						ICoord2D pos;
+						pos.x = cx;
+						pos.y = cy;
 					if (m_map[cx][cy].setTypeAsObstacle( obj, true, pos )) {
 						didAnything = true;
- 						m_map[cx][cy].setZone(PathfindZoneManager::UNINITIALIZED_ZONE);
+							m_map[cx][cy].setZone(PathfindZoneManager::UNINITIALIZED_ZONE);
 					}
- 				}
+					}
 				else {
 					if (m_map[cx][cy].removeObstacle(obj)) {
 						didAnything = true;
- 						m_map[cx][cy].setZone(PathfindZoneManager::UNINITIALIZED_ZONE);
+							m_map[cx][cy].setZone(PathfindZoneManager::UNINITIALIZED_ZONE);
 					}
 				}
 				if (cellBounds.lo.x>cx) cellBounds.lo.x = cx;
- 				if (cellBounds.lo.y>cy) cellBounds.lo.y = cy;
- 				if (cellBounds.hi.x<cx) cellBounds.hi.x = cx;
- 				if (cellBounds.hi.y<cy) cellBounds.hi.y = cy;
+					if (cellBounds.lo.y>cy) cellBounds.lo.y = cy;
+					if (cellBounds.hi.x<cx) cellBounds.hi.x = cx;
+					if (cellBounds.hi.y<cy) cellBounds.hi.y = cy;
 #endif
- 			}
- 		}
- 	}
+				}
+			}
+		}
 #if !(RTS_GENERALS && RETAIL_COMPATIBLE_PATHFINDING)
 	if (didAnything) {
 		m_zoneManager.markZonesDirty();
@@ -4351,8 +4351,8 @@ void Pathfinder::classifyObjectFootprint( Object *obj, Bool insert )
 		// lifeless immobile husks of debris, but we still need to remove them.  jba.
 
 #if !RTS_GENERALS
-    if ( obj->isKindOf( KINDOF_BLAST_CRATER ) ) // since these footprints are permanent, never remove them
-      return;
+			if ( obj->isKindOf( KINDOF_BLAST_CRATER ) ) // since these footprints are permanent, never remove them
+			return;
 #endif
 
 		removeUnitFromPathfindMap(obj);
@@ -4404,7 +4404,7 @@ void Pathfinder::classifyObjectFootprint( Object *obj, Bool insert )
 	}
 #else
 	if (obj->getHeightAboveTerrain() > PATHFIND_CELL_SIZE_F && ( ! obj->isKindOf( KINDOF_BLAST_CRATER ) ) )
-  {
+		{
 		return; // Don't add bounds that are up in the air.... unless a blast crater wants to do just that
 	}
 #endif
@@ -4476,18 +4476,18 @@ void Pathfinder::internal_classifyObjectFootprint( Object *obj, Bool insert )
 							pos.x = cx;
 							pos.y = cy;
 							if (m_map[cx][cy].setTypeAsObstacle( obj, false, pos )) {
- 								m_map[cx][cy].setZone(PathfindZoneManager::UNINITIALIZED_ZONE);
+									m_map[cx][cy].setZone(PathfindZoneManager::UNINITIALIZED_ZONE);
 							}
 						}
 						else {
 							if (m_map[cx][cy].removeObstacle(obj)) {
- 								m_map[cx][cy].setZone(PathfindZoneManager::UNINITIALIZED_ZONE);
+									m_map[cx][cy].setZone(PathfindZoneManager::UNINITIALIZED_ZONE);
 							}
 						}
- 						if (cellBounds.lo.x>cx) cellBounds.lo.x = cx;
- 						if (cellBounds.lo.y>cy) cellBounds.lo.y = cy;
- 						if (cellBounds.hi.x<cx) cellBounds.hi.x = cx;
- 						if (cellBounds.hi.y<cy) cellBounds.hi.y = cy;
+							if (cellBounds.lo.x>cx) cellBounds.lo.x = cx;
+							if (cellBounds.lo.y>cy) cellBounds.lo.y = cy;
+							if (cellBounds.hi.x<cx) cellBounds.hi.x = cx;
+							if (cellBounds.hi.y<cy) cellBounds.hi.y = cy;
 					}
 #endif
 				}
@@ -4547,18 +4547,18 @@ void Pathfinder::internal_classifyObjectFootprint( Object *obj, Bool insert )
 								pos.x = i;
 								pos.y = j;
 								if (m_map[i][j].setTypeAsObstacle( obj, false, pos )) {
- 									m_map[i][j].setZone(PathfindZoneManager::UNINITIALIZED_ZONE);
+										m_map[i][j].setZone(PathfindZoneManager::UNINITIALIZED_ZONE);
 								}
 							}
 							else {
 								if (m_map[i][j].removeObstacle(obj)) {
- 									m_map[i][j].setZone(PathfindZoneManager::UNINITIALIZED_ZONE);
+										m_map[i][j].setZone(PathfindZoneManager::UNINITIALIZED_ZONE);
 								}
 							}
- 							if (cellBounds.lo.x>i) cellBounds.lo.x = i;
- 							if (cellBounds.lo.y>j) cellBounds.lo.y = j;
- 							if (cellBounds.hi.x<i) cellBounds.hi.x = i;
- 							if (cellBounds.hi.y<j) cellBounds.hi.y = j;
+								if (cellBounds.lo.x>i) cellBounds.lo.x = i;
+								if (cellBounds.lo.y>j) cellBounds.lo.y = j;
+								if (cellBounds.hi.x<i) cellBounds.hi.x = i;
+								if (cellBounds.hi.y<j) cellBounds.hi.y = j;
 						}
 #endif
 					}
@@ -4757,7 +4757,7 @@ void Pathfinder::newMap()
 	if (!dataAllocated) {
 		m_extent = bounds;
 		DEBUG_ASSERTCRASH(m_map == nullptr, ("Can't reallocate pathfind cells."));
- 		m_zoneManager.allocateBlocks(m_extent);
+			m_zoneManager.allocateBlocks(m_extent);
 		// Allocate cells.
 		m_blockOfMapCells = MSGNEW("PathfindMapCells") PathfindCell[(bounds.hi.x+1)*(bounds.hi.y+1)];
 		m_map = MSGNEW("PathfindMapCells") PathfindCellP[bounds.hi.x+1];
@@ -5035,7 +5035,7 @@ void Pathfinder::cleanOpenAndClosedLists() {
 // Return true if we can move onto this position
 //
 Bool Pathfinder::validMovementPosition( Bool isCrusher, LocomotorSurfaceTypeMask acceptableSurfaces,
-																			 PathfindCell *toCell, PathfindCell *fromCell )
+		PathfindCell *toCell, PathfindCell *fromCell )
 {
 	if (toCell == nullptr)
 		return false;
@@ -5396,7 +5396,7 @@ Bool Pathfinder::checkForAdjust(Object *obj, const LocomotorSet& locomotorSet, B
 			adjustedPathExists = clientSafeQuickDoesPathExist( locomotorSet, obj->getPosition(), &adjustDest);
 			if (!pathExists) {
 				if (clientSafeQuickDoesPathExist( locomotorSet, dest, &adjustDest))	{
- 					adjustedPathExists = true;
+						adjustedPathExists = true;
 				}
 			}
 		}
@@ -5613,7 +5613,7 @@ Bool Pathfinder::checkForTarget(const Object *obj, 	Int cellX, Int cellY, const 
  * Returns false if there are no spots available within a reasonable radius.
  */
 Bool Pathfinder::adjustTargetDestination(const Object *obj, const Object *target, const Coord3D *targetPos,
-																				 const Weapon *weapon, Coord3D *dest)
+		const Weapon *weapon, Coord3D *dest)
 {
 	Int iRadius;
 	Bool center;
@@ -5699,7 +5699,7 @@ Bool Pathfinder::checkForPossible(Bool isCrusher, Int fromZone,  Bool center, co
  * Returns false if there are no spots available within a reasonable radius.
  */
 Bool Pathfinder::adjustToPossibleDestination(Object *obj, const LocomotorSet& locomotorSet,
-																						 Coord3D *dest)
+		Coord3D *dest)
 {
 	Int radius;
 	Bool center;
@@ -6219,7 +6219,7 @@ struct ExamineCellsStruct
 
 			if (!to->allocateInfo(newCellCoord)) {
 				// Out of cells for pathing...
- 				return 1;
+				return 1;
 			}
 			to->setBlockedByAlly(false);
 			Int costRemaining = 0;
@@ -6257,8 +6257,8 @@ struct ExamineCellsStruct
 
 
 Int Pathfinder::examineNeighboringCells(PathfindCell *parentCell, PathfindCell *goalCell, const LocomotorSet& locomotorSet,
-																				 Bool isHuman, Bool centerInCell, Int radius, const ICoord2D &startCellNdx,
-																				 const Object *obj, Int attackDistance)
+		Bool isHuman, Bool centerInCell, Int radius, const ICoord2D &startCellNdx,
+		const Object *obj, Int attackDistance)
 {
 		Bool canPathThroughUnits = false;
 		if (obj && obj->getAIUpdateInterface()) {
@@ -6395,7 +6395,7 @@ Int Pathfinder::examineNeighboringCells(PathfindCell *parentCell, PathfindCell *
 			if (!newCell->hasInfo()) {
 				if (!newCell->allocateInfo(newCellCoord)) {
 					// Out of cells for pathing...
- 					return cellCount;
+					return cellCount;
 				}
 				cellCount++;
 			}
@@ -6498,7 +6498,7 @@ Int Pathfinder::examineNeighboringCells(PathfindCell *parentCell, PathfindCell *
  * Uses A* algorithm.
  */
 Path *Pathfinder::findPath( Object *obj, const LocomotorSet& locomotorSet, const Coord3D *from,
-													 const Coord3D *rawTo)
+		const Coord3D *rawTo)
 {
 	if (!clientSafeQuickDoesPathExist(locomotorSet, from, rawTo)) {
 		return nullptr;
@@ -6528,7 +6528,7 @@ Path *Pathfinder::findPath( Object *obj, const LocomotorSet& locomotorSet, const
  * Uses A* algorithm.
  */
 Path *Pathfinder::internalFindPath( Object *obj, const LocomotorSet& locomotorSet, const Coord3D *from,
-													 const Coord3D *rawTo)
+		const Coord3D *rawTo)
 {
 	//CRCDEBUG_LOG(("Pathfinder::findPath()"));
 #ifdef INTENSE_DEBUG
@@ -6749,7 +6749,7 @@ Path *Pathfinder::internalFindPath( Object *obj, const LocomotorSet& locomotorSe
 	if (TheGlobalData->m_debugAI == AI_DEBUG_PATHS)
 	{
 		extern void addIcon(const Coord3D *pos, Real width, Int numFramesDuration, RGBColor color);
- 		RGBColor color;
+			RGBColor color;
 		color.blue = 0;
 		color.red = color.green = 1;
 		addIcon(nullptr, 0, 0, color);
@@ -6904,7 +6904,7 @@ Path *Pathfinder::buildGroundPath(Bool isCrusher, const Coord3D *fromPos, Pathfi
 	if (TheGlobalData->m_debugAI==AI_DEBUG_GROUND_PATHS)
 	{
 		extern void addIcon(const Coord3D *pos, Real width, Int numFramesDuration, RGBColor color);
- 		RGBColor color;
+			RGBColor color;
 		color.blue = 0;
 		color.red = color.green = 1;
 		Coord3D pos;
@@ -6970,7 +6970,7 @@ Path *Pathfinder::buildHierarchicalPath( const Coord3D *fromPos, PathfindCell *g
 	if (TheGlobalData->m_debugAI==AI_DEBUG_PATHS)
 	{
 		extern void addIcon(const Coord3D *pos, Real width, Int numFramesDuration, RGBColor color);
- 		RGBColor color;
+			RGBColor color;
 		color.blue = 0;
 		color.red = color.green = 1;
 		Coord3D pos;
@@ -7083,7 +7083,7 @@ struct GroundCellsStruct
 			newCellCoord.y = to_y;
 			if (!to->allocateInfo(newCellCoord)) {
 				// Out of cells for pathing...
- 				return 1;
+				return 1;
 			}
 
 			UnsignedInt newCostSoFar = from->getCostSoFar() + 0.5f*COST_ORTHOGONAL;
@@ -7108,7 +7108,7 @@ struct GroundCellsStruct
  * Uses A* algorithm.
  */
 Path *Pathfinder::findGroundPath( const Coord3D *from,
-													 const Coord3D *rawTo, Int pathDiameter, Bool crusher)
+		const Coord3D *rawTo, Int pathDiameter, Bool crusher)
 {
 	//CRCDEBUG_LOG(("Pathfinder::findGroundPath()"));
 #ifdef DEBUG_LOGGING
@@ -7381,7 +7381,7 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 
 				if (!newCell->allocateInfo(newCellCoord)) {
 					// Out of cells for pathing...
- 					continue;
+						continue;
 				}
 				cellCount++;
 
@@ -7440,7 +7440,7 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 	if (TheGlobalData->m_debugAI)
 	{
 		extern void addIcon(const Coord3D *pos, Real width, Int numFramesDuration, RGBColor color);
- 		RGBColor color;
+		RGBColor color;
 		color.blue = 0;
 		color.red = color.green = 1;
 		addIcon(nullptr, 0, 0, color);
@@ -7498,9 +7498,9 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
  * Uses A* algorithm.
  */
 void Pathfinder::processHierarchicalCell( const ICoord2D &scanCell, const ICoord2D &delta, PathfindCell *parentCell,
-																				 PathfindCell *goalCell, zoneStorageType parentZone,
-																				 zoneStorageType *examinedZones, Int &numExZones,
-																				 Bool crusher, Int &cellCount)
+	PathfindCell *goalCell, zoneStorageType parentZone,
+	zoneStorageType *examinedZones, Int &numExZones,
+	Bool crusher, Int &cellCount)
 {
 	if (scanCell.x<m_extent.lo.x || scanCell.x>m_extent.hi.x ||
 		scanCell.y<m_extent.lo.y || scanCell.y>m_extent.hi.y) {
@@ -7519,7 +7519,7 @@ void Pathfinder::processHierarchicalCell( const ICoord2D &scanCell, const ICoord
 #else
 		if( !newCell->hasInfo() )
 		{
- 			return;
+			return;
 		}
 
 		if( newCell->getOpen() || newCell->getClosed() )
@@ -7604,7 +7604,7 @@ void Pathfinder::processHierarchicalCell( const ICoord2D &scanCell, const ICoord
  * Uses A* algorithm.
  */
 Path *Pathfinder::findHierarchicalPath( Bool isHuman, const LocomotorSet& locomotorSet, const Coord3D *from,
-													 const Coord3D *to, Bool crusher)
+	const Coord3D *to, Bool crusher)
 {
 	return internal_findHierarchicalPath(isHuman, locomotorSet.getValidSurfaces(), from, to, crusher, FALSE);
 }
@@ -7615,7 +7615,7 @@ Path *Pathfinder::findHierarchicalPath( Bool isHuman, const LocomotorSet& locomo
  * Uses A* algorithm.
  */
 Path *Pathfinder::findClosestHierarchicalPath( Bool isHuman, const LocomotorSet& locomotorSet, const Coord3D *from,
-													 const Coord3D *to, Bool crusher)
+	const Coord3D *to, Bool crusher)
 {
 	return internal_findHierarchicalPath(isHuman, locomotorSet.getValidSurfaces(), from, to, crusher, TRUE);
 }
@@ -7627,7 +7627,7 @@ Path *Pathfinder::findClosestHierarchicalPath( Bool isHuman, const LocomotorSet&
  * Uses A* algorithm.
  */
 Path *Pathfinder::internal_findHierarchicalPath( Bool isHuman, const LocomotorSurfaceTypeMask locomotorSurface, const Coord3D *from,
-													 const Coord3D *rawTo, Bool crusher, Bool closestOK)
+	const Coord3D *rawTo, Bool crusher, Bool closestOK)
 {
 	//CRCDEBUG_LOG(("Pathfinder::findGroundPath()"));
 #ifdef DEBUG_LOGGING
@@ -7732,7 +7732,7 @@ Path *Pathfinder::internal_findHierarchicalPath( Bool isHuman, const LocomotorSu
 		ICoord2D toNdx;
 		m_layers[layer].getStartCellIndex(&ndx);
 		m_layers[layer].getEndCellIndex(&toNdx);
- 		PathfindCell *cell = getCell(LAYER_GROUND, toNdx.x, toNdx.y);
+		PathfindCell *cell = getCell(LAYER_GROUND, toNdx.x, toNdx.y);
 		PathfindCell *startCell = getCell(LAYER_GROUND, ndx.x, ndx.y);
 		if (cell && startCell) {
 			// Close parent cell;
@@ -7856,7 +7856,7 @@ Path *Pathfinder::internal_findHierarchicalPath( Bool isHuman, const LocomotorSu
 						reachedGoal = true;
 						break;
 					}
- 					PathfindCell *cell = getCell(LAYER_GROUND, toNdx.x, toNdx.y);
+					PathfindCell *cell = getCell(LAYER_GROUND, toNdx.x, toNdx.y);
 					if (!cell)
 						continue;
 
@@ -7963,7 +7963,7 @@ Path *Pathfinder::internal_findHierarchicalPath( Bool isHuman, const LocomotorSu
 		show |= (TheGlobalData->m_debugAI==AI_DEBUG_GROUND_PATHS);
 		if (show)	{
 			extern void addIcon(const Coord3D *pos, Real width, Int numFramesDuration, RGBColor color);
- 			RGBColor color;
+			RGBColor color;
 			color.blue = 1;
 			color.red = 1;
 			color.green = 0;
@@ -8144,7 +8144,7 @@ Path *Pathfinder::internal_findHierarchicalPath( Bool isHuman, const LocomotorSu
 	if (TheGlobalData->m_debugAI)
 	{
 		extern void addIcon(const Coord3D *pos, Real width, Int numFramesDuration, RGBColor color);
- 		RGBColor color;
+		RGBColor color;
 		color.blue = 0;
 		color.red = color.green = 1;
 		addIcon(nullptr, 0, 0, color);

--- a/Core/GameEngine/Source/GameNetwork/ConnectionManager.cpp
+++ b/Core/GameEngine/Source/GameNetwork/ConnectionManager.cpp
@@ -2050,7 +2050,7 @@ void ConnectionManager::parseUserList(const GameInfo *game)
 			if (game->getLocalSlotNum() == i)
 			{
 				m_localSlot = i;
-   			m_localUser->setName(slot->getName());
+				m_localUser->setName(slot->getName());
 			}
 
 			if (m_localSlot != i)
@@ -2178,7 +2178,7 @@ Real ConnectionManager::getIncomingBytesPerSecond()
 	if (m_transport)
 		return m_transport->getIncomingBytesPerSecond();
 	else
-	  return 0.0;
+	return 0.0;
 }
 
 /**
@@ -2189,7 +2189,7 @@ Real ConnectionManager::getIncomingPacketsPerSecond()
 	if (m_transport)
 		return m_transport->getIncomingPacketsPerSecond();
 	else
-	  return 0.0;
+	return 0.0;
 }
 
 /**
@@ -2200,7 +2200,7 @@ Real ConnectionManager::getOutgoingBytesPerSecond()
 	if (m_transport)
 		return m_transport->getOutgoingBytesPerSecond();
 	else
-	  return 0.0;
+	return 0.0;
 }
 
 /**
@@ -2211,7 +2211,7 @@ Real ConnectionManager::getOutgoingPacketsPerSecond()
 	if (m_transport) {
 		return m_transport->getOutgoingPacketsPerSecond();
 	} else {
-	  return 0.0;
+		return 0.0;
 	}
 }
 
@@ -2223,7 +2223,7 @@ Real ConnectionManager::getUnknownBytesPerSecond()
 	if (m_transport)
 		return m_transport->getUnknownBytesPerSecond();
 	else
-	  return 0.0;
+	return 0.0;
 }
 
 /**
@@ -2234,7 +2234,7 @@ Real ConnectionManager::getUnknownPacketsPerSecond()
 	if (m_transport)
 		return m_transport->getUnknownPacketsPerSecond();
 	else
-	  return 0.0;
+	return 0.0;
 }
 
 /**

--- a/Core/GameEngine/Source/GameNetwork/FirewallHelper.cpp
+++ b/Core/GameEngine/Source/GameNetwork/FirewallHelper.cpp
@@ -607,7 +607,7 @@ Short FirewallHelperClass::getSourcePortAllocationDelta() {
 
 Bool FirewallHelperClass::detectionBeginUpdate() {
 //	UnsignedShort mangler_port = MANGLER_PORT;
-	 m_packetID = 0x7f00;
+	m_packetID = 0x7f00;
 	//int current_mangler = 0;
 
 	/*

--- a/Core/GameEngine/Source/GameNetwork/GameInfo.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameInfo.cpp
@@ -309,13 +309,13 @@ void GameInfo::reset()
 	m_seed = GetTickCount(); //GameClientRandomValue(0, INT_MAX - 1);
 	m_useStats = TRUE;
 	m_surrendered = FALSE;
-  m_oldFactionsOnly = FALSE;
+	m_oldFactionsOnly = FALSE;
 //	m_localIP = 0; // BGC - actually we don't want this to be reset since the m_localIP is
 										// set properly in the constructor of LANGameInfo which uses this as a base class.
 	m_mapCRC = 0;
 	m_mapSize = 0;
-  m_superweaponRestriction = 0;
-  m_startingCash = TheGlobalData->m_defaultStartingCash;
+	m_superweaponRestriction = 0;
+	m_startingCash = TheGlobalData->m_defaultStartingCash;
 
 	for (Int i=0; i<MAX_SLOTS; ++i)
 	{
@@ -695,12 +695,12 @@ void GameInfo::setSlotPointer( Int index, GameSlot *slot )
 
 void GameInfo::setSuperweaponRestriction( UnsignedShort restriction )
 {
-  m_superweaponRestriction = restriction;
+	m_superweaponRestriction = restriction;
 }
 
 void GameInfo::setStartingCash( const Money & startingCash )
 {
-  m_startingCash = startingCash;
+	m_startingCash = startingCash;
 }
 
 Bool GameInfo::isColorTaken(Int colorIdx, Int slotToIgnore ) const
@@ -1017,10 +1017,10 @@ Bool ParseAsciiStringToGameInfo(GameInfo *game, AsciiString options)
 	Int seed = 0;
 	Int crc = 100;
 	Bool sawCRC = FALSE;
-  Bool oldFactionsOnly = FALSE;
+	Bool oldFactionsOnly = FALSE;
 	Int useStats = TRUE;
-  Money startingCash = TheGlobalData->m_defaultStartingCash;
-  UnsignedShort restriction = 0; // Always the default
+	Money startingCash = TheGlobalData->m_defaultStartingCash;
+	UnsignedShort restriction = 0; // Always the default
 
 	Bool sawMap = FALSE;
 	Bool sawMapCRC = FALSE;
@@ -1123,23 +1123,23 @@ Bool ParseAsciiStringToGameInfo(GameInfo *game, AsciiString options)
 			crc = atoi(val.str());
 			sawCRC = TRUE;
 		}
-    else if (key.compare("SR") == 0 )
-    {
-      restriction = (UnsignedShort)atoi(val.str());
-      sawSuperweaponRestriction = TRUE;
-    }
-    else if (key.compare("SC") == 0 )
-    {
-      UnsignedInt startingCashAmount = strtoul( val.str(), nullptr, 10 );
-      startingCash.init();
-      startingCash.deposit( startingCashAmount, FALSE, FALSE );
-      sawStartingCash = TRUE;
-    }
-    else if (key.compare("O") == 0 )
-    {
-      oldFactionsOnly = ( val.compareNoCase( "Y" ) == 0 );
-      sawOldFactions = TRUE;
-    }
+		else if (key.compare("SR") == 0 )
+		{
+			restriction = (UnsignedShort)atoi(val.str());
+			sawSuperweaponRestriction = TRUE;
+		}
+		else if (key.compare("SC") == 0 )
+		{
+			UnsignedInt startingCashAmount = strtoul( val.str(), nullptr, 10 );
+			startingCash.init();
+			startingCash.deposit( startingCashAmount, FALSE, FALSE );
+			sawStartingCash = TRUE;
+		}
+		else if (key.compare("O") == 0 )
+		{
+			oldFactionsOnly = ( val.compareNoCase( "Y" ) == 0 );
+			sawOldFactions = TRUE;
+		}
 		else if (key.getLength() == 1 && *key.str() == slotListID)
 		{
 			sawSlotlist = true;
@@ -1171,7 +1171,7 @@ Bool ParseAsciiStringToGameInfo(GameInfo *game, AsciiString options)
 								break;
 							}
 							UnicodeString name;
-              				name.set(MultiByteToWideCharSingleLine(slotValue.str() +1).c_str());
+						name.set(MultiByteToWideCharSingleLine(slotValue.str() +1).c_str());
 
 							//DEBUG_LOG(("ParseAsciiStringToGameInfo - name is %s", slotValue.str()+1));
 
@@ -1321,7 +1321,7 @@ Bool ParseAsciiStringToGameInfo(GameInfo *game, AsciiString options)
 						break;
 						case 'C':
 						{
-            	DEBUG_LOG(("ParseAsciiStringToGameInfo - AI player"));
+						DEBUG_LOG(("ParseAsciiStringToGameInfo - AI player"));
 							char *slotPos = nullptr;
 							//Parse out the Name
 							AsciiString slotValue(strtok_r((char *)rawSlot.str(),",",&slotPos));
@@ -1590,7 +1590,7 @@ void SkirmishGameInfo::xfer( Xfer *xfer )
 		Int origStartPos=m_slot[slot]->getOriginalStartPos();
 		xfer->xferInt(&origStartPos);
 
- 		Int origPlayerTemplate=m_slot[slot]->getOriginalPlayerTemplate();
+		Int origPlayerTemplate=m_slot[slot]->getOriginalPlayerTemplate();
 		xfer->xferInt(&origPlayerTemplate);
 
 		if( xfer->getXferMode() == XFER_LOAD ) {
@@ -1617,24 +1617,24 @@ void SkirmishGameInfo::xfer( Xfer *xfer )
 	xfer->xferInt(&m_mapMask);
 	xfer->xferInt(&m_seed);
 
-  if ( version >= 3 )
-  {
-    xfer->xferUnsignedShort( &m_superweaponRestriction );
+	if ( version >= 3 )
+	{
+		xfer->xferUnsignedShort( &m_superweaponRestriction );
 
-    if ( version == 3 )
-    {
-      // Version 3 had a bool which is now gone
-      Bool obsoleteBool;
-      xfer->xferBool( &obsoleteBool );
-    }
+		if ( version == 3 )
+		{
+			// Version 3 had a bool which is now gone
+			Bool obsoleteBool;
+			xfer->xferBool( &obsoleteBool );
+		}
 
-    xfer->xferSnapshot( &m_startingCash );
-  }
-  else if ( xfer->getXferMode() == XFER_LOAD )
-  {
-    m_superweaponRestriction = 0;
-    m_startingCash = TheGlobalData->m_defaultStartingCash;
-  }
+		xfer->xferSnapshot( &m_startingCash );
+	}
+	else if ( xfer->getXferMode() == XFER_LOAD )
+	{
+		m_superweaponRestriction = 0;
+		m_startingCash = TheGlobalData->m_defaultStartingCash;
+	}
 
 }
 

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Chat.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Chat.cpp
@@ -295,7 +295,7 @@ void GameSpyInfo::addChat( PlayerInfo p, UnicodeString msg, Bool isPublic, Bool 
 	// filters language
 //  if( TheGlobalData->m_languageFilterPref )
 //  {
-    TheLanguageFilter->filterLine(msg);
+	TheLanguageFilter->filterLine(msg);
 //  }
 
 	UnicodeString fullMsg;

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/GSConfig.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/GSConfig.cpp
@@ -126,7 +126,7 @@ public:
 	void addVar(const Bool *var) { m_bools.push_back(var); }
 	Bool isInSection();
 protected:
-	 SectionList m_bools;
+	SectionList m_bools;
 };
 Bool SectionChecker::isInSection() {
 	Bool ret = FALSE;

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/LobbyUtils.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/LobbyUtils.cpp
@@ -73,7 +73,7 @@ enum {
 	COLUMN_PASSWORD,
 	COLUMN_OBSERVER,
 #if !RTS_GENERALS
-  COLUMN_USE_STATS,
+	COLUMN_USE_STATS,
 #endif
 	COLUMN_PING,
 };
@@ -250,18 +250,18 @@ static void gameTooltip(GameWindow *window,
 		return;
 	}
 #if !RTS_GENERALS
-  if (col == COLUMN_USE_STATS)
-  {
-    if ( room->getUseStats() )
-    {
-      TheMouse->setCursorTooltip( TheGameText->fetch("TOOLTIP:UseStatsOn") );
-    }
-    else
-    {
-      TheMouse->setCursorTooltip( TheGameText->fetch("TOOLTIP:UseStatsOff") );
-    }
-    return;
-  }
+	if (col == COLUMN_USE_STATS)
+	{
+		if ( room->getUseStats() )
+		{
+			TheMouse->setCursorTooltip( TheGameText->fetch("TOOLTIP:UseStatsOn") );
+		}
+		else
+		{
+			TheMouse->setCursorTooltip( TheGameText->fetch("TOOLTIP:UseStatsOff") );
+		}
+		return;
+	}
 #endif
 
 	UnicodeString tooltip;
@@ -647,15 +647,15 @@ static Int insertGame( GameWindow *win, GameSpyStagingRoom *game, Bool showMap )
 	}
 
 #if !RTS_GENERALS
-  {
-    if (game->getUseStats())
-    {
-      if (const Image *img = TheMappedImageCollection->findImageByName("GoodStatsIcon"))
-      {
-        GadgetListBoxAddEntryImage(win, img, index, COLUMN_USE_STATS, img->getImageHeight(), img->getImageWidth());
-      }
-    }
-  }
+	{
+		if (game->getUseStats())
+		{
+			if (const Image *img = TheMappedImageCollection->findImageByName("GoodStatsIcon"))
+			{
+				GadgetListBoxAddEntryImage(win, img, index, COLUMN_USE_STATS, img->getImageHeight(), img->getImageWidth());
+			}
+		}
+	}
 #endif
 
 	s.format(L"%d", game->getPingAsInt());

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/PeerDefs.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/PeerDefs.cpp
@@ -517,19 +517,19 @@ void GameSpyInfo::markAsStagingRoomHost()
 	m_localStagingRoomID = 0;
 	m_joinedStagingRoom = FALSE; m_isHosting = TRUE;
 
-  // There are a few options we don't want to reset when we are hosting (they carry over
-  // from the the create game dialog).
-  // Interesting fact: oldFactionsOnly will be carried over correctly if I remove these
-  // lines. UseStats won't be. I have no idea why.
-  Int useStats = m_localStagingRoom.getUseStats();
-  Bool oldFactionsOnly = m_localStagingRoom.oldFactionsOnly();
+	// There are a few options we don't want to reset when we are hosting (they carry over
+	// from the the create game dialog).
+	// Interesting fact: oldFactionsOnly will be carried over correctly if I remove these
+	// lines. UseStats won't be. I have no idea why.
+	Int useStats = m_localStagingRoom.getUseStats();
+	Bool oldFactionsOnly = m_localStagingRoom.oldFactionsOnly();
 
-  m_localStagingRoom.reset();
+	m_localStagingRoom.reset();
 	m_localStagingRoom.enterGame();
 	m_localStagingRoom.setSeed(GetTickCount());
 
-  m_localStagingRoom.setUseStats( useStats );
-  m_localStagingRoom.setOldFactionsOnly( oldFactionsOnly );
+	m_localStagingRoom.setUseStats( useStats );
+	m_localStagingRoom.setOldFactionsOnly( oldFactionsOnly );
 
 	GameSlot newSlot;
 	UnicodeString uName;
@@ -724,7 +724,7 @@ Bool GameSpyInfo::isIgnored( AsciiString nick )
 
 IgnoreList GameSpyInfo::returnIgnoreList()
 {
- return m_ignoreList;
+	return m_ignoreList;
 }
 
 void GameSpyInfo::addToSavedIgnoreList( Int profileID, AsciiString nick)
@@ -905,8 +905,8 @@ void GameSpyInfo::updateAdditionalGameSpyDisconnections(Int count)
 		TheGameSpyPSMessageQueue->addResponse(newResp);
 
 		// cache our stuff for easy reading next time
-   		GameSpyMiscPreferences mPref;
-   		mPref.setCachedStats(GameSpyPSMessageQueueInterface::formatPlayerKVPairs(stats).c_str());
-   		mPref.write();
+		GameSpyMiscPreferences mPref;
+		mPref.setCachedStats(GameSpyPSMessageQueueInterface::formatPlayerKVPairs(stats).c_str());
+		mPref.write();
 	}
 }

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PeerThread.cpp
@@ -93,7 +93,7 @@ enum
 	PW_KEY,
 	OBS_KEY,
 #if !RTS_GENERALS
-  USE_STATS_KEY,
+	USE_STATS_KEY,
 #endif
 	LADIP_KEY,
 	LADPORT_KEY,
@@ -227,7 +227,7 @@ public:
 	void stopHostingAlready(PEER peer);
 	Bool hasPassword() { return m_hasPassword; }
 	Bool allowObservers() { return m_allowObservers; }
-  Bool useStats() const { return m_useStats; }
+	Bool useStats() const { return m_useStats; }
 	std::string getMapName() { return m_mapName; }
 	UnsignedInt exeCRC() { return m_exeCRC; }
 	UnsignedInt iniCRC() { return m_iniCRC; }
@@ -299,7 +299,7 @@ private:
 	UnsignedInt m_iniCRC;
 	UnsignedInt m_gameVersion;
 	Bool m_allowObservers;
-  Bool m_useStats;
+	Bool m_useStats;
 	std::string m_pingStr;
 	std::string m_ladderIP;
 	UnsignedShort m_ladderPort;
@@ -798,9 +798,9 @@ static void QRServerKeyCallback
 		ADDINT(t->allowObservers());
 		break;
 #if !RTS_GENERALS
-  case USE_STATS_KEY:
-    ADDINT(t->useStats());
-    break;
+		case USE_STATS_KEY:
+			ADDINT(t->useStats());
+			break;
 #endif
 	case LADIP_KEY:
 		ADD(t->ladderIP().c_str());
@@ -947,7 +947,7 @@ static void QRKeyListCallback
 		qr2_keybuffer_add(keyBuffer, PW_KEY);
 		qr2_keybuffer_add(keyBuffer, OBS_KEY);
 #if !RTS_GENERALS
-    qr2_keybuffer_add(keyBuffer, USE_STATS_KEY);
+		qr2_keybuffer_add(keyBuffer, USE_STATS_KEY);
 #endif
 		qr2_keybuffer_add(keyBuffer, LADIP_KEY);
 		qr2_keybuffer_add(keyBuffer, LADPORT_KEY);
@@ -1199,7 +1199,7 @@ void PeerThreadClass::Thread_Function()
 	qr2_register_key(PW_KEY, PW_STR);
 	qr2_register_key(OBS_KEY, OBS_STR);
 #if !RTS_GENERALS
-  qr2_register_key(USE_STATS_KEY, USE_STATS_STR);
+		qr2_register_key(USE_STATS_KEY, USE_STATS_STR);
 #endif
 	qr2_register_key(LADIP_KEY, LADIP_STR);
 	qr2_register_key(LADPORT_KEY, LADPORT_STR);
@@ -1235,7 +1235,7 @@ void PeerThreadClass::Thread_Function()
 		PW_KEY,
 		OBS_KEY,
 #if !RTS_GENERALS
-    USE_STATS_KEY,
+			USE_STATS_KEY,
 #endif
 		LADIP_KEY,
 		LADPORT_KEY,
@@ -1652,7 +1652,7 @@ void PeerThreadClass::Thread_Function()
 						s_wantStateChangedHeartbeat = FALSE;
 						m_isHosting = TRUE;
 						m_allowObservers = incomingRequest.stagingRoomCreation.allowObservers;
-            m_useStats = incomingRequest.stagingRoomCreation.useStats;
+							m_useStats = incomingRequest.stagingRoomCreation.useStats;
 						m_mapName = "";
 						for (Int i=0; i<MAX_SLOTS; ++i)
 						{
@@ -2886,7 +2886,7 @@ static void listingGamesCallback(PEER peer, PEERBool success, const char * name,
 	{
 		Bool hasPassword = (Bool)SBServerGetIntValue(server, PW_STR, FALSE);
 		Bool allowObservers = (Bool)SBServerGetIntValue(server, OBS_STR, FALSE);
-    Bool usesStats = (Bool)SBServerGetIntValue(server, USE_STATS_STR, TRUE);
+		Bool usesStats = (Bool)SBServerGetIntValue(server, USE_STATS_STR, TRUE);
 		const char *verStr = SBServerGetStringValue(server, "gamever", "000000");
 		const char *exeStr = SBServerGetStringValue(server, EXECRC_STR, "000000");
 		const char *iniStr = SBServerGetStringValue(server, INICRC_STR, "000000");
@@ -2898,7 +2898,7 @@ static void listingGamesCallback(PEER peer, PEERBool success, const char * name,
 		UnsignedInt iniVal = strtoul(iniStr, nullptr, 10);
 		resp.stagingRoom.requiresPassword = hasPassword;
 		resp.stagingRoom.allowObservers = allowObservers;
-    resp.stagingRoom.useStats = usesStats;
+		resp.stagingRoom.useStats = usesStats;
 		resp.stagingRoom.version = verVal;
 		resp.stagingRoom.exeCRC = exeVal;
 		resp.stagingRoom.iniCRC = iniVal;

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PingThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PingThread.cpp
@@ -341,11 +341,11 @@ BOOL WINAPI IcmpCloseHandle(HANDLE IcmpHandle); /* FALSE on error */
  */
 typedef struct ip_option_information
 {
-   UnsignedByte Ttl;         /* Time To Live (used for traceroute) */
-   UnsignedByte Tos;         /* Type Of Service (usually 0) */
-   UnsignedByte Flags;       /* IP header flags (usually 0) */
-   UnsignedByte OptionsSize; /* Size of options data (usually 0, max 40) */
-   UnsignedByte FAR *OptionsData;   /* Options data buffer */
+	UnsignedByte Ttl;         /* Time To Live (used for traceroute) */
+	UnsignedByte Tos;         /* Type Of Service (usually 0) */
+	UnsignedByte Flags;       /* IP header flags (usually 0) */
+	UnsignedByte OptionsSize; /* Size of options data (usually 0, max 40) */
+	UnsignedByte FAR *OptionsData;   /* Options data buffer */
 }
 IPINFO, *PIPINFO, FAR *LPIPINFO;
 
@@ -357,26 +357,26 @@ IPINFO, *PIPINFO, FAR *LPIPINFO;
  */
 typedef struct icmp_echo_reply
 {
-   UnsignedInt Address;     /* source address */
-   ////////UnsignedInt Status;      /* IP status value (see below) */
-   UnsignedInt RTTime;      /* Round Trip Time in milliseconds */
-   UnsignedShort DataSize;   /* reply data size */
-   UnsignedShort Reserved;   /* */
-   void FAR *Data;     /* reply data buffer */
-   struct ip_option_information Options; /* reply options */
+	UnsignedInt Address;     /* source address */
+	////////UnsignedInt Status;      /* IP status value (see below) */
+	UnsignedInt RTTime;      /* Round Trip Time in milliseconds */
+	UnsignedShort DataSize;   /* reply data size */
+	UnsignedShort Reserved;   /* */
+	void FAR *Data;     /* reply data buffer */
+	struct ip_option_information Options; /* reply options */
 }
 ICMPECHO, *PICMPECHO, FAR *LPICMPECHO;
 
 
 DWORD WINAPI IcmpSendEcho(
-   HANDLE IcmpHandle,   /* handle returned from IcmpCreateFile() */
-   UnsignedInt DestAddress,  /* destination IP address (in network order) */
-   LPVOID RequestData,  /* pointer to buffer to send */
-   WORD RequestSize,    /* length of data in buffer */
-   LPIPINFO RequestOptns,   /* see Note 2 */
-   LPVOID ReplyBuffer,  /* see Note 1 */
-   DWORD ReplySize,     /* length of reply (must allow at least 1 reply) */
-   DWORD Timeout       /* time in milliseconds to wait for reply */
+	HANDLE IcmpHandle,   /* handle returned from IcmpCreateFile() */
+	UnsignedInt DestAddress,  /* destination IP address (in network order) */
+	LPVOID RequestData,  /* pointer to buffer to send */
+	WORD RequestSize,    /* length of data in buffer */
+	LPIPINFO RequestOptns,   /* see Note 2 */
+	LPVOID ReplyBuffer,  /* see Note 1 */
+	DWORD ReplySize,     /* length of reply (must allow at least 1 reply) */
+	DWORD Timeout       /* time in milliseconds to wait for reply */
 );
 
 
@@ -420,91 +420,91 @@ Int PingThreadClass::doPing(UnsignedInt IP, Int timeout)
     * Initialize default settings
     */
 
-   IPINFO stIPInfo, *lpstIPInfo;
-   HANDLE hICMP, hICMP_DLL;
-   int i, j, nDataLen, nLoopLimit, nTimeOut, nTTL, nTOS;
-   DWORD dwReplyCount;
-   ///////IN_ADDR stDestAddr;
-   BOOL fRet, fDontStop;
-   ///BOOL fTraceRoute;
+	IPINFO stIPInfo, *lpstIPInfo;
+	HANDLE hICMP, hICMP_DLL;
+	int i, j, nDataLen, nLoopLimit, nTimeOut, nTTL, nTOS;
+	DWORD dwReplyCount;
+	///////IN_ADDR stDestAddr;
+	BOOL fRet, fDontStop;
+	///BOOL fTraceRoute;
 
-   nDataLen = DEFAULT_LEN;
-   nLoopLimit = LOOPLIMIT;
-   nTimeOut = timeout;
-   fDontStop = FALSE;
-   lpstIPInfo = nullptr;
-   nTTL = DEFAULT_TTL;
-   nTOS = 0;
+	nDataLen = DEFAULT_LEN;
+	nLoopLimit = LOOPLIMIT;
+	nTimeOut = timeout;
+	fDontStop = FALSE;
+	lpstIPInfo = nullptr;
+	nTTL = DEFAULT_TTL;
+	nTOS = 0;
 
-   Int pingTime = -1;  // in case of error
+	Int pingTime = -1;  // in case of error
 
-   char achReqData[BUFSIZE];
-   char achRepData[sizeof(ICMPECHO) + BUFSIZE];
+	char achReqData[BUFSIZE];
+	char achRepData[sizeof(ICMPECHO) + BUFSIZE];
 
 
-   HANDLE ( WINAPI *lpfnIcmpCreateFile )( VOID ) = nullptr;
-   BOOL ( WINAPI *lpfnIcmpCloseHandle )( HANDLE ) = nullptr;
-   DWORD (WINAPI *lpfnIcmpSendEcho)(HANDLE, DWORD, LPVOID, WORD, LPVOID,
-                                    LPVOID, DWORD, DWORD) = nullptr;
+	HANDLE ( WINAPI *lpfnIcmpCreateFile )( VOID ) = nullptr;
+	BOOL ( WINAPI *lpfnIcmpCloseHandle )( HANDLE ) = nullptr;
+	DWORD (WINAPI *lpfnIcmpSendEcho)(HANDLE, DWORD, LPVOID, WORD, LPVOID,
+		LPVOID, DWORD, DWORD) = nullptr;
 
 
    /*
     *  Load the ICMP.DLL
     */
-   hICMP_DLL = LoadLibrary("ICMP.DLL");
-   if (hICMP_DLL == nullptr)
-   {
-      DEBUG_LOG(("LoadLibrary() failed: Unable to locate ICMP.DLL!"));
-      goto cleanup;
-   }
+	hICMP_DLL = LoadLibrary("ICMP.DLL");
+	if (hICMP_DLL == nullptr)
+	{
+		DEBUG_LOG(("LoadLibrary() failed: Unable to locate ICMP.DLL!"));
+		goto cleanup;
+	}
 
    /*
     * Get pointers to ICMP.DLL functions
     */
-   lpfnIcmpCreateFile = (void * (__stdcall *)())GetProcAddress( (HINSTANCE)hICMP_DLL, "IcmpCreateFile");
-   lpfnIcmpCloseHandle = (int (__stdcall *)(void *))GetProcAddress( (HINSTANCE)hICMP_DLL, "IcmpCloseHandle");
-   lpfnIcmpSendEcho = (unsigned long (__stdcall *)(void *, unsigned long, void *, unsigned short,
-                       void *, void *, unsigned long, unsigned long))GetProcAddress( (HINSTANCE)hICMP_DLL, "IcmpSendEcho" );
+	lpfnIcmpCreateFile = (void * (__stdcall *)())GetProcAddress( (HINSTANCE)hICMP_DLL, "IcmpCreateFile");
+	lpfnIcmpCloseHandle = (int (__stdcall *)(void *))GetProcAddress( (HINSTANCE)hICMP_DLL, "IcmpCloseHandle");
+	lpfnIcmpSendEcho = (unsigned long (__stdcall *)(void *, unsigned long, void *, unsigned short,
+		void *, void *, unsigned long, unsigned long))GetProcAddress( (HINSTANCE)hICMP_DLL, "IcmpSendEcho" );
 
-   if ((!lpfnIcmpCreateFile) ||
-         (!lpfnIcmpCloseHandle) ||
-         (!lpfnIcmpSendEcho))
-   {
-      DEBUG_LOG(("GetProcAddr() failed for at least one function."));
-      goto cleanup;
-   }
+	if ((!lpfnIcmpCreateFile) ||
+		(!lpfnIcmpCloseHandle) ||
+		(!lpfnIcmpSendEcho))
+	{
+		DEBUG_LOG(("GetProcAddr() failed for at least one function."));
+		goto cleanup;
+	}
 
 
    /*
     * IcmpCreateFile() - Open the ping service
     */
-   hICMP = (HANDLE) lpfnIcmpCreateFile();
-   if (hICMP == INVALID_HANDLE_VALUE)
-   {
-      DEBUG_LOG(("IcmpCreateFile() failed"));
-      goto cleanup;
-   }
+	hICMP = (HANDLE) lpfnIcmpCreateFile();
+	if (hICMP == INVALID_HANDLE_VALUE)
+	{
+		DEBUG_LOG(("IcmpCreateFile() failed"));
+		goto cleanup;
+	}
 
    /*
     * Init data buffer printable ASCII
     *  32 (space) through 126 (tilde)
     */
-   for (j = 0, i = 32; j < nDataLen; j++, i++)
-   {
-      if (i >= 126)
-         i = 32;
-      achReqData[j] = i;
-   }
+	for (j = 0, i = 32; j < nDataLen; j++, i++)
+	{
+		if (i >= 126)
+		i = 32;
+		achReqData[j] = i;
+	}
 
    /*
    * Init IPInfo structure
    */
-   lpstIPInfo = &stIPInfo;
-   stIPInfo.Ttl = nTTL;
-   stIPInfo.Tos = nTOS;
-   stIPInfo.Flags = 0;
-   stIPInfo.OptionsSize = 0;
-   stIPInfo.OptionsData = nullptr;
+	lpstIPInfo = &stIPInfo;
+	stIPInfo.Ttl = nTTL;
+	stIPInfo.Tos = nTOS;
+	stIPInfo.Flags = 0;
+	stIPInfo.OptionsSize = 0;
+	stIPInfo.OptionsData = nullptr;
 
 
 
@@ -512,61 +512,61 @@ Int PingThreadClass::doPing(UnsignedInt IP, Int timeout)
     * IcmpSendEcho() - Send the ICMP Echo Request
     *                   and read the Reply
     */
-   dwReplyCount = lpfnIcmpSendEcho(
-                     hICMP,
-                     IP,
-                     achReqData,
-                     nDataLen,
-                     lpstIPInfo,
-                     achRepData,
-                     sizeof(achRepData),
-                     nTimeOut);
-   if (dwReplyCount != 0)
-   {
-      //////////IN_ADDR stDestAddr;
-      DWORD dwStatus;
+	dwReplyCount = lpfnIcmpSendEcho(
+		hICMP,
+		IP,
+		achReqData,
+		nDataLen,
+		lpstIPInfo,
+		achRepData,
+		sizeof(achRepData),
+		nTimeOut);
+	if (dwReplyCount != 0)
+	{
+		//////////IN_ADDR stDestAddr;
+		DWORD dwStatus;
 
-      pingTime = (*(UnsignedInt *) & (achRepData[8]));
+		pingTime = (*(UnsignedInt *) & (achRepData[8]));
 
-      // I've seen the ping time bigger than the timeout by a little
-      //   bit.  How lame.
-      if (pingTime > timeout)
-         pingTime = timeout;
+		// I've seen the ping time bigger than the timeout by a little
+		//   bit.  How lame.
+		if (pingTime > timeout)
+		pingTime = timeout;
 
-      dwStatus = *(DWORD *) & (achRepData[4]);
-      if (dwStatus != IP_SUCCESS)
-      {
-         DEBUG_LOG(("ICMPERR: %d", dwStatus));
-      }
+		dwStatus = *(DWORD *) & (achRepData[4]);
+		if (dwStatus != IP_SUCCESS)
+		{
+			DEBUG_LOG(("ICMPERR: %d", dwStatus));
+		}
 
-   }
-   else
-   {
-      DEBUG_LOG(("IcmpSendEcho() failed: %d", dwReplyCount));
-      // Ok we didn't get a packet, just say everything's OK
-      //  and the time was -1
-      pingTime = -1;
-      goto cleanup;
-   }
+	}
+	else
+	{
+		DEBUG_LOG(("IcmpSendEcho() failed: %d", dwReplyCount));
+		// Ok we didn't get a packet, just say everything's OK
+		//  and the time was -1
+		pingTime = -1;
+		goto cleanup;
+	}
 
 
    /*
     * IcmpCloseHandle - Close the ICMP handle
     */
-   fRet = lpfnIcmpCloseHandle(hICMP);
-   if (fRet == FALSE)
-   {
-      DEBUG_LOG(("Error closing ICMP handle"));
-   }
+	fRet = lpfnIcmpCloseHandle(hICMP);
+	if (fRet == FALSE)
+	{
+		DEBUG_LOG(("Error closing ICMP handle"));
+	}
 
-   // Say what you will about goto's but it's handy for stuff like this
+	// Say what you will about goto's but it's handy for stuff like this
 cleanup:
 
-   // Shut down...
-   if (hICMP_DLL)
-      FreeLibrary((HINSTANCE)hICMP_DLL);
+	// Shut down...
+	if (hICMP_DLL)
+	FreeLibrary((HINSTANCE)hICMP_DLL);
 
-   return pingTime;
+	return pingTime;
 }
 
 

--- a/Core/GameEngine/Source/GameNetwork/LANAPICallbacks.cpp
+++ b/Core/GameEngine/Source/GameNetwork/LANAPICallbacks.cpp
@@ -196,11 +196,11 @@ void LANAPI::OnGameStart()
 		option.format("%d", m_currentGame->getLANSlot( m_currentGame->getLocalSlotNum() )->getColor());
 		pref["Color"] = option;
 		if (m_currentGame->amIHost())
-    {
-    	pref["Map"] = AsciiStringToQuotedPrintable(m_currentGame->getMap());
-      pref.setSuperweaponRestricted( m_currentGame->getSuperweaponRestriction() > 0 );
-      pref.setStartingCash( m_currentGame->getStartingCash() );
-    }
+		{
+			pref["Map"] = AsciiStringToQuotedPrintable(m_currentGame->getMap());
+			pref.setSuperweaponRestricted( m_currentGame->getSuperweaponRestriction() > 0 );
+			pref.setStartingCash( m_currentGame->getStartingCash() );
+		}
 		pref.write();
 
 		m_isInLANMenu = FALSE;

--- a/Core/GameEngine/Source/GameNetwork/NAT.cpp
+++ b/Core/GameEngine/Source/GameNetwork/NAT.cpp
@@ -1275,7 +1275,7 @@ void NAT::setConnectionState(Int nodeNumber, NATConnectionState state) {
 			if (m_slotList[i]->isHuman()) {
 				if (i != m_connectionNodes[m_localNodeNumber].m_slotIndex) {
 					if (i == slotIndex) {
-					 break;
+						break;
 					}
 					++slot;
 				}

--- a/Core/GameEngine/Source/GameNetwork/NetCommandList.cpp
+++ b/Core/GameEngine/Source/GameNetwork/NetCommandList.cpp
@@ -153,8 +153,8 @@ NetCommandRef * NetCommandList::addMessage(NetCommandMsg *cmdMsg) {
 			(m_lastMessageInserted->getCommand()->getPlayerID() == msg->getCommand()->getPlayerID()) &&
 			(m_lastMessageInserted->getCommand()->getID() < msg->getCommand()->getID()) &&
 			((theNext == nullptr) || ((theNext->getCommand()->getNetCommandType() > msg->getCommand()->getNetCommandType()) ||
-			 (theNext->getCommand()->getPlayerID() > msg->getCommand()->getPlayerID()) ||
-			 (theNext->getCommand()->getID() > msg->getCommand()->getID())))) {
+			(theNext->getCommand()->getPlayerID() > msg->getCommand()->getPlayerID()) ||
+			(theNext->getCommand()->getID() > msg->getCommand()->getID())))) {
 
 			// Make sure this command isn't already in the list.
 			if (isEqualCommandMsg(m_lastMessageInserted->getCommand(), msg->getCommand())) {

--- a/Core/GameEngine/Source/GameNetwork/NetCommandRef.cpp
+++ b/Core/GameEngine/Source/GameNetwork/NetCommandRef.cpp
@@ -61,7 +61,7 @@ NetCommandRef::~NetCommandRef()
 	{
 		m_msg->detach();
 	}
- 	DEBUG_ASSERTCRASH(m_next == nullptr, ("NetCommandRef::~NetCommandRef - m_next != nullptr"));
+	DEBUG_ASSERTCRASH(m_next == nullptr, ("NetCommandRef::~NetCommandRef - m_next != nullptr"));
 	DEBUG_ASSERTCRASH(m_prev == nullptr, ("NetCommandRef::~NetCommandRef - m_prev != nullptr"));
 
 #ifdef DEBUG_NETCOMMANDREF

--- a/Core/GameEngine/Source/GameNetwork/Network.cpp
+++ b/Core/GameEngine/Source/GameNetwork/Network.cpp
@@ -706,7 +706,7 @@ void Network::update()
 			m_didSelfSlug = FALSE;
 		}
 		//m_conMgr->update(); // Do the priority thing, packetize thing. This also calls the Transport::update function.
-									 // depacketizes the incoming packets and puts them on the Network command list.
+		// depacketizes the incoming packets and puts them on the Network command list.
 	}
 
 	liteupdate();
@@ -828,7 +828,7 @@ Real Network::getIncomingBytesPerSecond()
 	if (m_conMgr)
 		return m_conMgr->getIncomingBytesPerSecond();
 	else
-	  return 0.0;
+	return 0.0;
 }
 
 /**
@@ -839,7 +839,7 @@ Real Network::getIncomingPacketsPerSecond()
 	if (m_conMgr)
 		return m_conMgr->getIncomingPacketsPerSecond();
 	else
-	  return 0.0;
+	return 0.0;
 }
 
 /**
@@ -850,7 +850,7 @@ Real Network::getOutgoingBytesPerSecond()
 	if (m_conMgr)
 		return m_conMgr->getOutgoingBytesPerSecond();
 	else
-	  return 0.0;
+	return 0.0;
 }
 
 /**
@@ -861,7 +861,7 @@ Real Network::getOutgoingPacketsPerSecond()
 	if (m_conMgr)
 		return m_conMgr->getOutgoingPacketsPerSecond();
 	else
-	  return 0.0;
+	return 0.0;
 }
 
 /**
@@ -872,7 +872,7 @@ Real Network::getUnknownBytesPerSecond()
 	if (m_conMgr)
 		return m_conMgr->getUnknownBytesPerSecond();
 	else
-	  return 0.0;
+	return 0.0;
 }
 
 /**
@@ -883,7 +883,7 @@ Real Network::getUnknownPacketsPerSecond()
 	if (m_conMgr)
 		return m_conMgr->getUnknownPacketsPerSecond();
 	else
-	  return 0.0;
+	return 0.0;
 }
 
 /**

--- a/Core/GameEngine/Source/GameNetwork/NetworkUtil.cpp
+++ b/Core/GameEngine/Source/GameNetwork/NetworkUtil.cpp
@@ -81,30 +81,30 @@ void dumpBufferToLog(const void *vBuf, Int len, const char *fname, Int line)
  */
 UnsignedInt ResolveIP(AsciiString host)
 {
-  struct hostent *hostStruct;
-  struct in_addr *hostNode;
+	struct hostent *hostStruct;
+	struct in_addr *hostNode;
 
-  if (host.isEmpty())
-  {
-	  DEBUG_LOG(("ResolveIP(): Can't resolve null"));
-	  return 0;
-  }
+	if (host.isEmpty())
+	{
+		DEBUG_LOG(("ResolveIP(): Can't resolve null"));
+		return 0;
+	}
 
-  // String such as "127.0.0.1"
-  if (isdigit(host.getCharAt(0)))
-  {
-    return ( ntohl(inet_addr(host.str())) );
-  }
+	// String such as "127.0.0.1"
+	if (isdigit(host.getCharAt(0)))
+	{
+		return ( ntohl(inet_addr(host.str())) );
+	}
 
-  // String such as "localhost"
-  hostStruct = gethostbyname(host.str());
-  if (hostStruct == nullptr)
-  {
-	  DEBUG_LOG(("ResolveIP(): Can't resolve %s", host.str()));
-	  return 0;
-  }
-  hostNode = (struct in_addr *) hostStruct->h_addr;
-  return ( ntohl(hostNode->s_addr) );
+	// String such as "localhost"
+	hostStruct = gethostbyname(host.str());
+	if (hostStruct == nullptr)
+	{
+		DEBUG_LOG(("ResolveIP(): Can't resolve %s", host.str()));
+		return 0;
+	}
+	hostNode = (struct in_addr *) hostStruct->h_addr;
+	return ( ntohl(hostNode->s_addr) );
 }
 
 /**

--- a/Core/GameEngine/Source/GameNetwork/Transport.cpp
+++ b/Core/GameEngine/Source/GameNetwork/Transport.cpp
@@ -379,7 +379,7 @@ Bool Transport::doRecv()
 }
 
 Bool Transport::queueSend(UnsignedInt addr, UnsignedShort port, const UnsignedByte *buf, Int len /*,
-						  NetMessageFlags flags, Int id */)
+	NetMessageFlags flags, Int id */)
 {
 	int i;
 

--- a/Core/GameEngine/Source/GameNetwork/WOLBrowser/WebBrowser.cpp
+++ b/Core/GameEngine/Source/GameNetwork/WOLBrowser/WebBrowser.cpp
@@ -58,7 +58,7 @@ public:
 	{
 		// Initialize this instance
 		OleInitialize(nullptr);
-	 }
+	}
 	~OLEInitializer()
 	{
 		OleUninitialize();

--- a/Core/GameEngine/Source/GameNetwork/udp.cpp
+++ b/Core/GameEngine/Source/GameNetwork/udp.cpp
@@ -116,7 +116,7 @@ AsciiString GetWSAErrorString( Int error )
 
 UDP::UDP()
 {
-  fd=0;
+	fd=0;
 }
 
 UDP::~UDP()
@@ -127,74 +127,74 @@ UDP::~UDP()
 
 Int UDP::Bind(const char *Host,UnsignedShort port)
 {
-  struct hostent *hostStruct;
-  struct in_addr *hostNode;
+	struct hostent *hostStruct;
+	struct in_addr *hostNode;
 
-  if (isdigit(Host[0]))
-    return ( Bind( ntohl(inet_addr(Host)), port) );
+	if (isdigit(Host[0]))
+	return ( Bind( ntohl(inet_addr(Host)), port) );
 
-  hostStruct = gethostbyname(Host);
-  if (hostStruct == nullptr)
-    return (0);
-  hostNode = (struct in_addr *) hostStruct->h_addr;
-  return ( Bind(ntohl(hostNode->s_addr),port) );
+	hostStruct = gethostbyname(Host);
+	if (hostStruct == nullptr)
+	return (0);
+	hostNode = (struct in_addr *) hostStruct->h_addr;
+	return ( Bind(ntohl(hostNode->s_addr),port) );
 }
 
 // You must call bind, implicit binding is for sissies
 //   Well... you can get implicit binding if you pass 0 for either arg
 Int UDP::Bind(UnsignedInt IP,UnsignedShort Port)
 {
-  int retval;
-  int status;
+	int retval;
+	int status;
 
-  IP=htonl(IP);
-  Port=htons(Port);
+	IP=htonl(IP);
+	Port=htons(Port);
 
-  addr.sin_family=AF_INET;
-  addr.sin_port=Port;
-  addr.sin_addr.s_addr=IP;
-  fd=socket(AF_INET,SOCK_DGRAM,DEFAULT_PROTOCOL);
+	addr.sin_family=AF_INET;
+	addr.sin_port=Port;
+	addr.sin_addr.s_addr=IP;
+	fd=socket(AF_INET,SOCK_DGRAM,DEFAULT_PROTOCOL);
   #ifdef _WIN32
-  if (fd==SOCKET_ERROR)
-    fd=-1;
+	if (fd==SOCKET_ERROR)
+	fd=-1;
   #endif
-  if (fd==-1)
-    return(UNKNOWN);
+	if (fd==-1)
+	return(UNKNOWN);
 
-  retval=bind(fd,(struct sockaddr *)&addr,sizeof(addr));
+	retval=bind(fd,(struct sockaddr *)&addr,sizeof(addr));
 
   #ifdef _WIN32
-  if (retval==SOCKET_ERROR)
+	if (retval==SOCKET_ERROR)
 	{
-    retval=-1;
+		retval=-1;
 		m_lastError = WSAGetLastError();
 	}
   #endif
-  if (retval==-1)
-  {
-    status=GetStatus();
-    //CERR("Bind failure (" << status << ") IP " << IP << " PORT " << Port )
-    return(status);
-  }
+	if (retval==-1)
+	{
+		status=GetStatus();
+		//CERR("Bind failure (" << status << ") IP " << IP << " PORT " << Port )
+		return(status);
+	}
 
-  int namelen=sizeof(addr);
-  getsockname(fd, (struct sockaddr *)&addr, &namelen);
+	int namelen=sizeof(addr);
+	getsockname(fd, (struct sockaddr *)&addr, &namelen);
 
-  myIP=ntohl(addr.sin_addr.s_addr);
-  myPort=ntohs(addr.sin_port);
+	myIP=ntohl(addr.sin_addr.s_addr);
+	myPort=ntohs(addr.sin_port);
 
-  retval=SetBlocking(FALSE);
-  if (retval==-1)
-    fprintf(stderr,"Couldn't set nonblocking mode!\n");
+	retval=SetBlocking(FALSE);
+	if (retval==-1)
+	fprintf(stderr,"Couldn't set nonblocking mode!\n");
 
-  return(OK);
+	return(OK);
 }
 
 Int UDP::getLocalAddr(UnsignedInt &ip, UnsignedShort &port)
 {
-  ip=myIP;
-  port=myPort;
-  return(OK);
+	ip=myIP;
+	port=myPort;
+	return(OK);
 }
 
 
@@ -202,52 +202,52 @@ Int UDP::getLocalAddr(UnsignedInt &ip, UnsignedShort &port)
 Int UDP::SetBlocking(Int block)
 {
   #ifdef _WIN32
-   unsigned long flag=1;
-   if (block)
-     flag=0;
-   int retval;
-   retval=ioctlsocket(fd,FIONBIO,&flag);
-   if (retval==SOCKET_ERROR)
-     return(UNKNOWN);
-   else
-     return(OK);
+	unsigned long flag=1;
+	if (block)
+	flag=0;
+	int retval;
+	retval=ioctlsocket(fd,FIONBIO,&flag);
+	if (retval==SOCKET_ERROR)
+	return(UNKNOWN);
+	else
+	return(OK);
   #else  // UNIX
-   int flags = fcntl(fd, F_GETFL, 0);
-   if (block==FALSE)          // set nonblocking
-     flags |= O_NONBLOCK;
-   else                       // set blocking
-     flags &= ~(O_NONBLOCK);
+	int flags = fcntl(fd, F_GETFL, 0);
+	if (block==FALSE)          // set nonblocking
+	flags |= O_NONBLOCK;
+	else                       // set blocking
+	flags &= ~(O_NONBLOCK);
 
-   if (fcntl(fd, F_SETFL, flags) < 0)
-   {
-     return(UNKNOWN);
-   }
-   return(OK);
+	if (fcntl(fd, F_SETFL, flags) < 0)
+	{
+		return(UNKNOWN);
+	}
+	return(OK);
   #endif
 }
 
 
 Int UDP::Write(const unsigned char *msg,UnsignedInt len,UnsignedInt IP,UnsignedShort port)
 {
-  Int retval;
-  struct sockaddr_in to;
+	Int retval;
+	struct sockaddr_in to;
 
-  // This happens frequently
-  if ((IP==0)||(port==0)) return(ADDRNOTAVAIL);
+	// This happens frequently
+	if ((IP==0)||(port==0)) return(ADDRNOTAVAIL);
 
 #ifdef _UNIX
-  errno=0;
+	errno=0;
 #endif
-  to.sin_port=htons(port);
-  to.sin_addr.s_addr=htonl(IP);
-  to.sin_family=AF_INET;
+	to.sin_port=htons(port);
+	to.sin_addr.s_addr=htonl(IP);
+	to.sin_family=AF_INET;
 
-  ClearStatus();
-  retval=sendto(fd,(const char *)msg,len,0,(struct sockaddr *)&to,sizeof(to));
+	ClearStatus();
+	retval=sendto(fd,(const char *)msg,len,0,(struct sockaddr *)&to,sizeof(to));
   #ifdef _WIN32
-  if (retval==SOCKET_ERROR)
+	if (retval==SOCKET_ERROR)
 	{
-    retval=-1;
+		retval=-1;
 		m_lastError = WSAGetLastError();
 #ifdef DEBUG_LOGGING
 		static Int errCount = 0;
@@ -256,19 +256,19 @@ Int UDP::Write(const unsigned char *msg,UnsignedInt len,UnsignedInt IP,UnsignedS
 	}
   #endif
 
-  return(retval);
+	return(retval);
 }
 
 Int UDP::Read(unsigned char *msg,UnsignedInt len,sockaddr_in *from)
 {
-  Int retval;
-  int    alen=sizeof(sockaddr_in);
+	Int retval;
+	int    alen=sizeof(sockaddr_in);
 
-  if (from!=nullptr)
-  {
-    retval=recvfrom(fd,(char *)msg,len,0,(struct sockaddr *)from,&alen);
+	if (from!=nullptr)
+	{
+		retval=recvfrom(fd,(char *)msg,len,0,(struct sockaddr *)from,&alen);
     #ifdef _WIN32
-    if (retval == SOCKET_ERROR)
+		if (retval == SOCKET_ERROR)
 		{
 			if (WSAGetLastError() != WSAEWOULDBLOCK)
 			{
@@ -284,12 +284,12 @@ Int UDP::Read(unsigned char *msg,UnsignedInt len,sockaddr_in *from)
 			}
 		}
     #endif
-  }
-  else
-  {
-    retval=recvfrom(fd,(char *)msg,len,0,nullptr,nullptr);
+	}
+	else
+	{
+		retval=recvfrom(fd,(char *)msg,len,0,nullptr,nullptr);
     #ifdef _WIN32
-    if (retval==SOCKET_ERROR)
+		if (retval==SOCKET_ERROR)
 		{
 			if (WSAGetLastError() != WSAEWOULDBLOCK)
 			{
@@ -305,15 +305,15 @@ Int UDP::Read(unsigned char *msg,UnsignedInt len,sockaddr_in *from)
 			}
 		}
     #endif
-  }
-  return(retval);
+	}
+	return(retval);
 }
 
 
 void UDP::ClearStatus()
 {
   #ifndef _WIN32
-  errno=0;
+	errno=0;
   #endif
 
 	m_lastError = 0;
@@ -323,63 +323,63 @@ UDP::sockStat UDP::GetStatus()
 {
 	Int status = m_lastError;
  #ifdef _WIN32
-  //int status=WSAGetLastError();
-  switch (status) {
-    case NO_ERROR:
-      return OK;
-    case WSAEINTR:
-      return INTR;
-    case WSAEINPROGRESS:
-      return INPROGRESS;
-    case WSAECONNREFUSED:
-      return CONNREFUSED;
-    case WSAEINVAL:
-      return INVAL;
-    case WSAEISCONN:
-      return ISCONN;
-    case WSAENOTSOCK:
-      return NOTSOCK;
-    case WSAETIMEDOUT:
-      return TIMEDOUT;
-    case WSAEALREADY:
-      return ALREADY;
-    case WSAEWOULDBLOCK:
-      return WOULDBLOCK;
-    case WSAEBADF:
-      return BADF;
-    default:
-      return (UDP::sockStat)status;
-  }
+	//int status=WSAGetLastError();
+	switch (status) {
+		case NO_ERROR:
+			return OK;
+		case WSAEINTR:
+			return INTR;
+		case WSAEINPROGRESS:
+			return INPROGRESS;
+		case WSAECONNREFUSED:
+			return CONNREFUSED;
+		case WSAEINVAL:
+			return INVAL;
+		case WSAEISCONN:
+			return ISCONN;
+		case WSAENOTSOCK:
+			return NOTSOCK;
+		case WSAETIMEDOUT:
+			return TIMEDOUT;
+		case WSAEALREADY:
+			return ALREADY;
+		case WSAEWOULDBLOCK:
+			return WOULDBLOCK;
+		case WSAEBADF:
+			return BADF;
+		default:
+			return (UDP::sockStat)status;
+	}
  #else
-  //int status=errno;
-  switch (status) {
-    case 0:
-      return OK;
-    case EINTR:
-      return INTR;
-    case EINPROGRESS:
-      return INPROGRESS;
-    case ECONNREFUSED:
-      return CONNREFUSED;
-    case EINVAL:
-      return INVAL;
-    case EISCONN:
-      return ISCONN;
-    case ENOTSOCK:
-      return NOTSOCK;
-    case ETIMEDOUT:
-      return TIMEDOUT;
-    case EALREADY:
-      return ALREADY;
-    case EAGAIN:
-      return AGAIN;
-    case EWOULDBLOCK:
-      return WOULDBLOCK;
-    case EBADF:
-      return BADF;
-    default:
-      return UNKNOWN;
-  }
+	//int status=errno;
+	switch (status) {
+		case 0:
+			return OK;
+		case EINTR:
+			return INTR;
+		case EINPROGRESS:
+			return INPROGRESS;
+		case ECONNREFUSED:
+			return CONNREFUSED;
+		case EINVAL:
+			return INVAL;
+		case EISCONN:
+			return ISCONN;
+		case ENOTSOCK:
+			return NOTSOCK;
+		case ETIMEDOUT:
+			return TIMEDOUT;
+		case EALREADY:
+			return ALREADY;
+		case EAGAIN:
+			return AGAIN;
+		case EWOULDBLOCK:
+			return WOULDBLOCK;
+		case EBADF:
+			return BADF;
+		default:
+			return UNKNOWN;
+	}
  #endif
 }
 
@@ -477,49 +477,49 @@ int UDP::Wait(Int sec,Int usec,fd_set &givenSet,fd_set &returnSet)
 
 Int UDP::SetInputBuffer(UnsignedInt bytes)
 {
-   int retval,arg=bytes;
+	int retval,arg=bytes;
 
-   retval=setsockopt(fd,SOL_SOCKET,SO_RCVBUF,
-     (char *)&arg,sizeof(int));
-   if (retval==0)
-     return(TRUE);
-   else
-     return(FALSE);
+	retval=setsockopt(fd,SOL_SOCKET,SO_RCVBUF,
+		(char *)&arg,sizeof(int));
+	if (retval==0)
+	return(TRUE);
+	else
+	return(FALSE);
 }
 
 // Same note goes for the output buffer
 
 Int UDP::SetOutputBuffer(UnsignedInt bytes)
 {
-   int retval,arg=bytes;
+	int retval,arg=bytes;
 
-   retval=setsockopt(fd,SOL_SOCKET,SO_SNDBUF,
-     (char *)&arg,sizeof(int));
-   if (retval==0)
-     return(TRUE);
-   else
-     return(FALSE);
+	retval=setsockopt(fd,SOL_SOCKET,SO_SNDBUF,
+		(char *)&arg,sizeof(int));
+	if (retval==0)
+	return(TRUE);
+	else
+	return(FALSE);
 }
 
 // Get the system buffer sizes
 
 int UDP::GetInputBuffer()
 {
-   int retval,arg=0,len=sizeof(int);
+	int retval,arg=0,len=sizeof(int);
 
-   retval=getsockopt(fd,SOL_SOCKET,SO_RCVBUF,
-     (char *)&arg,&len);
-   return(arg);
+	retval=getsockopt(fd,SOL_SOCKET,SO_RCVBUF,
+		(char *)&arg,&len);
+	return(arg);
 }
 
 
 int UDP::GetOutputBuffer()
 {
-   int retval,arg=0,len=sizeof(int);
+	int retval,arg=0,len=sizeof(int);
 
-   retval=getsockopt(fd,SOL_SOCKET,SO_SNDBUF,
-     (char *)&arg,&len);
-   return(arg);
+	retval=getsockopt(fd,SOL_SOCKET,SO_SNDBUF,
+		(char *)&arg,&len);
+	return(arg);
 }
 
 Int UDP::AllowBroadcasts(Bool status)

--- a/Core/GameEngineDevice/Include/MilesAudioDevice/MilesAudioManager.h
+++ b/Core/GameEngineDevice/Include/MilesAudioDevice/MilesAudioManager.h
@@ -80,8 +80,8 @@ struct PlayingAudio
 
 struct ProviderInfo
 {
-  AsciiString name;
-  HPROVIDER id;
+	AsciiString name;
+	HPROVIDER id;
 	Bool m_isValid;
 };
 
@@ -184,8 +184,8 @@ class MilesAudioManager : public AudioManager
 		virtual void setSpeakerType( UnsignedInt speakerType ) override;
 		virtual UnsignedInt getSpeakerType() override;
 
- 		virtual void *getHandleForBink() override;
- 		virtual void releaseHandleForBink() override;
+	virtual void *getHandleForBink() override;
+	virtual void releaseHandleForBink() override;
 
 		virtual void friend_forcePlayAudioEventRTS(const AudioEventRTS* eventToPlay) override;
 
@@ -225,7 +225,7 @@ class MilesAudioManager : public AudioManager
 		virtual void closeAnySamplesUsingFile( const void *fileToClose ) override;
 
 
-    virtual Bool has3DSensitiveStreamsPlaying() const override;
+	virtual Bool has3DSensitiveStreamsPlaying() const override;
 
 
 	protected:

--- a/Core/GameEngineDevice/Include/W3DDevice/Common/W3DRadar.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/Common/W3DRadar.h
@@ -95,8 +95,8 @@ protected:
 																	Real loZ );		///< "shade" color according to height value
 	void reconstructViewBox();							///< remake the view box
 	void radarToPixel( const ICoord2D *radar, ICoord2D *pixel,
-										 Int radarUpperLeftX, Int radarUpperLeftY,
-										 Int radarWidth, Int radarHeight );  ///< convert radar coord to pixel location
+		Int radarUpperLeftX, Int radarUpperLeftY,
+		Int radarWidth, Int radarHeight );  ///< convert radar coord to pixel location
 
 	WW3DFormat m_terrainTextureFormat;						///< format to use for terrain texture
 	Image *m_terrainImage;												///< terrain image abstraction for drawing

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/BaseHeightMap.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/BaseHeightMap.h
@@ -114,23 +114,23 @@ public:
 	virtual void					On_Frame_Update() override;
 	virtual void					Notify_Added(SceneClass * scene) override;
 
-  // Other VIRTUAL methods. [3/20/2003]
+	// Other VIRTUAL methods. [3/20/2003]
 
 	///allocate resources needed to render heightmap
 	virtual int initHeightData(Int width, Int height, WorldHeightMap *pMap, RefRenderObjListIterator *pLightsIterator, Bool updateExtraPassTiles=TRUE);
 	virtual Int freeMapResources();	///< free resources used to render heightmap
 	virtual void updateCenter(CameraClass *camera, RefRenderObjListIterator *pLightsIterator);
- 	virtual void adjustTerrainLOD(Int adj);
+	virtual void adjustTerrainLOD(Int adj);
 	virtual void doPartialUpdate(const IRegion2D &partialRange, WorldHeightMap *htMap, RefRenderObjListIterator *pLightsIterator) = 0;
 	virtual void staticLightingChanged();
 	virtual void oversizeTerrain(Int tilesToOversize);
 	virtual void reset();
 
-  void redirectToHeightmap( WorldHeightMap *pMap )
-  {
-    REF_PTR_RELEASE( m_map );
-	  REF_PTR_SET(m_map, pMap);	//update our heightmap pointer in case it changed since last call.
-  }
+	void redirectToHeightmap( WorldHeightMap *pMap )
+	{
+		REF_PTR_RELEASE( m_map );
+		REF_PTR_SET(m_map, pMap);	//update our heightmap pointer in case it changed since last call.
+	}
 
 
 	UnsignedByte getClipHeight(Int x, Int y) const

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/FlatHeightMap.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/FlatHeightMap.h
@@ -67,12 +67,12 @@ public:
 	virtual int initHeightData(Int width, Int height, WorldHeightMap *pMap, RefRenderObjListIterator *pLightsIterator,Bool updateExtraPassTiles=TRUE) override;
 	virtual Int freeMapResources() override;	///< free resources used to render heightmap
 	virtual void updateCenter(CameraClass *camera, RefRenderObjListIterator *pLightsIterator) override;
- 	virtual void adjustTerrainLOD(Int adj) override;
+	virtual void adjustTerrainLOD(Int adj) override;
 	virtual void reset() override;
 	virtual void oversizeTerrain(Int tilesToOversize) override;
 	virtual void staticLightingChanged() override;
 	virtual void doPartialUpdate(const IRegion2D &partialRange, WorldHeightMap *htMap, RefRenderObjListIterator *pLightsIterator) override;
-  virtual int updateBlock(Int x0, Int y0, Int x1, Int y1, WorldHeightMap *pMap, RefRenderObjListIterator *pLightsIterator) override {return 0;};
+	virtual int updateBlock(Int x0, Int y0, Int x1, Int y1, WorldHeightMap *pMap, RefRenderObjListIterator *pLightsIterator) override {return 0;};
 
 protected:
 	W3DTerrainBackground	*m_tiles;

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DDependencyModelDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DDependencyModelDraw.h
@@ -52,7 +52,7 @@ public:
 class W3DDependencyModelDraw : public W3DModelDraw
 {
 
- 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( W3DDependencyModelDraw, "W3DDependencyModelDraw" )
+	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( W3DDependencyModelDraw, "W3DDependencyModelDraw" )
 	MAKE_STANDARD_MODULE_MACRO_WITH_MODULE_DATA( W3DDependencyModelDraw, W3DDependencyModelDrawModuleData )
 
 public:

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DLaserDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DLaserDraw.h
@@ -41,15 +41,15 @@ class W3DLaserDrawModuleData : public ModuleData
 {
 public:
 
-  Color m_innerColor;
-  Color m_outerColor;
+	Color m_innerColor;
+	Color m_outerColor;
 	Real m_innerBeamWidth;
 	Real m_outerBeamWidth;
 	Real m_scrollRate;
 	Bool m_tile;
-  UnsignedInt m_numBeams;
-  UnsignedInt m_maxIntensityFrames;
-  UnsignedInt m_fadeFrames;
+	UnsignedInt m_numBeams;
+	UnsignedInt m_maxIntensityFrames;
+	UnsignedInt m_fadeFrames;
 	AsciiString m_textureName;
 	UnsignedInt m_segments;
 	Real m_arcHeight;

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DModelDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DModelDraw.h
@@ -306,16 +306,16 @@ public:
 #endif
 	mutable Byte											m_validated;
 
-  Bool                              m_particlesAttachedToAnimatedBones;
+	Bool                              m_particlesAttachedToAnimatedBones;
 
-  Bool                              m_receivesDynamicLights; ///< just like it sounds... it sets a property of Drawable, actually
+	Bool                              m_receivesDynamicLights; ///< just like it sounds... it sets a property of Drawable, actually
 
 
 	W3DModelDrawModuleData();
 	virtual ~W3DModelDrawModuleData() override;
 	void validateStuffForTimeAndWeather(const Drawable* draw, Bool night, Bool snowy) const;
 	static void buildFieldParse(MultiIniFieldParse& p);
- 	AsciiString getBestModelNameForWB(const ModelConditionFlags& c) const;
+	AsciiString getBestModelNameForWB(const ModelConditionFlags& c) const;
 	const ModelConditionInfo* findBestInfo(const ModelConditionFlags& c) const;
 	void preloadAssets( TimeOfDay timeOfDay, Real scale ) const;
 #ifdef CACHE_ATTACH_BONE
@@ -330,9 +330,9 @@ private:
 	static void parseConditionState( INI* ini, void *instance, void * /*store*/, const void* /*userData*/ );
 
 public:
- 	virtual void crc( Xfer *xfer ) override;
- 	virtual void xfer( Xfer *xfer ) override;
- 	virtual void loadPostProcess() override;
+	virtual void crc( Xfer *xfer ) override;
+	virtual void xfer( Xfer *xfer ) override;
+	virtual void loadPostProcess() override;
 };
 
 //-------------------------------------------------------------------------------------------------
@@ -347,7 +347,7 @@ public:
 	W3DModelDraw( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
-  /// preloading assets
+	/// preloading assets
 	virtual void preloadAssets( TimeOfDay timeOfDay ) override;
 
 	/// the draw method

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DOverlordAircraftDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DOverlordAircraftDraw.h
@@ -61,7 +61,7 @@ public:
 	W3DOverlordAircraftDraw( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
- 	virtual void setHidden(Bool h) override;
+	virtual void setHidden(Bool h) override;
 	virtual void doDrawModule(const Matrix3D* transformMtx) override;
 
 protected:

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DOverlordTankDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DOverlordTankDraw.h
@@ -61,7 +61,7 @@ public:
 	W3DOverlordTankDraw( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
- 	virtual void setHidden(Bool h) override;
+	virtual void setHidden(Bool h) override;
 	virtual void doDrawModule(const Matrix3D* transformMtx) override;
 
 protected:

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DOverlordTruckDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DOverlordTruckDraw.h
@@ -61,7 +61,7 @@ public:
 	W3DOverlordTruckDraw( Thing *thing, const ModuleData* moduleData );
 	// virtual destructor prototype provided by memory pool declaration
 
- 	virtual void setHidden(Bool h) override;
+	virtual void setHidden(Bool h) override;
 	virtual void doDrawModule(const Matrix3D* transformMtx) override;
 
 protected:

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DScienceModelDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DScienceModelDraw.h
@@ -49,7 +49,7 @@ public:
 class W3DScienceModelDraw : public W3DModelDraw
 {
 
- 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( W3DScienceModelDraw, "W3DScienceModelDraw" )
+	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( W3DScienceModelDraw, "W3DScienceModelDraw" )
 	MAKE_STANDARD_MODULE_MACRO_WITH_MODULE_DATA( W3DScienceModelDraw, W3DScienceModelDrawModuleData )
 
 public:

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DSupplyDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DSupplyDraw.h
@@ -47,7 +47,7 @@ public:
 class W3DSupplyDraw : public W3DModelDraw
 {
 
- 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( W3DSupplyDraw, "W3DSupplyDraw" )
+	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( W3DSupplyDraw, "W3DSupplyDraw" )
 	MAKE_STANDARD_MODULE_MACRO_WITH_MODULE_DATA( W3DSupplyDraw, W3DSupplyDrawModuleData )
 
 public:

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DTankTruckDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DTankTruckDraw.h
@@ -78,7 +78,7 @@ public:
 class W3DTankTruckDraw : public W3DModelDraw
 {
 
- 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( W3DTankTruckDraw, "W3DTankTruckDraw" )
+	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( W3DTankTruckDraw, "W3DTankTruckDraw" )
 	MAKE_STANDARD_MODULE_MACRO_WITH_MODULE_DATA( W3DTankTruckDraw, W3DTankTruckDrawModuleData )
 
 public:

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DTreeDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DTreeDraw.h
@@ -52,7 +52,7 @@ public:
 	Real m_initialVelocityPercent;
 	Real m_initialAccelPercent;
 	Real m_bounceVelocityPercent;
-  Real m_minimumToppleSpeed;
+	Real m_minimumToppleSpeed;
 	Bool m_killWhenToppled;
 	Bool m_doTopple;
 	UnsignedInt m_sinkFrames; // How long it takes to sink after toppling. [7/11/2003]

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DTruckDraw.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/Module/W3DTruckDraw.h
@@ -79,7 +79,7 @@ public:
 class W3DTruckDraw : public W3DModelDraw
 {
 
- 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( W3DTruckDraw, "W3DTruckDraw" )
+	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( W3DTruckDraw, "W3DTruckDraw" )
 	MAKE_STANDARD_MODULE_MACRO_WITH_MODULE_DATA( W3DTruckDraw, W3DTruckDrawModuleData )
 
 public:

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DShaderManager.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DShaderManager.h
@@ -143,7 +143,7 @@ public:
 	virtual Bool setup(FilterModes mode){return false;} ///< Called when the filter is started, one time before the first prerender.
 protected:
 	virtual Int set(FilterModes mode) = 0;		///<setup shader for the specified rendering pass.
-	 ///do any custom resetting necessary to bring W3D in sync.
+	///do any custom resetting necessary to bring W3D in sync.
 	virtual void reset() = 0;
 };
 

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DSnow.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DSnow.h
@@ -29,7 +29,7 @@ struct IDirect3DVertexBuffer8;
 
 class W3DSnowManager : public SnowManager
 {
-  public :
+public :
 
 	W3DSnowManager();
 	virtual ~W3DSnowManager() override;
@@ -45,12 +45,12 @@ class W3DSnowManager : public SnowManager
 	void	ReleaseResources();
 	Bool	ReAcquireResources();
 
- private:
+private:
 	DX8IndexBufferClass	*m_indexBuffer;
 	TextureClass *m_snowTexture;
 	IDirect3DVertexBuffer8*  m_VertexBufferD3D;
 	Int m_dwBase;	///<index to beginning of unused vertex buffer space.
-    Int m_dwFlush;	///<maximum amount of vertices to sumbit before rendering.
+	Int m_dwFlush;	///<maximum amount of vertices to sumbit before rendering.
 	Int m_dwDiscard;	///<maximum index allowed before needing to discard the buffer.
 	Int m_leafDim;		///<horizontal dimensions of leaf nodes that are always rendered without visibility checks.
 	Real m_snowCeiling;	///<height at the top of the cube with camera at center.

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DTerrainTracks.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DTerrainTracks.h
@@ -62,7 +62,7 @@ public:
 	virtual int						Class_ID() const override;
 	virtual void					Render(RenderInfoClass & rinfo) override;
 	virtual void					Get_Obj_Space_Bounding_Sphere(SphereClass & sphere) const override;
-    virtual void					Get_Obj_Space_Bounding_Box(AABoxClass & aabox) const override;
+	virtual void					Get_Obj_Space_Bounding_Box(AABoxClass & aabox) const override;
 
 	Int freeTerrainTracksResources();	///<free W3D assets used for this track
 	void init( Real width, Real length, const Char *texturename);	///<allocate W3D resources and set size

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DTerrainVisual.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DTerrainVisual.h
@@ -73,7 +73,7 @@ public:
 	virtual void setWaterGridHeightClamps( const WaterHandle *waterTable, Real minZ, Real maxZ ) override;
 	/// adjust fallof parameters for grid change method
 	virtual void setWaterAttenuationFactors( const WaterHandle *waterTable,
-																					 Real a, Real b, Real c, Real range ) override;
+		Real a, Real b, Real c, Real range ) override;
 	/// set the water table position and orientation in world space
 	virtual void setWaterTransform( const WaterHandle *waterTable,
 																	Real angle, Real x, Real y, Real z ) override;
@@ -81,14 +81,14 @@ public:
 	virtual void getWaterTransform( const WaterHandle *waterTable, Matrix3D *transform ) override;
 	/// water grid resolution spacing
 	virtual void setWaterGridResolution( const WaterHandle *waterTable,
-																			 Real gridCellsX, Real gridCellsY, Real cellSize ) override;
+		Real gridCellsX, Real gridCellsY, Real cellSize ) override;
 	virtual void getWaterGridResolution( const WaterHandle *waterTable,
-																			 Real *gridCellsX, Real *gridCellsY, Real *cellSize ) override;
+		Real *gridCellsX, Real *gridCellsY, Real *cellSize ) override;
 	/// adjust the water grid in world coords by the delta
 	virtual void changeWaterHeight( Real x, Real y, Real delta ) override;
 	/// adjust the velocity at a water grid point corresponding to the world x,y
 	virtual void addWaterVelocity( Real worldX, Real worldY,
-																 Real velocity, Real preferredHeight ) override;
+		Real velocity, Real preferredHeight ) override;
 	virtual Bool getWaterGridHeight( Real worldX, Real worldY, Real *height) override;
 
 	virtual void setTerrainTracksDetail() override;
@@ -125,24 +125,24 @@ public:
 	/// Replace the skybox texture
 	virtual void replaceSkyboxTextures(const AsciiString *oldTexName[NumSkyboxTextures], const AsciiString *newTexName[NumSkyboxTextures]) override;
 
-  ////////////////////////////////////////////////////
-  ////////////////////////////////////////////////////
-  ////////////////////////////////////////////////////
+	////////////////////////////////////////////////////
+	////////////////////////////////////////////////////
+	////////////////////////////////////////////////////
 #ifdef DO_SEISMIC_SIMULATIONS
-  virtual void addSeismicSimulation( const SeismicSimulationNode& sim );
+	virtual void addSeismicSimulation( const SeismicSimulationNode& sim );
 #endif
-  virtual WorldHeightMap* getLogicHeightMap() override {return m_logicHeightMap;};
-  virtual WorldHeightMap* getClientHeightMap() override
-  {
+	virtual WorldHeightMap* getLogicHeightMap() override {return m_logicHeightMap;};
+	virtual WorldHeightMap* getClientHeightMap() override
+	{
 #ifdef DO_SEISMIC_SIMULATIONS
-    return m_clientHeightMap;
+		return m_clientHeightMap;
 #else
-    return m_logicHeightMap;
+		return m_logicHeightMap;
 #endif
-  }
-  ////////////////////////////////////////////////////
-  ////////////////////////////////////////////////////
-  ////////////////////////////////////////////////////
+	}
+	////////////////////////////////////////////////////
+	////////////////////////////////////////////////////
+	////////////////////////////////////////////////////
 
 protected:
 
@@ -152,30 +152,30 @@ protected:
 	virtual void loadPostProcess() override;
 
 #ifdef DO_SEISMIC_SIMULATIONS
-  ////////////////////////////////////////////////////
-  ////////////////////////////////////////////////////
-  ////////////////////////////////////////////////////
-  virtual void handleSeismicSimulations();
-  SeismicSimulationList m_seismicSimulationList;
-  virtual void updateSeismicSimulations(); /// walk the SeismicSimulationList and, well, do it.
+	////////////////////////////////////////////////////
+	////////////////////////////////////////////////////
+	////////////////////////////////////////////////////
+	virtual void handleSeismicSimulations();
+	SeismicSimulationList m_seismicSimulationList;
+	virtual void updateSeismicSimulations(); /// walk the SeismicSimulationList and, well, do it.
 
-  ////////////////////////////////////////////////////
-  ////////////////////////////////////////////////////
-  ////////////////////////////////////////////////////
+	////////////////////////////////////////////////////
+	////////////////////////////////////////////////////
+	////////////////////////////////////////////////////
 #endif
 
 	BaseHeightMapRenderObjClass *m_terrainRenderObject;  ///< W3D render object for terrain
 	WaterRenderObjClass	*m_waterRenderObject;	///< W3D render object for water plane
 
-  WorldHeightMap *m_logicHeightMap;  ///< height map used for render obj building
+	WorldHeightMap *m_logicHeightMap;  ///< height map used for render obj building
 
 #ifdef DO_SEISMIC_SIMULATIONS
-  WorldHeightMap *m_clientHeightMap; ///< this is a workspace for animating the terrain elevations
+	WorldHeightMap *m_clientHeightMap; ///< this is a workspace for animating the terrain elevations
 #endif
 
 	Bool m_isWaterGridRenderingEnabled;
 
-  AsciiString	m_currentSkyboxTexNames[NumSkyboxTextures];	///<store current texture names applied to skybox.
+	AsciiString	m_currentSkyboxTexNames[NumSkyboxTextures];	///<store current texture names applied to skybox.
 	AsciiString m_initialSkyboxTexNames[NumSkyboxTextures];	///<store starting texture/default skybox textures.
 
 };

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DTreeBuffer.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DTreeBuffer.h
@@ -280,6 +280,6 @@ protected:
 
 	void updateTopplingTree(TTree *tree, Real timeScale);
 	void applyTopplingForce( TTree *tree, const Coord3D* toppleDirection, Real toppleSpeed,
-																			 UnsignedInt options );
+		UnsignedInt options );
 
 };

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DView.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DView.h
@@ -181,8 +181,8 @@ public:
 	virtual void moveCameraAlongWaypointPath(Waypoint *pWay, Int frames, Int shutter, Bool orient, Real easeIn, Real easeOut) override;
 	virtual Bool isCameraMovementFinished() override;
 	virtual Bool isCameraMovementAtWaypointAlongPath();
- 	virtual void resetCamera(const Coord3D *location, Int frames, Real easeIn, Real easeOut) override;	///< Move camera to location, and reset to default angle & zoom.
- 	virtual void rotateCamera(Real rotations, Int frames, Real easeIn, Real easeOut) override;					///< Rotate camera about current viewpoint.
+	virtual void resetCamera(const Coord3D *location, Int frames, Real easeIn, Real easeOut) override;	///< Move camera to location, and reset to default angle & zoom.
+	virtual void rotateCamera(Real rotations, Int frames, Real easeIn, Real easeOut) override;					///< Rotate camera about current viewpoint.
 	virtual void rotateCameraTowardObject(ObjectID id, Int milliseconds, Int holdMilliseconds, Real easeIn, Real easeOut) override;	///< Rotate camera to face an object, and hold on it
 	virtual void rotateCameraTowardPosition(const Coord3D *pLoc, Int milliseconds, Real easeIn, Real easeOut, Bool reverseRotation) override;	///< Rotate camera to face a location.
 	virtual void cameraModFreezeTime(){ m_freezeTimeForCameraMovement = true;}					///< Freezes time during the next camera movement.
@@ -214,7 +214,7 @@ public:
 
 	virtual void setFieldOfView( Real angle ) override;							///< Set the horizontal field of view angle
 
-  virtual WorldToScreenReturn worldToScreenTriReturn( const Coord3D *w, ICoord2D *s ) override;	///< Transform world coordinate "w" into screen coordinate "s"
+	virtual WorldToScreenReturn worldToScreenTriReturn( const Coord3D *w, ICoord2D *s ) override;	///< Transform world coordinate "w" into screen coordinate "s"
 	virtual void screenToTerrain( const ICoord2D *screen, Coord3D *world ) override;  ///< transform screen coord to a point on the 3D terrain
 	virtual void screenToWorldAtZ( const ICoord2D *s, Coord3D *w, Real z ) override;  ///< transform screen point to world point at the specified world Z value
 

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DWater.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DWater.h
@@ -89,10 +89,10 @@ public:
 //	virtual Bool					Intersect_OBBox(OBBoxIntersectionTestClass & boxtest);
 
 	virtual void					Get_Obj_Space_Bounding_Sphere(SphereClass & sphere) const override;
-    virtual void					Get_Obj_Space_Bounding_Box(AABoxClass & aabox) const override;
+	virtual void					Get_Obj_Space_Bounding_Box(AABoxClass & aabox) const override;
 	// Get and set static sort level
 	virtual int		Get_Sort_Level() const override { return m_sortLevel; }
-  	virtual void	Set_Sort_Level(int level) override { m_sortLevel = level;}
+	virtual void	Set_Sort_Level(int level) override { m_sortLevel = level;}
 
 	///allocate W3D resources needed to render water
 	void renderWater();				///<draw the water surface (flat)

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DWaterTracks.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DWaterTracks.h
@@ -42,7 +42,7 @@ public:
 
 	virtual void					Render() {};	///<draw this object
 	virtual void					Get_Obj_Space_Bounding_Sphere(SphereClass & sphere) const;	///<bounding sphere of this object
-    virtual void					Get_Obj_Space_Bounding_Box(AABoxClass & aabox) const;		///<bounding box of this object
+	virtual void					Get_Obj_Space_Bounding_Box(AABoxClass & aabox) const;		///<bounding box of this object
 
 	Int freeWaterTracksResources();	///<free W3D assets used for this track
 	void init( Real width, Real length, const Vector2 &start, const Vector2 &end, const Char *texturename, Int waveTimeOffset);	///<allocate W3D resources and set size

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/WorldHeightMap.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/WorldHeightMap.h
@@ -126,11 +126,11 @@ protected:
 	Int m_dataSize;			///< size of m_data.
 	UnsignedByte *m_data;	///< array of z(height) values in the height map.
 
-  UnsignedByte *m_seismicUpdateFlag;  ///< array of bits to prevent ovelapping physics-update regions from doubling effects on shared cells
-  UnsignedInt   m_seismicUpdateWidth; ///< width of the array holding SeismicUpdateFlags
-  Real         *m_seismicZVelocities; ///< how fast is the dirt rising/falling at this location
+	UnsignedByte *m_seismicUpdateFlag;  ///< array of bits to prevent ovelapping physics-update regions from doubling effects on shared cells
+	UnsignedInt   m_seismicUpdateWidth; ///< width of the array holding SeismicUpdateFlags
+	Real         *m_seismicZVelocities; ///< how fast is the dirt rising/falling at this location
 
-  UnsignedByte *m_cellFlipState;	///< array of bits to indicate the flip state of each cell.
+	UnsignedByte *m_cellFlipState;	///< array of bits to indicate the flip state of each cell.
 	Int m_flipStateWidth;			///< with of the array holding cellFlipState
 	UnsignedByte *m_cellCliffState;	///< array of bits to indicate the cliff state of each cell.
 
@@ -244,7 +244,7 @@ public:  // height map info.
 	void setDrawWidth(Int width) {m_drawWidthX = width; if (m_drawWidthX>m_width) m_drawWidthX = m_width;}
 	void setDrawHeight(Int height) {m_drawHeightY = height; if (m_drawHeightY>m_height) m_drawHeightY = m_height;}
 	virtual Int getBorderSize() override {return m_borderSize;}
-  Int getBorderSizeInline() const { return m_borderSize; }
+	Int getBorderSizeInline() const { return m_borderSize; }
 	/// Get height with the offset that HeightMapRenderObjClass uses built in.
 	UnsignedByte getDisplayHeight(Int x, Int y) { return m_data[x+m_drawOriginX+m_width*(y+m_drawOriginY)];}
 
@@ -293,13 +293,13 @@ public:  // tile and texture info.
 	Bool isCliffMappedTexture(Int xIndex, Int yIndex);
 
 
-  Bool getSeismicUpdateFlag(Int xIndex, Int yIndex) const;
-  void setSeismicUpdateFlag(Int xIndex, Int yIndex, Bool value);
-  void clearSeismicUpdateFlags() ;
-  virtual Real getSeismicZVelocity(Int xIndex, Int yIndex) const override;
-  virtual void setSeismicZVelocity(Int xIndex, Int yIndex, Real value) override;
-  void fillSeismicZVelocities( Real value );
-  virtual Real getBilinearSampleSeismicZVelocity( Int x, Int y) override;
+	Bool getSeismicUpdateFlag(Int xIndex, Int yIndex) const;
+	void setSeismicUpdateFlag(Int xIndex, Int yIndex, Bool value);
+	void clearSeismicUpdateFlags() ;
+	virtual Real getSeismicZVelocity(Int xIndex, Int yIndex) const override;
+	virtual void setSeismicZVelocity(Int xIndex, Int yIndex, Real value) override;
+	void fillSeismicZVelocities( Real value );
+	virtual Real getBilinearSampleSeismicZVelocity( Int x, Int y) override;
 
 
 

--- a/Core/GameEngineDevice/Include/Win32Device/GameClient/Win32Mouse.h
+++ b/Core/GameEngineDevice/Include/Win32Device/GameClient/Win32Mouse.h
@@ -102,8 +102,8 @@ protected:
 	Win32MouseEvent m_eventBuffer[ Mouse::NUM_MOUSE_EVENTS ];
 	UnsignedInt m_nextFreeIndex;  ///< insert new events at this index
 	UnsignedInt m_nextGetIndex;  /** events retrieved through getMouseEvent
-															 will come from this index, then it will be
-															 incremented to the next index */
+	will come from this index, then it will be
+	incremented to the next index */
 	MouseCursor m_currentWin32Cursor;	///< keep track of last cursor image sent to D3D.
 	Int m_directionFrame;	///< current frame of directional cursor (from 0 points up).
 	Bool m_lostFocus;		///< flag if window has lost focus and mouse should stop being updated.

--- a/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
+++ b/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
@@ -470,10 +470,10 @@ void MilesAudioManager::reset()
 
 	AudioManager::reset();
 	stopAllAudioImmediately();
-  removeAllAudioRequests();
-  // This must come after stopAllAudioImmediately() and removeAllAudioRequests(), to ensure that
-  // sounds pointing to the temporary AudioEventInfo handles are deleted before their info is deleted
-  removeLevelSpecificAudioEventInfos();
+	removeAllAudioRequests();
+	// This must come after stopAllAudioImmediately() and removeAllAudioRequests(), to ensure that
+	// sounds pointing to the temporary AudioEventInfo handles are deleted before their info is deleted
+	removeLevelSpecificAudioEventInfos();
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -718,7 +718,7 @@ void MilesAudioManager::playAudioEvent( AudioEventRTS *event )
 			if (stream) {
 				if ((info->m_soundType == AT_Streaming) && event->getUninterruptible()) {
 					setDisallowSpeech(TRUE);
-	 			}
+				}
 				AIL_set_stream_volume_pan(stream, getEffectiveVolume(event), 0.5f);
 				playStream(event, stream);
 				m_playingStreams.push_back(audio);
@@ -1154,15 +1154,15 @@ void MilesAudioManager::stopAllAudioImmediately()
 		it = m_playingStreams.erase(it);
 	}
 
-  for (it = m_fadingAudio.begin(); it != m_fadingAudio.end(); ) {
-    playing = (*it);
-    if (!playing) {
-      continue;
-    }
+	for (it = m_fadingAudio.begin(); it != m_fadingAudio.end(); ) {
+		playing = (*it);
+		if (!playing) {
+			continue;
+		}
 
-    releasePlayingAudio(playing);
-    it = m_fadingAudio.erase(it);
-  }
+		releasePlayingAudio(playing);
+		it = m_fadingAudio.erase(it);
+	}
 
 	std::list<HAUDIO>::iterator hit;
 	for (hit = m_audioForcePlayed.begin(); hit != m_audioForcePlayed.end(); ++hit) {
@@ -2386,28 +2386,28 @@ void MilesAudioManager::processPlayingList()
 
 Bool MilesAudioManager::has3DSensitiveStreamsPlaying() const
 {
-  if ( m_playingStreams.empty() )
-    return FALSE;
+	if ( m_playingStreams.empty() )
+	return FALSE;
 
 	for ( std::list< PlayingAudio* >::const_iterator it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it )
-  {
+	{
 		const PlayingAudio *playing = (*it);
 
-    if ( ! playing )
-      continue;
+		if ( ! playing )
+		continue;
 
-    if ( playing->m_audioEventRTS->getAudioEventInfo()->m_soundType != AT_Music )
-    {
-      return TRUE;
-    }
+		if ( playing->m_audioEventRTS->getAudioEventInfo()->m_soundType != AT_Music )
+		{
+			return TRUE;
+		}
 
-    if ( playing->m_audioEventRTS->getEventName().startsWith("Game_") == FALSE )
-    {
-      return TRUE;
-    }
-  }
+		if ( playing->m_audioEventRTS->getEventName().startsWith("Game_") == FALSE )
+		{
+			return TRUE;
+		}
+	}
 
-  return FALSE;
+	return FALSE;
 
 }
 
@@ -2511,14 +2511,14 @@ Bool MilesAudioManager::checkForSample( AudioRequest *req )
 		return true;
 	}
 
-  if ( req->m_pendingEvent->getAudioEventInfo() == nullptr )
-  {
-    // Fill in event info
-    getInfoForAudioEvent( req->m_pendingEvent );
-  }
+	if ( req->m_pendingEvent->getAudioEventInfo() == nullptr )
+	{
+		// Fill in event info
+		getInfoForAudioEvent( req->m_pendingEvent );
+	}
 
 	if (req->m_pendingEvent->getAudioEventInfo()->m_type != AT_SoundEffect)
-  {
+	{
 		return true;
 	}
 
@@ -2844,16 +2844,16 @@ void *MilesAudioManager::playSample3D( AudioEventRTS *event, H3DSAMPLE sample3D 
 //-------------------------------------------------------------------------------------------------
 void MilesAudioManager::buildProviderList()
 {
-   HPROENUM next = HPROENUM_FIRST;
+	HPROENUM next = HPROENUM_FIRST;
 
-	 char *name;
-	 UnsignedInt index = 0;
-	 while (index < MAXPROVIDERS && AIL_enumerate_3D_providers(&next, &m_provider3D[index].id, &name)) {
-		 m_provider3D[index].name.set(name);	// set it to the AsciiString
-		 ++index;
-	 }
+	char *name;
+	UnsignedInt index = 0;
+	while (index < MAXPROVIDERS && AIL_enumerate_3D_providers(&next, &m_provider3D[index].id, &name)) {
+		m_provider3D[index].name.set(name);	// set it to the AsciiString
+		++index;
+	}
 
-	 m_providerCount = index;
+	m_providerCount = index;
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Core/GameEngineDevice/Source/StdDevice/Common/StdBIGFileSystem.cpp
+++ b/Core/GameEngineDevice/Source/StdDevice/Common/StdBIGFileSystem.cpp
@@ -59,13 +59,13 @@ void StdBIGFileSystem::init() {
 	loadBigFilesFromDirectory("", "*.big");
 
 #if RTS_ZEROHOUR
-    // load original Generals assets
-    AsciiString installPath;
-    GetStringFromGeneralsRegistry("", "InstallPath", installPath );
-    //@todo this will need to be ramped up to a crash for release
-    DEBUG_ASSERTCRASH(!installPath.isEmpty(), ("Be 1337! Go install Generals!"));
-    if (!installPath.isEmpty())
-      loadBigFilesFromDirectory(installPath, "*.big");
+	// load original Generals assets
+	AsciiString installPath;
+	GetStringFromGeneralsRegistry("", "InstallPath", installPath );
+	//@todo this will need to be ramped up to a crash for release
+	DEBUG_ASSERTCRASH(!installPath.isEmpty(), ("Be 1337! Go install Generals!"));
+	if (!installPath.isEmpty())
+	loadBigFilesFromDirectory(installPath, "*.big");
 #endif
 }
 

--- a/Core/GameEngineDevice/Source/W3DDevice/Common/System/W3DRadar.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/Common/System/W3DRadar.cpp
@@ -197,8 +197,8 @@ void W3DRadar::reconstructViewBox()
 	{
 
 		// first convert to radar cells
- 		radar[ i ].x = world[ i ].x / (m_mapExtent.width() / RADAR_CELL_WIDTH);
- 		radar[ i ].y = world[ i ].y / (m_mapExtent.height() / RADAR_CELL_HEIGHT);
+		radar[ i ].x = world[ i ].x / (m_mapExtent.width() / RADAR_CELL_WIDTH);
+		radar[ i ].y = world[ i ].y / (m_mapExtent.height() / RADAR_CELL_HEIGHT);
 
 		//
 		// store these points in the view box array which contains a first position
@@ -229,8 +229,8 @@ void W3DRadar::reconstructViewBox()
 /** Convert radar position to actual pixel coord */
 //-------------------------------------------------------------------------------------------------
 void W3DRadar::radarToPixel( const ICoord2D *radar, ICoord2D *pixel,
-														 Int radarUpperLeftX, Int radarUpperLeftY,
-														 Int radarWidth, Int radarHeight )
+	Int radarUpperLeftX, Int radarUpperLeftY,
+	Int radarWidth, Int radarHeight )
 {
 
 	// sanity
@@ -307,8 +307,8 @@ void W3DRadar::drawViewBox( Int pixelX, Int pixelY, Int width, Int height )
 	TheTacticalView->screenToWorldAtZ( &ulScreen, &ulWorld, getTerrainAverageZ() );
 
 	// convert world to radar coords
- 	ulRadar.x = ulWorld.x / (m_mapExtent.width() / RADAR_CELL_WIDTH);
- 	ulRadar.y = ulWorld.y / (m_mapExtent.height() / RADAR_CELL_HEIGHT);
+	ulRadar.x = ulWorld.x / (m_mapExtent.width() / RADAR_CELL_WIDTH);
+	ulRadar.y = ulWorld.y / (m_mapExtent.height() / RADAR_CELL_HEIGHT);
 
 	//
 	// convert radar point to actual pixel coords on the screen, shifted
@@ -335,7 +335,7 @@ void W3DRadar::drawViewBox( Int pixelX, Int pixelY, Int width, Int height )
 		TheDisplay->drawLine( clipStart.x, clipStart.y, clipEnd.x, clipEnd.y,
 													lineWidth, topColor );
 
-  // right line
+	// right line
 	start = end;
 	radar.x += m_viewBox[ 2 ].x;
 	radar.y += m_viewBox[ 2 ].y;
@@ -344,7 +344,7 @@ void W3DRadar::drawViewBox( Int pixelX, Int pixelY, Int width, Int height )
 		TheDisplay->drawLine( clipStart.x, clipStart.y, clipEnd.x, clipEnd.y,
 													lineWidth, topColor, bottomColor );
 
-  // bottom line
+	// bottom line
 	start = end;
 	radar.x += m_viewBox[ 3 ].x;
 	radar.y += m_viewBox[ 3 ].y;
@@ -353,7 +353,7 @@ void W3DRadar::drawViewBox( Int pixelX, Int pixelY, Int width, Int height )
 		TheDisplay->drawLine( clipStart.x, clipStart.y, clipEnd.x, clipEnd.y,
 													lineWidth, bottomColor );
 
-  // left line
+	// left line
 	start = end;
 	end = ulStart;
 	if( ClipLine2D( &start, &end, &clipStart, &clipEnd, &clipRegion ) )
@@ -912,12 +912,12 @@ void W3DRadar::init()
 	// allocate our terrain texture
 	// poolify
 	m_terrainTexture = MSGNEW("TextureClass") TextureClass( m_textureWidth, m_textureHeight,
-																			 m_terrainTextureFormat, MIP_LEVELS_1 );
+		m_terrainTextureFormat, MIP_LEVELS_1 );
 	DEBUG_ASSERTCRASH( m_terrainTexture, ("W3DRadar: Unable to allocate terrain texture") );
 
 	// allocate our overlay texture
 	m_overlayTexture = MSGNEW("TextureClass") TextureClass( m_textureWidth, m_textureHeight,
-																			 m_overlayTextureFormat, MIP_LEVELS_1 );
+		m_overlayTextureFormat, MIP_LEVELS_1 );
 	DEBUG_ASSERTCRASH( m_overlayTexture, ("W3DRadar: Unable to allocate overlay texture") );
 
 	// set filter type for the overlay texture, try it and see if you like it, I don't ;)
@@ -926,7 +926,7 @@ void W3DRadar::init()
 
 	// allocate our shroud texture
 	m_shroudTexture = MSGNEW("TextureClass") TextureClass( m_textureWidth, m_textureHeight,
-																			 m_shroudTextureFormat, MIP_LEVELS_1 );
+		m_shroudTextureFormat, MIP_LEVELS_1 );
 	DEBUG_ASSERTCRASH( m_shroudTexture, ("W3DRadar: Unable to allocate shroud texture") );
 	m_shroudTexture->Get_Filter().Set_Min_Filter( TextureFilterClass::FILTER_TYPE_DEFAULT );
 	m_shroudTexture->Get_Filter().Set_Mag_Filter( TextureFilterClass::FILTER_TYPE_DEFAULT );
@@ -1149,8 +1149,8 @@ void W3DRadar::buildTerrainTexture( TerrainLogic *terrain )
 
 									// interpolate the water color for height in the water table
 									interpolateColorForHeight( &color, underwaterZ, waterZ,
-																						 waterZ,
-																						 m_mapExtent.lo.z );
+										waterZ,
+										m_mapExtent.lo.z );
 
 									// add color to our samples
 									sampleColor.red += color.red;
@@ -1222,14 +1222,14 @@ void W3DRadar::buildTerrainTexture( TerrainLogic *terrain )
 									// instead use the height for the entire bridge
 									//
 									Real bridgeHeight = (bridge->peekBridgeInfo()->fromLeft.z +
-																			 bridge->peekBridgeInfo()->fromRight.z +
-																			 bridge->peekBridgeInfo()->toLeft.z +
-																			 bridge->peekBridgeInfo()->toRight.z) / 4.0f;
+										bridge->peekBridgeInfo()->fromRight.z +
+										bridge->peekBridgeInfo()->toLeft.z +
+										bridge->peekBridgeInfo()->toRight.z) / 4.0f;
 
 									// interpolate the color, but use the bridge height, not the terrain height
 									interpolateColorForHeight( &color, bridgeHeight,
-																						 getTerrainAverageZ(),
-																						 m_mapExtent.hi.z, m_mapExtent.lo.z );
+										getTerrainAverageZ(),
+										m_mapExtent.hi.z, m_mapExtent.lo.z );
 
 								}
 								else
@@ -1240,7 +1240,7 @@ void W3DRadar::buildTerrainTexture( TerrainLogic *terrain )
 
 									// interpolate the color for height
 									interpolateColorForHeight( &color, worldPoint.z, getTerrainAverageZ(),
-																						 m_mapExtent.hi.z, m_mapExtent.lo.z );
+										m_mapExtent.hi.z, m_mapExtent.lo.z );
 
 								}
 
@@ -1493,7 +1493,7 @@ void W3DRadar::draw( Int pixelX, Int pixelY, Int width, Int height )
 	}
 
 	// draw the overlay image
- 	TheDisplay->drawImage( m_overlayImage, ul.x, ul.y, lr.x, lr.y );
+	TheDisplay->drawImage( m_overlayImage, ul.x, ul.y, lr.x, lr.y );
 
 	// draw the shroud image
 #if ENABLE_CONFIGURABLE_SHROUD

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/BaseHeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/BaseHeightMap.cpp
@@ -367,9 +367,9 @@ void BaseHeightMapRenderObjClass::adjustTerrainLOD(Int adj)
 	if (newROBJ) {
 		// apply the heightmap to the terrain render object
 		newROBJ->initHeightData( m_map->getDrawWidth(),
-																					 m_map->getDrawHeight(),
-																					 m_map,
-																					 nullptr);
+			m_map->getDrawHeight(),
+			m_map,
+			nullptr);
 		TheTerrainRenderObject = newROBJ;
 		newROBJ->staticLightingChanged();
 		newROBJ->m_roadBuffer->loadRoads();
@@ -688,10 +688,10 @@ bool BaseHeightMapRenderObjClass::Cast_Ray(RayCollisionTestClass & raytest)
 	CastResultStruct	result;
 	Int StartCellX = 0;
 	Int EndCellX = 0;
- 	Int StartCellY = 0;
+	Int StartCellY = 0;
 	Int EndCellY = 0;
 	const Int overhang = 2*VERTEX_BUFFER_TILE_LENGTH + m_map->getBorderSizeInline(); // Allow picking past the edge for scrolling & objects.
- 	Vector3 minPt(MAP_XY_FACTOR*(-overhang), MAP_XY_FACTOR*(-overhang), -MAP_XY_FACTOR);
+	Vector3 minPt(MAP_XY_FACTOR*(-overhang), MAP_XY_FACTOR*(-overhang), -MAP_XY_FACTOR);
 	Vector3 maxPt(MAP_XY_FACTOR*(m_map->getXExtent()+overhang),
 		MAP_XY_FACTOR*(m_map->getYExtent()+overhang), MAP_HEIGHT_SCALE*m_map->getMaxHeightValue()+MAP_XY_FACTOR);
 	MinMaxAABoxClass mmbox(minPt, maxPt);
@@ -844,20 +844,20 @@ bool BaseHeightMapRenderObjClass::Cast_Ray(RayCollisionTestClass & raytest)
 Real BaseHeightMapRenderObjClass::getHeightMapHeight(Real x, Real y, Coord3D* normal) const
 {
 
-  // SORRY, KIDS
-  // Had to make this function logic safe, so,
-  // even though this is a renderObject, and is thus classified as client-side
-  // it is responsible for reporting height map heights (for reasons I can't say)
-  // but to do so safely, I a going to pass it the logical heighmap from the W3dTerrainVisual
-  // yes another nosequiter. Ugh!
+	// SORRY, KIDS
+	// Had to make this function logic safe, so,
+	// even though this is a renderObject, and is thus classified as client-side
+	// it is responsible for reporting height map heights (for reasons I can't say)
+	// but to do so safely, I a going to pass it the logical heighmap from the W3dTerrainVisual
+	// yes another nosequiter. Ugh!
 
-  // M Lorenzen
+	// M Lorenzen
 
-  // by doing it this way the compiler won't call getLogicHeightMap twice...
-  WorldHeightMap *logicHeightMap = TheTerrainVisual?TheTerrainVisual->getLogicHeightMap():m_map;
+	// by doing it this way the compiler won't call getLogicHeightMap twice...
+	WorldHeightMap *logicHeightMap = TheTerrainVisual?TheTerrainVisual->getLogicHeightMap():m_map;
 
-  if ( !logicHeightMap )
-  {
+	if ( !logicHeightMap )
+	{
 		if (normal)
 		{
 			// return a default normal pointing up
@@ -866,7 +866,7 @@ Real BaseHeightMapRenderObjClass::getHeightMapHeight(Real x, Real y, Coord3D* no
 			normal->z = 1.0f;
 		}
 		return 0;
-  }
+	}
 
 
 	float height;
@@ -938,9 +938,9 @@ Real BaseHeightMapRenderObjClass::getHeightMapHeight(Real x, Real y, Coord3D* no
 		//
 		//		4			5
 		//Find surrounding grid points for smoothed normals.
- 		int idx4 = ix + (iy-1)*xExtent;
- 		int idx0 = ix + iy*xExtent;
- 		int idx3 = ix + iy*xExtent+xExtent;
+		int idx4 = ix + (iy-1)*xExtent;
+		int idx0 = ix + iy*xExtent;
+		int idx3 = ix + iy*xExtent+xExtent;
 		int idx9 = ix + (iy+2)*xExtent;
 		UnsignedByte d0, d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11;
 		d0 = data[idx0];
@@ -997,7 +997,7 @@ Bool BaseHeightMapRenderObjClass::isClearLineOfSight(const Coord3D& pos, const C
 	if (m_map == nullptr)
 		return false;	// doh. should not happen.
 
-  WorldHeightMap *logicHeightMap = TheTerrainVisual?TheTerrainVisual->getLogicHeightMap():m_map;
+	WorldHeightMap *logicHeightMap = TheTerrainVisual?TheTerrainVisual->getLogicHeightMap():m_map;
 
 #define DO_BRESENHAM
 #ifdef DO_BRESENHAM
@@ -1202,7 +1202,7 @@ Real BaseHeightMapRenderObjClass::getMaxCellHeight(Real x, Real y) const
 		return 0.0f;	//return default height
 	}
 
-  WorldHeightMap *logicHeightMap = TheTerrainVisual?TheTerrainVisual->getLogicHeightMap():m_map;
+	WorldHeightMap *logicHeightMap = TheTerrainVisual?TheTerrainVisual->getLogicHeightMap():m_map;
 
 
 	Int offset = 1;
@@ -1245,7 +1245,7 @@ Bool BaseHeightMapRenderObjClass::isCliffCell(Real x, Real y)
 		return false;
 	}
 
-  WorldHeightMap *logicHeightMap = TheTerrainVisual?TheTerrainVisual->getLogicHeightMap():m_map;
+	WorldHeightMap *logicHeightMap = TheTerrainVisual?TheTerrainVisual->getLogicHeightMap():m_map;
 
 	Int iX = x/MAP_XY_FACTOR;
 	Int iY = y/MAP_XY_FACTOR;
@@ -1992,10 +1992,10 @@ void BaseHeightMapRenderObjClass::updateScorches()
 #endif
 				if (flipForBlend) {
 					*curIb++ = startVertex + j*yOffset + i+1;
- 					*curIb++ = startVertex + j*yOffset + i+yOffset;
+					*curIb++ = startVertex + j*yOffset + i+yOffset;
 					*curIb++ = startVertex + j*yOffset + i;
- 					*curIb++ = startVertex + j*yOffset + i+1;
- 					*curIb++ = startVertex + j*yOffset + i+1+yOffset;
+					*curIb++ = startVertex + j*yOffset + i+1;
+					*curIb++ = startVertex + j*yOffset + i+1+yOffset;
 					*curIb++ = startVertex + j*yOffset + i+yOffset;
 				}
 				else
@@ -2049,9 +2049,9 @@ void BaseHeightMapRenderObjClass::addScorch(Vector3 location, Real radius, Scorc
 	Real limit = radius/4;
 	for (i=0; i<m_numScorches; i++) {
 		if ( abs(location.X-m_scorches[i].location.X) < limit &&
-				 abs(location.Y-m_scorches[i].location.Y) < limit &&
-				 abs(radius - m_scorches[i].radius) < limit &&
-				 m_scorches[i].scorchType == type) {
+			abs(location.Y-m_scorches[i].location.Y) < limit &&
+			abs(radius - m_scorches[i].radius) < limit &&
+			m_scorches[i].scorchType == type) {
 			return; // basically a duplicate.
 		}
 	}
@@ -2130,8 +2130,8 @@ Int BaseHeightMapRenderObjClass::getStaticDiffuse(Int x, Int y)
 		RefRenderObjListIterator *it = pMyScene->createLightsIterator();
 		doTheLight(&vertex, lightRay, &normalAtTexel, it, 1.0f);
 		if (it) {
-		 pMyScene->destroyLightsIterator(it);
-		 it = nullptr;
+			pMyScene->destroyLightsIterator(it);
+			it = nullptr;
 		}
 	} else {
 		doTheLight(&vertex, lightRay, &normalAtTexel, nullptr, 1.0f);

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DDebrisDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DDebrisDraw.cpp
@@ -52,7 +52,7 @@
 //-------------------------------------------------------------------------------------------------
 W3DDebrisDraw::W3DDebrisDraw(Thing *thing, const ModuleData* moduleData) : DrawModule(thing, moduleData)
 {
-  m_renderObject = nullptr;
+	m_renderObject = nullptr;
 	for (int i = 0; i < STATECOUNT; ++i)
 		m_anims[i] = nullptr;
 	m_fxFinal = nullptr;
@@ -75,8 +75,8 @@ W3DDebrisDraw::~W3DDebrisDraw()
 	{
 		if (W3DDisplay::m_3DScene != nullptr)
 			W3DDisplay::m_3DScene->Remove_Render_Object(m_renderObject);
-  	REF_PTR_RELEASE(m_renderObject);
- 		m_renderObject = nullptr;
+		REF_PTR_RELEASE(m_renderObject);
+		m_renderObject = nullptr;
 	}
 	for (int i = 0; i < STATECOUNT; ++i)
 	{
@@ -103,7 +103,7 @@ void W3DDebrisDraw::setFullyObscuredByShroud(Bool fullyObscured)
 //-------------------------------------------------------------------------------------------------
 void W3DDebrisDraw::setModelName(AsciiString name, Color color, ShadowType t)
 {
-  if (m_renderObject == nullptr && !name.isEmpty())
+	if (m_renderObject == nullptr && !name.isEmpty())
 	{
 		Int hexColor = 0;
 		if (color != 0)
@@ -129,7 +129,7 @@ void W3DDebrisDraw::setModelName(AsciiString name, Color color, ShadowType t)
 		{
 			Shadow::ShadowTypeInfo shadowInfo;
 			shadowInfo.m_type = t;
-  		m_shadow = TheW3DShadowManager->addShadow(m_renderObject, &shadowInfo);
+			m_shadow = TheW3DShadowManager->addShadow(m_renderObject, &shadowInfo);
 		}
 		else
 		{

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DDefaultDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DDefaultDraw.cpp
@@ -62,7 +62,7 @@ W3DDefaultDraw::W3DDefaultDraw(Thing *thing, const ModuleData* moduleData) : Dra
 
 		Shadow::ShadowTypeInfo shadowInfo;
 		shadowInfo.m_type=(ShadowType)SHADOW_VOLUME;
-  		m_shadow = TheW3DShadowManager->addShadow(m_renderObject, &shadowInfo);
+		m_shadow = TheW3DShadowManager->addShadow(m_renderObject, &shadowInfo);
 
 
 		DEBUG_ASSERTCRASH(m_renderObject, ("Test asset %s not found", getDrawable()->getTemplate()->getLTAName().str()));
@@ -87,8 +87,8 @@ W3DDefaultDraw::W3DDefaultDraw(Thing *thing, const ModuleData* moduleData) : Dra
 // ------------------------------------------------------------------------------------------------
 // ------------------------------------------------------------------------------------------------
 void W3DDefaultDraw::reactToTransformChange( const Matrix3D *oldMtx,
-																						 const Coord3D *oldPos,
-																						 Real oldAngle )
+	const Coord3D *oldPos,
+	Real oldAngle )
 {
 #ifdef LOAD_TEST_ASSETS
 	if( m_renderObject )
@@ -109,7 +109,7 @@ W3DDefaultDraw::~W3DDefaultDraw()
 	if (m_renderObject)
 	{
 		W3DDisplay::m_3DScene->Remove_Render_Object(m_renderObject);
-  	REF_PTR_RELEASE(m_renderObject);
+		REF_PTR_RELEASE(m_renderObject);
 		m_renderObject = nullptr;
 	}
 #endif

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DDependencyModelDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DDependencyModelDraw.cpp
@@ -55,7 +55,7 @@ W3DDependencyModelDrawModuleData::~W3DDependencyModelDrawModuleData()
 //-------------------------------------------------------------------------------------------------
 void W3DDependencyModelDrawModuleData::buildFieldParse(MultiIniFieldParse& p)
 {
-  W3DModelDrawModuleData::buildFieldParse(p);
+	W3DModelDrawModuleData::buildFieldParse(p);
 
 	static const FieldParse dataFieldParse[] =
 	{
@@ -63,7 +63,7 @@ void W3DDependencyModelDrawModuleData::buildFieldParse(MultiIniFieldParse& p)
 
 		{ nullptr, nullptr, nullptr, 0 }
 	};
-  p.add(dataFieldParse);
+	p.add(dataFieldParse);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -89,24 +89,24 @@ void W3DDependencyModelDraw::doDrawModule(const Matrix3D* transformMtx)
 		m_dependencyCleared = FALSE;
 
 
-    // A handy place to synchronize my drawable with container's
-    Drawable *myDrawable = getDrawable();
-    if ( ! myDrawable )
-      return;
+		// A handy place to synchronize my drawable with container's
+		Drawable *myDrawable = getDrawable();
+		if ( ! myDrawable )
+		return;
 
-    const Object *me = myDrawable->getObject();
-    if ( ! me )
-      return;
+		const Object *me = myDrawable->getObject();
+		if ( ! me )
+		return;
 
-	  Drawable *theirDrawable = nullptr;
+		Drawable *theirDrawable = nullptr;
 
-	  if( me->getContainedBy() && !me->getContainedBy()->getContain()->isEnclosingContainerFor(me) )
-		  theirDrawable = me->getContainedBy()->getDrawable();
+		if( me->getContainedBy() && !me->getContainedBy()->getContain()->isEnclosingContainerFor(me) )
+		theirDrawable = me->getContainedBy()->getDrawable();
 
-    if( ! theirDrawable )
-		  return;
+		if( ! theirDrawable )
+		return;
 
-    myDrawable->imitateStealthLook( *theirDrawable );
+		myDrawable->imitateStealthLook( *theirDrawable );
 
 	}
 }
@@ -144,7 +144,7 @@ void W3DDependencyModelDraw::adjustTransformMtx(Matrix3D& mtx) const
 			}
 			else
 			{
-        mtx = *theirDrawable->getTransformMatrix();//TransformMatrix();
+				mtx = *theirDrawable->getTransformMatrix();//TransformMatrix();
 				DEBUG_LOG(("m_attachToDrawableBoneInContainer %s not found",getW3DDependencyModelDrawModuleData()->m_attachToDrawableBoneInContainer.str()));
 			}
 		}

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DLaserDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DLaserDraw.cpp
@@ -61,9 +61,9 @@ W3DLaserDrawModuleData::W3DLaserDrawModuleData()
 {
 	m_innerBeamWidth = 0.0f;         //The total width of beam
 	m_outerBeamWidth = 1.0f;         //The total width of beam
-  m_numBeams = 1;                 //Number of overlapping cylinders that make the beam. 1 beam will just use inner data.
-  m_maxIntensityFrames = 0;				//Laser stays at max intensity for specified time in ms.
-  m_fadeFrames = 0;               //Laser will fade and delete.
+	m_numBeams = 1;                 //Number of overlapping cylinders that make the beam. 1 beam will just use inner data.
+	m_maxIntensityFrames = 0;				//Laser stays at max intensity for specified time in ms.
+	m_fadeFrames = 0;               //Laser will fade and delete.
 	m_scrollRate = 0.0f;
 	m_tile = false;
 	m_segments = 1;
@@ -82,7 +82,7 @@ W3DLaserDrawModuleData::~W3DLaserDrawModuleData()
 //-------------------------------------------------------------------------------------------------
 void W3DLaserDrawModuleData::buildFieldParse(MultiIniFieldParse& p)
 {
-  ModuleData::buildFieldParse(p);
+	ModuleData::buildFieldParse(p);
 
 	static const FieldParse dataFieldParse[] =
 	{
@@ -97,12 +97,12 @@ void W3DLaserDrawModuleData::buildFieldParse(MultiIniFieldParse& p)
 		{ "ScrollRate",						INI::parseReal,									nullptr, offsetof( W3DLaserDrawModuleData, m_scrollRate ) },
 		{ "Tile",									INI::parseBool,									nullptr, offsetof( W3DLaserDrawModuleData, m_tile ) },
 		{ "Segments",							INI::parseUnsignedInt,					nullptr, offsetof( W3DLaserDrawModuleData, m_segments ) },
-    { "ArcHeight",						INI::parseReal,									nullptr, offsetof( W3DLaserDrawModuleData, m_arcHeight ) },
+		{ "ArcHeight",						INI::parseReal,									nullptr, offsetof( W3DLaserDrawModuleData, m_arcHeight ) },
 		{ "SegmentOverlapRatio",	INI::parseReal,									nullptr, offsetof( W3DLaserDrawModuleData, m_segmentOverlapRatio ) },
 		{ "TilingScalar",					INI::parseReal,									nullptr, offsetof( W3DLaserDrawModuleData, m_tilingScalar ) },
 		{ nullptr, nullptr, nullptr, 0 }
 	};
-  p.add(dataFieldParse);
+	p.add(dataFieldParse);
 }
 
 

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
@@ -1020,7 +1020,7 @@ void ModelConditionInfo::clear()
 W3DModelDrawModuleData::W3DModelDrawModuleData() :
 	m_validated(0),
 	m_okToChangeModelColor(false),
-  m_particlesAttachedToAnimatedBones(false),
+	m_particlesAttachedToAnimatedBones(false),
 	m_animationsRequirePower(true),
 #ifdef CACHE_ATTACH_BONE
 	m_attachToDrawableBoneOffsetValid(false),
@@ -1040,7 +1040,7 @@ W3DModelDrawModuleData::W3DModelDrawModuleData() :
 	m_recoilSettle = SETTLE_RATE;
 
 
-  m_receivesDynamicLights = TRUE;
+	m_receivesDynamicLights = TRUE;
 
 	// m_ignoreConditionStates defaults to all zero, which is what we want
 }
@@ -1125,8 +1125,8 @@ void W3DModelDrawModuleData::preloadAssets( TimeOfDay timeOfDay, Real scale ) co
 {
 
 	for( ModelConditionVector::iterator it = m_conditionStates.begin();
-			 it != m_conditionStates.end();
-			 ++it )
+	it != m_conditionStates.end();
+	++it )
 	{
 
 		it->preloadAssets( timeOfDay, scale );
@@ -1195,7 +1195,7 @@ static void parseAsciiStringLC( INI* ini, void * /*instance*/, void *store, cons
 //-------------------------------------------------------------------------------------------------
 void W3DModelDrawModuleData::buildFieldParse(MultiIniFieldParse& p)
 {
-  ModuleData::buildFieldParse(p);
+	ModuleData::buildFieldParse(p);
 
 	static const FieldParse dataFieldParse[] =
 	{
@@ -1219,7 +1219,7 @@ void W3DModelDrawModuleData::buildFieldParse(MultiIniFieldParse& p)
 		{ "ReceivesDynamicLights", INI::parseBool, nullptr, offsetof(W3DModelDrawModuleData, m_receivesDynamicLights) },
 		{ nullptr, nullptr, nullptr, 0 }
 	};
-  p.add(dataFieldParse);
+	p.add(dataFieldParse);
 
 }
 
@@ -1758,24 +1758,24 @@ W3DModelDraw::W3DModelDraw(Thing *thing, const ModuleData* moduleData) : DrawMod
 
 	Drawable* draw = getDrawable();
 
-  if ( draw )
-  {
-	  Object* obj = draw->getObject();
-	  if (obj)
-	  {
-		  if (TheGlobalData->m_timeOfDay == TIME_OF_DAY_NIGHT)
-			  m_hexColor = obj->getNightIndicatorColor();
-		  else
-			  m_hexColor = obj->getIndicatorColor();
-	  }
+	if ( draw )
+	{
+		Object* obj = draw->getObject();
+		if (obj)
+		{
+			if (TheGlobalData->m_timeOfDay == TIME_OF_DAY_NIGHT)
+			m_hexColor = obj->getNightIndicatorColor();
+			else
+			m_hexColor = obj->getIndicatorColor();
+		}
 
-    // THE VAST MAJORITY OF THESE SHOULD BE TRUE
-    if ( ! getW3DModelDrawModuleData()->m_receivesDynamicLights)
-    {
-      draw->setReceivesDynamicLights( FALSE );
-		  DEBUG_LOG(("setReceivesDynamicLights = FALSE: %s", draw->getTemplate()->getName().str()));
-    }
-  }
+		// THE VAST MAJORITY OF THESE SHOULD BE TRUE
+		if ( ! getW3DModelDrawModuleData()->m_receivesDynamicLights)
+		{
+			draw->setReceivesDynamicLights( FALSE );
+			DEBUG_LOG(("setReceivesDynamicLights = FALSE: %s", draw->getTemplate()->getName().str()));
+		}
+	}
 
 	setModelState(info);
 }
@@ -1870,7 +1870,7 @@ void W3DModelDraw::allocateShadows()
 		shadowInfo.m_sizeY					= tmplate->getShadowSizeY();
 		shadowInfo.m_offsetX				= tmplate->getShadowOffsetX();
 		shadowInfo.m_offsetY				= tmplate->getShadowOffsetY();
-  		m_shadow = TheW3DShadowManager->addShadow(m_renderObject, &shadowInfo);
+		m_shadow = TheW3DShadowManager->addShadow(m_renderObject, &shadowInfo);
 		if (m_shadow)
 		{	m_shadow->enableShadowInvisible(m_fullyObscuredByShroud);
 			if (m_renderObject->Is_Hidden() || !m_shadowEnabled)
@@ -2105,12 +2105,12 @@ void W3DModelDraw::doDrawModule(const Matrix3D* transformMtx)
 	handleClientTurretPositioning();
 	recalcBonesForClientParticleSystems();
 
-  const W3DModelDrawModuleData *modData = getW3DModelDrawModuleData();
-  if ( modData->m_particlesAttachedToAnimatedBones )
-    updateBonesForClientParticleSystems();// LORENZEN ADDED THIS
-                                          // IT REPOSITIONS PARTICLESYSTEMS TO TSTAY IN SYNC WITH ANIMATED BONES
+	const W3DModelDrawModuleData *modData = getW3DModelDrawModuleData();
+	if ( modData->m_particlesAttachedToAnimatedBones )
+	updateBonesForClientParticleSystems();// LORENZEN ADDED THIS
+	// IT REPOSITIONS PARTICLESYSTEMS TO TSTAY IN SYNC WITH ANIMATED BONES
 
-  handleClientRecoil();
+	handleClientRecoil();
 
 }
 
@@ -2304,22 +2304,22 @@ static void doHideShowBoneSubObjs(Bool state, Int numSubObjects, Int boneIdx, Re
 #endif
 #if 0	//old slow version
 
-  for (Int i=0; i < numSubObjects; i++)
-  {
-  	Int childBoneIndex = fullObject->Get_Sub_Object_Bone_Index(0, i);
-  	Int parentIndex = htree->Get_Parent_Index(childBoneIndex);
-  	if (childBoneIndex == parentIndex)
-  		continue;
+	for (Int i=0; i < numSubObjects; i++)
+	{
+		Int childBoneIndex = fullObject->Get_Sub_Object_Bone_Index(0, i);
+		Int parentIndex = htree->Get_Parent_Index(childBoneIndex);
+		if (childBoneIndex == parentIndex)
+		continue;
 
-  	if (parentIndex == boneIdx)	// this object has our subobject as parent so copy hide state
-  	{
-  		RenderObjClass* childObject = fullObject->Get_Sub_Object(i);
-  		// recurse down the hierarchy to hide all sub-children
-  		doHideShowBoneSubObjs(state, numSubObjects, childBoneIndex, fullObject, htree);
+		if (parentIndex == boneIdx)	// this object has our subobject as parent so copy hide state
+		{
+			RenderObjClass* childObject = fullObject->Get_Sub_Object(i);
+			// recurse down the hierarchy to hide all sub-children
+			doHideShowBoneSubObjs(state, numSubObjects, childBoneIndex, fullObject, htree);
 		childObject->Set_Hidden(state);
-  		childObject->Release_Ref();
-  	}
-  }
+			childObject->Release_Ref();
+		}
+	}
 #endif
 }
 
@@ -2688,22 +2688,22 @@ Bool W3DModelDraw::updateBonesForClientParticleSystems()
 			Int boneIndex = (*it).boneIndex;
 			if ( (sys != nullptr) && (boneIndex != 0)  )
 			{
-    		const Matrix3D boneTransform = m_renderObject->Get_Bone_Transform(boneIndex);// just a little worried about state changes
+				const Matrix3D boneTransform = m_renderObject->Get_Bone_Transform(boneIndex);// just a little worried about state changes
 
-        Vector3 vpos = boneTransform.Get_Translation();
+				Vector3 vpos = boneTransform.Get_Translation();
 
-        Coord3D pos;
+				Coord3D pos;
 				pos.x = vpos.X;
 				pos.y = vpos.Y;
 				pos.z = vpos.Z;
 
 				sys->setPosition(&pos);
 
-        Real orientation = boneTransform.Get_Z_Rotation();
+				Real orientation = boneTransform.Get_Z_Rotation();
 				sys->rotateLocalTransformZ(orientation);
 
-        sys->setLocalTransform(&boneTransform);
-        sys->setSkipParentXfrm(true);
+				sys->setLocalTransform(&boneTransform);
+				sys->setSkipParentXfrm(true);
 
 			}
 		}
@@ -3102,8 +3102,8 @@ void W3DModelDraw::setModelState(const ModelConditionInfo* newState)
 			}
 
 			Object *obj = draw->getObject();
- 			if( obj )
-   		{
+			if( obj )
+			{
 
 				// for non bridge objects we adjust some collision types
 				if( obj->isKindOf( KINDOF_BRIDGE ) == FALSE &&
@@ -3112,16 +3112,16 @@ void W3DModelDraw::setModelState(const ModelConditionInfo* newState)
 
 					if( obj->isKindOf( KINDOF_STRUCTURE ) && draw->getModelConditionFlags().test( MODELCONDITION_RUBBLE ) )
 					{
-	 					//A dead building, -- don't allow the user to click on rubble! Treat it as a location instead.
-	   				m_renderObject->Set_Collision_Type( 0 );
+						//A dead building, -- don't allow the user to click on rubble! Treat it as a location instead.
+						m_renderObject->Set_Collision_Type( 0 );
 					}
 					else if( obj->isEffectivelyDead() )
 					{
- 						//A dead object, -- don't allow the user to click on rubble/hulks! Treat it as a location instead.
-	   				m_renderObject->Set_Collision_Type( 0 );
+						//A dead object, -- don't allow the user to click on rubble/hulks! Treat it as a location instead.
+						m_renderObject->Set_Collision_Type( 0 );
 					}
 				}
-   		}
+			}
 
 			// add render object to our scene
 			if (W3DDisplay::m_3DScene != nullptr)
@@ -3641,8 +3641,8 @@ Int W3DModelDraw::getCurrentBonePositions(
 
 //-------------------------------------------------------------------------------------------------
 void W3DModelDraw::reactToTransformChange( const Matrix3D* oldMtx,
-																					 const Coord3D* oldPos,
-																					 Real oldAngle )
+	const Coord3D* oldPos,
+	Real oldAngle )
 {
 
 	// set the position of our render object

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DOverlordAircraftDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DOverlordAircraftDraw.cpp
@@ -58,13 +58,13 @@ W3DOverlordAircraftDrawModuleData::~W3DOverlordAircraftDrawModuleData()
 //-------------------------------------------------------------------------------------------------
 void W3DOverlordAircraftDrawModuleData::buildFieldParse(MultiIniFieldParse& p)
 {
-  W3DModelDrawModuleData::buildFieldParse(p);
+	W3DModelDrawModuleData::buildFieldParse(p);
 
 	static const FieldParse dataFieldParse[] =
 	{
 		{ nullptr, nullptr, nullptr, 0 }
 	};
-  p.add(dataFieldParse);
+	p.add(dataFieldParse);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -95,16 +95,16 @@ void W3DOverlordAircraftDraw::doDrawModule(const Matrix3D* transformMtx)
 		)
 	{
 		Drawable *riderDraw = me->getContain()->friend_getRider()->getDrawable();
-    if ( riderDraw )
-    {
-      TintEnvelope *env = getDrawable()->getColorTintEnvelope();
-      if ( env )
-        riderDraw->setColorTintEnvelope( *env );
+		if ( riderDraw )
+		{
+			TintEnvelope *env = getDrawable()->getColorTintEnvelope();
+			if ( env )
+			riderDraw->setColorTintEnvelope( *env );
 
-      riderDraw->notifyDrawableDependencyCleared();
-      riderDraw->draw();
-    }
-    DEBUG_ASSERTCRASH( riderDraw, ("OverlordAircraftDraw finds no rider's drawable") );
+			riderDraw->notifyDrawableDependencyCleared();
+			riderDraw->draw();
+		}
+		DEBUG_ASSERTCRASH( riderDraw, ("OverlordAircraftDraw finds no rider's drawable") );
 
 	}
 }

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DOverlordTankDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DOverlordTankDraw.cpp
@@ -49,13 +49,13 @@ W3DOverlordTankDrawModuleData::~W3DOverlordTankDrawModuleData()
 //-------------------------------------------------------------------------------------------------
 void W3DOverlordTankDrawModuleData::buildFieldParse(MultiIniFieldParse& p)
 {
-  W3DTankDrawModuleData::buildFieldParse(p);
+	W3DTankDrawModuleData::buildFieldParse(p);
 
 	static const FieldParse dataFieldParse[] =
 	{
 		{ nullptr, nullptr, nullptr, 0 }
 	};
-  p.add(dataFieldParse);
+	p.add(dataFieldParse);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DOverlordTruckDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DOverlordTruckDraw.cpp
@@ -49,13 +49,13 @@ W3DOverlordTruckDrawModuleData::~W3DOverlordTruckDrawModuleData()
 //-------------------------------------------------------------------------------------------------
 void W3DOverlordTruckDrawModuleData::buildFieldParse(MultiIniFieldParse& p)
 {
-  W3DTruckDrawModuleData::buildFieldParse(p);
+	W3DTruckDrawModuleData::buildFieldParse(p);
 
 	static const FieldParse dataFieldParse[] =
 	{
 		{ nullptr, nullptr, nullptr, 0 }
 	};
-  p.add(dataFieldParse);
+	p.add(dataFieldParse);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DProjectileStreamDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DProjectileStreamDraw.cpp
@@ -55,7 +55,7 @@ W3DProjectileStreamDrawModuleData::~W3DProjectileStreamDrawModuleData()
 //-------------------------------------------------------------------------------------------------
 void W3DProjectileStreamDrawModuleData::buildFieldParse(MultiIniFieldParse& p)
 {
-  ModuleData::buildFieldParse(p);
+	ModuleData::buildFieldParse(p);
 
 	static const FieldParse dataFieldParse[] =
 	{
@@ -66,7 +66,7 @@ void W3DProjectileStreamDrawModuleData::buildFieldParse(MultiIniFieldParse& p)
 		{ "MaxSegments",	INI::parseInt,					nullptr, offsetof(W3DProjectileStreamDrawModuleData, m_maxSegments) },
 		{ nullptr, nullptr, nullptr, 0 }
 	};
-  p.add(dataFieldParse);
+	p.add(dataFieldParse);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DPropDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DPropDraw.cpp
@@ -52,14 +52,14 @@ W3DPropDrawModuleData::~W3DPropDrawModuleData()
 //-------------------------------------------------------------------------------------------------
 void W3DPropDrawModuleData::buildFieldParse(MultiIniFieldParse& p)
 {
-  ModuleData::buildFieldParse(p);
+	ModuleData::buildFieldParse(p);
 	static const FieldParse dataFieldParse[] =
 	{
 		{ "ModelName", INI::parseAsciiString, nullptr, offsetof(W3DPropDrawModuleData, m_modelName) },
 
 		{ nullptr, nullptr, nullptr, 0 }
 	};
-  p.add(dataFieldParse);
+	p.add(dataFieldParse);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -83,8 +83,8 @@ W3DPropDraw::~W3DPropDraw()
 
 //-------------------------------------------------------------------------------------------------
 void W3DPropDraw::reactToTransformChange( const Matrix3D *oldMtx,
-																							 const Coord3D *oldPos,
-																							 Real oldAngle )
+	const Coord3D *oldPos,
+	Real oldAngle )
 {
 	Drawable *draw = getDrawable();
 	if (m_propAdded) {

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DRopeDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DRopeDraw.cpp
@@ -87,20 +87,20 @@ void W3DRopeDraw::buildSegments()
 		info.wobbleAxisX = Cos(axis);
 		info.wobbleAxisY = Sin(axis);
 		info.line = NEW Line3DClass( Vector3(pos.x,pos.y,pos.z),
-																	 Vector3(pos.x,pos.y,pos.z+eachLen),
-																	 m_width * 0.5f,  // width
-																	 m_color.red,  // red
-																	 m_color.green,  // green
-																	 m_color.blue,  // blue
-																	 1.0f );  // transparency
+			Vector3(pos.x,pos.y,pos.z+eachLen),
+			m_width * 0.5f,  // width
+			m_color.red,  // red
+			m_color.green,  // green
+			m_color.blue,  // blue
+			1.0f );  // transparency
 
 		info.softLine = NEW Line3DClass( Vector3(pos.x,pos.y,pos.z),
-																	 Vector3(pos.x,pos.y,pos.z+eachLen),
-																	 m_width,  // width
-																	 m_color.red,  // red
-																	 m_color.green,  // green
-																	 m_color.blue,  // blue
-																	 0.5f );  // transparency
+			Vector3(pos.x,pos.y,pos.z+eachLen),
+			m_width,  // width
+			m_color.red,  // red
+			m_color.green,  // green
+			m_color.blue,  // blue
+			0.5f );  // transparency
 
 		if (W3DDisplay::m_3DScene)
 		{

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DScienceModelDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DScienceModelDraw.cpp
@@ -49,7 +49,7 @@ W3DScienceModelDrawModuleData::~W3DScienceModelDrawModuleData()
 //-------------------------------------------------------------------------------------------------
 void W3DScienceModelDrawModuleData::buildFieldParse(MultiIniFieldParse& p)
 {
-  W3DModelDrawModuleData::buildFieldParse(p);
+	W3DModelDrawModuleData::buildFieldParse(p);
 
 	static const FieldParse dataFieldParse[] =
 	{
@@ -57,7 +57,7 @@ void W3DScienceModelDrawModuleData::buildFieldParse(MultiIniFieldParse& p)
 
 		{ nullptr, nullptr, nullptr, 0 }
 	};
-  p.add(dataFieldParse);
+	p.add(dataFieldParse);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DSupplyDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DSupplyDraw.cpp
@@ -44,7 +44,7 @@ W3DSupplyDrawModuleData::~W3DSupplyDrawModuleData()
 //-------------------------------------------------------------------------------------------------
 void W3DSupplyDrawModuleData::buildFieldParse(MultiIniFieldParse& p)
 {
-  W3DModelDrawModuleData::buildFieldParse(p);
+	W3DModelDrawModuleData::buildFieldParse(p);
 
 	static const FieldParse dataFieldParse[] =
 	{
@@ -52,7 +52,7 @@ void W3DSupplyDrawModuleData::buildFieldParse(MultiIniFieldParse& p)
 
 		{ nullptr, nullptr, nullptr, 0 }
 	};
-  p.add(dataFieldParse);
+	p.add(dataFieldParse);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankDraw.cpp
@@ -75,7 +75,7 @@ W3DTankDrawModuleData::~W3DTankDrawModuleData()
 //-------------------------------------------------------------------------------------------------
 void W3DTankDrawModuleData::buildFieldParse(MultiIniFieldParse& p)
 {
-  W3DModelDrawModuleData::buildFieldParse(p);
+	W3DModelDrawModuleData::buildFieldParse(p);
 
 	static const FieldParse dataFieldParse[] =
 	{
@@ -86,7 +86,7 @@ void W3DTankDrawModuleData::buildFieldParse(MultiIniFieldParse& p)
 		{ "TreadDriveSpeedFraction", INI::parseReal, nullptr, offsetof(W3DTankDrawModuleData, m_treadDriveSpeedFraction) },
 		{ nullptr, nullptr, nullptr, 0 }
 	};
-  p.add(dataFieldParse);
+	p.add(dataFieldParse);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankTruckDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTankTruckDraw.cpp
@@ -71,7 +71,7 @@ W3DTankTruckDrawModuleData::~W3DTankTruckDrawModuleData()
 //-------------------------------------------------------------------------------------------------
 void W3DTankTruckDrawModuleData::buildFieldParse(MultiIniFieldParse& p)
 {
-  W3DModelDrawModuleData::buildFieldParse(p);
+	W3DModelDrawModuleData::buildFieldParse(p);
 
 	static const FieldParse dataFieldParse[] =
 	{
@@ -95,7 +95,7 @@ void W3DTankTruckDrawModuleData::buildFieldParse(MultiIniFieldParse& p)
 		{ "TreadDriveSpeedFraction", INI::parseReal, nullptr, offsetof(W3DTankTruckDrawModuleData, m_treadDriveSpeedFraction) },
 		{ nullptr, nullptr, nullptr, 0 }
 	};
-  p.add(dataFieldParse);
+	p.add(dataFieldParse);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTracerDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTracerDraw.cpp
@@ -98,8 +98,8 @@ W3DTracerDraw::~W3DTracerDraw()
 
 //-------------------------------------------------------------------------------------------------
 void W3DTracerDraw::reactToTransformChange( const Matrix3D *oldMtx,
-																							 const Coord3D *oldPos,
-																							 Real oldAngle )
+	const Coord3D *oldPos,
+	Real oldAngle )
 {
 	if( m_theTracer )
 		m_theTracer->Set_Transform( *getDrawable()->getTransformMatrix() );
@@ -120,12 +120,12 @@ void W3DTracerDraw::doDrawModule(const Matrix3D* transformMtx)
 		// create tracer render object for us to manipulate
 		// poolify
 		m_theTracer = NEW Line3DClass( start,
-																	 stop,
-																	 m_width,  // width
-																	 m_color.red,  // red
-																	 m_color.green,  // green
-																	 m_color.blue,  // blue
-																	 m_opacity );  // transparency
+			stop,
+			m_width,  // width
+			m_color.red,  // red
+			m_color.green,  // green
+			m_color.blue,  // blue
+			m_opacity );  // transparency
 		W3DDisplay::m_3DScene->Add_Render_Object( m_theTracer );
 
 		// set the transform for the tracer to that of the drawable

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTreeDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTreeDraw.cpp
@@ -51,7 +51,7 @@ m_maxOutwardMovement(1.0f)
 	const Real START_VELOCITY_PERCENT = 0.2f;
 	const Real START_ACCEL_PERCENT = 0.01f;
 	const Real VELOCITY_BOUNCE_PERCENT = 0.3f;			// multiply the velocity by this when you bounce
-  const Real MINIMUM_TOPPLE_SPEED = 0.5f;         // Won't let trees fall slower than this
+	const Real MINIMUM_TOPPLE_SPEED = 0.5f;         // Won't let trees fall slower than this
 	m_toppleFX = nullptr;
 	m_bounceFX = nullptr;
 	m_stumpName.clear();
@@ -61,7 +61,7 @@ m_maxOutwardMovement(1.0f)
 	m_initialVelocityPercent = START_VELOCITY_PERCENT;
 	m_initialAccelPercent = START_ACCEL_PERCENT;
 	m_bounceVelocityPercent = VELOCITY_BOUNCE_PERCENT;
-  m_minimumToppleSpeed = MINIMUM_TOPPLE_SPEED;
+	m_minimumToppleSpeed = MINIMUM_TOPPLE_SPEED;
 	m_sinkFrames = 10*LOGICFRAMES_PER_SECOND;
 	m_sinkDistance = 20.0f;
 
@@ -75,7 +75,7 @@ W3DTreeDrawModuleData::~W3DTreeDrawModuleData()
 //-------------------------------------------------------------------------------------------------
 void W3DTreeDrawModuleData::buildFieldParse(MultiIniFieldParse& p)
 {
-  ModuleData::buildFieldParse(p);
+	ModuleData::buildFieldParse(p);
 	static const FieldParse dataFieldParse[] =
 	{
 		{ "ModelName", INI::parseAsciiString, nullptr, offsetof(W3DTreeDrawModuleData, m_modelName) },
@@ -94,13 +94,13 @@ void W3DTreeDrawModuleData::buildFieldParse(MultiIniFieldParse& p)
 		{ "InitialVelocityPercent",	INI::parsePercentToReal, nullptr, offsetof( W3DTreeDrawModuleData, m_initialVelocityPercent ) },
 		{ "InitialAccelPercent",	INI::parsePercentToReal, nullptr, offsetof( W3DTreeDrawModuleData, m_initialAccelPercent ) },
 		{ "BounceVelocityPercent",	INI::parsePercentToReal, nullptr, offsetof( W3DTreeDrawModuleData, m_bounceVelocityPercent ) },
-    { "MinimumToppleSpeed",	INI::parsePositiveNonZeroReal, nullptr, offsetof( W3DTreeDrawModuleData, m_minimumToppleSpeed ) },
-    { "SinkDistance",	INI::parsePositiveNonZeroReal, nullptr, offsetof( W3DTreeDrawModuleData, m_sinkDistance ) },
+		{ "MinimumToppleSpeed",	INI::parsePositiveNonZeroReal, nullptr, offsetof( W3DTreeDrawModuleData, m_minimumToppleSpeed ) },
+		{ "SinkDistance",	INI::parsePositiveNonZeroReal, nullptr, offsetof( W3DTreeDrawModuleData, m_sinkDistance ) },
 		{ "SinkTime", INI::parseDurationUnsignedInt, nullptr, offsetof(W3DTreeDrawModuleData, m_sinkFrames) },
 		{ "DoShadow",	INI::parseBool, nullptr, offsetof( W3DTreeDrawModuleData, m_doShadow ) },
 		{ nullptr, nullptr, nullptr, 0 }
 	};
-  p.add(dataFieldParse);
+	p.add(dataFieldParse);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTruckDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DTruckDraw.cpp
@@ -63,7 +63,7 @@ W3DTruckDrawModuleData::~W3DTruckDrawModuleData()
 //-------------------------------------------------------------------------------------------------
 void W3DTruckDrawModuleData::buildFieldParse(MultiIniFieldParse& p)
 {
-  W3DModelDrawModuleData::buildFieldParse(p);
+	W3DModelDrawModuleData::buildFieldParse(p);
 
 	static const FieldParse dataFieldParse[] =
 	{
@@ -92,7 +92,7 @@ void W3DTruckDrawModuleData::buildFieldParse(MultiIniFieldParse& p)
 
 		{ nullptr, nullptr, nullptr, 0 }
 	};
-  p.add(dataFieldParse);
+	p.add(dataFieldParse);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/FlatHeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/FlatHeightMap.cpp
@@ -499,41 +499,41 @@ void FlatHeightMapRenderObjClass::Render(RenderInfoClass & rinfo)
 	DX8Wrapper::Set_Material(m_vertexMaterialClass);
 	DX8Wrapper::Set_Shader(m_shaderClass);
 
- 	st=W3DShaderManager::ST_FLAT_TERRAIN_BASE; //set default shader
+	st=W3DShaderManager::ST_FLAT_TERRAIN_BASE; //set default shader
 
- 	//set correct shader based on current settings
- 	if (TheGlobalData->m_useLightMap && doCloud)
- 	{	st=W3DShaderManager::ST_FLAT_TERRAIN_BASE_NOISE12;
- 	}
- 	else
- 	if (TheGlobalData->m_useLightMap)
- 	{	//lightmap only
- 		st=W3DShaderManager::ST_FLAT_TERRAIN_BASE_NOISE2;
- 	}
- 	else
- 	if (doCloud)
- 	{	//cloudmap only
- 		st=W3DShaderManager::ST_FLAT_TERRAIN_BASE_NOISE1;
- 	}
+	//set correct shader based on current settings
+	if (TheGlobalData->m_useLightMap && doCloud)
+	{	st=W3DShaderManager::ST_FLAT_TERRAIN_BASE_NOISE12;
+	}
+	else
+	if (TheGlobalData->m_useLightMap)
+	{	//lightmap only
+		st=W3DShaderManager::ST_FLAT_TERRAIN_BASE_NOISE2;
+	}
+	else
+	if (doCloud)
+	{	//cloudmap only
+		st=W3DShaderManager::ST_FLAT_TERRAIN_BASE_NOISE1;
+	}
 
 
 
 	//Find number of passes required to render current shader
- 	devicePasses=W3DShaderManager::getShaderPasses(st);
+	devicePasses=W3DShaderManager::getShaderPasses(st);
 
- 	if (m_disableTextures)
- 		devicePasses=1;	//force to 1 lighting-only pass
+	if (m_disableTextures)
+	devicePasses=1;	//force to 1 lighting-only pass
 
- 	//Specify all textures that this shader may need.
- 	W3DShaderManager::setTexture(0,m_stageZeroTexture);
+	//Specify all textures that this shader may need.
+	W3DShaderManager::setTexture(0,m_stageZeroTexture);
 	if (m_shroud && rinfo.Additional_Pass_Count() && !m_disableTextures)
 	{
 		W3DShaderManager::setTexture(0,TheTerrainRenderObject->getShroud()->getShroudTexture());
 	}
 
- 	W3DShaderManager::setTexture(1,nullptr);	// Set by the tile later. [3/31/2003]
- 	W3DShaderManager::setTexture(2,m_stageTwoTexture);	//cloud
- 	W3DShaderManager::setTexture(3,m_stageThreeTexture);//noise
+	W3DShaderManager::setTexture(1,nullptr);	// Set by the tile later. [3/31/2003]
+	W3DShaderManager::setTexture(2,m_stageTwoTexture);	//cloud
+	W3DShaderManager::setTexture(3,m_stageThreeTexture);//noise
 	//Disable writes to destination alpha channel (if there is one)
 	if (DX8Wrapper::getBackBufferFormat() == WW3D_FORMAT_A8R8G8B8) {
 		DX8Wrapper::Set_DX8_Render_State(D3DRS_COLORWRITEENABLE,D3DCOLORWRITEENABLE_BLUE|D3DCOLORWRITEENABLE_GREEN|D3DCOLORWRITEENABLE_RED);
@@ -544,7 +544,7 @@ void FlatHeightMapRenderObjClass::Render(RenderInfoClass & rinfo)
 	Int yCoordMin = m_map->getXExtent();
 	Int xCoordMax = 0;
 	Int xCoordMin = m_map->getYExtent();
- 	for (pass=0; pass<devicePasses; pass++) {
+	for (pass=0; pass<devicePasses; pass++) {
 		Bool disableTex = m_disableTextures;
 		if (m_disableTextures ) {
 			DX8Wrapper::Set_Shader(ShaderClass::_PresetOpaque2DShader);
@@ -580,7 +580,7 @@ void FlatHeightMapRenderObjClass::Render(RenderInfoClass & rinfo)
 	}
 
 	if (pass)	//shader was applied at least once?
- 		W3DShaderManager::resetShader(st);
+	W3DShaderManager::resetShader(st);
 #if 1
 
 	//Draw feathered shorelines

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/HeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/HeightMap.cpp
@@ -899,7 +899,7 @@ void HeightMapRenderObjClass::doPartialUpdate(const IRegion2D &partialRange, Wor
 
 		if (minY> m_y-1) {
 			minY -= m_y-1;
- 			maxY -= m_y-1;
+			maxY -= m_y-1;
 		}
 		if (maxY > m_y-1) {
 			maxY -= m_y-1;
@@ -1184,7 +1184,7 @@ void HeightMapRenderObjClass::oversizeTerrain(Int tilesToOversize)
 	}
 	Int dx = width-m_map->getDrawWidth();
 	Int dy = height-m_map->getDrawHeight();
- 	m_map->setDrawWidth(width);
+	m_map->setDrawWidth(width);
 	m_map->setDrawHeight(height);
 	dx /= 2;
 	dy /= 2;
@@ -1647,7 +1647,7 @@ void HeightMapRenderObjClass::updateCenter(CameraClass *camera , RefRenderObjLis
 
 	m_updating = true;
 	if (m_needFullUpdate)
-  {
+	{
 		m_needFullUpdate = false;
 		updateBlock(0, 0, m_x-1, m_y-1, m_map, pLightsIterator);
 		m_updating = false;
@@ -1655,7 +1655,7 @@ void HeightMapRenderObjClass::updateCenter(CameraClass *camera , RefRenderObjLis
 	}
 
 	if (m_x >= m_map->getXExtent() && m_y >= m_map->getYExtent())
-  {
+	{
 		m_updating = false;
 		return; // no need to center.
 	}
@@ -1956,57 +1956,57 @@ void HeightMapRenderObjClass::Render(RenderInfoClass & rinfo)
 		DX8Wrapper::Set_Material(m_vertexMaterialClass);
 		DX8Wrapper::Set_Shader(m_shaderClass);
 
- 		st=W3DShaderManager::ST_TERRAIN_BASE; //set default shader
+		st=W3DShaderManager::ST_TERRAIN_BASE; //set default shader
 
- 		//set correct shader based on current settings
- 		if (!ShaderClass::Is_Backface_Culling_Inverted())
- 		{	//not reflection pass
- 			if (TheGlobalData->m_useLightMap && doCloud)
- 			{	st=W3DShaderManager::ST_TERRAIN_BASE_NOISE12;
- 			}
- 			else
- 			if (TheGlobalData->m_useLightMap)
- 			{	//lightmap only
- 				st=W3DShaderManager::ST_TERRAIN_BASE_NOISE2;
- 			}
- 			else
- 			if (doCloud)
- 			{	//cloudmap only
- 				st=W3DShaderManager::ST_TERRAIN_BASE_NOISE1;
- 			}
- 		}
- 		else
- 		{	//reflection pass, just do base texture
- 			st=W3DShaderManager::ST_TERRAIN_BASE;
- 		}
+		//set correct shader based on current settings
+		if (!ShaderClass::Is_Backface_Culling_Inverted())
+		{	//not reflection pass
+			if (TheGlobalData->m_useLightMap && doCloud)
+			{	st=W3DShaderManager::ST_TERRAIN_BASE_NOISE12;
+			}
+			else
+			if (TheGlobalData->m_useLightMap)
+			{	//lightmap only
+				st=W3DShaderManager::ST_TERRAIN_BASE_NOISE2;
+			}
+			else
+			if (doCloud)
+			{	//cloudmap only
+				st=W3DShaderManager::ST_TERRAIN_BASE_NOISE1;
+			}
+		}
+		else
+		{	//reflection pass, just do base texture
+			st=W3DShaderManager::ST_TERRAIN_BASE;
+		}
 
- 		//Find number of passes required to render current shader
- 		devicePasses=W3DShaderManager::getShaderPasses(st);
+		//Find number of passes required to render current shader
+		devicePasses=W3DShaderManager::getShaderPasses(st);
 
- 		if (m_disableTextures)
- 			devicePasses=1;	//force to 1 lighting-only pass
+		if (m_disableTextures)
+		devicePasses=1;	//force to 1 lighting-only pass
 
- 		//Specify all textures that this shader may need.
- 		W3DShaderManager::setTexture(0,m_stageZeroTexture);
- 		W3DShaderManager::setTexture(1,m_stageZeroTexture);
- 		W3DShaderManager::setTexture(2,m_stageTwoTexture);	//cloud
- 		W3DShaderManager::setTexture(3,m_stageThreeTexture);//noise
+		//Specify all textures that this shader may need.
+		W3DShaderManager::setTexture(0,m_stageZeroTexture);
+		W3DShaderManager::setTexture(1,m_stageZeroTexture);
+		W3DShaderManager::setTexture(2,m_stageTwoTexture);	//cloud
+		W3DShaderManager::setTexture(3,m_stageThreeTexture);//noise
 		//Disable writes to destination alpha channel (if there is one)
 		if (DX8Wrapper::getBackBufferFormat() == WW3D_FORMAT_A8R8G8B8)
 			DX8Wrapper::Set_DX8_Render_State(D3DRS_COLORWRITEENABLE,D3DCOLORWRITEENABLE_BLUE|D3DCOLORWRITEENABLE_GREEN|D3DCOLORWRITEENABLE_RED);
 	}
 
 	Int pass;
- 	for (pass=0; pass<devicePasses; pass++) {
+	for (pass=0; pass<devicePasses; pass++) {
 #ifdef TIMING_TESTS
 #endif
 		if (!doMultiPassWireFrame)	//multi-pass wireframe doesn't use regular shaders.
 		{
- 			if (m_disableTextures ) {
- 				DX8Wrapper::Set_Shader(ShaderClass::_PresetOpaque2DShader);
- 				DX8Wrapper::Set_Texture(0,nullptr);
-   			} else {
- 				W3DShaderManager::setShader(st, pass);
+			if (m_disableTextures ) {
+				DX8Wrapper::Set_Shader(ShaderClass::_PresetOpaque2DShader);
+				DX8Wrapper::Set_Texture(0,nullptr);
+			} else {
+				W3DShaderManager::setShader(st, pass);
 			}
 		}
 
@@ -2041,7 +2041,7 @@ void HeightMapRenderObjClass::Render(RenderInfoClass & rinfo)
 	if (!doMultiPassWireFrame)
 	{
 		if (pass)	//shader was applied at least once?
- 			W3DShaderManager::resetShader(st);
+		W3DShaderManager::resetShader(st);
 
 		//Draw feathered shorelines
 		renderShoreLines(&rinfo.Camera);
@@ -2115,8 +2115,8 @@ void HeightMapRenderObjClass::Render(RenderInfoClass & rinfo)
 	else
 			m_bridgeBuffer->drawBridges(&rinfo.Camera, m_disableTextures, m_stageTwoTexture);
 
-  if ( m_waypointBuffer )
-	  m_waypointBuffer->drawWaypoints(rinfo);
+	if ( m_waypointBuffer )
+	m_waypointBuffer->drawWaypoints(rinfo);
 
 	m_bibBuffer->renderBibs();
 
@@ -2351,17 +2351,17 @@ void HeightMapRenderObjClass::renderExtraBlendTiles()
 			const Bool doCloud = useCloud();
 
 			if (TheGlobalData->m_useLightMap && doCloud)
- 			{
+			{
 				st = W3DShaderManager::ST_ROAD_BASE_NOISE12;
- 			}
- 			else if (TheGlobalData->m_useLightMap)
- 			{	//lightmap only
- 				st = W3DShaderManager::ST_ROAD_BASE_NOISE2;
- 			}
- 			else if (doCloud)
- 			{	//cloudmap only
- 				st = W3DShaderManager::ST_ROAD_BASE_NOISE1;
- 			}
+			}
+			else if (TheGlobalData->m_useLightMap)
+			{	//lightmap only
+				st = W3DShaderManager::ST_ROAD_BASE_NOISE2;
+			}
+			else if (doCloud)
+			{	//cloudmap only
+				st = W3DShaderManager::ST_ROAD_BASE_NOISE1;
+			}
 
 			Int devicePasses=W3DShaderManager::getShaderPasses(st);
 
@@ -2375,6 +2375,6 @@ void HeightMapRenderObjClass::renderExtraBlendTiles()
 			}
 			W3DShaderManager::resetShader(st);
 		}
-  }
+	}
 }
 #endif

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/TerrainTex.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/TerrainTex.cpp
@@ -327,7 +327,7 @@ int TerrainTextureClass::update(WorldHeightMap *htMap)
 				}
 			}
 		}
- 		for (cellY = 0; cellY < numRows; cellY++) {
+		for (cellY = 0; cellY < numRows; cellY++) {
 			Int rowBytes = surface_desc.Width*pixelBytes;
 			Int row = cellY*tilePixelExtent;
 			row += TILE_OFFSET/2;
@@ -620,7 +620,7 @@ void AlphaTerrainTextureClass::Apply(unsigned int stage)
 		}
 		else
 		{
-  			DX8Wrapper::Set_DX8_Texture_Stage_State( 0, D3DTSS_COLORARG1, D3DTA_TEXTURE );
+			DX8Wrapper::Set_DX8_Texture_Stage_State( 0, D3DTSS_COLORARG1, D3DTA_TEXTURE );
 			DX8Wrapper::Set_DX8_Texture_Stage_State( 0, D3DTSS_COLOROP,   D3DTOP_SELECTARG1 );
 			DX8Wrapper::Set_DX8_Texture_Stage_State( 0, D3DTSS_ALPHAARG1, D3DTA_TEXTURE );
 			DX8Wrapper::Set_DX8_Texture_Stage_State( 0, D3DTSS_ALPHAOP,   D3DTOP_SELECTARG1 );

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DPropBuffer.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DPropBuffer.cpp
@@ -343,8 +343,8 @@ void W3DPropBuffer::drawProps(RenderInfoClass &rinfo)
 	{
 			m_light->Set_Ambient(zeroVector);
 			m_light->Set_Diffuse(Vector3(objectLighting[i].diffuse.red,
-																		 objectLighting[i].diffuse.green,
-																		 objectLighting[i].diffuse.blue));
+			objectLighting[i].diffuse.green,
+			objectLighting[i].diffuse.blue));
 			m_light->Set_Specular(zeroVector);
 			mtx.Set(xVector, yVector, Vector3(objectLighting[i].lightPos.x, objectLighting[i].lightPos.y, objectLighting[i].lightPos.z), zeroVector);
 			m_light->Set_Transform(mtx);

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DShaderManager.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DShaderManager.cpp
@@ -85,7 +85,7 @@ class W3DShaderInterface
 public:
 	Int getNumPasses() {return m_numPasses;};	///<return number of passes needed for this shader
 	virtual Int set(Int pass) {return TRUE;};		///<setup shader for the specified rendering pass.
-	 ///do any custom resetting necessary to bring W3D in sync.
+	///do any custom resetting necessary to bring W3D in sync.
 	virtual void reset() {
 		ShaderClass::Invalidate();
 		DX8Wrapper::_Get_D3D_Device8()->SetTexture(0, nullptr);
@@ -2946,9 +2946,9 @@ ChipsetType W3DShaderManager::getChipset()
 				return DC_TNT2;
 
 			if ( (did.DeviceId >= 0x100 && did.DeviceId <= 0x103) ||	//GeForce
-				 (did.DeviceId >= 0x110 && did.DeviceId <= 0x113) ||	//GeForce2 MX
-						 (did.DeviceId >= 0x150 && did.DeviceId <= 0x153) )	//GeForce2
-           		return DC_GEFORCE2;
+				(did.DeviceId >= 0x110 && did.DeviceId <= 0x113) ||	//GeForce2 MX
+				(did.DeviceId >= 0x150 && did.DeviceId <= 0x153) )	//GeForce2
+			return DC_GEFORCE2;
 
 			if (did.DeviceId >= 0x200 && did.DeviceId < 0x250)
 				return DC_GEFORCE3;
@@ -3155,22 +3155,22 @@ void add(float *sum,float *addend)
 Real W3DShaderManager::GetCPUBenchTime()
 {
 	float ztot, yran, ymult, ymod, x, y, z, pi, prod;
-    long int low, ixran, itot, j, iprod;
+	long int low, ixran, itot, j, iprod;
 
-  	__int64 endTime64,freq64,startTime64;
+	__int64 endTime64,freq64,startTime64;
 	QueryPerformanceFrequency((LARGE_INTEGER *)&freq64);
 	QueryPerformanceCounter((LARGE_INTEGER *)&startTime64);
 
-    ztot = 0.0;
-    low = 1;
-    ixran = 1907;
-    yran = 5813.0;
-    ymult = 1307.0;
-    ymod = 5471.0;
-    itot = 560000;	//total iterations. This value ends up running at ~30 fps on our P4-2.2Ghz.
+	ztot = 0.0;
+	low = 1;
+	ixran = 1907;
+	yran = 5813.0;
+	ymult = 1307.0;
+	ymod = 5471.0;
+	itot = 560000;	//total iterations. This value ends up running at ~30 fps on our P4-2.2Ghz.
 
-    for(j=1; j<=itot; j++)
-    {
+	for(j=1; j<=itot; j++)
+	{
 		iprod = 27611 * ixran;
 		ixran = iprod - 74383*(long int)(iprod/74383);
 		x = (float)ixran / 74383.0;
@@ -3181,7 +3181,7 @@ Real W3DShaderManager::GetCPUBenchTime()
 		add(&ztot,&z);
 		if ( z <= 1.0 )
 		{
-		  low = low + 1;
+			low = low + 1;
 		}
 	}
 	pi = 4.0 * (float)low/(float)itot;

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DSmudge.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DSmudge.cpp
@@ -132,24 +132,24 @@ void W3DSmudgeManager::ReAcquireResources()
 /*Copies a portion of the current render target into a specified buffer*/
 Int copyRect(unsigned char *buf, Int bufSize, int oX, int oY, int width, int height)
 {
- 	IDirect3DSurface8 *surface=nullptr;	///<previous render target
- 	IDirect3DSurface8 *tempSurface=nullptr;
+	IDirect3DSurface8 *surface=nullptr;	///<previous render target
+	IDirect3DSurface8 *tempSurface=nullptr;
 	Int result = 0;
 	HRESULT hr = S_OK;
 
- 	LPDIRECT3DDEVICE8 m_pDev=DX8Wrapper::_Get_D3D_Device8();
+	LPDIRECT3DDEVICE8 m_pDev=DX8Wrapper::_Get_D3D_Device8();
 
 	if (!m_pDev)
 		goto error;
 
- 	m_pDev->GetRenderTarget(&surface);
+	m_pDev->GetRenderTarget(&surface);
 
 	if (!surface)
 		goto error;
 
- 	D3DSURFACE_DESC desc;
+	D3DSURFACE_DESC desc;
 
- 	surface->GetDesc(&desc);
+	surface->GetDesc(&desc);
 
 	RECT srcRect;
 	srcRect.left=oX;
@@ -161,24 +161,24 @@ Int copyRect(unsigned char *buf, Int bufSize, int oX, int oY, int width, int hei
 	dstPoint.x=0;
 	dstPoint.y=0;
 
- 	hr=m_pDev->CreateImageSurface(  width, height, desc.Format, &tempSurface);
+	hr=m_pDev->CreateImageSurface(  width, height, desc.Format, &tempSurface);
 
 	if (hr != S_OK)
 		goto error;
 
- 	hr=m_pDev->CopyRects(surface,&srcRect,1,tempSurface,&dstPoint);
+	hr=m_pDev->CopyRects(surface,&srcRect,1,tempSurface,&dstPoint);
 
 	if (hr != S_OK)
 		goto error;
 
- 	D3DLOCKED_RECT lrect;
+	D3DLOCKED_RECT lrect;
 
- 	hr=tempSurface->LockRect(&lrect,nullptr,D3DLOCK_READONLY);
+	hr=tempSurface->LockRect(&lrect,nullptr,D3DLOCK_READONLY);
 
 	if (hr != S_OK)
 		goto error;
 
- 	tempSurface->GetDesc(&desc);
+	tempSurface->GetDesc(&desc);
 
 	if (desc.Size < bufSize)
 		bufSize = desc.Size;

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DSnow.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DSnow.cpp
@@ -34,7 +34,7 @@
 
 struct POINTVERTEX
 {
-    Vector3 v;	//center of particle.
+	Vector3 v;	//center of particle.
 };
 
 W3DSnowManager::W3DSnowManager()
@@ -348,14 +348,14 @@ void W3DSnowManager::render(RenderInfoClass &rinfo)
 	Int cubeDimX=cubeCenterX + mumEmittersInHalf;		//bottom/right extents.
 	Int cubeDimY=cubeCenterY + mumEmittersInHalf;
 
- 	const FrustumClass & frustum = rinfo.Camera.Get_Frustum();
+	const FrustumClass & frustum = rinfo.Camera.Get_Frustum();
 	AABoxClass bbox;
 
 	//Get a bounding box around our visible universe.  Bounded by terrain and the sky
 	//so much tighter fitting volume than what's actually visible.  This will cull
 	//particles falling under the ground.
 
- 	TheTerrainRenderObject->getMaximumVisibleBox(frustum, &bbox, TRUE);
+	TheTerrainRenderObject->getMaximumVisibleBox(frustum, &bbox, TRUE);
 
 	//Particles move outside the visible box as a result of local sine movement
 	//so adjust bounding box to include them.
@@ -419,18 +419,18 @@ void W3DSnowManager::render(RenderInfoClass &rinfo)
 
 	DX8Wrapper::Apply_Render_State_Changes();
 
-    // Set the render states for using point sprites
+	// Set the render states for using point sprites
 	DX8Wrapper::Set_DX8_Render_State( D3DRS_POINTSPRITEENABLE, TRUE );
-    DX8Wrapper::Set_DX8_Render_State( D3DRS_POINTSCALEENABLE,  TRUE );
-    DX8Wrapper::Set_DX8_Render_State( D3DRS_POINTSIZE,     FtoDW(m_pointSize) );
-    DX8Wrapper::Set_DX8_Render_State( D3DRS_POINTSIZE_MIN, FtoDW(m_minPointSize) );
-    DX8Wrapper::Set_DX8_Render_State( D3DRS_POINTSIZE_MAX, FtoDW(m_maxPointSize) );
-    DX8Wrapper::Set_DX8_Render_State( D3DRS_POINTSCALE_A,  FtoDW(0.00f) );
-    DX8Wrapper::Set_DX8_Render_State( D3DRS_POINTSCALE_B,  FtoDW(0.00f) );
-    DX8Wrapper::Set_DX8_Render_State( D3DRS_POINTSCALE_C,  FtoDW(1.00f) );
+	DX8Wrapper::Set_DX8_Render_State( D3DRS_POINTSCALEENABLE,  TRUE );
+	DX8Wrapper::Set_DX8_Render_State( D3DRS_POINTSIZE,     FtoDW(m_pointSize) );
+	DX8Wrapper::Set_DX8_Render_State( D3DRS_POINTSIZE_MIN, FtoDW(m_minPointSize) );
+	DX8Wrapper::Set_DX8_Render_State( D3DRS_POINTSIZE_MAX, FtoDW(m_maxPointSize) );
+	DX8Wrapper::Set_DX8_Render_State( D3DRS_POINTSCALE_A,  FtoDW(0.00f) );
+	DX8Wrapper::Set_DX8_Render_State( D3DRS_POINTSCALE_B,  FtoDW(0.00f) );
+	DX8Wrapper::Set_DX8_Render_State( D3DRS_POINTSCALE_C,  FtoDW(1.00f) );
 
 	DX8Wrapper::_Get_D3D_Device8()->SetStreamSource( 0, m_VertexBufferD3D, sizeof(POINTVERTEX) );
-    DX8Wrapper::_Get_D3D_Device8()->SetVertexShader( D3DFVF_POINTVERTEX );
+	DX8Wrapper::_Get_D3D_Device8()->SetVertexShader( D3DFVF_POINTVERTEX );
 	m_dwBase = SNOW_BUFFER_SIZE;	//start with a new vertex buffer each frame.
 
 	m_leafDim = 45;	//cull boxes that are 20x20 emitters in size. Making them much smaller will result in too many draw calls.
@@ -442,8 +442,8 @@ void W3DSnowManager::render(RenderInfoClass &rinfo)
 	renderSubBox(rinfo,cubeOriginX,cubeOriginY,cubeDimX,cubeDimY);
 
 	// Reset render states
-    DX8Wrapper::Set_DX8_Render_State( D3DRS_POINTSPRITEENABLE, FALSE );
-    DX8Wrapper::Set_DX8_Render_State( D3DRS_POINTSCALEENABLE,  FALSE );
+	DX8Wrapper::Set_DX8_Render_State( D3DRS_POINTSPRITEENABLE, FALSE );
+	DX8Wrapper::Set_DX8_Render_State( D3DRS_POINTSCALEENABLE,  FALSE );
 
 }
 

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTerrainBackground.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTerrainBackground.cpp
@@ -276,7 +276,7 @@ Bool W3DTerrainBackground::advanceRight(ICoord2D &right, Int xOffset, Int yOffse
 /** Fills in vertex & index buffers.
 */
 void W3DTerrainBackground::fillVBRecursive(UnsignedShort *ib, Int xOffset, Int yOffset,
-																					 Int width, UnsignedShort *ndx, Int &curIndex)
+	Int width, UnsignedShort *ndx, Int &curIndex)
 {
 
 	Int bottomLeftNdx	= ndx[xOffset+yOffset*(m_width+1)];
@@ -765,7 +765,7 @@ void W3DTerrainBackground::drawVisiblePolys(RenderInfoClass & rinfo, Bool disabl
 	// Setup the vertex buffer, shader & texture.
 	DX8Wrapper::Set_Index_Buffer(m_indexTerrain,0);
 	DX8Wrapper::Set_Vertex_Buffer(m_vertexTerrain);
-  if (!disableTextures) {
+	if (!disableTextures) {
 		if (m_terrainTexture4X) {
 			DX8Wrapper::Set_Texture(1, m_terrainTexture4X);
 		}	else if (m_terrainTexture2X) {
@@ -785,7 +785,7 @@ void W3DTerrainBackground::drawVisiblePolys(RenderInfoClass & rinfo, Bool disabl
 	// Setup the vertex buffer, shader & texture.
 	DX8Wrapper::Set_Index_Buffer(m_indexTerrain,0);
 	DX8Wrapper::Set_Vertex_Buffer(m_vertexTerrain);
-  if (!disableTextures) {
+	if (!disableTextures) {
 		if (m_terrainTexture4X) {
 			DX8Wrapper::Set_Texture(0, m_terrainTexture4X);
 		}	else if (m_terrainTexture2X) {

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTerrainVisual.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTerrainVisual.cpp
@@ -69,83 +69,83 @@
 class TestSeismicFilter : public SeismicSimulationFilterBase
 {
 
-  virtual SeismicSimStatusCode filterCallback( WorldHeightMapInterfaceClass *heightMap, const SeismicSimulationNode *node ) override
-  {
+	virtual SeismicSimStatusCode filterCallback( WorldHeightMapInterfaceClass *heightMap, const SeismicSimulationNode *node ) override
+	{
 
 
-    Int life = node->m_life;
+		Int life = node->m_life;
 
-    if ( heightMap == nullptr )
-      return SEISMIC_STATUS_INVALID;
-
-
-    if ( life == 0 )
-      return SEISMIC_STATUS_ACTIVE;
-    if ( life < 15 )
-    {
-      // ADD HEIGHT BECAUSE THE EXPLOSION IS PUSHING DIRT UP
-
-      Real magnitude = node->m_magnitude;
-
-      Real offsScalar =  magnitude / (Real)life; // real-life, get it?
-      Int radius = node->m_radius;
-      Int border = heightMap->getBorderSize();
-      Int centerX = node->m_center.x + border ;
-      Int centerY = node->m_center.y + border ;
-
-      UnsignedInt workspaceWidth = radius*2;
-      Real *workspace = NEW Real[ sqr(workspaceWidth) ];
-      Real *workspaceEnd = workspace + sqr(workspaceWidth);
+		if ( heightMap == nullptr )
+		return SEISMIC_STATUS_INVALID;
 
 
-      for ( Real *t = workspace; t < workspaceEnd; ++t ) *t = 0.0f;// clear the workspace
+		if ( life == 0 )
+		return SEISMIC_STATUS_ACTIVE;
+		if ( life < 15 )
+		{
+			// ADD HEIGHT BECAUSE THE EXPLOSION IS PUSHING DIRT UP
 
-      Int x = 0;
-      for (; x < radius; ++x)
-      {
-        for (Int y = 0; y < radius; ++y)
-        {
+			Real magnitude = node->m_magnitude;
 
-          Real distance = sqrt( sqr(x) + sqr(y) );//Pythagoras
+			Real offsScalar =  magnitude / (Real)life; // real-life, get it?
+			Int radius = node->m_radius;
+			Int border = heightMap->getBorderSize();
+			Int centerX = node->m_center.x + border ;
+			Int centerY = node->m_center.y + border ;
 
-          if ( distance < radius )
-          {
-            Real distScalar = cos( ( distance / radius * (PI/2) ) );
-            Real height = (offsScalar * distScalar);
+			UnsignedInt workspaceWidth = radius*2;
+			Real *workspace = NEW Real[ sqr(workspaceWidth) ];
+			Real *workspaceEnd = workspace + sqr(workspaceWidth);
 
-            workspace[ (radius + x) +  workspaceWidth * (radius + y) ] = height + heightMap->getBilinearSampleSeismicZVelocity( centerX + x,  centerY + y ) ;//kaleidoscope
 
-            if ( x != 0 ) // non-zero test prevents cross-shaped double stamp
-            {
-      			  workspace[ (radius - x) + workspaceWidth * (radius + y) ] = height + heightMap->getBilinearSampleSeismicZVelocity( centerX - x,  centerY + y ) ;
-              if ( y != 0 )
-                workspace[ (radius - x) + workspaceWidth * (radius - y) ] =  height + heightMap->getBilinearSampleSeismicZVelocity( centerX - x,  centerY - y ) ;
-            }
-            if ( y != 0 )
-      			  workspace[ (radius + x) + workspaceWidth * (radius - y) ] = height + heightMap->getBilinearSampleSeismicZVelocity( centerX + x,  centerY - y ) ;
-          }
-        }
-      }
+			for ( Real *t = workspace; t < workspaceEnd; ++t ) *t = 0.0f;// clear the workspace
 
-      // stuff the values from the workspace into the heightmap's velocities
-      for (x = 0; x < workspaceWidth; ++x)
-        for (Int y = 0; y < workspaceWidth; ++y)
-    			heightMap->setSeismicZVelocity( centerX - radius + x, centerY - radius + y,  workspace[  x + workspaceWidth * y ]  );
+			Int x = 0;
+			for (; x < radius; ++x)
+			{
+				for (Int y = 0; y < radius; ++y)
+				{
 
-      delete [] workspace;
+					Real distance = sqrt( sqr(x) + sqr(y) );//Pythagoras
 
-      return SEISMIC_STATUS_ACTIVE;
-    }
-    else
-      return SEISMIC_STATUS_ZERO_ENERGY;
-  }
+					if ( distance < radius )
+					{
+						Real distScalar = cos( ( distance / radius * (PI/2) ) );
+						Real height = (offsScalar * distScalar);
 
-  virtual Real applyGravityCallback( Real velocityIn ) override
-  {
-    Real velocityOut = velocityIn;
-    velocityOut -= 1.5f;
-    return velocityOut;
-  }
+						workspace[ (radius + x) +  workspaceWidth * (radius + y) ] = height + heightMap->getBilinearSampleSeismicZVelocity( centerX + x,  centerY + y ) ;//kaleidoscope
+
+						if ( x != 0 ) // non-zero test prevents cross-shaped double stamp
+						{
+							workspace[ (radius - x) + workspaceWidth * (radius + y) ] = height + heightMap->getBilinearSampleSeismicZVelocity( centerX - x,  centerY + y ) ;
+							if ( y != 0 )
+							workspace[ (radius - x) + workspaceWidth * (radius - y) ] =  height + heightMap->getBilinearSampleSeismicZVelocity( centerX - x,  centerY - y ) ;
+						}
+						if ( y != 0 )
+						workspace[ (radius + x) + workspaceWidth * (radius - y) ] = height + heightMap->getBilinearSampleSeismicZVelocity( centerX + x,  centerY - y ) ;
+					}
+				}
+			}
+
+			// stuff the values from the workspace into the heightmap's velocities
+			for (x = 0; x < workspaceWidth; ++x)
+			for (Int y = 0; y < workspaceWidth; ++y)
+			heightMap->setSeismicZVelocity( centerX - radius + x, centerY - radius + y,  workspace[  x + workspaceWidth * y ]  );
+
+			delete [] workspace;
+
+			return SEISMIC_STATUS_ACTIVE;
+		}
+		else
+		return SEISMIC_STATUS_ZERO_ENERGY;
+	}
+
+	virtual Real applyGravityCallback( Real velocityIn ) override
+	{
+		Real velocityOut = velocityIn;
+		velocityOut -= 1.5f;
+		return velocityOut;
+	}
 
 
 };
@@ -163,10 +163,10 @@ W3DTerrainVisual::W3DTerrainVisual()
 	m_waterRenderObject = nullptr;
 	TheWaterRenderObj = nullptr;
 
-  m_logicHeightMap   = nullptr;
+	m_logicHeightMap   = nullptr;
 
 #ifdef DO_SEISMIC_SIMULATIONS
-  m_clientHeightMap = nullptr;
+	m_clientHeightMap = nullptr;
 #endif
 
 }
@@ -195,7 +195,7 @@ W3DTerrainVisual::~W3DTerrainVisual()
 	REF_PTR_RELEASE( m_logicHeightMap );
 
 #ifdef DO_SEISMIC_SIMULATIONS
-  REF_PTR_RELEASE( m_clientHeightMap );
+	REF_PTR_RELEASE( m_clientHeightMap );
 #endif
 }
 
@@ -220,7 +220,7 @@ void W3DTerrainVisual::init()
 
 		// initialize object shadow drawing system
 		TheW3DShadowManager = NEW W3DShadowManager;
- 		TheW3DShadowManager->init();
+		TheW3DShadowManager->init();
 
 		// create a water plane render object
 		TheWaterRenderObj=m_waterRenderObject = NEW_REF( WaterRenderObjClass, () );
@@ -236,7 +236,7 @@ void W3DTerrainVisual::init()
 #else
 		if (TheGlobalData->m_waterType == WaterRenderObjClass::WATER_TYPE_1_FB_REFLECTION)
 		{	// add water render object to the pre-pass scene (to be rendered before main scene)
- 			//W3DDisplay::m_prePass3DScene->Add_Render_Object( m_waterRenderObject);
+			//W3DDisplay::m_prePass3DScene->Add_Render_Object( m_waterRenderObject);
 		}
 		else
 		{	// add water render object to the post-pass scene (to be rendered after main scene)
@@ -255,10 +255,10 @@ void W3DTerrainVisual::init()
 																							TheGlobalData->m_vertexWaterHeightClampLow[ waterSettingIndex ],
 																							TheGlobalData->m_vertexWaterHeightClampHi[ waterSettingIndex ] );
 	TheTerrainVisual->setWaterTransform( nullptr,
-																			 TheGlobalData->m_vertexWaterAngle[ waterSettingIndex ],
-																			 TheGlobalData->m_vertexWaterXPosition[ waterSettingIndex ],
-																			 TheGlobalData->m_vertexWaterYPosition[ waterSettingIndex ],
-																			 TheGlobalData->m_vertexWaterZPosition[ waterSettingIndex ] );
+		TheGlobalData->m_vertexWaterAngle[ waterSettingIndex ],
+		TheGlobalData->m_vertexWaterXPosition[ waterSettingIndex ],
+		TheGlobalData->m_vertexWaterYPosition[ waterSettingIndex ],
+		TheGlobalData->m_vertexWaterZPosition[ waterSettingIndex ] );
 	TheTerrainVisual->setWaterGridResolution( nullptr,
 																						TheGlobalData->m_vertexWaterXGridCells[ waterSettingIndex ],
 																						TheGlobalData->m_vertexWaterYGridCells[ waterSettingIndex ],
@@ -271,7 +271,7 @@ void W3DTerrainVisual::init()
 	m_isWaterGridRenderingEnabled = FALSE;
 
 #ifdef DO_SEISMIC_SIMULATIONS
-  m_seismicSimulationList.clear();
+	m_seismicSimulationList.clear();
 #endif
 
 }
@@ -313,7 +313,7 @@ void W3DTerrainVisual::reset()
 	}
 
 #ifdef DO_SEISMIC_SIMULATIONS
-  m_seismicSimulationList.clear();
+	m_seismicSimulationList.clear();
 #endif
 
 }
@@ -328,7 +328,7 @@ void W3DTerrainVisual::update()
 	TerrainVisual::update();
 
 #ifdef DO_SEISMIC_SIMULATIONS
-  handleSeismicSimulations();
+	handleSeismicSimulations();
 #endif
 	// if we have a water render object, it has an update method
 	if( m_waterRenderObject )
@@ -341,108 +341,108 @@ void W3DTerrainVisual::update()
 
 void W3DTerrainVisual::addSeismicSimulation( const SeismicSimulationNode& sim )
 {
-    // HERE WOULD BE A GREAT PLACE FOR AN IDIOT TEST:
-  // REJECT SIMULATION NODES THAT ARE OFF SCREEN!!!!!!!!!!
-    // HERE WOULD BE A GREAT PLACE FOR AN IDIOT TEST:
-  // REJECT SIMULATION NODES THAT ARE OFF SCREEN!!!!!!!!!!
+	// HERE WOULD BE A GREAT PLACE FOR AN IDIOT TEST:
+	// REJECT SIMULATION NODES THAT ARE OFF SCREEN!!!!!!!!!!
+	// HERE WOULD BE A GREAT PLACE FOR AN IDIOT TEST:
+	// REJECT SIMULATION NODES THAT ARE OFF SCREEN!!!!!!!!!!
 
 
-  m_seismicSimulationList.push_back( sim );
+	m_seismicSimulationList.push_back( sim );
 }
 
 
 
 void W3DTerrainVisual::handleSeismicSimulations()
 {
-  if ( ! m_clientHeightMap || ! m_logicHeightMap || ! m_terrainRenderObject )
-    return;
+	if ( ! m_clientHeightMap || ! m_logicHeightMap || ! m_terrainRenderObject )
+	return;
 
 
-  if ( ! m_seismicSimulationList.empty() )
-  {
-    SeismicSimulationListIt it = m_seismicSimulationList.begin();
+	if ( ! m_seismicSimulationList.empty() )
+	{
+		SeismicSimulationListIt it = m_seismicSimulationList.begin();
 
 
-    m_clientHeightMap->clearSeismicUpdateFlags();
+		m_clientHeightMap->clearSeismicUpdateFlags();
 
 
-    while ( it != m_seismicSimulationList.end() )
-	  {
-      SeismicSimulationNode *ssn = &*it;
+		while ( it != m_seismicSimulationList.end() )
+		{
+			SeismicSimulationNode *ssn = &*it;
 
-      if ( ssn )
-      {
-        SeismicSimulationFilterBase::SeismicSimStatusCode code = ssn->handleFilterCallback( m_clientHeightMap );
-        DEBUG_ASSERTCRASH( code != SeismicSimulationFilterBase::SEISMIC_STATUS_INVALID, ("Trouble in the Seismic simulator.") );
+			if ( ssn )
+			{
+				SeismicSimulationFilterBase::SeismicSimStatusCode code = ssn->handleFilterCallback( m_clientHeightMap );
+				DEBUG_ASSERTCRASH( code != SeismicSimulationFilterBase::SEISMIC_STATUS_INVALID, ("Trouble in the Seismic simulator.") );
 
-        switch ( code )
-        {
-          case SeismicSimulationFilterBase::SEISMIC_STATUS_ACTIVE:
-          {
-        	  break;
-          }
-          case SeismicSimulationFilterBase::SEISMIC_STATUS_ZERO_ENERGY:
-          {
-        	  break;
-          }
-        }
+				switch ( code )
+				{
+					case SeismicSimulationFilterBase::SEISMIC_STATUS_ACTIVE:
+					{
+						break;
+					}
+					case SeismicSimulationFilterBase::SEISMIC_STATUS_ZERO_ENERGY:
+					{
+						break;
+					}
+				}
 
-        Int border = m_clientHeightMap->getBorderSizeInline();
+				Int border = m_clientHeightMap->getBorderSizeInline();
 
-        // Now we apply some gravity to the dirt, so it falls back to its "original" height
-        UnsignedInt fallCount = 0;
-        for (Int x = border+ssn->m_region.lo.x; x < border+ssn->m_region.hi.x; ++x)
-        {
-          for (Int y = border+ssn->m_region.lo.y; y < border+ssn->m_region.hi.y; ++y)
-          {
-            if ( ! m_clientHeightMap->getSeismicUpdateFlag( x, y ) )
-            {
-              UnsignedByte heightOfOriginal = m_logicHeightMap->getHeight( x, y ); // LOGIC, YES DEFINITELY THE LOGIC
+				// Now we apply some gravity to the dirt, so it falls back to its "original" height
+				UnsignedInt fallCount = 0;
+				for (Int x = border+ssn->m_region.lo.x; x < border+ssn->m_region.hi.x; ++x)
+				{
+					for (Int y = border+ssn->m_region.lo.y; y < border+ssn->m_region.hi.y; ++y)
+					{
+						if ( ! m_clientHeightMap->getSeismicUpdateFlag( x, y ) )
+						{
+							UnsignedByte heightOfOriginal = m_logicHeightMap->getHeight( x, y ); // LOGIC, YES DEFINITELY THE LOGIC
 
-              Real oldSpeed = m_clientHeightMap->getSeismicZVelocity( x, y );
-              Real newSpeed = ssn->applyGravity( oldSpeed );// - 0.5f;
+							Real oldSpeed = m_clientHeightMap->getSeismicZVelocity( x, y );
+							Real newSpeed = ssn->applyGravity( oldSpeed );// - 0.5f;
 
-              m_clientHeightMap->setSeismicZVelocity( x, y, newSpeed );
+							m_clientHeightMap->setSeismicZVelocity( x, y, newSpeed );
 
-              Int heightToUse = m_clientHeightMap->getHeight( x, y ) + newSpeed ;
+							Int heightToUse = m_clientHeightMap->getHeight( x, y ) + newSpeed ;
 
 
-              if (heightToUse <= heightOfOriginal)
-              {
-                heightToUse = heightOfOriginal;
-                m_clientHeightMap->setSeismicZVelocity( x, y, 0.0f ); //poof! the dirt hit ground level so stop "falling"
-              }
-              else
-              {
-                ++fallCount;
+							if (heightToUse <= heightOfOriginal)
+							{
+								heightToUse = heightOfOriginal;
+								m_clientHeightMap->setSeismicZVelocity( x, y, 0.0f ); //poof! the dirt hit ground level so stop "falling"
+							}
+							else
+							{
+								++fallCount;
 
-                if ( heightToUse > 255 )
-                  heightToUse = 255;
+								if ( heightToUse > 255 )
+								heightToUse = 255;
 
-              }
-    			    m_clientHeightMap->setRawHeight( x, y, heightToUse );
-              m_clientHeightMap->setSeismicUpdateFlag( x, y, TRUE );
-            }
+							}
+							m_clientHeightMap->setRawHeight( x, y, heightToUse );
+							m_clientHeightMap->setSeismicUpdateFlag( x, y, TRUE );
+						}
 
-          }
-        }
+					}
+				}
 
-        if ( fallCount == 0 )
-          ssn->m_clean = TRUE;
+				if ( fallCount == 0 )
+				ssn->m_clean = TRUE;
 
-      }
+			}
 
-      ++it;
+			++it;
 
-	  }
-  }
+		}
+	}
 
 }
 
-  ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-  ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-  ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-  ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 void W3DTerrainVisual::updateSeismicSimulations()
 {
 
@@ -452,59 +452,59 @@ void W3DTerrainVisual::updateSeismicSimulations()
 	if (m_clientHeightMap==nullptr)
 		return;
 
-  if (m_terrainRenderObject==nullptr)
-    return;
+	if (m_terrainRenderObject==nullptr)
+	return;
 
-  if ( ! m_seismicSimulationList.empty() )
-  {
-    SeismicSimulationListIt it = m_seismicSimulationList.begin();
+	if ( ! m_seismicSimulationList.empty() )
+	{
+		SeismicSimulationListIt it = m_seismicSimulationList.begin();
 
-    // First we run through the list and do our business for each region
+		// First we run through the list and do our business for each region
 
-	  while ( it != m_seismicSimulationList.end() )
-	  {
-      SeismicSimulationNode *hur = &*it;
-      if ( hur )
-      {
-        Int border = m_clientHeightMap->getBorderSizeInline();
+		while ( it != m_seismicSimulationList.end() )
+		{
+			SeismicSimulationNode *hur = &*it;
+			if ( hur )
+			{
+				Int border = m_clientHeightMap->getBorderSizeInline();
 
-		    TheTerrainRenderObject->updateBlock(
-          hur->m_region.lo.x + border,
-          hur->m_region.lo.y + border,
-          hur->m_region.hi.x + border,
-          hur->m_region.hi.y + border,
-          m_clientHeightMap,
-          0);
-      }
+				TheTerrainRenderObject->updateBlock(
+					hur->m_region.lo.x + border,
+					hur->m_region.lo.y + border,
+					hur->m_region.hi.x + border,
+					hur->m_region.hi.y + border,
+					m_clientHeightMap,
+					0);
+			}
 
-      ++it;
+			++it;
 
-	  }
-    // Then we check to see if these need to get erased from the list
-    it = m_seismicSimulationList.begin();
-	  while ( it != m_seismicSimulationList.end() )
-	  {
-      SeismicSimulationNode *hur = &*it;
-      if ( hur->m_clean )
-      {
-		    it = m_seismicSimulationList.erase( it );
-      }
-      else
-        ++it;
+		}
+		// Then we check to see if these need to get erased from the list
+		it = m_seismicSimulationList.begin();
+		while ( it != m_seismicSimulationList.end() )
+		{
+			SeismicSimulationNode *hur = &*it;
+			if ( hur->m_clean )
+			{
+				it = m_seismicSimulationList.erase( it );
+			}
+			else
+			++it;
 
-	  }
+		}
 
-  }
+	}
 }
 
 
 #endif //#defined DO_SEISMIC_SIMULATIONS
-  ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-  ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-  ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-  ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-  ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-  ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 
 
@@ -552,20 +552,20 @@ Bool W3DTerrainVisual::load( AsciiString filename )
 		return FALSE;
 
 
-  ChunkInputStream *pStrm = &fileStrm;
+	ChunkInputStream *pStrm = &fileStrm;
 
-  // allocate new height map data to read from file
-  REF_PTR_RELEASE( m_logicHeightMap );
+	// allocate new height map data to read from file
+	REF_PTR_RELEASE( m_logicHeightMap );
 	m_logicHeightMap = NEW WorldHeightMap(pStrm);
 
 #ifdef DO_SEISMIC_SIMULATIONS
 
-  fileStrm.close();
-  fileStrm.open(filename);
-  pStrm = &fileStrm;
+	fileStrm.close();
+	fileStrm.open(filename);
+	pStrm = &fileStrm;
 
 	REF_PTR_RELEASE( m_clientHeightMap );
-  m_clientHeightMap = NEW WorldHeightMap( pStrm );
+	m_clientHeightMap = NEW WorldHeightMap( pStrm );
 
 #endif
 
@@ -595,7 +595,7 @@ Bool W3DTerrainVisual::load( AsciiString filename )
 			lightP->Set_Position(Vector3(loc.x, loc.y, loc.z));
 
 			lightP->Set_Far_Attenuation_Range(d->getReal(TheKey_lightInnerRadius), d->getReal(TheKey_lightOuterRadius));
- 			W3DDisplay::m_3DScene->Add_Render_Object(lightP);
+			W3DDisplay::m_3DScene->Add_Render_Object(lightP);
 			REF_PTR_RELEASE( lightP );
 		}
 		pMapObj = pMapObj->getNext();
@@ -607,20 +607,20 @@ Bool W3DTerrainVisual::load( AsciiString filename )
 
 #ifdef DO_SEISMIC_SIMULATIONS
 	m_terrainRenderObject->initHeightData( m_clientHeightMap->getDrawWidth(),
-																				 m_clientHeightMap->getDrawHeight(),
-																				 m_clientHeightMap,
-																				 it);
+		m_clientHeightMap->getDrawHeight(),
+		m_clientHeightMap,
+		it);
 #else
 	m_terrainRenderObject->initHeightData( m_logicHeightMap->getDrawWidth(),
-																				 m_logicHeightMap->getDrawHeight(),
-																				 m_logicHeightMap,
-																				 it);
+		m_logicHeightMap->getDrawHeight(),
+		m_logicHeightMap,
+		it);
 #endif
 
 
 	if (it) {
-	 W3DDisplay::m_3DScene->destroyLightsIterator(it);
-	 it = nullptr;
+		W3DDisplay::m_3DScene->destroyLightsIterator(it);
+		it = nullptr;
 	}
 	// add our terrain render object to the scene
 	if (W3DDisplay::m_3DScene != nullptr)
@@ -690,8 +690,8 @@ void W3DTerrainVisual::enableWaterGrid( Bool enable )
 	* and the result point on the terrain is returned in "result" */
 //-------------------------------------------------------------------------------------------------
 Bool W3DTerrainVisual::intersectTerrain( Coord3D *rayStart,
-																				 Coord3D *rayEnd,
-																				 Coord3D *result )
+	Coord3D *rayEnd,
+	Coord3D *result )
 {
 	Bool hit = FALSE;
 
@@ -730,10 +730,10 @@ void W3DTerrainVisual::getTerrainColorAt( Real x, Real y, RGBColor *pColor )
 {
 
 #ifdef DO_SEISMIC_SIMULATIONS
-  if( m_clientHeightMap )
+	if( m_clientHeightMap )
 		m_clientHeightMap->getTerrainColorAt( x, y, pColor );
 #else
-  if( m_logicHeightMap )
+	if( m_logicHeightMap )
 		m_logicHeightMap->getTerrainColorAt( x, y, pColor );
 #endif
 
@@ -752,7 +752,7 @@ TerrainType *W3DTerrainVisual::getTerrainTile( Real x, Real y )
 		tile = TheTerrainTypes->findTerrain( tileName );
 	}
 #else
-  if( m_logicHeightMap )
+	if( m_logicHeightMap )
 	{
 		AsciiString tileName = m_logicHeightMap->getTerrainNameAt( x, y );
 		tile = TheTerrainTypes->findTerrain( tileName );
@@ -766,7 +766,7 @@ TerrainType *W3DTerrainVisual::getTerrainTile( Real x, Real y )
 /** set min/max height values allowed in water grid pointed to by waterTable */
 // ------------------------------------------------------------------------------------------------
 void W3DTerrainVisual::setWaterGridHeightClamps( const WaterHandle *waterTable,
-																								 Real minZ, Real maxZ )
+	Real minZ, Real maxZ )
 {
 
 	if( m_waterRenderObject )
@@ -778,7 +778,7 @@ void W3DTerrainVisual::setWaterGridHeightClamps( const WaterHandle *waterTable,
 /** adjust fallof parameters for grid change method */
 // ------------------------------------------------------------------------------------------------
 void W3DTerrainVisual::setWaterAttenuationFactors( const WaterHandle *waterTable,
-																									 Real a, Real b, Real c, Real range )
+	Real a, Real b, Real c, Real range )
 {
 
 	if( m_waterRenderObject )
@@ -824,7 +824,7 @@ void W3DTerrainVisual::getWaterTransform( const WaterHandle *waterTable, Matrix3
 /** water grid resolution spacing */
 // ------------------------------------------------------------------------------------------------
 void W3DTerrainVisual::setWaterGridResolution( const WaterHandle *waterTable,
-																							 Real gridCellsX, Real gridCellsY, Real cellSize )
+	Real gridCellsX, Real gridCellsY, Real cellSize )
 {
 
 	if( m_waterRenderObject )
@@ -836,7 +836,7 @@ void W3DTerrainVisual::setWaterGridResolution( const WaterHandle *waterTable,
 /** get water grid resolution spacing */
 // ------------------------------------------------------------------------------------------------
 void W3DTerrainVisual::getWaterGridResolution( const WaterHandle *waterTable,
-																							 Real *gridCellsX, Real *gridCellsY, Real *cellSize )
+	Real *gridCellsX, Real *gridCellsY, Real *cellSize )
 {
 
 	if( m_waterRenderObject )
@@ -858,7 +858,7 @@ void W3DTerrainVisual::changeWaterHeight( Real x, Real y, Real delta )
 // ------------------------------------------------------------------------------------------------
 // ------------------------------------------------------------------------------------------------
 void W3DTerrainVisual::addWaterVelocity( Real worldX, Real worldY,
-																				 Real velocity, Real preferredHeight )
+	Real velocity, Real preferredHeight )
 {
 
 	if( m_waterRenderObject )
@@ -885,28 +885,28 @@ Bool W3DTerrainVisual::getWaterGridHeight( Real worldX, Real worldY, Real *heigh
 // ------------------------------------------------------------------------------------------------
 void W3DTerrainVisual::setRawMapHeight(const ICoord2D *gridPos, Int height)
 {
-  // This method writes to the m_logicHeightMap member,
-  // since m_logicHeightMap is the true, golden standard to which m_clientHeightMap
-  // interpolates during or after its Seismic simulation displaces it..
-  // THIS IS TRUE ONLY WHEN DO_SEISMIC_SIMULATIONS is defined M Lorenzen, 8/23/03
+	// This method writes to the m_logicHeightMap member,
+	// since m_logicHeightMap is the true, golden standard to which m_clientHeightMap
+	// interpolates during or after its Seismic simulation displaces it..
+	// THIS IS TRUE ONLY WHEN DO_SEISMIC_SIMULATIONS is defined M Lorenzen, 8/23/03
 
 	if (m_logicHeightMap)
-  {
+	{
 		Int x = gridPos->x+m_logicHeightMap->getBorderSizeInline();
 		Int y = gridPos->y+m_logicHeightMap->getBorderSizeInline();
- 		//if (m_logicHeightMap->getHeight(x,y) != height) //ML changed to prevent scissoring with roads
- 		if (m_logicHeightMap->getHeight(x,y) > height)
+		//if (m_logicHeightMap->getHeight(x,y) != height) //ML changed to prevent scissoring with roads
+		if (m_logicHeightMap->getHeight(x,y) > height)
 		{
 			m_logicHeightMap->setRawHeight(x, y, height);
 			m_terrainRenderObject->staticLightingChanged(); // OOH! this could benefit from the new Seismic update code
 
 
 #ifdef DO_SEISMIC_SIMULATIONS
-      if ( m_clientHeightMap )
-      {
-        if ( height < m_clientHeightMap->getHeight( x,y ) )
-          m_clientHeightMap->setRawHeight( x, y, height ); // if the client map is higher than this height, it will fall down to it anyway!
-      }
+			if ( m_clientHeightMap )
+			{
+				if ( height < m_clientHeightMap->getHeight( x,y ) )
+				m_clientHeightMap->setRawHeight( x, y, height ); // if the client map is higher than this height, it will fall down to it anyway!
+			}
 #endif
 
 		}
@@ -918,13 +918,13 @@ void W3DTerrainVisual::setRawMapHeight(const ICoord2D *gridPos, Int height)
 Int W3DTerrainVisual::getRawMapHeight(const ICoord2D *gridPos)
 {
 	if (m_logicHeightMap)
-  {
+	{
 		Int x = gridPos->x+m_logicHeightMap->getBorderSizeInline();
 		Int y = gridPos->y+m_logicHeightMap->getBorderSizeInline();
- 		//if (m_logicHeightMap->getHeight(x,y) != height) //ML changed to prevent scissoring with roads
-    return m_logicHeightMap->getHeight(x,y) ;
+		//if (m_logicHeightMap->getHeight(x,y) != height) //ML changed to prevent scissoring with roads
+		return m_logicHeightMap->getHeight(x,y) ;
 	}
-  return 0;
+	return 0;
 
 }
 

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTreeBuffer.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTreeBuffer.cpp
@@ -1600,7 +1600,7 @@ void W3DTreeBuffer::drawTrees(CameraClass * camera, RefRenderObjListIterator *pD
 		}
 		const W3DTreeDrawModuleData *moduleData = m_treeTypes[type].m_data;
 		if(m_trees[curTree].m_toppleState == TOPPLE_FALLING ||
-			 m_trees[curTree].m_toppleState == TOPPLE_FOGGED) {
+			m_trees[curTree].m_toppleState == TOPPLE_FOGGED) {
 			updateTopplingTree(m_trees+curTree, timeScale);
 		} else if(m_trees[curTree].m_toppleState == TOPPLE_DOWN) {
 			if (moduleData->m_killWhenToppled) {
@@ -1799,19 +1799,19 @@ void W3DTreeBuffer::drawTrees(CameraClass * camera, RefRenderObjListIterator *pD
 ///< Start the toppling process by giving a force vector
 //-------------------------------------------------------------------------------------------------
 void W3DTreeBuffer::applyTopplingForce( TTree *tree, const Coord3D* toppleDirection, Real toppleSpeed,
-																			 UnsignedInt options )
+	UnsignedInt options )
 {
 	if (tree->m_toppleState != TOPPLE_UPRIGHT) {
 		return;
 	}
 	const W3DTreeDrawModuleData* d = m_treeTypes[tree->treeType].m_data;
-  // Having a low toppleSpeed is BAD. In particular, if the toppleSpeed is exactly 0, the
-  // tree will stay upright forever, frozen in place (because the sway update is dead)
-  // but never dying
-  if ( toppleSpeed < d->m_minimumToppleSpeed )
-  {
-    toppleSpeed = d->m_minimumToppleSpeed;
-  }
+	// Having a low toppleSpeed is BAD. In particular, if the toppleSpeed is exactly 0, the
+	// tree will stay upright forever, frozen in place (because the sway update is dead)
+	// but never dying
+	if ( toppleSpeed < d->m_minimumToppleSpeed )
+	{
+		toppleSpeed = d->m_minimumToppleSpeed;
+	}
 
 	tree->m_toppleDirection = *toppleDirection;
 	tree->m_toppleDirection.normalize();

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DVideoBuffer.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DVideoBuffer.cpp
@@ -239,15 +239,15 @@ WW3DFormat W3DVideoBuffer::TypeToW3DFormat( VideoBuffer::Type format )
 			w3dFormat = WW3D_FORMAT_X8R8G8B8;
 			break;
 
- 		case TYPE_R8G8B8:
+		case TYPE_R8G8B8:
 			w3dFormat = WW3D_FORMAT_R8G8B8;
 			break;
 
- 		case TYPE_R5G6B5:
+		case TYPE_R5G6B5:
 			w3dFormat = WW3D_FORMAT_R5G6B5;
 			break;
 
- 		case TYPE_X1R5G5B5:
+		case TYPE_X1R5G5B5:
 			w3dFormat = WW3D_FORMAT_X1R5G5B5;
 			break;
 	}

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -192,9 +192,9 @@ void W3DView::setHeight(Int height)
 
 	Vector2 vMin,vMax;
 	m_3DCamera->Set_Aspect_Ratio((Real)getWidth()/(Real)height);
- 	m_3DCamera->Get_Viewport(vMin,vMax);
- 	vMax.Y=(Real)(m_originY+height)/(Real)TheDisplay->getHeight();
- 	m_3DCamera->Set_Viewport(vMin,vMax);
+	m_3DCamera->Get_Viewport(vMin,vMax);
+	vMax.Y=(Real)(m_originY+height)/(Real)TheDisplay->getHeight();
+	m_3DCamera->Set_Viewport(vMin,vMax);
 
 	// TheSuperHackers @bugfix Now recalculates the camera constraints because
 	// showing or hiding the control bar will change the viewable area.
@@ -212,9 +212,9 @@ void W3DView::setWidth(Int width)
 
 	Vector2 vMin,vMax;
 	m_3DCamera->Set_Aspect_Ratio((Real)width/(Real)getHeight());
- 	m_3DCamera->Get_Viewport(vMin,vMax);
- 	vMax.X=(Real)(m_originX+width)/(Real)TheDisplay->getWidth();
- 	m_3DCamera->Set_Viewport(vMin,vMax);
+	m_3DCamera->Get_Viewport(vMin,vMax);
+	vMax.X=(Real)(m_originX+width)/(Real)TheDisplay->getWidth();
+	m_3DCamera->Set_Viewport(vMin,vMax);
 
 	//we want to maintain the same scale, so we'll need to adjust the fov.
 	//default W3D fov for full-screen is 50 degrees.
@@ -234,10 +234,10 @@ void W3DView::setOrigin( Int x, Int y)
 
 	Vector2 vMin,vMax;
 
- 	m_3DCamera->Get_Viewport(vMin,vMax);
- 	vMin.X=(Real)x/(Real)TheDisplay->getWidth();
+	m_3DCamera->Get_Viewport(vMin,vMax);
+	vMin.X=(Real)x/(Real)TheDisplay->getWidth();
 	vMin.Y=(Real)y/(Real)TheDisplay->getHeight();
- 	m_3DCamera->Set_Viewport(vMin,vMax);
+	m_3DCamera->Set_Viewport(vMin,vMax);
 
 	// bottom-right border was also moved my this call, so force an update of extents.
 	setWidth(m_width);
@@ -843,20 +843,20 @@ static void drawDrawable( Drawable *draw, void *userData )
 static void drawTerrainNormal( Drawable *draw, void *userData )
 {
 	UnsignedInt color = GameMakeColor( 255, 255, 0, 255 );
-  if (TheTerrainLogic)
-  {
-    Coord3D pos = *draw->getPosition();
-    Coord3D normal;
-    pos.z = TheTerrainLogic->getGroundHeight(pos.x, pos.y, &normal);
-    const Real NORMLEN = 20;
-    normal.x = pos.x + normal.x * NORMLEN;
-    normal.y = pos.y + normal.y * NORMLEN;
-    normal.z = pos.z + normal.z * NORMLEN;
-    ICoord2D start, end;
+	if (TheTerrainLogic)
+	{
+		Coord3D pos = *draw->getPosition();
+		Coord3D normal;
+		pos.z = TheTerrainLogic->getGroundHeight(pos.x, pos.y, &normal);
+		const Real NORMLEN = 20;
+		normal.x = pos.x + normal.x * NORMLEN;
+		normal.y = pos.y + normal.y * NORMLEN;
+		normal.z = pos.z + normal.z * NORMLEN;
+		ICoord2D start, end;
 		TheTacticalView->worldToScreen(&pos, &start);
 		TheTacticalView->worldToScreen(&normal, &end);
 		TheDisplay->drawLine(start.x, start.y, end.x, end.y, 1.0f, color);
-  }
+	}
 }
 
 #if defined(RTS_DEBUG)
@@ -865,31 +865,31 @@ static void drawTerrainNormal( Drawable *draw, void *userData )
 // ------------------------------------------------------------------------------------------------
 void drawDebugCircle( const Coord3D & center, Real radius, Real width, Color color )
 {
-  const Real inc = PI/4.0f;
-  Real angle = 0.0f;
-  Coord3D pnt, lastPnt;
-  ICoord2D start, end;
-  Bool endValid, startValid;
+	const Real inc = PI/4.0f;
+	Real angle = 0.0f;
+	Coord3D pnt, lastPnt;
+	ICoord2D start, end;
+	Bool endValid, startValid;
 
-  lastPnt.x = center.x + radius * (Real)cos(angle);
-  lastPnt.y = center.y + radius * (Real)sin(angle);
-  lastPnt.z = center.z;
-  endValid = ( TheTacticalView->worldToScreenTriReturn( &lastPnt, &end ) != View::WTS_INVALID );
+	lastPnt.x = center.x + radius * (Real)cos(angle);
+	lastPnt.y = center.y + radius * (Real)sin(angle);
+	lastPnt.z = center.z;
+	endValid = ( TheTacticalView->worldToScreenTriReturn( &lastPnt, &end ) != View::WTS_INVALID );
 
-  for( angle = inc; angle <= 2.0f * PI; angle += inc )
-  {
-    pnt.x = center.x + radius * (Real)cos(angle);
-    pnt.y = center.y + radius * (Real)sin(angle);
-    pnt.z = center.z;
-    startValid = ( TheTacticalView->worldToScreenTriReturn( &pnt, &start ) != View::WTS_INVALID );
+	for( angle = inc; angle <= 2.0f * PI; angle += inc )
+	{
+		pnt.x = center.x + radius * (Real)cos(angle);
+		pnt.y = center.y + radius * (Real)sin(angle);
+		pnt.z = center.z;
+		startValid = ( TheTacticalView->worldToScreenTriReturn( &pnt, &start ) != View::WTS_INVALID );
 
-    if ( startValid && endValid )
-      TheDisplay->drawLine( start.x, start.y, end.x, end.y, width, color );
+		if ( startValid && endValid )
+		TheDisplay->drawLine( start.x, start.y, end.x, end.y, width, color );
 
-    lastPnt = pnt;
-    end = start;
-    endValid = startValid;
-  }
+		lastPnt = pnt;
+		end = start;
+		endValid = startValid;
+	}
 }
 
 static void drawDrawableExtents( Drawable *draw, void *userData );  // FORWARD DECLARATION
@@ -962,24 +962,24 @@ static void drawDrawableExtents( Drawable *draw, void *userData )
 		case GEOMETRY_SPHERE:	// not quite right, but close enough
 		case GEOMETRY_CYLINDER:
 		{
-      Coord3D center = *draw->getPosition();
-      const Real radius = draw->getDrawableGeometryInfo().getMajorRadius();
+			Coord3D center = *draw->getPosition();
+			const Real radius = draw->getDrawableGeometryInfo().getMajorRadius();
 
 			// draw cylinder
 			for( int i=0; i<2; i++ )
 			{
-        drawDebugCircle( center, radius, 1.0f, color );
+				drawDebugCircle( center, radius, 1.0f, color );
 
-        // next time 'round, draw the top of the cylinder
-        center.z += draw->getDrawableGeometryInfo().getMaxHeightAbovePosition();
+				// next time 'round, draw the top of the cylinder
+				center.z += draw->getDrawableGeometryInfo().getMaxHeightAbovePosition();
 			}
 
 			// draw centerline
-      ICoord2D start, end;
-      center = *draw->getPosition();
-      TheTacticalView->worldToScreen( &center, &start );
-      center.z += draw->getDrawableGeometryInfo().getMaxHeightAbovePosition();
-      TheTacticalView->worldToScreen( &center, &end );
+			ICoord2D start, end;
+			center = *draw->getPosition();
+			TheTacticalView->worldToScreen( &center, &start );
+			center.z += draw->getDrawableGeometryInfo().getMaxHeightAbovePosition();
+			TheTacticalView->worldToScreen( &center, &end );
 			TheDisplay->drawLine( start.x, start.y, end.x, end.y, 1.0f, color );
 
 			break;
@@ -1008,10 +1008,10 @@ static void drawAudioLocations( Drawable *draw, void *userData );
 // ------------------------------------------------------------------------------------------------
 static void drawContainedAudioLocations( Object *obj, void *userData )
 {
-  Drawable *draw = obj->getDrawable();
+	Drawable *draw = obj->getDrawable();
 
-  if( draw )
-    drawAudioLocations( draw, userData );
+	if( draw )
+	drawAudioLocations( draw, userData );
 
 }
 
@@ -1021,62 +1021,62 @@ static void drawContainedAudioLocations( Object *obj, void *userData )
 //-------------------------------------------------------------------------------------------------
 static void drawAudioLocations( Drawable *draw, void *userData )
 {
-  // draw audio for things that are contained by this
-  Object *obj = draw->getObject();
-  if( obj )
-  {
-    ContainModuleInterface *contain = obj->getContain();
+	// draw audio for things that are contained by this
+	Object *obj = draw->getObject();
+	if( obj )
+	{
+		ContainModuleInterface *contain = obj->getContain();
 
-    if( contain )
-      contain->iterateContained( drawContainedAudioLocations, userData, FALSE );
+		if( contain )
+		contain->iterateContained( drawContainedAudioLocations, userData, FALSE );
 
-  }
+	}
 
-  const ThingTemplate * thingTemplate = draw->getTemplate();
+	const ThingTemplate * thingTemplate = draw->getTemplate();
 
-  if ( thingTemplate == nullptr || thingTemplate->getEditorSorting() != ES_AUDIO )
-  {
-    return; // All done
-  }
+	if ( thingTemplate == nullptr || thingTemplate->getEditorSorting() != ES_AUDIO )
+	{
+		return; // All done
+	}
 
-  // Copied in hideously inappropriate code copying ways from DrawObject.cpp
-  // Should definitely be a global, probably read in from an INI file <gasp>
-  static const Int poleHeight = 20;
-  static const Int flagHeight = 10;
-  static const Int flagWidth = 10;
-  const Color color = GameMakeColor(0x25, 0x25, 0xEF, 0xFF);
+	// Copied in hideously inappropriate code copying ways from DrawObject.cpp
+	// Should definitely be a global, probably read in from an INI file <gasp>
+	static const Int poleHeight = 20;
+	static const Int flagHeight = 10;
+	static const Int flagWidth = 10;
+	const Color color = GameMakeColor(0x25, 0x25, 0xEF, 0xFF);
 
-  // Draw flag for audio-only objects:
-  //  *
-  //  * *
-  //  *   *
-  //  *     *
-  //  *   *
-  //  * *
-  //  *
-  //  *
-  //  *
-  //  *
-  //  *
+	// Draw flag for audio-only objects:
+	//  *
+	//  * *
+	//  *   *
+	//  *     *
+	//  *   *
+	//  * *
+	//  *
+	//  *
+	//  *
+	//  *
+	//  *
 
-  Coord3D worldPoint;
-  ICoord2D start, end;
+	Coord3D worldPoint;
+	ICoord2D start, end;
 
-  worldPoint = *draw->getPosition();
-  TheTacticalView->worldToScreen( &worldPoint, &start );
-  worldPoint.z += poleHeight;
-  TheTacticalView->worldToScreen( &worldPoint, &end );
-  TheDisplay->drawLine( start.x, start.y, end.x, end.y, 1.0f, color );
+	worldPoint = *draw->getPosition();
+	TheTacticalView->worldToScreen( &worldPoint, &start );
+	worldPoint.z += poleHeight;
+	TheTacticalView->worldToScreen( &worldPoint, &end );
+	TheDisplay->drawLine( start.x, start.y, end.x, end.y, 1.0f, color );
 
-  worldPoint.z -= flagHeight / 2;
-  worldPoint.x += flagWidth;
-  TheTacticalView->worldToScreen( &worldPoint, &start );
-  TheDisplay->drawLine( start.x, start.y, end.x, end.y, 1.0f, color );
+	worldPoint.z -= flagHeight / 2;
+	worldPoint.x += flagWidth;
+	TheTacticalView->worldToScreen( &worldPoint, &start );
+	TheDisplay->drawLine( start.x, start.y, end.x, end.y, 1.0f, color );
 
-  worldPoint.z -= flagHeight / 2;
-  worldPoint.x -= flagWidth;
-  TheTacticalView->worldToScreen( &worldPoint, &end );
-  TheDisplay->drawLine( start.x, start.y, end.x, end.y, 1.0f, color );
+	worldPoint.z -= flagHeight / 2;
+	worldPoint.x -= flagWidth;
+	TheTacticalView->worldToScreen( &worldPoint, &end );
+	TheDisplay->drawLine( start.x, start.y, end.x, end.y, 1.0f, color );
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1085,31 +1085,31 @@ static void drawAudioLocations( Drawable *draw, void *userData )
 static void drawAudioRadii( const Drawable * drawable )
 {
 
-  // Draw radii, if sound is playing
-  const AudioEventRTS * ambientSound = drawable->getAmbientSound();
+	// Draw radii, if sound is playing
+	const AudioEventRTS * ambientSound = drawable->getAmbientSound();
 
-  if ( ambientSound && ambientSound->isCurrentlyPlaying() )
-  {
-    const AudioEventInfo * ambientInfo = ambientSound->getAudioEventInfo();
+	if ( ambientSound && ambientSound->isCurrentlyPlaying() )
+	{
+		const AudioEventInfo * ambientInfo = ambientSound->getAudioEventInfo();
 
-    if ( ambientInfo == nullptr )
-    {
-      // I don't think that's right...
-      OutputDebugString( ("Playing sound has null AudioEventInfo?\n" ) );
+		if ( ambientInfo == nullptr )
+		{
+			// I don't think that's right...
+			OutputDebugString( ("Playing sound has null AudioEventInfo?\n" ) );
 
-      if ( TheAudio != nullptr )
-      {
-        ambientInfo = TheAudio->findAudioEventInfo( ambientSound->getEventName() );
-      }
-    }
+			if ( TheAudio != nullptr )
+			{
+				ambientInfo = TheAudio->findAudioEventInfo( ambientSound->getEventName() );
+			}
+		}
 
-    if ( ambientInfo != nullptr )
-    {
-      // Colors match those used in WorldBuilder
-      drawDebugCircle( *drawable->getPosition(), ambientInfo->m_minDistance, 1.0f, GameMakeColor(0x00, 0x00, 0xFF, 0xFF) );
-      drawDebugCircle( *drawable->getPosition(), ambientInfo->m_maxDistance, 1.0f, GameMakeColor(0xFF, 0x00, 0xFF, 0xFF) );
-    }
-  }
+		if ( ambientInfo != nullptr )
+		{
+			// Colors match those used in WorldBuilder
+			drawDebugCircle( *drawable->getPosition(), ambientInfo->m_minDistance, 1.0f, GameMakeColor(0x00, 0x00, 0xFF, 0xFF) );
+			drawDebugCircle( *drawable->getPosition(), ambientInfo->m_maxDistance, 1.0f, GameMakeColor(0xFF, 0x00, 0xFF, 0xFF) );
+		}
+	}
 }
 
 #endif
@@ -1146,15 +1146,15 @@ static void drawablePostDraw( Drawable *draw, void *userData )
 #if defined(RTS_DEBUG)
 	// debug collision extents
 	if( TheGlobalData->m_showCollisionExtents )
-	  drawDrawableExtents( draw, userData );
+	drawDrawableExtents( draw, userData );
 
-  if ( TheGlobalData->m_showAudioLocations )
-    drawAudioLocations( draw, userData );
+	if ( TheGlobalData->m_showAudioLocations )
+	drawAudioLocations( draw, userData );
 #endif
 
 	// debug terrain normals at object positions
 	if( TheGlobalData->m_showTerrainNormals )
-	  drawTerrainNormal( draw, userData );
+	drawTerrainNormal( draw, userData );
 
 	TheGameClient->incrementRenderedObjectCount();
 
@@ -1565,8 +1565,8 @@ void W3DView::update()
 	}
 
 #ifdef DO_SEISMIC_SIMULATIONS
-  // Give the terrain a chance to refresh animating (Seismic) regions, if any.
-  TheTerrainVisual->updateSeismicSimulations();
+	// Give the terrain a chance to refresh animating (Seismic) regions, if any.
+	TheTerrainVisual->updateSeismicSimulations();
 #endif
 
 	Region3D axisAlignedRegion;
@@ -1844,12 +1844,12 @@ void W3DView::draw()
 				prevNode = node;
 				if (node->getNext()) {
 					if (worldToScreen( node->getPosition(), &start )) {
- 						TheDisplay->drawLine( start.x-4, start.y, start.x+3, start.y, 1.0f, color );
+						TheDisplay->drawLine( start.x-4, start.y, start.x+3, start.y, 1.0f, color );
 					}
 				}
 			}
 			if (prevNode && worldToScreen( prevNode->getPosition(), &start )) {
- 				TheDisplay->drawLine( start.x-4, start.y, start.x+3, start.y, 1.0f, color );
+				TheDisplay->drawLine( start.x-4, start.y, start.x+3, start.y, 1.0f, color );
 				TheDisplay->drawLine( start.x, start.y-4, start.x, start.y+3, 1.0f, color );
 			}
 			color = 0xFFFF0000;  //0xAARRGGBB
@@ -1920,17 +1920,17 @@ void W3DView::draw()
 
 	}
 
-  if ( TheGlobalData->m_showAudioLocations )
-  {
-    // Draw audio radii for ALL drawables, not just those on screen
-    const Drawable * drawable = TheGameClient->getDrawableList();
+	if ( TheGlobalData->m_showAudioLocations )
+	{
+		// Draw audio radii for ALL drawables, not just those on screen
+		const Drawable * drawable = TheGameClient->getDrawableList();
 
-    while ( drawable != nullptr )
-    {
-      drawAudioRadii( drawable );
-      drawable = drawable->getNextDrawable();
-    }
-  }
+		while ( drawable != nullptr )
+		{
+			drawAudioRadii( drawable );
+			drawable = drawable->getNextDrawable();
+		}
+	}
 #endif // RTS_DEBUG
 
 	Region3D axisAlignedRegion;
@@ -2163,7 +2163,7 @@ View::WorldToScreenReturn W3DView::worldToScreenTriReturn( const Coord3D *w, ICo
 {
 	// sanity
 	if( w == nullptr || s == nullptr )
-    return WTS_INVALID;
+	return WTS_INVALID;
 
 	if( m_3DCamera )
 	{
@@ -2177,7 +2177,7 @@ View::WorldToScreenReturn W3DView::worldToScreenTriReturn( const Coord3D *w, ICo
 			// Can't get a valid number if it's beyond the clip planes.  jba
 			s->x = 0;
 			s->y = 0;
-      return WTS_INVALID;
+			return WTS_INVALID;
 		}
 
 		//
@@ -2187,8 +2187,8 @@ View::WorldToScreenReturn W3DView::worldToScreenTriReturn( const Coord3D *w, ICo
 		// coords now
 		//
 		W3DLogicalScreenToPixelScreen( screen.X, screen.Y,
-																	 &s->x, &s->y,
-																	 getWidth(), getHeight());
+			&s->x, &s->y,
+			getWidth(), getHeight());
 		s->x += m_originX;	//convert viewport coordinates to full screen coordinates
 		s->y += m_originY;
 
@@ -2196,14 +2196,14 @@ View::WorldToScreenReturn W3DView::worldToScreenTriReturn( const Coord3D *w, ICo
 //		s->y = (getHeight() * (-screen.Y + 1.0f)) / 2.0f;
 		if (projection != CameraClass::INSIDE_FRUSTUM)
 		{
-      return WTS_OUTSIDE_FRUSTUM;
+			return WTS_OUTSIDE_FRUSTUM;
 		}
 
-    return WTS_INSIDE_FRUSTUM;
+		return WTS_INSIDE_FRUSTUM;
 
 	}
 
-  return WTS_INVALID;
+	return WTS_INVALID;
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -2213,8 +2213,8 @@ View::WorldToScreenReturn W3DView::worldToScreenTriReturn( const Coord3D *w, ICo
 	Screen coordinates assumed in absolute values relative to full display resolution. */
 //-------------------------------------------------------------------------------------------------
 Int W3DView::iterateDrawablesInRegion( IRegion2D *screenRegion,
-																			 Bool (*callback)( Drawable *draw, void *userData ),
-																			 void *userData )
+	Bool (*callback)( Drawable *draw, void *userData ),
+	void *userData )
 {
 	Bool inside = FALSE;
 	Int count = 0;
@@ -2262,13 +2262,13 @@ Int W3DView::iterateDrawablesInRegion( IRegion2D *screenRegion,
 	}
 
 	for( draw = TheGameClient->firstDrawable();
-			 draw;
-			 draw = draw->getNextDrawable() )
+	draw;
+	draw = draw->getNextDrawable() )
 	{
 		if (onlyDrawableToTest)
 		{
-		 draw = onlyDrawableToTest;
-		 inside = TRUE;
+			draw = onlyDrawableToTest;
+			inside = TRUE;
 		}
 		else
 		{
@@ -2971,7 +2971,7 @@ Bool W3DView::isCameraMovementAtWaypointAlongPath()
 // ------------------------------------------------------------------------------------------------
 /** Move camera along a waypoint path in an interesting fashion.  Sets up parameters that get
  * evaluated in draw(). */
- // ------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 void W3DView::moveCameraAlongWaypointPath(Waypoint *pWay, Int milliseconds, Int shutter, Bool orient, Real easeIn, Real easeOut)
 {
 	const Real MIN_DELTA = MAP_XY_FACTOR;

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
@@ -420,9 +420,9 @@ RenderObjClass *	 WaterRenderObjClass::Clone() const
 //-------------------------------------------------------------------------------------------------
 HRESULT WaterRenderObjClass::initBumpMap(LPDIRECT3DTEXTURE8 *pTex, TextureClass *pBumpSource)
 {
-    SurfaceClass::SurfaceDescription    d3dsd;
+	SurfaceClass::SurfaceDescription    d3dsd;
 	SurfaceClass * surf;
-    D3DLOCKED_RECT     d3dlr;
+	D3DLOCKED_RECT     d3dlr;
 	DWORD dwSrcPitch;
 	BYTE* pSrc;
 	Int numLevels;
@@ -530,84 +530,84 @@ HRESULT WaterRenderObjClass::initBumpMap(LPDIRECT3DTEXTURE8 *pTex, TextureClass 
 	surf->Get_Description(d3dsd);
 	pSrc=(unsigned char *)surf->Lock((int *)&dwSrcPitch);
 
-    // Create the bumpmap's surface and texture objects
+	// Create the bumpmap's surface and texture objects
 	m_pBumpTexture[i]=DX8Wrapper::_Create_DX8_Texture(d3dsd.Width,d3dsd.Height,WW3D_FORMAT_U8V8,TextureClass::MIP_LEVELS_1,D3DPOOL_MANAGED,false);
 
-    // Fill the bits of the new texture surface with bits from
-    // a private format.
+	// Fill the bits of the new texture surface with bits from
+	// a private format.
 
-    m_pBumpTexture[i]->LockRect( 0, &d3dlr, 0, 0 );
-    DWORD dwDstPitch = (DWORD)d3dlr.Pitch;
-    BYTE* pDst       = (BYTE*)d3dlr.pBits;
+	m_pBumpTexture[i]->LockRect( 0, &d3dlr, 0, 0 );
+	DWORD dwDstPitch = (DWORD)d3dlr.Pitch;
+	BYTE* pDst       = (BYTE*)d3dlr.pBits;
 
-    for( DWORD y=0; y<d3dsd.Height; y++ )
-    {
-        BYTE* pDstT  = pDst;
-        BYTE* pSrcB0 = (BYTE*)pSrc;
-        BYTE* pSrcB1 = ( pSrcB0 + dwSrcPitch );
-        BYTE* pSrcB2 = ( pSrcB0 - dwSrcPitch );
+	for( DWORD y=0; y<d3dsd.Height; y++ )
+	{
+		BYTE* pDstT  = pDst;
+		BYTE* pSrcB0 = (BYTE*)pSrc;
+		BYTE* pSrcB1 = ( pSrcB0 + dwSrcPitch );
+		BYTE* pSrcB2 = ( pSrcB0 - dwSrcPitch );
 
-        if( y == d3dsd.Height-1 )  // Don't go past the last line
-            pSrcB1 = pSrcB0;
-        if( y == 0 )               // Don't go before first line
-            pSrcB2 = pSrcB0;
+		if( y == d3dsd.Height-1 )  // Don't go past the last line
+		pSrcB1 = pSrcB0;
+		if( y == 0 )               // Don't go before first line
+		pSrcB2 = pSrcB0;
 
-        for( DWORD x=0; x<d3dsd.Width; x++ )
-        {
-            LONG v00 = 256-*(pSrcB0+0); // Get the current pixel
-            LONG v01 = 256-*(pSrcB0+4); // and the pixel to the right
-            LONG vM1 = 256-*(pSrcB0-4); // and the pixel to the left
-            LONG v10 = 256-*(pSrcB1+0); // and the pixel one line below.
-            LONG v1M = 256-*(pSrcB2+0); // and the pixel one line above.
+		for( DWORD x=0; x<d3dsd.Width; x++ )
+		{
+			LONG v00 = 256-*(pSrcB0+0); // Get the current pixel
+			LONG v01 = 256-*(pSrcB0+4); // and the pixel to the right
+			LONG vM1 = 256-*(pSrcB0-4); // and the pixel to the left
+			LONG v10 = 256-*(pSrcB1+0); // and the pixel one line below.
+			LONG v1M = 256-*(pSrcB2+0); // and the pixel one line above.
 
-            LONG iDu = (vM1-v01); // The delta-u bump value
-            LONG iDv = (v1M-v10); // The delta-v bump value
+			LONG iDu = (vM1-v01); // The delta-u bump value
+			LONG iDv = (v1M-v10); // The delta-v bump value
 
-            if( (v00 < vM1) && (v00 < v01) )  // If we are at valley
-            {
-                iDu = vM1-v00;                 // Choose greater of 1st order diffs
-                if( iDu < v00-v01 )
-                    iDu = v00-v01;
-            }
+			if( (v00 < vM1) && (v00 < v01) )  // If we are at valley
+			{
+				iDu = vM1-v00;                 // Choose greater of 1st order diffs
+				if( iDu < v00-v01 )
+				iDu = v00-v01;
+			}
 
-            // The luminance bump value (land masses are less shiny)
-            WORD uL = ( v00>1 ) ? 63 : 127;
+			// The luminance bump value (land masses are less shiny)
+			WORD uL = ( v00>1 ) ? 63 : 127;
 
-            switch( D3DFMT_V8U8)//m_BumpMapFormat )
-            {
-                case D3DFMT_V8U8:
-                    *pDstT++ = (BYTE)iDu;
-                    *pDstT++ = (BYTE)iDv;
-                    break;
+			switch( D3DFMT_V8U8)//m_BumpMapFormat )
+			{
+				case D3DFMT_V8U8:
+					*pDstT++ = (BYTE)iDu;
+					*pDstT++ = (BYTE)iDv;
+					break;
 
-                case D3DFMT_L6V5U5:
-                    *(WORD*)pDstT  = (WORD)( ( (iDu>>3) & 0x1f ) <<  0 );
-                    *(WORD*)pDstT |= (WORD)( ( (iDv>>3) & 0x1f ) <<  5 );
-                    *(WORD*)pDstT |= (WORD)( ( ( uL>>2) & 0x3f ) << 10 );
-                    pDstT += 2;
-                    break;
+				case D3DFMT_L6V5U5:
+					*(WORD*)pDstT  = (WORD)( ( (iDu>>3) & 0x1f ) <<  0 );
+					*(WORD*)pDstT |= (WORD)( ( (iDv>>3) & 0x1f ) <<  5 );
+					*(WORD*)pDstT |= (WORD)( ( ( uL>>2) & 0x3f ) << 10 );
+					pDstT += 2;
+					break;
 
-                case D3DFMT_X8L8V8U8:
-                    *pDstT++ = (BYTE)iDu;
-                    *pDstT++ = (BYTE)iDv;
-                    *pDstT++ = (BYTE)uL;
-                    *pDstT++ = (BYTE)0L;
-                    break;
-            }
+				case D3DFMT_X8L8V8U8:
+					*pDstT++ = (BYTE)iDu;
+					*pDstT++ = (BYTE)iDv;
+					*pDstT++ = (BYTE)uL;
+					*pDstT++ = (BYTE)0L;
+					break;
+			}
 
-            // Move one pixel to the left (src is 32-bpp)
-            pSrcB0+=4;   pSrcB1+=4;   pSrcB2+=4;
-        }
+			// Move one pixel to the left (src is 32-bpp)
+			pSrcB0+=4;   pSrcB1+=4;   pSrcB2+=4;
+		}
 
-        // Move to the next line
-        pSrc += dwSrcPitch;    pDst += dwDstPitch;
-    }
+		// Move to the next line
+		pSrc += dwSrcPitch;    pDst += dwDstPitch;
+	}
 
-    m_pBumpTexture[i]->UnlockRect(0);
-    surf->Unlock();
+	m_pBumpTexture[i]->UnlockRect(0);
+	surf->Unlock();
 #endif
 
-    return S_OK;
+	return S_OK;
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1377,32 +1377,32 @@ void WaterRenderObjClass::loadSetting( Setting *setting, TimeOfDay timeOfDay )
 	//
 	// bottom left
 	setting->vertex00Diffuse = (WaterSettings[ timeOfDay ].m_vertex00Diffuse.red << 16) |
-														 (WaterSettings[ timeOfDay ].m_vertex00Diffuse.green << 8) |
-														  WaterSettings[ timeOfDay ].m_vertex00Diffuse.blue;
+		(WaterSettings[ timeOfDay ].m_vertex00Diffuse.green << 8) |
+		WaterSettings[ timeOfDay ].m_vertex00Diffuse.blue;
 	// top left
 	setting->vertex01Diffuse = (WaterSettings[ timeOfDay ].m_vertex01Diffuse.red << 16) |
-														 (WaterSettings[ timeOfDay ].m_vertex01Diffuse.green << 8) |
-														  WaterSettings[ timeOfDay ].m_vertex01Diffuse.blue;
+		(WaterSettings[ timeOfDay ].m_vertex01Diffuse.green << 8) |
+		WaterSettings[ timeOfDay ].m_vertex01Diffuse.blue;
 	// bottom right
 	setting->vertex10Diffuse = (WaterSettings[ timeOfDay ].m_vertex10Diffuse.red << 16) |
-														 (WaterSettings[ timeOfDay ].m_vertex10Diffuse.green << 8) |
-														  WaterSettings[ timeOfDay ].m_vertex10Diffuse.blue;
+		(WaterSettings[ timeOfDay ].m_vertex10Diffuse.green << 8) |
+		WaterSettings[ timeOfDay ].m_vertex10Diffuse.blue;
 	// top right
 	setting->vertex11Diffuse = (WaterSettings[ timeOfDay ].m_vertex11Diffuse.red << 16) |
-														 (WaterSettings[ timeOfDay ].m_vertex11Diffuse.green << 8) |
-														  WaterSettings[ timeOfDay ].m_vertex11Diffuse.blue;
+		(WaterSettings[ timeOfDay ].m_vertex11Diffuse.green << 8) |
+		WaterSettings[ timeOfDay ].m_vertex11Diffuse.blue;
 
 	// diffuse water color
 	setting->waterDiffuse = (WaterSettings[ timeOfDay ].m_waterDiffuseColor.alpha << 24) |
-												  (WaterSettings[ timeOfDay ].m_waterDiffuseColor.red		<< 16) |
+		(WaterSettings[ timeOfDay ].m_waterDiffuseColor.red		<< 16) |
 													(WaterSettings[ timeOfDay ].m_waterDiffuseColor.green << 8) |
-												   WaterSettings[ timeOfDay ].m_waterDiffuseColor.blue;
+		WaterSettings[ timeOfDay ].m_waterDiffuseColor.blue;
 
 	// transparent water color
 	setting->transparentWaterDiffuse = (WaterSettings[ timeOfDay ].m_transparentWaterDiffuse.alpha << 24) |
-																		 (WaterSettings[ timeOfDay ].m_transparentWaterDiffuse.red	 << 16) |
-																		 (WaterSettings[ timeOfDay ].m_transparentWaterDiffuse.green << 8) |
-																		  WaterSettings[ timeOfDay ].m_transparentWaterDiffuse.blue;
+		(WaterSettings[ timeOfDay ].m_transparentWaterDiffuse.red	 << 16) |
+		(WaterSettings[ timeOfDay ].m_transparentWaterDiffuse.green << 8) |
+		WaterSettings[ timeOfDay ].m_transparentWaterDiffuse.blue;
 
 }
 
@@ -1466,10 +1466,10 @@ void WaterRenderObjClass::renderMirror(CameraClass *cam)
 
 	//Force reflected image to be drawn into full texture size - not a viewport inside texture.
 	Vector2 vMin,vMax,vOldMax,vOldMin;
- 	cam->Get_Viewport(vOldMin,vOldMax);
- 	vMax.X=vMax.Y=1.0f;
+	cam->Get_Viewport(vOldMin,vOldMax);
+	vMax.X=vMax.Y=1.0f;
 	vMin.X=vMin.Y=0.0f;
- 	cam->Set_Viewport(vMin,vMax);
+	cam->Set_Viewport(vMin,vMax);
 
 	cam->Apply();	//force an update of all the camera dependent parameters like frustum clip planes
 
@@ -1484,7 +1484,7 @@ void WaterRenderObjClass::renderMirror(CameraClass *cam)
 	WW3D::Render(m_parentScene,cam);
 
 	cam->Set_Transform(OldCameraMatrix);	//restore original non-reflected matrix
- 	cam->Set_Viewport(vOldMin,vOldMax);
+	cam->Set_Viewport(vOldMin,vOldMax);
 
 	cam->Apply();	//force an update of all the camera dependent parameters like frustum clip planes
 
@@ -1590,7 +1590,7 @@ void WaterRenderObjClass::Render(RenderInfoClass & rinfo)
 				ShaderClass::Invert_Backface_Culling(true);
 
 			#ifdef CLIP_GEOMETRY_TO_PLANE
-			  // Set a clip plane, so that only objects above the water are reflected
+			// Set a clip plane, so that only objects above the water are reflected
 				WaterPlane.W *= -1.0f;	//flip sign of plane distance for D3D use.
 
 			//	DX8Wrapper::Set_DX8_Clip_Plane( 0, &WaterPlane.X );
@@ -1765,7 +1765,7 @@ Bool WaterRenderObjClass::getClippedWaterPlane(CameraClass *cam, AABoxClass *box
 	{
 		//find axis aligned bounding box around visible polygon
 		if (box)
-  			box->Init(&(ClippedPoly0.Verts[0]),final_vcount);
+		box->Init(&(ClippedPoly0.Verts[0]),final_vcount);
 		return TRUE;
 	}
 
@@ -2459,7 +2459,7 @@ void WaterRenderObjClass::setGridHeightClamps(Real minz, Real maxz)
 }
 
 void WaterRenderObjClass::addVelocity( Real worldX, Real worldY,
-																			 Real zVelocity, Real preferredHeight )
+	Real zVelocity, Real preferredHeight )
 {
 
 	if( m_doWaterGrid)
@@ -2713,7 +2713,7 @@ void WaterRenderObjClass::drawRiverWater(PolygonTrigger *pTrig)
 	DynamicIBAccessClass ib_access(BUFFER_TYPE_DYNAMIC_DX8,(rectangleCount+1)*2*3);
 	{
 		DynamicIBAccessClass::WriteLockClass lockib(&ib_access);
- 		UnsignedShort *curIb = lockib.Get_Index_Array();
+		UnsignedShort *curIb = lockib.Get_Index_Array();
 		for (Int i=0; i<rectangleCount; i++)
 		{
 			//triangle 1
@@ -2837,7 +2837,7 @@ void WaterRenderObjClass::drawRiverWater(PolygonTrigger *pTrig)
 			vb->diffuse= diffuse;
 
 			Real wobbleConst=-m_riverVOrigin+vScale*(Real)i + WWMath::Fast_Sin(2*PI*(vScale*(Real)i) - constA)/22.0f;
- 			//old slower version
+			//old slower version
 			//vb->v1=-m_riverVOrigin+vScale*(Real)i + wobble(vScale*i, m_riverVOrigin, doWobble);
 			vb->v1=wobbleConst;
 			vb->u1=HEIGHT_TO_USE ;
@@ -2857,12 +2857,12 @@ void WaterRenderObjClass::drawRiverWater(PolygonTrigger *pTrig)
 			vb->y=y;
 			vb->z=outerPt.z;
 			vb->diffuse= diffuse;
- 			//old slower version
+			//old slower version
 			//vb->v1=-m_riverVOrigin+vScale*(Real)i + wobble(vScale*i, m_riverVOrigin, doWobble);
 			vb->v1=wobbleConst;
 			vb->u1=0;
 			//old slower version
- 			//vb->v2 = -m_riverVOrigin+vScale*(Real)i + wobble(vScale*i, m_riverVOrigin, doWobble);
+			//vb->v2 = -m_riverVOrigin+vScale*(Real)i + wobble(vScale*i, m_riverVOrigin, doWobble);
 			vb->v2 =wobbleConst;
 			vb->u2 = 0;
 			vb->nx = 0;
@@ -2888,7 +2888,7 @@ void WaterRenderObjClass::drawRiverWater(PolygonTrigger *pTrig)
 		DX8Wrapper::Set_DX8_Render_State(D3DRS_SRCBLEND, D3DBLEND_SRCALPHA );
 
 	if (m_riverWaterPixelShader) DX8Wrapper::_Get_D3D_Device8()->SetPixelShader(m_riverWaterPixelShader);
- 	DWORD cull;
+	DWORD cull;
 	DX8Wrapper::_Get_D3D_Device8()->GetRenderState(D3DRS_CULLMODE, &cull);
 	DX8Wrapper::_Get_D3D_Device8()->SetRenderState(D3DRS_CULLMODE, D3DCULL_NONE);
 
@@ -3058,7 +3058,7 @@ void WaterRenderObjClass::drawTrapezoidWater(Vector3 points[4])
 	DynamicIBAccessClass ib_access(BUFFER_TYPE_DYNAMIC_DX8,(rectangleCount+1)*2*3);
 	{
 		DynamicIBAccessClass::WriteLockClass lockib(&ib_access);
- 		UnsignedShort *curIb = lockib.Get_Index_Array();
+		UnsignedShort *curIb = lockib.Get_Index_Array();
 		for (j=0; j<vCount-1; j++)
 		{	for (i=0; i<uCount-1; i++)
 			{
@@ -3228,13 +3228,13 @@ void WaterRenderObjClass::drawTrapezoidWater(Vector3 points[4])
 
 				vb->diffuse= diffuse;
 				//Old slower version
- 				//vb->u1=(vertex.X/waterFactor) + 0.02*cos(11*m_riverVOrigin)*sin(25*m_riverVOrigin+vertex.X*PI/(4*MAP_XY_FACTOR));
- 				//vb->v1=(vertex.Y/waterFactor) + 0.02*cos(5*m_riverVOrigin)*sin(25*m_riverVOrigin+vertex.Y*PI/(4*MAP_XY_FACTOR));
+				//vb->u1=(vertex.X/waterFactor) + 0.02*cos(11*m_riverVOrigin)*sin(25*m_riverVOrigin+vertex.X*PI/(4*MAP_XY_FACTOR));
+				//vb->v1=(vertex.Y/waterFactor) + 0.02*cos(5*m_riverVOrigin)*sin(25*m_riverVOrigin+vertex.Y*PI/(4*MAP_XY_FACTOR));
 				vb->u1=vertex.X*ooWaterFactor + constA*WWMath::Fast_Sin(constC+vertex.X*constD);
 				vb->v1=vertex.Y*ooWaterFactor + constB*WWMath::Fast_Sin(constC+vertex.Y*constD);
 				vb->u2 = vertex.X/BUMP_SIZE;
 				//Old slower version
- 				//vb->v2 = vertex.Y/BUMP_SIZE + 0.3f*vertex.X/BUMP_SIZE;
+				//vb->v2 = vertex.Y/BUMP_SIZE + 0.3f*vertex.X/BUMP_SIZE;
 				vb->v2 = (vertex.Y+0.3f*vertex.X)/BUMP_SIZE;
 				vb->nx = 0;
 				vb->ny = 0;
@@ -3264,7 +3264,7 @@ void WaterRenderObjClass::drawTrapezoidWater(Vector3 points[4])
 	}
 
 
- 	DWORD cull;
+	DWORD cull;
 	DX8Wrapper::_Get_D3D_Device8()->GetRenderState(D3DRS_CULLMODE, &cull);
 	DX8Wrapper::_Get_D3D_Device8()->SetRenderState(D3DRS_CULLMODE, D3DCULL_NONE);
 

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/WorldHeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/WorldHeightMap.cpp
@@ -84,7 +84,7 @@ public:
 /*static*/ Dict MapObject::TheWorldDict;
 
 MapObject::MapObject(Coord3D loc, AsciiString name, Real angle, Int flags, const Dict* props,
-										 const ThingTemplate *thingTemplate )
+	const ThingTemplate *thingTemplate )
 {
 	m_objectName = validateName( name, flags );
 	m_thingTemplate = thingTemplate;
@@ -629,8 +629,8 @@ void WorldHeightMap::setSeismicZVelocity(Int xIndex, Int yIndex, Real value)
 void WorldHeightMap::fillSeismicZVelocities( Real value )
 {
 	if (!m_seismicZVelocities) return ;
-  for (Int idx = 0; idx < m_width*m_height; ++idx)
-    m_seismicZVelocities[idx] = value;
+	for (Int idx = 0; idx < m_width*m_height; ++idx)
+	m_seismicZVelocities[idx] = value;
 }
 
 Real WorldHeightMap::getBilinearSampleSeismicZVelocity( Int x, Int y)
@@ -640,58 +640,58 @@ Real WorldHeightMap::getBilinearSampleSeismicZVelocity( Int x, Int y)
 	if ( x >= m_width ) return 0;
 	if (!m_seismicZVelocities) return 0;
 
-  Real collector = 0.0f;
-  Real divisor = 0.0f;
+	Real collector = 0.0f;
+	Real divisor = 0.0f;
 
-  collector += m_seismicZVelocities[ y * m_width + x ];
-  ++divisor;
+	collector += m_seismicZVelocities[ y * m_width + x ];
+	++divisor;
 
-  if ( y > 0 )
-  {
-    collector += m_seismicZVelocities[ (y-1) * m_width + x ];//bottom
-    ++divisor;
+	if ( y > 0 )
+	{
+		collector += m_seismicZVelocities[ (y-1) * m_width + x ];//bottom
+		++divisor;
 
-    if( x > 0 )
-    {
-      collector += m_seismicZVelocities[ (y-1) * m_width + (x-1) ];//lower left
-      ++divisor;
-    }
-    if ( x < m_width-1 )
-    {
-      collector += m_seismicZVelocities[ (y-1) * m_width + (x+1) ];//lower right
-      ++divisor;
-    }
-  }
-  if ( y < m_height-1 )
-  {
-    collector += m_seismicZVelocities[ (y+1) * m_width + x ];//top
-    ++divisor;
+		if( x > 0 )
+		{
+			collector += m_seismicZVelocities[ (y-1) * m_width + (x-1) ];//lower left
+			++divisor;
+		}
+		if ( x < m_width-1 )
+		{
+			collector += m_seismicZVelocities[ (y-1) * m_width + (x+1) ];//lower right
+			++divisor;
+		}
+	}
+	if ( y < m_height-1 )
+	{
+		collector += m_seismicZVelocities[ (y+1) * m_width + x ];//top
+		++divisor;
 
-    if( x > 0 )
-    {
-      collector += m_seismicZVelocities[ (y+1) * m_width + (x-1) ];//upper left
-      ++divisor;
-    }
-    if ( x < m_width-1 )
-    {
-      collector += m_seismicZVelocities[ (y+1) * m_width + (x+1) ];//upper right
-      ++divisor;
-    }
-  }
-  if( x > 0 )
-  {
-    collector += m_seismicZVelocities[ y * m_width + (x-1) ];//left
-    ++divisor;
-  }
-  if ( x < m_width-1 )
-  {
-    collector += m_seismicZVelocities[ y * m_width + (x+1) ];//right
-    ++divisor;
-  }
+		if( x > 0 )
+		{
+			collector += m_seismicZVelocities[ (y+1) * m_width + (x-1) ];//upper left
+			++divisor;
+		}
+		if ( x < m_width-1 )
+		{
+			collector += m_seismicZVelocities[ (y+1) * m_width + (x+1) ];//upper right
+			++divisor;
+		}
+	}
+	if( x > 0 )
+	{
+		collector += m_seismicZVelocities[ y * m_width + (x-1) ];//left
+		++divisor;
+	}
+	if ( x < m_width-1 )
+	{
+		collector += m_seismicZVelocities[ y * m_width + (x+1) ];//right
+		++divisor;
+	}
 
-  collector /= divisor;
+	collector /= divisor;
 
-  return collector;
+	return collector;
 
 }
 
@@ -887,9 +887,9 @@ Bool WorldHeightMap::ParseHeightMapData(DataChunkInput &file, DataChunkInfo *inf
 	Int numBytesY = m_height;
 	m_seismicUpdateWidth=numBytesX;
 	m_seismicUpdateFlag	= MSGNEW("WorldHeightMap::ParseHeightMapData _ m_seismicUpdateFlag allocated") UnsignedByte[numBytesX*numBytesY];
-  clearSeismicUpdateFlags();
-  m_seismicZVelocities = MSGNEW("WorldHeightMap_ParseHeightMapData _ zvelocities allocated") Real[m_dataSize];
-  fillSeismicZVelocities( 0 );
+	clearSeismicUpdateFlags();
+	m_seismicZVelocities = MSGNEW("WorldHeightMap_ParseHeightMapData _ zvelocities allocated") Real[m_dataSize];
+	fillSeismicZVelocities( 0 );
 
 
 	file.readArrayOfBytes((char *)m_data, m_dataSize);
@@ -1289,8 +1289,8 @@ typedef struct {
 	Short			imageHeight;
 	UnsignedByte	pixelDepth;
 	UnsignedByte	flags; //  &0x0F = alpha channel bits, &0x10 is right to left flag,
-						   // 0x20 is top to bottom flag.  (0x0? is left to right, bottom to top)
-						   // 0x3? is top to bottom, right to left.
+	// 0x20 is top to bottom flag.  (0x0? is left to right, bottom to top)
+	// 0x3? is top to bottom, right to left.
 } TTargaHeader;
 
 // followed by idLength bytes of ascii data
@@ -2224,9 +2224,9 @@ Bool WorldHeightMap::setDrawOrg(Int xOrg, Int yOrg)
 	if (newY > m_height - newHeight) newY = m_height - newHeight;
 	if (newY<0) newY=0;
 	Bool anythingDifferent = (m_drawOriginX!=newX) ||
-										 (m_drawOriginY!=newY) ||
-										 (m_drawWidthX!=newWidth) ||
-										 (m_drawHeightY!=newHeight) ;
+		(m_drawOriginY!=newY) ||
+		(m_drawWidthX!=newWidth) ||
+		(m_drawHeightY!=newHeight) ;
 
 	if (anythingDifferent) {
 		m_drawOriginX=newX;
@@ -2503,7 +2503,7 @@ void WorldHeightMap::setupAlphaTiles()
 
 
 Bool  WorldHeightMap::getRawTileData(Short tileNdx, Int width,
-																				 UnsignedByte *buffer, Int bufLen)
+	UnsignedByte *buffer, Int bufLen)
 {
 	TileData *pSrc = nullptr;
 	if (tileNdx/4 < NUM_SOURCE_TILES) {

--- a/Core/GameEngineDevice/Source/Win32Device/Common/Win32BIGFileSystem.cpp
+++ b/Core/GameEngineDevice/Source/Win32Device/Common/Win32BIGFileSystem.cpp
@@ -60,13 +60,13 @@ void Win32BIGFileSystem::init() {
 	loadBigFilesFromDirectory("", "*.big");
 
 #if RTS_ZEROHOUR
-    // load original Generals assets
-    AsciiString installPath;
-    GetStringFromGeneralsRegistry("", "InstallPath", installPath );
-    //@todo this will need to be ramped up to a crash for release
-    DEBUG_ASSERTCRASH(!installPath.isEmpty(), ("Be 1337! Go install Generals!"));
-    if (!installPath.isEmpty())
-      loadBigFilesFromDirectory(installPath, "*.big");
+	// load original Generals assets
+	AsciiString installPath;
+	GetStringFromGeneralsRegistry("", "InstallPath", installPath );
+	//@todo this will need to be ramped up to a crash for release
+	DEBUG_ASSERTCRASH(!installPath.isEmpty(), ("Be 1337! Go install Generals!"));
+	if (!installPath.isEmpty())
+	loadBigFilesFromDirectory(installPath, "*.big");
 #endif
 }
 

--- a/Core/GameEngineDevice/Source/Win32Device/GameClient/Win32DIKeyboard.cpp
+++ b/Core/GameEngineDevice/Source/Win32Device/GameClient/Win32DIKeyboard.cpp
@@ -114,14 +114,14 @@ static void printReturnCode( char *label, HRESULT hr )
 //-------------------------------------------------------------------------------------------------
 void DirectInputKeyboard::openKeyboard()
 {
-  HRESULT hr;
+	HRESULT hr;
 
 	// create our interface to direct input
 	hr = DirectInput8Create( ApplicationHInstance,
-													 DIRECTINPUT_VERSION,
-													 IID_IDirectInput8,
-													 (void **)&m_pDirectInput,
-													 nullptr );
+		DIRECTINPUT_VERSION,
+		IID_IDirectInput8,
+		(void **)&m_pDirectInput,
+		nullptr );
 	if( FAILED( hr ) )
 	{
 
@@ -134,8 +134,8 @@ void DirectInputKeyboard::openKeyboard()
 
 	// obtain an interface to the system keyboard device
 	hr = m_pDirectInput->CreateDevice( GUID_SysKeyboard,
-																		 &m_pKeyboardDevice,
-																		 nullptr );
+		&m_pKeyboardDevice,
+		nullptr );
 	if( FAILED( hr ) )
 	{
 
@@ -164,8 +164,8 @@ void DirectInputKeyboard::openKeyboard()
 	// on 2000 etc
 	//
 	hr = m_pKeyboardDevice->SetCooperativeLevel( ApplicationHWnd,
-																							 DISCL_FOREGROUND |
-																							 DISCL_NONEXCLUSIVE );
+		DISCL_FOREGROUND |
+		DISCL_NONEXCLUSIVE );
 	if( FAILED( hr ) )
 	{
 
@@ -176,7 +176,7 @@ void DirectInputKeyboard::openKeyboard()
 
 	}
 
-  // set the keyboard buffer size
+	// set the keyboard buffer size
 	DIPROPDWORD prop;
 	prop.diph.dwSize = sizeof( DIPROPDWORD );
 	prop.diph.dwHeaderSize = sizeof( DIPROPHEADER );
@@ -260,7 +260,7 @@ void DirectInputKeyboard::getKey( KeyboardIO *key )
 		hr = m_pKeyboardDevice->Acquire();
 		if (hr == DI_OK || hr == S_FALSE)
 			hr = m_pKeyboardDevice->GetDeviceData( sizeof( DIDEVICEOBJECTDATA ),
-																						 &kbdat, &num, 0 );
+			&kbdat, &num, 0 );
 		switch( hr )
 		{
 

--- a/Core/GameEngineDevice/Source/Win32Device/GameClient/Win32DIMouse.cpp
+++ b/Core/GameEngineDevice/Source/Win32Device/GameClient/Win32DIMouse.cpp
@@ -47,10 +47,10 @@ void DirectInputMouse::openMouse()
 
 	// create our direct input device for mouse access
 	hr = DirectInput8Create( ApplicationHInstance,
-													 DIRECTINPUT_VERSION,
-													 IID_IDirectInput8,
-													 (void **)&m_pDirectInput,
-													 nullptr );
+		DIRECTINPUT_VERSION,
+		IID_IDirectInput8,
+		(void **)&m_pDirectInput,
+		nullptr );
 	if( FAILED( hr ) )
 	{
 
@@ -149,7 +149,7 @@ void DirectInputMouse::openMouse()
 		m_forceFeedback = BitIsSet( diDevCaps.dwFlags, DIDC_FORCEFEEDBACK );
 
 		DEBUG_LOG(( "OK - Mouse info: Buttons = '%d', Force Feedback = '%s', Axes = '%d'",
-						 m_numButtons, m_forceFeedback ? "Yes" : "No", m_numAxes ));
+			m_numButtons, m_forceFeedback ? "Yes" : "No", m_numAxes ));
 
 	}
 

--- a/Core/GameEngineDevice/Source/Win32Device/GameClient/Win32Mouse.cpp
+++ b/Core/GameEngineDevice/Source/Win32Device/GameClient/Win32Mouse.cpp
@@ -228,7 +228,7 @@ void Win32Mouse::translateEvent( UnsignedInt eventIndex, MouseIO *result )
 		{
 
 			DEBUG_CRASH(( "translateEvent: Unknown Win32 mouse event [%d,%d,%d]",
-							 msg, wParam, lParam ));
+				msg, wParam, lParam ));
 			return;
 
 		}

--- a/Core/Libraries/Include/Lib/BaseType.h
+++ b/Core/Libraries/Include/Lib/BaseType.h
@@ -119,45 +119,45 @@ __forceinline long fast_float2long_round(float f)
 __forceinline float fast_float_trunc(float f)
 {
 #if defined(_MSC_VER) && _MSC_VER < 1300
-  _asm
-  {
-    mov ecx,[f]
-    shr ecx,23
+	_asm
+	{
+		mov ecx,[f]
+		shr ecx,23
     mov eax,0xff800000
     xor ebx,ebx
     sub cl,127
     cmovc eax,ebx
     sar eax,cl
-    and [f],eax
-  }
-  return f;
+			and [f],eax
+	}
+	return f;
 #else
-  unsigned x = *(unsigned *)&f;
-  unsigned char exp = x >> 23;
-  int mask = exp < 127 ? 0 : 0xff800000;
-  exp -= 127;
-  mask >>= exp & 31;
-  x &= mask;
-  return *(float *)&x;
+	unsigned x = *(unsigned *)&f;
+	unsigned char exp = x >> 23;
+	int mask = exp < 127 ? 0 : 0xff800000;
+	exp -= 127;
+	mask >>= exp & 31;
+	x &= mask;
+	return *(float *)&x;
 #endif
 }
 
 // same here, fast floor function
 __forceinline float fast_float_floor(float f)
 {
-  static unsigned almost1=(126<<23)|0x7fffff;
-  if (*(unsigned *)&f &0x80000000)
-    f-=*(float *)&almost1;
-  return fast_float_trunc(f);
+	static unsigned almost1=(126<<23)|0x7fffff;
+	if (*(unsigned *)&f &0x80000000)
+	f-=*(float *)&almost1;
+	return fast_float_trunc(f);
 }
 
 // same here, fast ceil function
 __forceinline float fast_float_ceil(float f)
 {
-  static unsigned almost1=(126<<23)|0x7fffff;
-  if ( (*(unsigned *)&f &0x80000000)==0)
-    f+=*(float *)&almost1;
-  return fast_float_trunc(f);
+	static unsigned almost1=(126<<23)|0x7fffff;
+	if ( (*(unsigned *)&f &0x80000000)==0)
+	f+=*(float *)&almost1;
+	return fast_float_trunc(f);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -494,14 +494,14 @@ struct Region3D
 	Bool isInRegionNoZ( const Coord3D *query ) const
 	{
 		return (lo.x < query->x) && (query->x < hi.x) &&
-					 (lo.y < query->y) && (query->y < hi.y);
+			(lo.y < query->y) && (query->y < hi.y);
 	}
 
 	Bool isInRegion( const Coord3D *query ) const
 	{
 		return (lo.x < query->x) && (query->x < hi.x) &&
-					 (lo.y < query->y) && (query->y < hi.y) &&
-					 (lo.z < query->z) && (query->z < hi.z);
+			(lo.y < query->y) && (query->y < hi.y) &&
+			(lo.z < query->z) && (query->z < hi.z);
 	}
 };
 

--- a/Core/Libraries/Source/Compression/EAC/btreeabout.cpp
+++ b/Core/Libraries/Source/Compression/EAC/btreeabout.cpp
@@ -83,23 +83,23 @@
 
 CODEXABOUT *GCALL BTREE_about()
 {
-    CODEXABOUT* info;
+	CODEXABOUT* info;
 
-    info = (CODEXABOUT*) galloc(sizeof(CODEXABOUT));
-    if (info)
-    {
-        memset(info, 0, sizeof(CODEXABOUT));
+	info = (CODEXABOUT*) galloc(sizeof(CODEXABOUT));
+	if (info)
+	{
+		memset(info, 0, sizeof(CODEXABOUT));
 
-        info->signature       = QMAKEID('B','T','R','E');
-        info->size            = sizeof(CODEXABOUT);
-        info->version         = 200;    /* codex version number (200) */
-        info->decode          = 1;      /* supports decoding */
-        info->encode          = 1;      /* supports encoding */
-        info->size32          = 0;      /* supports 32 bit size field */
-        strcpy(info->versionstr,    "1.02");     /* version # */
-        strcpy(info->shorttypestr,  "btr");      /* type */
-        strcpy(info->longtypestr,   "BTree");    /* longtype */
-    }
-    return(info);
+		info->signature       = QMAKEID('B','T','R','E');
+		info->size            = sizeof(CODEXABOUT);
+		info->version         = 200;    /* codex version number (200) */
+		info->decode          = 1;      /* supports decoding */
+		info->encode          = 1;      /* supports encoding */
+		info->size32          = 0;      /* supports 32 bit size field */
+		strcpy(info->versionstr,    "1.02");     /* version # */
+		strcpy(info->shorttypestr,  "btr");      /* type */
+		strcpy(info->longtypestr,   "BTree");    /* longtype */
+	}
+	return(info);
 }
 

--- a/Core/Libraries/Source/Compression/EAC/btreedecode.cpp
+++ b/Core/Libraries/Source/Compression/EAC/btreedecode.cpp
@@ -31,90 +31,90 @@
 
 struct BTreeDecodeContext
 {
-    signed char    cluetbl[256];
-    unsigned char  left[256];
-    unsigned char  right[256];
-    unsigned char  *d;
+	signed char    cluetbl[256];
+	unsigned char  left[256];
+	unsigned char  right[256];
+	unsigned char  *d;
 };
 
 static void BTREE_chase(struct BTreeDecodeContext *DC, unsigned char node)
 {
-    if (DC->cluetbl[node])
-    {
-        BTREE_chase(DC,DC->left[node]);
-        BTREE_chase(DC,DC->right[node]);
-        return;
-    }
-    *DC->d++ = node;
+	if (DC->cluetbl[node])
+	{
+		BTREE_chase(DC,DC->left[node]);
+		BTREE_chase(DC,DC->right[node]);
+		return;
+	}
+	*DC->d++ = node;
 }
 
 static int BTREE_decompress(unsigned char *packbuf,unsigned char *unpackbuf)
 {
-    int  node;
-    int  i;
-    int  nodes;
-    int  clue;
-    int ulen;
-    unsigned char *s;
-    signed char c;
-    unsigned int type;
-    struct BTreeDecodeContext DC;
+	int  node;
+	int  i;
+	int  nodes;
+	int  clue;
+	int ulen;
+	unsigned char *s;
+	signed char c;
+	unsigned int type;
+	struct BTreeDecodeContext DC;
 
-    s = packbuf;
-    DC.d = unpackbuf;
-    ulen = 0L;
+	s = packbuf;
+	DC.d = unpackbuf;
+	ulen = 0L;
 
-    if (s)
-    {
-        type = ggetm(s,2);
-        s += 2;
+	if (s)
+	{
+		type = ggetm(s,2);
+		s += 2;
 
         /* (skip nothing for 0x46fb) */
-        if (type==0x47fb)                       /* skip ulen */
-            s += 3;
+		if (type==0x47fb)                       /* skip ulen */
+		s += 3;
 
-        ulen = ggetm(s,3);
-        s += 3;
+		ulen = ggetm(s,3);
+		s += 3;
 
-        for (i=0;i<256;++i)                     /* 0 means a code is a leaf */
-            DC.cluetbl[i] = 0;
+		for (i=0;i<256;++i)                     /* 0 means a code is a leaf */
+		DC.cluetbl[i] = 0;
 
-        clue = *s++;
-        DC.cluetbl[clue] = 1;                   /* mark clue as special */
+		clue = *s++;
+		DC.cluetbl[clue] = 1;                   /* mark clue as special */
 
-        nodes = *s++;
-        for (i=0;i<nodes;++i)
-        {   node = *s++;
-            DC.left[node]  = *s++;
-            DC.right[node] = *s++;
-            DC.cluetbl[node] = (signed char)-1;
-        }
+		nodes = *s++;
+		for (i=0;i<nodes;++i)
+		{   node = *s++;
+			DC.left[node]  = *s++;
+			DC.right[node] = *s++;
+			DC.cluetbl[node] = (signed char)-1;
+		}
 
-        for (;;)
-        {
-            node = (int) *s++;
-            c=DC.cluetbl[node];
-            if (!c)
-            {
-                *DC.d++ = (unsigned char) node;
-                continue;
-            }
-            if (c<0)
-            {
-                BTREE_chase(&DC,DC.left[node]);
-                BTREE_chase(&DC,DC.right[node]);
-                continue;
-            }
-            node = (int) *s++;
-            if (node)
-            {
-                *DC.d++ = (char) node;
-                continue;
-            }
-            break;
-        }
-    }
-    return(ulen);
+		for (;;)
+		{
+			node = (int) *s++;
+			c=DC.cluetbl[node];
+			if (!c)
+			{
+				*DC.d++ = (unsigned char) node;
+				continue;
+			}
+			if (c<0)
+			{
+				BTREE_chase(&DC,DC.left[node]);
+				BTREE_chase(&DC,DC.right[node]);
+				continue;
+			}
+			node = (int) *s++;
+			if (node)
+			{
+				*DC.d++ = (char) node;
+				continue;
+			}
+			break;
+		}
+	}
+	return(ulen);
 }
 
 /****************************************************************/
@@ -126,13 +126,13 @@ static int BTREE_decompress(unsigned char *packbuf,unsigned char *unpackbuf)
 
 bool GCALL BTREE_is(const void *compresseddata)
 {
-    bool ok=false;
+	bool ok=false;
 
-    if (ggetm(compresseddata,2)==0x46fb
-     || ggetm(compresseddata,2)==0x47fb)
-        ok = true;
+	if (ggetm(compresseddata,2)==0x46fb
+		|| ggetm(compresseddata,2)==0x47fb)
+	ok = true;
 
-    return(ok);
+	return(ok);
 }
 
 
@@ -142,23 +142,23 @@ bool GCALL BTREE_is(const void *compresseddata)
 
 int GCALL BTREE_size(const void *compresseddata)
 {
-    int len=0;
+	int len=0;
 
-    if (ggetm(compresseddata,2)==0x46fb)
-    {
-        len = ggetm((char *)compresseddata+2,3);
-    }
-    else
-    {
-        len = ggetm((char *)compresseddata+2+3,3);
-    }
+	if (ggetm(compresseddata,2)==0x46fb)
+	{
+		len = ggetm((char *)compresseddata+2,3);
+	}
+	else
+	{
+		len = ggetm((char *)compresseddata+2+3,3);
+	}
 
-    return(len);
+	return(len);
 }
 
 int GCALL BTREE_decode(void *dest, const void *compresseddata, int *compressedsize)
 {
-    return(BTREE_decompress((unsigned char *)compresseddata,(unsigned char *)dest));
+	return(BTREE_decompress((unsigned char *)compresseddata,(unsigned char *)dest));
 }
 
 #endif

--- a/Core/Libraries/Source/Compression/EAC/btreeencode.cpp
+++ b/Core/Libraries/Source/Compression/EAC/btreeencode.cpp
@@ -42,26 +42,26 @@ struct BTREEMemStruct
 
 struct BTreeEncodeContext
 {
-    unsigned int	packbits;
-    unsigned int	workpattern;
-    unsigned char  *bufptr;
-    unsigned int	ulen;
-    unsigned int	masks[17];
-    unsigned char	clueq[BTREECODES];
-    unsigned char	right[BTREECODES];
-    unsigned char	join[BTREECODES];
-    unsigned int	plen;
-    unsigned char  *bufbase;
-    unsigned char  *bufend;
-    unsigned char  *buffer;
-    unsigned char  *buf1;
-    unsigned char  *buf2;
+	unsigned int	packbits;
+	unsigned int	workpattern;
+	unsigned char  *bufptr;
+	unsigned int	ulen;
+	unsigned int	masks[17];
+	unsigned char	clueq[BTREECODES];
+	unsigned char	right[BTREECODES];
+	unsigned char	join[BTREECODES];
+	unsigned int	plen;
+	unsigned char  *bufbase;
+	unsigned char  *bufend;
+	unsigned char  *buffer;
+	unsigned char  *buf1;
+	unsigned char  *buf2;
 };
 
 static void BTREE_writebits(struct BTreeEncodeContext *EC,
-                            struct BTREEMemStruct *dest,
-                            unsigned int bitpattern,
-                            unsigned int len)
+	struct BTREEMemStruct *dest,
+	unsigned int bitpattern,
+	unsigned int len)
 {
 	if (len > 16)
 	{
@@ -90,15 +90,15 @@ static void BTREE_adjcount(unsigned char *s, unsigned char *bend, BTREEWORD *cou
 
 #ifdef __WATCOMC__
 
-    union
-    {
-        unsigned char           b[4];
-        int                     w;
-    } i;
+	union
+	{
+		unsigned char           b[4];
+		int                     w;
+	} i;
 
     #define	COUNTADJ(j)	i.b[1] = i.b[0]; i.b[0] = *(s+j); ++count[i.w];
 
-    i.w = 0;
+	i.w = 0;
 	i.b[0] = (unsigned BTREEWORD) *s++;
 
 #else
@@ -136,7 +136,7 @@ static void BTREE_adjcount(unsigned char *s, unsigned char *bend, BTREEWORD *cou
 			COUNTADJ(13);
 			COUNTADJ(14);
 			COUNTADJ(15);
-            s += 16;
+			s += 16;
 
 		} while (s<bend);
 	}
@@ -148,7 +148,7 @@ static void BTREE_adjcount(unsigned char *s, unsigned char *bend, BTREEWORD *cou
 		do
 		{
 			COUNTADJ(0);
-            ++s;
+			++s;
 
 		} while (s<bend);
 	}
@@ -193,7 +193,7 @@ static void BTREE_clearcount(unsigned char *tryq,BTREEWORD *countbuf)
 				*(intptr+13) = zero;
 				*(intptr+14) = zero;
 				*(intptr+15) = zero;
-                intptr += 16;
+				intptr += 16;
 
 			} while (--i);
 		}
@@ -206,10 +206,10 @@ static void BTREE_clearcount(unsigned char *tryq,BTREEWORD *countbuf)
 }
 
 static void BTREE_joinnodes(struct BTreeEncodeContext *EC,
-                            unsigned char *cluep,
-                            unsigned char *rightp,
-                            unsigned char *joinp,
-                            unsigned int  clue)
+	unsigned char *cluep,
+	unsigned char *rightp,
+	unsigned char *joinp,
+	unsigned int  clue)
 {
 	unsigned char			*s;
 	unsigned char			*d;
@@ -218,13 +218,13 @@ static void BTREE_joinnodes(struct BTreeEncodeContext *EC,
 
     /* pack file */
 
-    s = EC->bufbase;
+	s = EC->bufbase;
 	if (s==EC->buf1)
 	{
 		d = EC->buf2;
 	}
 	else
-    {
+	{
 		d = EC->buf1;
 	}
 	EC->bufbase = d;
@@ -260,10 +260,10 @@ static void BTREE_joinnodes(struct BTreeEncodeContext *EC,
 /* find 48 most common nodes */
 
 static unsigned int	BTREE_findbest(BTREEWORD     *countptr,
-                                   unsigned char *tryq,
-                                   unsigned int  *bestn,
-                                   unsigned int  *bestval,
-                                   int			  ratio)
+	unsigned char *tryq,
+	unsigned int  *bestn,
+	unsigned int  *bestval,
+	int			  ratio)
 {
 	unsigned int				i;
 	unsigned int				i1;
@@ -314,11 +314,11 @@ static unsigned int	BTREE_findbest(BTREEWORD     *countptr,
 }
 
 static void BTREE_treepack(struct BTreeEncodeContext *EC,
-                           struct BTREEMemStruct *dest,
-                           unsigned int     passes,
-                           unsigned int     multimax,
-                           unsigned int     quick,
-                          int				 zerosuppress)
+	struct BTREEMemStruct *dest,
+	unsigned int     passes,
+	unsigned int     multimax,
+	unsigned int     quick,
+	int				 zerosuppress)
 {
 
 	unsigned char	*bend;
@@ -334,7 +334,7 @@ static void BTREE_treepack(struct BTreeEncodeContext *EC,
 	unsigned int	domore;
 	unsigned int	cost, save;
 	unsigned int	tcost, tsave;
-    unsigned int	clue;
+	unsigned int	clue;
 
 	unsigned int	freeptr;
 	unsigned int	count2[BTREECODES];
@@ -350,20 +350,20 @@ static void BTREE_treepack(struct BTreeEncodeContext *EC,
 	unsigned int	bt_node[BTREECODES];
 	unsigned int	bt_left[BTREECODES];
 	unsigned int	bt_right[BTREECODES];
-    unsigned int	sortptr[BTREECODES];
+	unsigned int	sortptr[BTREECODES];
 
 	int			treebufsize;
 	int			buf1size;
 	int			buf2size;
 
-    // 3/2 allows for worst case, where 2nd most popular
+	// 3/2 allows for worst case, where 2nd most popular
 	treebufsize = 65536L*sizeof(BTREEWORD);  /* 131K */
 	buf1size = EC->ulen*3/2+(int)BTREESLOPAGE;
 	buf2size = EC->ulen*3/2+(int)BTREESLOPAGE;
 
 	treebuf =	(unsigned char *) galloc(treebufsize);
 	if (!treebuf)
-        return; /* failure Insufficient memory for work buffer */
+	return; /* failure Insufficient memory for work buffer */
 
 	EC->buf1 =	(unsigned char *) galloc(buf1size);
 	if (!EC->buf1)
@@ -380,7 +380,7 @@ static void BTREE_treepack(struct BTreeEncodeContext *EC,
 		return; /* failure Insufficient memory for work buffer */
 	}
 
-    memcpy(EC->buf1, EC->buffer, EC->ulen); /* copy to scratch buffer */
+	memcpy(EC->buf1, EC->buffer, EC->ulen); /* copy to scratch buffer */
 
 	EC->buffer = EC->buf1;
 	EC->bufptr = EC->buf1+EC->ulen;
@@ -624,16 +624,16 @@ static void BTREE_treepack(struct BTreeEncodeContext *EC,
 }
 
 static int BTREE_compressfile(struct BTreeEncodeContext *EC,
-                               struct BTREEMemStruct *infile,
-                               struct BTREEMemStruct *outfile,
-                               int			 ulen,
-                               int				 zerosuppress)
+	struct BTREEMemStruct *infile,
+	struct BTREEMemStruct *outfile,
+	int			 ulen,
+	int				 zerosuppress)
 {
 	unsigned int	i;
 
 	unsigned int	passes;
 	unsigned int	multimax;
-    int			flen;
+	int			flen;
 
 /* set defaults */
 
@@ -684,7 +684,7 @@ static int BTREE_compressfile(struct BTreeEncodeContext *EC,
 
 	BTREE_treepack(EC,outfile,passes, multimax, 0, zerosuppress);
 
-    return(outfile->len);
+	return(outfile->len);
 }
 
 
@@ -695,22 +695,22 @@ static int BTREE_compressfile(struct BTreeEncodeContext *EC,
 
 int GCALL BTREE_encode(void *compresseddata, const void *source, int sourcesize, int *opts)
 {
-    int   plen;
-    struct BTREEMemStruct infile;
-    struct BTREEMemStruct outfile;
-    struct BTreeEncodeContext EC;
-    int opt=0;
-    if (opts)
-        opt = opts[0];
+	int   plen;
+	struct BTREEMemStruct infile;
+	struct BTREEMemStruct outfile;
+	struct BTreeEncodeContext EC;
+	int opt=0;
+	if (opts)
+	opt = opts[0];
 
-    infile.ptr = (char *)source;
-    infile.len = sourcesize;
-    outfile.ptr = (char *)compresseddata;
-    outfile.len = sourcesize;
+	infile.ptr = (char *)source;
+	infile.len = sourcesize;
+	outfile.ptr = (char *)compresseddata;
+	outfile.len = sourcesize;
 
-    plen = BTREE_compressfile(&EC,&infile, &outfile, sourcesize, opt);
+	plen = BTREE_compressfile(&EC,&infile, &outfile, sourcesize, opt);
 
-    return(plen);
+	return(plen);
 }
 
 #endif

--- a/Core/Libraries/Source/Compression/EAC/codex.h
+++ b/Core/Libraries/Source/Compression/EAC/codex.h
@@ -53,18 +53,18 @@ extern "C" {
 
 typedef struct
 {
-    int signature;              /* signature of codex ie 'tga ' (optional) */
-    int size;                   /* size of CODEXABOUT structure */
-    int version;                /* version number of CODEXABOUT structure (200) */
+		int signature;              /* signature of codex ie 'tga ' (optional) */
+		int size;                   /* size of CODEXABOUT structure */
+		int version;                /* version number of CODEXABOUT structure (200) */
 
-    unsigned int decode    :1;  /* supports decoding */
-    unsigned int encode    :1;  /* supports encoding */
-    unsigned int size32    :1;  /* support 32 bit size field */
-    unsigned int pad       :29;
+		unsigned int decode    :1;  /* supports decoding */
+		unsigned int encode    :1;  /* supports encoding */
+		unsigned int size32    :1;  /* support 32 bit size field */
+		unsigned int pad       :29;
 
-    char versionstr[8];          /* version number of codex module ie 1.00 */
-    char shorttypestr[8];        /* 3 or 4 character type string ie ref */
-    char longtypestr[16];        /* full name of data format ie Refpack */
+		char versionstr[8];          /* version number of codex module ie 1.00 */
+		char shorttypestr[8];        /* 3 or 4 character type string ie ref */
+		char longtypestr[16];        /* full name of data format ie Refpack */
 } CODEXABOUT;
 
 #define QMAKEID(a,b,c,d) (((a)<<24)|((b)<<16)|((c)<<8)|(d))
@@ -80,11 +80,11 @@ typedef struct
 
 typedef struct QFUNCTIONS
 {
-    CODEXABOUT * (GCALL * CODEX_about)();
-    bool         (GCALL * CODEX_is)(const void *compressed);
-    int          (GCALL * CODEX_size)(const void *compressed);
-    int          (GCALL * CODEX_decode)(void *dest, const void *source, int *sourcesizeptr);
-    int          (GCALL * CODEX_encode)(void *dest, const void *source, int sourcesize, int *opts);
+		CODEXABOUT * (GCALL * CODEX_about)();
+		bool         (GCALL * CODEX_is)(const void *compressed);
+		int          (GCALL * CODEX_size)(const void *compressed);
+		int          (GCALL * CODEX_decode)(void *dest, const void *source, int *sourcesizeptr);
+		int          (GCALL * CODEX_encode)(void *dest, const void *source, int sourcesize, int *opts);
 } QFUNCTIONS;
 
 extern struct QFUNCTIONS qfunctions[];

--- a/Core/Libraries/Source/Compression/EAC/huffabout.cpp
+++ b/Core/Libraries/Source/Compression/EAC/huffabout.cpp
@@ -66,23 +66,23 @@
 
 CODEXABOUT *GCALL HUFF_about()
 {
-    CODEXABOUT *info;
+	CODEXABOUT *info;
 
-    info = (CODEXABOUT *) galloc(sizeof(CODEXABOUT));
-    if (info)
-    {
-        memset(info, 0, sizeof(CODEXABOUT));
+	info = (CODEXABOUT *) galloc(sizeof(CODEXABOUT));
+	if (info)
+	{
+		memset(info, 0, sizeof(CODEXABOUT));
 
-        info->signature       = QMAKEID('H','U','F','F');
-        info->size            = sizeof(CODEXABOUT);
-        info->version         = 200;    /* codex version number (200) */
-        info->decode          = 1;      /* supports decoding */
-        info->encode          = 1;      /* supports encoding */
-        info->size32          = 0;      /* supports 32 bit size field */
-        strcpy(info->versionstr,    "1.04");     /* version # */
-        strcpy(info->shorttypestr,  "huff");     /* type */
-        strcpy(info->longtypestr,   "Huffman");  /* longtype */
-    }
-    return(info);
+		info->signature       = QMAKEID('H','U','F','F');
+		info->size            = sizeof(CODEXABOUT);
+		info->version         = 200;    /* codex version number (200) */
+		info->decode          = 1;      /* supports decoding */
+		info->encode          = 1;      /* supports encoding */
+		info->size32          = 0;      /* supports 32 bit size field */
+		strcpy(info->versionstr,    "1.04");     /* version # */
+		strcpy(info->shorttypestr,  "huff");     /* type */
+		strcpy(info->longtypestr,   "Huffman");  /* longtype */
+	}
+	return(info);
 }
 

--- a/Core/Libraries/Source/Compression/EAC/huffdecode.cpp
+++ b/Core/Libraries/Source/Compression/EAC/huffdecode.cpp
@@ -35,9 +35,9 @@
 
 struct HuffDecodeContext
 {
-    unsigned char  *s;
-    int             bitsleft;
-    unsigned int   bits;
+	unsigned char  *s;
+	int             bitsleft;
+	unsigned int   bits;
 };
 
 /****************************************************************/
@@ -136,373 +136,373 @@ static int ZERO=0;
 
 static int HUFF_decompress(unsigned char *packbuf, unsigned char *unpackbuf)
 {
-    unsigned int    type;
-    unsigned char   clue;
-    int            ulen;
-    unsigned int    cmp;
-    int             bitnum=0;
-    int             cluelen=0;
-    unsigned char   *qs;
-    unsigned char   *qd;
-    unsigned int   bits;
-    unsigned int   bitsunshifted=0;
-    int             numbits;
-    int             bitsleft;
-    unsigned int   v;
+	unsigned int    type;
+	unsigned char   clue;
+	int            ulen;
+	unsigned int    cmp;
+	int             bitnum=0;
+	int             cluelen=0;
+	unsigned char   *qs;
+	unsigned char   *qd;
+	unsigned int   bits;
+	unsigned int   bitsunshifted=0;
+	int             numbits;
+	int             bitsleft;
+	unsigned int   v;
 
-    qs = packbuf;
-    qd = unpackbuf;
-    ulen = 0L;
+	qs = packbuf;
+	qd = unpackbuf;
+	ulen = 0L;
 
-    if (qs)
-    {
-        {
-            int             mostbits;
-            int             i;
-            int             bitnumtbl[16];
-            unsigned int    deltatbl[16];
-            unsigned int    cmptbl[16];
-            unsigned char   codetbl[256];
-            unsigned char   quickcodetbl[256];
-            unsigned char   quicklentbl[256];
+	if (qs)
+	{
+		{
+			int             mostbits;
+			int             i;
+			int             bitnumtbl[16];
+			unsigned int    deltatbl[16];
+			unsigned int    cmptbl[16];
+			unsigned char   codetbl[256];
+			unsigned char   quickcodetbl[256];
+			unsigned char   quicklentbl[256];
 
-            bitsleft = -16;                                 /* init bit stream */
-            bits = 0;
-            SQgetbits(v,ZERO);
+			bitsleft = -16;                                 /* init bit stream */
+			bits = 0;
+			SQgetbits(v,ZERO);
 
-            SQgetbits(type,16);
+			SQgetbits(type,16);
 
-            if (type&0x8000) /* 4 byte size field */
-            {
+			if (type&0x8000) /* 4 byte size field */
+			{
                 /* (skip nothing for 0x30fb) */
-                if (type&0x100)                                 /* skip ulen */
-                {
-                    SQgetbits(v,16);
-                    SQgetbits(v,16);
-                }
-                type &= ~0x100;
+				if (type&0x100)                                 /* skip ulen */
+				{
+					SQgetbits(v,16);
+					SQgetbits(v,16);
+				}
+				type &= ~0x100;
 
-                SQgetbits(v,16);                                 /* unpack len */
-                SQgetbits(ulen,16);
-                ulen |= (v<<16);
-            }
-            else
-            {
+				SQgetbits(v,16);                                 /* unpack len */
+				SQgetbits(ulen,16);
+				ulen |= (v<<16);
+			}
+			else
+			{
                 /* (skip nothing for 0x30fb) */
-                if (type&0x100)                                 /* skip ulen */
-                {
-                    SQgetbits(v,8);
-                    SQgetbits(v,16);
-                }
-                type &= ~0x100;
+				if (type&0x100)                                 /* skip ulen */
+				{
+					SQgetbits(v,8);
+					SQgetbits(v,16);
+				}
+				type &= ~0x100;
 
-                SQgetbits(v,8);                                 /* unpack len */
-                SQgetbits(ulen,16);
-                ulen |= (v<<16);
-            }
+				SQgetbits(v,8);                                 /* unpack len */
+				SQgetbits(ulen,16);
+				ulen |= (v<<16);
+			}
 
-            {
-                {
-                    int numchars;
+			{
+				{
+					int numchars;
 
-                    {
-                        unsigned int basecmp;
+					{
+						unsigned int basecmp;
 
-                        {
-                            unsigned int t;
-                            SQgetbits(t,8);                          /* clue byte */
-                            clue = (unsigned char)t;
-                        }
+						{
+							unsigned int t;
+							SQgetbits(t,8);                          /* clue byte */
+							clue = (unsigned char)t;
+						}
 
-                        numchars = 0;
-                        numbits = 1;
-                        basecmp = (unsigned int) 0;
+						numchars = 0;
+						numbits = 1;
+						basecmp = (unsigned int) 0;
 
                         /* decode bitnums */
 
-                        do
-                        {
-                            basecmp <<= 1;
-                            deltatbl[numbits] = basecmp-numchars;
+						do
+						{
+							basecmp <<= 1;
+							deltatbl[numbits] = basecmp-numchars;
 
-                            SQgetnum(bitnum);               /* # of codes of n bits */
-                            bitnumtbl[numbits] = bitnum;
+							SQgetnum(bitnum);               /* # of codes of n bits */
+							bitnumtbl[numbits] = bitnum;
 
-                            numchars += bitnum;
-                            basecmp += bitnum;
+							numchars += bitnum;
+							basecmp += bitnum;
 
-                            cmp = 0;
-                            if (bitnum)                             /* left justify cmp */
-                                cmp = (basecmp << (16-numbits) & 0xffff);
+							cmp = 0;
+							if (bitnum)                             /* left justify cmp */
+							cmp = (basecmp << (16-numbits) & 0xffff);
 
-                            cmptbl[numbits++] = cmp;
+							cmptbl[numbits++] = cmp;
 
-                        }
-                        while (!bitnum || cmp);                     /* n+1 bits in cmp? */
-                    }
-                    cmptbl[numbits-1] = 0xffffffff;               /* force match on most bits */
+						}
+						while (!bitnum || cmp);                     /* n+1 bits in cmp? */
+					}
+					cmptbl[numbits-1] = 0xffffffff;               /* force match on most bits */
 
-                    mostbits = numbits-1;
+					mostbits = numbits-1;
 
                     /* decode leapfrog code table */
 
-                    {
-                        signed char     leap[256];
-                        unsigned char   nextchar;
+					{
+						signed char     leap[256];
+						unsigned char   nextchar;
 
-                        SQmemset(leap,0,256);
-                        nextchar = (unsigned char) -1;
+						SQmemset(leap,0,256);
+						nextchar = (unsigned char) -1;
 
-                        for (i=0;i<numchars;++i)
-                        {
-                            int leapdelta=0;
+						for (i=0;i<numchars;++i)
+						{
+							int leapdelta=0;
 
-                            SQgetnum(leapdelta);
-                            ++leapdelta;
+							SQgetnum(leapdelta);
+							++leapdelta;
 
-                            do
-                            {
-                                ++nextchar;
-                                if (!leap[nextchar])
-                                    --leapdelta;
-                            } while (leapdelta);
+							do
+							{
+								++nextchar;
+								if (!leap[nextchar])
+								--leapdelta;
+							} while (leapdelta);
 
-                            leap[nextchar] = 1;
-                            codetbl[i] = nextchar;
-                        }
-                    }
-                }
+							leap[nextchar] = 1;
+							codetbl[i] = nextchar;
+						}
+					}
+				}
 
 /****************************************************************/
 /*  Make fast 8 tables                                          */
 /****************************************************************/
 
-                SQmemset(quicklentbl,64,256);
+				SQmemset(quicklentbl,64,256);
 
-                {
-                    int bits;
-                    int bitnum;
-                    int numbitentries;
-                    int nextcode;
-                    int nextlen;
-                    int i;
-                    unsigned char *codeptr;
-                    unsigned char *quickcodeptr;
-                    unsigned char *quicklenptr;
+				{
+					int bits;
+					int bitnum;
+					int numbitentries;
+					int nextcode;
+					int nextlen;
+					int i;
+					unsigned char *codeptr;
+					unsigned char *quickcodeptr;
+					unsigned char *quicklenptr;
 
-                    codeptr = codetbl;
-                    quickcodeptr = quickcodetbl;
-                    quicklenptr = quicklentbl;
+					codeptr = codetbl;
+					quickcodeptr = quickcodetbl;
+					quicklenptr = quicklentbl;
 
-                    for (bits=1; bits<=mostbits; ++bits)
-                    {
-                        bitnum = bitnumtbl[bits];
-                        if (bits>=9)
-                            break;
-                        numbitentries = 1<<(8-bits);
+					for (bits=1; bits<=mostbits; ++bits)
+					{
+						bitnum = bitnumtbl[bits];
+						if (bits>=9)
+						break;
+						numbitentries = 1<<(8-bits);
 
-                        while (bitnum--)
-                        {
-                            nextcode = *codeptr++;
-                            nextlen = bits;
-                            if (nextcode==clue)
-                            {
-                                cluelen = bits;
-                                nextlen = 96;                   /* will force out of main loop */
-                            }
-                            for (i=0; i<numbitentries; ++i)
-                            {
-                                *quickcodeptr++ = (unsigned char) nextcode;
-                                *quicklenptr++ = (unsigned char) nextlen;
-                            }
-                        }
-                    }
-                }
-            }
+						while (bitnum--)
+						{
+							nextcode = *codeptr++;
+							nextlen = bits;
+							if (nextcode==clue)
+							{
+								cluelen = bits;
+								nextlen = 96;                   /* will force out of main loop */
+							}
+							for (i=0; i<numbitentries; ++i)
+							{
+								*quickcodeptr++ = (unsigned char) nextcode;
+								*quicklenptr++ = (unsigned char) nextlen;
+							}
+						}
+					}
+				}
+			}
 
 /****************************************************************/
 /*  Main decoder                                                */
 /****************************************************************/
 
-            for (;;)
-            {
-                unsigned char   *quickcodeptr = quickcodetbl;
-                unsigned char   *quicklenptr  = quicklentbl;
+			for (;;)
+			{
+				unsigned char   *quickcodeptr = quickcodetbl;
+				unsigned char   *quicklenptr  = quicklentbl;
 
-                goto nextloop;
+				goto nextloop;
 
 /* quick 8 fetch */
 
-                do
-                {
+				do
+				{
 
-                    *qd++ = quickcodeptr[bits>>24];
-                    GET16BITS();
-                    bits = bitsunshifted<<(16-bitsleft);
+					*qd++ = quickcodeptr[bits>>24];
+					GET16BITS();
+					bits = bitsunshifted<<(16-bitsleft);
 
 /* quick 8 decode */
 
 nextloop:
-                    numbits = quicklenptr[bits>>24];
-                    bitsleft -= numbits;
+					numbits = quicklenptr[bits>>24];
+					bitsleft -= numbits;
 
-                    if (bitsleft>=0)
-                    {
-                        do
-                        {
-                            *qd++ = quickcodeptr[bits>>24];
-                            bits <<= numbits;
+					if (bitsleft>=0)
+					{
+						do
+						{
+							*qd++ = quickcodeptr[bits>>24];
+							bits <<= numbits;
 
-                            numbits = quicklenptr[bits>>24];
-                            bitsleft -= numbits;
-                            if (bitsleft<0) break;
-                            *qd++ = quickcodeptr[bits>>24];
-                            bits <<= numbits;
+							numbits = quicklenptr[bits>>24];
+							bitsleft -= numbits;
+							if (bitsleft<0) break;
+							*qd++ = quickcodeptr[bits>>24];
+							bits <<= numbits;
 
-                            numbits = quicklenptr[bits>>24];
-                            bitsleft -= numbits;
-                            if (bitsleft<0) break;
-                            *qd++ = quickcodeptr[bits>>24];
-                            bits <<= numbits;
+							numbits = quicklenptr[bits>>24];
+							bitsleft -= numbits;
+							if (bitsleft<0) break;
+							*qd++ = quickcodeptr[bits>>24];
+							bits <<= numbits;
 
-                            numbits = quicklenptr[bits>>24];
-                            bitsleft -= numbits;
-                            if (bitsleft<0) break;
-                            *qd++ = quickcodeptr[bits>>24];
-                            bits <<= numbits;
+							numbits = quicklenptr[bits>>24];
+							bitsleft -= numbits;
+							if (bitsleft<0) break;
+							*qd++ = quickcodeptr[bits>>24];
+							bits <<= numbits;
 
-                            numbits = quicklenptr[bits>>24];
-                            bitsleft -= numbits;
+							numbits = quicklenptr[bits>>24];
+							bitsleft -= numbits;
 
-                        } while (bitsleft>=0);
-                    }
-                    bitsleft += 16;
+						} while (bitsleft>=0);
+					}
+					bitsleft += 16;
 
-                } while (bitsleft>=0);  /* would fetching 16 bits do it? */
+				} while (bitsleft>=0);  /* would fetching 16 bits do it? */
 
-                bitsleft = bitsleft-16+numbits;   /* back to normal */
+				bitsleft = bitsleft-16+numbits;   /* back to normal */
 
 /****************************************************************/
 /*  16 bit decoder                                              */
 /****************************************************************/
 
-                {
-                    unsigned char   code;
+				{
+					unsigned char   code;
 
 
-                    if (numbits!=96)
-                    {
-                        cmp = (unsigned int) (bits>>16);  /* 16 bit left justified compare */
+					if (numbits!=96)
+					{
+						cmp = (unsigned int) (bits>>16);  /* 16 bit left justified compare */
 
-                        numbits = 8;
-                        do
-                        {
-                            ++numbits;
-                        }
-                        while (cmp>=cmptbl[numbits]);
-                    }
-                    else
-                        numbits = cluelen;
+						numbits = 8;
+						do
+						{
+							++numbits;
+						}
+						while (cmp>=cmptbl[numbits]);
+					}
+					else
+					numbits = cluelen;
 
 
-                    cmp = bits >> (32-(numbits));
-                    bits <<= (numbits);
-                    bitsleft -= (numbits);
+					cmp = bits >> (32-(numbits));
+					bits <<= (numbits);
+					bitsleft -= (numbits);
 
-                    code = codetbl[cmp-deltatbl[numbits]];  /* the code */
+					code = codetbl[cmp-deltatbl[numbits]];  /* the code */
 
-                    if (code!=clue && bitsleft>=0)
-                    {
-                        *qd++ = code;
-                        goto nextloop;
-                    }
+					if (code!=clue && bitsleft>=0)
+					{
+						*qd++ = code;
+						goto nextloop;
+					}
 
-                    if (bitsleft<0)
-                    {
-                        GET16BITS();
-                        bits = bitsunshifted<<-bitsleft;
-                        bitsleft += 16;
-                    }
+					if (bitsleft<0)
+					{
+						GET16BITS();
+						bits = bitsunshifted<<-bitsleft;
+						bitsleft += 16;
+					}
 
-                    if (code!=clue)
-                    {
-                        *qd++ = code;
-                        goto nextloop;
-                    }
+					if (code!=clue)
+					{
+						*qd++ = code;
+						goto nextloop;
+					}
 
                     /* handle clue */
 
-                    {
-                        int    runlen=0;
-                        unsigned char *d=qd;
-                        unsigned char *dest;
+					{
+						int    runlen=0;
+						unsigned char *d=qd;
+						unsigned char *dest;
 
-                        SQgetnum(runlen);
-                        if (runlen)                             /* runlength sequence */
-                        {
-                            dest = d+runlen;
-                            code = *(d-1);
-                            do
-                            {
-                                *d++ = code;
-                            } while (d<dest);
+						SQgetnum(runlen);
+						if (runlen)                             /* runlength sequence */
+						{
+							dest = d+runlen;
+							code = *(d-1);
+							do
+							{
+								*d++ = code;
+							} while (d<dest);
 
-                            qd = d;
-                            goto nextloop;
-                        }
-                    }
+							qd = d;
+							goto nextloop;
+						}
+					}
 
-                    SQgetbits(v,1);                         /* End Of File */
-                    if (v)
-                        break;
+					SQgetbits(v,1);                         /* End Of File */
+					if (v)
+					break;
 
-                    {
-                        unsigned int t;
-                        SQgetbits(t,8);                    /* explicite byte */
-                        code = (unsigned char)t;
-                    }
-                    *qd++ = code;
-                    goto nextloop;
-                }
+					{
+						unsigned int t;
+						SQgetbits(t,8);                    /* explicite byte */
+						code = (unsigned char)t;
+					}
+					*qd++ = code;
+					goto nextloop;
+				}
 
-            }
+			}
 
 
 /****************************************************************/
 /*  Undelta                                                     */
 /****************************************************************/
 
-            {
-                int i;
-                int nextchar;
+			{
+				int i;
+				int nextchar;
 
-                if (type==0x32fb || type==0xb2fb)                           /* deltaed? */
-                {
-                    i = 0;
-                    qd = unpackbuf;
-                    while (qd<unpackbuf+ulen)
-                    {
-                        i += (int) *qd;
-                        *qd++ = (unsigned char) i;
-                    }
-                }
-                else if (type==0x34fb || type==0xb4fb)                      /* accelerated? */
-                {
+				if (type==0x32fb || type==0xb2fb)                           /* deltaed? */
+				{
+					i = 0;
+					qd = unpackbuf;
+					while (qd<unpackbuf+ulen)
+					{
+						i += (int) *qd;
+						*qd++ = (unsigned char) i;
+					}
+				}
+				else if (type==0x34fb || type==0xb4fb)                      /* accelerated? */
+				{
 
-                    i = 0;
-                    nextchar = 0;
-                    qd = unpackbuf;
-                    while (qd<unpackbuf+ulen)
-                    {
-                        i += (int) *qd;
-                        nextchar += i;
-                        *qd++ = (unsigned char) nextchar;
-                    }
-                }
-            }
-        }
-    }
-    return(ulen);
+					i = 0;
+					nextchar = 0;
+					qd = unpackbuf;
+					while (qd<unpackbuf+ulen)
+					{
+						i += (int) *qd;
+						nextchar += i;
+						*qd++ = (unsigned char) nextchar;
+					}
+				}
+			}
+		}
+	}
+	return(ulen);
 }
 
 #if defined(_MSC_VER)
@@ -518,24 +518,24 @@ nextloop:
 
 bool GCALL HUFF_is(const void *compresseddata)
 {
-    bool ok=false;
-    int packtype=ggetm(compresseddata,2);
+	bool ok=false;
+	int packtype=ggetm(compresseddata,2);
 
-    if (packtype==0x30fb
-     || packtype==0x31fb
-     || packtype==0x32fb
-     || packtype==0x33fb
-     || packtype==0x34fb
-     || packtype==0x35fb
-     || packtype==0xb0fb
-     || packtype==0xb1fb
-     || packtype==0xb2fb
-     || packtype==0xb3fb
-     || packtype==0xb4fb
-     || packtype==0xb5fb)
-        ok = true;
+	if (packtype==0x30fb
+		|| packtype==0x31fb
+		|| packtype==0x32fb
+		|| packtype==0x33fb
+		|| packtype==0x34fb
+		|| packtype==0x35fb
+		|| packtype==0xb0fb
+		|| packtype==0xb1fb
+		|| packtype==0xb2fb
+		|| packtype==0xb3fb
+		|| packtype==0xb4fb
+		|| packtype==0xb5fb)
+	ok = true;
 
-    return(ok);
+	return(ok);
 }
 
 
@@ -545,25 +545,25 @@ bool GCALL HUFF_is(const void *compresseddata)
 
 int GCALL HUFF_size(const void *compresseddata)
 {
-    int len=0;
-    int packtype=ggetm(compresseddata,2);
-    int ssize=(packtype&0x8000)?4:3;
+	int len=0;
+	int packtype=ggetm(compresseddata,2);
+	int ssize=(packtype&0x8000)?4:3;
 
-    if (packtype&0x100)     /* 31fb 33fb 35fb */
-    {
-        len = ggetm((char *)compresseddata+2+ssize,ssize);
-    }
-    else                    /* 30fb 32fb 34fb */
-    {
-        len = ggetm((char *)compresseddata+2,ssize);
-    }
+	if (packtype&0x100)     /* 31fb 33fb 35fb */
+	{
+		len = ggetm((char *)compresseddata+2+ssize,ssize);
+	}
+	else                    /* 30fb 32fb 34fb */
+	{
+		len = ggetm((char *)compresseddata+2,ssize);
+	}
 
-    return(len);
+	return(len);
 }
 
 int GCALL HUFF_decode(void *dest, const void *compresseddata, int *compressedsize)
 {
-    return(HUFF_decompress((unsigned char *)compresseddata, (unsigned char *)dest));
+	return(HUFF_decompress((unsigned char *)compresseddata, (unsigned char *)dest));
 }
 
 #endif

--- a/Core/Libraries/Source/Compression/EAC/huffencode.cpp
+++ b/Core/Libraries/Source/Compression/EAC/huffencode.cpp
@@ -43,40 +43,40 @@ struct HUFFMemStruct
 
 struct HuffEncodeContext
 {
-    char            qleapcode[HUFFCODES];
-    unsigned int	count[768];
-    unsigned int	bitnum[HUFFMAXBITS+1];
-    unsigned int	repbits[HUFFREPTBL];
-    unsigned int	repbase[HUFFREPTBL];
-    unsigned int	tree_left[HUFFTREESIZE];
-    unsigned int	tree_right[HUFFTREESIZE];
-    unsigned int	bitsarray[HUFFCODES];
-    unsigned int	patternarray[HUFFCODES];
-    unsigned int	masks[17];
-    unsigned int	packbits;
-    unsigned int	workpattern;
-    unsigned char	*buffer;
-    unsigned char	*bufptr;
-    int			flen;
-    unsigned int	csum;
-    unsigned int	mostbits;
-    unsigned int	codes;
-    unsigned int	chainused;
-    unsigned int	clue;
-    unsigned int	dclue;
-    unsigned int	clues;
-    unsigned int	dclues;
-    int				mindelta;
-    int				maxdelta;
-    unsigned int	plen;
-    unsigned int	ulen;
-    unsigned int	sortptr[HUFFCODES];
+	char            qleapcode[HUFFCODES];
+	unsigned int	count[768];
+	unsigned int	bitnum[HUFFMAXBITS+1];
+	unsigned int	repbits[HUFFREPTBL];
+	unsigned int	repbase[HUFFREPTBL];
+	unsigned int	tree_left[HUFFTREESIZE];
+	unsigned int	tree_right[HUFFTREESIZE];
+	unsigned int	bitsarray[HUFFCODES];
+	unsigned int	patternarray[HUFFCODES];
+	unsigned int	masks[17];
+	unsigned int	packbits;
+	unsigned int	workpattern;
+	unsigned char	*buffer;
+	unsigned char	*bufptr;
+	int			flen;
+	unsigned int	csum;
+	unsigned int	mostbits;
+	unsigned int	codes;
+	unsigned int	chainused;
+	unsigned int	clue;
+	unsigned int	dclue;
+	unsigned int	clues;
+	unsigned int	dclues;
+	int				mindelta;
+	int				maxdelta;
+	unsigned int	plen;
+	unsigned int	ulen;
+	unsigned int	sortptr[HUFFCODES];
 };
 
 static void HUFF_deltabytes(const void *source,void *dest,int len)
 {
-    const unsigned char *s = (const unsigned char *) source;
-    unsigned char *d = (unsigned char *) dest;
+	const unsigned char *s = (const unsigned char *) source;
+	unsigned char *d = (unsigned char *) dest;
 	unsigned char c;
 	unsigned char c1;
 	const unsigned char *send;
@@ -93,9 +93,9 @@ static void HUFF_deltabytes(const void *source,void *dest,int len)
 
 
 static void HUFF_writebits(struct HuffEncodeContext *EC,
-                    struct HUFFMemStruct *dest,
-                    unsigned int	  bitpattern,
-                    unsigned int	  len)
+	struct HUFFMemStruct *dest,
+	unsigned int	  bitpattern,
+	unsigned int	  len)
 {
 	if (len > 16)
 	{
@@ -119,8 +119,8 @@ static void HUFF_writebits(struct HuffEncodeContext *EC,
 }
 
 static void HUFF_treechase(struct HuffEncodeContext *EC,
-                    unsigned int node,
-                    unsigned int bits)
+	unsigned int node,
+	unsigned int bits)
 {
 	if (node < HUFFCODES)
 		EC->bitsarray[node] = bits;
@@ -228,8 +228,8 @@ static void HUFF_maketree(struct HuffEncodeContext *EC)
 }
 
 static int HUFF_minrep(struct HuffEncodeContext *EC,
-                unsigned int remaining,
-                unsigned int r)
+	unsigned int remaining,
+	unsigned int r)
 {
 	int	min, min1, use, newremaining;
 
@@ -255,8 +255,8 @@ static int HUFF_minrep(struct HuffEncodeContext *EC,
 }
 
 static void HUFF_writenum(struct HuffEncodeContext *EC,
-                   struct HUFFMemStruct	*dest,
-                   unsigned int		num)
+	struct HUFFMemStruct	*dest,
+	unsigned int		num)
 {
 	unsigned int	dphuf;
 	unsigned int	dbase;
@@ -326,8 +326,8 @@ static void HUFF_writenum(struct HuffEncodeContext *EC,
 /* write explicite byte ([clue] 0gn [0] [byte]) */
 
 static void HUFF_writeexp(struct HuffEncodeContext *EC,
-                  struct HUFFMemStruct *dest,
-                  unsigned int code)
+	struct HUFFMemStruct *dest,
+	unsigned int code)
 {
 	HUFF_writebits(EC,dest,EC->patternarray[EC->clue], EC->bitsarray[EC->clue]);
 	HUFF_writenum(EC,dest,0L);
@@ -335,8 +335,8 @@ static void HUFF_writeexp(struct HuffEncodeContext *EC,
 }
 
 static void HUFF_writecode(struct HuffEncodeContext *EC,
-                    struct HUFFMemStruct *dest,
-                    unsigned int code)
+	struct HUFFMemStruct *dest,
+	unsigned int code)
 {
 	if (code==EC->clue)
 		HUFF_writeexp(EC,dest,code);
@@ -386,8 +386,8 @@ static void HUFF_init(struct HuffEncodeContext *EC)
 
 
 static void HUFF_analysis(struct HuffEncodeContext *EC,
-                   unsigned int opt,
-                   unsigned int chainsaw)
+	unsigned int opt,
+	unsigned int chainsaw)
 {
 	unsigned char			*bptr1;
 	unsigned char			*bptr2;
@@ -584,7 +584,7 @@ static void HUFF_analysis(struct HuffEncodeContext *EC,
 			if (EC->count[EC->clue+i])
 			{	i1 = HUFF_minrep(EC,i,i1);
 				if ((i1 <= EC->bitsarray[EC->clue+i])
-					 || (EC->count[EC->clue+i]*(i1-EC->bitsarray[EC->clue+i])<(i/2)))
+					|| (EC->count[EC->clue+i]*(i1-EC->bitsarray[EC->clue+i])<(i/2)))
 				{	EC->count[EC->clue+i] = 0;
 				}
 			}
@@ -850,8 +850,8 @@ static void HUFF_analysis(struct HuffEncodeContext *EC,
 
 
 static void HUFF_pack(struct HuffEncodeContext *EC,
-               struct HUFFMemStruct *dest,
-               unsigned int	opt)
+	struct HUFFMemStruct *dest,
+	unsigned int	opt)
 {
 	unsigned char			*bptr1;
 	unsigned char			*bptr2;
@@ -1068,10 +1068,10 @@ static void HUFF_pack(struct HuffEncodeContext *EC,
 }
 
 static int HUFF_packfile(struct HuffEncodeContext *EC,
-                   struct HUFFMemStruct	*infile,
-                   struct HUFFMemStruct	*outfile,
-                   int	ulen,
-                   int	deltaed)
+	struct HUFFMemStruct	*infile,
+	struct HUFFMemStruct	*outfile,
+	int	ulen,
+	int	deltaed)
 {
 	unsigned int i;
 	unsigned int uptype=0;
@@ -1114,61 +1114,61 @@ static int HUFF_packfile(struct HuffEncodeContext *EC,
 
 /* write standard header stuff (type/signature/ulen/adjust) */
 
-    if (ulen>0xffffff)  // 32 bit header required
-    {
+	if (ulen>0xffffff)  // 32 bit header required
+	{
     	/* simple fb6 header */
 
-    	if (ulen==infile->len)
-    	{
-    		if (deltaed==0) 		uptype = 0xb0fb;
-    		else if (deltaed==1)	uptype = 0xb2fb;
-    		else if (deltaed==2)	uptype = 0xb4fb;
-    		HUFF_writebits(EC,outfile,(unsigned int) uptype, 16);
-    		HUFF_writebits(EC,outfile,(unsigned int) infile->len, 32);
-    	}
+		if (ulen==infile->len)
+		{
+			if (deltaed==0) 		uptype = 0xb0fb;
+			else if (deltaed==1)	uptype = 0xb2fb;
+			else if (deltaed==2)	uptype = 0xb4fb;
+			HUFF_writebits(EC,outfile,(unsigned int) uptype, 16);
+			HUFF_writebits(EC,outfile,(unsigned int) infile->len, 32);
+		}
 
     	/* composite fb4 header */
 
-    	else
-    	{
-    		if (deltaed==0) 		uptype = 0xb1fb;
-    		else if (deltaed==1)	uptype = 0xb3fb;
-    		else if (deltaed==2)	uptype = 0xb5fb;
-    		HUFF_writebits(EC,outfile,(unsigned int) uptype, 16);
-    		HUFF_writebits(EC,outfile,(unsigned int) ulen, 32);
-    		HUFF_writebits(EC,outfile,(unsigned int) infile->len, 32);
-    	}
-    }
-    else
-    {
+		else
+		{
+			if (deltaed==0) 		uptype = 0xb1fb;
+			else if (deltaed==1)	uptype = 0xb3fb;
+			else if (deltaed==2)	uptype = 0xb5fb;
+			HUFF_writebits(EC,outfile,(unsigned int) uptype, 16);
+			HUFF_writebits(EC,outfile,(unsigned int) ulen, 32);
+			HUFF_writebits(EC,outfile,(unsigned int) infile->len, 32);
+		}
+	}
+	else
+	{
     	/* simple fb6 header */
 
 
-    	if (ulen==infile->len)
-    	{
-    		if (deltaed==0) 		uptype = 0x30fb;
-    		else if (deltaed==1)	uptype = 0x32fb;
-    		else if (deltaed==2)	uptype = 0x34fb;
-    		HUFF_writebits(EC,outfile,(unsigned int) uptype, 16);
-    		HUFF_writebits(EC,outfile,(unsigned int) infile->len, 24);
-    	}
+		if (ulen==infile->len)
+		{
+			if (deltaed==0) 		uptype = 0x30fb;
+			else if (deltaed==1)	uptype = 0x32fb;
+			else if (deltaed==2)	uptype = 0x34fb;
+			HUFF_writebits(EC,outfile,(unsigned int) uptype, 16);
+			HUFF_writebits(EC,outfile,(unsigned int) infile->len, 24);
+		}
 
     	/* composite fb4 header */
 
-    	else
-    	{
-    		if (deltaed==0) 		uptype = 0x31fb;
-    		else if (deltaed==1)	uptype = 0x33fb;
-    		else if (deltaed==2)	uptype = 0x35fb;
-    		HUFF_writebits(EC,outfile,(unsigned int) uptype, 16);
-    		HUFF_writebits(EC,outfile,(unsigned int) ulen, 24);
-    		HUFF_writebits(EC,outfile,(unsigned int) infile->len, 24);
-    	}
-    }
+		else
+		{
+			if (deltaed==0) 		uptype = 0x31fb;
+			else if (deltaed==1)	uptype = 0x33fb;
+			else if (deltaed==2)	uptype = 0x35fb;
+			HUFF_writebits(EC,outfile,(unsigned int) uptype, 16);
+			HUFF_writebits(EC,outfile,(unsigned int) ulen, 24);
+			HUFF_writebits(EC,outfile,(unsigned int) infile->len, 24);
+		}
+	}
 
 	HUFF_pack(EC,outfile, opt);
 
-    return(outfile->len);
+	return(outfile->len);
 }
 
 
@@ -1178,49 +1178,49 @@ static int HUFF_packfile(struct HuffEncodeContext *EC,
 
 int GCALL HUFF_encode(void *compresseddata, const void *source, int sourcesize, int *opts)
 {
-    int   plen=0;
-    struct HUFFMemStruct infile;
-    struct HUFFMemStruct outfile;
-    struct HuffEncodeContext *EC=nullptr;
-    void *deltabuf=nullptr;
-    int opt=0;
-    if (opts)
-        opt = opts[0];
+	int   plen=0;
+	struct HUFFMemStruct infile;
+	struct HUFFMemStruct outfile;
+	struct HuffEncodeContext *EC=nullptr;
+	void *deltabuf=nullptr;
+	int opt=0;
+	if (opts)
+	opt = opts[0];
 
-    EC = (struct HuffEncodeContext *)galloc(sizeof(struct HuffEncodeContext));
-    if (EC)
-    {
-        switch (opt)
-        {
-            default:
-            case 0:
-                infile.ptr = (char *)source;
-                break;
+	EC = (struct HuffEncodeContext *)galloc(sizeof(struct HuffEncodeContext));
+	if (EC)
+	{
+		switch (opt)
+		{
+			default:
+			case 0:
+				infile.ptr = (char *)source;
+				break;
 
-            case 1:
-                deltabuf = galloc(sourcesize);
-    			HUFF_deltabytes(source,deltabuf,sourcesize);
-                infile.ptr = (char *) deltabuf;
-                break;
+			case 1:
+				deltabuf = galloc(sourcesize);
+				HUFF_deltabytes(source,deltabuf,sourcesize);
+				infile.ptr = (char *) deltabuf;
+				break;
 
-            case 2:
-                deltabuf = galloc(sourcesize);
-    			HUFF_deltabytes(source,deltabuf,sourcesize);
-    			HUFF_deltabytes(deltabuf,deltabuf,sourcesize);
-                infile.ptr = (char *) deltabuf;
-                break;
-        }
+			case 2:
+				deltabuf = galloc(sourcesize);
+				HUFF_deltabytes(source,deltabuf,sourcesize);
+				HUFF_deltabytes(deltabuf,deltabuf,sourcesize);
+				infile.ptr = (char *) deltabuf;
+				break;
+		}
 
-        infile.len = sourcesize;
-        outfile.ptr = (char *)compresseddata;
-        outfile.len = sourcesize;
+		infile.len = sourcesize;
+		outfile.ptr = (char *)compresseddata;
+		outfile.len = sourcesize;
 
-        plen = HUFF_packfile(EC,&infile, &outfile, sourcesize, opt);
+		plen = HUFF_packfile(EC,&infile, &outfile, sourcesize, opt);
 
-        if (deltabuf) gfree(deltabuf);
-        gfree(EC);
-    }
-    return(plen);
+		if (deltabuf) gfree(deltabuf);
+		gfree(EC);
+	}
+	return(plen);
 }
 
 #endif

--- a/Core/Libraries/Source/Compression/EAC/refabout.cpp
+++ b/Core/Libraries/Source/Compression/EAC/refabout.cpp
@@ -83,23 +83,23 @@
 
 CODEXABOUT *GCALL REF_about()
 {
-    CODEXABOUT *info;
+	CODEXABOUT *info;
 
-    info = (CODEXABOUT *) galloc(sizeof(CODEXABOUT));
-    if (info)
-    {
-        memset(info, 0, sizeof(CODEXABOUT));
+	info = (CODEXABOUT *) galloc(sizeof(CODEXABOUT));
+	if (info)
+	{
+		memset(info, 0, sizeof(CODEXABOUT));
 
-        info->signature       = QMAKEID(0,'R','E','F');
-        info->size            = sizeof(CODEXABOUT);
-        info->version         = 200;    /* codex version number (200) */
-        info->decode          = 1;      /* supports decoding */
-        info->encode          = 1;      /* supports encoding */
-        info->size32          = 1;      /* supports 32 bit size field */
-        strcpy(info->versionstr,    "1.01");     /* version # */
-        strcpy(info->shorttypestr,  "ref");      /* type */
-        strcpy(info->longtypestr,   "Refpack");    /* longtype */
-    }
-    return(info);
+		info->signature       = QMAKEID(0,'R','E','F');
+		info->size            = sizeof(CODEXABOUT);
+		info->version         = 200;    /* codex version number (200) */
+		info->decode          = 1;      /* supports decoding */
+		info->encode          = 1;      /* supports encoding */
+		info->size32          = 1;      /* supports 32 bit size field */
+		strcpy(info->versionstr,    "1.01");     /* version # */
+		strcpy(info->shorttypestr,  "ref");      /* type */
+		strcpy(info->longtypestr,   "Refpack");    /* longtype */
+	}
+	return(info);
 }
 

--- a/Core/Libraries/Source/Compression/EAC/refdecode.cpp
+++ b/Core/Libraries/Source/Compression/EAC/refdecode.cpp
@@ -34,16 +34,16 @@
 
 bool GCALL REF_is(const void *compresseddata)
 {
-    bool ok=false;
-    int packtype=ggetm(compresseddata,2);
+	bool ok=false;
+	int packtype=ggetm(compresseddata,2);
 
-    if (packtype==0x10fb
-     || packtype==0x11fb
-     || packtype==0x90fb
-     || packtype==0x91fb)
-        ok = true;
+	if (packtype==0x10fb
+		|| packtype==0x11fb
+		|| packtype==0x90fb
+		|| packtype==0x91fb)
+	ok = true;
 
-    return(ok);
+	return(ok);
 }
 
 
@@ -53,133 +53,133 @@ bool GCALL REF_is(const void *compresseddata)
 
 int GCALL REF_size(const void *compresseddata)
 {
-    int len=0;
-    int packtype=ggetm(compresseddata,2);
-    int ssize=(packtype&0x8000)?4:3;
+	int len=0;
+	int packtype=ggetm(compresseddata,2);
+	int ssize=(packtype&0x8000)?4:3;
 
-    if (packtype&0x100)     /* 11fb */
-    {
-        len = ggetm((char *)compresseddata+2+ssize,ssize);
-    }
-    else                    /* 10fb */
-    {
-        len = ggetm((char *)compresseddata+2,ssize);
-    }
+	if (packtype&0x100)     /* 11fb */
+	{
+		len = ggetm((char *)compresseddata+2+ssize,ssize);
+	}
+	else                    /* 10fb */
+	{
+		len = ggetm((char *)compresseddata+2,ssize);
+	}
 
-    return(len);
+	return(len);
 }
 
 
 int GCALL REF_decode(void *dest, const void *compresseddata, int *compressedsize)
 {
-    unsigned char *s;
-    unsigned char *ref;
-    unsigned char *d;
-    unsigned char first;
-    unsigned char second;
-    unsigned char third;
-    unsigned char forth;
-    unsigned int  run;
-    unsigned int  type;
-    int          ulen;
+	unsigned char *s;
+	unsigned char *ref;
+	unsigned char *d;
+	unsigned char first;
+	unsigned char second;
+	unsigned char third;
+	unsigned char forth;
+	unsigned int  run;
+	unsigned int  type;
+	int          ulen;
 
-    s = (unsigned char *) compresseddata;
-    d = (unsigned char *) dest;
-    ulen = 0L;
+	s = (unsigned char *) compresseddata;
+	d = (unsigned char *) dest;
+	ulen = 0L;
 
-    if (s)
-    {
-        type = *s++;
-        type = (type<<8) + *s++;
+	if (s)
+	{
+		type = *s++;
+		type = (type<<8) + *s++;
 
-        if (type&0x8000) /* 4 byte size field */
-        {
-            if (type&0x100)                       /* skip ulen */
-                s += 4;
+		if (type&0x8000) /* 4 byte size field */
+		{
+			if (type&0x100)                       /* skip ulen */
+			s += 4;
 
-            ulen = *s++;
-            ulen = (ulen<<8) + *s++;
-            ulen = (ulen<<8) + *s++;
-            ulen = (ulen<<8) + *s++;
-        }
-        else
-        {
-            if (type&0x100)                       /* skip ulen */
-                s += 3;
+			ulen = *s++;
+			ulen = (ulen<<8) + *s++;
+			ulen = (ulen<<8) + *s++;
+			ulen = (ulen<<8) + *s++;
+		}
+		else
+		{
+			if (type&0x100)                       /* skip ulen */
+			s += 3;
 
-            ulen = *s++;
-            ulen = (ulen<<8) + *s++;
-            ulen = (ulen<<8) + *s++;
-        }
+			ulen = *s++;
+			ulen = (ulen<<8) + *s++;
+			ulen = (ulen<<8) + *s++;
+		}
 
-        for (;;)
-        {
-            first = *s++;
-            if (!(first&0x80))          /* short form */
-            {
-                second = *s++;
-                run = first&3;
-                while (run--)
-                    *d++ = *s++;
-                ref = d-1 - (((first&0x60)<<3) + second);
-                run = ((first&0x1c)>>2)+3-1;
-                do
-                {
-                    *d++ = *ref++;
-                } while (run--);
-                continue;
-            }
-            if (!(first&0x40))          /* int form */
-            {
-                second = *s++;
-                third = *s++;
-                run = second>>6;
-                while (run--)
-                    *d++ = *s++;
+		for (;;)
+		{
+			first = *s++;
+			if (!(first&0x80))          /* short form */
+			{
+				second = *s++;
+				run = first&3;
+				while (run--)
+				*d++ = *s++;
+				ref = d-1 - (((first&0x60)<<3) + second);
+				run = ((first&0x1c)>>2)+3-1;
+				do
+				{
+					*d++ = *ref++;
+				} while (run--);
+				continue;
+			}
+			if (!(first&0x40))          /* int form */
+			{
+				second = *s++;
+				third = *s++;
+				run = second>>6;
+				while (run--)
+				*d++ = *s++;
 
-                ref = d-1 - (((second&0x3f)<<8) + third);
+				ref = d-1 - (((second&0x3f)<<8) + third);
 
-                run = (first&0x3f)+4-1;
-                do
-                {
-                    *d++ = *ref++;
-                } while (run--);
-                continue;
-            }
-            if (!(first&0x20))          /* very int form */
-            {
-                second = *s++;
-                third = *s++;
-                forth = *s++;
-                run = first&3;
-                while (run--)
-                    *d++ = *s++;
+				run = (first&0x3f)+4-1;
+				do
+				{
+					*d++ = *ref++;
+				} while (run--);
+				continue;
+			}
+			if (!(first&0x20))          /* very int form */
+			{
+				second = *s++;
+				third = *s++;
+				forth = *s++;
+				run = first&3;
+				while (run--)
+				*d++ = *s++;
 
-                ref = d-1 - (((first&0x10)>>4<<16) +  (second<<8) + third);
+				ref = d-1 - (((first&0x10)>>4<<16) +  (second<<8) + third);
 
-                run = ((first&0x0c)>>2<<8) + forth + 5-1;
-                do
-                {
-                    *d++ = *ref++;
-                } while (run--);
-                continue;
-            }
-            run = ((first&0x1f)<<2)+4;  /* literal */
-            if (run<=112)
-            {
-                while (run--)
-                    *d++ = *s++;
-                continue;
-            }
-            run = first&3;              /* eof (+0..3 literal) */
-            while (run--)
-                *d++ = *s++;
-            break;
-        }
-    }
-    if (compressedsize)
-        *compressedsize = (int)((char *)s-(char *)compresseddata);
-    return(ulen);
+				run = ((first&0x0c)>>2<<8) + forth + 5-1;
+				do
+				{
+					*d++ = *ref++;
+				} while (run--);
+				continue;
+			}
+			run = ((first&0x1f)<<2)+4;  /* literal */
+			if (run<=112)
+			{
+				while (run--)
+				*d++ = *s++;
+				continue;
+			}
+			run = first&3;              /* eof (+0..3 literal) */
+			while (run--)
+			*d++ = *s++;
+			break;
+		}
+	}
+	if (compressedsize)
+	*compressedsize = (int)((char *)s-(char *)compresseddata);
+	return(ulen);
 }
 
 #endif

--- a/Core/Libraries/Source/Compression/EAC/refencode.cpp
+++ b/Core/Libraries/Source/Compression/EAC/refencode.cpp
@@ -31,205 +31,205 @@
 
 static unsigned int matchlen(unsigned char *s,unsigned char *d, unsigned int maxmatch)
 {
-    unsigned int current;
+	unsigned int current;
 
-    for (current=0; current<maxmatch && *s++==*d++; ++current)
-        ;
+	for (current=0; current<maxmatch && *s++==*d++; ++current)
+	;
 
-    return(current);
+	return(current);
 }
 
 #define HASH(cptr) (int)((((unsigned int)(unsigned char)cptr[0]<<8) | ((unsigned int)(unsigned char)cptr[2])) ^ ((unsigned int)(unsigned char)cptr[1]<<4))
 
 static int refcompress(unsigned char *from, int len, unsigned char *dest, int maxback, int quick)
 {
-    unsigned int tlen;
-    unsigned int tcost;
+	unsigned int tlen;
+	unsigned int tcost;
 //    unsigned int ccost;    // context cost
-    unsigned int run;
-    unsigned int toffset;
-    unsigned int boffset;
-    unsigned int blen;
-    unsigned int bcost;
-    unsigned int mlen;
-    unsigned char *tptr;
-    unsigned char *cptr;
-    unsigned char *to;
-    unsigned char *rptr;
-    int countliterals=0;
-    int countshort=0;
-    int countint=0;
-    int countvint=0;
-    int hash;
-    int hoffset;
-    int minhoffset;
-    int i;
-    int *link;
-    int *hashtbl;
+	unsigned int run;
+	unsigned int toffset;
+	unsigned int boffset;
+	unsigned int blen;
+	unsigned int bcost;
+	unsigned int mlen;
+	unsigned char *tptr;
+	unsigned char *cptr;
+	unsigned char *to;
+	unsigned char *rptr;
+	int countliterals=0;
+	int countshort=0;
+	int countint=0;
+	int countvint=0;
+	int hash;
+	int hoffset;
+	int minhoffset;
+	int i;
+	int *link;
+	int *hashtbl;
 
-    to = dest;
-    run = 0;
-    cptr = rptr = from;
+	to = dest;
+	run = 0;
+	cptr = rptr = from;
 
-    if ((unsigned int)maxback > (unsigned int)131071)
-        maxback = 131071;
+	if ((unsigned int)maxback > (unsigned int)131071)
+	maxback = 131071;
 
 	hashtbl = (int *) galloc(65536L*sizeof(int));
 	if (!hashtbl)
-        return(0);
+	return(0);
 	link = (int *) galloc(131072L*sizeof(int));
 	if (!link)
 	{
-	    gfree(hashtbl);
-	    return(0);
+		gfree(hashtbl);
+		return(0);
 	}
 
-    memset(hashtbl,-1,65536L*sizeof(int));
+	memset(hashtbl,-1,65536L*sizeof(int));
 
-    len -= 4;
-    while (len>=0)
-    {
-        boffset = 0;
-        blen = 2;
-        bcost = 2;
+	len -= 4;
+	while (len>=0)
+	{
+		boffset = 0;
+		blen = 2;
+		bcost = 2;
 //        ccost = 0;
-        mlen = qmin(len,1028);
-        tptr=cptr-1;
-        hash = HASH(cptr);
-        hoffset = hashtbl[hash];
-        minhoffset = qmax(cptr-from-131071,0);
+		mlen = qmin(len,1028);
+		tptr=cptr-1;
+		hash = HASH(cptr);
+		hoffset = hashtbl[hash];
+		minhoffset = qmax(cptr-from-131071,0);
 
 
-        if (hoffset>=minhoffset)
-        {
-            do
-            {
-                tptr = from+hoffset;
-                if (cptr[blen]==tptr[blen])
-                {
-                    tlen = matchlen(cptr,tptr,mlen);
-                    if (tlen > blen)
-                    {
-                        toffset = (cptr-1)-tptr;
-                        if (toffset<1024 && tlen<=10)       /* two byte int form */
-                            tcost = 2;
-                        else if (toffset<16384 && tlen<=67) /* three byte int form */
-                            tcost = 3;
-                        else                                /* four byte very int form */
-                            tcost = 4;
+		if (hoffset>=minhoffset)
+		{
+			do
+			{
+				tptr = from+hoffset;
+				if (cptr[blen]==tptr[blen])
+				{
+					tlen = matchlen(cptr,tptr,mlen);
+					if (tlen > blen)
+					{
+						toffset = (cptr-1)-tptr;
+						if (toffset<1024 && tlen<=10)       /* two byte int form */
+						tcost = 2;
+						else if (toffset<16384 && tlen<=67) /* three byte int form */
+						tcost = 3;
+						else                                /* four byte very int form */
+						tcost = 4;
 
-                        if (tlen-tcost+4 > blen-bcost+4)
-                        {
-                            blen = tlen;
-                            bcost = tcost;
-                            boffset = toffset;
-                            if (blen>=1028) break;
-                        }
-                    }
-                }
-            } while ((hoffset = link[hoffset&131071]) >= minhoffset);
-        }
+						if (tlen-tcost+4 > blen-bcost+4)
+						{
+							blen = tlen;
+							bcost = tcost;
+							boffset = toffset;
+							if (blen>=1028) break;
+						}
+					}
+				}
+			} while ((hoffset = link[hoffset&131071]) >= minhoffset);
+		}
 
 //        ccost = 0;
 //        if ((run<4) && ((run+blen)>=4))
 //            ccost = 1;  // extra packet cost to switch out of literal into reference
 
 //        if (bcost>blen || (blen<=2 && bcost==blen && !ccost) || (len<4))
-        if (bcost>=blen || len<4)
-        {
-            hoffset = (cptr-from);
-            link[hoffset&131071] = hashtbl[hash];
-            hashtbl[hash] = hoffset;
+		if (bcost>=blen || len<4)
+		{
+			hoffset = (cptr-from);
+			link[hoffset&131071] = hashtbl[hash];
+			hashtbl[hash] = hoffset;
 
-            ++run;
-            ++cptr;
-            --len;
-        }
-        else
-        {
-            while (run>3)                   /* literal block of data */
-            {
-                tlen = qmin(112,run&~3);
-                run -= tlen;
-                *to++ = (unsigned char) (0xe0+(tlen>>2)-1);
-                memcpy(to,rptr,tlen);
-                rptr += tlen;
-                to += tlen;
-                ++countliterals;
-            }
-            if (bcost==2)                   /* two byte int form */
-            {
-                *to++ = (unsigned char) (((boffset>>8)<<5) + ((blen-3)<<2) + run);
-                *to++ = (unsigned char) boffset;
-                ++countshort;
-            }
-            else if (bcost==3)              /* three byte int form */
-            {
-                *to++ = (unsigned char) (0x80 + (blen-4));
-                *to++ = (unsigned char) ((run<<6) + (boffset>>8));
-                *to++ = (unsigned char) boffset;
-                ++countint;
-            }
-            else                            /* four byte very int form */
-            {
-                *to++ = (unsigned char) (0xc0 + ((boffset>>16)<<4) + (((blen-5)>>8)<<2) + run);
-                *to++ = (unsigned char) (boffset>>8);
-                *to++ = (unsigned char) (boffset);
-                *to++ = (unsigned char) (blen-5);
-                ++countvint;
-            }
-            if (run)
-            {
-                memcpy(to, rptr, run);
-                to += run;
-                run = 0;
-            }
+			++run;
+			++cptr;
+			--len;
+		}
+		else
+		{
+			while (run>3)                   /* literal block of data */
+			{
+				tlen = qmin(112,run&~3);
+				run -= tlen;
+				*to++ = (unsigned char) (0xe0+(tlen>>2)-1);
+				memcpy(to,rptr,tlen);
+				rptr += tlen;
+				to += tlen;
+				++countliterals;
+			}
+			if (bcost==2)                   /* two byte int form */
+			{
+				*to++ = (unsigned char) (((boffset>>8)<<5) + ((blen-3)<<2) + run);
+				*to++ = (unsigned char) boffset;
+				++countshort;
+			}
+			else if (bcost==3)              /* three byte int form */
+			{
+				*to++ = (unsigned char) (0x80 + (blen-4));
+				*to++ = (unsigned char) ((run<<6) + (boffset>>8));
+				*to++ = (unsigned char) boffset;
+				++countint;
+			}
+			else                            /* four byte very int form */
+			{
+				*to++ = (unsigned char) (0xc0 + ((boffset>>16)<<4) + (((blen-5)>>8)<<2) + run);
+				*to++ = (unsigned char) (boffset>>8);
+				*to++ = (unsigned char) (boffset);
+				*to++ = (unsigned char) (blen-5);
+				++countvint;
+			}
+			if (run)
+			{
+				memcpy(to, rptr, run);
+				to += run;
+				run = 0;
+			}
 
-            if (quick)
-            {
-                hoffset = (cptr-from);
-                link[hoffset&131071] = hashtbl[hash];
-                hashtbl[hash] = hoffset;
-                cptr += blen;
-            }
-            else
-            {
-                for (i=0; i < (int)blen; ++i)
-                {
-                    hash = HASH(cptr);
-                    hoffset = (cptr-from);
-                    link[hoffset&131071] = hashtbl[hash];
-                    hashtbl[hash] = hoffset;
-                    ++cptr;
-                }
-            }
+			if (quick)
+			{
+				hoffset = (cptr-from);
+				link[hoffset&131071] = hashtbl[hash];
+				hashtbl[hash] = hoffset;
+				cptr += blen;
+			}
+			else
+			{
+				for (i=0; i < (int)blen; ++i)
+				{
+					hash = HASH(cptr);
+					hoffset = (cptr-from);
+					link[hoffset&131071] = hashtbl[hash];
+					hashtbl[hash] = hoffset;
+					++cptr;
+				}
+			}
 
-            rptr = cptr;
-            len -= blen;
-        }
-    }
-    len += 4;
-    run += len;
-    while (run>3)                       /* no match at end, use literal */
-    {
-        tlen = qmin(112,run&~3);
-        run -= tlen;
-        *to++ = (unsigned char) (0xe0+(tlen>>2)-1);
-        memcpy(to,rptr,tlen);
-        rptr += tlen;
-        to += tlen;
-    }
+			rptr = cptr;
+			len -= blen;
+		}
+	}
+	len += 4;
+	run += len;
+	while (run>3)                       /* no match at end, use literal */
+	{
+		tlen = qmin(112,run&~3);
+		run -= tlen;
+		*to++ = (unsigned char) (0xe0+(tlen>>2)-1);
+		memcpy(to,rptr,tlen);
+		rptr += tlen;
+		to += tlen;
+	}
 
-    *to++ = (unsigned char) (0xfc+run); /* end of stream command + 0..3 literal */
-    if (run)
-    {
-        memcpy(to,rptr,run);
-        to += run;
-    }
+	*to++ = (unsigned char) (0xfc+run); /* end of stream command + 0..3 literal */
+	if (run)
+	{
+		memcpy(to,rptr,run);
+		to += run;
+	}
 
 	gfree(link);
 	gfree(hashtbl);
-    return(to-dest);
+	return(to-dest);
 }
 
 
@@ -239,28 +239,28 @@ static int refcompress(unsigned char *from, int len, unsigned char *dest, int ma
 
 int GCALL REF_encode(void *compresseddata, const void *source, int sourcesize, int *opts)
 {
-    int    maxback=131072;
-    int     quick=0;
-    int    plen;
-    int    hlen;
+	int    maxback=131072;
+	int     quick=0;
+	int    plen;
+	int    hlen;
 
 
     /* simple fb6 header */
 
-    if (sourcesize>0xffffff)  // 32 bit header required
-    {
-        gputm(compresseddata,   (unsigned int) 0x90fb, 2);
-        gputm((char *)compresseddata+2, (unsigned int) sourcesize, 4);
-        hlen = 6L;
-    }
-    else
-    {
-        gputm(compresseddata,   (unsigned int) 0x10fb, 2);
-        gputm((char *)compresseddata+2, (unsigned int) sourcesize, 3);
-        hlen = 5L;
-    }
-    plen = hlen+refcompress((unsigned char *)source, sourcesize, (unsigned char *)compresseddata+hlen, maxback, quick);
-    return(plen);
+	if (sourcesize>0xffffff)  // 32 bit header required
+	{
+		gputm(compresseddata,   (unsigned int) 0x90fb, 2);
+		gputm((char *)compresseddata+2, (unsigned int) sourcesize, 4);
+		hlen = 6L;
+	}
+	else
+	{
+		gputm(compresseddata,   (unsigned int) 0x10fb, 2);
+		gputm((char *)compresseddata+2, (unsigned int) sourcesize, 3);
+		hlen = 5L;
+	}
+	plen = hlen+refcompress((unsigned char *)source, sourcesize, (unsigned char *)compresseddata+hlen, maxback, quick);
+	return(plen);
 }
 
 #endif

--- a/Core/Libraries/Source/Compression/LZHCompress/NoxCompress.cpp
+++ b/Core/Libraries/Source/Compression/LZHCompress/NoxCompress.cpp
@@ -89,7 +89,7 @@ Bool DecompressFile		(char *infile, char *outfile)
 		for (;;)
 		{
 			ok = LZHLDecompress( decompress, outBlock + rawSize - dstSz, &dstSz,
-																			 inBlock + compressedSize - srcSz, &srcSz);
+				inBlock + compressedSize - srcSz, &srcSz);
 
 			if ( !ok )
 				break;
@@ -245,7 +245,7 @@ Bool DecompressMemory		(void *inBufferVoid, Int inSize, void *outBufferVoid, Int
 	for (;;)
 	{
 		ok = LZHLDecompress( decompress, outBuffer + rawSize - dstSz, &dstSz,
-																		 inBuffer + compressedSize - srcSz, &srcSz);
+			inBuffer + compressedSize - srcSz, &srcSz);
 
 		if ( !ok )
 			break;

--- a/Core/Libraries/Source/WWVegas/WW3D2/FramGrab.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/FramGrab.cpp
@@ -54,8 +54,8 @@ FrameGrabClass::FrameGrabClass(const char *filename, MODE mode, int width, int h
 	} while(result != -1);
 
 	// Create new AVI file using AVIFileOpen.
-    hr = AVIFileOpen(&AVIFile, file, OF_WRITE | OF_CREATE, nullptr);
-    if (hr != 0) {
+	hr = AVIFileOpen(&AVIFile, file, OF_WRITE | OF_CREATE, nullptr);
+	if (hr != 0) {
 		char buf[256];
 		snprintf(buf, ARRAY_SIZE(buf), "Unable to open %s\n", Filename);
 		OutputDebugString(buf);
@@ -64,7 +64,7 @@ FrameGrabClass::FrameGrabClass(const char *filename, MODE mode, int width, int h
 	}
 
 
-    // Create a stream using AVIFileCreateStream.
+	// Create a stream using AVIFileCreateStream.
 	AVIStreamInfo.fccType = streamtypeVIDEO;
 	AVIStreamInfo.fccHandler = mmioFOURCC('M','S','V','C');
 	AVIStreamInfo.dwFlags = 0;
@@ -84,32 +84,32 @@ FrameGrabClass::FrameGrabClass(const char *filename, MODE mode, int width, int h
 	AVIStreamInfo.dwFormatChangeCount = 0;
 	sprintf(AVIStreamInfo.szName,"G");
 
-    hr = AVIFileCreateStream(AVIFile, &Stream, &AVIStreamInfo);
-    if (hr != 0) {
+	hr = AVIFileCreateStream(AVIFile, &Stream, &AVIStreamInfo);
+	if (hr != 0) {
 		CleanupAVI();
 		return;
 	}
 
-    // Set format of new stream
+	// Set format of new stream
 	BitmapInfoHeader.biWidth = width;
 	BitmapInfoHeader.biHeight = height;
 	BitmapInfoHeader.biBitCount = (unsigned short)bitcount;
-    BitmapInfoHeader.biSizeImage = ((((UINT)BitmapInfoHeader.biBitCount * BitmapInfoHeader.biWidth + 31) & ~31) / 8) * BitmapInfoHeader.biHeight;
+	BitmapInfoHeader.biSizeImage = ((((UINT)BitmapInfoHeader.biBitCount * BitmapInfoHeader.biWidth + 31) & ~31) / 8) * BitmapInfoHeader.biHeight;
 	BitmapInfoHeader.biSize = sizeof(BITMAPINFOHEADER); // size of structure
 	BitmapInfoHeader.biPlanes = 1; // must be set to 1
 	BitmapInfoHeader.biCompression = BI_RGB; // uncompressed
- 	BitmapInfoHeader.biXPelsPerMeter = 1; // not used
+	BitmapInfoHeader.biXPelsPerMeter = 1; // not used
 	BitmapInfoHeader.biYPelsPerMeter = 1; // not used
 	BitmapInfoHeader.biClrUsed = 0; // all colors are used
 	BitmapInfoHeader.biClrImportant = 0; // all colors are important
 
-    hr = AVIStreamSetFormat(Stream, 0, &BitmapInfoHeader, sizeof(BitmapInfoHeader));
-    if (hr != 0) {
+	hr = AVIStreamSetFormat(Stream, 0, &BitmapInfoHeader, sizeof(BitmapInfoHeader));
+	if (hr != 0) {
 		CleanupAVI();
 		return;
 	}
 
-    Bitmap = (long *) GlobalAllocPtr(GMEM_MOVEABLE, BitmapInfoHeader.biSizeImage);
+	Bitmap = (long *) GlobalAllocPtr(GMEM_MOVEABLE, BitmapInfoHeader.biSizeImage);
 }
 
 FrameGrabClass::~FrameGrabClass()
@@ -130,10 +130,10 @@ void FrameGrabClass::CleanupAVI() {
 
 void FrameGrabClass::GrabAVI(void *BitmapPointer)
 {
-    // CompressDIB(&bi, lpOld, &biNew, lpNew);
+	// CompressDIB(&bi, lpOld, &biNew, lpNew);
 
-    // Save the compressed data using AVIStreamWrite.
-    HRESULT hr = AVIStreamWrite(Stream, Counter++, 1, BitmapPointer, BitmapInfoHeader.biSizeImage, AVIIF_KEYFRAME, nullptr, nullptr);
+	// Save the compressed data using AVIStreamWrite.
+	HRESULT hr = AVIStreamWrite(Stream, Counter++, 1, BitmapPointer, BitmapInfoHeader.biSizeImage, AVIIF_KEYFRAME, nullptr, nullptr);
 	if(hr != 0) {
 		char buf[256];
 		sprintf(buf, "avi write error %x/%d\n", hr, hr);

--- a/Core/Libraries/Source/WWVegas/WW3D2/agg_def.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/agg_def.cpp
@@ -237,8 +237,8 @@ AggregateDefClass::Find_Subobject
 	// Loop through all the models in our "path" until we've either failed
 	// or found the exact mesh we were looking for...
 	for (int index = 1;
-		  (mesh_path[index][0] != 0) && (parent_model != nullptr);
-		  index ++) {
+	(mesh_path[index][0] != 0) && (parent_model != nullptr);
+	index ++) {
 
 		// Look one level deeper into the subobject chain...
 		RenderObjClass *sub_obj = nullptr;
@@ -325,7 +325,7 @@ AggregateDefClass::Create_Render_Object (const char *passet_name)
 	// If we couldn't find the render object in the asset manager, then attempt to
 	// load it from file
 	if ((prender_obj == nullptr) &&
-	    Load_Assets (passet_name)) {
+		Load_Assets (passet_name)) {
 
 		// It should be in the asset manager now, so attempt to get it again.
 		prender_obj = WW3DAssetManager::Get_Instance()->Create_Render_Obj (passet_name);
@@ -434,8 +434,8 @@ AggregateDefClass::Build_Subobject_List
 		// Build a list of nodes that are contained in the vanilla model
 		DynamicVectorClass <RenderObjClass *> orig_node_list;
 		for (index = 0;
-			  index < original_model.Get_Num_Sub_Objects_On_Bone (bone_index);
-			  index ++) {
+		index < original_model.Get_Num_Sub_Objects_On_Bone (bone_index);
+		index ++) {
 			RenderObjClass *psubobj = original_model.Get_Sub_Object_On_Bone (index, bone_index);
 			if (psubobj != nullptr) {
 				orig_node_list.Add (psubobj);
@@ -445,8 +445,8 @@ AggregateDefClass::Build_Subobject_List
 		// Build a list of nodes that are contained in this bone
 		DynamicVectorClass <RenderObjClass *> node_list;
 		for (index = 0;
-			  index < model.Get_Num_Sub_Objects_On_Bone (bone_index);
-			  index ++) {
+		index < model.Get_Num_Sub_Objects_On_Bone (bone_index);
+		index ++) {
 			RenderObjClass *psubobj = model.Get_Sub_Object_On_Bone (index, bone_index);
 			if (psubobj != nullptr) {
 				node_list.Add (psubobj);
@@ -465,7 +465,7 @@ AggregateDefClass::Build_Subobject_List
 				// Is this subobject new?  (i.e. not in a 'vanilla' instance?)
 				const char *prototype_name = psubobject->Get_Name ();
 				if (psubobject != nullptr &&
-					 (Is_Object_In_List (prototype_name, orig_node_list) == false)) {
+					(Is_Object_In_List (prototype_name, orig_node_list) == false)) {
 
 					// Add this subobject to our list
 					::lstrcpy (subobj_info.SubobjectName, prototype_name);
@@ -520,7 +520,7 @@ AggregateDefClass::Is_Object_In_List
 
 		// Is this the render object we were looking for?
 		if (prender_obj != nullptr &&
-		    ::lstrcmpi (prender_obj->Get_Name (), passet_name) == 0) {
+			::lstrcmpi (prender_obj->Get_Name (), passet_name) == 0) {
 			retval = true;
 		}
 	}
@@ -625,8 +625,8 @@ AggregateDefClass::Read_Info (ChunkLoadClass &chunk_load)
 
 		// Read all the subobjects from the file
 		for (UINT isubobject = 0;
-			  (isubobject < m_Info.SubobjectCount) && (ret_val == WW3D_ERROR_OK);
-			  isubobject ++) {
+		(isubobject < m_Info.SubobjectCount) && (ret_val == WW3D_ERROR_OK);
+		isubobject ++) {
 
 			// Read this subobject's definition from the file
 			ret_val = Read_Subobject (chunk_load);
@@ -720,8 +720,8 @@ AggregateDefClass::Save_W3D (ChunkSaveClass &chunk_save)
 
 		// Attempt to save the different sections of the aggregate definition
 		if ((Save_Header (chunk_save) == WW3D_ERROR_OK) &&
-			 (Save_Info (chunk_save) == WW3D_ERROR_OK) &&
-			 (Save_Class_Info (chunk_save) == WW3D_ERROR_OK)) {
+			(Save_Info (chunk_save) == WW3D_ERROR_OK) &&
+			(Save_Class_Info (chunk_save) == WW3D_ERROR_OK)) {
 
 			// Success!
 			ret_val = WW3D_ERROR_OK;
@@ -790,8 +790,8 @@ AggregateDefClass::Save_Info (ChunkSaveClass &chunk_save)
 
 			// Write all the subobjects to the file
 			for (int isubobject = 0;
-			     (isubobject < m_SubobjectList.Count ()) && (ret_val == WW3D_ERROR_OK);
-				  isubobject ++) {
+			(isubobject < m_SubobjectList.Count ()) && (ret_val == WW3D_ERROR_OK);
+			isubobject ++) {
 
 				// Write this object to the file
 				ret_val = Save_Subobject (chunk_save, m_SubobjectList[isubobject]);
@@ -889,7 +889,7 @@ AggregateLoaderClass::Load_W3D (ChunkLoadClass &chunk_load)
 		}
 	}
 
-    // Return a pointer to the prototype
-	 return pprototype;
+	// Return a pointer to the prototype
+	return pprototype;
 }
 

--- a/Core/Libraries/Source/WWVegas/WW3D2/animatedsoundmgr.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/animatedsoundmgr.cpp
@@ -104,8 +104,8 @@ Build_List_From_String
 	WWASSERT (delimiter != nullptr);
 	WWASSERT (string_list != nullptr);
 	if ((buffer != nullptr) &&
-		 (delimiter != nullptr) &&
-		 (string_list != nullptr))
+		(delimiter != nullptr) &&
+		(string_list != nullptr))
 	{
 		int delim_len = ::strlen (delimiter);
 
@@ -114,8 +114,8 @@ Build_List_From_String
 		//
 		const char *entry = buffer;
 		for (;
-			  (entry != nullptr) && (entry[1] != 0);
-			  entry = ::strstr (entry, delimiter))
+		(entry != nullptr) && (entry[1] != 0);
+		entry = ::strstr (entry, delimiter))
 		{
 
 			//
@@ -141,8 +141,8 @@ Build_List_From_String
 			//
 			count = 0;
 			for (entry = buffer;
-				  (entry != nullptr) && (entry[1] != 0);
-				  entry = ::strstr (entry, delimiter))
+			(entry != nullptr) && (entry[1] != 0);
+			entry = ::strstr (entry, delimiter))
 			{
 
 				//
@@ -228,7 +228,7 @@ Is_In_Param_List
 			// if ( stricmp( string.Peek_Buffer(), param_to_check ) == 0 ) // Breaks with whitespaces
 			if ( strstr( string.str(), param_to_check ) != nullptr )
 			{
-			 	return( true );
+				return( true );
 			}
 		}
 	}

--- a/Core/Libraries/Source/WWVegas/WW3D2/bitmaphandler.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/bitmaphandler.cpp
@@ -213,9 +213,9 @@ void BitmapHandlerClass::Copy_Image(
 				int iDv = (v1M-v10); // The delta-v bump value
 
 				if( (v00 < vM1) && (v00 < v01) ) {  // If we are at valley
-					 iDu = vM1-v00;                 // Choose greater of 1st order diffs
-					 if( iDu < v00-v01 )
-						  iDu = v00-v01;
+					iDu = vM1-v00;                 // Choose greater of 1st order diffs
+					if( iDu < v00-v01 )
+					iDu = v00-v01;
 				}
 
 				// The luminance bump value (land masses are less shiny)

--- a/Core/Libraries/Source/WWVegas/WW3D2/collect.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/collect.cpp
@@ -835,11 +835,11 @@ void CollectionClass::Update_Obj_Space_Bounding_Volumes()
 
 	BoundBox.Init(box);
 
-   Invalidate_Cached_Bounding_Volumes();
+	Invalidate_Cached_Bounding_Volumes();
 
-   // Now update the object space bounding volumes of this object's container:
-   RenderObjClass *container = Get_Container();
-   if (container) container->Update_Obj_Space_Bounding_Volumes();
+	// Now update the object space bounding volumes of this object's container:
+	RenderObjClass *container = Get_Container();
+	if (container) container->Update_Obj_Space_Bounding_Volumes();
 
 	Set_Transform(tm);
 }
@@ -1045,8 +1045,8 @@ WW3DErrorType CollectionDefClass::Load(ChunkLoadClass & cload)
 
 				// Create a matrix from the data in the chunk
 				Matrix3D transform (info.transform[0][0], info.transform[1][0], info.transform[2][0], info.transform[3][0],
-										  info.transform[0][1], info.transform[1][1], info.transform[2][1], info.transform[3][1],
-										  info.transform[0][2], info.transform[1][2], info.transform[2][2], info.transform[3][2]);
+					info.transform[0][1], info.transform[1][1], info.transform[2][1], info.transform[3][1],
+					info.transform[0][2], info.transform[1][2], info.transform[2][2], info.transform[3][2]);
 
 				// Add this placeholder to our list
 				ProxyList.Add (ProxyClass (name, transform));

--- a/Core/Libraries/Source/WWVegas/WW3D2/collect.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/collect.h
@@ -111,7 +111,7 @@ public:
 	virtual void					Get_Snap_Point(int index,Vector3 * set) override;
 	virtual void					Scale(float scale) override;
 	virtual void					Scale(float scalex, float scaley, float scalez) override;
-   virtual void               Update_Obj_Space_Bounding_Volumes() override;
+	virtual void               Update_Obj_Space_Bounding_Volumes() override;
 
 protected:
 

--- a/Core/Libraries/Source/WWVegas/WW3D2/composite.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/composite.cpp
@@ -518,11 +518,11 @@ void CompositeRenderObjClass::Update_Obj_Space_Bounding_Volumes()
 
 	ObjBox.Init(box);
 
-   Invalidate_Cached_Bounding_Volumes();
+	Invalidate_Cached_Bounding_Volumes();
 
-   // Now update the object space bounding volumes of this object's container:
-   RenderObjClass *container = Get_Container();
-   if (container) container->Update_Obj_Space_Bounding_Volumes();
+	// Now update the object space bounding volumes of this object's container:
+	RenderObjClass *container = Get_Container();
+	if (container) container->Update_Obj_Space_Bounding_Volumes();
 }
 
 /***********************************************************************************************

--- a/Core/Libraries/Source/WWVegas/WW3D2/composite.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/composite.h
@@ -75,7 +75,7 @@ public:
 	virtual void					Delete_Decal(uint32 decal_id) override;
 
 	virtual void					Get_Obj_Space_Bounding_Sphere(SphereClass	& sphere) const override { sphere = ObjSphere; }
-   virtual void					Get_Obj_Space_Bounding_Box(AABoxClass & box) const override { box = ObjBox; }
+	virtual void					Get_Obj_Space_Bounding_Box(AABoxClass & box) const override { box = ObjBox; }
 	virtual void					Update_Obj_Space_Bounding_Volumes() override;
 
 	virtual void					Set_User_Data(void *value, bool recursive = false) override;

--- a/Core/Libraries/Source/WWVegas/WW3D2/distlod.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/distlod.cpp
@@ -276,7 +276,7 @@ WW3DErrorType DistLODDefClass::Load_W3D(ChunkLoadClass & cload)
 	Free();
 
 	if (read_header(cload) == false) {
-	  return WW3D_ERROR_LOAD_FAILED;
+		return WW3D_ERROR_LOAD_FAILED;
 	}
 
 	/*
@@ -395,7 +395,7 @@ DistLODClass::DistLODClass(const DistLODDefClass & def)
 		// create a render object
 		Lods[i].Model = WW3DAssetManager::Get_Instance()->Create_Render_Obj(def.Lods[i].Name);
 		assert(Lods[i].Model != nullptr);
-      Lods[i].Model->Set_Container(this);
+		Lods[i].Model->Set_Container(this);
 
 		// copy the distances
 		Lods[i].ResUpDist = def.Lods[i].ResUpDist;
@@ -430,7 +430,7 @@ DistLODClass::DistLODClass(const DistLODClass & that) :
 		// create a render object
 		Lods[i].Model = that.Lods[i].Model->Clone();
 		assert(Lods[i].Model != nullptr);
-      Lods[i].Model->Set_Container(this);
+		Lods[i].Model->Set_Container(this);
 
 		// copy the distances
 		Lods[i].ResUpDist = that.Lods[i].ResUpDist;
@@ -808,7 +808,7 @@ const char * DistLODClass::Get_Bone_Name(int bone_index)
  *=============================================================================================*/
 int DistLODClass::Get_Bone_Index(const char * bonename)
 {
-   // Highest LOD is used since lowest may be a Null3DObjClass.
+	// Highest LOD is used since lowest may be a Null3DObjClass.
 	return Lods[0].Model->Get_Bone_Index(bonename);
 }
 
@@ -827,7 +827,7 @@ int DistLODClass::Get_Bone_Index(const char * bonename)
  *=============================================================================================*/
 const Matrix3D &	DistLODClass::Get_Bone_Transform(const char * bonename)
 {
-   // Highest LOD is used since lowest may be a Null3DObjClass.
+	// Highest LOD is used since lowest may be a Null3DObjClass.
 	return Lods[0].Model->Get_Bone_Transform(bonename);
 }
 
@@ -846,7 +846,7 @@ const Matrix3D &	DistLODClass::Get_Bone_Transform(const char * bonename)
  *=============================================================================================*/
 const Matrix3D &	DistLODClass::Get_Bone_Transform(int boneindex)
 {
-   // Highest LOD is used since lowest may be a Null3DObjClass.
+	// Highest LOD is used since lowest may be a Null3DObjClass.
 	return Lods[0].Model->Get_Bone_Transform(boneindex);
 }
 
@@ -907,7 +907,7 @@ void DistLODClass::Release_Bone(int bindex)
  *=============================================================================================*/
 bool DistLODClass::Is_Bone_Captured(int bindex) const
 {
-   // Highest LOD is used since lowest may be a Null3DObjClass.
+	// Highest LOD is used since lowest may be a Null3DObjClass.
 	return Lods[0].Model->Is_Bone_Captured(bindex);
 }
 

--- a/Core/Libraries/Source/WWVegas/WW3D2/dx8texman.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/dx8texman.h
@@ -59,9 +59,9 @@ public:
 		TextureBaseClass *tex
 	)
 	: Width(w),
-	  Height(h),
-	  Mip_level_count(count),
-	  Texture(tex)
+		Height(h),
+		Mip_level_count(count),
+		Texture(tex)
 	{
 	}
 

--- a/Core/Libraries/Source/WWVegas/WW3D2/dynamesh.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/dynamesh.h
@@ -154,8 +154,8 @@ public:
 	virtual int Get_Num_Vertices() const { return VertCount; }
 
 	// Get and set static sort level
-   virtual int		Get_Sort_Level() const override { return SortLevel; }
-  	virtual void	Set_Sort_Level(int level) override { SortLevel = level; if(level != SORT_LEVEL_NONE) Disable_Sort();}
+	virtual int		Get_Sort_Level() const override { return SortLevel; }
+	virtual void	Set_Sort_Level(int level) override { SortLevel = level; if(level != SORT_LEVEL_NONE) Disable_Sort();}
 
 	// object space bounding volumes
 	virtual inline void Get_Obj_Space_Bounding_Sphere(SphereClass & sphere) const override;
@@ -553,7 +553,7 @@ public:
 	virtual void Location( float x, float y, float z = 0.0f) override;
 
 	// For moving a vertex after the DynaMesh has already been created.
-   virtual void Move_Vertex(int index, float x, float y, float z = 0.0f) override;
+	virtual void Move_Vertex(int index, float x, float y, float z = 0.0f) override;
 
 	// Set position
 	virtual void Set_Position(const Vector3 &v) override;

--- a/Core/Libraries/Source/WWVegas/WW3D2/font3d.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/font3d.cpp
@@ -98,14 +98,14 @@ SurfaceClass *Font3DDataClass::Minimize_Font_Image( SurfaceClass *surface )
 
 	// determine new width make the size of the new image either 128x128 or 256x256,
 	// dependent on the width of the original image
-   int new_width;
+	int new_width;
 	if (current_width < 256) {
 		new_width = 128;
 	} else {
 		new_width = 256;
 	}
 
-   int new_height = new_width;
+	int new_height = new_width;
 	//  create a new 4 bit alpha image to build into
 	// We dont support non-homogeneous copies just yet
 	SurfaceClass	*new_surface = NEW_REF(SurfaceClass,(new_width, new_height,WW3D_FORMAT_A4R4G4B4));
@@ -256,7 +256,7 @@ bool	Font3DDataClass::Load_Font_Image( const char *filename )
 	// If input is a font strike (strip) process it as such
 	if ( sd.Width > 8 * sd.Height ) {
 
- 		// the height of the strike is the height of the characters
+		// the height of the strike is the height of the characters
 		VHeight = 1;
 		CharHeight = sd.Height;
 

--- a/Core/Libraries/Source/WWVegas/WW3D2/hanim.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/hanim.h
@@ -223,7 +223,7 @@ public:
 
 	void	Reset();		// empties the dynamic vector
 
- 	bool	Normalize_Weights();	// Normalizes all weights (returns true if succeeded)
+	bool	Normalize_Weights();	// Normalizes all weights (returns true if succeeded)
 	int	Get_Num_Anims() { return HAnimComboData.Count(); }
 
 	void	Set_Motion( int indx, HAnimClass *motion );

--- a/Core/Libraries/Source/WWVegas/WW3D2/hcanim.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/hcanim.cpp
@@ -85,10 +85,10 @@ struct NodeCompressedMotionStruct
 		} ad;
 
 		struct {
-			 void * X;
-			 void * Y;
-			 void * Z;
-			 void * Q;
+			void * X;
+			void * Y;
+			void * Z;
+			void * Q;
 		} vd;
 	};
 
@@ -261,11 +261,11 @@ int HCompressedAnimClass::Load_W3D(ChunkLoadClass & cload)
 	strlcat(Name, aheader.Name, ARRAY_SIZE(Name));
 
 	// TSS chasing crash bug 05/26/99
-   WWASSERT(HierarchyName != nullptr);
-   WWASSERT(aheader.HierarchyName != nullptr);
-   WWASSERT(sizeof(HierarchyName) >= W3D_NAME_LEN);
-	 static_assert(ARRAY_SIZE(HierarchyName) >= ARRAY_SIZE(aheader.HierarchyName), "Incorrect array size");
-	 strcpy(HierarchyName, aheader.HierarchyName);
+	WWASSERT(HierarchyName != nullptr);
+	WWASSERT(aheader.HierarchyName != nullptr);
+	WWASSERT(sizeof(HierarchyName) >= W3D_NAME_LEN);
+	static_assert(ARRAY_SIZE(HierarchyName) >= ARRAY_SIZE(aheader.HierarchyName), "Incorrect array size");
+	strcpy(HierarchyName, aheader.HierarchyName);
 
 	HTreeClass * base_pose = WW3DAssetManager::Get_Instance()->Get_HTree(HierarchyName);
 	if (base_pose == nullptr) {

--- a/Core/Libraries/Source/WWVegas/WW3D2/htree.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/htree.cpp
@@ -1181,11 +1181,11 @@ HTreeClass * HTreeClass::Create_Interpolated(	const HTreeClass * tree_a0_b0,
 	for (int pi = 0; pi < new_tree->NumPivots; pi++) {
 
 		Vector3::Lerp( tree_a0_b0->Pivot[pi].BaseTransform.Get_Translation(),
-							  		  tree_a0_b1->Pivot[pi].BaseTransform.Get_Translation(),
-									  lerp_b, &pos_a0 );
+			tree_a0_b1->Pivot[pi].BaseTransform.Get_Translation(),
+			lerp_b, &pos_a0 );
 		Vector3::Lerp( tree_a1_b0->Pivot[pi].BaseTransform.Get_Translation(),
-									  tree_a1_b1->Pivot[pi].BaseTransform.Get_Translation(),
-									  lerp_b, &pos_a1 );
+			tree_a1_b1->Pivot[pi].BaseTransform.Get_Translation(),
+			lerp_b, &pos_a1 );
 		Vector3::Lerp( pos_a0, pos_a1, lerp_a, &pos );
 
 		new_tree->Pivot[pi].BaseTransform.Set_Translation( pos );
@@ -1196,9 +1196,9 @@ HTreeClass * HTreeClass::Create_Interpolated(	const HTreeClass * tree_a0_b0,
 
 // Create an HTree by Interpolating between others
 HTreeClass * HTreeClass::Create_Interpolated(const HTreeClass * tree_base,
-														   const HTreeClass * tree_a,
-														   const HTreeClass * tree_b,
-														   float a_scale, float b_scale )
+	const HTreeClass * tree_a,
+	const HTreeClass * tree_b,
+	float a_scale, float b_scale )
 {
 	WWMEMLOG(MEM_ANIMATION);
 	assert( tree_base->NumPivots == tree_a->NumPivots );
@@ -1217,11 +1217,11 @@ HTreeClass * HTreeClass::Create_Interpolated(const HTreeClass * tree_base,
 		for (int pi = 0; pi < new_tree->NumPivots; pi++) {
 
 			Vector3::Lerp( tree_base->Pivot[pi].BaseTransform.Get_Translation(),
-							  			 tree_a->Pivot[pi].BaseTransform.Get_Translation(),
-										 a_scale, &pos_a );
+				tree_a->Pivot[pi].BaseTransform.Get_Translation(),
+				a_scale, &pos_a );
 			Vector3::Lerp( tree_base->Pivot[pi].BaseTransform.Get_Translation(),
-										 tree_b->Pivot[pi].BaseTransform.Get_Translation(),
-										 b_scale, &pos_b );
+				tree_b->Pivot[pi].BaseTransform.Get_Translation(),
+				b_scale, &pos_b );
 
 			pos   = (pos_a * a_scale_abs + pos_b * b_scale_abs ) / ( a_scale_abs + b_scale_abs );
 

--- a/Core/Libraries/Source/WWVegas/WW3D2/htree.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/htree.h
@@ -138,21 +138,21 @@ public:
 
 	// Morph the bones on the HTree using weights from a number of other HTrees
 	static HTreeClass *	Create_Morphed( int num_morph_sources,
-													 const float morph_weights[],
-													 const HTreeClass *tree_array[] );
+		const float morph_weights[],
+		const HTreeClass *tree_array[] );
 
 	// Create an HTree by Interpolating between others
 	static HTreeClass	*	Create_Interpolated( const HTreeClass * tree_a0_b0,
-														   const HTreeClass * tree_a0_b1,
-														   const HTreeClass * tree_a1_b0,
-														   const HTreeClass * tree_a1_b1,
-														   float lerp_a, float lerp_b );
+		const HTreeClass * tree_a0_b1,
+		const HTreeClass * tree_a1_b0,
+		const HTreeClass * tree_a1_b1,
+		float lerp_a, float lerp_b );
 
 	// Create an HTree by Interpolating between others
 	static HTreeClass	*	Create_Interpolated( const HTreeClass * tree_base,
-														   const HTreeClass * tree_a,
-														   const HTreeClass * tree_b,
-														   float a_scale, float b_scale );
+		const HTreeClass * tree_a,
+		const HTreeClass * tree_b,
+		float a_scale, float b_scale );
 
 private:
 

--- a/Core/Libraries/Source/WWVegas/WW3D2/intersec.inl
+++ b/Core/Libraries/Source/WWVegas/WW3D2/intersec.inl
@@ -171,21 +171,21 @@ inline bool IntersectionClass::_Point_In_Polygon_Z(
 	// and do bounds checking (sum <= 1)  to determine whether or not the triangle intersection occurs.
 
 	if (u1 == 0.0f)    {
-	  beta = u0 / u2;			// beta is the percentage down the edge Corner1->Corner3
-	  if ((beta >= 0.0f) && (beta <= 1.0f)) {		// make sure it's within the edge segment
+		beta = u0 / u2;			// beta is the percentage down the edge Corner1->Corner3
+		if ((beta >= 0.0f) && (beta <= 1.0f)) {		// make sure it's within the edge segment
 			alpha = (v0 - beta * v2) / v1;	 // alpha is the percentage down the edge Corner1->Corner2
 
 			// if alpha is valid & the sum of alpha & beta is <= 1 then it's within the triangle
 			// note:       0.00001 added after testing an intersection of a square in the middle indicated
 			// an error of 0.0000001350, apparently due to roundoff.
 			intersect = ((alpha >= 0.0) && ((alpha + beta) <= 1.0));
-	  }
+		}
 	} else {
-	  beta = (v0 * u1 - u0 * v1) / (v2 * u1 - u2 * v1);
-	  if ((beta >= 0.0) && (beta <= 1.0)) {
+		beta = (v0 * u1 - u0 * v1) / (v2 * u1 - u2 * v1);
+		if ((beta >= 0.0) && (beta <= 1.0)) {
 			alpha = (u0 - beta * u2) / u1;
 			intersect = ((alpha >= 0.0) && ((alpha + beta) <= 1.0));
-	  }
+		}
 	}
 
 	// if it is inside, adjust the Z value to sit upon the triangle plane.
@@ -249,21 +249,21 @@ inline bool IntersectionClass::_Point_In_Polygon(
 #endif
 
 	if (u1 == 0.0f)    {
-	  Beta = beta = u0 / u2;			// beta is the percentage down the edge loc1->loc3
-	  if ((beta >= 0.0f) && (beta <= 1.0f)) {		// make sure it's within the edge segment
+		Beta = beta = u0 / u2;			// beta is the percentage down the edge loc1->loc3
+		if ((beta >= 0.0f) && (beta <= 1.0f)) {		// make sure it's within the edge segment
 			Alpha = alpha = (v0 - beta * v2) / v1;	 // alpha is the percentage down the edge loc1->loc2
 
 			// if alpha is valid & the sum of alpha & beta is <= 1 then it's within the triangle
 			// note:       0.00001 added after testing an intersection of a square in the middle indicated
 			// an error of 0.0000001350, apparently due to roundoff.
 			intersect = ((alpha >= 0.0) && ((alpha + beta) <= 1.0));
-	  }
+		}
 	} else {
-	  Beta = beta = (v0 * u1 - u0 * v1) / (v2 * u1 - u2 * v1);
-	  if ((beta >= 0.0) && (beta <= 1.0)) {
+		Beta = beta = (v0 * u1 - u0 * v1) / (v2 * u1 - u2 * v1);
+		if ((beta >= 0.0) && (beta <= 1.0)) {
 			Alpha = alpha = (u0 - beta * u2) / u1;
 			intersect = ((alpha >= 0.0) && ((alpha + beta) <= 1.0));
-	  }
+		}
 	}
 
 #ifdef DEBUG_NORMALS

--- a/Core/Libraries/Source/WWVegas/WW3D2/line3d.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/line3d.cpp
@@ -97,7 +97,7 @@ Line3DClass::Line3DClass (const Vector3 & start, const Vector3 & end,
 	float width, float r, float g, float b, float opacity)
 {
 	Length = (end - start).Length();
-   Width = width;
+	Width = width;
 
 	// Create box model with origin at start point (X is major axis).
 
@@ -159,7 +159,7 @@ Line3DClass::Line3DClass (const Vector3 & start, const Vector3 & end,
 Line3DClass::Line3DClass(const Line3DClass & src) :
 	RenderObjClass(src),
 	Length(src.Length),
-   Width(src.Width),
+	Width(src.Width),
 	Shader(src.Shader),
 	Color(src.Color)
 {
@@ -190,7 +190,7 @@ Line3DClass & Line3DClass::operator = (const Line3DClass & that)
 
 	if (this != &that) {
 		Length = that.Length;
-      Width = that.Width;
+		Width = that.Width;
 		Shader=that.Shader;
 		Color=that.Color;
 		for (int i=0; i<8; i++)
@@ -322,13 +322,13 @@ void Line3DClass::Scale(float scale)
 {
 	for (int i=0; i<8; i++) vert[i]*=scale;
 	Length *= scale;
-   Width *= scale;
+	Width *= scale;
 
-   Invalidate_Cached_Bounding_Volumes();
+	Invalidate_Cached_Bounding_Volumes();
 
-   // Now update the object space bounding volumes of this object's container:
-   RenderObjClass *container = Get_Container();
-   if (container) container->Update_Obj_Space_Bounding_Volumes();
+	// Now update the object space bounding volumes of this object's container:
+	RenderObjClass *container = Get_Container();
+	if (container) container->Update_Obj_Space_Bounding_Volumes();
 }
 
 
@@ -353,13 +353,13 @@ void Line3DClass::Scale(float scalex, float scaley, float scalez)
 	Vector3 scale(scalex,scaley,scalez);
 	for (int i=0; i<8; i++) vert[i].Scale(scale);
 	Length *= scalex;
-   Width *= scaley;
+	Width *= scaley;
 
-   Invalidate_Cached_Bounding_Volumes();
+	Invalidate_Cached_Bounding_Volumes();
 
-   // Now update the object space bounding volumes of this object's container:
-   RenderObjClass *container = Get_Container();
-   if (container) container->Update_Obj_Space_Bounding_Volumes();
+	// Now update the object space bounding volumes of this object's container:
+	RenderObjClass *container = Get_Container();
+	if (container) container->Update_Obj_Space_Bounding_Volumes();
 }
 
 
@@ -406,11 +406,11 @@ void Line3DClass::Reset(const Vector3 & new_start, const Vector3 & new_end)
 	transform.Obj_Look_At(new_start, new_end, 0.0);
 	Set_Transform(transform);
 
-   Invalidate_Cached_Bounding_Volumes();
+	Invalidate_Cached_Bounding_Volumes();
 
-   // Now update the object space bounding volumes of this object's container:
-   RenderObjClass *container = Get_Container();
-   if (container) container->Update_Obj_Space_Bounding_Volumes();
+	// Now update the object space bounding volumes of this object's container:
+	RenderObjClass *container = Get_Container();
+	if (container) container->Update_Obj_Space_Bounding_Volumes();
 }
 
 
@@ -434,16 +434,16 @@ void Line3DClass::Reset(const Vector3 & new_start, const Vector3 & new_end, floa
 	if (new_length == 0) {
 		new_length = 0.001f;			// make sure we don't have a zero length BMG
 	}
-   float width_scale = new_width / Width;
+	float width_scale = new_width / Width;
 	Scale((new_length / Length), width_scale, width_scale);
 	Length = new_length;
-   Width = new_width;
+	Width = new_width;
 
 	// Adjust transform of line:
 	Matrix3D transform(true);
 	transform.Obj_Look_At(new_start, new_end, 0.0);
 	Set_Transform(transform);
-   Matrix3D inv;
+	Matrix3D inv;
 	transform.Get_Orthogonal_Inverse(inv);
 #ifdef ALLOW_TEMPORARIES
 //   Vector3 test = inv * Vector3(new_end);
@@ -452,11 +452,11 @@ void Line3DClass::Reset(const Vector3 & new_start, const Vector3 & new_end, floa
 //		inv.mulVector3(new_end, test);
 #endif
 
-   Invalidate_Cached_Bounding_Volumes();
+	Invalidate_Cached_Bounding_Volumes();
 
-   // Now update the object space bounding volumes of this object's container:
-   RenderObjClass *container = Get_Container();
-   if (container) container->Update_Obj_Space_Bounding_Volumes();
+	// Now update the object space bounding volumes of this object's container:
+	RenderObjClass *container = Get_Container();
+	if (container) container->Update_Obj_Space_Bounding_Volumes();
 }
 
 

--- a/Core/Libraries/Source/WWVegas/WW3D2/line3d.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/line3d.h
@@ -77,9 +77,9 @@ class Line3DClass : public W3DMPO, public RenderObjClass
 		// returns the number of polygons in the render object
 		virtual int Get_Num_Polys() const override;
 
-      // Get the object space bounding volumes
-      virtual void	Get_Obj_Space_Bounding_Sphere(SphereClass & sphere) const override;
-      virtual void	Get_Obj_Space_Bounding_Box(AABoxClass & box) const override;
+	// Get the object space bounding volumes
+	virtual void	Get_Obj_Space_Bounding_Sphere(SphereClass & sphere) const override;
+	virtual void	Get_Obj_Space_Bounding_Box(AABoxClass & box) const override;
 
 		// The following functions are unique to Line3DClass:
 

--- a/Core/Libraries/Source/WWVegas/WW3D2/pointgr.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/pointgr.cpp
@@ -795,7 +795,7 @@ void PointGroupClass::Render(RenderInfoClass &rinfo)
 	unsigned char *current_frame = nullptr;
 
 	// If there is a color or alpha array enable gradient in shader - otherwise disable.
-   float value_255 = 0.9961f;	//254 / 255
+	float value_255 = 0.9961f;	//254 / 255
 	bool default_white_opaque = (	DefaultPointColor.X > value_255 &&
 											DefaultPointColor.Y > value_255 &&
 											DefaultPointColor.Z > value_255 &&
@@ -1275,14 +1275,14 @@ void PointGroupClass::Update_Arrays(
 			{
 				// Offsets need to be scaled to the current screen resolution
 
-   			// First find x and y scale factors (sizes in pixels need to be
-   			// normalized to 2D cam viewplane of -1,-1 to 1,1)
-   			int xres, yres, bitdepth;
-   			bool windowed;
-   			WW3D::Get_Render_Target_Resolution(xres, yres, bitdepth, windowed);
+			// First find x and y scale factors (sizes in pixels need to be
+			// normalized to 2D cam viewplane of -1,-1 to 1,1)
+			int xres, yres, bitdepth;
+			bool windowed;
+			WW3D::Get_Render_Target_Resolution(xres, yres, bitdepth, windowed);
 
-   			float x_scale = (VPXMax - VPXMin) / xres;
-   			float y_scale = (VPYMax - VPYMin) / yres;
+			float x_scale = (VPXMax - VPXMin) / xres;
+			float y_scale = (VPYMax - VPYMin) / yres;
 
 				Vector3 scaled_locs[2][3];
 				for (int i = 0; i < 2; i++) {
@@ -1309,14 +1309,14 @@ void PointGroupClass::Update_Arrays(
 			{
 				// Offsets need to be scaled to the current screen resolution
 
-   			// First find x and y scale factors (sizes in pixels need to be
-   			// normalized to 2D cam viewplane of -1,-1 to 1,1)
-   			int xres, yres, bitdepth;
-   			bool windowed;
-   			WW3D::Get_Render_Target_Resolution(xres, yres, bitdepth, windowed);
+			// First find x and y scale factors (sizes in pixels need to be
+			// normalized to 2D cam viewplane of -1,-1 to 1,1)
+			int xres, yres, bitdepth;
+			bool windowed;
+			WW3D::Get_Render_Target_Resolution(xres, yres, bitdepth, windowed);
 
-   			float x_scale = (VPXMax - VPXMin) / xres;
-   			float y_scale = (VPYMax - VPYMin) / yres;
+			float x_scale = (VPXMax - VPXMin) / xres;
+			float y_scale = (VPYMax - VPYMin) / yres;
 
 				Vector3 scaled_locs[2][3];
 				for (int i = 0; i < 2; i++) {
@@ -1667,7 +1667,7 @@ void PointGroupClass::RenderVolumeParticle(RenderInfoClass &rinfo, unsigned int 
 	unsigned char *current_frame = nullptr;
 
 	// If there is a color or alpha array enable gradient in shader - otherwise disable.
-  float value_255 = 0.9961f;	//254 / 255
+	float value_255 = 0.9961f;	//254 / 255
 	bool default_white_opaque = (	DefaultPointColor.X > value_255 &&
 											DefaultPointColor.Y > value_255 &&
 											DefaultPointColor.Z > value_255 &&

--- a/Core/Libraries/Source/WWVegas/WW3D2/predlod.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/predlod.cpp
@@ -318,7 +318,7 @@ void PredictiveLODOptimizerClass::Optimize_LODs(float max_cost)
 			}
 
 			// Get (incrementable) tuple with maximum next value.
-		 	max_data = max_post_increment_value_queue.Top()->Get_Item();
+			max_data = max_post_increment_value_queue.Top()->Get_Item();
 
 			// Increment tuple (and update TotalCost accordingly).
 			TotalCost -= max_data->Get_Cost();
@@ -341,7 +341,7 @@ void PredictiveLODOptimizerClass::Optimize_LODs(float max_cost)
 			}
 
 			// Get (decrementable) tuple with minimum current value.
-		 	min_data = min_current_value_queue.Top()->Get_Item();
+			min_data = min_current_value_queue.Top()->Get_Item();
 
 			// Decrement tuple (and update TotalCost accordingly).
 			TotalCost -= min_data->Get_Cost();

--- a/Core/Libraries/Source/WWVegas/WW3D2/render2dsentence.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/render2dsentence.cpp
@@ -1238,7 +1238,7 @@ FontCharsClass::Get_Char_Data (WCHAR ch)
 	{
 		retval = ASCIICharArray[ch];
 	}
- 	else if ( AlternateUnicodeFont && this != AlternateUnicodeFont )
+	else if ( AlternateUnicodeFont && this != AlternateUnicodeFont )
 	{
 		return AlternateUnicodeFont->Get_Char_Data( ch );
 	}
@@ -1390,33 +1390,33 @@ FontCharsClass::Store_GDI_Char (WCHAR ch)
 			uint8 pixel_value = GDIBitmapBits[index];
 			index += 3;
 #ifdef TEST_PLACEMENT
- 			if (row==CharHeight-1&&col==0) {
- 				pixel_value = 0xff;
- 			}
- 			if (row==CharHeight-2&&col==1) {
- 				pixel_value = 0xff;
- 			}
- 			if (row==0&&col==0) {
- 				pixel_value = 0xff;
- 			}
- 			if (row==1&&col==1) {
- 				pixel_value = 0xff;
- 			}
- 			if (row==CharHeight-1&&col==char_size.cx-1-PixelOverlap) {
- 				pixel_value = 0xff;
- 			}
- 			if (row==CharHeight-2&&col==char_size.cx-2-PixelOverlap) {
- 				pixel_value = 0xff;
- 			}
- 			if (row==0&&col==char_size.cx-1-PixelOverlap) {
- 				pixel_value = 0xff;
- 			}
- 			if (row==1&&col==char_size.cx-2-PixelOverlap) {
- 				pixel_value = 0xff;
- 			}
- 			if (pixel_value == 0x00) {
- 				pixel_value = 0x40;
- 			}
+			if (row==CharHeight-1&&col==0) {
+				pixel_value = 0xff;
+			}
+			if (row==CharHeight-2&&col==1) {
+				pixel_value = 0xff;
+			}
+			if (row==0&&col==0) {
+				pixel_value = 0xff;
+			}
+			if (row==1&&col==1) {
+				pixel_value = 0xff;
+			}
+			if (row==CharHeight-1&&col==char_size.cx-1-PixelOverlap) {
+				pixel_value = 0xff;
+			}
+			if (row==CharHeight-2&&col==char_size.cx-2-PixelOverlap) {
+				pixel_value = 0xff;
+			}
+			if (row==0&&col==char_size.cx-1-PixelOverlap) {
+				pixel_value = 0xff;
+			}
+			if (row==1&&col==char_size.cx-2-PixelOverlap) {
+				pixel_value = 0xff;
+			}
+			if (pixel_value == 0x00) {
+				pixel_value = 0x40;
+			}
 #endif
 
 			uint16 pixel_color = 0;

--- a/Core/Libraries/Source/WWVegas/WW3D2/rendobj.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/rendobj.cpp
@@ -906,7 +906,7 @@ void RenderObjClass::Update_Cached_Bounding_Volumes() const
 #else
 	Get_Transform().mulVector3(CachedBoundingSphere.Center);
 #endif
- 	CachedBoundingSphere.Radius = ObjectScale * CachedBoundingSphere.Radius;
+	CachedBoundingSphere.Radius = ObjectScale * CachedBoundingSphere.Radius;
 	CachedBoundingBox.Transform(Get_Transform());
 
 	Validate_Cached_Bounding_Volumes();

--- a/Core/Libraries/Source/WWVegas/WW3D2/rendobj.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/rendobj.h
@@ -152,21 +152,21 @@ class RenderObjClass : public RefCountClass , public PersistClass, public MultiL
 {
 public:
 
- 	//Integer flag placed at the start of structure pointed to by
- 	//User_Data to signal that it points at custom mesh material settings.
+	//Integer flag placed at the start of structure pointed to by
+	//User_Data to signal that it points at custom mesh material settings.
 	//Added for 'Generals' - MW
- 	enum	{USER_DATA_MATERIAL_OVERRIDE = 0x01234567};
+	enum	{USER_DATA_MATERIAL_OVERRIDE = 0x01234567};
 
 	//This structure is used to pass custom rendering parameters into the W3D
- 	//mesh renderer so it can override settings which are usually shared across
- 	//all instances of a model - typically material settings like alpha, texture
- 	//animation, texture uv scrolling, etc.  Added for 'Generals' -MW
- 	struct Material_Override
- 	{	Material_Override()	: Struct_ID(USER_DATA_MATERIAL_OVERRIDE),customUVOffset(0,0) {}
+	//mesh renderer so it can override settings which are usually shared across
+	//all instances of a model - typically material settings like alpha, texture
+	//animation, texture uv scrolling, etc.  Added for 'Generals' -MW
+	struct Material_Override
+	{	Material_Override()	: Struct_ID(USER_DATA_MATERIAL_OVERRIDE),customUVOffset(0,0) {}
 
- 		int Struct_ID;	//ID used to identify this structure from a pointer to it.
- 		Vector2 customUVOffset;
- 	};
+		int Struct_ID;	//ID used to identify this structure from a pointer to it.
+		Vector2 customUVOffset;
+	};
 
 	//
 	//	Note:  It is very important that these values NEVER CHANGE.  That means
@@ -372,7 +372,7 @@ public:
 	virtual const AABoxClass &	Get_Bounding_Box() const;
 	virtual void		 			Get_Obj_Space_Bounding_Sphere(SphereClass & sphere) const;
 	virtual void					Get_Obj_Space_Bounding_Box(AABoxClass & box) const;
-   virtual void               Update_Obj_Space_Bounding_Volumes()								{ };
+	virtual void               Update_Obj_Space_Bounding_Volumes()								{ };
 
 
 	///////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -386,7 +386,7 @@ public:
 	static const float	AT_MAX_LOD;
 
 	virtual void	Prepare_LOD(CameraClass &camera);
-   virtual void   Recalculate_Static_LOD_Factors()													{ }
+	virtual void   Recalculate_Static_LOD_Factors()													{ }
 	virtual void	Increment_LOD()																			{ }
 	virtual void	Decrement_LOD()																			{ }
 	virtual float	Get_Cost() const;
@@ -432,13 +432,13 @@ public:
 	virtual float					Get_Screen_Size(CameraClass &camera);
 	virtual void					Scale(float scale) 															{ };
 	virtual void					Scale(float scalex, float scaley, float scalez)						{ };
- 	virtual void					Set_ObjectScale(float scale) { ObjectScale=scale;}	//set's a scale factor that's factored into transform matrix.									{ScaleFactor=scale; };
+	virtual void					Set_ObjectScale(float scale) { ObjectScale=scale;}	//set's a scale factor that's factored into transform matrix.									{ScaleFactor=scale; };
 	float							Get_ObjectScale() const { return ObjectScale; };
- 	void							Set_ObjectColor(unsigned int color) { ObjectColor=color;}	//the color that was used to modify the asset for player team color (for Generals). -MW
+	void							Set_ObjectColor(unsigned int color) { ObjectColor=color;}	//the color that was used to modify the asset for player team color (for Generals). -MW
 	unsigned int					Get_ObjectColor() const { return ObjectColor; };
 
-   virtual int						Get_Sort_Level() const													{ return 0; /* SORT_LEVEL_NONE */ }
-   virtual void					Set_Sort_Level(int level)													{ }
+	virtual int						Get_Sort_Level() const													{ return 0; /* SORT_LEVEL_NONE */ }
+	virtual void					Set_Sort_Level(int level)													{ }
 
 	virtual int						Is_Really_Visible()														{ return ((Bits & IS_REALLY_VISIBLE) == IS_REALLY_VISIBLE); }
 	virtual int						Is_Not_Hidden_At_All()													{ return ((Bits & IS_NOT_HIDDEN_AT_ALL) == IS_NOT_HIDDEN_AT_ALL); }
@@ -446,7 +446,7 @@ public:
 	virtual void					Set_Visible(int onoff)														{ if (onoff) { Bits |= IS_VISIBLE; } else { Bits &= ~IS_VISIBLE; } }
 
 // The cheatSpy has been put on ice until later... perhaps the next patch? - M Lorenzen
-  //	virtual int						Is_VisibleWithCheatSpy() const								{ return ((Bits&=~0x80) & (IS_VISIBLE); }
+	//	virtual int						Is_VisibleWithCheatSpy() const								{ return ((Bits&=~0x80) & (IS_VISIBLE); }
 //	virtual void					Set_VisibleWithCheatSpy(int onoff)								{ if (onoff) { Bits |= IS_VISIBLE|0x80; } else { Bits &= ~IS_VISIBLE; } }
 
 	virtual int						Is_Hidden() const														{ return !(Bits & IS_NOT_HIDDEN); }
@@ -464,7 +464,7 @@ public:
 	virtual void					Set_Additive(int onoff)													{ if (onoff) { Bits |= IS_ADDITIVE; } else { Bits &= ~IS_ADDITIVE; } }
 	virtual int						Get_Collision_Type() const											{ return (Bits & COLL_TYPE_MASK); }
 	virtual void					Set_Collision_Type(int type)												{ Bits &= ~COLL_TYPE_MASK; Bits |= (type & COLL_TYPE_MASK) | COLL_TYPE_ALL; }
-   virtual bool					Is_Complete()																{ return false; }
+	virtual bool					Is_Complete()																{ return false; }
 	virtual bool					Is_In_Scene()																{ return Scene != nullptr; }
 	virtual float					Get_Native_Screen_Size() const										{ return NativeScreenSize; }
 	virtual void					Set_Native_Screen_Size(float screensize)								{ NativeScreenSize = screensize; }
@@ -522,13 +522,13 @@ protected:
 		IS_SELF_SHADOWED =			0x00080000,			// the mesh is self shadowed
 		IS_CHEATER =            0x00100000,// the new cheat spy code uses these bits, since nothing else now does
 		IS_REALLY_VISIBLE =			IS_VISIBLE | IS_NOT_HIDDEN | IS_NOT_ANIMATION_HIDDEN,
-      IS_NOT_HIDDEN_AT_ALL =     IS_NOT_HIDDEN | IS_NOT_ANIMATION_HIDDEN,
+		IS_NOT_HIDDEN_AT_ALL =     IS_NOT_HIDDEN | IS_NOT_ANIMATION_HIDDEN,
 		DEFAULT_BITS =					COLL_TYPE_ALL | IS_NOT_HIDDEN | IS_NOT_ANIMATION_HIDDEN,
 	};
 
 	mutable unsigned long		Bits;
 	Matrix3D							Transform;
- 	float						ObjectScale;					//user applied scaling factor inside Transform matrix.
+	float						ObjectScale;					//user applied scaling factor inside Transform matrix.
 	unsigned int				ObjectColor;					//user applied coloring to the asset/prototype used to make this robj. - For Generals -MW
 	mutable SphereClass			CachedBoundingSphere;
 	mutable AABoxClass			CachedBoundingBox;

--- a/Core/Libraries/Source/WWVegas/WW3D2/ringobj.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/ringobj.h
@@ -122,8 +122,8 @@ public:
 	virtual void					Special_Render(SpecialRenderInfoClass & rinfo) override;
 	virtual void 					Set_Transform(const Matrix3D &m) override;
 	virtual void 					Set_Position(const Vector3 &v) override;
-   virtual void					Get_Obj_Space_Bounding_Sphere(SphereClass	& sphere) const override;
-   virtual void					Get_Obj_Space_Bounding_Box(AABoxClass & box) const override;
+	virtual void					Get_Obj_Space_Bounding_Sphere(SphereClass	& sphere) const override;
+	virtual void					Get_Obj_Space_Bounding_Box(AABoxClass & box) const override;
 
 	virtual void					Prepare_LOD(CameraClass &camera) override;
 	virtual void					Increment_LOD() override;

--- a/Core/Libraries/Source/WWVegas/WW3D2/shattersystem.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/shattersystem.cpp
@@ -809,7 +809,7 @@ void ShatterSystem::Init()
 	StringClass htree_name;
 	htree_name.Format(SHATTER_PATTERN_FORMAT,0);
 
- 	if (WW3DAssetManager::Get_Instance()==nullptr)
+	if (WW3DAssetManager::Get_Instance()==nullptr)
 		return;  // WorldBuilderTool doesn't initialize the asset manager.  jba.
 #if 1
 	HTreeClass *htree = nullptr;

--- a/Core/Libraries/Source/WWVegas/WW3D2/soundrobj.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/soundrobj.cpp
@@ -556,7 +556,7 @@ SoundRenderObjDefClass::Load_W3D (ChunkLoadClass &cload)
 	// Attempt to read the different sections of the definition
 	//
 	if ((Read_Header (cload) == WW3D_ERROR_OK) &&
-		 (Read_Definition (cload) == WW3D_ERROR_OK))
+		(Read_Definition (cload) == WW3D_ERROR_OK))
 	{
 		retval = WW3D_ERROR_OK;
 	}
@@ -584,7 +584,7 @@ SoundRenderObjDefClass::Save_W3D (ChunkSaveClass &csave)
 		// Attempt to save the different sections of the aggregate definition
 		//
 		if ((Write_Header (csave) == WW3D_ERROR_OK) &&
-			 (Write_Definition (csave) == WW3D_ERROR_OK))
+			(Write_Definition (csave) == WW3D_ERROR_OK))
 		{
 			retval = WW3D_ERROR_OK;
 		}
@@ -610,7 +610,7 @@ SoundRenderObjDefClass::Read_Header (ChunkLoadClass &cload)
 	// Is this the header chunk?
 	//
 	if (cload.Open_Chunk () &&
-	    (cload.Cur_Chunk_ID () == W3D_CHUNK_SOUNDROBJ_HEADER))
+		(cload.Cur_Chunk_ID () == W3D_CHUNK_SOUNDROBJ_HEADER))
 	{
 		//
 		//	Read the header from the chunk
@@ -648,7 +648,7 @@ SoundRenderObjDefClass::Read_Definition (ChunkLoadClass &cload)
 	// Is this the right chunk?
 	//
 	if (cload.Open_Chunk () &&
-	    (cload.Cur_Chunk_ID () == W3D_CHUNK_SOUNDROBJ_DEFINITION))
+		(cload.Cur_Chunk_ID () == W3D_CHUNK_SOUNDROBJ_DEFINITION))
 	{
 		//
 		//	Ask the definition to load its settings from the chunk

--- a/Core/Libraries/Source/WWVegas/WW3D2/sphereobj.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/sphereobj.cpp
@@ -476,7 +476,7 @@ void SphereRenderObjClass::render_sphere()
 
 	// Enable sorting if the primitive is translucent, alpha testing is not enabled, and sorting is enabled globally.
 	const bool sort = (SphereShader.Get_Dst_Blend_Func() != ShaderClass::DSTBLEND_ZERO) && (SphereShader.Get_Alpha_Test() == ShaderClass::ALPHATEST_DISABLE) && (WW3D::Is_Sorting_Enabled());
- 	const unsigned int buffer_type = sort ? BUFFER_TYPE_DYNAMIC_SORTING : BUFFER_TYPE_DYNAMIC_DX8;
+	const unsigned int buffer_type = sort ? BUFFER_TYPE_DYNAMIC_SORTING : BUFFER_TYPE_DYNAMIC_DX8;
 
 	DynamicVBAccessClass vb(buffer_type, dynamic_fvf_type, mesh.Vertex_ct);
 	{
@@ -1739,7 +1739,7 @@ void SphereMeshClass::Free()
 	vtx			= nullptr;
 	vtx_normal	= nullptr;
 	vtx_uv		= nullptr;
- 	dcg			= nullptr;
+	dcg			= nullptr;
 	strips		= nullptr;
 	fans			= nullptr;
 	tri_poly		= nullptr;

--- a/Core/Libraries/Source/WWVegas/WW3D2/sphereobj.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/sphereobj.h
@@ -249,8 +249,8 @@ public:
 	virtual void					Special_Render(SpecialRenderInfoClass & rinfo) override;
 	virtual void 					Set_Transform(const Matrix3D &m) override;
 	virtual void 					Set_Position(const Vector3 &v) override;
-   virtual void					Get_Obj_Space_Bounding_Sphere(SphereClass & sphere) const override;
-   virtual void					Get_Obj_Space_Bounding_Box(AABoxClass & aabox) const override;
+	virtual void					Get_Obj_Space_Bounding_Sphere(SphereClass & sphere) const override;
+	virtual void					Get_Obj_Space_Bounding_Box(AABoxClass & aabox) const override;
 
 	virtual void					Prepare_LOD(CameraClass &camera) override;
 	virtual void					Increment_LOD() override;

--- a/Core/Libraries/Source/WWVegas/WW3D2/streak.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/streak.cpp
@@ -161,10 +161,10 @@ void StreakLineClass::Set_Colors( unsigned int num_points, Vector4 *colors )
 }
 
 void StreakLineClass::Set_LocsWidthsColors( unsigned int num_points,
-																					 Vector3 *locs,
-																					 float *widths,
-																					 Vector4 *colors,
-																					 unsigned int *personalities)
+	Vector3 *locs,
+	float *widths,
+	Vector4 *colors,
+	unsigned int *personalities)
 {
 
 	Personalities = personalities;

--- a/Core/Libraries/Source/WWVegas/WW3D2/streakRender.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/streakRender.cpp
@@ -71,7 +71,7 @@ StreakRendererClass::StreakRendererClass() :
 		m_vertexBufferSize(0),
 		m_vertexBuffer(nullptr)
 {
-  // EMPTY
+	// EMPTY
 }
 
 StreakRendererClass::StreakRendererClass(const StreakRendererClass & that) :
@@ -1404,7 +1404,7 @@ VertexFormatXYZUV1 *StreakRendererClass::getVertexBuffer(unsigned int number)
 	if (number > m_vertexBufferSize)
 	{
 		unsigned int numberToAlloc = number + (number >> 1);
-	  delete [] m_vertexBuffer;
+		delete [] m_vertexBuffer;
 		m_vertexBuffer = W3DNEWARRAY VertexFormatXYZUV1[numberToAlloc];
 		m_vertexBufferSize = numberToAlloc;
 	}
@@ -1412,7 +1412,7 @@ VertexFormatXYZUV1 *StreakRendererClass::getVertexBuffer(unsigned int number)
 #ifdef RTS_DEBUG
 	for (unsigned i = 0; i < number; ++i)
 	{
-	  m_vertexBuffer[i].x = m_vertexBuffer[i].y = m_vertexBuffer[i].z = m_vertexBuffer[i].u1 = m_vertexBuffer[i].v1 = (float)0xdeadbeef;
+		m_vertexBuffer[i].x = m_vertexBuffer[i].y = m_vertexBuffer[i].z = m_vertexBuffer[i].u1 = m_vertexBuffer[i].v1 = (float)0xdeadbeef;
 	}
 #endif
 

--- a/Core/Libraries/Source/WWVegas/WW3D2/textdraw.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/textdraw.cpp
@@ -335,8 +335,8 @@ float	TextDrawClass::Print( Font3DInstanceClass *font, const char *message, floa
 void	TextDrawClass::Show_Font( Font3DInstanceClass *font, float screen_x, float screen_y )
 {
 	// normalize coordinates
-   float size_x = PixelSize.X * 256;
-   float size_y = PixelSize.Y * 256;
+	float size_x = PixelSize.X * 256;
+	float size_y = PixelSize.Y * 256;
 
 	Set_Texture( font->Peek_Texture('A') );
 

--- a/Core/Libraries/Source/WWVegas/WW3D2/texture.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/texture.cpp
@@ -86,7 +86,7 @@ TextureBaseClass::TextureBaseClass
 :	MipLevelCount(mip_level_count),
 	D3DTexture(nullptr),
 	Initialized(false),
-   Name(""),
+	Name(""),
 	FullPath(""),
 	texture_id(unused_texture_id++),
 	IsLightmap(false),
@@ -732,9 +732,9 @@ TextureClass::TextureClass
 	{
 		Width=thumb->Get_Original_Texture_Width();
 		Height=thumb->Get_Original_Texture_Height();
- 		if (MipLevelCount!=MIP_LEVELS_1) {
- 			MipLevelCount=(MipCountType)thumb->Get_Original_Texture_Mip_Level_Count();
- 		}
+		if (MipLevelCount!=MIP_LEVELS_1) {
+			MipLevelCount=(MipCountType)thumb->Get_Original_Texture_Mip_Level_Count();
+		}
 	}
 
 	LastAccessed=WW3D::Get_Sync_Time();
@@ -1477,9 +1477,9 @@ CubeTextureClass::CubeTextureClass
 	{
 		Width=thumb->Get_Original_Texture_Width();
 		Height=thumb->Get_Original_Texture_Height();
- 		if (MipLevelCount!=MIP_LEVELS_1) {
- 			MipLevelCount=(MipCountType)thumb->Get_Original_Texture_Mip_Level_Count();
- 		}
+		if (MipLevelCount!=MIP_LEVELS_1) {
+			MipLevelCount=(MipCountType)thumb->Get_Original_Texture_Mip_Level_Count();
+		}
 	}
 
 	LastAccessed=WW3D::Get_Sync_Time();
@@ -1625,7 +1625,7 @@ VolumeTextureClass::VolumeTextureClass
 	bool allow_reduction
 )
 : TextureClass(width, height, format, mip_level_count, pool, rendertarget),
-  Depth(depth)
+	Depth(depth)
 {
 	Initialized=true;
 	IsProcedural=true;
@@ -1762,9 +1762,9 @@ VolumeTextureClass::VolumeTextureClass
 	{
 		Width=thumb->Get_Original_Texture_Width();
 		Height=thumb->Get_Original_Texture_Height();
- 		if (MipLevelCount!=MIP_LEVELS_1) {
- 			MipLevelCount=(MipCountType)thumb->Get_Original_Texture_Mip_Level_Count();
- 		}
+		if (MipLevelCount!=MIP_LEVELS_1) {
+			MipLevelCount=(MipCountType)thumb->Get_Original_Texture_Mip_Level_Count();
+		}
 	}
 
 	LastAccessed=WW3D::Get_Sync_Time();

--- a/Core/Libraries/Source/WWVegas/WW3D2/textureloader.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/textureloader.cpp
@@ -1409,7 +1409,7 @@ bool TextureLoadTaskClass::Begin_Compressed_Load()
 	unsigned orig_w,orig_h,orig_d,orig_mip_count,reduction;
 	WW3DFormat orig_format;
 	if (!Get_Texture_Information
-		  (
+		(
 				Texture->Get_Full_Path(),
 				reduction,
 				orig_w,
@@ -1540,7 +1540,7 @@ bool TextureLoadTaskClass::Begin_Uncompressed_Load()
 	unsigned width,height,depth,orig_mip_count,reduction;
 	WW3DFormat orig_format;
 	if (!Get_Texture_Information
-		  (
+		(
 				Texture->Get_Full_Path(),
 				reduction,
 				width,
@@ -1559,9 +1559,9 @@ bool TextureLoadTaskClass::Begin_Uncompressed_Load()
 	WW3DFormat dest_format=src_format;
 	dest_format=Get_Valid_Texture_Format(dest_format,false);	// No compressed destination format if reading from targa...
 
-   if (	src_format != WW3D_FORMAT_A8R8G8B8
-   	&&	src_format != WW3D_FORMAT_R8G8B8
-  		&&	src_format != WW3D_FORMAT_X8R8G8B8 )
+	if (	src_format != WW3D_FORMAT_A8R8G8B8
+		&&	src_format != WW3D_FORMAT_R8G8B8
+		&&	src_format != WW3D_FORMAT_X8R8G8B8 )
 	{
 		WWDEBUG_SAY(("Invalid TGA format used in %s - only 24 and 32 bit formats should be used!", Texture->Get_Full_Path().str()));
 	}
@@ -2218,7 +2218,7 @@ bool CubeTextureLoadTaskClass::Begin_Compressed_Load()
 	unsigned orig_w,orig_h,orig_d,orig_mip_count,reduction;
 	WW3DFormat orig_format;
 	if (!Get_Texture_Information
-		  (
+		(
 				Texture->Get_Full_Path(),
 				reduction,
 				orig_w,
@@ -2227,7 +2227,7 @@ bool CubeTextureLoadTaskClass::Begin_Compressed_Load()
 				orig_format,
 				orig_mip_count,
 				true
-		  )
+	)
 		)
 	{
 		return false;
@@ -2320,7 +2320,7 @@ bool CubeTextureLoadTaskClass::Begin_Uncompressed_Load()
 	unsigned width,height,depth,orig_mip_count,reduction;
 	WW3DFormat orig_format;
 	if (!Get_Texture_Information
-		  (
+		(
 				Texture->Get_Full_Path(),
 				reduction,
 				width,
@@ -2339,9 +2339,9 @@ bool CubeTextureLoadTaskClass::Begin_Uncompressed_Load()
 	WW3DFormat dest_format=src_format;
 	dest_format=Get_Valid_Texture_Format(dest_format,false);	// No compressed destination format if reading from targa...
 
-   if (		src_format != WW3D_FORMAT_A8R8G8B8
-   		&&	src_format != WW3D_FORMAT_R8G8B8
-  			&&	src_format != WW3D_FORMAT_X8R8G8B8 )
+	if (		src_format != WW3D_FORMAT_A8R8G8B8
+		&&	src_format != WW3D_FORMAT_R8G8B8
+		&&	src_format != WW3D_FORMAT_X8R8G8B8 )
 	{
 		WWDEBUG_SAY(("Invalid TGA format used in %s - only 24 and 32 bit formats should be used!", Texture->Get_Full_Path().str()));
 	}
@@ -2578,7 +2578,7 @@ bool VolumeTextureLoadTaskClass::Begin_Compressed_Load()
 	unsigned orig_w,orig_h,orig_d,orig_mip_count,reduction;
 	WW3DFormat orig_format;
 	if (!Get_Texture_Information
-		  (
+		(
 				Texture->Get_Full_Path(),
 				reduction,
 				orig_w,
@@ -2587,7 +2587,7 @@ bool VolumeTextureLoadTaskClass::Begin_Compressed_Load()
 				orig_format,
 				orig_mip_count,
 				true
-		  )
+	)
 		)
 	{
 		return false;
@@ -2686,7 +2686,7 @@ bool VolumeTextureLoadTaskClass::Begin_Uncompressed_Load()
 	unsigned width,height,depth,orig_mip_count,reduction;
 	WW3DFormat orig_format;
 	if (!Get_Texture_Information
-		  (
+		(
 				Texture->Get_Full_Path(),
 				reduction,
 				width,
@@ -2705,9 +2705,9 @@ bool VolumeTextureLoadTaskClass::Begin_Uncompressed_Load()
 	WW3DFormat dest_format=src_format;
 	dest_format=Get_Valid_Texture_Format(dest_format,false);	// No compressed destination format if reading from targa...
 
-   if (		src_format != WW3D_FORMAT_A8R8G8B8
-   		&&	src_format != WW3D_FORMAT_R8G8B8
-  			&&	src_format != WW3D_FORMAT_X8R8G8B8 )
+	if (		src_format != WW3D_FORMAT_A8R8G8B8
+		&&	src_format != WW3D_FORMAT_R8G8B8
+		&&	src_format != WW3D_FORMAT_X8R8G8B8 )
 	{
 		WWDEBUG_SAY(("Invalid TGA format used in %s - only 24 and 32 bit formats should be used!", Texture->Get_Full_Path().str()));
 	}

--- a/Core/Libraries/Source/WWVegas/WW3D2/visrasterizer.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/visrasterizer.cpp
@@ -456,10 +456,10 @@ struct GradientsStruct
 		}
 
 		DOOZ_DX = oodx * ( ((OOZ[1] - OOZ[2]) * (verts[0].Y - verts[2].Y)) -
-								 ((OOZ[0] - OOZ[2]) * (verts[1].Y - verts[2].Y)));
+			((OOZ[0] - OOZ[2]) * (verts[1].Y - verts[2].Y)));
 
 		DOOZ_DY = oody * ( ((OOZ[1] - OOZ[2]) * (verts[0].X - verts[2].X)) -
-								 ((OOZ[0] - OOZ[2]) * (verts[1].X - verts[2].X)));
+			((OOZ[0] - OOZ[2]) * (verts[1].X - verts[2].X)));
 	}
 
 	float OOZ[3];			// 1/z for each vertex

--- a/Core/Libraries/Source/WWVegas/WW3D2/w3d_dep.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/w3d_dep.cpp
@@ -53,9 +53,9 @@
 class STLSpecialAlloc
 {
 public:
-  // this one is needed for proper simple_alloc wrapping
-  static void*  allocate(size_t __n) {  return ::operator new(__n); }
-  static void deallocate(void* __p, size_t) { ::operator delete(__p); }
+	// this one is needed for proper simple_alloc wrapping
+	static void*  allocate(size_t __n) {  return ::operator new(__n); }
+	static void deallocate(void* __p, size_t) { ::operator delete(__p); }
 };
 
 

--- a/Core/Libraries/Source/WWVegas/WW3D2/ww3dformat.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/ww3dformat.cpp
@@ -436,46 +436,46 @@ unsigned ARGB_Color_To_WW3D_Color(WW3DFormat format, unsigned argb)
 
 	case WW3D_FORMAT_R5G6B5:
 		return ((r >> 3) << 11) |
-					 ((g >> 2) << 5)  |
-					 ((b >> 3) << 0);
+				((g >> 2) << 5)  |
+				((b >> 3) << 0);
 
 	case WW3D_FORMAT_X1R5G5B5:
 		return ( 1       << 15) |
-					 ((r >> 3) << 10) |
-					 ((g >> 3) << 5)  |
-					 ((b >> 3) << 0);
+				((r >> 3) << 10) |
+				((g >> 3) << 5)  |
+				((b >> 3) << 0);
 
 	case WW3D_FORMAT_A1R5G5B5:
 		return ((a >> 7) << 15) |
-					 ((r >> 3) << 10) |
-					 ((g >> 3) << 5)  |
-					 ((b >> 3) << 0);
+				((r >> 3) << 10) |
+				((g >> 3) << 5)  |
+				((b >> 3) << 0);
 
 	case WW3D_FORMAT_A4R4G4B4:
 		return ((a >> 4) << 12) |
-					 ((r >> 4) << 8)  |
-					 ((g >> 4) << 4)  |
-					 ((b >> 4) << 0);
+				((r >> 4) << 8)  |
+				((g >> 4) << 4)  |
+				((b >> 4) << 0);
 
 	case WW3D_FORMAT_R3G3B2:
 		return ((r >> 5) << 5) |
-					 ((g >> 5) << 2) |
-					 ((b >> 6) << 0);
+				((g >> 5) << 2) |
+				((b >> 6) << 0);
 
 	case WW3D_FORMAT_A8:
 		return a;
 
 	case WW3D_FORMAT_A8R3G3B2:
 		return ( a       << 8) |
-					 ((r >> 5) << 5) |
-					 ((g >> 5) << 2) |
-					 ((b >> 6) << 0);
+				((r >> 5) << 5) |
+				((g >> 5) << 2) |
+				((b >> 6) << 0);
 
 	case WW3D_FORMAT_X4R4G4B4:
 		return ( 0xF     << 12) |
-					 ((r >> 4) << 8) |
-					 ((g >> 4) << 4) |
-					 ((b >> 4) << 0);
+				((r >> 4) << 8) |
+				((g >> 4) << 4) |
+				((b >> 4) << 0);
 
 	case WW3D_FORMAT_L8:
 	{

--- a/Core/Libraries/Source/WWVegas/WWAudio/AudibleSound.cpp
+++ b/Core/Libraries/Source/WWVegas/WWAudio/AudibleSound.cpp
@@ -465,7 +465,7 @@ AudibleSoundClass::Stop (bool remove_from_playlist)
 	bool retval = false;
 
 	if ((m_State == STATE_PAUSED) ||
-		 (m_State == STATE_PLAYING)) {
+		(m_State == STATE_PLAYING)) {
 
 		// Actually stop the sample from playing
 		if (m_SoundHandle != nullptr) {
@@ -909,8 +909,8 @@ AudibleSoundClass::On_Frame_Update (unsigned int milliseconds)
 	// Do we need to track this sound's play-progress?
 	//
 	if ((m_LoopCount != INFINITE_LOOPS) &&
-		 (m_State == STATE_PLAYING) &&
-		 (m_Length > 0))
+		(m_State == STATE_PLAYING) &&
+		(m_Length > 0))
 	{
 		Update_Play_Position ();
 	}

--- a/Core/Libraries/Source/WWVegas/WWAudio/FilteredSound.cpp
+++ b/Core/Libraries/Source/WWVegas/WWAudio/FilteredSound.cpp
@@ -113,7 +113,7 @@ FilteredSoundClass::Initialize_Miles_Handle ()
 	SoundPseudo3DClass::Initialize_Miles_Handle ();
 	m_hFilter = WWAudioClass::Get_Instance ()->Get_Reverb_Filter ();
 	if ((m_SoundHandle != nullptr) &&
-		 (m_hFilter != (HPROVIDER)INVALID_MILES_HANDLE)) {
+		(m_hFilter != (HPROVIDER)INVALID_MILES_HANDLE)) {
 
 		//
 		//	Pass the filter onto the sample

--- a/Core/Libraries/Source/WWVegas/WWAudio/Sound3D.cpp
+++ b/Core/Libraries/Source/WWVegas/WWAudio/Sound3D.cpp
@@ -79,11 +79,11 @@ enum
 ////////////////////////////////////////////////////////////////////////////////////////////////
 Sound3DClass::Sound3DClass ()
 	: m_bAutoCalcVel (true),
-	  m_CurrentVelocity (0, 0, 0),
-	  m_MaxVolRadius (0),
-	  m_LastUpdate (0),
-	  m_IsStatic (false),
-	  m_IsTransformInitted (false)
+	m_CurrentVelocity (0, 0, 0),
+	m_MaxVolRadius (0),
+	m_LastUpdate (0),
+	m_IsStatic (false),
+	m_IsTransformInitted (false)
 {
 	return ;
 }
@@ -96,12 +96,12 @@ Sound3DClass::Sound3DClass ()
 ////////////////////////////////////////////////////////////////////////////////////////////////
 Sound3DClass::Sound3DClass (const Sound3DClass &src)
 	: m_bAutoCalcVel (true),
-	  m_CurrentVelocity (0, 0, 0),
-	  m_MaxVolRadius (0),
-	  m_LastUpdate (0),
-	  m_IsStatic (false),
-	  m_IsTransformInitted (false),
-	  AudibleSoundClass (src)
+	m_CurrentVelocity (0, 0, 0),
+	m_MaxVolRadius (0),
+	m_LastUpdate (0),
+	m_IsStatic (false),
+	m_IsTransformInitted (false),
+	AudibleSoundClass (src)
 {
 	(*this) = src;
 	return ;
@@ -115,7 +115,7 @@ Sound3DClass::Sound3DClass (const Sound3DClass &src)
 ////////////////////////////////////////////////////////////////////////////////////////////////
 Sound3DClass::~Sound3DClass ()
 {
- 	Free_Miles_Handle ();
+	Free_Miles_Handle ();
 	return ;
 }
 
@@ -316,12 +316,12 @@ Sound3DClass::Update_Miles_Transform ()
 		Vector3 up		= listener_space_tm.Get_Z_Vector ();
 
 		::AIL_set_3D_orientation (m_SoundHandle->Get_H3DSAMPLE (),
-										  -facing.Y,
-										  facing.Z,
-										  facing.X,
-										  -up.Y,
-										  up.Z,
-										  up.X);
+			-facing.Y,
+			facing.Z,
+			facing.X,
+			-up.Y,
+			up.Z,
+			up.X);
 	}
 
 	return ;

--- a/Core/Libraries/Source/WWVegas/WWAudio/SoundBuffer.cpp
+++ b/Core/Libraries/Source/WWVegas/WWAudio/SoundBuffer.cpp
@@ -68,13 +68,13 @@ static DynamicVectorClass<FileMappingClass> MappingList;
 //
 SoundBufferClass::SoundBufferClass ()
 	: m_Buffer (nullptr),
-	  m_Length (0),
-	  m_Filename (nullptr),
-	  m_Duration (0),
-	  m_Rate (0),
-	  m_Bits (0),
-	  m_Channels (0),
-	  m_Type (WAVE_FORMAT_IMA_ADPCM)
+	m_Length (0),
+	m_Filename (nullptr),
+	m_Duration (0),
+	m_Rate (0),
+	m_Bits (0),
+	m_Channels (0),
+	m_Type (WAVE_FORMAT_IMA_ADPCM)
 {
 	return ;
 }
@@ -285,7 +285,7 @@ SoundBufferClass::Load_From_Memory
 //	StreamSoundBufferClass
 //
 StreamSoundBufferClass::StreamSoundBufferClass ()	:
-	  SoundBufferClass ()
+	SoundBufferClass ()
 {
 	return ;
 }

--- a/Core/Libraries/Source/WWVegas/WWAudio/SoundCullObj.h
+++ b/Core/Libraries/Source/WWVegas/WWAudio/SoundCullObj.h
@@ -59,7 +59,7 @@ class SoundCullObjClass : public MultiListObjectClass, public CullableClass
 		//////////////////////////////////////////////////////////////////////
 		SoundCullObjClass ()
 			: m_SoundObj (nullptr),
-			  m_Transform (1) {}
+		m_Transform (1) {}
 
 		virtual ~SoundCullObjClass () override { REF_PTR_RELEASE (m_SoundObj); }
 

--- a/Core/Libraries/Source/WWVegas/WWAudio/WWAudio.cpp
+++ b/Core/Libraries/Source/WWVegas/WWAudio/WWAudio.cpp
@@ -91,7 +91,7 @@ WWAudioClass::Is_OK_To_Give_Handle (const AudibleSoundClass &sound_obj)
 	bool is_ok = false;
 	AudibleSoundClass::SOUND_TYPE type = sound_obj.Get_Type ();
 	if (((type == AudibleSoundClass::TYPE_SOUND_EFFECT) && m_AreSoundEffectsEnabled) ||
-		 ((type == AudibleSoundClass::TYPE_MUSIC) && m_IsMusicEnabled)) {
+		((type == AudibleSoundClass::TYPE_MUSIC) && m_IsMusicEnabled)) {
 		is_ok = true;
 	}
 	return is_ok;
@@ -105,27 +105,27 @@ WWAudioClass::Is_OK_To_Give_Handle (const AudibleSoundClass &sound_obj)
 ////////////////////////////////////////////////////////////////////////////////////////////////
 WWAudioClass::WWAudioClass ()
 	: m_Driver2D (nullptr),
-	  m_Driver3D (nullptr),
-	  m_PlaybackRate (44100),
-	  m_PlaybackBits (16),
-	  m_PlaybackStereo (true),
-	  m_ReverbFilter ((HPROVIDER)INVALID_MILES_HANDLE),
-	  m_UpdateTimer (-1),
-	  m_Driver3DPseudo (nullptr),
-	  m_MusicVolume (DEF_MUSIC_VOL),
-	  m_SoundVolume (DEF_SFX_VOL),
-	  m_MaxCacheSize (DEF_CACHE_SIZE * 1024),
-	  m_CurrentCacheSize (0),
-	  m_Max2DSamples (DEF_2D_SAMPLE_COUNT),
-	  m_Max3DSamples (DEF_3D_SAMPLE_COUNT),
-	  m_Max2DBufferSize (DEF_MAX_2D_BUFFER_SIZE),
-	  m_Max3DBufferSize (DEF_MAX_3D_BUFFER_SIZE),
-	  m_SoundScene (nullptr),
-	  m_IsMusicEnabled (true),
-	  m_AreSoundEffectsEnabled (true),
-	  m_FileFactory (nullptr),
-	  m_EffectsLevel (0),
-	  m_ReverbRoomType (ENVIRONMENT_GENERIC)
+	m_Driver3D (nullptr),
+	m_PlaybackRate (44100),
+	m_PlaybackBits (16),
+	m_PlaybackStereo (true),
+	m_ReverbFilter ((HPROVIDER)INVALID_MILES_HANDLE),
+	m_UpdateTimer (-1),
+	m_Driver3DPseudo (nullptr),
+	m_MusicVolume (DEF_MUSIC_VOL),
+	m_SoundVolume (DEF_SFX_VOL),
+	m_MaxCacheSize (DEF_CACHE_SIZE * 1024),
+	m_CurrentCacheSize (0),
+	m_Max2DSamples (DEF_2D_SAMPLE_COUNT),
+	m_Max3DSamples (DEF_3D_SAMPLE_COUNT),
+	m_Max2DBufferSize (DEF_MAX_2D_BUFFER_SIZE),
+	m_Max3DBufferSize (DEF_MAX_3D_BUFFER_SIZE),
+	m_SoundScene (nullptr),
+	m_IsMusicEnabled (true),
+	m_AreSoundEffectsEnabled (true),
+	m_FileFactory (nullptr),
+	m_EffectsLevel (0),
+	m_ReverbRoomType (ENVIRONMENT_GENERIC)
 {
 	::InitializeCriticalSection (&MMSLockClass::_MSSLockCriticalSection);
 
@@ -242,12 +242,12 @@ WWAudioClass::Open_2D_Device (LPWAVEFORMAT format)
 
 	// Do we need to switch from direct sound to waveout?
 	if ((success == AIL_NO_ERROR) &&
-		 (m_Driver2D != nullptr) &&
-		 (m_Driver2D->emulated_ds == TRUE)) {
+		(m_Driver2D != nullptr) &&
+		(m_Driver2D->emulated_ds == TRUE)) {
 		::AIL_waveOutClose (m_Driver2D);
 		success = 2;
 		WWDEBUG_SAY (("WWAudio: Detected 2D DirectSound emulation, switching to WaveOut."));
-   }
+	}
 
 	// If we couldn't open the direct sound device, then use the
 	// default wave out device
@@ -301,7 +301,7 @@ WWAudioClass::Open_2D_Device
 
 	DRIVER_TYPE_2D type = DRIVER2D_ERROR;
 	while (((type = Open_2D_Device ((LPWAVEFORMAT)&wave_format)) == DRIVER2D_ERROR) &&
-			 (wave_format.wf.nSamplesPerSec >= 11025)) {
+		(wave_format.wf.nSamplesPerSec >= 11025)) {
 
 		//
 		//	Cut the playback rate in half and try again
@@ -461,13 +461,13 @@ WWAudioClass::Free_Cache_Space (int bytes)
 
 	// Loop through all the hash indices
 	for (int hash_index = 0;
-		  (hash_index < MAX_CACHE_HASH) && (bytes_freed < bytes);
-		  hash_index ++) {
+	(hash_index < MAX_CACHE_HASH) && (bytes_freed < bytes);
+	hash_index ++) {
 
 		// Loop through all the buffers at this hash index
 		for (int index = 0;
-			  (index < m_CachedBuffers[hash_index].Count ()) && (bytes_freed < bytes);
-			  index ++) {
+		(index < m_CachedBuffers[hash_index].Count ()) && (bytes_freed < bytes);
+		index ++) {
 
 			// Can we free this cached buffer?
 			CACHE_ENTRY_STRUCT &info = m_CachedBuffers[hash_index][index];
@@ -515,8 +515,8 @@ WWAudioClass::Cache_Buffer
 	WWASSERT (buffer != nullptr);
 	WWASSERT (string_id != nullptr);
 	if ((buffer != nullptr) &&
-		 (string_id != nullptr) &&
-		 (buffer->Get_Raw_Length () < (U32)(m_MaxCacheSize / 2))) {
+		(string_id != nullptr) &&
+		(buffer->Get_Raw_Length () < (U32)(m_MaxCacheSize / 2))) {
 
 		// Attempt to free space in the cache (if needed)
 		int space_needed = (m_CurrentCacheSize + buffer->Get_Raw_Length ()) - (int)m_MaxCacheSize;
@@ -1124,7 +1124,7 @@ WWAudioClass::Free_Completed_Sounds ()
 		for (int index = 0; index < m_CompletedSounds.Count (); index ++) {
 			AudibleSoundClass *sound_obj = m_CompletedSounds[index];
 
-         WWASSERT(sound_obj != nullptr); //TSS 05/24/99
+			WWASSERT(sound_obj != nullptr); //TSS 05/24/99
 
 			// Remove this sound from the playlist
 			bool found = false;
@@ -1290,8 +1290,8 @@ WWAudioClass::Reprioritize_Playlist ()
 		// Is this the highest priority without a miles handle?
 		AudibleSoundClass *sound_obj = m_Playlist[index];
 		if ((sound_obj->Get_Miles_Handle () == nullptr) &&
-			 (sound_obj->Is_Sound_Culled () == false) &&
-			 (sound_obj->Get_Priority () > hightest_priority))
+			(sound_obj->Is_Sound_Culled () == false) &&
+			(sound_obj->Get_Priority () > hightest_priority))
 		{
 			// This is now the highest priority sound effect without
 			// a play-handle.
@@ -1579,9 +1579,9 @@ WWAudioClass::Build_3D_Driver_List ()
 
 	// Attempt to select one of the known drivers (in the following order).
 	if ((Select_3D_Device (DRIVER3D_A3D) == false) &&
-		 (Select_3D_Device (DRIVER3D_EAX) == false) &&
-		 (Select_3D_Device (DRIVER3D_D3DSOUND) == false) &&
-		 (Select_3D_Device (DRIVER3D_DOLBY) == false)) {
+		(Select_3D_Device (DRIVER3D_EAX) == false) &&
+		(Select_3D_Device (DRIVER3D_D3DSOUND) == false) &&
+		(Select_3D_Device (DRIVER3D_DOLBY) == false)) {
 
 		// Couldn't select a known driver, so just use the first possible.
 		if (m_Driver3DList.Count () > 0) {
@@ -1884,9 +1884,9 @@ WWAudioClass::Validate_3D_Sound_Buffer (SoundBufferClass *buffer)
 	// 3D sound buffer MUST be uncompressed mono WAV data
 	//
 	if ((buffer != nullptr) &&
-		 (buffer->Get_Channels () == 1) &&
-		 (buffer->Get_Type () == WAVE_FORMAT_PCM) &&
-		 (buffer->Is_Streaming () == false))
+		(buffer->Get_Channels () == 1) &&
+		(buffer->Get_Type () == WAVE_FORMAT_PCM) &&
+		(buffer->Is_Streaming () == false))
 	{
 		retval = true;
 	}
@@ -1911,8 +1911,8 @@ WWAudioClass::ReAssign_2D_Handles ()
 		// If this is a 2D sound effect, then force it to 'get' a new
 		// sound handle.
 		if ((sound_obj->Get_Class_ID () == CLASSID_2D) ||
-			 (sound_obj->Get_Class_ID () == CLASSID_PSEUDO3D) ||
-			 (sound_obj->Get_Class_ID () == CLASSID_2DTRIGGER))
+			(sound_obj->Get_Class_ID () == CLASSID_PSEUDO3D) ||
+			(sound_obj->Get_Class_ID () == CLASSID_2DTRIGGER))
 		{
 			sound_obj->Free_Miles_Handle ();
 			sound_obj->Allocate_Miles_Handle ();

--- a/Core/Libraries/Source/WWVegas/WWDebug/wwdebug.cpp
+++ b/Core/Libraries/Source/WWVegas/WWDebug/wwdebug.cpp
@@ -309,21 +309,21 @@ void WWDebug_Assert_Fail(const char * expr,const char * file, int line)
 			ExitProcess(0);
 		}
 
-      char assertbuf[4096];
+		char assertbuf[4096];
 		sprintf(assertbuf, "Assert failed\n\n. File %s Line %d", file, line);
 
-      int code = MessageBoxA(nullptr, assertbuf, "WWDebug_Assert_Fail", MB_ABORTRETRYIGNORE|MB_ICONHAND|MB_SETFOREGROUND|MB_TASKMODAL);
+		int code = MessageBoxA(nullptr, assertbuf, "WWDebug_Assert_Fail", MB_ABORTRETRYIGNORE|MB_ICONHAND|MB_SETFOREGROUND|MB_TASKMODAL);
 
-      if (code == IDABORT) {
-      	raise(SIGABRT);
-      	_exit(3);
-      }
+		if (code == IDABORT) {
+			raise(SIGABRT);
+			_exit(3);
+		}
 
 		if (code == IDRETRY) {
 			WWDEBUG_BREAK
-      	return;
+				return;
 		}
-   }
+	}
 }
 #endif
 
@@ -468,61 +468,61 @@ void WWDebug_Profile_Stop( const char * title)
 void WWDebug_DBWin32_Message_Handler( const char * str )
 {
 
-    HANDLE heventDBWIN;  /* DBWIN32 synchronization object */
-    HANDLE heventData;   /* data passing synch object */
-    HANDLE hSharedFile;  /* memory mapped file shared data */
-    LPSTR lpszSharedMem;
+	HANDLE heventDBWIN;  /* DBWIN32 synchronization object */
+	HANDLE heventData;   /* data passing synch object */
+	HANDLE hSharedFile;  /* memory mapped file shared data */
+	LPSTR lpszSharedMem;
 
     /* make sure DBWIN is open and waiting */
-    heventDBWIN = OpenEvent(EVENT_MODIFY_STATE, FALSE, "DBWIN_BUFFER_READY");
-    if ( !heventDBWIN )
-    {
-        //MessageBox(nullptr, "DBWIN_BUFFER_READY nonexistent", nullptr, MB_OK);
-        return;
-    }
+	heventDBWIN = OpenEvent(EVENT_MODIFY_STATE, FALSE, "DBWIN_BUFFER_READY");
+	if ( !heventDBWIN )
+	{
+		//MessageBox(nullptr, "DBWIN_BUFFER_READY nonexistent", nullptr, MB_OK);
+		return;
+	}
 
     /* get a handle to the data synch object */
-    heventData = OpenEvent(EVENT_MODIFY_STATE, FALSE, "DBWIN_DATA_READY");
-    if ( !heventData )
-    {
-        // MessageBox(nullptr, "DBWIN_DATA_READY nonexistent", nullptr, MB_OK);
-        CloseHandle(heventDBWIN);
-        return;
-    }
+	heventData = OpenEvent(EVENT_MODIFY_STATE, FALSE, "DBWIN_DATA_READY");
+	if ( !heventData )
+	{
+		// MessageBox(nullptr, "DBWIN_DATA_READY nonexistent", nullptr, MB_OK);
+		CloseHandle(heventDBWIN);
+		return;
+	}
 
-    hSharedFile = CreateFileMapping((HANDLE)-1, nullptr, PAGE_READWRITE, 0, 4096, "DBWIN_BUFFER");
-    if (!hSharedFile)
-    {
-        //MessageBox(nullptr, "DebugTrace: Unable to create file mapping object DBWIN_BUFFER", "Error", MB_OK);
-        CloseHandle(heventDBWIN);
-        CloseHandle(heventData);
-        return;
-    }
+	hSharedFile = CreateFileMapping((HANDLE)-1, nullptr, PAGE_READWRITE, 0, 4096, "DBWIN_BUFFER");
+	if (!hSharedFile)
+	{
+		//MessageBox(nullptr, "DebugTrace: Unable to create file mapping object DBWIN_BUFFER", "Error", MB_OK);
+		CloseHandle(heventDBWIN);
+		CloseHandle(heventData);
+		return;
+	}
 
-    lpszSharedMem = (LPSTR)MapViewOfFile(hSharedFile, FILE_MAP_WRITE, 0, 0, 512);
-    if (!lpszSharedMem)
-    {
-        //MessageBox(nullptr, "DebugTrace: Unable to map shared memory", "Error", MB_OK);
-        CloseHandle(heventDBWIN);
-        CloseHandle(heventData);
-        return;
-    }
+	lpszSharedMem = (LPSTR)MapViewOfFile(hSharedFile, FILE_MAP_WRITE, 0, 0, 512);
+	if (!lpszSharedMem)
+	{
+		//MessageBox(nullptr, "DebugTrace: Unable to map shared memory", "Error", MB_OK);
+		CloseHandle(heventDBWIN);
+		CloseHandle(heventData);
+		return;
+	}
 
     /* wait for buffer event */
-    WaitForSingleObject(heventDBWIN, INFINITE);
+	WaitForSingleObject(heventDBWIN, INFINITE);
 
     /* write it to the shared memory */
-    *((LPDWORD)lpszSharedMem) = 0;
-    wsprintf(lpszSharedMem + sizeof(DWORD), "%s", str);
+	*((LPDWORD)lpszSharedMem) = 0;
+	wsprintf(lpszSharedMem + sizeof(DWORD), "%s", str);
 
     /* signal data ready event */
-    SetEvent(heventData);
+	SetEvent(heventData);
 
     /* clean up handles */
-    CloseHandle(hSharedFile);
-    CloseHandle(heventData);
-    CloseHandle(heventDBWIN);
+	CloseHandle(hSharedFile);
+	CloseHandle(heventData);
+	CloseHandle(heventDBWIN);
 
-    return;
+	return;
 }
 #endif // WWDEBUG

--- a/Core/Libraries/Source/WWVegas/WWDebug/wwprofile.cpp
+++ b/Core/Libraries/Source/WWVegas/WWDebug/wwprofile.cpp
@@ -98,7 +98,7 @@ WWINLINE double WWProfile_Get_Inv_Processor_Ticks_Per_Second()
 static inline void WWProfile_Get_Ticks(_int64 * ticks)
 {
 #ifdef _UNIX
-       *ticks = TIMEGETTIME();
+	*ticks = TIMEGETTIME();
 #else
 	*ticks = _rdtsc();
 #endif

--- a/Core/Libraries/Source/WWVegas/WWDownload/Download.cpp
+++ b/Core/Libraries/Source/WWVegas/WWDownload/Download.cpp
@@ -38,7 +38,7 @@
 
 HRESULT CDownload::DownloadFile(LPCSTR server, LPCSTR username, LPCSTR password, LPCSTR file, LPCSTR localfile, LPCSTR regkey, bool tryresume)
 {
- 	// Check we're not in the middle of another download.
+	// Check we're not in the middle of another download.
 	if((m_Status != DOWNLOADSTATUS_DONE ) && (m_Status != DOWNLOADSTATUS_FINDINGFILE))
 	{
 		return( DOWNLOAD_STATUSERROR );
@@ -61,7 +61,7 @@ HRESULT CDownload::DownloadFile(LPCSTR server, LPCSTR username, LPCSTR password,
 		( password == nullptr ) || ( file == nullptr ) ||
 		( localfile == nullptr ) || ( regkey == nullptr ) )
 	{
-     //////////DBGMSG("Download Paramerror");
+		//////////DBGMSG("Download Paramerror");
 		return( DOWNLOAD_PARAMERROR );
 	}
 
@@ -101,7 +101,7 @@ HRESULT CDownload::DownloadFile(LPCSTR server, LPCSTR username, LPCSTR password,
 	if (m_Status != DOWNLOADSTATUS_FINDINGFILE)
 		m_Status = DOWNLOADSTATUS_GO;
 
-   //////////DBGMSG("Ready to download");
+	//////////DBGMSG("Ready to download");
 	return S_OK;
 }
 
@@ -162,7 +162,7 @@ HRESULT CDownload::PumpMessages()
 
 	/* Avoid reentrancy. */
 
-   ////DBGMSG("Download Pump");
+	////DBGMSG("Download Pump");
 
 	if( reenter != 0 )
 	{
@@ -202,10 +202,10 @@ HRESULT CDownload::PumpMessages()
 	if( m_Status == DOWNLOADSTATUS_CONNECTING )
 	{
 		// Connect to the server
-      //////////DBGMSG("Connect to Server");
+		//////////DBGMSG("Connect to Server");
 
 		iResult = m_Ftp->ConnectToServer( m_Server );
-      ////////////DBGMSG("out of FTP connect");
+		////////////DBGMSG("out of FTP connect");
 
 		if( iResult == FTP_SUCCEEDED )
 		{
@@ -216,7 +216,7 @@ HRESULT CDownload::PumpMessages()
 			if( iResult == FTP_FAILED )
 			{
 				// Tell the client we couldn't connect
-            ///////////DBGMSG("Couldn't connect");
+				///////////DBGMSG("Couldn't connect");
 				Listener->OnError( DOWNLOADEVENT_COULDNOTCONNECT );
 				reenter = 0;
 				return DOWNLOAD_NETWORKERROR;
@@ -229,7 +229,7 @@ HRESULT CDownload::PumpMessages()
 	if( m_Status == DOWNLOADSTATUS_LOGGINGIN )
 	{
 		// Login to the server
-      ////////////DBGMSG("Login to server");
+		////////////DBGMSG("Login to server");
 
 		iResult = m_Ftp->LoginToServer( m_Login, m_Password );
 
@@ -256,7 +256,7 @@ HRESULT CDownload::PumpMessages()
 	{
 
 		// Find the file on the server
-      ///////////DBGMSG("Find File");
+		///////////DBGMSG("Find File");
 
 		if( m_Ftp->FindFile( m_File, &m_FileSize ) == FTP_FAILED )
 		{
@@ -329,7 +329,7 @@ HRESULT CDownload::PumpMessages()
 	{
 
 		// Get the next chunk of the file
-      ///DBGMSG("Get Next File Block");
+		///DBGMSG("Get Next File Block");
 
 		iResult = m_Ftp->GetNextFileBlock( m_LocalFile, &m_BytesRead );
 
@@ -359,7 +359,7 @@ HRESULT CDownload::PumpMessages()
 		timetaken = ( timeGetTime() - m_TimeStarted ) / 1000;
 
 		//////////if( m_BytesRead > 0 ) // NAK - RP said this is wrong
-      if( ( m_BytesRead - m_StartPosition ) > 0 )
+		if( ( m_BytesRead - m_StartPosition ) > 0 )
 		{
 			// Not the first read.
 			int predictionIndex = ( m_predictions++ ) & 0x7;
@@ -383,9 +383,9 @@ HRESULT CDownload::PumpMessages()
 				// We've had enough time to build up a few predictions, so calculate
 				// an average.
 				averagetimepredicted = ( m_predictionTimes[ 0 ] + m_predictionTimes[ 1 ] +
-										 m_predictionTimes[ 2 ] + m_predictionTimes[ 3 ] +
-										 m_predictionTimes[ 4 ] + m_predictionTimes[ 5 ] +
-										 m_predictionTimes[ 6 ] + m_predictionTimes[ 7 ] ) / 8;
+					m_predictionTimes[ 2 ] + m_predictionTimes[ 3 ] +
+					m_predictionTimes[ 4 ] + m_predictionTimes[ 5 ] +
+					m_predictionTimes[ 6 ] + m_predictionTimes[ 7 ] ) / 8;
 			}
 			else
 			{

--- a/Core/Libraries/Source/WWVegas/WWDownload/Download.h
+++ b/Core/Libraries/Source/WWVegas/WWDownload/Download.h
@@ -29,7 +29,7 @@
 
 class IDownload
 {
- public:
+public:
 	virtual HRESULT OnError( int error )=0;
 	virtual HRESULT OnEnd()=0;
 	virtual HRESULT OnQueryResume()=0;

--- a/Core/Libraries/Source/WWVegas/WWDownload/FTP.cpp
+++ b/Core/Libraries/Source/WWVegas/WWDownload/FTP.cpp
@@ -169,7 +169,7 @@ static bool Use_Non_Blocking_Mode()
 
 Cftp::Cftp()
 {
-  ZeroStuff();
+	ZeroStuff();
 }
 
 
@@ -193,7 +193,7 @@ Cftp::Cftp()
 
 Cftp::~Cftp()
 {
-  CloseSockets();
+	CloseSockets();
 
 	if (m_pfLocalFile)
 	{
@@ -245,13 +245,13 @@ void Cftp::ZeroStuff()
 DWORD WINAPI gethostbynameA( void * szName )
 {
 	HOSTENT *he = gethostbyname( (const char *)szName );
-   //////DBGMSG("Hostname copy start");
+	//////DBGMSG("Hostname copy start");
 
 	if (he)
 		memcpy((char *)&(gThreadAddress.sin_addr), he->h_addr, he->h_length );
 	else
 		memcpy((char *)&(gThreadAddress.sin_addr),"",strlen("")+1);
-   /////DBGMSG("Hostname copy complete");
+	/////DBGMSG("Hostname copy complete");
 
 	gThreadFlag = 1;
 	return 0;
@@ -267,7 +267,7 @@ int Cftp::AsyncGetHostByName(char * szName, struct sockaddr_in &address )
 	{
 		/* Kick off gethostname thread */
 		gThreadFlag = 0;
-      memset(&gThreadAddress,0,sizeof(gThreadAddress));
+		memset(&gThreadAddress,0,sizeof(gThreadAddress));
 
 		if( CreateThread( nullptr, 0, gethostbynameA, szName, 0, &threadid ) == nullptr )
 		{
@@ -280,8 +280,8 @@ int Cftp::AsyncGetHostByName(char * szName, struct sockaddr_in &address )
 		if( gThreadFlag )
 		{
 			/* Thread finished */
-         address = gThreadAddress;
-         address.sin_family=AF_INET;
+			address = gThreadAddress;
+			address.sin_family=AF_INET;
 			stat = 0;
 			return( FTP_SUCCEEDED );
 		}
@@ -338,27 +338,27 @@ HRESULT  Cftp::ConnectToServer(LPCSTR szServerName)
 		if( serverIP == INADDR_NONE )
 		{
 			/* It's an FQDN - hopefully. */
-         ////////DBGMSG("Async gethostbyname");
+			////////DBGMSG("Async gethostbyname");
 			if( AsyncGetHostByName( m_szServerName, address ) == FTP_TRYING )
 			{
 				return( FTP_TRYING );
 			}
-         //////DBGMSG("Got hostbyname");
+			//////DBGMSG("Got hostbyname");
 
 			if( address.sin_addr.s_addr == 0 )
 			{
-            ///////DBGMSG("gethostbyname failed");
+				///////DBGMSG("gethostbyname failed");
 				return( FTP_FAILED );
 			}
 
-         m_CommandSockAddr=address;
+			m_CommandSockAddr=address;
 
 			///////memcpy( (char *)&(m_CommandSockAddr.sin_addr), he.h_addr, he.h_length );
 
 			serverIP = m_CommandSockAddr.sin_addr.s_addr;
-         //////DBGMSG("ServerIP = "<<serverIP);
+			//////DBGMSG("ServerIP = "<<serverIP);
 
-         /////DBGMSG("Memcpy OK");
+			/////DBGMSG("Memcpy OK");
 		}
 		else
 		{
@@ -379,7 +379,7 @@ HRESULT  Cftp::ConnectToServer(LPCSTR szServerName)
 			return( FTP_FAILED );
 		}
 
-      //////DBGMSG("Socket created");
+		//////DBGMSG("Socket created");
 
 		/* Set socket to non-blocking */
 
@@ -407,7 +407,7 @@ HRESULT  Cftp::ConnectToServer(LPCSTR szServerName)
 
 			if( error != WSAEISCONN )
 			{
-            ////////DBGMSG("Connect failed");
+				////////DBGMSG("Connect failed");
 				closesocket( m_iCommandSocket );
 				return( FTP_FAILED );
 			}
@@ -600,7 +600,7 @@ HRESULT  Cftp::LogoffFromServer()
 				{
 					//m_iStatus = FTPSTAT_SENTQUIT;
 
-                    //m_iStatus = FTPSTAT_INIT;  // NAK
+					//m_iStatus = FTPSTAT_INIT;  // NAK
 
 					CloseSockets();
 					ZeroStuff();
@@ -665,12 +665,12 @@ HRESULT  Cftp::FindFile( LPCSTR szRemoteFileName, int * piSize )
 	char ext[ 10 ];
 
 	if (m_findStart==0)
-      m_findStart=time(nullptr);
+	m_findStart=time(nullptr);
 
 	if((time(nullptr)-m_findStart) > 30)  // try for 30 seconds
 	{
-        /////////DBGMSG("FindFile: Tried for too long");
-        m_findStart=0;
+		/////////DBGMSG("FindFile: Tried for too long");
+		m_findStart=0;
 		return( FTP_FAILED );
 	}
 
@@ -778,8 +778,8 @@ HRESULT  Cftp::FindFile( LPCSTR szRemoteFileName, int * piSize )
 		i = OpenDataConnection();
 		if( i != FTP_SUCCEEDED )
 		{
-            /////////DBGMSG("FindFile: OpenDataConnection failed: "<<i);
-            m_findStart=0;
+			/////////DBGMSG("FindFile: OpenDataConnection failed: "<<i);
+			m_findStart=0;
 			return( i );
 		}
 		m_iStatus = FTPSTAT_LISTDATAOPEN;
@@ -822,7 +822,7 @@ HRESULT  Cftp::FindFile( LPCSTR szRemoteFileName, int * piSize )
 	if( strncmp( listline, m_szRemoteFileName, sizeof( m_szRemoteFileName ) ) == 0 )
 	{
 		/* No */
-        ////////DBGMSG("FindFile: File not in list: "<<listline);
+		////////DBGMSG("FindFile: File not in list: "<<listline);
 		return( FTP_FAILED );
 	}
 
@@ -838,7 +838,7 @@ HRESULT  Cftp::FindFile( LPCSTR szRemoteFileName, int * piSize )
 		return( FTP_SUCCEEDED );
 	}
 
-    ////////DBGMSG("Default fail case: "<<listline);
+	////////DBGMSG("Default fail case: "<<listline);
 	return( FTP_FAILED );
 }
 
@@ -1164,12 +1164,12 @@ int Cftp::SendNewPort()
 		}
 
 		sprintf( command, "PORT %d,%d,%d,%d,%d,%d\r\n",
-				 i & 0xFF,
-				 ( i >> 8 ) & 0xFF,
-				 ( i >> 16 ) & 0xFF,
-				 ( i >> 24 ) & 0xFF,
-				 m_DataSockAddr.sin_port & 0xFF,
-				 m_DataSockAddr.sin_port >> 8 );
+			i & 0xFF,
+			( i >> 8 ) & 0xFF,
+			( i >> 16 ) & 0xFF,
+			( i >> 24 ) & 0xFF,
+			m_DataSockAddr.sin_port & 0xFF,
+			m_DataSockAddr.sin_port >> 8 );
 
 		if( SendCommand( command, strlen(command) ) < 0 )
 		{

--- a/Core/Libraries/Source/WWVegas/WWDownload/urlBuilder.cpp
+++ b/Core/Libraries/Source/WWVegas/WWDownload/urlBuilder.cpp
@@ -21,7 +21,7 @@
 #include "Registry.h"
 
 void FormatURLFromRegistry( std::string& gamePatchURL, std::string& mapPatchURL,
-													 std::string& configURL, std::string& motdURL )
+	std::string& configURL, std::string& motdURL )
 {
 #if RTS_GENERALS
 	std::string sku = "generals";

--- a/Core/Libraries/Source/WWVegas/WWDownload/urlBuilder.h
+++ b/Core/Libraries/Source/WWVegas/WWDownload/urlBuilder.h
@@ -19,4 +19,4 @@
 #pragma once
 
 void FormatURLFromRegistry( std::string& gamePatchURL, std::string& mapPatchURL,
-													 std::string& configURL, std::string& motdURL );
+	std::string& configURL, std::string& motdURL );

--- a/Core/Libraries/Source/WWVegas/WWLib/BSEARCH.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/BSEARCH.h
@@ -27,16 +27,16 @@
 template<class T>
 T * Binary_Search(T * A, int n, T const & target)
 {
-   const T * pointer = A;
-   int stride = n;
+	const T * pointer = A;
+	int stride = n;
 
 	/*
 	**	Keep binary searching until a match has been found
 	**	or the search has resulted in no match.
 	*/
-   while (0 < stride) {
-      int const pivot = stride / 2;
-      T const * const tryptr = pointer + pivot;
+	while (0 < stride) {
+		int const pivot = stride / 2;
+		T const * const tryptr = pointer + pivot;
 
 		/*
 		**	Binary stride forward or backward depending on if the candidate
@@ -45,7 +45,7 @@ T * Binary_Search(T * A, int n, T const & target)
 		**	then the base pointer must be adjusted and the stride must be
 		**	moved backward.
 		*/
-      if (target < *tryptr) {
+		if (target < *tryptr) {
 			stride = pivot;
 		} else {
 
@@ -60,9 +60,9 @@ T * Binary_Search(T * A, int n, T const & target)
 				return ((T *) tryptr);
 			}
 
-	      pointer = tryptr + 1;
-		   stride -= pivot + 1;
+			pointer = tryptr + 1;
+			stride -= pivot + 1;
 		}
-   }
-   return (nullptr);
+	}
+	return (nullptr);
 }

--- a/Core/Libraries/Source/WWVegas/WWLib/CallbackHook.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/CallbackHook.h
@@ -59,7 +59,7 @@ template<class T> class Callback :
 	public:
 		Callback(bool (*callback)(T), T userdata) :
 				mCallback(callback),
-			  mUserData(userdata)
+		mUserData(userdata)
 			{}
 
 		virtual ~Callback()

--- a/Core/Libraries/Source/WWVegas/WWLib/FastAllocator.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/FastAllocator.cpp
@@ -35,7 +35,7 @@ FastAllocatorGeneral::FastAllocatorGeneral() : MemoryLeakLogEnabled(false), Allo
 {
 	int alloc_size=ALLOC_STEP;
 	for (int i=0;i<MAX_ALLOC_SIZE/ALLOC_STEP;++i) {
-	   allocators[i].Init(alloc_size);
+		allocators[i].Init(alloc_size);
 		alloc_size+=ALLOC_STEP;
 	}
 }

--- a/Core/Libraries/Source/WWVegas/WWLib/FastAllocator.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/FastAllocator.h
@@ -129,75 +129,75 @@ class FastAllocatorGeneral;  //Allocates and deletes items of any size. Can use 
 template<class T, int nStackCount, int bConstruct=1>
 class StackAllocator{
 public:
-   StackAllocator() : mnAllocCount(-1), mpTHeap(nullptr){}
-  ~StackAllocator(){
-      if(mnAllocCount != -1){ //If there is anything to do...
-         if(mpTHeap)
-            delete mpTHeap;
-         else{
-            if(bConstruct){ //Since this constant, the comparison gets optimized away.
-               T* pTArray = (T*)mTArray;
-               const T* const pTArrayEnd = pTArray + mnAllocCount;
-               while(pTArray < pTArrayEnd){
-                  pTArray->~T(); //Call the destructor on the object directly.
-                  ++pTArray;
-               }
-            }
-         }
-      }
-   }
+	StackAllocator() : mnAllocCount(-1), mpTHeap(nullptr){}
+	~StackAllocator(){
+		if(mnAllocCount != -1){ //If there is anything to do...
+			if(mpTHeap)
+			delete mpTHeap;
+			else{
+				if(bConstruct){ //Since this constant, the comparison gets optimized away.
+					T* pTArray = (T*)mTArray;
+					const T* const pTArrayEnd = pTArray + mnAllocCount;
+					while(pTArray < pTArrayEnd){
+						pTArray->~T(); //Call the destructor on the object directly.
+						++pTArray;
+					}
+				}
+			}
+		}
+	}
 
-   T* New(unsigned nCount){
-      if(mnAllocCount == -1){
-         mnAllocCount = nCount;
-         if(nCount < nStackCount){ //If the request is small enough to come from the stack...
-            //We call the constructors of all the objects here.
-            if(bConstruct){ //Since this constant, the comparison gets optimized away.
-               T* pTArray = (T*)mTArray;
-               const T* const pTArrayEnd = pTArray + nCount;
-               while(pTArray < pTArrayEnd){
-                  //Use the placement operator new. This simply calls the constructor
-                  //of T with 'this' set to the input address. Note that we don't put
-                  //a '()' after the T this is because () causes trivial types like int
-                  //and class* to be assigned zero/null. We don't want that.
-                  new(pTArray)T;
-                  ++pTArray;
-               }
-            }
-            return (T*)mTArray;
-         }
-         //Else the request is too big. So let's use (the slower) operator new.
-         return (mpTHeap = new T[nCount]); //The compiler will call the constructors here.
-      }
-      //Else we are being used. Let's be nice and allocate something anyway.
-      return new T[nCount];
-   }
+	T* New(unsigned nCount){
+		if(mnAllocCount == -1){
+			mnAllocCount = nCount;
+			if(nCount < nStackCount){ //If the request is small enough to come from the stack...
+				//We call the constructors of all the objects here.
+				if(bConstruct){ //Since this constant, the comparison gets optimized away.
+					T* pTArray = (T*)mTArray;
+					const T* const pTArrayEnd = pTArray + nCount;
+					while(pTArray < pTArrayEnd){
+						//Use the placement operator new. This simply calls the constructor
+						//of T with 'this' set to the input address. Note that we don't put
+						//a '()' after the T this is because () causes trivial types like int
+						//and class* to be assigned zero/null. We don't want that.
+						new(pTArray)T;
+						++pTArray;
+					}
+				}
+				return (T*)mTArray;
+			}
+			//Else the request is too big. So let's use (the slower) operator new.
+			return (mpTHeap = new T[nCount]); //The compiler will call the constructors here.
+		}
+		//Else we are being used. Let's be nice and allocate something anyway.
+		return new T[nCount];
+	}
 
-   void Delete(T* pT){
-      if(pT == (T*)mTArray){ //If the allocation came from our stack...
-         if(bConstruct){ //Since this constant, the comparison gets optimized away.
-            T* pTArray = (T*)mTArray;
-            const T* const pTArrayEnd = pTArray + mnAllocCount;
-            while(pTArray < pTArrayEnd){
-               pTArray->~T(); //Call the destructor on the object directly.
-               ++pTArray;
-            }
-         }
-         mnAllocCount = -1;
-      }
-      else if(pT == mpTHeap){ //If the allocation came from our heap...
-         delete[] mpTHeap;    //The compiler will call the destructors here.
-         mpTHeap      = nullptr; //We clear these out so that we can possibly
-         mnAllocCount = -1;   //  use the allocator again.
-      }
-      else //Else the allocation came from the external heap.
-         delete[] pT;
-   }
+	void Delete(T* pT){
+		if(pT == (T*)mTArray){ //If the allocation came from our stack...
+			if(bConstruct){ //Since this constant, the comparison gets optimized away.
+				T* pTArray = (T*)mTArray;
+				const T* const pTArrayEnd = pTArray + mnAllocCount;
+				while(pTArray < pTArrayEnd){
+					pTArray->~T(); //Call the destructor on the object directly.
+					++pTArray;
+				}
+			}
+			mnAllocCount = -1;
+		}
+		else if(pT == mpTHeap){ //If the allocation came from our heap...
+			delete[] mpTHeap;    //The compiler will call the destructors here.
+			mpTHeap      = nullptr; //We clear these out so that we can possibly
+			mnAllocCount = -1;   //  use the allocator again.
+		}
+		else //Else the allocation came from the external heap.
+		delete[] pT;
+	}
 
 protected:
-   int  mnAllocCount;                     //Count of objects allocated. -1 means that nothing is allocated. We don't use zero because zero is a legal allocation count in C++.
-   T*   mpTHeap;                          //This is normally null, but gets used of the allocation request is too high.
-   char mTArray[nStackCount*sizeof(T)];   //This is our stack memory.
+	int  mnAllocCount;                     //Count of objects allocated. -1 means that nothing is allocated. We don't use zero because zero is a legal allocation count in C++.
+	T*   mpTHeap;                          //This is normally null, but gets used of the allocation request is too high.
+	char mTArray[nStackCount*sizeof(T)];   //This is our stack memory.
 };
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -211,9 +211,9 @@ class FastFixedAllocator
 {
 public:
 	FastFixedAllocator(unsigned int n=0);
-  ~FastFixedAllocator();
-   void  Init(unsigned int n); //Useful for setting allocation size *after* construction,
-                               //but before first use.
+	~FastFixedAllocator();
+	void  Init(unsigned int n); //Useful for setting allocation size *after* construction,
+	//but before first use.
 	void* Alloc();
 	void  Free(void* pAlloc);
 
@@ -227,7 +227,7 @@ protected:
 		Link* next;
 	};
 
-   struct Chunk
+	struct Chunk
 	{
 		enum {
 			size = 8*1024-16
@@ -255,12 +255,12 @@ WWINLINE void* FastFixedAllocator::Alloc()
 {
 	TotalAllocationCount++;
 	TotalAllocatedSize+=esize;
-   if (head==0) {
-      grow();
+	if (head==0) {
+		grow();
 	}
-   Link* p = head;
-   head    = p->next;
-   return p;
+	Link* p = head;
+	head    = p->next;
+	return p;
 }
 
 // ----------------------------------------------------------------------------
@@ -273,9 +273,9 @@ WWINLINE void FastFixedAllocator::Free(void* pAlloc)
 {
 	TotalAllocationCount--;
 	TotalAllocatedSize-=esize;
-   Link* p = static_cast<Link*>(pAlloc);
-   p->next = head;
-   head    = p;
+	Link* p = static_cast<Link*>(pAlloc);
+	p->next = head;
+	head    = p;
 }
 
 // ----------------------------------------------------------------------------
@@ -286,9 +286,9 @@ WWINLINE void FastFixedAllocator::Free(void* pAlloc)
 
 WWINLINE FastFixedAllocator::FastFixedAllocator(unsigned int n) : esize(1), TotalHeapSize(0), TotalAllocatedSize(0), TotalAllocationCount(0)
 {
-   head   = 0;
-   chunks = 0;
-   Init(n);
+	head   = 0;
+	chunks = 0;
+	Init(n);
 }
 
 // ----------------------------------------------------------------------------
@@ -299,12 +299,12 @@ WWINLINE FastFixedAllocator::FastFixedAllocator(unsigned int n) : esize(1), Tota
 
 WWINLINE FastFixedAllocator::~FastFixedAllocator()
 {
-   Chunk* n = chunks;
-   while(n){
-      Chunk* p = n;
-      n = n->next;
-      delete p;
-   }
+	Chunk* n = chunks;
+	while(n){
+		Chunk* p = n;
+		n = n->next;
+		delete p;
+	}
 }
 
 // ----------------------------------------------------------------------------
@@ -315,7 +315,7 @@ WWINLINE FastFixedAllocator::~FastFixedAllocator()
 
 WWINLINE void FastFixedAllocator::Init(unsigned int n)
 {
-   esize = (n<sizeof(Link*) ? sizeof(Link*) : n);
+	esize = (n<sizeof(Link*) ? sizeof(Link*) : n);
 }
 
 // ----------------------------------------------------------------------------
@@ -326,18 +326,18 @@ WWINLINE void FastFixedAllocator::Init(unsigned int n)
 
 WWINLINE void FastFixedAllocator::grow()
 {
-   Chunk* n = new Chunk;
-   n->next  = chunks;
-   chunks   = n;
+	Chunk* n = new Chunk;
+	n->next  = chunks;
+	chunks   = n;
 	TotalHeapSize+=sizeof(Chunk);
 
-   const int nelem = Chunk::size/esize;
-   char* start = n->mem;
-   char* last = &start[(nelem-1)*esize];
-   for(char* p = start; p<last; p+=esize)
-      reinterpret_cast<Link*>(p)->next = reinterpret_cast<Link*>(p+esize);
-   reinterpret_cast<Link*>(last)->next = 0;
-   head = reinterpret_cast<Link*>(start);
+	const int nelem = Chunk::size/esize;
+	char* start = n->mem;
+	char* last = &start[(nelem-1)*esize];
+	for(char* p = start; p<last; p+=esize)
+	reinterpret_cast<Link*>(p)->next = reinterpret_cast<Link*>(p+esize);
+	reinterpret_cast<Link*>(last)->next = 0;
+	head = reinterpret_cast<Link*>(start);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -364,7 +364,7 @@ public:
 	FastAllocatorGeneral();
 	void* Alloc(unsigned int n);
 	void  Free(void* pAlloc);
-  	void* Realloc(void* pAlloc, unsigned int n);
+	void* Realloc(void* pAlloc, unsigned int n);
 
 	unsigned Get_Total_Heap_Size();
 	unsigned Get_Total_Allocated_Size();
@@ -374,7 +374,7 @@ public:
 	static FastAllocatorGeneral* Get_Allocator();
 
 protected:
-   FastFixedAllocator allocators[MAX_ALLOC_SIZE/ALLOC_STEP];
+	FastFixedAllocator allocators[MAX_ALLOC_SIZE/ALLOC_STEP];
 	FastCriticalSectionClass CriticalSections[MAX_ALLOC_SIZE/ALLOC_STEP];
 	bool MemoryLeakLogEnabled;
 
@@ -422,14 +422,14 @@ WWINLINE unsigned FastAllocatorGeneral::Get_Total_Allocation_Count()
 
 WWINLINE void* FastAllocatorGeneral::Alloc(unsigned int n)
 {
-   void* pMemory;
+	void* pMemory;
 	static int re_entrancy=0;
 	re_entrancy++;
 
-   //We actually allocate n+4 bytes. We store the # allocated
-   //in the first 4 bytes, and return the ptr to the rest back
-   //to the user.
-   n += sizeof(unsigned int);
+	//We actually allocate n+4 bytes. We store the # allocated
+	//in the first 4 bytes, and return the ptr to the rest back
+	//to the user.
+	n += sizeof(unsigned int);
 #ifdef MEMORY_OVERWRITE_TEST
 	n+=sizeof(unsigned int);
 #endif
@@ -444,20 +444,20 @@ WWINLINE void* FastAllocatorGeneral::Alloc(unsigned int n)
 			pMemory = allocators[index].Alloc();
 		}
 	}
-   else {
+	else {
 		if (re_entrancy==1) {
 			AllocatedWithMalloc+=n;
 			AllocatedWithMallocCount++;
 		}
-      pMemory = ::malloc(n);
+		pMemory = ::malloc(n);
 	}
 #ifdef MEMORY_OVERWRITE_TEST
 	*((unsigned int*)((char*)pMemory+n)-1)=0xabbac0de;
 #endif
 
 	re_entrancy--;
-   *((unsigned int*)pMemory) = n;     //Write modified (augmented by 4) count into first four bytes.
-   return ((unsigned int*)pMemory)+1; //return ptr to bytes after it back to user.
+	*((unsigned int*)pMemory) = n;     //Write modified (augmented by 4) count into first four bytes.
+	return ((unsigned int*)pMemory)+1; //return ptr to bytes after it back to user.
 }
 
 // ----------------------------------------------------------------------------
@@ -468,8 +468,8 @@ WWINLINE void* FastAllocatorGeneral::Alloc(unsigned int n)
 
 WWINLINE void FastAllocatorGeneral::Free(void* pAlloc)
 {
-   if (pAlloc) {
-      unsigned int* n = ((unsigned int*)pAlloc)-1; //Subtract four bytes and the count is stored there.
+	if (pAlloc) {
+		unsigned int* n = ((unsigned int*)pAlloc)-1; //Subtract four bytes and the count is stored there.
 
 #ifdef MEMORY_OVERWRITE_TEST
 		WWASSERT(*((unsigned int*)((char*)n+*n)-1)==0xabbac0de);
@@ -481,14 +481,14 @@ WWINLINE void FastAllocatorGeneral::Free(void* pAlloc)
 		if (size<MAX_ALLOC_SIZE) {
 			int index=size/ALLOC_STEP;
 			FastCriticalSectionClass::LockClass lock(CriticalSections[index]);
-         allocators[index].Free(n);
+			allocators[index].Free(n);
 		}
-      else {
+		else {
 			AllocatedWithMallocCount--;
 			AllocatedWithMalloc-=size;
-         ::free(n);
+			::free(n);
 		}
-   }
+	}
 }
 
 //ANSI C requires:
@@ -497,17 +497,17 @@ WWINLINE void FastAllocatorGeneral::Free(void* pAlloc)
 //  (3) if the realloc() fails, the object pointed to by pblock is left unchanged.
 //
 WWINLINE void* FastAllocatorGeneral::Realloc(void* pAlloc, unsigned int n){
-   if(n){
-      void* const pNewAlloc = Alloc(n);      //Allocate the new memory. This never fails.
-      if(pAlloc){
-         n = *(((unsigned int*)pAlloc)-1);   //Subtract four bytes and the count is stored there.
-         ::memcpy(pNewAlloc, pAlloc, n);     //Copy the old memory into the new memory.
-         Free(pAlloc);                       //Delete the old memory.
-      }
-      return pNewAlloc;
-   }
-   Free(pAlloc);
-   return nullptr;
+	if(n){
+		void* const pNewAlloc = Alloc(n);      //Allocate the new memory. This never fails.
+		if(pAlloc){
+			n = *(((unsigned int*)pAlloc)-1);   //Subtract four bytes and the count is stored there.
+			::memcpy(pNewAlloc, pAlloc, n);     //Copy the old memory into the new memory.
+			Free(pAlloc);                       //Delete the old memory.
+		}
+		return pNewAlloc;
+	}
+	Free(pAlloc);
+	return nullptr;
 }
 
 
@@ -529,69 +529,69 @@ WWINLINE void* FastAllocatorGeneral::Realloc(void* pAlloc, unsigned int n){
 //
 
 #ifdef _MSC_VER
-   //VC++ continues to be the one compiler that lacks the ability to compile
-   //standard C++. So we define a version of the STL allocator specifically
-   //for VC++, and let other compilers use a standard allocator template.
-   template <class T>
-   struct FastSTLAllocator{
-      typedef size_t    size_type;        //basically, "unsigned int"
-      typedef ptrdiff_t difference_type;  //basically, "int"
-      typedef T*        pointer;
-      typedef const T*  const_pointer;
-      typedef T&        reference;
-      typedef const T&  const_reference;
-      typedef T         value_type;
+//VC++ continues to be the one compiler that lacks the ability to compile
+//standard C++. So we define a version of the STL allocator specifically
+//for VC++, and let other compilers use a standard allocator template.
+template <class T>
+struct FastSTLAllocator{
+	typedef size_t    size_type;        //basically, "unsigned int"
+	typedef ptrdiff_t difference_type;  //basically, "int"
+	typedef T*        pointer;
+	typedef const T*  const_pointer;
+	typedef T&        reference;
+	typedef const T&  const_reference;
+	typedef T         value_type;
 
-      T*            address(T& t)       const             { return (&t); } //These two are slightly strange but
-      const  T*     address(const T& t) const             { return (&t); } //required functions. Just do it.
-      static T*     allocate(size_t n, const void* =nullptr) { return (T*)FastAllocatorGeneral::Get_Allocator()->Alloc(n*sizeof(T)); }
-      static void   construct(T* ptr, const T& value)     { new(ptr) T(value); }
-      static void   deallocate(void* ptr, size_t /*n*/)   { FastAllocatorGeneral::Get_Allocator()->Free(ptr); }
-      static void   destroy(T* ptr)                       { ptr->~T(); }
-      static size_t max_size()                            { return (size_t)-1; }
+	T*            address(T& t)       const             { return (&t); } //These two are slightly strange but
+	const  T*     address(const T& t) const             { return (&t); } //required functions. Just do it.
+	static T*     allocate(size_t n, const void* =nullptr) { return (T*)FastAllocatorGeneral::Get_Allocator()->Alloc(n*sizeof(T)); }
+	static void   construct(T* ptr, const T& value)     { new(ptr) T(value); }
+	static void   deallocate(void* ptr, size_t /*n*/)   { FastAllocatorGeneral::Get_Allocator()->Free(ptr); }
+	static void   destroy(T* ptr)                       { ptr->~T(); }
+	static size_t max_size()                            { return (size_t)-1; }
 
-      //This _Charalloc is required by VC++5 since it VC++5 predates
-      //the language standardization. Allocator behaviour is one of the
-      //last things to have been hammered out. Important note: If you
-      //decide to write your own fast allocator, containers will allocate
-      //random objects through this function but delete them through
-      //the above delallocate() function. So your version of deallocate
-      //should *not* assume that it will only be given T objects to delete.
-      char* _Charalloc(size_t n){ return (char*)FastAllocatorGeneral::Get_Allocator()->Alloc(n*sizeof(char)); }
-   };
+	//This _Charalloc is required by VC++5 since it VC++5 predates
+	//the language standardization. Allocator behaviour is one of the
+	//last things to have been hammered out. Important note: If you
+	//decide to write your own fast allocator, containers will allocate
+	//random objects through this function but delete them through
+	//the above delallocate() function. So your version of deallocate
+	//should *not* assume that it will only be given T objects to delete.
+	char* _Charalloc(size_t n){ return (char*)FastAllocatorGeneral::Get_Allocator()->Alloc(n*sizeof(char)); }
+};
 #else
-   //This is a C++ language standard allocator. Most C++ compilers after 1999
-   //other than Microsoft C++ compile this fine. Otherwise. you might be able
-   //to use the same allocator as VC++ uses above.
-   template <class T>
-   class FastSTLAllocator{
-   public:
-     typedef size_t     size_type;
-     typedef ptrdiff_t  difference_type;
-     typedef T*         pointer;
-     typedef const T*   const_pointer;
-     typedef T&         reference;
-     typedef const T&   const_reference;
-     typedef T          value_type;
+//This is a C++ language standard allocator. Most C++ compilers after 1999
+//other than Microsoft C++ compile this fine. Otherwise. you might be able
+//to use the same allocator as VC++ uses above.
+template <class T>
+class FastSTLAllocator{
+public:
+	typedef size_t     size_type;
+	typedef ptrdiff_t  difference_type;
+	typedef T*         pointer;
+	typedef const T*   const_pointer;
+	typedef T&         reference;
+	typedef const T&   const_reference;
+	typedef T          value_type;
 
-     template <class T1> struct rebind {
-        typedef FastSTLAllocator<T1> other;
-     };
+	template <class T1> struct rebind {
+		typedef FastSTLAllocator<T1> other;
+	};
 
-     FastSTLAllocator() {}
-     FastSTLAllocator(const FastSTLAllocator&) {}
-     template <class T1> FastSTLAllocator(const FastSTLAllocator<T1>&) {}
-     ~FastSTLAllocator() {}
+	FastSTLAllocator() {}
+	FastSTLAllocator(const FastSTLAllocator&) {}
+	template <class T1> FastSTLAllocator(const FastSTLAllocator<T1>&) {}
+	~FastSTLAllocator() {}
 
-     pointer address(reference x) const             { return &x; }
-     const_pointer address(const_reference x) const { return &x; }
+	pointer address(reference x) const             { return &x; }
+	const_pointer address(const_reference x) const { return &x; }
 
-     T* allocate(size_type n, const void* = nullptr) { return n != 0 ? static_cast<T*>(FastAllocatorGeneral::Get_Allocator()->Alloc(n*sizeof(T))) : nullptr; }
-     void deallocate(pointer p, size_type n)      { FastAllocatorGeneral::Get_Allocator()->Free(p); }
-     size_type max_size() const                   { return size_t(-1) / sizeof(T); }
-     void construct(pointer p, const T& val)      { new(p) T(val); }
-     void destroy(pointer p)                      { p->~T(); }
-   };
+	T* allocate(size_type n, const void* = nullptr) { return n != 0 ? static_cast<T*>(FastAllocatorGeneral::Get_Allocator()->Alloc(n*sizeof(T))) : nullptr; }
+	void deallocate(pointer p, size_type n)      { FastAllocatorGeneral::Get_Allocator()->Free(p); }
+	size_type max_size() const                   { return size_t(-1) / sizeof(T); }
+	void construct(pointer p, const T& val)      { new(p) T(val); }
+	void destroy(pointer p)                      { p->~T(); }
+};
 #endif
 
 template<class T>

--- a/Core/Libraries/Source/WWVegas/WWLib/SLIST.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/SLIST.h
@@ -57,7 +57,7 @@
 
 template <class T>
 class SList {
-  private:
+private:
 		SLNode<T> *HeadNode;    // Note: Constructor not called for pointer.
 		SLNode<T> *TailNode;
 

--- a/Core/Libraries/Source/WWVegas/WWLib/Vector.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/Vector.h
@@ -539,12 +539,12 @@ class DynamicVectorClass : public VectorClass<T>
 			return(*this);
 		}
 
-      // Uninitialized Add - does everything an Add does, except copying an
-      // object into the 'new' spot in the array. It returns a pointer to
-      // the 'new' spot. (null if the Add failed). NOTE - you must then fill
-      // this memory area with a valid object (e.g. by using placement new),
-      // or chaos will result!
-      T * Uninitialized_Add();
+	// Uninitialized Add - does everything an Add does, except copying an
+	// object into the 'new' spot in the array. It returns a pointer to
+	// the 'new' spot. (null if the Add failed). NOTE - you must then fill
+	// this memory area with a valid object (e.g. by using placement new),
+	// or chaos will result!
+	T * Uninitialized_Add();
 
 	protected:
 
@@ -946,7 +946,7 @@ T * DynamicVectorClass<T>::Uninitialized_Add()
 	**	There is room for the new space now. Add it to the end of the object
    ** vector. and return a pointer to it.
 	*/
-   return &((*this)[ActiveCount++]);
+	return &((*this)[ActiveCount++]);
 }
 
 

--- a/Core/Libraries/Source/WWVegas/WWLib/argv.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/argv.cpp
@@ -160,7 +160,7 @@ const char *ArgvClass::Find_Again(const char *arg)
 int ArgvClass::Init(char *lpCmdLine, const char *fileprefix)
 {
 	// Get pointer to command line.
-   char	*ptr = lpCmdLine;
+	char	*ptr = lpCmdLine;
 	if (!ptr || !*ptr) {
 		return 0;
 	}

--- a/Core/Libraries/Source/WWVegas/WWLib/bfiofile.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/bfiofile.cpp
@@ -526,7 +526,7 @@ int BufferIOFileClass::Open(int rights)
 		BufferRights = rights;		// save rights requested for checks later
 
 		if (rights != READ ||
-			 (rights == READ && FileSize > BufferSize)) {
+			(rights == READ && FileSize > BufferSize)) {
 
 			if (rights == WRITE) {
 				BASECLASS::Open(rights);
@@ -889,7 +889,7 @@ int BufferIOFileClass::Seek(int pos, int dir)
 			BufferPos = FilePos;
 		} else {
 			if (FilePos >= BufferFilePos &&
-				 FilePos < (BufferFilePos + BufferSize)) {
+				FilePos < (BufferFilePos + BufferSize)) {
 				BufferPos = FilePos - BufferFilePos;
 			} else {
 				Commit();

--- a/Core/Libraries/Source/WWVegas/WWLib/cpudetect.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/cpudetect.cpp
@@ -811,15 +811,15 @@ void CPUDetectClass::Init_CPUID_Instruction()
 {
 	unsigned long cpuid_available=0;
 
-   // The pushfd/popfd commands are done using emits
-   // because CodeWarrior seems to have problems with
-   // the command (huh?)
+	// The pushfd/popfd commands are done using emits
+	// because CodeWarrior seems to have problems with
+	// the command (huh?)
 
 #if defined(_MSC_VER) && _MSC_VER < 1300
 #ifdef WIN32
-   __asm
-   {
-      mov cpuid_available, 0	// clear flag
+	__asm
+	{
+		mov cpuid_available, 0	// clear flag
       push ebx
       pushfd
       pop eax
@@ -836,26 +836,26 @@ void CPUDetectClass::Init_CPUID_Instruction()
       push ebx
       popfd
       pop ebx
-   }
+	}
 #elif defined(_UNIX)
-     __asm__(" mov $0, __cpuid_available");  // clear flag
-     __asm__(" push %ebx");
-     __asm__(" pushfd");
-     __asm__(" pop %eax");
-     __asm__(" mov %eax, %ebx");
-     __asm__(" xor 0x00200000, %eax");
-     __asm__(" push %eax");
-     __asm__(" popfd");
-     __asm__(" pushfd");
-     __asm__(" pop %eax");
-     __asm__(" xor %ebx, %eax");
-     __asm__(" je done");
-     __asm__(" mov $1, __cpuid_available");
-     goto done;  // just to shut the compiler up
-   done:
-     __asm__(" push %ebx");
-     __asm__(" popfd");
-     __asm__(" pop %ebx");
+	__asm__(" mov $0, __cpuid_available");  // clear flag
+	__asm__(" push %ebx");
+	__asm__(" pushfd");
+	__asm__(" pop %eax");
+	__asm__(" mov %eax, %ebx");
+	__asm__(" xor 0x00200000, %eax");
+	__asm__(" push %eax");
+	__asm__(" popfd");
+	__asm__(" pushfd");
+	__asm__(" pop %eax");
+	__asm__(" xor %ebx, %eax");
+	__asm__(" je done");
+	__asm__(" mov $1, __cpuid_available");
+	goto done;  // just to shut the compiler up
+	done:
+	__asm__(" push %ebx");
+	__asm__(" popfd");
+	__asm__(" pop %ebx");
 #endif
 	HasCPUIDInstruction=!!cpuid_available;
 #else
@@ -897,25 +897,25 @@ void CPUDetectClass::Init_Memory()
 
 #if defined(_MSC_VER) && _MSC_VER < 1300
 	MEMORYSTATUS mem;
-   GlobalMemoryStatus(&mem);
+	GlobalMemoryStatus(&mem);
 
-   TotalPhysicalMemory     = mem.dwTotalPhys;
-   AvailablePhysicalMemory = mem.dwAvailPhys;
-   TotalPageMemory         = mem.dwTotalPageFile;
-   AvailablePageMemory     = mem.dwAvailPageFile;
-   TotalVirtualMemory      = mem.dwTotalVirtual;
-   AvailableVirtualMemory  = mem.dwAvailVirtual;
+	TotalPhysicalMemory     = mem.dwTotalPhys;
+	AvailablePhysicalMemory = mem.dwAvailPhys;
+	TotalPageMemory         = mem.dwTotalPageFile;
+	AvailablePageMemory     = mem.dwAvailPageFile;
+	TotalVirtualMemory      = mem.dwTotalVirtual;
+	AvailableVirtualMemory  = mem.dwAvailVirtual;
 #else
 	MEMORYSTATUSEX mem;
 	mem.dwLength = sizeof(mem);
-   GlobalMemoryStatusEx(&mem);
+	GlobalMemoryStatusEx(&mem);
 
-   TotalPhysicalMemory     = mem.ullTotalPhys;
-   AvailablePhysicalMemory = mem.ullAvailPhys;
-   TotalPageMemory         = mem.ullTotalPageFile;
-   AvailablePageMemory     = mem.ullAvailPageFile;
-   TotalVirtualMemory      = mem.ullTotalVirtual;
-   AvailableVirtualMemory  = mem.ullAvailVirtual;
+	TotalPhysicalMemory     = mem.ullTotalPhys;
+	AvailablePhysicalMemory = mem.ullAvailPhys;
+	TotalPageMemory         = mem.ullTotalPageFile;
+	AvailablePageMemory     = mem.ullAvailPageFile;
+	TotalVirtualMemory      = mem.ullTotalVirtual;
+	AvailableVirtualMemory  = mem.ullAvailVirtual;
 #endif // defined(_MSC_VER) && _MSC_VER < 1300
 
 #else
@@ -932,39 +932,39 @@ void CPUDetectClass::Init_OS()
 // RtlGetVersion returns the correct information at least at the time of writing.
 #if defined(_MSC_VER) && _MSC_VER < 1300
 	OSVERSIONINFO os;
-   os.dwOSVersionInfoSize = sizeof(os);
+	os.dwOSVersionInfoSize = sizeof(os);
 	GetVersionEx(&os);
 
-   OSVersionNumberMajor = os.dwMajorVersion;
-   OSVersionNumberMinor = os.dwMinorVersion;
-   OSVersionBuildNumber = os.dwBuildNumber;
-   OSVersionPlatformId  = os.dwPlatformId;
-   OSVersionExtraInfo   = os.szCSDVersion;
+	OSVersionNumberMajor = os.dwMajorVersion;
+	OSVersionNumberMinor = os.dwMinorVersion;
+	OSVersionBuildNumber = os.dwBuildNumber;
+	OSVersionPlatformId  = os.dwPlatformId;
+	OSVersionExtraInfo   = os.szCSDVersion;
 #else
 	typedef LONG(WINAPI * RtlGetVersionPtr)(PRTL_OSVERSIONINFOW);
-    HMODULE ntdll = LoadLibraryExA("ntdll", nullptr, 0);
-    if (ntdll != nullptr) {
-        RtlGetVersionPtr RtlGetVersion = (RtlGetVersionPtr)::GetProcAddress(ntdll, "RtlGetVersion");
+	HMODULE ntdll = LoadLibraryExA("ntdll", nullptr, 0);
+	if (ntdll != nullptr) {
+		RtlGetVersionPtr RtlGetVersion = (RtlGetVersionPtr)::GetProcAddress(ntdll, "RtlGetVersion");
 
-        if (RtlGetVersion != nullptr) {
-            RTL_OSVERSIONINFOW os = {0};
-            os.dwOSVersionInfoSize = sizeof(os);
-            RtlGetVersion(&os);
-            OSVersionNumberMajor = os.dwMajorVersion;
-            OSVersionNumberMinor = os.dwMinorVersion;
-            OSVersionBuildNumber = os.dwBuildNumber;
-            OSVersionPlatformId = os.dwPlatformId;
-            OSVersionExtraInfo = os.szCSDVersion;
-            return;
-        }
-    }
+		if (RtlGetVersion != nullptr) {
+			RTL_OSVERSIONINFOW os = {0};
+			os.dwOSVersionInfoSize = sizeof(os);
+			RtlGetVersion(&os);
+			OSVersionNumberMajor = os.dwMajorVersion;
+			OSVersionNumberMinor = os.dwMinorVersion;
+			OSVersionBuildNumber = os.dwBuildNumber;
+			OSVersionPlatformId = os.dwPlatformId;
+			OSVersionExtraInfo = os.szCSDVersion;
+			return;
+		}
+	}
 
 	// GetVersionEx will return this info if no manifest is present so seems a safe fallback.
-    OSVersionNumberMajor = 6;
-    OSVersionNumberMinor = 2;
-    OSVersionBuildNumber = 0;
-    OSVersionPlatformId = 2;
-    OSVersionExtraInfo = "";
+	OSVersionNumberMajor = 6;
+	OSVersionNumberMinor = 2;
+	OSVersionBuildNumber = 0;
+	OSVersionPlatformId = 2;
+	OSVersionExtraInfo = "";
 #endif // defined(_MSC_VER) && _MSC_VER < 1300
 #else
 #warning FIX Init_OS()
@@ -1100,13 +1100,13 @@ void CPUDetectClass::Init_Compact_Log()
 	StringClass work(0,true);
 
 #ifdef WIN32
-   TIME_ZONE_INFORMATION time_zone;
-   GetTimeZoneInformation(&time_zone);
-   COMPACTLOG(("%d\t", time_zone.Bias));  // get diff between local time and UTC
+	TIME_ZONE_INFORMATION time_zone;
+	GetTimeZoneInformation(&time_zone);
+	COMPACTLOG(("%d\t", time_zone.Bias));  // get diff between local time and UTC
 #elif defined(_UNIX)
-   time_t t = time(nullptr);
-   localtime(&t);
-   COMPACTLOG(("%d\t", timezone));
+	time_t t = time(nullptr);
+	localtime(&t);
+	COMPACTLOG(("%d\t", timezone));
 #endif
 
 	OSInfoStruct os_info;

--- a/Core/Libraries/Source/WWVegas/WWLib/crc.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/crc.cpp
@@ -205,7 +205,7 @@ unsigned long  CRC::_Table[ 256 ] =
 
 unsigned long	CRC::Memory( unsigned char *data, unsigned long length, unsigned long crc )
 {
- 	crc ^= 0xFFFFFFFF;									// invert previous CRC
+	crc ^= 0xFFFFFFFF;									// invert previous CRC
 	while ( length-- ) {
 		crc = CRC32( *data++, crc );					// calc crc for each byte
 	}
@@ -214,7 +214,7 @@ unsigned long	CRC::Memory( unsigned char *data, unsigned long length, unsigned l
 
 unsigned long	CRC::String( const char *string, unsigned long crc)
 {
- 	crc ^= 0xFFFFFFFF;									// invert previous CRC
+	crc ^= 0xFFFFFFFF;									// invert previous CRC
 	while ( *string )	{
 		crc = CRC32( *string++, crc );				// calc crc for each byte
 	}

--- a/Core/Libraries/Source/WWVegas/WWLib/ini.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/ini.cpp
@@ -1637,17 +1637,17 @@ bool INIClass::Put_String(char const * section, char const * entry, char const *
 	*/
 	INIEntry * entryptr = secptr->Find_Entry(entry);
 	if (entryptr != nullptr) {
-      if (strcmp(entryptr->Entry, entry) != 0) {
-         DuplicateCRCError("INIClass::Put_String", section, entry);
-      } else {
+		if (strcmp(entryptr->Entry, entry) != 0) {
+			DuplicateCRCError("INIClass::Put_String", section, entry);
+		} else {
 #if 0
 			OutputDebugString("INIClass::Put_String - Duplicate Entry \"");
-	   	OutputDebugString(entry);
-		   OutputDebugString("\"\n");
+			OutputDebugString(entry);
+			OutputDebugString("\"\n");
 #endif
-      }
-   	secptr->EntryIndex.Remove_Index(entryptr->Index_ID());
-	   delete entryptr;
+		}
+		secptr->EntryIndex.Remove_Index(entryptr->Index_ID());
+		delete entryptr;
 	}
 
 	/*
@@ -1832,7 +1832,7 @@ int INIClass::Get_Int_Bitfield(char const * section, char const * entry, int def
 	int retval	= 0;
 	char *str	= strdup(entryptr->Value);
 
-   int lp;
+	int lp;
 	for (char *token = strtok(str, "|+"); token; token = strtok(nullptr, "|+")) {
 		for (lp = 0; list[lp]; lp++) {
 			// if this list entry matches our string token then we need

--- a/Core/Libraries/Source/WWVegas/WWLib/lzo.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/lzo.h
@@ -54,16 +54,16 @@
 
 int lzo1x_1_compress ( 	const lzo_byte *in,
 								lzo_uint  in_len,
-                         lzo_byte *out,
+	lzo_byte *out,
 								lzo_uint *out_len,
-                         lzo_voidp wrkmem);
+	lzo_voidp wrkmem);
 
 
 int lzo1x_decompress	(  const lzo_byte *in,
 								lzo_uint  in_len,
 								lzo_byte *out,
 								lzo_uint *out_len,
-                         lzo_voidp);
+	lzo_voidp);
 
 
 

--- a/Core/Libraries/Source/WWVegas/WWLib/lzo1x_c.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/lzo1x_c.cpp
@@ -220,7 +220,7 @@ code_match:
 		assert(ii == ip);
 		ip += 3;
 		if (*m_pos++ != *ip++ || *m_pos++ != *ip++ || *m_pos++ != *ip++ ||
-		    *m_pos++ != *ip++ || *m_pos++ != *ip++ || *m_pos++ != *ip++)
+	*m_pos++ != *ip++ || *m_pos++ != *ip++ || *m_pos++ != *ip++)
 		{
 			--ip;
 			m_len = ip - ii;
@@ -239,7 +239,7 @@ code_match:
 					m_off -= 0x4000;
 					assert(m_off > 0); assert(m_off <= 0x7fff);
 					*op++ = LZO_BYTE(M4_MARKER |
-					                 ((m_off & 0x4000) >> 11) | (m_len - 2));
+				((m_off & 0x4000) >> 11) | (m_len - 2));
 					goto m3_m4_offset;
 				}
 			}
@@ -267,7 +267,7 @@ code_match:
 				assert(m_off > 0); assert(m_off <= 0x7fff);
 				if (m_len <= 9) {
 					*op++ = LZO_BYTE(M4_MARKER |
-					                 ((m_off & 0x4000) >> 11) | (m_len - 2));
+				((m_off & 0x4000) >> 11) | (m_len - 2));
 				} else {
 					m_len -= 9;
 					*op++ = LZO_BYTE(M4_MARKER | ((m_off & 0x4000) >> 11));
@@ -333,8 +333,8 @@ m3_m4_offset:
 ************************************************************************/
 
 int lzo1x_1_compress     ( const lzo_byte * in, lzo_uint  in_len,
-                                 lzo_byte * out, lzo_uint *out_len,
-                                 lzo_voidp wrkmem )
+	lzo_byte * out, lzo_uint *out_len,
+	lzo_voidp wrkmem )
 {
 	lzo_byte *op = out;
 	int r = LZO_E_OK;

--- a/Core/Libraries/Source/WWVegas/WWLib/lzo1x_d.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/lzo1x_d.cpp
@@ -80,8 +80,8 @@
 ************************************************************************/
 
 int lzo1x_decompress     ( const lzo_byte * in, lzo_uint  in_len,
-                                 lzo_byte * out, lzo_uint * out_len,
-                                 lzo_voidp )
+	lzo_byte * out, lzo_uint * out_len,
+	lzo_voidp )
 {
 	register lzo_byte *op;
 	register const lzo_byte *ip;

--- a/Core/Libraries/Source/WWVegas/WWLib/lzo_conf.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/lzo_conf.h
@@ -110,9 +110,9 @@
 
 /* ptrdiff_t */
 #if (UINT_MAX >= 0xffffffffL)
-   typedef ptrdiff_t        lzo_ptrdiff_t;
+typedef ptrdiff_t        lzo_ptrdiff_t;
 #else
-   typedef long             lzo_ptrdiff_t;
+typedef long             lzo_ptrdiff_t;
 #endif
 
 

--- a/Core/Libraries/Source/WWVegas/WWLib/lzoconf.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/lzoconf.h
@@ -94,12 +94,12 @@
 
 /* Unsigned type with 32 bits or more */
 #if (UINT_MAX >= 0xffffffffL)
-   typedef unsigned int     lzo_uint;
-   typedef int              lzo_int;
+typedef unsigned int     lzo_uint;
+typedef int              lzo_int;
 #  define LZO_UINT_MAX      UINT_MAX
 #elif (ULONG_MAX >= 0xffffffffL)
-   typedef unsigned long    lzo_uint;
-   typedef long             lzo_int;
+typedef unsigned long    lzo_uint;
+typedef long             lzo_int;
 #  define LZO_UINT_MAX      ULONG_MAX
 #else
 #  error lzo_uint
@@ -164,13 +164,13 @@ typedef unsigned long       lzo_ptr_t;
 
 typedef int __LZO_ENTRY
 (__LZO_EXPORT *lzo_compress_t)  ( const lzo_byte *src, lzo_uint  src_len,
-                                        lzo_byte *dst, lzo_uint *dst_len,
-                                        lzo_voidp wrkmem );
+	lzo_byte *dst, lzo_uint *dst_len,
+	lzo_voidp wrkmem );
 
 typedef int __LZO_ENTRY
 (__LZO_EXPORT *lzo_decompress_t)( const lzo_byte *src, lzo_uint  src_len,
-                                        lzo_byte *dst, lzo_uint *dst_len,
-                                        lzo_voidp wrkmem );
+	lzo_byte *dst, lzo_uint *dst_len,
+	lzo_voidp wrkmem );
 
 
 /* a progress indicator callback function */

--- a/Core/Libraries/Source/WWVegas/WWLib/md5.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/md5.cpp
@@ -69,16 +69,16 @@ documentation and/or software.
 
 static void MD5Transform PROTO_LIST ((UINT4 [4], unsigned char [64]));
 static void Encode PROTO_LIST
-  ((unsigned char *, UINT4 *, unsigned int));
+	((unsigned char *, UINT4 *, unsigned int));
 static void Decode PROTO_LIST
-  ((UINT4 *, unsigned char *, unsigned int));
+	((UINT4 *, unsigned char *, unsigned int));
 static void MD5_memcpy PROTO_LIST ((POINTER, POINTER, unsigned int));
 static void MD5_memset PROTO_LIST ((POINTER, int, unsigned int));
 
 static unsigned char PADDING[64] = {
-  0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+	0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 };
 
 /* F, G, H and I are basic MD5 functions.
@@ -120,13 +120,13 @@ Rotation is separate from addition to prevent recomputation.
  */
 void MD5Init (MD5_CTX *context)
 {
-  context->count[0] = context->count[1] = 0;
+	context->count[0] = context->count[1] = 0;
   /* Load magic initialization constants.
 */
-  context->state[0] = 0x67452301;
-  context->state[1] = 0xefcdab89;
-  context->state[2] = 0x98badcfe;
-  context->state[3] = 0x10325476;
+	context->state[0] = 0x67452301;
+	context->state[1] = 0xefcdab89;
+	context->state[2] = 0x98badcfe;
+	context->state[3] = 0x10325476;
 }
 
 /* MD5 block update operation. Continues an MD5 message-digest
@@ -135,39 +135,39 @@ void MD5Init (MD5_CTX *context)
  */
 void MD5Update (MD5_CTX *context, unsigned char *input, unsigned int inputLen)
 {
-  unsigned int i, index, partLen;
+	unsigned int i, index, partLen;
 
   /* Compute number of bytes mod 64 */
-  index = (unsigned int)((context->count[0] >> 3) & 0x3F);
+	index = (unsigned int)((context->count[0] >> 3) & 0x3F);
 
   /* Update number of bits */
-  if ((context->count[0] += ((UINT4)inputLen << 3))
+	if ((context->count[0] += ((UINT4)inputLen << 3))
 
-   < ((UINT4)inputLen << 3))
- context->count[1]++;
-  context->count[1] += ((UINT4)inputLen >> 29);
+		< ((UINT4)inputLen << 3))
+	context->count[1]++;
+	context->count[1] += ((UINT4)inputLen >> 29);
 
-  partLen = 64 - index;
+	partLen = 64 - index;
 
   /* Transform as many times as possible.
 */
-  if (inputLen >= partLen) {
- MD5_memcpy
-   ((POINTER)&context->buffer[index], (POINTER)input, partLen);
- MD5Transform (context->state, context->buffer);
+	if (inputLen >= partLen) {
+		MD5_memcpy
+			((POINTER)&context->buffer[index], (POINTER)input, partLen);
+		MD5Transform (context->state, context->buffer);
 
- for (i = partLen; i + 63 < inputLen; i += 64)
-   MD5Transform (context->state, &input[i]);
+		for (i = partLen; i + 63 < inputLen; i += 64)
+		MD5Transform (context->state, &input[i]);
 
- index = 0;
-  }
-  else
- i = 0;
+		index = 0;
+	}
+	else
+	i = 0;
 
   /* Buffer remaining input */
-  MD5_memcpy
- ((POINTER)&context->buffer[index], (POINTER)&input[i],
-  inputLen-i);
+	MD5_memcpy
+		((POINTER)&context->buffer[index], (POINTER)&input[i],
+		inputLen-i);
 }
 
 /* MD5 finalization. Ends an MD5 message-digest operation, writing the
@@ -175,119 +175,119 @@ void MD5Update (MD5_CTX *context, unsigned char *input, unsigned int inputLen)
  */
 void MD5Final (unsigned char digest[16], MD5_CTX *context)
 {
-  unsigned char bits[8];
-  unsigned int index, padLen;
+	unsigned char bits[8];
+	unsigned int index, padLen;
 
   /* Save number of bits */
-  Encode (bits, context->count, 8);
+	Encode (bits, context->count, 8);
 
   /* Pad out to 56 mod 64.
 */
-  index = (unsigned int)((context->count[0] >> 3) & 0x3f);
-  padLen = (index < 56) ? (56 - index) : (120 - index);
-  MD5Update (context, PADDING, padLen);
+	index = (unsigned int)((context->count[0] >> 3) & 0x3f);
+	padLen = (index < 56) ? (56 - index) : (120 - index);
+	MD5Update (context, PADDING, padLen);
 
   /* Append length (before padding) */
-  MD5Update (context, bits, 8);
+	MD5Update (context, bits, 8);
 
   /* Store state in digest */
-  Encode (digest, context->state, 16);
+	Encode (digest, context->state, 16);
 
   /* Zeroize sensitive information.
 */
-  MD5_memset ((POINTER)context, 0, sizeof (*context));
+	MD5_memset ((POINTER)context, 0, sizeof (*context));
 }
 
 /* MD5 basic transformation. Transforms state based on block.
  */
 static void MD5Transform (UINT4 state[4], unsigned char block[64])
 {
-  UINT4 a = state[0], b = state[1], c = state[2], d = state[3], x[16];
+	UINT4 a = state[0], b = state[1], c = state[2], d = state[3], x[16];
 
-  Decode (x, block, 64);
+	Decode (x, block, 64);
 
   /* Round 1 */
-  FF (a, b, c, d, x[ 0], S11, 0xd76aa478); /* 1 */
-  FF (d, a, b, c, x[ 1], S12, 0xe8c7b756); /* 2 */
-  FF (c, d, a, b, x[ 2], S13, 0x242070db); /* 3 */
-  FF (b, c, d, a, x[ 3], S14, 0xc1bdceee); /* 4 */
-  FF (a, b, c, d, x[ 4], S11, 0xf57c0faf); /* 5 */
-  FF (d, a, b, c, x[ 5], S12, 0x4787c62a); /* 6 */
-  FF (c, d, a, b, x[ 6], S13, 0xa8304613); /* 7 */
-  FF (b, c, d, a, x[ 7], S14, 0xfd469501); /* 8 */
-  FF (a, b, c, d, x[ 8], S11, 0x698098d8); /* 9 */
-  FF (d, a, b, c, x[ 9], S12, 0x8b44f7af); /* 10 */
-  FF (c, d, a, b, x[10], S13, 0xffff5bb1); /* 11 */
-  FF (b, c, d, a, x[11], S14, 0x895cd7be); /* 12 */
-  FF (a, b, c, d, x[12], S11, 0x6b901122); /* 13 */
-  FF (d, a, b, c, x[13], S12, 0xfd987193); /* 14 */
-  FF (c, d, a, b, x[14], S13, 0xa679438e); /* 15 */
-  FF (b, c, d, a, x[15], S14, 0x49b40821); /* 16 */
+	FF (a, b, c, d, x[ 0], S11, 0xd76aa478); /* 1 */
+	FF (d, a, b, c, x[ 1], S12, 0xe8c7b756); /* 2 */
+	FF (c, d, a, b, x[ 2], S13, 0x242070db); /* 3 */
+	FF (b, c, d, a, x[ 3], S14, 0xc1bdceee); /* 4 */
+	FF (a, b, c, d, x[ 4], S11, 0xf57c0faf); /* 5 */
+	FF (d, a, b, c, x[ 5], S12, 0x4787c62a); /* 6 */
+	FF (c, d, a, b, x[ 6], S13, 0xa8304613); /* 7 */
+	FF (b, c, d, a, x[ 7], S14, 0xfd469501); /* 8 */
+	FF (a, b, c, d, x[ 8], S11, 0x698098d8); /* 9 */
+	FF (d, a, b, c, x[ 9], S12, 0x8b44f7af); /* 10 */
+	FF (c, d, a, b, x[10], S13, 0xffff5bb1); /* 11 */
+	FF (b, c, d, a, x[11], S14, 0x895cd7be); /* 12 */
+	FF (a, b, c, d, x[12], S11, 0x6b901122); /* 13 */
+	FF (d, a, b, c, x[13], S12, 0xfd987193); /* 14 */
+	FF (c, d, a, b, x[14], S13, 0xa679438e); /* 15 */
+	FF (b, c, d, a, x[15], S14, 0x49b40821); /* 16 */
 
  /* Round 2 */
-  GG (a, b, c, d, x[ 1], S21, 0xf61e2562); /* 17 */
-  GG (d, a, b, c, x[ 6], S22, 0xc040b340); /* 18 */
-  GG (c, d, a, b, x[11], S23, 0x265e5a51); /* 19 */
-  GG (b, c, d, a, x[ 0], S24, 0xe9b6c7aa); /* 20 */
-  GG (a, b, c, d, x[ 5], S21, 0xd62f105d); /* 21 */
-  GG (d, a, b, c, x[10], S22,  0x2441453); /* 22 */
-  GG (c, d, a, b, x[15], S23, 0xd8a1e681); /* 23 */
-  GG (b, c, d, a, x[ 4], S24, 0xe7d3fbc8); /* 24 */
-  GG (a, b, c, d, x[ 9], S21, 0x21e1cde6); /* 25 */
-  GG (d, a, b, c, x[14], S22, 0xc33707d6); /* 26 */
-  GG (c, d, a, b, x[ 3], S23, 0xf4d50d87); /* 27 */
+	GG (a, b, c, d, x[ 1], S21, 0xf61e2562); /* 17 */
+	GG (d, a, b, c, x[ 6], S22, 0xc040b340); /* 18 */
+	GG (c, d, a, b, x[11], S23, 0x265e5a51); /* 19 */
+	GG (b, c, d, a, x[ 0], S24, 0xe9b6c7aa); /* 20 */
+	GG (a, b, c, d, x[ 5], S21, 0xd62f105d); /* 21 */
+	GG (d, a, b, c, x[10], S22,  0x2441453); /* 22 */
+	GG (c, d, a, b, x[15], S23, 0xd8a1e681); /* 23 */
+	GG (b, c, d, a, x[ 4], S24, 0xe7d3fbc8); /* 24 */
+	GG (a, b, c, d, x[ 9], S21, 0x21e1cde6); /* 25 */
+	GG (d, a, b, c, x[14], S22, 0xc33707d6); /* 26 */
+	GG (c, d, a, b, x[ 3], S23, 0xf4d50d87); /* 27 */
 
-  GG (b, c, d, a, x[ 8], S24, 0x455a14ed); /* 28 */
-  GG (a, b, c, d, x[13], S21, 0xa9e3e905); /* 29 */
-  GG (d, a, b, c, x[ 2], S22, 0xfcefa3f8); /* 30 */
-  GG (c, d, a, b, x[ 7], S23, 0x676f02d9); /* 31 */
-  GG (b, c, d, a, x[12], S24, 0x8d2a4c8a); /* 32 */
+	GG (b, c, d, a, x[ 8], S24, 0x455a14ed); /* 28 */
+	GG (a, b, c, d, x[13], S21, 0xa9e3e905); /* 29 */
+	GG (d, a, b, c, x[ 2], S22, 0xfcefa3f8); /* 30 */
+	GG (c, d, a, b, x[ 7], S23, 0x676f02d9); /* 31 */
+	GG (b, c, d, a, x[12], S24, 0x8d2a4c8a); /* 32 */
 
   /* Round 3 */
-  HH (a, b, c, d, x[ 5], S31, 0xfffa3942); /* 33 */
-  HH (d, a, b, c, x[ 8], S32, 0x8771f681); /* 34 */
-  HH (c, d, a, b, x[11], S33, 0x6d9d6122); /* 35 */
-  HH (b, c, d, a, x[14], S34, 0xfde5380c); /* 36 */
-  HH (a, b, c, d, x[ 1], S31, 0xa4beea44); /* 37 */
-  HH (d, a, b, c, x[ 4], S32, 0x4bdecfa9); /* 38 */
-  HH (c, d, a, b, x[ 7], S33, 0xf6bb4b60); /* 39 */
-  HH (b, c, d, a, x[10], S34, 0xbebfbc70); /* 40 */
-  HH (a, b, c, d, x[13], S31, 0x289b7ec6); /* 41 */
-  HH (d, a, b, c, x[ 0], S32, 0xeaa127fa); /* 42 */
-  HH (c, d, a, b, x[ 3], S33, 0xd4ef3085); /* 43 */
-  HH (b, c, d, a, x[ 6], S34,  0x4881d05); /* 44 */
-  HH (a, b, c, d, x[ 9], S31, 0xd9d4d039); /* 45 */
-  HH (d, a, b, c, x[12], S32, 0xe6db99e5); /* 46 */
-  HH (c, d, a, b, x[15], S33, 0x1fa27cf8); /* 47 */
-  HH (b, c, d, a, x[ 2], S34, 0xc4ac5665); /* 48 */
+	HH (a, b, c, d, x[ 5], S31, 0xfffa3942); /* 33 */
+	HH (d, a, b, c, x[ 8], S32, 0x8771f681); /* 34 */
+	HH (c, d, a, b, x[11], S33, 0x6d9d6122); /* 35 */
+	HH (b, c, d, a, x[14], S34, 0xfde5380c); /* 36 */
+	HH (a, b, c, d, x[ 1], S31, 0xa4beea44); /* 37 */
+	HH (d, a, b, c, x[ 4], S32, 0x4bdecfa9); /* 38 */
+	HH (c, d, a, b, x[ 7], S33, 0xf6bb4b60); /* 39 */
+	HH (b, c, d, a, x[10], S34, 0xbebfbc70); /* 40 */
+	HH (a, b, c, d, x[13], S31, 0x289b7ec6); /* 41 */
+	HH (d, a, b, c, x[ 0], S32, 0xeaa127fa); /* 42 */
+	HH (c, d, a, b, x[ 3], S33, 0xd4ef3085); /* 43 */
+	HH (b, c, d, a, x[ 6], S34,  0x4881d05); /* 44 */
+	HH (a, b, c, d, x[ 9], S31, 0xd9d4d039); /* 45 */
+	HH (d, a, b, c, x[12], S32, 0xe6db99e5); /* 46 */
+	HH (c, d, a, b, x[15], S33, 0x1fa27cf8); /* 47 */
+	HH (b, c, d, a, x[ 2], S34, 0xc4ac5665); /* 48 */
 
   /* Round 4 */
-  II (a, b, c, d, x[ 0], S41, 0xf4292244); /* 49 */
-  II (d, a, b, c, x[ 7], S42, 0x432aff97); /* 50 */
-  II (c, d, a, b, x[14], S43, 0xab9423a7); /* 51 */
-  II (b, c, d, a, x[ 5], S44, 0xfc93a039); /* 52 */
-  II (a, b, c, d, x[12], S41, 0x655b59c3); /* 53 */
-  II (d, a, b, c, x[ 3], S42, 0x8f0ccc92); /* 54 */
-  II (c, d, a, b, x[10], S43, 0xffeff47d); /* 55 */
-  II (b, c, d, a, x[ 1], S44, 0x85845dd1); /* 56 */
-  II (a, b, c, d, x[ 8], S41, 0x6fa87e4f); /* 57 */
-  II (d, a, b, c, x[15], S42, 0xfe2ce6e0); /* 58 */
-  II (c, d, a, b, x[ 6], S43, 0xa3014314); /* 59 */
-  II (b, c, d, a, x[13], S44, 0x4e0811a1); /* 60 */
-  II (a, b, c, d, x[ 4], S41, 0xf7537e82); /* 61 */
-  II (d, a, b, c, x[11], S42, 0xbd3af235); /* 62 */
-  II (c, d, a, b, x[ 2], S43, 0x2ad7d2bb); /* 63 */
-  II (b, c, d, a, x[ 9], S44, 0xeb86d391); /* 64 */
+	II (a, b, c, d, x[ 0], S41, 0xf4292244); /* 49 */
+	II (d, a, b, c, x[ 7], S42, 0x432aff97); /* 50 */
+	II (c, d, a, b, x[14], S43, 0xab9423a7); /* 51 */
+	II (b, c, d, a, x[ 5], S44, 0xfc93a039); /* 52 */
+	II (a, b, c, d, x[12], S41, 0x655b59c3); /* 53 */
+	II (d, a, b, c, x[ 3], S42, 0x8f0ccc92); /* 54 */
+	II (c, d, a, b, x[10], S43, 0xffeff47d); /* 55 */
+	II (b, c, d, a, x[ 1], S44, 0x85845dd1); /* 56 */
+	II (a, b, c, d, x[ 8], S41, 0x6fa87e4f); /* 57 */
+	II (d, a, b, c, x[15], S42, 0xfe2ce6e0); /* 58 */
+	II (c, d, a, b, x[ 6], S43, 0xa3014314); /* 59 */
+	II (b, c, d, a, x[13], S44, 0x4e0811a1); /* 60 */
+	II (a, b, c, d, x[ 4], S41, 0xf7537e82); /* 61 */
+	II (d, a, b, c, x[11], S42, 0xbd3af235); /* 62 */
+	II (c, d, a, b, x[ 2], S43, 0x2ad7d2bb); /* 63 */
+	II (b, c, d, a, x[ 9], S44, 0xeb86d391); /* 64 */
 
-  state[0] += a;
-  state[1] += b;
-  state[2] += c;
-  state[3] += d;
+	state[0] += a;
+	state[1] += b;
+	state[2] += c;
+	state[3] += d;
 
   /* Zeroize sensitive information.
 
 */
-  MD5_memset ((POINTER)x, 0, sizeof (x));
+	MD5_memset ((POINTER)x, 0, sizeof (x));
 }
 
 /* Encodes input (UINT4) into output (unsigned char). Assumes len is
@@ -295,14 +295,14 @@ static void MD5Transform (UINT4 state[4], unsigned char block[64])
  */
 static void Encode (unsigned char *output, UINT4 *input, unsigned int len)
 {
-  unsigned int i, j;
+	unsigned int i, j;
 
-  for (i = 0, j = 0; j < len; i++, j += 4) {
- output[j] = (unsigned char)(input[i] & 0xff);
- output[j+1] = (unsigned char)((input[i] >> 8) & 0xff);
- output[j+2] = (unsigned char)((input[i] >> 16) & 0xff);
- output[j+3] = (unsigned char)((input[i] >> 24) & 0xff);
-  }
+	for (i = 0, j = 0; j < len; i++, j += 4) {
+		output[j] = (unsigned char)(input[i] & 0xff);
+		output[j+1] = (unsigned char)((input[i] >> 8) & 0xff);
+		output[j+2] = (unsigned char)((input[i] >> 16) & 0xff);
+		output[j+3] = (unsigned char)((input[i] >> 24) & 0xff);
+	}
 }
 
 /* Decodes input (unsigned char) into output (UINT4). Assumes len is
@@ -310,11 +310,11 @@ static void Encode (unsigned char *output, UINT4 *input, unsigned int len)
  */
 static void Decode (UINT4 *output, unsigned char *input, unsigned int len)
 {
-  unsigned int i, j;
+	unsigned int i, j;
 
-  for (i = 0, j = 0; j < len; i++, j += 4)
- output[i] = ((UINT4)input[j]) | (((UINT4)input[j+1]) << 8) |
-   (((UINT4)input[j+2]) << 16) | (((UINT4)input[j+3]) << 24);
+	for (i = 0, j = 0; j < len; i++, j += 4)
+	output[i] = ((UINT4)input[j]) | (((UINT4)input[j+1]) << 8) |
+		(((UINT4)input[j+2]) << 16) | (((UINT4)input[j+3]) << 24);
 }
 
 /* Note: Replace "for loop" with standard memcpy if possible.
@@ -322,19 +322,19 @@ static void Decode (UINT4 *output, unsigned char *input, unsigned int len)
 
 static void MD5_memcpy (POINTER output, POINTER input, unsigned int len)
 {
-  unsigned int i;
+	unsigned int i;
 
-  for (i = 0; i < len; i++)
+	for (i = 0; i < len; i++)
 
- output[i] = input[i];
+	output[i] = input[i];
 }
 
 /* Note: Replace "for loop" with standard memset if possible.
  */
 static void MD5_memset (POINTER output, int value, unsigned int len)
 {
-  unsigned int i;
+	unsigned int i;
 
-  for (i = 0; i < len; i++)
- ((char *)output)[i] = (char)value;
+	for (i = 0; i < len; i++)
+	((char *)output)[i] = (char)value;
 }

--- a/Core/Libraries/Source/WWVegas/WWLib/md5.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/md5.h
@@ -55,12 +55,12 @@ documentation and/or software.
 
 /* MD5 context. */
 typedef struct {
-  UINT4 state[4];                                   /* state (ABCD) */
-  UINT4 count[2];        /* number of bits, modulo 2^64 (lsb first) */
-  unsigned char buffer[64];                         /* input buffer */
+	UINT4 state[4];                                   /* state (ABCD) */
+	UINT4 count[2];        /* number of bits, modulo 2^64 (lsb first) */
+	unsigned char buffer[64];                         /* input buffer */
 } MD5_CTX;
 
 void MD5Init PROTO_LIST ((MD5_CTX *));
 void MD5Update PROTO_LIST
-  ((MD5_CTX *, unsigned char *, unsigned int));
+	((MD5_CTX *, unsigned char *, unsigned int));
 void MD5Final PROTO_LIST ((unsigned char [16], MD5_CTX *));

--- a/Core/Libraries/Source/WWVegas/WWLib/mpu.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/mpu.cpp
@@ -126,9 +126,9 @@ static unsigned long TSC_High;
 
 void RDTSC()
 {
-    auto TSC = _rdtsc();
-    TSC_Low = TSC & 0xFFFFFFFF;
-    TSC_High = TSC >> 32;
+	auto TSC = _rdtsc();
+	TSC_Low = TSC & 0xFFFFFFFF;
+	TSC_High = TSC >> 32;
 }
 
 

--- a/Core/Libraries/Source/WWVegas/WWLib/mutex.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/mutex.h
@@ -162,35 +162,35 @@ public:
 
 		  __asm mov ebx, [nFlag]
 		  __asm ts_lock
-		  __asm bts dword ptr [ebx], 0
+	__asm bts dword ptr [ebx], 0
 		  __asm jnc BitSet
-      //__asm _emit 0x73
-      //__asm _emit 0x0f
+	//__asm _emit 0x73
+	//__asm _emit 0x0f
 
 		  The_Bit_Was_Previously_Set_So_Try_Again:
-		    ThreadClass::Switch_Thread();
+	ThreadClass::Switch_Thread();
 		  __asm mov ebx, [nFlag]
 		  __asm ts_lock
-		  __asm bts dword ptr [ebx], 0
+	__asm bts dword ptr [ebx], 0
 		  __asm jc  The_Bit_Was_Previously_Set_So_Try_Again
-      //_asm _emit 0x72
-      //_asm _emit 0xf1
+	//_asm _emit 0x72
+	//_asm _emit 0xf1
 
       BitSet:
-        ;
+	;
 #else
         while (cs.Flag.test_and_set(std::memory_order_acq_rel)) {
-            cs.Flag.wait(true, std::memory_order_relaxed);
+	cs.Flag.wait(true, std::memory_order_relaxed);
         }
 #endif
     }
 
     void unlock() {
 #if defined(_MSC_VER) && _MSC_VER < 1300
-      cs.Flag=0;
+	cs.Flag=0;
 #else
-      cs.Flag.clear(std::memory_order_release);
-      cs.Flag.notify_one();
+	cs.Flag.clear(std::memory_order_release);
+	cs.Flag.notify_one();
 #endif
     }
 
@@ -198,5 +198,5 @@ public:
     LockClass(const LockClass&);
 	};
 
-  friend class LockClass;
+friend class LockClass;
 };

--- a/Core/Libraries/Source/WWVegas/WWLib/random.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/random.cpp
@@ -362,44 +362,44 @@ Random4Class::Random4Class(unsigned int seed)
     /*    Vol. 2 (2nd Ed.), pp102]                  */
 	if (!seed) seed=4375;
 
-    mt[0]= seed & 0xffffffff;
-    for (mti=1; mti<N; mti++)
-        mt[mti] = (69069 * mt[mti-1]) & 0xffffffff;
-	 // mti is N+1 after this
+	mt[0]= seed & 0xffffffff;
+	for (mti=1; mti<N; mti++)
+	mt[mti] = (69069 * mt[mti-1]) & 0xffffffff;
+	// mti is N+1 after this
 }
 
 int Random4Class::operator() ()
 {
-    unsigned int y;
-    static unsigned int mag01[2]={0x0, MATRIX_A};
+	unsigned int y;
+	static unsigned int mag01[2]={0x0, MATRIX_A};
     /* mag01[x] = x * MATRIX_A  for x=0,1 */
 
-    if (mti >= N) { /* generate N words at one time */
-        int kk;
+	if (mti >= N) { /* generate N words at one time */
+		int kk;
 
-        for (kk=0;kk<N-M;kk++) {
-            y = (mt[kk]&UPPER_MASK)|(mt[kk+1]&LOWER_MASK);
-            mt[kk] = mt[kk+M] ^ (y >> 1) ^ mag01[y & 0x1];
-        }
-        for (;kk<N-1;kk++) {
-            y = (mt[kk]&UPPER_MASK)|(mt[kk+1]&LOWER_MASK);
-            mt[kk] = mt[kk+(M-N)] ^ (y >> 1) ^ mag01[y & 0x1];
-        }
-        y = (mt[N-1]&UPPER_MASK)|(mt[0]&LOWER_MASK);
-        mt[N-1] = mt[M-1] ^ (y >> 1) ^ mag01[y & 0x1];
+		for (kk=0;kk<N-M;kk++) {
+			y = (mt[kk]&UPPER_MASK)|(mt[kk+1]&LOWER_MASK);
+			mt[kk] = mt[kk+M] ^ (y >> 1) ^ mag01[y & 0x1];
+		}
+		for (;kk<N-1;kk++) {
+			y = (mt[kk]&UPPER_MASK)|(mt[kk+1]&LOWER_MASK);
+			mt[kk] = mt[kk+(M-N)] ^ (y >> 1) ^ mag01[y & 0x1];
+		}
+		y = (mt[N-1]&UPPER_MASK)|(mt[0]&LOWER_MASK);
+		mt[N-1] = mt[M-1] ^ (y >> 1) ^ mag01[y & 0x1];
 
-        mti = 0;
-    }
+		mti = 0;
+	}
 
-    y = mt[mti++];
-    y ^= TEMPERING_SHIFT_U(y);
-    y ^= TEMPERING_SHIFT_S(y) & TEMPERING_MASK_B;
-    y ^= TEMPERING_SHIFT_T(y) & TEMPERING_MASK_C;
-    y ^= TEMPERING_SHIFT_L(y);
+	y = mt[mti++];
+	y ^= TEMPERING_SHIFT_U(y);
+	y ^= TEMPERING_SHIFT_S(y) & TEMPERING_MASK_B;
+	y ^= TEMPERING_SHIFT_T(y) & TEMPERING_MASK_C;
+	y ^= TEMPERING_SHIFT_L(y);
 
-	 int *x=(int *)&y;
+	int *x=(int *)&y;
 
-	 return *x;
+	return *x;
 }
 
 int Random4Class::operator() (int minval, int maxval)

--- a/Core/Libraries/Source/WWVegas/WWLib/realcrc.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/realcrc.cpp
@@ -125,7 +125,7 @@ unsigned long  CRC32_Table[ 256 ] =
  *=============================================================================================*/
 unsigned long	CRC_Memory( const unsigned char *data, unsigned long length, unsigned long crc )
 {
- 	crc ^= 0xFFFFFFFF;									// invert previous CRC
+	crc ^= 0xFFFFFFFF;									// invert previous CRC
 	while ( length-- ) {
 		crc = CRC32( *data++, crc );					// calc crc for each byte
 	}
@@ -146,7 +146,7 @@ unsigned long	CRC_Memory( const unsigned char *data, unsigned long length, unsig
  *=============================================================================================*/
 unsigned long	CRC_String( const char *string, unsigned long crc )
 {
- 	crc ^= 0xFFFFFFFF;									// invert previous CRC
+	crc ^= 0xFFFFFFFF;									// invert previous CRC
 	while ( *string )	{
 		crc = CRC32( *string++, crc );				// calc crc for each byte
 	}
@@ -167,7 +167,7 @@ unsigned long	CRC_String( const char *string, unsigned long crc )
  *=============================================================================================*/
 unsigned long	CRC_Stringi( const char *string, unsigned long crc )
 {
- 	crc ^= 0xFFFFFFFF;									// invert previous CRC
+	crc ^= 0xFFFFFFFF;									// invert previous CRC
 	while ( *string )	{
 		char c = (char)toupper(*string++);
 		crc = CRC32( c, crc );				// calc crc for each byte

--- a/Core/Libraries/Source/WWVegas/WWLib/refcount.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/refcount.h
@@ -221,7 +221,7 @@ public:
 	/*
 	** Adds the ref obj pointer to the active ref list
 	*/
-   static RefCountClass *			Add_Active_Ref(RefCountClass *obj);
+	static RefCountClass *			Add_Active_Ref(RefCountClass *obj);
 
 	/*
 	** Updates the owner file/line for the given ref obj in the active ref list

--- a/Core/Libraries/Source/WWVegas/WWLib/registry.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/registry.cpp
@@ -210,7 +210,7 @@ void	RegistryClass::Get_String( const char * name, StringClass &string, const ch
 
 
 char *RegistryClass::Get_String( const char * name, char *value, int value_size,
-   const char * default_string )
+	const char * default_string )
 {
 	assert( IsValid );
 	DWORD type = 0;
@@ -219,12 +219,12 @@ char *RegistryClass::Get_String( const char * name, char *value, int value_size,
 	} else {
 		//*value = 0;
 		//value = (char *) default_string;
-      if (default_string == nullptr) {
-		   *value = 0;
-      } else {
-         assert(strlen(default_string) < (unsigned int) value_size);
-         strcpy(value, default_string);
-      }
+		if (default_string == nullptr) {
+			*value = 0;
+		} else {
+			assert(strlen(default_string) < (unsigned int) value_size);
+			strcpy(value, default_string);
+		}
 	}
 	return value;
 }
@@ -232,7 +232,7 @@ char *RegistryClass::Get_String( const char * name, char *value, int value_size,
 void	RegistryClass::Set_String( const char * name, const char *value )
 {
 	assert( IsValid );
-   int size = strlen( value ) + 1; // must include null terminator
+	int size = strlen( value ) + 1; // must include null terminator
 	if (IsLocked) {
 		return;
 	}
@@ -323,7 +323,7 @@ void	RegistryClass::Set_String( const WCHAR * name, const WCHAR *value )
 {
 	assert( IsValid );
 
-   //
+	//
 	//	Determine the size
 	//
 	int size = wcslen( value ) + 1;
@@ -591,7 +591,7 @@ void RegistryClass::Load_Registry(const char *filename, char *old_path, char *ne
 								int temp = ini.Get_Int(section_name, entry, 0);
 								reg.Set_Int(entry+6, temp);
 							} else {
-					 			if (strncmp(entry, "STRING_", 7) == 0) {
+								if (strncmp(entry, "STRING_", 7) == 0) {
 									ini.Get_String(section_name, entry, "", string, sizeof(string));
 									reg.Set_String(entry+7, string);
 								} else {

--- a/Core/Libraries/Source/WWVegas/WWLib/registry.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/registry.h
@@ -69,7 +69,7 @@ public:
 
 	// String data type access
 	char *Get_String( const char * name, char *value, int value_size,
-      const char * default_string = nullptr );
+		const char * default_string = nullptr );
 	void	Get_String( const char * name, StringClass &string, const char *default_string = nullptr);
 	void	Set_String( const char * name, const char *value );
 

--- a/Core/Libraries/Source/WWVegas/WWLib/tgatodxt.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/tgatodxt.cpp
@@ -56,8 +56,8 @@ TGAToDXTClass _TGAToDXTConverter;
 ///////////////////////////////////////////////////////////////////////////////
 TGAToDXTClass::TGAToDXTClass()
 	: WriteTimePtr (nullptr),
-	  BufferSize (1024),
-	  BufferCount (0)
+	BufferSize (1024),
+	BufferCount (0)
 {
 	Buffer = new unsigned char [BufferSize];
 	WWASSERT (Buffer != nullptr);
@@ -209,9 +209,9 @@ void TGAToDXTClass::Write (const char *outputpathname)
 
 	hfile = ::CreateFile (outputpathname, GENERIC_WRITE, FILE_SHARE_READ, nullptr, CREATE_ALWAYS, 0L, nullptr);
 	if (hfile != INVALID_HANDLE_VALUE) {
-      LockFile (hfile, 0, 0, BufferCount, 0);
-      WriteFile (hfile, Buffer, BufferCount, &bytecountwritten, nullptr);
-      UnlockFile (hfile, 0, 0, BufferCount, 0);
+		LockFile (hfile, 0, 0, BufferCount, 0);
+		WriteFile (hfile, Buffer, BufferCount, &bytecountwritten, nullptr);
+		UnlockFile (hfile, 0, 0, BufferCount, 0);
 
 		// Stamp the write time (if one has been supplied).
 		if (WriteTimePtr != nullptr) {

--- a/Core/Libraries/Source/WWVegas/WWLib/tgatodxt.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/tgatodxt.h
@@ -49,7 +49,7 @@
 class TGAToDXTClass
 {
 	public:
-		 TGAToDXTClass();
+	TGAToDXTClass();
 		~TGAToDXTClass();
 
 		enum ErrorCode {

--- a/Core/Libraries/Source/WWVegas/WWLib/widestring.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/widestring.cpp
@@ -335,7 +335,7 @@ bool WideStringClass::Convert_From (const char *text)
 			// Success.
 			return (true);
 		}
-   }
+	}
 
 	// Failure.
 	return (false);

--- a/Core/Libraries/Source/WWVegas/WWLib/widestring.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/widestring.h
@@ -213,7 +213,7 @@ WideStringClass::WideStringClass (WCHAR ch, bool hint_temporary)
 ///////////////////////////////////////////////////////////////////
 inline
 WideStringClass::WideStringClass (const WideStringClass &string, bool hint_temporary)
- 	:	m_Buffer (m_EmptyString)
+:	m_Buffer (m_EmptyString)
 {
 	if (hint_temporary || (string.Get_Length()>1)) {
 		Get_String(string.Get_Length()+1, hint_temporary);

--- a/Core/Libraries/Source/WWVegas/WWLib/wwstring.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/wwstring.h
@@ -293,7 +293,7 @@ StringClass::StringClass (TCHAR ch, bool hint_temporary)
 ///////////////////////////////////////////////////////////////////
 inline
 StringClass::StringClass (const StringClass &string, bool hint_temporary)
- 	:	m_Buffer (m_EmptyString)
+:	m_Buffer (m_EmptyString)
 {
 	if (hint_temporary || (string.Get_Length()>0)) {
 		Get_String (string.Get_Length()+1, hint_temporary);

--- a/Core/Libraries/Source/WWVegas/WWMath/Vector3i.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/Vector3i.h
@@ -50,7 +50,7 @@ public:
 	WWINLINE Vector3i(int i,int j,int k);
 
 	WWINLINE bool			operator== (const Vector3i & v) const;
-   WWINLINE bool			operator!= (const Vector3i& v) const;
+	WWINLINE bool			operator!= (const Vector3i& v) const;
 	WWINLINE const	int&	operator[] (int n) const;
 	WWINLINE int&			operator[] (int n);
 };
@@ -99,7 +99,7 @@ public:
 	WWINLINE Vector3i16(unsigned short i,unsigned short j,unsigned short k);
 
 	WWINLINE bool			operator== (const Vector3i & v) const;
-   WWINLINE bool			operator!= (const Vector3i& v) const;
+	WWINLINE bool			operator!= (const Vector3i& v) const;
 	WWINLINE const	unsigned short &	operator[] (int n) const;
 	WWINLINE unsigned short & operator[] (int n);
 };

--- a/Core/Libraries/Source/WWVegas/WWMath/colmathobbobb.cpp
+++ b/Core/Libraries/Source/WWVegas/WWMath/colmathobbobb.cpp
@@ -578,7 +578,7 @@ private:
  *=============================================================================================*/
 static inline bool obb_separation_test
 (
- 	ObbCollisionStruct & context,
+	ObbCollisionStruct & context,
 	float ra,
 	float rb,
 	float u0,

--- a/Core/Libraries/Source/WWVegas/WWMath/colmathobbtri.cpp
+++ b/Core/Libraries/Source/WWVegas/WWMath/colmathobbtri.cpp
@@ -754,7 +754,7 @@ static inline void obbtri_compute_contact_point
 
 		for (i = 0; i < 3; i++) {
 			x[i] = eval_side(context.AN[i],context.Side) * context.Box.Extent[i];
-      }
+			}
 		break;
 
 	case AXIS_A0:		// part of the triangle is touching a face of the box

--- a/Core/Libraries/Source/WWVegas/WWMath/frustum.cpp
+++ b/Core/Libraries/Source/WWVegas/WWMath/frustum.cpp
@@ -73,22 +73,22 @@ void FrustumClass::Init
 	// Store the camera transform
 	CameraTransform = camera;
 
-   // Forward is negative Z in our viewspace coordinate system.
+	// Forward is negative Z in our viewspace coordinate system.
 	// Just flip the sign if the user passed in positive values.
-   if ((znear > 0.0f) && (zfar > 0.0f)) {
+	if ((znear > 0.0f) && (zfar > 0.0f)) {
 		znear = -znear;
 		zfar = -zfar;
 	}
 
 	// Calculate the corners of the camera frustum.
 	// Generate the camera-space frustum corners by linearly
-   // extrapolating the viewplane to the near and far z clipping planes.
+	// extrapolating the viewplane to the near and far z clipping planes.
 
 	// The camera frustum corners are defined in the following order:
 	// When looking at the frustum from the position of the camera, the near four corners are
 	// numbered: upper left 0, upper right 1, lower left 2, lower right 3. The far plane's
 	// Frustum corners are numbered from 4 to 7 in an analogous fashion.
-  // (remember: the camera space has x going to the right, y up and z backwards).
+	// (remember: the camera space has x going to the right, y up and z backwards).
 
 	//calculate a proper z-vector assuming our right-handed coordinate system
 	Vector3	zv;
@@ -98,8 +98,8 @@ void FrustumClass::Init
 	//opposite directions, we have a reflected camera matrix.
 	if (Vector3::Dot_Product(CameraTransform.Get_Z_Vector(),zv) < 0)
 	{	//flip the frustum corners horizontally for a reflected matrix
-	  Corners[1].Set(vpmin.X, vpmax.Y, 1.0);
-	  Corners[5] = Corners[1];
+		Corners[1].Set(vpmin.X, vpmax.Y, 1.0);
+		Corners[5] = Corners[1];
 		Corners[1] *= znear;
 		Corners[5] *= zfar;
 		Corners[0].Set(vpmax.X, vpmax.Y, 1.0);

--- a/Core/Libraries/Source/WWVegas/WWMath/matrix3.cpp
+++ b/Core/Libraries/Source/WWVegas/WWMath/matrix3.cpp
@@ -79,12 +79,12 @@ const Matrix3x3 Matrix3x3::RotateY90
 (
 	0.0,	0.0,	1.0,
 	0.0,	1.0,	0.0,
-  -1.0,	0.0,	0.0
+	-1.0,	0.0,	0.0
 );
 
 const Matrix3x3 Matrix3x3::RotateY180
 (
-  -1.0,	0.0,	0.0,
+	-1.0,	0.0,	0.0,
 	0.0,	1.0,	0.0,
 	0.0,	0.0, -1.0
 );
@@ -105,7 +105,7 @@ const Matrix3x3 Matrix3x3::RotateZ90
 
 const Matrix3x3 Matrix3x3::RotateZ180
 (
-  -1.0,	0.0,	0.0,
+	-1.0,	0.0,	0.0,
 	0.0, -1.0,	0.0,
 	0.0,	0.0,	1.0
 );
@@ -113,7 +113,7 @@ const Matrix3x3 Matrix3x3::RotateZ180
 const Matrix3x3 Matrix3x3::RotateZ270
 (
 	0.0,	1.0,	0.0,
-  -1.0,	0.0,	0.0,
+	-1.0,	0.0,	0.0,
 	0.0,	0.0,	1.0
 );
 

--- a/Core/Libraries/Source/WWVegas/WWMath/matrix3.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/matrix3.h
@@ -406,7 +406,7 @@ WWINLINE Matrix3x3::Matrix3x3(const Quaternion & q)
  *=============================================================================================*/
 WWINLINE Matrix3x3 Matrix3x3::Transpose() const
 {
-    return Matrix3x3(
+	return Matrix3x3(
 			Vector3(Row[0][0], Row[1][0], Row[2][0]),
 			Vector3(Row[0][1], Row[1][1], Row[2][1]),
 			Vector3(Row[0][2], Row[1][2], Row[2][2])
@@ -480,8 +480,8 @@ WWINLINE Matrix3x3 Matrix3x3::Inverse() const    // Gauss-Jordan elimination wit
 WWINLINE float Matrix3x3::Determinant() const
 {
 	return   Row[0][0] * (Row[1][1] * Row[2][2] - Row[1][2] * Row[2][1])
-		    - Row[0][1] * (Row[1][0] * Row[2][2] - Row[1][2] * Row[2][0])
-			 - Row[0][2] * (Row[1][0] * Row[2][1] - Row[1][1] * Row[2][0]);
+		- Row[0][1] * (Row[1][0] * Row[2][2] - Row[1][2] * Row[2][0])
+		- Row[0][2] * (Row[1][0] * Row[2][1] - Row[1][1] * Row[2][0]);
 }
 
 /***********************************************************************************************
@@ -630,32 +630,32 @@ WWINLINE float Matrix3x3::Get_Z_Rotation() const
 
 WWINLINE Vector3 Matrix3x3::Get_X_Vector() const
 {
-   return Vector3(Row[0][0], Row[1][0], Row[2][0]);
+	return Vector3(Row[0][0], Row[1][0], Row[2][0]);
 }
 
 WWINLINE Vector3 Matrix3x3::Get_Y_Vector() const
 {
-   return Vector3(Row[0][1], Row[1][1], Row[2][1]);
+	return Vector3(Row[0][1], Row[1][1], Row[2][1]);
 }
 
 WWINLINE Vector3 Matrix3x3::Get_Z_Vector() const
 {
-   return Vector3(Row[0][2], Row[1][2], Row[2][2]);
+	return Vector3(Row[0][2], Row[1][2], Row[2][2]);
 }
 
 WWINLINE void Matrix3x3::Get_X_Vector(Vector3 * set) const
 {
-   set->Set(Row[0][0], Row[1][0], Row[2][0]);
+	set->Set(Row[0][0], Row[1][0], Row[2][0]);
 }
 
 WWINLINE void Matrix3x3::Get_Y_Vector(Vector3 * set) const
 {
-   set->Set(Row[0][1], Row[1][1], Row[2][1]);
+	set->Set(Row[0][1], Row[1][1], Row[2][1]);
 }
 
 WWINLINE void Matrix3x3::Get_Z_Vector(Vector3 * set) const
 {
-   set->Set(Row[0][2], Row[1][2], Row[2][2]);
+	set->Set(Row[0][2], Row[1][2], Row[2][2]);
 }
 
 WWINLINE Matrix3x3 operator - (const Matrix3x3 & a)

--- a/Core/Libraries/Source/WWVegas/WWMath/matrix3d.cpp
+++ b/Core/Libraries/Source/WWVegas/WWMath/matrix3d.cpp
@@ -102,12 +102,12 @@ const Matrix3D Matrix3D::RotateY90
 (
 	0.0,	0.0,	1.0,	0.0,
 	0.0,	1.0,	0.0,	0.0,
-  -1.0,	0.0,	0.0,	0.0
+	-1.0,	0.0,	0.0,	0.0
 );
 
 const Matrix3D Matrix3D::RotateY180
 (
-  -1.0,	0.0,	0.0,	0.0,
+	-1.0,	0.0,	0.0,	0.0,
 	0.0,	1.0,	0.0,	0.0,
 	0.0,	0.0, -1.0,	0.0
 );
@@ -128,7 +128,7 @@ const Matrix3D	Matrix3D::RotateZ90
 
 const Matrix3D Matrix3D::RotateZ180
 (
-  -1.0,	0.0,	0.0,	0.0,
+	-1.0,	0.0,	0.0,	0.0,
 	0.0, -1.0,	0.0,	0.0,
 	0.0,	0.0,	1.0,	0.0
 );
@@ -136,8 +136,8 @@ const Matrix3D Matrix3D::RotateZ180
 const Matrix3D	Matrix3D::RotateZ270
 (
 	0.0,	1.0,	0.0,	0.0,
-  -1.0,	0.0,	0.0,	0.0,
- 	0.0,	0.0,	1.0,	0.0
+	-1.0,	0.0,	0.0,	0.0,
+	0.0,	0.0,	1.0,	0.0
 );
 
 
@@ -173,8 +173,8 @@ void Matrix3D::Set(const Matrix3x3 & rot,const Vector3 & pos)
  *=============================================================================================*/
 void Matrix3D::Set(const Quaternion & rot,const Vector3 & pos)
 {
-   Set_Rotation(rot);
-   Set_Translation(pos);
+	Set_Rotation(rot);
+	Set_Translation(pos);
 }
 
 
@@ -1228,12 +1228,12 @@ void Matrix3D::Re_Orthogonalize()
  *=============================================================================================*/
 void Matrix3D::Lerp(const Matrix3D &A, const Matrix3D &B, float factor, Matrix3D& result)
 {
-   assert(factor >= 0.0f);
-   assert(factor <= 1.0f);
+	assert(factor >= 0.0f);
+	assert(factor <= 1.0f);
 
 	// Lerp position
 #ifdef ALLOW_TEMPORARIES
-  Vector3 pos = Vector3::Lerp(A.Get_Translation(), B.Get_Translation(), factor);
+	Vector3 pos = Vector3::Lerp(A.Get_Translation(), B.Get_Translation(), factor);
 #else
 	Vector3 pos;
 	Vector3::Lerp(A.Get_Translation(), B.Get_Translation(), factor, &pos);

--- a/Core/Libraries/Source/WWVegas/WWMath/matrix3d.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/matrix3d.h
@@ -206,7 +206,7 @@ public:
 	WWINLINE void Set(const Vector3 & position);
 
 	// access functions:
- 	WWINLINE Vector4 & operator [] (int i) { return Row[i]; }
+	WWINLINE Vector4 & operator [] (int i) { return Row[i]; }
 	WWINLINE const Vector4 & operator [] (int i) const { return Row[i]; }
 
 	WWINLINE Vector3 Get_Translation() const { return Vector3(Row[0][3],Row[1][3],Row[2][3]); }
@@ -243,9 +243,9 @@ public:
 	WWINLINE void	Make_Identity();
 	void	Translate(float x,float y,float z);
 	void	Translate(const Vector3 &t);
-   void  Translate_X(float x);
-   void  Translate_Y(float y);
-   void  Translate_Z(float z);
+	void  Translate_X(float x);
+	void  Translate_Y(float y);
+	void  Translate_Z(float z);
 	void	Rotate_X(float theta);
 	void	Rotate_Y(float theta);
 	void 	Rotate_Z(float theta);
@@ -1504,7 +1504,7 @@ WWINLINE Matrix3D operator * (const Matrix3D &A,const Matrix3D &B)
 
 WWINLINE float submul(const Vector4& row, float tmp1, float tmp2, float tmp3)
 {
-  return row.X * tmp1 + row.Y * tmp2 + row.Z * tmp3;
+	return row.X * tmp1 + row.Y * tmp2 + row.Z * tmp3;
 }
 
 // does "this = that * this"
@@ -1523,7 +1523,7 @@ WWINLINE void Matrix3D::postMul(const Matrix3D& that)
 
 #define AVOID_TEMP_IN_POSTMUL
 #ifdef AVOID_TEMP_IN_POSTMUL
-  float tmpX, tmpY, tmpZ, tmpW;
+	float tmpX, tmpY, tmpZ, tmpW;
 
 	tmpX = submul(this->Row[0], that.Row[0].X, that.Row[1].X, that.Row[2].X);
 	tmpY = submul(this->Row[0], that.Row[0].Y, that.Row[1].Y, that.Row[2].Y);
@@ -1704,12 +1704,12 @@ WWINLINE void Matrix3D::mulVector3Array(Vector3* inout, int count) const
  *=============================================================================================*/
 WWINLINE bool operator == (const Matrix3D &A, const Matrix3D &B)
 {
-   for (int i = 0; i < 3; i++) {
-      for (int j = 0; j < 4; j++) {
-         if (A[i][j] != B[i][j]) return false;
-      }
-   }
-   return true;
+	for (int i = 0; i < 3; i++) {
+		for (int j = 0; j < 4; j++) {
+			if (A[i][j] != B[i][j]) return false;
+		}
+	}
+	return true;
 }
 
 
@@ -1727,7 +1727,7 @@ WWINLINE bool operator == (const Matrix3D &A, const Matrix3D &B)
  *=============================================================================================*/
 WWINLINE bool operator != (const Matrix3D &A, const Matrix3D &B)
 {
-   return !(A == B);
+	return !(A == B);
 }
 
 

--- a/Core/Libraries/Source/WWVegas/WWMath/matrix4.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/matrix4.h
@@ -512,7 +512,7 @@ WWINLINE void Matrix4x4::Init_Perspective
  *=============================================================================================*/
 WWINLINE Matrix4x4 Matrix4x4::Transpose() const
 {
-    return Matrix4x4(
+	return Matrix4x4(
 			Vector4(Row[0][0], Row[1][0], Row[2][0], Row[3][0]),
 			Vector4(Row[0][1], Row[1][1], Row[2][1], Row[3][1]),
 			Vector4(Row[0][2], Row[1][2], Row[2][2], Row[3][2]),

--- a/Core/Libraries/Source/WWVegas/WWMath/quat.cpp
+++ b/Core/Libraries/Source/WWVegas/WWMath/quat.cpp
@@ -317,7 +317,7 @@ void __cdecl Fast_Slerp(Quaternion& res, const Quaternion & p,const Quaternion &
 
 		fld		alpha
 		fsubr		st(0),st(1)				// st(1) contains 1.0
- 		fstp     beta
+		fstp     beta
 		jmp      done_slerp
 
 normal_slerp:

--- a/Core/Libraries/Source/WWVegas/WWMath/quat.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/quat.h
@@ -277,7 +277,7 @@ WWINLINE bool Quaternion::Is_Valid() const
 
 WWINLINE bool Equal_Within_Epsilon(const Quaternion &a, const Quaternion &b, float epsilon)
 {
-   return(	(WWMath::Fabs(a.X - b.X) < epsilon) &&
+	return(	(WWMath::Fabs(a.X - b.X) < epsilon) &&
 				(WWMath::Fabs(a.Y - b.Y) < epsilon) &&
 				(WWMath::Fabs(a.Z - b.Z) < epsilon)	&&
 				(WWMath::Fabs(a.W - b.W) < epsilon) );
@@ -297,10 +297,10 @@ WWINLINE bool Equal_Within_Epsilon(const Quaternion &a, const Quaternion &b, flo
  *=============================================================================================*/
 WWINLINE Quaternion & Quaternion::operator = (const Quaternion & source)
 {
-  X = source[0];
-  Y = source[1];
-  Z = source[2];
-  W = source[3];
+	X = source[0];
+	Y = source[1];
+	Z = source[2];
+	W = source[3];
 
-  return *this;
+	return *this;
 }

--- a/Core/Libraries/Source/WWVegas/WWMath/sphere.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/sphere.h
@@ -312,25 +312,25 @@ inline void SphereClass::Add_Sphere(const SphereClass & s)
 
 	float rnew = (dist + Radius + s.Radius) / 2.0f;
 
-   // If rnew is smaller than either of the two sphere radii (it can't be
-   // smaller than both of them), this means that the smaller sphere is
-   // completely inside the larger, and the result of adding the two is
-   // simply the larger sphere. If rnew isn't less than either of them, it is
-   // the new radius - calculate the new center.
-   if (rnew < Radius) {
-      // The existing sphere is the result - do nothing.
-   } else {
-      if (rnew < s.Radius) {
-         // The new sphere is the result:
-         Init(s.Center, s.Radius);
-      } else {
-         // Neither sphere is completely inside the other, so rnew is the new
-         // radius - calculate the new center
-	      float lerp = (rnew - Radius) / dist;
-	      Vector3 center = (s.Center - Center) * lerp + Center;
-	      Init(center, rnew);
-      }
-   }
+	// If rnew is smaller than either of the two sphere radii (it can't be
+	// smaller than both of them), this means that the smaller sphere is
+	// completely inside the larger, and the result of adding the two is
+	// simply the larger sphere. If rnew isn't less than either of them, it is
+	// the new radius - calculate the new center.
+	if (rnew < Radius) {
+		// The existing sphere is the result - do nothing.
+	} else {
+		if (rnew < s.Radius) {
+			// The new sphere is the result:
+			Init(s.Center, s.Radius);
+		} else {
+			// Neither sphere is completely inside the other, so rnew is the new
+			// radius - calculate the new center
+			float lerp = (rnew - Radius) / dist;
+			Vector3 center = (s.Center - Center) * lerp + Center;
+			Init(center, rnew);
+		}
+	}
 }
 
 /***********************************************************************************************

--- a/Core/Libraries/Source/WWVegas/WWMath/tri.cpp
+++ b/Core/Libraries/Source/WWVegas/WWMath/tri.cpp
@@ -230,17 +230,17 @@ bool TriClass::Contains_Point(const Vector3 & ipoint) const
 	// calculate alpha and beta as normalized (0..1) percentages across the 2d projected triangle
 	// and do bounds checking (sum <= 1)  to determine whether or not the triangle intersection occurs.
 	if (u1 == 0)    {
-	  beta = u0 / u2;
-	  if ((beta >= 0) && (beta <= 1)) {
+		beta = u0 / u2;
+		if ((beta >= 0) && (beta <= 1)) {
 			alpha = (v0 - beta * v2) / v1;
 			intersect = ((alpha >= 0) && ((alpha + beta) <= 1 + WWMATH_EPSILON));
-	  }
+		}
 	} else {
-	  beta = (v0 * u1 - u0 * v1) / (v2 * u1 - u2 * v1);
-	  if ((beta >= 0) && (beta <= 1)) {
+		beta = (v0 * u1 - u0 * v1) / (v2 * u1 - u2 * v1);
+		if ((beta >= 0) && (beta <= 1)) {
 			alpha = (u0 - beta * u2) / u1;
 			intersect = ((alpha >= 0) && ((alpha + beta) <= 1 + WWMATH_EPSILON));
-	  }
+		}
 	}
 
 	return intersect;

--- a/Core/Libraries/Source/WWVegas/WWMath/vector2.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/vector2.h
@@ -108,7 +108,7 @@ public:
 	// scalar multiplication, division
 	WWINLINE friend Vector2 operator * (const Vector2 &a,float k);
 	WWINLINE friend Vector2 operator * (float k,const Vector2 &a);
- 	WWINLINE friend Vector2 operator / (const Vector2 &a,float k);
+	WWINLINE friend Vector2 operator / (const Vector2 &a,float k);
 
 	// vector addition,subtraction
 	WWINLINE friend Vector2 operator + (const Vector2 &a,const Vector2 &b);
@@ -124,7 +124,7 @@ public:
 	// Equality operators
 	friend bool operator == (const Vector2 &a,const Vector2 &b);
 	friend bool operator != (const Vector2 &a,const Vector2 &b);
-   WWINLINE friend bool Equal_Within_Epsilon(const Vector2 &a,const Vector2 &b,float epsilon);
+	WWINLINE friend bool Equal_Within_Epsilon(const Vector2 &a,const Vector2 &b,float epsilon);
 
 	// Rotation
 	WWINLINE void Rotate(float theta);
@@ -309,7 +309,7 @@ WWINLINE bool operator != (const Vector2 &a,const Vector2 &b)
  *========================================================================*/
 WWINLINE bool Equal_Within_Epsilon(const Vector2 &a,const Vector2 &b,float epsilon)
 {
-   return( (WWMath::Fabs(a.X - b.X) < epsilon) && (WWMath::Fabs(a.Y - b.Y) < epsilon) );
+	return( (WWMath::Fabs(a.X - b.X) < epsilon) && (WWMath::Fabs(a.Y - b.Y) < epsilon) );
 }
 
 /**************************************************************************
@@ -658,5 +658,5 @@ WWINLINE void Vector2::Lerp(const Vector2 & a,const Vector2 & b,float t,Vector2 
 {
 	assert(set_result != nullptr);
 	set_result->X = (a.X + (b.X - a.X)*t);
-   set_result->Y = (a.Y + (b.Y - a.Y)*t);
+	set_result->Y = (a.Y + (b.Y - a.Y)*t);
 }

--- a/Core/Libraries/Source/WWVegas/WWMath/vector3.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/vector3.h
@@ -138,7 +138,7 @@ public:
 	// Equality operators
 	friend bool operator == (const Vector3 &a,const Vector3 &b);
 	friend bool operator != (const Vector3 &a,const Vector3 &b);
-   WWINLINE friend bool Equal_Within_Epsilon(const Vector3 &a,const Vector3 &b,float epsilon);
+	WWINLINE friend bool Equal_Within_Epsilon(const Vector3 &a,const Vector3 &b,float epsilon);
 
 	// dot product / inner product
 	WWINLINE friend float operator * (const Vector3 &a,const Vector3 &b);
@@ -343,7 +343,7 @@ WWINLINE bool operator != (const Vector3 &a,const Vector3 &b)
  *========================================================================*/
 WWINLINE bool Equal_Within_Epsilon(const Vector3 &a,const Vector3 &b,float epsilon)
 {
-   return(	(WWMath::Fabs(a.X - b.X) < epsilon) &&
+	return(	(WWMath::Fabs(a.X - b.X) < epsilon) &&
 				(WWMath::Fabs(a.Y - b.Y) < epsilon) &&
 				(WWMath::Fabs(a.Z - b.Z) < epsilon)	);
 }
@@ -390,17 +390,17 @@ WWINLINE void Vector3::Normalized_Cross_Product(const Vector3 &a,const Vector3 &
 
 WWINLINE float Vector3::Cross_Product_X(const Vector3 &a,const Vector3 &b)
 {
-   return a.Y * b.Z - a.Z * b.Y;
+	return a.Y * b.Z - a.Z * b.Y;
 }
 
 WWINLINE float Vector3::Cross_Product_Y(const Vector3 &a,const Vector3 &b)
 {
-   return a.Z * b.X - a.X * b.Z;
+	return a.Z * b.X - a.X * b.Z;
 }
 
 WWINLINE float Vector3::Cross_Product_Z(const Vector3 &a,const Vector3 &b)
 {
-   return a.X * b.Y - a.Y * b.X;
+	return a.X * b.Y - a.Y * b.X;
 }
 
 /**************************************************************************
@@ -536,8 +536,8 @@ WWINLINE void Vector3::Lerp(const Vector3 & a, const Vector3 & b, float alpha,Ve
 {
 	assert(set_result != nullptr);
 	set_result->X = (a.X + (b.X - a.X)*alpha);
-   set_result->Y = (a.Y + (b.Y - a.Y)*alpha);
-   set_result->Z = (a.Z + (b.Z - a.Z)*alpha);
+	set_result->Y = (a.Y + (b.Y - a.Y)*alpha);
+	set_result->Z = (a.Z + (b.Z - a.Z)*alpha);
 }
 
 
@@ -900,9 +900,9 @@ WWINLINE float Vector3::Quick_Distance(const Vector3 &p1, const Vector3 &p2)
 WWINLINE unsigned long	Vector3::Convert_To_ABGR() const
 {
 	return (unsigned(255)<<24) |
-			 (unsigned(Z*255.0f)<<16) |
-			 (unsigned(Y*255.0f)<<8) |
-			 (unsigned(X*255.0f));
+		(unsigned(Z*255.0f)<<16) |
+		(unsigned(Y*255.0f)<<8) |
+		(unsigned(X*255.0f));
 }
 
 /***********************************************************************************************
@@ -917,15 +917,15 @@ WWINLINE unsigned long	Vector3::Convert_To_ABGR() const
 WWINLINE unsigned long	Vector3::Convert_To_ARGB() const
 {
 	return (unsigned(255)<<24) |
-			 (unsigned(X*255.0f)<<16) |
-			 (unsigned(Y*255.0f)<<8) |
-			 (unsigned(Z*255.0f));
+		(unsigned(X*255.0f)<<16) |
+		(unsigned(Y*255.0f)<<8) |
+		(unsigned(Z*255.0f));
 }
 
 WWINLINE unsigned long Vector3::Convert_To_ARGB( float alpha ) const
 {
-    return (unsigned(alpha * 255)<<24) |
-        (unsigned(X*255.0f)<<16) |
-        (unsigned(Y*255.0f)<<8) |
-        (unsigned(Z*255.0f));
+	return (unsigned(alpha * 255)<<24) |
+		(unsigned(X*255.0f)<<16) |
+		(unsigned(Y*255.0f)<<8) |
+		(unsigned(Z*255.0f));
 }

--- a/Core/Libraries/Source/WWVegas/WWMath/vector4.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/vector4.h
@@ -356,27 +356,27 @@ WWINLINE void Swap(Vector4 & a,Vector4 & b)
  *=============================================================================================*/
 WWINLINE Vector4 Lerp(const Vector4 & a, const Vector4 & b, float alpha)
 {
-   return Vector4(
-      (a.X + (b.X - a.X)*alpha),
-      (a.Y + (b.Y - a.Y)*alpha),
-      (a.Z + (b.Z - a.Z)*alpha),
-      (a.W + (b.W - a.W)*alpha)
-   );
+	return Vector4(
+		(a.X + (b.X - a.X)*alpha),
+		(a.Y + (b.Y - a.Y)*alpha),
+		(a.Z + (b.Z - a.Z)*alpha),
+		(a.W + (b.W - a.W)*alpha)
+	);
 }
 
 WWINLINE Vector4 Vector4::Lerp(const Vector4 & a, const Vector4 & b, float alpha)
 {
-   return Vector4(
-      (a.X + (b.X - a.X)*alpha),
-      (a.Y + (b.Y - a.Y)*alpha),
-      (a.Z + (b.Z - a.Z)*alpha),
-      (a.W + (b.W - a.W)*alpha)
-   );
+	return Vector4(
+		(a.X + (b.X - a.X)*alpha),
+		(a.Y + (b.Y - a.Y)*alpha),
+		(a.Z + (b.Z - a.Z)*alpha),
+		(a.W + (b.W - a.W)*alpha)
+	);
 }
 
 WWINLINE void Vector4::Lerp(const Vector4 & a, const Vector4 & b, float alpha,Vector4 * set_result)
 {
-   set_result->X = (a.X + (b.X - a.X)*alpha);
+	set_result->X = (a.X + (b.X - a.X)*alpha);
 	set_result->Y = (a.Y + (b.Y - a.Y)*alpha);
 	set_result->Z = (a.Z + (b.Z - a.Z)*alpha);
 	set_result->X = (a.W + (b.W - a.W)*alpha);

--- a/Core/Libraries/Source/WWVegas/WWMath/wwmath.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/wwmath.h
@@ -580,12 +580,12 @@ WWINLINE float WWMath::Sqrt(float val)
 
 WWINLINE int WWMath::Float_To_Int_Chop(const float& f)
 {
-    int a	= *reinterpret_cast<const int*>(&f);				// take bit pattern of float into a register
-    int sign	= (a>>31);												// sign = 0xFFFFFFFF if original value is negative, 0 if positive
-    int mantissa	= (a&((1<<23)-1))|(1<<23);						// extract mantissa and add the hidden bit
-    int exponent	= ((a&0x7fffffff)>>23)-127;					// extract the exponent
-    int r	= ((unsigned int)(mantissa)<<8)>>(31-exponent);	// ((1<<exponent)*mantissa)>>24 -- (we know that mantissa > (1<<24))
-    return ((r ^ (sign)) - sign ) &~ (exponent>>31);			// add original sign. If exponent was negative, make return value 0.
+	int a	= *reinterpret_cast<const int*>(&f);				// take bit pattern of float into a register
+	int sign	= (a>>31);												// sign = 0xFFFFFFFF if original value is negative, 0 if positive
+	int mantissa	= (a&((1<<23)-1))|(1<<23);						// extract mantissa and add the hidden bit
+	int exponent	= ((a&0x7fffffff)>>23)-127;					// extract the exponent
+	int r	= ((unsigned int)(mantissa)<<8)>>(31-exponent);	// ((1<<exponent)*mantissa)>>24 -- (we know that mantissa > (1<<24))
+	return ((r ^ (sign)) - sign ) &~ (exponent>>31);			// add original sign. If exponent was negative, make return value 0.
 }
 
 WWINLINE int WWMath::Float_To_Int_Floor (const float& f)

--- a/Core/Libraries/Source/WWVegas/WWSaveLoad/definitionmgr.cpp
+++ b/Core/Libraries/Source/WWVegas/WWSaveLoad/definitionmgr.cpp
@@ -923,10 +923,10 @@ DefinitionMgrClass::fnCompareDefinitionsCallback
 	const void *elem2
 )
 {
-   WWASSERT (elem1 != nullptr);
-   WWASSERT (elem2 != nullptr);
-   DefinitionClass *definition1 = *((DefinitionClass **)elem1);
-   DefinitionClass *definition2 = *((DefinitionClass **)elem2);
+	WWASSERT (elem1 != nullptr);
+	WWASSERT (elem2 != nullptr);
+	DefinitionClass *definition1 = *((DefinitionClass **)elem1);
+	DefinitionClass *definition2 = *((DefinitionClass **)elem2);
 
 	//
 	//	Sort the definitions based on ID
@@ -940,5 +940,5 @@ DefinitionMgrClass::fnCompareDefinitionsCallback
 		result = 0;
 	}
 
-   return result;
+	return result;
 }

--- a/Core/Libraries/Source/WWVegas/WWSaveLoad/definitionmgr.h
+++ b/Core/Libraries/Source/WWVegas/WWSaveLoad/definitionmgr.h
@@ -80,8 +80,8 @@ public:
 	static DefinitionClass *	Find_Definition (uint32 id, bool twiddle = true);
 	static DefinitionClass *	Find_Named_Definition (const char *name, bool twiddle = true);
 	static DefinitionClass *	Find_Typed_Definition (const char *name, uint32 class_id, bool twiddle = true);
-   static void                List_Available_Definitions ();
-   static void                List_Available_Definitions (int superclass_id);
+	static void                List_Available_Definitions ();
+	static void                List_Available_Definitions (int superclass_id);
 	static uint32					Get_New_ID (uint32 class_id);
 
 	// Definition registration

--- a/Core/Libraries/Source/WWVegas/WWSaveLoad/parameter.cpp
+++ b/Core/Libraries/Source/WWVegas/WWSaveLoad/parameter.cpp
@@ -243,7 +243,7 @@ StringParameterClass::operator== (const StringParameterClass &src)
 	bool retval = false;
 
 	if (m_String != nullptr && src.m_String != nullptr &&
-		 (m_String->Compare (*(src.m_String)) == 0)) {
+		(m_String->Compare (*(src.m_String)) == 0)) {
 		retval = true;
 	}
 
@@ -571,7 +571,7 @@ EnumParameterClass::operator== (const EnumParameterClass &src)
 	bool retval = false;
 
 	if (m_Value != nullptr && src.m_Value != nullptr &&
-		 (*m_Value) == (*src.m_Value))
+		(*m_Value) == (*src.m_Value))
 	{
 		retval = true;
 	}
@@ -726,7 +726,7 @@ PhysDefParameterClass::operator== (const PhysDefParameterClass &src)
 	bool retval = false;
 
 	if (m_Value != nullptr && src.m_Value != nullptr &&
-		 (*m_Value) == (*src.m_Value))
+		(*m_Value) == (*src.m_Value))
 	{
 		retval = true;
 	}
@@ -824,7 +824,7 @@ ModelDefParameterClass::operator== (const ModelDefParameterClass &src)
 	bool retval = false;
 
 	if (m_Value != nullptr && src.m_Value != nullptr &&
-		 (*m_Value) == (*src.m_Value))
+		(*m_Value) == (*src.m_Value))
 	{
 		retval = true;
 	}
@@ -922,7 +922,7 @@ DefParameterClass::operator== (const DefParameterClass &src)
 	bool retval = false;
 
 	if (m_Value != nullptr && src.m_Value != nullptr &&
-		 (*m_Value) == (*src.m_Value))
+		(*m_Value) == (*src.m_Value))
 	{
 		retval = true;
 	}
@@ -1025,7 +1025,7 @@ GenericDefParameterClass::operator== (const GenericDefParameterClass &src)
 	bool retval = false;
 
 	if (m_Value != nullptr && src.m_Value != nullptr &&
-		 (*m_Value) == (*src.m_Value))
+		(*m_Value) == (*src.m_Value))
 	{
 		retval = true;
 	}
@@ -1125,7 +1125,7 @@ GameObjDefParameterClass::operator== (const GameObjDefParameterClass &src)
 	bool retval = false;
 
 	if (m_Value != nullptr && src.m_Value != nullptr &&
-		 (*m_Value) == (*src.m_Value))
+		(*m_Value) == (*src.m_Value))
 	{
 		retval = true;
 	}
@@ -1226,7 +1226,7 @@ WeaponObjDefParameterClass::operator== (const WeaponObjDefParameterClass &src)
 	bool retval = false;
 
 	if (m_Value != nullptr && src.m_Value != nullptr &&
-		 (*m_Value) == (*src.m_Value))
+		(*m_Value) == (*src.m_Value))
 	{
 		retval = true;
 	}
@@ -1327,7 +1327,7 @@ AmmoObjDefParameterClass::operator== (const AmmoObjDefParameterClass &src)
 	bool retval = false;
 
 	if (m_Value != nullptr && src.m_Value != nullptr &&
-		 (*m_Value) == (*src.m_Value))
+		(*m_Value) == (*src.m_Value))
 	{
 		retval = true;
 	}
@@ -1428,7 +1428,7 @@ ExplosionObjDefParameterClass::operator== (const ExplosionObjDefParameterClass &
 	bool retval = false;
 
 	if (m_Value != nullptr && src.m_Value != nullptr &&
-		 (*m_Value) == (*src.m_Value))
+		(*m_Value) == (*src.m_Value))
 	{
 		retval = true;
 	}
@@ -1527,7 +1527,7 @@ SoundDefParameterClass::operator== (const SoundDefParameterClass &src)
 	bool retval = false;
 
 	if (m_Value != nullptr && src.m_Value != nullptr &&
-		 (*m_Value) == (*src.m_Value))
+		(*m_Value) == (*src.m_Value))
 	{
 		retval = true;
 	}

--- a/Core/Libraries/Source/debug/debug_cmd.cpp
+++ b/Core/Libraries/Source/debug/debug_cmd.cpp
@@ -33,378 +33,378 @@
 #include <process.h>
 
 bool DebugCmdInterfaceDebug::Execute(class Debug& dbg, const char *cmd,
-                                     CommandMode cmdmode, unsigned argn,
-                                     const char * const * argv)
+	CommandMode cmdmode, unsigned argn,
+	const char * const * argv)
 {
-  // just for convenience...
-  bool normalMode=cmdmode==CommandMode::Normal;
+	// just for convenience...
+	bool normalMode=cmdmode==CommandMode::Normal;
 
-  if (strcmp(cmd,"help") == 0)
-  {
-    if (!normalMode)
-      return true;
+	if (strcmp(cmd,"help") == 0)
+	{
+		if (!normalMode)
+		return true;
 
-    if (!argn)
-    {
-      dbg << "debug group help:\n"
-             "  list, io, alwaysflush, timestamp, exit, clear, add, view\n";
-      return true;
-    }
-    else if (strcmp(argv[0],"list") == 0)
-    {
-      dbg << "list (g|l|d|a|c) [ <pattern> ]\n"
-             "\n"
-             "Shows some or all items of a specific type.\n"
-             "\n"
-             "The following items are supported:\n"
-             "- g: command groups\n"
-             "- l: log groups (only those encountered yet)\n"
-             "- d: log groups with descriptions (only those that have descriptions)\n"
-             "- a: asserts/crashes (only those hit yet)\n"
-             "- c: checks (only those failed yet)\n"
-             "\n"
-             "If a pattern is specified only items matching\n"
-             "that pattern are shown. A pattern can contain\n"
-             "any character, letter, or a wildcard '*'.\n"
-             "\n"
-             "Please note that assert, crashes, and check items have\n"
-             "their line number appended to the current file name,\n"
-             "e.g. debug.cpp(13).\n";
-      return true;
-    }
-    else if (strcmp(argv[0],"io") == 0)
-    {
-      dbg << "io <I/O Class> <cmd> { <param> }]\n"
-             "\n"
-             "Issues a I/O class command. I/O class commands are used\n"
-             "for determining where all log output should be sent. \n"
-             "Please check the list of \ref debug_ioclasses for a list\n"
-             "of existing I/O classes.\n"
-             "\n"
-             "Each existing I/O class must accept at least the\n"
-             "following two commands: 'add' and 'remove'. Usually\n"
-             "after a class has been added it reacts to the 'help'\n"
-             "command as well.\n"
-             "\n"
-             "If the command is entered without any parameters a list\n"
-             "of active I/O classes is shown. Typing 'io ?' retrieves\n"
-             "a list of possible I/O classes.\n";
-      return true;
-    }
-    else if (strcmp(argv[0],"alwaysflush") == 0)
-    {
-      dbg << "alwaysflush [ (+|-) ]\n\n"
-             "Enables/disables flushing after each new entry in\n"
-             "the log file (default: off).\n";
-      return true;
-    }
-    else if (strcmp(argv[0],"timestamp") == 0)
-    {
-      dbg << "timestamp [ (+|-) ]\n\n"
-             "Enables/disables timestamping each log entry\n"
-             "(default: off).\n";
-      return true;
-    }
-    else if (strcmp(argv[0],"exit") == 0)
-    {
-      dbg << "exit\n\nExits program immediately.\n";
-      return true;
-    }
-    else if (strcmp(argv[0],"clear") == 0)
-    {
-      dbg << "clear (l|a|c)\n\n"
-             "Clears the given inclusion/exclusion list\n"
-             "(l=logs, a=asserts/crashes, c=checks).\n";
-      return true;
-    }
-    else if (strcmp(argv[0],"add") == 0)
-    {
-      dbg << "add (l|a|c) (+|-) <pattern>\n"
-             "\n"
-             "Adds a pattern to the given list (l=logs, \n"
-             "a=asserts/crashes, c=checks). By default all\n"
-             "asserts, crashes, and checks are active, all logs\n"
-             "inactive. Each item is then checked \n"
-             "against all pattern in the respective\n"
-             "list. If a match is found the active/inactive\n"
-             "state is modified accordingly (+ for active,\n"
-             "- for inactive). The final state is always\n"
-             "the last match.";
-      return true;
-    }
-    else if (strcmp(argv[0],"view") == 0)
-    {
-      dbg << "view [ (l|a|c) ]\n\n"
-             "Shows the active pattern for the given list\n"
-             "(l=logs, a=asserts/crashes, c=checks).\n";
-      return true;
-    }
-    return false;
-  }
-  if (strcmp(cmd,"list") == 0)
-  {
-    const char *pattern=argn>=2?argv[1]:"*";
+		if (!argn)
+		{
+			dbg << "debug group help:\n"
+				"  list, io, alwaysflush, timestamp, exit, clear, add, view\n";
+			return true;
+		}
+		else if (strcmp(argv[0],"list") == 0)
+		{
+			dbg << "list (g|l|d|a|c) [ <pattern> ]\n"
+				"\n"
+				"Shows some or all items of a specific type.\n"
+				"\n"
+				"The following items are supported:\n"
+				"- g: command groups\n"
+				"- l: log groups (only those encountered yet)\n"
+				"- d: log groups with descriptions (only those that have descriptions)\n"
+				"- a: asserts/crashes (only those hit yet)\n"
+				"- c: checks (only those failed yet)\n"
+				"\n"
+				"If a pattern is specified only items matching\n"
+				"that pattern are shown. A pattern can contain\n"
+				"any character, letter, or a wildcard '*'.\n"
+				"\n"
+				"Please note that assert, crashes, and check items have\n"
+				"their line number appended to the current file name,\n"
+				"e.g. debug.cpp(13).\n";
+			return true;
+		}
+		else if (strcmp(argv[0],"io") == 0)
+		{
+			dbg << "io <I/O Class> <cmd> { <param> }]\n"
+				"\n"
+				"Issues a I/O class command. I/O class commands are used\n"
+				"for determining where all log output should be sent. \n"
+				"Please check the list of \ref debug_ioclasses for a list\n"
+				"of existing I/O classes.\n"
+				"\n"
+				"Each existing I/O class must accept at least the\n"
+				"following two commands: 'add' and 'remove'. Usually\n"
+				"after a class has been added it reacts to the 'help'\n"
+				"command as well.\n"
+				"\n"
+				"If the command is entered without any parameters a list\n"
+				"of active I/O classes is shown. Typing 'io ?' retrieves\n"
+				"a list of possible I/O classes.\n";
+			return true;
+		}
+		else if (strcmp(argv[0],"alwaysflush") == 0)
+		{
+			dbg << "alwaysflush [ (+|-) ]\n\n"
+				"Enables/disables flushing after each new entry in\n"
+				"the log file (default: off).\n";
+			return true;
+		}
+		else if (strcmp(argv[0],"timestamp") == 0)
+		{
+			dbg << "timestamp [ (+|-) ]\n\n"
+				"Enables/disables timestamping each log entry\n"
+				"(default: off).\n";
+			return true;
+		}
+		else if (strcmp(argv[0],"exit") == 0)
+		{
+			dbg << "exit\n\nExits program immediately.\n";
+			return true;
+		}
+		else if (strcmp(argv[0],"clear") == 0)
+		{
+			dbg << "clear (l|a|c)\n\n"
+				"Clears the given inclusion/exclusion list\n"
+				"(l=logs, a=asserts/crashes, c=checks).\n";
+			return true;
+		}
+		else if (strcmp(argv[0],"add") == 0)
+		{
+			dbg << "add (l|a|c) (+|-) <pattern>\n"
+				"\n"
+				"Adds a pattern to the given list (l=logs, \n"
+				"a=asserts/crashes, c=checks). By default all\n"
+				"asserts, crashes, and checks are active, all logs\n"
+				"inactive. Each item is then checked \n"
+				"against all pattern in the respective\n"
+				"list. If a match is found the active/inactive\n"
+				"state is modified accordingly (+ for active,\n"
+				"- for inactive). The final state is always\n"
+				"the last match.";
+			return true;
+		}
+		else if (strcmp(argv[0],"view") == 0)
+		{
+			dbg << "view [ (l|a|c) ]\n\n"
+				"Shows the active pattern for the given list\n"
+				"(l=logs, a=asserts/crashes, c=checks).\n";
+			return true;
+		}
+		return false;
+	}
+	if (strcmp(cmd,"list") == 0)
+	{
+		const char *pattern=argn>=2?argv[1]:"*";
 
-    switch(argn?*argv[0]:0)
-    {
-      case 'g':
-        {
-          if (normalMode)
-            dbg << "Command groups:\n";
-          for (Debug::CmdInterfaceListEntry *cur=dbg.firstCmdGroup;cur;cur=cur->next)
-            if (Debug::SimpleMatch(cur->group,pattern))
-              dbg << cur->group << "\n";
-        }
-        break;
-      case 'l':
-      case 'd':
-        {
-          if (normalMode)
-            dbg << "Logs:\n";
-          for (Debug::KnownLogGroupList *cur=dbg.firstLogGroup;cur;cur=cur->next)
-            if (Debug::SimpleMatch(cur->nameGroup,pattern)&&
-                (*argv[0]=='l'||cur->descr))
-            {
-              dbg << cur->nameGroup;
-              if (cur->descr)
-                dbg << " (" << cur->descr << ")";
-              dbg << "\n";
-            }
-        }
-        break;
-      case 'a':
-      case 'c':
-        {
-          if (normalMode)
-            dbg << (*argv[0]=='a'?"Asserts/Crashes:\n":"Checks:\n");
-          unsigned mask=*argv[0]=='a'?Debug::FrameTypeAssert:Debug::FrameTypeCheck;
-          for (unsigned k=0;k<Debug::FRAME_HASH_SIZE;k++)
-          {
-            for (Debug::FrameHashEntry *cur=dbg.frameHash[k];cur;cur=cur->next)
-            {
-              if (!(cur->frameType&mask))
-                continue;
+		switch(argn?*argv[0]:0)
+		{
+			case 'g':
+			{
+				if (normalMode)
+				dbg << "Command groups:\n";
+				for (Debug::CmdInterfaceListEntry *cur=dbg.firstCmdGroup;cur;cur=cur->next)
+				if (Debug::SimpleMatch(cur->group,pattern))
+				dbg << cur->group << "\n";
+			}
+				break;
+			case 'l':
+			case 'd':
+			{
+				if (normalMode)
+				dbg << "Logs:\n";
+				for (Debug::KnownLogGroupList *cur=dbg.firstLogGroup;cur;cur=cur->next)
+				if (Debug::SimpleMatch(cur->nameGroup,pattern)&&
+					(*argv[0]=='l'||cur->descr))
+				{
+					dbg << cur->nameGroup;
+					if (cur->descr)
+					dbg << " (" << cur->descr << ")";
+					dbg << "\n";
+				}
+			}
+				break;
+			case 'a':
+			case 'c':
+			{
+				if (normalMode)
+				dbg << (*argv[0]=='a'?"Asserts/Crashes:\n":"Checks:\n");
+				unsigned mask=*argv[0]=='a'?Debug::FrameTypeAssert:Debug::FrameTypeCheck;
+				for (unsigned k=0;k<Debug::FRAME_HASH_SIZE;k++)
+				{
+					for (Debug::FrameHashEntry *cur=dbg.frameHash[k];cur;cur=cur->next)
+					{
+						if (!(cur->frameType&mask))
+						continue;
 
-              char help[256];
-              wsprintf(help,"%s(%i)",cur->fileOrGroup,cur->line);
-              if (Debug::SimpleMatch(help,pattern))
-              {
-                dbg << help << " (" << cur->hits << " hits)";
-                if (cur->status==Debug::Skip)
-                  dbg << " [off]";
-                dbg << "\n";
-              }
-            }
-          }
-        }
-        break;
-      default:
-        dbg << "Unknown item type, see help.";
-    }
+						char help[256];
+						wsprintf(help,"%s(%i)",cur->fileOrGroup,cur->line);
+						if (Debug::SimpleMatch(help,pattern))
+						{
+							dbg << help << " (" << cur->hits << " hits)";
+							if (cur->status==Debug::Skip)
+							dbg << " [off]";
+							dbg << "\n";
+						}
+					}
+				}
+			}
+				break;
+			default:
+				dbg << "Unknown item type, see help.";
+		}
 
-    return true;
-  }
-  if (strcmp(cmd,"io") == 0)
-  {
-    // cmd: io
-    if (!argn||strcmp(argv[0],"?") == 0)
-    {
-      // show active/all I/O classes
-      if (normalMode)
-        dbg << (argn?"Possible:\n":"Active:\n");
+		return true;
+	}
+	if (strcmp(cmd,"io") == 0)
+	{
+		// cmd: io
+		if (!argn||strcmp(argv[0],"?") == 0)
+		{
+			// show active/all I/O classes
+			if (normalMode)
+			dbg << (argn?"Possible:\n":"Active:\n");
 
-      bool hadItem=false;
-      for (Debug::IOFactoryListEntry *cur=dbg.firstIOFactory;cur;cur=cur->next)
-      {
-        if (!argn&&!cur->io)
-          continue;
+			bool hadItem=false;
+			for (Debug::IOFactoryListEntry *cur=dbg.firstIOFactory;cur;cur=cur->next)
+			{
+				if (!argn&&!cur->io)
+				continue;
 
-        hadItem=true;
-        dbg << cur->ioID << " (" << cur->descr << ")\n";
-      }
-      if (normalMode&&!hadItem)
-        dbg << "(none)\n";
-    }
-    else
-    {
-      // regular I/O command
+				hadItem=true;
+				dbg << cur->ioID << " (" << cur->descr << ")\n";
+			}
+			if (normalMode&&!hadItem)
+			dbg << "(none)\n";
+		}
+		else
+		{
+			// regular I/O command
 
-      // find I/O class
-      Debug::IOFactoryListEntry *cur=dbg.firstIOFactory;
-      for (;cur;cur=cur->next)
-        if (strcmp(argv[0],cur->ioID) == 0)
-          break;
-      if (!cur)
-      {
-        dbg << "Unknown I/O class " << argv[0];
-        return true; // still return true because we knew the command
-      }
+			// find I/O class
+			Debug::IOFactoryListEntry *cur=dbg.firstIOFactory;
+			for (;cur;cur=cur->next)
+			if (strcmp(argv[0],cur->ioID) == 0)
+			break;
+			if (!cur)
+			{
+				dbg << "Unknown I/O class " << argv[0];
+				return true; // still return true because we knew the command
+			}
 
-      if (argn>1)
-      {
-        // 'add' command?
-        if (strcmp(argv[1],"add") == 0)
-        {
-          if (cur->io)
-          {
-            dbg << "I/O class already added";
-            return true;
-          }
-          cur->io=cur->factory();
-          if (!cur->io)
-          {
-            dbg << "I/O class factory failed";
-            return true;
-          }
-        }
-        // 'remove' command?
-        if (strcmp(argv[1],"remove") == 0)
-        {
-          if (cur->io)
-          {
-            cur->io->Delete();
-            cur->io=nullptr;
-          }
-          return true;
-        }
-      }
+			if (argn>1)
+			{
+				// 'add' command?
+				if (strcmp(argv[1],"add") == 0)
+				{
+					if (cur->io)
+					{
+						dbg << "I/O class already added";
+						return true;
+					}
+					cur->io=cur->factory();
+					if (!cur->io)
+					{
+						dbg << "I/O class factory failed";
+						return true;
+					}
+				}
+				// 'remove' command?
+				if (strcmp(argv[1],"remove") == 0)
+				{
+					if (cur->io)
+					{
+						cur->io->Delete();
+						cur->io=nullptr;
+					}
+					return true;
+				}
+			}
 
-      // now pass along I/O command
-      if (!cur->io)
-      {
-        dbg << "Add I/O class first";
-        return true;
-      }
+			// now pass along I/O command
+			if (!cur->io)
+			{
+				dbg << "Add I/O class first";
+				return true;
+			}
 
-      cur->io->Execute(dbg,argn>1?argv[1]:nullptr,!normalMode,argn>1?argn-2:0,argv+2);
-    }
-    return true;
-  }
-  if (strcmp(cmd,"alwaysflush") == 0)
-  {
-    if (argn)
-    {
-      if (*argv[0]=='+')
-        dbg.alwaysFlush=true;
-      if (*argv[0]=='-')
-        dbg.alwaysFlush=false;
-    }
-    if (normalMode)
-      dbg << "Always flush: " << (dbg.alwaysFlush?"on":"off");
-    else
-      dbg << (dbg.alwaysFlush?"1":"0");
+			cur->io->Execute(dbg,argn>1?argv[1]:nullptr,!normalMode,argn>1?argn-2:0,argv+2);
+		}
+		return true;
+	}
+	if (strcmp(cmd,"alwaysflush") == 0)
+	{
+		if (argn)
+		{
+			if (*argv[0]=='+')
+			dbg.alwaysFlush=true;
+			if (*argv[0]=='-')
+			dbg.alwaysFlush=false;
+		}
+		if (normalMode)
+		dbg << "Always flush: " << (dbg.alwaysFlush?"on":"off");
+		else
+		dbg << (dbg.alwaysFlush?"1":"0");
 
-    return true;
-  }
-  if (strcmp(cmd,"timestamp") == 0)
-  {
-    if (argn)
-    {
-      if (*argv[0]=='+')
-        dbg.timeStamp=true;
-      if (*argv[0]=='-')
-        dbg.timeStamp=false;
-    }
-    if (normalMode)
-      dbg << "Timestamp: " << (dbg.timeStamp?"on":"off");
-    else
-      dbg << (dbg.timeStamp?"1":"0");
+		return true;
+	}
+	if (strcmp(cmd,"timestamp") == 0)
+	{
+		if (argn)
+		{
+			if (*argv[0]=='+')
+			dbg.timeStamp=true;
+			if (*argv[0]=='-')
+			dbg.timeStamp=false;
+		}
+		if (normalMode)
+		dbg << "Timestamp: " << (dbg.timeStamp?"on":"off");
+		else
+		dbg << (dbg.timeStamp?"1":"0");
 
-    return true;
-  }
-  if (strcmp(cmd,"exit") == 0)
-  {
-    exit(1);
-    return true;
-  }
-  if (strcmp(cmd,"clear") == 0||
-      strcmp(cmd,"add") == 0||
-      strcmp(cmd,"view") == 0)
-  {
-    unsigned mask=0;
-    if (argn)
-    {
-      for (const char *p=argv[0];*p;p++)
-      {
-        switch(*p)
-        {
-          case 'l': mask|=Debug::FrameTypeLog; break;
-          case 'a': mask|=Debug::FrameTypeAssert; break;
-          case 'c': mask|=Debug::FrameTypeCheck; break;
-        }
-      }
-    }
-    if (!mask)
-      mask=0xffffffff;
+		return true;
+	}
+	if (strcmp(cmd,"exit") == 0)
+	{
+		exit(1);
+		return true;
+	}
+	if (strcmp(cmd,"clear") == 0||
+		strcmp(cmd,"add") == 0||
+		strcmp(cmd,"view") == 0)
+	{
+		unsigned mask=0;
+		if (argn)
+		{
+			for (const char *p=argv[0];*p;p++)
+			{
+				switch(*p)
+				{
+					case 'l': mask|=Debug::FrameTypeLog; break;
+					case 'a': mask|=Debug::FrameTypeAssert; break;
+					case 'c': mask|=Debug::FrameTypeCheck; break;
+				}
+			}
+		}
+		if (!mask)
+		mask=0xffffffff;
 
-    bool modified=false;
-    if (strcmp(cmd,"clear") == 0)
-    {
-      // remove some (or all) pattern
-      const char *pattern=argn<2?"*":argv[1];
-      for (Debug::PatternListEntry **entryPtr=&dbg.firstPatternEntry;*entryPtr;)
-      {
-        if ( (((*entryPtr)->frameTypes&mask)!=0)
-            && Debug::SimpleMatch((*entryPtr)->pattern,pattern) )
-        {
-          // remove this entry
-          modified=true;
-          Debug::PatternListEntry *cur=*entryPtr;
-          *entryPtr=cur->next;
-          DebugFreeMemory(cur->pattern);
-          DebugFreeMemory(cur);
-        }
-        else
-          entryPtr=&((*entryPtr)->next);
-      }
+		bool modified=false;
+		if (strcmp(cmd,"clear") == 0)
+		{
+			// remove some (or all) pattern
+			const char *pattern=argn<2?"*":argv[1];
+			for (Debug::PatternListEntry **entryPtr=&dbg.firstPatternEntry;*entryPtr;)
+			{
+				if ( (((*entryPtr)->frameTypes&mask)!=0)
+					&& Debug::SimpleMatch((*entryPtr)->pattern,pattern) )
+				{
+					// remove this entry
+					modified=true;
+					Debug::PatternListEntry *cur=*entryPtr;
+					*entryPtr=cur->next;
+					DebugFreeMemory(cur->pattern);
+					DebugFreeMemory(cur);
+				}
+				else
+				entryPtr=&((*entryPtr)->next);
+			}
 
-      // must fixup lastPatternEntry now
-      if (dbg.firstPatternEntry)
-      {
-        Debug::PatternListEntry *cur=dbg.firstPatternEntry;
-        for (;cur->next;cur=cur->next);
-        dbg.lastPatternEntry=cur;
-      }
-      else
-        dbg.lastPatternEntry=nullptr;
-    }
-    if (strcmp(cmd,"add") == 0)
-    {
-      // add a pattern
-      if (argn<3)
-        dbg << "Please specify mode and pattern";
-      else
-      {
-        dbg.AddPatternEntry(mask,*argv[1]=='+',argv[2]);
-        modified=true;
-      }
-    }
-    if (strcmp(cmd,"view") == 0)
-    {
-      // show list of defined patterns
-      for (Debug::PatternListEntry *cur=dbg.firstPatternEntry;cur;cur=cur->next)
-      {
-        if (!(cur->frameTypes&mask))
-          continue;
+			// must fixup lastPatternEntry now
+			if (dbg.firstPatternEntry)
+			{
+				Debug::PatternListEntry *cur=dbg.firstPatternEntry;
+				for (;cur->next;cur=cur->next);
+				dbg.lastPatternEntry=cur;
+			}
+			else
+			dbg.lastPatternEntry=nullptr;
+		}
+		if (strcmp(cmd,"add") == 0)
+		{
+			// add a pattern
+			if (argn<3)
+			dbg << "Please specify mode and pattern";
+			else
+			{
+				dbg.AddPatternEntry(mask,*argv[1]=='+',argv[2]);
+				modified=true;
+			}
+		}
+		if (strcmp(cmd,"view") == 0)
+		{
+			// show list of defined patterns
+			for (Debug::PatternListEntry *cur=dbg.firstPatternEntry;cur;cur=cur->next)
+			{
+				if (!(cur->frameTypes&mask))
+				continue;
 
-        if (cur->frameTypes&Debug::FrameTypeLog) dbg << "l";
-        if (cur->frameTypes&Debug::FrameTypeAssert) dbg << "a";
-        if (cur->frameTypes&Debug::FrameTypeCheck) dbg << "c";
+				if (cur->frameTypes&Debug::FrameTypeLog) dbg << "l";
+				if (cur->frameTypes&Debug::FrameTypeAssert) dbg << "a";
+				if (cur->frameTypes&Debug::FrameTypeCheck) dbg << "c";
 
-        dbg << (cur->isActive?" + ":" - ") << cur->pattern << "\n";
-      }
-    }
+				dbg << (cur->isActive?" + ":" - ") << cur->pattern << "\n";
+			}
+		}
 
-    if (modified)
-    {
-      // pattern list was modified, set all frame entries statuses to Unknown
-      for (unsigned k=0;k<Debug::FRAME_HASH_SIZE;k++)
-        for (Debug::FrameHashEntry *cur=dbg.frameHash[k];cur;cur=cur->next)
-          cur->status=Debug::Unknown;
-    }
-    return true;
-  }
+		if (modified)
+		{
+			// pattern list was modified, set all frame entries statuses to Unknown
+			for (unsigned k=0;k<Debug::FRAME_HASH_SIZE;k++)
+			for (Debug::FrameHashEntry *cur=dbg.frameHash[k];cur;cur=cur->next)
+			cur->status=Debug::Unknown;
+		}
+		return true;
+	}
 
-  // unknown command
-  return false;
+	// unknown command
+	return false;
 }

--- a/Core/Libraries/Source/debug/debug_cmd.h
+++ b/Core/Libraries/Source/debug/debug_cmd.h
@@ -47,29 +47,29 @@
 */
 class DebugCmdInterface
 {
-  // no copy/assign op
-  DebugCmdInterface(const DebugCmdInterface&);
-  DebugCmdInterface& operator=(const DebugCmdInterface&);
+	// no copy/assign op
+	DebugCmdInterface(const DebugCmdInterface&);
+	DebugCmdInterface& operator=(const DebugCmdInterface&);
 
 protected:
-  // nobody can call this destructor (except child classes)
-  virtual ~DebugCmdInterface() {}
+	// nobody can call this destructor (except child classes)
+	virtual ~DebugCmdInterface() {}
 
 public:
-  // interface only so no functionality here
-  explicit DebugCmdInterface() {}
+	// interface only so no functionality here
+	explicit DebugCmdInterface() {}
 
-  /// possible command modes
-  enum CommandMode
-  {
-    /// normal command mode
-    Normal,
+	/// possible command modes
+	enum CommandMode
+	{
+		/// normal command mode
+		Normal,
 
-    /// structured command mode
-    Structured,
+		/// structured command mode
+		Structured,
 
-    MAX
-  };
+		MAX
+	};
 
   /**
     \brief Execute the given command.
@@ -84,15 +84,15 @@ public:
     \param argv argument list
     \return true if command was known, false if not
   */
-  virtual bool Execute(class Debug& dbg, const char *cmd, CommandMode cmdmode,
-                       unsigned argn, const char * const * argv)=0;
+	virtual bool Execute(class Debug& dbg, const char *cmd, CommandMode cmdmode,
+		unsigned argn, const char * const * argv)=0;
 
   /**
     \brief Destroys the current command interface.
 
     Use this function instead of just delete'ing the instance.
   */
-  virtual void Delete()=0;
+	virtual void Delete()=0;
 };
 
 /**

--- a/Core/Libraries/Source/debug/debug_debug.cpp
+++ b/Core/Libraries/Source/debug/debug_debug.cpp
@@ -66,7 +66,7 @@ void *Debug::PostStatic = nullptr;
 
 Debug::LogDescription::LogDescription(const char *fileOrGroup, const char *description)
 {
-  Debug::Instance.AddLogGroup(fileOrGroup,description);
+	Debug::Instance.AddLogGroup(fileOrGroup,description);
 }
 
 // our global Debug instance
@@ -79,197 +79,197 @@ unsigned Debug::curStackFrame;
 // work is done in PreStaticInit (and some in PostStaticInit)
 Debug::Debug()
 {
-  // do not put any code in here (but it's good for keeping module global todo's)
-  /// @todo what about frame based logging?
-  /// @todo have new DLOG with category, add DWARN, DPERF, DERR etc. based on that,
-  ///       make it possible to enable/disable categories by adding category to log ID
+	// do not put any code in here (but it's good for keeping module global todo's)
+	/// @todo what about frame based logging?
+	/// @todo have new DLOG with category, add DWARN, DPERF, DERR etc. based on that,
+	///       make it possible to enable/disable categories by adding category to log ID
 }
 
 void Debug::PreStaticInit()
 {
-  // do not change any member variables that have constructors
-  // because they are not constructed yet!
+	// do not change any member variables that have constructors
+	// because they are not constructed yet!
 
-  // make sure this function gets called on exit
-  // (we might still have to call it manually if there's
-  // an exception and we're not calling exit)
-  atexit(StaticExit);
+	// make sure this function gets called on exit
+	// (we might still have to call it manually if there's
+	// an exception and we're not calling exit)
+	atexit(StaticExit);
 
-  // init vars
-  Instance.hrTranslators=nullptr;
-  Instance.numHrTranslators=0;
-  Instance.firstIOFactory=nullptr;
-  Instance.firstCmdGroup=nullptr;
-  memset(Instance.frameHash,0,sizeof(Instance.frameHash));
-  Instance.nextUnusedFrameHash=nullptr;
-  Instance.numAvailableFrameHash=0;
-  Instance.firstLogGroup=nullptr;
-  memset(Instance.ioBuffer,0,sizeof(Instance.ioBuffer));
-  Instance.curType=DebugIOInterface::StringType::MAX;
-  *Instance.curSource=0;
-  Instance.disableAssertsEtc=0;
-  Instance.curFrameEntry=nullptr;
-  Instance.firstPatternEntry=nullptr;
-  Instance.lastPatternEntry=nullptr;
-  *Instance.curCommandGroup=0;
-  Instance.alwaysFlush=false;
-  Instance.timeStamp=false;
-  Instance.m_radix=10;
-  Instance.m_fillChar=' ';
+	// init vars
+	Instance.hrTranslators=nullptr;
+	Instance.numHrTranslators=0;
+	Instance.firstIOFactory=nullptr;
+	Instance.firstCmdGroup=nullptr;
+	memset(Instance.frameHash,0,sizeof(Instance.frameHash));
+	Instance.nextUnusedFrameHash=nullptr;
+	Instance.numAvailableFrameHash=0;
+	Instance.firstLogGroup=nullptr;
+	memset(Instance.ioBuffer,0,sizeof(Instance.ioBuffer));
+	Instance.curType=DebugIOInterface::StringType::MAX;
+	*Instance.curSource=0;
+	Instance.disableAssertsEtc=0;
+	Instance.curFrameEntry=nullptr;
+	Instance.firstPatternEntry=nullptr;
+	Instance.lastPatternEntry=nullptr;
+	*Instance.curCommandGroup=0;
+	Instance.alwaysFlush=false;
+	Instance.timeStamp=false;
+	Instance.m_radix=10;
+	Instance.m_fillChar=' ';
 
-  /// install exception handler
-  SetUnhandledExceptionFilter(DebugExceptionhandler::ExceptionFilter);
+	/// install exception handler
+	SetUnhandledExceptionFilter(DebugExceptionhandler::ExceptionFilter);
 }
 
 void Debug::PostStaticInit()
 {
-  InstallExceptionHandler();
+	InstallExceptionHandler();
 
-  // register our default IO classes
-  AddIOFactory("con","Console window",DebugIOCon::Create);
-  AddIOFactory("flat","Flat local file(s)",DebugIOFlat::Create);
-  AddIOFactory("net","Network via named pipe",DebugIONet::Create);
-  AddIOFactory("ods","OutputDebugString function",DebugIOOds::Create);
+	// register our default IO classes
+	AddIOFactory("con","Console window",DebugIOCon::Create);
+	AddIOFactory("flat","Flat local file(s)",DebugIOFlat::Create);
+	AddIOFactory("net","Network via named pipe",DebugIONet::Create);
+	AddIOFactory("ods","OutputDebugString function",DebugIOOds::Create);
 
-  // add debug command handler
-  AddCommands("debug",new (DebugAllocMemory(sizeof(DebugCmdInterfaceDebug))) DebugCmdInterfaceDebug);
+	// add debug command handler
+	AddCommands("debug",new (DebugAllocMemory(sizeof(DebugCmdInterfaceDebug))) DebugCmdInterfaceDebug);
 
-  /// exec dbgcmd file
-  char ioBuffer[2048];
-  GetModuleFileName(nullptr,ioBuffer,sizeof(ioBuffer));
-  char *q=strrchr(ioBuffer,'.');
-  if (q)
-    strcpy(q,".dbgcmd");
-  HANDLE h=CreateFile(ioBuffer,GENERIC_READ,0,nullptr,OPEN_EXISTING,
-                      FILE_ATTRIBUTE_NORMAL,nullptr);
-  if (h==INVALID_HANDLE_VALUE)
-    h=CreateFile("default.dbgcmd",GENERIC_READ,0,nullptr,OPEN_EXISTING,
-                      FILE_ATTRIBUTE_NORMAL,nullptr);
-  if (h!=INVALID_HANDLE_VALUE)
-  {
-    char cmdBuffer[512];
-    unsigned long ioCur=0,ioUsed=0,cmdCur=0;
-    ReadFile(h,ioBuffer,sizeof(ioBuffer),&ioUsed,nullptr);
-    for (;;)
-    {
-      if (ioCur==ioUsed)
-      {
-        ReadFile(h,ioBuffer,sizeof(ioBuffer),&ioUsed,nullptr);
-        ioCur=0;
-      }
-      if (ioCur==ioUsed||ioBuffer[ioCur]=='\n'||ioBuffer[ioCur]=='\r')
-      {
-        if (cmdCur)
-        {
-          Instance.ExecCommand(cmdBuffer,cmdBuffer+cmdCur);
-          cmdCur=0;
-        }
-        if (ioCur==ioUsed)
-          break;
-        ioCur++;
-      }
-      else
-      {
-        if (cmdCur<sizeof(cmdBuffer))
-          cmdBuffer[cmdCur++]=ioBuffer[ioCur];
-        ioCur++;
-      }
-    }
-    CloseHandle(h);
-  }
-  else
-  {
-    // exec default commands
-    const char *p=DebugGetDefaultCommands();
-    while (p&&*p)
-    {
-      const char *q=strchr(p,'\n');
-      if (!q)
-        q=p+strlen(p);
-      if (p!=q)
-      {
-        Instance.ExecCommand(p,q);
-        p=*q?q+1:nullptr;
-      }
-    }
-  }
+	/// exec dbgcmd file
+	char ioBuffer[2048];
+	GetModuleFileName(nullptr,ioBuffer,sizeof(ioBuffer));
+	char *q=strrchr(ioBuffer,'.');
+	if (q)
+	strcpy(q,".dbgcmd");
+	HANDLE h=CreateFile(ioBuffer,GENERIC_READ,0,nullptr,OPEN_EXISTING,
+		FILE_ATTRIBUTE_NORMAL,nullptr);
+	if (h==INVALID_HANDLE_VALUE)
+	h=CreateFile("default.dbgcmd",GENERIC_READ,0,nullptr,OPEN_EXISTING,
+		FILE_ATTRIBUTE_NORMAL,nullptr);
+	if (h!=INVALID_HANDLE_VALUE)
+	{
+		char cmdBuffer[512];
+		unsigned long ioCur=0,ioUsed=0,cmdCur=0;
+		ReadFile(h,ioBuffer,sizeof(ioBuffer),&ioUsed,nullptr);
+		for (;;)
+		{
+			if (ioCur==ioUsed)
+			{
+				ReadFile(h,ioBuffer,sizeof(ioBuffer),&ioUsed,nullptr);
+				ioCur=0;
+			}
+			if (ioCur==ioUsed||ioBuffer[ioCur]=='\n'||ioBuffer[ioCur]=='\r')
+			{
+				if (cmdCur)
+				{
+					Instance.ExecCommand(cmdBuffer,cmdBuffer+cmdCur);
+					cmdCur=0;
+				}
+				if (ioCur==ioUsed)
+				break;
+				ioCur++;
+			}
+			else
+			{
+				if (cmdCur<sizeof(cmdBuffer))
+				cmdBuffer[cmdCur++]=ioBuffer[ioCur];
+				ioCur++;
+			}
+		}
+		CloseHandle(h);
+	}
+	else
+	{
+		// exec default commands
+		const char *p=DebugGetDefaultCommands();
+		while (p&&*p)
+		{
+			const char *q=strchr(p,'\n');
+			if (!q)
+			q=p+strlen(p);
+			if (p!=q)
+			{
+				Instance.ExecCommand(p,q);
+				p=*q?q+1:nullptr;
+			}
+		}
+	}
 
-  // check: are we using an old dbghelp.dll?
-  if (DebugStackwalk::IsOldDbghelp())
-  {
-    // give a serious hint
-    Instance.StartOutput(DebugIOInterface::Other,"");
-    Instance << RepeatChar('=',79) <<
-      "\nYou are using an older version of the DBGHELP.DLL library.\n"
-      "Please update to the newest available version in order to\n"
-      "get reliable stack and symbol information.\n\n";
+	// check: are we using an old dbghelp.dll?
+	if (DebugStackwalk::IsOldDbghelp())
+	{
+		// give a serious hint
+		Instance.StartOutput(DebugIOInterface::Other,"");
+		Instance << RepeatChar('=',79) <<
+			"\nYou are using an older version of the DBGHELP.DLL library.\n"
+			"Please update to the newest available version in order to\n"
+			"get reliable stack and symbol information.\n\n";
 
-    char buf[256];
-    GetModuleFileName((HMODULE)DebugStackwalk::GetDbghelpHandle(),buf,sizeof(buf));
-    Instance <<
-      "Hint: The DLL got loaded as:\n" << buf << "\n" << RepeatChar('=',79) << "\n\n";
+		char buf[256];
+		GetModuleFileName((HMODULE)DebugStackwalk::GetDbghelpHandle(),buf,sizeof(buf));
+		Instance <<
+			"Hint: The DLL got loaded as:\n" << buf << "\n" << RepeatChar('=',79) << "\n\n";
 
-    // flush output only if there is already an active I/O class
-    Instance.FlushOutput(false);
-  }
+		// flush output only if there is already an active I/O class
+		Instance.FlushOutput(false);
+	}
 }
 
 void Debug::StaticExit()
 {
-  // yes, we do leave memory 'leaks' but Win32 will take care of these
+	// yes, we do leave memory 'leaks' but Win32 will take care of these
 
-  // however, I/O classes must be actively shut down
-  if (Instance.curType!=DebugIOInterface::StringType::MAX)
-    Instance.FlushOutput();
-  for (IOFactoryListEntry *io=Instance.firstIOFactory;io;io=io->next)
-    if (io->io)
-    {
-      io->io->Delete();
-      io->io=nullptr;
-    }
+	// however, I/O classes must be actively shut down
+	if (Instance.curType!=DebugIOInterface::StringType::MAX)
+	Instance.FlushOutput();
+	for (IOFactoryListEntry *io=Instance.firstIOFactory;io;io=io->next)
+	if (io->io)
+	{
+		io->io->Delete();
+		io->io=nullptr;
+	}
 
-  // and command group interfaces...
-  for (CmdInterfaceListEntry *cmd=Instance.firstCmdGroup;cmd;cmd=cmd->next)
-    if (cmd->cmdif)
-    {
-      cmd->cmdif->Delete();
-      cmd->cmdif=nullptr;
-    }
+	// and command group interfaces...
+	for (CmdInterfaceListEntry *cmd=Instance.firstCmdGroup;cmd;cmd=cmd->next)
+	if (cmd->cmdif)
+	{
+		cmd->cmdif->Delete();
+		cmd->cmdif=nullptr;
+	}
 }
 
 Debug& Debug::operator<<(RepeatChar c)
 {
-  if (c.m_count>=10)
-  {
-    char help[10];
-    memset(help,c.m_char,10);
-    while ((c.m_count-=10)>=0)
-      AddOutput(help,10);
-  }
-  while (c.m_count-->0)
-    AddOutput(&c.m_char,1);
-  return *this;
+	if (c.m_count>=10)
+	{
+		char help[10];
+		memset(help,c.m_char,10);
+		while ((c.m_count-=10)>=0)
+		AddOutput(help,10);
+	}
+	while (c.m_count-->0)
+	AddOutput(&c.m_char,1);
+	return *this;
 }
 
 Debug::Format::Format(const char *format, ...)
 {
-  va_list va;
-  va_start(va,format);
-  vsnprintf(m_buffer,sizeof(m_buffer)-1,format,va);
-  va_end(va);
+	va_list va;
+	va_start(va,format);
+	vsnprintf(m_buffer,sizeof(m_buffer)-1,format,va);
+	va_end(va);
 }
 
 Debug::~Debug()
 {
-  // again, do not put any code in here
+	// again, do not put any code in here
 }
 
 #if defined(_MSC_VER)
 // MSVC: Use SE Translator
 static void LocalSETranslator(unsigned, struct _EXCEPTION_POINTERS *pExPtrs)
 {
-  // simply call our regular exception handler
-  DebugExceptionhandler::ExceptionFilter(pExPtrs);
+	// simply call our regular exception handler
+	DebugExceptionhandler::ExceptionFilter(pExPtrs);
 }
 #elif defined(__GNUC__) && defined(_WIN32)
 // MinGW-w64: Use Vectored Exception Handler (Windows-only)
@@ -278,19 +278,19 @@ static void LocalSETranslator(unsigned, struct _EXCEPTION_POINTERS *pExPtrs)
 // Returns EXCEPTION_CONTINUE_SEARCH to avoid interfering with normal exception handling.
 static LONG WINAPI LocalVectoredExceptionHandler(struct _EXCEPTION_POINTERS *pExPtrs)
 {
-  // Call our regular exception handler
-  DebugExceptionhandler::ExceptionFilter(pExPtrs);
-  return EXCEPTION_CONTINUE_SEARCH;
+	// Call our regular exception handler
+	DebugExceptionhandler::ExceptionFilter(pExPtrs);
+	return EXCEPTION_CONTINUE_SEARCH;
 }
 #endif
 
 void Debug::InstallExceptionHandler()
 {
 #if defined(_MSC_VER)
-  _set_se_translator(LocalSETranslator);
+	_set_se_translator(LocalSETranslator);
 #elif defined(__GNUC__) && defined(_WIN32)
-  // MinGW-w64 doesn't support _set_se_translator, use Vectored Exception Handler
-  AddVectoredExceptionHandler(1, LocalVectoredExceptionHandler);
+	// MinGW-w64 doesn't support _set_se_translator, use Vectored Exception Handler
+	AddVectoredExceptionHandler(1, LocalVectoredExceptionHandler);
 #else
   #error "Unsupported compiler for exception handling"
 #endif

--- a/Core/Libraries/Source/debug/debug_debug.h
+++ b/Core/Libraries/Source/debug/debug_debug.h
@@ -36,18 +36,18 @@
 */
 class Debug
 {
-  // necessary because all debug commands operate directly on this class
-  friend class DebugCmdInterfaceDebug;
+	// necessary because all debug commands operate directly on this class
+	friend class DebugCmdInterfaceDebug;
 
-  // necessary because exception handler needs direct access
-  friend class DebugExceptionhandler;
+	// necessary because exception handler needs direct access
+	friend class DebugExceptionhandler;
 
 public:
-  enum
-  {
-    /// maximum number of times a check can be hit before it is turned off
-    MAX_CHECK_HITS  =   20
-  };
+	enum
+	{
+		/// maximum number of times a check can be hit before it is turned off
+		MAX_CHECK_HITS  =   20
+	};
 
   /**
     \brief HRESULT translator callback function type.
@@ -60,7 +60,7 @@ public:
     \return true if value translated and no more translators should be called,
             false if next translator should be tried
   */
-  typedef bool (*HResultTranslator)(Debug &debug, long hresult, void *user);
+	typedef bool (*HResultTranslator)(Debug &debug, long hresult, void *user);
 
   /**
     \class MemDump debug.h <rts/debug.h>
@@ -72,24 +72,24 @@ public:
 DLOG( "This is 16 bytes of memory:\n" << Debug::MemDump::Raw(&somePointer,16) );
     \endcode
   */
-  class MemDump
-  {
-    // necessary because Debug needs access to the following private members
-    friend Debug;
+	class MemDump
+	{
+		// necessary because Debug needs access to the following private members
+		friend Debug;
 
-    const unsigned char *m_startPtr;  ///< start dumping with this address
-    unsigned m_numItems;              ///< dump the given number of items
-    unsigned m_bytePerItem;           ///< determines the number of bytes per item (1. 2 or 4)
-    bool m_absAddr;                   ///< show absolute addresses (true) or relative addresses (false)
-    bool m_withChars;                 ///< show printable characters on right side of dump (true) or not (false)
+		const unsigned char *m_startPtr;  ///< start dumping with this address
+		unsigned m_numItems;              ///< dump the given number of items
+		unsigned m_bytePerItem;           ///< determines the number of bytes per item (1. 2 or 4)
+		bool m_absAddr;                   ///< show absolute addresses (true) or relative addresses (false)
+		bool m_withChars;                 ///< show printable characters on right side of dump (true) or not (false)
 
-    // constructor is private on purpose so that nobody can
-    // create instances of this class except the static functions
-    // provided herein
-    MemDump(const void *ptr, unsigned num, unsigned bpi, bool absAddr, bool withChars):
-      m_startPtr((const unsigned char *)ptr), m_numItems(num),
-      m_bytePerItem(bpi), m_absAddr(absAddr), m_withChars(withChars) {}
-  public:
+		// constructor is private on purpose so that nobody can
+		// create instances of this class except the static functions
+		// provided herein
+		MemDump(const void *ptr, unsigned num, unsigned bpi, bool absAddr, bool withChars):
+			m_startPtr((const unsigned char *)ptr), m_numItems(num),
+			m_bytePerItem(bpi), m_absAddr(absAddr), m_withChars(withChars) {}
+	public:
 
     /**
       Creates a memory dump descriptor.
@@ -98,10 +98,10 @@ DLOG( "This is 16 bytes of memory:\n" << Debug::MemDump::Raw(&somePointer,16) );
       \param numItems number of items (usually bytes) to dump
       \param bytePerItem number of bytes per item (usually 1)
     */
-    static MemDump Raw(const void *startPtr, unsigned numItems, unsigned bytePerItem=1)
-    {
-      return MemDump(startPtr,numItems,bytePerItem,true,false);
-    }
+		static MemDump Raw(const void *startPtr, unsigned numItems, unsigned bytePerItem=1)
+		{
+		return MemDump(startPtr,numItems,bytePerItem,true,false);
+		}
 
     /**
       Creates a memory dump descriptor with relative addresses.
@@ -110,10 +110,10 @@ DLOG( "This is 16 bytes of memory:\n" << Debug::MemDump::Raw(&somePointer,16) );
       \param numItems number of items (usually bytes) to dump
       \param bytePerItem number of bytes per item (usually 1)
     */
-    static MemDump RawRel(const void *startPtr, unsigned numItems, unsigned bytePerItem=1)
-    {
-      return MemDump(startPtr,numItems,bytePerItem,false,false);
-    }
+		static MemDump RawRel(const void *startPtr, unsigned numItems, unsigned bytePerItem=1)
+		{
+		return MemDump(startPtr,numItems,bytePerItem,false,false);
+		}
 
     /**
       Creates a memory dump descriptor that dumps out ASCII chars as well.
@@ -122,10 +122,10 @@ DLOG( "This is 16 bytes of memory:\n" << Debug::MemDump::Raw(&somePointer,16) );
       \param numItems number of items (usually bytes) to dump
       \param bytePerItem number of bytes per item (usually 1)
     */
-    static MemDump Char(const void *startPtr, unsigned numItems, unsigned bytePerItem=1)
-    {
-      return MemDump(startPtr,numItems,bytePerItem,true,true);
-    }
+		static MemDump Char(const void *startPtr, unsigned numItems, unsigned bytePerItem=1)
+		{
+		return MemDump(startPtr,numItems,bytePerItem,true,true);
+		}
 
     /**
       Creates a memory dump descriptor with relative addresses that dumps out ASCII chars as well.
@@ -134,11 +134,11 @@ DLOG( "This is 16 bytes of memory:\n" << Debug::MemDump::Raw(&somePointer,16) );
       \param numItems number of items (usually bytes) to dump
       \param bytePerItem number of bytes per item (usually 1)
     */
-    static MemDump CharRel(const void *startPtr, unsigned numItems, unsigned bytePerItem=1)
-    {
-      return MemDump(startPtr,numItems,bytePerItem,false,true);
-    }
-  };
+		static MemDump CharRel(const void *startPtr, unsigned numItems, unsigned bytePerItem=1)
+		{
+		return MemDump(startPtr,numItems,bytePerItem,false,true);
+		}
+	};
 
   /**
     \class HResult debug.h <rts/debug.h>
@@ -154,35 +154,35 @@ DLOG( "My HResult is: " << Debug::HResult(SomeHRESULTValue) << "\n" );
     can be added or removed during runtime, see \ref Debug::AddHResultTranslator for more
     information.
   */
-  class HResult
-  {
-    // necessary because Debug needs access to the following private members
-    friend Debug;
+	class HResult
+	{
+		// necessary because Debug needs access to the following private members
+		friend Debug;
 
-    long m_hresult;                   ///< HRESULT value
+		long m_hresult;                   ///< HRESULT value
 
-  public:
+	public:
 
     /**
       Creates a HRESULT descriptor.
 
       \param hresult HRESULT value (checked, Windows declares HRESULT as typedef long)
     */
-    explicit HResult(long hresult): m_hresult(hresult) {}
-  };
+		explicit HResult(long hresult): m_hresult(hresult) {}
+	};
 
   /** \internal
 
     \brief Helper class for adding log group descriptions.
 
   */
-  class LogDescription
-  {
-    // sorry, no copies or assignments
-    LogDescription(const LogDescription&);
-    LogDescription& operator=(const LogDescription&);
+	class LogDescription
+	{
+		// sorry, no copies or assignments
+		LogDescription(const LogDescription&);
+		LogDescription& operator=(const LogDescription&);
 
-  public:
+	public:
 
     /** \internal
 
@@ -191,107 +191,107 @@ DLOG( "My HResult is: " << Debug::HResult(SomeHRESULTValue) << "\n" );
       \param fileOrGroup filename or logging group (see \ref Debug::LogBegin)
       \param description descriptive text for logging file/group
     */
-    LogDescription(const char *fileOrGroup, const char *description);
-  };
+		LogDescription(const char *fileOrGroup, const char *description);
+	};
 
   /**
     \brief Switches integer output to hexadecimal format.
   */
-  class Hex {};
+	class Hex {};
 
-  /// \internal Performs actual switch to hexadecimal format.
-  Debug& operator<<(const Hex)
-  {
-    SetPrefixAndRadix("0x",16);
-    return *this;
-  }
+	/// \internal Performs actual switch to hexadecimal format.
+	Debug& operator<<(const Hex)
+	{
+		SetPrefixAndRadix("0x",16);
+		return *this;
+	}
 
   /**
     \brief Switches integer output to decimal format.
   */
-  class Dec {};
+	class Dec {};
 
-  /// \internal Performs actuals switch to decimal format
-  Debug& operator<<(const Dec)
-  {
-    SetPrefixAndRadix("",10);
-    return *this;
-  }
+	/// \internal Performs actuals switch to decimal format
+	Debug& operator<<(const Dec)
+	{
+		SetPrefixAndRadix("",10);
+		return *this;
+	}
 
   /**
     \brief Switches integer output to binary format.
   */
-  class Bin {};
+	class Bin {};
 
-  /// \internal Performs actuals switch to binary format
-  Debug& operator<<(const Bin)
-  {
-    SetPrefixAndRadix("%",2);
-    return *this;
-  }
+	/// \internal Performs actuals switch to binary format
+	Debug& operator<<(const Bin)
+	{
+		SetPrefixAndRadix("%",2);
+		return *this;
+	}
 
   /**
     \brief Sets output width for the next insertion.
   */
-  class Width
-  {
-    // necessary because Debug needs access to the following private members
-    friend Debug;
+	class Width
+	{
+		// necessary because Debug needs access to the following private members
+		friend Debug;
 
-    int m_width;  ///< output width
+		int m_width;  ///< output width
 
-  public:
-    /// \brief Sets new output width (next insertion only).
-    explicit Width(int width): m_width(width) {}
-  };
+	public:
+		/// \brief Sets new output width (next insertion only).
+		explicit Width(int width): m_width(width) {}
+	};
 
-  /// \internal Performs actuals width switch
-  Debug& operator<<(const Width w)
-  {
-    m_width=w.m_width;
-    return *this;
-  }
+	/// \internal Performs actuals width switch
+	Debug& operator<<(const Width w)
+	{
+		m_width=w.m_width;
+		return *this;
+	}
 
   /**
     \brief Sets new fill character.
   */
-  class FillChar
-  {
-    // necessary because Debug needs access to the following private members
-    friend Debug;
+	class FillChar
+	{
+		// necessary because Debug needs access to the following private members
+		friend Debug;
 
-    char m_fill;  ///< fill character
+		char m_fill;  ///< fill character
 
-  public:
-    /// \brief Sets new fill character.
-    explicit FillChar(char ch=' '): m_fill(ch) {}
-  };
+	public:
+		/// \brief Sets new fill character.
+		explicit FillChar(char ch=' '): m_fill(ch) {}
+	};
 
-  /// \internal Performs actuals setting of fill char
-  Debug& operator<<(const FillChar c)
-  {
-    m_fillChar=c.m_fill;
-    return *this;
-  }
+	/// \internal Performs actuals setting of fill char
+	Debug& operator<<(const FillChar c)
+	{
+		m_fillChar=c.m_fill;
+		return *this;
+	}
 
   /**
     \brief Repeats a given character N times.
   */
-  class RepeatChar
-  {
-    // necessary because Debug needs access to the following private members
-    friend Debug;
+	class RepeatChar
+	{
+		// necessary because Debug needs access to the following private members
+		friend Debug;
 
-    char m_char;  ///< character
-    int m_count;  ///< repeat count
+		char m_char;  ///< character
+		int m_count;  ///< repeat count
 
-  public:
-    /// \brief Repeats a given character N times
-    explicit RepeatChar(char ch, int count): m_char(ch), m_count(count) {}
-  };
+	public:
+		/// \brief Repeats a given character N times
+		explicit RepeatChar(char ch, int count): m_char(ch), m_count(count) {}
+	};
 
-  /// \internal Performs actuals repeating of char
-  Debug& operator<<(RepeatChar c);
+	/// \internal Performs actuals repeating of char
+	Debug& operator<<(RepeatChar c);
 
   /**
     \brief Old printf style formatting.
@@ -299,37 +299,37 @@ DLOG( "My HResult is: " << Debug::HResult(SomeHRESULTValue) << "\n" );
     \note Do not use this helper class for new code. It is mainly here
     to get the old code base adapted to the new debug module more quickly.
   */
-  class Format
-  {
-    // necessary because Debug needs access to the following private members
-    friend Debug;
+	class Format
+	{
+		// necessary because Debug needs access to the following private members
+		friend Debug;
 
-    // no CC, AOp
-    Format(const Format &);
-    Format& operator=(const Format&);
+		// no CC, AOp
+		Format(const Format &);
+		Format& operator=(const Format&);
 
-    char m_buffer[512]; ///< this contains the string to write \note Fixed size buffer!
+		char m_buffer[512]; ///< this contains the string to write \note Fixed size buffer!
 
-  public:
-    /// \brief Old printf style formatting.
-    explicit Format(const char *format, ...);
-  };
+	public:
+		/// \brief Old printf style formatting.
+		explicit Format(const char *format, ...);
+	};
 
-  /// \internal Writes printf style formatted string to debug log.
-  Debug& operator<<(const Format &f)
-  {
+	/// \internal Writes printf style formatted string to debug log.
+	Debug& operator<<(const Format &f)
+	{
     operator<<(f.m_buffer);
-    return *this;
-  }
+		return *this;
+	}
 
-  // this is necessary because LogDescription needs to call AddLogGroup
-  friend class LogDescription;
+	// this is necessary because LogDescription needs to call AddLogGroup
+	friend class LogDescription;
 
   /** \internal
 
     \brief Performs logical cleanup.
   */
-  ~Debug();
+	~Debug();
 
   /**
     \brief Installs exception handler for current thread.
@@ -337,7 +337,7 @@ DLOG( "My HResult is: " << Debug::HResult(SomeHRESULTValue) << "\n" );
     For the main thread this is already done, but for any additional
     threads being created this function must be called.
   */
-  static void InstallExceptionHandler();
+	static void InstallExceptionHandler();
 
   /** \internal
 
@@ -352,7 +352,7 @@ DLOG( "My HResult is: " << Debug::HResult(SomeHRESULTValue) << "\n" );
 
     \return true if next assert/log should be skipped, false otherwise
   */
-  static bool SkipNext();
+	static bool SkipNext();
 
   /** \internal
 
@@ -368,7 +368,7 @@ DLOG( "My HResult is: " << Debug::HResult(SomeHRESULTValue) << "\n" );
     \param expr expression that triggered the assertion, nullptr for 'general failure' (\ref DFAIL)
     \return reference to Debug instance
   */
-  static Debug &AssertBegin(const char *file, int line, const char *expr);
+	static Debug &AssertBegin(const char *file, int line, const char *expr);
 
   /** \internal
 
@@ -380,7 +380,7 @@ DLOG( "My HResult is: " << Debug::HResult(SomeHRESULTValue) << "\n" );
 
     \return false (always)
   */
-  bool AssertDone();
+	bool AssertDone();
 
   /** \internal
 
@@ -396,7 +396,7 @@ DLOG( "My HResult is: " << Debug::HResult(SomeHRESULTValue) << "\n" );
     \param expr expression that triggered the assertion
     \return reference to Debug instance
   */
-  static Debug &CheckBegin(const char *file, int line, const char *expr);
+	static Debug &CheckBegin(const char *file, int line, const char *expr);
 
   /** \internal
 
@@ -406,7 +406,7 @@ DLOG( "My HResult is: " << Debug::HResult(SomeHRESULTValue) << "\n" );
 
     \return false (always)
   */
-  bool CheckDone();
+	bool CheckDone();
 
   /** \internal
 
@@ -420,7 +420,7 @@ DLOG( "My HResult is: " << Debug::HResult(SomeHRESULTValue) << "\n" );
     \param fileOrGroup current file or group the following log data is for
     \return reference to Debug instance
   */
-  static Debug &LogBegin(const char *fileOrGroup);
+	static Debug &LogBegin(const char *fileOrGroup);
 
   /** \internal
 
@@ -430,7 +430,7 @@ DLOG( "My HResult is: " << Debug::HResult(SomeHRESULTValue) << "\n" );
 
     \return false (always)
   */
-  bool LogDone();
+	bool LogDone();
 
   /** \internal
 
@@ -446,7 +446,7 @@ DLOG( "My HResult is: " << Debug::HResult(SomeHRESULTValue) << "\n" );
                 be given
     \return reference to Debug instance
   */
-  static Debug &CrashBegin(const char *file, int line);
+	static Debug &CrashBegin(const char *file, int line);
 
   /** \internal
 
@@ -458,7 +458,7 @@ DLOG( "My HResult is: " << Debug::HResult(SomeHRESULTValue) << "\n" );
                the user should have the choice
     \return false (always)
   */
-  bool CrashDone(bool die);
+	bool CrashDone(bool die);
 
   /** \internal
 
@@ -467,7 +467,7 @@ DLOG( "My HResult is: " << Debug::HResult(SomeHRESULTValue) << "\n" );
     \param str string to write
     \return *this
   */
-  Debug& operator<<(const char *str);
+	Debug& operator<<(const char *str);
 
   /** \internal
 
@@ -476,7 +476,7 @@ DLOG( "My HResult is: " << Debug::HResult(SomeHRESULTValue) << "\n" );
     \param prefix prefix to use (typically "" or "0x")
     \param radix radix to use (typically 10 or 16)
   */
-  void SetPrefixAndRadix(const char *prefix, int radix);
+	void SetPrefixAndRadix(const char *prefix, int radix);
 
   /** \internal
 
@@ -485,7 +485,7 @@ DLOG( "My HResult is: " << Debug::HResult(SomeHRESULTValue) << "\n" );
     \param val signed integer
     \return *this
   */
-  Debug& operator<<(int val);
+	Debug& operator<<(int val);
 
   /** \internal
 
@@ -494,7 +494,7 @@ DLOG( "My HResult is: " << Debug::HResult(SomeHRESULTValue) << "\n" );
     \param val unsigned integer
     \return *this
   */
-  Debug& operator<<(unsigned val);
+	Debug& operator<<(unsigned val);
 
   /** \internal
 
@@ -503,7 +503,7 @@ DLOG( "My HResult is: " << Debug::HResult(SomeHRESULTValue) << "\n" );
     \param val signed long
     \return *this
   */
-  Debug& operator<<(long val);
+	Debug& operator<<(long val);
 
   /** \internal
 
@@ -512,7 +512,7 @@ DLOG( "My HResult is: " << Debug::HResult(SomeHRESULTValue) << "\n" );
     \param val unsigned long
     \return *this
   */
-  Debug& operator<<(unsigned long val);
+	Debug& operator<<(unsigned long val);
 
   /** \internal
 
@@ -521,7 +521,7 @@ DLOG( "My HResult is: " << Debug::HResult(SomeHRESULTValue) << "\n" );
     \param val bool
     \return *this
   */
-  Debug& operator<<(bool val);
+	Debug& operator<<(bool val);
 
   /** \internal
 
@@ -530,7 +530,7 @@ DLOG( "My HResult is: " << Debug::HResult(SomeHRESULTValue) << "\n" );
     \param val float
     \return *this
   */
-  Debug& operator<<(float val);
+	Debug& operator<<(float val);
 
   /** \internal
 
@@ -539,7 +539,7 @@ DLOG( "My HResult is: " << Debug::HResult(SomeHRESULTValue) << "\n" );
     \param val double
     \return *this
   */
-  Debug& operator<<(double val);
+	Debug& operator<<(double val);
 
   /** \internal
 
@@ -548,7 +548,7 @@ DLOG( "My HResult is: " << Debug::HResult(SomeHRESULTValue) << "\n" );
     \param val signed short integer
     \return *this
   */
-  Debug& operator<<(short val);
+	Debug& operator<<(short val);
 
   /** \internal
 
@@ -557,7 +557,7 @@ DLOG( "My HResult is: " << Debug::HResult(SomeHRESULTValue) << "\n" );
     \param val unsigned short integer
     \return *this
   */
-  Debug& operator<<(unsigned short val);
+	Debug& operator<<(unsigned short val);
 
   /** \internal
 
@@ -566,7 +566,7 @@ DLOG( "My HResult is: " << Debug::HResult(SomeHRESULTValue) << "\n" );
     \param val signed 64 bit integer
     \return *this
   */
-  Debug& operator<<(__int64 val);
+	Debug& operator<<(__int64 val);
 
   /** \internal
 
@@ -575,7 +575,7 @@ DLOG( "My HResult is: " << Debug::HResult(SomeHRESULTValue) << "\n" );
     \param val unsigned 64 bit integer
     \return *this
   */
-  Debug& operator<<(unsigned __int64 val);
+	Debug& operator<<(unsigned __int64 val);
 
   /** \internal
 
@@ -584,7 +584,7 @@ DLOG( "My HResult is: " << Debug::HResult(SomeHRESULTValue) << "\n" );
     \param ptr pointer address
     \return *this
   */
-  Debug& operator<<(const void *ptr);
+	Debug& operator<<(const void *ptr);
 
   /** \internal
 
@@ -593,7 +593,7 @@ DLOG( "My HResult is: " << Debug::HResult(SomeHRESULTValue) << "\n" );
     \param dump MemDump descriptor, defines what range of memory to dump
     \return *this
   */
-  Debug& operator<<(const MemDump &dump);
+	Debug& operator<<(const MemDump &dump);
 
   /** \internal
 
@@ -602,7 +602,7 @@ DLOG( "My HResult is: " << Debug::HResult(SomeHRESULTValue) << "\n" );
     \param hres HResult descriptor
     \return *this
   */
-  Debug& operator<<(HResult hres);
+	Debug& operator<<(HResult hres);
 
   /** \internal
     \brief Determines if a log file/group is active or not.
@@ -614,7 +614,7 @@ DLOG( "My HResult is: " << Debug::HResult(SomeHRESULTValue) << "\n" );
                        as well.
     \return true if logging is enabled, false if not
   */
-  static bool IsLogEnabled(const char *fileOrGroup);
+	static bool IsLogEnabled(const char *fileOrGroup);
 
   /**
     \brief Adds a HRESULT translator.
@@ -631,7 +631,7 @@ DLOG( "My HResult is: " << Debug::HResult(SomeHRESULTValue) << "\n" );
     \param user optional user pointer which will be passed to the given translator
     \see RemoveHResultTranslator
   */
-  static void AddHResultTranslator(unsigned prio, HResultTranslator func, void *user=0);
+	static void AddHResultTranslator(unsigned prio, HResultTranslator func, void *user=0);
 
   /**
     \brief Removes a HRESULT translator.
@@ -642,7 +642,7 @@ DLOG( "My HResult is: " << Debug::HResult(SomeHRESULTValue) << "\n" );
     \param user optional user pointer
     \see AddHResultTranslator
   */
-  static void RemoveHResultTranslator(HResultTranslator func, void *user=0);
+	static void RemoveHResultTranslator(HResultTranslator func, void *user=0);
 
   /**
     \brief Registers a new I/O class factory function.
@@ -656,8 +656,8 @@ DLOG( "My HResult is: " << Debug::HResult(SomeHRESULTValue) << "\n" );
     \param func factory function
     \return true (so function can be used in static initializers)
   */
-  static bool AddIOFactory(const char *io_id, const char *descr,
-                           DebugIOInterface* (*func)());
+	static bool AddIOFactory(const char *io_id, const char *descr,
+		DebugIOInterface* (*func)());
 
   /**
     \brief Adds a new command group.
@@ -679,28 +679,28 @@ DLOG( "My HResult is: " << Debug::HResult(SomeHRESULTValue) << "\n" );
     \param cmdif command group interface instance
     \return true (so function can be used in static initializers)
   */
-  static bool AddCommands(const char *cmdgroup, DebugCmdInterface *cmdif);
+	static bool AddCommands(const char *cmdgroup, DebugCmdInterface *cmdif);
 
   /**
     \brief Removes a command group.
 
     \param cmdif command group interface that will be removed
   */
-  static void RemoveCommands(DebugCmdInterface *cmdif);
+	static void RemoveCommands(DebugCmdInterface *cmdif);
 
   /**
     \brief Issues a debug command.
 
     \param cmd command to execute
   */
-  static void Command(const char *cmd);
+	static void Command(const char *cmd);
 
   /**
     \brief Update method, must be called on a regular basis.
 
     Scans I/O classes for new command input and processes it.
   */
-  static void Update();
+	static void Update();
 
   /** \internal
 
@@ -710,7 +710,7 @@ DLOG( "My HResult is: " << Debug::HResult(SomeHRESULTValue) << "\n" );
     \param pattern pattern, only wildcard valid is '*'
     \return true if string matches pattern, false if not
   */
-  static bool SimpleMatch(const char *str, const char *pattern);
+	static bool SimpleMatch(const char *str, const char *pattern);
 
   /**
     \brief Tell debug module about build info.
@@ -721,25 +721,25 @@ DLOG( "My HResult is: " << Debug::HResult(SomeHRESULTValue) << "\n" );
     \param internalVersion internal version
     \param buildDate build date & time
   */
-  static void SetBuildInfo(const char *version,
-                           const char *internalVersion,
-                           const char *buildDate);
+	static void SetBuildInfo(const char *version,
+		const char *internalVersion,
+		const char *buildDate);
 
   /**
     \brief Write build information into log.
   */
-  void WriteBuildInfo();
+	void WriteBuildInfo();
 
 private:
 #if defined(__GNUC__) && defined(_WIN32)
-  // For GCC/MinGW-w64 targeting Windows, allow constructor functions to call init methods
-  friend void GccPreStaticInit();
-  friend void GccPostStaticInit();
+	// For GCC/MinGW-w64 targeting Windows, allow constructor functions to call init methods
+	friend void GccPreStaticInit();
+	friend void GccPostStaticInit();
 #endif
 
-  // no assignment, no copy constructor
-  Debug(const Debug&);
-  Debug& operator=(const Debug&);
+	// no assignment, no copy constructor
+	Debug(const Debug&);
+	Debug& operator=(const Debug&);
 
   /** \internal
 
@@ -749,7 +749,7 @@ private:
     initialization is rather performed by PreStaticInit() and
     PostStaticInit().
   */
-  Debug();
+	Debug();
 
   /** \internal
 
@@ -757,14 +757,14 @@ private:
     initialized. Code herein must be extremely careful because all
     global C++ instances are not initialized yet.
   */
-  static void PreStaticInit();
+	static void PreStaticInit();
 
   /** \internal
 
     This function gets called after all static C++ symbols have
     been initialized.
   */
-  static void PostStaticInit();
+	static void PostStaticInit();
 
   /** \internal
 
@@ -772,75 +772,75 @@ private:
     function for any cleanup purposes (not the destructor, it
     might get called too early).
   */
-  static void StaticExit();
+	static void StaticExit();
 
   /** \internal
 
     The only debug instance. Actually not used for anything
     except as magic first parameter for overloaded stream operators.
   */
-  static Debug Instance;
+	static Debug Instance;
 
   /** \internal
 
     Helper variable for putting PreStaticInit() into the MSVC
     startup list.
   */
-  static void *PreStatic;
+	static void *PreStatic;
 
   /** \internal
 
     Helper variable for putting PostStaticInit() into the MSVC
     startup list.
   */
-  static void *PostStatic;
+	static void *PostStatic;
 
-  /// \internal HResult translator vector entry
-  struct HResultTranslatorEntry
-  {
-    /// priority
-    unsigned prio;
+	/// \internal HResult translator vector entry
+	struct HResultTranslatorEntry
+	{
+		/// priority
+		unsigned prio;
 
-    /// translator function
-    HResultTranslator func;
+		/// translator function
+		HResultTranslator func;
 
-    /// user pointer
-    void *user;
-  };
+		/// user pointer
+		void *user;
+	};
 
-  /// \internal HResult translator vector
-  HResultTranslatorEntry *hrTranslators;
+	/// \internal HResult translator vector
+	HResultTranslatorEntry *hrTranslators;
 
-  /// \internal number of HResult translators
-  unsigned numHrTranslators;
+	/// \internal number of HResult translators
+	unsigned numHrTranslators;
 
-  /// \internal I/O class/factory list entry
-  struct IOFactoryListEntry
-  {
-    /// pointer to next entry in list
-    IOFactoryListEntry *next;
+	/// \internal I/O class/factory list entry
+	struct IOFactoryListEntry
+	{
+		/// pointer to next entry in list
+		IOFactoryListEntry *next;
 
-    /// I/O ID
-    const char *ioID;
+		/// I/O ID
+		const char *ioID;
 
-    /// I/O description
-    const char *descr;
+		/// I/O description
+		const char *descr;
 
-    /// factory function
-    DebugIOInterface* (*factory)();
+		/// factory function
+		DebugIOInterface* (*factory)();
 
-    /// I/O interface (may be null)
-    DebugIOInterface *io;
+		/// I/O interface (may be null)
+		DebugIOInterface *io;
 
-    /// input buffer
-    char *input;
+		/// input buffer
+		char *input;
 
-    /// used size of input buffer
-    unsigned inputUsed;
+		/// used size of input buffer
+		unsigned inputUsed;
 
-    /// allocated size of input buffer
-    unsigned inputAlloc;
-  };
+		/// allocated size of input buffer
+		unsigned inputAlloc;
+	};
 
   /** \internal
 
@@ -848,20 +848,20 @@ private:
     okay for this because looking up I/O IDs is not
     time critical.
   */
-  IOFactoryListEntry *firstIOFactory;
+	IOFactoryListEntry *firstIOFactory;
 
-  /// \internal command interface list entry
-  struct CmdInterfaceListEntry
-  {
-    /// pointer to next entry in list
-    CmdInterfaceListEntry *next;
+	/// \internal command interface list entry
+	struct CmdInterfaceListEntry
+	{
+		/// pointer to next entry in list
+		CmdInterfaceListEntry *next;
 
-    /// command group
-    const char *group;
+		/// command group
+		const char *group;
 
-    /// interface pointer
-    DebugCmdInterface *cmdif;
-  };
+		/// interface pointer
+		DebugCmdInterface *cmdif;
+	};
 
   /** \internal
 
@@ -869,10 +869,10 @@ private:
     okay for this because looking up command groups is not
     time critical.
   */
-  CmdInterfaceListEntry *firstCmdGroup;
+	CmdInterfaceListEntry *firstCmdGroup;
 
-  /// \internal current stack frame (used by SkipNext)
-  static unsigned curStackFrame;
+	/// \internal current stack frame (used by SkipNext)
+	static unsigned curStackFrame;
 
   /** \internal
 
@@ -881,77 +881,77 @@ private:
     list where a single pattern can apply to more than
     one type.
   */
-  enum
-  {
-    /// assert
-    FrameTypeAssert = 0x00000001,
+	enum
+	{
+		/// assert
+		FrameTypeAssert = 0x00000001,
 
-    /// check
-    FrameTypeCheck  = 0x00000002,
+		/// check
+		FrameTypeCheck  = 0x00000002,
 
-    /// log
-    FrameTypeLog    = 0x00000004
-  };
+		/// log
+		FrameTypeLog    = 0x00000004
+	};
 
   /** \internal
 
     List of possible statuses for a frame hash entry.
   */
-  enum FrameStatus
-  {
-    /// unknown, must check
-    Unknown = 0,
+	enum FrameStatus
+	{
+		/// unknown, must check
+		Unknown = 0,
 
-    /// skip this frame
-    Skip,
+		/// skip this frame
+		Skip,
 
-    /// do not skip this frame
-    NoSkip
-  };
+		/// do not skip this frame
+		NoSkip
+	};
 
   /** \internal
 
     \brief Hash table entry for mapping stack frame addresses to
     asserts/checks/logs.
   */
-  struct FrameHashEntry
-  {
-    /// pointer to next entry with same hash
-    FrameHashEntry *next;
+	struct FrameHashEntry
+	{
+		/// pointer to next entry with same hash
+		FrameHashEntry *next;
 
-    /// frame address
-    unsigned frameAddr;
+		/// frame address
+		unsigned frameAddr;
 
-    /// frame type (FrameTypeAssert, FrameTypeCheck, or FrameTypeLog)
-    unsigned frameType;
+		/// frame type (FrameTypeAssert, FrameTypeCheck, or FrameTypeLog)
+		unsigned frameType;
 
-    /// file (or group if log)
-    const char *fileOrGroup;
+		/// file (or group if log)
+		const char *fileOrGroup;
 
-    /// line number (undefined for logs)
-    int line;
+		/// line number (undefined for logs)
+		int line;
 
-    /// number of times this frame has been hit
-    int hits;
+		/// number of times this frame has been hit
+		int hits;
 
-    /// frame status
-    FrameStatus status;
-  };
+		/// frame status
+		FrameStatus status;
+	};
 
-  /// \internal initial frame hash size (prime number)
-  enum { FRAME_HASH_SIZE = 10007 };
+	/// \internal initial frame hash size (prime number)
+	enum { FRAME_HASH_SIZE = 10007 };
 
-  /// \internal frame hash pointers
-  FrameHashEntry *frameHash[FRAME_HASH_SIZE];
+	/// \internal frame hash pointers
+	FrameHashEntry *frameHash[FRAME_HASH_SIZE];
 
-  /// \internal number of FrameHashEntry structures to allocate at one time
-  enum { FRAME_HASH_ALLOC_COUNT = 100 };
+	/// \internal number of FrameHashEntry structures to allocate at one time
+	enum { FRAME_HASH_ALLOC_COUNT = 100 };
 
-  /// \internal next unused FrameHashEntry structure
-  FrameHashEntry *nextUnusedFrameHash;
+	/// \internal next unused FrameHashEntry structure
+	FrameHashEntry *nextUnusedFrameHash;
 
-  /// \internal number of available FrameHashEntry structures
-  unsigned numAvailableFrameHash;
+	/// \internal number of available FrameHashEntry structures
+	unsigned numAvailableFrameHash;
 
   /** \internal
 
@@ -960,13 +960,13 @@ private:
     \param addr frame address
     \return FrameHashEntry found or 0 if nothing found
   */
-  __forceinline FrameHashEntry *LookupFrame(unsigned addr)
-  {
-    for (FrameHashEntry *e=frameHash[addr%FRAME_HASH_SIZE];e;e=e->next)
-      if (e->frameAddr==addr)
-        return e;
-    return 0;
-  }
+	__forceinline FrameHashEntry *LookupFrame(unsigned addr)
+	{
+		for (FrameHashEntry *e=frameHash[addr%FRAME_HASH_SIZE];e;e=e->next)
+		if (e->frameAddr==addr)
+		return e;
+		return 0;
+	}
 
   /** \internal
 
@@ -980,8 +980,8 @@ private:
     \param line line number
     \return the entry just added
   */
-  FrameHashEntry *AddFrameEntry(unsigned addr, unsigned type,
-                                const char *fileOrGroup, int line);
+	FrameHashEntry *AddFrameEntry(unsigned addr, unsigned type,
+		const char *fileOrGroup, int line);
 
   /** \internal
 
@@ -990,7 +990,7 @@ private:
 
     \param entry entry that needs to be updated
   */
-  void UpdateFrameStatus(FrameHashEntry &entry);
+	void UpdateFrameStatus(FrameHashEntry &entry);
 
   /** \internal
 
@@ -1002,16 +1002,16 @@ private:
     \param line line number
     \return the entry just added (or the already existing entry)
   */
-  FrameHashEntry *GetFrameEntry(unsigned addr, unsigned type,
-                                const char *fileOrGroup, int line)
-  {
-    FrameHashEntry *e=LookupFrame(addr);
-    if (!e)
-      e=AddFrameEntry(addr,type,fileOrGroup,line);
-    if (e->status==Unknown)
-      UpdateFrameStatus(*e);
-    return e;
-  }
+	FrameHashEntry *GetFrameEntry(unsigned addr, unsigned type,
+		const char *fileOrGroup, int line)
+	{
+		FrameHashEntry *e=LookupFrame(addr);
+		if (!e)
+		e=AddFrameEntry(addr,type,fileOrGroup,line);
+		if (e->status==Unknown)
+		UpdateFrameStatus(*e);
+		return e;
+	}
 
   /** \internal
 
@@ -1022,20 +1022,20 @@ private:
     if a new stack frame entry is added (which happens only
     once for each log command).
   */
-  struct KnownLogGroupList
-  {
-    /// next entry
-    KnownLogGroupList *next;
+	struct KnownLogGroupList
+	{
+		/// next entry
+		KnownLogGroupList *next;
 
-    /// name of log group (dynamically allocated memory)
-    char *nameGroup;
+		/// name of log group (dynamically allocated memory)
+		char *nameGroup;
 
-    /// log description (if any)
-    const char *descr;
-  };
+		/// log description (if any)
+		const char *descr;
+	};
 
-  /// \internal first log group list entry
-  KnownLogGroupList *firstLogGroup;
+	/// \internal first log group list entry
+	KnownLogGroupList *firstLogGroup;
 
   /** \internal
 
@@ -1049,32 +1049,32 @@ private:
     \param descr description, may be nullptr
     \return translated log group name
   */
-  const char *AddLogGroup(const char *fileOrGroup, const char *descr);
+	const char *AddLogGroup(const char *fileOrGroup, const char *descr);
 
-  /// \internal I/O buffers for all I/O string types
-  struct
-  {
-    /// buffer
-    char *buffer;
+	/// \internal I/O buffers for all I/O string types
+	struct
+	{
+		/// buffer
+		char *buffer;
 
-    /// used buffer size
-    unsigned used;
+		/// used buffer size
+		unsigned used;
 
-    /// allocated buffer size
-    unsigned alloc;
+		/// allocated buffer size
+		unsigned alloc;
 
-    /// has last character been CR?
-    bool lastWasCR;
-  } ioBuffer[DebugIOInterface::StringType::MAX];
+		/// has last character been CR?
+		bool lastWasCR;
+	} ioBuffer[DebugIOInterface::StringType::MAX];
 
-  /// \internal current I/O string type we're writing
-  DebugIOInterface::StringType curType;
+	/// \internal current I/O string type we're writing
+	DebugIOInterface::StringType curType;
 
-  /// \internal current I/O string source (fixed size, careful!)
-  char curSource[256];
+	/// \internal current I/O string source (fixed size, careful!)
+	char curSource[256];
 
-  /// \internal used to enable/disable all asserts/checks/logs
-  int disableAssertsEtc;
+	/// \internal used to enable/disable all asserts/checks/logs
+	int disableAssertsEtc;
 
   /** \internal
 
@@ -1083,7 +1083,7 @@ private:
     \param type string type
     \param fmt wsprintf format string
   */
-  void StartOutput(DebugIOInterface::StringType type, const char *fmt, ...);
+	void StartOutput(DebugIOInterface::StringType type, const char *fmt, ...);
 
   /** \internal
 
@@ -1092,7 +1092,7 @@ private:
     \param str string
     \param len string length
   */
-  void AddOutput(const char *str, unsigned len);
+	void AddOutput(const char *str, unsigned len);
 
   /** \internal
 
@@ -1101,26 +1101,26 @@ private:
     \param defaultLog if true and no I/O class is active then data
            is written to default.log
   */
-  void FlushOutput(bool defaultLog=true);
+	void FlushOutput(bool defaultLog=true);
 
-  /// \internal pointer to currently active frame
-  FrameHashEntry *curFrameEntry;
+	/// \internal pointer to currently active frame
+	FrameHashEntry *curFrameEntry;
 
-  /// \internal pattern list entry
-  struct PatternListEntry
-  {
-    /// next entry
-    PatternListEntry *next;
+	/// \internal pattern list entry
+	struct PatternListEntry
+	{
+		/// next entry
+		PatternListEntry *next;
 
-    /// frame type(s)
-    unsigned frameTypes;
+		/// frame type(s)
+		unsigned frameTypes;
 
-    /// active (true) or inactive (false)?
-    bool isActive;
+		/// active (true) or inactive (false)?
+		bool isActive;
 
-    /// pattern itself (dynamic allocated memory)
-    char *pattern;
-  };
+		/// pattern itself (dynamic allocated memory)
+		char *pattern;
+	};
 
   /** \internal
 
@@ -1128,10 +1128,10 @@ private:
     okay for this because checking patterns is a costly
     operation anyway and is therefore cached.
   */
-  PatternListEntry *firstPatternEntry;
+	PatternListEntry *firstPatternEntry;
 
-  /// \internal last pattern list entry for fast additions to list at end
-  PatternListEntry *lastPatternEntry;
+	/// \internal last pattern list entry for fast additions to list at end
+	PatternListEntry *lastPatternEntry;
 
   /** \internal
 
@@ -1142,7 +1142,7 @@ private:
     \param isActive active (true) or inactive (false)?
     \param pattern pattern itself
   */
-  void AddPatternEntry(unsigned types, bool isActive, const char *pattern);
+	void AddPatternEntry(unsigned types, bool isActive, const char *pattern);
 
   /** \internal
 
@@ -1151,7 +1151,7 @@ private:
     \param cmdstart start of command
     \param cmdend end of command (not including this character)
   */
-  void ExecCommand(const char *cmdstart, const char *cmdend);
+	void ExecCommand(const char *cmdstart, const char *cmdend);
 
   /** \internal
 
@@ -1161,43 +1161,43 @@ private:
 
     \return true if windowed, false if full screen
   */
-  bool IsWindowed();
+	bool IsWindowed();
 
-  /// \internal name of current command group
-  char curCommandGroup[100];
+	/// \internal name of current command group
+	char curCommandGroup[100];
 
-  /// \internal if true then always flush after each line written
-  bool alwaysFlush;
+	/// \internal if true then always flush after each line written
+	bool alwaysFlush;
 
-  /// \internal if true then put timestamps before each new line
-  bool timeStamp;
+	/// \internal if true then put timestamps before each new line
+	bool timeStamp;
 
-  /// \internal the one and only stack walker
-  DebugStackwalk m_stackWalk;
+	/// \internal the one and only stack walker
+	DebugStackwalk m_stackWalk;
 
-  /// \internal current integer prefix to use
-  char m_prefix[16];
+	/// \internal current integer prefix to use
+	char m_prefix[16];
 
-  /// \internal current integer radix to use
-  int m_radix;
+	/// \internal current integer radix to use
+	int m_radix;
 
-  /// \internal official version
-  char m_version[64];
+	/// \internal official version
+	char m_version[64];
 
-  /// \internal internal version
-  char m_intVersion[64];
+	/// \internal internal version
+	char m_intVersion[64];
 
-  /// \internal build date/time
-  char m_buildDate[64];
+	/// \internal build date/time
+	char m_buildDate[64];
 
-  /// \internal output width
-  int m_width;
+	/// \internal output width
+	int m_width;
 
-  /// \internal fill char
-  char m_fillChar;
+	/// \internal fill char
+	char m_fillChar;
 
-  /// \internal <0 if fullscreen, >0 if windowed, ==0 if not checked yet
-  char m_isWindowed;
+	/// \internal <0 if fullscreen, >0 if windowed, ==0 if not checked yet
+	char m_isWindowed;
 };
 
 /// \addtogroup debug_fn Debugging functions

--- a/Core/Libraries/Source/debug/debug_dlg/debug_dlg.cpp
+++ b/Core/Libraries/Source/debug/debug_dlg/debug_dlg.cpp
@@ -36,172 +36,172 @@
 
 BOOL CALLBACK DialogProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-  switch(uMsg)
-  {
-    case WM_INITDIALOG:
-      {
-        SendDlgItemMessage(hWnd,100,WM_SETTEXT,0,(LPARAM)"EXCEPTION_TYPE");
-        SendDlgItemMessage(hWnd,101,WM_SETTEXT,0,(LPARAM)"Explains exception type further here...\n"
-                                  "123456789012345678901234567890123456789012345678901234567890");
-        SendDlgItemMessage(hWnd,102,WM_SETTEXT,0,(LPARAM)"Module/File/Line, Address");
-        SendDlgItemMessage(hWnd,103,WM_SETTEXT,0,(LPARAM)"File version, build type");
+	switch(uMsg)
+	{
+		case WM_INITDIALOG:
+		{
+			SendDlgItemMessage(hWnd,100,WM_SETTEXT,0,(LPARAM)"EXCEPTION_TYPE");
+			SendDlgItemMessage(hWnd,101,WM_SETTEXT,0,(LPARAM)"Explains exception type further here...\n"
+				"123456789012345678901234567890123456789012345678901234567890");
+			SendDlgItemMessage(hWnd,102,WM_SETTEXT,0,(LPARAM)"Module/File/Line, Address");
+			SendDlgItemMessage(hWnd,103,WM_SETTEXT,0,(LPARAM)"File version, build type");
 
-        HWND list;
-        list=GetDlgItem(hWnd,104);
+			HWND list;
+			list=GetDlgItem(hWnd,104);
 
-        LVCOLUMN c;
-        c.mask=LVCF_TEXT|LVCF_WIDTH;
-        c.pszText="";
-        c.cx=0;
-        ListView_InsertColumn(list,0,&c);
+			LVCOLUMN c;
+			c.mask=LVCF_TEXT|LVCF_WIDTH;
+			c.pszText="";
+			c.cx=0;
+			ListView_InsertColumn(list,0,&c);
 
-        c.mask=LVCF_TEXT|LVCF_WIDTH|LVCF_FMT;
-        c.pszText="Address";
-        c.cx=60;
-        c.fmt=LVCFMT_RIGHT;
-        ListView_InsertColumn(list,1,&c);
+			c.mask=LVCF_TEXT|LVCF_WIDTH|LVCF_FMT;
+			c.pszText="Address";
+			c.cx=60;
+			c.fmt=LVCFMT_RIGHT;
+			ListView_InsertColumn(list,1,&c);
 
-        c.mask=LVCF_TEXT|LVCF_WIDTH;
-        c.pszText="Module";
-        c.cx=120;
-        ListView_InsertColumn(list,2,&c);
+			c.mask=LVCF_TEXT|LVCF_WIDTH;
+			c.pszText="Module";
+			c.cx=120;
+			ListView_InsertColumn(list,2,&c);
 
-        c.pszText="Symbol";
-        c.cx=300;
-        ListView_InsertColumn(list,3,&c);
+			c.pszText="Symbol";
+			c.cx=300;
+			ListView_InsertColumn(list,3,&c);
 
-        c.pszText="File";
-        c.cx=130;
-        ListView_InsertColumn(list,4,&c);
+			c.pszText="File";
+			c.cx=130;
+			ListView_InsertColumn(list,4,&c);
 
-        c.pszText="Line";
-        c.cx=80;
-        ListView_InsertColumn(list,5,&c);
+			c.pszText="Line";
+			c.cx=80;
+			ListView_InsertColumn(list,5,&c);
 
-        LVITEM item;
-        item.iItem=0;
-        item.iSubItem=0;
-        item.mask=0;
+			LVITEM item;
+			item.iItem=0;
+			item.iSubItem=0;
+			item.mask=0;
 
-        item.iItem=ListView_InsertItem(list,&item);
-        item.mask=LVIF_TEXT;
+			item.iItem=ListView_InsertItem(list,&item);
+			item.mask=LVIF_TEXT;
 
-        item.iSubItem++;
-        item.pszText="01234567";
-        ListView_SetItem(list,&item);
+			item.iSubItem++;
+			item.pszText="01234567";
+			ListView_SetItem(list,&item);
 
-        item.iSubItem++;
-        item.pszText="MSVCRTD.dll+0xad38";
-        ListView_SetItem(list,&item);
+			item.iSubItem++;
+			item.pszText="MSVCRTD.dll+0xad38";
+			ListView_SetItem(list,&item);
 
-        item.iSubItem++;
-        item.pszText="mainCRTStartupSuperLongSymbolOYeahThisIsCool+0xd23e0";
-        ListView_SetItem(list,&item);
+			item.iSubItem++;
+			item.pszText="mainCRTStartupSuperLongSymbolOYeahThisIsCool+0xd23e0";
+			ListView_SetItem(list,&item);
 
-        item.iSubItem++;
-        item.pszText="reallyreallyverylongfilename.cpp";
-        ListView_SetItem(list,&item);
+			item.iSubItem++;
+			item.pszText="reallyreallyverylongfilename.cpp";
+			ListView_SetItem(list,&item);
 
-        item.iSubItem++;
-        item.pszText="5748+0xad38";
-        ListView_SetItem(list,&item);
+			item.iSubItem++;
+			item.pszText="5748+0xad38";
+			ListView_SetItem(list,&item);
 
-        for (int k=1;k<30;k++)
-        {
-          item.iItem=k;
-          item.iSubItem=0;
-          item.iItem=ListView_InsertItem(list,&item);
-          item.mask=LVIF_TEXT;
+			for (int k=1;k<30;k++)
+			{
+				item.iItem=k;
+				item.iSubItem=0;
+				item.iItem=ListView_InsertItem(list,&item);
+				item.mask=LVIF_TEXT;
 
-          item.iSubItem++;
-          item.pszText="88888888";
-          ListView_SetItem(list,&item);
+				item.iSubItem++;
+				item.pszText="88888888";
+				ListView_SetItem(list,&item);
 
-          item.iSubItem++;
-          item.pszText="MSVCRTD.dll+0xad38";
-          ListView_SetItem(list,&item);
+				item.iSubItem++;
+				item.pszText="MSVCRTD.dll+0xad38";
+				ListView_SetItem(list,&item);
 
-          item.iSubItem++;
-          item.pszText="Debug::DebugException::Symbol+0xd23e0";
-          ListView_SetItem(list,&item);
+				item.iSubItem++;
+				item.pszText="Debug::DebugException::Symbol+0xd23e0";
+				ListView_SetItem(list,&item);
 
-          item.iSubItem++;
-          item.pszText="regularfilename.cpp";
-          ListView_SetItem(list,&item);
+				item.iSubItem++;
+				item.pszText="regularfilename.cpp";
+				ListView_SetItem(list,&item);
 
-          item.iSubItem++;
-          item.pszText="5748+0x38";
-          ListView_SetItem(list,&item);
-        }
+				item.iSubItem++;
+				item.pszText="5748+0x38";
+				ListView_SetItem(list,&item);
+			}
 
-        HFONT hf;
-        hf=CreateFont(13,0,0,0,FW_NORMAL,
-                      FALSE,FALSE,FALSE,ANSI_CHARSET,
-                      OUT_DEFAULT_PRECIS,CLIP_DEFAULT_PRECIS,
-                      DEFAULT_QUALITY,FIXED_PITCH|FF_MODERN,nullptr);
-        SendDlgItemMessage(hWnd,105,WM_SETFONT,(WPARAM)hf,MAKELPARAM(TRUE,0));
-        SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"EAX:0x00000666 EBX:0x7ffdf000 ECX:0x00000000");
-        SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"EDX:0x00422208 ESI:0x02100210 EDI:0x0012fec4");
-        SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"EIP:0x0040103d ESP:0x0012fe78 EBP:0x0012fec4");
-        SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"Flags:%00000000000000010000001000000110");
-        SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"CS:0x001b DS:0x0023 SS:0x0023");
-        SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"ES:0x0023 FS:0x0038 GS:0x0000");
-        SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"");
-        SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"CW:%0000001001111111");
-        SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"SW:%0000000000000000");
-        SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"TW:%1111111111111111");
-        SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"ErrOfs:      0x00000000 ErrSel:  0x03020000");
-        SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"DataOfs:     0x00000000 DataSel: 0xffff0000");
-        SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"Cr0NpxState: 0x00000000");
-        SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"ST(0) 10020203100210021002 -1.#IND00");
-        SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"ST(1) 01031002010320020103 -1.#IND00");
-        SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"ST(2) 10021002100210021002 -1.#IND00");
-        SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"ST(3) 02031002020320020203 -1.#IND00");
-        SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"ST(4) 10021002100210021002 -1.#IND00");
-        SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"ST(5) 12031002100210021002 -1.#IND00");
-        SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"ST(6) 14021402100212031002 -1.#IND00");
-        SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"ST(7) 12031002100210021002 -1.#IND00");
-      }
-      return TRUE;
-    case WM_COMMAND:
-      switch(LOWORD(wParam))
-      {
-        case IDOK:
-          EndDialog(hWnd,IDOK);
-          break;
-      }
-      return FALSE;
-    default:
-      return FALSE;
-  }
+			HFONT hf;
+			hf=CreateFont(13,0,0,0,FW_NORMAL,
+				FALSE,FALSE,FALSE,ANSI_CHARSET,
+				OUT_DEFAULT_PRECIS,CLIP_DEFAULT_PRECIS,
+				DEFAULT_QUALITY,FIXED_PITCH|FF_MODERN,nullptr);
+			SendDlgItemMessage(hWnd,105,WM_SETFONT,(WPARAM)hf,MAKELPARAM(TRUE,0));
+			SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"EAX:0x00000666 EBX:0x7ffdf000 ECX:0x00000000");
+			SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"EDX:0x00422208 ESI:0x02100210 EDI:0x0012fec4");
+			SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"EIP:0x0040103d ESP:0x0012fe78 EBP:0x0012fec4");
+			SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"Flags:%00000000000000010000001000000110");
+			SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"CS:0x001b DS:0x0023 SS:0x0023");
+			SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"ES:0x0023 FS:0x0038 GS:0x0000");
+			SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"");
+			SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"CW:%0000001001111111");
+			SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"SW:%0000000000000000");
+			SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"TW:%1111111111111111");
+			SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"ErrOfs:      0x00000000 ErrSel:  0x03020000");
+			SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"DataOfs:     0x00000000 DataSel: 0xffff0000");
+			SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"Cr0NpxState: 0x00000000");
+			SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"ST(0) 10020203100210021002 -1.#IND00");
+			SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"ST(1) 01031002010320020103 -1.#IND00");
+			SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"ST(2) 10021002100210021002 -1.#IND00");
+			SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"ST(3) 02031002020320020203 -1.#IND00");
+			SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"ST(4) 10021002100210021002 -1.#IND00");
+			SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"ST(5) 12031002100210021002 -1.#IND00");
+			SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"ST(6) 14021402100212031002 -1.#IND00");
+			SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)"ST(7) 12031002100210021002 -1.#IND00");
+		}
+			return TRUE;
+		case WM_COMMAND:
+			switch(LOWORD(wParam))
+			{
+				case IDOK:
+					EndDialog(hWnd,IDOK);
+					break;
+			}
+			return FALSE;
+		default:
+			return FALSE;
+	}
 }
 
 int CALLBACK WinMain(HINSTANCE hInst, HINSTANCE, LPSTR, int)
 {
-  // show dialog box first
-  InitCommonControls();
-  DialogBox(hInst,MAKEINTRESOURCE(100),nullptr,DialogProc);
+	// show dialog box first
+	InitCommonControls();
+	DialogBox(hInst,MAKEINTRESOURCE(100),nullptr,DialogProc);
 
-  // write out resource data (if possible)
-  FILE *f=fopen("..\\rc_exception.inl","wt");
-  if (f)
-  {
-    fprintf(f,"static unsigned char rcException[]={ // program generated, do not edit\n");
+	// write out resource data (if possible)
+	FILE *f=fopen("..\\rc_exception.inl","wt");
+	if (f)
+	{
+		fprintf(f,"static unsigned char rcException[]={ // program generated, do not edit\n");
 
-    HRSRC h=FindResource(hInst,MAKEINTRESOURCE(100),RT_DIALOG);
-    DWORD size=SizeofResource(hInst,h);
+		HRSRC h=FindResource(hInst,MAKEINTRESOURCE(100),RT_DIALOG);
+		DWORD size=SizeofResource(hInst,h);
 
-    unsigned char *data=(unsigned char *)LockResource(LoadResource(hInst,h));
-    for (unsigned k=0;k<size;k+=8)
-    {
-      for (unsigned i=0;i<8;i++)
-        fprintf(f,"0x%02x,",k+i<size?data[k+i]:0);
-      fprintf(f,"\n");
-    }
+		unsigned char *data=(unsigned char *)LockResource(LoadResource(hInst,h));
+		for (unsigned k=0;k<size;k+=8)
+		{
+			for (unsigned i=0;i<8;i++)
+			fprintf(f,"0x%02x,",k+i<size?data[k+i]:0);
+			fprintf(f,"\n");
+		}
 
-    fprintf(f,"0 };\n");
-    fclose(f);
-  }
+		fprintf(f,"0 };\n");
+		fclose(f);
+	}
 
-  return 0;
+	return 0;
 }

--- a/Core/Libraries/Source/debug/debug_except.cpp
+++ b/Core/Libraries/Source/debug/debug_except.cpp
@@ -33,7 +33,7 @@
 
 DebugExceptionhandler::DebugExceptionhandler()
 {
-  // don't do anything here!
+	// don't do anything here!
 }
 
 const char *DebugExceptionhandler::GetExceptionType(struct _EXCEPTION_POINTERS *exptr, char *explanation)
@@ -41,146 +41,146 @@ const char *DebugExceptionhandler::GetExceptionType(struct _EXCEPTION_POINTERS *
   #define EX(code,text)   \
     case EXCEPTION_##code: strcpy(explanation,text); return "EXCEPTION_" #code;
 
-  switch(exptr->ExceptionRecord->ExceptionCode)
-  {
+	switch(exptr->ExceptionRecord->ExceptionCode)
+	{
 		case EXCEPTION_ACCESS_VIOLATION:
-      wsprintf(explanation,
-             "The thread tried to read from or write to a virtual\n"
-             "address for which it does not have the appropriate access.\n"
-             "Access address 0x%08x was %s.",
-                exptr->ExceptionRecord->ExceptionInformation[1],
-                exptr->ExceptionRecord->ExceptionInformation[0]?"written to":"read from");
-      return "EXCEPTION_ACCESS_VIOLATION";
+			wsprintf(explanation,
+				"The thread tried to read from or write to a virtual\n"
+				"address for which it does not have the appropriate access.\n"
+				"Access address 0x%08x was %s.",
+				exptr->ExceptionRecord->ExceptionInformation[1],
+				exptr->ExceptionRecord->ExceptionInformation[0]?"written to":"read from");
+			return "EXCEPTION_ACCESS_VIOLATION";
 		EX(ARRAY_BOUNDS_EXCEEDED,"The thread tried to access an array element that\n"
-                             "is out of bounds and the underlying hardware\n"
-                             "supports bounds checking.")
+				"is out of bounds and the underlying hardware\n"
+				"supports bounds checking.")
 		EX(BREAKPOINT,"A breakpoint was encountered.")
 		EX(DATATYPE_MISALIGNMENT,"The thread tried to read or write data that is\n"
-                             "misaligned on hardware that does not provide alignment.\n"
-                             "For example, 16-bit values must be aligned on\n"
-                             "2-byte boundaries; 32-bit values on 4-byte\n"
-                             "boundaries, and so on.")
+				"misaligned on hardware that does not provide alignment.\n"
+				"For example, 16-bit values must be aligned on\n"
+				"2-byte boundaries; 32-bit values on 4-byte\n"
+				"boundaries, and so on.")
 		EX(FLT_DENORMAL_OPERAND,"One of the operands in a floating-point operation is\n"
-                            "denormal. A denormal value is one that is too small\n"
-                            "to represent as a standard floating-point value.")
+				"denormal. A denormal value is one that is too small\n"
+				"to represent as a standard floating-point value.")
 		EX(FLT_DIVIDE_BY_ZERO,"The thread tried to divide a floating-point\n"
-                          "value by a floating-point divisor of zero.")
+				"value by a floating-point divisor of zero.")
 		EX(FLT_INEXACT_RESULT,"The result of a floating-point operation\n"
-                          "cannot be represented exactly as a decimal fraction.")
+				"cannot be represented exactly as a decimal fraction.")
 		EX(FLT_INVALID_OPERATION,"Some strange unknown floating point operation was attempted.")
 		EX(FLT_OVERFLOW,"The exponent of a floating-point operation is greater\n"
-                    "than the magnitude allowed by the corresponding type.")
+				"than the magnitude allowed by the corresponding type.")
 		EX(FLT_STACK_CHECK,"The stack overflowed or underflowed as the result\n"
-                       "of a floating-point operation.")
+				"of a floating-point operation.")
 		EX(FLT_UNDERFLOW,"The exponent of a floating-point operation is less\n"
-                     "than the magnitude allowed by the corresponding type.")
-    EX(GUARD_PAGE,"A guard page was accessed.")
+				"than the magnitude allowed by the corresponding type.")
+			EX(GUARD_PAGE,"A guard page was accessed.")
 		EX(ILLEGAL_INSTRUCTION,"The thread tried to execute an invalid instruction.")
 		EX(IN_PAGE_ERROR,"The thread tried to access a page that was not\n"
-                     "present, and the system was unable to load the page.\n"
-                     "For example, this exception might occur if a network "
-                     "connection is lost while running a program over the network.")
+				"present, and the system was unable to load the page.\n"
+				"For example, this exception might occur if a network "
+				"connection is lost while running a program over the network.")
 		EX(INT_DIVIDE_BY_ZERO,"The thread tried to divide an integer value by\n"
-                          "an integer divisor of zero.")
+				"an integer divisor of zero.")
 		EX(INT_OVERFLOW,"The result of an integer operation caused a carry\n"
-                    "out of the most significant bit of the result.")
+				"out of the most significant bit of the result.")
 		EX(INVALID_DISPOSITION,"An exception handler returned an invalid disposition\n"
-                           "to the exception dispatcher. Programmers using a\n"
-                           "high-level language such as C should never encounter\n"
-                           "this exception.")
-    EX(INVALID_HANDLE,"An invalid Windows handle was used.")
+				"to the exception dispatcher. Programmers using a\n"
+				"high-level language such as C should never encounter\n"
+				"this exception.")
+			EX(INVALID_HANDLE,"An invalid Windows handle was used.")
 		EX(NONCONTINUABLE_EXCEPTION,"The thread tried to continue execution after\n"
-                                "a noncontinuable exception occurred.")
+				"a noncontinuable exception occurred.")
 		EX(PRIV_INSTRUCTION,"The thread tried to execute an instruction whose\n"
-                        "operation is not allowed in the current machine mode.")
+				"operation is not allowed in the current machine mode.")
 		EX(SINGLE_STEP,"A trace trap or other single-instruction mechanism\n"
-                   "signaled that one instruction has been executed.")
+				"signaled that one instruction has been executed.")
 		EX(STACK_OVERFLOW,"The thread used up its stack.")
-    case 0xE06D7363: strcpy(explanation,"Microsoft C++ Exception"); return "EXCEPTION_MS";
-    default:
-      wsprintf(explanation,"Unknown exception code 0x%08x",exptr->ExceptionRecord->ExceptionCode);
-      return "EXCEPTION_UNKNOWN";
-  }
+		case 0xE06D7363: strcpy(explanation,"Microsoft C++ Exception"); return "EXCEPTION_MS";
+		default:
+			wsprintf(explanation,"Unknown exception code 0x%08x",exptr->ExceptionRecord->ExceptionCode);
+			return "EXCEPTION_UNKNOWN";
+	}
 
   #undef EX
 }
 
 void DebugExceptionhandler::LogExceptionLocation(Debug &dbg, struct _EXCEPTION_POINTERS *exptr)
 {
-  struct _CONTEXT &ctx=*exptr->ContextRecord;
+	struct _CONTEXT &ctx=*exptr->ContextRecord;
 
-  char buf[512];
-  DebugStackwalk::Signature::GetSymbol(ctx.Eip,buf,sizeof(buf));
-  dbg << "Exception occured at\n" << buf << ".";
+	char buf[512];
+	DebugStackwalk::Signature::GetSymbol(ctx.Eip,buf,sizeof(buf));
+	dbg << "Exception occured at\n" << buf << ".";
 }
 
 void DebugExceptionhandler::LogRegisters(Debug &dbg, struct _EXCEPTION_POINTERS *exptr)
 {
-  struct _CONTEXT &ctx=*exptr->ContextRecord;
+	struct _CONTEXT &ctx=*exptr->ContextRecord;
 
-  dbg << Debug::FillChar('0')
-      << Debug::Hex()
-      <<  "EAX:" << Debug::Width(8) << ctx.Eax
-      << " EBX:" << Debug::Width(8) << ctx.Ebx
-      << " ECX:" << Debug::Width(8) << ctx.Ecx << "\n"
-      <<  "EDX:" << Debug::Width(8) << ctx.Edx
-      << " ESI:" << Debug::Width(8) << ctx.Esi
-      << " EDI:" << Debug::Width(8) << ctx.Edi << "\n"
-      <<  "EIP:" << Debug::Width(8) << ctx.Eip
-      << " ESP:" << Debug::Width(8) << ctx.Esp
-      << " EBP:" << Debug::Width(8) << ctx.Ebp << "\n"
-      <<  "Flags:" << Debug::Bin() << Debug::Width(32) << ctx.EFlags << Debug::Hex() << "\n"
-      <<  "CS:" << Debug::Width(4) << ctx.SegCs
-      << " DS:" << Debug::Width(4) << ctx.SegDs
-      << " SS:" << Debug::Width(4) << ctx.SegSs
-      << "\nES:" << Debug::Width(4) << ctx.SegEs
-      << " FS:" << Debug::Width(4) << ctx.SegFs
-      << " GS:" << Debug::Width(4) << ctx.SegGs << "\n" << Debug::FillChar() << Debug::Dec();
+	dbg << Debug::FillChar('0')
+		<< Debug::Hex()
+		<<  "EAX:" << Debug::Width(8) << ctx.Eax
+		<< " EBX:" << Debug::Width(8) << ctx.Ebx
+		<< " ECX:" << Debug::Width(8) << ctx.Ecx << "\n"
+		<<  "EDX:" << Debug::Width(8) << ctx.Edx
+		<< " ESI:" << Debug::Width(8) << ctx.Esi
+		<< " EDI:" << Debug::Width(8) << ctx.Edi << "\n"
+		<<  "EIP:" << Debug::Width(8) << ctx.Eip
+		<< " ESP:" << Debug::Width(8) << ctx.Esp
+		<< " EBP:" << Debug::Width(8) << ctx.Ebp << "\n"
+		<<  "Flags:" << Debug::Bin() << Debug::Width(32) << ctx.EFlags << Debug::Hex() << "\n"
+		<<  "CS:" << Debug::Width(4) << ctx.SegCs
+		<< " DS:" << Debug::Width(4) << ctx.SegDs
+		<< " SS:" << Debug::Width(4) << ctx.SegSs
+		<< "\nES:" << Debug::Width(4) << ctx.SegEs
+		<< " FS:" << Debug::Width(4) << ctx.SegFs
+		<< " GS:" << Debug::Width(4) << ctx.SegGs << "\n" << Debug::FillChar() << Debug::Dec();
 }
 
 void DebugExceptionhandler::LogFPURegisters(Debug &dbg, struct _EXCEPTION_POINTERS *exptr)
 {
-  struct _CONTEXT &ctx=*exptr->ContextRecord;
+	struct _CONTEXT &ctx=*exptr->ContextRecord;
 
-  if (!(ctx.ContextFlags&CONTEXT_FLOATING_POINT))
-  {
-    dbg << "FP registers not available\n";
-    return;
-  }
+	if (!(ctx.ContextFlags&CONTEXT_FLOATING_POINT))
+	{
+		dbg << "FP registers not available\n";
+		return;
+	}
 
-  FLOATING_SAVE_AREA &flt=ctx.FloatSave;
-  dbg << Debug::Bin() << Debug::FillChar('0')
-      << "CW:" << Debug::Width(16) << (flt.ControlWord&0xffff) << "\n"
-      << "SW:" << Debug::Width(16) << (flt.StatusWord&0xffff) << "\n"
-      << "TW:" << Debug::Width(16) << (flt.TagWord&0xffff) << "\n"
-      << Debug::Hex()
-      << "ErrOfs:      " << Debug::Width(8) << flt.ErrorOffset
-      << " ErrSel:  "    << Debug::Width(8) << flt.ErrorSelector << "\n"
-      << "DataOfs:     " << Debug::Width(8) << flt.DataOffset
-      << " DataSel: "    << Debug::Width(8) << flt.DataSelector << "\n"
+	FLOATING_SAVE_AREA &flt=ctx.FloatSave;
+	dbg << Debug::Bin() << Debug::FillChar('0')
+		<< "CW:" << Debug::Width(16) << (flt.ControlWord&0xffff) << "\n"
+		<< "SW:" << Debug::Width(16) << (flt.StatusWord&0xffff) << "\n"
+		<< "TW:" << Debug::Width(16) << (flt.TagWord&0xffff) << "\n"
+		<< Debug::Hex()
+		<< "ErrOfs:      " << Debug::Width(8) << flt.ErrorOffset
+		<< " ErrSel:  "    << Debug::Width(8) << flt.ErrorSelector << "\n"
+		<< "DataOfs:     " << Debug::Width(8) << flt.DataOffset
+		<< " DataSel: "    << Debug::Width(8) << flt.DataSelector << "\n"
 #if !defined(WOW64_SIZE_OF_80387_REGISTERS)
-      << "Cr0NpxState: " << Debug::Width(8) << flt.Cr0NpxState << "\n"
+		<< "Cr0NpxState: " << Debug::Width(8) << flt.Cr0NpxState << "\n"
 #endif
-  ;
+		;
 
-  for (unsigned k=0;k<SIZE_OF_80387_REGISTERS/10;++k)
-  {
-    dbg << Debug::Dec() << "ST(" << k << ") ";
-    dbg.SetPrefixAndRadix("",16);
+	for (unsigned k=0;k<SIZE_OF_80387_REGISTERS/10;++k)
+	{
+		dbg << Debug::Dec() << "ST(" << k << ") ";
+		dbg.SetPrefixAndRadix("",16);
 
-    BYTE *value=flt.RegisterArea+k*10;
-    for (unsigned i=0;i<10;i++)
-      dbg << Debug::Width(2) << value[i];
+		BYTE *value=flt.RegisterArea+k*10;
+		for (unsigned i=0;i<10;i++)
+		dbg << Debug::Width(2) << value[i];
 
-    // TheSuperHackers @refactor Replaced MSVC inline assembly with portable C++ cast for MinGW compatibility
-    // Convert from temporary real (10 byte) to double (8 bytes).
-    // On x86, long double is the 10-byte x87 format, so we can just cast.
-    double fpVal = (double)(*(long double*)value);
-    dbg << " " << fpVal;
+		// TheSuperHackers @refactor Replaced MSVC inline assembly with portable C++ cast for MinGW compatibility
+		// Convert from temporary real (10 byte) to double (8 bytes).
+		// On x86, long double is the 10-byte x87 format, so we can just cast.
+		double fpVal = (double)(*(long double*)value);
+		dbg << " " << fpVal;
 
-    dbg << "\n";
-  }
-  dbg << Debug::FillChar() << Debug::Dec();
+		dbg << "\n";
+	}
+	dbg << Debug::FillChar() << Debug::Dec();
 }
 
 // include exception dialog box
@@ -197,218 +197,218 @@ static DebugStackwalk::Signature sig;
 
 static BOOL CALLBACK ExceptionDlgProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-  switch(uMsg)
-  {
-    case WM_INITDIALOG:
-      break;
-    case WM_COMMAND:
-      if (LOWORD(wParam)==IDOK)
-        EndDialog(hWnd,IDOK);
-    default:
-      return FALSE;
-  }
+	switch(uMsg)
+	{
+		case WM_INITDIALOG:
+			break;
+		case WM_COMMAND:
+			if (LOWORD(wParam)==IDOK)
+			EndDialog(hWnd,IDOK);
+		default:
+			return FALSE;
+	}
 
-  // init dialog box
+	// init dialog box
 
-  // version
-  SendDlgItemMessage(hWnd,103,WM_SETTEXT,0,(LPARAM)verInfo);
+	// version
+	SendDlgItemMessage(hWnd,103,WM_SETTEXT,0,(LPARAM)verInfo);
 
-  // registers
-  char *p=regInfo;
-  for (char *q=p;;q++)
-  {
-    if (!*q||*q=='\n')
-    {
-      bool quit=!*q; *q=0;
-      SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)p);
-      if (quit)
-        break;
-      p=q+1;
-    }
-  }
+	// registers
+	char *p=regInfo;
+	for (char *q=p;;q++)
+	{
+		if (!*q||*q=='\n')
+		{
+			bool quit=!*q; *q=0;
+			SendDlgItemMessage(hWnd,105,LB_ADDSTRING,0,(LPARAM)p);
+			if (quit)
+			break;
+			p=q+1;
+		}
+	}
 
-  // yes, this generates a GDI leak but we're crashing anyway
-  SendDlgItemMessage(hWnd,105,WM_SETFONT,(WPARAM)CreateFont(13,0,0,0,FW_NORMAL,
-                FALSE,FALSE,FALSE,ANSI_CHARSET,
-                OUT_DEFAULT_PRECIS,CLIP_DEFAULT_PRECIS,
-                DEFAULT_QUALITY,FIXED_PITCH|FF_MODERN,nullptr),MAKELPARAM(TRUE,0));
+	// yes, this generates a GDI leak but we're crashing anyway
+	SendDlgItemMessage(hWnd,105,WM_SETFONT,(WPARAM)CreateFont(13,0,0,0,FW_NORMAL,
+		FALSE,FALSE,FALSE,ANSI_CHARSET,
+		OUT_DEFAULT_PRECIS,CLIP_DEFAULT_PRECIS,
+		DEFAULT_QUALITY,FIXED_PITCH|FF_MODERN,nullptr),MAKELPARAM(TRUE,0));
 
-  // exception type
-  SendDlgItemMessage(hWnd,100,WM_SETTEXT,0,(LPARAM)
-            DebugExceptionhandler::GetExceptionType(exPtrs,regInfo));
-  SendDlgItemMessage(hWnd,101,WM_SETTEXT,0,(LPARAM)regInfo);
+	// exception type
+	SendDlgItemMessage(hWnd,100,WM_SETTEXT,0,(LPARAM)
+		DebugExceptionhandler::GetExceptionType(exPtrs,regInfo));
+	SendDlgItemMessage(hWnd,101,WM_SETTEXT,0,(LPARAM)regInfo);
 
-  // address
-  struct _CONTEXT &ctx=*exPtrs->ContextRecord;
-  DebugStackwalk::Signature::GetSymbol(ctx.Eip,regInfo,sizeof(regInfo));
-  SendDlgItemMessage(hWnd,102,WM_SETTEXT,0,(LPARAM)regInfo);
+	// address
+	struct _CONTEXT &ctx=*exPtrs->ContextRecord;
+	DebugStackwalk::Signature::GetSymbol(ctx.Eip,regInfo,sizeof(regInfo));
+	SendDlgItemMessage(hWnd,102,WM_SETTEXT,0,(LPARAM)regInfo);
 
-  // stack
-  // (this code is a little messy because we're dealing with a raw list control)
-  HWND list;
-  list=GetDlgItem(hWnd,104);
-  if (!sig.Size())
-  {
-    LVCOLUMN c;
-    c.mask=LVCF_TEXT|LVCF_WIDTH;
-    char columnText[] = "";
-    c.pszText=columnText;
-    c.cx=690;
-    ListView_InsertColumn(list,0,&c);
+	// stack
+	// (this code is a little messy because we're dealing with a raw list control)
+	HWND list;
+	list=GetDlgItem(hWnd,104);
+	if (!sig.Size())
+	{
+		LVCOLUMN c;
+		c.mask=LVCF_TEXT|LVCF_WIDTH;
+		char columnText[] = "";
+		c.pszText=columnText;
+		c.cx=690;
+		ListView_InsertColumn(list,0,&c);
 
-    LVITEM item;
-    item.iItem=0;
-    item.iSubItem=0;
-    item.mask=LVIF_TEXT;
-    char itemText[] = "No stack data available - check for dbghelp.dll";
-    item.pszText=itemText;
+		LVITEM item;
+		item.iItem=0;
+		item.iSubItem=0;
+		item.mask=LVIF_TEXT;
+		char itemText[] = "No stack data available - check for dbghelp.dll";
+		item.pszText=itemText;
 
-    item.iItem=ListView_InsertItem(list,&item);
-  }
-  else
-  {
-    // add columns first
-    LVCOLUMN c;
-    c.mask=LVCF_TEXT|LVCF_WIDTH;
-    char columnText1[] = "";
-    c.pszText=columnText1;
-    c.cx=0; // first column is empty (can't right-align 1st column)
-    ListView_InsertColumn(list,0,&c);
+		item.iItem=ListView_InsertItem(list,&item);
+	}
+	else
+	{
+		// add columns first
+		LVCOLUMN c;
+		c.mask=LVCF_TEXT|LVCF_WIDTH;
+		char columnText1[] = "";
+		c.pszText=columnText1;
+		c.cx=0; // first column is empty (can't right-align 1st column)
+		ListView_InsertColumn(list,0,&c);
 
-    c.mask=LVCF_TEXT|LVCF_WIDTH|LVCF_FMT;
-    char columnText2[] = "Address";
-    c.pszText=columnText2;
-    c.cx=60;
-    c.fmt=LVCFMT_RIGHT;
-    ListView_InsertColumn(list,1,&c);
+		c.mask=LVCF_TEXT|LVCF_WIDTH|LVCF_FMT;
+		char columnText2[] = "Address";
+		c.pszText=columnText2;
+		c.cx=60;
+		c.fmt=LVCFMT_RIGHT;
+		ListView_InsertColumn(list,1,&c);
 
-    c.mask=LVCF_TEXT|LVCF_WIDTH;
-    char columnText3[] = "Module";
-    c.pszText=columnText3;
-    c.cx=120;
-    ListView_InsertColumn(list,2,&c);
+		c.mask=LVCF_TEXT|LVCF_WIDTH;
+		char columnText3[] = "Module";
+		c.pszText=columnText3;
+		c.cx=120;
+		ListView_InsertColumn(list,2,&c);
 
-    char columnText4[] = "Symbol";
-    c.pszText=columnText4;
-    c.cx=300;
-    ListView_InsertColumn(list,3,&c);
+		char columnText4[] = "Symbol";
+		c.pszText=columnText4;
+		c.cx=300;
+		ListView_InsertColumn(list,3,&c);
 
-    char columnText5[] = "File";
-    c.pszText=columnText5;
-    c.cx=130;
-    ListView_InsertColumn(list,4,&c);
+		char columnText5[] = "File";
+		c.pszText=columnText5;
+		c.cx=130;
+		ListView_InsertColumn(list,4,&c);
 
-    char columnText6[] = "Line";
-    c.pszText=columnText6;
-    c.cx=80;
-    ListView_InsertColumn(list,5,&c);
+		char columnText6[] = "Line";
+		c.pszText=columnText6;
+		c.cx=80;
+		ListView_InsertColumn(list,5,&c);
 
-    // now add stack walk lines
-    for (unsigned k=0;k<sig.Size();k++)
-    {
-      DebugStackwalk::Signature::GetSymbol(sig.GetAddress(k),regInfo,sizeof(regInfo));
+		// now add stack walk lines
+		for (unsigned k=0;k<sig.Size();k++)
+		{
+			DebugStackwalk::Signature::GetSymbol(sig.GetAddress(k),regInfo,sizeof(regInfo));
 
-      LVITEM item;
-      item.iItem=k;
-      item.iSubItem=0;
-      item.mask=0;
-      item.iItem=ListView_InsertItem(list,&item);
-      item.mask=LVIF_TEXT;
+			LVITEM item;
+			item.iItem=k;
+			item.iSubItem=0;
+			item.mask=0;
+			item.iItem=ListView_InsertItem(list,&item);
+			item.mask=LVIF_TEXT;
 
-      item.iSubItem++;
-      item.pszText=strtok(regInfo," ");
-      ListView_SetItem(list,&item);
+			item.iSubItem++;
+			item.pszText=strtok(regInfo," ");
+			ListView_SetItem(list,&item);
 
-      item.iSubItem++;
-      item.pszText=strtok(nullptr,",");
-      ListView_SetItem(list,&item);
+			item.iSubItem++;
+			item.pszText=strtok(nullptr,",");
+			ListView_SetItem(list,&item);
 
-      item.iSubItem++;
-      item.pszText=strtok(nullptr,",");
-      ListView_SetItem(list,&item);
+			item.iSubItem++;
+			item.pszText=strtok(nullptr,",");
+			ListView_SetItem(list,&item);
 
-      item.iSubItem++;
-      item.pszText=strtok(nullptr,":");
-      ListView_SetItem(list,&item);
+			item.iSubItem++;
+			item.pszText=strtok(nullptr,":");
+			ListView_SetItem(list,&item);
 
-      item.iSubItem++;
-      item.pszText=strtok(nullptr,"");
-      ListView_SetItem(list,&item);
-    }
-  }
+			item.iSubItem++;
+			item.pszText=strtok(nullptr,"");
+			ListView_SetItem(list,&item);
+		}
+	}
 
-  return TRUE;
+	return TRUE;
 }
 
 LONG __stdcall DebugExceptionhandler::ExceptionFilter(struct _EXCEPTION_POINTERS* pExPtrs)
 {
-  // we should not be calling ourselves!
-  static bool inExceptionFilter;
-  if (inExceptionFilter)
-  {
-    MessageBox(nullptr,"Exception in exception handler","Fatal error",MB_OK);
-    return EXCEPTION_CONTINUE_SEARCH;
-  }
-  inExceptionFilter=true;
+	// we should not be calling ourselves!
+	static bool inExceptionFilter;
+	if (inExceptionFilter)
+	{
+		MessageBox(nullptr,"Exception in exception handler","Fatal error",MB_OK);
+		return EXCEPTION_CONTINUE_SEARCH;
+	}
+	inExceptionFilter=true;
 
-  if (pExPtrs->ExceptionRecord->ExceptionCode==EXCEPTION_STACK_OVERFLOW)
-  {
-    // almost everything we are about to do will generate a second
-    // stack overflow... double fault... so give at least a little warning
-    OutputDebugString("EA/DEBUG: EXCEPTION_STACK_OVERFLOW\n");
-  }
+	if (pExPtrs->ExceptionRecord->ExceptionCode==EXCEPTION_STACK_OVERFLOW)
+	{
+		// almost everything we are about to do will generate a second
+		// stack overflow... double fault... so give at least a little warning
+		OutputDebugString("EA/DEBUG: EXCEPTION_STACK_OVERFLOW\n");
+	}
 
-  // Let's log some info
-  Debug &dbg=Debug::Instance;
+	// Let's log some info
+	Debug &dbg=Debug::Instance;
 
-  // we're logging an exception
-  ++dbg.disableAssertsEtc;
-  if (dbg.curType!=DebugIOInterface::StringType::MAX)
-    dbg.FlushOutput();
-  dbg.StartOutput(DebugIOInterface::StringType::Exception,"");
+	// we're logging an exception
+	++dbg.disableAssertsEtc;
+	if (dbg.curType!=DebugIOInterface::StringType::MAX)
+	dbg.FlushOutput();
+	dbg.StartOutput(DebugIOInterface::StringType::Exception,"");
 
-  // start off with the exception type & location
-  dbg << "\n" << Debug::RepeatChar('=',80) << "\n";
-  dbg << GetExceptionType(pExPtrs,regInfo) << ":\n" << regInfo << "\n\n";
-  LogExceptionLocation(dbg,pExPtrs); dbg << "\n\n";
+	// start off with the exception type & location
+	dbg << "\n" << Debug::RepeatChar('=',80) << "\n";
+	dbg << GetExceptionType(pExPtrs,regInfo) << ":\n" << regInfo << "\n\n";
+	LogExceptionLocation(dbg,pExPtrs); dbg << "\n\n";
 
-  // build info must be saved off for dialog...
-  unsigned curOfs=dbg.ioBuffer[DebugIOInterface::Exception].used;
-  dbg.WriteBuildInfo();
-  unsigned len=dbg.ioBuffer[DebugIOInterface::Exception].used-curOfs;
-  if (len>=sizeof(verInfo))
-    len=sizeof(verInfo)-1;
-  memcpy(verInfo,dbg.ioBuffer[DebugIOInterface::Exception].buffer+curOfs,len);
-  verInfo[len]=0;
-  dbg << "\n\n";
+	// build info must be saved off for dialog...
+	unsigned curOfs=dbg.ioBuffer[DebugIOInterface::Exception].used;
+	dbg.WriteBuildInfo();
+	unsigned len=dbg.ioBuffer[DebugIOInterface::Exception].used-curOfs;
+	if (len>=sizeof(verInfo))
+	len=sizeof(verInfo)-1;
+	memcpy(verInfo,dbg.ioBuffer[DebugIOInterface::Exception].buffer+curOfs,len);
+	verInfo[len]=0;
+	dbg << "\n\n";
 
-  // save off register info as well...
-  curOfs=dbg.ioBuffer[DebugIOInterface::Exception].used;
-  LogRegisters(dbg,pExPtrs); dbg << "\n";
-  LogFPURegisters(dbg,pExPtrs); dbg << "\n";
-  len=dbg.ioBuffer[DebugIOInterface::Exception].used-curOfs;
-  if (len>=sizeof(regInfo))
-    len=sizeof(regInfo)-1;
-  memcpy(regInfo,dbg.ioBuffer[DebugIOInterface::Exception].buffer+curOfs,len);
-  regInfo[len]=0;
+	// save off register info as well...
+	curOfs=dbg.ioBuffer[DebugIOInterface::Exception].used;
+	LogRegisters(dbg,pExPtrs); dbg << "\n";
+	LogFPURegisters(dbg,pExPtrs); dbg << "\n";
+	len=dbg.ioBuffer[DebugIOInterface::Exception].used-curOfs;
+	if (len>=sizeof(regInfo))
+	len=sizeof(regInfo)-1;
+	memcpy(regInfo,dbg.ioBuffer[DebugIOInterface::Exception].buffer+curOfs,len);
+	regInfo[len]=0;
 
-  // now finally add stack & EIP dump
-  dbg.m_stackWalk.StackWalk(sig,pExPtrs->ContextRecord);
-  dbg << sig << "\n";
+	// now finally add stack & EIP dump
+	dbg.m_stackWalk.StackWalk(sig,pExPtrs->ContextRecord);
+	dbg << sig << "\n";
 
-  dbg << "Bytes around EIP:" << Debug::MemDump::Char(((char *)(pExPtrs->ContextRecord->Eip))-32,80);
+	dbg << "Bytes around EIP:" << Debug::MemDump::Char(((char *)(pExPtrs->ContextRecord->Eip))-32,80);
 
-  dbg.FlushOutput();
+	dbg.FlushOutput();
 
-  // shut down real Debug module now
-  // (atexit code never gets called in exception case)
-  Debug::StaticExit();
+	// shut down real Debug module now
+	// (atexit code never gets called in exception case)
+	Debug::StaticExit();
 
-  // Show a dialog box
-  InitCommonControls();
-  exPtrs=pExPtrs;
-  DialogBoxIndirect(NULL,(LPDLGTEMPLATE)rcException,nullptr,ExceptionDlgProc);
+	// Show a dialog box
+	InitCommonControls();
+	exPtrs=pExPtrs;
+	DialogBoxIndirect(NULL,(LPDLGTEMPLATE)rcException,nullptr,ExceptionDlgProc);
 
-  // Now die
-  return EXCEPTION_EXECUTE_HANDLER;
+	// Now die
+	return EXCEPTION_EXECUTE_HANDLER;
 }

--- a/Core/Libraries/Source/debug/debug_getdefaultcommands.cpp
+++ b/Core/Libraries/Source/debug/debug_getdefaultcommands.cpp
@@ -31,5 +31,5 @@
 // by another program using the Debug module
 const char *DebugGetDefaultCommands()
 {
-  return "!debug.io flat add";
+	return "!debug.io flat add";
 }

--- a/Core/Libraries/Source/debug/debug_internal.cpp
+++ b/Core/Libraries/Source/debug/debug_internal.cpp
@@ -32,57 +32,57 @@
 
 void DebugInternalAssert(const char *file, int line, const char *expr)
 {
-  // dangerous as well but since this function is used in this
-  // module only we know how long stuff can get
-  char buf[512];
-  wsprintf(buf,"File %s, line %i:\n%s",file,line,expr);
-  MessageBox(nullptr,buf,"Internal assert failed",
-                        MB_OK|MB_ICONSTOP|MB_TASKMODAL|MB_SETFOREGROUND);
+	// dangerous as well but since this function is used in this
+	// module only we know how long stuff can get
+	char buf[512];
+	wsprintf(buf,"File %s, line %i:\n%s",file,line,expr);
+	MessageBox(nullptr,buf,"Internal assert failed",
+		MB_OK|MB_ICONSTOP|MB_TASKMODAL|MB_SETFOREGROUND);
 
-  // stop right now!
-  TerminateProcess(GetCurrentProcess(),666);
+	// stop right now!
+	TerminateProcess(GetCurrentProcess(),666);
 }
 
 void *DebugAllocMemory(unsigned numBytes)
 {
-  HGLOBAL h=GlobalAlloc(GMEM_FIXED,numBytes);
-  if (!h)
-    DCRASH_RELEASE("Debug mem alloc failed");
-  return (void *)h;
+	HGLOBAL h=GlobalAlloc(GMEM_FIXED,numBytes);
+	if (!h)
+	DCRASH_RELEASE("Debug mem alloc failed");
+	return (void *)h;
 }
 
 void *DebugReAllocMemory(void *oldPtr, unsigned newSize)
 {
-  // Windows doesn't like ReAlloc with null handle/ptr...
-  if (!oldPtr)
-    return newSize?DebugAllocMemory(newSize):nullptr;
+	// Windows doesn't like ReAlloc with null handle/ptr...
+	if (!oldPtr)
+	return newSize?DebugAllocMemory(newSize):nullptr;
 
-  // Shrinking to 0 size is basically freeing memory
-  if (!newSize)
-  {
-    GlobalFree((HGLOBAL)oldPtr);
-    return nullptr;
-  }
+	// Shrinking to 0 size is basically freeing memory
+	if (!newSize)
+	{
+		GlobalFree((HGLOBAL)oldPtr);
+		return nullptr;
+	}
 
-  // now try GlobalReAlloc first
-  HGLOBAL h=GlobalReAlloc((HGLOBAL)oldPtr,newSize,0);
-  if (!h)
-  {
-    // this failed (Windows doesn't like ReAlloc'ing larger
-    // fixed memory blocks) - go with Alloc/Free instead
-    h=GlobalAlloc(GMEM_FIXED,newSize);
-    if (!h)
-      DCRASH_RELEASE("Debug mem realloc failed");
-    unsigned oldSize=GlobalSize((HGLOBAL)oldPtr);
-    memcpy((void *)h,oldPtr,oldSize<newSize?oldSize:newSize);
-    GlobalFree((HGLOBAL)oldPtr);
-  }
+	// now try GlobalReAlloc first
+	HGLOBAL h=GlobalReAlloc((HGLOBAL)oldPtr,newSize,0);
+	if (!h)
+	{
+		// this failed (Windows doesn't like ReAlloc'ing larger
+		// fixed memory blocks) - go with Alloc/Free instead
+		h=GlobalAlloc(GMEM_FIXED,newSize);
+		if (!h)
+		DCRASH_RELEASE("Debug mem realloc failed");
+		unsigned oldSize=GlobalSize((HGLOBAL)oldPtr);
+		memcpy((void *)h,oldPtr,oldSize<newSize?oldSize:newSize);
+		GlobalFree((HGLOBAL)oldPtr);
+	}
 
-  return (void *)h;
+	return (void *)h;
 }
 
 void DebugFreeMemory(void *ptr)
 {
-  if (ptr)
-    GlobalFree((HGLOBAL)ptr);
+	if (ptr)
+	GlobalFree((HGLOBAL)ptr);
 }

--- a/Core/Libraries/Source/debug/debug_io.h
+++ b/Core/Libraries/Source/debug/debug_io.h
@@ -42,9 +42,9 @@
 */
 class DebugIOInterface
 {
-  // no copy/assign op
-  DebugIOInterface(const DebugIOInterface&);
-  DebugIOInterface& operator=(const DebugIOInterface&);
+	// no copy/assign op
+	DebugIOInterface(const DebugIOInterface&);
+	DebugIOInterface& operator=(const DebugIOInterface&);
 
 protected:
   /**
@@ -53,41 +53,41 @@ protected:
     The destructor must always be protected. Destruction is
     done by calling the Delete member function.
   */
-  virtual ~DebugIOInterface() {}
+	virtual ~DebugIOInterface() {}
 
 public:
-  // interface only so no functionality here
-  explicit DebugIOInterface() {}
+	// interface only so no functionality here
+	explicit DebugIOInterface() {}
 
-  /// List of possible log string types
-  enum StringType
-  {
-    /// DASSERT etc
-    Assert = 0,
+	/// List of possible log string types
+	enum StringType
+	{
+		/// DASSERT etc
+		Assert = 0,
 
-    /// DCHECK etc
-    Check,
+		/// DCHECK etc
+		Check,
 
-    /// DLOG etc
-    Log,
+		/// DLOG etc
+		Log,
 
-    /// DCRASH etc
-    Crash,
+		/// DCRASH etc
+		Crash,
 
-    /// Exception
-    Exception,
+		/// Exception
+		Exception,
 
-    /// Regular command reply
-    CmdReply,
+		/// Regular command reply
+		CmdReply,
 
-    /// Structured command reply, see \ref debug_structcmd
-    StructuredCmdReply,
+		/// Structured command reply, see \ref debug_structcmd
+		StructuredCmdReply,
 
-    /// some other message
-    Other,
+		/// some other message
+		Other,
 
-    MAX
-  };
+		MAX
+	};
 
   /**
     \brief Retrieves up to the given number of characters from a command input source.
@@ -100,7 +100,7 @@ public:
     \return numbers of characters written to buffer
     \note There is no terminating NUL char written to the buffer
   */
-  virtual int Read(char *buf, int maxchar)=0;
+	virtual int Read(char *buf, int maxchar)=0;
 
   /**
     \brief Write out some characters differentiated by the log string type.
@@ -121,7 +121,7 @@ public:
     \param str string to output, NUL delimited, if nullptr then simply flush
                output (if applicable)
   */
-  virtual void Write(StringType type, const char *src, const char *str)=0;
+	virtual void Write(StringType type, const char *src, const char *str)=0;
 
   /**
     \brief Emergency shutdown function.
@@ -129,7 +129,7 @@ public:
     This function gets called during an exception and should perform the
     absolute bare minimum (e.g. just flushing and closing the output file).
   */
-  virtual void EmergencyFlush()=0;
+	virtual void EmergencyFlush()=0;
 
   /**
     \brief I/O class specific command.
@@ -144,15 +144,15 @@ public:
     \param argn number of additional arguments passed in
     \param argv argument list
   */
-  virtual void Execute(class Debug& dbg, const char *cmd, bool structuredCmd,
-                       unsigned argn, const char * const * argv)=0;
+	virtual void Execute(class Debug& dbg, const char *cmd, bool structuredCmd,
+		unsigned argn, const char * const * argv)=0;
 
   /**
     \brief Destroys the current I/O class instance.
 
     Use this function instead of just delete'ing the instance.
   */
-  virtual void Delete()=0;
+	virtual void Delete()=0;
 };
 
 /**

--- a/Core/Libraries/Source/debug/debug_io_con.cpp
+++ b/Core/Libraries/Source/debug/debug_io_con.cpp
@@ -34,200 +34,200 @@
 #include <new>      // needed for placement new prototype
 
 DebugIOCon::DebugIOCon():
-  m_inputUsed(0), m_inputRead(0)
+	m_inputUsed(0), m_inputRead(0)
 {
-  // check: is there already a console window open?
-  m_allocatedConsole=AllocConsole()!=0;
-  if (m_allocatedConsole)
-  {
-    HANDLE h=GetStdHandle(STD_INPUT_HANDLE);
-    SetConsoleMode(h,0);
+	// check: is there already a console window open?
+	m_allocatedConsole=AllocConsole()!=0;
+	if (m_allocatedConsole)
+	{
+		HANDLE h=GetStdHandle(STD_INPUT_HANDLE);
+		SetConsoleMode(h,0);
 
-    // make screen buffer same size as currently displayed area
-    // (prevents that our input line gets scrolled out of view)
-    h=GetStdHandle(STD_OUTPUT_HANDLE);
-    CONSOLE_SCREEN_BUFFER_INFO info;
-    GetConsoleScreenBufferInfo(h,&info);
+		// make screen buffer same size as currently displayed area
+		// (prevents that our input line gets scrolled out of view)
+		h=GetStdHandle(STD_OUTPUT_HANDLE);
+		CONSOLE_SCREEN_BUFFER_INFO info;
+		GetConsoleScreenBufferInfo(h,&info);
 
-    COORD newSize;
-    newSize.X=info.srWindow.Right+1;
-    newSize.Y=info.srWindow.Bottom+1;
-    SetConsoleScreenBufferSize(h,newSize);
+		COORD newSize;
+		newSize.X=info.srWindow.Right+1;
+		newSize.Y=info.srWindow.Bottom+1;
+		SetConsoleScreenBufferSize(h,newSize);
 
-    // hide cursor
-    CONSOLE_CURSOR_INFO ci;
-    ci.dwSize=1;
-    ci.bVisible=FALSE;
-    SetConsoleCursorInfo(h,&ci);
+		// hide cursor
+		CONSOLE_CURSOR_INFO ci;
+		ci.dwSize=1;
+		ci.bVisible=FALSE;
+		SetConsoleCursorInfo(h,&ci);
 
-    Write(StringType::Other,nullptr,"\n\nEA/Debug console open\n\n");
-  }
+		Write(StringType::Other,nullptr,"\n\nEA/Debug console open\n\n");
+	}
 }
 
 DebugIOCon::~DebugIOCon()
 {
-  // close console if we allocated it
-  if (m_allocatedConsole)
-    FreeConsole();
+	// close console if we allocated it
+	if (m_allocatedConsole)
+	FreeConsole();
 }
 
 int DebugIOCon::Read(char *buf, int maxchar)
 {
-  // We are not supporting reading from the console
-  // unless we allocated that console ourselves.
-  // The reason for that is that if we didn't allocate
-  // the console ourselves we're running as a console
-  // process and if we'd be reading data from the console
-  // we would probably be snatching away keyboard data
-  // for the process that is using that console.
-  if (!m_allocatedConsole)
-    return 0;
+	// We are not supporting reading from the console
+	// unless we allocated that console ourselves.
+	// The reason for that is that if we didn't allocate
+	// the console ourselves we're running as a console
+	// process and if we'd be reading data from the console
+	// we would probably be snatching away keyboard data
+	// for the process that is using that console.
+	if (!m_allocatedConsole)
+	return 0;
 
-  // are we doing a continuous read?
-  if (m_inputRead)
-  {
-    int numRead;
-    if (maxchar>m_inputUsed-m_inputRead)
-    {
-      // return all
-      numRead=m_inputUsed-m_inputRead;
-      memcpy(buf,m_input+m_inputRead,numRead);
-      m_inputRead=m_inputUsed=0;
-    }
-    else
-    {
-      // return partially
-      numRead=maxchar;
-      memcpy(buf,m_input+m_inputRead,numRead);
-      m_inputRead+=maxchar;
-    }
-    return numRead;
-  }
+	// are we doing a continuous read?
+	if (m_inputRead)
+	{
+		int numRead;
+		if (maxchar>m_inputUsed-m_inputRead)
+		{
+			// return all
+			numRead=m_inputUsed-m_inputRead;
+			memcpy(buf,m_input+m_inputRead,numRead);
+			m_inputRead=m_inputUsed=0;
+		}
+		else
+		{
+			// return partially
+			numRead=maxchar;
+			memcpy(buf,m_input+m_inputRead,numRead);
+			m_inputRead+=maxchar;
+		}
+		return numRead;
+	}
 
-  // update our input buffer
-  HANDLE h=GetStdHandle(STD_INPUT_HANDLE);
-  bool returnChars=false;
-  for (;;)
-  {
-    DWORD dwRecords;
-    if (!GetNumberOfConsoleInputEvents(h,&dwRecords))
-      break;
-    if (!dwRecords)
-      break;
+	// update our input buffer
+	HANDLE h=GetStdHandle(STD_INPUT_HANDLE);
+	bool returnChars=false;
+	for (;;)
+	{
+		DWORD dwRecords;
+		if (!GetNumberOfConsoleInputEvents(h,&dwRecords))
+		break;
+		if (!dwRecords)
+		break;
 
-    INPUT_RECORD record;
-    ReadConsoleInput(h,&record,1,&dwRecords);
-    if (record.EventType!=KEY_EVENT)
-      continue;
+		INPUT_RECORD record;
+		ReadConsoleInput(h,&record,1,&dwRecords);
+		if (record.EventType!=KEY_EVENT)
+		continue;
 
-    KEY_EVENT_RECORD &key=record.Event.KeyEvent;
-    if (!key.bKeyDown||!key.uChar.AsciiChar)
-      continue;
+		KEY_EVENT_RECORD &key=record.Event.KeyEvent;
+		if (!key.bKeyDown||!key.uChar.AsciiChar)
+		continue;
 
-    if (key.uChar.AsciiChar=='\r'||
-        key.uChar.AsciiChar=='\n')
-    {
-      m_input[m_inputUsed++]='\n';
-      returnChars=true;
-      break;
-    }
+		if (key.uChar.AsciiChar=='\r'||
+			key.uChar.AsciiChar=='\n')
+		{
+			m_input[m_inputUsed++]='\n';
+			returnChars=true;
+			break;
+		}
 
-    /// @todo_opt if somebody wants this can be improved by adding support for cursor keys, history, etc
+		/// @todo_opt if somebody wants this can be improved by adding support for cursor keys, history, etc
 
-    if (key.uChar.AsciiChar=='\b')
-    {
-      if (m_inputUsed)
-        m_inputUsed--;
-    }
-    else if (((unsigned char)key.uChar.AsciiChar)>=' ')
-    {
-      if (m_inputUsed<sizeof(m_input)-1)
-        m_input[m_inputUsed++]=key.uChar.AsciiChar;
-    }
-  }
+		if (key.uChar.AsciiChar=='\b')
+		{
+			if (m_inputUsed)
+			m_inputUsed--;
+		}
+		else if (((unsigned char)key.uChar.AsciiChar)>=' ')
+		{
+			if (m_inputUsed<sizeof(m_input)-1)
+			m_input[m_inputUsed++]=key.uChar.AsciiChar;
+		}
+	}
 
-  // update screen
-  h=GetStdHandle(STD_OUTPUT_HANDLE);
-  CONSOLE_SCREEN_BUFFER_INFO info;
-  GetConsoleScreenBufferInfo(h,&info);
-  CHAR_INFO ci[sizeof(m_input)+1];
-  for (unsigned k=0;k<=sizeof(m_input);k++)
-  {
-    ci[k].Char.AsciiChar=k<m_inputUsed?m_input[k]:' ';
-    ci[k].Attributes=BACKGROUND_GREEN|FOREGROUND_BLUE|FOREGROUND_GREEN
-                    |FOREGROUND_RED|FOREGROUND_INTENSITY;
-  }
+	// update screen
+	h=GetStdHandle(STD_OUTPUT_HANDLE);
+	CONSOLE_SCREEN_BUFFER_INFO info;
+	GetConsoleScreenBufferInfo(h,&info);
+	CHAR_INFO ci[sizeof(m_input)+1];
+	for (unsigned k=0;k<=sizeof(m_input);k++)
+	{
+		ci[k].Char.AsciiChar=k<m_inputUsed?m_input[k]:' ';
+		ci[k].Attributes=BACKGROUND_GREEN|FOREGROUND_BLUE|FOREGROUND_GREEN
+			|FOREGROUND_RED|FOREGROUND_INTENSITY;
+	}
 
-  // fake another cursor
-  if (GetTickCount()&512)
-    ci[m_inputUsed].Attributes=BACKGROUND_BLUE|BACKGROUND_GREEN
-                              |BACKGROUND_RED|BACKGROUND_INTENSITY|FOREGROUND_GREEN;
+	// fake another cursor
+	if (GetTickCount()&512)
+	ci[m_inputUsed].Attributes=BACKGROUND_BLUE|BACKGROUND_GREEN
+		|BACKGROUND_RED|BACKGROUND_INTENSITY|FOREGROUND_GREEN;
 
-  COORD srcSize,srcCoord;
-  srcSize.X=sizeof(m_input); srcSize.Y=1;
-  srcCoord.X=srcCoord.Y=0;
+	COORD srcSize,srcCoord;
+	srcSize.X=sizeof(m_input); srcSize.Y=1;
+	srcCoord.X=srcCoord.Y=0;
 
-  SMALL_RECT r;
-  r.Left=r.Top=r.Bottom=0; r.Right=info.dwSize.X-1;
-  WriteConsoleOutput(h,ci+(m_inputUsed<=info.dwSize.X?0:m_inputUsed-info.dwSize.X),
-                      srcSize,srcCoord,&r);
+	SMALL_RECT r;
+	r.Left=r.Top=r.Bottom=0; r.Right=info.dwSize.X-1;
+	WriteConsoleOutput(h,ci+(m_inputUsed<=info.dwSize.X?0:m_inputUsed-info.dwSize.X),
+		srcSize,srcCoord,&r);
 
-  // return data now?
-  if (returnChars&&m_inputUsed>1)
-  {
-    *buf=*m_input;
-    m_inputRead=1;
-    return 1;
-  }
+	// return data now?
+	if (returnChars&&m_inputUsed>1)
+	{
+		*buf=*m_input;
+		m_inputRead=1;
+		return 1;
+	}
 
-  return 0;
+	return 0;
 }
 
 void DebugIOCon::Write(StringType type, const char *src, const char *str)
 {
-  if (type==StringType::StructuredCmdReply||!str)
-    return;
+	if (type==StringType::StructuredCmdReply||!str)
+	return;
 
-  DWORD dwDummy;
-  WriteFile(GetStdHandle(STD_OUTPUT_HANDLE),str,strlen(str),&dwDummy,nullptr);
+	DWORD dwDummy;
+	WriteFile(GetStdHandle(STD_OUTPUT_HANDLE),str,strlen(str),&dwDummy,nullptr);
 }
 
 void DebugIOCon::Execute(class Debug& dbg, const char *cmd, bool structuredCmd,
-                         unsigned argn, const char * const * argv)
+	unsigned argn, const char * const * argv)
 {
-  if (!cmd||strcmp(cmd,"help") == 0)
-  {
-    dbg << "con I/O help:\n"
-           "  add [ <width> [ <height> ] ]\n"
-           "    create con I/O (optionally specifying the window size)\n";
-  }
-  else if (strcmp(cmd,"add") == 0)
-  {
-    if (argn>0&&m_allocatedConsole)
-    {
-      // resize our console area
-      HANDLE h=GetStdHandle(STD_OUTPUT_HANDLE);
-      COORD newSize;
-      newSize.X=atoi(argv[0]);
-      newSize.Y=argn>1?atoi(argv[1]):25;
-      SMALL_RECT sr;
-      sr.Left=sr.Top=0;
-      sr.Right=newSize.X-1;
-      sr.Bottom=newSize.Y-1;
-      SetConsoleWindowInfo(h,TRUE,&sr);
-      SetConsoleScreenBufferSize(h,newSize);
-      SetConsoleWindowInfo(h,TRUE,&sr);
-    }
-  }
+	if (!cmd||strcmp(cmd,"help") == 0)
+	{
+		dbg << "con I/O help:\n"
+			"  add [ <width> [ <height> ] ]\n"
+			"    create con I/O (optionally specifying the window size)\n";
+	}
+	else if (strcmp(cmd,"add") == 0)
+	{
+		if (argn>0&&m_allocatedConsole)
+		{
+			// resize our console area
+			HANDLE h=GetStdHandle(STD_OUTPUT_HANDLE);
+			COORD newSize;
+			newSize.X=atoi(argv[0]);
+			newSize.Y=argn>1?atoi(argv[1]):25;
+			SMALL_RECT sr;
+			sr.Left=sr.Top=0;
+			sr.Right=newSize.X-1;
+			sr.Bottom=newSize.Y-1;
+			SetConsoleWindowInfo(h,TRUE,&sr);
+			SetConsoleScreenBufferSize(h,newSize);
+			SetConsoleWindowInfo(h,TRUE,&sr);
+		}
+	}
 }
 
 DebugIOInterface *DebugIOCon::Create()
 {
-  return new (DebugAllocMemory(sizeof(DebugIOCon))) DebugIOCon();
+	return new (DebugAllocMemory(sizeof(DebugIOCon))) DebugIOCon();
 }
 
 void DebugIOCon::Delete()
 {
-  this->~DebugIOCon();
-  DebugFreeMemory(this);
+	this->~DebugIOCon();
+	DebugFreeMemory(this);
 }

--- a/Core/Libraries/Source/debug/debug_io_flat.cpp
+++ b/Core/Libraries/Source/debug/debug_io_flat.cpp
@@ -37,19 +37,19 @@
 #include <new>      // needed for placement new prototype
 
 DebugIOFlat::OutputStream::OutputStream(const char *filename, unsigned maxSize):
-  m_bufferUsed(0), m_nextChar(0)
+	m_bufferUsed(0), m_nextChar(0)
 {
-  m_fileName=(char *)DebugAllocMemory(strlen(filename)+1);
-  strcpy(m_fileName,filename);
+	m_fileName=(char *)DebugAllocMemory(strlen(filename)+1);
+	strcpy(m_fileName,filename);
 
-  m_limitedFileSize=maxSize>0;
-  m_bufferSize=m_limitedFileSize?maxSize:0x10000;
-  m_buffer=(char *)DebugAllocMemory(m_bufferSize);
+	m_limitedFileSize=maxSize>0;
+	m_bufferSize=m_limitedFileSize?maxSize:0x10000;
+	m_buffer=(char *)DebugAllocMemory(m_bufferSize);
 
-  if (!m_limitedFileSize)
-    m_fileHandle=CreateFile(m_fileName,GENERIC_WRITE,0,nullptr,CREATE_ALWAYS,
-                            FILE_ATTRIBUTE_NORMAL|FILE_FLAG_WRITE_THROUGH,
-                            nullptr);
+	if (!m_limitedFileSize)
+	m_fileHandle=CreateFile(m_fileName,GENERIC_WRITE,0,nullptr,CREATE_ALWAYS,
+		FILE_ATTRIBUTE_NORMAL|FILE_FLAG_WRITE_THROUGH,
+		nullptr);
 }
 
 DebugIOFlat::OutputStream::~OutputStream()
@@ -58,492 +58,492 @@ DebugIOFlat::OutputStream::~OutputStream()
 
 DebugIOFlat::OutputStream *DebugIOFlat::OutputStream::Create(const char *filename, unsigned maxSize)
 {
-  return new (DebugAllocMemory(sizeof(OutputStream))) OutputStream(filename,maxSize);
+	return new (DebugAllocMemory(sizeof(OutputStream))) OutputStream(filename,maxSize);
 }
 
 void DebugIOFlat::OutputStream::Delete(const char *path)
 {
-  Flush();
-  if (!m_limitedFileSize)
-    CloseHandle(m_fileHandle);
+	Flush();
+	if (!m_limitedFileSize)
+	CloseHandle(m_fileHandle);
 
-  if (path&&*path)
-  {
-    // copy file to given path
-    int run=-1;
-    char *ext=strrchr(m_fileName,'.');
-    if (!ext)
-      ext=m_fileName+strlen(m_fileName);
-    char *fileNameOnly=strrchr(m_fileName,'\\');
-    fileNameOnly=fileNameOnly?fileNameOnly+1:m_fileName;
+	if (path&&*path)
+	{
+		// copy file to given path
+		int run=-1;
+		char *ext=strrchr(m_fileName,'.');
+		if (!ext)
+		ext=m_fileName+strlen(m_fileName);
+		char *fileNameOnly=strrchr(m_fileName,'\\');
+		fileNameOnly=fileNameOnly?fileNameOnly+1:m_fileName;
 
-    unsigned pathLen=strlen(path);
-    for (;;)
-    {
-      // absolute path?
-      char help[512];
-      if (path[0]&&(path[1]==':'||(path[0]=='\\'&&path[1]=='\\')))
-      {
-        strlcpy(help, path, ARRAY_SIZE(help));
-        strlcat(help, fileNameOnly, ARRAY_SIZE(help));
-      }
-      else
-      {
-        // no, relative path given
-        strlcpy(help, m_fileName, ARRAY_SIZE(help));
-        strlcat(help, path, ARRAY_SIZE(help));
-        strlcat(help, fileNameOnly, ARRAY_SIZE(help));
-      }
-      if (++run)
-        wsprintf(help+strlen(help),"(%i)%s",run,ext);
-      else
-        strlcat(help, ext, ARRAY_SIZE(help));
-      if (CopyFile(m_fileName,help,TRUE))
-        break;
-      if (GetLastError()!=ERROR_FILE_EXISTS)
-        break;
-    }
-  }
+		unsigned pathLen=strlen(path);
+		for (;;)
+		{
+			// absolute path?
+			char help[512];
+			if (path[0]&&(path[1]==':'||(path[0]=='\\'&&path[1]=='\\')))
+			{
+				strlcpy(help, path, ARRAY_SIZE(help));
+				strlcat(help, fileNameOnly, ARRAY_SIZE(help));
+			}
+			else
+			{
+				// no, relative path given
+				strlcpy(help, m_fileName, ARRAY_SIZE(help));
+				strlcat(help, path, ARRAY_SIZE(help));
+				strlcat(help, fileNameOnly, ARRAY_SIZE(help));
+			}
+			if (++run)
+			wsprintf(help+strlen(help),"(%i)%s",run,ext);
+			else
+			strlcat(help, ext, ARRAY_SIZE(help));
+			if (CopyFile(m_fileName,help,TRUE))
+			break;
+			if (GetLastError()!=ERROR_FILE_EXISTS)
+			break;
+		}
+	}
 
-  DebugFreeMemory(m_buffer);
-  DebugFreeMemory(m_fileName);
+	DebugFreeMemory(m_buffer);
+	DebugFreeMemory(m_fileName);
 
-  this->~OutputStream();
-  DebugFreeMemory(this);
+	this->~OutputStream();
+	DebugFreeMemory(this);
 }
 
 void DebugIOFlat::OutputStream::Write(const char *src)
 {
-  if (!src)
-  {
-    // flush request, flush only if unlimited file size
-    if (!m_limitedFileSize)
-      Flush();
-  }
-  else
-  {
-    unsigned len=strlen(src);
+	if (!src)
+	{
+		// flush request, flush only if unlimited file size
+		if (!m_limitedFileSize)
+		Flush();
+	}
+	else
+	{
+		unsigned len=strlen(src);
 
-    while (len>m_bufferSize)
-    {
-      InternalWrite(src,m_bufferSize);
-      src+=m_bufferSize;
-      len-=m_bufferSize;
-    }
-    InternalWrite(src,len);
-  }
+		while (len>m_bufferSize)
+		{
+			InternalWrite(src,m_bufferSize);
+			src+=m_bufferSize;
+			len-=m_bufferSize;
+		}
+		InternalWrite(src,len);
+	}
 }
 
 void DebugIOFlat::OutputStream::InternalWrite(const char *src, unsigned len)
 {
-  __ASSERT(len<=m_bufferSize);
+	__ASSERT(len<=m_bufferSize);
 
-  // unlimited log file length?
-  if (!m_limitedFileSize)
-  {
-    if (m_bufferUsed+len>m_bufferSize)
-      Flush();
-    memcpy(m_buffer+m_bufferUsed,src,len);
-    m_bufferUsed+=len;
-  }
-  else
-  {
-    // just write to ring buffer
-    if ((m_bufferUsed+=len)>m_bufferSize)
-      m_bufferUsed=m_bufferSize;
+	// unlimited log file length?
+	if (!m_limitedFileSize)
+	{
+		if (m_bufferUsed+len>m_bufferSize)
+		Flush();
+		memcpy(m_buffer+m_bufferUsed,src,len);
+		m_bufferUsed+=len;
+	}
+	else
+	{
+		// just write to ring buffer
+		if ((m_bufferUsed+=len)>m_bufferSize)
+		m_bufferUsed=m_bufferSize;
 
-    while (len)
-    {
-      unsigned toWrite;
-      if (m_nextChar+len>m_bufferSize)
-        toWrite=m_bufferSize-m_nextChar;
-      else
-        toWrite=len;
-      memcpy(m_buffer+m_nextChar,src,toWrite);
-      if ((m_nextChar+=toWrite)>=m_bufferSize)
-        m_nextChar=0;
-      src+=toWrite;
-      len-=toWrite;
-    }
-  }
+		while (len)
+		{
+			unsigned toWrite;
+			if (m_nextChar+len>m_bufferSize)
+			toWrite=m_bufferSize-m_nextChar;
+			else
+			toWrite=len;
+			memcpy(m_buffer+m_nextChar,src,toWrite);
+			if ((m_nextChar+=toWrite)>=m_bufferSize)
+			m_nextChar=0;
+			src+=toWrite;
+			len-=toWrite;
+		}
+	}
 }
 
 void DebugIOFlat::OutputStream::Flush()
 {
-  if (!m_limitedFileSize)
-  {
-    // simple flush to file
-    DWORD written;
-    WriteFile(m_fileHandle,m_buffer,m_bufferUsed,&written,nullptr);
-    m_bufferUsed=0;
-  }
-  else
-  {
-    // create file, write ring buffer
-    m_fileHandle=CreateFile(m_fileName,GENERIC_WRITE,0,nullptr,CREATE_ALWAYS,
-                            FILE_ATTRIBUTE_NORMAL|FILE_FLAG_WRITE_THROUGH,
-                            nullptr);
-    DWORD written;
-    if (m_bufferUsed<m_bufferSize)
-      WriteFile(m_fileHandle,m_buffer,m_bufferUsed,&written,nullptr);
-    else
-    {
-      WriteFile(m_fileHandle,m_buffer+m_nextChar,m_bufferUsed-m_nextChar,&written,nullptr);
-      WriteFile(m_fileHandle,m_buffer,m_nextChar,&written,nullptr);
-    }
-    CloseHandle(m_fileHandle);
-  }
+	if (!m_limitedFileSize)
+	{
+		// simple flush to file
+		DWORD written;
+		WriteFile(m_fileHandle,m_buffer,m_bufferUsed,&written,nullptr);
+		m_bufferUsed=0;
+	}
+	else
+	{
+		// create file, write ring buffer
+		m_fileHandle=CreateFile(m_fileName,GENERIC_WRITE,0,nullptr,CREATE_ALWAYS,
+			FILE_ATTRIBUTE_NORMAL|FILE_FLAG_WRITE_THROUGH,
+			nullptr);
+		DWORD written;
+		if (m_bufferUsed<m_bufferSize)
+		WriteFile(m_fileHandle,m_buffer,m_bufferUsed,&written,nullptr);
+		else
+		{
+			WriteFile(m_fileHandle,m_buffer+m_nextChar,m_bufferUsed-m_nextChar,&written,nullptr);
+			WriteFile(m_fileHandle,m_buffer,m_nextChar,&written,nullptr);
+		}
+		CloseHandle(m_fileHandle);
+	}
 }
 
 //////////////////////////////////////////////////////////////////////////////
 
 void DebugIOFlat::ExpandMagic(const char *src, const char *splitName, char *buf)
 {
-  // barf if too long
-  if (strlen(src)>250)
-    src="*eMN";
+	// barf if too long
+	if (strlen(src)>250)
+	src="*eMN";
 
-  // non-magic name?
-  if (*src!='*')
-  {
-    // just return input name
-    if (splitName)
-    {
-      // must jam in split name before extension
-      const char *p=strrchr(src,'.');
-      if (!p)
-        p=src+strlen(src);
-      strncpy(buf,src,p-src);
-      buf[p-src]='-';
-      strcpy(buf+(p-src)+1,splitName);
-      strcat(buf,p);
-    }
-    else
-      strcpy(buf,src);
+	// non-magic name?
+	if (*src!='*')
+	{
+		// just return input name
+		if (splitName)
+		{
+			// must jam in split name before extension
+			const char *p=strrchr(src,'.');
+			if (!p)
+			p=src+strlen(src);
+			strncpy(buf,src,p-src);
+			buf[p-src]='-';
+			strcpy(buf+(p-src)+1,splitName);
+			strcat(buf,p);
+		}
+		else
+		strcpy(buf,src);
 
-    return;
-  }
+		return;
+	}
 
-  // translate magic name
-  src++;
-  char *dst=buf;
-  while (*src)
-  {
-    if (dst-buf>250)
-      break;
+	// translate magic name
+	src++;
+	char *dst=buf;
+	while (*src)
+	{
+		if (dst-buf>250)
+		break;
 
-    if (*src>='A'&&*src<='Z'&&(*src!='N'||splitName))
-      *dst++='-';
+		if (*src>='A'&&*src<='Z'&&(*src!='N'||splitName))
+		*dst++='-';
 
-    char help[256];
-    DWORD size=sizeof(help);
-    *help=0;
+		char help[256];
+		DWORD size=sizeof(help);
+		*help=0;
 
-    switch(*src++)
-    {
-      case 'e':
-      case 'E':
-        GetModuleFileName(nullptr,help,sizeof(help));
-        break;
-      case 'm':
-      case 'M':
-        GetComputerName(help,&size);
-        break;
-      case 'u':
-      case 'U':
-        GetUserName(help,&size);
-        break;
-      case 't':
-      case 'T':
-        {
-          SYSTEMTIME systime;
-          GetLocalTime(&systime);
+		switch(*src++)
+		{
+			case 'e':
+			case 'E':
+				GetModuleFileName(nullptr,help,sizeof(help));
+				break;
+			case 'm':
+			case 'M':
+				GetComputerName(help,&size);
+				break;
+			case 'u':
+			case 'U':
+				GetUserName(help,&size);
+				break;
+			case 't':
+			case 'T':
+			{
+				SYSTEMTIME systime;
+				GetLocalTime(&systime);
 
-          wsprintf(help,"%04i%02i%02i-%02i%02i-%02i",
-                   systime.wYear,systime.wMonth,systime.wDay,
-                   systime.wHour,systime.wMinute,systime.wSecond);
-        }
-        break;
-      case 'n':
-      case 'N':
-        if (splitName&&strlen(splitName)<250)
-          strlcpy(help, splitName, ARRAY_SIZE(help));
-        break;
-      default:
-        *dst++=src[-1];
-    }
+				wsprintf(help,"%04i%02i%02i-%02i%02i-%02i",
+					systime.wYear,systime.wMonth,systime.wDay,
+					systime.wHour,systime.wMinute,systime.wSecond);
+			}
+				break;
+			case 'n':
+			case 'N':
+				if (splitName&&strlen(splitName)<250)
+				strlcpy(help, splitName, ARRAY_SIZE(help));
+				break;
+			default:
+				*dst++=src[-1];
+		}
 
-    unsigned len=strlen(help);
-    if (dst-buf+len>250)
-      break;
-    strcpy(dst, help);
-    dst+=len;
-  }
-  strcpy(dst,".log");
+		unsigned len=strlen(help);
+		if (dst-buf+len>250)
+		break;
+		strcpy(dst, help);
+		dst+=len;
+	}
+	strcpy(dst,".log");
 }
 
 DebugIOFlat::DebugIOFlat():
-  m_firstStream(nullptr), m_firstSplit(nullptr),
-  m_lastStreamPtr(&m_firstStream), m_lastSplitPtr(&m_firstSplit)
+	m_firstStream(nullptr), m_firstSplit(nullptr),
+	m_lastStreamPtr(&m_firstStream), m_lastSplitPtr(&m_firstSplit)
 {
-  *m_copyDir=0;
+	*m_copyDir=0;
 }
 
 DebugIOFlat::~DebugIOFlat()
 {
-  for (SplitListEntry *cur=m_firstSplit;cur;)
-  {
-    SplitListEntry *kill=cur;
-    cur=cur->next;
-    DebugFreeMemory(kill);
-  }
-  m_firstSplit=nullptr;
+	for (SplitListEntry *cur=m_firstSplit;cur;)
+	{
+		SplitListEntry *kill=cur;
+		cur=cur->next;
+		DebugFreeMemory(kill);
+	}
+	m_firstSplit=nullptr;
 
-  for (StreamListEntry *stream=m_firstStream;stream;)
-  {
-    StreamListEntry *kill=stream;
-    stream=stream->next;
-    kill->stream->Delete(m_copyDir);
-    DebugFreeMemory(kill);
-  }
+	for (StreamListEntry *stream=m_firstStream;stream;)
+	{
+		StreamListEntry *kill=stream;
+		stream=stream->next;
+		kill->stream->Delete(m_copyDir);
+		DebugFreeMemory(kill);
+	}
 }
 
 void DebugIOFlat::Write(StringType type, const char *src, const char *str)
 {
-  SplitListEntry *cur=m_firstSplit;
-  for (;cur;cur=cur->next)
-  {
-    if (!(cur->stringTypes&(1<<type)))
-      continue;
-    if (src&&*src&&!Debug::SimpleMatch(src,cur->items))
-      continue;
-    cur->stream->Write(str);
-    break;
-  }
-  if (!cur)
-    m_firstStream->stream->Write(str);
+	SplitListEntry *cur=m_firstSplit;
+	for (;cur;cur=cur->next)
+	{
+		if (!(cur->stringTypes&(1<<type)))
+		continue;
+		if (src&&*src&&!Debug::SimpleMatch(src,cur->items))
+		continue;
+		cur->stream->Write(str);
+		break;
+	}
+	if (!cur)
+	m_firstStream->stream->Write(str);
 }
 
 void DebugIOFlat::EmergencyFlush()
 {
-  for (StreamListEntry *cur=m_firstStream;cur;cur=cur->next)
-    cur->stream->Flush();
+	for (StreamListEntry *cur=m_firstStream;cur;cur=cur->next)
+	cur->stream->Flush();
 }
 
 void DebugIOFlat::Execute(class Debug& dbg, const char *cmd, bool structuredCmd,
-                          unsigned argn, const char * const * argv)
+	unsigned argn, const char * const * argv)
 {
-  if (!cmd||strcmp(cmd,"help") == 0)
-  {
-    if (!argn)
-      dbg << "flat I/O help:\n"
-             "The following I/O commands are defined:\n"
-             "  add, copy, splitadd, splitview, splitremove\n"
-             "Type in debug.io flat help <cmd> for a detailed command help.\n";
-    else if (strcmp(argv[0],"add") == 0)
-      dbg <<
-        "add [ <filename> [ <size in kb> ] ]\n\n"
-        "Create flat file I/O (optionally specifying file name and file size).\n"
-        "If a filename is specified all output is written to that file. Otherwise\n"
-        "the magic filename '*eMN' is automatically used. Any existing files with\n"
-        "that name are overwritten.\n"
-        "\n"
-        "Instead of a real file name a 'magic' file name can be used by starting\n"
-        "the file name with a '*' followed by any number of special characters:\n"
-        "- 'e': inserts EXE name\n"
-        "- 'm': inserts machine name\n"
-        "- 'u': inserts username\n"
-        "- 't': inserts timestamp\n"
-        "- 'n': inserts split name (empty if main log file)\n"
-        "- '-': inserts '-'\n"
-        "- 'E', 'M', 'U', 'T', 'N': same as above but with '-' in front \n"
-        "  (for 'N': empty if main log file)\n"
-        ".log is automatically appended if using magic file names.\n"
-        "\n"
-        "If a size is specified then all data is internally written to a fixed \n"
-        "size memory based ring buffer. This data is flushed out once the \n"
-        "program exits. If no size is given then the size of the log file is not \n"
-        "limited and any log data is written out immediately.\n";
-    else if (strcmp(argv[0],"copy") == 0)
-      dbg <<
-        "copy <directory>\n\n"
-        "Copies generated log file(s) into the given directory if the program\n"
-        "exists or crashes. If there is already a log file with the same\n"
-        "name a unique number is appended to the current log files' name.\n";
-    else if (strcmp(argv[0],"splitadd") == 0)
-      dbg <<
-        "splitadd <types> <filter> <name> [ <size in kb> ]\n\n"
-        "Splits off part of the log data. Multiple splits can be defined. They \n"
-        "are written out to the first matching split file.\n"
-        "\n"
-        "'types' defines one or more string types which should be split off:\n"
-        "- a: asserts\n"
-        "- c: checks\n"
-        "- l: logs\n"
-        "- h: crash\n"
-        "- x: exceptions\n"
-        "- r: replies from commands\n"
-        "- o: other messages \n"
-        "\n"
-        "Next a filter is specified that determines which items are to be \n"
-        "filtered (only for string types a, c and l). Items can be listed with\n"
-        "then 'list' command. The filter is exactly specified as in that command.\n"
-        "\n"
-        "The third parameter defines a name for this split. If there is \n"
-        "already a split with the same name then both will write to the same \n"
-        "destination file.\n"
-        "\n"
-        "Note: If splits are used and the filename given for 'add' is static \n"
-        "or does not contain 'n' or 'N' then the split name is automatically \n"
-        "appended to the log file name (before the extension).\n"
-        "\n"
-        "If a size is specified then all data is internally written to a \n"
-        "fixed size memory based ring buffer. This data is flushed out once \n"
-        "the program exits.\n"
-        "\n"
-        "If no size is given then the size of the log file is not limited and \n"
-        "any log data is written out immediately.\n";
-    else if (strcmp(argv[0],"splitview") == 0)
-      dbg << "splitview\n\n"
-             "Shows all existing splits in the order they are evaluated.";
-    else if (strcmp(argv[0],"splitremove") == 0)
-      dbg << "splitremove <namepattern>\n\n"
-             "Removes all active splits matching the given name pattern.";
-    else
-      dbg << "Unknown flat I/O command";
-  }
-  else if (strcmp(cmd,"add") == 0)
-  {
-    // add [ <filename> [ <size in kb> ] ]
-    __ASSERT(m_firstStream==nullptr);
+	if (!cmd||strcmp(cmd,"help") == 0)
+	{
+		if (!argn)
+		dbg << "flat I/O help:\n"
+			"The following I/O commands are defined:\n"
+			"  add, copy, splitadd, splitview, splitremove\n"
+			"Type in debug.io flat help <cmd> for a detailed command help.\n";
+		else if (strcmp(argv[0],"add") == 0)
+		dbg <<
+			"add [ <filename> [ <size in kb> ] ]\n\n"
+			"Create flat file I/O (optionally specifying file name and file size).\n"
+			"If a filename is specified all output is written to that file. Otherwise\n"
+			"the magic filename '*eMN' is automatically used. Any existing files with\n"
+			"that name are overwritten.\n"
+			"\n"
+			"Instead of a real file name a 'magic' file name can be used by starting\n"
+			"the file name with a '*' followed by any number of special characters:\n"
+			"- 'e': inserts EXE name\n"
+			"- 'm': inserts machine name\n"
+			"- 'u': inserts username\n"
+			"- 't': inserts timestamp\n"
+			"- 'n': inserts split name (empty if main log file)\n"
+			"- '-': inserts '-'\n"
+			"- 'E', 'M', 'U', 'T', 'N': same as above but with '-' in front \n"
+			"  (for 'N': empty if main log file)\n"
+			".log is automatically appended if using magic file names.\n"
+			"\n"
+			"If a size is specified then all data is internally written to a fixed \n"
+			"size memory based ring buffer. This data is flushed out once the \n"
+			"program exits. If no size is given then the size of the log file is not \n"
+			"limited and any log data is written out immediately.\n";
+		else if (strcmp(argv[0],"copy") == 0)
+		dbg <<
+			"copy <directory>\n\n"
+			"Copies generated log file(s) into the given directory if the program\n"
+			"exists or crashes. If there is already a log file with the same\n"
+			"name a unique number is appended to the current log files' name.\n";
+		else if (strcmp(argv[0],"splitadd") == 0)
+		dbg <<
+			"splitadd <types> <filter> <name> [ <size in kb> ]\n\n"
+			"Splits off part of the log data. Multiple splits can be defined. They \n"
+			"are written out to the first matching split file.\n"
+			"\n"
+			"'types' defines one or more string types which should be split off:\n"
+			"- a: asserts\n"
+			"- c: checks\n"
+			"- l: logs\n"
+			"- h: crash\n"
+			"- x: exceptions\n"
+			"- r: replies from commands\n"
+			"- o: other messages \n"
+			"\n"
+			"Next a filter is specified that determines which items are to be \n"
+			"filtered (only for string types a, c and l). Items can be listed with\n"
+			"then 'list' command. The filter is exactly specified as in that command.\n"
+			"\n"
+			"The third parameter defines a name for this split. If there is \n"
+			"already a split with the same name then both will write to the same \n"
+			"destination file.\n"
+			"\n"
+			"Note: If splits are used and the filename given for 'add' is static \n"
+			"or does not contain 'n' or 'N' then the split name is automatically \n"
+			"appended to the log file name (before the extension).\n"
+			"\n"
+			"If a size is specified then all data is internally written to a \n"
+			"fixed size memory based ring buffer. This data is flushed out once \n"
+			"the program exits.\n"
+			"\n"
+			"If no size is given then the size of the log file is not limited and \n"
+			"any log data is written out immediately.\n";
+		else if (strcmp(argv[0],"splitview") == 0)
+		dbg << "splitview\n\n"
+			"Shows all existing splits in the order they are evaluated.";
+		else if (strcmp(argv[0],"splitremove") == 0)
+		dbg << "splitremove <namepattern>\n\n"
+			"Removes all active splits matching the given name pattern.";
+		else
+		dbg << "Unknown flat I/O command";
+	}
+	else if (strcmp(cmd,"add") == 0)
+	{
+		// add [ <filename> [ <size in kb> ] ]
+		__ASSERT(m_firstStream==nullptr);
 
-    strlcpy(m_baseFilename, argn?argv[0]:"*eMN", ARRAY_SIZE(m_baseFilename));
+		strlcpy(m_baseFilename, argn?argv[0]:"*eMN", ARRAY_SIZE(m_baseFilename));
 
-    char fn[256];
-    ExpandMagic(m_baseFilename,nullptr,fn);
+		char fn[256];
+		ExpandMagic(m_baseFilename,nullptr,fn);
 
-    m_firstStream=(StreamListEntry *)DebugAllocMemory(sizeof(StreamListEntry));
-    m_firstStream->next=nullptr;
-    m_firstStream->stream=OutputStream::Create(fn,argn>1?atoi(argv[1])*1024:0);
-    m_lastStreamPtr=&m_firstStream->next;
-  }
-  else if (strcmp(cmd,"copy") == 0)
-  {
-    // copy <directory>
-    if (argn)
-    {
-      strlcpy(m_copyDir,argv[0],sizeof(m_copyDir));
-    }
-  }
-  else if (strcmp(cmd,"splitadd") == 0)
-  {
-    // splitadd <types> <filter> <name> [ <size in kb> ]
-    if (argn>=3)
-    {
-      // add entry
-      SplitListEntry *cur=(SplitListEntry *)DebugAllocMemory(sizeof(SplitListEntry));
-      cur->next=*m_lastSplitPtr;
-      m_lastSplitPtr=&cur->next;
-      if (!m_firstSplit)
-        m_firstSplit=cur;
-      cur->stringTypes=0;
-      for (const char *p=argv[0];*p;++p)
-      {
-        switch(*p)
-        {
-          case 'a': cur->stringTypes|=1<<Assert; break;
-          case 'c': cur->stringTypes|=1<<Check; break;
-          case 'l': cur->stringTypes|=1<<Log; break;
-          case 'h': cur->stringTypes|=1<<Crash; break;
-          case 'x': cur->stringTypes|=1<<Exception; break;
-          case 'r': cur->stringTypes|=1<<CmdReply; break;
-          case 'o': cur->stringTypes|=1<<Other; break;
-        }
-      }
-      if (!cur->stringTypes)
-        cur->stringTypes=0xffffffff;
+		m_firstStream=(StreamListEntry *)DebugAllocMemory(sizeof(StreamListEntry));
+		m_firstStream->next=nullptr;
+		m_firstStream->stream=OutputStream::Create(fn,argn>1?atoi(argv[1])*1024:0);
+		m_lastStreamPtr=&m_firstStream->next;
+	}
+	else if (strcmp(cmd,"copy") == 0)
+	{
+		// copy <directory>
+		if (argn)
+		{
+			strlcpy(m_copyDir,argv[0],sizeof(m_copyDir));
+		}
+	}
+	else if (strcmp(cmd,"splitadd") == 0)
+	{
+		// splitadd <types> <filter> <name> [ <size in kb> ]
+		if (argn>=3)
+		{
+			// add entry
+			SplitListEntry *cur=(SplitListEntry *)DebugAllocMemory(sizeof(SplitListEntry));
+			cur->next=*m_lastSplitPtr;
+			m_lastSplitPtr=&cur->next;
+			if (!m_firstSplit)
+			m_firstSplit=cur;
+			cur->stringTypes=0;
+			for (const char *p=argv[0];*p;++p)
+			{
+				switch(*p)
+				{
+					case 'a': cur->stringTypes|=1<<Assert; break;
+					case 'c': cur->stringTypes|=1<<Check; break;
+					case 'l': cur->stringTypes|=1<<Log; break;
+					case 'h': cur->stringTypes|=1<<Crash; break;
+					case 'x': cur->stringTypes|=1<<Exception; break;
+					case 'r': cur->stringTypes|=1<<CmdReply; break;
+					case 'o': cur->stringTypes|=1<<Other; break;
+				}
+			}
+			if (!cur->stringTypes)
+			cur->stringTypes=0xffffffff;
 
-      strlcpy(cur->items,argv[1],sizeof(cur->items));
-      strlcpy(cur->name,argv[2],sizeof(cur->name));
+			strlcpy(cur->items,argv[1],sizeof(cur->items));
+			strlcpy(cur->name,argv[2],sizeof(cur->name));
 
-      // create our filename, search for stream with same filename
-      char fn[256];
-      ExpandMagic(m_baseFilename,cur->name,fn);
-      StreamListEntry *stream=m_firstStream;
-      for (;stream;stream=stream->next)
-        if (strcmp(stream->stream->GetFilename(),fn) == 0)
-          break;
-      if (!stream)
-      {
-        // must create new stream
-        stream=(StreamListEntry *)DebugAllocMemory(sizeof(StreamListEntry));
-        stream->next=nullptr;
-        *m_lastStreamPtr=stream;
-        m_lastStreamPtr=&stream->next;
-        stream->stream=OutputStream::Create(fn,argn>3?atoi(argv[3])*1024:0);
-      }
-      cur->stream=stream->stream;
-    }
-  }
-  else if (strcmp(cmd,"splitview") == 0)
-  {
-    // splitview
-    for (SplitListEntry *cur=m_firstSplit;cur;cur=cur->next)
-    {
-      for (StringType t=Assert;t<MAX;t=(StringType)(t+1))
-      {
-        if (t==StructuredCmdReply||!(cur->stringTypes&(1<<t)))
-          continue;
-        switch(t)
-        {
-          case Assert:    dbg << "a"; break;
-          case Check:     dbg << "c"; break;
-          case Log:       dbg << "l"; break;
-          case Crash:     dbg << "h"; break;
-          case Exception: dbg << "x"; break;
-          case CmdReply:  dbg << "r"; break;
-          case Other:     dbg << "o"; break;
-        }
-      }
-      dbg << " " << cur->items << " " << cur->name << "\n";
-    }
-  }
-  else if (strcmp(cmd,"splitremove") == 0)
-  {
-    // splitremove <namepattern>
-    const char *pattern=argn<1?"*":argv[0];
-    for (SplitListEntry **entryPtr=&m_firstSplit;*entryPtr;)
-    {
-      if ( Debug::SimpleMatch((*entryPtr)->name,pattern) )
-      {
-        // remove this entry
-        SplitListEntry *cur=*entryPtr;
-        *entryPtr=cur->next;
-        DebugFreeMemory(cur);
-      }
-      else
-        entryPtr=&((*entryPtr)->next);
-    }
+			// create our filename, search for stream with same filename
+			char fn[256];
+			ExpandMagic(m_baseFilename,cur->name,fn);
+			StreamListEntry *stream=m_firstStream;
+			for (;stream;stream=stream->next)
+			if (strcmp(stream->stream->GetFilename(),fn) == 0)
+			break;
+			if (!stream)
+			{
+				// must create new stream
+				stream=(StreamListEntry *)DebugAllocMemory(sizeof(StreamListEntry));
+				stream->next=nullptr;
+				*m_lastStreamPtr=stream;
+				m_lastStreamPtr=&stream->next;
+				stream->stream=OutputStream::Create(fn,argn>3?atoi(argv[3])*1024:0);
+			}
+			cur->stream=stream->stream;
+		}
+	}
+	else if (strcmp(cmd,"splitview") == 0)
+	{
+		// splitview
+		for (SplitListEntry *cur=m_firstSplit;cur;cur=cur->next)
+		{
+			for (StringType t=Assert;t<MAX;t=(StringType)(t+1))
+			{
+				if (t==StructuredCmdReply||!(cur->stringTypes&(1<<t)))
+				continue;
+				switch(t)
+				{
+					case Assert:    dbg << "a"; break;
+					case Check:     dbg << "c"; break;
+					case Log:       dbg << "l"; break;
+					case Crash:     dbg << "h"; break;
+					case Exception: dbg << "x"; break;
+					case CmdReply:  dbg << "r"; break;
+					case Other:     dbg << "o"; break;
+				}
+			}
+			dbg << " " << cur->items << " " << cur->name << "\n";
+		}
+	}
+	else if (strcmp(cmd,"splitremove") == 0)
+	{
+		// splitremove <namepattern>
+		const char *pattern=argn<1?"*":argv[0];
+		for (SplitListEntry **entryPtr=&m_firstSplit;*entryPtr;)
+		{
+			if ( Debug::SimpleMatch((*entryPtr)->name,pattern) )
+			{
+				// remove this entry
+				SplitListEntry *cur=*entryPtr;
+				*entryPtr=cur->next;
+				DebugFreeMemory(cur);
+			}
+			else
+			entryPtr=&((*entryPtr)->next);
+		}
 
-    // must fixup m_lastSplitPtr now
-    if (m_firstSplit)
-    {
-      SplitListEntry *cur=m_firstSplit;
-      for (;cur->next;cur=cur->next);
-      m_firstSplit=cur;
-    }
-    else
-      m_firstSplit=nullptr;
-  }
+		// must fixup m_lastSplitPtr now
+		if (m_firstSplit)
+		{
+			SplitListEntry *cur=m_firstSplit;
+			for (;cur->next;cur=cur->next);
+			m_firstSplit=cur;
+		}
+		else
+		m_firstSplit=nullptr;
+	}
 }
 
 DebugIOInterface *DebugIOFlat::Create()
 {
-  return new (DebugAllocMemory(sizeof(DebugIOFlat))) DebugIOFlat();
+	return new (DebugAllocMemory(sizeof(DebugIOFlat))) DebugIOFlat();
 }
 
 void DebugIOFlat::Delete()
 {
-  this->~DebugIOFlat();
-  DebugFreeMemory(this);
+	this->~DebugIOFlat();
+	DebugFreeMemory(this);
 }

--- a/Core/Libraries/Source/debug/debug_io_net.cpp
+++ b/Core/Libraries/Source/debug/debug_io_net.cpp
@@ -39,45 +39,45 @@ DebugIONet::DebugIONet()
 
 DebugIONet::~DebugIONet()
 {
-  if (m_pipe!=INVALID_HANDLE_VALUE)
-    CloseHandle(m_pipe);
+	if (m_pipe!=INVALID_HANDLE_VALUE)
+	CloseHandle(m_pipe);
 }
 
 int DebugIONet::Read(char *buf, int maxchar)
 {
-  if (m_pipe==INVALID_HANDLE_VALUE)
-    return 0;
+	if (m_pipe==INVALID_HANDLE_VALUE)
+	return 0;
 
-  DWORD mode=PIPE_READMODE_MESSAGE|PIPE_NOWAIT;
-  SetNamedPipeHandleState(m_pipe,&mode,nullptr,nullptr);
+	DWORD mode=PIPE_READMODE_MESSAGE|PIPE_NOWAIT;
+	SetNamedPipeHandleState(m_pipe,&mode,nullptr,nullptr);
 
-  DWORD read;
-  if (!ReadFile(m_pipe,buf,maxchar-1,&read,nullptr))
-    read=0;
-  mode=PIPE_READMODE_MESSAGE|PIPE_WAIT;
-  SetNamedPipeHandleState(m_pipe,&mode,nullptr,nullptr);
+	DWORD read;
+	if (!ReadFile(m_pipe,buf,maxchar-1,&read,nullptr))
+	read=0;
+	mode=PIPE_READMODE_MESSAGE|PIPE_WAIT;
+	SetNamedPipeHandleState(m_pipe,&mode,nullptr,nullptr);
 
-  return read;
+	return read;
 }
 
 void DebugIONet::Write(StringType type, const char *src, const char *str)
 {
-  if (m_pipe==INVALID_HANDLE_VALUE)
-    return;
+	if (m_pipe==INVALID_HANDLE_VALUE)
+	return;
 
-  DWORD dummy;
-  WriteFile(m_pipe,&type,1,&dummy,nullptr);
+	DWORD dummy;
+	WriteFile(m_pipe,&type,1,&dummy,nullptr);
 
-  unsigned len;
-  len=src?strlen(src):0;
-  WriteFile(m_pipe,&len,4,&dummy,nullptr);
-  if (len)
-    WriteFile(m_pipe,src,len,&dummy,nullptr);
+	unsigned len;
+	len=src?strlen(src):0;
+	WriteFile(m_pipe,&len,4,&dummy,nullptr);
+	if (len)
+	WriteFile(m_pipe,src,len,&dummy,nullptr);
 
-  len=strlen(str);
-  WriteFile(m_pipe,&len,4,&dummy,nullptr);
-  if (len)
-    WriteFile(m_pipe,str,len,&dummy,nullptr);
+	len=strlen(str);
+	WriteFile(m_pipe,&len,4,&dummy,nullptr);
+	if (len)
+	WriteFile(m_pipe,str,len,&dummy,nullptr);
 }
 
 void DebugIONet::EmergencyFlush()
@@ -85,48 +85,48 @@ void DebugIONet::EmergencyFlush()
 }
 
 void DebugIONet::Execute(class Debug& dbg, const char *cmd, bool structuredCmd,
-                         unsigned argn, const char * const * argv)
+	unsigned argn, const char * const * argv)
 {
-  if (!cmd||strcmp(cmd,"help") == 0)
-  {
-    dbg << "net I/O help:\n"
-           "  add [ <machine> ]\n"
-           "    create net I/O (optionally specifying the machine to connect to)\n";
-  }
-  else if (strcmp(cmd,"add") == 0)
-  {
-    const char *machine=argn?argv[0]:".";
+	if (!cmd||strcmp(cmd,"help") == 0)
+	{
+		dbg << "net I/O help:\n"
+			"  add [ <machine> ]\n"
+			"    create net I/O (optionally specifying the machine to connect to)\n";
+	}
+	else if (strcmp(cmd,"add") == 0)
+	{
+		const char *machine=argn?argv[0]:".";
 
-    char buf[256];
-    wsprintf(buf,"\\\\%s\\pipe\\ea_debug_v1",machine);
-    m_pipe=CreateFile(buf,GENERIC_READ|GENERIC_WRITE,
-                      0,nullptr,OPEN_EXISTING,0,nullptr);
-    if (m_pipe==INVALID_HANDLE_VALUE)
-    {
-      dbg << "Could not connect to given machine.\n";
-      return;
-    }
+		char buf[256];
+		wsprintf(buf,"\\\\%s\\pipe\\ea_debug_v1",machine);
+		m_pipe=CreateFile(buf,GENERIC_READ|GENERIC_WRITE,
+			0,nullptr,OPEN_EXISTING,0,nullptr);
+		if (m_pipe==INVALID_HANDLE_VALUE)
+		{
+			dbg << "Could not connect to given machine.\n";
+			return;
+		}
 
-    // we're reading messages
-    DWORD mode=PIPE_READMODE_MESSAGE;
-    SetNamedPipeHandleState(m_pipe,&mode,nullptr,nullptr);
+		// we're reading messages
+		DWORD mode=PIPE_READMODE_MESSAGE;
+		SetNamedPipeHandleState(m_pipe,&mode,nullptr,nullptr);
 
-    // write welcome message
-    char comp[128];
-    mode=sizeof(comp);
-    GetComputerName(comp,&mode);
-    wsprintf(buf,"Client at %s\n",comp);
-    Write(Other,nullptr,buf);
-  }
+		// write welcome message
+		char comp[128];
+		mode=sizeof(comp);
+		GetComputerName(comp,&mode);
+		wsprintf(buf,"Client at %s\n",comp);
+		Write(Other,nullptr,buf);
+	}
 }
 
 DebugIOInterface *DebugIONet::Create()
 {
-  return new (DebugAllocMemory(sizeof(DebugIONet))) DebugIONet();
+	return new (DebugAllocMemory(sizeof(DebugIONet))) DebugIONet();
 }
 
 void DebugIONet::Delete()
 {
-  this->~DebugIONet();
-  DebugFreeMemory(this);
+	this->~DebugIONet();
+	DebugFreeMemory(this);
 }

--- a/Core/Libraries/Source/debug/debug_io_ods.cpp
+++ b/Core/Libraries/Source/debug/debug_io_ods.cpp
@@ -33,17 +33,17 @@
 
 void DebugIOOds::Write(StringType type, const char *src, const char *str)
 {
-  if (type!=StringType::StructuredCmdReply&&str)
-    OutputDebugString(str);
+	if (type!=StringType::StructuredCmdReply&&str)
+	OutputDebugString(str);
 }
 
 DebugIOInterface *DebugIOOds::Create()
 {
-  return new (DebugAllocMemory(sizeof(DebugIOOds))) DebugIOOds();
+	return new (DebugAllocMemory(sizeof(DebugIOOds))) DebugIOOds();
 }
 
 void DebugIOOds::Delete()
 {
-  this->~DebugIOOds();
-  DebugFreeMemory(this);
+	this->~DebugIOOds();
+	DebugFreeMemory(this);
 }

--- a/Core/Libraries/Source/debug/debug_macro.h
+++ b/Core/Libraries/Source/debug/debug_macro.h
@@ -359,9 +359,9 @@ DFAIL_IF_MSG(!ptrval,"pointer must not be null") return;
 // put these helper templates in a namespace...
 namespace _Debug
 {
-  template<bool> struct StaticAssertionFailed;
-  template<> struct StaticAssertionFailed<true> {};
-  template<int x> struct StaticAssertionTest {};
+	template<bool> struct StaticAssertionFailed;
+	template<> struct StaticAssertionFailed<true> {};
+	template<int x> struct StaticAssertionTest {};
 
   #define DCTASSERT(expr)         typedef ::_Debug::StaticAssertionTest< \
                                     sizeof(::_Debug::StaticAssertionFailed< (bool)(expr) >) \

--- a/Core/Libraries/Source/debug/debug_purecall.cpp
+++ b/Core/Libraries/Source/debug/debug_purecall.cpp
@@ -31,6 +31,6 @@
 // Pure virtual function called
 int __cdecl _purecall()
 {
-  DCRASH_RELEASE("Pure virtual function called.");
-  return 0;
+	DCRASH_RELEASE("Pure virtual function called.");
+	return 0;
 }

--- a/Core/Libraries/Source/debug/debug_stack.cpp
+++ b/Core/Libraries/Source/debug/debug_stack.cpp
@@ -42,11 +42,11 @@
 #define DBGHELP(name,ret,par) name##Type _##name;
 static union
 {
-  struct
-  {
+	struct
+	{
 #include "debug_stack.inl"
-  };
-  unsigned funcPtr[1];
+	};
+	unsigned funcPtr[1];
 } gDbg;
 #undef DBGHELP
 
@@ -66,9 +66,9 @@ static bool g_oldDbghelp;
 
 static void InitDbghelp()
 {
-  // already called?
-  if (g_dbghelp)
-    return;
+	// already called?
+	if (g_dbghelp)
+	return;
 
 	// firstly check for dbghelp.dll in the EXE directory
 	char dbgHelpPath[256];
@@ -85,240 +85,240 @@ static void InitDbghelp()
 		// load any version we can
 		g_dbghelp=::LoadLibrary("DBGHELP.DLL");
 
-  if (!g_dbghelp)
-    return;
+	if (!g_dbghelp)
+	return;
 
-  // Get function addresses
-  unsigned *funcptr=gDbg.funcPtr;
-  unsigned k=0;
-  for (;DebughelpFunctionNames[k];++k,++funcptr)
-  {
-    *funcptr=(unsigned)GetProcAddress(g_dbghelp,DebughelpFunctionNames[k]);
-    if (!*funcptr)
-      break;
-  }
-  if (DebughelpFunctionNames[k])
-  {
-    // not all functions found -> clear them all
-    while (funcptr!=gDbg.funcPtr)
-      *--funcptr=0;
-  }
-  else
-  {
-    // Set options
-    gDbg._SymSetOptions(gDbg._SymGetOptions()|SYMOPT_DEFERRED_LOADS|SYMOPT_LOAD_LINES);
+	// Get function addresses
+	unsigned *funcptr=gDbg.funcPtr;
+	unsigned k=0;
+	for (;DebughelpFunctionNames[k];++k,++funcptr)
+	{
+		*funcptr=(unsigned)GetProcAddress(g_dbghelp,DebughelpFunctionNames[k]);
+		if (!*funcptr)
+		break;
+	}
+	if (DebughelpFunctionNames[k])
+	{
+		// not all functions found -> clear them all
+		while (funcptr!=gDbg.funcPtr)
+		*--funcptr=0;
+	}
+	else
+	{
+		// Set options
+		gDbg._SymSetOptions(gDbg._SymGetOptions()|SYMOPT_DEFERRED_LOADS|SYMOPT_LOAD_LINES);
 
-    // Init module
-    gDbg._SymInitialize((HANDLE)GetCurrentProcessId(),nullptr,TRUE);
+		// Init module
+		gDbg._SymInitialize((HANDLE)GetCurrentProcessId(),nullptr,TRUE);
 
-    // Check: are we using a newer version of dbghelp.dll?
-    // (older versions have some serious issues.. err... bugs)
-    if (!GetProcAddress(g_dbghelp,"SymEnumSymbolsForAddr"))
-      g_oldDbghelp=true;
-  }
+		// Check: are we using a newer version of dbghelp.dll?
+		// (older versions have some serious issues.. err... bugs)
+		if (!GetProcAddress(g_dbghelp,"SymEnumSymbolsForAddr"))
+		g_oldDbghelp=true;
+	}
 }
 
 //////////////////////////////////////////////////////////////////////////////
 
 DebugStackwalk::Signature::Signature(const Signature &src)
 {
-  *this=src;
+	*this=src;
 }
 
 DebugStackwalk::Signature& DebugStackwalk::Signature::operator=(const Signature& src)
 {
-  if (&src!=this)
-  {
-    m_numAddr=src.m_numAddr;
-    memcpy(m_addr,src.m_addr,m_numAddr*sizeof(*m_addr));
-  }
-  return *this;
+	if (&src!=this)
+	{
+		m_numAddr=src.m_numAddr;
+		memcpy(m_addr,src.m_addr,m_numAddr*sizeof(*m_addr));
+	}
+	return *this;
 }
 
 unsigned DebugStackwalk::Signature::GetAddress(int n) const
 {
-  DFAIL_IF_MSG(n<0||n>=MAX_ADDR,n << "/" << MAX_ADDR) return 0;
-  return m_addr[n];
+	DFAIL_IF_MSG(n<0||n>=MAX_ADDR,n << "/" << MAX_ADDR) return 0;
+	return m_addr[n];
 }
 
 void DebugStackwalk::Signature::GetSymbol(unsigned addr, char *buf, unsigned bufSize)
 {
-  DFAIL_IF(!buf) return;
+	DFAIL_IF(!buf) return;
   DFAIL_IF(bufSize<64||bufSize>=0x80000000) return;
 
-  InitDbghelp();
+	InitDbghelp();
 
-  char *bufEnd=buf+bufSize;
-  *buf=0;
-  buf+=wsprintf(buf,"%08x",addr);
+	char *bufEnd=buf+bufSize;
+	*buf=0;
+	buf+=wsprintf(buf,"%08x",addr);
 
-  // determine module
-  unsigned modBase=gDbg._SymGetModuleBase((HANDLE)GetCurrentProcessId(),addr);
-  if (!modBase)
+	// determine module
+	unsigned modBase=gDbg._SymGetModuleBase((HANDLE)GetCurrentProcessId(),addr);
+	if (!modBase)
 	{
 		strcpy(buf," (unknown module)");
-    return;
+		return;
 	}
 
-  // illegal code ptr?
+	// illegal code ptr?
 	if (IsBadReadPtr((void *)addr,4)||IsBadCodePtr((FARPROC)addr))
 	{
 		strcpy(buf," (invalid code addr)");
 		return;
 	}
 
-  char symbolBuffer[512];
-  GetModuleFileName((HMODULE)modBase,symbolBuffer,sizeof(symbolBuffer));
+	char symbolBuffer[512];
+	GetModuleFileName((HMODULE)modBase,symbolBuffer,sizeof(symbolBuffer));
 
-  char *p=strrchr(symbolBuffer,'\\'); // use filename only, strip off path
-  p=p?p+1:symbolBuffer;
-  *buf++=' ';
-  strcpy(buf,p);
-  buf+=strlen(buf);
-  if (bufEnd-buf<32)
-    return;
-  buf+=wsprintf(buf,"+0x%x",addr-modBase);
+	char *p=strrchr(symbolBuffer,'\\'); // use filename only, strip off path
+	p=p?p+1:symbolBuffer;
+	*buf++=' ';
+	strcpy(buf,p);
+	buf+=strlen(buf);
+	if (bufEnd-buf<32)
+	return;
+	buf+=wsprintf(buf,"+0x%x",addr-modBase);
 
-  // determine symbol
-  PIMAGEHLP_SYMBOL symPtr=(PIMAGEHLP_SYMBOL)symbolBuffer;
-  memset(symPtr,0,sizeof(symbolBuffer));
-  symPtr->SizeOfStruct=sizeof(IMAGEHLP_SYMBOL);
-  symPtr->MaxNameLength=sizeof(symbolBuffer)-sizeof(IMAGEHLP_SYMBOL);
-  DWORD displacement;
-  if (!gDbg._SymGetSymFromAddr((HANDLE)GetCurrentProcessId(),addr,&displacement,symPtr))
-    return;
-  if ((unsigned int)(bufEnd-buf)<strlen(symPtr->Name)+16)
-    return;
-  buf+=wsprintf(buf,", %s+0x%x",symPtr->Name,displacement);
+	// determine symbol
+	PIMAGEHLP_SYMBOL symPtr=(PIMAGEHLP_SYMBOL)symbolBuffer;
+	memset(symPtr,0,sizeof(symbolBuffer));
+	symPtr->SizeOfStruct=sizeof(IMAGEHLP_SYMBOL);
+	symPtr->MaxNameLength=sizeof(symbolBuffer)-sizeof(IMAGEHLP_SYMBOL);
+	DWORD displacement;
+	if (!gDbg._SymGetSymFromAddr((HANDLE)GetCurrentProcessId(),addr,&displacement,symPtr))
+	return;
+	if ((unsigned int)(bufEnd-buf)<strlen(symPtr->Name)+16)
+	return;
+	buf+=wsprintf(buf,", %s+0x%x",symPtr->Name,displacement);
 
-  // and line number
-  IMAGEHLP_LINE line;
-  memset(&line,0,sizeof(line));
-  line.SizeOfStruct=sizeof(line);
-  if (!gDbg._SymGetLineFromAddr((HANDLE)GetCurrentProcessId(),addr,&displacement,&line))
-    return;
+	// and line number
+	IMAGEHLP_LINE line;
+	memset(&line,0,sizeof(line));
+	line.SizeOfStruct=sizeof(line);
+	if (!gDbg._SymGetLineFromAddr((HANDLE)GetCurrentProcessId(),addr,&displacement,&line))
+	return;
 
-  p=strrchr(line.FileName,'\\'); // use filename only, strip off path
-  p=p?p+1:line.FileName;
+	p=strrchr(line.FileName,'\\'); // use filename only, strip off path
+	p=p?p+1:line.FileName;
 
-  if ((unsigned int)(bufEnd-buf)<strlen(p)+16)
-    return;
-  buf+=wsprintf(buf,", %s:%i+0x%x",p,line.LineNumber,displacement);
+	if ((unsigned int)(bufEnd-buf)<strlen(p)+16)
+	return;
+	buf+=wsprintf(buf,", %s:%i+0x%x",p,line.LineNumber,displacement);
 }
 
 void DebugStackwalk::Signature::GetSymbol(unsigned addr,
-                                          char *bufMod, unsigned sizeMod, unsigned *relMod,
-                                          char *bufSym, unsigned sizeSym, unsigned *relSym,
-                                          char *bufFile, unsigned sizeFile, unsigned *linePtr, unsigned *relLine)
+	char *bufMod, unsigned sizeMod, unsigned *relMod,
+	char *bufSym, unsigned sizeSym, unsigned *relSym,
+	char *bufFile, unsigned sizeFile, unsigned *linePtr, unsigned *relLine)
 {
-  InitDbghelp();
+	InitDbghelp();
 
-  if (bufMod) *bufMod=0;
-  if (relMod) *relMod=0;
-  if (bufSym) *bufSym=0;
-  if (relSym) *relSym=0;
+	if (bufMod) *bufMod=0;
+	if (relMod) *relMod=0;
+	if (bufSym) *bufSym=0;
+	if (relSym) *relSym=0;
 
-  if (bufFile) *bufFile=0;
-  if (linePtr) *linePtr=0;
-  if (relLine) *relLine=0;
+	if (bufFile) *bufFile=0;
+	if (linePtr) *linePtr=0;
+	if (relLine) *relLine=0;
 
-  DFAIL_IF(bufMod&&sizeMod<16) return;
-  DFAIL_IF(bufSym&&sizeSym<16) return;
-  DFAIL_IF(bufFile&&sizeFile<16) return;
+	DFAIL_IF(bufMod&&sizeMod<16) return;
+	DFAIL_IF(bufSym&&sizeSym<16) return;
+	DFAIL_IF(bufFile&&sizeFile<16) return;
 
-  // determine module
-  unsigned modBase=gDbg._SymGetModuleBase((HANDLE)GetCurrentProcessId(),addr);
-  if (!modBase)
+	// determine module
+	unsigned modBase=gDbg._SymGetModuleBase((HANDLE)GetCurrentProcessId(),addr);
+	if (!modBase)
 	{
-    if (bufMod)
-		  strcpy(bufMod,"(unknown mod)");
-    if (bufSym)
-      strcpy(bufSym,"(unknown)");
-    return;
-	}
-
-  // illegal code ptr?
-	if (IsBadReadPtr((void *)addr,4)||IsBadCodePtr((FARPROC)addr))
-	{
-    if (bufMod)
-		  strcpy(bufMod,"(inv code addr)");
-    if (bufSym)
-      strcpy(bufSym,"(unknown)");
+		if (bufMod)
+		strcpy(bufMod,"(unknown mod)");
+		if (bufSym)
+		strcpy(bufSym,"(unknown)");
 		return;
 	}
 
-  char symbolBuffer[512];
-  if (bufMod)
-  {
-    GetModuleFileName((HMODULE)modBase,symbolBuffer,sizeof(symbolBuffer));
+	// illegal code ptr?
+	if (IsBadReadPtr((void *)addr,4)||IsBadCodePtr((FARPROC)addr))
+	{
+		if (bufMod)
+		strcpy(bufMod,"(inv code addr)");
+		if (bufSym)
+		strcpy(bufSym,"(unknown)");
+		return;
+	}
 
-    char *p=strrchr(symbolBuffer,'\\'); // use filename only, strip off path
-    p=p?p+1:symbolBuffer;
-    strlcpy(bufMod,p,sizeMod);
-  }
-  if (relMod)
-    *relMod=addr-modBase;
+	char symbolBuffer[512];
+	if (bufMod)
+	{
+		GetModuleFileName((HMODULE)modBase,symbolBuffer,sizeof(symbolBuffer));
 
-  // determine symbol
-  if (bufSym)
-  {
-    PIMAGEHLP_SYMBOL symPtr=(PIMAGEHLP_SYMBOL)symbolBuffer;
-    memset(symPtr,0,sizeof(symbolBuffer));
-    symPtr->SizeOfStruct=sizeof(IMAGEHLP_SYMBOL);
-    symPtr->MaxNameLength=sizeof(symbolBuffer)-sizeof(IMAGEHLP_SYMBOL);
-    DWORD displacement;
-    if (gDbg._SymGetSymFromAddr((HANDLE)GetCurrentProcessId(),addr,&displacement,symPtr))
-    {
-      strlcpy(bufSym,symPtr->Name,sizeSym);
-      if (relSym)
-        *relSym=displacement;
-    }
-    else
-      strcpy(bufSym,"(unknown)");
-  }
+		char *p=strrchr(symbolBuffer,'\\'); // use filename only, strip off path
+		p=p?p+1:symbolBuffer;
+		strlcpy(bufMod,p,sizeMod);
+	}
+	if (relMod)
+	*relMod=addr-modBase;
 
-  // and line number
-  if (bufFile)
-  {
-    IMAGEHLP_LINE line;
-    memset(&line,0,sizeof(line));
-    line.SizeOfStruct=sizeof(line);
-    DWORD displacement;
-    if (!gDbg._SymGetLineFromAddr((HANDLE)GetCurrentProcessId(),addr,&displacement,&line))
-      strcpy(bufFile,"(unknown)");
-    else
-    {
-      char *p=strrchr(line.FileName,'\\'); // use filename only, strip off path
-      p=p?p+1:line.FileName;
-      strlcpy(bufFile,p,sizeFile);
-      if (linePtr)
-        *linePtr=line.LineNumber;
-      if (relLine)
-        *relLine=displacement;
-    }
-  }
+	// determine symbol
+	if (bufSym)
+	{
+		PIMAGEHLP_SYMBOL symPtr=(PIMAGEHLP_SYMBOL)symbolBuffer;
+		memset(symPtr,0,sizeof(symbolBuffer));
+		symPtr->SizeOfStruct=sizeof(IMAGEHLP_SYMBOL);
+		symPtr->MaxNameLength=sizeof(symbolBuffer)-sizeof(IMAGEHLP_SYMBOL);
+		DWORD displacement;
+		if (gDbg._SymGetSymFromAddr((HANDLE)GetCurrentProcessId(),addr,&displacement,symPtr))
+		{
+			strlcpy(bufSym,symPtr->Name,sizeSym);
+			if (relSym)
+			*relSym=displacement;
+		}
+		else
+		strcpy(bufSym,"(unknown)");
+	}
+
+	// and line number
+	if (bufFile)
+	{
+		IMAGEHLP_LINE line;
+		memset(&line,0,sizeof(line));
+		line.SizeOfStruct=sizeof(line);
+		DWORD displacement;
+		if (!gDbg._SymGetLineFromAddr((HANDLE)GetCurrentProcessId(),addr,&displacement,&line))
+		strcpy(bufFile,"(unknown)");
+		else
+		{
+			char *p=strrchr(line.FileName,'\\'); // use filename only, strip off path
+			p=p?p+1:line.FileName;
+			strlcpy(bufFile,p,sizeFile);
+			if (linePtr)
+			*linePtr=line.LineNumber;
+			if (relLine)
+			*relLine=displacement;
+		}
+	}
 }
 
 Debug& operator<<(Debug &dbg, const DebugStackwalk::Signature &sig)
 {
-  dbg << sig.Size() << " addresses:\n";
+	dbg << sig.Size() << " addresses:\n";
 
-  for (unsigned k=0;k<sig.Size();k++)
-  {
-    char buf[512];
-    sig.GetSymbol(sig.GetAddress(k),buf,sizeof(buf));
-    dbg << buf << "\n";
-  }
+	for (unsigned k=0;k<sig.Size();k++)
+	{
+		char buf[512];
+		sig.GetSymbol(sig.GetAddress(k),buf,sizeof(buf));
+		dbg << buf << "\n";
+	}
 
-  return dbg;
+	return dbg;
 }
 
 //////////////////////////////////////////////////////////////////////////////
 
 DebugStackwalk::DebugStackwalk()
 {
-  // it doesn't harm to do this here
-  InitDbghelp();
+	// it doesn't harm to do this here
+	InitDbghelp();
 }
 
 DebugStackwalk::~DebugStackwalk()
@@ -327,23 +327,23 @@ DebugStackwalk::~DebugStackwalk()
 
 void *DebugStackwalk::GetDbghelpHandle()
 {
-  return g_dbghelp;
+	return g_dbghelp;
 }
 
 bool DebugStackwalk::IsOldDbghelp()
 {
-  return g_oldDbghelp;
+	return g_oldDbghelp;
 }
 
 int DebugStackwalk::StackWalk(Signature &sig, struct _CONTEXT *ctx)
 {
-  InitDbghelp();
+	InitDbghelp();
 
-  sig.m_numAddr=0;
+	sig.m_numAddr=0;
 
-  // bail out if no stack walk available
-  if (!gDbg._StackWalk)
-    return 0;
+	// bail out if no stack walk available
+	if (!gDbg._StackWalk)
+	return 0;
 
 	// Set up the stack frame structure for the start point of the stack walk (i.e. here).
 	STACKFRAME stackFrame;
@@ -355,51 +355,51 @@ int DebugStackwalk::StackWalk(Signature &sig, struct _CONTEXT *ctx)
 
 	// Use the context struct if it was provided.
 	if (ctx)
-  {
+	{
 		stackFrame.AddrPC.Offset = ctx->Eip;
 		stackFrame.AddrStack.Offset = ctx->Esp;
 		stackFrame.AddrFrame.Offset = ctx->Ebp;
 	}
-  else
-  {
-    // walk stack back using current call chain
-	  unsigned long reg_eip, reg_ebp, reg_esp;
+	else
+	{
+		// walk stack back using current call chain
+		unsigned long reg_eip, reg_ebp, reg_esp;
 #if defined(_MSC_VER)
-	  __asm
-    {
-    here:
-		  lea	eax,here
+		__asm
+		{
+			here:
+			lea	eax,here
 		  mov	reg_eip,eax
 		  mov	reg_ebp,ebp
 		  mov	reg_esp,esp
 	  };
 #elif (defined(__GNUC__) || defined(__clang__)) && (defined(__i386__) || defined(_M_IX86))
-	  __asm__ __volatile__ (
-		  "call 1f\n\t"
-		  "1: pop %0\n\t"
-		  "mov %%ebp, %1\n\t"
-		  "mov %%esp, %2"
-		  : "=r" (reg_eip), "=r" (reg_ebp), "=r" (reg_esp)
-	  );
+			__asm__ __volatile__ (
+				"call 1f\n\t"
+				"1: pop %0\n\t"
+				"mov %%ebp, %1\n\t"
+				"mov %%esp, %2"
+				: "=r" (reg_eip), "=r" (reg_ebp), "=r" (reg_esp)
+			);
 #else
 #error "Unsupported compiler or architecture for register capture"
 #endif
-	  stackFrame.AddrPC.Offset = reg_eip;
-	  stackFrame.AddrStack.Offset = reg_esp;
-	  stackFrame.AddrFrame.Offset = reg_ebp;
-  }
+			stackFrame.AddrPC.Offset = reg_eip;
+			stackFrame.AddrStack.Offset = reg_esp;
+			stackFrame.AddrFrame.Offset = reg_ebp;
+		}
 
 	// Walk the stack by the requested number of return address iterations.
-  bool skipFirst=!ctx;
-  while (sig.m_numAddr<Signature::MAX_ADDR&&
-		     gDbg._StackWalk(IMAGE_FILE_MACHINE_I386,GetCurrentProcess(),GetCurrentThread(),
-                         &stackFrame,nullptr,nullptr,gDbg._SymFunctionTableAccess,gDbg._SymGetModuleBase,nullptr))
-  {
-    if (skipFirst)
-      skipFirst=false;
-    else
-      sig.m_addr[sig.m_numAddr++]=stackFrame.AddrPC.Offset;
-  }
+		bool skipFirst=!ctx;
+		while (sig.m_numAddr<Signature::MAX_ADDR&&
+			gDbg._StackWalk(IMAGE_FILE_MACHINE_I386,GetCurrentProcess(),GetCurrentThread(),
+			&stackFrame,nullptr,nullptr,gDbg._SymFunctionTableAccess,gDbg._SymGetModuleBase,nullptr))
+		{
+			if (skipFirst)
+			skipFirst=false;
+			else
+			sig.m_addr[sig.m_numAddr++]=stackFrame.AddrPC.Offset;
+		}
 
 	return sig.m_numAddr;
 }

--- a/Core/Libraries/Source/debug/debug_stack.h
+++ b/Core/Libraries/Source/debug/debug_stack.h
@@ -32,43 +32,43 @@
 /// \brief stack walker class (singleton)
 class DebugStackwalk
 {
-  friend class Debug;
+	friend class Debug;
 
-  DebugStackwalk(const DebugStackwalk&);
-  DebugStackwalk& operator=(DebugStackwalk&);
+	DebugStackwalk(const DebugStackwalk&);
+	DebugStackwalk& operator=(DebugStackwalk&);
 
-  // private so that only Debug can create and destroy us
-  DebugStackwalk();
-  ~DebugStackwalk();
+	// private so that only Debug can create and destroy us
+	DebugStackwalk();
+	~DebugStackwalk();
 
 public:
 
-  /// \brief a stack trace signature
-  class Signature
-  {
-    // makes life easier :)
-    friend class DebugStackwalk;
+	/// \brief a stack trace signature
+	class Signature
+	{
+		// makes life easier :)
+		friend class DebugStackwalk;
 
-    /// max # of possible addresses
-    enum { MAX_ADDR = 256 };
+		/// max # of possible addresses
+		enum { MAX_ADDR = 256 };
 
-    /// number of addresses
-    unsigned m_numAddr;
+		/// number of addresses
+		unsigned m_numAddr;
 
-    /// addresses
-    unsigned m_addr[MAX_ADDR];
+		/// addresses
+		unsigned m_addr[MAX_ADDR];
 
-  public:
-    explicit Signature(): m_numAddr(0) {}
-    Signature(const Signature &src);
-    Signature& operator=(const Signature& src);
+	public:
+		explicit Signature(): m_numAddr(0) {}
+		Signature(const Signature &src);
+		Signature& operator=(const Signature& src);
 
     /**
       \brief Determine the number of addresses in this signature.
 
       \return number of addresses in this signature
     */
-    unsigned Size() const { return m_numAddr; }
+		unsigned Size() const { return m_numAddr; }
 
     /**
       \brief Get a single address from the signature.
@@ -78,7 +78,7 @@ public:
       \param n index, 0..Size()-1
       \return signature address
     */
-    unsigned GetAddress(int n) const;
+		unsigned GetAddress(int n) const;
 
     /**
       \brief Strong ordering operator.
@@ -87,18 +87,18 @@ public:
       first. Implemented inline so that STL algorithms using this
       operator can be compiled more efficiently.
     */
-    bool operator<(const Signature &other) const
-    {
-      unsigned m=m_numAddr<other.m_numAddr?m_numAddr:other.m_numAddr;
-      for (unsigned k=0;k<m;k++)
-      {
-        if (m_addr[m_numAddr-k-1]<other.m_addr[other.m_numAddr-k-1])
-          return true;
-        if (m_addr[m_numAddr-k-1]>other.m_addr[other.m_numAddr-k-1])
-          return false;
-      }
-      return m_numAddr<other.m_numAddr;
-    }
+		bool operator<(const Signature &other) const
+		{
+		unsigned m=m_numAddr<other.m_numAddr?m_numAddr:other.m_numAddr;
+		for (unsigned k=0;k<m;k++)
+			{
+		if (m_addr[m_numAddr-k-1]<other.m_addr[other.m_numAddr-k-1])
+		return true;
+		if (m_addr[m_numAddr-k-1]>other.m_addr[other.m_numAddr-k-1])
+		return false;
+			}
+		return m_numAddr<other.m_numAddr;
+		}
 
     /**
       \brief Determines symbol for given address.
@@ -110,7 +110,7 @@ public:
       \param buf return buffer
       \param bufSize size of return buffer, minimum is 64 bytes (256 recommended)
     */
-    static void GetSymbol(unsigned addr, char *buf, unsigned bufSize);
+		static void GetSymbol(unsigned addr, char *buf, unsigned bufSize);
 
     /**
       \brief Determines symbol for given address.
@@ -127,25 +127,25 @@ public:
       \param line line number, may be nullptr
       \param relLine relative address within line, may be nullptr
     */
-    static void GetSymbol(unsigned addr,
-                          char *bufMod, unsigned sizeMod, unsigned *relMod,
-                          char *bufSym, unsigned sizeSym, unsigned *relSym,
-                          char *bufFile, unsigned sizeFile, unsigned *line, unsigned *relLine);
-  };
+		static void GetSymbol(unsigned addr,
+			char *bufMod, unsigned sizeMod, unsigned *relMod,
+			char *bufSym, unsigned sizeSym, unsigned *relSym,
+			char *bufFile, unsigned sizeFile, unsigned *line, unsigned *relLine);
+	};
 
   /** \internal
     \brief Returns dbghelp.dll DLL handle.
 
     \return dbghelp.dll DLL handle
   */
-  static void *GetDbghelpHandle();
+	static void *GetDbghelpHandle();
 
   /** \internal
     \brief Checks if dbghelp.dll version is old.
 
     \return true if old version, false if not
   */
-  static bool IsOldDbghelp();
+	static bool IsOldDbghelp();
 
   /**
     \brief Walks the stack from the given address.
@@ -154,7 +154,7 @@ public:
     \param ctx processor context, if nullptr then use current address
     \return number of addresses found
   */
-  static int StackWalk(Signature &sig, struct _CONTEXT *ctx=0);
+	static int StackWalk(Signature &sig, struct _CONTEXT *ctx=0);
 };
 
 /**

--- a/Core/Libraries/Source/debug/debug_stack.inl
+++ b/Core/Libraries/Source/debug/debug_stack.inl
@@ -20,8 +20,8 @@
 
 // keep this always as first entry
 DBGHELP(SymInitialize,
-        BOOL,
-        (HANDLE hProcess, PCSTR UserSearchPath, BOOL fInvadeProcess))
+	BOOL,
+	(HANDLE hProcess, PCSTR UserSearchPath, BOOL fInvadeProcess))
 
 DBGHELP(SymGetOptions,
         DWORD,

--- a/Core/Libraries/Source/debug/internal.h
+++ b/Core/Libraries/Source/debug/internal.h
@@ -85,12 +85,12 @@ void DebugFreeMemory(void *ptr);
 class DebugCmdInterfaceDebug: public DebugCmdInterface
 {
 public:
-  virtual bool Execute(class Debug& dbg, const char *cmd, CommandMode cmdmode,
-                       unsigned argn, const char * const * argv);
+	virtual bool Execute(class Debug& dbg, const char *cmd, CommandMode cmdmode,
+		unsigned argn, const char * const * argv);
 
-  virtual void Delete()
-  {
-    this->~DebugCmdInterfaceDebug();
-    DebugFreeMemory(this);
-  }
+	virtual void Delete()
+	{
+		this->~DebugCmdInterfaceDebug();
+		DebugFreeMemory(this);
+	}
 };

--- a/Core/Libraries/Source/debug/internal_except.h
+++ b/Core/Libraries/Source/debug/internal_except.h
@@ -32,11 +32,11 @@
 /// \internal exception handler
 class DebugExceptionhandler
 {
-  DebugExceptionhandler(const DebugExceptionhandler&);
-  DebugExceptionhandler& operator=(const DebugExceptionhandler&);
+	DebugExceptionhandler(const DebugExceptionhandler&);
+	DebugExceptionhandler& operator=(const DebugExceptionhandler&);
 
-  // nobody can instantiate us
-  DebugExceptionhandler();
+	// nobody can instantiate us
+	DebugExceptionhandler();
 
   /** \internal
 
@@ -45,7 +45,7 @@ class DebugExceptionhandler
     \param dbg debug instance
     \param exptr exception pointers
   */
-  static void LogExceptionLocation(Debug &dbg, struct _EXCEPTION_POINTERS *exptr);
+	static void LogExceptionLocation(Debug &dbg, struct _EXCEPTION_POINTERS *exptr);
 
   /** \internal
 
@@ -54,7 +54,7 @@ class DebugExceptionhandler
     \param dbg debug instance
     \param exptr exception pointers
   */
-  static void LogRegisters(Debug &dbg, struct _EXCEPTION_POINTERS *exptr);
+	static void LogRegisters(Debug &dbg, struct _EXCEPTION_POINTERS *exptr);
 
   /** \internal
 
@@ -63,7 +63,7 @@ class DebugExceptionhandler
     \param dbg debug instance
     \param exptr exception pointers
   */
-  static void LogFPURegisters(Debug &dbg, struct _EXCEPTION_POINTERS *exptr);
+	static void LogFPURegisters(Debug &dbg, struct _EXCEPTION_POINTERS *exptr);
 
 public:
 
@@ -75,11 +75,11 @@ public:
     \param explanation exception explanation, buffer must be 512 chars
     \return exception type as string
   */
-  static const char *GetExceptionType(struct _EXCEPTION_POINTERS *exptr, char *explanation);
+	static const char *GetExceptionType(struct _EXCEPTION_POINTERS *exptr, char *explanation);
 
   /** \internal
 
     \brief System exception filter
   */
-  static long __stdcall ExceptionFilter(struct _EXCEPTION_POINTERS* pExPtrs);
+	static long __stdcall ExceptionFilter(struct _EXCEPTION_POINTERS* pExPtrs);
 };

--- a/Core/Libraries/Source/debug/internal_io.h
+++ b/Core/Libraries/Source/debug/internal_io.h
@@ -38,70 +38,70 @@ class DebugIOCon: public DebugIOInterface
     true if we allocated the console, false if there has already
     been a console
   */
-  bool m_allocatedConsole;
+	bool m_allocatedConsole;
 
   /**
     internal input buffer
   */
-  char m_input[256];
+	char m_input[256];
 
   /**
     number of bytes in input buffer
   */
-  unsigned m_inputUsed;
+	unsigned m_inputUsed;
 
   /**
     Current read position. This variable is 0 while data is
     composed into m_input and >0 while multiple Read calls are
     received.
   */
-  unsigned m_inputRead;
+	unsigned m_inputRead;
 
 public:
-  explicit DebugIOCon();
-  virtual ~DebugIOCon();
-  virtual int Read(char *buf, int maxchar);
-  virtual void Write(StringType type, const char *src, const char *str);
-  virtual void EmergencyFlush() {}
-  virtual void Execute(class Debug& dbg, const char *cmd, bool structuredCmd,
-                       unsigned argn, const char * const * argv);
-  static DebugIOInterface *Create();
-  virtual void Delete();
+	explicit DebugIOCon();
+	virtual ~DebugIOCon();
+	virtual int Read(char *buf, int maxchar);
+	virtual void Write(StringType type, const char *src, const char *str);
+	virtual void EmergencyFlush() {}
+	virtual void Execute(class Debug& dbg, const char *cmd, bool structuredCmd,
+		unsigned argn, const char * const * argv);
+	static DebugIOInterface *Create();
+	virtual void Delete();
 };
 
 /// \internal \brief con flat I/O class
 class DebugIOFlat: public DebugIOInterface
 {
-  /// \brief single output stream
-  class OutputStream
-  {
-    OutputStream(const OutputStream&);
-    OutputStream& operator=(const OutputStream&);
+	/// \brief single output stream
+	class OutputStream
+	{
+		OutputStream(const OutputStream&);
+		OutputStream& operator=(const OutputStream&);
 
-    /// output file name (dynamically allocated)
-    char *m_fileName;
+		/// output file name (dynamically allocated)
+		char *m_fileName;
 
-    /// output file handle (only if unlimited output buffer size)
-    HANDLE m_fileHandle;
+		/// output file handle (only if unlimited output buffer size)
+		HANDLE m_fileHandle;
 
-    /// file size limited?
-    bool m_limitedFileSize;
+		/// file size limited?
+		bool m_limitedFileSize;
 
-    /// output buffer
-    char *m_buffer;
+		/// output buffer
+		char *m_buffer;
 
-    /// number of bytes in buffer
-    unsigned m_bufferUsed;
+		/// number of bytes in buffer
+		unsigned m_bufferUsed;
 
-    /// size of buffer (if m_limitedFileSize then m_bufferSize==m_maxSize)
-    unsigned m_bufferSize;
+		/// size of buffer (if m_limitedFileSize then m_bufferSize==m_maxSize)
+		unsigned m_bufferSize;
 
-    /// position of next free char in ring buffer (used if m_limitedFileSize)
-    unsigned m_nextChar;
+		/// position of next free char in ring buffer (used if m_limitedFileSize)
+		unsigned m_nextChar;
 
-    // these are private so that we are forced to use Create/Destroy
-    OutputStream(const char *filename, unsigned maxSize);
-    ~OutputStream();
+		// these are private so that we are forced to use Create/Destroy
+		OutputStream(const char *filename, unsigned maxSize);
+		~OutputStream();
 
     /**
       \brief Writes some data to output stream.
@@ -109,9 +109,9 @@ class DebugIOFlat: public DebugIOInterface
       \param src string to write
       \param len number of bytes to write
     */
-    void InternalWrite(const char *src, unsigned len);
+		void InternalWrite(const char *src, unsigned len);
 
-  public:
+	public:
 
     /**
       \brief Creates a new output stream instance.
@@ -119,7 +119,7 @@ class DebugIOFlat: public DebugIOInterface
       \param filename name of output file (will be overwritten if it exists)
       \param maxSize maximum size of output file, unlimited if 0
     */
-    static OutputStream *Create(const char *filename, unsigned maxSize);
+		static OutputStream *Create(const char *filename, unsigned maxSize);
 
     /**
       \brief Destroys this object.
@@ -130,74 +130,74 @@ class DebugIOFlat: public DebugIOInterface
 
       \param path optional path to a destination directory
     */
-    void Delete(const char *path=nullptr);
+		void Delete(const char *path=nullptr);
 
     /**
       \brief Determines name of output stream.
 
       \return name of output stream
     */
-    const char *GetFilename() { return m_fileName; }
+		const char *GetFilename() { return m_fileName; }
 
     /**
       \brief Writes data to the output stream.
 
       \param src NUL delimited string to write
     */
-    void Write(const char *src);
+		void Write(const char *src);
 
     /**
       \brief Flushes all buffered data.
     */
-    void Flush();
-  };
+		void Flush();
+	};
 
-  /// \brief a single split structure
-  struct SplitListEntry
-  {
-    /// next split
-    SplitListEntry *next;
+	/// \brief a single split structure
+	struct SplitListEntry
+	{
+		/// next split
+		SplitListEntry *next;
 
-    /// for which string types?
-    unsigned stringTypes;
+		/// for which string types?
+		unsigned stringTypes;
 
-    /// for which items?
-    char items[256];
+		/// for which items?
+		char items[256];
 
-    /// split name
-    char name[256];
+		/// split name
+		char name[256];
 
-    /// into which stream? (note: pointer not owned by this!)
-    OutputStream *stream;
-  };
+		/// into which stream? (note: pointer not owned by this!)
+		OutputStream *stream;
+	};
 
-  /// \brief List of output streams
-  struct StreamListEntry
-  {
-    /// next entry
-    StreamListEntry *next;
+	/// \brief List of output streams
+	struct StreamListEntry
+	{
+		/// next entry
+		StreamListEntry *next;
 
-    /// which stream?
-    OutputStream *stream;
-  };
+		/// which stream?
+		OutputStream *stream;
+	};
 
-  /// first split
-  SplitListEntry *m_firstSplit;
+	/// first split
+	SplitListEntry *m_firstSplit;
 
-  /// end of split list pointer
-  SplitListEntry **m_lastSplitPtr;
+	/// end of split list pointer
+	SplitListEntry **m_lastSplitPtr;
 
-  /// first output stream (first is always the default output stream)
-  StreamListEntry *m_firstStream;
+	/// first output stream (first is always the default output stream)
+	StreamListEntry *m_firstStream;
 
-  /// end of stream list pointer
-  StreamListEntry **m_lastStreamPtr;
+	/// end of stream list pointer
+	StreamListEntry **m_lastStreamPtr;
 
-  /// base filename
-  char m_baseFilename[256];
+	/// base filename
+	char m_baseFilename[256];
 
-  /// copy location
-  char m_copyDir[256];
+	/// copy location
+	char m_copyDir[256];
 
   /**
     \brief Expands a magic filename into a real filename.
@@ -206,48 +206,48 @@ class DebugIOFlat: public DebugIOInterface
     \param splitName split name, null for default stream
     \param buf output buffer, must have a size of at least 256 char's
   */
-  static void ExpandMagic(const char *src, const char *splitName, char *buf);
+	static void ExpandMagic(const char *src, const char *splitName, char *buf);
 
 public:
-  explicit DebugIOFlat();
-  virtual ~DebugIOFlat();
-  virtual int Read(char *buf, int maxchar) { return 0; }
-  virtual void Write(StringType type, const char *src, const char *str);
-  virtual void EmergencyFlush();
-  virtual void Execute(class Debug& dbg, const char *cmd, bool structuredCmd,
-                       unsigned argn, const char * const * argv);
-  static DebugIOInterface *Create();
-  virtual void Delete();
+	explicit DebugIOFlat();
+	virtual ~DebugIOFlat();
+	virtual int Read(char *buf, int maxchar) { return 0; }
+	virtual void Write(StringType type, const char *src, const char *str);
+	virtual void EmergencyFlush();
+	virtual void Execute(class Debug& dbg, const char *cmd, bool structuredCmd,
+		unsigned argn, const char * const * argv);
+	static DebugIOInterface *Create();
+	virtual void Delete();
 };
 
 /// \internal \brief net debug I/O class
 class DebugIONet: public DebugIOInterface
 {
-  /// our pipe handle
-  HANDLE m_pipe;
+	/// our pipe handle
+	HANDLE m_pipe;
 
 public:
-  explicit DebugIONet();
-  virtual ~DebugIONet();
-  virtual int Read(char *buf, int maxchar);
-  virtual void Write(StringType type, const char *src, const char *str);
-  virtual void EmergencyFlush();
-  virtual void Execute(class Debug& dbg, const char *cmd, bool structuredCmd,
-                       unsigned argn, const char * const * argv);
-  static DebugIOInterface *Create();
-  virtual void Delete();
+	explicit DebugIONet();
+	virtual ~DebugIONet();
+	virtual int Read(char *buf, int maxchar);
+	virtual void Write(StringType type, const char *src, const char *str);
+	virtual void EmergencyFlush();
+	virtual void Execute(class Debug& dbg, const char *cmd, bool structuredCmd,
+		unsigned argn, const char * const * argv);
+	static DebugIOInterface *Create();
+	virtual void Delete();
 };
 
 /// \internal \brief ods debug I/O class
 class DebugIOOds: public DebugIOInterface
 {
 public:
-  explicit DebugIOOds() {}
-  virtual int Read(char *buf, int maxchar) { return 0; }
-  virtual void Write(StringType type, const char *src, const char *str);
-  virtual void EmergencyFlush() {}
-  virtual void Execute(class Debug& dbg, const char *cmd, bool structuredCmd,
-                       unsigned argn, const char * const * argv) {}
-  static DebugIOInterface *Create();
-  virtual void Delete();
+	explicit DebugIOOds() {}
+	virtual int Read(char *buf, int maxchar) { return 0; }
+	virtual void Write(StringType type, const char *src, const char *str);
+	virtual void EmergencyFlush() {}
+	virtual void Execute(class Debug& dbg, const char *cmd, bool structuredCmd,
+		unsigned argn, const char * const * argv) {}
+	static DebugIOInterface *Create();
+	virtual void Delete();
 };

--- a/Core/Libraries/Source/debug/netserv/netserv.cpp
+++ b/Core/Libraries/Source/debug/netserv/netserv.cpp
@@ -39,290 +39,290 @@ static unsigned m_inputUsed;
 
 static void InitConsole()
 {
-  AllocConsole();
+	AllocConsole();
 
-  HANDLE h=GetStdHandle(STD_INPUT_HANDLE);
-  SetConsoleMode(h,0);
+	HANDLE h=GetStdHandle(STD_INPUT_HANDLE);
+	SetConsoleMode(h,0);
 
-  // make screen buffer same size as currently displayed area
-  // (prevents that our input line gets scrolled out of view)
-  h=GetStdHandle(STD_OUTPUT_HANDLE);
-  CONSOLE_SCREEN_BUFFER_INFO info;
-  GetConsoleScreenBufferInfo(h,&info);
+	// make screen buffer same size as currently displayed area
+	// (prevents that our input line gets scrolled out of view)
+	h=GetStdHandle(STD_OUTPUT_HANDLE);
+	CONSOLE_SCREEN_BUFFER_INFO info;
+	GetConsoleScreenBufferInfo(h,&info);
 
-  COORD newSize;
-  newSize.X=info.srWindow.Right+1;
-  newSize.Y=info.srWindow.Bottom+1;
-  SetConsoleScreenBufferSize(h,newSize);
+	COORD newSize;
+	newSize.X=info.srWindow.Right+1;
+	newSize.Y=info.srWindow.Bottom+1;
+	SetConsoleScreenBufferSize(h,newSize);
 
-  // hide cursor
-  CONSOLE_CURSOR_INFO ci;
-  ci.dwSize=1;
-  ci.bVisible=FALSE;
-  SetConsoleCursorInfo(h,&ci);
+	// hide cursor
+	CONSOLE_CURSOR_INFO ci;
+	ci.dwSize=1;
+	ci.bVisible=FALSE;
+	SetConsoleCursorInfo(h,&ci);
 }
 
 static char *InputConsole()
 {
-  // update our input buffer
-  HANDLE h=GetStdHandle(STD_INPUT_HANDLE);
-  bool returnChars=false;
-  for (;;)
-  {
-    DWORD dwRecords;
-    if (!GetNumberOfConsoleInputEvents(h,&dwRecords))
-      break;
-    if (!dwRecords)
-      break;
+	// update our input buffer
+	HANDLE h=GetStdHandle(STD_INPUT_HANDLE);
+	bool returnChars=false;
+	for (;;)
+	{
+		DWORD dwRecords;
+		if (!GetNumberOfConsoleInputEvents(h,&dwRecords))
+		break;
+		if (!dwRecords)
+		break;
 
-    INPUT_RECORD record;
-    ReadConsoleInput(h,&record,1,&dwRecords);
-    if (record.EventType!=KEY_EVENT)
-      continue;
+		INPUT_RECORD record;
+		ReadConsoleInput(h,&record,1,&dwRecords);
+		if (record.EventType!=KEY_EVENT)
+		continue;
 
-    KEY_EVENT_RECORD &key=record.Event.KeyEvent;
-    if (!key.bKeyDown||!key.uChar.AsciiChar)
-      continue;
+		KEY_EVENT_RECORD &key=record.Event.KeyEvent;
+		if (!key.bKeyDown||!key.uChar.AsciiChar)
+		continue;
 
-    if (key.uChar.AsciiChar=='\r'||
-        key.uChar.AsciiChar=='\n')
-    {
-      m_input[m_inputUsed++]='\n';
-      returnChars=true;
-      break;
-    }
+		if (key.uChar.AsciiChar=='\r'||
+			key.uChar.AsciiChar=='\n')
+		{
+			m_input[m_inputUsed++]='\n';
+			returnChars=true;
+			break;
+		}
 
-    /// @todo_opt if somebody wants this can be improved by adding support for cursor keys, history, etc
+		/// @todo_opt if somebody wants this can be improved by adding support for cursor keys, history, etc
 
-    if (key.uChar.AsciiChar=='\b')
-    {
-      if (m_inputUsed)
-        m_inputUsed--;
-    }
-    else if (((unsigned char)key.uChar.AsciiChar)>=' ')
-    {
-      if (m_inputUsed<sizeof(m_input)-1)
-        m_input[m_inputUsed++]=key.uChar.AsciiChar;
-    }
-  }
+		if (key.uChar.AsciiChar=='\b')
+		{
+			if (m_inputUsed)
+			m_inputUsed--;
+		}
+		else if (((unsigned char)key.uChar.AsciiChar)>=' ')
+		{
+			if (m_inputUsed<sizeof(m_input)-1)
+			m_input[m_inputUsed++]=key.uChar.AsciiChar;
+		}
+	}
 
-  // update screen
-  h=GetStdHandle(STD_OUTPUT_HANDLE);
-  CONSOLE_SCREEN_BUFFER_INFO info;
-  GetConsoleScreenBufferInfo(h,&info);
-  CHAR_INFO ci[sizeof(m_input)+1];
-  for (unsigned k=0;k<=sizeof(m_input);k++)
-  {
-    ci[k].Char.AsciiChar=k<m_inputUsed?m_input[k]:' ';
-    ci[k].Attributes=BACKGROUND_BLUE|FOREGROUND_BLUE|FOREGROUND_GREEN
-                    |FOREGROUND_RED|FOREGROUND_INTENSITY;
-  }
+	// update screen
+	h=GetStdHandle(STD_OUTPUT_HANDLE);
+	CONSOLE_SCREEN_BUFFER_INFO info;
+	GetConsoleScreenBufferInfo(h,&info);
+	CHAR_INFO ci[sizeof(m_input)+1];
+	for (unsigned k=0;k<=sizeof(m_input);k++)
+	{
+		ci[k].Char.AsciiChar=k<m_inputUsed?m_input[k]:' ';
+		ci[k].Attributes=BACKGROUND_BLUE|FOREGROUND_BLUE|FOREGROUND_GREEN
+			|FOREGROUND_RED|FOREGROUND_INTENSITY;
+	}
 
-  // fake another cursor
-  if (GetTickCount()&512)
-    ci[m_inputUsed].Attributes=BACKGROUND_BLUE|BACKGROUND_GREEN
-                              |BACKGROUND_RED|BACKGROUND_INTENSITY|FOREGROUND_BLUE;
+	// fake another cursor
+	if (GetTickCount()&512)
+	ci[m_inputUsed].Attributes=BACKGROUND_BLUE|BACKGROUND_GREEN
+		|BACKGROUND_RED|BACKGROUND_INTENSITY|FOREGROUND_BLUE;
 
-  COORD srcSize,srcCoord;
-  srcSize.X=sizeof(m_input); srcSize.Y=1;
-  srcCoord.X=srcCoord.Y=0;
+	COORD srcSize,srcCoord;
+	srcSize.X=sizeof(m_input); srcSize.Y=1;
+	srcCoord.X=srcCoord.Y=0;
 
-  SMALL_RECT r;
-  r.Left=r.Top=r.Bottom=0; r.Right=info.dwSize.X-1;
-  WriteConsoleOutput(h,ci+(m_inputUsed<=info.dwSize.X?0:m_inputUsed-info.dwSize.X),
-                      srcSize,srcCoord,&r);
+	SMALL_RECT r;
+	r.Left=r.Top=r.Bottom=0; r.Right=info.dwSize.X-1;
+	WriteConsoleOutput(h,ci+(m_inputUsed<=info.dwSize.X?0:m_inputUsed-info.dwSize.X),
+		srcSize,srcCoord,&r);
 
-  // return data now?
-  if (returnChars&&m_inputUsed>1)
-  {
-    m_input[--m_inputUsed]=0;
-    m_inputUsed=0;
-    return m_input;
-  }
+	// return data now?
+	if (returnChars&&m_inputUsed>1)
+	{
+		m_input[--m_inputUsed]=0;
+		m_inputUsed=0;
+		return m_input;
+	}
 
-  return 0;
+	return 0;
 }
 
 class Pipe
 {
-  Pipe(const Pipe&);
-  Pipe& operator=(const Pipe&);
+	Pipe(const Pipe&);
+	Pipe& operator=(const Pipe&);
 
-  HANDLE m_pipe;
-  bool m_connected;
-  int m_state;
-  int m_stringType;
-  int m_len;
-  char *m_src;
-  char *m_str;
+	HANDLE m_pipe;
+	bool m_connected;
+	int m_state;
+	int m_stringType;
+	int m_len;
+	char *m_src;
+	char *m_str;
 
 public:
-  Pipe():
-    m_pipe(INVALID_HANDLE_VALUE),
-    m_src(nullptr), m_str(nullptr), m_stringType(0)
-  {
-  }
+	Pipe():
+		m_pipe(INVALID_HANDLE_VALUE),
+		m_src(nullptr), m_str(nullptr), m_stringType(0)
+	{
+	}
 
-  ~Pipe()
-  {
-    if (m_pipe!=INVALID_HANDLE_VALUE)
-    {
-      DisconnectNamedPipe(m_pipe);
-      CloseHandle(m_pipe);
-      free(m_src);
-      free(m_str);
-    }
-  }
+	~Pipe()
+	{
+		if (m_pipe!=INVALID_HANDLE_VALUE)
+		{
+			DisconnectNamedPipe(m_pipe);
+			CloseHandle(m_pipe);
+			free(m_src);
+			free(m_str);
+		}
+	}
 
-  bool Create(const char *name)
-  {
-    m_pipe=CreateNamedPipe(name,
-                           PIPE_ACCESS_DUPLEX,
-                           PIPE_TYPE_MESSAGE|PIPE_READMODE_MESSAGE|PIPE_NOWAIT,
-                           PIPE_UNLIMITED_INSTANCES,1024,1024,0,nullptr);
-    m_connected=false;
-    return m_pipe!=INVALID_HANDLE_VALUE;
-  }
+	bool Create(const char *name)
+	{
+		m_pipe=CreateNamedPipe(name,
+			PIPE_ACCESS_DUPLEX,
+			PIPE_TYPE_MESSAGE|PIPE_READMODE_MESSAGE|PIPE_NOWAIT,
+			PIPE_UNLIMITED_INSTANCES,1024,1024,0,nullptr);
+		m_connected=false;
+		return m_pipe!=INVALID_HANDLE_VALUE;
+	}
 
-  bool Connected()
-  {
-    if (!m_connected)
-    {
-      ConnectNamedPipe(m_pipe,nullptr);
-      if (GetLastError()==ERROR_PIPE_CONNECTED)
-      {
-        DWORD dwDummy;
-        WriteFile(GetStdHandle(STD_OUTPUT_HANDLE),"\n<connect>\n",11,&dwDummy,nullptr);
-        m_connected=true;
-        m_state=0;
-      }
-    }
-    return m_connected;
-  }
+	bool Connected()
+	{
+		if (!m_connected)
+		{
+			ConnectNamedPipe(m_pipe,nullptr);
+			if (GetLastError()==ERROR_PIPE_CONNECTED)
+			{
+				DWORD dwDummy;
+				WriteFile(GetStdHandle(STD_OUTPUT_HANDLE),"\n<connect>\n",11,&dwDummy,nullptr);
+				m_connected=true;
+				m_state=0;
+			}
+		}
+		return m_connected;
+	}
 
-  void Write(char msg)
-  {
-    DWORD dummy;
-    if (!WriteFile(m_pipe,&msg,1,&dummy,nullptr)||!dummy)
-    {
-      char sp[30];
-      wsprintf(sp,"%c:%i/%i\n",msg,dummy,GetLastError());
+	void Write(char msg)
+	{
+		DWORD dummy;
+		if (!WriteFile(m_pipe,&msg,1,&dummy,nullptr)||!dummy)
+		{
+			char sp[30];
+			wsprintf(sp,"%c:%i/%i\n",msg,dummy,GetLastError());
 
-      DWORD dwDummy;
-      WriteFile(GetStdHandle(STD_OUTPUT_HANDLE),sp,strlen(sp),&dwDummy,nullptr);
-    }
-  }
+			DWORD dwDummy;
+			WriteFile(GetStdHandle(STD_OUTPUT_HANDLE),sp,strlen(sp),&dwDummy,nullptr);
+		}
+	}
 
-  const char *Read()
-  {
-    DWORD read;
-    switch(m_state)
-    {
-      case 0:
-        if (!ReadFile(m_pipe,&m_stringType,1,&read,nullptr))
-          break;
-        if (read==1)
-          m_state++;
-        return nullptr;
-      case 1:
-      case 3:
-        if (!ReadFile(m_pipe,&m_len,4,&read,nullptr))
-          break;
-        if (read==4)
-        {
-          if (m_state==1)
-            m_src=(char *)realloc(m_src,m_len+1);
-          else
-            m_str=(char *)realloc(m_str,m_len+1);
-          m_state++;
-        }
-        return nullptr;
-      case 2:
-        if (!ReadFile(m_pipe,m_src,m_len,&read,nullptr))
-          break;
-        if (read==m_len)
-        {
-          m_src[m_len]=0;
-          m_state++;
-        }
-        return nullptr;
-      case 4:
-        if (!ReadFile(m_pipe,m_str,m_len,&read,nullptr))
-          break;
-        if (read==m_len)
-        {
-          m_str[m_len]=0;
-          m_state=0;
-          return m_str;
-        }
-        return nullptr;
-    }
+	const char *Read()
+	{
+		DWORD read;
+		switch(m_state)
+		{
+			case 0:
+				if (!ReadFile(m_pipe,&m_stringType,1,&read,nullptr))
+				break;
+				if (read==1)
+				m_state++;
+				return nullptr;
+			case 1:
+			case 3:
+				if (!ReadFile(m_pipe,&m_len,4,&read,nullptr))
+				break;
+				if (read==4)
+				{
+					if (m_state==1)
+					m_src=(char *)realloc(m_src,m_len+1);
+					else
+					m_str=(char *)realloc(m_str,m_len+1);
+					m_state++;
+				}
+				return nullptr;
+			case 2:
+				if (!ReadFile(m_pipe,m_src,m_len,&read,nullptr))
+				break;
+				if (read==m_len)
+				{
+					m_src[m_len]=0;
+					m_state++;
+				}
+				return nullptr;
+			case 4:
+				if (!ReadFile(m_pipe,m_str,m_len,&read,nullptr))
+				break;
+				if (read==m_len)
+				{
+					m_str[m_len]=0;
+					m_state=0;
+					return m_str;
+				}
+				return nullptr;
+		}
 
-    if (GetLastError()==ERROR_BROKEN_PIPE)
-    {
-      DisconnectNamedPipe(m_pipe);
+		if (GetLastError()==ERROR_BROKEN_PIPE)
+		{
+			DisconnectNamedPipe(m_pipe);
 
-      DWORD dwDummy;
-      WriteFile(GetStdHandle(STD_OUTPUT_HANDLE),"\n<disconnect>\n",14,&dwDummy,nullptr);
-      m_connected=false;
-    }
+			DWORD dwDummy;
+			WriteFile(GetStdHandle(STD_OUTPUT_HANDLE),"\n<disconnect>\n",14,&dwDummy,nullptr);
+			m_connected=false;
+		}
 
-    return nullptr;
-  }
+		return nullptr;
+	}
 };
 
 int CALLBACK WinMain(HINSTANCE,HINSTANCE,LPSTR,int)
 {
-  InitConsole();
+	InitConsole();
 
-  char buf1[200],buf2[400];
-  DWORD dwDummy=sizeof(buf1);
-  GetComputerName(buf1,&dwDummy);
-  WriteFile(GetStdHandle(STD_OUTPUT_HANDLE),buf2,
-            wsprintf(buf2,"\n\nSimple debug.net Server ready. Enter 'quit' to exit.\n\nLocal machine: %s\n\n",buf1),
-            &dwDummy,nullptr);
+	char buf1[200],buf2[400];
+	DWORD dwDummy=sizeof(buf1);
+	GetComputerName(buf1,&dwDummy);
+	WriteFile(GetStdHandle(STD_OUTPUT_HANDLE),buf2,
+		wsprintf(buf2,"\n\nSimple debug.net Server ready. Enter 'quit' to exit.\n\nLocal machine: %s\n\n",buf1),
+		&dwDummy,nullptr);
 
-  Pipe p[10];
-  for (int k=0;k<10;k++)
-    if (!p[k].Create("\\\\.\\pipe\\ea_debug_v1"))
-    {
-      char msg[200];
-      wsprintf(msg,"Can't create named pipe (Code %i).",GetLastError());
-      MessageBox(nullptr,msg,"Error",MB_OK);
-      return 1;
-    }
+	Pipe p[10];
+	for (int k=0;k<10;k++)
+	if (!p[k].Create("\\\\.\\pipe\\ea_debug_v1"))
+	{
+		char msg[200];
+		wsprintf(msg,"Can't create named pipe (Code %i).",GetLastError());
+		MessageBox(nullptr,msg,"Error",MB_OK);
+		return 1;
+	}
 
-  for (;;)
-  {
-    char *input=InputConsole();
-    if (input)
-    {
-      if (strcmp(input,"quit") == 0)
-        break;
-    }
+	for (;;)
+	{
+		char *input=InputConsole();
+		if (input)
+		{
+			if (strcmp(input,"quit") == 0)
+			break;
+		}
 
-    for (int k=0;k<10;k++)
-    {
-      if (!p[k].Connected())
-        continue;
+		for (int k=0;k<10;k++)
+		{
+			if (!p[k].Connected())
+			continue;
 
-      const char *msg=p[k].Read();
-      if (msg)
-      {
-        DWORD dwDummy;
-        WriteFile(GetStdHandle(STD_OUTPUT_HANDLE),msg,strlen(msg),&dwDummy,nullptr);
-      }
+			const char *msg=p[k].Read();
+			if (msg)
+			{
+				DWORD dwDummy;
+				WriteFile(GetStdHandle(STD_OUTPUT_HANDLE),msg,strlen(msg),&dwDummy,nullptr);
+			}
 
-      if (input)
-      {
-        for (unsigned i=0;input[i];i++)
-          p[k].Write(input[i]);
-        p[k].Write('\n');
-      }
-    }
+			if (input)
+			{
+				for (unsigned i=0;input[i];i++)
+				p[k].Write(input[i]);
+				p[k].Write('\n');
+			}
+		}
 
-    Sleep(10);
-  }
+		Sleep(10);
+	}
 
-  return 0;
+	return 0;
 }

--- a/Core/Libraries/Source/debug/test1/test1.cpp
+++ b/Core/Libraries/Source/debug/test1/test1.cpp
@@ -30,7 +30,7 @@
 
 const char *DebugGetDefaultCommands()
 {
-  return "!debug.io con add";
+	return "!debug.io con add";
 }
 
 int divByNull;
@@ -38,8 +38,8 @@ unsigned *invalidPtr=(unsigned *)0x666;
 
 bool crash()
 {
-  *invalidPtr/=divByNull;
-  return true;
+	*invalidPtr/=divByNull;
+	return true;
 }
 
 bool thisWillCrash=crash();

--- a/Core/Libraries/Source/debug/test2/test2.cpp
+++ b/Core/Libraries/Source/debug/test2/test2.cpp
@@ -48,27 +48,27 @@ class TestCmdInterface: public DebugCmdInterface
 {
 public:
 
-  virtual bool Execute(class Debug& dbg, const char *cmd, CommandMode cmdmode,
-                       unsigned argn, const char * const * argv)
-  {
-    if (strcmp(cmd,"box") != 0)
-      return false;
+	virtual bool Execute(class Debug& dbg, const char *cmd, CommandMode cmdmode,
+		unsigned argn, const char * const * argv)
+	{
+		if (strcmp(cmd,"box") != 0)
+		return false;
 
-    MessageBox(nullptr,"Hello world!","Command",MB_OK);
-    return true;
-  }
+		MessageBox(nullptr,"Hello world!","Command",MB_OK);
+		return true;
+	}
 
-  virtual void Delete() { delete this; }
+	virtual void Delete() { delete this; }
 };
 
 DEBUG_CREATE_COMMAND_GROUP(test,TestCmdInterface)
 
 int APIENTRY WinMain(HINSTANCE hInstance,
-                     HINSTANCE hPrevInstance,
-                     LPSTR     lpCmdLine,
-                     int       nCmdShow)
+	HINSTANCE hPrevInstance,
+	LPSTR     lpCmdLine,
+	int       nCmdShow)
 {
- 	// TODO: Place code here.
+	// TODO: Place code here.
 	MSG msg;
 	HACCEL hAccelTable;
 
@@ -85,8 +85,8 @@ int APIENTRY WinMain(HINSTANCE hInstance,
 
 	hAccelTable = LoadAccelerators(hInstance, (LPCTSTR)IDC_TEST2);
 
-  // Send a command to Debug interface
-  Debug::Command("debug.io ; send via EXE, try test.box!");
+	// Send a command to Debug interface
+	Debug::Command("debug.io ; send via EXE, try test.box!");
 
 	// Main message loop:
 	while (GetMessage(&msg, nullptr, 0, 0))
@@ -149,25 +149,25 @@ ATOM MyRegisterClass(HINSTANCE hInstance)
 //
 BOOL InitInstance(HINSTANCE hInstance, int nCmdShow)
 {
-   HWND hWnd;
+	HWND hWnd;
 
-   hInst = hInstance; // Store instance handle in our global variable
+	hInst = hInstance; // Store instance handle in our global variable
 
-   hWnd = CreateWindow(szWindowClass, szTitle, WS_OVERLAPPEDWINDOW,
-      CW_USEDEFAULT, 0, CW_USEDEFAULT, 0, nullptr, nullptr, hInstance, nullptr);
+	hWnd = CreateWindow(szWindowClass, szTitle, WS_OVERLAPPEDWINDOW,
+		CW_USEDEFAULT, 0, CW_USEDEFAULT, 0, nullptr, nullptr, hInstance, nullptr);
 
-   if (!hWnd)
-   {
-      return FALSE;
-   }
+	if (!hWnd)
+	{
+		return FALSE;
+	}
 
-   // create a timer for calling Debug::Update
-   SetTimer(hWnd,1,100,nullptr);
+	// create a timer for calling Debug::Update
+	SetTimer(hWnd,1,100,nullptr);
 
-   ShowWindow(hWnd, nCmdShow);
-   UpdateWindow(hWnd);
+	ShowWindow(hWnd, nCmdShow);
+	UpdateWindow(hWnd);
 
-   return TRUE;
+	return TRUE;
 }
 
 //
@@ -197,13 +197,13 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 			switch (wmId)
 			{
 				case IDM_ABOUT:
-				   DialogBox(hInst, (LPCTSTR)IDD_ABOUTBOX, hWnd, (DLGPROC)About);
-				   break;
+					DialogBox(hInst, (LPCTSTR)IDD_ABOUTBOX, hWnd, (DLGPROC)About);
+					break;
 				case IDM_EXIT:
-				   DestroyWindow(hWnd);
-				   break;
+					DestroyWindow(hWnd);
+					break;
 				default:
-				   return DefWindowProc(hWnd, message, wParam, lParam);
+					return DefWindowProc(hWnd, message, wParam, lParam);
 			}
 			break;
 		case WM_PAINT:
@@ -217,13 +217,13 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 		case WM_DESTROY:
 			PostQuitMessage(0);
 			break;
-    case WM_TIMER:
-      Debug::Update();
-      break;
+		case WM_TIMER:
+			Debug::Update();
+			break;
 		default:
 			return DefWindowProc(hWnd, message, wParam, lParam);
-   }
-   return 0;
+	}
+	return 0;
 }
 
 // Message handler for about box.
@@ -242,5 +242,5 @@ LRESULT CALLBACK About(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 			}
 			break;
 	}
-    return FALSE;
+	return FALSE;
 }

--- a/Core/Libraries/Source/debug/test3/test3.cpp
+++ b/Core/Libraries/Source/debug/test3/test3.cpp
@@ -33,30 +33,30 @@ unsigned divByNull;
 
 void main()
 {
-  // switch to debug group
-  Debug::Command("debug.");
+	// switch to debug group
+	Debug::Command("debug.");
 
-  Debug::Command("alwaysflush +");
+	Debug::Command("alwaysflush +");
 
-  // we want our files copied
-  Debug::Command("io flat copy ..\\");
+	// we want our files copied
+	Debug::Command("io flat copy ..\\");
 
-  // split 'split_me' log group to separate file (with size limit)
-  Debug::Command("io flat splitadd l split_me splitted 1");
+	// split 'split_me' log group to separate file (with size limit)
+	Debug::Command("io flat splitadd l split_me splitted 1");
 
-  // turn all logs on
-  Debug::Command("add l + *");
+	// turn all logs on
+	Debug::Command("add l + *");
 
-  // disable no_log log
-  Debug::Command("add l - no_log");
+	// disable no_log log
+	Debug::Command("add l - no_log");
 
-  // now log something...
-  DLOG("This should be visible.\n");
-  DLOG_GROUP(no_log,"This should *NOT* be visible.\n");
-  for (int k=0;k<200;k++)
-    DLOG_GROUP(split_me,"Log line " << k << "\n");
-  DLOG_GROUP(split_me,"Final line in separate log file.\n");
+	// now log something...
+	DLOG("This should be visible.\n");
+	DLOG_GROUP(no_log,"This should *NOT* be visible.\n");
+	for (int k=0;k<200;k++)
+	DLOG_GROUP(split_me,"Log line " << k << "\n");
+	DLOG_GROUP(split_me,"Final line in separate log file.\n");
 
-  // and now let's crash!
-  divByNull/=divByNull;
+	// and now let's crash!
+	divByNull/=divByNull;
 }

--- a/Core/Libraries/Source/debug/test4/test4.cpp
+++ b/Core/Libraries/Source/debug/test4/test4.cpp
@@ -30,13 +30,13 @@
 
 void main()
 {
-  for (int i=0;i<30;i++)
-    DCHECK_MSG(i>100,"run#" << i);
-  Debug::Command("list c");
-  for (int k=0;k<3;k++)
-  {
-    DASSERT(k>4);
-    DASSERT_MSG(k<1,"k must be less than 1...");
-    Debug::Command("list a");
-  }
+	for (int i=0;i<30;i++)
+	DCHECK_MSG(i>100,"run#" << i);
+	Debug::Command("list c");
+	for (int k=0;k<3;k++)
+	{
+		DASSERT(k>4);
+		DASSERT_MSG(k<1,"k must be less than 1...");
+		Debug::Command("list a");
+	}
 }

--- a/Core/Libraries/Source/debug/test5/test5.cpp
+++ b/Core/Libraries/Source/debug/test5/test5.cpp
@@ -30,14 +30,14 @@
 
 const char *DebugGetDefaultCommands()
 {
-  return "!debug.io con add";
+	return "!debug.io con add";
 }
 
 void main()
 {
-  // turn on all logs
-  Debug::Command("add l + *");
+	// turn on all logs
+	Debug::Command("add l + *");
 
-  for (int k=0;k<16;k++)
-    DLOG("Testing: " << Debug::Format("0x%04x (%c)",k,'A'+k) << "\n");
+	for (int k=0;k<16;k++)
+	DLOG("Testing: " << Debug::Format("0x%04x (%c)",k,'A'+k) << "\n");
 }

--- a/Core/Libraries/Source/debug/test6/test6.cpp
+++ b/Core/Libraries/Source/debug/test6/test6.cpp
@@ -33,27 +33,27 @@ int test,divByZero;
 
 void func1()
 {
-  test/=divByZero;
+	test/=divByZero;
 }
 
 void func2()
 {
-  func1();
+	func1();
 }
 
 void func3()
 {
-  func2();
+	func2();
 }
 
 void main()
 {
-  try
-  {
-    func3();
-  }
-  catch (...)
-  {
-    printf("This catch clause should not be executed.\n");
-  }
+	try
+	{
+		func3();
+	}
+	catch (...)
+	{
+		printf("This catch clause should not be executed.\n");
+	}
 }

--- a/Core/Libraries/Source/profile/internal.h
+++ b/Core/Libraries/Source/profile/internal.h
@@ -43,8 +43,8 @@
 
 class ProfileFastCS
 {
-  ProfileFastCS(const ProfileFastCS&) CPP_11(= delete);
-  ProfileFastCS& operator=(const ProfileFastCS&) CPP_11(= delete);
+	ProfileFastCS(const ProfileFastCS&) CPP_11(= delete);
+	ProfileFastCS& operator=(const ProfileFastCS&) CPP_11(= delete);
 
 	static HANDLE testEvent;
 
@@ -65,9 +65,9 @@ class ProfileFastCS
 		return;
 
 	The_Bit_Was_Previously_Set_So_Try_Again:
-    // can't use SwitchToThread() here because Win9X doesn't have it!
-    if (testEvent)
-		  ::WaitForSingleObject(testEvent,1);
+		// can't use SwitchToThread() here because Win9X doesn't have it!
+		if (testEvent)
+		::WaitForSingleObject(testEvent,1);
 		__asm mov ebx, [nFlag]
 		__asm ts_lock
 		__asm bts dword ptr [ebx], 0
@@ -81,9 +81,9 @@ class ProfileFastCS
 
 public:
 	ProfileFastCS():
-    m_Flag(0)
-  {
-  }
+		m_Flag(0)
+	{
+	}
 #else
 
 	std::atomic_flag Flag{};
@@ -108,14 +108,14 @@ public:
 
 	class Lock
 	{
-    Lock(const Lock&) CPP_11(= delete);
+		Lock(const Lock&) CPP_11(= delete);
 	Lock& operator=(const Lock&) CPP_11(= delete);
 
 		ProfileFastCS& CriticalSection;
 
 	public:
 		Lock(ProfileFastCS& cs):
-      CriticalSection(cs)
+			CriticalSection(cs)
 		{
 			CriticalSection.ThreadSafeSetFlag();
 		}

--- a/Core/Libraries/Source/profile/internal_cmd.h
+++ b/Core/Libraries/Source/profile/internal_cmd.h
@@ -31,26 +31,26 @@
 
 class ProfileCmdInterface: public DebugCmdInterface
 {
-  struct Factory
-  {
-    ProfileResultInterface* (*func)(int, const char * const *);
-    const char *name,*arg;
-  };
+	struct Factory
+	{
+		ProfileResultInterface* (*func)(int, const char * const *);
+		const char *name,*arg;
+	};
 
-  static unsigned numResIf;
-  static Factory *resIf;
+	static unsigned numResIf;
+	static Factory *resIf;
 
-  unsigned numResFunc; // optimizer bug: must be declared volatile!
-  ProfileResultInterface **resFunc;
+	unsigned numResFunc; // optimizer bug: must be declared volatile!
+	ProfileResultInterface **resFunc;
 
 public:
-  ProfileCmdInterface(): numResFunc(0), resFunc(0) {}
+	ProfileCmdInterface(): numResFunc(0), resFunc(0) {}
 
-  static void AddResultFunction(ProfileResultInterface* (*func)(int, const char * const *),
-                                const char *name, const char *arg);
-  void RunResultFunctions();
+	static void AddResultFunction(ProfileResultInterface* (*func)(int, const char * const *),
+		const char *name, const char *arg);
+	void RunResultFunctions();
 
-  virtual bool Execute(class Debug& dbg, const char *cmd, CommandMode cmdmode,
-                       unsigned argn, const char * const * argv);
-  virtual void Delete() {}
+	virtual bool Execute(class Debug& dbg, const char *cmd, CommandMode cmdmode,
+		unsigned argn, const char * const * argv);
+	virtual void Delete() {}
 };

--- a/Core/Libraries/Source/profile/internal_funclevel.h
+++ b/Core/Libraries/Source/profile/internal_funclevel.h
@@ -33,156 +33,156 @@
 
 class ProfileFuncLevelTracer
 {
-  friend class ProfileCmdInterface;
+	friend class ProfileCmdInterface;
 
-  // can't copy this
-  ProfileFuncLevelTracer(const ProfileFuncLevelTracer&);
-  ProfileFuncLevelTracer& operator=(const ProfileFuncLevelTracer&);
+	// can't copy this
+	ProfileFuncLevelTracer(const ProfileFuncLevelTracer&);
+	ProfileFuncLevelTracer& operator=(const ProfileFuncLevelTracer&);
 
 public:
-  enum
-  {
-    // # of simultaneous frame recordings
-    MAX_FRAME_RECORDS = 4
-  };
+	enum
+	{
+		// # of simultaneous frame recordings
+		MAX_FRAME_RECORDS = 4
+	};
 
-  /// simple unique unsigned/unsigned map
-  class UnsignedMap
-  {
-    UnsignedMap(const UnsignedMap&);
-    UnsignedMap& operator=(const UnsignedMap&);
+	/// simple unique unsigned/unsigned map
+	class UnsignedMap
+	{
+		UnsignedMap(const UnsignedMap&);
+		UnsignedMap& operator=(const UnsignedMap&);
 
-    struct Entry
-    {
-      Entry *next;
-      unsigned val;
-      unsigned count;
-    };
+		struct Entry
+		{
+			Entry *next;
+			unsigned val;
+			unsigned count;
+		};
 
-    enum
-    {
-      // do not make this number too large
-      // a single function uses approx HASH_SIZE*20 bytes!
-      HASH_SIZE = 131
-    };
+		enum
+		{
+			// do not make this number too large
+			// a single function uses approx HASH_SIZE*20 bytes!
+			HASH_SIZE = 131
+		};
 
-    Entry *e;
-    unsigned alloc,used;
-    Entry *hash[HASH_SIZE];
-    bool writeLock;
+		Entry *e;
+		unsigned alloc,used;
+		Entry *hash[HASH_SIZE];
+		bool writeLock;
 
-    void _Insert(unsigned at, unsigned val, int countAdd);
+		void _Insert(unsigned at, unsigned val, int countAdd);
 
-  public:
-    UnsignedMap();
-    ~UnsignedMap();
+	public:
+		UnsignedMap();
+		~UnsignedMap();
 
-    void Clear();
-    void Insert(unsigned val, int countAdd);
-    unsigned Enumerate(int index);
-    unsigned GetCount(int index);
-    void Copy(const UnsignedMap &src);
-    void MixIn(const UnsignedMap &src);
-  };
+		void Clear();
+		void Insert(unsigned val, int countAdd);
+		unsigned Enumerate(int index);
+		unsigned GetCount(int index);
+		void Copy(const UnsignedMap &src);
+		void MixIn(const UnsignedMap &src);
+	};
 
-  /// profile entry
-  struct Profile
-  {
-    /// call count
-    __int64 callCount;
+	/// profile entry
+	struct Profile
+	{
+		/// call count
+		__int64 callCount;
 
-    /// pure time
-    __int64 tickPure;
+		/// pure time
+		__int64 tickPure;
 
-    /// total time
-    __int64 tickTotal;
+		/// total time
+		__int64 tickTotal;
 
-    /// caller list
-    UnsignedMap caller;
+		/// caller list
+		UnsignedMap caller;
 
-    /// tracer for this profile
-    ProfileFuncLevelTracer *tracer;
+		/// tracer for this profile
+		ProfileFuncLevelTracer *tracer;
 
-    void Copy(const Profile &src)
-    {
-      callCount=src.callCount;
-      tickPure=src.tickPure;
-      tickTotal=src.tickTotal;
-      caller.Copy(src.caller);
-    }
+		void Copy(const Profile &src)
+		{
+		callCount=src.callCount;
+		tickPure=src.tickPure;
+		tickTotal=src.tickTotal;
+		caller.Copy(src.caller);
+		}
 
-    void MixIn(const Profile &src)
-    {
-      callCount+=src.callCount;
-      tickPure+=src.tickPure;
-      tickTotal+=src.tickTotal;
-      caller.MixIn(src.caller);
-    }
-  };
+		void MixIn(const Profile &src)
+		{
+		callCount+=src.callCount;
+		tickPure+=src.tickPure;
+		tickTotal+=src.tickTotal;
+		caller.MixIn(src.caller);
+		}
+	};
 
-  /// map of profiles
-  class ProfileMap
-  {
-    ProfileMap(const ProfileMap&);
-    ProfileMap& operator=(const ProfileMap&);
+	/// map of profiles
+	class ProfileMap
+	{
+		ProfileMap(const ProfileMap&);
+		ProfileMap& operator=(const ProfileMap&);
 
-    struct List
-    {
-      List *next;
-      int frame;
-      Profile p;
-    };
+		struct List
+		{
+			List *next;
+			int frame;
+			Profile p;
+		};
 
-    List *root,**tail;
+		List *root,**tail;
 
-  public:
-    ProfileMap();
-    ~ProfileMap();
+	public:
+		ProfileMap();
+		~ProfileMap();
 
-    Profile *Find(int frame);
-    void Append(int frame, const Profile &p);
-    void MixIn(int frame, const Profile &p);
-  };
+		Profile *Find(int frame);
+		void Append(int frame, const Profile &p);
+		void MixIn(int frame, const Profile &p);
+	};
 
-  /// function entry (map address -> Function)
-  struct Function
-  {
-    /// address of this function
-    unsigned addr;
+	/// function entry (map address -> Function)
+	struct Function
+	{
+		/// address of this function
+		unsigned addr;
 
-    /// global profile
-    Profile glob;
+		/// global profile
+		Profile glob;
 
-    /// profile for current frame(s)
-    Profile cur[MAX_FRAME_RECORDS];
+		/// profile for current frame(s)
+		Profile cur[MAX_FRAME_RECORDS];
 
-    /// frame based profiles
-    ProfileMap frame;
+		/// frame based profiles
+		ProfileMap frame;
 
-    /// current call depth (for recursion)
-    int depth;
+		/// current call depth (for recursion)
+		int depth;
 
-    /// function source
-    char *funcSource;
+		/// function source
+		char *funcSource;
 
-    /// function source line
-    unsigned funcLine;
+		/// function source line
+		unsigned funcLine;
 
-    /// function name
-    char *funcName;
+		/// function name
+		char *funcName;
 
-    Function(ProfileFuncLevelTracer *tr)
-    {
-      glob.tracer=tr;
-      for (int k=0;k<MAX_FRAME_RECORDS;k++)
-        cur[k].tracer=tr;
-      funcSource=funcName=nullptr;
-      funcLine=0;
-    }
-  };
+		Function(ProfileFuncLevelTracer *tr)
+		{
+		glob.tracer=tr;
+		for (int k=0;k<MAX_FRAME_RECORDS;k++)
+		cur[k].tracer=tr;
+		funcSource=funcName=nullptr;
+		funcLine=0;
+		}
+	};
 
-  ProfileFuncLevelTracer();
-  ~ProfileFuncLevelTracer();
+	ProfileFuncLevelTracer();
+	~ProfileFuncLevelTracer();
 
   /**
     Enters the function at the given address.
@@ -191,7 +191,7 @@ public:
     @param esp current ESP value
     @param ret return address for given function
   */
-  void Enter(unsigned addr, unsigned esp, unsigned ret);
+	void Enter(unsigned addr, unsigned esp, unsigned ret);
 
   /**
     Leaves the function at the ESP value.
@@ -201,159 +201,159 @@ public:
     @param esp current ESP value
     @return return address
   */
-  unsigned Leave(unsigned esp);
+	unsigned Leave(unsigned esp);
 
   /**
     Shutdown function.
   */
-  static void Shutdown();
+	static void Shutdown();
 
   /**
     Starts frame based profiling, starts a new frame.
   */
-  static int FrameStart();
+	static int FrameStart();
 
   /**
     Ends frame based profiling.
   */
-  static void FrameEnd(int which, int mixIndex);
+	static void FrameEnd(int which, int mixIndex);
 
   /**
     Clears all total values.
   */
-  static void ClearTotals();
+	static void ClearTotals();
 
   /**
     Retrieves the first function level tracer.
 
     \return first function level tracer
   */
-  static ProfileFuncLevelTracer *GetFirst()
-  {
-    return head;
-  }
+	static ProfileFuncLevelTracer *GetFirst()
+	{
+		return head;
+	}
 
   /**
     Retrieves next function level tracer.
 
     \return next function level tracer, nullptr if none
   */
-  ProfileFuncLevelTracer *GetNext()
-  {
-    return next;
-  }
+	ProfileFuncLevelTracer *GetNext()
+	{
+		return next;
+	}
 
-  Function *FindFunction(unsigned addr)
-  {
-    return func.Find(addr);
-  }
+	Function *FindFunction(unsigned addr)
+	{
+		return func.Find(addr);
+	}
 
-  Function *EnumFunction(unsigned index)
-  {
-    return func.Enumerate(index);
-  }
+	Function *EnumFunction(unsigned index)
+	{
+		return func.Enumerate(index);
+	}
 
 private:
-  /// single stack entry
-  struct StackEntry
-  {
-    /// function
-    Function *func;
+	/// single stack entry
+	struct StackEntry
+	{
+		/// function
+		Function *func;
 
-    /// ESP value
-    unsigned esp;
+		/// ESP value
+		unsigned esp;
 
-    /// return value
-    unsigned retVal;
+		/// return value
+		unsigned retVal;
 
-    /// enter tick count
-    __int64 tickEnter;
+		/// enter tick count
+		__int64 tickEnter;
 
-    /// time spend in called functions
-    __int64 tickSubTime;
-  };
+		/// time spend in called functions
+		__int64 tickSubTime;
+	};
 
-  /// map of functions
-  class FunctionMap
-  {
-    FunctionMap(const FunctionMap&);
-    FunctionMap& operator=(const FunctionMap&);
+	/// map of functions
+	class FunctionMap
+	{
+		FunctionMap(const FunctionMap&);
+		FunctionMap& operator=(const FunctionMap&);
 
-    struct Entry
-    {
-      Entry *next;
-      Function *funcPtr;
-    };
+		struct Entry
+		{
+			Entry *next;
+			Function *funcPtr;
+		};
 
-    enum
-    {
-      HASH_SIZE = 15551
-    };
+		enum
+		{
+			HASH_SIZE = 15551
+		};
 
-    Entry *e;
-    unsigned alloc,used;
-    Entry *hash[HASH_SIZE];
+		Entry *e;
+		unsigned alloc,used;
+		Entry *hash[HASH_SIZE];
 
-  public:
-    FunctionMap();
-    ~FunctionMap();
+	public:
+		FunctionMap();
+		~FunctionMap();
 
-    Function *Find(unsigned addr);
-    void Insert(Function *funcPtr);
-    Function *Enumerate(int index);
-  };
+		Function *Find(unsigned addr);
+		void Insert(Function *funcPtr);
+		Function *Enumerate(int index);
+	};
 
-  /// head of list
-  static ProfileFuncLevelTracer *head;
+	/// head of list
+	static ProfileFuncLevelTracer *head;
 
-  /// next tracer object
-  ProfileFuncLevelTracer *next;
+	/// next tracer object
+	ProfileFuncLevelTracer *next;
 
-  /// are we in shutdown mode?
-  static bool shuttingDown;
+	/// are we in shutdown mode?
+	static bool shuttingDown;
 
-  /// stack
-  StackEntry *stack;
+	/// stack
+	StackEntry *stack;
 
-  /// number of used entries
-  int usedStack;
+	/// number of used entries
+	int usedStack;
 
-  /// total number of entries
-  int totalStack;
+	/// total number of entries
+	int totalStack;
 
-  /// max call depth
-  int maxDepth;
+	/// max call depth
+	int maxDepth;
 
-  /// current frame
-  static int curFrame;
+	/// current frame
+	static int curFrame;
 
-  /// function map
-  FunctionMap func;
+	/// function map
+	FunctionMap func;
 
-  /// bit mask, currently recording which cur[] entries?
-  static unsigned frameRecordMask;
+	/// bit mask, currently recording which cur[] entries?
+	static unsigned frameRecordMask;
 
-  /// record caller information?
-  static bool recordCaller;
+	/// record caller information?
+	static bool recordCaller;
 };
 
 inline void ProfileFuncLevelTracer::UnsignedMap::Insert(unsigned val, int countAdd)
 {
-  // in hash?
-  unsigned at=(val/16)%HASH_SIZE;
-  for (Entry *e=hash[at];e;e=e->next)
-    if (e->val==val)
-    {
-      e->count+=countAdd;
-      return;
-    }
-  _Insert(at,val,countAdd);
+	// in hash?
+	unsigned at=(val/16)%HASH_SIZE;
+	for (Entry *e=hash[at];e;e=e->next)
+	if (e->val==val)
+	{
+		e->count+=countAdd;
+		return;
+	}
+	_Insert(at,val,countAdd);
 }
 
 inline ProfileFuncLevelTracer::Function *ProfileFuncLevelTracer::FunctionMap::Find(unsigned addr)
 {
-  for (Entry *e=hash[(addr/16)%HASH_SIZE];e;e=e->next)
-    if (e->funcPtr->addr==addr)
-      return e->funcPtr;
-  return nullptr;
+	for (Entry *e=hash[(addr/16)%HASH_SIZE];e;e=e->next)
+	if (e->funcPtr->addr==addr)
+	return e->funcPtr;
+	return nullptr;
 }

--- a/Core/Libraries/Source/profile/internal_highlevel.h
+++ b/Core/Libraries/Source/profile/internal_highlevel.h
@@ -32,8 +32,8 @@
 /// an internal high level profile ID
 class ProfileId
 {
-  ProfileId(const ProfileId&);
-  ProfileId& operator=(const ProfileId&);
+	ProfileId(const ProfileId&);
+	ProfileId& operator=(const ProfileId&);
 
 public:
   /**
@@ -45,78 +45,78 @@ public:
     \param precision number of decimal places to show
     \param exp10 10 base exponent (used for scaleing)
   */
-  ProfileId(const char *name, const char *descr, const char *unit, int precision, int exp10);
+	ProfileId(const char *name, const char *descr, const char *unit, int precision, int exp10);
 
   /**
     Retrieves the first profile ID.
 
     \return first profile ID
   */
-  static ProfileId *GetFirst() { return first; }
+	static ProfileId *GetFirst() { return first; }
 
   /**
     Retrieves next profile ID.
 
     \return next profile ID, nullptr if none
   */
-  ProfileId *GetNext() const { return m_next; }
+	ProfileId *GetNext() const { return m_next; }
 
   /**
     Retrieves name of the profile ID.
 
     \return profile ID name
   */
-  const char *GetName() const { return m_name; }
+	const char *GetName() const { return m_name; }
 
   /**
     Retrieves unit name of the profile ID.
 
     \return profile ID unit name
   */
-  const char *GetUnit() const { return m_unit?m_unit:""; }
+	const char *GetUnit() const { return m_unit?m_unit:""; }
 
   /**
     Retrieves description of the profile ID.
 
     \return profile description
   */
-  const char *GetDescr() const { return m_descr?m_descr:""; }
+	const char *GetDescr() const { return m_descr?m_descr:""; }
 
   /**
     Increments the profile value.
 
     \param add add value
   */
-  void Increment(double add);
+	void Increment(double add);
 
   /**
     Sets a new maximum value.
 
     \param max new maximum value
   */
-  void Maximum(double max);
+	void Maximum(double max);
 
   /**
     Returns current value, internally resetting it.
 
     \return current value
   */
-  double GetCurrentValue()
-  {
-    double help=m_curVal;
-    m_curVal=0.;
-    return help;
-  }
+	double GetCurrentValue()
+	{
+		double help=m_curVal;
+		m_curVal=0.;
+		return help;
+	}
 
   /**
     Returns total value
 
     \return total value
   */
-  double GetTotalValue() const
-  {
-    return m_totalVal;
-  }
+	double GetTotalValue() const
+	{
+		return m_totalVal;
+	}
 
   /**
     Returns value at the given frame.
@@ -125,14 +125,14 @@ public:
     \param value value at frame
     \return true if frame found, false if not
   */
-  bool GetFrameValue(unsigned frame, double &value) const
-  {
-    if (frame<(unsigned)m_firstFrame||
-        frame>=(unsigned)curFrame)
-      return false;
-    value=m_recFrameVal[frame-m_firstFrame];
-    return true;
-  }
+	bool GetFrameValue(unsigned frame, double &value) const
+	{
+		if (frame<(unsigned)m_firstFrame||
+			frame>=(unsigned)curFrame)
+		return false;
+		value=m_recFrameVal[frame-m_firstFrame];
+		return true;
+	}
 
   /**
     Translate given numeric value into a string, using an internal temp buffer.
@@ -140,103 +140,103 @@ public:
     \param v value
     \return given numeric value as string
   */
-  const char *AsString(double v) const;
+	const char *AsString(double v) const;
 
   /**
     Shutdown function.
   */
-  static void Shutdown();
+	static void Shutdown();
 
   /**
     Starts frame based profiling, starts a new frame.
   */
-  static int FrameStart();
+	static int FrameStart();
 
   /**
     Ends frame based profiling.
   */
-  static void FrameEnd(int which, int mixIndex);
+	static void FrameEnd(int which, int mixIndex);
 
   /**
     Clears all total values.
   */
-  static void ClearTotals()
-  {
-    for (ProfileId *cur=first;cur;cur=cur->m_next)
-      cur->m_totalVal=0.;
-  }
+	static void ClearTotals()
+	{
+		for (ProfileId *cur=first;cur;cur=cur->m_next)
+		cur->m_totalVal=0.;
+	}
 
 private:
   /**
     ProfileId's can't be destructed.
   */
-  ~ProfileId() {}
+	~ProfileId() {}
 
-  enum
-  {
-    /// # of simultaneous frame recordings
-    MAX_FRAME_RECORDS = 4,
+	enum
+	{
+		/// # of simultaneous frame recordings
+		MAX_FRAME_RECORDS = 4,
 
-    /// size of internal string buffer
-    STRING_BUFFER_SIZE = 1024
-  };
+		/// size of internal string buffer
+		STRING_BUFFER_SIZE = 1024
+	};
 
-  /// possible value modes
-  enum ValueMode
-  {
-    Unknown,
-    ModeIncrement,
-    ModeMaximum
-  };
+	/// possible value modes
+	enum ValueMode
+	{
+		Unknown,
+		ModeIncrement,
+		ModeMaximum
+	};
 
-  /// first profile ID
-  static ProfileId *first;
+	/// first profile ID
+	static ProfileId *first;
 
-  /// next profile ID
-  ProfileId *m_next;
+	/// next profile ID
+	ProfileId *m_next;
 
-  /// profile name
-  char *m_name;
+	/// profile name
+	char *m_name;
 
-  /// profile description
-  char *m_descr;
+	/// profile description
+	char *m_descr;
 
-  /// profile unit
-  char *m_unit;
+	/// profile unit
+	char *m_unit;
 
-  /// number of decimal places to show
-  int m_precision;
+	/// number of decimal places to show
+	int m_precision;
 
-  /// 10 base exponent (used for scaleing)
-  int m_exp10;
+	/// 10 base exponent (used for scaleing)
+	int m_exp10;
 
-  /// current value
-  double m_curVal;
+	/// current value
+	double m_curVal;
 
-  /// total value
-  double m_totalVal;
+	/// total value
+	double m_totalVal;
 
-  /// frame values
-  double m_frameVal[MAX_FRAME_RECORDS];
+	/// frame values
+	double m_frameVal[MAX_FRAME_RECORDS];
 
-  /// list of recorded frame values
-  double *m_recFrameVal;
+	/// list of recorded frame values
+	double *m_recFrameVal;
 
-  /// index of first recorded frame
-  int m_firstFrame;
+	/// index of first recorded frame
+	int m_firstFrame;
 
-  /// value mode
-  ValueMode m_valueMode;
+	/// value mode
+	ValueMode m_valueMode;
 
-  /// current frame
-  static int curFrame;
+	/// current frame
+	static int curFrame;
 
-  /// bit mask, currently recording which cur[] entries?
-  static unsigned frameRecordMask;
+	/// bit mask, currently recording which cur[] entries?
+	static unsigned frameRecordMask;
 
-  /// internal string buffer
-  static char stringBuf[STRING_BUFFER_SIZE];
+	/// internal string buffer
+	static char stringBuf[STRING_BUFFER_SIZE];
 
-  /// next unused char in string buffer
-  static unsigned stringBufUnused;
+	/// next unused char in string buffer
+	static unsigned stringBufUnused;
 };

--- a/Core/Libraries/Source/profile/internal_result.h
+++ b/Core/Libraries/Source/profile/internal_result.h
@@ -32,15 +32,15 @@
 /// \brief Simple CSV format flat file result function, for all threads.
 class ProfileResultFileCSV: public ProfileResultInterface
 {
-  ProfileResultFileCSV() {}
+	ProfileResultFileCSV() {}
 
-  void WriteThread(ProfileFuncLevel::Thread &thread);
+	void WriteThread(ProfileFuncLevel::Thread &thread);
 
 public:
-  static ProfileResultInterface *Create(int argn, const char * const *);
-  virtual const char *GetName() const { return "file_csv"; }
-  virtual void WriteResults() override;
-  virtual void Delete() override;
+	static ProfileResultInterface *Create(int argn, const char * const *);
+	virtual const char *GetName() const { return "file_csv"; }
+	virtual void WriteResults() override;
+	virtual void Delete() override;
 };
 
 /**
@@ -57,10 +57,10 @@ public:
 class ProfileResultFileDOT: public ProfileResultInterface
 {
 public:
-  enum
-  {
-    MAX_FUNCTIONS_PER_FILE = 200
-  };
+	enum
+	{
+		MAX_FUNCTIONS_PER_FILE = 200
+	};
 
   /**
     \brief Creates a class instance.
@@ -72,26 +72,26 @@ public:
                          will be folded into a single entry
     \return new instance
   */
-  static ProfileResultInterface *Create(int argn, const char * const *);
+	static ProfileResultInterface *Create(int argn, const char * const *);
 
-  virtual const char *GetName() const { return "file_dot"; }
-  virtual void WriteResults() override;
-  virtual void Delete() override;
+	virtual const char *GetName() const { return "file_dot"; }
+	virtual void WriteResults() override;
+	virtual void Delete() override;
 
 private:
 
-  ProfileResultFileDOT(const char *fileName, const char *frameName, int foldThreshold);
+	ProfileResultFileDOT(const char *fileName, const char *frameName, int foldThreshold);
 
-  struct FoldHelper
-  {
-    FoldHelper *next;
-    const char *source;
-    ProfileFuncLevel::Id id[MAX_FUNCTIONS_PER_FILE];
-    unsigned numId;
-    bool mark;
-  };
+	struct FoldHelper
+	{
+		FoldHelper *next;
+		const char *source;
+		ProfileFuncLevel::Id id[MAX_FUNCTIONS_PER_FILE];
+		unsigned numId;
+		bool mark;
+	};
 
-  char *m_fileName;
-  char *m_frameName;
-  int m_foldThreshold;
+	char *m_fileName;
+	char *m_frameName;
+	int m_foldThreshold;
 };

--- a/Core/Libraries/Source/profile/profile.cpp
+++ b/Core/Libraries/Source/profile/profile.cpp
@@ -35,7 +35,7 @@
 // yuk, I'm doing this so weird because the destructor
 // of cmd must never be called...
 static ProfileCmdInterface &cmd=*(ProfileCmdInterface *)new
-                  (ProfileAllocMemory(sizeof(ProfileCmdInterface))) ProfileCmdInterface();
+	(ProfileAllocMemory(sizeof(ProfileCmdInterface))) ProfileCmdInterface();
 
 // we have this here so that our command interface will always
 // be linked in as well...
@@ -43,111 +43,111 @@ static bool __RegisterDebugCmdGroup_Profile=Debug::AddCommands("profile",&cmd);
 
 void *ProfileAllocMemory(unsigned numBytes)
 {
-  HGLOBAL h=GlobalAlloc(GMEM_FIXED,numBytes);
-  if (!h)
-    DCRASH_RELEASE("Debug mem alloc failed");
-  return (void *)h;
+	HGLOBAL h=GlobalAlloc(GMEM_FIXED,numBytes);
+	if (!h)
+	DCRASH_RELEASE("Debug mem alloc failed");
+	return (void *)h;
 }
 
 void *ProfileReAllocMemory(void *oldPtr, unsigned newSize)
 {
-  // Windows doesn't like ReAlloc with null handle/ptr...
-  if (!oldPtr)
-    return newSize?ProfileAllocMemory(newSize):nullptr;
+	// Windows doesn't like ReAlloc with null handle/ptr...
+	if (!oldPtr)
+	return newSize?ProfileAllocMemory(newSize):nullptr;
 
-  // Shrinking to 0 size is basically freeing memory
-  if (!newSize)
-  {
-    GlobalFree((HGLOBAL)oldPtr);
-    return nullptr;
-  }
+	// Shrinking to 0 size is basically freeing memory
+	if (!newSize)
+	{
+		GlobalFree((HGLOBAL)oldPtr);
+		return nullptr;
+	}
 
-  // now try GlobalReAlloc first
-  HGLOBAL h=GlobalReAlloc((HGLOBAL)oldPtr,newSize,0);
-  if (!h)
-  {
-    // this failed (Windows doesn't like ReAlloc'ing larger
-    // fixed memory blocks) - go with Alloc/Free instead
-    h=GlobalAlloc(GMEM_FIXED,newSize);
-    if (!h)
-      DCRASH_RELEASE("Debug mem realloc failed");
-    unsigned oldSize=GlobalSize((HGLOBAL)oldPtr);
-    memcpy((void *)h,oldPtr,oldSize<newSize?oldSize:newSize);
-    GlobalFree((HGLOBAL)oldPtr);
-  }
+	// now try GlobalReAlloc first
+	HGLOBAL h=GlobalReAlloc((HGLOBAL)oldPtr,newSize,0);
+	if (!h)
+	{
+		// this failed (Windows doesn't like ReAlloc'ing larger
+		// fixed memory blocks) - go with Alloc/Free instead
+		h=GlobalAlloc(GMEM_FIXED,newSize);
+		if (!h)
+		DCRASH_RELEASE("Debug mem realloc failed");
+		unsigned oldSize=GlobalSize((HGLOBAL)oldPtr);
+		memcpy((void *)h,oldPtr,oldSize<newSize?oldSize:newSize);
+		GlobalFree((HGLOBAL)oldPtr);
+	}
 
-  return (void *)h;
+	return (void *)h;
 }
 
 void ProfileFreeMemory(void *ptr)
 {
-  if (ptr)
-    GlobalFree((HGLOBAL)ptr);
+	if (ptr)
+	GlobalFree((HGLOBAL)ptr);
 }
 
 //////////////////////////////////////////////////////////////////////////////
 
 static _int64 GetClockCyclesFast()
 {
-  // this is where we're adding our internal result functions
-  Profile::AddResultFunction(ProfileResultFileCSV::Create,
-                              "file_csv",
-                              "");
-  Profile::AddResultFunction(ProfileResultFileCSV::Create,
-                              "file_dot",
-                              "[ file [ frame_name [ fold_threshold ] ] ]");
+	// this is where we're adding our internal result functions
+	Profile::AddResultFunction(ProfileResultFileCSV::Create,
+		"file_csv",
+		"");
+	Profile::AddResultFunction(ProfileResultFileCSV::Create,
+		"file_dot",
+		"[ file [ frame_name [ fold_threshold ] ] ]");
 
-  // this must not take a very huge CPU hit...
+	// this must not take a very huge CPU hit...
 
-  // measure clock cycles 3 times for 20 msec each
-  // then take the 2 counts that are closest, average
-  _int64 n[3];
-  for (int k=0;k<3;k++)
-  {
-    // wait for end of current tick
-    unsigned timeEnd=timeGetTime()+2;
-    while (timeGetTime()<timeEnd);
+	// measure clock cycles 3 times for 20 msec each
+	// then take the 2 counts that are closest, average
+	_int64 n[3];
+	for (int k=0;k<3;k++)
+	{
+		// wait for end of current tick
+		unsigned timeEnd=timeGetTime()+2;
+		while (timeGetTime()<timeEnd);
 
-    // get cycles
-    _int64 start,startQPC,endQPC;
-    QueryPerformanceCounter((LARGE_INTEGER *)&startQPC);
-    ProfileGetTime(start);
-    timeEnd+=20;
-    while (timeGetTime()<timeEnd);
-    ProfileGetTime(n[k]);
-    n[k]-=start;
+		// get cycles
+		_int64 start,startQPC,endQPC;
+		QueryPerformanceCounter((LARGE_INTEGER *)&startQPC);
+		ProfileGetTime(start);
+		timeEnd+=20;
+		while (timeGetTime()<timeEnd);
+		ProfileGetTime(n[k]);
+		n[k]-=start;
 
-    // convert to 1 second
-    if (QueryPerformanceCounter((LARGE_INTEGER *)&endQPC))
-    {
-      _int64 freq;
-      QueryPerformanceFrequency((LARGE_INTEGER *)&freq);
-      n[k]=(n[k]*freq)/(endQPC-startQPC);
-    }
-    else
-    {
-      n[k]=(n[k]*1000)/20;
-    }
-  }
+		// convert to 1 second
+		if (QueryPerformanceCounter((LARGE_INTEGER *)&endQPC))
+		{
+			_int64 freq;
+			QueryPerformanceFrequency((LARGE_INTEGER *)&freq);
+			n[k]=(n[k]*freq)/(endQPC-startQPC);
+		}
+		else
+		{
+			n[k]=(n[k]*1000)/20;
+		}
+	}
 
-  // find two closest values
-  _int64 d01=n[1]-n[0],d02=n[2]-n[0],d12=n[2]-n[1];
-  if (d01<0) d01=-d01;
-  if (d02<0) d02=-d02;
-  if (d12<0) d12=-d12;
-  _int64 avg;
-  if (d01<d02)
-  {
-    avg=d01<d12?n[0]+n[1]:n[1]+n[2];
-  }
-  else
-  {
-    avg=d02<d12?n[0]+n[2]:n[1]+n[2];
-  }
+	// find two closest values
+	_int64 d01=n[1]-n[0],d02=n[2]-n[0],d12=n[2]-n[1];
+	if (d01<0) d01=-d01;
+	if (d02<0) d02=-d02;
+	if (d12<0) d12=-d12;
+	_int64 avg;
+	if (d01<d02)
+	{
+		avg=d01<d12?n[0]+n[1]:n[1]+n[2];
+	}
+	else
+	{
+		avg=d02<d12?n[0]+n[2]:n[1]+n[2];
+	}
 
-  // return result
-  // (rounded to the next MHz)
-  return ((avg/2+500000)/1000000)*1000000;
+	// return result
+	// (rounded to the next MHz)
+	return ((avg/2+500000)/1000000)*1000000;
 }
 
 unsigned Profile::m_rec;
@@ -160,108 +160,108 @@ Profile::PatternListEntry *Profile::lastPatternEntry;
 
 void Profile::StartRange(const char *range)
 {
-  // set default
-  if (!range)
-    range="frame";
+	// set default
+	if (!range)
+	range="frame";
 
-  // known name?
-  unsigned k=0;
-  for (;k<m_names;++k)
-    if (strcmp(range,m_frameNames[k].name) == 0)
-      break;
-  if (k==m_names)
-  {
-    // no, must add to list
-    m_frameNames=(FrameName *)ProfileReAllocMemory(m_frameNames,(++m_names)*sizeof(FrameName));
-    m_frameNames[k].name=(char *)ProfileAllocMemory(strlen(range)+1);
-    strcpy(m_frameNames[k].name,range);
-    m_frameNames[k].frames=0;
-    m_frameNames[k].isRecording=false;
-    m_frameNames[k].doAppend=false;
-    m_frameNames[k].lastGlobalIndex=-1;
-  }
+	// known name?
+	unsigned k=0;
+	for (;k<m_names;++k)
+	if (strcmp(range,m_frameNames[k].name) == 0)
+	break;
+	if (k==m_names)
+	{
+		// no, must add to list
+		m_frameNames=(FrameName *)ProfileReAllocMemory(m_frameNames,(++m_names)*sizeof(FrameName));
+		m_frameNames[k].name=(char *)ProfileAllocMemory(strlen(range)+1);
+		strcpy(m_frameNames[k].name,range);
+		m_frameNames[k].frames=0;
+		m_frameNames[k].isRecording=false;
+		m_frameNames[k].doAppend=false;
+		m_frameNames[k].lastGlobalIndex=-1;
+	}
 
-  // stop old recording?
-  if (m_frameNames[k].isRecording)
-    StopRange(range);
+	// stop old recording?
+	if (m_frameNames[k].isRecording)
+	StopRange(range);
 
-  // start new recording
-  m_frameNames[k].isRecording=true;
-  m_frameNames[k].doAppend=false;
+	// start new recording
+	m_frameNames[k].isRecording=true;
+	m_frameNames[k].doAppend=false;
 
-  // but check first: is recording enabled?
-  bool active=false;
-  for (PatternListEntry *cur=firstPatternEntry;cur;cur=cur->next)
-  {
-    if (SimpleMatch(range,cur->pattern))
-      active=cur->isActive;
-  }
+	// but check first: is recording enabled?
+	bool active=false;
+	for (PatternListEntry *cur=firstPatternEntry;cur;cur=cur->next)
+	{
+		if (SimpleMatch(range,cur->pattern))
+		active=cur->isActive;
+	}
 
-  if (active)
-  {
+	if (active)
+	{
 #ifdef RTS_PROFILE
-    m_frameNames[k].funcIndex=ProfileFuncLevelTracer::FrameStart();
-    DASSERT(m_frameNames[k].funcIndex>=0);
+		m_frameNames[k].funcIndex=ProfileFuncLevelTracer::FrameStart();
+		DASSERT(m_frameNames[k].funcIndex>=0);
 #endif
-    m_frameNames[k].highIndex=ProfileId::FrameStart();
-    DASSERT(m_frameNames[k].highIndex>=0);
-  }
-  else
-  {
-    m_frameNames[k].funcIndex=-1;
-    m_frameNames[k].highIndex=-1;
-  }
+		m_frameNames[k].highIndex=ProfileId::FrameStart();
+		DASSERT(m_frameNames[k].highIndex>=0);
+	}
+	else
+	{
+		m_frameNames[k].funcIndex=-1;
+		m_frameNames[k].highIndex=-1;
+	}
 }
 
 void Profile::AppendRange(const char *range)
 {
-  // set default
-  if (!range)
-    range="frame";
+	// set default
+	if (!range)
+	range="frame";
 
-  // known name?
-  unsigned k=0;
-  for (;k<m_names;++k)
-    if (strcmp(range,m_frameNames[k].name) == 0)
-      break;
-  if (k==m_names)
-  {
-    // no, so StartRange will do the job for us
-    StartRange(range);
-    return;
-  }
+	// known name?
+	unsigned k=0;
+	for (;k<m_names;++k)
+	if (strcmp(range,m_frameNames[k].name) == 0)
+	break;
+	if (k==m_names)
+	{
+		// no, so StartRange will do the job for us
+		StartRange(range);
+		return;
+	}
 
-  // still recording?
-  if (m_frameNames[k].isRecording)
-    // don't do anything
-    return;
+	// still recording?
+	if (m_frameNames[k].isRecording)
+	// don't do anything
+	return;
 
-  // start new recording
-  m_frameNames[k].isRecording=true;
-  m_frameNames[k].doAppend=true;
+	// start new recording
+	m_frameNames[k].isRecording=true;
+	m_frameNames[k].doAppend=true;
 
-  // but check first: is recording enabled?
-  bool active=false;
-  for (PatternListEntry *cur=firstPatternEntry;cur;cur=cur->next)
-  {
-    if (SimpleMatch(range,cur->pattern))
-      active=cur->isActive;
-  }
+	// but check first: is recording enabled?
+	bool active=false;
+	for (PatternListEntry *cur=firstPatternEntry;cur;cur=cur->next)
+	{
+		if (SimpleMatch(range,cur->pattern))
+		active=cur->isActive;
+	}
 
-  if (active)
-  {
+	if (active)
+	{
 #ifdef RTS_PROFILE
-    m_frameNames[k].funcIndex=ProfileFuncLevelTracer::FrameStart();
-    DASSERT(m_frameNames[k].funcIndex>=0);
+		m_frameNames[k].funcIndex=ProfileFuncLevelTracer::FrameStart();
+		DASSERT(m_frameNames[k].funcIndex>=0);
 #endif
-    m_frameNames[k].highIndex=ProfileId::FrameStart();
-    DASSERT(m_frameNames[k].highIndex>=0);
-  }
-  else
-  {
-    m_frameNames[k].funcIndex=-1;
-    m_frameNames[k].highIndex=-1;
-  }
+		m_frameNames[k].highIndex=ProfileId::FrameStart();
+		DASSERT(m_frameNames[k].highIndex>=0);
+	}
+	else
+	{
+		m_frameNames[k].funcIndex=-1;
+		m_frameNames[k].highIndex=-1;
+	}
 }
 
 void Profile::StopRange(const char *range)

--- a/Core/Libraries/Source/profile/profile.h
+++ b/Core/Libraries/Source/profile/profile.h
@@ -40,10 +40,10 @@
 */
 class Profile
 {
-  friend class ProfileCmdInterface;
+	friend class ProfileCmdInterface;
 
-  // nobody can construct this class
-  Profile();
+	// nobody can construct this class
+	Profile();
 
 public:
 
@@ -52,7 +52,7 @@ public:
 
     \param range name of range to record, == nullptr for "frame"
   */
-  static void StartRange(const char *range=0);
+	static void StartRange(const char *range=0);
 
   /**
     \brief Appends profile data to the last recorded frame
@@ -60,7 +60,7 @@ public:
 
     \param range name of range to record, == nullptr for "frame"
   */
-  static void AppendRange(const char *range=0);
+	static void AppendRange(const char *range=0);
 
   /**
     \brief Stops range recording.
@@ -70,14 +70,14 @@ public:
 
     \param range name of range to record, == nullptr for "frame"
   */
-  static void StopRange(const char *range=0);
+	static void StopRange(const char *range=0);
 
   /**
     \brief Determines if any range recording is enabled or not.
 
     \return true if range profiling is enabled, false if not
   */
-  static bool IsEnabled();
+	static bool IsEnabled();
 
   /**
     \brief Determines the number of known (recorded) range frames.
@@ -88,7 +88,7 @@ public:
 
     \return number of recorded range frames
   */
-  static unsigned GetFrameCount();
+	static unsigned GetFrameCount();
 
   /**
     \brief Determines the range name of a recorded range frame.
@@ -99,14 +99,14 @@ public:
     \param frame number of recorded frame
     \return range name
   */
-  static const char *GetFrameName(unsigned frame);
+	static const char *GetFrameName(unsigned frame);
 
   /**
     \brief Resets all 'total' counter values to 0.
 
     This function does not change any recorded frames.
   */
-  static void ClearTotals();
+	static void ClearTotals();
 
   /**
     \brief Determines number of CPU clock cycles per second.
@@ -116,7 +116,7 @@ public:
 
     \return number of CPU clock cycles per second
   */
-  static _int64 GetClockCyclesPerSecond();
+	static _int64 GetClockCyclesPerSecond();
 
   /**
     \brief Add the given result function interface.
@@ -125,8 +125,8 @@ public:
     \param name factory name
     \param arg description of optional parameters the factory function recognizes
   */
-  static void AddResultFunction(ProfileResultInterface* (*func)(int, const char * const *),
-                                const char *name, const char *arg);
+	static void AddResultFunction(ProfileResultInterface* (*func)(int, const char * const *),
+		const char *name, const char *arg);
 
 private:
   /** \internal
@@ -137,45 +137,45 @@ private:
     \param pattern pattern, only wildcard valid is '*'
     \return true if string matches pattern, false if not
   */
-  static bool SimpleMatch(const char *str, const char *pattern);
+	static bool SimpleMatch(const char *str, const char *pattern);
 
-  /// known frame names
-  struct FrameName
-  {
-    /// frame name
-    char *name;
+	/// known frame names
+	struct FrameName
+	{
+		/// frame name
+		char *name;
 
-    /// number of recorded frames for this name
-    unsigned frames;
+		/// number of recorded frames for this name
+		unsigned frames;
 
-    /// are we currently recording?
-    bool isRecording;
+		/// are we currently recording?
+		bool isRecording;
 
-    /// should current frame be appended to last frame with same name
-    bool doAppend;
+		/// should current frame be appended to last frame with same name
+		bool doAppend;
 
-    /// internal index for function level profiler
-    int funcIndex;
+		/// internal index for function level profiler
+		int funcIndex;
 
-    /// internal index for high level profiler
-    int highIndex;
+		/// internal index for high level profiler
+		int highIndex;
 
-    /// global frame number of last recorded frame for this range, -1 if none
-    int lastGlobalIndex;
-  };
+		/// global frame number of last recorded frame for this range, -1 if none
+		int lastGlobalIndex;
+	};
 
-  /// \internal pattern list entry
-  struct PatternListEntry
-  {
-    /// next entry
-    PatternListEntry *next;
+	/// \internal pattern list entry
+	struct PatternListEntry
+	{
+		/// next entry
+		PatternListEntry *next;
 
-    /// active (true) or inactive (false)?
-    bool isActive;
+		/// active (true) or inactive (false)?
+		bool isActive;
 
-    /// pattern itself (dynamic allocated memory)
-    char *pattern;
-  };
+		/// pattern itself (dynamic allocated memory)
+		char *pattern;
+	};
 
   /** \internal
 
@@ -183,23 +183,23 @@ private:
     okay for this because checking patterns is a costly
     operation anyway and is therefore cached.
   */
-  static PatternListEntry *firstPatternEntry;
+	static PatternListEntry *firstPatternEntry;
 
-  /// \internal last pattern list entry for fast additions to list at end
-  static PatternListEntry *lastPatternEntry;
+	/// \internal last pattern list entry for fast additions to list at end
+	static PatternListEntry *lastPatternEntry;
 
-  /// number of recorded frames
-  static unsigned m_rec;
+	/// number of recorded frames
+	static unsigned m_rec;
 
-  /// names of recorded frames
-  static char **m_recNames;
+	/// names of recorded frames
+	static char **m_recNames;
 
-  /// number of known frame names
-  static unsigned m_names;
+	/// number of known frame names
+	static unsigned m_names;
 
-  /// list of known frame names
-  static FrameName *m_frameNames;
+	/// list of known frame names
+	static FrameName *m_frameNames;
 
-  /// CPU clock cycles/second
-  static _int64 m_clockCycles;
+	/// CPU clock cycles/second
+	static _int64 m_clockCycles;
 };

--- a/Core/Libraries/Source/profile/profile_cmd.cpp
+++ b/Core/Libraries/Source/profile/profile_cmd.cpp
@@ -34,225 +34,225 @@ unsigned ProfileCmdInterface::numResIf;
 ProfileCmdInterface::Factory *ProfileCmdInterface::resIf;
 
 void ProfileCmdInterface::AddResultFunction(ProfileResultInterface* (*func)(int, const char * const *),
-                                            const char *name, const char *arg)
+	const char *name, const char *arg)
 {
-  DFAIL_IF(!func) return;
-  DFAIL_IF(!name) return;
-  for (unsigned k=0;k<numResIf;k++)
-    if (strcmp(resIf[k].name,name) == 0)
-      return;
-  ++numResIf;
-  resIf=(Factory *)ProfileReAllocMemory(resIf,numResIf*sizeof(Factory));
-  resIf[numResIf-1].func=func;
-  resIf[numResIf-1].name=name;
-  resIf[numResIf-1].arg=arg;
+	DFAIL_IF(!func) return;
+	DFAIL_IF(!name) return;
+	for (unsigned k=0;k<numResIf;k++)
+	if (strcmp(resIf[k].name,name) == 0)
+	return;
+	++numResIf;
+	resIf=(Factory *)ProfileReAllocMemory(resIf,numResIf*sizeof(Factory));
+	resIf[numResIf-1].func=func;
+	resIf[numResIf-1].name=name;
+	resIf[numResIf-1].arg=arg;
 }
 
 void ProfileCmdInterface::RunResultFunctions()
 {
-  // no result functions registered?
-  if (!numResFunc)
-    Debug::Command("profile.result file_csv");
+	// no result functions registered?
+	if (!numResFunc)
+	Debug::Command("profile.result file_csv");
 
-  // process result interfaces
-  for (unsigned k=0;k<numResFunc;k++)
-  {
-    resFunc[k]->WriteResults();
-    resFunc[k]->Delete();
-  }
+	// process result interfaces
+	for (unsigned k=0;k<numResFunc;k++)
+	{
+		resFunc[k]->WriteResults();
+		resFunc[k]->Delete();
+	}
 }
 
 bool ProfileCmdInterface::Execute(class Debug& dbg, const char *cmd, CommandMode cmdmode,
-                                  unsigned argn, const char * const * argv)
+	unsigned argn, const char * const * argv)
 {
-  // just for convenience...
-  bool normalMode=cmdmode==CommandMode::Normal;
+	// just for convenience...
+	bool normalMode=cmdmode==CommandMode::Normal;
 
-  if (strcmp(cmd,"help") == 0)
-  {
-    if (!normalMode)
-      return true;
+	if (strcmp(cmd,"help") == 0)
+	{
+		if (!normalMode)
+		return true;
 
-    if (!argn)
-    {
-      dbg << "profile group help:\n"
-             "  result, caller, clear, add, view\n";
-      return true;
-    }
-    else if (strcmp(argv[0],"result") == 0)
-    {
-      dbg << "result\n\n"
-             "Shows the list of available result functions and their\n"
-             "optional parameters.\n"
-             "\n"
-             "result <res_func_name> [ <arg1> .. <argN> ]\n\n"
-             "Adds the given result function to be executed on program\n"
-             "exit.\n";
-    }
-    else if (strcmp(argv[0],"caller") == 0)
-    {
-      dbg << "caller [ (+|-) ]\n\n"
-             "Enables/disables recording of caller information while\n"
-             "performing function level profiling. Turned off by default\n"
-             "since CPU hit is non-zero.\n";
-    }
-    else if (strcmp(argv[0],"clear") == 0)
-    {
-      dbg << "clear\n\n"
-             "Clears the profile inclusion/exclusion list.\n";
-      return true;
-    }
-    else if (strcmp(argv[0],"add") == 0)
-    {
-      dbg << "add (+|-) <pattern>\n"
-             "\n"
-             "Adds a pattern to the profile list. By default all\n"
-             "profile ranges are disabled. Each new range is then checked\n"
-             "against all pattern in this list. If a match is found the\n"
-             "active/inactive state is modified accordingly (+ for active,\n"
-             "- for inactive). The final state is always the last match.";
-      return true;
-    }
-    else if (strcmp(argv[0],"view") == 0)
-    {
-      dbg << "view\n\n"
-             "Shows the active pattern list.\n";
-      return true;
-    }
-    return false;
-  }
+		if (!argn)
+		{
+			dbg << "profile group help:\n"
+				"  result, caller, clear, add, view\n";
+			return true;
+		}
+		else if (strcmp(argv[0],"result") == 0)
+		{
+			dbg << "result\n\n"
+				"Shows the list of available result functions and their\n"
+				"optional parameters.\n"
+				"\n"
+				"result <res_func_name> [ <arg1> .. <argN> ]\n\n"
+				"Adds the given result function to be executed on program\n"
+				"exit.\n";
+		}
+		else if (strcmp(argv[0],"caller") == 0)
+		{
+			dbg << "caller [ (+|-) ]\n\n"
+				"Enables/disables recording of caller information while\n"
+				"performing function level profiling. Turned off by default\n"
+				"since CPU hit is non-zero.\n";
+		}
+		else if (strcmp(argv[0],"clear") == 0)
+		{
+			dbg << "clear\n\n"
+				"Clears the profile inclusion/exclusion list.\n";
+			return true;
+		}
+		else if (strcmp(argv[0],"add") == 0)
+		{
+			dbg << "add (+|-) <pattern>\n"
+				"\n"
+				"Adds a pattern to the profile list. By default all\n"
+				"profile ranges are disabled. Each new range is then checked\n"
+				"against all pattern in this list. If a match is found the\n"
+				"active/inactive state is modified accordingly (+ for active,\n"
+				"- for inactive). The final state is always the last match.";
+			return true;
+		}
+		else if (strcmp(argv[0],"view") == 0)
+		{
+			dbg << "view\n\n"
+				"Shows the active pattern list.\n";
+			return true;
+		}
+		return false;
+	}
 
-  // command: result
-  if (strcmp(cmd,"result") == 0)
-  {
-    if (!argn)
-    {
-      unsigned k=0;
-      for (;k<numResIf;k++)
-      {
-        dbg << resIf[k].name;
-        if ((resIf[k].arg&&*resIf[k].arg)||!normalMode)
-          dbg << "\n  " << resIf[k].arg;
-        dbg << "\n";
-      }
-    }
-    else
-    {
-      unsigned k=0;
-      for (;k<numResIf;k++)
-        if (strcmp(argv[0],resIf[k].name) == 0)
-          break;
-      if (k==numResIf)
-      {
-        dbg << "Unknown result function\n";
-        return true;
-      }
+	// command: result
+	if (strcmp(cmd,"result") == 0)
+	{
+		if (!argn)
+		{
+			unsigned k=0;
+			for (;k<numResIf;k++)
+			{
+				dbg << resIf[k].name;
+				if ((resIf[k].arg&&*resIf[k].arg)||!normalMode)
+				dbg << "\n  " << resIf[k].arg;
+				dbg << "\n";
+			}
+		}
+		else
+		{
+			unsigned k=0;
+			for (;k<numResIf;k++)
+			if (strcmp(argv[0],resIf[k].name) == 0)
+			break;
+			if (k==numResIf)
+			{
+				dbg << "Unknown result function\n";
+				return true;
+			}
 
-      ProfileResultInterface *newIf=resIf[k].func(argn-1,argv+1);
-      if (!newIf)
-      {
-        dbg << "Could not add result function\n";
-        return true;
-      }
+			ProfileResultInterface *newIf=resIf[k].func(argn-1,argv+1);
+			if (!newIf)
+			{
+				dbg << "Could not add result function\n";
+				return true;
+			}
 
-      ++numResFunc;
-      resFunc=(ProfileResultInterface **)ProfileReAllocMemory(resFunc,numResFunc*sizeof(ProfileResultInterface *));
-      resFunc[numResFunc-1]=newIf;
-      if (normalMode)
-        dbg << "Result function " << argv[0] << " added\n";
-    }
+			++numResFunc;
+			resFunc=(ProfileResultInterface **)ProfileReAllocMemory(resFunc,numResFunc*sizeof(ProfileResultInterface *));
+			resFunc[numResFunc-1]=newIf;
+			if (normalMode)
+			dbg << "Result function " << argv[0] << " added\n";
+		}
 
-    return true;
-  }
+		return true;
+	}
 
-  // command: caller
-  if (strcmp(cmd,"caller") == 0)
-  {
+	// command: caller
+	if (strcmp(cmd,"caller") == 0)
+	{
 #ifdef HAS_PROFILE
-    if (argn)
-    {
-      if (*argv[0]=='+')
-        ProfileFuncLevelTracer::recordCaller=true;
-      if (*argv[0]=='-')
-        ProfileFuncLevelTracer::recordCaller=false;
-    }
-    if (normalMode)
-      dbg << "Record caller: " << (ProfileFuncLevelTracer::recordCaller?"on":"off");
-    else
-      dbg << (ProfileFuncLevelTracer::recordCaller?"1":"0");
+		if (argn)
+		{
+			if (*argv[0]=='+')
+			ProfileFuncLevelTracer::recordCaller=true;
+			if (*argv[0]=='-')
+			ProfileFuncLevelTracer::recordCaller=false;
+		}
+		if (normalMode)
+		dbg << "Record caller: " << (ProfileFuncLevelTracer::recordCaller?"on":"off");
+		else
+		dbg << (ProfileFuncLevelTracer::recordCaller?"1":"0");
 #endif
 
-    return true;
-  }
+		return true;
+	}
 
-  // command: clear
-  if (strcmp(cmd,"clear") == 0)
-  {
-    // remove some (or all) pattern
-    const char *pattern=argn<1?"*":argv[0];
-    for (Profile::PatternListEntry **entryPtr=&Profile::firstPatternEntry;*entryPtr;)
-    {
-      if (Profile::SimpleMatch((*entryPtr)->pattern,pattern))
-      {
-        // remove this entry
-        Profile::PatternListEntry *cur=*entryPtr;
-        *entryPtr=cur->next;
-        ProfileFreeMemory(cur->pattern);
-        ProfileFreeMemory(cur);
-      }
-      else
-        entryPtr=&((*entryPtr)->next);
-    }
+	// command: clear
+	if (strcmp(cmd,"clear") == 0)
+	{
+		// remove some (or all) pattern
+		const char *pattern=argn<1?"*":argv[0];
+		for (Profile::PatternListEntry **entryPtr=&Profile::firstPatternEntry;*entryPtr;)
+		{
+			if (Profile::SimpleMatch((*entryPtr)->pattern,pattern))
+			{
+				// remove this entry
+				Profile::PatternListEntry *cur=*entryPtr;
+				*entryPtr=cur->next;
+				ProfileFreeMemory(cur->pattern);
+				ProfileFreeMemory(cur);
+			}
+			else
+			entryPtr=&((*entryPtr)->next);
+		}
 
-    // must fixup lastPatternEntry now
-    if (Profile::firstPatternEntry)
-    {
-      Profile::PatternListEntry *cur=Profile::firstPatternEntry;
-      for (;cur->next;cur=cur->next);
-      Profile::lastPatternEntry=cur;
-    }
-    else
-      Profile::lastPatternEntry=nullptr;
-    return true;
-  }
+		// must fixup lastPatternEntry now
+		if (Profile::firstPatternEntry)
+		{
+			Profile::PatternListEntry *cur=Profile::firstPatternEntry;
+			for (;cur->next;cur=cur->next);
+			Profile::lastPatternEntry=cur;
+		}
+		else
+		Profile::lastPatternEntry=nullptr;
+		return true;
+	}
 
-  // command: add
-  if (strcmp(cmd,"add") == 0)
-  {
-    // add a pattern
-    if (argn<2)
-      dbg << "Please specify mode and pattern";
-    else
-    {
-      // alloc new pattern entry
-      Profile::PatternListEntry *cur=(Profile::PatternListEntry *)
-          ProfileAllocMemory(sizeof(Profile::PatternListEntry));
+	// command: add
+	if (strcmp(cmd,"add") == 0)
+	{
+		// add a pattern
+		if (argn<2)
+		dbg << "Please specify mode and pattern";
+		else
+		{
+			// alloc new pattern entry
+			Profile::PatternListEntry *cur=(Profile::PatternListEntry *)
+				ProfileAllocMemory(sizeof(Profile::PatternListEntry));
 
-      // init
-      cur->next=nullptr;
-      cur->isActive=*argv[0]=='+';
-      cur->pattern=(char *)ProfileAllocMemory(strlen(argv[1])+1);
-      strcpy(cur->pattern,argv[1]);
+			// init
+			cur->next=nullptr;
+			cur->isActive=*argv[0]=='+';
+			cur->pattern=(char *)ProfileAllocMemory(strlen(argv[1])+1);
+			strcpy(cur->pattern,argv[1]);
 
-      // add to list
-      if (Profile::lastPatternEntry)
-        Profile::lastPatternEntry->next=cur;
-      else
-        Profile::firstPatternEntry=cur;
-      Profile::lastPatternEntry=cur;
-    }
-    return true;
-  }
+			// add to list
+			if (Profile::lastPatternEntry)
+			Profile::lastPatternEntry->next=cur;
+			else
+			Profile::firstPatternEntry=cur;
+			Profile::lastPatternEntry=cur;
+		}
+		return true;
+	}
 
-  // command: view
-  if (strcmp(cmd,"view") == 0)
-  {
-    // show list of defined patterns
-    for (Profile::PatternListEntry *cur=Profile::firstPatternEntry;cur;cur=cur->next)
-      dbg << (cur->isActive?"+ ":"- ") << cur->pattern << "\n";
-    return true;
-  }
+	// command: view
+	if (strcmp(cmd,"view") == 0)
+	{
+		// show list of defined patterns
+		for (Profile::PatternListEntry *cur=Profile::firstPatternEntry;cur;cur=cur->next)
+		dbg << (cur->isActive?"+ ":"- ") << cur->pattern << "\n";
+		return true;
+	}
 
-  // unknown command
-  return false;
+	// unknown command
+	return false;
 }

--- a/Core/Libraries/Source/profile/profile_funclevel.h
+++ b/Core/Libraries/Source/profile/profile_funclevel.h
@@ -38,23 +38,23 @@
 */
 class ProfileFuncLevel
 {
-  friend class Profile;
+	friend class Profile;
 
-  // no, no copying allowed!
-  ProfileFuncLevel(const ProfileFuncLevel&);
-  ProfileFuncLevel& operator=(const ProfileFuncLevel&);
+	// no, no copying allowed!
+	ProfileFuncLevel(const ProfileFuncLevel&);
+	ProfileFuncLevel& operator=(const ProfileFuncLevel&);
 
 public:
-  class Id;
-  class Thread;
+	class Id;
+	class Thread;
 
-  /// \brief A list of function level profile IDs
-  class IdList
-  {
-    friend Id;
+	/// \brief A list of function level profile IDs
+	class IdList
+	{
+		friend Id;
 
-  public:
-    IdList(): m_ptr(0) {}
+	public:
+		IdList(): m_ptr(0) {}
 
     /**
       \brief Enumerates the list of IDs.
@@ -66,57 +66,57 @@ public:
       \param countPtr return buffer for count, if given
       \return true if ID found at given index, false if not
     */
-    bool Enum(unsigned index, Id &id, unsigned *countPtr=0) const;
+		bool Enum(unsigned index, Id &id, unsigned *countPtr=0) const;
 
-  private:
+	private:
 
-    /// internal value
-    void *m_ptr;
-  };
+		/// internal value
+		void *m_ptr;
+	};
 
-  /// \brief A function level profile ID.
-  class Id
-  {
-    friend IdList;
-    friend Thread;
+	/// \brief A function level profile ID.
+	class Id
+	{
+		friend IdList;
+		friend Thread;
 
-  public:
-    Id(): m_funcPtr(0) {}
+	public:
+		Id(): m_funcPtr(0) {}
 
-    /// special 'frame' numbers
-    enum
-    {
-      /// return the total value/count
-      Total = 0xffffffff
-    };
+		/// special 'frame' numbers
+		enum
+		{
+			/// return the total value/count
+			Total = 0xffffffff
+		};
 
     /**
       \brief Returns the source file this Id is in.
 
       \return source file name, may be nullptr
     */
-    const char *GetSource() const;
+		const char *GetSource() const;
 
     /**
       \brief Returns the function name for this Id.
 
       \return function name, may be nullptr
     */
-    const char *GetFunction() const;
+		const char *GetFunction() const;
 
     /**
       \brief Returns function address.
 
       \return function address
     */
-    unsigned GetAddress() const;
+		unsigned GetAddress() const;
 
     /**
       \brief Returns the line number for this Id.
 
       \return line number, 0 if unknown
     */
-    unsigned GetLine() const;
+		unsigned GetLine() const;
 
     /**
       \brief Determine call counts.
@@ -124,7 +124,7 @@ public:
       \param frame number of recorded frame, or Total
       \return number of calls
     */
-    unsigned _int64 GetCalls(unsigned frame) const;
+		unsigned _int64 GetCalls(unsigned frame) const;
 
     /**
       \brief Determine time spend in this function and its children.
@@ -132,7 +132,7 @@ public:
       \param frame number of recorded frame, or Total
       \return time spend (in CPU ticks)
     */
-    unsigned _int64 GetTime(unsigned frame) const;
+		unsigned _int64 GetTime(unsigned frame) const;
 
     /**
       \brief Determine time spend in this function only (exclude
@@ -141,7 +141,7 @@ public:
       \param frame number of recorded frame, or Total
       \return time spend in this function alone (in CPU ticks)
     */
-    unsigned _int64 GetFunctionTime(unsigned frame) const;
+		unsigned _int64 GetFunctionTime(unsigned frame) const;
 
     /**
       \brief Determine the list of caller Ids.
@@ -149,20 +149,20 @@ public:
       \param frame number of recorded frame, or Total
       \return Caller Id list (actually just a handle value)
     */
-    IdList GetCaller(unsigned frame) const;
+		IdList GetCaller(unsigned frame) const;
 
-  private:
-    /// internal function pointer
-    void *m_funcPtr;
-  };
+	private:
+		/// internal function pointer
+		void *m_funcPtr;
+	};
 
-  /// \brief a profiled thread
-  class Thread
-  {
-    friend ProfileFuncLevel;
+	/// \brief a profiled thread
+	class Thread
+	{
+		friend ProfileFuncLevel;
 
-  public:
-    Thread(): m_threadID(0) {}
+	public:
+		Thread(): m_threadID(0) {}
 
     /**
       \brief Enumerates the list of known function level profile values.
@@ -173,22 +173,22 @@ public:
       \param id return buffer for ID value
       \return true if ID found at given index, false if not
     */
-    bool EnumProfile(unsigned index, Id &id) const;
+		bool EnumProfile(unsigned index, Id &id) const;
 
     /**
       \brief Returns a unique thread ID (not related to Windows thread ID)
 
       \return profile thread ID
     */
-    unsigned GetId() const
-    {
-      return unsigned(m_threadID);
-    }
+		unsigned GetId() const
+		{
+		return unsigned(m_threadID);
+		}
 
-  private:
-    /// internal thread ID
-    class ProfileFuncLevelTracer *m_threadID;
-  };
+	private:
+		/// internal thread ID
+		class ProfileFuncLevelTracer *m_threadID;
+	};
 
   /**
     \brief Enumerates the list of known and profiled threads.
@@ -199,7 +199,7 @@ public:
     \param thread return buffer for thread handle
     \return true if Thread found, false if not
   */
-  static bool EnumThreads(unsigned index, Thread &thread);
+	static bool EnumThreads(unsigned index, Thread &thread);
 
 private:
 
@@ -209,10 +209,10 @@ private:
     We can make this private as well so nobody accidentally tries to create
     another instance.
   */
-  ProfileFuncLevel();
+	ProfileFuncLevel();
 
   /**
     \brief The only function level profiler instance.
   */
-  static ProfileFuncLevel Instance;
+	static ProfileFuncLevel Instance;
 };

--- a/Core/Libraries/Source/profile/profile_highlevel.cpp
+++ b/Core/Libraries/Source/profile/profile_highlevel.cpp
@@ -40,47 +40,47 @@ static ProfileFastCS cs;
 
 void ProfileHighLevel::Id::Increment(double add)
 {
-  if (m_idPtr)
-    m_idPtr->Increment(add);
+	if (m_idPtr)
+	m_idPtr->Increment(add);
 }
 
 void ProfileHighLevel::Id::SetMax(double max)
 {
-  if (m_idPtr)
-    m_idPtr->Maximum(max);
+	if (m_idPtr)
+	m_idPtr->Maximum(max);
 }
 
 const char *ProfileHighLevel::Id::GetName() const
 {
-  return m_idPtr?m_idPtr->GetName():nullptr;
+	return m_idPtr?m_idPtr->GetName():nullptr;
 }
 
 const char *ProfileHighLevel::Id::GetDescr() const
 {
-  return m_idPtr?m_idPtr->GetDescr():nullptr;
+	return m_idPtr?m_idPtr->GetDescr():nullptr;
 }
 
 const char *ProfileHighLevel::Id::GetUnit() const
 {
-  return m_idPtr?m_idPtr->GetUnit():nullptr;
+	return m_idPtr?m_idPtr->GetUnit():nullptr;
 }
 
 const char *ProfileHighLevel::Id::GetCurrentValue() const
 {
-  return m_idPtr?m_idPtr->AsString(m_idPtr->GetCurrentValue()):nullptr;
+	return m_idPtr?m_idPtr->AsString(m_idPtr->GetCurrentValue()):nullptr;
 }
 
 const char *ProfileHighLevel::Id::GetValue(unsigned frame) const
 {
-  double v;
-  if (!m_idPtr||!m_idPtr->GetFrameValue(frame,v))
-    return nullptr;
-  return m_idPtr->AsString(v);
+	double v;
+	if (!m_idPtr||!m_idPtr->GetFrameValue(frame,v))
+	return nullptr;
+	return m_idPtr->AsString(v);
 }
 
 const char *ProfileHighLevel::Id::GetTotalValue() const
 {
-  return m_idPtr?m_idPtr->AsString(m_idPtr->GetTotalValue()):nullptr;
+	return m_idPtr?m_idPtr->AsString(m_idPtr->GetTotalValue()):nullptr;
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -88,25 +88,25 @@ const char *ProfileHighLevel::Id::GetTotalValue() const
 
 ProfileHighLevel::Block::Block(const char *name)
 {
-  DFAIL_IF(!name) return;
+	DFAIL_IF(!name) return;
 
-  m_idTime=AddProfile(name,nullptr,"msec",6,-4);
+	m_idTime=AddProfile(name,nullptr,"msec",6,-4);
 
-  char help[256];
-  strlcpy(help, name, sizeof(help) - 2);
-  strlcat(help, ".c", sizeof(help));
-  AddProfile(help,nullptr,"calls",6,0).Increment();
+	char help[256];
+	strlcpy(help, name, sizeof(help) - 2);
+	strlcat(help, ".c", sizeof(help));
+	AddProfile(help,nullptr,"calls",6,0).Increment();
 
-  ProfileGetTime(m_start);
+	ProfileGetTime(m_start);
 }
 
 ProfileHighLevel::Block::~Block()
 {
-  _int64 end;
-  ProfileGetTime(end);
-  end-=m_start;
+	_int64 end;
+	ProfileGetTime(end);
+	end-=m_start;
 
-  m_idTime.Increment(double(end)/(double)Profile::GetClockCyclesPerSecond());
+	m_idTime.Increment(double(end)/(double)Profile::GetClockCyclesPerSecond());
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -121,115 +121,115 @@ unsigned ProfileId::stringBufUnused;
 
 ProfileId::ProfileId(const char *name, const char *descr, const char *unit, int precision, int exp10)
 {
-  m_next=first; first=this;
-  m_name=(char *)ProfileAllocMemory(strlen(name)+1);
-  strcpy(m_name,name);
-  if (descr)
-  {
-    m_descr=(char *)ProfileAllocMemory(strlen(descr)+1);
-    strcpy(m_descr,descr);
-  }
-  else
-    m_descr=nullptr;
-  if (unit)
-  {
-    m_unit=(char *)ProfileAllocMemory(strlen(unit)+1);
-    strcpy(m_unit,unit);
-  }
-  else
-    m_unit=nullptr;
-  m_precision=precision;
-  m_exp10=exp10;
-  m_curVal=m_totalVal=0.;
-  m_recFrameVal=nullptr;
-  m_firstFrame=curFrame;
-  m_valueMode=Unknown;
+	m_next=first; first=this;
+	m_name=(char *)ProfileAllocMemory(strlen(name)+1);
+	strcpy(m_name,name);
+	if (descr)
+	{
+		m_descr=(char *)ProfileAllocMemory(strlen(descr)+1);
+		strcpy(m_descr,descr);
+	}
+	else
+	m_descr=nullptr;
+	if (unit)
+	{
+		m_unit=(char *)ProfileAllocMemory(strlen(unit)+1);
+		strcpy(m_unit,unit);
+	}
+	else
+	m_unit=nullptr;
+	m_precision=precision;
+	m_exp10=exp10;
+	m_curVal=m_totalVal=0.;
+	m_recFrameVal=nullptr;
+	m_firstFrame=curFrame;
+	m_valueMode=Unknown;
 }
 
 void ProfileId::Increment(double add)
 {
-  DFAIL_IF(m_valueMode!=Unknown&&m_valueMode!=ModeIncrement)
+	DFAIL_IF(m_valueMode!=Unknown&&m_valueMode!=ModeIncrement)
     return;
 
-  m_valueMode=ModeIncrement;
-  m_curVal+=add;
-  m_totalVal+=add;
-  if (frameRecordMask)
-  {
-    unsigned mask=frameRecordMask;
-    for (unsigned i=0;i<MAX_FRAME_RECORDS;i++)
-    {
-      if (mask&1)
-        m_frameVal[i]+=add;
-      if (!(mask>>=1))
-        break;
-    }
-  }
+	m_valueMode=ModeIncrement;
+	m_curVal+=add;
+	m_totalVal+=add;
+	if (frameRecordMask)
+	{
+		unsigned mask=frameRecordMask;
+		for (unsigned i=0;i<MAX_FRAME_RECORDS;i++)
+		{
+			if (mask&1)
+			m_frameVal[i]+=add;
+			if (!(mask>>=1))
+			break;
+		}
+	}
 }
 
 void ProfileId::Maximum(double max)
 {
-  DFAIL_IF(m_valueMode!=Unknown&&m_valueMode!=ModeMaximum)
+	DFAIL_IF(m_valueMode!=Unknown&&m_valueMode!=ModeMaximum)
     return;
 
-  m_valueMode=ModeMaximum;
-  if (max>m_curVal)
-    m_curVal=max;
-  if (max>m_totalVal)
-    m_totalVal=max;
-  if (frameRecordMask)
-  {
-    unsigned mask=frameRecordMask;
-    for (unsigned i=0;i<MAX_FRAME_RECORDS;i++)
-    {
-      if (mask&1)
-      {
-        if (max>m_frameVal[i])
-          m_frameVal[i]=max;
-      }
-      if (!(mask>>=1))
-        break;
-    }
-  }
+	m_valueMode=ModeMaximum;
+	if (max>m_curVal)
+	m_curVal=max;
+	if (max>m_totalVal)
+	m_totalVal=max;
+	if (frameRecordMask)
+	{
+		unsigned mask=frameRecordMask;
+		for (unsigned i=0;i<MAX_FRAME_RECORDS;i++)
+		{
+			if (mask&1)
+			{
+				if (max>m_frameVal[i])
+				m_frameVal[i]=max;
+			}
+			if (!(mask>>=1))
+			break;
+		}
+	}
 }
 
 const char *ProfileId::AsString(double v) const
 {
-  char help1[10],help[40];
-  wsprintf(help1,"%%%i.lf",m_precision);
+	char help1[10],help[40];
+	wsprintf(help1,"%%%i.lf",m_precision);
 
-  double mul=1.0;
-  int k;
-  for (k=m_exp10;k<0;k++) mul*=10.0;
-  for (;k>0;k--) mul/=10.0;
+	double mul=1.0;
+	int k;
+	for (k=m_exp10;k<0;k++) mul*=10.0;
+	for (;k>0;k--) mul/=10.0;
 
-  unsigned len=snprintf(help,sizeof(help),help1,v*mul)+1;
+	unsigned len=snprintf(help,sizeof(help),help1,v*mul)+1;
 
-  ProfileFastCS::Lock lock(cs);
-  if (stringBufUnused+len>STRING_BUFFER_SIZE)
-    stringBufUnused=0;
-  char *ret=stringBuf+stringBufUnused;
-  memcpy(ret,help,len);
-  stringBufUnused+=len;
-  return ret;
+	ProfileFastCS::Lock lock(cs);
+	if (stringBufUnused+len>STRING_BUFFER_SIZE)
+	stringBufUnused=0;
+	char *ret=stringBuf+stringBufUnused;
+	memcpy(ret,help,len);
+	stringBufUnused+=len;
+	return ret;
 }
 
 int ProfileId::FrameStart()
 {
-  ProfileFastCS::Lock lock(cs);
+	ProfileFastCS::Lock lock(cs);
 
-  unsigned i=0;
-  for (;i<MAX_FRAME_RECORDS;i++)
-    if (!(frameRecordMask&(1<<i)))
-      break;
-  if (i==MAX_FRAME_RECORDS)
-    return -1;
+	unsigned i=0;
+	for (;i<MAX_FRAME_RECORDS;i++)
+	if (!(frameRecordMask&(1<<i)))
+	break;
+	if (i==MAX_FRAME_RECORDS)
+	return -1;
 
-  for (ProfileId *p=first;p;p=p->m_next)
-    p->m_frameVal[i]=0.;
+	for (ProfileId *p=first;p;p=p->m_next)
+	p->m_frameVal[i]=0.;
 
-  frameRecordMask|=1<<i;
-  return i;
+	frameRecordMask|=1<<i;
+	return i;
 }
 
 void ProfileId::FrameEnd(int which, int mixIndex)
@@ -239,56 +239,56 @@ void ProfileId::FrameEnd(int which, int mixIndex)
   DFAIL_IF(!(frameRecordMask&(1<<which)))
     return;
   DFAIL_IF(mixIndex>=curFrame)
-    return;
+	return;
 
-  ProfileFastCS::Lock lock(cs);
+	ProfileFastCS::Lock lock(cs);
 
-  frameRecordMask^=1<<which;
-  if (mixIndex<0)
-  {
-    // new frame
-    curFrame++;
-    for (ProfileId *p=first;p;p=p->m_next)
-    {
-      p->m_recFrameVal=(double *)ProfileReAllocMemory(p->m_recFrameVal,sizeof(double)*(curFrame-p->m_firstFrame));
-      p->m_recFrameVal[curFrame-p->m_firstFrame-1]=p->m_frameVal[which];
-    }
-  }
-  else
-  {
-    // append data
-    for (ProfileId *p=first;p;p=p->m_next)
-    {
-      if (p->m_firstFrame>mixIndex)
-        continue;
+	frameRecordMask^=1<<which;
+	if (mixIndex<0)
+	{
+		// new frame
+		curFrame++;
+		for (ProfileId *p=first;p;p=p->m_next)
+		{
+			p->m_recFrameVal=(double *)ProfileReAllocMemory(p->m_recFrameVal,sizeof(double)*(curFrame-p->m_firstFrame));
+			p->m_recFrameVal[curFrame-p->m_firstFrame-1]=p->m_frameVal[which];
+		}
+	}
+	else
+	{
+		// append data
+		for (ProfileId *p=first;p;p=p->m_next)
+		{
+			if (p->m_firstFrame>mixIndex)
+			continue;
 
-      double &val=p->m_recFrameVal[mixIndex-p->m_firstFrame];
-      switch(p->m_valueMode)
-      {
-        case ProfileId::Unknown:
-          break;
-        case ProfileId::ModeIncrement:
-          val+=p->m_frameVal[which];
-          break;
-        case ProfileId::ModeMaximum:
-          if (p->m_frameVal[which]>val)
-            val=p->m_frameVal[which];
-          break;
-        default:
-          DFAIL();
-      }
-    }
-  }
+			double &val=p->m_recFrameVal[mixIndex-p->m_firstFrame];
+			switch(p->m_valueMode)
+			{
+				case ProfileId::Unknown:
+					break;
+				case ProfileId::ModeIncrement:
+					val+=p->m_frameVal[which];
+					break;
+				case ProfileId::ModeMaximum:
+					if (p->m_frameVal[which]>val)
+					val=p->m_frameVal[which];
+					break;
+				default:
+					DFAIL();
+			}
+		}
+	}
 }
 
 void ProfileId::Shutdown()
 {
-  if (frameRecordMask)
-  {
-    for (unsigned i=0;i<MAX_FRAME_RECORDS;i++)
-      if (frameRecordMask&(1<<i))
-        FrameEnd(i,-1);
-  }
+	if (frameRecordMask)
+	{
+		for (unsigned i=0;i<MAX_FRAME_RECORDS;i++)
+		if (frameRecordMask&(1<<i))
+		FrameEnd(i,-1);
+	}
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -296,43 +296,43 @@ void ProfileId::Shutdown()
 
 ProfileHighLevel::Id ProfileHighLevel::AddProfile(const char *name, const char *descr, const char *unit, int precision, int exp10)
 {
-  // check if there is already an ID with the given name...
-  Id id;
-  if (FindProfile(name,id))
-    return id;
+	// check if there is already an ID with the given name...
+	Id id;
+	if (FindProfile(name,id))
+	return id;
 
-  // checks...
-  DFAIL_IF(!name) return id;
+	// checks...
+	DFAIL_IF(!name) return id;
 
-  // no, allocate one
-  ProfileFastCS::Lock lock(cs);
-  id.m_idPtr=new (ProfileAllocMemory(sizeof(ProfileId))) ProfileId(name,descr,unit,precision,exp10);
-  return id;
+	// no, allocate one
+	ProfileFastCS::Lock lock(cs);
+	id.m_idPtr=new (ProfileAllocMemory(sizeof(ProfileId))) ProfileId(name,descr,unit,precision,exp10);
+	return id;
 }
 
 bool ProfileHighLevel::EnumProfile(unsigned index, Id &id)
 {
-  ProfileFastCS::Lock lock(cs);
-  ProfileId *cur=ProfileId::GetFirst();
-  for (;cur&&index--;cur=cur->GetNext());
-  id.m_idPtr=cur;
-  return cur!=nullptr;
+	ProfileFastCS::Lock lock(cs);
+	ProfileId *cur=ProfileId::GetFirst();
+	for (;cur&&index--;cur=cur->GetNext());
+	id.m_idPtr=cur;
+	return cur!=nullptr;
 }
 
 bool ProfileHighLevel::FindProfile(const char *name, Id &id)
 {
-  DFAIL_IF(!name) return false;
+	DFAIL_IF(!name) return false;
 
-  ProfileFastCS::Lock lock(cs);
-  for (ProfileId *cur=ProfileId::GetFirst();cur;cur=cur->GetNext())
-    if (strcmp(name,cur->GetName()) == 0)
-    {
-      id.m_idPtr=cur;
-      return true;
-    }
+	ProfileFastCS::Lock lock(cs);
+	for (ProfileId *cur=ProfileId::GetFirst();cur;cur=cur->GetNext())
+	if (strcmp(name,cur->GetName()) == 0)
+	{
+		id.m_idPtr=cur;
+		return true;
+	}
 
-  id.m_idPtr=nullptr;
-  return false;
+	id.m_idPtr=nullptr;
+	return false;
 }
 
 ProfileHighLevel::ProfileHighLevel()

--- a/Core/Libraries/Source/profile/profile_highlevel.h
+++ b/Core/Libraries/Source/profile/profile_highlevel.h
@@ -37,21 +37,21 @@ class ProfileId;
 */
 class ProfileHighLevel
 {
-  friend class Profile;
+	friend class Profile;
 
-  // no, no copying allowed!
-  ProfileHighLevel(const ProfileHighLevel&);
-  ProfileHighLevel& operator=(const ProfileHighLevel&);
+	// no, no copying allowed!
+	ProfileHighLevel(const ProfileHighLevel&);
+	ProfileHighLevel& operator=(const ProfileHighLevel&);
 
 public:
 
-  /// \brief A high level profile ID.
-  class Id
-  {
-    friend ProfileHighLevel;
+	/// \brief A high level profile ID.
+	class Id
+	{
+		friend ProfileHighLevel;
 
-  public:
-    Id(): m_idPtr(0) {}
+	public:
+		Id(): m_idPtr(0) {}
 
     /**
       \brief Increment the internal profile value.
@@ -60,7 +60,7 @@ public:
 
       \param add amount to add to internal profile value
     */
-    void Increment(double add=1.0);
+		void Increment(double add=1.0);
 
     /**
       \brief Set a new maximum value.
@@ -73,28 +73,28 @@ public:
       \param max new maximum value (if larger than current max value,
                  otherwise current max value is left unchanged)
     */
-    void SetMax(double max);
+		void SetMax(double max);
 
     /**
       \brief Returns the internal Id name.
 
       \return internal Id name, e.g. 'render.texture.count.512x512'
     */
-    const char *GetName() const;
+		const char *GetName() const;
 
     /**
       \brief Returns the descriptive name.
 
       \return descriptive name, e.g. '# of 512x512 textures'
     */
-    const char *GetDescr() const;
+		const char *GetDescr() const;
 
     /**
       \brief Returns the value's unit text.
 
       \return unit text, e.g. 'bytes'
     */
-    const char *GetUnit() const;
+		const char *GetUnit() const;
 
     /**
       \brief Returns the current value.
@@ -110,7 +110,7 @@ public:
 
       \return current value
     */
-    const char *GetCurrentValue() const;
+		const char *GetCurrentValue() const;
 
     /**
       \brief Returns the value for the given recorded frame/range.
@@ -121,7 +121,7 @@ public:
       \param frame number of recorded frame/range
       \return value at given frame, nullptr if frame not found
     */
-    const char *GetValue(unsigned frame) const;
+		const char *GetValue(unsigned frame) const;
 
     /**
       \brief Returns the total value for all frames.
@@ -133,24 +133,24 @@ public:
 
       \return total value
     */
-    const char *GetTotalValue() const;
+		const char *GetTotalValue() const;
 
-  private:
+	private:
 
-    /// internal pointer
-    ProfileId *m_idPtr;
-  };
+		/// internal pointer
+		ProfileId *m_idPtr;
+	};
 
-  /// \brief Timer based function block profile
-  class Block
-  {
-    friend ProfileHighLevel;
+	/// \brief Timer based function block profile
+	class Block
+	{
+		friend ProfileHighLevel;
 
-    // no copying
-    Block(const Block&);
-    Block& operator=(const Block&);
+		// no copying
+		Block(const Block&);
+		Block& operator=(const Block&);
 
-  public:
+	public:
     /**
       \brief Instructs high level profiler to start a new timer
              based function block (or update if it already exists)
@@ -160,18 +160,18 @@ public:
 
       \param name name of function block
     */
-    explicit Block(const char *name);
+		explicit Block(const char *name);
 
-    /// \brief Updates timer based function block
-    ~Block();
+		/// \brief Updates timer based function block
+		~Block();
 
-  private:
-    /// internal id (time)
-    Id m_idTime;
+	private:
+		/// internal id (time)
+		Id m_idTime;
 
-    /// start time
-    _int64 m_start;
-  };
+		/// start time
+		_int64 m_start;
+	};
 
   /**
     \brief Registers a new high level profile value.
@@ -193,7 +193,7 @@ public:
     \param exp10 10 base exponent (used for scaleing)
     \return internal profile ID value
   */
-  static Id AddProfile(const char *name, const char *descr, const char *unit, int precision, int exp10=0);
+	static Id AddProfile(const char *name, const char *descr, const char *unit, int precision, int exp10=0);
 
   /**
     \brief Enumerates the list of known high level profile values.
@@ -204,7 +204,7 @@ public:
     \param id return buffer for ID value
     \return true if ID found at given index, false if not
   */
-  static bool EnumProfile(unsigned index, Id &id);
+	static bool EnumProfile(unsigned index, Id &id);
 
   /**
     \brief Searches for the given high level profile.
@@ -217,7 +217,7 @@ public:
     \param id return buffer for ID value
     \return true if ID found, false if not
   */
-  static bool FindProfile(const char *name, Id &id);
+	static bool FindProfile(const char *name, Id &id);
 
 private:
 
@@ -227,10 +227,10 @@ private:
     We can make this private as well so nobody accidentally tries to create
     another instance.
   */
-  ProfileHighLevel();
+	ProfileHighLevel();
 
   /**
     \brief The only high level profiler instance.
   */
-  static ProfileHighLevel Instance;
+	static ProfileHighLevel Instance;
 };

--- a/Core/Libraries/Source/profile/profile_result.cpp
+++ b/Core/Libraries/Source/profile/profile_result.cpp
@@ -38,106 +38,106 @@
 
 ProfileResultInterface *ProfileResultFileCSV::Create(int, const char * const *)
 {
-  return new (ProfileAllocMemory(sizeof(ProfileResultFileCSV))) ProfileResultFileCSV();
+	return new (ProfileAllocMemory(sizeof(ProfileResultFileCSV))) ProfileResultFileCSV();
 }
 
 void ProfileResultFileCSV::WriteThread(ProfileFuncLevel::Thread &thread)
 {
-  char help[40];
+	char help[40];
 
-  sprintf(help,"prof%08x-all.csv",thread.GetId());
-  FILE *f=fopen(help,"wt");
+	sprintf(help,"prof%08x-all.csv",thread.GetId());
+	FILE *f=fopen(help,"wt");
 
-  // CSV file header
-  fprintf(f,"Function\tFile\tCall count\tPTT (all)\tGTT (all)\tPT/C (all)\tGT/C (all)\tCaller (all)");
-  unsigned k=0;
-  for (;k<Profile::GetFrameCount();k++)
-  {
-    const char *s=Profile::GetFrameName(k);
-    fprintf(f,"\tCall (%s)\tPTT (%s)\tGTT (%s)\tPT/C (%s)\tGT/C (%s)\tCaller (%s)",s,s,s,s,s,s);
-  }
-  fprintf(f,"\n");
+	// CSV file header
+	fprintf(f,"Function\tFile\tCall count\tPTT (all)\tGTT (all)\tPT/C (all)\tGT/C (all)\tCaller (all)");
+	unsigned k=0;
+	for (;k<Profile::GetFrameCount();k++)
+	{
+		const char *s=Profile::GetFrameName(k);
+		fprintf(f,"\tCall (%s)\tPTT (%s)\tGTT (%s)\tPT/C (%s)\tGT/C (%s)\tCaller (%s)",s,s,s,s,s,s);
+	}
+	fprintf(f,"\n");
 
-  // now show all profile IDs (functions)
-  ProfileFuncLevel::Id id;
-  for (k=0;thread.EnumProfile(k,id);k++)
-  {
-    fprintf(f,"%s[%08x]\t%s, %i",id.GetFunction(),id.GetAddress(),
-                                   id.GetSource(),id.GetLine());
+	// now show all profile IDs (functions)
+	ProfileFuncLevel::Id id;
+	for (k=0;thread.EnumProfile(k,id);k++)
+	{
+		fprintf(f,"%s[%08x]\t%s, %i",id.GetFunction(),id.GetAddress(),
+			id.GetSource(),id.GetLine());
 
-    for (unsigned i=ProfileFuncLevel::Id::Total;i!=Profile::GetFrameCount();i++)
-    {
-      if (!id.GetCalls(i))
-      {
-        // early skip...
-        fprintf(f,"\t\t\t\t\t\t");
-        continue;
-      }
+		for (unsigned i=ProfileFuncLevel::Id::Total;i!=Profile::GetFrameCount();i++)
+		{
+			if (!id.GetCalls(i))
+			{
+				// early skip...
+				fprintf(f,"\t\t\t\t\t\t");
+				continue;
+			}
 
-      // call count
-      fprintf(f,"\t%I64i",id.GetCalls(i));
+			// call count
+			fprintf(f,"\t%I64i",id.GetCalls(i));
 
-      // pure total time
-      fprintf(f,"\t%I64i",id.GetFunctionTime(i));
+			// pure total time
+			fprintf(f,"\t%I64i",id.GetFunctionTime(i));
 
-      // global total time
-      fprintf(f,"\t%I64i",id.GetTime(i));
+			// global total time
+			fprintf(f,"\t%I64i",id.GetTime(i));
 
-      // pure time per call
-      fprintf(f,"\t%I64i",id.GetFunctionTime(i)/id.GetCalls(i));
+			// pure time per call
+			fprintf(f,"\t%I64i",id.GetFunctionTime(i)/id.GetCalls(i));
 
-      // global time per call
-      fprintf(f,"\t%I64i",id.GetTime(i)/id.GetCalls(i));
+			// global time per call
+			fprintf(f,"\t%I64i",id.GetTime(i)/id.GetCalls(i));
 
-      // list of callers
-      ProfileFuncLevel::IdList idlist=id.GetCaller(i);
-      fprintf(f,"\t");
-      ProfileFuncLevel::Id callid;
-      unsigned count;
-      for (unsigned j=0;idlist.Enum(j,callid,&count);j++)
-        fprintf(f," %s[%08x](%i)",callid.GetFunction(),callid.GetAddress(),count);
-    }
-    fprintf(f,"\n");
-  }
+			// list of callers
+			ProfileFuncLevel::IdList idlist=id.GetCaller(i);
+			fprintf(f,"\t");
+			ProfileFuncLevel::Id callid;
+			unsigned count;
+			for (unsigned j=0;idlist.Enum(j,callid,&count);j++)
+			fprintf(f," %s[%08x](%i)",callid.GetFunction(),callid.GetAddress(),count);
+		}
+		fprintf(f,"\n");
+	}
 
-  fclose(f);
+	fclose(f);
 }
 
 void ProfileResultFileCSV::WriteResults()
 {
-  ProfileFuncLevel::Thread t;
-  unsigned k=0;
-  for (;ProfileFuncLevel::EnumThreads(k,t);k++)
-    WriteThread(t);
+	ProfileFuncLevel::Thread t;
+	unsigned k=0;
+	for (;ProfileFuncLevel::EnumThreads(k,t);k++)
+	WriteThread(t);
 
-  FILE *f=fopen("profile-high.csv","wt");
+	FILE *f=fopen("profile-high.csv","wt");
 
-  // CSV file header
-  fprintf(f,"Profile\tUnit\ttotal");
-  for (k=0;k<Profile::GetFrameCount();k++)
-    fprintf(f,"\t%s",Profile::GetFrameName(k));
-  fprintf(f,"\n");
+	// CSV file header
+	fprintf(f,"Profile\tUnit\ttotal");
+	for (k=0;k<Profile::GetFrameCount();k++)
+	fprintf(f,"\t%s",Profile::GetFrameName(k));
+	fprintf(f,"\n");
 
-  // now show all high level profile IDs
-  ProfileHighLevel::Id id;
-  for (k=0;ProfileHighLevel::EnumProfile(k,id);k++)
-  {
-    fprintf(f,"%s\t%s\t%s",id.GetName(),id.GetUnit(),id.GetTotalValue());
-    for (unsigned i=0;i<Profile::GetFrameCount();i++)
-    {
-      const char *p=id.GetValue(i);
-      fprintf(f,"\t%s",p?p:"");
-    }
-    fprintf(f,"\n");
-  }
+	// now show all high level profile IDs
+	ProfileHighLevel::Id id;
+	for (k=0;ProfileHighLevel::EnumProfile(k,id);k++)
+	{
+		fprintf(f,"%s\t%s\t%s",id.GetName(),id.GetUnit(),id.GetTotalValue());
+		for (unsigned i=0;i<Profile::GetFrameCount();i++)
+		{
+			const char *p=id.GetValue(i);
+			fprintf(f,"\t%s",p?p:"");
+		}
+		fprintf(f,"\n");
+	}
 
-  fclose(f);
+	fclose(f);
 }
 
 void ProfileResultFileCSV::Delete()
 {
-  this->~ProfileResultFileCSV();
-  ProfileFreeMemory(this);
+	this->~ProfileResultFileCSV();
+	ProfileFreeMemory(this);
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -145,167 +145,167 @@ void ProfileResultFileCSV::Delete()
 
 ProfileResultInterface *ProfileResultFileDOT::Create(int argn, const char * const *argv)
 {
-  return new (ProfileAllocMemory(sizeof(ProfileResultFileDOT)))
-    ProfileResultFileDOT(argn>0?argv[0]:nullptr,
-                         argn>1?argv[1]:nullptr,
-                         argn>2?atoi(argv[2]): 0);
+	return new (ProfileAllocMemory(sizeof(ProfileResultFileDOT)))
+		ProfileResultFileDOT(argn>0?argv[0]:nullptr,
+		argn>1?argv[1]:nullptr,
+		argn>2?atoi(argv[2]): 0);
 }
 
 ProfileResultFileDOT::ProfileResultFileDOT(const char *fileName, const char *frameName, int foldThreshold)
 {
-  if (!fileName)
-    fileName="profile.dot";
-  m_fileName=(char *)ProfileAllocMemory(strlen(fileName)+1);
-  strcpy(m_fileName,fileName);
-  if (frameName)
-  {
-    m_frameName=(char *)ProfileAllocMemory(strlen(frameName)+1);
-    strcpy(m_frameName,frameName);
-  }
-  else
-    m_frameName=nullptr;
-  m_foldThreshold=foldThreshold;
+	if (!fileName)
+	fileName="profile.dot";
+	m_fileName=(char *)ProfileAllocMemory(strlen(fileName)+1);
+	strcpy(m_fileName,fileName);
+	if (frameName)
+	{
+		m_frameName=(char *)ProfileAllocMemory(strlen(frameName)+1);
+		strcpy(m_frameName,frameName);
+	}
+	else
+	m_frameName=nullptr;
+	m_foldThreshold=foldThreshold;
 }
 
 void ProfileResultFileDOT::WriteResults()
 {
-  // search "main" thread
-  ProfileFuncLevel::Thread t,tMax;
-  if (!ProfileFuncLevel::EnumThreads(0,tMax))
-    return;
+	// search "main" thread
+	ProfileFuncLevel::Thread t,tMax;
+	if (!ProfileFuncLevel::EnumThreads(0,tMax))
+	return;
 
-  unsigned curMax=0;
-  unsigned k=1;
-  for (;ProfileFuncLevel::EnumThreads(k,t);k++)
-  {
-    for (;curMax++;)
-    {
-      ProfileFuncLevel::Id help;
-      if (!tMax.EnumProfile(curMax,help))
-      {
-        tMax=t;
-        break;
-      }
-      if (!t.EnumProfile(curMax,help))
-        break;
-      curMax++;
-    }
-  }
+	unsigned curMax=0;
+	unsigned k=1;
+	for (;ProfileFuncLevel::EnumThreads(k,t);k++)
+	{
+		for (;curMax++;)
+		{
+			ProfileFuncLevel::Id help;
+			if (!tMax.EnumProfile(curMax,help))
+			{
+				tMax=t;
+				break;
+			}
+			if (!t.EnumProfile(curMax,help))
+			break;
+			curMax++;
+		}
+	}
 
-  // search frame
-  unsigned frame=ProfileFuncLevel::Id::Total;
-  if (m_frameName)
-  {
-    for (unsigned k=0;k<Profile::GetFrameCount();k++)
-      if (strcmp(Profile::GetFrameName(k),m_frameName) == 0)
-      {
-        frame=k;
-        break;
-      }
-  }
+	// search frame
+	unsigned frame=ProfileFuncLevel::Id::Total;
+	if (m_frameName)
+	{
+		for (unsigned k=0;k<Profile::GetFrameCount();k++)
+		if (strcmp(Profile::GetFrameName(k),m_frameName) == 0)
+		{
+			frame=k;
+			break;
+		}
+	}
 
-  // determine number of active functions
-  unsigned active=0;
-  ProfileFuncLevel::Id id;
-  for (k=0;tMax.EnumProfile(k,id);k++)
-    if (id.GetCalls(frame))
-      active++;
+	// determine number of active functions
+	unsigned active=0;
+	ProfileFuncLevel::Id id;
+	for (k=0;tMax.EnumProfile(k,id);k++)
+	if (id.GetCalls(frame))
+	active++;
 
-  FILE *f=fopen(m_fileName,"wt");
-  if (!f)
-    return;
+	FILE *f=fopen(m_fileName,"wt");
+	if (!f)
+	return;
 
-  // DOT header
-  fprintf(f,"digraph G { rankdir=\"LR\";\n");
-  fprintf(f,"node [shape=box, fontname=Arial]\n");
-  fprintf(f,"edge [arrowhead=%s, labelfontname=Arial, labelfontsize=10, labelangle=0, labelfontcolor=blue]\n",
-    active>m_foldThreshold?"closed":"none");
+	// DOT header
+	fprintf(f,"digraph G { rankdir=\"LR\";\n");
+	fprintf(f,"node [shape=box, fontname=Arial]\n");
+	fprintf(f,"edge [arrowhead=%s, labelfontname=Arial, labelfontsize=10, labelangle=0, labelfontcolor=blue]\n",
+		active>m_foldThreshold?"closed":"none");
 
-  // fold or not?
-  if (active>m_foldThreshold)
-  {
-    // folding version
+	// fold or not?
+	if (active>m_foldThreshold)
+	{
+		// folding version
 
-    // build source code clusters first
-    FoldHelper *fold=nullptr;
-    for (k=0;tMax.EnumProfile(k,id);k++)
-    {
-      const char *source=id.GetSource();
-      FoldHelper *cur=fold;
-      for (;cur;cur=cur->next)
-        if (strcmp(source,cur->source) == 0)
-        {
-          if (cur->numId<MAX_FUNCTIONS_PER_FILE)
-            cur->id[cur->numId++]=id;
-          break;
-        }
-      if (!cur)
-      {
-        cur=(FoldHelper *)ProfileAllocMemory(sizeof(FoldHelper));
-        cur->next=fold;
-        fold=cur;
-        cur->source=source;
-        cur->numId=1;
-        cur->id[0]=id;
-      }
-    }
+		// build source code clusters first
+		FoldHelper *fold=nullptr;
+		for (k=0;tMax.EnumProfile(k,id);k++)
+		{
+			const char *source=id.GetSource();
+			FoldHelper *cur=fold;
+			for (;cur;cur=cur->next)
+			if (strcmp(source,cur->source) == 0)
+			{
+				if (cur->numId<MAX_FUNCTIONS_PER_FILE)
+				cur->id[cur->numId++]=id;
+				break;
+			}
+			if (!cur)
+			{
+				cur=(FoldHelper *)ProfileAllocMemory(sizeof(FoldHelper));
+				cur->next=fold;
+				fold=cur;
+				cur->source=source;
+				cur->numId=1;
+				cur->id[0]=id;
+			}
+		}
 
-    // now write data
-    for (FoldHelper *cur=fold;cur;cur=cur->next)
-    {
-      FoldHelper *cur2=fold;
-      for (;cur2;cur2=cur2->next)
-        cur2->mark=false;
+		// now write data
+		for (FoldHelper *cur=fold;cur;cur=cur->next)
+		{
+			FoldHelper *cur2=fold;
+			for (;cur2;cur2=cur2->next)
+			cur2->mark=false;
 
-      for (k=0;k<cur->numId;k++)
-      {
-        ProfileFuncLevel::IdList idlist=id.GetCaller(frame);
-        ProfileFuncLevel::Id caller;
-        for (unsigned i=0;idlist.Enum(i,caller);i++)
-        {
-          const char *s=caller.GetSource();
-          for (FoldHelper *cur2=fold;cur2;cur2=cur2->next)
-            if (strcmp(cur2->source,s) == 0)
-              break;
-          if (!cur2||cur2->mark)
-            continue;
-          cur2->mark=true;
+			for (k=0;k<cur->numId;k++)
+			{
+				ProfileFuncLevel::IdList idlist=id.GetCaller(frame);
+				ProfileFuncLevel::Id caller;
+				for (unsigned i=0;idlist.Enum(i,caller);i++)
+				{
+					const char *s=caller.GetSource();
+					for (FoldHelper *cur2=fold;cur2;cur2=cur2->next)
+					if (strcmp(cur2->source,s) == 0)
+					break;
+					if (!cur2||cur2->mark)
+					continue;
+					cur2->mark=true;
 
-          fprintf(f,"\"%s\" -> \"%s\"\n",s,cur->source);
-        }
-      }
-    }
+					fprintf(f,"\"%s\" -> \"%s\"\n",s,cur->source);
+				}
+			}
+		}
 
-    // cleanup
-    while (fold)
-    {
-      FoldHelper *next=fold->next;
-      ProfileFreeMemory(fold);
-      fold=next;
-    }
-  }
-  else
-  {
-    // non-folding version
-    for (k=0;tMax.EnumProfile(k,id);k++)
-      if (id.GetCalls(frame))
-        fprintf(f,"f%08x [label=\"%s\"]\n",id.GetAddress(),id.GetFunction());
-    for (k=0;tMax.EnumProfile(k,id);k++)
-    {
-      ProfileFuncLevel::IdList idlist=id.GetCaller(frame);
-      ProfileFuncLevel::Id caller;
-      unsigned count;
-      for (unsigned i=0;idlist.Enum(i,caller,&count);i++)
-        fprintf(f,"f%08x -> f%08x [headlabel=\"%i\"];\n",caller.GetAddress(),id.GetAddress(),count);
-    }
-  }
+		// cleanup
+		while (fold)
+		{
+			FoldHelper *next=fold->next;
+			ProfileFreeMemory(fold);
+			fold=next;
+		}
+	}
+	else
+	{
+		// non-folding version
+		for (k=0;tMax.EnumProfile(k,id);k++)
+		if (id.GetCalls(frame))
+		fprintf(f,"f%08x [label=\"%s\"]\n",id.GetAddress(),id.GetFunction());
+		for (k=0;tMax.EnumProfile(k,id);k++)
+		{
+			ProfileFuncLevel::IdList idlist=id.GetCaller(frame);
+			ProfileFuncLevel::Id caller;
+			unsigned count;
+			for (unsigned i=0;idlist.Enum(i,caller,&count);i++)
+			fprintf(f,"f%08x -> f%08x [headlabel=\"%i\"];\n",caller.GetAddress(),id.GetAddress(),count);
+		}
+	}
 
-  fprintf(f,"}\n");
-  fclose(f);
+	fprintf(f,"}\n");
+	fclose(f);
 }
 
 void ProfileResultFileDOT::Delete()
 {
-  this->~ProfileResultFileDOT();
-  ProfileFreeMemory(this);
+	this->~ProfileResultFileDOT();
+	ProfileFreeMemory(this);
 }

--- a/Core/Libraries/Source/profile/profile_result.h
+++ b/Core/Libraries/Source/profile/profile_result.h
@@ -37,9 +37,9 @@
 */
 class ProfileResultInterface
 {
-  // no copying
-  ProfileResultInterface(const ProfileResultInterface&);
-  ProfileResultInterface& operator=(const ProfileResultInterface&);
+	// no copying
+	ProfileResultInterface(const ProfileResultInterface&);
+	ProfileResultInterface& operator=(const ProfileResultInterface&);
 
 public:
   /**
@@ -47,15 +47,15 @@ public:
 
     This function is called on program exit.
   */
-  virtual void WriteResults()=0;
+	virtual void WriteResults()=0;
 
   /**
     \brief Destroys the current result function.
 
     Use this function instead of just delete'ing the instance.
   */
-  virtual void Delete()=0;
+	virtual void Delete()=0;
 
 protected:
-  ProfileResultInterface() {}
+	ProfileResultInterface() {}
 };

--- a/Core/Libraries/Source/profile/test1/test1.cpp
+++ b/Core/Libraries/Source/profile/test1/test1.cpp
@@ -32,20 +32,20 @@
 
 const char *DebugGetDefaultCommands()
 {
-  return "!debug.io con add\ndebug.add l + *\nprofile.result";
+	return "!debug.io con add\ndebug.add l + *\nprofile.result";
 }
 
 extern int q;
 
 void calcThis()
 {
-  q++;
+	q++;
 }
 
 void calcThat()
 {
-  calcThis();
-  q--;
+	calcThis();
+	q--;
 }
 
 // it must be done this "complicated" because
@@ -55,40 +55,40 @@ void recursion2(int level);
 
 void recursion(int level)
 {
-  q+=level;
-  if (level<5000)
-    recursion2(level+1);
+	q+=level;
+	if (level<5000)
+	recursion2(level+1);
 }
 
 void recursion2(int level)
 {
-  recursion(level);
+	recursion(level);
 }
 
 void recursionShell()
 {
-  ProfileHighLevel::Block b("Test block");
-  recursion(0);
+	ProfileHighLevel::Block b("Test block");
+	recursion(0);
 }
 
 void showResults()
 {
-  ProfileHighLevel::Id id;
-  for (unsigned index=0;ProfileHighLevel::EnumProfile(index,id);index++)
-    printf("%-16s%-6s %s\n",id.GetName(),id.GetTotalValue(),id.GetUnit());
+	ProfileHighLevel::Id id;
+	for (unsigned index=0;ProfileHighLevel::EnumProfile(index,id);index++)
+	printf("%-16s%-6s %s\n",id.GetName(),id.GetTotalValue(),id.GetUnit());
 }
 
 void main()
 {
-  for (int k=0;k<100;k++)
-    if (k%2&&k>80)
-      calcThat();
-    else
-      calcThis();
+	for (int k=0;k<100;k++)
+	if (k%2&&k>80)
+	calcThat();
+	else
+	calcThis();
 
-  recursionShell();
+	recursionShell();
 
-  showResults();
+	showResults();
 }
 
 int q;

--- a/Dependencies/Utility/Utility/atl_compat.h
+++ b/Dependencies/Utility/Utility/atl_compat.h
@@ -66,10 +66,10 @@ extern "C" HRESULT WINAPI _ATL_DelegateQueryInterface(void* pv, REFIID riid, LPV
 // Define _Delegate implementation and macro now that ATL types are available
 inline HRESULT WINAPI _ATL_DelegateQueryInterface(void* pv, REFIID riid, LPVOID* ppv, DWORD_PTR dw)
 {
-    IUnknown** ppunk = reinterpret_cast<IUnknown**>(reinterpret_cast<char*>(pv) + dw);
-    if (*ppunk == nullptr)
-        return E_NOINTERFACE;
-    return (*ppunk)->QueryInterface(riid, ppv);
+	IUnknown** ppunk = reinterpret_cast<IUnknown**>(reinterpret_cast<char*>(pv) + dw);
+	if (*ppunk == nullptr)
+	return E_NOINTERFACE;
+	return (*ppunk)->QueryInterface(riid, ppv);
 }
 
 #ifndef _Delegate

--- a/Dependencies/Utility/Utility/comsupp_compat.h
+++ b/Dependencies/Utility/Utility/comsupp_compat.h
@@ -56,82 +56,82 @@ namespace _com_util
 
 inline BSTR WINAPI ConvertStringToBSTR(const char *pSrc)
 {
-    DWORD cwch;
-    BSTR wsOut = nullptr;
+		DWORD cwch;
+		BSTR wsOut = nullptr;
 
-    if (!pSrc)
-        return nullptr;
+		if (!pSrc)
+		return nullptr;
 
-    // Compute the needed size with the null terminator
-    cwch = MultiByteToWideChar(CP_ACP, 0, pSrc, -1, nullptr, 0);
-    if (cwch == 0)
-        return nullptr;
+		// Compute the needed size with the null terminator
+		cwch = MultiByteToWideChar(CP_ACP, 0, pSrc, -1, nullptr, 0);
+		if (cwch == 0)
+		return nullptr;
 
-    // Allocate the BSTR (without the null terminator)
-    wsOut = SysAllocStringLen(nullptr, cwch - 1);
-    if (!wsOut)
-    {
-        _com_issue_error(HRESULT_FROM_WIN32(ERROR_OUTOFMEMORY));
-        return nullptr;
-    }
+		// Allocate the BSTR (without the null terminator)
+		wsOut = SysAllocStringLen(nullptr, cwch - 1);
+		if (!wsOut)
+		{
+			_com_issue_error(HRESULT_FROM_WIN32(ERROR_OUTOFMEMORY));
+			return nullptr;
+		}
 
-    // Convert the string
-    if (MultiByteToWideChar(CP_ACP, 0, pSrc, -1, wsOut, cwch) == 0)
-    {
-        // We failed, clean everything up
-        cwch = GetLastError();
+		// Convert the string
+		if (MultiByteToWideChar(CP_ACP, 0, pSrc, -1, wsOut, cwch) == 0)
+		{
+			// We failed, clean everything up
+			cwch = GetLastError();
 
-        SysFreeString(wsOut);
-        wsOut = nullptr;
+			SysFreeString(wsOut);
+			wsOut = nullptr;
 
-        _com_issue_error(!IS_ERROR(cwch) ? HRESULT_FROM_WIN32(cwch) : cwch);
-    }
+			_com_issue_error(!IS_ERROR(cwch) ? HRESULT_FROM_WIN32(cwch) : cwch);
+		}
 
-    return wsOut;
+		return wsOut;
 }
 
 inline char* WINAPI ConvertBSTRToString(BSTR pSrc)
 {
-    DWORD cb, cwch;
-    char *szOut = nullptr;
+		DWORD cb, cwch;
+		char *szOut = nullptr;
 
-    if (!pSrc)
-        return nullptr;
+		if (!pSrc)
+		return nullptr;
 
-    // Retrieve the size of the BSTR with the null terminator
-    cwch = SysStringLen(pSrc) + 1;
+		// Retrieve the size of the BSTR with the null terminator
+		cwch = SysStringLen(pSrc) + 1;
 
-    // Compute the needed size with the null terminator
-    cb = WideCharToMultiByte(CP_ACP, 0, pSrc, cwch, nullptr, 0, nullptr, nullptr);
-    if (cb == 0)
-    {
-        cwch = GetLastError();
-        _com_issue_error(!IS_ERROR(cwch) ? HRESULT_FROM_WIN32(cwch) : cwch);
-        return nullptr;
-    }
+		// Compute the needed size with the null terminator
+		cb = WideCharToMultiByte(CP_ACP, 0, pSrc, cwch, nullptr, 0, nullptr, nullptr);
+		if (cb == 0)
+		{
+			cwch = GetLastError();
+			_com_issue_error(!IS_ERROR(cwch) ? HRESULT_FROM_WIN32(cwch) : cwch);
+			return nullptr;
+		}
 
-    // Allocate the string
-    szOut = (char*)::operator new(cb * sizeof(char));
-    if (!szOut)
-    {
-        _com_issue_error(HRESULT_FROM_WIN32(ERROR_OUTOFMEMORY));
-        return nullptr;
-    }
+		// Allocate the string
+		szOut = (char*)::operator new(cb * sizeof(char));
+		if (!szOut)
+		{
+			_com_issue_error(HRESULT_FROM_WIN32(ERROR_OUTOFMEMORY));
+			return nullptr;
+		}
 
-    // Convert the string and null-terminate
-    szOut[cb - 1] = '\0';
-    if (WideCharToMultiByte(CP_ACP, 0, pSrc, cwch, szOut, cb, nullptr, nullptr) == 0)
-    {
-        // We failed, clean everything up
-        cwch = GetLastError();
+		// Convert the string and null-terminate
+		szOut[cb - 1] = '\0';
+		if (WideCharToMultiByte(CP_ACP, 0, pSrc, cwch, szOut, cb, nullptr, nullptr) == 0)
+		{
+			// We failed, clean everything up
+			cwch = GetLastError();
 
-        ::operator delete(szOut);
-        szOut = nullptr;
+			::operator delete(szOut);
+			szOut = nullptr;
 
-        _com_issue_error(!IS_ERROR(cwch) ? HRESULT_FROM_WIN32(cwch) : cwch);
-    }
+			_com_issue_error(!IS_ERROR(cwch) ? HRESULT_FROM_WIN32(cwch) : cwch);
+		}
 
-    return szOut;
+		return szOut;
 }
 
 }

--- a/Dependencies/Utility/Utility/intrin_compat.h
+++ b/Dependencies/Utility/Utility/intrin_compat.h
@@ -39,8 +39,8 @@ static inline __int64 _rdtsc()
 		mov	[l],eax
 	}
 
-    __int64 result ((__int64)h << 32 | l);
-    return result;
+	__int64 result ((__int64)h << 32 | l);
+	return result;
 }
 #endif //_rdtsc
 
@@ -75,10 +75,10 @@ static inline __int64 _rdtsc()
 static inline uint32_t _lrotl(uint32_t value, int shift)
 {
 #if defined(__has_builtin) && __has_builtin(__builtin_rotateleft32)
-    return __builtin_rotateleft32(value, shift);
+	return __builtin_rotateleft32(value, shift);
 #else
-    shift &= 31;
-    return ((value << shift) | (value >> (32 - shift)));
+	shift &= 31;
+	return ((value << shift) | (value >> (32 - shift)));
 #endif
 }
 #endif
@@ -93,11 +93,11 @@ static inline uint32_t _lrotl(uint32_t value, int shift)
 static inline uint64_t _rdtsc()
 {
 #ifdef _WIN32
-    return __rdtsc();
+	return __rdtsc();
 #elif defined(__has_builtin) && __has_builtin(__builtin_readcyclecounter)
-    return __builtin_readcyclecounter();
+	return __builtin_readcyclecounter();
 #elif defined(__has_builtin) && __has_builtin(__builtin_ia32_rdtsc)
-    return __builtin_ia32_rdtsc();
+	return __builtin_ia32_rdtsc();
 #else
 #error "No implementation for _rdtsc"
 #endif
@@ -111,7 +111,7 @@ static inline uint64_t _rdtsc()
     #if __has_builtin(__builtin_return_address)
     static inline uintptr_t _ReturnAddress()
     {
-        return reinterpret_cast<uintptr_t>(__builtin_return_address(0));
+	return reinterpret_cast<uintptr_t>(__builtin_return_address(0));
     }
     #else
     #error "No implementation for _ReturnAddress"

--- a/Dependencies/Utility/Utility/iostream_adapter.h
+++ b/Dependencies/Utility/Utility/iostream_adapter.h
@@ -38,13 +38,13 @@ using ostream = std::ostream;
 template <class _Elem, class _Traits>
 std::basic_ostream<_Elem, _Traits>& endl(std::basic_ostream<_Elem, _Traits>& _Ostr)
 {
-    return std::endl(_Ostr);
+	return std::endl(_Ostr);
 }
 
 template <class _Elem, class _Traits>
 std::basic_ostream<_Elem, _Traits>& flush(std::basic_ostream<_Elem, _Traits>& _Ostr)
 {
-    return std::flush(_Ostr);
+	return std::flush(_Ostr);
 }
 
 #endif

--- a/Dependencies/Utility/Utility/stdint_adapter.h
+++ b/Dependencies/Utility/Utility/stdint_adapter.h
@@ -21,11 +21,11 @@
 #if defined(USING_STLPORT) || (defined(_MSC_VER) && _MSC_VER < 1300)
 /* 7.18.1.4  Integer types capable of holding object pointers */
 #ifdef _WIN64
-  typedef __int64 intptr_t;
-  typedef unsigned __int64 uintptr_t;
+typedef __int64 intptr_t;
+typedef unsigned __int64 uintptr_t;
 #else
-  typedef int intptr_t;
-  typedef unsigned int uintptr_t;
+typedef int intptr_t;
+typedef unsigned int uintptr_t;
 #endif
 
 /* 7.18.1.1  Exact-width integer types */

--- a/Dependencies/Utility/Utility/string_compat.h
+++ b/Dependencies/Utility/Utility/string_compat.h
@@ -25,10 +25,10 @@ typedef char* LPSTR;
 
 // String functions
 inline char *_strlwr(char *str) {
-  for (int i = 0; str[i] != '\0'; i++) {
-    str[i] = tolower(str[i]);
-  }
-  return str;
+	for (int i = 0; str[i] != '\0'; i++) {
+		str[i] = tolower(str[i]);
+	}
+	return str;
 }
 
 #define strlwr _strlwr

--- a/Dependencies/Utility/Utility/thread_compat.h
+++ b/Dependencies/Utility/Utility/thread_compat.h
@@ -23,11 +23,11 @@
 
 inline int GetCurrentThreadId()
 {
-  return pthread_self();
+	return pthread_self();
 }
 
 inline void Sleep(int ms)
 {
-  usleep(ms * 1000);
+	usleep(ms * 1000);
 }
 

--- a/Dependencies/Utility/Utility/time_compat.h
+++ b/Dependencies/Utility/Utility/time_compat.h
@@ -27,15 +27,15 @@ static inline MMRESULT timeEndPeriod(int) { return TIMERR_NOERROR; }
 
 inline unsigned int timeGetTime()
 {
-  struct timespec ts;
-  clock_gettime(CLOCK_BOOTTIME, &ts);
-  return ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+	struct timespec ts;
+	clock_gettime(CLOCK_BOOTTIME, &ts);
+	return ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
 }
 inline unsigned int GetTickCount()
 {
-  struct timespec ts;
-  clock_gettime(CLOCK_MONOTONIC, &ts);
-  // Return ms since boot
-  return ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	// Return ms since boot
+	return ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
 }
 

--- a/scripts/cpp/convert_leading_spaces_to_tabs.py
+++ b/scripts/cpp/convert_leading_spaces_to_tabs.py
@@ -174,16 +174,8 @@ def process_file(filepath, dry_run=False, verbose=False):
             new_lines.append(line)
             continue
 
-        # Skip mixed tab+space lines (e.g. tab then spaces for alignment)
-        # These need careful handling deferred to a later PR
-        if '\t' in leading_ws and ' ' in leading_ws:
-            new_lines.append(line)
-            skipped += 1
-            if verbose:
-                print(f"  SKIP mixed L{line_idx+1}: {line.rstrip()[:80]}")
-            continue
-
-        # This line has leading spaces. Use tree-sitter to determine depth.
+        # This line has spaces in its leading whitespace (possibly mixed with tabs).
+        # Use tree-sitter to determine the correct depth.
         # Find the AST node at the first non-whitespace character.
         col = len(leading_ws)
         node = tree.root_node.descendant_for_point_range(

--- a/scripts/cpp/convert_leading_spaces_to_tabs.py
+++ b/scripts/cpp/convert_leading_spaces_to_tabs.py
@@ -18,12 +18,40 @@ Usage:
 import argparse
 import glob
 import os
+import re
 
 import tree_sitter_cpp as tscpp
 from tree_sitter import Language, Parser
 
 
 CPP_LANGUAGE = Language(tscpp.language())
+
+
+# Macros that confuse tree-sitter's C++ parser. These are expanded in the
+# source text before parsing (but not in the output). Replacements are
+# same-length to preserve byte offsets between the parsed and original text.
+MACRO_EXPANSIONS = [
+    (re.compile(rb'\bCALLBACK\b'),    b'        '),
+    (re.compile(rb'\bGCALL\b'),       b'     '),
+    (re.compile(rb'\bWINAPI\b'),      b'      '),
+    (re.compile(rb'\bIN\b'),          b'  '),
+    (re.compile(rb'\bOUT\b'),         b'   '),
+    (re.compile(rb'\bRO\b'),          b'  '),
+    (re.compile(rb'\bW3DNEW\b'),      b'new   '),
+    (re.compile(rb'\bNEW\b'),         b'new'),
+    (re.compile(rb'\b__RPC_FAR\b'),   b'         '),
+    (re.compile(rb'\b__RPC_STUB\b'),  b'          '),
+    (re.compile(rb'\b__asm\b'),       b'     '),
+    (re.compile(rb'\b_asm\b'),        b'    '),
+]
+
+
+def preprocess_for_parsing(code_bytes):
+    """Apply macro expansions to help tree-sitter parse the code."""
+    result = code_bytes
+    for pattern, replacement in MACRO_EXPANSIONS:
+        result = pattern.sub(replacement, result)
+    return result
 
 
 # Node types that create an indentation level for their children.
@@ -116,7 +144,8 @@ def process_file(filepath, dry_run=False, verbose=False):
         lines = lines[:-1]  # split adds an empty string after trailing \n
 
     code_bytes = content.encode('utf-8')
-    tree = parser.parse(code_bytes)
+    parse_bytes = preprocess_for_parsing(code_bytes)
+    tree = parser.parse(parse_bytes)
 
     # If the file has excessive parse errors, the AST is unreliable - skip it.
     # Only count top-level errors (not deeply nested ones from macro expansions).

--- a/scripts/cpp/convert_leading_spaces_to_tabs.py
+++ b/scripts/cpp/convert_leading_spaces_to_tabs.py
@@ -1,0 +1,354 @@
+"""
+Convert leading spaces to tabs using tree-sitter for accurate C++ parsing.
+
+Uses the tree-sitter C++ parser to determine the correct indentation depth
+of each line, then replaces leading whitespace with the correct number of tabs.
+
+Only converts lines where the tool is confident about the correct depth.
+Lines inside block comments, continuation lines, and ambiguous cases are
+skipped and logged.
+
+Requirements:
+    pip install tree-sitter tree-sitter-cpp
+
+Usage:
+    python convert_leading_spaces_to_tabs.py [--dry-run] [--verbose]
+"""
+
+import argparse
+import glob
+import os
+
+import tree_sitter_cpp as tscpp
+from tree_sitter import Language, Parser
+
+
+CPP_LANGUAGE = Language(tscpp.language())
+
+
+# Node types that create an indentation level for their children.
+SCOPE_CREATING_TYPES = frozenset({
+    'compound_statement',
+    'field_declaration_list',
+    'declaration_list',      # namespace body
+    'enumerator_list',
+    'initializer_list',
+    'case_statement',
+})
+
+
+def get_indent_depth(node):
+    """Walk up the AST and count scope-creating ancestors to determine indent depth."""
+    depth = 0
+    current = node.parent
+
+    while current is not None:
+        if current.type in SCOPE_CREATING_TYPES:
+            # Special case: a compound_statement that is a direct child of
+            # case_statement does not add an extra indent level. The case_statement
+            # already provides the indent, and the braces are at the case level.
+            if (current.type == 'compound_statement'
+                    and current.parent is not None
+                    and current.parent.type == 'case_statement'):
+                pass  # don't increment
+            else:
+                depth += 1
+        current = current.parent
+
+    return depth
+
+
+def is_continuation_line(node, line_num):
+    """Check if this line is a continuation of a multi-line statement.
+
+    A continuation line is one where the innermost meaningful AST node
+    started on a previous line. We skip these because their alignment
+    is a style choice we don't want to change in this PR.
+    """
+    if node is None:
+        return False
+
+    # Walk up to find the nearest statement-level node
+    current = node
+    while current is not None:
+        # If this node starts on our line, it's not a continuation
+        if current.start_point[0] == line_num:
+            current = current.parent
+            continue
+
+        # If the node started on a previous line and is a statement-level
+        # construct, this is a continuation line
+        if current.start_point[0] < line_num:
+            if current.type in (
+                'declaration', 'field_declaration', 'expression_statement',
+                'return_statement', 'init_declarator', 'argument_list',
+                'parameter_list', 'condition_clause', 'call_expression',
+                'binary_expression', 'assignment_expression',
+                'function_declarator', 'template_argument_list',
+                'field_initializer_list', 'field_initializer',
+                'base_class_clause', 'initializer_pair',
+            ):
+                return True
+        current = current.parent
+
+    return False
+
+
+
+
+
+def process_file(filepath, dry_run=False, verbose=False):
+    """Process a single file, converting leading spaces to tabs.
+
+    Returns (changed, skipped, total_lines) tuple.
+    """
+    parser = Parser(CPP_LANGUAGE)
+
+    try:
+        with open(filepath, 'r', encoding='cp1252') as f:
+            content = f.read()
+    except (UnicodeDecodeError, OSError):
+        return 0, 0, 0
+
+    lines = content.split('\n')
+    # Preserve original line endings
+    if content.endswith('\n'):
+        lines = lines[:-1]  # split adds an empty string after trailing \n
+
+    code_bytes = content.encode('utf-8')
+    tree = parser.parse(code_bytes)
+
+    # If the file has excessive parse errors, the AST is unreliable - skip it.
+    # Only count top-level errors (not deeply nested ones from macro expansions).
+    error_count = sum(1 for child in tree.root_node.children if child.type == 'ERROR')
+    if error_count > 10:
+        if verbose:
+            print(f"  SKIP file (too many top-level parse errors: {error_count})")
+        return 0, 0, len(lines)
+
+    new_lines = []
+    changed = 0
+    skipped = 0
+    in_block_comment = False
+    in_macro_continuation = False
+
+    for line_idx, line in enumerate(lines):
+        # Track block comments manually for reliability
+        stripped = line.lstrip()
+        line_continues_macro = line.rstrip().endswith('\\')
+
+        if in_block_comment:
+            # Inside a block comment - don't touch
+            new_lines.append(line)
+            if '*/' in line:
+                in_block_comment = False
+            continue
+
+        if stripped.startswith('/*'):
+            if '*/' not in stripped or stripped.index('*/') < stripped.index('/*') + 2:
+                in_block_comment = '*/' not in stripped[2:]
+            new_lines.append(line)
+            continue
+
+        # Multi-line macro continuations - don't touch
+        if in_macro_continuation:
+            new_lines.append(line)
+            in_macro_continuation = line_continues_macro
+            continue
+
+        # Blank lines - preserve as-is
+        if stripped == '':
+            new_lines.append(line)
+            continue
+
+        # Preprocessor directives - always column 0
+        if stripped.startswith('#'):
+            new_lines.append(line)
+            in_macro_continuation = line_continues_macro
+            continue
+
+        # Check if the line already uses tabs (no leading spaces)
+        leading_ws = line[:len(line) - len(line.lstrip())]
+        if ' ' not in leading_ws:
+            # Already all tabs (or no indentation) - keep as-is
+            new_lines.append(line)
+            continue
+
+        # Skip mixed tab+space lines (e.g. tab then spaces for alignment)
+        # These need careful handling deferred to a later PR
+        if '\t' in leading_ws and ' ' in leading_ws:
+            new_lines.append(line)
+            skipped += 1
+            if verbose:
+                print(f"  SKIP mixed L{line_idx+1}: {line.rstrip()[:80]}")
+            continue
+
+        # This line has leading spaces. Use tree-sitter to determine depth.
+        # Find the AST node at the first non-whitespace character.
+        col = len(leading_ws)
+        node = tree.root_node.descendant_for_point_range(
+            (line_idx, col), (line_idx, col)
+        )
+
+        if node is None:
+            new_lines.append(line)
+            skipped += 1
+            continue
+
+        # Skip if the node or any ancestor is an ERROR node (parse failure)
+        error_ancestor = False
+        check = node
+        while check is not None:
+            if check.type == 'ERROR':
+                error_ancestor = True
+                break
+            check = check.parent
+        if error_ancestor:
+            new_lines.append(line)
+            skipped += 1
+            if verbose:
+                print(f"  SKIP parse error L{line_idx+1}: {line.rstrip()[:80]}")
+            continue
+
+        # For comment nodes, we can reindent // line comments but
+        # should skip /* */ block comments (their internal formatting
+        # is intentional). Block comments are already handled by the
+        # in_block_comment tracking above, so single-line comments
+        # that tree-sitter reports as 'comment' are fine to reindent.
+        # However, single-line /* */ comments on their own line are also
+        # fine to reindent.
+
+        # Skip continuation lines
+        if is_continuation_line(node, line_idx):
+            new_lines.append(line)
+            skipped += 1
+            if verbose:
+                print(f"  SKIP continuation L{line_idx+1}: {line.rstrip()[:80]}")
+            continue
+
+        # Calculate expected depth
+        depth = get_indent_depth(node)
+
+        # Special handling: the opening/closing braces of a compound_statement
+        # should be at the parent's depth, not the compound_statement's depth.
+        if node.type in ('{', '}'):
+            parent = node.parent
+            if parent is not None and parent.type in SCOPE_CREATING_TYPES:
+                # For a compound_statement inside case_statement, braces should
+                # be at the case label level (case_statement's own depth)
+                if (parent.type == 'compound_statement'
+                        and parent.parent is not None
+                        and parent.parent.type == 'case_statement'):
+                    depth = get_indent_depth(parent.parent)
+                else:
+                    depth = get_indent_depth(parent)
+
+        # Special handling: case/default labels - they are children of
+        # case_statement but should be at the case_statement's depth
+        # (the 'case' keyword itself)
+        if node.type in ('case', 'default'):
+            parent = node.parent
+            if parent is not None and parent.type == 'case_statement':
+                depth = get_indent_depth(parent)
+
+        # Special handling: access specifiers (public/private/protected)
+        # For now, skip these - deferred to another PR
+        if node.type in ('public', 'private', 'protected'):
+            new_lines.append(line)
+            skipped += 1
+            if verbose:
+                print(f"  SKIP access spec L{line_idx+1}: {line.rstrip()[:80]}")
+            continue
+
+        # Special handling: the colon after access specifier or case label
+        if node.type == ':':
+            parent = node.parent
+            if parent is not None and parent.type == 'access_specifier':
+                new_lines.append(line)
+                skipped += 1
+                continue
+
+        # Sanity check: if the line had significant indentation but we
+        # computed depth 0, something is likely wrong (parse errors nearby,
+        # inline assembly corrupting the AST, etc). Skip to be safe.
+        # Threshold of 4 spaces catches most misparses while allowing
+        # legitimate depth-0 code with minor (1-3 space) indentation errors.
+        space_count = len(leading_ws)
+        if depth == 0 and space_count >= 4:
+            new_lines.append(line)
+            skipped += 1
+            if verbose:
+                print(f"  SKIP sanity L{line_idx+1}: depth=0 but {space_count} spaces: {line.rstrip()[:80]}")
+            continue
+
+        # Build the new line: depth tabs + original content (no leading whitespace)
+        new_line = '\t' * depth + stripped
+        if new_line != line:
+            changed += 1
+            if verbose:
+                print(f"  CHANGE L{line_idx+1} (depth={depth}): '{leading_ws}' -> '{chr(9)*depth}'")
+        new_lines.append(new_line)
+
+    if changed > 0 and not dry_run:
+        with open(filepath, 'w', encoding='cp1252') as f:
+            f.write('\n'.join(new_lines))
+            if content.endswith('\n'):
+                f.write('\n')
+
+    return changed, skipped, len(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Convert leading spaces to tabs using tree-sitter C++ parsing.'
+    )
+    parser.add_argument('--dry-run', action='store_true',
+                        help='Show what would change without modifying files')
+    parser.add_argument('--verbose', '-v', action='store_true',
+                        help='Print details about each changed/skipped line')
+    parser.add_argument('--file', type=str,
+                        help='Process a single file instead of the whole codebase')
+    args = parser.parse_args()
+
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    root_dir = os.path.normpath(os.path.join(script_dir, '..', '..'))
+
+    if args.file:
+        file_list = [args.file]
+    else:
+        top_dirs = [
+            os.path.join(root_dir, 'Core'),
+            os.path.join(root_dir, 'Generals'),
+            os.path.join(root_dir, 'GeneralsMD'),
+            os.path.join(root_dir, 'Dependencies', 'Utility'),
+        ]
+        file_list = []
+        for ext in ['*.cpp', '*.h', '*.inl']:
+            for top_dir in top_dirs:
+                file_list.extend(
+                    glob.glob(os.path.join(top_dir, '**', ext), recursive=True)
+                )
+
+    total_changed = 0
+    total_skipped = 0
+    total_files_modified = 0
+
+    for filepath in sorted(file_list):
+        changed, skipped, total_lines = process_file(
+            filepath, dry_run=args.dry_run, verbose=args.verbose
+        )
+        if changed > 0:
+            total_files_modified += 1
+            rel = os.path.relpath(filepath, root_dir)
+            action = "Would change" if args.dry_run else "Changed"
+            print(f"{action} {changed} lines in {rel}")
+        total_changed += changed
+        total_skipped += skipped
+
+    action = "Would change" if args.dry_run else "Changed"
+    print(f"\n{action} {total_changed} lines across {total_files_modified} files")
+    print(f"Skipped {total_skipped} lines (continuations, access specifiers, ambiguous)")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/cpp/convert_leading_spaces_to_tabs.py
+++ b/scripts/cpp/convert_leading_spaces_to_tabs.py
@@ -86,15 +86,18 @@ def get_indent_depth(node):
     return depth
 
 
-def is_continuation_line(node, line_num):
-    """Check if this line is a continuation of a multi-line statement.
+def get_continuation_parent(node, line_num):
+    """Find the parent statement that this line is a continuation of.
+
+    Returns the parent statement node if this is a continuation line,
+    or None if it's not a continuation.
 
     A continuation line is one where the innermost meaningful AST node
-    started on a previous line. We skip these because their alignment
-    is a style choice we don't want to change in this PR.
+    started on a previous line (e.g., multi-line function arguments,
+    constructor initializer lists, multi-line conditions).
     """
     if node is None:
-        return False
+        return None
 
     # Walk up to find the nearest statement-level node
     current = node
@@ -116,10 +119,21 @@ def is_continuation_line(node, line_num):
                 'field_initializer_list', 'field_initializer',
                 'base_class_clause', 'initializer_pair',
             ):
-                return True
+                return current
         current = current.parent
 
-    return False
+    return None
+
+
+def is_closing_delimiter_line(stripped):
+    """Check if a line is just a closing delimiter, possibly with trailing punctuation.
+
+    Matches lines like ')', ');', ') {', ']);', etc.
+    These should be at the parent statement's depth, not +1.
+    """
+    # Strip trailing semicolons, braces, commas
+    s = stripped.rstrip(';,{ ')
+    return s in (')', ']', '}')
 
 
 
@@ -239,16 +253,18 @@ def process_file(filepath, dry_run=False, verbose=False):
         # However, single-line /* */ comments on their own line are also
         # fine to reindent.
 
-        # Skip continuation lines
-        if is_continuation_line(node, line_idx):
-            new_lines.append(line)
-            skipped += 1
-            if verbose:
-                print(f"  SKIP continuation L{line_idx+1}: {line.rstrip()[:80]}")
-            continue
-
-        # Calculate expected depth
-        depth = get_indent_depth(node)
+        # Continuation lines: indent at parent statement depth + 1.
+        # Closing delimiters on their own line go at parent depth (no +1).
+        continuation_parent = get_continuation_parent(node, line_idx)
+        if continuation_parent is not None:
+            parent_depth = get_indent_depth(continuation_parent)
+            if is_closing_delimiter_line(stripped):
+                depth = parent_depth
+            else:
+                depth = parent_depth + 1
+        else:
+            # Calculate expected depth
+            depth = get_indent_depth(node)
 
         # Special handling: the opening/closing braces of a compound_statement
         # should be at the parent's depth, not the compound_statement's depth.
@@ -368,7 +384,7 @@ def main():
 
     action = "Would change" if args.dry_run else "Changed"
     print(f"\n{action} {total_changed} lines across {total_files_modified} files")
-    print(f"Skipped {total_skipped} lines (continuations, ambiguous)")
+    print(f"Skipped {total_skipped} lines (ambiguous)")
 
 
 if __name__ == '__main__':

--- a/scripts/cpp/convert_leading_spaces_to_tabs.py
+++ b/scripts/cpp/convert_leading_spaces_to_tabs.py
@@ -273,21 +273,21 @@ def process_file(filepath, dry_run=False, verbose=False):
                 depth = get_indent_depth(parent)
 
         # Special handling: access specifiers (public/private/protected)
-        # For now, skip these - deferred to another PR
+        # These sit at the class brace level, not indented inside the class body.
         if node.type in ('public', 'private', 'protected'):
-            new_lines.append(line)
-            skipped += 1
-            if verbose:
-                print(f"  SKIP access spec L{line_idx+1}: {line.rstrip()[:80]}")
-            continue
+            access_spec = node.parent  # access_specifier node
+            if access_spec is not None and access_spec.type == 'access_specifier':
+                field_list = access_spec.parent  # field_declaration_list
+                if field_list is not None:
+                    depth = get_indent_depth(field_list)
 
-        # Special handling: the colon after access specifier or case label
+        # Special handling: the colon after access specifier
         if node.type == ':':
             parent = node.parent
             if parent is not None and parent.type == 'access_specifier':
-                new_lines.append(line)
-                skipped += 1
-                continue
+                field_list = parent.parent
+                if field_list is not None:
+                    depth = get_indent_depth(field_list)
 
         # Sanity check: if the line had significant indentation but we
         # computed depth 0, something is likely wrong (parse errors nearby,
@@ -368,7 +368,7 @@ def main():
 
     action = "Would change" if args.dry_run else "Changed"
     print(f"\n{action} {total_changed} lines across {total_files_modified} files")
-    print(f"Skipped {total_skipped} lines (continuations, access specifiers, ambiguous)")
+    print(f"Skipped {total_skipped} lines (continuations, ambiguous)")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- Convert leading spaces/mixed whitespace to tabs, including continuation line indentation
- All changes are whitespace-only (`git diff -w` is empty)
- Uses tree-sitter-cpp for accurate C++ parsing with macro preprocessing

Continuation lines (multi-line function args, constructor initializer lists,
multi-line conditions, etc.) are indented at parent statement depth + 1 tab.
Closing delimiters on their own line go at parent depth.

## Script

The formatting script is included in the PR for reference but is not intended
to be merged — it shows how the changes were generated.

See `scripts/cpp/convert_leading_spaces_to_tabs.py` for details.

## All parts
- #2565 Core engine and libraries (324 files)
- #2566 Core tools (289 files)
- #2567 Generals GameEngine (362 files)
- #2568 Generals libraries and tools (182 files)
- #2569 GeneralsMD GameEngine (439 files)
- #2570 GeneralsMD libraries and tools (195 files)