### PR TITLE
perf(scene): Create light list iterators on the stack at points of use

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/BaseHeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/BaseHeightMap.cpp
@@ -2135,12 +2135,9 @@ Int BaseHeightMapRenderObjClass::getStaticDiffuse(Int x, Int y)
 
 	RTS3DScene *pMyScene = (RTS3DScene *)Scene;
 	if (pMyScene) {
-		RefRenderObjListIterator *it = pMyScene->createLightsIterator();
-		doTheLight(&vertex, lightRay, &normalAtTexel, it, 1.0f);
-		if (it) {
-		 pMyScene->destroyLightsIterator(it);
-		 it = nullptr;
-		}
+		RefRenderObjListClass *lightlist = pMyScene->getLightList();
+		RefRenderObjListIterator it(lightlist);
+		doTheLight(&vertex, lightRay, &normalAtTexel, &it, 1.0f);
 	} else {
 		doTheLight(&vertex, lightRay, &normalAtTexel, nullptr, 1.0f);
 	}

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTerrainVisual.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTerrainVisual.cpp
@@ -606,27 +606,39 @@ Bool W3DTerrainVisual::load( AsciiString filename )
 		pMapObj = pMapObj->getNext();
 	}
 
-
-	RefRenderObjListIterator *it = W3DDisplay::m_3DScene ? W3DDisplay::m_3DScene->createLightsIterator() : nullptr;
 	// apply the heightmap to the terrain render object
+	if (W3DDisplay::m_3DScene != nullptr)
+	{
+		RefRenderObjListClass* lightlist = W3DDisplay::m_3DScene->getLightList();
+		RefRenderObjListIterator it(lightlist);
 
 #ifdef DO_SEISMIC_SIMULATIONS
-	m_terrainRenderObject->initHeightData( m_clientHeightMap->getDrawWidth(),
-																				 m_clientHeightMap->getDrawHeight(),
-																				 m_clientHeightMap,
-																				 it);
+		m_terrainRenderObject->initHeightData(m_clientHeightMap->getDrawWidth(),
+			m_clientHeightMap->getDrawHeight(),
+			m_clientHeightMap,
+			&it);
 #else
-	m_terrainRenderObject->initHeightData( m_logicHeightMap->getDrawWidth(),
-																				 m_logicHeightMap->getDrawHeight(),
-																				 m_logicHeightMap,
-																				 it);
+		m_terrainRenderObject->initHeightData(m_logicHeightMap->getDrawWidth(),
+			m_logicHeightMap->getDrawHeight(),
+			m_logicHeightMap,
+			&it);
 #endif
-
-
-	if (it) {
-	 W3DDisplay::m_3DScene->destroyLightsIterator(it);
-	 it = nullptr;
 	}
+	else
+	{
+#ifdef DO_SEISMIC_SIMULATIONS
+		m_terrainRenderObject->initHeightData(m_clientHeightMap->getDrawWidth(),
+			m_clientHeightMap->getDrawHeight(),
+			m_clientHeightMap,
+			nullptr);
+#else
+		m_terrainRenderObject->initHeightData(m_logicHeightMap->getDrawWidth(),
+			m_logicHeightMap->getDrawHeight(),
+			m_logicHeightMap,
+			nullptr);
+#endif
+	}
+
 	// add our terrain render object to the scene
 	if (W3DDisplay::m_3DScene != nullptr)
 		W3DDisplay::m_3DScene->Add_Render_Object( m_terrainRenderObject );

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -3749,14 +3749,9 @@ void W3DView::updateTerrain()
 		TheTerrainRenderObject->setTerrainDrawSize(drawSize.x, drawSize.y);
 	}
 
-	RefRenderObjListIterator *it = W3DDisplay::m_3DScene->createLightsIterator();
+	RefRenderObjListClass* lightlist = W3DDisplay::m_3DScene->getLightList();
+	RefRenderObjListIterator it(lightlist);
 
 	const Vector3 cameraPivot(m_pos.x, m_pos.y, m_pos.z);
-	TheTerrainRenderObject->updateCenter(m_3DCamera, &cameraPivot, it);
-
-	if (it)
-	{
-		W3DDisplay::m_3DScene->destroyLightsIterator(it);
-		it = nullptr;
-	}
+	TheTerrainRenderObject->updateCenter(m_3DCamera, &cameraPivot, &it);
 }

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DScene.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DScene.h
@@ -85,12 +85,11 @@ public:
 	/// Lighting methods
 	void addDynamicLight(W3DDynamicLight * obj);
 	void removeDynamicLight(W3DDynamicLight * obj);
-	RefRenderObjListIterator *createLightsIterator();
-	void destroyLightsIterator(RefRenderObjListIterator * it);
 	RefRenderObjListClass *getDynamicLights() {return &m_dynamicLightList;};
 	W3DDynamicLight *getADynamicLight();
 	void setGlobalLight(LightClass *pLight,Int lightIndex=0);
 	LightEnvironmentClass &getDefaultLightEnv() {return m_defaultLightEnv;}
+	RefRenderObjListClass* getLightList() { return &LightList; }
 
 	virtual void init() override {}
 	virtual void update() override {}

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DScene.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DScene.cpp
@@ -1597,29 +1597,6 @@ void RTS3DScene::flushTranslucentObjects(RenderInfoClass & rinfo)
 }
 
 //=============================================================================
-// RTS3DScene::createLightsIterator
-//=============================================================================
-/** Returns an iterator of the lights in the scene. */
-//=============================================================================
-RefRenderObjListIterator * RTS3DScene::createLightsIterator()
-{
-	RefRenderObjListIterator * it = NEW RefRenderObjListIterator(&LightList);	// poolify
-	return it;
-}
-
-
-//=============================================================================
-// RTS3DScene::destroyLightsIterator
-//=============================================================================
-/** Destroys the iterator returned by createLightsIterator. */
-//=============================================================================
-void RTS3DScene::destroyLightsIterator(RefRenderObjListIterator * it)
-{
-	delete it;
-}
-
-
-//=============================================================================
 // RTS3DScene::addDynamicLight
 //=============================================================================
 /** Adds a dynamic light. */

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DScene.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DScene.h
@@ -85,12 +85,11 @@ public:
 	/// Lighting methods
 	void addDynamicLight(W3DDynamicLight * obj);
 	void removeDynamicLight(W3DDynamicLight * obj);
-	RefRenderObjListIterator *createLightsIterator();
-	void destroyLightsIterator(RefRenderObjListIterator * it);
 	RefRenderObjListClass *getDynamicLights() {return &m_dynamicLightList;};
 	W3DDynamicLight *getADynamicLight();
 	void setGlobalLight(LightClass *pLight,Int lightIndex=0);
 	LightEnvironmentClass &getDefaultLightEnv() {return m_defaultLightEnv;}
+	RefRenderObjListClass* getLightList() { return &LightList; }
 
 	virtual void init() override {}
 	virtual void update() override {}

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DScene.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DScene.cpp
@@ -1669,29 +1669,6 @@ void RTS3DScene::flushTranslucentObjects(RenderInfoClass & rinfo)
 }
 
 //=============================================================================
-// RTS3DScene::createLightsIterator
-//=============================================================================
-/** Returns an iterator of the lights in the scene. */
-//=============================================================================
-RefRenderObjListIterator * RTS3DScene::createLightsIterator()
-{
-	RefRenderObjListIterator * it = NEW RefRenderObjListIterator(&LightList);	// poolify
-	return it;
-}
-
-
-//=============================================================================
-// RTS3DScene::destroyLightsIterator
-//=============================================================================
-/** Destroys the iterator returned by createLightsIterator. */
-//=============================================================================
-void RTS3DScene::destroyLightsIterator(RefRenderObjListIterator * it)
-{
-	delete it;
-}
-
-
-//=============================================================================
 // RTS3DScene::addDynamicLight
 //=============================================================================
 /** Adds a dynamic light. */


### PR DESCRIPTION
This PR helps with a performance issue caused by a non block allocated, heap based, memory allocation that occurs multiple times every frame.

`BaseHeightMapRenderObjClass::getStaticDiffuse()` was calling `RTS3DScene::createLightsIterator()` and `destroyLightsIterator(RefRenderObjListIterator * it)` to retrieve the `LightList` from the current `RTS3DScene`.

Since the `RefRenderObjListIterator` is not properly poolified in the W3D or GameMemory managers, it was causing the game memory manager to constantly acquire, zero, then release system memory.

In this tweak i added an extra function in `RTS3DScene` to retrieve a pointer to the `LightList` instead.
This then allowed a stack created `RefRenderObjListIterator` to be created within `BaseHeightMapRenderObjClass::getStaticDiffuse()` instead.

This then resulted in a 20-40% performance improvement at the start of the game depending on map.

EDIT:

I have updated this to also remove the create and destroy iterator functions. I then upated all current call sites to use a stack created iterator where necessary or removed using the iterator if it was unused.