### PR TITLE
refactor(metaevent): Move meta event type asserts from key event update to engine initialization

### DIFF
--- a/Generals/Code/GameEngine/Include/GameClient/MetaEvent.h
+++ b/Generals/Code/GameEngine/Include/GameClient/MetaEvent.h
@@ -391,9 +391,11 @@ public:
 
 	static void parseMetaMap(INI* ini);
 
-	// TheSuperHackers @info Function to generate default key mappings
+	// TheSuperHackers @feature Function to generate default key mappings
 	// for actions that were not found in a CommandMap.ini
-	static void generateMetaMap();
+	void generateMetaMap();
+
+	void verifyMetaMap();
 
 	const MetaMapRec *getFirstMetaMapRec() const { return m_metaMaps; }
 };

--- a/Generals/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -486,11 +486,12 @@ void GameEngine::init()
 		fname.format("Data\\%s\\CommandMap", GetRegistryLanguage().str());
 		initSubsystem(TheMetaMap,"TheMetaMap", MSGNEW("GameEngineSubsystem") MetaMap(), nullptr, fname.str(), "Data\\INI\\CommandMap");
 
-		TheMetaMap->generateMetaMap();
-
 #if defined(RTS_DEBUG)
 		ini.loadFileDirectory("Data\\INI\\CommandMapDebug", INI_LOAD_MULTIFILE, nullptr);
 #endif
+
+		TheMetaMap->generateMetaMap();
+		TheMetaMap->verifyMetaMap();
 
 		initSubsystem(TheActionManager,"TheActionManager", MSGNEW("GameEngineSubsystem") ActionManager(), nullptr);
 		//initSubsystem((CComObject<WebBrowser> *)TheWebBrowser,"(CComObject<WebBrowser> *)TheWebBrowser", (CComObject<WebBrowser> *)createWebBrowser(), nullptr);

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/MetaEvent.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/MetaEvent.cpp
@@ -427,9 +427,6 @@ GameMessageDisposition MetaEventTranslator::translateGameMessage(const GameMessa
 
 		for (const MetaMapRec *map = TheMetaMap->getFirstMetaMapRec(); map; map = map->m_next)
 		{
-			DEBUG_ASSERTCRASH(map->m_meta > GameMessage::MSG_BEGIN_META_MESSAGES &&
-				map->m_meta < GameMessage::MSG_END_META_MESSAGES, ("hmm, expected only meta-msgs here"));
-
 			if (!isMessageUsable(map->m_usableIn))
 				continue;
 
@@ -667,14 +664,14 @@ MetaMapRec *MetaMap::getMetaMapRec(GameMessage::Type t)
 }
 
 //-------------------------------------------------------------------------------------------------
-/*static */ void MetaMap::generateMetaMap()
+void MetaMap::generateMetaMap()
 {
 	// TheSuperHackers @info A default mapping for MSG_META_SELECT_ALL_AIRCRAFT would be useful for Generals
 	// but is not recommended, because it will cause key mapping conflicts with original game languages.
 
 	{
 		// Is useful for Generals and Zero Hour.
-		MetaMapRec *map = TheMetaMap->getMetaMapRec(GameMessage::MSG_META_INCREASE_MAX_RENDER_FPS);
+		MetaMapRec *map = getMetaMapRec(GameMessage::MSG_META_INCREASE_MAX_RENDER_FPS);
 		if (map->m_key == MK_NONE)
 		{
 			map->m_key = MK_KPPLUS;
@@ -685,7 +682,7 @@ MetaMapRec *MetaMap::getMetaMapRec(GameMessage::Type t)
 	}
 	{
 		// Is useful for Generals and Zero Hour.
-		MetaMapRec *map = TheMetaMap->getMetaMapRec(GameMessage::MSG_META_DECREASE_MAX_RENDER_FPS);
+		MetaMapRec *map = getMetaMapRec(GameMessage::MSG_META_DECREASE_MAX_RENDER_FPS);
 		if (map->m_key == MK_NONE)
 		{
 			map->m_key = MK_KPMINUS;
@@ -696,7 +693,7 @@ MetaMapRec *MetaMap::getMetaMapRec(GameMessage::Type t)
 	}
 	{
 		// Is useful for Generals and Zero Hour.
-		MetaMapRec *map = TheMetaMap->getMetaMapRec(GameMessage::MSG_META_INCREASE_LOGIC_TIME_SCALE);
+		MetaMapRec *map = getMetaMapRec(GameMessage::MSG_META_INCREASE_LOGIC_TIME_SCALE);
 		if (map->m_key == MK_NONE)
 		{
 			map->m_key = MK_KPPLUS;
@@ -707,7 +704,7 @@ MetaMapRec *MetaMap::getMetaMapRec(GameMessage::Type t)
 	}
 	{
 		// Is useful for Generals and Zero Hour.
-		MetaMapRec *map = TheMetaMap->getMetaMapRec(GameMessage::MSG_META_DECREASE_LOGIC_TIME_SCALE);
+		MetaMapRec *map = getMetaMapRec(GameMessage::MSG_META_DECREASE_LOGIC_TIME_SCALE);
 		if (map->m_key == MK_NONE)
 		{
 			map->m_key = MK_KPMINUS;
@@ -718,7 +715,7 @@ MetaMapRec *MetaMap::getMetaMapRec(GameMessage::Type t)
 	}
 	{
 		// Is useful for Generals and Zero Hour.
-		MetaMapRec *map = TheMetaMap->getMetaMapRec(GameMessage::MSG_META_TOGGLE_PLAYER_OBSERVER);
+		MetaMapRec *map = getMetaMapRec(GameMessage::MSG_META_TOGGLE_PLAYER_OBSERVER);
 		if (map->m_key == MK_NONE)
 		{
 			map->m_key = MK_M;
@@ -729,7 +726,7 @@ MetaMapRec *MetaMap::getMetaMapRec(GameMessage::Type t)
 	}
 	{
 		// Is mostly useful for Generals.
-		MetaMapRec *map = TheMetaMap->getMetaMapRec(GameMessage::MSG_META_TOGGLE_FAST_FORWARD_REPLAY);
+		MetaMapRec *map = getMetaMapRec(GameMessage::MSG_META_TOGGLE_FAST_FORWARD_REPLAY);
 		if (map->m_key == MK_NONE)
 		{
 			map->m_key = MK_F;
@@ -740,7 +737,7 @@ MetaMapRec *MetaMap::getMetaMapRec(GameMessage::Type t)
 	}
 	{
 		// Is useful for Generals and Zero Hour.
-		MetaMapRec *map = TheMetaMap->getMetaMapRec(GameMessage::MSG_META_TOGGLE_PAUSE);
+		MetaMapRec *map = getMetaMapRec(GameMessage::MSG_META_TOGGLE_PAUSE);
 		if (map->m_key == MK_NONE)
 		{
 			map->m_key = MK_P;
@@ -751,7 +748,7 @@ MetaMapRec *MetaMap::getMetaMapRec(GameMessage::Type t)
 	}
 	{
 		// Is useful for Generals and Zero Hour.
-		MetaMapRec *map = TheMetaMap->getMetaMapRec(GameMessage::MSG_META_TOGGLE_PAUSE_ALT);
+		MetaMapRec *map = getMetaMapRec(GameMessage::MSG_META_TOGGLE_PAUSE_ALT);
 		if (map->m_key == MK_NONE)
 		{
 			map->m_key = MK_P;
@@ -762,7 +759,7 @@ MetaMapRec *MetaMap::getMetaMapRec(GameMessage::Type t)
 	}
 	{
 		// Is useful for Generals and Zero Hour.
-		MetaMapRec *map = TheMetaMap->getMetaMapRec(GameMessage::MSG_META_STEP_FRAME);
+		MetaMapRec *map = getMetaMapRec(GameMessage::MSG_META_STEP_FRAME);
 		if (map->m_key == MK_NONE)
 		{
 			map->m_key = MK_O;
@@ -773,7 +770,7 @@ MetaMapRec *MetaMap::getMetaMapRec(GameMessage::Type t)
 	}
 	{
 		// Is useful for Generals and Zero Hour.
-		MetaMapRec *map = TheMetaMap->getMetaMapRec(GameMessage::MSG_META_STEP_FRAME_ALT);
+		MetaMapRec *map = getMetaMapRec(GameMessage::MSG_META_STEP_FRAME_ALT);
 		if (map->m_key == MK_NONE)
 		{
 			map->m_key = MK_O;
@@ -784,7 +781,7 @@ MetaMapRec *MetaMap::getMetaMapRec(GameMessage::Type t)
 	}
 	{
 		// Is useful for Generals and Zero Hour.
-		MetaMapRec* map = TheMetaMap->getMetaMapRec(GameMessage::MSG_META_SELECT_NEXT_IDLE_WORKER);
+		MetaMapRec *map = getMetaMapRec(GameMessage::MSG_META_SELECT_NEXT_IDLE_WORKER);
 		if (map->m_key == MK_NONE) {
 			map->m_key = MK_I;
 			map->m_transition = DOWN;
@@ -796,7 +793,7 @@ MetaMapRec *MetaMap::getMetaMapRec(GameMessage::Type t)
 		}
 	}
 	{
-		MetaMapRec* map = TheMetaMap->getMetaMapRec(GameMessage::MSG_META_ALT_CAMERA_ROTATE_LEFT);
+		MetaMapRec *map = getMetaMapRec(GameMessage::MSG_META_ALT_CAMERA_ROTATE_LEFT);
 		if (map->m_key == MK_NONE) {
 			map->m_key = MK_KP4;
 			map->m_transition = DOWN;
@@ -805,7 +802,7 @@ MetaMapRec *MetaMap::getMetaMapRec(GameMessage::Type t)
 		}
 	}
 	{
-		MetaMapRec* map = TheMetaMap->getMetaMapRec(GameMessage::MSG_META_ALT_CAMERA_ROTATE_RIGHT);
+		MetaMapRec *map = getMetaMapRec(GameMessage::MSG_META_ALT_CAMERA_ROTATE_RIGHT);
 		if (map->m_key == MK_NONE) {
 			map->m_key = MK_KP6;
 			map->m_transition = DOWN;
@@ -817,7 +814,7 @@ MetaMapRec *MetaMap::getMetaMapRec(GameMessage::Type t)
 #if defined(RTS_DEBUG)
 	{
 		// Is useful for Generals and Zero Hour.
-		MetaMapRec *map = TheMetaMap->getMetaMapRec(GameMessage::MSG_META_DEMO_REMOVE_PREREQ);
+		MetaMapRec *map = getMetaMapRec(GameMessage::MSG_META_DEMO_REMOVE_PREREQ);
 		if (map->m_key == MK_NONE)
 		{
 			map->m_key = MK_P;
@@ -828,7 +825,7 @@ MetaMapRec *MetaMap::getMetaMapRec(GameMessage::Type t)
 	}
 	{
 		// Is useful for Generals and Zero Hour.
-		MetaMapRec *map = TheMetaMap->getMetaMapRec(GameMessage::MSG_META_DEMO_FREE_BUILD);
+		MetaMapRec *map = getMetaMapRec(GameMessage::MSG_META_DEMO_FREE_BUILD);
 		if (map->m_key == MK_NONE)
 		{
 			map->m_key = MK_B;
@@ -838,6 +835,20 @@ MetaMapRec *MetaMap::getMetaMapRec(GameMessage::Type t)
 		}
 	}
 #endif // defined(RTS_DEBUG)
+}
+
+//-------------------------------------------------------------------------------------------------
+void MetaMap::verifyMetaMap()
+{
+#ifdef DEBUG_CRASHING
+	for (const MetaMapRec *map = getFirstMetaMapRec(); map; map = map->m_next)
+	{
+		DEBUG_ASSERTCRASH(
+			map->m_meta > GameMessage::MSG_BEGIN_META_MESSAGES &&
+			map->m_meta < GameMessage::MSG_END_META_MESSAGES,
+			("hmm, expected only meta-msgs here"));
+	}
+#endif
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/MetaEvent.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/MetaEvent.h
@@ -391,9 +391,11 @@ public:
 
 	static void parseMetaMap(INI* ini);
 
-	// TheSuperHackers @info Function to generate default key mappings
+	// TheSuperHackers @feature Function to generate default key mappings
 	// for actions that were not found in a CommandMap.ini
-	static void generateMetaMap();
+	void generateMetaMap();
+
+	void verifyMetaMap();
 
 	const MetaMapRec *getFirstMetaMapRec() const { return m_metaMaps; }
 };

--- a/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -628,6 +628,7 @@ void GameEngine::init()
 		initSubsystem(TheMetaMap,"TheMetaMap", MSGNEW("GameEngineSubsystem") MetaMap(), nullptr, fname.str(), "Data\\INI\\CommandMap");
 
 		TheMetaMap->generateMetaMap();
+		TheMetaMap->verifyMetaMap();
 
 #if defined(RTS_DEBUG)
 		ini.loadFileDirectory("Data\\INI\\CommandMapDebug", INI_LOAD_MULTIFILE, nullptr);

--- a/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -627,9 +627,6 @@ void GameEngine::init()
 		fname.format("Data\\%s\\CommandMap", GetRegistryLanguage().str());
 		initSubsystem(TheMetaMap,"TheMetaMap", MSGNEW("GameEngineSubsystem") MetaMap(), nullptr, fname.str(), "Data\\INI\\CommandMap");
 
-		TheMetaMap->generateMetaMap();
-		TheMetaMap->verifyMetaMap();
-
 #if defined(RTS_DEBUG)
 		ini.loadFileDirectory("Data\\INI\\CommandMapDebug", INI_LOAD_MULTIFILE, nullptr);
 #endif
@@ -637,6 +634,9 @@ void GameEngine::init()
 #if defined(_ALLOW_DEBUG_CHEATS_IN_RELEASE)
 		ini.loadFileDirectory("Data\\INI\\CommandMapDemo", INI_LOAD_MULTIFILE, nullptr);
 #endif
+
+		TheMetaMap->generateMetaMap();
+		TheMetaMap->verifyMetaMap();
 
 
 		initSubsystem(TheActionManager,"TheActionManager", MSGNEW("GameEngineSubsystem") ActionManager(), nullptr);

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/MetaEvent.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/MetaEvent.cpp
@@ -466,9 +466,6 @@ GameMessageDisposition MetaEventTranslator::translateGameMessage(const GameMessa
 
 		for (const MetaMapRec *map = TheMetaMap->getFirstMetaMapRec(); map; map = map->m_next)
 		{
-			DEBUG_ASSERTCRASH(map->m_meta > GameMessage::MSG_BEGIN_META_MESSAGES &&
-				map->m_meta < GameMessage::MSG_END_META_MESSAGES, ("hmm, expected only meta-msgs here"));
-
 			if (!isMessageUsable(map->m_usableIn))
 				continue;
 
@@ -725,14 +722,14 @@ MetaMapRec *MetaMap::getMetaMapRec(GameMessage::Type t)
 }
 
 //-------------------------------------------------------------------------------------------------
-/*static */ void MetaMap::generateMetaMap()
+void MetaMap::generateMetaMap()
 {
 	// TheSuperHackers @info A default mapping for MSG_META_SELECT_ALL_AIRCRAFT would be useful for Generals
 	// but is not recommended, because it will cause key mapping conflicts with original game languages.
 
 	{
 		// Is useful for Generals and Zero Hour.
-		MetaMapRec *map = TheMetaMap->getMetaMapRec(GameMessage::MSG_META_INCREASE_MAX_RENDER_FPS);
+		MetaMapRec *map = getMetaMapRec(GameMessage::MSG_META_INCREASE_MAX_RENDER_FPS);
 		if (map->m_key == MK_NONE)
 		{
 			map->m_key = MK_KPPLUS;
@@ -743,7 +740,7 @@ MetaMapRec *MetaMap::getMetaMapRec(GameMessage::Type t)
 	}
 	{
 		// Is useful for Generals and Zero Hour.
-		MetaMapRec *map = TheMetaMap->getMetaMapRec(GameMessage::MSG_META_DECREASE_MAX_RENDER_FPS);
+		MetaMapRec *map = getMetaMapRec(GameMessage::MSG_META_DECREASE_MAX_RENDER_FPS);
 		if (map->m_key == MK_NONE)
 		{
 			map->m_key = MK_KPMINUS;
@@ -754,7 +751,7 @@ MetaMapRec *MetaMap::getMetaMapRec(GameMessage::Type t)
 	}
 	{
 		// Is useful for Generals and Zero Hour.
-		MetaMapRec *map = TheMetaMap->getMetaMapRec(GameMessage::MSG_META_INCREASE_LOGIC_TIME_SCALE);
+		MetaMapRec *map = getMetaMapRec(GameMessage::MSG_META_INCREASE_LOGIC_TIME_SCALE);
 		if (map->m_key == MK_NONE)
 		{
 			map->m_key = MK_KPPLUS;
@@ -765,7 +762,7 @@ MetaMapRec *MetaMap::getMetaMapRec(GameMessage::Type t)
 	}
 	{
 		// Is useful for Generals and Zero Hour.
-		MetaMapRec *map = TheMetaMap->getMetaMapRec(GameMessage::MSG_META_DECREASE_LOGIC_TIME_SCALE);
+		MetaMapRec *map = getMetaMapRec(GameMessage::MSG_META_DECREASE_LOGIC_TIME_SCALE);
 		if (map->m_key == MK_NONE)
 		{
 			map->m_key = MK_KPMINUS;
@@ -776,7 +773,7 @@ MetaMapRec *MetaMap::getMetaMapRec(GameMessage::Type t)
 	}
 	{
 		// Is useful for Generals and Zero Hour.
-		MetaMapRec *map = TheMetaMap->getMetaMapRec(GameMessage::MSG_META_TOGGLE_PLAYER_OBSERVER);
+		MetaMapRec *map = getMetaMapRec(GameMessage::MSG_META_TOGGLE_PLAYER_OBSERVER);
 		if (map->m_key == MK_NONE)
 		{
 			map->m_key = MK_M;
@@ -787,7 +784,7 @@ MetaMapRec *MetaMap::getMetaMapRec(GameMessage::Type t)
 	}
 	{
 		// Is mostly useful for Generals.
-		MetaMapRec *map = TheMetaMap->getMetaMapRec(GameMessage::MSG_META_TOGGLE_FAST_FORWARD_REPLAY);
+		MetaMapRec *map = getMetaMapRec(GameMessage::MSG_META_TOGGLE_FAST_FORWARD_REPLAY);
 		if (map->m_key == MK_NONE)
 		{
 			map->m_key = MK_F;
@@ -798,7 +795,7 @@ MetaMapRec *MetaMap::getMetaMapRec(GameMessage::Type t)
 	}
 	{
 		// Is useful for Generals and Zero Hour.
-		MetaMapRec *map = TheMetaMap->getMetaMapRec(GameMessage::MSG_META_TOGGLE_PAUSE);
+		MetaMapRec *map = getMetaMapRec(GameMessage::MSG_META_TOGGLE_PAUSE);
 		if (map->m_key == MK_NONE)
 		{
 			map->m_key = MK_P;
@@ -809,7 +806,7 @@ MetaMapRec *MetaMap::getMetaMapRec(GameMessage::Type t)
 	}
 	{
 		// Is useful for Generals and Zero Hour.
-		MetaMapRec *map = TheMetaMap->getMetaMapRec(GameMessage::MSG_META_TOGGLE_PAUSE_ALT);
+		MetaMapRec *map = getMetaMapRec(GameMessage::MSG_META_TOGGLE_PAUSE_ALT);
 		if (map->m_key == MK_NONE)
 		{
 			map->m_key = MK_P;
@@ -820,7 +817,7 @@ MetaMapRec *MetaMap::getMetaMapRec(GameMessage::Type t)
 	}
 	{
 		// Is useful for Generals and Zero Hour.
-		MetaMapRec *map = TheMetaMap->getMetaMapRec(GameMessage::MSG_META_STEP_FRAME);
+		MetaMapRec *map = getMetaMapRec(GameMessage::MSG_META_STEP_FRAME);
 		if (map->m_key == MK_NONE)
 		{
 			map->m_key = MK_O;
@@ -831,7 +828,7 @@ MetaMapRec *MetaMap::getMetaMapRec(GameMessage::Type t)
 	}
 	{
 		// Is useful for Generals and Zero Hour.
-		MetaMapRec *map = TheMetaMap->getMetaMapRec(GameMessage::MSG_META_STEP_FRAME_ALT);
+		MetaMapRec *map = getMetaMapRec(GameMessage::MSG_META_STEP_FRAME_ALT);
 		if (map->m_key == MK_NONE)
 		{
 			map->m_key = MK_O;
@@ -842,7 +839,7 @@ MetaMapRec *MetaMap::getMetaMapRec(GameMessage::Type t)
 	}
 	{
 		// Is useful for Generals and Zero Hour.
-		MetaMapRec* map = TheMetaMap->getMetaMapRec(GameMessage::MSG_META_SELECT_NEXT_IDLE_WORKER);
+		MetaMapRec *map = getMetaMapRec(GameMessage::MSG_META_SELECT_NEXT_IDLE_WORKER);
 		if (map->m_key == MK_NONE) {
 			map->m_key = MK_I;
 			map->m_transition = DOWN;
@@ -854,7 +851,7 @@ MetaMapRec *MetaMap::getMetaMapRec(GameMessage::Type t)
 		}
 	}
 	{
-		MetaMapRec* map = TheMetaMap->getMetaMapRec(GameMessage::MSG_META_ALT_CAMERA_ROTATE_LEFT);
+		MetaMapRec *map = getMetaMapRec(GameMessage::MSG_META_ALT_CAMERA_ROTATE_LEFT);
 		if (map->m_key == MK_NONE) {
 			map->m_key = MK_KP4;
 			map->m_transition = DOWN;
@@ -863,7 +860,7 @@ MetaMapRec *MetaMap::getMetaMapRec(GameMessage::Type t)
 		}
 	}
 	{
-		MetaMapRec* map = TheMetaMap->getMetaMapRec(GameMessage::MSG_META_ALT_CAMERA_ROTATE_RIGHT);
+		MetaMapRec *map = getMetaMapRec(GameMessage::MSG_META_ALT_CAMERA_ROTATE_RIGHT);
 		if (map->m_key == MK_NONE) {
 			map->m_key = MK_KP6;
 			map->m_transition = DOWN;
@@ -875,7 +872,7 @@ MetaMapRec *MetaMap::getMetaMapRec(GameMessage::Type t)
 #if defined(RTS_DEBUG)
 	{
 		// Is useful for Generals and Zero Hour.
-		MetaMapRec *map = TheMetaMap->getMetaMapRec(GameMessage::MSG_META_DEMO_REMOVE_PREREQ);
+		MetaMapRec *map = getMetaMapRec(GameMessage::MSG_META_DEMO_REMOVE_PREREQ);
 		if (map->m_key == MK_NONE)
 		{
 			map->m_key = MK_P;
@@ -886,7 +883,7 @@ MetaMapRec *MetaMap::getMetaMapRec(GameMessage::Type t)
 	}
 	{
 		// Is useful for Generals and Zero Hour.
-		MetaMapRec *map = TheMetaMap->getMetaMapRec(GameMessage::MSG_META_DEMO_FREE_BUILD);
+		MetaMapRec *map = getMetaMapRec(GameMessage::MSG_META_DEMO_FREE_BUILD);
 		if (map->m_key == MK_NONE)
 		{
 			map->m_key = MK_B;
@@ -896,6 +893,20 @@ MetaMapRec *MetaMap::getMetaMapRec(GameMessage::Type t)
 		}
 	}
 #endif // defined(RTS_DEBUG)
+}
+
+//-------------------------------------------------------------------------------------------------
+void MetaMap::verifyMetaMap()
+{
+#ifdef DEBUG_CRASHING
+	for (const MetaMapRec *map = getFirstMetaMapRec(); map; map = map->m_next)
+	{
+		DEBUG_ASSERTCRASH(
+			map->m_meta > GameMessage::MSG_BEGIN_META_MESSAGES &&
+			map->m_meta < GameMessage::MSG_END_META_MESSAGES,
+			("hmm, expected only meta-msgs here"));
+	}
+#endif
 }
 
 //-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This change moves the meta event type asserts from the key event update to engine initialization.

Additionally function `MetaMap::generateMetaMap` is no longer static. It never was supposed to be.

## TODO

- [x] Replicate in Generals