### PR TITLE
bugfix(aigroup): Prevent game crash when a player is selected in Replay playback (2)

### DIFF
--- a/Core/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/Core/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -2120,7 +2120,7 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 	}
 
 #if RETAIL_COMPATIBLE_AIGROUP
-	// TheSuperHackers @bugfix xezon/Caball009 14/05/2026 This hack avoids crashing when players are selected during Replay playback.
+	// TheSuperHackers @bugfix xezon/Caball009 14/05/2026 This fix avoids crashing when players are selected during Replay playback.
 	// The current AI group may have been destroyed, and its memory deallocated, in which case it shouldn't be used.
 	if (currentlySelectedGroup && !TheAI->doesGroupExist(currentlySelectedGroup))
 		return;

--- a/Core/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
+++ b/Core/GameEngine/Source/GameLogic/System/GameLogicDispatch.cpp
@@ -2120,10 +2120,9 @@ void GameLogic::logicMessageDispatcher( GameMessage *msg, void *userData )
 	}
 
 #if RETAIL_COMPATIBLE_AIGROUP
-	// TheSuperHackers @bugfix xezon 28/06/2025 This hack avoids crashing when players are selected during Replay playback.
-	// It can read data from an already deleted AIGroup and return this function when its member size is 0, signifying that
-	// it is indeed deleted.
-	if (currentlySelectedGroup && currentlySelectedGroup->getCount() == 0)
+	// TheSuperHackers @bugfix xezon/Caball009 14/05/2026 This hack avoids crashing when players are selected during Replay playback.
+	// The current AI group may have been destroyed, and its memory deallocated, in which case it shouldn't be used.
+	if (currentlySelectedGroup && !TheAI->doesGroupExist(currentlySelectedGroup))
 		return;
 #endif
 

--- a/Generals/Code/GameEngine/Include/GameLogic/AI.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AI.h
@@ -273,7 +273,7 @@ public:
 	AIGroupPtr createGroup(); ///< instantiate a new AI Group
 	void destroyGroup( AIGroup *group );	///< destroy the given AI Group
 	AIGroup *findGroup( UnsignedInt id );	///< return the AI Group with the given ID
-	Bool doesGroupExist(AIGroup* group); ///< return whether the given AI Group exists, i.e. is part of the group list
+	Bool doesGroupExist(AIGroup* group) const; ///< return whether the given AI Group exists, i.e. is part of the group list
 
 	// Formation info
 	enum FormationID getNextFormationID();

--- a/Generals/Code/GameEngine/Include/GameLogic/AI.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AI.h
@@ -273,6 +273,7 @@ public:
 	AIGroupPtr createGroup(); ///< instantiate a new AI Group
 	void destroyGroup( AIGroup *group );	///< destroy the given AI Group
 	AIGroup *findGroup( UnsignedInt id );	///< return the AI Group with the given ID
+	Bool doesGroupExist(AIGroup* group); ///< return whether the given AI Group exists, i.e. is part of the group list
 
 	// Formation info
 	enum FormationID getNextFormationID();

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AI.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AI.cpp
@@ -494,6 +494,11 @@ AIGroup *AI::findGroup( UnsignedInt id )
 	return nullptr;
 }
 
+Bool AI::doesGroupExist(AIGroup* group)
+{
+	return std::find(m_groupList.begin(), m_groupList.end(), group) != m_groupList.end();
+}
+
 //--------------------------------------------------------------------------------------------------------
 /**
  * Get the next formation id.

--- a/Generals/Code/GameEngine/Source/GameLogic/AI/AI.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/AI/AI.cpp
@@ -494,7 +494,7 @@ AIGroup *AI::findGroup( UnsignedInt id )
 	return nullptr;
 }
 
-Bool AI::doesGroupExist(AIGroup* group)
+Bool AI::doesGroupExist(AIGroup* group) const
 {
 	return std::find(m_groupList.begin(), m_groupList.end(), group) != m_groupList.end();
 }

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
@@ -279,7 +279,7 @@ public:
 	AIGroupPtr createGroup(); ///< instantiate a new AI Group
 	void destroyGroup( AIGroup *group );	///< destroy the given AI Group
 	AIGroup *findGroup( UnsignedInt id );	///< return the AI Group with the given ID
-	Bool doesGroupExist(AIGroup* group); ///< return whether the given AI Group exists, i.e. is part of the group list
+	Bool doesGroupExist(AIGroup* group) const; ///< return whether the given AI Group exists, i.e. is part of the group list
 
 	// Formation info
 	enum FormationID getNextFormationID();

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/AI.h
@@ -279,6 +279,7 @@ public:
 	AIGroupPtr createGroup(); ///< instantiate a new AI Group
 	void destroyGroup( AIGroup *group );	///< destroy the given AI Group
 	AIGroup *findGroup( UnsignedInt id );	///< return the AI Group with the given ID
+	Bool doesGroupExist(AIGroup* group); ///< return whether the given AI Group exists, i.e. is part of the group list
 
 	// Formation info
 	enum FormationID getNextFormationID();

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AI.cpp
@@ -497,7 +497,7 @@ AIGroup *AI::findGroup( UnsignedInt id )
 	return nullptr;
 }
 
-Bool AI::doesGroupExist(AIGroup* group)
+Bool AI::doesGroupExist(AIGroup* group) const
 {
 	return std::find(m_groupList.begin(), m_groupList.end(), group) != m_groupList.end();
 }

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/AI/AI.cpp
@@ -497,6 +497,11 @@ AIGroup *AI::findGroup( UnsignedInt id )
 	return nullptr;
 }
 
+Bool AI::doesGroupExist(AIGroup* group)
+{
+	return std::find(m_groupList.begin(), m_groupList.end(), group) != m_groupList.end();
+}
+
 //--------------------------------------------------------------------------------------------------------
 /**
  * Get the next formation id.


### PR DESCRIPTION
* Follow up for PR https://github.com/TheSuperHackers/GeneralsGameCode/pull/1212

With the fix from #1212 `AIGroupPtr currentlySelectedGroup` would be accessed even if it had been destroyed and its memory deallocated. This is a use-after-free bug. It relies on the memory not being overwritten on deallocation. 

If macro `MEMORYPOOL_DEBUG` (enabled by `RTS_DEBUG`) is enabled, freed memory is overwritten with a garbage value, so the game crashes when `currentlySelectedGroup` is dereferenced (at line 2132).

## TODO:
- [x] Tweak TSH comment.
- [x] Replicate in Generals.