### PR TITLE
bugfix(view): Set camera far z to acceptable distance

### DIFF
--- a/Core/GameEngine/Include/GameClient/View.h
+++ b/Core/GameEngine/Include/GameClient/View.h
@@ -53,6 +53,7 @@ enum FilterModes CPP_11(: Int);
 // ------------------------------------------------------------------------------------------------
 constexpr const Real ViewDefaultPitchRadians = DEG_TO_RADF(37.5f);
 constexpr const Real ViewDefaultYawRadians = DEG_TO_RADF(0.0f);
+constexpr const Real ViewDefaultMaxHeightAboveTerrain = 310.0f;
 
 // ------------------------------------------------------------------------------------------------
 enum PickType CPP_11(: Int)

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -752,8 +752,8 @@ void W3DView::updateCameraClipPlanes()
 	static_assert(WorldHeightMap::NORMAL_DRAW_WIDTH == WorldHeightMap::NORMAL_DRAW_HEIGHT, "Expects squared draw area");
 	Real farZ = (WorldHeightMap::NORMAL_DRAW_WIDTH * 1.08f) * MAP_XY_FACTOR;
 
-	const Real heightMultiplicator = m_heightAboveGround / ViewDefaultMaxHeightAboveTerrain;
-	farZ *= heightMultiplicator;
+	const Real heightMultiplier = m_heightAboveGround / ViewDefaultMaxHeightAboveTerrain;
+	farZ *= std::max(heightMultiplier, 1.0f);
 
 	if (m_useRealZoomCam)	//WST 10.19.2002
 	{

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -747,20 +747,28 @@ void W3DView::updateCameraTransform()
 //-------------------------------------------------------------------------------------------------
 void W3DView::updateCameraClipPlanes()
 {
-	Real farZ = 1200.0f;
+	// TheSuperHackers @bugfix Extends the initial far Z from 1200 because that is not enough at
+	// default max height 310 and default pitch 37.5.
+	static_assert(WorldHeightMap::NORMAL_DRAW_WIDTH == WorldHeightMap::NORMAL_DRAW_HEIGHT, "Expects squared draw area");
+	Real farZ = (WorldHeightMap::NORMAL_DRAW_WIDTH * 1.08f) * MAP_XY_FACTOR;
+
+	const Real heightMultiplicator = m_heightAboveGround / ViewDefaultMaxHeightAboveTerrain;
+	farZ *= heightMultiplicator;
 
 	if (m_useRealZoomCam)	//WST 10.19.2002
 	{
-		if (m_FXPitch<0.95f)
+		if (m_FXPitch < 0.95f)
 		{
-			farZ = farZ / m_FXPitch; //Extend far Z when we pitch up for RealZoomCam
+			//Extend far Z when we pitch up for RealZoomCam
+			farZ /= m_FXPitch;
 		}
 	}
 	else
 	{
-		if ((TheGlobalData->m_drawEntireTerrain) || (m_FXPitch<0.95f || m_zoom>1.05))
-		{	//need to extend far clip plane so entire terrain can be visible
-			farZ *= MAP_XY_FACTOR;
+		if (TheGlobalData->m_drawEntireTerrain || m_FXPitch < 0.95f)
+		{
+			//need to extend far clip plane so entire terrain can be visible
+			farZ = 1200.0f * MAP_XY_FACTOR;
 		}
 	}
 

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DView.cpp
@@ -767,8 +767,8 @@ void W3DView::updateCameraClipPlanes()
 	{
 		if (TheGlobalData->m_drawEntireTerrain || m_FXPitch < 0.95f)
 		{
-			//need to extend far clip plane so entire terrain can be visible
-			farZ = 1200.0f * MAP_XY_FACTOR;
+			//Extend far clip plane so entire terrain can be visible
+			farZ *= 10.0f;
 		}
 	}
 


### PR DESCRIPTION
* Fixes #2494

This change sets the camera far z to an acceptable distance depending on the max camera height, based on an initial setup made for max camera height 310 and pitch 37.5.

This is an original game bug, but was more obvious in this project after recent changes to how the camera zoom value works (zoom=1 being max instead of zoom=1.3).