### PR TITLE
perf: eliminate AsciiString ref-count overhead in rendering, logic, and UI hot paths

### DIFF
--- a/Core/GameEngine/Include/GameClient/TerrainVisual.h
+++ b/Core/GameEngine/Include/GameClient/TerrainVisual.h
@@ -209,7 +209,7 @@ public:
 	virtual void reset() override;
 	virtual void update() override;
 
-	virtual Bool load( AsciiString filename );
+	virtual Bool load( const AsciiString& filename );
 
 	/// get color of texture on the terrain at location specified
 	virtual void getTerrainColorAt( Real x, Real y, RGBColor *pColor ) = 0;

--- a/Core/GameEngine/Source/GameClient/Terrain/TerrainVisual.cpp
+++ b/Core/GameEngine/Source/GameClient/Terrain/TerrainVisual.cpp
@@ -85,7 +85,7 @@ void TerrainVisual::update()
 //-------------------------------------------------------------------------------------------------
 /** device independent implementation for common terrain visual systems */
 //-------------------------------------------------------------------------------------------------
-Bool TerrainVisual::load( AsciiString filename )
+Bool TerrainVisual::load( const AsciiString& filename )
 {
 
 	// save the filename

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DTerrainVisual.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/W3DTerrainVisual.h
@@ -53,7 +53,7 @@ public:
 	virtual void reset() override;
 	virtual void update() override;
 
-	virtual Bool load( AsciiString filename ) override;
+	virtual Bool load( const AsciiString& filename ) override;
 
 	virtual void getTerrainColorAt( Real x, Real y, RGBColor *pColor ) override;
 

--- a/Core/GameEngineDevice/Include/W3DDevice/GameClient/WorldHeightMap.h
+++ b/Core/GameEngineDevice/Include/W3DDevice/GameClient/WorldHeightMap.h
@@ -289,7 +289,7 @@ public:  // tile and texture info.
 	/// UV mapping data for a cell to map into the alpha terrain texture.
 	void getAlphaUVData(Int xIndex, Int yIndex, float U[4], float V[4], UnsignedByte alpha[4], Bool *flip);
 	void getTerrainColorAt(Real x, Real y, RGBColor *pColor);
-	AsciiString getTerrainNameAt(Real x, Real y);
+	const AsciiString& getTerrainNameAt(Real x, Real y);
 	Bool isCliffMappedTexture(Int xIndex, Int yIndex);
 
 

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTerrainVisual.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/W3DTerrainVisual.cpp
@@ -511,7 +511,7 @@ void W3DTerrainVisual::updateSeismicSimulations()
 //-------------------------------------------------------------------------------------------------
 /** load method for W3D visual terrain */
 //-------------------------------------------------------------------------------------------------
-Bool W3DTerrainVisual::load( AsciiString filename )
+Bool W3DTerrainVisual::load( const AsciiString& filename )
 {
 
 #if 0
@@ -748,13 +748,13 @@ TerrainType *W3DTerrainVisual::getTerrainTile( Real x, Real y )
 #ifdef DO_SEISMIC_SIMULATIONS
 	if( m_clientHeightMap )
 	{
-		AsciiString tileName = m_clientHeightMap->getTerrainNameAt( x, y );
+		const AsciiString& tileName = m_clientHeightMap->getTerrainNameAt( x, y );
 		tile = TheTerrainTypes->findTerrain( tileName );
 	}
 #else
   if( m_logicHeightMap )
 	{
-		AsciiString tileName = m_logicHeightMap->getTerrainNameAt( x, y );
+		const AsciiString& tileName = m_logicHeightMap->getTerrainNameAt( x, y );
 		tile = TheTerrainTypes->findTerrain( tileName );
 	}
 #endif

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWaterTracks.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWaterTracks.cpp
@@ -957,7 +957,7 @@ void WaterTracksRenderSystem::saveTracks()
 	if (!TheTerrainLogic)
 		return;
 
-	AsciiString fileName=TheTerrainLogic->getSourceFilename();
+	const AsciiString& fileName=TheTerrainLogic->getSourceFilename();
 	char path[256];
 
 	strlcpy(path, fileName.str(), ARRAY_SIZE(path));
@@ -993,7 +993,7 @@ void WaterTracksRenderSystem::loadTracks()
 	if (!TheTerrainLogic)
 		return;
 
-	AsciiString fileName=TheTerrainLogic->getSourceFilename();
+	const AsciiString& fileName=TheTerrainLogic->getSourceFilename();
 	char path[256];
 
 	strlcpy(path, fileName.str(), ARRAY_SIZE(path));

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/WorldHeightMap.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/WorldHeightMap.cpp
@@ -2336,7 +2336,7 @@ void WorldHeightMap::getTerrainColorAt(Real x, Real y, RGBColor *pColor)
 	}
 }
 
-AsciiString WorldHeightMap::getTerrainNameAt(Real x, Real y)
+const AsciiString& WorldHeightMap::getTerrainNameAt(Real x, Real y)
 {
 	Int xIndex = REAL_TO_INT_FLOOR(x/MAP_XY_FACTOR);
 	Int yIndex = REAL_TO_INT_FLOOR(y/MAP_XY_FACTOR);

--- a/Generals/Code/GameEngine/Include/Common/MapReaderWriterInfo.h
+++ b/Generals/Code/GameEngine/Include/Common/MapReaderWriterInfo.h
@@ -86,7 +86,7 @@ protected:
 public:
 	CachedFileInputStream();
 	~CachedFileInputStream();
-	Bool open(AsciiString path);	///< Returns true if open succeeded.
+	Bool open(const AsciiString& path);	///< Returns true if open succeeded.
 	void close();  ///< Explict close.  Destructor closes if file is left open.
 	virtual Int read(void *pData, Int numBytes) override;
 	virtual UnsignedInt tell() override;
@@ -104,7 +104,7 @@ protected:
 public:
 	FileInputStream();
 	~FileInputStream();
-	Bool open(AsciiString path);	///< Returns true if open succeeded.
+	Bool open(const AsciiString& path);	///< Returns true if open succeeded.
 	void close();  ///< Explict close.  Destructor closes if file is left open.
 	virtual Int read(void *pData, Int numBytes);
 	virtual UnsignedInt tell();

--- a/Generals/Code/GameEngine/Include/Common/TerrainTypes.h
+++ b/Generals/Code/GameEngine/Include/Common/TerrainTypes.h
@@ -152,7 +152,7 @@ public:
 	// destructor prototype defined by memory pool glue
 
 	/// get the name for this terrain
-	AsciiString getName() { return m_name; }
+	const AsciiString& getName() { return m_name; }
 
 	/// get whether this terrain is blend edge terrain.
 	Bool isBlendEdge() { return m_blendEdgeTexture; }
@@ -164,19 +164,19 @@ public:
 	Bool getRestrictConstruction() { return m_restrictConstruction; }
 
 	/// get the texture file for this terrain
-	AsciiString getTexture() { return m_texture; }
+	const AsciiString& getTexture() { return m_texture; }
 
 	/// get next terrain in list, only for use by the terrain collection
 	TerrainType *friend_getNext() { return m_next; }
 
 	/// set the name for this terrain, for use by terrain collection only
-	void friend_setName( AsciiString name ) { m_name = name; }
+	void friend_setName( const AsciiString& name ) { m_name = name; }
 
 	/// set the next pointer for the terrain list, for use by terrain collection only
 	void friend_setNext( TerrainType *next ) { m_next = next; }
 
 	/// set the texture, for use by terrain collection only
-	void friend_setTexture( AsciiString texture ) { m_texture = texture; }
+	void friend_setTexture( const AsciiString& texture ) { m_texture = texture; }
 
 	/// set the class, for use by terrain collection only
 	void friend_setClass( TerrainClass terrainClass ) { m_class = terrainClass; }
@@ -219,8 +219,8 @@ public:
 	virtual void reset() override { }
 	virtual void update() override { }
 
-	TerrainType *findTerrain( AsciiString name );		///< find terrain by name
-	TerrainType *newTerrain( AsciiString name );			///< allocate a new terrain
+	TerrainType *findTerrain( const AsciiString& name );		///< find terrain by name
+	TerrainType *newTerrain( const AsciiString& name );			///< allocate a new terrain
 
 	/// get first terrain in list
 	TerrainType *firstTerrain() { return m_terrainList; }

--- a/Generals/Code/GameEngine/Include/Common/ThingTemplate.h
+++ b/Generals/Code/GameEngine/Include/Common/ThingTemplate.h
@@ -294,7 +294,7 @@ public:
 	}
 #endif
 
-	AsciiString getNthName(size_t i) const
+	const AsciiString& getNthName(size_t i) const
 	{
 		if (i >= 0 && i < m_info.size())
 		{
@@ -303,7 +303,7 @@ public:
 		return AsciiString::TheEmptyString;
 	}
 
-	AsciiString getNthTag(size_t i) const
+	const AsciiString& getNthTag(size_t i) const
 	{
 		if (i >= 0 && i < m_info.size())
 		{
@@ -608,7 +608,7 @@ public:
 	UnsignedByte getCrushableLevel() const { return m_crushableLevel; }
 	UnsignedByte getCrusherLevel() const { return m_crusherLevel; }
 
-	AsciiString getUpgradeCameoName( Int n)const{ return m_upgradeCameoUpgradeNames[n];	}
+	const AsciiString& getUpgradeCameoName( Int n)const{ return m_upgradeCameoUpgradeNames[n];	}
 
 protected:
 

--- a/Generals/Code/GameEngine/Include/GameLogic/PolygonTrigger.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/PolygonTrigger.h
@@ -125,7 +125,7 @@ public:
 	Int getID() const {return m_triggerID;}
 	PolygonTrigger *getNext() {return m_nextPolygonTrigger;}
 	const PolygonTrigger *getNext() const {return m_nextPolygonTrigger;}
-	AsciiString getTriggerName()  const {return m_triggerName;} ///< Gets the trigger name.
+	const AsciiString& getTriggerName()  const {return m_triggerName;} ///< Gets the trigger name.
 	Bool pointInTrigger(ICoord3D &point) const;
 	Bool doExportWithScripts() const {return m_exportWithScripts;}
 	void setDoExportWithScripts(Bool val) {m_exportWithScripts = val;}

--- a/Generals/Code/GameEngine/Include/GameLogic/TerrainLogic.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/TerrainLogic.h
@@ -65,8 +65,8 @@ class Waypoint : public MemoryPoolObject
 // friends do not play well with MPO (srj)
 //friend class TerrainLogic;
 public:
-	Waypoint(WaypointID id, AsciiString name, const Coord3D *pLoc, AsciiString label1,
-						AsciiString label2, AsciiString label3, Bool biDirectional);
+	Waypoint(WaypointID id, const AsciiString& name, const Coord3D *pLoc, const AsciiString& label1,
+						const AsciiString& label2, const AsciiString& label3, Bool biDirectional);
 	//~Waypoint();
 	enum {MAX_LINKS=8};
 
@@ -106,17 +106,17 @@ public:
 	/// Get the n'th directed link.  (May be nullptr).
 	Waypoint *getLink(Int ndx) const {if (ndx>=0 && ndx <= MAX_LINKS) return m_links[ndx]; return nullptr; }
 	/// Get the waypoint's name.
-	AsciiString getName() const {return m_name; }
+	const AsciiString& getName() const {return m_name; }
 	/// Get the integer id.
 	WaypointID getID() const {return m_id; }
 	/// Get the waypoint's position
 	const Coord3D *getLocation() const { return &m_location;  }
 	/// Get the waypoint's first path label
-	AsciiString getPathLabel1() const { return m_pathLabel1;  }
+	const AsciiString& getPathLabel1() const { return m_pathLabel1;  }
 	/// Get the waypoint's second path label
-	AsciiString getPathLabel2() const { return m_pathLabel2;  }
+	const AsciiString& getPathLabel2() const { return m_pathLabel2;  }
 	/// Get the waypoint's third path label
-	AsciiString getPathLabel3() const { return m_pathLabel3;  }
+	const AsciiString& getPathLabel3() const { return m_pathLabel3;  }
 	/// Get bi-directionality.
 	Bool getBiDirectional() const { return m_biDirectional; }
 
@@ -183,7 +183,7 @@ public:
 
 public:
 	/// return the bridge template name
-	AsciiString getBridgeTemplateName() { return m_templateName; }
+	const AsciiString& getBridgeTemplateName() { return m_templateName; }
 	/// Enumerate all bridges using getNext;
 	Bridge	*getNext() {return m_next; }
 	/// Get the height for an object on bridge.  Note - assumes object is on bridge. Use isPointOnBridge to check.
@@ -224,7 +224,7 @@ public:
 	virtual void reset() override;		///< Reset
 	virtual void update() override;	///< Update
 
-	virtual Bool loadMap( AsciiString filename, Bool query );
+	virtual Bool loadMap( const AsciiString& filename, Bool query );
 	virtual void newMap( Bool saveGame );	///< Initialize the logic for new map.
 
 	virtual Real getGroundHeight( Real x, Real y, Coord3D* normal = nullptr )  const;
@@ -236,14 +236,14 @@ public:
 	virtual Coord3D findFarthestEdgePoint( const Coord3D *farthestFrom ) const ;
 	virtual Bool isClearLineOfSight(const Coord3D& pos, const Coord3D& posOther) const;
 
-	virtual AsciiString getSourceFilename() { return m_filenameString; }
+	virtual const AsciiString& getSourceFilename() { return m_filenameString; }
 
 	virtual PathfindLayerEnum alignOnTerrain( Real angle, const Coord3D& pos, Bool stickToGround, Matrix3D& mtx);
 
 	virtual Bool isUnderwater( Real x, Real y, Real *waterZ = nullptr, Real *terrainZ = nullptr );			///< is point under water
 	virtual Bool isCliffCell( Real x, Real y) const;			///< is point cliff cell
 	virtual const WaterHandle* getWaterHandle( Real x, Real y );					///< get water handle at this location
-	virtual const WaterHandle* getWaterHandleByName( AsciiString name );	///< get water handle by name
+	virtual const WaterHandle* getWaterHandleByName( const AsciiString& name );	///< get water handle by name
 	virtual Real getWaterHeight( const WaterHandle *water );							///< get height of water table
 	virtual void setWaterHeight( const WaterHandle *water,
 															 Real height,
@@ -257,19 +257,19 @@ public:
 	virtual Waypoint *getFirstWaypoint() { return m_waypointListHead; }
 
 	/// Return the waypoint with the given name
-	virtual Waypoint *getWaypointByName( AsciiString name );
+	virtual Waypoint *getWaypointByName( const AsciiString& name );
 
 	/// Return the waypoint with the given ID
 	virtual Waypoint *getWaypointByID( UnsignedInt id );
 
 	/// Return the closest waypoint on the labeled path
-	virtual Waypoint *getClosestWaypointOnPath( const Coord3D *pos, AsciiString label );
+	virtual Waypoint *getClosestWaypointOnPath( const Coord3D *pos, const AsciiString& label );
 
 	/// Return true if the waypoint path containing pWay is labeled with the label.
-	virtual Bool isPurposeOfPath( Waypoint *pWay, AsciiString label );
+	virtual Bool isPurposeOfPath( Waypoint *pWay, const AsciiString& label );
 
 	/// Return the trigger area with the given name
-	virtual PolygonTrigger *getTriggerAreaByName( AsciiString name );
+	virtual PolygonTrigger *getTriggerAreaByName( const AsciiString& name );
 
 	///Gets the first bridge.  Traverse all bridges using bridge->getNext();
 	virtual Bridge *getFirstBridge() const { return m_bridgeListHead; }
@@ -288,7 +288,7 @@ public:
 
 	virtual Drawable *pickBridge(const Vector3 &from, const Vector3 &to, Vector3 *pos);
 
-	virtual void addBridgeToLogic(BridgeInfo *pInfo, Dict *props, AsciiString bridgeTemplateName); ///< Adds a bridge's logical info.
+	virtual void addBridgeToLogic(BridgeInfo *pInfo, Dict *props, const AsciiString& bridgeTemplateName); ///< Adds a bridge's logical info.
 	virtual void addLandmarkBridgeToLogic(Object *bridgeObj); ///< Adds a bridge's logical info.
 	virtual void deleteBridge( Bridge *bridge );	///< remove a bridge
 

--- a/Generals/Code/GameEngine/Source/Common/System/DataChunk.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/DataChunk.cpp
@@ -47,7 +47,7 @@ CachedFileInputStream::~CachedFileInputStream()
 	m_buffer=nullptr;
 }
 
-Bool CachedFileInputStream::open(AsciiString path)
+Bool CachedFileInputStream::open(const AsciiString& path)
 {
 	File *file=TheFileSystem->openFile(path.str(), File::READ | File::BINARY);
 	m_size = 0;

--- a/Generals/Code/GameEngine/Source/Common/System/DataChunk.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/DataChunk.cpp
@@ -166,7 +166,7 @@ FileInputStream::~FileInputStream()
 	}
 }
 
-Bool FileInputStream::open(AsciiString path)
+Bool FileInputStream::open(const AsciiString& path)
 {
 	m_file = TheFileSystem->openFile(path.str(), File::READ | File::BINARY);
 	return m_file == nullptr?false:true;

--- a/Generals/Code/GameEngine/Source/Common/TerrainTypes.cpp
+++ b/Generals/Code/GameEngine/Source/Common/TerrainTypes.cpp
@@ -111,7 +111,7 @@ TerrainTypeCollection::~TerrainTypeCollection()
 //-------------------------------------------------------------------------------------------------
 /** Find a terrain type given the name */
 //-------------------------------------------------------------------------------------------------
-TerrainType *TerrainTypeCollection::findTerrain( AsciiString name )
+TerrainType *TerrainTypeCollection::findTerrain( const AsciiString& name )
 {
 	TerrainType *terrain;
 
@@ -131,7 +131,7 @@ TerrainType *TerrainTypeCollection::findTerrain( AsciiString name )
 //-------------------------------------------------------------------------------------------------
 /** Allocate a new type, assign the name, and tie to type list */
 //-------------------------------------------------------------------------------------------------
-TerrainType *TerrainTypeCollection::newTerrain( AsciiString name )
+TerrainType *TerrainTypeCollection::newTerrain( const AsciiString& name )
 {
 	TerrainType *terrain = nullptr;
 

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -2661,7 +2661,7 @@ void ControlBar::setPortraitByObject( Object *obj )
 
 		for(Int i = 0; i < MAX_UPGRADE_CAMEO_UPGRADES; ++i)
 		{
-			AsciiString upgradeName = thing->getUpgradeCameoName(i);
+			const AsciiString& upgradeName = thing->getUpgradeCameoName(i);
 			if(upgradeName.isEmpty())
 			{
 				m_rightHUDUpgradeCameos[i]->winHide(TRUE);

--- a/Generals/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
@@ -1633,7 +1633,7 @@ Bool TerrainLogic::isPurposeOfPath( Waypoint *pWay, const AsciiString& label )
 PolygonTrigger *TerrainLogic::getTriggerAreaByName( const AsciiString& name )
 {
 	for (PolygonTrigger* pTrig = PolygonTrigger::getFirstPolygonTrigger(); pTrig; pTrig = pTrig->getNext()) {
-		AsciiString trigName = pTrig->getTriggerName();
+		const AsciiString& trigName = pTrig->getTriggerName();
 		if (name == trigName)
 			return pTrig;
 	}

--- a/Generals/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
@@ -70,8 +70,8 @@ WaterHandle TerrainLogic::m_gridWaterHandle;
 
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
-Waypoint::Waypoint(WaypointID id, AsciiString name, const Coord3D *pLoc, AsciiString label1, AsciiString label2,
-									 AsciiString label3, Bool biDirectional) :
+Waypoint::Waypoint(WaypointID id, const AsciiString& name, const Coord3D *pLoc, const AsciiString& label1, const AsciiString& label2,
+									 const AsciiString& label3, Bool biDirectional) :
 m_name(name),
 m_pNext(nullptr),
 m_location(*pLoc),
@@ -1243,7 +1243,7 @@ void TerrainLogic::enableWaterGrid( Bool enable )
 /** device independent terrain logic load.  If query is true, we are just loading it to get
 look at some data rather than running a game, so don't pass this load to the client. */
 //-------------------------------------------------------------------------------------------------
-Bool TerrainLogic::loadMap( AsciiString filename, Bool query )
+Bool TerrainLogic::loadMap( const AsciiString& filename, Bool query )
 {
 
 	// sanity
@@ -1262,7 +1262,7 @@ Bool TerrainLogic::loadMap( AsciiString filename, Bool query )
 	}
 
 	CachedFileInputStream theInputStream;
-	if (theInputStream.open(AsciiString(m_filenameString.str())))
+	if (theInputStream.open(m_filenameString))
 	try {
 		ChunkInputStream *pStrm = &theInputStream;
 		pStrm->absoluteSeek(0);
@@ -1527,7 +1527,7 @@ PathfindLayerEnum TerrainLogic::alignOnTerrain( Real angle, const Coord3D& pos, 
 //-------------------------------------------------------------------------------------------------
 /** Adds a bridge's info get height function for logical terrain */
 //-------------------------------------------------------------------------------------------------
-void TerrainLogic::addBridgeToLogic(BridgeInfo *pInfo, Dict *props, AsciiString bridgeTemplateName)
+void TerrainLogic::addBridgeToLogic(BridgeInfo *pInfo, Dict *props, const AsciiString& bridgeTemplateName)
 {
 	Bridge *pBridge = newInstance(Bridge)(*pInfo, props, bridgeTemplateName);
 	pBridge->setNext(m_bridgeListHead);
@@ -1554,7 +1554,7 @@ void TerrainLogic::addLandmarkBridgeToLogic(Object *bridgeObj)
 //-------------------------------------------------------------------------------------------------
 /** Given a name, return the associated waypoint. */
 //-------------------------------------------------------------------------------------------------
-Waypoint *TerrainLogic::getWaypointByName( AsciiString name )
+Waypoint *TerrainLogic::getWaypointByName( const AsciiString& name )
 {
 	for( Waypoint *way = m_waypointListHead; way; way = way->getNext() )
 		if (way->getName() == name)
@@ -1578,7 +1578,7 @@ Waypoint *TerrainLogic::getWaypointByID( UnsignedInt id )
 //-------------------------------------------------------------------------------------------------
 /** Return the closest waypoint on the labeled path. */
 //-------------------------------------------------------------------------------------------------
-Waypoint *TerrainLogic::getClosestWaypointOnPath( const Coord3D *pos, AsciiString label )
+Waypoint *TerrainLogic::getClosestWaypointOnPath( const Coord3D *pos, const AsciiString& label )
 {
 	Real distSqr = 0;
 	Waypoint *pClosestWay = nullptr;
@@ -1611,7 +1611,7 @@ Waypoint *TerrainLogic::getClosestWaypointOnPath( const Coord3D *pos, AsciiStrin
 //-------------------------------------------------------------------------------------------------
 /** Return true if the waypoint path containing pWay is labeled with the label. */
 //-------------------------------------------------------------------------------------------------
-Bool TerrainLogic::isPurposeOfPath( Waypoint *pWay, AsciiString label )
+Bool TerrainLogic::isPurposeOfPath( Waypoint *pWay, const AsciiString& label )
 {
 	if (label.isEmpty() || pWay==nullptr) {
 		DEBUG_LOG(("***Warning - asking for empth path label."));
@@ -1630,7 +1630,7 @@ Bool TerrainLogic::isPurposeOfPath( Waypoint *pWay, AsciiString label )
 //-------------------------------------------------------------------------------------------------
 /** Given a name, return the associated trigger area, or null if one doesn't exist. */
 //-------------------------------------------------------------------------------------------------
-PolygonTrigger *TerrainLogic::getTriggerAreaByName( AsciiString name )
+PolygonTrigger *TerrainLogic::getTriggerAreaByName( const AsciiString& name )
 {
 	for (PolygonTrigger* pTrig = PolygonTrigger::getFirstPolygonTrigger(); pTrig; pTrig = pTrig->getNext()) {
 		AsciiString trigName = pTrig->getTriggerName();
@@ -2237,7 +2237,7 @@ const WaterHandle* TerrainLogic::getWaterHandle( Real x, Real y )
 // ------------------------------------------------------------------------------------------------
 /** Get water handle by name assigned from the editor */
 // ------------------------------------------------------------------------------------------------
-const WaterHandle* TerrainLogic::getWaterHandleByName( AsciiString name )
+const WaterHandle* TerrainLogic::getWaterHandleByName( const AsciiString& name )
 {
 	if (name.compare(WATER_GRID) == 0)
 		return &TerrainLogic::m_gridWaterHandle;

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
@@ -952,7 +952,7 @@ UpdateSleepTime ProductionUpdate::update()
 				const ThingTemplate *thing = selectedObject->getTemplate();
 				for( Int i = 0; i < MAX_UPGRADE_CAMEO_UPGRADES; i++ )
 				{
-					AsciiString upgradeName = thing->getUpgradeCameoName( i );
+					const AsciiString& upgradeName = thing->getUpgradeCameoName( i );
 					const UpgradeTemplate *testUpgrade = TheUpgradeCenter->findUpgrade( upgradeName );
 					if( testUpgrade == upgrade )
 					{

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameLogic/W3DTerrainLogic.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameLogic/W3DTerrainLogic.h
@@ -50,7 +50,7 @@ public:
 	virtual void update() override;	///< Update
 
 	/// @todo The loading of the raw height data should be device independent
-	virtual Bool loadMap( AsciiString filename , Bool query ) override;
+	virtual Bool loadMap( const AsciiString& filename , Bool query ) override;
 	virtual void newMap( Bool saveGame ) override;	///< Initialize the logic for new map.
 
 	virtual Real getGroundHeight( Real x, Real y, Coord3D* normal = nullptr ) const override;

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameLogic/W3DTerrainLogic.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameLogic/W3DTerrainLogic.cpp
@@ -110,7 +110,7 @@ void W3DTerrainLogic::update()
 /** Device DEPENDENT implementation for load details of logical terrain.
 Note - if query is true, we are  */
 //-------------------------------------------------------------------------------------------------
-Bool W3DTerrainLogic::loadMap( AsciiString filename , Bool query )
+Bool W3DTerrainLogic::loadMap( const AsciiString& filename , Bool query )
 {
 	if(!TheMapCache)
 		return FALSE;

--- a/GeneralsMD/Code/GameEngine/Include/Common/MapReaderWriterInfo.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/MapReaderWriterInfo.h
@@ -88,7 +88,7 @@ protected:
 public:
 	CachedFileInputStream();
 	~CachedFileInputStream();
-	Bool open(AsciiString path);	///< Returns true if open succeeded.
+	Bool open(const AsciiString& path);	///< Returns true if open succeeded.
 	void close();  ///< Explict close.  Destructor closes if file is left open.
 	virtual Int read(void *pData, Int numBytes) override;
 	virtual UnsignedInt tell() override;
@@ -106,7 +106,7 @@ protected:
 public:
 	FileInputStream();
 	~FileInputStream();
-	Bool open(AsciiString path);	///< Returns true if open succeeded.
+	Bool open(const AsciiString& path);	///< Returns true if open succeeded.
 	void close();  ///< Explict close.  Destructor closes if file is left open.
 	virtual Int read(void *pData, Int numBytes);
 	virtual UnsignedInt tell();

--- a/GeneralsMD/Code/GameEngine/Include/Common/TerrainTypes.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/TerrainTypes.h
@@ -152,7 +152,7 @@ public:
 	// destructor prototype defined by memory pool glue
 
 	/// get the name for this terrain
-	AsciiString getName() { return m_name; }
+	const AsciiString& getName() { return m_name; }
 
 	/// get whether this terrain is blend edge terrain.
 	Bool isBlendEdge() { return m_blendEdgeTexture; }
@@ -164,19 +164,19 @@ public:
 	Bool getRestrictConstruction() { return m_restrictConstruction; }
 
 	/// get the texture file for this terrain
-	AsciiString getTexture() { return m_texture; }
+	const AsciiString& getTexture() { return m_texture; }
 
 	/// get next terrain in list, only for use by the terrain collection
 	TerrainType *friend_getNext() { return m_next; }
 
 	/// set the name for this terrain, for use by terrain collection only
-	void friend_setName( AsciiString name ) { m_name = name; }
+	void friend_setName( const AsciiString& name ) { m_name = name; }
 
 	/// set the next pointer for the terrain list, for use by terrain collection only
 	void friend_setNext( TerrainType *next ) { m_next = next; }
 
 	/// set the texture, for use by terrain collection only
-	void friend_setTexture( AsciiString texture ) { m_texture = texture; }
+	void friend_setTexture( const AsciiString& texture ) { m_texture = texture; }
 
 	/// set the class, for use by terrain collection only
 	void friend_setClass( TerrainClass terrainClass ) { m_class = terrainClass; }
@@ -219,8 +219,8 @@ public:
 	virtual void reset() override { }
 	virtual void update() override { }
 
-	TerrainType *findTerrain( AsciiString name );		///< find terrain by name
-	TerrainType *newTerrain( AsciiString name );			///< allocate a new terrain
+	TerrainType *findTerrain( const AsciiString& name );		///< find terrain by name
+	TerrainType *newTerrain( const AsciiString& name );			///< allocate a new terrain
 
 	/// get first terrain in list
 	TerrainType *firstTerrain() { return m_terrainList; }

--- a/GeneralsMD/Code/GameEngine/Include/Common/ThingTemplate.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/ThingTemplate.h
@@ -294,7 +294,7 @@ public:
 	}
 #endif
 
-	AsciiString getNthName(size_t i) const
+	const AsciiString& getNthName(size_t i) const
 	{
 		if (i >= 0 && i < m_info.size())
 		{
@@ -303,7 +303,7 @@ public:
 		return AsciiString::TheEmptyString;
 	}
 
-	AsciiString getNthTag(size_t i) const
+	const AsciiString& getNthTag(size_t i) const
 	{
 		if (i >= 0 && i < m_info.size())
 		{
@@ -619,7 +619,7 @@ public:
 	UnsignedByte getCrushableLevel() const { return m_crushableLevel; }
 	UnsignedByte getCrusherLevel() const { return m_crusherLevel; }
 
-	AsciiString getUpgradeCameoName( Int n)const{ return m_upgradeCameoUpgradeNames[n];	}
+	const AsciiString& getUpgradeCameoName( Int n)const{ return m_upgradeCameoUpgradeNames[n];	}
 
 	const WeaponTemplateSetVector& getWeaponTemplateSets() const {return m_weaponTemplateSets;}
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/PolygonTrigger.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/PolygonTrigger.h
@@ -120,7 +120,7 @@ public:
 	void setTriggerName(AsciiString name) {m_triggerName = name;};
 
 	void setLayerName(AsciiString name) {m_layerName = name;};
-	AsciiString getLayerName()  const {return m_layerName;}
+	const AsciiString& getLayerName()  const {return m_layerName;}
 
 	void setShouldRender(Bool toggle) {m_shouldRender = toggle;}
 	Bool getShouldRender() {return m_shouldRender;}
@@ -137,7 +137,7 @@ public:
 	Int getID() const {return m_triggerID;}
 	PolygonTrigger *getNext() {return m_nextPolygonTrigger;}
 	const PolygonTrigger *getNext() const {return m_nextPolygonTrigger;}
-	AsciiString getTriggerName()  const {return m_triggerName;} ///< Gets the trigger name.
+	const AsciiString& getTriggerName()  const {return m_triggerName;} ///< Gets the trigger name.
 	Bool pointInTrigger(ICoord3D &point) const;
 	Bool doExportWithScripts() const {return m_exportWithScripts;}
 	void setDoExportWithScripts(Bool val) {m_exportWithScripts = val;}

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/TerrainLogic.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/TerrainLogic.h
@@ -65,8 +65,8 @@ class Waypoint : public MemoryPoolObject
 // friends do not play well with MPO (srj)
 //friend class TerrainLogic;
 public:
-	Waypoint(WaypointID id, AsciiString name, const Coord3D *pLoc, AsciiString label1,
-						AsciiString label2, AsciiString label3, Bool biDirectional);
+	Waypoint(WaypointID id, const AsciiString& name, const Coord3D *pLoc, const AsciiString& label1,
+						const AsciiString& label2, const AsciiString& label3, Bool biDirectional);
 	//~Waypoint();
 	enum {MAX_LINKS=8};
 
@@ -106,17 +106,17 @@ public:
 	/// Get the n'th directed link.  (May be nullptr).
 	Waypoint *getLink(Int ndx) const {if (ndx>=0 && ndx <= MAX_LINKS) return m_links[ndx]; return nullptr; }
 	/// Get the waypoint's name.
-	AsciiString getName() const {return m_name; }
+	const AsciiString& getName() const {return m_name; }
 	/// Get the integer id.
 	WaypointID getID() const {return m_id; }
 	/// Get the waypoint's position
 	const Coord3D *getLocation() const { return &m_location;  }
 	/// Get the waypoint's first path label
-	AsciiString getPathLabel1() const { return m_pathLabel1;  }
+	const AsciiString& getPathLabel1() const { return m_pathLabel1;  }
 	/// Get the waypoint's second path label
-	AsciiString getPathLabel2() const { return m_pathLabel2;  }
+	const AsciiString& getPathLabel2() const { return m_pathLabel2;  }
 	/// Get the waypoint's third path label
-	AsciiString getPathLabel3() const { return m_pathLabel3;  }
+	const AsciiString& getPathLabel3() const { return m_pathLabel3;  }
 	/// Get bi-directionality.
 	Bool getBiDirectional() const { return m_biDirectional; }
 
@@ -183,7 +183,7 @@ public:
 
 public:
 	/// return the bridge template name
-	AsciiString getBridgeTemplateName() { return m_templateName; }
+	const AsciiString& getBridgeTemplateName() { return m_templateName; }
 	/// Enumerate all bridges using getNext;
 	Bridge	*getNext() {return m_next; }
 	/// Get the height for an object on bridge.  Note - assumes object is on bridge. Use isPointOnBridge to check.
@@ -224,7 +224,7 @@ public:
 	virtual void reset() override;		///< Reset
 	virtual void update() override;	///< Update
 
-	virtual Bool loadMap( AsciiString filename, Bool query );
+	virtual Bool loadMap( const AsciiString& filename, Bool query );
 	virtual void newMap( Bool saveGame );	///< Initialize the logic for new map.
 
 	virtual Real getGroundHeight( Real x, Real y, Coord3D* normal = nullptr )  const;
@@ -236,14 +236,14 @@ public:
 	virtual Coord3D findFarthestEdgePoint( const Coord3D *farthestFrom ) const ;
 	virtual Bool isClearLineOfSight(const Coord3D& pos, const Coord3D& posOther) const;
 
-	virtual AsciiString getSourceFilename() { return m_filenameString; }
+	virtual const AsciiString& getSourceFilename() { return m_filenameString; }
 
 	virtual PathfindLayerEnum alignOnTerrain( Real angle, const Coord3D& pos, Bool stickToGround, Matrix3D& mtx);
 
 	virtual Bool isUnderwater( Real x, Real y, Real *waterZ = nullptr, Real *terrainZ = nullptr );			///< is point under water
 	virtual Bool isCliffCell( Real x, Real y) const;			///< is point cliff cell
 	virtual const WaterHandle* getWaterHandle( Real x, Real y );					///< get water handle at this location
-	virtual const WaterHandle* getWaterHandleByName( AsciiString name );	///< get water handle by name
+	virtual const WaterHandle* getWaterHandleByName( const AsciiString& name );	///< get water handle by name
 	virtual Real getWaterHeight( const WaterHandle *water );							///< get height of water table
 	virtual void setWaterHeight( const WaterHandle *water,
 															 Real height,
@@ -257,19 +257,19 @@ public:
 	virtual Waypoint *getFirstWaypoint() { return m_waypointListHead; }
 
 	/// Return the waypoint with the given name
-	virtual Waypoint *getWaypointByName( AsciiString name );
+	virtual Waypoint *getWaypointByName( const AsciiString& name );
 
 	/// Return the waypoint with the given ID
 	virtual Waypoint *getWaypointByID( UnsignedInt id );
 
 	/// Return the closest waypoint on the labeled path
-	virtual Waypoint *getClosestWaypointOnPath( const Coord3D *pos, AsciiString label );
+	virtual Waypoint *getClosestWaypointOnPath( const Coord3D *pos, const AsciiString& label );
 
 	/// Return true if the waypoint path containing pWay is labeled with the label.
-	virtual Bool isPurposeOfPath( Waypoint *pWay, AsciiString label );
+	virtual Bool isPurposeOfPath( Waypoint *pWay, const AsciiString& label );
 
 	/// Return the trigger area with the given name
-	virtual PolygonTrigger *getTriggerAreaByName( AsciiString name );
+	virtual PolygonTrigger *getTriggerAreaByName( const AsciiString& name );
 
 	///Gets the first bridge.  Traverse all bridges using bridge->getNext();
 	virtual Bridge *getFirstBridge() const { return m_bridgeListHead; }
@@ -288,7 +288,7 @@ public:
 
 	virtual Drawable *pickBridge(const Vector3 &from, const Vector3 &to, Vector3 *pos);
 
-	virtual void addBridgeToLogic(BridgeInfo *pInfo, Dict *props, AsciiString bridgeTemplateName); ///< Adds a bridge's logical info.
+	virtual void addBridgeToLogic(BridgeInfo *pInfo, Dict *props, const AsciiString& bridgeTemplateName); ///< Adds a bridge's logical info.
 	virtual void addLandmarkBridgeToLogic(Object *bridgeObj); ///< Adds a bridge's logical info.
 	virtual void deleteBridge( Bridge *bridge );	///< remove a bridge
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/DataChunk.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/DataChunk.cpp
@@ -47,7 +47,7 @@ CachedFileInputStream::~CachedFileInputStream()
 	m_buffer=nullptr;
 }
 
-Bool CachedFileInputStream::open(AsciiString path)
+Bool CachedFileInputStream::open(const AsciiString& path)
 {
 	File *file=TheFileSystem->openFile(path.str(), File::READ | File::BINARY);
 	m_size = 0;

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/DataChunk.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/DataChunk.cpp
@@ -166,7 +166,7 @@ FileInputStream::~FileInputStream()
 	}
 }
 
-Bool FileInputStream::open(AsciiString path)
+Bool FileInputStream::open(const AsciiString& path)
 {
 	m_file = TheFileSystem->openFile(path.str(), File::READ | File::BINARY);
 	return m_file == nullptr?false:true;

--- a/GeneralsMD/Code/GameEngine/Source/Common/TerrainTypes.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/TerrainTypes.cpp
@@ -111,7 +111,7 @@ TerrainTypeCollection::~TerrainTypeCollection()
 //-------------------------------------------------------------------------------------------------
 /** Find a terrain type given the name */
 //-------------------------------------------------------------------------------------------------
-TerrainType *TerrainTypeCollection::findTerrain( AsciiString name )
+TerrainType *TerrainTypeCollection::findTerrain( const AsciiString& name )
 {
 	TerrainType *terrain;
 
@@ -131,7 +131,7 @@ TerrainType *TerrainTypeCollection::findTerrain( AsciiString name )
 //-------------------------------------------------------------------------------------------------
 /** Allocate a new type, assign the name, and tie to type list */
 //-------------------------------------------------------------------------------------------------
-TerrainType *TerrainTypeCollection::newTerrain( AsciiString name )
+TerrainType *TerrainTypeCollection::newTerrain( const AsciiString& name )
 {
 	TerrainType *terrain = nullptr;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -2661,7 +2661,7 @@ void ControlBar::setPortraitByObject( Object *obj )
 
 		for(Int i = 0; i < MAX_UPGRADE_CAMEO_UPGRADES; ++i)
 		{
-			AsciiString upgradeName = thing->getUpgradeCameoName(i);
+			const AsciiString& upgradeName = thing->getUpgradeCameoName(i);
 			if(upgradeName.isEmpty())
 			{
 				m_rightHUDUpgradeCameos[i]->winHide(TRUE);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
@@ -1633,7 +1633,7 @@ Bool TerrainLogic::isPurposeOfPath( Waypoint *pWay, const AsciiString& label )
 PolygonTrigger *TerrainLogic::getTriggerAreaByName( const AsciiString& name )
 {
 	for (PolygonTrigger* pTrig = PolygonTrigger::getFirstPolygonTrigger(); pTrig; pTrig = pTrig->getNext()) {
-		AsciiString trigName = pTrig->getTriggerName();
+		const AsciiString& trigName = pTrig->getTriggerName();
 		if (name == trigName)
 			return pTrig;
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Map/TerrainLogic.cpp
@@ -70,8 +70,8 @@ WaterHandle TerrainLogic::m_gridWaterHandle;
 
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
-Waypoint::Waypoint(WaypointID id, AsciiString name, const Coord3D *pLoc, AsciiString label1, AsciiString label2,
-									 AsciiString label3, Bool biDirectional) :
+Waypoint::Waypoint(WaypointID id, const AsciiString& name, const Coord3D *pLoc, const AsciiString& label1, const AsciiString& label2,
+									 const AsciiString& label3, Bool biDirectional) :
 m_name(name),
 m_pNext(nullptr),
 m_location(*pLoc),
@@ -1243,7 +1243,7 @@ void TerrainLogic::enableWaterGrid( Bool enable )
 /** device independent terrain logic load.  If query is true, we are just loading it to get
 look at some data rather than running a game, so don't pass this load to the client. */
 //-------------------------------------------------------------------------------------------------
-Bool TerrainLogic::loadMap( AsciiString filename, Bool query )
+Bool TerrainLogic::loadMap( const AsciiString& filename, Bool query )
 {
 
 	// sanity
@@ -1262,7 +1262,7 @@ Bool TerrainLogic::loadMap( AsciiString filename, Bool query )
 	}
 
 	CachedFileInputStream theInputStream;
-	if (theInputStream.open(AsciiString(m_filenameString.str())))
+	if (theInputStream.open(m_filenameString))
 	try {
 		ChunkInputStream *pStrm = &theInputStream;
 		pStrm->absoluteSeek(0);
@@ -1527,7 +1527,7 @@ PathfindLayerEnum TerrainLogic::alignOnTerrain( Real angle, const Coord3D& pos, 
 //-------------------------------------------------------------------------------------------------
 /** Adds a bridge's info get height function for logical terrain */
 //-------------------------------------------------------------------------------------------------
-void TerrainLogic::addBridgeToLogic(BridgeInfo *pInfo, Dict *props, AsciiString bridgeTemplateName)
+void TerrainLogic::addBridgeToLogic(BridgeInfo *pInfo, Dict *props, const AsciiString& bridgeTemplateName)
 {
 	Bridge *pBridge = newInstance(Bridge)(*pInfo, props, bridgeTemplateName);
 	pBridge->setNext(m_bridgeListHead);
@@ -1554,7 +1554,7 @@ void TerrainLogic::addLandmarkBridgeToLogic(Object *bridgeObj)
 //-------------------------------------------------------------------------------------------------
 /** Given a name, return the associated waypoint. */
 //-------------------------------------------------------------------------------------------------
-Waypoint *TerrainLogic::getWaypointByName( AsciiString name )
+Waypoint *TerrainLogic::getWaypointByName( const AsciiString& name )
 {
 	for( Waypoint *way = m_waypointListHead; way; way = way->getNext() )
 		if (way->getName() == name)
@@ -1578,7 +1578,7 @@ Waypoint *TerrainLogic::getWaypointByID( UnsignedInt id )
 //-------------------------------------------------------------------------------------------------
 /** Return the closest waypoint on the labeled path. */
 //-------------------------------------------------------------------------------------------------
-Waypoint *TerrainLogic::getClosestWaypointOnPath( const Coord3D *pos, AsciiString label )
+Waypoint *TerrainLogic::getClosestWaypointOnPath( const Coord3D *pos, const AsciiString& label )
 {
 	Real distSqr = 0;
 	Waypoint *pClosestWay = nullptr;
@@ -1611,7 +1611,7 @@ Waypoint *TerrainLogic::getClosestWaypointOnPath( const Coord3D *pos, AsciiStrin
 //-------------------------------------------------------------------------------------------------
 /** Return true if the waypoint path containing pWay is labeled with the label. */
 //-------------------------------------------------------------------------------------------------
-Bool TerrainLogic::isPurposeOfPath( Waypoint *pWay, AsciiString label )
+Bool TerrainLogic::isPurposeOfPath( Waypoint *pWay, const AsciiString& label )
 {
 	if (label.isEmpty() || pWay==nullptr) {
 		DEBUG_LOG(("***Warning - asking for empth path label."));
@@ -1630,7 +1630,7 @@ Bool TerrainLogic::isPurposeOfPath( Waypoint *pWay, AsciiString label )
 //-------------------------------------------------------------------------------------------------
 /** Given a name, return the associated trigger area, or null if one doesn't exist. */
 //-------------------------------------------------------------------------------------------------
-PolygonTrigger *TerrainLogic::getTriggerAreaByName( AsciiString name )
+PolygonTrigger *TerrainLogic::getTriggerAreaByName( const AsciiString& name )
 {
 	for (PolygonTrigger* pTrig = PolygonTrigger::getFirstPolygonTrigger(); pTrig; pTrig = pTrig->getNext()) {
 		AsciiString trigName = pTrig->getTriggerName();
@@ -2237,7 +2237,7 @@ const WaterHandle* TerrainLogic::getWaterHandle( Real x, Real y )
 // ------------------------------------------------------------------------------------------------
 /** Get water handle by name assigned from the editor */
 // ------------------------------------------------------------------------------------------------
-const WaterHandle* TerrainLogic::getWaterHandleByName( AsciiString name )
+const WaterHandle* TerrainLogic::getWaterHandleByName( const AsciiString& name )
 {
 	if (name.compare(WATER_GRID) == 0)
 		return &TerrainLogic::m_gridWaterHandle;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ProductionUpdate.cpp
@@ -956,7 +956,7 @@ UpdateSleepTime ProductionUpdate::update()
 				const ThingTemplate *thing = selectedObject->getTemplate();
 				for( Int i = 0; i < MAX_UPGRADE_CAMEO_UPGRADES; i++ )
 				{
-					AsciiString upgradeName = thing->getUpgradeCameoName( i );
+					const AsciiString& upgradeName = thing->getUpgradeCameoName( i );
 					const UpgradeTemplate *testUpgrade = TheUpgradeCenter->findUpgrade( upgradeName );
 					if( testUpgrade == upgrade )
 					{

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameLogic/W3DTerrainLogic.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameLogic/W3DTerrainLogic.h
@@ -50,7 +50,7 @@ public:
 	virtual void update() override;	///< Update
 
 	/// @todo The loading of the raw height data should be device independent
-	virtual Bool loadMap( AsciiString filename , Bool query ) override;
+	virtual Bool loadMap( const AsciiString& filename , Bool query ) override;
 	virtual void newMap( Bool saveGame ) override;	///< Initialize the logic for new map.
 
 	virtual Real getGroundHeight( Real x, Real y, Coord3D* normal = nullptr ) const override;

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameLogic/W3DTerrainLogic.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameLogic/W3DTerrainLogic.cpp
@@ -110,7 +110,7 @@ void W3DTerrainLogic::update()
 /** Device DEPENDENT implementation for load details of logical terrain.
 Note - if query is true, we are  */
 //-------------------------------------------------------------------------------------------------
-Bool W3DTerrainLogic::loadMap( AsciiString filename , Bool query )
+Bool W3DTerrainLogic::loadMap( const AsciiString& filename , Bool query )
 {
 	if(!TheMapCache)
 		return FALSE;


### PR DESCRIPTION
This refactor eliminates global lock contention in the AsciiString system by replacing pass-by-value with const AsciiString& references. Boosting performance from 14 to 87 FPS (1% low) on AOD Cobalt Rush. Inspired by #1942.

<img width="1063" height="212" alt="tracy" src="https://github.com/user-attachments/assets/f3b6fd35-e3ed-45da-b367-ad0fc53359de" />

AsciiString is bottlenecked by heavy lock contention in RtlEnterCriticalSection, specifically during releaseBuffer and object construction. This forces getClosestWaypointOnPath to stall as it repeatedly creates and destroys temporary string labels, turning a spatial query into a series of expensive global synchronization events.


Optimization Targets

Our optimizations target the high-frequency "Hot Paths" where string operations directly impact game performance. This includes Terrain Rendering (getTerrainNameAt, getName, getTexture), where strings are accessed per tile every frame; Unit Templates and UI (getUpgradeCameoName, getNthName, getNthTag), which are evaluated constantly for HUD refreshes; and Map Logic (getSourceFilename, Waypoint, and Trigger getters), which are processed every simulation tick. We also standardized Infrastructure calls (FileStream::open, TerrainVisual::load) to ensure data flows through the engine without redundant copies.

Rationale for Limited Scope

We intentionally limited this scope to ensure internal consistency and completeness. As the maintainer (xezon) noted, changing a function to return a reference is "incomplete" if the call sites still copy the result into a value-type variable. By focusing on these specific subsystems, we were able to verify and update every single call site to use const&, achieving 100% efficiency for these paths.

This change was generated with AI assistance. All generated code has been reviewed, tested, and verified for correctness.
Process and Methodology: The work followed a data-driven diagnostic path:
We used the Tracy Profiler to pinpoint high contention on TheAsciiStringCriticalSection during unit-heavy simulation steps.
Based on the profile, we systematically replaced high-frequency AsciiString value-passing with const AsciiString& references across TerrainLogic, Waypoint, and PolygonTrigger classes.
We performed a secondary audit to eliminate hidden copies in the file-system abstraction and internal search loops, ensuring a completely zero-copy string path for these logical systems.


