### PR TITLE
unify(shroud): Merge W3DShroud code from Zero Hour and implicitly fix black terrain for one frame on far camera jumps

### DIFF
--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DShroud.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DShroud.cpp
@@ -120,13 +120,17 @@ void W3DShroud::init(WorldHeightMap *pMap, Real worldCellSizeX, Real worldCellSi
 	//Precompute a bounding box for entire shroud layer
 	if (pMap)
 	{
-		m_numCellsX = REAL_TO_INT_CEIL((Real)(pMap->getXExtent() - 1 - pMap->getBorderSize()*2)*MAP_XY_FACTOR/m_cellWidth);
-		m_numCellsY = REAL_TO_INT_CEIL((Real)(pMap->getYExtent() - 1 - pMap->getBorderSize()*2)*MAP_XY_FACTOR/m_cellHeight);
+		m_numCellsX = REAL_TO_INT_CEIL((Real)(pMap->getXExtent() - 1 - pMap->getBorderSizeInline()*2)*MAP_XY_FACTOR/m_cellWidth);
+		m_numCellsY = REAL_TO_INT_CEIL((Real)(pMap->getYExtent() - 1 - pMap->getBorderSizeInline()*2)*MAP_XY_FACTOR/m_cellHeight);
 
 		//Maximum visible cells will depend on maximum drawable terrain size plus 1 for partial cells (since
 		//shroud cells are larger than terrain cells).
 		dstTextureWidth=m_numMaxVisibleCellsX=REAL_TO_INT_FLOOR((Real)(pMap->getDrawWidth()-1)*MAP_XY_FACTOR/m_cellWidth)+1;
 		dstTextureHeight=m_numMaxVisibleCellsY=REAL_TO_INT_FLOOR((Real)(pMap->getDrawHeight()-1)*MAP_XY_FACTOR/m_cellHeight)+1;
+
+		dstTextureWidth = m_numCellsX;
+		dstTextureHeight = m_numCellsY;
+
 		dstTextureWidth += 2;	//enlarge by 2 pixels so we can have a border color all the way around.
 		unsigned int depth = 1;
 		dstTextureHeight += 2;	//enlarge by 2 pixels so we can have border color all the way around.
@@ -225,7 +229,7 @@ void W3DShroud::ReleaseResources()
 Bool W3DShroud::ReAcquireResources()
 {
 		if (!m_dstTextureWidth)
-			return TRUE;	//nothing to reaquire since shroud was never initialized with valid data
+			return TRUE;	//nothing to reacquire since shroud was never initialized with valid data
 
 		DEBUG_ASSERTCRASH( m_pDstTexture == nullptr, ("ReAcquire of existing shroud texture"));
 
@@ -613,14 +617,22 @@ void W3DShroud::render(CameraClass *cam)
 
 
 	WorldHeightMap *hm=TheTerrainRenderObject->getMap();
-	Int visStartX=REAL_TO_INT_FLOOR((Real)(hm->getDrawOrgX()-hm->getBorderSize())*MAP_XY_FACTOR/m_cellWidth);	//start of rendered heightmap rectangle
+	Int visStartX=REAL_TO_INT_FLOOR((Real)(hm->getDrawOrgX()-hm->getBorderSizeInline())*MAP_XY_FACTOR/m_cellWidth);	//start of rendered heightmap rectangle
 	if (visStartX < 0)
 		visStartX = 0;	//no shroud is applied in border area so it always starts at > 0
-	Int visStartY=REAL_TO_INT_FLOOR((Real)(hm->getDrawOrgY()-hm->getBorderSize())*MAP_XY_FACTOR/m_cellHeight);
+	Int visStartY=REAL_TO_INT_FLOOR((Real)(hm->getDrawOrgY()-hm->getBorderSizeInline())*MAP_XY_FACTOR/m_cellHeight);
 	if (visStartY < 0)
 		visStartY = 0;	//no shroud is applied in border area so it always starts at > 0
+
+	visStartX = 0;
+	visStartY = 0;
+
 	Int visEndX=visStartX+REAL_TO_INT_FLOOR((Real)(hm->getDrawWidth()-1)*MAP_XY_FACTOR/m_cellWidth)+1;	//size of rendered heightmap rectangle
 	Int visEndY=visStartY+REAL_TO_INT_FLOOR((Real)(hm->getDrawHeight()-1)*MAP_XY_FACTOR/m_cellHeight)+1;
+
+	
+	visEndX = m_numCellsX;
+	visEndY = m_numCellsY;
 
 	if (visEndX > m_numCellsX)
 	{

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DShroud.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DShroud.cpp
@@ -137,6 +137,7 @@ void W3DShroud::init(WorldHeightMap *pMap, Real worldCellSizeX, Real worldCellSi
 		TextureLoader::Validate_Texture_Size((unsigned int &)dstTextureWidth,(unsigned int &)dstTextureHeight, depth);
 	}
 
+
 	UnsignedInt srcWidth,srcHeight;
 
 	srcWidth=m_numCellsX;
@@ -624,13 +625,14 @@ void W3DShroud::render(CameraClass *cam)
 	if (visStartY < 0)
 		visStartY = 0;	//no shroud is applied in border area so it always starts at > 0
 
+	// Do it all [3/11/2003]
 	visStartX = 0;
 	visStartY = 0;
 
 	Int visEndX=visStartX+REAL_TO_INT_FLOOR((Real)(hm->getDrawWidth()-1)*MAP_XY_FACTOR/m_cellWidth)+1;	//size of rendered heightmap rectangle
 	Int visEndY=visStartY+REAL_TO_INT_FLOOR((Real)(hm->getDrawHeight()-1)*MAP_XY_FACTOR/m_cellHeight)+1;
 
-	
+	// Do it all [3/11/2003]
 	visEndX = m_numCellsX;
 	visEndY = m_numCellsY;
 


### PR DESCRIPTION
* Closes #2689 

The shroud destination texture in Generals was allocated at visible terrain size
rather than full map size. The shroud ```render()``` function uses getDrawOrgX/Y to
determine which region of the shroud to upload to the GPU each frame. Because
the shroud renders before ```updateViews()``` in``` W3DDisplay::draw()``` ,the draw origin
is still stale from the previous frame when the camera jumps far, such as when
clicking the radar and scrolling. This causes the shroud to upload the wrong region, making
newly visible terrain appear black for one frame.

Unifies the Generals ```W3DShroud``` destination texture allocation with Zero Hour,
which allocates at full map size and renders the full shroud every frame. This
makes the shroud correct regardless of the draw origin state at render time.

The tradeoff is an increase in GPU upload bandwidth per frame, but it matches the ```W3DShroud```
implementation in Zero Hour.