### PR TITLE
bugfix(view): Fix ground level of bookmarks, replay camera and game world microphone

### DIFF
--- a/Core/GameEngine/Include/GameClient/View.h
+++ b/Core/GameEngine/Include/GameClient/View.h
@@ -221,6 +221,8 @@ public:
 	Bool userSetCameraLockDrawable(Drawable *drawable)   { return doUserAction(&View::setCameraLockDrawable, drawable); }
 
 	void lockUserControlUntilFrame(UnsignedInt frame) { m_userControlLockedUntilFrame = frame; } ///< Locks the user control over camera until the given frame is reached.
+
+	virtual void setUserControlled(Bool value) { m_isUserControlled = value; }
 	Bool isUserControlLocked() const;
 
 	// for debugging
@@ -272,8 +274,6 @@ protected:
 
 	virtual View *prependViewToList( View *list );							///< Prepend this view to the given list, return the new list
 	virtual View *getNextView() { return m_next; }				///< Return next view in the set
-
-	virtual void setUserControlled(Bool value) { m_isUserControlled = value; }
 
 private:
 

--- a/Core/GameEngine/Include/GameClient/View.h
+++ b/Core/GameEngine/Include/GameClient/View.h
@@ -187,8 +187,10 @@ public:
 	virtual Real getDefaultPitch() { return m_defaultPitch; }						///< Return current default camera pitch
 	virtual void setAngleToDefault();															///< Set the view angle back to default
 	virtual void setPitchToDefault();															///< Set the view pitch back to default
-	void setPosition( const Coord3D *pos ) { m_pos = *pos; }
-	void getPosition(Coord3D *pos) { *pos = m_pos;}							///< Returns position camera is looking at (z will be zero)
+	void setPosition( const Coord3D &pos ) { m_pos = pos; }
+	void setPosition2D( const Coord2D &pos ) { m_pos.x = pos.x; m_pos.y = pos.y; }
+	const Coord3D &getPosition() const { return m_pos; } ///< Returns position camera is looking at
+	Coord2D getPosition2D() const { Coord2D c = { m_pos.x, m_pos.y }; return c; } ///< Returns position camera is looking at
 
 	virtual const Coord3D& get3DCameraPosition() const = 0;							///< Returns the actual camera position
 
@@ -201,7 +203,7 @@ public:
 	virtual void setOkToAdjustHeight( Bool val ) { m_okToAdjustHeight = val; }	///< Set this to adjust camera height
 
 	// TheSuperHackers @info Functions to call for user camera controls, not by the scripted camera.
-	Bool userSetPosition(const Coord3D *pos)             { return doUserAction(&View::setPosition, pos); }
+	Bool userSetPosition(const Coord3D &pos)             { return doUserAction(&View::setPosition, pos); }
 	Bool userSetAngle(Real radians)                      { return doUserAction(&View::setAngle, radians); }
 	Bool userSetAngleToDefault()                         { return doUserAction(&View::setAngleToDefault); }
 	Bool userSetPitch(Real radians)                      { return doUserAction(&View::setPitch, radians); }
@@ -268,8 +270,6 @@ protected:
 	virtual void xfer( Xfer *xfer ) override;
 	virtual void loadPostProcess() override { }
 
-	const Coord3D *getPosition() const { return &m_pos; }
-
 	virtual View *prependViewToList( View *list );							///< Prepend this view to the given list, return the new list
 	virtual View *getNextView() { return m_next; }				///< Return next view in the set
 
@@ -309,7 +309,7 @@ protected:
 	UnsignedInt m_userControlLockedUntilFrame;									///< Locks the user control over camera until the given frame is reached
 	Bool m_isUserControlled;																		///< True if the user moved the camera last, false if the scripted camera moved the camera last
 
-	Coord3D m_pos;																							///< Pivot of the camera, in world coordinates // TheSuperHackers @todo Make this Coord2D or use the Z component
+	Coord3D m_pos;																							///< Pivot of the camera, in world coordinates
 	Int m_width, m_height;																			///< Dimensions of the view
 	Int m_originX, m_originY;																		///< Location of top/left view corner
 
@@ -363,12 +363,10 @@ public:
 	Real getPitch() const { return m_pitch; }
 	Real getZoom() const { return m_zoom; }
 
-	void init(Real x, Real y, Real z, Real angle, Real pitch, Real zoom)
+	void init(Coord3D pos, Real angle, Real pitch, Real zoom)
 	{
 		m_valid = true;
-		m_pos.x = x;
-		m_pos.y = y;
-		m_pos.z = z;
+		m_pos = pos;
 		m_angle = angle;
 		m_pitch = pitch;
 		m_zoom = zoom;

--- a/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
+++ b/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
@@ -282,7 +282,6 @@ void AudioManager::reset()
 //-------------------------------------------------------------------------------------------------
 void AudioManager::update()
 {
-	Coord3D microphonePos;
 	Coord3D cameraPivot = TheTacticalView->getPosition();
 	Real angle = TheTacticalView->getAngle();
 	Matrix3D rot = Matrix3D::Identity;
@@ -290,7 +289,8 @@ void AudioManager::update()
 	Vector3 forward( 0, 1, 0 );
 	rot.mulVector3( forward );
 
-	const Real desiredHeight = m_audioSettings->m_microphoneDesiredHeightAboveTerrain + cameraPivot.z;
+	const Real desiredHeightRel = m_audioSettings->m_microphoneDesiredHeightAboveTerrain;
+	const Real desiredHeightAbs = desiredHeightRel + cameraPivot.z;
 	const Real maxPercentage = m_audioSettings->m_microphoneMaxPercentageBetweenGroundAndCamera;
 
 	Coord3D lookTo;
@@ -306,7 +306,7 @@ void AudioManager::update()
 	groundToCameraVector.sub( &cameraPivot );
 	Real bestScaleFactor;
 
-	if( cameraPos.z <= desiredHeight || groundToCameraVector.z <= 0.0f )
+	if( cameraPos.z <= desiredHeightAbs || groundToCameraVector.z <= 0.0f )
 	{
 		//Use the percentage calculation!
 		bestScaleFactor = maxPercentage;
@@ -314,7 +314,7 @@ void AudioManager::update()
 	else
 	{
 		//Calculate the stopping position of the groundToCameraVector when we force z to be m_microphoneDesiredHeightAboveTerrain
-		Real zScale = desiredHeight / groundToCameraVector.z;
+		Real zScale = desiredHeightRel / groundToCameraVector.z;
 
 		//Use the smallest of the two scale calculations
 		bestScaleFactor = MIN( maxPercentage, zScale );
@@ -324,6 +324,7 @@ void AudioManager::update()
 	groundToCameraVector.scale( bestScaleFactor );
 
 	//Set the microphone to be the ground position adjusted for terrain plus the vector we just calculated.
+	Coord3D microphonePos;
 	microphonePos.set( &cameraPivot );
 	microphonePos.add( &groundToCameraVector );
 

--- a/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
+++ b/Core/GameEngine/Source/Common/Audio/GameAudio.cpp
@@ -282,16 +282,16 @@ void AudioManager::reset()
 //-------------------------------------------------------------------------------------------------
 void AudioManager::update()
 {
-	Coord3D groundPos, microphonePos;
-	TheTacticalView->getPosition( &groundPos );
+	Coord3D microphonePos;
+	Coord3D cameraPivot = TheTacticalView->getPosition();
 	Real angle = TheTacticalView->getAngle();
 	Matrix3D rot = Matrix3D::Identity;
 	rot.Rotate_Z( angle );
 	Vector3 forward( 0, 1, 0 );
 	rot.mulVector3( forward );
 
-	Real desiredHeight = m_audioSettings->m_microphoneDesiredHeightAboveTerrain;
-	Real maxPercentage = m_audioSettings->m_microphoneMaxPercentageBetweenGroundAndCamera;
+	const Real desiredHeight = m_audioSettings->m_microphoneDesiredHeightAboveTerrain + cameraPivot.z;
+	const Real maxPercentage = m_audioSettings->m_microphoneMaxPercentageBetweenGroundAndCamera;
 
 	Coord3D lookTo;
 	lookTo.set(forward.X, forward.Y, forward.Z);
@@ -303,7 +303,7 @@ void AudioManager::update()
 	Coord3D cameraPos = TheTacticalView->get3DCameraPosition();
 	Coord3D groundToCameraVector;
 	groundToCameraVector.set( &cameraPos );
-	groundToCameraVector.sub( &groundPos );
+	groundToCameraVector.sub( &cameraPivot );
 	Real bestScaleFactor;
 
 	if( cameraPos.z <= desiredHeight || groundToCameraVector.z <= 0.0f )
@@ -324,8 +324,7 @@ void AudioManager::update()
 	groundToCameraVector.scale( bestScaleFactor );
 
 	//Set the microphone to be the ground position adjusted for terrain plus the vector we just calculated.
-	groundPos.z = TheTerrainLogic->getGroundHeight( groundPos.x, groundPos.y );
-	microphonePos.set( &groundPos );
+	microphonePos.set( &cameraPivot );
 	microphonePos.add( &groundToCameraVector );
 
 	//Viola! A properly placed microphone.

--- a/Core/GameEngine/Source/GameClient/View.cpp
+++ b/Core/GameEngine/Source/GameClient/View.cpp
@@ -136,12 +136,11 @@ void View::zoom( Real height )
  */
 void View::lookAt( const Coord3D *o )
 {
-
 	/// @todo this needs to be changed to be 3D, this is still old 2D stuff
-	Coord3D pos = *getPosition();
+	Coord2D pos = getPosition2D();
 	pos.x = o->x - m_width * 0.5f;
 	pos.y = o->y - m_height * 0.5f;
-	setPosition(&pos);
+	setPosition2D(pos);
 }
 
 /**
@@ -218,10 +217,7 @@ void View::setHeightAboveGround(Real z)
  */
 void View::getLocation( ViewLocation *location )
 {
-
-	const Coord3D *pos = getPosition();
-	location->init( pos->x, pos->y, pos->z, getAngle(), getPitch(), getZoom() );
-
+	location->init( getPosition(), getAngle(), getPitch(), getZoom() );
 }
 
 
@@ -232,11 +228,10 @@ void View::setLocation( const ViewLocation *location )
 {
 	if ( location->isValid() )
 	{
-		setPosition(&location->getPosition());
+		setPosition(location->getPosition());
 		setAngle(location->getAngle());
 		setPitch(location->getPitch());
 		setZoom(location->getZoom());
-		forceRedraw();
 	}
 
 }
@@ -302,8 +297,7 @@ void View::xfer( Xfer *xfer )
 	setAngle( angle );
 
 	// view position
-	Coord3D viewPos;
-	getPosition( &viewPos );
+	Coord3D viewPos = getPosition();
 	xfer->xferReal( &viewPos.x );
 	xfer->xferReal( &viewPos.y );
 	xfer->xferReal( &viewPos.z );

--- a/Core/GameEngine/Source/GameClient/View.cpp
+++ b/Core/GameEngine/Source/GameClient/View.cpp
@@ -58,8 +58,7 @@ View::View()
 	m_snapImmediate = FALSE;
 	m_terrainHeightAtPivot = 0.0f;
 	m_zoom = 0.0f;
-	m_pos.x = 0;
-	m_pos.y = 0;
+	m_pos.zero();
 	m_width = 0;
 	m_height = 0;
 	m_angle = 0.0f;
@@ -90,8 +89,7 @@ void View::init()
 	m_height = DEFAULT_VIEW_HEIGHT;
 	m_originX = DEFAULT_VIEW_ORIGIN_X;
 	m_originY = DEFAULT_VIEW_ORIGIN_Y;
-	m_pos.x = 0;
-	m_pos.y = 0;
+	m_pos.zero();
 	m_angle = 0.0f;
 	m_cameraLock = INVALID_ID;
 	m_cameraLockDrawable = nullptr;

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DView.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DView.h
@@ -280,7 +280,6 @@ private:
 	Coord2D m_scrollAmount;													///< scroll speed
 	Real m_scrollAmountCutoffSqr;										///< scroll speed at which we do not adjust height
 
-	Real m_groundLevel;															///< height of ground.
 #if PRESERVE_RETAIL_SCRIPTED_CAMERA
 	// TheSuperHackers @tweak Uses the initial ground level for preserving the original look of the scripted camera,
 	// because alterations to the ground level do affect the positioning in subtle ways.

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DView.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DView.h
@@ -57,7 +57,6 @@ typedef struct
 	Real		waySegLength[MAX_WAYPOINTS+2];	// Length of each segment;
 	Real		cameraAngle[MAX_WAYPOINTS+2];	// Camera Angle;
 	Int			timeMultiplier[MAX_WAYPOINTS+2];	// Time speedup factor.
-	Real		groundHeight[MAX_WAYPOINTS+1];	// Ground height.
 	Real		totalTimeMilliseconds;					// Num of ms to do this movement.
 	Real		elapsedTimeMilliseconds;				// Time since start.
 	Real		totalDistance;								// Total length of paths.

--- a/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
+++ b/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
@@ -134,9 +134,7 @@ void MilesAudioManager::audioDebugDisplay(DebugDisplayInterface *dd, void *, FIL
 		AIL_MSS_version(buffer, 128);
 	}
 
-	Coord3D lookPos;
-	TheTacticalView->getPosition( &lookPos );
-	lookPos.z = TheTerrainLogic->getGroundHeight( lookPos.x, lookPos.y );
+	Coord3D lookPos = TheTacticalView->getPosition();
 	const Coord3D *mikePos = TheAudio->getListenerPosition();
 	Coord3D distanceVector = TheTacticalView->get3DCameraPosition();
 	distanceVector.sub( mikePos );

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -400,8 +400,8 @@ void W3DView::buildCameraTransform( Matrix3D *transform, const Vector3 &sourcePo
 						// WST 10.22.2002. Update the Listener positions used by audio system
 						//--------------------------------------------------------------------
 						Vector3 position = transform->Get_Translation();
-						Coord3D coord = { position.X, position.Y, position.Z };
-						View::setPosition(coord);
+						Coord2D coord = { position.X, position.Y };
+						View::setPosition2D(coord);
 						break;
 					}
 				}

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -3068,7 +3068,7 @@ void W3DView::setupWaypointPath(Bool orient)
 		Real factor2 = curDistance / m_mcwpInfo.totalDistance;
 		Real factor1 = 1.0-factor2;
 		m_mcwpInfo.timeMultiplier[i] = m_timeMultiplier;
-		m_mcwpInfo.groundHeight[i] = m_pos.z*factor1 + newGround*factor2;
+		m_mcwpInfo.waypoints[i].z = m_pos.z*factor1 + newGround*factor2;
 		curDistance += m_mcwpInfo.waySegLength[i];
 		//DEBUG_LOG(("New Index %d, angle %.2f", i, m_mcwpInfo.cameraAngle[i]*180/PI));
 	}
@@ -3079,9 +3079,8 @@ void W3DView::setupWaypointPath(Bool orient)
 	Coord3D prev = m_mcwpInfo.waypoints[m_mcwpInfo.numWaypoints-1];
 	m_mcwpInfo.waypoints[m_mcwpInfo.numWaypoints+1].x += cur.x-prev.x;
 	m_mcwpInfo.waypoints[m_mcwpInfo.numWaypoints+1].y += cur.y-prev.y;
+	m_mcwpInfo.waypoints[m_mcwpInfo.numWaypoints+1].z = newGround;
 	m_mcwpInfo.cameraAngle[m_mcwpInfo.numWaypoints+1] = m_mcwpInfo.cameraAngle[m_mcwpInfo.numWaypoints];
-	m_mcwpInfo.groundHeight[m_mcwpInfo.numWaypoints+1] = newGround;
-
 
 	cur = m_mcwpInfo.waypoints[2];
 	prev = m_mcwpInfo.waypoints[1];
@@ -3304,7 +3303,6 @@ void W3DView::moveAlongWaypointPath(Real milliseconds)
 		View::setAngle(m_mcwpInfo.cameraAngle[m_mcwpInfo.numWaypoints]);
 
 		Coord3D pos = m_mcwpInfo.waypoints[m_mcwpInfo.numWaypoints];
-		pos.z = m_mcwpInfo.groundHeight[m_mcwpInfo.numWaypoints];
 		setPosition(pos);
 		// Note - assuming that the scripter knows what he is doing, we adjust the constraints so that
 		// the scripted action can occur.
@@ -3407,8 +3405,8 @@ void W3DView::moveAlongWaypointPath(Real milliseconds)
 	result.y += factor*(end.y-start.y);
 	result.x += (1-factor)*factor*(mid.x-end.x + mid.x-start.x);
 	result.y += (1-factor)*factor*(mid.y-end.y + mid.y-start.y);
-	result.z = m_mcwpInfo.groundHeight[m_mcwpInfo.curSegment]*factor1 +
-			m_mcwpInfo.groundHeight[m_mcwpInfo.curSegment+1]*factor2;
+	result.z = m_mcwpInfo.waypoints[m_mcwpInfo.curSegment].z*factor1 +
+			m_mcwpInfo.waypoints[m_mcwpInfo.curSegment+1].z*factor2;
 /*
 	DEBUG_LOG(("Dx %.2f, dy %.2f, DeltaANgle = %.2f, %.2f DeltaGround %.2f", m_pos.x-result.x, m_pos.y-result.y, deltaAngle, result.z, result.z-m_pos.z));
 */

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -505,7 +505,7 @@ void W3DView::updateCameraAreaConstraints()
 /*
 Note the following restrictions on camera constraints!
 
--- they assume that all maps are height 'm_groundLevel' at the edges.
+-- they assume that all maps are raised to the common ground level at the edges.
 		(since you need to add some "buffer" around the edges of your map
 		anyway, this shouldn't be an issue.)
 
@@ -1865,9 +1865,7 @@ void W3DView::draw()
 	if( TheGlobalData->m_debugCamera )
 	{
 		UnsignedInt c = 0xaaffffff;
-		Coord3D worldPos;
-		worldPos.x = getPosition().x;
-		worldPos.y = getPosition().y;
+		Coord3D worldPos = getPosition();
 		worldPos.z = TheTerrainLogic->getGroundHeight(worldPos.x, worldPos.y);
 
 		Coord3D p1, p2;
@@ -3305,9 +3303,7 @@ void W3DView::moveAlongWaypointPath(Real milliseconds)
 		m_freezeTimeForCameraMovement = false;
 		View::setAngle(m_mcwpInfo.cameraAngle[m_mcwpInfo.numWaypoints]);
 
-		Coord3D pos;
-		pos.x = m_mcwpInfo.waypoints[m_mcwpInfo.numWaypoints].x;
-		pos.y = m_mcwpInfo.waypoints[m_mcwpInfo.numWaypoints].y;
+		Coord3D pos = m_mcwpInfo.waypoints[m_mcwpInfo.numWaypoints];
 		pos.z = m_mcwpInfo.groundHeight[m_mcwpInfo.numWaypoints];
 		setPosition(pos);
 		// Note - assuming that the scripter knows what he is doing, we adjust the constraints so that

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -141,9 +141,9 @@ W3DView::W3DView()
 
 	m_3DCamera = nullptr;
 	m_2DCamera = nullptr;
-	m_groundLevel = 10.0f;
+
 #if PRESERVE_RETAIL_SCRIPTED_CAMERA
-	m_initialGroundLevel = m_groundLevel;
+	m_initialGroundLevel = 10.0f;
 #endif
 
 	m_viewFilterMode = FM_VIEW_DEFAULT;
@@ -250,12 +250,10 @@ void W3DView::setOrigin( Int x, Int y)
 #define MIN_CAPPED_ZOOM (0.5f) //WST 10.19.2002. JSC integrated 5/20/03.
 void W3DView::buildCameraPosition( Vector3& sourcePos, Vector3& targetPos )
 {
-	Real groundLevel = m_groundLevel; // 93.0f;
-
-	Real zoom = getZoom();
-	Real angle = getAngle();
-	Real pitch = getPitch();
-	Coord3D pos = *getPosition();
+	const Real zoom = getZoom();
+	const Real angle = getAngle();
+	const Real pitch = getPitch();
+	Coord3D pos = getPosition();
 
 	// add in the camera shake, if any
 	pos.x += m_shakeOffset.x;
@@ -280,14 +278,10 @@ void W3DView::buildCameraPosition( Vector3& sourcePos, Vector3& targetPos )
 		sourcePos.Z *= zoom;
 	}
 
-	// camera looking at origin
-	targetPos.X = 0;
-	targetPos.Y = 0;
-	targetPos.Z = 0;
 
 	// TheSuperHackers @info Scales the source position later by this much
 	// to achieve the intended camera height. Must not scale before pitching!
-	const Real heightScale = 1.0f - (groundLevel / sourcePos.Z);
+	const Real heightScale = 1.0f - (pos.z / sourcePos.Z);
 
 	// construct a matrix to rotate around the up vector by the given angle
 	const Matrix3D angleTransform( Vector3( 0.0f, 0.0f, 1.0f ), angle - ViewDefaultYawRadians );
@@ -307,9 +301,9 @@ void W3DView::buildCameraPosition( Vector3& sourcePos, Vector3& targetPos )
 	sourcePos *= heightScale;
 
 	// set look at position
-	targetPos.X += pos.x;
-	targetPos.Y += pos.y;
-	targetPos.Z += groundLevel;
+	targetPos.X = pos.x;
+	targetPos.Y = pos.y;
+	targetPos.Z = pos.z;
 
 	// translate to world space
 	sourcePos += targetPos;
@@ -406,9 +400,8 @@ void W3DView::buildCameraTransform( Matrix3D *transform, const Vector3 &sourcePo
 						// WST 10.22.2002. Update the Listener positions used by audio system
 						//--------------------------------------------------------------------
 						Vector3 position = transform->Get_Translation();
-						Coord3D coord;
-						coord.set(position.X, position.Y, position.Z);
-						View::setPosition(&coord);
+						Coord3D coord = { position.X, position.Y, position.Z };
+						View::setPosition(coord);
 						break;
 					}
 				}
@@ -443,14 +436,14 @@ Bool W3DView::zoomCameraToDesiredHeight()
 // This is essential to correctly center the camera above the ground when playing.
 Bool W3DView::movePivotToGround()
 {
-	const Real groundLevel = m_groundLevel;
+	const Real groundLevel = m_pos.z;
 	const Real groundLevelDiff = m_terrainHeightAtPivot - groundLevel;
 	if (fabs(groundLevelDiff) > 0.1f)
 	{
 		const Real fpsRatio = TheFramePacer->getBaseOverUpdateFpsRatio();
 		const Real adjustFactor = std::min(TheGlobalData->m_cameraAdjustSpeed * fpsRatio, 1.0f);
 		// Adjust the ground level. This will change the world height of the camera.
-		m_groundLevel += groundLevelDiff * adjustFactor;
+		m_pos.z += groundLevelDiff * adjustFactor;
 
 		// Reposition the camera relative to its pitch.
 		// This effectively zooms the camera in the view direction together with the ground level change.
@@ -478,10 +471,10 @@ Bool W3DView::movePivotToGround()
 			repositionStrength = WWMath::Clamp(repositionStrength, 0.0f, 1.0f);
 			posDiff *= repositionStrength;
 
-			Coord3D pos = *getPosition();
+			Coord2D pos = getPosition2D();
 			pos.x += posDiff.X * adjustFactor;
 			pos.y += posDiff.Y * adjustFactor;
-			setPosition(&pos);
+			setPosition2D(pos);
 		}
 
 		return true;
@@ -541,7 +534,7 @@ void W3DView::calcCameraAreaConstraints()
 		Matrix3D prevCameraTransform = m_3DCamera->Get_Transform();
 		m_3DCamera->Set_Transform(cameraTransform);
 
-		Real offset = calcCameraAreaOffset(m_groundLevel);
+		Real offset = calcCameraAreaOffset(m_pos.z);
 		offset = std::min(offset, (mapRegion.hi.x - mapRegion.lo.x) / 2);
 		offset = std::min(offset, (mapRegion.hi.y - mapRegion.lo.y) / 2);
 
@@ -604,17 +597,17 @@ Real W3DView::calcCameraAreaOffset(Real maxEdgeZ)
 void W3DView::clipCameraIntoAreaConstraints()
 {
 	constexpr const Real eps = 1e-6f;
-	Coord3D pos = *getPosition();
+	Coord2D pos = getPosition2D();
 	pos.x = clamp(m_cameraAreaConstraints.lo.x + eps, pos.x, m_cameraAreaConstraints.hi.x - eps);
 	pos.y = clamp(m_cameraAreaConstraints.lo.y + eps, pos.y, m_cameraAreaConstraints.hi.y - eps);
-	setPosition(&pos);
+	setPosition2D(pos);
 }
 
 //-------------------------------------------------------------------------------------------------
 Bool W3DView::isWithinCameraAreaConstraints() const
 {
-	const Coord3D* pos = getPosition();
-	return m_cameraAreaConstraints.isInRegion(pos->x, pos->y);
+	const Coord3D &pos = getPosition();
+	return m_cameraAreaConstraints.isInRegion(pos.x, pos.y);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -662,7 +655,7 @@ Real W3DView::getCameraOffsetZ() const
 	}
 #endif
 
-	return m_groundLevel + TheGlobalData->m_maxCameraHeight;
+	return m_pos.z + TheGlobalData->m_maxCameraHeight;
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -678,7 +671,7 @@ Real W3DView::getDesiredHeight(Real x, Real y) const
 	}
 #endif
 
-	return m_groundLevel + m_heightAboveGround;
+	return m_pos.z + m_heightAboveGround;
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -692,7 +685,7 @@ Real W3DView::getMaxHeight(Real x, Real y) const
 	}
 #endif
 
-	return m_groundLevel + m_maxHeightAboveGround;
+	return m_pos.z + m_maxHeightAboveGround;
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -772,14 +765,11 @@ void W3DView::init()
 	setName("W3DView");
 	// set default camera "look at" point
 	Coord3D pos;
-	pos.x = 87.0f;
-	pos.y = 77.0f;
-	pos.z = 0;
+	pos.x = 87.0f * MAP_XY_FACTOR;
+	pos.y = 77.0f * MAP_XY_FACTOR;
+	pos.z = 10.0f;
 
-	pos.x *= MAP_XY_FACTOR;
-	pos.y *= MAP_XY_FACTOR;
-
-	setPosition(&pos);
+	setPosition(pos);
 
 	// create our 3D camera
 	m_3DCamera = NEW_REF( CameraClass, () );
@@ -822,7 +812,7 @@ void W3DView::reset()
 
 	// Just move the camera to zero. It'll get repositioned at the beginning of the next game anyways.
 	Coord3D arbitraryPos = { 0, 0, 0 };
-	setPosition(&arbitraryPos);
+	setPosition(arbitraryPos);
 	setAngleToDefault();
 	setPitchToDefault();
 	setZoomToDefault();
@@ -1192,13 +1182,13 @@ Bool W3DView::updateCameraMovements()
 	}
 	if (hasScriptedState(Scripted_Rotate))
 	{
-		m_previousLookAtPosition = *getPosition();
+		m_previousLookAtPosition = getPosition();
 		rotateCameraOneFrame();
 		didUpdate = true;
 	}
 	else if (hasScriptedState(Scripted_MoveOnWaypointPath))
 	{
-		m_previousLookAtPosition = *getPosition();
+		m_previousLookAtPosition = getPosition();
 		// TheSuperHackers @tweak The scripted camera movement is now decoupled from the render update.
 		// The scripted camera will still move when the time is frozen, but not when the game is halted.
 		moveAlongWaypointPath(TheFramePacer->getLogicTimeStepMilliseconds(FramePacer::IgnoreFrozenTime));
@@ -1364,7 +1354,7 @@ void W3DView::update()
 			}
 			else
 			{	Coord3D objpos = *cameraLockObj->getPosition();
-				Coord3D curpos = *getPosition();
+				Coord3D curpos = getPosition();
 				// don't "snap" directly to the pos, but move there smoothly.
 				Real snapThreshSqr = sqr(TheGlobalData->m_partitionCellSize);
 				Real curDistSqr = sqr(curpos.x - objpos.x) + sqr(curpos.y - objpos.y);
@@ -1407,9 +1397,9 @@ void W3DView::update()
 					}
 				}
 				if (!(TheScriptEngine->isTimeFrozenDebug() || TheScriptEngine->isTimeFrozenScript()) && !TheGameLogic->isGamePaused()) {
-					m_previousLookAtPosition = *getPosition();
+					m_previousLookAtPosition = getPosition();
 				}
-				setPosition(&curpos);
+				setPosition(curpos);
 
 				if (m_lockType == LOCK_FOLLOW)
 				{
@@ -1437,7 +1427,7 @@ void W3DView::update()
 				if (m_snapImmediate)
 					m_snapImmediate = FALSE;
 
-				m_groundLevel = objpos.z;
+				m_pos.z = objpos.z;
 				didScriptedMovement = true;
 				m_recalcCamera = true;
 			}
@@ -1687,13 +1677,13 @@ void W3DView::calcDeltaScroll(Coord2D &screenDelta)
 {
 	screenDelta.x = 0;
 	screenDelta.y = 0;
-	Vector3 prevPos(m_previousLookAtPosition.x,m_previousLookAtPosition.y, m_groundLevel);
+	Vector3 prevPos(m_previousLookAtPosition.x, m_previousLookAtPosition.y, m_pos.z);
 	Vector3 prevScreen;
 	if (m_3DCamera->Project( prevScreen, prevPos ) != CameraClass::INSIDE_FRUSTUM)
 	{
 		return;
 	}
-	Vector3 pos(m_pos.x,m_pos.y, m_groundLevel);
+	Vector3 pos(m_pos.x, m_pos.y, m_pos.z);
 	Vector3 screen;
 	if (m_3DCamera->Project( screen, pos ) != CameraClass::INSIDE_FRUSTUM)
 	{
@@ -1875,7 +1865,9 @@ void W3DView::draw()
 	if( TheGlobalData->m_debugCamera )
 	{
 		UnsignedInt c = 0xaaffffff;
-		Coord3D worldPos = *getPosition();
+		Coord3D worldPos;
+		worldPos.x = getPosition().x;
+		worldPos.y = getPosition().y;
 		worldPos.z = TheTerrainLogic->getGroundHeight(worldPos.x, worldPos.y);
 
 		Coord3D p1, p2;
@@ -2016,12 +2008,11 @@ void W3DView::scrollBy( const Coord2D *delta )
 		world.Z = worldEnd.Z - worldStart.Z;
 
 		// scroll by delta
-		Coord3D pos = *getPosition();
+		Coord2D pos = getPosition2D();
 		pos.x += world.X;
 		pos.y += world.Y;
 		//DEBUG_LOG(("Delta %.2f, %.2f", world.X, world.Z));
-		// no change to z
-		setPosition(&pos);
+		setPosition2D(pos);
 
 		//m_cameraConstraintValid = false;	// pos change does NOT invalidate cam constraints
 
@@ -2505,8 +2496,10 @@ void W3DView::lookAt( const Coord3D *o )
 
 		}
 	}
-	pos.z = 0;
-	setPosition(&pos);
+
+	setPosition(pos);
+
+	resetPivotToGround();
 
 	removeScriptedState(Scripted_Rotate | Scripted_CameraLock | Scripted_MoveOnWaypointPath);
 	m_CameraArrivedAtWaypointOnPathFlag = false;
@@ -2532,7 +2525,7 @@ void W3DView::initHeightForMap()
 //-------------------------------------------------------------------------------------------------
 void W3DView::resetPivotToGround( void )
 {
-	m_groundLevel = getHeightAroundPos(m_pos.x, m_pos.y);
+	m_pos.z = getHeightAroundPos(m_pos.x, m_pos.y);
 	m_cameraAreaConstraintsValid = false; // possible ground level change invalidates camera constraints
 	m_recalcCamera = true;
 }
@@ -2543,11 +2536,11 @@ void W3DView::resetPivotToGround( void )
 //-------------------------------------------------------------------------------------------------
 void W3DView::moveCameraTo(const Coord3D *o, Int milliseconds, Int shutter, Bool orient, Real easeIn, Real easeOut)
 {
-	m_mcwpInfo.waypoints[0] = *getPosition();
+	m_mcwpInfo.waypoints[0] = getPosition();
 	m_mcwpInfo.cameraAngle[0] = getAngle();
 	m_mcwpInfo.waySegLength[0] = 0;
 
-	m_mcwpInfo.waypoints[1] = *getPosition();
+	m_mcwpInfo.waypoints[1] = getPosition();
 	m_mcwpInfo.waySegLength[1] = 0;
 
 	m_mcwpInfo.waypoints[2] = *o;
@@ -2637,7 +2630,7 @@ void W3DView::rotateCameraTowardPosition(const Coord3D *pLoc, Int milliseconds, 
 	if (m_rcInfo.numFrames < 1) {
 		m_rcInfo.numFrames = 1;
 	}
-	Coord3D curPos = *getPosition();
+	Coord2D curPos = getPosition2D();
 	Vector2 dir(pLoc->x-curPos.x, pLoc->y-curPos.y);
 	const Real dirLength = dir.Length();
 	if (dirLength<0.1f) return;
@@ -2996,10 +2989,10 @@ void W3DView::moveCameraAlongWaypointPath(Waypoint *pWay, Int milliseconds, Int 
 {
 	const Real MIN_DELTA = MAP_XY_FACTOR;
 
-	m_mcwpInfo.waypoints[0] = *getPosition();
+	m_mcwpInfo.waypoints[0] = getPosition();
 	m_mcwpInfo.cameraAngle[0] = getAngle();
 	m_mcwpInfo.waySegLength[0] = 0;
-	m_mcwpInfo.waypoints[1] = *getPosition();
+	m_mcwpInfo.waypoints[1] = getPosition();
 	m_mcwpInfo.numWaypoints = 1;
 	if (milliseconds<1) milliseconds = 1;
 	m_mcwpInfo.totalTimeMilliseconds = milliseconds;
@@ -3077,7 +3070,7 @@ void W3DView::setupWaypointPath(Bool orient)
 		Real factor2 = curDistance / m_mcwpInfo.totalDistance;
 		Real factor1 = 1.0-factor2;
 		m_mcwpInfo.timeMultiplier[i] = m_timeMultiplier;
-		m_mcwpInfo.groundHeight[i] = m_groundLevel*factor1 + newGround*factor2;
+		m_mcwpInfo.groundHeight[i] = m_pos.z*factor1 + newGround*factor2;
 		curDistance += m_mcwpInfo.waySegLength[i];
 		//DEBUG_LOG(("New Index %d, angle %.2f", i, m_mcwpInfo.cameraAngle[i]*180/PI));
 	}
@@ -3312,11 +3305,11 @@ void W3DView::moveAlongWaypointPath(Real milliseconds)
 		m_freezeTimeForCameraMovement = false;
 		View::setAngle(m_mcwpInfo.cameraAngle[m_mcwpInfo.numWaypoints]);
 
-		m_groundLevel = m_mcwpInfo.groundHeight[m_mcwpInfo.numWaypoints];
-
-		Coord3D pos = m_mcwpInfo.waypoints[m_mcwpInfo.numWaypoints];
-		pos.z = 0;
-		setPosition(&pos);
+		Coord3D pos;
+		pos.x = m_mcwpInfo.waypoints[m_mcwpInfo.numWaypoints].x;
+		pos.y = m_mcwpInfo.waypoints[m_mcwpInfo.numWaypoints].y;
+		pos.z = m_mcwpInfo.groundHeight[m_mcwpInfo.numWaypoints];
+		setPosition(pos);
 		// Note - assuming that the scripter knows what he is doing, we adjust the constraints so that
 		// the scripted action can occur.
 		m_cameraAreaConstraints.lo.x = minf(m_cameraAreaConstraints.lo.x, pos.x);
@@ -3384,9 +3377,6 @@ void W3DView::moveAlongWaypointPath(Real milliseconds)
 			m_mcwpInfo.timeMultiplier[m_mcwpInfo.curSegment+1]*factor2;
 	m_timeMultiplier = REAL_TO_INT_FLOOR(0.5 + timeMultiplier);
 
-	m_groundLevel = m_mcwpInfo.groundHeight[m_mcwpInfo.curSegment]*factor1 +
-			m_mcwpInfo.groundHeight[m_mcwpInfo.curSegment+1]*factor2;
-
 	Coord3D start, mid, end;
 	if (factor<0.5) {
 		start = m_mcwpInfo.waypoints[m_mcwpInfo.curSegment-1];
@@ -3421,13 +3411,12 @@ void W3DView::moveAlongWaypointPath(Real milliseconds)
 	result.y += factor*(end.y-start.y);
 	result.x += (1-factor)*factor*(mid.x-end.x + mid.x-start.x);
 	result.y += (1-factor)*factor*(mid.y-end.y + mid.y-start.y);
-	result.z = 0;
+	result.z = m_mcwpInfo.groundHeight[m_mcwpInfo.curSegment]*factor1 +
+			m_mcwpInfo.groundHeight[m_mcwpInfo.curSegment+1]*factor2;
 /*
-	static Real prevGround = 0;
-	DEBUG_LOG(("Dx %.2f, dy %.2f, DeltaANgle = %.2f, %.2f DeltaGround %.2f", m_pos.x-result.x, m_pos.y-result.y, deltaAngle, m_groundLevel, m_groundLevel-prevGround));
-	prevGround = m_groundLevel;
+	DEBUG_LOG(("Dx %.2f, dy %.2f, DeltaANgle = %.2f, %.2f DeltaGround %.2f", m_pos.x-result.x, m_pos.y-result.y, deltaAngle, result.z, result.z-m_pos.z));
 */
-	setPosition(&result);
+	setPosition(result);
 	// Note - assuming that the scripter knows what he is doing, we adjust the constraints so that
 	// the scripted action can occur.
 	m_cameraAreaConstraints.lo.x = minf(m_cameraAreaConstraints.lo.x, result.x);
@@ -3481,12 +3470,11 @@ void W3DView::shake( const Coord3D *epicenter, CameraShakeType shakeType )
 	}
 
 	// intensity falls off with distance
-	const Coord3D *viewPos = getPosition();
-	Coord3D d;
-	d.x = epicenter->x - viewPos->x;
-	d.y = epicenter->y - viewPos->y;
 	/// @todo make this 3D once we have the real "lookat" spot
-	//d.z = epicenter->z - viewPos->z;
+	const Coord2D viewPos = getPosition2D();
+	Coord2D d;
+	d.x = epicenter->x - viewPos.x;
+	d.y = epicenter->y - viewPos.y;
 
 	Real dist = (Real)sqrt( d.x*d.x + d.y*d.y );
 

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -2495,9 +2495,17 @@ void W3DView::lookAt( const Coord3D *o )
 		}
 	}
 
-	setPosition(pos);
+	Coord2D pos2D = { pos.x, pos.y };
+	setPosition2D(pos2D);
 
 	resetPivotToGround();
+
+#if PRESERVE_RETAIL_SCRIPTED_CAMERA
+	if (!m_isUserControlled)
+	{
+		m_zoom = getDesiredZoom(m_pos.x, m_pos.y);
+	}
+#endif
 
 	removeScriptedState(Scripted_Rotate | Scripted_CameraLock | Scripted_MoveOnWaypointPath);
 	m_CameraArrivedAtWaypointOnPathFlag = false;
@@ -2509,20 +2517,29 @@ void W3DView::lookAt( const Coord3D *o )
 //-------------------------------------------------------------------------------------------------
 void W3DView::initHeightForMap()
 {
-	resetPivotToGround();
-
 #if PRESERVE_RETAIL_SCRIPTED_CAMERA
 	// jba - starting ground level can't exceed this height.
 	constexpr const Real MAX_GROUND_LEVEL = 120.0f;
 	const Real accurateGroundLevel = TheTerrainLogic->getGroundHeight(m_pos.x, m_pos.y);
 	m_initialGroundLevel = min(MAX_GROUND_LEVEL, accurateGroundLevel);
 #endif
+
+	resetPivotToGround();
 }
 
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
 void W3DView::resetPivotToGround( void )
 {
+#if PRESERVE_RETAIL_SCRIPTED_CAMERA
+	if (!m_isUserControlled)
+	{
+		m_pos.z = m_initialGroundLevel;
+		m_cameraAreaConstraintsValid = false; // possible ground level change invalidates camera constraints
+		m_recalcCamera = true;
+		return;
+	}
+#endif
 	m_pos.z = getHeightAroundPos(m_pos.x, m_pos.y);
 	m_cameraAreaConstraintsValid = false; // possible ground level change invalidates camera constraints
 	m_recalcCamera = true;

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -3929,8 +3929,7 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 					mode = FM_VIEW_MB_PAN_ALPHA;
 				}
 				saturate = !saturate;
-				Coord3D curpos;
-				TheTacticalView->getPosition(&curpos);
+				Coord3D curpos = TheTacticalView->getPosition();
 				curpos.x += 200;
 				curpos.y += 200;
 				TheTacticalView->setViewFilterPos(&curpos);

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
@@ -900,7 +900,7 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 			// 3) 3-D camera position has changed
 			m_deselectFeedbackAnchor = msg->getArgument( 0 )->pixel;
 			m_lastClick = (UnsignedInt) msg->getArgument( 2 )->integer;
-			TheTacticalView->getPosition(&m_deselectDownCameraPosition);
+			m_deselectDownCameraPosition = TheTacticalView->getPosition();
 
 			break;
 		}
@@ -908,8 +908,7 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 		//-----------------------------------------------------------------------------
 		case GameMessage::MSG_RAW_MOUSE_RIGHT_BUTTON_UP:
 		{
-			Coord3D cameraPos;
-			TheTacticalView->getPosition(&cameraPos);
+			Coord3D cameraPos = TheTacticalView->getPosition();
 			cameraPos.sub(&m_deselectDownCameraPosition);
 
 			ICoord2D pixel = msg->getArgument( 0 )->pixel;

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
@@ -4803,8 +4803,7 @@ void ScriptActions::doRadarRevertNormal()
 //-------------------------------------------------------------------------------------------------
 void ScriptActions::doScreenShake( UnsignedInt intensity )
 {
-	Coord3D pos;
-	TheTacticalView->getPosition( &pos );
+	Coord3D pos = TheTacticalView->getPosition();
 	TheTacticalView->shake( &pos, (View::CameraShakeType)intensity );
 }
 

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
@@ -2907,11 +2907,16 @@ void ScriptActions::doCameraMotionBlurJump(const AsciiString& waypointName, Bool
 			};
 		}
 		if (passed)
+		{
+			TheTacticalView->setUserControlled(false);
 			TheTacticalView->setViewFilterPos(&pos);
+		}
 	}
 	if (!passed)
-	{	//if we failed to apply the filter, we still need to get the camera to the target
+	{
+		//if we failed to apply the filter, we still need to get the camera to the target
 		//so do it another way:
+		TheTacticalView->setUserControlled(false);
 		TheTacticalView->lookAt(&pos);
 	}
 }

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -1933,7 +1933,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 					// TheSuperHackers @info Definitely call in user mode to ensure the camera operates with auto-zoom
 					// over terrain elevations, because the Replay Camera does not store the absolute camera location,
 					// but key parameters relative to the terrain height at the camera pivot.
-					TheTacticalView->userSetPosition(&pos);
+					TheTacticalView->userSetPosition(pos);
 					TheTacticalView->userSetAngle(angle);
 					TheTacticalView->userSetPitch(pitch);
 					TheTacticalView->userSetZoom(zoom);

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -1176,8 +1176,7 @@ void W3DDisplay::gatherDebugStats()
 		m_displayStrings[TerrainStats]->setText( unibuffer );
 
 		// misc debug info
-		Coord3D camPos;
-		TheTacticalView->getPosition(&camPos);
+		Coord3D camPos = TheTacticalView->getPosition();
 		Real zoom = TheTacticalView->getZoom();
 		Real pitch = TheTacticalView->getPitch();
 		Real FXPitch = TheTacticalView->getFXPitch();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -4315,8 +4315,7 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 					mode = FM_VIEW_MB_PAN_ALPHA;
 				}
 				saturate = !saturate;
-				Coord3D curpos;
-				TheTacticalView->getPosition(&curpos);
+				Coord3D curpos = TheTacticalView->getPosition();
 				curpos.x += 200;
 				curpos.y += 200;
 				TheTacticalView->setViewFilterPos(&curpos);

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/SelectionXlat.cpp
@@ -976,7 +976,7 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 			// 3) 3-D camera position has changed
 			m_deselectFeedbackAnchor = msg->getArgument( 0 )->pixel;
 			m_lastClick = (UnsignedInt) msg->getArgument( 2 )->integer;
-			TheTacticalView->getPosition(&m_deselectDownCameraPosition);
+			m_deselectDownCameraPosition = TheTacticalView->getPosition();
 
 			break;
 		}
@@ -984,8 +984,7 @@ GameMessageDisposition SelectionTranslator::translateGameMessage(const GameMessa
 		//-----------------------------------------------------------------------------
 		case GameMessage::MSG_RAW_MOUSE_RIGHT_BUTTON_UP:
 		{
-			Coord3D cameraPos;
-			TheTacticalView->getPosition(&cameraPos);
+			Coord3D cameraPos = TheTacticalView->getPosition();
 			cameraPos.sub(&m_deselectDownCameraPosition);
 
 			ICoord2D pixel = msg->getArgument( 0 )->pixel;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
@@ -5134,8 +5134,7 @@ void ScriptActions::doRadarRevertNormal()
 //-------------------------------------------------------------------------------------------------
 void ScriptActions::doScreenShake( UnsignedInt intensity )
 {
-	Coord3D pos;
-	TheTacticalView->getPosition( &pos );
+	Coord3D pos = TheTacticalView->getPosition();
 	TheTacticalView->shake( &pos, (View::CameraShakeType)intensity );
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
@@ -3003,11 +3003,16 @@ void ScriptActions::doCameraMotionBlurJump(const AsciiString& waypointName, Bool
 			};
 		}
 		if (passed)
+		{
+			TheTacticalView->setUserControlled(false);
 			TheTacticalView->setViewFilterPos(&pos);
+		}
 	}
 	if (!passed)
-	{	//if we failed to apply the filter, we still need to get the camera to the target
+	{
+		//if we failed to apply the filter, we still need to get the camera to the target
 		//so do it another way:
+		TheTacticalView->setUserControlled(false);
 		TheTacticalView->lookAt(&pos);
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -1966,7 +1966,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 					// TheSuperHackers @info Definitely call in user mode to ensure the camera operates with auto-zoom
 					// over terrain elevations, because the Replay Camera does not store the absolute camera location,
 					// but key parameters relative to the terrain height at the camera pivot.
-					TheTacticalView->userSetPosition(&pos);
+					TheTacticalView->userSetPosition(pos);
 					TheTacticalView->userSetAngle(angle);
 					TheTacticalView->userSetPitch(pitch);
 					TheTacticalView->userSetZoom(zoom);

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -1227,8 +1227,7 @@ void W3DDisplay::gatherDebugStats()
 		m_displayStrings[TerrainStats]->setText( unibuffer );
 
 		// misc debug info
-		Coord3D camPos;
-		TheTacticalView->getPosition(&camPos);
+		Coord3D camPos = TheTacticalView->getPosition();
 		Real zoom = TheTacticalView->getZoom();
 		Real pitch = TheTacticalView->getPitch();
 		Real FXPitch = TheTacticalView->getFXPitch();


### PR DESCRIPTION
* Fixes #2520

This change fixes the ground level of bookmarks, replay camera and the game world microphone by merging `View::m_groundLevel` into `View::m_pos::z`.

`View::m_pos::z` was originally unused and `View::m_groundLevel` was effectively that. They are now consolidated which automatically adds the ground level into bookmarks and the replay camera through `ViewLocation` (cool).

The game world microphone, used for positional audio, did not calculate the microphone height correctly which was fixed as well.

In `View::lookAt` the pivot is now reset to the ground which corrects behavior as well.

## TODO

- [x] Replicate in Generals
- [x] Test a few cutscenes