### PR TITLE
fix(milesaudiomanager): Prevent multithread crashing in MilesAudioManager

### DIFF
--- a/Core/GameEngine/Include/Common/GameAudio.h
+++ b/Core/GameEngine/Include/Common/GameAudio.h
@@ -177,11 +177,10 @@ class AudioManager : public SubsystemInterface
 		AsciiString prevTrackName(const AsciiString& currentTrack );
 
 		// changing music tracks
-		virtual void nextMusicTrack() = 0;
-		virtual void prevMusicTrack() = 0;
+		virtual AsciiString nextMusicTrack() = 0;
+		virtual AsciiString prevMusicTrack() = 0;
 		virtual Bool isMusicPlaying() const = 0;
 		virtual Bool hasMusicTrackCompleted( const AsciiString& trackName, Int numberOfTimes ) const = 0;
-		virtual AsciiString getMusicTrackName() const = 0;
 
 		virtual void setAudioEventEnabled( AsciiString eventToAffect, Bool enable );
 		virtual void setAudioEventVolumeOverride( AsciiString eventToAffect, Real newVolume );

--- a/Core/GameEngineDevice/Include/MilesAudioDevice/MilesAudioManager.h
+++ b/Core/GameEngineDevice/Include/MilesAudioDevice/MilesAudioManager.h
@@ -40,7 +40,6 @@ enum PlayingStatus CPP_11(: Int)
 {
 	PS_Playing,
 	PS_Stopped,
-	PS_Paused
 };
 
 enum PlayingWhich CPP_11(: Int)
@@ -60,22 +59,24 @@ struct PlayingAudio
 		HSTREAM m_stream;
 	};
 
-	PlayingAudioType m_type;
-	volatile PlayingStatus m_status;	// This member is adjusted by another running thread.
 	AudioEventRTS *m_audioEventRTS;
-	void *m_file;		// The file that was opened to play this
+	void *m_file; // The file that was opened to play this
+	PlayingAudioType m_type;
+	volatile PlayingStatus m_status; // This member is adjusted by another running thread.
+	Int m_framesFaded;
 	Bool m_requestStop;
 	Bool m_cleanupAudioEventRTS;
-	Int m_framesFaded;
 
-	PlayingAudio() :
-		m_type(PAT_INVALID),
-		m_audioEventRTS(nullptr),
-		m_requestStop(false),
-		m_cleanupAudioEventRTS(true),
-		m_sample(nullptr),
-		m_framesFaded(0)
-	{ }
+	PlayingAudio()
+		: m_sample(nullptr)
+		, m_audioEventRTS(nullptr)
+		, m_file(nullptr)
+		, m_type(PAT_INVALID)
+		, m_status(PS_Playing)
+		, m_framesFaded(0)
+		, m_requestStop(false)
+		, m_cleanupAudioEventRTS(true)
+	{}
 };
 
 struct ProviderInfo
@@ -114,7 +115,7 @@ class AudioFileCache
 		// End Protected by mutex
 
 		// Note: These functions should be used for informational purposes only. For speed reasons,
-		// they are not protected by the mutex, so they are not guarenteed to be valid if called from
+		// they are not protected by the mutex, so they are not guaranteed to be valid if called from
 		// outside the audio cache. They should be used as a rough estimate only.
 		UnsignedInt getCurrentlyUsedSize() const { return m_currentlyUsedSize; }
 		UnsignedInt getMaxSize() const { return m_maxSize; }
@@ -150,12 +151,10 @@ class MilesAudioManager : public AudioManager
 		MilesAudioManager();
 		virtual ~MilesAudioManager() override;
 
-
-		virtual void nextMusicTrack() override;
-		virtual void prevMusicTrack() override;
+		virtual AsciiString nextMusicTrack() override;
+		virtual AsciiString prevMusicTrack() override;
 		virtual Bool isMusicPlaying() const override;
 		virtual Bool hasMusicTrackCompleted( const AsciiString& trackName, Int numberOfTimes ) const override;
-		virtual AsciiString getMusicTrackName() const override;
 
 		virtual void openDevice() override;
 		virtual void closeDevice() override;
@@ -172,8 +171,8 @@ class MilesAudioManager : public AudioManager
 		///< NOTE NOTE NOTE !!DO NOT USE THIS IN FOR GAMELOGIC PURPOSES!! NOTE NOTE NOTE
 		virtual Bool isCurrentlyPlaying( AudioHandle handle ) override;
 
-		virtual void notifyOfAudioCompletion( UnsignedInt audioCompleted, UnsignedInt flags ) override;
-		virtual PlayingAudio *findPlayingAudioFrom( UnsignedInt audioCompleted, UnsignedInt flags );
+		virtual void notifyOfAudioCompletion( UnsignedInt handle, UnsignedInt flags ) override;
+		virtual PlayingAudio *findPlayingAudioFrom( UnsignedInt handle, UnsignedInt flags );
 
 		virtual UnsignedInt getProviderCount() const override;
 		virtual AsciiString getProviderName( UnsignedInt providerNum ) const override;
@@ -208,7 +207,6 @@ class MilesAudioManager : public AudioManager
 		virtual void processRequestList() override;
 		virtual void processPlayingList();
 		virtual void processFadingList();
-		virtual void processStoppedList();
 
 		Bool shouldProcessRequestThisFrame( AudioRequest *req ) const;
 		void adjustRequest( AudioRequest *req );
@@ -243,7 +241,6 @@ class MilesAudioManager : public AudioManager
 		void *playSample( AudioEventRTS *event, HSAMPLE sample );
 		void *playSample3D( AudioEventRTS *event, H3DSAMPLE sample3D );
 
-	protected:
 		void buildProviderList();
 		void createListener();
 		void initDelayFilter();
@@ -262,6 +259,9 @@ class MilesAudioManager : public AudioManager
 		void releaseMilesHandles( PlayingAudio *release );
 		void releasePlayingAudio( PlayingAudio *release );
 
+		PlayingAudio *findActiveMusic( const AsciiString *trackName = nullptr );
+		const PlayingAudio *findActiveMusic( const AsciiString* trackName = nullptr ) const;
+
 		void stopAllAudioImmediately();
 		void freeAllMilesHandles();
 
@@ -272,7 +272,6 @@ class MilesAudioManager : public AudioManager
 
 		void stopAllSpeech();
 
-	protected:
 		void initFilters( HSAMPLE sample, AudioEventRTS *eventInfo );
 		void initFilters3D( H3DSAMPLE sample, AudioEventRTS *eventInfo, const Coord3D *pos );
 
@@ -298,22 +297,15 @@ class MilesAudioManager : public AudioManager
 		std::list<HSAMPLE> m_availableSamples;
 		std::list<H3DSAMPLE> m_available3DSamples;
 
-		// Currently Playing stuff. Useful if we have to preempt it.
+		// Currently Playing audio. Useful if we have to preempt it.
 		// This should rarely if ever happen, as we mirror this in Sounds, and attempt to
 		// keep preemption from taking place here.
 		std::list<PlayingAudio *> m_playingSounds;
 		std::list<PlayingAudio *> m_playing3DSounds;
 		std::list<PlayingAudio *> m_playingStreams;
 
-		// Currently fading stuff. At this point, we just want to let it finish fading, when it is
-		// done it should be added to the completed list, then "freed" and the counts should be updated
-		// on the next update
+		// Currently fading music. We just let it finish fading, then release it.
 		std::list<PlayingAudio *> m_fadingAudio;
-
-		// Stuff that is done playing (either because it has finished or because it was killed)
-		// This stuff should be cleaned up during the next update cycle. This includes updating counts
-		// in the sound engine
-		std::list<PlayingAudio *> m_stoppedAudio;
 
 		AudioFileCache *m_audioCache;
 		PlayingAudio *m_binkHandle;
@@ -343,17 +335,16 @@ class MilesAudioManagerDummy : public MilesAudioManager
 	virtual void resumeAudio(AudioAffect which) override {}
 	virtual void pauseAmbient(Bool shouldPause) override {}
 	virtual void killAudioEventImmediately(AudioHandle audioEvent) override {}
-	virtual void nextMusicTrack() override {}
-	virtual void prevMusicTrack() override {}
+	virtual AsciiString nextMusicTrack() override { return AsciiString::TheEmptyString; }
+	virtual AsciiString prevMusicTrack() override { return AsciiString::TheEmptyString; }
 	virtual Bool isMusicPlaying() const override { return false; }
 	virtual Bool hasMusicTrackCompleted(const AsciiString& trackName, Int numberOfTimes) const override { return false; }
-	virtual AsciiString getMusicTrackName() const override { return ""; }
 	//virtual void openDevice() override {}
 	//virtual void closeDevice() override {}
 	//virtual void* getDevice() override { return nullptr; }
 	virtual void notifyOfAudioCompletion(UnsignedInt audioCompleted, UnsignedInt flags) override {}
 	virtual UnsignedInt getProviderCount() const override { return 0; };
-	virtual AsciiString getProviderName(UnsignedInt providerNum) const override { return ""; }
+	virtual AsciiString getProviderName(UnsignedInt providerNum) const override { return AsciiString::TheEmptyString; }
 	virtual UnsignedInt getProviderIndex(AsciiString providerName) const override { return 0; }
 	virtual void selectProvider(UnsignedInt providerNdx) override {}
 	virtual void unselectProvider() override {}

--- a/Core/GameEngineDevice/Include/MilesAudioDevice/MilesAudioManager.h
+++ b/Core/GameEngineDevice/Include/MilesAudioDevice/MilesAudioManager.h
@@ -23,6 +23,7 @@
 #include "Common/AsciiString.h"
 #include "Common/GameAudio.h"
 #include "mss/mss.h"
+#include "mutex.h"
 
 class AudioEventRTS;
 
@@ -39,7 +40,8 @@ enum PlayingAudioType CPP_11(: Int)
 enum PlayingStatus CPP_11(: Int)
 {
 	PS_Playing,
-	PS_Stopped,
+	PS_Stopping, ///< Is about to be stopped
+	PS_Stopped, ///< Is about to be released
 };
 
 enum PlayingWhich CPP_11(: Int)
@@ -63,8 +65,8 @@ struct PlayingAudio
 	void *m_file; // The file that was opened to play this
 	PlayingAudioType m_type;
 	volatile PlayingStatus m_status; // This member is adjusted by another running thread.
-	Int m_framesFaded;
-	Bool m_requestStop;
+	Short m_framesFaded;
+	Bool m_fade;
 	Bool m_cleanupAudioEventRTS;
 
 	PlayingAudio()
@@ -74,9 +76,11 @@ struct PlayingAudio
 		, m_type(PAT_INVALID)
 		, m_status(PS_Playing)
 		, m_framesFaded(0)
-		, m_requestStop(false)
+		, m_fade(false)
 		, m_cleanupAudioEventRTS(true)
 	{}
+
+	static_assert(sizeof(m_status) == sizeof(long), "Must be size of long, because it is used with Interlocked functions");
 };
 
 struct ProviderInfo
@@ -258,10 +262,13 @@ class MilesAudioManager : public AudioManager
 		PlayingAudio *allocatePlayingAudio();
 		void releaseMilesHandles( PlayingAudio *release );
 		void releasePlayingAudio( PlayingAudio *release );
+		void stopPlayingAudio( PlayingAudio *release );
+		void fadePlayingAudio( PlayingAudio *playing );
 
 		PlayingAudio *findActiveMusic( const AsciiString *trackName = nullptr );
 		const PlayingAudio *findActiveMusic( const AsciiString* trackName = nullptr ) const;
 
+		void releasePlayingAudioInListIfStopped(std::list<PlayingAudio *> &list, CriticalSectionClass &cs);
 		void stopAllAudioImmediately();
 		void freeAllMilesHandles();
 
@@ -306,6 +313,13 @@ class MilesAudioManager : public AudioManager
 
 		// Currently fading music. We just let it finish fading, then release it.
 		std::list<PlayingAudio *> m_fadingAudio;
+
+		// TheSuperHackers @fix Erasing from PlayingAudio lists on main thread is not safe when the MSS Timer thread
+		// needs to iterate the same lists. The critical sections are used to guard writes that will invalidate iterators.
+		CriticalSectionClass m_playingSoundsCS;
+		CriticalSectionClass m_playing3DSoundsCS;
+		CriticalSectionClass m_playingStreamsCS;
+		CriticalSectionClass m_fadingAudioCS;
 
 		AudioFileCache *m_audioCache;
 		PlayingAudio *m_binkHandle;

--- a/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
+++ b/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
@@ -66,6 +66,8 @@
 
 #include "Common/file.h"
 
+#include <Utility/interlocked_adapter.h>
+
 
 enum { INFINITE_LOOP_COUNT = 1000000 };
 
@@ -475,18 +477,14 @@ void MilesAudioManager::stopAudio( AudioAffect which )
 	if (BitIsSet(which, AudioAffect_Sound)) {
 		for (it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it) {
 			playing = *it;
-			AIL_register_EOS_callback(playing->m_sample, nullptr);
-			AIL_stop_sample(playing->m_sample);
-			playing->m_status = PS_Stopped;
+			stopPlayingAudio(playing);
 		}
 	}
 
 	if (BitIsSet(which, AudioAffect_Sound3D)) {
 		for (it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it) {
 			playing = *it;
-			AIL_register_3D_EOS_callback(playing->m_3DSample, nullptr);
-			AIL_stop_3D_sample(playing->m_3DSample);
-			playing->m_status = PS_Stopped;
+			stopPlayingAudio(playing);
 		}
 	}
 
@@ -502,9 +500,7 @@ void MilesAudioManager::stopAudio( AudioAffect which )
 					continue;
 				}
 			}
-			AIL_register_stream_callback(playing->m_stream, nullptr);
-			AIL_pause_stream(playing->m_stream, 1);
-			playing->m_status = PS_Stopped;
+			stopPlayingAudio(playing);
 		}
 	}
 }
@@ -518,6 +514,7 @@ void MilesAudioManager::pauseAudio( AudioAffect which )
 	if (BitIsSet(which, AudioAffect_Sound)) {
 		for (it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it) {
 			playing = *it;
+			DEBUG_ASSERTCRASH(playing->m_sample, ("Sample is not expected to be null"));
 			AIL_stop_sample(playing->m_sample);
 		}
 	}
@@ -525,6 +522,7 @@ void MilesAudioManager::pauseAudio( AudioAffect which )
 	if (BitIsSet(which, AudioAffect_Sound3D)) {
 		for (it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it) {
 			playing = *it;
+			DEBUG_ASSERTCRASH(playing->m_sample, ("3D Sample is not expected to be null"));
 			AIL_stop_3D_sample(playing->m_3DSample);
 		}
 	}
@@ -541,7 +539,7 @@ void MilesAudioManager::pauseAudio( AudioAffect which )
 					continue;
 				}
 			}
-
+			DEBUG_ASSERTCRASH(playing->m_sample, ("Stream is not expected to be null"));
 			AIL_pause_stream(playing->m_stream, 1);
 		}
 	}
@@ -573,6 +571,7 @@ void MilesAudioManager::resumeAudio( AudioAffect which )
 	if (BitIsSet(which, AudioAffect_Sound)) {
 		for (it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it) {
 			playing = *it;
+			DEBUG_ASSERTCRASH(playing->m_sample, ("Sample is not expected to be null"));
 			AIL_resume_sample(playing->m_sample);
 		}
 	}
@@ -580,6 +579,7 @@ void MilesAudioManager::resumeAudio( AudioAffect which )
 	if (BitIsSet(which, AudioAffect_Sound3D)) {
 		for (it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it) {
 			playing = *it;
+			DEBUG_ASSERTCRASH(playing->m_3DSample, ("3D Sample is not expected to be null"));
 			AIL_resume_3D_sample(playing->m_3DSample);
 		}
 	}
@@ -596,6 +596,7 @@ void MilesAudioManager::resumeAudio( AudioAffect which )
 					continue;
 				}
 			}
+			DEBUG_ASSERTCRASH(playing->m_stream, ("Stream is not expected to be null"));
 			AIL_pause_stream(playing->m_stream, 0);
 		}
 	}
@@ -650,8 +651,7 @@ void MilesAudioManager::playAudioEvent( AudioRequest* req )
 					if (playing->m_audioEventRTS && playing->m_audioEventRTS->getPlayingHandle() == handleToKill)
 					{
 						//Release this streaming channel immediately because we are going to play another sound in it's place.
-						releasePlayingAudio(playing);
-						m_playingStreams.erase(it);
+						stopPlayingAudio(playing);
 						foundSoundToReplace = true;
 						break;
 					}
@@ -676,6 +676,8 @@ void MilesAudioManager::playAudioEvent( AudioRequest* req )
 	 			}
 				AIL_set_stream_volume_pan(stream, getEffectiveVolume(event), 0.5f);
 				playStream(event, stream);
+
+				CriticalSectionClass::LockClass lock(m_playingStreamsCS);
 				m_playingStreams.push_back(audio);
 				audio = nullptr;
 			}
@@ -703,8 +705,7 @@ void MilesAudioManager::playAudioEvent( AudioRequest* req )
 						if( playing->m_audioEventRTS && playing->m_audioEventRTS->getPlayingHandle() == handleToKill )
 						{
 							//Release this 3D sound channel immediately because we are going to play another sound in it's place.
-							releasePlayingAudio(playing);
-							m_playing3DSounds.erase(it);
+							stopPlayingAudio(playing);
 							foundSoundToReplace = true;
 							break;
 						}
@@ -736,7 +737,6 @@ void MilesAudioManager::playAudioEvent( AudioRequest* req )
 				audio->m_3DSample = sample3D;
 				audio->m_file = nullptr;
 				audio->m_type = PAT_3DSample;
-				m_playing3DSounds.push_back(audio);
 
 				if (sample3D) {
 					audio->m_file = playSample3D(event, sample3D);
@@ -745,13 +745,14 @@ void MilesAudioManager::playAudioEvent( AudioRequest* req )
 
 				if( !audio->m_file )
 				{
-					m_playing3DSounds.pop_back();
 					#ifdef INTENSIVE_AUDIO_DEBUG
 						DEBUG_LOG((" Killed (no handles available)"));
 					#endif
 				}
 				else
 				{
+					CriticalSectionClass::LockClass lock(m_playing3DSoundsCS);
+					m_playing3DSounds.push_back(audio);
 					audio = nullptr;
 					#ifdef INTENSIVE_AUDIO_DEBUG
 						DEBUG_LOG((" Playing."));
@@ -770,8 +771,7 @@ void MilesAudioManager::playAudioEvent( AudioRequest* req )
 						if (playing->m_audioEventRTS && playing->m_audioEventRTS->getPlayingHandle() == handleToKill)
 						{
 							//Release this 2D sound channel immediately because we are going to play another sound in it's place.
-							releasePlayingAudio(playing);
-							m_playingSounds.erase(it);
+							stopPlayingAudio(playing);
 							foundSoundToReplace = true;
 							break;
 						}
@@ -804,7 +804,6 @@ void MilesAudioManager::playAudioEvent( AudioRequest* req )
 				audio->m_sample = sample;
 				audio->m_file = nullptr;
 				audio->m_type = PAT_Sample;
-				m_playingSounds.push_back(audio);
 
 				if (sample) {
 					audio->m_file = playSample(event, sample);
@@ -815,14 +814,14 @@ void MilesAudioManager::playAudioEvent( AudioRequest* req )
 					#ifdef INTENSIVE_AUDIO_DEBUG
 						DEBUG_LOG((" Killed (no handles available)"));
 					#endif
-					m_playingSounds.pop_back();
 				} else {
+					CriticalSectionClass::LockClass lock(m_playingSoundsCS);
+					m_playingSounds.push_back(audio);
 					audio = nullptr;
+					#ifdef INTENSIVE_AUDIO_DEBUG
+						DEBUG_LOG((" Playing."));
+					#endif
 				}
-
-				#ifdef INTENSIVE_AUDIO_DEBUG
-					DEBUG_LOG((" Playing."));
-				#endif
 			}
 			break;
 		}
@@ -831,6 +830,7 @@ void MilesAudioManager::playAudioEvent( AudioRequest* req )
 	// If we were able to successfully play audio, then we set it to null above. (And it will be freed
 	// later. However, if audio is non-null at this point, then it must be freed.
 	if (audio) {
+		stopPlayingAudio(audio);
 		releasePlayingAudio(audio);
 	}
 }
@@ -844,7 +844,7 @@ void MilesAudioManager::stopAudioEvent( AudioHandle handle )
 
 	std::list<PlayingAudio *>::iterator it;
 	if ( handle == AHSV_StopTheMusic || handle == AHSV_StopTheMusicFade ) {
-		// for music, just find the currently playing music stream and kill it.
+		// for music, find and stop the currently playing music stream(s).
 		for ( it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it ) {
 			PlayingAudio *audio = (*it);
 
@@ -852,25 +852,22 @@ void MilesAudioManager::stopAudioEvent( AudioHandle handle )
 			{
 				if( handle == AHSV_StopTheMusicFade )
 				{
-					m_fadingAudio.push_back(audio);
+					fadePlayingAudio(audio);
 				}
 				else
 				{
-					//m_stoppedAudio.push_back(audio);
-					releasePlayingAudio( audio );
+					stopPlayingAudio(audio);
 				}
-				m_playingStreams.erase(it);
-				break;
 			}
 		}
+		return;
 	}
 
 	for ( it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it ) {
 		PlayingAudio *audio = (*it);
 
 		if (audio->m_audioEventRTS->getPlayingHandle() == handle) {
-			audio->m_requestStop = true;
-			notifyOfAudioCompletion((UnsignedInt)(audio->m_stream), PAT_Stream);
+			stopPlayingAudio(audio);
 			break;
 		}
 	}
@@ -879,7 +876,7 @@ void MilesAudioManager::stopAudioEvent( AudioHandle handle )
 		PlayingAudio *audio = (*it);
 
 		if (audio->m_audioEventRTS->getPlayingHandle() == handle) {
-			audio->m_requestStop = true;
+			stopPlayingAudio(audio);
 			break;
 		}
 	}
@@ -891,7 +888,7 @@ void MilesAudioManager::stopAudioEvent( AudioHandle handle )
 		#ifdef INTENSIVE_AUDIO_DEBUG
 			DEBUG_LOG((" (%s)", audio->m_audioEventRTS->getEventName()));
 		#endif
-			audio->m_requestStop = true;
+			stopPlayingAudio(audio);
 			break;
 		}
 	}
@@ -921,8 +918,7 @@ void MilesAudioManager::killAudioEventImmediately( AudioHandle audioEvent )
 
 		if( audio->m_audioEventRTS->getPlayingHandle() == audioEvent )
 		{
-			releasePlayingAudio( audio );
-			m_playing3DSounds.erase( it );
+			stopPlayingAudio(audio);
 			return;
 		}
 	}
@@ -934,8 +930,7 @@ void MilesAudioManager::killAudioEventImmediately( AudioHandle audioEvent )
 
 		if( audio->m_audioEventRTS->getPlayingHandle() == audioEvent )
 		{
-			releasePlayingAudio( audio );
-			m_playingSounds.erase( it );
+			stopPlayingAudio(audio);
 			return;
 		}
 	}
@@ -947,8 +942,7 @@ void MilesAudioManager::killAudioEventImmediately( AudioHandle audioEvent )
 
 		if( audio->m_audioEventRTS->getPlayingHandle() == audioEvent )
 		{
-			releasePlayingAudio( audio );
-			m_playingStreams.erase( it );
+			stopPlayingAudio(audio);
 			return;
 		}
 	}
@@ -993,6 +987,7 @@ void MilesAudioManager::releaseMilesHandles( PlayingAudio *release )
 				AIL_register_EOS_callback(release->m_sample, nullptr);
 				AIL_stop_sample(release->m_sample);
 				m_availableSamples.push_back(release->m_sample);
+				release->m_sample = nullptr;
 			}
 			break;
 		}
@@ -1002,6 +997,7 @@ void MilesAudioManager::releaseMilesHandles( PlayingAudio *release )
 				AIL_register_3D_EOS_callback(release->m_3DSample, nullptr);
 				AIL_stop_3D_sample(release->m_3DSample);
 				m_available3DSamples.push_back(release->m_3DSample);
+				release->m_3DSample = nullptr;
 			}
 			break;
 		}
@@ -1010,6 +1006,7 @@ void MilesAudioManager::releaseMilesHandles( PlayingAudio *release )
 			if (release->m_stream) {
 				AIL_register_stream_callback(release->m_stream, nullptr);
 				AIL_close_stream(release->m_stream);
+				release->m_stream = nullptr;
 			}
 			break;
 		}
@@ -1020,6 +1017,31 @@ void MilesAudioManager::releaseMilesHandles( PlayingAudio *release )
 //-------------------------------------------------------------------------------------------------
 void MilesAudioManager::releasePlayingAudio( PlayingAudio *release )
 {
+	DEBUG_ASSERTCRASH(release->m_status == PS_Stopped, ("PlayingAudio must be stopped by now"));
+	DEBUG_ASSERTCRASH(release->m_type == PAT_INVALID, ("PlayingAudio must be invalidated by now"));
+
+	if (release->m_file) {
+		closeFile(release->m_file);
+		release->m_file = nullptr;
+	}
+
+	if (release->m_cleanupAudioEventRTS) {
+		releaseAudioEventRTS(release->m_audioEventRTS);
+	}
+
+	delete release;
+}
+
+//-------------------------------------------------------------------------------------------------
+void MilesAudioManager::stopPlayingAudio( PlayingAudio *release )
+{
+	// Advance from Playing to Stopping
+	InterlockedCompareExchange(reinterpret_cast<volatile long*>(&release->m_status), PS_Stopping, PS_Playing);
+	// Advance from Stopping to Stopped
+	const long prevStatus = InterlockedCompareExchange(reinterpret_cast<volatile long*>(&release->m_status), PS_Stopped, PS_Stopping);
+	if (prevStatus != PS_Stopping) {
+		return;
+	}
 	if (release->m_audioEventRTS->getAudioEventInfo()->m_soundType == AT_SoundEffect) {
 		if (release->m_type == PAT_Sample) {
 			if (release->m_sample) {
@@ -1031,13 +1053,13 @@ void MilesAudioManager::releasePlayingAudio( PlayingAudio *release )
 			}
 		}
 	}
-	releaseMilesHandles(release);	// forces stop of this audio
-	closeFile( release->m_file );
-	if (release->m_cleanupAudioEventRTS) {
-		releaseAudioEventRTS(release->m_audioEventRTS);
-	}
-	delete release;
-	release = nullptr;
+	releaseMilesHandles(release);
+}
+
+//-------------------------------------------------------------------------------------------------
+void MilesAudioManager::fadePlayingAudio( PlayingAudio *playing )
+{
+	playing->m_fade = true;
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1048,6 +1070,9 @@ PlayingAudio *MilesAudioManager::findActiveMusic( const AsciiString* trackName )
 	for (it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it) {
 		playing = *it;
 		if (playing->m_status != PS_Playing) {
+			continue;
+		}
+		if (playing->m_fade) {
 			continue;
 		}
 		if (playing->m_audioEventRTS->getAudioEventInfo()->m_soundType != AT_Music) {
@@ -1067,35 +1092,70 @@ const PlayingAudio *MilesAudioManager::findActiveMusic( const AsciiString* track
 	return const_cast<MilesAudioManager*>(this)->findActiveMusic(trackName);
 }
 
+
+//-------------------------------------------------------------------------------------------------
+void MilesAudioManager::releasePlayingAudioInListIfStopped(std::list<PlayingAudio *> &list, CriticalSectionClass &cs)
+{
+	std::list<PlayingAudio *>::iterator it;
+	PlayingAudio *playing;
+	CriticalSectionClass::LockClass lock(cs);
+
+	for (it = list.begin(); it != list.end(); )
+	{
+		playing = (*it);
+
+		if (playing->m_status == PS_Stopped)
+		{
+			releasePlayingAudio(playing);
+			it = list.erase(it);
+			continue;
+		}
+
+		++it;
+	}
+}
+
 //-------------------------------------------------------------------------------------------------
 void MilesAudioManager::stopAllAudioImmediately()
 {
 	std::list<PlayingAudio *>::iterator it;
 	PlayingAudio *playing;
 
-	for (it = m_playingSounds.begin(); it != m_playingSounds.end(); ) {
-		playing = *it;
-		releasePlayingAudio(playing);
-		it = m_playingSounds.erase(it);
-	}
-
-	for (it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ) {
-		playing = *it;
-		releasePlayingAudio(playing);
-		it = m_playing3DSounds.erase(it);
-	}
-
-	for (it = m_playingStreams.begin(); it != m_playingStreams.end(); ) {
+	//
+	// Stop audio without locking. Calls into Miles.
+	//
+	for (it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it) {
 		playing = (*it);
-		releasePlayingAudio(playing);
-		it = m_playingStreams.erase(it);
+		stopPlayingAudio(playing);
 	}
 
-	for (it = m_fadingAudio.begin(); it != m_fadingAudio.end(); ) {
+	for (it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it) {
 		playing = (*it);
-		releasePlayingAudio(playing);
-		it = m_fadingAudio.erase(it);
+		stopPlayingAudio(playing);
 	}
+
+	for (it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it) {
+		playing = (*it);
+		stopPlayingAudio(playing);
+	}
+
+	for (it = m_fadingAudio.begin(); it != m_fadingAudio.end(); ++it) {
+		playing = (*it);
+		stopPlayingAudio(playing);
+	}
+
+	//
+	// Release audio with locking. Must not call into Miles!
+	//
+	releasePlayingAudioInListIfStopped(m_playingSounds, m_playingSoundsCS);
+	releasePlayingAudioInListIfStopped(m_playing3DSounds, m_playing3DSoundsCS);
+	releasePlayingAudioInListIfStopped(m_playingStreams, m_playingStreamsCS);
+	releasePlayingAudioInListIfStopped(m_fadingAudio, m_fadingAudioCS);
+
+	DEBUG_ASSERTCRASH(m_playingSounds.empty(), ("List is expected to be empty now"));
+	DEBUG_ASSERTCRASH(m_playing3DSounds.empty(), ("List is expected to be empty now"));
+	DEBUG_ASSERTCRASH(m_playingStreams.empty(), ("List is expected to be empty now"));
+	DEBUG_ASSERTCRASH(m_fadingAudio.empty(), ("List is expected to be empty now"));
 
 	std::list<HAUDIO>::iterator hit;
 	for (hit = m_audioForcePlayed.begin(); hit != m_audioForcePlayed.end(); ++hit) {
@@ -1188,13 +1248,10 @@ void MilesAudioManager::stopAllSpeech()
 {
 	std::list<PlayingAudio *>::iterator it;
 	PlayingAudio *playing;
-	for (it = m_playingStreams.begin(); it != m_playingStreams.end(); ) {
+	for (it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it) {
 		playing = (*it);
 		if (playing->m_audioEventRTS->getAudioEventInfo()->m_soundType == AT_Streaming) {
-			releasePlayingAudio(playing);
-			it = m_playingStreams.erase(it);
-		} else {
-			++it;
+			stopPlayingAudio(playing);
 		}
 	}
 
@@ -1447,7 +1504,8 @@ void MilesAudioManager::notifyOfAudioCompletion( UnsignedInt handle, UnsignedInt
 		}
 	}
 
-	playing->m_status = PS_Stopped;	// it will be cleaned up on the next frame update
+	// it will be cleaned up on the next frame update
+	InterlockedCompareExchange(reinterpret_cast<volatile long*>(&playing->m_status), PS_Stopping, PS_Playing);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1458,6 +1516,7 @@ PlayingAudio *MilesAudioManager::findPlayingAudioFrom( UnsignedInt handle, Unsig
 
 	if (flags == PAT_Sample) {
 		HSAMPLE sample = (HSAMPLE) handle;
+		CriticalSectionClass::LockClass lock(m_playingSoundsCS);
 		for (it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it) {
 			playing = *it;
 			if (playing->m_sample == sample) {
@@ -1468,6 +1527,7 @@ PlayingAudio *MilesAudioManager::findPlayingAudioFrom( UnsignedInt handle, Unsig
 
 	if (flags == PAT_3DSample) {
 		H3DSAMPLE sample3D = (H3DSAMPLE) handle;
+		CriticalSectionClass::LockClass lock(m_playing3DSoundsCS);
 		for (it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it) {
 			playing = *it;
 			if (playing->m_3DSample == sample3D) {
@@ -1478,10 +1538,22 @@ PlayingAudio *MilesAudioManager::findPlayingAudioFrom( UnsignedInt handle, Unsig
 
 	if (flags == PAT_Stream) {
 		HSTREAM stream = (HSTREAM) handle;
-		for (it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it) {
-			playing = *it;
-			if (playing->m_stream == stream) {
-				return playing;
+		{
+			CriticalSectionClass::LockClass lock(m_playingStreamsCS);
+			for (it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it) {
+				playing = *it;
+				if (playing->m_stream == stream) {
+					return playing;
+				}
+			}
+		}
+		{
+			CriticalSectionClass::LockClass lock(m_fadingAudioCS);
+			for (it = m_fadingAudio.begin(); it != m_fadingAudio.end(); ++it) {
+				playing = *it;
+				if (playing->m_stream == stream) {
+					return playing;
+				}
 			}
 		}
 	}
@@ -1923,8 +1995,7 @@ Bool MilesAudioManager::killLowestPrioritySoundImmediately( AudioEventRTS *event
 				if( playing->m_audioEventRTS && playing->m_audioEventRTS == lowestPriorityEvent )
 				{
 					//Release this 3D sound channel immediately because we are going to play another sound in it's place.
-					releasePlayingAudio( playing );
-					m_playing3DSounds.erase( it );
+					stopPlayingAudio(playing);
 					return TRUE;
 				}
 			}
@@ -1938,8 +2009,7 @@ Bool MilesAudioManager::killLowestPrioritySoundImmediately( AudioEventRTS *event
 				if( playing->m_audioEventRTS && playing->m_audioEventRTS == lowestPriorityEvent )
 				{
 					//Release this sound channel immediately because we are going to play another sound in it's place.
-					releasePlayingAudio( playing );
-					m_playingSounds.erase( it );
+					stopPlayingAudio(playing);
 					return TRUE;
 				}
 			}
@@ -1959,7 +2029,7 @@ void MilesAudioManager::adjustVolumeOfPlayingAudio(AsciiString eventName, Real n
 	for (it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it) {
 		playing = *it;
 		if (playing->m_audioEventRTS->getEventName() == eventName) {
-			// Adjust it
+			DEBUG_ASSERTCRASH(playing->m_sample, ("Sample is not expected to be null"));
 			playing->m_audioEventRTS->setVolume(newVolume);
 			AIL_sample_volume_pan(playing->m_sample, nullptr, &pan);
 			AIL_set_sample_volume_pan(playing->m_sample, getEffectiveVolume(playing->m_audioEventRTS), pan);
@@ -1969,7 +2039,7 @@ void MilesAudioManager::adjustVolumeOfPlayingAudio(AsciiString eventName, Real n
 	for (it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it) {
 		playing = *it;
 		if (playing->m_audioEventRTS->getEventName() == eventName) {
-			// Adjust it
+			DEBUG_ASSERTCRASH(playing->m_3DSample, ("3D Sample is not expected to be null"));
 			playing->m_audioEventRTS->setVolume(newVolume);
 			AIL_set_3D_sample_volume(playing->m_3DSample, getEffectiveVolume(playing->m_audioEventRTS));
 		}
@@ -1978,7 +2048,7 @@ void MilesAudioManager::adjustVolumeOfPlayingAudio(AsciiString eventName, Real n
 	for (it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it) {
 		playing = *it;
 		if (playing->m_audioEventRTS->getEventName() == eventName) {
-			// Adjust it
+			DEBUG_ASSERTCRASH(playing->m_stream, ("Stream is not expected to be null"));
 			playing->m_audioEventRTS->setVolume(newVolume);
 			AIL_stream_volume_pan(playing->m_stream, nullptr, &pan);
 			AIL_set_stream_volume_pan(playing->m_stream, getEffectiveVolume(playing->m_audioEventRTS), pan);
@@ -1993,45 +2063,30 @@ void MilesAudioManager::removePlayingAudio( AsciiString eventName )
 	std::list<PlayingAudio *>::iterator it;
 
 	PlayingAudio *playing = nullptr;
-	for( it = m_playingSounds.begin(); it != m_playingSounds.end(); )
+	for( it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it )
 	{
 		playing = *it;
 		if( playing->m_audioEventRTS->getEventName() == eventName )
 		{
-			releasePlayingAudio( playing );
-			it = m_playingSounds.erase(it);
-		}
-		else
-		{
-			it++;
+			stopPlayingAudio(playing);
 		}
 	}
 
-	for( it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); )
+	for( it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it )
 	{
 		playing = *it;
 		if( playing->m_audioEventRTS->getEventName() == eventName )
 		{
-			releasePlayingAudio( playing );
-			it = m_playing3DSounds.erase(it);
-		}
-		else
-		{
-			it++;
+			stopPlayingAudio(playing);
 		}
 	}
 
-	for( it = m_playingStreams.begin(); it != m_playingStreams.end(); )
+	for( it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it )
 	{
 		playing = *it;
 		if( playing->m_audioEventRTS->getEventName() == eventName )
 		{
-			releasePlayingAudio( playing );
-			it = m_playingStreams.erase(it);
-		}
-		else
-		{
-			it++;
+			stopPlayingAudio(playing);
 		}
 	}
 }
@@ -2042,45 +2097,30 @@ void MilesAudioManager::removeAllDisabledAudio()
 	std::list<PlayingAudio *>::iterator it;
 
 	PlayingAudio *playing = nullptr;
-	for( it = m_playingSounds.begin(); it != m_playingSounds.end(); )
+	for( it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it )
 	{
 		playing = *it;
 		if( playing->m_audioEventRTS->getVolume() == 0.0f )
 		{
-			releasePlayingAudio( playing );
-			it = m_playingSounds.erase(it);
-		}
-		else
-		{
-			it++;
+			stopPlayingAudio(playing);
 		}
 	}
 
-	for( it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); )
+	for( it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it )
 	{
 		playing = *it;
 		if( playing->m_audioEventRTS->getVolume() == 0.0f )
 		{
-			releasePlayingAudio( playing );
-			it = m_playing3DSounds.erase(it);
-		}
-		else
-		{
-			it++;
+			stopPlayingAudio(playing);
 		}
 	}
 
-	for( it = m_playingStreams.begin(); it != m_playingStreams.end(); )
+	for( it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it )
 	{
 		playing = *it;
 		if( playing->m_audioEventRTS->getVolume() == 0.0f )
 		{
-			releasePlayingAudio( playing );
-			it = m_playingStreams.erase(it);
-		}
-		else
-		{
-			it++;
+			stopPlayingAudio(playing);
 		}
 	}
 }
@@ -2108,107 +2148,122 @@ void MilesAudioManager::processRequestList()
 //-------------------------------------------------------------------------------------------------
 void MilesAudioManager::processPlayingList()
 {
-	// There are two types of processing we have to do here.
-	// 1. Move the item to the stopped list if it has become stopped.
-	// 2. Update the position of the audio if it is positional
 	std::list<PlayingAudio *>::iterator it;
 	PlayingAudio *playing;
 
-	for (it = m_playingSounds.begin(); it != m_playingSounds.end(); ) {
+	//
+	// Stop audio without locking. Calls into Miles.
+	// Update the position of the audio if it is positional.
+	//
+	for (it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it) {
 		playing = (*it);
 
-		if (playing->m_status == PS_Stopped)
-		{
-			//m_stoppedAudio.push_back(playing);
-			releasePlayingAudio( playing );
-			it = m_playingSounds.erase(it);
+		if (playing->m_status == PS_Stopping) {
+			stopPlayingAudio(playing);
+			continue;
 		}
-		else
+
+		if (playing->m_status == PS_Stopped) {
+			continue;
+		}
+
+		if (m_volumeHasChanged)
 		{
-			if (m_volumeHasChanged)
-			{
-				adjustPlayingVolume(playing);
-			}
-			++it;
+			adjustPlayingVolume(playing);
 		}
 	}
 
-	for (it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); )
-	{
+	for (it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it) {
 		playing = (*it);
 
-		if (playing->m_status == PS_Stopped)
-		{
-			//m_stoppedAudio.push_back(playing);
-			releasePlayingAudio( playing );
-			it = m_playing3DSounds.erase(it);
+		if (playing->m_status == PS_Stopping) {
+			stopPlayingAudio(playing);
+			continue;
 		}
-		else
-		{
-			if (m_volumeHasChanged)
-			{
-				adjustPlayingVolume(playing);
-			}
 
-			const Coord3D *pos = getCurrentPositionFromEvent(playing->m_audioEventRTS);
-			if (pos)
+		if (playing->m_status == PS_Stopped) {
+			continue;
+		}
+
+		if (m_volumeHasChanged)
+		{
+			adjustPlayingVolume(playing);
+		}
+
+		const Coord3D *pos = getCurrentPositionFromEvent(playing->m_audioEventRTS);
+		if (pos)
+		{
+			if( playing->m_audioEventRTS->isDead() )
 			{
-				if( playing->m_audioEventRTS->isDead() )
-				{
-					stopAudioEvent( playing->m_audioEventRTS->getPlayingHandle() );
-					it++;
-					continue;
-				}
-				else
-				{
-					Real volForConsideration = getEffectiveVolume(playing->m_audioEventRTS);
-					volForConsideration /= (m_sound3DVolume > 0.0f ? m_soundVolume : 1.0f);
-					Bool playAnyways = BitIsSet( playing->m_audioEventRTS->getAudioEventInfo()->m_type, ST_GLOBAL) || playing->m_audioEventRTS->getAudioEventInfo()->m_priority == AP_CRITICAL;
-					if( volForConsideration < m_audioSettings->m_minVolume && !playAnyways )
-					{
-						// don't want to get an additional callback for this sample
-						AIL_register_3D_EOS_callback(playing->m_3DSample, nullptr);
-						//m_stoppedAudio.push_back(playing);
-						releasePlayingAudio( playing );
-						it = m_playing3DSounds.erase(it);
-						continue;
-					}
-					else
-					{
-						Real x = pos->x;
-						Real y = pos->y;
-						Real z = pos->z;
-						AIL_set_3D_position( playing->m_3DSample, x, y, z );
-					}
-				}
+				stopAudioEvent( playing->m_audioEventRTS->getPlayingHandle() );
 			}
 			else
 			{
-				AIL_register_3D_EOS_callback(playing->m_3DSample, nullptr);
-				//m_stoppedAudio.push_back(playing);
-				releasePlayingAudio( playing );
-				it = m_playing3DSounds.erase(it);
-				continue;
+				Real volForConsideration = getEffectiveVolume(playing->m_audioEventRTS);
+				volForConsideration /= (m_sound3DVolume > 0.0f ? m_soundVolume : 1.0f);
+				Bool playAnyways = BitIsSet( playing->m_audioEventRTS->getAudioEventInfo()->m_type, ST_GLOBAL)
+					|| playing->m_audioEventRTS->getAudioEventInfo()->m_priority == AP_CRITICAL;
+				if( volForConsideration < m_audioSettings->m_minVolume && !playAnyways )
+				{
+					stopPlayingAudio(playing);
+				}
+				else
+				{
+					Real x = pos->x;
+					Real y = pos->y;
+					Real z = pos->z;
+					DEBUG_ASSERTCRASH(playing->m_3DSample, ("3D Sample is not expected to be null"));
+					AIL_set_3D_position( playing->m_3DSample, x, y, z );
+				}
 			}
-
-			++it;
-		}
-	}
-
-	for (it = m_playingStreams.begin(); it != m_playingStreams.end(); ) {
-		playing = (*it);
-
-		if (playing->m_status == PS_Stopped)
-		{
-			//m_stoppedAudio.push_back(playing);
-			releasePlayingAudio( playing );
-			it = m_playingStreams.erase(it);
 		}
 		else
 		{
-			if (m_volumeHasChanged)
+			stopPlayingAudio(playing);
+		}
+	}
+
+	for (it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it) {
+		playing = (*it);
+
+		if (playing->m_status == PS_Stopping) {
+			stopPlayingAudio(playing);
+			continue;
+		}
+
+		if (playing->m_status == PS_Stopped) {
+			continue;
+		}
+
+		if (m_volumeHasChanged)
+		{
+			adjustPlayingVolume(playing);
+		}
+	}
+
+	//
+	// Release audio with locking. Must not call into Miles!
+	//
+	releasePlayingAudioInListIfStopped(m_playingSounds, m_playingSoundsCS);
+	releasePlayingAudioInListIfStopped(m_playing3DSounds, m_playing3DSoundsCS);
+	releasePlayingAudioInListIfStopped(m_playingStreams, m_playingStreamsCS);
+
+	//
+	// Transfer streams to fade list when signaled.
+	//
+	{
+		CriticalSectionClass::LockClass lock(m_playingStreamsCS);
+		for (it = m_playingStreams.begin(); it != m_playingStreams.end(); ) {
+			playing = (*it);
+
+			if (playing->m_fade)
 			{
-				adjustPlayingVolume(playing);
+				{
+					CriticalSectionClass::LockClass lock(m_fadingAudioCS);
+					m_fadingAudio.push_back(playing);
+				}
+				it = m_playingStreams.erase(it);
+				continue;
 			}
 
 			++it;
@@ -2261,15 +2316,18 @@ void MilesAudioManager::processFadingList()
 	std::list<PlayingAudio *>::iterator it;
 	PlayingAudio *playing;
 
-	for (it = m_fadingAudio.begin(); it != m_fadingAudio.end(); /* emtpy */) {
-		playing = *it;
+	//
+	// Stop audio without locking. Calls into Miles.
+	//
+	for (it = m_fadingAudio.begin(); it != m_fadingAudio.end(); ++it) {
+		playing = (*it);
 
 		if (playing->m_framesFaded >= getAudioSettings()->m_fadeAudioFrames) {
-			playing->m_status = PS_Stopped;
-			playing->m_requestStop = true;
-			//m_stoppedAudio.push_back(playing);
-			releasePlayingAudio( playing );
-			it = m_fadingAudio.erase(it);
+			stopPlayingAudio(playing);
+			continue;
+		}
+
+		if (playing->m_status == PS_Stopped) {
 			continue;
 		}
 
@@ -2296,11 +2354,13 @@ void MilesAudioManager::processFadingList()
 				AIL_set_stream_volume_pan(playing->m_stream, volume, 0.5f);
 				break;
 			}
-
 		}
-
-		++it;
 	}
+
+	//
+	// Release audio with locking. Must not call into Miles!
+	//
+	releasePlayingAudioInListIfStopped(m_fadingAudio, m_fadingAudioCS);
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -2424,25 +2484,19 @@ void MilesAudioManager::closeAnySamplesUsingFile( const void *fileToClose )
 	std::list<PlayingAudio *>::iterator it;
 	PlayingAudio *playing;
 
-	for (it = m_playingSounds.begin(); it != m_playingSounds.end(); ) {
+	for (it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it ) {
 		playing = *it;
 
 		if (playing->m_file == fileToClose) {
-			releasePlayingAudio(playing);
-			it = m_playingSounds.erase(it);
-		} else {
-			++it;
+			stopPlayingAudio(playing);
 		}
 	}
 
-	for (it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ) {
+	for (it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it ) {
 		playing = *it;
 
 		if (playing->m_file == fileToClose) {
-			releasePlayingAudio(playing);
-			it = m_playing3DSounds.erase(it);
-		} else {
-			++it;
+			stopPlayingAudio(playing);
 		}
 	}
 }
@@ -2552,7 +2606,7 @@ Bool MilesAudioManager::startNextLoop( PlayingAudio *looping )
 	closeFile(looping->m_file);
 	looping->m_file = nullptr;
 
-	if (looping->m_requestStop) {
+	if (looping->m_status != PS_Playing) {
 		return false;
 	}
 
@@ -2564,9 +2618,7 @@ Bool MilesAudioManager::startNextLoop( PlayingAudio *looping )
 			// fake it out so that this sound appears done, but also so that it will not
 			// delete the sound on completion (which would suck)
 			looping->m_cleanupAudioEventRTS = false;
-			looping->m_requestStop = true;
-			looping->m_status = PS_Stopped;
-
+			InterlockedCompareExchange(reinterpret_cast<volatile long*>(&looping->m_status), PS_Stopping, PS_Playing);
 
 			AudioRequest *req = allocateAudioRequest(true);
 			req->m_pendingEvent = looping->m_audioEventRTS;
@@ -2777,6 +2829,7 @@ void *MilesAudioManager::getHandleForBink()
 		aud->m_type = PAT_Sample;
 
 		if (!aud->m_sample) {
+			stopPlayingAudio(aud);
 			releasePlayingAudio(aud);
 			return nullptr;
 		}
@@ -2793,6 +2846,7 @@ void *MilesAudioManager::getHandleForBink()
 void MilesAudioManager::releaseHandleForBink()
 {
 	if (m_binkHandle) {
+		stopPlayingAudio(m_binkHandle);
 		releasePlayingAudio(m_binkHandle);
 		m_binkHandle = nullptr;
 	}

--- a/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
+++ b/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
@@ -229,10 +229,6 @@ void MilesAudioManager::audioDebugDisplay(DebugDisplayInterface *dd, void *, FIL
 		channelCount = TheAudio->getNum2DSamples();
 		for (it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it) {
 			playing = *it;
-			if (!playing) {
-				continue;
-			}
-
 			playingArray[(int)AIL_sample_user_data(playing->m_sample, 0)] = playing;
 		}
 
@@ -262,10 +258,6 @@ void MilesAudioManager::audioDebugDisplay(DebugDisplayInterface *dd, void *, FIL
 		for( it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it )
 		{
 			playing = *it;
-			if( !playing )
-			{
-				continue;
-			}
 			filenameNoSlashes = playing->m_audioEventRTS->getFilename();
 			filenameNoSlashes = filenameNoSlashes.reverseFind( '\\' ) + 1;
 
@@ -290,10 +282,6 @@ void MilesAudioManager::audioDebugDisplay(DebugDisplayInterface *dd, void *, FIL
 		channelCount = TheAudio->getNum3DSamples();
 		for (it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it) {
 			playing = *it;
-			if (!playing) {
-				continue;
-			}
-
 			playingArray[(int)AIL_3D_user_data(playing->m_3DSample, 0)] = playing;
 		}
 
@@ -357,10 +345,6 @@ void MilesAudioManager::audioDebugDisplay(DebugDisplayInterface *dd, void *, FIL
 		for( it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it )
 		{
 			playing = *it;
-			if( !playing )
-			{
-				continue;
-			}
 			filenameNoSlashes = playing->m_audioEventRTS->getFilename();
 			filenameNoSlashes = filenameNoSlashes.reverseFind('\\') + 1;
 
@@ -384,12 +368,8 @@ void MilesAudioManager::audioDebugDisplay(DebugDisplayInterface *dd, void *, FIL
 		channel = 1;
 		for (it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it) {
 			playing = *it;
-			if (!playing) {
-				continue;
-			}
 			filenameNoSlashes = playing->m_audioEventRTS->getFilename();
 			filenameNoSlashes = filenameNoSlashes.reverseFind('\\') + 1;
-
 
 			// Calculate Sample volume
 			volume = 100.0f;
@@ -411,10 +391,6 @@ void MilesAudioManager::audioDebugDisplay(DebugDisplayInterface *dd, void *, FIL
 		for( it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it )
 		{
 			playing = *it;
-			if( !playing )
-			{
-				continue;
-			}
 			filenameNoSlashes = playing->m_audioEventRTS->getFilename();
 			filenameNoSlashes = filenameNoSlashes.reverseFind('\\') + 1;
 
@@ -482,7 +458,6 @@ void MilesAudioManager::update()
 	processRequestList();
 	processPlayingList();
 	processFadingList();
-	processStoppedList();
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -494,49 +469,42 @@ void MilesAudioManager::stopAudio( AudioAffect which )
 	// 3) Set the status to stopped, so that when we next process the playing list, we will
 	//		correctly clean up the sample.
 
-
 	std::list<PlayingAudio *>::iterator it;
 
 	PlayingAudio *playing = nullptr;
 	if (BitIsSet(which, AudioAffect_Sound)) {
 		for (it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it) {
 			playing = *it;
-			if (playing) {
-				AIL_register_EOS_callback(playing->m_sample, nullptr);
-				AIL_stop_sample(playing->m_sample);
-				playing->m_status = PS_Stopped;
-			}
+			AIL_register_EOS_callback(playing->m_sample, nullptr);
+			AIL_stop_sample(playing->m_sample);
+			playing->m_status = PS_Stopped;
 		}
 	}
 
 	if (BitIsSet(which, AudioAffect_Sound3D)) {
 		for (it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it) {
 			playing = *it;
-			if (playing) {
-				AIL_register_3D_EOS_callback(playing->m_3DSample, nullptr);
-				AIL_stop_3D_sample(playing->m_3DSample);
-				playing->m_status = PS_Stopped;
-			}
+			AIL_register_3D_EOS_callback(playing->m_3DSample, nullptr);
+			AIL_stop_3D_sample(playing->m_3DSample);
+			playing->m_status = PS_Stopped;
 		}
 	}
 
 	if (BitIsSet(which, AudioAffect_Speech | AudioAffect_Music)) {
 		for (it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it) {
 			playing = *it;
-			if (playing) {
-				if (playing->m_audioEventRTS->getAudioEventInfo()->m_soundType == AT_Music) {
-					if (!BitIsSet(which, AudioAffect_Music)) {
-						continue;
-					}
-				} else {
-					if (!BitIsSet(which, AudioAffect_Speech)) {
-						continue;
-					}
+			if (playing->m_audioEventRTS->getAudioEventInfo()->m_soundType == AT_Music) {
+				if (!BitIsSet(which, AudioAffect_Music)) {
+					continue;
 				}
-				AIL_register_stream_callback(playing->m_stream, nullptr);
-				AIL_pause_stream(playing->m_stream, 1);
-				playing->m_status = PS_Stopped;
+			} else {
+				if (!BitIsSet(which, AudioAffect_Speech)) {
+					continue;
+				}
 			}
+			AIL_register_stream_callback(playing->m_stream, nullptr);
+			AIL_pause_stream(playing->m_stream, 1);
+			playing->m_status = PS_Stopped;
 		}
 	}
 }
@@ -550,46 +518,40 @@ void MilesAudioManager::pauseAudio( AudioAffect which )
 	if (BitIsSet(which, AudioAffect_Sound)) {
 		for (it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it) {
 			playing = *it;
-			if (playing) {
-				AIL_stop_sample(playing->m_sample);
-			}
+			AIL_stop_sample(playing->m_sample);
 		}
 	}
 
 	if (BitIsSet(which, AudioAffect_Sound3D)) {
 		for (it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it) {
 			playing = *it;
-			if (playing) {
-				AIL_stop_3D_sample(playing->m_3DSample);
-			}
+			AIL_stop_3D_sample(playing->m_3DSample);
 		}
 	}
 
 	if (BitIsSet(which, AudioAffect_Speech | AudioAffect_Music)) {
 		for (it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it) {
 			playing = *it;
-			if (playing) {
-				if (playing->m_audioEventRTS->getAudioEventInfo()->m_soundType == AT_Music) {
-					if (!BitIsSet(which, AudioAffect_Music)) {
-						continue;
-					}
-				} else {
-					if (!BitIsSet(which, AudioAffect_Speech)) {
-						continue;
-					}
+			if (playing->m_audioEventRTS->getAudioEventInfo()->m_soundType == AT_Music) {
+				if (!BitIsSet(which, AudioAffect_Music)) {
+					continue;
 				}
-
-				AIL_pause_stream(playing->m_stream, 1);
+			} else {
+				if (!BitIsSet(which, AudioAffect_Speech)) {
+					continue;
+				}
 			}
+
+			AIL_pause_stream(playing->m_stream, 1);
 		}
 	}
 
 	//Get rid of PLAY audio requests when pausing audio.
 	std::list<AudioRequest*>::iterator ait;
-	for (ait = m_audioRequests.begin(); ait != m_audioRequests.end(); /* empty */)
+	for (ait = m_audioRequests.begin(); ait != m_audioRequests.end(); )
 	{
 		AudioRequest *req = (*ait);
-		if( req && req->m_request == AR_Play )
+		if( req->m_request == AR_Play )
 		{
 			deleteInstance(req);
 			ait = m_audioRequests.erase(ait);
@@ -611,36 +573,30 @@ void MilesAudioManager::resumeAudio( AudioAffect which )
 	if (BitIsSet(which, AudioAffect_Sound)) {
 		for (it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it) {
 			playing = *it;
-			if (playing) {
-				AIL_resume_sample(playing->m_sample);
-			}
+			AIL_resume_sample(playing->m_sample);
 		}
 	}
 
 	if (BitIsSet(which, AudioAffect_Sound3D)) {
 		for (it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it) {
 			playing = *it;
-			if (playing) {
-				AIL_resume_3D_sample(playing->m_3DSample);
-			}
+			AIL_resume_3D_sample(playing->m_3DSample);
 		}
 	}
 
 	if (BitIsSet(which, AudioAffect_Speech | AudioAffect_Music)) {
 		for (it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it) {
 			playing = *it;
-			if (playing) {
-				if (playing->m_audioEventRTS->getAudioEventInfo()->m_soundType == AT_Music) {
-					if (!BitIsSet(which, AudioAffect_Music)) {
-						continue;
-					}
-				} else {
-					if (!BitIsSet(which, AudioAffect_Speech)) {
-						continue;
-					}
+			if (playing->m_audioEventRTS->getAudioEventInfo()->m_soundType == AT_Music) {
+				if (!BitIsSet(which, AudioAffect_Music)) {
+					continue;
 				}
-				AIL_pause_stream(playing->m_stream, 0);
+			} else {
+				if (!BitIsSet(which, AudioAffect_Speech)) {
+					continue;
+				}
 			}
+			AIL_pause_stream(playing->m_stream, 0);
 		}
 	}
 }
@@ -690,9 +646,6 @@ void MilesAudioManager::playAudioEvent( AudioRequest* req )
 			if (handleToKill) {
 				for (it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it) {
 					playing = (*it);
-					if (!playing) {
-						continue;
-					}
 
 					if (playing->m_audioEventRTS && playing->m_audioEventRTS->getPlayingHandle() == handleToKill)
 					{
@@ -746,9 +699,6 @@ void MilesAudioManager::playAudioEvent( AudioRequest* req )
 				{
 					for (it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it) {
 						playing = (*it);
-						if (!playing) {
-							continue;
-						}
 
 						if( playing->m_audioEventRTS && playing->m_audioEventRTS->getPlayingHandle() == handleToKill )
 						{
@@ -811,14 +761,11 @@ void MilesAudioManager::playAudioEvent( AudioRequest* req )
 			else
 			{
 				// UI sounds are always 2-D. All other sounds should be Positional
-				// Unit acknowledgement, etc, falls into the UI category of sound.
+				// Unit acknowledgment, etc, falls into the UI category of sound.
 				Bool foundSoundToReplace = false;
 				if (handleToKill) {
 					for (it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it) {
 						playing = (*it);
-						if (!playing) {
-							continue;
-						}
 
 						if (playing->m_audioEventRTS && playing->m_audioEventRTS->getPlayingHandle() == handleToKill)
 						{
@@ -900,9 +847,6 @@ void MilesAudioManager::stopAudioEvent( AudioHandle handle )
 		// for music, just find the currently playing music stream and kill it.
 		for ( it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it ) {
 			PlayingAudio *audio = (*it);
-			if (!audio) {
-				continue;
-			}
 
 			if( audio->m_audioEventRTS->getAudioEventInfo()->m_soundType == AT_Music )
 			{
@@ -923,12 +867,8 @@ void MilesAudioManager::stopAudioEvent( AudioHandle handle )
 
 	for ( it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it ) {
 		PlayingAudio *audio = (*it);
-		if (!audio) {
-			continue;
-		}
 
 		if (audio->m_audioEventRTS->getPlayingHandle() == handle) {
-			// found it
 			audio->m_requestStop = true;
 			notifyOfAudioCompletion((UnsignedInt)(audio->m_stream), PAT_Stream);
 			break;
@@ -937,9 +877,6 @@ void MilesAudioManager::stopAudioEvent( AudioHandle handle )
 
 	for ( it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it ) {
 		PlayingAudio *audio = (*it);
-		if (!audio) {
-			continue;
-		}
 
 		if (audio->m_audioEventRTS->getPlayingHandle() == handle) {
 			audio->m_requestStop = true;
@@ -949,9 +886,6 @@ void MilesAudioManager::stopAudioEvent( AudioHandle handle )
 
 	for ( it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it ) {
 		PlayingAudio *audio = (*it);
-		if (!audio) {
-			continue;
-		}
 
 		if (audio->m_audioEventRTS->getPlayingHandle() == handle) {
 		#ifdef INTENSIVE_AUDIO_DEBUG
@@ -971,7 +905,7 @@ void MilesAudioManager::killAudioEventImmediately( AudioHandle audioEvent )
 	for( ait = m_audioRequests.begin(); ait != m_audioRequests.end(); ait++ )
 	{
 		AudioRequest *req = (*ait);
-		if( req && req->m_request == AR_Play && req->m_handleToInteractOn == audioEvent )
+		if( req->m_request == AR_Play && req->m_handleToInteractOn == audioEvent )
 		{
 			deleteInstance(req);
 			ait = m_audioRequests.erase(ait);
@@ -984,10 +918,6 @@ void MilesAudioManager::killAudioEventImmediately( AudioHandle audioEvent )
 	for( it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); it++ )
 	{
 		PlayingAudio *audio = (*it);
-		if( !audio )
-		{
-			continue;
-		}
 
 		if( audio->m_audioEventRTS->getPlayingHandle() == audioEvent )
 		{
@@ -1001,10 +931,6 @@ void MilesAudioManager::killAudioEventImmediately( AudioHandle audioEvent )
 	for( it = m_playingSounds.begin(); it != m_playingSounds.end(); it++ )
 	{
 		PlayingAudio *audio = (*it);
-		if( !audio )
-		{
-			continue;
-		}
 
 		if( audio->m_audioEventRTS->getPlayingHandle() == audioEvent )
 		{
@@ -1018,10 +944,6 @@ void MilesAudioManager::killAudioEventImmediately( AudioHandle audioEvent )
 	for( it = m_playingStreams.begin(); it != m_playingStreams.end(); it++ )
 	{
 		PlayingAudio *audio = (*it);
-		if( !audio )
-		{
-			continue;
-		}
 
 		if( audio->m_audioEventRTS->getPlayingHandle() == audioEvent )
 		{
@@ -1056,9 +978,7 @@ void MilesAudioManager::closeFile( void *fileRead )
 //-------------------------------------------------------------------------------------------------
 PlayingAudio *MilesAudioManager::allocatePlayingAudio()
 {
-	PlayingAudio *aud = NEW PlayingAudio;	// poolify
-	aud->m_status = PS_Playing;
-	return aud;
+	return NEW PlayingAudio; // poolify
 }
 
 
@@ -1121,6 +1041,33 @@ void MilesAudioManager::releasePlayingAudio( PlayingAudio *release )
 }
 
 //-------------------------------------------------------------------------------------------------
+PlayingAudio *MilesAudioManager::findActiveMusic( const AsciiString* trackName )
+{
+	std::list<PlayingAudio *>::const_iterator it;
+	PlayingAudio *playing;
+	for (it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it) {
+		playing = *it;
+		if (playing->m_status != PS_Playing) {
+			continue;
+		}
+		if (playing->m_audioEventRTS->getAudioEventInfo()->m_soundType != AT_Music) {
+			continue;
+		}
+		if (trackName && *trackName != playing->m_audioEventRTS->getEventName()) {
+			continue;
+		}
+		return playing;
+	}
+	return nullptr;
+}
+
+//-------------------------------------------------------------------------------------------------
+const PlayingAudio *MilesAudioManager::findActiveMusic( const AsciiString* trackName ) const
+{
+	return const_cast<MilesAudioManager*>(this)->findActiveMusic(trackName);
+}
+
+//-------------------------------------------------------------------------------------------------
 void MilesAudioManager::stopAllAudioImmediately()
 {
 	std::list<PlayingAudio *>::iterator it;
@@ -1128,43 +1075,27 @@ void MilesAudioManager::stopAllAudioImmediately()
 
 	for (it = m_playingSounds.begin(); it != m_playingSounds.end(); ) {
 		playing = *it;
-		if (!playing) {
-			continue;
-		}
-
 		releasePlayingAudio(playing);
 		it = m_playingSounds.erase(it);
 	}
 
 	for (it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ) {
 		playing = *it;
-		if (!playing) {
-			continue;
-		}
-
 		releasePlayingAudio(playing);
 		it = m_playing3DSounds.erase(it);
 	}
 
 	for (it = m_playingStreams.begin(); it != m_playingStreams.end(); ) {
 		playing = (*it);
-		if (!playing) {
-			continue;
-		}
-
 		releasePlayingAudio(playing);
 		it = m_playingStreams.erase(it);
 	}
 
-  for (it = m_fadingAudio.begin(); it != m_fadingAudio.end(); ) {
-    playing = (*it);
-    if (!playing) {
-      continue;
-    }
-
-    releasePlayingAudio(playing);
-    it = m_fadingAudio.erase(it);
-  }
+	for (it = m_fadingAudio.begin(); it != m_fadingAudio.end(); ) {
+		playing = (*it);
+		releasePlayingAudio(playing);
+		it = m_fadingAudio.erase(it);
+	}
 
 	std::list<HAUDIO>::iterator hit;
 	for (hit = m_audioForcePlayed.begin(); hit != m_audioForcePlayed.end(); ++hit) {
@@ -1185,7 +1116,7 @@ void MilesAudioManager::freeAllMilesHandles()
 
 	// Walks through the available 2-D and 3-D handles and releases them
 	std::list<HSAMPLE>::iterator it;
-	for ( it = m_availableSamples.begin(); it != m_availableSamples.end(); /* empty */ ) {
+	for ( it = m_availableSamples.begin(); it != m_availableSamples.end(); ) {
 		HSAMPLE sample = *it;
 		AIL_release_sample_handle(sample);
 		it = m_availableSamples.erase(it);
@@ -1193,7 +1124,7 @@ void MilesAudioManager::freeAllMilesHandles()
 	m_num2DSamples = 0;
 
 	std::list<H3DSAMPLE>::iterator it3D;
-	for ( it3D = m_available3DSamples.begin(); it3D != m_available3DSamples.end(); /* empty */ ) {
+	for ( it3D = m_available3DSamples.begin(); it3D != m_available3DSamples.end(); ) {
 		H3DSAMPLE sample3D = *it3D;
 		AIL_release_3D_sample_handle(sample3D);
 		it3D = m_available3DSamples.erase(it3D);
@@ -1259,10 +1190,6 @@ void MilesAudioManager::stopAllSpeech()
 	PlayingAudio *playing;
 	for (it = m_playingStreams.begin(); it != m_playingStreams.end(); ) {
 		playing = (*it);
-		if (!playing) {
-			continue;
-		}
-
 		if (playing->m_audioEventRTS->getAudioEventInfo()->m_soundType == AT_Streaming) {
 			releasePlayingAudio(playing);
 			it = m_playingStreams.erase(it);
@@ -1321,16 +1248,12 @@ void MilesAudioManager::initFilters3D( H3DSAMPLE sample, AudioEventRTS *event, c
 }
 
 //-------------------------------------------------------------------------------------------------
-void MilesAudioManager::nextMusicTrack()
+AsciiString MilesAudioManager::nextMusicTrack()
 {
 	AsciiString trackName;
-	std::list<PlayingAudio *>::iterator it;
-	PlayingAudio *playing;
-	for (it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it) {
-		playing = *it;
-		if (playing && playing->m_audioEventRTS->getAudioEventInfo()->m_soundType == AT_Music) {
-			trackName = playing->m_audioEventRTS->getEventName();
-		}
+
+	if (PlayingAudio *playing = findActiveMusic()) {
+		trackName = playing->m_audioEventRTS->getEventName();
 	}
 
 	// Stop currently playing music
@@ -1339,19 +1262,17 @@ void MilesAudioManager::nextMusicTrack()
 	trackName = nextTrackName(trackName);
 	AudioEventRTS newTrack(trackName);
 	TheAudio->addAudioEvent(&newTrack);
+
+	return trackName;
 }
 
 //-------------------------------------------------------------------------------------------------
-void MilesAudioManager::prevMusicTrack()
+AsciiString MilesAudioManager::prevMusicTrack()
 {
 	AsciiString trackName;
-	std::list<PlayingAudio *>::iterator it;
-	PlayingAudio *playing;
-	for (it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it) {
-		playing = *it;
-		if (playing && playing->m_audioEventRTS->getAudioEventInfo()->m_soundType == AT_Music) {
-			trackName = playing->m_audioEventRTS->getEventName();
-		}
+
+	if (PlayingAudio *playing = findActiveMusic()) {
+		trackName = playing->m_audioEventRTS->getEventName();
 	}
 
 	// Stop currently playing music
@@ -1360,71 +1281,25 @@ void MilesAudioManager::prevMusicTrack()
 	trackName = prevTrackName(trackName);
 	AudioEventRTS newTrack(trackName);
 	TheAudio->addAudioEvent(&newTrack);
+
+	return trackName;
 }
 
 //-------------------------------------------------------------------------------------------------
 Bool MilesAudioManager::isMusicPlaying() const
 {
-	std::list<PlayingAudio *>::const_iterator it;
-	PlayingAudio *playing;
-	for (it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it) {
-		playing = *it;
-		if (playing && playing->m_audioEventRTS->getAudioEventInfo()->m_soundType == AT_Music) {
-			return TRUE;
-		}
-	}
-
-	return FALSE;
+	return findActiveMusic() != nullptr;
 }
 
 //-------------------------------------------------------------------------------------------------
 Bool MilesAudioManager::hasMusicTrackCompleted( const AsciiString& trackName, Int numberOfTimes ) const
 {
-	std::list<PlayingAudio *>::const_iterator it;
-	PlayingAudio *playing;
-	for (it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it) {
-		playing = *it;
-		if (playing && playing->m_audioEventRTS->getAudioEventInfo()->m_soundType == AT_Music) {
-			if (playing->m_audioEventRTS->getEventName() == trackName) {
-				if (INFINITE_LOOP_COUNT - AIL_stream_loop_count(playing->m_stream) >= numberOfTimes) {
-					return TRUE;
-				}
-			}
+	if (const PlayingAudio *playing = findActiveMusic(&trackName)) {
+		if (INFINITE_LOOP_COUNT - AIL_stream_loop_count(playing->m_stream) >= numberOfTimes) {
+			return TRUE;
 		}
 	}
-
 	return FALSE;
-}
-
-//-------------------------------------------------------------------------------------------------
-AsciiString MilesAudioManager::getMusicTrackName() const
-{
-	// First check the requests. If there's one there, then report that as the currently playing track.
-	std::list<AudioRequest *>::const_iterator ait;
-	for (ait = m_audioRequests.begin(); ait != m_audioRequests.end(); ++ait) {
-		if ((*ait)->m_request != AR_Play) {
-			continue;
-		}
-
-		if (!(*ait)->m_usePendingEvent) {
-			continue;
-		}
-
-		if ((*ait)->m_pendingEvent->getAudioEventInfo()->m_soundType == AT_Music) {
-			return (*ait)->m_pendingEvent->getEventName();
-		}
-	}
-
-	std::list<PlayingAudio *>::const_iterator it;
-	PlayingAudio *playing;
-	for (it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it) {
-		playing = *it;
-		if (playing && playing->m_audioEventRTS->getAudioEventInfo()->m_soundType == AT_Music) {
-			return playing->m_audioEventRTS->getEventName();
-		}
-	}
-
-	return AsciiString::TheEmptyString;
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -1482,21 +1357,21 @@ Bool MilesAudioManager::isCurrentlyPlaying( AudioHandle handle )
 
 	for (it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it) {
 		playing = *it;
-		if (playing && playing->m_audioEventRTS->getPlayingHandle() == handle) {
+		if (playing->m_audioEventRTS->getPlayingHandle() == handle) {
 			return true;
 		}
 	}
 
 	for (it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it) {
 		playing = *it;
-		if (playing && playing->m_audioEventRTS->getPlayingHandle() == handle) {
+		if (playing->m_audioEventRTS->getPlayingHandle() == handle) {
 			return true;
 		}
 	}
 
 	for (it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it) {
 		playing = *it;
-		if (playing && playing->m_audioEventRTS->getPlayingHandle() == handle) {
+		if (playing->m_audioEventRTS->getPlayingHandle() == handle) {
 			return true;
 		}
 	}
@@ -1506,7 +1381,7 @@ Bool MilesAudioManager::isCurrentlyPlaying( AudioHandle handle )
 	AudioRequest *req = nullptr;
 	for (ait = m_audioRequests.begin(); ait != m_audioRequests.end(); ++ait) {
 		req = *ait;
-		if (req && req->m_usePendingEvent && req->m_pendingEvent->getPlayingHandle() == handle) {
+		if (req->m_usePendingEvent && req->m_pendingEvent->getPlayingHandle() == handle) {
 			return true;
 		}
 	}
@@ -1515,9 +1390,9 @@ Bool MilesAudioManager::isCurrentlyPlaying( AudioHandle handle )
 }
 
 //-------------------------------------------------------------------------------------------------
-void MilesAudioManager::notifyOfAudioCompletion( UnsignedInt audioCompleted, UnsignedInt flags )
+void MilesAudioManager::notifyOfAudioCompletion( UnsignedInt handle, UnsignedInt flags )
 {
-	PlayingAudio *playing = findPlayingAudioFrom(audioCompleted, flags);
+	PlayingAudio *playing = findPlayingAudioFrom(handle, flags);
 	if (!playing) {
 		DEBUG_CRASH(("Audio has completed playing, but we can't seem to find it. - jkmcd"));
 		return;
@@ -1568,7 +1443,6 @@ void MilesAudioManager::notifyOfAudioCompletion( UnsignedInt audioCompleted, Uns
 	if (playing->m_type == PAT_Stream) {
 		if (playing->m_audioEventRTS->getAudioEventInfo()->m_soundType == AT_Music) {
 			playStream(playing->m_audioEventRTS, playing->m_stream);
-
 			return;
 		}
 	}
@@ -1577,36 +1451,36 @@ void MilesAudioManager::notifyOfAudioCompletion( UnsignedInt audioCompleted, Uns
 }
 
 //-------------------------------------------------------------------------------------------------
-PlayingAudio *MilesAudioManager::findPlayingAudioFrom( UnsignedInt audioCompleted, UnsignedInt flags )
+PlayingAudio *MilesAudioManager::findPlayingAudioFrom( UnsignedInt handle, UnsignedInt flags )
 {
 	std::list<PlayingAudio *>::iterator it;
 	PlayingAudio *playing;
 
 	if (flags == PAT_Sample) {
-		HSAMPLE sample = (HSAMPLE) audioCompleted;
+		HSAMPLE sample = (HSAMPLE) handle;
 		for (it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it) {
 			playing = *it;
-			if (playing && playing->m_sample == sample) {
+			if (playing->m_sample == sample) {
 				return playing;
 			}
 		}
 	}
 
 	if (flags == PAT_3DSample) {
-		H3DSAMPLE sample3D = (H3DSAMPLE) audioCompleted;
+		H3DSAMPLE sample3D = (H3DSAMPLE) handle;
 		for (it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it) {
 			playing = *it;
-			if (playing && playing->m_3DSample == sample3D) {
+			if (playing->m_3DSample == sample3D) {
 				return playing;
 			}
 		}
 	}
 
 	if (flags == PAT_Stream) {
-		HSTREAM stream = (HSTREAM) audioCompleted;
+		HSTREAM stream = (HSTREAM) handle;
 		for (it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it) {
 			playing = *it;
-			if (playing && playing->m_stream == stream) {
+			if (playing->m_stream == stream) {
 				return playing;
 			}
 		}
@@ -1849,9 +1723,6 @@ Bool MilesAudioManager::doesViolateLimit( AudioEventRTS *event ) const
 	std::list<AudioRequest*>::const_iterator arIt;
 	for (arIt = m_audioRequests.begin(); arIt != m_audioRequests.end(); ++arIt) {
 		AudioRequest *req = (*arIt);
-		if (req == nullptr) {
-			continue;
-		}
 		if( req->m_usePendingEvent )
 		{
 			if( req->m_pendingEvent->getEventName() == event->getEventName() )
@@ -2048,10 +1919,6 @@ Bool MilesAudioManager::killLowestPrioritySoundImmediately( AudioEventRTS *event
 			for( it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it )
 			{
 				PlayingAudio *playing = (*it);
-				if( !playing )
-				{
-					continue;
-				}
 
 				if( playing->m_audioEventRTS && playing->m_audioEventRTS == lowestPriorityEvent )
 				{
@@ -2067,10 +1934,6 @@ Bool MilesAudioManager::killLowestPrioritySoundImmediately( AudioEventRTS *event
 			for( it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it )
 			{
 				PlayingAudio *playing = (*it);
-				if( !playing )
-				{
-					continue;
-				}
 
 				if( playing->m_audioEventRTS && playing->m_audioEventRTS == lowestPriorityEvent )
 				{
@@ -2095,7 +1958,7 @@ void MilesAudioManager::adjustVolumeOfPlayingAudio(AsciiString eventName, Real n
 	PlayingAudio *playing = nullptr;
 	for (it = m_playingSounds.begin(); it != m_playingSounds.end(); ++it) {
 		playing = *it;
-		if (playing && playing->m_audioEventRTS->getEventName() == eventName) {
+		if (playing->m_audioEventRTS->getEventName() == eventName) {
 			// Adjust it
 			playing->m_audioEventRTS->setVolume(newVolume);
 			AIL_sample_volume_pan(playing->m_sample, nullptr, &pan);
@@ -2105,7 +1968,7 @@ void MilesAudioManager::adjustVolumeOfPlayingAudio(AsciiString eventName, Real n
 
 	for (it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ++it) {
 		playing = *it;
-		if (playing && playing->m_audioEventRTS->getEventName() == eventName) {
+		if (playing->m_audioEventRTS->getEventName() == eventName) {
 			// Adjust it
 			playing->m_audioEventRTS->setVolume(newVolume);
 			AIL_set_3D_sample_volume(playing->m_3DSample, getEffectiveVolume(playing->m_audioEventRTS));
@@ -2114,7 +1977,7 @@ void MilesAudioManager::adjustVolumeOfPlayingAudio(AsciiString eventName, Real n
 
 	for (it = m_playingStreams.begin(); it != m_playingStreams.end(); ++it) {
 		playing = *it;
-		if (playing && playing->m_audioEventRTS->getEventName() == eventName) {
+		if (playing->m_audioEventRTS->getEventName() == eventName) {
 			// Adjust it
 			playing->m_audioEventRTS->setVolume(newVolume);
 			AIL_stream_volume_pan(playing->m_stream, nullptr, &pan);
@@ -2133,7 +1996,7 @@ void MilesAudioManager::removePlayingAudio( AsciiString eventName )
 	for( it = m_playingSounds.begin(); it != m_playingSounds.end(); )
 	{
 		playing = *it;
-		if( playing && playing->m_audioEventRTS->getEventName() == eventName )
+		if( playing->m_audioEventRTS->getEventName() == eventName )
 		{
 			releasePlayingAudio( playing );
 			it = m_playingSounds.erase(it);
@@ -2147,7 +2010,7 @@ void MilesAudioManager::removePlayingAudio( AsciiString eventName )
 	for( it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); )
 	{
 		playing = *it;
-		if( playing && playing->m_audioEventRTS->getEventName() == eventName )
+		if( playing->m_audioEventRTS->getEventName() == eventName )
 		{
 			releasePlayingAudio( playing );
 			it = m_playing3DSounds.erase(it);
@@ -2161,7 +2024,7 @@ void MilesAudioManager::removePlayingAudio( AsciiString eventName )
 	for( it = m_playingStreams.begin(); it != m_playingStreams.end(); )
 	{
 		playing = *it;
-		if( playing && playing->m_audioEventRTS->getEventName() == eventName )
+		if( playing->m_audioEventRTS->getEventName() == eventName )
 		{
 			releasePlayingAudio( playing );
 			it = m_playingStreams.erase(it);
@@ -2182,7 +2045,7 @@ void MilesAudioManager::removeAllDisabledAudio()
 	for( it = m_playingSounds.begin(); it != m_playingSounds.end(); )
 	{
 		playing = *it;
-		if( playing && playing->m_audioEventRTS->getVolume() == 0.0f )
+		if( playing->m_audioEventRTS->getVolume() == 0.0f )
 		{
 			releasePlayingAudio( playing );
 			it = m_playingSounds.erase(it);
@@ -2196,7 +2059,7 @@ void MilesAudioManager::removeAllDisabledAudio()
 	for( it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); )
 	{
 		playing = *it;
-		if( playing && playing->m_audioEventRTS->getVolume() == 0.0f )
+		if( playing->m_audioEventRTS->getVolume() == 0.0f )
 		{
 			releasePlayingAudio( playing );
 			it = m_playing3DSounds.erase(it);
@@ -2210,7 +2073,7 @@ void MilesAudioManager::removeAllDisabledAudio()
 	for( it = m_playingStreams.begin(); it != m_playingStreams.end(); )
 	{
 		playing = *it;
-		if( playing && playing->m_audioEventRTS->getVolume() == 0.0f )
+		if( playing->m_audioEventRTS->getVolume() == 0.0f )
 		{
 			releasePlayingAudio( playing );
 			it = m_playingStreams.erase(it);
@@ -2226,12 +2089,8 @@ void MilesAudioManager::removeAllDisabledAudio()
 void MilesAudioManager::processRequestList()
 {
 	std::list<AudioRequest*>::iterator it;
-	for (it = m_audioRequests.begin(); it != m_audioRequests.end(); /* empty */) {
+	for (it = m_audioRequests.begin(); it != m_audioRequests.end(); ) {
 		AudioRequest *req = (*it);
-		if (req == nullptr) {
-			continue;
-		}
-
 		if (!shouldProcessRequestThisFrame(req)) {
 			adjustRequest(req);
 			++it;
@@ -2255,13 +2114,8 @@ void MilesAudioManager::processPlayingList()
 	std::list<PlayingAudio *>::iterator it;
 	PlayingAudio *playing;
 
-	for (it = m_playingSounds.begin(); it != m_playingSounds.end(); /* empty */) {
+	for (it = m_playingSounds.begin(); it != m_playingSounds.end(); ) {
 		playing = (*it);
-		if (!playing)
-		{
-			it = m_playingSounds.erase(it);
-			continue;
-		}
 
 		if (playing->m_status == PS_Stopped)
 		{
@@ -2282,11 +2136,6 @@ void MilesAudioManager::processPlayingList()
 	for (it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); )
 	{
 		playing = (*it);
-		if (!playing)
-		{
-			it = m_playing3DSounds.erase(it);
-			continue;
-		}
 
 		if (playing->m_status == PS_Stopped)
 		{
@@ -2348,11 +2197,6 @@ void MilesAudioManager::processPlayingList()
 
 	for (it = m_playingStreams.begin(); it != m_playingStreams.end(); ) {
 		playing = (*it);
-		if (!playing)
-		{
-			it = m_playingStreams.erase(it);
-			continue;
-		}
 
 		if (playing->m_status == PS_Stopped)
 		{
@@ -2395,9 +2239,6 @@ Bool MilesAudioManager::has3DSensitiveStreamsPlaying() const
   {
 		const PlayingAudio *playing = (*it);
 
-    if ( ! playing )
-      continue;
-
     if ( playing->m_audioEventRTS->getAudioEventInfo()->m_soundType != AT_Music )
     {
       return TRUE;
@@ -2422,9 +2263,6 @@ void MilesAudioManager::processFadingList()
 
 	for (it = m_fadingAudio.begin(); it != m_fadingAudio.end(); /* emtpy */) {
 		playing = *it;
-		if (!playing) {
-			continue;
-		}
 
 		if (playing->m_framesFaded >= getAudioSettings()->m_fadeAudioFrames) {
 			playing->m_status = PS_Stopped;
@@ -2464,22 +2302,6 @@ void MilesAudioManager::processFadingList()
 		++it;
 	}
 }
-
-//-------------------------------------------------------------------------------------------------
-void MilesAudioManager::processStoppedList()
-{
-	std::list<PlayingAudio *>::iterator it;
-	PlayingAudio *playing;
-
-	for (it = m_stoppedAudio.begin(); it != m_stoppedAudio.end(); /* emtpy */) {
-		playing = *it;
-		if (playing) {
-			releasePlayingAudio(playing);
-		}
-		it = m_stoppedAudio.erase(it);
-	}
-}
-
 
 //-------------------------------------------------------------------------------------------------
 Bool MilesAudioManager::shouldProcessRequestThisFrame( AudioRequest *req ) const
@@ -2604,9 +2426,6 @@ void MilesAudioManager::closeAnySamplesUsingFile( const void *fileToClose )
 
 	for (it = m_playingSounds.begin(); it != m_playingSounds.end(); ) {
 		playing = *it;
-		if (!playing) {
-			continue;
-		}
 
 		if (playing->m_file == fileToClose) {
 			releasePlayingAudio(playing);
@@ -2618,9 +2437,6 @@ void MilesAudioManager::closeAnySamplesUsingFile( const void *fileToClose )
 
 	for (it = m_playing3DSounds.begin(); it != m_playing3DSounds.end(); ) {
 		playing = *it;
-		if (!playing) {
-			continue;
-		}
 
 		if (playing->m_file == fileToClose) {
 			releasePlayingAudio(playing);

--- a/Dependencies/Utility/CMakeLists.txt
+++ b/Dependencies/Utility/CMakeLists.txt
@@ -4,6 +4,7 @@ set(UTILITY_SRC
     Utility/endian_compat.h
     Utility/fstream_adapter.h
     Utility/hash_map_adapter.h
+    Utility/interlocked_adapter.h
     Utility/intrin_compat.h
     Utility/iostream_adapter.h
     Utility/mem_compat.h

--- a/Dependencies/Utility/Utility/interlocked_adapter.h
+++ b/Dependencies/Utility/Utility/interlocked_adapter.h
@@ -1,0 +1,28 @@
+/*
+**	Command & Conquer Generals Zero Hour(tm)
+**	Copyright 2026 TheSuperHackers
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#if defined(_MSC_VER) && _MSC_VER < 1300
+
+inline long InterlockedCompareExchange(long volatile *Destination, long Exchange, long Comparand)
+{
+	return (long)InterlockedCompareExchange((PVOID*)Destination, (PVOID)Exchange, (PVOID)Comparand);
+}
+
+#endif

--- a/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -4521,8 +4521,8 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 		//-----------------------------------------------------------------------------------------
 		case GameMessage::MSG_META_DEMO_MUSIC_NEXT_TRACK:
 		{
-			TheAudio->nextMusicTrack();
-			TheInGameUI->message( TheGameText->FETCH_OR_SUBSTITUTE_FORMAT("GUI:DebugMusicTrack", L"Playing Track: %hs", TheAudio->getMusicTrackName().str()) );
+			AsciiString trackName = TheAudio->nextMusicTrack();
+			TheInGameUI->message( TheGameText->FETCH_OR_SUBSTITUTE_FORMAT("GUI:DebugMusicTrack", L"Playing Track: %hs", trackName.str()) );
 			disp = DESTROY_MESSAGE;
 			break;
 		}
@@ -4531,8 +4531,8 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 		//-----------------------------------------------------------------------------------------
 		case GameMessage::MSG_META_DEMO_MUSIC_PREV_TRACK:
 		{
-			TheAudio->prevMusicTrack();
-			TheInGameUI->message( TheGameText->FETCH_OR_SUBSTITUTE_FORMAT("GUI:DebugMusicTrack", L"Playing Track: %hs", TheAudio->getMusicTrackName().str()) );
+			AsciiString trackName = TheAudio->prevMusicTrack();
+			TheInGameUI->message( TheGameText->FETCH_OR_SUBSTITUTE_FORMAT("GUI:DebugMusicTrack", L"Playing Track: %hs", trackName.str()) );
 			disp = DESTROY_MESSAGE;
 			break;
 		}

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -4904,8 +4904,8 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 		//-----------------------------------------------------------------------------------------
 		case GameMessage::MSG_META_DEMO_MUSIC_NEXT_TRACK:
 		{
-			TheAudio->nextMusicTrack();
-			TheInGameUI->message( TheGameText->FETCH_OR_SUBSTITUTE_FORMAT("GUI:DebugMusicTrack", L"Playing Track: %hs", TheAudio->getMusicTrackName().str()) );
+			AsciiString trackName = TheAudio->nextMusicTrack();
+			TheInGameUI->message( TheGameText->FETCH_OR_SUBSTITUTE_FORMAT("GUI:DebugMusicTrack", L"Playing Track: %hs", trackName.str()) );
 			disp = DESTROY_MESSAGE;
 			break;
 		}
@@ -4914,8 +4914,8 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 		//-----------------------------------------------------------------------------------------
 		case GameMessage::MSG_META_DEMO_MUSIC_PREV_TRACK:
 		{
-			TheAudio->prevMusicTrack();
-			TheInGameUI->message( TheGameText->FETCH_OR_SUBSTITUTE_FORMAT("GUI:DebugMusicTrack", L"Playing Track: %hs", TheAudio->getMusicTrackName().str()) );
+			AsciiString trackName = TheAudio->prevMusicTrack();
+			TheInGameUI->message( TheGameText->FETCH_OR_SUBSTITUTE_FORMAT("GUI:DebugMusicTrack", L"Playing Track: %hs", trackName.str()) );
 			disp = DESTROY_MESSAGE;
 			break;
 		}


### PR DESCRIPTION
**Merge with Rebase**

* Fixes #2715 

This change is split into 2 commits. The first cleans up some junk in Miles Audio Manager. And the second applies everything necessary for the fix.

It fixes a rare data race in `MilesAudioManager`, by preventing accessing potentially invalidated iterators in `MilesAudioManager::findPlayingAudioFrom`, which runs on the MSS Timer thread. This potentially is no issue in regular builds, because an invalidated iterator might still be usable when the memory was not reused.

Note that it NOT possible to simply defer the event processing coming in `MilesAudioManager::notifyOfAudioCompletion` to Main thread, because it wants to continue looping sounds immediately, and any delays will introduce audible stutter.

Note that the stop playing audio step is often seperated from the release playing audio step, because it is illegal to call into Miles while holding the new critical section due Miles holding its own internal mutex during callbacks to `MilesAudioManager::notifyOfAudioCompletion` and Miles API functions.

## TODO

- [x] Test and listen
- [x] Add pull id to commits
- [x] Replicate in Generals