### PR TITLE
bugfix(watertracks): Correct the path handling for .wak files in the WaterTracksRenderSystem

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWaterTracks.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWaterTracks.cpp
@@ -958,15 +958,13 @@ void WaterTracksRenderSystem::saveTracks()
 		return;
 
 	AsciiString fileName=TheTerrainLogic->getSourceFilename();
-	char path[256];
-
-	strlcpy(path, fileName.str(), ARRAY_SIZE(path));
-	strlcat(path, ".wak", ARRAY_SIZE(path));
+	FileSystem::removeExtension(fileName);
+	fileName.concat(".wak");
 
 	WaterTracksObj *umod;
 	Int trackCount=0;
 
-	FILE *fp=fopen(path,"wb");
+	FILE *fp=fopen(fileName.str(), "wb");
 
 	if (fp)
 	{
@@ -994,12 +992,10 @@ void WaterTracksRenderSystem::loadTracks()
 		return;
 
 	AsciiString fileName=TheTerrainLogic->getSourceFilename();
-	char path[256];
+	FileSystem::removeExtension(fileName);
+	fileName.concat(".wak");
 
-	strlcpy(path, fileName.str(), ARRAY_SIZE(path));
-	strlcat(path, ".wak", ARRAY_SIZE(path));
-
-	File *file = TheFileSystem->openFile(path, File::READ | File::BINARY);
+	File *file = TheFileSystem->openFile(fileName.str(), File::READ | File::BINARY);
 	WaterTracksObj *umod;
 	Int trackCount=0;
 	Int flipU=0;


### PR DESCRIPTION
Closes: #2633

Merge After: #2635

This fixes a file loading issue which was introduced by a regression in #1808 

The functionality that was overlooked was the original code truncating the `.map` extension from the file name.

We now use the ~~`AsciiString::truncateBy()`~~ ~~`AsciiString::removeExtensions()`~~ TheFileSystem::removeExtension() function to remove the `.map` extension before copying the ascii string.