### PR TITLE
refactor: Add override keyword to virtual function overrides in Generals code (2)

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/Module.h
+++ b/Generals/Code/GameEngine/Include/Common/Module.h
@@ -133,20 +133,20 @@ private:
 #define MAKE_STANDARD_MODULE_MACRO( cls ) \
 public: \
 	static Module* friend_newModuleInstance( Thing *thing, const ModuleData* moduleData ) { return newInstance( cls )( thing, moduleData ); } \
-	virtual NameKeyType getModuleNameKey() const { static NameKeyType nk = NAMEKEY(#cls); return nk; } \
+	virtual NameKeyType getModuleNameKey() const override { static NameKeyType nk = NAMEKEY(#cls); return nk; } \
 protected: \
-	virtual void crc( Xfer *xfer ); \
-	virtual void xfer( Xfer *xfer ); \
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override; \
+	virtual void xfer( Xfer *xfer ) override; \
+	virtual void loadPostProcess() override;
 
 // ------------------------------------------------------------------------------------------------
 // For the creation of abstract module classes
 // ------------------------------------------------------------------------------------------------
 #define MAKE_STANDARD_MODULE_MACRO_ABC( cls ) \
 protected: \
-	virtual void crc( Xfer *xfer ); \
-	virtual void xfer( Xfer *xfer ); \
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override; \
+	virtual void xfer( Xfer *xfer ) override; \
+	virtual void loadPostProcess() override;
 
 //-------------------------------------------------------------------------------------------------
 // only use this macro for an ABC. for a real class, use MAKE_STANDARD_MODULE_MACRO_WITH_MODULE_DATA.

--- a/Generals/Code/GameEngine/Include/Common/Module.h
+++ b/Generals/Code/GameEngine/Include/Common/Module.h
@@ -45,6 +45,7 @@ class Object;
 class Player;
 class Thing;
 class W3DModelDrawModuleData;	// ugh, hack (srj)
+class W3DTreeDrawModuleData; // ugh, hack (srj)
 struct FieldParse;
 
 // TYPES //////////////////////////////////////////////////////////////////////////////////////////
@@ -109,6 +110,8 @@ public:
 
 	// ugh, hack
 	virtual const W3DModelDrawModuleData* getAsW3DModelDrawModuleData() const { return nullptr; }
+	// ugh, hack
+	virtual const W3DTreeDrawModuleData* getAsW3DTreeDrawModuleData() const { return nullptr; }
 	virtual StaticGameLODLevel getMinimumRequiredGameLOD() const { return (StaticGameLODLevel)0;}
 
 	static void buildFieldParse(MultiIniFieldParse& p)

--- a/Generals/Code/GameEngine/Include/Common/StateMachine.h
+++ b/Generals/Code/GameEngine/Include/Common/StateMachine.h
@@ -180,15 +180,6 @@ protected:
 	inline void setName(AsciiString n) { m_name = n; }
 #endif
 
-protected:
-	// snapshot interface	 - pure virtual here.
-	// Essentially all the member data gets set up on creation and shouldn't change.
-	// So none of it needs to be saved, and it nicely forces all user states to
-	// remember to implement crc, xfer & loadPostProcess.  jba
-	virtual void crc( Xfer *xfer )=0;
-	virtual void xfer( Xfer *xfer )=0;
-	virtual void loadPostProcess()=0;
-
 private:
 
 	struct TransitionInfo

--- a/Generals/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/Generals/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -455,7 +455,7 @@ public:  // ********************************************************************
 	virtual void disregardDrawable( Drawable *draw );				///< Drawable is being destroyed, clean up any UI elements associated with it
 
 	virtual void preDraw();														///< Logic which needs to occur before the UI renders
-	virtual void draw() = 0;													///< Render the in-game user interface
+	virtual void draw() override = 0;													///< Render the in-game user interface
 	virtual void postDraw();													///< Logic which needs to occur after the UI renders
 	virtual void postWindowDraw();											///< Logic which needs to occur after the WindowManager has repainted the menus
 

--- a/Generals/Code/GameEngine/Include/GameLogic/AIStateMachine.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AIStateMachine.h
@@ -160,7 +160,7 @@ public:
 public:	// overrides.
 	virtual StateReturnType updateStateMachine() override;				///< run one step of the machine
 #ifdef STATE_MACHINE_DEBUG
-	virtual AsciiString getCurrentStateName() const ;
+	virtual AsciiString getCurrentStateName() const override;
 #endif
 
 protected:
@@ -573,7 +573,7 @@ public:
 	virtual void onExit( StateExitType status ) override;
 	virtual StateReturnType update() override;
 #ifdef STATE_MACHINE_DEBUG
-	virtual AsciiString getName() const ;
+	virtual AsciiString getName() const override;
 #endif
 
 protected:
@@ -681,7 +681,7 @@ public:
 	virtual void onExit( StateExitType status ) override;
 	virtual StateReturnType update() override;
 #ifdef STATE_MACHINE_DEBUG
-	virtual AsciiString getName() const ;
+	virtual AsciiString getName() const override;
 #endif
 
 protected:
@@ -983,7 +983,7 @@ public:
 	virtual Bool isAttackingObject() const override { return m_isAttackingObject; }
 	virtual Bool isForceAttacking() const { return m_isForceAttacking; }
 #ifdef STATE_MACHINE_DEBUG
-	virtual AsciiString getName() const ;
+	virtual AsciiString getName() const override;
 #endif
 
 	virtual Bool isAttack() const override { return TRUE; }
@@ -1022,7 +1022,7 @@ public:
 	virtual StateReturnType update() override;
 	Object *chooseVictim();
 #ifdef STATE_MACHINE_DEBUG
-	virtual AsciiString getName() const ;
+	virtual AsciiString getName() const override;
 #endif
 
 
@@ -1064,7 +1064,7 @@ public:
 	virtual void onExit( StateExitType status ) override;
 	virtual StateReturnType update() override;
 #ifdef STATE_MACHINE_DEBUG
-	virtual AsciiString getName() const ;
+	virtual AsciiString getName() const override;
 #endif
 
 protected:
@@ -1135,7 +1135,7 @@ public:
 	virtual void onExit( StateExitType status ) override;
 	virtual StateReturnType update() override;
 #ifdef STATE_MACHINE_DEBUG
-	virtual AsciiString getName() const ;
+	virtual AsciiString getName() const override;
 #endif
 protected:
 	// snapshot interface
@@ -1164,7 +1164,7 @@ public:
 	virtual void onExit( StateExitType status ) override;
 	virtual StateReturnType update() override;
 #ifdef STATE_MACHINE_DEBUG
-	virtual AsciiString getName() const ;
+	virtual AsciiString getName() const override;
 #endif
 protected:
 	// snapshot interface
@@ -1193,7 +1193,7 @@ public:
 	virtual void onExit( StateExitType status ) override;
 	virtual StateReturnType update() override;
 #ifdef STATE_MACHINE_DEBUG
-	virtual AsciiString getName() const ;
+	virtual AsciiString getName() const override;
 #endif
 
 protected:
@@ -1223,7 +1223,7 @@ public:
 	virtual void onExit( StateExitType status ) override;
 	virtual StateReturnType update() override;
 #ifdef STATE_MACHINE_DEBUG
-	virtual AsciiString getName() const ;
+	virtual AsciiString getName() const override;
 #endif
 
 protected:

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/BodyModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/BodyModule.h
@@ -207,42 +207,9 @@ public:
 	// BehaviorModule
 	virtual BodyModuleInterface* getBody() override { return this; }
 
-	/**
-		Try to damage this Object. The module's Armor
-		will be taken into account, so the actual damage done may vary
-		considerably from what you requested. Also note that (if damage is done)
-		the DamageFX will be invoked to provide a/v fx as appropriate.
-	*/
-	virtual void attemptDamage( DamageInfo *damageInfo ) = 0;
-
-	/**
-		Instead of having negative damage count as healing, or allowing access to the private
-		changeHealth Method, we will use this parallel to attemptDamage to do healing without hack.
-	*/
-	virtual void attemptHealing( DamageInfo *healingInfo ) = 0;
-
-	/**
-		Estimate the (unclipped) damage that would be done to this object
-		by the given damage (taking bonuses, armor, etc into account),
-		but DO NOT alter the body in any way. (This is used by the AI system
-		to choose weapons.)
-	*/
-	virtual Real estimateDamage( DamageInfoInput& damageInfo ) const = 0;
-
-	virtual Real getHealth() const = 0;													///< get current health
-
 	virtual Real getMaxHealth() const override {return 0.0f;}  ///< return max health
 
 	virtual Real getInitialHealth() const override {return 0.0f;}  // return initial health
-
-	virtual BodyDamageType getDamageState() const = 0;
-	virtual void setDamageState( BodyDamageType newState ) = 0;	///< control damage state directly.  Will adjust hitpoints.
-	virtual void setAflame( Bool setting ) = 0;///< This is a major change like a damage state.
-
-	virtual void onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel newLevel, Bool provideFeedback = FALSE ) = 0;	///< I just achieved this level right this moment
-
-	virtual void setArmorSetFlag(ArmorSetType ast) = 0;
-	virtual void clearArmorSetFlag(ArmorSetType ast) = 0;
 
 	virtual const DamageInfo *getLastDamageInfo() const override { return nullptr; }	///< return info on last damage dealt to this object
 	virtual UnsignedInt getLastDamageTimestamp() const override { return 0; }	///< return frame of last damage dealt
@@ -265,15 +232,6 @@ public:
 	//Allows outside systems to apply defensive bonuses or penalties (they all stack as a multiplier!)
 	virtual void applyDamageScalar( Real scalar ) override { m_damageScalar *= scalar; }
 	virtual Real getDamageScalar() const override { return m_damageScalar; }
-
-	/**
-		Change the module's health by the given delta. Note that
-		the module's DamageFX and Armor are NOT taken into
-		account, so you should think about what you're bypassing when you
-		call this directly (especially when when decreasing health, since
-		you probably want "attemptDamage" or "attemptHealing")
-	*/
-	virtual void internalChangeHealth( Real delta ) = 0;
 
 	virtual void evaluateVisualCondition() override { }
 	virtual void updateBodyParticleSystems() override { };// made public for topple anf building collapse updates -ML

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/CollideModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/CollideModule.h
@@ -84,8 +84,6 @@ public:
 	// BehaviorModule
 	virtual CollideModuleInterface* getCollide() override { return this; }
 
-	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal ) = 0;
-
 	/// this is used for things like pilots, to determine if they can "enter" something
 	virtual Bool wouldLikeToCollideWith(const Object* other) const override { return false; }
 	virtual Bool isHijackedVehicleCrateCollide() const override { return false; }

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/CreateModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/CreateModule.h
@@ -73,7 +73,6 @@ public:
 	// BehaviorModule
 	virtual CreateModuleInterface* getCreate() override { return this; }
 
-	virtual void onCreate() = 0;				///< This is called when you become a code Object
 	virtual void onBuildComplete() override { m_needToRunOnBuildComplete = FALSE; }	///< This is called when you are a finished game object
 	virtual Bool shouldDoOnBuildComplete() const override { return m_needToRunOnBuildComplete; }
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/DamageModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/DamageModule.h
@@ -97,13 +97,6 @@ public:
 	// BehaviorModule
 	virtual DamageModuleInterface* getDamage() override { return this; }
 
-	// damage module callbacks
-	virtual void onDamage( DamageInfo *damageInfo ) = 0;	///< damage callback
-	virtual void onHealing( DamageInfo *damageInfo ) = 0;	///< healing callback
-	virtual void onBodyDamageStateChange( const DamageInfo* damageInfo,
-																				BodyDamageType oldState,
-																				BodyDamageType newState) = 0;  ///< state change callback
-
 protected:
 
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/DestroyModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/DestroyModule.h
@@ -58,8 +58,6 @@ public:
 	// BehaviorModule
 	virtual DestroyModuleInterface* getDestroy() override { return this; }
 
-	virtual void onDestroy() = 0;
-
 protected:
 
 };

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/DieModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/DieModule.h
@@ -97,8 +97,6 @@ public:
 	// BehaviorModule
 	virtual DieModuleInterface* getDie() override { return this; }
 
-	virtual void onDie( const DamageInfo *damageInfo ) = 0;
-
 protected:
 	Bool isDieApplicable(const DamageInfo *damageInfo) const { return getDieModuleData()->isDieApplicable(getObject(), damageInfo); }
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/JetAIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/JetAIUpdate.h
@@ -122,7 +122,7 @@ protected:
 
 	virtual AIStateMachine* makeStateMachine() override;
 
-	virtual void privateFollowPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource, Bool exitProduction );///< follow the path defined by the given array of points
+	virtual void privateFollowPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource, Bool exitProduction ) override;///< follow the path defined by the given array of points
 	virtual void privateFollowPathAppend( const Coord3D *pos, CommandSourceType cmdSource ) override;
 	virtual void privateEnter( Object *obj, CommandSourceType cmdSource ) override;							///< enter the given object
 	virtual void privateGetRepaired( Object *repairDepot, CommandSourceType cmdSource ) override;///< get repaired at repair depot

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/ObjectHelper.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/ObjectHelper.h
@@ -54,9 +54,6 @@ public:
 		setWakeFrame(getObject(), UPDATE_SLEEP_FOREVER);
 	}
 
-	// inherited from UpdateModuleInterface
-	virtual UpdateSleepTime update() = 0;
-
 	// custom to this class.
 	void sleepUntil(UnsignedInt when);
 

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/OpenContain.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/OpenContain.h
@@ -147,7 +147,7 @@ public:
 	// default OpenContain has unlimited capacity...!
 	virtual Bool isValidContainerFor(const Object* obj, Bool checkCapacity) const override;
 	virtual void addToContain( Object *obj ) override;				///< add 'obj' to contain list
-	virtual void addToContainList( Object *obj );		///< The part of AddToContain that inheritors can override (Can't do whole thing because of all the private stuff involved)
+	virtual void addToContainList( Object *obj ) override;		///< The part of AddToContain that inheritors can override (Can't do whole thing because of all the private stuff involved)
 	virtual void removeFromContain( Object *obj, Bool exposeStealthUnits = FALSE ) override;	///< remove 'obj' from contain list
 	virtual void removeAllContained( Bool exposeStealthUnits = FALSE ) override;				///< remove all objects on contain list
 	virtual Bool isEnclosingContainerFor( const Object *obj ) const override;	///< Does this type of Contain Visibly enclose its contents?

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/OverlordContain.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/OverlordContain.h
@@ -72,7 +72,7 @@ public:
 
 	virtual Bool isValidContainerFor(const Object* obj, Bool checkCapacity) const override;
 	virtual void addToContain( Object *obj ) override;				///< add 'obj' to contain list
-	virtual void addToContainList( Object *obj );		///< The part of AddToContain that inheritors can override (Can't do whole thing because of all the private stuff involved)
+	virtual void addToContainList( Object *obj ) override;		///< The part of AddToContain that inheritors can override (Can't do whole thing because of all the private stuff involved)
 	virtual void removeFromContain( Object *obj, Bool exposeStealthUnits = FALSE ) override;	///< remove 'obj' from contain list
 	virtual void removeAllContained( Bool exposeStealthUnits = FALSE ) override;				///< remove all objects on contain list
 	virtual Bool isEnclosingContainerFor( const Object *obj ) const override;	///< Does this type of Contain Visibly enclose its contents?

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/UpdateModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/UpdateModule.h
@@ -171,9 +171,6 @@ public:
 	// BehaviorModule
 	virtual UpdateModuleInterface* getUpdate() override { return this; }
 
-	// UpdateModuleInterface
-	virtual UpdateSleepTime update() = 0;
-
 	virtual DisabledMaskType getDisabledTypesToProcess() const override
 	{
 		return DISABLEDMASK_NONE;

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/UpgradeModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/UpgradeModule.h
@@ -120,7 +120,6 @@ protected:
 	virtual void getUpgradeActivationMasks(UpgradeMaskType& activation, UpgradeMaskType& conflicting) const = 0; ///< Here's the actual work of Upgrading
 	virtual void performUpgradeFX() = 0;	///< perform the associated fx list
 	virtual Bool requiresAllActivationUpgrades() const = 0;
-	virtual Bool isSubObjectsUpgrade() = 0;
 
 	void giveSelfUpgrade()
 	{

--- a/Generals/Code/GameEngine/Include/GameLogic/PartitionManager.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/PartitionManager.h
@@ -611,7 +611,7 @@ public:
 	PartitionFilterIsFlying() { }
 	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterIsFlying"; }
+	virtual const char* debugGetName() override { return "PartitionFilterIsFlying"; }
 #endif
 };
 
@@ -627,7 +627,7 @@ public:
 	PartitionFilterWouldCollide(const Coord3D& pos, const GeometryInfo& geom, Real angle, Bool desired);
 	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterWouldCollide"; }
+	virtual const char* debugGetName() override { return "PartitionFilterWouldCollide"; }
 #endif
 };
 
@@ -643,7 +643,7 @@ public:
 	PartitionFilterSamePlayer(const Player *player) : m_player(player) { }
 	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterSamePlayer"; }
+	virtual const char* debugGetName() override { return "PartitionFilterSamePlayer"; }
 #endif
 };
 
@@ -669,7 +669,7 @@ public:
 	PartitionFilterRelationship(const Object *obj, Int flags) : m_obj(obj), m_flags(flags) { }
 	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterRelationship"; }
+	virtual const char* debugGetName() override { return "PartitionFilterRelationship"; }
 #endif
 };
 
@@ -686,7 +686,7 @@ public:
 	PartitionFilterAcceptOnTeam(const Team *team);
 	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterAcceptOnTeam"; }
+	virtual const char* debugGetName() override { return "PartitionFilterAcceptOnTeam"; }
 #endif
 };
 
@@ -703,7 +703,7 @@ public:
 	PartitionFilterAcceptOnSquad(const Squad *squad);
 	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterAcceptOnSquad"; }
+	virtual const char* debugGetName() override { return "PartitionFilterAcceptOnSquad"; }
 #endif
 };
 
@@ -726,7 +726,7 @@ public:
 	PartitionFilterLineOfSight(const Object *obj);
 	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterLineOfSight"; }
+	virtual const char* debugGetName() override { return "PartitionFilterLineOfSight"; }
 #endif
 };
 
@@ -744,7 +744,7 @@ public:
 	PartitionFilterPossibleToAttack(AbleToAttackType t, const Object *obj, CommandSourceType commandSource);
 	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterPossibleToAttack"; }
+	virtual const char* debugGetName() override { return "PartitionFilterPossibleToAttack"; }
 #endif
 };
 
@@ -760,7 +760,7 @@ public:
 	PartitionFilterLastAttackedBy(Object *obj);
 	virtual Bool allow(Object *other) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterLastAttackedBy"; }
+	virtual const char* debugGetName() override { return "PartitionFilterLastAttackedBy"; }
 #endif
 };
 
@@ -776,7 +776,7 @@ public:
 	PartitionFilterAcceptByObjectStatus(ObjectStatusMaskType mustBeSet, ObjectStatusMaskType mustBeClear) : m_mustBeSet(mustBeSet), m_mustBeClear(mustBeClear) { }
 	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterAcceptByObjectStatus"; }
+	virtual const char* debugGetName() override { return "PartitionFilterAcceptByObjectStatus"; }
 #endif
 };
 
@@ -796,7 +796,7 @@ public:
 	}
 	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterRejectByObjectStatus"; }
+	virtual const char* debugGetName() override { return "PartitionFilterRejectByObjectStatus"; }
 #endif
 };
 
@@ -813,7 +813,7 @@ public:
 	PartitionFilterStealthedAndUndetected( const Object *obj, Bool allow ) { m_obj = obj; m_allow = allow; }
 	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterStealthedAndUndetected"; }
+	virtual const char* debugGetName() override { return "PartitionFilterStealthedAndUndetected"; }
 #endif
 };
 
@@ -829,7 +829,7 @@ public:
 	PartitionFilterAcceptByKindOf(const KindOfMaskType& mustBeSet, const KindOfMaskType& mustBeClear) : m_mustBeSet(mustBeSet), m_mustBeClear(mustBeClear) { }
 	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterAcceptByKindOf"; }
+	virtual const char* debugGetName() override { return "PartitionFilterAcceptByKindOf"; }
 #endif
 };
 
@@ -849,7 +849,7 @@ public:
 	}
 	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterRejectByKindOf"; }
+	virtual const char* debugGetName() override { return "PartitionFilterRejectByKindOf"; }
 #endif
 };
 
@@ -866,7 +866,7 @@ public:
 	PartitionFilterRejectBehind( Object *obj );
 	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterRejectBehind"; }
+	virtual const char* debugGetName() override { return "PartitionFilterRejectBehind"; }
 #endif
 };
 
@@ -881,7 +881,7 @@ public:
 protected:
 	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterAlive"; }
+	virtual const char* debugGetName() override { return "PartitionFilterAlive"; }
 #endif
 };
 
@@ -899,7 +899,7 @@ public:
 protected:
 	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterSameMapStatus"; }
+	virtual const char* debugGetName() override { return "PartitionFilterSameMapStatus"; }
 #endif
 };
 
@@ -914,7 +914,7 @@ public:
 protected:
 	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterOnMap"; }
+	virtual const char* debugGetName() override { return "PartitionFilterOnMap"; }
 #endif
 };
 
@@ -934,7 +934,7 @@ public:
 protected:
 	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterRejectBuildings"; }
+	virtual const char* debugGetName() override { return "PartitionFilterRejectBuildings"; }
 #endif
 };
 
@@ -954,7 +954,7 @@ public:
 protected:
 	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterInsignificantBuildings"; }
+	virtual const char* debugGetName() override { return "PartitionFilterInsignificantBuildings"; }
 #endif
 };
 
@@ -972,7 +972,7 @@ public:
 protected:
 	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterFreeOfFog"; }
+	virtual const char* debugGetName() override { return "PartitionFilterFreeOfFog"; }
 #endif
 };
 
@@ -989,7 +989,7 @@ public:
 protected:
 	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterRepulsor"; }
+	virtual const char* debugGetName() override { return "PartitionFilterRepulsor"; }
 #endif
 };
 
@@ -1010,7 +1010,7 @@ public:
 protected:
 	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterIrregularArea"; }
+	virtual const char* debugGetName() override { return "PartitionFilterIrregularArea"; }
 #endif
 };
 
@@ -1030,7 +1030,7 @@ public:
 protected:
 	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterPolygonTrigger"; }
+	virtual const char* debugGetName() override { return "PartitionFilterPolygonTrigger"; }
 #endif
 };
 
@@ -1050,7 +1050,7 @@ public:
 protected:
 	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterPlayer"; }
+	virtual const char* debugGetName() override { return "PartitionFilterPlayer"; }
 #endif
 };
 
@@ -1075,7 +1075,7 @@ public:
 protected:
 	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterPlayerAffiliation"; }
+	virtual const char* debugGetName() override { return "PartitionFilterPlayerAffiliation"; }
 #endif
 };
 
@@ -1097,7 +1097,7 @@ public:
 protected:
 	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterThing"; }
+	virtual const char* debugGetName() override { return "PartitionFilterThing"; }
 #endif
 };
 
@@ -1119,7 +1119,7 @@ public:
 protected:
 	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterGarrisonable"; }
+	virtual const char* debugGetName() override { return "PartitionFilterGarrisonable"; }
 #endif
 };
 
@@ -1142,7 +1142,7 @@ public:
 protected:
 	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterGarrisonableByPlayer"; }
+	virtual const char* debugGetName() override { return "PartitionFilterGarrisonableByPlayer"; }
 #endif
 };
 
@@ -1160,7 +1160,7 @@ public:
 protected:
 	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterUnmannedObject"; }
+	virtual const char* debugGetName() override { return "PartitionFilterUnmannedObject"; }
 #endif
 };
 
@@ -1182,7 +1182,7 @@ public:
 protected:
 	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterValidCommandButtonTarget"; }
+	virtual const char* debugGetName() override { return "PartitionFilterValidCommandButtonTarget"; }
 #endif
 };
 

--- a/Generals/Code/GameEngine/Include/GameLogic/ScriptActions.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/ScriptActions.h
@@ -48,10 +48,6 @@ public:
 
 	virtual ~ScriptActionsInterface() override { };
 
-	virtual void init() = 0;		///< Init
-	virtual void reset() = 0;		///< Reset
-	virtual void update() = 0;	///< Update
-
 	virtual void executeAction( ScriptAction *pAction ) = 0; ///< execute a script action.
 	virtual void closeWindows( Bool suppressNewWindows ) = 0;
 

--- a/Generals/Code/GameEngine/Include/GameLogic/ScriptConditions.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/ScriptConditions.h
@@ -45,10 +45,6 @@ public:
 
 	virtual ~ScriptConditionsInterface() override { };
 
-	virtual void init() = 0;		///< Init
-	virtual void reset() = 0;		///< Reset
-	virtual void update() = 0;	///< Update
-
 	virtual Bool evaluateCondition( Condition *pCondition ) = 0; ///< evaluate a a script condition.
 
 	virtual Bool evaluateSkirmishCommandButtonIsReady( Parameter *pSkirmishPlayerParm, Parameter *pTeamParm, Parameter *pCommandButtonParm, Bool allReady ) = 0;

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AI.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AI.cpp
@@ -531,7 +531,7 @@ public:
 	}
 
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterLiveMapEnemies"; }
+	virtual const char* debugGetName() override { return "PartitionFilterLiveMapEnemies"; }
 #endif
 };
 
@@ -561,7 +561,7 @@ public:
 	}
 
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterWithinAttackRange"; }
+	virtual const char* debugGetName() override { return "PartitionFilterWithinAttackRange"; }
 #endif
 };
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -132,7 +132,7 @@ public:
 	PartitionFilterHasParkingPlace(ObjectID id) : m_id(id) { }
 protected:
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterHasParkingPlace"; }
+	virtual const char* debugGetName() override { return "PartitionFilterHasParkingPlace"; }
 #endif
 	virtual Bool allow(Object *objOther) override
 	{

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/RailroadGuideAIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/RailroadGuideAIUpdate.cpp
@@ -863,7 +863,7 @@ public:
 	PartitionFilterIsValidCarriage(Object* obj, const RailroadBehaviorModuleData* data) : m_obj(obj), m_data(data) { }
 
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterIsValidCarriage"; }
+	virtual const char* debugGetName() override { return "PartitionFilterIsValidCarriage"; }
 #endif
 
 	virtual Bool allow(Object *objOther) override

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/FireSpreadUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/FireSpreadUpdate.cpp
@@ -52,7 +52,7 @@ public:
 
 	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterFlammable"; }
+	virtual const char* debugGetName() override { return "PartitionFilterFlammable"; }
 #endif
 };
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/HordeUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/HordeUpdate.cpp
@@ -75,7 +75,7 @@ public:
 	PartitionFilterHordeMember(Object* obj, const HordeUpdateModuleData* data) : m_obj(obj), m_data(data) { }
 
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterHordeMember"; }
+	virtual const char* debugGetName() override { return "PartitionFilterHordeMember"; }
 #endif
 
 	virtual Bool allow(Object *objOther) override

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/StealthDetectorUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/StealthDetectorUpdate.cpp
@@ -117,7 +117,7 @@ public:
 	virtual Bool allow(Object *objOther) override;
 
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterStealthedOrStealthGarrisoned"; }
+	virtual const char* debugGetName() override { return "PartitionFilterStealthedOrStealthGarrisoned"; }
 #endif
 };
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/TensileFormationUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/TensileFormationUpdate.cpp
@@ -72,7 +72,7 @@ private:
 public:
 	PartitionFilterTensileFormationMember( Object* obj ) : m_obj( obj ) { }
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterTensileFormationMember"; }
+	virtual const char* debugGetName() override { return "PartitionFilterTensileFormationMember"; }
 #endif
 	virtual Bool allow( Object *objOther ) override
 	{

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -69,7 +69,7 @@ public:
  	virtual void setGamma(Real gamma, Real bright, Real contrast, Bool calibrate) override;
 	virtual void doSmartAssetPurgeAndPreload(const char* usageFileName) override;
 #if defined(RTS_DEBUG)
-	virtual void dumpAssetUsage(const char* mapname);
+	virtual void dumpAssetUsage(const char* mapname) override;
 #endif
 
 	//---------------------------------------------------------------------------
@@ -133,7 +133,7 @@ public:
 	virtual void setShroudLevel(Int x, Int y, CellShroudStatus setting) override;
 	virtual void setBorderShroudLevel(UnsignedByte level) override;	///<color that will appear in unused border terrain.
 #if defined(RTS_DEBUG)
-	virtual void dumpModelAssets(const char *path);	///< dump all used models/textures to a file.
+	virtual void dumpModelAssets(const char *path) override;	///< dump all used models/textures to a file.
 #endif
 	virtual void preloadModelAssets( AsciiString model ) override;			///< preload model asset
 	virtual void preloadTextureAssets( AsciiString texture ) override;	///< preload texture asset

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DProjectedShadow.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DProjectedShadow.h
@@ -117,7 +117,7 @@ class W3DProjectedShadow	: public Shadow
 		void updateProjectionParameters(const Matrix3D &cameraXform);	///<recompute projection matrix - needed when light or object moves.
 		TexProjectClass *getShadowProjector()	{return m_shadowProjector;}
 		#if defined(RTS_DEBUG)
-		virtual void getRenderCost(RenderCost & rc) const;
+		virtual void getRenderCost(RenderCost & rc) const override;
 		#endif
 		W3DShadowTexture *getTexture(Int lightIndex) {return m_shadowTexture[lightIndex];}
 

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DVolumetricShadow.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DVolumetricShadow.h
@@ -105,7 +105,7 @@ class W3DVolumetricShadow	: public Shadow
 		virtual void release() override	{TheW3DVolumetricShadowManager->removeShadow(this);}	///<release shadow from manager
 
 		#if defined(RTS_DEBUG)
-		virtual void getRenderCost(RenderCost & rc) const;
+		virtual void getRenderCost(RenderCost & rc) const override;
 		#endif
 
 		// tie in geometry and transformation for this shadow

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/meshbuild.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/meshbuild.cpp
@@ -120,12 +120,12 @@ public:
 		HashVal = (int)(item.VertIdx[0]*12345.6f + item.VertIdx[1]*1714.38484f + item.VertIdx[2]*27561.3f)&1023;
 	}
 
-	virtual int		Num_Hash_Bits()
+	virtual int		Num_Hash_Bits() override
 	{
 		return 10;
 	}
 
-	virtual int		Num_Hash_Values()
+	virtual int		Num_Hash_Values() override
 	{
 		return 1;
 	}

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/scene.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/scene.h
@@ -220,7 +220,7 @@ public:
 	SimpleSceneClass();
 	virtual ~SimpleSceneClass() override;
 
-	virtual int	Get_Scene_ID()	{	return SCENE_ID_SIMPLE;	}
+	virtual int	Get_Scene_ID() const override {	return SCENE_ID_SIMPLE;	}
 
 	virtual void Add_Render_Object(RenderObjClass * obj) override;
 	virtual void Remove_Render_Object(RenderObjClass * obj) override;

--- a/Generals/Code/Tools/GUIEdit/Include/GUIEditDisplay.h
+++ b/Generals/Code/Tools/GUIEdit/Include/GUIEditDisplay.h
@@ -116,11 +116,11 @@ public:
 	virtual void toggleLetterBox(void) override {}
 	virtual void enableLetterBox(Bool enable) override {}
 #if defined(RTS_DEBUG)
-	virtual void dumpModelAssets(const char *path) {}
+	virtual void dumpModelAssets(const char *path) override {}
 #endif
 	virtual void doSmartAssetPurgeAndPreload(const char* usageFileName) override {}
 #if defined(RTS_DEBUG)
-	virtual void dumpAssetUsage(const char* mapname) {}
+	virtual void dumpAssetUsage(const char* mapname) override {}
 #endif
 
 	virtual Real getAverageFPS(void) override { return 0; }

--- a/Generals/Code/Tools/WorldBuilder/include/MainFrm.h
+++ b/Generals/Code/Tools/WorldBuilder/include/MainFrm.h
@@ -75,8 +75,8 @@ public:
 public:
 	virtual ~CMainFrame() override;
 #ifdef RTS_DEBUG
-	virtual void AssertValid() const;
-	virtual void Dump(CDumpContext& dc) const;
+	virtual void AssertValid() const override;
+	virtual void Dump(CDumpContext& dc) const override;
 #endif
 
 	static CMainFrame *GetMainFrame() { return TheMainFrame; }

--- a/Generals/Code/Tools/WorldBuilder/include/WorldBuilderDoc.h
+++ b/Generals/Code/Tools/WorldBuilder/include/WorldBuilderDoc.h
@@ -166,8 +166,8 @@ public:
 public:
 	virtual ~CWorldBuilderDoc() override;
 #ifdef RTS_DEBUG
-	virtual void AssertValid() const;
-	virtual void Dump(CDumpContext& dc) const;
+	virtual void AssertValid() const override;
+	virtual void Dump(CDumpContext& dc) const override;
 #endif
 	void AddAndDoUndoable(Undoable *pUndo);
 // Generated message map functions

--- a/Generals/Code/Tools/WorldBuilder/include/WorldBuilderView.h
+++ b/Generals/Code/Tools/WorldBuilder/include/WorldBuilderView.h
@@ -56,8 +56,8 @@ public:
 public:
 	virtual ~CWorldBuilderView() override;
 #ifdef RTS_DEBUG
-	virtual void AssertValid() const;
-	virtual void Dump(CDumpContext& dc) const;
+	virtual void AssertValid() const override;
+	virtual void Dump(CDumpContext& dc) const override;
 #endif
 
 protected:

--- a/Generals/Code/Tools/WorldBuilder/include/wbview.h
+++ b/Generals/Code/Tools/WorldBuilder/include/wbview.h
@@ -156,8 +156,8 @@ public:
 protected:
 	virtual ~WbView() override;
 #ifdef RTS_DEBUG
-	virtual void AssertValid() const;
-	virtual void Dump(CDumpContext& dc) const;
+	virtual void AssertValid() const override;
+	virtual void Dump(CDumpContext& dc) const override;
 #endif
 
 	// Generated message map functions

--- a/Generals/Code/Tools/WorldBuilder/include/wbview3d.h
+++ b/Generals/Code/Tools/WorldBuilder/include/wbview3d.h
@@ -82,8 +82,8 @@ public:
 protected:
 	virtual ~WbView3d() override;
 #ifdef RTS_DEBUG
-	virtual void AssertValid() const;
-	virtual void Dump(CDumpContext& dc) const;
+	virtual void AssertValid() const override;
+	virtual void Dump(CDumpContext& dc) const override;
 #endif
 
 	// Generated message map functions


### PR DESCRIPTION
* Follow up PR for https://github.com/TheSuperHackers/GeneralsGameCode/pull/2101

This PR adds the keyword `override` to a number of virtual functions in the Generals code that were missed in the previous round of refactoring.

Check out the commits as they separate different types of changes.

Related PRs:
https://github.com/TheSuperHackers/GeneralsGameCode/pull/2603
https://github.com/TheSuperHackers/GeneralsGameCode/pull/2605