### PR TITLE
fix(pathfinder): Fix CRC computation of PathFinder::m_wallPieces

### DIFF
--- a/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -11339,18 +11339,18 @@ void Pathfinder::crc( Xfer *xfer )
 	xfer->xferInt(&m_numWallPieces);
 	CRCDEBUG_LOG(("m_numWallPieces: %8.8X", ((XferCRC *)xfer)->getCRC()));
 
+#if RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @fix The original code effectively accessed m_numWallPieces 128 times,
+	// because it used &m_wallPieces[MAX_WALL_PIECES] which is out-of-bounds and points to m_numWallPieces.
+	static_assert(sizeof(Int) == sizeof(ObjectID), "Type sizes must be equal for correct xfer");
+
 	for (Int i = 0; i < MAX_WALL_PIECES; ++i)
 	{
-#if RETAIL_COMPATIBLE_CRC
-		// TheSuperHackers @info The original code effectively wrote m_numWallPieces 128 times,
-		// because it used &m_wallPieces[MAX_WALL_PIECES] which is out-of-bounds and points to m_numWallPieces.
-		static_assert(sizeof(Int) == sizeof(ObjectID));
-
 		xfer->xferInt(&m_numWallPieces);
-#else
-		xfer->xferObjectID(&m_wallPieces[i]);
-#endif
 	}
+#else
+	xfer->xferUser(m_wallPieces, sizeof(m_wallPieces));
+#endif
 
 	CRCDEBUG_LOG(("m_wallPieces: %8.8X", ((XferCRC *)xfer)->getCRC()));
 

--- a/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
+++ b/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp
@@ -11338,10 +11338,20 @@ void Pathfinder::crc( Xfer *xfer )
 
 	xfer->xferInt(&m_numWallPieces);
 	CRCDEBUG_LOG(("m_numWallPieces: %8.8X", ((XferCRC *)xfer)->getCRC()));
-	for (Int i=0; i<MAX_WALL_PIECES; ++i)
+
+	for (Int i = 0; i < MAX_WALL_PIECES; ++i)
 	{
-		xfer->xferObjectID(&m_wallPieces[MAX_WALL_PIECES]);
+#if RETAIL_COMPATIBLE_CRC
+		// TheSuperHackers @info The original code effectively wrote m_numWallPieces 128 times,
+		// because it used &m_wallPieces[MAX_WALL_PIECES] which is out-of-bounds and points to m_numWallPieces.
+		static_assert(sizeof(Int) == sizeof(ObjectID));
+
+		xfer->xferInt(&m_numWallPieces);
+#else
+		xfer->xferObjectID(&m_wallPieces[i]);
+#endif
 	}
+
 	CRCDEBUG_LOG(("m_wallPieces: %8.8X", ((XferCRC *)xfer)->getCRC()));
 
 	xfer->xferReal(&m_wallHeight);


### PR DESCRIPTION
<details>
<summary>Original EA code links</summary>

https://github.com/electronicarts/CnC_Generals_Zero_Hour/blob/main/Generals/Code/GameEngine/Include/GameLogic/AIPathfind.h#L846-L847

https://github.com/electronicarts/CnC_Generals_Zero_Hour/blob/main/Generals/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp#L10395-L10398

https://github.com/electronicarts/CnC_Generals_Zero_Hour/blob/main/GeneralsMD/Code/GameEngine/Include/GameLogic/AIPathfind.h#L858-L859

https://github.com/electronicarts/CnC_Generals_Zero_Hour/blob/main/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIPathfind.cpp#L11095-L11098
</details>

https://github.com/TheSuperHackers/GeneralsGameCode/blob/64b5eaad7e6e695729f87d20de22e5bff822fc54/Core/GameEngine/Include/GameLogic/AIPathfind.h#L908-L909

https://github.com/TheSuperHackers/GeneralsGameCode/blob/64b5eaad7e6e695729f87d20de22e5bff822fc54/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp#L11341-L11344

This loop uses the address of the first element _after_ the `m_numWallPieces` array, which is effectively the same as:
```cpp
 for (Int i=0; i<MAX_WALL_PIECES; ++i) 
 { 
 	xfer->xferObjectID(&m_numWallPieces); 
 }
 ```

This should be a change that's not user facing, but I need to check some replays to verify that everything works as expected.

Edit: FWIW this equals true:
```cpp
static_assert(offsetof(Pathfinder, m_wallPieces) 
  + sizeof(m_wallPieces) == offsetof(Pathfinder, m_numWallPieces));
```

## TODO:
- [x] Check replays.