### PR TITLE
bugfix(money): Fix undefined behavior for starting cash combo box

### DIFF
--- a/Generals/Code/GameEngine/Include/GameNetwork/GUIUtil.h
+++ b/Generals/Code/GameEngine/Include/GameNetwork/GUIUtil.h
@@ -36,7 +36,6 @@ void ShowUnderlyingGUIElements( Bool show, const char *layoutFilename, const cha
 void PopulateColorComboBox(Int comboBox, GameWindow *comboArray[], GameInfo *myGame, Bool isObserver = FALSE);
 void PopulatePlayerTemplateComboBox(Int comboBox, GameWindow *comboArray[], GameInfo *myGame, Bool allowObservers );
 void PopulateTeamComboBox(Int comboBox, GameWindow *comboArray[], GameInfo *myGame, Bool isObserver = FALSE);
-void PopulateStartingCashComboBox(GameWindow *comboBox, GameInfo *myGame);
 
 void EnableSlotListUpdates( Bool val );
 Bool AreSlotListUpdatesEnabled();

--- a/Generals/Code/GameEngine/Include/GameNetwork/GUIUtil.h
+++ b/Generals/Code/GameEngine/Include/GameNetwork/GUIUtil.h
@@ -36,6 +36,7 @@ void ShowUnderlyingGUIElements( Bool show, const char *layoutFilename, const cha
 void PopulateColorComboBox(Int comboBox, GameWindow *comboArray[], GameInfo *myGame, Bool isObserver = FALSE);
 void PopulatePlayerTemplateComboBox(Int comboBox, GameWindow *comboArray[], GameInfo *myGame, Bool allowObservers );
 void PopulateTeamComboBox(Int comboBox, GameWindow *comboArray[], GameInfo *myGame, Bool isObserver = FALSE);
+void PopulateStartingCashComboBox(GameWindow *comboBox, GameInfo *myGame);
 
 void EnableSlotListUpdates( Bool val );
 Bool AreSlotListUpdatesEnabled();

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/GUIUtil.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/GUIUtil.cpp
@@ -334,8 +334,7 @@ void PopulateStartingCashComboBox(GameWindow *comboBox, GameInfo *myGame)
   const MultiplayerStartingMoneyList & startingCashMap = TheMultiplayerSettings->getStartingMoneyList();
   Int currentSelectionIndex = -1;
 
-  MultiplayerStartingMoneyList::const_iterator it = startingCashMap.begin();
-  for ( ; it != startingCashMap.end(); it++ )
+  for (MultiplayerStartingMoneyList::const_iterator it = startingCashMap.begin(); it != startingCashMap.end(); it++ )
   {
     Int newIndex = GadgetComboBoxAddEntry(comboBox, formatMoneyForStartingCashComboBox( *it ),
                                           comboBox->winGetEnabled() ? comboBox->winGetEnabledTextColor() : comboBox->winGetDisabledTextColor());
@@ -352,7 +351,7 @@ void PopulateStartingCashComboBox(GameWindow *comboBox, GameInfo *myGame)
     DEBUG_CRASH( ("Current selection for starting cash not found in list") );
     currentSelectionIndex = GadgetComboBoxAddEntry(comboBox, formatMoneyForStartingCashComboBox( myGame->getStartingCash() ),
                                           comboBox->winGetEnabled() ? comboBox->winGetEnabledTextColor() : comboBox->winGetDisabledTextColor());
-    GadgetComboBoxSetItemData(comboBox, currentSelectionIndex, (void *)it->countMoney() );
+    GadgetComboBoxSetItemData(comboBox, currentSelectionIndex, (void *)myGame->getStartingCash().countMoney() );
   }
 
   GadgetComboBoxSetSelectedPos(comboBox, currentSelectionIndex);


### PR DESCRIPTION
Players that modify their `GlobalData::m_defaultStartingCash` value may see strange behavior when it comes to their starting cash (skirmish and multiplayer). That's because the game dereferences an end iterator if it cannot find one of the four default starting cash values. This crashes the game in debug builds and it may produce 'random' starting cash values in release builds. (Even though the starting cash is unsigned, the visual amount may show up as negative in the control bar).

## TODO:
- [x] Replicate in Generals. (code doesn't exist in Generals)