### PR TITLE
fix: Fix unused variables in WW3D

### DIFF
--- a/Dependencies/Utility/Utility/CppMacros.h
+++ b/Dependencies/Utility/Utility/CppMacros.h
@@ -40,9 +40,11 @@
 #if __cplusplus >= 201703L
 #define REGISTER
 #define FALLTHROUGH [[fallthrough]]
+#define MAYBE_UNUSED [[maybe_unused]]
 #else
 #define REGISTER register
 #define FALLTHROUGH
+#define MAYBE_UNUSED
 #endif
 
 // noexcept for methods of IUNKNOWN interface

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
@@ -278,8 +278,9 @@ WW3DErrorType WW3D::Init(void *hwnd, char *defaultpal, bool lite)
 	WWDEBUG_SAY(("Allocate Debug Resources"));
 	Allocate_Debug_Resources();
 
- 	MMRESULT r=timeBeginPeriod(1);
+	MAYBE_UNUSED MMRESULT r=timeBeginPeriod(1);
 	WWASSERT(r==TIMERR_NOERROR);
+	(void)r;
 
 	/*
 	** Initialize the dazzle system
@@ -336,8 +337,9 @@ WW3DErrorType WW3D::Shutdown()
 #endif //WW3D_DX8
 
 	//restore the previous timer resolution
-	MMRESULT r=timeEndPeriod(1);
+	MAYBE_UNUSED MMRESULT r=timeEndPeriod(1);
 	WWASSERT(r==TIMERR_NOERROR);
+	(void)r;
 	/*
 	** Free memory in predictive LOD optimizer
 	*/

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
@@ -279,8 +279,9 @@ WW3DErrorType WW3D::Init(void *hwnd, char *defaultpal, bool lite)
 	WWDEBUG_SAY(("Allocate Debug Resources"));
 	Allocate_Debug_Resources();
 
- 	MMRESULT r=timeBeginPeriod(1);
+	MAYBE_UNUSED MMRESULT r=timeBeginPeriod(1);
 	WWASSERT(r==TIMERR_NOERROR);
+	(void)r;
 
 	/*
 	** Initialize the dazzle system
@@ -337,8 +338,9 @@ WW3DErrorType WW3D::Shutdown()
 #endif //WW3D_DX8
 
 	//restore the previous timer resolution
-	MMRESULT r=timeEndPeriod(1);
+	MAYBE_UNUSED MMRESULT r=timeEndPeriod(1);
 	WWASSERT(r==TIMERR_NOERROR);
+	(void)r;
 	/*
 	** Free memory in predictive LOD optimizer
 	*/


### PR DESCRIPTION
This PR fixes an unused variable that was causing release builds to fail in #2454

It adds the `MAYBE_UNUSED` macro to allow c++17 `[[maybe_unused]]` to be used within the code base.