### PR TITLE
bugfix(input): Block all button presses except ESC during scripted camera scenes

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/WindowXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/WindowXlat.cpp
@@ -308,9 +308,10 @@ GameMessageDisposition WindowTranslator::translateGameMessage(const GameMessage 
 				returnCode = WIN_INPUT_USED;
 			}
 
+			// TheSuperHackers @bugfix If the input is disabled, then only allow the ESC button to get through.
+			// Otherwise it would be possible to call user camera actions during scripted camera scenes.
 			if(returnCode != WIN_INPUT_USED
-				&& (key == KEY_ESC)
-				&& (BitIsSet( state, KEY_STATE_UP ))
+				&& (key != KEY_ESC)
 				&& (TheInGameUI && (TheInGameUI->getInputEnabled() == FALSE)) )
 			{
 				returnCode = WIN_INPUT_USED;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/WindowXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/WindowXlat.cpp
@@ -326,9 +326,10 @@ GameMessageDisposition WindowTranslator::translateGameMessage(const GameMessage 
 				returnCode = WIN_INPUT_USED;
 			}
 
+			// TheSuperHackers @bugfix If the input is disabled, then only allow the ESC button to get through.
+			// Otherwise it would be possible to call user camera actions during scripted camera scenes.
 			if(returnCode != WIN_INPUT_USED
-				&& (key == KEY_ESC)
-				&& (BitIsSet( state, KEY_STATE_UP ))
+				&& (key != KEY_ESC)
 				&& (TheInGameUI && (TheInGameUI->getInputEnabled() == FALSE)) )
 			{
 				returnCode = WIN_INPUT_USED;


### PR DESCRIPTION
It is possible to call user camera action during cinematic scenes. For example set a Bookmark with CTRL+F1, and then press F1 during a cutscene: the camera jumps there.

The fixed logic prevents all button presses except ESC when the input is disabled.