### PR TITLE
bugfix(input): Fix touchpad upward scrolling in UI list boxes

### DIFF
--- a/Core/GameEngine/Source/GameClient/Input/Mouse.cpp
+++ b/Core/GameEngine/Source/GameClient/Input/Mouse.cpp
@@ -824,10 +824,8 @@ void Mouse::createStreamMessages()
 		{
 			msg = TheMessageStream->appendMessage( GameMessage::MSG_RAW_MOUSE_WHEEL );
 			msg->appendPixelArgument( m_currMouse.pos );
-			// TheSuperHackers @bugfix Guarantee non-zero wheel delta to preserve scroll direction for touchpad input
-			Int wheelTicks = m_currMouse.wheelPos / MOUSE_WHEEL_DELTA;
-			wheelTicks = m_currMouse.wheelPos > 0 ? max( 1, wheelTicks ) : min( -1, wheelTicks );
-			msg->appendIntegerArgument( wheelTicks );
+			// TheSuperHackers @bugfix Use float wheel delta to preserve fractional values from touchpad input
+			msg->appendRealArgument( m_currMouse.wheelPos / (Real)MOUSE_WHEEL_DELTA );
 			msg->appendIntegerArgument( TheKeyboard->getModifierFlags() );
 		}
 

--- a/Core/GameEngine/Source/GameClient/Input/Mouse.cpp
+++ b/Core/GameEngine/Source/GameClient/Input/Mouse.cpp
@@ -824,9 +824,10 @@ void Mouse::createStreamMessages()
 		{
 			msg = TheMessageStream->appendMessage( GameMessage::MSG_RAW_MOUSE_WHEEL );
 			msg->appendPixelArgument( m_currMouse.pos );
-			// TheSuperHackers @bugfix Preserve wheel delta sign for touchpad scroll direction detection
-			const Int wheelTicks = m_currMouse.wheelPos / MOUSE_WHEEL_DELTA;
-			msg->appendIntegerArgument( m_currMouse.wheelPos > 0 ? max( 1, wheelTicks ) : min( -1, wheelTicks ) );
+			// TheSuperHackers @bugfix Guarantee non-zero wheel delta to preserve scroll direction for touchpad input
+			Int wheelTicks = m_currMouse.wheelPos / MOUSE_WHEEL_DELTA;
+			wheelTicks = m_currMouse.wheelPos > 0 ? max( 1, wheelTicks ) : min( -1, wheelTicks );
+			msg->appendIntegerArgument( wheelTicks );
 			msg->appendIntegerArgument( TheKeyboard->getModifierFlags() );
 		}
 

--- a/Core/GameEngine/Source/GameClient/Input/Mouse.cpp
+++ b/Core/GameEngine/Source/GameClient/Input/Mouse.cpp
@@ -824,7 +824,9 @@ void Mouse::createStreamMessages()
 		{
 			msg = TheMessageStream->appendMessage( GameMessage::MSG_RAW_MOUSE_WHEEL );
 			msg->appendPixelArgument( m_currMouse.pos );
-			msg->appendIntegerArgument( m_currMouse.wheelPos / 120 );  // wheel delta
+			// TheSuperHackers @bugfix Preserve wheel delta sign for touchpad scroll direction detection
+			const Int wheelTicks = m_currMouse.wheelPos / MOUSE_WHEEL_DELTA;
+			msg->appendIntegerArgument( m_currMouse.wheelPos > 0 ? max( 1, wheelTicks ) : min( -1, wheelTicks ) );
 			msg->appendIntegerArgument( TheKeyboard->getModifierFlags() );
 		}
 

--- a/Generals/Code/GameEngine/Include/Common/MessageStream.h
+++ b/Generals/Code/GameEngine/Include/Common/MessageStream.h
@@ -131,7 +131,7 @@ public:
 		MSG_RAW_MOUSE_RIGHT_DOUBLE_CLICK,						///< (pixel, modifiers, time)
 		MSG_RAW_MOUSE_RIGHT_BUTTON_UP,							///< (pixel, modifiers, time)
 		MSG_RAW_MOUSE_RIGHT_DRAG,										///< drag of the mouse with a button held down
-		MSG_RAW_MOUSE_WHEEL,												///< (Int spin, + is away, - is toward user)
+		MSG_RAW_MOUSE_WHEEL,												///< (Real spin, + is away, - is toward user)
 		MSG_RAW_MOUSE_END,
 
 		MSG_RAW_KEY_DOWN,														///< (KeyDefType) the given key was pressed (uses Microsoft VK_ codes)

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
@@ -406,7 +406,7 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 		{
 			m_lastMouseMoveTimeMsec = timeGetTime();
 
-			const Int spin = msg->getArgument( 1 )->integer;
+			const Real spin = msg->getArgument( 1 )->real;
 			const Real zoom = -spin * View::ZoomHeightPerSecond;
 			TheTacticalView->userZoom(zoom);
 

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/WindowXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/WindowXlat.cpp
@@ -135,7 +135,7 @@ static GameWindowMessage rawMouseToWindowMessage( const GameMessage *msg )
 
 		// ------------------------------------------------------------------------
 		case GameMessage::MSG_RAW_MOUSE_WHEEL:
-			if( msg->getArgument( 1 )->integer > 0 )
+			if( msg->getArgument( 1 )->real > 0 )
 				gwm = GWM_WHEEL_UP;
 			else
 				gwm = GWM_WHEEL_DOWN;
@@ -266,7 +266,7 @@ GameMessageDisposition WindowTranslator::translateGameMessage(const GameMessage 
 			ICoord2D mousePos = msg->getArgument( 0 )->pixel;
 
 			// get wheel position
-			Int wheelPos = msg->getArgument( 1 )->integer;
+			Real wheelPos = msg->getArgument( 1 )->real;
 
 			// process wheel event
 			GameWindowMessage gwm = rawMouseToWindowMessage( msg );

--- a/GeneralsMD/Code/GameEngine/Include/Common/MessageStream.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/MessageStream.h
@@ -131,7 +131,7 @@ public:
 		MSG_RAW_MOUSE_RIGHT_DOUBLE_CLICK,						///< (pixel, modifiers, time)
 		MSG_RAW_MOUSE_RIGHT_BUTTON_UP,							///< (pixel, modifiers, time)
 		MSG_RAW_MOUSE_RIGHT_DRAG,										///< drag of the mouse with a button held down
-		MSG_RAW_MOUSE_WHEEL,												///< (Int spin, + is away, - is toward user)
+		MSG_RAW_MOUSE_WHEEL,												///< (Real spin, + is away, - is toward user)
 		MSG_RAW_MOUSE_END,
 
 		MSG_RAW_KEY_DOWN,														///< (KeyDefType) the given key was pressed (uses Microsoft VK_ codes)

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/LookAtXlat.cpp
@@ -405,7 +405,7 @@ GameMessageDisposition LookAtTranslator::translateGameMessage(const GameMessage 
 		{
 			m_lastMouseMoveTimeMsec = timeGetTime();
 
-			const Int spin = msg->getArgument( 1 )->integer;
+			const Real spin = msg->getArgument( 1 )->real;
 			const Real zoom = -spin * View::ZoomHeightPerSecond;
 			TheTacticalView->userZoom(zoom);
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/WindowXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/WindowXlat.cpp
@@ -135,7 +135,7 @@ static GameWindowMessage rawMouseToWindowMessage( const GameMessage *msg )
 
 		// ------------------------------------------------------------------------
 		case GameMessage::MSG_RAW_MOUSE_WHEEL:
-			if( msg->getArgument( 1 )->integer > 0 )
+			if( msg->getArgument( 1 )->real > 0 )
 				gwm = GWM_WHEEL_UP;
 			else
 				gwm = GWM_WHEEL_DOWN;
@@ -284,7 +284,7 @@ GameMessageDisposition WindowTranslator::translateGameMessage(const GameMessage 
 			ICoord2D mousePos = msg->getArgument( 0 )->pixel;
 
 			// get wheel position
-			Int wheelPos = msg->getArgument( 1 )->integer;
+			Real wheelPos = msg->getArgument( 1 )->real;
 
 			// process wheel event
 			GameWindowMessage gwm = rawMouseToWindowMessage( msg );


### PR DESCRIPTION
## Summary                                                                                                                             
  
  - Fixes touchpad upward scrolling in UI list boxes (GadgetListBox) where the list momentarily scrolls up then jumps back down            - Preserves wheel delta sign when normalizing, so touchpad's small continuous deltas are no longer truncated to 0 and misidentified as downward scroll                                                                                                                        
  - Mouse wheel behavior is completely unchanged

  ## Root Cause

  In `Mouse::createStreamMessages()`, the wheel delta was divided by `MOUSE_WHEEL_DELTA` (120) before being sent as a message argument.  
  Touchpad devices send small deltas (e.g. +30) that truncate to 0 on integer division. In `WindowXlat.cpp`, the direction check `if     
  (argument > 0)` maps 0 to `GWM_WHEEL_DOWN`, causing upward touchpad scroll to be treated as downward.

  ## Fix

  Clamp the normalized wheel delta to at least `1` or `-1` based on the original sign of `wheelPos`, ensuring the scroll direction is    
  always preserved. Only `Mouse.cpp` is changed — no consumers need modification.

  ## Test plan

  - [x] Verified mouse wheel scrolls up and down correctly in UI list boxes
  - [x] Verified mouse wheel zoom in/out works correctly on the map
  - [x] Verified no regression in combo box scrolling
  - [x] Verified touchpad upward scrolling no longer jumps back down