### PR TITLE
perf(network): Replace extern global network variables with const ones

### DIFF
--- a/Core/GameEngine/Include/GameNetwork/NetworkDefs.h
+++ b/Core/GameEngine/Include/GameNetwork/NetworkDefs.h
@@ -27,10 +27,10 @@
 #include "Lib/BaseType.h"
 #include "Common/MessageStream.h"
 
-static const Int WOL_NAME_LEN = 64;
+static constexpr const Int WOL_NAME_LEN = 64;
 
 /// Max number of commands per frame
-static const Int MAX_COMMANDS = 256;
+static constexpr const Int MAX_COMMANDS = 256;
 
 // TheSuperHackers @tweak Mauller 26/08/2025 reduce the minimum runahead from 10
 // This lets network games run at latencies down to 133ms when the network conditions allow
@@ -87,7 +87,7 @@ static constexpr const Int MAX_MESSAGES = 256;
  * Command packet - contains frame #, total # of commands, and each command.  This is what gets sent
  * to each player every frame
  */
-static const Int numCommandsPerCommandPacket = (MAX_NETWORK_MESSAGE_LEN - sizeof(UnsignedInt) - sizeof(UnsignedShort))/sizeof(GameMessage);
+static constexpr const Int numCommandsPerCommandPacket = (MAX_NETWORK_MESSAGE_LEN - sizeof(UnsignedInt) - sizeof(UnsignedShort))/sizeof(GameMessage);
 #pragma pack(push, 1)
 struct CommandPacket
 {
@@ -195,38 +195,38 @@ enum PlayerLeaveCode CPP_11(: Int) {
 };
 
 // Magic number for identifying a Generals packet.
-static const UnsignedShort GENERALS_MAGIC_NUMBER = 0xF00D;
+static constexpr const UnsignedShort GENERALS_MAGIC_NUMBER = 0xF00D;
 
 // The number of fps history entries.
-//static const Int NETWORK_FPS_HISTORY_LENGTH = 30;
+//static constexpr const Int NETWORK_FPS_HISTORY_LENGTH = 30;
 
 // The number of ping history entries.
-//static const Int NETWORK_LATENCY_HISTORY_LENGTH = 200;
+//static constexpr const Int NETWORK_LATENCY_HISTORY_LENGTH = 200;
 
 // The number of miliseconds between run ahead metrics things
-//static const Int NETWORK_RUN_AHEAD_METRICS_TIME = 5000;
+//static constexpr const Int NETWORK_RUN_AHEAD_METRICS_TIME = 5000;
 
 // The number of cushion values to keep.
-//static const Int NETWORK_CUSHION_HISTORY_LENGTH = 10;
+//static constexpr const Int NETWORK_CUSHION_HISTORY_LENGTH = 10;
 
 // The amount of slack in the run ahead value.  This is the percentage of the calculated run ahead that is added.
-//static const Int NETWORK_RUN_AHEAD_SLACK = 20;
+//static constexpr const Int NETWORK_RUN_AHEAD_SLACK = 20;
 
 // The number of seconds between when the connections to each player send a keep-alive packet.
 // This should be less than 30 just to keep firewall ports open.
-//static const Int NETWORK_KEEPALIVE_DELAY = 20;
+//static constexpr const Int NETWORK_KEEPALIVE_DELAY = 20;
 
 // The number of milliseconds between when the game gets stuck on a frame for a network stall and
 // and when the disconnect dialog comes up.
-//static const Int NETWORK_DISCONNECT_TIME = 5000;
+//static constexpr const Int NETWORK_DISCONNECT_TIME = 5000;
 
 // The number of miliseconds between when a player's last disconnect keep alive command
 // was received and when they are considered disconnected from the game.
-//static const Int NETWORK_PLAYER_TIMEOUT_TIME = 60000;
+//static constexpr const Int NETWORK_PLAYER_TIMEOUT_TIME = 60000;
 
 // The base port number used for the transport socket.  A players slot number is added to this
 // value to get their actual port number.
-static const Int NETWORK_BASE_PORT_NUMBER = 8088;
+static constexpr const Int NETWORK_BASE_PORT_NUMBER = 8088;
 
 // the singleton
 class NetworkInterface;

--- a/Core/GameEngine/Include/GameNetwork/NetworkDefs.h
+++ b/Core/GameEngine/Include/GameNetwork/NetworkDefs.h
@@ -32,14 +32,16 @@ static const Int WOL_NAME_LEN = 64;
 /// Max number of commands per frame
 static const Int MAX_COMMANDS = 256;
 
-extern Int MIN_LOGIC_FRAMES;
-extern Int MAX_FRAMES_AHEAD;
-extern Int MIN_RUNAHEAD;
+// TheSuperHackers @tweak Mauller 26/08/2025 reduce the minimum runahead from 10
+// This lets network games run at latencies down to 133ms when the network conditions allow
+static const Int MIN_LOGIC_FRAMES = 5;
+static const Int MAX_FRAMES_AHEAD = 128;
+static const Int MIN_RUNAHEAD = 4;
 
 // FRAME_DATA_LENGTH needs to be MAX_FRAMES_AHEAD+1 because a player on a different
 // computer can send commands for a frame that is one beyond twice the max runahead.
-extern Int FRAME_DATA_LENGTH;
-extern Int FRAMES_TO_KEEP;
+static const Int FRAME_DATA_LENGTH = (MAX_FRAMES_AHEAD + 1) * 2;
+static const Int FRAMES_TO_KEEP = (MAX_FRAMES_AHEAD / 2) + 1;
 
 // This is the connection numbering: 1-8 are for players
 enum ConnectionNumbers CPP_11(: Int)

--- a/Core/GameEngine/Include/GameNetwork/NetworkDefs.h
+++ b/Core/GameEngine/Include/GameNetwork/NetworkDefs.h
@@ -34,14 +34,14 @@ static const Int MAX_COMMANDS = 256;
 
 // TheSuperHackers @tweak Mauller 26/08/2025 reduce the minimum runahead from 10
 // This lets network games run at latencies down to 133ms when the network conditions allow
-static const Int MIN_LOGIC_FRAMES = 5;
-static const Int MAX_FRAMES_AHEAD = 128;
-static const Int MIN_RUNAHEAD = 4;
+static constexpr const Int MIN_LOGIC_FRAMES = 5;
+static constexpr const Int MAX_FRAMES_AHEAD = 128;
+static constexpr const Int MIN_RUNAHEAD = 4;
 
 // FRAME_DATA_LENGTH needs to be MAX_FRAMES_AHEAD+1 because a player on a different
 // computer can send commands for a frame that is one beyond twice the max runahead.
-static const Int FRAME_DATA_LENGTH = (MAX_FRAMES_AHEAD + 1) * 2;
-static const Int FRAMES_TO_KEEP = (MAX_FRAMES_AHEAD / 2) + 1;
+static constexpr const Int FRAME_DATA_LENGTH = (MAX_FRAMES_AHEAD + 1) * 2;
+static constexpr const Int FRAMES_TO_KEEP = (MAX_FRAMES_AHEAD / 2) + 1;
 
 // This is the connection numbering: 1-8 are for players
 enum ConnectionNumbers CPP_11(: Int)

--- a/Core/GameEngine/Source/GameNetwork/NetworkUtil.cpp
+++ b/Core/GameEngine/Source/GameNetwork/NetworkUtil.cpp
@@ -27,14 +27,6 @@
 
 #include "GameNetwork/networkutil.h"
 
-// TheSuperHackers @tweak Mauller 26/08/2025 reduce the minimum runahead from 10
-// This lets network games run at latencies down to 133ms when the network conditions allow
-Int MIN_LOGIC_FRAMES = 5;
-Int MAX_FRAMES_AHEAD = 128;
-Int MIN_RUNAHEAD = 4;
-Int FRAME_DATA_LENGTH = (MAX_FRAMES_AHEAD+1)*2;
-Int FRAMES_TO_KEEP = (MAX_FRAMES_AHEAD/2) + 1;
-
 #ifdef DEBUG_LOGGING
 
 void dumpBufferToLog(const void *vBuf, Int len, const char *fname, Int line)

--- a/Generals/Code/GameEngine/Source/Common/CommandLine.cpp
+++ b/Generals/Code/GameEngine/Source/Common/CommandLine.cpp
@@ -868,17 +868,6 @@ Int parseSelectAll( char *args[], int num )
 
 	return 1;
 }
-
-Int parseRunAhead( char *args[], Int num )
-{
-	if (num > 2)
-	{
-		MIN_RUNAHEAD = atoi(args[1]);
-		MAX_FRAMES_AHEAD = atoi(args[2]);
-		FRAME_DATA_LENGTH = (MAX_FRAMES_AHEAD + 1)*2;
-	}
-	return 3;
-}
 #endif
 
 
@@ -1279,7 +1268,6 @@ static CommandLineParam paramsForEngineInit[] =
 	{ "-logToCon", parseLogToConsole },
 	{ "-vTune", parseVTune },
 	{ "-selectTheUnselectable", parseSelectAll },
-	{ "-RunAhead", parseRunAhead },
 #if ENABLE_CONFIGURABLE_SHROUD
 	{ "-noshroud", parseNoShroud },
 #endif

--- a/GeneralsMD/Code/GameEngine/Source/Common/CommandLine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/CommandLine.cpp
@@ -868,17 +868,6 @@ Int parseSelectAll( char *args[], int num )
 
 	return 1;
 }
-
-Int parseRunAhead( char *args[], Int num )
-{
-	if (num > 2)
-	{
-		MIN_RUNAHEAD = atoi(args[1]);
-		MAX_FRAMES_AHEAD = atoi(args[2]);
-		FRAME_DATA_LENGTH = (MAX_FRAMES_AHEAD + 1)*2;
-	}
-	return 3;
-}
 #endif
 
 
@@ -1279,7 +1268,6 @@ static CommandLineParam paramsForEngineInit[] =
 	{ "-logToCon", parseLogToConsole },
 	{ "-vTune", parseVTune },
 	{ "-selectTheUnselectable", parseSelectAll },
-	{ "-RunAhead", parseRunAhead },
 #if ENABLE_CONFIGURABLE_SHROUD
 	{ "-noshroud", parseNoShroud },
 #endif


### PR DESCRIPTION
This PR removes the "-RunAhead" command line so that a couple of global network variables can be marked ~`static const`~ `static constexpr const` for safety and performance. Considering that the "RunAhead" command is for development only and likely rarely used, I think it's ok to get rid of it.

The current setup with `extern` in the header and definition in the source file causes the compiler to miss out on optimizations. It's possible that link time optimization would fix this, but that's not currently used.

## TODO:
- [x] Replicate in Generals.