### PR TITLE
fix(memory): Fix audio event related memory leaks when pausing the game

### DIFF
--- a/Core/GameEngine/Include/Common/AudioRequest.h
+++ b/Core/GameEngine/Include/Common/AudioRequest.h
@@ -45,6 +45,8 @@ struct AudioRequest : public MemoryPoolObject
 	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( AudioRequest, "AudioRequest" )
 
 public:
+	AudioEventRTS* releasePendingEvent();
+
 	RequestType m_request;
 	union
 	{

--- a/Core/GameEngine/Source/Common/Audio/AudioRequest.cpp
+++ b/Core/GameEngine/Source/Common/Audio/AudioRequest.cpp
@@ -30,5 +30,8 @@
 
 AudioRequest::~AudioRequest()
 {
-
+	if (m_usePendingEvent)
+	{
+		delete m_pendingEvent;
+	}
 }

--- a/Core/GameEngine/Source/Common/Audio/AudioRequest.cpp
+++ b/Core/GameEngine/Source/Common/Audio/AudioRequest.cpp
@@ -35,3 +35,15 @@ AudioRequest::~AudioRequest()
 		delete m_pendingEvent;
 	}
 }
+
+AudioEventRTS* AudioRequest::releasePendingEvent()
+{
+	if (m_usePendingEvent)
+	{
+		m_usePendingEvent = false;
+		AudioEventRTS* event = m_pendingEvent;
+		m_pendingEvent = nullptr;
+		return event;
+	}
+	return nullptr;
+}

--- a/Core/GameEngineDevice/Include/MilesAudioDevice/MilesAudioManager.h
+++ b/Core/GameEngineDevice/Include/MilesAudioDevice/MilesAudioManager.h
@@ -251,7 +251,7 @@ class MilesAudioManager : public AudioManager
 		void initSamplePools();
 		void processRequest( AudioRequest *req );
 
-		void playAudioEvent( AudioEventRTS *event );
+		void playAudioEvent( AudioEventRTS*& event );
 		void stopAudioEvent( AudioHandle handle );
 		void pauseAudioEvent( AudioHandle handle );
 

--- a/Core/GameEngineDevice/Include/MilesAudioDevice/MilesAudioManager.h
+++ b/Core/GameEngineDevice/Include/MilesAudioDevice/MilesAudioManager.h
@@ -251,7 +251,7 @@ class MilesAudioManager : public AudioManager
 		void initSamplePools();
 		void processRequest( AudioRequest *req );
 
-		void playAudioEvent( AudioEventRTS*& event );
+		void playAudioEvent( AudioRequest* req );
 		void stopAudioEvent( AudioHandle handle );
 		void pauseAudioEvent( AudioHandle handle );
 

--- a/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
+++ b/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
@@ -713,16 +713,16 @@ void MilesAudioManager::playAudioEvent( AudioRequest* req )
 			}
 
 			// Put this on here, so that the audio event RTS will be cleaned up regardless.
-			audio->m_audioEventRTS = req->releasePendingEvent();
+			audio->m_audioEventRTS = event = req->releasePendingEvent();
 			audio->m_stream = stream;
 			audio->m_type = PAT_Stream;
 
 			if (stream) {
-				if ((info->m_soundType == AT_Streaming) && audio->m_audioEventRTS->getUninterruptible()) {
+				if ((info->m_soundType == AT_Streaming) && event->getUninterruptible()) {
 					setDisallowSpeech(TRUE);
 	 			}
-				AIL_set_stream_volume_pan(stream, getEffectiveVolume(audio->m_audioEventRTS), 0.5f);
-				playStream(audio->m_audioEventRTS, stream);
+				AIL_set_stream_volume_pan(stream, getEffectiveVolume(event), 0.5f);
+				playStream(event, stream);
 				m_playingStreams.push_back(audio);
 				audio = nullptr;
 			}
@@ -782,14 +782,14 @@ void MilesAudioManager::playAudioEvent( AudioRequest* req )
 					sample3D = nullptr;
 				}
 				// Push it onto the list of playing things
-				audio->m_audioEventRTS = req->releasePendingEvent();
+				audio->m_audioEventRTS = event = req->releasePendingEvent();
 				audio->m_3DSample = sample3D;
 				audio->m_file = nullptr;
 				audio->m_type = PAT_3DSample;
 				m_playing3DSounds.push_back(audio);
 
 				if (sample3D) {
-					audio->m_file = playSample3D(audio->m_audioEventRTS, sample3D);
+					audio->m_file = playSample3D(event, sample3D);
 					m_sound->notifyOf3DSampleStart();
 				}
 
@@ -853,14 +853,14 @@ void MilesAudioManager::playAudioEvent( AudioRequest* req )
 				}
 
 				// Push it onto the list of playing things
-				audio->m_audioEventRTS = req->releasePendingEvent();
+				audio->m_audioEventRTS = event = req->releasePendingEvent();
 				audio->m_sample = sample;
 				audio->m_file = nullptr;
 				audio->m_type = PAT_Sample;
 				m_playingSounds.push_back(audio);
 
 				if (sample) {
-					audio->m_file = playSample(audio->m_audioEventRTS, sample);
+					audio->m_file = playSample(event, sample);
 					m_sound->notifyOf2DSampleStart();
 				}
 

--- a/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
+++ b/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
@@ -652,8 +652,12 @@ void MilesAudioManager::pauseAmbient( Bool shouldPause )
 }
 
 //-------------------------------------------------------------------------------------------------
-void MilesAudioManager::playAudioEvent( AudioEventRTS*& event )
+void MilesAudioManager::playAudioEvent( AudioRequest* req )
 {
+	DEBUG_ASSERTCRASH(req->m_usePendingEvent && req->m_pendingEvent, ("audio request was expected to contain a valid audio event"));
+
+	AudioEventRTS* event = req->m_pendingEvent;
+
 #ifdef INTENSIVE_AUDIO_DEBUG
 	DEBUG_LOG(("MILES (%d) - Processing play request: %d (%s)", TheGameLogic->getFrame(), event->getPlayingHandle(), event->getEventName().str()));
 #endif
@@ -709,8 +713,7 @@ void MilesAudioManager::playAudioEvent( AudioEventRTS*& event )
 			}
 
 			// Put this on here, so that the audio event RTS will be cleaned up regardless.
-			audio->m_audioEventRTS = event;
-			event = nullptr;
+			audio->m_audioEventRTS = req->releasePendingEvent();
 			audio->m_stream = stream;
 			audio->m_type = PAT_Stream;
 
@@ -779,8 +782,7 @@ void MilesAudioManager::playAudioEvent( AudioEventRTS*& event )
 					sample3D = nullptr;
 				}
 				// Push it onto the list of playing things
-				audio->m_audioEventRTS = event;
-				event = nullptr;
+				audio->m_audioEventRTS = req->releasePendingEvent();
 				audio->m_3DSample = sample3D;
 				audio->m_file = nullptr;
 				audio->m_type = PAT_3DSample;
@@ -851,8 +853,7 @@ void MilesAudioManager::playAudioEvent( AudioEventRTS*& event )
 				}
 
 				// Push it onto the list of playing things
-				audio->m_audioEventRTS = event;
-				event = nullptr;
+				audio->m_audioEventRTS = req->releasePendingEvent();
 				audio->m_sample = sample;
 				audio->m_file = nullptr;
 				audio->m_type = PAT_Sample;
@@ -2933,7 +2934,7 @@ void MilesAudioManager::processRequest( AudioRequest *req )
 	{
 		case AR_Play:
 		{
-			playAudioEvent(req->m_pendingEvent);
+			playAudioEvent(req);
 			break;
 		}
 		case AR_Pause:

--- a/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
+++ b/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp
@@ -652,7 +652,7 @@ void MilesAudioManager::pauseAmbient( Bool shouldPause )
 }
 
 //-------------------------------------------------------------------------------------------------
-void MilesAudioManager::playAudioEvent( AudioEventRTS *event )
+void MilesAudioManager::playAudioEvent( AudioEventRTS*& event )
 {
 #ifdef INTENSIVE_AUDIO_DEBUG
 	DEBUG_LOG(("MILES (%d) - Processing play request: %d (%s)", TheGameLogic->getFrame(), event->getPlayingHandle(), event->getEventName().str()));
@@ -710,15 +710,16 @@ void MilesAudioManager::playAudioEvent( AudioEventRTS *event )
 
 			// Put this on here, so that the audio event RTS will be cleaned up regardless.
 			audio->m_audioEventRTS = event;
+			event = nullptr;
 			audio->m_stream = stream;
 			audio->m_type = PAT_Stream;
 
 			if (stream) {
-				if ((info->m_soundType == AT_Streaming) && event->getUninterruptible()) {
+				if ((info->m_soundType == AT_Streaming) && audio->m_audioEventRTS->getUninterruptible()) {
 					setDisallowSpeech(TRUE);
 	 			}
-				AIL_set_stream_volume_pan(stream, getEffectiveVolume(event), 0.5f);
-				playStream(event, stream);
+				AIL_set_stream_volume_pan(stream, getEffectiveVolume(audio->m_audioEventRTS), 0.5f);
+				playStream(audio->m_audioEventRTS, stream);
 				m_playingStreams.push_back(audio);
 				audio = nullptr;
 			}
@@ -779,13 +780,14 @@ void MilesAudioManager::playAudioEvent( AudioEventRTS *event )
 				}
 				// Push it onto the list of playing things
 				audio->m_audioEventRTS = event;
+				event = nullptr;
 				audio->m_3DSample = sample3D;
 				audio->m_file = nullptr;
 				audio->m_type = PAT_3DSample;
 				m_playing3DSounds.push_back(audio);
 
 				if (sample3D) {
-					audio->m_file = playSample3D(event, sample3D);
+					audio->m_file = playSample3D(audio->m_audioEventRTS, sample3D);
 					m_sound->notifyOf3DSampleStart();
 				}
 
@@ -850,13 +852,14 @@ void MilesAudioManager::playAudioEvent( AudioEventRTS *event )
 
 				// Push it onto the list of playing things
 				audio->m_audioEventRTS = event;
+				event = nullptr;
 				audio->m_sample = sample;
 				audio->m_file = nullptr;
 				audio->m_type = PAT_Sample;
 				m_playingSounds.push_back(audio);
 
 				if (sample) {
-					audio->m_file = playSample(event, sample);
+					audio->m_file = playSample(audio->m_audioEventRTS, sample);
 					m_sound->notifyOf2DSampleStart();
 				}
 


### PR DESCRIPTION
* Related PR https://github.com/TheSuperHackers/GeneralsGameCode/pull/2710

Pausing the game leaks audio events that were in the audio request container at the time. This PR fixes that.

This code is called to get rid of some of the audio requests when pausing the game:
https://github.com/TheSuperHackers/GeneralsGameCode/blob/2219f63c8b3713841f1a618bbbc4f3798bb4ec53/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp#L587-L601

`AudioRequest::m_pendingEvent` can be an owning raw pointer, though, which the destructor of `AudioRequest` should delete when needed. It currently doesn't, which is why the leak happens.
https://github.com/TheSuperHackers/GeneralsGameCode/blob/2219f63c8b3713841f1a618bbbc4f3798bb4ec53/Core/GameEngine/Include/Common/AudioRequest.h#L51

There's one exception where the ownership of the audio event is taken away from the audio request:
https://github.com/TheSuperHackers/GeneralsGameCode/blob/2219f63c8b3713841f1a618bbbc4f3798bb4ec53/Core/GameEngineDevice/Source/MilesAudioDevice/MilesAudioManager.cpp#L2238