### PR TITLE
fix(headless): Skip early load abort in headless replay simulations

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/GameEngine.h
+++ b/Generals/Code/GameEngine/Include/Common/GameEngine.h
@@ -104,7 +104,6 @@ protected:
 	Bool m_isActive; ///< app has OS focus.
 };
 
-inline void GameEngine::setQuitting( Bool quitting ) { m_quitting = quitting; }
 inline Bool GameEngine::getQuitting() { return m_quitting; }
 
 // the game engine singleton

--- a/Generals/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -299,6 +299,15 @@ GameEngine::~GameEngine()
 #endif
 }
 
+void GameEngine::setQuitting( Bool quitting )
+{
+	if (quitting && TheGlobalData && TheGlobalData->m_headless)
+	{
+		return;
+	}
+	m_quitting = quitting;
+}
+
 //-------------------------------------------------------------------------------------------------
 Bool GameEngine::isTimeFrozen()
 {

--- a/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -3712,6 +3712,11 @@ void GameLogic::exitGame()
 
 void GameLogic::quit(Bool toDesktop)
 {
+	if (TheGlobalData && TheGlobalData->m_headless)
+	{
+		return;
+	}
+
 	const Bool isNotLoading = (!isLoadingMap() && !isLoadingSave());
 
 	if (isInGame())

--- a/GeneralsMD/Code/GameEngine/Include/Common/GameEngine.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/GameEngine.h
@@ -103,7 +103,6 @@ protected:
 	Bool m_isActive; ///< app has OS focus.
 };
 
-inline void GameEngine::setQuitting( Bool quitting ) { m_quitting = quitting; }
 inline Bool GameEngine::getQuitting() { return m_quitting; }
 
 // the game engine singleton

--- a/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -300,6 +300,15 @@ GameEngine::~GameEngine()
 #endif
 }
 
+void GameEngine::setQuitting( Bool quitting )
+{
+	if (quitting && TheGlobalData && TheGlobalData->m_headless)
+	{
+		return;
+	}
+	m_quitting = quitting;
+}
+
 //-------------------------------------------------------------------------------------------------
 Bool GameEngine::isTimeFrozen()
 {

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -4272,6 +4272,11 @@ void GameLogic::exitGame()
 
 void GameLogic::quit(Bool toDesktop)
 {
+	if (TheGlobalData && TheGlobalData->m_headless)
+	{
+		return;
+	}
+
 	const Bool isNotLoading = (!isLoadingMap() && !isLoadingSave());
 
 	if (isInGame())


### PR DESCRIPTION
Fixes the CI replay checker instantly completing introduced by #2336.

Prevents transitioning the engine to a quitting state globally and ignores quit events in GameLogic when running in headless mode. This eliminates the need for bypass hacks in GameLogic::updateLoadProgress() and ensures that early initialization triggers or replay quit events do not prematurely abort consecutive replay simulations.

Claude helped. Worked locally.