### PR TITLE
build(docker): Set correct targets in docker-build.sh

### DIFF
--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -59,7 +59,7 @@ Build Generals/Zero Hour on Linux using Docker (produces Windows executables).
 Options:
     -h, --help          Show this help message
     -g, --game GAME     Build specific game: 'zh' (Zero Hour), 'generals', or 'all' (default: all)
-    -t, --target TARGET Build specific CMake target (e.g., generalszh, WorldBuilderZH)
+    -t, --target TARGET Build specific CMake target (e.g., z_generals, z_worldbuilder)
     -c, --clean         Clean build directory before building
     -i, --interactive   Enter container shell for debugging
     --cmake             Force CMake reconfiguration

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -9,7 +9,7 @@
 #   ./scripts/docker-build.sh                  # Full build (both games)
 #   ./scripts/docker-build.sh --game zh        # Build Zero Hour only
 #   ./scripts/docker-build.sh --game generals  # Build Generals only
-#   ./scripts/docker-build.sh --target generalszh  # Build specific target
+#   ./scripts/docker-build.sh --target z_generals  # Build specific target
 #   ./scripts/docker-build.sh --clean          # Clean build directory
 #   ./scripts/docker-build.sh --interactive    # Enter container shell
 #
@@ -68,7 +68,7 @@ Options:
 Examples:
     $(basename "$0")                      # Build everything
     $(basename "$0") --game zh            # Build Zero Hour only
-    $(basename "$0") --target generalszh  # Build Zero Hour executable only
+    $(basename "$0") --target z_generals  # Build Zero Hour executable only
     $(basename "$0") --clean --game all   # Clean and rebuild everything
     $(basename "$0") --interactive        # Enter container for debugging
 
@@ -250,10 +250,10 @@ done
 if [[ -z "$TARGET" ]]; then
     case "$GAME" in
         zh|zerohour)
-            TARGET="generalszh generalszh_tools"
+            TARGET="z_generals z_worldbuilder core_particleeditor core_debugwindow z_guiedit z_imagepacker z_mapcachebuilder z_w3dview z_wdump"
             ;;
         generals)
-            TARGET="generalsv generalsv_tools"
+            TARGET="g_generals g_worldbuilder core_particleeditor core_debugwindow g_guiedit g_imagepacker g_mapcachebuilder g_w3dview"
             ;;
         all)
             TARGET=""  # Build all


### PR DESCRIPTION
Relates to #2085

In the script comments and usage section, it says that `./scripts/docker-build.sh --target generalszh` should be used to build Generals ZH. As no such target exists, the build fails with `ninja: error: unknown target 'generalszh'`.  Moreover, the script allows to build both `generalszh.exe` and the ZH tools via `--game zh` instead of `--target` but it derives the wrong targets if that option is used. Thus, this PR fixes the script to set the correct targets and updates the comment and usage sections accordingly. 

I also want to note that there is a [wiki page](https://github.com/TheSuperHackers/GeneralsGameCode/wiki/build_on_linux) describing how to use the `docker-build.sh` script. This will need to be updated as well. From what I can see, it would be sufficient to replace `--target generalszh` with `--target z_generals`. However, I would suggest removing these instructions from the wiki page and instead referring to the usage section of the script to improve maintainability.