### PR TITLE
style(guiedit): Adjust indentation for combo box data output in save function

### DIFF
--- a/Generals/Code/Tools/GUIEdit/Source/Save.cpp
+++ b/Generals/Code/Tools/GUIEdit/Source/Save.cpp
@@ -710,13 +710,13 @@ static Bool saveComboBoxData( GameWindow *window, FILE *fp, Int dataIndent )
 
 	sprintf( &buffer[ dataIndent ], "COMBOBOXDATA = ISEDITABLE: %d,\n", comboData->isEditable );
 	writeBufferToFile( fp, buffer );
-	sprintf( &buffer[ dataIndent ], "              MAXCHARS: %d,\n", comboData->maxChars );
+	sprintf( &buffer[ dataIndent ], "               MAXCHARS: %d,\n", comboData->maxChars );
 	writeBufferToFile( fp, buffer );
-	sprintf( &buffer[ dataIndent ], "              MAXDISPLAY: %d,\n", comboData->maxDisplay );
+	sprintf( &buffer[ dataIndent ], "               MAXDISPLAY: %d,\n", comboData->maxDisplay );
 	writeBufferToFile( fp, buffer );
-	sprintf( &buffer[ dataIndent ], "              ASCIIONLY: %d,\n", comboData->asciiOnly );
+	sprintf( &buffer[ dataIndent ], "               ASCIIONLY: %d,\n", comboData->asciiOnly );
 	writeBufferToFile( fp, buffer );
-	sprintf( &buffer[ dataIndent ], "              LETTERSANDNUMBERS: %d;\n", comboData->lettersAndNumbersOnly );
+	sprintf( &buffer[ dataIndent ], "               LETTERSANDNUMBERS: %d;\n", comboData->lettersAndNumbersOnly );
 	writeBufferToFile( fp, buffer );
 
 	//Save the dropDownButton draw data for the combo box

--- a/GeneralsMD/Code/Tools/GUIEdit/Source/Save.cpp
+++ b/GeneralsMD/Code/Tools/GUIEdit/Source/Save.cpp
@@ -710,13 +710,13 @@ static Bool saveComboBoxData( GameWindow *window, FILE *fp, Int dataIndent )
 
 	sprintf( &buffer[ dataIndent ], "COMBOBOXDATA = ISEDITABLE: %d,\n", comboData->isEditable );
 	writeBufferToFile( fp, buffer );
-	sprintf( &buffer[ dataIndent ], "              MAXCHARS: %d,\n", comboData->maxChars );
+	sprintf( &buffer[ dataIndent ], "               MAXCHARS: %d,\n", comboData->maxChars );
 	writeBufferToFile( fp, buffer );
-	sprintf( &buffer[ dataIndent ], "              MAXDISPLAY: %d,\n", comboData->maxDisplay );
+	sprintf( &buffer[ dataIndent ], "               MAXDISPLAY: %d,\n", comboData->maxDisplay );
 	writeBufferToFile( fp, buffer );
-	sprintf( &buffer[ dataIndent ], "              ASCIIONLY: %d,\n", comboData->asciiOnly );
+	sprintf( &buffer[ dataIndent ], "               ASCIIONLY: %d,\n", comboData->asciiOnly );
 	writeBufferToFile( fp, buffer );
-	sprintf( &buffer[ dataIndent ], "              LETTERSANDNUMBERS: %d;\n", comboData->lettersAndNumbersOnly );
+	sprintf( &buffer[ dataIndent ], "               LETTERSANDNUMBERS: %d;\n", comboData->lettersAndNumbersOnly );
 	writeBufferToFile( fp, buffer );
 
 	//Save the dropDownButton draw data for the combo box


### PR DESCRIPTION
This PR fixes an indentation issue when saving WND files, thus preventing new indentation issues in https://github.com/TheSuperHackers/GeneralsGamePatch2/pull/12

There is still a problem that when saving the file, the fonts defined in the file are overwritten