### PR TITLE
bugfix(connection): Remove incorrect magic byte check for map transfers

### DIFF
--- a/Core/GameEngine/Source/GameNetwork/ConnectionManager.cpp
+++ b/Core/GameEngine/Source/GameNetwork/ConnectionManager.cpp
@@ -154,14 +154,7 @@ static Bool hasValidTransferFileContent(const AsciiString& filePath, const Unsig
 	switch (fileType)
 	{
 	case TransferFileType_Map:
-	{
-		if (dataSize < 4 || memcmp(data, "CkMp", 4) != 0)
-		{
-			DEBUG_LOG(("Map file '%s' has invalid magic bytes.", filePath.str()));
-			return false;
-		}
 		break;
-	}
 
 	case TransferFileType_Ini:
 	{


### PR DESCRIPTION
* Follow up for #1819
* Fixes #2612 

Removes the CkMp magic byte check at offset 0. Map files saved by WorldBuilder are RefPack-compressed and start with an EAR header, not the CkMp chunk tag. The CkMp tag only appears at offset 0 in uncompressed maps. The simplest fix is to remove this check, as the CkMp byte doesn't always end up at the same offset in compressed files. Also the other validation checks already handle the practical security issues - this check was more about rejecting malformed map files early.

