### PR TITLE
refactor: Add override keyword to virtual function overrides in Zero Hour code (2)

### DIFF
--- a/GeneralsMD/Code/GameEngine/Include/Common/Module.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Module.h
@@ -136,20 +136,20 @@ private:
 #define MAKE_STANDARD_MODULE_MACRO( cls ) \
 public: \
 	static Module* friend_newModuleInstance( Thing *thing, const ModuleData* moduleData ) { return newInstance( cls )( thing, moduleData ); } \
-	virtual NameKeyType getModuleNameKey() const { static NameKeyType nk = NAMEKEY(#cls); return nk; } \
+	virtual NameKeyType getModuleNameKey() const override { static NameKeyType nk = NAMEKEY(#cls); return nk; } \
 protected: \
-	virtual void crc( Xfer *xfer ); \
-	virtual void xfer( Xfer *xfer ); \
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override; \
+	virtual void xfer( Xfer *xfer ) override; \
+	virtual void loadPostProcess() override;
 
 // ------------------------------------------------------------------------------------------------
 // For the creation of abstract module classes
 // ------------------------------------------------------------------------------------------------
 #define MAKE_STANDARD_MODULE_MACRO_ABC( cls ) \
 protected: \
-	virtual void crc( Xfer *xfer ); \
-	virtual void xfer( Xfer *xfer ); \
-	virtual void loadPostProcess();
+	virtual void crc( Xfer *xfer ) override; \
+	virtual void xfer( Xfer *xfer ) override; \
+	virtual void loadPostProcess() override;
 
 //-------------------------------------------------------------------------------------------------
 // only use this macro for an ABC. for a real class, use MAKE_STANDARD_MODULE_MACRO_WITH_MODULE_DATA.

--- a/GeneralsMD/Code/GameEngine/Include/Common/StateMachine.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/StateMachine.h
@@ -181,15 +181,6 @@ protected:
 	inline void setName(AsciiString n) { m_name = n; }
 #endif
 
-protected:
-	// snapshot interface	 - pure virtual here.
-	// Essentially all the member data gets set up on creation and shouldn't change.
-	// So none of it needs to be saved, and it nicely forces all user states to
-	// remember to implement crc, xfer & loadPostProcess.  jba
-	virtual void crc( Xfer *xfer )=0;
-	virtual void xfer( Xfer *xfer )=0;
-	virtual void loadPostProcess()=0;
-
 private:
 
 	struct TransitionInfo

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -470,7 +470,7 @@ public:  // ********************************************************************
 	virtual void disregardDrawable( Drawable *draw );				///< Drawable is being destroyed, clean up any UI elements associated with it
 
 	virtual void preDraw();														///< Logic which needs to occur before the UI renders
-	virtual void draw() = 0;													///< Render the in-game user interface
+	virtual void draw() override = 0;													///< Render the in-game user interface
 	virtual void postDraw();													///< Logic which needs to occur after the UI renders
 	virtual void postWindowDraw();											///< Logic which needs to occur after the WindowManager has repainted the menus
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AIGuardRetaliate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AIGuardRetaliate.h
@@ -239,7 +239,7 @@ public:
 	virtual StateReturnType update() override;
 	virtual void onExit( StateExitType status ) override;
 #ifdef STATE_MACHINE_DEBUG
-	virtual AsciiString getName() const ;
+	virtual AsciiString getName() const override;
 #endif
 protected:
 	// snapshot interface

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AIStateMachine.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AIStateMachine.h
@@ -163,7 +163,7 @@ public:
 public:	// overrides.
 	virtual StateReturnType updateStateMachine() override;				///< run one step of the machine
 #ifdef STATE_MACHINE_DEBUG
-	virtual AsciiString getCurrentStateName() const ;
+	virtual AsciiString getCurrentStateName() const override;
 #endif
 
 protected:
@@ -579,7 +579,7 @@ public:
 	virtual void onExit( StateExitType status ) override;
 	virtual StateReturnType update() override;
 #ifdef STATE_MACHINE_DEBUG
-	virtual AsciiString getName() const ;
+	virtual AsciiString getName() const override;
 #endif
 
 protected:
@@ -690,7 +690,7 @@ public:
 	virtual void onExit( StateExitType status ) override;
 	virtual StateReturnType update() override;
 #ifdef STATE_MACHINE_DEBUG
-	virtual AsciiString getName() const ;
+	virtual AsciiString getName() const override;
 #endif
 
 protected:
@@ -995,7 +995,7 @@ public:
 	virtual Bool isAttackingObject() const override { return m_isAttackingObject; }
 	virtual Bool isForceAttacking() const { return m_isForceAttacking; }
 #ifdef STATE_MACHINE_DEBUG
-	virtual AsciiString getName() const ;
+	virtual AsciiString getName() const override;
 #endif
 
 protected:
@@ -1033,7 +1033,7 @@ public:
 	virtual StateReturnType update() override;
 	Object *chooseVictim();
 #ifdef STATE_MACHINE_DEBUG
-	virtual AsciiString getName() const ;
+	virtual AsciiString getName() const override;
 #endif
 
 
@@ -1076,7 +1076,7 @@ public:
 	virtual void onExit( StateExitType status ) override;
 	virtual StateReturnType update() override;
 #ifdef STATE_MACHINE_DEBUG
-	virtual AsciiString getName() const ;
+	virtual AsciiString getName() const override;
 #endif
 
 protected:
@@ -1169,7 +1169,7 @@ public:
 	virtual void onExit( StateExitType status ) override;
 	virtual StateReturnType update() override;
 #ifdef STATE_MACHINE_DEBUG
-	virtual AsciiString getName() const ;
+	virtual AsciiString getName() const override;
 #endif
 protected:
 	// snapshot interface
@@ -1196,7 +1196,7 @@ public:
 	virtual void onExit( StateExitType status ) override;
 	virtual StateReturnType update() override;
 #ifdef STATE_MACHINE_DEBUG
-	virtual AsciiString getName() const ;
+	virtual AsciiString getName() const override;
 #endif
 protected:
 	// snapshot interface
@@ -1226,7 +1226,7 @@ public:
 	virtual void onExit( StateExitType status ) override;
 	virtual StateReturnType update() override;
 #ifdef STATE_MACHINE_DEBUG
-	virtual AsciiString getName() const ;
+	virtual AsciiString getName() const override;
 #endif
 protected:
 	// snapshot interface
@@ -1256,7 +1256,7 @@ public:
 	virtual void onExit( StateExitType status ) override;
 	virtual StateReturnType update() override;
 #ifdef STATE_MACHINE_DEBUG
-	virtual AsciiString getName() const ;
+	virtual AsciiString getName() const override;
 #endif
 
 protected:
@@ -1287,7 +1287,7 @@ public:
 	virtual void onExit( StateExitType status ) override;
 	virtual StateReturnType update() override;
 #ifdef STATE_MACHINE_DEBUG
-	virtual AsciiString getName() const ;
+	virtual AsciiString getName() const override;
 #endif
 
 protected:

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BodyModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/BodyModule.h
@@ -217,30 +217,6 @@ public:
 	// BehaviorModule
 	virtual BodyModuleInterface* getBody() override { return this; }
 
-	/**
-		Try to damage this Object. The module's Armor
-		will be taken into account, so the actual damage done may vary
-		considerably from what you requested. Also note that (if damage is done)
-		the DamageFX will be invoked to provide a/v fx as appropriate.
-	*/
-	virtual void attemptDamage( DamageInfo *damageInfo ) = 0;
-
-	/**
-		Instead of having negative damage count as healing, or allowing access to the private
-		changeHealth Method, we will use this parallel to attemptDamage to do healing without hack.
-	*/
-	virtual void attemptHealing( DamageInfo *healingInfo ) = 0;
-
-	/**
-		Estimate the (unclipped) damage that would be done to this object
-		by the given damage (taking bonuses, armor, etc into account),
-		but DO NOT alter the body in any way. (This is used by the AI system
-		to choose weapons.)
-	*/
-	virtual Real estimateDamage( DamageInfoInput& damageInfo ) const = 0;
-
-	virtual Real getHealth() const = 0;													///< get current health
-
 	virtual Real getMaxHealth() const override {return 0.0f;}  ///< return max health
 	virtual Real getPreviousHealth() const override { return 0.0f; } ///< return previous health
 
@@ -250,16 +226,6 @@ public:
 	virtual Real getCurrentSubdualDamageAmount() const override { return 0.0f; }
 
 	virtual Real getInitialHealth() const override {return 0.0f;}  // return initial health
-
-	virtual BodyDamageType getDamageState() const = 0;
-	virtual void setDamageState( BodyDamageType newState ) = 0;	///< control damage state directly.  Will adjust hitpoints.
-	virtual void setAflame( Bool setting ) = 0;///< This is a major change like a damage state.
-
-	virtual void onVeterancyLevelChanged( VeterancyLevel oldLevel, VeterancyLevel newLevel, Bool provideFeedback = FALSE ) = 0;	///< I just achieved this level right this moment
-
-	virtual void setArmorSetFlag(ArmorSetType ast) = 0;
-	virtual void clearArmorSetFlag(ArmorSetType ast) = 0;
-	virtual Bool testArmorSetFlag(ArmorSetType ast) = 0;
 
 	virtual const DamageInfo *getLastDamageInfo() const override { return nullptr; }	///< return info on last damage dealt to this object
 	virtual UnsignedInt getLastDamageTimestamp() const override { return 0; }	///< return frame of last damage dealt
@@ -282,15 +248,6 @@ public:
 	//Allows outside systems to apply defensive bonuses or penalties (they all stack as a multiplier!)
 	virtual void applyDamageScalar( Real scalar ) override { m_damageScalar *= scalar; }
 	virtual Real getDamageScalar() const override { return m_damageScalar; }
-
-	/**
-		Change the module's health by the given delta. Note that
-		the module's DamageFX and Armor are NOT taken into
-		account, so you should think about what you're bypassing when you
-		call this directly (especially when when decreasing health, since
-		you probably want "attemptDamage" or "attemptHealing")
-	*/
-	virtual void internalChangeHealth( Real delta ) = 0;
 
 	virtual void evaluateVisualCondition() override { }
 	virtual void updateBodyParticleSystems() override { };// made public for topple anf building collapse updates -ML

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CollideModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CollideModule.h
@@ -85,8 +85,6 @@ public:
 	// BehaviorModule
 	virtual CollideModuleInterface* getCollide() override { return this; }
 
-	virtual void onCollide( Object *other, const Coord3D *loc, const Coord3D *normal ) = 0;
-
 	/// this is used for things like pilots, to determine if they can "enter" something
 	virtual Bool wouldLikeToCollideWith(const Object* other) const override { return false; }
 	virtual Bool isHijackedVehicleCrateCollide() const override { return false; }

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CreateModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/CreateModule.h
@@ -73,7 +73,6 @@ public:
 	// BehaviorModule
 	virtual CreateModuleInterface* getCreate() override { return this; }
 
-	virtual void onCreate() = 0;				///< This is called when you become a code Object
 	virtual void onBuildComplete() override { m_needToRunOnBuildComplete = FALSE; }	///< This is called when you are a finished game object
 	virtual Bool shouldDoOnBuildComplete() const override { return m_needToRunOnBuildComplete; }
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DamageModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DamageModule.h
@@ -97,13 +97,6 @@ public:
 	// BehaviorModule
 	virtual DamageModuleInterface* getDamage() override { return this; }
 
-	// damage module callbacks
-	virtual void onDamage( DamageInfo *damageInfo ) = 0;	///< damage callback
-	virtual void onHealing( DamageInfo *damageInfo ) = 0;	///< healing callback
-	virtual void onBodyDamageStateChange( const DamageInfo* damageInfo,
-																				BodyDamageType oldState,
-																				BodyDamageType newState) = 0;  ///< state change callback
-
 protected:
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DestroyModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DestroyModule.h
@@ -58,8 +58,6 @@ public:
 	// BehaviorModule
 	virtual DestroyModuleInterface* getDestroy() override { return this; }
 
-	virtual void onDestroy() = 0;
-
 protected:
 
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DieModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/DieModule.h
@@ -97,8 +97,6 @@ public:
 	// BehaviorModule
 	virtual DieModuleInterface* getDie() override { return this; }
 
-	virtual void onDie( const DamageInfo *damageInfo ) = 0;
-
 protected:
 	Bool isDieApplicable(const DamageInfo *damageInfo) const { return getDieModuleData()->isDieApplicable(getObject(), damageInfo); }
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/FlightDeckBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/FlightDeckBehavior.h
@@ -150,8 +150,8 @@ public:
 	// AIUpdateInterface
 	virtual void aiDoCommand(const AICommandParms* parms) override;
 
-	virtual const std::vector<Coord3D>* getTaxiLocations( ObjectID id ) const;
-	virtual const std::vector<Coord3D>* getCreationLocations( ObjectID id ) const;
+	virtual const std::vector<Coord3D>* getTaxiLocations( ObjectID id ) const override;
+	virtual const std::vector<Coord3D>* getCreationLocations( ObjectID id ) const override;
 
 private:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/FlightDeckBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/FlightDeckBehavior.h
@@ -116,7 +116,7 @@ public:
 	virtual void unreserveDoorForExit( ExitDoorType exitDoor ) override;
 	virtual void exitObjectByBudding( Object *newObj, Object *budHost ) override { return; }
 	virtual Bool getExitPosition( Coord3D& rallyPoint ) const override { return FALSE; }
-	virtual Bool getNaturalRallyPoint( Coord3D& rallyPoint, Bool offset = TRUE ) { return FALSE; }
+	virtual Bool getNaturalRallyPoint( Coord3D& rallyPoint, Bool offset = TRUE ) const override { return FALSE; }
 	virtual void setRallyPoint( const Coord3D *pos ) override {}
 	virtual const Coord3D *getRallyPoint() const override { return nullptr;}
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/HelixContain.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/HelixContain.h
@@ -91,7 +91,7 @@ public:
 
 	virtual Bool isValidContainerFor(const Object* obj, Bool checkCapacity) const override;
 	virtual void addToContain( Object *obj ) override;				///< add 'obj' to contain list
-	virtual void addToContainList( Object *obj );		///< The part of AddToContain that inheritors can override (Can't do whole thing because of all the private stuff involved)
+	virtual void addToContainList( Object *obj ) override;		///< The part of AddToContain that inheritors can override (Can't do whole thing because of all the private stuff involved)
 	virtual void removeFromContain( Object *obj, Bool exposeStealthUnits = FALSE ) override;	///< remove 'obj' from contain list
 	//virtual void removeAllContained( Bool exposeStealthUnits = FALSE );				///< remove all objects on contain list
 	virtual Bool isEnclosingContainerFor( const Object *obj ) const override;	///< Does this type of Contain Visibly enclose its contents?

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/JetAIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/JetAIUpdate.h
@@ -131,7 +131,7 @@ protected:
 
 	virtual AIStateMachine* makeStateMachine() override;
 
-	virtual void privateFollowPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource, Bool exitProduction );///< follow the path defined by the given array of points
+	virtual void privateFollowPath( std::vector<Coord3D>* path, Object *ignoreObject, CommandSourceType cmdSource, Bool exitProduction ) override;///< follow the path defined by the given array of points
 	virtual void privateFollowPathAppend( const Coord3D *pos, CommandSourceType cmdSource ) override;
 	virtual void privateEnter( Object *obj, CommandSourceType cmdSource ) override;							///< enter the given object
 	virtual void privateGetRepaired( Object *repairDepot, CommandSourceType cmdSource ) override;///< get repaired at repair depot

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ObjectHelper.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ObjectHelper.h
@@ -54,9 +54,6 @@ public:
 		setWakeFrame(getObject(), UPDATE_SLEEP_FOREVER);
 	}
 
-	// inherited from UpdateModuleInterface
-	virtual UpdateSleepTime update() = 0;
-
 	// custom to this class.
 	void sleepUntil(UnsignedInt when);
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OpenContain.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OpenContain.h
@@ -152,7 +152,7 @@ public:
 	// default OpenContain has unlimited capacity...!
 	virtual Bool isValidContainerFor(const Object* obj, Bool checkCapacity) const override;
 	virtual void addToContain( Object *obj ) override;				///< add 'obj' to contain list
-	virtual void addToContainList( Object *obj );		///< The part of AddToContain that inheritors can override (Can't do whole thing because of all the private stuff involved)
+	virtual void addToContainList( Object *obj ) override;		///< The part of AddToContain that inheritors can override (Can't do whole thing because of all the private stuff involved)
 	virtual void removeFromContain( Object *obj, Bool exposeStealthUnits = FALSE ) override;	///< remove 'obj' from contain list
 	virtual void removeAllContained( Bool exposeStealthUnits = FALSE ) override;				///< remove all objects on contain list
 	virtual void killAllContained() override;				///< kill all objects on contain list

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OverlordContain.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OverlordContain.h
@@ -69,7 +69,7 @@ public:
 
 	virtual OpenContain *asOpenContain() override { return this; }  ///< treat as open container
 	virtual Bool isGarrisonable() const override;	///< can this unit be Garrisoned? (ick)
-  virtual Bool isBustable() { return false;};	///< can this container get busted by bunkerbuster? (ick)
+  virtual Bool isBustable() const override { return false;};	///< can this container get busted by bunkerbuster? (ick)
 	virtual Bool isHealContain() const override { return false; } ///< true when container only contains units while healing (not a transport!)
 	virtual Bool isTunnelContain() const override { return FALSE; }
 	virtual Bool isImmuneToClearBuildingAttacks() const override { return true; }

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OverlordContain.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OverlordContain.h
@@ -88,7 +88,7 @@ public:
 
 	virtual Bool isValidContainerFor(const Object* obj, Bool checkCapacity) const override;
 	virtual void addToContain( Object *obj ) override;				///< add 'obj' to contain list
-	virtual void addToContainList( Object *obj );		///< The part of AddToContain that inheritors can override (Can't do whole thing because of all the private stuff involved)
+	virtual void addToContainList( Object *obj ) override;		///< The part of AddToContain that inheritors can override (Can't do whole thing because of all the private stuff involved)
 	virtual void removeFromContain( Object *obj, Bool exposeStealthUnits = FALSE ) override;	///< remove 'obj' from contain list
 	virtual void removeAllContained( Bool exposeStealthUnits = FALSE ) override;				///< remove all objects on contain list
 	virtual Bool isEnclosingContainerFor( const Object *obj ) const override;	///< Does this type of Contain Visibly enclose its contents?

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ParkingPlaceBehavior.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/ParkingPlaceBehavior.h
@@ -149,8 +149,8 @@ public:
 	virtual void killAllParkedUnits() override;
 	virtual void defectAllParkedUnits(Team* newTeam, UnsignedInt detectionTime) override;
 	virtual Bool calcBestParkingAssignment( ObjectID id, Coord3D *pos, Int *oldIndex = nullptr, Int *newIndex = nullptr ) override { return FALSE; }
-	virtual const std::vector<Coord3D>* getTaxiLocations( ObjectID id ) const { return nullptr; }
-	virtual const std::vector<Coord3D>* getCreationLocations( ObjectID id ) const { return nullptr; }
+	virtual const std::vector<Coord3D>* getTaxiLocations( ObjectID id ) const override { return nullptr; }
+	virtual const std::vector<Coord3D>* getCreationLocations( ObjectID id ) const override { return nullptr; }
 
 private:
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SpecialPowerUpdateModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/SpecialPowerUpdateModule.h
@@ -66,15 +66,4 @@ public:
 	virtual Bool doesSpecialPowerUpdatePassScienceTest() const override;
 	virtual ScienceType getExtraRequiredScience() const override { return SCIENCE_INVALID; } //Does this object have more than one special power module with the same spTemplate?
 
-	//SpecialPowerUpdateInterface PURE virtual implementations
-	virtual Bool initiateIntentToDoSpecialPower(const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions ) = 0;
-	virtual Bool isSpecialAbility() const = 0;
-	virtual Bool isSpecialPower() const = 0;
-	virtual Bool isActive() const = 0;
-	virtual CommandOption getCommandOption() const = 0;
-	virtual Bool doesSpecialPowerHaveOverridableDestinationActive() const = 0; //Is it active now?
-	virtual Bool doesSpecialPowerHaveOverridableDestination() const = 0;	//Does it have it, even if it's not active?
-	virtual void setSpecialPowerOverridableDestination( const Coord3D *loc ) = 0;
-	virtual Bool isPowerCurrentlyInUse( const CommandButton *command = nullptr ) const = 0;
-
 };

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/TunnelContain.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/TunnelContain.h
@@ -103,7 +103,7 @@ public:
 	virtual void orderAllPassengersToIdle( CommandSourceType commandSource ) override; ///< Just like it sounds
 
 	virtual Bool isValidContainerFor(const Object* obj, Bool checkCapacity) const override;
-	virtual void addToContainList( Object *obj );		///< The part of AddToContain that inheritors can override (Can't do whole thing because of all the private stuff involved)
+	virtual void addToContainList( Object *obj ) override;		///< The part of AddToContain that inheritors can override (Can't do whole thing because of all the private stuff involved)
 	virtual void removeFromContain( Object *obj, Bool exposeStealthUnits = FALSE ) override;	///< remove 'obj' from contain list
 	virtual void removeAllContained( Bool exposeStealthUnits = FALSE ) override;				///< remove all objects on contain list
   virtual void harmAndForceExitAllContained( DamageInfo *info ) override;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/UpdateModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/UpdateModule.h
@@ -169,9 +169,6 @@ public:
 	// BehaviorModule
 	virtual UpdateModuleInterface* getUpdate() override { return this; }
 
-	// UpdateModuleInterface
-	virtual UpdateSleepTime update() = 0;
-
 	virtual DisabledMaskType getDisabledTypesToProcess() const override
 	{
 		return DISABLEDMASK_NONE;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/UpgradeModule.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/UpgradeModule.h
@@ -131,7 +131,6 @@ protected:
 	virtual void getUpgradeActivationMasks(UpgradeMaskType& activation, UpgradeMaskType& conflicting) const = 0; ///< Here's the actual work of Upgrading
 	virtual void performUpgradeFX() = 0;	///< perform the associated fx list
 	virtual Bool requiresAllActivationUpgrades() const = 0;
-	virtual Bool isSubObjectsUpgrade() = 0;
 	virtual void processUpgradeRemoval() = 0;
 
 	void giveSelfUpgrade();

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/PartitionManager.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/PartitionManager.h
@@ -612,7 +612,7 @@ public:
 	PartitionFilterIsFlying() { }
 	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterIsFlying"; }
+	virtual const char* debugGetName() override { return "PartitionFilterIsFlying"; }
 #endif
 };
 
@@ -628,7 +628,7 @@ public:
 	PartitionFilterWouldCollide(const Coord3D& pos, const GeometryInfo& geom, Real angle, Bool desired);
 	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterWouldCollide"; }
+	virtual const char* debugGetName() override { return "PartitionFilterWouldCollide"; }
 #endif
 };
 
@@ -644,7 +644,7 @@ public:
 	PartitionFilterSamePlayer(const Player *player) : m_player(player) { }
 	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterSamePlayer"; }
+	virtual const char* debugGetName() override { return "PartitionFilterSamePlayer"; }
 #endif
 };
 
@@ -670,7 +670,7 @@ public:
 	PartitionFilterRelationship(const Object *obj, Int flags) : m_obj(obj), m_flags(flags) { }
 	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterRelationship"; }
+	virtual const char* debugGetName() override { return "PartitionFilterRelationship"; }
 #endif
 };
 
@@ -687,7 +687,7 @@ public:
 	PartitionFilterAcceptOnTeam(const Team *team);
 	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterAcceptOnTeam"; }
+	virtual const char* debugGetName() override { return "PartitionFilterAcceptOnTeam"; }
 #endif
 };
 
@@ -704,7 +704,7 @@ public:
 	PartitionFilterAcceptOnSquad(const Squad *squad);
 	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterAcceptOnSquad"; }
+	virtual const char* debugGetName() override { return "PartitionFilterAcceptOnSquad"; }
 #endif
 };
 
@@ -727,7 +727,7 @@ public:
 	PartitionFilterLineOfSight(const Object *obj);
 	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterLineOfSight"; }
+	virtual const char* debugGetName() override { return "PartitionFilterLineOfSight"; }
 #endif
 };
 
@@ -745,7 +745,7 @@ public:
 	PartitionFilterPossibleToAttack(AbleToAttackType t, const Object *obj, CommandSourceType commandSource);
 	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterPossibleToAttack"; }
+	virtual const char* debugGetName() override { return "PartitionFilterPossibleToAttack"; }
 #endif
 };
 
@@ -763,7 +763,7 @@ public:
 	PartitionFilterPossibleToEnter(const Object *obj, CommandSourceType commandSource);
 	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterPossibleToEnter"; }
+	virtual const char* debugGetName() override { return "PartitionFilterPossibleToEnter"; }
 #endif
 };
 
@@ -781,7 +781,7 @@ public:
 	PartitionFilterPossibleToHijack(const Object *obj, CommandSourceType commandSource);
 	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterPossibleToHijack"; }
+	virtual const char* debugGetName() override { return "PartitionFilterPossibleToHijack"; }
 #endif
 };
 
@@ -797,7 +797,7 @@ public:
 	PartitionFilterLastAttackedBy(Object *obj);
 	virtual Bool allow(Object *other) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterLastAttackedBy"; }
+	virtual const char* debugGetName() override { return "PartitionFilterLastAttackedBy"; }
 #endif
 };
 
@@ -813,7 +813,7 @@ public:
 	PartitionFilterAcceptByObjectStatus( ObjectStatusMaskType mustBeSet, ObjectStatusMaskType mustBeClear) : m_mustBeSet(mustBeSet), m_mustBeClear(mustBeClear) { }
 	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterAcceptByObjectStatus"; }
+	virtual const char* debugGetName() override { return "PartitionFilterAcceptByObjectStatus"; }
 #endif
 };
 
@@ -833,7 +833,7 @@ public:
 	}
 	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterRejectByObjectStatus"; }
+	virtual const char* debugGetName() override { return "PartitionFilterRejectByObjectStatus"; }
 #endif
 };
 
@@ -850,7 +850,7 @@ public:
 	PartitionFilterStealthedAndUndetected( const Object *obj, Bool allow ) { m_obj = obj; m_allow = allow; }
 	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterStealthedAndUndetected"; }
+	virtual const char* debugGetName() override { return "PartitionFilterStealthedAndUndetected"; }
 #endif
 };
 
@@ -866,7 +866,7 @@ public:
 	PartitionFilterAcceptByKindOf(const KindOfMaskType& mustBeSet, const KindOfMaskType& mustBeClear) : m_mustBeSet(mustBeSet), m_mustBeClear(mustBeClear) { }
 	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterAcceptByKindOf"; }
+	virtual const char* debugGetName() override { return "PartitionFilterAcceptByKindOf"; }
 #endif
 };
 
@@ -886,7 +886,7 @@ public:
 	}
 	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterRejectByKindOf"; }
+	virtual const char* debugGetName() override { return "PartitionFilterRejectByKindOf"; }
 #endif
 };
 
@@ -903,7 +903,7 @@ public:
 	PartitionFilterRejectBehind( Object *obj );
 	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterRejectBehind"; }
+	virtual const char* debugGetName() override { return "PartitionFilterRejectBehind"; }
 #endif
 };
 
@@ -918,7 +918,7 @@ public:
 protected:
 	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterAlive"; }
+	virtual const char* debugGetName() override { return "PartitionFilterAlive"; }
 #endif
 };
 
@@ -936,7 +936,7 @@ public:
 protected:
 	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterSameMapStatus"; }
+	virtual const char* debugGetName() override { return "PartitionFilterSameMapStatus"; }
 #endif
 };
 
@@ -951,7 +951,7 @@ public:
 protected:
 	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterOnMap"; }
+	virtual const char* debugGetName() override { return "PartitionFilterOnMap"; }
 #endif
 };
 
@@ -971,7 +971,7 @@ public:
 protected:
 	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterRejectBuildings"; }
+	virtual const char* debugGetName() override { return "PartitionFilterRejectBuildings"; }
 #endif
 };
 
@@ -991,7 +991,7 @@ public:
 protected:
 	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterInsignificantBuildings"; }
+	virtual const char* debugGetName() override { return "PartitionFilterInsignificantBuildings"; }
 #endif
 };
 
@@ -1009,7 +1009,7 @@ public:
 protected:
 	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterFreeOfFog"; }
+	virtual const char* debugGetName() override { return "PartitionFilterFreeOfFog"; }
 #endif
 };
 
@@ -1026,7 +1026,7 @@ public:
 protected:
 	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterRepulsor"; }
+	virtual const char* debugGetName() override { return "PartitionFilterRepulsor"; }
 #endif
 };
 
@@ -1047,7 +1047,7 @@ public:
 protected:
 	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterIrregularArea"; }
+	virtual const char* debugGetName() override { return "PartitionFilterIrregularArea"; }
 #endif
 };
 
@@ -1067,7 +1067,7 @@ public:
 protected:
 	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterPolygonTrigger"; }
+	virtual const char* debugGetName() override { return "PartitionFilterPolygonTrigger"; }
 #endif
 };
 
@@ -1087,7 +1087,7 @@ public:
 protected:
 	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterPlayer"; }
+	virtual const char* debugGetName() override { return "PartitionFilterPlayer"; }
 #endif
 };
 
@@ -1112,7 +1112,7 @@ public:
 protected:
 	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterPlayerAffiliation"; }
+	virtual const char* debugGetName() override { return "PartitionFilterPlayerAffiliation"; }
 #endif
 };
 
@@ -1134,7 +1134,7 @@ public:
 protected:
 	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterThing"; }
+	virtual const char* debugGetName() override { return "PartitionFilterThing"; }
 #endif
 };
 
@@ -1156,7 +1156,7 @@ public:
 protected:
 	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterGarrisonable"; }
+	virtual const char* debugGetName() override { return "PartitionFilterGarrisonable"; }
 #endif
 };
 
@@ -1179,7 +1179,7 @@ public:
 protected:
 	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterGarrisonableByPlayer"; }
+	virtual const char* debugGetName() override { return "PartitionFilterGarrisonableByPlayer"; }
 #endif
 };
 
@@ -1197,7 +1197,7 @@ public:
 protected:
 	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterUnmannedObject"; }
+	virtual const char* debugGetName() override { return "PartitionFilterUnmannedObject"; }
 #endif
 };
 
@@ -1219,7 +1219,7 @@ public:
 protected:
 	virtual Bool allow( Object *other ) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterValidCommandButtonTarget"; }
+	virtual const char* debugGetName() override { return "PartitionFilterValidCommandButtonTarget"; }
 #endif
 };
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/ScriptActions.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/ScriptActions.h
@@ -48,10 +48,6 @@ public:
 
 	virtual ~ScriptActionsInterface() override { };
 
-	virtual void init() = 0;		///< Init
-	virtual void reset() = 0;		///< Reset
-	virtual void update() = 0;	///< Update
-
 	virtual void executeAction( ScriptAction *pAction ) = 0; ///< execute a script action.
 	virtual void closeWindows( Bool suppressNewWindows ) = 0;
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/ScriptActions.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/ScriptActions.h
@@ -46,7 +46,7 @@ class ScriptActionsInterface : public SubsystemInterface
 
 public:
 
-	virtual ~ScriptActionsInterface() { };
+	virtual ~ScriptActionsInterface() override { };
 
 	virtual void executeAction( ScriptAction *pAction ) = 0; ///< execute a script action.
 	virtual void closeWindows( Bool suppressNewWindows ) = 0;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/ScriptActions.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/ScriptActions.h
@@ -46,7 +46,7 @@ class ScriptActionsInterface : public SubsystemInterface
 
 public:
 
-	virtual ~ScriptActionsInterface() override { };
+	virtual ~ScriptActionsInterface() { };
 
 	virtual void executeAction( ScriptAction *pAction ) = 0; ///< execute a script action.
 	virtual void closeWindows( Bool suppressNewWindows ) = 0;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/ScriptConditions.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/ScriptConditions.h
@@ -45,10 +45,6 @@ public:
 
 	virtual ~ScriptConditionsInterface() override { };
 
-	virtual void init() = 0;		///< Init
-	virtual void reset() = 0;		///< Reset
-	virtual void update() = 0;	///< Update
-
 	virtual Bool evaluateCondition( Condition *pCondition ) = 0; ///< evaluate a a script condition.
 
 	virtual Bool evaluateSkirmishCommandButtonIsReady( Parameter *pSkirmishPlayerParm, Parameter *pTeamParm, Parameter *pCommandButtonParm, Bool allReady ) = 0;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AI.cpp
@@ -534,7 +534,7 @@ public:
 	}
 
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterLiveMapEnemies"; }
+	virtual const char* debugGetName() override { return "PartitionFilterLiveMapEnemies"; }
 #endif
 };
 
@@ -564,7 +564,7 @@ public:
 	}
 
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterWithinAttackRange"; }
+	virtual const char* debugGetName() override { return "PartitionFilterWithinAttackRange"; }
 #endif
 };
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/JetAIUpdate.cpp
@@ -150,7 +150,7 @@ public:
 	PartitionFilterHasParkingPlace(ObjectID id) : m_id(id) { }
 protected:
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterHasParkingPlace"; }
+	virtual const char* debugGetName() override { return "PartitionFilterHasParkingPlace"; }
 #endif
 	virtual Bool allow(Object *objOther) override
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/RailroadGuideAIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate/RailroadGuideAIUpdate.cpp
@@ -903,7 +903,7 @@ public:
 	PartitionFilterIsValidCarriage(Object* obj, const RailroadBehaviorModuleData* data) : m_obj(obj), m_data(data) { }
 
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterIsValidCarriage"; }
+	virtual const char* debugGetName() override { return "PartitionFilterIsValidCarriage"; }
 #endif
 
 	virtual Bool allow(Object *objOther) override

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/FireSpreadUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/FireSpreadUpdate.cpp
@@ -52,7 +52,7 @@ public:
 
 	virtual Bool allow(Object *objOther) override;
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterFlammable"; }
+	virtual const char* debugGetName() override { return "PartitionFilterFlammable"; }
 #endif
 };
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/HordeUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/HordeUpdate.cpp
@@ -75,7 +75,7 @@ public:
 	PartitionFilterHordeMember(Object* obj, const HordeUpdateModuleData* data) : m_obj(obj), m_data(data) { }
 
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterHordeMember"; }
+	virtual const char* debugGetName() override { return "PartitionFilterHordeMember"; }
 #endif
 
 	virtual Bool allow(Object *objOther) override

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpectreGunshipUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpectreGunshipUpdate.cpp
@@ -340,7 +340,7 @@ public:
 	}
 
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterLiveMapEnemies"; }
+	virtual const char* debugGetName() override { return "PartitionFilterLiveMapEnemies"; }
 #endif
 };
 //-----------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/StealthDetectorUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/StealthDetectorUpdate.cpp
@@ -118,7 +118,7 @@ public:
 	virtual Bool allow(Object *objOther) override;
 
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterStealthedOrStealthGarrisoned"; }
+	virtual const char* debugGetName() override { return "PartitionFilterStealthedOrStealthGarrisoned"; }
 #endif
 };
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/TensileFormationUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/TensileFormationUpdate.cpp
@@ -72,7 +72,7 @@ private:
 public:
 	PartitionFilterTensileFormationMember( Object* obj ) : m_obj( obj ) { }
 #if defined(RTS_DEBUG)
-	virtual const char* debugGetName() { return "PartitionFilterTensileFormationMember"; }
+	virtual const char* debugGetName() override { return "PartitionFilterTensileFormationMember"; }
 #endif
 	virtual Bool allow( Object *objOther ) override
 	{

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -69,7 +69,7 @@ public:
  	virtual void setGamma(Real gamma, Real bright, Real contrast, Bool calibrate) override;
 	virtual void doSmartAssetPurgeAndPreload(const char* usageFileName) override;
 #if defined(RTS_DEBUG)
-	virtual void dumpAssetUsage(const char* mapname);
+	virtual void dumpAssetUsage(const char* mapname) override;
 #endif
 
 	//---------------------------------------------------------------------------
@@ -133,7 +133,7 @@ public:
 	virtual void setShroudLevel(Int x, Int y, CellShroudStatus setting) override;
 	virtual void setBorderShroudLevel(UnsignedByte level) override;	///<color that will appear in unused border terrain.
 #if defined(RTS_DEBUG)
-	virtual void dumpModelAssets(const char *path);	///< dump all used models/textures to a file.
+	virtual void dumpModelAssets(const char *path) override;	///< dump all used models/textures to a file.
 #endif
 	virtual void preloadModelAssets( AsciiString model ) override;			///< preload model asset
 	virtual void preloadTextureAssets( AsciiString texture ) override;	///< preload texture asset

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DProjectedShadow.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DProjectedShadow.h
@@ -117,7 +117,7 @@ class W3DProjectedShadow	: public Shadow
 		void updateProjectionParameters(const Matrix3D &cameraXform);	///<recompute projection matrix - needed when light or object moves.
 		TexProjectClass *getShadowProjector()	{return m_shadowProjector;}
 		#if defined(RTS_DEBUG)
-		virtual void getRenderCost(RenderCost & rc) const;
+		virtual void getRenderCost(RenderCost & rc) const override;
 		#endif
 		W3DShadowTexture *getTexture(Int lightIndex) {return m_shadowTexture[lightIndex];}
 

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DVolumetricShadow.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DVolumetricShadow.h
@@ -105,7 +105,7 @@ class W3DVolumetricShadow	: public Shadow
 		virtual void release() override	{TheW3DVolumetricShadowManager->removeShadow(this);}	///<release shadow from manager
 
 		#if defined(RTS_DEBUG)
-		virtual void getRenderCost(RenderCost & rc) const;
+		virtual void getRenderCost(RenderCost & rc) const override;
 		#endif
 
 		// tie in geometry and transformation for this shadow

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshbuild.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshbuild.cpp
@@ -120,12 +120,12 @@ public:
 		HashVal = (int)(item.VertIdx[0]*12345.6f + item.VertIdx[1]*1714.38484f + item.VertIdx[2]*27561.3f)&1023;
 	}
 
-	virtual int		Num_Hash_Bits()
+	virtual int		Num_Hash_Bits() override
 	{
 		return 10;
 	}
 
-	virtual int		Num_Hash_Values()
+	virtual int		Num_Hash_Values() override
 	{
 		return 1;
 	}

--- a/GeneralsMD/Code/Tools/GUIEdit/Include/GUIEditDisplay.h
+++ b/GeneralsMD/Code/Tools/GUIEdit/Include/GUIEditDisplay.h
@@ -116,11 +116,11 @@ public:
 	virtual void toggleLetterBox(void) override {}
 	virtual void enableLetterBox(Bool enable) override {}
 #if defined(RTS_DEBUG)
-	virtual void dumpModelAssets(const char *path) {}
+	virtual void dumpModelAssets(const char *path) override {}
 #endif
 	virtual void doSmartAssetPurgeAndPreload(const char* usageFileName) override {}
 #if defined(RTS_DEBUG)
-	virtual void dumpAssetUsage(const char* mapname) {}
+	virtual void dumpAssetUsage(const char* mapname) override {}
 #endif
 
 	virtual Real getAverageFPS(void) override { return 0; }

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/MainFrm.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/MainFrm.h
@@ -76,8 +76,8 @@ public:
 public:
 	virtual ~CMainFrame() override;
 #ifdef RTS_DEBUG
-	virtual void AssertValid() const;
-	virtual void Dump(CDumpContext& dc) const;
+	virtual void AssertValid() const override;
+	virtual void Dump(CDumpContext& dc) const override;
 #endif
 
 	static CMainFrame *GetMainFrame() { return TheMainFrame; }

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/WorldBuilderDoc.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/WorldBuilderDoc.h
@@ -166,8 +166,8 @@ public:
 public:
 	virtual ~CWorldBuilderDoc() override;
 #ifdef RTS_DEBUG
-	virtual void AssertValid() const;
-	virtual void Dump(CDumpContext& dc) const;
+	virtual void AssertValid() const override;
+	virtual void Dump(CDumpContext& dc) const override;
 #endif
 	void AddAndDoUndoable(Undoable *pUndo);
 // Generated message map functions

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/WorldBuilderView.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/WorldBuilderView.h
@@ -56,8 +56,8 @@ public:
 public:
 	virtual ~CWorldBuilderView() override;
 #ifdef RTS_DEBUG
-	virtual void AssertValid() const;
-	virtual void Dump(CDumpContext& dc) const;
+	virtual void AssertValid() const override;
+	virtual void Dump(CDumpContext& dc) const override;
 #endif
 
 protected:

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/wbview.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/wbview.h
@@ -167,8 +167,8 @@ public:
 protected:
 	virtual ~WbView() override;
 #ifdef RTS_DEBUG
-	virtual void AssertValid() const;
-	virtual void Dump(CDumpContext& dc) const;
+	virtual void AssertValid() const override;
+	virtual void Dump(CDumpContext& dc) const override;
 #endif
 
 	// Generated message map functions

--- a/GeneralsMD/Code/Tools/WorldBuilder/include/wbview3d.h
+++ b/GeneralsMD/Code/Tools/WorldBuilder/include/wbview3d.h
@@ -83,8 +83,8 @@ public:
 protected:
 	virtual ~WbView3d() override;
 #ifdef RTS_DEBUG
-	virtual void AssertValid() const;
-	virtual void Dump(CDumpContext& dc) const;
+	virtual void AssertValid() const override;
+	virtual void Dump(CDumpContext& dc) const override;
 #endif
 
 	// Generated message map functions

--- a/GeneralsMD/Code/Tools/wdump/FindDialog.h
+++ b/GeneralsMD/Code/Tools/wdump/FindDialog.h
@@ -64,7 +64,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(FindDialog)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -72,7 +72,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(FindDialog)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnChangeFindString();
 	afx_msg void OnUpdateFindString();
 	//}}AFX_MSG

--- a/GeneralsMD/Code/Tools/wdump/mainfrm.h
+++ b/GeneralsMD/Code/Tools/wdump/mainfrm.h
@@ -48,8 +48,8 @@ public:
 public:
 	virtual ~CMainFrame();
 #ifdef RTS_DEBUG
-	virtual void AssertValid() const;
-	virtual void Dump(CDumpContext& dc) const;
+	virtual void AssertValid() const override;
+	virtual void Dump(CDumpContext& dc) const override;
 #endif
 
 protected:  // control bar embedded members

--- a/GeneralsMD/Code/Tools/wdump/mainfrm.h
+++ b/GeneralsMD/Code/Tools/wdump/mainfrm.h
@@ -40,8 +40,8 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CMainFrame)
 	public:
-	virtual BOOL OnCreateClient(LPCREATESTRUCT lpcs, CCreateContext* pContext);
-	virtual BOOL PreCreateWindow(CREATESTRUCT& cs);
+	virtual BOOL OnCreateClient(LPCREATESTRUCT lpcs, CCreateContext* pContext) override;
+	virtual BOOL PreCreateWindow(CREATESTRUCT& cs) override;
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/GeneralsMD/Code/Tools/wdump/wdeview.h
+++ b/GeneralsMD/Code/Tools/wdump/wdeview.h
@@ -40,8 +40,8 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CWDumpEditView)
 	protected:
-	virtual void OnDraw(CDC* pDC);      // overridden to draw this view
-	virtual void OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint);
+	virtual void OnDraw(CDC* pDC) override;      // overridden to draw this view
+	virtual void OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint) override;
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/GeneralsMD/Code/Tools/wdump/wdeview.h
+++ b/GeneralsMD/Code/Tools/wdump/wdeview.h
@@ -48,8 +48,8 @@ public:
 protected:
 	virtual ~CWDumpEditView();
 #ifdef RTS_DEBUG
-	virtual void AssertValid() const;
-	virtual void Dump(CDumpContext& dc) const;
+	virtual void AssertValid() const override;
+	virtual void Dump(CDumpContext& dc) const override;
 #endif
 
 	// Generated message map functions

--- a/GeneralsMD/Code/Tools/wdump/wdlview.h
+++ b/GeneralsMD/Code/Tools/wdump/wdlview.h
@@ -40,10 +40,10 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CWDumpListView)
 	public:
-	virtual void OnInitialUpdate();
+	virtual void OnInitialUpdate() override;
 	protected:
-	virtual void OnDraw(CDC* pDC);      // overridden to draw this view
-	virtual void OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint);
+	virtual void OnDraw(CDC* pDC) override;      // overridden to draw this view
+	virtual void OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint) override;
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/GeneralsMD/Code/Tools/wdump/wdlview.h
+++ b/GeneralsMD/Code/Tools/wdump/wdlview.h
@@ -50,8 +50,8 @@ public:
 protected:
 	virtual ~CWDumpListView();
 #ifdef RTS_DEBUG
-	virtual void AssertValid() const;
-	virtual void Dump(CDumpContext& dc) const;
+	virtual void AssertValid() const override;
+	virtual void Dump(CDumpContext& dc) const override;
 #endif
 
 	// Generated message map functions

--- a/GeneralsMD/Code/Tools/wdump/wdtview.h
+++ b/GeneralsMD/Code/Tools/wdump/wdtview.h
@@ -48,8 +48,8 @@ public:
 protected:
 	virtual ~CWDumpTreeView();
 #ifdef RTS_DEBUG
-	virtual void AssertValid() const;
-	virtual void Dump(CDumpContext& dc) const;
+	virtual void AssertValid() const override;
+	virtual void Dump(CDumpContext& dc) const override;
 #endif
 
 	// Generated message map functions

--- a/GeneralsMD/Code/Tools/wdump/wdtview.h
+++ b/GeneralsMD/Code/Tools/wdump/wdtview.h
@@ -40,8 +40,8 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CWDumpTreeView)
 	protected:
-	virtual void OnDraw(CDC* pDC);      // overridden to draw this view
-	virtual void OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint);
+	virtual void OnDraw(CDC* pDC) override;      // overridden to draw this view
+	virtual void OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint) override;
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/GeneralsMD/Code/Tools/wdump/wdump.h
+++ b/GeneralsMD/Code/Tools/wdump/wdump.h
@@ -45,7 +45,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CWdumpApp)
 	public:
-	virtual BOOL InitInstance();
+	virtual BOOL InitInstance() override;
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/GeneralsMD/Code/Tools/wdump/wdumpdoc.h
+++ b/GeneralsMD/Code/Tools/wdump/wdumpdoc.h
@@ -48,8 +48,8 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CWdumpDoc)
 	public:
-	virtual BOOL OnNewDocument();
-	virtual void Serialize(CArchive& ar);
+	virtual BOOL OnNewDocument() override;
+	virtual void Serialize(CArchive& ar) override;
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/GeneralsMD/Code/Tools/wdump/wdumpdoc.h
+++ b/GeneralsMD/Code/Tools/wdump/wdumpdoc.h
@@ -56,8 +56,8 @@ public:
 public:
 	virtual ~CWdumpDoc();
 #ifdef RTS_DEBUG
-	virtual void AssertValid() const;
-	virtual void Dump(CDumpContext& dc) const;
+	virtual void AssertValid() const override;
+	virtual void Dump(CDumpContext& dc) const override;
 #endif
 
 protected:

--- a/GeneralsMD/Code/Tools/wdump/wdview.h
+++ b/GeneralsMD/Code/Tools/wdump/wdview.h
@@ -39,8 +39,8 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CWdumpView)
 	public:
-	virtual void OnDraw(CDC* pDC);  // overridden to draw this view
-	virtual BOOL PreCreateWindow(CREATESTRUCT& cs);
+	virtual void OnDraw(CDC* pDC) override;  // overridden to draw this view
+	virtual BOOL PreCreateWindow(CREATESTRUCT& cs) override;
 	protected:
 	//}}AFX_VIRTUAL
 

--- a/GeneralsMD/Code/Tools/wdump/wdview.h
+++ b/GeneralsMD/Code/Tools/wdump/wdview.h
@@ -48,8 +48,8 @@ public:
 public:
 	virtual ~CWdumpView();
 #ifdef RTS_DEBUG
-	virtual void AssertValid() const;
-	virtual void Dump(CDumpContext& dc) const;
+	virtual void AssertValid() const override;
+	virtual void Dump(CDumpContext& dc) const override;
 #endif
 
 protected:


### PR DESCRIPTION
* Follow up PR for https://github.com/TheSuperHackers/GeneralsGameCode/pull/2101

This PR adds the keyword `override` to a number of virtual functions in the Zero Hour code that were missed in the previous round of refactoring.

Check out the commits as they separate different types of changes.

Related PRs:
https://github.com/TheSuperHackers/GeneralsGameCode/pull/2603
https://github.com/TheSuperHackers/GeneralsGameCode/pull/2604