### PR TITLE
  bugfix(dumbprojectile): Fix in-flight DumbProjectile detonating instantly on save load

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
@@ -697,7 +697,8 @@ void DumbProjectileBehavior::crc( Xfer *xfer )
 /** Xfer method
 	* Version Info:
 	* 1: Initial version
-	* 2: TheSuperHackers @bugfix Added m_currentFlightPathStep for mid-flight save/load. */
+	* 2: TheSuperHackers @bugfix Added m_currentFlightPathStep for mid-flight save/load.
+	*/
 // ------------------------------------------------------------------------------------------------
 void DumbProjectileBehavior::xfer( Xfer *xfer )
 {
@@ -758,7 +759,6 @@ void DumbProjectileBehavior::xfer( Xfer *xfer )
 	// lifespan frame
 	xfer->xferUnsignedInt( &m_lifespanFrame );
 
-	// TheSuperHackers @bugfix Serialize current flight path step so projectiles can resume mid-flight on load.
 	if( version >= 2 )
 	{
 		xfer->xferInt( &m_currentFlightPathStep );
@@ -775,7 +775,6 @@ void DumbProjectileBehavior::loadPostProcess()
 	// extend base class
 	UpdateModule::loadPostProcess();
 
-	// TheSuperHackers @bugfix Rebuild flight path on load to prevent immediate detonation of in-flight projectiles.
 	if( m_flightPathSegments > 0 )
 	{
 		calcFlightPath( false );

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
@@ -696,13 +696,14 @@ void DumbProjectileBehavior::crc( Xfer *xfer )
 // ------------------------------------------------------------------------------------------------
 /** Xfer method
 	* Version Info:
-	* 1: Initial version */
+	* 1: Initial version
+	* 2: Added m_currentFlightPathStep for mid-flight save/load */
 // ------------------------------------------------------------------------------------------------
 void DumbProjectileBehavior::xfer( Xfer *xfer )
 {
 
 	// version
-	XferVersion currentVersion = 1;
+	XferVersion currentVersion = 2;
 	XferVersion version = currentVersion;
 	xfer->xferVersion( &version, currentVersion );
 
@@ -753,6 +754,12 @@ void DumbProjectileBehavior::xfer( Xfer *xfer )
 	// lifespan frame
 	xfer->xferUnsignedInt( &m_lifespanFrame );
 
+	// TheSuperHackers @bugfix Serialize current flight path step so projectiles can resume mid-flight on load.
+	if( version >= 2 )
+	{
+		xfer->xferInt( &m_currentFlightPathStep );
+	}
+
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -763,5 +770,11 @@ void DumbProjectileBehavior::loadPostProcess()
 
 	// extend base class
 	UpdateModule::loadPostProcess();
+
+	// TheSuperHackers @bugfix Rebuild flight path on load to prevent immediate detonation of in-flight projectiles.
+	if( m_flightPathSegments > 0 )
+	{
+		calcFlightPath( false );
+	}
 
 }

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
@@ -697,13 +697,17 @@ void DumbProjectileBehavior::crc( Xfer *xfer )
 /** Xfer method
 	* Version Info:
 	* 1: Initial version
-	* 2: Added m_currentFlightPathStep for mid-flight save/load */
+	* 2: TheSuperHackers @bugfix Added m_currentFlightPathStep for mid-flight save/load. */
 // ------------------------------------------------------------------------------------------------
 void DumbProjectileBehavior::xfer( Xfer *xfer )
 {
 
 	// version
+#if RETAIL_COMPATIBLE_XFER_SAVE
+	XferVersion currentVersion = 1;
+#else
 	XferVersion currentVersion = 2;
+#endif
 	XferVersion version = currentVersion;
 	xfer->xferVersion( &version, currentVersion );
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
@@ -748,7 +748,8 @@ void DumbProjectileBehavior::crc( Xfer *xfer )
 /** Xfer method
 	* Version Info:
 	* 1: Initial version
-	* 2: TheSuperHackers @bugfix Added m_currentFlightPathStep for mid-flight save/load. */
+	* 2: TheSuperHackers @bugfix Added m_currentFlightPathStep for mid-flight save/load.
+	*/
 // ------------------------------------------------------------------------------------------------
 void DumbProjectileBehavior::xfer( Xfer *xfer )
 {
@@ -809,7 +810,6 @@ void DumbProjectileBehavior::xfer( Xfer *xfer )
 	// lifespan frame
 	xfer->xferUnsignedInt( &m_lifespanFrame );
 
-	// TheSuperHackers @bugfix Serialize current flight path step so projectiles can resume mid-flight on load.
 	if( version >= 2 )
 	{
 		xfer->xferInt( &m_currentFlightPathStep );
@@ -826,7 +826,6 @@ void DumbProjectileBehavior::loadPostProcess()
 	// extend base class
 	UpdateModule::loadPostProcess();
 
-	// TheSuperHackers @bugfix Rebuild flight path on load to prevent immediate detonation of in-flight projectiles.
 	if( m_flightPathSegments > 0 )
 	{
 		calcFlightPath( false );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
@@ -747,13 +747,14 @@ void DumbProjectileBehavior::crc( Xfer *xfer )
 // ------------------------------------------------------------------------------------------------
 /** Xfer method
 	* Version Info:
-	* 1: Initial version */
+	* 1: Initial version
+	* 2: Added m_currentFlightPathStep for mid-flight save/load */
 // ------------------------------------------------------------------------------------------------
 void DumbProjectileBehavior::xfer( Xfer *xfer )
 {
 
 	// version
-	XferVersion currentVersion = 1;
+	XferVersion currentVersion = 2;
 	XferVersion version = currentVersion;
 	xfer->xferVersion( &version, currentVersion );
 
@@ -804,6 +805,12 @@ void DumbProjectileBehavior::xfer( Xfer *xfer )
 	// lifespan frame
 	xfer->xferUnsignedInt( &m_lifespanFrame );
 
+	// TheSuperHackers @bugfix Serialize current flight path step so projectiles can resume mid-flight on load.
+	if( version >= 2 )
+	{
+		xfer->xferInt( &m_currentFlightPathStep );
+	}
+
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -814,5 +821,11 @@ void DumbProjectileBehavior::loadPostProcess()
 
 	// extend base class
 	UpdateModule::loadPostProcess();
+
+	// TheSuperHackers @bugfix Rebuild flight path on load to prevent immediate detonation of in-flight projectiles.
+	if( m_flightPathSegments > 0 )
+	{
+		calcFlightPath( false );
+	}
 
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/DumbProjectileBehavior.cpp
@@ -748,13 +748,17 @@ void DumbProjectileBehavior::crc( Xfer *xfer )
 /** Xfer method
 	* Version Info:
 	* 1: Initial version
-	* 2: Added m_currentFlightPathStep for mid-flight save/load */
+	* 2: TheSuperHackers @bugfix Added m_currentFlightPathStep for mid-flight save/load. */
 // ------------------------------------------------------------------------------------------------
 void DumbProjectileBehavior::xfer( Xfer *xfer )
 {
 
 	// version
+#if RETAIL_COMPATIBLE_XFER_SAVE
+	XferVersion currentVersion = 1;
+#else
 	XferVersion currentVersion = 2;
+#endif
 	XferVersion version = currentVersion;
 	xfer->xferVersion( &version, currentVersion );
 


### PR DESCRIPTION
* Fixes TheSuperHackers/GeneralsGameCode#2346

  DumbProjectileBehavior does not serialize `m_flightPath` (the Bezier curve points) or `m_currentFlightPathStep` (the current      
  position along the path). On load, `m_flightPath` is empty and `m_currentFlightPathStep` is 0, so the first `update()` call       
  evaluates `0 >= 0` as true and immediately calls `detonate()`. This is most visible with slow artillery like Inferno Cannons and  
  Nuke Cannons.

  The fix adds two things:

  1. Serializes `m_currentFlightPathStep` in `xfer()` (version bumped from 1 to 2) so the projectile knows where it was along its   
  flight path.
  2. Rebuilds the flight path Bezier curve in `loadPostProcess()` using the already-saved start, end, segments and speed parameters.

  Old saves (version 1) remain compatible — the step defaults to 0 and the path is rebuilt, so projectiles restart from the
  beginning of their arc rather than detonating instantly.

  ## Test
  - Built and launched Zero Hour
  - Started a skirmish and built artillery units
  - Fired artillery and immediately saved the game while shells were mid-flight
  - Loaded the save — projectiles continued their flight path and landed at their target without instant detonation
  - Verified loading old saves works correctly — projectiles restart from the beginning of their arc instead of detonating