### PR TITLE
feat(replay): Check CRC messages from all players in replays

### DIFF
--- a/Core/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/Core/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -2383,6 +2383,9 @@ bool GameLogic::onLogicCrc(MAYBE_UNUSED GameMessage *msg)
 	Player *msgPlayer = getMessagePlayer(msg);
 	if (TheNetwork)
 	{
+		if (TheNetwork->sawCRCMismatch())
+			return false;
+
 		Int slotIndex = -1;
 		for (Int i=0; i<MAX_SLOTS; ++i)
 		{
@@ -2401,17 +2404,14 @@ bool GameLogic::onLogicCrc(MAYBE_UNUSED GameMessage *msg)
 #if defined(RTS_DEBUG)
 			// don't even put this in release, cause someone might hack it.
 			if (!TheDebugIgnoreSyncErrors)
-			{
 #endif
-				m_shouldValidateCRCs = TRUE;
-#if defined(RTS_DEBUG)
-			}
-#endif
+				m_validationModeCRC = CRCMODE_NETWORK;
 		}
 
-		UnsignedInt newCRC = msg->getArgument(0)->integer;
+		const UnsignedInt newCRC = msg->getArgument(0)->integer;
 		//DEBUG_LOG(("Received CRC of %8.8X from %ls on frame %d", newCRC,
 			//msgPlayer->getPlayerDisplayName().str(), m_frame));
+
 		m_cachedCRCs[msgPlayer->getPlayerIndex()] = newCRC;
 	}
 	else if (TheRecorder && TheRecorder->isPlaybackMode())
@@ -2421,17 +2421,23 @@ bool GameLogic::onLogicCrc(MAYBE_UNUSED GameMessage *msg)
 			("CRC message origin is unexpected; playback message argument doesn't match message player index"));
 #endif
 
-		UnsignedInt newCRC = msg->getArgument(0)->integer;
-		//DEBUG_LOG(("Saw CRC of %X from player %d.  Our CRC is %X.  Arg count is %d",
+		if (TheRecorder->sawCRCMismatch())
+			return false;
+
+		const UnsignedInt newCRC = msg->getArgument(0)->integer;
+		//DEBUG_LOG(("Saw CRC of %X from player %d. Our CRC is %X. Arg count is %d",
 			//newCRC, msgPlayer->getPlayerIndex(), getCRC(), msg->getArgumentCount()));
 
 		if (msgPlayer->isLocalPlayer())
 		{
-			TheRecorder->handleCRCMessage(newCRC, msgPlayer->getPlayerIndex(), true);
+			// TheSuperHackers @info The replay observer / playback player is the local player during playback mode.
+			TheRecorder->handlePlaybackCRCMessage(newCRC);
 		}
 		else
 		{
-			TheRecorder->handleCRCMessage(newCRC, msgPlayer->getPlayerIndex(), false);
+			TheRecorder->handlePlayerCRCMessage(msgPlayer->getPlayerIndex(), newCRC);
+
+			m_validationModeCRC = CRCMODE_REPLAY;
 		}
 	}
 

--- a/Core/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/Core/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -2416,11 +2416,23 @@ bool GameLogic::onLogicCrc(MAYBE_UNUSED GameMessage *msg)
 	}
 	else if (TheRecorder && TheRecorder->isPlaybackMode())
 	{
+#if RETAIL_COMPATIBLE_CRC
+		DEBUG_ASSERTCRASH(msg->getArgument(1)->boolean == msgPlayer->isLocalPlayer(),
+			("CRC message origin is unexpected; playback message argument doesn't match message player index"));
+#endif
+
 		UnsignedInt newCRC = msg->getArgument(0)->integer;
 		//DEBUG_LOG(("Saw CRC of %X from player %d.  Our CRC is %X.  Arg count is %d",
 			//newCRC, msgPlayer->getPlayerIndex(), getCRC(), msg->getArgumentCount()));
 
-		TheRecorder->handleCRCMessage(newCRC, msgPlayer->getPlayerIndex(), (msg->getArgument(1)->boolean));
+		if (msgPlayer->isLocalPlayer())
+		{
+			TheRecorder->handleCRCMessage(newCRC, msgPlayer->getPlayerIndex(), true);
+		}
+		else
+		{
+			TheRecorder->handleCRCMessage(newCRC, msgPlayer->getPlayerIndex(), false);
+		}
 	}
 
 	return true;

--- a/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
@@ -367,6 +367,8 @@ public:
 	Bool m_afterIntro;								///< we need to tell the game our intro is done
 	Bool m_allowExitOutOfMovies;			///< flag to allow exit out of movies only after the Intro has played
 
+	Bool m_replayOnlyCheckLocalPlayer; ///< flag to check only the CRC messages from the player that recorded a replay
+
 	Bool m_loadScreenRender;						///< flag to disallow rendering of almost everything during a loadscreen
 
 	Real m_keyboardScrollFactor;			///< Factor applied to game scrolling speed via keyboard scrolling

--- a/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
@@ -368,6 +368,8 @@ public:
 	Bool m_afterIntro;								///< we need to tell the game our intro is done
 	Bool m_allowExitOutOfMovies;			///< flag to allow exit out of movies only after the Intro has played
 
+	Bool m_replayLocalPlayerCRC;			///< flag to validate CRC messages only from the player who recorded a replay
+
 	Bool m_loadScreenRender;						///< flag to disallow rendering of almost everything during a loadscreen
 
 	Real m_keyboardScrollFactor;			///< Factor applied to game scrolling speed via keyboard scrolling

--- a/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GlobalData.h
@@ -368,8 +368,6 @@ public:
 	Bool m_afterIntro;								///< we need to tell the game our intro is done
 	Bool m_allowExitOutOfMovies;			///< flag to allow exit out of movies only after the Intro has played
 
-	Bool m_replayLocalPlayerCRC;			///< flag to validate CRC messages only from the player who recorded a replay
-
 	Bool m_loadScreenRender;						///< flag to disallow rendering of almost everything during a loadscreen
 
 	Real m_keyboardScrollFactor;			///< Factor applied to game scrolling speed via keyboard scrolling
@@ -380,6 +378,8 @@ public:
 	Bool m_animateWindows;						///< Should we animate window transitions?
 
 	Bool m_incrementalAGPBuf;
+
+	UnsignedByte m_replayCRCCheckMode;///< flag to control whose CRC messages are allowed to trigger a mismatch during replay playback
 
 	UnsignedInt m_iniCRC;							///< CRC of important INI files
 	UnsignedInt m_exeCRC;							///< CRC of the executable

--- a/GeneralsMD/Code/GameEngine/Include/Common/Player.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Player.h
@@ -221,7 +221,7 @@ public:
 
 	void deletePlayerAI();
 
-	UnicodeString getPlayerDisplayName() { return m_playerDisplayName; }
+	UnicodeString getPlayerDisplayName() const { return m_playerDisplayName; }
 	NameKeyType getPlayerNameKey() const { return m_playerNameKey; }
 
 	AsciiString getSide() const { return m_side; }

--- a/GeneralsMD/Code/GameEngine/Include/Common/Recorder.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Recorder.h
@@ -53,7 +53,61 @@ enum RecorderModeType CPP_11(: Int) {
 	RECORDERMODETYPE_NONE // this is a valid state to be in on the shell map, or in saved games
 };
 
-class CRCInfo;
+// TheSuperHackers @info helmutbuhler 03/04/2025
+// Some info about CRC:
+// In each game, each peer periodically calculates a CRC from the local gamestate and sends that
+// in a message to all peers (including itself) so that everyone can check that the crc is synchronous.
+// In a network game, there is a delay between sending the CRC message and receiving it. This is
+// necessary because if you were to wait each frame for all messages from all peers, things would go
+// horribly slow.
+// But this delay is not a problem for CRC checking because everyone receives the CRC in the same frame
+// and every peer just makes sure all the received CRCs are equal.
+// While playing replays, this is a problem however: The CRC messages in the replays appear on the frame
+// they were received, which can be a few frames delayed if it was a network game. And if we were to
+// compare those with the local gamestate, they wouldn't sync up.
+// So, in order to fix this, we need to queue up our local CRCs,
+// so that we can check it with the crc messages that come later.
+// This class is basically that queue.
+class CRCInfo
+{
+public:
+	struct MismatchData
+	{
+		MismatchData() :
+			mismatched(FALSE),
+			playerIndex(0),
+			queueSize(0),
+			playbackCRC(0),
+			playerCRC(0)
+		{}
+
+		Bool mismatched;
+		Byte playerIndex;
+		UnsignedShort queueSize;
+		UnsignedInt playbackCRC;
+		UnsignedInt playerCRC;
+	};
+
+	CRCInfo();
+	void init(Bool isMultiplayer, Int localPlayerIndex);
+	void addPlaybackCRC(UnsignedInt val);
+	void addPlayerCRC(Int playerIndex, UnsignedInt val);
+	void setSawCRCMismatch();
+	Bool sawCRCMismatch() const;
+	Byte getLocalPlayerIndex() const;
+	MismatchData getMismatchData();
+
+	static Int getPlayerIndexOffset();
+
+protected:
+	UnsignedInt getLargestPlayerQueueSize() const;
+
+	Bool m_skippedOne;
+	Bool m_sawCRCMismatch;
+	Byte m_localPlayerIndex;
+	std::list<UnsignedInt> m_playbackData;
+	std::list<UnsignedInt> m_playerData[MAX_SLOTS];
+};
 
 class RecorderClass : public SubsystemInterface {
 public:
@@ -84,10 +138,12 @@ public:
 #endif
 	Bool isPlaybackInProgress() const;
 
-public:
-	void handleCRCMessage(UnsignedInt newCRC, Int playerIndex, Bool fromPlayback);
+	void handlePlaybackCRCMessage(UnsignedInt newCRC);
+	void handlePlayerCRCMessage(Int playerIndex, UnsignedInt newCRC);
+	void checkForMismatch();
+
 protected:
-	CRCInfo *m_crcInfo;
+	CRCInfo m_crcInfo;
 public:
 
 	// read in info relating to a replay, conditionally setting up m_file for playback

--- a/GeneralsMD/Code/GameEngine/Include/Common/Recorder.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Recorder.h
@@ -67,20 +67,55 @@ protected:
 	class CRCInfo
 	{
 	public:
+		struct MismatchData
+		{
+			enum CPP_11(: Byte)
+			{
+				PLAYER_PLAYBACK = -1,
+				PLAYER_UNKNOWN  = -2,
+			};
+
+			MismatchData() :
+				mismatched(false),
+				playerIndex(0),
+				queueSize(0),
+				playbackCRC(0),
+				playerCRC(0)
+			{}
+
+			MismatchData(Byte playerIndex, UnsignedShort queueSize, UnsignedInt playbackCRC, UnsignedInt playerCRC) :
+				mismatched(true),
+				playerIndex(playerIndex),
+				queueSize(queueSize),
+				playbackCRC(playbackCRC),
+				playerCRC(playerCRC)
+			{}
+
+			Bool mismatched;
+			Byte playerIndex;
+			UnsignedShort queueSize;
+			UnsignedInt playbackCRC;
+			UnsignedInt playerCRC;
+		};
+
 		CRCInfo();
-		CRCInfo(UnsignedInt localPlayer, Bool isMultiplayer);
-		void addCRC(UnsignedInt val);
-		UnsignedInt readCRC();
-		int GetQueueSize() const { return m_data.size(); }
-		UnsignedInt getLocalPlayer() const { return m_localPlayer; }
-		void setSawCRCMismatch() { m_sawCRCMismatch = TRUE; }
-		Bool sawCRCMismatch() const { return m_sawCRCMismatch; }
+		void init(Bool isMultiplayer, Int localPlayerIndex);
+		void pushPlaybackCRC(UnsignedInt val);
+		void pushPlayerCRC(Int playerIndex, UnsignedInt val);
+		void setSawCRCMismatch();
+		Bool sawCRCMismatch() const;
+		Byte getLocalPlayerIndex() const;
+		MismatchData generateMismatchData();
 
 	protected:
-		Bool m_sawCRCMismatch;
+		UnsignedInt getLargestQueueSize() const;
+		UnsignedInt popPlaybackCRC();
+
 		Bool m_skippedOne;
-		UnsignedInt m_localPlayer;
-		std::list<UnsignedInt> m_data;
+		Bool m_sawCRCMismatch;
+		Byte m_localPlayerIndex;
+		std::list<UnsignedInt> m_playbackData;
+		std::vector<UnsignedInt> m_playerData[MAX_PLAYER_COUNT];
 	};
 
 public:
@@ -110,8 +145,9 @@ public:
 #endif
 	Bool isPlaybackInProgress() const;
 
-public:
-	void handleCRCMessage(UnsignedInt newCRC, Int playerIndex, Bool fromPlayback);
+	void handlePlaybackCRCMessage(UnsignedInt newCRC);
+	void handlePlayerCRCMessage(Int playerIndex, UnsignedInt newCRC);
+	void checkForMismatch();
 
 	// read in info relating to a replay, conditionally setting up m_file for playback
 	struct ReplayHeader

--- a/GeneralsMD/Code/GameEngine/Include/Common/Recorder.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Recorder.h
@@ -66,6 +66,13 @@ protected:
 	// corresponding replay CRC messages arrive. This class implements that queue.
 	class CRCInfo
 	{
+		enum CPP_11(: Byte)
+		{
+			CRC_LOCALPLAYER_SINGLEMISMATCH  =  0, // never ignore mismatch caused by local player (original behavior)
+			CRC_ALLPLAYERS_SINGLEMISMATCH   = -1, // never ignore mismatch caused by any player (default behavior)
+			CRC_ALLPLAYERS_MULTIPLEMISMATCH = -2, // ignore mismatch unless indicated by multiple or all players (optional behavior)
+		};
+
 	public:
 		struct MismatchData
 		{

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/GameLogic.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/GameLogic.h
@@ -293,6 +293,13 @@ private:
 
 private:
 
+	enum CRCValidationMode CPP_11(: UnsignedByte)
+	{
+		CRCMODE_NONE,
+		CRCMODE_NETWORK,
+		CRCMODE_REPLAY,
+	};
+
 	/**
 		overrides to thing template buildable status. doesn't really belong here,
 		but has to go somewhere. (srj)
@@ -312,7 +319,7 @@ private:
 	// CRC cache system -----------------------------------------------------------------------------
 	UnsignedInt	m_CRC;																			///< Cache of previous CRC value
 	std::map<Int, UnsignedInt> m_cachedCRCs;								///< CRCs we've seen this frame
-	Bool m_shouldValidateCRCs;															///< Should we validate CRCs this frame?
+	CRCValidationMode m_shouldValidateCRCs;									///< Should we validate CRCs this frame?
 	//-----------------------------------------------------------------------------------------------
 	//Bool m_loadingScene;
 	Bool m_loadingMap;

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/GameLogic.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/GameLogic.h
@@ -370,6 +370,8 @@ private:
 
 	static void createOptimizedTree(const ThingTemplate *thingTemplate, Coord3D *pos, Real angle);
 
+	void checkForMismatch();
+
 private:
 
 	/**

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/GameLogic.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/GameLogic.h
@@ -374,6 +374,13 @@ private:
 
 private:
 
+	enum CRCValidationMode CPP_11(: UnsignedByte)
+	{
+		CRCMODE_NONE,
+		CRCMODE_NETWORK,
+		CRCMODE_REPLAY,
+	};
+
 	/**
 		overrides to thing template buildable status. doesn't really belong here,
 		but has to go somewhere. (srj)
@@ -394,7 +401,7 @@ private:
 	UnsignedInt	m_CRC;																			///< Cache of previous CRC value
 	typedef std::map<Int, UnsignedInt> CachedCRCMap;
 	CachedCRCMap m_cachedCRCs;															///< CRCs we've seen this frame
-	Bool m_shouldValidateCRCs;															///< Should we validate CRCs this frame?
+	CRCValidationMode m_validationModeCRC;									///< (How) should we validate CRCs this frame?
 	//-----------------------------------------------------------------------------------------------
 	//Bool m_loadingScene;
 	Bool m_loadingMap;

--- a/GeneralsMD/Code/GameEngine/Source/Common/CommandLine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/CommandLine.cpp
@@ -465,6 +465,13 @@ Int parseJobs(char *args[], int num)
 	return 1;
 }
 
+Int parseReplayCRC(char* args[], int num)
+{
+	TheWritableGlobalData->m_replayOnlyCheckLocalPlayer = TRUE;
+
+	return 1;
+}
+
 Int parseXRes(char *args[], int num)
 {
 	if (num > 1)
@@ -1176,6 +1183,9 @@ static CommandLineParam paramsForEngineInit[] =
 
 	// TheSuperHackers @feature xezon 03/08/2025 Force full viewport for 'Control Bar Pro' Addons like GenTool did it.
 	{ "-forcefullviewport", parseFullViewport },
+
+	// TheSuperHackers @feature Caball009 24/04/2026 Enable checking only the CRC messages from the player that recorded a replay.
+	{ "-replayLocalPlayerCRC", parseReplayCRC },
 
 #if defined(RTS_DEBUG)
 	{ "-noaudio", parseNoAudio },

--- a/GeneralsMD/Code/GameEngine/Source/Common/CommandLine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/CommandLine.cpp
@@ -465,6 +465,13 @@ Int parseJobs(char *args[], int num)
 	return 1;
 }
 
+Int parseReplayLocalPlayerCRC(char* args[], int num)
+{
+	TheWritableGlobalData->m_replayLocalPlayerCRC = TRUE;
+
+	return 1;
+}
+
 Int parseXRes(char *args[], int num)
 {
 	if (num > 1)
@@ -1165,6 +1172,9 @@ static CommandLineParam paramsForEngineInit[] =
 
 	// TheSuperHackers @feature xezon 03/08/2025 Force full viewport for 'Control Bar Pro' Addons like GenTool did it.
 	{ "-forcefullviewport", parseFullViewport },
+
+	// TheSuperHackers @feature Caball009 21/06/2026 Validate CRC messages only from the player who recorded a replay.
+	{ "-replayLocalPlayerCRC", parseReplayLocalPlayerCRC },
 
 #if defined(RTS_DEBUG)
 	{ "-noaudio", parseNoAudio },

--- a/GeneralsMD/Code/GameEngine/Source/Common/CommandLine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/CommandLine.cpp
@@ -465,10 +465,13 @@ Int parseJobs(char *args[], int num)
 	return 1;
 }
 
-Int parseReplayLocalPlayerCRC(char* args[], int num)
+Int parseReplayCRCMode(char* args[], int num)
 {
-	TheWritableGlobalData->m_replayLocalPlayerCRC = TRUE;
-
+	if (num > 1)
+	{
+		TheWritableGlobalData->m_replayCRCCheckMode = static_cast<UnsignedByte>(atoi(args[1]));
+		return 2;
+	}
 	return 1;
 }
 
@@ -1173,8 +1176,8 @@ static CommandLineParam paramsForEngineInit[] =
 	// TheSuperHackers @feature xezon 03/08/2025 Force full viewport for 'Control Bar Pro' Addons like GenTool did it.
 	{ "-forcefullviewport", parseFullViewport },
 
-	// TheSuperHackers @feature Caball009 21/06/2026 Validate CRC messages only from the player who recorded a replay.
-	{ "-replayLocalPlayerCRC", parseReplayLocalPlayerCRC },
+	// TheSuperHackers @feature Caball009 21/06/2026 Control whose CRC messages are allowed to trigger a mismatch during replay playback.
+	{ "-replayCRCMode", parseReplayCRCMode },
 
 #if defined(RTS_DEBUG)
 	{ "-noaudio", parseNoAudio },

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -1009,6 +1009,7 @@ GlobalData::GlobalData()
 	m_playSizzle = TRUE;
 	m_afterIntro = FALSE;
 	m_allowExitOutOfMovies = FALSE;
+	m_replayOnlyCheckLocalPlayer = FALSE;
 	m_loadScreenRender = FALSE;
 
 	m_keyboardDefaultScrollFactor = m_keyboardScrollFactor = 0.5f;

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -1014,6 +1014,7 @@ GlobalData::GlobalData()
 	m_playSizzle = TRUE;
 	m_afterIntro = FALSE;
 	m_allowExitOutOfMovies = FALSE;
+	m_replayLocalPlayerCRC = FALSE;
 	m_loadScreenRender = FALSE;
 
 	m_keyboardDefaultScrollFactor = m_keyboardScrollFactor = 0.5f;

--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -1014,7 +1014,6 @@ GlobalData::GlobalData()
 	m_playSizzle = TRUE;
 	m_afterIntro = FALSE;
 	m_allowExitOutOfMovies = FALSE;
-	m_replayLocalPlayerCRC = FALSE;
 	m_loadScreenRender = FALSE;
 
 	m_keyboardDefaultScrollFactor = m_keyboardScrollFactor = 0.5f;
@@ -1025,6 +1024,8 @@ GlobalData::GlobalData()
 	m_enforceMaxCameraHeight = TRUE;
 
 	m_animateWindows = TRUE;
+
+	m_replayCRCCheckMode = 0;
 
 	m_iniCRC = 0;
 	m_exeCRC = 0;

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -102,6 +102,144 @@ static FILE* openStatsLogFile()
 }
 #endif
 
+Int CRCInfo::getPlayerIndexOffset()
+{
+	return 2; // first two slots of PlayerList::m_players are used for neutral and civilian players
+}
+
+CRCInfo::CRCInfo() :
+	m_skippedOne(FALSE),
+	m_sawCRCMismatch(FALSE),
+	m_localPlayerIndex(-1)
+{}
+
+void CRCInfo::init(Bool isMultiplayer, Int localPlayerIndex)
+{
+	DEBUG_ASSERTCRASH((localPlayerIndex >= 0 && localPlayerIndex < MAX_SLOTS) || localPlayerIndex == -1,
+		("replay local player index is unexpected"));
+
+	m_skippedOne = !isMultiplayer;
+	m_sawCRCMismatch = FALSE;
+	m_localPlayerIndex = static_cast<Byte>(localPlayerIndex);
+
+	m_playbackData.clear();
+
+	for (size_t i = 0; i < ARRAY_SIZE(m_playerData); ++i)
+	{
+		m_playerData[i].clear();
+	}
+}
+
+void CRCInfo::addPlaybackCRC(UnsignedInt val)
+{
+	// TheSuperHackers @fix helmutbuhler 03/04/2025
+	// In Multiplayer, the first MSG_LOGIC_CRC message somehow doesn't make it through the network.
+	// Perhaps this happens because the network is not yet set up on frame 0.
+	// So we also don't queue up the first local crc message, otherwise the crc
+	// messages wouldn't match up anymore and we'd desync immediately during playback.
+	if (!m_skippedOne)
+	{
+		m_skippedOne = TRUE;
+		return;
+	}
+
+	m_playbackData.push_back(val);
+	//DEBUG_LOG(("CRCInfo::addPlaybackCRC() - crc %8.8X pushes list to %d entries", val, m_playbackData.size()));
+}
+
+void CRCInfo::addPlayerCRC(Int playerIndex, UnsignedInt val)
+{
+	const UnsignedInt index = static_cast<UnsignedInt>(playerIndex - getPlayerIndexOffset());
+	if (index < ARRAY_SIZE(m_playerData))
+	{
+		m_playerData[index].push_back(val);
+		//DEBUG_LOG(("CRCInfo::addPlayerCRC() - crc %8.8X pushes list to %d entries", val, m_playerData[index].size()));
+	}
+}
+
+void CRCInfo::setSawCRCMismatch()
+{
+	m_sawCRCMismatch = TRUE;
+}
+
+Bool CRCInfo::sawCRCMismatch() const
+{
+	return m_sawCRCMismatch;
+}
+
+Byte CRCInfo::getLocalPlayerIndex() const
+{
+	return m_localPlayerIndex;
+}
+
+CRCInfo::MismatchData CRCInfo::getMismatchData()
+{
+	const UnsignedInt size = getLargestPlayerQueueSize();
+	CRCInfo::MismatchData data;
+
+	for (UnsignedInt j = 0; j < size; ++j)
+	{
+		const UnsignedInt playbackCRC = m_playbackData.empty() ? 0 : m_playbackData.front();
+		if (!m_playbackData.empty())
+		{
+			m_playbackData.pop_front();
+		}
+
+		UnsignedInt playerCount = 0;
+		UnsignedInt mismatchPlayerCount = 0;
+
+		for (Int i = 0; i < ARRAY_SIZE(m_playerData); ++i)
+		{
+			if (m_playerData[i].empty())
+				continue;
+
+			const UnsignedInt playerCRC = m_playerData[i].front();
+			m_playerData[i].pop_front();
+
+			++playerCount;
+
+			if (playbackCRC == playerCRC)
+				continue;
+
+			++mismatchPlayerCount;
+
+			if (!data.mismatched)
+			{
+				if (const Bool isAllowedToSetCRCMismatch = m_localPlayerIndex >= 0 ? i == m_localPlayerIndex : TRUE)
+				{
+					data.mismatched = TRUE;
+					data.playerIndex = static_cast<Byte>(i + getPlayerIndexOffset());
+					data.queueSize = static_cast<UnsignedShort>(m_playbackData.size());
+					data.playbackCRC = playbackCRC;
+					data.playerCRC = playerCRC;
+				}
+			}
+		}
+
+		if (playerCount <= 1 || mismatchPlayerCount >= 2)
+		{
+			data.playerIndex = -1;
+		}
+	}
+
+	return data;
+}
+
+UnsignedInt CRCInfo::getLargestPlayerQueueSize() const
+{
+	UnsignedInt size = 0;
+
+	for (size_t i = 0; i < ARRAY_SIZE(m_playerData); ++i)
+	{
+		if (m_playerData[i].size() > size)
+		{
+			size = m_playerData[i].size();
+		}
+	}
+
+	return size;
+}
+
 void RecorderClass::logGameStart(AsciiString options)
 {
 	if (!m_file)
@@ -937,151 +1075,72 @@ AsciiString RecorderClass::getCurrentReplayFilename()
 	return AsciiString::TheEmptyString;
 }
 
-// TheSuperHackers @info helmutbuhler 03/04/2025
-// Some info about CRC:
-// In each game, each peer periodically calculates a CRC from the local gamestate and sends that
-// in a message to all peers (including itself) so that everyone can check that the crc is synchronous.
-// In a network game, there is a delay between sending the CRC message and receiving it. This is
-// necessary because if you were to wait each frame for all messages from all peers, things would go
-// horribly slow.
-// But this delay is not a problem for CRC checking because everyone receives the CRC in the same frame
-// and every peer just makes sure all the received CRCs are equal.
-// While playing replays, this is a problem however: The CRC messages in the replays appear on the frame
-// they were received, which can be a few frames delayed if it was a network game. And if we were to
-// compare those with the local gamestate, they wouldn't sync up.
-// So, in order to fix this, we need to queue up our local CRCs,
-// so that we can check it with the crc messages that come later.
-// This class is basically that queue.
-class CRCInfo
-{
-public:
-	CRCInfo(UnsignedInt localPlayer, Bool isMultiplayer);
-	void addCRC(UnsignedInt val);
-	UnsignedInt readCRC();
-
-	int GetQueueSize() const { return m_data.size(); }
-
-	UnsignedInt getLocalPlayer() { return m_localPlayer; }
-
-	void setSawCRCMismatch() { m_sawCRCMismatch = TRUE; }
-	Bool sawCRCMismatch() const { return m_sawCRCMismatch; }
-
-protected:
-
-	Bool m_sawCRCMismatch;
-	Bool m_skippedOne;
-	std::list<UnsignedInt> m_data;
-	UnsignedInt m_localPlayer;
-};
-
-CRCInfo::CRCInfo(UnsignedInt localPlayer, Bool isMultiplayer)
-{
-	m_localPlayer = localPlayer;
-	m_skippedOne = !isMultiplayer;
-	m_sawCRCMismatch = FALSE;
-}
-
-void CRCInfo::addCRC(UnsignedInt val)
-{
-	// TheSuperHackers @fix helmutbuhler 03/04/2025
-	// In Multiplayer, the first MSG_LOGIC_CRC message somehow doesn't make it through the network.
-	// Perhaps this happens because the network is not yet set up on frame 0.
-	// So we also don't queue up the first local crc message, otherwise the crc
-	// messages wouldn't match up anymore and we'd desync immediately during playback.
-	if (!m_skippedOne)
-	{
-		m_skippedOne = TRUE;
-		return;
-	}
-
-	m_data.push_back(val);
-	//DEBUG_LOG(("CRCInfo::addCRC() - crc %8.8X pushes list to %d entries (full=%d)", val, m_data.size(), !m_data.empty()));
-}
-
-UnsignedInt CRCInfo::readCRC()
-{
-	if (m_data.empty())
-	{
-		DEBUG_LOG(("CRCInfo::readCRC() - bailing, full=0, size=%d", m_data.size()));
-		return 0;
-	}
-
-	UnsignedInt val = m_data.front();
-	m_data.pop_front();
-	//DEBUG_LOG(("CRCInfo::readCRC() - returning %8.8X, full=%d, size=%d", val, !m_data.empty(), m_data.size()));
-	return val;
-}
-
 Bool RecorderClass::sawCRCMismatch() const
 {
-	return m_crcInfo->sawCRCMismatch();
+	return m_crcInfo.sawCRCMismatch();
 }
 
-void RecorderClass::handleCRCMessage(UnsignedInt newCRC, Int playerIndex, Bool fromPlayback)
+void RecorderClass::handlePlaybackCRCMessage(UnsignedInt newCRC)
 {
-	if (fromPlayback)
-	{
-		//DEBUG_LOG(("RecorderClass::handleCRCMessage() - Adding CRC of %X from %d to m_crcInfo", newCRC, playerIndex));
-		m_crcInfo->addCRC(newCRC);
-		return;
-	}
+	m_crcInfo.addPlaybackCRC(newCRC);
 
-	Int localPlayerIndex = m_crcInfo->getLocalPlayer();
-	Bool samePlayer = FALSE;
-	AsciiString playerName;
-	playerName.format("player%d", localPlayerIndex);
-	const Player *p = ThePlayerList->getNthPlayer(playerIndex);
-	if (!p || (p->getPlayerNameKey() == NAMEKEY(playerName)))
-		samePlayer = TRUE;
-	if (samePlayer || (localPlayerIndex < 0))
+	//DEBUG_LOG(("RecorderClass::handlePlaybackCRCMessage() - Adding CRC of %X from playback to m_crcInfo", newCRC));
+}
+
+void RecorderClass::handlePlayerCRCMessage(Int playerIndex, UnsignedInt newCRC)
+{
+	m_crcInfo.addPlayerCRC(playerIndex, newCRC);
+
+	//DEBUG_LOG(("RecorderClass::handlePlayerCRCMessage() - Adding CRC of %X from %d to m_crcInfo", newCRC, playerIndex));
+}
+
+void RecorderClass::checkForMismatch()
+{
+	const CRCInfo::MismatchData data = m_crcInfo.getMismatchData();
+	if (data.mismatched)
 	{
-		UnsignedInt playbackCRC = m_crcInfo->readCRC();
-		//DEBUG_LOG(("RecorderClass::handleCRCMessage() - Comparing CRCs of InGame:%8.8X Replay:%8.8X Frame:%d from Player %d",
-		//	playbackCRC, newCRC, TheGameLogic->getFrame()-m_crcInfo->GetQueueSize()-1, playerIndex));
-		if (TheGameLogic->getFrame() > 0 && newCRC != playbackCRC && !m_crcInfo->sawCRCMismatch())
+		// Kris: Patch 1.01 November 10, 2003 (integrated changes from Matt Campbell)
+		// Since we don't seem to have any *visible* desyncs when replaying games, but get this warning
+		// virtually every replay, the assumption is our CRC checking is faulty. Since we're at the
+		// tail end of patch season, let's just disable the message, and hope the users believe the
+		// problem is fixed. -MDC 3/20/2003
+		//
+		// TheSuperHackers @tweak helmutbuhler 03/04/2025
+		// More than 20 years later, but finally fixed and re-enabled!
+		TheInGameUI->message("GUI:CRCMismatch");
+
+		// TheSuperHackers @info helmutbuhler 03/04/2025
+		// Note: We subtract the queue size from the frame number. This way we calculate the correct frame
+		// the mismatch first happened in case the NetCRCInterval is set to 1 during the game.
+		const UnsignedInt mismatchFrame = TheGameLogic->getFrame() - data.queueSize - 1;
+
+		// Now also prints a UI message for it.
+		const Player* player = ThePlayerList->getNthPlayer(data.playerIndex);
+		const UnicodeString mismatchDetailsStr = TheGameText->FETCH_OR_SUBSTITUTE("GUI:CRCMismatchDetails",
+			L"InGame:%8.8X Replay:%8.8X Frame:%d Player:%ls");
+		TheInGameUI->message(mismatchDetailsStr, data.playbackCRC, data.playerCRC, mismatchFrame,
+			player ? player->getPlayerDisplayName().str() : L"Unknown");
+
+		DEBUG_LOG(("Replay has gone out of sync!\nInGame:%8.8X Replay:%8.8X\nFrame:%d\nPlayer:%ls",
+			data.playbackCRC, data.playerCRC, mismatchFrame, player ? player->getPlayerDisplayName().str() : L"Unknown"));
+
+		// Print Mismatch in case we are simulating replays from console.
+		printf("CRC Mismatch in Frame %d, Local PlayerIndex %d, Mismatch PlayerIndex %d\n",
+			mismatchFrame, m_crcInfo.getLocalPlayerIndex(), data.playerIndex == -1 ? -1 : data.playerIndex - m_crcInfo.getPlayerIndexOffset());
+
+		// TheSuperHackers @tweak Pause the game on mismatch.
+		// But not when a window with focus is opened, because that can make resuming difficult.
+		if (TheWindowManager->winGetFocus() == nullptr)
 		{
-			//Kris: Patch 1.01 November 10, 2003 (integrated changes from Matt Campbell)
-			// Since we don't seem to have any *visible* desyncs when replaying games, but get this warning
-			// virtually every replay, the assumption is our CRC checking is faulty.  Since we're at the
-			// tail end of patch season, let's just disable the message, and hope the users believe the
-			// problem is fixed. -MDC 3/20/2003
-			//
-			// TheSuperHackers @tweak helmutbuhler 03/04/2025
-			// More than 20 years later, but finally fixed and re-enabled!
-			TheInGameUI->message("GUI:CRCMismatch");
+			const Bool pause = TRUE;
+			const Bool pauseMusic = FALSE;
+			const Bool pauseInput = FALSE;
+			TheGameLogic->setGamePaused(pause, pauseMusic, pauseInput);
 
-			// TheSuperHackers @info helmutbuhler 03/04/2025
-			// Note: We subtract the queue size from the frame number. This way we calculate the correct frame
-			// the mismatch first happened in case the NetCRCInterval is set to 1 during the game.
-			const UnsignedInt mismatchFrame = TheGameLogic->getFrame() - m_crcInfo->GetQueueSize() - 1;
-
-			// Now also prints a UI message for it.
-			const UnicodeString mismatchDetailsStr = TheGameText->FETCH_OR_SUBSTITUTE("GUI:CRCMismatchDetails", L"InGame:%8.8X Replay:%8.8X Frame:%d");
-			TheInGameUI->message(mismatchDetailsStr, playbackCRC, newCRC, mismatchFrame);
-
-			DEBUG_LOG(("Replay has gone out of sync!\nInGame:%8.8X Replay:%8.8X\nFrame:%d",
-				playbackCRC, newCRC, mismatchFrame));
-
-			// Print Mismatch in case we are simulating replays from console.
-			printf("CRC Mismatch in Frame %d\n", mismatchFrame);
-
-			// TheSuperHackers @tweak Pause the game on mismatch.
-			// But not when a window with focus is opened, because that can make resuming difficult.
-			if (TheWindowManager->winGetFocus() == nullptr)
-			{
-				Bool pause = TRUE;
-				Bool pauseMusic = FALSE;
-				Bool pauseInput = FALSE;
-				TheGameLogic->setGamePaused(pause, pauseMusic, pauseInput);
-
-				// Mark this mismatch as seen when we had the chance to pause once.
-				m_crcInfo->setSawCRCMismatch();
-			}
+			// Mark this mismatch as seen when we had the chance to pause once.
+			m_crcInfo.setSawCRCMismatch();
 		}
-		return;
 	}
-
-	//DEBUG_LOG(("RecorderClass::handleCRCMessage() - Skipping CRC of %8.8X from %d (our index is %d)", newCRC, playerIndex, localPlayerIndex));
 }
 
 /**
@@ -1197,9 +1256,9 @@ Bool RecorderClass::playbackFile(AsciiString filename)
 #endif
 
 	Bool isMultiplayer = m_gameInfo.getSlot(header.localPlayerIndex)->getIP() != 0;
-	m_crcInfo = NEW CRCInfo(header.localPlayerIndex, isMultiplayer);
+	m_crcInfo.init(isMultiplayer, TheGlobalData->m_replayOnlyCheckLocalPlayer ? header.localPlayerIndex : -1);
 	REPLAY_CRC_INTERVAL = m_gameInfo.getCRCInterval();
-	DEBUG_LOG(("Player index is %d, replay CRC interval is %d", m_crcInfo->getLocalPlayer(), REPLAY_CRC_INTERVAL));
+	DEBUG_LOG(("Player index is %d, replay CRC interval is %d", header.localPlayerIndex, REPLAY_CRC_INTERVAL));
 
 	Int difficulty = 0;
 	m_file->read(&difficulty, sizeof(difficulty));

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -103,19 +103,31 @@ static FILE* openStatsLogFile()
 RecorderClass::CRCInfo::CRCInfo() :
 	m_skippedOne(false),
 	m_sawCRCMismatch(false),
-	m_localPlayerIndex(-1)
+	m_localPlayerIndex(CRC_ALLPLAYERS_SINGLEMISMATCH)
 {
 	static_assert(ARRAY_SIZE(m_playerData) == MAX_PLAYER_COUNT, "array size must be equal to player count");
 }
 
 void RecorderClass::CRCInfo::init(Bool isMultiplayer, Int localPlayerIndex)
 {
-	DEBUG_ASSERTCRASH((localPlayerIndex >= 0 && localPlayerIndex < MAX_PLAYER_COUNT) || localPlayerIndex == -1,
+	DEBUG_ASSERTCRASH((localPlayerIndex >= 0 && localPlayerIndex < MAX_PLAYER_COUNT),
 		("replay local player index is unexpected"));
 
 	m_skippedOne = !isMultiplayer;
 	m_sawCRCMismatch = false;
-	m_localPlayerIndex = static_cast<Byte>(localPlayerIndex);
+
+	if (TheGlobalData->m_replayCRCCheckMode == 2)
+	{
+		m_localPlayerIndex = static_cast<Byte>(localPlayerIndex);
+	}
+	else if (TheGlobalData->m_replayCRCCheckMode == 1)
+	{
+		m_localPlayerIndex = CRC_ALLPLAYERS_MULTIPLEMISMATCH;
+	}
+	else
+	{
+		m_localPlayerIndex = CRC_ALLPLAYERS_SINGLEMISMATCH;
+	}
 
 	m_playbackData.clear();
 
@@ -139,18 +151,18 @@ void RecorderClass::CRCInfo::pushPlaybackCRC(UnsignedInt val)
 	}
 
 	m_playbackData.push_back(val);
-	//DEBUG_LOG(("CRCInfo::addPlaybackCRC() - crc %8.8X pushes list to %d entries", val, m_playbackData.size()));
+	//DEBUG_LOG(("CRCInfo::pushPlaybackCRC() - crc %8.8X pushes list to %d entries", val, m_playbackData.size()));
 }
 
 void RecorderClass::CRCInfo::pushPlayerCRC(Int playerIndex, UnsignedInt val)
 {
-	if (const Bool isAllowedToAddPlayerCRC = (m_localPlayerIndex < 0 || playerIndex == m_localPlayerIndex))
+	if (const Bool isAllowedToAddPlayerCRC = (m_localPlayerIndex < CRC_LOCALPLAYER_SINGLEMISMATCH || playerIndex == m_localPlayerIndex))
 	{
 		const UnsignedInt index = static_cast<UnsignedInt>(playerIndex);
 		if (index < ARRAY_SIZE(m_playerData))
 		{
 			m_playerData[index].push_back(val);
-			//DEBUG_LOG(("CRCInfo::addPlayerCRC() - crc %8.8X pushes list to %d entries", val, m_playerData[index].size()));
+			//DEBUG_LOG(("CRCInfo::pushPlayerCRC() - crc %8.8X pushes list to %d entries", val, m_playerData[index].size()));
 		}
 	}
 }
@@ -202,22 +214,30 @@ RecorderClass::CRCInfo::MismatchData RecorderClass::CRCInfo::generateMismatchDat
 
 		if (mmData.mismatched)
 		{
-			if (const Bool allPlayersMismatch = (playerCount >= 2 && playerCount == mismatchPlayerCount))
+			const Bool ignoreMismatch = (m_localPlayerIndex == CRC_ALLPLAYERS_MULTIPLEMISMATCH && playerCount >= 2 && mismatchPlayerCount <= 1);
+			if (ignoreMismatch)
 			{
-				mmData.playerIndex = CRCInfo::MismatchData::PLAYER_PLAYBACK;
+				mmData.mismatched = FALSE;
 			}
-			else if (const Bool cannotAttributeMismatch = (playerCount <= 1 || mismatchPlayerCount >= 2))
+			else
 			{
-				mmData.playerIndex = CRCInfo::MismatchData::PLAYER_UNKNOWN;
-			}
+				if (const Bool allPlayersMismatch = (playerCount >= 2 && playerCount == mismatchPlayerCount))
+				{
+					mmData.playerIndex = CRCInfo::MismatchData::PLAYER_PLAYBACK;
+				}
+				else if (const Bool cannotAttributeMismatch = (playerCount <= 1 || mismatchPlayerCount >= 2))
+				{
+					mmData.playerIndex = CRCInfo::MismatchData::PLAYER_UNKNOWN;
+				}
 
-			// leave the playback data in a valid state in case the caller ignores the mismatch
-			while (!m_playbackData.empty() && ++j < largestQueueSize)
-			{
-				m_playbackData.pop_front();
-			}
+				// leave the playback data in a valid state in case the caller ignores the mismatch
+				while (!m_playbackData.empty() && ++j < largestQueueSize)
+				{
+					m_playbackData.pop_front();
+				}
 
-			break;
+				break;
+			}
 		}
 	}
 
@@ -1271,8 +1291,8 @@ Bool RecorderClass::playbackFile(AsciiString filename)
 	}
 #endif
 
-	Bool isMultiplayer = m_gameInfo.getSlot(header.localPlayerIndex)->getIP() != 0;
-	m_crcInfo.init(isMultiplayer, TheGlobalData->m_replayLocalPlayerCRC ? header.localPlayerIndex : -1);
+	const Bool isMultiplayer = m_gameInfo.getSlot(header.localPlayerIndex)->getIP() != 0;
+	m_crcInfo.init(isMultiplayer, header.localPlayerIndex);
 	REPLAY_CRC_INTERVAL = m_gameInfo.getCRCInterval();
 	DEBUG_LOG(("Player index is %d, replay CRC interval is %d", header.localPlayerIndex, REPLAY_CRC_INTERVAL));
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -1272,7 +1272,7 @@ Bool RecorderClass::playbackFile(AsciiString filename)
 #endif
 
 	Bool isMultiplayer = m_gameInfo.getSlot(header.localPlayerIndex)->getIP() != 0;
-	m_crcInfo.init(isMultiplayer, -1);
+	m_crcInfo.init(isMultiplayer, TheGlobalData->m_replayLocalPlayerCRC ? header.localPlayerIndex : -1);
 	REPLAY_CRC_INTERVAL = m_gameInfo.getCRCInterval();
 	DEBUG_LOG(("Player index is %d, replay CRC interval is %d", header.localPlayerIndex, REPLAY_CRC_INTERVAL));
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -101,19 +101,31 @@ static FILE* openStatsLogFile()
 #endif
 
 RecorderClass::CRCInfo::CRCInfo() :
-	m_sawCRCMismatch(FALSE),
-	m_skippedOne(FALSE),
-	m_localPlayer(0)
-{}
-
-RecorderClass::CRCInfo::CRCInfo(UnsignedInt localPlayer, Bool isMultiplayer)
+	m_skippedOne(false),
+	m_sawCRCMismatch(false),
+	m_localPlayerIndex(-1)
 {
-	m_sawCRCMismatch = FALSE;
-	m_skippedOne = !isMultiplayer;
-	m_localPlayer = localPlayer;
+	static_assert(ARRAY_SIZE(m_playerData) == MAX_PLAYER_COUNT, "array size must be equal to player count");
 }
 
-void RecorderClass::CRCInfo::addCRC(UnsignedInt val)
+void RecorderClass::CRCInfo::init(Bool isMultiplayer, Int localPlayerIndex)
+{
+	DEBUG_ASSERTCRASH((localPlayerIndex >= 0 && localPlayerIndex < MAX_PLAYER_COUNT) || localPlayerIndex == -1,
+		("replay local player index is unexpected"));
+
+	m_skippedOne = !isMultiplayer;
+	m_sawCRCMismatch = false;
+	m_localPlayerIndex = static_cast<Byte>(localPlayerIndex);
+
+	m_playbackData.clear();
+
+	for (size_t i = 0; i < ARRAY_SIZE(m_playerData); ++i)
+	{
+		m_playerData[i].clear();
+	}
+}
+
+void RecorderClass::CRCInfo::pushPlaybackCRC(UnsignedInt val)
 {
 	// TheSuperHackers @fix helmutbuhler 03/04/2025
 	// In Multiplayer, the first MSG_LOGIC_CRC message somehow doesn't make it through the network.
@@ -126,22 +138,122 @@ void RecorderClass::CRCInfo::addCRC(UnsignedInt val)
 		return;
 	}
 
-	m_data.push_back(val);
-	//DEBUG_LOG(("CRCInfo::addCRC() - crc %8.8X pushes list to %d entries (full=%d)", val, m_data.size(), !m_data.empty()));
+	m_playbackData.push_back(val);
+	//DEBUG_LOG(("CRCInfo::addPlaybackCRC() - crc %8.8X pushes list to %d entries", val, m_playbackData.size()));
 }
 
-UnsignedInt RecorderClass::CRCInfo::readCRC()
+void RecorderClass::CRCInfo::pushPlayerCRC(Int playerIndex, UnsignedInt val)
 {
-	if (m_data.empty())
+	if (const Bool isAllowedToAddPlayerCRC = (m_localPlayerIndex < 0 || playerIndex == m_localPlayerIndex))
 	{
-		DEBUG_LOG(("CRCInfo::readCRC() - bailing, full=0, size=%d", m_data.size()));
+		const UnsignedInt index = static_cast<UnsignedInt>(playerIndex);
+		if (index < ARRAY_SIZE(m_playerData))
+		{
+			m_playerData[index].push_back(val);
+			//DEBUG_LOG(("CRCInfo::addPlayerCRC() - crc %8.8X pushes list to %d entries", val, m_playerData[index].size()));
+		}
+	}
+}
+
+void RecorderClass::CRCInfo::setSawCRCMismatch()
+{
+	m_sawCRCMismatch = TRUE;
+}
+
+Bool RecorderClass::CRCInfo::sawCRCMismatch() const
+{
+	return m_sawCRCMismatch;
+}
+
+Byte RecorderClass::CRCInfo::getLocalPlayerIndex() const
+{
+	return m_localPlayerIndex;
+}
+
+RecorderClass::CRCInfo::MismatchData RecorderClass::CRCInfo::generateMismatchData()
+{
+	CRCInfo::MismatchData mmData;
+
+	for (size_t largestQueueSize = getLargestQueueSize(), j = 0; j < largestQueueSize; ++j)
+	{
+		const UnsignedInt playbackCRC = popPlaybackCRC();
+		UnsignedInt playerCount = 0;
+		UnsignedInt mismatchPlayerCount = 0;
+
+		for (size_t i = 0; i < ARRAY_SIZE(m_playerData); ++i)
+		{
+			if (j >= m_playerData[i].size())
+				continue;
+
+			++playerCount;
+
+			const UnsignedInt playerCRC = m_playerData[i][j];
+			if (playbackCRC == playerCRC)
+				continue;
+
+			++mismatchPlayerCount;
+
+			if (!mmData.mismatched)
+			{
+				mmData = CRCInfo::MismatchData(static_cast<Byte>(i),
+					static_cast<UnsignedShort>(m_playbackData.size()), playbackCRC, playerCRC);
+			}
+		}
+
+		if (mmData.mismatched)
+		{
+			if (const Bool allPlayersMismatch = (playerCount >= 2 && playerCount == mismatchPlayerCount))
+			{
+				mmData.playerIndex = CRCInfo::MismatchData::PLAYER_PLAYBACK;
+			}
+			else if (const Bool cannotAttributeMismatch = (playerCount <= 1 || mismatchPlayerCount >= 2))
+			{
+				mmData.playerIndex = CRCInfo::MismatchData::PLAYER_UNKNOWN;
+			}
+
+			// leave the playback data in a valid state in case the caller ignores the mismatch
+			while (!m_playbackData.empty() && ++j < largestQueueSize)
+			{
+				m_playbackData.pop_front();
+			}
+
+			break;
+		}
+	}
+
+	for (size_t i = 0; i < ARRAY_SIZE(m_playerData); ++i)
+	{
+		m_playerData[i].clear();
+	}
+
+	return mmData;
+}
+
+UnsignedInt RecorderClass::CRCInfo::getLargestQueueSize() const
+{
+	UnsignedInt size = 0;
+	for (size_t i = 0; i < ARRAY_SIZE(m_playerData); ++i)
+	{
+		if (m_playerData[i].size() > size)
+		{
+			size = m_playerData[i].size();
+		}
+	}
+
+	return size;
+}
+
+UnsignedInt RecorderClass::CRCInfo::popPlaybackCRC()
+{
+	if (m_playbackData.empty())
+	{
 		return 0;
 	}
 
-	UnsignedInt val = m_data.front();
-	m_data.pop_front();
-	//DEBUG_LOG(("CRCInfo::readCRC() - returning %8.8X, full=%d, size=%d", val, !m_data.empty(), m_data.size()));
-	return val;
+	const UnsignedInt crc = m_playbackData.front();
+	m_playbackData.pop_front();
+
+	return crc;
 }
 
 void RecorderClass::logGameStart(AsciiString options)
@@ -981,71 +1093,70 @@ Bool RecorderClass::sawCRCMismatch() const
 	return m_crcInfo.sawCRCMismatch();
 }
 
-void RecorderClass::handleCRCMessage(UnsignedInt newCRC, Int playerIndex, Bool fromPlayback)
+void RecorderClass::handlePlaybackCRCMessage(UnsignedInt newCRC)
 {
-	if (fromPlayback)
-	{
-		//DEBUG_LOG(("RecorderClass::handleCRCMessage() - Adding CRC of %X from %d to m_crcInfo", newCRC, playerIndex));
-		m_crcInfo.addCRC(newCRC);
-		return;
-	}
+	m_crcInfo.pushPlaybackCRC(newCRC);
 
-	Int localPlayerIndex = m_crcInfo.getLocalPlayer();
-	Bool samePlayer = FALSE;
-	AsciiString playerName;
-	playerName.format("player%d", localPlayerIndex);
-	const Player *p = ThePlayerList->getNthPlayer(playerIndex);
-	if (!p || (p->getPlayerNameKey() == NAMEKEY(playerName)))
-		samePlayer = TRUE;
-	if (samePlayer || (localPlayerIndex < 0))
+	//DEBUG_LOG(("RecorderClass::handlePlaybackCRCMessage() - Adding CRC of %X from playback to m_crcInfo", newCRC));
+}
+
+void RecorderClass::handlePlayerCRCMessage(Int playerIndex, UnsignedInt newCRC)
+{
+	m_crcInfo.pushPlayerCRC(playerIndex, newCRC);
+
+	//DEBUG_LOG(("RecorderClass::handlePlayerCRCMessage() - Adding CRC of %X from %d to m_crcInfo", newCRC, playerIndex));
+}
+
+void RecorderClass::checkForMismatch()
+{
+	const CRCInfo::MismatchData mmData = m_crcInfo.generateMismatchData();
+	if (mmData.mismatched)
 	{
-		UnsignedInt playbackCRC = m_crcInfo.readCRC();
-		//DEBUG_LOG(("RecorderClass::handleCRCMessage() - Comparing CRCs of InGame:%8.8X Replay:%8.8X Frame:%d from Player %d",
-		//	playbackCRC, newCRC, TheGameLogic->getFrame()-m_crcInfo.GetQueueSize()-1, playerIndex));
-		if (TheGameLogic->getFrame() > 0 && newCRC != playbackCRC && !m_crcInfo.sawCRCMismatch())
+		// Kris: Patch 1.01 November 10, 2003 (integrated changes from Matt Campbell)
+		// Since we don't seem to have any *visible* desyncs when replaying games, but get this warning
+		// virtually every replay, the assumption is our CRC checking is faulty. Since we're at the
+		// tail end of patch season, let's just disable the message, and hope the users believe the
+		// problem is fixed. -MDC 3/20/2003
+		//
+		// TheSuperHackers @tweak helmutbuhler 03/04/2025
+		// More than 20 years later, but finally fixed and re-enabled!
+		TheInGameUI->message("GUI:CRCMismatch");
+
+		// TheSuperHackers @info helmutbuhler 03/04/2025
+		// Note: We subtract the queue size from the frame number. This way we calculate the correct frame
+		// the mismatch first happened in case the NetCRCInterval is set to 1 during the game.
+		const UnsignedInt mismatchFrame = TheGameLogic->getFrame() - mmData.queueSize - 1;
+
+		// Now also prints a UI message for it.
+		const Player* player = ThePlayerList->getNthPlayer(mmData.playerIndex);
+		const UnicodeString mismatchDetailsStr = TheGameText->FETCH_OR_SUBSTITUTE("GUI:CRCMismatchDetails",
+			L"InGame:%8.8X Replay:%8.8X Frame:%d Player:%ls");
+		TheInGameUI->message(mismatchDetailsStr, mmData.playbackCRC, mmData.playerCRC, mismatchFrame, player
+			? player->getPlayerDisplayName().str()
+			: mmData.playerIndex == CRCInfo::MismatchData::PLAYER_PLAYBACK ? L"Playback" : L"Unknown");
+
+		DEBUG_LOG(("Replay has gone out of sync!\nInGame:%8.8X Replay:%8.8X\nFrame:%d\nPlayer:%ls",
+			mmData.playbackCRC, mmData.playerCRC, mismatchFrame, player
+			? player->getPlayerDisplayName().str()
+			: mmData.playerIndex == CRCInfo::MismatchData::PLAYER_PLAYBACK ? L"Playback" : L"Unknown"));
+
+		// Print mismatch in case we are simulating replays from console.
+		printf("CRC Mismatch in Frame %d, Local PlayerIndex %d, Mismatch PlayerIndex %d\n",
+			mismatchFrame, m_crcInfo.getLocalPlayerIndex(), mmData.playerIndex);
+
+		// TheSuperHackers @tweak Pause the game on mismatch.
+		// But not when a window with focus is opened, because that can make resuming difficult.
+		if (TheWindowManager->winGetFocus() == nullptr)
 		{
-			//Kris: Patch 1.01 November 10, 2003 (integrated changes from Matt Campbell)
-			// Since we don't seem to have any *visible* desyncs when replaying games, but get this warning
-			// virtually every replay, the assumption is our CRC checking is faulty.  Since we're at the
-			// tail end of patch season, let's just disable the message, and hope the users believe the
-			// problem is fixed. -MDC 3/20/2003
-			//
-			// TheSuperHackers @tweak helmutbuhler 03/04/2025
-			// More than 20 years later, but finally fixed and re-enabled!
-			TheInGameUI->message("GUI:CRCMismatch");
+			const Bool pause = TRUE;
+			const Bool pauseMusic = FALSE;
+			const Bool pauseInput = FALSE;
+			TheGameLogic->setGamePaused(pause, pauseMusic, pauseInput);
 
-			// TheSuperHackers @info helmutbuhler 03/04/2025
-			// Note: We subtract the queue size from the frame number. This way we calculate the correct frame
-			// the mismatch first happened in case the NetCRCInterval is set to 1 during the game.
-			const UnsignedInt mismatchFrame = TheGameLogic->getFrame() - m_crcInfo.GetQueueSize() - 1;
-
-			// Now also prints a UI message for it.
-			const UnicodeString mismatchDetailsStr = TheGameText->FETCH_OR_SUBSTITUTE("GUI:CRCMismatchDetails", L"InGame:%8.8X Replay:%8.8X Frame:%d");
-			TheInGameUI->message(mismatchDetailsStr, playbackCRC, newCRC, mismatchFrame);
-
-			DEBUG_LOG(("Replay has gone out of sync!\nInGame:%8.8X Replay:%8.8X\nFrame:%d",
-				playbackCRC, newCRC, mismatchFrame));
-
-			// Print Mismatch in case we are simulating replays from console.
-			printf("CRC Mismatch in Frame %d\n", mismatchFrame);
-
-			// TheSuperHackers @tweak Pause the game on mismatch.
-			// But not when a window with focus is opened, because that can make resuming difficult.
-			if (TheWindowManager->winGetFocus() == nullptr)
-			{
-				Bool pause = TRUE;
-				Bool pauseMusic = FALSE;
-				Bool pauseInput = FALSE;
-				TheGameLogic->setGamePaused(pause, pauseMusic, pauseInput);
-
-				// Mark this mismatch as seen when we had the chance to pause once.
-				m_crcInfo.setSawCRCMismatch();
-			}
+			// Mark this mismatch as seen when we had the chance to pause once.
+			m_crcInfo.setSawCRCMismatch();
 		}
-		return;
 	}
-
-	//DEBUG_LOG(("RecorderClass::handleCRCMessage() - Skipping CRC of %8.8X from %d (our index is %d)", newCRC, playerIndex, localPlayerIndex));
 }
 
 /**
@@ -1161,9 +1272,9 @@ Bool RecorderClass::playbackFile(AsciiString filename)
 #endif
 
 	Bool isMultiplayer = m_gameInfo.getSlot(header.localPlayerIndex)->getIP() != 0;
-	m_crcInfo = CRCInfo(header.localPlayerIndex, isMultiplayer);
+	m_crcInfo.init(isMultiplayer, -1);
 	REPLAY_CRC_INTERVAL = m_gameInfo.getCRCInterval();
-	DEBUG_LOG(("Player index is %d, replay CRC interval is %d", m_crcInfo.getLocalPlayer(), REPLAY_CRC_INTERVAL));
+	DEBUG_LOG(("Player index is %d, replay CRC interval is %d", header.localPlayerIndex, REPLAY_CRC_INTERVAL));
 
 	Int difficulty = 0;
 	m_file->read(&difficulty, sizeof(difficulty));

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -254,7 +254,7 @@ GameLogic::GameLogic()
 		m_progressCompleteTimeout[i] = 0;
 	}
 
-	m_shouldValidateCRCs = FALSE;
+	m_shouldValidateCRCs = CRCMODE_NONE;
 
 	m_startNewGame = FALSE;
 
@@ -2600,17 +2600,65 @@ void GameLogic::processDestroyList()
 	//in the request for a new deletion (sub-object), the new object was added to the end of this list.
 }
 
+static void checkForMismatch(const std::map<Int, UnsignedInt>& cachedCRCs)
+{
+	Bool sawCRCMismatch = FALSE;
+	Int numPlayers = 0;
+
+	for (Int i=0; i<MAX_SLOTS; ++i)
+	{
+		if (TheNetwork->isPlayerConnected(i))
+			++numPlayers;
+	}
+
+	if (cachedCRCs.size() < numPlayers)
+	{
+		DEBUG_CRASH(("Not enough CRCs!"));
+		sawCRCMismatch = TRUE;
+	}
+	else
+	{
+		//DEBUG_LOG(("Comparing %d CRCs on frame %d", cachedCRCs.size(), m_frame));
+		std::map<Int, UnsignedInt>::const_iterator crcIt = cachedCRCs.begin();
+		Int validatorCRC = crcIt->second;
+		//DEBUG_LOG(("Validator CRC from player %d is %8.8X", crcIt->first, validatorCRC));
+		while (++crcIt != cachedCRCs.end())
+		{
+			Int validatedCRC = crcIt->second;
+			//DEBUG_LOG(("CRC to validate is from player %d: %8.8X", crcIt->first, validatedCRC));
+			if (validatorCRC != validatedCRC)
+			{
+				DEBUG_CRASH(("CRC mismatch!"));
+				sawCRCMismatch = TRUE;
+			}
+		}
+	}
+
+	if (sawCRCMismatch)
+	{
+#ifdef DEBUG_LOGGING
+		DEBUG_LOG(("CRC Mismatch - saw %d CRCs from %d players", cachedCRCs.size(), numPlayers));
+		for (std::map<Int, UnsignedInt>::const_iterator crcIt = cachedCRCs.begin(); crcIt != cachedCRCs.end(); ++crcIt)
+		{
+			Player* player = ThePlayerList->getNthPlayer(crcIt->first);
+			DEBUG_LOG(("CRC from player %d (%ls) = %X", crcIt->first,
+				player ? player->getPlayerDisplayName().str() : L"<NONE>", crcIt->second));
+		}
+#endif // DEBUG_LOGGING
+
+		TheNetwork->setSawCRCMismatch();
+	}
+}
+
 //-------------------------------------------------------------------------------------------------
 /** Process the command list passed to the logic from the network */
 //-------------------------------------------------------------------------------------------------
 void GameLogic::processCommandList( CommandList *list )
 {
 	m_cachedCRCs.clear();
-	m_shouldValidateCRCs = FALSE;
+	m_shouldValidateCRCs = CRCMODE_NONE;
 
-	GameMessage* msg;
-
-	for( msg = list->getFirstMessage(); msg; msg = msg->next() )
+	for( GameMessage* msg = list->getFirstMessage(); msg; msg = msg->next() )
 	{
 #ifdef RTS_DEBUG
 		DEBUG_ASSERTCRASH(msg != nullptr && msg != (GameMessage*)0xdeadbeef, ("bad msg"));
@@ -2618,58 +2666,17 @@ void GameLogic::processCommandList( CommandList *list )
 		logicMessageDispatcher( msg, nullptr );
 	}
 
-	if (m_shouldValidateCRCs && !TheNetwork->sawCRCMismatch())
+	if (m_shouldValidateCRCs)
 	{
-		Bool sawCRCMismatch = FALSE;
-		Int numPlayers = 0;
-		DEBUG_ASSERTCRASH(TheNetwork, ("No Network!"));
-		if (TheNetwork)
+		if (m_shouldValidateCRCs == CRCMODE_NETWORK)
 		{
-			for (Int i=0; i<MAX_SLOTS; ++i)
-			{
-				if (TheNetwork->isPlayerConnected(i))
-					++numPlayers;
-			}
-
-			if (m_cachedCRCs.size() < numPlayers)
-			{
-				DEBUG_CRASH(("Not enough CRCs!"));
-				sawCRCMismatch = TRUE;
-			}
-			else
-			{
-				//DEBUG_LOG(("Comparing %d CRCs on frame %d", m_cachedCRCs.size(), m_frame));
-				std::map<Int, UnsignedInt>::const_iterator crcIt = m_cachedCRCs.begin();
-				Int validatorCRC = crcIt->second;
-				//DEBUG_LOG(("Validator CRC from player %d is %8.8X", crcIt->first, validatorCRC));
-				while (++crcIt != m_cachedCRCs.end())
-				{
-					Int validatedCRC = crcIt->second;
-					//DEBUG_LOG(("CRC to validate is from player %d: %8.8X", crcIt->first, validatedCRC));
-					if (validatorCRC != validatedCRC)
-					{
-						DEBUG_CRASH(("CRC mismatch!"));
-						sawCRCMismatch = TRUE;
-					}
-				}
-			}
+			checkForMismatch(m_cachedCRCs);
 		}
-
-		if (sawCRCMismatch)
+		else if (m_shouldValidateCRCs == CRCMODE_REPLAY)
 		{
-#ifdef DEBUG_LOGGING
-			DEBUG_LOG(("CRC Mismatch - saw %d CRCs from %d players", m_cachedCRCs.size(), numPlayers));
-			for (std::map<Int, UnsignedInt>::const_iterator crcIt = m_cachedCRCs.begin(); crcIt != m_cachedCRCs.end(); ++crcIt)
-			{
-				Player *player = ThePlayerList->getNthPlayer(crcIt->first);
-				DEBUG_LOG(("CRC from player %d (%ls) = %X", crcIt->first,
-					player?player->getPlayerDisplayName().str():L"<NONE>", crcIt->second));
-			}
-#endif // DEBUG_LOGGING
-			TheNetwork->setSawCRCMismatch();
+			TheRecorder->checkForMismatch();
 		}
 	}
-
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -3768,11 +3768,16 @@ void GameLogic::update()
 	if (generateForSolo || generateForMP)
 	{
 		m_CRC = getCRC( CRC_RECALC );
-		bool isPlayback = (TheRecorder && TheRecorder->isPlaybackMode());
 
 		GameMessage *msg = newInstance(GameMessage)(GameMessage::MSG_LOGIC_CRC);
 		msg->appendIntegerArgument(m_CRC);
+
+#if RETAIL_COMPATIBLE_CRC
+		// TheSuperHackers @tweak Caball009 21/06/2026 Playback argument serves no purpose anymore
+		// other than to be able play replays from newer retail compatible builds on older builds or retail.
+		const bool isPlayback = (TheRecorder && TheRecorder->isPlaybackMode());
 		msg->appendBooleanArgument(isPlayback);
+#endif
 
 		// TheSuperHackers @info helmutbuhler 13/04/2025
 		// During replay simulation, we bypass TheMessageStream and instead put the CRC message
@@ -3782,7 +3787,7 @@ void GameLogic::update()
 			messageList = TheCommandList;
 		messageList->appendMessage(msg);
 
-		DEBUG_LOG(("Appended %sCRC on frame %d: %8.8X", isPlayback ? "Playback " : "", m_frame, m_CRC));
+		DEBUG_LOG(("Appended %sCRC on frame %d: %8.8X", (TheRecorder && TheRecorder->isPlaybackMode()) ? "Playback " : "", m_frame, m_CRC));
 	}
 
 	// collect stats

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -256,7 +256,7 @@ GameLogic::GameLogic()
 		m_progressCompleteTimeout[i] = 0;
 	}
 
-	m_shouldValidateCRCs = FALSE;
+	m_validationModeCRC = CRCMODE_NONE;
 
 	m_startNewGame = FALSE;
 
@@ -2632,7 +2632,7 @@ void GameLogic::processDestroyList()
 void GameLogic::processCommandList( CommandList *list )
 {
 	m_cachedCRCs.clear();
-	m_shouldValidateCRCs = FALSE;
+	m_validationModeCRC = CRCMODE_NONE;
 
 	for( GameMessage* msg = list->getFirstMessage(); msg; msg = msg->next() )
 	{
@@ -2642,9 +2642,13 @@ void GameLogic::processCommandList( CommandList *list )
 		logicMessageDispatcher( msg, nullptr );
 	}
 
-	if (m_shouldValidateCRCs && !TheNetwork->sawCRCMismatch())
+	if (m_validationModeCRC == CRCMODE_NETWORK)
 	{
 		checkForMismatch();
+	}
+	else if (m_validationModeCRC == CRCMODE_REPLAY)
+	{
+		TheRecorder->checkForMismatch();
 	}
 }
 
@@ -2655,7 +2659,7 @@ void GameLogic::checkForMismatch()
 	DEBUG_ASSERTCRASH(TheNetwork, ("No Network!"));
 
 	Bool sawCRCMismatch = FALSE;
-	Int numPlayers = 0;
+	UnsignedInt numPlayers = 0;
 
 	for (Int i=0; i<MAX_SLOTS; ++i)
 	{
@@ -2703,7 +2707,7 @@ void GameLogic::checkForMismatch()
 		DEBUG_LOG(("CRC Mismatch - saw %d CRCs from %d players", m_cachedCRCs.size(), numPlayers));
 		for (CachedCRCMap::const_iterator crcIt = m_cachedCRCs.begin(); crcIt != m_cachedCRCs.end(); ++crcIt)
 		{
-			Player* player = ThePlayerList->getNthPlayer(crcIt->first);
+			const Player* player = ThePlayerList->getNthPlayer(crcIt->first);
 			DEBUG_LOG(("CRC from player %d (%ls) = %X", crcIt->first,
 				player ? player->getPlayerDisplayName().str() : L"<NONE>", crcIt->second));
 		}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -2634,9 +2634,7 @@ void GameLogic::processCommandList( CommandList *list )
 	m_cachedCRCs.clear();
 	m_shouldValidateCRCs = FALSE;
 
-	GameMessage* msg;
-
-	for( msg = list->getFirstMessage(); msg; msg = msg->next() )
+	for( GameMessage* msg = list->getFirstMessage(); msg; msg = msg->next() )
 	{
 #ifdef RTS_DEBUG
 		DEBUG_ASSERTCRASH(msg != nullptr && msg != (GameMessage*)0xdeadbeef, ("bad msg"));
@@ -2646,67 +2644,73 @@ void GameLogic::processCommandList( CommandList *list )
 
 	if (m_shouldValidateCRCs && !TheNetwork->sawCRCMismatch())
 	{
-		Bool sawCRCMismatch = FALSE;
-		Int numPlayers = 0;
-		DEBUG_ASSERTCRASH(TheNetwork, ("No Network!"));
-		if (TheNetwork)
+		checkForMismatch();
+	}
+}
+
+// ------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
+void GameLogic::checkForMismatch()
+{
+	DEBUG_ASSERTCRASH(TheNetwork, ("No Network!"));
+
+	Bool sawCRCMismatch = FALSE;
+	Int numPlayers = 0;
+
+	for (Int i=0; i<MAX_SLOTS; ++i)
+	{
+		if (TheNetwork->isPlayerConnected(i))
+			++numPlayers;
+	}
+
+	if (m_cachedCRCs.size() < numPlayers)
+	{
+		DEBUG_CRASH(("Not enough CRCs!"));
+		sawCRCMismatch = TRUE;
+	}
+	else
+	{
+		Bool hasReferenceCRC = FALSE;
+		UnsignedInt referenceCRC = 0;
+
+		for (CachedCRCMap::const_iterator it = m_cachedCRCs.begin(); it != m_cachedCRCs.end(); ++it)
 		{
-			for (Int i=0; i<MAX_SLOTS; ++i)
+			// TheSuperHackers @bugfix Caball009 14/06/2026 Check if player is still connected,
+			// to avoid spurious mismatches at low CRC intervals, e.g. every frame.
+			if (!TheNetwork->isPlayerConnected(it->first))
+				continue;
+
+			const UnsignedInt crc = it->second;
+
+			if (!hasReferenceCRC)
 			{
-				if (TheNetwork->isPlayerConnected(i))
-					++numPlayers;
+				hasReferenceCRC = TRUE;
+				referenceCRC = crc;
+				continue;
 			}
 
-			if (m_cachedCRCs.size() < numPlayers)
+			if (referenceCRC != crc)
 			{
-				DEBUG_CRASH(("Not enough CRCs!"));
+				DEBUG_CRASH(("CRC mismatch!"));
 				sawCRCMismatch = TRUE;
 			}
-			else
-			{
-				Bool hasReferenceCRC = FALSE;
-				UnsignedInt referenceCRC = 0;
-
-				for (CachedCRCMap::const_iterator it = m_cachedCRCs.begin(); it != m_cachedCRCs.end(); ++it)
-				{
-					// TheSuperHackers @bugfix Caball009 14/06/2026 Check if player is still connected,
-					// to avoid spurious mismatches at low CRC intervals, e.g. every frame.
-					if (!TheNetwork->isPlayerConnected(it->first))
-						continue;
-
-					const UnsignedInt crc = it->second;
-
-					if (!hasReferenceCRC)
-					{
-						hasReferenceCRC = TRUE;
-						referenceCRC = crc;
-						continue;
-					}
-
-					if (referenceCRC != crc)
-					{
-						DEBUG_CRASH(("CRC mismatch!"));
-						sawCRCMismatch = TRUE;
-					}
-				}
-			}
-		}
-
-		if (sawCRCMismatch)
-		{
-#ifdef DEBUG_LOGGING
-			DEBUG_LOG(("CRC Mismatch - saw %d CRCs from %d players", m_cachedCRCs.size(), numPlayers));
-			for (CachedCRCMap::const_iterator crcIt = m_cachedCRCs.begin(); crcIt != m_cachedCRCs.end(); ++crcIt)
-			{
-				Player *player = ThePlayerList->getNthPlayer(crcIt->first);
-				DEBUG_LOG(("CRC from player %d (%ls) = %X", crcIt->first,
-					player?player->getPlayerDisplayName().str():L"<NONE>", crcIt->second));
-			}
-#endif // DEBUG_LOGGING
-			TheNetwork->setSawCRCMismatch();
 		}
 	}
 
+	if (sawCRCMismatch)
+	{
+#ifdef DEBUG_LOGGING
+		DEBUG_LOG(("CRC Mismatch - saw %d CRCs from %d players", m_cachedCRCs.size(), numPlayers));
+		for (CachedCRCMap::const_iterator crcIt = m_cachedCRCs.begin(); crcIt != m_cachedCRCs.end(); ++crcIt)
+		{
+			Player* player = ThePlayerList->getNthPlayer(crcIt->first);
+			DEBUG_LOG(("CRC from player %d (%ls) = %X", crcIt->first,
+				player ? player->getPlayerDisplayName().str() : L"<NONE>", crcIt->second));
+		}
+#endif // DEBUG_LOGGING
+
+		TheNetwork->setSawCRCMismatch();
+	}
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -2045,6 +2045,9 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 		{
 			if (TheNetwork)
 			{
+				if (TheNetwork->sawCRCMismatch())
+					break;
+
 				Int slotIndex = -1;
 				for (Int i=0; i<MAX_SLOTS; ++i)
 				{
@@ -2058,31 +2061,47 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 				if (slotIndex < 0 || !TheNetwork->isPlayerConnected(slotIndex))
 					break;
 
+				const UnsignedInt newCRC = msg->getArgument(0)->integer;
+				//DEBUG_LOG(("Received CRC of %8.8X from %ls on frame %d", newCRC,
+					//msgPlayer->getPlayerDisplayName().str(), m_frame));
+
 				if (msgPlayer->isLocalPlayer())
 				{
 #if defined(RTS_DEBUG)
 					// don't even put this in release, cause someone might hack it.
 					if (!TheDebugIgnoreSyncErrors)
-					{
 #endif
-						m_shouldValidateCRCs = TRUE;
-#if defined(RTS_DEBUG)
-					}
-#endif
+						m_shouldValidateCRCs = CRCMODE_NETWORK;
 				}
 
-				UnsignedInt newCRC = msg->getArgument(0)->integer;
-				//DEBUG_LOG(("Received CRC of %8.8X from %ls on frame %d", newCRC,
-					//msgPlayer->getPlayerDisplayName().str(), m_frame));
 				m_cachedCRCs[msgPlayer->getPlayerIndex()] = newCRC;
 			}
 			else if (TheRecorder && TheRecorder->isPlaybackMode())
 			{
-				UnsignedInt newCRC = msg->getArgument(0)->integer;
-				//DEBUG_LOG(("Saw CRC of %X from player %d.  Our CRC is %X.  Arg count is %d",
+				if (TheRecorder->sawCRCMismatch())
+					break;
+
+				const UnsignedInt newCRC = msg->getArgument(0)->integer;
+				//DEBUG_LOG(("Saw CRC of %X from player %d. Our CRC is %X. Arg count is %d",
 					//newCRC, msgPlayer->getPlayerIndex(), getCRC(), msg->getArgumentCount()));
 
-				TheRecorder->handleCRCMessage(newCRC, msgPlayer->getPlayerIndex(), (msg->getArgument(1)->boolean));
+				DEBUG_ASSERTCRASH(msg->getArgument(1)->boolean == msgPlayer->isLocalPlayer(),
+					("CRC message origin is unexpected; playback message argument doesn't match message player index"));
+
+				if (msgPlayer->isLocalPlayer())
+				{
+					TheRecorder->handlePlaybackCRCMessage(newCRC);
+				}
+				else
+				{
+#if defined(RTS_DEBUG)
+					// don't even put this in release, cause someone might hack it.
+					if (!TheDebugIgnoreSyncErrors)
+#endif
+						m_shouldValidateCRCs = CRCMODE_REPLAY;
+
+					TheRecorder->handlePlayerCRCMessage(msgPlayer->getPlayerIndex(), newCRC);
+				}
 			}
 			break;
 


### PR DESCRIPTION
The original behavior wrt replays is that only the CRC messages from the player that recorded the replay are checked. This means that players can experience a 'live' mismatch, but the game won't show the mismatch for their replay if they didn't cause it.

That's not a big deal for regular players but still unexpected behavior. For developers it can be very useful to get the exact frame the mismatch happens, regardless of which player recorded the replay or which player caused the mismatch.

This PR changes the default behavior so that the CRC messages from all players are checked. I also added an opt-out command line `-replayLocalPlayerCRC` because developers with large replay collections may want to rely on the original behavior. As a small bonus the name of the mismatching player is now displayed on screen if it's possible to determine which player is responsible.

See commits for cleaner diff.

### Before:

https://github.com/user-attachments/assets/b7ebdecd-9ccd-40ec-a84e-b86363aa82a1

### After:

https://github.com/user-attachments/assets/fd328f2a-26d8-49ea-aa68-7bfdd82191cf

## TODO:
- [ ] Replicate in Generals.
- [ ] Do another large replay test before merging.
- [ ] Clean up commits.
- [ ] Update this post with the updated command line options.
- [x] Create separate commit for the deprecation of the CRC playback argument.
- [x] Move changes from last commit to other commits.
- [x] Split into smaller commits.
- [x] Add comments
