### PR TITLE
bugfix(input): Revert changes to local group creation

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -3415,26 +3415,6 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 		}
 
 		// --------------------------------------------------------------------------------------------
-		case GameMessage::MSG_CREATE_TEAM0:
-		case GameMessage::MSG_CREATE_TEAM1:
-		case GameMessage::MSG_CREATE_TEAM2:
-		case GameMessage::MSG_CREATE_TEAM3:
-		case GameMessage::MSG_CREATE_TEAM4:
-		case GameMessage::MSG_CREATE_TEAM5:
-		case GameMessage::MSG_CREATE_TEAM6:
-		case GameMessage::MSG_CREATE_TEAM7:
-		case GameMessage::MSG_CREATE_TEAM8:
-		case GameMessage::MSG_CREATE_TEAM9:
-		{
-			Int playerIndex = msg->getPlayerIndex();
-			Player* player = ThePlayerList->getNthPlayer(playerIndex);
-			if (player && player->isLocalPlayer())
-				player->processCreateTeamGameMessage(t - GameMessage::MSG_CREATE_TEAM0, msg);
-
-			break;
-		}
-
-		// --------------------------------------------------------------------------------------------
 		case GameMessage::MSG_CREATE_SELECTED_GROUP:
 		case GameMessage::MSG_SELECT_TEAM0:
 		case GameMessage::MSG_SELECT_TEAM1:

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -1985,10 +1985,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 		case GameMessage::MSG_CREATE_TEAM8:
 		case GameMessage::MSG_CREATE_TEAM9:
 		{
-			// TheSuperHackers @tweak Stubbjax 17/08/2025 The local player processes this message in CommandXlat for immediate assignment.
-			if (!msgPlayer->isLocalPlayer())
-				msgPlayer->processCreateTeamGameMessage(msg->getType() - GameMessage::MSG_CREATE_TEAM0, msg);
-
+			msgPlayer->processCreateTeamGameMessage(msg->getType() - GameMessage::MSG_CREATE_TEAM0, msg);
 			break;
 		}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -3744,26 +3744,6 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 		}
 
 		// --------------------------------------------------------------------------------------------
-		case GameMessage::MSG_CREATE_TEAM0:
-		case GameMessage::MSG_CREATE_TEAM1:
-		case GameMessage::MSG_CREATE_TEAM2:
-		case GameMessage::MSG_CREATE_TEAM3:
-		case GameMessage::MSG_CREATE_TEAM4:
-		case GameMessage::MSG_CREATE_TEAM5:
-		case GameMessage::MSG_CREATE_TEAM6:
-		case GameMessage::MSG_CREATE_TEAM7:
-		case GameMessage::MSG_CREATE_TEAM8:
-		case GameMessage::MSG_CREATE_TEAM9:
-		{
-			Int playerIndex = msg->getPlayerIndex();
-			Player* player = ThePlayerList->getNthPlayer(playerIndex);
-			if (player && player->isLocalPlayer())
-				player->processCreateTeamGameMessage(t - GameMessage::MSG_CREATE_TEAM0, msg);
-
-			break;
-		}
-
-		// --------------------------------------------------------------------------------------------
 		case GameMessage::MSG_CREATE_SELECTED_GROUP:
 		case GameMessage::MSG_SELECT_TEAM0:
 		case GameMessage::MSG_SELECT_TEAM1:

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -2018,10 +2018,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 		case GameMessage::MSG_CREATE_TEAM8:
 		case GameMessage::MSG_CREATE_TEAM9:
 		{
-			// TheSuperHackers @tweak Stubbjax 17/08/2025 The local player processes this message in CommandXlat for immediate assignment.
-			if (!msgPlayer->isLocalPlayer())
-				msgPlayer->processCreateTeamGameMessage(msg->getType() - GameMessage::MSG_CREATE_TEAM0, msg);
-
+			msgPlayer->processCreateTeamGameMessage(msg->getType() - GameMessage::MSG_CREATE_TEAM0, msg);
 			break;
 		}
 


### PR DESCRIPTION
* Follow up for #1471
* Closes issue https://github.com/TheSuperHackers/GeneralsGameCode/issues/2660

Local group creation is not logically safe and can cause mismatches. This PR reverts previous changes, so that group creation is only handled by the Logic and not the Client.

## TODO:
- [x] Replicate in Generals.