### PR TITLE
fix(ini): Support plus sign prefix in INI integer parse

### DIFF
--- a/Core/GameEngine/Source/Common/INI/INI.cpp
+++ b/Core/GameEngine/Source/Common/INI/INI.cpp
@@ -1618,7 +1618,7 @@ void INI::initFromINIMulti( void *what, const MultiIniFieldParse& parseTableList
 template <typename Type>
 Type scanType(std::string_view token)
 {
-	DEBUG_ASSERTCRASH(!token.empty(), ("token is not expected empty"));
+	DEBUG_ASSERTCRASH(!token.empty(), ("token is not expected to be empty"));
 
 	// Unlike sscanf, std::from_chars cannot parse "+"
 	if (token[0] == '+')

--- a/Core/GameEngine/Source/Common/INI/INI.cpp
+++ b/Core/GameEngine/Source/Common/INI/INI.cpp
@@ -1618,7 +1618,7 @@ void INI::initFromINIMulti( void *what, const MultiIniFieldParse& parseTableList
 template <typename Type>
 Type scanType(std::string_view token)
 {
-	DEBUG_ASSERTCRASH(!token.empty(), "token is not expected empty");
+	DEBUG_ASSERTCRASH(!token.empty(), ("token is not expected empty"));
 
 	// Unlike sscanf, std::from_chars cannot parse "+"
 	if (token[0] == '+')

--- a/Core/GameEngine/Source/Common/INI/INI.cpp
+++ b/Core/GameEngine/Source/Common/INI/INI.cpp
@@ -1620,13 +1620,14 @@ Type scanType(std::string_view token)
 {
 	DEBUG_ASSERTCRASH(!token.empty(), ("token is not expected to be empty"));
 
-	// Unlike sscanf, std::from_chars cannot parse "+"
+	// Unlike sscanf, std::from_chars cannot parse "+".
+	// Consume the plus symbol to accommodate custom ini files that have numbers prefixed with a plus.
 	if (token[0] == '+')
 	{
 		token.remove_prefix(1);
 	}
 
-	// Unlike sscanf, std::from_chars cannot parse "-" as unsigned integer
+	// Unlike sscanf, std::from_chars cannot parse "-" as unsigned integer.
 	std::conditional_t<std::is_integral_v<Type>, Int64, Type> result{};
 	const auto [ptr, ec] = std::from_chars(token.data(), token.data() + token.size(), result);
 

--- a/Core/GameEngine/Source/Common/INI/INI.cpp
+++ b/Core/GameEngine/Source/Common/INI/INI.cpp
@@ -1618,8 +1618,16 @@ void INI::initFromINIMulti( void *what, const MultiIniFieldParse& parseTableList
 template <typename Type>
 Type scanType(std::string_view token)
 {
-	// TheSuperHackers @info std::from_chars cannot parse "-1" as uint32 so the result needs to be int64 for integers.
-	std::conditional_t<std::is_integral_v<Type>, Int64, Real> result{};
+	DEBUG_ASSERTCRASH(!token.empty(), "token is not expected empty");
+
+	// Unlike sscanf, std::from_chars cannot parse "+"
+	if (token[0] == '+')
+	{
+		token.remove_prefix(1);
+	}
+
+	// Unlike sscanf, std::from_chars cannot parse "-" as unsigned integer
+	std::conditional_t<std::is_integral_v<Type>, Int64, Type> result{};
 	const auto [ptr, ec] = std::from_chars(token.data(), token.data() + token.size(), result);
 
 	if (ec != std::errc{})


### PR DESCRIPTION
* Closes #2548

Alternative fix to #2548

Omits empty test because a token is implicitly not empty.

This change was not required for the original INI files.

Tested and worked.