### PR TITLE
bugfix(physics): Prevent building crash damage from dealing damage to other objects

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
@@ -32,6 +32,7 @@
 #define NO_DEBUG_CRC
 
 #include "Common/PerfTimer.h"
+#include "Common/Player.h"
 #include "Common/ThingTemplate.h"
 #include "Common/Xfer.h"
 #include "GameClient/FXList.h"
@@ -1266,6 +1267,7 @@ void PhysicsBehavior::onCollide( Object *other, const Coord3D *loc, const Coord3
 							damageInfo.in.m_damageType = weaponTemplate->getDamageType();
 							damageInfo.in.m_deathType = weaponTemplate->getDeathType();
 							damageInfo.in.m_sourceID = obj->getID();
+							damageInfo.in.m_sourcePlayerMask = obj->getControllingPlayer() ? obj->getControllingPlayer()->getPlayerMask() : 0;
 							damageInfo.in.m_amount = weaponTemplate->getPrimaryDamage(nullBonus);
 
 							other->attemptDamage(&damageInfo);

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
@@ -1258,16 +1258,19 @@ void PhysicsBehavior::onCollide( Object *other, const Coord3D *loc, const Coord3
 #else
 						// TheSuperHackers @bugfix Stubbjax 17/05/2026 Prevent building collisions from dealing collateral damage to other objects.
 						const WeaponTemplate* weaponTemplate = getPhysicsBehaviorModuleData()->m_vehicleCrashesIntoBuildingWeaponTemplate;
-						WeaponBonus nullBonus;
+						if (weaponTemplate != nullptr)
+						{
+							WeaponBonus nullBonus;
 
-						DamageInfo damageInfo;
-						damageInfo.in.m_damageType = weaponTemplate->getDamageType();
-						damageInfo.in.m_deathType = weaponTemplate->getDeathType();
-						damageInfo.in.m_sourceID = obj->getID();
-						damageInfo.in.m_amount = weaponTemplate->getPrimaryDamage(nullBonus);
+							DamageInfo damageInfo;
+							damageInfo.in.m_damageType = weaponTemplate->getDamageType();
+							damageInfo.in.m_deathType = weaponTemplate->getDeathType();
+							damageInfo.in.m_sourceID = obj->getID();
+							damageInfo.in.m_amount = weaponTemplate->getPrimaryDamage(nullBonus);
 
-						other->attemptDamage(&damageInfo);
-						FXList::doFXObj(weaponTemplate->getFireFX(obj->getVeterancyLevel()), obj);
+							other->attemptDamage(&damageInfo);
+							FXList::doFXObj(weaponTemplate->getFireFX(obj->getVeterancyLevel()), obj);
+						}
 #endif
 					}
 					TheGameLogic->destroyObject(obj);

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
@@ -34,6 +34,7 @@
 #include "Common/PerfTimer.h"
 #include "Common/ThingTemplate.h"
 #include "Common/Xfer.h"
+#include "GameClient/FXList.h"
 #include "GameLogic/GameLogic.h"
 #include "GameLogic/Module/AIUpdate.h"
 #include "GameLogic/Module/BodyModule.h"
@@ -1252,7 +1253,22 @@ void PhysicsBehavior::onCollide( Object *other, const Coord3D *loc, const Coord3
 					// fall into a building. if a vehicle, blow up. then destroy ourself (not die), regardless.
 					if (obj->isKindOf(KINDOF_VEHICLE))
 					{
+#if RETAIL_COMPATIBLE_CRC
 						TheWeaponStore->createAndFireTempWeapon(getPhysicsBehaviorModuleData()->m_vehicleCrashesIntoBuildingWeaponTemplate, obj, obj->getPosition());
+#else
+						// TheSuperHackers @bugfix Stubbjax 17/05/2026 Prevent building collisions from dealing collateral damage to other objects.
+						const WeaponTemplate* weaponTemplate = getPhysicsBehaviorModuleData()->m_vehicleCrashesIntoBuildingWeaponTemplate;
+						WeaponBonus nullBonus;
+
+						DamageInfo damageInfo;
+						damageInfo.in.m_damageType = weaponTemplate->getDamageType();
+						damageInfo.in.m_deathType = weaponTemplate->getDeathType();
+						damageInfo.in.m_sourceID = obj->getID();
+						damageInfo.in.m_amount = weaponTemplate->getPrimaryDamage(nullBonus);
+
+						other->attemptDamage(&damageInfo);
+						FXList::doFXObj(weaponTemplate->getFireFX(obj->getVeterancyLevel()), obj);
+#endif
 					}
 					TheGameLogic->destroyObject(obj);
 					return;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
@@ -34,6 +34,7 @@
 #include "Common/PerfTimer.h"
 #include "Common/ThingTemplate.h"
 #include "Common/Xfer.h"
+#include "GameClient/FXList.h"
 #include "GameLogic/GameLogic.h"
 #include "GameLogic/Module/AIUpdate.h"
 #include "GameLogic/Module/BodyModule.h"
@@ -1377,7 +1378,22 @@ void PhysicsBehavior::onCollide( Object *other, const Coord3D *loc, const Coord3
 					// fall into a building. if a vehicle, blow up. then destroy ourself (not die), regardless.
 					if (obj->isKindOf(KINDOF_VEHICLE))
 					{
+#if RETAIL_COMPATIBLE_CRC
 						TheWeaponStore->createAndFireTempWeapon(getPhysicsBehaviorModuleData()->m_vehicleCrashesIntoBuildingWeaponTemplate, obj, obj->getPosition());
+#else
+						// TheSuperHackers @bugfix Stubbjax 17/05/2026 Prevent building collisions from dealing collateral damage to other objects.
+						const WeaponTemplate* weaponTemplate = getPhysicsBehaviorModuleData()->m_vehicleCrashesIntoBuildingWeaponTemplate;
+						WeaponBonus nullBonus;
+
+						DamageInfo damageInfo;
+						damageInfo.in.m_damageType = weaponTemplate->getDamageType();
+						damageInfo.in.m_deathType = weaponTemplate->getDeathType();
+						damageInfo.in.m_sourceID = obj->getID();
+						damageInfo.in.m_amount = weaponTemplate->getPrimaryDamage(nullBonus);
+
+						other->attemptDamage(&damageInfo);
+						FXList::doFXObj(weaponTemplate->getFireFX(obj->getVeterancyLevel()), obj);
+#endif
 					}
 					TheGameLogic->destroyObject(obj);
 					return;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
@@ -32,6 +32,7 @@
 #define NO_DEBUG_CRC
 
 #include "Common/PerfTimer.h"
+#include "Common/Player.h"
 #include "Common/ThingTemplate.h"
 #include "Common/Xfer.h"
 #include "GameClient/FXList.h"
@@ -1391,6 +1392,7 @@ void PhysicsBehavior::onCollide( Object *other, const Coord3D *loc, const Coord3
 							damageInfo.in.m_damageType = weaponTemplate->getDamageType();
 							damageInfo.in.m_deathType = weaponTemplate->getDeathType();
 							damageInfo.in.m_sourceID = obj->getID();
+							damageInfo.in.m_sourcePlayerMask = obj->getControllingPlayer() ? obj->getControllingPlayer()->getPlayerMask() : 0;
 							damageInfo.in.m_amount = weaponTemplate->getPrimaryDamage(nullBonus);
 
 							other->attemptDamage(&damageInfo);

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/PhysicsUpdate.cpp
@@ -1383,16 +1383,19 @@ void PhysicsBehavior::onCollide( Object *other, const Coord3D *loc, const Coord3
 #else
 						// TheSuperHackers @bugfix Stubbjax 17/05/2026 Prevent building collisions from dealing collateral damage to other objects.
 						const WeaponTemplate* weaponTemplate = getPhysicsBehaviorModuleData()->m_vehicleCrashesIntoBuildingWeaponTemplate;
-						WeaponBonus nullBonus;
+						if (weaponTemplate != nullptr)
+						{
+							WeaponBonus nullBonus;
 
-						DamageInfo damageInfo;
-						damageInfo.in.m_damageType = weaponTemplate->getDamageType();
-						damageInfo.in.m_deathType = weaponTemplate->getDeathType();
-						damageInfo.in.m_sourceID = obj->getID();
-						damageInfo.in.m_amount = weaponTemplate->getPrimaryDamage(nullBonus);
+							DamageInfo damageInfo;
+							damageInfo.in.m_damageType = weaponTemplate->getDamageType();
+							damageInfo.in.m_deathType = weaponTemplate->getDeathType();
+							damageInfo.in.m_sourceID = obj->getID();
+							damageInfo.in.m_amount = weaponTemplate->getPrimaryDamage(nullBonus);
 
-						other->attemptDamage(&damageInfo);
-						FXList::doFXObj(weaponTemplate->getFireFX(obj->getVeterancyLevel()), obj);
+							other->attemptDamage(&damageInfo);
+							FXList::doFXObj(weaponTemplate->getFireFX(obj->getVeterancyLevel()), obj);
+						}
 #endif
 					}
 					TheGameLogic->destroyObject(obj);


### PR DESCRIPTION
This change prevents collateral damage caused by `VehicleCrashesIntoBuildingWeapon` when a dead vehicle collides with a building. This fix is supplemental to #2204.

### Before
The Tank Hunters receive damage if the dead Helix collides with the Bunker

https://github.com/user-attachments/assets/7345c639-e5fd-4b5b-912a-a7a99a5470ba

### After
The Tank Hunters no longer receive damage if the dead Helix collides with the Bunker

https://github.com/user-attachments/assets/93311b62-e95e-4dae-84c1-13321f23fb02