### PR TITLE
fix: Fix assertion format argument for non-trivial types

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -1477,7 +1477,7 @@ const WeaponTemplate *WeaponStore::findWeaponTemplate( const AsciiString& name )
 	if (name.compareNoCase("None") == 0)
 		return nullptr;
 	const WeaponTemplate * wt = findWeaponTemplatePrivate( TheNameKeyGenerator->nameToKey( name ) );
-	DEBUG_ASSERTCRASH(wt != nullptr, ("Weapon %s not found!",name));
+	DEBUG_ASSERTCRASH(wt != nullptr, ("Weapon %s not found!", name.str()));
 	return wt;
 }
 

--- a/Generals/Code/Tools/WorldBuilder/src/GlobalLightOptions.cpp
+++ b/Generals/Code/Tools/WorldBuilder/src/GlobalLightOptions.cpp
@@ -141,18 +141,16 @@ void GlobalLightOptions::applyAngle(Int lightIndex)
 static void SpitLights()
 {
 #ifdef DEBUG_LOGGING
-	CString lightstrings[100];
 	DEBUG_LOG(("GlobalLighting\n"));
 	Int redA, greenA, blueA;
 	Int redD, greenD, blueD;
 	Real x, y, z;
-	CString times[4];
-	CString lights[3];
+	const char* times[4];
 	times[0] = "Morning";
 	times[1] = "Afternoon";
 	times[2] = "Evening";
 	times[3] = "Night";
-
+	const char* lights[3];
 	lights[0] = "";
 	lights[1] = "2";
 	lights[2] = "3";

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -1623,7 +1623,7 @@ const WeaponTemplate *WeaponStore::findWeaponTemplate( const AsciiString& name )
 	if (name.compareNoCase("None") == 0)
 		return nullptr;
 	const WeaponTemplate * wt = findWeaponTemplatePrivate( TheNameKeyGenerator->nameToKey( name ) );
-	DEBUG_ASSERTCRASH(wt != nullptr, ("Weapon %s not found!",name));
+	DEBUG_ASSERTCRASH(wt != nullptr, ("Weapon %s not found!", name.str()));
 	return wt;
 }
 

--- a/GeneralsMD/Code/Tools/WorldBuilder/src/GlobalLightOptions.cpp
+++ b/GeneralsMD/Code/Tools/WorldBuilder/src/GlobalLightOptions.cpp
@@ -141,18 +141,16 @@ void GlobalLightOptions::applyAngle(Int lightIndex)
 static void SpitLights()
 {
 #ifdef DEBUG_LOGGING
-	CString lightstrings[100];
 	DEBUG_LOG(("GlobalLighting\n"));
 	Int redA, greenA, blueA;
 	Int redD, greenD, blueD;
 	Real x, y, z;
-	CString times[4];
-	CString lights[3];
+	const char* times[4];
 	times[0] = "Morning";
 	times[1] = "Afternoon";
 	times[2] = "Evening";
 	times[3] = "Night";
-
+	const char* lights[3];
 	lights[0] = "";
 	lights[1] = "2";
 	lights[2] = "3";


### PR DESCRIPTION
This PR fixes a bug in a debug assertion where `%s` is used for `AsciiString` instead of `const char*`.