### PR TITLE
fix(aiupdate): Fix XFER and CRC of AIUpdateInterface::m_guardTargetType

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -4808,12 +4808,21 @@ void AIUpdateInterface::crc( Xfer *x )
 // ------------------------------------------------------------------------------------------------
 /** Xfer method
 	* Version Info:
-	* 1: Initial version */
+	* 1: Initial version, contains specific surrender and demoralize variables
+	* 2: Added m_demoralizedFramesLeft (behind ALLOW_DEMORALIZE)
+	* 3: Removed lastFrameMoved and repulsorCountdown; removed surrender and demoralize variables
+	* 4: Read m_curLocomotorSet from ini
+	* 5: TheSuperHackers @fix Fixed out-of-bounds xfer of m_guardTargetType
+	*/
 // ------------------------------------------------------------------------------------------------
 void AIUpdateInterface::xfer( Xfer *xfer )
 {
   // version
-  const XferVersion currentVersion = 4;
+#if RETAIL_COMPATIBLE_CRC || RETAIL_COMPATIBLE_XFER_SAVE
+	const XferVersion currentVersion = 4;
+#else
+	const XferVersion currentVersion = 5;
+#endif
   XferVersion version = currentVersion;
   xfer->xferVersion( &version, currentVersion );
 
@@ -4830,8 +4839,22 @@ void AIUpdateInterface::xfer( Xfer *xfer )
 	xfer->xferObjectID(&m_currentVictimID);
 	xfer->xferReal(&m_desiredSpeed);
 	xfer->xferUser(&m_lastCommandSource, sizeof(m_lastCommandSource));
-	xfer->xferUser(&m_guardTargetType[0], sizeof(m_guardTargetType));
-	xfer->xferUser(&m_guardTargetType[1], sizeof(m_guardTargetType));
+
+	if (version < 5)
+	{
+		// TheSuperHackers @fix The original code effectively accessed m_guardTargetType[0], [1], [1], [2].
+		// The last one is out-of-bounds and points to m_locationToGuard.
+		static_assert(sizeof(m_locationToGuard) >= sizeof(m_guardTargetType[2]), "Xfer size must not exceed variable size");
+
+		xfer->xferUser(&m_guardTargetType[0], sizeof(m_guardTargetType));
+		xfer->xferUser(&m_guardTargetType[1], sizeof(m_guardTargetType[1]));
+		xfer->xferUser(&m_locationToGuard, sizeof(m_guardTargetType[2]));
+	}
+	else
+	{
+		xfer->xferUser(m_guardTargetType, sizeof(m_guardTargetType));
+	}
+
 	xfer->xferCoord3D(&m_locationToGuard);
 
 	xfer->xferObjectID(&m_objectToGuard);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -5056,12 +5056,21 @@ void AIUpdateInterface::crc( Xfer *x )
 // ------------------------------------------------------------------------------------------------
 /** Xfer method
 	* Version Info:
-	* 1: Initial version */
+	* 1: Initial version, contains specific surrender and demoralize variables
+	* 2: Added m_demoralizedFramesLeft (behind ALLOW_DEMORALIZE)
+	* 3: Removed lastFrameMoved and repulsorCountdown; removed surrender and demoralize variables
+	* 4: Read m_curLocomotorSet from ini
+	* 5: Fixed out-of-bounds xfer of m_guardTargetType
+	*/
 // ------------------------------------------------------------------------------------------------
 void AIUpdateInterface::xfer( Xfer *xfer )
 {
   // version
-  const XferVersion currentVersion = 4;
+#if RETAIL_COMPATIBLE_CRC || RETAIL_COMPATIBLE_XFER_SAVE
+	const XferVersion currentVersion = 4;
+#else
+	const XferVersion currentVersion = 5;
+#endif
   XferVersion version = currentVersion;
   xfer->xferVersion( &version, currentVersion );
 
@@ -5080,16 +5089,23 @@ void AIUpdateInterface::xfer( Xfer *xfer )
 	xfer->xferUser(&m_lastCommandSource, sizeof(m_lastCommandSource));
 
 #if RETAIL_COMPATIBLE_CRC || RETAIL_COMPATIBLE_XFER_SAVE
-	// TheSuperHackers @fix The original code effectively accessed m_guardTargetType[0], [1], [1], [2].
-	// The last one is out-of-bounds and points to m_locationToGuard.
-	static_assert(sizeof(m_locationToGuard) >= sizeof(m_guardTargetType[2]), "Type sizes must be right for correct xfer");
-
-	xfer->xferUser(&m_guardTargetType[0], sizeof(m_guardTargetType));
-	xfer->xferUser(&m_guardTargetType[1], sizeof(m_guardTargetType[1]));
-	xfer->xferUser(&m_locationToGuard, sizeof(m_guardTargetType[2]));
+	if (TRUE)
 #else
-	xfer->xferUser(m_guardTargetType, sizeof(m_guardTargetType));
+	if (version < 5)
 #endif
+	{
+		// TheSuperHackers @fix The original code effectively accessed m_guardTargetType[0], [1], [1], [2].
+		// The last one is out-of-bounds and points to m_locationToGuard.
+		static_assert(sizeof(m_locationToGuard) >= sizeof(m_guardTargetType[2]), "Type sizes must be right for correct xfer");
+
+		xfer->xferUser(&m_guardTargetType[0], sizeof(m_guardTargetType));
+		xfer->xferUser(&m_guardTargetType[1], sizeof(m_guardTargetType[1]));
+		xfer->xferUser(&m_locationToGuard, sizeof(m_guardTargetType[2]));
+	}
+	else
+	{
+		xfer->xferUser(m_guardTargetType, sizeof(m_guardTargetType));
+	}
 
 	xfer->xferCoord3D(&m_locationToGuard);
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -5060,7 +5060,7 @@ void AIUpdateInterface::crc( Xfer *x )
 	* 2: Added m_demoralizedFramesLeft (behind ALLOW_DEMORALIZE)
 	* 3: Removed lastFrameMoved and repulsorCountdown; removed surrender and demoralize variables
 	* 4: Read m_curLocomotorSet from ini
-	* 5: Fixed out-of-bounds xfer of m_guardTargetType
+	* 5: TheSuperHackers @fix Fixed out-of-bounds xfer of m_guardTargetType
 	*/
 // ------------------------------------------------------------------------------------------------
 void AIUpdateInterface::xfer( Xfer *xfer )
@@ -5088,15 +5088,11 @@ void AIUpdateInterface::xfer( Xfer *xfer )
 	xfer->xferReal(&m_desiredSpeed);
 	xfer->xferUser(&m_lastCommandSource, sizeof(m_lastCommandSource));
 
-#if RETAIL_COMPATIBLE_CRC || RETAIL_COMPATIBLE_XFER_SAVE
-	if (TRUE)
-#else
 	if (version < 5)
-#endif
 	{
 		// TheSuperHackers @fix The original code effectively accessed m_guardTargetType[0], [1], [1], [2].
 		// The last one is out-of-bounds and points to m_locationToGuard.
-		static_assert(sizeof(m_locationToGuard) >= sizeof(m_guardTargetType[2]), "Type sizes must be right for correct xfer");
+		static_assert(sizeof(m_locationToGuard) >= sizeof(m_guardTargetType[2]), "Xfer size must not exceed variable size");
 
 		xfer->xferUser(&m_guardTargetType[0], sizeof(m_guardTargetType));
 		xfer->xferUser(&m_guardTargetType[1], sizeof(m_guardTargetType[1]));

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -5078,8 +5078,19 @@ void AIUpdateInterface::xfer( Xfer *xfer )
 	xfer->xferObjectID(&m_currentVictimID);
 	xfer->xferReal(&m_desiredSpeed);
 	xfer->xferUser(&m_lastCommandSource, sizeof(m_lastCommandSource));
+
+#if RETAIL_COMPATIBLE_CRC || RETAIL_COMPATIBLE_XFER_SAVE
+	// TheSuperHackers @fix The original code effectively accessed m_guardTargetType[0], [1], [1], [2].
+	// The last one is out-of-bounds and points to m_locationToGuard.
+	static_assert(sizeof(m_locationToGuard) >= sizeof(m_guardTargetType[2]), "Type sizes must be right for correct xfer");
+
 	xfer->xferUser(&m_guardTargetType[0], sizeof(m_guardTargetType));
-	xfer->xferUser(&m_guardTargetType[1], sizeof(m_guardTargetType));
+	xfer->xferUser(&m_guardTargetType[1], sizeof(m_guardTargetType[1]));
+	xfer->xferUser(&m_locationToGuard, sizeof(m_guardTargetType[2]));
+#else
+	xfer->xferUser(m_guardTargetType, sizeof(m_guardTargetType));
+#endif
+
 	xfer->xferCoord3D(&m_locationToGuard);
 
 	xfer->xferObjectID(&m_objectToGuard);


### PR DESCRIPTION
* Similar to https://github.com/TheSuperHackers/GeneralsGameCode/pull/2575

<details>
<summary>Original EA code links</summary>

https://github.com/electronicarts/CnC_Generals_Zero_Hour/blob/0a05454d8574207440a5fb15241b98ad0b435590/Generals/Code/GameEngine/Include/GameLogic/Module/AIUpdate.h#L679-L680

https://github.com/electronicarts/CnC_Generals_Zero_Hour/blob/0a05454d8574207440a5fb15241b98ad0b435590/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp#L4760-L4761

https://github.com/electronicarts/CnC_Generals_Zero_Hour/blob/0a05454d8574207440a5fb15241b98ad0b435590/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/AIUpdate.h#L697-L698

https://github.com/electronicarts/CnC_Generals_Zero_Hour/blob/0a05454d8574207440a5fb15241b98ad0b435590/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp#L5039-L5040
</details>

https://github.com/TheSuperHackers/GeneralsGameCode/blob/ffac8f952391af2c9f2902cb1d3ce0ce90c2766a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/AIUpdate.h#L700-L701

https://github.com/TheSuperHackers/GeneralsGameCode/blob/ffac8f952391af2c9f2902cb1d3ce0ce90c2766a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp#L5081-L5082

The above code xfers `m_guardTargetType` indices [0], [1], [1], [2], which is out-of-bounds. This PR fixes that.

Edit: FWIW this equals true:
```cpp
static_assert(offsetof(AIUpdateInterface, m_guardTargetType) 
  + sizeof(m_guardTargetType) == offsetof(AIUpdateInterface, m_locationToGuard))
```

## TODO:
- [x] Replicate in Generals.