### PR TITLE
perf(hashmap): Reduce hashmap access overhead within getRelationship() functions

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Player.cpp
@@ -540,10 +540,9 @@ Relationship Player::getRelationship(const Team *that) const
 		// do we have an override for that particular team? if so, return it.
 		if (!m_teamRelations->m_map.empty())
 		{
-			TeamRelationMapType::const_iterator it = m_teamRelations->m_map.find(that->getID());
-			if (it != m_teamRelations->m_map.end())
+			if (m_teamRelations->m_map.count(that->getID()))
 			{
-				return (*it).second;
+				return m_teamRelations->m_map[that->getID()];
 			}
 		}
 
@@ -553,10 +552,9 @@ Relationship Player::getRelationship(const Team *that) const
 			const Player* thatPlayer = that->getControllingPlayer();
 			if (thatPlayer != nullptr)
 			{
-				PlayerRelationMapType::const_iterator it = m_playerRelations->m_map.find(thatPlayer->getPlayerIndex());
-				if (it != m_playerRelations->m_map.end())
+				if (m_playerRelations->m_map.count(thatPlayer->getPlayerIndex()))
 				{
-					return (*it).second;
+					return m_playerRelations->m_map[thatPlayer->getPlayerIndex()];
 				}
 			}
 		}

--- a/GeneralsMD/Code/GameEngine/Source/Common/RTS/Team.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/RTS/Team.cpp
@@ -1471,10 +1471,9 @@ Relationship Team::getRelationship(const Team *that) const
 	// do we have an override for that particular team? if so, return it.
 	if (!m_teamRelations->m_map.empty() && that != nullptr)
 	{
-		TeamRelationMapType::const_iterator it = m_teamRelations->m_map.find(that->getID());
-		if (it != m_teamRelations->m_map.end())
+		if (m_teamRelations->m_map.count(that->getID()))
 		{
-			return (*it).second;
+			return m_teamRelations->m_map[that->getID()];
 		}
 	}
 
@@ -1484,10 +1483,9 @@ Relationship Team::getRelationship(const Team *that) const
 		Player* thatPlayer = that->getControllingPlayer();
 		if (thatPlayer != nullptr)
 		{
-			PlayerRelationMapType::const_iterator it = m_playerRelations->m_map.find(thatPlayer->getPlayerIndex());
-			if (it != m_playerRelations->m_map.end())
+			if (m_playerRelations->m_map.count(thatPlayer->getPlayerIndex()))
 			{
-				return (*it).second;
+				return m_playerRelations->m_map[thatPlayer->getPlayerIndex()];
 			}
 		}
 	}


### PR DESCRIPTION
This PR reduces the access overhead within the `Team` and `Player` class `getRelationship()` functions.

The main cause of overhead was due to the use of iterators and the find function.

as we only care about retrieving a value from the hashmap, we only need to determine if the key exists using the `count` function and then retrieve the value from the key with the `[ ]` brackets based access functionality.

The `count` function is safe to use to determine if a key is present in this instance, as a hash_map only allows unique keys.
So for our purposes it acts as a boolean flag to determine if the key is present.


Some Flame graphs to show comparisons, this was within a pathfinding heavy test map run within a VS22 debug build.
I also have the retail compatible insertion sorting code commented out in this instance to help make the `getRelationship()` function access more visible.

Before the change:
<img width="1721" height="478" alt="image" src="https://github.com/user-attachments/assets/55cfeaa2-69b2-4010-91cf-ccc154713b0d" />
<img width="1720" height="548" alt="image" src="https://github.com/user-attachments/assets/081b18af-8e35-431b-9c59-6e040c86e7a5" />
The circled box is also a `Player::getRelationship()` function call with ~4% cpu usage.
<img width="1052" height="447" alt="image" src="https://github.com/user-attachments/assets/faae681c-131e-4eda-b509-8639c016d99b" />


After the change:
<img width="1725" height="400" alt="image" src="https://github.com/user-attachments/assets/5c3a96c9-b9e6-4ec9-bf2b-709cb334272e" />

---

- [ ] Replicate in generals