### PR TITLE
  bugfix(water): Fix river borders appearing darkened under shroud                                                                                                                                                

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
@@ -2814,6 +2814,11 @@ void WaterRenderObjClass::drawRiverWater(PolygonTrigger *pTrig)
 
 		Real constA=3*m_riverVOrigin;
 
+		// TheSuperHackers @bugfix Apply shroud per-vertex to avoid double-darkening at river borders.
+		// The old separate multiplicative shroud pass darkened the entire framebuffer, including
+		// already-shrouded terrain showing through transparent river edges.
+		W3DShroud *shroud = TheTerrainRenderObject ? TheTerrainRenderObject->getShroud() : nullptr;
+
 		for (i=0; i<(pTrig->getNumPoints()/2); i++)
 		{
 			Real x,y;
@@ -2834,7 +2839,16 @@ void WaterRenderObjClass::drawRiverWater(PolygonTrigger *pTrig)
 			vb->y=y;
 
 			vb->z=innerPt.z;
-			vb->diffuse= diffuse;
+
+			if (shroud) {
+				Int cellX = REAL_TO_INT_FLOOR(x / shroud->getCellWidth());
+				Int cellY = REAL_TO_INT_FLOOR(y / shroud->getCellHeight());
+				W3DShroudLevel level = shroud->getShroudLevel(cellX, cellY);
+				Real shroudScale = (Real)level / 255.0f;
+				vb->diffuse = REAL_TO_INT(shadeB * shroudScale) | (REAL_TO_INT(shadeG * shroudScale) << 8) | (REAL_TO_INT(shadeR * shroudScale) << 16) | (diffuse & 0xff000000);
+			} else {
+				vb->diffuse = diffuse;
+			}
 
 			Real wobbleConst=-m_riverVOrigin+vScale*(Real)i + WWMath::Fast_Sin(2*PI*(vScale*(Real)i) - constA)/22.0f;
  			//old slower version
@@ -2856,7 +2870,16 @@ void WaterRenderObjClass::drawRiverWater(PolygonTrigger *pTrig)
 			vb->x=x;
 			vb->y=y;
 			vb->z=outerPt.z;
-			vb->diffuse= diffuse;
+
+			if (shroud) {
+				Int cellX = REAL_TO_INT_FLOOR(x / shroud->getCellWidth());
+				Int cellY = REAL_TO_INT_FLOOR(y / shroud->getCellHeight());
+				W3DShroudLevel level = shroud->getShroudLevel(cellX, cellY);
+				Real shroudScale = (Real)level / 255.0f;
+				vb->diffuse = REAL_TO_INT(shadeB * shroudScale) | (REAL_TO_INT(shadeG * shroudScale) << 8) | (REAL_TO_INT(shadeR * shroudScale) << 16) | (diffuse & 0xff000000);
+			} else {
+				vb->diffuse = diffuse;
+			}
  			//old slower version
 			//vb->v1=-m_riverVOrigin+vScale*(Real)i + wobble(vScale*i, m_riverVOrigin, doWobble);
 			vb->v1=wobbleConst;
@@ -2908,19 +2931,8 @@ void WaterRenderObjClass::drawRiverWater(PolygonTrigger *pTrig)
 	if (TheWaterTransparency->m_additiveBlend)
 		DX8Wrapper::Set_DX8_Render_State(D3DRS_SRCBLEND, D3DBLEND_ONE );
 
-	//do second pass to apply the shroud on water plane
-	if (TheTerrainRenderObject->getShroud())
-	{
-		W3DShaderManager::setTexture(0,TheTerrainRenderObject->getShroud()->getShroudTexture());
-		W3DShaderManager::setShader(W3DShaderManager::ST_SHROUD_TEXTURE, 0);
-		DX8Wrapper::_Get_D3D_Device8()->SetRenderState(D3DRS_CULLMODE, D3DCULL_NONE);
-		//Shroud shader uses z-compare of EQUAL which wouldn't work on water because it doesn't
-		//write to the zbuffer.  Change to LESSEQUAL.
-		DX8Wrapper::_Get_D3D_Device8()->SetRenderState(D3DRS_ZFUNC, D3DCMP_LESSEQUAL);
-		DX8Wrapper::Draw_Triangles(	0,rectangleCount*2, 0,	(rectangleCount+1)*2);
-		DX8Wrapper::_Get_D3D_Device8()->SetRenderState(D3DRS_ZFUNC, D3DCMP_EQUAL);
-		W3DShaderManager::resetShader(W3DShaderManager::ST_SHROUD_TEXTURE);
-	}
+	// TheSuperHackers @bugfix Shroud is now applied per-vertex above, removing the old
+	// separate multiplicative shroud pass that caused double-darkening at river borders.
 	DX8Wrapper::_Get_D3D_Device8()->SetRenderState(D3DRS_CULLMODE, cull);
 
 

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
@@ -56,6 +56,7 @@
 #include "Common/Xfer.h"
 #include "Common/GameLOD.h"
 
+#include "GameClient/Color.h"
 #include "GameClient/Water.h"
 #include "GameLogic/GameLogic.h"
 #include "GameLogic/PolygonTrigger.h"
@@ -164,6 +165,19 @@ static ShaderClass zFillAlphaShader(SC_ZFILL_BLEND3);
 static ShaderClass blendStagesShader(SC_DETAIL_BLEND);
 
 WaterRenderObjClass *TheWaterRenderObj=nullptr; ///<global water rendering object
+
+static Int getRiverVertexDiffuseWithShroud(W3DShroud *shroud, Real x, Real y, Real shadeR, Real shadeG, Real shadeB, Int diffuse)
+{
+	Int cellX = (Int)(x / shroud->getCellWidth());
+	Int cellY = (Int)(y / shroud->getCellHeight());
+	W3DShroudLevel level = shroud->getShroudLevel(cellX, cellY);
+	Real shroudScale = (Real)level / 255.0f;
+	return GameMakeColor(
+		REAL_TO_INT(shadeR * shroudScale),
+		REAL_TO_INT(shadeG * shroudScale),
+		REAL_TO_INT(shadeB * shroudScale),
+		(diffuse >> 24) & 0xff);
+}
 
 void doSkyBoxSet(Bool startDraw)
 {
@@ -2814,9 +2828,8 @@ void WaterRenderObjClass::drawRiverWater(PolygonTrigger *pTrig)
 
 		Real constA=3*m_riverVOrigin;
 
-		// TheSuperHackers @bugfix Apply shroud per-vertex to avoid double-darkening at river borders.
-		// The old separate multiplicative shroud pass darkened the entire framebuffer, including
-		// already-shrouded terrain showing through transparent river edges.
+		// TheSuperHackers @bugfix afc-afc0 14/04/2026 Apply shroud per-vertex to avoid double-darkening
+		// at river borders.
 		W3DShroud *shroud = TheTerrainRenderObject ? TheTerrainRenderObject->getShroud() : nullptr;
 
 		for (i=0; i<(pTrig->getNumPoints()/2); i++)
@@ -2841,11 +2854,7 @@ void WaterRenderObjClass::drawRiverWater(PolygonTrigger *pTrig)
 			vb->z=innerPt.z;
 
 			if (shroud) {
-				Int cellX = REAL_TO_INT_FLOOR(x / shroud->getCellWidth());
-				Int cellY = REAL_TO_INT_FLOOR(y / shroud->getCellHeight());
-				W3DShroudLevel level = shroud->getShroudLevel(cellX, cellY);
-				Real shroudScale = (Real)level / 255.0f;
-				vb->diffuse = REAL_TO_INT(shadeB * shroudScale) | (REAL_TO_INT(shadeG * shroudScale) << 8) | (REAL_TO_INT(shadeR * shroudScale) << 16) | (diffuse & 0xff000000);
+				vb->diffuse = getRiverVertexDiffuseWithShroud(shroud, x, y, shadeR, shadeG, shadeB, diffuse);
 			} else {
 				vb->diffuse = diffuse;
 			}
@@ -2872,11 +2881,7 @@ void WaterRenderObjClass::drawRiverWater(PolygonTrigger *pTrig)
 			vb->z=outerPt.z;
 
 			if (shroud) {
-				Int cellX = REAL_TO_INT_FLOOR(x / shroud->getCellWidth());
-				Int cellY = REAL_TO_INT_FLOOR(y / shroud->getCellHeight());
-				W3DShroudLevel level = shroud->getShroudLevel(cellX, cellY);
-				Real shroudScale = (Real)level / 255.0f;
-				vb->diffuse = REAL_TO_INT(shadeB * shroudScale) | (REAL_TO_INT(shadeG * shroudScale) << 8) | (REAL_TO_INT(shadeR * shroudScale) << 16) | (diffuse & 0xff000000);
+				vb->diffuse = getRiverVertexDiffuseWithShroud(shroud, x, y, shadeR, shadeG, shadeB, diffuse);
 			} else {
 				vb->diffuse = diffuse;
 			}
@@ -2931,8 +2936,6 @@ void WaterRenderObjClass::drawRiverWater(PolygonTrigger *pTrig)
 	if (TheWaterTransparency->m_additiveBlend)
 		DX8Wrapper::Set_DX8_Render_State(D3DRS_SRCBLEND, D3DBLEND_ONE );
 
-	// TheSuperHackers @bugfix Shroud is now applied per-vertex above, removing the old
-	// separate multiplicative shroud pass that caused double-darkening at river borders.
 	DX8Wrapper::_Get_D3D_Device8()->SetRenderState(D3DRS_CULLMODE, cull);
 
 

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
@@ -166,16 +166,19 @@ static ShaderClass blendStagesShader(SC_DETAIL_BLEND);
 
 WaterRenderObjClass *TheWaterRenderObj=nullptr; ///<global water rendering object
 
-static Int getRiverVertexDiffuseWithShroud(W3DShroud *shroud, Real x, Real y, Real shadeR, Real shadeG, Real shadeB, Int diffuse)
+static Int getRiverVertexDiffuse(W3DShroud *shroud, Real x, Real y, Real shadeR, Real shadeG, Real shadeB, Int diffuse)
 {
+	if (!shroud)
+		return diffuse;
+
 	Int cellX = (Int)(x / shroud->getCellWidth());
 	Int cellY = (Int)(y / shroud->getCellHeight());
 	W3DShroudLevel level = shroud->getShroudLevel(cellX, cellY);
 	Real shroudScale = (Real)level / 255.0f;
 	return GameMakeColor(
-		REAL_TO_INT(shadeR * shroudScale),
-		REAL_TO_INT(shadeG * shroudScale),
-		REAL_TO_INT(shadeB * shroudScale),
+		(Int)(shadeR * shroudScale),
+		(Int)(shadeG * shroudScale),
+		(Int)(shadeB * shroudScale),
 		(diffuse >> 24) & 0xff);
 }
 
@@ -2853,11 +2856,7 @@ void WaterRenderObjClass::drawRiverWater(PolygonTrigger *pTrig)
 
 			vb->z=innerPt.z;
 
-			if (shroud) {
-				vb->diffuse = getRiverVertexDiffuseWithShroud(shroud, x, y, shadeR, shadeG, shadeB, diffuse);
-			} else {
-				vb->diffuse = diffuse;
-			}
+			vb->diffuse = getRiverVertexDiffuse(shroud, x, y, shadeR, shadeG, shadeB, diffuse);
 
 			Real wobbleConst=-m_riverVOrigin+vScale*(Real)i + WWMath::Fast_Sin(2*PI*(vScale*(Real)i) - constA)/22.0f;
  			//old slower version
@@ -2880,11 +2879,7 @@ void WaterRenderObjClass::drawRiverWater(PolygonTrigger *pTrig)
 			vb->y=y;
 			vb->z=outerPt.z;
 
-			if (shroud) {
-				vb->diffuse = getRiverVertexDiffuseWithShroud(shroud, x, y, shadeR, shadeG, shadeB, diffuse);
-			} else {
-				vb->diffuse = diffuse;
-			}
+			vb->diffuse = getRiverVertexDiffuse(shroud, x, y, shadeR, shadeG, shadeB, diffuse);
  			//old slower version
 			//vb->v1=-m_riverVOrigin+vScale*(Real)i + wobble(vScale*i, m_riverVOrigin, doWobble);
 			vb->v1=wobbleConst;


### PR DESCRIPTION
Fixes #2364                                                                                                                                                                                                                                                           

## Description                                                                                                                                                                                                                                                          River borders appear darkened when under shroud, creating visual artifacts that force map makers to place rocks and other objects   to hide them.                                                                                                                     

  ### Root Cause

  River water rendering in `drawRiverWater()` applies the shroud as a separate multiplicative pass on the framebuffer after the     
  water is already alpha-blended onto the terrain. This causes double-darkening at transparent river edges:

  1. Terrain renders with its own shroud: `pixel = terrain × shroud`
  2. River alpha-blends on top: `pixel = α × water + (1-α) × terrain × shroud`
  3. River's multiplicative shroud pass darkens the entire framebuffer: `pixel = shroud × (α × water + (1-α) × terrain × shroud)`   

  The terrain contribution at river borders becomes `terrain × shroud²` instead of `terrain × shroud` — visibly darker than
  surrounding terrain. This is only noticeable under shroud (when `shroud < 1.0`), since `1.0² = 1.0`.

  Note: Trapezoid water (lakes/ponds) avoids this by applying shroud in texture stage 3 of the main pass when pixel shaders are     
  available. River water cannot do this because stage 3 is already used for the river alpha edge texture.

  ### Fix

  Applies shroud per-vertex by looking up the shroud level at each river vertex's world position and multiplying it into the vertex 
  diffuse color before alpha blending. This ensures only the water's color contribution is shroud-modulated:

  `pixel = α × (water × shroud) + (1-α) × (terrain × shroud) = shroud × (α × water + (1-α) × terrain)`

  The separate multiplicative shroud pass is removed, which also eliminates one draw call per river.

  ### Testing

  Tested with the minimal reproduction map (`Ariver.zip` from #2364) — river borders no longer show dark outlines under shroud.