### PR TITLE
chore(dx8fvf): Remove unused vertex_size parameter from FVFInfoClass

### DIFF
--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8vertexbuffer.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8vertexbuffer.cpp
@@ -80,6 +80,7 @@ VertexBufferClass::VertexBufferClass(unsigned type_, unsigned FVF, unsigned shor
 {
 	WWASSERT(VertexCount);
 	WWASSERT(type==BUFFER_TYPE_DX8 || type==BUFFER_TYPE_SORTING);
+	WWASSERT(FVF != 0);
 	fvf_info=W3DNEW FVFInfoClass(FVF);
 
 	_VertexBufferCount++;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8fvf.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8fvf.cpp
@@ -48,10 +48,10 @@ static unsigned Get_FVF_Vertex_Size(unsigned FVF)
 	return D3DXGetFVFVertexSize(FVF);
 }
 
-FVFInfoClass::FVFInfoClass(unsigned FVF_, unsigned vertex_size)
+FVFInfoClass::FVFInfoClass(unsigned FVF_)
 	:
 	FVF(FVF_),
-	fvf_size(FVF!=0 ? Get_FVF_Vertex_Size(FVF) : vertex_size)
+	fvf_size(Get_FVF_Vertex_Size(FVF))
 {
 	location_offset=0;
 	blend_offset=location_offset;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8fvf.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8fvf.h
@@ -258,7 +258,7 @@ class FVFInfoClass : public W3DMPO
 	unsigned							diffuse_offset;
 	unsigned							specular_offset;
 public:
-	FVFInfoClass(unsigned FVF, unsigned vertex_size=0);
+	FVFInfoClass(unsigned FVF);
 
 	unsigned Get_Location_Offset() const { return location_offset; }
 	unsigned Get_Normal_Offset() const { return normal_offset; }

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8vertexbuffer.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8vertexbuffer.cpp
@@ -83,6 +83,7 @@ VertexBufferClass::VertexBufferClass(unsigned type_, unsigned FVF, unsigned shor
 	WWMEMLOG(MEM_RENDERER);
 	WWASSERT(VertexCount);
 	WWASSERT(type==BUFFER_TYPE_DX8 || type==BUFFER_TYPE_SORTING);
+	WWASSERT(FVF != 0);
 	fvf_info=W3DNEW FVFInfoClass(FVF);
 
 	_VertexBufferCount++;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8vertexbuffer.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8vertexbuffer.cpp
@@ -74,7 +74,7 @@ static int _VertexBufferTotalSize;
 //
 // ----------------------------------------------------------------------------
 
-VertexBufferClass::VertexBufferClass(unsigned type_, unsigned FVF, unsigned short vertex_count_, unsigned vertex_size)
+VertexBufferClass::VertexBufferClass(unsigned type_, unsigned FVF, unsigned short vertex_count_)
 	:
 	VertexCount(vertex_count_),
 	type(type_),
@@ -83,8 +83,7 @@ VertexBufferClass::VertexBufferClass(unsigned type_, unsigned FVF, unsigned shor
 	WWMEMLOG(MEM_RENDERER);
 	WWASSERT(VertexCount);
 	WWASSERT(type==BUFFER_TYPE_DX8 || type==BUFFER_TYPE_SORTING);
-	WWASSERT((FVF!=0 && vertex_size==0) || (FVF==0 && vertex_size!=0));
-	fvf_info=W3DNEW FVFInfoClass(FVF,vertex_size);
+	fvf_info=W3DNEW FVFInfoClass(FVF);
 
 	_VertexBufferCount++;
 	_VertexBufferTotalVertices+=VertexCount;
@@ -307,9 +306,9 @@ SortingVertexBufferClass::~SortingVertexBufferClass()
 
 //	bool dynamic=false,bool softwarevp=false);
 
-DX8VertexBufferClass::DX8VertexBufferClass(unsigned FVF, unsigned short vertex_count_, UsageType usage, unsigned vertex_size)
+DX8VertexBufferClass::DX8VertexBufferClass(unsigned FVF, unsigned short vertex_count_, UsageType usage)
 	:
-	VertexBufferClass(BUFFER_TYPE_DX8, FVF, vertex_count_, vertex_size),
+	VertexBufferClass(BUFFER_TYPE_DX8, FVF, vertex_count_),
 	VertexBuffer(nullptr)
 {
 	Create_Vertex_Buffer(usage);

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8vertexbuffer.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8vertexbuffer.h
@@ -79,7 +79,7 @@ class VertexBufferClass : public W3DMPO, public RefCountClass
 	//W3DMPO_GLUE(VertexBufferClass)
 
 protected:
-	VertexBufferClass(unsigned type, unsigned FVF, unsigned short VertexCount, unsigned vertex_size=0);
+	VertexBufferClass(unsigned type, unsigned FVF, unsigned short VertexCount);
 	virtual ~VertexBufferClass() override;
 public:
 
@@ -211,7 +211,7 @@ public:
 		USAGE_NPATCHES=4
 	};
 
-	DX8VertexBufferClass(unsigned FVF, unsigned short VertexCount, UsageType usage=USAGE_DEFAULT, unsigned vertex_size=0); // Vertex size not used with FVF formats
+	DX8VertexBufferClass(unsigned FVF, unsigned short VertexCount, UsageType usage=USAGE_DEFAULT);
 	DX8VertexBufferClass(const Vector3* vertices, const Vector3* normals, const Vector2* tex_coords, unsigned short VertexCount,UsageType usage=USAGE_DEFAULT);
 	DX8VertexBufferClass(const Vector3* vertices, const Vector3* normals, const Vector4* diffuse, const Vector2* tex_coords, unsigned short VertexCount,UsageType usage=USAGE_DEFAULT);
 	DX8VertexBufferClass(const Vector3* vertices, const Vector4* diffuse, const Vector2* tex_coords, unsigned short VertexCount,UsageType usage=USAGE_DEFAULT);


### PR DESCRIPTION
This removes the `vertex_size` parameter from `FVFInfoClass` which was introduced in ZH but unused.

It was added to support vertex buffer layouts not describable with existing FVF layouts, presumably to use for cube mapping or displacement mapping as the file header suggests.