### PR TITLE
bugfix(gui): Fix preferred starting cash not showing in combo box

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanGameOptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanGameOptionsMenu.cpp
@@ -858,6 +858,8 @@ void LanGameOptionsMenuInit( WindowLayout *layout, void *userData )
 		slot->setNATBehavior(FirewallHelperClass::FIREWALL_TYPE_SIMPLE);
 		game->setMap( pref.getPreferredMap() );
     game->setStartingCash( pref.getStartingCash() );
+    // TheSuperHackers @bugfix Re-populate starting cash combo box after applying user preferences.
+    PopulateStartingCashComboBox(comboBoxStartingCash, game);
     game->setSuperweaponRestriction( pref.getSuperweaponRestricted() ? 1 : 0 );
 		AsciiString lowerMap = pref.getPreferredMap();
 		lowerMap.toLower();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishGameOptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/SkirmishGameOptionsMenu.cpp
@@ -1317,6 +1317,8 @@ void SkirmishGameOptionsMenuInit( WindowLayout *layout, void *userData )
 	}
 
   TheSkirmishGameInfo->setStartingCash( prefs.getStartingCash() );
+  // TheSuperHackers @bugfix Re-populate starting cash combo box after applying user preferences.
+  PopulateStartingCashComboBox(comboBoxStartingCash, TheSkirmishGameInfo);
   TheSkirmishGameInfo->setSuperweaponRestriction( prefs.getSuperweaponRestricted() ? 1 : 0 );
 
   TheSkirmishGameInfo->setMap(prefs.getPreferredMap());

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLGameSetupMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLGameSetupMenu.cpp
@@ -1377,6 +1377,8 @@ void WOLGameSetupMenuInit( WindowLayout *layout, void *userData )
 		// This should probably be enforced at the gamespy level as well, to prevent exploits.
 		Int isUsingStats = TheGameSpyGame->getUseStats();
 		game->setStartingCash( isUsingStats? TheMultiplayerSettings->getDefaultStartingMoney() : customPref.getStartingCash() );
+		// TheSuperHackers @bugfix Re-populate starting cash combo box after applying user preferences.
+		PopulateStartingCashComboBox(comboBoxStartingCash, game);
 		game->setSuperweaponRestriction( isUsingStats? 0 : customPref.getSuperweaponRestricted() ? 1 : 0 );
 		if (isUsingStats)
 			game->setOldFactionsOnly( 0 );

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/GUIUtil.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/GUIUtil.cpp
@@ -352,7 +352,8 @@ void PopulateStartingCashComboBox(GameWindow *comboBox, GameInfo *myGame)
     DEBUG_CRASH( ("Current selection for starting cash not found in list") );
     currentSelectionIndex = GadgetComboBoxAddEntry(comboBox, formatMoneyForStartingCashComboBox( myGame->getStartingCash() ),
                                           comboBox->winGetEnabled() ? comboBox->winGetEnabledTextColor() : comboBox->winGetDisabledTextColor());
-    GadgetComboBoxSetItemData(comboBox, currentSelectionIndex, (void *)it->countMoney() );
+    // TheSuperHackers @bugfix Fix undefined behavior from dereferencing past-the-end iterator.
+    GadgetComboBoxSetItemData(comboBox, currentSelectionIndex, (void *)myGame->getStartingCash().countMoney() );
   }
 
   GadgetComboBoxSetSelectedPos(comboBox, currentSelectionIndex);


### PR DESCRIPTION
* Fixes #2583

Re-populate the starting cash combo box after applying user preferences from INI files in Skirmish, LAN and WOL game setup menus. Previously, the combo box was populated before preferences were applied, so non-standard starting cash values would not appear in the dropdown.

Also fix undefined behavior in PopulateStartingCashComboBox where a past-the-end iterator was dereferenced when the starting cash value was not found in the standard list.