### PR TITLE
fix(view): Prevent the camera from clipping under terrain

### DIFF
--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DView.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DView.h
@@ -37,6 +37,7 @@
 // SYSTEM INCLUDES ////////////////////////////////////////////////////////////////////////////////
 
 // USER INCLUDES //////////////////////////////////////////////////////////////////////////////////
+#include "Common/MapObject.h"
 #include "Common/STLTypedefs.h"
 #include "GameClient/ParabolicEase.h"
 #include "GameClient/View.h"
@@ -48,7 +49,7 @@ class Drawable;
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 enum {MAX_WAYPOINTS=25};
 
-constexpr const Real TERRAIN_SAMPLE_SIZE = 40.0f;
+constexpr const Real TERRAIN_SAMPLE_SIZE = MAP_XY_FACTOR * 4;
 
 // ------------------------------------------------------------------------------------------------
 // ------------------------------------------------------------------------------------------------

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -737,7 +737,8 @@ void W3DView::updateCameraTransform()
 	Vector3 targetPos;
 	buildCameraPosition(sourcePos, targetPos);
 
-	// TheSuperHackers @fix Moves the camera above the terrain. Uses a bit smoothing to reduce bumpy movements.
+	// TheSuperHackers @fix Moves the camera above the terrain.
+	// Uses averaged terrain height sampling to reduce bumpy movements.
 	const Real minAcceptableCameraHeight = getHeightAroundPos(sourcePos.X, sourcePos.Y, MAP_XY_FACTOR) + NearZ;
 	if (sourcePos.Z < minAcceptableCameraHeight)
 	{

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -737,8 +737,8 @@ void W3DView::updateCameraTransform()
 	Vector3 targetPos;
 	buildCameraPosition(sourcePos, targetPos);
 
-	// TheSuperHackers @fix Always move camera above the terrain.
-	const Real minAcceptableCameraHeight = getHeightAroundPos(sourcePos.X, sourcePos.Y, 10.0f) + NearZ;
+	// TheSuperHackers @fix Moves the camera above the terrain. Uses a bit smoothing to reduce bumpy movements.
+	const Real minAcceptableCameraHeight = getHeightAroundPos(sourcePos.X, sourcePos.Y, MAP_XY_FACTOR) + NearZ;
 	if (sourcePos.Z < minAcceptableCameraHeight)
 	{
 		const Real repositionZ = minAcceptableCameraHeight - sourcePos.Z;

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -737,6 +737,15 @@ void W3DView::updateCameraTransform()
 	Vector3 targetPos;
 	buildCameraPosition(sourcePos, targetPos);
 
+	// TheSuperHackers @fix Always move camera above the terrain.
+	const Real minAcceptableCameraHeight = getHeightAroundPos(sourcePos.X, sourcePos.Y, 10.0f) + NearZ;
+	if (sourcePos.Z < minAcceptableCameraHeight)
+	{
+		const Real repositionZ = minAcceptableCameraHeight - sourcePos.Z;
+		sourcePos.Z += repositionZ;
+		targetPos.Z += repositionZ;
+	}
+
 	Matrix3D cameraTransform;
 	buildCameraTransform(&cameraTransform, sourcePos, targetPos);
 

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -737,14 +737,22 @@ void W3DView::updateCameraTransform()
 	Vector3 targetPos;
 	buildCameraPosition(sourcePos, targetPos);
 
-	// TheSuperHackers @fix Moves the camera above the terrain.
-	// Uses averaged terrain height sampling to reduce bumpy movements.
-	const Real minAcceptableCameraHeight = getHeightAroundPos(sourcePos.X, sourcePos.Y, MAP_XY_FACTOR) + NearZ;
-	if (sourcePos.Z < minAcceptableCameraHeight)
+#if PRESERVE_RETAIL_SCRIPTED_CAMERA
+	const Bool clipCameraAboveTerrain = m_isUserControlled;
+#else
+	const Bool clipCameraAboveTerrain = true;
+#endif
+	if (clipCameraAboveTerrain)
 	{
-		const Real repositionZ = minAcceptableCameraHeight - sourcePos.Z;
-		sourcePos.Z += repositionZ;
-		targetPos.Z += repositionZ;
+		// TheSuperHackers @fix Moves the camera above the terrain.
+		// Uses averaged terrain height sampling to reduce bumpy movements.
+		const Real minAcceptableCameraHeight = getHeightAroundPos(sourcePos.X, sourcePos.Y, MAP_XY_FACTOR) + NearZ;
+		if (sourcePos.Z < minAcceptableCameraHeight)
+		{
+			const Real repositionZ = minAcceptableCameraHeight - sourcePos.Z;
+			sourcePos.Z += repositionZ;
+			targetPos.Z += repositionZ;
+		}
 	}
 
 	Matrix3D cameraTransform;


### PR DESCRIPTION
This change prevents the camera from clipping under the terrain.

Clipping can be reproduced by using a low camera pitch (Comma key) over hilly terrain.