### PR TITLE
bugfix(water): Fix river visuals in black shroud

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
@@ -179,7 +179,7 @@ static Int getRiverVertexDiffuse(W3DShroud *shroud, Real x, Real y, Real shadeR,
 		(Int)(shadeR * shroudScale),
 		(Int)(shadeG * shroudScale),
 		(Int)(shadeB * shroudScale),
-		(diffuse >> 24) & 0xff);
+		((diffuse >> 24) & 0xff) * shroudScale);
 }
 
 void doSkyBoxSet(Bool startDraw)

--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWater.cpp
@@ -926,9 +926,11 @@ void WaterRenderObjClass::ReAcquireResources()
 			tex t1	\n\
 			tex t2	\n\
 			tex t3\n\
-			mul r0,v0,t0 ; blend vertex color into t0. \n\
+			mul r0.rgb, v0, t0 ; blend vertex color into t0. \n\
+			mov r0.a, t0 ; keep vertex alpha from fading the base water. \n\
 			mul r1, t1, t2 ; mul\n\
-			add r0.rgb, r0, t3\n\
+			add r1.rgb, r1, t3\n\
+			mul r1.rgb, r1, v0.a\n\
 			+mul r0.a, r0, t3\n\
 			add r0.rgb, r0, r1\n";
 		hr = D3DXAssembleShader( shader, strlen(shader), 0, nullptr, &compiledShader, nullptr);


### PR DESCRIPTION
* Fixes #2671

The problem was that the opacity of the river visuals ("sparkles") did not get scaled by the shroud level. To apply this alpha scaling only to the sparkles a change to the river shader was made.

Observe that the sparkles are now also less bright inside the fog.

Before:

<img width="1915" height="1078" alt="Screenshot From 2026-05-27 20-50-49" src="https://github.com/user-attachments/assets/eda78779-dae1-405a-8cf4-8beab8c3b2ab" />

After:
<img width="1915" height="1078" alt="Screenshot From 2026-05-27 22-46-22" src="https://github.com/user-attachments/assets/33f09595-57e6-42f0-9b3f-536f502c0b75" />

