### PR TITLE
Add support for MSVC ATL paths in CMake configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ build.ninja
 ## Python
 __pycache__/
 *.pyc
+Docs/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ project(genzh LANGUAGES C CXX)
 
 # This file handles extra settings wanted/needed for different compilers.
 include(cmake/compilers.cmake)
+include(cmake/msvc-atl.cmake)
 
 # Debug symbol stripping for Release builds (MinGW)
 include(cmake/debug_strip.cmake)

--- a/Core/GameEngine/CMakeLists.txt
+++ b/Core/GameEngine/CMakeLists.txt
@@ -89,6 +89,7 @@ set(GAMEENGINE_SRC
 #    Include/Common/Override.h
 #    Include/Common/PartitionSolver.h
 #    Include/Common/PerfMetrics.h
+    Include/Common/PerfTrace.h
 #    Include/Common/PerfTimer.h
 #    Include/Common/Player.h
 #    Include/Common/PlayerList.h
@@ -581,6 +582,7 @@ set(GAMEENGINE_SRC
 #    Source/Common/GameLOD.cpp
 #    Source/Common/GameMain.cpp
     Source/Common/GameUtility.cpp
+    Source/Common/PerfTrace.cpp
 #    Source/Common/GlobalData.cpp
     Source/Common/INI/INI.cpp
 #    Source/Common/INI/INIAiData.cpp

--- a/Core/GameEngine/Include/Common/PerfTrace.h
+++ b/Core/GameEngine/Include/Common/PerfTrace.h
@@ -1,0 +1,167 @@
+#pragma once
+
+#include "Lib/BaseType.h"
+
+#include <cstdint>
+
+namespace PerfTrace
+{
+enum PathRequestClass
+{
+	PATH_REQUEST_EXPLICIT_MOVE = 0,
+	PATH_REQUEST_ATTACK_MOVE_OR_ATTACK_PATH = 1,
+	PATH_REQUEST_PATCH_OR_REPATH = 2,
+	PATH_REQUEST_SAFE_PATH_OR_AUTONOMOUS = 3,
+	PATH_REQUEST_CLASS_COUNT = 4,
+};
+
+enum PathTimerKind
+{
+	PATH_TIMER_PATHFIND_UPDATE = 0,
+	PATH_TIMER_PATH_REQUEST_DISPATCH,
+	PATH_TIMER_ASTAR_EXPAND,
+	PATH_TIMER_ZONE_UPDATE,
+	PATH_TIMER_CHECK_FOR_MOVEMENT,
+	PATH_TIMER_CHECK_DESTINATION,
+	PATH_TIMER_MOVE_ALLIES,
+};
+
+enum RenderTimerKind
+{
+	RENDER_TIMER_SUBMIT = 0,
+	RENDER_TIMER_DRAW,
+};
+
+struct PathfindFrameStats
+{
+	UnsignedInt frame;
+	Int pathQueue;
+	Int pathQueuePeak;
+	Int pathCells;
+	Int requestAttempts;
+	Int requestEnqueued;
+	Int requestDuplicate;
+	Int requestFailed;
+	Int requestProcessed;
+	Int classAttempts[PATH_REQUEST_CLASS_COUNT];
+	Int classEnqueued[PATH_REQUEST_CLASS_COUNT];
+	Int classDuplicate[PATH_REQUEST_CLASS_COUNT];
+	Int classFailed[PATH_REQUEST_CLASS_COUNT];
+	Int classProcessed[PATH_REQUEST_CLASS_COUNT];
+	double pathfindUpdateMS;
+	double pathRequestDispatchMS;
+	double aStarExpandMS;
+	double zoneUpdateMS;
+	double checkForMovementMS;
+	double checkDestinationMS;
+	double moveAlliesMS;
+	Int nodesPopped;
+	Int nodesInserted;
+	Int repathsTriggered;
+	Int blockedByUnitChecks;
+	Int blockedByTerrainChecks;
+	Int zoneRecomputes;
+	Int bridgeSpecialTerrainChecks;
+	Int longestSingleRequestCells;
+	Int maxQueueWaitFrames;
+	Int pathQueueOldestAge;
+	Int pathQueueExplicitOldestAge;
+	Int queueReplaced;
+	Int queueSuppressedSameGoal;
+	Int queueSuppressedWeakerThanExisting;
+	Int queueServicePass1;
+	Int queueServicePass2;
+	Int openListPeak;
+	Int closedListPeak;
+	Int cellInfoPeakLive;
+	Int cellInfoAllocFailures;
+	Int cellInfoPoolCapacity;
+	Int requestCellBudget;
+
+	PathfindFrameStats();
+	void reset(UnsignedInt newFrame);
+};
+
+struct RenderFrameStats
+{
+	uint64_t engineFrame;
+	double renderSubmitMS;
+	double drawMS;
+
+	RenderFrameStats();
+	void reset(uint64_t newFrame);
+};
+
+void SetEnabled(Bool enabled);
+Bool IsEnabled();
+void SetSampleFrames(Int sampleFrames);
+Int GetSampleFrames();
+void SetSpikeMS(Real spikeMS);
+Real GetSpikeMS();
+
+void ResetSession();
+void Shutdown();
+
+void BeginEngineFrame();
+void EndEngineFrame(Bool logicUpdated, double frameMS);
+uint64_t GetCurrentEngineFrame();
+
+void AdvancePathfindFrameStats(UnsignedInt frame);
+PathfindFrameStats GetPathfindFrameStatsForFrame(UnsignedInt frame);
+
+void NotePathQueueDepth(UnsignedInt frame, Int queueDepth);
+void NotePathCells(UnsignedInt frame, Int cellCount);
+void NotePathRequestAttempt(UnsignedInt frame, PathRequestClass requestClass);
+void NotePathRequestEnqueued(UnsignedInt frame, PathRequestClass requestClass);
+void NotePathRequestDuplicate(UnsignedInt frame, PathRequestClass requestClass);
+void NotePathRequestFailed(UnsignedInt frame, PathRequestClass requestClass);
+void NotePathRequestProcessed(UnsignedInt frame, PathRequestClass requestClass);
+void NoteQueueReplaced(UnsignedInt frame);
+void NoteQueueSuppressedSameGoal(UnsignedInt frame);
+void NoteQueueSuppressedWeakerThanExisting(UnsignedInt frame);
+void NoteQueueServicePass(UnsignedInt frame, Int pass);
+void NoteNodesPopped(UnsignedInt frame, Int count = 1);
+void NoteNodesInserted(UnsignedInt frame, Int count = 1);
+void NoteRepathTriggered(UnsignedInt frame, Int count = 1);
+void NoteBlockedByUnitChecks(UnsignedInt frame, Int count = 1);
+void NoteBlockedByTerrainChecks(UnsignedInt frame, Int count = 1);
+void NoteZoneRecomputes(UnsignedInt frame, Int count = 1);
+void NoteBridgeSpecialTerrainChecks(UnsignedInt frame, Int count = 1);
+void NoteLongestSingleRequestCells(UnsignedInt frame, Int cellCount);
+void NoteMaxQueueWaitFrames(UnsignedInt frame, Int frameCount);
+void NoteQueueOldestAge(UnsignedInt frame, Int frameCount);
+void NoteQueueExplicitOldestAge(UnsignedInt frame, Int frameCount);
+
+void NoteOpenListPeak(UnsignedInt frame, Int count);
+void NoteClosedListPeak(UnsignedInt frame, Int count);
+void NoteCellInfoPeakLive(UnsignedInt frame, Int count);
+void NoteCellInfoAllocFailures(UnsignedInt frame, Int count);
+void NoteCellInfoPoolCapacity(UnsignedInt frame, Int count);
+void NoteRequestCellBudget(UnsignedInt frame, Int budget);
+
+void NotePathTimer(UnsignedInt frame, PathTimerKind kind, double elapsedMS);
+void NoteRenderTimer(RenderTimerKind kind, double elapsedMS);
+
+class ScopedPathTimer
+{
+public:
+	ScopedPathTimer(UnsignedInt frame, PathTimerKind kind);
+	~ScopedPathTimer();
+
+private:
+	UnsignedInt m_frame;
+	PathTimerKind m_kind;
+	int64_t m_startTicks;
+};
+
+class ScopedRenderTimer
+{
+public:
+	explicit ScopedRenderTimer(RenderTimerKind kind);
+	~ScopedRenderTimer();
+
+private:
+	RenderTimerKind m_kind;
+	int64_t m_startTicks;
+};
+}

--- a/Core/GameEngine/Include/GameLogic/AIPathfind.h
+++ b/Core/GameEngine/Include/GameLogic/AIPathfind.h
@@ -57,6 +57,18 @@ class PathfindCell;
 
 //----------------------------------------------------------------------------------------------------------
 
+constexpr const UnsignedInt PATHFIND_CELLS_PER_FRAME = 5000;
+constexpr const UnsignedInt PATHFIND_CELLS_PER_REQUEST_EXPLICIT = 2500;
+constexpr const UnsignedInt PATHFIND_CELLS_PER_REQUEST_LOW = 1500;
+constexpr const UnsignedInt CELL_INFOS_INITIAL = 30000;
+constexpr const UnsignedInt CELL_INFOS_ARENA_BLOCK = 8192;
+constexpr const UnsignedInt PATHFIND_QUEUE_LEN = 512;
+constexpr const UnsignedInt PATHFIND_REPATH_CONGESTION_THRESHOLD = 96;
+constexpr const UnsignedInt PATHFIND_REPATH_COOLDOWN_PATCH_FRAMES = 2;
+constexpr const UnsignedInt PATHFIND_REPATH_COOLDOWN_SAFE_FRAMES = 3;
+
+//----------------------------------------------------------------------------------------------------------
+
 /**
  * PathNodes are used to create a final Path to return from the
  * pathfinder.  Note that these are not used during the A* search.
@@ -208,6 +220,8 @@ enum {MAX_WALL_PIECES = 128};
 class PathfindCellInfo
 {
 	friend class PathfindCell;
+	friend class PathfindCellInfoArena;
+	friend class Pathfinder;
 public:
 #if RETAIL_COMPATIBLE_PATHFINDING
 	static void forceCleanPathFindCellInfos();
@@ -217,6 +231,11 @@ public:
 
 	static PathfindCellInfo * getACellInfo(PathfindCell *cell, const ICoord2D &pos);
 	static void releaseACellInfo(PathfindCellInfo *theInfo);
+
+	static Int getCellInfoPeakLive();
+	static Int getCellInfoLiveCount();
+	static Int getCellInfoAllocFailures();
+	static Int getCellInfoPoolCapacity();
 
 protected:
 	static PathfindCellInfo *s_infoArray;
@@ -229,6 +248,7 @@ protected:
 	PathfindCell *m_cell;															///< Cell this info belongs to currently.
 
 	UnsignedShort m_totalCost, m_costSoFar;	///< cost estimates for A* search
+	UnsignedInt m_openInsertOrder;										///< Stable heap tie-break to preserve deterministic insertion order.
 
 	/// have to include cell's coordinates, since cells are often accessed via pointer only
 	ICoord2D m_pos;
@@ -248,21 +268,66 @@ protected:
 	UnsignedInt m_closed:1;												///< place for marking this cell as on the closed list
 };
 
+class PathfindCellHeap
+{
+public:
+	PathfindCellHeap();
+	~PathfindCellHeap();
+	void reset();
+	Bool empty() const { return m_size == 0; }
+	Int size() const { return m_size; }
+	void push(PathfindCell *cell);
+	PathfindCell *pop();
+	void clear();
+	static const Int INITIAL_CAPACITY = 4096;
+private:
+	void grow();
+	Int m_capacity;
+	Int m_size;
+	PathfindCell **m_data;
+};
+
+class PathfindCellInfoArena
+{
+public:
+	PathfindCellInfoArena();
+	~PathfindCellInfoArena();
+	void init();
+	void reset();
+	PathfindCellInfo *alloc(PathfindCell *cell, const ICoord2D &pos);
+	void free(PathfindCellInfo *info);
+	Int getPeakLive() const { return m_peakLive; }
+	Int getLiveCount() const { return m_liveCount; }
+	Int getAllocFailures() const { return m_allocFailures; }
+	Int getPoolCapacity() const { return m_totalCapacity; }
+private:
+	struct Block { PathfindCellInfo *data; Int count; };
+	Block *m_blocks;
+	Int m_blockCount;
+	Int m_blockCapacity;
+	PathfindCellInfo *m_firstFree;
+	Int m_liveCount;
+	Int m_peakLive;
+	Int m_allocFailures;
+	Int m_totalCapacity;
+};
+
 // TheSuperHackers @info The PathfindCellList class acts as a new management class for the pathfindcell open and closed lists
 class PathfindCellList
 {
 	friend class PathfindCell;
 
 public:
-	PathfindCellList() : m_head(nullptr), m_tail(nullptr) {}
+	PathfindCellList() : m_head(nullptr), m_tail(nullptr), m_count(0) {}
 
 #if RETAIL_COMPATIBLE_PATHFINDING
-	void reset(PathfindCell* newHead = nullptr) { m_head = newHead; m_tail = nullptr; }
+	void reset(PathfindCell* newHead = nullptr) { m_head = newHead; m_tail = newHead; m_count = newHead ? 1 : 0; }
 #else
-	void reset() { m_head = nullptr; m_tail = nullptr; }
+	void reset() { m_head = nullptr; m_tail = nullptr; m_count = 0; }
 #endif
 
 	PathfindCell* getHead() const { return m_head; }
+	Int size() const { return m_count; }
 
 	Bool empty() const { return m_head == nullptr; }
 
@@ -271,6 +336,7 @@ public:
 private:
 	PathfindCell* m_head;
 	PathfindCell* m_tail;
+	Int m_count;
 };
 
 /**
@@ -281,6 +347,7 @@ private:
  */
 class PathfindCell
 {
+	friend class Pathfinder;
 public:
 
 	enum CellType
@@ -375,6 +442,7 @@ public:
 	inline Bool getClosed() const {return m_info->m_closed;}
 	inline UnsignedInt getCostSoFar() const {return m_info->m_costSoFar;}
 	inline UnsignedInt getTotalCost() const {return m_info->m_totalCost;}
+	inline UnsignedInt getOpenInsertOrder() const { return m_info ? m_info->m_openInsertOrder : 0; }
 
 	inline UnsignedInt getTotalCostDifference(PathfindCell& other) const;
 
@@ -490,8 +558,6 @@ private:
 
 #define PATHFIND_CELL_SIZE		10
 #define PATHFIND_CELL_SIZE_F	10.0f
-
-enum { PATHFIND_QUEUE_LEN=512};
 
 struct TCheckMovementInfo;
 
@@ -639,6 +705,8 @@ public:
  */
 class Pathfinder : PathfindServicesInterface, public Snapshot
 {
+	friend class PathfindCell;
+
 // The following routines are private, but available through the doPathfind callback to aiInterface. jba.
 private:
 	virtual Path *findPath( Object *obj, const LocomotorSet& locomotorSet, const Coord3D *from, const Coord3D *to) override;	///< Find a short, valid path between given locations
@@ -776,6 +844,12 @@ public:
 	void removeWallPiece(Object *wallPiece);  // Removes a wall piece.
 	Real getWallHeight() {return m_wallHeight;}
 	Bool isPointOnWall(const Coord3D *pos);
+	Int getQueuedPathRequestCount() const;
+	void getQueueAgeMetrics(UnsignedInt currentFrame, Int &oldestAll, Int &oldestExplicit) const;
+	void getGridMetrics(Int &mapCellsX, Int &mapCellsY, Int &mapCellsTotal,
+		Int &logicalCellsX, Int &logicalCellsY, Int &logicalCellsTotal,
+		Int &zoneBlockCountX, Int &zoneBlockCountY, Int &zoneBlockCountTotal) const;
+	void computeFootprintMetrics(const Object *obj, Int &sideCells, Int &areaCells, Int &radius, Bool &center);
 
 	void updateLayer(Object *obj, PathfindLayerEnum layer); ///< Updates object's layer.
 
@@ -818,6 +892,8 @@ protected:
 	Int checkPathCost(Object *obj, const LocomotorSet& locomotorSet, const Coord3D *from,
 		const Coord3D *to);
 
+	static Bool isHighPriorityRequestClass(UnsignedByte requestClassByte);
+
 	void tightenPath(Object *obj, const LocomotorSet& locomotorSet, Coord3D *from,
 		const Coord3D *to);
 
@@ -855,6 +931,8 @@ protected:
 	void classifyUnitFootprint( Object *obj, Bool insert, Bool remove, Bool update );	/** Classify the cells under the given object If 'insert' is true, object is being added */
 	/// Convert world coordinate to array index
 	void worldToGrid( const Coord3D *pos, ICoord2D *cellIndex );
+	void clearQueuedRequestSlot(Int slot);
+	void removeQueuedRequestAt(Int slot);
 
 	Bool evaluateCell(PathfindCell* newCell, PathfindCell *parentCell,
 									const LocomotorSet& locomotorSet,
@@ -869,6 +947,9 @@ protected:
 
 	void  prependCells( Path *path, const Coord3D *fromPos,
 																	PathfindCell *goalCell, Bool center ); ///< Add pathfind cells to a path.
+	void beginOpenSearch(PathfindCell *startCell);
+	Bool hasOpenCells() const;
+	PathfindCell *popNextOpenCell();
 
 	void debugShowSearch( Bool pathFound );				///< Show all cells touched in the last search
 	static LocomotorSurfaceTypeMask validLocomotorSurfacesForCellType(PathfindCell::CellType t);
@@ -888,11 +969,13 @@ private:
 	IRegion2D m_extent;														///< Grid extent limits
 	IRegion2D m_logicalExtent;										///< Logical grid extent limits
 
-	PathfindCellList m_openList;									///< Cells ready to be explored
-	PathfindCellList m_closedList;								///< Cells already explored
+	PathfindCellList m_openList;
+	PathfindCellHeap m_openHeap;
+	PathfindCellList m_closedList;
+	Bool m_useHeapOpenList;
 
-	Bool m_isMapReady;														///< True if all cells of map have been classified
-	Bool m_isTunneling;														///< True if path started in an obstacle
+	Bool m_isMapReady;
+	Bool m_isTunneling;
 
 	Int m_frameToShowObstacles;										///< Time to redraw obstacles.  For debug output.
 
@@ -914,9 +997,24 @@ private:
 
 	// Pathfind queue
 	ObjectID			m_queuedPathfindRequests[PATHFIND_QUEUE_LEN];
+	UnsignedInt	m_queuedRequestFrames[PATHFIND_QUEUE_LEN];
+	UnsignedByte m_queuedRequestClasses[PATHFIND_QUEUE_LEN];
+	Coord3D			m_queuedRequestDestinations[PATHFIND_QUEUE_LEN];
+	UnsignedInt	m_queuedRequestGoalFingerprints[PATHFIND_QUEUE_LEN];
+	UnsignedInt	m_queuedRequestLocomotorFingerprints[PATHFIND_QUEUE_LEN];
+	UnsignedInt	m_queuedRequestSequences[PATHFIND_QUEUE_LEN];
 	Int						m_queuePRHead;
 	Int						m_queuePRTail;
 	Int						m_cumulativeCellsAllocated;
+	Int						m_requestCellBudget;
+	ObjectID			m_recentlyServicedRequestIDs[PATHFIND_QUEUE_LEN];
+	UnsignedInt	m_recentlyServicedRequestFrames[PATHFIND_QUEUE_LEN];
+	UnsignedByte m_recentlyServicedRequestClasses[PATHFIND_QUEUE_LEN];
+	UnsignedInt	m_recentlyServicedGoalFingerprints[PATHFIND_QUEUE_LEN];
+	UnsignedInt	m_recentlyServicedCooldownUntilFrames[PATHFIND_QUEUE_LEN];
+	Int						m_recentlyServicedCursor;
+	UnsignedInt	m_nextQueuedRequestSequence;
+	UnsignedInt	m_nextOpenInsertOrder;
 
 #if RTS_ZEROHOUR && RETAIL_COMPATIBLE_CRC
 public:

--- a/Core/GameEngine/Source/Common/PerfTrace.cpp
+++ b/Core/GameEngine/Source/Common/PerfTrace.cpp
@@ -1,0 +1,964 @@
+#include "Common/PerfTrace.h"
+
+#include "Common/GameEngine.h"
+#include "Common/GameUtility.h"
+#include "Common/Money.h"
+#include "Common/Player.h"
+#include "GameClient/Drawable.h"
+#include "GameClient/InGameUI.h"
+#include "GameLogic/AI.h"
+#include "GameLogic/AIPathfind.h"
+#include "GameLogic/GameLogic.h"
+#include "GameLogic/Module/AIUpdate.h"
+#include "GameLogic/Object.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <ctime>
+#include <windows.h>
+
+using namespace std::chrono;
+
+namespace
+{
+Bool g_enabled = FALSE;
+Int g_sampleFrames = 1;
+Real g_spikeMS = 100.0f;
+steady_clock::time_point g_sessionStart;
+Bool g_sessionStarted = FALSE;
+uint64_t g_engineFrame = 0;
+PerfTrace::PathfindFrameStats g_pathCurrent;
+PerfTrace::PathfindFrameStats g_pathLast;
+PerfTrace::RenderFrameStats g_renderCurrent;
+FILE *g_perfTraceFile = nullptr;
+Bool g_perfTraceHeaderWritten = FALSE;
+char g_perfTracePath[MAX_PATH] = {};
+
+int64_t nowTicks()
+{
+	return duration_cast<microseconds>(steady_clock::now().time_since_epoch()).count();
+}
+
+double elapsedMS(const int64_t startTicks)
+{
+	return static_cast<double>(nowTicks() - startTicks) / 1000.0;
+}
+
+uint64_t getUptimeMS()
+{
+	if (!g_sessionStarted)
+	{
+		return 0;
+	}
+
+	return static_cast<uint64_t>(duration_cast<milliseconds>(steady_clock::now() - g_sessionStart).count());
+}
+
+void appendTimestamp(char *buffer, size_t bufferLen)
+{
+	const auto now = system_clock::now();
+	const auto nowMS = duration_cast<milliseconds>(now.time_since_epoch()) % 1000;
+	const std::time_t tt = system_clock::to_time_t(now);
+	std::tm tmValue{};
+#if defined(_WIN32)
+	localtime_s(&tmValue, &tt);
+#else
+	localtime_r(&tt, &tmValue);
+#endif
+	std::snprintf(buffer, bufferLen,
+		"%04d-%02d-%02dT%02d:%02d:%02d.%03d",
+		tmValue.tm_year + 1900,
+		tmValue.tm_mon + 1,
+		tmValue.tm_mday,
+		tmValue.tm_hour,
+		tmValue.tm_min,
+		tmValue.tm_sec,
+		static_cast<int>(nowMS.count()));
+}
+
+void closePerfTraceFile()
+{
+	if (g_perfTraceFile != nullptr)
+	{
+		std::fclose(g_perfTraceFile);
+		g_perfTraceFile = nullptr;
+	}
+}
+
+void openPerfTraceFileIfNeeded()
+{
+	if (!g_enabled || g_perfTraceFile != nullptr)
+	{
+		return;
+	}
+
+	if (g_perfTracePath[0] == '\0')
+	{
+		DWORD len = ::GetModuleFileNameA(nullptr, g_perfTracePath, MAX_PATH);
+		if (len > 0 && len < MAX_PATH)
+		{
+			char *leaf = std::strrchr(g_perfTracePath, '\\');
+			if (leaf != nullptr)
+			{
+				*(leaf + 1) = '\0';
+				std::strncat(g_perfTracePath, "PerfTrace.txt", MAX_PATH - std::strlen(g_perfTracePath) - 1);
+			}
+			else
+			{
+				std::strncpy(g_perfTracePath, "PerfTrace.txt", MAX_PATH - 1);
+				g_perfTracePath[MAX_PATH - 1] = '\0';
+			}
+		}
+		else
+		{
+			std::strncpy(g_perfTracePath, "PerfTrace.txt", MAX_PATH - 1);
+			g_perfTracePath[MAX_PATH - 1] = '\0';
+		}
+	}
+
+	g_perfTraceFile = std::fopen(g_perfTracePath, "w");
+	if (!g_perfTraceFile)
+	{
+		return;
+	}
+
+	if (!g_perfTraceHeaderWritten)
+	{
+		std::fputs(
+			"timestamp,uptime_ms,frame,event,frame_ms,frame_fps,logic_updated,objects,structures,ground_units,air_units,infantry,vehicles,aircraft,"
+			"path_queue,path_queue_max,path_queue_peak,path_cells,path_requests,path_enqueued,path_duplicate,path_failed,path_processed,"
+			"explicit_req,explicit_enq,explicit_dup,explicit_fail,explicit_proc,"
+			"attack_req,attack_enq,attack_dup,attack_fail,attack_proc,"
+			"patch_req,patch_enq,patch_dup,patch_fail,patch_proc,"
+			"safe_req,safe_enq,safe_dup,safe_fail,safe_proc,"
+			"pathfind_update_ms,path_request_dispatch_ms,a_star_expand_ms,zone_update_ms,checkForMovement_ms,checkDestination_ms,move_allies_ms,"
+			"render_submit_ms,draw_ms,nodes_popped,nodes_inserted,repaths_triggered,blocked_by_unit_checks,blocked_by_terrain_checks,zone_recomputes,bridge_special_terrain_checks,"
+			"longest_single_request_cells,max_queue_wait_frames,units_waiting_path,units_active_path,ground_waiting_path,ground_active_path,air_waiting_path,air_active_path,"
+			"local_player,local_side,local_money,selected_total,selected_structures,selected_ground,selected_air,selected_infantry,selected_vehicles,selected_aircraft,"
+			"map_cells_x,map_cells_y,map_cells_total,logical_cells_x,logical_cells_y,logical_cells_total,zone_block_count_x,zone_block_count_y,zone_block_count_total,"
+			"unit_footprint_cells_total_ground,unit_footprint_cells_total_air,unit_footprint_cells_total_all,avg_ground_unit_footprint_cells,avg_vehicle_footprint_cells,avg_infantry_footprint_cells,max_unit_footprint_cells,"
+			"footprint_1x1_count,footprint_2x2_count,footprint_3x3_count,footprint_4x4_count,footprint_5x5_count,selected_avg_footprint_cells,selected_max_footprint_cells,"
+			"path_queue_oldest_age,path_queue_explicit_oldest_age,queue_replaced,queue_suppressed_same_goal,queue_suppressed_weaker_than_existing,queue_service_pass1,queue_service_pass2,"
+			"open_list_peak,closed_list_peak,cell_info_peak_live,cell_info_alloc_failures,cell_info_pool_capacity,request_cell_budget\n",
+			g_perfTraceFile);
+		g_perfTraceHeaderWritten = TRUE;
+	}
+}
+
+Int requestClassIndex(const PerfTrace::PathRequestClass requestClass)
+{
+	const Int idx = static_cast<Int>(requestClass);
+	return std::max(0, std::min(idx, PerfTrace::PATH_REQUEST_CLASS_COUNT - 1));
+}
+
+struct ObjectCounters
+{
+	Int totalObjects;
+	Int structures;
+	Int groundUnits;
+	Int airUnits;
+	Int infantry;
+	Int vehicles;
+	Int aircraft;
+	Int unitsWaitingPath;
+	Int unitsActivePath;
+	Int groundWaitingPath;
+	Int groundActivePath;
+	Int airWaitingPath;
+	Int airActivePath;
+	Int footprintGroundTotal;
+	Int footprintAirTotal;
+	Int footprintAllTotal;
+	Int vehicleFootprintTotal;
+	Int infantryFootprintTotal;
+	Int groundFootprintCount;
+	Int vehicleFootprintCount;
+	Int infantryFootprintCount;
+	Int maxFootprintCells;
+	Int footprintBuckets[5];
+
+	ObjectCounters()
+	{
+		std::memset(this, 0, sizeof(*this));
+	}
+};
+
+struct SelectionCounters
+{
+	Int total;
+	Int structures;
+	Int ground;
+	Int air;
+	Int infantry;
+	Int vehicles;
+	Int aircraft;
+	Int footprintTotal;
+	Int footprintMax;
+
+	SelectionCounters()
+	{
+		std::memset(this, 0, sizeof(*this));
+	}
+};
+
+void accumulateObjectCounts(ObjectCounters &counters)
+{
+	if (!TheGameLogic || !TheAI || !TheAI->pathfinder())
+	{
+		return;
+	}
+
+	Pathfinder *pathfinder = TheAI->pathfinder();
+	for (Object *obj = TheGameLogic->getFirstObject(); obj; obj = obj->getNextObject())
+	{
+		++counters.totalObjects;
+
+		const Bool isStructure = obj->isKindOf(KINDOF_STRUCTURE);
+		const Bool isInfantry = obj->isKindOf(KINDOF_INFANTRY);
+		const Bool isAircraft = obj->isKindOf(KINDOF_AIRCRAFT);
+		const Bool isVehicle = obj->isKindOf(KINDOF_VEHICLE) && !isAircraft;
+
+		if (isStructure)
+		{
+			++counters.structures;
+		}
+		if (isInfantry)
+		{
+			++counters.infantry;
+			++counters.groundUnits;
+		}
+		if (isVehicle)
+		{
+			++counters.vehicles;
+			++counters.groundUnits;
+		}
+		if (isAircraft)
+		{
+			++counters.aircraft;
+			++counters.airUnits;
+		}
+
+		AIUpdateInterface *ai = obj->getAIUpdateInterface();
+		if (ai != nullptr)
+		{
+			if (ai->isWaitingForPath())
+			{
+				++counters.unitsWaitingPath;
+				if (isAircraft)
+				{
+					++counters.airWaitingPath;
+				}
+				else if (isInfantry || isVehicle)
+				{
+					++counters.groundWaitingPath;
+				}
+			}
+			if (ai->getPath() != nullptr)
+			{
+				++counters.unitsActivePath;
+				if (isAircraft)
+				{
+					++counters.airActivePath;
+				}
+				else if (isInfantry || isVehicle)
+				{
+					++counters.groundActivePath;
+				}
+			}
+		}
+
+		Int sideCells = 0;
+		Int areaCells = 0;
+		Int radius = 0;
+		Bool center = false;
+		pathfinder->computeFootprintMetrics(obj, sideCells, areaCells, radius, center);
+		if (areaCells <= 0)
+		{
+			continue;
+		}
+
+		counters.maxFootprintCells = std::max(counters.maxFootprintCells, areaCells);
+		counters.footprintAllTotal += areaCells;
+		++counters.footprintBuckets[std::min(std::max(sideCells, 1), 5) - 1];
+
+		if (isAircraft)
+		{
+			counters.footprintAirTotal += areaCells;
+		}
+		else if (isInfantry || isVehicle)
+		{
+			counters.footprintGroundTotal += areaCells;
+			++counters.groundFootprintCount;
+		}
+
+		if (isVehicle)
+		{
+			counters.vehicleFootprintTotal += areaCells;
+			++counters.vehicleFootprintCount;
+		}
+		if (isInfantry)
+		{
+			counters.infantryFootprintTotal += areaCells;
+			++counters.infantryFootprintCount;
+		}
+	}
+}
+
+void accumulateSelectionCounts(SelectionCounters &counters)
+{
+	if (!TheInGameUI || !TheAI || !TheAI->pathfinder())
+	{
+		return;
+	}
+
+	const DrawableList *selected = TheInGameUI->getAllSelectedDrawables();
+	if (!selected)
+	{
+		return;
+	}
+
+	Pathfinder *pathfinder = TheAI->pathfinder();
+	for (DrawableListCIt it = selected->begin(); it != selected->end(); ++it)
+	{
+		Drawable *drawable = *it;
+		if (!drawable || !drawable->getObject())
+		{
+			continue;
+		}
+
+		Object *obj = drawable->getObject();
+		++counters.total;
+
+		const Bool isStructure = obj->isKindOf(KINDOF_STRUCTURE);
+		const Bool isInfantry = obj->isKindOf(KINDOF_INFANTRY);
+		const Bool isAircraft = obj->isKindOf(KINDOF_AIRCRAFT);
+		const Bool isVehicle = obj->isKindOf(KINDOF_VEHICLE) && !isAircraft;
+
+		if (isStructure)
+		{
+			++counters.structures;
+		}
+		if (isInfantry || isVehicle)
+		{
+			++counters.ground;
+		}
+		if (isAircraft)
+		{
+			++counters.air;
+		}
+		if (isInfantry)
+		{
+			++counters.infantry;
+		}
+		if (isVehicle)
+		{
+			++counters.vehicles;
+		}
+		if (isAircraft)
+		{
+			++counters.aircraft;
+		}
+
+		Int sideCells = 0;
+		Int areaCells = 0;
+		Int radius = 0;
+		Bool center = false;
+		pathfinder->computeFootprintMetrics(obj, sideCells, areaCells, radius, center);
+		counters.footprintTotal += areaCells;
+		counters.footprintMax = std::max(counters.footprintMax, areaCells);
+	}
+}
+
+void writeFrameSnapshot(const Bool logicUpdated, const double frameMS)
+{
+	openPerfTraceFileIfNeeded();
+	if (!g_perfTraceFile || !TheGameLogic)
+	{
+		return;
+	}
+
+	const UnsignedInt logicFrame = TheGameLogic->getFrame();
+	const UnsignedInt snapshotFrame = (logicUpdated && logicFrame > 0) ? (logicFrame - 1) : logicFrame;
+	PerfTrace::PathfindFrameStats pathStats = PerfTrace::GetPathfindFrameStatsForFrame(snapshotFrame);
+	if (logicUpdated && logicFrame > 0)
+	{
+		const PerfTrace::PathfindFrameStats nextFrameStats = PerfTrace::GetPathfindFrameStatsForFrame(logicFrame);
+		if (nextFrameStats.requestAttempts > pathStats.requestAttempts ||
+			nextFrameStats.requestEnqueued > pathStats.requestEnqueued ||
+			nextFrameStats.requestProcessed > pathStats.requestProcessed ||
+			nextFrameStats.pathQueuePeak > pathStats.pathQueuePeak ||
+			nextFrameStats.pathCells > pathStats.pathCells)
+		{
+			pathStats = nextFrameStats;
+		}
+	}
+
+	const Bool sampleFrame = logicUpdated && (snapshotFrame == 0 || snapshotFrame % static_cast<UnsignedInt>(std::max(g_sampleFrames, 1)) == 0);
+	const Bool spikeFrame = frameMS >= static_cast<double>(g_spikeMS);
+	if (!sampleFrame && !spikeFrame)
+	{
+		return;
+	}
+
+	ObjectCounters objectCounters;
+	accumulateObjectCounts(objectCounters);
+
+	SelectionCounters selectionCounters;
+	accumulateSelectionCounts(selectionCounters);
+
+	Int mapCellsX = 0;
+	Int mapCellsY = 0;
+	Int mapCellsTotal = 0;
+	Int logicalCellsX = 0;
+	Int logicalCellsY = 0;
+	Int logicalCellsTotal = 0;
+	Int zoneBlockCountX = 0;
+	Int zoneBlockCountY = 0;
+	Int zoneBlockCountTotal = 0;
+	Int queueOldestAge = 0;
+	Int queueExplicitOldestAge = 0;
+	if (TheAI && TheAI->pathfinder())
+	{
+		TheAI->pathfinder()->getGridMetrics(
+			mapCellsX, mapCellsY, mapCellsTotal,
+			logicalCellsX, logicalCellsY, logicalCellsTotal,
+			zoneBlockCountX, zoneBlockCountY, zoneBlockCountTotal);
+		TheAI->pathfinder()->getQueueAgeMetrics(snapshotFrame, queueOldestAge, queueExplicitOldestAge);
+	}
+
+	Player *localPlayer = rts::getObservedOrLocalPlayer();
+	const Int localPlayerIndex = localPlayer ? localPlayer->getPlayerIndex() : -1;
+	const char *localSide = localPlayer ? localPlayer->getSide().str() : "";
+	const UnsignedInt localMoney = localPlayer ? localPlayer->getMoney()->countMoney() : 0;
+
+	const double frameFPS = frameMS > 0.0 ? 1000.0 / frameMS : 0.0;
+	const double avgGroundFootprint = objectCounters.groundFootprintCount > 0
+		? static_cast<double>(objectCounters.footprintGroundTotal) / static_cast<double>(objectCounters.groundFootprintCount)
+		: 0.0;
+	const double avgVehicleFootprint = objectCounters.vehicleFootprintCount > 0
+		? static_cast<double>(objectCounters.vehicleFootprintTotal) / static_cast<double>(objectCounters.vehicleFootprintCount)
+		: 0.0;
+	const double avgInfantryFootprint = objectCounters.infantryFootprintCount > 0
+		? static_cast<double>(objectCounters.infantryFootprintTotal) / static_cast<double>(objectCounters.infantryFootprintCount)
+		: 0.0;
+	const double selectedAvgFootprint = selectionCounters.total > 0
+		? static_cast<double>(selectionCounters.footprintTotal) / static_cast<double>(selectionCounters.total)
+		: 0.0;
+
+	char timestamp[64] = {};
+	appendTimestamp(timestamp, sizeof(timestamp));
+
+	std::fprintf(
+		g_perfTraceFile,
+		"%s,%llu,%u,%s,%.3f,%.2f,%d,%d,%d,%d,%d,%d,%d,%d,"
+		"%d,%d,%d,%d,%d,%d,%d,%d,%d,"
+		"%d,%d,%d,%d,%d,"
+		"%d,%d,%d,%d,%d,"
+		"%d,%d,%d,%d,%d,"
+		"%d,%d,%d,%d,%d,"
+		"%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,"
+		"%.3f,%.3f,%d,%d,%d,%d,%d,%d,%d,"
+		"%d,%d,%d,%d,%d,%d,%d,%d,%d,%s,%u,%d,%d,%d,%d,%d,%d,%d,"
+		"%d,%d,%d,%d,%d,%d,%d,%d,%d,"
+		"%d,%d,%d,%.3f,%.3f,%.3f,%d,"
+		"%d,%d,%d,%d,%d,%.3f,%d,"
+		"%d,%d,%d,%d,%d,%d,%d,"
+		"%d,%d,%d,%d,%d,%d\n",
+		timestamp,
+		static_cast<unsigned long long>(getUptimeMS()),
+		snapshotFrame,
+		spikeFrame ? "SPIKE" : "SAMPLE",
+		frameMS,
+		frameFPS,
+		logicUpdated ? 1 : 0,
+		objectCounters.totalObjects,
+		objectCounters.structures,
+		objectCounters.groundUnits,
+		objectCounters.airUnits,
+		objectCounters.infantry,
+		objectCounters.vehicles,
+		objectCounters.aircraft,
+		pathStats.pathQueue,
+		PATHFIND_QUEUE_LEN,
+		pathStats.pathQueuePeak,
+		pathStats.pathCells,
+		pathStats.requestAttempts,
+		pathStats.requestEnqueued,
+		pathStats.requestDuplicate,
+		pathStats.requestFailed,
+		pathStats.requestProcessed,
+		pathStats.classAttempts[PerfTrace::PATH_REQUEST_EXPLICIT_MOVE],
+		pathStats.classEnqueued[PerfTrace::PATH_REQUEST_EXPLICIT_MOVE],
+		pathStats.classDuplicate[PerfTrace::PATH_REQUEST_EXPLICIT_MOVE],
+		pathStats.classFailed[PerfTrace::PATH_REQUEST_EXPLICIT_MOVE],
+		pathStats.classProcessed[PerfTrace::PATH_REQUEST_EXPLICIT_MOVE],
+		pathStats.classAttempts[PerfTrace::PATH_REQUEST_ATTACK_MOVE_OR_ATTACK_PATH],
+		pathStats.classEnqueued[PerfTrace::PATH_REQUEST_ATTACK_MOVE_OR_ATTACK_PATH],
+		pathStats.classDuplicate[PerfTrace::PATH_REQUEST_ATTACK_MOVE_OR_ATTACK_PATH],
+		pathStats.classFailed[PerfTrace::PATH_REQUEST_ATTACK_MOVE_OR_ATTACK_PATH],
+		pathStats.classProcessed[PerfTrace::PATH_REQUEST_ATTACK_MOVE_OR_ATTACK_PATH],
+		pathStats.classAttempts[PerfTrace::PATH_REQUEST_PATCH_OR_REPATH],
+		pathStats.classEnqueued[PerfTrace::PATH_REQUEST_PATCH_OR_REPATH],
+		pathStats.classDuplicate[PerfTrace::PATH_REQUEST_PATCH_OR_REPATH],
+		pathStats.classFailed[PerfTrace::PATH_REQUEST_PATCH_OR_REPATH],
+		pathStats.classProcessed[PerfTrace::PATH_REQUEST_PATCH_OR_REPATH],
+		pathStats.classAttempts[PerfTrace::PATH_REQUEST_SAFE_PATH_OR_AUTONOMOUS],
+		pathStats.classEnqueued[PerfTrace::PATH_REQUEST_SAFE_PATH_OR_AUTONOMOUS],
+		pathStats.classDuplicate[PerfTrace::PATH_REQUEST_SAFE_PATH_OR_AUTONOMOUS],
+		pathStats.classFailed[PerfTrace::PATH_REQUEST_SAFE_PATH_OR_AUTONOMOUS],
+		pathStats.classProcessed[PerfTrace::PATH_REQUEST_SAFE_PATH_OR_AUTONOMOUS],
+		pathStats.pathfindUpdateMS,
+		pathStats.pathRequestDispatchMS,
+		pathStats.aStarExpandMS,
+		pathStats.zoneUpdateMS,
+		pathStats.checkForMovementMS,
+		pathStats.checkDestinationMS,
+		pathStats.moveAlliesMS,
+		g_renderCurrent.renderSubmitMS,
+		g_renderCurrent.drawMS,
+		pathStats.nodesPopped,
+		pathStats.nodesInserted,
+		pathStats.repathsTriggered,
+		pathStats.blockedByUnitChecks,
+		pathStats.blockedByTerrainChecks,
+		pathStats.zoneRecomputes,
+		pathStats.bridgeSpecialTerrainChecks,
+		pathStats.longestSingleRequestCells,
+		pathStats.maxQueueWaitFrames,
+		objectCounters.unitsWaitingPath,
+		objectCounters.unitsActivePath,
+		objectCounters.groundWaitingPath,
+		objectCounters.groundActivePath,
+		objectCounters.airWaitingPath,
+		objectCounters.airActivePath,
+		localPlayerIndex,
+		localSide,
+		localMoney,
+		selectionCounters.total,
+		selectionCounters.structures,
+		selectionCounters.ground,
+		selectionCounters.air,
+		selectionCounters.infantry,
+		selectionCounters.vehicles,
+		selectionCounters.aircraft,
+		mapCellsX,
+		mapCellsY,
+		mapCellsTotal,
+		logicalCellsX,
+		logicalCellsY,
+		logicalCellsTotal,
+		zoneBlockCountX,
+		zoneBlockCountY,
+		zoneBlockCountTotal,
+		objectCounters.footprintGroundTotal,
+		objectCounters.footprintAirTotal,
+		objectCounters.footprintAllTotal,
+		avgGroundFootprint,
+		avgVehicleFootprint,
+		avgInfantryFootprint,
+		objectCounters.maxFootprintCells,
+		objectCounters.footprintBuckets[0],
+		objectCounters.footprintBuckets[1],
+		objectCounters.footprintBuckets[2],
+		objectCounters.footprintBuckets[3],
+		objectCounters.footprintBuckets[4],
+		selectedAvgFootprint,
+		selectionCounters.footprintMax,
+		queueOldestAge,
+		queueExplicitOldestAge,
+		pathStats.queueReplaced,
+		pathStats.queueSuppressedSameGoal,
+		pathStats.queueSuppressedWeakerThanExisting,
+		pathStats.queueServicePass1,
+		pathStats.queueServicePass2,
+		pathStats.openListPeak,
+		pathStats.closedListPeak,
+		pathStats.cellInfoPeakLive,
+		pathStats.cellInfoAllocFailures,
+		pathStats.cellInfoPoolCapacity,
+		pathStats.requestCellBudget);
+	std::fflush(g_perfTraceFile);
+}
+}
+
+namespace PerfTrace
+{
+PathfindFrameStats::PathfindFrameStats()
+{
+	reset(0);
+}
+
+void PathfindFrameStats::reset(const UnsignedInt newFrame)
+{
+	frame = newFrame;
+	pathQueue = 0;
+	pathQueuePeak = 0;
+	pathCells = 0;
+	requestAttempts = 0;
+	requestEnqueued = 0;
+	requestDuplicate = 0;
+	requestFailed = 0;
+	requestProcessed = 0;
+	std::memset(classAttempts, 0, sizeof(classAttempts));
+	std::memset(classEnqueued, 0, sizeof(classEnqueued));
+	std::memset(classDuplicate, 0, sizeof(classDuplicate));
+	std::memset(classFailed, 0, sizeof(classFailed));
+	std::memset(classProcessed, 0, sizeof(classProcessed));
+	pathfindUpdateMS = 0.0;
+	pathRequestDispatchMS = 0.0;
+	aStarExpandMS = 0.0;
+	zoneUpdateMS = 0.0;
+	checkForMovementMS = 0.0;
+	checkDestinationMS = 0.0;
+	moveAlliesMS = 0.0;
+	nodesPopped = 0;
+	nodesInserted = 0;
+	repathsTriggered = 0;
+	blockedByUnitChecks = 0;
+	blockedByTerrainChecks = 0;
+	zoneRecomputes = 0;
+	bridgeSpecialTerrainChecks = 0;
+	longestSingleRequestCells = 0;
+	maxQueueWaitFrames = 0;
+	pathQueueOldestAge = 0;
+	pathQueueExplicitOldestAge = 0;
+	queueReplaced = 0;
+	queueSuppressedSameGoal = 0;
+	queueSuppressedWeakerThanExisting = 0;
+	queueServicePass1 = 0;
+	queueServicePass2 = 0;
+	openListPeak = 0;
+	closedListPeak = 0;
+	cellInfoPeakLive = 0;
+	cellInfoAllocFailures = 0;
+	cellInfoPoolCapacity = 0;
+	requestCellBudget = 0;
+}
+
+RenderFrameStats::RenderFrameStats()
+{
+	reset(0);
+}
+
+void RenderFrameStats::reset(const uint64_t newFrame)
+{
+	engineFrame = newFrame;
+	renderSubmitMS = 0.0;
+	drawMS = 0.0;
+}
+
+void SetEnabled(const Bool enabled)
+{
+	g_enabled = enabled;
+	if (!g_enabled)
+	{
+		closePerfTraceFile();
+	}
+}
+
+Bool IsEnabled()
+{
+	return g_enabled;
+}
+
+void SetSampleFrames(const Int sampleFrames)
+{
+	g_sampleFrames = std::max(sampleFrames, 1);
+}
+
+Int GetSampleFrames()
+{
+	return g_sampleFrames;
+}
+
+void SetSpikeMS(const Real spikeMS)
+{
+	g_spikeMS = std::max(spikeMS, 0.0f);
+}
+
+Real GetSpikeMS()
+{
+	return g_spikeMS;
+}
+
+void ResetSession()
+{
+	g_sessionStarted = TRUE;
+	g_sessionStart = steady_clock::now();
+	g_engineFrame = 0;
+	g_pathCurrent.reset(0);
+	g_pathLast.reset(0);
+	g_renderCurrent.reset(0);
+	closePerfTraceFile();
+	g_perfTraceHeaderWritten = FALSE;
+}
+
+void Shutdown()
+{
+	closePerfTraceFile();
+}
+
+void BeginEngineFrame()
+{
+	if (!g_enabled)
+	{
+		return;
+	}
+
+	if (!g_sessionStarted)
+	{
+		ResetSession();
+	}
+
+	++g_engineFrame;
+	g_renderCurrent.reset(g_engineFrame);
+}
+
+void EndEngineFrame(const Bool logicUpdated, const double frameMS)
+{
+	if (!g_enabled)
+	{
+		return;
+	}
+
+	writeFrameSnapshot(logicUpdated, frameMS);
+}
+
+uint64_t GetCurrentEngineFrame()
+{
+	return g_engineFrame;
+}
+
+void AdvancePathfindFrameStats(const UnsignedInt frame)
+{
+	if (!g_enabled)
+	{
+		return;
+	}
+
+	if (g_pathCurrent.frame != frame)
+	{
+		g_pathLast = g_pathCurrent;
+		g_pathCurrent.reset(frame);
+	}
+}
+
+PathfindFrameStats GetPathfindFrameStatsForFrame(const UnsignedInt frame)
+{
+	if (g_pathCurrent.frame == frame)
+	{
+		return g_pathCurrent;
+	}
+	if (g_pathLast.frame == frame)
+	{
+		return g_pathLast;
+	}
+
+	PathfindFrameStats emptyStats;
+	emptyStats.reset(frame);
+	return emptyStats;
+}
+
+#define PERFTRACE_NOTE(field, value) \
+	AdvancePathfindFrameStats(frame); \
+	g_pathCurrent.field += (value)
+
+void NotePathQueueDepth(const UnsignedInt frame, const Int queueDepth)
+{
+	AdvancePathfindFrameStats(frame);
+	g_pathCurrent.pathQueue = queueDepth;
+	g_pathCurrent.pathQueuePeak = std::max(g_pathCurrent.pathQueuePeak, queueDepth);
+}
+
+void NotePathCells(const UnsignedInt frame, const Int cellCount)
+{
+	AdvancePathfindFrameStats(frame);
+	g_pathCurrent.pathCells = cellCount;
+}
+
+void NotePathRequestAttempt(const UnsignedInt frame, const PathRequestClass requestClass)
+{
+	PERFTRACE_NOTE(requestAttempts, 1);
+	++g_pathCurrent.classAttempts[requestClassIndex(requestClass)];
+}
+
+void NotePathRequestEnqueued(const UnsignedInt frame, const PathRequestClass requestClass)
+{
+	PERFTRACE_NOTE(requestEnqueued, 1);
+	++g_pathCurrent.classEnqueued[requestClassIndex(requestClass)];
+}
+
+void NotePathRequestDuplicate(const UnsignedInt frame, const PathRequestClass requestClass)
+{
+	PERFTRACE_NOTE(requestDuplicate, 1);
+	++g_pathCurrent.classDuplicate[requestClassIndex(requestClass)];
+}
+
+void NotePathRequestFailed(const UnsignedInt frame, const PathRequestClass requestClass)
+{
+	PERFTRACE_NOTE(requestFailed, 1);
+	++g_pathCurrent.classFailed[requestClassIndex(requestClass)];
+}
+
+void NotePathRequestProcessed(const UnsignedInt frame, const PathRequestClass requestClass)
+{
+	PERFTRACE_NOTE(requestProcessed, 1);
+	++g_pathCurrent.classProcessed[requestClassIndex(requestClass)];
+}
+
+void NoteQueueReplaced(const UnsignedInt frame) { PERFTRACE_NOTE(queueReplaced, 1); }
+void NoteQueueSuppressedSameGoal(const UnsignedInt frame) { PERFTRACE_NOTE(queueSuppressedSameGoal, 1); }
+void NoteQueueSuppressedWeakerThanExisting(const UnsignedInt frame) { PERFTRACE_NOTE(queueSuppressedWeakerThanExisting, 1); }
+
+void NoteQueueServicePass(const UnsignedInt frame, const Int pass)
+{
+	AdvancePathfindFrameStats(frame);
+	if (pass == 1)
+	{
+		++g_pathCurrent.queueServicePass1;
+	}
+	else if (pass == 2)
+	{
+		++g_pathCurrent.queueServicePass2;
+	}
+}
+
+void NoteNodesPopped(const UnsignedInt frame, const Int count) { PERFTRACE_NOTE(nodesPopped, count); }
+void NoteNodesInserted(const UnsignedInt frame, const Int count) { PERFTRACE_NOTE(nodesInserted, count); }
+void NoteRepathTriggered(const UnsignedInt frame, const Int count) { PERFTRACE_NOTE(repathsTriggered, count); }
+void NoteBlockedByUnitChecks(const UnsignedInt frame, const Int count) { PERFTRACE_NOTE(blockedByUnitChecks, count); }
+void NoteBlockedByTerrainChecks(const UnsignedInt frame, const Int count) { PERFTRACE_NOTE(blockedByTerrainChecks, count); }
+void NoteZoneRecomputes(const UnsignedInt frame, const Int count) { PERFTRACE_NOTE(zoneRecomputes, count); }
+void NoteBridgeSpecialTerrainChecks(const UnsignedInt frame, const Int count) { PERFTRACE_NOTE(bridgeSpecialTerrainChecks, count); }
+
+void NoteLongestSingleRequestCells(const UnsignedInt frame, const Int cellCount)
+{
+	AdvancePathfindFrameStats(frame);
+	g_pathCurrent.longestSingleRequestCells = std::max(g_pathCurrent.longestSingleRequestCells, cellCount);
+}
+
+void NoteMaxQueueWaitFrames(const UnsignedInt frame, const Int frameCount)
+{
+	AdvancePathfindFrameStats(frame);
+	g_pathCurrent.maxQueueWaitFrames = std::max(g_pathCurrent.maxQueueWaitFrames, frameCount);
+}
+
+void NoteQueueOldestAge(const UnsignedInt frame, const Int frameCount)
+{
+	AdvancePathfindFrameStats(frame);
+	g_pathCurrent.pathQueueOldestAge = std::max(g_pathCurrent.pathQueueOldestAge, frameCount);
+}
+
+void NoteQueueExplicitOldestAge(const UnsignedInt frame, const Int frameCount)
+{
+	AdvancePathfindFrameStats(frame);
+	g_pathCurrent.pathQueueExplicitOldestAge = std::max(g_pathCurrent.pathQueueExplicitOldestAge, frameCount);
+}
+
+void NoteOpenListPeak(const UnsignedInt frame, const Int count)
+{
+	AdvancePathfindFrameStats(frame);
+	g_pathCurrent.openListPeak = std::max(g_pathCurrent.openListPeak, count);
+}
+
+void NoteClosedListPeak(const UnsignedInt frame, const Int count)
+{
+	AdvancePathfindFrameStats(frame);
+	g_pathCurrent.closedListPeak = std::max(g_pathCurrent.closedListPeak, count);
+}
+
+void NoteCellInfoPeakLive(const UnsignedInt frame, const Int count)
+{
+	AdvancePathfindFrameStats(frame);
+	g_pathCurrent.cellInfoPeakLive = std::max(g_pathCurrent.cellInfoPeakLive, count);
+}
+
+void NoteCellInfoAllocFailures(const UnsignedInt frame, const Int count)
+{
+	AdvancePathfindFrameStats(frame);
+	g_pathCurrent.cellInfoAllocFailures += count;
+}
+
+void NoteCellInfoPoolCapacity(const UnsignedInt frame, const Int count)
+{
+	AdvancePathfindFrameStats(frame);
+	g_pathCurrent.cellInfoPoolCapacity = count;
+}
+
+void NoteRequestCellBudget(const UnsignedInt frame, const Int budget)
+{
+	AdvancePathfindFrameStats(frame);
+	g_pathCurrent.requestCellBudget = budget;
+}
+
+void NotePathTimer(const UnsignedInt frame, const PathTimerKind kind, const double elapsedMSValue)
+{
+	AdvancePathfindFrameStats(frame);
+	switch (kind)
+	{
+		case PATH_TIMER_PATHFIND_UPDATE: g_pathCurrent.pathfindUpdateMS += elapsedMSValue; break;
+		case PATH_TIMER_PATH_REQUEST_DISPATCH: g_pathCurrent.pathRequestDispatchMS += elapsedMSValue; break;
+		case PATH_TIMER_ASTAR_EXPAND: g_pathCurrent.aStarExpandMS += elapsedMSValue; break;
+		case PATH_TIMER_ZONE_UPDATE: g_pathCurrent.zoneUpdateMS += elapsedMSValue; break;
+		case PATH_TIMER_CHECK_FOR_MOVEMENT: g_pathCurrent.checkForMovementMS += elapsedMSValue; break;
+		case PATH_TIMER_CHECK_DESTINATION: g_pathCurrent.checkDestinationMS += elapsedMSValue; break;
+		case PATH_TIMER_MOVE_ALLIES: g_pathCurrent.moveAlliesMS += elapsedMSValue; break;
+	}
+}
+
+void NoteRenderTimer(const RenderTimerKind kind, const double elapsedMSValue)
+{
+	if (!g_enabled)
+	{
+		return;
+	}
+
+	switch (kind)
+	{
+		case RENDER_TIMER_SUBMIT: g_renderCurrent.renderSubmitMS += elapsedMSValue; break;
+		case RENDER_TIMER_DRAW: g_renderCurrent.drawMS += elapsedMSValue; break;
+	}
+}
+
+ScopedPathTimer::ScopedPathTimer(const UnsignedInt frame, const PathTimerKind kind)
+	: m_frame(frame), m_kind(kind), m_startTicks(0)
+{
+	if (g_enabled)
+	{
+		m_startTicks = nowTicks();
+	}
+}
+
+ScopedPathTimer::~ScopedPathTimer()
+{
+	if (!g_enabled || m_startTicks == 0)
+	{
+		return;
+	}
+
+	NotePathTimer(m_frame, m_kind, elapsedMS(m_startTicks));
+}
+
+ScopedRenderTimer::ScopedRenderTimer(const RenderTimerKind kind)
+	: m_kind(kind), m_startTicks(0)
+{
+	if (g_enabled)
+	{
+		m_startTicks = nowTicks();
+	}
+}
+
+ScopedRenderTimer::~ScopedRenderTimer()
+{
+	if (!g_enabled || m_startTicks == 0)
+	{
+		return;
+	}
+
+	NoteRenderTimer(m_kind, elapsedMS(m_startTicks));
+}
+
+#undef PERFTRACE_NOTE
+}

--- a/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp.clean
+++ b/Core/GameEngine/Source/GameLogic/AI/AIPathfind.cpp.clean
@@ -1,4 +1,4 @@
-/*
+﻿/*
 **	Command & Conquer Generals Zero Hour(tm)
 **	Copyright 2025 Electronic Arts Inc.
 **
@@ -27,12 +27,9 @@
 // Author: Michael S. Booth, October 2001
 #include "PreRTS.h"	// This must go first in EVERY cpp file in the GameEngine
 
-#include <cstring>
-
 #include "GameLogic/AIPathfind.h"
 
 #include "Common/PerfTimer.h"
-#include "Common/PerfTrace.h"
 #include "Common/Player.h"
 #include "Common/CRCDebug.h"
 #include "Common/GlobalData.h"
@@ -111,119 +108,6 @@ struct TCheckMovementInfo
 
 inline Int IABS(Int x) {	if (x>=0) return x; return -x;};
 
-static UnsignedInt getPerfTraceFrame()
-{
-	return TheGameLogic ? TheGameLogic->getFrame() : 0;
-}
-
-static PerfTrace::PathRequestClass getPathRequestClass(const AIUpdateInterface *ai)
-{
-	if (ai == nullptr)
-	{
-		return PerfTrace::PATH_REQUEST_EXPLICIT_MOVE;
-	}
-	if (ai->isSafePath())
-	{
-		return PerfTrace::PATH_REQUEST_SAFE_PATH_OR_AUTONOMOUS;
-	}
-	if (ai->isAttackPath())
-	{
-		return PerfTrace::PATH_REQUEST_ATTACK_MOVE_OR_ATTACK_PATH;
-	}
-	if (ai->isApproachPath() || ai->isBlockedAndStuck())
-	{
-		return PerfTrace::PATH_REQUEST_PATCH_OR_REPATH;
-	}
-	return PerfTrace::PATH_REQUEST_EXPLICIT_MOVE;
-}
-
-static Int getPathRequestPriority(const PerfTrace::PathRequestClass requestClass)
-{
-	switch (requestClass)
-	{
-		case PerfTrace::PATH_REQUEST_EXPLICIT_MOVE: return 3;
-		case PerfTrace::PATH_REQUEST_ATTACK_MOVE_OR_ATTACK_PATH: return 2;
-		case PerfTrace::PATH_REQUEST_PATCH_OR_REPATH: return 1;
-		case PerfTrace::PATH_REQUEST_SAFE_PATH_OR_AUTONOMOUS: return 0;
-		default: return 0;
-	}
-}
-
-Bool Pathfinder::isHighPriorityRequestClass(UnsignedByte requestClassByte)
-{
-	const PerfTrace::PathRequestClass rc = static_cast<PerfTrace::PathRequestClass>(requestClassByte);
-	return rc == PerfTrace::PATH_REQUEST_EXPLICIT_MOVE || rc == PerfTrace::PATH_REQUEST_ATTACK_MOVE_OR_ATTACK_PATH;
-}
-
-static Coord3D getPathRequestDestination(const AIUpdateInterface *ai)
-{
-	Coord3D dest;
-	dest.zero();
-	if (ai != nullptr)
-	{
-		dest = *ai->getRequestedDestination();
-	}
-	return dest;
-}
-
-static UnsignedInt hashPathRequestValue(UnsignedInt seed, UnsignedInt value)
-{
-	return (seed ^ value) * 16777619u;
-}
-
-static UnsignedInt getPathRequestGoalFingerprint(const AIUpdateInterface *ai)
-{
-	UnsignedInt hash = 2166136261u;
-	if (ai == nullptr)
-	{
-		return hash;
-	}
-
-	const Coord3D *primary = ai->getRequestedDestination();
-	const Coord3D *secondary = ai->getRequestedDestination2();
-	const Int primaryX = REAL_TO_INT_FLOOR(primary->x / PATHFIND_CELL_SIZE_F);
-	const Int primaryY = REAL_TO_INT_FLOOR(primary->y / PATHFIND_CELL_SIZE_F);
-	const Int secondaryX = REAL_TO_INT_FLOOR(secondary->x / PATHFIND_CELL_SIZE_F);
-	const Int secondaryY = REAL_TO_INT_FLOOR(secondary->y / PATHFIND_CELL_SIZE_F);
-
-	hash = hashPathRequestValue(hash, static_cast<UnsignedInt>(primaryX));
-	hash = hashPathRequestValue(hash, static_cast<UnsignedInt>(primaryY));
-	hash = hashPathRequestValue(hash, static_cast<UnsignedInt>(secondaryX));
-	hash = hashPathRequestValue(hash, static_cast<UnsignedInt>(secondaryY));
-	hash = hashPathRequestValue(hash, static_cast<UnsignedInt>(ai->getRequestedVictimID()));
-	return hash;
-}
-
-static UnsignedInt getPathRequestLocomotorFingerprint(const Object *obj, const AIUpdateInterface *ai)
-{
-	UnsignedInt hash = 2166136261u;
-	hash = hashPathRequestValue(hash, static_cast<UnsignedInt>(obj ? obj->getLayer() : LAYER_GROUND));
-	if (ai != nullptr)
-	{
-		hash = hashPathRequestValue(hash, static_cast<UnsignedInt>(ai->getCurLocomotorSetType()));
-		hash = hashPathRequestValue(hash, static_cast<UnsignedInt>(ai->getLocomotorSet().getValidSurfaces()));
-	}
-	return hash;
-}
-
-static UnsignedInt getRepathCooldownFrames(const Int queueDepth, const PerfTrace::PathRequestClass requestClass)
-{
-	if (queueDepth < static_cast<Int>(PATHFIND_REPATH_CONGESTION_THRESHOLD))
-	{
-		return 0;
-	}
-
-	switch (requestClass)
-	{
-		case PerfTrace::PATH_REQUEST_PATCH_OR_REPATH:
-			return PATHFIND_REPATH_COOLDOWN_PATCH_FRAMES;
-		case PerfTrace::PATH_REQUEST_SAFE_PATH_OR_AUTONOMOUS:
-			return PATHFIND_REPATH_COOLDOWN_SAFE_FRAMES;
-		default:
-			return 0;
-	}
-}
-
 //-----------------------------------------------------------------------------------
 static Int frameToShowObstacles;
 
@@ -231,6 +115,9 @@ constexpr const UnsignedInt ZONE_UPDATE_FREQUENCY = 300;
 constexpr const UnsignedInt MAX_CELL_COUNT = 500;
 constexpr const UnsignedInt MAX_ADJUSTMENT_CELL_COUNT = 400;
 constexpr const UnsignedInt MAX_SAFE_PATH_CELL_COUNT = 2000;
+
+constexpr const UnsignedInt PATHFIND_CELLS_PER_FRAME = 5000; // Number of cells we will search pathfinding per frame.
+constexpr const UnsignedInt CELL_INFOS_TO_ALLOCATE = 30000;
 
 //-----------------------------------------------------------------------------------
 PathNode::PathNode() :
@@ -585,158 +472,6 @@ void Path::updateLastNode( const Coord3D *pos )
 	}
 }
 
-static Bool isPhase3GroupSpreadActive(const Object *obj, Coord2D *offsetOut = nullptr)
-{
-	const Int PHASE3_MIN_GROUP_MEMBERS = 6;
-
-	if (obj == nullptr)
-	{
-		return false;
-	}
-
-	Coord2D offset;
-	obj->getFormationOffset(&offset);
-	const Real offsetLenSqr = offset.x * offset.x + offset.y * offset.y;
-	if (offsetLenSqr < sqr(PATHFIND_CELL_SIZE_F * 0.75f))
-	{
-		return false;
-	}
-
-	Object *mutableObj = const_cast<Object *>(obj);
-	AIGroup *group = mutableObj->getGroup();
-	if (obj->getFormationID() == NO_FORMATION_ID)
-	{
-		if (group == nullptr || group->getCount() < PHASE3_MIN_GROUP_MEMBERS)
-		{
-			return false;
-		}
-	}
-
-	if (offsetOut != nullptr)
-	{
-		*offsetOut = offset;
-	}
-	return true;
-}
-
-static Real computePathSegmentLength(const PathNode *anchor, const PathNode *node)
-{
-	Real pathLength = 0.0f;
-	for (const PathNode *cur = anchor; cur != nullptr && cur != node; cur = cur->getNext())
-	{
-		const PathNode *next = cur->getNext();
-		if (next == nullptr)
-		{
-			break;
-		}
-
-		const Real dx = next->getPosition()->x - cur->getPosition()->x;
-		const Real dy = next->getPosition()->y - cur->getPosition()->y;
-		pathLength += sqrt(dx * dx + dy * dy);
-	}
-	return pathLength;
-}
-
-static Bool shouldPreserveGroupSpreadOptimization(const Object *obj, const PathNode *anchor, const PathNode *node)
-{
-	Coord2D offset;
-	if (!isPhase3GroupSpreadActive(obj, &offset))
-	{
-		return false;
-	}
-
-	const Real directDx = node->getPosition()->x - anchor->getPosition()->x;
-	const Real directDy = node->getPosition()->y - anchor->getPosition()->y;
-	const Real directLength = sqrt(directDx * directDx + directDy * directDy);
-	if (directLength < PATHFIND_CELL_SIZE_F * 4.0f)
-	{
-		return false;
-	}
-
-	const Real pathLength = computePathSegmentLength(anchor, node);
-	if (pathLength <= directLength + PATHFIND_CELL_SIZE_F * 1.5f)
-	{
-		return false;
-	}
-
-	const Real invLength = 1.0f / directLength;
-	Coord2D right;
-	right.x = -directDy * invLength;
-	right.y = directDx * invLength;
-	const Real desiredLateral = offset.x * right.x + offset.y * right.y;
-	return fabs(desiredLateral) >= PATHFIND_CELL_SIZE_F * 0.5f;
-}
-
-static Int getPhase3LaneBiasCost(
-	const Object *obj,
-	const ICoord2D &startCellNdx,
-	const PathfindCell *goalCell,
-	const ICoord2D &candidateCell,
-	const TCheckMovementInfo &info)
-{
-	Coord2D offset;
-	if (!isPhase3GroupSpreadActive(obj, &offset) || goalCell == nullptr)
-	{
-		return 0;
-	}
-
-	const Int PHASE3_COST_ORTHOGONAL = 10;
-
-	Real axisX = static_cast<Real>(goalCell->getXIndex() - startCellNdx.x);
-	Real axisY = static_cast<Real>(goalCell->getYIndex() - startCellNdx.y);
-	const Real axisLenSqr = axisX * axisX + axisY * axisY;
-	if (axisLenSqr < 1.0f)
-	{
-		return 0;
-	}
-
-	const Real axisLen = sqrt(axisLenSqr);
-	axisX /= axisLen;
-	axisY /= axisLen;
-
-	Coord2D right;
-	right.x = -axisY;
-	right.y = axisX;
-	const Real desiredLateral = offset.x * right.x + offset.y * right.y;
-	if (fabs(desiredLateral) < PATHFIND_CELL_SIZE_F * 0.5f)
-	{
-		return 0;
-	}
-
-	const Real relX = static_cast<Real>(candidateCell.x - goalCell->getXIndex()) * PATHFIND_CELL_SIZE_F;
-	const Real relY = static_cast<Real>(candidateCell.y - goalCell->getYIndex()) * PATHFIND_CELL_SIZE_F;
-	const Real candidateLateral = relX * right.x + relY * right.y;
-
-	Int laneBiasCost = 0;
-	if ((desiredLateral > 0.0f && candidateLateral < -PATHFIND_CELL_SIZE_F * 0.5f)
-		|| (desiredLateral < 0.0f && candidateLateral > PATHFIND_CELL_SIZE_F * 0.5f))
-	{
-		laneBiasCost += 2 * PHASE3_COST_ORTHOGONAL;
-	}
-
-	const Real lateralDelta = fabs(candidateLateral - desiredLateral);
-	if (lateralDelta > PATHFIND_CELL_SIZE_F)
-	{
-		const Real scaled = MIN(2.5f, lateralDelta / (PATHFIND_CELL_SIZE_F * 2.0f));
-		laneBiasCost += static_cast<Int>(scaled * PHASE3_COST_ORTHOGONAL);
-	}
-
-	if (info.allyMoving)
-	{
-		laneBiasCost += PHASE3_COST_ORTHOGONAL;
-	}
-	if (info.allyGoal)
-	{
-		laneBiasCost += PHASE3_COST_ORTHOGONAL;
-	}
-	if (info.allyFixedCount > 1)
-	{
-		laneBiasCost += (info.allyFixedCount - 1) * PHASE3_COST_ORTHOGONAL;
-	}
-
-	return laneBiasCost;
-}
-
 /**
  * Optimize the path by checking line of sight
  */
@@ -843,7 +578,7 @@ void Path::optimize( const Object *obj, LocomotorSurfaceTypeMask acceptableSurfa
 					isPassable = true;
 				}
 			}
-			if (isPassable && !shouldPreserveGroupSpreadOptimization(obj, anchor, node))
+			if (isPassable)
 			{
 				// anchor can directly see this node, make it next in the optimized path
 				anchor->setNextOptimized( node );
@@ -1371,16 +1106,21 @@ Real Path::computeFlightDistToGoal( const Coord3D *pos, Coord3D& goalPos )
 
 PathfindCellInfo *PathfindCellInfo::s_infoArray = nullptr;
 PathfindCellInfo *PathfindCellInfo::s_firstFree = nullptr;
-static PathfindCellInfoArena s_cellInfoArena;
 
 #if RETAIL_COMPATIBLE_PATHFINDING
+// TheSuperHackers @info This variable is here so the code will run down the retail compatible path till a failure mode is hit
+// The pathfinding will then switch over to the corrected pathfinding code for SH clients
 Bool s_useFixedPathfinding = false;
 Bool s_forceCleanCells = false;
 
 void PathfindCellInfo::forceCleanPathFindCellInfos()
 {
-	s_cellInfoArena.reset();
-	s_cellInfoArena.init();
+	for (Int i = 0; i < CELL_INFOS_TO_ALLOCATE - 1; i++) {
+		s_infoArray[i].m_nextOpen = nullptr;
+		s_infoArray[i].m_prevOpen = nullptr;
+		s_infoArray[i].m_open = FALSE;
+		s_infoArray[i].m_closed = FALSE;
+	}
 }
 
 void Pathfinder::forceCleanCells()
@@ -1392,7 +1132,6 @@ void Pathfinder::forceCleanCells()
 
 	PathfindCellInfo::forceCleanPathFindCellInfos();
 	m_openList.reset();
-	m_openHeap.reset();
 	m_closedList.reset();
 
 	for (int j = 0; j <= m_extent.hi.y; ++j) {
@@ -1414,300 +1153,84 @@ void Pathfinder::forceCleanCells()
 }
 #endif
 
-PathfindCellHeap::PathfindCellHeap()
-	: m_capacity(0), m_size(0), m_data(nullptr)
-{
-	grow();
-}
-
-PathfindCellHeap::~PathfindCellHeap()
-{
-	delete[] m_data;
-	m_data = nullptr;
-	m_capacity = 0;
-	m_size = 0;
-}
-
-void PathfindCellHeap::reset()
-{
-	m_size = 0;
-}
-
-void PathfindCellHeap::clear()
-{
-	m_size = 0;
-}
-
-void PathfindCellHeap::grow()
-{
-	Int newCapacity = m_capacity == 0 ? INITIAL_CAPACITY : m_capacity * 2;
-	PathfindCell **newData = MSGNEW("PathfindHeap") PathfindCell*[newCapacity];
-	if (m_data && m_size > 0)
-	{
-		std::memcpy(newData, m_data, m_size * sizeof(PathfindCell *));
-	}
-	delete[] m_data;
-	m_data = newData;
-	m_capacity = newCapacity;
-}
-
-static Bool pathfindHeapLess(const PathfindCell *lhs, const PathfindCell *rhs)
-{
-	if (lhs->getTotalCost() != rhs->getTotalCost())
-	{
-		return lhs->getTotalCost() < rhs->getTotalCost();
-	}
-	return lhs->getOpenInsertOrder() < rhs->getOpenInsertOrder();
-}
-
-void PathfindCellHeap::push(PathfindCell *cell)
-{
-	if (m_size >= m_capacity)
-	{
-		grow();
-	}
-	m_data[m_size] = cell;
-	Int idx = m_size;
-	m_size++;
-	while (idx > 0)
-	{
-		Int parent = (idx - 1) / 2;
-		if (!pathfindHeapLess(m_data[idx], m_data[parent]))
-		{
-			break;
-		}
-		PathfindCell *tmp = m_data[parent];
-		m_data[parent] = m_data[idx];
-		m_data[idx] = tmp;
-		idx = parent;
-	}
-}
-
-PathfindCell *PathfindCellHeap::pop()
-{
-	if (m_size == 0)
-	{
-		return nullptr;
-	}
-	PathfindCell *result = m_data[0];
-	m_size--;
-	if (m_size > 0)
-	{
-		m_data[0] = m_data[m_size];
-		Int idx = 0;
-		for (;;)
-		{
-			Int left = 2 * idx + 1;
-			Int right = 2 * idx + 2;
-			Int smallest = idx;
-			if (left < m_size && pathfindHeapLess(m_data[left], m_data[smallest]))
-			{
-				smallest = left;
-			}
-			if (right < m_size && pathfindHeapLess(m_data[right], m_data[smallest]))
-			{
-				smallest = right;
-			}
-			if (smallest == idx)
-			{
-				break;
-			}
-			PathfindCell *tmp = m_data[idx];
-			m_data[idx] = m_data[smallest];
-			m_data[smallest] = tmp;
-			idx = smallest;
-		}
-	}
-	return result;
-}
-
-PathfindCellInfoArena::PathfindCellInfoArena()
-	: m_blocks(nullptr), m_blockCount(0), m_blockCapacity(0),
-	  m_firstFree(nullptr), m_liveCount(0), m_peakLive(0),
-	  m_allocFailures(0), m_totalCapacity(0)
-{
-}
-
-PathfindCellInfoArena::~PathfindCellInfoArena()
-{
-	reset();
-}
-
-void PathfindCellInfoArena::init()
-{
-	reset();
-	m_blockCapacity = 4;
-	m_blocks = MSGNEW("PathfindArena") Block[m_blockCapacity];
-	m_blockCount = 0;
-	m_firstFree = nullptr;
-
-	Int initialCount = CELL_INFOS_INITIAL;
-	PathfindCellInfo *block = MSGNEW("PathfindCellInfo") PathfindCellInfo[initialCount];
-	if (m_blockCount >= m_blockCapacity)
-	{
-		Int newCap = m_blockCapacity * 2;
-		Block *newBlocks = MSGNEW("PathfindArena") Block[newCap];
-		for (Int i = 0; i < m_blockCount; i++)
-		{
-			newBlocks[i] = m_blocks[i];
-		}
-		delete[] m_blocks;
-		m_blocks = newBlocks;
-		m_blockCapacity = newCap;
-	}
-	m_blocks[m_blockCount].data = block;
-	m_blocks[m_blockCount].count = initialCount;
-	m_blockCount++;
-	m_totalCapacity += initialCount;
-
-	for (Int i = initialCount - 1; i >= 0; i--)
-	{
-		block[i].m_isFree = true;
-		block[i].m_pathParent = m_firstFree;
-		m_firstFree = &block[i];
-	}
-}
-
-void PathfindCellInfoArena::reset()
-{
-	for (Int i = 0; i < m_blockCount; i++)
-	{
-		delete[] m_blocks[i].data;
-	}
-	delete[] m_blocks;
-	m_blocks = nullptr;
-	m_blockCount = 0;
-	m_blockCapacity = 0;
-	m_firstFree = nullptr;
-	m_liveCount = 0;
-	m_peakLive = 0;
-	m_allocFailures = 0;
-	m_totalCapacity = 0;
-}
-
-PathfindCellInfo *PathfindCellInfoArena::alloc(PathfindCell *cell, const ICoord2D &pos)
-{
-	if (!m_firstFree)
-	{
-		Int growCount = CELL_INFOS_ARENA_BLOCK;
-		PathfindCellInfo *block = MSGNEW("PathfindCellInfo") PathfindCellInfo[growCount];
-		if (!block)
-		{
-			m_allocFailures++;
-			return nullptr;
-		}
-		if (m_blockCount >= m_blockCapacity)
-		{
-			Int newCap = m_blockCapacity * 2;
-			Block *newBlocks = MSGNEW("PathfindArena") Block[newCap];
-			for (Int i = 0; i < m_blockCount; i++)
-			{
-				newBlocks[i] = m_blocks[i];
-			}
-			delete[] m_blocks;
-			m_blocks = newBlocks;
-			m_blockCapacity = newCap;
-		}
-		m_blocks[m_blockCount].data = block;
-		m_blocks[m_blockCount].count = growCount;
-		m_blockCount++;
-		m_totalCapacity += growCount;
-
-		for (Int i = growCount - 1; i >= 0; i--)
-		{
-			block[i].m_isFree = true;
-			block[i].m_pathParent = m_firstFree;
-			m_firstFree = &block[i];
-		}
-	}
-
-	PathfindCellInfo *info = m_firstFree;
-	m_firstFree = info->m_pathParent;
-	info->m_isFree = false;
-	info->m_cell = cell;
-	info->m_pos = pos;
-	info->m_nextOpen = nullptr;
-	info->m_prevOpen = nullptr;
-	info->m_pathParent = nullptr;
-	info->m_costSoFar = 0;
-	info->m_totalCost = 0;
-	info->m_openInsertOrder = 0;
-	info->m_open = 0;
-	info->m_closed = 0;
-	info->m_obstacleID = INVALID_ID;
-	info->m_goalUnitID = INVALID_ID;
-	info->m_posUnitID = INVALID_ID;
-	info->m_goalAircraftID = INVALID_ID;
-	info->m_obstacleIsFence = false;
-	info->m_obstacleIsTransparent = false;
-	info->m_blockedByAlly = false;
-
-	m_liveCount++;
-	if (m_liveCount > m_peakLive)
-	{
-		m_peakLive = m_liveCount;
-	}
-	return info;
-}
-
-void PathfindCellInfoArena::free(PathfindCellInfo *info)
-{
-	DEBUG_ASSERTCRASH(!info->m_isFree, ("Double free of PathfindCellInfo."));
-	info->m_pathParent = m_firstFree;
-	m_firstFree = info;
-	info->m_isFree = true;
-	m_liveCount--;
-}
-
+/**
+ * Allocates a pool of pathfind cell infos.
+ */
 void PathfindCellInfo::allocateCellInfos()
 {
 	releaseCellInfos();
-	s_cellInfoArena.init();
-	s_infoArray = nullptr;
-	s_firstFree = nullptr;
+	s_infoArray = MSGNEW("PathfindCellInfo") PathfindCellInfo[CELL_INFOS_TO_ALLOCATE];	// pool[]ify
+	s_infoArray[CELL_INFOS_TO_ALLOCATE-1].m_pathParent = nullptr;
+	s_infoArray[CELL_INFOS_TO_ALLOCATE-1].m_isFree = true;
+	s_firstFree = s_infoArray;
+	for (Int i=0; i<CELL_INFOS_TO_ALLOCATE-1; i++) {
+		s_infoArray[i].m_pathParent = &s_infoArray[i+1];
+		s_infoArray[i].m_isFree = true;
+	}
 }
 
+/**
+ * Releases a pool of pathfind cell infos.
+ */
 void PathfindCellInfo::releaseCellInfos()
 {
-	s_cellInfoArena.reset();
+	if (s_infoArray==nullptr) {
+		return; // haven't allocated any yet.
+	}
+	Int count=0;
+	while (s_firstFree) {
+		count++;
+		DEBUG_ASSERTCRASH(s_firstFree->m_isFree, ("Should be freed."));
+		s_firstFree = s_firstFree->m_pathParent;
+	}
+	DEBUG_ASSERTCRASH(count==CELL_INFOS_TO_ALLOCATE, ("Error - Allocated cellinfos."));
+	delete[] s_infoArray;
 	s_infoArray = nullptr;
 	s_firstFree = nullptr;
 }
 
-PathfindCellInfo *PathfindCellInfo::getACellInfo(PathfindCell *cell, const ICoord2D &pos)
+/**
+ * Gets a pathfindcellinfo.
+ */
+PathfindCellInfo *PathfindCellInfo::getACellInfo(PathfindCell *cell,const ICoord2D &pos)
 {
-	PathfindCellInfo *info = s_cellInfoArena.alloc(cell, pos);
-	if (!info)
-	{
-		DEBUG_CRASH(("Ran out of pathfind cell infos in arena."));
+	PathfindCellInfo *info = s_firstFree;
+	if (s_firstFree) {
+		DEBUG_ASSERTCRASH(s_firstFree->m_isFree, ("Should be freed."));
+		s_firstFree = s_firstFree->m_pathParent;
+		info->m_isFree = false;  // Just allocated it.
+		info->m_cell = cell;
+		info->m_pos = pos;
+
+		info->m_nextOpen = nullptr;
+		info->m_prevOpen = nullptr;
+		info->m_pathParent = nullptr;
+		info->m_costSoFar = 0;
+		info->m_totalCost = 0;
+		info->m_open = 0;
+		info->m_closed = 0;
+		info->m_obstacleID = INVALID_ID;
+		info->m_goalUnitID = INVALID_ID;
+		info->m_posUnitID = INVALID_ID;
+		info->m_goalAircraftID = INVALID_ID;
+		info->m_obstacleIsFence = false;
+		info->m_obstacleIsTransparent = false;
+		info->m_blockedByAlly = false;
 	}
 	return info;
 }
 
+/**
+ * Returns a pathfindcellinfo.
+ */
 void PathfindCellInfo::releaseACellInfo(PathfindCellInfo *theInfo)
 {
 	DEBUG_ASSERTCRASH(!theInfo->m_isFree, ("Shouldn't be free."));
-	s_cellInfoArena.free(theInfo);
-}
-
-Int PathfindCellInfo::getCellInfoPeakLive()
-{
-	return s_cellInfoArena.getPeakLive();
-}
-
-Int PathfindCellInfo::getCellInfoLiveCount()
-{
-	return s_cellInfoArena.getLiveCount();
-}
-
-Int PathfindCellInfo::getCellInfoAllocFailures()
-{
-	return s_cellInfoArena.getAllocFailures();
-}
-
-Int PathfindCellInfo::getCellInfoPoolCapacity()
-{
-	return s_cellInfoArena.getPoolCapacity();
+	//@ todo -fix this assert on usa04.  jba.
+	//DEBUG_ASSERTCRASH(theInfo->m_obstacleID==0, ("Shouldn't be obstacle."));
+	theInfo->m_pathParent = s_firstFree;
+	s_firstFree = theInfo;
+	s_firstFree->m_isFree = true;
 }
 
 //-----------------------------------------------------------------------------------
@@ -2193,8 +1716,6 @@ void PathfindCell::forwardInsertionSortRetailCompatible(PathfindCellList& list)
 	if (list.m_head == nullptr)
 	{
 		list.m_head = this;
-		list.m_tail = this;
-		list.m_count = 1;
 		m_info->m_prevOpen = nullptr;
 		m_info->m_nextOpen = nullptr;
 		return;
@@ -2231,9 +1752,7 @@ void PathfindCell::forwardInsertionSortRetailCompatible(PathfindCellList& list)
 		previousCell->m_info->m_nextOpen = this->m_info;
 		m_info->m_prevOpen = previousCell->m_info;
 		m_info->m_nextOpen = nullptr;
-		list.m_tail = this;
 	}
-	list.m_count++;
 }
 #endif
 
@@ -2252,7 +1771,6 @@ void PathfindCell::forwardInsertionSort(PathfindCellList& list)
 		m_info->m_nextOpen = nullptr;
 		list.m_head = this;
 		list.m_tail = this;
-		list.m_count = 1;
 		return;
 	}
 
@@ -2282,7 +1800,6 @@ void PathfindCell::forwardInsertionSort(PathfindCellList& list)
 
 	current->m_info->m_nextOpen = this->m_info;
 	m_info->m_prevOpen = current->m_info;
-	list.m_count++;
 }
 
 // Reverse insertion sort, returns early if the list is being initialized or we are appending the list
@@ -2300,7 +1817,6 @@ void PathfindCell::reverseInsertionSort(PathfindCellList& list)
 		m_info->m_nextOpen = nullptr;
 		list.m_tail = this;
 		list.m_head = this;
-		list.m_count = 1;
 		return;
 	}
 
@@ -2330,56 +1846,34 @@ void PathfindCell::reverseInsertionSort(PathfindCellList& list)
 
 	current->m_info->m_prevOpen = this->m_info;
 	m_info->m_nextOpen = current->m_info;
-	list.m_count++;
 }
 
+/// put self on "open" list in ascending cost order, return new list
 void PathfindCell::putOnSortedOpenList( PathfindCellList &list )
 {
-	PerfTrace::NoteNodesInserted(getPerfTraceFrame());
-	Pathfinder *pf = TheAI ? TheAI->pathfinder() : nullptr;
-	if (pf && pf->m_useHeapOpenList)
-	{
-		DEBUG_ASSERTCRASH(m_info, ("Has to have info."));
-		DEBUG_ASSERTCRASH(m_info->m_closed == FALSE && m_info->m_open == FALSE, ("Serious error - Invalid flags. jba"));
-		m_info->m_open = true;
-		m_info->m_closed = false;
-		m_info->m_openInsertOrder = pf->m_nextOpenInsertOrder++;
-		pf->m_openHeap.push(this);
-		PerfTrace::NoteOpenListPeak(getPerfTraceFrame(), pf->m_openHeap.size());
-		return;
-	}
 #if RETAIL_COMPATIBLE_PATHFINDING
 	if (!s_useFixedPathfinding) {
 		forwardInsertionSortRetailCompatible(list);
-		PerfTrace::NoteOpenListPeak(getPerfTraceFrame(), list.size());
 		return;
 	}
 #endif
 
+	// TheSuperHackers @performance Mauller 20/03/2026 Implement reverse insertion sorting.
+	// Long and complex paths often append PathfindCell's, with high total path costs, to the open list.
+	// Appending and reverse traversal allow faster insertion of these cells, reducing pathfinding overhead by 50 - 66%.
 	if (list.canReverseSort(*this)) {
 		reverseInsertionSort(list);
 	}
 	else {
 		forwardInsertionSort(list);
 	}
-	PerfTrace::NoteOpenListPeak(getPerfTraceFrame(), list.size());
 }
 
 /// remove self from "open" list
 void PathfindCell::removeFromOpenList( PathfindCellList &list )
 {
-	PerfTrace::NoteNodesPopped(getPerfTraceFrame());
 	DEBUG_ASSERTCRASH(m_info, ("Has to have info."));
 	DEBUG_ASSERTCRASH(m_info->m_closed==FALSE && m_info->m_open==TRUE, ("Serious error - Invalid flags. jba"));
-	Pathfinder *pf = TheAI ? TheAI->pathfinder() : nullptr;
-	if (pf && pf->m_useHeapOpenList)
-	{
-		m_info->m_open = false;
-		m_info->m_nextOpen = nullptr;
-		m_info->m_prevOpen = nullptr;
-		m_info->m_openInsertOrder = 0;
-		return;
-	}
 	if (m_info->m_nextOpen)
 		m_info->m_nextOpen->m_prevOpen = m_info->m_prevOpen;
 	else {
@@ -2394,9 +1888,6 @@ void PathfindCell::removeFromOpenList( PathfindCellList &list )
 	m_info->m_open = false;
 	m_info->m_nextOpen = nullptr;
 	m_info->m_prevOpen = nullptr;
-	if (list.m_count > 0)
-		list.m_count--;
-	m_info->m_openInsertOrder = 0;
 
 }
 
@@ -2431,9 +1922,6 @@ Int PathfindCell::releaseOpenList( PathfindCellList &list )
 		curInfo->m_nextOpen = nullptr;
 		curInfo->m_prevOpen = nullptr;
 		curInfo->m_open = FALSE;
-		curInfo->m_openInsertOrder = 0;
-		if (list.m_count > 0)
-			list.m_count--;
 		cur->releaseInfo();
 	}
 	return count;
@@ -2469,8 +1957,6 @@ Int PathfindCell::releaseClosedList( PathfindCellList &list )
 		curInfo->m_nextOpen = nullptr;
 		curInfo->m_prevOpen = nullptr;
 		curInfo->m_closed = FALSE;
-		if (list.m_count > 0)
-			list.m_count--;
 		cur->releaseInfo();
 	}
 	return count;
@@ -2493,10 +1979,6 @@ void PathfindCell::putOnClosedList( PathfindCellList &list )
 			list.m_head->m_info->m_prevOpen = this->m_info;
 
 		list.m_head = this;
-		if (list.m_tail == nullptr)
-			list.m_tail = this;
-		list.m_count++;
-		PerfTrace::NoteClosedListPeak(getPerfTraceFrame(), list.size());
 	}
 
 }
@@ -2517,8 +1999,6 @@ void PathfindCell::removeFromClosedList( PathfindCellList &list )
 	m_info->m_closed = false;
 	m_info->m_nextOpen = nullptr;
 	m_info->m_prevOpen = nullptr;
-	if (list.m_count > 0)
-		list.m_count--;
 
 }
 
@@ -4578,9 +4058,7 @@ void Pathfinder::reset()
 	m_extent.lo.x=m_extent.lo.y=m_extent.hi.x=m_extent.hi.y=0;
 	m_logicalExtent.lo.x=m_logicalExtent.lo.y=m_logicalExtent.hi.x=m_logicalExtent.hi.y=0;
 	m_openList.reset();
-	m_openHeap.reset();
 	m_closedList.reset();
-	m_useHeapOpenList = true;
 
 	m_ignoreObstacleID = INVALID_ID;
 	m_isTunneling = false;
@@ -4590,10 +4068,6 @@ void Pathfinder::reset()
 	// pathfind grid cells have not been classified yet
 	m_isMapReady = false;
 	m_cumulativeCellsAllocated = 0;
-	m_requestCellBudget = 0;
-	m_recentlyServicedCursor = 0;
-	m_nextQueuedRequestSequence = 1;
-	m_nextOpenInsertOrder = 1;
 
 	debugPathPos.x = 0.0f;
 	debugPathPos.y = 0.0f;
@@ -4606,17 +4080,6 @@ void Pathfinder::reset()
 
 	for (m_queuePRHead=0; m_queuePRHead<PATHFIND_QUEUE_LEN; m_queuePRHead++) {
 		m_queuedPathfindRequests[m_queuePRHead] = INVALID_ID;
-		m_queuedRequestFrames[m_queuePRHead] = 0;
-		m_queuedRequestClasses[m_queuePRHead] = static_cast<UnsignedByte>(PerfTrace::PATH_REQUEST_EXPLICIT_MOVE);
-		m_queuedRequestDestinations[m_queuePRHead].zero();
-		m_queuedRequestGoalFingerprints[m_queuePRHead] = 0;
-		m_queuedRequestLocomotorFingerprints[m_queuePRHead] = 0;
-		m_queuedRequestSequences[m_queuePRHead] = 0;
-		m_recentlyServicedRequestIDs[m_queuePRHead] = INVALID_ID;
-		m_recentlyServicedRequestFrames[m_queuePRHead] = 0;
-		m_recentlyServicedRequestClasses[m_queuePRHead] = static_cast<UnsignedByte>(PerfTrace::PATH_REQUEST_EXPLICIT_MOVE);
-		m_recentlyServicedGoalFingerprints[m_queuePRHead] = 0;
-		m_recentlyServicedCooldownUntilFrames[m_queuePRHead] = 0;
 	}
 	m_queuePRHead = 0;
 	m_queuePRTail = 0;
@@ -5327,8 +4790,6 @@ void Pathfinder::newMap()
  */
 void Pathfinder::classifyMap()
 {
-	PerfTrace::ScopedPathTimer timer(getPerfTraceFrame(), PerfTrace::PATH_TIMER_ZONE_UPDATE);
-	PerfTrace::NoteZoneRecomputes(getPerfTraceFrame());
 
 	Int i, j;
 	// for now, sample cell corners and classify cell accordingly
@@ -5411,188 +4872,6 @@ void Pathfinder::classifyMap()
 void Pathfinder::forceMapRecalculation()
 {
 	classifyMap();
-}
-
-Int Pathfinder::getQueuedPathRequestCount() const
-{
-	Int count = m_queuePRTail - m_queuePRHead;
-	if (count < 0)
-	{
-		count += PATHFIND_QUEUE_LEN;
-	}
-	return count;
-}
-
-void Pathfinder::clearQueuedRequestSlot(Int slot)
-{
-	m_queuedPathfindRequests[slot] = INVALID_ID;
-	m_queuedRequestFrames[slot] = 0;
-	m_queuedRequestClasses[slot] = static_cast<UnsignedByte>(PerfTrace::PATH_REQUEST_EXPLICIT_MOVE);
-	m_queuedRequestDestinations[slot].zero();
-	m_queuedRequestGoalFingerprints[slot] = 0;
-	m_queuedRequestLocomotorFingerprints[slot] = 0;
-	m_queuedRequestSequences[slot] = 0;
-}
-
-void Pathfinder::removeQueuedRequestAt(Int slot)
-{
-	if (m_queuePRHead == m_queuePRTail)
-	{
-		return;
-	}
-
-	Int current = slot;
-	Int next = current + 1;
-	if (next >= PATHFIND_QUEUE_LEN)
-	{
-		next = 0;
-	}
-
-	while (next != m_queuePRTail)
-	{
-		m_queuedPathfindRequests[current] = m_queuedPathfindRequests[next];
-		m_queuedRequestFrames[current] = m_queuedRequestFrames[next];
-		m_queuedRequestClasses[current] = m_queuedRequestClasses[next];
-		m_queuedRequestDestinations[current] = m_queuedRequestDestinations[next];
-		m_queuedRequestGoalFingerprints[current] = m_queuedRequestGoalFingerprints[next];
-		m_queuedRequestLocomotorFingerprints[current] = m_queuedRequestLocomotorFingerprints[next];
-		m_queuedRequestSequences[current] = m_queuedRequestSequences[next];
-
-		current = next;
-		next++;
-		if (next >= PATHFIND_QUEUE_LEN)
-		{
-			next = 0;
-		}
-	}
-
-	clearQueuedRequestSlot(current);
-	m_queuePRTail = current;
-}
-
-void Pathfinder::getQueueAgeMetrics(const UnsignedInt currentFrame, Int &oldestAll, Int &oldestExplicit) const
-{
-	oldestAll = 0;
-	oldestExplicit = 0;
-
-	Int slot = m_queuePRHead;
-	while (slot != m_queuePRTail)
-	{
-		if (m_queuedPathfindRequests[slot] != INVALID_ID)
-		{
-			const Int age = static_cast<Int>(currentFrame - m_queuedRequestFrames[slot]);
-			if (age > oldestAll)
-			{
-				oldestAll = age;
-			}
-			if (m_queuedRequestClasses[slot] == static_cast<UnsignedByte>(PerfTrace::PATH_REQUEST_EXPLICIT_MOVE)
-				&& age > oldestExplicit)
-			{
-				oldestExplicit = age;
-			}
-		}
-
-		++slot;
-		if (slot >= PATHFIND_QUEUE_LEN)
-		{
-			slot = 0;
-		}
-	}
-}
-
-void Pathfinder::getGridMetrics(Int &mapCellsX, Int &mapCellsY, Int &mapCellsTotal,
-	Int &logicalCellsX, Int &logicalCellsY, Int &logicalCellsTotal,
-	Int &zoneBlockCountX, Int &zoneBlockCountY, Int &zoneBlockCountTotal) const
-{
-	mapCellsX = m_extent.hi.x >= m_extent.lo.x ? (m_extent.hi.x - m_extent.lo.x + 1) : 0;
-	mapCellsY = m_extent.hi.y >= m_extent.lo.y ? (m_extent.hi.y - m_extent.lo.y + 1) : 0;
-	mapCellsTotal = mapCellsX * mapCellsY;
-
-	logicalCellsX = m_logicalExtent.hi.x >= m_logicalExtent.lo.x ? (m_logicalExtent.hi.x - m_logicalExtent.lo.x + 1) : 0;
-	logicalCellsY = m_logicalExtent.hi.y >= m_logicalExtent.lo.y ? (m_logicalExtent.hi.y - m_logicalExtent.lo.y + 1) : 0;
-	logicalCellsTotal = logicalCellsX * logicalCellsY;
-
-	zoneBlockCountX = mapCellsX > 0 ? ((mapCellsX + PathfindZoneManager::ZONE_BLOCK_SIZE - 1) / PathfindZoneManager::ZONE_BLOCK_SIZE) : 0;
-	zoneBlockCountY = mapCellsY > 0 ? ((mapCellsY + PathfindZoneManager::ZONE_BLOCK_SIZE - 1) / PathfindZoneManager::ZONE_BLOCK_SIZE) : 0;
-	zoneBlockCountTotal = zoneBlockCountX * zoneBlockCountY;
-}
-
-void Pathfinder::computeFootprintMetrics(const Object *obj, Int &sideCells, Int &areaCells, Int &radius, Bool &center)
-{
-	sideCells = 0;
-	areaCells = 0;
-	radius = 0;
-	center = false;
-
-	if (obj == nullptr)
-	{
-		return;
-	}
-
-	getRadiusAndCenter(obj, radius, center);
-	sideCells = radius * 2 + (center ? 1 : 0);
-	if (sideCells < 1)
-	{
-		sideCells = 1;
-	}
-	areaCells = sideCells * sideCells;
-}
-
-void Pathfinder::beginOpenSearch(PathfindCell *startCell)
-{
-#if RETAIL_COMPATIBLE_PATHFINDING
-	if (!s_useFixedPathfinding)
-	{
-		m_useHeapOpenList = false;
-		m_openHeap.reset();
-		m_openList.reset(startCell);
-		if (startCell)
-		{
-			PerfTrace::NoteOpenListPeak(getPerfTraceFrame(), m_openList.size());
-		}
-		return;
-	}
-#endif
-
-	m_openList.reset();
-	m_openHeap.reset();
-	m_useHeapOpenList = true;
-	m_nextOpenInsertOrder = 1;
-	if (startCell)
-	{
-		startCell->putOnSortedOpenList(m_openList);
-	}
-}
-
-Bool Pathfinder::hasOpenCells() const
-{
-	return !m_openList.empty() || (m_useHeapOpenList && !m_openHeap.empty());
-}
-
-PathfindCell *Pathfinder::popNextOpenCell()
-{
-	PathfindCell *parentCell = nullptr;
-	if (m_useHeapOpenList)
-	{
-		while (!m_openHeap.empty())
-		{
-			parentCell = m_openHeap.pop();
-			if (!parentCell || !parentCell->hasInfo() || !parentCell->getOpen())
-			{
-				continue;
-			}
-
-			parentCell->removeFromOpenList(m_openList);
-			return parentCell;
-		}
-	}
-	if (!m_openList.empty())
-	{
-		parentCell = m_openList.getHead();
-		parentCell->removeFromOpenList(m_openList);
-		return parentCell;
-	}
-	return nullptr;
 }
 
 /**
@@ -5718,38 +4997,17 @@ Bool Pathfinder::validMovementTerrain( PathfindLayerEnum layer, const Locomotor*
 //
 void Pathfinder::cleanOpenAndClosedLists() {
 	Int count = 0;
-	if (m_useHeapOpenList) {
-		while (!m_openHeap.empty()) {
-			PathfindCell *cell = m_openHeap.pop();
-			if (cell && cell->hasInfo()) {
-				PathfindCellInfo *info = cell->m_info;
-#if RETAIL_COMPATIBLE_PATHFINDING
-				if (!info && !s_useFixedPathfinding) {
-					s_useFixedPathfinding = true;
-					s_forceCleanCells = true;
-					break;
-				}
-#endif
-				if (info) {
-					info->m_nextOpen = nullptr;
-					info->m_prevOpen = nullptr;
-					info->m_open = FALSE;
-					info->m_openInsertOrder = 0;
-					cell->releaseInfo();
-					count++;
-				}
-			}
-		}
-		m_openHeap.reset();
-		m_openList.reset();
-	} else if (!m_openList.empty()) {
+	if (!m_openList.empty()) {
 		count += PathfindCell::releaseOpenList(m_openList);
 		m_openList.reset();
 	}
 
 #if RETAIL_COMPATIBLE_PATHFINDING
+	// TheSuperHackers @info this is here as the map cells are contained within the pathfinder and cannot be cleaned externally.
+	// If the crash mode within PathfindCell::releaseOpenList is hit, it will set s_forceCleanCells to allow the system to cleanly recover.
 	if (s_forceCleanCells) {
 		forceCleanCells();
+		// TheSuperHackers @info cells on the closed list are forcefully cleaned up by this point
 		s_forceCleanCells = false;
 	}
 #endif
@@ -5760,6 +5018,8 @@ void Pathfinder::cleanOpenAndClosedLists() {
 	}
 
 #if RETAIL_COMPATIBLE_PATHFINDING
+	// TheSuperHackers @info this is here and performs the same function as the above block, but for when the crash occurs within the closed list.
+	// If the crash mode within PathfindCell::releaseClosedList is hit, it will set s_forceCleanCells to allow the system to cleanly recover.
 	if (s_forceCleanCells) {
 		forceCleanCells();
 		s_forceCleanCells = false;
@@ -5803,9 +5063,6 @@ Bool Pathfinder::validMovementPosition( Bool isCrusher, LocomotorSurfaceTypeMask
  */
 Bool Pathfinder::checkDestination(const Object *obj, Int cellX, Int cellY, PathfindLayerEnum layer, Int iRadius, Bool centerInCell)
 {
-	const UnsignedInt frame = getPerfTraceFrame();
-	PerfTrace::ScopedPathTimer timer(frame, PerfTrace::PATH_TIMER_CHECK_DESTINATION);
-
 	// If obj==nullptr, means we are checking for any ground units present.  jba.
 	Int numCellsAbove = iRadius;
 	if (centerInCell) numCellsAbove++;
@@ -5822,7 +5079,6 @@ Bool Pathfinder::checkDestination(const Object *obj, Int cellX, Int cellY, Pathf
 		for (j=cellY-iRadius; j<cellY+numCellsAbove; j++) {
 			PathfindCell	*cell = getCell(layer, i, j);
 			if (!cell) {
-				PerfTrace::NoteBlockedByTerrainChecks(frame);
 				return false; // off the map, so can't place here.
 			}
 
@@ -5833,24 +5089,17 @@ Bool Pathfinder::checkDestination(const Object *obj, Int cellX, Int cellY, Pathf
 				if (cell->getGoalAircraft() == objID) {
 					continue;
 				}
-				PerfTrace::NoteBlockedByUnitChecks(frame);
 				return false;
 			}
 
 			if (cell->getType()==PathfindCell::CELL_OBSTACLE) {
 				if (cell->isObstaclePresent( ignoreId ))
 					continue;
-				PerfTrace::NoteBlockedByTerrainChecks(frame);
 				return false;
 			}
 
 #if !(RTS_GENERALS && RETAIL_COMPATIBLE_PATHFINDING)
 			if (IS_IMPASSABLE(cell->getType())) {
-				if (cell->getType() == PathfindCell::CELL_BRIDGE_IMPASSABLE)
-				{
-					PerfTrace::NoteBridgeSpecialTerrainChecks(frame);
-				}
-				PerfTrace::NoteBlockedByTerrainChecks(frame);
 				return false;
 			}
 #endif
@@ -5873,7 +5122,6 @@ Bool Pathfinder::checkDestination(const Object *obj, Int cellX, Int cellY, Pathf
 			}
 
 			if (!obj) {
-				PerfTrace::NoteBlockedByUnitChecks(frame);
 				return false;
 			}
 			Object *unit = TheGameLogic->findObjectByID(goalUnitID);
@@ -5883,13 +5131,11 @@ Bool Pathfinder::checkDestination(const Object *obj, Int cellX, Int cellY, Pathf
 
 			// order matters: we want to know if I consider it to be an ally, not vice versa
 			if (obj->getRelationship(unit) == ALLIES) {
-				PerfTrace::NoteBlockedByUnitChecks(frame);
 				return false; 	// Don't usurp your allies goals.  jba.
 			}
 			if (cell->getFlags()==PathfindCell::UNIT_PRESENT_FIXED) {
 				Bool canCrush = obj->canCrushOrSquish(unit, TEST_CRUSH_OR_SQUISH);
 				if (!canCrush) {
-					PerfTrace::NoteBlockedByUnitChecks(frame);
 					return false; // Don't move to an occupied cell.
 				}
 			}
@@ -5905,9 +5151,6 @@ Bool Pathfinder::checkDestination(const Object *obj, Int cellX, Int cellY, Pathf
  */
 Bool Pathfinder::checkForMovement(const Object *obj, TCheckMovementInfo &info)
 {
-	const UnsignedInt frame = getPerfTraceFrame();
-	PerfTrace::ScopedPathTimer timer(frame, PerfTrace::PATH_TIMER_CHECK_FOR_MOVEMENT);
-
 	info.allyFixedCount = 0;
 	info.allyMoving = false;
 	info.allyGoal = false;
@@ -5934,7 +5177,6 @@ Bool Pathfinder::checkForMovement(const Object *obj, TCheckMovementInfo &info)
 		for (j=info.cell.y-info.radius; j<info.cell.y+numCellsAbove; j++) {
 			PathfindCell	*cell = getCell(info.layer,i, j);
 			if (!cell) {
-				PerfTrace::NoteBlockedByTerrainChecks(frame);
 				return false; // off the map, so can't move here.
 			}
 
@@ -5990,12 +5232,10 @@ Bool Pathfinder::checkForMovement(const Object *obj, TCheckMovementInfo &info)
 			// order matters: we want to know if I consider it to be an ally, not vice versa
 			if (obj->getRelationship(unit) == ALLIES) {
 				if (!unit->getAIUpdateInterface()) {
-					PerfTrace::NoteBlockedByUnitChecks(frame);
 					return false; // can't path through not-idle units.
 				}
 #if RTS_GENERALS && RETAIL_COMPATIBLE_PATHFINDING
 				if (!unit->getAIUpdateInterface()->isIdle()) {
-					PerfTrace::NoteBlockedByUnitChecks(frame);
 					return false; // can't path through not-idle units.
 				}
 #endif
@@ -6017,7 +5257,6 @@ Bool Pathfinder::checkForMovement(const Object *obj, TCheckMovementInfo &info)
 				Bool canCrush = obj->canCrushOrSquish( unit, TEST_CRUSH_OR_SQUISH );
 				if (!canCrush) {
 					info.enemyFixed = true;
-					PerfTrace::NoteBlockedByUnitChecks(frame);
 				}
 			}
 		}
@@ -6572,19 +5811,9 @@ Bool Pathfinder::adjustToPossibleDestination(Object *obj, const LocomotorSet& lo
  */
 Bool Pathfinder::queueForPath(ObjectID id)
 {
-	const UnsignedInt frame = getPerfTraceFrame();
-	Object *queuedObj = TheGameLogic ? TheGameLogic->findObjectByID(id) : nullptr;
-	AIUpdateInterface *queuedAI = queuedObj ? queuedObj->getAIUpdateInterface() : nullptr;
-	const PerfTrace::PathRequestClass requestClass = getPathRequestClass(queuedAI);
-	const Coord3D requestedDest = getPathRequestDestination(queuedAI);
-	const UnsignedInt goalFingerprint = getPathRequestGoalFingerprint(queuedAI);
-	const UnsignedInt locomotorFingerprint = getPathRequestLocomotorFingerprint(queuedObj, queuedAI);
-
-	PerfTrace::NotePathRequestAttempt(frame, requestClass);
-
 #ifdef DEBUG_LOGGING
 	{
-		Object *tmpObj = queuedObj;
+		Object *tmpObj = TheGameLogic->findObjectByID(id);
 		if (tmpObj) {
 			AIUpdateInterface *tmpAI = tmpObj->getAIUpdateInterface();
 			if (tmpAI) {
@@ -6595,71 +5824,10 @@ Bool Pathfinder::queueForPath(ObjectID id)
 	}
 #endif
 
-	Int recentMatch = -1;
-	for (Int recentSlot = 0; recentSlot < PATHFIND_QUEUE_LEN; recentSlot++)
-	{
-		if (m_recentlyServicedRequestIDs[recentSlot] != id)
-		{
-			continue;
-		}
-		if (recentMatch < 0 || m_recentlyServicedRequestFrames[recentSlot] >= m_recentlyServicedRequestFrames[recentMatch])
-		{
-			recentMatch = recentSlot;
-		}
-	}
-
-	if (recentMatch >= 0)
-	{
-		const Int recentSlot = recentMatch;
-		const PerfTrace::PathRequestClass recentClass =
-			static_cast<PerfTrace::PathRequestClass>(m_recentlyServicedRequestClasses[recentSlot]);
-		const Bool sameGoal = m_recentlyServicedGoalFingerprints[recentSlot] == goalFingerprint;
-		const Bool strongerThanRecent =
-			getPathRequestPriority(requestClass) > getPathRequestPriority(recentClass);
-		const Bool sameFrame = m_recentlyServicedRequestFrames[recentSlot] == frame;
-		const Bool coolingDown = m_recentlyServicedCooldownUntilFrames[recentSlot] > frame;
-
-		if ((sameFrame || coolingDown) && !strongerThanRecent)
-		{
-			PerfTrace::NotePathRequestDuplicate(frame, requestClass);
-			if (sameGoal)
-			{
-				PerfTrace::NoteQueueSuppressedSameGoal(frame);
-			}
-			else
-			{
-				PerfTrace::NoteQueueSuppressedWeakerThanExisting(frame);
-			}
-			PerfTrace::NotePathQueueDepth(frame, getQueuedPathRequestCount());
-			return true;
-		}
-	}
-
 	/* Check & see if we are already queued. */
 	Int slot = m_queuePRHead;
 	while (slot != m_queuePRTail) {
 		if (m_queuedPathfindRequests[slot] == id) {
-			PerfTrace::NotePathRequestDuplicate(frame, requestClass);
-			const PerfTrace::PathRequestClass existingClass = static_cast<PerfTrace::PathRequestClass>(m_queuedRequestClasses[slot]);
-			const Bool sameGoal = existingClass == requestClass
-				&& m_queuedRequestGoalFingerprints[slot] == goalFingerprint
-				&& m_queuedRequestLocomotorFingerprints[slot] == locomotorFingerprint;
-			if (sameGoal) {
-				PerfTrace::NoteQueueSuppressedSameGoal(frame);
-			}
-			else if (getPathRequestPriority(requestClass) > getPathRequestPriority(existingClass)) {
-				PerfTrace::NoteQueueReplaced(frame);
-				m_queuedRequestClasses[slot] = static_cast<UnsignedByte>(requestClass);
-				m_queuedRequestFrames[slot] = frame;
-				m_queuedRequestDestinations[slot] = requestedDest;
-				m_queuedRequestGoalFingerprints[slot] = goalFingerprint;
-				m_queuedRequestLocomotorFingerprints[slot] = locomotorFingerprint;
-				m_queuedRequestSequences[slot] = m_nextQueuedRequestSequence++;
-			}
-			else {
-				PerfTrace::NoteQueueSuppressedWeakerThanExisting(frame);
-			}
-			PerfTrace::NotePathQueueDepth(frame, getQueuedPathRequestCount());
 			return true;
 		}
 		slot++;
@@ -6674,64 +5842,11 @@ Bool Pathfinder::queueForPath(ObjectID id)
 		nextSlot = 0;
 	}
 	if (nextSlot==m_queuePRHead) {
-		if (getPathRequestPriority(requestClass) > 0)
-		{
-			Int replacementSlot = -1;
-			UnsignedInt replacementSequence = 0;
-			Int scanSlot = m_queuePRHead;
-			while (scanSlot != m_queuePRTail)
-			{
-				if (m_queuedPathfindRequests[scanSlot] != INVALID_ID)
-				{
-					const PerfTrace::PathRequestClass queuedClass =
-						static_cast<PerfTrace::PathRequestClass>(m_queuedRequestClasses[scanSlot]);
-					if (getPathRequestPriority(requestClass) > getPathRequestPriority(queuedClass))
-					{
-						if (replacementSlot < 0 || m_queuedRequestSequences[scanSlot] < replacementSequence)
-						{
-							replacementSlot = scanSlot;
-							replacementSequence = m_queuedRequestSequences[scanSlot];
-						}
-					}
-				}
-
-				scanSlot++;
-				if (scanSlot >= PATHFIND_QUEUE_LEN)
-				{
-					scanSlot = 0;
-				}
-			}
-
-			if (replacementSlot >= 0)
-			{
-				PerfTrace::NoteQueueReplaced(frame);
-				m_queuedPathfindRequests[replacementSlot] = id;
-				m_queuedRequestFrames[replacementSlot] = frame;
-				m_queuedRequestClasses[replacementSlot] = static_cast<UnsignedByte>(requestClass);
-				m_queuedRequestDestinations[replacementSlot] = requestedDest;
-				m_queuedRequestGoalFingerprints[replacementSlot] = goalFingerprint;
-				m_queuedRequestLocomotorFingerprints[replacementSlot] = locomotorFingerprint;
-				m_queuedRequestSequences[replacementSlot] = m_nextQueuedRequestSequence++;
-				PerfTrace::NotePathRequestEnqueued(frame, requestClass);
-				PerfTrace::NotePathQueueDepth(frame, getQueuedPathRequestCount());
-				return true;
-			}
-		}
-
-		PerfTrace::NotePathRequestFailed(frame, requestClass);
 		DEBUG_CRASH(("Ran out of pathfind queue slots."));
 		return false;
 	}
 	m_queuedPathfindRequests[m_queuePRTail] = id;
-	m_queuedRequestFrames[m_queuePRTail] = frame;
-	m_queuedRequestClasses[m_queuePRTail] = static_cast<UnsignedByte>(requestClass);
-	m_queuedRequestDestinations[m_queuePRTail] = requestedDest;
-	m_queuedRequestGoalFingerprints[m_queuePRTail] = goalFingerprint;
-	m_queuedRequestLocomotorFingerprints[m_queuePRTail] = locomotorFingerprint;
-	m_queuedRequestSequences[m_queuePRTail] = m_nextQueuedRequestSequence++;
 	m_queuePRTail = nextSlot;
-	PerfTrace::NotePathRequestEnqueued(frame, requestClass);
-	PerfTrace::NotePathQueueDepth(frame, getQueuedPathRequestCount());
 	return true;
 }
 
@@ -6924,15 +6039,11 @@ Path *Pathfinder::getAircraftPath( const Object *obj, const Coord3D *to )
 //DECLARE_PERF_TIMER(processPathfindQueue)
 void Pathfinder::processPathfindQueue()
 {
-	const UnsignedInt frame = getPerfTraceFrame();
-	PerfTrace::ScopedPathTimer timer(frame, PerfTrace::PATH_TIMER_PATHFIND_UPDATE);
-
 	//USE_PERF_TIMER(processPathfindQueue)
 	if (!m_isMapReady) {
 		return;
 	}
 #ifdef DEBUG_QPF
-	Int pathsFound = 0;
 #ifdef DEBUG_LOGGING
 	Int startTimeMS = ::GetTickCount();
 	__int64 startTime64;
@@ -6944,8 +6055,6 @@ void Pathfinder::processPathfindQueue()
 #endif
 
 	if (m_zoneManager.needToCalculateZones()) {
-		PerfTrace::ScopedPathTimer zoneTimer(frame, PerfTrace::PATH_TIMER_ZONE_UPDATE);
-		PerfTrace::NoteZoneRecomputes(frame);
 		m_zoneManager.calculateZones(m_map, m_layers, m_extent);
 		return;
 	}
@@ -6962,92 +6071,28 @@ void Pathfinder::processPathfindQueue()
 	bounds.hi.y--;
 	m_logicalExtent = bounds;
 
-	m_cumulativeCellsAllocated = 0;
-	PerfTrace::NotePathQueueDepth(frame, getQueuedPathRequestCount());
-	Int oldestQueueAge = 0;
-	Int oldestExplicitQueueAge = 0;
-	getQueueAgeMetrics(frame, oldestQueueAge, oldestExplicitQueueAge);
-	PerfTrace::NoteQueueOldestAge(frame, oldestQueueAge);
-	PerfTrace::NoteQueueExplicitOldestAge(frame, oldestExplicitQueueAge);
-	PerfTrace::NoteCellInfoPeakLive(frame, PathfindCellInfo::getCellInfoPeakLive());
-	PerfTrace::NoteCellInfoAllocFailures(frame, PathfindCellInfo::getCellInfoAllocFailures());
-	PerfTrace::NoteCellInfoPoolCapacity(frame, PathfindCellInfo::getCellInfoPoolCapacity());
-
-	for (Int pass = 1; pass <= 2; pass++)
-	{
-		while (m_cumulativeCellsAllocated < PATHFIND_CELLS_PER_FRAME &&
-			m_queuePRTail != m_queuePRHead)
-		{
-			Int slot = m_queuePRHead;
-			Bool found = false;
-			Int scanSlot = slot;
-			Int queueLen = getQueuedPathRequestCount();
-
-			for (Int scanned = 0; scanned < queueLen; scanned++)
-			{
-				if (m_queuedPathfindRequests[scanSlot] != INVALID_ID)
-				{
-					const UnsignedByte slotClass = m_queuedRequestClasses[scanSlot];
-					const Bool isHigh = isHighPriorityRequestClass(slotClass);
-					if ((pass == 1 && isHigh) || (pass == 2 && !isHigh))
-					{
-						slot = scanSlot;
-						found = true;
-						break;
-					}
-				}
-				scanSlot++;
-				if (scanSlot >= PATHFIND_QUEUE_LEN) scanSlot = 0;
-			}
-
-			if (!found) break;
-
-			PerfTrace::ScopedPathTimer dispatchTimer(frame, PerfTrace::PATH_TIMER_PATH_REQUEST_DISPATCH);
-			PerfTrace::NoteQueueServicePass(frame, pass);
-
-			Object *obj = TheGameLogic->findObjectByID(m_queuedPathfindRequests[slot]);
-			const PerfTrace::PathRequestClass requestClass =
-				static_cast<PerfTrace::PathRequestClass>(m_queuedRequestClasses[slot]);
-			const Int waitFrames = static_cast<Int>(frame - m_queuedRequestFrames[slot]);
-			const UnsignedInt goalFingerprint = m_queuedRequestGoalFingerprints[slot];
-			removeQueuedRequestAt(slot);
-
-			PerfTrace::NotePathRequestProcessed(frame, requestClass);
-			PerfTrace::NoteMaxQueueWaitFrames(frame, waitFrames);
-
-			if (obj)
-			{
-				AIUpdateInterface *ai = obj->getAIUpdateInterface();
-				if (ai)
-				{
-					const Bool isHigh = isHighPriorityRequestClass(static_cast<UnsignedByte>(requestClass));
-					m_requestCellBudget = isHigh ? PATHFIND_CELLS_PER_REQUEST_EXPLICIT : PATHFIND_CELLS_PER_REQUEST_LOW;
-					PerfTrace::NoteRequestCellBudget(frame, m_requestCellBudget);
-					const UnsignedInt cooldownFrames = getRepathCooldownFrames(getQueuedPathRequestCount(), requestClass);
-					const Int recentSlot = m_recentlyServicedCursor;
-					m_recentlyServicedRequestIDs[recentSlot] = obj->getID();
-					m_recentlyServicedRequestFrames[recentSlot] = frame;
-					m_recentlyServicedRequestClasses[recentSlot] = static_cast<UnsignedByte>(requestClass);
-					m_recentlyServicedGoalFingerprints[recentSlot] = goalFingerprint;
-					m_recentlyServicedCooldownUntilFrames[recentSlot] = frame + cooldownFrames;
-					m_recentlyServicedCursor++;
-					if (m_recentlyServicedCursor >= PATHFIND_QUEUE_LEN)
-					{
-						m_recentlyServicedCursor = 0;
-					}
-
-					const Int cellsBefore = m_cumulativeCellsAllocated;
-					ai->doPathfind(this);
-					PerfTrace::NoteLongestSingleRequestCells(frame, m_cumulativeCellsAllocated - cellsBefore);
+	m_cumulativeCellsAllocated = 0;	// Number of pathfind cells examined.
 #ifdef DEBUG_QPF
-					pathsFound++;
+	Int pathsFound = 0;
 #endif
-				}
+	while (m_cumulativeCellsAllocated < PATHFIND_CELLS_PER_FRAME &&
+		m_queuePRTail!=m_queuePRHead) {
+		Object *obj = TheGameLogic->findObjectByID(m_queuedPathfindRequests[m_queuePRHead]);
+		m_queuedPathfindRequests[m_queuePRHead] = INVALID_ID;
+		if (obj) {
+			AIUpdateInterface *ai = obj->getAIUpdateInterface();
+			if (ai) {
+				ai->doPathfind(this);
+#ifdef DEBUG_QPF
+				pathsFound++;
+#endif
 			}
-			PerfTrace::NotePathQueueDepth(frame, getQueuedPathRequestCount());
+		}
+		m_queuePRHead = m_queuePRHead+1;
+		if (m_queuePRHead >= PATHFIND_QUEUE_LEN) {
+			m_queuePRHead = 0;
 		}
 	}
-	PerfTrace::NotePathCells(frame, m_cumulativeCellsAllocated);
 #ifdef DEBUG_QPF
 	if (pathsFound>0) {
 #ifdef DEBUG_LOGGING
@@ -7358,7 +6403,6 @@ Int Pathfinder::examineNeighboringCells(PathfindCell *parentCell, PathfindCell *
 			if (info.allyMoving && dx<10 && dy<10) {
 				newCostSoFar += 3*COST_DIAGONAL;
 			}
-			newCostSoFar += getPhase3LaneBiasCost(obj, startCellNdx, goalCell, newCellCoord, info);
 
 			if (newCell->getType() == PathfindCell::CELL_CLIFF && !newCell->getPinched() ) {
 				Coord3D fromPos;
@@ -7485,7 +6529,6 @@ Path *Pathfinder::findPath( Object *obj, const LocomotorSet& locomotorSet, const
 Path *Pathfinder::internalFindPath( Object *obj, const LocomotorSet& locomotorSet, const Coord3D *from,
 													 const Coord3D *rawTo)
 {
-	PerfTrace::ScopedPathTimer timer(getPerfTraceFrame(), PerfTrace::PATH_TIMER_ASTAR_EXPAND);
 	//CRCDEBUG_LOG(("Pathfinder::findPath()"));
 #ifdef INTENSE_DEBUG
 	DEBUG_LOG(("internal find path..."));
@@ -7620,27 +6663,32 @@ Path *Pathfinder::internalFindPath( Object *obj, const LocomotorSet& locomotorSe
 
 	parentCell->startPathfind(goalCell);
 
-	beginOpenSearch(parentCell);
+	// initialize "open" list to contain start cell
+#if RETAIL_COMPATIBLE_PATHFINDING
+	if (!s_useFixedPathfinding) {
+		m_openList.reset(parentCell);
+	}
+	else
+#endif
+	{
+		m_openList.reset();
+		parentCell->putOnSortedOpenList(m_openList);
+	}
 
+	// "closed" list is initially empty
 	m_closedList.reset();
 
 	Int cellCount = 0;
 
-	Int requestBudget = m_requestCellBudget > 0 ? m_requestCellBudget : PATHFIND_CELLS_PER_REQUEST_EXPLICIT;
-
-	while (hasOpenCells())
+	//
+	// Continue search until "open" list is empty, or
+	// until goal is found.
+	//
+	while( !m_openList.empty() )
 	{
-		if (m_cumulativeCellsAllocated + cellCount >= PATHFIND_CELLS_PER_FRAME)
-		{
-			break;
-		}
-		if (cellCount >= requestBudget)
-		{
-			break;
-		}
-
-		parentCell = popNextOpenCell();
-		if (!parentCell) break;
+		// take head cell off of open list - it has lowest estimated total path cost
+		parentCell = m_openList.getHead();
+		parentCell->removeFromOpenList(m_openList);
 
 		if (parentCell == goalCell)
 		{
@@ -7689,11 +6737,6 @@ Path *Pathfinder::internalFindPath( Object *obj, const LocomotorSet& locomotorSe
 		checkChangeLayers(parentCell);
 
 		cellCount += examineNeighboringCells(parentCell, goalCell, locomotorSet, isHuman, centerInCell, radius, startCellNdx, obj, NO_ATTACK);
-
-		if (m_useHeapOpenList)
-		{
-			PerfTrace::NoteOpenListPeak(getPerfTraceFrame(), m_openHeap.size());
-		}
 
 	}
 
@@ -8182,7 +7225,16 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 	parentCell->startPathfind(goalCell);
 
 	// initialize "open" list to contain start cell
-	beginOpenSearch(parentCell);
+#if RETAIL_COMPATIBLE_PATHFINDING
+	if (!s_useFixedPathfinding) {
+		m_openList.reset(parentCell);
+	}
+	else
+#endif
+	{
+		m_openList.reset();
+		parentCell->putOnSortedOpenList(m_openList);
+	}
 
 	// "closed" list is initially empty
 	m_closedList.reset();
@@ -8197,13 +7249,11 @@ Path *Pathfinder::findGroundPath( const Coord3D *from,
 	// until goal is found.
 	//
 	Int cellCount = 0;
-	while (hasOpenCells())
+	while( !m_openList.empty() )
 	{
 		// take head cell off of open list - it has lowest estimated total path cost
-		parentCell = popNextOpenCell();
-		if (!parentCell) {
-			break;
-		}
+		parentCell = m_openList.getHead();
+		parentCell->removeFromOpenList(m_openList);
 
 		if (parentCell == goalCell)
 		{
@@ -8662,7 +7712,17 @@ Path *Pathfinder::internal_findHierarchicalPath( Bool isHuman, const LocomotorSu
 		goalBlockNdx.y = -1;
 	}
 
-	beginOpenSearch(parentCell);
+	// initialize "open" list to contain start cell
+#if RETAIL_COMPATIBLE_PATHFINDING
+	if (!s_useFixedPathfinding) {
+		m_openList.reset(parentCell);
+	}
+	else
+#endif
+	{
+		m_openList.reset();
+		parentCell->putOnSortedOpenList(m_openList);
+	}
 
 	if (parentCell->getLayer()!=LAYER_GROUND) {
 		PathfindLayerEnum layer = parentCell->getLayer();
@@ -8671,16 +7731,11 @@ Path *Pathfinder::internal_findHierarchicalPath( Bool isHuman, const LocomotorSu
 		ICoord2D toNdx;
 		m_layers[layer].getStartCellIndex(&ndx);
 		m_layers[layer].getEndCellIndex(&toNdx);
-		PathfindCell *cell = getCell(LAYER_GROUND, toNdx.x, toNdx.y);
+ 		PathfindCell *cell = getCell(LAYER_GROUND, toNdx.x, toNdx.y);
 		PathfindCell *startCell = getCell(LAYER_GROUND, ndx.x, ndx.y);
 		if (cell && startCell) {
 			// Close parent cell;
-			parentCell = popNextOpenCell();
-			if (!parentCell) {
-				cleanOpenAndClosedLists();
-				goalCell->releaseInfo();
-				return nullptr;
-			}
+			parentCell->removeFromOpenList(m_openList);
 			parentCell->putOnClosedList(m_closedList);
 			if (!startCell->allocateInfo(ndx)) {
 				// TheSuperHackers @info We need to forcefully cleanup dangling pathfinding cells if this failure condition is hit in retail
@@ -8742,13 +7797,11 @@ Path *Pathfinder::internal_findHierarchicalPath( Bool isHuman, const LocomotorSu
 	// Continue search until "open" list is empty, or
 	// until goal is found.
 	//
-	while (hasOpenCells())
+	while( !m_openList.empty() )
 	{
 		// take head cell off of open list - it has lowest estimated total path cost
-		parentCell = popNextOpenCell();
-		if (!parentCell) {
-			break;
-		}
+		parentCell = m_openList.getHead();
+		parentCell->removeFromOpenList(m_openList);
 
 		zoneStorageType parentZone;
 		if (parentCell->getLayer()==LAYER_GROUND) {
@@ -9473,7 +8526,16 @@ Int Pathfinder::checkPathCost(Object *obj, const LocomotorSet& locomotorSet, con
 	parentCell->startPathfind(goalCell);
 
 	// initialize "open" list to contain start cell
-	beginOpenSearch(parentCell);
+#if RETAIL_COMPATIBLE_PATHFINDING
+	if (!s_useFixedPathfinding) {
+		m_openList.reset(parentCell);
+	}
+	else
+#endif
+	{
+		m_openList.reset();
+		parentCell->putOnSortedOpenList(m_openList);
+	}
 
 	// "closed" list is initially empty
 	m_closedList.reset();
@@ -9482,13 +8544,11 @@ Int Pathfinder::checkPathCost(Object *obj, const LocomotorSet& locomotorSet, con
 	// Continue search until "open" list is empty, or
 	// until goal is found.
 	//
-	while (hasOpenCells())
+	while( !m_openList.empty() )
 	{
 		// take head cell off of open list - it has lowest estimated total path cost
-		parentCell = popNextOpenCell();
-		if (!parentCell) {
-			break;
-		}
+		parentCell = m_openList.getHead();
+		parentCell->removeFromOpenList(m_openList);
 
 		// put parent cell onto closed list - its evaluation is finished - Retail compatible behaviour
 #if RETAIL_COMPATIBLE_PATHFINDING
@@ -9665,7 +8725,6 @@ Int Pathfinder::checkPathCost(Object *obj, const LocomotorSet& locomotorSet, con
 Path *Pathfinder::findClosestPath( Object *obj, const LocomotorSet& locomotorSet, const Coord3D *from,
 																	Coord3D *rawTo, Bool blocked, Real pathCostMultiplier, Bool moveAllies)
 {
-	PerfTrace::ScopedPathTimer timer(getPerfTraceFrame(), PerfTrace::PATH_TIMER_ASTAR_EXPAND);
 	//CRCDEBUG_LOG(("Pathfinder::findClosestPath()"));
 #ifdef DEBUG_LOGGING
 	Int startTimeMS = ::GetTickCount();
@@ -9809,27 +8868,33 @@ Path *Pathfinder::findClosestPath( Object *obj, const LocomotorSet& locomotorSet
 	Real closestDistScreenSqr = FLT_MAX;
 
 	// initialize "open" list to contain start cell
-	beginOpenSearch(parentCell);
+#if RETAIL_COMPATIBLE_PATHFINDING
+	if (!s_useFixedPathfinding) {
+		m_openList.reset(parentCell);
+	}
+	else
+#endif
+	{
+		m_openList.reset();
+		parentCell->putOnSortedOpenList(m_openList);
+	}
 
 	// "closed" list is initially empty
 	m_closedList.reset();
 	Int count = 0;
-
 	//
 	// Continue search until "open" list is empty, or
 	// until goal is found.
 	//
 	Bool foundGoal = false;
-	while (hasOpenCells())
+	while( !m_openList.empty() )
 	{
 		Real dx;
 		Real dy;
 		Real distSqr;
 		// take head cell off of open list - it has lowest estimated total path cost
-		parentCell = popNextOpenCell();
-		if (!parentCell) {
-			break;
-		}
+		parentCell = m_openList.getHead();
+		parentCell->removeFromOpenList(m_openList);
 
 		if (parentCell == goalCell)
 		{
@@ -11184,7 +10249,6 @@ void Pathfinder::removeUnitFromPathfindMap(  Object *obj )
 
 Bool Pathfinder::moveAllies(Object *obj, Path *path)
 {
-	PerfTrace::ScopedPathTimer timer(getPerfTraceFrame(), PerfTrace::PATH_TIMER_MOVE_ALLIES);
 
 #ifdef DO_UNIT_TIMINGS
 #pragma MESSAGE("*** WARNING *** DOING DO_UNIT_TIMINGS!!!!")
@@ -11272,7 +10336,6 @@ if (g_UT_startTiming) return false;
 #endif
 
 				//DEBUG_LOG(("Moving ally"));
-				PerfTrace::NoteRepathTriggered(getPerfTraceFrame());
 				otherObj->getAI()->aiMoveAwayFromUnit(obj, CMD_FROM_AI);
 			}
 		}
@@ -11350,7 +10413,17 @@ Path *Pathfinder::getMoveAwayFromPath(Object* obj, Object *otherObj,
 	}
 	parentCell->startPathfind(nullptr);
 
-	beginOpenSearch(parentCell);
+	// initialize "open" list to contain start cell
+#if RETAIL_COMPATIBLE_PATHFINDING
+	if (!s_useFixedPathfinding) {
+		m_openList.reset(parentCell);
+	}
+	else
+#endif
+	{
+		m_openList.reset();
+		parentCell->putOnSortedOpenList(m_openList);
+	}
 
 	// "closed" list is initially empty
 	m_closedList.reset();
@@ -11365,13 +10438,11 @@ Path *Pathfinder::getMoveAwayFromPath(Object* obj, Object *otherObj,
 	boxHalfWidth += otherRadius*PATHFIND_CELL_SIZE_F;
 	if (otherCenter) boxHalfWidth+=PATHFIND_CELL_SIZE_F/2;
 
-	while (hasOpenCells())
+	while( !m_openList.empty() )
 	{
 		// take head cell off of open list - it has lowest estimated total path cost
-		parentCell = popNextOpenCell();
-		if (!parentCell) {
-			break;
-		}
+		parentCell = m_openList.getHead();
+		parentCell->removeFromOpenList(m_openList);
 
 		Region2D bounds;
 		Coord3D cellCenter;
@@ -11473,7 +10544,6 @@ Path *Pathfinder::getMoveAwayFromPath(Object* obj, Object *otherObj,
 Path *Pathfinder::patchPath( const Object *obj, const LocomotorSet& locomotorSet,
 		Path *originalPath, Bool blocked )
 {
-	PerfTrace::ScopedPathTimer timer(getPerfTraceFrame(), PerfTrace::PATH_TIMER_ASTAR_EXPAND);
 	//CRCDEBUG_LOG(("Pathfinder::patchPath()"));
 #ifdef DEBUG_LOGGING
 	Int startTimeMS = ::GetTickCount();
@@ -11520,7 +10590,16 @@ Path *Pathfinder::patchPath( const Object *obj, const LocomotorSet& locomotorSet
 	parentCell->startPathfind( nullptr);
 
 	// initialize "open" list to contain start cell
-	beginOpenSearch(parentCell);
+#if RETAIL_COMPATIBLE_PATHFINDING
+	if (!s_useFixedPathfinding) {
+		m_openList.reset(parentCell);
+	}
+	else
+#endif
+	{
+		m_openList.reset();
+		parentCell->putOnSortedOpenList(m_openList);
+	}
 
 	// "closed" list is initially empty
 	m_closedList.reset();
@@ -11604,13 +10683,11 @@ Path *Pathfinder::patchPath( const Object *obj, const LocomotorSet& locomotorSet
 		return nullptr;
 	}
 
-	while (hasOpenCells())
+	while( !m_openList.empty() )
 	{
 		// take head cell off of open list - it has lowest estimated total path cost
-		parentCell = popNextOpenCell();
-		if (!parentCell) {
-			break;
-		}
+		parentCell = m_openList.getHead();
+		parentCell->removeFromOpenList(m_openList);
 
 		Coord3D cellCenter;
 		adjustCoordToCell(parentCell->getXIndex(), parentCell->getYIndex(), centerInCell, cellCenter, parentCell->getLayer());
@@ -11696,7 +10773,6 @@ Path *Pathfinder::patchPath( const Object *obj, const LocomotorSet& locomotorSet
 Path *Pathfinder::findAttackPath( const Object *obj, const LocomotorSet& locomotorSet, const Coord3D *from,
 		const Object *victim, const Coord3D* victimPos, const Weapon *weapon )
 {
-	PerfTrace::ScopedPathTimer timer(getPerfTraceFrame(), PerfTrace::PATH_TIMER_ASTAR_EXPAND);
 	if (!m_isMapReady)
 		return nullptr; // Should always be ok.
 
@@ -11808,7 +10884,16 @@ Path *Pathfinder::findAttackPath( const Object *obj, const LocomotorSet& locomot
 	}
 
 	// initialize "open" list to contain start cell
-	beginOpenSearch(parentCell);
+#if RETAIL_COMPATIBLE_PATHFINDING
+	if (!s_useFixedPathfinding) {
+		m_openList.reset(parentCell);
+	}
+	else
+#endif
+	{
+		m_openList.reset();
+		parentCell->putOnSortedOpenList(m_openList);
+	}
 
 	// "closed" list is initially empty
 	m_closedList.reset();
@@ -11828,13 +10913,11 @@ Path *Pathfinder::findAttackPath( const Object *obj, const LocomotorSet& locomot
 		checkLOS = true;
 	}
 
-	while (hasOpenCells())
+	while( !m_openList.empty() )
 	{
 		// take head cell off of open list - it has lowest estimated total path cost
-		parentCell = popNextOpenCell();
-		if (!parentCell) {
-			break;
-		}
+		parentCell = m_openList.getHead();
+		parentCell->removeFromOpenList(m_openList);
 
 		Coord3D cellCenter;
 		adjustCoordToCell(parentCell->getXIndex(), parentCell->getYIndex(), centerInCell, cellCenter, parentCell->getLayer());
@@ -12045,7 +11128,6 @@ Path *Pathfinder::findAttackPath( const Object *obj, const LocomotorSet& locomot
 Path *Pathfinder::findSafePath( const Object *obj, const LocomotorSet& locomotorSet,
 		const Coord3D *from, const Coord3D* repulsorPos1, const Coord3D* repulsorPos2, Real repulsorRadius)
 {
-	PerfTrace::ScopedPathTimer timer(getPerfTraceFrame(), PerfTrace::PATH_TIMER_ASTAR_EXPAND);
 	//CRCDEBUG_LOG(("Pathfinder::findSafePath()"));
 	if (m_isMapReady == false) return nullptr; // Should always be ok.
 #if defined(RTS_DEBUG)
@@ -12083,18 +11165,32 @@ Path *Pathfinder::findSafePath( const Object *obj, const LocomotorSet& locomotor
 	parentCell->startPathfind( nullptr);
 
 	// initialize "open" list to contain start cell
-	beginOpenSearch(parentCell);
+#if RETAIL_COMPATIBLE_PATHFINDING
+	if (!s_useFixedPathfinding) {
+		m_openList.reset(parentCell);
+	}
+	else
+#endif
+	{
+		m_openList.reset();
+		parentCell->putOnSortedOpenList(m_openList);
+	}
 
 	// "closed" list is initially empty
 	m_closedList.reset();
+
+	//
+	// Continue search until "open" list is empty, or
+	// until goal is found.
+	//
+
 	Real farthestDistanceSqr = 0;
-	while (hasOpenCells())
+
+	while( !m_openList.empty() )
 	{
 		// take head cell off of open list - it has lowest estimated total path cost
-		parentCell = popNextOpenCell();
-		if (!parentCell) {
-			break;
-		}
+		parentCell = m_openList.getHead();
+		parentCell->removeFromOpenList(m_openList);
 
 		Coord3D cellCenter;
 		adjustCoordToCell(parentCell->getXIndex(), parentCell->getYIndex(), centerInCell, cellCenter, parentCell->getLayer());
@@ -12113,7 +11209,7 @@ Path *Pathfinder::findSafePath( const Object *obj, const LocomotorSet& locomotor
 		if (distSqr>repulsorDistSqr) {
 			ok = true;
 		}
-		if (!hasOpenCells() && cellCount>0) {
+		if (m_openList.empty() && cellCount>0) {
 			ok = true; // exhausted the search space, just take the last cell.
 		}
 		if (distSqr > farthestDistanceSqr) {

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Drawable/Draw/W3DModelDraw.cpp
@@ -690,8 +690,9 @@ void ModelConditionInfo::validateCachedBones(RenderObjClass* robj, Real scale) c
 	{
 		if (!doSingleBoneName(robj, *it, m_pristineBones))
 		{
-			// DO crash here, since we specifically requested this bone for this model
-			DEBUG_CRASH(("*** ASSET ERROR: public bone '%s' (and variations thereof) not found in model %s!",it->str(),m_modelName.str()));
+			// Be tolerant here: damaged/rubble variants often inherit public bone declarations
+			// from their healthy state but intentionally omit those bones in the replacement model.
+			DEBUG_LOG(("ASSET WARNING: public bone '%s' (and variations thereof) not found in model %s", it->str(), m_modelName.str()));
 		}
 		//else
 		//{
@@ -878,7 +879,7 @@ void ModelConditionInfo::validateTurretInfo() const
 		{
 			if (findPristineBone(tur.m_turretAngleNameKey, &tur.m_turretAngleBone) == nullptr)
 			{
-				DEBUG_CRASH(("*** ASSET ERROR: TurretBone %s not found! (%s)",KEYNAME(tur.m_turretAngleNameKey).str(),m_modelName.str()));
+				DEBUG_LOG(("ASSET WARNING: TurretBone %s not found! (%s)", KEYNAME(tur.m_turretAngleNameKey).str(), m_modelName.str()));
 				tur.m_turretAngleBone = 0;
 			}
 		}
@@ -891,7 +892,7 @@ void ModelConditionInfo::validateTurretInfo() const
 		{
 			if (findPristineBone(tur.m_turretPitchNameKey, &tur.m_turretPitchBone) == nullptr)
 			{
-				DEBUG_CRASH(("*** ASSET ERROR: TurretBone %s not found! (%s)",KEYNAME(tur.m_turretPitchNameKey).str(),m_modelName.str()));
+				DEBUG_LOG(("ASSET WARNING: TurretBone %s not found! (%s)", KEYNAME(tur.m_turretPitchNameKey).str(), m_modelName.str()));
 				tur.m_turretPitchBone = 0;
 			}
 		}
@@ -3360,7 +3361,7 @@ Bool W3DModelDraw::getProjectileLaunchOffset(
 			if (turInfo.m_turretAngleNameKey != NAMEKEY_INVALID &&
 					!stateToUse->findPristineBonePos(turInfo.m_turretAngleNameKey, *turretRotPos))
 			{
-				DEBUG_CRASH(("*** ASSET ERROR: TurretBone %s not found!",KEYNAME(turInfo.m_turretAngleNameKey).str()));
+				DEBUG_LOG(("ASSET WARNING: TurretBone %s not found!", KEYNAME(turInfo.m_turretAngleNameKey).str()));
 			}
 #ifdef CACHE_ATTACH_BONE
 			if (offset)
@@ -3376,7 +3377,7 @@ Bool W3DModelDraw::getProjectileLaunchOffset(
 			if (turInfo.m_turretPitchNameKey != NAMEKEY_INVALID &&
 					!stateToUse->findPristineBonePos(turInfo.m_turretPitchNameKey, *turretPitchPos))
 			{
-				DEBUG_CRASH(("*** ASSET ERROR: TurretBone %s not found!",KEYNAME(turInfo.m_turretPitchNameKey).str()));
+				DEBUG_LOG(("ASSET WARNING: TurretBone %s not found!", KEYNAME(turInfo.m_turretPitchNameKey).str()));
 			}
 #ifdef CACHE_ATTACH_BONE
 			if (offset)

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/AIUpdate.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/AIUpdate.h
@@ -454,11 +454,16 @@ public:
 
 	Bool isWaitingForPath() const {return m_waitingForPath;}
 	Bool isAttackPath() const {return m_isAttackPath;} ///< True if we have a path to an attack location.
+	Bool isApproachPath() const {return m_isApproachPath;}
+	Bool isSafePath() const {return m_isSafePath;}
 	void cancelPath(); ///< Called if we no longer need the path.
 	Path* getPath() { return m_path; }				///< return the agent's current path
 	const Path* getPath() const { return m_path; }				///< return the agent's current path
 	void destroyPath();												///< destroy the current path, setting it to null
 	UnsignedInt getPathAge() const { return TheGameLogic->getFrame() - m_pathTimestamp; }	///< return the "age" of the path
+	const Coord3D *getRequestedDestination() const { return &m_requestedDestination; }
+	const Coord3D *getRequestedDestination2() const { return &m_requestedDestination2; }
+	ObjectID getRequestedVictimID() const { return m_requestedVictimID; }
 	Bool isPathAvailable( const Coord3D *destination ) const; ///< does a path exist between us and the destination
 	Bool isQuickPathAvailable( const Coord3D *destination ) const;  ///< does a path (using quick pathfind) exist between us and the destination
 	Int getNumFramesBlocked() const {return m_blockedFrames;}

--- a/Generals/Code/GameEngine/Source/Common/CommandLine.cpp
+++ b/Generals/Code/GameEngine/Source/Common/CommandLine.cpp
@@ -29,6 +29,7 @@
 #include "Common/CommandLine.h"
 #include "Common/CRCDebug.h"
 #include "Common/LocalFileSystem.h"
+#include "Common/PerfTrace.h"
 #include "Common/Recorder.h"
 #include "Common/version.h"
 #include "GameClient/ClientInstance.h"
@@ -167,6 +168,32 @@ Int parseFullViewport(char *args[], int num)
 {
 	TheWritableGlobalData->m_viewportHeightScale = 1.0f;
 
+	return 1;
+}
+
+Int parsePerfTrace(char *args[], int)
+{
+	PerfTrace::SetEnabled(TRUE);
+	return 1;
+}
+
+Int parsePerfTraceFrames(char *args[], int argc)
+{
+	if (argc > 1)
+	{
+		PerfTrace::SetSampleFrames(atoi(args[1]));
+		return 2;
+	}
+	return 1;
+}
+
+Int parsePerfTraceSpikeMS(char *args[], int argc)
+{
+	if (argc > 1)
+	{
+		PerfTrace::SetSpikeMS(static_cast<Real>(atof(args[1])));
+		return 2;
+	}
 	return 1;
 }
 
@@ -1173,6 +1200,9 @@ static CommandLineParam paramsForEngineInit[] =
 	{ "-noshaders", parseNoShaders },
 	{ "-quickstart", parseQuickStart },
 	{ "-useWaveEditor", parseUseWaveEditor },
+	{ "-perfTrace", parsePerfTrace },
+	{ "-perfTraceFrames", parsePerfTraceFrames },
+	{ "-perfTraceSpikeMS", parsePerfTraceSpikeMS },
 
 	// TheSuperHackers @feature xezon 03/08/2025 Force full viewport for 'Control Bar Pro' Addons like GenTool did it.
 	{ "-forcefullviewport", parseFullViewport },

--- a/Generals/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -49,6 +49,7 @@
 #include "Common/LocalFileSystem.h"
 #include "Common/GlobalData.h"
 #include "Common/PerfTimer.h"
+#include "Common/PerfTrace.h"
 #include "Common/RandomValue.h"
 #include "Common/NameKeyGenerator.h"
 #include "Common/ModuleFactory.h"
@@ -782,6 +783,9 @@ void GameEngine::execute()
 	// pretty basic for now
 	while( !m_quitting )
 	{
+		const DWORD frameStartMS = timeGetTime();
+		PerfTrace::BeginEngineFrame();
+		Bool logicUpdated = FALSE;
 
 		//if (TheGlobalData->m_vTune)
 		{
@@ -819,6 +823,7 @@ void GameEngine::execute()
 				{
 					// compute a frame
 					update();
+					logicUpdated = TheGameLogic != nullptr && TheGameLogic->hasUpdated();
 				}
 				catch (INIException e)
 				{
@@ -843,6 +848,8 @@ void GameEngine::execute()
 				}
 			}
 
+			const double frameMS = static_cast<double>(timeGetTime() - frameStartMS);
+			PerfTrace::EndEngineFrame(logicUpdated, frameMS);
 			TheFramePacer->update();
 		}
 
@@ -856,6 +863,8 @@ void GameEngine::execute()
 #endif
 
 	}
+
+	PerfTrace::Shutdown();
 }
 
 /** -----------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -73,6 +73,11 @@
 
 #define SLEEPY_AI
 
+namespace
+{
+	const Int PATHFIND_QUEUE_RETRY_FRAMES = 2;
+}
+
 
 //-------------------------------------------------------------------------------------------------
 AIUpdateModuleData::AIUpdateModuleData()
@@ -507,7 +512,9 @@ void AIUpdateInterface::requestPath( Coord3D *destination, Bool isFinalGoal )
 		}
 		return;
 	}
-	TheAI->pathfinder()->queueForPath(getObject()->getID());
+	if (!TheAI->pathfinder()->queueForPath(getObject()->getID())) {
+		setQueueForPathTime(PATHFIND_QUEUE_RETRY_FRAMES);
+	}
 
 }
 
@@ -530,7 +537,9 @@ void AIUpdateInterface::requestAttackPath( ObjectID victimID, const Coord3D* vic
 		setQueueForPathTime(2*LOGICFRAMES_PER_SECOND);
 		return;
 	}
-	TheAI->pathfinder()->queueForPath(getObject()->getID());
+	if (!TheAI->pathfinder()->queueForPath(getObject()->getID())) {
+		setQueueForPathTime(PATHFIND_QUEUE_RETRY_FRAMES);
+	}
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -553,7 +562,9 @@ void AIUpdateInterface::requestApproachPath( Coord3D *destination )
 		setQueueForPathTime(2*LOGICFRAMES_PER_SECOND);
 		return;
 	}
-	TheAI->pathfinder()->queueForPath(getObject()->getID());
+	if (!TheAI->pathfinder()->queueForPath(getObject()->getID())) {
+		setQueueForPathTime(PATHFIND_QUEUE_RETRY_FRAMES);
+	}
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -577,7 +588,9 @@ void AIUpdateInterface::requestSafePath( ObjectID repulsor )
 		setQueueForPathTime(2*LOGICFRAMES_PER_SECOND);
 		return;
 	}
-	TheAI->pathfinder()->queueForPath(getObject()->getID());
+	if (!TheAI->pathfinder()->queueForPath(getObject()->getID())) {
+		setQueueForPathTime(PATHFIND_QUEUE_RETRY_FRAMES);
+	}
 }
 
 enum {WAYPOINT_PATH_LIMIT=1024};
@@ -1060,8 +1073,11 @@ UpdateSleepTime AIUpdateInterface::update()
 	{
 		if (now >= m_queueForPathFrame)
 		{
-			TheAI->pathfinder()->queueForPath(getObject()->getID());
-			setQueueForPathTime(0);
+			if (TheAI->pathfinder()->queueForPath(getObject()->getID())) {
+				setQueueForPathTime(0);
+			} else {
+				setQueueForPathTime(PATHFIND_QUEUE_RETRY_FRAMES);
+			}
 		}
 		else
 		{

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DScene.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DScene.h
@@ -106,6 +106,9 @@ protected:
 	void flagOccludedObjects(CameraClass * camera);
 	void flushOccludedObjectsIntoStencil(RenderInfoClass & rinfo);
 	void updatePlayerColorPasses();
+	void ensureVisibleRenderObjectCapacity(Int desiredCapacity);
+	void clearVisibleRenderObjectSnapshot();
+	void appendVisibleRenderObject(RenderObjClass *robj);
 
 protected:
 	RefRenderObjListClass	m_dynamicLightList;
@@ -116,6 +119,7 @@ protected:
 	LightClass						*m_infantryLight[LightEnvironmentClass::MAX_LIGHTS];	///< The global direction light modified to make infantry easier to see.
 	Int m_numGlobalLights;			///<number of global lights
 	LightEnvironmentClass	m_defaultLightEnv;		///<default light environment applied to objects without custom/dynamic lighting.
+	LightEnvironmentClass	m_defaultInfantryLightEnv;	///<default light environment for infantry when only global lights apply.
 	LightEnvironmentClass	m_foggedLightEnv;		///<default light environment applied to objects without custom/dynamic lighting.
 
 	W3DShroudMaterialPassClass	*m_shroudMaterialPass;	///< Custom render pass which applies shrouds to objects
@@ -134,6 +138,9 @@ protected:
 	Int m_numPotentialOccluders;
 	Int m_numPotentialOccludees;
 	Int m_numNonOccluderOrOccludee;
+	RenderObjClass **m_visibleRenderObjects;	///< main-pass render snapshot for the current scene pass.
+	Int m_visibleRenderObjectCount;
+	Int m_visibleRenderObjectCapacity;
 
 	CameraClass *m_camera;
 };

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -45,6 +45,7 @@ static void drawFramerateBar();
 #include "Common/ThingFactory.h"
 #include "Common/GlobalData.h"
 #include "Common/PerfTimer.h"
+#include "Common/PerfTrace.h"
 #include "Common/FileSystem.h"
 #include "Common/LocalFileSystem.h"
 #include "Common/Player.h"
@@ -1828,28 +1829,33 @@ AGAIN:
 	}
 
 	do {
+		Int numRenderTargetPolygons = 0;
+		Int numRenderTargetVertices = 0;
+		{
+			PerfTrace::ScopedRenderTimer renderSubmitTimer(PerfTrace::RENDER_TIMER_SUBMIT);
 
-		// update all views of the world - recomputes data which will affect drawing
-		if (DX8Wrapper::_Get_D3D_Device8() && (DX8Wrapper::_Get_D3D_Device8()->TestCooperativeLevel()) == D3D_OK)
-		{	//Checking if we have the device before updating views because the heightmap crashes otherwise while
-			//trying to refresh the visible terrain geometry.
-//			if(TheGlobalData->m_loadScreenRender != TRUE)
-				updateViews();
+			// update all views of the world - recomputes data which will affect drawing
+			if (DX8Wrapper::_Get_D3D_Device8() && (DX8Wrapper::_Get_D3D_Device8()->TestCooperativeLevel()) == D3D_OK)
+			{	//Checking if we have the device before updating views because the heightmap crashes otherwise while
+				//trying to refresh the visible terrain geometry.
+//				if(TheGlobalData->m_loadScreenRender != TRUE)
+					updateViews();
 
-			if (TheWaterRenderObj && TheGlobalData->m_waterType == 2)
-				TheWaterRenderObj->updateRenderTargetTextures(primaryW3DView->get3DCamera());	//do a render into each texture
+				if (TheWaterRenderObj && TheGlobalData->m_waterType == 2)
+					TheWaterRenderObj->updateRenderTargetTextures(primaryW3DView->get3DCamera());	//do a render into each texture
 
-			//Can't render into textures while rendering to screen so these textures need to be updated
-			//before we enter main rendering loop.
-			if (TheW3DProjectedShadowManager)
-				TheW3DProjectedShadowManager->updateRenderTargetTextures();
+				//Can't render into textures while rendering to screen so these textures need to be updated
+				//before we enter main rendering loop.
+				if (TheW3DProjectedShadowManager)
+					TheW3DProjectedShadowManager->updateRenderTargetTextures();
+			}
+
+			Debug_Statistics::End_Statistics();	//record number of polygons rendered in RenderTargetTextures.
+
+			//Store number of polygons rendered in renderTargetTextures.
+			numRenderTargetPolygons = Debug_Statistics::Get_DX8_Polygons();
+			numRenderTargetVertices = Debug_Statistics::Get_DX8_Vertices();
 		}
-
-		Debug_Statistics::End_Statistics();	//record number of polygons rendered in RenderTargetTextures.
-
-		//Store number of polygons rendered in renderTargetTextures.
-		Int numRenderTargetPolygons=Debug_Statistics::Get_DX8_Polygons();
-		Int numRenderTargetVertices=Debug_Statistics::Get_DX8_Vertices();
 
 		// start render block
 		#if defined(_ALLOW_DEBUG_CHEATS_IN_RELEASE)
@@ -1862,6 +1868,7 @@ AGAIN:
 			static Bool couldRender = true;
 			if ((TheGlobalData->m_breakTheMovie == FALSE) && (TheGlobalData->m_disableRender == false) && WW3D::Begin_Render( true, true, Vector3( 0.0f, 0.0f, 0.0f ), TheWaterTransparency->m_minWaterOpacity ) == WW3D_ERROR_OK)
 			{
+				PerfTrace::ScopedRenderTimer drawTimer(PerfTrace::RENDER_TIMER_DRAW);
 
 				if(TheGlobalData->m_loadScreenRender == TRUE)
 				{

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DScene.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DScene.cpp
@@ -54,6 +54,7 @@
 #include "W3DDevice/GameClient/W3DStatusCircle.h"
 #include "W3DDevice/GameClient/W3DCustomScene.h"
 #include "W3DDevice/GameClient/W3DShroud.h"
+#include "W3DDevice/GameClient/W3DWater.h"
 #include "WW3D2/camera.h"
 #include "WW3D2/dx8renderer.h"
 #include "WW3D2/sortingrenderer.h"
@@ -82,6 +83,15 @@ extern void DoParticles(RenderInfoClass & rinfo);
 	ShaderClass::DETAILCOLOR_DISABLE, ShaderClass::DETAILALPHA_DISABLE) )
 static ShaderClass PlayerColorShader(SC_PLAYER_COLOR);
 
+static Bool shouldRenderInMainPass(const DrawableInfo *drawInfo, const Drawable *draw)
+{
+#ifdef USE_NON_STENCIL_OCCLUSION
+	return !(draw && drawInfo && (drawInfo->m_flags & DrawableInfo::ERF_DELAYED_RENDER));
+#else
+	return !(draw && drawInfo && (drawInfo->m_flags & (DrawableInfo::ERF_DELAYED_RENDER | DrawableInfo::ERF_POTENTIAL_OCCLUDER | DrawableInfo::ERF_IS_NON_OCCLUDER_OR_OCCLUDEE)));
+#endif
+}
+
 //=============================================================================
 // RTS3DScene::RTS3DScene
 //=============================================================================
@@ -92,6 +102,9 @@ RTS3DScene::RTS3DScene()
 	setName("RTS3DScene");
 	m_drawTerrainOnly = false;
 	m_numGlobalLights=0;
+	m_visibleRenderObjects = nullptr;
+	m_visibleRenderObjectCount = 0;
+	m_visibleRenderObjectCapacity = 0;
 	Int i=0;
 	for (; i<LightEnvironmentClass::MAX_LIGHTS; i++)
 	{
@@ -211,6 +224,8 @@ RTS3DScene::~RTS3DScene()
 	delete [] m_nonOccludersOrOccludees;
 	delete [] m_potentialOccludees;
 	delete [] m_potentialOccluders;
+	clearVisibleRenderObjectSnapshot();
+	delete [] m_visibleRenderObjects;
 
 	for (i=0; i<MAX_PLAYER_COUNT; i++)
 	{
@@ -224,6 +239,54 @@ void	RTS3DScene::setGlobalLight(LightClass *pLight, Int lightIndex)
 	if (m_numGlobalLights < (lightIndex+1))
 		m_numGlobalLights=(lightIndex+1);
 	REF_PTR_SET(m_globalLight[lightIndex], pLight);
+}
+
+void RTS3DScene::ensureVisibleRenderObjectCapacity(Int desiredCapacity)
+{
+	if (desiredCapacity <= m_visibleRenderObjectCapacity)
+	{
+		return;
+	}
+
+	Int newCapacity = m_visibleRenderObjectCapacity > 0 ? m_visibleRenderObjectCapacity : 256;
+	while (newCapacity < desiredCapacity)
+	{
+		newCapacity *= 2;
+	}
+
+	RenderObjClass **newBuffer = NEW RenderObjClass *[newCapacity];
+	for (Int i = 0; i < m_visibleRenderObjectCount; i++)
+	{
+		newBuffer[i] = m_visibleRenderObjects[i];
+	}
+
+	delete [] m_visibleRenderObjects;
+	m_visibleRenderObjects = newBuffer;
+	m_visibleRenderObjectCapacity = newCapacity;
+}
+
+void RTS3DScene::clearVisibleRenderObjectSnapshot()
+{
+	for (Int i = 0; i < m_visibleRenderObjectCount; i++)
+	{
+		if (m_visibleRenderObjects[i])
+		{
+			m_visibleRenderObjects[i]->Release_Ref();
+		}
+	}
+	m_visibleRenderObjectCount = 0;
+}
+
+void RTS3DScene::appendVisibleRenderObject(RenderObjClass *robj)
+{
+	if (!robj)
+	{
+		return;
+	}
+
+	ensureVisibleRenderObjectCapacity(m_visibleRenderObjectCount + 1);
+	robj->Add_Ref();
+	m_visibleRenderObjects[m_visibleRenderObjectCount++] = robj;
 }
 
 /**Find all objects which need to be drawn in a special way because they are occluded by other
@@ -392,6 +455,8 @@ void RTS3DScene::Visibility_Check(CameraClass * camera)
 	m_numPotentialOccludees=0;
 	m_translucentObjectsCount=0;
 	m_numNonOccluderOrOccludee=0;
+	clearVisibleRenderObjectSnapshot();
+	ensureVisibleRenderObjectCapacity(RenderList.Count());
 
 	Int currentFrame = TheGameLogic ? TheGameLogic->getFrame() : 0;
 	if (currentFrame <= TheGlobalData->m_defaultOcclusionDelay)
@@ -429,6 +494,12 @@ void RTS3DScene::Visibility_Check(CameraClass * camera)
 				} else {
 					robj->Set_Visible(!camera->Cull_Sphere(robj->Get_Bounding_Sphere()));
 				}
+			}
+
+			if (robj->Is_Really_Visible() && robj->Class_ID() != RenderObjClass::CLASSID_TILEMAP &&
+				robj != TheWaterRenderObj)
+			{
+				appendVisibleRenderObject(robj);
 			}
 		}
 	}
@@ -495,6 +566,12 @@ void RTS3DScene::Visibility_Check(CameraClass * camera)
 				}
 
 				robj->Set_Visible(isVisible);
+				if (isVisible && robj->Class_ID() != RenderObjClass::CLASSID_TILEMAP &&
+					robj != TheWaterRenderObj &&
+					shouldRenderInMainPass(drawInfo, draw))
+				{
+					appendVisibleRenderObject(robj);
+				}
 			}
 
 			///@todo: We're not using LOD yet so I disabled this code. MW
@@ -563,7 +640,11 @@ void RTS3DScene::renderOneObject(RenderInfoClass &rinfo, RenderObjClass *robj, I
 	ObjectShroudStatus ss=OBJECTSHROUD_INVALID;
 	Bool doExtraMaterialPop=FALSE;
 	Bool doExtraFlagsPop=FALSE;
+	Bool useCachedLightEnv = FALSE;
 	LightClass **sceneLights=m_globalLight;
+	LightEnvironmentClass *activeLightEnv = nullptr;
+	const Bool hasSceneLights = LightList.Count() > 0;
+	const Bool hasAnyDynamicLights = m_dynamicLightList.Count() > 0;
 
 	if (robj->Class_ID() == RenderObjClass::CLASSID_IMAGE3D	)
 	{
@@ -583,10 +664,6 @@ void RTS3DScene::renderOneObject(RenderInfoClass &rinfo, RenderObjClass *robj, I
 			ss = OBJECTSHROUD_FOGGED;
 	}
 
-	// all this ambient business no longer handles the tinting and flashing stuff,
-	// but it does still light the drawable explicitly, and can be fudged like this
-	// infantry test does, here...
-	// the tint has been delegated to the getTint() stuff, below... MLorenzen
 	Vector3 ambient = Get_Ambient_Light();
 	if (draw && (drawableHidden=draw->isDrawableEffectivelyHidden()) != TRUE)
 	{
@@ -598,9 +675,6 @@ void RTS3DScene::renderOneObject(RenderInfoClass &rinfo, RenderObjClass *robj, I
 		obj = draw->getObject();
 		if (obj) {
 			ss = obj->getShroudedStatus(localPlayerIndex);
-			// For objects like planes, that pop out of the shroud, fire, then head back,
-			// we keep drawing them for 2 seconds after they return to the fogged area,
-			// so the player can see them and missiles chasing them.  jba.
 			if (ss == OBJECTSHROUD_CLEAR) {
 				draw->setShroudClearFrame(TheGameLogic->getFrame());
 			}	else if (ss >= OBJECTSHROUD_FOGGED && draw->getShroudClearFrame() != InvalidShroudClearFrame) {
@@ -609,24 +683,20 @@ void RTS3DScene::renderOneObject(RenderInfoClass &rinfo, RenderObjClass *robj, I
 					limit += 3*LOGICFRAMES_PER_SECOND;
 				}
 				if (TheGameLogic->getFrame() < limit + draw->getShroudClearFrame()) {
-					// It's been less than 2 seconds since we could see them clear, so keep showing them.
 					ss = OBJECTSHROUD_PARTIAL_CLEAR;
 				}
 			}
  			if (!robj->Peek_Scene())
- 				return;	//this object was removed by the getShroudedStatus() call.
+ 				return;
 		}
 		else
 		{
-			//drawable with no object so no way to know if it's shrouded.
-			ss = OBJECTSHROUD_CLEAR;	//assume not shrouded/fogged.
-			//Check to see if there is another unrelated object which controls the shroud status
-			//(Hack for prison camps which contain enemy prisoner drawables)
+			ss = OBJECTSHROUD_CLEAR;
 			if (drawInfo->m_shroudStatusObjectID != INVALID_ID)
 			{
 				Object *shroudObject=TheGameLogic->findObjectByID(drawInfo->m_shroudStatusObjectID);
 				if (shroudObject && shroudObject->getShroudedStatus(localPlayerIndex) >= OBJECTSHROUD_FOGGED)
-					ss = OBJECTSHROUD_SHROUDED;	//we will assume that drawables without objects are 'particle' like and therefore don't need drawing if fogged/shrouded.
+					ss = OBJECTSHROUD_SHROUDED;
 			}
 		}
 
@@ -636,69 +706,68 @@ void RTS3DScene::renderOneObject(RenderInfoClass &rinfo, RenderObjClass *robj, I
 			sceneLights = m_infantryLight;
 		}
 
-		lightEnv.Reset(sph.Center, ambient);
+		const Vector3 *tintColor = draw->getTintColor();
+		const Vector3 *selectionColor = draw->getSelectionColor();
 
-
-		// HANDLE THE SPECIAL DRAWABLE-LEVEL COLORING SETTINGS FIRST
-
-		const Vector3 *tintColor = nullptr;
-		const Vector3 *selectionColor = nullptr;
-
-		tintColor			 = draw->getTintColor();
-		selectionColor = draw->getSelectionColor();
-
-		if ( tintColor || selectionColor )
+		if (!tintColor && !selectionColor && ss <= OBJECTSHROUD_CLEAR &&
+			!hasSceneLights && !hasAnyDynamicLights)
 		{
-			Vector3 sumTint, temp, restore;
+			useCachedLightEnv = TRUE;
+			activeLightEnv = draw->isKindOf(KINDOF_INFANTRY) ? &m_defaultInfantryLightEnv : &m_defaultLightEnv;
+		}
+		else
+		{
+			lightEnv.Reset(sph.Center, ambient);
 
-			sumTint.Set(0,0,0);
-
-			if (tintColor)
-				Vector3::Add(sumTint, *tintColor, &sumTint);
-			if (selectionColor)
-				Vector3::Add(sumTint, *selectionColor, &sumTint);
-
-			for (Int globalLightIndex = 0; globalLightIndex < m_numGlobalLights; globalLightIndex++)
+			if ( tintColor || selectionColor )
 			{
-				sceneLights[globalLightIndex]->Get_Diffuse( &temp );
-				restore = temp;
+				Vector3 sumTint, temp, restore;
 
-				Vector3::Add(temp, sumTint, &temp);
+				sumTint.Set(0,0,0);
 
-				sceneLights[globalLightIndex]->Set_Diffuse( temp );
-				lightEnv.Add_Light(*sceneLights[globalLightIndex]);
-				sceneLights[globalLightIndex]->Set_Diffuse( restore );
+				if (tintColor)
+					Vector3::Add(sumTint, *tintColor, &sumTint);
+				if (selectionColor)
+					Vector3::Add(sumTint, *selectionColor, &sumTint);
 
+				for (Int globalLightIndex = 0; globalLightIndex < m_numGlobalLights; globalLightIndex++)
+				{
+					sceneLights[globalLightIndex]->Get_Diffuse( &temp );
+					restore = temp;
+
+					Vector3::Add(temp, sumTint, &temp);
+
+					sceneLights[globalLightIndex]->Set_Diffuse( temp );
+					lightEnv.Add_Light(*sceneLights[globalLightIndex]);
+					sceneLights[globalLightIndex]->Set_Diffuse( restore );
+				}
+
+				temp = lightEnv.Get_Equivalent_Ambient();
+				Vector3::Add(sumTint, temp, &temp );
+				lightEnv.Set_Output_Ambient( temp );
+			}
+			else
+			{
+				for (Int globalLightIndex = 0; globalLightIndex < m_numGlobalLights; globalLightIndex++)
+				{
+					lightEnv.Add_Light(*sceneLights[globalLightIndex]);
+				}
 			}
 
-			temp = lightEnv.Get_Equivalent_Ambient();
-			Vector3::Add(sumTint, temp, &temp );
-
-			lightEnv.Set_Output_Ambient( temp );
-
-		}
-		else // no funny coloring going on, so just add the lights normally
-		{
-			for (Int globalLightIndex = 0; globalLightIndex < m_numGlobalLights; globalLightIndex++)
-			{
-				lightEnv.Add_Light(*sceneLights[globalLightIndex]);
-			}
+			activeLightEnv = &lightEnv;
 		}
 
-		//Apply custom render pass for any drawables with heatvision enabled
 		if (draw->getHeatVisionOpacity() != 0 )
 		{
 			rinfo.materialPassEmissiveOverride = draw->getHeatVisionOpacity();
 			if (draw->getStealthLook() == STEALTHLOOK_VISIBLE_DETECTED )
 			{
-				// THIS WILL EXPLICITLY SKIP THE FIRST PASS SO THAT HEATVISION ONLY WILL RENDER
 				rinfo.Push_Override_Flags(RenderInfoClass::RINFO_OVERRIDE_ADDITIONAL_PASSES_ONLY);
 				rinfo.Push_Material_Pass(m_heatVisionOnlyPass);
 				doExtraFlagsPop=TRUE;
 			}
 			else
 			{
-				//THIS CALLS FOR THE HEATVISION TO RENDER
 				rinfo.Push_Material_Pass(m_heatVisionMaterialPass);
 			}
 			doExtraMaterialPop=TRUE;
@@ -706,59 +775,64 @@ void RTS3DScene::renderOneObject(RenderInfoClass &rinfo, RenderObjClass *robj, I
 	}
 	else
 	{
-		//either no drawable or it is hidden
 		if (drawableHidden)
-			return;	//don't bother with anything else
+			return;
 
-		//Render object without a drawable.  Must be either some fluff/debug object or a ghostObject.
 		if (ss == OBJECTSHROUD_FOGGED)
 		{
-			//Must be ghost object because we don't fog normal things.  Fogged objects always have a predefined
-			//lighting environment applied which emulates the look of fog.
 			rinfo.light_environment = &m_foggedLightEnv;
 			robj->Render(rinfo);
 			rinfo.light_environment = nullptr;
 			return;
+		}
+		else if (!hasSceneLights)
+		{
+			useCachedLightEnv = TRUE;
+			activeLightEnv = &m_defaultLightEnv;
 		}
 		else
 		{
 			lightEnv.Reset(sph.Center, ambient);
 			for (Int globalLightIndex = 0; globalLightIndex < m_numGlobalLights; globalLightIndex++)
 				lightEnv.Add_Light(*m_globalLight[globalLightIndex]);
+			activeLightEnv = &lightEnv;
 		}
 	}
 
 	if (!drawableHidden)
 	{
-		//standard scene lights
-		RefRenderObjListIterator it2(&LightList);
-		for (it2.First(); !it2.Is_Done(); it2.Next())
+		if (!useCachedLightEnv)
 		{
-			LightClass *pLight = (LightClass*)it2.Peek_Obj();
-			SphereClass lSph = pLight->Get_Bounding_Sphere();
-			Bool cull = (pLight->Get_Type() == LightClass::POINT && !Spheres_Intersect(sph, lSph));
-			if (!cull) {
-				lightEnv.Add_Light(*pLight);
+			RefRenderObjListIterator it2(&LightList);
+			for (it2.First(); !it2.Is_Done(); it2.Next())
+			{
+				LightClass *pLight = (LightClass*)it2.Peek_Obj();
+				SphereClass lSph = pLight->Get_Bounding_Sphere();
+				Bool cull = (pLight->Get_Type() == LightClass::POINT && !Spheres_Intersect(sph, lSph));
+				if (!cull) {
+					lightEnv.Add_Light(*pLight);
+				}
 			}
+
+			RefRenderObjListIterator dynaLightIt(&m_dynamicLightList);
+			for (dynaLightIt.First(); !dynaLightIt.Is_Done(); dynaLightIt.Next())
+			{
+				W3DDynamicLight* pDyna = (W3DDynamicLight*)dynaLightIt.Peek_Obj();
+				if (!pDyna->isEnabled()) {
+					continue;
+				}
+				SphereClass lSph = pDyna->Get_Bounding_Sphere();
+				if (pDyna->Get_Type() == LightClass::POINT && !Spheres_Intersect(sph, lSph)) {
+					continue;
+				}
+				lightEnv.Add_Light(*(LightClass*)dynaLightIt.Peek_Obj());
+			}
+
+			lightEnv.Pre_Render_Update(rinfo.Camera.Get_Transform());
+			activeLightEnv = &lightEnv;
 		}
 
-		// dynamic lights
-		RefRenderObjListIterator dynaLightIt(&m_dynamicLightList);
-		for (dynaLightIt.First(); !dynaLightIt.Is_Done(); dynaLightIt.Next())
-		{
-			W3DDynamicLight* pDyna = (W3DDynamicLight*)dynaLightIt.Peek_Obj();
-			if (!pDyna->isEnabled()) {
-				continue;
-			}
-			SphereClass lSph = pDyna->Get_Bounding_Sphere();
-			if (pDyna->Get_Type() == LightClass::POINT && !Spheres_Intersect(sph, lSph)) {
-				continue;
-			}
-			lightEnv.Add_Light(*(LightClass*)dynaLightIt.Peek_Obj());
-		}
-
-		lightEnv.Pre_Render_Update(rinfo.Camera.Get_Transform());
-		rinfo.light_environment = &lightEnv;
+		rinfo.light_environment = activeLightEnv;
 
 		if (drawInfo)
 		{
@@ -796,10 +870,10 @@ void RTS3DScene::renderOneObject(RenderInfoClass &rinfo, RenderObjClass *robj, I
 	}
 
 	rinfo.light_environment = nullptr;
-	if (doExtraMaterialPop)	//check if there is an extra material on the stack from the heatvision effect.
+	if (doExtraMaterialPop)
 		rinfo.Pop_Material_Pass();
 	if (doExtraFlagsPop)
-		rinfo.Pop_Override_Flags();	//flags used to disable base pass and only render custom heat vision pass.
+		rinfo.Pop_Override_Flags();
 }
 
 //DECLARE_PERF_TIMER(translucentRender)
@@ -863,6 +937,7 @@ void RTS3DScene::updateFixedLightEnvironments(RenderInfoClass & rinfo)
 
 	//Generate the default light environment
 	m_defaultLightEnv.Reset(Vector3(0,0,0), Get_Ambient_Light());
+	m_defaultInfantryLightEnv.Reset(Vector3(0,0,0), Get_Ambient_Light());
 	m_foggedLightEnv.Reset(Vector3(0,0,0), Get_Ambient_Light()*foggedLightFrac);
 
 	for (Int globalLightIndex = 0; globalLightIndex < m_numGlobalLights; globalLightIndex++)
@@ -875,6 +950,7 @@ void RTS3DScene::updateFixedLightEnvironments(RenderInfoClass & rinfo)
 		m_globalLight[globalLightIndex]->Get_Ambient(&oldDiffuse);
 		m_infantryLight[globalLightIndex]->Set_Ambient(oldDiffuse*infantryLightScale);
 		m_infantryLight[globalLightIndex]->Set_Transform(m_globalLight[globalLightIndex]->Get_Transform());
+		m_defaultInfantryLightEnv.Add_Light(*m_infantryLight[globalLightIndex]);
 
 		//copy the normal light for fog so we can modify it
 		m_scratchLight->Set_Transform(m_globalLight[globalLightIndex]->Get_Transform());
@@ -887,6 +963,7 @@ void RTS3DScene::updateFixedLightEnvironments(RenderInfoClass & rinfo)
 	}
 
 	m_defaultLightEnv.Pre_Render_Update(rinfo.Camera.Get_Transform());
+	m_defaultInfantryLightEnv.Pre_Render_Update(rinfo.Camera.Get_Transform());
 	m_foggedLightEnv.Pre_Render_Update(rinfo.Camera.Get_Transform());
 
 	m_infantryAmbient = Get_Ambient_Light();// * infantryLightScale;	//for now don't adjust ambient so that we don't lose directional lighting.
@@ -1066,16 +1143,6 @@ void RTS3DScene::Customized_Render( RenderInfoClass &rinfo )
 
 #define USE_LIGHT_ENV 1
 
-   if (!Visibility_Checked) {
-      // set the visibility bit in all render objects in all layers.
-	   Visibility_Check(&rinfo.Camera);
-#ifdef USE_NON_STENCIL_OCCLUSION
-	   flagOccludedObjects(&rinfo.Camera);
-#endif
-   }
-   Visibility_Checked = false;
-
-
 	RefRenderObjListIterator it(&UpdateList);
 	// allow all objects in the update list to do their "every frame" processing
 	for (it.First(); !it.Is_Done(); it.Next()) {
@@ -1089,6 +1156,15 @@ void RTS3DScene::Customized_Render( RenderInfoClass &rinfo )
 			it.Peek_Obj()->On_Frame_Update();
 		}
 	}
+
+	if (!Visibility_Checked) {
+		// Build the visible render snapshot after per-frame object updates.
+		Visibility_Check(&rinfo.Camera);
+#ifdef USE_NON_STENCIL_OCCLUSION
+		flagOccludedObjects(&rinfo.Camera);
+#endif
+	}
+	Visibility_Checked = false;
 
 	//terrain needs to be rendered first
 	if (terrainObject)	// Don't check visibility - terrain is always visible. jba.
@@ -1121,28 +1197,23 @@ void RTS3DScene::Customized_Render( RenderInfoClass &rinfo )
 	}
 #endif
 
-	// loop through all render objects in the list:
-	for (it.First(&RenderList); !it.Is_Done();)
+	for (Int visibleIndex = 0; visibleIndex < m_visibleRenderObjectCount; visibleIndex++)
 	{
-		// get the render object
-		robj = it.Peek_Obj();
- 		it.Next();	//advance to next object in case this one gets deleted during renderOneObject().
-
-		if (robj->Class_ID() == RenderObjClass::CLASSID_TILEMAP)
-			continue;	//we already rendered terrain
-
-		if (robj->Is_Really_Visible()) {
-			DrawableInfo *drawInfo = (DrawableInfo *)robj->Get_User_Data();
-			Drawable *draw=nullptr;
-			if (drawInfo)
-				draw = drawInfo->m_drawable;
-#ifdef USE_NON_STENCIL_OCCLUSION
-			if (!(draw && drawInfo->m_flags & DrawableInfo::ERF_DELAYED_RENDER))	//model rendering is delayed for some reason until end of normal scene
-#else
-				if (!(draw && drawInfo->m_flags & (DrawableInfo::ERF_DELAYED_RENDER|DrawableInfo::ERF_POTENTIAL_OCCLUDER|DrawableInfo::ERF_IS_NON_OCCLUDER_OR_OCCLUDEE)))	//in this mode we delay almost all objects in order to do correct sorting with stencil.
-#endif
-				renderOneObject(rinfo, robj, localPlayerIndex);
+		robj = m_visibleRenderObjects[visibleIndex];
+		if (!robj || !robj->Peek_Scene() || !robj->Is_Really_Visible())
+		{
+			continue;
 		}
+
+		renderOneObject(rinfo, robj, localPlayerIndex);
+	}
+
+	// Water queues itself into static sort lists and is safer on the legacy explicit path.
+	if (TheWaterRenderObj && TheWaterRenderObj->Peek_Scene() == this && !TheWaterRenderObj->Is_Hidden())
+	{
+		rinfo.light_environment = nullptr;
+		TheWaterRenderObj->Render(rinfo);
+		rinfo.light_environment = nullptr;
 	}
 
 	//Tell shadow manager to render shadows at the end of this frame

--- a/Generals/Code/Main/RTS.RC
+++ b/Generals/Code/Main/RTS.RC
@@ -7,7 +7,7 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include <winres.h>
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS
@@ -34,7 +34,7 @@ END
 
 2 TEXTINCLUDE DISCARDABLE 
 BEGIN
-    "#include ""afxres.h""\r\n"
+    "#include <winres.h>\r\n"
     "\0"
 END
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/AIUpdate.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/AIUpdate.h
@@ -467,11 +467,16 @@ public:
 
 	Bool isWaitingForPath() const {return m_waitingForPath;}
 	Bool isAttackPath() const {return m_isAttackPath;} ///< True if we have a path to an attack location.
+	Bool isApproachPath() const {return m_isApproachPath;}
+	Bool isSafePath() const {return m_isSafePath;}
 	void cancelPath(); ///< Called if we no longer need the path.
 	Path* getPath() { return m_path; }				///< return the agent's current path
 	const Path* getPath() const { return m_path; }				///< return the agent's current path
 	void destroyPath();												///< destroy the current path, setting it to null
 	UnsignedInt getPathAge() const { return TheGameLogic->getFrame() - m_pathTimestamp; }	///< return the "age" of the path
+	const Coord3D *getRequestedDestination() const { return &m_requestedDestination; }
+	const Coord3D *getRequestedDestination2() const { return &m_requestedDestination2; }
+	ObjectID getRequestedVictimID() const { return m_requestedVictimID; }
 	Bool isPathAvailable( const Coord3D *destination ) const; ///< does a path exist between us and the destination
 	Bool isQuickPathAvailable( const Coord3D *destination ) const;  ///< does a path (using quick pathfind) exist between us and the destination
 	Int getNumFramesBlocked() const {return m_blockedFrames;}

--- a/GeneralsMD/Code/GameEngine/Source/Common/CommandLine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/CommandLine.cpp
@@ -29,6 +29,7 @@
 #include "Common/CommandLine.h"
 #include "Common/CRCDebug.h"
 #include "Common/LocalFileSystem.h"
+#include "Common/PerfTrace.h"
 #include "Common/Recorder.h"
 #include "Common/version.h"
 #include "GameClient/ClientInstance.h"
@@ -167,6 +168,32 @@ Int parseFullViewport(char *args[], int num)
 {
 	TheWritableGlobalData->m_viewportHeightScale = 1.0f;
 
+	return 1;
+}
+
+Int parsePerfTrace(char *args[], int)
+{
+	PerfTrace::SetEnabled(TRUE);
+	return 1;
+}
+
+Int parsePerfTraceFrames(char *args[], int argc)
+{
+	if (argc > 1)
+	{
+		PerfTrace::SetSampleFrames(atoi(args[1]));
+		return 2;
+	}
+	return 1;
+}
+
+Int parsePerfTraceSpikeMS(char *args[], int argc)
+{
+	if (argc > 1)
+	{
+		PerfTrace::SetSpikeMS(static_cast<Real>(atof(args[1])));
+		return 2;
+	}
 	return 1;
 }
 
@@ -1173,6 +1200,9 @@ static CommandLineParam paramsForEngineInit[] =
 	{ "-noshaders", parseNoShaders },
 	{ "-quickstart", parseQuickStart },
 	{ "-useWaveEditor", parseUseWaveEditor },
+	{ "-perfTrace", parsePerfTrace },
+	{ "-perfTraceFrames", parsePerfTraceFrames },
+	{ "-perfTraceSpikeMS", parsePerfTraceSpikeMS },
 
 	// TheSuperHackers @feature xezon 03/08/2025 Force full viewport for 'Control Bar Pro' Addons like GenTool did it.
 	{ "-forcefullviewport", parseFullViewport },

--- a/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -49,6 +49,7 @@
 #include "Common/LocalFileSystem.h"
 #include "Common/GlobalData.h"
 #include "Common/PerfTimer.h"
+#include "Common/PerfTrace.h"
 #include "Common/RandomValue.h"
 #include "Common/NameKeyGenerator.h"
 #include "Common/ModuleFactory.h"
@@ -946,6 +947,9 @@ void GameEngine::execute()
 	// pretty basic for now
 	while( !m_quitting )
 	{
+		const DWORD frameStartMS = timeGetTime();
+		PerfTrace::BeginEngineFrame();
+		Bool logicUpdated = FALSE;
 
 		//if (TheGlobalData->m_vTune)
 		{
@@ -983,6 +987,7 @@ void GameEngine::execute()
 				{
 					// compute a frame
 					update();
+					logicUpdated = TheGameLogic != nullptr && TheGameLogic->hasUpdated();
 				}
 				catch (INIException e)
 				{
@@ -1007,6 +1012,8 @@ void GameEngine::execute()
 				}
 			}
 
+			const double frameMS = static_cast<double>(timeGetTime() - frameStartMS);
+			PerfTrace::EndEngineFrame(logicUpdated, frameMS);
 			TheFramePacer->update();
 		}
 
@@ -1020,6 +1027,8 @@ void GameEngine::execute()
 #endif
 
 	}
+
+	PerfTrace::Shutdown();
 }
 
 /** -----------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIGroup.cpp
@@ -27,6 +27,7 @@
 // Author: Michael S. Booth, January 2002
 #include "PreRTS.h"	// This must go first in EVERY cpp file in the GameEngine
 
+#include <algorithm>
 
 #include "Common/ActionManager.h"
 #include "Common/BuildAssistant.h"
@@ -55,6 +56,287 @@
 #include "GameLogic/Module/StealthUpdate.h"
 #include "GameLogic/Module/SpecialPowerUpdateModule.h"
 #include "GameLogic/ObjectIter.h"
+
+namespace
+{
+const Int PHASE3_MIN_SPREAD_UNITS = 6;
+const Real PHASE3_MIN_SPREAD_OFFSET = PATHFIND_CELL_SIZE_F * 0.75f;
+const Int MASS_COMMAND_STAGGER_THRESHOLD = 128;
+const Int MASS_COMMAND_COHORT_SIZE = 96;
+const Int MASS_COMMAND_MAX_DELAY_FRAMES = 48;
+
+struct Phase3SpreadCandidate
+{
+	Object *object;
+	AIUpdateInterface *ai;
+	Real radius;
+	Real lateral;
+	Real forward;
+	ObjectID id;
+};
+
+static Bool comparePhase3SpreadCandidate(const Phase3SpreadCandidate &lhs, const Phase3SpreadCandidate &rhs)
+{
+	if (lhs.radius > rhs.radius + 0.1f)
+	{
+		return true;
+	}
+	if (lhs.radius + 0.1f < rhs.radius)
+	{
+		return false;
+	}
+	if (lhs.forward > rhs.forward + PATHFIND_CELL_SIZE_F)
+	{
+		return true;
+	}
+	if (lhs.forward + PATHFIND_CELL_SIZE_F < rhs.forward)
+	{
+		return false;
+	}
+	if (lhs.lateral < rhs.lateral - PATHFIND_CELL_SIZE_F)
+	{
+		return true;
+	}
+	if (lhs.lateral > rhs.lateral + PATHFIND_CELL_SIZE_F)
+	{
+		return false;
+	}
+	return lhs.id < rhs.id;
+}
+
+static void computePhase3MoveAxes(const Coord3D &center, const Coord3D &goal, Coord2D &forward, Coord2D &right)
+{
+	forward.x = goal.x - center.x;
+	forward.y = goal.y - center.y;
+	if (forward.lengthSqr() < sqr(PATHFIND_CELL_SIZE_F))
+	{
+		forward.x = 0.0f;
+		forward.y = 1.0f;
+	}
+	else
+	{
+		forward.normalize();
+	}
+
+	right.x = -forward.y;
+	right.y = forward.x;
+}
+
+static void clearGeneratedFormationOffsets(const std::list<Object *> &memberList)
+{
+	for (std::list<Object *>::const_iterator it = memberList.begin(); it != memberList.end(); ++it)
+	{
+		Object *obj = *it;
+		if (obj == nullptr || obj->getFormationID() != NO_FORMATION_ID)
+		{
+			continue;
+		}
+
+		Coord2D offset;
+		offset.x = 0.0f;
+		offset.y = 0.0f;
+		obj->setFormationOffset(offset);
+	}
+}
+
+static Int assignPhase3SpreadOffsets(const std::list<Object *> &memberList, const Coord3D &center, const Coord3D &goal)
+{
+	std::vector<Phase3SpreadCandidate> candidates;
+	candidates.reserve(memberList.size());
+
+	Coord2D forward;
+	Coord2D right;
+	computePhase3MoveAxes(center, goal, forward, right);
+
+	Real radiusSum = 0.0f;
+	Real maxRadius = PATHFIND_CELL_SIZE_F * 0.5f;
+
+	for (std::list<Object *>::const_iterator it = memberList.begin(); it != memberList.end(); ++it)
+	{
+		Object *obj = *it;
+		if (obj == nullptr || obj->isDisabledByType(DISABLED_HELD) || obj->isKindOf(KINDOF_IMMOBILE))
+		{
+			continue;
+		}
+
+		AIUpdateInterface *ai = obj->getAIUpdateInterface();
+		if (ai == nullptr)
+		{
+			continue;
+		}
+
+		Phase3SpreadCandidate candidate;
+		candidate.object = obj;
+		candidate.ai = ai;
+		candidate.radius = MAX(obj->getGeometryInfo().getBoundingCircleRadius(), PATHFIND_CELL_SIZE_F * 0.5f);
+		const Coord3D *pos = obj->getPosition();
+		const Real dx = pos->x - center.x;
+		const Real dy = pos->y - center.y;
+		candidate.lateral = dx * right.x + dy * right.y;
+		candidate.forward = dx * forward.x + dy * forward.y;
+		candidate.id = obj->getID();
+		candidates.push_back(candidate);
+		radiusSum += candidate.radius;
+		maxRadius = MAX(maxRadius, candidate.radius);
+	}
+
+	if (static_cast<Int>(candidates.size()) < PHASE3_MIN_SPREAD_UNITS)
+	{
+		clearGeneratedFormationOffsets(memberList);
+		return 0;
+	}
+
+	std::sort(candidates.begin(), candidates.end(), comparePhase3SpreadCandidate);
+
+	const Real averageRadius = radiusSum / candidates.size();
+	Real laneSpacing = MAX(PATHFIND_CELL_SIZE_F * 1.75f, averageRadius * 2.35f);
+	laneSpacing = MAX(laneSpacing, maxRadius * 1.7f);
+	Real rowSpacing = MAX(PATHFIND_CELL_SIZE_F * 1.75f, averageRadius * 2.15f);
+	rowSpacing = MAX(rowSpacing, maxRadius * 1.85f);
+
+	Int columns = 1;
+	while (columns * columns < static_cast<Int>(candidates.size()))
+	{
+		++columns;
+	}
+	columns = MAX(3, MIN(columns, 8));
+
+	for (Int index = 0; index < static_cast<Int>(candidates.size()); ++index)
+	{
+		const Int row = index / columns;
+		const Int column = index % columns;
+		Int laneIndex = 0;
+		if (column > 0)
+		{
+			const Int lane = (column + 1) / 2;
+			laneIndex = (column & 1) ? lane : -lane;
+		}
+
+		const Real sizeBias = MAX(0.0f, candidates[index].radius - averageRadius) * 0.35f;
+		const Real forwardOffset = -(row * rowSpacing + sizeBias);
+		const Real lateralOffset = laneIndex * laneSpacing;
+
+		Coord2D offset;
+		offset.x = forward.x * forwardOffset + right.x * lateralOffset;
+		offset.y = forward.y * forwardOffset + right.y * lateralOffset;
+		candidates[index].object->setFormationOffset(offset);
+	}
+
+	return static_cast<Int>(candidates.size());
+}
+
+static Bool shouldUsePhase3Spread(const std::list<Object *> &memberList, Bool addWaypoint, Bool isFormation)
+{
+	if (addWaypoint || isFormation)
+	{
+		return false;
+	}
+
+	Int movableCount = 0;
+	for (std::list<Object *>::const_iterator it = memberList.begin(); it != memberList.end(); ++it)
+	{
+		Object *obj = *it;
+		if (obj == nullptr || obj->isDisabledByType(DISABLED_HELD) || obj->isKindOf(KINDOF_IMMOBILE))
+		{
+			continue;
+		}
+
+		if (obj->getAIUpdateInterface() != nullptr)
+		{
+			++movableCount;
+			if (movableCount >= PHASE3_MIN_SPREAD_UNITS)
+			{
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+static Bool isMassCommandPathCandidate(Object *obj, AIUpdateInterface *ai)
+{
+	if (obj == nullptr || ai == nullptr)
+	{
+		return false;
+	}
+	if (obj->isDisabledByType(DISABLED_HELD) || obj->isKindOf(KINDOF_IMMOBILE))
+	{
+		return false;
+	}
+	return ai->isDoingGroundMovement();
+}
+
+static Int countMassCommandPathCandidates(const std::list<Object *> &memberList)
+{
+	Int count = 0;
+	for (std::list<Object *>::const_iterator it = memberList.begin(); it != memberList.end(); ++it)
+	{
+		Object *obj = *it;
+		AIUpdateInterface *ai = obj ? obj->getAIUpdateInterface() : nullptr;
+		if (isMassCommandPathCandidate(obj, ai))
+		{
+			++count;
+		}
+	}
+	return count;
+}
+
+static Int computeMassCommandPathDelayFrames(Int totalCandidates, Int scheduledIndex, AIUpdateInterface *ai)
+{
+	if (totalCandidates < MASS_COMMAND_STAGGER_THRESHOLD || ai == nullptr || !ai->isDoingGroundMovement())
+	{
+		return 0;
+	}
+	if (ai->isBlockedAndStuck() || ai->isWaitingForPath())
+	{
+		return 0;
+	}
+
+	Int delayFrames = scheduledIndex / MASS_COMMAND_COHORT_SIZE;
+	if (delayFrames > MASS_COMMAND_MAX_DELAY_FRAMES)
+	{
+		delayFrames = MASS_COMMAND_MAX_DELAY_FRAMES;
+	}
+	return delayFrames;
+}
+
+static void applyMassCommandPathDelay(AIUpdateInterface *ai, Int totalCandidates, Int &scheduledIndex)
+{
+	if (ai == nullptr || !ai->isDoingGroundMovement())
+	{
+		return;
+	}
+
+	ai->setQueueForPathTime(computeMassCommandPathDelayFrames(totalCandidates, scheduledIndex, ai));
+	++scheduledIndex;
+}
+
+static void computeFormationOffsetDestination(
+	Coord3D *dest,
+	const Coord3D *groupDest,
+	Object *obj,
+	AIUpdateInterface *ai,
+	Bool updateGoal)
+{
+	Coord2D offset;
+	obj->getFormationOffset(&offset);
+
+	PathfindLayerEnum layer = TheTerrainLogic->getLayerForDestination(groupDest);
+	dest->x = groupDest->x + offset.x;
+	dest->y = groupDest->y + offset.y;
+	dest->z = TheTerrainLogic->getLayerHeight(dest->x, dest->y, layer);
+
+	if (ai != nullptr && ai->isDoingGroundMovement())
+	{
+		TheAI->pathfinder()->adjustDestination(obj, ai->getLocomotorSet(), dest, groupDest);
+		if (updateGoal)
+		{
+			TheAI->pathfinder()->updateGoal(obj, dest, LAYER_GROUND);
+		}
+	}
+}
+}
 
 
 /**
@@ -1076,6 +1358,9 @@ void AIGroup::friend_moveFormationToPos( const Coord3D *pos, CommandSourceType c
 	Real dx, dy;
 	Coord3D center;
 	if (!getCenter( &center )) return;
+	const Int totalMassCommandCandidates =
+		(cmdSource == CMD_FROM_PLAYER) ? countMassCommandPathCandidates(m_memberList) : 0;
+	Int scheduledMassCommandCandidates = 0;
 
 
 	PathNode *startNode = nullptr;
@@ -1142,6 +1427,14 @@ void AIGroup::friend_moveFormationToPos( const Coord3D *pos, CommandSourceType c
 			theUnit->setFormationOffset(offset);
 		}
 		theUnit->getFormationOffset(&offset);
+		if (!ai->isDoingGroundMovement())
+		{
+			Coord3D dest;
+			computeFormationOffsetDestination(&dest, &endPoint, theUnit, ai, false);
+			ai->aiMoveToPosition(&dest, cmdSource);
+			continue;
+		}
+
 		if (startNode) {
 			std::vector<Coord3D> path;
 			PathNode *node = startNode;
@@ -1159,14 +1452,14 @@ void AIGroup::friend_moveFormationToPos( const Coord3D *pos, CommandSourceType c
 			dest.x += offset.x;
 			dest.y += offset.y;
 
-			TheAI->pathfinder()->adjustDestination(theUnit, ai->getLocomotorSet(), &dest, nullptr);
+			TheAI->pathfinder()->adjustDestination(theUnit, ai->getLocomotorSet(), &dest, &endPoint);
 			TheAI->pathfinder()->updateGoal(theUnit, &dest, LAYER_GROUND);
 			path.push_back(dest);
 			ai->aiFollowPath( &path, nullptr, cmdSource );
 		}	else {
-			Coord3D dest = endPoint;
-			dest.x += offset.x;
-			dest.y += offset.y;
+			Coord3D dest;
+			computeFormationOffsetDestination(&dest, &endPoint, theUnit, ai, true);
+			applyMassCommandPathDelay(ai, totalMassCommandCandidates, scheduledMassCommandCandidates);
 			ai->aiMoveToPosition( &dest, cmdSource );
 		}
 
@@ -1602,19 +1895,16 @@ void AIGroup::groupMoveToPosition( const Coord3D *p_posIn, Bool addWaypoint, Com
 	Coord2D max;
 	Coord3D dest;
 	Bool tightenGroup = FALSE;
+	Bool usePhase3Spread = FALSE;
+	const Int totalMassCommandCandidates =
+		(cmdSource == CMD_FROM_PLAYER) ? countMassCommandPathCandidates(m_memberList) : 0;
+	Int scheduledMassCommandCandidates = 0;
 
 	Bool isFormation = getMinMaxAndCenter( &min, &max, &center );
 	if (addWaypoint)
   {
     isFormation = false;
   }
-
-
-	if (!addWaypoint && !isFormation) {
-		friend_computeGroundPath(pos, cmdSource);
-		didInfantry = friend_moveInfantryToPos(pos, cmdSource);
-		didVehicles = friend_moveVehicleToPos(pos, cmdSource);
-	}
 	if (m_dirty)
 		recompute();
 
@@ -1660,6 +1950,7 @@ void AIGroup::groupMoveToPosition( const Coord3D *p_posIn, Bool addWaypoint, Com
 
 	if (tightenGroup)
 	{
+		clearGeneratedFormationOffsets(m_memberList);
 		isFormation = false;
 		if (!addWaypoint) {
 			Int dx = (max.x-min.x)/PATHFIND_CELL_SIZE_F;
@@ -1676,6 +1967,21 @@ void AIGroup::groupMoveToPosition( const Coord3D *p_posIn, Bool addWaypoint, Com
 		friend_computeGroundPath(pos, cmdSource);
 		friend_moveFormationToPos(pos, cmdSource);
 		return;
+	}
+
+	usePhase3Spread = shouldUsePhase3Spread(m_memberList, addWaypoint, isFormation);
+	if (usePhase3Spread)
+	{
+		assignPhase3SpreadOffsets(m_memberList, center, position);
+		friend_computeGroundPath(pos, cmdSource);
+		friend_moveFormationToPos(pos, cmdSource);
+		return;
+	}
+	clearGeneratedFormationOffsets(m_memberList);
+	if (!addWaypoint && !isFormation) {
+		friend_computeGroundPath(pos, cmdSource);
+		didInfantry = friend_moveInfantryToPos(pos, cmdSource);
+		didVehicles = friend_moveVehicleToPos(pos, cmdSource);
 	}
 
 	// Move.
@@ -1782,6 +2088,7 @@ void AIGroup::groupMoveToPosition( const Coord3D *p_posIn, Bool addWaypoint, Com
 
 		if( !addWaypoint )
 		{
+			applyMassCommandPathDelay(ai, totalMassCommandCandidates, scheduledMassCommandCandidates);
 			ai->aiMoveToPosition( &dest, cmdSource );
 		}
 		else
@@ -2326,16 +2633,51 @@ void AIGroup::groupAttackPosition( const Coord3D *pos, Int maxShotsToFire, Comma
  */
 void AIGroup::groupAttackMoveToPosition( const Coord3D *pos, Int maxShotsToFire, CommandSourceType cmdSource )
 {
+	if (pos == nullptr)
+	{
+		return;
+	}
+
+	Coord3D center;
+	Coord2D min;
+	Coord2D max;
+	Coord3D attackPos = *pos;
+	const Int totalMassCommandCandidates =
+		(cmdSource == CMD_FROM_PLAYER) ? countMassCommandPathCandidates(m_memberList) : 0;
+	Int scheduledMassCommandCandidates = 0;
+	Bool isFormation = getMinMaxAndCenter(&min, &max, &center);
+	const Bool usePhase3Spread = shouldUsePhase3Spread(m_memberList, false, isFormation);
+
+	if (isFormation)
+	{
+		// Preserve explicit player formations on attack-move as well.
+	}
+	else if (usePhase3Spread)
+	{
+		assignPhase3SpreadOffsets(m_memberList, center, attackPos);
+	}
+	else
+	{
+		clearGeneratedFormationOffsets(m_memberList);
+	}
+
 	std::list<Object *>::iterator i;
 	for( i = m_memberList.begin(); i != m_memberList.end(); ++i )
 	{
 		AIUpdateInterface *ai = (*i)->getAIUpdateInterface();
 		if (ai)
 		{
+			Coord3D unitDest = attackPos;
+			if (isFormation || usePhase3Spread)
+			{
+				computeFormationOffsetDestination(&unitDest, &attackPos, *i, ai, true);
+			}
+
+			applyMassCommandPathDelay(ai, totalMassCommandCandidates, scheduledMassCommandCandidates);
 			if ((*i)->isAbleToAttack())
-				ai->aiAttackMoveToPosition( pos, maxShotsToFire, cmdSource );
+				ai->aiAttackMoveToPosition( &unitDest, maxShotsToFire, cmdSource );
 			else
-				ai->aiMoveToPosition( pos, cmdSource );
+				ai->aiMoveToPosition( &unitDest, cmdSource );
 		}
 	}
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -73,6 +73,11 @@
 
 #define SLEEPY_AI
 
+namespace
+{
+	const Int PATHFIND_QUEUE_RETRY_FRAMES = 2;
+}
+
 
 //-------------------------------------------------------------------------------------------------
 AIUpdateModuleData::AIUpdateModuleData()
@@ -478,6 +483,7 @@ will be processed when we get to the front of the pathfind queue. jba */
 //-------------------------------------------------------------------------------------------------
 void AIUpdateInterface::requestPath( Coord3D *destination, Bool isFinalGoal )
 {
+	const UnsignedInt currentFrame = TheGameLogic->getFrame();
 
 	if (m_locomotorSet.getValidSurfaces() == 0) {
 		DEBUG_CRASH(("Attempting to path immobile unit."));
@@ -496,7 +502,10 @@ void AIUpdateInterface::requestPath( Coord3D *destination, Bool isFinalGoal )
 		return;
 	}
 	m_waitingForPath = TRUE;
-	if (m_pathTimestamp > TheGameLogic->getFrame()-3) {
+	if (m_queueForPathFrame != 0 && currentFrame < m_queueForPathFrame) {
+		return;
+	}
+	if (m_pathTimestamp > currentFrame-3) {
 		/* Requesting path very quickly.  Can cause a spin. */
 		//DEBUG_LOG(("%d Pathfind - repathing in less than 3 frames.  Waiting 1 second",
 			//TheGameLogic->getFrame()));
@@ -512,13 +521,17 @@ void AIUpdateInterface::requestPath( Coord3D *destination, Bool isFinalGoal )
 		}
 		return;
 	}
-	TheAI->pathfinder()->queueForPath(getObject()->getID());
+	if (!TheAI->pathfinder()->queueForPath(getObject()->getID())) {
+		setQueueForPathTime(PATHFIND_QUEUE_RETRY_FRAMES);
+	}
 
 }
 
 //-------------------------------------------------------------------------------------------------
 void AIUpdateInterface::requestAttackPath( ObjectID victimID, const Coord3D* victimPos )
 {
+	const UnsignedInt currentFrame = TheGameLogic->getFrame();
+
 	if (m_locomotorSet.getValidSurfaces() == 0) {
 		DEBUG_CRASH(("Attempting to path immobile unit."));
 	}
@@ -529,19 +542,26 @@ void AIUpdateInterface::requestAttackPath( ObjectID victimID, const Coord3D* vic
 	m_isApproachPath = FALSE;
 	m_isSafePath = FALSE;
 	m_waitingForPath = TRUE;
-	if (m_pathTimestamp > TheGameLogic->getFrame()-3) {
+	if (m_queueForPathFrame != 0 && currentFrame < m_queueForPathFrame) {
+		return;
+	}
+	if (m_pathTimestamp > currentFrame-3) {
 		/* Requesting path very quickly.  Can cause a spin. */
 		//DEBUG_LOG(("%d Pathfind - repathing in less than 3 frames.  Waiting 2 second",TheGameLogic->getFrame()));
 		setQueueForPathTime(2*LOGICFRAMES_PER_SECOND);
 		setLocomotorGoalNone();
 		return;
 	}
-	TheAI->pathfinder()->queueForPath(getObject()->getID());
+	if (!TheAI->pathfinder()->queueForPath(getObject()->getID())) {
+		setQueueForPathTime(PATHFIND_QUEUE_RETRY_FRAMES);
+	}
 }
 
 //-------------------------------------------------------------------------------------------------
 void AIUpdateInterface::requestApproachPath( Coord3D *destination )
 {
+	const UnsignedInt currentFrame = TheGameLogic->getFrame();
+
 	if (m_locomotorSet.getValidSurfaces() == 0) {
 		DEBUG_CRASH(("Attempting to path immobile unit."));
 	}
@@ -553,19 +573,26 @@ void AIUpdateInterface::requestApproachPath( Coord3D *destination )
 	m_isApproachPath = TRUE;
 	m_isSafePath = FALSE;
 	m_waitingForPath = TRUE;
-	if (m_pathTimestamp > TheGameLogic->getFrame()-3) {
+	if (m_queueForPathFrame != 0 && currentFrame < m_queueForPathFrame) {
+		return;
+	}
+	if (m_pathTimestamp > currentFrame-3) {
 		/* Requesting path very quickly.  Can cause a spin. */
 		//DEBUG_LOG(("%d Pathfind - repathing in less than 3 frames.  Waiting 2 second",TheGameLogic->getFrame()));
 		setQueueForPathTime(2*LOGICFRAMES_PER_SECOND);
 		return;
 	}
-	TheAI->pathfinder()->queueForPath(getObject()->getID());
+	if (!TheAI->pathfinder()->queueForPath(getObject()->getID())) {
+		setQueueForPathTime(PATHFIND_QUEUE_RETRY_FRAMES);
+	}
 }
 
 //-------------------------------------------------------------------------------------------------
 // Requests a safe path away from the repulsor.
 void AIUpdateInterface::requestSafePath( ObjectID repulsor )
 {
+	const UnsignedInt currentFrame = TheGameLogic->getFrame();
+
 	if (repulsor != m_repulsor1) {
 		m_repulsor2 = m_repulsor1; // save the prior repulsor.
 	}
@@ -577,13 +604,18 @@ void AIUpdateInterface::requestSafePath( ObjectID repulsor )
 	m_isApproachPath = FALSE;
 	m_isSafePath = TRUE;
 	m_waitingForPath = TRUE;
-	if (m_pathTimestamp > TheGameLogic->getFrame()-3) {
+	if (m_queueForPathFrame != 0 && currentFrame < m_queueForPathFrame) {
+		return;
+	}
+	if (m_pathTimestamp > currentFrame-3) {
 		/* Requesting path very quickly.  Can cause a spin. */
 		//DEBUG_LOG(("%d Pathfind - repathing in less than 3 frames.  Waiting 2 second",TheGameLogic->getFrame()));
 		setQueueForPathTime(2*LOGICFRAMES_PER_SECOND);
 		return;
 	}
-	TheAI->pathfinder()->queueForPath(getObject()->getID());
+	if (!TheAI->pathfinder()->queueForPath(getObject()->getID())) {
+		setQueueForPathTime(PATHFIND_QUEUE_RETRY_FRAMES);
+	}
 }
 
 enum {WAYPOINT_PATH_LIMIT=1024};
@@ -1066,8 +1098,11 @@ UpdateSleepTime AIUpdateInterface::update()
 	{
 		if (now >= m_queueForPathFrame)
 		{
-			TheAI->pathfinder()->queueForPath(getObject()->getID());
-			setQueueForPathTime(0);
+			if (TheAI->pathfinder()->queueForPath(getObject()->getID())) {
+				setQueueForPathTime(0);
+			} else {
+				setQueueForPathTime(PATHFIND_QUEUE_RETRY_FRAMES);
+			}
 		}
 		else
 		{

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DScene.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DScene.h
@@ -47,6 +47,7 @@
 class W3DDynamicLight;
 class LightClass;
 class Drawable;
+struct DrawableInfo;
 enum CustomScenePassModes CPP_11(: Int);
 class MaterialPassClass;
 class W3DShroudMaterialPassClass;
@@ -60,6 +61,12 @@ class RTS3DScene : public SimpleSceneClass, public SubsystemInterface
 {
 
 public:
+	struct FrameRenderEntry
+	{
+		RenderObjClass *m_renderObject;
+		DrawableInfo *m_drawInfo;
+		Drawable *m_drawable;
+	};
 
 	RTS3DScene();  ///< RTSScene constructor
 	virtual ~RTS3DScene() override;  ///< RTSScene destructor
@@ -99,13 +106,17 @@ public:
 	void doRender(CameraClass * cam);
 
 protected:
-	void renderOneObject(RenderInfoClass &rinfo, RenderObjClass *robj, Int localPlayerIndex);
+	void renderOneObject(RenderInfoClass &rinfo, RenderObjClass *robj, Int localPlayerIndex,
+		DrawableInfo *cachedDrawInfo = nullptr, Drawable *cachedDraw = nullptr);
 	void updateFixedLightEnvironments(RenderInfoClass & rinfo);
 	void flushTranslucentObjects(RenderInfoClass & rinfo);
 	void flushOccludedObjects(RenderInfoClass & rinfo);
 	void flagOccludedObjects(CameraClass * camera);
 	void flushOccludedObjectsIntoStencil(RenderInfoClass & rinfo);
 	void updatePlayerColorPasses();
+	void ensureVisibleRenderEntryCapacity(Int desiredCapacity);
+	void clearVisibleRenderObjectSnapshot();
+	void appendVisibleRenderObject(RenderObjClass *robj, DrawableInfo *drawInfo, Drawable *draw);
 
 protected:
 	RefRenderObjListClass	m_dynamicLightList;
@@ -116,6 +127,7 @@ protected:
 	LightClass						*m_infantryLight[LightEnvironmentClass::MAX_LIGHTS];	///< The global direction light modified to make infantry easier to see.
 	Int m_numGlobalLights;			///<number of global lights
 	LightEnvironmentClass	m_defaultLightEnv;		///<default light environment applied to objects without custom/dynamic lighting.
+	LightEnvironmentClass	m_defaultInfantryLightEnv;	///<default light environment for infantry when only global lights apply.
 	LightEnvironmentClass	m_foggedLightEnv;		///<default light environment applied to objects without custom/dynamic lighting.
 
 	W3DShroudMaterialPassClass	*m_shroudMaterialPass;	///< Custom render pass which applies shrouds to objects
@@ -135,6 +147,9 @@ protected:
 	Int m_numPotentialOccluders;
 	Int m_numPotentialOccludees;
 	Int m_numNonOccluderOrOccludee;
+	FrameRenderEntry *m_visibleRenderEntries;	///< packed main-pass render snapshot for the current scene pass.
+	Int m_visibleRenderObjectCount;
+	Int m_visibleRenderObjectCapacity;
 
 	CameraClass *m_camera;
 };

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -45,6 +45,7 @@ static void drawFramerateBar();
 #include "Common/ThingFactory.h"
 #include "Common/GlobalData.h"
 #include "Common/PerfTimer.h"
+#include "Common/PerfTrace.h"
 #include "Common/FileSystem.h"
 #include "Common/LocalFileSystem.h"
 #include "Common/Player.h"
@@ -1908,14 +1909,18 @@ AGAIN:
 	}
 
 	do {
+		Int numRenderTargetPolygons = 0;
+		Int numRenderTargetVertices = 0;
+		{
+			PerfTrace::ScopedRenderTimer renderSubmitTimer(PerfTrace::RENDER_TIMER_SUBMIT);
 
-		// update all views of the world - recomputes data which will affect drawing
-		if (DX8Wrapper::_Get_D3D_Device8() && (DX8Wrapper::_Get_D3D_Device8()->TestCooperativeLevel()) == D3D_OK)
-		{	//Checking if we have the device before updating views because the heightmap crashes otherwise while
-			//trying to refresh the visible terrain geometry.
-//			if(TheGlobalData->m_loadScreenRender != TRUE)
-				updateViews();
-     		TheParticleSystemManager->update();//LORENZEN AND WILCZYNSKI MOVED THIS FROM ITS NATIVE POSITION, ABOVE
+			// update all views of the world - recomputes data which will affect drawing
+			if (DX8Wrapper::_Get_D3D_Device8() && (DX8Wrapper::_Get_D3D_Device8()->TestCooperativeLevel()) == D3D_OK)
+			{	//Checking if we have the device before updating views because the heightmap crashes otherwise while
+				//trying to refresh the visible terrain geometry.
+//				if(TheGlobalData->m_loadScreenRender != TRUE)
+					updateViews();
+     			TheParticleSystemManager->update();//LORENZEN AND WILCZYNSKI MOVED THIS FROM ITS NATIVE POSITION, ABOVE
                                            //FOR THE PURPOSE OF LETTING THE PARTICLE SYSTEM LOOK UP THE RENDER OBJECT"S
                                            //TRANSFORM MATRIX, WHILE IT IS STILL VALID (HAVING DONE ITS CLIENT TRANSFORMS
                                            //BUT NOT YET RESETTING TOT HE LOGICAL TRANSFORM)
@@ -1925,20 +1930,21 @@ AGAIN:
                                            //-LORENZEN
 
 
-			if (TheWaterRenderObj && TheGlobalData->m_waterType == 2)
-				TheWaterRenderObj->updateRenderTargetTextures(primaryW3DView->get3DCamera());	//do a render into each texture
+				if (TheWaterRenderObj && TheGlobalData->m_waterType == 2)
+					TheWaterRenderObj->updateRenderTargetTextures(primaryW3DView->get3DCamera());	//do a render into each texture
 
-			//Can't render into textures while rendering to screen so these textures need to be updated
-			//before we enter main rendering loop.
-			if (TheW3DProjectedShadowManager)
-				TheW3DProjectedShadowManager->updateRenderTargetTextures();
+				//Can't render into textures while rendering to screen so these textures need to be updated
+				//before we enter main rendering loop.
+				if (TheW3DProjectedShadowManager)
+					TheW3DProjectedShadowManager->updateRenderTargetTextures();
+			}
+
+			Debug_Statistics::End_Statistics();	//record number of polygons rendered in RenderTargetTextures.
+
+			//Store number of polygons rendered in renderTargetTextures.
+			numRenderTargetPolygons = Debug_Statistics::Get_DX8_Polygons();
+			numRenderTargetVertices = Debug_Statistics::Get_DX8_Vertices();
 		}
-
-		Debug_Statistics::End_Statistics();	//record number of polygons rendered in RenderTargetTextures.
-
-		//Store number of polygons rendered in renderTargetTextures.
-		Int numRenderTargetPolygons=Debug_Statistics::Get_DX8_Polygons();
-		Int numRenderTargetVertices=Debug_Statistics::Get_DX8_Vertices();
 
 		// start render block
 		#if defined(_ALLOW_DEBUG_CHEATS_IN_RELEASE)
@@ -1951,6 +1957,7 @@ AGAIN:
 			static Bool couldRender = true;
 			if ((TheGlobalData->m_breakTheMovie == FALSE) && (TheGlobalData->m_disableRender == false) && WW3D::Begin_Render( true, true, Vector3( 0.0f, 0.0f, 0.0f ), TheWaterTransparency->m_minWaterOpacity ) == WW3D_ERROR_OK)
 			{
+				PerfTrace::ScopedRenderTimer drawTimer(PerfTrace::RENDER_TIMER_DRAW);
 
 				if(TheGlobalData->m_loadScreenRender == TRUE)
 				{

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DScene.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DScene.cpp
@@ -54,6 +54,7 @@
 #include "W3DDevice/GameClient/W3DStatusCircle.h"
 #include "W3DDevice/GameClient/W3DCustomScene.h"
 #include "W3DDevice/GameClient/W3DShroud.h"
+#include "W3DDevice/GameClient/W3DWater.h"
 #include "WW3D2/camera.h"
 #include "WW3D2/dx8renderer.h"
 #include "WW3D2/sortingrenderer.h"
@@ -83,6 +84,15 @@ extern void DoParticles(RenderInfoClass & rinfo);
 	ShaderClass::DETAILCOLOR_DISABLE, ShaderClass::DETAILALPHA_DISABLE) )
 static ShaderClass PlayerColorShader(SC_PLAYER_COLOR);
 
+static Bool shouldRenderInMainPass(const DrawableInfo *drawInfo, const Drawable *draw)
+{
+#ifdef USE_NON_STENCIL_OCCLUSION
+	return !(draw && drawInfo && (drawInfo->m_flags & DrawableInfo::ERF_DELAYED_RENDER));
+#else
+	return !(draw && drawInfo && (drawInfo->m_flags & (DrawableInfo::ERF_DELAYED_RENDER | DrawableInfo::ERF_POTENTIAL_OCCLUDER | DrawableInfo::ERF_IS_NON_OCCLUDER_OR_OCCLUDEE)));
+#endif
+}
+
 //=============================================================================
 // RTS3DScene::RTS3DScene
 //=============================================================================
@@ -93,6 +103,9 @@ RTS3DScene::RTS3DScene()
 	setName("RTS3DScene");
 	m_drawTerrainOnly = false;
 	m_numGlobalLights=0;
+	m_visibleRenderEntries = nullptr;
+	m_visibleRenderObjectCount = 0;
+	m_visibleRenderObjectCapacity = 0;
 	Int i=0;
 	for (; i<LightEnvironmentClass::MAX_LIGHTS; i++)
 	{
@@ -227,6 +240,8 @@ RTS3DScene::~RTS3DScene()
 	delete [] m_nonOccludersOrOccludees;
 	delete [] m_potentialOccludees;
 	delete [] m_potentialOccluders;
+	clearVisibleRenderObjectSnapshot();
+	delete [] m_visibleRenderEntries;
 
 	for (i=0; i<MAX_PLAYER_COUNT; i++)
 	{
@@ -240,6 +255,57 @@ void	RTS3DScene::setGlobalLight(LightClass *pLight, Int lightIndex)
 	if (m_numGlobalLights < (lightIndex+1))
 		m_numGlobalLights=(lightIndex+1);
 	REF_PTR_SET(m_globalLight[lightIndex], pLight);
+}
+
+void RTS3DScene::ensureVisibleRenderEntryCapacity(Int desiredCapacity)
+{
+	if (desiredCapacity <= m_visibleRenderObjectCapacity)
+	{
+		return;
+	}
+
+	Int newCapacity = m_visibleRenderObjectCapacity > 0 ? m_visibleRenderObjectCapacity : 256;
+	while (newCapacity < desiredCapacity)
+	{
+		newCapacity *= 2;
+	}
+
+	RTS3DScene::FrameRenderEntry *newBuffer = NEW RTS3DScene::FrameRenderEntry[newCapacity];
+	for (Int i = 0; i < m_visibleRenderObjectCount; i++)
+	{
+		newBuffer[i] = m_visibleRenderEntries[i];
+	}
+
+	delete [] m_visibleRenderEntries;
+	m_visibleRenderEntries = newBuffer;
+	m_visibleRenderObjectCapacity = newCapacity;
+}
+
+void RTS3DScene::clearVisibleRenderObjectSnapshot()
+{
+	for (Int i = 0; i < m_visibleRenderObjectCount; i++)
+	{
+		if (m_visibleRenderEntries[i].m_renderObject)
+		{
+			m_visibleRenderEntries[i].m_renderObject->Release_Ref();
+		}
+	}
+	m_visibleRenderObjectCount = 0;
+}
+
+void RTS3DScene::appendVisibleRenderObject(RenderObjClass *robj, DrawableInfo *drawInfo, Drawable *draw)
+{
+	if (!robj)
+	{
+		return;
+	}
+
+	ensureVisibleRenderEntryCapacity(m_visibleRenderObjectCount + 1);
+	robj->Add_Ref();
+	m_visibleRenderEntries[m_visibleRenderObjectCount].m_renderObject = robj;
+	m_visibleRenderEntries[m_visibleRenderObjectCount].m_drawInfo = drawInfo;
+	m_visibleRenderEntries[m_visibleRenderObjectCount].m_drawable = draw;
+	m_visibleRenderObjectCount++;
 }
 
 /**Find all objects which need to be drawn in a special way because they are occluded by other
@@ -408,6 +474,8 @@ void RTS3DScene::Visibility_Check(CameraClass * camera)
 	m_numPotentialOccludees=0;
 	m_translucentObjectsCount=0;
 	m_numNonOccluderOrOccludee=0;
+	clearVisibleRenderObjectSnapshot();
+	ensureVisibleRenderEntryCapacity(RenderList.Count());
 
 	Int currentFrame = TheGameLogic ? TheGameLogic->getFrame() : 0;
 	if (currentFrame <= TheGlobalData->m_defaultOcclusionDelay)
@@ -445,6 +513,12 @@ void RTS3DScene::Visibility_Check(CameraClass * camera)
 				} else {
 					robj->Set_Visible(!camera->Cull_Sphere(robj->Get_Bounding_Sphere()));
 				}
+			}
+
+			if (robj->Is_Really_Visible() && robj->Class_ID() != RenderObjClass::CLASSID_TILEMAP &&
+				robj != TheWaterRenderObj)
+			{
+				appendVisibleRenderObject(robj, drawInfo, draw);
 			}
 		}
 	}
@@ -521,6 +595,12 @@ void RTS3DScene::Visibility_Check(CameraClass * camera)
 				}
 
 				robj->Set_Visible(isVisible);
+				if (isVisible && robj->Class_ID() != RenderObjClass::CLASSID_TILEMAP &&
+					robj != TheWaterRenderObj &&
+					shouldRenderInMainPass(drawInfo, draw))
+				{
+					appendVisibleRenderObject(robj, drawInfo, draw);
+				}
 			}
 
 			///@todo: We're not using LOD yet so I disabled this code. MW
@@ -580,7 +660,8 @@ void RTS3DScene::renderSpecificDrawables(RenderInfoClass &rinfo, Int numDrawable
 //=============================================================================
 /** Renders a single drawable entity. */
 //=============================================================================
-void RTS3DScene::renderOneObject(RenderInfoClass &rinfo, RenderObjClass *robj, Int localPlayerIndex)
+void RTS3DScene::renderOneObject(RenderInfoClass &rinfo, RenderObjClass *robj, Int localPlayerIndex,
+	DrawableInfo *cachedDrawInfo, Drawable *cachedDraw)
 {
 	Drawable *draw = nullptr;
 	DrawableInfo *drawInfo = nullptr;
@@ -589,7 +670,11 @@ void RTS3DScene::renderOneObject(RenderInfoClass &rinfo, RenderObjClass *robj, I
 	ObjectShroudStatus ss=OBJECTSHROUD_INVALID;
 	Bool doExtraMaterialPop=FALSE;
 	Bool doExtraFlagsPop=FALSE;
+	Bool useCachedLightEnv = FALSE;
 	LightClass **sceneLights=m_globalLight;
+	LightEnvironmentClass *activeLightEnv = nullptr;
+	const Bool hasSceneLights = LightList.Count() > 0;
+	const Bool hasAnyDynamicLights = m_dynamicLightList.Count() > 0;
 
 	if (robj->Class_ID() == RenderObjClass::CLASSID_IMAGE3D	)
 	{
@@ -598,11 +683,12 @@ void RTS3DScene::renderOneObject(RenderInfoClass &rinfo, RenderObjClass *robj, I
 	}
 
 	LightEnvironmentClass lightEnv;
-	SphereClass sph = robj->Get_Bounding_Sphere();
-	drawInfo = (DrawableInfo *)robj->Get_User_Data();
+	SphereClass sph;
+	Bool haveBoundingSphere = FALSE;
+	drawInfo = cachedDrawInfo ? cachedDrawInfo : (DrawableInfo *)robj->Get_User_Data();
 	if (drawInfo)
 	{
-		draw = drawInfo->m_drawable;
+		draw = cachedDraw ? cachedDraw : drawInfo->m_drawable;
 		//If we have a drawInfo but not drawable, we must be dealing with
 		//a ghost object which is always fogged.
 		if (!draw)
@@ -662,9 +748,6 @@ void RTS3DScene::renderOneObject(RenderInfoClass &rinfo, RenderObjClass *robj, I
 			sceneLights = m_infantryLight;
 		}
 
-		lightEnv.Reset(sph.Center, ambient);
-
-
 		// HANDLE THE SPECIAL DRAWABLE-LEVEL COLORING SETTINGS FIRST
 
 		const Vector3 *tintColor = nullptr;
@@ -673,42 +756,60 @@ void RTS3DScene::renderOneObject(RenderInfoClass &rinfo, RenderObjClass *robj, I
 		tintColor			 = draw->getTintColor();
 		selectionColor = draw->getSelectionColor();
 
-		if ( tintColor || selectionColor )
+		if (!tintColor && !selectionColor && ss <= OBJECTSHROUD_CLEAR &&
+			!hasSceneLights && (!draw->getReceivesDynamicLights() || !hasAnyDynamicLights))
 		{
-			Vector3 sumTint, temp, restore;
-
-			sumTint.Set(0,0,0);
-
-			if (tintColor)
-				Vector3::Add(sumTint, *tintColor, &sumTint);
-			if (selectionColor)
-				Vector3::Add(sumTint, *selectionColor, &sumTint);
-
-			for (Int globalLightIndex = 0; globalLightIndex < m_numGlobalLights; globalLightIndex++)
-			{
-				sceneLights[globalLightIndex]->Get_Diffuse( &temp );
-				restore = temp;
-
-				Vector3::Add(temp, sumTint, &temp);
-
-				sceneLights[globalLightIndex]->Set_Diffuse( temp );
-				lightEnv.Add_Light(*sceneLights[globalLightIndex]);
-				sceneLights[globalLightIndex]->Set_Diffuse( restore );
-
-			}
-
-			temp = lightEnv.Get_Equivalent_Ambient();
-			Vector3::Add(sumTint, temp, &temp );
-
-			lightEnv.Set_Output_Ambient( temp );
-
+			useCachedLightEnv = TRUE;
+			activeLightEnv = draw->isKindOf(KINDOF_INFANTRY) ? &m_defaultInfantryLightEnv : &m_defaultLightEnv;
 		}
-		else // no funny coloring going on, so just add the lights normally
+		else
 		{
-			for (Int globalLightIndex = 0; globalLightIndex < m_numGlobalLights; globalLightIndex++)
+			if (!haveBoundingSphere)
 			{
-				lightEnv.Add_Light(*sceneLights[globalLightIndex]);
+				sph = robj->Get_Bounding_Sphere();
+				haveBoundingSphere = TRUE;
 			}
+			lightEnv.Reset(sph.Center, ambient);
+
+			if ( tintColor || selectionColor )
+			{
+				Vector3 sumTint, temp, restore;
+
+				sumTint.Set(0,0,0);
+
+				if (tintColor)
+					Vector3::Add(sumTint, *tintColor, &sumTint);
+				if (selectionColor)
+					Vector3::Add(sumTint, *selectionColor, &sumTint);
+
+				for (Int globalLightIndex = 0; globalLightIndex < m_numGlobalLights; globalLightIndex++)
+				{
+					sceneLights[globalLightIndex]->Get_Diffuse( &temp );
+					restore = temp;
+
+					Vector3::Add(temp, sumTint, &temp);
+
+					sceneLights[globalLightIndex]->Set_Diffuse( temp );
+					lightEnv.Add_Light(*sceneLights[globalLightIndex]);
+					sceneLights[globalLightIndex]->Set_Diffuse( restore );
+
+				}
+
+				temp = lightEnv.Get_Equivalent_Ambient();
+				Vector3::Add(sumTint, temp, &temp );
+
+				lightEnv.Set_Output_Ambient( temp );
+
+			}
+			else // no funny coloring going on, so just add the lights normally
+			{
+				for (Int globalLightIndex = 0; globalLightIndex < m_numGlobalLights; globalLightIndex++)
+				{
+					lightEnv.Add_Light(*sceneLights[globalLightIndex]);
+				}
+			}
+
+			activeLightEnv = &lightEnv;
 		}
 
 		//Apply custom render pass for any drawables with heatvision enabled
@@ -757,46 +858,70 @@ void RTS3DScene::renderOneObject(RenderInfoClass &rinfo, RenderObjClass *robj, I
 		}
 		else
 		{
-			lightEnv.Reset(sph.Center, ambient);
-			for (Int globalLightIndex = 0; globalLightIndex < m_numGlobalLights; globalLightIndex++)
-				lightEnv.Add_Light(*m_globalLight[globalLightIndex]);
+			if (!hasSceneLights)
+			{
+				useCachedLightEnv = TRUE;
+				activeLightEnv = &m_defaultLightEnv;
+			}
+			else
+			{
+				if (!haveBoundingSphere)
+				{
+					sph = robj->Get_Bounding_Sphere();
+					haveBoundingSphere = TRUE;
+				}
+				lightEnv.Reset(sph.Center, ambient);
+				for (Int globalLightIndex = 0; globalLightIndex < m_numGlobalLights; globalLightIndex++)
+					lightEnv.Add_Light(*m_globalLight[globalLightIndex]);
+				activeLightEnv = &lightEnv;
+			}
 		}
 	}
 
 	if (!drawableHidden)
 	{
-		//standard scene lights
-		RefRenderObjListIterator it2(&LightList);
-		for (it2.First(); !it2.Is_Done(); it2.Next())
+		if (!useCachedLightEnv)
 		{
-			LightClass *pLight = (LightClass*)it2.Peek_Obj();
-			SphereClass lSph = pLight->Get_Bounding_Sphere();
-			Bool cull = (pLight->Get_Type() == LightClass::POINT && !Spheres_Intersect(sph, lSph));
-			if (!cull) {
-				lightEnv.Add_Light(*pLight);
+			if (!haveBoundingSphere)
+			{
+				sph = robj->Get_Bounding_Sphere();
+				haveBoundingSphere = TRUE;
 			}
+			//standard scene lights
+			RefRenderObjListIterator it2(&LightList);
+			for (it2.First(); !it2.Is_Done(); it2.Next())
+			{
+				LightClass *pLight = (LightClass*)it2.Peek_Obj();
+				SphereClass lSph = pLight->Get_Bounding_Sphere();
+				Bool cull = (pLight->Get_Type() == LightClass::POINT && !Spheres_Intersect(sph, lSph));
+				if (!cull) {
+					lightEnv.Add_Light(*pLight);
+				}
+			}
+
+			if( draw && draw->getReceivesDynamicLights() )
+			{
+				// dynamic lights
+				RefRenderObjListIterator dynaLightIt(&m_dynamicLightList);
+				for (dynaLightIt.First(); !dynaLightIt.Is_Done(); dynaLightIt.Next())
+				{
+					W3DDynamicLight* pDyna = (W3DDynamicLight*)dynaLightIt.Peek_Obj();
+					if (!pDyna->isEnabled()) {
+						continue;
+					}
+					SphereClass lSph = pDyna->Get_Bounding_Sphere();
+					if (pDyna->Get_Type() == LightClass::POINT && !Spheres_Intersect(sph, lSph)) {
+						continue;
+					}
+					lightEnv.Add_Light(*(LightClass*)dynaLightIt.Peek_Obj());
+				}
+			}
+
+			lightEnv.Pre_Render_Update(rinfo.Camera.Get_Transform());
+			activeLightEnv = &lightEnv;
 		}
 
-    if( draw && draw->getReceivesDynamicLights() )
-    {
-		  // dynamic lights
-		  RefRenderObjListIterator dynaLightIt(&m_dynamicLightList);
-		  for (dynaLightIt.First(); !dynaLightIt.Is_Done(); dynaLightIt.Next())
-		  {
-			  W3DDynamicLight* pDyna = (W3DDynamicLight*)dynaLightIt.Peek_Obj();
-			  if (!pDyna->isEnabled()) {
-				  continue;
-			  }
-			  SphereClass lSph = pDyna->Get_Bounding_Sphere();
-			  if (pDyna->Get_Type() == LightClass::POINT && !Spheres_Intersect(sph, lSph)) {
-				  continue;
-			  }
-			  lightEnv.Add_Light(*(LightClass*)dynaLightIt.Peek_Obj());
-		  }
-    }
-
-		lightEnv.Pre_Render_Update(rinfo.Camera.Get_Transform());
-		rinfo.light_environment = &lightEnv;
+		rinfo.light_environment = activeLightEnv;
 
 		if (drawInfo)
 		{
@@ -904,6 +1029,7 @@ void RTS3DScene::updateFixedLightEnvironments(RenderInfoClass & rinfo)
 
 	//Generate the default light environment
 	m_defaultLightEnv.Reset(Vector3(0,0,0), Get_Ambient_Light());
+	m_defaultInfantryLightEnv.Reset(Vector3(0,0,0), Get_Ambient_Light());
 	m_foggedLightEnv.Reset(Vector3(0,0,0), Get_Ambient_Light()*foggedLightFrac);
 
 	Vector3 oldDiffuse, oldAmbient;
@@ -923,6 +1049,7 @@ void RTS3DScene::updateFixedLightEnvironments(RenderInfoClass & rinfo)
     oldAmbient.Cap_Absolute_To(id);
 		m_infantryLight[globalLightIndex]->Set_Ambient(oldAmbient);//CLAMPED
 		m_infantryLight[globalLightIndex]->Set_Diffuse(oldDiffuse);//CLAMPED
+		m_defaultInfantryLightEnv.Add_Light(*m_infantryLight[globalLightIndex]);
 
 		//copy the normal light for fog so we can modify it
 		m_scratchLight->Set_Transform(m_globalLight[globalLightIndex]->Get_Transform());
@@ -935,6 +1062,7 @@ void RTS3DScene::updateFixedLightEnvironments(RenderInfoClass & rinfo)
 	}
 
 	m_defaultLightEnv.Pre_Render_Update(rinfo.Camera.Get_Transform());
+	m_defaultInfantryLightEnv.Pre_Render_Update(rinfo.Camera.Get_Transform());
 	m_foggedLightEnv.Pre_Render_Update(rinfo.Camera.Get_Transform());
 
 	m_infantryAmbient = Get_Ambient_Light();// * infantryLightScale;	//for now don't adjust ambient so that we don't lose directional lighting.
@@ -1114,16 +1242,6 @@ void RTS3DScene::Customized_Render( RenderInfoClass &rinfo )
 
 #define USE_LIGHT_ENV 1
 
-   if (!Visibility_Checked) {
-      // set the visibility bit in all render objects in all layers.
-	   Visibility_Check(&rinfo.Camera);
-#ifdef USE_NON_STENCIL_OCCLUSION
-	   flagOccludedObjects(&rinfo.Camera);
-#endif
-   }
-   Visibility_Checked = false;
-
-
 	RefRenderObjListIterator it(&UpdateList);
 	// allow all objects in the update list to do their "every frame" processing
 	for (it.First(); !it.Is_Done(); it.Next()) {
@@ -1137,6 +1255,15 @@ void RTS3DScene::Customized_Render( RenderInfoClass &rinfo )
 			it.Peek_Obj()->On_Frame_Update();
 		}
 	}
+
+	if (!Visibility_Checked) {
+		// Build the visible render snapshot after per-frame object updates.
+		Visibility_Check(&rinfo.Camera);
+#ifdef USE_NON_STENCIL_OCCLUSION
+		flagOccludedObjects(&rinfo.Camera);
+#endif
+	}
+	Visibility_Checked = false;
 
 	//terrain needs to be rendered first
 	if (terrainObject)	// Don't check visibility - terrain is always visible. jba.
@@ -1169,28 +1296,24 @@ void RTS3DScene::Customized_Render( RenderInfoClass &rinfo )
 	}
 #endif
 
-	// loop through all render objects in the list:
-	for (it.First(&RenderList); !it.Is_Done();)
+	for (Int visibleIndex = 0; visibleIndex < m_visibleRenderObjectCount; visibleIndex++)
 	{
-		// get the render object
-		robj = it.Peek_Obj();
- 		it.Next();	//advance to next object in case this one gets deleted during renderOneObject().
-
-		if (robj->Class_ID() == RenderObjClass::CLASSID_TILEMAP)
-			continue;	//we already rendered terrain
-
-		if (robj->Is_Really_Visible()) {
-			DrawableInfo *drawInfo = (DrawableInfo *)robj->Get_User_Data();
-			Drawable *draw=nullptr;
-			if (drawInfo)
-				draw = drawInfo->m_drawable;
-#ifdef USE_NON_STENCIL_OCCLUSION
-			if (!(draw && drawInfo->m_flags & DrawableInfo::ERF_DELAYED_RENDER))	//model rendering is delayed for some reason until end of normal scene
-#else
-			if (!(draw && drawInfo->m_flags & (DrawableInfo::ERF_DELAYED_RENDER|DrawableInfo::ERF_POTENTIAL_OCCLUDER|DrawableInfo::ERF_IS_NON_OCCLUDER_OR_OCCLUDEE)))	//in this mode we delay almost all objects in order to do correct sorting with stencil.
-#endif
-				renderOneObject(rinfo, robj, localPlayerIndex);
+		const FrameRenderEntry &entry = m_visibleRenderEntries[visibleIndex];
+		robj = entry.m_renderObject;
+		if (!robj || !robj->Peek_Scene() || !robj->Is_Really_Visible())
+		{
+			continue;
 		}
+
+		renderOneObject(rinfo, robj, localPlayerIndex, entry.m_drawInfo, entry.m_drawable);
+	}
+
+	// Water queues itself into static sort lists and is safer on the legacy explicit path.
+	if (TheWaterRenderObj && TheWaterRenderObj->Peek_Scene() == this && !TheWaterRenderObj->Is_Hidden())
+	{
+		rinfo.light_environment = nullptr;
+		TheWaterRenderObj->Render(rinfo);
+		rinfo.light_environment = nullptr;
 	}
 
 	//Tell shadow manager to render shadows at the end of this frame

--- a/GeneralsMD/Code/Main/RTS.RC
+++ b/GeneralsMD/Code/Main/RTS.RC
@@ -7,7 +7,7 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include <winres.h>
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS
@@ -34,7 +34,7 @@ END
 
 2 TEXTINCLUDE DISCARDABLE 
 BEGIN
-    "#include ""afxres.h""\r\n"
+    "#include <winres.h>\r\n"
     "\0"
 END
 

--- a/cmake/msvc-atl.cmake
+++ b/cmake/msvc-atl.cmake
@@ -1,0 +1,78 @@
+if(NOT MSVC OR MINGW)
+    return()
+endif()
+
+function(_genzh_get_msvc_toolset_root out_var compiler_path)
+    get_filename_component(_toolset_root "${compiler_path}" DIRECTORY)
+    get_filename_component(_toolset_root "${_toolset_root}" DIRECTORY)
+    get_filename_component(_toolset_root "${_toolset_root}" DIRECTORY)
+    get_filename_component(_toolset_root "${_toolset_root}" DIRECTORY)
+    set(${out_var} "${_toolset_root}" PARENT_SCOPE)
+endfunction()
+
+function(_genzh_add_msvc_atl_paths)
+    _genzh_get_msvc_toolset_root(_current_toolset_root "${CMAKE_CXX_COMPILER}")
+
+    set(_current_atl_include "${_current_toolset_root}/atlmfc/include")
+    if(EXISTS "${_current_atl_include}/atlbase.h")
+        message(STATUS "MSVC ATL found in active toolset: ${_current_atl_include}")
+        include_directories(BEFORE SYSTEM "${_current_atl_include}")
+        string(APPEND CMAKE_RC_FLAGS " /I\"${_current_atl_include}\"")
+        if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+            link_directories("${_current_toolset_root}/atlmfc/lib/x64")
+        else()
+            link_directories("${_current_toolset_root}/atlmfc/lib/x86")
+        endif()
+        return()
+    endif()
+
+    set(_atl_arch "x86")
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+        set(_atl_arch "x64")
+    endif()
+
+    get_filename_component(_current_toolset_version "${_current_toolset_root}" NAME)
+    set(_atl_candidate_include "")
+    set(_atl_candidate_lib "")
+
+    file(GLOB _msvc_toolset_candidates LIST_DIRECTORIES TRUE
+        "C:/Program Files/Microsoft Visual Studio/*/*/VC/Tools/MSVC/*"
+        "C:/Program Files (x86)/Microsoft Visual Studio/*/*/VC/Tools/MSVC/*")
+
+    foreach(_candidate_root IN LISTS _msvc_toolset_candidates)
+        if(NOT EXISTS "${_candidate_root}/atlmfc/include/atlbase.h")
+            continue()
+        endif()
+        if(NOT EXISTS "${_candidate_root}/atlmfc/lib/${_atl_arch}/atls.lib")
+            continue()
+        endif()
+
+        get_filename_component(_candidate_version "${_candidate_root}" NAME)
+        if(_candidate_version STREQUAL _current_toolset_version)
+            set(_atl_candidate_include "${_candidate_root}/atlmfc/include")
+            set(_atl_candidate_lib "${_candidate_root}/atlmfc/lib/${_atl_arch}")
+            break()
+        endif()
+
+        if(_atl_candidate_include STREQUAL "")
+            set(_atl_candidate_include "${_candidate_root}/atlmfc/include")
+            set(_atl_candidate_lib "${_candidate_root}/atlmfc/lib/${_atl_arch}")
+        endif()
+    endforeach()
+
+    if(_atl_candidate_include STREQUAL "" OR _atl_candidate_lib STREQUAL "")
+        message(FATAL_ERROR
+            "MSVC ATL headers/libs were not found.\n"
+            "Compiler toolset: ${_current_toolset_root}\n"
+            "Expected header: ${_current_toolset_root}/atlmfc/include/atlbase.h\n"
+            "Install the Visual Studio ATL/MFC component, or provide a VS toolset installation that contains atlmfc.")
+    endif()
+
+    message(STATUS "MSVC ATL fallback include: ${_atl_candidate_include}")
+    message(STATUS "MSVC ATL fallback lib: ${_atl_candidate_lib}")
+    include_directories(BEFORE SYSTEM "${_atl_candidate_include}")
+    string(APPEND CMAKE_RC_FLAGS " /I\"${_atl_candidate_include}\"")
+    link_directories("${_atl_candidate_lib}")
+endfunction()
+
+_genzh_add_msvc_atl_paths()


### PR DESCRIPTION
This commit introduces a new CMake script that checks for the presence of the Microsoft Visual C++ (MSVC) Active Template Library (ATL) and adds the necessary include and library paths to the build configuration. The script verifies the toolset version and falls back to searching for ATL in common installation directories if not found in the active toolset. This enhancement ensures that projects using ATL can be built correctly with the appropriate dependencies.