### PR TITLE
bugfix(contain): Prevent riders from being added to destroyed container object when Reinforcement Pad is destroyed before Troop Crawler drop

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -234,6 +234,9 @@ void OpenContain::addOrRemoveObjFromWorld(Object* obj, Bool add)
 	}
 	else
 	{
+		DEBUG_ASSERTCRASH(!getObject()->isEffectivelyDead() && !getObject()->isDestroyed(),
+			("object shouldn't become an occupant of a dead or destroyed container object"));
+
 		// remove object from its group (if any)
 		obj->leaveGroup();
 
@@ -277,11 +280,26 @@ void OpenContain::addToContain( Object *rider )
 	if( rider == nullptr )
 		return;
 
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix Caball009 25/05/2026 Ensure the occupant is only added to a non-destroyed
+	// container to avoid an invalid state and use-after-free bugs when accessing the contained by pointer.
+	if (getObject()->isDestroyed())
+	{
+		DEBUG_CRASH(("'%s' is about to be added to '%s', which is destroyed",
+			rider->getTemplate()->getName().str(), getObject()->getTemplate()->getName().str()));
+		return;
+	}
+#endif
+
 	// TheSuperHackers @bugfix Stubbjax 06/02/2026 Ensure the rider is not destroyed to prevent a
 	// likely crash if it enters the container on the same frame. If this occurs with an unpatched
 	// client present in a match, the game has a small chance to mismatch.
 	if (rider->isDestroyed())
+	{
+		DEBUG_CRASH(("'%s', which is destroyed, is about to be added to '%s'",
+			rider->getTemplate()->getName().str(), getObject()->getTemplate()->getName().str()));
 		return;
+	}
 
 #if defined(RTS_DEBUG)
 	if( !isValidContainerFor( rider, false ) )

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
@@ -362,8 +362,19 @@ UpdateSleepTime TransportContain::update()
 {
 	const TransportContainModuleData *moduleData = getTransportContainModuleData();
 
-	if( m_payloadCreated == FALSE )
+	if (m_payloadCreated == FALSE)
+	{
+#if RETAIL_COMPATIBLE_CRC
 		createPayload();
+#else
+		// TheSuperHackers @bugfix Caball009 25/05/2026 Don't create payload
+		// for destroyed object to avoid leaving the payload in an invalid state.
+		if (!getObject()->isDestroyed())
+		{
+			createPayload();
+		}
+#endif
+	}
 
 	if( moduleData && moduleData->m_healthRegen )
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -296,14 +296,22 @@ void OpenContain::addToContain( Object *rider )
 	// TheSuperHackers @bugfix Caball009 25/05/2026 Ensure the occupant is only added to a non-destroyed
 	// container to avoid an invalid state and use-after-free bugs when accessing the contained by pointer.
 	if (getObject()->isDestroyed())
+	{
+		DEBUG_CRASH(("'%s' is about to be added to '%s', which is destroyed",
+			rider->getTemplate()->getName().str(), getObject()->getTemplate()->getName().str()));
 		return;
+	}
 #endif
 
 	// TheSuperHackers @bugfix Stubbjax 06/02/2026 Ensure the rider is not destroyed to prevent a
 	// likely crash if it enters the container on the same frame. If this occurs with an unpatched
 	// client present in a match, the game has a small chance to mismatch.
 	if (rider->isDestroyed())
+	{
+		DEBUG_CRASH(("'%s', which is destroyed, is about to be added to '%s'",
+			rider->getTemplate()->getName().str(), getObject()->getTemplate()->getName().str()));
 		return;
+	}
 
 	Drawable *riderDraw = rider->getDrawable();
 	Bool wasSelected = FALSE;

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -292,6 +292,13 @@ void OpenContain::addToContain( Object *rider )
 	if( rider == nullptr )
 		return;
 
+#if !RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @bugfix Caball009 25/05/2026 Ensure the occupant is only added to a non-destroyed
+	// container to avoid an invalid state and use-after-free bugs when accessing the contained by pointer.
+	if (getObject()->isDestroyed())
+		return;
+#endif
+
 	// TheSuperHackers @bugfix Stubbjax 06/02/2026 Ensure the rider is not destroyed to prevent a
 	// likely crash if it enters the container on the same frame. If this occurs with an unpatched
 	// client present in a match, the game has a small chance to mismatch.

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -249,7 +249,7 @@ void OpenContain::addOrRemoveObjFromWorld(Object* obj, Bool add)
 
 		if (Drawable* drawable = obj->getDrawable())
 		{
-#if RETAIL_COMPATIBLE_CRC
+#if RTS_DEBUG
 			// TheSuperHackers @tweak This shouldn't happen but don't make the occupant invisible if it does.
 			if (!(getObject()->isEffectivelyDead() || getObject()->isDestroyed()))
 #endif

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -359,7 +359,7 @@ void OpenContain::addToContain( Object *rider )
 	{
 		addOrRemoveObjFromWorld(rider, false);
 
-		// TheSuperHackers @tweak This shouldn't happen but make the occupants visible if it does.
+		// TheSuperHackers @tweak This shouldn't happen but make the occupant visible if it does.
 		if (getObject()->isEffectivelyDead() || getObject()->isDestroyed())
 		{
 			if (Drawable* drawable = rider->getDrawable())

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -241,23 +241,18 @@ void OpenContain::addOrRemoveObjFromWorld(Object* obj, Bool add)
 	}
 	else
 	{
+		DEBUG_ASSERTCRASH(!getObject()->isEffectivelyDead() && !getObject()->isDestroyed(),
+			("object shouldn't become an occupant of a dead or destroyed container object"));
+
 		// remove object from its group (if any)
 		obj->leaveGroup();
 
 		// remove rider from partition manager
 		ThePartitionManager->unRegisterObject( obj );
 
-		if (Drawable* drawable = obj->getDrawable())
-		{
-#if RTS_DEBUG
-			// TheSuperHackers @tweak This shouldn't happen but don't make the occupant invisible if it does.
-			if (!(getObject()->isEffectivelyDead() || getObject()->isDestroyed()))
-#endif
-			{
-				// hide the drawable associated with rider
-				drawable->setDrawableHidden(true);
-			}
-		}
+		// hide the drawable associated with rider
+		if( obj->getDrawable() )
+			obj->getDrawable()->setDrawableHidden( true );
 
 		// remove object from pathfind map
 		TheAI->pathfinder()->removeObjectFromPathfindMap( obj );

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -247,9 +247,17 @@ void OpenContain::addOrRemoveObjFromWorld(Object* obj, Bool add)
 		// remove rider from partition manager
 		ThePartitionManager->unRegisterObject( obj );
 
-		// hide the drawable associated with rider
-		if( obj->getDrawable() )
-			obj->getDrawable()->setDrawableHidden( true );
+		if (Drawable* drawable = obj->getDrawable())
+		{
+#if RETAIL_COMPATIBLE_CRC
+			// TheSuperHackers @tweak This shouldn't happen but don't make the occupant invisible if it does.
+			if (!(getObject()->isEffectivelyDead() || getObject()->isDestroyed()))
+#endif
+			{
+				// hide the drawable associated with rider
+				drawable->setDrawableHidden(true);
+			}
+		}
 
 		// remove object from pathfind map
 		TheAI->pathfinder()->removeObjectFromPathfindMap( obj );
@@ -358,13 +366,6 @@ void OpenContain::addToContain( Object *rider )
 	if (isEnclosingContainerFor( rider ))
 	{
 		addOrRemoveObjFromWorld(rider, false);
-
-		// TheSuperHackers @tweak This shouldn't happen but make the occupant visible if it does.
-		if (getObject()->isEffectivelyDead() || getObject()->isDestroyed())
-		{
-			if (Drawable* drawable = rider->getDrawable())
-				drawable->setDrawableHidden(FALSE);
-		}
 	}
 
 #if RETAIL_COMPATIBLE_CRC

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OpenContain.cpp
@@ -343,6 +343,13 @@ void OpenContain::addToContain( Object *rider )
 	if (isEnclosingContainerFor( rider ))
 	{
 		addOrRemoveObjFromWorld(rider, false);
+
+		// TheSuperHackers @tweak This shouldn't happen but make the occupants visible if it does.
+		if (getObject()->isEffectivelyDead() || getObject()->isDestroyed())
+		{
+			if (Drawable* drawable = rider->getDrawable())
+				drawable->setDrawableHidden(FALSE);
+		}
 	}
 
 #if RETAIL_COMPATIBLE_CRC

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
@@ -469,8 +469,19 @@ UpdateSleepTime TransportContain::update()
 {
 	const TransportContainModuleData *moduleData = getTransportContainModuleData();
 
-	if( m_payloadCreated == FALSE )
+	if (m_payloadCreated == FALSE)
+	{
+#if RETAIL_COMPATIBLE_CRC
 		createPayload();
+#else
+		// TheSuperHackers @bugfix Caball009 25/05/2026 Don't create payload
+		// for destroyed object to avoid an invalid state for the payload.
+		if (!getObject()->isDestroyed())
+		{
+			createPayload();
+		}
+#endif
+	}
 
 	if( moduleData && moduleData->m_healthRegen )
 	{

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
@@ -475,7 +475,7 @@ UpdateSleepTime TransportContain::update()
 		createPayload();
 #else
 		// TheSuperHackers @bugfix Caball009 25/05/2026 Don't create payload
-		// for destroyed object to avoid an invalid state for the payload.
+		// for destroyed object to avoid leaving the payload in an invalid state.
 		if (!getObject()->isDestroyed())
 		{
 			createPayload();


### PR DESCRIPTION
* Closes https://github.com/TheSuperHackers/GeneralsGameCode/issues/2741
* Related PR https://github.com/TheSuperHackers/GeneralsGameCode/pull/2747

When a reinforcement plane with an Infantry General Troop Crawler is destroyed en route, the plane and vehicle are destroyed, but the infantry spawned and remains in an invalid state (see issue for more details). 

Beside being a gameplay and logic bug, there's also another issue because the infantry objects will hold on the container pointer even though that object has been destroyed. This can lead to use-after-free bugs and a crash (see related PR).

This PR makes 4 changes:
1. Objects that are spawned in such a state ~are now visible~ should now trigger a debug assertion.
2. Added code to prevent the creation of the transport payload (e.g. the Mini-Gunners) if the container object is destroyed (non-retail only).
3. Added an early return to `OpenContain::addToContain` to prevent units from being added to a destroyed object  (non-retail only).
4. Added debug assertions for dead container objects or occupants.

## TODO:
- [x] Replicate in Generals.