### PR TITLE
refactor: Eliminate macro-split assignments

### DIFF
--- a/Core/GameEngine/Source/Common/System/ArchiveFileSystem.cpp
+++ b/Core/GameEngine/Source/Common/System/ArchiveFileSystem.cpp
@@ -230,10 +230,8 @@ void ArchiveFileSystem::loadMods()
 
 	if (TheGlobalData->m_modDir.isNotEmpty())
 	{
-#ifdef DEBUG_LOGGING
-		Bool ret =
-#endif
-		loadBigFilesFromDirectory(TheGlobalData->m_modDir, "*.big", TRUE);
+		MAYBE_UNUSED Bool ret = loadBigFilesFromDirectory(TheGlobalData->m_modDir, "*.big", TRUE);
+		(void)ret;
 		DEBUG_ASSERTLOG(ret, ("loadBigFilesFromDirectory(%s) returned FALSE!", TheGlobalData->m_modDir.str()));
 	}
 }

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/MainMenuUtils.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/MainMenuUtils.cpp
@@ -808,10 +808,8 @@ void StopAsyncDNSCheck()
 {
 	if (s_asyncDNSThreadHandle)
 	{
-#ifdef DEBUG_CRASHING
-		Int res =
-#endif
-			TerminateThread(s_asyncDNSThreadHandle,0);
+		MAYBE_UNUSED Int res = TerminateThread(s_asyncDNSThreadHandle, 0);
+		(void)res;
 		DEBUG_ASSERTCRASH(res, ("Could not terminate the Async DNS Lookup thread!"));	// Thread still not killed!
 	}
 	s_asyncDNSThreadHandle = nullptr;

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/PeerDefs.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/PeerDefs.cpp
@@ -559,10 +559,8 @@ void GameSpyInfo::markAsStagingRoomJoiner( Int game )
 		GameSpyStagingRoom *info = it->second;
 		info->cleanUpSlotPointers();
 		AsciiString options = GameInfoToAsciiString(info);
-#ifdef DEBUG_CRASHING
-		Bool res =
-#endif
-		ParseAsciiStringToGameInfo(&m_localStagingRoom, options);
+		MAYBE_UNUSED Bool res = ParseAsciiStringToGameInfo(&m_localStagingRoom, options);
+		(void)res;
 		DEBUG_ASSERTCRASH(res, ("Could not parse game info \"%s\"", options.str()));
 		m_localStagingRoom.setInGame();
 		m_localStagingRoom.setLocalName(m_localName);

--- a/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PersistentStorageThread.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/Thread/PersistentStorageThread.cpp
@@ -860,10 +860,8 @@ void PSThreadClass::Thread_Function()
 					if (tryConnect())
 					{
 						NewGame(0);
-#ifdef DEBUG_LOGGING
-						Int res =
-#endif // DEBUG_LOGGING
-							SendGameSnapShot(nullptr, req.results.c_str(), SNAP_FINAL);
+						MAYBE_UNUSED Int res = SendGameSnapShot(nullptr, req.results.c_str(), SNAP_FINAL);
+						(void)res;
 						DEBUG_LOG(("Just sent game results - res was %d", res));
 						FreeGame(nullptr);
 					}

--- a/Core/Libraries/Source/WWVegas/WWDebug/wwmemlog.cpp
+++ b/Core/Libraries/Source/WWVegas/WWDebug/wwmemlog.cpp
@@ -300,10 +300,8 @@ WWINLINE void Lock_Mem_Log_Mutex()
 #if MEMLOG_USE_MUTEX
 
 	void * mutex = Get_Mem_Log_Mutex();
-#ifdef DEBUG_CRASHING
-	int res =
-#endif
-		WaitForSingleObject(mutex,INFINITE);
+	MAYBE_UNUSED int res = WaitForSingleObject(mutex,INFINITE);
+	(void)res;
 	WWASSERT(res==WAIT_OBJECT_0);
 	_MemLogLockCounter++;
 #endif
@@ -344,10 +342,8 @@ WWINLINE void Unlock_Mem_Log_Mutex()
 
 	void * mutex = Get_Mem_Log_Mutex();
 	_MemLogLockCounter--;
-#ifdef DEBUG_CRASHING
-	int res=
-#endif
-		ReleaseMutex(mutex);
+	MAYBE_UNUSED int res = ReleaseMutex(mutex);
+	(void)res;
 	WWASSERT(res);
 
 #endif

--- a/Core/Tools/Launcher/Toolkit/Support/StringConvert.cpp
+++ b/Core/Tools/Launcher/Toolkit/Support/StringConvert.cpp
@@ -89,10 +89,8 @@ Char* UnicodeToANSI(const WChar* string, Char* buffer, UInt bufferLength)
 		return nullptr;
 		}
 
-	#ifdef RTS_DEBUG
-	int result =
-	#endif
-		WideCharToMultiByte(CP_ACP, 0, string, -1, buffer, bufferLength, nullptr, nullptr);
+	MAYBE_UNUSED int result = WideCharToMultiByte(CP_ACP, 0, string, -1, buffer, bufferLength, nullptr, nullptr);
+	(void)result;
 
 	#ifdef RTS_DEBUG
 	if (result == 0)

--- a/Generals/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Recorder.cpp
@@ -79,10 +79,8 @@ static void writeAtOffset(File* file, Int offset, const void* data, Int dataSize
 	{
 		file->write(data, dataSize);
 	}
-#ifdef DEBUG_CRASHING
-	Int res =
-#endif
-	file->seek(fileSize, File::seekMode::START);
+	MAYBE_UNUSED Int res = file->seek(fileSize, File::seekMode::START);
+	(void)res;
 	DEBUG_ASSERTCRASH(res == fileSize, ("Could not seek to end of file!"));
 }
 

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/ParkingPlaceBehavior.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Behavior/ParkingPlaceBehavior.cpp
@@ -757,10 +757,8 @@ void ParkingPlaceBehavior::exitObjectViaDoor( Object *newObj, ExitDoorType exitD
 		CRCDEBUG_LOG(("Produced at helipad (door = %d)", exitDoor));
 		DEBUG_ASSERTCRASH(exitDoor == DOOR_NONE_NEEDED, ("Hmm, unlikely"));
 		Matrix3D mtx;
-#ifdef DEBUG_CRASHING
-		Bool boneOk =
-#endif
-			getObject()->getSingleLogicalBonePosition("HeliPark01", &ppinfo.hangarInternal, &mtx);
+		MAYBE_UNUSED Bool boneOk = getObject()->getSingleLogicalBonePosition("HeliPark01", &ppinfo.hangarInternal, &mtx);
+		(void)boneOk;
 
 		DEBUG_ASSERTCRASH(boneOk, ("Could not get bone!"));
 		ppinfo.hangarInternalOrient = mtx.Get_Z_Rotation();

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -79,10 +79,8 @@ static void writeAtOffset(File* file, Int offset, const void* data, Int dataSize
 	{
 		file->write(data, dataSize);
 	}
-#ifdef DEBUG_CRASHING
-	Int res =
-#endif
-	file->seek(fileSize, File::seekMode::START);
+	MAYBE_UNUSED Int res = file->seek(fileSize, File::seekMode::START);
+	(void)res;
 	DEBUG_ASSERTCRASH(res == fileSize, ("Could not seek to end of file!"));
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/ParkingPlaceBehavior.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Behavior/ParkingPlaceBehavior.cpp
@@ -820,10 +820,8 @@ void ParkingPlaceBehavior::exitObjectViaDoor( Object *newObj, ExitDoorType exitD
 		CRCDEBUG_LOG(("Produced at helipad (door = %d)", exitDoor));
 		DEBUG_ASSERTCRASH(exitDoor == DOOR_NONE_NEEDED, ("Hmm, unlikely"));
 		Matrix3D mtx;
-#ifdef DEBUG_CRASHING
-		Bool boneOk =
-#endif
-			getObject()->getSingleLogicalBonePosition("HeliPark01", &ppinfo.hangarInternal, &mtx);
+		MAYBE_UNUSED Bool boneOk = getObject()->getSingleLogicalBonePosition("HeliPark01", &ppinfo.hangarInternal, &mtx);
+		(void)boneOk;
 
 		DEBUG_ASSERTCRASH(boneOk, ("Could not get bone!"));
 		ppinfo.hangarInternalOrient = mtx.Get_Z_Rotation();


### PR DESCRIPTION
### 📝 Motivation / Context
When running `clang-format`, the AST parser struggles to correctly interpret macro-split variable assignments (cases where `#ifdef` / `#if` blocks interrupt a variable declaration and its initialization). This causes the formatter to misread the code structure and apply incorrect indentation. 

### 🛠️ Changes Made
* Refactored inline `#ifdef` blocks that split statements across multiple lines.
* Variables are now declared and assigned unconditionally to ensure valid AST structure for `clang-format`. See https://github.com/TheSuperHackers/GeneralsGameCode/pull/2638#discussion_r3120128099
* Implemented the `MAYBE_UNUSED` macro (introduced in #2629) alongside a standard `(void)variableName;` cast. 

**Note on implementation:** Both the macro and the `(void)` cast are used together because `MAYBE_UNUSED` evaluates to an empty definition on pre-C++17 compilers.

I used the regex `=\s*[\r\n]+\s*#` to scan the codebase for these macro-split assignments. All 11 identified occurrences were refactored.