### PR TITLE
feat(stats): Add 1% low FPS tracking

### DIFF
--- a/Core/GameEngine/Include/GameClient/Display.h
+++ b/Core/GameEngine/Include/GameClient/Display.h
@@ -184,6 +184,7 @@ public:
 	virtual void setCinematicTextFrames( Int frames ) { m_cinematicTextFrames = frames; }
 
 	virtual Real getAverageFPS() = 0;	///< returns the average FPS.
+	virtual Real getLow1PercentFPS() = 0;	///< returns the 1% low FPS.
 	virtual Real getCurrentFPS() = 0;	///< returns the current FPS.
 	virtual Int getLastFrameDrawCalls() = 0;  ///< returns the number of draw calls issued in the previous frame
 

--- a/Core/GameEngine/Include/GameClient/Display.h
+++ b/Core/GameEngine/Include/GameClient/Display.h
@@ -193,6 +193,7 @@ public:
 	virtual void setCinematicTextFrames( Int frames ) { m_cinematicTextFrames = frames; }
 
 	virtual Real getAverageFPS() = 0;	///< returns the average FPS.
+	virtual Real getLow1PercentFPS() = 0;	///< returns the 1% low FPS.
 	virtual Real getCurrentFPS() = 0;	///< returns the current FPS.
 	virtual Int getLastFrameDrawCalls() = 0;  ///< returns the number of draw calls issued in the previous frame
 

--- a/Generals/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/Generals/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -747,16 +747,19 @@ protected:
 
 	// Render FPS Counter
 	DisplayString *							m_renderFpsString;
+	DisplayString *							m_renderFpsLowString;
 	DisplayString *							m_renderFpsLimitString;
 	AsciiString									m_renderFpsFont;
 	Int													m_renderFpsPointSize;
 	Bool												m_renderFpsBold;
 	Coord2D											m_renderFpsPosition;
 	Color												m_renderFpsColor;
+	Color												m_renderFpsLowColor;
 	Color												m_renderFpsLimitColor;
 	Color												m_renderFpsDropColor;
 	UnsignedInt									m_renderFpsRefreshMs;
 	UnsignedInt									m_lastRenderFps;
+	UnsignedInt									m_lastRenderFpsLow;
 	UnsignedInt									m_lastRenderFpsLimit;
 	UnsignedInt									m_lastRenderFpsUpdateMs;
 

--- a/Generals/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/Generals/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -755,16 +755,19 @@ protected:
 
 	// Render FPS Counter
 	DisplayString *							m_renderFpsString;
+	DisplayString *							m_renderFpsLowString;
 	DisplayString *							m_renderFpsLimitString;
 	AsciiString									m_renderFpsFont;
 	Int													m_renderFpsPointSize;
 	Bool												m_renderFpsBold;
 	Coord2D											m_renderFpsPosition;
 	Color												m_renderFpsColor;
+	Color												m_renderFpsLowColor;
 	Color												m_renderFpsLimitColor;
 	Color												m_renderFpsDropColor;
 	UnsignedInt									m_renderFpsRefreshMs;
 	UnsignedInt									m_lastRenderFps;
+	UnsignedInt									m_lastRenderFpsLow;
 	UnsignedInt									m_lastRenderFpsLimit;
 	UnsignedInt									m_lastRenderFpsUpdateMs;
 

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -888,6 +888,7 @@ const FieldParse InGameUI::s_fieldParseTable[] =
 	{ "RenderFpsBold",          INI::parseBool,         nullptr, offsetof( InGameUI, m_renderFpsBold ) },
 	{ "RenderFpsPosition",      INI::parseCoord2D,      nullptr, offsetof( InGameUI, m_renderFpsPosition ) },
 	{ "RenderFpsColor",         INI::parseColorInt,     nullptr, offsetof( InGameUI, m_renderFpsColor ) },
+	{ "RenderFpsLowColor",      INI::parseColorInt,     nullptr, offsetof( InGameUI, m_renderFpsLowColor ) },
 	{ "RenderFpsLimitColor",    INI::parseColorInt,     nullptr, offsetof( InGameUI, m_renderFpsLimitColor ) },
 	{ "RenderFpsDropColor",     INI::parseColorInt,     nullptr, offsetof( InGameUI, m_renderFpsDropColor ) },
 	{ "RenderFpsRefreshMs",     INI::parseUnsignedInt,  nullptr, offsetof( InGameUI, m_renderFpsRefreshMs ) },
@@ -1133,6 +1134,7 @@ InGameUI::InGameUI()
 	m_lastNetworkLatencyFrames = ~0u;
 
 	m_renderFpsString = nullptr;
+	m_renderFpsLowString = nullptr;
 	m_renderFpsLimitString = nullptr;
 	m_renderFpsFont = "Tahoma";
 	m_renderFpsPointSize = TheGlobalData->m_renderFpsFontSize;
@@ -1140,10 +1142,12 @@ InGameUI::InGameUI()
 	m_renderFpsPosition.x = kHudAnchorX;
 	m_renderFpsPosition.y = kHudAnchorY;
 	m_renderFpsColor = GameMakeColor( 255, 255, 0, 255 );
+	m_renderFpsLowColor = GameMakeColor( 180, 170, 120, 255 );
 	m_renderFpsLimitColor = GameMakeColor(119, 119, 119, 255);
 	m_renderFpsDropColor = GameMakeColor( 0, 0, 0, 255 );
 	m_renderFpsRefreshMs = 1000;
 	m_lastRenderFps = ~0u;
+	m_lastRenderFpsLow = ~0u;
 	m_lastRenderFpsLimit = ~0u;
 	m_lastRenderFpsUpdateMs = 0u;
 
@@ -2215,6 +2219,8 @@ void InGameUI::freeCustomUiResources()
 	m_networkLatencyString = nullptr;
 	TheDisplayStringManager->freeDisplayString(m_renderFpsString);
 	m_renderFpsString = nullptr;
+	TheDisplayStringManager->freeDisplayString(m_renderFpsLowString);
+	m_renderFpsLowString = nullptr;
 	TheDisplayStringManager->freeDisplayString(m_renderFpsLimitString);
 	m_renderFpsLimitString = nullptr;
 	TheDisplayStringManager->freeDisplayString(m_systemTimeString);
@@ -5868,6 +5874,12 @@ void InGameUI::refreshRenderFpsResources()
 		m_lastRenderFpsUpdateMs = 0u;
 	}
 
+	if (!m_renderFpsLowString)
+	{
+		m_renderFpsLowString = TheDisplayStringManager->newDisplayString();
+		m_lastRenderFpsLow = ~0u;
+	}
+
 	if (!m_renderFpsLimitString)
 	{
 		m_renderFpsLimitString = TheDisplayStringManager->newDisplayString();
@@ -5878,6 +5890,7 @@ void InGameUI::refreshRenderFpsResources()
 	Int adjustedRenderFpsFontSize = TheGlobalLanguageData->adjustFontSize(m_renderFpsPointSize);
 	GameFont *fpsFont = TheWindowManager->winFindFont(m_renderFpsFont, adjustedRenderFpsFontSize, m_renderFpsBold);
 	m_renderFpsString->setFont(fpsFont);
+	m_renderFpsLowString->setFont(fpsFont);
 	m_renderFpsLimitString->setFont(fpsFont);
 
 	if (m_renderFpsPointSize > 0)
@@ -5990,6 +6003,15 @@ void InGameUI::updateRenderFpsString()
 		m_renderFpsString->setText(fpsStr);
 		m_lastRenderFps = renderFps;
 	}
+
+	const UnsignedInt renderFpsLow = (UnsignedInt)(TheDisplay->getLow1PercentFPS() + 0.5f);
+	if (renderFpsLow != m_lastRenderFpsLow)
+	{
+		UnicodeString lowStr;
+		lowStr.format(L"(%u)", renderFpsLow);
+		m_renderFpsLowString->setText(lowStr);
+		m_lastRenderFpsLow = renderFpsLow;
+	}
 }
 
 void InGameUI::drawNetworkLatency(Int &x, Int &y)
@@ -6056,14 +6078,20 @@ void InGameUI::drawRenderFps(Int &x, Int &y)
 		const Int drawY = kHudAnchorY + y;
 
 		m_renderFpsString->draw(kHudAnchorX + x, drawY, m_renderFpsColor, m_renderFpsDropColor);
-		x += m_renderFpsString->getWidth();
+		x += m_renderFpsString->getWidth() + kHudGapPx / 2;
+		m_renderFpsLowString->draw(kHudAnchorX + x, drawY, m_renderFpsLowColor, m_renderFpsDropColor);
+		x += m_renderFpsLowString->getWidth() + kHudGapPx / 2;
 		m_renderFpsLimitString->draw(kHudAnchorX + x, drawY, m_renderFpsLimitColor, m_renderFpsDropColor);
 		x += m_renderFpsLimitString->getWidth() + kHudGapPx;
 	}
 	else
 	{
-		m_renderFpsString->draw(m_renderFpsPosition.x, m_renderFpsPosition.y, m_renderFpsColor, m_renderFpsDropColor);
-		m_renderFpsLimitString->draw(m_renderFpsPosition.x + m_renderFpsString->getWidth(), m_renderFpsPosition.y, m_renderFpsLimitColor, m_renderFpsDropColor);
+		Int currentX = m_renderFpsPosition.x;
+		m_renderFpsString->draw(currentX, m_renderFpsPosition.y, m_renderFpsColor, m_renderFpsDropColor);
+		currentX += m_renderFpsString->getWidth() + kHudGapPx / 2;
+		m_renderFpsLowString->draw(currentX, m_renderFpsPosition.y, m_renderFpsLowColor, m_renderFpsDropColor);
+		currentX += m_renderFpsLowString->getWidth() + kHudGapPx / 2;
+		m_renderFpsLimitString->draw(currentX, m_renderFpsPosition.y, m_renderFpsLimitColor, m_renderFpsDropColor);
 	}
 }
 

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -6055,19 +6055,22 @@ void InGameUI::drawRenderFps(Int &x, Int &y)
 		updateRenderFpsString();
 	}
 
-	UnsignedInt renderFpsLimit = 0u;
+	UnsignedInt renderFpsLimit = RenderFpsPreset::UncappedFpsValue;
 	if (TheGlobalData->m_useFpsLimit)
 	{
 		renderFpsLimit = (UnsignedInt)TheFramePacer->getFramesPerSecondLimit();
-		if (renderFpsLimit == RenderFpsPreset::UncappedFpsValue)
-		{
-			renderFpsLimit = 0u;
-		}
 	}
 	if (renderFpsLimit != m_lastRenderFpsLimit)
 	{
 		UnicodeString fpsLimitStr;
-		fpsLimitStr.format(L"[%u]", renderFpsLimit);
+		if (renderFpsLimit == RenderFpsPreset::UncappedFpsValue)
+		{
+			fpsLimitStr.format(L"[X]");
+		}
+		else
+		{
+			fpsLimitStr.format(L"[%u]", renderFpsLimit);
+		}
 		m_renderFpsLimitString->setText(fpsLimitStr);
 		m_lastRenderFpsLimit = renderFpsLimit;
 	}

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -1145,7 +1145,7 @@ InGameUI::InGameUI()
 	m_renderFpsPosition.x = kHudAnchorX;
 	m_renderFpsPosition.y = kHudAnchorY;
 	m_renderFpsColor = GameMakeColor( 255, 255, 0, 255 );
-	m_renderFpsLowColor = GameMakeColor( 180, 170, 120, 255 );
+	m_renderFpsLowColor = GameMakeColor( 190, 180, 130, 255 );
 	m_renderFpsLimitColor = GameMakeColor(119, 119, 119, 255);
 	m_renderFpsDropColor = GameMakeColor( 0, 0, 0, 255 );
 	m_renderFpsRefreshMs = 1000;
@@ -6052,7 +6052,7 @@ void InGameUI::updateRenderFpsString()
 	if (renderFpsLow != m_lastRenderFpsLow)
 	{
 		UnicodeString lowStr;
-		lowStr.format(L"(%u)", renderFpsLow);
+		lowStr.format(L"\x25BC%u", renderFpsLow);
 		m_renderFpsLowString->setText(lowStr);
 		m_lastRenderFpsLow = renderFpsLow;
 	}
@@ -6109,11 +6109,11 @@ void InGameUI::drawRenderFps(Int &x, Int &y)
 		UnicodeString fpsLimitStr;
 		if (renderFpsLimit == RenderFpsPreset::UncappedFpsValue)
 		{
-			fpsLimitStr.format(L"[X]");
+			fpsLimitStr.format(L"\x25B2X");
 		}
 		else
 		{
-			fpsLimitStr.format(L"[%u]", renderFpsLimit);
+			fpsLimitStr.format(L"\x25B2%u", renderFpsLimit);
 		}
 		m_renderFpsLimitString->setText(fpsLimitStr);
 		m_lastRenderFpsLimit = renderFpsLimit;

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -888,6 +888,7 @@ const FieldParse InGameUI::s_fieldParseTable[] =
 	{ "RenderFpsBold",          INI::parseBool,         nullptr, offsetof( InGameUI, m_renderFpsBold ) },
 	{ "RenderFpsPosition",      INI::parseCoord2D,      nullptr, offsetof( InGameUI, m_renderFpsPosition ) },
 	{ "RenderFpsColor",         INI::parseColorInt,     nullptr, offsetof( InGameUI, m_renderFpsColor ) },
+	{ "RenderFpsLowColor",      INI::parseColorInt,     nullptr, offsetof( InGameUI, m_renderFpsLowColor ) },
 	{ "RenderFpsLimitColor",    INI::parseColorInt,     nullptr, offsetof( InGameUI, m_renderFpsLimitColor ) },
 	{ "RenderFpsDropColor",     INI::parseColorInt,     nullptr, offsetof( InGameUI, m_renderFpsDropColor ) },
 	{ "RenderFpsRefreshMs",     INI::parseUnsignedInt,  nullptr, offsetof( InGameUI, m_renderFpsRefreshMs ) },
@@ -1136,6 +1137,7 @@ InGameUI::InGameUI()
 	m_lastNetworkLatencyFrames = ~0u;
 
 	m_renderFpsString = nullptr;
+	m_renderFpsLowString = nullptr;
 	m_renderFpsLimitString = nullptr;
 	m_renderFpsFont = "Tahoma";
 	m_renderFpsPointSize = TheGlobalData->m_renderFpsFontSize;
@@ -1143,10 +1145,12 @@ InGameUI::InGameUI()
 	m_renderFpsPosition.x = kHudAnchorX;
 	m_renderFpsPosition.y = kHudAnchorY;
 	m_renderFpsColor = GameMakeColor( 255, 255, 0, 255 );
+	m_renderFpsLowColor = GameMakeColor( 180, 170, 120, 255 );
 	m_renderFpsLimitColor = GameMakeColor(119, 119, 119, 255);
 	m_renderFpsDropColor = GameMakeColor( 0, 0, 0, 255 );
 	m_renderFpsRefreshMs = 1000;
 	m_lastRenderFps = ~0u;
+	m_lastRenderFpsLow = ~0u;
 	m_lastRenderFpsLimit = ~0u;
 	m_lastRenderFpsUpdateMs = 0u;
 
@@ -2248,6 +2252,8 @@ void InGameUI::freeCustomUiResources()
 	m_networkLatencyString = nullptr;
 	TheDisplayStringManager->freeDisplayString(m_renderFpsString);
 	m_renderFpsString = nullptr;
+	TheDisplayStringManager->freeDisplayString(m_renderFpsLowString);
+	m_renderFpsLowString = nullptr;
 	TheDisplayStringManager->freeDisplayString(m_renderFpsLimitString);
 	m_renderFpsLimitString = nullptr;
 	TheDisplayStringManager->freeDisplayString(m_systemTimeString);
@@ -5912,6 +5918,12 @@ void InGameUI::refreshRenderFpsResources()
 		m_lastRenderFpsUpdateMs = 0u;
 	}
 
+	if (!m_renderFpsLowString)
+	{
+		m_renderFpsLowString = TheDisplayStringManager->newDisplayString();
+		m_lastRenderFpsLow = ~0u;
+	}
+
 	if (!m_renderFpsLimitString)
 	{
 		m_renderFpsLimitString = TheDisplayStringManager->newDisplayString();
@@ -5922,6 +5934,7 @@ void InGameUI::refreshRenderFpsResources()
 	Int adjustedRenderFpsFontSize = TheGlobalLanguageData->adjustFontSize(m_renderFpsPointSize);
 	GameFont *fpsFont = TheWindowManager->winFindFont(m_renderFpsFont, adjustedRenderFpsFontSize, m_renderFpsBold);
 	m_renderFpsString->setFont(fpsFont);
+	m_renderFpsLowString->setFont(fpsFont);
 	m_renderFpsLimitString->setFont(fpsFont);
 
 	if (m_renderFpsPointSize > 0)
@@ -6034,6 +6047,15 @@ void InGameUI::updateRenderFpsString()
 		m_renderFpsString->setText(fpsStr);
 		m_lastRenderFps = renderFps;
 	}
+
+	const UnsignedInt renderFpsLow = (UnsignedInt)(TheDisplay->getLow1PercentFPS() + 0.5f);
+	if (renderFpsLow != m_lastRenderFpsLow)
+	{
+		UnicodeString lowStr;
+		lowStr.format(L"(%u)", renderFpsLow);
+		m_renderFpsLowString->setText(lowStr);
+		m_lastRenderFpsLow = renderFpsLow;
+	}
 }
 
 void InGameUI::drawNetworkLatency(Int &x, Int &y)
@@ -6100,14 +6122,20 @@ void InGameUI::drawRenderFps(Int &x, Int &y)
 		const Int drawY = kHudAnchorY + y;
 
 		m_renderFpsString->draw(kHudAnchorX + x, drawY, m_renderFpsColor, m_renderFpsDropColor);
-		x += m_renderFpsString->getWidth();
+		x += m_renderFpsString->getWidth() + kHudGapPx / 2;
+		m_renderFpsLowString->draw(kHudAnchorX + x, drawY, m_renderFpsLowColor, m_renderFpsDropColor);
+		x += m_renderFpsLowString->getWidth() + kHudGapPx / 2;
 		m_renderFpsLimitString->draw(kHudAnchorX + x, drawY, m_renderFpsLimitColor, m_renderFpsDropColor);
 		x += m_renderFpsLimitString->getWidth() + kHudGapPx;
 	}
 	else
 	{
-		m_renderFpsString->draw(m_renderFpsPosition.x, m_renderFpsPosition.y, m_renderFpsColor, m_renderFpsDropColor);
-		m_renderFpsLimitString->draw(m_renderFpsPosition.x + m_renderFpsString->getWidth(), m_renderFpsPosition.y, m_renderFpsLimitColor, m_renderFpsDropColor);
+		Int currentX = m_renderFpsPosition.x;
+		m_renderFpsString->draw(currentX, m_renderFpsPosition.y, m_renderFpsColor, m_renderFpsDropColor);
+		currentX += m_renderFpsString->getWidth() + kHudGapPx / 2;
+		m_renderFpsLowString->draw(currentX, m_renderFpsPosition.y, m_renderFpsLowColor, m_renderFpsDropColor);
+		currentX += m_renderFpsLowString->getWidth() + kHudGapPx / 2;
+		m_renderFpsLimitString->draw(currentX, m_renderFpsPosition.y, m_renderFpsLimitColor, m_renderFpsDropColor);
 	}
 }
 

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -6099,19 +6099,22 @@ void InGameUI::drawRenderFps(Int &x, Int &y)
 		updateRenderFpsString();
 	}
 
-	UnsignedInt renderFpsLimit = 0u;
+	UnsignedInt renderFpsLimit = RenderFpsPreset::UncappedFpsValue;
 	if (TheGlobalData->m_useFpsLimit)
 	{
 		renderFpsLimit = (UnsignedInt)TheFramePacer->getFramesPerSecondLimit();
-		if (renderFpsLimit == RenderFpsPreset::UncappedFpsValue)
-		{
-			renderFpsLimit = 0u;
-		}
 	}
 	if (renderFpsLimit != m_lastRenderFpsLimit)
 	{
 		UnicodeString fpsLimitStr;
-		fpsLimitStr.format(L"[%u]", renderFpsLimit);
+		if (renderFpsLimit == RenderFpsPreset::UncappedFpsValue)
+		{
+			fpsLimitStr.format(L"[X]");
+		}
+		else
+		{
+			fpsLimitStr.format(L"[%u]", renderFpsLimit);
+		}
 		m_renderFpsLimitString->setText(fpsLimitStr);
 		m_lastRenderFpsLimit = renderFpsLimit;
 	}

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -180,7 +180,7 @@ protected:
 	Real m_low1PercentFPS;	///<1% low fps.
 	Real m_currentFPS;		///<current fps value.
 
-	static constexpr Int FPS_HISTORY_SIZE = 5000;   // covers 5s at 1000 FPS, degrades gracefully beyond
+	enum { FPS_HISTORY_SIZE = 5000 }; // covers 5s at 1000 FPS, degrades gracefully beyond
 	Real m_fpsHistory[FPS_HISTORY_SIZE];
 	Real m_durationHistory[FPS_HISTORY_SIZE];
 	Int  m_historyOffset;

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -162,7 +162,10 @@ protected:
 	void drawCurrentDebugDisplay();			///< draws current debug display
 	void calculateTerrainLOD();						///< Calculate terrain LOD.
 	void renderLetterBox(UnsignedInt time);							///< draw letter box border
-	void updateAverageFPS();	///< calculate the average and 1% low fps over time windows (0.5s and 3.0s).
+	void updatePerformanceMetrics(); ///< update the average and 1% low fps metrics.
+	void addFpsSample(Real elapsedSeconds); ///< add a new sample to the history buffer.
+	Real calculateAverageFPS(Real windowSeconds); ///< calculate average FPS over a time window.
+	Real calculateLow1PercentFPS(Real windowSeconds); ///< calculate 1% low FPS over a time window.
 	void setup2DRenderState(TextureClass *tex, DrawImageMode mode, Bool grayscale);
 	virtual void onBeginBatch() override;
 	virtual void onEndBatch() override;
@@ -176,6 +179,13 @@ protected:
 	Real m_averageFPS;		///< average fps over the last 0.5s.
 	Real m_low1PercentFPS;	///<1% low fps.
 	Real m_currentFPS;		///<current fps value.
+
+	static constexpr Int FPS_HISTORY_SIZE = 5000;   // covers 5s at 1000 FPS, degrades gracefully beyond
+	Real m_fpsHistory[FPS_HISTORY_SIZE];
+	Real m_durationHistory[FPS_HISTORY_SIZE];
+	Int  m_historyOffset;
+	Int  m_historyCount;
+	Int64 m_lastUpdateTime64;
 
 	TextureClass *m_batchTexture;
 	DrawImageMode m_batchMode;

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -148,6 +148,7 @@ public:
 
 	void drawFPSStats();								///< draw the fps on the screen
 	virtual Real getAverageFPS() override;						///< return the average FPS.
+	virtual Real getLow1PercentFPS() override;					///< return the 1% low FPS.
 	virtual Real getCurrentFPS() override;						///< return the current FPS.
 	virtual Int getLastFrameDrawCalls() override;				///< returns the number of draw calls issued in the previous frame
 
@@ -161,7 +162,7 @@ protected:
 	void drawCurrentDebugDisplay();			///< draws current debug display
 	void calculateTerrainLOD();						///< Calculate terrain LOD.
 	void renderLetterBox(UnsignedInt time);							///< draw letter box border
-	void updateAverageFPS();	///< calculate the average fps over the last 30 frames.
+	void updateAverageFPS();	///< calculate the average and 1% low fps over time windows (0.5s and 3.0s).
 	void setup2DRenderState(TextureClass *tex, DrawImageMode mode, Bool grayscale);
 	virtual void onBeginBatch() override;
 	virtual void onEndBatch() override;
@@ -172,7 +173,8 @@ protected:
 	Render2DClass *m_2DRender;								///< interface for common 2D functions
 	IRegion2D m_clipRegion;									///< the clipping region for images
 	Bool m_isClippedEnabled;	///<used by 2D drawing operations to define clip re
-	Real m_averageFPS;		///<average fps over the last 30 frames.
+	Real m_averageFPS;		///< average fps over the last 0.5s.
+	Real m_low1PercentFPS;	///<1% low fps.
 	Real m_currentFPS;		///<current fps value.
 
 	TextureClass *m_batchTexture;

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -183,6 +183,7 @@ protected:
 	enum { FPS_HISTORY_SIZE = 5000 }; // covers 5s at 1000 FPS, degrades gracefully beyond
 	Real m_fpsHistory[FPS_HISTORY_SIZE];
 	Real m_durationHistory[FPS_HISTORY_SIZE];
+	Real m_sortBuffer[FPS_HISTORY_SIZE];
 	Int  m_historyOffset;
 	Int  m_historyCount;
 	Int64 m_lastUpdateTime64;

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -180,7 +180,7 @@ protected:
 	Real m_low1PercentFPS;	///<1% low fps.
 	Real m_currentFPS;		///<current fps value.
 
-	enum { FPS_HISTORY_SIZE = 5000 }; // covers 5s at 1000 FPS, degrades gracefully beyond
+	enum { FPS_HISTORY_SIZE = 4096 }; ; // degrades gracefully beyond this size
 	Real m_fpsHistory[FPS_HISTORY_SIZE];
 	Real m_durationHistory[FPS_HISTORY_SIZE];
 	Real m_sortBuffer[FPS_HISTORY_SIZE];

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -176,17 +176,16 @@ protected:
 	Render2DClass *m_2DRender;								///< interface for common 2D functions
 	IRegion2D m_clipRegion;									///< the clipping region for images
 	Bool m_isClippedEnabled;	///<used by 2D drawing operations to define clip re
-	Real m_averageFPS;		///< average fps over the last 0.5s.
+	Real m_averageFPS;		///< average fps over the last 1.0s.
 	Real m_low1PercentFPS;	///<1% low fps.
 	Real m_currentFPS;		///<current fps value.
 
-	enum { FPS_HISTORY_SIZE = 4096 }; ; // degrades gracefully beyond this size
-	Real m_fpsHistory[FPS_HISTORY_SIZE];
-	Real m_durationHistory[FPS_HISTORY_SIZE];
-	Real m_sortBuffer[FPS_HISTORY_SIZE];
+	enum { FPS_HISTORY_SIZE = 4096 }; // degrades gracefully beyond this size
+	UnsignedShort m_durationHistory[FPS_HISTORY_SIZE];
 	Int  m_historyOffset;
 	Int  m_historyCount;
 	Int64 m_lastUpdateTime64;
+	UnsignedInt m_lastLow1PercentUpdateMs;
 
 	TextureClass *m_batchTexture;
 	DrawImageMode m_batchMode;

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -49,6 +49,33 @@ class RTS3DInterfaceScene;
 class TextureClass;
 
 
+class QuantizedUnsignedShort
+{
+public:
+	QuantizedUnsignedShort() : m_value(2083) {}
+	explicit QuantizedUnsignedShort(UnsignedShort val) : m_value(val) {}
+
+	static QuantizedUnsignedShort fromSeconds(Real seconds)
+	{
+		Int64 ticks = (Int64)(seconds * 62500.0f + 0.5f);
+		if (ticks >= 65535) return QuantizedUnsignedShort(65535);
+		if (ticks <= 0) return QuantizedUnsignedShort(1);
+		return QuantizedUnsignedShort((UnsignedShort)ticks);
+	}
+
+	UnsignedShort getValue() const { return m_value; }
+	void setValue(UnsignedShort val) { m_value = val; }
+
+	Real toFPS() const { return 62500.0f / (Real)m_value; }
+	Real toSeconds() const { return (Real)m_value / 62500.0f; }
+
+	operator UnsignedShort() const { return m_value; }
+
+private:
+	UnsignedShort m_value;
+};
+
+
 //=============================================================================
 /** W3D implementation of the game display which is responsible for creating
   * all interaction with the screen and updating the display
@@ -181,7 +208,7 @@ protected:
 	Real m_currentFPS;		///<current fps value.
 
 	enum { FPS_HISTORY_SIZE = 4096 }; // degrades gracefully beyond this size
-	UnsignedShort m_durationHistory[FPS_HISTORY_SIZE];
+	QuantizedUnsignedShort m_durationHistory[FPS_HISTORY_SIZE];
 	Int  m_historyOffset;
 	Int  m_historyCount;
 	Int64 m_lastUpdateTime64;

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -59,8 +59,14 @@ public:
 	static QuantizedUnsignedShort fromSeconds(Real seconds)
 	{
 		Int64 ticks = (Int64)(seconds * TICKS_PER_SECOND + 0.5f);
-		if (ticks >= 65535) return QuantizedUnsignedShort(65535);
-		if (ticks <= 0) return QuantizedUnsignedShort(1);
+		if (ticks >= 65535)
+		{
+			return QuantizedUnsignedShort(65535);
+		}
+		if (ticks <= 0)
+		{
+			return QuantizedUnsignedShort(1);
+		}
 		return QuantizedUnsignedShort((UnsignedShort)ticks);
 	}
 

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -48,12 +48,11 @@ class RTS2DScene;
 class RTS3DInterfaceScene;
 class TextureClass;
 
+constexpr const Real TICKS_PER_SECOND = 62500.0f;
 
 class QuantizedUnsignedShort
 {
 public:
-	static constexpr Real TICKS_PER_SECOND = 62500.0f;
-
 	QuantizedUnsignedShort() : m_value(2083) {}
 	explicit QuantizedUnsignedShort(UnsignedShort val) : m_value(val) {}
 

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -52,12 +52,14 @@ class TextureClass;
 class QuantizedUnsignedShort
 {
 public:
+	static constexpr Real TICKS_PER_SECOND = 62500.0f;
+
 	QuantizedUnsignedShort() : m_value(2083) {}
 	explicit QuantizedUnsignedShort(UnsignedShort val) : m_value(val) {}
 
 	static QuantizedUnsignedShort fromSeconds(Real seconds)
 	{
-		Int64 ticks = (Int64)(seconds * 62500.0f + 0.5f);
+		Int64 ticks = (Int64)(seconds * TICKS_PER_SECOND + 0.5f);
 		if (ticks >= 65535) return QuantizedUnsignedShort(65535);
 		if (ticks <= 0) return QuantizedUnsignedShort(1);
 		return QuantizedUnsignedShort((UnsignedShort)ticks);
@@ -66,8 +68,8 @@ public:
 	UnsignedShort getValue() const { return m_value; }
 	void setValue(UnsignedShort val) { m_value = val; }
 
-	Real toFPS() const { return 62500.0f / (Real)m_value; }
-	Real toSeconds() const { return (Real)m_value / 62500.0f; }
+	Real toFPS() const { return TICKS_PER_SECOND / (Real)m_value; }
+	Real toSeconds() const { return (Real)m_value / TICKS_PER_SECOND; }
 
 	operator UnsignedShort() const { return m_value; }
 

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -1039,7 +1039,7 @@ Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 		return m_currentFPS;
 	}
 
-	const Int bottomSampleCount = std::max((sampleCount + 99) / 100, 1);
+	const Int bottomSampleCount = std::max((sampleCount + 50) / 100, 1);
 
 	std::nth_element(m_sortBuffer, m_sortBuffer + bottomSampleCount, m_sortBuffer + sampleCount);
 

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -996,7 +996,10 @@ void W3DDisplay::updateAverageFPS()
 		fpsHistory[historyOffset] = m_currentFPS;
 		durationHistory[historyOffset] = elapsedSeconds;
 		historyOffset = (historyOffset + 1) % FPS_HISTORY_SIZE;
-		if (historyCount < FPS_HISTORY_SIZE) historyCount++;
+		if (historyCount < FPS_HISTORY_SIZE)
+		{
+			historyCount++;
+		}
 	}
 
 	// determine average frame rate over the last 0.5 seconds and 1% low over 3.0 seconds.
@@ -1019,10 +1022,16 @@ void W3DDisplay::updateAverageFPS()
 			{
 				fpsSum += fpsHistory[idx];
 				avgSamples++;
-				if (timeSum >= 0.5f) avgDone = TRUE;
+				if (timeSum >= 0.5f)
+				{
+					avgDone = TRUE;
+				}
 			}
 			
-			if (timeSum >= 3.0f) break;
+			if (timeSum >= 3.0f)
+			{
+				break;
+			}
 		}
 
 		m_averageFPS = avgSamples > 0 ? fpsSum / (Real)avgSamples : m_currentFPS;

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -361,6 +361,15 @@ W3DDisplay::W3DDisplay()
 	m_batchGrayscale = FALSE;
 	m_batchNeedsInit = FALSE;
 
+	m_historyOffset = 0;
+	m_historyCount = 0;
+	m_lastUpdateTime64 = 0;
+	for (Int h = 0; h < FPS_HISTORY_SIZE; ++h)
+	{
+		m_fpsHistory[h] = 0.0f;
+		m_durationHistory[h] = 0.0f;
+	}
+
 #ifdef PROFILER_ENABLED
 	m_profilerFrameCapture = NEW W3DProfilerFrameCapture();
 #endif
@@ -959,103 +968,98 @@ void W3DDisplay::reset()
 
 const UnsignedInt START_CUMU_FRAME = LOGICFRAMES_PER_SECOND / 2;	// skip first half-sec
 
-void W3DDisplay::updateAverageFPS()
+void W3DDisplay::addFpsSample(Real elapsedSeconds)
 {
-	constexpr const Int FPS_HISTORY_SIZE = 1000;
-	static Real fpsHistory[FPS_HISTORY_SIZE] = {0};
-	static Real durationHistory[FPS_HISTORY_SIZE] = {0};
-	static Int historyOffset = 0;
-	static Int historyCount = 0;
-	static Int64 lastUpdateTime64 = 0;
+	if (elapsedSeconds <= 0.0f) return;
 
+	m_currentFPS = 1.0f / elapsedSeconds;
+	m_fpsHistory[m_historyOffset] = m_currentFPS;
+	m_durationHistory[m_historyOffset] = elapsedSeconds;
+
+	m_historyOffset = (m_historyOffset + 1) % FPS_HISTORY_SIZE;
+	if (m_historyCount < FPS_HISTORY_SIZE) m_historyCount++;
+}
+
+Real W3DDisplay::calculateAverageFPS(Real windowSeconds)
+{
+	if (m_historyCount == 0) return m_currentFPS;
+
+	Real timeSum = 0;
+	Real fpsSum = 0;
+	Int samples = 0;
+
+	for (Int i = 0; i < m_historyCount; ++i)
+	{
+		Int idx = (m_historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
+		timeSum += m_durationHistory[idx];
+		fpsSum += m_fpsHistory[idx];
+		samples++;
+
+		if (timeSum >= windowSeconds) break;
+	}
+
+	return (samples > 0) ? (fpsSum / (Real)samples) : m_currentFPS;
+}
+
+Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
+{
+	if (m_historyCount == 0) return m_currentFPS;
+
+	static Real sortBuffer[FPS_HISTORY_SIZE];
+	Real timeSum = 0;
+	Int sampleCount = 0;
+
+	for (Int i = 0; i < m_historyCount; ++i)
+	{
+		Int idx = (m_historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
+		timeSum += m_durationHistory[idx];
+		sortBuffer[sampleCount++] = m_fpsHistory[idx];
+
+		if (timeSum >= windowSeconds) break;
+	}
+
+	if (sampleCount == 0) return m_currentFPS;
+
+	const Int bottomSampleCount = std::max((sampleCount + 99) / 100, 1);
+
+	std::nth_element(sortBuffer, sortBuffer + bottomSampleCount, sortBuffer + sampleCount);
+
+	Real lowSum = 0;
+	for (Int i = 0; i < bottomSampleCount; ++i) lowSum += sortBuffer[i];
+
+	return lowSum / (Real)bottomSampleCount;
+}
+
+void W3DDisplay::updatePerformanceMetrics()
+{
 	const Int64 freq64 = getPerformanceCounterFrequency();
 	const Int64 time64 = getPerformanceCounter();
 
 #if defined(RTS_DEBUG)
-	if (TheGameLogic->getFrame() == START_CUMU_FRAME)
-	{
-		m_timerAtCumuFPSStart = time64;
-	}
+	if (TheGameLogic->getFrame() == START_CUMU_FRAME) m_timerAtCumuFPSStart = time64;
 #endif
 
-	if (lastUpdateTime64 == 0)
+	if (m_lastUpdateTime64 == 0)
 	{
-		lastUpdateTime64 = time64;
+		m_lastUpdateTime64 = time64;
 		return;
 	}
 
-	const Int64 timeDiff = time64 - lastUpdateTime64;
+	const Int64 timeDiff = time64 - m_lastUpdateTime64;
+	Real elapsedSeconds = (Real)timeDiff / (Real)freq64;
 
-	// convert elapsed time to seconds
-	Real elapsedSeconds = (Real)timeDiff/(Real)freq64;
+	addFpsSample(elapsedSeconds);
+	m_averageFPS = calculateAverageFPS(0.5f);
 
-	// append new sample to fps history.
-	if (elapsedSeconds > 0)
+	static UnsignedInt lastLowUpdate = 0;
+	UnsignedInt now = timeGetTime();
+	if (now - lastLowUpdate >= 1000)
 	{
-		m_currentFPS = 1.0f/elapsedSeconds;
-		fpsHistory[historyOffset] = m_currentFPS;
-		durationHistory[historyOffset] = elapsedSeconds;
-		historyOffset = (historyOffset + 1) % FPS_HISTORY_SIZE;
-		if (historyCount < FPS_HISTORY_SIZE)
-		{
-			historyCount++;
-		}
+		lastLowUpdate = now;
+		m_low1PercentFPS = calculateLow1PercentFPS(3.0f);
 	}
 
-	// determine average frame rate over the last 0.5 seconds and 1% low over 3.0 seconds.
-	if (historyCount > 0)
-	{
-		Real timeSum = 0;
-		Real fpsSum = 0;
-		Int avgSamples = 0;
-		Int lowSamples = 0;
-		Bool avgDone = FALSE;
-
-		for (Int i = 0; i < historyCount; ++i)
-		{
-			Int idx = (historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
-			timeSum += durationHistory[idx];
-			
-			lowSamples++;
-			
-			if (!avgDone)
-			{
-				fpsSum += fpsHistory[idx];
-				avgSamples++;
-				if (timeSum >= 0.5f)
-				{
-					avgDone = TRUE;
-				}
-			}
-			
-			if (timeSum >= 3.0f)
-			{
-				break;
-			}
-		}
-
-		m_averageFPS = avgSamples > 0 ? fpsSum / (Real)avgSamples : m_currentFPS;
-
-		// TheSuperHackers @feature One percent low FPS calculation (last 3.0 seconds)
-		// Throttle sorting to 1000ms intervals to match HUD refresh and save CPU
-		static UnsignedInt lastLowUpdate = 0;
-		UnsignedInt now = timeGetTime();
-		if (now - lastLowUpdate >= 1000)
-		{
-			lastLowUpdate = now;
-			static Real sortBuffer[FPS_HISTORY_SIZE];
-			for (Int i = 0; i < lowSamples; ++i)
-			{
-				Int idx = (historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
-				sortBuffer[i] = fpsHistory[idx];
-			}
-			const Int lowCount = std::max(lowSamples / 100, 1);
-			std::nth_element(sortBuffer, sortBuffer + lowCount, sortBuffer + lowSamples);
-			m_low1PercentFPS = std::accumulate(sortBuffer, sortBuffer + lowCount, 0.0f) / (Real)lowCount;
-		}
-	}
-
-	lastUpdateTime64 = time64;
+	m_lastUpdateTime64 = time64;
 }
 
 #if defined(RTS_DEBUG)	//debug hack to view object under mouse stats
@@ -1795,7 +1799,7 @@ void W3DDisplay::draw()
 	if (TheGlobalData->m_headless)
 		return;
 
-	updateAverageFPS();
+	updatePerformanceMetrics();
 	if (TheGlobalData->m_enableDynamicLOD && TheGameLogic->getShowDynamicLOD())
 	{
 		DynamicGameLODLevel lod=TheGameLODManager->findDynamicLODLevel(m_averageFPS);

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -1008,8 +1008,9 @@ Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 	static Real sortBuffer[FPS_HISTORY_SIZE];
 	Real timeSum = 0;
 	Int sampleCount = 0;
+	Int i;
 
-	for (Int i = 0; i < m_historyCount; ++i)
+	for (i = 0; i < m_historyCount; ++i)
 	{
 		Int idx = (m_historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
 		timeSum += m_durationHistory[idx];
@@ -1025,7 +1026,7 @@ Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 	std::nth_element(sortBuffer, sortBuffer + bottomSampleCount, sortBuffer + sampleCount);
 
 	Real lowSum = 0;
-	for (Int i = 0; i < bottomSampleCount; ++i) lowSum += sortBuffer[i];
+	for (i = 0; i < bottomSampleCount; ++i) lowSum += sortBuffer[i];
 
 	return lowSum / (Real)bottomSampleCount;
 }

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -970,42 +970,54 @@ const UnsignedInt START_CUMU_FRAME = LOGICFRAMES_PER_SECOND / 2;	// skip first h
 
 void W3DDisplay::addFpsSample(Real elapsedSeconds)
 {
-	if (elapsedSeconds <= 0.0f) return;
+	if (elapsedSeconds <= 0.0f)
+	{
+		return;
+	}
 
 	m_currentFPS = 1.0f / elapsedSeconds;
 	m_fpsHistory[m_historyOffset] = m_currentFPS;
 	m_durationHistory[m_historyOffset] = elapsedSeconds;
 
 	m_historyOffset = (m_historyOffset + 1) % FPS_HISTORY_SIZE;
-	if (m_historyCount < FPS_HISTORY_SIZE) m_historyCount++;
+	if (m_historyCount < FPS_HISTORY_SIZE)
+	{
+		m_historyCount++;
+	}
 }
 
 Real W3DDisplay::calculateAverageFPS(Real windowSeconds)
 {
-	if (m_historyCount == 0) return m_currentFPS;
+	if (m_historyCount == 0)
+	{
+		return m_currentFPS;
+	}
 
 	Real timeSum = 0;
-	Real fpsSum = 0;
 	Int samples = 0;
 
 	for (Int i = 0; i < m_historyCount; ++i)
 	{
 		Int idx = (m_historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
 		timeSum += m_durationHistory[idx];
-		fpsSum += m_fpsHistory[idx];
 		samples++;
 
-		if (timeSum >= windowSeconds) break;
+		if (timeSum >= windowSeconds)
+		{
+			break;
+		}
 	}
 
-	return (samples > 0) ? (fpsSum / (Real)samples) : m_currentFPS;
+	return (timeSum > 0) ? ((Real)samples / timeSum) : m_currentFPS;
 }
 
 Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 {
-	if (m_historyCount == 0) return m_currentFPS;
+	if (m_historyCount == 0)
+	{
+		return m_currentFPS;
+	}
 
-	static Real sortBuffer[FPS_HISTORY_SIZE];
 	Real timeSum = 0;
 	Int sampleCount = 0;
 	Int i;
@@ -1014,19 +1026,28 @@ Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 	{
 		Int idx = (m_historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
 		timeSum += m_durationHistory[idx];
-		sortBuffer[sampleCount++] = m_fpsHistory[idx];
+		m_sortBuffer[sampleCount++] = m_fpsHistory[idx];
 
-		if (timeSum >= windowSeconds) break;
+		if (timeSum >= windowSeconds)
+		{
+			break;
+		}
 	}
 
-	if (sampleCount == 0) return m_currentFPS;
+	if (sampleCount == 0)
+	{
+		return m_currentFPS;
+	}
 
 	const Int bottomSampleCount = std::max((sampleCount + 99) / 100, 1);
 
-	std::nth_element(sortBuffer, sortBuffer + bottomSampleCount, sortBuffer + sampleCount);
+	std::nth_element(m_sortBuffer, m_sortBuffer + bottomSampleCount, m_sortBuffer + sampleCount);
 
 	Real lowSum = 0;
-	for (i = 0; i < bottomSampleCount; ++i) lowSum += sortBuffer[i];
+	for (i = 0; i < bottomSampleCount; ++i)
+	{
+		lowSum += m_sortBuffer[i];
+	}
 
 	return lowSum / (Real)bottomSampleCount;
 }
@@ -1037,7 +1058,10 @@ void W3DDisplay::updatePerformanceMetrics()
 	const Int64 time64 = getPerformanceCounter();
 
 #if defined(RTS_DEBUG)
-	if (TheGameLogic->getFrame() == START_CUMU_FRAME) m_timerAtCumuFPSStart = time64;
+	if (TheGameLogic->getFrame() == START_CUMU_FRAME)
+	{
+		m_timerAtCumuFPSStart = time64;
+	}
 #endif
 
 	if (m_lastUpdateTime64 == 0)

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -340,6 +340,7 @@ W3DDisplay::W3DDisplay()
 	m_2DScene = nullptr;
 	m_3DInterfaceScene = nullptr;
 	m_averageFPS = TheGlobalData->m_framesPerSecondLimit;
+	m_low1PercentFPS = TheGlobalData->m_framesPerSecondLimit;
 #if defined(RTS_DEBUG)
 	m_timerAtCumuFPSStart = 0;
 #endif
@@ -960,11 +961,12 @@ const UnsignedInt START_CUMU_FRAME = LOGICFRAMES_PER_SECOND / 2;	// skip first h
 
 void W3DDisplay::updateAverageFPS()
 {
-	constexpr const Int FPS_HISTORY_SIZE = 30;
-
-	static Int64 lastUpdateTime64 = 0;
-	static Int historyOffset = 0;
+	constexpr const Int FPS_HISTORY_SIZE = 1000;
 	static Real fpsHistory[FPS_HISTORY_SIZE] = {0};
+	static Real durationHistory[FPS_HISTORY_SIZE] = {0};
+	static Int historyOffset = 0;
+	static Int historyCount = 0;
+	static Int64 lastUpdateTime64 = 0;
 
 	const Int64 freq64 = getPerformanceCounterFrequency();
 	const Int64 time64 = getPerformanceCounter();
@@ -976,21 +978,73 @@ void W3DDisplay::updateAverageFPS()
 	}
 #endif
 
+	if (lastUpdateTime64 == 0)
+	{
+		lastUpdateTime64 = time64;
+		return;
+	}
+
 	const Int64 timeDiff = time64 - lastUpdateTime64;
 
 	// convert elapsed time to seconds
 	Real elapsedSeconds = (Real)timeDiff/(Real)freq64;
 
 	// append new sample to fps history.
-	if (historyOffset >= FPS_HISTORY_SIZE)
-		historyOffset = 0;
+	if (elapsedSeconds > 0)
+	{
+		m_currentFPS = 1.0f/elapsedSeconds;
+		fpsHistory[historyOffset] = m_currentFPS;
+		durationHistory[historyOffset] = elapsedSeconds;
+		historyOffset = (historyOffset + 1) % FPS_HISTORY_SIZE;
+		if (historyCount < FPS_HISTORY_SIZE) historyCount++;
+	}
 
-	m_currentFPS = 1.0f/elapsedSeconds;
-	fpsHistory[historyOffset++] = m_currentFPS;
+	// determine average frame rate over the last 0.5 seconds and 1% low over 3.0 seconds.
+	if (historyCount > 0)
+	{
+		Real timeSum = 0;
+		Real fpsSum = 0;
+		Int avgSamples = 0;
+		Int lowSamples = 0;
+		Bool avgDone = FALSE;
 
-	// determine average frame rate over our past history.
-	const Real sum = std::accumulate(fpsHistory, fpsHistory + FPS_HISTORY_SIZE, 0.0f);
-	m_averageFPS = sum / FPS_HISTORY_SIZE;
+		for (Int i = 0; i < historyCount; ++i)
+		{
+			Int idx = (historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
+			timeSum += durationHistory[idx];
+			
+			lowSamples++;
+			
+			if (!avgDone)
+			{
+				fpsSum += fpsHistory[idx];
+				avgSamples++;
+				if (timeSum >= 0.5f) avgDone = TRUE;
+			}
+			
+			if (timeSum >= 3.0f) break;
+		}
+
+		m_averageFPS = avgSamples > 0 ? fpsSum / (Real)avgSamples : m_currentFPS;
+
+		// TheSuperHackers @feature One percent low FPS calculation (last 3.0 seconds)
+		// Throttle sorting to 1000ms intervals to match HUD refresh and save CPU
+		static UnsignedInt lastLowUpdate = 0;
+		UnsignedInt now = timeGetTime();
+		if (now - lastLowUpdate >= 1000)
+		{
+			lastLowUpdate = now;
+			static Real sortBuffer[FPS_HISTORY_SIZE];
+			for (Int i = 0; i < lowSamples; ++i)
+			{
+				Int idx = (historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
+				sortBuffer[i] = fpsHistory[idx];
+			}
+			const Int lowCount = std::max(lowSamples / 100, 1);
+			std::nth_element(sortBuffer, sortBuffer + lowCount, sortBuffer + lowSamples);
+			m_low1PercentFPS = std::accumulate(sortBuffer, sortBuffer + lowCount, 0.0f) / (Real)lowCount;
+		}
+	}
 
 	lastUpdateTime64 = time64;
 }
@@ -1691,6 +1745,11 @@ void W3DDisplay::calculateTerrainLOD()
 Real W3DDisplay::getAverageFPS()
 {
 	return m_averageFPS;
+}
+
+Real W3DDisplay::getLow1PercentFPS()
+{
+	return m_low1PercentFPS;
 }
 
 Real W3DDisplay::getCurrentFPS()

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -362,12 +362,13 @@ W3DDisplay::W3DDisplay()
 	m_batchNeedsInit = FALSE;
 
 	m_historyOffset = 0;
-	m_historyCount = 0;
+	m_historyCount = 1;
 	m_lastUpdateTime64 = 0;
+	m_currentFPS = 30.0f;
 	for (Int h = 0; h < FPS_HISTORY_SIZE; ++h)
 	{
-		m_fpsHistory[h] = 0.0f;
-		m_durationHistory[h] = 0.0f;
+		m_fpsHistory[h] = 30.0f;
+		m_durationHistory[h] = 1.0f / 30.0f;
 	}
 
 #ifdef PROFILER_ENABLED
@@ -925,6 +926,7 @@ void W3DDisplay::init()
 
 	// we're now online
 	m_initialized = true;
+	m_lastUpdateTime64 = getPerformanceCounter();
 	if( TheGlobalData->m_displayDebug )
 	{
 		m_debugDisplayCallback = StatDebugDisplay;
@@ -970,16 +972,16 @@ const UnsignedInt START_CUMU_FRAME = LOGICFRAMES_PER_SECOND / 2;	// skip first h
 
 void W3DDisplay::addFpsSample(Real elapsedSeconds)
 {
-	if (elapsedSeconds <= 0.0f)
+	if (elapsedSeconds < 0.0001f)
 	{
-		return;
+		elapsedSeconds = 0.0001f;
 	}
 
 	m_currentFPS = 1.0f / elapsedSeconds;
 	m_fpsHistory[m_historyOffset] = m_currentFPS;
 	m_durationHistory[m_historyOffset] = elapsedSeconds;
 
-	m_historyOffset = (m_historyOffset + 1) % FPS_HISTORY_SIZE;
+	m_historyOffset = (m_historyOffset + 1) & (FPS_HISTORY_SIZE - 1);
 	if (m_historyCount < FPS_HISTORY_SIZE)
 	{
 		m_historyCount++;
@@ -988,17 +990,13 @@ void W3DDisplay::addFpsSample(Real elapsedSeconds)
 
 Real W3DDisplay::calculateAverageFPS(Real windowSeconds)
 {
-	if (m_historyCount == 0)
-	{
-		return m_currentFPS;
-	}
-
 	Real timeSum = 0;
 	Int samples = 0;
 
+	Int idx = m_historyOffset - 1;
 	for (Int i = 0; i < m_historyCount; ++i)
 	{
-		Int idx = (m_historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
+		if (idx < 0) idx += FPS_HISTORY_SIZE;
 		timeSum += m_durationHistory[idx];
 		samples++;
 
@@ -1006,6 +1004,7 @@ Real W3DDisplay::calculateAverageFPS(Real windowSeconds)
 		{
 			break;
 		}
+		--idx;
 	}
 
 	return (timeSum > 0) ? ((Real)samples / timeSum) : m_currentFPS;
@@ -1013,18 +1012,14 @@ Real W3DDisplay::calculateAverageFPS(Real windowSeconds)
 
 Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 {
-	if (m_historyCount == 0)
-	{
-		return m_currentFPS;
-	}
-
 	Real timeSum = 0;
 	Int sampleCount = 0;
 	Int i;
 
+	Int idx = m_historyOffset - 1;
 	for (i = 0; i < m_historyCount; ++i)
 	{
-		Int idx = (m_historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
+		if (idx < 0) idx += FPS_HISTORY_SIZE;
 		timeSum += m_durationHistory[idx];
 		m_sortBuffer[sampleCount++] = m_fpsHistory[idx];
 
@@ -1032,6 +1027,7 @@ Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 		{
 			break;
 		}
+		--idx;
 	}
 
 	if (sampleCount == 0)
@@ -1064,21 +1060,15 @@ void W3DDisplay::updatePerformanceMetrics()
 	}
 #endif
 
-	if (m_lastUpdateTime64 == 0)
-	{
-		m_lastUpdateTime64 = time64;
-		return;
-	}
-
 	const Int64 timeDiff = time64 - m_lastUpdateTime64;
 	Real elapsedSeconds = (Real)timeDiff / (Real)freq64;
 
 	addFpsSample(elapsedSeconds);
-	m_averageFPS = calculateAverageFPS(0.5f);
+	m_averageFPS = calculateAverageFPS(1.0f); // 1.0s window for smooth Dynamic LOD tracking and UI matching
 
 	static UnsignedInt lastLowUpdate = 0;
 	UnsignedInt now = timeGetTime();
-	if (now - lastLowUpdate >= 1000)
+	if (now - lastLowUpdate >= 100) // update low 1% metrics at 100ms intervals instead of 1000ms since it is now extremely cheap
 	{
 		lastLowUpdate = now;
 		m_low1PercentFPS = calculateLow1PercentFPS(3.0f);

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -988,7 +988,7 @@ Real W3DDisplay::calculateAverageFPS(Real windowSeconds)
 {
 	UnsignedInt unitsSum = 0;
 	Int samples = 0;
-	const UnsignedInt windowUnits = (UnsignedInt)(windowSeconds * QuantizedUnsignedShort::TICKS_PER_SECOND);
+	const UnsignedInt windowUnits = (UnsignedInt)(windowSeconds * TICKS_PER_SECOND);
 
 	for (Int i = 0; i < m_historyCount; ++i)
 	{
@@ -1002,14 +1002,14 @@ Real W3DDisplay::calculateAverageFPS(Real windowSeconds)
 		}
 	}
 
-	return (unitsSum > 0) ? ((Real)samples * QuantizedUnsignedShort::TICKS_PER_SECOND / (Real)unitsSum) : m_currentFPS;
+	return (unitsSum > 0) ? ((Real)samples * TICKS_PER_SECOND / (Real)unitsSum) : m_currentFPS;
 }
 
 Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 {
 	UnsignedInt unitsSum = 0;
 	Int sampleCount = 0;
-	const UnsignedInt windowUnits = (UnsignedInt)(windowSeconds * QuantizedUnsignedShort::TICKS_PER_SECOND);
+	const UnsignedInt windowUnits = (UnsignedInt)(windowSeconds * TICKS_PER_SECOND);
 	QuantizedUnsignedShort sortBuffer[FPS_HISTORY_SIZE];
 
 	Int i;
@@ -1040,7 +1040,7 @@ Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 		durationUnitsSum += sortBuffer[i];
 	}
 
-	return (durationUnitsSum > 0) ? ((Real)bottomSampleCount * QuantizedUnsignedShort::TICKS_PER_SECOND / (Real)durationUnitsSum) : m_currentFPS;
+	return (durationUnitsSum > 0) ? ((Real)bottomSampleCount * TICKS_PER_SECOND / (Real)durationUnitsSum) : m_currentFPS;
 }
 
 void W3DDisplay::updatePerformanceMetrics()

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -369,7 +369,7 @@ W3DDisplay::W3DDisplay()
 	m_lastUpdateTime64 = 0;
 	m_lastLow1PercentUpdateMs = 0;
 	m_currentFPS = 30.0f;
-	std::fill(m_durationHistory, m_durationHistory + FPS_HISTORY_SIZE, (UnsignedShort)2083);
+	std::fill(m_durationHistory, m_durationHistory + FPS_HISTORY_SIZE, QuantizedUnsignedShort());
 
 #ifdef PROFILER_ENABLED
 	m_profilerFrameCapture = NEW W3DProfilerFrameCapture();
@@ -972,11 +972,10 @@ const UnsignedInt START_CUMU_FRAME = LOGICFRAMES_PER_SECOND / 2;	// skip first h
 
 void W3DDisplay::addFpsSample(Real elapsedSeconds)
 {
-	Int64 ticks = (Int64)(elapsedSeconds * 62500.0f + 0.5f);
-	UnsignedShort quantized = (ticks >= 65535) ? 65535 : (ticks <= 0 ? 1 : (UnsignedShort)ticks);
+	QuantizedUnsignedShort duration = QuantizedUnsignedShort::fromSeconds(elapsedSeconds);
 
-	m_currentFPS = 62500.0f / (Real)quantized;
-	m_durationHistory[m_historyOffset] = quantized;
+	m_currentFPS = duration.toFPS();
+	m_durationHistory[m_historyOffset] = duration;
 
 	m_historyOffset = (m_historyOffset + 1) & (FPS_HISTORY_SIZE - 1);
 	if (m_historyCount < FPS_HISTORY_SIZE)
@@ -1011,7 +1010,7 @@ Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 	UnsignedInt unitsSum = 0;
 	Int sampleCount = 0;
 	const UnsignedInt windowUnits = (UnsignedInt)(windowSeconds * 62500.0f);
-	UnsignedShort sortBuffer[FPS_HISTORY_SIZE];
+	QuantizedUnsignedShort sortBuffer[FPS_HISTORY_SIZE];
 
 	Int i;
 	for (i = 0; i < m_historyCount; ++i)
@@ -1033,7 +1032,7 @@ Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 
 	const Int bottomSampleCount = std::max((sampleCount + 50) / 100, 1);
 
-	std::nth_element(sortBuffer, sortBuffer + bottomSampleCount, sortBuffer + sampleCount, std::greater<UnsignedShort>());
+	std::nth_element(sortBuffer, sortBuffer + bottomSampleCount, sortBuffer + sampleCount, std::greater<QuantizedUnsignedShort>());
 
 	UnsignedInt durationUnitsSum = 0;
 	for (i = 0; i < bottomSampleCount; ++i)

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -1009,8 +1009,9 @@ Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 	static Real sortBuffer[FPS_HISTORY_SIZE];
 	Real timeSum = 0;
 	Int sampleCount = 0;
+	Int i;
 
-	for (Int i = 0; i < m_historyCount; ++i)
+	for (i = 0; i < m_historyCount; ++i)
 	{
 		Int idx = (m_historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
 		timeSum += m_durationHistory[idx];
@@ -1026,7 +1027,7 @@ Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 	std::nth_element(sortBuffer, sortBuffer + bottomSampleCount, sortBuffer + sampleCount);
 
 	Real lowSum = 0;
-	for (Int i = 0; i < bottomSampleCount; ++i) lowSum += sortBuffer[i];
+	for (i = 0; i < bottomSampleCount; ++i) lowSum += sortBuffer[i];
 
 	return lowSum / (Real)bottomSampleCount;
 }

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -997,7 +997,10 @@ void W3DDisplay::updateAverageFPS()
 		fpsHistory[historyOffset] = m_currentFPS;
 		durationHistory[historyOffset] = elapsedSeconds;
 		historyOffset = (historyOffset + 1) % FPS_HISTORY_SIZE;
-		if (historyCount < FPS_HISTORY_SIZE) historyCount++;
+		if (historyCount < FPS_HISTORY_SIZE)
+		{
+			historyCount++;
+		}
 	}
 
 	// determine average frame rate over the last 0.5 seconds and 1% low over 3.0 seconds.
@@ -1020,10 +1023,16 @@ void W3DDisplay::updateAverageFPS()
 			{
 				fpsSum += fpsHistory[idx];
 				avgSamples++;
-				if (timeSum >= 0.5f) avgDone = TRUE;
+				if (timeSum >= 0.5f)
+				{
+					avgDone = TRUE;
+				}
 			}
 			
-			if (timeSum >= 3.0f) break;
+			if (timeSum >= 3.0f)
+			{
+				break;
+			}
 		}
 
 		m_averageFPS = avgSamples > 0 ? fpsSum / (Real)avgSamples : m_currentFPS;

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -988,7 +988,7 @@ Real W3DDisplay::calculateAverageFPS(Real windowSeconds)
 {
 	UnsignedInt unitsSum = 0;
 	Int samples = 0;
-	const UnsignedInt windowUnits = (UnsignedInt)(windowSeconds * 62500.0f);
+	const UnsignedInt windowUnits = (UnsignedInt)(windowSeconds * QuantizedUnsignedShort::TICKS_PER_SECOND);
 
 	for (Int i = 0; i < m_historyCount; ++i)
 	{
@@ -1002,14 +1002,14 @@ Real W3DDisplay::calculateAverageFPS(Real windowSeconds)
 		}
 	}
 
-	return (unitsSum > 0) ? ((Real)samples * 62500.0f / (Real)unitsSum) : m_currentFPS;
+	return (unitsSum > 0) ? ((Real)samples * QuantizedUnsignedShort::TICKS_PER_SECOND / (Real)unitsSum) : m_currentFPS;
 }
 
 Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 {
 	UnsignedInt unitsSum = 0;
 	Int sampleCount = 0;
-	const UnsignedInt windowUnits = (UnsignedInt)(windowSeconds * 62500.0f);
+	const UnsignedInt windowUnits = (UnsignedInt)(windowSeconds * QuantizedUnsignedShort::TICKS_PER_SECOND);
 	QuantizedUnsignedShort sortBuffer[FPS_HISTORY_SIZE];
 
 	Int i;
@@ -1040,7 +1040,7 @@ Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 		durationUnitsSum += sortBuffer[i];
 	}
 
-	return (durationUnitsSum > 0) ? ((Real)bottomSampleCount * 62500.0f / (Real)durationUnitsSum) : m_currentFPS;
+	return (durationUnitsSum > 0) ? ((Real)bottomSampleCount * QuantizedUnsignedShort::TICKS_PER_SECOND / (Real)durationUnitsSum) : m_currentFPS;
 }
 
 void W3DDisplay::updatePerformanceMetrics()

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -363,12 +363,13 @@ W3DDisplay::W3DDisplay()
 	m_batchNeedsInit = FALSE;
 
 	m_historyOffset = 0;
-	m_historyCount = 0;
+	m_historyCount = 1;
 	m_lastUpdateTime64 = 0;
+	m_currentFPS = 30.0f;
 	for (Int h = 0; h < FPS_HISTORY_SIZE; ++h)
 	{
-		m_fpsHistory[h] = 0.0f;
-		m_durationHistory[h] = 0.0f;
+		m_fpsHistory[h] = 30.0f;
+		m_durationHistory[h] = 1.0f / 30.0f;
 	}
 
 #ifdef PROFILER_ENABLED
@@ -926,6 +927,7 @@ void W3DDisplay::init()
 
 	// we're now online
 	m_initialized = true;
+	m_lastUpdateTime64 = getPerformanceCounter();
 	if( TheGlobalData->m_displayDebug )
 	{
 		m_debugDisplayCallback = StatDebugDisplay;
@@ -971,16 +973,16 @@ const UnsignedInt START_CUMU_FRAME = LOGICFRAMES_PER_SECOND / 2;	// skip first h
 
 void W3DDisplay::addFpsSample(Real elapsedSeconds)
 {
-	if (elapsedSeconds <= 0.0f)
+	if (elapsedSeconds < 0.0001f)
 	{
-		return;
+		elapsedSeconds = 0.0001f;
 	}
 
 	m_currentFPS = 1.0f / elapsedSeconds;
 	m_fpsHistory[m_historyOffset] = m_currentFPS;
 	m_durationHistory[m_historyOffset] = elapsedSeconds;
 
-	m_historyOffset = (m_historyOffset + 1) % FPS_HISTORY_SIZE;
+	m_historyOffset = (m_historyOffset + 1) & (FPS_HISTORY_SIZE - 1);
 	if (m_historyCount < FPS_HISTORY_SIZE)
 	{
 		m_historyCount++;
@@ -989,17 +991,13 @@ void W3DDisplay::addFpsSample(Real elapsedSeconds)
 
 Real W3DDisplay::calculateAverageFPS(Real windowSeconds)
 {
-	if (m_historyCount == 0)
-	{
-		return m_currentFPS;
-	}
-
 	Real timeSum = 0;
 	Int samples = 0;
 
+	Int idx = m_historyOffset - 1;
 	for (Int i = 0; i < m_historyCount; ++i)
 	{
-		Int idx = (m_historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
+		if (idx < 0) idx += FPS_HISTORY_SIZE;
 		timeSum += m_durationHistory[idx];
 		samples++;
 
@@ -1007,6 +1005,7 @@ Real W3DDisplay::calculateAverageFPS(Real windowSeconds)
 		{
 			break;
 		}
+		--idx;
 	}
 
 	return (timeSum > 0) ? ((Real)samples / timeSum) : m_currentFPS;
@@ -1014,18 +1013,14 @@ Real W3DDisplay::calculateAverageFPS(Real windowSeconds)
 
 Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 {
-	if (m_historyCount == 0)
-	{
-		return m_currentFPS;
-	}
-
 	Real timeSum = 0;
 	Int sampleCount = 0;
 	Int i;
 
+	Int idx = m_historyOffset - 1;
 	for (i = 0; i < m_historyCount; ++i)
 	{
-		Int idx = (m_historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
+		if (idx < 0) idx += FPS_HISTORY_SIZE;
 		timeSum += m_durationHistory[idx];
 		m_sortBuffer[sampleCount++] = m_fpsHistory[idx];
 
@@ -1033,6 +1028,7 @@ Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 		{
 			break;
 		}
+		--idx;
 	}
 
 	if (sampleCount == 0)
@@ -1065,21 +1061,15 @@ void W3DDisplay::updatePerformanceMetrics()
 	}
 #endif
 
-	if (m_lastUpdateTime64 == 0)
-	{
-		m_lastUpdateTime64 = time64;
-		return;
-	}
-
 	const Int64 timeDiff = time64 - m_lastUpdateTime64;
 	Real elapsedSeconds = (Real)timeDiff / (Real)freq64;
 
 	addFpsSample(elapsedSeconds);
-	m_averageFPS = calculateAverageFPS(0.5f);
+	m_averageFPS = calculateAverageFPS(1.0f); // 1.0s window for smooth Dynamic LOD tracking and UI matching
 
 	static UnsignedInt lastLowUpdate = 0;
 	UnsignedInt now = timeGetTime();
-	if (now - lastLowUpdate >= 1000)
+	if (now - lastLowUpdate >= 100) // update low 1% metrics at 100ms intervals instead of 1000ms since it is now extremely cheap
 	{
 		lastLowUpdate = now;
 		m_low1PercentFPS = calculateLow1PercentFPS(3.0f);

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -369,7 +369,7 @@ W3DDisplay::W3DDisplay()
 	m_lastUpdateTime64 = 0;
 	m_lastLow1PercentUpdateMs = 0;
 	m_currentFPS = 30.0f;
-	std::fill(std::begin(m_durationHistory), std::end(m_durationHistory), (UnsignedShort)2083);
+	std::fill(m_durationHistory, m_durationHistory + FPS_HISTORY_SIZE, (UnsignedShort)2083);
 
 #ifdef PROFILER_ENABLED
 	m_profilerFrameCapture = NEW W3DProfilerFrameCapture();
@@ -1013,7 +1013,8 @@ Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 	const UnsignedInt windowUnits = (UnsignedInt)(windowSeconds * 62500.0f);
 	UnsignedShort sortBuffer[FPS_HISTORY_SIZE];
 
-	for (Int i = 0; i < m_historyCount; ++i)
+	Int i;
+	for (i = 0; i < m_historyCount; ++i)
 	{
 		Int idx = (m_historyOffset - 1 - i) & (FPS_HISTORY_SIZE - 1);
 		unitsSum += m_durationHistory[idx];
@@ -1035,7 +1036,7 @@ Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 	std::nth_element(sortBuffer, sortBuffer + bottomSampleCount, sortBuffer + sampleCount, std::greater<UnsignedShort>());
 
 	UnsignedInt durationUnitsSum = 0;
-	for (Int i = 0; i < bottomSampleCount; ++i)
+	for (i = 0; i < bottomSampleCount; ++i)
 	{
 		durationUnitsSum += sortBuffer[i];
 	}

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -971,42 +971,54 @@ const UnsignedInt START_CUMU_FRAME = LOGICFRAMES_PER_SECOND / 2;	// skip first h
 
 void W3DDisplay::addFpsSample(Real elapsedSeconds)
 {
-	if (elapsedSeconds <= 0.0f) return;
+	if (elapsedSeconds <= 0.0f)
+	{
+		return;
+	}
 
 	m_currentFPS = 1.0f / elapsedSeconds;
 	m_fpsHistory[m_historyOffset] = m_currentFPS;
 	m_durationHistory[m_historyOffset] = elapsedSeconds;
 
 	m_historyOffset = (m_historyOffset + 1) % FPS_HISTORY_SIZE;
-	if (m_historyCount < FPS_HISTORY_SIZE) m_historyCount++;
+	if (m_historyCount < FPS_HISTORY_SIZE)
+	{
+		m_historyCount++;
+	}
 }
 
 Real W3DDisplay::calculateAverageFPS(Real windowSeconds)
 {
-	if (m_historyCount == 0) return m_currentFPS;
+	if (m_historyCount == 0)
+	{
+		return m_currentFPS;
+	}
 
 	Real timeSum = 0;
-	Real fpsSum = 0;
 	Int samples = 0;
 
 	for (Int i = 0; i < m_historyCount; ++i)
 	{
 		Int idx = (m_historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
 		timeSum += m_durationHistory[idx];
-		fpsSum += m_fpsHistory[idx];
 		samples++;
 
-		if (timeSum >= windowSeconds) break;
+		if (timeSum >= windowSeconds)
+		{
+			break;
+		}
 	}
 
-	return (samples > 0) ? (fpsSum / (Real)samples) : m_currentFPS;
+	return (timeSum > 0) ? ((Real)samples / timeSum) : m_currentFPS;
 }
 
 Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 {
-	if (m_historyCount == 0) return m_currentFPS;
+	if (m_historyCount == 0)
+	{
+		return m_currentFPS;
+	}
 
-	static Real sortBuffer[FPS_HISTORY_SIZE];
 	Real timeSum = 0;
 	Int sampleCount = 0;
 	Int i;
@@ -1015,19 +1027,28 @@ Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 	{
 		Int idx = (m_historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
 		timeSum += m_durationHistory[idx];
-		sortBuffer[sampleCount++] = m_fpsHistory[idx];
+		m_sortBuffer[sampleCount++] = m_fpsHistory[idx];
 
-		if (timeSum >= windowSeconds) break;
+		if (timeSum >= windowSeconds)
+		{
+			break;
+		}
 	}
 
-	if (sampleCount == 0) return m_currentFPS;
+	if (sampleCount == 0)
+	{
+		return m_currentFPS;
+	}
 
 	const Int bottomSampleCount = std::max((sampleCount + 99) / 100, 1);
 
-	std::nth_element(sortBuffer, sortBuffer + bottomSampleCount, sortBuffer + sampleCount);
+	std::nth_element(m_sortBuffer, m_sortBuffer + bottomSampleCount, m_sortBuffer + sampleCount);
 
 	Real lowSum = 0;
-	for (i = 0; i < bottomSampleCount; ++i) lowSum += sortBuffer[i];
+	for (i = 0; i < bottomSampleCount; ++i)
+	{
+		lowSum += m_sortBuffer[i];
+	}
 
 	return lowSum / (Real)bottomSampleCount;
 }
@@ -1038,7 +1059,10 @@ void W3DDisplay::updatePerformanceMetrics()
 	const Int64 time64 = getPerformanceCounter();
 
 #if defined(RTS_DEBUG)
-	if (TheGameLogic->getFrame() == START_CUMU_FRAME) m_timerAtCumuFPSStart = time64;
+	if (TheGameLogic->getFrame() == START_CUMU_FRAME)
+	{
+		m_timerAtCumuFPSStart = time64;
+	}
 #endif
 
 	if (m_lastUpdateTime64 == 0)

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -362,6 +362,15 @@ W3DDisplay::W3DDisplay()
 	m_batchGrayscale = FALSE;
 	m_batchNeedsInit = FALSE;
 
+	m_historyOffset = 0;
+	m_historyCount = 0;
+	m_lastUpdateTime64 = 0;
+	for (Int h = 0; h < FPS_HISTORY_SIZE; ++h)
+	{
+		m_fpsHistory[h] = 0.0f;
+		m_durationHistory[h] = 0.0f;
+	}
+
 #ifdef PROFILER_ENABLED
 	m_profilerFrameCapture = NEW W3DProfilerFrameCapture();
 #endif
@@ -960,103 +969,98 @@ void W3DDisplay::reset()
 
 const UnsignedInt START_CUMU_FRAME = LOGICFRAMES_PER_SECOND / 2;	// skip first half-sec
 
-void W3DDisplay::updateAverageFPS()
+void W3DDisplay::addFpsSample(Real elapsedSeconds)
 {
-	constexpr const Int FPS_HISTORY_SIZE = 1000;
-	static Real fpsHistory[FPS_HISTORY_SIZE] = {0};
-	static Real durationHistory[FPS_HISTORY_SIZE] = {0};
-	static Int historyOffset = 0;
-	static Int historyCount = 0;
-	static Int64 lastUpdateTime64 = 0;
+	if (elapsedSeconds <= 0.0f) return;
 
+	m_currentFPS = 1.0f / elapsedSeconds;
+	m_fpsHistory[m_historyOffset] = m_currentFPS;
+	m_durationHistory[m_historyOffset] = elapsedSeconds;
+
+	m_historyOffset = (m_historyOffset + 1) % FPS_HISTORY_SIZE;
+	if (m_historyCount < FPS_HISTORY_SIZE) m_historyCount++;
+}
+
+Real W3DDisplay::calculateAverageFPS(Real windowSeconds)
+{
+	if (m_historyCount == 0) return m_currentFPS;
+
+	Real timeSum = 0;
+	Real fpsSum = 0;
+	Int samples = 0;
+
+	for (Int i = 0; i < m_historyCount; ++i)
+	{
+		Int idx = (m_historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
+		timeSum += m_durationHistory[idx];
+		fpsSum += m_fpsHistory[idx];
+		samples++;
+
+		if (timeSum >= windowSeconds) break;
+	}
+
+	return (samples > 0) ? (fpsSum / (Real)samples) : m_currentFPS;
+}
+
+Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
+{
+	if (m_historyCount == 0) return m_currentFPS;
+
+	static Real sortBuffer[FPS_HISTORY_SIZE];
+	Real timeSum = 0;
+	Int sampleCount = 0;
+
+	for (Int i = 0; i < m_historyCount; ++i)
+	{
+		Int idx = (m_historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
+		timeSum += m_durationHistory[idx];
+		sortBuffer[sampleCount++] = m_fpsHistory[idx];
+
+		if (timeSum >= windowSeconds) break;
+	}
+
+	if (sampleCount == 0) return m_currentFPS;
+
+	const Int bottomSampleCount = std::max((sampleCount + 99) / 100, 1);
+
+	std::nth_element(sortBuffer, sortBuffer + bottomSampleCount, sortBuffer + sampleCount);
+
+	Real lowSum = 0;
+	for (Int i = 0; i < bottomSampleCount; ++i) lowSum += sortBuffer[i];
+
+	return lowSum / (Real)bottomSampleCount;
+}
+
+void W3DDisplay::updatePerformanceMetrics()
+{
 	const Int64 freq64 = getPerformanceCounterFrequency();
 	const Int64 time64 = getPerformanceCounter();
 
 #if defined(RTS_DEBUG)
-	if (TheGameLogic->getFrame() == START_CUMU_FRAME)
-	{
-		m_timerAtCumuFPSStart = time64;
-	}
+	if (TheGameLogic->getFrame() == START_CUMU_FRAME) m_timerAtCumuFPSStart = time64;
 #endif
 
-	if (lastUpdateTime64 == 0)
+	if (m_lastUpdateTime64 == 0)
 	{
-		lastUpdateTime64 = time64;
+		m_lastUpdateTime64 = time64;
 		return;
 	}
 
-	const Int64 timeDiff = time64 - lastUpdateTime64;
+	const Int64 timeDiff = time64 - m_lastUpdateTime64;
+	Real elapsedSeconds = (Real)timeDiff / (Real)freq64;
 
-	// convert elapsed time to seconds
-	Real elapsedSeconds = (Real)timeDiff/(Real)freq64;
+	addFpsSample(elapsedSeconds);
+	m_averageFPS = calculateAverageFPS(0.5f);
 
-	// append new sample to fps history.
-	if (elapsedSeconds > 0)
+	static UnsignedInt lastLowUpdate = 0;
+	UnsignedInt now = timeGetTime();
+	if (now - lastLowUpdate >= 1000)
 	{
-		m_currentFPS = 1.0f/elapsedSeconds;
-		fpsHistory[historyOffset] = m_currentFPS;
-		durationHistory[historyOffset] = elapsedSeconds;
-		historyOffset = (historyOffset + 1) % FPS_HISTORY_SIZE;
-		if (historyCount < FPS_HISTORY_SIZE)
-		{
-			historyCount++;
-		}
+		lastLowUpdate = now;
+		m_low1PercentFPS = calculateLow1PercentFPS(3.0f);
 	}
 
-	// determine average frame rate over the last 0.5 seconds and 1% low over 3.0 seconds.
-	if (historyCount > 0)
-	{
-		Real timeSum = 0;
-		Real fpsSum = 0;
-		Int avgSamples = 0;
-		Int lowSamples = 0;
-		Bool avgDone = FALSE;
-
-		for (Int i = 0; i < historyCount; ++i)
-		{
-			Int idx = (historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
-			timeSum += durationHistory[idx];
-			
-			lowSamples++;
-			
-			if (!avgDone)
-			{
-				fpsSum += fpsHistory[idx];
-				avgSamples++;
-				if (timeSum >= 0.5f)
-				{
-					avgDone = TRUE;
-				}
-			}
-			
-			if (timeSum >= 3.0f)
-			{
-				break;
-			}
-		}
-
-		m_averageFPS = avgSamples > 0 ? fpsSum / (Real)avgSamples : m_currentFPS;
-
-		// TheSuperHackers @feature One percent low FPS calculation (last 3.0 seconds)
-		// Throttle sorting to 1000ms intervals to match HUD refresh and save CPU
-		static UnsignedInt lastLowUpdate = 0;
-		UnsignedInt now = timeGetTime();
-		if (now - lastLowUpdate >= 1000)
-		{
-			lastLowUpdate = now;
-			static Real sortBuffer[FPS_HISTORY_SIZE];
-			for (Int i = 0; i < lowSamples; ++i)
-			{
-				Int idx = (historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
-				sortBuffer[i] = fpsHistory[idx];
-			}
-			const Int lowCount = std::max(lowSamples / 100, 1);
-			std::nth_element(sortBuffer, sortBuffer + lowCount, sortBuffer + lowSamples);
-			m_low1PercentFPS = std::accumulate(sortBuffer, sortBuffer + lowCount, 0.0f) / (Real)lowCount;
-		}
-	}
-
-	lastUpdateTime64 = time64;
+	m_lastUpdateTime64 = time64;
 }
 
 #if defined(RTS_DEBUG)	//debug hack to view object under mouse stats
@@ -1805,7 +1809,7 @@ void W3DDisplay::draw()
 	// TheSuperHackers @feature bobtista 10/07/2026 Show messages for screenshots finished by the screenshot thread.
 	W3D_UpdateScreenshotMessages();
 
-	updateAverageFPS();
+	updatePerformanceMetrics();
 	if (TheGlobalData->m_enableDynamicLOD && TheGameLogic->getShowDynamicLOD())
 	{
 		DynamicGameLODLevel lod=TheGameLODManager->findDynamicLODLevel(m_averageFPS);

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -1040,7 +1040,7 @@ Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 		return m_currentFPS;
 	}
 
-	const Int bottomSampleCount = std::max((sampleCount + 99) / 100, 1);
+	const Int bottomSampleCount = std::max((sampleCount + 50) / 100, 1);
 
 	std::nth_element(m_sortBuffer, m_sortBuffer + bottomSampleCount, m_sortBuffer + sampleCount);
 

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -35,6 +35,8 @@ static void drawFramerateBar();
 
 // SYSTEM INCLUDES ////////////////////////////////////////////////////////////
 #include <numeric>
+#include <algorithm>
+#include <functional>
 #include <stdlib.h>
 #include <windows.h>
 #include <io.h>
@@ -365,12 +367,9 @@ W3DDisplay::W3DDisplay()
 	m_historyOffset = 0;
 	m_historyCount = 1;
 	m_lastUpdateTime64 = 0;
+	m_lastLow1PercentUpdateMs = 0;
 	m_currentFPS = 30.0f;
-	for (Int h = 0; h < FPS_HISTORY_SIZE; ++h)
-	{
-		m_fpsHistory[h] = 30.0f;
-		m_durationHistory[h] = 1.0f / 30.0f;
-	}
+	std::fill(std::begin(m_durationHistory), std::end(m_durationHistory), (UnsignedShort)2083);
 
 #ifdef PROFILER_ENABLED
 	m_profilerFrameCapture = NEW W3DProfilerFrameCapture();
@@ -973,14 +972,11 @@ const UnsignedInt START_CUMU_FRAME = LOGICFRAMES_PER_SECOND / 2;	// skip first h
 
 void W3DDisplay::addFpsSample(Real elapsedSeconds)
 {
-	if (elapsedSeconds < 0.0001f)
-	{
-		elapsedSeconds = 0.0001f;
-	}
+	Int64 ticks = (Int64)(elapsedSeconds * 62500.0f + 0.5f);
+	UnsignedShort quantized = (ticks >= 65535) ? 65535 : (ticks <= 0 ? 1 : (UnsignedShort)ticks);
 
-	m_currentFPS = 1.0f / elapsedSeconds;
-	m_fpsHistory[m_historyOffset] = m_currentFPS;
-	m_durationHistory[m_historyOffset] = elapsedSeconds;
+	m_currentFPS = 62500.0f / (Real)quantized;
+	m_durationHistory[m_historyOffset] = quantized;
 
 	m_historyOffset = (m_historyOffset + 1) & (FPS_HISTORY_SIZE - 1);
 	if (m_historyCount < FPS_HISTORY_SIZE)
@@ -991,44 +987,42 @@ void W3DDisplay::addFpsSample(Real elapsedSeconds)
 
 Real W3DDisplay::calculateAverageFPS(Real windowSeconds)
 {
-	Real timeSum = 0;
+	UnsignedInt unitsSum = 0;
 	Int samples = 0;
+	const UnsignedInt windowUnits = (UnsignedInt)(windowSeconds * 62500.0f);
 
-	Int idx = m_historyOffset - 1;
 	for (Int i = 0; i < m_historyCount; ++i)
 	{
-		if (idx < 0) idx += FPS_HISTORY_SIZE;
-		timeSum += m_durationHistory[idx];
+		Int idx = (m_historyOffset - 1 - i) & (FPS_HISTORY_SIZE - 1);
+		unitsSum += m_durationHistory[idx];
 		samples++;
 
-		if (timeSum >= windowSeconds)
+		if (unitsSum >= windowUnits)
 		{
 			break;
 		}
-		--idx;
 	}
 
-	return (timeSum > 0) ? ((Real)samples / timeSum) : m_currentFPS;
+	return (unitsSum > 0) ? ((Real)samples * 62500.0f / (Real)unitsSum) : m_currentFPS;
 }
 
 Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 {
-	Real timeSum = 0;
+	UnsignedInt unitsSum = 0;
 	Int sampleCount = 0;
-	Int i;
+	const UnsignedInt windowUnits = (UnsignedInt)(windowSeconds * 62500.0f);
+	UnsignedShort sortBuffer[FPS_HISTORY_SIZE];
 
-	Int idx = m_historyOffset - 1;
-	for (i = 0; i < m_historyCount; ++i)
+	for (Int i = 0; i < m_historyCount; ++i)
 	{
-		if (idx < 0) idx += FPS_HISTORY_SIZE;
-		timeSum += m_durationHistory[idx];
-		m_sortBuffer[sampleCount++] = m_fpsHistory[idx];
+		Int idx = (m_historyOffset - 1 - i) & (FPS_HISTORY_SIZE - 1);
+		unitsSum += m_durationHistory[idx];
+		sortBuffer[sampleCount++] = m_durationHistory[idx];
 
-		if (timeSum >= windowSeconds)
+		if (unitsSum >= windowUnits)
 		{
 			break;
 		}
-		--idx;
 	}
 
 	if (sampleCount == 0)
@@ -1038,15 +1032,15 @@ Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 
 	const Int bottomSampleCount = std::max((sampleCount + 50) / 100, 1);
 
-	std::nth_element(m_sortBuffer, m_sortBuffer + bottomSampleCount, m_sortBuffer + sampleCount);
+	std::nth_element(sortBuffer, sortBuffer + bottomSampleCount, sortBuffer + sampleCount, std::greater<UnsignedShort>());
 
-	Real lowSum = 0;
-	for (i = 0; i < bottomSampleCount; ++i)
+	UnsignedInt durationUnitsSum = 0;
+	for (Int i = 0; i < bottomSampleCount; ++i)
 	{
-		lowSum += m_sortBuffer[i];
+		durationUnitsSum += sortBuffer[i];
 	}
 
-	return lowSum / (Real)bottomSampleCount;
+	return (durationUnitsSum > 0) ? ((Real)bottomSampleCount * 62500.0f / (Real)durationUnitsSum) : m_currentFPS;
 }
 
 void W3DDisplay::updatePerformanceMetrics()
@@ -1066,14 +1060,6 @@ void W3DDisplay::updatePerformanceMetrics()
 
 	addFpsSample(elapsedSeconds);
 	m_averageFPS = calculateAverageFPS(1.0f); // 1.0s window for smooth Dynamic LOD tracking and UI matching
-
-	static UnsignedInt lastLowUpdate = 0;
-	UnsignedInt now = timeGetTime();
-	if (now - lastLowUpdate >= 100) // update low 1% metrics at 100ms intervals instead of 1000ms since it is now extremely cheap
-	{
-		lastLowUpdate = now;
-		m_low1PercentFPS = calculateLow1PercentFPS(3.0f);
-	}
 
 	m_lastUpdateTime64 = time64;
 }
@@ -1784,6 +1770,12 @@ Real W3DDisplay::getAverageFPS()
 
 Real W3DDisplay::getLow1PercentFPS()
 {
+	UnsignedInt now = timeGetTime();
+	if (now - m_lastLow1PercentUpdateMs >= 1000)
+	{
+		m_low1PercentFPS = calculateLow1PercentFPS(3.0f);
+		m_lastLow1PercentUpdateMs = now;
+	}
 	return m_low1PercentFPS;
 }
 

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -341,6 +341,7 @@ W3DDisplay::W3DDisplay()
 	m_2DScene = nullptr;
 	m_3DInterfaceScene = nullptr;
 	m_averageFPS = TheGlobalData->m_framesPerSecondLimit;
+	m_low1PercentFPS = TheGlobalData->m_framesPerSecondLimit;
 #if defined(RTS_DEBUG)
 	m_timerAtCumuFPSStart = 0;
 #endif
@@ -961,11 +962,12 @@ const UnsignedInt START_CUMU_FRAME = LOGICFRAMES_PER_SECOND / 2;	// skip first h
 
 void W3DDisplay::updateAverageFPS()
 {
-	constexpr const Int FPS_HISTORY_SIZE = 30;
-
-	static Int64 lastUpdateTime64 = 0;
-	static Int historyOffset = 0;
+	constexpr const Int FPS_HISTORY_SIZE = 1000;
 	static Real fpsHistory[FPS_HISTORY_SIZE] = {0};
+	static Real durationHistory[FPS_HISTORY_SIZE] = {0};
+	static Int historyOffset = 0;
+	static Int historyCount = 0;
+	static Int64 lastUpdateTime64 = 0;
 
 	const Int64 freq64 = getPerformanceCounterFrequency();
 	const Int64 time64 = getPerformanceCounter();
@@ -977,21 +979,73 @@ void W3DDisplay::updateAverageFPS()
 	}
 #endif
 
+	if (lastUpdateTime64 == 0)
+	{
+		lastUpdateTime64 = time64;
+		return;
+	}
+
 	const Int64 timeDiff = time64 - lastUpdateTime64;
 
 	// convert elapsed time to seconds
 	Real elapsedSeconds = (Real)timeDiff/(Real)freq64;
 
 	// append new sample to fps history.
-	if (historyOffset >= FPS_HISTORY_SIZE)
-		historyOffset = 0;
+	if (elapsedSeconds > 0)
+	{
+		m_currentFPS = 1.0f/elapsedSeconds;
+		fpsHistory[historyOffset] = m_currentFPS;
+		durationHistory[historyOffset] = elapsedSeconds;
+		historyOffset = (historyOffset + 1) % FPS_HISTORY_SIZE;
+		if (historyCount < FPS_HISTORY_SIZE) historyCount++;
+	}
 
-	m_currentFPS = 1.0f/elapsedSeconds;
-	fpsHistory[historyOffset++] = m_currentFPS;
+	// determine average frame rate over the last 0.5 seconds and 1% low over 3.0 seconds.
+	if (historyCount > 0)
+	{
+		Real timeSum = 0;
+		Real fpsSum = 0;
+		Int avgSamples = 0;
+		Int lowSamples = 0;
+		Bool avgDone = FALSE;
 
-	// determine average frame rate over our past history.
-	const Real sum = std::accumulate(fpsHistory, fpsHistory + FPS_HISTORY_SIZE, 0.0f);
-	m_averageFPS = sum / FPS_HISTORY_SIZE;
+		for (Int i = 0; i < historyCount; ++i)
+		{
+			Int idx = (historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
+			timeSum += durationHistory[idx];
+			
+			lowSamples++;
+			
+			if (!avgDone)
+			{
+				fpsSum += fpsHistory[idx];
+				avgSamples++;
+				if (timeSum >= 0.5f) avgDone = TRUE;
+			}
+			
+			if (timeSum >= 3.0f) break;
+		}
+
+		m_averageFPS = avgSamples > 0 ? fpsSum / (Real)avgSamples : m_currentFPS;
+
+		// TheSuperHackers @feature One percent low FPS calculation (last 3.0 seconds)
+		// Throttle sorting to 1000ms intervals to match HUD refresh and save CPU
+		static UnsignedInt lastLowUpdate = 0;
+		UnsignedInt now = timeGetTime();
+		if (now - lastLowUpdate >= 1000)
+		{
+			lastLowUpdate = now;
+			static Real sortBuffer[FPS_HISTORY_SIZE];
+			for (Int i = 0; i < lowSamples; ++i)
+			{
+				Int idx = (historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
+				sortBuffer[i] = fpsHistory[idx];
+			}
+			const Int lowCount = std::max(lowSamples / 100, 1);
+			std::nth_element(sortBuffer, sortBuffer + lowCount, sortBuffer + lowSamples);
+			m_low1PercentFPS = std::accumulate(sortBuffer, sortBuffer + lowCount, 0.0f) / (Real)lowCount;
+		}
+	}
 
 	lastUpdateTime64 = time64;
 }
@@ -1698,6 +1752,11 @@ void W3DDisplay::calculateTerrainLOD()
 Real W3DDisplay::getAverageFPS()
 {
 	return m_averageFPS;
+}
+
+Real W3DDisplay::getLow1PercentFPS()
+{
+	return m_low1PercentFPS;
 }
 
 Real W3DDisplay::getCurrentFPS()

--- a/Generals/Code/Tools/GUIEdit/Include/GUIEditDisplay.h
+++ b/Generals/Code/Tools/GUIEdit/Include/GUIEditDisplay.h
@@ -124,6 +124,7 @@ public:
 #endif
 
 	virtual Real getAverageFPS() override { return 0; }
+	virtual Real getLow1PercentFPS() override { return 0; }
 	virtual Real getCurrentFPS() override { return 0; }
 	virtual Int getLastFrameDrawCalls() override { return 0; }
 

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -769,16 +769,19 @@ protected:
 
 	// Render FPS Counter
 	DisplayString *							m_renderFpsString;
+	DisplayString *							m_renderFpsLowString;
 	DisplayString *							m_renderFpsLimitString;
 	AsciiString									m_renderFpsFont;
 	Int													m_renderFpsPointSize;
 	Bool												m_renderFpsBold;
 	Coord2D											m_renderFpsPosition;
 	Color												m_renderFpsColor;
+	Color												m_renderFpsLowColor;
 	Color												m_renderFpsLimitColor;
 	Color												m_renderFpsDropColor;
 	UnsignedInt									m_renderFpsRefreshMs;
 	UnsignedInt									m_lastRenderFps;
+	UnsignedInt									m_lastRenderFpsLow;
 	UnsignedInt									m_lastRenderFpsLimit;
 	UnsignedInt									m_lastRenderFpsUpdateMs;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -917,6 +917,7 @@ const FieldParse InGameUI::s_fieldParseTable[] =
 	{ "RenderFpsBold",          INI::parseBool,         nullptr, offsetof( InGameUI, m_renderFpsBold ) },
 	{ "RenderFpsPosition",      INI::parseCoord2D,      nullptr, offsetof( InGameUI, m_renderFpsPosition ) },
 	{ "RenderFpsColor",         INI::parseColorInt,     nullptr, offsetof( InGameUI, m_renderFpsColor ) },
+	{ "RenderFpsLowColor",      INI::parseColorInt,     nullptr, offsetof( InGameUI, m_renderFpsLowColor ) },
 	{ "RenderFpsLimitColor",    INI::parseColorInt,     nullptr, offsetof( InGameUI, m_renderFpsLimitColor ) },
 	{ "RenderFpsDropColor",     INI::parseColorInt,     nullptr, offsetof( InGameUI, m_renderFpsDropColor ) },
 	{ "RenderFpsRefreshMs",     INI::parseUnsignedInt,  nullptr, offsetof( InGameUI, m_renderFpsRefreshMs ) },
@@ -1163,6 +1164,7 @@ InGameUI::InGameUI()
 	m_lastNetworkLatencyFrames = ~0u;
 
 	m_renderFpsString = nullptr;
+	m_renderFpsLowString = nullptr;
 	m_renderFpsLimitString = nullptr;
 	m_renderFpsFont = "Tahoma";
 	m_renderFpsPointSize = TheGlobalData->m_renderFpsFontSize;
@@ -1170,10 +1172,12 @@ InGameUI::InGameUI()
 	m_renderFpsPosition.x = kHudAnchorX;
 	m_renderFpsPosition.y = kHudAnchorY;
 	m_renderFpsColor = GameMakeColor( 255, 255, 0, 255 );
+	m_renderFpsLowColor = GameMakeColor( 180, 170, 120, 255 );
 	m_renderFpsLimitColor = GameMakeColor(119, 119, 119, 255);
 	m_renderFpsDropColor = GameMakeColor( 0, 0, 0, 255 );
 	m_renderFpsRefreshMs = 1000;
 	m_lastRenderFps = ~0u;
+	m_lastRenderFpsLow = ~0u;
 	m_lastRenderFpsLimit = ~0u;
 	m_lastRenderFpsUpdateMs = 0u;
 
@@ -2272,6 +2276,8 @@ void InGameUI::freeCustomUiResources()
 	m_networkLatencyString = nullptr;
 	TheDisplayStringManager->freeDisplayString(m_renderFpsString);
 	m_renderFpsString = nullptr;
+	TheDisplayStringManager->freeDisplayString(m_renderFpsLowString);
+	m_renderFpsLowString = nullptr;
 	TheDisplayStringManager->freeDisplayString(m_renderFpsLimitString);
 	m_renderFpsLimitString = nullptr;
 	TheDisplayStringManager->freeDisplayString(m_systemTimeString);
@@ -6041,6 +6047,12 @@ void InGameUI::refreshRenderFpsResources()
 		m_lastRenderFpsUpdateMs = 0u;
 	}
 
+	if (!m_renderFpsLowString)
+	{
+		m_renderFpsLowString = TheDisplayStringManager->newDisplayString();
+		m_lastRenderFpsLow = ~0u;
+	}
+
 	if (!m_renderFpsLimitString)
 	{
 		m_renderFpsLimitString = TheDisplayStringManager->newDisplayString();
@@ -6051,6 +6063,7 @@ void InGameUI::refreshRenderFpsResources()
 	Int adjustedRenderFpsFontSize = TheGlobalLanguageData->adjustFontSize(m_renderFpsPointSize);
 	GameFont *fpsFont = TheWindowManager->winFindFont(m_renderFpsFont, adjustedRenderFpsFontSize, m_renderFpsBold);
 	m_renderFpsString->setFont(fpsFont);
+	m_renderFpsLowString->setFont(fpsFont);
 	m_renderFpsLimitString->setFont(fpsFont);
 
 	if (m_renderFpsPointSize > 0)
@@ -6163,6 +6176,15 @@ void InGameUI::updateRenderFpsString()
 		m_renderFpsString->setText(fpsStr);
 		m_lastRenderFps = renderFps;
 	}
+
+	const UnsignedInt renderFpsLow = (UnsignedInt)(TheDisplay->getLow1PercentFPS() + 0.5f);
+	if (renderFpsLow != m_lastRenderFpsLow)
+	{
+		UnicodeString fpsLowStr;
+		fpsLowStr.format(L"(%u)", renderFpsLow);
+		m_renderFpsLowString->setText(fpsLowStr);
+		m_lastRenderFpsLow = renderFpsLow;
+	}
 }
 
 void InGameUI::drawNetworkLatency(Int &x, Int &y)
@@ -6229,14 +6251,20 @@ void InGameUI::drawRenderFps(Int &x, Int &y)
 		const Int drawY = kHudAnchorY + y;
 
 		m_renderFpsString->draw(kHudAnchorX + x, drawY, m_renderFpsColor, m_renderFpsDropColor);
-		x += m_renderFpsString->getWidth();
+		x += m_renderFpsString->getWidth() + kHudGapPx / 2;
+		m_renderFpsLowString->draw(kHudAnchorX + x, drawY, m_renderFpsLowColor, m_renderFpsDropColor);
+		x += m_renderFpsLowString->getWidth() + kHudGapPx / 2;
 		m_renderFpsLimitString->draw(kHudAnchorX + x, drawY, m_renderFpsLimitColor, m_renderFpsDropColor);
 		x += m_renderFpsLimitString->getWidth() + kHudGapPx;
 	}
 	else
 	{
-		m_renderFpsString->draw(m_renderFpsPosition.x, m_renderFpsPosition.y, m_renderFpsColor, m_renderFpsDropColor);
-		m_renderFpsLimitString->draw(m_renderFpsPosition.x + m_renderFpsString->getWidth(), m_renderFpsPosition.y, m_renderFpsLimitColor, m_renderFpsDropColor);
+		Int currentX = m_renderFpsPosition.x;
+		m_renderFpsString->draw(currentX, m_renderFpsPosition.y, m_renderFpsColor, m_renderFpsDropColor);
+		currentX += m_renderFpsString->getWidth() + kHudGapPx / 2;
+		m_renderFpsLowString->draw(currentX, m_renderFpsPosition.y, m_renderFpsLowColor, m_renderFpsDropColor);
+		currentX += m_renderFpsLowString->getWidth() + kHudGapPx / 2;
+		m_renderFpsLimitString->draw(currentX, m_renderFpsPosition.y, m_renderFpsLimitColor, m_renderFpsDropColor);
 	}
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -6228,19 +6228,15 @@ void InGameUI::drawRenderFps(Int &x, Int &y)
 		updateRenderFpsString();
 	}
 
-	UnsignedInt renderFpsLimit = 0u;
+	UnsignedInt renderFpsLimit = RenderFpsPreset::UncappedFpsValue;
 	if (TheGlobalData->m_useFpsLimit)
 	{
 		renderFpsLimit = (UnsignedInt)TheFramePacer->getFramesPerSecondLimit();
-		if (renderFpsLimit == RenderFpsPreset::UncappedFpsValue)
-		{
-			renderFpsLimit = 0u;
-		}
 	}
 	if (renderFpsLimit != m_lastRenderFpsLimit)
 	{
 		UnicodeString fpsLimitStr;
-		if (renderFpsLimit == 0)
+		if (renderFpsLimit == RenderFpsPreset::UncappedFpsValue)
 		{
 			fpsLimitStr.format(L"\x25B2X");
 		}

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -1172,7 +1172,7 @@ InGameUI::InGameUI()
 	m_renderFpsPosition.x = kHudAnchorX;
 	m_renderFpsPosition.y = kHudAnchorY;
 	m_renderFpsColor = GameMakeColor( 255, 255, 0, 255 );
-	m_renderFpsLowColor = GameMakeColor( 180, 170, 120, 255 );
+	m_renderFpsLowColor = GameMakeColor( 190, 180, 130, 255 );
 	m_renderFpsLimitColor = GameMakeColor(119, 119, 119, 255);
 	m_renderFpsDropColor = GameMakeColor( 0, 0, 0, 255 );
 	m_renderFpsRefreshMs = 1000;
@@ -6181,7 +6181,7 @@ void InGameUI::updateRenderFpsString()
 	if (renderFpsLow != m_lastRenderFpsLow)
 	{
 		UnicodeString fpsLowStr;
-		fpsLowStr.format(L"(%u)", renderFpsLow);
+		fpsLowStr.format(L"\x25BC%u", renderFpsLow);
 		m_renderFpsLowString->setText(fpsLowStr);
 		m_lastRenderFpsLow = renderFpsLow;
 	}
@@ -6240,7 +6240,14 @@ void InGameUI::drawRenderFps(Int &x, Int &y)
 	if (renderFpsLimit != m_lastRenderFpsLimit)
 	{
 		UnicodeString fpsLimitStr;
-		fpsLimitStr.format(L"[%u]", renderFpsLimit);
+		if (renderFpsLimit == 0)
+		{
+			fpsLimitStr.format(L"\x25B2X");
+		}
+		else
+		{
+			fpsLimitStr.format(L"\x25B2%u", renderFpsLimit);
+		}
 		m_renderFpsLimitString->setText(fpsLimitStr);
 		m_lastRenderFpsLimit = renderFpsLimit;
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -917,6 +917,7 @@ const FieldParse InGameUI::s_fieldParseTable[] =
 	{ "RenderFpsBold",          INI::parseBool,         nullptr, offsetof( InGameUI, m_renderFpsBold ) },
 	{ "RenderFpsPosition",      INI::parseCoord2D,      nullptr, offsetof( InGameUI, m_renderFpsPosition ) },
 	{ "RenderFpsColor",         INI::parseColorInt,     nullptr, offsetof( InGameUI, m_renderFpsColor ) },
+	{ "RenderFpsLowColor",      INI::parseColorInt,     nullptr, offsetof( InGameUI, m_renderFpsLowColor ) },
 	{ "RenderFpsLimitColor",    INI::parseColorInt,     nullptr, offsetof( InGameUI, m_renderFpsLimitColor ) },
 	{ "RenderFpsDropColor",     INI::parseColorInt,     nullptr, offsetof( InGameUI, m_renderFpsDropColor ) },
 	{ "RenderFpsRefreshMs",     INI::parseUnsignedInt,  nullptr, offsetof( InGameUI, m_renderFpsRefreshMs ) },
@@ -1164,6 +1165,7 @@ InGameUI::InGameUI()
 	m_lastNetworkLatencyFrames = ~0u;
 
 	m_renderFpsString = nullptr;
+	m_renderFpsLowString = nullptr;
 	m_renderFpsLimitString = nullptr;
 	m_renderFpsFont = "Tahoma";
 	m_renderFpsPointSize = TheGlobalData->m_renderFpsFontSize;
@@ -1171,10 +1173,12 @@ InGameUI::InGameUI()
 	m_renderFpsPosition.x = kHudAnchorX;
 	m_renderFpsPosition.y = kHudAnchorY;
 	m_renderFpsColor = GameMakeColor( 255, 255, 0, 255 );
+	m_renderFpsLowColor = GameMakeColor( 180, 170, 120, 255 );
 	m_renderFpsLimitColor = GameMakeColor(119, 119, 119, 255);
 	m_renderFpsDropColor = GameMakeColor( 0, 0, 0, 255 );
 	m_renderFpsRefreshMs = 1000;
 	m_lastRenderFps = ~0u;
+	m_lastRenderFpsLow = ~0u;
 	m_lastRenderFpsLimit = ~0u;
 	m_lastRenderFpsUpdateMs = 0u;
 
@@ -2283,6 +2287,8 @@ void InGameUI::freeCustomUiResources()
 	m_networkLatencyString = nullptr;
 	TheDisplayStringManager->freeDisplayString(m_renderFpsString);
 	m_renderFpsString = nullptr;
+	TheDisplayStringManager->freeDisplayString(m_renderFpsLowString);
+	m_renderFpsLowString = nullptr;
 	TheDisplayStringManager->freeDisplayString(m_renderFpsLimitString);
 	m_renderFpsLimitString = nullptr;
 	TheDisplayStringManager->freeDisplayString(m_systemTimeString);
@@ -6045,6 +6051,12 @@ void InGameUI::refreshRenderFpsResources()
 		m_lastRenderFpsUpdateMs = 0u;
 	}
 
+	if (!m_renderFpsLowString)
+	{
+		m_renderFpsLowString = TheDisplayStringManager->newDisplayString();
+		m_lastRenderFpsLow = ~0u;
+	}
+
 	if (!m_renderFpsLimitString)
 	{
 		m_renderFpsLimitString = TheDisplayStringManager->newDisplayString();
@@ -6055,6 +6067,7 @@ void InGameUI::refreshRenderFpsResources()
 	Int adjustedRenderFpsFontSize = TheGlobalLanguageData->adjustFontSize(m_renderFpsPointSize);
 	GameFont *fpsFont = TheWindowManager->winFindFont(m_renderFpsFont, adjustedRenderFpsFontSize, m_renderFpsBold);
 	m_renderFpsString->setFont(fpsFont);
+	m_renderFpsLowString->setFont(fpsFont);
 	m_renderFpsLimitString->setFont(fpsFont);
 
 	if (m_renderFpsPointSize > 0)
@@ -6167,6 +6180,15 @@ void InGameUI::updateRenderFpsString()
 		m_renderFpsString->setText(fpsStr);
 		m_lastRenderFps = renderFps;
 	}
+
+	const UnsignedInt renderFpsLow = (UnsignedInt)(TheDisplay->getLow1PercentFPS() + 0.5f);
+	if (renderFpsLow != m_lastRenderFpsLow)
+	{
+		UnicodeString fpsLowStr;
+		fpsLowStr.format(L"(%u)", renderFpsLow);
+		m_renderFpsLowString->setText(fpsLowStr);
+		m_lastRenderFpsLow = renderFpsLow;
+	}
 }
 
 void InGameUI::drawNetworkLatency(Int &x, Int &y)
@@ -6233,14 +6255,20 @@ void InGameUI::drawRenderFps(Int &x, Int &y)
 		const Int drawY = kHudAnchorY + y;
 
 		m_renderFpsString->draw(kHudAnchorX + x, drawY, m_renderFpsColor, m_renderFpsDropColor);
-		x += m_renderFpsString->getWidth();
+		x += m_renderFpsString->getWidth() + kHudGapPx / 2;
+		m_renderFpsLowString->draw(kHudAnchorX + x, drawY, m_renderFpsLowColor, m_renderFpsDropColor);
+		x += m_renderFpsLowString->getWidth() + kHudGapPx / 2;
 		m_renderFpsLimitString->draw(kHudAnchorX + x, drawY, m_renderFpsLimitColor, m_renderFpsDropColor);
 		x += m_renderFpsLimitString->getWidth() + kHudGapPx;
 	}
 	else
 	{
-		m_renderFpsString->draw(m_renderFpsPosition.x, m_renderFpsPosition.y, m_renderFpsColor, m_renderFpsDropColor);
-		m_renderFpsLimitString->draw(m_renderFpsPosition.x + m_renderFpsString->getWidth(), m_renderFpsPosition.y, m_renderFpsLimitColor, m_renderFpsDropColor);
+		Int currentX = m_renderFpsPosition.x;
+		m_renderFpsString->draw(currentX, m_renderFpsPosition.y, m_renderFpsColor, m_renderFpsDropColor);
+		currentX += m_renderFpsString->getWidth() + kHudGapPx / 2;
+		m_renderFpsLowString->draw(currentX, m_renderFpsPosition.y, m_renderFpsLowColor, m_renderFpsDropColor);
+		currentX += m_renderFpsLowString->getWidth() + kHudGapPx / 2;
+		m_renderFpsLimitString->draw(currentX, m_renderFpsPosition.y, m_renderFpsLimitColor, m_renderFpsDropColor);
 	}
 }
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -1173,7 +1173,7 @@ InGameUI::InGameUI()
 	m_renderFpsPosition.x = kHudAnchorX;
 	m_renderFpsPosition.y = kHudAnchorY;
 	m_renderFpsColor = GameMakeColor( 255, 255, 0, 255 );
-	m_renderFpsLowColor = GameMakeColor( 180, 170, 120, 255 );
+	m_renderFpsLowColor = GameMakeColor( 190, 180, 130, 255 );
 	m_renderFpsLimitColor = GameMakeColor(119, 119, 119, 255);
 	m_renderFpsDropColor = GameMakeColor( 0, 0, 0, 255 );
 	m_renderFpsRefreshMs = 1000;
@@ -6185,7 +6185,7 @@ void InGameUI::updateRenderFpsString()
 	if (renderFpsLow != m_lastRenderFpsLow)
 	{
 		UnicodeString fpsLowStr;
-		fpsLowStr.format(L"(%u)", renderFpsLow);
+		fpsLowStr.format(L"\x25BC%u", renderFpsLow);
 		m_renderFpsLowString->setText(fpsLowStr);
 		m_lastRenderFpsLow = renderFpsLow;
 	}
@@ -6244,7 +6244,14 @@ void InGameUI::drawRenderFps(Int &x, Int &y)
 	if (renderFpsLimit != m_lastRenderFpsLimit)
 	{
 		UnicodeString fpsLimitStr;
-		fpsLimitStr.format(L"[%u]", renderFpsLimit);
+		if (renderFpsLimit == 0)
+		{
+			fpsLimitStr.format(L"\x25B2X");
+		}
+		else
+		{
+			fpsLimitStr.format(L"\x25B2%u", renderFpsLimit);
+		}
 		m_renderFpsLimitString->setText(fpsLimitStr);
 		m_lastRenderFpsLimit = renderFpsLimit;
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -6232,19 +6232,15 @@ void InGameUI::drawRenderFps(Int &x, Int &y)
 		updateRenderFpsString();
 	}
 
-	UnsignedInt renderFpsLimit = 0u;
+	UnsignedInt renderFpsLimit = RenderFpsPreset::UncappedFpsValue;
 	if (TheGlobalData->m_useFpsLimit)
 	{
 		renderFpsLimit = (UnsignedInt)TheFramePacer->getFramesPerSecondLimit();
-		if (renderFpsLimit == RenderFpsPreset::UncappedFpsValue)
-		{
-			renderFpsLimit = 0u;
-		}
 	}
 	if (renderFpsLimit != m_lastRenderFpsLimit)
 	{
 		UnicodeString fpsLimitStr;
-		if (renderFpsLimit == 0)
+		if (renderFpsLimit == RenderFpsPreset::UncappedFpsValue)
 		{
 			fpsLimitStr.format(L"\x25B2X");
 		}

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -180,7 +180,7 @@ protected:
 	Real m_low1PercentFPS;	///<1% low fps.
 	Real m_currentFPS;		///<current fps value.
 
-	static constexpr Int FPS_HISTORY_SIZE = 5000;  // covers 5s at 1000 FPS, degrades gracefully beyond
+	enum { FPS_HISTORY_SIZE = 5000 }; // covers 5s at 1000 FPS, degrades gracefully beyond
 	Real m_fpsHistory[FPS_HISTORY_SIZE];
 	Real m_durationHistory[FPS_HISTORY_SIZE];
 	Int  m_historyOffset;

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -162,7 +162,10 @@ protected:
 	void drawCurrentDebugDisplay();			///< draws current debug display
 	void calculateTerrainLOD();						///< Calculate terrain LOD.
 	void renderLetterBox(UnsignedInt time);							///< draw letter box border
-	void updateAverageFPS();	///< calculate the average and 1% low fps over time windows (0.5s and 3.0s).
+	void updatePerformanceMetrics(); ///< update the average and 1% low fps metrics.
+	void addFpsSample(Real elapsedSeconds); ///< add a new sample to the history buffer.
+	Real calculateAverageFPS(Real windowSeconds); ///< calculate average FPS over a time window.
+	Real calculateLow1PercentFPS(Real windowSeconds); ///< calculate 1% low FPS over a time window.
 	void setup2DRenderState(TextureClass *tex, DrawImageMode mode, Bool grayscale);
 	virtual void onBeginBatch() override;
 	virtual void onEndBatch() override;
@@ -176,6 +179,13 @@ protected:
 	Real m_averageFPS;		///< average fps over the last 0.5s.
 	Real m_low1PercentFPS;	///<1% low fps.
 	Real m_currentFPS;		///<current fps value.
+
+	static constexpr Int FPS_HISTORY_SIZE = 5000;  // covers 5s at 1000 FPS, degrades gracefully beyond
+	Real m_fpsHistory[FPS_HISTORY_SIZE];
+	Real m_durationHistory[FPS_HISTORY_SIZE];
+	Int  m_historyOffset;
+	Int  m_historyCount;
+	Int64 m_lastUpdateTime64;
 
 	TextureClass *m_batchTexture;
 	DrawImageMode m_batchMode;

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -148,6 +148,7 @@ public:
 
 	void drawFPSStats();								///< draw the fps on the screen
 	virtual Real getAverageFPS() override;						///< return the average FPS.
+	virtual Real getLow1PercentFPS() override;					///< return the 1% low FPS.
 	virtual Real getCurrentFPS() override;						///< return the current FPS.
 	virtual Int getLastFrameDrawCalls() override;				///< returns the number of draw calls issued in the previous frame
 
@@ -161,7 +162,7 @@ protected:
 	void drawCurrentDebugDisplay();			///< draws current debug display
 	void calculateTerrainLOD();						///< Calculate terrain LOD.
 	void renderLetterBox(UnsignedInt time);							///< draw letter box border
-	void updateAverageFPS();	///< calculate the average fps over the last 30 frames.
+	void updateAverageFPS();	///< calculate the average and 1% low fps over time windows (0.5s and 3.0s).
 	void setup2DRenderState(TextureClass *tex, DrawImageMode mode, Bool grayscale);
 	virtual void onBeginBatch() override;
 	virtual void onEndBatch() override;
@@ -172,7 +173,8 @@ protected:
 	Render2DClass *m_2DRender;								///< interface for common 2D functions
 	IRegion2D m_clipRegion;									///< the clipping region for images
 	Bool m_isClippedEnabled;	///<used by 2D drawing operations to define clip re
-	Real m_averageFPS;		///<average fps over the last 30 frames.
+	Real m_averageFPS;		///< average fps over the last 0.5s.
+	Real m_low1PercentFPS;	///<1% low fps.
 	Real m_currentFPS;		///<current fps value.
 
 	TextureClass *m_batchTexture;

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -183,6 +183,7 @@ protected:
 	enum { FPS_HISTORY_SIZE = 5000 }; // covers 5s at 1000 FPS, degrades gracefully beyond
 	Real m_fpsHistory[FPS_HISTORY_SIZE];
 	Real m_durationHistory[FPS_HISTORY_SIZE];
+	Real m_sortBuffer[FPS_HISTORY_SIZE];
 	Int  m_historyOffset;
 	Int  m_historyCount;
 	Int64 m_lastUpdateTime64;

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -180,7 +180,7 @@ protected:
 	Real m_low1PercentFPS;	///<1% low fps.
 	Real m_currentFPS;		///<current fps value.
 
-	enum { FPS_HISTORY_SIZE = 5000 }; // covers 5s at 1000 FPS, degrades gracefully beyond
+	enum { FPS_HISTORY_SIZE = 4096 }; ; // degrades gracefully beyond this size
 	Real m_fpsHistory[FPS_HISTORY_SIZE];
 	Real m_durationHistory[FPS_HISTORY_SIZE];
 	Real m_sortBuffer[FPS_HISTORY_SIZE];

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -176,17 +176,16 @@ protected:
 	Render2DClass *m_2DRender;								///< interface for common 2D functions
 	IRegion2D m_clipRegion;									///< the clipping region for images
 	Bool m_isClippedEnabled;	///<used by 2D drawing operations to define clip re
-	Real m_averageFPS;		///< average fps over the last 0.5s.
+	Real m_averageFPS;		///< average fps over the last 1.0s.
 	Real m_low1PercentFPS;	///<1% low fps.
 	Real m_currentFPS;		///<current fps value.
 
-	enum { FPS_HISTORY_SIZE = 4096 }; ; // degrades gracefully beyond this size
-	Real m_fpsHistory[FPS_HISTORY_SIZE];
-	Real m_durationHistory[FPS_HISTORY_SIZE];
-	Real m_sortBuffer[FPS_HISTORY_SIZE];
+	enum { FPS_HISTORY_SIZE = 4096 }; // degrades gracefully beyond this size
+	UnsignedShort m_durationHistory[FPS_HISTORY_SIZE];
 	Int  m_historyOffset;
 	Int  m_historyCount;
 	Int64 m_lastUpdateTime64;
+	UnsignedInt m_lastLow1PercentUpdateMs;
 
 	TextureClass *m_batchTexture;
 	DrawImageMode m_batchMode;

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -49,6 +49,33 @@ class RTS3DInterfaceScene;
 class TextureClass;
 
 
+class QuantizedUnsignedShort
+{
+public:
+	QuantizedUnsignedShort() : m_value(2083) {}
+	explicit QuantizedUnsignedShort(UnsignedShort val) : m_value(val) {}
+
+	static QuantizedUnsignedShort fromSeconds(Real seconds)
+	{
+		Int64 ticks = (Int64)(seconds * 62500.0f + 0.5f);
+		if (ticks >= 65535) return QuantizedUnsignedShort(65535);
+		if (ticks <= 0) return QuantizedUnsignedShort(1);
+		return QuantizedUnsignedShort((UnsignedShort)ticks);
+	}
+
+	UnsignedShort getValue() const { return m_value; }
+	void setValue(UnsignedShort val) { m_value = val; }
+
+	Real toFPS() const { return 62500.0f / (Real)m_value; }
+	Real toSeconds() const { return (Real)m_value / 62500.0f; }
+
+	operator UnsignedShort() const { return m_value; }
+
+private:
+	UnsignedShort m_value;
+};
+
+
 //=============================================================================
 /** W3D implementation of the game display which is responsible for creating
   * all interaction with the screen and updating the display
@@ -181,7 +208,7 @@ protected:
 	Real m_currentFPS;		///<current fps value.
 
 	enum { FPS_HISTORY_SIZE = 4096 }; // degrades gracefully beyond this size
-	UnsignedShort m_durationHistory[FPS_HISTORY_SIZE];
+	QuantizedUnsignedShort m_durationHistory[FPS_HISTORY_SIZE];
 	Int  m_historyOffset;
 	Int  m_historyCount;
 	Int64 m_lastUpdateTime64;

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -59,8 +59,14 @@ public:
 	static QuantizedUnsignedShort fromSeconds(Real seconds)
 	{
 		Int64 ticks = (Int64)(seconds * TICKS_PER_SECOND + 0.5f);
-		if (ticks >= 65535) return QuantizedUnsignedShort(65535);
-		if (ticks <= 0) return QuantizedUnsignedShort(1);
+		if (ticks >= 65535)
+		{
+			return QuantizedUnsignedShort(65535);
+		}
+		if (ticks <= 0)
+		{
+			return QuantizedUnsignedShort(1);
+		}
 		return QuantizedUnsignedShort((UnsignedShort)ticks);
 	}
 

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -48,12 +48,11 @@ class RTS2DScene;
 class RTS3DInterfaceScene;
 class TextureClass;
 
+constexpr const Real TICKS_PER_SECOND = 62500.0f;
 
 class QuantizedUnsignedShort
 {
 public:
-	static constexpr Real TICKS_PER_SECOND = 62500.0f;
-
 	QuantizedUnsignedShort() : m_value(2083) {}
 	explicit QuantizedUnsignedShort(UnsignedShort val) : m_value(val) {}
 

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDisplay.h
@@ -52,12 +52,14 @@ class TextureClass;
 class QuantizedUnsignedShort
 {
 public:
+	static constexpr Real TICKS_PER_SECOND = 62500.0f;
+
 	QuantizedUnsignedShort() : m_value(2083) {}
 	explicit QuantizedUnsignedShort(UnsignedShort val) : m_value(val) {}
 
 	static QuantizedUnsignedShort fromSeconds(Real seconds)
 	{
-		Int64 ticks = (Int64)(seconds * 62500.0f + 0.5f);
+		Int64 ticks = (Int64)(seconds * TICKS_PER_SECOND + 0.5f);
 		if (ticks >= 65535) return QuantizedUnsignedShort(65535);
 		if (ticks <= 0) return QuantizedUnsignedShort(1);
 		return QuantizedUnsignedShort((UnsignedShort)ticks);
@@ -66,8 +68,8 @@ public:
 	UnsignedShort getValue() const { return m_value; }
 	void setValue(UnsignedShort val) { m_value = val; }
 
-	Real toFPS() const { return 62500.0f / (Real)m_value; }
-	Real toSeconds() const { return (Real)m_value / 62500.0f; }
+	Real toFPS() const { return TICKS_PER_SECOND / (Real)m_value; }
+	Real toSeconds() const { return (Real)m_value / TICKS_PER_SECOND; }
 
 	operator UnsignedShort() const { return m_value; }
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -411,6 +411,15 @@ W3DDisplay::W3DDisplay()
 	m_batchGrayscale = FALSE;
 	m_batchNeedsInit = FALSE;
 
+	m_historyOffset = 0;
+	m_historyCount = 0;
+	m_lastUpdateTime64 = 0;
+	for (Int h = 0; h < FPS_HISTORY_SIZE; ++h)
+	{
+		m_fpsHistory[h] = 0.0f;
+		m_durationHistory[h] = 0.0f;
+	}
+
 #ifdef PROFILER_ENABLED
 	m_profilerFrameCapture = NEW W3DProfilerFrameCapture();
 #endif
@@ -1010,103 +1019,98 @@ void W3DDisplay::reset()
 
 const UnsignedInt START_CUMU_FRAME = LOGICFRAMES_PER_SECOND / 2;	// skip first half-sec
 
-void W3DDisplay::updateAverageFPS()
+void W3DDisplay::addFpsSample(Real elapsedSeconds)
 {
-	constexpr const Int FPS_HISTORY_SIZE = 1000;
-	static Real fpsHistory[FPS_HISTORY_SIZE] = {0};
-	static Real durationHistory[FPS_HISTORY_SIZE] = {0};
-	static Int historyOffset = 0;
-	static Int historyCount = 0;
-	static Int64 lastUpdateTime64 = 0;
+	if (elapsedSeconds <= 0.0f) return;
 
+	m_currentFPS = 1.0f / elapsedSeconds;
+	m_fpsHistory[m_historyOffset] = m_currentFPS;
+	m_durationHistory[m_historyOffset] = elapsedSeconds;
+
+	m_historyOffset = (m_historyOffset + 1) % FPS_HISTORY_SIZE;
+	if (m_historyCount < FPS_HISTORY_SIZE) m_historyCount++;
+}
+
+Real W3DDisplay::calculateAverageFPS(Real windowSeconds)
+{
+	if (m_historyCount == 0) return m_currentFPS;
+
+	Real timeSum = 0;
+	Real fpsSum = 0;
+	Int samples = 0;
+
+	for (Int i = 0; i < m_historyCount; ++i)
+	{
+		Int idx = (m_historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
+		timeSum += m_durationHistory[idx];
+		fpsSum += m_fpsHistory[idx];
+		samples++;
+
+		if (timeSum >= windowSeconds) break;
+	}
+
+	return (samples > 0) ? (fpsSum / (Real)samples) : m_currentFPS;
+}
+
+Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
+{
+	if (m_historyCount == 0) return m_currentFPS;
+
+	static Real sortBuffer[FPS_HISTORY_SIZE];
+	Real timeSum = 0;
+	Int sampleCount = 0;
+
+	for (Int i = 0; i < m_historyCount; ++i)
+	{
+		Int idx = (m_historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
+		timeSum += m_durationHistory[idx];
+		sortBuffer[sampleCount++] = m_fpsHistory[idx];
+
+		if (timeSum >= windowSeconds) break;
+	}
+
+	if (sampleCount == 0) return m_currentFPS;
+
+	const Int bottomSampleCount = std::max((sampleCount + 99) / 100, 1);
+
+	std::nth_element(sortBuffer, sortBuffer + bottomSampleCount, sortBuffer + sampleCount);
+
+	Real lowSum = 0;
+	for (Int i = 0; i < bottomSampleCount; ++i) lowSum += sortBuffer[i];
+
+	return lowSum / (Real)bottomSampleCount;
+}
+
+void W3DDisplay::updatePerformanceMetrics()
+{
 	const Int64 freq64 = getPerformanceCounterFrequency();
 	const Int64 time64 = getPerformanceCounter();
 
 #if defined(RTS_DEBUG)
-	if (TheGameLogic->getFrame() == START_CUMU_FRAME)
-	{
-		m_timerAtCumuFPSStart = time64;
-	}
+	if (TheGameLogic->getFrame() == START_CUMU_FRAME) m_timerAtCumuFPSStart = time64;
 #endif
 
-	if (lastUpdateTime64 == 0)
+	if (m_lastUpdateTime64 == 0)
 	{
-		lastUpdateTime64 = time64;
+		m_lastUpdateTime64 = time64;
 		return;
 	}
 
-	const Int64 timeDiff = time64 - lastUpdateTime64;
+	const Int64 timeDiff = time64 - m_lastUpdateTime64;
+	Real elapsedSeconds = (Real)timeDiff / (Real)freq64;
 
-	// convert elapsed time to seconds
-	Real elapsedSeconds = (Real)timeDiff/(Real)freq64;
+	addFpsSample(elapsedSeconds);
+	m_averageFPS = calculateAverageFPS(0.5f);
 
-	// append new sample to fps history.
-	if (elapsedSeconds > 0)
+	static UnsignedInt lastLowUpdate = 0;
+	UnsignedInt now = timeGetTime();
+	if (now - lastLowUpdate >= 1000)
 	{
-		m_currentFPS = 1.0f/elapsedSeconds;
-		fpsHistory[historyOffset] = m_currentFPS;
-		durationHistory[historyOffset] = elapsedSeconds;
-		historyOffset = (historyOffset + 1) % FPS_HISTORY_SIZE;
-		if (historyCount < FPS_HISTORY_SIZE)
-		{
-			historyCount++;
-		}
+		lastLowUpdate = now;
+		m_low1PercentFPS = calculateLow1PercentFPS(3.0f);
 	}
 
-	// determine average frame rate over the last 0.5 seconds and 1% low over 3.0 seconds.
-	if (historyCount > 0)
-	{
-		Real timeSum = 0;
-		Real fpsSum = 0;
-		Int avgSamples = 0;
-		Int lowSamples = 0;
-		Bool avgDone = FALSE;
-
-		for (Int i = 0; i < historyCount; ++i)
-		{
-			Int idx = (historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
-			timeSum += durationHistory[idx];
-			
-			lowSamples++;
-			
-			if (!avgDone)
-			{
-				fpsSum += fpsHistory[idx];
-				avgSamples++;
-				if (timeSum >= 0.5f)
-				{
-					avgDone = TRUE;
-				}
-			}
-			
-			if (timeSum >= 3.0f)
-			{
-				break;
-			}
-		}
-
-		m_averageFPS = avgSamples > 0 ? fpsSum / (Real)avgSamples : m_currentFPS;
-
-		// TheSuperHackers @feature One percent low FPS calculation (last 3.0 seconds)
-		// Throttle sorting to 1000ms intervals to match HUD refresh and save CPU
-		static UnsignedInt lastLowUpdate = 0;
-		UnsignedInt now = timeGetTime();
-		if (now - lastLowUpdate >= 1000)
-		{
-			lastLowUpdate = now;
-			static Real sortBuffer[FPS_HISTORY_SIZE];
-			for (Int i = 0; i < lowSamples; ++i)
-			{
-				Int idx = (historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
-				sortBuffer[i] = fpsHistory[idx];
-			}
-			const Int lowCount = std::max(lowSamples / 100, 1);
-			std::nth_element(sortBuffer, sortBuffer + lowCount, sortBuffer + lowSamples);
-			m_low1PercentFPS = std::accumulate(sortBuffer, sortBuffer + lowCount, 0.0f) / (Real)lowCount;
-		}
-	}
-
-	lastUpdateTime64 = time64;
+	m_lastUpdateTime64 = time64;
 }
 
 #if defined(RTS_DEBUG)	//debug hack to view object under mouse stats
@@ -1865,7 +1869,7 @@ void W3DDisplay::draw()
 	if (TheGlobalData->m_headless)
 		return;
 
-	updateAverageFPS();
+	updatePerformanceMetrics();
 	if (TheGlobalData->m_enableDynamicLOD && TheGameLogic->getShowDynamicLOD())
 	{
 		DynamicGameLODLevel lod=TheGameLODManager->findDynamicLODLevel(m_averageFPS);

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -1059,8 +1059,9 @@ Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 	static Real sortBuffer[FPS_HISTORY_SIZE];
 	Real timeSum = 0;
 	Int sampleCount = 0;
+	Int i;
 
-	for (Int i = 0; i < m_historyCount; ++i)
+	for (i = 0; i < m_historyCount; ++i)
 	{
 		Int idx = (m_historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
 		timeSum += m_durationHistory[idx];
@@ -1076,7 +1077,7 @@ Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 	std::nth_element(sortBuffer, sortBuffer + bottomSampleCount, sortBuffer + sampleCount);
 
 	Real lowSum = 0;
-	for (Int i = 0; i < bottomSampleCount; ++i) lowSum += sortBuffer[i];
+	for (i = 0; i < bottomSampleCount; ++i) lowSum += sortBuffer[i];
 
 	return lowSum / (Real)bottomSampleCount;
 }

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -1047,7 +1047,10 @@ void W3DDisplay::updateAverageFPS()
 		fpsHistory[historyOffset] = m_currentFPS;
 		durationHistory[historyOffset] = elapsedSeconds;
 		historyOffset = (historyOffset + 1) % FPS_HISTORY_SIZE;
-		if (historyCount < FPS_HISTORY_SIZE) historyCount++;
+		if (historyCount < FPS_HISTORY_SIZE)
+		{
+			historyCount++;
+		}
 	}
 
 	// determine average frame rate over the last 0.5 seconds and 1% low over 3.0 seconds.
@@ -1070,10 +1073,16 @@ void W3DDisplay::updateAverageFPS()
 			{
 				fpsSum += fpsHistory[idx];
 				avgSamples++;
-				if (timeSum >= 0.5f) avgDone = TRUE;
+				if (timeSum >= 0.5f)
+				{
+					avgDone = TRUE;
+				}
 			}
 			
-			if (timeSum >= 3.0f) break;
+			if (timeSum >= 3.0f)
+			{
+				break;
+			}
 		}
 
 		m_averageFPS = avgSamples > 0 ? fpsSum / (Real)avgSamples : m_currentFPS;

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -1090,7 +1090,7 @@ Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 		return m_currentFPS;
 	}
 
-	const Int bottomSampleCount = std::max((sampleCount + 99) / 100, 1);
+	const Int bottomSampleCount = std::max((sampleCount + 50) / 100, 1);
 
 	std::nth_element(m_sortBuffer, m_sortBuffer + bottomSampleCount, m_sortBuffer + sampleCount);
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -1021,42 +1021,54 @@ const UnsignedInt START_CUMU_FRAME = LOGICFRAMES_PER_SECOND / 2;	// skip first h
 
 void W3DDisplay::addFpsSample(Real elapsedSeconds)
 {
-	if (elapsedSeconds <= 0.0f) return;
+	if (elapsedSeconds <= 0.0f)
+	{
+		return;
+	}
 
 	m_currentFPS = 1.0f / elapsedSeconds;
 	m_fpsHistory[m_historyOffset] = m_currentFPS;
 	m_durationHistory[m_historyOffset] = elapsedSeconds;
 
 	m_historyOffset = (m_historyOffset + 1) % FPS_HISTORY_SIZE;
-	if (m_historyCount < FPS_HISTORY_SIZE) m_historyCount++;
+	if (m_historyCount < FPS_HISTORY_SIZE)
+	{
+		m_historyCount++;
+	}
 }
 
 Real W3DDisplay::calculateAverageFPS(Real windowSeconds)
 {
-	if (m_historyCount == 0) return m_currentFPS;
+	if (m_historyCount == 0)
+	{
+		return m_currentFPS;
+	}
 
 	Real timeSum = 0;
-	Real fpsSum = 0;
 	Int samples = 0;
 
 	for (Int i = 0; i < m_historyCount; ++i)
 	{
 		Int idx = (m_historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
 		timeSum += m_durationHistory[idx];
-		fpsSum += m_fpsHistory[idx];
 		samples++;
 
-		if (timeSum >= windowSeconds) break;
+		if (timeSum >= windowSeconds)
+		{
+			break;
+		}
 	}
 
-	return (samples > 0) ? (fpsSum / (Real)samples) : m_currentFPS;
+	return (timeSum > 0) ? ((Real)samples / timeSum) : m_currentFPS;
 }
 
 Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 {
-	if (m_historyCount == 0) return m_currentFPS;
+	if (m_historyCount == 0)
+	{
+		return m_currentFPS;
+	}
 
-	static Real sortBuffer[FPS_HISTORY_SIZE];
 	Real timeSum = 0;
 	Int sampleCount = 0;
 	Int i;
@@ -1065,19 +1077,28 @@ Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 	{
 		Int idx = (m_historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
 		timeSum += m_durationHistory[idx];
-		sortBuffer[sampleCount++] = m_fpsHistory[idx];
+		m_sortBuffer[sampleCount++] = m_fpsHistory[idx];
 
-		if (timeSum >= windowSeconds) break;
+		if (timeSum >= windowSeconds)
+		{
+			break;
+		}
 	}
 
-	if (sampleCount == 0) return m_currentFPS;
+	if (sampleCount == 0)
+	{
+		return m_currentFPS;
+	}
 
 	const Int bottomSampleCount = std::max((sampleCount + 99) / 100, 1);
 
-	std::nth_element(sortBuffer, sortBuffer + bottomSampleCount, sortBuffer + sampleCount);
+	std::nth_element(m_sortBuffer, m_sortBuffer + bottomSampleCount, m_sortBuffer + sampleCount);
 
 	Real lowSum = 0;
-	for (i = 0; i < bottomSampleCount; ++i) lowSum += sortBuffer[i];
+	for (i = 0; i < bottomSampleCount; ++i)
+	{
+		lowSum += m_sortBuffer[i];
+	}
 
 	return lowSum / (Real)bottomSampleCount;
 }
@@ -1088,7 +1109,10 @@ void W3DDisplay::updatePerformanceMetrics()
 	const Int64 time64 = getPerformanceCounter();
 
 #if defined(RTS_DEBUG)
-	if (TheGameLogic->getFrame() == START_CUMU_FRAME) m_timerAtCumuFPSStart = time64;
+	if (TheGameLogic->getFrame() == START_CUMU_FRAME)
+	{
+		m_timerAtCumuFPSStart = time64;
+	}
 #endif
 
 	if (m_lastUpdateTime64 == 0)

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -390,6 +390,7 @@ W3DDisplay::W3DDisplay()
 	m_2DScene = nullptr;
 	m_3DInterfaceScene = nullptr;
 	m_averageFPS = TheGlobalData->m_framesPerSecondLimit;
+	m_low1PercentFPS = TheGlobalData->m_framesPerSecondLimit;
 #if defined(RTS_DEBUG)
 	m_timerAtCumuFPSStart = 0;
 #endif
@@ -1011,11 +1012,12 @@ const UnsignedInt START_CUMU_FRAME = LOGICFRAMES_PER_SECOND / 2;	// skip first h
 
 void W3DDisplay::updateAverageFPS()
 {
-	constexpr const Int FPS_HISTORY_SIZE = 30;
-
-	static Int64 lastUpdateTime64 = 0;
-	static Int historyOffset = 0;
+	constexpr const Int FPS_HISTORY_SIZE = 1000;
 	static Real fpsHistory[FPS_HISTORY_SIZE] = {0};
+	static Real durationHistory[FPS_HISTORY_SIZE] = {0};
+	static Int historyOffset = 0;
+	static Int historyCount = 0;
+	static Int64 lastUpdateTime64 = 0;
 
 	const Int64 freq64 = getPerformanceCounterFrequency();
 	const Int64 time64 = getPerformanceCounter();
@@ -1027,21 +1029,73 @@ void W3DDisplay::updateAverageFPS()
 	}
 #endif
 
+	if (lastUpdateTime64 == 0)
+	{
+		lastUpdateTime64 = time64;
+		return;
+	}
+
 	const Int64 timeDiff = time64 - lastUpdateTime64;
 
 	// convert elapsed time to seconds
 	Real elapsedSeconds = (Real)timeDiff/(Real)freq64;
 
 	// append new sample to fps history.
-	if (historyOffset >= FPS_HISTORY_SIZE)
-		historyOffset = 0;
+	if (elapsedSeconds > 0)
+	{
+		m_currentFPS = 1.0f/elapsedSeconds;
+		fpsHistory[historyOffset] = m_currentFPS;
+		durationHistory[historyOffset] = elapsedSeconds;
+		historyOffset = (historyOffset + 1) % FPS_HISTORY_SIZE;
+		if (historyCount < FPS_HISTORY_SIZE) historyCount++;
+	}
 
-	m_currentFPS = 1.0f/elapsedSeconds;
-	fpsHistory[historyOffset++] = m_currentFPS;
+	// determine average frame rate over the last 0.5 seconds and 1% low over 3.0 seconds.
+	if (historyCount > 0)
+	{
+		Real timeSum = 0;
+		Real fpsSum = 0;
+		Int avgSamples = 0;
+		Int lowSamples = 0;
+		Bool avgDone = FALSE;
 
-	// determine average frame rate over our past history.
-	const Real sum = std::accumulate(fpsHistory, fpsHistory + FPS_HISTORY_SIZE, 0.0f);
-	m_averageFPS = sum / FPS_HISTORY_SIZE;
+		for (Int i = 0; i < historyCount; ++i)
+		{
+			Int idx = (historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
+			timeSum += durationHistory[idx];
+			
+			lowSamples++;
+			
+			if (!avgDone)
+			{
+				fpsSum += fpsHistory[idx];
+				avgSamples++;
+				if (timeSum >= 0.5f) avgDone = TRUE;
+			}
+			
+			if (timeSum >= 3.0f) break;
+		}
+
+		m_averageFPS = avgSamples > 0 ? fpsSum / (Real)avgSamples : m_currentFPS;
+
+		// TheSuperHackers @feature One percent low FPS calculation (last 3.0 seconds)
+		// Throttle sorting to 1000ms intervals to match HUD refresh and save CPU
+		static UnsignedInt lastLowUpdate = 0;
+		UnsignedInt now = timeGetTime();
+		if (now - lastLowUpdate >= 1000)
+		{
+			lastLowUpdate = now;
+			static Real sortBuffer[FPS_HISTORY_SIZE];
+			for (Int i = 0; i < lowSamples; ++i)
+			{
+				Int idx = (historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
+				sortBuffer[i] = fpsHistory[idx];
+			}
+			const Int lowCount = std::max(lowSamples / 100, 1);
+			std::nth_element(sortBuffer, sortBuffer + lowCount, sortBuffer + lowSamples);
+			m_low1PercentFPS = std::accumulate(sortBuffer, sortBuffer + lowCount, 0.0f) / (Real)lowCount;
+		}
+	}
 
 	lastUpdateTime64 = time64;
 }
@@ -1761,6 +1815,11 @@ void W3DDisplay::calculateTerrainLOD()
 Real W3DDisplay::getAverageFPS()
 {
 	return m_averageFPS;
+}
+
+Real W3DDisplay::getLow1PercentFPS()
+{
+	return m_low1PercentFPS;
 }
 
 Real W3DDisplay::getCurrentFPS()

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -412,12 +412,13 @@ W3DDisplay::W3DDisplay()
 	m_batchNeedsInit = FALSE;
 
 	m_historyOffset = 0;
-	m_historyCount = 0;
+	m_historyCount = 1;
 	m_lastUpdateTime64 = 0;
+	m_currentFPS = 30.0f;
 	for (Int h = 0; h < FPS_HISTORY_SIZE; ++h)
 	{
-		m_fpsHistory[h] = 0.0f;
-		m_durationHistory[h] = 0.0f;
+		m_fpsHistory[h] = 30.0f;
+		m_durationHistory[h] = 1.0f / 30.0f;
 	}
 
 #ifdef PROFILER_ENABLED
@@ -976,6 +977,7 @@ void W3DDisplay::init()
 
 	// we're now online
 	m_initialized = true;
+	m_lastUpdateTime64 = getPerformanceCounter();
 	if( TheGlobalData->m_displayDebug )
 	{
 		m_debugDisplayCallback = StatDebugDisplay;
@@ -1021,16 +1023,16 @@ const UnsignedInt START_CUMU_FRAME = LOGICFRAMES_PER_SECOND / 2;	// skip first h
 
 void W3DDisplay::addFpsSample(Real elapsedSeconds)
 {
-	if (elapsedSeconds <= 0.0f)
+	if (elapsedSeconds < 0.0001f)
 	{
-		return;
+		elapsedSeconds = 0.0001f;
 	}
 
 	m_currentFPS = 1.0f / elapsedSeconds;
 	m_fpsHistory[m_historyOffset] = m_currentFPS;
 	m_durationHistory[m_historyOffset] = elapsedSeconds;
 
-	m_historyOffset = (m_historyOffset + 1) % FPS_HISTORY_SIZE;
+	m_historyOffset = (m_historyOffset + 1) & (FPS_HISTORY_SIZE - 1);
 	if (m_historyCount < FPS_HISTORY_SIZE)
 	{
 		m_historyCount++;
@@ -1039,17 +1041,13 @@ void W3DDisplay::addFpsSample(Real elapsedSeconds)
 
 Real W3DDisplay::calculateAverageFPS(Real windowSeconds)
 {
-	if (m_historyCount == 0)
-	{
-		return m_currentFPS;
-	}
-
 	Real timeSum = 0;
 	Int samples = 0;
 
+	Int idx = m_historyOffset - 1;
 	for (Int i = 0; i < m_historyCount; ++i)
 	{
-		Int idx = (m_historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
+		if (idx < 0) idx += FPS_HISTORY_SIZE;
 		timeSum += m_durationHistory[idx];
 		samples++;
 
@@ -1057,6 +1055,7 @@ Real W3DDisplay::calculateAverageFPS(Real windowSeconds)
 		{
 			break;
 		}
+		--idx;
 	}
 
 	return (timeSum > 0) ? ((Real)samples / timeSum) : m_currentFPS;
@@ -1064,18 +1063,14 @@ Real W3DDisplay::calculateAverageFPS(Real windowSeconds)
 
 Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 {
-	if (m_historyCount == 0)
-	{
-		return m_currentFPS;
-	}
-
 	Real timeSum = 0;
 	Int sampleCount = 0;
 	Int i;
 
+	Int idx = m_historyOffset - 1;
 	for (i = 0; i < m_historyCount; ++i)
 	{
-		Int idx = (m_historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
+		if (idx < 0) idx += FPS_HISTORY_SIZE;
 		timeSum += m_durationHistory[idx];
 		m_sortBuffer[sampleCount++] = m_fpsHistory[idx];
 
@@ -1083,6 +1078,7 @@ Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 		{
 			break;
 		}
+		--idx;
 	}
 
 	if (sampleCount == 0)
@@ -1115,21 +1111,15 @@ void W3DDisplay::updatePerformanceMetrics()
 	}
 #endif
 
-	if (m_lastUpdateTime64 == 0)
-	{
-		m_lastUpdateTime64 = time64;
-		return;
-	}
-
 	const Int64 timeDiff = time64 - m_lastUpdateTime64;
 	Real elapsedSeconds = (Real)timeDiff / (Real)freq64;
 
 	addFpsSample(elapsedSeconds);
-	m_averageFPS = calculateAverageFPS(0.5f);
+	m_averageFPS = calculateAverageFPS(1.0f); // 1.0s window for smooth Dynamic LOD tracking and UI matching
 
 	static UnsignedInt lastLowUpdate = 0;
 	UnsignedInt now = timeGetTime();
-	if (now - lastLowUpdate >= 1000)
+	if (now - lastLowUpdate >= 100) // update low 1% metrics at 100ms intervals instead of 1000ms since it is now extremely cheap
 	{
 		lastLowUpdate = now;
 		m_low1PercentFPS = calculateLow1PercentFPS(3.0f);

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -1060,8 +1060,9 @@ Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 	static Real sortBuffer[FPS_HISTORY_SIZE];
 	Real timeSum = 0;
 	Int sampleCount = 0;
+	Int i;
 
-	for (Int i = 0; i < m_historyCount; ++i)
+	for (i = 0; i < m_historyCount; ++i)
 	{
 		Int idx = (m_historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
 		timeSum += m_durationHistory[idx];
@@ -1077,7 +1078,7 @@ Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 	std::nth_element(sortBuffer, sortBuffer + bottomSampleCount, sortBuffer + sampleCount);
 
 	Real lowSum = 0;
-	for (Int i = 0; i < bottomSampleCount; ++i) lowSum += sortBuffer[i];
+	for (i = 0; i < bottomSampleCount; ++i) lowSum += sortBuffer[i];
 
 	return lowSum / (Real)bottomSampleCount;
 }

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -1039,7 +1039,7 @@ Real W3DDisplay::calculateAverageFPS(Real windowSeconds)
 {
 	UnsignedInt unitsSum = 0;
 	Int samples = 0;
-	const UnsignedInt windowUnits = (UnsignedInt)(windowSeconds * QuantizedUnsignedShort::TICKS_PER_SECOND);
+	const UnsignedInt windowUnits = (UnsignedInt)(windowSeconds * TICKS_PER_SECOND);
 
 	for (Int i = 0; i < m_historyCount; ++i)
 	{
@@ -1053,14 +1053,14 @@ Real W3DDisplay::calculateAverageFPS(Real windowSeconds)
 		}
 	}
 
-	return (unitsSum > 0) ? ((Real)samples * QuantizedUnsignedShort::TICKS_PER_SECOND / (Real)unitsSum) : m_currentFPS;
+	return (unitsSum > 0) ? ((Real)samples * TICKS_PER_SECOND / (Real)unitsSum) : m_currentFPS;
 }
 
 Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 {
 	UnsignedInt unitsSum = 0;
 	Int sampleCount = 0;
-	const UnsignedInt windowUnits = (UnsignedInt)(windowSeconds * QuantizedUnsignedShort::TICKS_PER_SECOND);
+	const UnsignedInt windowUnits = (UnsignedInt)(windowSeconds * TICKS_PER_SECOND);
 	QuantizedUnsignedShort sortBuffer[FPS_HISTORY_SIZE];
 
 	Int i;
@@ -1091,7 +1091,7 @@ Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 		durationUnitsSum += sortBuffer[i];
 	}
 
-	return (durationUnitsSum > 0) ? ((Real)bottomSampleCount * QuantizedUnsignedShort::TICKS_PER_SECOND / (Real)durationUnitsSum) : m_currentFPS;
+	return (durationUnitsSum > 0) ? ((Real)bottomSampleCount * TICKS_PER_SECOND / (Real)durationUnitsSum) : m_currentFPS;
 }
 
 void W3DDisplay::updatePerformanceMetrics()

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -419,7 +419,7 @@ W3DDisplay::W3DDisplay()
 	m_lastUpdateTime64 = 0;
 	m_lastLow1PercentUpdateMs = 0;
 	m_currentFPS = 30.0f;
-	std::fill(std::begin(m_durationHistory), std::end(m_durationHistory), (UnsignedShort)2083);
+	std::fill(m_durationHistory, m_durationHistory + FPS_HISTORY_SIZE, (UnsignedShort)2083);
 
 #ifdef PROFILER_ENABLED
 	m_profilerFrameCapture = NEW W3DProfilerFrameCapture();
@@ -1064,7 +1064,8 @@ Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 	const UnsignedInt windowUnits = (UnsignedInt)(windowSeconds * 62500.0f);
 	UnsignedShort sortBuffer[FPS_HISTORY_SIZE];
 
-	for (Int i = 0; i < m_historyCount; ++i)
+	Int i;
+	for (i = 0; i < m_historyCount; ++i)
 	{
 		Int idx = (m_historyOffset - 1 - i) & (FPS_HISTORY_SIZE - 1);
 		unitsSum += m_durationHistory[idx];
@@ -1086,7 +1087,7 @@ Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 	std::nth_element(sortBuffer, sortBuffer + bottomSampleCount, sortBuffer + sampleCount, std::greater<UnsignedShort>());
 
 	UnsignedInt durationUnitsSum = 0;
-	for (Int i = 0; i < bottomSampleCount; ++i)
+	for (i = 0; i < bottomSampleCount; ++i)
 	{
 		durationUnitsSum += sortBuffer[i];
 	}

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -413,12 +413,13 @@ W3DDisplay::W3DDisplay()
 	m_batchNeedsInit = FALSE;
 
 	m_historyOffset = 0;
-	m_historyCount = 0;
+	m_historyCount = 1;
 	m_lastUpdateTime64 = 0;
+	m_currentFPS = 30.0f;
 	for (Int h = 0; h < FPS_HISTORY_SIZE; ++h)
 	{
-		m_fpsHistory[h] = 0.0f;
-		m_durationHistory[h] = 0.0f;
+		m_fpsHistory[h] = 30.0f;
+		m_durationHistory[h] = 1.0f / 30.0f;
 	}
 
 #ifdef PROFILER_ENABLED
@@ -977,6 +978,7 @@ void W3DDisplay::init()
 
 	// we're now online
 	m_initialized = true;
+	m_lastUpdateTime64 = getPerformanceCounter();
 	if( TheGlobalData->m_displayDebug )
 	{
 		m_debugDisplayCallback = StatDebugDisplay;
@@ -1022,16 +1024,16 @@ const UnsignedInt START_CUMU_FRAME = LOGICFRAMES_PER_SECOND / 2;	// skip first h
 
 void W3DDisplay::addFpsSample(Real elapsedSeconds)
 {
-	if (elapsedSeconds <= 0.0f)
+	if (elapsedSeconds < 0.0001f)
 	{
-		return;
+		elapsedSeconds = 0.0001f;
 	}
 
 	m_currentFPS = 1.0f / elapsedSeconds;
 	m_fpsHistory[m_historyOffset] = m_currentFPS;
 	m_durationHistory[m_historyOffset] = elapsedSeconds;
 
-	m_historyOffset = (m_historyOffset + 1) % FPS_HISTORY_SIZE;
+	m_historyOffset = (m_historyOffset + 1) & (FPS_HISTORY_SIZE - 1);
 	if (m_historyCount < FPS_HISTORY_SIZE)
 	{
 		m_historyCount++;
@@ -1040,17 +1042,13 @@ void W3DDisplay::addFpsSample(Real elapsedSeconds)
 
 Real W3DDisplay::calculateAverageFPS(Real windowSeconds)
 {
-	if (m_historyCount == 0)
-	{
-		return m_currentFPS;
-	}
-
 	Real timeSum = 0;
 	Int samples = 0;
 
+	Int idx = m_historyOffset - 1;
 	for (Int i = 0; i < m_historyCount; ++i)
 	{
-		Int idx = (m_historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
+		if (idx < 0) idx += FPS_HISTORY_SIZE;
 		timeSum += m_durationHistory[idx];
 		samples++;
 
@@ -1058,6 +1056,7 @@ Real W3DDisplay::calculateAverageFPS(Real windowSeconds)
 		{
 			break;
 		}
+		--idx;
 	}
 
 	return (timeSum > 0) ? ((Real)samples / timeSum) : m_currentFPS;
@@ -1065,18 +1064,14 @@ Real W3DDisplay::calculateAverageFPS(Real windowSeconds)
 
 Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 {
-	if (m_historyCount == 0)
-	{
-		return m_currentFPS;
-	}
-
 	Real timeSum = 0;
 	Int sampleCount = 0;
 	Int i;
 
+	Int idx = m_historyOffset - 1;
 	for (i = 0; i < m_historyCount; ++i)
 	{
-		Int idx = (m_historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
+		if (idx < 0) idx += FPS_HISTORY_SIZE;
 		timeSum += m_durationHistory[idx];
 		m_sortBuffer[sampleCount++] = m_fpsHistory[idx];
 
@@ -1084,6 +1079,7 @@ Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 		{
 			break;
 		}
+		--idx;
 	}
 
 	if (sampleCount == 0)
@@ -1116,21 +1112,15 @@ void W3DDisplay::updatePerformanceMetrics()
 	}
 #endif
 
-	if (m_lastUpdateTime64 == 0)
-	{
-		m_lastUpdateTime64 = time64;
-		return;
-	}
-
 	const Int64 timeDiff = time64 - m_lastUpdateTime64;
 	Real elapsedSeconds = (Real)timeDiff / (Real)freq64;
 
 	addFpsSample(elapsedSeconds);
-	m_averageFPS = calculateAverageFPS(0.5f);
+	m_averageFPS = calculateAverageFPS(1.0f); // 1.0s window for smooth Dynamic LOD tracking and UI matching
 
 	static UnsignedInt lastLowUpdate = 0;
 	UnsignedInt now = timeGetTime();
-	if (now - lastLowUpdate >= 1000)
+	if (now - lastLowUpdate >= 100) // update low 1% metrics at 100ms intervals instead of 1000ms since it is now extremely cheap
 	{
 		lastLowUpdate = now;
 		m_low1PercentFPS = calculateLow1PercentFPS(3.0f);

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -391,6 +391,7 @@ W3DDisplay::W3DDisplay()
 	m_2DScene = nullptr;
 	m_3DInterfaceScene = nullptr;
 	m_averageFPS = TheGlobalData->m_framesPerSecondLimit;
+	m_low1PercentFPS = TheGlobalData->m_framesPerSecondLimit;
 #if defined(RTS_DEBUG)
 	m_timerAtCumuFPSStart = 0;
 #endif
@@ -1012,11 +1013,12 @@ const UnsignedInt START_CUMU_FRAME = LOGICFRAMES_PER_SECOND / 2;	// skip first h
 
 void W3DDisplay::updateAverageFPS()
 {
-	constexpr const Int FPS_HISTORY_SIZE = 30;
-
-	static Int64 lastUpdateTime64 = 0;
-	static Int historyOffset = 0;
+	constexpr const Int FPS_HISTORY_SIZE = 1000;
 	static Real fpsHistory[FPS_HISTORY_SIZE] = {0};
+	static Real durationHistory[FPS_HISTORY_SIZE] = {0};
+	static Int historyOffset = 0;
+	static Int historyCount = 0;
+	static Int64 lastUpdateTime64 = 0;
 
 	const Int64 freq64 = getPerformanceCounterFrequency();
 	const Int64 time64 = getPerformanceCounter();
@@ -1028,21 +1030,73 @@ void W3DDisplay::updateAverageFPS()
 	}
 #endif
 
+	if (lastUpdateTime64 == 0)
+	{
+		lastUpdateTime64 = time64;
+		return;
+	}
+
 	const Int64 timeDiff = time64 - lastUpdateTime64;
 
 	// convert elapsed time to seconds
 	Real elapsedSeconds = (Real)timeDiff/(Real)freq64;
 
 	// append new sample to fps history.
-	if (historyOffset >= FPS_HISTORY_SIZE)
-		historyOffset = 0;
+	if (elapsedSeconds > 0)
+	{
+		m_currentFPS = 1.0f/elapsedSeconds;
+		fpsHistory[historyOffset] = m_currentFPS;
+		durationHistory[historyOffset] = elapsedSeconds;
+		historyOffset = (historyOffset + 1) % FPS_HISTORY_SIZE;
+		if (historyCount < FPS_HISTORY_SIZE) historyCount++;
+	}
 
-	m_currentFPS = 1.0f/elapsedSeconds;
-	fpsHistory[historyOffset++] = m_currentFPS;
+	// determine average frame rate over the last 0.5 seconds and 1% low over 3.0 seconds.
+	if (historyCount > 0)
+	{
+		Real timeSum = 0;
+		Real fpsSum = 0;
+		Int avgSamples = 0;
+		Int lowSamples = 0;
+		Bool avgDone = FALSE;
 
-	// determine average frame rate over our past history.
-	const Real sum = std::accumulate(fpsHistory, fpsHistory + FPS_HISTORY_SIZE, 0.0f);
-	m_averageFPS = sum / FPS_HISTORY_SIZE;
+		for (Int i = 0; i < historyCount; ++i)
+		{
+			Int idx = (historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
+			timeSum += durationHistory[idx];
+			
+			lowSamples++;
+			
+			if (!avgDone)
+			{
+				fpsSum += fpsHistory[idx];
+				avgSamples++;
+				if (timeSum >= 0.5f) avgDone = TRUE;
+			}
+			
+			if (timeSum >= 3.0f) break;
+		}
+
+		m_averageFPS = avgSamples > 0 ? fpsSum / (Real)avgSamples : m_currentFPS;
+
+		// TheSuperHackers @feature One percent low FPS calculation (last 3.0 seconds)
+		// Throttle sorting to 1000ms intervals to match HUD refresh and save CPU
+		static UnsignedInt lastLowUpdate = 0;
+		UnsignedInt now = timeGetTime();
+		if (now - lastLowUpdate >= 1000)
+		{
+			lastLowUpdate = now;
+			static Real sortBuffer[FPS_HISTORY_SIZE];
+			for (Int i = 0; i < lowSamples; ++i)
+			{
+				Int idx = (historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
+				sortBuffer[i] = fpsHistory[idx];
+			}
+			const Int lowCount = std::max(lowSamples / 100, 1);
+			std::nth_element(sortBuffer, sortBuffer + lowCount, sortBuffer + lowSamples);
+			m_low1PercentFPS = std::accumulate(sortBuffer, sortBuffer + lowCount, 0.0f) / (Real)lowCount;
+		}
+	}
 
 	lastUpdateTime64 = time64;
 }
@@ -1768,6 +1822,11 @@ void W3DDisplay::calculateTerrainLOD()
 Real W3DDisplay::getAverageFPS()
 {
 	return m_averageFPS;
+}
+
+Real W3DDisplay::getLow1PercentFPS()
+{
+	return m_low1PercentFPS;
 }
 
 Real W3DDisplay::getCurrentFPS()

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -1022,42 +1022,54 @@ const UnsignedInt START_CUMU_FRAME = LOGICFRAMES_PER_SECOND / 2;	// skip first h
 
 void W3DDisplay::addFpsSample(Real elapsedSeconds)
 {
-	if (elapsedSeconds <= 0.0f) return;
+	if (elapsedSeconds <= 0.0f)
+	{
+		return;
+	}
 
 	m_currentFPS = 1.0f / elapsedSeconds;
 	m_fpsHistory[m_historyOffset] = m_currentFPS;
 	m_durationHistory[m_historyOffset] = elapsedSeconds;
 
 	m_historyOffset = (m_historyOffset + 1) % FPS_HISTORY_SIZE;
-	if (m_historyCount < FPS_HISTORY_SIZE) m_historyCount++;
+	if (m_historyCount < FPS_HISTORY_SIZE)
+	{
+		m_historyCount++;
+	}
 }
 
 Real W3DDisplay::calculateAverageFPS(Real windowSeconds)
 {
-	if (m_historyCount == 0) return m_currentFPS;
+	if (m_historyCount == 0)
+	{
+		return m_currentFPS;
+	}
 
 	Real timeSum = 0;
-	Real fpsSum = 0;
 	Int samples = 0;
 
 	for (Int i = 0; i < m_historyCount; ++i)
 	{
 		Int idx = (m_historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
 		timeSum += m_durationHistory[idx];
-		fpsSum += m_fpsHistory[idx];
 		samples++;
 
-		if (timeSum >= windowSeconds) break;
+		if (timeSum >= windowSeconds)
+		{
+			break;
+		}
 	}
 
-	return (samples > 0) ? (fpsSum / (Real)samples) : m_currentFPS;
+	return (timeSum > 0) ? ((Real)samples / timeSum) : m_currentFPS;
 }
 
 Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 {
-	if (m_historyCount == 0) return m_currentFPS;
+	if (m_historyCount == 0)
+	{
+		return m_currentFPS;
+	}
 
-	static Real sortBuffer[FPS_HISTORY_SIZE];
 	Real timeSum = 0;
 	Int sampleCount = 0;
 	Int i;
@@ -1066,19 +1078,28 @@ Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 	{
 		Int idx = (m_historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
 		timeSum += m_durationHistory[idx];
-		sortBuffer[sampleCount++] = m_fpsHistory[idx];
+		m_sortBuffer[sampleCount++] = m_fpsHistory[idx];
 
-		if (timeSum >= windowSeconds) break;
+		if (timeSum >= windowSeconds)
+		{
+			break;
+		}
 	}
 
-	if (sampleCount == 0) return m_currentFPS;
+	if (sampleCount == 0)
+	{
+		return m_currentFPS;
+	}
 
 	const Int bottomSampleCount = std::max((sampleCount + 99) / 100, 1);
 
-	std::nth_element(sortBuffer, sortBuffer + bottomSampleCount, sortBuffer + sampleCount);
+	std::nth_element(m_sortBuffer, m_sortBuffer + bottomSampleCount, m_sortBuffer + sampleCount);
 
 	Real lowSum = 0;
-	for (i = 0; i < bottomSampleCount; ++i) lowSum += sortBuffer[i];
+	for (i = 0; i < bottomSampleCount; ++i)
+	{
+		lowSum += m_sortBuffer[i];
+	}
 
 	return lowSum / (Real)bottomSampleCount;
 }
@@ -1089,7 +1110,10 @@ void W3DDisplay::updatePerformanceMetrics()
 	const Int64 time64 = getPerformanceCounter();
 
 #if defined(RTS_DEBUG)
-	if (TheGameLogic->getFrame() == START_CUMU_FRAME) m_timerAtCumuFPSStart = time64;
+	if (TheGameLogic->getFrame() == START_CUMU_FRAME)
+	{
+		m_timerAtCumuFPSStart = time64;
+	}
 #endif
 
 	if (m_lastUpdateTime64 == 0)

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -1048,7 +1048,10 @@ void W3DDisplay::updateAverageFPS()
 		fpsHistory[historyOffset] = m_currentFPS;
 		durationHistory[historyOffset] = elapsedSeconds;
 		historyOffset = (historyOffset + 1) % FPS_HISTORY_SIZE;
-		if (historyCount < FPS_HISTORY_SIZE) historyCount++;
+		if (historyCount < FPS_HISTORY_SIZE)
+		{
+			historyCount++;
+		}
 	}
 
 	// determine average frame rate over the last 0.5 seconds and 1% low over 3.0 seconds.
@@ -1071,10 +1074,16 @@ void W3DDisplay::updateAverageFPS()
 			{
 				fpsSum += fpsHistory[idx];
 				avgSamples++;
-				if (timeSum >= 0.5f) avgDone = TRUE;
+				if (timeSum >= 0.5f)
+				{
+					avgDone = TRUE;
+				}
 			}
 			
-			if (timeSum >= 3.0f) break;
+			if (timeSum >= 3.0f)
+			{
+				break;
+			}
 		}
 
 		m_averageFPS = avgSamples > 0 ? fpsSum / (Real)avgSamples : m_currentFPS;

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -1039,7 +1039,7 @@ Real W3DDisplay::calculateAverageFPS(Real windowSeconds)
 {
 	UnsignedInt unitsSum = 0;
 	Int samples = 0;
-	const UnsignedInt windowUnits = (UnsignedInt)(windowSeconds * 62500.0f);
+	const UnsignedInt windowUnits = (UnsignedInt)(windowSeconds * QuantizedUnsignedShort::TICKS_PER_SECOND);
 
 	for (Int i = 0; i < m_historyCount; ++i)
 	{
@@ -1053,14 +1053,14 @@ Real W3DDisplay::calculateAverageFPS(Real windowSeconds)
 		}
 	}
 
-	return (unitsSum > 0) ? ((Real)samples * 62500.0f / (Real)unitsSum) : m_currentFPS;
+	return (unitsSum > 0) ? ((Real)samples * QuantizedUnsignedShort::TICKS_PER_SECOND / (Real)unitsSum) : m_currentFPS;
 }
 
 Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 {
 	UnsignedInt unitsSum = 0;
 	Int sampleCount = 0;
-	const UnsignedInt windowUnits = (UnsignedInt)(windowSeconds * 62500.0f);
+	const UnsignedInt windowUnits = (UnsignedInt)(windowSeconds * QuantizedUnsignedShort::TICKS_PER_SECOND);
 	QuantizedUnsignedShort sortBuffer[FPS_HISTORY_SIZE];
 
 	Int i;
@@ -1091,7 +1091,7 @@ Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 		durationUnitsSum += sortBuffer[i];
 	}
 
-	return (durationUnitsSum > 0) ? ((Real)bottomSampleCount * 62500.0f / (Real)durationUnitsSum) : m_currentFPS;
+	return (durationUnitsSum > 0) ? ((Real)bottomSampleCount * QuantizedUnsignedShort::TICKS_PER_SECOND / (Real)durationUnitsSum) : m_currentFPS;
 }
 
 void W3DDisplay::updatePerformanceMetrics()

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -1091,7 +1091,7 @@ Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 		return m_currentFPS;
 	}
 
-	const Int bottomSampleCount = std::max((sampleCount + 99) / 100, 1);
+	const Int bottomSampleCount = std::max((sampleCount + 50) / 100, 1);
 
 	std::nth_element(m_sortBuffer, m_sortBuffer + bottomSampleCount, m_sortBuffer + sampleCount);
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -412,6 +412,15 @@ W3DDisplay::W3DDisplay()
 	m_batchGrayscale = FALSE;
 	m_batchNeedsInit = FALSE;
 
+	m_historyOffset = 0;
+	m_historyCount = 0;
+	m_lastUpdateTime64 = 0;
+	for (Int h = 0; h < FPS_HISTORY_SIZE; ++h)
+	{
+		m_fpsHistory[h] = 0.0f;
+		m_durationHistory[h] = 0.0f;
+	}
+
 #ifdef PROFILER_ENABLED
 	m_profilerFrameCapture = NEW W3DProfilerFrameCapture();
 #endif
@@ -1011,103 +1020,98 @@ void W3DDisplay::reset()
 
 const UnsignedInt START_CUMU_FRAME = LOGICFRAMES_PER_SECOND / 2;	// skip first half-sec
 
-void W3DDisplay::updateAverageFPS()
+void W3DDisplay::addFpsSample(Real elapsedSeconds)
 {
-	constexpr const Int FPS_HISTORY_SIZE = 1000;
-	static Real fpsHistory[FPS_HISTORY_SIZE] = {0};
-	static Real durationHistory[FPS_HISTORY_SIZE] = {0};
-	static Int historyOffset = 0;
-	static Int historyCount = 0;
-	static Int64 lastUpdateTime64 = 0;
+	if (elapsedSeconds <= 0.0f) return;
 
+	m_currentFPS = 1.0f / elapsedSeconds;
+	m_fpsHistory[m_historyOffset] = m_currentFPS;
+	m_durationHistory[m_historyOffset] = elapsedSeconds;
+
+	m_historyOffset = (m_historyOffset + 1) % FPS_HISTORY_SIZE;
+	if (m_historyCount < FPS_HISTORY_SIZE) m_historyCount++;
+}
+
+Real W3DDisplay::calculateAverageFPS(Real windowSeconds)
+{
+	if (m_historyCount == 0) return m_currentFPS;
+
+	Real timeSum = 0;
+	Real fpsSum = 0;
+	Int samples = 0;
+
+	for (Int i = 0; i < m_historyCount; ++i)
+	{
+		Int idx = (m_historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
+		timeSum += m_durationHistory[idx];
+		fpsSum += m_fpsHistory[idx];
+		samples++;
+
+		if (timeSum >= windowSeconds) break;
+	}
+
+	return (samples > 0) ? (fpsSum / (Real)samples) : m_currentFPS;
+}
+
+Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
+{
+	if (m_historyCount == 0) return m_currentFPS;
+
+	static Real sortBuffer[FPS_HISTORY_SIZE];
+	Real timeSum = 0;
+	Int sampleCount = 0;
+
+	for (Int i = 0; i < m_historyCount; ++i)
+	{
+		Int idx = (m_historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
+		timeSum += m_durationHistory[idx];
+		sortBuffer[sampleCount++] = m_fpsHistory[idx];
+
+		if (timeSum >= windowSeconds) break;
+	}
+
+	if (sampleCount == 0) return m_currentFPS;
+
+	const Int bottomSampleCount = std::max((sampleCount + 99) / 100, 1);
+
+	std::nth_element(sortBuffer, sortBuffer + bottomSampleCount, sortBuffer + sampleCount);
+
+	Real lowSum = 0;
+	for (Int i = 0; i < bottomSampleCount; ++i) lowSum += sortBuffer[i];
+
+	return lowSum / (Real)bottomSampleCount;
+}
+
+void W3DDisplay::updatePerformanceMetrics()
+{
 	const Int64 freq64 = getPerformanceCounterFrequency();
 	const Int64 time64 = getPerformanceCounter();
 
 #if defined(RTS_DEBUG)
-	if (TheGameLogic->getFrame() == START_CUMU_FRAME)
-	{
-		m_timerAtCumuFPSStart = time64;
-	}
+	if (TheGameLogic->getFrame() == START_CUMU_FRAME) m_timerAtCumuFPSStart = time64;
 #endif
 
-	if (lastUpdateTime64 == 0)
+	if (m_lastUpdateTime64 == 0)
 	{
-		lastUpdateTime64 = time64;
+		m_lastUpdateTime64 = time64;
 		return;
 	}
 
-	const Int64 timeDiff = time64 - lastUpdateTime64;
+	const Int64 timeDiff = time64 - m_lastUpdateTime64;
+	Real elapsedSeconds = (Real)timeDiff / (Real)freq64;
 
-	// convert elapsed time to seconds
-	Real elapsedSeconds = (Real)timeDiff/(Real)freq64;
+	addFpsSample(elapsedSeconds);
+	m_averageFPS = calculateAverageFPS(0.5f);
 
-	// append new sample to fps history.
-	if (elapsedSeconds > 0)
+	static UnsignedInt lastLowUpdate = 0;
+	UnsignedInt now = timeGetTime();
+	if (now - lastLowUpdate >= 1000)
 	{
-		m_currentFPS = 1.0f/elapsedSeconds;
-		fpsHistory[historyOffset] = m_currentFPS;
-		durationHistory[historyOffset] = elapsedSeconds;
-		historyOffset = (historyOffset + 1) % FPS_HISTORY_SIZE;
-		if (historyCount < FPS_HISTORY_SIZE)
-		{
-			historyCount++;
-		}
+		lastLowUpdate = now;
+		m_low1PercentFPS = calculateLow1PercentFPS(3.0f);
 	}
 
-	// determine average frame rate over the last 0.5 seconds and 1% low over 3.0 seconds.
-	if (historyCount > 0)
-	{
-		Real timeSum = 0;
-		Real fpsSum = 0;
-		Int avgSamples = 0;
-		Int lowSamples = 0;
-		Bool avgDone = FALSE;
-
-		for (Int i = 0; i < historyCount; ++i)
-		{
-			Int idx = (historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
-			timeSum += durationHistory[idx];
-			
-			lowSamples++;
-			
-			if (!avgDone)
-			{
-				fpsSum += fpsHistory[idx];
-				avgSamples++;
-				if (timeSum >= 0.5f)
-				{
-					avgDone = TRUE;
-				}
-			}
-			
-			if (timeSum >= 3.0f)
-			{
-				break;
-			}
-		}
-
-		m_averageFPS = avgSamples > 0 ? fpsSum / (Real)avgSamples : m_currentFPS;
-
-		// TheSuperHackers @feature One percent low FPS calculation (last 3.0 seconds)
-		// Throttle sorting to 1000ms intervals to match HUD refresh and save CPU
-		static UnsignedInt lastLowUpdate = 0;
-		UnsignedInt now = timeGetTime();
-		if (now - lastLowUpdate >= 1000)
-		{
-			lastLowUpdate = now;
-			static Real sortBuffer[FPS_HISTORY_SIZE];
-			for (Int i = 0; i < lowSamples; ++i)
-			{
-				Int idx = (historyOffset - 1 - i + FPS_HISTORY_SIZE) % FPS_HISTORY_SIZE;
-				sortBuffer[i] = fpsHistory[idx];
-			}
-			const Int lowCount = std::max(lowSamples / 100, 1);
-			std::nth_element(sortBuffer, sortBuffer + lowCount, sortBuffer + lowSamples);
-			m_low1PercentFPS = std::accumulate(sortBuffer, sortBuffer + lowCount, 0.0f) / (Real)lowCount;
-		}
-	}
-
-	lastUpdateTime64 = time64;
+	m_lastUpdateTime64 = time64;
 }
 
 #if defined(RTS_DEBUG)	//debug hack to view object under mouse stats
@@ -1875,7 +1879,7 @@ void W3DDisplay::draw()
 	// TheSuperHackers @feature bobtista 10/07/2026 Show messages for screenshots finished by the screenshot thread.
 	W3D_UpdateScreenshotMessages();
 
-	updateAverageFPS();
+	updatePerformanceMetrics();
 	if (TheGlobalData->m_enableDynamicLOD && TheGameLogic->getShowDynamicLOD())
 	{
 		DynamicGameLODLevel lod=TheGameLODManager->findDynamicLODLevel(m_averageFPS);

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -419,7 +419,7 @@ W3DDisplay::W3DDisplay()
 	m_lastUpdateTime64 = 0;
 	m_lastLow1PercentUpdateMs = 0;
 	m_currentFPS = 30.0f;
-	std::fill(m_durationHistory, m_durationHistory + FPS_HISTORY_SIZE, (UnsignedShort)2083);
+	std::fill(m_durationHistory, m_durationHistory + FPS_HISTORY_SIZE, QuantizedUnsignedShort());
 
 #ifdef PROFILER_ENABLED
 	m_profilerFrameCapture = NEW W3DProfilerFrameCapture();
@@ -1023,11 +1023,10 @@ const UnsignedInt START_CUMU_FRAME = LOGICFRAMES_PER_SECOND / 2;	// skip first h
 
 void W3DDisplay::addFpsSample(Real elapsedSeconds)
 {
-	Int64 ticks = (Int64)(elapsedSeconds * 62500.0f + 0.5f);
-	UnsignedShort quantized = (ticks >= 65535) ? 65535 : (ticks <= 0 ? 1 : (UnsignedShort)ticks);
+	QuantizedUnsignedShort duration = QuantizedUnsignedShort::fromSeconds(elapsedSeconds);
 
-	m_currentFPS = 62500.0f / (Real)quantized;
-	m_durationHistory[m_historyOffset] = quantized;
+	m_currentFPS = duration.toFPS();
+	m_durationHistory[m_historyOffset] = duration;
 
 	m_historyOffset = (m_historyOffset + 1) & (FPS_HISTORY_SIZE - 1);
 	if (m_historyCount < FPS_HISTORY_SIZE)
@@ -1062,7 +1061,7 @@ Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 	UnsignedInt unitsSum = 0;
 	Int sampleCount = 0;
 	const UnsignedInt windowUnits = (UnsignedInt)(windowSeconds * 62500.0f);
-	UnsignedShort sortBuffer[FPS_HISTORY_SIZE];
+	QuantizedUnsignedShort sortBuffer[FPS_HISTORY_SIZE];
 
 	Int i;
 	for (i = 0; i < m_historyCount; ++i)
@@ -1084,7 +1083,7 @@ Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 
 	const Int bottomSampleCount = std::max((sampleCount + 50) / 100, 1);
 
-	std::nth_element(sortBuffer, sortBuffer + bottomSampleCount, sortBuffer + sampleCount, std::greater<UnsignedShort>());
+	std::nth_element(sortBuffer, sortBuffer + bottomSampleCount, sortBuffer + sampleCount, std::greater<QuantizedUnsignedShort>());
 
 	UnsignedInt durationUnitsSum = 0;
 	for (i = 0; i < bottomSampleCount; ++i)

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -35,6 +35,8 @@ static void drawFramerateBar();
 
 // SYSTEM INCLUDES ////////////////////////////////////////////////////////////
 #include <numeric>
+#include <algorithm>
+#include <functional>
 #include <stdlib.h>
 #include <windows.h>
 #include <io.h>
@@ -415,12 +417,9 @@ W3DDisplay::W3DDisplay()
 	m_historyOffset = 0;
 	m_historyCount = 1;
 	m_lastUpdateTime64 = 0;
+	m_lastLow1PercentUpdateMs = 0;
 	m_currentFPS = 30.0f;
-	for (Int h = 0; h < FPS_HISTORY_SIZE; ++h)
-	{
-		m_fpsHistory[h] = 30.0f;
-		m_durationHistory[h] = 1.0f / 30.0f;
-	}
+	std::fill(std::begin(m_durationHistory), std::end(m_durationHistory), (UnsignedShort)2083);
 
 #ifdef PROFILER_ENABLED
 	m_profilerFrameCapture = NEW W3DProfilerFrameCapture();
@@ -1024,14 +1023,11 @@ const UnsignedInt START_CUMU_FRAME = LOGICFRAMES_PER_SECOND / 2;	// skip first h
 
 void W3DDisplay::addFpsSample(Real elapsedSeconds)
 {
-	if (elapsedSeconds < 0.0001f)
-	{
-		elapsedSeconds = 0.0001f;
-	}
+	Int64 ticks = (Int64)(elapsedSeconds * 62500.0f + 0.5f);
+	UnsignedShort quantized = (ticks >= 65535) ? 65535 : (ticks <= 0 ? 1 : (UnsignedShort)ticks);
 
-	m_currentFPS = 1.0f / elapsedSeconds;
-	m_fpsHistory[m_historyOffset] = m_currentFPS;
-	m_durationHistory[m_historyOffset] = elapsedSeconds;
+	m_currentFPS = 62500.0f / (Real)quantized;
+	m_durationHistory[m_historyOffset] = quantized;
 
 	m_historyOffset = (m_historyOffset + 1) & (FPS_HISTORY_SIZE - 1);
 	if (m_historyCount < FPS_HISTORY_SIZE)
@@ -1042,44 +1038,42 @@ void W3DDisplay::addFpsSample(Real elapsedSeconds)
 
 Real W3DDisplay::calculateAverageFPS(Real windowSeconds)
 {
-	Real timeSum = 0;
+	UnsignedInt unitsSum = 0;
 	Int samples = 0;
+	const UnsignedInt windowUnits = (UnsignedInt)(windowSeconds * 62500.0f);
 
-	Int idx = m_historyOffset - 1;
 	for (Int i = 0; i < m_historyCount; ++i)
 	{
-		if (idx < 0) idx += FPS_HISTORY_SIZE;
-		timeSum += m_durationHistory[idx];
+		Int idx = (m_historyOffset - 1 - i) & (FPS_HISTORY_SIZE - 1);
+		unitsSum += m_durationHistory[idx];
 		samples++;
 
-		if (timeSum >= windowSeconds)
+		if (unitsSum >= windowUnits)
 		{
 			break;
 		}
-		--idx;
 	}
 
-	return (timeSum > 0) ? ((Real)samples / timeSum) : m_currentFPS;
+	return (unitsSum > 0) ? ((Real)samples * 62500.0f / (Real)unitsSum) : m_currentFPS;
 }
 
 Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 {
-	Real timeSum = 0;
+	UnsignedInt unitsSum = 0;
 	Int sampleCount = 0;
-	Int i;
+	const UnsignedInt windowUnits = (UnsignedInt)(windowSeconds * 62500.0f);
+	UnsignedShort sortBuffer[FPS_HISTORY_SIZE];
 
-	Int idx = m_historyOffset - 1;
-	for (i = 0; i < m_historyCount; ++i)
+	for (Int i = 0; i < m_historyCount; ++i)
 	{
-		if (idx < 0) idx += FPS_HISTORY_SIZE;
-		timeSum += m_durationHistory[idx];
-		m_sortBuffer[sampleCount++] = m_fpsHistory[idx];
+		Int idx = (m_historyOffset - 1 - i) & (FPS_HISTORY_SIZE - 1);
+		unitsSum += m_durationHistory[idx];
+		sortBuffer[sampleCount++] = m_durationHistory[idx];
 
-		if (timeSum >= windowSeconds)
+		if (unitsSum >= windowUnits)
 		{
 			break;
 		}
-		--idx;
 	}
 
 	if (sampleCount == 0)
@@ -1089,15 +1083,15 @@ Real W3DDisplay::calculateLow1PercentFPS(Real windowSeconds)
 
 	const Int bottomSampleCount = std::max((sampleCount + 50) / 100, 1);
 
-	std::nth_element(m_sortBuffer, m_sortBuffer + bottomSampleCount, m_sortBuffer + sampleCount);
+	std::nth_element(sortBuffer, sortBuffer + bottomSampleCount, sortBuffer + sampleCount, std::greater<UnsignedShort>());
 
-	Real lowSum = 0;
-	for (i = 0; i < bottomSampleCount; ++i)
+	UnsignedInt durationUnitsSum = 0;
+	for (Int i = 0; i < bottomSampleCount; ++i)
 	{
-		lowSum += m_sortBuffer[i];
+		durationUnitsSum += sortBuffer[i];
 	}
 
-	return lowSum / (Real)bottomSampleCount;
+	return (durationUnitsSum > 0) ? ((Real)bottomSampleCount * 62500.0f / (Real)durationUnitsSum) : m_currentFPS;
 }
 
 void W3DDisplay::updatePerformanceMetrics()
@@ -1117,14 +1111,6 @@ void W3DDisplay::updatePerformanceMetrics()
 
 	addFpsSample(elapsedSeconds);
 	m_averageFPS = calculateAverageFPS(1.0f); // 1.0s window for smooth Dynamic LOD tracking and UI matching
-
-	static UnsignedInt lastLowUpdate = 0;
-	UnsignedInt now = timeGetTime();
-	if (now - lastLowUpdate >= 100) // update low 1% metrics at 100ms intervals instead of 1000ms since it is now extremely cheap
-	{
-		lastLowUpdate = now;
-		m_low1PercentFPS = calculateLow1PercentFPS(3.0f);
-	}
 
 	m_lastUpdateTime64 = time64;
 }
@@ -1854,6 +1840,12 @@ Real W3DDisplay::getAverageFPS()
 
 Real W3DDisplay::getLow1PercentFPS()
 {
+	UnsignedInt now = timeGetTime();
+	if (now - m_lastLow1PercentUpdateMs >= 1000)
+	{
+		m_low1PercentFPS = calculateLow1PercentFPS(3.0f);
+		m_lastLow1PercentUpdateMs = now;
+	}
 	return m_low1PercentFPS;
 }
 

--- a/GeneralsMD/Code/Tools/GUIEdit/Include/GUIEditDisplay.h
+++ b/GeneralsMD/Code/Tools/GUIEdit/Include/GUIEditDisplay.h
@@ -124,6 +124,7 @@ public:
 #endif
 
 	virtual Real getAverageFPS() override { return 0; }
+	virtual Real getLow1PercentFPS() override { return 0; }
 	virtual Real getCurrentFPS() override { return 0; }
 	virtual Int getLastFrameDrawCalls() override { return 0; }
 


### PR DESCRIPTION
This PR adds a 1% low FPS metric to the existing FPS counter HUD, displayed in parentheses next to the average FPS. The 1% low is a standard performance metric used to surface frame time spikes that the average FPS hides. Inspired by #1942.

Add 1% low FPS display to HUD counter
Add m_renderFpsLowString and supporting UI members
Add RenderFpsLowColor configuration to InGameUI INI
Increase history to 4,096 frames for bitwise indexing
Implement rolling 1.0s window for average FPS
Implement rolling 3.0s window for 1% lows

The following screenshot from AOD Cobalt Rush shows the 1% low FPS overlay compared to CapFrameX (an external benchmarking tool, centered right), demonstrating the value of surfacing this metric separately from the average.

<img width="634" height="321" alt="lowfps" src="https://github.com/user-attachments/assets/d37da7db-9a6e-448f-8201-e088594c61c3" />

This change was generated with AI assistance. All generated code has been reviewed, tested, and verified for correctness. The implementation went through multiple iterations, including fundamental changes to the underlying approach, as well as passes to apply simplifications, fix inconsistencies, and optimize performance. Both Generals and GeneralsMD implementations are included in this PR with identical code.