### PR TITLE
refactor: Remove the W3DMPO class to remove clutter and unnecessary vtables

### DIFF
--- a/Core/GameEngine/Include/GameClient/Smudge.h
+++ b/Core/GameEngine/Include/GameClient/Smudge.h
@@ -64,7 +64,7 @@ struct SmudgeSet : public DLNodeClass<SmudgeSet>
 	W3DMPO_CODE(SmudgeSet)
 
 	SmudgeSet();
-	virtual ~SmudgeSet() override;
+	~SmudgeSet();
 
 	void reset();
 	void resetDraw();

--- a/Core/GameEngine/Include/GameClient/Smudge.h
+++ b/Core/GameEngine/Include/GameClient/Smudge.h
@@ -30,7 +30,7 @@ struct Smudge : public DLNodeClass<Smudge>
 {
 	typedef void *Identifier;
 
-	W3DMPO_GLUE(Smudge)
+	W3DMPO_CODE(Smudge)
 
 	Identifier m_identifier;	//a number or pointer to identify this smudge
 	Vector3 m_pos;	//position of smudge center
@@ -61,7 +61,7 @@ struct SmudgeSet : public DLNodeClass<SmudgeSet>
 {
 	friend class SmudgeManager;
 
-	W3DMPO_GLUE(SmudgeSet)
+	W3DMPO_CODE(SmudgeSet)
 
 	SmudgeSet();
 	virtual ~SmudgeSet() override;

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/TerrainTex.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/TerrainTex.h
@@ -41,7 +41,7 @@ class WorldHeightMap;
 ***************************************************************************/
 class TerrainTextureClass : public TextureClass
 {
-	W3DMPO_GLUE(TerrainTextureClass)
+	W3DMPO_CODE(TerrainTextureClass)
 protected:
 	virtual void Apply(unsigned int stage) override;
 
@@ -62,7 +62,7 @@ public:
 
 class AlphaTerrainTextureClass : public TextureClass
 {
-	W3DMPO_GLUE(AlphaTerrainTextureClass)
+	W3DMPO_CODE(AlphaTerrainTextureClass)
 protected:
 		virtual void Apply(unsigned int stage) override;
 public:
@@ -78,7 +78,7 @@ public:
 ***************************************************************************/
 class AlphaEdgeTextureClass : public TextureClass
 {
-	W3DMPO_GLUE(AlphaEdgeTextureClass)
+	W3DMPO_CODE(AlphaEdgeTextureClass)
 protected:
 	virtual void Apply(unsigned int stage) override;
 	int update256(WorldHeightMap *htMap);///< Sets the pixels, and returns the actual height of the texture.
@@ -95,7 +95,7 @@ public:
 
 class LightMapTerrainTextureClass : public TextureClass
 {
-	W3DMPO_GLUE(LightMapTerrainTextureClass)
+	W3DMPO_CODE(LightMapTerrainTextureClass)
 protected:
 		virtual void Apply(unsigned int stage) override;
 
@@ -108,7 +108,7 @@ public:
 
 class ScorchTextureClass : public TextureClass
 {
-	W3DMPO_GLUE(ScorchTextureClass)
+	W3DMPO_CODE(ScorchTextureClass)
 protected:
 		virtual void Apply(unsigned int stage) override;
 
@@ -121,7 +121,7 @@ public:
 
 class CloudMapTerrainTextureClass : public TextureClass
 {
-	W3DMPO_GLUE(CloudMapTerrainTextureClass)
+	W3DMPO_CODE(CloudMapTerrainTextureClass)
 protected:
 		virtual void Apply(unsigned int stage) override;
 

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DTerrainTracks.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DTerrainTracks.h
@@ -44,7 +44,7 @@ class Drawable;
 /**
 This render object handles drawing tracks left by objects moving on the terrain.
 */
-class TerrainTracksRenderObjClass : public W3DMPO, public RenderObjClass
+class TerrainTracksRenderObjClass : public RenderObjClass
 {
 	W3DMPO_CODE(TerrainTracksRenderObjClass)
 

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DTerrainTracks.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DTerrainTracks.h
@@ -46,7 +46,7 @@ This render object handles drawing tracks left by objects moving on the terrain.
 */
 class TerrainTracksRenderObjClass : public W3DMPO, public RenderObjClass
 {
-	W3DMPO_GLUE(TerrainTracksRenderObjClass)
+	W3DMPO_CODE(TerrainTracksRenderObjClass)
 
 	friend class TerrainTracksRenderObjClassSystem;
 

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DTreeBuffer.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DTreeBuffer.h
@@ -153,7 +153,7 @@ class W3DTreeBuffer : public Snapshot
 	//-----------------------------------------------------------------------------
 	class W3DTreeTextureClass : public TextureClass
 	{
-		W3DMPO_GLUE(W3DTreeTextureClass)
+		W3DMPO_CODE(W3DTreeTextureClass)
 	protected:
 		virtual void Apply(unsigned int stage) override;
 

--- a/Core/Libraries/Source/WWVegas/WW3D2/aabtree.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/aabtree.h
@@ -81,7 +81,7 @@ struct BoxRayAPTContextStruct;
 */
 class AABTreeClass : public W3DMPO, public RefCountClass
 {
-	W3DMPO_GLUE(AABTreeClass)
+	W3DMPO_CODE(AABTreeClass)
 public:
 
 	AABTreeClass();

--- a/Core/Libraries/Source/WWVegas/WW3D2/aabtree.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/aabtree.h
@@ -79,7 +79,7 @@ struct BoxRayAPTContextStruct;
 ** is in MeshGeometryClass.  I moved these out into a separate file just to reduce the
 ** size of meshmdl.cpp.
 */
-class AABTreeClass : public W3DMPO, public RefCountClass
+class AABTreeClass : public RefCountClass
 {
 	W3DMPO_CODE(AABTreeClass)
 public:

--- a/Core/Libraries/Source/WWVegas/WW3D2/agg_def.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/agg_def.h
@@ -196,7 +196,7 @@ class AggregateDefClass
 //
 class AggregatePrototypeClass : public W3DMPO, public PrototypeClass
 {
-	W3DMPO_GLUE(AggregatePrototypeClass)
+	W3DMPO_CODE(AggregatePrototypeClass)
 	public:
 
 		///////////////////////////////////////////////////////////

--- a/Core/Libraries/Source/WWVegas/WW3D2/agg_def.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/agg_def.h
@@ -194,7 +194,7 @@ class AggregateDefClass
 //
 //	AggregatePrototypeClass
 //
-class AggregatePrototypeClass : public W3DMPO, public PrototypeClass
+class AggregatePrototypeClass : public PrototypeClass
 {
 	W3DMPO_CODE(AggregatePrototypeClass)
 	public:

--- a/Core/Libraries/Source/WWVegas/WW3D2/collect.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/collect.cpp
@@ -119,7 +119,7 @@ protected:
 */
 class CollectionPrototypeClass : public W3DMPO, public PrototypeClass
 {
-	W3DMPO_GLUE(CollectionPrototypeClass)
+	W3DMPO_CODE(CollectionPrototypeClass)
 public:
 	CollectionPrototypeClass(CollectionDefClass * def)		{ ColDef = def; WWASSERT(ColDef); }
 

--- a/Core/Libraries/Source/WWVegas/WW3D2/collect.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/collect.cpp
@@ -117,7 +117,7 @@ protected:
 ** CollectionPrototypeClass this is the render object prototype for
 ** Collections.
 */
-class CollectionPrototypeClass : public W3DMPO, public PrototypeClass
+class CollectionPrototypeClass : public PrototypeClass
 {
 	W3DMPO_CODE(CollectionPrototypeClass)
 public:

--- a/Core/Libraries/Source/WWVegas/WW3D2/distlod.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/distlod.h
@@ -216,7 +216,7 @@ private:
 */
 class DistLODPrototypeClass : public W3DMPO, public PrototypeClass
 {
-	W3DMPO_GLUE(DistLODPrototypeClass)
+	W3DMPO_CODE(DistLODPrototypeClass)
 public:
 	DistLODPrototypeClass( DistLODDefClass *def ) { Definition = def; }
 

--- a/Core/Libraries/Source/WWVegas/WW3D2/distlod.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/distlod.h
@@ -214,7 +214,7 @@ private:
 /*
 ** Prototype for Dist-LOD objects
 */
-class DistLODPrototypeClass : public W3DMPO, public PrototypeClass
+class DistLODPrototypeClass : public PrototypeClass
 {
 	W3DMPO_CODE(DistLODPrototypeClass)
 public:

--- a/Core/Libraries/Source/WWVegas/WW3D2/dllist.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/dllist.h
@@ -81,9 +81,6 @@ public:
 template <class T>
 class DLNodeClass
 {
-	// nope, this is an ABC
-	//W3DMPO_CODE(DLNodeClass)
-
 	friend DLListClass<T>;
 	DLNodeClass<T>* succ;
 	DLNodeClass<T>* pred;

--- a/Core/Libraries/Source/WWVegas/WW3D2/dllist.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/dllist.h
@@ -82,7 +82,7 @@ template <class T>
 class DLNodeClass : public W3DMPO
 {
 	// nope, this is an ABC
-	//W3DMPO_GLUE(DLNodeClass)
+	//W3DMPO_CODE(DLNodeClass)
 
 	friend DLListClass<T>;
 	DLNodeClass<T>* succ;

--- a/Core/Libraries/Source/WWVegas/WW3D2/dllist.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/dllist.h
@@ -79,7 +79,7 @@ public:
 };
 
 template <class T>
-class DLNodeClass : public W3DMPO
+class DLNodeClass
 {
 	// nope, this is an ABC
 	//W3DMPO_CODE(DLNodeClass)

--- a/Core/Libraries/Source/WWVegas/WW3D2/dllist.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/dllist.h
@@ -87,7 +87,7 @@ class DLNodeClass
 	DLListClass<T>* list;
 public:
 	DLNodeClass() : succ(0), pred(0), list(0) {}
-	virtual ~DLNodeClass() override { Remove(); }
+	~DLNodeClass() { Remove(); }
 
 	void Insert_Before(DLNodeClass<T>* n)
 	{

--- a/Core/Libraries/Source/WWVegas/WW3D2/dynamesh.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/dynamesh.h
@@ -52,7 +52,7 @@ class	IntersectionResultClass;
 */
 class DynamicMeshModel : public MeshGeometryClass
 {
-	W3DMPO_GLUE(DynamicMeshModel)
+	W3DMPO_CODE(DynamicMeshModel)
 
 public:
 

--- a/Core/Libraries/Source/WWVegas/WW3D2/htree.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/htree.h
@@ -79,7 +79,7 @@ public:
 
 	HTreeClass();
 	HTreeClass(const HTreeClass & src);
-	virtual ~HTreeClass() override;
+	~HTreeClass();
 
 	int					Load_W3D(ChunkLoadClass & cload);
 	void					Init_Default();

--- a/Core/Libraries/Source/WWVegas/WW3D2/htree.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/htree.h
@@ -68,7 +68,7 @@ class HRawAnimClass;
 */
 class HTreeClass : public W3DMPO
 {
-	W3DMPO_GLUE(HTreeClass)
+	W3DMPO_CODE(HTreeClass)
 public:
 
 	enum

--- a/Core/Libraries/Source/WWVegas/WW3D2/htree.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/htree.h
@@ -66,7 +66,7 @@ class HRawAnimClass;
 	by the HierarchyModelClass.
 
 */
-class HTreeClass : public W3DMPO
+class HTreeClass
 {
 	W3DMPO_CODE(HTreeClass)
 public:

--- a/Core/Libraries/Source/WWVegas/WW3D2/line3d.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/line3d.h
@@ -54,7 +54,7 @@ class RenderInfoClass;
 */
 class Line3DClass : public W3DMPO, public RenderObjClass
 {
-	W3DMPO_GLUE(Line3DClass)
+	W3DMPO_CODE(Line3DClass)
 
 	public:
 

--- a/Core/Libraries/Source/WWVegas/WW3D2/line3d.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/line3d.h
@@ -52,7 +52,7 @@ class RenderInfoClass;
 ** Line3DCLass objects are unlit, therefore only the sihouette needs to be
 ** approximated).
 */
-class Line3DClass : public W3DMPO, public RenderObjClass
+class Line3DClass : public RenderObjClass
 {
 	W3DMPO_CODE(Line3DClass)
 

--- a/Core/Libraries/Source/WWVegas/WW3D2/matinfo.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/matinfo.h
@@ -63,7 +63,7 @@ class MeshMatDescClass;
 ** that the mesh is using.
 **
 ***********************************************************************************************/
-class MaterialInfoClass : public W3DMPO, public RefCountClass
+class MaterialInfoClass : public RefCountClass
 {
 	W3DMPO_CODE(MaterialInfoClass)
 public:

--- a/Core/Libraries/Source/WWVegas/WW3D2/matinfo.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/matinfo.h
@@ -65,7 +65,7 @@ class MeshMatDescClass;
 ***********************************************************************************************/
 class MaterialInfoClass : public W3DMPO, public RefCountClass
 {
-	W3DMPO_GLUE(MaterialInfoClass)
+	W3DMPO_CODE(MaterialInfoClass)
 public:
 
 	MaterialInfoClass();

--- a/Core/Libraries/Source/WWVegas/WW3D2/proto.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/proto.cpp
@@ -88,7 +88,7 @@ RenderObjClass * PrimitivePrototypeClass::Create()
 
 class HModelPrototypeClass : public W3DMPO, public PrototypeClass
 {
-	W3DMPO_GLUE(HModelPrototypeClass)
+	W3DMPO_CODE(HModelPrototypeClass)
 public:
 	HModelPrototypeClass(HModelDefClass * def)				{ HModelDef = def; assert(HModelDef); }
 

--- a/Core/Libraries/Source/WWVegas/WW3D2/proto.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/proto.cpp
@@ -86,7 +86,7 @@ RenderObjClass * PrimitivePrototypeClass::Create()
 }
 
 
-class HModelPrototypeClass : public W3DMPO, public PrototypeClass
+class HModelPrototypeClass : public PrototypeClass
 {
 	W3DMPO_CODE(HModelPrototypeClass)
 public:

--- a/Core/Libraries/Source/WWVegas/WW3D2/proto.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/proto.h
@@ -104,7 +104,7 @@ private:
 
 class PrimitivePrototypeClass : public W3DMPO, public PrototypeClass
 {
-	W3DMPO_GLUE(PrimitivePrototypeClass)
+	W3DMPO_CODE(PrimitivePrototypeClass)
 public:
 	PrimitivePrototypeClass(RenderObjClass * proto);
 

--- a/Core/Libraries/Source/WWVegas/WW3D2/proto.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/proto.h
@@ -102,7 +102,7 @@ private:
 	PrototypeClass & operator = (const PrototypeClass & that);
 };
 
-class PrimitivePrototypeClass : public W3DMPO, public PrototypeClass
+class PrimitivePrototypeClass : public PrototypeClass
 {
 	W3DMPO_CODE(PrimitivePrototypeClass)
 public:

--- a/Core/Libraries/Source/WWVegas/WW3D2/render2dsentence.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/render2dsentence.h
@@ -53,7 +53,7 @@ class	SurfaceClass;
 //
 class FontCharsClassCharDataStruct : public W3DMPO
 {
-	W3DMPO_GLUE(FontCharsClassCharDataStruct)
+	W3DMPO_CODE(FontCharsClassCharDataStruct)
 public:
 	WCHAR				Value;
 	short				Width;
@@ -64,7 +64,7 @@ enum { CHAR_BUFFER_LEN		= 32768 };
 
 class FontCharsBuffer : public W3DMPO
 {
-	W3DMPO_GLUE(FontCharsBuffer)
+	W3DMPO_CODE(FontCharsBuffer)
 public:
 	uint16			Buffer[CHAR_BUFFER_LEN];
 };
@@ -72,7 +72,7 @@ public:
 
 class FontCharsClass : public W3DMPO, public RefCountClass
 {
-	W3DMPO_GLUE(FontCharsClass)
+	W3DMPO_CODE(FontCharsClass)
 
 public:
 	FontCharsClass();

--- a/Core/Libraries/Source/WWVegas/WW3D2/render2dsentence.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/render2dsentence.h
@@ -51,7 +51,7 @@ class	SurfaceClass;
 //
 //	Private data structures
 //
-class FontCharsClassCharDataStruct : public W3DMPO
+class FontCharsClassCharDataStruct
 {
 	W3DMPO_CODE(FontCharsClassCharDataStruct)
 public:
@@ -62,7 +62,7 @@ public:
 
 enum { CHAR_BUFFER_LEN		= 32768 };
 
-class FontCharsBuffer : public W3DMPO
+class FontCharsBuffer
 {
 	W3DMPO_CODE(FontCharsBuffer)
 public:
@@ -70,7 +70,7 @@ public:
 };
 
 
-class FontCharsClass : public W3DMPO, public RefCountClass
+class FontCharsClass : public RefCountClass
 {
 	W3DMPO_CODE(FontCharsClass)
 

--- a/Core/Libraries/Source/WWVegas/WW3D2/ringobj.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/ringobj.h
@@ -324,7 +324,7 @@ public:
 /*
 ** Prototype for Ring objects
 */
-class RingPrototypeClass : public W3DMPO, public PrototypeClass
+class RingPrototypeClass : public PrototypeClass
 {
 	W3DMPO_CODE(RingPrototypeClass)
 

--- a/Core/Libraries/Source/WWVegas/WW3D2/ringobj.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/ringobj.h
@@ -326,7 +326,7 @@ public:
 */
 class RingPrototypeClass : public W3DMPO, public PrototypeClass
 {
-	W3DMPO_GLUE(RingPrototypeClass)
+	W3DMPO_CODE(RingPrototypeClass)
 
 public:
 	RingPrototypeClass ();

--- a/Core/Libraries/Source/WWVegas/WW3D2/soundrobj.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/soundrobj.h
@@ -222,7 +222,7 @@ private:
 //	SoundRenderObjPrototypeClass
 //
 ///////////////////////////////////////////////////////////////////////////////////
-class SoundRenderObjPrototypeClass : public W3DMPO, public PrototypeClass
+class SoundRenderObjPrototypeClass : public PrototypeClass
 {
 	W3DMPO_CODE(SoundRenderObjPrototypeClass)
 public:

--- a/Core/Libraries/Source/WWVegas/WW3D2/soundrobj.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/soundrobj.h
@@ -224,7 +224,7 @@ private:
 ///////////////////////////////////////////////////////////////////////////////////
 class SoundRenderObjPrototypeClass : public W3DMPO, public PrototypeClass
 {
-	W3DMPO_GLUE(SoundRenderObjPrototypeClass)
+	W3DMPO_CODE(SoundRenderObjPrototypeClass)
 public:
 
 	///////////////////////////////////////////////////////////

--- a/Core/Libraries/Source/WWVegas/WW3D2/sphereobj.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/sphereobj.h
@@ -435,7 +435,7 @@ public:
 */
 class SpherePrototypeClass : public W3DMPO, public PrototypeClass
 {
-	W3DMPO_GLUE(SpherePrototypeClass)
+	W3DMPO_CODE(SpherePrototypeClass)
 public:
 	SpherePrototypeClass ();
 	SpherePrototypeClass (SphereRenderObjClass *sphere);

--- a/Core/Libraries/Source/WWVegas/WW3D2/sphereobj.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/sphereobj.h
@@ -433,7 +433,7 @@ public:
 /*
 ** Prototype for Sphere objects
 */
-class SpherePrototypeClass : public W3DMPO, public PrototypeClass
+class SpherePrototypeClass : public PrototypeClass
 {
 	W3DMPO_CODE(SpherePrototypeClass)
 public:

--- a/Core/Libraries/Source/WWVegas/WW3D2/surfaceclass.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/surfaceclass.h
@@ -53,7 +53,7 @@ class Vector3;
 ** Hector Yee 2/12/01 - added in fills, blits etc for font3d class
 **
 *************************************************************************/
-class SurfaceClass : public W3DMPO, public RefCountClass
+class SurfaceClass : public RefCountClass
 {
 	W3DMPO_CODE(SurfaceClass)
 	public:

--- a/Core/Libraries/Source/WWVegas/WW3D2/surfaceclass.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/surfaceclass.h
@@ -55,7 +55,7 @@ class Vector3;
 *************************************************************************/
 class SurfaceClass : public W3DMPO, public RefCountClass
 {
-	W3DMPO_GLUE(SurfaceClass)
+	W3DMPO_CODE(SurfaceClass)
 	public:
 		typedef void *LockedSurfacePtr;
 

--- a/Core/Libraries/Source/WWVegas/WW3D2/texture.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/texture.h
@@ -263,7 +263,7 @@ private:
 *************************************************************************/
 class TextureClass : public W3DMPO, public TextureBaseClass
 {
-	W3DMPO_GLUE(TextureClass)
+	W3DMPO_CODE(TextureClass)
 //	friend DX8Wrapper;
 
 public:

--- a/Core/Libraries/Source/WWVegas/WW3D2/texture.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/texture.h
@@ -261,7 +261,7 @@ private:
 ** modes.
 **
 *************************************************************************/
-class TextureClass : public W3DMPO, public TextureBaseClass
+class TextureClass : public TextureBaseClass
 {
 	W3DMPO_CODE(TextureClass)
 //	friend DX8Wrapper;

--- a/Core/Libraries/Source/WWVegas/WW3D2/texturethumbnail.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/texturethumbnail.h
@@ -96,7 +96,7 @@ class ThumbnailManagerClass : public DLNodeClass<ThumbnailManagerClass>
 	unsigned long DateTime;
 
 	ThumbnailManagerClass(const char* thumbnail_filename);
-	virtual ~ThumbnailManagerClass() override;
+	~ThumbnailManagerClass();
 
 	void Remove_From_Hash(ThumbnailClass* thumb);
 	void Insert_To_Hash(ThumbnailClass* thumb);

--- a/Core/Libraries/Source/WWVegas/WW3D2/texturethumbnail.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/texturethumbnail.h
@@ -83,7 +83,7 @@ public:
 
 class ThumbnailManagerClass : public DLNodeClass<ThumbnailManagerClass>
 {
-	W3DMPO_GLUE(ThumbnailManagerClass);
+	W3DMPO_CODE(ThumbnailManagerClass);
 
 	friend ThumbnailClass;
 

--- a/Core/Libraries/Source/WWVegas/WWLib/always.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/always.h
@@ -130,43 +130,22 @@ extern void* allocateFromW3DMemPool(void* p, int allocationSize, const char* msg
 extern void freeFromW3DMemPool(void* pool, void* p);
 
 // ----------------------------------------------------------------------------
-#define W3DMPO_GLUE(ARGCLASS) \
+#define W3DMPO_CODE(ARGCLASS) \
 private: \
 	static void* getClassMemoryPool() \
 	{ \
-		/* \
-			Note that this static variable will be initialized exactly once: the first time \
-			control flows over this section of code. This allows us to neatly resolve the \
-			order-of-execution problem for static variables, ensuring this is not executed \
-			prior to the initialization of TheMemoryPoolFactory. \
+		/*
+		construct on first first use to avoid static initialization order fiasco
+		that may occur if this were initialized prior to the initialization of TheMemoryPoolFactory.
 		*/ \
 		static void* The##ARGCLASS##Pool = createW3DMemPool(#ARGCLASS, sizeof(ARGCLASS)); \
 		return The##ARGCLASS##Pool; \
 	} \
-protected: \
-	virtual void glueEnforcer() const override { } \
 public: \
 	inline void* operator new(size_t s) { return allocateFromW3DMemPool(getClassMemoryPool(), s); } \
 	inline void operator delete(void *p) { freeFromW3DMemPool(getClassMemoryPool(), p); } \
 	inline void* operator new(size_t s, const char* msg, int unused) { return allocateFromW3DMemPool(getClassMemoryPool(), s, msg, unused); } \
 	inline void operator delete(void *p, const char* msg, int unused) { freeFromW3DMemPool(getClassMemoryPool(), p); } \
-
-// ----------------------------------------------------------------------------
-class W3DMPO
-{
-private:
-	static void* getClassMemoryPool()
-	{
-		assert(0);	// must replace this via W3DMPO_GLUE
-		return nullptr;
-	}
-protected:
-	// we never call this; it is present to cause compile errors in descendent classes
-	virtual void glueEnforcer() const = 0;
-public:
-	virtual ~W3DMPO() { /* nothing */ }
-};
-// ----------------------------------------------------------------------------
 
 #else
 
@@ -178,9 +157,7 @@ public:
 	#define NEW_REF( C, P )					( W3DNEW C P )
 	#define SET_REF_OWNER( P )			P
 
-	#define W3DMPO_GLUE(ARGCLASS)
-
-	class W3DMPO { };
+	#define W3DMPO_CODE(ARGCLASS)
 
 #endif // (gth) removing the generals memory stuff from W3D
 

--- a/Core/Libraries/Source/WWVegas/WWLib/sharebuf.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/sharebuf.h
@@ -45,7 +45,7 @@
 ** refcounted wrapper (also a count).
 */
 template <class T>
-class ShareBufferClass : public W3DMPO, public RefCountClass
+class ShareBufferClass : public RefCountClass
 {
 	W3DMPO_CODE(ShareBufferClass)
 	public:

--- a/Core/Libraries/Source/WWVegas/WWLib/sharebuf.h
+++ b/Core/Libraries/Source/WWVegas/WWLib/sharebuf.h
@@ -47,7 +47,7 @@
 template <class T>
 class ShareBufferClass : public W3DMPO, public RefCountClass
 {
-	W3DMPO_GLUE(ShareBufferClass)
+	W3DMPO_CODE(ShareBufferClass)
 	public:
 		ShareBufferClass(int count, const char* msg);
 		ShareBufferClass(const ShareBufferClass & that);

--- a/Core/Libraries/Source/WWVegas/WWMath/matrix3d.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/matrix3d.h
@@ -1807,7 +1807,7 @@ WWINLINE void	Matrix3D::Inverse_Rotate_Vector(const Matrix3D & A,const Vector3 &
 
 class DynamicMatrix3D : public W3DMPO
 {
-	W3DMPO_GLUE(DynamicMatrix3D)
+	W3DMPO_CODE(DynamicMatrix3D)
 public:
 	Matrix3D Mat;
 };

--- a/Core/Libraries/Source/WWVegas/WWMath/matrix3d.h
+++ b/Core/Libraries/Source/WWVegas/WWMath/matrix3d.h
@@ -1805,7 +1805,7 @@ WWINLINE void	Matrix3D::Inverse_Rotate_Vector(const Matrix3D & A,const Vector3 &
 	out->Z = (A[0][2] * v->X + A[1][2] * v->Y + A[2][2] * v->Z);
 }
 
-class DynamicMatrix3D : public W3DMPO
+class DynamicMatrix3D
 {
 	W3DMPO_CODE(DynamicMatrix3D)
 public:

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/boxrobj.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/boxrobj.h
@@ -129,9 +129,9 @@ inline void BoxRenderObjClass::Set_Local_Min_Max(const Vector3 & min,const Vecto
 /*
 ** AABoxRenderObjClass -- RenderObject for axis-aligned collision boxes.
 */
-class AABoxRenderObjClass : public W3DMPO, public BoxRenderObjClass
+class AABoxRenderObjClass : public BoxRenderObjClass
 {
-	W3DMPO_GLUE(AABoxRenderObjClass)
+	W3DMPO_CODE(AABoxRenderObjClass)
 public:
 
 	AABoxRenderObjClass();
@@ -180,9 +180,9 @@ inline const AABoxClass & AABoxRenderObjClass::Get_Box()
 /*
 ** OBBoxRenderObjClass - render object for oriented collision boxes
 */
-class OBBoxRenderObjClass : public W3DMPO, public BoxRenderObjClass
+class OBBoxRenderObjClass : public BoxRenderObjClass
 {
-	W3DMPO_GLUE(OBBoxRenderObjClass)
+	W3DMPO_CODE(OBBoxRenderObjClass)
 public:
 
 	OBBoxRenderObjClass();
@@ -237,9 +237,9 @@ public:
 /*
 ** Prototype for Box objects
 */
-class BoxPrototypeClass : public W3DMPO, public PrototypeClass
+class BoxPrototypeClass : public PrototypeClass
 {
-	W3DMPO_GLUE(BoxPrototypeClass)
+	W3DMPO_CODE(BoxPrototypeClass)
 public:
 	BoxPrototypeClass(W3dBoxStruct box);
 	virtual const char *				Get_Name() const override;

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dazzle.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dazzle.h
@@ -353,9 +353,9 @@ public:
 ** information needed to construct a particular instance of a dazzle.  Prototypes are
 ** stored in the asset manager and used to construct render objects when needed.
 */
-class DazzlePrototypeClass : public W3DMPO, public PrototypeClass
+class DazzlePrototypeClass : public PrototypeClass
 {
-	W3DMPO_GLUE(DazzlePrototypeClass)
+	W3DMPO_CODE(DazzlePrototypeClass)
 public:
 	DazzlePrototypeClass() : DazzleType(0)				{ }
 

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8fvf.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8fvf.h
@@ -244,9 +244,9 @@ struct VertexFormatXYZNDCUBEMAP
 // FVF info class can be created for any legal FVF. It constructs information
 // of offsets to various elements in the vertex buffer.
 
-class FVFInfoClass : public W3DMPO
+class FVFInfoClass
 {
-	W3DMPO_GLUE(FVFInfoClass)
+	W3DMPO_CODE(FVFInfoClass)
 
 	mutable unsigned						FVF;
 	mutable unsigned						fvf_size;

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8indexbuffer.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8indexbuffer.h
@@ -50,10 +50,8 @@ class SortingIndexBufferClass;
 
 // ----------------------------------------------------------------------------
 
-class IndexBufferClass : public W3DMPO, public RefCountClass
+class IndexBufferClass : public RefCountClass
 {
-	// nope, it's an ABC
-	//W3DMPO_GLUE(IndexBufferClass)
 protected:
 	virtual ~IndexBufferClass() override;
 public:
@@ -105,9 +103,9 @@ protected:
 
 // HY 2/14/01
 // Created
-class DynamicIBAccessClass : public W3DMPO
+class DynamicIBAccessClass
 {
-	W3DMPO_GLUE(DynamicIBAccessClass)
+	W3DMPO_CODE(DynamicIBAccessClass)
 
 	friend DX8Wrapper;
 	friend SortingRendererClass;
@@ -122,7 +120,7 @@ class DynamicIBAccessClass : public W3DMPO
 
 public:
 	DynamicIBAccessClass(unsigned short type, unsigned short index_count);
-	virtual ~DynamicIBAccessClass() override;
+	~DynamicIBAccessClass();
 
 	unsigned Get_Type() const { return Type; }
 	unsigned short Get_Index_Count() const { return IndexCount; }
@@ -155,7 +153,7 @@ public:
 */
 class DX8IndexBufferClass : public IndexBufferClass
 {
-	W3DMPO_GLUE(DX8IndexBufferClass)
+	W3DMPO_CODE(DX8IndexBufferClass)
 
 	friend IndexBufferClass::WriteLockClass;
 	friend IndexBufferClass::AppendLockClass;
@@ -183,7 +181,7 @@ private:
 
 class SortingIndexBufferClass : public IndexBufferClass
 {
-	W3DMPO_GLUE(SortingIndexBufferClass)
+	W3DMPO_CODE(SortingIndexBufferClass)
 
 	friend DX8Wrapper;
 	friend SortingRendererClass;

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8vertexbuffer.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8vertexbuffer.h
@@ -72,11 +72,8 @@ public:
 ** DX8VertexBufferClass
 ** This class wraps a DX8 vertex buffer.  Use the lock objects to modify or append to the vertex buffer.
 */
-class VertexBufferClass : public W3DMPO, public RefCountClass
+class VertexBufferClass : public RefCountClass
 {
-	// nope, an ABC
-	//W3DMPO_GLUE(VertexBufferClass)
-
 protected:
 	VertexBufferClass(unsigned type, unsigned FVF, unsigned short VertexCount);
 	virtual ~VertexBufferClass() override;
@@ -199,7 +196,7 @@ inline VertexFormatXYZNDUV2 * DynamicVBAccessClass::WriteLockClass::Get_Formatte
 */
 class DX8VertexBufferClass : public VertexBufferClass
 {
-	W3DMPO_GLUE(DX8VertexBufferClass)
+	W3DMPO_CODE(DX8VertexBufferClass)
 protected:
 	virtual ~DX8VertexBufferClass() override;
 public:
@@ -238,7 +235,7 @@ protected:
 */
 class SortingVertexBufferClass : public VertexBufferClass
 {
-	W3DMPO_GLUE(SortingVertexBufferClass)
+	W3DMPO_CODE(SortingVertexBufferClass)
 
 	friend DX8Wrapper;
 	friend SortingRendererClass;

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/hlod.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/hlod.cpp
@@ -182,9 +182,9 @@ protected:
 ** This is a ref-counted list of proxy objects.  It is generated whenever an HLODdef contains
 ** proxies.  Each instantiated HLOD simply add-refs a pointer to the single list.
 */
-class ProxyArrayClass : public W3DMPO, public VectorClass<ProxyRecordClass>, public RefCountClass
+class ProxyArrayClass : public VectorClass<ProxyRecordClass>, public RefCountClass
 {
-	W3DMPO_GLUE(ProxyArrayClass)
+	W3DMPO_CODE(ProxyArrayClass)
 public:
 	ProxyArrayClass(int size) : VectorClass<ProxyRecordClass>(size)
 	{

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/hlod.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/hlod.h
@@ -58,9 +58,9 @@ class ProxyArrayClass;
 	This is an hierarchical, animatable level-of-detail model.
 
 */
-class HLodClass : public W3DMPO, public Animatable3DObjClass
+class HLodClass : public Animatable3DObjClass
 {
-	W3DMPO_GLUE(HLodClass)
+	W3DMPO_CODE(HLodClass)
 public:
 
 	HLodClass(const HLodClass & src);
@@ -276,14 +276,14 @@ public:
 ** This description object is generated when reading a W3D_CHUNK_HLOD.  It
 ** directly describes the contents of an HLod model.
 */
-class HLodDefClass : public W3DMPO
+class HLodDefClass
 {
-	W3DMPO_GLUE(HLodDefClass)
+	W3DMPO_CODE(HLodDefClass)
 public:
 
 	HLodDefClass();
 	HLodDefClass(HLodClass &src_lod);
-	virtual ~HLodDefClass() override;
+	~HLodDefClass();
 
 	WW3DErrorType				Load_W3D(ChunkLoadClass & cload);
 	WW3DErrorType				Save(ChunkSaveClass & csave);
@@ -342,9 +342,9 @@ private:
 /*
 ** Prototype for HLod objects
 */
-class HLodPrototypeClass : public W3DMPO, public PrototypeClass
+class HLodPrototypeClass : public PrototypeClass
 {
-	W3DMPO_GLUE(HLodPrototypeClass)
+	W3DMPO_CODE(HLodPrototypeClass)
 public:
 	HLodPrototypeClass( HLodDefClass *def )					{ Definition = def; }
 

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/mapper.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/mapper.h
@@ -53,7 +53,7 @@ class INIClass;
 ** TextureMapperClass
 ** Base class for all texture mappers.
 */
-class TextureMapperClass : public W3DMPO, public RefCountClass
+class TextureMapperClass : public RefCountClass
 {
 	public:
 
@@ -106,7 +106,7 @@ class TextureMapperClass : public W3DMPO, public RefCountClass
 */
 class ScaleTextureMapperClass : public TextureMapperClass
 {
-	W3DMPO_GLUE(ScaleTextureMapperClass)
+	W3DMPO_CODE(ScaleTextureMapperClass)
 public:
 	ScaleTextureMapperClass(unsigned int stage);
 	ScaleTextureMapperClass(const Vector2 &scale, unsigned int stage);
@@ -129,7 +129,7 @@ protected:
 */
 class LinearOffsetTextureMapperClass : public ScaleTextureMapperClass
 {
-	W3DMPO_GLUE(LinearOffsetTextureMapperClass)
+	W3DMPO_CODE(LinearOffsetTextureMapperClass)
 public:
 	LinearOffsetTextureMapperClass(const Vector2 &offset_per_sec, const Vector2 &scale, unsigned int stage);
 	LinearOffsetTextureMapperClass(const INIClass &ini, const char *section, unsigned int stage);
@@ -169,7 +169,7 @@ protected:
 */
 class GridTextureMapperClass : public TextureMapperClass
 {
-	W3DMPO_GLUE(GridTextureMapperClass)
+	W3DMPO_CODE(GridTextureMapperClass)
 public:
 	GridTextureMapperClass(float fps, unsigned int gridwidth_log2, unsigned int stage);
 	GridTextureMapperClass(const INIClass &ini, const char *section, unsigned int stage);
@@ -211,7 +211,7 @@ protected:
 */
 class RotateTextureMapperClass : public ScaleTextureMapperClass
 {
-	W3DMPO_GLUE(RotateTextureMapperClass)
+	W3DMPO_CODE(RotateTextureMapperClass)
 public:
 	RotateTextureMapperClass(float rad_per_sec, const Vector2& center, unsigned int stage);
 	RotateTextureMapperClass(const INIClass &ini, const char *section, unsigned int stage);
@@ -238,7 +238,7 @@ private:
 */
 class SineLinearOffsetTextureMapperClass : public TextureMapperClass
 {
-	W3DMPO_GLUE(SineLinearOffsetTextureMapperClass)
+	W3DMPO_CODE(SineLinearOffsetTextureMapperClass)
 public:
 	SineLinearOffsetTextureMapperClass(const Vector3 &uafp, const Vector3 &vafp, unsigned int stage);
 	SineLinearOffsetTextureMapperClass(const INIClass &ini, const char *section, unsigned int stage);
@@ -265,7 +265,7 @@ private:
 */
 class StepLinearOffsetTextureMapperClass : public TextureMapperClass
 {
-	W3DMPO_GLUE(StepLinearOffsetTextureMapperClass)
+	W3DMPO_CODE(StepLinearOffsetTextureMapperClass)
 public:
 	StepLinearOffsetTextureMapperClass(const Vector2 &step, float steps_per_sec, unsigned int stage);
 	StepLinearOffsetTextureMapperClass(const INIClass &ini, const char *section, unsigned int stage);
@@ -292,7 +292,7 @@ private:
 */
 class ZigZagLinearOffsetTextureMapperClass : public TextureMapperClass
 {
-	W3DMPO_GLUE(ZigZagLinearOffsetTextureMapperClass)
+	W3DMPO_CODE(ZigZagLinearOffsetTextureMapperClass)
 public:
 	ZigZagLinearOffsetTextureMapperClass(const Vector2 &speed, float period, unsigned int stage);
 	ZigZagLinearOffsetTextureMapperClass(const INIClass &ini, const char *section, unsigned int stage);
@@ -321,7 +321,7 @@ private:
 
 class ClassicEnvironmentMapperClass : public TextureMapperClass
 {
-	W3DMPO_GLUE(ClassicEnvironmentMapperClass)
+	W3DMPO_CODE(ClassicEnvironmentMapperClass)
 public:
 	ClassicEnvironmentMapperClass(unsigned int stage) : TextureMapperClass(stage) { }
 	ClassicEnvironmentMapperClass(const ClassicEnvironmentMapperClass & src) : TextureMapperClass(src) { }
@@ -333,7 +333,7 @@ public:
 
 class EnvironmentMapperClass : public TextureMapperClass
 {
-	W3DMPO_GLUE(EnvironmentMapperClass)
+	W3DMPO_CODE(EnvironmentMapperClass)
 public:
 	EnvironmentMapperClass(unsigned int stage) : TextureMapperClass(stage) { }
 	EnvironmentMapperClass(const EnvironmentMapperClass & src) : TextureMapperClass(src) { }
@@ -345,7 +345,7 @@ public:
 
 class EdgeMapperClass : public TextureMapperClass
 {
-	W3DMPO_GLUE(EdgeMapperClass)
+	W3DMPO_CODE(EdgeMapperClass)
 public:
 	EdgeMapperClass(unsigned int stage);
 	EdgeMapperClass(const INIClass &ini, const char *section, unsigned int stage);
@@ -365,7 +365,7 @@ protected:
 
 class WSClassicEnvironmentMapperClass : public TextureMapperClass
 {
-	W3DMPO_GLUE(WSClassicEnvironmentMapperClass)
+	W3DMPO_CODE(WSClassicEnvironmentMapperClass)
 public:
 	WSClassicEnvironmentMapperClass(unsigned int stage) : TextureMapperClass(stage) { }
 	WSClassicEnvironmentMapperClass(const WSClassicEnvironmentMapperClass & src) : TextureMapperClass(src) { }
@@ -377,7 +377,7 @@ public:
 
 class WSEnvironmentMapperClass : public TextureMapperClass
 {
-	W3DMPO_GLUE(WSEnvironmentMapperClass)
+	W3DMPO_CODE(WSEnvironmentMapperClass)
 public:
 	WSEnvironmentMapperClass(unsigned int stage) : TextureMapperClass(stage) { }
 	WSEnvironmentMapperClass(const WSEnvironmentMapperClass & src) : TextureMapperClass(src) { }
@@ -389,7 +389,7 @@ public:
 
 class GridClassicEnvironmentMapperClass : public GridTextureMapperClass
 {
-	W3DMPO_GLUE(GridClassicEnvironmentMapperClass)
+	W3DMPO_CODE(GridClassicEnvironmentMapperClass)
 public:
 	GridClassicEnvironmentMapperClass(float fps,unsigned int gridwidth, unsigned int stage):GridTextureMapperClass(fps,gridwidth,stage) { }
 	GridClassicEnvironmentMapperClass(const INIClass &ini, const char *section, unsigned int stage) : GridTextureMapperClass(ini,section,stage) { }
@@ -402,7 +402,7 @@ public:
 
 class GridEnvironmentMapperClass : public GridTextureMapperClass
 {
-	W3DMPO_GLUE(GridEnvironmentMapperClass)
+	W3DMPO_CODE(GridEnvironmentMapperClass)
 public:
 	GridEnvironmentMapperClass(float fps,unsigned int gridwidth, unsigned int stage):GridTextureMapperClass(fps,gridwidth,stage) { }
 	GridEnvironmentMapperClass(const INIClass &ini, const char *section, unsigned int stage) : GridTextureMapperClass(ini,section,stage) { }
@@ -421,7 +421,7 @@ public:
 // ----------------------------------------------------------------------------
 class ScreenMapperClass : public LinearOffsetTextureMapperClass
 {
-	W3DMPO_GLUE(ScreenMapperClass)
+	W3DMPO_CODE(ScreenMapperClass)
 public:
 	ScreenMapperClass(const Vector2 &offset_per_sec, const Vector2 &scale, unsigned int stage):LinearOffsetTextureMapperClass(offset_per_sec,scale,stage) { }
 	ScreenMapperClass(const INIClass &ini, const char *section, unsigned int stage):LinearOffsetTextureMapperClass(ini,section,stage) { }
@@ -437,7 +437,7 @@ public:
 */
 class RandomTextureMapperClass : public TextureMapperClass
 {
-	W3DMPO_GLUE(RandomTextureMapperClass)
+	W3DMPO_CODE(RandomTextureMapperClass)
 public:
 	RandomTextureMapperClass(float fps, unsigned int stage);
 	RandomTextureMapperClass(const INIClass &ini, const char *section, unsigned int stage);
@@ -466,7 +466,7 @@ protected:
 */
 class BumpEnvTextureMapperClass : public LinearOffsetTextureMapperClass
 {
-	W3DMPO_GLUE(BumpEnvTextureMapperClass)
+	W3DMPO_CODE(BumpEnvTextureMapperClass)
 public:
 	BumpEnvTextureMapperClass(float rad_per_sec, float scale_factor, const Vector2 & offset_per_sec, const Vector2 &scale, unsigned int stage);
 	BumpEnvTextureMapperClass(INIClass &ini, const char *section, unsigned int stage);

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/matrixmapper.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/matrixmapper.h
@@ -60,7 +60,7 @@
 */
 class MatrixMapperClass : public TextureMapperClass
 {
-	W3DMPO_GLUE(MatrixMapperClass)
+	W3DMPO_CODE(MatrixMapperClass)
 public:
 
 	enum {

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/mesh.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/mesh.h
@@ -65,9 +65,9 @@ struct VertexFormatXYZNDUV2;
 /**
 ** MeshClass -- Render3DObject for rendering meshes.
 */
-class MeshClass : public W3DMPO, public RenderObjClass
+class MeshClass : public RenderObjClass
 {
-	W3DMPO_GLUE(MeshClass)
+	W3DMPO_CODE(MeshClass)
 public:
 
 	MeshClass();

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/meshgeometry.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/meshgeometry.h
@@ -81,10 +81,8 @@ typedef Vector3i TriIndex;
 ** This class encapsulates the geometry data for a triangle mesh.
 */
 
-class MeshGeometryClass : public W3DMPO, public RefCountClass, public MultiListObjectClass
+class MeshGeometryClass : public RefCountClass, public MultiListObjectClass
 {
-	//W3DMPO_GLUE(MeshGeometryClass)
-
 public:
 
 	MeshGeometryClass();

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/meshmatdesc.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/meshmatdesc.h
@@ -57,9 +57,9 @@ class MeshModelClass;
 ** MeshMatDescClass - This class encapsulates all of the material description data for a mesh.
 ** WARNING: The vertex count and polygon count *MUST* be kept in sync with the mesh
 */
-class MeshMatDescClass : public W3DMPO
+class MeshMatDescClass
 {
-	W3DMPO_GLUE(MeshMatDescClass)
+	W3DMPO_CODE(MeshMatDescClass)
 public:
 
 	enum
@@ -72,7 +72,7 @@ public:
 
 	MeshMatDescClass();
 	MeshMatDescClass(const MeshMatDescClass & that);
-	virtual ~MeshMatDescClass() override;
+	~MeshMatDescClass();
 	void							Reset(int polycount,int vertcount,int passcount);
 	MeshMatDescClass &		operator = (const MeshMatDescClass & that);
 
@@ -230,7 +230,7 @@ protected:
 */
 class MatBufferClass : public ShareBufferClass < VertexMaterialClass * >
 {
-	W3DMPO_GLUE(MatBufferClass)
+	W3DMPO_CODE(MatBufferClass)
 public:
 	MatBufferClass(int count, const char* msg) : ShareBufferClass<VertexMaterialClass *>(count, msg) { Clear(); }
 	MatBufferClass(const MatBufferClass & that);
@@ -252,7 +252,7 @@ private:
 */
 class TexBufferClass : public ShareBufferClass < TextureClass * >
 {
-	W3DMPO_GLUE(TexBufferClass)
+	W3DMPO_CODE(TexBufferClass)
 public:
 	TexBufferClass(int count, const char* msg) : ShareBufferClass<TextureClass *>(count, msg) { Clear(); }
 	TexBufferClass(const TexBufferClass & that);
@@ -274,7 +274,7 @@ private:
 */
 class UVBufferClass : public ShareBufferClass < Vector2 >
 {
-	W3DMPO_GLUE(UVBufferClass)
+	W3DMPO_CODE(UVBufferClass)
 public:
 	UVBufferClass(int count, const char* msg) : ShareBufferClass<Vector2>(count, msg), CRC(0xFFFFFFFF) { }
 	UVBufferClass(const UVBufferClass & that);

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/meshmdl.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/meshmdl.h
@@ -117,9 +117,9 @@ struct VertexFormatXYZNDUV2;
 ** GapFillerClass
 ** This class is used to generate gap-filling polygons for "N-Patched" meshes
 */
-class GapFillerClass : public W3DMPO
+class GapFillerClass
 {
-	W3DMPO_GLUE(GapFillerClass)
+	W3DMPO_CODE(GapFillerClass)
 
 	TriIndex* PolygonArray;
 	unsigned PolygonCount;
@@ -133,7 +133,7 @@ class GapFillerClass : public W3DMPO
 public:
 	GapFillerClass(MeshModelClass* mmc);
 	GapFillerClass(const GapFillerClass& that);
-	virtual ~GapFillerClass() override;
+	~GapFillerClass();
 
 	WWINLINE const TriIndex* Get_Polygon_Array() const { return PolygonArray; }
 	WWINLINE unsigned Get_Polygon_Count() const { return PolygonCount; }
@@ -147,7 +147,7 @@ public:
 
 class MeshModelClass : public MeshGeometryClass
 {
-	W3DMPO_GLUE(MeshModelClass)
+	W3DMPO_CODE(MeshModelClass)
 	GapFillerClass* GapFiller;
 
 public:

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/meshmdlio.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/meshmdlio.cpp
@@ -109,12 +109,12 @@
 ** will own the refs for the mesh.  The load context object is destroyed once
 ** loading is complete...
 */
-class MeshLoadContextClass : public W3DMPO
+class MeshLoadContextClass
 {
-	W3DMPO_GLUE(MeshLoadContextClass)
+	W3DMPO_CODE(MeshLoadContextClass)
 private:
 	MeshLoadContextClass();
-	virtual ~MeshLoadContextClass() override;
+	~MeshLoadContextClass();
 
 	W3dTexCoordStruct *		Get_Texcoord_Array();
 

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/motchan.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/motchan.h
@@ -56,14 +56,14 @@ class Quaternion;
 
 ******************************************************************************/
 
-class MotionChannelClass : public W3DMPO
+class MotionChannelClass
 {
-	W3DMPO_GLUE(MotionChannelClass)
+	W3DMPO_CODE(MotionChannelClass)
 
 public:
 
 	MotionChannelClass();
-	virtual ~MotionChannelClass() override;
+	~MotionChannelClass();
 
 	bool	Load_W3D(ChunkLoadClass & cload);
 	WWINLINE int Get_Type() const { return Type; }
@@ -147,14 +147,14 @@ WWINLINE void MotionChannelClass::Get_Vector_As_Quat(int frame, Quaternion& quat
 
 ******************************************************************************/
 
-class BitChannelClass : public W3DMPO
+class BitChannelClass
 {
-	W3DMPO_GLUE(BitChannelClass)
+	W3DMPO_CODE(BitChannelClass)
 
 public:
 
 	BitChannelClass();
-	virtual ~BitChannelClass() override;
+	~BitChannelClass();
 
 	bool	Load_W3D(ChunkLoadClass & cload);
 	WWINLINE int	Get_Type() const { return Type; }
@@ -203,14 +203,14 @@ WWINLINE int BitChannelClass::Get_Bit(int frame) const
 
 ******************************************************************************/
 
-class TimeCodedMotionChannelClass : public W3DMPO
+class TimeCodedMotionChannelClass
 {
-	W3DMPO_GLUE(TimeCodedMotionChannelClass)
+	W3DMPO_CODE(TimeCodedMotionChannelClass)
 
 public:
 
 	TimeCodedMotionChannelClass();
-	virtual ~TimeCodedMotionChannelClass() override;
+	~TimeCodedMotionChannelClass();
 
 	bool	Load_W3D(ChunkLoadClass & cload);
 	int	Get_Type() { return Type; }
@@ -241,14 +241,14 @@ private:
 	friend class HCompressedAnimClass;
 };
 
-class AdaptiveDeltaMotionChannelClass : public W3DMPO
+class AdaptiveDeltaMotionChannelClass
 {
-	W3DMPO_GLUE(AdaptiveDeltaMotionChannelClass)
+	W3DMPO_CODE(AdaptiveDeltaMotionChannelClass)
 
 public:
 
 	AdaptiveDeltaMotionChannelClass();
-	virtual ~AdaptiveDeltaMotionChannelClass() override;
+	~AdaptiveDeltaMotionChannelClass();
 
 	bool	Load_W3D(ChunkLoadClass & cload);
 	int	Get_Type() { return Type; }
@@ -290,14 +290,14 @@ private:
 
 ******************************************************************************/
 
-class TimeCodedBitChannelClass : public W3DMPO
+class TimeCodedBitChannelClass
 {
-	W3DMPO_GLUE(TimeCodedBitChannelClass)
+	W3DMPO_CODE(TimeCodedBitChannelClass)
 
 public:
 
 	TimeCodedBitChannelClass();
-	virtual ~TimeCodedBitChannelClass() override;
+	~TimeCodedBitChannelClass();
 
 	bool	Load_W3D(ChunkLoadClass & cload);
 	int	Get_Type() { return Type; }

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/nullrobj.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/nullrobj.h
@@ -60,9 +60,9 @@ protected:
 };
 
 
-class NullPrototypeClass : public W3DMPO, public PrototypeClass
+class NullPrototypeClass : public PrototypeClass
 {
-	W3DMPO_GLUE(NullPrototypeClass)
+	W3DMPO_CODE(NullPrototypeClass)
 public:
 	NullPrototypeClass();
 	NullPrototypeClass(const W3dNullObjectStruct &null);

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/part_ldr.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/part_ldr.h
@@ -312,9 +312,9 @@ inline void ParticleEmitterDefClass::Set_Line_Texture_Mapping_Mode(int mode)
 //
 //	ParticleEmitterPrototypeClass
 //
-class ParticleEmitterPrototypeClass : public W3DMPO, public PrototypeClass
+class ParticleEmitterPrototypeClass : public PrototypeClass
 {
-	W3DMPO_GLUE(ParticleEmitterPrototypeClass)
+	W3DMPO_CODE(ParticleEmitterPrototypeClass)
 	public:
 
 		///////////////////////////////////////////////////////////

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/render2d.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/render2d.h
@@ -90,12 +90,12 @@ class	Vector4;
 /*
 ** Render2DClass
 */
-class Render2DClass : public W3DMPO
+class Render2DClass
 {
-	W3DMPO_GLUE(Render2DClass)
+	W3DMPO_CODE(Render2DClass)
 public:
 	Render2DClass( TextureClass* tex = nullptr );
-	virtual ~Render2DClass() override;
+	virtual ~Render2DClass();
 
 	virtual	void	Reset();
 	void	Render();

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/sortingrenderer.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/sortingrenderer.cpp
@@ -214,7 +214,7 @@ void Sort (
 
 class SortingNodeStruct : public DLNodeClass<SortingNodeStruct>
 {
-	W3DMPO_GLUE(SortingNodeStruct)
+	W3DMPO_CODE(SortingNodeStruct)
 
 public:
 	RenderStateStruct sorting_state;

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/vertmaterial.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/vertmaterial.cpp
@@ -53,9 +53,9 @@ static unsigned int unique=1;
 VertexMaterialClass* VertexMaterialClass::Presets[VertexMaterialClass::PRESET_COUNT];
 
 #ifdef DYN_MAT8
-class DynD3DMATERIAL8 : public W3DMPO
+class DynD3DMATERIAL8
 {
-	W3DMPO_GLUE(DynD3DMATERIAL8)
+	W3DMPO_CODE(DynD3DMATERIAL8)
 public:
 	D3DMATERIAL8 Mat;
 };

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/vertmaterial.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/vertmaterial.h
@@ -60,9 +60,9 @@ struct _D3DMATERIAL8;
 ** This is simply the typical W3D thin-wrapper around the surrender vertex material.
 ** The vertex material defines things like the lighting properties of a vertex.
 */
-class VertexMaterialClass : public W3DMPO, public RefCountClass
+class VertexMaterialClass : public RefCountClass
 {
-	W3DMPO_GLUE(VertexMaterialClass)
+	W3DMPO_CODE(VertexMaterialClass)
 
 	friend DX8Wrapper;
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/boxrobj.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/boxrobj.h
@@ -129,7 +129,7 @@ inline void BoxRenderObjClass::Set_Local_Min_Max(const Vector3 & min,const Vecto
 /*
 ** AABoxRenderObjClass -- RenderObject for axis-aligned collision boxes.
 */
-class AABoxRenderObjClass : public W3DMPO, public BoxRenderObjClass
+class AABoxRenderObjClass : public BoxRenderObjClass
 {
 	W3DMPO_CODE(AABoxRenderObjClass)
 public:
@@ -180,7 +180,7 @@ inline const AABoxClass & AABoxRenderObjClass::Get_Box()
 /*
 ** OBBoxRenderObjClass - render object for oriented collision boxes
 */
-class OBBoxRenderObjClass : public W3DMPO, public BoxRenderObjClass
+class OBBoxRenderObjClass : public BoxRenderObjClass
 {
 	W3DMPO_CODE(OBBoxRenderObjClass)
 public:
@@ -237,7 +237,7 @@ public:
 /*
 ** Prototype for Box objects
 */
-class BoxPrototypeClass : public W3DMPO, public PrototypeClass
+class BoxPrototypeClass : public PrototypeClass
 {
 	W3DMPO_CODE(BoxPrototypeClass)
 public:

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/boxrobj.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/boxrobj.h
@@ -131,7 +131,7 @@ inline void BoxRenderObjClass::Set_Local_Min_Max(const Vector3 & min,const Vecto
 */
 class AABoxRenderObjClass : public W3DMPO, public BoxRenderObjClass
 {
-	W3DMPO_GLUE(AABoxRenderObjClass)
+	W3DMPO_CODE(AABoxRenderObjClass)
 public:
 
 	AABoxRenderObjClass();
@@ -182,7 +182,7 @@ inline const AABoxClass & AABoxRenderObjClass::Get_Box()
 */
 class OBBoxRenderObjClass : public W3DMPO, public BoxRenderObjClass
 {
-	W3DMPO_GLUE(OBBoxRenderObjClass)
+	W3DMPO_CODE(OBBoxRenderObjClass)
 public:
 
 	OBBoxRenderObjClass();
@@ -239,7 +239,7 @@ public:
 */
 class BoxPrototypeClass : public W3DMPO, public PrototypeClass
 {
-	W3DMPO_GLUE(BoxPrototypeClass)
+	W3DMPO_CODE(BoxPrototypeClass)
 public:
 	BoxPrototypeClass(W3dBoxStruct box);
 	virtual const char *				Get_Name() const override;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dazzle.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dazzle.h
@@ -353,7 +353,7 @@ public:
 ** information needed to construct a particular instance of a dazzle.  Prototypes are
 ** stored in the asset manager and used to construct render objects when needed.
 */
-class DazzlePrototypeClass : public W3DMPO, public PrototypeClass
+class DazzlePrototypeClass : public PrototypeClass
 {
 	W3DMPO_CODE(DazzlePrototypeClass)
 public:

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dazzle.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dazzle.h
@@ -355,7 +355,7 @@ public:
 */
 class DazzlePrototypeClass : public W3DMPO, public PrototypeClass
 {
-	W3DMPO_GLUE(DazzlePrototypeClass)
+	W3DMPO_CODE(DazzlePrototypeClass)
 public:
 	DazzlePrototypeClass() : DazzleType(0)				{ }
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8fvf.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8fvf.h
@@ -244,7 +244,7 @@ struct VertexFormatXYZNDCUBEMAP
 // FVF info class can be created for any legal FVF. It constructs information
 // of offsets to various elements in the vertex buffer.
 
-class FVFInfoClass : public W3DMPO
+class FVFInfoClass
 {
 	W3DMPO_CODE(FVFInfoClass)
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8fvf.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8fvf.h
@@ -246,7 +246,7 @@ struct VertexFormatXYZNDCUBEMAP
 
 class FVFInfoClass : public W3DMPO
 {
-	W3DMPO_GLUE(FVFInfoClass)
+	W3DMPO_CODE(FVFInfoClass)
 
 	mutable unsigned						FVF;
 	mutable unsigned						fvf_size;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8indexbuffer.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8indexbuffer.h
@@ -52,8 +52,6 @@ class SortingIndexBufferClass;
 
 class IndexBufferClass : public RefCountClass
 {
-	// nope, it's an ABC
-	//W3DMPO_CODE(IndexBufferClass)
 protected:
 	virtual ~IndexBufferClass() override;
 public:

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8indexbuffer.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8indexbuffer.h
@@ -53,7 +53,7 @@ class SortingIndexBufferClass;
 class IndexBufferClass : public W3DMPO, public RefCountClass
 {
 	// nope, it's an ABC
-	//W3DMPO_GLUE(IndexBufferClass)
+	//W3DMPO_CODE(IndexBufferClass)
 protected:
 	virtual ~IndexBufferClass() override;
 public:
@@ -107,7 +107,7 @@ protected:
 // Created
 class DynamicIBAccessClass : public W3DMPO
 {
-	W3DMPO_GLUE(DynamicIBAccessClass)
+	W3DMPO_CODE(DynamicIBAccessClass)
 
 	friend DX8Wrapper;
 	friend SortingRendererClass;
@@ -155,7 +155,7 @@ public:
 */
 class DX8IndexBufferClass : public IndexBufferClass
 {
-	W3DMPO_GLUE(DX8IndexBufferClass)
+	W3DMPO_CODE(DX8IndexBufferClass)
 
 	friend IndexBufferClass::WriteLockClass;
 	friend IndexBufferClass::AppendLockClass;
@@ -183,7 +183,7 @@ private:
 
 class SortingIndexBufferClass : public IndexBufferClass
 {
-	W3DMPO_GLUE(SortingIndexBufferClass)
+	W3DMPO_CODE(SortingIndexBufferClass)
 
 	friend DX8Wrapper;
 	friend SortingRendererClass;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8indexbuffer.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8indexbuffer.h
@@ -50,7 +50,7 @@ class SortingIndexBufferClass;
 
 // ----------------------------------------------------------------------------
 
-class IndexBufferClass : public W3DMPO, public RefCountClass
+class IndexBufferClass : public RefCountClass
 {
 	// nope, it's an ABC
 	//W3DMPO_CODE(IndexBufferClass)
@@ -105,7 +105,7 @@ protected:
 
 // HY 2/14/01
 // Created
-class DynamicIBAccessClass : public W3DMPO
+class DynamicIBAccessClass
 {
 	W3DMPO_CODE(DynamicIBAccessClass)
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8indexbuffer.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8indexbuffer.h
@@ -120,7 +120,7 @@ class DynamicIBAccessClass
 
 public:
 	DynamicIBAccessClass(unsigned short type, unsigned short index_count);
-	virtual ~DynamicIBAccessClass() override;
+	~DynamicIBAccessClass();
 
 	unsigned Get_Type() const { return Type; }
 	unsigned short Get_Index_Count() const { return IndexCount; }

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8vertexbuffer.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8vertexbuffer.h
@@ -73,7 +73,7 @@ public:
 ** DX8VertexBufferClass
 ** This class wraps a DX8 vertex buffer.  Use the lock objects to modify or append to the vertex buffer.
 */
-class VertexBufferClass : public W3DMPO, public RefCountClass
+class VertexBufferClass : public RefCountClass
 {
 	// nope, an ABC
 	//W3DMPO_CODE(VertexBufferClass)

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8vertexbuffer.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8vertexbuffer.h
@@ -76,7 +76,7 @@ public:
 class VertexBufferClass : public W3DMPO, public RefCountClass
 {
 	// nope, an ABC
-	//W3DMPO_GLUE(VertexBufferClass)
+	//W3DMPO_CODE(VertexBufferClass)
 
 protected:
 	VertexBufferClass(unsigned type, unsigned FVF, unsigned short VertexCount);
@@ -200,7 +200,7 @@ inline VertexFormatXYZNDUV2 * DynamicVBAccessClass::WriteLockClass::Get_Formatte
 */
 class DX8VertexBufferClass : public VertexBufferClass
 {
-	W3DMPO_GLUE(DX8VertexBufferClass)
+	W3DMPO_CODE(DX8VertexBufferClass)
 protected:
 	virtual ~DX8VertexBufferClass() override;
 public:
@@ -239,7 +239,7 @@ protected:
 */
 class SortingVertexBufferClass : public VertexBufferClass
 {
-	W3DMPO_GLUE(SortingVertexBufferClass)
+	W3DMPO_CODE(SortingVertexBufferClass)
 
 	friend DX8Wrapper;
 	friend SortingRendererClass;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8vertexbuffer.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8vertexbuffer.h
@@ -75,9 +75,6 @@ public:
 */
 class VertexBufferClass : public RefCountClass
 {
-	// nope, an ABC
-	//W3DMPO_CODE(VertexBufferClass)
-
 protected:
 	VertexBufferClass(unsigned type, unsigned FVF, unsigned short VertexCount);
 	virtual ~VertexBufferClass() override;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/hlod.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/hlod.cpp
@@ -182,7 +182,7 @@ protected:
 ** This is a ref-counted list of proxy objects.  It is generated whenever an HLODdef contains
 ** proxies.  Each instantiated HLOD simply add-refs a pointer to the single list.
 */
-class ProxyArrayClass : public W3DMPO, public VectorClass<ProxyRecordClass>, public RefCountClass
+class ProxyArrayClass : public VectorClass<ProxyRecordClass>, public RefCountClass
 {
 	W3DMPO_CODE(ProxyArrayClass)
 public:

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/hlod.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/hlod.cpp
@@ -184,7 +184,7 @@ protected:
 */
 class ProxyArrayClass : public W3DMPO, public VectorClass<ProxyRecordClass>, public RefCountClass
 {
-	W3DMPO_GLUE(ProxyArrayClass)
+	W3DMPO_CODE(ProxyArrayClass)
 public:
 	ProxyArrayClass(int size) : VectorClass<ProxyRecordClass>(size)
 	{

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/hlod.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/hlod.h
@@ -59,7 +59,7 @@ class ProxyArrayClass;
 	This is an hierarchical, animatable level-of-detail model.
 
 */
-class HLodClass : public W3DMPO, public Animatable3DObjClass
+class HLodClass : public Animatable3DObjClass
 {
 	W3DMPO_CODE(HLodClass)
 public:
@@ -277,7 +277,7 @@ public:
 ** This description object is generated when reading a W3D_CHUNK_HLOD.  It
 ** directly describes the contents of an HLod model.
 */
-class HLodDefClass : public W3DMPO
+class HLodDefClass
 {
 	W3DMPO_CODE(HLodDefClass)
 public:
@@ -343,7 +343,7 @@ private:
 /*
 ** Prototype for HLod objects
 */
-class HLodPrototypeClass : public W3DMPO, public PrototypeClass
+class HLodPrototypeClass : public PrototypeClass
 {
 	W3DMPO_CODE(HLodPrototypeClass)
 public:

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/hlod.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/hlod.h
@@ -284,7 +284,7 @@ public:
 
 	HLodDefClass();
 	HLodDefClass(HLodClass &src_lod);
-	virtual ~HLodDefClass() override;
+	~HLodDefClass();
 
 	WW3DErrorType				Load_W3D(ChunkLoadClass & cload);
 	WW3DErrorType				Save(ChunkSaveClass & csave);

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/hlod.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/hlod.h
@@ -61,7 +61,7 @@ class ProxyArrayClass;
 */
 class HLodClass : public W3DMPO, public Animatable3DObjClass
 {
-	W3DMPO_GLUE(HLodClass)
+	W3DMPO_CODE(HLodClass)
 public:
 
 	HLodClass(const HLodClass & src);
@@ -279,7 +279,7 @@ public:
 */
 class HLodDefClass : public W3DMPO
 {
-	W3DMPO_GLUE(HLodDefClass)
+	W3DMPO_CODE(HLodDefClass)
 public:
 
 	HLodDefClass();
@@ -345,7 +345,7 @@ private:
 */
 class HLodPrototypeClass : public W3DMPO, public PrototypeClass
 {
-	W3DMPO_GLUE(HLodPrototypeClass)
+	W3DMPO_CODE(HLodPrototypeClass)
 public:
 	HLodPrototypeClass( HLodDefClass *def )					{ Definition = def; }
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/mapper.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/mapper.h
@@ -113,7 +113,7 @@ class TextureMapperClass : public W3DMPO, public RefCountClass
 */
 class ScaleTextureMapperClass : public TextureMapperClass
 {
-	W3DMPO_GLUE(ScaleTextureMapperClass)
+	W3DMPO_CODE(ScaleTextureMapperClass)
 public:
 	ScaleTextureMapperClass(const Vector2 &scale, unsigned int stage);
 	ScaleTextureMapperClass(const INIClass &ini, const char *section, unsigned int stage);
@@ -136,7 +136,7 @@ protected:
 */
 class LinearOffsetTextureMapperClass : public ScaleTextureMapperClass
 {
-	W3DMPO_GLUE(LinearOffsetTextureMapperClass)
+	W3DMPO_CODE(LinearOffsetTextureMapperClass)
 public:
 	LinearOffsetTextureMapperClass(const Vector2 &offset_per_sec, const Vector2 & start_offset,
 		bool clamp_fix, const Vector2 &scale, unsigned int stage);
@@ -179,7 +179,7 @@ protected:
 */
 class GridTextureMapperClass : public TextureMapperClass
 {
-	W3DMPO_GLUE(GridTextureMapperClass)
+	W3DMPO_CODE(GridTextureMapperClass)
 public:
 	GridTextureMapperClass(float fps, unsigned int gridwidth_log2, unsigned int last_frame, unsigned int offset, unsigned int stage);
 	GridTextureMapperClass(const INIClass &ini, const char *section, unsigned int stage);
@@ -223,7 +223,7 @@ protected:
 */
 class RotateTextureMapperClass : public ScaleTextureMapperClass
 {
-	W3DMPO_GLUE(RotateTextureMapperClass)
+	W3DMPO_CODE(RotateTextureMapperClass)
 public:
 	RotateTextureMapperClass(float rad_per_sec, const Vector2& center, const Vector2 &scale, unsigned int stage);
 	RotateTextureMapperClass(const INIClass &ini, const char *section, unsigned int stage);
@@ -250,7 +250,7 @@ private:
 */
 class SineLinearOffsetTextureMapperClass : public ScaleTextureMapperClass
 {
-	W3DMPO_GLUE(SineLinearOffsetTextureMapperClass)
+	W3DMPO_CODE(SineLinearOffsetTextureMapperClass)
 public:
 	SineLinearOffsetTextureMapperClass(const Vector3 &uafp, const Vector3 &vafp, const Vector2 &scale, unsigned int stage);
 	SineLinearOffsetTextureMapperClass(const INIClass &ini, const char *section, unsigned int stage);
@@ -277,7 +277,7 @@ private:
 */
 class StepLinearOffsetTextureMapperClass : public ScaleTextureMapperClass
 {
-	W3DMPO_GLUE(StepLinearOffsetTextureMapperClass)
+	W3DMPO_CODE(StepLinearOffsetTextureMapperClass)
 public:
 	StepLinearOffsetTextureMapperClass(const Vector2 &step, float steps_per_sec, bool clamp_fix,
 		const Vector2 &scale, unsigned int stage);
@@ -307,7 +307,7 @@ private:
 */
 class ZigZagLinearOffsetTextureMapperClass : public ScaleTextureMapperClass
 {
-	W3DMPO_GLUE(ZigZagLinearOffsetTextureMapperClass)
+	W3DMPO_CODE(ZigZagLinearOffsetTextureMapperClass)
 public:
 	ZigZagLinearOffsetTextureMapperClass(const Vector2 &speed, float period, const Vector2 &scale, unsigned int stage);
 	ZigZagLinearOffsetTextureMapperClass(const INIClass &ini, const char *section, unsigned int stage);
@@ -338,7 +338,7 @@ private:
 
 class ClassicEnvironmentMapperClass : public TextureMapperClass
 {
-	W3DMPO_GLUE(ClassicEnvironmentMapperClass)
+	W3DMPO_CODE(ClassicEnvironmentMapperClass)
 public:
 	ClassicEnvironmentMapperClass(unsigned int stage) : TextureMapperClass(stage) { }
 	ClassicEnvironmentMapperClass(const ClassicEnvironmentMapperClass & src) : TextureMapperClass(src) { }
@@ -351,7 +351,7 @@ public:
 
 class EnvironmentMapperClass : public TextureMapperClass
 {
-	W3DMPO_GLUE(EnvironmentMapperClass)
+	W3DMPO_CODE(EnvironmentMapperClass)
 public:
 	EnvironmentMapperClass(unsigned int stage) : TextureMapperClass(stage) { }
 	EnvironmentMapperClass(const EnvironmentMapperClass & src) : TextureMapperClass(src) { }
@@ -364,7 +364,7 @@ public:
 
 class EdgeMapperClass : public TextureMapperClass
 {
-	W3DMPO_GLUE(EdgeMapperClass)
+	W3DMPO_CODE(EdgeMapperClass)
 public:
 	EdgeMapperClass(unsigned int stage);
 	EdgeMapperClass(const INIClass &ini, const char *section, unsigned int stage);
@@ -398,7 +398,7 @@ protected:
 
 class WSClassicEnvironmentMapperClass : public WSEnvMapperClass
 {
-	W3DMPO_GLUE(WSClassicEnvironmentMapperClass)
+	W3DMPO_CODE(WSClassicEnvironmentMapperClass)
 public:
 	WSClassicEnvironmentMapperClass(AxisType axis, unsigned int stage) : WSEnvMapperClass(axis, stage) { }
 	WSClassicEnvironmentMapperClass(const WSClassicEnvironmentMapperClass & src) : WSEnvMapperClass(src) { }
@@ -410,7 +410,7 @@ public:
 
 class WSEnvironmentMapperClass : public WSEnvMapperClass
 {
-	W3DMPO_GLUE(WSEnvironmentMapperClass)
+	W3DMPO_CODE(WSEnvironmentMapperClass)
 public:
 	WSEnvironmentMapperClass(AxisType axis, unsigned int stage) : WSEnvMapperClass(axis, stage) { }
 	WSEnvironmentMapperClass(const WSClassicEnvironmentMapperClass & src) : WSEnvMapperClass(src) { }
@@ -422,7 +422,7 @@ public:
 
 class GridClassicEnvironmentMapperClass : public GridTextureMapperClass
 {
-	W3DMPO_GLUE(GridClassicEnvironmentMapperClass)
+	W3DMPO_CODE(GridClassicEnvironmentMapperClass)
 public:
 	GridClassicEnvironmentMapperClass(float fps, unsigned int gridwidth_log2, unsigned int last_frame, unsigned int offset, unsigned int stage) : GridTextureMapperClass(fps, gridwidth_log2, last_frame, offset, stage) { }
 	GridClassicEnvironmentMapperClass(const INIClass &ini, const char *section, unsigned int stage) : GridTextureMapperClass(ini, section, stage) { }
@@ -436,7 +436,7 @@ public:
 
 class GridEnvironmentMapperClass : public GridTextureMapperClass
 {
-	W3DMPO_GLUE(GridEnvironmentMapperClass)
+	W3DMPO_CODE(GridEnvironmentMapperClass)
 public:
 	GridEnvironmentMapperClass(float fps, unsigned int gridwidth_log2, unsigned int last_frame, unsigned int offset, unsigned int stage) : GridTextureMapperClass(fps, gridwidth_log2, last_frame, offset, stage) { }
 	GridEnvironmentMapperClass(const INIClass &ini, const char *section, unsigned int stage) : GridTextureMapperClass(ini, section, stage) { }
@@ -456,7 +456,7 @@ public:
 // ----------------------------------------------------------------------------
 class ScreenMapperClass : public LinearOffsetTextureMapperClass
 {
-	W3DMPO_GLUE(ScreenMapperClass)
+	W3DMPO_CODE(ScreenMapperClass)
 public:
 	ScreenMapperClass(const Vector2 &offset_per_sec, const Vector2 & start_offset, bool clamp_fix,
 		const Vector2 &scale, unsigned int stage) : LinearOffsetTextureMapperClass(offset_per_sec, start_offset, clamp_fix, scale, stage) { }
@@ -474,7 +474,7 @@ public:
 */
 class RandomTextureMapperClass : public ScaleTextureMapperClass
 {
-	W3DMPO_GLUE(RandomTextureMapperClass)
+	W3DMPO_CODE(RandomTextureMapperClass)
 public:
 	RandomTextureMapperClass(float fps, const Vector2 &scale, unsigned int stage);
 	RandomTextureMapperClass(const INIClass &ini, const char *section, unsigned int stage);
@@ -505,7 +505,7 @@ protected:
 */
 class BumpEnvTextureMapperClass : public LinearOffsetTextureMapperClass
 {
-	W3DMPO_GLUE(BumpEnvTextureMapperClass)
+	W3DMPO_CODE(BumpEnvTextureMapperClass)
 public:
 	BumpEnvTextureMapperClass(float rad_per_sec, float scale_factor, const Vector2 & offset_per_sec,
 		const Vector2 & start_offset, bool clamp_fix, const Vector2 &scale, unsigned int stage);

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/mapper.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/mapper.h
@@ -53,7 +53,7 @@ class INIClass;
 ** TextureMapperClass
 ** Base class for all texture mappers.
 */
-class TextureMapperClass : public W3DMPO, public RefCountClass
+class TextureMapperClass : public RefCountClass
 {
 	public:
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/matrixmapper.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/matrixmapper.h
@@ -60,7 +60,7 @@
 */
 class MatrixMapperClass : public TextureMapperClass
 {
-	W3DMPO_GLUE(MatrixMapperClass)
+	W3DMPO_CODE(MatrixMapperClass)
 public:
 
 	enum {

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/mesh.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/mesh.h
@@ -65,7 +65,7 @@ struct VertexFormatXYZNDUV2;
 /**
 ** MeshClass -- Render3DObject for rendering meshes.
 */
-class MeshClass : public W3DMPO, public RenderObjClass
+class MeshClass : public RenderObjClass
 {
 	W3DMPO_CODE(MeshClass)
 public:

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/mesh.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/mesh.h
@@ -67,7 +67,7 @@ struct VertexFormatXYZNDUV2;
 */
 class MeshClass : public W3DMPO, public RenderObjClass
 {
-	W3DMPO_GLUE(MeshClass)
+	W3DMPO_CODE(MeshClass)
 public:
 
 	MeshClass();

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshgeometry.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshgeometry.h
@@ -85,8 +85,6 @@ typedef Vector3i16 TriIndex;
 
 class MeshGeometryClass : public RefCountClass, public MultiListObjectClass
 {
-	//W3DMPO_CODE(MeshGeometryClass)
-
 public:
 
 	MeshGeometryClass();

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshgeometry.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshgeometry.h
@@ -85,7 +85,7 @@ typedef Vector3i16 TriIndex;
 
 class MeshGeometryClass : public W3DMPO, public RefCountClass, public MultiListObjectClass
 {
-	//W3DMPO_GLUE(MeshGeometryClass)
+	//W3DMPO_CODE(MeshGeometryClass)
 
 public:
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshgeometry.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshgeometry.h
@@ -83,7 +83,7 @@ typedef Vector3i16 TriIndex;
 ** This class encapsulates the geometry data for a triangle mesh.
 */
 
-class MeshGeometryClass : public W3DMPO, public RefCountClass, public MultiListObjectClass
+class MeshGeometryClass : public RefCountClass, public MultiListObjectClass
 {
 	//W3DMPO_CODE(MeshGeometryClass)
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmatdesc.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmatdesc.h
@@ -72,7 +72,7 @@ public:
 
 	MeshMatDescClass();
 	MeshMatDescClass(const MeshMatDescClass & that);
-	virtual ~MeshMatDescClass() override;
+	~MeshMatDescClass();
 	void							Reset(int polycount,int vertcount,int passcount);
 	MeshMatDescClass &		operator = (const MeshMatDescClass & that);
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmatdesc.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmatdesc.h
@@ -57,7 +57,7 @@ class MeshModelClass;
 ** MeshMatDescClass - This class encapsulates all of the material description data for a mesh.
 ** WARNING: The vertex count and polygon count *MUST* be kept in sync with the mesh
 */
-class MeshMatDescClass : public W3DMPO
+class MeshMatDescClass
 {
 	W3DMPO_CODE(MeshMatDescClass)
 public:

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmatdesc.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmatdesc.h
@@ -59,7 +59,7 @@ class MeshModelClass;
 */
 class MeshMatDescClass : public W3DMPO
 {
-	W3DMPO_GLUE(MeshMatDescClass)
+	W3DMPO_CODE(MeshMatDescClass)
 public:
 
 	enum
@@ -230,7 +230,7 @@ protected:
 */
 class MatBufferClass : public ShareBufferClass < VertexMaterialClass * >
 {
-	W3DMPO_GLUE(MatBufferClass)
+	W3DMPO_CODE(MatBufferClass)
 public:
 	MatBufferClass(int count, const char* msg) : ShareBufferClass<VertexMaterialClass *>(count, msg) { Clear(); }
 	MatBufferClass(const MatBufferClass & that);
@@ -252,7 +252,7 @@ private:
 */
 class TexBufferClass : public ShareBufferClass < TextureClass * >
 {
-	W3DMPO_GLUE(TexBufferClass)
+	W3DMPO_CODE(TexBufferClass)
 public:
 	TexBufferClass(int count, const char* msg) : ShareBufferClass<TextureClass *>(count, msg) { Clear(); }
 	TexBufferClass(const TexBufferClass & that);
@@ -274,7 +274,7 @@ private:
 */
 class UVBufferClass : public ShareBufferClass < Vector2 >
 {
-	W3DMPO_GLUE(UVBufferClass)
+	W3DMPO_CODE(UVBufferClass)
 public:
 	UVBufferClass(int count, const char* msg) : ShareBufferClass<Vector2>(count, msg), CRC(0xFFFFFFFF) { }
 	UVBufferClass(const UVBufferClass & that);

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmdl.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmdl.h
@@ -133,7 +133,7 @@ class GapFillerClass
 public:
 	GapFillerClass(MeshModelClass* mmc);
 	GapFillerClass(const GapFillerClass& that);
-	virtual ~GapFillerClass() override;
+	~GapFillerClass();
 
 	WWINLINE const TriIndex* Get_Polygon_Array() const { return PolygonArray; }
 	WWINLINE unsigned Get_Polygon_Count() const { return PolygonCount; }

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmdl.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmdl.h
@@ -117,7 +117,7 @@ struct VertexFormatXYZNDUV2;
 ** GapFillerClass
 ** This class is used to generate gap-filling polygons for "N-Patched" meshes
 */
-class GapFillerClass : public W3DMPO
+class GapFillerClass
 {
 	W3DMPO_CODE(GapFillerClass)
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmdl.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmdl.h
@@ -119,7 +119,7 @@ struct VertexFormatXYZNDUV2;
 */
 class GapFillerClass : public W3DMPO
 {
-	W3DMPO_GLUE(GapFillerClass)
+	W3DMPO_CODE(GapFillerClass)
 
 	TriIndex* PolygonArray;
 	unsigned PolygonCount;
@@ -147,7 +147,7 @@ public:
 
 class MeshModelClass : public MeshGeometryClass
 {
-	W3DMPO_GLUE(MeshModelClass)
+	W3DMPO_CODE(MeshModelClass)
 
 public:
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmdlio.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmdlio.cpp
@@ -109,7 +109,7 @@
 ** will own the refs for the mesh.  The load context object is destroyed once
 ** loading is complete...
 */
-class MeshLoadContextClass : public W3DMPO
+class MeshLoadContextClass
 {
 	W3DMPO_CODE(MeshLoadContextClass)
 private:

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmdlio.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmdlio.cpp
@@ -114,7 +114,7 @@ class MeshLoadContextClass
 	W3DMPO_CODE(MeshLoadContextClass)
 private:
 	MeshLoadContextClass();
-	virtual ~MeshLoadContextClass() override;
+	~MeshLoadContextClass();
 
 	W3dTexCoordStruct *		Get_Texcoord_Array();
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmdlio.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/meshmdlio.cpp
@@ -111,7 +111,7 @@
 */
 class MeshLoadContextClass : public W3DMPO
 {
-	W3DMPO_GLUE(MeshLoadContextClass)
+	W3DMPO_CODE(MeshLoadContextClass)
 private:
 	MeshLoadContextClass();
 	virtual ~MeshLoadContextClass() override;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/motchan.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/motchan.h
@@ -55,7 +55,7 @@ class Quaternion;
 
 ******************************************************************************/
 
-class MotionChannelClass : public W3DMPO
+class MotionChannelClass
 {
 	W3DMPO_CODE(MotionChannelClass)
 
@@ -152,7 +152,7 @@ WWINLINE void MotionChannelClass::Get_Vector_As_Quat(int frame, Quaternion& quat
 
 ******************************************************************************/
 
-class BitChannelClass : public W3DMPO
+class BitChannelClass
 {
 	W3DMPO_CODE(BitChannelClass)
 
@@ -208,7 +208,7 @@ WWINLINE int BitChannelClass::Get_Bit(int frame) const
 
 ******************************************************************************/
 
-class TimeCodedMotionChannelClass : public W3DMPO
+class TimeCodedMotionChannelClass
 {
 	W3DMPO_CODE(TimeCodedMotionChannelClass)
 
@@ -246,7 +246,7 @@ private:
 	friend class HCompressedAnimClass;
 };
 
-class AdaptiveDeltaMotionChannelClass : public W3DMPO
+class AdaptiveDeltaMotionChannelClass
 {
 	W3DMPO_CODE(AdaptiveDeltaMotionChannelClass)
 
@@ -295,7 +295,7 @@ private:
 
 ******************************************************************************/
 
-class TimeCodedBitChannelClass : public W3DMPO
+class TimeCodedBitChannelClass
 {
 	W3DMPO_CODE(TimeCodedBitChannelClass)
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/motchan.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/motchan.h
@@ -64,7 +64,7 @@ public:
 	void Get_Vector(int frame,float * setvec) const;
 
 	MotionChannelClass();
-	virtual ~MotionChannelClass() override;
+	~MotionChannelClass();
 
 	bool	Load_W3D(ChunkLoadClass & cload);
 	WWINLINE int Get_Type() const { return Type; }
@@ -159,7 +159,7 @@ class BitChannelClass
 public:
 
 	BitChannelClass();
-	virtual ~BitChannelClass() override;
+	~BitChannelClass();
 
 	bool	Load_W3D(ChunkLoadClass & cload);
 	WWINLINE int	Get_Type() const { return Type; }
@@ -215,7 +215,7 @@ class TimeCodedMotionChannelClass
 public:
 
 	TimeCodedMotionChannelClass();
-	virtual ~TimeCodedMotionChannelClass() override;
+	~TimeCodedMotionChannelClass();
 
 	bool	Load_W3D(ChunkLoadClass & cload);
 	int	Get_Type() { return Type; }
@@ -253,7 +253,7 @@ class AdaptiveDeltaMotionChannelClass
 public:
 
 	AdaptiveDeltaMotionChannelClass();
-	virtual ~AdaptiveDeltaMotionChannelClass() override;
+	~AdaptiveDeltaMotionChannelClass();
 
 	bool	Load_W3D(ChunkLoadClass & cload);
 	int	Get_Type() { return Type; }
@@ -302,7 +302,7 @@ class TimeCodedBitChannelClass
 public:
 
 	TimeCodedBitChannelClass();
-	virtual ~TimeCodedBitChannelClass() override;
+	~TimeCodedBitChannelClass();
 
 	bool	Load_W3D(ChunkLoadClass & cload);
 	int	Get_Type() { return Type; }

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/motchan.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/motchan.h
@@ -57,7 +57,7 @@ class Quaternion;
 
 class MotionChannelClass : public W3DMPO
 {
-	W3DMPO_GLUE(MotionChannelClass)
+	W3DMPO_CODE(MotionChannelClass)
 
 public:
 	void Do_Data_Compression(int datasize);
@@ -154,7 +154,7 @@ WWINLINE void MotionChannelClass::Get_Vector_As_Quat(int frame, Quaternion& quat
 
 class BitChannelClass : public W3DMPO
 {
-	W3DMPO_GLUE(BitChannelClass)
+	W3DMPO_CODE(BitChannelClass)
 
 public:
 
@@ -210,7 +210,7 @@ WWINLINE int BitChannelClass::Get_Bit(int frame) const
 
 class TimeCodedMotionChannelClass : public W3DMPO
 {
-	W3DMPO_GLUE(TimeCodedMotionChannelClass)
+	W3DMPO_CODE(TimeCodedMotionChannelClass)
 
 public:
 
@@ -248,7 +248,7 @@ private:
 
 class AdaptiveDeltaMotionChannelClass : public W3DMPO
 {
-	W3DMPO_GLUE(AdaptiveDeltaMotionChannelClass)
+	W3DMPO_CODE(AdaptiveDeltaMotionChannelClass)
 
 public:
 
@@ -297,7 +297,7 @@ private:
 
 class TimeCodedBitChannelClass : public W3DMPO
 {
-	W3DMPO_GLUE(TimeCodedBitChannelClass)
+	W3DMPO_CODE(TimeCodedBitChannelClass)
 
 public:
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/nullrobj.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/nullrobj.h
@@ -60,7 +60,7 @@ protected:
 };
 
 
-class NullPrototypeClass : public W3DMPO, public PrototypeClass
+class NullPrototypeClass : public PrototypeClass
 {
 	W3DMPO_CODE(NullPrototypeClass)
 public:

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/nullrobj.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/nullrobj.h
@@ -62,7 +62,7 @@ protected:
 
 class NullPrototypeClass : public W3DMPO, public PrototypeClass
 {
-	W3DMPO_GLUE(NullPrototypeClass)
+	W3DMPO_CODE(NullPrototypeClass)
 public:
 	NullPrototypeClass();
 	NullPrototypeClass(const W3dNullObjectStruct &null);

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/part_ldr.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/part_ldr.h
@@ -319,7 +319,7 @@ inline void ParticleEmitterDefClass::Set_Line_Texture_Mapping_Mode(int mode)
 //
 class ParticleEmitterPrototypeClass : public W3DMPO, public PrototypeClass
 {
-	W3DMPO_GLUE(ParticleEmitterPrototypeClass)
+	W3DMPO_CODE(ParticleEmitterPrototypeClass)
 	public:
 
 		///////////////////////////////////////////////////////////

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/part_ldr.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/part_ldr.h
@@ -317,7 +317,7 @@ inline void ParticleEmitterDefClass::Set_Line_Texture_Mapping_Mode(int mode)
 //
 //	ParticleEmitterPrototypeClass
 //
-class ParticleEmitterPrototypeClass : public W3DMPO, public PrototypeClass
+class ParticleEmitterPrototypeClass : public PrototypeClass
 {
 	W3DMPO_CODE(ParticleEmitterPrototypeClass)
 	public:

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/render2d.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/render2d.h
@@ -91,7 +91,7 @@ class	Vector4;
 /*
 ** Render2DClass
 */
-class Render2DClass : public W3DMPO
+class Render2DClass
 {
 	W3DMPO_CODE(Render2DClass)
 public:

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/render2d.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/render2d.h
@@ -93,7 +93,7 @@ class	Vector4;
 */
 class Render2DClass : public W3DMPO
 {
-	W3DMPO_GLUE(Render2DClass)
+	W3DMPO_CODE(Render2DClass)
 public:
 	Render2DClass( TextureClass* tex = nullptr );
 	virtual ~Render2DClass() override;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/render2d.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/render2d.h
@@ -96,7 +96,7 @@ class Render2DClass
 	W3DMPO_CODE(Render2DClass)
 public:
 	Render2DClass( TextureClass* tex = nullptr );
-	virtual ~Render2DClass() override;
+	virtual ~Render2DClass();
 
 	virtual	void	Reset();
 	void	Render();

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/sortingrenderer.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/sortingrenderer.cpp
@@ -152,7 +152,7 @@ void Sort(TempIndexStruct *begin, TempIndexStruct *end)
 
 class SortingNodeStruct : public DLNodeClass<SortingNodeStruct>
 {
-	W3DMPO_GLUE(SortingNodeStruct)
+	W3DMPO_CODE(SortingNodeStruct)
 
 public:
 	RenderStateStruct sorting_state;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/vertmaterial.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/vertmaterial.cpp
@@ -53,7 +53,7 @@ static unsigned int unique=1;
 VertexMaterialClass* VertexMaterialClass::Presets[VertexMaterialClass::PRESET_COUNT];
 
 #ifdef DYN_MAT8
-class DynD3DMATERIAL8 : public W3DMPO
+class DynD3DMATERIAL8
 {
 	W3DMPO_CODE(DynD3DMATERIAL8)
 public:

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/vertmaterial.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/vertmaterial.cpp
@@ -55,7 +55,7 @@ VertexMaterialClass* VertexMaterialClass::Presets[VertexMaterialClass::PRESET_CO
 #ifdef DYN_MAT8
 class DynD3DMATERIAL8 : public W3DMPO
 {
-	W3DMPO_GLUE(DynD3DMATERIAL8)
+	W3DMPO_CODE(DynD3DMATERIAL8)
 public:
 	D3DMATERIAL8 Mat;
 };

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/vertmaterial.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/vertmaterial.h
@@ -62,7 +62,7 @@ struct _D3DMATERIAL8;
 */
 class VertexMaterialClass : public W3DMPO, public RefCountClass
 {
-	W3DMPO_GLUE(VertexMaterialClass)
+	W3DMPO_CODE(VertexMaterialClass)
 
 	friend DX8Wrapper;
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/vertmaterial.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/vertmaterial.h
@@ -60,7 +60,7 @@ struct _D3DMATERIAL8;
 ** This is simply the typical W3D thin-wrapper around the surrender vertex material.
 ** The vertex material defines things like the lighting properties of a vertex.
 */
-class VertexMaterialClass : public W3DMPO, public RefCountClass
+class VertexMaterialClass : public RefCountClass
 {
 	W3DMPO_CODE(VertexMaterialClass)
 


### PR DESCRIPTION
* Closes issue https://github.com/TheSuperHackers/GeneralsGameCode/issues/1948
* Merge after PR https://github.com/TheSuperHackers/GeneralsGameCode/pull/2603

This PR removes the `W3DMPO` class because it has no value in and of itself. Originally, `W3DMPO` could not be derived from by other classes without adding the `W3DMPO_GLUE` (due to the pure virtual function in `W3DMPO`) , but there was no mechanism in place to prevent the opposite (see `TextureClass`).

Check commits for cleaner diff.

## TODO:
- [x] Replicate in Generals.