### PR TITLE
bugfix(veterancy): Disable audiovisual cues for ejected veteran pilots

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
@@ -995,7 +995,10 @@ protected:
 			DEBUG_LOG(("Object %s inherits veterancy level %d from %s",
 				obj->getTemplate()->getName().str(), sourceObj->getVeterancyLevel(), sourceObj->getTemplate()->getName().str()));
 			VeterancyLevel v = sourceObj->getVeterancyLevel();
-			obj->getExperienceTracker()->setVeterancyLevel(v);
+
+			// TheSuperHackers @bugfix Caball009 22/04/2026 Disable audiovisual cues for a veterancy level change because this object was just created.
+			// Otherwise the cues would be at an incorrect position, because the object's matrix is not set yet.
+			obj->getExperienceTracker()->setVeterancyLevel(v, FALSE);
 
 			//In order to make things easier for the designers, we are going to transfer the unit name
 			//to the ejected thing... so the designer can control the pilot with the scripts.

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
@@ -1010,7 +1010,10 @@ protected:
 			DEBUG_LOG(("Object %s inherits veterancy level %d from %s",
 				obj->getTemplate()->getName().str(), sourceObj->getVeterancyLevel(), sourceObj->getTemplate()->getName().str()));
 			VeterancyLevel v = sourceObj->getVeterancyLevel();
-			obj->getExperienceTracker()->setVeterancyLevel(v);
+
+			// TheSuperHackers @fix Caball009 22/04/2026 Disable audiovisual cues for a veterancy level change because this object was just created.
+			// Otherwise the cues would be at an incorrect position, because the object's matrix is not set yet.
+			obj->getExperienceTracker()->setVeterancyLevel(v, FALSE);
 
 			//In order to make things easier for the designers, we are going to transfer the unit name
 			//to the ejected thing... so the designer can control the pilot with the scripts.

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/ObjectCreationList.cpp
@@ -1011,7 +1011,7 @@ protected:
 				obj->getTemplate()->getName().str(), sourceObj->getVeterancyLevel(), sourceObj->getTemplate()->getName().str()));
 			VeterancyLevel v = sourceObj->getVeterancyLevel();
 
-			// TheSuperHackers @fix Caball009 22/04/2026 Disable audiovisual cues for a veterancy level change because this object was just created.
+			// TheSuperHackers @bugfix Caball009 22/04/2026 Disable audiovisual cues for a veterancy level change because this object was just created.
 			// Otherwise the cues would be at an incorrect position, because the object's matrix is not set yet.
 			obj->getExperienceTracker()->setVeterancyLevel(v, FALSE);
 


### PR DESCRIPTION
* Related to #1458
* Related to #226 

The ejection of veteran pilots is accompanied with audiovisual promotion cues. This is not obvious because the position (and matrix) of the pilot objects is not set yet when it goes through the veterancy level change, so they take place around coordinates 0, 0, 0:

https://github.com/user-attachments/assets/4936549f-a747-4f89-b4cf-e534670a79ef

This PR disables the audiovisual cues / feedback.

## TODO:
- [x] Replicate in Generals.
