### PR TITLE
bugfix(lan): Fix crash when changing settings in the LAN lobby

### DIFF
--- a/Core/GameEngine/Include/GameNetwork/LANGameInfo.h
+++ b/Core/GameEngine/Include/GameNetwork/LANGameInfo.h
@@ -171,6 +171,7 @@ private:
 
 void LANDisplayGameList( GameWindow *gameListbox, LANGameInfo *gameList );	///< Displays the list of games in a listbox, preserving selections
 void LANEnableStartButton(Bool enabled);
+void LANDisableButtons();
 
 void LANDisplaySlotList();		///< Displays the slot list according to TheLANGameInfo
 void LANDisplayGameOptions();	///< Displays the game options according to TheLANGameInfo

--- a/Core/GameEngine/Source/GameNetwork/LANAPI.cpp
+++ b/Core/GameEngine/Source/GameNetwork/LANAPI.cpp
@@ -589,6 +589,13 @@ void LANAPI::update()
 		// m_gameStartTime is when the next message goes out
 		// m_gameStartSeconds is how many seconds remain in the message
 
+		if (m_gameStartSeconds == 1)
+		{
+			// TheSuperHackers @bugfix Disable LAN controls early to avoid a rare crash
+			// that may happen when using the buttons at the very last moment (after they're deinitialized).
+			LANDisableButtons();
+		}
+
 		RequestGameStartTimer( m_gameStartSeconds );
 	}
 	else if (m_gameStartTime && m_gameStartTime <= now)

--- a/Core/GameEngine/Source/GameNetwork/LANAPI.cpp
+++ b/Core/GameEngine/Source/GameNetwork/LANAPI.cpp
@@ -591,8 +591,8 @@ void LANAPI::update()
 
 		if (m_gameStartSeconds == 1)
 		{
-			// TheSuperHackers @bugfix Disable LAN controls early to avoid a rare crash
-			// that may happen when using the buttons at the very last moment (after they're deinitialized).
+			// TheSuperHackers @bugfix Disable LAN menu buttons early to avoid a rare crash
+			// that may happen when using the buttons at the last moment (after they're deinitialized).
 			LANDisableButtons();
 		}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanGameOptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanGameOptionsMenu.cpp
@@ -1152,9 +1152,13 @@ WindowMsgHandledType LanGameOptionsMenuSystem( GameWindow *window, UnsignedInt m
 			{
 				if (LANbuttonPushed)
 					break;
+
+				LANGameInfo* myGame = TheLAN->GetMyGame();
+				if (myGame->isGameInProgress())
+					return MSG_IGNORED;
+
 				GameWindow *control = (GameWindow *)mData1;
 				Int controlID = control->winGetWindowId();
-				LANGameInfo *myGame = TheLAN->GetMyGame();
 
         if ( controlID == comboBoxStartingCashID )
         {
@@ -1220,6 +1224,11 @@ WindowMsgHandledType LanGameOptionsMenuSystem( GameWindow *window, UnsignedInt m
 			{
 				if (LANbuttonPushed)
 					break;
+
+				LANGameInfo* myGame = TheLAN->GetMyGame();
+				if (myGame->isGameInProgress())
+					return MSG_IGNORED;
+
 				GameWindow *control = (GameWindow *)mData1;
 				Int controlID = control->winGetWindowId();
 
@@ -1270,7 +1279,7 @@ WindowMsgHandledType LanGameOptionsMenuSystem( GameWindow *window, UnsignedInt m
 						TheLAN->RequestAccept();
 
 						// Disable the accept button
-						EnableAcceptControls(TRUE, TheLAN->GetMyGame(), comboBoxPlayer, comboBoxColor, comboBoxPlayerTemplate,
+						EnableAcceptControls(TRUE, myGame, comboBoxPlayer, comboBoxColor, comboBoxPlayerTemplate,
 							comboBoxTeam, buttonAccept, buttonStart, buttonMapStartPosition);
 
 					}
@@ -1285,11 +1294,10 @@ WindowMsgHandledType LanGameOptionsMenuSystem( GameWindow *window, UnsignedInt m
 					{
 						if (controlID == buttonMapStartPositionID[i])
 						{
-							LANGameInfo *game = TheLAN->GetMyGame();
 							Int playerIdxInPos = -1;
 							for (Int j=0; j<MAX_SLOTS; ++j)
 							{
-								LANGameSlot *slot = game->getLANSlot(j);
+								LANGameSlot *slot = myGame->getLANSlot(j);
 								if (slot && slot->getStartPos() == i)
 								{
 									playerIdxInPos = j;
@@ -1298,8 +1306,8 @@ WindowMsgHandledType LanGameOptionsMenuSystem( GameWindow *window, UnsignedInt m
 							}
 							if (playerIdxInPos >= 0)
 							{
-								LANGameSlot *slot = game->getLANSlot(playerIdxInPos);
-								if (playerIdxInPos == game->getLocalSlotNum() || (game->amIHost() && slot && slot->isAI()))
+								LANGameSlot *slot = myGame->getLANSlot(playerIdxInPos);
+								if (playerIdxInPos == myGame->getLocalSlotNum() || (myGame->amIHost() && slot && slot->isAI()))
 								{
 									// it's one of my type.  Try to change it.
 									Int nextPlayer = getNextSelectablePlayer(playerIdxInPos+1);
@@ -1315,7 +1323,7 @@ WindowMsgHandledType LanGameOptionsMenuSystem( GameWindow *window, UnsignedInt m
 								// nobody in the slot - put us in
 								Int nextPlayer = getNextSelectablePlayer(0);
 								if (nextPlayer < 0)
-									nextPlayer = getFirstSelectablePlayer(game);
+									nextPlayer = getFirstSelectablePlayer(myGame);
 								handleStartPositionSelection(nextPlayer, i);
 							}
 						}
@@ -1330,17 +1338,21 @@ WindowMsgHandledType LanGameOptionsMenuSystem( GameWindow *window, UnsignedInt m
 			if (LANbuttonPushed)
 				break;
 
+			LANGameInfo* myGame = TheLAN->GetMyGame();
+			if (myGame->isGameInProgress())
+				return MSG_IGNORED;
+
 			GameWindow *control = (GameWindow *)mData1;
 			Int controlID = control->winGetWindowId();
+
 			for (Int i = 0; i < MAX_SLOTS; i++)
 			{
 				if (controlID == buttonMapStartPositionID[i])
 				{
-					LANGameInfo *game = TheLAN->GetMyGame();
 					Int playerIdxInPos = -1;
 					for (Int j=0; j<MAX_SLOTS; ++j)
 					{
-						LANGameSlot *slot = game->getLANSlot(j);
+						LANGameSlot *slot = myGame->getLANSlot(j);
 						if (slot && slot->getStartPos() == i)
 						{
 							playerIdxInPos = j;
@@ -1349,8 +1361,8 @@ WindowMsgHandledType LanGameOptionsMenuSystem( GameWindow *window, UnsignedInt m
 					}
 					if (playerIdxInPos >= 0)
 					{
-						LANGameSlot *slot = game->getLANSlot(playerIdxInPos);
-						if (playerIdxInPos == game->getLocalSlotNum() || (game->amIHost() && slot && slot->isAI()))
+						LANGameSlot *slot = myGame->getLANSlot(playerIdxInPos);
+						if (playerIdxInPos == myGame->getLocalSlotNum() || (myGame->amIHost() && slot && slot->isAI()))
 						{
 							// it's one of my type.  Remove it.
 							handleStartPositionSelection(playerIdxInPos, -1);
@@ -1365,6 +1377,11 @@ WindowMsgHandledType LanGameOptionsMenuSystem( GameWindow *window, UnsignedInt m
 			{
 				if (LANbuttonPushed)
 					break;
+
+				LANGameInfo* myGame = TheLAN->GetMyGame();
+				if (myGame->isGameInProgress())
+					return MSG_IGNORED;
+
 				GameWindow *control = (GameWindow *)mData1;
 				Int controlID = control->winGetWindowId();
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanGameOptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanGameOptionsMenu.cpp
@@ -389,6 +389,25 @@ void LANEnableStartButton(Bool enabled)
 	buttonSelectMap->winEnable(enabled);
 }
 
+void LANDisableButtons()
+{
+	buttonStart->winEnable(false);
+	buttonBack->winEnable(false);
+	buttonSelectMap->winEnable(false);
+	checkboxLimitSuperweapons->winEnable(false);
+	comboBoxStartingCash->winEnable(false);
+
+	for (Int i = 0; i < MAX_SLOTS; ++i)
+	{
+		comboBoxPlayer[i]->winEnable(false);
+		comboBoxColor[i]->winEnable(false);
+		comboBoxPlayerTemplate[i]->winEnable(false);
+		comboBoxTeam[i]->winEnable(false);
+		buttonAccept[i]->winEnable(false);
+		buttonMapStartPosition[i]->winEnable(false);
+	}
+}
+
 static void handleColorSelection(int index)
 {
 	GameWindow *combo = comboBoxColor[index];

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanGameOptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/LanGameOptionsMenu.cpp
@@ -1171,13 +1171,9 @@ WindowMsgHandledType LanGameOptionsMenuSystem( GameWindow *window, UnsignedInt m
 			{
 				if (LANbuttonPushed)
 					break;
-
-				LANGameInfo* myGame = TheLAN->GetMyGame();
-				if (myGame->isGameInProgress())
-					return MSG_IGNORED;
-
 				GameWindow *control = (GameWindow *)mData1;
 				Int controlID = control->winGetWindowId();
+				LANGameInfo *myGame = TheLAN->GetMyGame();
 
         if ( controlID == comboBoxStartingCashID )
         {
@@ -1243,11 +1239,6 @@ WindowMsgHandledType LanGameOptionsMenuSystem( GameWindow *window, UnsignedInt m
 			{
 				if (LANbuttonPushed)
 					break;
-
-				LANGameInfo* myGame = TheLAN->GetMyGame();
-				if (myGame->isGameInProgress())
-					return MSG_IGNORED;
-
 				GameWindow *control = (GameWindow *)mData1;
 				Int controlID = control->winGetWindowId();
 
@@ -1298,7 +1289,7 @@ WindowMsgHandledType LanGameOptionsMenuSystem( GameWindow *window, UnsignedInt m
 						TheLAN->RequestAccept();
 
 						// Disable the accept button
-						EnableAcceptControls(TRUE, myGame, comboBoxPlayer, comboBoxColor, comboBoxPlayerTemplate,
+						EnableAcceptControls(TRUE, TheLAN->GetMyGame(), comboBoxPlayer, comboBoxColor, comboBoxPlayerTemplate,
 							comboBoxTeam, buttonAccept, buttonStart, buttonMapStartPosition);
 
 					}
@@ -1313,10 +1304,11 @@ WindowMsgHandledType LanGameOptionsMenuSystem( GameWindow *window, UnsignedInt m
 					{
 						if (controlID == buttonMapStartPositionID[i])
 						{
+							LANGameInfo *game = TheLAN->GetMyGame();
 							Int playerIdxInPos = -1;
 							for (Int j=0; j<MAX_SLOTS; ++j)
 							{
-								LANGameSlot *slot = myGame->getLANSlot(j);
+								LANGameSlot *slot = game->getLANSlot(j);
 								if (slot && slot->getStartPos() == i)
 								{
 									playerIdxInPos = j;
@@ -1325,8 +1317,8 @@ WindowMsgHandledType LanGameOptionsMenuSystem( GameWindow *window, UnsignedInt m
 							}
 							if (playerIdxInPos >= 0)
 							{
-								LANGameSlot *slot = myGame->getLANSlot(playerIdxInPos);
-								if (playerIdxInPos == myGame->getLocalSlotNum() || (myGame->amIHost() && slot && slot->isAI()))
+								LANGameSlot *slot = game->getLANSlot(playerIdxInPos);
+								if (playerIdxInPos == game->getLocalSlotNum() || (game->amIHost() && slot && slot->isAI()))
 								{
 									// it's one of my type.  Try to change it.
 									Int nextPlayer = getNextSelectablePlayer(playerIdxInPos+1);
@@ -1342,7 +1334,7 @@ WindowMsgHandledType LanGameOptionsMenuSystem( GameWindow *window, UnsignedInt m
 								// nobody in the slot - put us in
 								Int nextPlayer = getNextSelectablePlayer(0);
 								if (nextPlayer < 0)
-									nextPlayer = getFirstSelectablePlayer(myGame);
+									nextPlayer = getFirstSelectablePlayer(game);
 								handleStartPositionSelection(nextPlayer, i);
 							}
 						}
@@ -1357,21 +1349,17 @@ WindowMsgHandledType LanGameOptionsMenuSystem( GameWindow *window, UnsignedInt m
 			if (LANbuttonPushed)
 				break;
 
-			LANGameInfo* myGame = TheLAN->GetMyGame();
-			if (myGame->isGameInProgress())
-				return MSG_IGNORED;
-
 			GameWindow *control = (GameWindow *)mData1;
 			Int controlID = control->winGetWindowId();
-
 			for (Int i = 0; i < MAX_SLOTS; i++)
 			{
 				if (controlID == buttonMapStartPositionID[i])
 				{
+					LANGameInfo *game = TheLAN->GetMyGame();
 					Int playerIdxInPos = -1;
 					for (Int j=0; j<MAX_SLOTS; ++j)
 					{
-						LANGameSlot *slot = myGame->getLANSlot(j);
+						LANGameSlot *slot = game->getLANSlot(j);
 						if (slot && slot->getStartPos() == i)
 						{
 							playerIdxInPos = j;
@@ -1380,8 +1368,8 @@ WindowMsgHandledType LanGameOptionsMenuSystem( GameWindow *window, UnsignedInt m
 					}
 					if (playerIdxInPos >= 0)
 					{
-						LANGameSlot *slot = myGame->getLANSlot(playerIdxInPos);
-						if (playerIdxInPos == myGame->getLocalSlotNum() || (myGame->amIHost() && slot && slot->isAI()))
+						LANGameSlot *slot = game->getLANSlot(playerIdxInPos);
+						if (playerIdxInPos == game->getLocalSlotNum() || (game->amIHost() && slot && slot->isAI()))
 						{
 							// it's one of my type.  Remove it.
 							handleStartPositionSelection(playerIdxInPos, -1);
@@ -1396,11 +1384,6 @@ WindowMsgHandledType LanGameOptionsMenuSystem( GameWindow *window, UnsignedInt m
 			{
 				if (LANbuttonPushed)
 					break;
-
-				LANGameInfo* myGame = TheLAN->GetMyGame();
-				if (myGame->isGameInProgress())
-					return MSG_IGNORED;
-
 				GameWindow *control = (GameWindow *)mData1;
 				Int controlID = control->winGetWindowId();
 


### PR DESCRIPTION
It's currently possible to crash the game with a well-timed option change in the LAN lobby / options menu. The game calls `DeinitLanGameGadgets`, which sets a few button pointers to `nullptr`, when the countdown is somewhere between 1 and game start. If the options are changed after this (but before the game the actually starts), the game crashes because it attempts to dereference the pointers.

~This PR adds a few checks in `LanGameOptionsMenuSystem` to ignore such changes.~ This PR disables the LAN buttons early, before they're deinitialized, to prevent the host from using them at the last moment.

### Callstack for `DeinitLanGameGadgets`:
```
generalszh.exe!DeinitLanGameGadgets()
generalszh.exe!shutdownComplete(WindowLayout * layout)
generalszh.exe!LanGameOptionsMenuShutdown(WindowLayout * layout, void * userData)
generalszh.exe!WindowLayout::runShutdown(void * userData)
generalszh.exe!Shell::hideShell()
generalszh.exe!GameLogic::prepareNewGame(GameMode gameMode, GameDifficulty diff, int rankPoints)
generalszh.exe!GameLogic::logicMessageDispatcher(GameMessage * msg, void * userData)
generalszh.exe!GameLogic::processCommandList(CommandList * list)
generalszh.exe!GameLogic::update()
generalszh.exe!SubsystemInterface::UPDATE()
generalszh.exe!GameEngine::update()
generalszh.exe!Win32GameEngine::update()
generalszh.exe!GameEngine::execute()
generalszh.exe!GameMain()
generalszh.exe!WinMain(HINSTANCE__ * hInstance, HINSTANCE__ * hPrevInstance, char * lpCmdLine, int nCmdShow)
```

### Callstack for crash (in this case changing the super weapon limit):
```
generalszh.exe!GadgetCheckBoxIsChecked(GameWindow * g)
generalszh.exe!handleLimitSuperweaponsClick()
generalszh.exe!LanGameOptionsMenuSystem(GameWindow * window, unsigned int msg, unsigned int mData1, unsigned int mData2)
generalszh.exe!GameWindowManager::winSendSystemMsg(GameWindow * window, unsigned int msg, unsigned int mData1, unsigned int mData2)
generalszh.exe!PassMessagesToParentSystem(GameWindow * window, unsigned int msg, unsigned int mData1, unsigned int mData2)
generalszh.exe!GameWindowManager::winSendSystemMsg(GameWindow * window, unsigned int msg, unsigned int mData1, unsigned int mData2)
generalszh.exe!GadgetCheckBoxInput(GameWindow * window, unsigned int msg, unsigned int mData1, unsigned int mData2)
generalszh.exe!GameWindowManager::winSendInputMsg(GameWindow * window, unsigned int msg, unsigned int mData1, unsigned int mData2)
generalszh.exe!GameWindowManager::winProcessMouseEvent(GameWindowMessage msg, ICoord2D * mousePos, void * data)
generalszh.exe!WindowTranslator::translateGameMessage(const GameMessage * msg)
generalszh.exe!MessageStream::propagateMessages()
generalszh.exe!GameEngine::update()
generalszh.exe!Win32GameEngine::update()
generalszh.exe!GameEngine::execute()
generalszh.exe!GameMain()
generalszh.exe!WinMain(HINSTANCE__ * hInstance, HINSTANCE__ * hPrevInstance, char * lpCmdLine, int nCmdShow)
```

## TODO:
- [ ] Replicate in Generals.