### PR TITLE
perf: Remove superfluous null tests in iterateObjects callbacks

### DIFF
--- a/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/Generals/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -1154,9 +1154,6 @@ struct PlayerObjectFindInfo
 //-------------------------------------------------------------------------------------------------
 static void doFindCommandCenter(Object* obj, void* userData)
 {
-	if (!obj)
-		return;
-
 	PlayerObjectFindInfo* info = (PlayerObjectFindInfo*)userData;
 
 	if (info->obj == nullptr

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarCommandProcessing.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarCommandProcessing.cpp
@@ -71,10 +71,6 @@ struct SelectObjectsInfo
 void selectObjectOfType( Object* obj, void* selectObjectsInfo )
 {
 	SelectObjectsInfo *soInfo = (SelectObjectsInfo*)selectObjectsInfo;
-	if( !obj || !soInfo )
-	{
-		return;
-	}
 
 	//Do the templates match?
 	if( obj->getTemplate()->isEquivalentTo( soInfo->thingTemplate ) )

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -98,8 +98,6 @@
 void countObjects(Object *obj, void *userData)
 {
 	Int *numObjects = (Int *)userData;
-	if (!numObjects || !obj)
-		return;
 
 	DEBUG_LOG(("Looking at obj %d (%s) - isEffectivelyDead()==%d, isDestroyed==%d, numObjects==%d",
 		obj->getID(), obj->getTemplate()->getName().str(), obj->isEffectivelyDead(), obj->isDestroyed(), *numObjects));
@@ -110,9 +108,6 @@ void countObjects(Object *obj, void *userData)
 
 void printObjects(Object *obj, void *userData)
 {
-	if (!obj)
-		return;
-
 	Bool isDead = obj->isEffectivelyDead() || obj->isDestroyed();
 	Bool isInert = obj->isKindOf(KINDOF_INERT);
 	AsciiString statusStr = (isDead)?"Dead":(isInert)?"Inert":"Living";
@@ -858,10 +853,6 @@ struct CommandCenterLocator
 
 void findCommandCenterOrMostExpensiveBuilding(Object* obj, void* vccl)
 {
-	if (!obj) {
-		return;
-	}
-
 	CommandCenterLocator *ccl = (CommandCenterLocator*) vccl;
 
 	// here's the deal. We want to get the first Command Center in the list.
@@ -911,9 +902,7 @@ struct HeroHolder
 
 void amIAHero(Object* obj, void* heroHolder)
 {
-
-
-	if (!obj || ((HeroHolder*)heroHolder)->hero != nullptr)
+	if (((HeroHolder*)heroHolder)->hero != nullptr)
 	{
 		return;
 	}

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AIDock.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AIDock.cpp
@@ -648,7 +648,7 @@ void findDrone( Object *obj, void *droneInfo )
 {
 	DroneInfo *dInfo = (DroneInfo*)droneInfo;
 
-	if( !dInfo->found && obj )
+	if( !dInfo->found )
 	{
 		if( obj->isKindOf( KINDOF_DRONE ) && obj->getProducerID() == dInfo->owner->getID() )
 		{

--- a/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
@@ -92,20 +92,17 @@ extern void oversizeTheTerrain(Int amount);
 // or the indicator color. this allows us to force the situation. (srj)
 static void updateTeamAndPlayerStuff( Object *obj, void *userData )
 {
-	if (obj)
-	{
-		obj->updateUpgradeModules();
+	obj->updateUpgradeModules();
 
-		// srj sez: apparently we have to do this too, since Team::setControllingPlayer
-		// does not. Might make more sense to do it there, but am scared to at this point.
-		Drawable* draw = obj->getDrawable();
-		if (draw)
-		{
-			if (TheGlobalData->m_timeOfDay == TIME_OF_DAY_NIGHT)
-				draw->setIndicatorColor(obj->getNightIndicatorColor());
-			else
-				draw->setIndicatorColor(obj->getIndicatorColor());
-		}
+	// srj sez: apparently we have to do this too, since Team::setControllingPlayer
+	// does not. Might make more sense to do it there, but am scared to at this point.
+	Drawable* draw = obj->getDrawable();
+	if (draw)
+	{
+		if (TheGlobalData->m_timeOfDay == TIME_OF_DAY_NIGHT)
+			draw->setIndicatorColor(obj->getNightIndicatorColor());
+		else
+			draw->setIndicatorColor(obj->getIndicatorColor());
 	}
 }
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -2137,7 +2137,7 @@ void GameLogic::tryStartNewGame( Bool loadingSaveGame )
 //-----------------------------------------------------------------------------------------
 static void findAndSelectCommandCenter(Object *obj, void* alreadyFound)
 {
-	if (!((*(Bool*)alreadyFound)) && obj && obj->isKindOf(KINDOF_COMMANDCENTER) )
+	if (!((*(Bool*)alreadyFound)) && obj->isKindOf(KINDOF_COMMANDCENTER) )
 	{
 		((*(Bool*)alreadyFound)) = TRUE;
 		TheGameLogic->selectObject(obj, TRUE, obj->getControllingPlayer()->getPlayerMask(), obj->isLocallyControlled());

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/AcademyStats.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/AcademyStats.cpp
@@ -88,7 +88,7 @@ void findDozerCommandSet( Object *object, void *userData )
 	{
 		return;
 	}
-	if( object && object->isKindOf( KINDOF_DOZER ) )
+	if( object->isKindOf( KINDOF_DOZER ) )
 	{
 		dozerCommandSet = TheControlBar->findCommandSet( object->getCommandSetString() );
 	}
@@ -284,10 +284,6 @@ void AcademyStats::init( const Player *player )
 static void updateAcademyStats( Object *obj, void *userData )
 {
 	AcademyStats *academy = (AcademyStats*)userData;
-	if( !obj || !academy )
-	{
-		return;
-	}
 
 	if( academy->isFirstUpdate() )
 	{

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -1204,9 +1204,6 @@ struct PlayerObjectFindInfo
 //-------------------------------------------------------------------------------------------------
 static void doFindCommandCenter(Object* obj, void* userData)
 {
-	if (!obj)
-		return;
-
 	PlayerObjectFindInfo* info = (PlayerObjectFindInfo*)userData;
 
 	if (info->obj == nullptr

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarCommandProcessing.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBarCommandProcessing.cpp
@@ -71,10 +71,6 @@ struct SelectObjectsInfo
 void selectObjectOfType( Object* obj, void* selectObjectsInfo )
 {
 	SelectObjectsInfo *soInfo = (SelectObjectsInfo*)selectObjectsInfo;
-	if( !obj || !soInfo )
-	{
-		return;
-	}
 
 	//Do the templates match?
 	if( obj->getTemplate()->isEquivalentTo( soInfo->thingTemplate ) )

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -97,8 +97,6 @@
 void countObjects(Object *obj, void *userData)
 {
 	Int *numObjects = (Int *)userData;
-	if (!numObjects || !obj)
-		return;
 
 	DEBUG_LOG(("Looking at obj %d (%s) - isEffectivelyDead()==%d, isDestroyed==%d, numObjects==%d",
 		obj->getID(), obj->getTemplate()->getName().str(), obj->isEffectivelyDead(), obj->isDestroyed(), *numObjects));
@@ -109,9 +107,6 @@ void countObjects(Object *obj, void *userData)
 
 void printObjects(Object *obj, void *userData)
 {
-	if (!obj)
-		return;
-
 	Bool isDead = obj->isEffectivelyDead() || obj->isDestroyed();
 	Bool isInert = obj->isKindOf(KINDOF_INERT);
 	AsciiString statusStr = (isDead)?"Dead":(isInert)?"Inert":"Living";
@@ -912,10 +907,6 @@ struct CommandCenterLocator
 
 void findCommandCenterOrMostExpensiveBuilding(Object* obj, void* vccl)
 {
-	if (!obj) {
-		return;
-	}
-
 	CommandCenterLocator *ccl = (CommandCenterLocator*) vccl;
 
 	// here's the deal. We want to get the first Command Center in the list.
@@ -965,9 +956,7 @@ struct HeroHolder
 
 void amIAHero(Object* obj, void* heroHolder)
 {
-
-
-	if (!obj || ((HeroHolder*)heroHolder)->hero != nullptr)
+	if (((HeroHolder*)heroHolder)->hero != nullptr)
 	{
 		return;
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIDock.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AIDock.cpp
@@ -648,7 +648,7 @@ void findDrone( Object *obj, void *droneInfo )
 {
 	DroneInfo *dInfo = (DroneInfo*)droneInfo;
 
-	if( !dInfo->found && obj )
+	if( !dInfo->found )
 	{
 		if( obj->isKindOf( KINDOF_DRONE ) && obj->getProducerID() == dInfo->owner->getID() )
 		{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/ScriptEngine/ScriptActions.cpp
@@ -96,20 +96,17 @@ extern void oversizeTheTerrain(Int amount);
 // or the indicator color. this allows us to force the situation. (srj)
 static void updateTeamAndPlayerStuff( Object *obj, void *userData )
 {
-	if (obj)
-	{
-		obj->updateUpgradeModules();
+	obj->updateUpgradeModules();
 
-		// srj sez: apparently we have to do this too, since Team::setControllingPlayer
-		// does not. Might make more sense to do it there, but am scared to at this point.
-		Drawable* draw = obj->getDrawable();
-		if (draw)
-		{
-			if (TheGlobalData->m_timeOfDay == TIME_OF_DAY_NIGHT)
-				draw->setIndicatorColor(obj->getNightIndicatorColor());
-			else
-				draw->setIndicatorColor(obj->getIndicatorColor());
-		}
+	// srj sez: apparently we have to do this too, since Team::setControllingPlayer
+	// does not. Might make more sense to do it there, but am scared to at this point.
+	Drawable* draw = obj->getDrawable();
+	if (draw)
+	{
+		if (TheGlobalData->m_timeOfDay == TIME_OF_DAY_NIGHT)
+			draw->setIndicatorColor(obj->getNightIndicatorColor());
+		else
+			draw->setIndicatorColor(obj->getIndicatorColor());
 	}
 }
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -2452,7 +2452,7 @@ void GameLogic::createOptimizedTree(const ThingTemplate *thingTemplate, Coord3D 
 //-----------------------------------------------------------------------------------------
 static void findAndSelectCommandCenter(Object *obj, void* alreadyFound)
 {
-	if (!((*(Bool*)alreadyFound)) && obj && obj->isKindOf(KINDOF_COMMANDCENTER) )
+	if (!((*(Bool*)alreadyFound)) && obj->isKindOf(KINDOF_COMMANDCENTER) )
 	{
 		((*(Bool*)alreadyFound)) = TRUE;
 		TheGameLogic->selectObject(obj, TRUE, obj->getControllingPlayer()->getPlayerMask(), obj->isLocallyControlled());


### PR DESCRIPTION
* Follow up for #2652

Greptile did complain that some callbacks to `iterateObjects` contained no null test for `Object*` while others did.

We can confidently assume that the callback will only be called for non-null objects.

I did a pass on all callbacks that I could find and removed the superfluous null tests.