### PR TITLE
bugfix(controlbar): Show shortcut special powers in Generals again

### DIFF
--- a/Generals/Code/GameEngine/Include/GameClient/ControlBar.h
+++ b/Generals/Code/GameEngine/Include/GameClient/ControlBar.h
@@ -700,6 +700,8 @@ public:
 	void hidePurchaseScience();
 	void togglePurchaseScience();
 
+	Bool hasAnyShortcutSelection() const;
+	Bool canShowSpecialPowerShortcut() const;
 	void showSpecialPowerShortcut();
 	void hideSpecialPowerShortcut();
 	void animateSpecialPowerShortcut( Bool isOn );
@@ -783,8 +785,6 @@ public:
 	void triggerRadarAttackGlow();
 
 	void drawSpecialPowerShortcutMultiplierText();
-
-	Bool hasAnyShortcutSelection() const;
 
 protected:
 	void updateRadarAttackGlow ();

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -3558,8 +3558,8 @@ Bool ControlBar::hasAnyShortcutSelection() const
 Bool ControlBar::canShowSpecialPowerShortcut() const
 {
 #ifdef RTS_GENERALS
-	// Special Powers in Generals do not have the ShortcutPower flag set and therefore
-	// this function needs to assumes that shortcut special powers come from the Command Center.
+	// Special Powers in Generals do not have the ShortcutPower flag set and therefore this function
+	// is satisfied with the presence of a Command Center, which is supposed to host Special Powers.
 	if (ThePlayerList->getLocalPlayer()->findNaturalCommandCenter() != nullptr)
 		return true;
 #endif

--- a/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -3555,16 +3555,32 @@ Bool ControlBar::hasAnyShortcutSelection() const
 }
 
 //-------------------------------------------------------------------------------------------------
+Bool ControlBar::canShowSpecialPowerShortcut() const
+{
+#ifdef RTS_GENERALS
+	// Special Powers in Generals do not have the ShortcutPower flag set and therefore
+	// this function needs to assumes that shortcut special powers come from the Command Center.
+	if (ThePlayerList->getLocalPlayer()->findNaturalCommandCenter() != nullptr)
+		return true;
+#endif
+
+	if (hasAnyShortcutSelection())
+		return true;
+
+	if (ThePlayerList->getLocalPlayer()->hasAnyShortcutSpecialPower())
+		return true;
+
+	return false;
+}
+
+//-------------------------------------------------------------------------------------------------
 void ControlBar::updateSpecialPowerShortcut()
 {
 	if(!m_specialPowerShortcutParent || !m_specialPowerShortcutButtons
 	   || !ThePlayerList || !ThePlayerList->getLocalPlayer())
 		return;
 
-	Bool hasShortcutSelectionButtons = hasAnyShortcutSelection();
-	Bool hasAnyShortcutSpecialPower = ThePlayerList->getLocalPlayer()->hasAnyShortcutSpecialPower();
-
-	Bool hasValidShortcutButton = hasShortcutSelectionButtons || hasAnyShortcutSpecialPower;
+	const Bool hasValidShortcutButton = canShowSpecialPowerShortcut();
 
 	if( hasValidShortcutButton
 		  && m_specialPowerShortcutParent->winIsHidden()
@@ -3776,7 +3792,7 @@ void ControlBar::showSpecialPowerShortcut()
 			break;
 		}
 	}
-	if( dontAnimate || (!ThePlayerList->getLocalPlayer()->hasAnyShortcutSpecialPower() && !hasAnyShortcutSelection()) )
+	if( dontAnimate || !canShowSpecialPowerShortcut() )
 		return;
 	m_specialPowerShortcutParent->winHide(FALSE);
 	populateSpecialPowerShortcut(ThePlayerList->getLocalPlayer());

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/ControlBar.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/ControlBar.h
@@ -700,6 +700,8 @@ public:
 	void hidePurchaseScience();
 	void togglePurchaseScience();
 
+	Bool hasAnyShortcutSelection() const;
+	Bool canShowSpecialPowerShortcut() const;
 	void showSpecialPowerShortcut();
 	void hideSpecialPowerShortcut();
 	void animateSpecialPowerShortcut( Bool isOn );
@@ -783,8 +785,6 @@ public:
 	void triggerRadarAttackGlow();
 
 	void drawSpecialPowerShortcutMultiplierText();
-
-	Bool hasAnyShortcutSelection() const;
 
 protected:
 	void updateRadarAttackGlow ();

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -3558,8 +3558,8 @@ Bool ControlBar::hasAnyShortcutSelection() const
 Bool ControlBar::canShowSpecialPowerShortcut() const
 {
 #ifdef RTS_GENERALS
-	// Special Powers in Generals do not have the ShortcutPower flag set and therefore
-	// this function needs to assumes that shortcut special powers come from the Command Center.
+	// Special Powers in Generals do not have the ShortcutPower flag set and therefore this function
+	// is satisfied with the presence of a Command Center, which is supposed to host Special Powers.
 	if (ThePlayerList->getLocalPlayer()->findNaturalCommandCenter() != nullptr)
 		return true;
 #endif

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/ControlBar/ControlBar.cpp
@@ -3555,16 +3555,32 @@ Bool ControlBar::hasAnyShortcutSelection() const
 }
 
 //-------------------------------------------------------------------------------------------------
+Bool ControlBar::canShowSpecialPowerShortcut() const
+{
+#ifdef RTS_GENERALS
+	// Special Powers in Generals do not have the ShortcutPower flag set and therefore
+	// this function needs to assumes that shortcut special powers come from the Command Center.
+	if (ThePlayerList->getLocalPlayer()->findNaturalCommandCenter() != nullptr)
+		return true;
+#endif
+
+	if (hasAnyShortcutSelection())
+		return true;
+
+	if (ThePlayerList->getLocalPlayer()->hasAnyShortcutSpecialPower())
+		return true;
+
+	return false;
+}
+
+//-------------------------------------------------------------------------------------------------
 void ControlBar::updateSpecialPowerShortcut()
 {
 	if(!m_specialPowerShortcutParent || !m_specialPowerShortcutButtons
 	   || !ThePlayerList || !ThePlayerList->getLocalPlayer())
 		return;
 
-	Bool hasShortcutSelectionButtons = hasAnyShortcutSelection();
-	Bool hasAnyShortcutSpecialPower = ThePlayerList->getLocalPlayer()->hasAnyShortcutSpecialPower();
-
-	Bool hasValidShortcutButton = hasShortcutSelectionButtons || hasAnyShortcutSpecialPower;
+	const Bool hasValidShortcutButton = canShowSpecialPowerShortcut();
 
 	if( hasValidShortcutButton
 		  && m_specialPowerShortcutParent->winIsHidden()
@@ -3776,7 +3792,7 @@ void ControlBar::showSpecialPowerShortcut()
 			break;
 		}
 	}
-	if( dontAnimate || (!ThePlayerList->getLocalPlayer()->hasAnyShortcutSpecialPower() && !hasAnyShortcutSelection()) )
+	if( dontAnimate || !canShowSpecialPowerShortcut() )
 		return;
 	m_specialPowerShortcutParent->winHide(FALSE);
 	populateSpecialPowerShortcut(ThePlayerList->getLocalPlayer());


### PR DESCRIPTION
* Follow up for #2655

#2655 broke the Shortcut special powers in Generals. Reason being, Generals does not have the "ShortcutPower" flags set in the INI files.

To support the legacy setup, Generals is satisfied with the presence of the command center again.