### PR TITLE
bugfix(gui): Remove slider bounds checks to prevent unexpected reset of custom settings

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/Gadget/GadgetHorizontalSlider.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/Gadget/GadgetHorizontalSlider.cpp
@@ -394,8 +394,8 @@ WindowMsgHandledType GadgetHorizontalSliderSystem( GameWindow *window, UnsignedI
 			Int newPos = (Int)mData1;
 			GameWindow *child = window->winGetChild();
 
-			if( newPos < s->minVal || newPos > s->maxVal )
-				break;
+			// TheSuperHackers @info position bounds check has been removed as it
+			// resets custom option.ini settings to 0. Has no effect on slider UI.
 
 			s->position = newPos;
 

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/Gadget/GadgetHorizontalSlider.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/Gadget/GadgetHorizontalSlider.cpp
@@ -394,13 +394,14 @@ WindowMsgHandledType GadgetHorizontalSliderSystem( GameWindow *window, UnsignedI
 			Int newPos = (Int)mData1;
 			GameWindow *child = window->winGetChild();
 
-			// TheSuperHackers @info position bounds check has been removed as it
-			// resets custom option.ini settings to 0. Has no effect on slider UI.
+			// TheSuperHackers @fix No longer reject out of bounds positions to prevent
+			// reset of custom option.ini settings to 0.
 
 			s->position = newPos;
 
 			// Translate to window coords
 			newPos = (Int)((newPos - s->minVal) * s->numTicks);
+			newPos = clamp(0, newPos, (Int)((s->maxVal - s->minVal) * s->numTicks));
 
 			child->winSetPosition( newPos , HORIZONTAL_SLIDER_THUMB_POSITION );
 			break;

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/Gadget/GadgetVerticalSlider.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/Gadget/GadgetVerticalSlider.cpp
@@ -378,13 +378,14 @@ WindowMsgHandledType GadgetVerticalSliderSystem( GameWindow *window, UnsignedInt
 			Int newPos = (Int)mData1;
 			GameWindow *child = window->winGetChild();
 
-			if (newPos < s->minVal || newPos > s->maxVal)
-				break;
+			// TheSuperHackers @fix No longer reject out of bounds positions to prevent
+			// reset of custom option.ini settings to 0.
 
 			s->position = newPos;
 
 			// Translate to window coords
 			newPos = (Int)((s->maxVal - newPos) * s->numTicks);
+			newPos = clamp(0, newPos, (Int)((s->maxVal - s->minVal) * s->numTicks));
 
 			child->winSetPosition( 0, newPos );
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/Gadget/GadgetHorizontalSlider.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/Gadget/GadgetHorizontalSlider.cpp
@@ -394,8 +394,8 @@ WindowMsgHandledType GadgetHorizontalSliderSystem( GameWindow *window, UnsignedI
 			Int newPos = (Int)mData1;
 			GameWindow *child = window->winGetChild();
 
-			if( newPos < s->minVal || newPos > s->maxVal )
-				break;
+			// TheSuperHackers @info position bounds check has been removed as it
+			// resets custom option.ini settings to 0. Has no effect on slider UI.
 
 			s->position = newPos;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/Gadget/GadgetHorizontalSlider.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/Gadget/GadgetHorizontalSlider.cpp
@@ -394,13 +394,14 @@ WindowMsgHandledType GadgetHorizontalSliderSystem( GameWindow *window, UnsignedI
 			Int newPos = (Int)mData1;
 			GameWindow *child = window->winGetChild();
 
-			// TheSuperHackers @info position bounds check has been removed as it
-			// resets custom option.ini settings to 0. Has no effect on slider UI.
+			// TheSuperHackers @fix No longer reject out of bounds positions to prevent
+			// reset of custom option.ini settings to 0.
 
 			s->position = newPos;
 
 			// Translate to window coords
 			newPos = (Int)((newPos - s->minVal) * s->numTicks);
+			newPos = clamp(0, newPos, (Int)((s->maxVal - s->minVal) * s->numTicks));
 
 			child->winSetPosition( newPos , HORIZONTAL_SLIDER_THUMB_POSITION );
 			break;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/Gadget/GadgetVerticalSlider.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/Gadget/GadgetVerticalSlider.cpp
@@ -378,13 +378,14 @@ WindowMsgHandledType GadgetVerticalSliderSystem( GameWindow *window, UnsignedInt
 			Int newPos = (Int)mData1;
 			GameWindow *child = window->winGetChild();
 
-			if (newPos < s->minVal || newPos > s->maxVal)
-				break;
+			// TheSuperHackers @fix No longer reject out of bounds positions to prevent
+			// reset of custom option.ini settings to 0.
 
 			s->position = newPos;
 
 			// Translate to window coords
 			newPos = (Int)((s->maxVal - newPos) * s->numTicks);
+			newPos = clamp(0, newPos, (Int)((s->maxVal - s->minVal) * s->numTicks));
 
 			child->winSetPosition( 0, newPos );
 


### PR DESCRIPTION
- Resolves: #2623 

When any slider value is out of bounds, an early return is initialized, causing the slider position value not be set at all.
The slider position value is then 0, even if the minimum is higher than 0.

Instead the slider UI is bound instead. If the slider is touched by the user, it will set its value between the minimum and maximum - easily allowing to reset the value if needed.

I left a comment to ensure in the future coders understand why there is no check in place. Can remove if desired.
