### PR TITLE
tweak(gamemessage): Remove unused argument of MSG_DESTROY_SELECTED_GROUP

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/MessageStream.h
+++ b/Generals/Code/GameEngine/Include/Common/MessageStream.h
@@ -472,7 +472,7 @@ public:
 																									* The selected team is created/augmented with the given team members.
 																									* Do not play their selection sounds.
 																									*/
-		MSG_DESTROY_SELECTED_GROUP,									///< (teamID) the given team is no longer valid
+		MSG_DESTROY_SELECTED_GROUP,									///< deselect currently selected objects (which can be none)
 		MSG_REMOVE_FROM_SELECTED_GROUP,							/**< (objectID1, objectID2, ... objectIDN)
 																									* Remove these units from the selected group. (N should almost always be 1)
 																									*/

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -3493,10 +3493,8 @@ void InGameUI::deselectAllDrawables( Bool postMsg )
 	the order of operations of things happening in the code (CBD) */
 	if( postMsg )
 	{
-		GameMessage *groupMsg = TheMessageStream->appendMessage( GameMessage::MSG_DESTROY_SELECTED_GROUP );
-
-		//True deletes entire group.
-		groupMsg->appendBooleanArgument( true );
+		// TheSuperHackers @tweak Originally this message had one boolean argument, but it wasn't used for anything.
+		TheMessageStream->appendMessage( GameMessage::MSG_DESTROY_SELECTED_GROUP );
 	}
 }
 

--- a/GeneralsMD/Code/GameEngine/Include/Common/MessageStream.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/MessageStream.h
@@ -503,7 +503,7 @@ public:
 																									* The selected team is created/augmented with the given team members.
 																									* Do not play their selection sounds.
 																									*/
-		MSG_DESTROY_SELECTED_GROUP,									///< (teamID) the given team is no longer valid
+		MSG_DESTROY_SELECTED_GROUP,									///< deselect currently selected objects (which can be none)
 		MSG_REMOVE_FROM_SELECTED_GROUP,							/**< (objectID1, objectID2, ... objectIDN)
 																									* Remove these units from the selected group. (N should almost always be 1)
 																									*/

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -3584,10 +3584,8 @@ void InGameUI::deselectAllDrawables( Bool postMsg )
 	the order of operations of things happening in the code (CBD) */
 	if( postMsg )
 	{
-		GameMessage *groupMsg = TheMessageStream->appendMessage( GameMessage::MSG_DESTROY_SELECTED_GROUP );
-
-		//True deletes entire group.
-		groupMsg->appendBooleanArgument( true );
+		// TheSuperHackers @tweak Originally this message had one boolean argument, but it wasn't used for anything.
+		TheMessageStream->appendMessage( GameMessage::MSG_DESTROY_SELECTED_GROUP );
 	}
 }
 


### PR DESCRIPTION
This PR makes a small tweak to `GameMessage::MSG_DESTROY_SELECTED_GROUP`. It had an unused boolean argument, but it's called many times; on every left mouse click that's not on the HUD, actually. The removal should provide a modest reduction in the number of bytes that are stored in replays or sent across the network.

## TODO:
- [x] Replicate in Generals.