### PR TITLE
tweak(gui): Show Money Per Minute in Player Info List

### DIFF
--- a/Generals/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/Generals/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -789,6 +789,7 @@ protected:
 		{
 			LabelType_Team,
 			LabelType_Money,
+			LabelType_MoneyPerMinute,
 			LabelType_Rank,
 			LabelType_Xp,
 
@@ -799,6 +800,7 @@ protected:
 		{
 			ValueType_Team,
 			ValueType_Money,
+			ValueType_MoneyPerMinute,
 			ValueType_Rank,
 			ValueType_Xp,
 			ValueType_Name,

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -6156,6 +6156,9 @@ void InGameUI::drawPlayerInfoList()
 			{
 				if (column == PlayerInfoList::ValueType_MoneyPerMinute)
 				{
+					if (!showMoneyPerMinute)
+						continue;
+
 					playerInfoListValue = formatIncomeValue(currentValues[column]);
 				}
 				else
@@ -6188,7 +6191,7 @@ void InGameUI::drawPlayerInfoList()
 	Int labelX = baseX;
 	for (column = 0; column < PlayerInfoList::LabelType_Count; ++column)
 	{
-		if (!showMoneyPerMinute && column == PlayerInfoList::LabelType_MoneyPerMinute)
+		if (column == PlayerInfoList::LabelType_MoneyPerMinute && !showMoneyPerMinute)
 			continue;
 
 		labelWidths[column] = m_playerInfoList.labels[column]->getWidth();
@@ -6203,7 +6206,7 @@ void InGameUI::drawPlayerInfoList()
 
 		for (column = 0; column < PlayerInfoList::LabelType_Count; ++column)
 		{
-			if (!showMoneyPerMinute && column == PlayerInfoList::LabelType_MoneyPerMinute)
+			if (column == PlayerInfoList::LabelType_MoneyPerMinute && !showMoneyPerMinute)
 				continue;
 
 			m_playerInfoList.labels[column]->draw(columnLabelX[column], drawY, m_playerInfoListLabelColor, m_playerInfoListDropColor);

--- a/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -978,6 +978,7 @@ void InGameUI::PlayerInfoList::init(const AsciiString &fontName, Int pointSize, 
 
 	labels[LabelType_Team]->setText(TheGameText->FETCH_OR_SUBSTITUTE_FORMAT("GUI:PlayerInfoListLabelTeam", L"T"));
 	labels[LabelType_Money]->setText(TheGameText->FETCH_OR_SUBSTITUTE_FORMAT("GUI:PlayerInfoListLabelMoney", L"$"));
+	labels[LabelType_MoneyPerMinute]->setText(TheGameText->FETCH_OR_SUBSTITUTE_FORMAT("GUI:PlayerInfoListLabelMoneyPerMinute", L"+"));
 	labels[LabelType_Rank]->setText(TheGameText->FETCH_OR_SUBSTITUTE_FORMAT("GUI:PlayerInfoListLabelRank", L"*"));
 	labels[LabelType_Xp]->setText(TheGameText->FETCH_OR_SUBSTITUTE_FORMAT("GUI:PlayerInfoListLabelXp", L"XP"));
 }
@@ -6125,6 +6126,7 @@ void InGameUI::drawPlayerInfoList()
 	Int maxValueWidths[PlayerInfoList::LabelType_Count] = {0};
 	Color rowColors[MAX_PLAYER_COUNT] = {0};
 	Int nameValueWidth[MAX_PLAYER_COUNT] = {0};
+	const Bool showMoneyPerMinute = TheGlobalData->m_showMoneyPerMinute;
 	Int column;
 
 	for (Int slotIndex = 0; slotIndex < MAX_SLOTS && rowCount < MAX_PLAYER_COUNT; ++slotIndex)
@@ -6139,18 +6141,27 @@ void InGameUI::drawPlayerInfoList()
 
 		const Int row = rowCount++;
 		const UnsignedInt teamValue = (slot && slot->getTeamNumber() >= 0) ? static_cast<UnsignedInt>(slot->getTeamNumber() + 1) : 0;
-		const UnsignedInt moneyValue = player->getMoney()->countMoney();
+		const Money *money = player->getMoney();
+		const UnsignedInt moneyValue = money->countMoney();
+		const UnsignedInt moneyPerMinuteValue = money->getCashPerMinute();
 		const UnsignedInt rankValue = static_cast<UnsignedInt>(player->getRankLevel());
 		const UnsignedInt xpValue = static_cast<UnsignedInt>(player->getSkillPoints());
 		const UnicodeString nameValue = player->getPlayerDisplayName();
 
-		const UnsignedInt currentValues[] = {teamValue, moneyValue, rankValue, xpValue};
+		const UnsignedInt currentValues[] = {teamValue, moneyValue, moneyPerMinuteValue, rankValue, xpValue};
 		for (column = 0; column < ARRAY_SIZE(currentValues); ++column)
 		{
 			UnsignedInt &lastValue = m_playerInfoList.lastValues.values[column][row];
 			if (lastValue != currentValues[column])
 			{
-				playerInfoListValue.format(L"%u", currentValues[column]);
+				if (column == PlayerInfoList::ValueType_MoneyPerMinute)
+				{
+					playerInfoListValue = formatIncomeValue(currentValues[column]);
+				}
+				else
+				{
+					playerInfoListValue.format(L"%u", currentValues[column]);
+				}
 				m_playerInfoList.values[column][row]->setText(playerInfoListValue);
 				lastValue = currentValues[column];
 			}
@@ -6177,6 +6188,9 @@ void InGameUI::drawPlayerInfoList()
 	Int labelX = baseX;
 	for (column = 0; column < PlayerInfoList::LabelType_Count; ++column)
 	{
+		if (!showMoneyPerMinute && column == PlayerInfoList::LabelType_MoneyPerMinute)
+			continue;
+
 		labelWidths[column] = m_playerInfoList.labels[column]->getWidth();
 		columnLabelX[column] = labelX;
 		labelX += labelWidths[column] + maxValueWidths[column] + columnGap;
@@ -6189,6 +6203,9 @@ void InGameUI::drawPlayerInfoList()
 
 		for (column = 0; column < PlayerInfoList::LabelType_Count; ++column)
 		{
+			if (!showMoneyPerMinute && column == PlayerInfoList::LabelType_MoneyPerMinute)
+				continue;
+
 			m_playerInfoList.labels[column]->draw(columnLabelX[column], drawY, m_playerInfoListLabelColor, m_playerInfoListDropColor);
 			m_playerInfoList.values[column][row]->draw(columnLabelX[column] + labelWidths[column], drawY, m_playerInfoListValueColor, m_playerInfoListDropColor);
 		}

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/InGameUI.h
@@ -811,6 +811,7 @@ protected:
 		{
 			LabelType_Team,
 			LabelType_Money,
+			LabelType_MoneyPerMinute,
 			LabelType_Rank,
 			LabelType_Xp,
 
@@ -821,6 +822,7 @@ protected:
 		{
 			ValueType_Team,
 			ValueType_Money,
+			ValueType_MoneyPerMinute,
 			ValueType_Rank,
 			ValueType_Xp,
 			ValueType_Name,

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -1007,6 +1007,7 @@ void InGameUI::PlayerInfoList::init(const AsciiString &fontName, Int pointSize, 
 
 	labels[LabelType_Team]->setText(TheGameText->FETCH_OR_SUBSTITUTE_FORMAT("GUI:PlayerInfoListLabelTeam", L"T"));
 	labels[LabelType_Money]->setText(TheGameText->FETCH_OR_SUBSTITUTE_FORMAT("GUI:PlayerInfoListLabelMoney", L"$"));
+	labels[LabelType_MoneyPerMinute]->setText(TheGameText->FETCH_OR_SUBSTITUTE_FORMAT("GUI:PlayerInfoListLabelMoneyPerMinute", L"+"));
 	labels[LabelType_Rank]->setText(TheGameText->FETCH_OR_SUBSTITUTE_FORMAT("GUI:PlayerInfoListLabelRank", L"*"));
 	labels[LabelType_Xp]->setText(TheGameText->FETCH_OR_SUBSTITUTE_FORMAT("GUI:PlayerInfoListLabelXp", L"XP"));
 }
@@ -6298,6 +6299,7 @@ void InGameUI::drawPlayerInfoList()
 	Int maxValueWidths[PlayerInfoList::LabelType_Count] = {0};
 	Color rowColors[MAX_PLAYER_COUNT] = {0};
 	Int nameValueWidth[MAX_PLAYER_COUNT] = {0};
+	const Bool showMoneyPerMinute = TheGlobalData->m_showMoneyPerMinute;
 	Int column;
 
 	for (Int slotIndex = 0; slotIndex < MAX_SLOTS && rowCount < MAX_PLAYER_COUNT; ++slotIndex)
@@ -6312,18 +6314,27 @@ void InGameUI::drawPlayerInfoList()
 
 		const Int row = rowCount++;
 		const UnsignedInt teamValue = (slot && slot->getTeamNumber() >= 0) ? static_cast<UnsignedInt>(slot->getTeamNumber() + 1) : 0;
-		const UnsignedInt moneyValue = player->getMoney()->countMoney();
+		const Money *money = player->getMoney();
+		const UnsignedInt moneyValue = money->countMoney();
+		const UnsignedInt moneyPerMinuteValue = money->getCashPerMinute();
 		const UnsignedInt rankValue = static_cast<UnsignedInt>(player->getRankLevel());
 		const UnsignedInt xpValue = static_cast<UnsignedInt>(player->getSkillPoints());
 		const UnicodeString nameValue = player->getPlayerDisplayName();
 
-		const UnsignedInt currentValues[] = {teamValue, moneyValue, rankValue, xpValue};
+		const UnsignedInt currentValues[] = {teamValue, moneyValue, moneyPerMinuteValue, rankValue, xpValue};
 		for (column = 0; column < ARRAY_SIZE(currentValues); ++column)
 		{
 			UnsignedInt &lastValue = m_playerInfoList.lastValues.values[column][row];
 			if (lastValue != currentValues[column])
 			{
-				playerInfoListValue.format(L"%u", currentValues[column]);
+				if (column == PlayerInfoList::ValueType_MoneyPerMinute)
+				{
+					playerInfoListValue = formatIncomeValue(currentValues[column]);
+				}
+				else
+				{
+					playerInfoListValue.format(L"%u", currentValues[column]);
+				}
 				m_playerInfoList.values[column][row]->setText(playerInfoListValue);
 				lastValue = currentValues[column];
 			}
@@ -6350,6 +6361,9 @@ void InGameUI::drawPlayerInfoList()
 	Int labelX = baseX;
 	for (column = 0; column < PlayerInfoList::LabelType_Count; ++column)
 	{
+		if (!showMoneyPerMinute && column == PlayerInfoList::LabelType_MoneyPerMinute)
+			continue;
+
 		labelWidths[column] = m_playerInfoList.labels[column]->getWidth();
 		columnLabelX[column] = labelX;
 		labelX += labelWidths[column] + maxValueWidths[column] + columnGap;
@@ -6362,6 +6376,9 @@ void InGameUI::drawPlayerInfoList()
 
 		for (column = 0; column < PlayerInfoList::LabelType_Count; ++column)
 		{
+			if (!showMoneyPerMinute && column == PlayerInfoList::LabelType_MoneyPerMinute)
+				continue;
+
 			m_playerInfoList.labels[column]->draw(columnLabelX[column], drawY, m_playerInfoListLabelColor, m_playerInfoListDropColor);
 			m_playerInfoList.values[column][row]->draw(columnLabelX[column] + labelWidths[column], drawY, m_playerInfoListValueColor, m_playerInfoListDropColor);
 		}

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -6329,6 +6329,9 @@ void InGameUI::drawPlayerInfoList()
 			{
 				if (column == PlayerInfoList::ValueType_MoneyPerMinute)
 				{
+					if (!showMoneyPerMinute)
+						continue;
+
 					playerInfoListValue = formatIncomeValue(currentValues[column]);
 				}
 				else
@@ -6361,7 +6364,7 @@ void InGameUI::drawPlayerInfoList()
 	Int labelX = baseX;
 	for (column = 0; column < PlayerInfoList::LabelType_Count; ++column)
 	{
-		if (!showMoneyPerMinute && column == PlayerInfoList::LabelType_MoneyPerMinute)
+		if (column == PlayerInfoList::LabelType_MoneyPerMinute && !showMoneyPerMinute)
 			continue;
 
 		labelWidths[column] = m_playerInfoList.labels[column]->getWidth();
@@ -6376,7 +6379,7 @@ void InGameUI::drawPlayerInfoList()
 
 		for (column = 0; column < PlayerInfoList::LabelType_Count; ++column)
 		{
-			if (!showMoneyPerMinute && column == PlayerInfoList::LabelType_MoneyPerMinute)
+			if (column == PlayerInfoList::LabelType_MoneyPerMinute && !showMoneyPerMinute)
 				continue;
 
 			m_playerInfoList.labels[column]->draw(columnLabelX[column], drawY, m_playerInfoListLabelColor, m_playerInfoListDropColor);


### PR DESCRIPTION
- Relates To: #2136

This change show Money Per Minute in Player Info List for match Observers in Generals and Zero Hour.
It is only shown when `ShowMoneyPerMinute = yes` because some players may prefer the original Gentool replication or because the extra column takes additional space now.

<img width="1200" height="524" alt="shot_full" src="https://github.com/user-attachments/assets/3d0d7a7f-900c-4a25-927f-e6604301af44" />

