### PR TITLE
fix(network): Verify accepted type of incoming game messages

### DIFF
--- a/Core/GameEngine/Include/GameNetwork/NetCommandMsg.h
+++ b/Core/GameEngine/Include/GameNetwork/NetCommandMsg.h
@@ -174,6 +174,7 @@ public:
 	GameMessage *constructGameMessage() const;
 	void addArgument(const GameMessageArgumentDataType type, GameMessageArgumentType arg);
 	void setGameMessageType(GameMessage::Type type);
+	GameMessage::Type getGameMessageType() const;
 
 	virtual Select getSmallNetPacketSelect() const override;
 

--- a/Core/GameEngine/Source/GameNetwork/NetCommandMsg.cpp
+++ b/Core/GameEngine/Source/GameNetwork/NetCommandMsg.cpp
@@ -224,6 +224,10 @@ void NetGameCommandMsg::setGameMessageType(GameMessage::Type type) {
 	m_type = type;
 }
 
+GameMessage::Type NetGameCommandMsg::getGameMessageType() const {
+	return m_type;
+}
+
 NetCommandMsg::Select NetGameCommandMsg::getSmallNetPacketSelect() const {
 	Select select;
 	select.useCommandType = 1;

--- a/Core/GameEngine/Source/GameNetwork/Network.cpp
+++ b/Core/GameEngine/Source/GameNetwork/Network.cpp
@@ -586,16 +586,17 @@ void Network::RelayCommandsToCommandList(UnsignedInt frame) {
 	while (msg != nullptr) {
 		NetCommandType cmdType = msg->getCommand()->getNetCommandType();
 		if (cmdType == NETCOMMANDTYPE_GAMECOMMAND) {
-			GameMessage *gmsg = ((NetGameCommandMsg *)msg->getCommand())->constructGameMessage();
+			GameMessage* gmsg = static_cast<NetGameCommandMsg*>(msg->getCommand())->constructGameMessage();
 #if RETAIL_COMPATIBLE_CRC
 			TheCommandList->appendMessage(gmsg);
 #else
+			// TheSuperHackers @fix stephanmeesters 14/05/2026 Verify allowed network type of incoming GameMessages
 			if (isTransferCommand(gmsg)) {
 				//DEBUG_LOG(("Network::RelayCommandsToCommandList - appending command %d of type %s to command list on frame %d", msg->getCommand()->getID(), gmsg->getCommandAsString(), TheGameLogic->getFrame()));
 				TheCommandList->appendMessage(gmsg);
 			} else {
 				DEBUG_LOG(("Network::RelayCommandsToCommandList - rejecting GameMessage from player %d of type %s, which is not a valid networking type.",
-					msg->getCommand()->getPlayerID(), gmsg->getCommandAsString()));
+					gmsg->getPlayerIndex(), gmsg->getCommandAsString()));
 				deleteInstance(gmsg);
 			}
 #endif

--- a/Core/GameEngine/Source/GameNetwork/Network.cpp
+++ b/Core/GameEngine/Source/GameNetwork/Network.cpp
@@ -183,7 +183,7 @@ protected:
 	void SendCommandsToConnectionManager();												///< Send the new commands to the ConnectionManager
 	Bool AllCommandsReady(UnsignedInt frame);											///< Do we have all the commands for the given frame?
 	void RelayCommandsToCommandList(UnsignedInt frame);						///< Put the commands for the given frame onto TheCommandList.
-	Bool isTransferCommand(GameMessage *msg);											///< Is this a command that needs to be transfered to the other clients?
+	static Bool isMessageTypeWithinNetworkRange(GameMessage::Type type);
 	Bool processCommand(GameMessage *msg);												///< Whatever needs to be done as a result of this command, do it now.
 	void processFrameSynchronizedNetCommand(NetCommandRef *msg);	///< If there is a network command that needs to be executed at the same frame number on all clients, it happens here.
 	void processRunAheadCommand(NetRunAheadCommandMsg *msg);			///< Do what needs to be done when we get a new run ahead command.
@@ -446,14 +446,8 @@ void Network::attachTransport(Transport *transport) {
 	}
 }
 
-/**
- * Does this command need to be transfered to the other game clients?
- */
-Bool Network::isTransferCommand(GameMessage *msg) {
-	if ((msg != nullptr) && ((msg->getType() > GameMessage::MSG_BEGIN_NETWORK_MESSAGES) && (msg->getType() < GameMessage::MSG_END_NETWORK_MESSAGES))) {
-		return TRUE;
-	}
-	return FALSE;
+Bool Network::isMessageTypeWithinNetworkRange(GameMessage::Type type) {
+	return type > GameMessage::MSG_BEGIN_NETWORK_MESSAGES && type < GameMessage::MSG_END_NETWORK_MESSAGES;
 }
 
 /**
@@ -464,7 +458,7 @@ void Network::GetCommandsFromCommandList() {
 	GameMessage *next = nullptr;
 	while (msg != nullptr) {
 		next = msg->next();
-		if (isTransferCommand(msg)) { // Is this something we should be sending to the other players?
+		if (isMessageTypeWithinNetworkRange(msg->getType())) { // Is this something we should be sending to the other players?
 			if (m_localStatus == NETLOCALSTATUS_INGAME) {
 				m_conMgr->sendLocalGameMessage(msg, getExecutionFrame());
 			}
@@ -586,18 +580,17 @@ void Network::RelayCommandsToCommandList(UnsignedInt frame) {
 	while (msg != nullptr) {
 		NetCommandType cmdType = msg->getCommand()->getNetCommandType();
 		if (cmdType == NETCOMMANDTYPE_GAMECOMMAND) {
-			GameMessage* gmsg = static_cast<NetGameCommandMsg*>(msg->getCommand())->constructGameMessage();
+			NetGameCommandMsg* gmsg = static_cast<NetGameCommandMsg*>(msg->getCommand());
 #if RETAIL_COMPATIBLE_CRC
-			TheCommandList->appendMessage(gmsg);
+			TheCommandList->appendMessage(gmsg->constructGameMessage());
 #else
-			// TheSuperHackers @fix stephanmeesters 14/05/2026 Verify allowed network type of incoming GameMessages
-			if (isTransferCommand(gmsg)) {
+			// TheSuperHackers @fix stephanmeesters 14/05/2026 Verify accepted type of incoming game messages
+			if (isMessageTypeWithinNetworkRange(gmsg->getGameMessageType())) {
 				//DEBUG_LOG(("Network::RelayCommandsToCommandList - appending command %d of type %s to command list on frame %d", msg->getCommand()->getID(), gmsg->getCommandAsString(), TheGameLogic->getFrame()));
-				TheCommandList->appendMessage(gmsg);
+				TheCommandList->appendMessage(gmsg->constructGameMessage());
 			} else {
-				DEBUG_LOG(("Network::RelayCommandsToCommandList - rejecting GameMessage from player %d of type %s, which is not a valid network type.",
-					gmsg->getPlayerIndex(), gmsg->getCommandAsString()));
-				deleteInstance(gmsg);
+				DEBUG_LOG(("Network::RelayCommandsToCommandList - rejecting game message from player %d of type %s, which is not a network type.",
+					gmsg->getPlayerID(), GameMessage::getCommandTypeAsString(gmsg->getGameMessageType())));
 			}
 #endif
 		} else {

--- a/Core/GameEngine/Source/GameNetwork/Network.cpp
+++ b/Core/GameEngine/Source/GameNetwork/Network.cpp
@@ -595,7 +595,7 @@ void Network::RelayCommandsToCommandList(UnsignedInt frame) {
 				//DEBUG_LOG(("Network::RelayCommandsToCommandList - appending command %d of type %s to command list on frame %d", msg->getCommand()->getID(), gmsg->getCommandAsString(), TheGameLogic->getFrame()));
 				TheCommandList->appendMessage(gmsg);
 			} else {
-				DEBUG_LOG(("Network::RelayCommandsToCommandList - rejecting GameMessage from player %d of type %s, which is not a valid networking type.",
+				DEBUG_LOG(("Network::RelayCommandsToCommandList - rejecting GameMessage from player %d of type %s, which is not a valid network type.",
 					gmsg->getPlayerIndex(), gmsg->getCommandAsString()));
 				deleteInstance(gmsg);
 			}

--- a/Core/GameEngine/Source/GameNetwork/Network.cpp
+++ b/Core/GameEngine/Source/GameNetwork/Network.cpp
@@ -586,8 +586,15 @@ void Network::RelayCommandsToCommandList(UnsignedInt frame) {
 	while (msg != nullptr) {
 		NetCommandType cmdType = msg->getCommand()->getNetCommandType();
 		if (cmdType == NETCOMMANDTYPE_GAMECOMMAND) {
-			//DEBUG_LOG(("Network::RelayCommandsToCommandList - appending command %d of type %s to command list on frame %d", msg->getCommand()->getID(), ((NetGameCommandMsg *)msg->getCommand())->constructGameMessage()->getCommandAsString(), TheGameLogic->getFrame()));
-			TheCommandList->appendMessage(((NetGameCommandMsg *)msg->getCommand())->constructGameMessage());
+			GameMessage *gmsg = ((NetGameCommandMsg *)msg->getCommand())->constructGameMessage();
+			if (isTransferCommand(gmsg)) {
+				//DEBUG_LOG(("Network::RelayCommandsToCommandList - appending command %d of type %s to command list on frame %d", msg->getCommand()->getID(), gmsg->getCommandAsString(), TheGameLogic->getFrame()));
+				TheCommandList->appendMessage(gmsg);
+			} else {
+				DEBUG_LOG(("Network::RelayCommandsToCommandList - rejecting GameMessage from player %d of type %s, which is not a valid networking type.",
+					msg->getCommand()->getPlayerID(), gmsg->getCommandAsString()));
+				deleteInstance(gmsg);
+			}
 		} else {
 			processFrameSynchronizedNetCommand(msg);
 		}

--- a/Core/GameEngine/Source/GameNetwork/Network.cpp
+++ b/Core/GameEngine/Source/GameNetwork/Network.cpp
@@ -587,6 +587,9 @@ void Network::RelayCommandsToCommandList(UnsignedInt frame) {
 		NetCommandType cmdType = msg->getCommand()->getNetCommandType();
 		if (cmdType == NETCOMMANDTYPE_GAMECOMMAND) {
 			GameMessage *gmsg = ((NetGameCommandMsg *)msg->getCommand())->constructGameMessage();
+#if RETAIL_COMPATIBLE_CRC
+			TheCommandList->appendMessage(gmsg);
+#else
 			if (isTransferCommand(gmsg)) {
 				//DEBUG_LOG(("Network::RelayCommandsToCommandList - appending command %d of type %s to command list on frame %d", msg->getCommand()->getID(), gmsg->getCommandAsString(), TheGameLogic->getFrame()));
 				TheCommandList->appendMessage(gmsg);
@@ -595,6 +598,7 @@ void Network::RelayCommandsToCommandList(UnsignedInt frame) {
 					msg->getCommand()->getPlayerID(), gmsg->getCommandAsString()));
 				deleteInstance(gmsg);
 			}
+#endif
 		} else {
 			processFrameSynchronizedNetCommand(msg);
 		}


### PR DESCRIPTION
Currently outgoing `GameMessage`'s are checked using `Network::isTransferCommand` but incoming messages are not checked, which can potentially enable certain cheats. Credits to Caball for pointing this out.