### PR TITLE
bugfix(smudge): Include hash_map_adapter.h to fix STLport build of W3DSmudge

### DIFF
--- a/Core/GameEngine/Include/GameClient/Smudge.h
+++ b/Core/GameEngine/Include/GameClient/Smudge.h
@@ -24,6 +24,9 @@
 #include "WWMath/vector2.h"
 #include "WWMath/vector3.h"
 
+// TheSuperHackers @bugfix Include hash_map_adapter.h so that std::hash is visible as a class template before this header specializes std::hash<Smudge::Identifier> and uses std::hash_map below. Without this, translation units that include Smudge.h without having pulled in <hash_map> beforehand (e.g. W3DSmudge.cpp) fail to compile under STLport. Fixes #2674.
+#include <Utility/hash_map_adapter.h>
+
 #define SET_SMUDGE_PARAMETERS(smudge,pos,offset,size,opacity) (smudge->m_pos=pos;smudge->m_offset=offset;smudge->m_size=size;smudge->m_opacity=opacity;)
 
 struct Smudge : public DLNodeClass<Smudge>


### PR DESCRIPTION
* Fixes #2674
* Follow up for #2484

## What

Adds `#include <Utility/hash_map_adapter.h>` to
`Core/GameEngine/Include/GameClient/Smudge.h`, so that `std::hash` is
visible as a class template before this header specializes it for
`Smudge::Identifier` and uses `std::hash_map<...>` further down.

## Why

PR #2484 introduced a `std::hash<Smudge::Identifier>` specialization
and a `std::hash_map<Smudge::Identifier, Smudge*>` typedef inside
`Smudge.h`, but did not include a header that declares `std::hash`
as a class template under STLport. Translation units that bring
`<hash_map>` in transitively before they `#include "Smudge.h"`
happen to compile; those that do not (e.g. `W3DSmudge.cpp`) fail.

Failure mode reported in #2674:

```
Smudge.h(53) : error C2913: explicit specialization; 'struct std::hash std::hash' is not a class template
Smudge.h(53) : error C2143: syntax error : missing ';' before '<'
…
_hash_fun.h(40) : error C2989: 'hash' : template class has already been defined as a non-template class
        Smudge.h(53) : see declaration of 'hash'
```

The repo already provides `Dependencies/Utility/Utility/hash_map_adapter.h`
as a cross-toolchain shim (STLport → `<hash_map>`, modern → `<unordered_map>`
plus a `std::hash_map` alias). It is the same header `Common/FileSystem.h`
and several other headers use. Including it here fixes the order-of-
declarations issue at the source of the problem, instead of pushing it
onto every TU that includes `Smudge.h`.

## How tested

`./scripts/docker-build.sh --game zh` on Linux (Docker 29.1.3, Wine-Stable
from the SuperHackers container):

* Without this patch: build fails at `W3DSmudge.cpp.obj` exactly as reported in #2674.
* With this patch: build completes successfully, all `z_*` targets link,
  `generalszh.exe` produced at the expected size (~6.1 MB). Game launches
  via Proton against an existing Zero Hour Steam install.

## AI disclosure

Prepared with assistance from Anthropic Claude. The diff is three lines
(one `#include` + one in-line comment + a blank line). It was authored,
reviewed, built and tested end-to-end by the human submitter before
submission.