### PR TITLE
bugfix(object): Avoid crash with dangling contain module in Object::onDestroy() when Reinforcement Pad is destroyed before Troop Crawler drop

### DIFF
--- a/Generals/Code/GameEngine/Include/GameLogic/Object.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Object.h
@@ -717,7 +717,7 @@ private:
 
 	Object*												m_containedBy;					/**< an object can only be contained by at most one
 																	other object, this is that object (if present) */
-	ObjectID											m_xferContainedByID;	///< xfer uses IDs to store pointers and looks them up after
+	ObjectID											m_containedByID;	///< ID of the object we're contained by; only to be used when m_containedBy cannot be used
 	UnsignedInt										m_containedByFrame;	///< frame we were contained by m_containedBy
 
 	Real													m_constructionPercent;			///< for objects being built ... this is the amount completed (0.0 to 100.0)

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -173,7 +173,7 @@ Object::Object( const ThingTemplate *tt, const ObjectStatusMaskType &objectStatu
 	m_physics(nullptr),
 	m_geometryInfo(tt->getTemplateGeometryInfo()),
 	m_containedBy(nullptr),
-	m_xferContainedByID(INVALID_ID),
+	m_containedByID(INVALID_ID),
 	m_containedByFrame(0),
 	m_behaviors(nullptr),
 	m_body(nullptr),
@@ -621,6 +621,22 @@ void Object::onContainedBy( Object *containedBy )
 		clearStatus( MAKE_OBJECT_STATUS_MASK( OBJECT_STATUS_MASKED ) );
 	m_containedBy = containedBy;
 	m_containedByFrame = TheGameLogic->getFrame();
+
+#if RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @info Set INVALID_ID if the container object was destroyed
+	// to indicate that the pointer will become a dangling pointer in the next frame.
+	if (containedBy && !containedBy->isDestroyed())
+	{
+		m_containedByID = containedBy->getID();
+	}
+	else
+	{
+		m_containedByID = INVALID_ID;
+	}
+#else
+	DEBUG_ASSERTCRASH(containedBy == nullptr || !containedBy->isDestroyed(),
+		("Object::onContainedBy - Adding into a destroyed container"));
+#endif
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -631,6 +647,10 @@ void Object::onRemovedFrom( Object *removedFrom )
 	clearStatus( MAKE_OBJECT_STATUS_MASK2( OBJECT_STATUS_MASKED, OBJECT_STATUS_UNSELECTABLE ) );
 	m_containedBy = nullptr;
 	m_containedByFrame = 0;
+
+#if RETAIL_COMPATIBLE_CRC
+	m_containedByID = INVALID_ID;
+#endif
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -681,9 +701,33 @@ void Object::onDestroy()
 {
 
 	// This is the old cleanUpContain safeguard.  Say goodbye so they don't try to look us up.
-	if( m_containedBy && m_containedBy->getContain() )
+	if (m_containedBy)
 	{
-		m_containedBy->getContain()->removeFromContain( this );
+#if RETAIL_COMPATIBLE_CRC
+		if (m_containedByID == INVALID_ID)
+		{
+			// TheSuperHackers @bugfix Caball009 25/05/2026 Due to a potential use-after-free bug that cannot be fixed
+			// with retail compatibility, the 'contained by' pointer of this object may point to an already destroyed object.
+			// Avoid removing this object from the contain list, because it could crash the game,
+			// as the begin / end iterator for STLPort and MSVC std::list implementations depends on dynamically allocated memory.
+			DEBUG_CRASH(("container object must be valid; this looks like use-after-free"));
+		}
+		else
+		{
+			DEBUG_ASSERTCRASH(TheGameLogic->findObjectByID(m_containedByID) == m_containedBy,
+				("contained by pointer is out of sync with contained by ID"));
+
+			if (ContainModuleInterface* contain = m_containedBy->getContain())
+			{
+				contain->removeFromContain(this);
+			}
+		}
+#else
+		if (ContainModuleInterface* contain = m_containedBy->getContain())
+		{
+			contain->removeFromContain(this);
+		}
+#endif
 	}
 
 	//
@@ -3727,16 +3771,18 @@ void Object::xfer( Xfer *xfer )
 		// No, the contain module is just going to friend_ reach in and set this for us.
 		// Containers more complicated than Open (like Tunnel) can't do that.  Our variable,
 		// our responsibility.
+#if !RETAIL_COMPATIBLE_CRC
+		// TheSuperHackers @tweak Contained by ID is already set with retail compatibility; don't overwrite it.
 		if( xfer->getXferMode() == XFER_SAVE )
 		{
 			if( m_containedBy != nullptr )
-				m_xferContainedByID = m_containedBy->getID();
+				m_containedByID = m_containedBy->getID();
 			else
-				m_xferContainedByID = INVALID_ID;
+				m_containedByID = INVALID_ID;
 		}
+#endif
 
-
-		xfer->xferObjectID( &m_xferContainedByID );
+		xfer->xferObjectID( &m_containedByID );
 	}
 
 	// contained by frame
@@ -3961,8 +4007,8 @@ void Object::xfer( Xfer *xfer )
 //-------------------------------------------------------------------------------------------------
 void Object::loadPostProcess()
 {
-	if( m_xferContainedByID != INVALID_ID )
-		m_containedBy = TheGameLogic->findObjectByID(m_xferContainedByID);
+	if( m_containedByID != INVALID_ID )
+		m_containedBy = TheGameLogic->findObjectByID(m_containedByID);
 	else
 		m_containedBy = nullptr;
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Object.h
@@ -761,7 +761,7 @@ private:
 
 	Object*												m_containedBy;					/**< an object can only be contained by at most one
 																	other object, this is that object (if present) */
-	ObjectID											m_xferContainedByID;	///< xfer uses IDs to store pointers and looks them up after
+	ObjectID											m_containedByID;	///< ID of the object we're contained by; only to be used when m_containedBy cannot be used
 	UnsignedInt										m_containedByFrame;	///< frame we were contained by m_containedBy
 
 	Real													m_constructionPercent;			///< for objects being built ... this is the amount completed (0.0 to 100.0)

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -182,7 +182,7 @@ Object::Object( const ThingTemplate *tt, const ObjectStatusMaskType &objectStatu
 	m_physics(nullptr),
 	m_geometryInfo(tt->getTemplateGeometryInfo()),
 	m_containedBy(nullptr),
-	m_xferContainedByID(INVALID_ID),
+	m_containedByID(INVALID_ID),
 	m_containedByFrame(0),
 	m_behaviors(nullptr),
 	m_body(nullptr),
@@ -691,6 +691,17 @@ void Object::onContainedBy( Object *containedBy )
 	m_containedBy = containedBy;
 	m_containedByFrame = TheGameLogic->getFrame();
 
+#if RETAIL_COMPATIBLE_CRC
+	if (containedBy && !containedBy->isDestroyed())
+	{
+		m_containedByID = containedBy->getID();
+	}
+	else
+	{
+		m_containedByID = INVALID_ID;
+	}
+#endif
+
   handlePartitionCellMaintenance(); // which should unlook me now that I am contained
 
 }
@@ -703,6 +714,10 @@ void Object::onRemovedFrom( Object *removedFrom )
 	clearStatus( MAKE_OBJECT_STATUS_MASK2( OBJECT_STATUS_MASKED, OBJECT_STATUS_UNSELECTABLE ) );
 	m_containedBy = nullptr;
 	m_containedByFrame = 0;
+
+#if RETAIL_COMPATIBLE_CRC
+	m_containedByID = INVALID_ID;
+#endif
 
   handlePartitionCellMaintenance(); // get a clean look, now that I am outdoors, again
 
@@ -756,9 +771,29 @@ void Object::onDestroy()
 {
 
 	// This is the old cleanUpContain safeguard.  Say goodbye so they don't try to look us up.
-	if( m_containedBy && m_containedBy->getContain() )
+	if (m_containedBy)
 	{
-		m_containedBy->getContain()->removeFromContain( this );
+		if (ContainModuleInterface* contained = m_containedBy->getContain())
+		{
+#if RETAIL_COMPATIBLE_CRC
+			if (m_containedByID == INVALID_ID)
+			{
+				// TheSuperHackers @bugfix Caball009 25/05/2026 Due to a potential use-after-free bug that cannot be fixed
+				// with retail compatibility, the 'contained by' pointer of this object may point to an already destroyed object.
+				// Avoid removing this object from the contain list, because it could crash the game,
+				// as the begin / end iterator for STLPort and MSVC std::list implementations depends on dynamically allocated memory.
+				DEBUG_CRASH(("container object must be valid; this looks like use-after-free"));
+			}
+			else
+			{
+				DEBUG_ASSERTCRASH(TheGameLogic->findObjectByID(m_containedByID) == m_containedBy,
+					("contained by pointer is out of sync with contained by ID"));
+				contained->removeFromContain(this);
+			}
+#else
+			contained->removeFromContain(this);
+#endif
+		}
 	}
 
 	//
@@ -4249,13 +4284,13 @@ void Object::xfer( Xfer *xfer )
 		if( xfer->getXferMode() == XFER_SAVE )
 		{
 			if( m_containedBy != nullptr )
-				m_xferContainedByID = m_containedBy->getID();
+				m_containedByID = m_containedBy->getID();
 			else
-				m_xferContainedByID = INVALID_ID;
+				m_containedByID = INVALID_ID;
 		}
 
 
-		xfer->xferObjectID( &m_xferContainedByID );
+		xfer->xferObjectID( &m_containedByID );
 	}
 
 	// contained by frame
@@ -4480,8 +4515,8 @@ void Object::xfer( Xfer *xfer )
 //-------------------------------------------------------------------------------------------------
 void Object::loadPostProcess()
 {
-	if( m_xferContainedByID != INVALID_ID )
-		m_containedBy = TheGameLogic->findObjectByID(m_xferContainedByID);
+	if( m_containedByID != INVALID_ID )
+		m_containedBy = TheGameLogic->findObjectByID(m_containedByID);
 	else
 		m_containedBy = nullptr;
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -777,9 +777,6 @@ void Object::onDestroy()
 	if (m_containedBy)
 	{
 #if RETAIL_COMPATIBLE_CRC
-		DEBUG_ASSERTCRASH(TheGameLogic->findObjectByID(m_containedByID) == m_containedBy,
-			("contained by pointer is out of sync with contained by ID"));
-
 		if (m_containedByID == INVALID_ID)
 		{
 			// TheSuperHackers @bugfix Caball009 25/05/2026 Due to a potential use-after-free bug that cannot be fixed
@@ -788,9 +785,15 @@ void Object::onDestroy()
 			// as the begin / end iterator for STLPort and MSVC std::list implementations depends on dynamically allocated memory.
 			DEBUG_CRASH(("container object must be valid; this looks like use-after-free"));
 		}
-		else if (ContainModuleInterface* contained = m_containedBy->getContain())
+		else
 		{
-			contained->removeFromContain(this);
+			DEBUG_ASSERTCRASH(TheGameLogic->findObjectByID(m_containedByID) == m_containedBy,
+				("contained by pointer is out of sync with contained by ID"));
+
+			if (ContainModuleInterface* contained = m_containedBy->getContain())
+			{
+				contained->removeFromContain(this);
+			}
 		}
 #else
 		if (ContainModuleInterface* contained = m_containedBy->getContain())

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -692,6 +692,8 @@ void Object::onContainedBy( Object *containedBy )
 	m_containedByFrame = TheGameLogic->getFrame();
 
 #if RETAIL_COMPATIBLE_CRC
+	// TheSuperHackers @info Set INVALID_ID if the container object was destroyed
+	// to indicate that the pointer will become a dangling pointer in the next frame.
 	if (containedBy && !containedBy->isDestroyed())
 	{
 		m_containedByID = containedBy->getID();
@@ -790,15 +792,15 @@ void Object::onDestroy()
 			DEBUG_ASSERTCRASH(TheGameLogic->findObjectByID(m_containedByID) == m_containedBy,
 				("contained by pointer is out of sync with contained by ID"));
 
-			if (ContainModuleInterface* contained = m_containedBy->getContain())
+			if (ContainModuleInterface* contain = m_containedBy->getContain())
 			{
-				contained->removeFromContain(this);
+				contain->removeFromContain(this);
 			}
 		}
 #else
-		if (ContainModuleInterface* contained = m_containedBy->getContain())
+		if (ContainModuleInterface* contain = m_containedBy->getContain())
 		{
-			contained->removeFromContain(this);
+			contain->removeFromContain(this);
 		}
 #endif
 	}
@@ -4288,16 +4290,16 @@ void Object::xfer( Xfer *xfer )
 		// No, the contain module is just going to friend_ reach in and set this for us.
 		// Containers more complicated than Open (like Tunnel) can't do that.  Our variable,
 		// our responsibility.
+#if !RETAIL_COMPATIBLE_CRC
+		// TheSuperHackers @tweak Contained by ID is already set with retail compatibility; don't overwrite it.
 		if( xfer->getXferMode() == XFER_SAVE )
 		{
-			// TheSuperHackers @tweak Contained by ID is already set with retail compatibility; don't overwrite it.
-#if !RETAIL_COMPATIBLE_CRC
 			if( m_containedBy != nullptr )
 				m_containedByID = m_containedBy->getID();
 			else
 				m_containedByID = INVALID_ID;
-#endif
 		}
+#endif
 
 		xfer->xferObjectID( &m_containedByID );
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -4287,12 +4287,14 @@ void Object::xfer( Xfer *xfer )
 		// our responsibility.
 		if( xfer->getXferMode() == XFER_SAVE )
 		{
+			// TheSuperHackers @tweak Contained by ID is already set with retail compatibility; don't overwrite it.
+#if !RETAIL_COMPATIBLE_CRC
 			if( m_containedBy != nullptr )
 				m_containedByID = m_containedBy->getID();
 			else
 				m_containedByID = INVALID_ID;
+#endif
 		}
-
 
 		xfer->xferObjectID( &m_containedByID );
 	}

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Object.cpp
@@ -700,6 +700,9 @@ void Object::onContainedBy( Object *containedBy )
 	{
 		m_containedByID = INVALID_ID;
 	}
+#else
+	DEBUG_ASSERTCRASH(containedBy == nullptr || !containedBy->isDestroyed(),
+		("Object::onContainedBy - Adding into a destroyed container"));
 #endif
 
   handlePartitionCellMaintenance(); // which should unlook me now that I am contained
@@ -773,27 +776,28 @@ void Object::onDestroy()
 	// This is the old cleanUpContain safeguard.  Say goodbye so they don't try to look us up.
 	if (m_containedBy)
 	{
+#if RETAIL_COMPATIBLE_CRC
+		DEBUG_ASSERTCRASH(TheGameLogic->findObjectByID(m_containedByID) == m_containedBy,
+			("contained by pointer is out of sync with contained by ID"));
+
+		if (m_containedByID == INVALID_ID)
+		{
+			// TheSuperHackers @bugfix Caball009 25/05/2026 Due to a potential use-after-free bug that cannot be fixed
+			// with retail compatibility, the 'contained by' pointer of this object may point to an already destroyed object.
+			// Avoid removing this object from the contain list, because it could crash the game,
+			// as the begin / end iterator for STLPort and MSVC std::list implementations depends on dynamically allocated memory.
+			DEBUG_CRASH(("container object must be valid; this looks like use-after-free"));
+		}
+		else if (ContainModuleInterface* contained = m_containedBy->getContain())
+		{
+			contained->removeFromContain(this);
+		}
+#else
 		if (ContainModuleInterface* contained = m_containedBy->getContain())
 		{
-#if RETAIL_COMPATIBLE_CRC
-			if (m_containedByID == INVALID_ID)
-			{
-				// TheSuperHackers @bugfix Caball009 25/05/2026 Due to a potential use-after-free bug that cannot be fixed
-				// with retail compatibility, the 'contained by' pointer of this object may point to an already destroyed object.
-				// Avoid removing this object from the contain list, because it could crash the game,
-				// as the begin / end iterator for STLPort and MSVC std::list implementations depends on dynamically allocated memory.
-				DEBUG_CRASH(("container object must be valid; this looks like use-after-free"));
-			}
-			else
-			{
-				DEBUG_ASSERTCRASH(TheGameLogic->findObjectByID(m_containedByID) == m_containedBy,
-					("contained by pointer is out of sync with contained by ID"));
-				contained->removeFromContain(this);
-			}
-#else
 			contained->removeFromContain(this);
-#endif
 		}
+#endif
 	}
 
 	//


### PR DESCRIPTION
* Closes https://github.com/TheSuperHackers/GeneralsGameCode/issues/2467
* Related PR https://github.com/TheSuperHackers/GeneralsGameCode/pull/2746

This PR provides a retail specific workaround for use-after-free bug that could crash the game under very specific conditions (see issue and related PR).

The actual crash would happen when e.g. `OpenContain::m_containList` is accessed after it's been destructed. STLPort and MSVC implementations for `std::list` rely on dynamically allocated memory, so accessing the begin / end iterator after the destruction of the list is not just undefined behavior, it crashes the game. See minimal crash reproduction: https://godbolt.org/z/T9sEb4MsK

## TODO:
- [x] Verify that resetting the contain pointer is not an alternative (not retail compatible).
- [x] Replicate in Generals.