### PR TITLE
fix(ini): Replace unsafe uses of INI::getNextTokenOrNull

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AutoDepositUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AutoDepositUpdate.cpp
@@ -86,7 +86,7 @@ void parseUpgradePair( INI *ini, void *instance, void *store, const void *userDa
 		throw INI_INVALID_DATA;
 
 
-	token = ini->getNextTokenOrNull( ini->getSepsColon() );
+	token = ini->getNextToken( ini->getSepsColon() );
 	if ( stricmp(token, "Boost") == 0 )
 		info.amount = INI::scanInt(ini->getNextToken( ini->getSepsColon() ));
 	else

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -360,13 +360,12 @@ void WeaponTemplate::reset()
 	static const char *MIN_LABEL = "Min";
 	static const char *MAX_LABEL = "Max";
 
-	const char* token = ini->getNextTokenOrNull(ini->getSepsColon());
-
+	const char* token = ini->getNextToken(ini->getSepsColon());
 	if( stricmp(token, MIN_LABEL) == 0 )
 	{
 		// Two entry min/max
 		self->m_minDelayBetweenShots = INI::scanInt(ini->getNextToken(ini->getSepsColon()));
-		token = ini->getNextTokenOrNull(ini->getSepsColon());
+		token = ini->getNextToken(ini->getSepsColon());
 		if( stricmp(token, MAX_LABEL) != 0 )
 		{
 			// Messed up double entry

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AutoDepositUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AutoDepositUpdate.cpp
@@ -87,7 +87,7 @@ void parseUpgradePair( INI *ini, void *instance, void *store, const void *userDa
 		throw INI_INVALID_DATA;
 
 
-	token = ini->getNextTokenOrNull( ini->getSepsColon() );
+	token = ini->getNextToken( ini->getSepsColon() );
 	if ( stricmp(token, "Boost") == 0 )
 		info.amount = INI::scanInt(ini->getNextToken( ini->getSepsColon() ));
 	else

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/OCLUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/OCLUpdate.cpp
@@ -61,7 +61,7 @@ void parseFactionObjectCreationList( INI *ini, void *instance, void *store, cons
 		throw INI_INVALID_DATA;
 
 
-	token = ini->getNextTokenOrNull( ini->getSepsColon() );
+	token = ini->getNextToken( ini->getSepsColon() );
 	if ( stricmp(token, "OCL") == 0 )
 		ini->parseObjectCreationList( ini, instance, &info.m_ocl, nullptr );
 	else

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -374,13 +374,12 @@ void WeaponTemplate::reset()
 	static const char *MIN_LABEL = "Min";
 	static const char *MAX_LABEL = "Max";
 
-	const char* token = ini->getNextTokenOrNull(ini->getSepsColon());
-
+	const char* token = ini->getNextToken(ini->getSepsColon());
 	if( stricmp(token, MIN_LABEL) == 0 )
 	{
 		// Two entry min/max
 		self->m_minDelayBetweenShots = INI::scanInt(ini->getNextToken(ini->getSepsColon()));
-		token = ini->getNextTokenOrNull(ini->getSepsColon());
+		token = ini->getNextToken(ini->getSepsColon());
 		if( stricmp(token, MAX_LABEL) != 0 )
 		{
 			// Messed up double entry


### PR DESCRIPTION
https://github.com/TheSuperHackers/GeneralsGameCode/blob/b7fcf9f5212fa4735039e0366c0c99f5e5f09aad/Core/GameEngine/Source/Common/INI/INI.cpp#L1603-L1608

https://github.com/TheSuperHackers/GeneralsGameCode/blob/b7fcf9f5212fa4735039e0366c0c99f5e5f09aad/Core/GameEngine/Source/Common/INI/INI.cpp#L1593-L1600

`INI::getNextTokenOrNull` is allowed to return a `nullptr`. The returned pointer should be checked before use, though. There are a couple of places where that doesn't happen (e.g. the pointer is passed to `stricmp` without checking). This PR changes those cases to `getNextToken` because that function isn't allowed to return a `nullptr`, and will throw an exception instead.

Edit: I checked manually and with regex: `getNextTokenOrNull(?:.*\n){0,30}.*str.?.?cmp`