### PR TITLE
chore(script): add safety check for identical files during unification and move files

### DIFF
--- a/scripts/cpp/unify_move_files.py
+++ b/scripts/cpp/unify_move_files.py
@@ -4,6 +4,7 @@
 
 import os
 import shutil
+import filecmp
 from enum import Enum
 
 
@@ -78,6 +79,14 @@ def unify_file(fromGame: Game, fromFile: str, toGame: Game, toFile: str):
     fromOppositeGamePath = get_game_path(fromOppositeGame)
     fromGamePath = get_game_path(fromGame)
     toGamePath = get_game_path(toGame)
+
+    # Safety Identical Check
+    fullFromPath = os.path.join(fromGamePath, os.path.normpath(fromFile))
+    fullOppositePath = os.path.join(fromOppositeGamePath, os.path.normpath(fromFile))
+
+    if not filecmp.cmp(fullFromPath, fullOppositePath, shallow=False):
+        print(f"ERROR: Files are not identical! Skipping to prevent data loss: {fromFile}")
+        return
 
     fromFirstFolderIndex = fromFile.find("/")
     toFirstFolderIndex = toFile.find("/")

--- a/scripts/cpp/unify_move_files.py
+++ b/scripts/cpp/unify_move_files.py
@@ -84,6 +84,10 @@ def unify_file(fromGame: Game, fromFile: str, toGame: Game, toFile: str):
     fullFromPath = os.path.join(fromGamePath, os.path.normpath(fromFile))
     fullOppositePath = os.path.join(fromOppositeGamePath, os.path.normpath(fromFile))
 
+    if not os.path.exists(fullFromPath) or not os.path.exists(fullOppositePath):
+        print(f"ERROR: One or both files do not exist! Skipping: {fromFile}")
+        return
+
     if not filecmp.cmp(fullFromPath, fullOppositePath, shallow=False):
         print(f"ERROR: Files are not identical! Skipping to prevent data loss: {fromFile}")
         return


### PR DESCRIPTION
Updated the file unification script to include a safety mechanism that prevents accidental data loss during the move/merge process.

The script now skips files and prints an error message if a mismatch is detected, allowing for manual inspection.