### PR TITLE
fix(particlesys): Decouple particle systems from logic crc

### DIFF
--- a/Core/GameEngine/Include/Common/RandomValue.h
+++ b/Core/GameEngine/Include/Common/RandomValue.h
@@ -37,22 +37,22 @@ extern UnsignedInt GetGameLogicRandomSeedCRC();///< Get the seed (used for CRCs)
 
 struct RandomValueClass
 {
-	virtual Int GetGameRandomValue( Int lo, Int hi, const char *file, Int line ) const = 0;
-	virtual Real GetGameRandomValueReal( Real lo, Real hi, const char *file, Int line ) const = 0;
+	virtual Int GetRandomValueInt( Int lo, Int hi, const char *file, Int line ) const = 0;
+	virtual Real GetRandomValueReal( Real lo, Real hi, const char *file, Int line ) const = 0;
 };
 struct LogicRandomValueClass final : RandomValueClass
 {
-	virtual Int GetGameRandomValue( Int lo, Int hi, const char *file, Int line ) const override;
-	virtual Real GetGameRandomValueReal( Real lo, Real hi, const char *file, Int line ) const override;
+	virtual Int GetRandomValueInt( Int lo, Int hi, const char *file, Int line ) const override;
+	virtual Real GetRandomValueReal( Real lo, Real hi, const char *file, Int line ) const override;
 };
 struct ClientRandomValueClass final : RandomValueClass
 {
-	virtual Int GetGameRandomValue( Int lo, Int hi, const char *file, Int line ) const override;
-	virtual Real GetGameRandomValueReal( Real lo, Real hi, const char *file, Int line ) const override;
+	virtual Int GetRandomValueInt( Int lo, Int hi, const char *file, Int line ) const override;
+	virtual Real GetRandomValueReal( Real lo, Real hi, const char *file, Int line ) const override;
 };
 
 // use these macros to access the random value functions
-#define GameRandomValue(randomValueClass, hi, lo) randomValueClass.GetGameRandomValue( lo, hi, __FILE__, __LINE__ )
-#define GameRandomValueReal(randomValueClass, hi, lo) randomValueClass.GetGameRandomValueReal( lo, hi, __FILE__, __LINE__ )
+#define RandomValueInt(randomValueClass, hi, lo) randomValueClass.GetRandomValueInt( lo, hi, __FILE__, __LINE__ )
+#define RandomValueReal(randomValueClass, hi, lo) randomValueClass.GetRandomValueReal( lo, hi, __FILE__, __LINE__ )
 
 //--------------------------------------------------------------------------------------------------------------

--- a/Core/GameEngine/Include/Common/RandomValue.h
+++ b/Core/GameEngine/Include/Common/RandomValue.h
@@ -35,4 +35,24 @@ extern void InitRandom( UnsignedInt seed );
 extern UnsignedInt GetGameLogicRandomSeed();   ///< Get the seed (used for replays)
 extern UnsignedInt GetGameLogicRandomSeedCRC();///< Get the seed (used for CRCs)
 
+struct RandomValueClass
+{
+	virtual Int GetGameRandomValue( Int lo, Int hi, const char *file, Int line ) const = 0;
+	virtual Real GetGameRandomValueReal( Real lo, Real hi, const char *file, Int line ) const = 0;
+};
+struct LogicRandomValueClass final : RandomValueClass
+{
+	virtual Int GetGameRandomValue( Int lo, Int hi, const char *file, Int line ) const override;
+	virtual Real GetGameRandomValueReal( Real lo, Real hi, const char *file, Int line ) const override;
+};
+struct ClientRandomValueClass final : RandomValueClass
+{
+	virtual Int GetGameRandomValue( Int lo, Int hi, const char *file, Int line ) const override;
+	virtual Real GetGameRandomValueReal( Real lo, Real hi, const char *file, Int line ) const override;
+};
+
+// use these macros to access the random value functions
+#define GameRandomValue(randomValueClass, hi, lo) randomValueClass.GetGameRandomValue( lo, hi, __FILE__, __LINE__ )
+#define GameRandomValueReal(randomValueClass, hi, lo) randomValueClass.GetGameRandomValueReal( lo, hi, __FILE__, __LINE__ )
+
 //--------------------------------------------------------------------------------------------------------------

--- a/Core/GameEngine/Include/Common/RandomValue.h
+++ b/Core/GameEngine/Include/Common/RandomValue.h
@@ -52,7 +52,7 @@ struct ClientRandomValueClass final : RandomValueClass
 };
 
 // use these macros to access the random value functions
-#define RandomValueInt(randomValueClass, hi, lo) randomValueClass.GetRandomValueInt( lo, hi, __FILE__, __LINE__ )
-#define RandomValueReal(randomValueClass, hi, lo) randomValueClass.GetRandomValueReal( lo, hi, __FILE__, __LINE__ )
+#define RandomValueInt(randomValueClass, lo, hi) randomValueClass.GetRandomValueInt( lo, hi, __FILE__, __LINE__ )
+#define RandomValueReal(randomValueClass, lo, hi) randomValueClass.GetRandomValueReal( lo, hi, __FILE__, __LINE__ )
 
 //--------------------------------------------------------------------------------------------------------------

--- a/Core/GameEngine/Source/Common/RandomValue.cpp
+++ b/Core/GameEngine/Source/Common/RandomValue.cpp
@@ -465,3 +465,24 @@ Real GameLogicRandomVariable::getValue() const
 			return 0.0f;
 	}
 }
+
+
+Int LogicRandomValueClass::GetGameRandomValue( Int lo, Int hi, const char *file, Int line ) const
+{
+	return GetGameLogicRandomValue(lo, hi, file, line);
+}
+
+Real LogicRandomValueClass::GetGameRandomValueReal( Real lo, Real hi, const char *file, Int line ) const
+{
+	return GetGameLogicRandomValueReal(lo, hi, file, line);
+}
+
+Int ClientRandomValueClass::GetGameRandomValue( Int lo, Int hi, const char *file, Int line ) const
+{
+	return GetGameClientRandomValue(lo, hi, file, line);
+}
+
+Real ClientRandomValueClass::GetGameRandomValueReal( Real lo, Real hi, const char *file, Int line ) const
+{
+	return GetGameClientRandomValueReal(lo, hi, file, line);
+}

--- a/Core/GameEngine/Source/Common/RandomValue.cpp
+++ b/Core/GameEngine/Source/Common/RandomValue.cpp
@@ -467,22 +467,22 @@ Real GameLogicRandomVariable::getValue() const
 }
 
 
-Int LogicRandomValueClass::GetGameRandomValue( Int lo, Int hi, const char *file, Int line ) const
+Int LogicRandomValueClass::GetRandomValueInt( Int lo, Int hi, const char *file, Int line ) const
 {
 	return GetGameLogicRandomValue(lo, hi, file, line);
 }
 
-Real LogicRandomValueClass::GetGameRandomValueReal( Real lo, Real hi, const char *file, Int line ) const
+Real LogicRandomValueClass::GetRandomValueReal( Real lo, Real hi, const char *file, Int line ) const
 {
 	return GetGameLogicRandomValueReal(lo, hi, file, line);
 }
 
-Int ClientRandomValueClass::GetGameRandomValue( Int lo, Int hi, const char *file, Int line ) const
+Int ClientRandomValueClass::GetRandomValueInt( Int lo, Int hi, const char *file, Int line ) const
 {
 	return GetGameClientRandomValue(lo, hi, file, line);
 }
 
-Real ClientRandomValueClass::GetGameRandomValueReal( Real lo, Real hi, const char *file, Int line ) const
+Real ClientRandomValueClass::GetRandomValueReal( Real lo, Real hi, const char *file, Int line ) const
 {
 	return GetGameClientRandomValueReal(lo, hi, file, line);
 }

--- a/Generals/Code/GameEngine/Include/Common/Geometry.h
+++ b/Generals/Code/GameEngine/Include/Common/Geometry.h
@@ -31,6 +31,7 @@
 
 #include "Lib/BaseType.h"
 #include "Common/AsciiString.h"
+#include "Common/RandomValue.h"
 #include "Common/Snapshot.h"
 
 class INI;
@@ -171,9 +172,8 @@ public:
 	/// get the 2d bounding box
 	void get2DBounds(const Coord3D& geomCenter, Real angle, Region2D& bounds	) const;
 
-	/// note that the pt is generated using game logic random, not game client random!
-	void makeRandomOffsetWithinFootprint(Coord3D& pt) const;
-	void makeRandomOffsetOnPerimeter(Coord3D& pt) const; //Chooses a random point on the extent border.
+	void makeRandomOffsetWithinFootprint(Coord3D& pt, const RandomValueClass& random = LogicRandomValueClass()) const;
+	void makeRandomOffsetOnPerimeter(Coord3D& pt) const; ///< Chooses a random point on the extent border. Uses game logic random!
 
 	void clipPointToFootprint(const Coord3D& geomCenter, Coord3D& ptToClip) const;
 

--- a/Generals/Code/GameEngine/Source/Common/System/Geometry.cpp
+++ b/Generals/Code/GameEngine/Source/Common/System/Geometry.cpp
@@ -376,7 +376,7 @@ Bool GeometryInfo::isPointInFootprint(const Coord3D& geomCenter, const Coord3D& 
 }
 
 //=============================================================================
-void GeometryInfo::makeRandomOffsetWithinFootprint(Coord3D& pt) const
+void GeometryInfo::makeRandomOffsetWithinFootprint(Coord3D& pt, const RandomValueClass& random) const
 {
 	switch(m_type)
 	{
@@ -390,14 +390,14 @@ void GeometryInfo::makeRandomOffsetWithinFootprint(Coord3D& pt) const
 			Real distSqr;
 			do
 			{
-				pt.x = GameLogicRandomValueReal(-m_majorRadius, m_majorRadius);
-				pt.y = GameLogicRandomValueReal(-m_majorRadius, m_majorRadius);
+				pt.x = RandomValueReal(random, -m_majorRadius, m_majorRadius);
+				pt.y = RandomValueReal(random, -m_majorRadius, m_majorRadius);
 				pt.z = 0.0f;
 				distSqr = sqr(pt.x) + sqr(pt.y);
 			} while (distSqr > maxDistSqr);
 #else
-			Real radius = GameLogicRandomValueReal(0.0f, m_boundingCircleRadius);
-			Real angle = GameLogicRandomValueReal(-PI, PI);
+			Real radius = RandomValueReal(random, 0.0f, m_boundingCircleRadius);
+			Real angle = RandomValueReal(random, -PI, PI);
 			pt.x = radius * Cos(angle);
 			pt.y = radius * Sin(angle);
 			pt.z = 0.0f;
@@ -407,8 +407,8 @@ void GeometryInfo::makeRandomOffsetWithinFootprint(Coord3D& pt) const
 
 		case GEOMETRY_BOX:
 		{
-			pt.x = GameLogicRandomValueReal(-m_majorRadius, m_majorRadius);
-			pt.y = GameLogicRandomValueReal(-m_minorRadius, m_minorRadius);
+			pt.x = RandomValueReal(random, -m_majorRadius, m_majorRadius);
+			pt.y = RandomValueReal(random, -m_minorRadius, m_minorRadius);
 			pt.z = 0.0f;
 			break;
 		}

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Damage/TransitionDamageFX.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Damage/TransitionDamageFX.cpp
@@ -253,7 +253,7 @@ void TransitionDamageFX::onDelete()
 /** Given an FXLoc info struct, return the effect position that we are supposed to use.
 	* The position is local to to the object */
 //-------------------------------------------------------------------------------------------------
-static Coord3D getLocalEffectPos( const FXLocInfo *locInfo, Drawable *draw )
+static Coord3D getLocalEffectPos( const FXLocInfo *locInfo, Drawable *draw, const RandomValueClass &random = LogicRandomValueClass() )
 {
 
 	DEBUG_ASSERTCRASH( locInfo, ("getLocalEffectPos: locInfo is null") );
@@ -290,7 +290,7 @@ static Coord3D getLocalEffectPos( const FXLocInfo *locInfo, Drawable *draw )
 				return locInfo->loc;
 
 			// pick one of the bone positions
-			Int pick = GameLogicRandomValue( 0, boneCount - 1 );
+			Int pick = RandomValueInt( random, 0, boneCount - 1 );
 			return positions[ pick ];
 
 		}
@@ -387,6 +387,11 @@ void TransitionDamageFX::onBodyDamageStateChange( const DamageInfo* damageInfo,
 				if( lastDamageInfo == nullptr ||
 						getDamageTypeFlag( modData->m_damageParticleTypes, lastDamageInfo->in.m_damageType ) )
 				{
+#if RETAIL_COMPATIBLE_CRC
+					// TheSuperHackers @fix The particle system is now decoupled from the logic crc
+					// and the side effects on the logic random seed values are preserved for retail compatibility.
+					getLocalEffectPos( &modData->m_particleSystem[ newState ][ i ].locInfo, draw, LogicRandomValueClass() );
+#endif
 
 					// create a new particle system based on the template provided
 					ParticleSystem* pSystem = TheParticleSystemManager->createParticleSystem( pSystemT );
@@ -394,7 +399,7 @@ void TransitionDamageFX::onBodyDamageStateChange( const DamageInfo* damageInfo,
 					{
 
 						// get the what is the position we're going to played the effect at
-						pos = getLocalEffectPos( &modData->m_particleSystem[ newState ][ i ].locInfo, draw );
+						pos = getLocalEffectPos( &modData->m_particleSystem[ newState ][ i ].locInfo, draw, ClientRandomValueClass() );
 
 						//
 						// set position on system given any bone position provided, the bone position is

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/EMPUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/EMPUpdate.cpp
@@ -235,14 +235,24 @@ void EMPUpdate::doDisableAttack()
 
 					for (UnsignedInt e = 0 ; e < emitterCount; ++e)
 					{
+#if RETAIL_COMPATIBLE_CRC
+						// TheSuperHackers @fix The particle system is now decoupled from the logic crc
+						// and the side effects on the logic random seed values are preserved for retail compatibility.
+						{
+							Coord3D offs = {0,0,0};
+							curVictim->getGeometryInfo().makeRandomOffsetWithinFootprint( offs, LogicRandomValueClass() );
+							GameLogicRandomValue(3, victimHeight);
+							GameLogicRandomValue(1, 100);
+						}
+#endif
 
 						ParticleSystem *sys = TheParticleSystemManager->createParticleSystem(tmp);
 
 						if (sys)
 						{
 							Coord3D offs = {0,0,0};
-							curVictim->getGeometryInfo().makeRandomOffsetWithinFootprint( offs );
-							offs.z = GameLogicRandomValue(3, victimHeight);
+							curVictim->getGeometryInfo().makeRandomOffsetWithinFootprint( offs, ClientRandomValueClass() );
+							offs.z = GameClientRandomValue(3, victimHeight);
 
 							//This puts all the sparks within a quadrahemicycloid (rectangular dome) volume
 							//The same shape as a four cornered camping dome tent, for those with less Greek
@@ -259,7 +269,7 @@ void EMPUpdate::doDisableAttack()
 							sys->attachToObject(curVictim);
 							sys->setPosition( &offs );
 							sys->setSystemLifetime(MAX(0, data->m_disabledDuration - 30));
-							sys->setInitialDelay(GameLogicRandomValue(1,100));
+							sys->setInitialDelay(GameClientRandomValue(1,100));
 						}
 					}
 				}

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
@@ -1263,11 +1263,20 @@ void SpecialAbilityUpdate::triggerAbilityEffect()
 				const ParticleSystemTemplate *tmp = data->m_disableFXParticleSystem;
 				if (tmp)
 				{
+#if RETAIL_COMPATIBLE_CRC
+					// TheSuperHackers @fix The particle system is now decoupled from the logic crc
+					// and the side effects on the logic random seed values are preserved for retail compatibility.
+					{
+						Coord3D offs = {0,0,0};
+						target->getGeometryInfo().makeRandomOffsetWithinFootprint( offs, LogicRandomValueClass() );
+					}
+#endif
+
 					ParticleSystem *sys = TheParticleSystemManager->createParticleSystem(tmp);
 					if (sys)
 					{
 						Coord3D offs = {0,0,0};
-						target->getGeometryInfo().makeRandomOffsetWithinFootprint( offs );
+						target->getGeometryInfo().makeRandomOffsetWithinFootprint( offs, ClientRandomValueClass() );
 
 						sys->attachToObject(target);
 						sys->setPosition( &offs );

--- a/GeneralsMD/Code/GameEngine/Include/Common/Geometry.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Geometry.h
@@ -31,6 +31,7 @@
 
 #include "Lib/BaseType.h"
 #include "Common/AsciiString.h"
+#include "Common/RandomValue.h"
 #include "Common/Snapshot.h"
 
 class INI;
@@ -172,7 +173,7 @@ public:
 	void get2DBounds(const Coord3D& geomCenter, Real angle, Region2D& bounds	) const;
 
 	/// note that the pt is generated using game logic random, not game client random!
-	void makeRandomOffsetWithinFootprint(Coord3D& pt) const;
+	void makeRandomOffsetWithinFootprint(Coord3D& pt, const RandomValueClass& random = LogicRandomValueClass()) const;
 	void makeRandomOffsetOnPerimeter(Coord3D& pt) const; //Chooses a random point on the extent border.
 
 	void clipPointToFootprint(const Coord3D& geomCenter, Coord3D& ptToClip) const;

--- a/GeneralsMD/Code/GameEngine/Include/Common/Geometry.h
+++ b/GeneralsMD/Code/GameEngine/Include/Common/Geometry.h
@@ -172,9 +172,8 @@ public:
 	/// get the 2d bounding box
 	void get2DBounds(const Coord3D& geomCenter, Real angle, Region2D& bounds	) const;
 
-	/// note that the pt is generated using game logic random, not game client random!
 	void makeRandomOffsetWithinFootprint(Coord3D& pt, const RandomValueClass& random = LogicRandomValueClass()) const;
-	void makeRandomOffsetOnPerimeter(Coord3D& pt) const; //Chooses a random point on the extent border.
+	void makeRandomOffsetOnPerimeter(Coord3D& pt) const; ///< Chooses a random point on the extent border. Uses game logic random!
 
 	void clipPointToFootprint(const Coord3D& geomCenter, Coord3D& ptToClip) const;
 

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/Geometry.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/Geometry.cpp
@@ -376,7 +376,7 @@ Bool GeometryInfo::isPointInFootprint(const Coord3D& geomCenter, const Coord3D& 
 }
 
 //=============================================================================
-void GeometryInfo::makeRandomOffsetWithinFootprint(Coord3D& pt) const
+void GeometryInfo::makeRandomOffsetWithinFootprint(Coord3D& pt, const RandomValueClass& random) const
 {
 	switch(m_type)
 	{
@@ -390,14 +390,14 @@ void GeometryInfo::makeRandomOffsetWithinFootprint(Coord3D& pt) const
 			Real distSqr;
 			do
 			{
-				pt.x = GameLogicRandomValueReal(-m_majorRadius, m_majorRadius);
-				pt.y = GameLogicRandomValueReal(-m_majorRadius, m_majorRadius);
+				pt.x = GameRandomValueReal(random, -m_majorRadius, m_majorRadius);
+				pt.y = GameRandomValueReal(random, -m_majorRadius, m_majorRadius);
 				pt.z = 0.0f;
 				distSqr = sqr(pt.x) + sqr(pt.y);
 			} while (distSqr > maxDistSqr);
 #else
-			Real radius = GameLogicRandomValueReal(0.0f, m_boundingCircleRadius);
-			Real angle = GameLogicRandomValueReal(-PI, PI);
+			Real radius = GameRandomValueReal(random, 0.0f, m_boundingCircleRadius);
+			Real angle = GameRandomValueReal(random, -PI, PI);
 			pt.x = radius * Cos(angle);
 			pt.y = radius * Sin(angle);
 			pt.z = 0.0f;
@@ -407,8 +407,8 @@ void GeometryInfo::makeRandomOffsetWithinFootprint(Coord3D& pt) const
 
 		case GEOMETRY_BOX:
 		{
-			pt.x = GameLogicRandomValueReal(-m_majorRadius, m_majorRadius);
-			pt.y = GameLogicRandomValueReal(-m_minorRadius, m_minorRadius);
+			pt.x = GameRandomValueReal(random, -m_majorRadius, m_majorRadius);
+			pt.y = GameRandomValueReal(random, -m_minorRadius, m_minorRadius);
 			pt.z = 0.0f;
 			break;
 		}

--- a/GeneralsMD/Code/GameEngine/Source/Common/System/Geometry.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/System/Geometry.cpp
@@ -390,14 +390,14 @@ void GeometryInfo::makeRandomOffsetWithinFootprint(Coord3D& pt, const RandomValu
 			Real distSqr;
 			do
 			{
-				pt.x = GameRandomValueReal(random, -m_majorRadius, m_majorRadius);
-				pt.y = GameRandomValueReal(random, -m_majorRadius, m_majorRadius);
+				pt.x = RandomValueReal(random, -m_majorRadius, m_majorRadius);
+				pt.y = RandomValueReal(random, -m_majorRadius, m_majorRadius);
 				pt.z = 0.0f;
 				distSqr = sqr(pt.x) + sqr(pt.y);
 			} while (distSqr > maxDistSqr);
 #else
-			Real radius = GameRandomValueReal(random, 0.0f, m_boundingCircleRadius);
-			Real angle = GameRandomValueReal(random, -PI, PI);
+			Real radius = RandomValueReal(random, 0.0f, m_boundingCircleRadius);
+			Real angle = RandomValueReal(random, -PI, PI);
 			pt.x = radius * Cos(angle);
 			pt.y = radius * Sin(angle);
 			pt.z = 0.0f;
@@ -407,8 +407,8 @@ void GeometryInfo::makeRandomOffsetWithinFootprint(Coord3D& pt, const RandomValu
 
 		case GEOMETRY_BOX:
 		{
-			pt.x = GameRandomValueReal(random, -m_majorRadius, m_majorRadius);
-			pt.y = GameRandomValueReal(random, -m_minorRadius, m_minorRadius);
+			pt.x = RandomValueReal(random, -m_majorRadius, m_majorRadius);
+			pt.y = RandomValueReal(random, -m_minorRadius, m_minorRadius);
 			pt.z = 0.0f;
 			break;
 		}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Damage/TransitionDamageFX.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Damage/TransitionDamageFX.cpp
@@ -290,7 +290,7 @@ static Coord3D getLocalEffectPos( const FXLocInfo *locInfo, Drawable *draw, cons
 				return locInfo->loc;
 
 			// pick one of the bone positions
-			Int pick = GameRandomValue( random, 0, boneCount - 1 );
+			Int pick = RandomValueInt( random, 0, boneCount - 1 );
 			return positions[ pick ];
 
 		}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Damage/TransitionDamageFX.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Damage/TransitionDamageFX.cpp
@@ -253,7 +253,7 @@ void TransitionDamageFX::onDelete()
 /** Given an FXLoc info struct, return the effect position that we are supposed to use.
 	* The position is local to to the object */
 //-------------------------------------------------------------------------------------------------
-static Coord3D getLocalEffectPos( const FXLocInfo *locInfo, Drawable *draw )
+static Coord3D getLocalEffectPos( const FXLocInfo *locInfo, Drawable *draw, const RandomValueClass &random = LogicRandomValueClass() )
 {
 
 	DEBUG_ASSERTCRASH( locInfo, ("getLocalEffectPos: locInfo is null") );
@@ -290,7 +290,7 @@ static Coord3D getLocalEffectPos( const FXLocInfo *locInfo, Drawable *draw )
 				return locInfo->loc;
 
 			// pick one of the bone positions
-			Int pick = GameLogicRandomValue( 0, boneCount - 1 );
+			Int pick = GameRandomValue( random, 0, boneCount - 1 );
 			return positions[ pick ];
 
 		}
@@ -387,6 +387,11 @@ void TransitionDamageFX::onBodyDamageStateChange( const DamageInfo* damageInfo,
 				if( lastDamageInfo == nullptr ||
 						getDamageTypeFlag( modData->m_damageParticleTypes, lastDamageInfo->in.m_damageType ) )
 				{
+#if RETAIL_COMPATIBLE_CRC
+					// TheSuperHackers @fix The particle system is now decoupled from the logic crc
+					// and the legacy logic random values are preserved here.
+					getLocalEffectPos( &modData->m_particleSystem[ newState ][ i ].locInfo, draw, LogicRandomValueClass() );
+#endif
 
 					// create a new particle system based on the template provided
 					ParticleSystem* pSystem = TheParticleSystemManager->createParticleSystem( pSystemT );
@@ -394,7 +399,7 @@ void TransitionDamageFX::onBodyDamageStateChange( const DamageInfo* damageInfo,
 					{
 
 						// get the what is the position we're going to played the effect at
-						pos = getLocalEffectPos( &modData->m_particleSystem[ newState ][ i ].locInfo, draw );
+						pos = getLocalEffectPos( &modData->m_particleSystem[ newState ][ i ].locInfo, draw, ClientRandomValueClass() );
 
 						//
 						// set position on system given any bone position provided, the bone position is

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Damage/TransitionDamageFX.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Damage/TransitionDamageFX.cpp
@@ -389,7 +389,7 @@ void TransitionDamageFX::onBodyDamageStateChange( const DamageInfo* damageInfo,
 				{
 #if RETAIL_COMPATIBLE_CRC
 					// TheSuperHackers @fix The particle system is now decoupled from the logic crc
-					// and the legacy logic random values are preserved here.
+					// and the side effects on the logic random seed values are preserved for retail compatibility.
 					getLocalEffectPos( &modData->m_particleSystem[ newState ][ i ].locInfo, draw, LogicRandomValueClass() );
 #endif
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/EMPUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/EMPUpdate.cpp
@@ -306,7 +306,7 @@ void EMPUpdate::doDisableAttack()
 					{
 #if RETAIL_COMPATIBLE_CRC
 						// TheSuperHackers @fix The particle system is now decoupled from the logic crc
-						// and the legacy logic random values are preserved here.
+						// and the side effects on the logic random seed values are preserved for retail compatibility.
 						{
 							Coord3D offs = {0,0,0};
 							curVictim->getGeometryInfo().makeRandomOffsetWithinFootprint( offs, LogicRandomValueClass() );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/EMPUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/EMPUpdate.cpp
@@ -304,14 +304,24 @@ void EMPUpdate::doDisableAttack()
 
 					for (UnsignedInt e = 0 ; e < emitterCount; ++e)
 					{
+#if RETAIL_COMPATIBLE_CRC
+						// TheSuperHackers @fix The particle system is now decoupled from the logic crc
+						// and the legacy logic random values are preserved here.
+						{
+							Coord3D offs = {0,0,0};
+							curVictim->getGeometryInfo().makeRandomOffsetWithinFootprint( offs, LogicRandomValueClass() );
+							GameLogicRandomValue(3, victimHeight);
+							GameLogicRandomValue(1, 100);
+						}
+#endif
 
 						ParticleSystem *sys = TheParticleSystemManager->createParticleSystem(tmp);
 
 						if (sys)
 						{
 							Coord3D offs = {0,0,0};
-							curVictim->getGeometryInfo().makeRandomOffsetWithinFootprint( offs );
-							offs.z = GameLogicRandomValue(3, victimHeight);
+							curVictim->getGeometryInfo().makeRandomOffsetWithinFootprint( offs, ClientRandomValueClass() );
+							offs.z = GameClientRandomValue(3, victimHeight);
 
 							//This puts all the sparks within a quadrahemicycloid (rectangular dome) volume
 							//The same shape as a four cornered camping dome tent, for those with less Greek
@@ -328,7 +338,7 @@ void EMPUpdate::doDisableAttack()
 							sys->attachToObject(curVictim);
 							sys->setPosition( &offs );
 							sys->setSystemLifetime(MAX(0, data->m_disabledDuration - 30));
-							sys->setInitialDelay(GameLogicRandomValue(1,100));
+							sys->setInitialDelay(GameClientRandomValue(1,100));
 						}
 					}
 				}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
@@ -1402,7 +1402,7 @@ void SpecialAbilityUpdate::triggerAbilityEffect()
         {
 #if RETAIL_COMPATIBLE_CRC
           // TheSuperHackers @fix The particle system is now decoupled from the logic crc
-          // and the legacy logic random values are preserved here.
+          // and the side effects on the logic random seed values are preserved for retail compatibility.
           {
             Coord3D offs = {0,0,0};
             target->getGeometryInfo().makeRandomOffsetWithinFootprint( offs, LogicRandomValueClass() );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpecialAbilityUpdate.cpp
@@ -1400,11 +1400,20 @@ void SpecialAbilityUpdate::triggerAbilityEffect()
         const ParticleSystemTemplate *tmp = data->m_disableFXParticleSystem;
         if (tmp)
         {
+#if RETAIL_COMPATIBLE_CRC
+          // TheSuperHackers @fix The particle system is now decoupled from the logic crc
+          // and the legacy logic random values are preserved here.
+          {
+            Coord3D offs = {0,0,0};
+            target->getGeometryInfo().makeRandomOffsetWithinFootprint( offs, LogicRandomValueClass() );
+          }
+#endif
+
           ParticleSystem *sys = TheParticleSystemManager->createParticleSystem(tmp);
           if (sys)
           {
             Coord3D offs = {0,0,0};
-            target->getGeometryInfo().makeRandomOffsetWithinFootprint( offs );
+            target->getGeometryInfo().makeRandomOffsetWithinFootprint( offs, ClientRandomValueClass() );
 
             sys->attachToObject(target);
             sys->setPosition( &offs );


### PR DESCRIPTION
* Closes #2717
* ~~Merge after #2740~~

This change decouples particle systems from logic crc and is an alternative to #2717.

The implementation adds a tiny runtime cost for virtual table lookups, but it provides an easy to use runtime switch for logic and client random values. Using it requires no refactors, template functions or static functions.

## TODO

- [x] Replicate in Generals